### PR TITLE
fix(auth): make MFA factor removal an explicit call, require codes on rotation (#4934 follow-up)

### DIFF
--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -158,6 +158,34 @@ vi.mock('../services', () => {
       cleanup: { redisOk: true, permissionCacheOk: true, oauthOk: true, remoteSessionsTerminated: 0 },
     };
   }),
+  completeMfaFactorRemoval: vi.fn(async (input: any) => {
+    // Minimal drizzle-shaped tx so the caller's persistFactor runs for real.
+    const tx = {
+      update: () => ({
+        set: () => ({
+          where: () => ({ returning: async () => [{ id: input.userId }] }),
+        }),
+      }),
+    };
+    // A factor REMOVAL (#4934 /mfa/disable) omits the code pair entirely — the
+    // real service defaults both to [], so the mock must too.
+    await input.persistFactor(tx, input.recoveryCodeHashes ?? []);
+    return {
+      value: undefined,
+      recoveryCodes: [...(input.recoveryCodes ?? [])],
+      issued: {
+        accessToken: 'replacement-access-token',
+        refreshToken: 'replacement-refresh-token',
+        refreshJti: 'replacement-jti',
+        expiresInSeconds: 900,
+        familyId: 'replacement-family',
+        transitionId: 'transition-1',
+        generation: 1,
+      },
+      mfaEpoch: 2,
+      cleanup: { redisOk: true, permissionCacheOk: true, oauthOk: true, remoteSessionsTerminated: 0 },
+    };
+  }),
   issueUserSessionLegacyDuringTransition: issueLegacy,
   bindIssuedUserSession: vi.fn(async () => undefined),
   authBrowserTransitionsEnforced: vi.fn(() => process.env.AUTH_BROWSER_TRANSITIONS_ENFORCED === 'true'),
@@ -387,6 +415,7 @@ import {
   AuthIssuanceCapabilityError,
   AuthIssuanceConflictError,
   completeInitialMfaEnrollment,
+  completeMfaFactorRemoval,
   replaceSessionOnMfaFactorWrite,
   bindIssuedUserSession,
 } from '../services';
@@ -3974,15 +4003,15 @@ describe('auth routes', () => {
         // ...and the rotated refresh cookie is what survives the family revoke.
         expect(res.headers.get('set-cookie') ?? '').toContain('replacement-refresh-token');
 
-        expect(replaceSessionOnMfaFactorWrite).toHaveBeenCalledTimes(1);
-        const input = vi.mocked(replaceSessionOnMfaFactorWrite).mock.calls[0]?.[0] as any;
+        expect(completeMfaFactorRemoval).toHaveBeenCalledTimes(1);
+        const input = vi.mocked(completeMfaFactorRemoval).mock.calls[0]?.[0] as any;
         expect(input).toMatchObject({
           userId: 'user-123',
-          // Every OTHER session still dies, and the removal is predicated on the
-          // factor still existing when the bump lands — a concurrent second
-          // disable loses with a 409 rather than bumping the epoch twice and
-          // evicting the session the first one just issued.
-          expectedMfaEnabled: true,
+          // Every OTHER session still dies. The "factor must still exist when
+          // the bump lands" precondition (a concurrent second disable loses
+          // with a 409) is now fixed inside completeMfaFactorRemoval itself —
+          // asserted in mfaEnrollmentSession.test.ts — so it no longer appears
+          // on the call-site input.
           revokeReason: 'mfa-disable',
         });
         // A removal installs NO code set — the account must be left holding none.
@@ -4014,7 +4043,7 @@ describe('auth routes', () => {
         mockSuccessfulDisable();
         const policySpy = allowSelfDisable();
         const capturedSets: Array<Record<string, unknown>> = [];
-        vi.mocked(replaceSessionOnMfaFactorWrite).mockImplementationOnce(async (input: any) => {
+        vi.mocked(completeMfaFactorRemoval).mockImplementationOnce(async (input: any) => {
           const tx = {
             update: () => ({
               set: (values: Record<string, unknown>) => {
@@ -4080,7 +4109,7 @@ describe('auth routes', () => {
         policySpy.mockRestore();
 
         expect(res.status).toBe(200);
-        const input = vi.mocked(replaceSessionOnMfaFactorWrite).mock.calls[0]?.[0] as any;
+        const input = vi.mocked(completeMfaFactorRemoval).mock.calls[0]?.[0] as any;
         expect(input.expectedAuthEpoch).toBe(4);
         expect(input.expectedMfaEpoch).toBe(9);
         expect(input.identity).toMatchObject({
@@ -4117,7 +4146,7 @@ describe('auth routes', () => {
         policySpy.mockRestore();
 
         expect(res.status).toBe(200);
-        const input = vi.mocked(replaceSessionOnMfaFactorWrite).mock.calls[0]?.[0] as any;
+        const input = vi.mocked(completeMfaFactorRemoval).mock.calls[0]?.[0] as any;
         expect(input.identity.mfa).toBe(false);
       });
 
@@ -4144,7 +4173,7 @@ describe('auth routes', () => {
       it('surfaces a lost issuance race as 409 and cancels the issuance', async () => {
         mockSuccessfulDisable();
         const policySpy = allowSelfDisable();
-        vi.mocked(replaceSessionOnMfaFactorWrite).mockRejectedValueOnce(new AuthIssuanceConflictError());
+        vi.mocked(completeMfaFactorRemoval).mockRejectedValueOnce(new AuthIssuanceConflictError());
 
         const res = await postDisable(proof);
         policySpy.mockRestore();

--- a/apps/api/src/routes/auth/mfa.ts
+++ b/apps/api/src/routes/auth/mfa.ts
@@ -23,6 +23,7 @@ import {
   AuthIssuanceCapabilityError,
   issueUserSession,
   completeInitialMfaEnrollment,
+  completeMfaFactorRemoval,
   replaceSessionOnMfaFactorWrite,
   issueUserSessionLegacyDuringTransition,
   bindIssuedUserSession,
@@ -922,7 +923,7 @@ mfaRoutes.post('/mfa/disable', authMiddleware, zValidator('json', mfaDisableSche
   }
   let result;
   try {
-    result = await replaceSessionOnMfaFactorWrite({
+    result = await completeMfaFactorRemoval({
       userId: auth.user.id,
       identity: {
         userId: auth.user.id,
@@ -951,7 +952,6 @@ mfaRoutes.post('/mfa/disable', authMiddleware, zValidator('json', mfaDisableSche
       // 400); this is the real check, folded into the epoch bump's WHERE so a
       // concurrent second /mfa/disable loses with a 409 instead of bumping the
       // epoch again and evicting the session the first one just issued.
-      expectedMfaEnabled: true,
       revokeReason: 'mfa-disable',
       // A removal supplies no code pair: the account must be left holding no
       // recovery codes at all.

--- a/apps/api/src/services/mfaEnrollmentSession.test.ts
+++ b/apps/api/src/services/mfaEnrollmentSession.test.ts
@@ -41,7 +41,7 @@ vi.mock('./remoteSessionTeardown', () => ({
   terminateUserRemoteSessions: terminateUserRemoteSessionsMock,
 }));
 
-import { completeInitialMfaEnrollment, replaceSessionOnMfaFactorWrite } from './mfaEnrollmentSession';
+import { completeInitialMfaEnrollment, completeMfaFactorRemoval, replaceSessionOnMfaFactorWrite } from './mfaEnrollmentSession';
 import type { AuthIssuanceCapability } from './authBrowserTransition';
 import { EpochAdvancePreconditionError } from './authLifecycle';
 import type { AuthorizedUserSession, UserSessionIdentity } from './userSession';
@@ -169,7 +169,7 @@ describe('completeInitialMfaEnrollment', () => {
       recoveryCodes: ['code-1', 'code-2'],
       recoveryCodeHashes: ['hash-1'],
       persistFactor: vi.fn(),
-    })).rejects.toThrow(/count/i);
+    } as never)).rejects.toThrow(/count/i);
 
     expect(finishAuthIssuanceMock).not.toHaveBeenCalled();
   });
@@ -451,13 +451,12 @@ describe('replaceSessionOnMfaFactorWrite — factor removal with no recovery cod
       return undefined;
     });
 
-    const result = await replaceSessionOnMfaFactorWrite({
+    const result = await completeMfaFactorRemoval({
       userId: identity.userId,
       identity,
       capability,
       expectedAuthEpoch: 3,
       expectedMfaEpoch: 7,
-      expectedMfaEnabled: true,
       revokeReason: 'mfa-disable',
       persistFactor,
     });
@@ -478,11 +477,35 @@ describe('replaceSessionOnMfaFactorWrite — factor removal with no recovery cod
       expectedEpochs: { authEpoch: 3, mfaEpoch: 8 },
     });
     expect(result.recoveryCodes).toEqual([]);
+    // The wrapper, not the caller, fixes the precondition: the factor must still
+    // exist when the bump lands.
+    expect(advanceUserEpochsMock).toHaveBeenCalledWith(
+      tx, 'user-123', { mfa: true }, expect.objectContaining({ mfaEnabled: true }),
+    );
+
     expect(result.issued).toBe(issued);
     // The replacement token must survive its own post-commit revocation cutoff.
     expect(runPostCommitCleanupMock).toHaveBeenCalledTimes(1);
     expect(runPostCommitCleanupMock.mock.calls[0]?.[1]?.preserveTokensIssuedAtOrAfter)
       .toBeLessThanOrEqual(Math.floor(Date.now() / 1000));
+  });
+
+  it('rejects a ROTATION that omits its code pair — omission is the removal shape only', async () => {
+    // #5008 review: making the pair optional on the shared primitive let a
+    // rotation caller forget it and silently persist [] — wiping the user's
+    // only lockout escape hatch. Removal must be an explicit call
+    // (completeMfaFactorRemoval), never an omitted argument.
+    await expect(replaceSessionOnMfaFactorWrite({
+      userId: 'user-123',
+      identity,
+      capability,
+      expectedAuthEpoch: 3,
+      expectedMfaEpoch: 7,
+      expectedMfaEnabled: true,
+      revokeReason: 'mfa_recovery_codes_rotated',
+      persistFactor: async () => undefined,
+    } as never)).rejects.toThrow(/recovery-code/i);
+    expect(finishAuthIssuanceMock).not.toHaveBeenCalled();
   });
 
   it('still rejects a supplied-but-empty code set', async () => {
@@ -497,7 +520,7 @@ describe('replaceSessionOnMfaFactorWrite — factor removal with no recovery cod
       recoveryCodes: [],
       recoveryCodeHashes: [],
       persistFactor: vi.fn(),
-    })).rejects.toThrow(/count/i);
+    } as never)).rejects.toThrow(/count/i);
 
     expect(finishAuthIssuanceMock).not.toHaveBeenCalled();
   });
@@ -513,7 +536,7 @@ describe('replaceSessionOnMfaFactorWrite — factor removal with no recovery cod
       revokeReason: 'mfa-recovery-rotate',
       recoveryCodes: ['code-1'],
       persistFactor: vi.fn(),
-    })).rejects.toThrow(/count/i);
+    } as never)).rejects.toThrow(/count/i);
 
     expect(finishAuthIssuanceMock).not.toHaveBeenCalled();
   });
@@ -527,7 +550,7 @@ describe('replaceSessionOnMfaFactorWrite — factor removal with no recovery cod
       expectedMfaEpoch: 7,
       revokeReason: 'initial-mfa-enrollment',
       persistFactor: vi.fn(),
-    })).rejects.toThrow(/recovery-code/i);
+    } as never)).rejects.toThrow(/recovery-code/i);
 
     expect(finishAuthIssuanceMock).not.toHaveBeenCalled();
   });

--- a/apps/api/src/services/mfaEnrollmentSession.ts
+++ b/apps/api/src/services/mfaEnrollmentSession.ts
@@ -90,12 +90,14 @@ export interface MfaFactorSessionReplacement<T> {
  * when the response body carries a one-time secret the user has to read
  * (recovery codes, #4480): a caller signed out by its own request never sees it.
  *
- * Three shapes call this, differing only in `expectedMfaEnabled` and whether a
- * code set accompanies the write: initial enrollment (factor must not exist yet,
- * codes required), rotation on a protected account (factor must still exist,
- * codes required), and factor REMOVAL (factor must still exist, no codes — a
- * self-disable that evicted its own caller bounced the user to
- * /login?reason=session-expired the moment they turned MFA off, #4934).
+ * Three shapes exist, differing only in `expectedMfaEnabled` and whether a code
+ * set accompanies the write, and each has its own entry point: this function
+ * is ROTATION on a protected account (factor must still exist, codes required);
+ * `completeInitialMfaEnrollment` is INSTALL (factor must not exist yet, codes
+ * required); `completeMfaFactorRemoval` is REMOVAL (factor must still exist, no
+ * codes — a self-disable that evicted its own caller bounced the user to
+ * /login?reason=session-expired the moment they turned MFA off, #4934). All
+ * three funnel into the same private core.
  *
  * Expensive recovery-code generation and hashing belong before this call; every
  * authority-bearing write happens inside finishAuthIssuance's supplied
@@ -221,8 +223,13 @@ export async function completeInitialMfaEnrollment<T>(
   // codes it returns are the only escape hatch a user locked out of their own
   // factor has, and they exist exactly once. (An omitted pair is the
   // removal shape — `completeMfaFactorRemoval`, #4934 — never this one.)
-  if (input.recoveryCodes === undefined || input.recoveryCodes.length === 0) {
-    throw new Error('Initial MFA enrollment must install a recovery-code set');
+  if (
+    input.recoveryCodes === undefined
+    || input.recoveryCodes.length === 0
+    || input.recoveryCodeHashes === undefined
+    || input.recoveryCodeHashes.length !== input.recoveryCodes.length
+  ) {
+    throw new Error('Initial MFA enrollment must install a count-matched recovery-code set');
   }
   return replaceSessionOnMfaFactorWriteCore({ ...input, expectedMfaEnabled: false, factorWrite: 'install' });
 }

--- a/apps/api/src/services/mfaEnrollmentSession.ts
+++ b/apps/api/src/services/mfaEnrollmentSession.ts
@@ -39,20 +39,37 @@ export interface ReplaceSessionOnMfaFactorWriteInput<T> {
   revokeReason: string;
   /**
    * The plaintext codes to hand back to the caller, paired one-for-one with
-   * `recoveryCodeHashes` (which is what actually lands in the row). OMIT both
-   * for a factor REMOVAL (#4934 `/mfa/disable`): the account must be left
-   * holding no code set at all, and there is no one-time secret to reveal, so
-   * faking an empty pair would only obscure the caller's intent. Supplying one
-   * without the other, supplying an empty pair, or mismatching the counts is a
-   * caller bug and throws before finalization opens.
+   * `recoveryCodeHashes` (which is what actually lands in the row). REQUIRED
+   * and non-empty on this shape: a supplied set is the account's only valid
+   * one from this commit on, so an empty or missing pair would be a silent
+   * lockout. A factor REMOVAL (#4934 `/mfa/disable`) installs no codes and
+   * must go through `completeMfaFactorRemoval`, which omits these fields by
+   * TYPE rather than by convention — the #5008 review found that an optional
+   * pair here let a rotation caller forget it and persist `[]` unnoticed.
    */
-  recoveryCodes?: readonly string[];
-  recoveryCodeHashes?: readonly string[];
+  recoveryCodes: readonly string[];
+  recoveryCodeHashes: readonly string[];
   persistFactor: (tx: Tx, recoveryCodeHashes: readonly string[]) => Promise<T>;
 }
 
 export type CompleteInitialMfaEnrollmentInput<T> =
   Omit<ReplaceSessionOnMfaFactorWriteInput<T>, 'expectedMfaEnabled'>;
+
+/**
+ * Factor REMOVAL shape: the account is left holding no code set and there is
+ * no one-time secret to reveal, so the pair is absent from the type entirely.
+ * `expectedMfaEnabled` is fixed at `true` — removing a factor that is not there
+ * is a precondition failure, not a no-op.
+ */
+export type CompleteMfaFactorRemovalInput<T> = Omit<
+  ReplaceSessionOnMfaFactorWriteInput<T>,
+  'expectedMfaEnabled' | 'recoveryCodes' | 'recoveryCodeHashes'
+>;
+
+/** Internal: the union both public entry points funnel into. */
+type MfaFactorWriteCoreInput<T> =
+  | (ReplaceSessionOnMfaFactorWriteInput<T> & { factorWrite: 'install' | 'rotate' })
+  | (CompleteMfaFactorRemovalInput<T> & { expectedMfaEnabled: true; factorWrite: 'remove' });
 
 export interface MfaFactorSessionReplacement<T> {
   value: T;
@@ -91,23 +108,49 @@ export interface MfaFactorSessionReplacement<T> {
 export async function replaceSessionOnMfaFactorWrite<T>(
   input: ReplaceSessionOnMfaFactorWriteInput<T>,
 ): Promise<MfaFactorSessionReplacement<T>> {
+  // Rotation shape (and, via completeInitialMfaEnrollment, install): the code
+  // pair is mandatory. Checked at runtime too, since JS callers can still pass
+  // `undefined` past the type.
+  const codes = (input as { recoveryCodes?: readonly string[] }).recoveryCodes;
+  const hashes = (input as { recoveryCodeHashes?: readonly string[] }).recoveryCodeHashes;
+  if (codes === undefined || hashes === undefined || codes.length === 0 || codes.length !== hashes.length) {
+    throw new Error(
+      'A factor rotation must supply a non-empty, count-matched recovery-code pair; use completeMfaFactorRemoval to remove a factor',
+    );
+  }
+  return replaceSessionOnMfaFactorWriteCore({ ...input, factorWrite: 'rotate' });
+}
+
+/**
+ * Factor-removal specialization (#4934 `/mfa/disable`): the account must still
+ * be protected when the bump lands, no code set is installed, and the caller's
+ * own assurance is carried forward. The only sanctioned way to call the
+ * primitive without recovery codes.
+ */
+export async function completeMfaFactorRemoval<T>(
+  input: CompleteMfaFactorRemovalInput<T>,
+): Promise<MfaFactorSessionReplacement<T>> {
+  if ('recoveryCodes' in input || 'recoveryCodeHashes' in input) {
+    throw new Error('A factor removal installs no recovery codes; use replaceSessionOnMfaFactorWrite to rotate them');
+  }
+  return replaceSessionOnMfaFactorWriteCore({ ...input, expectedMfaEnabled: true, factorWrite: 'remove' });
+}
+
+async function replaceSessionOnMfaFactorWriteCore<T>(
+  input: MfaFactorWriteCoreInput<T>,
+): Promise<MfaFactorSessionReplacement<T>> {
   if (input.identity.userId !== input.userId) {
     throw new Error('Factor-write identity does not match the target user');
   }
-  const recoveryCodes = input.recoveryCodes ?? [];
-  const recoveryCodeHashes = input.recoveryCodeHashes ?? [];
+  const recoveryCodes = input.factorWrite === 'remove' ? [] : input.recoveryCodes;
+  const recoveryCodeHashes = input.factorWrite === 'remove' ? [] : input.recoveryCodeHashes;
   if (
     !Number.isInteger(input.expectedAuthEpoch)
     || input.expectedAuthEpoch < 0
     || !Number.isInteger(input.expectedMfaEpoch)
     || input.expectedMfaEpoch < 0
-    // The pair is all-or-nothing: a caller that generated codes must hand over
-    // the hashes too, and a removal omits both.
-    || (input.recoveryCodes === undefined) !== (input.recoveryCodeHashes === undefined)
     || recoveryCodes.length !== recoveryCodeHashes.length
-    // A SUPPLIED set is the account's only valid one from this commit on, so an
-    // empty pair would be a silent lockout. A removal omits the fields instead.
-    || (input.recoveryCodes !== undefined && recoveryCodes.length === 0)
+    || (input.factorWrite !== 'remove' && recoveryCodes.length === 0)
   ) {
     throw new Error('Expected auth/MFA epochs and recovery-code counts must be valid');
   }
@@ -176,10 +219,10 @@ export async function completeInitialMfaEnrollment<T>(
   }
   // Enrollment is the one factor write that must never omit its code set: the
   // codes it returns are the only escape hatch a user locked out of their own
-  // factor has, and they exist exactly once. (`replaceSessionOnMfaFactorWrite`
-  // itself allows an omitted pair — that is the removal shape, #4934.)
+  // factor has, and they exist exactly once. (An omitted pair is the
+  // removal shape — `completeMfaFactorRemoval`, #4934 — never this one.)
   if (input.recoveryCodes === undefined || input.recoveryCodes.length === 0) {
     throw new Error('Initial MFA enrollment must install a recovery-code set');
   }
-  return replaceSessionOnMfaFactorWrite({ ...input, expectedMfaEnabled: false });
+  return replaceSessionOnMfaFactorWriteCore({ ...input, expectedMfaEnabled: false, factorWrite: 'install' });
 }

--- a/apps/docs/src/content/docs/reference/users-and-roles.mdx
+++ b/apps/docs/src/content/docs/reference/users-and-roles.mdx
@@ -234,7 +234,7 @@ MFA verification is rate-limited separately from login.
 
 ### Disabling MFA
 
-Call `POST /auth/mfa/disable` with the current 6-digit code (TOTP or SMS depending on active method). This clears the MFA secret, phone number, and recovery codes. If the organisation enforces MFA, the endpoint returns `403`.
+Call `POST /auth/mfa/disable` with `currentPassword` and the current 6-digit code (TOTP or SMS depending on active method). This clears the MFA secret, phone number, and recovery codes. Every **other** session and refresh token for the user is revoked; the calling session is replaced in the same response (new access and refresh tokens, or refreshed cookies in the browser flow), so the user is not signed out by their own request. If the organisation enforces MFA, the endpoint returns `403`. A caller that cannot receive the replacement session (a bearer-only client with no device binding) receives `428`.
 
 ### Recovery Codes
 
@@ -520,7 +520,7 @@ Auth endpoints are mounted under `/api/v1/auth`. Public endpoints do not require
 | `POST` | `/auth/mfa/setup` | Authenticated | Begin TOTP MFA setup; returns QR code and recovery codes. |
 | `POST` | `/auth/mfa/verify` | Public/Auth | Verify an MFA code during login (with `tempToken`) or setup confirmation. |
 | `POST` | `/auth/mfa/enable` | Authenticated | Confirm MFA setup (frontend settings flow). |
-| `POST` | `/auth/mfa/disable` | Authenticated | Disable MFA (requires current code). |
+| `POST` | `/auth/mfa/disable` | Authenticated | Disable MFA (requires current password and code; revokes all other sessions, re-issues the caller's). |
 | `POST` | `/auth/mfa/recovery-codes` | Authenticated | Regenerate MFA recovery codes. |
 | `POST` | `/auth/phone/verify` | Authenticated | Send a phone verification SMS. |
 | `POST` | `/auth/phone/confirm` | Authenticated | Confirm phone verification code. |


### PR DESCRIPTION
## Summary
Follow-up from the post-merge review of #5008.

That PR made `recoveryCodes`/`recoveryCodeHashes` optional on the shared `replaceSessionOnMfaFactorWrite` primitive so `/mfa/disable` could omit them. Side effect: a **rotation** caller (`/mfa/recovery-codes`) that forgets the pair now passes validation and `persistFactor` writes `mfaRecoveryCodes: []` — silently stripping the user's only lockout escape hatch. `expectedMfaEnabled: true` is shared by rotation and removal, so it could not discriminate.

## Change
- `replaceSessionOnMfaFactorWrite` (rotation): pair is **required and non-empty** again, by type and at runtime.
- New `completeMfaFactorRemoval`: the only sanctioned no-codes call. Its input type omits the code fields entirely and it fixes `expectedMfaEnabled: true` itself. `/mfa/disable` uses it.
- Both funnel into a private core with a `factorWrite: 'install' | 'rotate' | 'remove'` discriminator.
- Docs: `users-and-roles.mdx` now states `currentPassword` is required, that all other sessions are revoked and the caller's is re-issued, and the `428` for bearer-only clients (the OpenAPI spec already said so).

## Tests
- Red first: "rejects a ROTATION that omits its code pair" failed on main (promise resolved), green after.
- Removal test now asserts the wrapper pins `mfaEnabled: true` on the epoch bump.
- `mfaEnrollmentSession.test.ts` + `auth.test.ts` + `routes/auth/*`: 629/629 across 25 files. `tsc --noEmit` clean.

Not in scope (noted by the reviewer): `passkeys.ts` register/delete still use `invalidateMfaAssuranceAfterFactorChange` and evict the actor — same bug class as #4934, worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUsfUH7smCCDiSVrGFTasC