### PR TITLE
fix(alerts): gate correlation-member move on the group, group-first lock order (#4867)

### DIFF
--- a/apps/api/src/__tests__/integration/deviceMoveOrgAlertChildren.integration.test.ts
+++ b/apps/api/src/__tests__/integration/deviceMoveOrgAlertChildren.integration.test.ts
@@ -1,0 +1,352 @@
+/**
+ * Integration test: the ALERT-axis children of a device org-move (#4867, and
+ * the post-merge review of #5005).
+ *
+ * The three tables `alert_correlation_members`, `alert_correlation_groups` and
+ * `ai_alert_verdicts` denormalize `org_id` but have NO `device_id` column, so
+ * moveOrg.ts reaches them with three hand-written raw UPDATEs. `moveOrg.test.ts`
+ * mocks `../../db` wholesale, so those statements are only ever compared as
+ * TEXT there — nothing in CI executed them until this file. Every predicate
+ * they carry (the three group hold-back guards, the member gate, the verdict's
+ * two legs) is therefore asserted here against real Postgres, through the real
+ * route, under real RLS.
+ *
+ * Proves:
+ *   (1) a correlation group whose member alerts ALL reach the target org
+ *       travels with the device — the group, every one of its member rows, its
+ *       group-level verdict and the alert-level verdict on a moved alert are
+ *       all re-stamped to the target org;
+ *   (2) a group still SPANNING two orgs afterwards (one member alert sits on a
+ *       device that did not move) is held back — and, the #5005 review's
+ *       split-brain finding, its member rows are held back WITH it. Before the
+ *       fix the member row moved unconditionally while its group stayed, and
+ *       `correlationMetadataCondition` (routes/alerts/alerts.ts) pins BOTH
+ *       org_ids, so the row was then visible to neither org;
+ *   (3) both audit rows carry the split hold-back counts.
+ *
+ * Harness mirrors deviceMoveOrgCurrency.integration.test.ts: a partner-scope
+ * environment with wildcard permissions and an MFA-bearing access token.
+ */
+import './setup';
+import { describe, expect, it } from 'vitest';
+import { Hono } from 'hono';
+import { eq, inArray } from 'drizzle-orm';
+import {
+  aiAgentRuns,
+  aiAgents,
+  aiAlertVerdicts,
+  alertCorrelationGroups,
+  alertCorrelationMembers,
+  alerts,
+  auditLogs,
+  devices,
+} from '../../db/schema';
+import { createOrganization, createSite, setupTestEnvironment } from './db-utils';
+import { getTestDb } from './setup';
+import { createAccessToken } from '../../services/jwt';
+import { moveOrgRoutes } from '../../routes/devices/moveOrg';
+
+function uid(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/**
+ * Two orgs under one partner, two devices in the source org, and two
+ * correlation groups whose fates differ:
+ *
+ *   gTravelling — members are alertA1 + alertA2, BOTH on `deviceMoved`. After
+ *     the move every member alert is in orgB, so the group travels.
+ *   gSpanning   — members are alertA4 (on `deviceMoved`) and alertB1 (on
+ *     `deviceStays`). After the move alertB1 is still in orgA, so the group is
+ *     held back — and alertA4's member row must be held back with it.
+ *
+ * Verdicts cover both legs of the verdict statement: `verdictOnAlert` is
+ * alert-level on alertA1, `verdictOnTravellingGroup` is group-level on
+ * gTravelling (alert_id NULL — the `duplicate_of_group` shape the alert leg
+ * alone can never reach), `verdictOnSpanningGroup` is group-level on the group
+ * that stays.
+ */
+async function seed() {
+  const adminDb = getTestDb() as any;
+  const unique = uid();
+
+  const env = await setupTestEnvironment({ scope: 'partner' });
+  const { partner, organization: orgA, site: siteA, user, role } = env;
+
+  const orgB = await createOrganization({ partnerId: partner.id });
+  const siteB = await createSite({ orgId: orgB.id });
+
+  const insertDevice = async (label: string) => {
+    const [row] = await adminDb.insert(devices).values({
+      orgId: orgA.id,
+      siteId: siteA.id,
+      agentId: `ac-${label}-agent-${unique}`,
+      hostname: `ac-${label}-host-${unique}`,
+      osType: 'linux',
+      osVersion: '22.04',
+      architecture: 'x86_64',
+      agentVersion: '0.0.0-test',
+      status: 'offline',
+    }).returning();
+    return row;
+  };
+  const deviceMoved = await insertDevice('moved');
+  const deviceStays = await insertDevice('stays');
+
+  const insertAlert = async (deviceId: string, title: string) => {
+    const [row] = await adminDb.insert(alerts).values({
+      orgId: orgA.id,
+      deviceId,
+      severity: 'high',
+      status: 'active',
+      title: `${title} ${unique}`,
+    }).returning();
+    return row;
+  };
+  const alertA1 = await insertAlert(deviceMoved.id, 'moved-root');
+  const alertA2 = await insertAlert(deviceMoved.id, 'moved-related');
+  const alertA4 = await insertAlert(deviceMoved.id, 'moved-spanning');
+  const alertB1 = await insertAlert(deviceStays.id, 'stays-spanning');
+
+  const insertGroup = async (rootAlertId: string) => {
+    const [row] = await adminDb.insert(alertCorrelationGroups).values({
+      orgId: orgA.id,
+      // Same shape the correlation job mints (services/alertCorrelationGroups.ts).
+      groupKey: `root:${rootAlertId}`,
+      rootAlertId,
+      status: 'open',
+      score: '0.90',
+      noiseReductionPercent: 50,
+      memberCount: 2,
+      firstSeenAt: new Date(),
+      lastSeenAt: new Date(),
+    }).returning();
+    return row;
+  };
+  const gTravelling = await insertGroup(alertA1.id);
+  const gSpanning = await insertGroup(alertA4.id);
+
+  const insertMember = async (groupId: string, alertId: string, role_: 'root' | 'related') => {
+    const [row] = await adminDb.insert(alertCorrelationMembers).values({
+      orgId: orgA.id,
+      groupId,
+      alertId,
+      role: role_,
+      confidence: '0.90',
+    }).returning();
+    return row;
+  };
+  const memberA1 = await insertMember(gTravelling.id, alertA1.id, 'root');
+  const memberA2 = await insertMember(gTravelling.id, alertA2.id, 'related');
+  const memberA4 = await insertMember(gSpanning.id, alertA4.id, 'root');
+  const memberB1 = await insertMember(gSpanning.id, alertB1.id, 'related');
+
+  // `ai_alert_verdicts.run_id` is NOT NULL, so a verdict needs a real agent run.
+  // The run itself deliberately STAYS in the source org (owner decision
+  // 2026-08-23), which is why the route re-stamps the verdict and not the run.
+  const [agent] = await adminDb.insert(aiAgents).values({
+    orgId: orgA.id,
+    partnerId: null,
+    kind: 'triage',
+    name: `Verdict agent ${unique}`,
+    createdBy: user.id,
+  }).returning();
+  const [run] = await adminDb.insert(aiAgentRuns).values({
+    agentId: agent.id,
+    orgId: orgA.id,
+    triggerKind: 'alert',
+    dedupeKey: `alert-children-${unique}`,
+    modeAtStart: 'shadow',
+    policySnapshot: { schemaVersion: 1 } as never,
+  }).returning();
+
+  const insertVerdict = async (target: { alertId?: string; correlationGroupId?: string }) => {
+    const [row] = await adminDb.insert(aiAlertVerdicts).values({
+      orgId: orgA.id,
+      runId: run.id,
+      alertId: target.alertId ?? null,
+      correlationGroupId: target.correlationGroupId ?? null,
+      classification: target.alertId ? 'actionable' : 'duplicate_of_group',
+      confidence: '0.80',
+      rationale: 'integration fixture',
+    }).returning();
+    return row;
+  };
+  const verdictOnAlert = await insertVerdict({ alertId: alertA1.id });
+  const verdictOnTravellingGroup = await insertVerdict({ correlationGroupId: gTravelling.id });
+  const verdictOnSpanningGroup = await insertVerdict({ correlationGroupId: gSpanning.id });
+
+  const token = await createAccessToken({
+    sub: user.id,
+    email: user.email,
+    roleId: role.id,
+    orgId: null,
+    partnerId: partner.id,
+    scope: 'partner',
+    mfa: true,
+    aep: 1,
+    mep: 1,
+    sid: 'it-session',
+  });
+
+  const app = new Hono();
+  app.route('/devices', moveOrgRoutes);
+
+  const move = () =>
+    app.request(`/devices/${deviceMoved.id}/move-org`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ orgId: orgB.id, siteId: siteB.id }),
+    });
+
+  return {
+    adminDb, orgA, orgB, siteB,
+    deviceMoved, deviceStays,
+    alertA1, alertA2, alertA4, alertB1,
+    gTravelling, gSpanning,
+    memberA1, memberA2, memberA4, memberB1,
+    verdictOnAlert, verdictOnTravellingGroup, verdictOnSpanningGroup,
+    move,
+  };
+}
+
+type Fixture = Awaited<ReturnType<typeof seed>>;
+
+/** org_id of every seeded row, keyed by the fixture's own names. */
+async function readOrgIds(f: Fixture) {
+  const byId = (rows: Array<{ id: string; orgId: string }>) =>
+    new Map(rows.map((r) => [r.id, r] as const));
+
+  const deviceRows = byId(await f.adminDb
+    .select({ id: devices.id, orgId: devices.orgId, siteId: devices.siteId })
+    .from(devices)
+    .where(inArray(devices.id, [f.deviceMoved.id, f.deviceStays.id])));
+  const alertRows = byId(await f.adminDb
+    .select({ id: alerts.id, orgId: alerts.orgId })
+    .from(alerts)
+    .where(inArray(alerts.id, [f.alertA1.id, f.alertA2.id, f.alertA4.id, f.alertB1.id])));
+  const groupRows = byId(await f.adminDb
+    .select({ id: alertCorrelationGroups.id, orgId: alertCorrelationGroups.orgId })
+    .from(alertCorrelationGroups)
+    .where(inArray(alertCorrelationGroups.id, [f.gTravelling.id, f.gSpanning.id])));
+  const memberRows = byId(await f.adminDb
+    .select({ id: alertCorrelationMembers.id, orgId: alertCorrelationMembers.orgId })
+    .from(alertCorrelationMembers)
+    .where(inArray(alertCorrelationMembers.id, [
+      f.memberA1.id, f.memberA2.id, f.memberA4.id, f.memberB1.id,
+    ])));
+  const verdictRows = byId(await f.adminDb
+    .select({ id: aiAlertVerdicts.id, orgId: aiAlertVerdicts.orgId })
+    .from(aiAlertVerdicts)
+    .where(inArray(aiAlertVerdicts.id, [
+      f.verdictOnAlert.id, f.verdictOnTravellingGroup.id, f.verdictOnSpanningGroup.id,
+    ])));
+
+  const org = (map: Map<string, { orgId: string }>, id: string) => map.get(id)?.orgId;
+  return {
+    deviceMoved: org(deviceRows, f.deviceMoved.id),
+    deviceStays: org(deviceRows, f.deviceStays.id),
+    alertA1: org(alertRows, f.alertA1.id),
+    alertA2: org(alertRows, f.alertA2.id),
+    alertA4: org(alertRows, f.alertA4.id),
+    alertB1: org(alertRows, f.alertB1.id),
+    gTravelling: org(groupRows, f.gTravelling.id),
+    gSpanning: org(groupRows, f.gSpanning.id),
+    memberA1: org(memberRows, f.memberA1.id),
+    memberA2: org(memberRows, f.memberA2.id),
+    memberA4: org(memberRows, f.memberA4.id),
+    memberB1: org(memberRows, f.memberB1.id),
+    verdictOnAlert: org(verdictRows, f.verdictOnAlert.id),
+    verdictOnTravellingGroup: org(verdictRows, f.verdictOnTravellingGroup.id),
+    verdictOnSpanningGroup: org(verdictRows, f.verdictOnSpanningGroup.id),
+  };
+}
+
+describe('POST /devices/:id/move-org — alert-axis children (#4867)', () => {
+  it('re-stamps the group, ALL of its members and both verdict legs when every member alert reaches the target org', async () => {
+    const f = await seed();
+
+    const res = await f.move();
+    const body = (await res.json()) as any;
+    expect(res.status, JSON.stringify(body)).toBe(200);
+
+    const after = await readOrgIds(f);
+    expect(after.deviceMoved).toBe(f.orgB.id);
+    // The generic device loop carries the alerts themselves.
+    expect(after.alertA1).toBe(f.orgB.id);
+    expect(after.alertA2).toBe(f.orgB.id);
+
+    // Group: all member alerts are in orgB and the (org_id, group_key) slot is
+    // free there, so all three guards pass.
+    expect(after.gTravelling).toBe(f.orgB.id);
+    // Members travel WITH the group — never apart from it.
+    expect(after.memberA1).toBe(f.orgB.id);
+    expect(after.memberA2).toBe(f.orgB.id);
+    // Verdict, alert leg (alert_id set) and group leg (alert_id NULL,
+    // correlation_group_id set) — the second is the one the alert leg alone
+    // can never reach.
+    expect(after.verdictOnAlert).toBe(f.orgB.id);
+    expect(after.verdictOnTravellingGroup).toBe(f.orgB.id);
+  });
+
+  it('holds a group that still spans two orgs back — and holds ITS member rows back with it', async () => {
+    const f = await seed();
+
+    const res = await f.move();
+    expect(res.status).toBe(200);
+
+    const after = await readOrgIds(f);
+    // The moved device's alert follows the device...
+    expect(after.alertA4).toBe(f.orgB.id);
+    // ...but the alert on the device that stayed does not, so the group is
+    // still split across two orgs and is deliberately left behind.
+    expect(after.deviceStays).toBe(f.orgA.id);
+    expect(after.alertB1).toBe(f.orgA.id);
+    expect(after.gSpanning).toBe(f.orgA.id);
+
+    // THE REGRESSION THIS FILE EXISTS FOR (#5005 review, split-brain): the
+    // member row for the MOVED device's alert must stay with its group. Moving
+    // it while the group stays makes it invisible to both orgs, because
+    // correlationMetadataCondition joins on members.org_id AND groups.org_id.
+    expect(after.memberA4).toBe(f.orgA.id);
+    expect(after.memberB1).toBe(f.orgA.id);
+    // A group-level verdict follows its group, so it stays too.
+    expect(after.verdictOnSpanningGroup).toBe(f.orgA.id);
+  });
+
+  it('records the moved and held-back counts, split by hold-back reason, on BOTH audit rows', async () => {
+    const f = await seed();
+
+    const res = await f.move();
+    expect(res.status).toBe(200);
+
+    // writeRouteAudit is fire-and-forget — let it land.
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    const audits = await f.adminDb
+      .select({ action: auditLogs.action, orgId: auditLogs.orgId, details: auditLogs.details })
+      .from(auditLogs)
+      .where(eq(auditLogs.resourceId, f.deviceMoved.id));
+    expect(audits.map((a: { action: string }) => a.action).sort())
+      .toEqual(['device.move_org.source', 'device.move_org.target']);
+    expect(audits.map((a: { orgId: string }) => a.orgId).sort())
+      .toEqual([f.orgA.id, f.orgB.id].sort());
+
+    for (const row of audits) {
+      expect(row.details).toMatchObject({
+        alertChildRewrite: {
+          // gTravelling moved; gSpanning was held back for spanning two orgs
+          // (no group_key collision in this fixture).
+          correlationGroups: 1,
+          correlationGroupsHeldSpanning: 1,
+          correlationGroupsHeldKeyCollision: 0,
+          // memberA1 + memberA2 travelled with gTravelling; memberA4 (this
+          // device's membership in the held group) stayed.
+          correlationMembers: 2,
+          correlationMembersHeld: 1,
+          // verdictOnAlert + verdictOnTravellingGroup.
+          alertVerdicts: 2,
+        },
+      });
+    }
+  });
+});

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -379,14 +379,25 @@ export const CUSTOM_ORG_REWRITE_TABLES = [
  * regenerates them: the verdict scheduler is event-driven off `alert.triggered`
  * (jobs/alertVerdictScheduler.ts) and never re-scans existing alerts.
  *
- * ORDER IS LOAD-BEARING, but for a different reason than the ticket list's:
- * member -> group -> verdict, because each later statement's predicate reads
- * the rows the earlier one just re-stamped (the group's "every member alert is
- * now in the target org" test reads `alerts.org_id` from the generic loop, and
- * the verdict's group leg reads `alert_correlation_groups.org_id` from the
- * group statement). None of the three carries a composite tenant FK, so there
- * is no 23503 ordering hazard of the kind the ticket chain above is ordered
- * for. These statements run AFTER that chain, extending — never reordering —
+ * ORDER IS LOAD-BEARING — group -> member -> verdict — and, unlike the ticket
+ * list's, the primary reason is a LOCK ORDER (#5005 review). The correlation
+ * job (services/alertCorrelationGroups.ts) upserts the GROUP and then its
+ * MEMBERS on every pass; a mover that took them the other way round would form
+ * an AB-BA with a concurrent correlation pass and lose one side to 40P01.
+ * Aligning with the existing writer is the same discipline
+ * services/ticketOrgMoveLockOrder.ts encodes for the ticket axis (#4657).
+ *
+ * The data dependency runs the same way and is downstream only: the member
+ * statement reads `alert_correlation_groups.org_id` as re-stamped by the group
+ * statement, and the verdict's group leg reads that same column. Nothing reads
+ * `alert_correlation_members.org_id` — the group's "does this group still span
+ * two orgs?" guard reads `alerts.org_id` from the generic loop, never the
+ * member row's own org. (Before #5005's follow-up this comment claimed the
+ * reverse order was load-bearing for that reason; it was not.)
+ *
+ * None of the three carries a composite tenant FK, so there is no 23503
+ * ordering hazard of the kind the ticket chain above is ordered for. These
+ * statements run AFTER that chain, extending — never reordering —
  * services/ticketOrgMoveLockOrder.ts's documented order.
  *
  * moveOrg.coverage.test.ts DERIVES the expected membership from the schema
@@ -395,8 +406,8 @@ export const CUSTOM_ORG_REWRITE_TABLES = [
  * statement sequence to this array's order.
  */
 export const ALERT_CHILD_ORG_REWRITE_TABLES = [
-  'alert_correlation_members',
   'alert_correlation_groups',
+  'alert_correlation_members',
   'ai_alert_verdicts',
 ] as const;
 

--- a/apps/api/src/routes/devices/moveOrg.coverage.test.ts
+++ b/apps/api/src/routes/devices/moveOrg.coverage.test.ts
@@ -297,6 +297,21 @@ describe('CUSTOM_ORG_REWRITE_TABLES coverage', () => {
  * repeat #4867 by skipping both paths. `ticket_alert_links` is the one derived
  * name that is deliberately NOT here — it is the ticket axis's row and is
  * already rewritten by CUSTOM_ORG_REWRITE_TABLES.
+ *
+ * LIMIT OF THIS GUARD (#5005 review): the derivation walks
+ * `getTableConfig(table).foreignKeys`, which sees only the FKs DECLARED in the
+ * Drizzle schema — not the ones that exist solely in a migration. Nothing in
+ * this repo forces the two to agree: `pnpm db:check-drift` compares the schema
+ * against the migrations' DDL for columns, but drizzle-kit does not surface a
+ * migration-only FK as drift the schema must adopt (the same gap
+ * `aiAlertVerdicts.supersededBy`'s DEFERRABLE note and
+ * `deviceMtlsCertificates`' composite FK already call out from the other
+ * direction). So a future alert child whose only link to `alerts` is an FK
+ * added in raw SQL — or one that reaches alerts through an untyped uuid column
+ * with no FK at all — is invisible here and will be missed exactly the way
+ * #4867 was. When adding such a table, add it to ALERT_CHILD_ORG_REWRITE_TABLES
+ * by hand; the `stale` assertion below will then flag it, which is the prompt
+ * to declare the FK in the Drizzle schema too.
  */
 describe('ALERT_CHILD_ORG_REWRITE_TABLES coverage (#4867)', () => {
   const alertChildSet = new Set<string>(ALERT_CHILD_ORG_REWRITE_TABLES);
@@ -410,15 +425,20 @@ describe('ALERT_CHILD_ORG_REWRITE_TABLES coverage (#4867)', () => {
     ).toEqual([]);
   });
 
-  it('is ordered member -> group -> verdict, the order moveOrg.ts issues them in', () => {
-    // Load-bearing, not cosmetic: the group statement's "every member alert is
-    // now in the target org" predicate reads alerts.org_id as re-stamped by the
-    // generic loop, and the verdict statement's group leg reads
-    // alert_correlation_groups.org_id as re-stamped by the group statement.
+  it('is ordered group -> member -> verdict, the order moveOrg.ts issues them in', () => {
+    // Load-bearing for TWO reasons, and the first is a lock order (#5005
+    // review): the correlation job (services/alertCorrelationGroups.ts) writes
+    // the GROUP then its MEMBERS on every pass, so a mover taking them the
+    // other way round forms an AB-BA with a concurrent correlation pass and
+    // loses one side to 40P01. Second, the data dependency runs the same way:
+    // the member statement and the verdict statement's group leg both read
+    // alert_correlation_groups.org_id as re-stamped by the group statement,
+    // whose own "does this group still span two orgs?" guard reads
+    // alerts.org_id from the generic loop — never members.org_id.
     // moveOrg.test.ts pins the real statement sequence to this array.
     expect(ALERT_CHILD_ORG_REWRITE_TABLES).toEqual([
-      'alert_correlation_members',
       'alert_correlation_groups',
+      'alert_correlation_members',
       'ai_alert_verdicts',
     ]);
   });

--- a/apps/api/src/routes/devices/moveOrg.test.ts
+++ b/apps/api/src/routes/devices/moveOrg.test.ts
@@ -395,8 +395,10 @@ describe('POST /devices/:id/move-org', () => {
       // ORDER, which is the cross-axis lock order (#4657, #4743, #4643).
       // ALERT_CHILD_ORG_REWRITE_TABLES (#4867 — the alert-axis children with
       // no device_id) come next, pinned to their array's order the same way:
-      // member -> group -> verdict, because each later predicate reads the
-      // rows the earlier statement just re-stamped. The SITE loop runs last
+      // group -> member -> verdict, matching the correlation job's own write
+      // order (services/alertCorrelationGroups.ts) so the two writers can't
+      // form an AB-BA, and because each later predicate reads the rows the
+      // group statement just re-stamped. The SITE loop runs last
       // and any table in DEVICE_SITE_DENORMALIZED_TABLES appears in
       // updatedTables a second time for the site_id rewrite.
       expect(updatedTables).toEqual([
@@ -871,13 +873,29 @@ describe('POST /devices/:id/move-org', () => {
       return matches[0]!;
     }
 
-    it('re-stamps alert_correlation_members via the alert join — a member row always follows its alert', async () => {
+    it('re-stamps alert_correlation_members only for groups that actually moved — a member never travels apart from its group', async () => {
       const { statements } = await moveDevice();
 
+      // #5005 post-merge review (split-brain): the gate is the GROUP's org_id
+      // after the group statement, NOT the member's own alert.
+      // correlationMetadataCondition (routes/alerts/alerts.ts) joins a member to
+      // its group and pins BOTH org_ids, so a member re-stamped to the target
+      // while its group was held back is visible to NEITHER org. Matching on
+      // `g.org_id = <target>` rather than on the group statement's RETURNING ids
+      // also heals a member the pre-fix code stranded under a group that is
+      // already in the target org.
       expect(onlyStatement(statements, 'alert_correlation_members')).toBe(collapseStmt(`
-        UPDATE alert_correlation_members SET org_id = ${TARGET_ORG}::uuid
-        WHERE alert_id IN (SELECT id FROM alerts WHERE device_id = ${DEVICE_ID}::uuid)
-        RETURNING id
+        UPDATE alert_correlation_members m SET org_id = ${TARGET_ORG}::uuid
+        WHERE m.org_id IS DISTINCT FROM ${TARGET_ORG}::uuid
+        AND EXISTS (
+        SELECT 1 FROM alert_correlation_groups g
+        WHERE g.id = m.group_id
+        AND g.org_id = ${TARGET_ORG}::uuid
+        AND EXISTS (
+        SELECT 1 FROM alert_correlation_members m2
+        JOIN alerts a ON a.id = m2.alert_id
+        WHERE m2.group_id = g.id AND a.device_id = ${DEVICE_ID}::uuid))
+        RETURNING m.id
       `));
     });
 
@@ -939,7 +957,7 @@ describe('POST /devices/:id/move-org', () => {
       `));
     });
 
-    it('orders the three AFTER the generic alerts re-stamp, and the group before the verdict', async () => {
+    it('takes the GROUP before its MEMBERS (the correlation job\'s lock order), all after the generic alerts re-stamp', async () => {
       const { statements } = await moveDevice();
 
       const idx = (prefix: string) => {
@@ -948,13 +966,20 @@ describe('POST /devices/:id/move-org', () => {
         return found;
       };
 
-      // Load-bearing: the group predicate reads `alerts.org_id` AS RE-STAMPED
-      // by the generic loop, so running earlier would see every moved alert
-      // still in the source org and hold every group back.
+      // Load-bearing: the group guard reads `alerts.org_id` AS RE-STAMPED by
+      // the generic loop, so running earlier would see every moved alert still
+      // in the source org and hold every group back.
       const alertsRestamp = idx('UPDATE alerts SET org_id');
-      expect(idx('UPDATE alert_correlation_members ')).toBeGreaterThan(alertsRestamp);
       expect(idx('UPDATE alert_correlation_groups ')).toBeGreaterThan(alertsRestamp);
+      expect(idx('UPDATE alert_correlation_members ')).toBeGreaterThan(alertsRestamp);
       expect(idx('UPDATE ai_alert_verdicts ')).toBeGreaterThan(alertsRestamp);
+
+      // THE LOCK ORDER (#5005 review). services/alertCorrelationGroups.ts
+      // upserts the GROUP and then its MEMBERS on every correlation pass. A
+      // mover that took members first would be an AB-BA against a concurrent
+      // pass over the same group and lose one side to 40P01 — a 500 on an
+      // admin action. Same discipline as services/ticketOrgMoveLockOrder.ts.
+      expect(idx('UPDATE alert_correlation_members ')).toBeGreaterThan(idx('UPDATE alert_correlation_groups '));
 
       // Load-bearing: the verdict's group leg selects groups already sitting in
       // the TARGET org, which is only true of a group this move just re-stamped
@@ -964,30 +989,57 @@ describe('POST /devices/:id/move-org', () => {
       // Extends — never reorders — the documented ticket-child lock order
       // (services/ticketOrgMoveLockOrder.ts): the alert-axis statements all
       // follow the last ticket-chain table.
-      expect(idx('UPDATE alert_correlation_members ')).toBeGreaterThan(idx('UPDATE ticket_email_links '));
+      expect(idx('UPDATE alert_correlation_groups ')).toBeGreaterThan(idx('UPDATE ticket_email_links '));
     });
 
-    it('counts the groups it touched but held back, for the audit trail', async () => {
+    it('counts the groups it held back SPLIT BY CAUSE, and this device\'s memberships that stayed with them', async () => {
       const { statements } = await moveDevice();
 
       // A held group is one this device's alerts belong to that is still not in
-      // the target org after the re-stamp — i.e. split across orgs, or blocked
-      // by an occupied group_key. Counted so an operator asking "why did the
-      // correlation badge not follow this device?" has the number in the audit
-      // row instead of having to reconstruct it.
-      const held = statements.map(collapseStmt).filter((s) => s.startsWith('SELECT count(*)::int AS held '));
+      // the target org after the re-stamp. The group UPDATE has already run, so
+      // it failed exactly one of its two skippable guards — it spans two orgs,
+      // or its (org_id, group_key) slot is occupied there. The two have
+      // different operator answers (#5005 review): spanning resolves itself when
+      // the last device moves, a key collision never does.
+      const held = statements.map(collapseStmt).filter((s) => s.startsWith('SELECT count(*) FILTER'));
       expect(
         held,
         `Expected exactly one held-group count.\nStatements:\n${statements.join('\n')}`,
       ).toEqual([
         collapseStmt(`
-          SELECT count(*)::int AS held
+          SELECT
+          count(*) FILTER (WHERE t.spans)::int AS held_spanning,
+          count(*) FILTER (WHERE NOT t.spans)::int AS held_key_collision
+          FROM (
+          SELECT EXISTS (
+          SELECT 1 FROM alert_correlation_members m2
+          JOIN alerts a2 ON a2.id = m2.alert_id
+          WHERE m2.group_id = g.id
+          AND a2.org_id IS DISTINCT FROM ${TARGET_ORG}::uuid) AS spans
           FROM alert_correlation_groups g
           WHERE g.org_id IS DISTINCT FROM ${TARGET_ORG}::uuid
           AND EXISTS (
           SELECT 1 FROM alert_correlation_members m
           JOIN alerts a ON a.id = m.alert_id
           WHERE m.group_id = g.id AND a.device_id = ${DEVICE_ID}::uuid)
+          ) t
+        `),
+      ]);
+
+      // The members that stayed behind WITH a held group — this device's alerts
+      // that moved without their correlation membership.
+      const heldMembers = statements.map(collapseStmt).filter((s) => s.startsWith('SELECT count(*)::int AS held_members'));
+      expect(
+        heldMembers,
+        `Expected exactly one held-member count.\nStatements:\n${statements.join('\n')}`,
+      ).toEqual([
+        collapseStmt(`
+          SELECT count(*)::int AS held_members
+          FROM alert_correlation_members m
+          JOIN alerts a ON a.id = m.alert_id
+          JOIN alert_correlation_groups g ON g.id = m.group_id
+          WHERE a.device_id = ${DEVICE_ID}::uuid
+          AND g.org_id IS DISTINCT FROM ${TARGET_ORG}::uuid
         `),
       ]);
     });
@@ -997,15 +1049,18 @@ describe('POST /devices/:id/move-org', () => {
         if (text.startsWith('UPDATE alert_correlation_members ')) return [{ id: 'm1' }, { id: 'm2' }];
         if (text.startsWith('UPDATE alert_correlation_groups ')) return [{ id: 'g1' }];
         if (text.startsWith('UPDATE ai_alert_verdicts ')) return [{ id: 'v1' }, { id: 'v2' }, { id: 'v3' }];
-        if (text.startsWith('SELECT count(*)::int AS held ')) return [{ held: 4 }];
+        if (text.startsWith('SELECT count(*) FILTER')) return [{ held_spanning: 4, held_key_collision: 2 }];
+        if (text.startsWith('SELECT count(*)::int AS held_members')) return [{ held_members: 5 }];
         return null;
       };
       await moveDevice();
 
       const expected = {
-        correlationMembers: 2,
         correlationGroups: 1,
-        correlationGroupsHeld: 4,
+        correlationGroupsHeldSpanning: 4,
+        correlationGroupsHeldKeyCollision: 2,
+        correlationMembers: 2,
+        correlationMembersHeld: 5,
         alertVerdicts: 3,
       };
       const auditRows = vi.mocked(writeRouteAudit).mock.calls.map((call) => call[1] as any);

--- a/apps/api/src/routes/devices/moveOrg.ts
+++ b/apps/api/src/routes/devices/moveOrg.ts
@@ -55,14 +55,27 @@ class OrgVanishedDuringMoveError extends Error {
 /**
  * How much alert-axis derived state a device org-move carried over (#4867),
  * recorded on BOTH audit rows so the source and target feeds agree.
- * `correlationGroupsHeld` counts the groups the move touched but deliberately
- * left in the source org — still spanning two orgs, or their
- * (org_id, group_key) slot already taken in the target org.
+ *
+ * The held counts are split by CAUSE, because the two have different operator
+ * answers (#5005 review):
+ *
+ *  - `correlationGroupsHeldSpanning` — the group still has a member alert on a
+ *    device in another org. It travels by itself once that last device moves;
+ *    nothing to do.
+ *  - `correlationGroupsHeldKeyCollision` — the target org already holds a group
+ *    with this `group_key` (`alert_correlation_groups_org_key_uq`). This one
+ *    never self-resolves: the two groups need a human decision, so the number
+ *    being non-zero is the signal.
+ *  - `correlationMembersHeld` — this device's own membership rows that stayed
+ *    behind with a held group. Members always travel with their group, so this
+ *    is the count of alerts that moved without their correlation membership.
  */
 interface AlertChildOrgRewriteCounts {
-  correlationMembers: number;
   correlationGroups: number;
-  correlationGroupsHeld: number;
+  correlationGroupsHeldSpanning: number;
+  correlationGroupsHeldKeyCollision: number;
+  correlationMembers: number;
+  correlationMembersHeld: number;
   alertVerdicts: number;
 }
 
@@ -625,7 +638,7 @@ moveOrgRoutes.post(
         );
 
         // #4867 — the ALERT-axis children (ALERT_CHILD_ORG_REWRITE_TABLES in
-        // core.ts): alert_correlation_members, alert_correlation_groups and
+        // core.ts): alert_correlation_groups, alert_correlation_members and
         // ai_alert_verdicts all denormalize org_id but have NO device_id
         // column, so neither the generic loop above nor the DB-side
         // breeze_cascade_device_org_id() trigger (which discovers its tables BY
@@ -639,28 +652,43 @@ moveOrgRoutes.post(
         // and nothing regenerates either (the verdict scheduler is event-driven
         // off `alert.triggered` and never re-scans).
         //
-        // Placement is load-bearing twice: AFTER the generic loop, because the
-        // group predicate below reads alerts.org_id AS RE-STAMPED by it; and
-        // AFTER the ticket chain above, so this extends — never reorders — the
-        // documented ticket-child lock order
-        // (services/ticketOrgMoveLockOrder.ts). The three run member -> group ->
-        // verdict because each later predicate reads what the earlier one just
-        // wrote. None of them carries a composite tenant FK, so there is no
-        // 23503 hazard of the kind the ticket chain is ordered for.
+        // ORDER — group -> member -> verdict. Two reasons, and the FIRST is a
+        // lock order, not a data dependency:
         //
-        // A member row describes ONE alert's membership, so it always follows
-        // that alert — even when its group does not (next statement).
-        const movedCorrelationMembers = (await tx.execute(
-          sql`UPDATE ${sql.identifier('alert_correlation_members')} SET org_id = ${targetOrgId}::uuid
-              WHERE alert_id IN (SELECT id FROM alerts WHERE device_id = ${deviceId}::uuid)
-              RETURNING id`,
-        )) as unknown as Array<{ id: string }>;
-
-        // A GROUP can span alerts from several devices, so it travels only once
-        // EVERY member alert shares the target org — handing a group to an org
-        // that owns part of it would make its member_count / noise_reduction_
-        // percent claims wrong for both orgs. A group still spanning two orgs
-        // is left behind and counted below instead.
+        //  1. LOCK ORDER (#5005 review). The other writer of this pair is the
+        //     correlation job (services/alertCorrelationGroups.ts), which
+        //     upserts the GROUP and then its MEMBERS, in that order, on every
+        //     pass. Taking them the other way round here is a textbook AB-BA:
+        //     a correlation pass running concurrently over the same group
+        //     deadlocks with this move and Postgres kills one with 40P01,
+        //     surfacing as a 500 on an admin action. Same class of bug and same
+        //     fix as the ticket-child order in
+        //     services/ticketOrgMoveLockOrder.ts (#4657) — read that module for
+        //     the precedent. This pair is not listed there because its
+        //     counterpart is the correlation job rather than a second org-mover,
+        //     but the rule is identical: state the order once, and align with
+        //     the existing writer instead of reasoning locally.
+        //  2. DATA DEPENDENCY, and it runs the same way. The member statement
+        //     reads `alert_correlation_groups.org_id` as re-stamped by the group
+        //     statement, and the verdict's group leg reads that same column.
+        //     NOTHING reads `alert_correlation_members.org_id`: the group's
+        //     "does this group still span two orgs?" guard reads `alerts.org_id`
+        //     (re-stamped by the generic loop above), never the member row's own
+        //     org. An earlier revision of this comment asserted the opposite —
+        //     that member -> group -> verdict was load-bearing — and the order
+        //     it justified was the deadlock in 1.
+        //
+        // Placement of the whole block is load-bearing too: AFTER the generic
+        // loop, because the group guard reads alerts.org_id as re-stamped by it;
+        // and AFTER the ticket chain above, so this extends — never reorders —
+        // ticketOrgMoveLockOrder.ts's documented order. None of the three
+        // carries a composite tenant FK, so there is no 23503 hazard of the kind
+        // the ticket chain is ordered for.
+        //
+        // A GROUP travels only once EVERY member alert shares the target org —
+        // handing a group to an org that owns part of it would make its
+        // member_count / noise_reduction_percent claims wrong for both orgs. A
+        // group still spanning two orgs is left behind and counted below.
         //
         // The third guard is `alert_correlation_groups_org_key_uq (org_id,
         // group_key)`: the correlation job mints group_key as
@@ -686,6 +714,36 @@ moveOrgRoutes.post(
                   SELECT 1 FROM alert_correlation_groups existing
                   WHERE existing.org_id = ${targetOrgId}::uuid AND existing.group_key = g.group_key)
               RETURNING g.id`,
+        )) as unknown as Array<{ id: string }>;
+
+        // Members travel WITH their group — never apart from it. The gate is the
+        // GROUP's org_id as this transaction just left it, not the member's own
+        // alert: `correlationMetadataCondition` (routes/alerts/alerts.ts) joins a
+        // member to its group and pins BOTH org_ids, so a member re-stamped to
+        // the target while its group stayed behind is visible to NEITHER org.
+        // That is strictly worse than leaving both in the source org, where the
+        // source org still renders the group intact and the target org merely
+        // sees an uncorrelated alert (#5005 post-merge review).
+        //
+        // Scoped to groups this device's alerts belong to, so an unrelated
+        // target-org group is never touched. Within such a group EVERY member
+        // moves, including one whose own alert lives on a DIFFERENT device —
+        // that device's alerts already sit in the target org, which is exactly
+        // what let the group past the guards above. Matching on
+        // `g.org_id = <target>` rather than on the ids RETURNed above also heals
+        // a member stranded by the pre-fix code, whose group is already there.
+        const movedCorrelationMembers = (await tx.execute(
+          sql`UPDATE ${sql.identifier('alert_correlation_members')} m SET org_id = ${targetOrgId}::uuid
+              WHERE m.org_id IS DISTINCT FROM ${targetOrgId}::uuid
+                AND EXISTS (
+                  SELECT 1 FROM alert_correlation_groups g
+                  WHERE g.id = m.group_id
+                    AND g.org_id = ${targetOrgId}::uuid
+                    AND EXISTS (
+                      SELECT 1 FROM alert_correlation_members m2
+                      JOIN alerts a ON a.id = m2.alert_id
+                      WHERE m2.group_id = g.id AND a.device_id = ${deviceId}::uuid))
+              RETURNING m.id`,
         )) as unknown as Array<{ id: string }>;
 
         // A verdict follows the row it judges. The OR is the point: a
@@ -718,24 +776,52 @@ moveOrgRoutes.post(
               RETURNING id`,
         )) as unknown as Array<{ id: string }>;
 
-        // Groups this move touched but deliberately left behind (still spanning
-        // two orgs, or blocked by an occupied group_key). Counted so an operator
-        // asking "why didn't the correlation badge follow this device?" finds
-        // the number in the audit row instead of reconstructing it from SQL.
+        // Groups this move touched but deliberately left behind, split by CAUSE
+        // so an operator asking "why didn't the correlation badge follow this
+        // device?" reads the answer off the audit row instead of reconstructing
+        // it from SQL. The group UPDATE has already run, so a group still
+        // outside the target org failed exactly one of its two skippable
+        // guards: it spans two orgs, or its (org_id, group_key) slot is taken
+        // there. `spans` is evaluated first and wins when both are true, so the
+        // two counts always sum to the number of held groups.
         const [heldCorrelationGroups] = (await tx.execute(
-          sql`SELECT count(*)::int AS held
-              FROM alert_correlation_groups g
-              WHERE g.org_id IS DISTINCT FROM ${targetOrgId}::uuid
-                AND EXISTS (
-                  SELECT 1 FROM alert_correlation_members m
-                  JOIN alerts a ON a.id = m.alert_id
-                  WHERE m.group_id = g.id AND a.device_id = ${deviceId}::uuid)`,
-        )) as unknown as Array<{ held: number }>;
+          sql`SELECT
+                count(*) FILTER (WHERE t.spans)::int AS held_spanning,
+                count(*) FILTER (WHERE NOT t.spans)::int AS held_key_collision
+              FROM (
+                SELECT EXISTS (
+                    SELECT 1 FROM alert_correlation_members m2
+                    JOIN alerts a2 ON a2.id = m2.alert_id
+                    WHERE m2.group_id = g.id
+                      AND a2.org_id IS DISTINCT FROM ${targetOrgId}::uuid) AS spans
+                FROM alert_correlation_groups g
+                WHERE g.org_id IS DISTINCT FROM ${targetOrgId}::uuid
+                  AND EXISTS (
+                    SELECT 1 FROM alert_correlation_members m
+                    JOIN alerts a ON a.id = m.alert_id
+                    WHERE m.group_id = g.id AND a.device_id = ${deviceId}::uuid)
+              ) t`,
+        )) as unknown as Array<{ held_spanning: number; held_key_collision: number }>;
+
+        // This device's OWN memberships that stayed behind with a held group:
+        // the alert moved, its correlation membership deliberately did not.
+        // Counted separately from the moved members so the two numbers never
+        // have to be read as "everything else".
+        const [heldCorrelationMembers] = (await tx.execute(
+          sql`SELECT count(*)::int AS held_members
+              FROM alert_correlation_members m
+              JOIN alerts a ON a.id = m.alert_id
+              JOIN alert_correlation_groups g ON g.id = m.group_id
+              WHERE a.device_id = ${deviceId}::uuid
+                AND g.org_id IS DISTINCT FROM ${targetOrgId}::uuid`,
+        )) as unknown as Array<{ held_members: number }>;
 
         const alertChildCounts = {
-          correlationMembers: movedCorrelationMembers.length,
           correlationGroups: movedCorrelationGroups.length,
-          correlationGroupsHeld: Number(heldCorrelationGroups?.held ?? 0),
+          correlationGroupsHeldSpanning: Number(heldCorrelationGroups?.held_spanning ?? 0),
+          correlationGroupsHeldKeyCollision: Number(heldCorrelationGroups?.held_key_collision ?? 0),
+          correlationMembers: movedCorrelationMembers.length,
+          correlationMembersHeld: Number(heldCorrelationMembers?.held_members ?? 0),
           alertVerdicts: movedAlertVerdicts.length,
         };
         // Only audit the block when the device actually had alert-axis rows, so


### PR DESCRIPTION
Follow-up to #5005 (merged as `f4387aa58d`), addressing every finding from its post-merge review. Branched fresh off `main`.

## Important 1 — split-brain member rewrite

`moveOrg.ts` re-stamped **every** `alert_correlation_members` row for the device's alerts, but the group statement holds a group back when it still spans two orgs or its `(org_id, group_key)` slot is occupied in the target. `correlationMetadataCondition` (`routes/alerts/alerts.ts`) joins a member to its group and pins **both** `org_id`s, so a member moved to the target under a group left in the source was visible to **neither** org — strictly worse than holding both, where the source org still renders the group intact and the target org merely sees an uncorrelated alert.

Members are now gated on the **group's** `org_id` as this transaction leaves it:

```sql
UPDATE alert_correlation_members m SET org_id = <target>
WHERE m.org_id IS DISTINCT FROM <target>
  AND EXISTS (SELECT 1 FROM alert_correlation_groups g
              WHERE g.id = m.group_id AND g.org_id = <target>
                AND EXISTS (… this device's alerts are in the group …))
```

Two deliberate details: within a moved group **every** member travels, including one whose own alert lives on a different device (that device's alerts are already in the target org — which is precisely what let the group past the guards); and matching on `g.org_id = <target>` rather than on the group statement's `RETURNING` ids also heals a member the pre-fix code stranded under a group that is already in the target org.

## Important 2 — lock order

`services/alertCorrelationGroups.ts` upserts the **GROUP** and then its **MEMBERS** on every correlation pass (`upsertGroup` → `upsertMembers`). `moveOrg` took members first — a textbook AB-BA that a concurrent correlation pass over the same group turns into a 40P01, surfacing as a 500 on an admin action.

The three statements now run **group → member → verdict**, matching the writer. `ALERT_CHILD_ORG_REWRITE_TABLES` (`routes/devices/core.ts`) is reordered to match, since `moveOrg.test.ts` pins the real statement sequence to that array. `services/ticketOrgMoveLockOrder.ts` was read for the precedent; the order and its rationale are now stated once, at the statements and on the array, the same way that module does for the ticket axis (#4657). This pair is not added to that module because its counterpart is the correlation job rather than a second org-mover.

Secondary, and *inferred* rather than executed: `orgMerge.ts` walks `topologicalCascadeOrder()` **reversed** (parents-first), and `alert_correlation_members.group_id → alert_correlation_groups.id` is a real FK in the DB (verified via `pg_constraint` on the test database), so the merge walker takes groups before members too. The new order aligns with it; the old one did not.

## Critical — no integration test

`moveOrg.test.ts` mocks `../../db` wholesale, so these three raw UPDATEs were only ever compared as **text** — nothing in CI had executed them. New `apps/api/src/__tests__/integration/deviceMoveOrgAlertChildren.integration.test.ts` (shape copied from `deviceMoveOrgCurrency.integration.test.ts`) drives the real route against real Postgres under real RLS:

1. a group whose member alerts **all** reach the target org travels with the device — group, every member row, the alert-level verdict and the group-level (`alert_id NULL`) verdict are all re-stamped;
2. a group spanning two devices in different orgs is held back **and its member rows are held back with it** — this case failed before the fix (see below);
3. both audit rows carry the split hold-back counts.

It lives under `src/__tests__/integration/**`, so `vitest.integration.config.ts`'s shared glob already picks it up (blocking `integration-test` job); no config change needed, and `integration-suite-coverage` passes.

**Red before the fix** (same file, same stack, on the pre-fix code):

```
 FAIL  deviceMoveOrgAlertChildren.integration.test.ts > holds a group that still spans two orgs
       back — and holds ITS member rows back with it
 AssertionError: expected '0a54848e-…' to be 'd0f8375a-…'   ← memberA4 had moved to org B
   310|     expect(after.memberA4).toBe(f.orgA.id);

 FAIL  … > records the moved and held-back counts, split by hold-back reason, on BOTH audit rows
 -     "correlationGroupsHeldKeyCollision": 0,
 -     "correlationGroupsHeldSpanning": 1,
 -     "correlationMembers": 2,
 -     "correlationMembersHeld": 1,
 +     "correlationMembers": 3,

 Test Files  1 failed (1)
      Tests  2 failed | 1 passed (3)
```

**Green after** (private worktree test stack, `pnpm test-stack up`):

```
$ npx vitest run --config vitest.integration.config.ts \
    src/__tests__/integration/deviceMoveOrgAlertChildren.integration.test.ts \
    src/__tests__/integration/deviceMoveOrgCurrency.integration.test.ts

 Test Files  2 passed (2)
      Tests  6 passed (6)
   Duration  15.30s
```

## Suggestions

- **The wrong comment.** "member → group → verdict … because each later predicate reads what the earlier one just wrote" was false: the group's span guard reads `alerts.org_id` (re-stamped by the generic loop), never `members.org_id`. Corrected in place in both `moveOrg.ts` and `core.ts`, with an explicit note that the order it justified was the deadlock above.
- **Split hold-back counts.** `correlationGroupsHeld` → `correlationGroupsHeldSpanning` (self-resolves when the group's last device moves; nothing to do) + `correlationGroupsHeldKeyCollision` (never self-resolves — two groups need a human decision, so a non-zero value is the signal). `spans` is evaluated first and wins when both are true, so the two always sum to the number of held groups. New `correlationMembersHeld` counts this device's memberships that stayed behind. These live in the `alertChildRewrite` audit-details block on both audit rows, where the existing counts already were; the HTTP response body is unchanged.
- **Drizzle-FK limit.** `moveOrg.coverage.test.ts` derives its expected membership from `getTableConfig(table).foreignKeys`, which only sees FKs **declared in the Drizzle schema** — a migration-only FK (or an untyped uuid column) is invisible to the guard, and such a table would be missed exactly the way #4867 was. Documented on the describe block, with the instruction to hand-add the table and let the `stale` assertion prompt declaring the FK.

## Verification

| Check | Result |
|---|---|
| `deviceMoveOrgAlertChildren.integration.test.ts` + `deviceMoveOrgCurrency.integration.test.ts` (real PG) | 6/6 passed |
| `moveOrg.test.ts`, `moveOrg.coverage.test.ts`, `ticketOrgMoveLockOrder.test.ts`, `alertVerdicts.test.ts` | 133/133 passed |
| `integration-suite-coverage` | 5/5 passed |
| `tsc --noEmit -p apps/api` | clean (exit 0) |
| `eslint` on all 5 touched files | clean |

No migration, no schema change, no new table — so no cascade/export-policy registration applies.

Refs #4867

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KDahzaq8PRqkwR3eo2k9VB
