### PR TITLE
feat(web): Remove asks about the agent — uninstall by default (#3987 items 2, 6)

### DIFF
--- a/apps/api/src/routes/devices/index.test.ts
+++ b/apps/api/src/routes/devices/index.test.ts
@@ -11,6 +11,18 @@ describe('device router mount order', () => {
     expect(coreMount).toBeGreaterThan(rollbackMount);
   });
 
+  it('mounts the Remove-dialog config route before core parameter routes (#3987)', () => {
+    // `/removal-config` is a STATIC path under /devices. Mounted after
+    // coreRoutes, core's `GET /:id` matcher would claim it and the Remove
+    // dialog would fetch a 404 (or a 400 uuid error) instead of the window.
+    const source = readFileSync(fileURLToPath(new URL('./index.ts', import.meta.url)), 'utf8');
+    expect(source).toContain("import { removalConfigRoutes } from './removalConfig'");
+    const removalMount = source.indexOf("deviceRoutes.route('/', removalConfigRoutes)");
+    const coreMount = source.indexOf("deviceRoutes.route('/', coreRoutes)");
+    expect(removalMount).toBeGreaterThan(-1);
+    expect(coreMount).toBeGreaterThan(removalMount);
+  });
+
   it('mounts the billing sub-resource after core parameter routes (#3205 W06)', () => {
     const source = readFileSync(fileURLToPath(new URL('./index.ts', import.meta.url)), 'utf8');
     expect(source).toContain("import { billingRoutes } from './billing'");

--- a/apps/api/src/routes/devices/index.ts
+++ b/apps/api/src/routes/devices/index.ts
@@ -32,6 +32,7 @@ import { statsRoutes } from './stats';
 import { postureRoutes } from './posture';
 import { optionsRoutes } from './options';
 import { healthRoutes } from './health';
+import { removalConfigRoutes } from './removalConfig';
 import { agentRollbackRoutes } from '../agentRollback';
 
 export const deviceRoutes = new Hono();
@@ -87,6 +88,10 @@ deviceRoutes.route('/', postureRoutes);
 
 // Mount the high-power literal sub-resource before core's /:id routes.
 deviceRoutes.route('/', agentRollbackRoutes);
+
+// Mount the Remove-dialog config BEFORE core — `/removal-config` is a static
+// path that must not be eaten by the `/:id` matcher in coreRoutes.
+deviceRoutes.route('/', removalConfigRoutes);
 
 // Mount core routes (/, /:id, PATCH /:id, DELETE /:id)
 deviceRoutes.route('/', coreRoutes);

--- a/apps/api/src/routes/devices/removalConfig.test.ts
+++ b/apps/api/src/routes/devices/removalConfig.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: vi.fn((c: any, next: any) => {
+    c.set('auth', { user: { id: 'u1' }, scope: 'organization', orgId: 'org-1', accessibleOrgIds: ['org-1'] });
+    return next();
+  }),
+  requireScope: vi.fn(() => async (_c: any, next: any) => next()),
+  requirePermission: vi.fn(() => async (_c: any, next: any) => next()),
+}));
+vi.mock('../../services/deviceUninstallDrain', () => ({
+  DEVICE_UNINSTALL_DRAIN_WINDOW_HOURS: 72,
+}));
+
+import { removalConfigRoutes } from './removalConfig';
+
+describe('GET /devices/removal-config', () => {
+  it('returns the configured uninstall drain window in hours', async () => {
+    const app = new Hono().route('/devices', removalConfigRoutes);
+    const res = await app.request('/devices/removal-config', { headers: { Authorization: 'Bearer t' } });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ uninstallDrainWindowHours: 72 });
+  });
+});

--- a/apps/api/src/routes/devices/removalConfig.ts
+++ b/apps/api/src/routes/devices/removalConfig.ts
@@ -1,0 +1,25 @@
+import { Hono } from 'hono';
+import { authMiddleware, requireScope, requirePermission } from '../../middleware/auth';
+import { PERMISSIONS } from '../../services/permissions';
+import { DEVICE_UNINSTALL_DRAIN_WINDOW_HOURS } from '../../services/deviceUninstallDrain';
+
+export const removalConfigRoutes = new Hono();
+removalConfigRoutes.use('*', authMiddleware);
+
+/**
+ * GET /devices/removal-config — read-only knobs the Remove dialog needs.
+ *
+ * `uninstallDrainWindowHours` is how long a queued self_uninstall waits for a
+ * removed device to check in before the stale-command reaper cancels it
+ * (`DEVICE_UNINSTALL_DRAIN_WINDOW_HOURS`, env-driven, floored at 1). The web
+ * must not hardcode it: operators tune it per deployment.
+ *
+ * Static path — MUST be mounted before coreRoutes in devices/index.ts or the
+ * `/:id` matcher eats it as a device id.
+ */
+removalConfigRoutes.get(
+  '/removal-config',
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action),
+  (c) => c.json({ uninstallDrainWindowHours: DEVICE_UNINSTALL_DRAIN_WINDOW_HOURS }),
+);

--- a/apps/web/src/components/devices/DeviceActions.test.tsx
+++ b/apps/web/src/components/devices/DeviceActions.test.tsx
@@ -289,7 +289,31 @@ describe('DeviceActions — offline gating (issue #2013)', () => {
 
       await user.click(screen.getByTestId('device-action-remove'));
       expect(onAction).not.toHaveBeenCalled();
-      expect(await screen.findByText('Remove Device')).toBeInTheDocument();
+      // #3987: the generic "Remove Device" confirm was replaced by
+      // RemoveDeviceDialog, which titles itself with the hostname.
+      expect(await screen.findByText('Remove edge-01?')).toBeInTheDocument();
+    });
+
+    // #3987 items 2 + 6: Remove is no longer a bare yes/no confirm — it asks
+    // what should happen to the agent and forwards the answer, so the detail
+    // page's DELETE carries `uninstallAgent` exactly like the fleet list's.
+    it('Remove opens the agent-choice dialog and forwards the choice to onAction', async () => {
+      const user = userEvent.setup();
+      const onAction = vi.fn();
+      render(<DeviceActions device={onlineDevice} onAction={onAction} />);
+
+      await user.click(screen.getByTestId('device-actions-menu'));
+      await user.click(screen.getByTestId('device-action-remove'));
+
+      expect(screen.getByTestId('remove-choice-uninstall')).toBeChecked();
+      await user.click(screen.getByTestId('remove-choice-leave'));
+      await user.click(screen.getByTestId('device-actions-remove-confirm'));
+
+      expect(onAction).toHaveBeenCalledWith(
+        'decommission',
+        expect.objectContaining({ id: baseDevice.id }),
+        { uninstallAgent: false },
+      );
     });
 
     // The compact variant is currently unused in production — the sole

--- a/apps/web/src/components/devices/DeviceActions.tsx
+++ b/apps/web/src/components/devices/DeviceActions.tsx
@@ -20,6 +20,7 @@ import {
 import type { Device, DeviceStatus } from "./DeviceList";
 import ConnectDesktopButton from "../remote/ConnectDesktopButton";
 import { ConfirmDialog } from "../shared/ConfirmDialog";
+import RemoveDeviceDialog from "./RemoveDeviceDialog";
 import { useTranslation } from "react-i18next";
 import "../../lib/i18n";
 
@@ -95,9 +96,18 @@ function unavailableTitle(status: DeviceStatus, t: DeviceTranslation): string {
   }
 }
 
+/**
+ * Extra answers a confirm dialog collected from the operator (#3987). Today
+ * only Remove has one: whether to queue the agent uninstall. Passed through to
+ * the page-level handler, which turns it into the DELETE body.
+ */
+export interface DeviceActionOptions {
+  uninstallAgent?: boolean;
+}
+
 type DeviceActionsProps = {
   device: Device;
-  onAction?: (action: string, device: Device) => void;
+  onAction?: (action: string, device: Device, opts?: DeviceActionOptions) => void | Promise<void>;
   compact?: boolean;
 };
 
@@ -123,7 +133,9 @@ type ModalConfigEntry = {
 // than a bespoke modal. `destructive` = irreversible/offline-inducing; everything
 // else is `warning`.
 function getModalConfig(
-  type: Exclude<ModalType, "none">,
+  // `decommission` is deliberately absent: RemoveDeviceDialog owns the Remove
+  // copy (#3987) because Remove asks a question rather than posing a yes/no.
+  type: Exclude<ModalType, "none" | "decommission">,
   device: Device,
   t: DeviceTranslation,
 ): ModalConfigEntry {
@@ -173,15 +185,6 @@ function getModalConfig(
             confirmLabel: t("deviceActions.confirm.enterMaintenance.confirm"),
             variant: "warning",
           };
-    case "decommission":
-      return {
-        title: t("deviceActions.confirm.decommission.title"),
-        message: t("deviceActions.confirm.decommission.message", {
-          hostname: device.hostname,
-        }),
-        confirmLabel: t("deviceActions.confirm.decommission.confirm"),
-        variant: "destructive",
-      };
     case "install-homebrew":
       return {
         title: t("deviceActions.confirm.installHomebrew.title"),
@@ -248,12 +251,17 @@ export default function DeviceActions({
     }
   };
 
-  const handleConfirm = async () => {
+  const handleConfirm = async (opts?: DeviceActionOptions) => {
     if (modalType === "none") return;
 
     setLoading(true);
     try {
-      await onAction?.(modalType, device);
+      // Only Remove collects an answer. Forwarding a bare `undefined` for every
+      // other action would change its call arity for no reason, so the two
+      // shapes stay distinct.
+      await (opts
+        ? onAction?.(modalType, device, opts)
+        : onAction?.(modalType, device));
       setModalType("none");
     } finally {
       setLoading(false);
@@ -267,7 +275,9 @@ export default function DeviceActions({
   };
 
   const modalCfg =
-    modalType === "none" ? null : getModalConfig(modalType, device, t);
+    modalType === "none" || modalType === "decommission"
+      ? null
+      : getModalConfig(modalType, device, t);
 
   // Same JSX, testids, and handlers rendered by both the compact and full
   // menu below — computed once so the two variants can't drift.
@@ -447,11 +457,20 @@ export default function DeviceActions({
           )}
         </div>
 
-        {modalCfg && (
+        {modalType === "decommission" ? (
+          <RemoveDeviceDialog
+            open
+            targets={[{ hostname: device.hostname, status: device.status }]}
+            onClose={closeModal}
+            onConfirm={(choice) => void handleConfirm(choice)}
+            isLoading={loading}
+            confirmTestId="device-actions-remove-confirm"
+          />
+        ) : modalCfg && (
           <ConfirmDialog
             open
             onClose={closeModal}
-            onConfirm={handleConfirm}
+            onConfirm={() => void handleConfirm()}
             title={modalCfg.title}
             message={modalCfg.message}
             confirmLabel={modalCfg.confirmLabel}
@@ -675,11 +694,20 @@ export default function DeviceActions({
         </div>
       </div>
 
-      {modalCfg && (
+      {modalType === "decommission" ? (
+        <RemoveDeviceDialog
+          open
+          targets={[{ hostname: device.hostname, status: device.status }]}
+          onClose={closeModal}
+          onConfirm={(choice) => void handleConfirm(choice)}
+          isLoading={loading}
+          confirmTestId="device-actions-remove-confirm"
+        />
+      ) : modalCfg && (
         <ConfirmDialog
           open
           onClose={closeModal}
-          onConfirm={handleConfirm}
+          onConfirm={() => void handleConfirm()}
           title={modalCfg.title}
           message={modalCfg.message}
           confirmLabel={modalCfg.confirmLabel}

--- a/apps/web/src/components/devices/DeviceDetailPage.removeDialog.test.tsx
+++ b/apps/web/src/components/devices/DeviceDetailPage.removeDialog.test.tsx
@@ -1,0 +1,172 @@
+import '@/lib/i18n';
+
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import DeviceDetailPage from './DeviceDetailPage';
+import { fetchWithAuth } from '../../stores/auth';
+import { decommissionDevice } from '../../services/deviceActions';
+
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+vi.mock('../../hooks/useEventStream', () => ({ useEventStream: () => ({ subscribe: vi.fn() }) }));
+vi.mock('@/stores/aiStore', () => ({ useAiStore: () => vi.fn() }));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
+vi.mock('../../services/deviceActions', () => ({
+  sendDeviceCommand: vi.fn(),
+  executeScript: vi.fn(),
+  toggleMaintenanceMode: vi.fn(),
+  decommissionDevice: vi.fn(),
+  clearDeviceSessions: vi.fn(),
+  restoreDevice: vi.fn(),
+  permanentDeleteDevice: vi.fn(),
+  sendWakeCommand: vi.fn(),
+  watchWakeOutcome: vi.fn(),
+  WakeCommandError: class WakeCommandError extends Error {},
+  wakeFriendlyErrorMessage: vi.fn(),
+  // RemoveDeviceDialog fetches the env-driven drain window when it opens.
+  fetchRemovalConfig: vi.fn(async () => ({ uninstallDrainWindowHours: 72 })),
+}));
+
+// Two callers, two call SHAPES — that is the whole contract under test:
+//   * DeviceSettingsModal's Danger Zone fires `onAction('decommission', device)`
+//     with NO third argument. It has no dialog of its own, so the PAGE owes it one.
+//   * DeviceActions' kebab already asked the question in its own
+//     RemoveDeviceDialog and fires `onAction('decommission', device, choice)`.
+//     That path must execute straight through — a second dialog would be a bug.
+// DeviceSettingsModal itself is stubbed rather than driven: W03 is editing the
+// real component on another branch. The stub reproduces its exact call shape;
+// the gate being pinned here keys on the ABSENCE of `opts`, so it holds for any
+// caller that omits it, not just this one.
+vi.mock('./DeviceDetails', () => ({
+  default: ({ device, onAction }: {
+    device: { hostname: string };
+    onAction: (action: string, device: unknown, opts?: { uninstallAgent?: boolean }) => void;
+  }) => (
+    <button
+      type="button"
+      data-testid="kebab-remove-with-choice"
+      onClick={() => onAction('decommission', device, { uninstallAgent: false })}
+    >
+      Kebab Remove
+    </button>
+  ),
+}));
+vi.mock('./DeviceSettingsModal', () => ({
+  default: ({ device, onAction }: {
+    device: { hostname: string };
+    onAction?: (action: string, device: unknown) => void;
+  }) => (
+    <button
+      type="button"
+      data-testid="settings-decommission"
+      onClick={() => onAction?.('decommission', device)}
+    >
+      Settings Decommission
+    </button>
+  ),
+}));
+vi.mock('./ChangeSiteModal', () => ({ default: () => null }));
+vi.mock('./ScriptPickerModal', () => ({ default: () => null }));
+
+const DEVICE_ID = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+
+async function advanceUndoWindow() {
+  // Only setTimeout is faked, and it must be installed BEFORE the click that
+  // schedules the 5s undo timer (see DeviceDetailPage.permanentDelete.test.tsx).
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(5000);
+  });
+}
+
+// #3987 follow-up: the detail page had a gate-less `case "decommission"`, so the
+// Settings → Danger Zone button removed the device with no dialog at all — the
+// one Remove surface that still could not choose "leave the agent installed",
+// and it defaulted to uninstall silently. DevicesPage has always split gate from
+// execute; the detail page now does too.
+describe('DeviceDetailPage — Settings → Remove goes through RemoveDeviceDialog (#3987)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fetchWithAuth).mockResolvedValue(new Response(JSON.stringify({
+      id: DEVICE_ID,
+      hostname: 'alpha-01',
+      osType: 'windows',
+      status: 'online',
+      orgId: 'org-1',
+      siteId: 'site-1',
+    }), { status: 200 }));
+    vi.mocked(decommissionDevice).mockResolvedValue({ success: true } as never);
+  });
+
+  it('opens the agent-choice dialog and removes nothing until it is confirmed', async () => {
+    render(<DeviceDetailPage deviceId={DEVICE_ID} />);
+
+    fireEvent.click(await screen.findByTestId('settings-decommission'));
+
+    expect(await screen.findByTestId('remove-choice-uninstall')).toBeChecked();
+    expect(screen.getByText('Remove alpha-01?')).toBeInTheDocument();
+
+    // Not even the undo window has opened — nothing is in flight.
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    try {
+      await advanceUndoWindow();
+    } finally {
+      vi.useRealTimers();
+    }
+    expect(vi.mocked(decommissionDevice)).not.toHaveBeenCalled();
+  });
+
+  it('forwards uninstallAgent: false when the operator chooses to leave the agent', async () => {
+    render(<DeviceDetailPage deviceId={DEVICE_ID} />);
+
+    fireEvent.click(await screen.findByTestId('settings-decommission'));
+    fireEvent.click(await screen.findByTestId('remove-choice-leave'));
+
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    try {
+      fireEvent.click(screen.getByTestId('detail-remove-confirm'));
+      await advanceUndoWindow();
+    } finally {
+      vi.useRealTimers();
+    }
+
+    await waitFor(() =>
+      expect(vi.mocked(decommissionDevice)).toHaveBeenCalledWith(DEVICE_ID, { uninstallAgent: false }),
+    );
+  });
+
+  it('cancelling the dialog removes nothing', async () => {
+    render(<DeviceDetailPage deviceId={DEVICE_ID} />);
+
+    fireEvent.click(await screen.findByTestId('settings-decommission'));
+    await screen.findByTestId('detail-remove-confirm');
+
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+    await waitFor(() => expect(screen.queryByTestId('detail-remove-confirm')).toBeNull());
+    expect(vi.mocked(decommissionDevice)).not.toHaveBeenCalled();
+  });
+
+  // The kebab already asked. Re-gating a call that carries an answer would show
+  // the operator two identical dialogs back to back.
+  it('does NOT re-ask when the caller already carries a choice (DeviceActions kebab)', async () => {
+    render(<DeviceDetailPage deviceId={DEVICE_ID} />);
+
+    const trigger = await screen.findByTestId('kebab-remove-with-choice');
+
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    try {
+      fireEvent.click(trigger);
+      // No page-level dialog on top of the one DeviceActions already showed.
+      expect(screen.queryByTestId('detail-remove-confirm')).toBeNull();
+      expect(screen.queryByTestId('remove-choice-uninstall')).toBeNull();
+      await advanceUndoWindow();
+    } finally {
+      vi.useRealTimers();
+    }
+
+    await waitFor(() =>
+      expect(vi.mocked(decommissionDevice)).toHaveBeenCalledWith(DEVICE_ID, { uninstallAgent: false }),
+    );
+  });
+});

--- a/apps/web/src/components/devices/DeviceDetailPage.tsx
+++ b/apps/web/src/components/devices/DeviceDetailPage.tsx
@@ -10,6 +10,7 @@ import ScriptPickerModal, {
   type ScriptRunAsSelection,
 } from "./ScriptPickerModal";
 import type { Device, DeviceStatus, OSType } from "./DeviceList";
+import type { DeviceActionOptions } from "./DeviceActions";
 import { fetchWithAuth } from "../../stores/auth";
 import {
   sendDeviceCommand,
@@ -232,7 +233,12 @@ export default function DeviceDetailPage({ deviceId }: DeviceDetailPageProps) {
     void navigateTo("/devices");
   };
 
-  const handleAction = async (action: string, device: Device) => {
+  const handleAction = async (
+    action: string,
+    device: Device,
+    // #3987: RemoveDeviceDialog's agent answer, present only for Remove.
+    opts?: DeviceActionOptions,
+  ) => {
     if (actionInProgress) return;
 
     try {
@@ -395,7 +401,7 @@ export default function DeviceDetailPage({ deviceId }: DeviceDetailPageProps) {
           setTimeout(async () => {
             if (cancelled) return;
             try {
-              await decommissionDevice(device.id);
+              await decommissionDevice(device.id, { uninstallAgent: opts?.uninstallAgent ?? true });
               showToast({
                 type: "success",
                 message: `${device.hostname} has been removed`,

--- a/apps/web/src/components/devices/DeviceDetailPage.tsx
+++ b/apps/web/src/components/devices/DeviceDetailPage.tsx
@@ -5,6 +5,7 @@ import { showToast } from "../shared/Toast";
 import DeviceDetails from "./DeviceDetails";
 import DeviceSettingsModal from "./DeviceSettingsModal";
 import ChangeSiteModal from "./ChangeSiteModal";
+import RemoveDeviceDialog from "./RemoveDeviceDialog";
 import ScriptPickerModal, {
   type Script,
   type ScriptRunAsSelection,
@@ -44,6 +45,11 @@ export default function DeviceDetailPage({ deviceId }: DeviceDetailPageProps) {
   const [error, setError] = useState<string>();
   const [actionInProgress, setActionInProgress] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  // #3987: Remove has to ask what happens to the agent before it runs.
+  // DeviceActions asks in its own dialog and passes the answer down;
+  // DeviceSettingsModal's Danger Zone button has no dialog at all, so the
+  // page owes that caller one. Set = "asked, not yet answered".
+  const [pendingRemove, setPendingRemove] = useState<Device | null>(null);
   const [changeSiteOpen, setChangeSiteOpen] = useState(false);
   const [scriptPickerOpen, setScriptPickerOpen] = useState(false);
 
@@ -240,6 +246,16 @@ export default function DeviceDetailPage({ deviceId }: DeviceDetailPageProps) {
     opts?: DeviceActionOptions,
   ) => {
     if (actionInProgress) return;
+
+    // Gate/execute split, mirroring DevicesPage. A `decommission` that carries
+    // no agent answer has not been through a dialog yet — open one and come
+    // back through here with `opts` set. Keying on the ABSENCE of `opts` (not on
+    // the caller) means any present or future Remove trigger on this page is
+    // gated by default; a caller that already asked is not asked twice.
+    if (action === "decommission" && !opts) {
+      setPendingRemove(device);
+      return;
+    }
 
     try {
       setActionInProgress(true);
@@ -603,6 +619,19 @@ export default function DeviceDetailPage({ deviceId }: DeviceDetailPageProps) {
         onSaved={fetchDevice}
         onAction={handleAction}
       />
+      {pendingRemove && (
+        <RemoveDeviceDialog
+          open
+          targets={[{ hostname: pendingRemove.hostname, status: pendingRemove.status }]}
+          onClose={() => setPendingRemove(null)}
+          onConfirm={(choice) => {
+            const target = pendingRemove;
+            setPendingRemove(null);
+            void handleAction("decommission", target, choice);
+          }}
+          confirmTestId="detail-remove-confirm"
+        />
+      )}
       <ChangeSiteModal
         device={device}
         isOpen={changeSiteOpen}

--- a/apps/web/src/components/devices/DevicesPage.test.tsx
+++ b/apps/web/src/components/devices/DevicesPage.test.tsx
@@ -53,6 +53,8 @@ vi.mock('../../services/deviceActions', () => ({
   wakeFriendlyErrorMessage: vi.fn(() => null),
   linkDevicesMultiboot: vi.fn(),
   linkDevicesVmHost: vi.fn(),
+  // #3987: RemoveDeviceDialog fetches the env-driven drain window on open.
+  fetchRemovalConfig: vi.fn(async () => ({ uninstallDrainWindowHours: 72 })),
 }));
 
 vi.mock('@/lib/navigation', () => ({
@@ -1368,6 +1370,10 @@ describe('DevicesPage — bulk agent commands gated on decommissioned only (#246
 
     fireEvent.click(screen.getByTestId('confirm-decommissioned-skip'));
 
+    // #3987: the skip gate hands off to the agent-choice dialog, which is what
+    // actually fires the batch.
+    fireEvent.click(await screen.findByTestId('confirm-bulk-remove'));
+
     await waitFor(() => expect(vi.mocked(bulkDecommissionDevices)).toHaveBeenCalledTimes(1));
     // DEV_3 (already decommissioned) must NOT be re-submitted — that's the
     // doomed request the API 400s. DEV_2 (offline) IS a legitimate target:
@@ -1417,6 +1423,7 @@ describe('DevicesPage — bulk agent commands gated on decommissioned only (#246
     await renderMixedFleet([DEV_1, DEV_2]);
 
     fireEvent.click(screen.getByTestId('bulk-decommission'));
+    fireEvent.click(await screen.findByTestId('confirm-bulk-remove'));
 
     await waitFor(() => expect(vi.mocked(bulkDecommissionDevices)).toHaveBeenCalledTimes(1));
     await waitFor(() => {
@@ -1665,13 +1672,14 @@ describe('DevicesPage — decommission from the row/grid kebab is confirm-gated 
     expect(decommissionDevice).not.toHaveBeenCalled();
     expect(await toastTypes()).not.toContain('undo');
 
-    // The SAME keys DeviceActions.tsx renders — proving no new copy was needed
-    // and that the two screens still read identically. The VALUES moved to
-    // "Remove" in #3987/#3994 (the action id stayed `decommission`); asserting
-    // the rendered text is what makes a future divergence between the two
-    // screens visible here, so these track the copy deliberately.
-    expect(await screen.findByText('Remove Device')).toBeTruthy();
-    expect(screen.getByText(/remove host-alpha\?/i)).toBeTruthy();
+    // The SAME component DeviceActions.tsx renders — RemoveDeviceDialog
+    // (#3987) — proving the two screens still read identically. The generic
+    // deviceActions.confirm.decommission.* copy this used to assert was
+    // replaced by the dialog's own removeDialog.* block, which asks the agent
+    // question instead of just "are you sure?"; asserting the rendered text is
+    // what makes a future divergence between the two screens visible here.
+    expect(await screen.findByText('Remove host-alpha?')).toBeTruthy();
+    expect(screen.getByTestId('remove-choice-uninstall')).toBeChecked();
 
     const confirmBtn = await screen.findByTestId('confirm-device-action');
     expect(confirmBtn.textContent).toBe('Remove');
@@ -1721,7 +1729,9 @@ describe('DevicesPage — decommission from the row/grid kebab is confirm-gated 
     }
 
     expect(decommissionDevice).toHaveBeenCalledTimes(1);
-    expect(decommissionDevice).toHaveBeenCalledWith(DEV_1);
+    // #3987: uninstall is the web's default answer, so an untouched dialog
+    // still queues the agent teardown.
+    expect(decommissionDevice).toHaveBeenCalledWith(DEV_1, { uninstallAgent: true });
   });
 
   // The gate lives on the shared handleDeviceAction, so the grid card inherits
@@ -1742,7 +1752,7 @@ describe('DevicesPage — decommission from the row/grid kebab is confirm-gated 
     fireEvent.click(await screen.findByTestId(`card-decommission-${DEV_1}`));
 
     expect(decommissionDevice).not.toHaveBeenCalled();
-    expect(await screen.findByText('Remove Device')).toBeTruthy();
+    expect(await screen.findByText('Remove host-alpha?')).toBeTruthy();
   });
 
   // Deliberate scope boundary (#4009): `restore` is the UNDO of a decommission.
@@ -2011,12 +2021,17 @@ describe('DevicesPage — ungated bulk actions still work on an all-offline flee
     await waitFor(() => expect(list.getAttribute('data-device-count')).toBe('2'));
   }
 
-  it('decommissions every offline device — no gate, no confirm', async () => {
+  it('decommissions every offline device — no skip gate', async () => {
     const { bulkDecommissionDevices } = await import('../../services/deviceActions');
     vi.mocked(bulkDecommissionDevices).mockResolvedValue({ succeeded: 2, failed: [] } as never);
 
     await renderOfflineFleet();
     fireEvent.click(screen.getByTestId('bulk-decommission'));
+
+    // #3987: the agent-choice dialog is NOT the #2465 skip gate — it asks what
+    // to do with the agent, it does not drop devices from the batch. The
+    // exemption this test pins is the absence of `confirm-decommissioned-skip`.
+    fireEvent.click(await screen.findByTestId('confirm-bulk-remove'));
 
     await waitFor(() => expect(vi.mocked(bulkDecommissionDevices)).toHaveBeenCalledTimes(1));
     expect(screen.queryByTestId('confirm-decommissioned-skip')).toBeNull();
@@ -2216,5 +2231,98 @@ describe('DevicesPage — permanent delete surfaces the API warning (#4368)', ()
         message: expect.stringContaining('host-alpha'),
       }),
     );
+  });
+});
+
+// #3987 items 2 + 6: every Remove surface asks what should happen to the agent
+// and forwards the answer to the API. Before this, the web issued a bodyless
+// DELETE, so `uninstallAgent` defaulted to false server-side and every removed
+// machine kept a zombie agent heartbeating into a 403.
+describe('DevicesPage — Remove asks about the agent (#3987)', () => {
+  it('single Remove from the row kebab defaults to uninstall and sends uninstallAgent: true', async () => {
+    const { decommissionDevice } = await import('../../services/deviceActions');
+    vi.mocked(decommissionDevice).mockResolvedValue({ success: true } as never);
+    vi.mocked(fetchAllDevices).mockResolvedValue({
+      data: [{ ...rawDevice(DEV_1, 'host-alpha'), status: 'online' }],
+    } as never);
+
+    render(<DevicesPage />);
+    fireEvent.click(await screen.findByTestId(`row-decommission-${DEV_1}`));
+
+    const uninstallRadio = await screen.findByTestId('remove-choice-uninstall');
+    expect(uninstallRadio).toBeChecked();
+
+    // Only setTimeout is faked — the 5s undo window is a plain timer inside
+    // runDeviceAction (see the #4009 describe above for why not Date).
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    try {
+      fireEvent.click(screen.getByTestId('confirm-device-action'));
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+
+    await waitFor(() =>
+      expect(vi.mocked(decommissionDevice)).toHaveBeenCalledWith(DEV_1, { uninstallAgent: true }),
+    );
+  });
+
+  it('single Remove forwards uninstallAgent: false when the operator leaves the agent', async () => {
+    const { decommissionDevice } = await import('../../services/deviceActions');
+    vi.mocked(decommissionDevice).mockResolvedValue({ success: true } as never);
+    vi.mocked(fetchAllDevices).mockResolvedValue({
+      data: [{ ...rawDevice(DEV_1, 'host-alpha'), status: 'online' }],
+    } as never);
+
+    render(<DevicesPage />);
+    fireEvent.click(await screen.findByTestId(`row-decommission-${DEV_1}`));
+    fireEvent.click(await screen.findByTestId('remove-choice-leave'));
+
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    try {
+      fireEvent.click(screen.getByTestId('confirm-device-action'));
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+
+    await waitFor(() =>
+      expect(vi.mocked(decommissionDevice)).toHaveBeenCalledWith(DEV_1, { uninstallAgent: false }),
+    );
+  });
+
+  it('bulk Remove asks once and forwards the one choice to bulkDecommissionDevices', async () => {
+    const { bulkDecommissionDevices } = await import('../../services/deviceActions');
+    vi.mocked(bulkDecommissionDevices).mockResolvedValue({ succeeded: 2, failed: [] } as never);
+    vi.mocked(fetchAllDevices).mockResolvedValue({
+      data: [
+        { ...rawDevice(DEV_1, 'host-alpha'), status: 'online' },
+        { ...rawDevice(DEV_2, 'host-beta'), status: 'offline' },
+      ],
+    } as never);
+    const { decodeFilterFromHash } = await import('./filterUrl');
+    vi.mocked(decodeFilterFromHash).mockReturnValue(null);
+
+    render(<DevicesPage />);
+    const list = await screen.findByTestId('device-list');
+    await waitFor(() => expect(list.getAttribute('data-device-count')).toBe('2'));
+
+    fireEvent.click(screen.getByTestId('bulk-decommission'));
+
+    // One dialog for the whole selection, bucketed online vs not-currently-online.
+    expect(await screen.findByText('Remove 2 devices?')).toBeTruthy();
+    expect(screen.getByTestId('remove-dialog-summary').textContent)
+      .toBe('1 online, 1 not currently online.');
+    expect(vi.mocked(bulkDecommissionDevices)).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId('remove-choice-leave'));
+    fireEvent.click(screen.getByTestId('confirm-bulk-remove'));
+
+    await waitFor(() => expect(vi.mocked(bulkDecommissionDevices)).toHaveBeenCalledTimes(1));
+    expect(vi.mocked(bulkDecommissionDevices).mock.calls[0][1]).toEqual({ uninstallAgent: false });
   });
 });

--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -11,6 +11,7 @@ import DeviceCard from './DeviceCard';
 import DecommissionedHiddenHint from './DecommissionedHiddenHint';
 import ScriptPickerModal, { type Script, type ScriptRunAsSelection } from './ScriptPickerModal';
 import DeviceSettingsModal from './DeviceSettingsModal';
+import RemoveDeviceDialog from './RemoveDeviceDialog';
 import AddDeviceModal from './AddDeviceModal';
 import CreateGroupModal from './CreateGroupModal';
 import LinkVmHostModal from './LinkVmHostModal';
@@ -190,6 +191,9 @@ export default function DevicesPage() {
   // on which screen you were on — and the list is the dense, easy-to-mis-click
   // one, with Reboot sitting next to Run Script and Wake.
   const [pendingDeviceAction, setPendingDeviceAction] = useState<{ action: string; device: Device } | null>(null);
+  // #3987: bulk Remove asks the agent question ONCE for the whole selection,
+  // then runBulkRemove runs the per-device DELETE loop with that one answer.
+  const [pendingBulkRemove, setPendingBulkRemove] = useState<Device[] | null>(null);
   const [settingsDevice, setSettingsDevice] = useState<Device | null>(null);
   // v2 chip bar seeds its filter from the URL hash so a filtered view is
   // shareable; the legacy DeviceFilterBar owns its own state and ignores it.
@@ -793,7 +797,14 @@ export default function DevicesPage() {
     await runDeviceAction(action, device);
   };
 
-  const runDeviceAction = async (action: string, device: Device) => {
+  const runDeviceAction = async (
+    action: string,
+    device: Device,
+    // #3987: the Remove dialog's agent answer. Absent for every other
+    // action, and absent means UNINSTALL — the web default, deliberately
+    // stricter than the API's back-compat `false`.
+    opts?: { uninstallAgent?: boolean },
+  ) => {
     if (actionInProgress) return;
 
     try {
@@ -921,7 +932,7 @@ export default function DevicesPage() {
           setTimeout(async () => {
             if (cancelled) return;
             try {
-              await decommissionDevice(device.id);
+              await decommissionDevice(device.id, { uninstallAgent: opts?.uninstallAgent ?? true });
               showToast({ type: 'success', message: t('devicesPage.toasts.decommissioned', { hostname: device.hostname }) });
               await fetchDevices();
             } catch (err) {
@@ -1225,31 +1236,12 @@ export default function DevicesPage() {
         }
 
         case 'decommission': {
-          const result = await bulkDecommissionDevices(
-            selectedDevices.map(d => ({ id: d.id, hostname: d.hostname })),
-          );
-          if (result.failed.length === 0) {
-            showToast({ type: 'success', message: t('devicesPage.toasts.bulkDecommissioned', { count: result.succeeded }) });
-          } else if (result.succeeded === 0) {
-            showToast({
-              type: 'error',
-              message: t('devicesPage.toasts.bulkDecommissionAllFailed', {
-                count: result.failed.length,
-                devices: summarizeFailedDevices(result.failed.map(f => f.hostname)),
-              }),
-            });
-          } else {
-            showToast({
-              type: 'error',
-              message: t('devicesPage.toasts.bulkDecommissionFailed', {
-                succeeded: result.succeeded,
-                failed: result.failed.length,
-                devices: summarizeFailedDevices(result.failed.map(f => f.hostname)),
-              }),
-            });
-          }
-          await fetchDevices();
-          break;
+          // Ask the agent question once for the whole selection (#3987). The
+          // actual DELETE loop runs in runBulkRemove once the dialog confirms.
+          // `return` inside `try` still runs the `finally` that clears
+          // actionInProgress, so the dialog's own Confirm is not dead on arrival.
+          setPendingBulkRemove(selectedDevices);
+          return;
         }
 
         case 'wake': {
@@ -1288,6 +1280,45 @@ export default function DevicesPage() {
       }
     } catch (err) {
       showToast({ type: 'error', message: err instanceof Error ? err.message : t('devicesPage.toasts.bulkActionFailed', { action }) });
+    } finally {
+      setActionInProgress(false);
+    }
+  };
+
+  // #3987: the second half of bulk Remove. runBulkAction's `decommission` case
+  // only opens RemoveDeviceDialog; this runs once the operator has answered the
+  // agent question, with the SAME answer applied to every device in the batch.
+  const runBulkRemove = async (selectedDevices: Device[], choice: { uninstallAgent: boolean }) => {
+    if (selectedDevices.length === 0) return;
+    setActionInProgress(true);
+    try {
+      const result = await bulkDecommissionDevices(
+        selectedDevices.map(d => ({ id: d.id, hostname: d.hostname })),
+        choice,
+      );
+      if (result.failed.length === 0) {
+        showToast({ type: 'success', message: t('devicesPage.toasts.bulkDecommissioned', { count: result.succeeded }) });
+      } else if (result.succeeded === 0) {
+        showToast({
+          type: 'error',
+          message: t('devicesPage.toasts.bulkDecommissionAllFailed', {
+            count: result.failed.length,
+            devices: summarizeFailedDevices(result.failed.map(f => f.hostname)),
+          }),
+        });
+      } else {
+        showToast({
+          type: 'error',
+          message: t('devicesPage.toasts.bulkDecommissionFailed', {
+            succeeded: result.succeeded,
+            failed: result.failed.length,
+            devices: summarizeFailedDevices(result.failed.map(f => f.hostname)),
+          }),
+        });
+      }
+      await fetchDevices();
+    } catch (err) {
+      showToast({ type: 'error', message: err instanceof Error ? err.message : t('devicesPage.toasts.bulkActionFailed', { action: 'decommission' }) });
     } finally {
       setActionInProgress(false);
     }
@@ -1641,7 +1672,28 @@ export default function DevicesPage() {
           deviceActions.confirm.* copy so the two screens read identically and
           no new locale keys are needed. Double-click safety is the shared
           components' job (#3705) — see the decommissioned-skip dialog above. */}
-      {pendingDeviceAction && (
+      {/* #3987: Remove owns its own dialog — it is the one confirm that has a
+          question to ask (uninstall the agent, or leave it?), not just a
+          yes/no. Every other gated action keeps the generic ConfirmDialog
+          below with the shared deviceActions.confirm.* copy. */}
+      {pendingDeviceAction && pendingDeviceAction.action === 'decommission' && (
+        <RemoveDeviceDialog
+          open
+          targets={[{
+            hostname: pendingDeviceAction.device.hostname,
+            status: pendingDeviceAction.device.status,
+          }]}
+          onClose={() => setPendingDeviceAction(null)}
+          onConfirm={(choice) => {
+            const p = pendingDeviceAction;
+            setPendingDeviceAction(null);
+            void runDeviceAction(p.action, p.device, choice);
+          }}
+          confirmTestId="confirm-device-action"
+        />
+      )}
+
+      {pendingDeviceAction && pendingDeviceAction.action !== 'decommission' && (
         <ConfirmDialog
           open={true}
           onClose={() => setPendingDeviceAction(null)}
@@ -1657,6 +1709,21 @@ export default function DevicesPage() {
           confirmLabel={t(/* i18n-dynamic */ `deviceActions.confirm.${confirmKeyFor(pendingDeviceAction.action)}.confirm`)}
           variant={DESTRUCTIVE_CONFIRM_ACTIONS.has(pendingDeviceAction.action) ? 'destructive' : 'warning'}
           confirmTestId="confirm-device-action"
+        />
+      )}
+
+      {pendingBulkRemove && (
+        <RemoveDeviceDialog
+          open
+          targets={pendingBulkRemove.map(d => ({ hostname: d.hostname, status: d.status }))}
+          onClose={() => setPendingBulkRemove(null)}
+          onConfirm={(choice) => {
+            const devicesToRemove = pendingBulkRemove;
+            setPendingBulkRemove(null);
+            void runBulkRemove(devicesToRemove, choice);
+          }}
+          isLoading={actionInProgress}
+          confirmTestId="confirm-bulk-remove"
         />
       )}
 

--- a/apps/web/src/components/devices/PossibleReplacementBanner.test.tsx
+++ b/apps/web/src/components/devices/PossibleReplacementBanner.test.tsx
@@ -21,6 +21,14 @@ vi.mock('@/lib/navigation', () => ({
   navigateTo: vi.fn(),
 }));
 
+// RemoveDeviceDialog (#3987) fetches the env-driven uninstall drain window on
+// open. Mocked at the service boundary so it does not land in this file's
+// fetchWithAuth call-count assertions, which pin exactly which requests the
+// banner itself makes.
+vi.mock('../../services/deviceActions', () => ({
+  fetchRemovalConfig: vi.fn(async () => ({ uninstallDrainWindowHours: 72 })),
+}));
+
 const fetchWithAuthMock = vi.mocked(fetchWithAuth);
 const showToastMock = vi.mocked(showToast);
 
@@ -114,6 +122,28 @@ describe('PossibleReplacementBanner (#2764)', () => {
     );
   });
 
+  // #3987: the banner used to issue its own bodyless DELETE — the one Remove
+  // surface that could not queue the agent uninstall at all. It now asks the
+  // same question every other Remove asks, and sends the answer.
+  it('Remove old device asks about the agent and sends uninstallAgent in the DELETE body', async () => {
+    fetchWithAuthMock
+      .mockResolvedValueOnce(jsonResponse(oldDevicePayload({ status: 'offline' })))
+      .mockResolvedValueOnce(jsonResponse({ success: true }))
+      .mockResolvedValueOnce(jsonResponse(oldDevicePayload({ status: 'decommissioned' })));
+
+    render(<PossibleReplacementBanner possibleReplacementOfDeviceId={OLD_DEVICE_ID} />);
+
+    fireEvent.click(await screen.findByTestId('possible-replacement-decommission'));
+    expect(await screen.findByTestId('remove-choice-uninstall')).toBeChecked();
+    fireEvent.click(screen.getByTestId('possible-replacement-confirm'));
+
+    await waitFor(() => {
+      const del = fetchWithAuthMock.mock.calls.find(([, init]) => init?.method === 'DELETE');
+      expect(del).toBeDefined();
+      expect(JSON.parse(String(del![1]?.body))).toEqual({ uninstallAgent: true });
+    });
+  });
+
   it('sends nothing and closes the dialog when the confirm is cancelled', async () => {
     fetchWithAuthMock.mockResolvedValue(jsonResponse(oldDevicePayload()));
 
@@ -148,8 +178,11 @@ describe('PossibleReplacementBanner (#2764)', () => {
     fireEvent.click(await screen.findByTestId('possible-replacement-confirm'));
 
     await waitFor(() =>
+      // #3987: the DELETE now carries the agent choice; uninstall is the default.
       expect(fetchWithAuthMock).toHaveBeenCalledWith(`/devices/${OLD_DEVICE_ID}`, {
         method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ uninstallAgent: true }),
       }),
     );
 

--- a/apps/web/src/components/devices/PossibleReplacementBanner.tsx
+++ b/apps/web/src/components/devices/PossibleReplacementBanner.tsx
@@ -3,7 +3,7 @@ import { AlertTriangle } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { fetchWithAuth } from '../../stores/auth';
 import { runAction, handleActionError } from '../../lib/runAction';
-import { ConfirmDialog } from '../shared/ConfirmDialog';
+import RemoveDeviceDialog from './RemoveDeviceDialog';
 import { navigateTo } from '@/lib/navigation';
 import { loginPathWithNext } from '../../lib/authScope';
 
@@ -45,12 +45,13 @@ type PossibleReplacementBannerProps = {
  * site scope hides. In that case the banner still renders (the collision is
  * real and worth surfacing) with a generic label and no action.
  *
- * Decommission is IRREVERSIBLE from the user's point of view — server-side it
+ * Remove is IRREVERSIBLE from the user's point of view — server-side it
  * force-disconnects the agent WebSocket and tears down live remote sessions —
- * so it goes through the same `ConfirmDialog` every other decommission trigger
- * in the app uses (`DeviceActions.tsx`), reusing that component's copy keys
- * verbatim rather than paraphrasing them. A single-click DELETE here would be
- * the only unconfirmed path to that endpoint in the web app.
+ * so it goes through the same `RemoveDeviceDialog` every other Remove trigger
+ * in the app uses (`DeviceActions.tsx`, `DevicesPage.tsx`), reusing that
+ * component verbatim rather than paraphrasing it. A single-click DELETE here
+ * would be the only unconfirmed path to that endpoint in the web app — and,
+ * until #3987, the only one that could not queue the agent uninstall.
  */
 export default function PossibleReplacementBanner({
   possibleReplacementOfDeviceId,
@@ -112,11 +113,18 @@ export default function PossibleReplacementBanner({
   const alreadyDecommissioned = oldDevice?.status === 'decommissioned';
   const canDecommission = !unavailable && oldDevice != null && !alreadyDecommissioned;
 
-  const handleDecommission = async () => {
+  const handleDecommission = async (choice: { uninstallAgent: boolean }) => {
     setBusy(true);
     try {
       await runAction({
-        request: () => fetchWithAuth(`/devices/${oldDeviceId}`, { method: 'DELETE' }),
+        // #3987: the agent answer rides in the JSON body. A bodyless DELETE
+        // reads as `uninstallAgent: false` on the API (back-compat default),
+        // which is how this surface left zombie agents behind.
+        request: () => fetchWithAuth(`/devices/${oldDeviceId}`, {
+          method: 'DELETE',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ uninstallAgent: choice.uninstallAgent }),
+        }),
         errorFallback: t('possibleReplacementBanner.decommissionFailed'),
         successMessage: t('possibleReplacementBanner.decommissionSucceeded'),
         onUnauthorized: UNAUTHORIZED,
@@ -196,21 +204,16 @@ export default function PossibleReplacementBanner({
         </div>
       </div>
       {confirmOpen && (
-        // Same dialog, same copy keys, same `destructive` variant as every
-        // other decommission trigger (DeviceActions.tsx). Reused rather than
-        // paraphrased so the two can never drift apart in any locale.
-        <ConfirmDialog
+        // Same dialog as every other Remove trigger (DeviceActions.tsx,
+        // DevicesPage.tsx). Reused rather than paraphrased so the surfaces can
+        // never drift apart in any locale — or on the agent question.
+        <RemoveDeviceDialog
           open
+          targets={[{ hostname: label, status: oldDevice?.status ?? 'offline' }]}
           onClose={() => {
             if (!busy) setConfirmOpen(false);
           }}
-          onConfirm={() => void handleDecommission()}
-          title={t('deviceActions.confirm.decommission.title')}
-          message={t('deviceActions.confirm.decommission.message', {
-            hostname: label,
-          })}
-          confirmLabel={t('deviceActions.confirm.decommission.confirm')}
-          variant="destructive"
+          onConfirm={(choice) => void handleDecommission(choice)}
           isLoading={busy}
           confirmTestId="possible-replacement-confirm"
         />

--- a/apps/web/src/components/devices/RemoveDeviceDialog.test.tsx
+++ b/apps/web/src/components/devices/RemoveDeviceDialog.test.tsx
@@ -1,0 +1,65 @@
+import '@/lib/i18n';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../services/deviceActions', () => ({
+  fetchRemovalConfig: vi.fn(),
+}));
+import { fetchRemovalConfig } from '../../services/deviceActions';
+import RemoveDeviceDialog from './RemoveDeviceDialog';
+
+const cfg = vi.mocked(fetchRemovalConfig);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  cfg.mockResolvedValue({ uninstallDrainWindowHours: 72 });
+});
+
+describe('RemoveDeviceDialog', () => {
+  it('defaults the agent radio to Uninstall and confirms with uninstallAgent: true', async () => {
+    const onConfirm = vi.fn();
+    render(<RemoveDeviceDialog open targets={[{ hostname: 'WKSTN-042', status: 'online' }]} onClose={() => {}} onConfirm={onConfirm} confirmTestId="remove-confirm" />);
+    expect(screen.getByRole('radio', { name: /uninstall the breeze agent/i })).toBeChecked();
+    fireEvent.click(screen.getByTestId('remove-confirm'));
+    expect(onConfirm).toHaveBeenCalledWith({ uninstallAgent: true });
+    await waitFor(() => expect(cfg).toHaveBeenCalled());
+  });
+
+  it('confirms with uninstallAgent: false when Leave is chosen', () => {
+    const onConfirm = vi.fn();
+    render(<RemoveDeviceDialog open targets={[{ hostname: 'WKSTN-042', status: 'offline' }]} onClose={() => {}} onConfirm={onConfirm} confirmTestId="remove-confirm" />);
+    fireEvent.click(screen.getByRole('radio', { name: /leave the agent installed/i }));
+    fireEvent.click(screen.getByTestId('remove-confirm'));
+    expect(onConfirm).toHaveBeenCalledWith({ uninstallAgent: false });
+  });
+
+  it('says "queued now" for an online device and never says "runs now"', () => {
+    render(<RemoveDeviceDialog open targets={[{ hostname: 'A', status: 'online' }]} onClose={() => {}} onConfirm={() => {}} />);
+    expect(screen.getByText(/queued now/i)).toBeInTheDocument();
+    expect(screen.queryByText(/runs now/i)).toBeNull();
+  });
+
+  it('shows the drain window from the API for a not-online device', async () => {
+    render(<RemoveDeviceDialog open targets={[{ hostname: 'A', status: 'maintenance' }]} onClose={() => {}} onConfirm={() => {}} />);
+    await waitFor(() => expect(screen.getByText(/after 72 hours/i)).toBeInTheDocument());
+  });
+
+  it('falls back to window-less copy when the config fetch fails', async () => {
+    cfg.mockRejectedValue(new Error('boom'));
+    render(<RemoveDeviceDialog open targets={[{ hostname: 'A', status: 'offline' }]} onClose={() => {}} onConfirm={() => {}} />);
+    await waitFor(() => expect(cfg).toHaveBeenCalled());
+    expect(screen.getByText(/runs the next time the device checks in\.$/i)).toBeInTheDocument();
+    expect(screen.queryByText(/after .* hours/i)).toBeNull();
+  });
+
+  it('bulk: titles with the count and buckets online vs not-currently-online', () => {
+    render(<RemoveDeviceDialog open targets={[
+      { hostname: 'A', status: 'online' },
+      { hostname: 'B', status: 'offline' },
+      { hostname: 'C', status: 'quarantined' },
+    ]} onClose={() => {}} onConfirm={() => {}} />);
+    expect(screen.getByText('Remove 3 devices?')).toBeInTheDocument();
+    expect(screen.getByText('1 online, 2 not currently online.')).toBeInTheDocument();
+    expect(screen.queryByText(/offline/i)).toBeNull();
+  });
+});

--- a/apps/web/src/components/devices/RemoveDeviceDialog.tsx
+++ b/apps/web/src/components/devices/RemoveDeviceDialog.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useId, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ConfirmDialog } from '../shared/ConfirmDialog';
+import { fetchRemovalConfig } from '../../services/deviceActions';
+
+export interface RemoveDialogTarget {
+  hostname: string;
+  status: string;
+}
+
+export interface RemoveDeviceDialogProps {
+  open: boolean;
+  /** One entry = single-device Remove; several = bulk Remove (one choice for all). */
+  targets: RemoveDialogTarget[];
+  onClose: () => void;
+  onConfirm: (choice: { uninstallAgent: boolean }) => void;
+  isLoading?: boolean;
+  confirmTestId?: string;
+}
+
+/**
+ * The Remove confirm (#3987). Composes ConfirmDialog — it already has a
+ * `children` slot and the #3705 single-fire latch — and adds the one question
+ * Remove actually needs answered: what happens to the agent.
+ *
+ * DEFAULTS TO UNINSTALL. Owner decision 2026-08-24: defaulting to "leave
+ * installed" is what produces zombie agents heartbeating into a 403 forever.
+ *
+ * Copy says "queued", never "runs now": DELETE /devices/:id inserts a pending
+ * self_uninstall and force-closes the agent WS (core.ts) — the agent collects
+ * the command on its next poll, moments later if online. The wait window for
+ * a device that never checks in is env-driven on the API
+ * (DEVICE_UNINSTALL_DRAIN_WINDOW_HOURS), so it is fetched, not hardcoded.
+ */
+export default function RemoveDeviceDialog({
+  open,
+  targets,
+  onClose,
+  onConfirm,
+  isLoading = false,
+  confirmTestId,
+}: RemoveDeviceDialogProps) {
+  const { t } = useTranslation('devices');
+  const [uninstallAgent, setUninstallAgent] = useState(true);
+  const [windowHours, setWindowHours] = useState<number | null>(null);
+  const legendId = useId();
+
+  useEffect(() => {
+    if (!open) return;
+    setUninstallAgent(true);
+    let cancelled = false;
+    fetchRemovalConfig()
+      .then((cfg) => { if (!cancelled) setWindowHours(cfg.uninstallDrainWindowHours); })
+      .catch(() => { if (!cancelled) setWindowHours(null); });
+    return () => { cancelled = true; };
+  }, [open]);
+
+  if (!open || targets.length === 0) return null;
+
+  // "online" vs "not currently online" — NOT "offline". maintenance,
+  // quarantined, updating and pending are none of the three, and calling them
+  // offline is a lie the operator would act on.
+  const online = targets.filter((d) => d.status === 'online').length;
+  const notOnline = targets.length - online;
+  const many = targets.length > 1;
+
+  let uninstallHint: string;
+  if (many && online > 0 && notOnline > 0) {
+    uninstallHint = t('deviceActions.removeDialog.uninstallMixed');
+  } else if (notOnline === 0) {
+    uninstallHint = t('deviceActions.removeDialog.uninstallOnline');
+  } else if (windowHours != null) {
+    uninstallHint = t('deviceActions.removeDialog.uninstallQueuedWithWindow', { hours: windowHours });
+  } else {
+    uninstallHint = t('deviceActions.removeDialog.uninstallQueued');
+  }
+
+  return (
+    <ConfirmDialog
+      open
+      onClose={onClose}
+      onConfirm={() => onConfirm({ uninstallAgent })}
+      title={many
+        ? t('deviceActions.removeDialog.titleMany', { count: targets.length })
+        : t('deviceActions.removeDialog.titleOne', { hostname: targets[0].hostname })}
+      message={many ? t('deviceActions.removeDialog.bodyMany') : t('deviceActions.removeDialog.bodyOne')}
+      confirmLabel={t('deviceActions.removeDialog.confirm')}
+      variant="destructive"
+      isLoading={isLoading}
+      confirmTestId={confirmTestId}
+    >
+      {many && (
+        <p className="text-sm text-muted-foreground" data-testid="remove-dialog-summary">
+          {t('deviceActions.removeDialog.summary', { online, notOnline })}
+        </p>
+      )}
+      <fieldset className="mt-3 space-y-2" aria-labelledby={legendId}>
+        <legend id={legendId} className="text-sm font-medium">
+          {t('deviceActions.removeDialog.legend')}
+        </legend>
+        <label className="flex items-start gap-2 text-sm">
+          <input
+            type="radio"
+            name="remove-agent-choice"
+            className="mt-1"
+            checked={uninstallAgent}
+            onChange={() => setUninstallAgent(true)}
+            data-testid="remove-choice-uninstall"
+          />
+          <span>
+            <span className="block">{t('deviceActions.removeDialog.uninstall')}</span>
+            <span className="block text-xs text-muted-foreground">{uninstallHint}</span>
+          </span>
+        </label>
+        <label className="flex items-start gap-2 text-sm">
+          <input
+            type="radio"
+            name="remove-agent-choice"
+            className="mt-1"
+            checked={!uninstallAgent}
+            onChange={() => setUninstallAgent(false)}
+            data-testid="remove-choice-leave"
+          />
+          <span>
+            <span className="block">{t('deviceActions.removeDialog.leave')}</span>
+            <span className="block text-xs text-muted-foreground">{t('deviceActions.removeDialog.leaveHint')}</span>
+          </span>
+        </label>
+      </fieldset>
+    </ConfirmDialog>
+  );
+}

--- a/apps/web/src/components/devices/__tests__/removeSendsUninstallChoice.test.ts
+++ b/apps/web/src/components/devices/__tests__/removeSendsUninstallChoice.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '../../..');
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) walk(p, out);
+    else if (/\.(ts|tsx)$/.test(p) && !/\.test\.tsx?$/.test(p)) out.push(p);
+  }
+  return out;
+}
+
+/**
+ * #3987: the API has accepted `{ uninstallAgent }` on DELETE /devices/:id since
+ * #4001, but no web caller sent it — every Remove left the agent installed and
+ * heartbeating into a 403. Four surfaces went through the service layer (which
+ * now always sends a body) and one, PossibleReplacementBanner, issued its own
+ * bodyless DELETE. Code review would not catch a fifth: this does.
+ */
+describe('every Remove sends the agent choice (#3987)', () => {
+  it('no component issues a bodyless DELETE /devices/:id', () => {
+    const offenders: string[] = [];
+    for (const file of walk(join(root, 'components'))) {
+      const src = readFileSync(file, 'utf8');
+      // fetchWithAuth(`/devices/${x}`, { method: 'DELETE' }) with no `body:` in the same call
+      const re = /fetchWithAuth\(\s*`\/devices\/\$\{[^}]+\}`\s*,\s*\{([^}]*)\}\s*\)/g;
+      let m: RegExpExecArray | null;
+      while ((m = re.exec(src))) {
+        if (/method:\s*['"]DELETE['"]/.test(m[1]) && !/body:/.test(m[1])) offenders.push(file.replace(root, ''));
+      }
+    }
+    expect(offenders, 'Route these through decommissionDevice(id, { uninstallAgent }) or add the JSON body').toEqual([]);
+  });
+});

--- a/apps/web/src/locales/de-DE/devices.json
+++ b/apps/web/src/locales/de-DE/devices.json
@@ -205,6 +205,22 @@
         "confirm": "Homebrew installieren"
       }
     },
+    "removeDialog": {
+      "titleOne": "{{hostname}} entfernen?",
+      "titleMany": "{{count}} Geräte entfernen?",
+      "bodyOne": "Es wird aus Ihrer aktiven Flotte genommen und nicht mehr überwacht. Der Verlauf bleibt erhalten, und Sie können es später wiederherstellen.",
+      "bodyMany": "Sie werden aus Ihrer aktiven Flotte genommen und nicht mehr überwacht. Der Verlauf bleibt erhalten, und Sie können sie später wiederherstellen.",
+      "summary": "{{online}} online, {{notOnline}} derzeit nicht online.",
+      "legend": "Was soll mit dem Breeze-Agenten geschehen?",
+      "uninstall": "Den Breeze-Agenten deinstallieren",
+      "uninstallOnline": "Jetzt eingereiht — ein Online-Agent holt den Befehl in wenigen Augenblicken ab.",
+      "uninstallQueuedWithWindow": "Eingereiht — wird ausgeführt, sobald sich das Gerät das nächste Mal meldet. Wird abgebrochen, wenn das nicht innerhalb von {{hours}} Stunden geschieht.",
+      "uninstallQueued": "Eingereiht — wird ausgeführt, sobald sich das Gerät das nächste Mal meldet.",
+      "uninstallMixed": "Online-Geräte holen den Befehl in wenigen Augenblicken ab; die übrigen führen ihn bei der nächsten Meldung aus.",
+      "leave": "Den Agenten installiert lassen",
+      "leaveHint": "Auf dem Rechner läuft der Agent weiter, er kann aber nicht verwaltet werden.",
+      "confirm": "Entfernen"
+    },
     "runScript": "Skript ausführen",
     "remoteTools": "Remote-Tools",
     "reRunAgentInventoryCollectorsSo": "Bestandsdatenerfassung des Agents erneut ausführen, damit die Benutzeroberfläche aktuelle Hardware-, Software- und Netzwerkdaten erhält, ohne auf den nächsten Heartbeat-Zyklus zu warten",

--- a/apps/web/src/locales/en/devices.json
+++ b/apps/web/src/locales/en/devices.json
@@ -205,6 +205,22 @@
         "confirm": "Install Homebrew"
       }
     },
+    "removeDialog": {
+      "titleOne": "Remove {{hostname}}?",
+      "titleMany": "Remove {{count}} devices?",
+      "bodyOne": "It will be taken out of your active fleet and stop being monitored. History is kept and you can restore it later.",
+      "bodyMany": "They will be taken out of your active fleet and stop being monitored. History is kept and you can restore them later.",
+      "summary": "{{online}} online, {{notOnline}} not currently online.",
+      "legend": "What should happen to the Breeze agent?",
+      "uninstall": "Uninstall the Breeze agent",
+      "uninstallOnline": "Queued now — an online agent collects it within moments.",
+      "uninstallQueuedWithWindow": "Queued — runs the next time the device checks in. Cancelled if it hasn't after {{hours}} hours.",
+      "uninstallQueued": "Queued — runs the next time the device checks in.",
+      "uninstallMixed": "Online devices collect it within moments; the rest run it on their next check-in.",
+      "leave": "Leave the agent installed",
+      "leaveHint": "The machine keeps running the agent but can't be managed.",
+      "confirm": "Remove"
+    },
     "runScript": "Run Script",
     "remoteTools": "Remote Tools",
     "reRunAgentInventoryCollectorsSo": "Re-run agent inventory collectors so the UI sees fresh hardware/software/network data without waiting for the next heartbeat cycle",

--- a/apps/web/src/locales/es-419/devices.json
+++ b/apps/web/src/locales/es-419/devices.json
@@ -205,6 +205,22 @@
         "confirm": "Instalar Homebrew"
       }
     },
+    "removeDialog": {
+      "titleOne": "¿Quitar {{hostname}}?",
+      "titleMany": "¿Quitar {{count}} dispositivos?",
+      "bodyOne": "Se sacará de su flota activa y dejará de ser supervisado. El historial se conserva y puede restaurarlo más adelante.",
+      "bodyMany": "Se sacarán de su flota activa y dejarán de ser supervisados. El historial se conserva y puede restaurarlos más adelante.",
+      "summary": "{{online}} en línea, {{notOnline}} sin conexión en este momento.",
+      "legend": "¿Qué debe pasar con el agente Breeze?",
+      "uninstall": "Desinstalar el agente Breeze",
+      "uninstallOnline": "En cola ahora — un agente en línea lo recoge en unos instantes.",
+      "uninstallQueuedWithWindow": "En cola — se ejecuta la próxima vez que el dispositivo se comunique. Se cancela si no lo hace en {{hours}} horas.",
+      "uninstallQueued": "En cola — se ejecuta la próxima vez que el dispositivo se comunique.",
+      "uninstallMixed": "Los dispositivos en línea lo recogen en unos instantes; el resto lo ejecuta en su próxima comunicación.",
+      "leave": "Dejar el agente instalado",
+      "leaveHint": "La máquina sigue ejecutando el agente, pero no se puede administrar.",
+      "confirm": "Quitar"
+    },
     "runScript": "Ejecutar secuencia de comandos",
     "remoteTools": "Herramientas remotas",
     "reRunAgentInventoryCollectorsSo": "Vuelva a ejecutar los recopiladores de inventario de agentes para que UI vea datos nuevos de hardware/software/red sin esperar el siguiente ciclo de latidos.",

--- a/apps/web/src/locales/fr-CA/devices.json
+++ b/apps/web/src/locales/fr-CA/devices.json
@@ -201,6 +201,22 @@
         "confirm": "Installer Homebrew"
       }
     },
+    "removeDialog": {
+      "titleOne": "Retirer {{hostname}} ?",
+      "titleMany": "Retirer {{count}} appareils ?",
+      "bodyOne": "Il sera sorti de votre parc actif et ne sera plus surveillé. L’historique est conservé et vous pourrez le restaurer plus tard.",
+      "bodyMany": "Ils seront sortis de votre parc actif et ne seront plus surveillés. L’historique est conservé et vous pourrez les restaurer plus tard.",
+      "summary": "{{online}} en ligne, {{notOnline}} pas en ligne actuellement.",
+      "legend": "Que doit-il advenir de l’agent Breeze ?",
+      "uninstall": "Désinstaller l’agent Breeze",
+      "uninstallOnline": "Mis en file d’attente — un agent en ligne le récupère dans quelques instants.",
+      "uninstallQueuedWithWindow": "Mis en file d’attente — s’exécute à la prochaine communication de l’appareil. Annulé s’il ne se manifeste pas dans un délai de {{hours}} heures.",
+      "uninstallQueued": "Mis en file d’attente — s’exécute à la prochaine communication de l’appareil.",
+      "uninstallMixed": "Les appareils en ligne le récupèrent dans quelques instants; les autres l’exécutent à leur prochaine communication.",
+      "leave": "Laisser l’agent installé",
+      "leaveHint": "La machine continue d’exécuter l’agent, mais elle ne peut plus être gérée.",
+      "confirm": "Retirer"
+    },
     "runScript": "Exécuter un script",
     "remoteTools": "Outils à distance",
     "reRunAgentInventoryCollectorsSo": "Relancez les collecteurs d’inventaire de l’agent pour que l’interface puisse voir de nouvelles données matérielles/logicielles/réseau sans attendre le prochain cycle de battements de cœur",

--- a/apps/web/src/locales/fr-FR/devices.json
+++ b/apps/web/src/locales/fr-FR/devices.json
@@ -205,6 +205,22 @@
         "confirm": "Installer Homebrew"
       }
     },
+    "removeDialog": {
+      "titleOne": "Retirer {{hostname}} ?",
+      "titleMany": "Retirer {{count}} appareils ?",
+      "bodyOne": "Il sera sorti de votre parc actif et ne sera plus surveillé. L’historique est conservé et vous pourrez le restaurer plus tard.",
+      "bodyMany": "Ils seront sortis de votre parc actif et ne seront plus surveillés. L’historique est conservé et vous pourrez les restaurer plus tard.",
+      "summary": "{{online}} en ligne, {{notOnline}} pas en ligne actuellement.",
+      "legend": "Que doit-il advenir de l’agent Breeze ?",
+      "uninstall": "Désinstaller l’agent Breeze",
+      "uninstallOnline": "Mis en file d’attente — un agent en ligne le récupère dans quelques instants.",
+      "uninstallQueuedWithWindow": "Mis en file d’attente — s’exécute à la prochaine communication de l’appareil. Annulé s’il ne se manifeste pas dans un délai de {{hours}} heures.",
+      "uninstallQueued": "Mis en file d’attente — s’exécute à la prochaine communication de l’appareil.",
+      "uninstallMixed": "Les appareils en ligne le récupèrent dans quelques instants; les autres l’exécutent à leur prochaine communication.",
+      "leave": "Laisser l’agent installé",
+      "leaveHint": "La machine continue d’exécuter l’agent, mais elle ne peut plus être gérée.",
+      "confirm": "Retirer"
+    },
     "runScript": "Exécuter un script",
     "remoteTools": "Outils à distance",
     "reRunAgentInventoryCollectorsSo": "Relancez les collecteurs d’inventaire de l’agent pour que l’interface puisse voir de nouvelles données matérielles/logicielles/réseau sans attendre le prochain cycle de battements de cœur",

--- a/apps/web/src/locales/it-IT/devices.json
+++ b/apps/web/src/locales/it-IT/devices.json
@@ -201,6 +201,22 @@
         "confirm": "Installa Homebrew"
       }
     },
+    "removeDialog": {
+      "titleOne": "Rimuovere {{hostname}}?",
+      "titleMany": "Rimuovere {{count}} dispositivi?",
+      "bodyOne": "Verrà tolto dalla tua flotta attiva e non sarà più monitorato. La cronologia viene conservata e potrai ripristinarlo in seguito.",
+      "bodyMany": "Verranno tolti dalla tua flotta attiva e non saranno più monitorati. La cronologia viene conservata e potrai ripristinarli in seguito.",
+      "summary": "{{online}} online, {{notOnline}} al momento non online.",
+      "legend": "Che cosa deve succedere all’agente Breeze?",
+      "uninstall": "Disinstalla l’agente Breeze",
+      "uninstallOnline": "In coda ora — un agente online lo raccoglie in pochi istanti.",
+      "uninstallQueuedWithWindow": "In coda — viene eseguito alla prossima connessione del dispositivo. Viene annullato se non avviene entro {{hours}} ore.",
+      "uninstallQueued": "In coda — viene eseguito alla prossima connessione del dispositivo.",
+      "uninstallMixed": "I dispositivi online lo raccolgono in pochi istanti; gli altri lo eseguono alla loro prossima connessione.",
+      "leave": "Lascia l’agente installato",
+      "leaveHint": "La macchina continua a eseguire l’agente, ma non può essere gestita.",
+      "confirm": "Rimuovi"
+    },
     "runScript": "Esegui script",
     "remoteTools": "Strumenti remoti",
     "reRunAgentInventoryCollectorsSo": "Esegui di nuovo i moduli di raccolta dell'inventario dell'agente, così l'interfaccia mostra dati hardware, software e di rete aggiornati senza attendere il successivo heartbeat",

--- a/apps/web/src/locales/pt-BR/devices.json
+++ b/apps/web/src/locales/pt-BR/devices.json
@@ -205,6 +205,22 @@
         "confirm": "Instalar o Homebrew"
       }
     },
+    "removeDialog": {
+      "titleOne": "Remover {{hostname}}?",
+      "titleMany": "Remover {{count}} dispositivos?",
+      "bodyOne": "Ele sairá da sua frota ativa e deixará de ser monitorado. O histórico é mantido e você pode restaurá-lo depois.",
+      "bodyMany": "Eles sairão da sua frota ativa e deixarão de ser monitorados. O histórico é mantido e você pode restaurá-los depois.",
+      "summary": "{{online}} on-line, {{notOnline}} no momento sem conexão.",
+      "legend": "O que deve acontecer com o agente Breeze?",
+      "uninstall": "Desinstalar o agente Breeze",
+      "uninstallOnline": "Na fila agora — um agente on-line o recolhe em instantes.",
+      "uninstallQueuedWithWindow": "Na fila — é executado na próxima vez que o dispositivo se comunicar. Cancelado se isso não acontecer em {{hours}} horas.",
+      "uninstallQueued": "Na fila — é executado na próxima vez que o dispositivo se comunicar.",
+      "uninstallMixed": "Os dispositivos on-line o recolhem em instantes; os demais o executam na próxima comunicação.",
+      "leave": "Manter o agente instalado",
+      "leaveHint": "A máquina continua executando o agente, mas não pode ser gerenciada.",
+      "confirm": "Remover"
+    },
     "runScript": "Executar script",
     "remoteTools": "Ferramentas remotas",
     "reRunAgentInventoryCollectorsSo": "Executar novamente os coletores de inventário do agente para que a interface veja dados atualizados de hardware, software e rede sem aguardar o próximo ciclo de heartbeat",

--- a/apps/web/src/locales/tr-TR/devices.json
+++ b/apps/web/src/locales/tr-TR/devices.json
@@ -205,6 +205,22 @@
         "confirm": "Homebrew'u yükle"
       }
     },
+    "removeDialog": {
+      "titleOne": "{{hostname}} çıkarılsın mı?",
+      "titleMany": "{{count}} cihaz çıkarılsın mı?",
+      "bodyOne": "Etkin filonuzdan çıkarılacak ve izlenmeyecek. Geçmiş korunur ve daha sonra geri yükleyebilirsiniz.",
+      "bodyMany": "Etkin filonuzdan çıkarılacak ve izlenmeyecekler. Geçmiş korunur ve daha sonra geri yükleyebilirsiniz.",
+      "summary": "{{online}} çevrimiçi, {{notOnline}} şu anda çevrimiçi değil.",
+      "legend": "Breeze aracısına ne olsun?",
+      "uninstall": "Breeze aracısını kaldır",
+      "uninstallOnline": "Şimdi sıraya alındı — çevrimiçi bir aracı komutu birkaç saniye içinde alır.",
+      "uninstallQueuedWithWindow": "Sıraya alındı — cihaz bir sonraki bağlantısında çalıştırır. {{hours}} saat içinde bağlanmazsa iptal edilir.",
+      "uninstallQueued": "Sıraya alındı — cihaz bir sonraki bağlantısında çalıştırır.",
+      "uninstallMixed": "Çevrimiçi cihazlar komutu birkaç saniye içinde alır; diğerleri bir sonraki bağlantılarında çalıştırır.",
+      "leave": "Aracıyı yüklü bırak",
+      "leaveHint": "Makine aracıyı çalıştırmaya devam eder ancak yönetilemez.",
+      "confirm": "Çıkar"
+    },
     "runScript": "Komut Dosyasını Çalıştır",
     "remoteTools": "Uzaktan Araçlar",
     "reRunAgentInventoryCollectorsSo": "Kullanıcı arayüzünün bir sonraki kalp atışı döngüsünü beklemeden yeni donanım/yazılım/ağ verilerini görmesi için aracı envanter toplayıcılarını yeniden çalıştırın",

--- a/apps/web/src/services/__tests__/deviceActions.test.ts
+++ b/apps/web/src/services/__tests__/deviceActions.test.ts
@@ -214,16 +214,22 @@ describe('deviceActions service', () => {
     it('returns success payload on delete', async () => {
       fetchWithAuthMock.mockResolvedValue(makeResponse({ data: { success: true } }));
 
-      const result = await decommissionDevice('dev-1');
+      const result = await decommissionDevice('dev-1', { uninstallAgent: true });
 
-      expect(fetchWithAuthMock).toHaveBeenCalledWith('/devices/dev-1', { method: 'DELETE' });
+      // #3987: the agent choice always rides along in the JSON body. A
+      // bodyless DELETE is what left zombie agents installed on removed boxes.
+      expect(fetchWithAuthMock).toHaveBeenCalledWith('/devices/dev-1', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ uninstallAgent: true }),
+      });
       expect(result).toEqual({ success: true });
     });
 
     it('throws helpful error on failure', async () => {
       fetchWithAuthMock.mockResolvedValue(makeResponse({ message: 'Delete rejected' }, false, 403));
 
-      await expect(decommissionDevice('dev-1')).rejects.toThrow('Delete rejected');
+      await expect(decommissionDevice('dev-1', { uninstallAgent: true })).rejects.toThrow('Delete rejected');
     });
   });
 
@@ -385,7 +391,7 @@ describe('deviceActions service', () => {
         { id: 'dev-1', hostname: 'host-1' },
         { id: 'dev-2', hostname: 'host-2' },
         { id: 'dev-3', hostname: 'host-3' },
-      ]);
+      ], { uninstallAgent: true });
 
       // The real bug this guards: previously `catch { failed++; }` discarded
       // which device failed — a partial-failure toast could only say "1
@@ -398,7 +404,7 @@ describe('deviceActions service', () => {
     it('falls back to id when hostname is empty', async () => {
       fetchWithAuthMock.mockResolvedValueOnce(makeResponse({ error: 'gone' }, false, 404));
 
-      const result = await bulkDecommissionDevices([{ id: 'dev-1', hostname: '' }]);
+      const result = await bulkDecommissionDevices([{ id: 'dev-1', hostname: '' }], { uninstallAgent: true });
 
       expect(result.failed).toEqual([{ id: 'dev-1', hostname: 'dev-1' }]);
     });

--- a/apps/web/src/services/deviceActions.test.ts
+++ b/apps/web/src/services/deviceActions.test.ts
@@ -111,3 +111,47 @@ describe('linkDevicesVmHost wire shape (#2308)', () => {
     );
   });
 });
+
+describe('decommissionDevice — agent choice is sent to the API', () => {
+  it('sends { uninstallAgent: true } as the JSON body', async () => {
+    const { decommissionDevice } = await import('./deviceActions');
+    fetchMock.mockResolvedValue(makeJsonResponse({ success: true, uninstallQueued: true }));
+    await decommissionDevice('dev-1', { uninstallAgent: true });
+    const [path, init] = fetchMock.mock.calls[0]!;
+    expect(path).toBe('/devices/dev-1');
+    expect(init?.method).toBe('DELETE');
+    expect(JSON.parse(String(init?.body))).toEqual({ uninstallAgent: true });
+    expect((init?.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+  });
+
+  it('sends { uninstallAgent: false } when the user chose to leave the agent', async () => {
+    const { decommissionDevice } = await import('./deviceActions');
+    fetchMock.mockResolvedValue(makeJsonResponse({ success: true, uninstallQueued: false }));
+    await decommissionDevice('dev-1', { uninstallAgent: false });
+    expect(JSON.parse(String(fetchMock.mock.calls[0]![1]?.body))).toEqual({ uninstallAgent: false });
+  });
+});
+
+describe('bulkDecommissionDevices — one body per device, same choice', () => {
+  it('forwards the same uninstallAgent to every DELETE', async () => {
+    const { bulkDecommissionDevices } = await import('./deviceActions');
+    fetchMock.mockResolvedValue(makeJsonResponse({ success: true }));
+    const result = await bulkDecommissionDevices(
+      [{ id: 'a', hostname: 'A' }, { id: 'b', hostname: 'B' }],
+      { uninstallAgent: true },
+    );
+    expect(result).toEqual({ succeeded: 2, failed: [] });
+    for (const call of fetchMock.mock.calls) {
+      expect(JSON.parse(String(call[1]?.body))).toEqual({ uninstallAgent: true });
+    }
+  });
+});
+
+describe('fetchRemovalConfig', () => {
+  it('returns the drain window from GET /devices/removal-config', async () => {
+    const { fetchRemovalConfig } = await import('./deviceActions');
+    fetchMock.mockResolvedValue(makeJsonResponse({ uninstallDrainWindowHours: 48 }));
+    expect(await fetchRemovalConfig()).toEqual({ uninstallDrainWindowHours: 48 });
+    expect(fetchMock.mock.calls[0]![0]).toBe('/devices/removal-config');
+  });
+});

--- a/apps/web/src/services/deviceActions.ts
+++ b/apps/web/src/services/deviceActions.ts
@@ -376,9 +376,24 @@ export async function executeScript(
   return await response.json() as ScriptAdmissionResult;
 }
 
-export async function decommissionDevice(deviceId: string): Promise<{ success: boolean }> {
+export interface RemoveDeviceOptions {
+  /**
+   * Queue a durable self_uninstall alongside the Remove (#3986/#4001). The
+   * API defaults this to false for back-compat; the WEB defaults it to true
+   * in RemoveDeviceDialog — defaulting to "leave installed" is what produces
+   * zombie agents nobody notices (owner decision 2026-08-24).
+   */
+  uninstallAgent: boolean;
+}
+
+export async function decommissionDevice(
+  deviceId: string,
+  opts: RemoveDeviceOptions,
+): Promise<{ success: boolean; uninstallQueued?: boolean }> {
   const response = await fetchWithAuth(`/devices/${deviceId}`, {
-    method: 'DELETE'
+    method: 'DELETE',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ uninstallAgent: opts.uninstallAgent }),
   });
 
   if (!response.ok) {
@@ -387,6 +402,19 @@ export async function decommissionDevice(deviceId: string): Promise<{ success: b
 
   const data = await response.json();
   return data.data ?? data;
+}
+
+/**
+ * Read-only knobs the Remove dialog needs. `uninstallDrainWindowHours` is
+ * env-driven on the API (DEVICE_UNINSTALL_DRAIN_WINDOW_HOURS) — operators tune
+ * it per deployment, so the web must fetch it and never hardcode it.
+ */
+export async function fetchRemovalConfig(): Promise<{ uninstallDrainWindowHours: number }> {
+  const response = await fetchWithAuth('/devices/removal-config');
+  if (!response.ok) {
+    throw new Error(await getErrorMessage(response, 'Failed to load removal settings'));
+  }
+  return response.json();
 }
 
 /**
@@ -483,14 +511,17 @@ export interface BulkDecommissionResult {
  * summary naming which devices failed, not just a count.
  */
 export async function bulkDecommissionDevices(
-  devices: Array<{ id: string; hostname: string }>
+  devices: Array<{ id: string; hostname: string }>,
+  opts: RemoveDeviceOptions,
 ): Promise<BulkDecommissionResult> {
   let succeeded = 0;
   const failed: BulkDecommissionFailed[] = [];
 
   for (const device of devices) {
     try {
-      await decommissionDevice(device.id);
+      // One radio for the whole selection (#3987) — every DELETE carries the
+      // same agent choice the operator made once in RemoveDeviceDialog.
+      await decommissionDevice(device.id, opts);
       succeeded++;
     } catch {
       failed.push({ id: device.id, hostname: device.hostname || device.id });


### PR DESCRIPTION
## The zombie gap

`DELETE /devices/:id` has accepted `{ uninstallAgent }` and queued a durable, provenance-tagged `self_uninstall` since #4001 — but **no web caller ever sent it** (`grep uninstallAgent apps/web/src` → 0 hits before this PR). Every Remove issued a bodyless DELETE, so the API's back-compat default `false` applied and the machine kept running an agent that heartbeats into a 403 forever. That is exactly the outcome the 2026-08-24 owner decision was meant to eliminate.

This wave makes every Remove ask the one question Remove actually has — *uninstall the agent, or leave it?* — default it to **Uninstall**, and send the answer.

## The six surfaces

All six now render the same `RemoveDeviceDialog`:

| Surface | Path |
|---|---|
| DevicesPage row kebab | `pendingDeviceAction` → `runDeviceAction(action, device, choice)` |
| DevicesPage grid card | same handler (`handleDeviceAction` is shared) |
| DevicesPage bulk bar | new `pendingBulkRemove` state → `runBulkRemove(devices, choice)` — asked **once** for the whole selection |
| Device detail page kebab | `DeviceActions` → `handleConfirm(opts)` → `DeviceDetailPage.handleAction(action, device, opts)` |
| `PossibleReplacementBanner` | was the one surface issuing its own bodyless DELETE; now goes through the dialog and sends the body |
| Device detail page → Settings → Danger Zone | `DeviceSettingsModal` fires `onAction('decommission', device)` with **no** choice; `DeviceDetailPage.handleAction` now gates any opts-less `decommission` through the dialog (found in review — see below) |

Service layer: `decommissionDevice(id, { uninstallAgent })` and `bulkDecommissionDevices(devices, { uninstallAgent })` — the option is a **required** argument, so a new call site cannot silently omit it (that requirement is what surfaced the two stale call sites during implementation).

### Review fix — a sixth surface

Review caught a Remove path this PR had missed. `DeviceSettingsModal`'s Danger Zone button calls `onClose(); onAction('decommission', device)` with no choice argument. On `DevicesPage` that is harmless — `handleDeviceAction` gates every `decommission` through the dialog before it reaches `runDeviceAction`. On `DeviceDetailPage` there was no such gate: `case "decommission"` went straight into the undo toast and removed the device with `uninstallAgent: true` silently, giving the operator no way to choose "leave installed".

`DeviceDetailPage.handleAction` now has the same gate/execute split `DevicesPage` has, keyed on the **absence of `opts`** rather than on the caller:

```ts
if (action === "decommission" && !opts) {
  setPendingRemove(device);
  return;
}
```

Keying on `opts` rather than on which component called means any present or future Remove trigger on this page is gated by default, and a caller that already asked (the `DeviceActions` kebab) is not asked twice. `DeviceSettingsModal.tsx` is deliberately **not** touched — W03 is editing it on another branch.

## Copy decisions

- **Defaults to Uninstall.** Never "leave installed" (owner decision 2026-08-24).
- **"Queued", never "runs now."** Remove inserts a pending `self_uninstall` and force-closes the agent WS; the agent collects it on its next poll. Online → *"Queued now — an online agent collects it within moments."* Anything else → *"Queued — runs the next time the device checks in. Cancelled if it hasn't after N hours."*
- **The window is fetched, not hardcoded.** `DEVICE_UNINSTALL_DRAIN_WINDOW_HOURS` is env-driven per deployment, so this PR adds a tiny read-only route `GET /devices/removal-config` → `{ uninstallDrainWindowHours }` (requires `devices:read`, mounted **before** `coreRoutes` so `/:id` cannot eat the static path — pinned by a new assertion in `index.test.ts`). If that fetch fails, the dialog falls back to the window-less sentence rather than inventing a number.
- **Bulk buckets are "online" / "not currently online"**, never "offline" — `maintenance`, `quarantined`, `updating`, `pending` are none of the three, and calling them offline is a claim an operator would act on.
- New `deviceActions.removeDialog.*` block added to **all eight locales** in the same commit.

The 5-second undo toast on single Remove is untouched: the dialog decides *how*, the toast still offers *whether*.

## Guard

`apps/web/src/components/devices/__tests__/removeSendsUninstallChoice.test.ts` statically scans every component for `fetchWithAuth(\`/devices/${...}\`, { method: 'DELETE' })` with no `body:`. Verified to discriminate — reverting the banner's body makes it fail and names the file.

## Tests (all verified locally, on the merge with `origin/main`)

| Command | Result |
|---|---|
| `apps/web` — `src/components/devices` | **76 files / 834 tests passed** |
| `apps/web` — `src/components/devices src/services/deviceActions.test.ts src/lib/i18n` | **84 files / 985 tests passed** (before the review fix; the devices row above supersedes it) |
| `apps/api` — `src/routes/devices` | **47 files / 678 tests passed** |
| `tsc --noEmit -p apps/web/tsconfig.json` | clean |
| `tsc --noEmit -p apps/api/tsconfig.json` | clean (needs `NODE_OPTIONS=--max-old-space-size=8192`, same as the CI job) |
| `pnpm lint` | clean — 6/6 turbo tasks |

New tests: 1 API route test + 1 mount-order assertion, 3 service tests, 6 `RemoveDeviceDialog` tests, 3 `DevicesPage` tests, 1 `DeviceActions` test, 1 banner test, 1 static guard, **4 `DeviceDetailPage.removeDialog` tests** (review fix).

## Deviations from the plan

1. **`index.test.ts` mount assertion is a static source scan, not a request.** The plan asked for a `GET /devices/removal-config` request with "the file's standard auth mock" — that file has no auth mock and never imports the router; every existing case reads `index.ts` as text and compares mount offsets. Followed the file's own convention instead, and proved the new assertion fails when the mount is moved after `coreRoutes`.
2. **`DeviceActions` testids differed from the plan's guesses.** Real ones are `device-actions-menu` (trigger) and `device-action-remove` (menu item), not `device-actions-menu-trigger` / `device-action-decommission`. Used the real ones; added no new trigger testid.
3. **A second, unlisted test file needed updating**: `apps/web/src/services/__tests__/deviceActions.test.ts` (distinct from `src/services/deviceActions.test.ts`) held four `decommissionDevice`/`bulkDecommissionDevices` call sites. Updated in the same commit as Task 2.
4. **`PossibleReplacementBanner.test.tsx` mocks `../../services/deviceActions`** rather than adding a second `fetchWithAuth` response for the config fetch. That file pins exact `fetchWithAuth` call counts to prove which requests the banner itself makes; letting the dialog's config fetch land in those counts would have broken three unrelated assertions. (The plan explicitly allowed this branch.)
5. **`handleConfirm` forwards `opts` only when present** (`opts ? onAction?.(t, d, opts) : onAction?.(t, d)`). Passing a bare `undefined` third argument to every confirm action would change its call arity and break the existing `toHaveBeenCalledWith('maintenance', device)` assertions for no benefit.
6. **Six pre-existing tests were updated**, all because the Remove copy moved from `deviceActions.confirm.decommission.*` to the dialog's own block, or because the bulk path now has an extra dialog to click through: two bulk-decommission tests in the #2465 describe, three in the #4009 describe, one in the all-offline describe, plus one in `DeviceActions.test.tsx` and one in the banner. One test title was corrected from "no gate, no confirm" to "no skip gate" — there *is* now a confirm; what it pins is the absence of the #2465 skip gate.
7. **`getModalConfig` lost its `decommission` case** and its parameter type now excludes it, so a future Remove cannot accidentally re-acquire generic yes/no copy.
8. **Review-fix naming:** the review note suggested calling the executor `runAction(...)` inside `DeviceDetailPage`. That name is already taken in this file by the imported `runAction` helper from `@/lib/runAction`, so the dialog's `onConfirm` re-enters `handleAction('decommission', target, choice)` instead — the same gate/execute round-trip, no shadowed import.
9. **`DeviceSettingsModal` is stubbed, not driven, in the new test** (W03 owns the real file on another branch). The stub reproduces its exact call shape; the assertion keys on the missing `opts`, so it holds for any caller that omits one. Worth knowing: if W03 changes that call shape, this test would keep passing while the real button regressed.

Closes #5024
Refs #3987, closes #2250

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZAsMVZBbCxwBUtRFmrY7A

