### PR TITLE
feat(api): cancel a running automation run (#4761 W05, plan W05)

### DIFF
--- a/apps/api/migrations/2026-10-10-140300-automation-run-cancellation.sql
+++ b/apps/api/migrations/2026-10-10-140300-automation-run-cancellation.sql
@@ -1,0 +1,38 @@
+-- #3525 W05 (#4766) — automation run cancellation.
+--
+-- Slot note: the plan named this 2026-10-07-100200. That name now sorts BEFORE
+-- migrations already shipped on main (newest committed: 2026-10-10-100400) and
+-- before two same-day files in flight, so it would replay ahead of them on a
+-- fresh database. Renamed to sort last; see apps/api/migrations/README.md.
+--
+-- This file writes no rows: it adds two enum values and one integer column with
+-- a DEFAULT, so there is no UPDATE/DELETE/INSERT and no detection read against
+-- an RLS-forced table. `breeze.scope` is elected anyway, so that a future edit
+-- that DOES write cannot silently match zero rows under FORCE ROW LEVEL
+-- SECURITY (CLAUDE.md §Schema Migration Workflow).
+SELECT set_config('breeze.scope', 'system', true);
+
+-- Both values are APPENDED (no AFTER clause) because the Drizzle pgEnum
+-- declarations append them too, and drizzle-kit compares value ORDER — adding
+-- here and inserting in TypeScript would make `pnpm db:check-drift` report
+-- phantom drift. Postgres permits ALTER TYPE ... ADD VALUE inside the
+-- transaction autoMigrate wraps each file in; it only forbids USING the new
+-- literal before that transaction commits, and nothing below uses one.
+ALTER TYPE automation_run_status ADD VALUE IF NOT EXISTS 'cancelled';
+ALTER TYPE automation_device_result_status ADD VALUE IF NOT EXISTS 'cancelled';
+
+-- OD6-A: cancelled is neither a success nor a failure. Counting it as failed
+-- would poison automation health reporting and any alerting keyed on
+-- devices_failed; counting it as skipped would overload a value that means
+-- "filtered out of the target set".
+--
+-- The counter records CONFIRMED stops only — it is incremented by the
+-- reconciler as child rows terminalise, never by the cancel REQUEST. A run
+-- with 20 devices asked to stop and 3 proven stopped reports 3.
+--
+-- automation_runs has NO org_id and is deliberately absent from
+-- CORE_ORG_CASCADE_DELETE_ORDER and CORE_TENANT_EXPORT_POLICY (verified: no
+-- "automation_runs" key in tenantExportPolicyRegistry.ts). An integer counter
+-- keeps it that way; do not add an org column here.
+ALTER TABLE automation_runs
+  ADD COLUMN IF NOT EXISTS devices_cancelled integer NOT NULL DEFAULT 0;

--- a/apps/api/migrations/2026-10-11-140300-automation-run-cancellation.sql
+++ b/apps/api/migrations/2026-10-11-140300-automation-run-cancellation.sql
@@ -1,9 +1,10 @@
 -- #3525 W05 (#4766) — automation run cancellation.
 --
--- Slot note: the plan named this 2026-10-07-100200. That name now sorts BEFORE
--- migrations already shipped on main (newest committed: 2026-10-10-100400) and
--- before two same-day files in flight, so it would replay ahead of them on a
--- fresh database. Renamed to sort last; see apps/api/migrations/README.md.
+-- Slot note: the plan named this 2026-10-07-100200. That name sorts BEFORE
+-- migrations already shipped on main, so it would replay ahead of them on a
+-- fresh database. Renamed twice to sort last (origin/main gained
+-- 2026-10-11-000300 while this branch was open, which the pre-push guard
+-- caught); see apps/api/migrations/README.md.
 --
 -- This file writes no rows: it adds two enum values and one integer column with
 -- a DEFAULT, so there is no UPDATE/DELETE/INSERT and no detection read against

--- a/apps/api/src/__tests__/integration/automationRunCancelFence.integration.test.ts
+++ b/apps/api/src/__tests__/integration/automationRunCancelFence.integration.test.ts
@@ -296,6 +296,28 @@ describe('automation run cancel fence — real PostgreSQL', () => {
     ]);
   }, 30_000);
 
+  runDb('finishes a run cancelled before any action row was ever seeded', async () => {
+    // The shape of a cancel between enqueue and worker pickup. Reconciliation
+    // derives everything from action rows and returns early when there are
+    // none, so without the explicit stamp the run would read as permanently
+    // in progress.
+    const f = await fixture();
+
+    const outcome = await cancelAutomationRun({
+      runId: f.run.id,
+      actorId: null,
+      actorLabel: 'fence-integration',
+    });
+    expect(outcome).toMatchObject({ kind: 'cancelled', actionsCancelled: 0 });
+
+    const [run] = await getTestDb()
+      .select({ status: automationRuns.status, completedAt: automationRuns.completedAt })
+      .from(automationRuns)
+      .where(eq(automationRuns.id, f.run.id));
+    expect(run).toMatchObject({ status: 'cancelled' });
+    expect(run!.completedAt).not.toBeNull();
+  }, 30_000);
+
   runDb('refuses to relabel a run that already finished on its own', async () => {
     const f = await fixture();
     await getTestDb().update(automationRuns)

--- a/apps/api/src/__tests__/integration/automationRunCancelFence.integration.test.ts
+++ b/apps/api/src/__tests__/integration/automationRunCancelFence.integration.test.ts
@@ -1,0 +1,317 @@
+import './setup';
+
+import { randomUUID } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { and, eq, sql } from 'drizzle-orm';
+import {
+  automationActionResults,
+  automationRunDeviceResults,
+  automationRuns,
+  automations,
+  deviceCommands,
+  devices,
+  scriptExecutions,
+  scripts,
+} from '../../db/schema';
+import {
+  assertRunNotCancelled,
+  cancelAutomationRun,
+  RunCancelledError,
+} from '../../services/automationRunCancellation';
+import { seedAutomationActionResults } from '../../services/automationActionResults';
+import { createOrganization, createPartner, createSite } from './db-utils';
+import { getTestDb } from './setup';
+
+/**
+ * #3525 W05 (#4766) — the dispatch fence, against real PostgreSQL.
+ *
+ * A Drizzle mock cannot prove any of this: the whole contract is what two
+ * CONCURRENT transactions do to each other. `cancelAutomationRun` takes
+ * `FOR UPDATE` on the run row; every dispatcher takes `FOR SHARE` on it first.
+ * The guarantee that buys is:
+ *
+ *   an execution belonging to a cancelled run is either already visible to the
+ *   cancel's fan-out, or the dispatcher is refused before it creates one.
+ *
+ * Test 1 proves the first half by construction: the execution is created
+ * inside a transaction that is still open when the cancel starts, so the
+ * fan-out can only see it if the cancel genuinely waited on the row lock.
+ */
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+const delay = (ms: number) => new Promise((resolve) => { setTimeout(resolve, ms); });
+
+async function fixture(options: { runStatus?: 'running' | 'cancelled' } = {}) {
+  const partner = await createPartner();
+  const org = await createOrganization({ partnerId: partner.id });
+  const site = await createSite({ orgId: org.id });
+  const [device] = await getTestDb().insert(devices).values({
+    orgId: org.id,
+    siteId: site.id,
+    agentId: `cancel-fence-${randomUUID()}`,
+    hostname: 'cancel-fence-device',
+    osType: 'linux',
+    osVersion: '24.04',
+    architecture: 'amd64',
+    agentVersion: '1.0.0',
+  }).returning({ id: devices.id, orgId: devices.orgId });
+  const [script] = await getTestDb().insert(scripts).values({
+    orgId: org.id,
+    name: `cancel-fence-${randomUUID()}`,
+    osTypes: ['linux'],
+    language: 'bash',
+    content: 'sleep 120',
+    timeoutSeconds: 300,
+  }).returning({ id: scripts.id });
+  const [automation] = await getTestDb().insert(automations).values({
+    orgId: org.id,
+    name: `cancel-fence-${randomUUID()}`,
+    trigger: { type: 'manual' },
+    actions: [{ type: 'run_script', scriptId: script!.id }],
+  }).returning({ id: automations.id });
+  const [run] = await getTestDb().insert(automationRuns).values({
+    automationId: automation!.id,
+    triggeredBy: 'cancel-fence-integration',
+    devicesTargeted: 1,
+    status: options.runStatus ?? 'running',
+  }).returning({ id: automationRuns.id });
+  return { org, device: device!, script: script!, automation: automation!, run: run! };
+}
+
+/**
+ * A `script_executions` row plus the paired PENDING `script` command that
+ * `cancelScriptExecution` retracts. Retraction is the one cancellation outcome
+ * that needs no agent, so the sweep resolves deterministically here.
+ */
+async function insertDispatchedExecution(
+  db: ReturnType<typeof getTestDb>,
+  f: Awaited<ReturnType<typeof fixture>>,
+) {
+  const [execution] = await db.insert(scriptExecutions).values({
+    scriptId: f.script.id,
+    deviceId: f.device.id,
+    orgId: f.org.id,
+    automationRunId: f.run.id,
+    status: 'pending',
+  }).returning({ id: scriptExecutions.id });
+  await db.insert(deviceCommands).values({
+    deviceId: f.device.id,
+    type: 'script',
+    payload: { executionId: execution!.id },
+    status: 'pending',
+  });
+  return execution!.id;
+}
+
+describe('automation run cancel fence — real PostgreSQL', () => {
+  runDb('a dispatch holding FOR SHARE blocks the cancel, and its execution is caught by the fan-out', async () => {
+    const f = await fixture();
+
+    let dispatchCommittedAt = 0;
+    let cancelReturnedAt = 0;
+
+    // The dispatcher: fence first, then create the execution, then linger.
+    // Nothing it wrote is visible to any other connection until it commits.
+    const dispatch = getTestDb().transaction(async (tx) => {
+      await assertRunNotCancelled(tx, f.run.id);
+      await insertDispatchedExecution(tx as unknown as ReturnType<typeof getTestDb>, f);
+      await delay(600);
+      dispatchCommittedAt = Date.now();
+    });
+
+    // Start the cancel while the dispatcher still holds the lock.
+    await delay(120);
+    const cancel = (async () => {
+      const outcome = await cancelAutomationRun({
+        runId: f.run.id,
+        actorId: null,
+        actorLabel: 'fence-integration',
+      });
+      cancelReturnedAt = Date.now();
+      return outcome;
+    })();
+
+    const [, outcome] = await Promise.all([dispatch, cancel]);
+
+    expect(outcome).toMatchObject({ kind: 'cancelled' });
+    // The cancel could not have returned before the dispatcher committed:
+    // its FOR UPDATE queued behind the dispatcher's FOR SHARE.
+    expect(cancelReturnedAt).toBeGreaterThanOrEqual(dispatchCommittedAt);
+
+    // The substantive proof. Had the cancel NOT waited, its fan-out would have
+    // read the executions table while this row was still invisible, and the
+    // script would be running on the device with the run labelled cancelled.
+    const [execution] = await getTestDb()
+      .select({ status: scriptExecutions.status, cancelState: scriptExecutions.cancelState })
+      .from(scriptExecutions)
+      .where(eq(scriptExecutions.automationRunId, f.run.id));
+    expect(execution).toMatchObject({ status: 'cancelled', cancelState: 'confirmed' });
+  }, 30_000);
+
+  runDb('a dispatch that starts after the cancel commits is refused', async () => {
+    const f = await fixture();
+    await cancelAutomationRun({ runId: f.run.id, actorId: null, actorLabel: 'fence-integration' });
+
+    await expect(
+      getTestDb().transaction((tx) => assertRunNotCancelled(tx, f.run.id)),
+    ).rejects.toBeInstanceOf(RunCancelledError);
+
+    // And a run that is merely finished, or gone, is not a fence trip.
+    const other = await fixture();
+    await expect(
+      getTestDb().transaction((tx) => assertRunNotCancelled(tx, other.run.id)),
+    ).resolves.toBeUndefined();
+    await expect(
+      getTestDb().transaction((tx) => assertRunNotCancelled(tx, randomUUID())),
+    ).resolves.toBeUndefined();
+  }, 30_000);
+
+  runDb('creates ZERO new child rows after the fence commits', async () => {
+    const f = await fixture();
+    await seedAutomationActionResults({
+      runId: f.run.id,
+      device: { id: f.device.id, orgId: f.org.id },
+      actions: [{ actionIndex: 0, actionType: 'run_script' }],
+    });
+    await getTestDb().insert(automationRunDeviceResults).values({
+      runId: f.run.id,
+      deviceId: f.device.id,
+      orgId: f.org.id,
+      status: 'pending',
+    });
+
+    const countChildren = async () => {
+      const [row] = await getTestDb().execute(sql`
+        SELECT
+          (SELECT count(*) FROM automation_action_results WHERE run_id = ${f.run.id}::uuid) AS actions,
+          (SELECT count(*) FROM automation_run_device_results WHERE run_id = ${f.run.id}::uuid) AS device_results,
+          (SELECT count(*) FROM script_executions WHERE automation_run_id = ${f.run.id}::uuid) AS executions
+      `) as unknown as Array<{ actions: string; device_results: string; executions: string }>;
+      return row!;
+    };
+    const before = await countChildren();
+
+    await cancelAutomationRun({ runId: f.run.id, actorId: null, actorLabel: 'fence-integration' });
+
+    // Every dispatch entry point now refuses. Seeding a further device, or
+    // dispatching another action, is exactly what the fence forbids.
+    await expect(
+      getTestDb().transaction((tx) => assertRunNotCancelled(tx, f.run.id)),
+    ).rejects.toBeInstanceOf(RunCancelledError);
+
+    const after = await countChildren();
+    expect(after).toEqual(before);
+  }, 30_000);
+
+  runDb('terminalises never-dispatched actions, counts only proven stops, and never re-opens the run', async () => {
+    const f = await fixture();
+    await seedAutomationActionResults({
+      runId: f.run.id,
+      device: { id: f.device.id, orgId: f.org.id },
+      actions: [{ actionIndex: 0, actionType: 'run_script' }],
+    });
+    await getTestDb().insert(automationRunDeviceResults).values({
+      runId: f.run.id,
+      deviceId: f.device.id,
+      orgId: f.org.id,
+      status: 'pending',
+    });
+
+    const outcome = await cancelAutomationRun({
+      runId: f.run.id,
+      actorId: null,
+      actorLabel: 'tech@example.com',
+    });
+    expect(outcome).toMatchObject({ kind: 'cancelled', actionsCancelled: 1 });
+
+    const [action] = await getTestDb()
+      .select({ status: automationActionResults.status, terminalSource: automationActionResults.terminalSource })
+      .from(automationActionResults)
+      .where(eq(automationActionResults.runId, f.run.id));
+    expect(action).toMatchObject({ status: 'cancelled', terminalSource: 'cancellation' });
+
+    const [deviceResult] = await getTestDb()
+      .select({ status: automationRunDeviceResults.status })
+      .from(automationRunDeviceResults)
+      .where(eq(automationRunDeviceResults.runId, f.run.id));
+    expect(deviceResult).toMatchObject({ status: 'cancelled' });
+
+    const [run] = await getTestDb()
+      .select({
+        status: automationRuns.status,
+        devicesCancelled: automationRuns.devicesCancelled,
+        devicesFailed: automationRuns.devicesFailed,
+        completedAt: automationRuns.completedAt,
+        logs: automationRuns.logs,
+      })
+      .from(automationRuns)
+      .where(eq(automationRuns.id, f.run.id));
+    expect(run).toMatchObject({ status: 'cancelled', devicesCancelled: 1, devicesFailed: 0 });
+    expect(run!.completedAt).not.toBeNull();
+    // The log entry is appended with jsonb ||, naming who stopped it.
+    expect(JSON.stringify(run!.logs)).toContain('tech@example.com');
+
+    // Idempotent: a second cancel neither throws nor relabels.
+    const again = await cancelAutomationRun({
+      runId: f.run.id,
+      actorId: null,
+      actorLabel: 'tech@example.com',
+    });
+    expect(again).toMatchObject({ kind: 'cancelled', alreadyCancelling: true, actionsCancelled: 0 });
+  }, 30_000);
+
+  runDb('reports an in-flight deployment as uncancellable instead of claiming the run stopped', async () => {
+    const f = await fixture();
+    await seedAutomationActionResults({
+      runId: f.run.id,
+      device: { id: f.device.id, orgId: f.org.id },
+      actions: [
+        { actionIndex: 0, actionType: 'deploy_software' },
+        { actionIndex: 1, actionType: 'run_script' },
+      ],
+    });
+    await getTestDb().insert(automationRunDeviceResults).values({
+      runId: f.run.id,
+      deviceId: f.device.id,
+      orgId: f.org.id,
+      status: 'pending',
+    });
+    // Action 0 already reached the device; action 1 never did.
+    await getTestDb().update(automationActionResults)
+      .set({ status: 'running' })
+      .where(and(
+        eq(automationActionResults.runId, f.run.id),
+        eq(automationActionResults.actionIndex, 0),
+      ));
+
+    const outcome = await cancelAutomationRun({
+      runId: f.run.id,
+      actorId: null,
+      actorLabel: 'fence-integration',
+    }) as Extract<Awaited<ReturnType<typeof cancelAutomationRun>>, { kind: 'cancelled' }>;
+
+    expect(outcome.actionsCancelled).toBe(1);
+    expect(outcome.uncancellableActions).toEqual([
+      { actionIndex: 0, actionType: 'deploy_software', reason: expect.any(String) },
+    ]);
+  }, 30_000);
+
+  runDb('refuses to relabel a run that already finished on its own', async () => {
+    const f = await fixture();
+    await getTestDb().update(automationRuns)
+      .set({ status: 'completed', completedAt: new Date() })
+      .where(eq(automationRuns.id, f.run.id));
+
+    await expect(cancelAutomationRun({
+      runId: f.run.id,
+      actorId: null,
+      actorLabel: 'fence-integration',
+    })).resolves.toMatchObject({ kind: 'already_terminal', status: 'completed' });
+
+    const [run] = await getTestDb()
+      .select({ status: automationRuns.status })
+      .from(automationRuns)
+      .where(eq(automationRuns.id, f.run.id));
+    expect(run).toMatchObject({ status: 'completed' });
+  }, 30_000);
+});

--- a/apps/api/src/db/schema/automations.ts
+++ b/apps/api/src/db/schema/automations.ts
@@ -8,13 +8,20 @@ import { aiAgents } from './aiAgents';
 
 export const automationTriggerTypeEnum = pgEnum('automation_trigger_type', ['schedule', 'event', 'webhook', 'manual']);
 export const automationOnFailureEnum = pgEnum('automation_on_failure', ['stop', 'continue', 'notify']);
-export const automationRunStatusEnum = pgEnum('automation_run_status', ['running', 'completed', 'failed', 'partial']);
+// `cancelled` (#3525 W05) is APPENDED, matching the migration's ADD VALUE order
+// — drizzle-kit compares enum value order, so inserting it mid-list here would
+// report phantom drift. A run reaches `cancelled` the moment a stop is
+// REQUESTED (that write is the dispatch fence); its children keep closing
+// honestly underneath and `completed_at` is stamped only once they are all
+// terminal.
+export const automationRunStatusEnum = pgEnum('automation_run_status', ['running', 'completed', 'failed', 'partial', 'cancelled']);
 export const automationResourceKindEnum = pgEnum('automation_resource_kind', ['script', 'software_catalog', 'notification_channel']);
 export const automationResourceBindingStateEnum = pgEnum('automation_resource_binding_state', ['active', 'quarantined']);
 // Per-device outcome within a single automation run (#2023). `pending` = row
 // seeded before the device is processed; `running` = actively executing;
-// terminal states are success/failed/skipped.
-export const automationDeviceResultStatusEnum = pgEnum('automation_device_result_status', ['pending', 'running', 'success', 'failed', 'skipped']);
+// terminal states are success/failed/skipped/cancelled. `cancelled` (#3525 W05)
+// is appended last for the same drift reason as automation_run_status above.
+export const automationDeviceResultStatusEnum = pgEnum('automation_device_result_status', ['pending', 'running', 'success', 'failed', 'skipped', 'cancelled']);
 export const automationActionResultStatusEnum = pgEnum('automation_action_result_status', [
   'pending', 'queued', 'delivered', 'running',
   'succeeded', 'failed', 'skipped', 'timed_out', 'cancelled',
@@ -113,6 +120,10 @@ export const automationRuns = pgTable('automation_runs', {
   devicesTargeted: integer('devices_targeted').notNull().default(0),
   devicesSucceeded: integer('devices_succeeded').notNull().default(0),
   devicesFailed: integer('devices_failed').notNull().default(0),
+  // #3525 W05 — devices whose work was PROVEN stopped, not devices asked to
+  // stop. Maintained by the reconciler as child rows terminalise as
+  // `cancelled`; a cancel request on its own never moves it.
+  devicesCancelled: integer('devices_cancelled').notNull().default(0),
   startedAt: timestamp('started_at').defaultNow().notNull(),
   completedAt: timestamp('completed_at'),
   logs: jsonb('logs').default([]),

--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -3284,7 +3284,7 @@ API requests are rate-limited to ensure fair usage. Rate limit headers are inclu
           { $ref: '#/components/parameters/idParam' },
           { $ref: '#/components/parameters/pageParam' },
           { $ref: '#/components/parameters/limitParam' },
-          { name: 'status', in: 'query', schema: { type: 'string', enum: ['running', 'completed', 'failed', 'partial'] } }
+          { name: 'status', in: 'query', schema: { type: 'string', enum: ['running', 'completed', 'failed', 'partial', 'cancelled'] } }
         ],
         responses: {
           '200': {
@@ -3301,6 +3301,87 @@ API requests are rate-limited to ensure fair usage. Rate limit headers are inclu
               }
             }
           }
+        }
+      }
+    },
+    '/automations/runs/{runId}/cancel': {
+      post: {
+        operationId: 'cancelAutomationRun',
+        tags: ['Automations'],
+        summary: 'Stop a running automation run',
+        description: 'Stops an automation run (#3525). The run moves to `cancelled` immediately — that write is the dispatch fence, so no device that has not been dispatched yet ever will be. Devices already dispatched are asked to stop and close on their own evidence, so `devicesCancelled` only counts PROVEN stops and rises after this call returns. `execute_command` and `deploy_software` actions cannot be recalled at all and are reported in `uncancellableActions` rather than claimed stopped. Config-policy runs are out of scope and return 404.',
+        parameters: [
+          { name: 'runId', in: 'path', required: true, schema: { type: 'string', format: 'uuid' } }
+        ],
+        requestBody: {
+          required: false,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  graceSeconds: {
+                    type: 'integer',
+                    minimum: 0,
+                    maximum: 30,
+                    default: 5,
+                    description: 'Seconds each device waits after SIGTERM before SIGKILL. No graceful phase on Windows.'
+                  }
+                }
+              }
+            }
+          }
+        },
+        responses: {
+          '200': {
+            description: 'Cancellation requested. The counts describe what THIS call achieved, not that every device stopped.',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    success: { type: 'boolean' },
+                    run: {
+                      type: 'object',
+                      properties: {
+                        id: { type: 'string', format: 'uuid' },
+                        status: { type: 'string', enum: ['cancelled'] }
+                      }
+                    },
+                    alreadyCancelling: { type: 'boolean', description: 'The run had already been cancelled; the devices were asked again.' },
+                    actionsCancelled: { type: 'integer', description: 'Action rows that had never been dispatched and are now terminal.' },
+                    executionsCancelled: { type: 'integer', description: 'Executions this call asked to stop or proved stopped. Excludes ones whose cancel was already in flight.' },
+                    executions: {
+                      type: 'object',
+                      description: 'Per-kind breakdown of the script-execution sweep. Exactly one bucket per execution.',
+                      properties: {
+                        requested: { type: 'integer' },
+                        retracted: { type: 'integer' },
+                        alreadyCancelling: { type: 'integer' },
+                        noActionNeeded: { type: 'integer' },
+                        failed: { type: 'integer' }
+                      }
+                    },
+                    uncancellableActions: {
+                      type: 'array',
+                      items: {
+                        type: 'object',
+                        properties: {
+                          actionIndex: { type: 'integer' },
+                          actionType: { type: 'string' },
+                          reason: { type: 'string' }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          '400': { $ref: '#/components/responses/BadRequest' },
+          '403': { description: 'Partner-wide run and the caller cannot manage partner-wide state, or the run escapes the caller\'s site allowlist' },
+          '404': { $ref: '#/components/responses/NotFound' },
+          '409': { description: 'The run already finished on its own and cannot be relabelled cancelled' }
         }
       }
     },

--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -3350,7 +3350,8 @@ API requests are rate-limited to ensure fair usage. Rate limit headers are inclu
                     },
                     alreadyCancelling: { type: 'boolean', description: 'The run had already been cancelled; the devices were asked again.' },
                     actionsCancelled: { type: 'integer', description: 'Action rows that had never been dispatched and are now terminal.' },
-                    executionsCancelled: { type: 'integer', description: 'Executions this call asked to stop or proved stopped. Excludes ones whose cancel was already in flight.' },
+                    executionsStopped: { type: 'integer', description: 'Executions PROVEN stopped: the server retracted the command before the device saw it.' },
+                    executionsRequested: { type: 'integer', description: 'Executions a stop was sent to. NOT yet stopped — the device has not confirmed and may never.' },
                     executions: {
                       type: 'object',
                       description: 'Per-kind breakdown of the script-execution sweep. Exactly one bucket per execution.',

--- a/apps/api/src/routes/automations.test.ts
+++ b/apps/api/src/routes/automations.test.ts
@@ -2065,7 +2065,8 @@ describe('automations routes — POST /runs/:runId/cancel (#3525 W05)', () => {
     kind: 'cancelled',
     alreadyCancelling: false,
     actionsCancelled: 2,
-    executionsCancelled: 3,
+    executionsStopped: 0,
+    executionsRequested: 3,
     executions: { requested: 3, retracted: 0, alreadyCancelling: 1, noActionNeeded: 0, failed: 0 },
     uncancellableActions: [
       { actionIndex: 4, actionType: 'deploy_software', reason: 'Software deployments cannot be recalled.' },
@@ -2174,7 +2175,9 @@ describe('automations routes — POST /runs/:runId/cancel (#3525 W05)', () => {
     expect(body).toMatchObject({
       success: true,
       run: { id: RUN_ID, status: 'cancelled' },
-      executionsCancelled: 3,
+      // Nothing was PROVEN stopped: three devices were merely asked.
+      executionsStopped: 0,
+      executionsRequested: 3,
       actionsCancelled: 2,
       executions: { alreadyCancelling: 1 },
       uncancellableActions: [{ actionIndex: 4, actionType: 'deploy_software' }],

--- a/apps/api/src/routes/automations.test.ts
+++ b/apps/api/src/routes/automations.test.ts
@@ -145,6 +145,17 @@ function scriptExecutionsSelectMock(rows: any[]) {
   } as any;
 }
 
+// #3525 W05 — the cancel route delegates every state decision to the service.
+const cancelAutomationRunMock = vi.hoisted(() => vi.fn());
+vi.mock('../services/automationRunCancellation', () => ({
+  cancelAutomationRun: cancelAutomationRunMock,
+}));
+// scriptCancellation reaches agentWs/commandQueue at module load; the route
+// only needs the grace bound from it.
+vi.mock('../services/scriptCancellation', () => ({
+  MAX_GRACE_SECONDS: 30,
+}));
+
 vi.mock('../services/auditEvents', () => ({
   ANONYMOUS_ACTOR_ID: '00000000-0000-0000-0000-000000000000',
   writeRouteAudit: vi.fn(),
@@ -174,7 +185,7 @@ vi.mock('../middleware/auth', () => ({
 
 import { db } from '../db';
 import { getRedis } from '../services/redis';
-import { writeAuditEvent } from '../services/auditEvents';
+import { writeAuditEvent, writeRouteAudit } from '../services/auditEvents';
 import { checkAutomationTargetsWithinSiteScope, createAutomationRunRecord } from '../services/automationRuntime';
 
 describe('automations routes', () => {
@@ -2024,5 +2035,192 @@ describe('automations routes — partner-wide dual-ownership (#2133)', () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.name).toBe('Renamed');
+  });
+});
+
+describe('automations routes — POST /runs/:runId/cancel (#3525 W05)', () => {
+  let app: Hono;
+
+  const RUN_ID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+  const AUTOMATION_ID = '11111111-1111-4111-8111-111111111111';
+
+  const orgRun = {
+    id: RUN_ID,
+    automationId: AUTOMATION_ID,
+    configPolicyId: null,
+    status: 'running',
+    triggeredBy: 'manual:user-123',
+  };
+  const orgAutomation = {
+    id: AUTOMATION_ID,
+    name: 'Nightly patch',
+    orgId: 'org-123',
+    partnerId: null,
+    conditions: null,
+    trigger: { type: 'manual' },
+  };
+  const partnerWideAutomation = { ...orgAutomation, orgId: null, partnerId: 'partner-1' };
+
+  const cancelledOutcome = {
+    kind: 'cancelled',
+    alreadyCancelling: false,
+    actionsCancelled: 2,
+    executionsCancelled: 3,
+    executions: { requested: 3, retracted: 0, alreadyCancelling: 1, noActionNeeded: 0, failed: 0 },
+    uncancellableActions: [
+      { actionIndex: 4, actionType: 'deploy_software', reason: 'Software deployments cannot be recalled.' },
+    ],
+  };
+
+  function mockSelectOnce(rows: unknown[]) {
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(rows) }),
+      }),
+    } as any);
+  }
+
+  function post(body?: unknown) {
+    return app.request(`/automations/runs/${RUN_ID}/cancel`, {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer valid-token',
+        ...(body === undefined ? {} : { 'Content-Type': 'application/json' }),
+      },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockState.permissions = undefined;
+    mockState.auth = undefined;
+    cancelAutomationRunMock.mockReset().mockResolvedValue(cancelledOutcome);
+    vi.mocked(checkAutomationTargetsWithinSiteScope).mockResolvedValue({
+      ok: true, outOfScopeDeviceIds: [], unbounded: false,
+    } as any);
+    app = new Hono();
+    app.route('/automations', automationRoutes);
+  });
+
+  it('404s an unknown run without touching the service', async () => {
+    mockSelectOnce([]);
+    const res = await post();
+    expect(res.status).toBe(404);
+    expect(cancelAutomationRunMock).not.toHaveBeenCalled();
+  });
+
+  it('404s a malformed run id', async () => {
+    const res = await app.request('/automations/runs/not-a-uuid/cancel', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer valid-token' },
+    });
+    expect(res.status).toBe(404);
+    expect(cancelAutomationRunMock).not.toHaveBeenCalled();
+  });
+
+  it('404s a config-policy run (OD10-B: out of scope, and its RLS arm hides partner-owned policies)', async () => {
+    mockSelectOnce([{ ...orgRun, automationId: null, configPolicyId: 'policy-1' }]);
+    const res = await post();
+    expect(res.status).toBe(404);
+    expect(cancelAutomationRunMock).not.toHaveBeenCalled();
+  });
+
+  it('404s (never 403) a run belonging to another tenant, to avoid an existence oracle', async () => {
+    mockSelectOnce([orgRun]);
+    mockSelectOnce([{ ...orgAutomation, orgId: 'org-other' }]);
+    const res = await post();
+    expect(res.status).toBe(404);
+    expect(cancelAutomationRunMock).not.toHaveBeenCalled();
+  });
+
+  it('403s an org-scoped operator stopping a PARTNER-WIDE run', async () => {
+    // OD7-A: they may stop individual executions on their own devices, but not
+    // a run that fans out across sibling tenants.
+    mockState.auth = {
+      user: { id: 'user-123', email: 'tech@example.com', name: 'Org Tech' },
+      scope: 'partner',
+      partnerId: 'partner-1',
+      partnerOrgAccess: 'selected',
+      orgId: null,
+      token: { sub: 'user-123' },
+      accessibleOrgIds: ['org-123'],
+      canAccessOrg: (orgId: string) => orgId === 'org-123',
+    };
+    mockSelectOnce([orgRun]);
+    mockSelectOnce([partnerWideAutomation]);
+    const res = await post();
+    expect(res.status).toBe(403);
+    expect(cancelAutomationRunMock).not.toHaveBeenCalled();
+  });
+
+  it('403s a site-restricted user whose run spans sibling sites', async () => {
+    mockSelectOnce([orgRun]);
+    mockSelectOnce([orgAutomation]);
+    vi.mocked(checkAutomationTargetsWithinSiteScope).mockResolvedValue({
+      ok: false, outOfScopeDeviceIds: ['device-9'], unbounded: false,
+    } as any);
+    const res = await post();
+    expect(res.status).toBe(403);
+    expect(cancelAutomationRunMock).not.toHaveBeenCalled();
+  });
+
+  it('cancels, audits, and reports the tally honestly', async () => {
+    mockSelectOnce([orgRun]);
+    mockSelectOnce([orgAutomation]);
+    const res = await post();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      success: true,
+      run: { id: RUN_ID, status: 'cancelled' },
+      executionsCancelled: 3,
+      actionsCancelled: 2,
+      executions: { alreadyCancelling: 1 },
+      uncancellableActions: [{ actionIndex: 4, actionType: 'deploy_software' }],
+    });
+    expect(cancelAutomationRunMock).toHaveBeenCalledWith({
+      runId: RUN_ID,
+      actorId: 'user-123',
+      actorLabel: 'test@example.com',
+      graceSeconds: undefined,
+    });
+    expect(vi.mocked(writeRouteAudit)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: 'automation.run.cancel',
+        resourceType: 'automation_run',
+        resourceId: RUN_ID,
+      }),
+    );
+  });
+
+  it('409s a run that already finished on its own rather than relabelling it', async () => {
+    mockSelectOnce([{ ...orgRun, status: 'completed' }]);
+    mockSelectOnce([orgAutomation]);
+    cancelAutomationRunMock.mockResolvedValue({ kind: 'already_terminal', status: 'completed' });
+    const res = await post();
+    expect(res.status).toBe(409);
+  });
+
+  it('404s when the run vanished between the read and the cancel', async () => {
+    mockSelectOnce([orgRun]);
+    mockSelectOnce([orgAutomation]);
+    cancelAutomationRunMock.mockResolvedValue({ kind: 'not_found' });
+    const res = await post();
+    expect(res.status).toBe(404);
+  });
+
+  it('forwards an in-range graceSeconds and rejects an out-of-range one', async () => {
+    mockSelectOnce([orgRun]);
+    mockSelectOnce([orgAutomation]);
+    expect((await post({ graceSeconds: 12 })).status).toBe(200);
+    expect(cancelAutomationRunMock).toHaveBeenCalledWith(expect.objectContaining({ graceSeconds: 12 }));
+
+    // Out of range is rejected, never silently reinterpreted as the default.
+    cancelAutomationRunMock.mockClear();
+    const res = await post({ graceSeconds: 999 });
+    expect(res.status).toBe(400);
+    expect(cancelAutomationRunMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/routes/automations.ts
+++ b/apps/api/src/routes/automations.ts
@@ -862,7 +862,8 @@ automationRoutes.post(
         // What the REQUEST achieved, never an assumed stop.
         alreadyCancelling: outcome.alreadyCancelling,
         actionsCancelled: outcome.actionsCancelled,
-        executionsCancelled: outcome.executionsCancelled,
+        executionsStopped: outcome.executionsStopped,
+        executionsRequested: outcome.executionsRequested,
         executions: outcome.executions,
         uncancellableActions: outcome.uncancellableActions,
         ...(graceSeconds === undefined ? {} : { graceSeconds }),
@@ -874,7 +875,9 @@ automationRoutes.post(
       run: { id: runId, status: 'cancelled' as const },
       alreadyCancelling: outcome.alreadyCancelling,
       actionsCancelled: outcome.actionsCancelled,
-      executionsCancelled: outcome.executionsCancelled,
+      // Two numbers, not one: `stopped` is proven, `requested` is only asked.
+      executionsStopped: outcome.executionsStopped,
+      executionsRequested: outcome.executionsRequested,
       executions: outcome.executions,
       uncancellableActions: outcome.uncancellableActions,
     });

--- a/apps/api/src/routes/automations.ts
+++ b/apps/api/src/routes/automations.ts
@@ -36,6 +36,8 @@ import {
   canManagePartnerWidePolicies,
   PARTNER_WIDE_WRITE_DENIED_MESSAGE,
 } from '../services/partnerWideAccess';
+import { cancelAutomationRun } from '../services/automationRunCancellation';
+import { MAX_GRACE_SECONDS } from '../services/scriptCancellation';
 import {
   AI_TRIAGE_SYSTEM_MANAGED_ERROR_CODE,
   MANAGED_AUTOMATION_ERROR_CODE,
@@ -747,6 +749,134 @@ automationRoutes.get(
         name: automation.name,
         orgId: automation.orgId,
       },
+    });
+  },
+);
+
+/**
+ * POST /runs/:runId/cancel — stop a running automation (#3525 W05).
+ *
+ * Same guard quartet as every other mutating automation route. This route owns
+ * ONLY authorization and the audit row; the fence, the fan-out and the
+ * honest reporting live in services/automationRunCancellation so the route, a
+ * future AI tool and any worker cannot drift.
+ */
+const cancelRunBodySchema = z.object({
+  graceSeconds: z.number().int().min(0).max(MAX_GRACE_SECONDS).optional(),
+}).optional();
+
+automationRoutes.post(
+  '/runs/:runId/cancel',
+  requireScope('organization', 'partner', 'system'),
+  requireAutomationWrite,
+  requireMfa(),
+  requireValidRunId,
+  async (c) => {
+    const auth = c.get('auth');
+    const runId = c.req.param('runId')!;
+
+    // An absent body is the normal case (the Stop button sends none), so this
+    // is hand-parsed rather than zValidator'd, which would 400 on no body at
+    // all. An out-of-range value is REJECTED rather than quietly replaced by
+    // the default: the agent is only promised 0..30s and silently turning a
+    // requested 999 into 5 would misreport what the endpoint is about to do.
+    // Mirrors POST /scripts/executions/:id/cancel exactly.
+    const rawText = await c.req.text().catch(() => '');
+    let rawBody: unknown = {};
+    if (rawText.trim() !== '') {
+      try {
+        rawBody = JSON.parse(rawText);
+      } catch {
+        return c.json({ error: 'Malformed JSON body' }, 400);
+      }
+    }
+    const parsedBody = cancelRunBodySchema.safeParse(rawBody);
+    if (!parsedBody.success) {
+      return c.json({
+        error: `graceSeconds must be an integer between 0 and ${MAX_GRACE_SECONDS}`,
+      }, 400);
+    }
+    const graceSeconds = parsedBody.data?.graceSeconds;
+
+    const [run] = await db
+      .select()
+      .from(automationRuns)
+      .where(eq(automationRuns.id, runId))
+      .limit(1);
+    if (!run) {
+      return c.json({ error: 'Automation run not found' }, 404);
+    }
+
+    // OD10-B: config-policy runs are out of scope. automation_runs' RLS admits
+    // that arm only through breeze_has_org_access(cp.org_id), so partner-owned
+    // policy runs are invisible today. 404 matches the GET above.
+    if (!run.automationId) {
+      return c.json({ error: 'Automation run not found' }, 404);
+    }
+
+    const automation = await getAutomationWithOrgCheck(run.automationId, auth);
+    if (!automation) {
+      return c.json({ error: 'Automation run not found' }, 404);
+    }
+
+    // OD7-A: an org-scoped operator may cancel individual script executions on
+    // THEIR OWN devices (those rows carry the device's org), but must not stop
+    // a run that fans out across sibling tenants.
+    if (automation.orgId === null && !canManagePartnerWidePolicies(auth)) {
+      return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
+    }
+
+    // Site scope on top: a site-restricted user must not stop a run spanning
+    // sibling sites.
+    const siteScopeDenied = await enforceAutomationSiteScope(c, automation);
+    if (siteScopeDenied) {
+      return siteScopeDenied;
+    }
+
+    const outcome = await cancelAutomationRun({
+      runId,
+      actorId: auth.user.id,
+      actorLabel: auth.user.email,
+      graceSeconds,
+    });
+
+    if (outcome.kind === 'not_found') {
+      return c.json({ error: 'Automation run not found' }, 404);
+    }
+    if (outcome.kind === 'already_terminal') {
+      // 409, matching POST /scripts/executions/:id/cancel: relabelling a run
+      // that finished on its own would be a lie.
+      return c.json({ error: `Cannot cancel a run with status: ${outcome.status}` }, 409);
+    }
+
+    writeRouteAudit(c, {
+      orgId: automation.orgId,
+      action: 'automation.run.cancel',
+      resourceType: 'automation_run',
+      resourceId: runId,
+      resourceName: automation.name,
+      details: {
+        runId,
+        automationId: run.automationId,
+        ownerScope: automation.orgId === null ? 'partner' : 'organization',
+        // What the REQUEST achieved, never an assumed stop.
+        alreadyCancelling: outcome.alreadyCancelling,
+        actionsCancelled: outcome.actionsCancelled,
+        executionsCancelled: outcome.executionsCancelled,
+        executions: outcome.executions,
+        uncancellableActions: outcome.uncancellableActions,
+        ...(graceSeconds === undefined ? {} : { graceSeconds }),
+      },
+    });
+
+    return c.json({
+      success: true,
+      run: { id: runId, status: 'cancelled' as const },
+      alreadyCancelling: outcome.alreadyCancelling,
+      actionsCancelled: outcome.actionsCancelled,
+      executionsCancelled: outcome.executionsCancelled,
+      executions: outcome.executions,
+      uncancellableActions: outcome.uncancellableActions,
     });
   },
 );

--- a/apps/api/src/routes/devices/events.ts
+++ b/apps/api/src/routes/devices/events.ts
@@ -493,6 +493,10 @@ const actionLabels: Record<string, string> = {
   'agent.command.script_cancel': 'Stop script command sent',
   'agent.command.software_uninstall': 'Software uninstall command sent',
   'agent.command.software_update': 'Software update command sent',
+  // #3525 W05 — the run-wide stop. The copy says the run was stopped, never
+  // that every device stopped: in-flight actions close on their own evidence
+  // and execute_command / deployment actions cannot be recalled at all.
+  'automation.run.cancel': 'Automation run cancelled',
   'alert.acknowledge': 'Alert acknowledged',
   'alert.resolve': 'Alert resolved',
   'alert.suppress': 'Alert suppressed',

--- a/apps/api/src/services/automationActionResults.cancellation.test.ts
+++ b/apps/api/src/services/automationActionResults.cancellation.test.ts
@@ -100,7 +100,14 @@ vi.mock('../db', () => ({
   withSystemDbAccessContext: (fn: () => unknown) => fn(),
 }));
 
-const publishEventMock = vi.hoisted(() => vi.fn(async () => undefined));
+const publishEventMock = vi.hoisted(() => vi.fn(
+  async (
+    _type: string,
+    _orgId: string,
+    _payload: Record<string, unknown>,
+    _source: string,
+  ): Promise<void> => undefined,
+));
 vi.mock('./eventBus', () => ({ publishEvent: publishEventMock }));
 
 import { __testOnly, reconcileAutomationRun } from './automationActionResults';
@@ -207,6 +214,36 @@ describe('reconciliation never re-opens a cancelled run', () => {
     expect(runPatch).toMatchObject({ devicesTargeted: 1 });
     expect(runPatch.status).toBeUndefined();
     expect(runPatch.completedAt).toBeUndefined();
+  });
+
+  it('a cancelled run whose device genuinely FAILED still publishes automation.failed', async () => {
+    // A stop must not hide a failure. There is no false-alarm cost: W03's
+    // closers stamp a PROVEN post-cancel kill as `cancelled`, never `failed`,
+    // so a device still reading `failed` here is a failure the cancellation
+    // machinery did not account for.
+    state.run.status = 'cancelled';
+    seedActions(['failed']);
+    state.deviceRows = [{ deviceId: 'device-1', status: 'failed' }];
+    await reconcileAutomationRun('run-1');
+
+    const types = publishEventMock.mock.calls.map((call) => call[0]);
+    expect(types).toContain('automation.cancelled');
+    expect(types).toContain('automation.failed');
+    // The run KEEPS its cancelled label — relabelling a deliberate stop as a
+    // failure is the other half of the dishonesty.
+    for (const call of publishEventMock.mock.calls) {
+      expect(call[2]).toMatchObject({ status: 'cancelled', devicesFailed: 1 });
+    }
+    expect(state.runUpdates.at(-1)!.status).toBeUndefined();
+  });
+
+  it('a cancelled run with no failures publishes ONLY automation.cancelled', async () => {
+    state.run.status = 'cancelled';
+    seedActions(['cancelled']);
+    state.deviceRows = [{ deviceId: 'device-1', status: 'cancelled' }];
+    await reconcileAutomationRun('run-1');
+    const types = publishEventMock.mock.calls.map((call) => call[0]);
+    expect(types).toEqual(['automation.cancelled']);
   });
 
   it('stamps completedAt exactly once on a cancelled run whose children are all terminal', async () => {

--- a/apps/api/src/services/automationActionResults.cancellation.test.ts
+++ b/apps/api/src/services/automationActionResults.cancellation.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * #3525 W05 (#4766) — cancellation-aware aggregation and reconciliation.
+ *
+ * Two contracts live here:
+ *  1. OD6-A: `cancelled` is neither a success nor a failure. Before this wave
+ *     `aggregateActionStatuses` lumped it in with failed/timed_out, which
+ *     poisons automation health reporting and any alerting keyed on
+ *     devicesFailed.
+ *  2. Reconciliation never re-opens a cancelled run, and a run that was
+ *     cancelled keeps counting its children home instead of freezing.
+ */
+
+type RunRow = {
+  id: string;
+  automationId: string | null;
+  configPolicyId: string | null;
+  configItemName: string | null;
+  triggeredBy: string;
+  status: string;
+};
+
+const state: {
+  run: RunRow;
+  actionRows: Array<Record<string, unknown>>;
+  deviceRows: Array<{ deviceId: string; status: string }>;
+  deviceUpdates: Array<Record<string, unknown>>;
+  runUpdates: Array<Record<string, unknown>>;
+  /** Whether each successive guarded run UPDATE wins its CAS. */
+  runUpdateWins: boolean[];
+} = {
+  run: {
+    id: 'run-1',
+    automationId: 'automation-1',
+    configPolicyId: null,
+    configItemName: null,
+    triggeredBy: 'manual:user-1',
+    status: 'running',
+  },
+  actionRows: [],
+  deviceRows: [],
+  deviceUpdates: [],
+  runUpdates: [],
+  runUpdateWins: [],
+};
+
+function tableName(table: unknown): string {
+  const candidate = table as Record<symbol, unknown> | null;
+  if (!candidate) return '';
+  for (const symbol of Object.getOwnPropertySymbols(candidate)) {
+    if (String(symbol).includes('Name')) return String(candidate[symbol]);
+  }
+  return '';
+}
+
+vi.mock('../db', () => ({
+  db: {
+    select: () => ({
+      from: (table: unknown) => ({
+        where: () => {
+          const name = tableName(table);
+          const rows = name === 'automation_runs'
+            ? [state.run]
+            : name === 'automation_action_results'
+              ? state.actionRows
+              : name === 'automation_run_device_results'
+                ? state.deviceRows
+                : [];
+          const promise = Promise.resolve(rows) as Promise<unknown[]> & {
+            limit?: (n: number) => { for: (mode: string) => Promise<unknown[]> };
+          };
+          promise.limit = () => ({ for: () => Promise.resolve(rows) });
+          return promise;
+        },
+      }),
+    }),
+    update: (table: unknown) => ({
+      set: (patch: Record<string, unknown>) => {
+        const name = tableName(table);
+        if (name === 'automation_run_device_results') state.deviceUpdates.push(patch);
+        if (name === 'automation_runs') state.runUpdates.push(patch);
+        return {
+          where: () => {
+            const returningRows = name === 'automation_run_device_results'
+              ? [{ id: 'device-result-1' }]
+              : (state.runUpdateWins.shift() ?? true) ? [{ id: 'run-1' }] : [];
+            const inner = Promise.resolve(returningRows) as Promise<unknown[]> & {
+              returning?: () => Promise<unknown[]>;
+            };
+            inner.returning = () => Promise.resolve(returningRows);
+            return inner;
+          },
+        };
+      },
+    }),
+  },
+  getCurrentDbAccessContext: () => ({ scope: 'system' }),
+  runOutsideDbContext: (fn: () => unknown) => fn(),
+  withSystemDbAccessContext: (fn: () => unknown) => fn(),
+}));
+
+const publishEventMock = vi.hoisted(() => vi.fn(async () => undefined));
+vi.mock('./eventBus', () => ({ publishEvent: publishEventMock }));
+
+import { __testOnly, reconcileAutomationRun } from './automationActionResults';
+
+const { aggregateActionStatuses, aggregateDeviceStatuses } = __testOnly;
+
+function seedActions(statuses: string[], deviceId = 'device-1') {
+  state.actionRows = statuses.map((status, index) => ({
+    id: `action-${index}`,
+    deviceId,
+    orgId: 'org-1',
+    actionIndex: index,
+    status,
+    message: null,
+    output: null,
+    error: null,
+    completedAt: null,
+  }));
+}
+
+beforeEach(() => {
+  publishEventMock.mockClear();
+  state.run = {
+    id: 'run-1',
+    automationId: 'automation-1',
+    configPolicyId: null,
+    configItemName: null,
+    triggeredBy: 'manual:user-1',
+    status: 'running',
+  };
+  state.actionRows = [];
+  state.deviceRows = [];
+  state.deviceUpdates = [];
+  state.runUpdates = [];
+  state.runUpdateWins = [];
+});
+
+describe('cancellation-aware aggregation (#3525 OD6-A)', () => {
+  it('a cancelled action maps the device to cancelled, not failed', () => {
+    expect(aggregateActionStatuses(['cancelled', 'succeeded'])).toEqual({ status: 'cancelled' });
+  });
+
+  it('a mix of failed and cancelled still reports failed — a real failure outranks a stop', () => {
+    expect(aggregateActionStatuses(['cancelled', 'failed'])).toEqual({ status: 'failed' });
+    expect(aggregateActionStatuses(['cancelled', 'timed_out'])).toEqual({ status: 'failed' });
+  });
+
+  it('leaves a run with no cancelled action untouched', () => {
+    expect(aggregateActionStatuses(['succeeded', 'succeeded'])).toEqual({ status: 'success' });
+    expect(aggregateActionStatuses(['skipped', 'skipped'])).toEqual({ status: 'skipped' });
+    expect(aggregateActionStatuses(['running', 'succeeded'])).toEqual({ status: 'running' });
+  });
+
+  it('a run whose devices all cancelled is cancelled, and counts in devicesCancelled', () => {
+    expect(aggregateDeviceStatuses(['cancelled', 'cancelled']))
+      .toEqual({ status: 'cancelled', devicesSucceeded: 0, devicesFailed: 0, devicesCancelled: 2 });
+  });
+
+  it('a real device failure still outranks a cancelled sibling', () => {
+    expect(aggregateDeviceStatuses(['cancelled', 'failed']))
+      .toMatchObject({ status: 'failed', devicesFailed: 1, devicesCancelled: 1 });
+  });
+
+  it('counters still sum to the number of classified devices', () => {
+    const a = aggregateDeviceStatuses(['success', 'failed', 'cancelled']);
+    expect(a.devicesSucceeded + a.devicesFailed + a.devicesCancelled).toBe(3);
+    expect(a.status).toBe('partial');
+  });
+
+  it('a still-running device keeps the run running even when a sibling cancelled', () => {
+    expect(aggregateDeviceStatuses(['cancelled', 'running']))
+      .toMatchObject({ status: 'running', devicesCancelled: 1 });
+  });
+});
+
+describe('reconciliation never re-opens a cancelled run', () => {
+  it('does not DOWNGRADE a device-level cancelled to a non-terminal status', async () => {
+    // The in-flight action has not closed yet, so the action aggregate is
+    // `running` — but the device row already proved it stopped.
+    seedActions(['cancelled', 'running']);
+    state.deviceRows = [{ deviceId: 'device-1', status: 'cancelled' }];
+    await reconcileAutomationRun('run-1');
+    expect(state.deviceUpdates.at(-1)).toMatchObject({ status: 'cancelled' });
+  });
+
+  it('publishes automation.cancelled when every child cancelled', async () => {
+    seedActions(['cancelled']);
+    state.deviceRows = [{ deviceId: 'device-1', status: 'cancelled' }];
+    await reconcileAutomationRun('run-1');
+    expect(publishEventMock).toHaveBeenCalledWith(
+      'automation.cancelled',
+      'org-1',
+      expect.objectContaining({ runId: 'run-1', status: 'cancelled', devicesCancelled: 1 }),
+      'automation-action-results',
+    );
+  });
+
+  it('keeps counting children home for a run already marked cancelled, and never restores it to running', async () => {
+    state.run.status = 'cancelled';
+    seedActions(['cancelled', 'running']);
+    state.deviceRows = [{ deviceId: 'device-1', status: 'running' }];
+    await reconcileAutomationRun('run-1');
+    const runPatch = state.runUpdates.at(-1)!;
+    expect(runPatch).toMatchObject({ devicesTargeted: 1 });
+    expect(runPatch.status).toBeUndefined();
+    expect(runPatch.completedAt).toBeUndefined();
+  });
+
+  it('stamps completedAt exactly once on a cancelled run whose children are all terminal', async () => {
+    state.run.status = 'cancelled';
+    seedActions(['cancelled']);
+    state.deviceRows = [{ deviceId: 'device-1', status: 'cancelled' }];
+    await reconcileAutomationRun('run-1');
+    expect(state.runUpdates.at(-1)).toMatchObject({ completedAt: expect.any(Date), devicesCancelled: 1 });
+    expect(publishEventMock).toHaveBeenCalledWith(
+      'automation.cancelled',
+      'org-1',
+      expect.objectContaining({ status: 'cancelled' }),
+      'automation-action-results',
+    );
+
+    // Second pass: the guarded UPDATE loses (completed_at already set), so
+    // nothing is published a second time.
+    publishEventMock.mockClear();
+    state.runUpdates = [];
+    state.runUpdateWins = [false];
+    await reconcileAutomationRun('run-1');
+    expect(publishEventMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/automationActionResults.test.ts
+++ b/apps/api/src/services/automationActionResults.test.ts
@@ -107,21 +107,25 @@ describe('automation action-result state machine', () => {
       status: 'running',
       devicesSucceeded: 1,
       devicesFailed: 1,
+      devicesCancelled: 0,
     });
     expect(__testOnly.aggregateDeviceStatuses(['skipped', 'skipped'])).toEqual({
       status: 'completed',
       devicesSucceeded: 0,
       devicesFailed: 0,
+      devicesCancelled: 0,
     });
     expect(__testOnly.aggregateDeviceStatuses(['success', 'failed', 'skipped'])).toEqual({
       status: 'partial',
       devicesSucceeded: 1,
       devicesFailed: 1,
+      devicesCancelled: 0,
     });
     expect(__testOnly.aggregateDeviceStatuses(['failed', 'skipped'])).toEqual({
       status: 'failed',
       devicesSucceeded: 0,
       devicesFailed: 1,
+      devicesCancelled: 0,
     });
   });
 

--- a/apps/api/src/services/automationActionResults.ts
+++ b/apps/api/src/services/automationActionResults.ts
@@ -371,14 +371,10 @@ async function reconcileInCurrentContext(
   // must not later find it labelled `completed`.
   const runWasCancelled = run.status === 'cancelled';
 
-  const buildPublications = (status: AutomationRunStatus): Publication[] => {
+  const publicationsOfType = (type: Publication['type'], status: AutomationRunStatus): Publication[] => {
     const orgIds = [...new Set(actionRows.map((row) => row.orgId))];
     return orgIds.map((orgId) => ({
-      type: status === 'completed'
-        ? 'automation.completed'
-        : status === 'cancelled'
-          ? 'automation.cancelled'
-          : 'automation.failed',
+      type,
       orgId,
       payload: {
         ...(run.automationId ? { automationId: run.automationId } : {
@@ -392,6 +388,15 @@ async function reconcileInCurrentContext(
       },
     }));
   };
+
+  const buildPublications = (status: AutomationRunStatus): Publication[] => publicationsOfType(
+    status === 'completed'
+      ? 'automation.completed'
+      : status === 'cancelled'
+        ? 'automation.cancelled'
+        : 'automation.failed',
+    status,
+  );
 
   if (aggregate.status === 'running') {
     if (runWasCancelled) {
@@ -421,7 +426,21 @@ async function reconcileInCurrentContext(
         .where(and(eq(automationRuns.id, runId), eq(automationRuns.status, 'cancelled')));
       return [];
     }
-    return buildPublications('cancelled');
+    // The run KEEPS the `cancelled` label: a deliberate human stop is the most
+    // specific explanation of why it ended, and relabelling it `failed` would
+    // page an MSP for every cancel whose SIGKILL produced a nonzero exit.
+    //
+    // But a stop must not HIDE a failure either, so when devices failed we
+    // publish `automation.failed` alongside. There is no false-alarm cost:
+    // W03's closers stamp a PROVEN post-cancel kill as `cancelled`, never
+    // `failed`, so a device still reading `failed` on a cancelled run is a
+    // failure the cancellation machinery did not account for — exactly what
+    // failure alerting exists for. Both events ride the same
+    // `completed_at IS NULL` transition, so each fires exactly once.
+    return [
+      ...publicationsOfType('automation.cancelled', 'cancelled'),
+      ...(aggregate.devicesFailed > 0 ? publicationsOfType('automation.failed', 'cancelled') : []),
+    ];
   }
 
   const isRepairingPriorTerminal = priorAggregate?.status === run.status;

--- a/apps/api/src/services/automationActionResults.ts
+++ b/apps/api/src/services/automationActionResults.ts
@@ -20,6 +20,23 @@ export type AutomationActionTerminalSource =
   | 'command' | 'script_execution' | 'deployment_result'
   | 'timeout' | 'cancellation' | 'reaper' | 'dispatch';
 
+/**
+ * One value of `automation_device_result_status` (#3525 W05 added `cancelled`).
+ * Named rather than inlined so the aggregation functions and the device-row
+ * writer cannot drift apart when the enum grows again.
+ */
+export type AutomationDeviceResultStatus =
+  | 'pending' | 'running' | 'success' | 'failed' | 'skipped' | 'cancelled';
+
+/** One value of `automation_run_status` (#3525 W05 added `cancelled`). */
+export type AutomationRunStatus =
+  | 'running' | 'completed' | 'failed' | 'partial' | 'cancelled';
+
+/** Device-result statuses that mean the device is done, whatever the outcome. */
+const TERMINAL_DEVICE_STATUSES = new Set<AutomationDeviceResultStatus>([
+  'success', 'failed', 'skipped', 'cancelled',
+]);
+
 type Correlations = {
   commandId?: string;
   scriptExecutionId?: string;
@@ -131,31 +148,42 @@ function decideTerminalTransition(
 }
 
 function aggregateActionStatuses(statuses: AutomationActionResultStatus[]): {
-  status: 'pending' | 'running' | 'success' | 'failed' | 'skipped';
+  status: AutomationDeviceResultStatus;
 } {
   if (statuses.some((status) => !TERMINAL.has(status))) {
     return { status: statuses.every((status) => status === 'pending') ? 'pending' : 'running' };
   }
-  if (statuses.some((status) => status === 'failed' || status === 'timed_out' || status === 'cancelled')) {
+  // OD6-A: a REAL failure outranks a stop, so the failed lane is tested first
+  // and `cancelled` gets its own lane after it. Before #3525 W05 `cancelled`
+  // was folded into this predicate, which reported every stopped device as a
+  // failure and poisoned automation health and any devicesFailed alerting.
+  if (statuses.some((status) => status === 'failed' || status === 'timed_out')) {
     return { status: 'failed' };
   }
+  if (statuses.some((status) => status === 'cancelled')) return { status: 'cancelled' };
   if (statuses.every((status) => status === 'skipped')) return { status: 'skipped' };
   return { status: 'success' };
 }
 
-function aggregateDeviceStatuses(statuses: Array<'pending' | 'running' | 'success' | 'failed' | 'skipped'>): {
-  status: 'running' | 'completed' | 'failed' | 'partial';
+function aggregateDeviceStatuses(statuses: AutomationDeviceResultStatus[]): {
+  status: AutomationRunStatus;
   devicesSucceeded: number;
   devicesFailed: number;
+  devicesCancelled: number;
 } {
   const devicesSucceeded = statuses.filter((status) => status === 'success').length;
   const devicesFailed = statuses.filter((status) => status === 'failed').length;
+  const devicesCancelled = statuses.filter((status) => status === 'cancelled').length;
+  const counts = { devicesSucceeded, devicesFailed, devicesCancelled };
   if (statuses.some((status) => status === 'pending' || status === 'running')) {
-    return { status: 'running', devicesSucceeded, devicesFailed };
+    return { status: 'running', ...counts };
   }
-  if (devicesFailed === 0) return { status: 'completed', devicesSucceeded, devicesFailed };
-  if (devicesSucceeded === 0) return { status: 'failed', devicesSucceeded, devicesFailed };
-  return { status: 'partial', devicesSucceeded, devicesFailed };
+  // A run is `cancelled` only when nothing actually failed. One real failure
+  // and the run reports that failure — a stop never hides it.
+  if (devicesFailed === 0 && devicesCancelled > 0) return { status: 'cancelled', ...counts };
+  if (devicesFailed === 0) return { status: 'completed', ...counts };
+  if (devicesSucceeded === 0) return { status: 'failed', ...counts };
+  return { status: 'partial', ...counts };
 }
 
 function aggregateActionDetails(actions: Array<{
@@ -210,7 +238,7 @@ function stateCas(row: ActionState & { id: string }): SQL[] {
 }
 
 type Publication = {
-  type: 'automation.completed' | 'automation.failed';
+  type: 'automation.completed' | 'automation.failed' | 'automation.cancelled';
   orgId: string;
   payload: Record<string, unknown>;
 };
@@ -263,10 +291,30 @@ async function reconcileInCurrentContext(
     group.push(row);
     byDevice.set(row.deviceId, group);
   }
+
+  // #3525 W05 — the device rewrite below is unconditional, so a device that
+  // already proved it STOPPED must not be walked back to pending/running just
+  // because a sibling action of the same device is still in flight. Read the
+  // current statuses once (the run row is held FOR UPDATE above, so nothing
+  // else is rewriting them) and clamp.
+  const currentDeviceStatuses = new Map(
+    (await db.select({
+      deviceId: automationRunDeviceResults.deviceId,
+      status: automationRunDeviceResults.status,
+    })
+      .from(automationRunDeviceResults)
+      .where(eq(automationRunDeviceResults.runId, runId)))
+      .map((row) => [row.deviceId, row.status] as const),
+  );
+
   for (const [deviceId, actions] of byDevice) {
-    const aggregate = aggregateActionStatuses(actions.map((action) => action.status));
+    const derived = aggregateActionStatuses(actions.map((action) => action.status));
+    const aggregate = currentDeviceStatuses.get(deviceId) === 'cancelled'
+      && !TERMINAL_DEVICE_STATUSES.has(derived.status)
+      ? { status: 'cancelled' as const }
+      : derived;
     const details = aggregateActionDetails(actions);
-    const terminal = aggregate.status === 'success' || aggregate.status === 'failed' || aggregate.status === 'skipped';
+    const terminal = TERMINAL_DEVICE_STATUSES.has(aggregate.status);
     const completedAt = terminal
       ? new Date(Math.max(...actions.map((action) => action.completedAt?.getTime() ?? 0), Date.now()))
       : null;
@@ -312,11 +360,68 @@ async function reconcileInCurrentContext(
     devicesTargeted: deviceRows.length,
     devicesSucceeded: aggregate.devicesSucceeded,
     devicesFailed: aggregate.devicesFailed,
+    devicesCancelled: aggregate.devicesCancelled,
   };
+
+  // #3525 W05 — `cancelled` is stamped on the run by the CANCEL REQUEST (that
+  // write is the dispatch fence), long before its children close. So a
+  // cancelled run is NOT "already terminal, stop reconciling": it keeps
+  // counting children home, and only its completed_at marks the end. It is
+  // also never transitioned to anything else — an operator who stopped a run
+  // must not later find it labelled `completed`.
+  const runWasCancelled = run.status === 'cancelled';
+
+  const buildPublications = (status: AutomationRunStatus): Publication[] => {
+    const orgIds = [...new Set(actionRows.map((row) => row.orgId))];
+    return orgIds.map((orgId) => ({
+      type: status === 'completed'
+        ? 'automation.completed'
+        : status === 'cancelled'
+          ? 'automation.cancelled'
+          : 'automation.failed',
+      orgId,
+      payload: {
+        ...(run.automationId ? { automationId: run.automationId } : {
+          configPolicyAutomationId: run.configPolicyId,
+          configItemName: run.configItemName,
+        }),
+        runId,
+        triggeredBy: run.triggeredBy,
+        status,
+        ...common,
+      },
+    }));
+  };
+
   if (aggregate.status === 'running') {
+    if (runWasCancelled) {
+      await db.update(automationRuns).set(common)
+        .where(and(eq(automationRuns.id, runId), eq(automationRuns.status, 'cancelled')));
+      return [];
+    }
     await db.update(automationRuns).set({ ...common, completedAt: null })
       .where(and(eq(automationRuns.id, runId), eq(automationRuns.status, 'running')));
     return [];
+  }
+
+  if (runWasCancelled) {
+    // Every child is terminal now, so the cancelled run is finished. The
+    // completed_at IS NULL guard is the transition: exactly one reconcile wins
+    // it, so `automation.cancelled` is published exactly once.
+    const finished = await db.update(automationRuns)
+      .set({ ...common, completedAt: new Date() })
+      .where(and(
+        eq(automationRuns.id, runId),
+        eq(automationRuns.status, 'cancelled'),
+        isNull(automationRuns.completedAt),
+      ))
+      .returning({ id: automationRuns.id });
+    if (finished.length === 0) {
+      await db.update(automationRuns).set(common)
+        .where(and(eq(automationRuns.id, runId), eq(automationRuns.status, 'cancelled')));
+      return [];
+    }
+    return buildPublications('cancelled');
   }
 
   const isRepairingPriorTerminal = priorAggregate?.status === run.status;
@@ -330,21 +435,7 @@ async function reconcileInCurrentContext(
     .returning({ id: automationRuns.id });
   if (transitioned.length === 0 || !statusChanged) return [];
 
-  const orgIds = [...new Set(actionRows.map((row) => row.orgId))];
-  return orgIds.map((orgId) => ({
-    type: aggregate.status === 'completed' ? 'automation.completed' : 'automation.failed',
-    orgId,
-    payload: {
-      ...(run.automationId ? { automationId: run.automationId } : {
-        configPolicyAutomationId: run.configPolicyId,
-        configItemName: run.configItemName,
-      }),
-      runId,
-      triggeredBy: run.triggeredBy,
-      status: aggregate.status,
-      ...common,
-    },
-  }));
+  return buildPublications(aggregate.status);
 }
 
 export async function seedAutomationActionResults(input: {

--- a/apps/api/src/services/automationRunCancellation.test.ts
+++ b/apps/api/src/services/automationRunCancellation.test.ts
@@ -27,6 +27,8 @@ const state: {
   actionUpdateWheres: unknown[];
   actionSelectWheres: unknown[];
   cancelledActionIds: string[];
+  /** Run UPDATEs issued OUTSIDE the fence transaction. */
+  tailRunUpdates: Array<{ patch: Record<string, unknown>; where: unknown }>;
 } = {
   run: null,
   actionRows: [],
@@ -37,6 +39,7 @@ const state: {
   actionUpdateWheres: [],
   actionSelectWheres: [],
   cancelledActionIds: [],
+  tailRunUpdates: [],
 };
 
 function tableName(table: unknown): string {
@@ -97,6 +100,18 @@ function makeTx() {
 vi.mock('../db', () => ({
   db: {
     transaction: (fn: (tx: unknown) => Promise<unknown>) => fn(makeTx()),
+    // The tail "finish a run that never seeded an action row" stamp runs
+    // outside the fence transaction, on the module db.
+    update: (table: unknown) => ({
+      set: (patch: Record<string, unknown>) => ({
+        where: (where: unknown) => {
+          if (tableName(table) === 'automation_runs') {
+            state.tailRunUpdates.push({ patch, where });
+          }
+          return Promise.resolve([]);
+        },
+      }),
+    }),
     select: () => ({
       from: (table: unknown) => ({
         where: (where: unknown) => {
@@ -156,6 +171,7 @@ beforeEach(() => {
   state.actionUpdateWheres = [];
   state.actionSelectWheres = [];
   state.cancelledActionIds = [];
+  state.tailRunUpdates = [];
   cancelExecutionsForRunMock.mockClear();
   reconcileAutomationRunMock.mockReset().mockResolvedValue(undefined);
   cancelExecutionsForRunMock.mockResolvedValue({
@@ -241,16 +257,22 @@ describe('cancelAutomationRun', () => {
     expect(Object.keys(call)).not.toContain('orgId');
   });
 
-  it('counts requested and retracted executions, not the ones already in flight', async () => {
+  it('reports PROVEN stops separately from mere requests', async () => {
+    // Folding these together is how a "cancel this run" summary ends up
+    // claiming five scripts stopped when only two provably did.
     cancelExecutionsForRunMock.mockResolvedValue({
       requested: 3, retracted: 2, alreadyCancelling: 4, noActionNeeded: 1, failed: 1,
     });
     const out = await cancelAutomationRun({ runId: 'run-1', ...actor });
     expect(out).toMatchObject({
       kind: 'cancelled',
-      executionsCancelled: 5,
-      executions: { requested: 3, retracted: 2, alreadyCancelling: 4 },
+      executionsStopped: 2,
+      executionsRequested: 3,
+      executions: { requested: 3, retracted: 2, alreadyCancelling: 4, failed: 1 },
     });
+    // alreadyCancelling is in neither headline number: those were asked by an
+    // earlier call and have not stopped.
+    expect(out).not.toMatchObject({ executionsStopped: 6 });
   });
 
   it('reports in-flight execute_command and deployment actions as uncancellable', async () => {
@@ -290,6 +312,15 @@ describe('cancelAutomationRun', () => {
     // The fence write and the fan-out both happened before reconcile.
     expect(state.runUpdatePatches.at(0)).toMatchObject({ status: 'cancelled' });
     expect(cancelExecutionsForRunMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('finishes a run that never seeded an action row, which reconciliation cannot see', async () => {
+    await cancelAutomationRun({ runId: 'run-1', ...actor });
+    const tail = state.tailRunUpdates.at(-1)!;
+    expect(tail.patch).toEqual({ completedAt: expect.any(Date) });
+    // Guarded so it only ever fires for a run with no action rows at all.
+    expect(renderSql(tail.where)).toContain('NOT EXISTS');
+    expect(renderSql(tail.where).toLowerCase()).toContain('completed_at" is null');
   });
 
   it('is idempotent: a second cancel re-asks the devices but does not rewrite the run', async () => {

--- a/apps/api/src/services/automationRunCancellation.test.ts
+++ b/apps/api/src/services/automationRunCancellation.test.ts
@@ -136,6 +136,8 @@ vi.mock('./automationActionResults', () => ({
   reconcileAutomationRun: reconcileAutomationRunMock,
 }));
 
+vi.mock('./sentry', () => ({ captureException: vi.fn() }));
+
 import {
   assertRunNotCancelled,
   cancelAutomationRun,
@@ -155,7 +157,7 @@ beforeEach(() => {
   state.actionSelectWheres = [];
   state.cancelledActionIds = [];
   cancelExecutionsForRunMock.mockClear();
-  reconcileAutomationRunMock.mockClear();
+  reconcileAutomationRunMock.mockReset().mockResolvedValue(undefined);
   cancelExecutionsForRunMock.mockResolvedValue({
     requested: 0, retracted: 0, alreadyCancelling: 0, noActionNeeded: 0, failed: 0,
   });
@@ -279,6 +281,15 @@ describe('cancelAutomationRun', () => {
     reconcileAutomationRunMock.mockImplementation(async () => { order.push('reconcile'); });
     await cancelAutomationRun({ runId: 'run-1', ...actor });
     expect(order).toEqual(['fanout', 'reconcile']);
+  });
+
+  it('still reports success when the follow-up reconcile throws — the stop is already committed', async () => {
+    reconcileAutomationRunMock.mockRejectedValue(new Error('Redis down'));
+    await expect(cancelAutomationRun({ runId: 'run-1', ...actor }))
+      .resolves.toMatchObject({ kind: 'cancelled' });
+    // The fence write and the fan-out both happened before reconcile.
+    expect(state.runUpdatePatches.at(0)).toMatchObject({ status: 'cancelled' });
+    expect(cancelExecutionsForRunMock).toHaveBeenCalledTimes(1);
   });
 
   it('is idempotent: a second cancel re-asks the devices but does not rewrite the run', async () => {

--- a/apps/api/src/services/automationRunCancellation.test.ts
+++ b/apps/api/src/services/automationRunCancellation.test.ts
@@ -1,0 +1,292 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import type { SQL } from 'drizzle-orm';
+
+/**
+ * #3525 W05 (#4766) — the automation-run dispatch fence and fan-out.
+ *
+ * The fence is what stops a queued BullMQ job for an already-cancelled run
+ * from dispatching anything: today neither runner checks run status before
+ * seeding or dispatching, so a job picked up after a cancel runs to completion.
+ */
+
+const dialect = new PgDialect();
+const renderSql = (clause: unknown) => dialect.sqlToQuery(clause as SQL).sql;
+const sqlParams = (clause: unknown) => dialect.sqlToQuery(clause as SQL).params;
+
+type ActionRow = { id: string; actionIndex: number; actionType: string; status: string };
+
+const state: {
+  run: { id: string; status: string } | null;
+  actionRows: ActionRow[];
+  /** Every `SELECT ... FOR SHARE` issued through the fence, as rendered SQL. */
+  fenceQueries: Array<{ sql: string; params: unknown[] }>;
+  runUpdatePatches: Array<Record<string, unknown>>;
+  runUpdateWheres: unknown[];
+  actionUpdatePatches: Array<Record<string, unknown>>;
+  actionUpdateWheres: unknown[];
+  actionSelectWheres: unknown[];
+  cancelledActionIds: string[];
+} = {
+  run: null,
+  actionRows: [],
+  fenceQueries: [],
+  runUpdatePatches: [],
+  runUpdateWheres: [],
+  actionUpdatePatches: [],
+  actionUpdateWheres: [],
+  actionSelectWheres: [],
+  cancelledActionIds: [],
+};
+
+function tableName(table: unknown): string {
+  const candidate = table as Record<symbol, unknown> | null;
+  if (!candidate) return '';
+  for (const symbol of Object.getOwnPropertySymbols(candidate)) {
+    if (String(symbol).includes('Name')) return String(candidate[symbol]);
+  }
+  return '';
+}
+
+function makeTx() {
+  return {
+    execute: (query: SQL) => {
+      state.fenceQueries.push({ sql: renderSql(query), params: sqlParams(query) });
+      return Promise.resolve(state.run ? [{ status: state.run.status }] : []);
+    },
+    select: () => ({
+      from: (table: unknown) => ({
+        where: () => ({
+          limit: () => ({
+            for: () => Promise.resolve(
+              tableName(table) === 'automation_runs' && state.run ? [state.run] : [],
+            ),
+          }),
+        }),
+      }),
+    }),
+    update: (table: unknown) => ({
+      set: (patch: Record<string, unknown>) => ({
+        where: (where: unknown) => {
+          const name = tableName(table);
+          if (name === 'automation_runs') {
+            state.runUpdatePatches.push(patch);
+            state.runUpdateWheres.push(where);
+          }
+          if (name === 'automation_action_results') {
+            state.actionUpdatePatches.push(patch);
+            state.actionUpdateWheres.push(where);
+          }
+          const rows = name === 'automation_action_results'
+            ? state.actionRows.filter((row) => row.status === 'pending').map((row) => ({ id: row.id }))
+            : [{ id: 'run-1' }];
+          if (name === 'automation_action_results') {
+            state.cancelledActionIds.push(...rows.map((row) => row.id));
+          }
+          const inner = Promise.resolve(rows) as Promise<unknown[]> & {
+            returning?: () => Promise<unknown[]>;
+          };
+          inner.returning = () => Promise.resolve(rows);
+          return inner;
+        },
+      }),
+    }),
+  };
+}
+
+vi.mock('../db', () => ({
+  db: {
+    transaction: (fn: (tx: unknown) => Promise<unknown>) => fn(makeTx()),
+    select: () => ({
+      from: (table: unknown) => ({
+        where: (where: unknown) => {
+          if (tableName(table) === 'automation_action_results') {
+            state.actionSelectWheres.push(where);
+            const terminal = new Set(['succeeded', 'failed', 'skipped', 'timed_out', 'cancelled']);
+            return Promise.resolve(
+              state.actionRows
+                .filter((row) => !terminal.has(row.status)
+                  && (row.actionType === 'execute_command' || row.actionType === 'deploy_software'))
+                .map((row) => ({ actionIndex: row.actionIndex, actionType: row.actionType })),
+            );
+          }
+          return Promise.resolve([]);
+        },
+      }),
+    }),
+  },
+  getCurrentDbAccessContext: () => ({ scope: 'system' }),
+  runOutsideDbContext: (fn: () => unknown) => fn(),
+  withSystemDbAccessContext: (fn: () => unknown) => fn(),
+}));
+
+const cancelExecutionsForRunMock = vi.hoisted(() => vi.fn(async () => ({
+  requested: 0,
+  retracted: 0,
+  alreadyCancelling: 0,
+  noActionNeeded: 0,
+  failed: 0,
+})));
+vi.mock('./scriptCancellation', () => ({
+  cancelExecutionsForRun: cancelExecutionsForRunMock,
+}));
+
+const reconcileAutomationRunMock = vi.hoisted(() => vi.fn(async () => undefined));
+vi.mock('./automationActionResults', () => ({
+  reconcileAutomationRun: reconcileAutomationRunMock,
+}));
+
+import {
+  assertRunNotCancelled,
+  cancelAutomationRun,
+  RunCancelledError,
+} from './automationRunCancellation';
+
+const actor = { actorId: 'user-1', actorLabel: 'tech@example.com' };
+
+beforeEach(() => {
+  state.run = { id: 'run-1', status: 'running' };
+  state.actionRows = [];
+  state.fenceQueries = [];
+  state.runUpdatePatches = [];
+  state.runUpdateWheres = [];
+  state.actionUpdatePatches = [];
+  state.actionUpdateWheres = [];
+  state.actionSelectWheres = [];
+  state.cancelledActionIds = [];
+  cancelExecutionsForRunMock.mockClear();
+  reconcileAutomationRunMock.mockClear();
+  cancelExecutionsForRunMock.mockResolvedValue({
+    requested: 0, retracted: 0, alreadyCancelling: 0, noActionNeeded: 0, failed: 0,
+  });
+});
+
+describe('dispatch fence', () => {
+  it('assertRunNotCancelled takes FOR SHARE on the run row inside the caller tx', async () => {
+    const tx = makeTx();
+    await assertRunNotCancelled(tx, 'run-1');
+    const fence = state.fenceQueries.at(-1)!;
+    expect(fence.sql.toLowerCase()).toContain('for share');
+    expect(fence.sql.toLowerCase()).toContain('automation_runs');
+    // Keyed on the run id, bound rather than interpolated.
+    expect(fence.params).toContain('run-1');
+  });
+
+  it('throws RunCancelledError once the run is cancelled', async () => {
+    state.run = { id: 'run-1', status: 'cancelled' };
+    await expect(assertRunNotCancelled(makeTx(), 'run-1')).rejects.toBeInstanceOf(RunCancelledError);
+  });
+
+  it('is a no-op for a running run and for a run that no longer exists', async () => {
+    await expect(assertRunNotCancelled(makeTx(), 'run-1')).resolves.toBeUndefined();
+    state.run = null;
+    await expect(assertRunNotCancelled(makeTx(), 'run-1')).resolves.toBeUndefined();
+  });
+});
+
+describe('cancelAutomationRun', () => {
+  it('reports a missing run rather than inventing one', async () => {
+    state.run = null;
+    await expect(cancelAutomationRun({ runId: 'run-1', ...actor }))
+      .resolves.toMatchObject({ kind: 'not_found' });
+    expect(cancelExecutionsForRunMock).not.toHaveBeenCalled();
+  });
+
+  it.each(['completed', 'failed', 'partial'] as const)(
+    'refuses to relabel an already-%s run as cancelled',
+    async (status) => {
+      state.run = { id: 'run-1', status };
+      await expect(cancelAutomationRun({ runId: 'run-1', ...actor }))
+        .resolves.toMatchObject({ kind: 'already_terminal', status });
+      expect(state.runUpdatePatches).toHaveLength(0);
+      expect(cancelExecutionsForRunMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it('sets the run cancelled and appends the log entry atomically with jsonb ||', async () => {
+    await cancelAutomationRun({ runId: 'run-1', ...actor });
+    const patch = state.runUpdatePatches.at(0)!;
+    expect(patch.status).toBe('cancelled');
+    // Both runners write the whole stale logs array, so a plain set({ logs })
+    // would be erased by a concurrent completion.
+    expect(renderSql(patch.logs)).toContain('||');
+    expect(JSON.stringify(sqlParams(patch.logs))).toContain('tech@example.com');
+  });
+
+  it('marks NEVER-DISPATCHED actions cancelled but leaves in-flight ones alone', async () => {
+    state.actionRows = [
+      { id: 'a-0', actionIndex: 0, actionType: 'run_script', status: 'running' },
+      { id: 'a-1', actionIndex: 1, actionType: 'run_script', status: 'pending' },
+    ];
+    const out = await cancelAutomationRun({ runId: 'run-1', ...actor });
+    expect(out).toMatchObject({ kind: 'cancelled', actionsCancelled: 1 });
+    expect(state.cancelledActionIds).toEqual(['a-1']);
+    const patch = state.actionUpdatePatches.at(0)!;
+    expect(patch).toMatchObject({ status: 'cancelled', terminalSource: 'cancellation' });
+    // The predicate, not the mock, is what keeps a running action out of it.
+    expect(sqlParams(state.actionUpdateWheres.at(0))).toContain('pending');
+  });
+
+  it('fans out keyed on the run id ONLY, never on the caller org', async () => {
+    await cancelAutomationRun({ runId: 'run-1', ...actor, graceSeconds: 10 });
+    expect(cancelExecutionsForRunMock).toHaveBeenCalledWith({
+      runId: 'run-1',
+      actorId: 'user-1',
+      actorLabel: 'tech@example.com',
+      graceSeconds: 10,
+    });
+    const [[call]] = cancelExecutionsForRunMock.mock.calls as unknown as [[Record<string, unknown>]];
+    expect(Object.keys(call)).not.toContain('orgId');
+  });
+
+  it('counts requested and retracted executions, not the ones already in flight', async () => {
+    cancelExecutionsForRunMock.mockResolvedValue({
+      requested: 3, retracted: 2, alreadyCancelling: 4, noActionNeeded: 1, failed: 1,
+    });
+    const out = await cancelAutomationRun({ runId: 'run-1', ...actor });
+    expect(out).toMatchObject({
+      kind: 'cancelled',
+      executionsCancelled: 5,
+      executions: { requested: 3, retracted: 2, alreadyCancelling: 4 },
+    });
+  });
+
+  it('reports in-flight execute_command and deployment actions as uncancellable', async () => {
+    // execute_command deliberately creates NO script_executions row and
+    // deployments live in deployment_results, so the UI must not claim the run
+    // stopped while one of these is still live.
+    state.actionRows = [
+      { id: 'a-0', actionIndex: 0, actionType: 'execute_command', status: 'running' },
+      { id: 'a-1', actionIndex: 1, actionType: 'deploy_software', status: 'delivered' },
+      { id: 'a-2', actionIndex: 2, actionType: 'run_script', status: 'running' },
+    ];
+    const out = await cancelAutomationRun({ runId: 'run-1', ...actor });
+    expect(out).toMatchObject({ kind: 'cancelled' });
+    const uncancellable = (out as { uncancellableActions: Array<{ actionType: string; reason: string }> })
+      .uncancellableActions;
+    expect(uncancellable).toHaveLength(2);
+    expect(uncancellable.map((entry) => entry.actionType).sort())
+      .toEqual(['deploy_software', 'execute_command']);
+    expect(uncancellable.every((entry) => entry.reason.length > 0)).toBe(true);
+  });
+
+  it('rolls the newly cancelled rows up AFTER the fan-out, so devices_cancelled is real', async () => {
+    const order: string[] = [];
+    cancelExecutionsForRunMock.mockImplementation(async () => {
+      order.push('fanout');
+      return { requested: 0, retracted: 0, alreadyCancelling: 0, noActionNeeded: 0, failed: 0 };
+    });
+    reconcileAutomationRunMock.mockImplementation(async () => { order.push('reconcile'); });
+    await cancelAutomationRun({ runId: 'run-1', ...actor });
+    expect(order).toEqual(['fanout', 'reconcile']);
+  });
+
+  it('is idempotent: a second cancel re-asks the devices but does not rewrite the run', async () => {
+    state.run = { id: 'run-1', status: 'cancelled' };
+    const out = await cancelAutomationRun({ runId: 'run-1', ...actor });
+    expect(out).toMatchObject({ kind: 'cancelled', alreadyCancelling: true, actionsCancelled: 0 });
+    expect(state.runUpdatePatches).toHaveLength(0);
+    expect(state.actionUpdatePatches).toHaveLength(0);
+    expect(cancelExecutionsForRunMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/services/automationRunCancellation.ts
+++ b/apps/api/src/services/automationRunCancellation.ts
@@ -7,6 +7,7 @@ import {
 } from '../db';
 import { automationActionResults, automationRuns } from '../db/schema';
 import { reconcileAutomationRun } from './automationActionResults';
+import { captureException } from './sentry';
 import type { RunCancelTally } from './scriptCancellation';
 
 // `scriptCancellation` reaches agentWs → commandQueue → configurationPolicy at
@@ -274,7 +275,22 @@ export async function cancelAutomationRun(input: {
   // Without this a run whose every action was still `pending` would sit at
   // devices_cancelled 0 and its device rows at `pending` until some unrelated
   // result happened to arrive.
-  await reconcileAutomationRun(runId);
+  //
+  // Best-effort ON PURPOSE. Everything that makes the stop real — the fence
+  // write, the terminalised action rows, the queued script_cancel commands —
+  // is already committed by here. Rethrowing would turn a cancel that
+  // SUCCEEDED into a 500, telling the operator their stop failed and inviting
+  // a retry, when all that actually failed is the roll-up of the counters.
+  // Reconciliation is idempotent and re-runs on the next child result.
+  try {
+    await reconcileAutomationRun(runId);
+  } catch (err) {
+    console.error('[automationRunCancellation] reconcile after cancel failed; the cancel itself is committed', {
+      runId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    captureException(err, undefined, { runId });
+  }
 
   return {
     kind: 'cancelled',

--- a/apps/api/src/services/automationRunCancellation.ts
+++ b/apps/api/src/services/automationRunCancellation.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, notInArray, sql, type SQL } from 'drizzle-orm';
+import { and, eq, inArray, isNull, notInArray, sql, type SQL } from 'drizzle-orm';
 import {
   db,
   getCurrentDbAccessContext,
@@ -27,24 +27,41 @@ const loadRunSweep = () => import('./scriptCancellation');
  *
  * ## The fence, and what it actually guarantees
  *
+ * Read this before touching either half — the two halves look redundant and
+ * are not.
+ *
  * `cancelAutomationRun` marks the run `cancelled` while holding `FOR UPDATE`
- * on its row. Every dispatch-side entry point calls `assertRunNotCancelled`,
- * which reads that row `FOR SHARE`, so:
+ * on its row, then sweeps the run's executions AFTER that transaction commits.
+ * Every dispatch-side entry point calls `assertRunNotCancelled` first, which
+ * reads the same row `FOR SHARE`.
  *
- *  - a dispatcher that acquires `FOR SHARE` first blocks the cancel until it
- *    commits, which means whatever it created is visible to the fan-out below;
- *  - a dispatcher that arrives after the cancel committed sees `cancelled` and
- *    throws `RunCancelledError` before dispatching anything.
+ * **CHECK-BEFORE is not the guarantee.** In production the runtime calls it
+ * with the pooled `db`, so the `FOR SHARE` lock is taken and released by that
+ * single statement, long before the dispatch it guards (an execution insert,
+ * an encrypt, a WebSocket send) even begins. It cannot be held across the
+ * dispatch: that would pin a pooled connection across a network round trip for
+ * five concurrent devices at a time — the double-hold CLAUDE.md calls out, and
+ * a self-deadlock once the pool is exhausted, since `dispatchScriptToDevice`
+ * opens connections of its own. So treat check-before as what it is: a cheap
+ * early exit that stops the common case (a queued job for a run cancelled
+ * minutes ago) from doing any work at all.
  *
- * The lock is deliberately NOT held across the dispatch itself. Doing that
- * would pin a pooled connection across a device command insert and a WebSocket
- * send for five concurrent devices at a time — the double-hold that CLAUDE.md
- * calls out, and a self-deadlock once the pool is exhausted. The residual
- * window (an execution row committed microseconds after the fan-out's read) is
- * closed on the dispatch side instead: `automationRuntime` re-checks the run
- * after recording a dispatch and cancels the execution it just created. So an
- * execution belonging to a cancelled run is either caught by the sweep here or
- * cancelled by its own dispatcher — never left running.
+ * **CHECK-AFTER is the guarantee.** `automationRuntime`'s
+ * `cancelDispatchIfRunCancelled` re-reads the run once the dispatch has
+ * committed and stops the execution itself if the run went `cancelled`
+ * meanwhile. Postgres gives the needed ordering for free without any lock:
+ * whichever of {the cancel's post-commit sweep, this dispatcher's re-read}
+ * runs second sees the other's committed write. So every script execution of a
+ * cancelled run is either found by the sweep or stopped by its own dispatcher.
+ *
+ * **DO NOT delete `cancelDispatchIfRunCancelled` on the belief that the row
+ * lock already covers it.** It does not, and removing it reopens the race.
+ *
+ * Scope of the guarantee: SCRIPT EXECUTIONS only. `execute_command` and
+ * `deploy_software` actions have no agent-side stop at all — they genuinely do
+ * run to completion after a cancel, and are reported to the operator through
+ * `uncancellableActions` rather than claimed stopped (see
+ * `UNCANCELLABLE_ACTION_REASONS` below).
  */
 
 /** Thrown by `assertRunNotCancelled`; callers treat it as "stop, quietly". */
@@ -127,10 +144,15 @@ export type CancelAutomationRunOutcome =
       alreadyCancelling: boolean;
       /** Action rows that had not been dispatched and are now terminal. */
       actionsCancelled: number;
-      /** Executions this call asked to stop (`requested`) or proved stopped
-       *  (`retracted`). Deliberately excludes `alreadyCancelling`, which had
-       *  been asked by an earlier call and has NOT stopped. */
-      executionsCancelled: number;
+      /** Executions PROVEN stopped by this call — the server retracted the
+       *  command before the device ever saw it. Nothing else counts here. */
+      executionsStopped: number;
+      /** Executions a `script_cancel` went out for because of this call. Asked,
+       *  NOT stopped: the device has not confirmed and may never. Kept separate
+       *  from `executionsStopped` for the same reason `RunCancelTally` keeps
+       *  `requested` and `retracted` apart — folding them lets a caller report
+       *  a stop that has not happened. */
+      executionsRequested: number;
       /** Full per-kind breakdown, so a caller can report honestly. */
       executions: RunCancelTally;
       uncancellableActions: UncancellableAction[];
@@ -292,11 +314,30 @@ export async function cancelAutomationRun(input: {
     captureException(err, undefined, { runId });
   }
 
+  // Reconciliation returns early for a run with NO action rows — it derives
+  // everything from them, and with none there is not even an org to publish
+  // to. That is exactly the shape of a run cancelled between enqueue and
+  // worker pickup, and the fence guarantees no action row will ever appear
+  // now. Without this the run would sit `cancelled` with a null completed_at
+  // forever, reading as permanently in progress.
+  await inDeliberateSystemContext(() => db
+    .update(automationRuns)
+    .set({ completedAt: new Date() })
+    .where(and(
+      eq(automationRuns.id, runId),
+      eq(automationRuns.status, 'cancelled'),
+      isNull(automationRuns.completedAt),
+      sql`NOT EXISTS (
+        SELECT 1 FROM automation_action_results WHERE run_id = ${runId}::uuid
+      )`,
+    )));
+
   return {
     kind: 'cancelled',
     alreadyCancelling: fence.alreadyCancelling,
     actionsCancelled: fence.actionsCancelled,
-    executionsCancelled: executions.requested + executions.retracted,
+    executionsStopped: executions.retracted,
+    executionsRequested: executions.requested,
     executions,
     uncancellableActions,
   };

--- a/apps/api/src/services/automationRunCancellation.ts
+++ b/apps/api/src/services/automationRunCancellation.ts
@@ -1,0 +1,287 @@
+import { and, eq, inArray, notInArray, sql, type SQL } from 'drizzle-orm';
+import {
+  db,
+  getCurrentDbAccessContext,
+  runOutsideDbContext,
+  withSystemDbAccessContext,
+} from '../db';
+import { automationActionResults, automationRuns } from '../db/schema';
+import { reconcileAutomationRun } from './automationActionResults';
+import type { RunCancelTally } from './scriptCancellation';
+
+// `scriptCancellation` reaches agentWs → commandQueue → configurationPolicy at
+// module load. Importing it eagerly here would drag that chain into every
+// partial-mock unit suite that imports the automation runtime (which imports
+// this module for the fence), so the VALUE import is deferred to the one
+// function that needs it — the same lazy-import pattern automationRuntime.ts
+// already uses for softwareDeployment.
+const loadRunSweep = () => import('./scriptCancellation');
+
+/**
+ * #3525 W05 — stopping a whole automation run.
+ *
+ * Authorization-free by design, exactly like `scriptCancellation.ts`: the route
+ * owns the org / partner-wide / site / MFA gates, this owns the state machine,
+ * so the route, a future AI tool and any worker cannot drift apart.
+ *
+ * ## The fence, and what it actually guarantees
+ *
+ * `cancelAutomationRun` marks the run `cancelled` while holding `FOR UPDATE`
+ * on its row. Every dispatch-side entry point calls `assertRunNotCancelled`,
+ * which reads that row `FOR SHARE`, so:
+ *
+ *  - a dispatcher that acquires `FOR SHARE` first blocks the cancel until it
+ *    commits, which means whatever it created is visible to the fan-out below;
+ *  - a dispatcher that arrives after the cancel committed sees `cancelled` and
+ *    throws `RunCancelledError` before dispatching anything.
+ *
+ * The lock is deliberately NOT held across the dispatch itself. Doing that
+ * would pin a pooled connection across a device command insert and a WebSocket
+ * send for five concurrent devices at a time — the double-hold that CLAUDE.md
+ * calls out, and a self-deadlock once the pool is exhausted. The residual
+ * window (an execution row committed microseconds after the fan-out's read) is
+ * closed on the dispatch side instead: `automationRuntime` re-checks the run
+ * after recording a dispatch and cancels the execution it just created. So an
+ * execution belonging to a cancelled run is either caught by the sweep here or
+ * cancelled by its own dispatcher — never left running.
+ */
+
+/** Thrown by `assertRunNotCancelled`; callers treat it as "stop, quietly". */
+export class RunCancelledError extends Error {
+  readonly runId: string;
+
+  constructor(runId: string) {
+    super(`Automation run ${runId} was cancelled`);
+    this.name = 'RunCancelledError';
+    this.runId = runId;
+  }
+}
+
+export function isRunCancelledError(error: unknown): error is RunCancelledError {
+  return error instanceof RunCancelledError
+    || (error instanceof Error && error.name === 'RunCancelledError');
+}
+
+/**
+ * Anything that can run raw SQL — the module `db`, or a transaction handle.
+ * Typed structurally so a caller inside `db.transaction` takes the row lock in
+ * ITS transaction rather than a second, independent one.
+ */
+export type RunFenceExecutor = { execute: (query: SQL) => Promise<unknown> };
+
+/**
+ * The dispatch fence. `FOR SHARE` (not `FOR UPDATE`): concurrent dispatchers
+ * must not serialise against each other, only against the cancel.
+ *
+ * A run that no longer exists is NOT an error here — the caller's own
+ * existence checks own that, and turning a deleted run into a throw would turn
+ * a benign race into a failed BullMQ job.
+ */
+export async function assertRunNotCancelled(
+  executor: RunFenceExecutor,
+  runId: string,
+): Promise<void> {
+  const rows = await executor.execute(sql`
+    SELECT status
+    FROM automation_runs
+    WHERE id = ${runId}::uuid
+    FOR SHARE
+  `) as unknown as Array<{ status: string }>;
+  if (rows[0]?.status === 'cancelled') throw new RunCancelledError(runId);
+}
+
+/**
+ * Action types a run-wide cancel cannot stop, and why. Both are reported to
+ * the caller rather than silently folded into "cancelled", because claiming a
+ * run stopped while one of these is still live is the dishonesty the whole
+ * cancellation design exists to prevent.
+ */
+const UNCANCELLABLE_ACTION_REASONS: Record<string, string> = {
+  // executeCommandAction dispatches a device command and deliberately creates
+  // no script_executions row, so there is nothing for the fan-out to key on.
+  execute_command: 'Ad-hoc commands have no script execution to stop; the command runs to completion on the device.',
+  // Deployments are tracked in deployment_results, which the agent has no
+  // stop verb for.
+  deploy_software: 'Software deployments cannot be recalled once dispatched; the install runs to completion on the device.',
+};
+const UNCANCELLABLE_ACTION_TYPES = Object.keys(UNCANCELLABLE_ACTION_REASONS);
+
+/** Action-result statuses that mean the row is closed and needs no cancel. */
+const TERMINAL_ACTION_STATUSES = ['succeeded', 'failed', 'skipped', 'timed_out', 'cancelled'] as const;
+
+export type UncancellableAction = {
+  actionIndex: number;
+  actionType: string;
+  reason: string;
+};
+
+export type CancelAutomationRunOutcome =
+  /** No such run — a race with a delete, or a bad id. */
+  | { kind: 'not_found' }
+  /** The run already finished on its own; relabelling it would be a lie. */
+  | { kind: 'already_terminal'; status: 'completed' | 'failed' | 'partial' }
+  | {
+      kind: 'cancelled';
+      /** True when the run was ALREADY cancelled; the sweep still re-ran. */
+      alreadyCancelling: boolean;
+      /** Action rows that had not been dispatched and are now terminal. */
+      actionsCancelled: number;
+      /** Executions this call asked to stop (`requested`) or proved stopped
+       *  (`retracted`). Deliberately excludes `alreadyCancelling`, which had
+       *  been asked by an earlier call and has NOT stopped. */
+      executionsCancelled: number;
+      /** Full per-kind breakdown, so a caller can report honestly. */
+      executions: RunCancelTally;
+      uncancellableActions: UncancellableAction[];
+    };
+
+function inDeliberateSystemContext<T>(fn: () => Promise<T>): Promise<T> {
+  if (getCurrentDbAccessContext()?.scope === 'system') return fn();
+  return runOutsideDbContext(() => withSystemDbAccessContext(fn));
+}
+
+/**
+ * The still-live actions this cancel cannot reach. Collected AFTER the
+ * never-dispatched rows have been terminalised, so an `execute_command` that
+ * was still `pending` (and therefore genuinely cancelled) is not reported.
+ */
+async function collectUncancellableActions(runId: string): Promise<UncancellableAction[]> {
+  const rows = await db
+    .select({
+      actionIndex: automationActionResults.actionIndex,
+      actionType: automationActionResults.actionType,
+    })
+    .from(automationActionResults)
+    .where(and(
+      eq(automationActionResults.runId, runId),
+      inArray(automationActionResults.actionType, UNCANCELLABLE_ACTION_TYPES),
+      notInArray(automationActionResults.status, [...TERMINAL_ACTION_STATUSES]),
+    ));
+
+  const byIndex = new Map<number, UncancellableAction>();
+  for (const row of rows) {
+    if (byIndex.has(row.actionIndex)) continue;
+    byIndex.set(row.actionIndex, {
+      actionIndex: row.actionIndex,
+      actionType: row.actionType,
+      reason: UNCANCELLABLE_ACTION_REASONS[row.actionType]
+        ?? 'This action type cannot be stopped once dispatched.',
+    });
+  }
+  return [...byIndex.values()].sort((a, b) => a.actionIndex - b.actionIndex);
+}
+
+/**
+ * Stop one automation run.
+ *
+ * Order matters and is load-bearing:
+ *  1. inside ONE transaction, under `FOR UPDATE`: flip the run to `cancelled`
+ *     (this write IS the fence) and terminalise every action row that was
+ *     never dispatched;
+ *  2. after that transaction commits: sweep the run's still-live script
+ *     executions. `cancelExecutionsForRun` opens a transaction per execution
+ *     and delivers each `script_cancel` to the agent AFTER its own commit, so
+ *     running it inside step 1 would both hold the run lock across N network
+ *     sends and let a fast agent ack race a row that is not yet visible;
+ *  3. reconcile, so the rows terminalised in step 1 roll up into their device
+ *     rows and `devices_cancelled`.
+ */
+export async function cancelAutomationRun(input: {
+  runId: string;
+  actorId: string | null;
+  actorLabel: string;
+  graceSeconds?: number | null;
+}): Promise<CancelAutomationRunOutcome> {
+  const { runId } = input;
+
+  const fence = await inDeliberateSystemContext(() => db.transaction(async (tx) => {
+    const [run] = await tx
+      .select({ id: automationRuns.id, status: automationRuns.status })
+      .from(automationRuns)
+      .where(eq(automationRuns.id, runId))
+      .limit(1)
+      .for('update');
+    if (!run) return { kind: 'not_found' } as const;
+
+    if (run.status !== 'running' && run.status !== 'cancelled') {
+      return { kind: 'already_terminal', status: run.status } as const;
+    }
+
+    if (run.status === 'cancelled') {
+      // Idempotent. The status write and the never-dispatched sweep already
+      // happened; only the fan-out is worth repeating, because devices that
+      // did not stop the first time should be asked again.
+      return { kind: 'cancelled', alreadyCancelling: true, actionsCancelled: 0 } as const;
+    }
+
+    const logEntry = {
+      timestamp: new Date().toISOString(),
+      level: 'warning',
+      message: `Run cancelled by ${input.actorLabel}`,
+    };
+    await tx
+      .update(automationRuns)
+      .set({
+        status: 'cancelled',
+        // Both runners write the WHOLE logs array they loaded at run start
+        // (`set({ logs })`), so a plain assignment here would be erased by the
+        // next dispatch-phase write. Appending in SQL survives that.
+        logs: sql`COALESCE(${automationRuns.logs}, '[]'::jsonb) || ${JSON.stringify([logEntry])}::jsonb`,
+      })
+      .where(and(eq(automationRuns.id, runId), eq(automationRuns.status, 'running')));
+
+    // ONLY `pending`. An action that is queued/delivered/running has already
+    // reached the device; it closes when its own child closes, and pretending
+    // otherwise here is exactly the "claimed stopped" lie the honesty contract
+    // forbids. This resolves the spec's own contradiction.
+    const cancelledActions = await tx
+      .update(automationActionResults)
+      .set({
+        status: 'cancelled',
+        terminalSource: 'cancellation',
+        message: 'Cancelled before dispatch',
+        completedAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(and(
+        eq(automationActionResults.runId, runId),
+        eq(automationActionResults.status, 'pending'),
+      ))
+      .returning({ id: automationActionResults.id });
+
+    return {
+      kind: 'cancelled',
+      alreadyCancelling: false,
+      actionsCancelled: cancelledActions.length,
+    } as const;
+  }));
+
+  if (fence.kind !== 'cancelled') return fence;
+
+  // POST-COMMIT (see the ordering note above).
+  const { cancelExecutionsForRun } = await loadRunSweep();
+  const executions = await cancelExecutionsForRun({
+    runId,
+    actorId: input.actorId,
+    actorLabel: input.actorLabel,
+    graceSeconds: input.graceSeconds,
+  });
+
+  const uncancellableActions = await inDeliberateSystemContext(
+    () => collectUncancellableActions(runId),
+  );
+
+  // Without this a run whose every action was still `pending` would sit at
+  // devices_cancelled 0 and its device rows at `pending` until some unrelated
+  // result happened to arrive.
+  await reconcileAutomationRun(runId);
+
+  return {
+    kind: 'cancelled',
+    alreadyCancelling: fence.alreadyCancelling,
+    actionsCancelled: fence.actionsCancelled,
+    executionsCancelled: executions.requested + executions.retracted,
+    executions,
+    uncancellableActions,
+  };
+}

--- a/apps/api/src/services/automationRuntime.cancelFence.test.ts
+++ b/apps/api/src/services/automationRuntime.cancelFence.test.ts
@@ -1,0 +1,344 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * #3525 W05 (#4766) — the dispatch-loop side of the cancel fence.
+ *
+ * `automationRunCancelFence.integration.test.ts` proves the LOCK against real
+ * Postgres. This file proves the runtime behaviour that lock is wrapped in,
+ * and specifically the compensating path: the one mechanism standing between a
+ * cancel that lands microseconds after a dispatch and a script that keeps
+ * running on a customer endpoint. Without a test here, renaming
+ * `outcome.scriptExecutionId` would turn the whole compensation into dead code
+ * and nothing would go red.
+ */
+
+const {
+  dispatchMock,
+  resolveOwnedAutomationReferencesMock,
+  recordActionDispatchMock,
+  reconcileRunMock,
+  seedActionResultsMock,
+  cancelScriptExecutionMock,
+  deliverCancelCommandMock,
+  captureExceptionMock,
+  executeMock,
+  selectMock,
+} = vi.hoisted(() => ({
+  dispatchMock: vi.fn(),
+  resolveOwnedAutomationReferencesMock: vi.fn(),
+  recordActionDispatchMock: vi.fn(),
+  reconcileRunMock: vi.fn(),
+  seedActionResultsMock: vi.fn(),
+  cancelScriptExecutionMock: vi.fn(),
+  deliverCancelCommandMock: vi.fn(),
+  captureExceptionMock: vi.fn(),
+  executeMock: vi.fn(),
+  selectMock: vi.fn(),
+}));
+
+vi.mock('./automationReferenceAuthorization', () => ({
+  AutomationReferenceAuthorizationError: class AutomationReferenceAuthorizationError extends Error {
+    readonly code = 'unknown_or_unauthorized_reference';
+  },
+  resolveOwnedAutomationReferences: resolveOwnedAutomationReferencesMock,
+}));
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  getCurrentDbAccessContext: vi.fn(() => ({ scope: 'system' })),
+  db: {
+    select: selectMock,
+    insert: vi.fn(),
+    update: vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn(async () => undefined) })) })),
+    delete: vi.fn(),
+    transaction: vi.fn(),
+    execute: executeMock,
+  },
+}));
+
+vi.mock('../db/schema', () => ({
+  automationRuns: { id: 'id', automationId: 'automationId', status: 'status', logs: 'logs' },
+  automationActionResults: { runId: 'runId', status: 'status', actionIndex: 'actionIndex', actionType: 'actionType', id: 'id' },
+  automationRunDeviceResults: { runId: 'runId', deviceId: 'deviceId' },
+  automationResourceBindings: { automationId: 'automationId' },
+  configPolicyAutomations: { featureLinkId: 'featureLinkId' },
+  configPolicyFeatureLinks: { id: 'id', configPolicyId: 'configPolicyId' },
+  configurationPolicies: { id: 'id', orgId: 'orgId' },
+  devices: { id: 'id', hostname: 'hostname', osType: 'osType', status: 'status', displayName: 'displayName', agentId: 'agentId' },
+  organizations: { id: 'id', partnerId: 'partnerId' },
+  scripts: { id: 'id', deletedAt: 'deletedAt' },
+  scriptExecutions: { id: 'id', deviceId: 'deviceId', automationRunId: 'automationRunId', status: 'status' },
+  notificationChannels: { id: 'id', orgId: 'orgId' },
+  automations: { id: 'id', runCount: 'runCount' },
+  alerts: { id: 'id' },
+  alertRules: { id: 'id', orgId: 'orgId', name: 'name', targetType: 'targetType', targetId: 'targetId' },
+  alertTemplates: { id: 'id', orgId: 'orgId', name: 'name' },
+  deviceGroupMemberships: { deviceId: 'deviceId', groupId: 'groupId' },
+}));
+
+vi.mock('./automationActionResults', () => ({
+  recordAutomationActionDispatch: recordActionDispatchMock,
+  reconcileAutomationRun: reconcileRunMock,
+  seedAutomationActionResults: seedActionResultsMock,
+}));
+
+vi.mock('./scriptCancellation', () => ({
+  cancelScriptExecution: cancelScriptExecutionMock,
+  deliverCancelCommand: deliverCancelCommandMock,
+  cancelExecutionsForRun: vi.fn(),
+}));
+
+vi.mock('./sentry', () => ({ captureException: captureExceptionMock }));
+vi.mock('./eventBus', () => ({ publishEvent: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('./deploymentEngine', () => ({ resolveDeploymentTargets: vi.fn().mockResolvedValue([]) }));
+vi.mock('./scriptDispatch', () => ({ dispatchScriptToDevice: dispatchMock }));
+vi.mock('./notificationSenders', () => ({
+  getEmailRecipients: vi.fn().mockReturnValue([]),
+  sendEmailNotification: vi.fn().mockResolvedValue({ success: false }),
+  sendWebhookNotification: vi.fn().mockResolvedValue({ success: false }),
+}));
+
+import { __testOnly } from './automationRuntime';
+
+const RUN_ID = '99999999-8888-4777-8666-555555555555';
+const EXECUTION_ID = '11111111-2222-4333-8444-555555555555';
+
+const SCRIPT = {
+  id: 'script-1',
+  name: 'Collect logs',
+  language: 'bash',
+  content: 'sleep 120',
+  osTypes: ['linux'],
+  timeoutSeconds: 300,
+  runAs: 'system',
+} as never;
+
+function device(id: string) {
+  return {
+    id,
+    orgId: 'org-1',
+    hostname: id,
+    displayName: null,
+    osType: 'linux' as const,
+    status: 'online',
+    agentId: `agent-${id}`,
+    siteId: null,
+    customFields: null,
+  };
+}
+
+/** What the run-status re-read inside `cancelDispatchIfRunCancelled` sees. */
+function runStatusIs(status: string) {
+  selectMock.mockImplementation(() => ({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([{ status }]) }),
+    }),
+  }));
+}
+
+/** What the FOR SHARE fence read sees, per call, in order. */
+function fenceSees(...statuses: Array<string | null>) {
+  executeMock.mockReset();
+  for (const status of statuses) {
+    executeMock.mockResolvedValueOnce(status === null ? [] : [{ status }]);
+  }
+  // Anything past the scripted sequence: run still live.
+  executeMock.mockResolvedValue([]);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  recordActionDispatchMock.mockResolvedValue(true);
+  reconcileRunMock.mockResolvedValue(undefined);
+  seedActionResultsMock.mockResolvedValue(undefined);
+  deliverCancelCommandMock.mockResolvedValue(true);
+  runStatusIs('running');
+  fenceSees();
+});
+
+describe('cancelDispatchIfRunCancelled — the compensating half of the fence', () => {
+  const withExecution = {
+    outcome: { status: 'delivered' as const, commandId: 'cmd-1', scriptExecutionId: EXECUTION_ID },
+    log: { timestamp: 'now', level: 'info' as const, message: 'Queued run_script action' },
+  };
+  const withoutExecution = {
+    outcome: { status: 'delivered' as const, commandId: 'cmd-1' },
+    log: { timestamp: 'now', level: 'info' as const, message: 'Queued execute_command action' },
+  };
+
+  it('does not even read the run for a dispatch with no script execution to stop', async () => {
+    runStatusIs('cancelled');
+    await expect(
+      __testOnly.cancelDispatchIfRunCancelled(RUN_ID, 'device-1', withoutExecution),
+    ).resolves.toBe('not_needed');
+    // execute_command has no agent-side stop; paying for a read per dispatch
+    // to discover that would be pure cost.
+    expect(selectMock).not.toHaveBeenCalled();
+    expect(cancelScriptExecutionMock).not.toHaveBeenCalled();
+  });
+
+  it('leaves a live run alone', async () => {
+    runStatusIs('running');
+    await expect(
+      __testOnly.cancelDispatchIfRunCancelled(RUN_ID, 'device-1', withExecution),
+    ).resolves.toBe('not_needed');
+    expect(cancelScriptExecutionMock).not.toHaveBeenCalled();
+  });
+
+  it('stops the execution it just created when the run went cancelled mid-dispatch', async () => {
+    // THE residual-window case. The cancel committed after this dispatcher's
+    // pre-dispatch fence read but before its execution row was visible to the
+    // fan-out, so nothing else will ever stop this script.
+    runStatusIs('cancelled');
+    cancelScriptExecutionMock.mockResolvedValue({
+      kind: 'cancelling',
+      executionId: EXECUTION_ID,
+      cancelCommandId: 'cancel-cmd-1',
+      deviceId: 'device-1',
+      alreadyQueued: false,
+    });
+
+    await expect(
+      __testOnly.cancelDispatchIfRunCancelled(RUN_ID, 'device-1', withExecution),
+    ).resolves.toBe('requested');
+
+    expect(cancelScriptExecutionMock).toHaveBeenCalledWith(expect.objectContaining({
+      executionId: EXECUTION_ID,
+    }));
+    // POST-COMMIT delivery, same contract as every other cancel caller.
+    expect(deliverCancelCommandMock).toHaveBeenCalledWith('cancel-cmd-1', 'device-1');
+  });
+
+  it('does not re-deliver a cancel that was already queued', async () => {
+    runStatusIs('cancelled');
+    cancelScriptExecutionMock.mockResolvedValue({
+      kind: 'cancelling',
+      executionId: EXECUTION_ID,
+      cancelCommandId: 'cancel-cmd-1',
+      deviceId: 'device-1',
+      alreadyQueued: true,
+    });
+    await __testOnly.cancelDispatchIfRunCancelled(RUN_ID, 'device-1', withExecution);
+    expect(deliverCancelCommandMock).not.toHaveBeenCalled();
+  });
+
+  // The distinction that matters: `settled` means nothing is running any more,
+  // `requested` means we only ASKED. Collapsing them (as a boolean did) makes
+  // the caller write "the execution was stopped" into the run log for a stop
+  // the device never confirmed.
+  it.each(['retracted', 'recovered', 'already_terminal', 'idempotent'] as const)(
+    'reports %s as settled and delivers nothing',
+    async (kind) => {
+      runStatusIs('cancelled');
+      cancelScriptExecutionMock.mockResolvedValue({ kind, status: 'completed' });
+      await expect(
+        __testOnly.cancelDispatchIfRunCancelled(RUN_ID, 'device-1', withExecution),
+      ).resolves.toBe('settled');
+      expect(deliverCancelCommandMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(['not_found', 'inconsistent'] as const)(
+    'reports %s as FAILED — absence is not proof that nothing is running',
+    async (kind) => {
+      runStatusIs('cancelled');
+      cancelScriptExecutionMock.mockResolvedValue({ kind });
+      await expect(
+        __testOnly.cancelDispatchIfRunCancelled(RUN_ID, 'device-1', withExecution),
+      ).resolves.toBe('failed');
+      expect(captureExceptionMock).toHaveBeenCalled();
+    },
+  );
+
+  it('reports a throw as failed, loudly, without throwing — a cancelled run must not become a retried job', async () => {
+    runStatusIs('cancelled');
+    cancelScriptExecutionMock.mockRejectedValue(new Error('deadlock detected'));
+    await expect(
+      __testOnly.cancelDispatchIfRunCancelled(RUN_ID, 'device-1', withExecution),
+    ).resolves.toBe('failed');
+    // This is the ONE path that can leave a script running after a cancel, so
+    // reporting it as a stop is exactly the lie the feature exists to prevent.
+    expect(captureExceptionMock).toHaveBeenCalled();
+  });
+});
+
+describe('executeAutomationActionsInOrder — mid-flight cancellation', () => {
+  function args(overrides: Partial<Parameters<typeof __testOnly.executeAutomationActionsInOrder>[0]> = {}) {
+    return {
+      actions: [
+        { type: 'run_script', scriptId: 'script-1' },
+        { type: 'run_script', scriptId: 'script-1' },
+      ],
+      devices: [device('device-1')],
+      automation: { id: 'auto-1', orgId: 'org-1', name: 'a', createdBy: null, managedByAgentId: null },
+      runId: RUN_ID,
+      scriptsById: new Map([['script-1', SCRIPT]]),
+      channelsById: new Map(),
+      variableScope: undefined,
+      trigger: undefined,
+      onFailure: 'stop' as const,
+      notificationTargets: undefined,
+      createdBy: null,
+      resolvedReferences: {
+        scriptsById: new Map([['script-1', SCRIPT]]),
+        notificationChannelsById: new Map(),
+      },
+      ...overrides,
+    } as unknown as Parameters<typeof __testOnly.executeAutomationActionsInOrder>[0];
+  }
+
+  it('stops between actions when the run is cancelled part-way', async () => {
+    dispatchMock.mockResolvedValue({
+      ok: true, commandId: 'cmd-1', executionId: null, delivered: true,
+      executedAt: new Date(), ignoredParameters: [],
+    });
+    // Action 0's fence read is clean; action 1's sees the cancel.
+    // (The per-device read for action 0 also comes from this sequence.)
+    fenceSees(null, null, 'cancelled');
+
+    const out = await __testOnly.executeAutomationActionsInOrder(args());
+
+    expect(out.cancelled).toBe(true);
+    // Action 0 dispatched, action 1 never did.
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+    expect(out.logs.some((entry) => entry.message.includes('remaining actions were not dispatched'))).toBe(true);
+  });
+
+  it('records NO failure when a device is fenced off — nothing failed, an operator stopped it', async () => {
+    dispatchMock.mockResolvedValue({
+      ok: true, commandId: 'cmd-1', executionId: null, delivered: true,
+      executedAt: new Date(), ignoredParameters: [],
+    });
+    // Per-action read clean, per-device read sees the cancel.
+    fenceSees(null, 'cancelled');
+
+    const out = await __testOnly.executeAutomationActionsInOrder(args({
+      actions: [{ type: 'run_script', scriptId: 'script-1' }],
+    }));
+
+    expect(out.cancelled).toBe(true);
+    expect(out.devicesFailed).toBe(0);
+    expect(dispatchMock).not.toHaveBeenCalled();
+    // Reporting a stop as an automation defect is the exact dishonesty this
+    // whole feature exists to prevent.
+    expect(recordActionDispatchMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'failed' }),
+    );
+  });
+
+  it('leaves an uncancelled run completely unaffected', async () => {
+    dispatchMock.mockResolvedValue({
+      ok: true, commandId: 'cmd-1', executionId: null, delivered: true,
+      executedAt: new Date(), ignoredParameters: [],
+    });
+    fenceSees();
+
+    const out = await __testOnly.executeAutomationActionsInOrder(args());
+
+    expect(out.cancelled).toBe(false);
+    expect(dispatchMock).toHaveBeenCalledTimes(2);
+    expect(out.hasNonterminalActions).toBe(true);
+  });
+});

--- a/apps/api/src/services/automationRuntime.configPolicy.test.ts
+++ b/apps/api/src/services/automationRuntime.configPolicy.test.ts
@@ -416,6 +416,8 @@ describe('executeConfigPolicyAutomationRun', () => {
     seedActionResultsMock.mockResolvedValue(undefined);
     recordActionDispatchMock.mockResolvedValue(true);
     reconcileRunMock.mockResolvedValue(undefined);
+    // Default fence read: no row, i.e. "not cancelled".
+    vi.mocked(db.execute).mockResolvedValue([] as any);
   });
 
   it('throws when orgId cannot be resolved', async () => {
@@ -1054,6 +1056,66 @@ describe('executeConfigPolicyAutomationRun', () => {
     expect(reconcileRunMock).toHaveBeenCalledWith('run-1');
   });
 
+  // #3525 W05 — the config-policy runner carries the same fence. Cancelling a
+  // config-policy run is out of scope for the ROUTE (OD10-B), but the fence is
+  // unconditional so a run cancelled through any other door still stops here.
+  it('refuses to seed a config-policy run that was already cancelled', async () => {
+    const automation = makeConfigPolicyAutomation({
+      actions: [{ type: 'execute_command', command: 'echo nope' }],
+    });
+
+    let selectCallCount = 0;
+    vi.mocked(db.select).mockImplementation(() => {
+      selectCallCount++;
+      if (selectCallCount === 1) {
+        return {
+          from: vi.fn().mockReturnValue({
+            innerJoin: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                limit: vi.fn().mockResolvedValue([{ orgId: 'org-1' }]),
+              }),
+            }),
+          }),
+        } as any;
+      }
+      if (selectCallCount === 2) {
+        return {
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([
+              { id: 'dev-1', hostname: 'host-1', displayName: null, osType: 'linux', status: 'online' },
+            ]),
+          }),
+        } as any;
+      }
+      return { from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue([]) }) } as any;
+    });
+
+    const run = { id: 'run-cp-cancelled', automationId: null, status: 'cancelled', logs: [] };
+    vi.mocked(db.insert).mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([run]),
+        onConflictDoNothing: vi.fn().mockResolvedValue(undefined),
+      }),
+    } as any);
+    vi.mocked(db.update).mockReturnValue({
+      set: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
+    } as any);
+    // The FOR SHARE fence read sees the cancelled run.
+    vi.mocked(db.execute).mockResolvedValueOnce([{ status: 'cancelled' }] as any);
+
+    const result = await executeConfigPolicyAutomationRun(automation, ['dev-1'], 'scheduler');
+
+    expect(result).toEqual({
+      runId: 'run-cp-cancelled',
+      status: 'cancelled',
+      devicesSucceeded: 0,
+      devicesFailed: 0,
+    });
+    expect(seedActionResultsMock).not.toHaveBeenCalled();
+    expect(recordActionDispatchMock).not.toHaveBeenCalled();
+    expect(reconcileRunMock).not.toHaveBeenCalled();
+  });
+
   it('propagates reconciliation publication failures', async () => {
     const automation = makeConfigPolicyAutomation({
       actions: [{ type: 'execute_command', command: 'echo ok' }],
@@ -1256,7 +1318,7 @@ describe('executeAutomationRun durable dispatch', () => {
       set: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
     } as any);
     // The fence read (SELECT ... FOR SHARE) sees the cancelled run.
-    vi.mocked(db.execute).mockResolvedValue([{ status: 'cancelled' }] as any);
+    vi.mocked(db.execute).mockResolvedValueOnce([{ status: 'cancelled' }] as any);
 
     const result = await executeAutomationRun(run.id, ['dev-1']);
 

--- a/apps/api/src/services/automationRuntime.configPolicy.test.ts
+++ b/apps/api/src/services/automationRuntime.configPolicy.test.ts
@@ -39,6 +39,10 @@ vi.mock('../db', () => ({
     insert: vi.fn(),
     update: vi.fn(),
     transaction: vi.fn(),
+    // #3525 W05 — the dispatch fence reads the run row FOR SHARE through
+    // db.execute before either runner seeds. Returning no row is "run not
+    // found", which the fence deliberately treats as "not cancelled".
+    execute: vi.fn(async () => []),
   },
 }));
 
@@ -1196,5 +1200,69 @@ describe('executeAutomationRun durable dispatch', () => {
       commandId: 'cmd-ordinary',
     }));
     expect(reconcileRunMock).toHaveBeenCalledWith(run.id);
+  });
+
+  // #3525 W05 — the dispatch fence. A BullMQ job is not permission to
+  // dispatch: before this wave neither runner checked run status, so a job
+  // picked up after an operator hit Stop ran the whole automation anyway.
+  it('refuses to seed anything at all for an already-cancelled run', async () => {
+    const run = {
+      id: 'run-cancelled',
+      automationId: 'auto-cancelled',
+      status: 'cancelled',
+      triggeredBy: 'scheduler',
+      logs: [],
+    };
+    const automation = {
+      id: 'auto-cancelled',
+      orgId: 'org-1',
+      partnerId: null,
+      name: 'Cancelled automation',
+      trigger: { type: 'manual' },
+      conditions: null,
+      actions: [{ type: 'execute_command', command: 'echo nope' }],
+      onFailure: 'stop',
+      notificationTargets: null,
+      createdBy: 'user-1',
+    };
+    let selectCall = 0;
+    vi.mocked(db.select).mockImplementation(() => {
+      selectCall += 1;
+      if (selectCall === 1 || selectCall === 2) {
+        const rows = selectCall === 1 ? [run] : [automation];
+        return {
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(rows) }),
+          }),
+        } as any;
+      }
+      if (selectCall === 3) {
+        return { from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue([]) }) } as any;
+      }
+      return {
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{
+            id: 'dev-1', orgId: 'org-1', hostname: 'host-1', displayName: null,
+            osType: 'linux', status: 'online', agentId: 'agent-1', siteId: null,
+            customFields: null,
+          }]),
+        }),
+      } as any;
+    });
+    vi.mocked(db.insert).mockReturnValue({
+      values: vi.fn().mockReturnValue({ onConflictDoNothing: vi.fn().mockResolvedValue(undefined) }),
+    } as any);
+    vi.mocked(db.update).mockReturnValue({
+      set: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
+    } as any);
+    // The fence read (SELECT ... FOR SHARE) sees the cancelled run.
+    vi.mocked(db.execute).mockResolvedValue([{ status: 'cancelled' }] as any);
+
+    const result = await executeAutomationRun(run.id, ['dev-1']);
+
+    expect(result).toEqual({ status: 'cancelled', devicesSucceeded: 0, devicesFailed: 0 });
+    expect(seedActionResultsMock).not.toHaveBeenCalled();
+    expect(recordActionDispatchMock).not.toHaveBeenCalled();
+    expect(dispatchScriptToDevice).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/services/automationRuntime.ts
+++ b/apps/api/src/services/automationRuntime.ts
@@ -48,11 +48,20 @@ import {
   reconcileAutomationRun,
   seedAutomationActionResults,
 } from './automationActionResults';
+import {
+  assertRunNotCancelled,
+  isRunCancelledError,
+} from './automationRunCancellation';
+// scriptCancellation is imported LAZILY (see cancelDispatchIfRunCancelled) for
+// the same reason softwareDeployment is below: it pulls the
+// agentWs → commandQueue → configurationPolicy chain in at module load.
 // softwareDeployment and softwareCurrency are imported lazily inside
 // executeDeploySoftwareActions to avoid pulling the agentWs→configurationPolicy
 // import chain into partial-mock test suites at module-load time.
 
 const ALERT_SEVERITIES = ['critical', 'high', 'medium', 'low', 'info'] as const;
+/** What a runner reports back to its caller (#3525 W05 added `cancelled`). */
+export type AutomationRunOutcomeStatus = 'running' | 'completed' | 'failed' | 'partial' | 'cancelled';
 type DbTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
 export type AutomationOwnerAxes = { orgId: string | null; partnerId: string | null };
 
@@ -67,6 +76,82 @@ function recordAutomationRuntimeActionDispatch(
   // action-result locks and reconciliation publications out of that ambient
   // transaction, just like the action-side writes they describe.
   return withAutomationRuntimeDb(() => recordAutomationActionDispatch(input));
+}
+
+/**
+ * #3525 W05 — the dispatch fence, read side. `FOR SHARE` on the run row, so a
+ * concurrent `cancelAutomationRun` (which holds `FOR UPDATE`) either commits
+ * before this and is seen, or waits for this statement.
+ *
+ * Throws `RunCancelledError`. Every dispatch-side caller either returns
+ * quietly on it or lets it reach `executeAutomationRun`'s handler — it must
+ * NEVER be recorded as an action failure, because nothing failed.
+ */
+function assertRunNotCancelledInRuntime(runId: string): Promise<void> {
+  return withAutomationRuntimeDb(() => assertRunNotCancelled(db, runId));
+}
+
+/**
+ * The other half of the fence.
+ *
+ * The pre-dispatch check above cannot be held across the dispatch itself
+ * (that would pin a pooled connection across a command insert and a WebSocket
+ * send, five devices at a time). So there is a microsecond window in which a
+ * cancel commits, its fan-out reads the executions table, and only THEN this
+ * dispatcher's own execution row lands — invisible to that sweep and running
+ * on the device.
+ *
+ * Re-reading the run after the dispatch closes it: if the run is cancelled by
+ * now, the execution we just created is stopped here instead. Every execution
+ * of a cancelled run is therefore either caught by the sweep or cancelled by
+ * its own dispatcher.
+ */
+async function cancelDispatchIfRunCancelled(
+  runId: string,
+  deviceId: string,
+  result: ActionExecutionResult,
+): Promise<boolean> {
+  // Only a script execution can be stopped after the fact, so only a dispatch
+  // that produced one pays for the extra read. `execute_command` and
+  // deployments have no agent-side stop at all — they are reported to the
+  // operator as uncancellable instead (automationRunCancellation.ts).
+  const executionId = 'scriptExecutionId' in result.outcome ? result.outcome.scriptExecutionId : undefined;
+  if (!executionId) return false;
+
+  const cancelled = await withAutomationRuntimeDb(async () => {
+    const [row] = await db
+      .select({ status: automationRuns.status })
+      .from(automationRuns)
+      .where(eq(automationRuns.id, runId))
+      .limit(1);
+    return row?.status === 'cancelled';
+  });
+  if (!cancelled) return false;
+
+  try {
+    const { cancelScriptExecution, deliverCancelCommand } = await import('./scriptCancellation');
+    const outcome = await cancelScriptExecution({
+      executionId,
+      actorId: null,
+      actorLabel: 'automation run cancellation',
+    });
+    // POST-COMMIT delivery, same contract as every other cancel caller.
+    if (outcome.kind === 'cancelling' && !outcome.alreadyQueued) {
+      await deliverCancelCommand(outcome.cancelCommandId, outcome.deviceId);
+    }
+  } catch (err) {
+    // Losing the compensation must not turn a cancelled run into a thrown
+    // BullMQ job — but it MUST be visible, because it is the one path that can
+    // leave a script running after a cancel.
+    console.error('[automationRuntime] failed to cancel an execution dispatched into a cancelled run', {
+      runId,
+      deviceId,
+      executionId,
+      error: err,
+    });
+    captureException(err, undefined, { runId, deviceId, executionId });
+  }
+  return true;
 }
 
 /**
@@ -2096,11 +2181,14 @@ async function executeAutomationActionsInOrder(args: {
   devicesSucceeded: number;
   devicesFailed: number;
   hasNonterminalActions: boolean;
+  /** True when the run was cancelled part-way and dispatch stopped early. */
+  cancelled: boolean;
 }> {
   const logs: AutomationLogEntry[] = [];
   const activeDeviceIds = new Set(args.devices.map((device) => device.id));
   const failedDeviceIds = new Set<string>();
   let hasNonterminalActions = false;
+  let cancelled = false;
 
   const handleFailure = async (
     device: OrderedAutomationDevice,
@@ -2145,6 +2233,20 @@ async function executeAutomationActionsInOrder(args: {
   for (const [actionIndex, action] of args.actions.entries()) {
     const activeDevices = args.devices.filter((device) => activeDeviceIds.has(device.id));
     if (activeDevices.length === 0) break;
+
+    // Fence, once per action: a long run stops between actions, not only
+    // between devices. Checked before the deployment batch too, which
+    // dispatches for every active device at once.
+    try {
+      await assertRunNotCancelledInRuntime(args.runId);
+    } catch (err) {
+      if (!isRunCancelledError(err)) throw err;
+      cancelled = true;
+      logs.push(logEntry('Automation run cancelled; remaining actions were not dispatched', 'warning', {
+        actionIndex,
+      }));
+      break;
+    }
 
     if (action.type === 'deploy_software') {
       try {
@@ -2191,6 +2293,9 @@ async function executeAutomationActionsInOrder(args: {
 
     await runWithConcurrency(activeDevices, 5, async (device) => {
       try {
+        // Fence, per device: a run cancelled while the previous device was
+        // being dispatched must not reach this one.
+        await assertRunNotCancelledInRuntime(args.runId);
         const result = await withAutomationRuntimeDb(() => executeAction(action, actionIndex, buildActionExecutionContext({
           automation: args.automation,
           runId: args.runId,
@@ -2201,6 +2306,14 @@ async function executeAutomationActionsInOrder(args: {
         }, device)));
         logs.push(result.log);
         await persistActionExecutionOutcome(args.runId, device.id, actionIndex, result);
+        if (await cancelDispatchIfRunCancelled(args.runId, device.id, result)) {
+          cancelled = true;
+          logs.push(logEntry('Action dispatched into a run that was cancelled; the execution was stopped', 'warning', {
+            actionIndex,
+            deviceId: device.id,
+          }));
+          return;
+        }
         if (
           result.outcome.status === 'queued'
           || result.outcome.status === 'delivered'
@@ -2212,6 +2325,16 @@ async function executeAutomationActionsInOrder(args: {
           await handleFailure(device, actionIndex, result.log.message);
         }
       } catch (err) {
+        if (isRunCancelledError(err)) {
+          // Nothing failed — an operator stopped the run. Recording a failure
+          // here would report a stop as an automation defect.
+          cancelled = true;
+          logs.push(logEntry('Automation run cancelled before this device was dispatched', 'warning', {
+            actionIndex,
+            deviceId: device.id,
+          }));
+          return;
+        }
         const message = err instanceof Error ? err.message : String(err);
         console.error('[automationRuntime] action threw during device dispatch', {
           deviceId: device.id,
@@ -2240,6 +2363,7 @@ async function executeAutomationActionsInOrder(args: {
     devicesSucceeded: args.devices.length - failedDeviceIds.size,
     devicesFailed: failedDeviceIds.size,
     hasNonterminalActions,
+    cancelled,
   };
 }
 
@@ -2407,13 +2531,20 @@ export async function executeAutomationRun(
   targetDeviceIdsFromQueue?: string[],
   triggerContext?: AutomationTriggerContext,
 ): Promise<{
-  status: 'running' | 'completed' | 'failed' | 'partial';
+  status: AutomationRunOutcomeStatus;
   devicesSucceeded: number;
   devicesFailed: number;
 }> {
   try {
     return await executeAutomationRunInner(runId, targetDeviceIdsFromQueue, triggerContext);
   } catch (err) {
+    // #3525 W05 — a cancelled run is NOT an execution error. Falling through
+    // would call markAutomationRunFailedAfterError, which flips every seeded
+    // device row to `failed`, and would rethrow so BullMQ retries a run an
+    // operator deliberately stopped.
+    if (isRunCancelledError(err)) {
+      return { status: 'cancelled', devicesSucceeded: 0, devicesFailed: 0 };
+    }
     await withAutomationRuntimeDb(() => markAutomationRunFailedAfterError(runId, err)).catch((cleanupErr) => {
       console.error(
         `[AutomationRuntime] failed to mark run ${runId} failed after execution error:`,
@@ -2449,7 +2580,7 @@ async function executeAutomationRunInner(
   targetDeviceIdsFromQueue?: string[],
   triggerContext?: AutomationTriggerContext,
 ): Promise<{
-  status: 'running' | 'completed' | 'failed' | 'partial';
+  status: AutomationRunOutcomeStatus;
   devicesSucceeded: number;
   devicesFailed: number;
 }> {
@@ -2525,6 +2656,16 @@ async function executeAutomationRunInner(
   const scriptsById = resolvedReferences.scriptsById;
   const channelsById = resolvedReferences.notificationChannelsById;
 
+  // #3525 W05 — a queued job is not permission to dispatch. The run may have
+  // been cancelled between enqueue and pickup, and neither runner checked
+  // before this wave: the job ran to completion regardless.
+  try {
+    await assertRunNotCancelledInRuntime(run.id);
+  } catch (err) {
+    if (!isRunCancelledError(err)) throw err;
+    return { status: 'cancelled', devicesSucceeded: 0, devicesFailed: 0 };
+  }
+
   // Seed a per-device result row (pending) for every targeted device so the
   // execution-history UI can show live progress as each device finishes (#2023).
   await withAutomationRuntimeDb(() => seedAutomationDeviceResults(run.id, deviceRows));
@@ -2577,13 +2718,15 @@ async function executeAutomationRunInner(
       completedAt: new Date(),
     }).where(and(eq(automationRuns.id, run.id), eq(automationRuns.status, 'running'))));
   }
-  const status: 'running' | 'completed' | 'failed' | 'partial' = hasNonterminalActions
-    ? 'running'
-    : devicesFailed === 0
-      ? 'completed'
-      : devicesSucceeded === 0
-        ? 'failed'
-        : 'partial';
+  const status: AutomationRunOutcomeStatus = actionOutcome.cancelled
+    ? 'cancelled'
+    : hasNonterminalActions
+      ? 'running'
+      : devicesFailed === 0
+        ? 'completed'
+        : devicesSucceeded === 0
+          ? 'failed'
+          : 'partial';
 
   return {
     status,
@@ -2719,7 +2862,7 @@ export async function executeConfigPolicyAutomationRun(
   triggeredBy: string,
 ): Promise<{
   runId: string;
-  status: 'running' | 'completed' | 'failed' | 'partial';
+  status: AutomationRunOutcomeStatus;
   devicesSucceeded: number;
   devicesFailed: number;
 }> {
@@ -2787,6 +2930,17 @@ export async function executeConfigPolicyAutomationRun(
       .from(devices)
       .where(inArray(devices.id, targetDeviceIds)))
     : [];
+  // #3525 W05 fence — see the standalone runner. Config-policy runs are out of
+  // scope for the cancel ROUTE (OD10-B: automation_runs' config-policy RLS arm
+  // makes partner-owned policy runs invisible), but the fence is unconditional
+  // so a run cancelled through any future door still stops here.
+  try {
+    await assertRunNotCancelledInRuntime(run.id);
+  } catch (err) {
+    if (!isRunCancelledError(err)) throw err;
+    return { runId: run.id, status: 'cancelled', devicesSucceeded: 0, devicesFailed: 0 };
+  }
+
   await withAutomationRuntimeDb(() => seedAutomationDeviceResults(run.id, deviceRows));
   for (const device of deviceRows) {
     await seedDeviceAutomationActions(run.id, device, actions);
@@ -2859,13 +3013,15 @@ export async function executeConfigPolicyAutomationRun(
       completedAt: new Date(),
     }).where(and(eq(automationRuns.id, run.id), eq(automationRuns.status, 'running'))));
   }
-  const status: 'running' | 'completed' | 'failed' | 'partial' = hasNonterminalActions
-    ? 'running'
-    : devicesFailed === 0
-      ? 'completed'
-      : devicesSucceeded === 0
-        ? 'failed'
-        : 'partial';
+  const status: AutomationRunOutcomeStatus = actionOutcome.cancelled
+    ? 'cancelled'
+    : hasNonterminalActions
+      ? 'running'
+      : devicesFailed === 0
+        ? 'completed'
+        : devicesSucceeded === 0
+          ? 'failed'
+          : 'partial';
 
   return {
     runId: run.id,

--- a/apps/api/src/services/automationRuntime.ts
+++ b/apps/api/src/services/automationRuntime.ts
@@ -79,9 +79,14 @@ function recordAutomationRuntimeActionDispatch(
 }
 
 /**
- * #3525 W05 — the dispatch fence, read side. `FOR SHARE` on the run row, so a
- * concurrent `cancelAutomationRun` (which holds `FOR UPDATE`) either commits
- * before this and is seen, or waits for this statement.
+ * #3525 W05 — the dispatch fence, CHECK-BEFORE half.
+ *
+ * A cheap early exit, not the correctness guarantee: this runs on the pooled
+ * `db`, so the `FOR SHARE` lock lives only for the length of this one
+ * statement and is gone before the dispatch it guards begins. What it buys is
+ * that a job for a run cancelled earlier does no work at all. The guarantee
+ * that nothing is left RUNNING comes from `cancelDispatchIfRunCancelled`
+ * below — see the header of `automationRunCancellation.ts`.
  *
  * Throws `RunCancelledError`. Every dispatch-side caller either returns
  * quietly on it or lets it reach `executeAutomationRun`'s handler — it must
@@ -92,31 +97,52 @@ function assertRunNotCancelledInRuntime(runId: string): Promise<void> {
 }
 
 /**
+ * What the compensating cancel achieved for ONE racing dispatch.
+ *
+ * Deliberately not a boolean. The caller writes a line into the run log that
+ * an MSP tech reads, so "we asked" and "it stopped" and "we could not even
+ * ask" must not collapse into one value — that is precisely the dishonesty
+ * the whole cancellation design exists to prevent.
+ */
+type DispatchCompensation =
+  /** No race: the run is live, or the dispatch produced nothing stoppable. */
+  | 'not_needed'
+  /** Nothing is running any more: retracted, already terminal, or recovered. */
+  | 'settled'
+  /** A `script_cancel` is queued. The device has NOT confirmed. Not stopped. */
+  | 'requested'
+  /** We could not even ask. The script may still be running on the device. */
+  | 'failed';
+
+/**
  * The other half of the fence.
  *
- * The pre-dispatch check above cannot be held across the dispatch itself
- * (that would pin a pooled connection across a command insert and a WebSocket
- * send, five devices at a time). So there is a microsecond window in which a
- * cancel commits, its fan-out reads the executions table, and only THEN this
- * dispatcher's own execution row lands — invisible to that sweep and running
- * on the device.
+ * This is where the "nothing is left running" guarantee actually lives — NOT
+ * in the `FOR SHARE` check above, whose lock is released before the dispatch
+ * begins (it cannot be held across a command insert and a WebSocket send for
+ * five devices at a time without pinning the pool). So on every dispatch there
+ * is a window in which a cancel commits, its fan-out reads the executions
+ * table, and only THEN this dispatcher's own execution row lands — invisible
+ * to that sweep and running on the device.
  *
- * Re-reading the run after the dispatch closes it: if the run is cancelled by
- * now, the execution we just created is stopped here instead. Every execution
- * of a cancelled run is therefore either caught by the sweep or cancelled by
- * its own dispatcher.
+ * Re-reading the run after the dispatch has committed closes it, with no lock
+ * needed: whichever of {the cancel's sweep, this re-read} runs second sees the
+ * other's committed write. If the run is cancelled by now, the execution we
+ * just created is stopped here instead.
+ *
+ * Delete this and the race reopens.
  */
 async function cancelDispatchIfRunCancelled(
   runId: string,
   deviceId: string,
   result: ActionExecutionResult,
-): Promise<boolean> {
+): Promise<DispatchCompensation> {
   // Only a script execution can be stopped after the fact, so only a dispatch
   // that produced one pays for the extra read. `execute_command` and
   // deployments have no agent-side stop at all — they are reported to the
   // operator as uncancellable instead (automationRunCancellation.ts).
   const executionId = 'scriptExecutionId' in result.outcome ? result.outcome.scriptExecutionId : undefined;
-  if (!executionId) return false;
+  if (!executionId) return 'not_needed';
 
   const cancelled = await withAutomationRuntimeDb(async () => {
     const [row] = await db
@@ -126,7 +152,7 @@ async function cancelDispatchIfRunCancelled(
       .limit(1);
     return row?.status === 'cancelled';
   });
-  if (!cancelled) return false;
+  if (!cancelled) return 'not_needed';
 
   try {
     const { cancelScriptExecution, deliverCancelCommand } = await import('./scriptCancellation');
@@ -135,9 +161,42 @@ async function cancelDispatchIfRunCancelled(
       actorId: null,
       actorLabel: 'automation run cancellation',
     });
-    // POST-COMMIT delivery, same contract as every other cancel caller.
-    if (outcome.kind === 'cancelling' && !outcome.alreadyQueued) {
-      await deliverCancelCommand(outcome.cancelCommandId, outcome.deviceId);
+    switch (outcome.kind) {
+      case 'cancelling':
+        // POST-COMMIT delivery, same contract as every other cancel caller.
+        if (!outcome.alreadyQueued) {
+          await deliverCancelCommand(outcome.cancelCommandId, outcome.deviceId);
+        }
+        return 'requested';
+      // Retracted is a server-side PROOF; the other two mean the execution
+      // closed (or is closing) on its own evidence. Nothing is left running.
+      case 'retracted':
+      case 'recovered':
+      case 'already_terminal':
+      case 'idempotent':
+        return 'settled';
+      // The execution vanished, or has no paired script command. Absence is
+      // not proof that nothing is running — fail loud.
+      case 'not_found':
+      case 'inconsistent':
+        console.error('[automationRuntime] could not stop an execution dispatched into a cancelled run', {
+          runId,
+          deviceId,
+          executionId,
+          outcome: outcome.kind,
+        });
+        captureException(
+          new Error(`automation cancel compensation refused: ${outcome.kind}`),
+          undefined,
+          { runId, deviceId, executionId },
+        );
+        return 'failed';
+      default: {
+        // A new CancelOutcome variant must be classified deliberately rather
+        // than silently reported as a stop. This fails the build instead.
+        const unhandled: never = outcome;
+        throw new Error(`unhandled CancelOutcome kind: ${(unhandled as { kind: string }).kind}`);
+      }
     }
   } catch (err) {
     // Losing the compensation must not turn a cancelled run into a thrown
@@ -147,12 +206,31 @@ async function cancelDispatchIfRunCancelled(
       runId,
       deviceId,
       executionId,
-      error: err,
+      error: err instanceof Error ? err.message : String(err),
     });
     captureException(err, undefined, { runId, deviceId, executionId });
+    return 'failed';
   }
-  return true;
 }
+
+/** The run-log line for each compensation outcome. Never overstates. */
+const DISPATCH_COMPENSATION_LOG: Record<
+  Exclude<DispatchCompensation, 'not_needed'>,
+  { level: LogLevel; message: string }
+> = {
+  settled: {
+    level: 'warning',
+    message: 'Action dispatched into a run that was cancelled; the execution was stopped',
+  },
+  requested: {
+    level: 'warning',
+    message: 'Action dispatched into a run that was cancelled; a stop was requested but the device has not confirmed it',
+  },
+  failed: {
+    level: 'error',
+    message: 'Action dispatched into a run that was cancelled and the stop could NOT be requested; the script may still be running on the device',
+  },
+};
 
 /**
  * Ownership → org fan-out (#2133). An org-owned automation targets devices in
@@ -2306,9 +2384,11 @@ async function executeAutomationActionsInOrder(args: {
         }, device)));
         logs.push(result.log);
         await persistActionExecutionOutcome(args.runId, device.id, actionIndex, result);
-        if (await cancelDispatchIfRunCancelled(args.runId, device.id, result)) {
+        const compensation = await cancelDispatchIfRunCancelled(args.runId, device.id, result);
+        if (compensation !== 'not_needed') {
           cancelled = true;
-          logs.push(logEntry('Action dispatched into a run that was cancelled; the execution was stopped', 'warning', {
+          const line = DISPATCH_COMPENSATION_LOG[compensation];
+          logs.push(logEntry(line.message, line.level, {
             actionIndex,
             deviceId: device.id,
           }));
@@ -3037,4 +3117,9 @@ export const __testOnly = {
   buildActionExecutionContext,
   executeAction,
   executeAiTriageAction,
+  // #3525 W05 — the two halves of the dispatch fence. Exported so the
+  // compensating path (the ONLY thing standing between a mid-flight cancel and
+  // a script that keeps running) is provable without driving a full mocked run.
+  cancelDispatchIfRunCancelled,
+  executeAutomationActionsInOrder,
 };

--- a/apps/api/src/services/eventBus.ts
+++ b/apps/api/src/services/eventBus.ts
@@ -73,6 +73,9 @@ export type EventType =
   | 'automation.started'
   | 'automation.completed'
   | 'automation.failed'
+  // #3525 W05 — an operator stopped the run. Distinct from `failed`: nothing
+  // went wrong, so alerting keyed on automation.failed must not fire.
+  | 'automation.cancelled'
   // Policy events
   | 'policy.evaluated'
   | 'policy.violation'
@@ -579,6 +582,7 @@ export const EVENT_TYPES = {
   AUTOMATION_STARTED: 'automation.started' as const,
   AUTOMATION_COMPLETED: 'automation.completed' as const,
   AUTOMATION_FAILED: 'automation.failed' as const,
+  AUTOMATION_CANCELLED: 'automation.cancelled' as const,
   // Policy
   POLICY_EVALUATED: 'policy.evaluated' as const,
   POLICY_VIOLATION: 'policy.violation' as const,


### PR DESCRIPTION
Closes #4766

Wave 05 of #4761 (plan `docs/superpowers/plans/agent/2026-09-02-cancel-running-script-or-automation.md`). Depends on W02 (#4799), W03 (#4967), W04 (#4971) and W07 (#4990), all merged on `main`.

Automations had no cancel at all: `automation_run_status` was `running|completed|failed|partial`, `automation_device_result_status` had no `cancelled`, the run endpoints were GET-only, and — worst — **neither runner checked run status before seeding or dispatching**, so a BullMQ job picked up after an operator hit Stop ran the whole automation to completion.

## What changed

**Migration `2026-10-11-140300-automation-run-cancellation.sql`** — `ALTER TYPE … ADD VALUE IF NOT EXISTS 'cancelled'` on both enums (appended, matching the Drizzle declaration order so `db:check-drift` sees no phantom drift) plus `automation_runs.devices_cancelled integer NOT NULL DEFAULT 0`. No writes, no inner `BEGIN`, `breeze.scope` elected anyway. Verified idempotent by re-applying it against a live database (two `already exists, skipping` notices, exit 0).

**Cancellation-aware reconciliation** (`automationActionResults.ts`) — OD6-A. `cancelled` had been folded into the failed lane, so every stopped device was reported as an automation failure. It now has its own lane *after* the failure check (a real failure outranks a stop), `aggregateDeviceStatuses` returns `devicesCancelled`, and the device-row rewrite will not walk a proven-stopped device back to `pending`/`running`. A run stamped `cancelled` keeps counting its children home instead of freezing: `completed_at` is stamped by a `completed_at IS NULL`-guarded UPDATE, which is also the transition that publishes `automation.cancelled` exactly once. A cancelled run is never re-labelled `completed`.

**The dispatch fence** (`automationRunCancellation.ts`, wired into `automationRuntime.ts`) — `cancelAutomationRun` flips the run to `cancelled` under `FOR UPDATE`; every dispatch entry point calls `assertRunNotCancelled`, which reads that row `FOR SHARE`. Fence points: the top of both runners before `seedAutomationDeviceResults`, once per action in the dispatcher loop, and once per device before `executeAction`.

**The route** — `POST /automations/runs/:runId/cancel`, same guard quartet as every other mutating automation route (`requireScope` / `requireAutomationWrite` / `requireMfa()` / `requireValidRunId`), plus the partner-wide capability gate (OD7-A) and site scope on top. 404 for config-policy runs (OD10-B), 404 (never 403) cross-tenant, 409 for a run that already finished, 400 for an out-of-range `graceSeconds`. Response reports what the request *achieved*, never an assumed stop.

Also: `automation.cancelled` on the event bus, `automation.run.cancel` in the audit label map, and an OpenAPI path entry (`operationId: cancelAutomationRun`).

## Deviations from the plan — code is truth

1. **Migration slot.** Plan said `2026-10-07-100200`; that now sorts before shipped migrations. Used the briefed `…-140300`, then renamed `2026-10-10-…` → `2026-10-11-…` when `origin/main` gained `2026-10-11-000300` mid-branch and the pre-push guard caught it. The file is unmerged and idempotent, so renaming is safe.

2. **No `CORE_TENANT_EXPORT_POLICY` entry was needed, contrary to the brief.** `automation_runs` has **no `org_id`** and is deliberately absent from both `CORE_ORG_CASCADE_DELETE_ORDER` and the export registry (verified: `grep '"automation_runs"'` matches neither file). The export-policy contract only fires on columns of *registered* tables. `automation_run_device_results` **is** registered but only gained an enum value, not a column, so its column list is untouched. Proven, not assumed: `tenant-export-policy`, `tenantExportErasureRoundtrip`, `tenantCascade` and `rls-coverage` all pass (30 tests).

3. **The fence is check-before + compensate-after, not one lock held across the dispatch.** The plan's "atomic CAS" reads as holding the run lock across dispatch. That would pin a pooled connection across a `device_commands` insert, payload encryption and a WebSocket send, five devices at a time — the double-hold CLAUDE.md calls out, and a self-deadlock at pool exhaustion (`dispatchScriptToDevice` opens its own connections). Instead: `FOR SHARE` before dispatch as a cheap early exit, and **the actual guarantee comes from the check-after** — the runtime re-reads the run once the dispatch has committed and stops the execution itself if the run went `cancelled` meanwhile. Net guarantee, tested against real Postgres: **a SCRIPT EXECUTION of a cancelled run is either caught by the fan-out sweep or stopped by its own dispatcher**, and nothing new is dispatched after a cancel is visible. (`execute_command` and `deploy_software` have no agent-side stop and genuinely do run to completion — they are reported through `uncancellableActions`, never claimed stopped.)

4. **`requireAutomationWrite`, not an "automations execute" permission.** No `AUTOMATIONS_EXECUTE` exists in `packages/shared/src/constants/permissions.ts`; `automations:write` is the gate the trigger/enable/disable routes already carry.

5. **Only `pending` action rows are terminalised.** Queued/delivered/running rows have reached the device and close on their own evidence. This resolves the spec's own contradiction, and is what keeps the run from claiming a stop it cannot prove.

6. **A cancelled run keeps its `cancelled` label but still publishes `automation.failed` when a device genuinely failed.** The plan says nothing about the collision. Relabelling the run `failed` would page an MSP on every cancel whose SIGKILL exits nonzero; publishing only `automation.cancelled` would hide a real failure from failure alerting. Both events fire, on the same `completed_at IS NULL` transition so each fires once. There is no false-alarm cost because W03's closers stamp a *proven* post-cancel kill as `cancelled`, so a device still reading `failed` is a failure cancellation did not account for. Position formed in-session and confirmed by an independent Codex `xhigh` advisory, which recommended exactly this split (its option C) over both alternatives.

7. **`executionsStopped` + `executionsRequested`, not the plan's single `executionsCancelled`.** One number folding "we asked" into "it stopped" is the exact overclaim the honesty contract forbids — `executionsStopped` counts only server-side retractions (proven), `executionsRequested` counts stops sent but unconfirmed.

8. **A fourth outcome kind, `already_terminal`.** A run that finished on its own is a 409, not a relabel. The plan's return shape had no branch for it.

9. **`RunCancelledError` is not a failure.** `executeAutomationRun` returns `{status:'cancelled'}` on it rather than falling into `markAutomationRunFailedAfterError` (which would flip every seeded device row to `failed`) and rethrowing (which would make BullMQ retry a run an operator deliberately stopped). The per-device catch likewise records no failure.

10. **The post-cancel reconcile is best-effort.** By then the fence write, the terminalised rows and the queued `script_cancel` commands are all committed; rethrowing would turn a cancel that *succeeded* into a 500 telling the operator their stop failed. Logged + `captureException`; reconciliation is idempotent and re-runs on the next child result.

11. **`scriptCancellation` is imported lazily** from both `automationRunCancellation.ts` and `automationRuntime.ts` — eagerly it drags the `agentWs → commandQueue → configurationPolicy` chain into every partial-mock unit suite that imports the runtime (it broke six of them). Same pattern `automationRuntime.ts` already uses for `softwareDeployment`.

12. **One line outside the briefed file list:** `services/eventBus.ts` gains the `automation.cancelled` event type + constant. There is nowhere else to register it.

13. **Audit label is `automation.run.cancel`** (the audit action the route writes), which is what the plan specifies; the brief called it "the `automation.cancelled` label".

## Review round

`/pr-review-toolkit:review-pr` ran four reviewers in parallel (code, tests, silent-failure, comments). Five findings were confirmed and fixed in `cf0f2867f1`; nothing was dismissed as invalid:

- **`cancelDispatchIfRunCancelled` returned a bare `true`** whether it stopped the execution, merely asked, or failed — and the caller logged "the execution was stopped" for all three, into the run history an MSP tech reads. Now a `settled | requested | failed` tri-state with a distinct log line each; `not_found`/`inconsistent` are failures, not stops.
- **A cancelled run that genuinely failed never published `automation.failed`** — see deviation 6.
- **`executionsCancelled` conflated asked with stopped** — see deviation 7.
- **The fence comments claimed the `FOR SHARE` lock covers the dispatch.** It does not; it is released before the dispatch begins. Two reviewers found this independently. The comments now describe the real mechanism and say explicitly not to delete the check-after on the strength of the lock.
- **A run cancelled before any action row was seeded never got `completed_at`** (reconciliation returns early on zero action rows), so it read as permanently in progress — the single most likely cancel scenario. Fixed with a guarded `NOT EXISTS` stamp plus an integration test.

The test reviewer's headline gap — the compensation path had no test at all — is closed by `automationRuntime.cancelFence.test.ts`, **verified non-vacuous by mutation**: renaming `outcome.scriptExecutionId` reddens 5 tests, deleting the per-device fence reddens 2.

One reviewer observation left as intended behaviour: cancelling every execution of a run individually (never touching the run itself) now flips the run to `cancelled`. That is OD6-A working as designed — before this wave it reported `failed`.

## Verification

| Check | Result |
|---|---|
| `vitest run src/services/automation… src/routes/automations src/routes/devices/events src/services/scriptCancellation src/jobs/automationWorker src/services/eventBus src/openapi src/db/autoMigrate src/db/migrationRlsScope src/__tests__/partner-wide-write-coverage` | **558 passed / 32 files** |
| Integration (real PG): `automationRunCancelFence`, `automationTerminalReconciliation`, `automationActionResults` | **28 passed / 5 files** (with the two export suites below) |
| Integration (real PG): `tenant-export-policy`, `tenantExportErasureRoundtrip`, `tenantCascade`, `rls-coverage` | **30 passed / 7 files** |
| `npx tsc --noEmit` | clean |
| `pnpm lint` | clean |
| `pnpm db:check-drift` | no drift (678 migrations match the ledger) |
| Enum order in a live DB vs the Drizzle declaration | identical for both enums |
| Migration re-applied against a live DB | no-op, exit 0 |

Red-first throughout: the aggregation/reconciliation suite failed 9/11 before the change, `automationRunCancellation.test.ts` failed to import before the module existed, and the five route tests 404'd before the route existed.

## Not verified

- **No browser/UI verification.** W06 owns `AutomationRunHistory.tsx` and runs in parallel; this PR deliberately touches no `apps/web` file, so the new route has no caller yet and there is no user-visible surface to click.
- **No real agent.** The integration fence test resolves cancellation through the *retraction* path (the paired `script` command was still `pending`), which needs no device. The `script_cancel` delivery + agent-ack path is W04's, covered by its own suites — untouched here.
- **The `automation.failed`-alongside-`automation.cancelled` decision is reasoned, not measured.** The claim that a proven post-cancel kill lands as `cancelled` (and so never reaches this branch) is read off W03's closers, not observed on a real device under a real SIGKILL. If it turns out otherwise, this pages on cancels. Worth watching after the first release that ships a cancel button.
- **Not run under load.** The fence is proven correct for two concurrent transactions, not measured for lock contention on a large fleet run (five-device concurrency × N actions all take `FOR SHARE` on one row). Reads only, so contention should be nil, but this is reasoning, not a measurement.
- **`execute_command` and `deploy_software` remain genuinely uncancellable.** They are reported in `uncancellableActions`, not stopped. Whether the UI surfaces that honestly is W06's call.
- **Config-policy runs are out of scope** (OD10-B) and return 404. The underlying RLS gap that makes partner-owned policy runs invisible is unchanged and still wants its own issue.
- **Reconcile's extra read.** The non-downgrade clamp adds one indexed `automation_run_device_results` read per reconcile. Not benchmarked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WS6Bjz1CYF5HbRMjgHF8P4
