### PR TITLE
feat(web): locale cookie + Astro.locals.locale + html lang attribute

### DIFF
--- a/apps/web/src/env.d.ts
+++ b/apps/web/src/env.d.ts
@@ -1,5 +1,11 @@
 /// <reference types="astro/client" />
 
+declare namespace App {
+  interface Locals {
+    locale?: import('@breeze/shared').SupportedLocale;
+  }
+}
+
 interface ImportMetaEnv {
   readonly PUBLIC_ENABLE_ENDPOINT_AV_FEATURES?: string;
   readonly PUBLIC_ENABLE_NETWORK_DEVICES_IN_LIST?: string;

--- a/apps/web/src/layouts/AuthLayout.astro
+++ b/apps/web/src/layouts/AuthLayout.astro
@@ -10,7 +10,7 @@ const { title } = Astro.props;
 ---
 
 <!DOCTYPE html>
-<html lang="en">
+<html lang={Astro.locals.locale ?? 'en'}>
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/apps/web/src/layouts/AuthShellBranded.astro
+++ b/apps/web/src/layouts/AuthShellBranded.astro
@@ -17,7 +17,7 @@ const {
 ---
 
 <!DOCTYPE html>
-<html lang="en">
+<html lang={Astro.locals.locale ?? 'en'}>
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/apps/web/src/layouts/ErrorLayout.astro
+++ b/apps/web/src/layouts/ErrorLayout.astro
@@ -10,7 +10,7 @@ const { title, statusCode } = Astro.props;
 ---
 
 <!DOCTYPE html>
-<html lang="en">
+<html lang={Astro.locals.locale ?? 'en'}>
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/apps/web/src/layouts/Layout.astro
+++ b/apps/web/src/layouts/Layout.astro
@@ -10,7 +10,7 @@ const { title } = Astro.props;
 ---
 
 <!DOCTYPE html>
-<html lang="en">
+<html lang={Astro.locals.locale ?? 'en'}>
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/apps/web/src/layouts/SetupLayout.astro
+++ b/apps/web/src/layouts/SetupLayout.astro
@@ -10,7 +10,7 @@ const { title } = Astro.props;
 ---
 
 <!DOCTYPE html>
-<html lang="en">
+<html lang={Astro.locals.locale ?? 'en'}>
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/apps/web/src/lib/__tests__/localePreference.test.ts
+++ b/apps/web/src/lib/__tests__/localePreference.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, beforeEach, vi, afterEach } from 'vitest';
 import {
   LOCALE_OPTIONS,
+  LOCALE_COOKIE_NAME,
   LOCALE_STORAGE_KEY,
   PARTNER_LOCALE_STORAGE_KEY,
   isValidLocale,
@@ -16,9 +17,17 @@ import {
   applyAppearancePreferences,
 } from '../appearance';
 
+function clearCookies(): void {
+  for (const pair of document.cookie.split(';')) {
+    const name = pair.split('=')[0]?.trim();
+    if (name) document.cookie = `${name}=; Path=/; Max-Age=0`;
+  }
+}
+
 describe('locale preference', () => {
   beforeEach(() => {
     window.localStorage.clear();
+    clearCookies();
   });
   afterEach(() => {
     vi.unstubAllGlobals();
@@ -126,5 +135,29 @@ describe('locale preference', () => {
     expect(readLocalePreference()).toBe('pt-BR');
     applyAppearancePreferences({});
     expect(readLocalePreference()).toBe('pt-BR'); // untouched when absent
+  });
+
+  it('mirrors an explicit locale write into the breeze.locale cookie', () => {
+    writeLocalePreference('pt-BR');
+    expect(document.cookie).toContain(`${LOCALE_COOKIE_NAME}=pt-BR`);
+
+    writeLocalePreference('fr-CA');
+    expect(document.cookie).toContain(`${LOCALE_COOKIE_NAME}=fr-CA`);
+  });
+
+  it('applyResolvedLocalePreferences mirrors the resolved user/partner locale into the cookie', () => {
+    applyResolvedLocalePreferences(undefined, 'pt-BR');
+    expect(document.cookie).toContain(`${LOCALE_COOKIE_NAME}=pt-BR`);
+
+    applyResolvedLocalePreferences('de-DE', 'pt-BR');
+    expect(document.cookie).toContain(`${LOCALE_COOKIE_NAME}=de-DE`);
+  });
+
+  it('applyResolvedLocalePreferences clears the cookie when neither user nor partner locale is set', () => {
+    applyResolvedLocalePreferences('pt-BR', undefined);
+    expect(document.cookie).toContain(LOCALE_COOKIE_NAME);
+
+    applyResolvedLocalePreferences(undefined, undefined);
+    expect(document.cookie).not.toContain(`${LOCALE_COOKIE_NAME}=pt-BR`);
   });
 });

--- a/apps/web/src/lib/appearance.ts
+++ b/apps/web/src/lib/appearance.ts
@@ -44,6 +44,14 @@ export const FONT_STORAGE_KEY = 'breeze.font';
 export const TIME_FORMAT_STORAGE_KEY = 'breeze.timeFormat';
 export const LOCALE_STORAGE_KEY = 'breeze.locale';
 export const PARTNER_LOCALE_STORAGE_KEY = 'breeze.partnerLocale';
+
+/**
+ * Mirrors the localStorage locale preference into a cookie so Astro SSR
+ * (which has no access to localStorage) can render the shell in the right
+ * language on first paint. localStorage stays the client source of truth —
+ * see writeLocaleCookie's callers.
+ */
+export const LOCALE_COOKIE_NAME = 'breeze.locale';
 export const LINKED_PROFILE_COLLAPSE_STORAGE_KEY = 'breeze.collapseLinkedProfiles';
 
 export function isValidTheme(value: unknown): value is ThemePreference {
@@ -124,6 +132,17 @@ function removeStorageValue(key: string): void {
     window.localStorage?.removeItem(key);
   } catch {
     // Storage unavailable: the runtime resolution still uses browser defaults.
+  }
+}
+
+function writeLocaleCookie(value: LocalePreference | undefined): void {
+  if (typeof document === 'undefined') return;
+  try {
+    document.cookie = value === undefined
+      ? `${LOCALE_COOKIE_NAME}=; Path=/; Max-Age=0; SameSite=Lax`
+      : `${LOCALE_COOKIE_NAME}=${value}; Path=/; Max-Age=31536000; SameSite=Lax`;
+  } catch {
+    // Cookie write failures must not break the preference itself.
   }
 }
 
@@ -266,6 +285,7 @@ export function writeTimeFormatPreference(value: TimeFormatPreference): void {
 export function writeLocalePreference(value: LocalePreference): void {
   if (!isValidLocale(value)) return;
   writeStorageValue(LOCALE_STORAGE_KEY, value);
+  writeLocaleCookie(value);
   notifyLocale(value);
 }
 
@@ -300,6 +320,11 @@ export function applyResolvedLocalePreferences(
 
   if (normalizedPartner) writeStorageValue(PARTNER_LOCALE_STORAGE_KEY, normalizedPartner);
   else removeStorageValue(PARTNER_LOCALE_STORAGE_KEY);
+
+  // Mirror only an explicit user/partner locale into the cookie — an
+  // undetermined browser default is a per-request client heuristic, not a
+  // preference worth pinning server-side for a year.
+  writeLocaleCookie(normalizedUser ?? normalizedPartner);
 
   const resolved = normalizedUser ?? normalizedPartner ?? detectBrowserLocale();
   notifyLocale(resolved);

--- a/apps/web/src/middleware.test.ts
+++ b/apps/web/src/middleware.test.ts
@@ -3,7 +3,19 @@ import { join } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
-import { buildFallbackCspDirectives, relaxExistingCsp } from './middleware';
+import { buildFallbackCspDirectives, relaxExistingCsp, resolveLocaleFromCookie, onRequest } from './middleware';
+import { LOCALE_COOKIE_NAME } from './lib/appearance';
+
+type MockLocals = { locale?: string };
+
+function makeContext(cookieValue: string | undefined) {
+  return {
+    cookies: {
+      get: (name: string) => (name === LOCALE_COOKIE_NAME && cookieValue !== undefined ? { value: cookieValue } : undefined),
+    },
+    locals: {} as MockLocals,
+  };
+}
 
 // #1023: Monaco is now self-hosted from /monaco/vs, so cdn.jsdelivr.net — a
 // broad package-CDN gadget host — must no longer appear in any CSP directive.
@@ -70,5 +82,35 @@ describe('CSP directives drop the jsdelivr CDN (#1023)', () => {
     const frameSrcSet = source.match(/new Set\(\[[^\]]*docs\.breezermm\.com[^\]]*\]\)/);
     expect(frameSrcSet, 'frame-src source Set not found in astro.config.mjs').not.toBeNull();
     expect(frameSrcSet![0]).toContain("'blob:'");
+  });
+});
+
+describe('locale cookie -> context.locals.locale', () => {
+  it('accepts any of the 8 supported locales, not just en/pt-BR', () => {
+    for (const locale of ['en', 'pt-BR', 'es-419', 'fr-FR', 'fr-CA', 'de-DE', 'it-IT', 'tr-TR']) {
+      expect(resolveLocaleFromCookie(locale)).toBe(locale);
+    }
+  });
+
+  it('rejects unsupported or missing cookie values', () => {
+    expect(resolveLocaleFromCookie('fr')).toBeUndefined();
+    expect(resolveLocaleFromCookie('klingon')).toBeUndefined();
+    expect(resolveLocaleFromCookie(undefined)).toBeUndefined();
+  });
+
+  it('onRequest sets context.locals.locale from a valid breeze.locale cookie', async () => {
+    const context = makeContext('fr-CA');
+    await onRequest(context as any, async () => new Response('ok'));
+    expect(context.locals.locale).toBe('fr-CA');
+  });
+
+  it('onRequest leaves context.locals.locale undefined for a missing or invalid cookie', async () => {
+    const missing = makeContext(undefined);
+    await onRequest(missing as any, async () => new Response('ok'));
+    expect(missing.locals.locale).toBeUndefined();
+
+    const invalid = makeContext('klingon');
+    await onRequest(invalid as any, async () => new Response('ok'));
+    expect(invalid.locals.locale).toBeUndefined();
   });
 });

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,5 +1,12 @@
 import { defineMiddleware } from 'astro:middleware';
+import { isSupportedLocale, type SupportedLocale } from '@breeze/shared';
 import { resolveConnectSrcDirective, resolveFrameSrcDirective, resolveUnsafeInlineCspOptions } from './lib/csp';
+import { LOCALE_COOKIE_NAME } from './lib/appearance';
+
+/** Exported for direct unit testing alongside the CSP helpers below. */
+export function resolveLocaleFromCookie(value: string | undefined): SupportedLocale | undefined {
+  return isSupportedLocale(value) ? value : undefined;
+}
 
 function readFlag(name: string): boolean {
   const raw = process.env[name]?.trim().toLowerCase();
@@ -116,7 +123,9 @@ export function relaxExistingCsp(
   return directives.join('; ');
 }
 
-export const onRequest = defineMiddleware(async (_context, next) => {
+export const onRequest = defineMiddleware(async (context, next) => {
+  context.locals.locale = resolveLocaleFromCookie(context.cookies.get(LOCALE_COOKIE_NAME)?.value);
+
   const response = await next();
   const headers = new Headers(response.headers);
   const strictDevCsp = import.meta.env.DEV && readFlag('CSP_STRICT_DEV');


### PR DESCRIPTION
## Summary

Phase-3 **Task 1** of the in-repo plan `docs/superpowers/plans/open/2026-07-10-web-i18n-phase3-ssr-and-api-messages.md`: give the SSR shell a locale to render with, so a non-English user gets the right `<html lang>` on first paint instead of the hardcoded `en`.

- `appearance.ts` now mirrors the localStorage locale preference into a `breeze.locale` cookie (localStorage stays the client source of truth; the cookie exists only so SSR, which can't read localStorage, has the value).
- `middleware.ts` reads that cookie into `Astro.locals.locale` (the middleware previously ignored `context` entirely — it was CSP-only, so this is clean net-new).
- The 5 root layouts render `<html lang={Astro.locals.locale ?? 'en'}>`.
- `App.Locals` is declared in `env.d.ts`.

## Linked issues

Part of #3859. This is the first of the plan's stacked PRs (Task 1); Tasks 2–4 (SSR shell strings / `tServer`, additive API error codes, adoption waves) follow separately, so this PR intentionally does **not** close the issue.

## Deviation from the plan (worth a look)

The plan was written when only `['en','pt-BR']` shipped and hardcodes that pair. The project now ships **8 locales**, so I widened every locale surface to the existing single source of truth in `@breeze/shared`:

- `middleware.ts` validates the cookie with `isSupportedLocale` from `@breeze/shared` (rather than the plan's inline two-literal check), so all 8 locales resolve and the set can't drift out of sync again.
- `env.d.ts` types `locale?: import('@breeze/shared').SupportedLocale`.
- Cookie attributes per the plan: `Path=/; Max-Age=31536000; SameSite=Lax`, not `HttpOnly` (client JS writes it), no hardcoded `Secure` (dev is http).
- The cookie mirror only pins an explicit user/partner locale — an undetermined browser default is a per-request heuristic and is not written server-side.

## Type of change

- [x] New feature (non-breaking)

## Verification

Run locally against `feat/i18n-phase3-task1` (Node 22.23, 4 vCPU):

| Check | Result |
| --- | --- |
| `pnpm lint` | pass |
| `pnpm --filter=@breeze/web exec astro check` | **0 errors**, 0 warnings, 252 hints (1877 files) |
| Task-1 unit tests (`localePreference.test.ts`, `middleware.test.ts`) | **29 passed** — cookie mirror cases + `locals.locale` extraction |
| `pnpm build --filter=@breeze/web` | pass |

`astro check` and the web build need `NODE_OPTIONS=--max-old-space-size=6144` on an 8 GB host.

## Notes

Additive and scoped: no existing behavior changes, no client i18n module imported into `.astro` shells, no React-island SSR touched. Tasks 2–4 build on the `Astro.locals.locale` seam introduced here.
