### PR TITLE
fix(portal): route ticket-page gate 403s through the shared home redirect (#4932 follow-up)

### DIFF
--- a/apps/portal/src/lib/disabledPageCoverage.test.ts
+++ b/apps/portal/src/lib/disabledPageCoverage.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { PORTAL_GATED_PAGES } from './visibilityGate';
 
 /**
  * Contract test: a portal page whose data comes from behind a visibility gate
@@ -110,6 +111,23 @@ describe('visibility-gate handling in portal pages', () => {
       'A gate 403 means the MSP switched this page off — redirect through ' +
         'redirectToPortalHomeAfterDisabled instead of rendering a load failure:\n' +
         violations.join('\n'),
+    ).toEqual([]);
+  });
+
+  it('never redirects a disabled page onto another gated page', () => {
+    // #4932 follow-up: a gate 403 that bounces to /devices (itself gated on
+    // Self-service) becomes two hops when both are off. The "handled" check
+    // above accepts any page that names its gate code, so a stale hardcoded
+    // target passes it — assert the target directly.
+    const gated = PORTAL_GATED_PAGES.map((page) => page.replace(/^\//, ''));
+    const pattern = new RegExp(`Astro\\.redirect\\(withBase\\('/(?:${gated.join('|')})(?:/[^']*)?'\\)\\)`);
+    const stale = pages
+      .filter(({ source }) => gatedMethodsIn(source).length > 0)
+      .filter(({ source }) => pattern.test(frontmatterOf(source) ?? ''))
+      .map(({ path }) => path);
+    expect(
+      stale,
+      'these pages answer a gate 403 by redirecting onto another gated page — use redirectToPortalHomeAfterDisabled',
     ).toEqual([]);
   });
 

--- a/apps/portal/src/lib/ticketsPage.test.ts
+++ b/apps/portal/src/lib/ticketsPage.test.ts
@@ -9,7 +9,7 @@ describe('decideTicketsPage', () => {
     )).toEqual({
       ticketsDisabled: true,
       usageStrictlyDisabled: false,
-      redirectToDevices: false,
+      redirectHome: false,
     });
   });
 
@@ -17,14 +17,14 @@ describe('decideTicketsPage', () => {
     expect(decideTicketsPage(
       { statusCode: 403, code: 'PORTAL_TICKETS_DISABLED' },
       { statusCode: 403 },
-    ).redirectToDevices).toBe(true);
+    ).redirectHome).toBe(true);
   });
 
   it('redirects when tickets are disabled and support usage is unavailable', () => {
     expect(decideTicketsPage(
       { statusCode: 403, code: 'PORTAL_TICKETS_DISABLED' },
       { statusCode: 500 },
-    ).redirectToDevices).toBe(true);
+    ).redirectHome).toBe(true);
   });
 
   it('shows the normal ticket list when tickets are available', () => {
@@ -34,7 +34,7 @@ describe('decideTicketsPage', () => {
     )).toEqual({
       ticketsDisabled: false,
       usageStrictlyDisabled: true,
-      redirectToDevices: false,
+      redirectHome: false,
     });
   });
 });

--- a/apps/portal/src/lib/ticketsPage.ts
+++ b/apps/portal/src/lib/ticketsPage.ts
@@ -6,7 +6,7 @@ interface PortalResponseState {
 export interface TicketsPageDecision {
   ticketsDisabled: boolean;
   usageStrictlyDisabled: boolean;
-  redirectToDevices: boolean;
+  redirectHome: boolean;
 }
 
 export function decideTicketsPage(
@@ -21,6 +21,6 @@ export function decideTicketsPage(
   return {
     ticketsDisabled,
     usageStrictlyDisabled,
-    redirectToDevices: ticketsDisabled && usageResponse.statusCode !== 200,
+    redirectHome: ticketsDisabled && usageResponse.statusCode !== 200,
   };
 }

--- a/apps/portal/src/pages/tickets/[id].astro
+++ b/apps/portal/src/pages/tickets/[id].astro
@@ -1,6 +1,6 @@
 ---
 import PortalLayout from '../../layouts/PortalLayout.astro';
-import { withBase } from '../../lib/basePath';
+import { isPortalPageDisabled, redirectToPortalHomeAfterDisabled } from '../../lib/visibilityGate';
 import { redirectToLoginAfter401 } from '../../lib/session';
 import TicketDetails from '../../components/portal/TicketDetails';
 import { portalApi } from '../../lib/api';
@@ -18,8 +18,10 @@ if (response.statusCode === 401) {
 // bounce to the portal home instead of rendering a dead page. Other 403s
 // (e.g. "Account is not active") keep the previous behavior: fall through and
 // render the page with the API error inline.
-if (response.statusCode === 403 && response.code === 'PORTAL_TICKETS_DISABLED') {
-  return Astro.redirect(withBase('/devices'));
+if (isPortalPageDisabled(response)) {
+  // PORTAL_TICKETS_DISABLED — bounce to the ungated home, never to /devices,
+  // which is itself gated on Self-service (#4932 follow-up).
+  return redirectToPortalHomeAfterDisabled(Astro);
 }
 ---
 

--- a/apps/portal/src/pages/tickets/index.astro
+++ b/apps/portal/src/pages/tickets/index.astro
@@ -1,6 +1,6 @@
 ---
 import PortalLayout from '../../layouts/PortalLayout.astro';
-import { withBase } from '../../lib/basePath';
+import { redirectToPortalHomeAfterDisabled } from '../../lib/visibilityGate';
 import { redirectToLoginAfter401 } from '../../lib/session';
 import TicketList from '../../components/portal/TicketList';
 import { SupportUsagePanel } from '../../components/portal/SupportUsagePanel';
@@ -20,11 +20,11 @@ if (response.statusCode === 401 || usageResponse.statusCode === 401) {
   return redirectToLoginAfter401(Astro);
 }
 
-const { ticketsDisabled, usageStrictlyDisabled, redirectToDevices } =
+const { ticketsDisabled, usageStrictlyDisabled, redirectHome } =
   decideTicketsPage(response, usageResponse);
 
-if (redirectToDevices) {
-  return Astro.redirect(withBase('/devices'));
+if (redirectHome) {
+  return redirectToPortalHomeAfterDisabled(Astro);
 }
 
 // SupportUsagePanel renders nothing without data or an error to report; only

--- a/apps/portal/src/pages/tickets/new.astro
+++ b/apps/portal/src/pages/tickets/new.astro
@@ -1,7 +1,7 @@
 ---
 import PortalLayout from '../../layouts/PortalLayout.astro';
 import NewTicketForm from '../../components/portal/NewTicketForm';
-import { withBase } from '../../lib/basePath';
+import { isPortalPageDisabled, redirectToPortalHomeAfterDisabled } from '../../lib/visibilityGate';
 import { redirectToLoginAfter401 } from '../../lib/session';
 import { portalApi } from '../../lib/api';
 import { buildServerApiConfig } from '../../lib/server';
@@ -18,8 +18,10 @@ if (formsResponse.statusCode === 401) {
   // Dead session: clear the stale cookie and come back here after sign-in.
   return redirectToLoginAfter401(Astro);
 }
-if (formsResponse.statusCode === 403 && formsResponse.code === 'PORTAL_TICKETS_DISABLED') {
-  return Astro.redirect(withBase('/devices'));
+if (isPortalPageDisabled(formsResponse)) {
+  // PORTAL_TICKETS_DISABLED — bounce to the ungated home, never to /devices,
+  // which is itself gated on Self-service (#4932 follow-up).
+  return redirectToPortalHomeAfterDisabled(Astro);
 }
 if (formsResponse.error && formsResponse.statusCode !== 403) {
   // Fail-open is intentional, but never invisible: without this breadcrumb a


### PR DESCRIPTION
## Summary
Follow-up from the post-merge review of #4995.

Three ticket pages (`tickets/index.astro`, `tickets/new.astro`, `tickets/[id].astro`) still answered `PORTAL_TICKETS_DISABLED` with `Astro.redirect(withBase('/devices'))`. #4995 made `/devices` gate-aware, so with Tickets and Self-service both switched off a customer bounced `/tickets/* → /devices → /quotes` — two hops, contradicting the "chain is structurally impossible" invariant. All three now use `redirectToPortalHomeAfterDisabled`. `decideTicketsPage`'s `redirectToDevices` flag is renamed `redirectHome` to match.

## Test
`disabledPageCoverage.test.ts` gains **"never redirects a disabled page onto another gated page"** — a regex over each gated page's frontmatter for a redirect onto any `PORTAL_GATED_PAGES` path. The existing "handled" check accepted these pages because they name their gate code. Red on main (flagged all three pages, one more than the reviewer found), green after. 23/23 across the three portal lib suites; `astro check` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUsfUH7smCCDiSVrGFTasC