### PR TITLE
fix(devices): re-evaluate dynamic groups off the request path (#4630 review follow-up)

### DIFF
--- a/apps/api/src/__tests__/integration/dynamicGroupReevaluation.integration.test.ts
+++ b/apps/api/src/__tests__/integration/dynamicGroupReevaluation.integration.test.ts
@@ -30,16 +30,40 @@
  *   4. the processor uses the DEVICE's own org, not the job payload's, so a
  *      stale/forged payload cannot steer the evaluation at another tenant.
  *   5. a matching device in another partner's org is never absorbed.
+ *   6. a device DELETED between enqueue and run no-ops (and that this is
+ *      distinguishable from "not committed yet" — see case 7).
+ *   7. #5039 review finding 1, the enqueue-before-commit race: the enqueue
+ *      happens INSIDE the caller's still-open transaction, so an undelayed
+ *      worker reads a snapshot without the device row and silently completes
+ *      having evaluated nothing. Driven end to end against real Redis with a
+ *      real BullMQ worker, with the undelayed behaviour as a paired negative
+ *      control in the same test.
  */
 import './setup';
 
-import { describe, expect, it } from 'vitest';
+import { afterAll, afterEach, describe, expect, it } from 'vitest';
 import { randomUUID } from 'crypto';
 import { and, eq } from 'drizzle-orm';
+import type { Worker } from 'bullmq';
 
 import { db, withSystemDbAccessContext } from '../../db';
-import { deviceGroupMemberships, deviceGroups, devices } from '../../db/schema';
-import { processDeviceGroupReevaluation } from '../../jobs/deviceGroupJobs';
+import {
+  deviceGroupMemberships,
+  deviceGroups,
+  devices,
+  groupMembershipLog,
+} from '../../db/schema';
+import {
+  DEVICE_GROUP_REEVALUATION_DELAY_MS,
+  createDeviceGroupReevaluationWorker,
+  deviceGroupReevaluationJobId,
+  getDeviceGroupReevaluationQueue,
+  processDeviceGroupReevaluation,
+  runDeviceGroupReevaluationJob,
+  scheduleDeviceGroupReevaluation,
+  shutdownDeviceGroupJobs,
+} from '../../jobs/deviceGroupJobs';
+import { closeRedis } from '../../services/redis';
 import {
   createOrganization,
   createPartner,
@@ -257,7 +281,55 @@ describe('dynamic device group re-evaluation on device change (#4630)', () => {
     expect(anyRowForForeign).toHaveLength(0);
   });
 
+  /**
+   * The `!device` branch means DELETED, not "committing right now".
+   *
+   * That distinction is only true because of `DEVICE_GROUP_REEVALUATION_DELAY_MS`
+   * (#5039 review finding 1). Before the delay, the same branch also absorbed a
+   * device whose INSERT had not committed yet — the enrolment path — and
+   * reported `{evaluated: false}` as a SUCCESS, so nothing retried and the
+   * device was never added to any dynamic group. Case 7 below proves the
+   * not-yet-committed device now IS evaluated, which is what makes it safe for
+   * this branch to treat a missing row as a genuine deletion.
+   */
   runDb('no-ops for a device deleted between enqueue and run', async () => {
+    const env = await setupTestEnvironment();
+    const groupId = await seedDynamicGroup(env.organization.id);
+    const deviceId = await seedDevice(env.organization.id, env.site.id, 'srv-epsilon');
+
+    // It matched and was a member before the delete.
+    await runReevaluation({
+      deviceId,
+      orgId: env.organization.id,
+      eventType: 'device.updated',
+      changedFields: ['hostname'],
+    });
+    expect(await memberDeviceIds(groupId)).toEqual([deviceId]);
+
+    // Delete it in the same order the device cascade does: children first.
+    // Neither device_group_memberships.device_id nor group_membership_log
+    // .device_id is ON DELETE CASCADE, so both have to go before the device
+    // (this is exactly why CORE_DEVICE_CASCADE_DELETE_TABLES exists).
+    await withSystemDbAccessContext(async () => {
+      await db.delete(groupMembershipLog).where(eq(groupMembershipLog.deviceId, deviceId));
+      await db.delete(deviceGroupMemberships).where(eq(deviceGroupMemberships.deviceId, deviceId));
+      await db.delete(devices).where(eq(devices.id, deviceId));
+    });
+
+    const result = await runReevaluation({
+      deviceId,
+      orgId: env.organization.id,
+      eventType: 'device.updated',
+      changedFields: ['hostname'],
+    });
+
+    expect(result).toEqual({ evaluated: false, orgId: null });
+    expect(await memberDeviceIds(groupId)).toEqual([]);
+  });
+
+  // A device id that never existed takes the same branch — there is nothing to
+  // evaluate either way.
+  runDb('no-ops for a device id that never existed', async () => {
     const env = await setupTestEnvironment();
     await seedDynamicGroup(env.organization.id);
 
@@ -270,4 +342,171 @@ describe('dynamic device group re-evaluation on device change (#4630)', () => {
 
     expect(result).toEqual({ evaluated: false, orgId: null });
   });
+});
+
+/**
+ * #5039 review finding 1 — the enqueue-before-commit race, end to end against
+ * real Redis + real Postgres with a real BullMQ worker.
+ *
+ * Every producer (`/enroll`, `/provision`, the heartbeat) calls
+ * `requestDeviceGroupReevaluation` from INSIDE its own still-open
+ * `withDbAccessContext` / `withSystemDbAccessContext` transaction — that is the
+ * point of the queue. The worker runs on a different pooled connection, so
+ * without a delay it can start before the producer commits and read a snapshot
+ * in which the device row does not exist. That is not an error: it is
+ * `{evaluated: false}`, a COMPLETED job, no retry, and a device that is never
+ * added to any dynamic group.
+ *
+ * This is the only place in the file that goes through the real queue. Every
+ * other case calls `processDeviceGroupReevaluation` directly, which cannot
+ * observe the delay — or the race — at all.
+ */
+describe('enqueue-before-commit race (#5039)', () => {
+  const workers: Worker[] = [];
+
+  afterEach(async () => {
+    await Promise.all(workers.splice(0).map((w) => w.close()));
+    // Delayed jobs outlive the test's TRUNCATE; drop them so a later case
+    // cannot be woken by one.
+    await getDeviceGroupReevaluationQueue().obliterate({ force: true }).catch(() => {});
+  });
+
+  afterAll(async () => {
+    await shutdownDeviceGroupJobs();
+    await closeRedis();
+  });
+
+  runDb('evaluates a device whose INSERT commits only after the enqueue', async () => {
+    const env = await setupTestEnvironment();
+    const groupId = await seedDynamicGroup(env.organization.id);
+    const deviceId = randomUUID();
+
+    // The worker is running BEFORE the enqueue, so it has every opportunity to
+    // pick the job up the instant it becomes runnable. Anything that stops it
+    // from doing so is the delay, not a slow test.
+    const worker = createDeviceGroupReevaluationWorker();
+    workers.push(worker);
+    await worker.waitUntilReady();
+
+    const completed = new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error('re-evaluation job never completed')),
+        DEVICE_GROUP_REEVALUATION_DELAY_MS + 20_000,
+      );
+      worker.on('completed', (job) => {
+        if (job.data?.deviceId !== deviceId) return;
+        clearTimeout(timer);
+        resolve();
+      });
+    });
+
+    let releaseCommit!: () => void;
+    const commitGate = new Promise<void>((resolve) => { releaseCommit = resolve; });
+    let markEnqueued!: () => void;
+    const enqueued = new Promise<void>((resolve) => { markEnqueued = resolve; });
+
+    // Stand in for the /enroll handler: INSERT the device and enqueue, both
+    // inside one transaction that stays open for a while afterwards (the real
+    // handler goes on to issue an mTLS certificate).
+    const enrolment = withSystemDbAccessContext(async () => {
+      await db.insert(devices).values({
+        id: deviceId,
+        orgId: env.organization.id,
+        siteId: env.site.id,
+        agentId: `agent-${randomUUID()}`,
+        hostname: 'srv-uncommitted',
+        osType: 'windows',
+        osVersion: '10',
+        architecture: 'amd64',
+        agentVersion: '1.0.0',
+        status: 'online',
+      });
+
+      await scheduleDeviceGroupReevaluation({
+        deviceId,
+        orgId: env.organization.id,
+        eventType: 'device.created',
+        reason: 'device_enrolled',
+      });
+
+      markEnqueued();
+      await commitGate;
+    });
+
+    let sawUncommitted: { evaluated: boolean; orgId: string | null } | undefined;
+    try {
+      await enqueued;
+
+      // NEGATIVE CONTROL. Deliberately run from the TEST BODY, outside the
+      // enrolment's async-local DB context, so this opens its own transaction
+      // on its own pooled connection — a nested withSystemDbAccessContext
+      // would reuse the caller's transaction and see the uncommitted row,
+      // which is exactly the thing the real worker cannot do. This is what the
+      // worker would have concluded had the job been runnable immediately: the
+      // bug, reproduced.
+      sawUncommitted = await runDeviceGroupReevaluationJob({
+        type: 'group-reevaluation',
+        deviceId,
+        orgId: env.organization.id,
+        eventType: 'device.created',
+        changedFields: [],
+        reason: 'negative-control',
+        queuedAt: new Date().toISOString(),
+      });
+
+      // Give the ready worker a real chance to grab the job early.
+      await new Promise((resolve) => setTimeout(resolve, 750));
+
+      const job = await getDeviceGroupReevaluationQueue()
+        .getJob(deviceGroupReevaluationJobId(deviceId));
+      expect(job, 'the job should be queued').toBeDefined();
+      expect(job!.opts.delay).toBe(DEVICE_GROUP_REEVALUATION_DELAY_MS);
+      // Still parked: the running worker has NOT been able to take it.
+      expect(await job!.getState()).toBe('delayed');
+      expect(await memberDeviceIds(groupId)).toEqual([]);
+    } finally {
+      releaseCommit();
+      await enrolment;
+    }
+
+    // The bug, as it would have happened without the delay.
+    expect(sawUncommitted).toEqual({ evaluated: false, orgId: null });
+
+    // And the fix: once the delay elapses the device is visible and evaluated.
+    await completed;
+    expect(await memberDeviceIds(groupId)).toEqual([deviceId]);
+  }, DEVICE_GROUP_REEVALUATION_DELAY_MS + 45_000);
+
+  runDb('coalesces a second change into the still-delayed job', async () => {
+    // The delay window doubles as the coalescing window, so `delayed` has to
+    // stay in isReusableState — otherwise every change inside the window would
+    // add a duplicate job instead of merging.
+    const env = await setupTestEnvironment();
+    await seedDynamicGroup(env.organization.id);
+    const deviceId = await seedDevice(env.organization.id, env.site.id, 'wks-coalesce');
+
+    await scheduleDeviceGroupReevaluation({
+      deviceId,
+      orgId: env.organization.id,
+      eventType: 'device.updated',
+      changedFields: ['hostname'],
+      reason: 'heartbeat_device_change',
+    });
+    const secondId = await scheduleDeviceGroupReevaluation({
+      deviceId,
+      orgId: env.organization.id,
+      eventType: 'device.updated',
+      changedFields: ['osVersion'],
+      reason: 'heartbeat_device_change',
+    });
+
+    const jobId = deviceGroupReevaluationJobId(deviceId);
+    expect(secondId).toBe(jobId);
+
+    const job = await getDeviceGroupReevaluationQueue().getJob(jobId);
+    expect(await job!.getState()).toBe('delayed');
+    // Merged, not duplicated: one job carrying the union of both changes.
+    expect([...job!.data.changedFields].sort()).toEqual(['hostname', 'osVersion']);
+    expect(await getDeviceGroupReevaluationQueue().getDelayedCount()).toBe(1);
+  }, 30_000);
 });

--- a/apps/api/src/__tests__/integration/dynamicGroupReevaluation.integration.test.ts
+++ b/apps/api/src/__tests__/integration/dynamicGroupReevaluation.integration.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Real-Postgres proof that a DEVICE ATTRIBUTE CHANGE flips dynamic group
+ * membership — the actual thing #4630 asked for, in both directions.
+ *
+ * Why a real database is mandatory here. Every unit test on this path mocks
+ * either `services/groupMembership` or `events/deviceEvents`, so the whole
+ * chain reduces to "a vi.fn() was called with the right arguments". The two
+ * ways this feature silently does nothing are invisible to that:
+ *
+ *   1. RLS. `device_groups` is FORCE ROW LEVEL SECURITY under the
+ *      unprivileged `breeze_app` role, so a re-evaluation that runs with no DB
+ *      access context reads ZERO dynamic groups and reports a perfectly happy
+ *      `{evaluatedGroups: 0}` — no error, no log, no membership change. A mock
+ *      returns whatever rows it was handed regardless of context.
+ *   2. The filter engine. `deviceMatchesFilter` compiles the stored
+ *      filterConditions to SQL; whether `hostname startsWith 'srv-'` actually
+ *      matches the row after an UPDATE is a Postgres question, not a
+ *      TypeScript one.
+ *
+ * So this drives the REAL queue processor (`processDeviceGroupReevaluation`,
+ * the function the BullMQ worker runs) against real Postgres, real RLS and the
+ * real filter engine — mutating device rows exactly the way a heartbeat does
+ * and asserting the membership table afterwards.
+ *
+ * Coverage:
+ *   1. add — a device whose hostname starts matching the filter gains a row.
+ *   2. remove — the same device losing the match has its row deleted.
+ *   3. device.created — a device that already matched at insert is picked up
+ *      without waiting for a change (the enrollment/provision path).
+ *   4. the processor uses the DEVICE's own org, not the job payload's, so a
+ *      stale/forged payload cannot steer the evaluation at another tenant.
+ *   5. a matching device in another partner's org is never absorbed.
+ */
+import './setup';
+
+import { describe, expect, it } from 'vitest';
+import { randomUUID } from 'crypto';
+import { and, eq } from 'drizzle-orm';
+
+import { db, withSystemDbAccessContext } from '../../db';
+import { deviceGroupMemberships, deviceGroups, devices } from '../../db/schema';
+import { processDeviceGroupReevaluation } from '../../jobs/deviceGroupJobs';
+import {
+  createOrganization,
+  createPartner,
+  createSite,
+  setupTestEnvironment,
+} from './db-utils';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+/** `hostname startsWith 'srv-'` — a filter a heartbeat's hostname change can flip. */
+const SERVER_HOSTNAME_FILTER = {
+  operator: 'AND' as const,
+  conditions: [{ field: 'hostname', operator: 'startsWith', value: 'srv-' }],
+};
+
+async function seedDevice(orgId: string, siteId: string, hostname: string): Promise<string> {
+  return withSystemDbAccessContext(async () => {
+    const [row] = await db
+      .insert(devices)
+      .values({
+        orgId,
+        siteId,
+        agentId: `agent-${randomUUID()}`,
+        hostname,
+        osType: 'windows',
+        osVersion: '10',
+        architecture: 'amd64',
+        agentVersion: '1.0.0',
+        status: 'online',
+      })
+      .returning({ id: devices.id });
+    return row!.id;
+  });
+}
+
+async function seedDynamicGroup(orgId: string): Promise<string> {
+  return withSystemDbAccessContext(async () => {
+    const [row] = await db
+      .insert(deviceGroups)
+      .values({
+        orgId,
+        name: `servers ${randomUUID().slice(0, 8)}`,
+        type: 'dynamic',
+        filterConditions: SERVER_HOSTNAME_FILTER,
+        filterFieldsUsed: ['hostname'],
+      })
+      .returning({ id: deviceGroups.id });
+    return row!.id;
+  });
+}
+
+/** Mutate the device the way the heartbeat handler's `UPDATE devices` does. */
+async function setHostname(deviceId: string, hostname: string): Promise<void> {
+  await withSystemDbAccessContext(async () => {
+    await db.update(devices).set({ hostname }).where(eq(devices.id, deviceId));
+  });
+}
+
+async function memberDeviceIds(groupId: string): Promise<string[]> {
+  const rows = await withSystemDbAccessContext(async () =>
+    db
+      .select({ deviceId: deviceGroupMemberships.deviceId })
+      .from(deviceGroupMemberships)
+      .where(eq(deviceGroupMemberships.groupId, groupId)),
+  );
+  return rows.map((r) => r.deviceId).sort();
+}
+
+/**
+ * Run the job body exactly as `createDeviceGroupReevaluationWorker` does:
+ * inside a system DB access context, from the queue payload.
+ */
+async function runReevaluation(payload: {
+  deviceId: string;
+  orgId: string;
+  eventType: 'device.created' | 'device.updated';
+  changedFields?: string[];
+}) {
+  return withSystemDbAccessContext(() =>
+    processDeviceGroupReevaluation({
+      type: 'group-reevaluation',
+      deviceId: payload.deviceId,
+      orgId: payload.orgId,
+      eventType: payload.eventType,
+      changedFields: payload.changedFields ?? [],
+      reason: 'integration-test',
+      queuedAt: new Date().toISOString(),
+    }),
+  );
+}
+
+describe('dynamic device group re-evaluation on device change (#4630)', () => {
+  runDb('adds the device when a hostname change starts matching the filter', async () => {
+    const env = await setupTestEnvironment();
+    const groupId = await seedDynamicGroup(env.organization.id);
+    const deviceId = await seedDevice(env.organization.id, env.site.id, 'wks-alpha');
+
+    // Baseline: the device does not match, so re-evaluating changes nothing.
+    await runReevaluation({
+      deviceId,
+      orgId: env.organization.id,
+      eventType: 'device.updated',
+      changedFields: ['hostname'],
+    });
+    expect(await memberDeviceIds(groupId)).toEqual([]);
+
+    // The heartbeat's own UPDATE, then the queued re-evaluation.
+    await setHostname(deviceId, 'srv-alpha');
+    const result = await runReevaluation({
+      deviceId,
+      orgId: env.organization.id,
+      eventType: 'device.updated',
+      changedFields: ['hostname'],
+    });
+
+    expect(result).toEqual({ evaluated: true, orgId: env.organization.id });
+    expect(await memberDeviceIds(groupId)).toEqual([deviceId]);
+  });
+
+  runDb('removes the device when a hostname change stops matching the filter', async () => {
+    const env = await setupTestEnvironment();
+    const groupId = await seedDynamicGroup(env.organization.id);
+    const deviceId = await seedDevice(env.organization.id, env.site.id, 'srv-beta');
+
+    await runReevaluation({
+      deviceId,
+      orgId: env.organization.id,
+      eventType: 'device.updated',
+      changedFields: ['hostname'],
+    });
+    expect(await memberDeviceIds(groupId)).toEqual([deviceId]);
+
+    // Renamed out of the filter — the membership must not survive.
+    await setHostname(deviceId, 'wks-beta');
+    await runReevaluation({
+      deviceId,
+      orgId: env.organization.id,
+      eventType: 'device.updated',
+      changedFields: ['hostname'],
+    });
+
+    expect(await memberDeviceIds(groupId)).toEqual([]);
+  });
+
+  runDb('picks up a device that already matched at insert (device.created)', async () => {
+    // The enrollment/provision path: hostname is already correct at insert, so
+    // no later heartbeat diff would ever fire for this device.
+    const env = await setupTestEnvironment();
+    const groupId = await seedDynamicGroup(env.organization.id);
+    const deviceId = await seedDevice(env.organization.id, env.site.id, 'srv-gamma');
+
+    await runReevaluation({ deviceId, orgId: env.organization.id, eventType: 'device.created' });
+
+    expect(await memberDeviceIds(groupId)).toEqual([deviceId]);
+  });
+
+  runDb('evaluates against the DEVICE\'s org, not the org named in the job payload', async () => {
+    // The job outlives the request that produced it. A membership row stamped
+    // from a stale or forged payload org would be a cross-tenant row, so the
+    // processor re-reads the device's own org id.
+    const env = await setupTestEnvironment();
+    const groupId = await seedDynamicGroup(env.organization.id);
+    const deviceId = await seedDevice(env.organization.id, env.site.id, 'srv-delta');
+
+    const foreignPartner = await createPartner();
+    const foreignOrg = await createOrganization({ partnerId: foreignPartner.id });
+
+    const result = await runReevaluation({
+      deviceId,
+      orgId: foreignOrg.id, // wrong on purpose
+      eventType: 'device.updated',
+      changedFields: ['hostname'],
+    });
+
+    expect(result.orgId).toBe(env.organization.id);
+    const rows = await withSystemDbAccessContext(async () =>
+      db
+        .select({ deviceId: deviceGroupMemberships.deviceId, orgId: deviceGroupMemberships.orgId })
+        .from(deviceGroupMemberships)
+        .where(eq(deviceGroupMemberships.groupId, groupId)),
+    );
+    expect(rows.map((r) => r.deviceId)).toEqual([deviceId]);
+    // Every row carries the GROUP's own org, never the payload's.
+    expect(rows[0]!.orgId).toBe(env.organization.id);
+  });
+
+  runDb('never absorbs a matching device from another tenant', async () => {
+    const env = await setupTestEnvironment();
+    const groupId = await seedDynamicGroup(env.organization.id);
+
+    const foreignPartner = await createPartner();
+    const foreignOrg = await createOrganization({ partnerId: foreignPartner.id });
+    const foreignSite = await createSite({ orgId: foreignOrg.id });
+    const foreignDevice = await seedDevice(foreignOrg.id, foreignSite.id, 'srv-foreign');
+
+    // Re-evaluating the foreign device names org A's group nowhere, and org A's
+    // group is not in the foreign device's org, so nothing is written at all.
+    await runReevaluation({
+      deviceId: foreignDevice,
+      orgId: foreignOrg.id,
+      eventType: 'device.updated',
+      changedFields: ['hostname'],
+    });
+
+    expect(await memberDeviceIds(groupId)).toEqual([]);
+    const anyRowForForeign = await withSystemDbAccessContext(async () =>
+      db
+        .select({ groupId: deviceGroupMemberships.groupId })
+        .from(deviceGroupMemberships)
+        .where(and(
+          eq(deviceGroupMemberships.deviceId, foreignDevice),
+          eq(deviceGroupMemberships.groupId, groupId),
+        )),
+    );
+    expect(anyRowForForeign).toHaveLength(0);
+  });
+
+  runDb('no-ops for a device deleted between enqueue and run', async () => {
+    const env = await setupTestEnvironment();
+    await seedDynamicGroup(env.organization.id);
+
+    const result = await runReevaluation({
+      deviceId: randomUUID(),
+      orgId: env.organization.id,
+      eventType: 'device.updated',
+      changedFields: ['hostname'],
+    });
+
+    expect(result).toEqual({ evaluated: false, orgId: null });
+  });
+});

--- a/apps/api/src/__tests__/integration/dynamicGroupReevaluation.integration.test.ts
+++ b/apps/api/src/__tests__/integration/dynamicGroupReevaluation.integration.test.ts
@@ -433,7 +433,7 @@ describe('enqueue-before-commit race (#5039)', () => {
       await commitGate;
     });
 
-    let sawUncommitted: { evaluated: boolean; orgId: string | null } | undefined;
+    let sawUncommitted: unknown;
     try {
       await enqueued;
 
@@ -444,6 +444,9 @@ describe('enqueue-before-commit race (#5039)', () => {
       // which is exactly the thing the real worker cannot do. This is what the
       // worker would have concluded had the job been runnable immediately: the
       // bug, reproduced.
+      // Round 3: on device.created the processor THROWS for a missing row rather
+      // than completing — the retry is the safety net for an enrolment held
+      // open past the delay. Capture the rejection as the reproduced bug.
       sawUncommitted = await runDeviceGroupReevaluationJob({
         type: 'group-reevaluation',
         deviceId,
@@ -452,7 +455,10 @@ describe('enqueue-before-commit race (#5039)', () => {
         changedFields: [],
         reason: 'negative-control',
         queuedAt: new Date().toISOString(),
-      });
+      }).then(
+        () => 'resolved',
+        (error: unknown) => error,
+      );
 
       // Give the ready worker a real chance to grab the job early.
       await new Promise((resolve) => setTimeout(resolve, 750));
@@ -469,8 +475,10 @@ describe('enqueue-before-commit race (#5039)', () => {
       await enrolment;
     }
 
-    // The bug, as it would have happened without the delay.
-    expect(sawUncommitted).toEqual({ evaluated: false, orgId: null });
+    // The bug, as it would have happened without the delay: the row was not
+    // visible — and the processor refused to treat that as success.
+    expect(sawUncommitted).toBeInstanceOf(Error);
+    expect(String(sawUncommitted)).toMatch(/device\.created/);
 
     // And the fix: once the delay elapses the device is visible and evaluated.
     await completed;

--- a/apps/api/src/events/deviceEvents.test.ts
+++ b/apps/api/src/events/deviceEvents.test.ts
@@ -4,7 +4,9 @@
  *   - initializeDeviceEventHandlers wires one handler per DeviceChangeEventType
  *     to the correct groupMembership.ts function.
  *   - emitDeviceChange fans out to every registered handler and never lets one
- *     handler's rejection stop another (Promise.allSettled).
+ *     handler's rejection stop another (Promise.allSettled) — but SURFACES the
+ *     failures as an AggregateError so the BullMQ worker retries (#5039 review
+ *     finding 2: `attempts: 5` was dead code while this resolved).
  *   - mapChangedFieldsToFilterFields's field-name mapping used by the
  *     heartbeat/enrollment/provision emit sites.
  */
@@ -133,7 +135,17 @@ describe('deviceEvents', () => {
     onDeviceChange(eventType, failing);
     onDeviceChange(eventType, succeeding);
 
-    await emitDeviceChange(createDeviceChangeEvent(eventType, DEVICE_ID, ORG_ID, ['hostname']));
+    const original = console.error;
+    console.error = () => {};
+    try {
+      // Rejects (see the AggregateError case below) but only AFTER every
+      // handler has settled — that is the property under test here.
+      await expect(
+        emitDeviceChange(createDeviceChangeEvent(eventType, DEVICE_ID, ORG_ID, ['hostname'])),
+      ).rejects.toBeInstanceOf(AggregateError);
+    } finally {
+      console.error = original;
+    }
 
     expect(failing).toHaveBeenCalled();
     expect(succeeding).toHaveBeenCalled();
@@ -158,7 +170,9 @@ describe('deviceEvents', () => {
     const original = console.error;
     console.error = (...args: unknown[]) => { errors.push(args); };
     try {
-      await emitDeviceChange(createDeviceChangeEvent('device.metrics_updated', DEVICE_ID, ORG_ID, []));
+      await expect(
+        emitDeviceChange(createDeviceChangeEvent('device.metrics_updated', DEVICE_ID, ORG_ID, [])),
+      ).rejects.toThrow();
     } finally {
       console.error = original;
     }
@@ -168,6 +182,7 @@ describe('deviceEvents', () => {
     expect(String(errors[0]![0])).toContain(DEVICE_ID);
     expect(errors[0]![1]).toBe(boom);
   });
+
 
   it('does not log when every handler resolves', async () => {
     const errors: unknown[][] = [];
@@ -179,6 +194,97 @@ describe('deviceEvents', () => {
       console.error = original;
     }
     expect(errors).toHaveLength(0);
+  });
+});
+
+// #5039 review finding 2. Logging alone made `attempts: 5` on the re-evaluation
+// queue dead code: a transient 40P01 inside the evaluation completed the job
+// "successfully" and membership stayed stale forever. These cases run against a
+// RESET registry so the assertions are exact rather than "contains".
+describe('emitDeviceChange failure propagation (#5039)', () => {
+  beforeEach(() => {
+    resetDeviceEventHandlersForTests();
+    vi.clearAllMocks();
+    mockSelect.mockReturnValue(chainSelect([]));
+  });
+
+  it('throws an AggregateError carrying EVERY rejection so the BullMQ job retries', async () => {
+    const first = new Error('deadlock detected');
+    const second = new Error('filter exploded');
+    const survivor = vi.fn().mockResolvedValue(undefined);
+    onDeviceChange('device.metrics_updated', vi.fn().mockRejectedValue(first));
+    onDeviceChange('device.metrics_updated', vi.fn().mockRejectedValue(second));
+    onDeviceChange('device.metrics_updated', survivor);
+
+    const original = console.error;
+    console.error = () => {};
+    let raised: unknown;
+    try {
+      await emitDeviceChange(createDeviceChangeEvent('device.metrics_updated', DEVICE_ID, ORG_ID, []));
+    } catch (err) {
+      raised = err;
+    } finally {
+      console.error = original;
+    }
+
+    expect(raised).toBeInstanceOf(AggregateError);
+    expect((raised as AggregateError).errors).toEqual([first, second]);
+    expect(String((raised as Error).message)).toContain('device.metrics_updated');
+    // Still fanned out: the surviving handler ran despite the two rejections.
+    expect(survivor).toHaveBeenCalled();
+  });
+
+  it('resolves when every handler resolves', async () => {
+    onDeviceChange('device.metrics_updated', vi.fn().mockResolvedValue(undefined));
+    await expect(
+      emitDeviceChange(createDeviceChangeEvent('device.metrics_updated', DEVICE_ID, ORG_ID, [])),
+    ).resolves.toBeUndefined();
+  });
+
+  // The device.created handler evaluates every dynamic group in the org and
+  // deliberately continues past a failure. It must not SWALLOW them, or
+  // emitDeviceChange's throw above is inert for the whole enrolment/provision
+  // path — exactly where concurrent enrolments make a 40P01 most likely.
+  it('device.created evaluates every group and then rethrows the failures', async () => {
+    initializeDeviceEventHandlers();
+    mockSelect.mockReturnValue(chainSelect([{ id: 'group-1' }, { id: 'group-2' }, { id: 'group-3' }]));
+    const deadlock = new Error('deadlock detected');
+    mockEvaluateDeviceMembershipForGroup
+      .mockResolvedValueOnce({ evaluatedGroups: 1, added: 0, removed: 0 })
+      .mockRejectedValueOnce(deadlock)
+      .mockResolvedValueOnce({ evaluatedGroups: 1, added: 1, removed: 0 });
+
+    const original = console.error;
+    console.error = () => {};
+    let raised: unknown;
+    try {
+      await emitDeviceChange(createDeviceChangeEvent('device.created', DEVICE_ID, ORG_ID, []));
+    } catch (err) {
+      raised = err;
+    } finally {
+      console.error = original;
+    }
+
+    // group-3 was still evaluated despite group-2 blowing up...
+    expect(mockEvaluateDeviceMembershipForGroup).toHaveBeenCalledTimes(3);
+    expect(mockEvaluateDeviceMembershipForGroup).toHaveBeenLastCalledWith('group-3', DEVICE_ID);
+    // ...and the failure reached the worker instead of vanishing into a log.
+    // emitDeviceChange wraps the handler's own aggregate, so the deadlock is
+    // one level down: emit-aggregate -> created-handler aggregate -> 40P01.
+    expect(raised).toBeInstanceOf(AggregateError);
+    const handlerFailure = (raised as AggregateError).errors[0] as AggregateError;
+    expect(handlerFailure).toBeInstanceOf(AggregateError);
+    expect(handlerFailure.message).toContain('1 of 3 dynamic group evaluations');
+    expect(handlerFailure.errors).toEqual([deadlock]);
+  });
+
+  it('device.created resolves when every group evaluation succeeds', async () => {
+    initializeDeviceEventHandlers();
+    mockSelect.mockReturnValue(chainSelect([{ id: 'group-1' }, { id: 'group-2' }]));
+
+    await expect(
+      emitDeviceChange(createDeviceChangeEvent('device.created', DEVICE_ID, ORG_ID, [])),
+    ).resolves.toBeUndefined();
   });
 });
 

--- a/apps/api/src/events/deviceEvents.test.ts
+++ b/apps/api/src/events/deviceEvents.test.ts
@@ -42,24 +42,32 @@ import {
   initializeDeviceEventHandlers,
   mapChangedFieldsToFilterFields,
   onDeviceChange,
+  resetDeviceEventHandlersForTests,
   type DeviceChangeEventType,
 } from './deviceEvents';
 
 const DEVICE_ID = 'dddd0001-dddd-dddd-dddd-dddddddddddd';
 const ORG_ID = 'aaaa0000-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
 
+// The device.created group SELECT now ends in `.orderBy(deviceGroups.id)` (a
+// lock-order contract, #4630 review finding 2), so `where` has to be
+// thenable AND carry an orderBy that resolves to the same rows.
 function chainSelect(rows: unknown[]) {
+  const whereResult = {
+    orderBy: vi.fn().mockResolvedValue(rows),
+    then: (resolve: (value: unknown) => unknown) => Promise.resolve(rows).then(resolve),
+  };
   return {
     from: vi.fn().mockReturnValue({
-      where: vi.fn().mockResolvedValue(rows),
+      where: vi.fn().mockReturnValue(whereResult),
     }),
   };
 }
 
 describe('deviceEvents', () => {
-  // eventHandlers is a module-scope singleton with no reset hook, so this
-  // must register exactly once for the whole suite — calling it per-test
-  // would stack duplicate handlers on every DeviceChangeEventType.
+  // eventHandlers is a module-scope singleton. initializeDeviceEventHandlers is
+  // now idempotent (see its own test below), but registering once here still
+  // keeps the ad hoc handlers added by individual tests out of each other's way.
   beforeAll(() => {
     initializeDeviceEventHandlers();
   });
@@ -138,6 +146,61 @@ describe('deviceEvents', () => {
     await expect(
       emitDeviceChange(createDeviceChangeEvent('device.metrics_updated', DEVICE_ID, ORG_ID, ['cpuPercent'])),
     ).resolves.toBeUndefined();
+  });
+
+  // #4630 review finding 5: a permanently-throwing handler used to be swallowed
+  // whole by Promise.allSettled, so a dynamic group could go stale forever with
+  // nothing in the logs.
+  it('logs every rejected handler at error level', async () => {
+    const boom = new Error('evaluation exploded');
+    onDeviceChange('device.metrics_updated', vi.fn().mockRejectedValue(boom));
+    const errors: unknown[][] = [];
+    const original = console.error;
+    console.error = (...args: unknown[]) => { errors.push(args); };
+    try {
+      await emitDeviceChange(createDeviceChangeEvent('device.metrics_updated', DEVICE_ID, ORG_ID, []));
+    } finally {
+      console.error = original;
+    }
+
+    expect(errors).toHaveLength(1);
+    expect(String(errors[0]![0])).toContain('device.metrics_updated');
+    expect(String(errors[0]![0])).toContain(DEVICE_ID);
+    expect(errors[0]![1]).toBe(boom);
+  });
+
+  it('does not log when every handler resolves', async () => {
+    const errors: unknown[][] = [];
+    const original = console.error;
+    console.error = (...args: unknown[]) => { errors.push(args); };
+    try {
+      await emitDeviceChange(createDeviceChangeEvent('device.deleted', DEVICE_ID, ORG_ID, []));
+    } finally {
+      console.error = original;
+    }
+    expect(errors).toHaveLength(0);
+  });
+});
+
+describe('initializeDeviceEventHandlers idempotency (#4630)', () => {
+  // The BullMQ re-evaluation worker calls this on every job so a worker-role
+  // process (which never runs index.ts's bootstrap) has handlers at all. Without
+  // the guard that would stack a duplicate handler per job and evaluate each
+  // device N times.
+  beforeEach(() => {
+    resetDeviceEventHandlersForTests();
+    vi.clearAllMocks();
+    mockSelect.mockReturnValue(chainSelect([]));
+  });
+
+  it('registers each handler exactly once no matter how many times it is called', async () => {
+    initializeDeviceEventHandlers();
+    initializeDeviceEventHandlers();
+    initializeDeviceEventHandlers();
+
+    await emitDeviceChange(createDeviceChangeEvent('device.updated', DEVICE_ID, ORG_ID, ['hostname']));
+
+    expect(mockUpdateDeviceMemberships).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/api/src/events/deviceEvents.ts
+++ b/apps/api/src/events/deviceEvents.ts
@@ -46,15 +46,33 @@ export function onDeviceChange(eventType: DeviceChangeEventType, handler: Device
 }
 
 /**
- * Emit a device change event
+ * Emit a device change event.
+ *
+ * One handler's failure must not stop the others, but it must not vanish
+ * either: a permanently-throwing evaluation (a malformed filter, an RLS-blind
+ * context) would otherwise leave dynamic groups quietly stale with nothing in
+ * the logs — the #4630 failure mode all over again. Every rejection is logged
+ * at error level, and the emit still resolves so the caller (the BullMQ
+ * worker) treats the job as done rather than retrying a deterministic failure
+ * forever.
  */
 export async function emitDeviceChange(event: DeviceChangeEvent): Promise<void> {
   const handlers = eventHandlers.get(event.type) || [];
+  if (handlers.length === 0) return;
 
-  // Run all handlers (don't fail if one handler fails)
-  await Promise.allSettled(
+  const results = await Promise.allSettled(
     handlers.map(handler => handler(event))
   );
+
+  results.forEach((result, index) => {
+    if (result.status === 'rejected') {
+      console.error(
+        `[deviceEvents] handler #${index} for ${event.type} failed `
+        + `(device ${event.deviceId}, org ${event.orgId}):`,
+        result.reason,
+      );
+    }
+  });
 }
 
 /**
@@ -168,11 +186,22 @@ export function createDeviceChangeEvent(
   };
 }
 
+let handlersInitialized = false;
+
 /**
- * Initialize default event handlers
- * This should be called during app startup
+ * Initialize default event handlers.
+ *
+ * Called from `index.ts`'s bootstrap AND from the re-evaluation worker
+ * (`jobs/deviceGroupJobs.ts`), because a `worker`-role process never runs
+ * index.ts at all and would otherwise drain the queue with an empty registry —
+ * a silent no-op. Idempotent: `eventHandlers` is an append-only module
+ * singleton, so a second unguarded call would double-register every handler and
+ * evaluate each device twice.
  */
 export function initializeDeviceEventHandlers(): void {
+  if (handlersInitialized) return;
+  handlersInitialized = true;
+
   // Handler for device updates - re-evaluate group memberships
   onDeviceChange('device.updated', async (event) => {
     if (event.changedFields.length > 0) {
@@ -214,6 +243,11 @@ export function initializeDeviceEventHandlers(): void {
   // Handler for device creation - add to matching dynamic groups
   onDeviceChange('device.created', async (event) => {
     // Get all dynamic groups for the org and evaluate membership
+    // ORDER BY id: evaluateDeviceMembershipForGroup can UPDATE device_groups
+    // (ensureFilterFieldsUsed backfilling filter_fields_used), so two
+    // concurrent evaluations touching the same pair of groups in opposite
+    // orders deadlock (40P01, the #3911 shape). A stable id order makes every
+    // evaluator acquire the group row locks in the same sequence.
     const groups = await db
       .select({ id: deviceGroups.id })
       .from(deviceGroups)
@@ -221,7 +255,8 @@ export function initializeDeviceEventHandlers(): void {
         sql`${deviceGroups.orgId} = ${event.orgId}
           AND ${deviceGroups.type} = 'dynamic'
           AND ${deviceGroups.filterConditions} IS NOT NULL`
-      );
+      )
+      .orderBy(deviceGroups.id);
 
     for (const group of groups) {
       try {
@@ -237,4 +272,13 @@ export function initializeDeviceEventHandlers(): void {
   onDeviceChange('device.deleted', async (event) => {
     await removeDeviceFromAllGroups(event.deviceId);
   });
+}
+
+/**
+ * Test-only: drop every registered handler and re-arm
+ * `initializeDeviceEventHandlers`. Production code must never call this.
+ */
+export function resetDeviceEventHandlersForTests(): void {
+  eventHandlers.clear();
+  handlersInitialized = false;
 }

--- a/apps/api/src/events/deviceEvents.ts
+++ b/apps/api/src/events/deviceEvents.ts
@@ -48,13 +48,20 @@ export function onDeviceChange(eventType: DeviceChangeEventType, handler: Device
 /**
  * Emit a device change event.
  *
- * One handler's failure must not stop the others, but it must not vanish
- * either: a permanently-throwing evaluation (a malformed filter, an RLS-blind
- * context) would otherwise leave dynamic groups quietly stale with nothing in
- * the logs — the #4630 failure mode all over again. Every rejection is logged
- * at error level, and the emit still resolves so the caller (the BullMQ
- * worker) treats the job as done rather than retrying a deterministic failure
- * forever.
+ * One handler's failure must not stop the others — every handler is run to
+ * completion via `Promise.allSettled` and every rejection is logged at error
+ * level — but the failure must not vanish either. This used to RESOLVE after
+ * logging, which made `attempts: 5` on the re-evaluation queue dead code: a
+ * transient 40P01 deadlock inside the evaluation (the #3911 shape, which this
+ * path can genuinely produce because `evaluateDeviceMembershipForGroup` writes
+ * `device_groups.filter_fields_used`) completed the job "successfully" and the
+ * membership stayed stale forever with only a log line.
+ *
+ * So it now THROWS an `AggregateError` carrying every rejection once all
+ * handlers have settled. Its only caller is the BullMQ processor
+ * (`jobs/deviceGroupJobs.ts`), so a throw here is exactly what makes BullMQ
+ * retry with backoff, and a genuinely deterministic failure still terminates
+ * after `attempts` and is retained by `removeOnFail` for inspection.
  */
 export async function emitDeviceChange(event: DeviceChangeEvent): Promise<void> {
   const handlers = eventHandlers.get(event.type) || [];
@@ -64,6 +71,7 @@ export async function emitDeviceChange(event: DeviceChangeEvent): Promise<void> 
     handlers.map(handler => handler(event))
   );
 
+  const failures: Error[] = [];
   results.forEach((result, index) => {
     if (result.status === 'rejected') {
       console.error(
@@ -71,8 +79,22 @@ export async function emitDeviceChange(event: DeviceChangeEvent): Promise<void> 
         + `(device ${event.deviceId}, org ${event.orgId}):`,
         result.reason,
       );
+      failures.push(asError(result.reason));
     }
   });
+
+  if (failures.length > 0) {
+    throw new AggregateError(
+      failures,
+      `[deviceEvents] ${failures.length} of ${handlers.length} handler(s) for ${event.type} `
+      + `failed (device ${event.deviceId}, org ${event.orgId})`,
+    );
+  }
+}
+
+/** Normalise an unknown rejection reason into an Error for AggregateError. */
+function asError(reason: unknown): Error {
+  return reason instanceof Error ? reason : new Error(String(reason));
 }
 
 /**
@@ -258,13 +280,29 @@ export function initializeDeviceEventHandlers(): void {
       )
       .orderBy(deviceGroups.id);
 
+    // One malformed filter must not strand the remaining groups, so failures
+    // are collected rather than thrown immediately — but they are NOT
+    // swallowed. Swallowing here would defeat emitDeviceChange's throw above
+    // for the whole device.created path (enrollment + provisioning), which is
+    // precisely where a 40P01 deadlock is most likely: N concurrent enrolments
+    // in one org all UPDATE the same device_groups rows.
+    const failures: Error[] = [];
     for (const group of groups) {
       try {
         // Evaluate if device matches the group's filter
         await evaluateDeviceMembershipForGroup(group.id, event.deviceId);
       } catch (error) {
         console.error(`Failed to evaluate membership for group ${group.id}:`, error);
+        failures.push(asError(error));
       }
+    }
+
+    if (failures.length > 0) {
+      throw new AggregateError(
+        failures,
+        `device.created: ${failures.length} of ${groups.length} dynamic group evaluations `
+        + `failed for device ${event.deviceId} (org ${event.orgId})`,
+      );
     }
   });
 

--- a/apps/api/src/jobs/deviceGroupJobs.test.ts
+++ b/apps/api/src/jobs/deviceGroupJobs.test.ts
@@ -1,0 +1,286 @@
+/**
+ * #4630 review finding 1 — the dynamic-group re-evaluation moved off the
+ * request path onto a coalescing BullMQ queue. Covers:
+ *   - per-device coalescing under the fixed `group-reeval-<deviceId>` jobId,
+ *     including the union-merge of changed fields and the created-subsumes-
+ *     updated rule;
+ *   - the active-job follow-up branch and the stale-record replace branch;
+ *   - `requestDeviceGroupReevaluation` never rejecting (a Redis outage must
+ *     not surface on the agent heartbeat/enrollment path);
+ *   - the processor re-reading the device's OWN org id instead of trusting the
+ *     job payload, and no-oping for a device that vanished.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockQueueAdd,
+  mockQueueGetJob,
+  mockQueueClose,
+  mockSelect,
+  mockWithSystemDbAccessContext,
+  mockEmitDeviceChange,
+  mockInitializeDeviceEventHandlers,
+} = vi.hoisted(() => ({
+  mockQueueAdd: vi.fn(),
+  mockQueueGetJob: vi.fn(),
+  mockQueueClose: vi.fn().mockResolvedValue(undefined),
+  mockSelect: vi.fn(),
+  mockWithSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  mockEmitDeviceChange: vi.fn().mockResolvedValue(undefined),
+  mockInitializeDeviceEventHandlers: vi.fn(),
+}));
+
+vi.mock('bullmq', () => ({
+  // `new Queue(...)` needs a constructible mock — an arrow-function
+  // mockImplementation is not one.
+  Queue: class {
+    add = mockQueueAdd;
+    getJob = mockQueueGetJob;
+    close = mockQueueClose;
+  },
+  Worker: class {
+    on = vi.fn();
+    close = vi.fn().mockResolvedValue(undefined);
+  },
+  Job: class {},
+}));
+
+vi.mock('../services/redis', () => ({
+  getBullMQConnection: vi.fn(() => ({})),
+}));
+
+vi.mock('./workerObservability', () => ({
+  attachWorkerObservability: vi.fn(),
+}));
+
+vi.mock('../db', () => ({
+  db: { select: mockSelect },
+  withSystemDbAccessContext: mockWithSystemDbAccessContext,
+}));
+
+vi.mock('../db/schema', () => ({
+  devices: { id: 'id', orgId: 'orgId' },
+}));
+
+vi.mock('../events/deviceEvents', () => ({
+  emitDeviceChange: mockEmitDeviceChange,
+  initializeDeviceEventHandlers: mockInitializeDeviceEventHandlers,
+  createDeviceChangeEvent: (
+    type: string,
+    deviceId: string,
+    orgId: string,
+    changedFields: string[],
+  ) => ({ type, deviceId, orgId, changedFields, timestamp: new Date() }),
+}));
+
+import {
+  deviceGroupReevaluationJobId,
+  mergeReevaluationRequests,
+  processDeviceGroupReevaluation,
+  requestDeviceGroupReevaluation,
+  scheduleDeviceGroupReevaluation,
+  shutdownDeviceGroupJobs,
+  type DeviceGroupReevaluationJobData,
+} from './deviceGroupJobs';
+
+const DEVICE_ID = 'dddd0001-dddd-dddd-dddd-dddddddddddd';
+const ORG_ID = 'aaaa0000-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const OTHER_ORG_ID = 'bbbb0000-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+
+function selectResolving(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(rows),
+      }),
+    }),
+  };
+}
+
+function jobData(overrides: Partial<DeviceGroupReevaluationJobData> = {}): DeviceGroupReevaluationJobData {
+  return {
+    type: 'group-reevaluation',
+    deviceId: DEVICE_ID,
+    orgId: ORG_ID,
+    eventType: 'device.updated',
+    changedFields: ['hostname'],
+    reason: 'heartbeat_device_change',
+    queuedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+beforeEach(async () => {
+  await shutdownDeviceGroupJobs();
+  vi.clearAllMocks();
+  mockQueueAdd.mockResolvedValue({ id: 'job-new' });
+  mockQueueGetJob.mockResolvedValue(undefined);
+  mockWithSystemDbAccessContext.mockImplementation(async (fn: () => Promise<unknown>) => fn());
+});
+
+describe('mergeReevaluationRequests', () => {
+  it('unions the changed fields', () => {
+    expect(mergeReevaluationRequests(
+      { eventType: 'device.updated', changedFields: ['hostname'] },
+      { eventType: 'device.updated', changedFields: ['osVersion', 'hostname'] },
+    )).toEqual({ eventType: 'device.updated', changedFields: ['hostname', 'osVersion'] });
+  });
+
+  it('lets device.created win — it evaluates every group, so it is the superset', () => {
+    expect(mergeReevaluationRequests(
+      { eventType: 'device.updated', changedFields: ['hostname'] },
+      { eventType: 'device.created', changedFields: [] },
+    ).eventType).toBe('device.created');
+
+    expect(mergeReevaluationRequests(
+      { eventType: 'device.created', changedFields: [] },
+      { eventType: 'device.updated', changedFields: ['hostname'] },
+    ).eventType).toBe('device.created');
+  });
+});
+
+describe('scheduleDeviceGroupReevaluation', () => {
+  it('adds a new job under the per-device coalescing jobId', async () => {
+    const id = await scheduleDeviceGroupReevaluation({
+      deviceId: DEVICE_ID,
+      orgId: ORG_ID,
+      eventType: 'device.updated',
+      changedFields: ['hostname', 'hostname'],
+      reason: 'heartbeat_device_change',
+    });
+
+    expect(id).toBe('job-new');
+    expect(mockQueueAdd).toHaveBeenCalledTimes(1);
+    const [name, payload, options] = mockQueueAdd.mock.calls[0]!;
+    expect(name).toBe('group-reevaluation');
+    expect(payload).toMatchObject({
+      deviceId: DEVICE_ID,
+      orgId: ORG_ID,
+      eventType: 'device.updated',
+      changedFields: ['hostname'],
+    });
+    expect(options.jobId).toBe(`group-reeval-${DEVICE_ID}`);
+    expect(deviceGroupReevaluationJobId(DEVICE_ID)).toBe(`group-reeval-${DEVICE_ID}`);
+  });
+
+  it('coalesces into a waiting job instead of enqueuing a second one', async () => {
+    const updateData = vi.fn().mockResolvedValue(undefined);
+    mockQueueGetJob.mockResolvedValue({
+      id: 'job-existing',
+      data: jobData({ changedFields: ['hostname'] }),
+      getState: vi.fn().mockResolvedValue('waiting'),
+      updateData,
+    });
+
+    const id = await scheduleDeviceGroupReevaluation({
+      deviceId: DEVICE_ID,
+      orgId: ORG_ID,
+      eventType: 'device.created',
+      changedFields: ['osVersion'],
+      reason: 'device_provisioned',
+    });
+
+    expect(id).toBe('job-existing');
+    expect(mockQueueAdd).not.toHaveBeenCalled();
+    expect(updateData).toHaveBeenCalledWith(expect.objectContaining({
+      eventType: 'device.created',
+      changedFields: ['hostname', 'osVersion'],
+      reason: 'device_provisioned',
+    }));
+  });
+
+  it('queues a distinct follow-up when the coalescing job is already running', async () => {
+    // An active job's snapshot of the device predates this change, so merging
+    // into it would silently drop the change.
+    mockQueueGetJob.mockResolvedValue({
+      id: 'job-active',
+      data: jobData(),
+      getState: vi.fn().mockResolvedValue('active'),
+      updateData: vi.fn(),
+    });
+    mockQueueAdd.mockResolvedValue({ id: 'job-follow-up' });
+
+    const id = await scheduleDeviceGroupReevaluation({
+      deviceId: DEVICE_ID,
+      orgId: ORG_ID,
+      eventType: 'device.updated',
+      changedFields: ['osBuild'],
+      reason: 'heartbeat_device_change',
+    });
+
+    expect(id).toBe('job-follow-up');
+    const options = mockQueueAdd.mock.calls[0]![2];
+    expect(options.jobId).toMatch(new RegExp(`^group-reeval-${DEVICE_ID}-follow-up-`));
+  });
+
+  it('removes and replaces a spent (failed) record under the same jobId', async () => {
+    // BullMQ's jobId dedup keys on "a record exists", so a retained failure
+    // would swallow every later add forever (services/bullmqUtils.ts).
+    const remove = vi.fn().mockResolvedValue(undefined);
+    mockQueueGetJob.mockResolvedValue({
+      id: 'job-failed',
+      data: jobData(),
+      getState: vi.fn().mockResolvedValue('failed'),
+      remove,
+    });
+
+    await scheduleDeviceGroupReevaluation({
+      deviceId: DEVICE_ID,
+      orgId: ORG_ID,
+      eventType: 'device.updated',
+      changedFields: ['hostname'],
+      reason: 'heartbeat_device_change',
+    });
+
+    expect(remove).toHaveBeenCalled();
+    expect(mockQueueAdd).toHaveBeenCalledTimes(1);
+    expect(mockQueueAdd.mock.calls[0]![2].jobId).toBe(`group-reeval-${DEVICE_ID}`);
+  });
+});
+
+describe('requestDeviceGroupReevaluation', () => {
+  it('never rejects — a Redis outage must not surface on the heartbeat path', async () => {
+    mockQueueGetJob.mockRejectedValue(new Error('redis down'));
+    const original = console.error;
+    const errors: unknown[] = [];
+    console.error = (...args: unknown[]) => { errors.push(args[0]); };
+    try {
+      await expect(requestDeviceGroupReevaluation({
+        deviceId: DEVICE_ID,
+        orgId: ORG_ID,
+        eventType: 'device.updated',
+        changedFields: ['hostname'],
+        reason: 'heartbeat_device_change',
+      })).resolves.toBeNull();
+    } finally {
+      console.error = original;
+    }
+    expect(String(errors[0])).toContain(DEVICE_ID);
+  });
+});
+
+describe('processDeviceGroupReevaluation', () => {
+  it('emits the change with the device\'s OWN org id, never the payload\'s', async () => {
+    mockSelect.mockReturnValue(selectResolving([{ orgId: ORG_ID }]));
+
+    const result = await processDeviceGroupReevaluation(jobData({ orgId: OTHER_ORG_ID }));
+
+    expect(result).toEqual({ evaluated: true, orgId: ORG_ID });
+    expect(mockInitializeDeviceEventHandlers).toHaveBeenCalled();
+    expect(mockEmitDeviceChange).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'device.updated',
+      deviceId: DEVICE_ID,
+      orgId: ORG_ID,
+      changedFields: ['hostname'],
+    }));
+  });
+
+  it('no-ops when the device is gone (deleted between enqueue and run)', async () => {
+    mockSelect.mockReturnValue(selectResolving([]));
+
+    const result = await processDeviceGroupReevaluation(jobData());
+
+    expect(result).toEqual({ evaluated: false, orgId: null });
+    expect(mockEmitDeviceChange).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/jobs/deviceGroupJobs.test.ts
+++ b/apps/api/src/jobs/deviceGroupJobs.test.ts
@@ -355,6 +355,20 @@ describe('processDeviceGroupReevaluation', () => {
     expect(mockEmitDeviceChange).not.toHaveBeenCalled();
   });
 
+  // #5039 round-3 review: on device.created the row MUST exist — its absence
+  // means the enrolling transaction is still open (a slow mTLS issuance can hold
+  // it past the 5s delay) or rolled back. Completing silently would drop the
+  // device's first-ever evaluation with no retry; throw so `attempts` retries
+  // and a true rollback ends in removeOnFail retention, visible.
+  it('THROWS when a device.created job finds no row — retry, never a silent no-op', async () => {
+    mockSelect.mockReturnValue(selectResolving([]));
+
+    await expect(
+      processDeviceGroupReevaluation(jobData({ eventType: 'device.created', changedFields: [] })),
+    ).rejects.toThrow(/device\.created/);
+    expect(mockEmitDeviceChange).not.toHaveBeenCalled();
+  });
+
   // #5039 review finding 2. emitDeviceChange used to swallow handler
   // rejections, so `attempts: 5` never fired: a 40P01 deadlock inside the
   // membership evaluation completed the job and left membership stale.

--- a/apps/api/src/jobs/deviceGroupJobs.test.ts
+++ b/apps/api/src/jobs/deviceGroupJobs.test.ts
@@ -9,6 +9,14 @@
  *     not surface on the agent heartbeat/enrollment path);
  *   - the processor re-reading the device's OWN org id instead of trusting the
  *     job payload, and no-oping for a device that vanished.
+ *
+ * Plus the three #5039 review fixes:
+ *   - every job carries `delay: DEVICE_GROUP_REEVALUATION_DELAY_MS` so it
+ *     cannot run before the enqueuing request's transaction commits, and
+ *     `delayed` stays a coalescing state;
+ *   - the processor THROWS when a handler rejected, so `attempts` retries;
+ *   - the job refuses to run at all when `withSystemDbAccessContext` is
+ *     unavailable, rather than evaluating with no DB access context.
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -20,6 +28,7 @@ const {
   mockWithSystemDbAccessContext,
   mockEmitDeviceChange,
   mockInitializeDeviceEventHandlers,
+  dbExports,
 } = vi.hoisted(() => ({
   mockQueueAdd: vi.fn(),
   mockQueueGetJob: vi.fn(),
@@ -28,6 +37,10 @@ const {
   mockWithSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   mockEmitDeviceChange: vi.fn().mockResolvedValue(undefined),
   mockInitializeDeviceEventHandlers: vi.fn(),
+  // Mutable holder behind a getter on the '../db' mock, so one test can make
+  // `withSystemDbAccessContext` disappear the way a partially-loaded module
+  // would (#5039 review finding 3).
+  dbExports: { withSystemDbAccessContext: undefined as unknown },
 }));
 
 vi.mock('bullmq', () => ({
@@ -55,7 +68,9 @@ vi.mock('./workerObservability', () => ({
 
 vi.mock('../db', () => ({
   db: { select: mockSelect },
-  withSystemDbAccessContext: mockWithSystemDbAccessContext,
+  get withSystemDbAccessContext() {
+    return dbExports.withSystemDbAccessContext;
+  },
 }));
 
 vi.mock('../db/schema', () => ({
@@ -73,11 +88,14 @@ vi.mock('../events/deviceEvents', () => ({
   ) => ({ type, deviceId, orgId, changedFields, timestamp: new Date() }),
 }));
 
+import { isReusableState } from '../services/bullmqUtils';
 import {
+  DEVICE_GROUP_REEVALUATION_DELAY_MS,
   deviceGroupReevaluationJobId,
   mergeReevaluationRequests,
   processDeviceGroupReevaluation,
   requestDeviceGroupReevaluation,
+  runDeviceGroupReevaluationJob,
   scheduleDeviceGroupReevaluation,
   shutdownDeviceGroupJobs,
   type DeviceGroupReevaluationJobData,
@@ -116,6 +134,7 @@ beforeEach(async () => {
   mockQueueAdd.mockResolvedValue({ id: 'job-new' });
   mockQueueGetJob.mockResolvedValue(undefined);
   mockWithSystemDbAccessContext.mockImplementation(async (fn: () => Promise<unknown>) => fn());
+  dbExports.withSystemDbAccessContext = mockWithSystemDbAccessContext;
 });
 
 describe('mergeReevaluationRequests', () => {
@@ -161,6 +180,58 @@ describe('scheduleDeviceGroupReevaluation', () => {
     });
     expect(options.jobId).toBe(`group-reeval-${DEVICE_ID}`);
     expect(deviceGroupReevaluationJobId(DEVICE_ID)).toBe(`group-reeval-${DEVICE_ID}`);
+    // #5039 review finding 1: the caller enqueues from inside its own open
+    // transaction, so the job must not be runnable until that has committed.
+    expect(options.delay).toBe(DEVICE_GROUP_REEVALUATION_DELAY_MS);
+    expect(DEVICE_GROUP_REEVALUATION_DELAY_MS).toBeGreaterThan(0);
+  });
+
+  it('delays the follow-up job too — it is enqueued from a request path as well', async () => {
+    mockQueueGetJob.mockResolvedValue({
+      id: 'job-active',
+      data: jobData(),
+      getState: vi.fn().mockResolvedValue('active'),
+      updateData: vi.fn(),
+    });
+    mockQueueAdd.mockResolvedValue({ id: 'job-follow-up' });
+
+    await scheduleDeviceGroupReevaluation({
+      deviceId: DEVICE_ID,
+      orgId: ORG_ID,
+      eventType: 'device.updated',
+      changedFields: ['hostname'],
+      reason: 'heartbeat_device_change',
+    });
+
+    expect(mockQueueAdd.mock.calls[0]![2].delay).toBe(DEVICE_GROUP_REEVALUATION_DELAY_MS);
+  });
+
+  it('still coalesces while the job sits DELAYED — delayed is a reusable state', async () => {
+    // The delay window is also the coalescing window, so `delayed` has to stay
+    // in isReusableState or every change inside it would add a duplicate job.
+    expect(isReusableState('delayed')).toBe(true);
+
+    const updateData = vi.fn().mockResolvedValue(undefined);
+    mockQueueGetJob.mockResolvedValue({
+      id: 'job-delayed',
+      data: jobData({ changedFields: ['hostname'] }),
+      getState: vi.fn().mockResolvedValue('delayed'),
+      updateData,
+    });
+
+    const id = await scheduleDeviceGroupReevaluation({
+      deviceId: DEVICE_ID,
+      orgId: ORG_ID,
+      eventType: 'device.updated',
+      changedFields: ['osBuild'],
+      reason: 'heartbeat_device_change',
+    });
+
+    expect(id).toBe('job-delayed');
+    expect(mockQueueAdd).not.toHaveBeenCalled();
+    expect(updateData).toHaveBeenCalledWith(expect.objectContaining({
+      changedFields: ['hostname', 'osBuild'],
+    }));
   });
 
   it('coalesces into a waiting job instead of enqueuing a second one', async () => {
@@ -281,6 +352,42 @@ describe('processDeviceGroupReevaluation', () => {
     const result = await processDeviceGroupReevaluation(jobData());
 
     expect(result).toEqual({ evaluated: false, orgId: null });
+    expect(mockEmitDeviceChange).not.toHaveBeenCalled();
+  });
+
+  // #5039 review finding 2. emitDeviceChange used to swallow handler
+  // rejections, so `attempts: 5` never fired: a 40P01 deadlock inside the
+  // membership evaluation completed the job and left membership stale.
+  it('propagates an emitDeviceChange failure so BullMQ retries the job', async () => {
+    mockSelect.mockReturnValue(selectResolving([{ orgId: ORG_ID }]));
+    const deadlock = new AggregateError([new Error('deadlock detected')], 'handlers failed');
+    mockEmitDeviceChange.mockRejectedValueOnce(deadlock);
+
+    await expect(processDeviceGroupReevaluation(jobData())).rejects.toBe(deadlock);
+  });
+});
+
+describe('runDeviceGroupReevaluationJob — the exact function the worker runs', () => {
+  it('runs the evaluation inside a system DB access context', async () => {
+    mockSelect.mockReturnValue(selectResolving([{ orgId: ORG_ID }]));
+
+    const result = await runDeviceGroupReevaluationJob(jobData());
+
+    expect(result).toEqual({ evaluated: true, orgId: ORG_ID });
+    expect(mockWithSystemDbAccessContext).toHaveBeenCalledTimes(1);
+  });
+
+  // #5039 review finding 3. Falling back to a bare fn() is not a degraded
+  // mode: under forced RLS the evaluation reads zero groups and the job
+  // reports success having changed nothing.
+  it('THROWS rather than evaluating without a DB access context', async () => {
+    dbExports.withSystemDbAccessContext = undefined;
+    mockSelect.mockReturnValue(selectResolving([{ orgId: ORG_ID }]));
+
+    await expect(runDeviceGroupReevaluationJob(jobData()))
+      .rejects.toThrow(/withSystemDbAccessContext is unavailable/);
+    // And it refused BEFORE touching the database.
+    expect(mockSelect).not.toHaveBeenCalled();
     expect(mockEmitDeviceChange).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/jobs/deviceGroupJobs.ts
+++ b/apps/api/src/jobs/deviceGroupJobs.ts
@@ -26,6 +26,11 @@
  *     a Redis outage can never turn into a failed heartbeat. It touches no
  *     Postgres connection, so unlike a detached DB call it cannot be stranded
  *     on a committed transaction (the #3182 materialization bug).
+ *   - Every job is DELAYED by `DEVICE_GROUP_REEVALUATION_DELAY_MS` so it cannot
+ *     run before the enqueuing request's transaction commits — the worker reads
+ *     on a different connection and would otherwise see a snapshot without the
+ *     device row (enrollment) or with the pre-UPDATE hostname (heartbeat). See
+ *     that constant for the full failure mode.
  *   - The worker wraps the evaluation in `withSystemDbAccessContext` and
  *     re-reads the device's OWN org id from the database rather than trusting
  *     the job payload, so a stale or forged payload can never steer an
@@ -49,9 +54,29 @@ import {
 } from '../events/deviceEvents';
 
 const { db } = dbModule;
+
+/**
+ * Look `withSystemDbAccessContext` up on the module object at call time rather
+ * than destructuring it at import time (the worker module is imported by
+ * `workerRegistry` before some test doubles are installed).
+ *
+ * If it is missing we THROW rather than fall through to a bare `fn()`. Running
+ * the evaluation with no DB access context is not a degraded mode: under
+ * `FORCE ROW LEVEL SECURITY` the unprivileged `breeze_app` role reads ZERO
+ * dynamic groups, so every job would report a cheerful `{evaluated: true}`
+ * having changed nothing — the exact silent-no-op shape #4630 was filed for.
+ * A thrown job is retried, then retained by `removeOnFail` where it is visible.
+ */
 const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
   const withSystem = dbModule.withSystemDbAccessContext;
-  return typeof withSystem === 'function' ? withSystem(fn) : fn();
+  if (typeof withSystem !== 'function') {
+    throw new Error(
+      '[DeviceGroupJobs] db.withSystemDbAccessContext is unavailable — refusing to evaluate '
+      + 'without a DB access context (forced RLS would return zero groups and the job would '
+      + 'report success having changed nothing).',
+    );
+  }
+  return withSystem(fn);
 };
 
 export const DEVICE_GROUP_REEVALUATION_QUEUE = 'device-group-reevaluation';
@@ -175,8 +200,37 @@ export async function scheduleDeviceGroupReevaluation(
   return String(job.id);
 }
 
+/**
+ * How long a re-evaluation job waits before it becomes runnable.
+ *
+ * THIS IS A CORRECTNESS CONSTANT, not a throttle. Every caller enqueues from
+ * INSIDE its own still-open `withDbAccessContext` / `withSystemDbAccessContext`
+ * transaction (that is the whole point — the enqueue must not wait on, or run
+ * after, the request's DB work). The worker opens its OWN transaction on a
+ * different pooled connection, so without a delay it races the caller's COMMIT
+ * and can read a snapshot in which the device row does not exist yet:
+ *
+ *   - enrollment/provision: `INSERT INTO devices` has not committed, so the
+ *     processor's SELECT finds nothing and returns `{evaluated: false}` — a
+ *     "successful" job that never evaluates the device, and since nothing
+ *     threw, nothing retries. The device is never added to any dynamic group.
+ *     The window is wide: `/enroll` awaits mTLS certificate issuance AFTER the
+ *     enqueue.
+ *   - heartbeat: the row exists but the SELECT reads the PRE-`UPDATE` hostname,
+ *     so the filter flip the job was queued for is invisible.
+ *
+ * 5s is far longer than any of these handlers' remaining work, and the cost is
+ * only that dynamic membership lags a device change by ~5s. Coalescing is
+ * unaffected: `delayed` is in `isReusableState` (services/bullmqUtils.ts), so a
+ * second change to the same device inside the window still merges into the
+ * waiting job rather than adding a duplicate — and, usefully, the whole delay
+ * window becomes a coalescing window for a flapping device.
+ */
+export const DEVICE_GROUP_REEVALUATION_DELAY_MS = 5000;
+
 function jobOptions() {
   return {
+    delay: DEVICE_GROUP_REEVALUATION_DELAY_MS,
     attempts: 5,
     backoff: { type: 'exponential' as const, delay: 500 },
     removeOnComplete: { count: 100 },
@@ -204,6 +258,10 @@ export function requestDeviceGroupReevaluation(
 /**
  * Run one re-evaluation. Assumes it is already inside a system DB access
  * context (the worker wraps it; the integration test wraps it explicitly).
+ *
+ * THROWS if any event handler rejected (`emitDeviceChange` aggregates them),
+ * so BullMQ's `attempts` genuinely retries — a 40P01 deadlock inside the
+ * membership evaluation must not complete as a success with stale membership.
  */
 export async function processDeviceGroupReevaluation(
   data: DeviceGroupReevaluationJobData,
@@ -218,8 +276,14 @@ export async function processDeviceGroupReevaluation(
     .limit(1);
 
   if (!device) {
-    // Device deleted (or org erased) between enqueue and run — the deletion
-    // cascade already removed its memberships. Nothing to do.
+    // The device is GONE, not merely uncommitted. `DEVICE_GROUP_REEVALUATION_DELAY_MS`
+    // is what lets us make that distinction: the job cannot run until 5s after
+    // the enqueue, by which point the enqueuing request's transaction has long
+    // since committed or rolled back. So "no row" means deleted (or the org was
+    // erased, or the enrolling transaction rolled back) — the deletion cascade
+    // has already removed any memberships and there is nothing to evaluate.
+    // Without the delay this branch would also swallow "committing right now",
+    // silently dropping the evaluation with no error and no retry.
     return { evaluated: false, orgId: null };
   }
 
@@ -235,11 +299,25 @@ export async function processDeviceGroupReevaluation(
   return { evaluated: true, orgId: device.orgId };
 }
 
-function createDeviceGroupReevaluationWorker(): Worker<DeviceGroupReevaluationJobData> {
+/**
+ * Exactly what the BullMQ worker runs for one job: the system DB access
+ * context plus the evaluation. Exported so both suites can exercise the real
+ * thing — including the refusal to run with no DB context.
+ */
+export async function runDeviceGroupReevaluationJob(
+  data: DeviceGroupReevaluationJobData,
+): Promise<{ evaluated: boolean; orgId: string | null }> {
+  return runWithSystemDbAccess(() => processDeviceGroupReevaluation(data));
+}
+
+/**
+ * Exported for the integration suite, which drives a REAL BullMQ worker against
+ * real Redis + Postgres to prove the delay actually closes the commit race.
+ */
+export function createDeviceGroupReevaluationWorker(): Worker<DeviceGroupReevaluationJobData> {
   return new Worker<DeviceGroupReevaluationJobData>(
     DEVICE_GROUP_REEVALUATION_QUEUE,
-    async (job: Job<DeviceGroupReevaluationJobData>) =>
-      runWithSystemDbAccess(() => processDeviceGroupReevaluation(job.data)),
+    async (job: Job<DeviceGroupReevaluationJobData>) => runDeviceGroupReevaluationJob(job.data),
     {
       connection: getBullMQConnection(),
       concurrency: 4,

--- a/apps/api/src/jobs/deviceGroupJobs.ts
+++ b/apps/api/src/jobs/deviceGroupJobs.ts
@@ -284,6 +284,19 @@ export async function processDeviceGroupReevaluation(
     // has already removed any memberships and there is nothing to evaluate.
     // Without the delay this branch would also swallow "committing right now",
     // silently dropping the evaluation with no error and no retry.
+    //
+    // EXCEPT on device.created: that row must exist, and the one way it can be
+    // missing after the delay is an enrolment transaction still open past 5s
+    // (hosted `issueMtlsCertForDevice` is an unbounded Cloudflare fetch) or
+    // rolled back. Completing here would drop the device's first-ever
+    // evaluation with nothing to rescue it later, so throw: `attempts` retries
+    // with backoff, and a genuine rollback ends in removeOnFail retention
+    // where it is visible — never a silent no-op (#5039 round-3 review).
+    if (data.eventType === 'device.created') {
+      throw new Error(
+        `device.created re-evaluation found no row for device ${data.deviceId}; retrying (enrolment not yet committed?)`,
+      );
+    }
     return { evaluated: false, orgId: null };
   }
 

--- a/apps/api/src/jobs/deviceGroupJobs.ts
+++ b/apps/api/src/jobs/deviceGroupJobs.ts
@@ -1,0 +1,273 @@
+/**
+ * Dynamic device-group membership re-evaluation queue (#4630).
+ *
+ * WHY A QUEUE. The request handlers that observe a device attribute change
+ * (agent heartbeat, agent enrollment, device provisioning) all run inside
+ * `withDbAccessContext`, which is a real `baseDb.transaction(...)` holding a
+ * pooled Postgres connection. Re-evaluating group membership inline there is
+ * unbounded work — one SELECT + filter evaluation per dynamic group in the
+ * org, plus an INSERT/DELETE, a membership-log write and a peripheral-policy
+ * enqueue (2-3 Redis round trips) per membership flip — all while the
+ * heartbeat's `UPDATE devices` row lock is still held. That is exactly the
+ * pool-starvation shape of the 09-03 US incident, on the highest-volume
+ * endpoint in the product.
+ *
+ * So the request side does nothing but hand the device id to this queue, and
+ * a worker does the evaluation afterwards, off the request's connection:
+ *
+ *   - Coalesced per device under a fixed `jobId` (`group-reeval-<deviceId>`),
+ *     the same shape `jobs/peripheralJobs.ts` uses for
+ *     `policy-reconciliation-<deviceId>`. A device that flaps hostname three
+ *     times in one second re-evaluates once, with the union of the changed
+ *     fields — a burst can never fan out into a burst of evaluations.
+ *   - `requestDeviceGroupReevaluation` is FIRE-AND-FORGET on purpose: it
+ *     returns a promise the caller must not await, so not even the enqueue's
+ *     own Redis round trips happen while the request transaction is open, and
+ *     a Redis outage can never turn into a failed heartbeat. It touches no
+ *     Postgres connection, so unlike a detached DB call it cannot be stranded
+ *     on a committed transaction (the #3182 materialization bug).
+ *   - The worker wraps the evaluation in `withSystemDbAccessContext` and
+ *     re-reads the device's OWN org id from the database rather than trusting
+ *     the job payload, so a stale or forged payload can never steer an
+ *     evaluation at another tenant's groups. Without a DB access context the
+ *     forced-RLS `breeze_app` role returns zero rows from every SELECT, which
+ *     would make the whole evaluation a silent no-op.
+ */
+import { randomUUID } from 'node:crypto';
+import { Job, Queue, Worker } from 'bullmq';
+import { eq } from 'drizzle-orm';
+
+import * as dbModule from '../db';
+import { devices } from '../db/schema';
+import { getBullMQConnection } from '../services/redis';
+import { isReusableState } from '../services/bullmqUtils';
+import { attachWorkerObservability } from './workerObservability';
+import {
+  createDeviceChangeEvent,
+  emitDeviceChange,
+  initializeDeviceEventHandlers,
+} from '../events/deviceEvents';
+
+const { db } = dbModule;
+const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
+  const withSystem = dbModule.withSystemDbAccessContext;
+  return typeof withSystem === 'function' ? withSystem(fn) : fn();
+};
+
+export const DEVICE_GROUP_REEVALUATION_QUEUE = 'device-group-reevaluation';
+const JOB_NAME = 'group-reevaluation';
+
+/**
+ * Only the two event types a request path can produce. `device.deleted` is
+ * handled synchronously by the cascade, and the hardware/network/software
+ * variants have no wired producer yet (see the PR body's unwired list).
+ */
+export type DeviceGroupReevaluationEventType = 'device.created' | 'device.updated';
+
+export interface DeviceGroupReevaluationJobData {
+  type: 'group-reevaluation';
+  deviceId: string;
+  orgId: string;
+  eventType: DeviceGroupReevaluationEventType;
+  changedFields: string[];
+  reason: string;
+  queuedAt: string;
+}
+
+let queue: Queue<DeviceGroupReevaluationJobData> | null = null;
+let worker: Worker<DeviceGroupReevaluationJobData> | null = null;
+
+export function getDeviceGroupReevaluationQueue(): Queue<DeviceGroupReevaluationJobData> {
+  if (!queue) {
+    queue = new Queue<DeviceGroupReevaluationJobData>(DEVICE_GROUP_REEVALUATION_QUEUE, {
+      connection: getBullMQConnection(),
+    });
+  }
+  return queue;
+}
+
+export function deviceGroupReevaluationJobId(deviceId: string): string {
+  return `group-reeval-${deviceId}`;
+}
+
+/**
+ * Merge a newly requested re-evaluation into one that is already queued.
+ *
+ * `device.created` subsumes `device.updated`: the created handler evaluates
+ * EVERY dynamic group in the org rather than only the ones whose filter keys
+ * on a changed field, so collapsing the pair down to `device.updated` would
+ * drop groups. Changed fields are unioned for the same reason — the coalesced
+ * job has to cover everything each of its inputs would have covered.
+ */
+export function mergeReevaluationRequests(
+  existing: Pick<DeviceGroupReevaluationJobData, 'eventType' | 'changedFields'>,
+  incoming: Pick<DeviceGroupReevaluationJobData, 'eventType' | 'changedFields'>,
+): { eventType: DeviceGroupReevaluationEventType; changedFields: string[] } {
+  const eventType: DeviceGroupReevaluationEventType =
+    existing.eventType === 'device.created' || incoming.eventType === 'device.created'
+      ? 'device.created'
+      : 'device.updated';
+  const changedFields = [...new Set([...(existing.changedFields ?? []), ...(incoming.changedFields ?? [])])];
+  return { eventType, changedFields };
+}
+
+export interface DeviceGroupReevaluationRequest {
+  deviceId: string;
+  orgId: string;
+  eventType: DeviceGroupReevaluationEventType;
+  changedFields?: string[];
+  reason: string;
+}
+
+/**
+ * Enqueue (or coalesce into) the re-evaluation job for one device.
+ *
+ * Throws on Redis failure — callers on a request path must use
+ * `requestDeviceGroupReevaluation` instead, which swallows and logs.
+ */
+export async function scheduleDeviceGroupReevaluation(
+  request: DeviceGroupReevaluationRequest,
+): Promise<string> {
+  const targetQueue = getDeviceGroupReevaluationQueue();
+  const jobId = deviceGroupReevaluationJobId(request.deviceId);
+  const changedFields = [...new Set(request.changedFields ?? [])];
+  const payload: DeviceGroupReevaluationJobData = {
+    type: 'group-reevaluation',
+    deviceId: request.deviceId,
+    orgId: request.orgId,
+    eventType: request.eventType,
+    changedFields,
+    reason: request.reason,
+    queuedAt: new Date().toISOString(),
+  };
+
+  const existing = await targetQueue.getJob(jobId);
+  if (existing) {
+    const state = await existing.getState();
+    if (isReusableState(state)) {
+      if (state === 'active') {
+        // Already running: its snapshot of the device predates this change, so
+        // coalescing into it would drop the change entirely. Queue a distinct
+        // follow-up instead (same shape as schedulePeripheralPolicyDevice).
+        const followUp = await targetQueue.add(JOB_NAME, payload, {
+          ...jobOptions(),
+          jobId: `${jobId}-follow-up-${randomUUID()}`,
+        });
+        return String(followUp.id);
+      }
+      const merged = mergeReevaluationRequests(existing.data, payload);
+      await (existing as Job<DeviceGroupReevaluationJobData>).updateData({
+        ...existing.data,
+        ...merged,
+        reason: request.reason,
+        queuedAt: payload.queuedAt,
+      });
+      return String(existing.id);
+    }
+    // A `failed`/`completed` record under this jobId would silently swallow
+    // every future add (see services/bullmqUtils.ts) — drop it and re-add.
+    await existing.remove().catch((error) => {
+      console.error(`[DeviceGroupJobs] Failed to remove stale re-evaluation job ${jobId}:`, error);
+    });
+  }
+
+  const job = await targetQueue.add(JOB_NAME, payload, { ...jobOptions(), jobId });
+  return String(job.id);
+}
+
+function jobOptions() {
+  return {
+    attempts: 5,
+    backoff: { type: 'exponential' as const, delay: 500 },
+    removeOnComplete: { count: 100 },
+    removeOnFail: { count: 200 },
+  };
+}
+
+/**
+ * Request-path entry point. Deliberately NOT awaited by its callers: the whole
+ * point of the queue is that no Redis I/O happens while the request's Postgres
+ * transaction is open. Returns the in-flight promise so tests can settle it.
+ */
+export function requestDeviceGroupReevaluation(
+  request: DeviceGroupReevaluationRequest,
+): Promise<string | null> {
+  return scheduleDeviceGroupReevaluation(request).catch((error) => {
+    console.error(
+      `[DeviceGroupJobs] Failed to enqueue group re-evaluation for device ${request.deviceId}:`,
+      error,
+    );
+    return null;
+  });
+}
+
+/**
+ * Run one re-evaluation. Assumes it is already inside a system DB access
+ * context (the worker wraps it; the integration test wraps it explicitly).
+ */
+export async function processDeviceGroupReevaluation(
+  data: DeviceGroupReevaluationJobData,
+): Promise<{ evaluated: boolean; orgId: string | null }> {
+  // Re-read the device's own org rather than trusting the payload: the job
+  // outlives the request that produced it, and a membership write stamped from
+  // a stale org id is a cross-tenant row.
+  const [device] = await db
+    .select({ orgId: devices.orgId })
+    .from(devices)
+    .where(eq(devices.id, data.deviceId))
+    .limit(1);
+
+  if (!device) {
+    // Device deleted (or org erased) between enqueue and run — the deletion
+    // cascade already removed its memberships. Nothing to do.
+    return { evaluated: false, orgId: null };
+  }
+
+  // The queue can be drained by a `worker`-role process, which never runs
+  // index.ts's bootstrap — without this the handler registry would be empty and
+  // every job would be a silent no-op. Idempotent.
+  initializeDeviceEventHandlers();
+
+  await emitDeviceChange(
+    createDeviceChangeEvent(data.eventType, data.deviceId, device.orgId, data.changedFields ?? []),
+  );
+
+  return { evaluated: true, orgId: device.orgId };
+}
+
+function createDeviceGroupReevaluationWorker(): Worker<DeviceGroupReevaluationJobData> {
+  return new Worker<DeviceGroupReevaluationJobData>(
+    DEVICE_GROUP_REEVALUATION_QUEUE,
+    async (job: Job<DeviceGroupReevaluationJobData>) =>
+      runWithSystemDbAccess(() => processDeviceGroupReevaluation(job.data)),
+    {
+      connection: getBullMQConnection(),
+      concurrency: 4,
+    },
+  );
+}
+
+export async function initializeDeviceGroupJobs(): Promise<void> {
+  worker = createDeviceGroupReevaluationWorker();
+  attachWorkerObservability(worker, 'deviceGroupReevaluationWorker');
+
+  worker.on('error', (error) => {
+    console.error('[DeviceGroupJobs] Re-evaluation worker error:', error);
+  });
+  worker.on('failed', (job, error) => {
+    console.error(`[DeviceGroupJobs] Re-evaluation job ${job?.id} failed:`, error);
+  });
+
+  console.log('[DeviceGroupJobs] Dynamic device group re-evaluation worker initialized');
+}
+
+export async function shutdownDeviceGroupJobs(): Promise<void> {
+  if (worker) {
+    await worker.close();
+    worker = null;
+  }
+  if (queue) {
+    await queue.close();
+    queue = null;
+  }
+}

--- a/apps/api/src/routes/agents/enrollment.test.ts
+++ b/apps/api/src/routes/agents/enrollment.test.ts
@@ -152,12 +152,11 @@ vi.mock('../../services/partnerTrust', () => ({
   })),
 }));
 
-// #4630 — dynamic device group re-evaluation emit on enrollment.
-const emitDeviceChangeMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
-vi.mock('../../events/deviceEvents', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../../events/deviceEvents')>();
-  return { ...actual, emitDeviceChange: emitDeviceChangeMock };
-});
+// #4630 — dynamic device group re-evaluation ENQUEUE on enrollment.
+const requestDeviceGroupReevaluationMock = vi.hoisted(() => vi.fn().mockResolvedValue('job-1'));
+vi.mock('../../jobs/deviceGroupJobs', () => ({
+  requestDeviceGroupReevaluation: requestDeviceGroupReevaluationMock,
+}));
 
 // ---------- imports after mocks ----------
 
@@ -375,43 +374,37 @@ describe('POST /agents/enroll — backup server URL delivery (#2288)', () => {
   });
 });
 
-describe('POST /agents/enroll — dynamic device group re-evaluation emit (#4630)', () => {
+describe('POST /agents/enroll — dynamic device group re-evaluation enqueue (#4630)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    requestDeviceGroupReevaluationMock.mockResolvedValue('job-1');
     delete process.env.AGENT_ENROLLMENT_SECRET;
     delete process.env.AGENT_BACKUP_SERVER_URL;
     process.env.NODE_ENV = 'test';
   });
 
-  it('emits device.created INSIDE a system DB access context (RLS denies contextless reads)', async () => {
-    // Outside withSystemDbAccessContext the handler's dynamic-group SELECT
-    // runs with breeze.scope='none' and silently returns zero rows, so the
-    // enrollment-time evaluation would be a no-op in production.
-    let insideContext = 0;
-    vi.mocked(withSystemDbAccessContext).mockImplementation(async (fn: any) => {
-      insideContext++;
-      try { return await fn(); } finally { insideContext--; }
-    });
-    let emittedInside: number | null = null;
-    emitDeviceChangeMock.mockImplementationOnce(async () => { emittedInside = insideContext; });
-
+  it('enqueues a device.created re-evaluation for the freshly enrolled device', async () => {
     await enrollOk();
 
-    expect(emitDeviceChangeMock).toHaveBeenCalledTimes(1);
-    expect(emittedInside).toBeGreaterThan(0);
-    vi.mocked(withSystemDbAccessContext).mockImplementation(async (fn: any) => fn());
-  });
-
-  it('emits device.created for the freshly enrolled device', async () => {
-    await enrollOk();
-
-    expect(emitDeviceChangeMock).toHaveBeenCalledWith(
+    expect(requestDeviceGroupReevaluationMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        type: 'device.created',
         deviceId: 'device-backup-url',
         orgId: 'org-backup-url',
+        eventType: 'device.created',
       }),
     );
+  });
+
+  it('does not await the enqueue — a stalled queue must not hold the enrollment transaction', async () => {
+    // The enrollment handler body runs inside withSystemDbAccessContext, i.e. an
+    // open transaction on a pooled connection. A never-settling enqueue proves
+    // the call site is `void`-ed: an `await` here would hang the test out.
+    requestDeviceGroupReevaluationMock.mockReturnValue(new Promise(() => {}));
+
+    // enrollOk asserts the 201 itself; reaching this line at all is the proof.
+    await enrollOk();
+
+    expect(requestDeviceGroupReevaluationMock).toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/routes/agents/enrollment.ts
+++ b/apps/api/src/routes/agents/enrollment.ts
@@ -40,7 +40,7 @@ import {
 import { partnerTrustMode } from '../../config/partnerTrustMode';
 import { evaluateCapability, trustDenyBody, unresolvedPartnerDecision } from '../../services/partnerTrust';
 import { enqueueIpClassify } from '../../services/ipClassify';
-import { emitDeviceChange, createDeviceChangeEvent } from '../../events/deviceEvents';
+import { requestDeviceGroupReevaluation } from '../../jobs/deviceGroupJobs';
 
 export const enrollmentRoutes = new Hono();
 const ENROLLMENT_RATE_LIMIT = 10;
@@ -1052,13 +1052,21 @@ enrollmentRoutes.post('/enroll', zValidator('json', enrollSchema), async (c) => 
       throw err;
     }
 
-    // #4630 — a freshly enrolled device must be evaluated against every
-    // dynamic group in its org immediately, not just on its next filterable
-    // heartbeat change (hostname/OS are already correct at insert, so no
-    // later heartbeat diff would ever fire for a device that matched from
-    // day one). Runs inside this handler's existing withSystemDbAccessContext
-    // wrapper (see the top of this handler), self-tenanted by key.orgId.
-    await emitDeviceChange(createDeviceChangeEvent('device.created', device.id, key.orgId, []));
+    // #4630 — a freshly enrolled device must be evaluated against every dynamic
+    // group in its org immediately, not just on its next filterable heartbeat
+    // change (hostname/OS are already correct at insert, so no later heartbeat
+    // diff would ever fire for a device that matched from day one).
+    //
+    // Enqueue only, never awaited: this runs inside the handler's open
+    // withSystemDbAccessContext transaction, and the evaluation must not hold
+    // that pooled connection. The worker re-reads the device's own org id, so
+    // the org here is only a diagnostic hint.
+    void requestDeviceGroupReevaluation({
+      deviceId: device.id,
+      orgId: key.orgId,
+      eventType: 'device.created',
+      reason: 'device_enrolled',
+    });
 
     const mtlsCert = await issueMtlsCertForDevice(device.id, key.orgId);
 

--- a/apps/api/src/routes/agents/heartbeat.test.ts
+++ b/apps/api/src/routes/agents/heartbeat.test.ts
@@ -277,14 +277,13 @@ vi.mock('../metrics', () => ({
   resolveResponseStatus: (c: any) => (c?.finalized ? (c.res?.status ?? 500) : 500),
 }));
 
-// #4630 — the heartbeat's dynamic-group re-evaluation emit site. Real
-// createDeviceChangeEvent (pure), mocked emitDeviceChange so tests can assert
-// on the event shape without pulling in groupMembership.ts's DB graph.
-const emitDeviceChangeMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
-vi.mock('../../events/deviceEvents', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../../events/deviceEvents')>();
-  return { ...actual, emitDeviceChange: emitDeviceChangeMock };
-});
+// #4630 — the heartbeat's dynamic-group re-evaluation ENQUEUE site. The
+// evaluation itself never runs on the request path any more; the handler only
+// hands the device id to the coalescing BullMQ queue.
+const requestDeviceGroupReevaluationMock = vi.hoisted(() => vi.fn().mockResolvedValue('job-1'));
+vi.mock('../../jobs/deviceGroupJobs', () => ({
+  requestDeviceGroupReevaluation: requestDeviceGroupReevaluationMock,
+}));
 
 import { and, eq, notInArray } from 'drizzle-orm';
 import { heartbeatRoutes } from './heartbeat';
@@ -3739,7 +3738,7 @@ describe('POST /agents/:id/heartbeat — watchdogVersion telemetry (#1802)', () 
   });
 });
 
-describe('POST /agents/:id/heartbeat — dynamic device group re-evaluation emit (#4630)', () => {
+describe('POST /agents/:id/heartbeat — dynamic device group re-evaluation enqueue (#4630)', () => {
   const deviceRow = {
     id: 'device-1', orgId: 'org-1', siteId: 'site-1', hostname: 'old-host',
     osType: 'windows', osVersion: '10.0.19045', osBuild: '19045',
@@ -3749,6 +3748,7 @@ describe('POST /agents/:id/heartbeat — dynamic device group re-evaluation emit
 
   function arrange() {
     vi.clearAllMocks();
+    requestDeviceGroupReevaluationMock.mockResolvedValue('job-1');
     getActiveTrustKeysetMock.mockResolvedValue([]);
     selectMock.mockReturnValueOnce(selectChainResolving([deviceRow]));
     selectMock.mockReturnValue(selectChainResolving([]));
@@ -3764,17 +3764,17 @@ describe('POST /agents/:id/heartbeat — dynamic device group re-evaluation emit
     });
   }
 
-  it('emits device.updated with the changed filterable fields when hostname changes', async () => {
+  it('enqueues a device.updated re-evaluation with the changed filterable fields', async () => {
     arrange();
 
     const resp = await post({ agentVersion: '0.66.0', hostname: 'new-host' });
 
     expect(resp.status).toBe(200);
-    expect(emitDeviceChangeMock).toHaveBeenCalledWith(
+    expect(requestDeviceGroupReevaluationMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        type: 'device.updated',
         deviceId: 'device-1',
         orgId: 'org-1',
+        eventType: 'device.updated',
         changedFields: ['hostname'],
       }),
     );
@@ -3792,24 +3792,22 @@ describe('POST /agents/:id/heartbeat — dynamic device group re-evaluation emit
     });
 
     expect(resp.status).toBe(200);
-    const [event] = emitDeviceChangeMock.mock.calls.find(
-      (call: unknown[]) => (call[0] as { type: string }).type === 'device.updated',
-    ) ?? [];
-    expect(event?.changedFields).toEqual(
+    const request = requestDeviceGroupReevaluationMock.mock.calls[0]?.[0];
+    expect(request?.changedFields).toEqual(
       expect.arrayContaining(['hostname', 'osVersion', 'osBuild', 'deviceRole']),
     );
   });
 
-  it('does not emit when no filterable field changes (steady-state heartbeat)', async () => {
+  it('does not enqueue when no filterable field changes (steady-state heartbeat)', async () => {
     arrange();
 
     const resp = await post({ agentVersion: '0.66.0' });
 
     expect(resp.status).toBe(200);
-    expect(emitDeviceChangeMock).not.toHaveBeenCalled();
+    expect(requestDeviceGroupReevaluationMock).not.toHaveBeenCalled();
   });
 
-  it('does not emit when the agent re-reports its unchanged auto deviceRole (real steady state)', async () => {
+  it('does not enqueue when the agent re-reports its unchanged auto deviceRole (real steady state)', async () => {
     // The Go agent sends deviceRole on EVERY heartbeat (heartbeat.go
     // sendHeartbeat), and deviceRoleSource defaults to 'auto' fleet-wide, so a
     // body that omits deviceRole is not the steady state — this is.
@@ -3824,16 +3822,30 @@ describe('POST /agents/:id/heartbeat — dynamic device group re-evaluation emit
     });
 
     expect(resp.status).toBe(200);
-    expect(emitDeviceChangeMock).not.toHaveBeenCalled();
+    expect(requestDeviceGroupReevaluationMock).not.toHaveBeenCalled();
   });
 
-  it('does not emit for a non-filterable-only change (agentServerUrl)', async () => {
+  it('does not enqueue for a non-filterable-only change (agentServerUrl)', async () => {
     arrange();
 
     const resp = await post({ agentVersion: '0.66.0', serverUrl: 'https://api.example.com' });
 
     expect(resp.status).toBe(200);
-    expect(emitDeviceChangeMock).not.toHaveBeenCalled();
+    expect(requestDeviceGroupReevaluationMock).not.toHaveBeenCalled();
+  });
+
+  it('answers without waiting on the enqueue — a stalled Redis must not hold the transaction', async () => {
+    // The whole point of the queue is that no Redis round trip happens while
+    // this request's Postgres transaction is open. A never-settling enqueue
+    // proves the call site is `void`-ed rather than awaited: if the route ever
+    // regains an `await`, this test hangs to its timeout instead of passing.
+    arrange();
+    requestDeviceGroupReevaluationMock.mockReturnValue(new Promise(() => {}));
+
+    const resp = await post({ agentVersion: '0.66.0', hostname: 'new-host' });
+
+    expect(resp.status).toBe(200);
+    expect(requestDeviceGroupReevaluationMock).toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -38,7 +38,7 @@ import {
 } from './helpers';
 import { shouldSendAgentUpgrade } from './agentUpdatePolicy';
 import { processDeviceIPHistoryUpdate } from '../../services/deviceIpHistory';
-import { emitDeviceChange, createDeviceChangeEvent } from '../../events/deviceEvents';
+import { requestDeviceGroupReevaluation } from '../../jobs/deviceGroupJobs';
 import { claimPendingCommandsForDevice } from '../../services/commandDispatch';
 import { publishEvent } from '../../services/eventBus';
 import { DRAIN_CLAIM_TYPE_ALLOWLIST, isAgentTokenRotationDue } from '../../middleware/agentAuth';
@@ -1096,19 +1096,26 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
       });
     }
 
-    // #4630 — dynamic device group membership re-evaluation. Only the fields
-    // a filter can actually key on; must be awaited so the DB work it triggers
-    // (groupMembership.ts) runs inside this request's still-open
-    // withDbAccessContext, not after the response has released it.
+    // #4630 — dynamic device group membership re-evaluation. Only the fields a
+    // filter can actually key on.
+    //
+    // NOT awaited, and deliberately no DB or Redis work here: this handler runs
+    // inside `withDbAccessContext`, i.e. a real transaction still holding this
+    // request's pooled Postgres connection and the `UPDATE devices` row lock.
+    // The evaluation itself is unbounded (one filter evaluation per dynamic
+    // group in the org, plus a peripheral-policy enqueue per membership flip),
+    // so it belongs on the queue — see jobs/deviceGroupJobs.ts for the full
+    // rationale. `requestDeviceGroupReevaluation` never rejects.
     const filterableChangedFields = (['hostname', 'osVersion', 'osBuild', 'deviceRole'] as const)
       .filter((field) => deviceUpdates[field] !== undefined);
     if (filterableChangedFields.length > 0) {
-      await emitDeviceChange(createDeviceChangeEvent(
-        'device.updated',
-        device.id,
-        device.orgId,
-        filterableChangedFields,
-      ));
+      void requestDeviceGroupReevaluation({
+        deviceId: device.id,
+        orgId: device.orgId,
+        eventType: 'device.updated',
+        changedFields: [...filterableChangedFields],
+        reason: 'heartbeat_device_change',
+      });
     }
   }
 

--- a/apps/api/src/routes/devices/groups.test.ts
+++ b/apps/api/src/routes/devices/groups.test.ts
@@ -69,7 +69,6 @@ vi.mock('../../services/auditEvents', () => ({
 
 vi.mock('../../services/groupMembership', () => ({
   pruneGroupMembershipsOutsideSite: vi.fn().mockResolvedValue({ removed: 0 }),
-  evaluateGroupMembership: vi.fn().mockResolvedValue({ evaluatedGroups: 1, added: 0, removed: 0 }),
 }));
 
 vi.mock('../../jobs/peripheralJobs', () => ({
@@ -110,7 +109,7 @@ vi.mock('@hono/zod-validator', () => ({
 
 import { groupsRoutes } from './groups';
 import { writeRouteAudit } from '../../services/auditEvents';
-import { pruneGroupMembershipsOutsideSite, evaluateGroupMembership } from '../../services/groupMembership';
+import { pruneGroupMembershipsOutsideSite } from '../../services/groupMembership';
 import { DeviceGroupDeleteError } from '../../services/deviceGroupDelete';
 
 // ---------------------------------------------------------------------------
@@ -361,29 +360,6 @@ describe('Device Groups routes — multi-tenant isolation', () => {
       const json = await res.json();
       expect(json.id).toBe(GROUP_ID);
       expect(writeRouteAudit).toHaveBeenCalled();
-      expect(evaluateGroupMembership).not.toHaveBeenCalled();
-    });
-
-    // #4630 — parity with POST /groups (routes/groups.ts): a dynamic group's
-    // filter must be evaluated immediately on create, on this route too.
-    it('evaluates membership for a dynamic group carrying filterConditions', async () => {
-      const created = {
-        id: GROUP_ID,
-        orgId: ORG_A,
-        name: 'Servers',
-        type: 'dynamic',
-        filterConditions: { operator: 'AND', conditions: [] },
-      };
-      mockInsert.mockReturnValue(chainInsert([created]));
-
-      const res = await app.request('/devices/groups', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ orgId: ORG_A, name: 'Servers', type: 'dynamic' }),
-      });
-
-      expect(res.status).toBe(201);
-      expect(evaluateGroupMembership).toHaveBeenCalledWith(GROUP_ID);
     });
 
     it('returns 403 when org-scoped user targets a different org', async () => {
@@ -609,49 +585,6 @@ describe('Device Groups routes — multi-tenant isolation', () => {
         DEVICE_1,
         'dynamic_membership_changed',
       );
-    });
-
-    // #4630 — parity with PATCH /groups/:id (routes/groups.ts): a dynamic
-    // group's filter must be re-evaluated when its site changes.
-    it('evaluates membership for a dynamic group with filterConditions when its site changes', async () => {
-      const oldSiteId = 'eeee0001-eeee-eeee-eeee-eeeeeeeeeeee';
-      const group = {
-        ...groupInOrgA,
-        type: 'dynamic',
-        siteId: oldSiteId,
-        filterConditions: { operator: 'AND', conditions: [] },
-      };
-      mockSelect
-        .mockReturnValueOnce(chainSelect([group]))
-        .mockReturnValueOnce(chainSelect([{ id: SITE_ID }]));
-      mockUpdate.mockReturnValue(chainUpdate([{ ...group, siteId: SITE_ID }]));
-
-      const res = await app.request(`/devices/groups/${GROUP_ID}`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ siteId: SITE_ID }),
-      });
-
-      expect(res.status).toBe(200);
-      expect(evaluateGroupMembership).toHaveBeenCalledWith(GROUP_ID);
-    });
-
-    it('does not evaluate membership for a static group whose site changes', async () => {
-      const oldSiteId = 'eeee0001-eeee-eeee-eeee-eeeeeeeeeeee';
-      const group = { ...groupInOrgA, siteId: oldSiteId };
-      mockSelect
-        .mockReturnValueOnce(chainSelect([group]))
-        .mockReturnValueOnce(chainSelect([{ id: SITE_ID }]));
-      mockUpdate.mockReturnValue(chainUpdate([{ ...group, siteId: SITE_ID }]));
-
-      const res = await app.request(`/devices/groups/${GROUP_ID}`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ siteId: SITE_ID }),
-      });
-
-      expect(res.status).toBe(200);
-      expect(evaluateGroupMembership).not.toHaveBeenCalled();
     });
 
     it('rolls back a legacy site reassignment when membership pruning fails', async () => {

--- a/apps/api/src/routes/devices/groups.ts
+++ b/apps/api/src/routes/devices/groups.ts
@@ -9,7 +9,7 @@ import { getPagination, ensureOrgAccess } from './helpers';
 import { PG_UUID_REGEX } from '../../utils/uuid';
 import { createGroupSchema, updateGroupSchema } from './schemas';
 import { writeRouteAudit } from '../../services/auditEvents';
-import { evaluateGroupMembership, pruneGroupMembershipsOutsideSite } from '../../services/groupMembership';
+import { pruneGroupMembershipsOutsideSite } from '../../services/groupMembership';
 import { schedulePeripheralPolicyDevice } from '../../jobs/peripheralJobs';
 import { deleteDeviceGroup, DeviceGroupDeleteError } from '../../services/deviceGroupDelete';
 
@@ -179,20 +179,6 @@ groupsRoutes.post(
       resourceName: group?.name
     });
 
-    // #4630 — same materialization path as POST /groups (routes/groups.ts):
-    // a dynamic group must never be created without evaluating its filter.
-    // This endpoint's schema has no filterConditions field today, so
-    // group.filterConditions is always null and this is currently a no-op —
-    // kept for structural parity so it activates automatically if/when this
-    // route gains filter support.
-    if (group?.type === 'dynamic' && group.filterConditions) {
-      try {
-        await evaluateGroupMembership(group.id);
-      } catch (err) {
-        console.error(`Failed to evaluate membership for new group ${group.id}:`, err);
-      }
-    }
-
     return c.json(group, 201);
   }
 );
@@ -313,17 +299,6 @@ groupsRoutes.patch(
       resourceName: updated?.name ?? group.name,
       details: { changedFields: Object.keys(data) }
     });
-
-    // #4630 — same materialization path as PATCH /groups/:id. See the create
-    // handler above for why this is currently a no-op on this route.
-    const effectiveType = data.type ?? group.type;
-    if (effectiveType === 'dynamic' && siteChanged && updated?.filterConditions) {
-      try {
-        await evaluateGroupMembership(updated.id);
-      } catch (err) {
-        console.error(`Failed to evaluate membership for group ${updated.id}:`, err);
-      }
-    }
 
     return c.json(updated);
   }

--- a/apps/api/src/routes/devices/provision.test.ts
+++ b/apps/api/src/routes/devices/provision.test.ts
@@ -83,12 +83,11 @@ vi.mock('../../services/provisionCredentialHandle', () => ({
   provisionHandleExpiresAt: vi.fn(() => new Date('2030-01-01T00:00:00.000Z')),
 }));
 
-// #4630 — dynamic device group re-evaluation emit on provisioning.
-const emitDeviceChangeMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
-vi.mock('../../events/deviceEvents', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../../events/deviceEvents')>();
-  return { ...actual, emitDeviceChange: emitDeviceChangeMock };
-});
+// #4630 — dynamic device group re-evaluation ENQUEUE on provisioning.
+const requestDeviceGroupReevaluationMock = vi.hoisted(() => vi.fn().mockResolvedValue('job-1'));
+vi.mock('../../jobs/deviceGroupJobs', () => ({
+  requestDeviceGroupReevaluation: requestDeviceGroupReevaluationMock,
+}));
 
 import { db } from '../../db';
 import { writeRouteAudit } from '../../services/auditEvents';
@@ -408,11 +407,12 @@ describe('POST /devices/provision', () => {
         }),
       );
 
-      // #4630 — the new device is evaluated against every dynamic group in
-      // its org immediately, not just on its next heartbeat.
-      expect(emitDeviceChangeMock).toHaveBeenCalledWith(
+      // #4630 — the new device is queued for evaluation against every dynamic
+      // group in its org immediately, not just on its next heartbeat. The
+      // evaluation itself runs off the request's transaction.
+      expect(requestDeviceGroupReevaluationMock).toHaveBeenCalledWith(
         expect.objectContaining({
-          type: 'device.created',
+          eventType: 'device.created',
           deviceId: 'device-prov-id',
           orgId: ORG_ID,
         }),

--- a/apps/api/src/routes/devices/provision.ts
+++ b/apps/api/src/routes/devices/provision.ts
@@ -24,7 +24,7 @@ import {
   generateProvisionHandleToken,
   provisionHandleExpiresAt,
 } from '../../services/provisionCredentialHandle';
-import { emitDeviceChange, createDeviceChangeEvent } from '../../events/deviceEvents';
+import { requestDeviceGroupReevaluation } from '../../jobs/deviceGroupJobs';
 
 export const provisionRoutes = new Hono();
 
@@ -301,10 +301,14 @@ provisionRoutes.post(
     // #4630 — evaluate the new device against every dynamic group in its org
     // immediately, so a group filtering on hostname/site (already correct at
     // insert) doesn't have to wait for a heartbeat that would never report a
-    // diff for those fields. Runs inside this request's own org-scoped
-    // withDbAccessContext, matching evaluateGroupMembership's usage in
-    // routes/groups.ts.
-    await emitDeviceChange(createDeviceChangeEvent('device.created', device.id, data.orgId, []));
+    // diff for those fields. Enqueue only, never awaited: the evaluation must
+    // not run on this request's still-open withDbAccessContext transaction.
+    void requestDeviceGroupReevaluation({
+      deviceId: device.id,
+      orgId: data.orgId,
+      eventType: 'device.created',
+      reason: 'device_provisioned',
+    });
 
     // ----------- mTLS cert + manifest trust keys for the config blob -----------
     const mtlsCert = await issueMtlsCertForDevice(device.id, data.orgId);

--- a/apps/api/src/services/groupMembership.siteScope.test.ts
+++ b/apps/api/src/services/groupMembership.siteScope.test.ts
@@ -54,9 +54,15 @@ import {
 } from './groupMembership';
 
 function selectChain(rows: unknown[], withLimit = false) {
+  // `updateDeviceMembership`'s group SELECT now ends in
+  // `.orderBy(deviceGroups.id)` — a lock-order contract, #4630 review finding 2
+  // — so the non-limit terminal must be thenable AND carry `orderBy`.
   const terminal = withLimit
     ? { limit: vi.fn().mockResolvedValue(rows) }
-    : Promise.resolve(rows);
+    : {
+      orderBy: vi.fn().mockResolvedValue(rows),
+      then: (resolve: (value: unknown) => unknown) => Promise.resolve(rows).then(resolve),
+    };
   return { from: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue(terminal) }) };
 }
 

--- a/apps/api/src/services/groupMembership.ts
+++ b/apps/api/src/services/groupMembership.ts
@@ -564,6 +564,14 @@ export async function updateDeviceMembership(
     resolvedOrgId = device.orgId;
   }
 
+  // ORDER BY id is a LOCK-ORDER contract, not cosmetics. Both
+  // `ensureFilterFieldsUsed` (below) and `evaluateDeviceMembershipForGroup`
+  // UPDATE `device_groups`, so two concurrent re-evaluations for two devices in
+  // the same org that walk the org's groups in different orders can take the
+  // group row locks in opposite orders and deadlock (40P01 — the #3911 shape).
+  // An unordered SELECT gives no ordering guarantee whatsoever; sorting by the
+  // primary key makes every evaluator lock the same groups in the same
+  // sequence, which is the standard deadlock-free discipline.
   const groups = await db
     .select({
       id: deviceGroups.id,
@@ -575,7 +583,8 @@ export async function updateDeviceMembership(
       sql`${deviceGroups.orgId} = ${resolvedOrgId}
         AND ${deviceGroups.type} = 'dynamic'
         AND ${deviceGroups.filterConditions} IS NOT NULL`
-    );
+    )
+    .orderBy(deviceGroups.id);
 
   let summary: MembershipUpdateSummary = { evaluatedGroups: 0, added: 0, removed: 0 };
 

--- a/apps/api/src/services/workerEntrypointClosure.contract.test.ts
+++ b/apps/api/src/services/workerEntrypointClosure.contract.test.ts
@@ -291,6 +291,7 @@ const EXPECTED_NAMES = [
   'dnsSyncWorker', 's1SyncWorker', 'huntressSyncWorker', 'pax8SyncWorker',
   'tdSynnexSftpSyncWorker', 'logForwardingWorker', 'patchJobWorker', 'patchSchedulerWorker',
   'maintenanceRebootWorker', 'backupWorker', 'sensitiveDataWorker', 'peripheralJobs',
+  'deviceGroupJobs',
   'browserSecurityWorker', 'c2cBackupWorker', 'backupSlaWorker', 'drExecutionWorker',
   'recoveryMediaWorker', 'recoveryBootMediaWorker', 'warrantyWorker', 'ssoDomainRecheckWorker',
   'incidentCorrelationWorker', 'incidentTimelineEnricher', 'incidentSlaMonitor', 'staleCommandReaper',

--- a/apps/api/src/services/workerEntrypointClosure.contract.test.ts
+++ b/apps/api/src/services/workerEntrypointClosure.contract.test.ts
@@ -454,7 +454,7 @@ describe('workerEntrypointClosure contract (#4086 Task 5)', () => {
 
   describe('global-placement entries never reach socket-local dispatch', () => {
     const entries = parseRegistrySource();
-    expect(entries.length).toBe(124); // sanity: the source-parsing regex itself must find all 124
+    expect(entries.length).toBe(125); // sanity: the source-parsing regex itself must find all 125
 
     const globalEntries = entries.filter((e) => e.placement === 'global');
     expect(globalEntries.length).toBeGreaterThan(0);

--- a/apps/api/src/services/workerRegistry.test.ts
+++ b/apps/api/src/services/workerRegistry.test.ts
@@ -20,7 +20,8 @@ import {
 // Phase 2 wave P2-6 Task A5, #4193; `aiAgentGraduation`, Phase 2 wave P2-5
 // Task 9, #4192; `accountingReconcileWorker`, QuickBooks Phase D Task 4;
 // `ticketOutboxRetention` / `intentOutboxRetention` /
-// `metricAnomalyIncidentRetention`, #4210).
+// `metricAnomalyIncidentRetention`, #4210; `deviceGroupJobs`, dynamic device
+// group re-evaluation, #4630).
 // This list is duplicated here deliberately — the whole point of the test is
 // to catch drift between the plan's documented contract and the actual
 // registry, so it must not import the list from the module under test.
@@ -46,6 +47,7 @@ const EXPECTED_124_NAMES = [
   'dnsSyncWorker', 's1SyncWorker', 'huntressSyncWorker', 'pax8SyncWorker',
   'tdSynnexSftpSyncWorker', 'logForwardingWorker', 'patchJobWorker', 'patchSchedulerWorker',
   'maintenanceRebootWorker', 'backupWorker', 'sensitiveDataWorker', 'peripheralJobs',
+  'deviceGroupJobs',
   'browserSecurityWorker', 'c2cBackupWorker', 'backupSlaWorker', 'drExecutionWorker',
   'recoveryMediaWorker', 'recoveryBootMediaWorker', 'warrantyWorker', 'ssoDomainRecheckWorker',
   'incidentCorrelationWorker', 'incidentTimelineEnricher', 'incidentSlaMonitor', 'staleCommandReaper',

--- a/apps/api/src/services/workerRegistry.test.ts
+++ b/apps/api/src/services/workerRegistry.test.ts
@@ -25,7 +25,7 @@ import {
 // This list is duplicated here deliberately — the whole point of the test is
 // to catch drift between the plan's documented contract and the actual
 // registry, so it must not import the list from the module under test.
-const EXPECTED_124_NAMES = [
+const EXPECTED_125_NAMES = [
   'alertWorkers', 'alertCorrelationWorker', 'metricRollupsWorker', 'metricRollupMaintenance',
   'metricAnomaliesWorker', 'aiBudgetAlertDeliveryWorker', 'fleetFindingsWorker', 'fleetRemediationDispatchWorker', 'mlOutputRetention',
   'offlineDetector', 'notificationDispatcher', 'webhookDelivery', 'webhookDeliveryRecovery',
@@ -62,12 +62,12 @@ const EXPECTED_124_NAMES = [
 ];
 
 describe('workerRegistry: losslessness', () => {
-  it('contains exactly the 124 known names, in order', () => {
-    expect(WORKER_REGISTRY.map((e) => e.name)).toEqual(EXPECTED_124_NAMES);
+  it('contains exactly the 125 known names, in order', () => {
+    expect(WORKER_REGISTRY.map((e) => e.name)).toEqual(EXPECTED_125_NAMES);
   });
 
-  it('has exactly 124 entries', () => {
-    expect(WORKER_REGISTRY.length).toBe(124);
+  it('has exactly 125 entries', () => {
+    expect(WORKER_REGISTRY.length).toBe(125);
   });
 
   it('every entry has a well-formed shape', () => {
@@ -87,14 +87,14 @@ describe('workerRegistry: losslessness', () => {
 
 describe('workerRegistry: selectWorkers', () => {
   it("'all' selects every entry", () => {
-    expect(selectWorkers('all').length).toBe(124);
+    expect(selectWorkers('all').length).toBe(125);
     expect(selectWorkers('all')).toEqual(WORKER_REGISTRY);
   });
 
   it("'api' and 'worker' partition the set with no overlap and no loss", () => {
     const api = selectWorkers('api');
     const worker = selectWorkers('worker');
-    expect(api.length + worker.length).toBe(124);
+    expect(api.length + worker.length).toBe(125);
 
     const apiNames = new Set(api.map((e) => e.name));
     const workerNames = new Set(worker.map((e) => e.name));
@@ -102,7 +102,7 @@ describe('workerRegistry: selectWorkers', () => {
       expect(workerNames.has(name)).toBe(false);
     }
     const union = new Set([...apiNames, ...workerNames]);
-    expect(union.size).toBe(124);
+    expect(union.size).toBe(125);
   });
 
   it("'api' selects only socket-owner placements", () => {

--- a/apps/api/src/services/workerRegistry.ts
+++ b/apps/api/src/services/workerRegistry.ts
@@ -806,6 +806,18 @@ export const WORKER_REGISTRY: readonly WorkerRegistration[] = [
     },
   },
   {
+    // #4630 — dynamic device group membership re-evaluation. socket-owner, not
+    // global: its closure reaches jobs/peripheralJobs.ts (via
+    // services/groupMembership.ts), which is itself socket-owner. Verified by
+    // workerEntrypointClosure.contract.test.ts, not by guessing.
+    name: 'deviceGroupJobs',
+    placement: 'socket-owner',
+    load: async () => {
+      const m = await import('../jobs/deviceGroupJobs');
+      return { init: m.initializeDeviceGroupJobs, shutdown: m.shutdownDeviceGroupJobs };
+    },
+  },
+  {
     name: 'browserSecurityWorker',
     placement: 'global',
     load: async () => {


### PR DESCRIPTION
## Summary

Follow-up to **#5015**, which was squash-merged (`1a76507d3a`) before its review fixes landed. This PR addresses all five findings from the pr-review-toolkit (Opus) round on that PR, on top of current `main`.

The headline change: **dynamic device-group re-evaluation no longer runs on the request path.** It now goes through a coalescing BullMQ queue drained by a worker under `withSystemDbAccessContext`.

## Findings addressed

### 1. (critical) Re-evaluation ran inline inside the heartbeat's open PG transaction

`withDbAccessContext` is a real `baseDb.transaction(...)`, so `#5015`'s `await emitDeviceChange(...)` in `routes/agents/heartbeat.ts` ran *after* `UPDATE devices` took its row lock, and each membership flip made 2–3 Redis round trips (`schedulePeripheralPolicyDevice`) while holding a pooled Postgres connection. No debounce, no per-device coalescing — the pool-starvation shape from the 09-03 US incident, on the highest-volume endpoint in the product.

New `apps/api/src/jobs/deviceGroupJobs.ts`:

- Queue `device-group-reevaluation`, coalesced per device under `jobId = group-reeval-<deviceId>` — the same shape `jobs/peripheralJobs.ts` uses for `policy-reconciliation-<deviceId>`, including the *active-job follow-up* branch and the *spent-record replace* branch (a retained `failed` record under a fixed jobId silently swallows every later `add`; see `services/bullmqUtils.ts`).
- Coalescing **merges** rather than overwrites: changed fields are unioned, and `device.created` subsumes `device.updated` (created evaluates *every* dynamic group, so collapsing the pair the other way would drop groups).
- `requestDeviceGroupReevaluation` is **fire-and-forget** (`void`-ed at all three call sites) and never rejects, so not even the enqueue's own Redis round trips happen while the request transaction is open, and a Redis outage can't fail a heartbeat. It touches no Postgres connection, so unlike a detached DB call it can't be stranded on a committed transaction (the #3182 materialization bug).
- The worker wraps the evaluation in `withSystemDbAccessContext` and **re-reads the device's own `org_id` from the database** instead of trusting the job payload — the job outlives the request that produced it, and a membership row stamped from a stale payload org would be a cross-tenant row.
- Registered in `workerRegistry` as `deviceGroupJobs` with placement `socket-owner` (its closure reaches `jobs/peripheralJobs.ts` via `services/groupMembership.ts`) — confirmed by `workerEntrypointClosure.contract.test.ts`, not guessed.
- `initializeDeviceEventHandlers()` is now **idempotent** and called from the job processor. This is load-bearing: `worker.ts` never runs `index.ts`'s bootstrap, so a `worker`-role process would otherwise drain the queue with an empty handler registry and every job would be a silent no-op.

`routes/agents/heartbeat.ts`, `routes/agents/enrollment.ts` and `routes/devices/provision.ts` now contain no DB or Redis work for this feature at all — just the enqueue.

### 2. (critical) Unordered multi-group lock acquisition

`evaluateDeviceMembershipForGroup` → `ensureFilterFieldsUsed` UPDATEs `device_groups` when `filter_fields_used` is stale, so two concurrent evaluations that walk an org's groups in different orders can take the group row locks in opposite orders and deadlock (40P01, the #3911 shape). Added `ORDER BY id` to:

- the dynamic-group SELECT in `updateDeviceMembership` (`services/groupMembership.ts`) — the site the finding named;
- the `device.created` handler's group SELECT in `events/deviceEvents.ts`, which has the identical hazard.

### 3. (important) No integration test

New `apps/api/src/__tests__/integration/dynamicGroupReevaluation.integration.test.ts` drives the real queue processor against real Postgres, real forced RLS as `breeze_app`, and the real filter engine — mutating device rows exactly the way a heartbeat does. Six cases:

1. **add** — a hostname change that starts matching `hostname startsWith 'srv-'` materializes the membership row;
2. **remove** — the same device renamed out of the filter has its row deleted;
3. `device.created` picks up a device that already matched at insert (the enrollment/provision path);
4. the processor evaluates against the **device's** org, not the payload's;
5. a matching device in another partner's org is never absorbed;
6. a device deleted between enqueue and run is a clean no-op.

Every unit test on this path mocks either `groupMembership` or `deviceEvents`, so the two ways this feature silently does nothing — a contextless SELECT returning zero groups under forced RLS, and whether the compiled filter SQL actually matches the row after an UPDATE — are invisible to them.

**Proved discriminating:** commenting out the handler-registry init in the processor reds 4 of the 6 (see the run below).

### 4. (important) `Promise.allSettled` results never inspected

`emitDeviceChange` now logs every rejected handler at error level with the event type, device id and org id. A permanently-throwing evaluation used to leave a dynamic group stale forever with nothing in the logs — the #4630 failure mode all over again. The emit still resolves, so the BullMQ worker treats the job as done rather than retrying a deterministic failure forever.

### 5. (suggestion) Inert `routes/devices/groups.ts` wiring removed

That route's `createGroupSchema`/`updateGroupSchema` never accepted `filterConditions`, so `group.filterConditions` is always null and the `evaluateGroupMembership` branch could never fire. Removed it and the two mock-only tests that only proved the mock was called. Whether that duplicate route should gain filter support or be deleted in favour of `/groups` is the open question #4630 itself raises, and is not decided here.

## `Refs #4630`, not `Closes` — still-unwired call sites

#5015 claimed `Closes #4630`. It does not close it. Wired today: **agent heartbeat** (`hostname`, `osVersion`, `osBuild`, `deviceRole`), **agent enrollment**, **device provisioning**. Still unwired:

| Path | File | Why it matters |
|---|---|---|
| `PATCH /devices/:id` | `routes/devices/core.ts` | a tech renaming a device, or editing `displayName`/`tags`/`customFields`, does not re-evaluate |
| Site move (`siteId` on that PATCH) | `routes/devices/core.ts:1557` | `updateDeviceMembership`'s `changedFields.includes('siteId')` branch exists and has **no caller** |
| Org move | `routes/devices/moveOrg.ts` | memberships are *dropped* correctly, but the device is never evaluated against the destination org's dynamic groups |
| Tag changes | tag routes | `tags` is a filterable field with no emit |
| Hardware inventory ingest | `routes/agents/inventory.ts` | `device.hardware_updated` handler exists, no producer |
| Network inventory ingest | `routes/agents/inventory.ts` | `device.network_updated` handler exists, no producer |
| Software inventory ingest | `ingestSoftwareInventoryReport` | `device.software_changed` handler exists, no producer — needs a real "did the installed set change" signal first, or every routine sync re-evaluates every dynamic group in the org |
| Custom-field writes | `routes/devices/customFieldValues.ts` | `custom.*` filters go stale |
| Device delete | `routes/devices/core.ts` | `device.deleted` handler exists; hard delete already cascades memberships, soft-decommission deliberately left alone (evicting a decommissioned device that still matches would be a behaviour change) |
| Periodic reconciliation sweep | — | the issue's suggested backstop #2; no drift repair exists |

Each of those is a `requestDeviceGroupReevaluation(...)` call now that the queue exists, but they are behaviour changes with their own blast radius and belong in follow-up PRs.

## Verification

```
cd apps/api

NODE_OPTIONS="--max-old-space-size=8192" npx tsc --noEmit -p .        # exit 0

npx vitest run src/routes/agents src/routes/devices src/events \
  src/jobs/deviceGroupJobs.test.ts src/services/groupMembership \
  src/services/workerRegistry.test.ts \
  src/services/workerEntrypointClosure.contract.test.ts \
  src/routes/groups.test.ts
#  Test Files  104 passed (104)
#       Tests  1858 passed (1858)

npx eslint <all changed files>                                        # clean
```

Integration suite, real Postgres (`localhost:5433/breeze_test`):

```
BREEZE_INTEGRATION_ALLOW_LEDGER_DRIFT=1 npx vitest run \
  --config vitest.integration.config.ts --reporter=verbose \
  src/__tests__/integration/dynamicGroupReevaluation

 ✓ dynamic device group re-evaluation on device change (#4630) > adds the device when a hostname change starts matching the filter 280ms
 ✓ dynamic device group re-evaluation on device change (#4630) > removes the device when a hostname change stops matching the filter 240ms
 ✓ dynamic device group re-evaluation on device change (#4630) > picks up a device that already matched at insert (device.created) 251ms
 ✓ dynamic device group re-evaluation on device change (#4630) > evaluates against the DEVICE's org, not the org named in the job payload 317ms
 ✓ dynamic device group re-evaluation on device change (#4630) > never absorbs a matching device from another tenant 246ms
 ✓ dynamic device group re-evaluation on device change (#4630) > no-ops for a device deleted between enqueue and run 204ms

 Test Files  1 passed (1)
      Tests  6 passed (6)
```

(`BREEZE_INTEGRATION_ALLOW_LEDGER_DRIFT=1` only because the shared local test DB carries one migration this checkout predates; this suite enumerates no schema, so the drift is inert here. CI runs it against a clean database with no flag.)

**Mutation control** — commenting out `initializeDeviceEventHandlers()` in `processDeviceGroupReevaluation`, i.e. simulating exactly the worker-role blind spot the idempotent init closes:

```
 × adds the device when a hostname change starts matching the filter
 × removes the device when a hostname change stops matching the filter
 × picks up a device that already matched at insert (device.created)
 × evaluates against the DEVICE's org, not the org named in the job payload

 Tests  4 failed | 2 passed (6)
```

## Tenancy

No new tables, no migration. `device_groups` and `device_group_memberships` are org-only and already registered in every cascade/export list. The one tenancy-relevant addition is the worker's org re-read (finding 1), covered by integration cases 4 and 5.

## Notes for reviewer

- The three call sites deliberately do **not** `await` the enqueue. Two tests pin that: a never-settling mock still returns 200 from the heartbeat and 201 from enrollment, so re-adding an `await` hangs those tests to their timeout rather than passing quietly.
- `WORKER_REGISTRY` grows 123 → 124; `workerRegistry.test.ts` and `workerEntrypointClosure.contract.test.ts` updated accordingly. The `socket-owner` placement is what the closure contract test computes, not a judgement call.

Refs #4630

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpNjRgZYEmxZfr4axwGBQk
