### PR TITLE
docs: device removal completion — design + 3 wave plans (#5023)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -292,9 +292,19 @@ cd e2e-tests && pnpm test
 
 ---
 
+## Model Routing (cost/speed strategy — benchmarked 2026-09-01)
+
+**Expensive models write contracts and verify claims; cheap models do everything in between; mechanical checks replace expensive review wherever the work is gradeable.** Basis: two head-to-head benchmarks (blind bug-hunt + blind spec→codegen) across Laguna, Codex gpt-5.6-sol med/high, Haiku, Sonnet, Opus — see memory `model-benchmark-codex-claude-laguna-2026-09-01`.
+
+1. **Spec-down (Fable/Opus in-session).** Spend top-tier tokens only on: resolving spec ambiguity, choosing contracts (tenancy shape, cascade lists, API surface), and cross-file reachability judgment. All six models aced a fully-resolved spec (39/39 each); 2 of 3 Claude PRIMARY bug claims died on a file the blind reviewer couldn't see. The orchestrator's value is the contract, not the typing.
+2. **Generate cheap — route by access needs, not quality.** Laguna (free, local, ~10× faster): any paste-in-shaped work — spec'd modules, co-located tests, migration drafts from a stated contract. Codex `medium` (flat sub, ~0 marginal): well-scoped repo-touching edits and single-file bug-hunts. Haiku subagents: mechanical repo chores needing tools, with explicit file lists.
+3. **Verify mechanically first.** tsc/tests/grep-the-contract before any model review — the cascade-list history is contract tests 5/5 vs human review 0/5. A hidden acceptance suite converts "needs expensive review" into "needs a script."
+4. **Review sized by blast radius.** Default: Laguna + Codex `medium` in parallel (~free, ~1 min), orchestrator arbitrates — disagreement is signal; Laguna's hallucinations die at verification (it misread code 2× in the bench — never trust its line-level claims unre-read). Reserve Sonnet (precision: 4/4 real findings, 0 hallucinations) or Opus (depth: found the billing bug nobody else saw) for tenancy/auth/billing/agent-shipped code.
+5. **Advisor quorum unchanged** — Fable + codex `xhigh` only for consequential, hard-to-reverse design (see Working Style).
+
 ## Codex Delegation
 
-This project uses OpenAI Codex CLI for **read-only analysis (bug-hunting, security review, design-from-plan — its strongest uses) and well-scoped single-file edits** (utilities, co-located tests, CRUD endpoints, mechanical renames). Keep with Claude: repo-wide sweeps/enumeration, cross-module refactors (codex misses existing canonical code), UI work, and the *architecture* of multi-tenant/auth changes — though codex may *execute* an RLS migration once Claude hands it the tenancy contract. Default to `high`; reserve `xhigh` for open-ended design. For commands, reasoning levels, and the benchmarked delegation matrix, use the **`delegating-to-codex`** skill.
+This project uses OpenAI Codex CLI for **read-only analysis (bug-hunting, security review, design-from-plan — its strongest uses) and well-scoped single-file edits** (utilities, co-located tests, CRUD endpoints, mechanical renames). Keep with Claude: repo-wide sweeps/enumeration, cross-module refactors (codex misses existing canonical code), UI work, and the *architecture* of multi-tenant/auth changes — though codex may *execute* an RLS migration once Claude hands it the tenancy contract. Default to `medium` (2026-09-01 bench: `medium` beat `high` on bug-hunts and tied on codegen); escalate to `high` only when medium comes back thin; reserve `xhigh` for open-ended design. Model is `gpt-5.6-sol`. For commands, reasoning levels, and the benchmarked delegation matrix, use the **`delegating-to-codex`** skill.
 
 ---
 

--- a/docs/superpowers/plans/device-lifecycle/2026-09-05-device-removal-01-remove-dialog.md
+++ b/docs/superpowers/plans/device-lifecycle/2026-09-05-device-removal-01-remove-dialog.md
@@ -1,0 +1,862 @@
+---
+tracking_issue: LanternOps/breeze#5023
+---
+# Device Removal 01 — Remove Dialog with Agent Choice (single + bulk) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Every web Remove action asks "uninstall the agent or leave it?" (default: uninstall) and sends `uninstallAgent` to `DELETE /devices/:id`, closing the zombie-agent gap.
+
+**Architecture:** A thin `RemoveDeviceDialog` composes the existing `ConfirmDialog` (children slot + single-fire latch). The five Remove surfaces (DevicesPage row/card via `pendingDeviceAction`, bulk bar, DeviceActions/detail page, PossibleReplacementBanner) all render it and forward `{ uninstallAgent }` through the service layer. One new read-only API route exposes the env-driven drain window so the copy can say how long a queued uninstall waits.
+
+**Tech Stack:** Hono route + Vitest (API); React + react-i18next + Vitest/jsdom (web).
+
+**Spec:** `docs/superpowers/specs/device-lifecycle/2026-09-05-device-removal-completion-design.md` (PR 1). Issues: #3987 items 2 and 6; supersedes #2250.
+
+## Global Constraints
+
+- Single-device API contract unchanged: `DELETE /devices/:id` body `{ uninstallAgent?: boolean }` already exists (`apps/api/src/routes/devices/schemas.ts:119`); default stays `false` on the API — the **web** supplies `true` by default.
+- Radio defaults to **Uninstall** (owner decision 2026-08-24). Never default to leave-installed.
+- Copy must say **queued**, never "runs now" — Remove inserts a pending command and disconnects the WS; the agent collects on its next poll.
+- Drain window is env-driven (`DEVICE_UNINSTALL_DRAIN_WINDOW_HOURS`, `services/deviceUninstallDrain.ts:80`). Never hardcode it in web or shared.
+- Bulk status summary buckets are "online" / "not currently online" (not "offline") — `maintenance`, `quarantined`, `updating`, `pending` are neither.
+- All new locale keys go into `en` AND `de-DE es-419 fr-CA fr-FR it-IT pt-BR tr-TR` in the same commit (`apps/web/src/lib/i18n/localeParity.test.ts` fails otherwise). Machine-quality translations are acceptable; interpolation tokens must match exactly.
+- Mutations go through `runAction` or the existing `deviceActions` service functions (no-silent-mutations test).
+- Commit after each task. Run `cd apps/web && npx vitest run <file>` / `cd apps/api && npx vitest run <file>` — never `pnpm --filter x test -- --run`.
+
+---
+
+### Task 1: API — `GET /devices/removal-config` exposes the drain window
+
+**Files:**
+- Create: `apps/api/src/routes/devices/removalConfig.ts`
+- Create: `apps/api/src/routes/devices/removalConfig.test.ts`
+- Modify: `apps/api/src/routes/devices/index.ts:79` (mount before `coreRoutes`)
+
+**Interfaces:**
+- Produces: `GET /api/v1/devices/removal-config` → `200 { uninstallDrainWindowHours: number }`. Requires `devices:read`, any scope.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// apps/api/src/routes/devices/removalConfig.test.ts
+import { describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: vi.fn((c: any, next: any) => {
+    c.set('auth', { user: { id: 'u1' }, scope: 'organization', orgId: 'org-1', accessibleOrgIds: ['org-1'] });
+    return next();
+  }),
+  requireScope: vi.fn(() => async (_c: any, next: any) => next()),
+  requirePermission: vi.fn(() => async (_c: any, next: any) => next()),
+}));
+vi.mock('../../services/deviceUninstallDrain', () => ({
+  DEVICE_UNINSTALL_DRAIN_WINDOW_HOURS: 72,
+}));
+
+import { removalConfigRoutes } from './removalConfig';
+
+describe('GET /devices/removal-config', () => {
+  it('returns the configured uninstall drain window in hours', async () => {
+    const app = new Hono().route('/devices', removalConfigRoutes);
+    const res = await app.request('/devices/removal-config', { headers: { Authorization: 'Bearer t' } });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ uninstallDrainWindowHours: 72 });
+  });
+});
+```
+
+- [ ] **Step 2: Run it — expect FAIL** (`Cannot find module './removalConfig'`)
+
+```bash
+cd apps/api && npx vitest run src/routes/devices/removalConfig.test.ts
+```
+
+- [ ] **Step 3: Implement the route**
+
+```ts
+// apps/api/src/routes/devices/removalConfig.ts
+import { Hono } from 'hono';
+import { authMiddleware, requireScope, requirePermission } from '../../middleware/auth';
+import { PERMISSIONS } from '../../services/permissions';
+import { DEVICE_UNINSTALL_DRAIN_WINDOW_HOURS } from '../../services/deviceUninstallDrain';
+
+export const removalConfigRoutes = new Hono();
+removalConfigRoutes.use('*', authMiddleware);
+
+/**
+ * GET /devices/removal-config — read-only knobs the Remove dialog needs.
+ *
+ * `uninstallDrainWindowHours` is how long a queued self_uninstall waits for a
+ * removed device to check in before the stale-command reaper cancels it
+ * (`DEVICE_UNINSTALL_DRAIN_WINDOW_HOURS`, env-driven, floored at 1). The web
+ * must not hardcode it: operators tune it per deployment.
+ *
+ * Static path — MUST be mounted before coreRoutes in devices/index.ts or the
+ * `/:id` matcher eats it as a device id.
+ */
+removalConfigRoutes.get(
+  '/removal-config',
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action),
+  (c) => c.json({ uninstallDrainWindowHours: DEVICE_UNINSTALL_DRAIN_WINDOW_HOURS }),
+);
+```
+
+In `apps/api/src/routes/devices/index.ts`, add the import and mount it directly before the `// Mount core routes` line:
+
+```ts
+import { removalConfigRoutes } from './removalConfig';
+// ...
+// Mount the Remove-dialog config BEFORE core — `/removal-config` is a static
+// path that must not be eaten by the `/:id` matcher in coreRoutes.
+deviceRoutes.route('/', removalConfigRoutes);
+```
+
+- [ ] **Step 4: Run the test — expect PASS.** Also run the assembled-router guard: `npx vitest run src/routes/devices/index.test.ts` (must stay green).
+
+- [ ] **Step 5: Add a mount-order assertion** to `apps/api/src/routes/devices/index.test.ts` (find the existing `describe` for static-before-dynamic; add a case): request `GET /devices/removal-config` with the file's standard auth mock and assert `status !== 404 && status !== 400` and the body has `uninstallDrainWindowHours`. Run, expect PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/routes/devices/removalConfig.ts apps/api/src/routes/devices/removalConfig.test.ts apps/api/src/routes/devices/index.ts apps/api/src/routes/devices/index.test.ts
+git commit -m "feat(api): GET /devices/removal-config exposes the uninstall drain window (#3987)"
+```
+
+---
+
+### Task 2: Web service — `decommissionDevice` / `bulkDecommissionDevices` send `uninstallAgent`; add `fetchRemovalConfig`
+
+**Files:**
+- Modify: `apps/web/src/services/deviceActions.ts:386-398` and `:490-506`
+- Test: `apps/web/src/services/deviceActions.test.ts`
+
+**Interfaces:**
+- Produces:
+  ```ts
+  export interface RemoveDeviceOptions { uninstallAgent: boolean }
+  export async function decommissionDevice(deviceId: string, opts: RemoveDeviceOptions): Promise<{ success: boolean; uninstallQueued?: boolean }>
+  export async function bulkDecommissionDevices(devices: Array<{ id: string; hostname: string }>, opts: RemoveDeviceOptions): Promise<BulkDecommissionResult>
+  export async function fetchRemovalConfig(): Promise<{ uninstallDrainWindowHours: number }>
+  ```
+
+- [ ] **Step 1: Write the failing tests** (append to `deviceActions.test.ts`; it already mocks `@/stores/auth` `fetchWithAuth` and has `makeJsonResponse`)
+
+```ts
+import { decommissionDevice, bulkDecommissionDevices, fetchRemovalConfig } from './deviceActions';
+
+describe('decommissionDevice — agent choice is sent to the API', () => {
+  it('sends { uninstallAgent: true } as the JSON body', async () => {
+    fetchMock.mockResolvedValue(makeJsonResponse({ success: true, uninstallQueued: true }));
+    await decommissionDevice('dev-1', { uninstallAgent: true });
+    const [path, init] = fetchMock.mock.calls[0];
+    expect(path).toBe('/devices/dev-1');
+    expect(init?.method).toBe('DELETE');
+    expect(JSON.parse(String(init?.body))).toEqual({ uninstallAgent: true });
+    expect((init?.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+  });
+
+  it('sends { uninstallAgent: false } when the user chose to leave the agent', async () => {
+    fetchMock.mockResolvedValue(makeJsonResponse({ success: true, uninstallQueued: false }));
+    await decommissionDevice('dev-1', { uninstallAgent: false });
+    expect(JSON.parse(String(fetchMock.mock.calls[0][1]?.body))).toEqual({ uninstallAgent: false });
+  });
+});
+
+describe('bulkDecommissionDevices — one body per device, same choice', () => {
+  it('forwards the same uninstallAgent to every DELETE', async () => {
+    fetchMock.mockResolvedValue(makeJsonResponse({ success: true }));
+    const result = await bulkDecommissionDevices(
+      [{ id: 'a', hostname: 'A' }, { id: 'b', hostname: 'B' }],
+      { uninstallAgent: true },
+    );
+    expect(result).toEqual({ succeeded: 2, failed: [] });
+    for (const call of fetchMock.mock.calls) {
+      expect(JSON.parse(String(call[1]?.body))).toEqual({ uninstallAgent: true });
+    }
+  });
+});
+
+describe('fetchRemovalConfig', () => {
+  it('returns the drain window from GET /devices/removal-config', async () => {
+    fetchMock.mockResolvedValue(makeJsonResponse({ uninstallDrainWindowHours: 48 }));
+    expect(await fetchRemovalConfig()).toEqual({ uninstallDrainWindowHours: 48 });
+    expect(fetchMock.mock.calls[0][0]).toBe('/devices/removal-config');
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL** (TypeScript: `Expected 1 arguments`; `fetchRemovalConfig` not exported)
+
+```bash
+cd apps/web && npx vitest run src/services/deviceActions.test.ts
+```
+
+- [ ] **Step 3: Implement**
+
+Replace `decommissionDevice`:
+
+```ts
+export interface RemoveDeviceOptions {
+  /**
+   * Queue a durable self_uninstall alongside the Remove (#3986/#4001). The
+   * API defaults this to false for back-compat; the WEB defaults it to true
+   * in RemoveDeviceDialog — defaulting to "leave installed" is what produces
+   * zombie agents nobody notices (owner decision 2026-08-24).
+   */
+  uninstallAgent: boolean;
+}
+
+export async function decommissionDevice(
+  deviceId: string,
+  opts: RemoveDeviceOptions,
+): Promise<{ success: boolean; uninstallQueued?: boolean }> {
+  const response = await fetchWithAuth(`/devices/${deviceId}`, {
+    method: 'DELETE',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ uninstallAgent: opts.uninstallAgent }),
+  });
+
+  if (!response.ok) {
+    throw new Error(await getErrorMessage(response, 'Failed to remove device'));
+  }
+
+  const data = await response.json();
+  return data.data ?? data;
+}
+
+export async function fetchRemovalConfig(): Promise<{ uninstallDrainWindowHours: number }> {
+  const response = await fetchWithAuth('/devices/removal-config');
+  if (!response.ok) {
+    throw new Error(await getErrorMessage(response, 'Failed to load removal settings'));
+  }
+  return response.json();
+}
+```
+
+Change `bulkDecommissionDevices` signature to `(devices, opts: RemoveDeviceOptions)` and call `decommissionDevice(device.id, opts)` in the loop.
+
+- [ ] **Step 4: Run — expect PASS.** Then `cd apps/web && npx tsc --noEmit -p tsconfig.json 2>&1 | grep deviceActions` — expect call-site errors in DevicesPage.tsx / DeviceDetailPage.tsx (fixed in Tasks 4–5; that is the point of the required arg).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/services/deviceActions.ts apps/web/src/services/deviceActions.test.ts
+git commit -m "feat(web): deviceActions sends uninstallAgent on Remove; add fetchRemovalConfig (#3987)"
+```
+
+---
+
+### Task 3: `RemoveDeviceDialog` component
+
+**Files:**
+- Create: `apps/web/src/components/devices/RemoveDeviceDialog.tsx`
+- Create: `apps/web/src/components/devices/RemoveDeviceDialog.test.tsx`
+- Modify: `apps/web/src/locales/en/devices.json` (new `removeDialog` block under `deviceActions`) + the 7 other locales
+
+**Interfaces:**
+- Consumes: `fetchRemovalConfig` (Task 2), `ConfirmDialog` (`../shared/ConfirmDialog`).
+- Produces:
+  ```ts
+  export interface RemoveDialogTarget { hostname: string; status: string }
+  export interface RemoveDeviceDialogProps {
+    open: boolean;
+    targets: RemoveDialogTarget[];          // 1 = single, >1 = bulk
+    onClose: () => void;
+    onConfirm: (choice: { uninstallAgent: boolean }) => void;
+    isLoading?: boolean;
+    confirmTestId?: string;
+  }
+  export default function RemoveDeviceDialog(props: RemoveDeviceDialogProps): JSX.Element | null
+  ```
+
+- [ ] **Step 1: Add locale keys** to `apps/web/src/locales/en/devices.json` inside the existing `"deviceActions"` object (sibling of `"confirm"`):
+
+```json
+"removeDialog": {
+  "titleOne": "Remove {{hostname}}?",
+  "titleMany": "Remove {{count}} devices?",
+  "bodyOne": "It will be taken out of your active fleet and stop being monitored. History is kept and you can restore it later.",
+  "bodyMany": "They will be taken out of your active fleet and stop being monitored. History is kept and you can restore them later.",
+  "summary": "{{online}} online, {{notOnline}} not currently online.",
+  "legend": "What should happen to the Breeze agent?",
+  "uninstall": "Uninstall the Breeze agent",
+  "uninstallOnline": "Queued now — an online agent collects it within moments.",
+  "uninstallQueuedWithWindow": "Queued — runs the next time the device checks in. Cancelled if it hasn't after {{hours}} hours.",
+  "uninstallQueued": "Queued — runs the next time the device checks in.",
+  "uninstallMixed": "Online devices collect it within moments; the rest run it on their next check-in.",
+  "leave": "Leave the agent installed",
+  "leaveHint": "The machine keeps running the agent but can't be managed.",
+  "confirm": "Remove"
+}
+```
+
+Add the same block (translated) to `de-DE`, `es-419`, `fr-CA`, `fr-FR`, `it-IT`, `pt-BR`, `tr-TR` `devices.json`. Keep `{{hostname}}`, `{{count}}`, `{{online}}`, `{{notOnline}}`, `{{hours}}` tokens verbatim. Run `npx vitest run src/lib/i18n/localeParity.test.ts` — expect PASS.
+
+- [ ] **Step 2: Write the failing component test**
+
+```tsx
+// apps/web/src/components/devices/RemoveDeviceDialog.test.tsx
+import '@/lib/i18n';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../services/deviceActions', () => ({
+  fetchRemovalConfig: vi.fn(),
+}));
+import { fetchRemovalConfig } from '../../services/deviceActions';
+import RemoveDeviceDialog from './RemoveDeviceDialog';
+
+const cfg = vi.mocked(fetchRemovalConfig);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  cfg.mockResolvedValue({ uninstallDrainWindowHours: 72 });
+});
+
+describe('RemoveDeviceDialog', () => {
+  it('defaults the agent radio to Uninstall and confirms with uninstallAgent: true', async () => {
+    const onConfirm = vi.fn();
+    render(<RemoveDeviceDialog open targets={[{ hostname: 'WKSTN-042', status: 'online' }]} onClose={() => {}} onConfirm={onConfirm} confirmTestId="remove-confirm" />);
+    expect(screen.getByRole('radio', { name: /uninstall the breeze agent/i })).toBeChecked();
+    fireEvent.click(screen.getByTestId('remove-confirm'));
+    expect(onConfirm).toHaveBeenCalledWith({ uninstallAgent: true });
+  });
+
+  it('confirms with uninstallAgent: false when Leave is chosen', () => {
+    const onConfirm = vi.fn();
+    render(<RemoveDeviceDialog open targets={[{ hostname: 'WKSTN-042', status: 'offline' }]} onClose={() => {}} onConfirm={onConfirm} confirmTestId="remove-confirm" />);
+    fireEvent.click(screen.getByRole('radio', { name: /leave the agent installed/i }));
+    fireEvent.click(screen.getByTestId('remove-confirm'));
+    expect(onConfirm).toHaveBeenCalledWith({ uninstallAgent: false });
+  });
+
+  it('says "queued now" for an online device and never says "runs now"', () => {
+    render(<RemoveDeviceDialog open targets={[{ hostname: 'A', status: 'online' }]} onClose={() => {}} onConfirm={() => {}} />);
+    expect(screen.getByText(/queued now/i)).toBeInTheDocument();
+    expect(screen.queryByText(/runs now/i)).toBeNull();
+  });
+
+  it('shows the drain window from the API for a not-online device', async () => {
+    render(<RemoveDeviceDialog open targets={[{ hostname: 'A', status: 'maintenance' }]} onClose={() => {}} onConfirm={() => {}} />);
+    await waitFor(() => expect(screen.getByText(/after 72 hours/i)).toBeInTheDocument());
+  });
+
+  it('falls back to window-less copy when the config fetch fails', async () => {
+    cfg.mockRejectedValue(new Error('boom'));
+    render(<RemoveDeviceDialog open targets={[{ hostname: 'A', status: 'offline' }]} onClose={() => {}} onConfirm={() => {}} />);
+    await waitFor(() => expect(cfg).toHaveBeenCalled());
+    expect(screen.getByText(/runs the next time the device checks in\.$/i)).toBeInTheDocument();
+    expect(screen.queryByText(/after .* hours/i)).toBeNull();
+  });
+
+  it('bulk: titles with the count and buckets online vs not-currently-online', () => {
+    render(<RemoveDeviceDialog open targets={[
+      { hostname: 'A', status: 'online' },
+      { hostname: 'B', status: 'offline' },
+      { hostname: 'C', status: 'quarantined' },
+    ]} onClose={() => {}} onConfirm={() => {}} />);
+    expect(screen.getByText('Remove 3 devices?')).toBeInTheDocument();
+    expect(screen.getByText('1 online, 2 not currently online.')).toBeInTheDocument();
+    expect(screen.queryByText(/offline/i)).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 3: Run — expect FAIL** (`Cannot find module './RemoveDeviceDialog'`)
+
+```bash
+cd apps/web && npx vitest run src/components/devices/RemoveDeviceDialog.test.tsx
+```
+
+- [ ] **Step 4: Implement**
+
+```tsx
+// apps/web/src/components/devices/RemoveDeviceDialog.tsx
+import { useEffect, useId, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ConfirmDialog } from '../shared/ConfirmDialog';
+import { fetchRemovalConfig } from '../../services/deviceActions';
+
+export interface RemoveDialogTarget {
+  hostname: string;
+  status: string;
+}
+
+export interface RemoveDeviceDialogProps {
+  open: boolean;
+  /** One entry = single-device Remove; several = bulk Remove (one choice for all). */
+  targets: RemoveDialogTarget[];
+  onClose: () => void;
+  onConfirm: (choice: { uninstallAgent: boolean }) => void;
+  isLoading?: boolean;
+  confirmTestId?: string;
+}
+
+/**
+ * The Remove confirm (#3987). Composes ConfirmDialog — it already has a
+ * `children` slot and the #3705 single-fire latch — and adds the one question
+ * Remove actually needs answered: what happens to the agent.
+ *
+ * DEFAULTS TO UNINSTALL. Owner decision 2026-08-24: defaulting to "leave
+ * installed" is what produces zombie agents heartbeating into a 403 forever.
+ *
+ * Copy says "queued", never "runs now": DELETE /devices/:id inserts a pending
+ * self_uninstall and force-closes the agent WS (core.ts) — the agent collects
+ * the command on its next poll, moments later if online. The wait window for
+ * a device that never checks in is env-driven on the API
+ * (DEVICE_UNINSTALL_DRAIN_WINDOW_HOURS), so it is fetched, not hardcoded.
+ */
+export default function RemoveDeviceDialog({
+  open,
+  targets,
+  onClose,
+  onConfirm,
+  isLoading = false,
+  confirmTestId,
+}: RemoveDeviceDialogProps) {
+  const { t } = useTranslation('devices');
+  const [uninstallAgent, setUninstallAgent] = useState(true);
+  const [windowHours, setWindowHours] = useState<number | null>(null);
+  const legendId = useId();
+
+  useEffect(() => {
+    if (!open) return;
+    setUninstallAgent(true);
+    let cancelled = false;
+    fetchRemovalConfig()
+      .then((cfg) => { if (!cancelled) setWindowHours(cfg.uninstallDrainWindowHours); })
+      .catch(() => { if (!cancelled) setWindowHours(null); });
+    return () => { cancelled = true; };
+  }, [open]);
+
+  if (!open || targets.length === 0) return null;
+
+  const online = targets.filter((d) => d.status === 'online').length;
+  const notOnline = targets.length - online;
+  const many = targets.length > 1;
+
+  let uninstallHint: string;
+  if (many && online > 0 && notOnline > 0) {
+    uninstallHint = t('deviceActions.removeDialog.uninstallMixed');
+  } else if (notOnline === 0) {
+    uninstallHint = t('deviceActions.removeDialog.uninstallOnline');
+  } else if (windowHours != null) {
+    uninstallHint = t('deviceActions.removeDialog.uninstallQueuedWithWindow', { hours: windowHours });
+  } else {
+    uninstallHint = t('deviceActions.removeDialog.uninstallQueued');
+  }
+
+  return (
+    <ConfirmDialog
+      open
+      onClose={onClose}
+      onConfirm={() => onConfirm({ uninstallAgent })}
+      title={many
+        ? t('deviceActions.removeDialog.titleMany', { count: targets.length })
+        : t('deviceActions.removeDialog.titleOne', { hostname: targets[0].hostname })}
+      message={many ? t('deviceActions.removeDialog.bodyMany') : t('deviceActions.removeDialog.bodyOne')}
+      confirmLabel={t('deviceActions.removeDialog.confirm')}
+      variant="destructive"
+      isLoading={isLoading}
+      confirmTestId={confirmTestId}
+    >
+      {many && (
+        <p className="text-sm text-muted-foreground" data-testid="remove-dialog-summary">
+          {t('deviceActions.removeDialog.summary', { online, notOnline })}
+        </p>
+      )}
+      <fieldset className="mt-3 space-y-2" aria-labelledby={legendId}>
+        <legend id={legendId} className="text-sm font-medium">
+          {t('deviceActions.removeDialog.legend')}
+        </legend>
+        <label className="flex items-start gap-2 text-sm">
+          <input
+            type="radio"
+            name="remove-agent-choice"
+            className="mt-1"
+            checked={uninstallAgent}
+            onChange={() => setUninstallAgent(true)}
+            data-testid="remove-choice-uninstall"
+          />
+          <span>
+            <span className="block">{t('deviceActions.removeDialog.uninstall')}</span>
+            <span className="block text-xs text-muted-foreground">{uninstallHint}</span>
+          </span>
+        </label>
+        <label className="flex items-start gap-2 text-sm">
+          <input
+            type="radio"
+            name="remove-agent-choice"
+            className="mt-1"
+            checked={!uninstallAgent}
+            onChange={() => setUninstallAgent(false)}
+            data-testid="remove-choice-leave"
+          />
+          <span>
+            <span className="block">{t('deviceActions.removeDialog.leave')}</span>
+            <span className="block text-xs text-muted-foreground">{t('deviceActions.removeDialog.leaveHint')}</span>
+          </span>
+        </label>
+      </fieldset>
+    </ConfirmDialog>
+  );
+}
+```
+
+- [ ] **Step 5: Run — expect PASS** (all six). Also `npx vitest run src/lib/i18n/keyUsage.test.ts src/lib/i18n/localeParity.test.ts` — PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/devices/RemoveDeviceDialog.tsx apps/web/src/components/devices/RemoveDeviceDialog.test.tsx apps/web/src/locales/*/devices.json
+git commit -m "feat(web): RemoveDeviceDialog — agent uninstall choice, defaults to uninstall (#3987)"
+```
+
+---
+
+### Task 4: Wire DevicesPage — single (row/card) and bulk Remove
+
+**Files:**
+- Modify: `apps/web/src/components/devices/DevicesPage.tsx` (`runDeviceAction` ~:760, `case 'decommission'` :873, bulk `case 'decommission'` :1180, `pendingDeviceAction` render :1579)
+- Test: `apps/web/src/components/devices/DevicesPage.test.tsx` (mocks `decommissionDevice`/`bulkDecommissionDevices` at :43-44)
+
+**Interfaces:**
+- Consumes: `RemoveDeviceDialog` (Task 3), `RemoveDeviceOptions` (Task 2).
+- Produces (internal): `runDeviceAction(action: string, device: Device, opts?: { uninstallAgent?: boolean })`; new state `pendingBulkRemove: Device[] | null`.
+
+- [ ] **Step 1: Write the failing tests** (append to `DevicesPage.test.tsx`, using the file's existing helpers for rendering a fleet and opening the row kebab / bulk menu — copy the setup from the test at :1235 "bulkDecommissionDevices fires one DELETE…")
+
+```tsx
+describe('Remove — agent choice (#3987)', () => {
+  it('single Remove from the row kebab opens the agent-choice dialog and sends uninstallAgent: true by default', async () => {
+    const { decommissionDevice } = await import('../../services/deviceActions');
+    vi.mocked(decommissionDevice).mockResolvedValue({ success: true } as never);
+    // …render fleet with one online agent device; open its kebab; click "Remove"
+    // (same steps the existing "#3698 confirm gate" test in this file uses)…
+    expect(screen.getByRole('radio', { name: /uninstall the breeze agent/i })).toBeChecked();
+    fireEvent.click(screen.getByTestId('confirm-device-action'));
+    // 5-second undo toast still fires; advance it
+    await act(async () => { vi.advanceTimersByTime(5000); });
+    await waitFor(() => expect(vi.mocked(decommissionDevice)).toHaveBeenCalledWith(expect.any(String), { uninstallAgent: true }));
+  });
+
+  it('bulk Remove asks once and forwards the choice to bulkDecommissionDevices', async () => {
+    const { bulkDecommissionDevices } = await import('../../services/deviceActions');
+    vi.mocked(bulkDecommissionDevices).mockResolvedValue({ succeeded: 2, failed: [] } as never);
+    // …render 2 active devices, select all, Bulk Actions → Remove Selected…
+    expect(screen.getByText('Remove 2 devices?')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('radio', { name: /leave the agent installed/i }));
+    fireEvent.click(screen.getByTestId('confirm-bulk-remove'));
+    await waitFor(() => expect(vi.mocked(bulkDecommissionDevices)).toHaveBeenCalledTimes(1));
+    expect(vi.mocked(bulkDecommissionDevices).mock.calls[0][1]).toEqual({ uninstallAgent: false });
+  });
+});
+```
+
+(Fill the `// …` lines with the exact render/select helpers already present in this test file — they exist at :1235-1290 for the bulk path and in the "#3698" describe for the row kebab. Do not invent new fixtures.)
+
+- [ ] **Step 2: Run — expect FAIL**
+
+```bash
+cd apps/web && npx vitest run src/components/devices/DevicesPage.test.tsx -t "agent choice"
+```
+
+- [ ] **Step 3: Implement in `DevicesPage.tsx`**
+
+a) Import: `import RemoveDeviceDialog from './RemoveDeviceDialog';`
+
+b) State (next to `pendingDeviceAction`):
+```ts
+  // #3987: bulk Remove asks the agent question ONCE for the whole selection.
+  const [pendingBulkRemove, setPendingBulkRemove] = useState<Device[] | null>(null);
+```
+
+c) `runDeviceAction` signature → `(action: string, device: Device, opts?: { uninstallAgent?: boolean })`. In `case 'decommission'` replace `await decommissionDevice(device.id);` with:
+```ts
+              await decommissionDevice(device.id, { uninstallAgent: opts?.uninstallAgent ?? true });
+```
+
+d) In `runBulkAction`, replace the body of `case 'decommission'` so it defers to the dialog:
+```ts
+        case 'decommission': {
+          // Ask the agent question once for the whole selection (#3987). The
+          // actual loop runs in runBulkRemove after the dialog confirms.
+          setPendingBulkRemove(selectedDevices);
+          return;
+        }
+```
+and add a new function directly after `runBulkAction`:
+```ts
+  const runBulkRemove = async (selectedDevices: Device[], choice: { uninstallAgent: boolean }) => {
+    setActionInProgress(true);
+    try {
+      const result = await bulkDecommissionDevices(
+        selectedDevices.map(d => ({ id: d.id, hostname: d.hostname })),
+        choice,
+      );
+      if (result.failed.length === 0) {
+        showToast({ type: 'success', message: t('devicesPage.toasts.bulkDecommissioned', { count: result.succeeded }) });
+      } else if (result.succeeded === 0) {
+        showToast({ type: 'error', message: t('devicesPage.toasts.bulkDecommissionAllFailed', { count: result.failed.length, devices: summarizeFailedDevices(result.failed.map(f => f.hostname)) }) });
+      } else {
+        showToast({ type: 'error', message: t('devicesPage.toasts.bulkDecommissionFailed', { succeeded: result.succeeded, failed: result.failed.length, devices: summarizeFailedDevices(result.failed.map(f => f.hostname)) }) });
+      }
+      await fetchDevices();
+    } catch (err) {
+      showToast({ type: 'error', message: err instanceof Error ? err.message : t('devicesPage.toasts.bulkActionFailed', { action: 'decommission' }) });
+    } finally {
+      setActionInProgress(false);
+    }
+  };
+```
+Check `runBulkAction`'s `finally { setActionInProgress(false) }` still runs on the early `return` (it does — `return` inside `try` runs `finally`).
+
+e) In the JSX, change the `pendingDeviceAction` block so `decommission` renders the new dialog and everything else keeps `ConfirmDialog`:
+```tsx
+      {pendingDeviceAction && pendingDeviceAction.action === 'decommission' && (
+        <RemoveDeviceDialog
+          open
+          targets={[{ hostname: pendingDeviceAction.device.hostname, status: pendingDeviceAction.device.status }]}
+          onClose={() => setPendingDeviceAction(null)}
+          onConfirm={(choice) => {
+            const p = pendingDeviceAction;
+            setPendingDeviceAction(null);
+            void runDeviceAction(p.action, p.device, choice);
+          }}
+          confirmTestId="confirm-device-action"
+        />
+      )}
+      {pendingDeviceAction && pendingDeviceAction.action !== 'decommission' && (
+        <ConfirmDialog … existing props unchanged … />
+      )}
+      {pendingBulkRemove && (
+        <RemoveDeviceDialog
+          open
+          targets={pendingBulkRemove.map(d => ({ hostname: d.hostname, status: d.status }))}
+          onClose={() => setPendingBulkRemove(null)}
+          onConfirm={(choice) => {
+            const devicesToRemove = pendingBulkRemove;
+            setPendingBulkRemove(null);
+            void runBulkRemove(devicesToRemove, choice);
+          }}
+          isLoading={actionInProgress}
+          confirmTestId="confirm-bulk-remove"
+        />
+      )}
+```
+
+- [ ] **Step 4: Run the whole file — expect PASS**, including the pre-existing bulk-decommission tests at :1235-1290 (update their assertions to the two-arg call: `mock.calls[0][0]` still holds the device list; they now also need to click through the new dialog — add `fireEvent.click(screen.getByTestId('confirm-bulk-remove'))` after opening "Remove Selected").
+
+```bash
+cd apps/web && npx vitest run src/components/devices/DevicesPage.test.tsx
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/devices/DevicesPage.tsx apps/web/src/components/devices/DevicesPage.test.tsx
+git commit -m "feat(web): DevicesPage Remove (row, card, bulk) goes through RemoveDeviceDialog (#3987)"
+```
+
+---
+
+### Task 5: Wire DeviceActions (detail page) and DeviceDetailPage
+
+**Files:**
+- Modify: `apps/web/src/components/devices/DeviceActions.tsx` (`onAction` prop :100, `handleConfirm` :251, `getModalConfig` case :176, both `<ConfirmDialog` renders :451 and :659)
+- Modify: `apps/web/src/components/devices/DeviceDetailPage.tsx` (`handleAction` :219, `case "decommission"` :363)
+- Test: `apps/web/src/components/devices/DeviceActions.test.tsx` (exists)
+
+**Interfaces:**
+- Produces: `onAction?: (action: string, device: Device, opts?: DeviceActionOptions) => void | Promise<void>` where `export interface DeviceActionOptions { uninstallAgent?: boolean }` is exported from `DeviceActions.tsx`.
+
+- [ ] **Step 1: Write the failing test** (append to `DeviceActions.test.tsx`, reusing its render helper and `baseDevice`)
+
+```tsx
+it('Remove opens the agent-choice dialog and forwards the choice to onAction', () => {
+  const onAction = vi.fn();
+  render(<DeviceActions device={{ ...baseDevice, status: 'online' }} onAction={onAction} />);
+  // open the actions menu and click Remove (testid used by the existing menu-parity tests)
+  fireEvent.click(screen.getByTestId('device-actions-menu-trigger'));
+  fireEvent.click(screen.getByTestId('device-action-decommission'));
+  expect(screen.getByRole('radio', { name: /uninstall the breeze agent/i })).toBeChecked();
+  fireEvent.click(screen.getByRole('radio', { name: /leave the agent installed/i }));
+  fireEvent.click(screen.getByTestId('device-actions-remove-confirm'));
+  expect(onAction).toHaveBeenCalledWith('decommission', expect.objectContaining({ id: baseDevice.id }), { uninstallAgent: false });
+});
+```
+
+If the menu trigger / Remove item testids differ, read the existing parity tests in the same file and use those testids — do not add new ones for the trigger.
+
+- [ ] **Step 2: Run — expect FAIL**
+
+```bash
+cd apps/web && npx vitest run src/components/devices/DeviceActions.test.tsx -t "agent-choice"
+```
+
+- [ ] **Step 3: Implement**
+
+`DeviceActions.tsx`:
+```ts
+export interface DeviceActionOptions { uninstallAgent?: boolean }
+// prop:
+  onAction?: (action: string, device: Device, opts?: DeviceActionOptions) => void | Promise<void>;
+```
+`handleConfirm` becomes `(opts?: DeviceActionOptions)` and calls `await onAction?.(modalType, device, opts)`. Remove the `case "decommission"` from `getModalConfig` (the dialog owns its copy). At BOTH `<ConfirmDialog` render sites (compact :451 and full :659) wrap:
+```tsx
+        {modalType === 'decommission' ? (
+          <RemoveDeviceDialog
+            open
+            targets={[{ hostname: device.hostname, status: device.status }]}
+            onClose={closeModal}
+            onConfirm={(choice) => void handleConfirm(choice)}
+            isLoading={loading}
+            confirmTestId="device-actions-remove-confirm"
+          />
+        ) : modalCfg && (
+          <ConfirmDialog … unchanged … />
+        )}
+```
+Import `RemoveDeviceDialog from './RemoveDeviceDialog'`.
+
+`DeviceDetailPage.tsx`: `handleAction = async (action: string, device: Device, opts?: DeviceActionOptions)`; in `case "decommission"` call `await decommissionDevice(device.id, { uninstallAgent: opts?.uninstallAgent ?? true });`. Import the `DeviceActionOptions` type from `./DeviceActions`.
+
+- [ ] **Step 4: Run — expect PASS.** Then `cd apps/web && npx tsc --noEmit -p tsconfig.json` — expect zero errors from `deviceActions`, `DevicesPage`, `DeviceDetailPage`, `DeviceActions`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/devices/DeviceActions.tsx apps/web/src/components/devices/DeviceActions.test.tsx apps/web/src/components/devices/DeviceDetailPage.tsx
+git commit -m "feat(web): detail-page Remove goes through RemoveDeviceDialog (#3987)"
+```
+
+---
+
+### Task 6: Wire PossibleReplacementBanner (the fifth surface)
+
+**Files:**
+- Modify: `apps/web/src/components/devices/PossibleReplacementBanner.tsx:115-125` and `:198-218`
+- Test: `apps/web/src/components/devices/PossibleReplacementBanner.test.tsx`
+
+- [ ] **Step 1: Write the failing test** (append; file already mocks `fetchWithAuth` and has `jsonResponse` + `oldDevicePayload`)
+
+```tsx
+it('Remove old device asks about the agent and sends uninstallAgent in the DELETE body', async () => {
+  fetchWithAuthMock.mockResolvedValueOnce(jsonResponse(oldDevicePayload({ status: 'offline' })));
+  fetchWithAuthMock.mockResolvedValueOnce(jsonResponse({ uninstallDrainWindowHours: 72 })); // removal-config
+  fetchWithAuthMock.mockResolvedValueOnce(jsonResponse({ success: true }));                 // DELETE
+  fetchWithAuthMock.mockResolvedValueOnce(jsonResponse(oldDevicePayload({ status: 'decommissioned' })));
+  render(<PossibleReplacementBanner oldDeviceId={OLD_DEVICE_ID} />);
+  fireEvent.click(await screen.findByRole('button', { name: /remove old device/i }));
+  expect(screen.getByRole('radio', { name: /uninstall the breeze agent/i })).toBeChecked();
+  fireEvent.click(screen.getByTestId('possible-replacement-confirm'));
+  await waitFor(() => {
+    const del = fetchWithAuthMock.mock.calls.find(([, init]) => init?.method === 'DELETE');
+    expect(del).toBeDefined();
+    expect(JSON.parse(String(del![1]?.body))).toEqual({ uninstallAgent: true });
+  });
+});
+```
+
+(If the banner test file mocks `../../services/deviceActions` elsewhere, mock `fetchRemovalConfig` there instead of the second `fetchWithAuth` response.)
+
+- [ ] **Step 2: Run — expect FAIL**
+
+```bash
+cd apps/web && npx vitest run src/components/devices/PossibleReplacementBanner.test.tsx -t "uninstallAgent"
+```
+
+- [ ] **Step 3: Implement**
+
+`handleDecommission = async (choice: { uninstallAgent: boolean })` and the request becomes:
+```ts
+        request: () => fetchWithAuth(`/devices/${oldDeviceId}`, {
+          method: 'DELETE',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ uninstallAgent: choice.uninstallAgent }),
+        }),
+```
+Replace the `<ConfirmDialog …>` at :202 with:
+```tsx
+        <RemoveDeviceDialog
+          open
+          targets={[{ hostname: label, status: oldDevice?.status ?? 'offline' }]}
+          onClose={() => { if (!busy) setConfirmOpen(false); }}
+          onConfirm={(choice) => void handleDecommission(choice)}
+          isLoading={busy}
+          confirmTestId="possible-replacement-confirm"
+        />
+```
+Import `RemoveDeviceDialog`; drop the now-unused `ConfirmDialog` import; update the comment at :50 to name `RemoveDeviceDialog`.
+
+- [ ] **Step 4: Run the whole file — expect PASS.** Run `npx vitest run src/lib/__tests__/no-silent-mutations.test.ts` — PASS (still goes through `runAction`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/devices/PossibleReplacementBanner.tsx apps/web/src/components/devices/PossibleReplacementBanner.test.tsx
+git commit -m "feat(web): replacement banner Remove goes through RemoveDeviceDialog (#3987)"
+```
+
+---
+
+### Task 7: Guard — no bodyless Remove can come back
+
+**Files:**
+- Create: `apps/web/src/components/devices/__tests__/removeSendsUninstallChoice.test.ts`
+
+- [ ] **Step 1: Write the test** (static source scan; fails on any `DELETE` to `/devices/${…}` without a JSON body outside `deviceActions.ts`)
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '../../..');
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) walk(p, out);
+    else if (/\.(ts|tsx)$/.test(p) && !/\.test\.tsx?$/.test(p)) out.push(p);
+  }
+  return out;
+}
+
+describe('every Remove sends the agent choice (#3987)', () => {
+  it('no component issues a bodyless DELETE /devices/:id', () => {
+    const offenders: string[] = [];
+    for (const file of walk(join(root, 'components'))) {
+      const src = readFileSync(file, 'utf8');
+      // fetchWithAuth(`/devices/${x}`, { method: 'DELETE' }) with no `body:` in the same call
+      const re = /fetchWithAuth\(\s*`\/devices\/\$\{[^}]+\}`\s*,\s*\{([^}]*)\}\s*\)/g;
+      let m: RegExpExecArray | null;
+      while ((m = re.exec(src))) {
+        if (/method:\s*['"]DELETE['"]/.test(m[1]) && !/body:/.test(m[1])) offenders.push(file.replace(root, ''));
+      }
+    }
+    expect(offenders, 'Route these through decommissionDevice(id, { uninstallAgent }) or add the JSON body').toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect PASS** (Task 6 removed the last offender). Temporarily revert Task 6's body to confirm it FAILS, then restore.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/components/devices/__tests__/removeSendsUninstallChoice.test.ts
+git commit -m "test(web): guard — every Remove must send the agent choice (#3987)"
+```
+
+---
+
+### Task 8: PR
+
+- [ ] Run: `cd apps/web && npx vitest run src/components/devices src/services/deviceActions.test.ts src/lib/i18n` and `cd apps/api && npx vitest run src/routes/devices` — all green. `pnpm lint` clean.
+- [ ] Merge `origin/main` into the branch before pushing (CI tests the merge commit).
+- [ ] Open PR titled `feat(web): Remove asks about the agent — uninstall by default (#3987 items 2, 6)`. Body: the zombie gap (web never sent `uninstallAgent`), the five surfaces, the copy decisions (queued not "runs now"; window fetched), screenshots of single and bulk dialogs. `Refs #3987, closes #2250`. Stop at the PR.

--- a/docs/superpowers/plans/device-lifecycle/2026-09-05-device-removal-02-lifecycle-service-and-bulk.md
+++ b/docs/superpowers/plans/device-lifecycle/2026-09-05-device-removal-02-lifecycle-service-and-bulk.md
@@ -1,0 +1,1029 @@
+---
+tracking_issue: LanternOps/breeze#5023
+---
+# Device Removal 02 — Lifecycle Service Hardening + Bulk Restore / Bulk Purge Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A selection of removed devices offers exactly Restore and Delete permanently; both work in bulk; single and bulk share one hardened lifecycle service so a purge can never race a restore or destroy a pending agent uninstall.
+
+**Architecture:** Extract `services/deviceLifecycle.ts` (`restoreRemovedDevice`, `purgeRemovedDevice`) that lock the `devices` row first, re-check state under the lock, and refuse purge while a `device_remove` uninstall is pending. Single routes become thin wrappers. Bulk restore is a synchronous self-managed route over `runBulkIsolated`. Bulk purge is a BullMQ job (`device-bulk-purge`) returning `202 { jobId }` with a status endpoint; the worker re-verifies org + status per device under a system context. The web bulk bar becomes selection-aware with a third gating set `REMOVED_ONLY_BULK_ACTIONS`.
+
+**Tech Stack:** Hono, Drizzle, postgres-js, BullMQ, Vitest (API unit + integration); React, react-i18next, Vitest/jsdom (web).
+
+**Spec:** `docs/superpowers/specs/device-lifecycle/2026-09-05-device-removal-completion-design.md` (PR 2). Issues: #2787 (closes), #3987 item 3.
+
+## Global Constraints
+
+- **Rigor: high** — data deletion + concurrency. TDD every task; integration suite in Task 3 is mandatory before the PR.
+- Lock order everywhere: `devices` row `FOR UPDATE` FIRST, then anything in `device_commands`. (`deviceDeletion.ts:79` explains the AB-BA class; Restore currently violates it.)
+- Purge REFUSES while a `self_uninstall` row with `uninstall_reasons @> {device_remove}` is `pending`/`sent` and unexpired → `409 UNINSTALL_PENDING`. The legacy fire-and-forget WS uninstall in `DELETE /:id/permanent` is REMOVED.
+- No new tables. No migration. The only new persistent state is the BullMQ job payload in Redis.
+- New static paths (`/bulk/restore`, `/bulk/permanent-delete`, `/bulk/purge-runs/:jobId`) are mounted BEFORE `coreRoutes` and guarded by a mount-order test.
+- Bulk restore route is registered in `middleware/selfManagedDbContextRoutes.ts` (request tx must not be held across the loop — `auth.ts:738`).
+- `DEVICES_DELETE` + `requireMfa()` on every new mutating route; `DEVICES_READ` on the status route. Partner-scope callers get **404** on another partner's job (mirror `routes/orgMerge.ts:246`).
+- Max 500 ids per bulk call, enforced by zod AND re-enforced in the worker.
+- Cascade lists untouched (no schema change) — but `cascadeDelete.test.ts` must stay green because it binds `deleteDeviceCascade` to the schema.
+- Locale keys → all 8 locales in the same commit.
+- Commit after each task. `cd apps/api && npx vitest run <file>`; never `pnpm --filter x test -- --run`.
+
+---
+
+### Task 1: `services/deviceLifecycle.ts` — restore + purge with lock-first, re-check, refusal
+
+**Files:**
+- Create: `apps/api/src/services/deviceLifecycle.ts`
+- Create: `apps/api/src/services/deviceLifecycle.test.ts`
+
+**Interfaces:**
+- Consumes: `deleteDeviceCascade(tx, deviceId)` (`services/deviceDeletion.ts:75`), `releaseDeviceRemoveReason(tx, deviceId, reason)` and `UNINSTALL_REASON_DEVICE_REMOVE` (`services/deviceUninstallDrain.ts`), `dissolveLinkGroupIfBelowMinimum(tx, linkGroupId)` (`services/deviceLinkGroups.ts`), `Tx` type from `deviceUninstallDrain.ts:52`.
+- Produces:
+  ```ts
+  export type DeviceLifecycleCode = 'NOT_FOUND' | 'NOT_REMOVED' | 'UNINSTALL_PENDING';
+  export class DeviceLifecycleError extends Error {
+    constructor(public readonly code: DeviceLifecycleCode, message: string) { super(message); }
+    get status(): 404 | 409 { return this.code === 'NOT_FOUND' ? 404 : 409; }
+  }
+  export interface RestoreResult { device: typeof devices.$inferSelect; uninstallAlreadyDispatched: boolean }
+  export interface PurgeResult { linkGroupDissolved: boolean }
+  /** Locks devices row, re-checks status='decommissioned', releases device_remove reason, flips to 'offline'. */
+  export async function restoreRemovedDevice(tx: Tx, deviceId: string): Promise<RestoreResult>
+  /** Locks devices row, re-checks status='decommissioned', refuses on pending device_remove uninstall, cascades, dissolves link group. */
+  export async function purgeRemovedDevice(tx: Tx, deviceId: string): Promise<PurgeResult>
+  ```
+  Both take a `Tx` because the caller owns the transaction (route: request tx or `db.transaction`; worker: `withSystemDbAccessContext` + `db.transaction`). Neither reads `auth` — the caller authorises first (`getDeviceWithOrgAndSiteCheck` or the worker's expected-org check).
+
+- [ ] **Step 1: Write the failing tests** (compiled-SQL style with a fake `tx`, mirroring `deviceUninstallDrain.test.ts`)
+
+```ts
+// apps/api/src/services/deviceLifecycle.test.ts
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./deviceDeletion', () => ({ deleteDeviceCascade: vi.fn(async () => undefined) }));
+vi.mock('./deviceLinkGroups', () => ({ dissolveLinkGroupIfBelowMinimum: vi.fn(async () => true) }));
+vi.mock('./deviceUninstallDrain', async (orig) => {
+  const actual = await orig<typeof import('./deviceUninstallDrain')>();
+  return { ...actual, releaseDeviceRemoveReason: vi.fn(async () => ({ cancelled: 1, retainedOtherOwner: 0, alreadyDispatched: 0 })) };
+});
+
+import { restoreRemovedDevice, purgeRemovedDevice, DeviceLifecycleError } from './deviceLifecycle';
+import { deleteDeviceCascade } from './deviceDeletion';
+import { releaseDeviceRemoveReason } from './deviceUninstallDrain';
+
+const DEV = '11111111-1111-4111-8111-111111111111';
+
+/** Minimal tx double: records the order of statements; scripted rows per call. */
+function makeTx(script: { lockRow?: Record<string, unknown> | null; pendingUninstall?: boolean; updatedRow?: Record<string, unknown> }) {
+  const calls: string[] = [];
+  const tx = {
+    execute: vi.fn(async (q: { queryChunks?: unknown } | string) => {
+      const text = JSON.stringify(q);
+      if (text.includes('FOR UPDATE')) { calls.push('lock'); return script.lockRow ? [script.lockRow] : []; }
+      if (text.includes('self_uninstall')) { calls.push('pending-check'); return script.pendingUninstall ? [{ id: 'cmd' }] : []; }
+      calls.push('execute'); return [];
+    }),
+    update: vi.fn(() => ({ set: () => ({ where: () => ({ returning: async () => { calls.push('update'); return [script.updatedRow ?? { id: DEV, status: 'offline' }]; } }) }) })),
+    select: vi.fn(),
+  };
+  return { tx: tx as never, calls };
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('restoreRemovedDevice', () => {
+  it('locks the devices row BEFORE releasing the uninstall reason (lock order)', async () => {
+    const { tx, calls } = makeTx({ lockRow: { id: DEV, status: 'decommissioned' } });
+    vi.mocked(releaseDeviceRemoveReason).mockImplementation(async () => { calls.push('release'); return { cancelled: 1, retainedOtherOwner: 0, alreadyDispatched: 0 }; });
+    await restoreRemovedDevice(tx, DEV);
+    expect(calls.indexOf('lock')).toBeLessThan(calls.indexOf('release'));
+    expect(calls.indexOf('release')).toBeLessThan(calls.indexOf('update'));
+  });
+
+  it('throws NOT_FOUND when the lock returns no row', async () => {
+    const { tx } = makeTx({ lockRow: null });
+    await expect(restoreRemovedDevice(tx, DEV)).rejects.toMatchObject({ code: 'NOT_FOUND', status: 404 });
+  });
+
+  it('throws NOT_REMOVED when the locked row is no longer decommissioned', async () => {
+    const { tx } = makeTx({ lockRow: { id: DEV, status: 'online' } });
+    await expect(restoreRemovedDevice(tx, DEV)).rejects.toMatchObject({ code: 'NOT_REMOVED', status: 409 });
+    expect(releaseDeviceRemoveReason).not.toHaveBeenCalled();
+  });
+
+  it('reports uninstallAlreadyDispatched from the release result', async () => {
+    const { tx } = makeTx({ lockRow: { id: DEV, status: 'decommissioned' } });
+    vi.mocked(releaseDeviceRemoveReason).mockResolvedValueOnce({ cancelled: 0, retainedOtherOwner: 0, alreadyDispatched: 1 });
+    const r = await restoreRemovedDevice(tx, DEV);
+    expect(r.uninstallAlreadyDispatched).toBe(true);
+  });
+});
+
+describe('purgeRemovedDevice', () => {
+  it('re-checks status under the lock and refuses a device that was restored concurrently', async () => {
+    const { tx } = makeTx({ lockRow: { id: DEV, status: 'offline', link_group_id: null } });
+    await expect(purgeRemovedDevice(tx, DEV)).rejects.toMatchObject({ code: 'NOT_REMOVED' });
+    expect(deleteDeviceCascade).not.toHaveBeenCalled();
+  });
+
+  it('refuses while a device_remove uninstall is still pending', async () => {
+    const { tx } = makeTx({ lockRow: { id: DEV, status: 'decommissioned', link_group_id: null }, pendingUninstall: true });
+    await expect(purgeRemovedDevice(tx, DEV)).rejects.toMatchObject({ code: 'UNINSTALL_PENDING', status: 409 });
+    expect(deleteDeviceCascade).not.toHaveBeenCalled();
+  });
+
+  it('cascades and dissolves the link group when eligible', async () => {
+    const { tx, calls } = makeTx({ lockRow: { id: DEV, status: 'decommissioned', link_group_id: 'lg-1' } });
+    const r = await purgeRemovedDevice(tx, DEV);
+    expect(deleteDeviceCascade).toHaveBeenCalledWith(tx, DEV);
+    expect(r.linkGroupDissolved).toBe(true);
+    expect(calls[0]).toBe('lock');
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL** (`Cannot find module './deviceLifecycle'`)
+
+```bash
+cd apps/api && npx vitest run src/services/deviceLifecycle.test.ts
+```
+
+- [ ] **Step 3: Implement**
+
+```ts
+// apps/api/src/services/deviceLifecycle.ts
+/**
+ * Single-device lifecycle operations shared by the single routes
+ * (routes/devices/core.ts), the bulk routes (routes/devices/bulkLifecycle.ts)
+ * and the bulk-purge worker (jobs/deviceBulkPurge.ts). ONE implementation so
+ * single and bulk cannot drift (#2787), and so the two latent defects found in
+ * the pre-#2787 single routes stay fixed:
+ *
+ *  1. TOCTOU — permanent delete checked `status = 'decommissioned'` OUTSIDE the
+ *     deletion transaction and never re-checked under the devices lock, so a
+ *     Restore committing in between was silently purged. Both operations here
+ *     lock first and decide second.
+ *  2. Lock-order inversion — Restore released the uninstall reason (locking
+ *     device_commands rows) BEFORE touching the devices row, opposite to the
+ *     cascade's devices-first order (deviceDeletion.ts). AB-BA → 40P01. Both
+ *     operations here take `devices FOR UPDATE` as their first statement.
+ *
+ * Purge additionally REFUSES while a `device_remove` self_uninstall is still
+ * pending/sent and unexpired: device_commands is in the device cascade, so
+ * purging would destroy the only thing that will ever clean the endpoint.
+ *
+ * Callers own authorisation and the transaction. Nothing here reads `auth`.
+ */
+import { and, arrayContains, eq, gt, inArray, sql } from 'drizzle-orm';
+import { deviceCommands, devices } from '../db/schema';
+import { deleteDeviceCascade } from './deviceDeletion';
+import { dissolveLinkGroupIfBelowMinimum } from './deviceLinkGroups';
+import {
+  releaseDeviceRemoveReason,
+  UNINSTALL_REASON_DEVICE_REMOVE,
+  type Tx,
+} from './deviceUninstallDrain';
+
+export type DeviceLifecycleCode = 'NOT_FOUND' | 'NOT_REMOVED' | 'UNINSTALL_PENDING';
+
+export class DeviceLifecycleError extends Error {
+  constructor(public readonly code: DeviceLifecycleCode, message: string) {
+    super(message);
+    this.name = 'DeviceLifecycleError';
+  }
+  get status(): 404 | 409 {
+    return this.code === 'NOT_FOUND' ? 404 : 409;
+  }
+}
+
+export interface RestoreResult {
+  device: typeof devices.$inferSelect;
+  uninstallAlreadyDispatched: boolean;
+}
+
+export interface PurgeResult {
+  linkGroupDissolved: boolean;
+}
+
+interface LockedRow { id: string; status: string; link_group_id: string | null }
+
+/** First statement of every operation: devices row FOR UPDATE, then decide. */
+async function lockDevice(tx: Tx, deviceId: string): Promise<LockedRow> {
+  const rows = (await tx.execute(
+    sql`SELECT id, status, link_group_id FROM devices WHERE id = ${deviceId} FOR UPDATE`,
+  )) as unknown as LockedRow[];
+  const row = Array.isArray(rows) ? rows[0] : undefined;
+  if (!row) throw new DeviceLifecycleError('NOT_FOUND', 'Device not found');
+  if (row.status !== 'decommissioned') {
+    throw new DeviceLifecycleError('NOT_REMOVED', 'Device is not removed');
+  }
+  return row;
+}
+
+export async function restoreRemovedDevice(tx: Tx, deviceId: string): Promise<RestoreResult> {
+  await lockDevice(tx, deviceId);
+  // Release-then-flip inside the caller's transaction — the safety property is
+  // the transaction; the order is secondary defense (see core.ts restore doc).
+  const release = await releaseDeviceRemoveReason(tx, deviceId, 'device_restored');
+  const [device] = await tx
+    .update(devices)
+    .set({ status: 'offline', updatedAt: new Date() })
+    .where(eq(devices.id, deviceId))
+    .returning();
+  return { device, uninstallAlreadyDispatched: release.alreadyDispatched > 0 };
+}
+
+async function hasPendingDeviceRemoveUninstall(tx: Tx, deviceId: string): Promise<boolean> {
+  const rows = (await tx.execute(sql`
+    SELECT id FROM device_commands
+     WHERE device_id = ${deviceId}
+       AND type = 'self_uninstall'
+       AND status IN ('pending', 'sent')
+       AND uninstall_reasons @> ARRAY[${UNINSTALL_REASON_DEVICE_REMOVE}]::text[]
+       AND device_remove_expires_at > now()
+     LIMIT 1
+  `)) as unknown as Array<{ id: string }>;
+  return Array.isArray(rows) && rows.length > 0;
+}
+
+export async function purgeRemovedDevice(tx: Tx, deviceId: string): Promise<PurgeResult> {
+  const row = await lockDevice(tx, deviceId);
+  if (await hasPendingDeviceRemoveUninstall(tx, deviceId)) {
+    throw new DeviceLifecycleError(
+      'UNINSTALL_PENDING',
+      'An agent uninstall is still queued for this device. Wait for it to check in, or restore the device and remove it again choosing "Leave the agent installed".',
+    );
+  }
+  await deleteDeviceCascade(tx, deviceId);
+  let linkGroupDissolved = false;
+  if (row.link_group_id) {
+    linkGroupDissolved = await dissolveLinkGroupIfBelowMinimum(tx, row.link_group_id);
+  }
+  return { linkGroupDissolved };
+}
+```
+
+(Unused imports `and, arrayContains, gt, inArray, deviceCommands` — remove them; the raw SQL form is used so the `@>` and `now()` predicates match `isDeviceUninstallDraining` exactly.)
+
+- [ ] **Step 4: Run — expect PASS** (7 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/deviceLifecycle.ts apps/api/src/services/deviceLifecycle.test.ts
+git commit -m "feat(api): deviceLifecycle service — lock-first restore/purge, refuse purge on pending uninstall (#2787)"
+```
+
+---
+
+### Task 2: Single routes become thin wrappers; drop the fire-and-forget uninstall
+
+**Files:**
+- Modify: `apps/api/src/routes/devices/core.ts:1631-1729` (restore) and `:1731-1908` (permanent)
+- Test: `apps/api/src/routes/devices/cascadeDelete.test.ts` (behaviour half), `apps/api/src/routes/devices/core.permissions.test.ts` (unchanged, must stay green)
+
+- [ ] **Step 1: Write the failing tests** (append to `cascadeDelete.test.ts` behaviour describe; the file already mocks `../../db`, auth, `deviceLinkGroups`, `agentWs`, and rigs `db.select` for `getDeviceWithOrgAndSiteCheck`)
+
+```ts
+vi.mock('../../services/deviceLifecycle', () => ({
+  purgeRemovedDevice: vi.fn(),
+  restoreRemovedDevice: vi.fn(),
+  DeviceLifecycleError: class DeviceLifecycleError extends Error {
+    constructor(public code: string, message: string) { super(message); }
+    get status() { return this.code === 'NOT_FOUND' ? 404 : 409; }
+  },
+}));
+import { purgeRemovedDevice, DeviceLifecycleError } from '../../services/deviceLifecycle';
+import { sendCommandToAgent } from '../agentWs';
+
+it('DELETE /:id/permanent delegates to purgeRemovedDevice and never fires a WS uninstall', async () => {
+  rigDeviceLookup({ ...DECOMMISSIONED_DEVICE, agentId: 'agent-1' });
+  vi.mocked(purgeRemovedDevice).mockResolvedValue({ linkGroupDissolved: false });
+  const res = await app.request(`/devices/${DECOMMISSIONED_DEVICE.id}/permanent`, { method: 'DELETE', headers: { Authorization: 'Bearer t' } });
+  expect(res.status).toBe(200);
+  expect(purgeRemovedDevice).toHaveBeenCalledTimes(1);
+  expect(sendCommandToAgent).not.toHaveBeenCalled();
+});
+
+it('DELETE /:id/permanent maps UNINSTALL_PENDING to 409 with the code in the body', async () => {
+  rigDeviceLookup(DECOMMISSIONED_DEVICE);
+  vi.mocked(purgeRemovedDevice).mockRejectedValue(new DeviceLifecycleError('UNINSTALL_PENDING', 'queued'));
+  const res = await app.request(`/devices/${DECOMMISSIONED_DEVICE.id}/permanent`, { method: 'DELETE', headers: { Authorization: 'Bearer t' } });
+  expect(res.status).toBe(409);
+  expect(await res.json()).toMatchObject({ code: 'UNINSTALL_PENDING' });
+});
+
+it('DELETE /:id/permanent maps NOT_REMOVED (lost race with Restore) to 409', async () => {
+  rigDeviceLookup(DECOMMISSIONED_DEVICE);
+  vi.mocked(purgeRemovedDevice).mockRejectedValue(new DeviceLifecycleError('NOT_REMOVED', 'restored'));
+  const res = await app.request(`/devices/${DECOMMISSIONED_DEVICE.id}/permanent`, { method: 'DELETE', headers: { Authorization: 'Bearer t' } });
+  expect(res.status).toBe(409);
+  expect(await res.json()).toMatchObject({ code: 'NOT_REMOVED' });
+});
+```
+
+Use the file's existing decommissioned fixture name if it differs from `DECOMMISSIONED_DEVICE`.
+
+- [ ] **Step 2: Run — expect FAIL**
+
+```bash
+cd apps/api && npx vitest run src/routes/devices/cascadeDelete.test.ts
+```
+
+- [ ] **Step 3: Implement**
+
+Restore route body (keep auth/lookup/400 pre-checks — the pre-check gives a friendly 400 for the common case; the service re-checks under lock for the race):
+```ts
+    let result: Awaited<ReturnType<typeof restoreRemovedDevice>>;
+    try {
+      result = await db.transaction((tx) => restoreRemovedDevice(tx, deviceId));
+    } catch (err) {
+      if (err instanceof DeviceLifecycleError) {
+        return c.json({ error: err.message, code: err.code }, err.status);
+      }
+      throw err;
+    }
+    writeRouteAudit(c, { orgId: device.orgId, action: 'device.restore', resourceType: 'device', resourceId: deviceId, resourceName: result.device.hostname ?? device.hostname, details: { uninstallAlreadyDispatched: result.uninstallAlreadyDispatched } });
+    return c.json({ success: true, device: stripSensitiveDeviceFields(result.device), uninstallAlreadyDispatched: result.uninstallAlreadyDispatched });
+```
+
+Permanent route: delete the `uninstallSent` block (lines 1752-1765) and the `isAgentConnected`/`sendCommandToAgent`/`CommandTypes` usages it needed (remove the imports if now unused). Replace the `db.transaction(...)` body with:
+```ts
+    let linkGroupDissolved = false;
+    try {
+      const r = await db.transaction((tx) => purgeRemovedDevice(tx, deviceId));
+      linkGroupDissolved = r.linkGroupDissolved;
+    } catch (err: unknown) {
+      if (err instanceof DeviceLifecycleError) {
+        return c.json({ error: err.message, code: err.code }, err.status);
+      }
+      const pgCode = pgErrorCode(err);
+      if (pgCode === '23503') { /* keep existing branch, drop every `uninstallSent` clause */ }
+      if (pgCode === '55P03') { /* keep existing branch, drop `uninstallSent` clause */ }
+      console.error(`[devices] unhandled ${pgCode ?? 'non-postgres'} error during cascade delete of ${deviceId}`, err);
+      throw err;
+    }
+```
+Audit details drop `uninstallCommandSent`; response becomes `{ success: true }` (drop `agentUninstallSent` and the `warning` — the durable queue on Remove replaced it; the new refusal is the honest signal). Keep the `invalidateOrgDeviceCount` block.
+
+- [ ] **Step 4: Run — expect PASS.** Then the neighbours: `npx vitest run src/routes/devices/core.permissions.test.ts src/routes/devices/core.decommission.test.ts src/routes/devices/cascadeDelete.test.ts` — all PASS (cascadeDelete's static half binds `CORE_DEVICE_CASCADE_DELETE_TABLES`; untouched).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/devices/core.ts apps/api/src/routes/devices/cascadeDelete.test.ts
+git commit -m "refactor(api): single restore/permanent-delete routes delegate to deviceLifecycle; drop WS fire-and-forget uninstall (#2787)"
+```
+
+---
+
+### Task 3: Integration suite — the races, against real Postgres
+
+**Files:**
+- Create: `apps/api/src/__tests__/integration/deviceLifecycle.integration.test.ts`
+
+Model setup on `deviceUninstallDrain.integration.test.ts` (same dir: it creates partner/org/site/device via the integration db-utils and runs inside `withSystemDbAccessContext`).
+
+- [ ] **Step 1: Write the tests**
+
+```ts
+import { describe, expect, it, beforeAll, afterAll } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { db, withSystemDbAccessContext, runOutsideDbContext } from '../../db';
+import { queueDeviceUninstall } from '../../services/deviceUninstallDrain';
+import { purgeRemovedDevice, restoreRemovedDevice, DeviceLifecycleError } from '../../services/deviceLifecycle';
+// import the same fixture helpers deviceUninstallDrain.integration.test.ts uses (createTestOrg / createTestDevice / cleanup)
+
+describe('deviceLifecycle (integration)', () => {
+  // …beforeAll: create org + decommissioned device `devId`; afterAll: cleanup…
+
+  it('purge refuses while a device_remove uninstall is pending, and the device row survives', async () => {
+    await withSystemDbAccessContext(() => db.transaction((tx) => queueDeviceUninstall(tx, devId, null)));
+    await expect(
+      withSystemDbAccessContext(() => db.transaction((tx) => purgeRemovedDevice(tx, devId))),
+    ).rejects.toMatchObject({ code: 'UNINSTALL_PENDING' });
+    const [row] = await withSystemDbAccessContext(() => db.execute(sql`SELECT id FROM devices WHERE id = ${devId}`)) as unknown as Array<{ id: string }>;
+    expect(row?.id).toBe(devId);
+  });
+
+  it('purge racing restore: whichever commits second sees the other and does not double-act', async () => {
+    // Restore first on connection A, then purge on connection B — purge must fail NOT_REMOVED.
+    await withSystemDbAccessContext(() => db.transaction(async (tx) => {
+      await tx.execute(sql`UPDATE device_commands SET status='cancelled' WHERE device_id=${devId}`); // clear the pending uninstall from the previous test
+      await restoreRemovedDevice(tx, devId);
+    }));
+    await expect(
+      withSystemDbAccessContext(() => db.transaction((tx) => purgeRemovedDevice(tx, devId))),
+    ).rejects.toMatchObject({ code: 'NOT_REMOVED' });
+    const [row] = await withSystemDbAccessContext(() => db.execute(sql`SELECT status FROM devices WHERE id = ${devId}`)) as unknown as Array<{ status: string }>;
+    expect(row.status).toBe('offline');
+  });
+
+  it('purge succeeds on a removed device with no pending uninstall and removes the row', async () => {
+    await withSystemDbAccessContext(() => db.execute(sql`UPDATE devices SET status='decommissioned' WHERE id=${devId}`));
+    await withSystemDbAccessContext(() => db.transaction((tx) => purgeRemovedDevice(tx, devId)));
+    const rows = await withSystemDbAccessContext(() => db.execute(sql`SELECT id FROM devices WHERE id = ${devId}`)) as unknown as unknown[];
+    expect(rows.length).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run against the local integration DB** (needs `DATABASE_URL`; see `vitest.integration.config.ts`)
+
+```bash
+cd apps/api && npx vitest run --config vitest.integration.config.ts src/__tests__/integration/deviceLifecycle.integration.test.ts
+```
+Expected: 3 PASS. If the fixture helper names differ, read the sibling suite and use its helpers — do not hand-roll inserts.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/__tests__/integration/deviceLifecycle.integration.test.ts
+git commit -m "test(api): deviceLifecycle integration — purge refuses pending uninstall, loses cleanly to restore (#2787)"
+```
+
+---
+
+### Task 4: `POST /devices/bulk/restore` (synchronous, isolated per item)
+
+**Files:**
+- Create: `apps/api/src/routes/devices/bulkLifecycle.ts`
+- Create: `apps/api/src/routes/devices/bulkLifecycle.test.ts`
+- Create: `apps/api/src/routes/devices/bulkLifecycle.mountorder.test.ts`
+- Modify: `apps/api/src/routes/devices/schemas.ts` (add `bulkDeviceIdsSchema`)
+- Modify: `apps/api/src/routes/devices/index.ts` (mount before core)
+- Modify: `apps/api/src/middleware/selfManagedDbContextRoutes.ts:30` + `.test.ts` MATCH/NO_MATCH arrays
+- Modify: `apps/api/src/routes/devices/core.permissions.test.ts:367` lifecycle matrix
+
+**Interfaces:**
+- Produces: `POST /api/v1/devices/bulk/restore { deviceIds: string[] }` → `200 { succeeded: Array<{ deviceId: string; uninstallAlreadyDispatched: boolean }>, failed: Array<{ deviceId: string; code: 'NOT_FOUND' | 'NOT_REMOVED' | 'UNINSTALL_PENDING' | 'SITE_ACCESS_DENIED' | 'ERROR'; message: string }> }`.
+- `export const bulkDeviceIdsSchema = z.object({ deviceIds: z.array(z.string().guid()).min(1).max(500) })` in `schemas.ts`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`bulkLifecycle.test.ts` — mocks mirror `core.decommission.test.ts` (`../../db`, `../../middleware/auth`, `../../services/auditEvents`) plus:
+```ts
+vi.mock('../../services/deviceLifecycle', () => ({ restoreRemovedDevice: vi.fn(), purgeRemovedDevice: vi.fn(), DeviceLifecycleError: class extends Error { constructor(public code: string, m: string) { super(m); } get status() { return this.code === 'NOT_FOUND' ? 404 : 409; } } }));
+vi.mock('./helpers', async (orig) => ({ ...(await orig<typeof import('./helpers')>()), getDeviceWithOrgAndSiteCheck: vi.fn() }));
+```
+Cases:
+1. `restores every accessible removed device and reports per-device outcomes` — 3 ids: one restored (`uninstallAlreadyDispatched: false`), one throws `NOT_REMOVED`, one where `getDeviceWithOrgAndSiteCheck` returns `null` → expect `succeeded.length === 1`, `failed` has `{code:'NOT_REMOVED'}` and `{code:'NOT_FOUND'}`, status 200.
+2. `rejects > 500 ids with 400` — body of 501 guids.
+3. `dedupes repeated ids` — same id twice → `restoreRemovedDevice` called once.
+4. `runs each item outside the request transaction` — assert `runOutsideDbContext` mock was called once and `withDbAccessContext` called once per unique id (that is what `runBulkIsolated` does; this pins that the route uses it and not a bare loop).
+
+`bulkLifecycle.mountorder.test.ts` — copy `links.mountorder.test.ts` wholesale, change the request to `POST /devices/bulk/restore` with `{ deviceIds: [ORG_A_DEVICE] }`, assert `status !== 404` and `status !== 400` (core's `/:id/restore` would 404 "Device not found" for the literal id `bulk`).
+
+`selfManagedDbContextRoutes.test.ts` — add to MATCH: `['POST', '/api/v1/devices/bulk/restore']`; to NO_MATCH: `['POST', '/api/v1/devices/bulk/restore/extra', 'extra segment must not match']`, `['POST', '/api/v1/devices/11111111-1111-4111-8111-111111111111/restore', 'single restore keeps ambient tx']`.
+
+`core.permissions.test.ts` — add `['POST', '/devices/bulk/restore']` to `lifecyclePaths` with body `{ deviceIds: [ACCESSIBLE_DEVICE.id] }` (the loop sends no body today; extend it to send JSON for POSTs).
+
+- [ ] **Step 2: Run all four — expect FAIL**
+
+```bash
+cd apps/api && npx vitest run src/routes/devices/bulkLifecycle src/middleware/selfManagedDbContextRoutes.test.ts src/routes/devices/core.permissions.test.ts
+```
+
+- [ ] **Step 3: Implement**
+
+`schemas.ts`:
+```ts
+export const BULK_LIFECYCLE_MAX_DEVICES = 500;
+export const bulkDeviceIdsSchema = z.object({
+  deviceIds: z.array(z.string().guid()).min(1).max(BULK_LIFECYCLE_MAX_DEVICES),
+});
+```
+
+`selfManagedDbContextRoutes.ts` — add:
+```ts
+  // #2787 bulk restore: one short RLS transaction per device via runBulkIsolated.
+  // Holding the request tx across up to 500 restores would pin one connection
+  // and every devices/device_commands lock until the last item finished.
+  { method: 'POST', pattern: /^\/api\/v1\/devices\/bulk\/restore\/?$/ },
+```
+
+`bulkLifecycle.ts`:
+```ts
+import { Hono } from 'hono';
+import { db } from '../../db';
+import { zValidator } from '../../lib/validation';
+import { runBulkIsolated } from '../../lib/bulkOps';
+import { authMiddleware, requireScope, requirePermission, requireMfa, dbAccessContextFromAuth, type AuthContext } from '../../middleware/auth';
+import { PERMISSIONS } from '../../services/permissions';
+import { writeRouteAudit } from '../../services/auditEvents';
+import { restoreRemovedDevice, DeviceLifecycleError } from '../../services/deviceLifecycle';
+import { bulkDeviceIdsSchema } from './schemas';
+import { getDeviceWithOrgAndSiteCheck, SITE_ACCESS_DENIED } from './helpers';
+
+export const bulkLifecycleRoutes = new Hono();
+bulkLifecycleRoutes.use('*', authMiddleware);
+
+type FailCode = 'NOT_FOUND' | 'NOT_REMOVED' | 'UNINSTALL_PENDING' | 'SITE_ACCESS_DENIED' | 'ERROR';
+interface BulkFailed { deviceId: string; code: FailCode; message: string }
+
+/**
+ * POST /devices/bulk/restore — restore up to 500 removed devices (#2787).
+ *
+ * Synchronous: a restore is two small writes. Each device runs in its OWN
+ * short RLS transaction via runBulkIsolated (this route is listed in
+ * selfManagedDbContextRoutes, so no ambient request tx is held across the
+ * loop). Authorisation goes through the same getDeviceWithOrgAndSiteCheck
+ * chokepoint as the single route; the service re-checks state under lock.
+ *
+ * Static path — mounted before coreRoutes so `/:id/restore` can't eat it.
+ */
+bulkLifecycleRoutes.post(
+  '/bulk/restore',
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.DEVICES_DELETE.resource, PERMISSIONS.DEVICES_DELETE.action),
+  requireMfa(),
+  zValidator('json', bulkDeviceIdsSchema),
+  async (c) => {
+    const auth = c.get('auth') as AuthContext;
+    const ids = [...new Set(c.req.valid('json').deviceIds)];
+    const ctx = dbAccessContextFromAuth(auth);
+    const succeeded: Array<{ deviceId: string; uninstallAlreadyDispatched: boolean }> = [];
+    const failed: BulkFailed[] = [];
+
+    await runBulkIsolated(ctx, ids, async (deviceId) => {
+      const device = await getDeviceWithOrgAndSiteCheck(c, deviceId, auth);
+      if (device === SITE_ACCESS_DENIED) { failed.push({ deviceId, code: 'SITE_ACCESS_DENIED', message: 'Access to this site denied' }); return; }
+      if (!device) { failed.push({ deviceId, code: 'NOT_FOUND', message: 'Device not found' }); return; }
+      try {
+        const r = await db.transaction((tx) => restoreRemovedDevice(tx, deviceId));
+        succeeded.push({ deviceId, uninstallAlreadyDispatched: r.uninstallAlreadyDispatched });
+        writeRouteAudit(c, { orgId: device.orgId, action: 'device.restore', resourceType: 'device', resourceId: deviceId, resourceName: r.device.hostname ?? device.hostname, details: { uninstallAlreadyDispatched: r.uninstallAlreadyDispatched, bulk: true } });
+      } catch (err) {
+        if (err instanceof DeviceLifecycleError) { failed.push({ deviceId, code: err.code, message: err.message }); return; }
+        console.error(`[devices] bulk restore failed for ${deviceId}:`, err);
+        failed.push({ deviceId, code: 'ERROR', message: 'Restore failed' });
+      }
+    });
+
+    return c.json({ succeeded, failed });
+  },
+);
+```
+(`runBulkIsolated` counts thrown errors; we swallow inside `perItem` and keep our own per-device arrays — the `BulkResult` return is ignored on purpose because the web needs per-device ids, not counts.)
+
+`index.ts` — import `bulkLifecycleRoutes` and mount directly before `coreRoutes` with the standard "static path before `/:id`" comment.
+
+- [ ] **Step 4: Run all four — expect PASS.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/devices/bulkLifecycle.ts apps/api/src/routes/devices/bulkLifecycle.test.ts apps/api/src/routes/devices/bulkLifecycle.mountorder.test.ts apps/api/src/routes/devices/schemas.ts apps/api/src/routes/devices/index.ts apps/api/src/middleware/selfManagedDbContextRoutes.ts apps/api/src/middleware/selfManagedDbContextRoutes.test.ts apps/api/src/routes/devices/core.permissions.test.ts
+git commit -m "feat(api): POST /devices/bulk/restore — per-item isolated bulk restore (#2787)"
+```
+
+---
+
+### Task 5: Bulk purge — BullMQ job + `POST /bulk/permanent-delete` (202) + `GET /bulk/purge-runs/:jobId`
+
+**Files:**
+- Create: `apps/api/src/jobs/deviceBulkPurge.ts`
+- Create: `apps/api/src/jobs/deviceBulkPurge.test.ts`
+- Modify: `apps/api/src/routes/devices/bulkLifecycle.ts` (two more routes)
+- Modify: `apps/api/src/routes/devices/bulkLifecycle.test.ts`, `bulkLifecycle.mountorder.test.ts`, `core.permissions.test.ts`
+- Modify: `apps/api/src/services/workerRegistry.ts:~533` (register after `orgMerge`)
+
+**Interfaces:**
+- Produces:
+  ```ts
+  // jobs/deviceBulkPurge.ts
+  export interface DeviceBulkPurgeJobPayload {
+    jobId: string;                                  // uuid, also the BullMQ jobId suffix
+    targets: Array<{ deviceId: string; orgId: string; hostname: string }>;
+    actorUserId: string;
+    actorEmail?: string;
+    partnerId: string | null;                       // for status-route ownership check
+  }
+  export interface DeviceBulkPurgeResult {
+    purged: string[];
+    skipped: Array<{ deviceId: string; code: 'NOT_FOUND' | 'NOT_REMOVED' | 'UNINSTALL_PENDING' | 'ORG_CHANGED' | 'ERROR' }>;
+  }
+  export function getDeviceBulkPurgeQueue(): Queue
+  export async function enqueueDeviceBulkPurge(payload: DeviceBulkPurgeJobPayload): Promise<{ id: string }>
+  export function createDeviceBulkPurgeWorker(): Worker
+  export async function initializeDeviceBulkPurgeWorker(): Promise<void>
+  export async function shutdownDeviceBulkPurgeWorker(): Promise<void>
+  ```
+  - `POST /api/v1/devices/bulk/permanent-delete { deviceIds[] }` → `202 { jobId, accepted: number, rejected: Array<{ deviceId; code; message }> }` (up-front cheap checks: access, `status='decommissioned'`; a pending uninstall is NOT pre-checked here — the worker refuses it under lock, keeping one source of truth). If `accepted === 0` → `409 { error, rejected }` and no job.
+  - `GET /api/v1/devices/bulk/purge-runs/:jobId` → `200 { state, progress: { done: number; total: number }, result: DeviceBulkPurgeResult | null, failedReason: string | null }`; 404 for unknown or other-partner jobs.
+
+- [ ] **Step 1: Write the failing tests**
+
+`jobs/deviceBulkPurge.test.ts` (mock `bullmq` `Queue`/`Worker` like `abuseSignalsSweep.test.ts:19` does; mock `../db` with `withSystemDbAccessContext: (fn) => fn()`, `runOutsideDbContext: (fn) => fn()`, `db.transaction: (fn) => fn(fakeTx)`; mock `../services/deviceLifecycle`, `../services/auditService`, `../services/agentOrgRateLimit`):
+1. `skips a device whose org changed after enqueue (ORG_CHANGED) and never calls purgeRemovedDevice for it` — fakeTx.execute for the lock returns `{ id, status:'decommissioned', org_id:'other-org' }`.
+2. `maps a DeviceLifecycleError to its code in skipped` — `purgeRemovedDevice` rejects `UNINSTALL_PENDING`.
+3. `writes one device.permanent_delete audit row per purged device carrying bulkJobId, and invalidates the org device count once per org`.
+4. `reports progress after every device` — `job.updateProgress` called `targets.length` times with `{ done, total }`.
+5. `enqueue uses jobId device-bulk-purge-<uuid>`.
+
+`bulkLifecycle.test.ts` additions:
+6. `POST /bulk/permanent-delete pre-rejects a non-removed device and enqueues only the removed ones` → 202, `accepted: 1`, `rejected: [{ code: 'NOT_REMOVED' }]`, `enqueueDeviceBulkPurge` called with `targets.length === 1` and `partnerId: auth.partnerId`.
+7. `POST /bulk/permanent-delete returns 409 and enqueues nothing when every device is rejected`.
+8. `GET /bulk/purge-runs/:jobId returns 404 for another partner's job` — mock `getDeviceBulkPurgeQueue().getJob` → `{ data: { partnerId: 'other' }, getState: async () => 'active', progress: {done:1,total:3}, returnvalue: null, failedReason: null }` with `auth.scope = 'partner', partnerId = 'mine'`.
+9. `GET /bulk/purge-runs/:jobId returns state + progress + result for the owner`.
+
+`mountorder.test.ts`: add `POST /devices/bulk/permanent-delete` and `GET /devices/bulk/purge-runs/x` cases (not 404/400 from core).
+
+`core.permissions.test.ts`: add `['POST', '/devices/bulk/permanent-delete']` to the lifecycle matrix (devices:delete + MFA).
+
+- [ ] **Step 2: Run — expect FAIL**
+
+```bash
+cd apps/api && npx vitest run src/jobs/deviceBulkPurge.test.ts src/routes/devices/bulkLifecycle src/routes/devices/core.permissions.test.ts
+```
+
+- [ ] **Step 3: Implement the job**
+
+```ts
+// apps/api/src/jobs/deviceBulkPurge.ts
+/**
+ * Bulk permanent delete of REMOVED devices (#2787).
+ *
+ * Async on purpose: deleteDeviceCascade touches ~40 tables per device; 500 of
+ * them inside one request would pin a pooled connection for minutes under the
+ * request transaction (auth.ts wraps every handler in one) and one bad row
+ * would abort them all. The route validates cheaply, enqueues, returns 202; the
+ * web polls GET /devices/bulk/purge-runs/:jobId.
+ *
+ * Authorisation is re-derived per device under lock: the payload carries the
+ * org each device belonged to when the operator confirmed. A device moved to
+ * another org (or restored) between confirm and execution is SKIPPED, never
+ * deleted under stale authorisation. Runs in a system DB context — the cascade
+ * needs to see tables a tenant context deliberately hides (deviceDeletion.ts).
+ *
+ * Module shape mirrors jobs/orgMerge.ts (lazy Queue/Worker singletons,
+ * enqueueOrReplaceStale, attempts: 1 — a retry could re-run a half-finished
+ * purge list against devices whose state has moved on).
+ */
+import { Queue, Worker, type Job } from 'bullmq';
+import { sql } from 'drizzle-orm';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
+import { captureException } from '../services/sentry';
+import { getBullMQConnection, getRedis } from '../services/redis';
+import { enqueueOrReplaceStale } from '../services/bullmqUtils';
+import { createAuditLog } from '../services/auditService';
+import { invalidateOrgDeviceCount } from '../services/agentOrgRateLimit';
+import { purgeRemovedDevice, DeviceLifecycleError } from '../services/deviceLifecycle';
+
+const QUEUE_NAME = 'device-bulk-purge';
+const JOB_NAME = 'device-bulk-purge';
+export const DEVICE_BULK_PURGE_MAX_TARGETS = 500;
+
+export interface DeviceBulkPurgeJobPayload {
+  jobId: string;
+  targets: Array<{ deviceId: string; orgId: string; hostname: string }>;
+  actorUserId: string;
+  actorEmail?: string;
+  partnerId: string | null;
+}
+
+export type BulkPurgeSkipCode = 'NOT_FOUND' | 'NOT_REMOVED' | 'UNINSTALL_PENDING' | 'ORG_CHANGED' | 'ERROR';
+export interface DeviceBulkPurgeResult {
+  purged: string[];
+  skipped: Array<{ deviceId: string; code: BulkPurgeSkipCode }>;
+}
+
+let purgeQueue: Queue | null = null;
+let purgeWorker: Worker | null = null;
+
+export function getDeviceBulkPurgeQueue(): Queue {
+  if (!purgeQueue) purgeQueue = new Queue(QUEUE_NAME, { connection: getBullMQConnection() });
+  return purgeQueue;
+}
+
+export async function enqueueDeviceBulkPurge(payload: DeviceBulkPurgeJobPayload): Promise<{ id: string }> {
+  return enqueueOrReplaceStale(
+    getDeviceBulkPurgeQueue(), JOB_NAME, `device-bulk-purge-${payload.jobId}`, payload,
+    { attempts: 1, removeOnComplete: { count: 100 }, removeOnFail: { count: 100 } },
+    '[DeviceBulkPurge]',
+  );
+}
+
+async function purgeOne(target: DeviceBulkPurgeJobPayload['targets'][number], payload: DeviceBulkPurgeJobPayload): Promise<BulkPurgeSkipCode | null> {
+  return runOutsideDbContext(() => withSystemDbAccessContext(() => db.transaction(async (tx) => {
+    // Lock + re-derive authorisation from CURRENT state before the service's
+    // own lock-and-check (a second FOR UPDATE on the same row in the same tx
+    // is a no-op).
+    const rows = (await tx.execute(sql`SELECT org_id FROM devices WHERE id = ${target.deviceId} FOR UPDATE`)) as unknown as Array<{ org_id: string }>;
+    if (!rows[0]) return 'NOT_FOUND';
+    if (rows[0].org_id !== target.orgId) return 'ORG_CHANGED';
+    try {
+      await purgeRemovedDevice(tx, target.deviceId);
+      return null;
+    } catch (err) {
+      if (err instanceof DeviceLifecycleError) return err.code;
+      throw err;
+    }
+  })));
+}
+
+export function createDeviceBulkPurgeWorker(): Worker {
+  return new Worker(QUEUE_NAME, async (job: Job<DeviceBulkPurgeJobPayload>) => {
+    if (job.name !== JOB_NAME) return { skipped: true };
+    const payload = job.data;
+    const targets = payload.targets.slice(0, DEVICE_BULK_PURGE_MAX_TARGETS);
+    const result: DeviceBulkPurgeResult = { purged: [], skipped: [] };
+    const touchedOrgs = new Set<string>();
+
+    for (const [i, target] of targets.entries()) {
+      let code: BulkPurgeSkipCode | null;
+      try {
+        code = await purgeOne(target, payload);
+      } catch (err) {
+        console.error(`[DeviceBulkPurge] ${payload.jobId}: unexpected error purging ${target.deviceId}:`, err);
+        captureException(err);
+        code = 'ERROR';
+      }
+      if (code) {
+        result.skipped.push({ deviceId: target.deviceId, code });
+      } else {
+        result.purged.push(target.deviceId);
+        touchedOrgs.add(target.orgId);
+        try {
+          await createAuditLog({
+            orgId: target.orgId, actorType: 'user', actorId: payload.actorUserId, actorEmail: payload.actorEmail,
+            action: 'device.permanent_delete', resourceType: 'device', resourceId: target.deviceId, resourceName: target.hostname,
+            details: { bulkJobId: payload.jobId }, result: 'success',
+          });
+        } catch (err) { console.error('[DeviceBulkPurge] audit write failed:', err); }
+      }
+      await job.updateProgress({ done: i + 1, total: targets.length });
+    }
+
+    for (const orgId of touchedOrgs) {
+      try { void invalidateOrgDeviceCount(getRedis(), orgId); } catch (err) { console.error('[DeviceBulkPurge] device-count cache invalidation failed', err); }
+    }
+    return result;
+  }, { connection: getBullMQConnection(), concurrency: 1 });
+}
+
+export async function initializeDeviceBulkPurgeWorker(): Promise<void> {
+  purgeWorker = createDeviceBulkPurgeWorker();
+  purgeWorker.on('error', (error) => { console.error('[DeviceBulkPurge] Worker error:', error); captureException(error); });
+  purgeWorker.on('failed', (job, error) => { console.error(`[DeviceBulkPurge] Job ${job?.id} failed:`, error); captureException(error); });
+}
+
+export async function shutdownDeviceBulkPurgeWorker(): Promise<void> {
+  if (purgeWorker) { await purgeWorker.close(); purgeWorker = null; }
+  if (purgeQueue) { await purgeQueue.close(); purgeQueue = null; }
+}
+```
+
+`workerRegistry.ts` — add directly after the `orgMerge` entry:
+```ts
+  {
+    // #2787: async bulk permanent delete of removed devices.
+    name: 'deviceBulkPurge',
+    placement: 'socket-owner',
+    load: async () => {
+      const m = await import('../jobs/deviceBulkPurge');
+      return { init: m.initializeDeviceBulkPurgeWorker, shutdown: m.shutdownDeviceBulkPurgeWorker };
+    },
+  },
+```
+(If `workerRegistry` has a closure-contract test asserting placement, run it and pick the placement it demands; `deviceLifecycle` → `deviceDeletion` does not import `agentWs`, so `'plain'`/default placement may be correct — the test decides.)
+
+- [ ] **Step 4: Implement the two routes** (append to `bulkLifecycle.ts`)
+
+```ts
+import { randomUUID } from 'crypto';
+import { enqueueDeviceBulkPurge, getDeviceBulkPurgeQueue, type DeviceBulkPurgeJobPayload, type DeviceBulkPurgeResult } from '../../jobs/deviceBulkPurge';
+
+bulkLifecycleRoutes.post(
+  '/bulk/permanent-delete',
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.DEVICES_DELETE.resource, PERMISSIONS.DEVICES_DELETE.action),
+  requireMfa(),
+  zValidator('json', bulkDeviceIdsSchema),
+  async (c) => {
+    const auth = c.get('auth') as AuthContext;
+    const ids = [...new Set(c.req.valid('json').deviceIds)];
+    const targets: DeviceBulkPurgeJobPayload['targets'] = [];
+    const rejected: BulkFailed[] = [];
+    for (const deviceId of ids) {
+      const device = await getDeviceWithOrgAndSiteCheck(c, deviceId, auth);
+      if (device === SITE_ACCESS_DENIED) { rejected.push({ deviceId, code: 'SITE_ACCESS_DENIED', message: 'Access to this site denied' }); continue; }
+      if (!device) { rejected.push({ deviceId, code: 'NOT_FOUND', message: 'Device not found' }); continue; }
+      if (device.status !== 'decommissioned') { rejected.push({ deviceId, code: 'NOT_REMOVED', message: 'Device must be removed before permanent deletion' }); continue; }
+      targets.push({ deviceId, orgId: device.orgId, hostname: device.hostname ?? device.displayName ?? deviceId });
+    }
+    if (targets.length === 0) {
+      return c.json({ error: 'No selected device can be permanently deleted', rejected }, 409);
+    }
+    const jobId = randomUUID();
+    await enqueueDeviceBulkPurge({ jobId, targets, actorUserId: auth.user.id, actorEmail: auth.user.email, partnerId: auth.partnerId ?? null });
+    writeRouteAudit(c, { orgId: targets[0].orgId, action: 'device.bulk_permanent_delete.enqueued', resourceType: 'device_bulk_purge', resourceId: jobId, details: { accepted: targets.length, rejected: rejected.length, orgIds: [...new Set(targets.map(t => t.orgId))] } });
+    return c.json({ jobId, accepted: targets.length, rejected }, 202);
+  },
+);
+
+bulkLifecycleRoutes.get(
+  '/bulk/purge-runs/:jobId',
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action),
+  async (c) => {
+    const auth = c.get('auth') as AuthContext;
+    const jobId = c.req.param('jobId')!;
+    const job = await getDeviceBulkPurgeQueue().getJob(`device-bulk-purge-${jobId}`);
+    if (!job) return c.json({ error: 'Purge run not found' }, 404);
+    const payload = job.data as DeviceBulkPurgeJobPayload | undefined;
+    // jobId is a UUID the caller was handed, but a partner-scope caller must
+    // still be denied another partner's run (mirror routes/orgMerge.ts:246).
+    // Org-scope callers: every target org must be accessible.
+    if (auth.scope === 'partner' && payload?.partnerId !== auth.partnerId) return c.json({ error: 'Purge run not found' }, 404);
+    if (auth.scope === 'organization' && payload && !payload.targets.every(t => auth.canAccessOrg(t.orgId))) return c.json({ error: 'Purge run not found' }, 404);
+    const state = await job.getState();
+    const progress = (job.progress as { done: number; total: number } | number) ;
+    return c.json({
+      state,
+      progress: typeof progress === 'object' ? progress : { done: 0, total: payload?.targets.length ?? 0 },
+      result: (job.returnvalue as DeviceBulkPurgeResult | null) ?? null,
+      failedReason: job.failedReason ?? null,
+    });
+  },
+);
+```
+
+- [ ] **Step 5: Run — expect PASS** on all four files. Run `npx vitest run src/services/workerRegistry` (whatever tests exist) — PASS.
+
+- [ ] **Step 6: Integration case for the worker** — append to `deviceLifecycle.integration.test.ts`:
+```ts
+it('bulk purge worker skips a device whose org changed after enqueue', async () => {
+  // create removed device in org A; build payload with orgId = A; move the device to org B via UPDATE; run createDeviceBulkPurgeWorker()'s processor directly by importing the module and calling the processor function extracted for tests (export `processDeviceBulkPurgeJob(job)` from the job module and have the Worker call it).
+  // assert result.skipped contains { code: 'ORG_CHANGED' } and the device row still exists.
+});
+```
+Export `processDeviceBulkPurgeJob` from the job module (the Worker callback becomes `(job) => processDeviceBulkPurgeJob(job)`) so the integration test can drive it without Redis. Run the integration file — 4 PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/jobs/deviceBulkPurge.ts apps/api/src/jobs/deviceBulkPurge.test.ts apps/api/src/routes/devices/bulkLifecycle.ts apps/api/src/routes/devices/bulkLifecycle.test.ts apps/api/src/routes/devices/bulkLifecycle.mountorder.test.ts apps/api/src/routes/devices/core.permissions.test.ts apps/api/src/services/workerRegistry.ts apps/api/src/__tests__/integration/deviceLifecycle.integration.test.ts
+git commit -m "feat(api): async bulk permanent delete — BullMQ job, 202 enqueue route, purge-run status (#2787)"
+```
+
+---
+
+### Task 6: Web service functions
+
+**Files:**
+- Modify: `apps/web/src/services/deviceActions.ts`
+- Test: `apps/web/src/services/deviceActions.test.ts`
+
+**Interfaces:**
+```ts
+export interface BulkRestoreResult { succeeded: Array<{ deviceId: string; uninstallAlreadyDispatched: boolean }>; failed: Array<{ deviceId: string; code: string; message: string }> }
+export async function bulkRestoreDevices(deviceIds: string[]): Promise<BulkRestoreResult>
+export interface BulkPurgeStart { jobId: string; accepted: number; rejected: Array<{ deviceId: string; code: string; message: string }> }
+export async function startBulkPurge(deviceIds: string[]): Promise<BulkPurgeStart>
+export interface PurgeRun { state: string; progress: { done: number; total: number }; result: { purged: string[]; skipped: Array<{ deviceId: string; code: string }> } | null; failedReason: string | null }
+export async function fetchPurgeRun(jobId: string): Promise<PurgeRun>
+export const PURGE_POLL_INTERVAL_MS = 2000;
+```
+
+- [ ] **Step 1: Tests** — one per function asserting path, method, JSON body, and that a non-OK response throws with the API's `error` message (`getErrorMessage`). `startBulkPurge` on 409 must throw with the message and attach `rejected` (use a subclass `BulkPurgeRejectedError extends Error { rejected }`).
+- [ ] **Step 2: Run — FAIL.** **Step 3: Implement** following `restoreDevice`'s shape (`fetchWithAuth`, `getErrorMessage`). **Step 4: PASS.**
+- [ ] **Step 5: Commit** `feat(web): bulk restore / bulk purge service calls (#2787)`.
+
+---
+
+### Task 7: Gating — third classification set + contract test
+
+**Files:**
+- Modify: `apps/web/src/components/devices/bulkActionGating.ts`
+- Modify: `apps/web/src/components/devices/DeviceList.test.tsx:1340-1385`
+
+**Interfaces:**
+```ts
+export const REMOVED_ONLY_BULK_ACTIONS: ReadonlySet<string> = new Set(['restore', 'permanent-delete']);
+export type BulkSelectionKind = 'active' | 'removed' | 'mixed';
+export function classifyBulkSelection(statuses: readonly string[]): BulkSelectionKind
+```
+
+- [ ] **Step 1: Tests** (extend the existing describe at :1340; it renders the bulk menu and enumerates emitted actions via `emittedBulkActions()`)
+```ts
+it('classifies every emitted action into exactly one of the three sets', () => {
+  const all = [...emittedBulkActions(), ...emittedBulkActionsForRemovedSelection()];
+  for (const a of new Set(all)) {
+    const n = [DECOMMISSION_BLOCKED_BULK_ACTIONS, INTENTIONALLY_UNGATED_BULK_ACTIONS, REMOVED_ONLY_BULK_ACTIONS].filter(s => s.has(a)).length;
+    expect(n, `${a} is in ${n} sets`).toBe(1);
+  }
+});
+it('an all-removed selection emits ONLY removed-only actions (+ compare)', () => {
+  const emitted = emittedBulkActionsForRemovedSelection(); // render 3 decommissioned devices, select all, open menu, click every item, collect action names
+  expect(emitted.sort()).toEqual(['compare', 'permanent-delete', 'restore']);
+});
+it('an active selection never emits a removed-only action', () => {
+  expect(emittedBulkActions().some(a => REMOVED_ONLY_BULK_ACTIONS.has(a))).toBe(false);
+});
+it('classifyBulkSelection', () => {
+  expect(classifyBulkSelection(['online', 'offline'])).toBe('active');
+  expect(classifyBulkSelection(['decommissioned'])).toBe('removed');
+  expect(classifyBulkSelection(['online', 'decommissioned'])).toBe('mixed');
+});
+```
+- [ ] **Step 2: Run — FAIL.** **Step 3: Implement** in `bulkActionGating.ts` (doc comment: why a third set — removed-only actions are the inverse gate; the contract test forces classification so a new bulk button cannot be silently ungated). `classifyBulkSelection`: all `decommissioned` → `'removed'`; none → `'active'`; else `'mixed'`. The menu rendering itself lands in Task 8, so `emittedBulkActionsForRemovedSelection` will only pass after Task 8 — mark the two rendering tests `it.todo` here and un-todo them in Task 8, keeping the set/classify tests green now.
+- [ ] **Step 4: PASS.** **Step 5: Commit** `feat(web): REMOVED_ONLY_BULK_ACTIONS + classifyBulkSelection (#2787)`.
+
+---
+
+### Task 8: DeviceList bulk bar is selection-aware
+
+**Files:**
+- Modify: `apps/web/src/components/devices/DeviceList.tsx:2056-2160`
+- Modify: `apps/web/src/components/devices/DeviceList.test.tsx` (un-todo Task 7's rendering tests)
+- Modify: `apps/web/src/locales/*/devices.json` — `deviceList.restoreSelected: "Restore Selected"`, `deviceList.permanentDeleteSelected: "Delete permanently…"`.
+
+- [ ] **Step 1: Un-todo the tests; run — FAIL.**
+- [ ] **Step 2: Implement.** Compute once above the JSX:
+```ts
+  const selectionKind = classifyBulkSelection(
+    devices.filter(d => selectedIds.has(d.id)).map(d => d.status),
+  );
+```
+Inside `bulk-actions-menu`, wrap the existing items in `{selectionKind !== 'removed' && (<>…all current buttons…</>)}` and add, for `selectionKind === 'removed'`:
+```tsx
+                {selectionKind === 'removed' && (
+                  <>
+                    <button type="button" data-testid="bulk-restore" onClick={() => handleBulkAction('restore')} className="w-full px-4 py-2 text-left text-sm text-success hover:bg-success/10">
+                      {t('deviceList.restoreSelected')}
+                    </button>
+                    {selectedIds.size >= 2 && selectedIds.size <= 4 && (
+                      <button type="button" data-testid="bulk-compare" onClick={() => handleBulkAction('compare')} className="w-full px-4 py-2 text-left text-sm hover:bg-muted">
+                        {t('deviceList.compareSelected')}
+                      </button>
+                    )}
+                    <hr className="my-1" />
+                    <button type="button" data-testid="bulk-permanent-delete" onClick={() => handleBulkAction('permanent-delete')} className="w-full px-4 py-2 text-left text-sm text-destructive hover:bg-destructive/10">
+                      {t('deviceList.permanentDeleteSelected')}
+                    </button>
+                  </>
+                )}
+```
+Keep the `compare` item out of the active-branch duplicate (it already exists there). Add `data-testid="bulk-decommission"` to the existing Remove Selected button if absent (DevicesPage.test references it).
+- [ ] **Step 3: PASS** (`npx vitest run src/components/devices/DeviceList.test.tsx`, plus `localeParity`).
+- [ ] **Step 4: Commit** `feat(web): bulk bar offers only Restore / Delete permanently for a removed selection (#2787)`.
+
+---
+
+### Task 9: DevicesPage — bulk restore handler, `BulkPurgeDialog`, purge-run polling
+
+**Files:**
+- Create: `apps/web/src/components/devices/BulkPurgeDialog.tsx` + `.test.tsx`
+- Modify: `apps/web/src/components/devices/DevicesPage.tsx` (`runBulkAction` switch, new state, JSX)
+- Test: `apps/web/src/components/devices/DevicesPage.test.tsx`
+- Locales: `devicesPage.bulkPurge.*`, `devicesPage.toasts.bulkRestored`, `bulkRestoreSomeFailed`, `bulkRestoreAllFailed`, `bulkRestoreUninstallAlreadySent`, `bulkPurgeStarted`, `bulkPurgeProgress`, `bulkPurgeDone`, `bulkPurgeDoneWithSkips`, `bulkPurgeFailed`.
+
+**Interfaces:**
+```ts
+export interface BulkPurgeDialogProps {
+  open: boolean;
+  targets: Array<{ hostname: string; orgId?: string | null }>;
+  onClose: () => void;
+  onConfirm: () => void;
+  isLoading?: boolean;
+}
+```
+Renders `ConfirmDialog` with purge copy; children: bounded target list (first 5 hostnames + "and N more"), org count when > 1, and a text input `data-testid="bulk-purge-count"`; **Confirm disabled until input === String(targets.length)**. `ConfirmDialog` has no `confirmDisabled` prop — add one (`confirmDisabled?: boolean`, applied to the confirm button alongside `isLoading`), with a one-line test in `ConfirmDialog.test.tsx`.
+
+- [ ] **Step 1: Tests**
+  - `BulkPurgeDialog.test.tsx`: confirm disabled until the exact count is typed; shows "and 3 more" for 8 targets; `onConfirm` fires only after typing.
+  - `DevicesPage.test.tsx`: (a) all-removed selection → Restore Selected → `bulkRestoreDevices` called with the 3 ids → success toast; (b) Delete permanently → dialog → type `3` → confirm → `startBulkPurge` called → `fetchPurgeRun` polled with fake timers until `state: 'completed'` → done toast + `fetchDevices` refetch; (c) a `startBulkPurge` 409 shows the error toast and does not poll.
+- [ ] **Step 2: Run — FAIL.**
+- [ ] **Step 3: Implement**
+  - `runBulkAction`: add
+    ```ts
+        case 'restore': {
+          const r = await bulkRestoreDevices(deviceIds);
+          const dispatched = r.succeeded.filter(s => s.uninstallAlreadyDispatched).length;
+          if (r.failed.length === 0) showToast({ type: 'success', message: t('devicesPage.toasts.bulkRestored', { count: r.succeeded.length }) });
+          else if (r.succeeded.length === 0) showToast({ type: 'error', message: t('devicesPage.toasts.bulkRestoreAllFailed', { count: r.failed.length }) });
+          else showToast({ type: 'error', message: t('devicesPage.toasts.bulkRestoreSomeFailed', { succeeded: r.succeeded.length, failed: r.failed.length }) });
+          if (dispatched > 0) showToast({ type: 'warning', message: t('devicesPage.toasts.bulkRestoreUninstallAlreadySent', { count: dispatched }) });
+          await fetchDevices();
+          break;
+        }
+        case 'permanent-delete': {
+          // Prune to rows still present in the current fetch (selection persists across filters).
+          const present = new Set(devices.map(d => d.id));
+          setPendingBulkPurge(selectedDevices.filter(d => present.has(d.id)));
+          return;
+        }
+    ```
+  - New state `pendingBulkPurge: Device[] | null`; `runBulkPurge(targets)` calls `startBulkPurge`, toasts `bulkPurgeStarted`, then polls `fetchPurgeRun(jobId)` every `PURGE_POLL_INTERVAL_MS` (pattern: `MergeOrgModal.tsx:209` — token ref to drop stale polls, stop on `completed`/`failed`, unmount-safe). On `completed`: `bulkPurgeDone` (or `bulkPurgeDoneWithSkips` with the skip count grouped by code) + `fetchDevices()`. On `failed`: `bulkPurgeFailed` with `failedReason`.
+  - JSX: `<BulkPurgeDialog open targets=… onClose=… onConfirm={() => { const t = pendingBulkPurge; setPendingBulkPurge(null); void runBulkPurge(t); }} />`.
+  - `handleBulkAction`: the network-row filter and the `DECOMMISSION_BLOCKED` gate are untouched; `restore`/`permanent-delete` fall through to `runBulkAction` (they are only emitted for an all-removed selection, so the mixed-selection confirm never triggers for them — pinned by Task 7's rendering test).
+- [ ] **Step 4: PASS** — whole `DevicesPage.test.tsx`, `BulkPurgeDialog.test.tsx`, `ConfirmDialog.test.tsx`, `localeParity`, `keyUsage`, `no-silent-mutations`.
+- [ ] **Step 5: Commit** `feat(web): bulk Restore + async bulk Delete permanently with type-the-count confirm (#2787)`.
+
+---
+
+### Task 10: PR
+
+- [ ] `cd apps/api && npx vitest run src/routes/devices src/services/deviceLifecycle.test.ts src/jobs/deviceBulkPurge.test.ts src/middleware/selfManagedDbContextRoutes.test.ts` — green. Integration: `npx vitest run --config vitest.integration.config.ts src/__tests__/integration/deviceLifecycle.integration.test.ts src/__tests__/integration/deviceUninstallDrain.integration.test.ts` — green. `cd apps/web && npx vitest run src/components/devices src/services src/lib/i18n` — green. `pnpm lint`; tsc on both apps.
+- [ ] Merge `origin/main` first. Bring up the worktree stack (`worktree-stack` skill) and walk: select 8 removed devices → menu shows only Restore / Delete permanently / Compare → Restore 2 → Delete permanently 6 with typed count → progress toast → rows gone. Screenshot both.
+- [ ] Open PR `feat: bulk restore + async bulk permanent delete for removed devices; harden single lifecycle routes (#2787)`. Body: the two latent defects (TOCTOU, lock order) and how the service fixes them; the pending-uninstall refusal decision; why purge is async; the three gating sets. `Closes #2787. Refs #3987`. Stop at the PR.

--- a/docs/superpowers/plans/device-lifecycle/2026-09-05-device-removal-03-uninstall-state.md
+++ b/docs/superpowers/plans/device-lifecycle/2026-09-05-device-removal-03-uninstall-state.md
@@ -1,0 +1,112 @@
+---
+tracking_issue: LanternOps/breeze#5023
+---
+# Device Removal 03 — Pending-Uninstall State on a Removed Device Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A removed device tells the operator what happened to its queued agent uninstall — queued (with deadline), delivered, expired, cancelled, or none — so "did the agent actually come off?" has an answer on screen.
+
+**Architecture:** `GET /devices/:id` derives an `uninstall` object from the newest `self_uninstall` row carrying the `device_remove` reason, read only after the device authorisation chokepoint (device_commands is intentionally unscoped). The web renders it as a badge beside the Removed status on the detail page and as a line in the Removed panel of `DeviceSettingsModal`.
+
+**Tech Stack:** Hono + Drizzle (API); React + react-i18next (web).
+
+**Spec:** `docs/superpowers/specs/device-lifecycle/2026-09-05-device-removal-completion-design.md` (PR 3). Issue: #3987 item 7 (final item — PR closes #3987).
+
+## Global Constraints
+
+- Read `device_commands` ONLY after `getDeviceWithOrgAndSiteCheck` has authorised the device (`device_commands` has no RLS — memory: intentionally system-scoped).
+- `sent` means dispatched and acked by the agent's handler, NOT confirmed torn down (`core.ts` restore doc). Label it "delivered", never "uninstalled".
+- Reaper expiry lands as `status='failed'`, `result.status='timeout'` (`jobs/staleCommandReaper.ts:313`). Map that to `expired`; any other `failed` → `failed`.
+- `cancelled` = `status='cancelled'` (what `releaseDeviceRemoveReason` sets when Restore cancels it).
+- Rows lacking the `device_remove` reason (tenant-offboarding, abuse suspension) are NOT this device's Remove — ignore them here.
+- No schema change. Locale keys → all 8 locales.
+
+---
+
+### Task 1: API — derive `uninstall` on `GET /devices/:id`
+
+**Files:**
+- Create: `apps/api/src/services/deviceUninstallState.ts` + `.test.ts`
+- Modify: `apps/api/src/routes/devices/core.ts:995-1140` (detail route; add one call + one response key)
+- Test: `apps/api/src/routes/devices/core.uninstallState.test.ts` (new; mocks mirror `core.decommission.test.ts`)
+
+**Interfaces:**
+```ts
+export type DeviceUninstallState = 'pending' | 'sent' | 'completed' | 'expired' | 'failed' | 'cancelled';
+export interface DeviceUninstallStatus {
+  state: DeviceUninstallState;
+  queuedAt: string;            // ISO
+  sentAt: string | null;       // executed_at
+  completedAt: string | null;
+  expiresAt: string | null;    // device_remove_expires_at
+}
+/** Newest self_uninstall row carrying the device_remove reason, or null. Caller MUST have authorised the device. */
+export async function getDeviceUninstallStatus(deviceId: string): Promise<DeviceUninstallStatus | null>
+```
+Response: `GET /devices/:id` body gains `uninstall: DeviceUninstallStatus | null`.
+
+- [ ] **Step 1: Service tests** (compiled-SQL style: mock `../db` `db.select` chain to return a scripted row; assert the mapping)
+```ts
+const base = { id: 'c1', status: 'pending', createdAt: new Date('2026-09-05T10:00:00Z'), executedAt: null, completedAt: null, result: null, deviceRemoveExpiresAt: new Date('2026-09-08T10:00:00Z') };
+it('maps pending', …) → state 'pending', expiresAt '2026-09-08T10:00:00.000Z'
+it('maps sent → sent with sentAt', …)
+it('maps failed+timeout → expired', { status: 'failed', result: { status: 'timeout' } })
+it('maps failed without timeout → failed')
+it('maps cancelled', …) ; it('maps completed', …)
+it('returns null when no device_remove row exists')
+```
+- [ ] **Step 2: Run — FAIL.** **Step 3: Implement**
+```ts
+import { and, arrayContains, desc, eq } from 'drizzle-orm';
+import { db } from '../db';
+import { deviceCommands } from '../db/schema';
+import { UNINSTALL_REASON_DEVICE_REMOVE } from './deviceUninstallDrain';
+
+export async function getDeviceUninstallStatus(deviceId: string): Promise<DeviceUninstallStatus | null> {
+  const [row] = await db
+    .select({ status: deviceCommands.status, createdAt: deviceCommands.createdAt, executedAt: deviceCommands.executedAt, completedAt: deviceCommands.completedAt, result: deviceCommands.result, expiresAt: deviceCommands.deviceRemoveExpiresAt })
+    .from(deviceCommands)
+    .where(and(eq(deviceCommands.deviceId, deviceId), eq(deviceCommands.type, 'self_uninstall'), arrayContains(deviceCommands.uninstallReasons, [UNINSTALL_REASON_DEVICE_REMOVE])))
+    .orderBy(desc(deviceCommands.createdAt))
+    .limit(1);
+  if (!row) return null;
+  const timedOut = row.status === 'failed' && (row.result as { status?: string } | null)?.status === 'timeout';
+  const state: DeviceUninstallState =
+    timedOut ? 'expired'
+    : row.status === 'pending' || row.status === 'sent' || row.status === 'completed' || row.status === 'failed' || row.status === 'cancelled' ? row.status
+    : 'failed';
+  return { state, queuedAt: row.createdAt.toISOString(), sentAt: row.executedAt?.toISOString() ?? null, completedAt: row.completedAt?.toISOString() ?? null, expiresAt: row.expiresAt?.toISOString() ?? null };
+}
+```
+- [ ] **Step 4: Route test** — `core.uninstallState.test.ts`: rig the detail route's lookups (copy the mock scaffold from `core.decommission.test.ts`; `db.select` returns the device for the chokepoint and `[]` for hardware/network/metrics/groups), mock `../../services/deviceUninstallState` → `{ state: 'pending', … }`, assert `GET /devices/:id` body has `uninstall.state === 'pending'`; second case: mock returns `null` → `uninstall: null`; third: the service is NOT called when the chokepoint returns `null` (404 path).
+- [ ] **Step 5: Wire the route** — in `GET /:id` after the groups lookup: `const uninstall = device.status === 'decommissioned' ? await getDeviceUninstallStatus(deviceId) : null;` and add `uninstall,` to the `c.json({...})`. (Skipping the read for non-removed devices keeps the hot detail path unchanged.)
+- [ ] **Step 6: PASS** all three files + `core.permissions.test.ts`. **Commit** `feat(api): GET /devices/:id reports pending-uninstall state for removed devices (#3987)`.
+
+---
+
+### Task 2: Web — badge on the detail page + line in the Removed panel
+
+**Files:**
+- Create: `apps/web/src/components/devices/UninstallStateBadge.tsx` + `.test.tsx`
+- Modify: `apps/web/src/components/devices/DeviceDetails.tsx` (next to the status pill for a `decommissioned` device — locate via `grep -n decommissioned DeviceDetails.tsx`)
+- Modify: `apps/web/src/components/devices/DeviceSettingsModal.tsx:209-215` (Removed panel: add the line under `decommissionedDescription`)
+- Modify: `apps/web/src/components/devices/DeviceList.tsx` `Device` type: add `uninstall?: { state: string; expiresAt: string | null; sentAt: string | null } | null`
+- Locales: `devices.json` → `uninstallState.pending: "Agent uninstall queued — expires {{when}}"`, `pendingNoDeadline: "Agent uninstall queued"`, `sent: "Agent uninstall delivered"`, `completed: "Agent uninstalled"`, `expired: "Uninstall expired — the agent never checked in and may still be installed"`, `failed: "Agent uninstall failed"`, `cancelled: "Agent uninstall cancelled"`, `none: "Agent was left installed"` — all 8 locales.
+
+**Interfaces:**
+```ts
+export interface UninstallStateBadgeProps { uninstall: Device['uninstall']; status: string; compact?: boolean }
+```
+Renders nothing unless `status === 'decommissioned'`. `uninstall === null` → `none` copy (muted). `pending` uses `formatRelativeTime(expiresAt)` from `@/lib/formatTime` (check the exact exported helper name in that module and use it) for `{{when}}`; falls back to `pendingNoDeadline` when `expiresAt` is null. Tone: `pending`/`sent` info, `completed` success, `expired`/`failed` warning, `cancelled`/`none` muted. `data-testid="uninstall-state"` with `data-state={state}`.
+
+- [ ] **Step 1: Tests** — one render per state asserting copy and `data-state`; `returns null for a non-removed device`; `expired uses the warning tone class`.
+- [ ] **Step 2: FAIL.** **Step 3: Implement** the badge; mount it in `DeviceDetails.tsx` beside the status pill, and in `DeviceSettingsModal` under the description with `compact`. DeviceSettingsModal receives `device` — the `uninstall` field arrives on the detail payload, so `DevicesPage`'s list rows won't have it; the badge renders `none` copy only when `uninstall === null` is *explicitly* present, and renders nothing when `uninstall === undefined` (list row). Pin that with a test.
+- [ ] **Step 4: PASS** + `localeParity` + `keyUsage`. `npx tsc --noEmit`. **Commit** `feat(web): show agent-uninstall state on removed devices (#3987)`.
+
+---
+
+### Task 3: PR
+
+- [ ] API + web suites above green; merge `origin/main` first; stack walk: remove a device with Uninstall while its agent is offline → detail shows "queued — expires in 3 days"; restore → "cancelled"; screenshot.
+- [ ] PR `feat: surface agent-uninstall state on removed devices (#3987)` — `Closes #3987`. Stop at the PR.

--- a/docs/superpowers/specs/device-lifecycle/2026-09-05-device-removal-completion-design.md
+++ b/docs/superpowers/specs/device-lifecycle/2026-09-05-device-removal-completion-design.md
@@ -1,0 +1,96 @@
+---
+tracking_issue: LanternOps/breeze#5023
+---
+# Device Removal Completion — Design
+
+**Date:** 2026-09-05
+**Status:** Approved shape — advisor quorum run (Fable position + Codex `xhigh` read-only review, gpt-5.6-sol). Both agreed on the three-PR shape; Codex corrected three points (recorded below). Plans: `docs/superpowers/plans/device-lifecycle/2026-09-05-device-removal-0{1,2,3}-*.md`.
+**Tracking:** #5023 (waves #5024 #5025 #5026). **Issues:** #3987 (remaining scope), #2787 (bulk delete/restore), #2250 (agent choice on Remove — superseded by #3987). API half #3986 shipped in #4001.
+
+## Problem
+
+Screenshot 2026-09-05: eight devices filtered to `Status is Removed`, all selected. The bulk bar offers Reboot, Run Script, Deploy Software, Maintenance, Wake, Link, and "Remove Selected" — every one a no-op or a 400 on a removed device — and offers neither Restore nor Delete permanently. The operator has the exact selection they want and no action for it.
+
+Underneath that UX gap sits a worse one: the API's `DELETE /devices/:id` accepts `{ uninstallAgent }` and queues a durable, provenance-tagged `self_uninstall` (#4001), but **no web caller sends it** (`grep uninstallAgent apps/web/src` → 0 hits). Every Remove today leaves the agent installed, heartbeating into a 403 forever. That is the zombie outcome the 2026-08-24 owner decision was meant to eliminate.
+
+## What already exists (verified)
+
+| Piece | Where | State |
+|---|---|---|
+| Remove route with `uninstallAgent` + durable queue | `apps/api/src/routes/devices/core.ts:1518`, `services/deviceUninstallDrain.ts` | shipped #4001 |
+| Restore cancels pending uninstall atomically | `core.ts:1631` (`releaseDeviceRemoveReason` + flip in one tx) | shipped |
+| Permanent delete (single) | `core.ts:1731`, cascade in `services/deviceDeletion.ts` | shipped; **has a TOCTOU** (below) |
+| Menu parity on removed devices (row, card, detail) | `DeviceActions.tsx:275`, `DeviceList.tsx:2487`, `DeviceCard.tsx` | shipped #3994 — #3987 scope item 1 is DONE |
+| Label sweep Decommission→Remove | locales | shipped #3994 |
+| Bulk gating contract | `bulkActionGating.ts` + `DeviceList.test.tsx:1352` | shipped #2465 |
+| Bulk Remove | `services/deviceActions.ts:490` — client loop of single DELETEs | shipped, sends no body |
+| Bulk restore / bulk permanent delete | — | **does not exist** (API or web) |
+| Per-item isolated bulk helper | `lib/bulkOps.ts:70` `runBulkIsolated` | exists, used by invoices/quotes |
+| BullMQ job + status-endpoint pattern | `jobs/orgMerge.ts`, `routes/orgMerge.ts:246` | reference |
+
+## Locked decisions (owner, 2026-08-24 — do not re-litigate)
+
+1. Two verbs: **Remove** = offboard, history kept, restorable. **Delete permanently** = purge history.
+2. The Remove dialog's agent radio **defaults to Uninstall**.
+3. UI labels only; DB enum stays `decommissioned`; single-device API contract unchanged.
+
+## Design
+
+### PR 1 — Remove dialog with agent radio (single + bulk)
+
+`RemoveDeviceDialog` composes the existing `ConfirmDialog` via its `children` slot (it already has one plus the #3705 single-fire latch — no new generic slot). Radio: **Uninstall the Breeze agent** (default) / **Leave the agent installed**. Second line under Uninstall is state-aware:
+
+- online → "Queued now — an online agent collects it within moments."
+- any other status → "Queued — runs the next time the device checks in. Cancelled if it hasn't after {{hours}} hours."
+
+**Codex correction 1:** "runs now" is false — Remove only inserts a pending command then disconnects the WS (`core.ts:1553`, `:1598`); the agent collects on reconnect/poll. Copy says "queued".
+**Codex correction 2:** do not hardcode the drain window in web/shared. `DEVICE_UNINSTALL_DRAIN_WINDOW_HOURS` is env-driven (`deviceUninstallDrain.ts:80`). Expose it via a tiny read endpoint `GET /devices/removal-config` → `{ uninstallDrainWindowHours }`; the dialog fetches it once and falls back to the copy without a number.
+**Codex correction 3:** "X online / Y offline" mis-buckets maintenance/quarantined/updating/pending. Bulk summary uses "X online / Y not currently online".
+
+Web `decommissionDevice(id, { uninstallAgent })` sends the JSON body; `bulkDecommissionDevices(devices, { uninstallAgent })` passes it through, one radio for the whole selection. All **five** Remove surfaces route through the dialog: DevicesPage (row kebab + card, via `pendingDeviceAction`), DeviceDetailPage/DeviceActions, bulk bar, and `PossibleReplacementBanner.tsx:115` (issues its own bodyless DELETE today). The 5-second undo toast on single Remove stays — the dialog decides *how*, the toast still offers *whether*.
+
+### PR 2 — Removed-selection bulk bar + bulk restore + async bulk purge (#2787)
+
+**Prerequisite inside the PR: extract and harden a single-device lifecycle service.** Codex found two latent defects in the existing single permanent delete that bulk would multiply:
+
+- **TOCTOU:** status is checked outside the deletion transaction and never re-checked under the device lock (`core.ts:1748`, cascade lock at `deviceDeletion.ts:79`). A concurrent Restore can commit between the check and the cascade and the restored device is still purged. Fix: `SELECT ... FOR UPDATE` the device row, re-check `status = 'decommissioned'` inside the transaction, abort with a typed `DeviceNotRemovedError` otherwise.
+- **Lock-order inversion:** Restore locks `device_commands` rows (via `releaseDeviceRemoveReason`) before the `devices` row; the cascade locks `devices` first. AB-BA deadlock class (40P01). Fix: Restore takes `devices FOR UPDATE` first, then releases the reason.
+
+New module `services/deviceLifecycle.ts` exports `restoreDevice(tx, deviceId, actorUserId)` and `permanentlyDeleteDevice(tx, device, opts)`; the single routes become thin wrappers so single and bulk cannot drift.
+
+**Pending-uninstall vs purge.** `device_commands` is in the device cascade (`core.ts:307`), so purging a device with a pending `self_uninstall` destroys the only thing that would clean the endpoint. Decision: **purge refuses while a `device_remove` uninstall is pending** (409 `UNINSTALL_PENDING`, per-device in bulk), with copy telling the operator to wait for the agent to check in or restore-and-remove with "leave installed". The legacy fire-and-forget WS uninstall in the permanent route is removed (it was redundant once Remove queues durably, and it was the source of the "irreversible command sent, then tx rolled back" hazard the route's 409 branches apologise for).
+
+**Bulk restore — synchronous.** `POST /devices/bulk/restore { deviceIds[] }` (max 500), registered in `selfManagedDbContextRoutes.ts` so the request-level transaction is not held across the loop (`auth.ts:738` wraps every non-self-managed handler in one tx; nested `db.transaction` would only be savepoints). Runs `runBulkIsolated(ctx, ids, id => restoreOne(id))` with site/org check per device. Returns `{ succeeded: [{deviceId, uninstallAlreadyDispatched}], failed: [{deviceId, code, message}] }`. Must mount before core's `/:id/restore`.
+
+**Bulk permanent delete — async.** `POST /devices/bulk/permanent-delete { deviceIds[] }` (max 500) → validates every id is accessible + `decommissioned` + no pending uninstall **up front** (cheap SELECT), then enqueues one BullMQ job (`device-bulk-purge`, `jobId = device-bulk-purge-<uuid>`) whose payload carries `{ deviceIds, expected: [{deviceId, orgId}], actorUserId, partnerId, orgScope }`. Returns `202 { jobId, accepted, rejected[] }`. Worker runs each device in its own `withSystemDbAccessContext` transaction, **re-verifies `org_id` matches the expected org and status is still `decommissioned` under lock** (a device moved or restored after enqueue is skipped, not deleted under stale authorization), writes one `device.permanent_delete` audit row per device with `bulkJobId`, invalidates the org device-count cache, updates `job.updateProgress`. `GET /devices/bulk/purge-runs/:jobId` mirrors `routes/orgMerge.ts:246`: partner-scope callers get 404 on another partner's job. Web polls it every 2s while the job is active and shows a progress toast.
+
+Why async, not a 500-iteration loop in the request: `deleteDeviceCascade` touches ~40 tables per device; at 500 devices that is minutes of work on one pooled connection under the request transaction, and one bad row aborts everything. The repo already warns about exactly this (`db/index.ts:213`).
+
+**Bulk bar — selection-aware.** Three states computed from the selected devices:
+
+| Selection | Menu |
+|---|---|
+| all `status !== 'decommissioned'` | today's menu unchanged |
+| all `decommissioned` | **Restore Selected**, **Delete permanently…**, Compare (2–4) — nothing else |
+| mixed | today's menu; the existing "skip N removed" confirm stays (explicit, not a passive hint — Codex) |
+
+New classification set `REMOVED_ONLY_BULK_ACTIONS = {'restore', 'permanent-delete'}` in `bulkActionGating.ts`; the contract test gains "every emitted action is in exactly one of the three sets" and "removed-only actions are never emitted for an active selection".
+
+**Delete permanently confirm (bulk):** purge-framed copy listing what is destroyed, a bounded summary of targets (first 5 hostnames + "and N more", grouped org count), and a type-the-count field; Confirm is disabled until the typed number equals the selection size. Selection is pruned to rows still present in the current fetch before the dialog opens (selection persists across filter changes — `DeviceList.tsx:715`).
+
+### PR 3 — Pending-uninstall state on a removed device (#3987 item 7)
+
+`GET /devices/:id` gains `uninstall: null | { state: 'pending' | 'sent' | 'expired' | 'completed' | 'cancelled', expiresAt, queuedAt, sentAt }`, derived from the newest `self_uninstall` row carrying `device_remove`, read **after** `getDeviceWithOrgAndSiteCheck` authorises (device_commands is intentionally unscoped). `sent` means dispatched and acked, not confirmed torn down (`core.ts:1682` comment). A `staleCommandReaper` expiry lands as `status='failed'` with a timeout result → `expired`. Web: a badge next to the Removed status pill on the detail page and a line in the Removed panel of `DeviceSettingsModal`: "Agent uninstall queued — expires in 2d 3h" / "Agent uninstall delivered" / "Uninstall expired — the agent never checked in; it may still be installed."
+
+## Out of scope
+
+- Agent-side pre-teardown fence for `sent` rows (#3995).
+- Purge-older-than-N-days retention job (#2787 item 4) — a later slice once bulk purge exists.
+- Bulk Remove as a server-side endpoint — the client loop is acceptable at ≤500 because each DELETE is one small transaction; revisit if a real fleet-scale Remove appears.
+
+## Test obligations (from CLAUDE.md contracts)
+
+- No new tables → no RLS/cascade/export-policy registration. The BullMQ payload is the only new persistent-ish state; it lives in Redis.
+- New routes → add to `core.permissions.test.ts` matrix (DEVICES_DELETE + MFA), `selfManagedDbContextRoutes.test.ts` (bulk restore), `index.test.ts` mount-order (`/bulk/*` before `/:id`).
+- `DeviceList.test.tsx` gating contract extended to three sets.
+- Integration: `deviceLifecycle.integration.test.ts` proving (a) purge racing restore loses cleanly, (b) purge refused on pending uninstall, (c) bulk purge worker skips a device whose org changed after enqueue.


### PR DESCRIPTION
Design doc + three wave plans for feature #5023 (waves #5024, #5025, #5026). Docs only.

Advisor quorum (Fable + codex xhigh) on finishing #3987 / #2787: Remove dialog with agent choice (web never sends `uninstallAgent` today), lifecycle service hardening (TOCTOU + lock-order in single purge/restore) with bulk restore and async bulk purge, and pending-uninstall state on removed devices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZAsMVZBbCxwBUtRFmrY7A