### PR TITLE
fix(web): give the AI-agent inert badge its own accessible label prefix (#4170 follow-up)

### DIFF
--- a/apps/web/src/components/settings/AiAgentsPage.test.tsx
+++ b/apps/web/src/components/settings/AiAgentsPage.test.tsx
@@ -167,7 +167,13 @@ describe('AiAgentsPage', () => {
     });
     render(<AiAgentsPage />);
 
-    expect(await screen.findByTestId('ai-agent-inert-badge-a2')).toBeInTheDocument();
+    const badge = await screen.findByTestId('ai-agent-inert-badge-a2');
+    expect(badge).toBeInTheDocument();
+    // Its own label prefix — NOT chipLabels.running, which the adjacent
+    // enabled/mode badge already uses; a screen reader would otherwise hear
+    // "Status: Running" then "Status: Inactive" for the same row (#5014 review).
+    expect(badge).toHaveAttribute('aria-label', 'Partner baseline: Inactive');
+    expect(screen.getByTestId('ai-agent-row-a2').querySelectorAll('[aria-label^="Status:"]')).toHaveLength(1);
   });
 
   it('does not badge an org-owned agent whose kind has an active partner-wide baseline', async () => {

--- a/apps/web/src/components/settings/AiAgentsPage.tsx
+++ b/apps/web/src/components/settings/AiAgentsPage.tsx
@@ -515,7 +515,7 @@ export default function AiAgentsPage() {
                     <span
                       className={badgeClass('warning', { size: 'sm' })}
                       aria-describedby={inertHintId}
-                      aria-label={`${t('aiAgentsPage.chipLabels.running')}: ${t('aiAgentsPage.inertBadge.label')}`}
+                      aria-label={`${t('aiAgentsPage.chipLabels.baseline')}: ${t('aiAgentsPage.inertBadge.label')}`}
                       data-testid={`ai-agent-inert-badge-${agent.id}`}
                     >
                       {t('aiAgentsPage.inertBadge.label')}

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -1575,6 +1575,7 @@
       "ownership": "Zugehörigkeit",
       "mode": "Modus",
       "running": "Status",
+      "baseline": "Partner-Basis",
       "lastRunStatus": "Ergebnis des letzten Laufs"
     },
     "inertBadge": {

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -1575,6 +1575,7 @@
       "ownership": "Ownership",
       "mode": "Mode",
       "running": "Status",
+      "baseline": "Partner baseline",
       "lastRunStatus": "Last run outcome"
     },
     "inertBadge": {

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -1575,6 +1575,7 @@
       "ownership": "Propiedad",
       "mode": "Modo",
       "running": "Estado",
+      "baseline": "Base del partner",
       "lastRunStatus": "Resultado de la última ejecución"
     },
     "inertBadge": {

--- a/apps/web/src/locales/fr-CA/settings.json
+++ b/apps/web/src/locales/fr-CA/settings.json
@@ -1575,6 +1575,7 @@
       "ownership": "Propriété",
       "mode": "Mode",
       "running": "Statut",
+      "baseline": "Référence du partenaire",
       "lastRunStatus": "Résultat de la dernière exécution"
     },
     "inertBadge": {

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -1575,6 +1575,7 @@
       "ownership": "Propriété",
       "mode": "Mode",
       "running": "Statut",
+      "baseline": "Référence du partenaire",
       "lastRunStatus": "Résultat de la dernière exécution"
     },
     "inertBadge": {

--- a/apps/web/src/locales/it-IT/settings.json
+++ b/apps/web/src/locales/it-IT/settings.json
@@ -1575,6 +1575,7 @@
       "ownership": "Proprietà",
       "mode": "Modalità",
       "running": "Stato",
+      "baseline": "Base del partner",
       "lastRunStatus": "Esito dell’ultima esecuzione"
     },
     "inertBadge": {

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -1575,6 +1575,7 @@
       "ownership": "Propriedade",
       "mode": "Modo",
       "running": "Status",
+      "baseline": "Base do parceiro",
       "lastRunStatus": "Resultado da última execução"
     },
     "inertBadge": {

--- a/apps/web/src/locales/tr-TR/settings.json
+++ b/apps/web/src/locales/tr-TR/settings.json
@@ -1575,6 +1575,7 @@
       "ownership": "Sahiplik",
       "mode": "Mod",
       "running": "Durum",
+      "baseline": "Partner temeli",
       "lastRunStatus": "Son çalıştırma sonucu"
     },
     "inertBadge": {


### PR DESCRIPTION
Follow-up from the post-merge review of #5014.

The "Inactive" (no partner baseline) badge reused `chipLabels.running` ("Status") as its `aria-label` prefix — the same prefix the adjacent enabled/mode badge uses — so a screen reader announced "Status: Running" then "Status: Inactive" for the same row. Every other chip has its own prefix key. Adds `aiAgentsPage.chipLabels.baseline` ("Partner baseline") to all 8 locales and switches the badge to it.

Test: existing inert-badge case now asserts the exact `aria-label` and that a row carries exactly one `Status:` label. AiAgentsPage 73/73; locale/i18n suites 167/167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUsfUH7smCCDiSVrGFTasC