### PR TITLE
feat: surface agent-uninstall state on removed devices (#3987)

### DIFF
--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -66,6 +66,7 @@ import { hashEnrollmentKey } from '../../services/enrollmentKeySecurity';
 import { sendCommandToAgent, isAgentConnected, disconnectAgent } from '../agentWs';
 import { terminateDeviceRemoteSessions, TEARDOWN_FAILED } from '../../services/remoteSessionTeardown';
 import { queueDeviceUninstall, releaseDeviceRemoveReason } from '../../services/deviceUninstallDrain';
+import { getDeviceUninstallStatus } from '../../services/deviceUninstallState';
 import { CommandTypes } from '../../services/commandQueue';
 import { getGlobalEnrollmentSecret } from '../agents/enrollment';
 import { assertTtlWithinCap } from '../../services/enrollmentDefaults';
@@ -1263,6 +1264,19 @@ coreRoutes.get(
     // substitution) -- though `scheme_not_allowed` can only ever be
     // observed by the issuance path (POST), since detecting it requires the
     // substitution this availability check deliberately skips.
+    // What happened to the agent-uninstall this device's Remove queued
+    // (#3987 item 7). Only meaningful for a removed device, and deliberately
+    // skipped otherwise so the hot detail path is unchanged for the 99% case.
+    //
+    // Ordering is load-bearing, not incidental: `device_commands` carries no
+    // RLS (intentionally system-scoped for the agent WS path), so this read
+    // MUST sit downstream of `getDeviceWithOrgAndSiteCheck` above — which has
+    // already 403/404'd an id outside the caller's tenant or allowed sites.
+    // Pinned by core.uninstallState.test.ts.
+    const uninstall = device.status === 'decommissioned'
+      ? await getDeviceUninstallStatus(deviceId)
+      : null;
+
     let hasRemoteAccessLauncher = false;
     let remoteAccessLaunchSkipReason: RemoteAccessLaunchSkipReason | 'config_error' | null = null;
     try {
@@ -1294,6 +1308,7 @@ coreRoutes.get(
       remoteAccessPolicy,
       hasRemoteAccessLauncher,
       remoteAccessLaunchSkipReason,
+      uninstall,
     });
   }
 );

--- a/apps/api/src/routes/devices/core.uninstallState.test.ts
+++ b/apps/api/src/routes/devices/core.uninstallState.test.ts
@@ -1,0 +1,210 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+// ---------------------------------------------------------------------------
+// #3987 item 7 — GET /devices/:id reports what happened to the agent-uninstall
+// queued by Remove.
+//
+// This file covers the ROUTE's wiring only; the query and the state mapping it
+// depends on are covered on compiled SQL by
+// `services/deviceUninstallState.test.ts`. The two properties that can only be
+// asserted here:
+//
+//   1. `uninstall` actually reaches the response body (this exact class of
+//      "selected but never mapped" drop has shipped three times on the device
+//      list — see core.list-response-shape.test.ts's comment).
+//   2. The read happens AFTER the authorisation chokepoint and only for a
+//      removed device. `device_commands` has no RLS (intentionally
+//      system-scoped, agent WS path), so calling the service before
+//      `getDeviceWithOrgAndSiteCheck` has cleared the id would read another
+//      tenant's command row.
+//
+// Mock scaffold mirrors core.remoteAccessLaunch.test.ts, which is the existing
+// suite that drives this same GET handler end to end.
+// ---------------------------------------------------------------------------
+
+vi.mock('../../services/partnerTrust', () => ({
+  evaluateCapability: vi.fn(async () => ({ allow: true })),
+  requireCapability: vi.fn(() => async (_c: any, next: any) => next()),
+}));
+
+// Chainable, table-agnostic query-builder stub: every lookup the GET handler
+// makes (hardware, network interfaces, metrics, memberships, site, org,
+// partner settings) resolves to an empty array instead of crashing partway
+// through on an unmocked chain shape.
+function makeSelectMock() {
+  return vi.fn(() => {
+    const node: any = {
+      from: vi.fn(() => node),
+      innerJoin: vi.fn(() => node),
+      where: vi.fn(() => node),
+      orderBy: vi.fn(() => node),
+      limit: vi.fn(async () => []),
+      then: (resolve: (v: unknown[]) => unknown, reject?: (e: unknown) => unknown) =>
+        Promise.resolve([]).then(resolve, reject),
+    };
+    return node;
+  });
+}
+
+vi.mock('../../db', () => ({
+  getCurrentDbAccessContext: vi.fn(() => undefined),
+  runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: {
+    select: makeSelectMock(),
+  },
+}));
+
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: vi.fn((c: any, next: any) => {
+    c.set('auth', {
+      user: { id: '11111111-1111-1111-1111-111111111111', email: 'test@example.com', name: 'Test User' },
+      scope: 'organization',
+      orgId: 'org-123',
+      partnerId: null,
+      accessibleOrgIds: ['org-123'],
+      principal: { kind: 'user_session' },
+      canAccessOrg: (orgId: string) => orgId === 'org-123',
+    });
+    return next();
+  }),
+  requireScope: vi.fn(() => async (_c: any, next: any) => next()),
+  requirePermission: vi.fn(() => async (_c: any, next: any) => next()),
+  requireMfa: vi.fn(() => async (_c: any, next: any) => next()),
+  isInteractiveUserSession: vi.fn(() => true),
+}));
+
+vi.mock('./helpers', () => ({
+  getPagination: vi.fn(() => ({ page: 1, limit: 50, offset: 0 })),
+  getDeviceWithOrgCheck: vi.fn(),
+  getDeviceWithOrgAndSiteCheck: vi.fn(),
+  SITE_ACCESS_DENIED: Symbol('SITE_ACCESS_DENIED'),
+  stripSensitiveDeviceFields: vi.fn((d: unknown) => d),
+}));
+
+vi.mock('../../services/deviceUninstallState', () => ({
+  getDeviceUninstallStatus: vi.fn(),
+}));
+
+vi.mock('../../services/remoteAccessPolicy', () => ({
+  resolveRemoteAccessForDevice: vi.fn(async () => ({ policyId: null, policyName: null, settings: {} })),
+}));
+
+vi.mock('../../services/agentWs', () => ({
+  sendCommandToAgent: vi.fn(),
+  isAgentConnected: vi.fn(() => false),
+}));
+
+vi.mock('../../services/commandQueue', () => ({ CommandTypes: {} }));
+
+vi.mock('../agents/enrollment', () => ({
+  getGlobalEnrollmentSecret: vi.fn(() => null),
+}));
+
+vi.mock('../../services/enrollmentKeySecurity', () => ({
+  hashEnrollmentKey: vi.fn((k: string) => `hash:${k}`),
+}));
+
+vi.mock('../../services/auditEvents', () => ({
+  requestLikeFromSnapshot: vi.fn(() => ({ req: { header: () => undefined } })),
+  writeRouteAudit: vi.fn(),
+}));
+
+vi.mock('../../services/sentry', () => ({ captureException: vi.fn() }));
+
+import { coreRoutes } from './core';
+import { getDeviceWithOrgAndSiteCheck } from './helpers';
+import { getDeviceUninstallStatus } from '../../services/deviceUninstallState';
+
+const DEVICE_ID = '22222222-2222-4222-8222-222222222222';
+
+const REMOVED_DEVICE = {
+  id: DEVICE_ID,
+  orgId: 'org-123',
+  siteId: 'site-1',
+  hostname: 'host-1',
+  displayName: 'Host 1',
+  status: 'decommissioned',
+  customFields: {},
+};
+
+const PENDING_UNINSTALL = {
+  state: 'pending' as const,
+  queuedAt: '2026-09-05T10:00:00.000Z',
+  sentAt: null,
+  completedAt: null,
+  expiresAt: '2026-09-08T10:00:00.000Z',
+};
+
+describe('GET /devices/:id — agent-uninstall state (#3987)', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = new Hono();
+    app.route('/devices', coreRoutes);
+  });
+
+  async function get() {
+    return app.request(`/devices/${DEVICE_ID}`, {
+      method: 'GET',
+      headers: { Authorization: 'Bearer token' },
+    });
+  }
+
+  it('surfaces the queued uninstall (state + deadline) on a removed device', async () => {
+    vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue(REMOVED_DEVICE as never);
+    vi.mocked(getDeviceUninstallStatus).mockResolvedValue(PENDING_UNINSTALL);
+
+    const res = await get();
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as { uninstall?: unknown };
+    expect(body.uninstall).toEqual(PENDING_UNINSTALL);
+    expect(getDeviceUninstallStatus).toHaveBeenCalledWith(DEVICE_ID);
+  });
+
+  it('reports uninstall: null when the Remove left the agent installed', async () => {
+    vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue(REMOVED_DEVICE as never);
+    vi.mocked(getDeviceUninstallStatus).mockResolvedValue(null);
+
+    const res = await get();
+
+    expect(res.status).toBe(200);
+    // Explicitly present-and-null, not absent: the web badge distinguishes
+    // "this Remove left the agent installed" (null) from "this payload does
+    // not carry the field at all" (a list row), and renders different things.
+    const body = await res.json() as Record<string, unknown>;
+    expect(body).toHaveProperty('uninstall');
+    expect(body.uninstall).toBeNull();
+  });
+
+  it('does not read device_commands for a device that is not removed', async () => {
+    vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue({
+      ...REMOVED_DEVICE,
+      status: 'online',
+    } as never);
+
+    const res = await get();
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.uninstall).toBeNull();
+    // Keeps the hot detail path exactly as it was for the 99% case.
+    expect(getDeviceUninstallStatus).not.toHaveBeenCalled();
+  });
+
+  it('never reads device_commands when the authorisation chokepoint rejects the id', async () => {
+    // The load-bearing isolation property: `device_commands` carries no RLS,
+    // so a read issued before/without the chokepoint would happily return
+    // another tenant's uninstall row for a guessed device id.
+    vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue(null as never);
+
+    const res = await get();
+
+    expect(res.status).toBe(404);
+    expect(getDeviceUninstallStatus).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/deviceUninstallState.test.ts
+++ b/apps/api/src/services/deviceUninstallState.test.ts
@@ -1,0 +1,213 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PgDialect } from 'drizzle-orm/pg-core';
+
+// Real drizzle-orm + real schema (deliberately NOT mocked), mirroring
+// `deviceUninstallDrain.test.ts`: the security-relevant part of this read is
+// its WHERE clause — a row that does NOT carry the `device_remove` reason
+// belongs to tenant offboarding or abuse suspension, and reporting it as
+// "this device's Remove" would tell an operator the wrong story about why
+// their endpoint is being torn down. That clause is asserted on COMPILED SQL
+// (`new PgDialect().sqlToQuery(...)`) rather than via
+// `expect(where).toHaveBeenCalled()`, which would pass identically whether the
+// code wrote `eq()`, `ne()`, or the wrong column.
+
+const selectMock = vi.fn();
+
+vi.mock('../db', () => ({
+  db: {
+    select: (...args: unknown[]) => selectMock(...args),
+  },
+}));
+
+import { UNINSTALL_REASON_DEVICE_REMOVE } from './deviceUninstallDrain';
+import { getDeviceUninstallStatus } from './deviceUninstallState';
+
+const dialect = new PgDialect();
+
+const DEVICE_ID = '11111111-1111-4111-8111-111111111111';
+const QUEUED_AT = new Date('2026-09-05T10:00:00.000Z');
+const EXPIRES_AT = new Date('2026-09-08T10:00:00.000Z');
+
+/** The shape `getDeviceUninstallStatus`'s SELECT projects, at its most boring:
+ * a freshly queued, never-dispatched device-remove uninstall. */
+const BASE_ROW = {
+  status: 'pending',
+  createdAt: QUEUED_AT,
+  executedAt: null as Date | null,
+  completedAt: null as Date | null,
+  result: null as unknown,
+  expiresAt: EXPIRES_AT as Date | null,
+};
+
+/**
+ * Chainable `.from()/.where()/.orderBy()/.limit()` surface where every link is
+ * both awaitable (resolves to `rows`) AND continues the chain — same helper
+ * shape as `deviceUninstallDrain.test.ts`'s `rigSelect`. Captures the condition
+ * handed to `.where()` so it can be compiled and asserted.
+ */
+function rigSelect(rows: unknown[]): { where: () => unknown; orderBy: () => unknown } {
+  const captured: { where?: unknown; orderBy?: unknown } = {};
+  const chain: Record<string, any> = {};
+  for (const method of ['from', 'limit']) {
+    chain[method] = vi.fn(() => Object.assign(Promise.resolve(rows), chain));
+  }
+  chain.where = vi.fn((cond: unknown) => {
+    captured.where = cond;
+    return Object.assign(Promise.resolve(rows), chain);
+  });
+  chain.orderBy = vi.fn((cond: unknown) => {
+    captured.orderBy = cond;
+    return Object.assign(Promise.resolve(rows), chain);
+  });
+  selectMock.mockReturnValueOnce(Object.assign(Promise.resolve(rows), chain));
+  return { where: () => captured.where, orderBy: () => captured.orderBy };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('getDeviceUninstallStatus — the query', () => {
+  it('compiles a 3-way CONJUNCTION requiring the device, self_uninstall, and the device_remove reason', async () => {
+    const rig = rigSelect([]);
+
+    await getDeviceUninstallStatus(DEVICE_ID);
+
+    const built = dialect.sqlToQuery(rig.where() as never);
+    const sqlText = built.sql.toLowerCase();
+
+    // AND, not OR. `or(a, b, c)` would contain every clause below as a
+    // substring too, and would make an abuse-queued self_uninstall on some
+    // OTHER device satisfy the predicate on its `type` clause alone.
+    expect(sqlText).not.toContain(' or ');
+    expect(sqlText.split(' and ')).toHaveLength(3);
+
+    expect(built.params).toContain(DEVICE_ID);
+    expect(built.params).toContain('self_uninstall');
+    // THE provenance guard: uninstall_reasons @> ARRAY['device_remove'] — the
+    // clause that keeps a tenant-offboarding or abuse-suspension uninstall
+    // from being reported as this device's Remove.
+    expect(sqlText).toContain('"uninstall_reasons" @> $');
+    // Bound as a Postgres array literal; assert the value is actually bound
+    // rather than depending on the exact literal formatting.
+    expect(
+      built.params.some(
+        (p) => typeof p === 'string' && p.includes(UNINSTALL_REASON_DEVICE_REMOVE),
+      ),
+    ).toBe(true);
+  });
+
+  it('orders newest-first so a restore-then-remove cycle reports the CURRENT uninstall', async () => {
+    const rig = rigSelect([]);
+
+    await getDeviceUninstallStatus(DEVICE_ID);
+
+    const built = dialect.sqlToQuery(rig.orderBy() as never);
+    expect(built.sql.toLowerCase()).toContain('"created_at" desc');
+  });
+});
+
+describe('getDeviceUninstallStatus — state mapping', () => {
+  it('maps a queued row to pending and surfaces the drain deadline', async () => {
+    rigSelect([{ ...BASE_ROW }]);
+
+    const status = await getDeviceUninstallStatus(DEVICE_ID);
+
+    expect(status).toEqual({
+      state: 'pending',
+      queuedAt: '2026-09-05T10:00:00.000Z',
+      sentAt: null,
+      completedAt: null,
+      expiresAt: '2026-09-08T10:00:00.000Z',
+    });
+  });
+
+  it('maps a dispatched row to sent and reports when it was handed over', async () => {
+    const executedAt = new Date('2026-09-05T11:30:00.000Z');
+    rigSelect([{ ...BASE_ROW, status: 'sent', executedAt }]);
+
+    const status = await getDeviceUninstallStatus(DEVICE_ID);
+
+    expect(status?.state).toBe('sent');
+    expect(status?.sentAt).toBe('2026-09-05T11:30:00.000Z');
+  });
+
+  it('maps a reaper timeout (failed + result.status=timeout) to expired', async () => {
+    // staleCommandReaper.ts writes exactly this shape when the drain window
+    // runs out: status 'failed', result.status 'timeout'. "Failed" would tell
+    // the operator the agent tried and could not; "expired" tells them the
+    // agent never checked in at all, which is the actionable difference.
+    rigSelect([{
+      ...BASE_ROW,
+      status: 'failed',
+      completedAt: new Date('2026-09-08T10:05:00.000Z'),
+      result: { status: 'timeout', error: 'Command expired', timedOutBy: 'server' },
+    }]);
+
+    const status = await getDeviceUninstallStatus(DEVICE_ID);
+
+    expect(status?.state).toBe('expired');
+    expect(status?.completedAt).toBe('2026-09-08T10:05:00.000Z');
+  });
+
+  it('maps a failure that is NOT a timeout to failed', async () => {
+    rigSelect([{
+      ...BASE_ROW,
+      status: 'failed',
+      result: { status: 'error', error: 'uninstaller exited 1' },
+    }]);
+
+    expect((await getDeviceUninstallStatus(DEVICE_ID))?.state).toBe('failed');
+  });
+
+  it('maps a failure with no result payload at all to failed, not expired', async () => {
+    rigSelect([{ ...BASE_ROW, status: 'failed', result: null }]);
+
+    expect((await getDeviceUninstallStatus(DEVICE_ID))?.state).toBe('failed');
+  });
+
+  it('maps a cancelled row to cancelled', async () => {
+    rigSelect([{
+      ...BASE_ROW,
+      status: 'cancelled',
+      completedAt: new Date('2026-09-05T12:00:00.000Z'),
+    }]);
+
+    expect((await getDeviceUninstallStatus(DEVICE_ID))?.state).toBe('cancelled');
+  });
+
+  it('maps a completed row to completed', async () => {
+    rigSelect([{
+      ...BASE_ROW,
+      status: 'completed',
+      executedAt: new Date('2026-09-05T11:00:00.000Z'),
+      completedAt: new Date('2026-09-05T11:00:30.000Z'),
+    }]);
+
+    const status = await getDeviceUninstallStatus(DEVICE_ID);
+    expect(status?.state).toBe('completed');
+    expect(status?.completedAt).toBe('2026-09-05T11:00:30.000Z');
+  });
+
+  it('falls back to failed for an unrecognised command status rather than leaking it verbatim', async () => {
+    // `device_commands.status` is a plain varchar, so a future writer can put
+    // anything in it. The union type must stay closed: an unknown value is
+    // reported as `failed` (the conservative "do not claim it came off"
+    // reading), never passed through where the web would render a raw key.
+    rigSelect([{ ...BASE_ROW, status: 'queued_somewhere_new' }]);
+
+    expect((await getDeviceUninstallStatus(DEVICE_ID))?.state).toBe('failed');
+  });
+
+  it('tolerates a row with no drain deadline (a merged pre-provenance row)', async () => {
+    rigSelect([{ ...BASE_ROW, expiresAt: null }]);
+
+    expect((await getDeviceUninstallStatus(DEVICE_ID))?.expiresAt).toBeNull();
+  });
+
+  it('returns null when the device has no device_remove uninstall at all', async () => {
+    rigSelect([]);
+
+    expect(await getDeviceUninstallStatus(DEVICE_ID)).toBeNull();
+  });
+});

--- a/apps/api/src/services/deviceUninstallState.ts
+++ b/apps/api/src/services/deviceUninstallState.ts
@@ -1,0 +1,121 @@
+/**
+ * Read-side companion to `deviceUninstallDrain.ts` (#3987 item 7).
+ *
+ * A Remove with "uninstall the agent" queues a durable `self_uninstall`
+ * `device_commands` row and then disconnects the socket; whether the endpoint
+ * actually came off is decided minutes-to-days later, by an agent that may be
+ * powered down. Until this module existed, the console had no answer at all to
+ * "did the agent actually go away?" — the device just sat there as Removed.
+ *
+ * Two things this deliberately does NOT do:
+ *
+ *  - It does not authorise anything. `device_commands` is intentionally
+ *    system-scoped (no RLS — the agent WS path writes it), so a caller that
+ *    passed a device id straight from the request into here would read a row
+ *    for ANY device in the fleet. Every caller MUST have already run
+ *    `getDeviceWithOrgAndSiteCheck` (or an equivalent chokepoint) on the id.
+ *
+ *  - It does not report bare presence of a pending `self_uninstall`. Tenant
+ *    offboarding and abuse suspension queue their own rows against the same
+ *    device (see `deviceUninstallDrain.ts`'s module doc for the incident that
+ *    predicate shape caused), and neither is "this device's Remove". Only a
+ *    row carrying the explicit `device_remove` reason is reported here — the
+ *    same provenance stamp the drain exemption is keyed on.
+ */
+
+import { and, arrayContains, desc, eq } from 'drizzle-orm';
+import { db } from '../db';
+import { deviceCommands } from '../db/schema';
+import { UNINSTALL_REASON_DEVICE_REMOVE } from './deviceUninstallDrain';
+
+export type DeviceUninstallState =
+  | 'pending'
+  | 'sent'
+  | 'completed'
+  | 'expired'
+  | 'failed'
+  | 'cancelled';
+
+export interface DeviceUninstallStatus {
+  /**
+   * NOTE on `sent`: it means the command was dispatched and acked by the
+   * agent's command handler, NOT that the uninstall is confirmed torn down
+   * (`core.ts`'s restore doc makes the same point about `alreadyDispatched`).
+   * The web copy for this state says "delivered" for exactly that reason —
+   * never "uninstalled". `completed` is the only state that claims teardown.
+   */
+  state: DeviceUninstallState;
+  /** When the Remove queued it. ISO. */
+  queuedAt: string;
+  /** `executed_at` — when the agent was handed the command. */
+  sentAt: string | null;
+  completedAt: string | null;
+  /** `device_remove_expires_at` — the end of the drain window, after which the
+   * reaper expires the command and the agent can never collect it. */
+  expiresAt: string | null;
+}
+
+/**
+ * The newest `self_uninstall` row for `deviceId` carrying the `device_remove`
+ * reason, mapped to a state the console can render — or `null` when this
+ * device's Remove never queued one (the "leave the agent installed" choice).
+ *
+ * Newest-first because a restore-then-remove cycle legitimately leaves an
+ * older cancelled row behind; the operator is asking about the CURRENT
+ * uninstall, not the one they cancelled last week.
+ *
+ * **The caller MUST have authorised `deviceId` already** — see the module doc.
+ */
+export async function getDeviceUninstallStatus(
+  deviceId: string,
+): Promise<DeviceUninstallStatus | null> {
+  const [row] = await db
+    .select({
+      status: deviceCommands.status,
+      createdAt: deviceCommands.createdAt,
+      executedAt: deviceCommands.executedAt,
+      completedAt: deviceCommands.completedAt,
+      result: deviceCommands.result,
+      expiresAt: deviceCommands.deviceRemoveExpiresAt,
+    })
+    .from(deviceCommands)
+    .where(
+      and(
+        eq(deviceCommands.deviceId, deviceId),
+        eq(deviceCommands.type, 'self_uninstall'),
+        arrayContains(deviceCommands.uninstallReasons, [UNINSTALL_REASON_DEVICE_REMOVE]),
+      ),
+    )
+    .orderBy(desc(deviceCommands.createdAt))
+    .limit(1);
+
+  if (!row) return null;
+
+  // `staleCommandReaper.ts` lands a drain-window expiry as status 'failed'
+  // with `result.status = 'timeout'`. Surfacing that as a plain failure would
+  // read as "the uninstaller ran and errored"; it is the opposite — the agent
+  // never came back at all, so the endpoint is very likely still installed.
+  const timedOut =
+    row.status === 'failed' && (row.result as { status?: string } | null)?.status === 'timeout';
+
+  // `device_commands.status` is an unconstrained varchar, so the union stays
+  // closed here: anything unrecognised degrades to `failed` (the reading that
+  // does NOT claim the agent came off) rather than being passed through to a
+  // UI that would render it as a missing translation key.
+  const state: DeviceUninstallState = timedOut
+    ? 'expired'
+    : row.status === 'pending'
+      || row.status === 'sent'
+      || row.status === 'completed'
+      || row.status === 'cancelled'
+      ? row.status
+      : 'failed';
+
+  return {
+    state,
+    queuedAt: row.createdAt.toISOString(),
+    sentAt: row.executedAt?.toISOString() ?? null,
+    completedAt: row.completedAt?.toISOString() ?? null,
+    expiresAt: row.expiresAt?.toISOString() ?? null,
+  };
+}

--- a/apps/web/src/components/devices/DeviceDetails.tsx
+++ b/apps/web/src/components/devices/DeviceDetails.tsx
@@ -38,6 +38,7 @@ import { formatUptime } from "../../lib/utils";
 import type { Device, DeviceStatus } from "./DeviceList";
 import { formatDeviceSummaryOs } from "./osDisplay";
 import RebootScheduledBadge from "./RebootScheduledBadge";
+import UninstallStateBadge from "./UninstallStateBadge";
 import DeviceActions from "./DeviceActions";
 import DeviceInfoTab from "./DeviceInfoTab";
 import DeviceHardwareInventory from "./DeviceHardwareInventory";
@@ -606,6 +607,13 @@ export default function DeviceDetails({
                 >
                   {statusLabels[device.status]}
                 </span>
+                {/* "Removed" says the record was offboarded; this says what
+                    happened to the agent on the actual machine (#3987).
+                    Renders nothing for any device that is not removed. */}
+                <UninstallStateBadge
+                  uninstall={device.uninstall}
+                  status={device.status}
+                />
                 {device.pendingReboot && (
                   <span
                     data-testid="device-pending-reboot-badge"

--- a/apps/web/src/components/devices/DeviceList.tsx
+++ b/apps/web/src/components/devices/DeviceList.tsx
@@ -204,6 +204,28 @@ export type Device = {
    * device page.
    */
   possibleReplacementOfDeviceId?: string | null;
+  /**
+   * What became of the agent-uninstall this device's Remove queued (#3987).
+   *
+   * Present ONLY on the `GET /devices/:id` detail payload, and only ever
+   * non-null for a `decommissioned` device. The three-way distinction is
+   * load-bearing for `UninstallStateBadge`:
+   *
+   *   undefined → this payload does not carry the field (a list row) — say
+   *               nothing, because we do not know.
+   *   null      → the Remove deliberately left the agent installed.
+   *   object    → an uninstall was queued; `state` says how far it got.
+   *
+   * `state: 'sent'` means the agent's handler acked the command, NOT that the
+   * teardown is confirmed — only `'completed'` claims that.
+   */
+  uninstall?: {
+    state: string;
+    queuedAt?: string | null;
+    sentAt: string | null;
+    completedAt?: string | null;
+    expiresAt: string | null;
+  } | null;
   desktopAccess?: DesktopAccessState | null;
   remoteAccessPolicy?: RemoteAccessPolicy | null;
   /**

--- a/apps/web/src/components/devices/DeviceSettingsModal.tsx
+++ b/apps/web/src/components/devices/DeviceSettingsModal.tsx
@@ -6,6 +6,7 @@ import { Dialog } from '../shared/Dialog';
 import { fetchWithAuth } from '../../stores/auth';
 import { extractApiError } from '@/lib/apiError';
 import { asList } from '@/lib/asList';
+import UninstallStateBadge from './UninstallStateBadge';
 
 type Site = {
   id: string;
@@ -212,6 +213,10 @@ export default function DeviceSettingsModal({ device, isOpen, onClose, onSaved, 
               <p className="text-xs text-muted-foreground">
                 {t('deviceSettingsModal.decommissionedDescription')}
               </p>
+              {/* Whether the agent actually came off (#3987). Renders nothing
+                  when the modal was opened from a list row, whose payload
+                  carries no `uninstall` field — see UninstallStateBadge. */}
+              <UninstallStateBadge uninstall={device.uninstall} status={device.status} compact />
               <div className="flex gap-2">
                 <button
                   type="button"

--- a/apps/web/src/components/devices/UninstallStateBadge.test.tsx
+++ b/apps/web/src/components/devices/UninstallStateBadge.test.tsx
@@ -1,0 +1,153 @@
+import "@/lib/i18n";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import UninstallStateBadge from "./UninstallStateBadge";
+import type { Device } from "./DeviceList";
+
+// #3987 item 7 — what happened to the agent-uninstall a Remove queued.
+
+const NOW = new Date("2026-09-05T12:00:00.000Z");
+const EXPIRES = "2026-09-08T12:00:00.000Z"; // exactly 3 days out
+
+function renderBadge(
+  uninstall: Device["uninstall"],
+  overrides: { status?: string; compact?: boolean } = {},
+) {
+  return render(
+    <UninstallStateBadge
+      uninstall={uninstall}
+      status={overrides.status ?? "decommissioned"}
+      compact={overrides.compact}
+      now={NOW}
+    />,
+  );
+}
+
+const base = {
+  queuedAt: "2026-09-05T10:00:00.000Z",
+  sentAt: null,
+  completedAt: null,
+  expiresAt: null,
+};
+
+describe("UninstallStateBadge", () => {
+  it("reports a queued uninstall with its deadline", () => {
+    renderBadge({ ...base, state: "pending", expiresAt: EXPIRES });
+
+    const badge = screen.getByTestId("uninstall-state");
+    expect(badge).toHaveAttribute("data-state", "pending");
+    expect(badge).toHaveTextContent("queued");
+    // The deadline is what makes this actionable — "queued" alone does not
+    // tell a tech whether to wait or to go touch the machine.
+    expect(badge).toHaveTextContent("in 3 days");
+  });
+
+  it("falls back to deadline-free copy when the row carries no expiry", () => {
+    renderBadge({ ...base, state: "pending", expiresAt: null });
+
+    const badge = screen.getByTestId("uninstall-state");
+    expect(badge).toHaveAttribute("data-state", "pending");
+    expect(badge).toHaveTextContent("queued");
+    expect(badge).not.toHaveTextContent("in ");
+  });
+
+  it("falls back to deadline-free copy when the deadline has already passed", () => {
+    // The reaper has not swept it yet, but "expires in -2 hours" is nonsense
+    // and "expires now" would be a lie about a window that is already shut.
+    renderBadge({ ...base, state: "pending", expiresAt: "2026-09-05T10:00:00.000Z" });
+
+    const badge = screen.getByTestId("uninstall-state");
+    expect(badge).toHaveTextContent("queued");
+    expect(badge).not.toHaveTextContent("in ");
+  });
+
+  it("says delivered — never uninstalled — for a dispatched command", () => {
+    // `sent` means the agent's handler acked the command, NOT that the
+    // teardown finished. Claiming "uninstalled" here would tell an operator
+    // the endpoint is clean when it may not be (see #3995).
+    renderBadge({ ...base, state: "sent", sentAt: "2026-09-05T11:00:00.000Z" });
+
+    const badge = screen.getByTestId("uninstall-state");
+    expect(badge).toHaveAttribute("data-state", "sent");
+    expect(badge).toHaveTextContent("delivered");
+    expect(badge.textContent?.toLowerCase()).not.toContain("uninstalled");
+  });
+
+  it("claims teardown only for a completed command", () => {
+    renderBadge({ ...base, state: "completed", completedAt: "2026-09-05T11:00:30.000Z" });
+
+    const badge = screen.getByTestId("uninstall-state");
+    expect(badge).toHaveAttribute("data-state", "completed");
+    expect(badge).toHaveTextContent("Agent uninstalled");
+  });
+
+  it("warns that an expired uninstall may still be installed", () => {
+    renderBadge({ ...base, state: "expired" });
+
+    const badge = screen.getByTestId("uninstall-state");
+    expect(badge).toHaveAttribute("data-state", "expired");
+    expect(badge).toHaveTextContent("expired");
+    expect(badge).toHaveTextContent("still be installed");
+    // Tone carries the warning as much as the words do.
+    expect(badge.className).toContain("warning");
+  });
+
+  it("renders the failed state", () => {
+    renderBadge({ ...base, state: "failed" });
+
+    const badge = screen.getByTestId("uninstall-state");
+    expect(badge).toHaveAttribute("data-state", "failed");
+    expect(badge).toHaveTextContent("failed");
+    expect(badge.className).toContain("warning");
+  });
+
+  it("renders the cancelled state", () => {
+    renderBadge({ ...base, state: "cancelled" });
+
+    const badge = screen.getByTestId("uninstall-state");
+    expect(badge).toHaveAttribute("data-state", "cancelled");
+    expect(badge).toHaveTextContent("cancelled");
+  });
+
+  it("says the agent was left installed when the Remove queued nothing", () => {
+    renderBadge(null);
+
+    const badge = screen.getByTestId("uninstall-state");
+    expect(badge).toHaveAttribute("data-state", "none");
+    expect(badge).toHaveTextContent("left installed");
+  });
+
+  it("renders nothing when the field is absent (a list row, not the detail payload)", () => {
+    // `uninstall` only rides on GET /devices/:id. A list row has no such
+    // field, and rendering "Agent was left installed" there would be an
+    // outright false claim about every removed device on the page — hence
+    // undefined and null must NOT collapse to the same branch.
+    renderBadge(undefined);
+
+    expect(screen.queryByTestId("uninstall-state")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing for a device that is not removed", () => {
+    renderBadge({ ...base, state: "pending", expiresAt: EXPIRES }, { status: "online" });
+
+    expect(screen.queryByTestId("uninstall-state")).not.toBeInTheDocument();
+  });
+
+  it("drops the pill chrome in compact mode but keeps the state readable", () => {
+    renderBadge({ ...base, state: "expired" }, { compact: true });
+
+    const badge = screen.getByTestId("uninstall-state");
+    expect(badge).toHaveAttribute("data-state", "expired");
+    expect(badge).toHaveTextContent("still be installed");
+    expect(badge.className).not.toContain("rounded-full");
+  });
+
+  it("ignores an unrecognised state rather than rendering a raw translation key", () => {
+    // Defense in depth: the API closes this union already, but a stale client
+    // against a newer server must not paint "uninstallState.somethingNew"
+    // across the device header.
+    renderBadge({ ...base, state: "something-new" } as Device["uninstall"]);
+
+    expect(screen.queryByTestId("uninstall-state")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/devices/UninstallStateBadge.tsx
+++ b/apps/web/src/components/devices/UninstallStateBadge.tsx
@@ -1,0 +1,138 @@
+import { useTranslation } from "react-i18next";
+import { formatTimeUntil } from "@/lib/formatTime";
+import type { Device } from "./DeviceList";
+
+/**
+ * What became of the agent-uninstall a Remove queued (#3987 item 7).
+ *
+ * Removing a device with "uninstall the Breeze agent" queues a durable command
+ * and then drops the socket; whether the endpoint actually came off is settled
+ * later, by a machine that may be powered down for a week. This is the only
+ * place the console answers "did the agent go away?".
+ *
+ * Three input states, and they are NOT interchangeable:
+ *
+ *   `undefined` → the payload does not carry the field (a device-list row).
+ *                 Render nothing: we do not know, and guessing "left
+ *                 installed" would be a false claim on every removed row.
+ *   `null`      → the detail payload says this Remove queued no uninstall.
+ *   an object   → an uninstall exists; `state` says how far it got.
+ */
+
+type Tone = "info" | "success" | "warning" | "muted";
+
+export interface UninstallStateBadgeProps {
+  uninstall: Device["uninstall"];
+  /** The device's status — the badge is only meaningful on a removed device. */
+  status: string;
+  /** Inline text instead of a pill, for the Removed panel in the settings modal. */
+  compact?: boolean;
+  /** Injectable for tests; defaults to the wall clock. */
+  now?: Date;
+}
+
+const PILL_TONE: Record<Tone, string> = {
+  info: "bg-info/15 text-info border-info/30",
+  success: "bg-success/15 text-success border-success/30",
+  warning: "bg-warning/15 text-warning border-warning/30",
+  muted: "bg-muted text-muted-foreground border-border",
+};
+
+const COMPACT_TONE: Record<Tone, string> = {
+  info: "text-info",
+  success: "text-success",
+  warning: "text-warning",
+  muted: "text-muted-foreground",
+};
+
+export default function UninstallStateBadge({
+  uninstall,
+  status,
+  compact,
+  now,
+}: UninstallStateBadgeProps) {
+  const { t } = useTranslation("devices");
+
+  if (status !== "decommissioned") return null;
+  // `undefined` (field absent) and `null` (explicitly no uninstall) are
+  // different answers — see the component doc.
+  if (uninstall === undefined) return null;
+
+  let label: string;
+  let tone: Tone;
+  let state: string;
+
+  if (uninstall === null) {
+    state = "none";
+    tone = "muted";
+    label = t("uninstallState.none");
+  } else {
+    state = uninstall.state;
+    // An explicit switch, not `t(\`uninstallState.${state}\`)`: the value comes
+    // off the wire, so a stale client against a newer server must land
+    // somewhere sane rather than painting a raw translation key across the
+    // device header — and keyUsage.test.ts can only verify literal keys.
+    switch (uninstall.state) {
+      case "pending": {
+        tone = "info";
+        // The deadline is what makes this actionable: it tells a tech whether
+        // to wait for the machine to come back or to go touch it. Null (and a
+        // deadline already in the past) fall back to deadline-free copy rather
+        // than printing a nonsensical or already-shut window.
+        const when = uninstall.expiresAt
+          ? formatTimeUntil(uninstall.expiresAt, now)
+          : null;
+        label = when
+          ? t("uninstallState.pending", { when })
+          : t("uninstallState.pendingNoDeadline");
+        break;
+      }
+      case "sent":
+        tone = "info";
+        // "delivered", never "uninstalled": `sent` means the agent's command
+        // handler acked it, not that the teardown finished (#3995).
+        label = t("uninstallState.sent");
+        break;
+      case "completed":
+        tone = "success";
+        label = t("uninstallState.completed");
+        break;
+      case "expired":
+        tone = "warning";
+        label = t("uninstallState.expired");
+        break;
+      case "failed":
+        tone = "warning";
+        label = t("uninstallState.failed");
+        break;
+      case "cancelled":
+        tone = "muted";
+        label = t("uninstallState.cancelled");
+        break;
+      default:
+        return null;
+    }
+  }
+
+  if (compact) {
+    return (
+      <p
+        data-testid="uninstall-state"
+        data-state={state}
+        className={`text-xs ${COMPACT_TONE[tone]}`}
+      >
+        {label}
+      </p>
+    );
+  }
+
+  return (
+    <span
+      data-testid="uninstall-state"
+      data-state={state}
+      className={`inline-flex shrink-0 items-center rounded-full border px-2.5 py-1 text-xs font-medium ${PILL_TONE[tone]}`}
+    >
+      {label}
+    </span>
+  );
+}

--- a/apps/web/src/lib/formatTime.test.ts
+++ b/apps/web/src/lib/formatTime.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { i18n, loadLocale } from './i18n';
-import { formatTimeAgo } from './formatTime';
+import { formatTimeAgo, formatTimeUntil } from './formatTime';
 
 describe('formatTimeAgo', () => {
   beforeEach(() => {
@@ -25,5 +25,40 @@ describe('formatTimeAgo', () => {
 describe('formatTimeAgo invalid input', () => {
   it('returns a placeholder instead of throwing on an unparseable timestamp', () => {
     expect(formatTimeAgo('not-a-date')).toBe('—');
+  });
+});
+
+describe('formatTimeUntil', () => {
+  const NOW = new Date('2026-09-05T12:00:00Z');
+
+  it('counts forward in days, hours and minutes', () => {
+    expect(formatTimeUntil('2026-09-08T12:00:00Z', NOW)).toBe('in 3 days');
+    expect(formatTimeUntil('2026-09-05T17:00:00Z', NOW)).toBe('in 5 hours');
+    expect(formatTimeUntil('2026-09-05T12:20:00Z', NOW)).toBe('in 20 minutes');
+  });
+
+  it('floors at a minute rather than saying "now" about a window still open', () => {
+    expect(formatTimeUntil('2026-09-05T12:00:10Z', NOW)).toBe('in 1 minute');
+  });
+
+  it('returns null once the instant has passed, so callers can drop the deadline', () => {
+    expect(formatTimeUntil('2026-09-05T11:59:00Z', NOW)).toBeNull();
+    expect(formatTimeUntil('2026-09-05T12:00:00Z', NOW)).toBeNull();
+  });
+
+  it('returns null on an unparseable timestamp instead of throwing', () => {
+    // Intl.RelativeTimeFormat.format(NaN) throws — a bad stamp must not take
+    // the device page down.
+    expect(formatTimeUntil('not-a-date', NOW)).toBeNull();
+  });
+
+  it('formats in the active locale', async () => {
+    await loadLocale('pt-BR');
+    await i18n.changeLanguage('pt-BR');
+    try {
+      expect(formatTimeUntil('2026-09-08T12:00:00Z', NOW)).toBe('em 3 dias');
+    } finally {
+      await i18n.changeLanguage('en');
+    }
   });
 });

--- a/apps/web/src/lib/formatTime.ts
+++ b/apps/web/src/lib/formatTime.ts
@@ -23,6 +23,43 @@ export function formatTimeAgo(dateString: string): string {
   return formatter.format(-diffDays, 'day');
 }
 
+/**
+ * Forward-looking sibling of `formatTimeAgo`: "in 3 days", "in 5 hours".
+ *
+ * Deadlines are the one place the console looks FORWARD, and neither existing
+ * helper can express that — `formatTimeAgo` computes `now - date`, so a future
+ * instant collapses to "now", and `formatRelativeTime` in `lib/utils.ts` is
+ * past-only with hardcoded English strings. `Intl.RelativeTimeFormat` handles
+ * the direction and the locale here, same as `formatTimeAgo`.
+ *
+ * Returns `null` — not a formatted string — for an unparseable stamp or an
+ * instant that has already passed, so callers fall back to deadline-free copy
+ * instead of printing "in 0 minutes" about a window that is already shut.
+ *
+ * `now` is injectable so tests can pin the clock without fake timers.
+ */
+export function formatTimeUntil(dateString: string, now?: Date): string | null {
+  const date = new Date(dateString);
+  if (Number.isNaN(date.getTime())) return null;
+
+  const diffMs = date.getTime() - (now ?? new Date()).getTime();
+  if (diffMs <= 0) return null;
+
+  const diffMins = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMs / 3600000);
+  const diffDays = Math.floor(diffMs / 86400000);
+
+  const formatter = new Intl.RelativeTimeFormat(resolvedFormattingLocale(), {
+    numeric: 'always',
+  });
+  // Floor at one minute rather than falling through to a "now" phrasing: the
+  // window is still open, and saying "now" about an open deadline reads as
+  // "too late".
+  if (diffHours < 1) return formatter.format(Math.max(diffMins, 1), 'minute');
+  if (diffDays < 1) return formatter.format(diffHours, 'hour');
+  return formatter.format(diffDays, 'day');
+}
+
 /** Compact "last seen" format for tables: 5m ago, 3h ago, 2d ago, then absolute date */
 export function formatLastSeen(dateString: string, timezone?: string): string {
   const date = new Date(dateString);

--- a/apps/web/src/locales/de-DE/devices.json
+++ b/apps/web/src/locales/de-DE/devices.json
@@ -2382,5 +2382,15 @@
     "colDetectedVersion": "Erkannte Version",
     "colScannedAt": "Letzter Scan",
     "loadMore": "Mehr laden"
+  },
+  "uninstallState": {
+    "pending": "Agent-Deinstallation in Warteschlange — läuft {{when}} ab",
+    "pendingNoDeadline": "Agent-Deinstallation in Warteschlange",
+    "sent": "Agent-Deinstallation zugestellt",
+    "completed": "Agent deinstalliert",
+    "expired": "Deinstallation abgelaufen — der Agent hat sich nie gemeldet und ist möglicherweise noch installiert",
+    "failed": "Agent-Deinstallation fehlgeschlagen",
+    "cancelled": "Agent-Deinstallation abgebrochen",
+    "none": "Agent wurde installiert gelassen"
   }
 }

--- a/apps/web/src/locales/en/devices.json
+++ b/apps/web/src/locales/en/devices.json
@@ -2382,5 +2382,15 @@
     "colDetectedVersion": "Detected version",
     "colScannedAt": "Last scan",
     "loadMore": "Load more"
+  },
+  "uninstallState": {
+    "pending": "Agent uninstall queued — expires {{when}}",
+    "pendingNoDeadline": "Agent uninstall queued",
+    "sent": "Agent uninstall delivered",
+    "completed": "Agent uninstalled",
+    "expired": "Uninstall expired — the agent never checked in and may still be installed",
+    "failed": "Agent uninstall failed",
+    "cancelled": "Agent uninstall cancelled",
+    "none": "Agent was left installed"
   }
 }

--- a/apps/web/src/locales/es-419/devices.json
+++ b/apps/web/src/locales/es-419/devices.json
@@ -2382,5 +2382,15 @@
     "colDetectedVersion": "Versión detectada",
     "colScannedAt": "Último escaneo",
     "loadMore": "Cargar más"
+  },
+  "uninstallState": {
+    "pending": "Desinstalación del agente en cola — vence {{when}}",
+    "pendingNoDeadline": "Desinstalación del agente en cola",
+    "sent": "Desinstalación del agente entregada",
+    "completed": "Agente desinstalado",
+    "expired": "La desinstalación venció — el agente nunca se conectó y puede seguir instalado",
+    "failed": "Error en la desinstalación del agente",
+    "cancelled": "Desinstalación del agente cancelada",
+    "none": "El agente se dejó instalado"
   }
 }

--- a/apps/web/src/locales/fr-CA/devices.json
+++ b/apps/web/src/locales/fr-CA/devices.json
@@ -2382,5 +2382,15 @@
     "colDetectedVersion": "Version détectée",
     "colScannedAt": "Dernière analyse",
     "loadMore": "Charger plus"
+  },
+  "uninstallState": {
+    "pending": "Désinstallation de l'agent en file d'attente — expire {{when}}",
+    "pendingNoDeadline": "Désinstallation de l'agent en file d'attente",
+    "sent": "Désinstallation de l'agent livrée",
+    "completed": "Agent désinstallé",
+    "expired": "Désinstallation expirée — l'agent ne s'est jamais connecté et pourrait être encore installé",
+    "failed": "Échec de la désinstallation de l'agent",
+    "cancelled": "Désinstallation de l'agent annulée",
+    "none": "L'agent a été laissé installé"
   }
 }

--- a/apps/web/src/locales/fr-FR/devices.json
+++ b/apps/web/src/locales/fr-FR/devices.json
@@ -2382,5 +2382,15 @@
     "colDetectedVersion": "Version détectée",
     "colScannedAt": "Dernière analyse",
     "loadMore": "Charger plus"
+  },
+  "uninstallState": {
+    "pending": "Désinstallation de l'agent en file d'attente — expire {{when}}",
+    "pendingNoDeadline": "Désinstallation de l'agent en file d'attente",
+    "sent": "Désinstallation de l'agent transmise",
+    "completed": "Agent désinstallé",
+    "expired": "Désinstallation expirée — l'agent ne s'est jamais connecté et pourrait être encore installé",
+    "failed": "Échec de la désinstallation de l'agent",
+    "cancelled": "Désinstallation de l'agent annulée",
+    "none": "L'agent a été laissé installé"
   }
 }

--- a/apps/web/src/locales/it-IT/devices.json
+++ b/apps/web/src/locales/it-IT/devices.json
@@ -2382,5 +2382,15 @@
     "colDetectedVersion": "Versione rilevata",
     "colScannedAt": "Ultima scansione",
     "loadMore": "Carica altro"
+  },
+  "uninstallState": {
+    "pending": "Disinstallazione dell'agent in coda — scade {{when}}",
+    "pendingNoDeadline": "Disinstallazione dell'agent in coda",
+    "sent": "Disinstallazione dell'agent consegnata",
+    "completed": "Agent disinstallato",
+    "expired": "Disinstallazione scaduta — l'agent non si è mai collegato e potrebbe essere ancora installato",
+    "failed": "Disinstallazione dell'agent non riuscita",
+    "cancelled": "Disinstallazione dell'agent annullata",
+    "none": "L'agent è stato lasciato installato"
   }
 }

--- a/apps/web/src/locales/pt-BR/devices.json
+++ b/apps/web/src/locales/pt-BR/devices.json
@@ -2382,5 +2382,15 @@
     "colDetectedVersion": "Versão detectada",
     "colScannedAt": "Última verificação",
     "loadMore": "Carregar mais"
+  },
+  "uninstallState": {
+    "pending": "Desinstalação do agente na fila — expira {{when}}",
+    "pendingNoDeadline": "Desinstalação do agente na fila",
+    "sent": "Desinstalação do agente entregue",
+    "completed": "Agente desinstalado",
+    "expired": "Desinstalação expirada — o agente nunca se conectou e pode continuar instalado",
+    "failed": "Falha na desinstalação do agente",
+    "cancelled": "Desinstalação do agente cancelada",
+    "none": "O agente foi deixado instalado"
   }
 }

--- a/apps/web/src/locales/tr-TR/devices.json
+++ b/apps/web/src/locales/tr-TR/devices.json
@@ -2382,5 +2382,15 @@
     "colDetectedVersion": "Algılanan sürüm",
     "colScannedAt": "Son tarama",
     "loadMore": "Daha fazlasını yükle"
+  },
+  "uninstallState": {
+    "pending": "Aracı kaldırma sıraya alındı — {{when}} sona eriyor",
+    "pendingNoDeadline": "Aracı kaldırma sıraya alındı",
+    "sent": "Aracı kaldırma iletildi",
+    "completed": "Aracı kaldırıldı",
+    "expired": "Kaldırma süresi doldu — aracı hiç bağlanmadı ve hâlâ kurulu olabilir",
+    "failed": "Aracı kaldırma başarısız oldu",
+    "cancelled": "Aracı kaldırma iptal edildi",
+    "none": "Aracı kurulu bırakıldı"
   }
 }


### PR DESCRIPTION
Wave W03 of #5023 — the final item of #3987. A removed device now tells the operator what happened to its queued agent uninstall, so "did the agent actually come off?" has an answer on screen.

## What the API derives, and from where

`GET /devices/:id` gains `uninstall: DeviceUninstallStatus | null`, derived by the new `services/deviceUninstallState.ts` from the **newest `self_uninstall` `device_commands` row carrying the `device_remove` reason**:

| Source row | Reported state |
|---|---|
| `status = 'pending' \| 'sent' \| 'completed' \| 'cancelled'` | passed through |
| `status = 'failed'` **and** `result.status = 'timeout'` | `expired` |
| any other `failed`, and any unrecognised status | `failed` |

Plus `queuedAt` (`created_at`), `sentAt` (`executed_at`), `completedAt`, and `expiresAt` (`device_remove_expires_at` — the drain deadline).

`expired` is split out from `failed` on purpose: `staleCommandReaper.ts` writes a drain-window expiry as `failed` + `result.status='timeout'`, which is not "the uninstaller ran and errored" but "the agent never checked in at all" — the only state where the endpoint is probably *still installed* and a human needs to go touch it.

Two constraints, both pinned by tests rather than left to review:

- **The reason filter is `uninstall_reasons @> ARRAY['device_remove']`, never bare presence of a pending `self_uninstall`.** Tenant offboarding and abuse suspension queue their own rows against the same device (see `deviceUninstallDrain.ts`'s module doc for the incident that shape caused); reporting one of those as this device's Remove would tell the operator the wrong story about why their endpoint is being torn down. Asserted on **compiled SQL**, including that the predicate is a 3-way conjunction — `or(...)` would leave every `toContain` assertion green while widening the match.
- **`device_commands` carries no RLS** (intentionally system-scoped for the agent WS path), so the read sits strictly downstream of `getDeviceWithOrgAndSiteCheck`, and is skipped entirely unless `device.status === 'decommissioned'`. That also leaves the hot detail path byte-for-byte unchanged for the 99% case. `core.uninstallState.test.ts` asserts the service is *not* called on the 404 path and *not* called for a live device.

No schema change, no new table — so no RLS / cascade / export-policy registration is due.

## sent vs. completed

`sent` means the command was dispatched and acked by the agent's command handler; it does **not** mean the teardown is confirmed (the same distinction `core.ts`'s restore path draws with `alreadyDispatched`, and what #3995 is about). The copy says **"Agent uninstall delivered"** for that state and reserves **"Agent uninstalled"** for `completed`, which is the only state that claims the machine is clean. A test asserts the `sent` badge does not contain the word "uninstalled".

## Web

`UninstallStateBadge` renders beside the Removed pill on the device page, and as a line in the Removed panel of `DeviceSettingsModal` (`compact`).

Copy: `pending` → "Agent uninstall queued — expires in 3 days" · `sent` → "Agent uninstall delivered" · `completed` → "Agent uninstalled" · `expired` → "Uninstall expired — the agent never checked in and may still be installed" (warning tone) · `failed` · `cancelled` · `none` → "Agent was left installed".

**Three input states, not two.** `uninstall === undefined` means the payload does not carry the field at all (a device-list row, since `uninstall` only rides on the detail response) and the badge renders **nothing**; only an explicit `null` means "this Remove left the agent installed". Collapsing them would stamp a false claim on every removed row rendered from list data. Pinned by a test, as is the unknown-state fallback — a stale client against a newer server must not paint `uninstallState.somethingNew` across the device header, so the state→copy mapping is an explicit `switch`, never an interpolated key.

Locale keys added to **all eight** catalogs; `localeParity` and `keyUsage` both green.

## Deviations from the plan

1. **`formatRelativeTime` from `@/lib/formatTime` does not exist** — the plan flagged this to check, and the check came back empty in a load-bearing way. That module exports only `formatTimeAgo` and `formatLastSeen`, both of which compute `now - date`, so a *future* deadline collapses to "now". The one `formatRelativeTime` in the repo (`lib/utils.ts`) is past-only with hardcoded English strings ("3d ago"). Rather than inline a one-off in the badge, I added **`formatTimeUntil(dateString, now?)`** beside `formatTimeAgo`, locale-aware via `Intl.RelativeTimeFormat` (verified: `em 3 dias` under pt-BR), with its own tests in the existing `formatTime.test.ts`. This is the only file touched outside the wave's declared set.
2. **`formatTimeUntil` returns `null` for an already-passed deadline**, and the badge then falls back to `pendingNoDeadline`. The plan only specified the `expiresAt === null` fallback. A `pending` row whose deadline has passed but which the reaper has not yet swept would otherwise print "expires in 0 minutes" about a window that is already shut.
3. **`getDeviceUninstallStatus` maps an unrecognised `device_commands.status` to `failed`** rather than passing it through. `status` is an unconstrained `varchar`, and the plan's sketch would have widened the returned union past its own type. `failed` is the conservative reading — it never claims the agent came off.

**Observation, not fixed here (deliberately):** `cancelled` is currently hard to observe in practice. `releaseDeviceRemoveReason` strips `device_remove` from the row *before* cancelling it, so a Restore-cancelled row no longer matches this query — and the device is no longer `decommissioned` anyway, so the route skips the read. The `cancelled` branch is retained for co-owned rows and for any future canceller that leaves the device removed; it costs nothing and failing to handle it would be the worse error.

## Verification

All run on the merged head (`git merge origin/main` first):

| Suite | Result |
|---|---|
| `apps/api` — `src/routes/devices` + `src/services/deviceUninstallState.test.ts` | **48 files / 692 tests passed** |
| `apps/web` — `src/components/devices` + `src/lib/i18n` + `src/lib/formatTime.test.ts` | **83 files / 984 tests passed** |
| `tsc --noEmit --project apps/api/tsconfig.json` | clean (exit 0) |
| `astro check` (apps/web) | **0 errors, 0 warnings** |
| `pnpm lint` | **6/6 tasks successful** |

New tests: 12 (service, compiled-SQL + mapping) + 4 (route wiring/authorisation ordering) + 13 (badge) + 5 (`formatTimeUntil`) = **34**.

Not done: the stack walk / screenshot from the plan's Task 3 — this branch has no running stack, and the behaviour it would exercise (Remove with Uninstall while the agent is offline) is covered by the unit suites above. Flagging rather than claiming it.

Closes #5026
Closes #3987

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZAsMVZBbCxwBUtRFmrY7A
