### PR TITLE
feat(web): stop a running script or automation from the UI (#4761 W06)

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -56,6 +56,7 @@ export default defineConfig({
               items: [
                 { slug: 'features/remote-access' },
                 { slug: 'features/scripts' },
+                { slug: 'scripts/stopping-a-running-script' },
                 { slug: 'features/script-ai' },
                 { slug: 'features/ai-agents' },
                 { slug: 'features/ai-impact' },

--- a/apps/docs/src/content/docs/agents/commands.mdx
+++ b/apps/docs/src/content/docs/agents/commands.mdx
@@ -522,7 +522,21 @@ When `runAs` is set to a username (or `"user"`), the agent forwards the script t
 
 | Param | Type | Required | Description |
 |---|---|---|---|
-| `executionId` | string | Yes | Execution ID to cancel |
+| `executionId` | string | Yes | The **original `script` command's id** (`device_commands.id`), not the `script_executions` row id. The agent keys its in-memory running-script map on the command id, so sending the execution row id here is a silent no-op against the deployed fleet. |
+| `scriptExecutionId` | string | No | The `script_executions` row id, sent alongside `executionId` for server-side bookkeeping. Older agents (pre-#3525) ignore this field. |
+| `graceSeconds` | int | No | Grace period before escalating to a hard kill. `0`-`30`, default `5`. Ignored entirely on Windows — see below. |
+
+Result (always a SUCCESS result, even when the process was not stopped):
+
+```json
+{ "executionId": "<the original executionId echoed back>", "outcome": "terminated" | "not_found" | "kill_failed", "cancelled": true | false }
+```
+
+`cancelled` is `true` only for `outcome: "terminated"` — the server only ever marks `script_executions.status = 'cancelled'` on this proof. `not_found` most often means the script had already finished and its result is in flight, not that the stop succeeded; `kill_failed` means the device tried and could not kill the process.
+
+<Aside type="caution">
+**No graceful phase on Windows.** Unix sends `SIGTERM`, waits up to `graceSeconds`, then `SIGKILL`s the process group. Windows skips straight to `TerminateJobObject` regardless of `graceSeconds`, because `GenerateConsoleCtrlEvent` requires a console shared with the target process and script children are launched with `CREATE_NO_WINDOW` — there is no console to signal.
+</Aside>
 
 ### `script_list_running`
 

--- a/apps/docs/src/content/docs/scripts/stopping-a-running-script.mdx
+++ b/apps/docs/src/content/docs/scripts/stopping-a-running-script.mdx
@@ -1,0 +1,54 @@
+---
+title: Stopping a Running Script
+description: What the Stop button does, what an unconfirmed stop means, and what Breeze cannot promise to kill.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Every execution row on a script's execution history — and the execution detail panel — offers a **Stop** action while the script is `Pending`, `Queued`, or `Running`. This page explains what it does, what "Stopping…" means while you wait, and what it does not promise.
+
+## Where to find it
+
+Open a script's execution history (or click into a single execution's details) and look for the **Stop** button next to any row that is still pending, queued, or running. It only appears if your role has the `scripts:execute` permission — without it the button is hidden, not shown disabled.
+
+## What happens when you click Stop
+
+1. Breeze sends the device a request to end the process, with a short **grace period** (5 seconds by default).
+2. The row's status changes to **Stopping…** immediately. This is a request in flight, not a confirmed outcome.
+3. On most platforms the agent asks the process to exit gracefully (`SIGTERM` on macOS/Linux) and waits out the grace period before forcing it closed (`SIGKILL`).
+4. Once the device reports back, the row settles into its final state — see below.
+
+**Force stop** skips step 3 entirely and kills the process immediately, with no grace period. Use it when you don't need the script to clean up after itself, or when a normal Stop has already timed out.
+
+<Aside type="note">
+On Windows, there is no graceful phase at all — Force stop and a normal Stop behave the same way. Windows scripts run without a console window, so the agent cannot ask them to exit cleanly; it terminates the whole process tree directly.
+</Aside>
+
+## Reading the outcome
+
+A stop request is not a guarantee. Breeze only ever marks an execution **Cancelled** once the device has actually proven the process is gone — either because it caught the process before the agent even started it, or because the agent confirmed the kill. Every other outcome is reported honestly rather than assumed:
+
+| What you see | What it means |
+|---|---|
+| **Cancelled** | The stop was confirmed. The process is gone. |
+| **Completed / Failed / Timed out — your stop request arrived too late** | The script finished on its own before the stop could take effect. The row shows its real outcome, not a claimed cancellation. |
+| **Stop failed — the device could not stop the process** | The agent tried and could not kill it (for example, a permission error). The script may still be running. |
+
+An execution that never reports back — because the device went offline, or an older agent didn't understand the request — settles the same way: Breeze does not claim a stop it cannot prove.
+
+<Aside type="caution">
+Older agents (deployed before this feature shipped) don't recognize the stop command at all. Devices on an outdated agent version will answer "unknown command," which Breeze records as an unconfirmed stop rather than a failure — the script itself is unaffected either way.
+</Aside>
+
+## What Stop does not cover
+
+Stop (and Force stop) terminate the script process and its normal child processes. They do **not** reach:
+
+- Processes the script deliberately **detaches** from itself, such as one launched with `nohup`, `disown`, or `systemd-run --scope`.
+- A **scheduled task, cron job, or service** the script registers as a side effect — once created, that's an independent unit the operating system manages on its own.
+
+If a script needs guaranteed cleanup on cancellation, write that cleanup into the script itself (for example, trapping `SIGTERM`) rather than relying on Stop to reach into work it has already handed off elsewhere.
+
+## Automation runs
+
+An automation run that includes script actions can be cancelled as a whole from the run history panel — see [Automations](/features/automations/). Cancelling a run stops every script execution it is still waiting on, the same way Stop does for a single execution. Actions that don't produce a script execution (a raw device command, or a software deployment already in progress) are reported separately as **could not be stopped**, since the run has no honest way to prove they ended.

--- a/apps/docs/src/content/docs/scripts/stopping-a-running-script.mdx
+++ b/apps/docs/src/content/docs/scripts/stopping-a-running-script.mdx
@@ -37,6 +37,10 @@ A stop request is not a guarantee. Breeze only ever marks an execution **Cancell
 An execution that never reports back — because the device went offline, or an older agent didn't understand the request — settles the same way: Breeze does not claim a stop it cannot prove.
 
 <Aside type="caution">
+The distinctions above ("too late", "stop failed") depend on the execution list carrying its stop outcome end to end — a piece of plumbing still being finished. Until it lands, an execution the device could not confirm may briefly read as a plain status instead of the more specific copy described here; it never reads as a false **Cancelled**.
+</Aside>
+
+<Aside type="caution">
 Older agents (deployed before this feature shipped) don't recognize the stop command at all. Devices on an outdated agent version will answer "unknown command," which Breeze records as an unconfirmed stop rather than a failure — the script itself is unaffected either way.
 </Aside>
 

--- a/apps/web/src/components/ai-risk/tierConfig.ts
+++ b/apps/web/src/components/ai-risk/tierConfig.ts
@@ -209,6 +209,10 @@ export const TIER_DEFINITIONS: TierDefinition[] = [
       // Remote Access & Control
       { name: 'execute_command (kill_process/start_service/stop_service/restart_service/file_read/list_services/event_logs_query)', description: 'Mutating system commands, file reads, and commands that can return unredacted credential/PII-bearing content (service binary paths, raw event log messages)', category: 'Remote Access & Control' },
       { name: 'run_script', description: 'Run scripts on up to 10 devices', category: 'Remote Access & Control' },
+      // #4767/#4990 — the cancel tool requests a stop on an in-flight script
+      // execution; flagged as missing from this registry when the API side
+      // (script_cancel command dispatch) shipped.
+      { name: 'cancel_script_execution', description: 'Request a stop on a running script execution', category: 'Remote Access & Control' },
       { name: 'computer_control', description: 'Send input actions to device', category: 'Remote Access & Control' },
       { name: 'create_remote_session', description: 'Create remote terminal or file session', category: 'Remote Access & Control' },
       { name: 'take_screenshot', description: 'Capture device screenshot', category: 'Remote Access & Control' },

--- a/apps/web/src/components/ai-risk/tierConfig.ts
+++ b/apps/web/src/components/ai-risk/tierConfig.ts
@@ -209,9 +209,10 @@ export const TIER_DEFINITIONS: TierDefinition[] = [
       // Remote Access & Control
       { name: 'execute_command (kill_process/start_service/stop_service/restart_service/file_read/list_services/event_logs_query)', description: 'Mutating system commands, file reads, and commands that can return unredacted credential/PII-bearing content (service binary paths, raw event log messages)', category: 'Remote Access & Control' },
       { name: 'run_script', description: 'Run scripts on up to 10 devices', category: 'Remote Access & Control' },
-      // #4767/#4990 — the cancel tool requests a stop on an in-flight script
-      // execution; flagged as missing from this registry when the API side
-      // (script_cancel command dispatch) shipped.
+      // #4767 — the cancel tool requests a stop on an in-flight script
+      // execution. Noted as missing from this registry in #4990's PR body
+      // when the API side (script_cancel command dispatch) shipped; there is
+      // no automated check that catches the next tool this registry misses.
       { name: 'cancel_script_execution', description: 'Request a stop on a running script execution', category: 'Remote Access & Control' },
       { name: 'computer_control', description: 'Send input actions to device', category: 'Remote Access & Control' },
       { name: 'create_remote_session', description: 'Create remote terminal or file session', category: 'Remote Access & Control' },

--- a/apps/web/src/components/automations/AutomationRunHistory.cancel.test.tsx
+++ b/apps/web/src/components/automations/AutomationRunHistory.cancel.test.tsx
@@ -7,14 +7,21 @@ import type { Permission } from '@/stores/auth';
 
 const { fetchWithAuthMock } = vi.hoisted(() => ({ fetchWithAuthMock: vi.fn() }));
 const { showToastMock } = vi.hoisted(() => ({ showToastMock: vi.fn() }));
+const { navigateToMock } = vi.hoisted(() => ({ navigateToMock: vi.fn() }));
 
 vi.mock('../../stores/auth', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../stores/auth')>();
   return { ...actual, fetchWithAuth: fetchWithAuthMock };
 });
 vi.mock('../shared/Toast', () => ({ showToast: showToastMock }));
+vi.mock('@/lib/navigation', () => ({ navigateTo: navigateToMock }));
 
-const withScriptsExecute: Permission[] = [{ resource: 'scripts', action: 'execute' }];
+// The cancel-run route (POST /automations/runs/:runId/cancel,
+// apps/api/src/routes/automations.ts) is gated on requireAutomationWrite
+// (automations:write) — NOT scripts:execute, which gates the sibling
+// execution-level cancel route. See the matching comment in
+// AutomationRunHistory.tsx.
+const withAutomationsWrite: Permission[] = [{ resource: 'automations', action: 'write' }];
 
 function makeRun(overrides: Partial<AutomationRun> = {}): AutomationRun {
   return {
@@ -43,20 +50,33 @@ describe('Cancel run affordance', () => {
   beforeEach(() => {
     fetchWithAuthMock.mockReset();
     showToastMock.mockReset();
+    navigateToMock.mockReset();
   });
 
-  it('offers Cancel run on a running run with scripts:execute', () => {
-    render(<AutomationRunHistory runs={[makeRun()]} isOpen onClose={() => {}} permissions={withScriptsExecute} />);
+  it('offers Cancel run on a running run with automations:write', () => {
+    render(<AutomationRunHistory runs={[makeRun()]} isOpen onClose={() => {}} permissions={withAutomationsWrite} />);
     expect(screen.getByTestId('cancel-run')).toBeInTheDocument();
   });
 
   it('is absent for a non-running run', () => {
-    render(<AutomationRunHistory runs={[makeRun({ status: 'success' })]} isOpen onClose={() => {}} permissions={withScriptsExecute} />);
+    render(<AutomationRunHistory runs={[makeRun({ status: 'success' })]} isOpen onClose={() => {}} permissions={withAutomationsWrite} />);
     expect(screen.queryByTestId('cancel-run')).toBeNull();
   });
 
-  it('is hidden without scripts:execute', () => {
+  it('is hidden without automations:write', () => {
     render(<AutomationRunHistory runs={[makeRun()]} isOpen onClose={() => {}} permissions={[]} />);
+    expect(screen.queryByTestId('cancel-run')).toBeNull();
+  });
+
+  it('is hidden with only scripts:execute — the two permissions are not interchangeable', () => {
+    render(
+      <AutomationRunHistory
+        runs={[makeRun()]}
+        isOpen
+        onClose={() => {}}
+        permissions={[{ resource: 'scripts', action: 'execute' }]}
+      />,
+    );
     expect(screen.queryByTestId('cancel-run')).toBeNull();
   });
 
@@ -66,7 +86,7 @@ describe('Cancel run affordance', () => {
         runs={[makeRun({ ownerScope: 'partner' })]}
         isOpen
         onClose={() => {}}
-        permissions={withScriptsExecute}
+        permissions={withAutomationsWrite}
         canManagePartnerWide={false}
       />,
     );
@@ -80,7 +100,7 @@ describe('Cancel run affordance', () => {
         runs={[makeRun({ ownerScope: 'partner' })]}
         isOpen
         onClose={() => {}}
-        permissions={withScriptsExecute}
+        permissions={withAutomationsWrite}
         canManagePartnerWide={true}
       />,
     );
@@ -91,12 +111,13 @@ describe('Cancel run affordance', () => {
     fetchWithAuthMock.mockResolvedValue(
       jsonResponse({
         success: true,
+        run: { id: 'run-1', status: 'cancelled' },
         executionsCancelled: 3,
         uncancellableActions: [{ actionIndex: 0, actionType: 'execute_command', reason: 'no_execution_row' }],
       }),
     );
     const user = userEvent.setup();
-    render(<AutomationRunHistory runs={[makeRun()]} isOpen onClose={() => {}} permissions={withScriptsExecute} />);
+    render(<AutomationRunHistory runs={[makeRun()]} isOpen onClose={() => {}} permissions={withAutomationsWrite} />);
 
     await user.click(screen.getByTestId('cancel-run'));
     await user.click(screen.getByTestId('confirm-cancel-run'));
@@ -107,12 +128,48 @@ describe('Cancel run affordance', () => {
     expect(fetchWithAuthMock).toHaveBeenCalledWith('/automations/runs/run-1/cancel', expect.objectContaining({ method: 'POST' }));
   });
 
+  it('renders no uncancellable-actions banner when the cancel fully succeeded', async () => {
+    fetchWithAuthMock.mockResolvedValue(
+      jsonResponse({ success: true, run: { id: 'run-1', status: 'cancelled' }, executionsCancelled: 4, uncancellableActions: [] }),
+    );
+    const user = userEvent.setup();
+    render(<AutomationRunHistory runs={[makeRun()]} isOpen onClose={() => {}} permissions={withAutomationsWrite} />);
+
+    await user.click(screen.getByTestId('cancel-run'));
+    await user.click(screen.getByTestId('confirm-cancel-run'));
+
+    await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalled());
+    expect(screen.queryByTestId('uncancellable-actions')).toBeNull();
+  });
+
+  it('calls onRunCancelled with the run id after a successful cancel, so the host page can refresh', async () => {
+    fetchWithAuthMock.mockResolvedValue(
+      jsonResponse({ success: true, run: { id: 'run-1', status: 'cancelled' }, executionsCancelled: 4, uncancellableActions: [] }),
+    );
+    const onRunCancelled = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <AutomationRunHistory
+        runs={[makeRun()]}
+        isOpen
+        onClose={() => {}}
+        permissions={withAutomationsWrite}
+        onRunCancelled={onRunCancelled}
+      />,
+    );
+
+    await user.click(screen.getByTestId('cancel-run'));
+    await user.click(screen.getByTestId('confirm-cancel-run'));
+
+    await waitFor(() => expect(onRunCancelled).toHaveBeenCalledWith('run-1'));
+  });
+
   it('a 403 partner-wide denial surfaces a toast rather than a silent no-op', async () => {
     fetchWithAuthMock.mockResolvedValue(
       jsonResponse({ error: 'Modifying a partner-wide policy requires full partner org access (orgAccess must be "all")' }, 403),
     );
     const user = userEvent.setup();
-    render(<AutomationRunHistory runs={[makeRun()]} isOpen onClose={() => {}} permissions={withScriptsExecute} />);
+    render(<AutomationRunHistory runs={[makeRun()]} isOpen onClose={() => {}} permissions={withAutomationsWrite} />);
 
     await user.click(screen.getByTestId('cancel-run'));
     await user.click(screen.getByTestId('confirm-cancel-run'));
@@ -122,13 +179,29 @@ describe('Cancel run affordance', () => {
     });
   });
 
+  it('a 401 redirects to login rather than silently no-opping', async () => {
+    fetchWithAuthMock.mockResolvedValue(jsonResponse({ error: 'Unauthorized' }, 401));
+    const user = userEvent.setup();
+    render(<AutomationRunHistory runs={[makeRun()]} isOpen onClose={() => {}} permissions={withAutomationsWrite} />);
+
+    await user.click(screen.getByTestId('cancel-run'));
+    await user.click(screen.getByTestId('confirm-cancel-run'));
+
+    await waitFor(() => {
+      expect(navigateToMock).toHaveBeenCalledWith('/login', { replace: true });
+    });
+    // A 401 is session-expiry, not a normal error — no redundant toast on
+    // top of the redirect (runAction's own documented contract).
+    expect(showToastMock).not.toHaveBeenCalled();
+  });
+
   it('renders devicesCancelled separately from succeeded and failed', () => {
     render(
       <AutomationRunHistory
         runs={[makeRun({ status: 'cancelled', devicesCancelled: 2, devicesSuccess: 1, devicesFailed: 1 })]}
         isOpen
         onClose={() => {}}
-        permissions={withScriptsExecute}
+        permissions={withAutomationsWrite}
       />,
     );
     expect(screen.getByText(/2 cancelled/i)).toBeInTheDocument();

--- a/apps/web/src/components/automations/AutomationRunHistory.cancel.test.tsx
+++ b/apps/web/src/components/automations/AutomationRunHistory.cancel.test.tsx
@@ -1,0 +1,136 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import '@/lib/i18n';
+import AutomationRunHistory, { type AutomationRun } from './AutomationRunHistory';
+import type { Permission } from '@/stores/auth';
+
+const { fetchWithAuthMock } = vi.hoisted(() => ({ fetchWithAuthMock: vi.fn() }));
+const { showToastMock } = vi.hoisted(() => ({ showToastMock: vi.fn() }));
+
+vi.mock('../../stores/auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../stores/auth')>();
+  return { ...actual, fetchWithAuth: fetchWithAuthMock };
+});
+vi.mock('../shared/Toast', () => ({ showToast: showToastMock }));
+
+const withScriptsExecute: Permission[] = [{ resource: 'scripts', action: 'execute' }];
+
+function makeRun(overrides: Partial<AutomationRun> = {}): AutomationRun {
+  return {
+    id: 'run-1',
+    automationId: 'auto-1',
+    automationName: 'Nightly patch',
+    triggeredBy: 'manual',
+    startedAt: '2026-07-08T00:00:00.000Z',
+    completedAt: undefined,
+    status: 'running',
+    devicesTotal: 4,
+    devicesSuccess: 1,
+    devicesFailed: 1,
+    devicesSkipped: 0,
+    deviceResults: [],
+    logs: [],
+    ...overrides,
+  };
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { status });
+}
+
+describe('Cancel run affordance', () => {
+  beforeEach(() => {
+    fetchWithAuthMock.mockReset();
+    showToastMock.mockReset();
+  });
+
+  it('offers Cancel run on a running run with scripts:execute', () => {
+    render(<AutomationRunHistory runs={[makeRun()]} isOpen onClose={() => {}} permissions={withScriptsExecute} />);
+    expect(screen.getByTestId('cancel-run')).toBeInTheDocument();
+  });
+
+  it('is absent for a non-running run', () => {
+    render(<AutomationRunHistory runs={[makeRun({ status: 'success' })]} isOpen onClose={() => {}} permissions={withScriptsExecute} />);
+    expect(screen.queryByTestId('cancel-run')).toBeNull();
+  });
+
+  it('is hidden without scripts:execute', () => {
+    render(<AutomationRunHistory runs={[makeRun()]} isOpen onClose={() => {}} permissions={[]} />);
+    expect(screen.queryByTestId('cancel-run')).toBeNull();
+  });
+
+  it('is hidden for a partner-owned run without partner-wide management, with a tooltip explaining why', () => {
+    render(
+      <AutomationRunHistory
+        runs={[makeRun({ ownerScope: 'partner' })]}
+        isOpen
+        onClose={() => {}}
+        permissions={withScriptsExecute}
+        canManagePartnerWide={false}
+      />,
+    );
+    expect(screen.queryByTestId('cancel-run')).toBeNull();
+    expect(screen.getByTestId('cancel-run-partner-tooltip')).toBeInTheDocument();
+  });
+
+  it('is offered for a partner-owned run when the caller can manage partner-wide state', () => {
+    render(
+      <AutomationRunHistory
+        runs={[makeRun({ ownerScope: 'partner' })]}
+        isOpen
+        onClose={() => {}}
+        permissions={withScriptsExecute}
+        canManagePartnerWide={true}
+      />,
+    );
+    expect(screen.getByTestId('cancel-run')).toBeInTheDocument();
+  });
+
+  it('surfaces uncancellable actions rather than claiming the run stopped', async () => {
+    fetchWithAuthMock.mockResolvedValue(
+      jsonResponse({
+        success: true,
+        executionsCancelled: 3,
+        uncancellableActions: [{ actionIndex: 0, actionType: 'execute_command', reason: 'no_execution_row' }],
+      }),
+    );
+    const user = userEvent.setup();
+    render(<AutomationRunHistory runs={[makeRun()]} isOpen onClose={() => {}} permissions={withScriptsExecute} />);
+
+    await user.click(screen.getByTestId('cancel-run'));
+    await user.click(screen.getByTestId('confirm-cancel-run'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/could not be stopped/i)).toBeInTheDocument();
+    });
+    expect(fetchWithAuthMock).toHaveBeenCalledWith('/automations/runs/run-1/cancel', expect.objectContaining({ method: 'POST' }));
+  });
+
+  it('a 403 partner-wide denial surfaces a toast rather than a silent no-op', async () => {
+    fetchWithAuthMock.mockResolvedValue(
+      jsonResponse({ error: 'Modifying a partner-wide policy requires full partner org access (orgAccess must be "all")' }, 403),
+    );
+    const user = userEvent.setup();
+    render(<AutomationRunHistory runs={[makeRun()]} isOpen onClose={() => {}} permissions={withScriptsExecute} />);
+
+    await user.click(screen.getByTestId('cancel-run'));
+    await user.click(screen.getByTestId('confirm-cancel-run'));
+
+    await waitFor(() => {
+      expect(showToastMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+    });
+  });
+
+  it('renders devicesCancelled separately from succeeded and failed', () => {
+    render(
+      <AutomationRunHistory
+        runs={[makeRun({ status: 'cancelled', devicesCancelled: 2, devicesSuccess: 1, devicesFailed: 1 })]}
+        isOpen
+        onClose={() => {}}
+        permissions={withScriptsExecute}
+      />,
+    );
+    expect(screen.getByText(/2 cancelled/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/automations/AutomationRunHistory.tsx
+++ b/apps/web/src/components/automations/AutomationRunHistory.tsx
@@ -14,7 +14,8 @@ import {
   Terminal,
   Calendar,
   Timer,
-  Square
+  Square,
+  Info
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { formatDateTime } from '@/lib/dateTimeFormat';
@@ -22,8 +23,9 @@ import { formatNumber } from '@/lib/i18n/format';
 import { hasPermission } from '@/lib/permissions';
 import type { Permission } from '@/stores/auth';
 import { fetchWithAuth } from '@/stores/auth';
-import { runAction, ActionError } from '@/lib/runAction';
+import { runAction, handleActionError } from '@/lib/runAction';
 import { ConfirmDialog } from '@/components/shared/ConfirmDialog';
+import { navigateTo } from '@/lib/navigation';
 
 type ScriptsT = TFunction<'scripts'>;
 
@@ -114,8 +116,12 @@ type AutomationRunHistoryProps = {
   timezone?: string;
   /** When provided, expanding a run lazily fetches its per-device breakdown. */
   onLoadRunDetail?: RunDetailLoader;
-  // #4767 — UX-only gate mirroring the API's own requirePermission(scripts:execute)
-  // on the cancel route. Cancel run is HIDDEN, never merely disabled, without it.
+  // #4767 — UX-only gate mirroring the cancel route's own
+  // requireAutomationWrite (automations:write) — see the requirePermission
+  // call in apps/api/src/routes/automations.ts's POST /runs/:runId/cancel.
+  // NOT scripts:execute, which gates the separate, execution-level cancel
+  // route ExecutionHistory/ExecutionDetails call. Cancel run is HIDDEN,
+  // never merely disabled, without it.
   permissions?: Permission[];
   // #4767 — mirrors canManagePartnerWidePolicies(auth) server-side (OD7-A): an
   // org-scoped operator may still cancel individual executions on their own
@@ -347,23 +353,37 @@ function RunItem({
   const [uncancellableActions, setUncancellableActions] = useState<UncancellableAction[] | null>(null);
 
   const isRunning = run.status === 'running';
-  const canExecuteScripts = hasPermission(permissions, 'scripts', 'execute');
+  // #4767/#4766 (W05, apps/api/src/routes/automations.ts) — the route this
+  // button calls is gated on requireAutomationWrite (automations:write), NOT
+  // scripts:execute. scripts:execute stays the gate on the SIBLING
+  // execution-level route (POST /scripts/executions/:id/cancel) that
+  // ExecutionHistory/ExecutionDetails call — the two are easy to conflate
+  // but they are different permissions on different routes.
+  const canManageAutomations = hasPermission(permissions, 'automations', 'write');
   const isPartnerOwned = run.ownerScope === 'partner';
-  const canCancelRun = isRunning && canExecuteScripts && (!isPartnerOwned || canManagePartnerWide);
-  const cancelHiddenByPartnerScope = isRunning && canExecuteScripts && isPartnerOwned && !canManagePartnerWide;
+  const canCancelRun = isRunning && canManageAutomations && (!isPartnerOwned || canManagePartnerWide);
+  const cancelHiddenByPartnerScope = isRunning && canManageAutomations && isPartnerOwned && !canManagePartnerWide;
 
   const handleConfirmCancelRun = async () => {
     setCancelling(true);
     try {
-      const result = await runAction<{ executionsCancelled: number; uncancellableActions?: UncancellableAction[] }>({
+      // Real shape from apps/api/src/routes/automations.ts's
+      // POST /runs/:runId/cancel (#4766/W05): { success, run: {id, status},
+      // alreadyCancelling, actionsCancelled, executionsCancelled, executions,
+      // uncancellableActions }.
+      const result = await runAction<{
+        executionsCancelled: number;
+        uncancellableActions?: UncancellableAction[];
+      }>({
         request: () => fetchWithAuth(`/automations/runs/${run.id}/cancel`, { method: 'POST' }),
         errorFallback: t('automationRunHistory.errors.cancelRun'),
+        successMessage: (data) => t('automationRunHistory.actions.cancelRunSuccess', { count: data.executionsCancelled }),
+        onUnauthorized: () => void navigateTo('/login', { replace: true }),
       });
       setUncancellableActions(result.uncancellableActions ?? []);
       onRunCancelled?.(run.id);
     } catch (err) {
-      if (err instanceof ActionError && err.status === 401) return;
-      // Any other ActionError was already toasted by runAction.
+      handleActionError(err, t('automationRunHistory.errors.cancelRun'));
     } finally {
       setCancelling(false);
       setConfirmingCancel(false);
@@ -494,12 +514,16 @@ function RunItem({
             </button>
           )}
           {cancelHiddenByPartnerScope && (
+            // #4767 review: the full explanation is long (and longer still in
+            // some locales) — it belongs in `title`, not as inline row text,
+            // or it blows out every partner-owned run row.
             <span
               data-testid="cancel-run-partner-tooltip"
               title={t('automationRunHistory.actions.partnerScopeTooltip')}
-              className="text-xs text-muted-foreground"
+              className="flex h-8 w-8 items-center justify-center text-muted-foreground"
             >
-              {t('automationRunHistory.actions.partnerScopeTooltip')}
+              <Info className="h-4 w-4" />
+              <span className="sr-only">{t('automationRunHistory.actions.partnerScopeTooltip')}</span>
             </span>
           )}
           <button

--- a/apps/web/src/components/automations/AutomationRunHistory.tsx
+++ b/apps/web/src/components/automations/AutomationRunHistory.tsx
@@ -13,13 +13,25 @@ import {
   Monitor,
   Terminal,
   Calendar,
-  Timer
+  Timer,
+  Square
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { formatDateTime } from '@/lib/dateTimeFormat';
 import { formatNumber } from '@/lib/i18n/format';
+import { hasPermission } from '@/lib/permissions';
+import type { Permission } from '@/stores/auth';
+import { fetchWithAuth } from '@/stores/auth';
+import { runAction, ActionError } from '@/lib/runAction';
+import { ConfirmDialog } from '@/components/shared/ConfirmDialog';
 
 type ScriptsT = TFunction<'scripts'>;
+
+// #4767 — one action the fan-out could not stop and left running/reporting on
+// its own (execute_command creates no script_executions row; a deployment
+// lives in deployment_results). Rendered so the operator never reads
+// "cancelled" as "everything actually stopped".
+export type UncancellableAction = { actionIndex: number; actionType: string; reason: string };
 
 /**
  * One `run_script` action's real script output on one device (#3162). Distinct
@@ -86,6 +98,12 @@ export type AutomationRun = {
   devicesCancelled?: number;
   deviceResults: DeviceRunResult[];
   logs?: string[];
+  // #4767 (W05 dependency) — whether this run belongs to an org-owned or a
+  // partner-wide automation. Absent/undefined is treated as 'organization'
+  // (the common case, and the safe default if a not-yet-updated GET response
+  // omits the field): Cancel run stays offered rather than mysteriously
+  // vanishing.
+  ownerScope?: 'organization' | 'partner';
 };
 
 type AutomationRunHistoryProps = {
@@ -96,6 +114,15 @@ type AutomationRunHistoryProps = {
   timezone?: string;
   /** When provided, expanding a run lazily fetches its per-device breakdown. */
   onLoadRunDetail?: RunDetailLoader;
+  // #4767 — UX-only gate mirroring the API's own requirePermission(scripts:execute)
+  // on the cancel route. Cancel run is HIDDEN, never merely disabled, without it.
+  permissions?: Permission[];
+  // #4767 — mirrors canManagePartnerWidePolicies(auth) server-side (OD7-A): an
+  // org-scoped operator may still cancel individual executions on their own
+  // devices, but must not stop a run that fans out across sibling tenants.
+  canManagePartnerWide?: boolean;
+  /** Called after a successful cancel so the host page can refresh the run list. */
+  onRunCancelled?: (runId: string) => void;
 };
 
 export type AutomationRunHistoryStatusKey =
@@ -296,11 +323,17 @@ function RunItem({
   timezone,
   onLoadRunDetail,
   t,
+  permissions,
+  canManagePartnerWide,
+  onRunCancelled,
 }: {
   run: AutomationRun;
   timezone: string;
   onLoadRunDetail?: RunDetailLoader;
   t: ScriptsT;
+  permissions?: Permission[];
+  canManagePartnerWide?: boolean;
+  onRunCancelled?: (runId: string) => void;
 }) {
   const [expanded, setExpanded] = useState(false);
   const [showLogs, setShowLogs] = useState(false);
@@ -309,8 +342,33 @@ function RunItem({
   const [detailError, setDetailError] = useState(false);
   // Bumped by the script-result poll below to re-run the fetch effect.
   const [scriptPollTick, setScriptPollTick] = useState(0);
+  const [confirmingCancel, setConfirmingCancel] = useState(false);
+  const [cancelling, setCancelling] = useState(false);
+  const [uncancellableActions, setUncancellableActions] = useState<UncancellableAction[] | null>(null);
 
   const isRunning = run.status === 'running';
+  const canExecuteScripts = hasPermission(permissions, 'scripts', 'execute');
+  const isPartnerOwned = run.ownerScope === 'partner';
+  const canCancelRun = isRunning && canExecuteScripts && (!isPartnerOwned || canManagePartnerWide);
+  const cancelHiddenByPartnerScope = isRunning && canExecuteScripts && isPartnerOwned && !canManagePartnerWide;
+
+  const handleConfirmCancelRun = async () => {
+    setCancelling(true);
+    try {
+      const result = await runAction<{ executionsCancelled: number; uncancellableActions?: UncancellableAction[] }>({
+        request: () => fetchWithAuth(`/automations/runs/${run.id}/cancel`, { method: 'POST' }),
+        errorFallback: t('automationRunHistory.errors.cancelRun'),
+      });
+      setUncancellableActions(result.uncancellableActions ?? []);
+      onRunCancelled?.(run.id);
+    } catch (err) {
+      if (err instanceof ActionError && err.status === 401) return;
+      // Any other ActionError was already toasted by runAction.
+    } finally {
+      setCancelling(false);
+      setConfirmingCancel(false);
+    }
+  };
 
   // Lazily load the per-device breakdown on first expand, and refresh it while
   // the run is still in progress (parent polling bumps the counts below, which
@@ -371,12 +429,16 @@ function RunItem({
 
   return (
     <div className="rounded-md border">
-      <button
-        type="button"
-        onClick={() => setExpanded(!expanded)}
-        className="flex w-full items-center justify-between p-4 text-left hover:bg-muted/40"
-      >
-        <div className="flex items-center gap-3">
+      {/* A plain row, not a <button> — Cancel run below nests a real
+          <button>, which native <button>-in-<button> forbids. The toggle
+          itself stays a <button> (just the left content), which is also what
+          existing tests query via `.closest('button')`. */}
+      <div className="flex w-full items-center justify-between p-4 hover:bg-muted/40">
+        <button
+          type="button"
+          onClick={() => setExpanded(!expanded)}
+          className="flex flex-1 items-center gap-3 text-left"
+        >
           <StatusIcon className={cn('h-5 w-5', statusConfig[run.status].color)} />
           <div>
             <div className="flex items-center gap-2">
@@ -396,7 +458,7 @@ function RunItem({
               {t('automationRunHistory.deviceCount', { count: run.devicesTotal })}
             </p>
           </div>
-        </div>
+        </button>
         <div className="flex items-center gap-4">
           <div className="text-right text-xs">
             <div className="flex items-center gap-2 text-muted-foreground">
@@ -407,18 +469,52 @@ function RunItem({
               {run.devicesSkipped > 0 && (
                 <span className="text-gray-500">{t('automationRunHistory.resultCount.skipped', { count: run.devicesSkipped })}</span>
               )}
+              {/* #4767 — rendered separately from failed/succeeded: a
+                  cancelled device is neither, and folding it into either
+                  count would misreport why the run didn't finish. */}
+              {(run.devicesCancelled ?? 0) > 0 && (
+                <span className="text-muted-foreground">
+                  {t('automationRunHistory.resultCount.cancelled', { count: run.devicesCancelled })}
+                </span>
+              )}
             </div>
             {duration && (
               <p className="text-muted-foreground">{t('automationRunHistory.duration', { duration: formatDuration(duration) })}</p>
             )}
           </div>
-          {expanded ? (
-            <ChevronUp className="h-4 w-4 text-muted-foreground" />
-          ) : (
-            <ChevronDown className="h-4 w-4 text-muted-foreground" />
+          {canCancelRun && (
+            <button
+              type="button"
+              data-testid="cancel-run"
+              onClick={(e) => { e.stopPropagation(); setConfirmingCancel(true); }}
+              className="flex h-8 items-center gap-1.5 rounded-md border px-2.5 text-xs font-medium text-destructive transition hover:bg-destructive/10"
+            >
+              <Square className="h-3.5 w-3.5" />
+              {t('automationRunHistory.actions.cancelRun')}
+            </button>
           )}
+          {cancelHiddenByPartnerScope && (
+            <span
+              data-testid="cancel-run-partner-tooltip"
+              title={t('automationRunHistory.actions.partnerScopeTooltip')}
+              className="text-xs text-muted-foreground"
+            >
+              {t('automationRunHistory.actions.partnerScopeTooltip')}
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={() => setExpanded(!expanded)}
+            className="flex h-8 w-8 items-center justify-center rounded-md hover:bg-muted"
+          >
+            {expanded ? (
+              <ChevronUp className="h-4 w-4 text-muted-foreground" />
+            ) : (
+              <ChevronDown className="h-4 w-4 text-muted-foreground" />
+            )}
+          </button>
         </div>
-      </button>
+      </div>
 
       {/* Live progress bar — shown while a run is in progress (#2023). */}
       {isRunning && run.devicesTotal > 0 && (
@@ -496,6 +592,26 @@ function RunItem({
           </div>
         </div>
       )}
+
+      {uncancellableActions && uncancellableActions.length > 0 && (
+        <div className="border-t bg-warning/10 px-4 py-2 text-xs text-warning" data-testid="uncancellable-actions">
+          {t('automationRunHistory.actions.uncancellableActions', { count: uncancellableActions.length })}
+        </div>
+      )}
+
+      {confirmingCancel && (
+        <ConfirmDialog
+          open={true}
+          onClose={() => setConfirmingCancel(false)}
+          onConfirm={() => void handleConfirmCancelRun()}
+          title={t('automationRunHistory.actions.confirmCancelRunTitle')}
+          message={t('automationRunHistory.actions.confirmCancelRunMessage')}
+          variant="warning"
+          confirmLabel={t('automationRunHistory.actions.cancelRun')}
+          confirmTestId="confirm-cancel-run"
+          isLoading={cancelling}
+        />
+      )}
     </div>
   );
 }
@@ -506,7 +622,10 @@ export default function AutomationRunHistory({
   onClose,
   automationName,
   timezone = Intl.DateTimeFormat().resolvedOptions().timeZone,
-  onLoadRunDetail
+  onLoadRunDetail,
+  permissions,
+  canManagePartnerWide,
+  onRunCancelled
 }: AutomationRunHistoryProps) {
   const { t } = useTranslation('scripts');
   const [statusFilter, setStatusFilter] = useState<string>('all');
@@ -565,7 +684,16 @@ export default function AutomationRunHistory({
           ) : (
             <div className="space-y-3">
               {filteredRuns.map(run => (
-                <RunItem key={run.id} run={run} timezone={timezone} onLoadRunDetail={onLoadRunDetail} t={t} />
+                <RunItem
+                  key={run.id}
+                  run={run}
+                  timezone={timezone}
+                  onLoadRunDetail={onLoadRunDetail}
+                  t={t}
+                  permissions={permissions}
+                  canManagePartnerWide={canManagePartnerWide}
+                  onRunCancelled={onRunCancelled}
+                />
               ))}
             </div>
           )}

--- a/apps/web/src/components/automations/AutomationsPage.managed.test.tsx
+++ b/apps/web/src/components/automations/AutomationsPage.managed.test.tsx
@@ -2,7 +2,15 @@ import '@/lib/i18n';
 import { render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+vi.mock('../../stores/auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../stores/auth')>();
+  // #4767 — AutomationsPage now also reads useAuthStore (via usePermissions()
+  // and its own canManagePartnerWide selector) to gate the Cancel run
+  // affordance; a bare `{ fetchWithAuth }` replacement drops that export and
+  // usePermissions() throws. Keep the real store (defaults to no user, so
+  // Cancel run stays correctly hidden — this file isn't testing that).
+  return { ...actual, fetchWithAuth: vi.fn() };
+});
 vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
 
 import AutomationsPage from './AutomationsPage';

--- a/apps/web/src/components/automations/AutomationsPage.tsx
+++ b/apps/web/src/components/automations/AutomationsPage.tsx
@@ -8,8 +8,9 @@ import AutomationRunHistory, {
   type DeviceRunResult,
   type DeviceScriptResult,
 } from './AutomationRunHistory';
-import { fetchWithAuth } from '../../stores/auth';
+import { fetchWithAuth, useAuthStore } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
+import { usePermissions } from '@/lib/permissions';
 // Initializes the shared i18next singleton. Islands hydrate independently, so
 // an island that hydrates before whichever other island happens to pull i18n in
 // would otherwise render raw keys (and mismatch the SSR markup).
@@ -171,6 +172,10 @@ function toDeviceRunResult(raw: unknown): DeviceRunResult | null {
 
 export default function AutomationsPage() {
   const { t } = useTranslation('scripts');
+  const { permissions } = usePermissions();
+  // #3262 — mirrors canManagePartnerWidePolicies(auth) server-side. UX only;
+  // the cancel route re-checks this on every request.
+  const canManagePartnerWide = useAuthStore((s) => s.user?.canManagePartnerWide);
   const [automations, setAutomations] = useState<Automation[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
@@ -423,6 +428,9 @@ export default function AutomationsPage() {
           onClose={handleCloseModal}
           automationName={selectedAutomation.name}
           onLoadRunDetail={fetchRunDetail}
+          permissions={permissions}
+          canManagePartnerWide={canManagePartnerWide}
+          onRunCancelled={() => void fetchRunHistory(selectedAutomation)}
         />
       )}
     </div>

--- a/apps/web/src/components/scripts/ExecutionDetails.test.tsx
+++ b/apps/web/src/components/scripts/ExecutionDetails.test.tsx
@@ -1,8 +1,12 @@
 import type { ComponentProps } from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import ExecutionDetails from './ExecutionDetails';
 import type { ScriptExecution } from './ExecutionHistory';
+import type { Permission } from '@/stores/auth';
+
+const withScriptsExecute: Permission[] = [{ resource: 'scripts', action: 'execute' }];
 
 function baseExecution(overrides: Partial<ScriptExecution> = {}): ScriptExecution {
   return {
@@ -171,5 +175,54 @@ describe('ExecutionDetails duration (no `duration` field on the wire)', () => {
 
     const durationLabel = screen.getByText('Duration');
     expect(durationLabel.parentElement).toHaveTextContent('—');
+  });
+});
+
+// #4767 — this mirrors ExecutionHistory's own Stop wiring (same
+// CANCELLABLE_STATUSES/DEFAULT_GRACE_SECONDS constants, deliberately kept
+// local rather than shared — see the file header comment), so it needs its
+// own regression coverage rather than relying on ExecutionHistory's tests to
+// stand in for it.
+describe('ExecutionDetails Stop affordance', () => {
+  it.each(['pending', 'queued', 'running'] as const)('offers Stop on %s', (status) => {
+    renderExecution({ status }, { onCancel: vi.fn(), permissions: withScriptsExecute });
+    expect(screen.getByTestId('cancel-execution')).toBeInTheDocument();
+  });
+
+  it.each(['completed', 'failed', 'timeout', 'cancelled'] as const)('has no Stop button on %s', (status) => {
+    renderExecution({ status }, { onCancel: vi.fn(), permissions: withScriptsExecute });
+    expect(screen.queryByTestId('cancel-execution')).toBeNull();
+  });
+
+  it('hides Stop without scripts:execute', () => {
+    renderExecution({ status: 'running' }, { onCancel: vi.fn(), permissions: [] });
+    expect(screen.queryByTestId('cancel-execution')).toBeNull();
+  });
+
+  it('shows a disabled Stopping… button while cancelling', () => {
+    renderExecution({ status: 'cancelling' }, { onCancel: vi.fn(), permissions: withScriptsExecute });
+    expect(screen.getByTestId('cancel-execution')).toBeDisabled();
+  });
+
+  it('Force stop sends graceSeconds 0', async () => {
+    const user = userEvent.setup();
+    const onCancel = vi.fn().mockResolvedValue(undefined);
+    renderExecution({ status: 'running' }, { onCancel, permissions: withScriptsExecute });
+
+    await user.click(screen.getByTestId('cancel-execution'));
+    await user.click(screen.getByTestId('confirm-force-stop'));
+
+    expect(onCancel).toHaveBeenCalledWith(expect.objectContaining({ id: 'exec-1' }), 0);
+  });
+
+  it('the primary Stop confirm sends the default 5s grace', async () => {
+    const user = userEvent.setup();
+    const onCancel = vi.fn().mockResolvedValue(undefined);
+    renderExecution({ status: 'running' }, { onCancel, permissions: withScriptsExecute });
+
+    await user.click(screen.getByTestId('cancel-execution'));
+    await user.click(screen.getByTestId('confirm-stop'));
+
+    expect(onCancel).toHaveBeenCalledWith(expect.objectContaining({ id: 'exec-1' }), 5);
   });
 });

--- a/apps/web/src/components/scripts/ExecutionDetails.tsx
+++ b/apps/web/src/components/scripts/ExecutionDetails.tsx
@@ -269,6 +269,11 @@ export default function ExecutionDetails({
     setSubmitting(true);
     try {
       await onCancel(execution, graceSeconds);
+    } catch (err) {
+      // Backstop only — see the identical comment in ExecutionHistory.tsx.
+      if (import.meta.env.DEV) {
+        console.warn('[ExecutionDetails] onCancel rejected without reporting its own failure', err);
+      }
     } finally {
       setSubmitting(false);
       setConfirming(false);

--- a/apps/web/src/components/scripts/ExecutionDetails.tsx
+++ b/apps/web/src/components/scripts/ExecutionDetails.tsx
@@ -1,12 +1,22 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { X, ChevronDown, ChevronUp, Copy, Check, Loader2, Terminal, AlertOctagon, ListChecks, RotateCcw } from 'lucide-react';
+import { X, ChevronDown, ChevronUp, Copy, Check, Loader2, Terminal, AlertOctagon, ListChecks, RotateCcw, Square } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { formatDateTime as formatUserDateTime } from '@/lib/dateTimeFormat';
 import type { ScriptExecution, ScriptCustomFieldWriteResult } from './ExecutionHistory';
 import { computeDurationSeconds, formatDuration } from './ExecutionHistory';
-import { executionDetailStatusConfig as statusConfig } from './executionStatus';
+import { executionDetailStatusConfig as statusConfig, resolveExecutionStatusLabel } from './executionStatus';
 import { RunContextChip } from '@/components/common/RunContext';
+import { hasPermission } from '@/lib/permissions';
+import type { Permission } from '@/stores/auth';
+import { ConfirmDialog } from '@/components/shared/ConfirmDialog';
+import type { ExecutionStatus } from '@breeze/shared';
+
+// Mirrors ExecutionHistory.tsx — kept as a local constant rather than a shared
+// export since this is the only other call site and a shared module would be
+// pure ceremony for two five-line consumers.
+const CANCELLABLE_STATUSES = new Set<ExecutionStatus>(['pending', 'queued', 'running']);
+const DEFAULT_GRACE_SECONDS = 5;
 
 type ExecutionDetailsProps = {
   execution: ScriptExecution;
@@ -17,6 +27,11 @@ type ExecutionDetailsProps = {
   // execution's device + parameters. Omitted entirely (no button rendered)
   // where the host page has nowhere to send it.
   onRunAgain?: (execution: ScriptExecution) => void;
+  // #4767 — same contract as ExecutionHistory's onCancel/permissions: omitted
+  // entirely where the host page has no cancel endpoint to call, and
+  // permission-gated (hidden, not disabled) client-side as UX only.
+  onCancel?: (execution: ScriptExecution, graceSeconds: number) => Promise<void> | void;
+  permissions?: Permission[];
 };
 
 function formatDateTime(dateString: string, timezone?: string): string {
@@ -235,12 +250,30 @@ export default function ExecutionDetails({
   isOpen,
   onClose,
   timezone,
-  onRunAgain
+  onRunAgain,
+  onCancel,
+  permissions
 }: ExecutionDetailsProps) {
   const { t } = useTranslation('scripts');
+  const [confirming, setConfirming] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
   if (!isOpen) return null;
 
   const StatusIcon = statusConfig[execution.status].icon;
+  const canCancel = hasPermission(permissions, 'scripts', 'execute');
+  const isCancellable = CANCELLABLE_STATUSES.has(execution.status);
+  const isCancelling = execution.status === 'cancelling';
+
+  const handleConfirmCancel = async (graceSeconds: number) => {
+    if (!onCancel) return;
+    setSubmitting(true);
+    try {
+      await onCancel(execution, graceSeconds);
+    } finally {
+      setSubmitting(false);
+      setConfirming(false);
+    }
+  };
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 px-4 py-8">
@@ -251,13 +284,27 @@ export default function ExecutionDetails({
             <h2 className="text-lg font-semibold">{t('executionDetails.title')}</h2>
             <p className="text-sm text-muted-foreground">{execution.scriptName}</p>
           </div>
-          <button
-            type="button"
-            onClick={onClose}
-            className="flex h-8 w-8 items-center justify-center rounded-md hover:bg-muted"
-          >
-            <X className="h-5 w-5" />
-          </button>
+          <div className="flex items-center gap-2">
+            {onCancel && canCancel && (isCancellable || isCancelling) && (
+              <button
+                type="button"
+                data-testid="cancel-execution"
+                disabled={isCancelling}
+                onClick={() => setConfirming(true)}
+                className="flex h-9 items-center gap-1.5 rounded-md border px-3 text-sm font-medium text-destructive transition hover:bg-destructive/10 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {isCancelling ? <Loader2 className="h-4 w-4 animate-spin" /> : <Square className="h-4 w-4" />}
+                {isCancelling ? t('executionHistory.status.cancelling') : t('executionHistory.actions.stop')}
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex h-8 w-8 items-center justify-center rounded-md hover:bg-muted"
+            >
+              <X className="h-5 w-5" />
+            </button>
+          </div>
         </div>
 
         {/* Content */}
@@ -278,7 +325,7 @@ export default function ExecutionDetails({
                   'text-lg font-semibold',
                   statusConfig[execution.status].color
                 )}>
-                  {t(/* i18n-dynamic */ `executionDetails.${statusConfig[execution.status].label}`)}
+                  {t(/* i18n-dynamic */ `executionDetails.${resolveExecutionStatusLabel(execution.status, execution.cancelState)}`)}
                 </p>
                 <p className="text-sm text-muted-foreground">
                   {t(/* i18n-dynamic */ `executionDetails.statusDescription.${execution.status}`)}
@@ -389,6 +436,30 @@ export default function ExecutionDetails({
           </button>
         </div>
       </div>
+
+      {confirming && (
+        <ConfirmDialog
+          open={true}
+          onClose={() => setConfirming(false)}
+          onConfirm={() => void handleConfirmCancel(DEFAULT_GRACE_SECONDS)}
+          title={t('executionHistory.actions.confirmStopTitle')}
+          message={t('executionHistory.actions.confirmStopMessage', { script: execution.scriptName })}
+          variant="warning"
+          confirmLabel={t('executionHistory.actions.stop')}
+          confirmTestId="confirm-stop"
+          isLoading={submitting}
+        >
+          <button
+            type="button"
+            data-testid="confirm-force-stop"
+            disabled={submitting}
+            onClick={() => void handleConfirmCancel(0)}
+            className="text-sm font-medium text-destructive hover:underline disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {t('executionHistory.actions.forceStop')}
+          </button>
+        </ConfirmDialog>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/scripts/ExecutionHistory.cancel.test.tsx
+++ b/apps/web/src/components/scripts/ExecutionHistory.cancel.test.tsx
@@ -6,8 +6,9 @@ import type { Permission } from '@/stores/auth';
 
 const { fetchWithAuthMock } = vi.hoisted(() => ({ fetchWithAuthMock: vi.fn() }));
 const { showToastMock } = vi.hoisted(() => ({ showToastMock: vi.fn() }));
+const { navigateToMock } = vi.hoisted(() => ({ navigateToMock: vi.fn() }));
 
-vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('@/lib/navigation', () => ({ navigateTo: navigateToMock }));
 vi.mock('../../stores/auth', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../stores/auth')>();
   return { ...actual, fetchWithAuth: fetchWithAuthMock };
@@ -151,9 +152,25 @@ describe('ScriptExecutionsPage cancel + polling', () => {
   beforeEach(() => {
     fetchWithAuthMock.mockReset();
     showToastMock.mockReset();
+    navigateToMock.mockReset();
   });
 
-  it('a 409 surfaces a toast rather than a silent no-op', async () => {
+  it('a 401 redirects to login rather than silently no-opping', async () => {
+    mockApi(baseRow(), () => jsonResponse({ error: 'Unauthorized' }, 401));
+    const user = userEvent.setup();
+    render(<ScriptExecutionsPage scriptId={SCRIPT_ID} />);
+    await screen.findByText('alpha-01');
+
+    await user.click(screen.getByTestId(`cancel-execution-${EXECUTION_ID}`));
+    await user.click(screen.getByTestId('confirm-stop'));
+
+    await waitFor(() => {
+      expect(navigateToMock).toHaveBeenCalledWith('/login', { replace: true });
+    });
+    expect(showToastMock).not.toHaveBeenCalled();
+  });
+
+  it('a 409 surfaces the friendly "no longer cancellable" message, not the raw server text', async () => {
     mockApi(baseRow(), () => jsonResponse({ error: 'Cannot cancel execution with status: completed' }, 409));
     const user = userEvent.setup();
     render(<ScriptExecutionsPage scriptId={SCRIPT_ID} />);
@@ -163,8 +180,31 @@ describe('ScriptExecutionsPage cancel + polling', () => {
     await user.click(screen.getByTestId('confirm-stop'));
 
     await waitFor(() => {
-      expect(showToastMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+      expect(showToastMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'error',
+          message: 'This execution already finished and can no longer be stopped.',
+        }),
+      );
     });
+  });
+
+  it('a successful cancel refreshes the execution list', async () => {
+    mockApi(baseRow(), () => jsonResponse({ success: true, execution: { id: EXECUTION_ID, status: 'cancelling' } }));
+    const user = userEvent.setup();
+    render(<ScriptExecutionsPage scriptId={SCRIPT_ID} />);
+    await screen.findByText('alpha-01');
+
+    const executionsCallsBefore = fetchWithAuthMock.mock.calls.filter(([u]) => u === `/scripts/${SCRIPT_ID}/executions`).length;
+
+    await user.click(screen.getByTestId(`cancel-execution-${EXECUTION_ID}`));
+    await user.click(screen.getByTestId('confirm-stop'));
+
+    await waitFor(() => {
+      const executionsCallsAfter = fetchWithAuthMock.mock.calls.filter(([u]) => u === `/scripts/${SCRIPT_ID}/executions`).length;
+      expect(executionsCallsAfter).toBeGreaterThan(executionsCallsBefore);
+    });
+    expect(showToastMock).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
   });
 
   it('polls while any row is running or cancelling', async () => {

--- a/apps/web/src/components/scripts/ExecutionHistory.cancel.test.tsx
+++ b/apps/web/src/components/scripts/ExecutionHistory.cancel.test.tsx
@@ -56,34 +56,34 @@ function jsonResponse(body: unknown, status = 200) {
 describe('Stop affordance', () => {
   it.each(['pending', 'queued', 'running'] as const)('is offered on %s', (status) => {
     render(<ExecutionHistory executions={[exec({ status })]} onCancel={vi.fn()} permissions={withScriptsExecute} />);
-    expect(screen.getByTestId('cancel-execution')).toBeInTheDocument();
+    expect(screen.getByTestId('cancel-execution-e1')).toBeInTheDocument();
   });
 
   it.each(['completed', 'failed', 'timeout', 'cancelled'] as const)('is absent on %s', (status) => {
     render(<ExecutionHistory executions={[exec({ status })]} onCancel={vi.fn()} permissions={withScriptsExecute} />);
-    expect(screen.queryByTestId('cancel-execution')).toBeNull();
+    expect(screen.queryByTestId('cancel-execution-e1')).toBeNull();
   });
 
   it('shows a disabled Stopping… spinner while cancelling', () => {
     render(<ExecutionHistory executions={[exec({ status: 'cancelling' })]} onCancel={vi.fn()} permissions={withScriptsExecute} />);
-    expect(screen.getByTestId('cancel-execution')).toBeDisabled();
+    expect(screen.getByTestId('cancel-execution-e1')).toBeDisabled();
   });
 
   it('is HIDDEN, not disabled, without scripts:execute', () => {
     render(<ExecutionHistory executions={[exec({ status: 'running' })]} onCancel={vi.fn()} permissions={withoutScriptsExecute} />);
-    expect(screen.queryByTestId('cancel-execution')).toBeNull();
+    expect(screen.queryByTestId('cancel-execution-e1')).toBeNull();
   });
 
   it('is absent entirely without an onCancel handler, regardless of permission', () => {
     render(<ExecutionHistory executions={[exec({ status: 'running' })]} permissions={withScriptsExecute} />);
-    expect(screen.queryByTestId('cancel-execution')).toBeNull();
+    expect(screen.queryByTestId('cancel-execution-e1')).toBeNull();
   });
 
   it('Force stop sends graceSeconds 0', async () => {
     const user = userEvent.setup();
     const onCancel = vi.fn().mockResolvedValue(undefined);
     render(<ExecutionHistory executions={[exec({ status: 'running' })]} onCancel={onCancel} permissions={withScriptsExecute} />);
-    await user.click(screen.getByTestId('cancel-execution'));
+    await user.click(screen.getByTestId('cancel-execution-e1'));
     await user.click(screen.getByTestId('confirm-force-stop'));
     expect(onCancel).toHaveBeenCalledWith(expect.objectContaining({ id: 'e1' }), 0);
   });
@@ -92,7 +92,7 @@ describe('Stop affordance', () => {
     const user = userEvent.setup();
     const onCancel = vi.fn().mockResolvedValue(undefined);
     render(<ExecutionHistory executions={[exec({ status: 'running' })]} onCancel={onCancel} permissions={withScriptsExecute} />);
-    await user.click(screen.getByTestId('cancel-execution'));
+    await user.click(screen.getByTestId('cancel-execution-e1'));
     await user.click(screen.getByTestId('confirm-stop'));
     expect(onCancel).toHaveBeenCalledWith(expect.objectContaining({ id: 'e1' }), 5);
   });
@@ -159,7 +159,7 @@ describe('ScriptExecutionsPage cancel + polling', () => {
     render(<ScriptExecutionsPage scriptId={SCRIPT_ID} />);
     await screen.findByText('alpha-01');
 
-    await user.click(screen.getByTestId('cancel-execution'));
+    await user.click(screen.getByTestId(`cancel-execution-${EXECUTION_ID}`));
     await user.click(screen.getByTestId('confirm-stop'));
 
     await waitFor(() => {

--- a/apps/web/src/components/scripts/ExecutionHistory.cancel.test.tsx
+++ b/apps/web/src/components/scripts/ExecutionHistory.cancel.test.tsx
@@ -1,0 +1,207 @@
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import ExecutionHistory, { type ScriptExecution } from './ExecutionHistory';
+import type { Permission } from '@/stores/auth';
+
+const { fetchWithAuthMock } = vi.hoisted(() => ({ fetchWithAuthMock: vi.fn() }));
+const { showToastMock } = vi.hoisted(() => ({ showToastMock: vi.fn() }));
+
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../../stores/auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../stores/auth')>();
+  return { ...actual, fetchWithAuth: fetchWithAuthMock };
+});
+vi.mock('../shared/Toast', () => ({ showToast: showToastMock }));
+
+// Imported AFTER the mocks above are registered so ScriptExecutionsPage picks
+// up the mocked fetchWithAuth/showToast.
+const { default: ScriptExecutionsPage } = await import('./ScriptExecutionsPage');
+const { useAuthStore } = await import('../../stores/auth');
+
+// usePermissions() reads the real zustand store (only fetchWithAuth is
+// mocked above) — without a user carrying scripts:execute, the Stop
+// affordance stays correctly hidden and every test below would spuriously
+// fail on the permission gate rather than what it's actually asserting.
+useAuthStore.setState({
+  user: {
+    id: 'u1',
+    email: 'tech@example.com',
+    name: 'Tech',
+    mfaEnabled: true,
+    permissions: [{ resource: 'scripts', action: 'execute' }],
+  },
+});
+
+const withScriptsExecute: Permission[] = [{ resource: 'scripts', action: 'execute' }];
+const withoutScriptsExecute: Permission[] = [{ resource: 'scripts', action: 'read' }];
+
+function exec(overrides: Partial<ScriptExecution> = {}): ScriptExecution {
+  return {
+    id: 'e1',
+    scriptId: 's1',
+    scriptName: 'Disk Cleanup',
+    deviceId: 'd1',
+    deviceHostname: 'alpha-01',
+    status: 'running',
+    startedAt: '2026-08-10T10:00:00.000Z',
+    ...overrides,
+  } as ScriptExecution;
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { status });
+}
+
+describe('Stop affordance', () => {
+  it.each(['pending', 'queued', 'running'] as const)('is offered on %s', (status) => {
+    render(<ExecutionHistory executions={[exec({ status })]} onCancel={vi.fn()} permissions={withScriptsExecute} />);
+    expect(screen.getByTestId('cancel-execution')).toBeInTheDocument();
+  });
+
+  it.each(['completed', 'failed', 'timeout', 'cancelled'] as const)('is absent on %s', (status) => {
+    render(<ExecutionHistory executions={[exec({ status })]} onCancel={vi.fn()} permissions={withScriptsExecute} />);
+    expect(screen.queryByTestId('cancel-execution')).toBeNull();
+  });
+
+  it('shows a disabled Stopping… spinner while cancelling', () => {
+    render(<ExecutionHistory executions={[exec({ status: 'cancelling' })]} onCancel={vi.fn()} permissions={withScriptsExecute} />);
+    expect(screen.getByTestId('cancel-execution')).toBeDisabled();
+  });
+
+  it('is HIDDEN, not disabled, without scripts:execute', () => {
+    render(<ExecutionHistory executions={[exec({ status: 'running' })]} onCancel={vi.fn()} permissions={withoutScriptsExecute} />);
+    expect(screen.queryByTestId('cancel-execution')).toBeNull();
+  });
+
+  it('is absent entirely without an onCancel handler, regardless of permission', () => {
+    render(<ExecutionHistory executions={[exec({ status: 'running' })]} permissions={withScriptsExecute} />);
+    expect(screen.queryByTestId('cancel-execution')).toBeNull();
+  });
+
+  it('Force stop sends graceSeconds 0', async () => {
+    const user = userEvent.setup();
+    const onCancel = vi.fn().mockResolvedValue(undefined);
+    render(<ExecutionHistory executions={[exec({ status: 'running' })]} onCancel={onCancel} permissions={withScriptsExecute} />);
+    await user.click(screen.getByTestId('cancel-execution'));
+    await user.click(screen.getByTestId('confirm-force-stop'));
+    expect(onCancel).toHaveBeenCalledWith(expect.objectContaining({ id: 'e1' }), 0);
+  });
+
+  it('the primary Stop confirm sends the default 5s grace', async () => {
+    const user = userEvent.setup();
+    const onCancel = vi.fn().mockResolvedValue(undefined);
+    render(<ExecutionHistory executions={[exec({ status: 'running' })]} onCancel={onCancel} permissions={withScriptsExecute} />);
+    await user.click(screen.getByTestId('cancel-execution'));
+    await user.click(screen.getByTestId('confirm-stop'));
+    expect(onCancel).toHaveBeenCalledWith(expect.objectContaining({ id: 'e1' }), 5);
+  });
+
+  it('an OD9-C loser renders the too-late copy, not a bare Completed', () => {
+    render(<ExecutionHistory executions={[exec({ status: 'completed', cancelState: 'unconfirmed' })]} permissions={withScriptsExecute} />);
+    expect(screen.getByText(/too late/i)).toBeInTheDocument();
+  });
+
+  it('a genuinely confirmed cancel still reads as plain Cancelled', () => {
+    render(<ExecutionHistory executions={[exec({ status: 'cancelled', cancelState: 'confirmed' })]} permissions={withScriptsExecute} />);
+    // "Cancelled" also appears as a <select> option in the status filter, so
+    // scope to the row's status badge specifically.
+    const badges = screen.getAllByText('Cancelled');
+    expect(badges.some((el) => el.tagName !== 'OPTION')).toBe(true);
+  });
+});
+
+describe('ScriptExecutionsPage cancel + polling', () => {
+  const SCRIPT_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+  const EXECUTION_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+  const script = {
+    id: SCRIPT_ID,
+    name: 'Disk Cleanup',
+    language: 'powershell',
+    category: 'Maintenance',
+    osTypes: ['windows'],
+    status: 'active',
+  };
+
+  function baseRow(overrides: Record<string, unknown> = {}) {
+    return {
+      id: EXECUTION_ID,
+      scriptId: SCRIPT_ID,
+      scriptName: 'Disk Cleanup',
+      deviceId: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+      deviceHostname: 'alpha-01',
+      status: 'running',
+      startedAt: '2026-08-10T10:00:00.000Z',
+      ...overrides,
+    };
+  }
+
+  function mockApi(row: Record<string, unknown>, cancelResponse?: () => Response) {
+    fetchWithAuthMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === `/scripts/${SCRIPT_ID}`) return jsonResponse({ script });
+      if (url === `/scripts/${SCRIPT_ID}/executions`) return jsonResponse({ executions: [row] });
+      if (url === '/orgs/sites') return jsonResponse({ sites: [] });
+      if (url === `/scripts/executions/${EXECUTION_ID}/cancel` && init?.method === 'POST') {
+        return cancelResponse ? cancelResponse() : jsonResponse({ success: true, execution: { id: EXECUTION_ID, status: 'cancelling' } });
+      }
+      return jsonResponse({}, 404);
+    });
+  }
+
+  beforeEach(() => {
+    fetchWithAuthMock.mockReset();
+    showToastMock.mockReset();
+  });
+
+  it('a 409 surfaces a toast rather than a silent no-op', async () => {
+    mockApi(baseRow(), () => jsonResponse({ error: 'Cannot cancel execution with status: completed' }, 409));
+    const user = userEvent.setup();
+    render(<ScriptExecutionsPage scriptId={SCRIPT_ID} />);
+    await screen.findByText('alpha-01');
+
+    await user.click(screen.getByTestId('cancel-execution'));
+    await user.click(screen.getByTestId('confirm-stop'));
+
+    await waitFor(() => {
+      expect(showToastMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+    });
+  });
+
+  it('polls while any row is running or cancelling', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      mockApi(baseRow({ status: 'cancelling' }));
+      render(<ScriptExecutionsPage scriptId={SCRIPT_ID} />);
+      await screen.findByText('alpha-01');
+      const callsBefore = fetchWithAuthMock.mock.calls.filter(([u]) => u === `/scripts/${SCRIPT_ID}/executions`).length;
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2100);
+      });
+
+      const callsAfter = fetchWithAuthMock.mock.calls.filter(([u]) => u === `/scripts/${SCRIPT_ID}/executions`).length;
+      expect(callsAfter).toBeGreaterThan(callsBefore);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('stops polling once every row is terminal', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      mockApi(baseRow({ status: 'completed' }));
+      render(<ScriptExecutionsPage scriptId={SCRIPT_ID} />);
+      await screen.findByText('alpha-01');
+      const callsBefore = fetchWithAuthMock.mock.calls.filter(([u]) => u === `/scripts/${SCRIPT_ID}/executions`).length;
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(6000);
+      });
+
+      const callsAfter = fetchWithAuthMock.mock.calls.filter(([u]) => u === `/scripts/${SCRIPT_ID}/executions`).length;
+      expect(callsAfter).toBe(callsBefore);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/apps/web/src/components/scripts/ExecutionHistory.tsx
+++ b/apps/web/src/components/scripts/ExecutionHistory.tsx
@@ -392,10 +392,12 @@ export default function ExecutionHistory({
                     )}
                     <td className="px-4 py-3 text-sm">{execution.deviceHostname}</td>
                     <td className="px-4 py-3">
-                      <span className={cn(
-                        'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium',
-                        statusConfig[execution.status].color
-                      )}>
+                      <span
+                        data-testid={`execution-status-${execution.id}`}
+                        className={cn(
+                          'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium',
+                          statusConfig[execution.status].color
+                        )}>
                         <StatusIcon className={cn(
                           'h-3 w-3',
                           (execution.status === 'running' || execution.status === 'cancelling') && 'animate-spin'
@@ -435,7 +437,7 @@ export default function ExecutionHistory({
                         {onCancel && canCancel && (CANCELLABLE_STATUSES.has(execution.status) || execution.status === 'cancelling') && (
                           <button
                             type="button"
-                            data-testid="cancel-execution"
+                            data-testid={`cancel-execution-${execution.id}`}
                             disabled={execution.status === 'cancelling'}
                             onClick={(e) => {
                               e.stopPropagation();

--- a/apps/web/src/components/scripts/ExecutionHistory.tsx
+++ b/apps/web/src/components/scripts/ExecutionHistory.tsx
@@ -1,14 +1,27 @@
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
-import { Search, ChevronLeft, ChevronRight, ChevronUp, ChevronDown, Eye, Clock } from 'lucide-react';
+import { Search, ChevronLeft, ChevronRight, ChevronUp, ChevronDown, Eye, Clock, Square, Loader2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { formatDateTime as formatUserDateTime, formatTime as formatUserTime } from '@/lib/dateTimeFormat';
-import { executionRowStatusConfig as statusConfig } from './executionStatus';
-import type { ExecutionStatus } from '@breeze/shared';
+import { executionRowStatusConfig as statusConfig, resolveExecutionStatusLabel } from './executionStatus';
+import type { ExecutionStatus, CancelState } from '@breeze/shared';
 import type { RunContextValue } from '@/components/common/RunContext';
+import { hasPermission } from '@/lib/permissions';
+import type { Permission } from '@/stores/auth';
+import { ConfirmDialog } from '@/components/shared/ConfirmDialog';
 export type { ExecutionStatus } from '@breeze/shared';
 type ScriptsT = TFunction<'scripts'>;
+
+// #4767 — the only statuses a Stop request is meaningful against. `cancelling`
+// itself is not offered a NEW stop (that's the Force-stop path below), it gets
+// the disabled "Stopping…" affordance instead.
+const CANCELLABLE_STATUSES = new Set<ExecutionStatus>(['pending', 'queued', 'running']);
+
+// Mirrors the API's own default (apps/api/src/services/scriptCancellation.ts) —
+// shown here only as what the primary Stop action requests; Force stop always
+// sends 0 regardless of this constant.
+const DEFAULT_GRACE_SECONDS = 5;
 
 // #2698: per-run summary of the script custom-field write-back. Mirrors
 // `ScriptCustomFieldWriteSummary` in apps/api/src/db/schema/scripts.ts — kept
@@ -53,11 +66,22 @@ export type ScriptExecution = {
   // no room for a compact indicator without crowding the table.
   runAs?: RunContextValue | null;
   targetSessionId?: number | null;
+  // #4767 — set once a stop was requested; drives resolveExecutionStatusLabel's
+  // "too late" / "stop failed" copy once the execution reaches a terminal
+  // status. Absent/null means no cancel was ever requested.
+  cancelState?: CancelState | null;
 };
 
 type ExecutionHistoryProps = {
   executions: ScriptExecution[];
   onViewDetails?: (execution: ScriptExecution) => void;
+  // #4767 — wired by ScriptExecutionsPage via runAction. Omitted entirely (no
+  // Stop affordance rendered) where the host page has no cancel endpoint to
+  // call, mirroring the onRunAgain optionality pattern in ExecutionDetails.
+  onCancel?: (execution: ScriptExecution, graceSeconds: number) => Promise<void> | void;
+  // UX-only gate (the API re-checks scripts:execute server-side) — Stop is
+  // HIDDEN, never merely disabled, without it.
+  permissions?: Permission[];
   pageSize?: number;
   showScriptName?: boolean;
   timezone?: string;
@@ -126,6 +150,8 @@ function formatDateTime(dateString: string, t: ScriptsT, timezone?: string): str
 export default function ExecutionHistory({
   executions,
   onViewDetails,
+  onCancel,
+  permissions,
   pageSize = 10,
   showScriptName = true,
   timezone
@@ -137,6 +163,24 @@ export default function ExecutionHistory({
   const [currentPage, setCurrentPage] = useState(1);
   const [sortColumn, setSortColumn] = useState<string | null>(null);
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
+  // #4767 — the execution currently in the Stop confirm dialog, and (a
+  // superset while the request is in flight) the one whose Stop/Force-stop
+  // button must show the ConfirmDialog's isLoading state. Tracked by row
+  // rather than a single boolean since any row in view could be the target.
+  const [confirming, setConfirming] = useState<ScriptExecution | null>(null);
+  const [submittingId, setSubmittingId] = useState<string | null>(null);
+  const canCancel = hasPermission(permissions, 'scripts', 'execute');
+
+  const handleConfirmCancel = async (execution: ScriptExecution, graceSeconds: number) => {
+    if (!onCancel) return;
+    setSubmittingId(execution.id);
+    try {
+      await onCancel(execution, graceSeconds);
+    } finally {
+      setSubmittingId(null);
+      setConfirming(null);
+    }
+  };
 
   const toggleSort = (column: string) => {
     if (sortColumn === column) {
@@ -354,9 +398,9 @@ export default function ExecutionHistory({
                       )}>
                         <StatusIcon className={cn(
                           'h-3 w-3',
-                          execution.status === 'running' && 'animate-spin'
+                          (execution.status === 'running' || execution.status === 'cancelling') && 'animate-spin'
                         )} />
-                        {t(/* i18n-dynamic */ `executionHistory.${statusConfig[execution.status].label}`)}
+                        {t(/* i18n-dynamic */ `executionHistory.${resolveExecutionStatusLabel(execution.status, execution.cancelState)}`)}
                       </span>
                     </td>
                     <td className="px-4 py-3 text-sm text-muted-foreground">
@@ -387,7 +431,26 @@ export default function ExecutionHistory({
                       )}
                     </td>
                     <td className="px-4 py-3">
-                      <div className="flex items-center justify-end">
+                      <div className="flex items-center justify-end gap-1">
+                        {onCancel && canCancel && (CANCELLABLE_STATUSES.has(execution.status) || execution.status === 'cancelling') && (
+                          <button
+                            type="button"
+                            data-testid="cancel-execution"
+                            disabled={execution.status === 'cancelling'}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              if (execution.status !== 'cancelling') setConfirming(execution);
+                            }}
+                            className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-destructive disabled:cursor-not-allowed disabled:opacity-50"
+                            title={execution.status === 'cancelling'
+                              ? t('executionHistory.status.cancelling')
+                              : t('executionHistory.actions.stop')}
+                          >
+                            {execution.status === 'cancelling'
+                              ? <Loader2 className="h-4 w-4 animate-spin" />
+                              : <Square className="h-4 w-4" />}
+                          </button>
+                        )}
                         <button
                           type="button"
                           onClick={(e) => {
@@ -440,6 +503,32 @@ export default function ExecutionHistory({
             </button>
           </div>
         </div>
+      )}
+
+      {confirming && (
+        <ConfirmDialog
+          open={true}
+          onClose={() => setConfirming(null)}
+          onConfirm={() => void handleConfirmCancel(confirming, DEFAULT_GRACE_SECONDS)}
+          title={t('executionHistory.actions.confirmStopTitle')}
+          message={t('executionHistory.actions.confirmStopMessage', {
+            script: confirming.scriptName ?? confirming.deviceHostname,
+          })}
+          variant="warning"
+          confirmLabel={t('executionHistory.actions.stop')}
+          confirmTestId="confirm-stop"
+          isLoading={submittingId === confirming.id}
+        >
+          <button
+            type="button"
+            data-testid="confirm-force-stop"
+            disabled={submittingId === confirming.id}
+            onClick={() => void handleConfirmCancel(confirming, 0)}
+            className="text-sm font-medium text-destructive hover:underline disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {t('executionHistory.actions.forceStop')}
+          </button>
+        </ConfirmDialog>
       )}
     </div>
   );

--- a/apps/web/src/components/scripts/ExecutionHistory.tsx
+++ b/apps/web/src/components/scripts/ExecutionHistory.tsx
@@ -176,6 +176,15 @@ export default function ExecutionHistory({
     setSubmittingId(execution.id);
     try {
       await onCancel(execution, graceSeconds);
+    } catch (err) {
+      // onCancel's real (and only) implementation, ScriptExecutionsPage's
+      // handleCancel, already reports every failure via runAction/
+      // handleActionError — this is only a backstop against a FUTURE onCancel
+      // that throws instead, so that becomes a loud dev warning rather than
+      // ever landing as a silent unhandled promise rejection.
+      if (import.meta.env.DEV) {
+        console.warn('[ExecutionHistory] onCancel rejected without reporting its own failure', err);
+      }
     } finally {
       setSubmittingId(null);
       setConfirming(null);

--- a/apps/web/src/components/scripts/ScriptExecutionsPage.tsx
+++ b/apps/web/src/components/scripts/ScriptExecutionsPage.tsx
@@ -13,7 +13,7 @@ import Breadcrumbs from '../layout/Breadcrumbs';
 import { asList } from '@/lib/asList';
 import { deviceScriptsHref, scriptExecutionsHref } from '@/lib/deviceScriptsLink';
 import type { ScriptAdmissionResult } from '@breeze/shared';
-import { runAction, ActionError } from '@/lib/runAction';
+import { runAction, handleActionError } from '@/lib/runAction';
 import { usePermissions } from '@/lib/permissions';
 // Initializes the shared i18next singleton. Islands hydrate independently, so
 // an island that hydrates before whichever other island happens to pull i18n in
@@ -83,7 +83,18 @@ export default function ScriptExecutionsPage({ scriptId }: ScriptExecutionsPageP
         throw new Error(t('scriptExecutionsPage.errors.fetchExecutions'));
       }
       const data = await response.json();
-      setExecutions(asList(data, 'executions'));
+      const list = asList(data, 'executions') as ScriptExecution[];
+      setExecutions(list);
+      // #4767 review: the details modal holds its own snapshot
+      // (selectedExecution), so without this a Stop/Force-stop clicked from
+      // INSIDE the modal never reflects back into it — the header would keep
+      // reading "Running" and stay clickable after a successful cancel,
+      // inviting a second request that only ever gets a 409.
+      setSelectedExecution((prev) => {
+        if (!prev) return prev;
+        const updated = list.find((e) => e.id === prev.id);
+        return updated ? { ...prev, ...updated } : prev;
+      });
     } catch (err) {
       setError(err instanceof Error ? err.message : t('scriptExecutionsPage.errors.generic'));
     } finally {
@@ -146,8 +157,7 @@ export default function ScriptExecutionsPage({ scriptId }: ScriptExecutionsPageP
       });
       await fetchExecutions();
     } catch (err) {
-      if (err instanceof ActionError && err.status === 401) return;
-      // Any other ActionError was already toasted by runAction.
+      handleActionError(err, t('executionHistory.errors.cancelFailed'));
     }
   }, [t, fetchExecutions]);
 

--- a/apps/web/src/components/scripts/ScriptExecutionsPage.tsx
+++ b/apps/web/src/components/scripts/ScriptExecutionsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ArrowLeft, Play } from 'lucide-react';
 import ExecutionHistory, { type ScriptExecution } from './ExecutionHistory';
@@ -13,6 +13,8 @@ import Breadcrumbs from '../layout/Breadcrumbs';
 import { asList } from '@/lib/asList';
 import { deviceScriptsHref, scriptExecutionsHref } from '@/lib/deviceScriptsLink';
 import type { ScriptAdmissionResult } from '@breeze/shared';
+import { runAction, ActionError } from '@/lib/runAction';
+import { usePermissions } from '@/lib/permissions';
 // Initializes the shared i18next singleton. Islands hydrate independently, so
 // an island that hydrates before whichever other island happens to pull i18n in
 // would otherwise render raw keys (and mismatch the SSR markup).
@@ -27,8 +29,14 @@ type ScriptWithDetails = Script & {
   content?: string;
 };
 
+// #4767 — mirrors the ScriptTestRunner.tsx poll cadence. While any execution
+// is `running` or `cancelling` the list can go stale (a stop resolving, or a
+// run simply finishing) with nothing else on this page to re-trigger a fetch.
+const POLL_INTERVAL_MS = 2000;
+
 export default function ScriptExecutionsPage({ scriptId }: ScriptExecutionsPageProps) {
   const { t } = useTranslation('scripts');
+  const { permissions } = usePermissions();
   const [script, setScript] = useState<ScriptWithDetails | null>(null);
   const [executions, setExecutions] = useState<ScriptExecution[]>([]);
   const [sites, setSites] = useState<Site[]>([]);
@@ -101,6 +109,48 @@ export default function ScriptExecutionsPage({ scriptId }: ScriptExecutionsPageP
     fetchSites();
   }, [fetchScript, fetchExecutions, fetchSites]);
 
+  // #4767 — poll while a Stop is in flight (or a run is simply still going) so
+  // "Stopping…" doesn't freeze forever once the device (or the reaper) settles
+  // it. Keyed on a boolean rather than the executions array itself so the
+  // interval isn't torn down and recreated on every poll tick.
+  const hasActiveExecutions = useMemo(
+    () => executions.some((execution) => execution.status === 'running' || execution.status === 'cancelling'),
+    [executions],
+  );
+  useEffect(() => {
+    if (!hasActiveExecutions) return;
+    const timer = setInterval(() => {
+      fetchExecutions();
+    }, POLL_INTERVAL_MS);
+    return () => clearInterval(timer);
+  }, [hasActiveExecutions, fetchExecutions]);
+
+  const handleCancel = useCallback(async (execution: ScriptExecution, graceSeconds: number) => {
+    try {
+      await runAction({
+        request: () =>
+          fetchWithAuth(`/scripts/executions/${execution.id}/cancel`, {
+            method: 'POST',
+            body: JSON.stringify({ graceSeconds }),
+          }),
+        errorFallback: t('executionHistory.errors.cancelFailed'),
+        // The route's 409 body is a dynamic message ("Cannot cancel execution
+        // with status: completed"), not a machine token — matched by prefix
+        // rather than exact-equality against a `code` field the route never
+        // sends.
+        friendly: (token) =>
+          typeof token === 'string' && token.startsWith('Cannot cancel execution with status')
+            ? t('executionHistory.errors.noLongerCancellable')
+            : undefined,
+        onUnauthorized: () => void navigateTo('/login', { replace: true }),
+      });
+      await fetchExecutions();
+    } catch (err) {
+      if (err instanceof ActionError && err.status === 401) return;
+      // Any other ActionError was already toasted by runAction.
+    }
+  }, [t, fetchExecutions]);
+
   const handleViewDetails = (execution: ScriptExecution) => {
     // Open immediately with the list row, then upgrade with the full record —
     // the list endpoint omits stdout/stderr to keep its payload small.
@@ -149,6 +199,9 @@ export default function ScriptExecutionsPage({ scriptId }: ScriptExecutionsPageP
     parameters: Record<string, string | number | boolean>,
     runAs: 'system' | 'user'
   ) => {
+    // runaction-exempt: this throws to ScriptExecutionModal, which renders the
+    // failure (or the per-target admission result) inline in its own form —
+    // a toast on top would be redundant, not a silent failure.
     const response = await fetchWithAuth(`/scripts/${scriptId}/execute`, {
       method: 'POST',
       body: JSON.stringify({ deviceIds, parameters, runAs })
@@ -288,6 +341,8 @@ export default function ScriptExecutionsPage({ scriptId }: ScriptExecutionsPageP
       <ExecutionHistory
         executions={executions}
         onViewDetails={handleViewDetails}
+        onCancel={handleCancel}
+        permissions={permissions}
         showScriptName={false}
       />
 
@@ -298,6 +353,8 @@ export default function ScriptExecutionsPage({ scriptId }: ScriptExecutionsPageP
           isOpen={true}
           onClose={handleCloseDetails}
           onRunAgain={handleRunAgain}
+          onCancel={handleCancel}
+          permissions={permissions}
         />
       )}
 

--- a/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+++ b/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
@@ -248,6 +248,13 @@ const TARGET_GLOBS = [
   // assign/unassign mutations here were bare fetchWithAuth calls with no
   // toast — a failed assign or unassign looked identical to a successful one.
   'src/components/configurationPolicies/AssignmentsTab.tsx',
+  // #4767 — Stop / Force-stop wires the long-dormant cancel endpoint to the UI
+  // for the first time. A bare fetchWithAuth here would silently no-op a
+  // Force-stop click, which is exactly the "did it work?" ambiguity runAction
+  // exists to remove.
+  'src/components/scripts/ExecutionHistory.tsx',
+  'src/components/scripts/ExecutionDetails.tsx',
+  'src/components/scripts/ScriptExecutionsPage.tsx',
 ];
 
 const absoluteFiles: string[] = TARGET_GLOBS.map((rel) => resolve(WEB_ROOT, '..', rel));
@@ -560,10 +567,12 @@ describe('no silent mutations in targeted set', () => {
     // #4549 W07 — the admin trust queue page's approve/suspend actions).
     // NOTE: merge-base held 108; this branch added 1 (TrustActionPage.tsx) and
     // main added 3 in parallel, so the true merged count was 113. A prior
-    // commit added 1 more (TrustQueue.tsx) to reach 114. This commit adds 1
-    // more (AssignmentsTab.tsx), so the count is now 115 — bump it
-    // deliberately on every merge, never by resolving the hunk.
-    expect(absoluteFiles.length).toBe(115);
+    // commit added 1 more (TrustQueue.tsx) to reach 114. A prior commit added 1
+    // more (AssignmentsTab.tsx) to reach 115. This commit adds 3 more (#4767 —
+    // ExecutionHistory.tsx, ExecutionDetails.tsx, ScriptExecutionsPage.tsx), so
+    // the count is now 118 — bump it deliberately on every merge, never by
+    // resolving the hunk.
+    expect(absoluteFiles.length).toBe(118);
     for (const f of absoluteFiles) {
       expect(() => statSync(f)).not.toThrow();
     }

--- a/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+++ b/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
@@ -255,6 +255,10 @@ const TARGET_GLOBS = [
   'src/components/scripts/ExecutionHistory.tsx',
   'src/components/scripts/ExecutionDetails.tsx',
   'src/components/scripts/ScriptExecutionsPage.tsx',
+  // #4767 review — Cancel run's own POST /automations/runs/:runId/cancel
+  // lives inside this component (it has no owning page-level fetch layer),
+  // so it needs the same guard as the scripts-side files above.
+  'src/components/automations/AutomationRunHistory.tsx',
 ];
 
 const absoluteFiles: string[] = TARGET_GLOBS.map((rel) => resolve(WEB_ROOT, '..', rel));
@@ -568,11 +572,12 @@ describe('no silent mutations in targeted set', () => {
     // NOTE: merge-base held 108; this branch added 1 (TrustActionPage.tsx) and
     // main added 3 in parallel, so the true merged count was 113. A prior
     // commit added 1 more (TrustQueue.tsx) to reach 114. A prior commit added 1
-    // more (AssignmentsTab.tsx) to reach 115. This commit adds 3 more (#4767 —
-    // ExecutionHistory.tsx, ExecutionDetails.tsx, ScriptExecutionsPage.tsx), so
-    // the count is now 118 — bump it deliberately on every merge, never by
-    // resolving the hunk.
-    expect(absoluteFiles.length).toBe(118);
+    // more (AssignmentsTab.tsx) to reach 115. A prior commit added 3 more
+    // (#4767 — ExecutionHistory.tsx, ExecutionDetails.tsx,
+    // ScriptExecutionsPage.tsx) to reach 118. This commit adds 1 more
+    // (AutomationRunHistory.tsx), so the count is now 119 — bump it
+    // deliberately on every merge, never by resolving the hunk.
+    expect(absoluteFiles.length).toBe(119);
     for (const f of absoluteFiles) {
       expect(() => statSync(f)).not.toThrow();
     }

--- a/apps/web/src/locales/de-DE/scripts.json
+++ b/apps/web/src/locales/de-DE/scripts.json
@@ -272,7 +272,9 @@
       "confirmCancelRunTitle": "Diese Ausführung abbrechen?",
       "confirmCancelRunMessage": "Breeze stoppt jede Skriptausführung, auf die diese Ausführung noch wartet. Bereits laufende Aktionen können abgeschlossen werden, bevor sie gestoppt werden können.",
       "uncancellableActions_one": "{{count}} Aktion konnte nicht gestoppt werden und läuft möglicherweise weiterhin eigenständig.",
-      "uncancellableActions_other": "{{count}} Aktionen konnten nicht gestoppt werden und laufen möglicherweise weiterhin eigenständig."
+      "uncancellableActions_other": "{{count}} Aktionen konnten nicht gestoppt werden und laufen möglicherweise weiterhin eigenständig.",
+      "cancelRunSuccess_one": "Abgebrochen — {{count}} Ausführung gestoppt.",
+      "cancelRunSuccess_other": "Abgebrochen — {{count}} Ausführungen gestoppt."
     },
     "timestamps": {
       "started": "Gestartet: {{date}}",

--- a/apps/web/src/locales/de-DE/scripts.json
+++ b/apps/web/src/locales/de-DE/scripts.json
@@ -251,7 +251,8 @@
     "resultCount": {
       "passed": "{{count}} erfolgreich",
       "failed": "{{count}} fehlgeschlagen",
-      "skipped": "{{count}} übersprungen"
+      "skipped": "{{count}} übersprungen",
+      "cancelled": "{{count}} abgebrochen"
     },
     "duration": "Dauer: {{duration}}",
     "progress": {
@@ -265,7 +266,13 @@
     },
     "actions": {
       "hideLogs": "Protokolle ausblenden",
-      "viewLogs": "Protokolle anzeigen"
+      "viewLogs": "Protokolle anzeigen",
+      "cancelRun": "Ausführung abbrechen",
+      "partnerScopeTooltip": "Diese Ausführung gilt für alle Organisationen unter Ihrem Partnerkonto. Bitten Sie einen vollständigen Partneradministrator, sie abzubrechen, oder stoppen Sie stattdessen einzelne Ausführungen auf Ihren eigenen Geräten.",
+      "confirmCancelRunTitle": "Diese Ausführung abbrechen?",
+      "confirmCancelRunMessage": "Breeze stoppt jede Skriptausführung, auf die diese Ausführung noch wartet. Bereits laufende Aktionen können abgeschlossen werden, bevor sie gestoppt werden können.",
+      "uncancellableActions_one": "{{count}} Aktion konnte nicht gestoppt werden und läuft möglicherweise weiterhin eigenständig.",
+      "uncancellableActions_other": "{{count}} Aktionen konnten nicht gestoppt werden und laufen möglicherweise weiterhin eigenständig."
     },
     "timestamps": {
       "started": "Gestartet: {{date}}",
@@ -304,6 +311,9 @@
       "untitled": "Skript",
       "awaiting": "Warten auf Rückmeldung des Agenten…",
       "truncated": "Ausgabe gekürzt — vollständiger Text im Skriptverlauf des Geräts."
+    },
+    "errors": {
+      "cancelRun": "Die Ausführung konnte nicht abgebrochen werden."
     }
   },
   "automationsPage": {
@@ -717,11 +727,19 @@
     },
     "empty": "Keine Hinrichtungen gefunden. Versuchen Sie, Ihre Filter anzupassen.",
     "actions": {
-      "viewDetails": "Details anzeigen"
+      "viewDetails": "Details anzeigen",
+      "stop": "Stoppen",
+      "forceStop": "Sofort stoppen",
+      "confirmStopTitle": "Diese Ausführung stoppen?",
+      "confirmStopMessage": "Breeze bittet das Gerät, {{script}} zu stoppen. Das kann einige Sekunden dauern — „Sofort stoppen“ überspringt die Karenzzeit und beendet den Prozess sofort."
     },
     "pagination": {
       "showing": "Zeigt {{start}} bis {{end}} von {{total}}",
       "page": "Seite {{page}} von {{total}}"
+    },
+    "errors": {
+      "noLongerCancellable": "Diese Ausführung ist bereits abgeschlossen und kann nicht mehr gestoppt werden.",
+      "cancelFailed": "Der Stopp der Ausführung ist fehlgeschlagen."
     }
   },
   "scriptAiInput": {

--- a/apps/web/src/locales/en/scripts.json
+++ b/apps/web/src/locales/en/scripts.json
@@ -274,6 +274,8 @@
       "partnerScopeTooltip": "This run applies to every organization under your partner account. Ask a full partner admin to cancel it, or stop individual executions on your own devices instead.",
       "confirmCancelRunTitle": "Cancel this run?",
       "confirmCancelRunMessage": "Breeze will stop every execution this run is still waiting on. Actions already in progress may finish before they can be stopped.",
+      "cancelRunSuccess_one": "Cancelled — {{count}} execution stopped.",
+      "cancelRunSuccess_other": "Cancelled — {{count}} executions stopped.",
       "uncancellableActions_one": "{{count}} action could not be stopped and may still be running on its own.",
       "uncancellableActions_other": "{{count}} actions could not be stopped and may still be running on their own."
     },

--- a/apps/web/src/locales/en/scripts.json
+++ b/apps/web/src/locales/en/scripts.json
@@ -251,7 +251,8 @@
     "resultCount": {
       "passed": "{{count}} passed",
       "failed": "{{count}} failed",
-      "skipped": "{{count}} skipped"
+      "skipped": "{{count}} skipped",
+      "cancelled": "{{count}} cancelled"
     },
     "duration": "Duration: {{duration}}",
     "progress": {
@@ -263,9 +264,18 @@
       "error": "Couldn't load device results. Try reopening the run.",
       "empty": "No per-device results recorded for this run."
     },
+    "errors": {
+      "cancelRun": "Failed to cancel the run."
+    },
     "actions": {
       "hideLogs": "Hide Logs",
-      "viewLogs": "View Logs"
+      "viewLogs": "View Logs",
+      "cancelRun": "Cancel run",
+      "partnerScopeTooltip": "This run applies to every organization under your partner account. Ask a full partner admin to cancel it, or stop individual executions on your own devices instead.",
+      "confirmCancelRunTitle": "Cancel this run?",
+      "confirmCancelRunMessage": "Breeze will stop every execution this run is still waiting on. Actions already in progress may finish before they can be stopped.",
+      "uncancellableActions_one": "{{count}} action could not be stopped and may still be running on its own.",
+      "uncancellableActions_other": "{{count}} actions could not be stopped and may still be running on their own."
     },
     "timestamps": {
       "started": "Started: {{date}}",
@@ -716,8 +726,16 @@
       "exitCode": "Exit Code"
     },
     "empty": "No executions found. Try adjusting your filters.",
+    "errors": {
+      "noLongerCancellable": "This execution already finished and can no longer be stopped.",
+      "cancelFailed": "Failed to stop the execution."
+    },
     "actions": {
-      "viewDetails": "View details"
+      "viewDetails": "View details",
+      "stop": "Stop",
+      "forceStop": "Force stop",
+      "confirmStopTitle": "Stop this execution?",
+      "confirmStopMessage": "Breeze will ask the device to stop {{script}}. This can take a few seconds — Force stop skips the grace period and kills the process immediately."
     },
     "pagination": {
       "showing": "Showing {{start}} to {{end}} of {{total}}",

--- a/apps/web/src/locales/es-419/scripts.json
+++ b/apps/web/src/locales/es-419/scripts.json
@@ -272,7 +272,9 @@
       "confirmCancelRunTitle": "¿Cancelar esta ejecución?",
       "confirmCancelRunMessage": "Breeze detendrá cada ejecución de script que esta ejecución aún esté esperando. Las acciones ya en curso pueden finalizar antes de poder detenerse.",
       "uncancellableActions_one": "{{count}} acción no se pudo detener y puede seguir ejecutándose por su cuenta.",
-      "uncancellableActions_other": "{{count}} acciones no se pudieron detener y pueden seguir ejecutándose por su cuenta."
+      "uncancellableActions_other": "{{count}} acciones no se pudieron detener y pueden seguir ejecutándose por su cuenta.",
+      "cancelRunSuccess_one": "Cancelado: {{count}} ejecución detenida.",
+      "cancelRunSuccess_other": "Cancelado: {{count}} ejecuciones detenidas."
     },
     "timestamps": {
       "started": "Iniciado: {{date}}",

--- a/apps/web/src/locales/es-419/scripts.json
+++ b/apps/web/src/locales/es-419/scripts.json
@@ -251,7 +251,8 @@
     "resultCount": {
       "passed": "{{count}} pasó",
       "failed": "{{count}} falló",
-      "skipped": "{{count}} omitido"
+      "skipped": "{{count}} omitido",
+      "cancelled": "{{count}} cancelado"
     },
     "duration": "Duración: {{duration}}",
     "progress": {
@@ -265,7 +266,13 @@
     },
     "actions": {
       "hideLogs": "Ocultar registros",
-      "viewLogs": "Ver registros"
+      "viewLogs": "Ver registros",
+      "cancelRun": "Cancelar ejecución",
+      "partnerScopeTooltip": "Esta ejecución se aplica a todas las organizaciones de su cuenta de socio. Pídale a un administrador de socio completo que la cancele, o detenga ejecuciones individuales en sus propios dispositivos.",
+      "confirmCancelRunTitle": "¿Cancelar esta ejecución?",
+      "confirmCancelRunMessage": "Breeze detendrá cada ejecución de script que esta ejecución aún esté esperando. Las acciones ya en curso pueden finalizar antes de poder detenerse.",
+      "uncancellableActions_one": "{{count}} acción no se pudo detener y puede seguir ejecutándose por su cuenta.",
+      "uncancellableActions_other": "{{count}} acciones no se pudieron detener y pueden seguir ejecutándose por su cuenta."
     },
     "timestamps": {
       "started": "Iniciado: {{date}}",
@@ -304,6 +311,9 @@
       "untitled": "Script",
       "awaiting": "Esperando la respuesta del agente…",
       "truncated": "Salida truncada: consulta el historial de scripts del dispositivo para ver el texto completo."
+    },
+    "errors": {
+      "cancelRun": "No se pudo cancelar la ejecución."
     }
   },
   "automationsPage": {
@@ -717,11 +727,19 @@
     },
     "empty": "No se encontraron ejecuciones. Intente ajustar sus filtros.",
     "actions": {
-      "viewDetails": "Ver detalles"
+      "viewDetails": "Ver detalles",
+      "stop": "Detener",
+      "forceStop": "Detener inmediatamente",
+      "confirmStopTitle": "¿Detener esta ejecución?",
+      "confirmStopMessage": "Breeze le pedirá al dispositivo que detenga {{script}}. Esto puede tardar unos segundos. \"Detener inmediatamente\" omite el período de gracia y finaliza el proceso de inmediato."
     },
     "pagination": {
       "showing": "Mostrando {{start}} a {{end}} de {{total}}",
       "page": "Página {{page}} de {{total}}"
+    },
+    "errors": {
+      "noLongerCancellable": "Esta ejecución ya terminó y ya no se puede detener.",
+      "cancelFailed": "No se pudo detener la ejecución."
     }
   },
   "scriptAiInput": {

--- a/apps/web/src/locales/fr-CA/scripts.json
+++ b/apps/web/src/locales/fr-CA/scripts.json
@@ -272,7 +272,9 @@
       "confirmCancelRunTitle": "Annuler cette exécution ?",
       "confirmCancelRunMessage": "Breeze arrêtera chaque exécution de script que cette exécution attend encore. Les actions déjà en cours peuvent se terminer avant de pouvoir être arrêtées.",
       "uncancellableActions_one": "{{count}} action n'a pas pu être arrêtée et pourrait continuer à s'exécuter seule.",
-      "uncancellableActions_other": "{{count}} actions n'ont pas pu être arrêtées et pourraient continuer à s'exécuter seules."
+      "uncancellableActions_other": "{{count}} actions n'ont pas pu être arrêtées et pourraient continuer à s'exécuter seules.",
+      "cancelRunSuccess_one": "Annulé — {{count}} exécution arrêtée.",
+      "cancelRunSuccess_other": "Annulé — {{count}} exécutions arrêtées."
     },
     "timestamps": {
       "started": "Démarré le {{date}}",

--- a/apps/web/src/locales/fr-CA/scripts.json
+++ b/apps/web/src/locales/fr-CA/scripts.json
@@ -251,7 +251,8 @@
     "resultCount": {
       "passed": "{{count}} réussis",
       "failed": "{{count}} en échec",
-      "skipped": "{{count}} ignorés"
+      "skipped": "{{count}} ignorés",
+      "cancelled": "{{count}} annulés"
     },
     "duration": "Durée : {{duration}}",
     "progress": {
@@ -265,7 +266,13 @@
     },
     "actions": {
       "hideLogs": "Masquer les journaux",
-      "viewLogs": "Voir les journaux"
+      "viewLogs": "Voir les journaux",
+      "cancelRun": "Annuler l'exécution",
+      "partnerScopeTooltip": "Cette exécution s'applique à toutes les organisations de votre compte partenaire. Demandez à un administrateur partenaire complet de l'annuler, ou arrêtez plutôt des exécutions individuelles sur vos propres appareils.",
+      "confirmCancelRunTitle": "Annuler cette exécution ?",
+      "confirmCancelRunMessage": "Breeze arrêtera chaque exécution de script que cette exécution attend encore. Les actions déjà en cours peuvent se terminer avant de pouvoir être arrêtées.",
+      "uncancellableActions_one": "{{count}} action n'a pas pu être arrêtée et pourrait continuer à s'exécuter seule.",
+      "uncancellableActions_other": "{{count}} actions n'ont pas pu être arrêtées et pourraient continuer à s'exécuter seules."
     },
     "timestamps": {
       "started": "Démarré le {{date}}",
@@ -304,6 +311,9 @@
       "untitled": "Script",
       "awaiting": "En attente de la réponse de l'agent…",
       "truncated": "Sortie tronquée — voir l'historique des scripts de l'appareil pour le texte complet."
+    },
+    "errors": {
+      "cancelRun": "Impossible d'annuler l'exécution."
     }
   },
   "automationsPage": {
@@ -717,11 +727,19 @@
     },
     "empty": "Aucune exécution trouvée. Essayez d’ajuster vos filtres.",
     "actions": {
-      "viewDetails": "Voir les détails"
+      "viewDetails": "Voir les détails",
+      "stop": "Arrêter",
+      "forceStop": "Arrêter immédiatement",
+      "confirmStopTitle": "Arrêter cette exécution ?",
+      "confirmStopMessage": "Breeze demandera à l'appareil d'arrêter {{script}}. Cela peut prendre quelques secondes — « Arrêter immédiatement » ignore le délai de grâce et met fin au processus sur-le-champ."
     },
     "pagination": {
       "showing": "Affichage de {{start}} à {{end}} sur {{total}}",
       "page": "Page {{page}} sur {{total}}"
+    },
+    "errors": {
+      "noLongerCancellable": "Cette exécution est déjà terminée et ne peut plus être arrêtée.",
+      "cancelFailed": "Impossible d'arrêter l'exécution."
     }
   },
   "scriptAiInput": {

--- a/apps/web/src/locales/fr-FR/scripts.json
+++ b/apps/web/src/locales/fr-FR/scripts.json
@@ -272,7 +272,9 @@
       "confirmCancelRunTitle": "Annuler cette exécution ?",
       "confirmCancelRunMessage": "Breeze arrêtera chaque exécution de script que cette exécution attend encore. Les actions déjà en cours peuvent se terminer avant de pouvoir être arrêtées.",
       "uncancellableActions_one": "{{count}} action n'a pas pu être arrêtée et pourrait continuer à s'exécuter seule.",
-      "uncancellableActions_other": "{{count}} actions n'ont pas pu être arrêtées et pourraient continuer à s'exécuter seules."
+      "uncancellableActions_other": "{{count}} actions n'ont pas pu être arrêtées et pourraient continuer à s'exécuter seules.",
+      "cancelRunSuccess_one": "Annulé — {{count}} exécution arrêtée.",
+      "cancelRunSuccess_other": "Annulé — {{count}} exécutions arrêtées."
     },
     "timestamps": {
       "started": "Démarré le {{date}}",

--- a/apps/web/src/locales/fr-FR/scripts.json
+++ b/apps/web/src/locales/fr-FR/scripts.json
@@ -251,7 +251,8 @@
     "resultCount": {
       "passed": "{{count}} réussis",
       "failed": "{{count}} en échec",
-      "skipped": "{{count}} ignorés"
+      "skipped": "{{count}} ignorés",
+      "cancelled": "{{count}} annulés"
     },
     "duration": "Durée : {{duration}}",
     "progress": {
@@ -265,7 +266,13 @@
     },
     "actions": {
       "hideLogs": "Masquer les journaux",
-      "viewLogs": "Voir les journaux"
+      "viewLogs": "Voir les journaux",
+      "cancelRun": "Annuler l'exécution",
+      "partnerScopeTooltip": "Cette exécution s'applique à toutes les organisations de votre compte partenaire. Demandez à un administrateur partenaire complet de l'annuler, ou arrêtez plutôt des exécutions individuelles sur vos propres appareils.",
+      "confirmCancelRunTitle": "Annuler cette exécution ?",
+      "confirmCancelRunMessage": "Breeze arrêtera chaque exécution de script que cette exécution attend encore. Les actions déjà en cours peuvent se terminer avant de pouvoir être arrêtées.",
+      "uncancellableActions_one": "{{count}} action n'a pas pu être arrêtée et pourrait continuer à s'exécuter seule.",
+      "uncancellableActions_other": "{{count}} actions n'ont pas pu être arrêtées et pourraient continuer à s'exécuter seules."
     },
     "timestamps": {
       "started": "Démarré le {{date}}",
@@ -304,6 +311,9 @@
       "untitled": "Script",
       "awaiting": "En attente de la réponse de l'agent…",
       "truncated": "Sortie tronquée — voir l'historique des scripts de l'appareil pour le texte complet."
+    },
+    "errors": {
+      "cancelRun": "Impossible d'annuler l'exécution."
     }
   },
   "automationsPage": {
@@ -717,11 +727,19 @@
     },
     "empty": "Aucune exécution trouvée. Essayez d’ajuster vos filtres.",
     "actions": {
-      "viewDetails": "Voir les détails"
+      "viewDetails": "Voir les détails",
+      "stop": "Arrêter",
+      "forceStop": "Arrêter immédiatement",
+      "confirmStopTitle": "Arrêter cette exécution ?",
+      "confirmStopMessage": "Breeze demandera à l'appareil d'arrêter {{script}}. Cela peut prendre quelques secondes — « Arrêter immédiatement » ignore le délai de grâce et met fin au processus sur-le-champ."
     },
     "pagination": {
       "showing": "Affichage de {{start}} à {{end}} sur {{total}}",
       "page": "Page {{page}} sur {{total}}"
+    },
+    "errors": {
+      "noLongerCancellable": "Cette exécution est déjà terminée et ne peut plus être arrêtée.",
+      "cancelFailed": "Impossible d'arrêter l'exécution."
     }
   },
   "scriptAiInput": {

--- a/apps/web/src/locales/it-IT/scripts.json
+++ b/apps/web/src/locales/it-IT/scripts.json
@@ -251,7 +251,8 @@
     "resultCount": {
       "passed": "{{count}} superati",
       "failed": "{{count}} non riusciti",
-      "skipped": "{{count}} ignorati"
+      "skipped": "{{count}} ignorati",
+      "cancelled": "{{count}} annullati"
     },
     "duration": "Durata: {{duration}}",
     "progress": {
@@ -265,7 +266,13 @@
     },
     "actions": {
       "hideLogs": "Nascondi log",
-      "viewLogs": "Visualizza log"
+      "viewLogs": "Visualizza log",
+      "cancelRun": "Annulla esecuzione",
+      "partnerScopeTooltip": "Questa esecuzione si applica a tutte le organizzazioni del tuo account partner. Chiedi a un amministratore partner completo di annullarla, oppure interrompi singole esecuzioni sui tuoi dispositivi.",
+      "confirmCancelRunTitle": "Annullare questa esecuzione?",
+      "confirmCancelRunMessage": "Breeze interromperà ogni esecuzione di script che questa esecuzione sta ancora attendendo. Le azioni già in corso potrebbero terminare prima di poter essere interrotte.",
+      "uncancellableActions_one": "{{count}} azione non è stata interrotta e potrebbe essere ancora in esecuzione per conto proprio.",
+      "uncancellableActions_other": "{{count}} azioni non sono state interrotte e potrebbero essere ancora in esecuzione per conto proprio."
     },
     "timestamps": {
       "started": "Avviata: {{date}}",
@@ -304,6 +311,9 @@
       "untitled": "Script",
       "awaiting": "In attesa della risposta dell'agente…",
       "truncated": "Output troncato: consulta la cronologia degli script del dispositivo per il testo completo."
+    },
+    "errors": {
+      "cancelRun": "Impossibile annullare l'esecuzione."
     }
   },
   "automationsPage": {
@@ -717,11 +727,19 @@
     },
     "empty": "Nessuna esecuzione trovata. Prova a modificare i filtri.",
     "actions": {
-      "viewDetails": "Visualizza dettagli"
+      "viewDetails": "Visualizza dettagli",
+      "stop": "Interrompi",
+      "forceStop": "Interrompi immediatamente",
+      "confirmStopTitle": "Interrompere questa esecuzione?",
+      "confirmStopMessage": "Breeze chiederà al dispositivo di interrompere {{script}}. L'operazione può richiedere alcuni secondi — “Interrompi immediatamente” salta il periodo di tolleranza e termina il processo all'istante."
     },
     "pagination": {
       "showing": "Visualizzazione da {{start}} a {{end}} di {{total}}",
       "page": "Pagina {{page}} di {{total}}"
+    },
+    "errors": {
+      "noLongerCancellable": "Questa esecuzione è già terminata e non può più essere interrotta.",
+      "cancelFailed": "Impossibile interrompere l'esecuzione."
     }
   },
   "scriptAiInput": {

--- a/apps/web/src/locales/it-IT/scripts.json
+++ b/apps/web/src/locales/it-IT/scripts.json
@@ -272,7 +272,9 @@
       "confirmCancelRunTitle": "Annullare questa esecuzione?",
       "confirmCancelRunMessage": "Breeze interromperà ogni esecuzione di script che questa esecuzione sta ancora attendendo. Le azioni già in corso potrebbero terminare prima di poter essere interrotte.",
       "uncancellableActions_one": "{{count}} azione non è stata interrotta e potrebbe essere ancora in esecuzione per conto proprio.",
-      "uncancellableActions_other": "{{count}} azioni non sono state interrotte e potrebbero essere ancora in esecuzione per conto proprio."
+      "uncancellableActions_other": "{{count}} azioni non sono state interrotte e potrebbero essere ancora in esecuzione per conto proprio.",
+      "cancelRunSuccess_one": "Annullato — {{count}} esecuzione interrotta.",
+      "cancelRunSuccess_other": "Annullato — {{count}} esecuzioni interrotte."
     },
     "timestamps": {
       "started": "Avviata: {{date}}",

--- a/apps/web/src/locales/pt-BR/scripts.json
+++ b/apps/web/src/locales/pt-BR/scripts.json
@@ -272,7 +272,9 @@
       "confirmCancelRunTitle": "Cancelar esta execução?",
       "confirmCancelRunMessage": "O Breeze interromperá cada execução de script que esta execução ainda estiver aguardando. Ações já em andamento podem terminar antes de poderem ser interrompidas.",
       "uncancellableActions_one": "{{count}} ação não pôde ser interrompida e pode continuar em execução por conta própria.",
-      "uncancellableActions_other": "{{count}} ações não puderam ser interrompidas e podem continuar em execução por conta própria."
+      "uncancellableActions_other": "{{count}} ações não puderam ser interrompidas e podem continuar em execução por conta própria.",
+      "cancelRunSuccess_one": "Cancelado — {{count}} execução interrompida.",
+      "cancelRunSuccess_other": "Cancelado — {{count}} execuções interrompidas."
     },
     "timestamps": {
       "started": "Iniciada em: {{date}}",

--- a/apps/web/src/locales/pt-BR/scripts.json
+++ b/apps/web/src/locales/pt-BR/scripts.json
@@ -251,7 +251,8 @@
     "resultCount": {
       "passed": "{{count}} aprovados",
       "failed": "{{count}} com falha",
-      "skipped": "{{count}} ignorados"
+      "skipped": "{{count}} ignorados",
+      "cancelled": "{{count}} cancelados"
     },
     "duration": "Duração: {{duration}}",
     "progress": {
@@ -265,7 +266,13 @@
     },
     "actions": {
       "hideLogs": "Ocultar logs",
-      "viewLogs": "Ver logs"
+      "viewLogs": "Ver logs",
+      "cancelRun": "Cancelar execução",
+      "partnerScopeTooltip": "Esta execução se aplica a todas as organizações da sua conta de parceiro. Peça a um administrador de parceiro completo para cancelá-la, ou interrompa execuções individuais nos seus próprios dispositivos.",
+      "confirmCancelRunTitle": "Cancelar esta execução?",
+      "confirmCancelRunMessage": "O Breeze interromperá cada execução de script que esta execução ainda estiver aguardando. Ações já em andamento podem terminar antes de poderem ser interrompidas.",
+      "uncancellableActions_one": "{{count}} ação não pôde ser interrompida e pode continuar em execução por conta própria.",
+      "uncancellableActions_other": "{{count}} ações não puderam ser interrompidas e podem continuar em execução por conta própria."
     },
     "timestamps": {
       "started": "Iniciada em: {{date}}",
@@ -304,6 +311,9 @@
       "untitled": "Script",
       "awaiting": "Aguardando a resposta do agente…",
       "truncated": "Saída truncada — consulte o histórico de scripts do dispositivo para ver o texto completo."
+    },
+    "errors": {
+      "cancelRun": "Não foi possível cancelar a execução."
     }
   },
   "automationsPage": {
@@ -717,11 +727,19 @@
     },
     "empty": "Nenhuma execução encontrada. Tente ajustar os filtros.",
     "actions": {
-      "viewDetails": "Ver detalhes"
+      "viewDetails": "Ver detalhes",
+      "stop": "Interromper",
+      "forceStop": "Interromper imediatamente",
+      "confirmStopTitle": "Interromper esta execução?",
+      "confirmStopMessage": "O Breeze pedirá ao dispositivo que interrompa {{script}}. Isso pode levar alguns segundos — “Interromper imediatamente” pula o período de tolerância e encerra o processo na hora."
     },
     "pagination": {
       "showing": "Mostrando {{start}} a {{end}} de {{total}}",
       "page": "Página {{page}} de {{total}}"
+    },
+    "errors": {
+      "noLongerCancellable": "Esta execução já foi concluída e não pode mais ser interrompida.",
+      "cancelFailed": "Falha ao interromper a execução."
     }
   },
   "scriptAiInput": {

--- a/apps/web/src/locales/tr-TR/scripts.json
+++ b/apps/web/src/locales/tr-TR/scripts.json
@@ -251,7 +251,8 @@
     "resultCount": {
       "passed": "{{count}} geçti",
       "failed": "{{count}} başarısız oldu",
-      "skipped": "{{count}} atlandı"
+      "skipped": "{{count}} atlandı",
+      "cancelled": "{{count}} iptal edildi"
     },
     "duration": "Süre: {{duration}}\n__BREEZE_TOKEN_1__ cihazdan ",
     "progress": {
@@ -265,7 +266,13 @@
     },
     "actions": {
       "hideLogs": "Günlükleri Gizle",
-      "viewLogs": "Günlükleri Görüntüle"
+      "viewLogs": "Günlükleri Görüntüle",
+      "cancelRun": "Çalıştırmayı iptal et",
+      "partnerScopeTooltip": "Bu çalıştırma, iş ortağı hesabınızdaki tüm kuruluşlar için geçerlidir. İptal etmesi için tam yetkili bir iş ortağı yöneticisinden isteyin veya bunun yerine kendi cihazlarınızdaki tek tek yürütmeleri durdurun.",
+      "confirmCancelRunTitle": "Bu çalıştırma iptal edilsin mi?",
+      "confirmCancelRunMessage": "Breeze, bu çalıştırmanın hâlâ beklediği her komut dosyası yürütmesini durduracak. Zaten devam etmekte olan işlemler durdurulmadan önce tamamlanabilir.",
+      "uncancellableActions_one": "{{count}} eylem durdurulamadı ve kendi başına çalışmaya devam ediyor olabilir.",
+      "uncancellableActions_other": "{{count}} eylem durdurulamadı ve kendi başına çalışmaya devam ediyor olabilir."
     },
     "timestamps": {
       "started": "Başlangıç: {{date}}",
@@ -304,6 +311,9 @@
       "untitled": "Komut Dosyası",
       "awaiting": "Temsilcinin rapor vermesi bekleniyor…",
       "truncated": "Çıktı kesildi — tam metin için cihazın komut dosyası geçmişine bakın."
+    },
+    "errors": {
+      "cancelRun": "Çalıştırma iptal edilemedi."
     }
   },
   "automationsPage": {
@@ -717,11 +727,19 @@
     },
     "empty": "Hiçbir yürütme bulunamadı. Filtrelerinizi ayarlamayı deneyin.",
     "actions": {
-      "viewDetails": "Ayrıntıları görüntüle"
+      "viewDetails": "Ayrıntıları görüntüle",
+      "stop": "Durdur",
+      "forceStop": "Hemen durdur",
+      "confirmStopTitle": "Bu yürütme durdurulsun mu?",
+      "confirmStopMessage": "Breeze, cihazdan {{script}} işlemini durdurmasını isteyecek. Bu birkaç saniye sürebilir — “Hemen durdur” bekleme süresini atlar ve işlemi anında sonlandırır."
     },
     "pagination": {
       "showing": "{{start}} ila {{end}} / {{total}} gösteriliyor",
       "page": "Sayfa {{page}} / {{total}}"
+    },
+    "errors": {
+      "noLongerCancellable": "Bu yürütme zaten tamamlandı ve artık durdurulamaz.",
+      "cancelFailed": "Yürütme durdurulamadı."
     }
   },
   "scriptAiInput": {

--- a/apps/web/src/locales/tr-TR/scripts.json
+++ b/apps/web/src/locales/tr-TR/scripts.json
@@ -272,7 +272,9 @@
       "confirmCancelRunTitle": "Bu çalıştırma iptal edilsin mi?",
       "confirmCancelRunMessage": "Breeze, bu çalıştırmanın hâlâ beklediği her komut dosyası yürütmesini durduracak. Zaten devam etmekte olan işlemler durdurulmadan önce tamamlanabilir.",
       "uncancellableActions_one": "{{count}} eylem durdurulamadı ve kendi başına çalışmaya devam ediyor olabilir.",
-      "uncancellableActions_other": "{{count}} eylem durdurulamadı ve kendi başına çalışmaya devam ediyor olabilir."
+      "uncancellableActions_other": "{{count}} eylem durdurulamadı ve kendi başına çalışmaya devam ediyor olabilir.",
+      "cancelRunSuccess_one": "İptal edildi — {{count}} yürütme durduruldu.",
+      "cancelRunSuccess_other": "İptal edildi — {{count}} yürütme durduruldu."
     },
     "timestamps": {
       "started": "Başlangıç: {{date}}",

--- a/e2e-tests/pages/ScriptsPage.ts
+++ b/e2e-tests/pages/ScriptsPage.ts
@@ -1,0 +1,49 @@
+import type { Page } from '@playwright/test';
+import { BasePage } from './BasePage';
+
+/**
+ * Page object for a single script's execution history (`/scripts/:id`,
+ * ScriptExecutionsPage.tsx). testid-only — see e2e-tests/README.md.
+ *
+ * There is no page object for the Script Library / creation flow yet: those
+ * components (ScriptList.tsx, ScriptForm.tsx) carry no data-testid coverage
+ * today, so #4767's spec creates and executes its fixture script directly
+ * against the API (see script-cancel.spec.ts) and only drives the UI for the
+ * Stop interaction this wave actually owns.
+ */
+export class ScriptsPage extends BasePage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async gotoScript(scriptId: string) {
+    await this.page.goto(`/scripts/${scriptId}`);
+  }
+
+  /** The status badge for one execution row, indexed by execution id. */
+  executionStatus(executionId: string) {
+    return this.page.getByTestId(`execution-status-${executionId}`);
+  }
+
+  cancelExecutionButton(executionId: string) {
+    return this.page.getByTestId(`cancel-execution-${executionId}`);
+  }
+
+  confirmStopButton() {
+    return this.page.getByTestId('confirm-stop');
+  }
+
+  confirmForceStopButton() {
+    return this.page.getByTestId('confirm-force-stop');
+  }
+
+  async cancelExecution(executionId: string) {
+    await this.cancelExecutionButton(executionId).click();
+    await this.confirmStopButton().click();
+  }
+
+  async forceStopExecution(executionId: string) {
+    await this.cancelExecutionButton(executionId).click();
+    await this.confirmForceStopButton().click();
+  }
+}

--- a/e2e-tests/pages/ScriptsPage.ts
+++ b/e2e-tests/pages/ScriptsPage.ts
@@ -2,14 +2,20 @@ import type { Page } from '@playwright/test';
 import { BasePage } from './BasePage';
 
 /**
- * Page object for a single script's execution history (`/scripts/:id`,
- * ScriptExecutionsPage.tsx). testid-only — see e2e-tests/README.md.
+ * Page object for a single script's execution history
+ * (`/scripts/:id/executions`, `apps/web/src/pages/scripts/[id]/executions.astro`
+ * → `ScriptExecutionsPage.tsx`). testid-only — see e2e-tests/README.md.
  *
- * There is no page object for the Script Library / creation flow yet: those
- * components (ScriptList.tsx, ScriptForm.tsx) carry no data-testid coverage
- * today, so #4767's spec creates and executes its fixture script directly
- * against the API (see script-cancel.spec.ts) and only drives the UI for the
- * Stop interaction this wave actually owns.
+ * NOT `/scripts/:id` — that route (`apps/web/src/pages/scripts/[id].astro`)
+ * renders `ScriptEditPage`, a different component with none of the
+ * execution-row testids this page object reads.
+ *
+ * There is no page object for the Script Library / creation flow yet:
+ * `ScriptList.tsx` has zero `data-testid` coverage and `ScriptForm.tsx` has
+ * none on its create/submit fields (only on unrelated warning banners), so
+ * #4767's spec creates and executes its fixture script directly against the
+ * API (see script-cancel.spec.ts) and only drives the UI for the Stop
+ * interaction this wave actually owns.
  */
 export class ScriptsPage extends BasePage {
   constructor(page: Page) {
@@ -17,7 +23,7 @@ export class ScriptsPage extends BasePage {
   }
 
   async gotoScript(scriptId: string) {
-    await this.page.goto(`/scripts/${scriptId}`);
+    await this.page.goto(`/scripts/${scriptId}/executions`);
   }
 
   /** The status badge for one execution row, indexed by execution id. */

--- a/e2e-tests/tests/script-cancel.spec.ts
+++ b/e2e-tests/tests/script-cancel.spec.ts
@@ -1,0 +1,100 @@
+import { test, expect } from '../fixtures';
+import type { APIRequestContext, Page, Request } from '@playwright/test';
+import { ScriptsPage } from '../pages/ScriptsPage';
+
+// Seeded by e2e-tests/seed-fixtures.sql — see v_macos_device_id there.
+const SEEDED_DEVICE_ID = '42fc7de0-48f5-48f2-846b-6dd95924baf9';
+
+/**
+ * Recover the access token the app itself is using, by watching one of its
+ * own authenticated API calls (same technique as multi-currency.spec.ts).
+ *
+ * The auth store persists only the user profile to localStorage — the access
+ * token lives in memory, so it's lifted off an outgoing request header
+ * instead of minted fresh (a fresh POST /auth/refresh would rotate the
+ * session's refresh cookie out from under the rest of the test).
+ */
+async function readAccessToken(page: Page): Promise<string> {
+  let token: string | null = null;
+  const onRequest = (req: Request) => {
+    if (token) return;
+    const header = req.headers()['authorization'];
+    if (header?.startsWith('Bearer ') && req.url().includes('/api/v1/')) token = header.slice(7);
+  };
+  page.on('request', onRequest);
+  try {
+    await page.goto('/');
+    await expect.poll(() => token, {
+      message: 'an authenticated /api/v1 request from the app',
+      timeout: 30_000,
+    }).toBeTruthy();
+  } finally {
+    page.off('request', onRequest);
+  }
+  return token!;
+}
+
+async function apiJson<T>(
+  request: APIRequestContext,
+  token: string,
+  method: 'get' | 'post',
+  path: string,
+  data?: unknown,
+): Promise<T> {
+  const res = await request[method](path, {
+    headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+    ...(data === undefined ? {} : { data }),
+  });
+  expect(res.ok(), `${method.toUpperCase()} ${path} → ${res.status()} ${await res.text()}`).toBeTruthy();
+  return (await res.json()) as T;
+}
+
+type ScriptAdmissionResult = {
+  targets: Array<{ deviceId: string; admission: string; executionId?: string }>;
+};
+
+test.describe('Stop a running script execution (#4767)', () => {
+  // There is no fake/live agent in the e2e stack (only postgres + redis are
+  // driven by docker compose here — see global-setup.ts), so the command
+  // this creates is never delivered and its device_commands row stays
+  // `pending` forever. That is exactly the case scriptCancellation.ts's
+  // retraction branch (3a) proves synchronously, server-side, with no device
+  // involved: it atomically cancels the still-pending command and marks the
+  // execution `cancelled`/`confirmed` in the same request. This is real,
+  // fully provable behavior, not a fake wait for something this stack can't
+  // do — but it means this spec cannot exercise the `cancelling` → device-ack
+  // path (W03/W04, the agent's own Cancel handler), which needs a live or
+  // simulated agent.
+  test('a pending script execution can be stopped, and the row shows Cancelled', async ({ authedPage: page }) => {
+    const scripts = new ScriptsPage(page);
+    const token = await readAccessToken(page);
+
+    const script = await apiJson<{ id: string }>(page.request, token, 'post', '/api/v1/scripts', {
+      name: `e2e-cancel-fixture-${Date.now()}`,
+      osTypes: ['macos'],
+      language: 'bash',
+      content: 'sleep 120',
+      timeoutSeconds: 300,
+      runAs: 'system',
+    });
+
+    const admission = await apiJson<ScriptAdmissionResult>(
+      page.request, token, 'post', `/api/v1/scripts/${script.id}/execute`,
+      { deviceIds: [SEEDED_DEVICE_ID], parameters: {}, runAs: 'system' },
+    );
+    const target = admission.targets.find((t) => t.deviceId === SEEDED_DEVICE_ID);
+    expect(target?.admission, JSON.stringify(admission)).toBe('admitted');
+    const executionId = target!.executionId!;
+    expect(executionId).toBeTruthy();
+
+    await scripts.gotoScript(script.id);
+    await expect(scripts.executionStatus(executionId)).toHaveText(/pending|queued/i);
+
+    await scripts.cancelExecution(executionId);
+
+    // No live agent ever picks the command up, so the server's own retraction
+    // branch fires: it never leaves `pending`, and the row goes straight to a
+    // confirmed Cancelled without ever passing through "Stopping…" here.
+    await expect(scripts.executionStatus(executionId)).toHaveText(/cancelled/i, { timeout: 10_000 });
+  });
+});

--- a/e2e-tests/tests/script-cancel.spec.ts
+++ b/e2e-tests/tests/script-cancel.spec.ts
@@ -49,8 +49,11 @@ async function apiJson<T>(
   return (await res.json()) as T;
 }
 
+// Mirrors packages/shared/src/types/scriptAdmission.ts (not imported directly:
+// e2e-tests is a standalone npm package outside the pnpm workspace, so
+// @breeze/shared does not resolve here).
 type ScriptAdmissionResult = {
-  targets: Array<{ deviceId: string; admission: string; executionId?: string }>;
+  targets: Array<{ requestedDeviceId: string; admission: string; executionId?: string }>;
 };
 
 test.describe('Stop a running script execution (#4767)', () => {
@@ -82,7 +85,7 @@ test.describe('Stop a running script execution (#4767)', () => {
       page.request, token, 'post', `/api/v1/scripts/${script.id}/execute`,
       { deviceIds: [SEEDED_DEVICE_ID], parameters: {}, runAs: 'system' },
     );
-    const target = admission.targets.find((t) => t.deviceId === SEEDED_DEVICE_ID);
+    const target = admission.targets.find((t) => t.requestedDeviceId === SEEDED_DEVICE_ID);
     expect(target?.admission, JSON.stringify(admission)).toBe('admitted');
     const executionId = target!.executionId!;
     expect(executionId).toBeTruthy();


### PR DESCRIPTION
Closes #4767

Wave 6 of 6 for #3525/#4761 (Cancel a Running Script or Automation) — web affordances, polling, i18n, docs, and E2E. Depends on W01 (#4788, merged) and W02 (#4799, merged); all four prerequisite waves (#4788, #4799, #4967 W03, #4990 W07) are merged on `main` and the route contract was read directly off `apps/api/src/routes/scripts.ts` on `main` before writing the client.

## What changed

**Task 6.1 — Stop button (script executions)**
- `ExecutionHistory.tsx`: per-row Stop button (`pending|queued|running` only, hidden — not disabled — without `scripts:execute`), a disabled "Stopping…" spinner while `cancelling`, and `resolveExecutionStatusLabel` (W01) replacing the raw status label so an unconfirmed/too-late stop reads honestly instead of a bare "Completed".
- `ExecutionDetails.tsx`: the same Stop affordance in the header, sharing the same `ConfirmDialog` + Force-stop (`graceSeconds: 0`) pattern via the dialog's `children` slot (no change to `ConfirmDialog.tsx` itself, which only supports one primary action).
- `ScriptExecutionsPage.tsx`: `handleCancel` wraps `POST /scripts/executions/:id/cancel` in `runAction`, mapping the route's dynamic 409 body ("Cannot cancel execution with status: …") to `executionHistory.errors.noLongerCancellable` by prefix match (the route sends no stable `code` field), and using `handleActionError` for anything else. Polls every 2s while any execution is `running`/`cancelling`, keyed on a derived boolean so the interval isn't torn down every tick. The details modal's own snapshot (`selectedExecution`) resyncs on every refetch, so Stop clicked from inside the modal reflects back into it.
- `no-silent-mutations.test.ts`: added `ExecutionHistory.tsx`/`ExecutionDetails.tsx`/`ScriptExecutionsPage.tsx`/`AutomationRunHistory.tsx` to `TARGET_GLOBS` (the guard's list is literal file paths, not real globs) and fixed the one bare `fetchWithAuth` it flagged (`handleExecute`) with a `// runaction-exempt:` marker — it already reports failure/success inline through `ScriptExecutionModal`, a toast on top would be redundant.

**Task 6.2 — Cancel run (automation runs)**
W05's route (sibling PR #5030, `POST /automations/runs/:runId/cancel`) opened mid-review, so this is now built and verified against the **real, PR-diffed route** rather than the plan's prose: response `{ success, run: {id, status}, alreadyCancelling, actionsCancelled, executionsCancelled, executions, uncancellableActions }`, gated on `requireAutomationWrite` (**`automations:write`**, not `scripts:execute` — that permission gates the separate, execution-level cancel route only), 403 on a partner-wide run without `canManagePartnerWidePolicies`, 404 for a config-policy or missing run, 409 (`Cannot cancel a run with status: …`) if it already finished. The component now:
- Renders `data-testid="cancel-run"` on a `running` run, gated on `automations:write` and (for `ownerScope: 'partner'` runs) a new `canManagePartnerWide` prop — hidden with a compact info-icon tooltip (`cancel-run-partner-tooltip`) for an org-scoped operator on a partner-wide run (OD7-A: they can still cancel their own devices' individual executions).
- Surfaces `uncancellableActions` inline rather than claiming the run stopped, shows a success toast naming how many executions were cancelled, and renders `devicesCancelled` as its own count, separate from succeeded/failed.
- Restructured the row's outer `<button>` into a plain row with the toggle as its own `<button>` (left content) so the new Cancel-run `<button>` isn't nested inside another button (invalid HTML) — the pre-existing test file's `.closest('button')` calls still resolve correctly against the toggle button, no changes needed there.
- **`AutomationsPage.tsx` now wires `permissions`/`canManagePartnerWide`/`onRunCancelled`** into `AutomationRunHistory` — without this the whole affordance would have been unreachable dead code (caught in review, see below).

**Task 6.3 — i18n, docs, AI-risk tier, E2E**
- All 8 locales (`en` + 7 translated) got the new keys real, non-English translations, verified against `localeParity`/`translationCoverage`/`terminologyQuality`/`extractionQuality` (135/135 passing) — terminology for "stop"/"run" matched to each locale's existing verb already used in the W01 status copy (e.g. DE `stoppen`, FR `arrêter`, TR `durdurmak`).
- `tierConfig.ts`: registered `cancel_script_execution` at tier 3 (noted missing from the AI-risk registry in #4990's PR body).
- `apps/docs/src/content/docs/agents/commands.mdx`: documents `script_cancel`'s `graceSeconds`/`scriptExecutionId` fields, that `executionId` is the **original command's id**, the `{executionId, outcome, cancelled}` result shape, and the no-graceful-phase-on-Windows behavior — all verified against the actual agent/API source, not the plan's prose.
- New `apps/docs/src/content/docs/scripts/stopping-a-running-script.mdx` (added to the sidebar in `astro.config.mjs`, next to the existing Scripts feature page) — what Stop/Force-stop do, what an unconfirmed stop means, what they don't cover (detached processes, scheduled tasks the script itself registers), and a caveat about the `cancelState` read-path gap below.
- `e2e-tests/pages/ScriptsPage.ts` + `e2e-tests/tests/script-cancel.spec.ts` — navigates to `/scripts/:id/executions` (not `/scripts/:id`, which is the script *editor*), creates its fixture script/execution directly against the real API, and drives only the Stop interaction through the UI.

## Deviations from the plan (flagged per the process rules)

1. **E2E scenario differs from the plan's literal script.** The plan's snippet assumes a seeded 120s-sleep script and a live agent that eventually acks `Cancelled`. Neither exists in this e2e stack (`global-setup.ts` only brings up postgres+redis; the seeded devices are DB rows with no live WebSocket agent — confirmed no other script-execution e2e spec exists today either). Rather than write an unrunnable spec, I read `scriptCancellation.ts`'s retraction branch (3a): since the command is never delivered, it stays `pending` forever, and the cancel route retracts it **synchronously, server-side, with proof** — the execution goes straight to `cancelled`/`confirmed` in the same request. The spec creates its script + execution directly against the real API (`page.request`, bearer token sniffed off an authenticated request the same way `multi-currency.spec.ts` already does), then drives the Stop button through the UI and asserts this real, provable outcome. It does **not** exercise the `cancelling` → device-ack path (W03/W04 territory) — that needs a live or simulated agent.
2. **Per-row Stop button testid disambiguated.** The plan's snippets used a bare `cancel-execution` testid; with more than one cancellable row (or the row + the details modal open simultaneously) that collides under Playwright's/RTL's strict-mode. Row buttons are now `cancel-execution-<executionId>`; `ExecutionDetails`' single button keeps the bare `cancel-execution` id since only one is ever mounted.
3. **AutomationRunHistory's cancel mutation lives in the component itself**, not behind a callback prop, since (a) I don't own any automations *page* file in this brief (though I did end up touching `AutomationsPage.tsx` — see the review-fix below), and (b) the plan's own test snippet mocks `fetchWithAuth` directly rather than a passed-in handler.

## Review round (this PR's own review-pr, 4 parallel agents)

Caught and fixed before merge — see the `efe22f3321` commit and the PR comment with the full review summary:
- **Cancel run was unreachable in production** — `AutomationsPage.tsx` never passed the three new props down. Fixed.
- **Wrong client-side permission** — checked `scripts:execute` instead of the route's real `automations:write` (only knowable once #5030 opened mid-review). Fixed.
- **E2E spec had two bugs that would have failed on first run** — wrong URL, wrong field name. Fixed and re-verified with `tsc --noEmit` + `playwright test --list`.
- **Silent 401 on Cancel run**, **zero test coverage on `ExecutionDetails`' Stop wiring**, **stale details-modal snapshot after cancel**, **partner tooltip rendered as inline paragraph text** — all fixed, with new regression tests.

## Not verified

- **E2E spec was not run against a live stack.** `pnpm wt-stack up` in this worktree failed on multiple `.env` vars (`REMOTE_WS_REDIS_TOPOLOGY`, `EVENT_PERMISSION_EPOCH_MODE`, and others — the checked-out `.env` is significantly stale vs. `.env.example`, ~50 vars behind) that would need a proper provisioning pass out of scope for this UI-only wave, on a host already running 8 other worktree stacks. Verified instead: `npx tsc --noEmit` clean in `e2e-tests/`, and `npx playwright test --list` resolves the spec correctly.
- **Task 6.1's `cancelState` gap on the read path.** `GET /scripts/:id/executions` and `GET /scripts/executions/:id` (`apps/api/src/routes/scripts.ts`) do not select `cancel_state` — only the cancel route's own response does. Without it, `resolveExecutionStatusLabel`'s "too late"/"stop failed" copy can never actually render against real data (unit tests pass because they pass `cancelState` directly as a prop, bypassing the API). This is an `apps/api` fix outside this wave's file ownership (and W05/#5030 is concurrently touching `apps/api`); the docs page now carries a caveat about it, and a follow-up issue should be filed to add the column to both SELECTs.
- **A second surface, `DeviceScriptHistory.tsx`** (the device Scripts tab, where #4886's post-run redirect sends the operator to watch the script they just launched) lists script executions with its own local type/rendering and gets no Stop button from this PR — flagged in review as a "sweep all call sites" gap. Left for a follow-up rather than expanding this wave's scope further.
- **`ownerScope` is not yet on the GET runs list response** — #5030 only sets it in the cancel route's own audit details, not on `GET /automations/:id/runs`. Until a follow-up adds it, every run's `ownerScope` is `undefined` client-side, which this component treats as `'organization'` (Cancel run stays offered) — the safe default, but it means the partner-wide hide/tooltip path (OD7-A) has no real data to exercise yet either.

## Tests

- `cd apps/web && npx vitest run src/components/scripts src/components/automations src/lib/__tests__/no-silent-mutations.test.ts src/lib/i18n/ src/components/ai-risk` — 578/578 passing.
- `pnpm --filter @breeze/web exec astro check` — 0 errors, 0 warnings.
- `pnpm --filter @breeze/docs build` — 170 pages built clean, including the new docs page.
- `pnpm lint` — clean.
- `e2e-tests`: `npx tsc --noEmit` clean; `npx playwright test --list` resolves 1 test. Not executed end-to-end (see Not verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
