### PR TITLE
feat(api): custom-field definitions importer — preview + commit (#3257 W07)

### DIFF
--- a/apps/api/src/__tests__/integration/customFieldDefinitionImport.integration.test.ts
+++ b/apps/api/src/__tests__/integration/customFieldDefinitionImport.integration.test.ts
@@ -1,0 +1,421 @@
+/**
+ * Custom-field DEFINITION importer against real Postgres (#3257 W07, #4775).
+ *
+ * Four things this suite exists to prove, none of which a mocked unit test can:
+ *
+ *  a. A partner-wide import from a caller without `canManagePartnerWidePolicies`
+ *     is refused **403** at preview AND at commit, through the real route stack
+ *     (real `resolveImportPartnerId`, real capability helper) — not a 200 with
+ *     an annotation the browser might ignore.
+ *  b. A cross-axis shadow is annotated `key-shadowed` at PREVIEW, and if
+ *     submitted anyway the commit refuses it with the same code — driven by
+ *     W03's real `custom_field_definitions_no_shadow` trigger (P0001), not by a
+ *     stub.
+ *  c. TOCTOU: a definition created BETWEEN preview and commit flips the
+ *     annotation, and the row is rejected with `annotation-changed` rather than
+ *     silently becoming a no-op or a duplicate.
+ *  d. Organization isolation: a row naming an organization outside the caller's
+ *     reach never lands, and reports `org-not-found` rather than acting as an
+ *     existence oracle.
+ *
+ * ── Why the middleware is re-created rather than stubbed away ───────────────
+ * `authMiddleware` does two things this suite depends on: it puts an
+ * `AuthContext` on the request, and it opens the request's
+ * `withDbAccessContext` transaction. `fakeAuth` below does BOTH, so the route
+ * handlers, the service's per-row nested `db.transaction` (a SAVEPOINT inside
+ * that request transaction) and RLS all behave exactly as they do in
+ * production. Only the token exchange is skipped.
+ *
+ * The importer's snapshot READ runs in a system context by design (the table
+ * has no partner-wide RLS SELECT branch — `PARTNER_WIDE_SELECT_BRANCH_EXEMPT`,
+ * TODO #4944), so RLS is NOT the control on it. Test (d) is therefore an
+ * app-layer assertion by necessity, and asserting it here — under a real
+ * system-context read — is the only place it can be proven at all.
+ */
+import './setup';
+import { afterEach, describe, expect, it } from 'vitest';
+import { and, eq } from 'drizzle-orm';
+import { Hono } from 'hono';
+import { db, withDbAccessContext, type DbAccessContext } from '../../db';
+import { customFieldDefinitions } from '../../db/schema';
+import {
+  assignUserToOrganization,
+  assignUserToPartner,
+  createOrganization,
+  createPartner,
+  createRole,
+  createUser,
+  grantRolePermissions,
+} from './db-utils';
+import { pgErrorCode, pgErrorNode } from '../../utils/pgErrors';
+import { customFieldImportRoutes } from '../../routes/customFieldImport';
+import { PARTNER_WIDE_WRITE_DENIED_MESSAGE } from '../../services/partnerWideAccess';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+const SYSTEM_CTX: DbAccessContext = {
+  scope: 'system',
+  orgId: null,
+  accessibleOrgIds: null,
+  accessiblePartnerIds: null,
+  userId: null,
+};
+
+const createdDefinitions: string[] = [];
+
+afterEach(async () => {
+  if (createdDefinitions.length === 0) return;
+  await withDbAccessContext(SYSTEM_CTX, async () => {
+    for (const id of createdDefinitions) {
+      await db.delete(customFieldDefinitions).where(eq(customFieldDefinitions.id, id));
+    }
+  });
+  createdDefinitions.length = 0;
+});
+
+/**
+ * The shape `middleware/auth` puts on the request.
+ *
+ * `token.mfa` and the `user` row are real requirements, not decoration: the
+ * routes mount the REAL `requireMfa()` and the REAL `requirePermission()`, and
+ * the latter resolves `devices:write` out of the permissions catalog for this
+ * user id. The fixtures below therefore create a genuine user + membership +
+ * role + grant, so the whole middleware chain runs — only the token exchange is
+ * skipped.
+ */
+interface FakeAuth {
+  scope: 'organization' | 'partner' | 'system';
+  partnerId: string | null;
+  orgId: string | null;
+  accessibleOrgIds: string[] | null;
+  partnerOrgAccess: 'all' | 'selected' | null;
+  user: { id: string; email: string };
+  token: { mfa: boolean };
+}
+
+const DEVICES_WRITE = [{ resource: 'devices', action: 'write' }];
+
+async function partnerAuth(
+  partnerId: string,
+  orgIds: string[],
+  orgAccess: 'all' | 'selected',
+): Promise<FakeAuth> {
+  const role = await createRole({ scope: 'partner', partnerId });
+  await grantRolePermissions(role.id, DEVICES_WRITE);
+  const user = await createUser({ partnerId });
+  await assignUserToPartner(user.id, partnerId, role.id, orgAccess);
+  return {
+    scope: 'partner',
+    partnerId,
+    orgId: null,
+    accessibleOrgIds: orgIds,
+    partnerOrgAccess: orgAccess,
+    user: { id: user.id, email: user.email },
+    token: { mfa: true },
+  };
+}
+
+async function orgAuth(partnerId: string, orgId: string): Promise<FakeAuth> {
+  const role = await createRole({ scope: 'organization', orgId });
+  await grantRolePermissions(role.id, DEVICES_WRITE);
+  const user = await createUser({ partnerId, orgId });
+  await assignUserToOrganization(user.id, orgId, role.id);
+  return {
+    scope: 'organization',
+    partnerId,
+    orgId,
+    accessibleOrgIds: [orgId],
+    partnerOrgAccess: null,
+    user: { id: user.id, email: user.email },
+    token: { mfa: true },
+  };
+}
+
+function dbContextFor(auth: FakeAuth): DbAccessContext {
+  return {
+    scope: auth.scope,
+    orgId: auth.orgId,
+    accessibleOrgIds: auth.accessibleOrgIds,
+    accessiblePartnerIds: auth.scope === 'partner' && auth.partnerId ? [auth.partnerId] : [],
+    userId: auth.user?.id ?? null,
+  };
+}
+
+/**
+ * Stand up the real route app with everything but the token exchange intact:
+ * the auth context AND the request's db access transaction, exactly as
+ * `authMiddleware` provides them.
+ */
+function appFor(auth: FakeAuth) {
+  const app = new Hono();
+  app.use('*', async (c, next) => {
+    c.set('auth', auth as never);
+    await withDbAccessContext(dbContextFor(auth), () => next());
+  });
+  app.route('/custom-fields', customFieldImportRoutes);
+  return app;
+}
+
+async function post(auth: FakeAuth, path: string, body: unknown) {
+  const res = await appFor(auth).request(path, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: 'Bearer test' },
+    body: JSON.stringify(body),
+  });
+  return { status: res.status, body: (await res.json()) as any };
+}
+
+const PREVIEW = '/custom-fields/import/preview';
+const COMMIT = '/custom-fields/import';
+
+async function seedDefinition(
+  owner: { orgId: string | null; partnerId: string | null },
+  fieldKey: string,
+  type: 'text' | 'date',
+): Promise<string> {
+  const rows = await withDbAccessContext(SYSTEM_CTX, () =>
+    db
+      .insert(customFieldDefinitions)
+      .values({ ...owner, name: fieldKey, fieldKey, type })
+      .returning({ id: customFieldDefinitions.id }),
+  );
+  const id = rows[0]!.id;
+  createdDefinitions.push(id);
+  return id;
+}
+
+async function definitionCount(fieldKey: string, orgId: string | null, partnerId: string | null) {
+  return withDbAccessContext(SYSTEM_CTX, async () => {
+    const rows = await db
+      .select({ id: customFieldDefinitions.id })
+      .from(customFieldDefinitions)
+      .where(
+        and(
+          eq(customFieldDefinitions.fieldKey, fieldKey),
+          orgId ? eq(customFieldDefinitions.orgId, orgId) : eq(customFieldDefinitions.partnerId, partnerId!),
+        ),
+      );
+    for (const r of rows) if (!createdDefinitions.includes(r.id)) createdDefinitions.push(r.id);
+    return rows.length;
+  });
+}
+
+/** Unique per test so a parallel shard cannot collide on the per-axis unique index. */
+function uniqueKey(prefix: string): string {
+  return `${prefix}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+describe('custom-field definition import (integration)', () => {
+  runDb('refuses a partner-wide import from an org-scoped caller with 403 at preview AND commit', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const auth = await orgAuth(partner.id, org.id);
+    const fieldKey = uniqueKey('udf_pw');
+    const rows = [{ fieldKey, name: 'Warranty', type: 'date', ownerScope: 'partner' }];
+
+    const preview = await post(auth, PREVIEW, { rows });
+    expect(preview.status).toBe(403);
+    expect(preview.body.error).toBe(PARTNER_WIDE_WRITE_DENIED_MESSAGE);
+
+    const commit = await post(auth, COMMIT, { rows: [{ ...rows[0], expectedAnnotation: 'create' }] });
+    expect(commit.status).toBe(403);
+
+    // The refusal is real, not cosmetic: nothing was written on either call.
+    expect(await definitionCount(fieldKey, null, partner.id)).toBe(0);
+  });
+
+  runDb('refuses a partner-wide import from a `selected` partner user with 403', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const fieldKey = uniqueKey('udf_sel');
+    const auth = await partnerAuth(partner.id, [org.id], 'selected');
+
+    const preview = await post(auth, PREVIEW, {
+      rows: [{ fieldKey, name: 'Warranty', type: 'date', ownerScope: 'partner' }],
+    });
+    expect(preview.status).toBe(403);
+    expect(await definitionCount(fieldKey, null, partner.id)).toBe(0);
+  });
+
+  runDb('annotates a cross-axis shadow at preview and refuses it at commit', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const fieldKey = uniqueKey('udf_shadow');
+    await seedDefinition({ orgId: null, partnerId: partner.id }, fieldKey, 'text');
+
+    const auth = await partnerAuth(partner.id, [org.id], 'all');
+    const row = { fieldKey, name: 'Local copy', type: 'text', ownerScope: 'organization', organizationId: org.id };
+
+    const preview = await post(auth, PREVIEW, { rows: [row] });
+    expect(preview.status).toBe(200);
+    expect(preview.body.rows[0].annotation).toBe('key-shadowed');
+
+    // Submitted anyway, acknowledged as a `create`: refused, with the shadow
+    // reported rather than an unexplained write failure.
+    const commit = await post(auth, COMMIT, { rows: [{ ...row, expectedAnnotation: 'create' }] });
+    expect(commit.status).toBe(200);
+    expect(commit.body.created).toHaveLength(0);
+    expect(commit.body.errors[0].code).toBe('key-shadowed');
+    expect(await definitionCount(fieldKey, org.id, null)).toBe(0);
+  });
+
+  runDb("proves W03's trigger — not just the snapshot — refuses the shadow", async () => {
+    // The service annotates from a snapshot. If that snapshot were wrong, the
+    // DATABASE must still refuse the write. Forge the insert directly to show
+    // the trigger is live and raises P0001, which is what the commit path maps
+    // to `key-shadowed` when a shadow appears after the snapshot was taken.
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const fieldKey = uniqueKey('udf_trig');
+    await seedDefinition({ orgId: null, partnerId: partner.id }, fieldKey, 'text');
+
+    let thrown: unknown;
+    try {
+      await withDbAccessContext(SYSTEM_CTX, () =>
+        db.insert(customFieldDefinitions).values({
+          orgId: org.id,
+          partnerId: null,
+          name: 'forged',
+          fieldKey,
+          type: 'text',
+        }),
+      );
+    } catch (err) {
+      thrown = err;
+    }
+    // Drizzle wraps the driver error, so the SQLSTATE lives on `.cause` — which
+    // is exactly why the service reads it through `pgErrorCode` rather than
+    // `err.code`. A check on the outer error would pass vacuously here and miss
+    // every real trigger violation in production.
+    expect(pgErrorCode(thrown)).toBe('P0001');
+    expect(pgErrorNode(thrown)?.constraint_name).toBe('custom_field_definitions_no_shadow');
+  });
+
+  runDb('rejects a row whose annotation changed between preview and commit (TOCTOU)', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const auth = await partnerAuth(partner.id, [org.id], 'all');
+    const fieldKey = uniqueKey('udf_toctou');
+    const row = { fieldKey, name: 'Warranty', type: 'date', ownerScope: 'partner' };
+
+    const preview = await post(auth, PREVIEW, { rows: [row] });
+    expect(preview.body.rows[0].annotation).toBe('create');
+
+    // Someone else creates it in the window between preview and commit.
+    const raced = await seedDefinition({ orgId: null, partnerId: partner.id }, fieldKey, 'date');
+
+    const commit = await post(auth, COMMIT, { rows: [{ ...row, expectedAnnotation: 'create' }] });
+    expect(commit.status).toBe(200);
+    expect(commit.body.created).toHaveLength(0);
+    expect(commit.body.errors[0].code).toBe('annotation-changed');
+    // The acknowledged `create` did NOT silently become a no-op against the
+    // row that appeared: exactly one definition exists, the raced one.
+    expect(await definitionCount(fieldKey, null, partner.id)).toBe(1);
+    expect(createdDefinitions).toContain(raced);
+  });
+
+  runDb('rejects an already-exists acknowledgement pinned to a definition that changed hands', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const auth = await partnerAuth(partner.id, [org.id], 'all');
+    const fieldKey = uniqueKey('udf_pin');
+    await seedDefinition({ orgId: null, partnerId: partner.id }, fieldKey, 'date');
+
+    const commit = await post(auth, COMMIT, {
+      rows: [{
+        fieldKey,
+        name: 'Warranty',
+        type: 'date',
+        ownerScope: 'partner',
+        expectedAnnotation: 'already-exists',
+        expectedDefinitionId: '99999999-9999-4999-8999-999999999999',
+      }],
+    });
+    expect(commit.body.errors[0].code).toBe('match-changed');
+    expect(commit.body.skipped).toHaveLength(0);
+  });
+
+  runDb('never lands a row naming an organization outside the caller reach', async () => {
+    const partner = await createPartner();
+    const mine = await createOrganization({ partnerId: partner.id });
+    const theirs = await createOrganization({ partnerId: partner.id });
+    // A partner user restricted to `mine` — `theirs` exists and is under the
+    // same partner, which is the case a partner-only filter would let through.
+    const auth = await partnerAuth(partner.id, [mine.id], 'all');
+    const fieldKey = uniqueKey('udf_iso');
+
+    const preview = await post(auth, PREVIEW, {
+      rows: [{ fieldKey, name: 'Asset tag', type: 'text', ownerScope: 'organization', organizationId: theirs.id }],
+    });
+    expect(preview.body.rows[0].annotation).toBe('org-not-found');
+
+    const commit = await post(auth, COMMIT, {
+      rows: [{
+        fieldKey,
+        name: 'Asset tag',
+        type: 'text',
+        ownerScope: 'organization',
+        organizationId: theirs.id,
+        expectedAnnotation: 'create',
+      }],
+    });
+    expect(commit.body.created).toHaveLength(0);
+    expect(commit.body.errors[0].code).toBe('org-not-found');
+    expect(await definitionCount(fieldKey, theirs.id, null)).toBe(0);
+  });
+
+  runDb('creates, then skips on re-import, and isolates a failing row from a good one', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const auth = await partnerAuth(partner.id, [org.id], 'all');
+    const goodKey = uniqueKey('udf_ok');
+    const shadowKey = uniqueKey('udf_bad');
+    await seedDefinition({ orgId: null, partnerId: partner.id }, shadowKey, 'text');
+
+    const first = await post(auth, COMMIT, {
+      externalSystem: 'datto_rmm',
+      rows: [
+        { fieldKey: goodKey, name: 'Asset tag', type: 'text', ownerScope: 'organization', organizationId: org.id, sourceLabel: 'udf7', expectedAnnotation: 'create' },
+        { fieldKey: shadowKey, name: 'Shadow', type: 'text', ownerScope: 'organization', organizationId: org.id, expectedAnnotation: 'create' },
+      ],
+    });
+    expect(first.status).toBe(200);
+    expect(first.body.created).toHaveLength(1);
+    expect(first.body.created[0]).toMatchObject({ index: 0, fieldKey: goodKey, ownerScope: 'organization' });
+    // The refused row did not cost the good one: per-row isolation is real,
+    // which inside ONE request transaction is only true because each write runs
+    // in its own nested transaction (SAVEPOINT).
+    expect(first.body.errors[0]).toMatchObject({ index: 1, code: 'key-shadowed' });
+    createdDefinitions.push(first.body.created[0].definitionId);
+
+    // Re-importing the same file writes nothing.
+    const again = await post(auth, COMMIT, {
+      rows: [{
+        fieldKey: goodKey,
+        name: 'Asset tag',
+        type: 'text',
+        ownerScope: 'organization',
+        organizationId: org.id,
+        expectedAnnotation: 'already-exists',
+        expectedDefinitionId: first.body.created[0].definitionId,
+      }],
+    });
+    expect(again.body.created).toHaveLength(0);
+    expect(again.body.skipped[0]).toMatchObject({ fieldKey: goodKey, reason: 'already-exists' });
+    expect(await definitionCount(goodKey, org.id, null)).toBe(1);
+  });
+
+  runDb('never leaks the driver message for a failed write', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const auth = await partnerAuth(partner.id, [org.id], 'all');
+    const fieldKey = uniqueKey('udf_leak');
+    await seedDefinition({ orgId: null, partnerId: partner.id }, fieldKey, 'text');
+
+    const commit = await post(auth, COMMIT, {
+      rows: [{ fieldKey, name: 'X', type: 'text', ownerScope: 'organization', organizationId: org.id, expectedAnnotation: 'create' }],
+    });
+    const serialized = JSON.stringify(commit.body);
+    expect(serialized).not.toMatch(/DETAIL|insert into|select .* from/i);
+  });
+});

--- a/apps/api/src/__tests__/integration/customFieldDefinitionImport.integration.test.ts
+++ b/apps/api/src/__tests__/integration/customFieldDefinitionImport.integration.test.ts
@@ -47,7 +47,13 @@ import {
   createUser,
   grantRolePermissions,
 } from './db-utils';
+import { buildDbAccessContext } from '../../middleware/auth';
 import { pgErrorCode, pgErrorNode } from '../../utils/pgErrors';
+import {
+  commitCustomFieldDefinitionImport,
+  previewCustomFieldDefinitionImport,
+  type DefinitionImportContext,
+} from '../../services/customFields/import/definitionImport';
 import { customFieldImportRoutes } from '../../routes/customFieldImport';
 import { PARTNER_WIDE_WRITE_DENIED_MESSAGE } from '../../services/partnerWideAccess';
 
@@ -131,14 +137,22 @@ async function orgAuth(partnerId: string, orgId: string): Promise<FakeAuth> {
   };
 }
 
+/**
+ * Built with the CANONICAL helper, not by hand. `buildDbAccessContext` derives
+ * `accessiblePartnerIds` from scope+partnerId and sets `currentPartnerId` —
+ * a hand-rolled copy would drift from the request path (and `currentPartnerId`
+ * becomes load-bearing for this table the day #4944 adds its partner-wide
+ * SELECT branch, at which point a harness that omitted it would quietly stop
+ * proving anything about that path).
+ */
 function dbContextFor(auth: FakeAuth): DbAccessContext {
-  return {
+  return buildDbAccessContext({
     scope: auth.scope,
     orgId: auth.orgId,
     accessibleOrgIds: auth.accessibleOrgIds,
-    accessiblePartnerIds: auth.scope === 'partner' && auth.partnerId ? [auth.partnerId] : [],
-    userId: auth.user?.id ?? null,
-  };
+    partnerId: auth.partnerId,
+    userId: auth.user.id,
+  });
 }
 
 /**
@@ -405,17 +419,93 @@ describe('custom-field definition import (integration)', () => {
     expect(await definitionCount(goodKey, org.id, null)).toBe(1);
   });
 
-  runDb('never leaks the driver message for a failed write', async () => {
+  runDb('isolates a REAL write-time database refusal from a good row in the same batch', async () => {
+    // Every other refusal in this suite is caught by the snapshot BEFORE any
+    // insert is attempted, so none of them exercises the per-row nested
+    // transaction under an actual failing statement. This one does.
+    //
+    // The setup is the one legitimate way the snapshot can be blind: an
+    // org-owned definition lives under an organization the caller cannot
+    // reach, so `loadSnapshot` skips it, `annotateRows` says `create` for a
+    // partner-wide row with that key — and W03's trigger refuses the INSERT.
     const partner = await createPartner();
-    const org = await createOrganization({ partnerId: partner.id });
-    const auth = await partnerAuth(partner.id, [org.id], 'all');
-    const fieldKey = uniqueKey('udf_leak');
-    await seedDefinition({ orgId: null, partnerId: partner.id }, fieldKey, 'text');
+    const mine = await createOrganization({ partnerId: partner.id });
+    const unreachable = await createOrganization({ partnerId: partner.id });
+    const shadowed = uniqueKey('udf_race');
+    const good = uniqueKey('udf_good');
+    await seedDefinition({ orgId: unreachable.id, partnerId: null }, shadowed, 'text');
+
+    // The service is called directly: the route derives the caller's reach from
+    // the token, and this scenario is precisely "reach that excludes a row the
+    // database still enforces against".
+    const ctx: DefinitionImportContext = {
+      partnerId: partner.id,
+      accessibleOrgIds: [mine.id],
+      canManagePartnerWide: true,
+    };
+    const auth = await partnerAuth(partner.id, [mine.id], 'all');
+
+    const summary = await withDbAccessContext(dbContextFor(auth), async () => {
+      const preview = await previewCustomFieldDefinitionImport(
+        [{ fieldKey: shadowed, name: 'Shadowed', type: 'text', ownerScope: 'partner' }],
+        ctx,
+      );
+      // Preview genuinely could not see it — this is what makes the write real.
+      expect(preview[0]!.annotation).toBe('create');
+
+      return commitCustomFieldDefinitionImport(
+        [
+          { fieldKey: shadowed, name: 'Shadowed', type: 'text', ownerScope: 'partner', expectedAnnotation: 'create' },
+          { fieldKey: good, name: 'Good', type: 'text', ownerScope: 'partner', expectedAnnotation: 'create' },
+        ],
+        ctx,
+        { userId: auth.user.id },
+      );
+    });
+
+    // Row 0 failed at the INSERT and was mapped from the trigger's P0001.
+    expect(summary.errors).toHaveLength(1);
+    expect(summary.errors[0]).toMatchObject({ index: 0, code: 'key-shadowed' });
+    // Row 1 still landed: the failure rolled back to row 0's SAVEPOINT and left
+    // the request transaction healthy. Without the nested transaction this
+    // would be a 25P02 instead.
+    expect(summary.created).toHaveLength(1);
+    expect(summary.created[0]).toMatchObject({ index: 1, fieldKey: good });
+    createdDefinitions.push(summary.created[0]!.definitionId);
+    expect(await definitionCount(shadowed, null, partner.id)).toBe(0);
+
+    // …and the driver's own text never reaches the wire.
+    const serialized = JSON.stringify(summary);
+    expect(serialized).not.toMatch(/DETAIL|insert into|Failed query|params:/i);
+    expect(serialized).not.toMatch(/cause/);
+  });
+
+  runDb('treats a soft-deleted organization as out of reach', async () => {
+    // `loadSnapshot` filters on `isNull(organizations.deletedAt)`. The mocked
+    // unit tests cannot see that predicate at all — only a real query can.
+    const partner = await createPartner();
+    const live = await createOrganization({ partnerId: partner.id });
+    const deleted = await createOrganization({ partnerId: partner.id, deletedAt: new Date() });
+    const auth = await partnerAuth(partner.id, [live.id, deleted.id], 'all');
+    const fieldKey = uniqueKey('udf_soft');
+
+    const preview = await post(auth, PREVIEW, {
+      rows: [{ fieldKey, name: 'Asset tag', type: 'text', ownerScope: 'organization', organizationId: deleted.id }],
+    });
+    expect(preview.body.rows[0].annotation).toBe('org-not-found');
 
     const commit = await post(auth, COMMIT, {
-      rows: [{ fieldKey, name: 'X', type: 'text', ownerScope: 'organization', organizationId: org.id, expectedAnnotation: 'create' }],
+      rows: [{
+        fieldKey,
+        name: 'Asset tag',
+        type: 'text',
+        ownerScope: 'organization',
+        organizationId: deleted.id,
+        expectedAnnotation: 'create',
+      }],
     });
-    const serialized = JSON.stringify(commit.body);
-    expect(serialized).not.toMatch(/DETAIL|insert into|select .* from/i);
+    expect(commit.body.created).toHaveLength(0);
+    expect(commit.body.errors[0].code).toBe('org-not-found');
+    expect(await definitionCount(fieldKey, deleted.id, null)).toBe(0);
   });
 });

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -122,6 +122,7 @@ import { partnerTrustRoutes } from './routes/partnerTrust';
 import { networkKnownGuestsRoutes } from './routes/networkKnownGuests';
 import { tagRoutes } from './routes/tags';
 import { customFieldRoutes } from './routes/customFields';
+import { customFieldImportRoutes } from './routes/customFieldImport';
 import { filterRoutes } from './routes/filters';
 import { deploymentRoutes } from './routes/deployments';
 import { createAgentWsRoutes } from './routes/agentWs';
@@ -1020,6 +1021,11 @@ api.route('/partner', partnerRoutes);
 api.route('/internal/synthetic', internalSyntheticRoutes);
 api.route('/partner/known-guests', networkKnownGuestsRoutes);
 api.route('/tags', tagRoutes);
+// Mounted BEFORE customFieldRoutes so `/custom-fields/import*` is matched by
+// the importer rather than falling through to the CRUD app's `/:id` handlers
+// (#3257 W07). The two apps carry disjoint methods+paths today, so the order is
+// belt-and-braces rather than load-bearing.
+api.route('/custom-fields', customFieldImportRoutes);
 api.route('/custom-fields', customFieldRoutes);
 api.route('/filters', filterRoutes);
 api.route('/deployments', deploymentRoutes);

--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -95,6 +95,67 @@ API requests are rate-limited to ensure fair usage. Rate limit headers are inclu
       }
     },
     schemas: {
+      // Custom-field definition importer (#3257 W07)
+      CustomFieldDefinitionImportRow: {
+        type: 'object',
+        required: ['fieldKey', 'name', 'type', 'ownerScope'],
+        properties: {
+          fieldKey: {
+            type: 'string',
+            pattern: '^[a-z][a-z0-9_]*$',
+            maxLength: 100,
+            description: 'Lowercase alphanumeric with underscores — the same rule POST /custom-fields enforces.'
+          },
+          name: { type: 'string', maxLength: 100 },
+          type: { type: 'string', enum: ['text', 'number', 'boolean', 'dropdown', 'date'] },
+          options: { type: 'object', nullable: true, description: 'Shared CustomFieldOptions contract (choices/min/max/…).' },
+          required: { type: 'boolean' },
+          deviceTypes: { type: 'array', nullable: true, items: { type: 'string', enum: ['windows', 'macos', 'linux'] } },
+          ownerScope: {
+            type: 'string',
+            enum: ['partner', 'organization'],
+            description: 'Ownership axis. Org XOR partner is enforced by custom_field_definitions_one_owner_chk.'
+          },
+          organizationId: { type: 'string', format: 'uuid', description: 'Required when ownerScope is "organization".' },
+          sourceLabel: {
+            type: 'string',
+            maxLength: 120,
+            description: 'The incumbent RMM\'s own name for the field (e.g. "udf7"). Recorded in the audit trail, never stored on the definition.'
+          },
+          expectedAnnotation: {
+            type: 'string',
+            description: 'COMMIT only. The annotation preview returned; the row is rejected if it has since moved.'
+          },
+          expectedDefinitionId: {
+            type: 'string',
+            format: 'uuid',
+            description: 'COMMIT only. Required when expectedAnnotation is "already-exists" — pins the acknowledgement to one definition.'
+          }
+        }
+      },
+      CustomFieldDefinitionImportRequest: {
+        type: 'object',
+        required: ['rows'],
+        properties: {
+          partnerId: {
+            type: 'string',
+            format: 'uuid',
+            description: 'System scope only may name a partner other than its own; anyone else supplying a different one gets 403.'
+          },
+          externalSystem: {
+            type: 'string',
+            maxLength: 64,
+            default: 'csv',
+            description: 'Which RMM the file came from (datto_rmm, ninjaone, cw_automate, n_central, csv). Recorded in the audit trail.'
+          },
+          rows: {
+            type: 'array',
+            minItems: 1,
+            maxItems: 1000,
+            items: { $ref: '#/components/schemas/CustomFieldDefinitionImportRow' }
+          }
+        }
+      },
       // Common schemas
       Pagination: {
         type: 'object',
@@ -2510,6 +2571,144 @@ API requests are rate-limited to ensure fair usage. Rate limit headers are inclu
           }
         }
       }
+    },
+
+    // ============================================
+    // CUSTOM FIELD DEFINITION IMPORT (#3257 W07)
+    // ============================================
+    '/custom-fields/import/preview': {
+      post: {
+        operationId: 'previewCustomFieldDefinitionImport',
+        tags: ['Devices'],
+        summary: 'Preview a custom-field definition import',
+        description:
+          'Annotate every submitted definition row against current state without writing anything. '
+          + 'Requires organization, partner or system scope, devices:write and MFA; JWT only (an X-API-Key caller gets 401). '
+          + 'Rows with ownerScope "partner" additionally require full partner org access — a batch containing one from a '
+          + 'caller without it is refused 403 in full, matching POST /custom-fields.',
+        requestBody: {
+          required: true,
+          content: { 'application/json': { schema: { $ref: '#/components/schemas/CustomFieldDefinitionImportRequest' } } },
+        },
+        responses: {
+          '200': {
+            description: 'Annotated rows',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    rows: {
+                      type: 'array',
+                      items: {
+                        allOf: [
+                          { $ref: '#/components/schemas/CustomFieldDefinitionImportRow' },
+                          {
+                            type: 'object',
+                            properties: {
+                              index: { type: 'integer' },
+                              annotation: {
+                                type: 'string',
+                                enum: ['create', 'already-exists', 'type-conflict', 'key-shadowed', 'org-not-found', 'partner-wide-denied'],
+                                description:
+                                  'create = no field owns this key on the row\'s axis; already-exists = same axis, same type (skipped at commit); '
+                                  + 'type-conflict = same axis different type, or the key appears twice in the file; '
+                                  + 'key-shadowed = the key is taken on the OTHER ownership axis (W03 anti-shadowing trigger); '
+                                  + 'org-not-found = the organization is absent or out of reach; '
+                                  + 'partner-wide-denied = the caller may not create all-organizations fields.',
+                              },
+                              existingId: { type: 'string', format: 'uuid', nullable: true },
+                              existingType: { type: 'string', nullable: true },
+                              conflictReason: { type: 'string' },
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          '400': { description: 'Invalid input (row cap exceeded, bad field key, organization row with no organizationId)' },
+          '403': { description: 'Access denied to this partner, or partner-wide rows without full partner org access' },
+        },
+      },
+    },
+    '/custom-fields/import': {
+      post: {
+        operationId: 'commitCustomFieldDefinitionImport',
+        tags: ['Devices'],
+        summary: 'Commit a custom-field definition import',
+        description:
+          'Create the acknowledged definitions. Every annotation is RE-DERIVED against fresh state inside the request and a row '
+          + 'whose annotation moved since preview is rejected with code "annotation-changed"; an "already-exists" acknowledgement '
+          + 'must pin expectedDefinitionId or it is rejected with "match-changed". '
+          + 'Always responds 200, even when errors[] is non-empty: a partial import must not read as a total failure.',
+        requestBody: {
+          required: true,
+          content: { 'application/json': { schema: { $ref: '#/components/schemas/CustomFieldDefinitionImportRequest' } } },
+        },
+        responses: {
+          '200': {
+            description: 'Import summary (may report per-row errors)',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    created: {
+                      type: 'array',
+                      items: {
+                        type: 'object',
+                        properties: {
+                          index: { type: 'integer' },
+                          definitionId: { type: 'string', format: 'uuid' },
+                          fieldKey: { type: 'string' },
+                          ownerScope: { type: 'string', enum: ['partner', 'organization'] },
+                          organizationId: { type: 'string', format: 'uuid', nullable: true },
+                        },
+                      },
+                    },
+                    skipped: {
+                      type: 'array',
+                      items: {
+                        type: 'object',
+                        properties: {
+                          index: { type: 'integer' },
+                          definitionId: { type: 'string', format: 'uuid' },
+                          fieldKey: { type: 'string' },
+                          reason: { type: 'string', enum: ['already-exists'] },
+                        },
+                      },
+                    },
+                    errors: {
+                      type: 'array',
+                      items: {
+                        type: 'object',
+                        properties: {
+                          index: { type: 'integer' },
+                          fieldKey: { type: 'string' },
+                          error: { type: 'string' },
+                          code: {
+                            type: 'string',
+                            enum: [
+                              'org-not-found', 'type-conflict', 'key-shadowed', 'annotation-changed',
+                              'match-changed', 'partner-wide-denied', 'write-failed',
+                            ],
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          '400': { description: 'Invalid input (row cap exceeded, unpinned "already-exists" acknowledgement)' },
+          '403': { description: 'Access denied to this partner, or partner-wide rows without full partner org access' },
+        },
+      },
     },
 
     // ============================================

--- a/apps/api/src/routes/customFieldImport.test.ts
+++ b/apps/api/src/routes/customFieldImport.test.ts
@@ -1,0 +1,293 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+const {
+  authRef,
+  permissionDenied,
+  requirePermissionSpy,
+  requireMfaSpy,
+  previewMock,
+  commitMock,
+  auditMock,
+} = vi.hoisted(() => ({
+  authRef: {
+    current: {
+      scope: 'partner' as 'partner' | 'organization' | 'system',
+      partnerId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa' as string | null,
+      partnerOrgAccess: 'all' as 'all' | 'selected' | 'none' | null | undefined,
+      orgId: null as string | null,
+      accessibleOrgIds: null as string[] | null,
+      user: { id: 'u-1', email: 'admin@example.com' },
+    },
+  },
+  permissionDenied: { current: false },
+  requirePermissionSpy: vi.fn(),
+  requireMfaSpy: vi.fn(),
+  previewMock: vi.fn(),
+  commitMock: vi.fn(),
+  auditMock: vi.fn(),
+}));
+
+/**
+ * `authMiddleware` is modelled on production's actual contract rather than
+ * stubbed to always succeed: it authenticates a Bearer JWT and has NO
+ * X-API-Key branch at all. That is what makes the "rejects an X-API-Key
+ * caller" test below meaningful — swapping the route to `dualAuth` would
+ * change which middleware the route mounts, and this mock would stop covering
+ * it.
+ */
+vi.mock('../middleware/auth', () => ({
+  authMiddleware: vi.fn(async (c: any, next: any) => {
+    if (!c.req.header('authorization')?.startsWith('Bearer ')) {
+      return c.json({ error: 'Not authenticated' }, 401);
+    }
+    c.set('auth', authRef.current);
+    await next();
+  }),
+  requireScope: () => async (_c: any, next: any) => next(),
+  requirePermission: (resource: string, action: string) => {
+    requirePermissionSpy(resource, action);
+    return async (c: any, next: any) => {
+      if (permissionDenied.current) return c.json({ error: 'Insufficient permissions' }, 403);
+      await next();
+    };
+  },
+  requireMfa: () => async (_c: any, next: any) => {
+    requireMfaSpy();
+    await next();
+  },
+}));
+
+vi.mock('../services/permissions', () => ({
+  PERMISSIONS: {
+    DEVICES_READ: { resource: 'devices', action: 'read' },
+    DEVICES_WRITE: { resource: 'devices', action: 'write' },
+    ORGS_WRITE: { resource: 'organizations', action: 'write' },
+  },
+}));
+
+vi.mock('../services/customFields/import/definitionImport', () => ({
+  previewCustomFieldDefinitionImport: previewMock,
+  commitCustomFieldDefinitionImport: commitMock,
+}));
+
+vi.mock('../services/customFields/import/audit', () => ({
+  writeCustomFieldDefinitionImportAudits: auditMock,
+}));
+
+import { PARTNER_WIDE_WRITE_DENIED_MESSAGE } from '../services/partnerWideAccess';
+import { customFieldImportRoutes } from './customFieldImport';
+
+const PARTNER = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const OTHER_PARTNER = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+const ORG = '11111111-1111-4111-8111-111111111111';
+const DEF = '33333333-3333-4333-8333-333333333333';
+
+const PREVIEW = '/custom-fields/import/preview';
+const COMMIT = '/custom-fields/import';
+const BOTH = [PREVIEW, COMMIT];
+
+function app() {
+  const a = new Hono();
+  a.route('/custom-fields', customFieldImportRoutes);
+  return a;
+}
+
+function post(path: string, body: unknown, headers: Record<string, string> = {}) {
+  return app().request(path, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: 'Bearer t', ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+function partnerRow(overrides: Record<string, unknown> = {}) {
+  return { fieldKey: 'udf7', name: 'Warranty Expiry', type: 'date', ownerScope: 'partner', ...overrides };
+}
+
+function setPartnerAuth(partnerOrgAccess: 'all' | 'selected') {
+  authRef.current = {
+    scope: 'partner',
+    partnerId: PARTNER,
+    partnerOrgAccess,
+    orgId: null,
+    accessibleOrgIds: [ORG],
+    user: { id: 'u-1', email: 'admin@example.com' },
+  };
+}
+
+function setOrgAuth() {
+  authRef.current = {
+    scope: 'organization',
+    partnerId: PARTNER,
+    partnerOrgAccess: undefined,
+    orgId: ORG,
+    accessibleOrgIds: [ORG],
+    user: { id: 'u-2', email: 'org-admin@example.com' },
+  };
+}
+
+beforeEach(() => {
+  setPartnerAuth('all');
+  permissionDenied.current = false;
+  previewMock.mockReset().mockResolvedValue([]);
+  commitMock.mockReset().mockResolvedValue({ created: [], skipped: [], errors: [] });
+  auditMock.mockReset();
+  requireMfaSpy.mockClear();
+});
+
+describe('custom-field definition import routes', () => {
+  it('rejects an X-API-Key caller on both routes', async () => {
+    for (const path of BOTH) {
+      const res = await app().request(path, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-API-Key': 'k' },
+        body: JSON.stringify({ rows: [partnerRow()] }),
+      });
+      expect(res.status).toBe(401);
+    }
+  });
+
+  it('gates on the same permission the single-create route uses (devices:write)', () => {
+    expect(requirePermissionSpy).toHaveBeenCalledWith('devices', 'write');
+  });
+
+  it('403s a caller without that permission on both routes', async () => {
+    permissionDenied.current = true;
+    for (const path of BOTH) {
+      const res = await post(path, { rows: [partnerRow()] });
+      expect(res.status).toBe(403);
+    }
+    expect(previewMock).not.toHaveBeenCalled();
+    expect(commitMock).not.toHaveBeenCalled();
+  });
+
+  it('requires MFA on both routes', async () => {
+    for (const path of BOTH) {
+      await post(path, { rows: [partnerRow()] });
+    }
+    expect(requireMfaSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('403s an org token naming another partner in the body', async () => {
+    setOrgAuth();
+    const res = await post(PREVIEW, {
+      partnerId: OTHER_PARTNER,
+      rows: [{ ...partnerRow(), ownerScope: 'organization', organizationId: ORG }],
+    });
+    expect(res.status).toBe(403);
+    expect(await res.json()).toMatchObject({ error: 'Access denied to this partner' });
+    expect(previewMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects more than MAX_IMPORT_ROWS rows at the zod layer', async () => {
+    const rows = Array.from({ length: 1001 }, (_, i) => partnerRow({ fieldKey: `udf${i}` }));
+    const res = await post(PREVIEW, { rows });
+    expect(res.status).toBe(400);
+    expect(previewMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty rows array', async () => {
+    const res = await post(PREVIEW, { rows: [] });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects an organization row with no organizationId at the zod layer', async () => {
+    const res = await post(PREVIEW, { rows: [partnerRow({ ownerScope: 'organization' })] });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/organizationId is required/i);
+  });
+
+  it('rejects a field key the single-create route would reject', async () => {
+    const res = await post(PREVIEW, { rows: [partnerRow({ fieldKey: 'UDF 7' })] });
+    expect(res.status).toBe(400);
+  });
+
+  it('requires expectedDefinitionId when the commit acknowledges already-exists', async () => {
+    const res = await post(COMMIT, {
+      rows: [partnerRow({ expectedAnnotation: 'already-exists' })],
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/expectedDefinitionId is required/i);
+    expect(commitMock).not.toHaveBeenCalled();
+  });
+
+  describe('partner-wide capability gate', () => {
+    it('403s a partner user without full org access on both routes', async () => {
+      setPartnerAuth('selected');
+      for (const path of BOTH) {
+        const res = await post(path, { rows: [partnerRow()] });
+        expect(res.status).toBe(403);
+        expect(await res.json()).toMatchObject({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE });
+      }
+      expect(previewMock).not.toHaveBeenCalled();
+      expect(commitMock).not.toHaveBeenCalled();
+    });
+
+    it('403s an ORG-scoped token submitting a partner-wide row', async () => {
+      setOrgAuth();
+      const res = await post(PREVIEW, { rows: [partnerRow()] });
+      expect(res.status).toBe(403);
+      expect(previewMock).not.toHaveBeenCalled();
+    });
+
+    it('admits an org-scoped token submitting only organization rows', async () => {
+      setOrgAuth();
+      const res = await post(PREVIEW, {
+        rows: [partnerRow({ ownerScope: 'organization', organizationId: ORG })],
+      });
+      expect(res.status).toBe(200);
+      expect(previewMock.mock.calls[0]![1]).toMatchObject({
+        partnerId: PARTNER,
+        accessibleOrgIds: [ORG],
+        canManagePartnerWide: false,
+      });
+    });
+
+    it('passes the capability and the caller reach into the service context', async () => {
+      setPartnerAuth('all');
+      await post(PREVIEW, { rows: [partnerRow()] });
+      expect(previewMock.mock.calls[0]![1]).toEqual({
+        partnerId: PARTNER,
+        accessibleOrgIds: [ORG],
+        canManagePartnerWide: true,
+      });
+    });
+  });
+
+  it('returns 200 with a non-empty errors[] on a partial commit', async () => {
+    commitMock.mockResolvedValue({
+      created: [{ index: 0, definitionId: DEF, fieldKey: 'udf7', ownerScope: 'partner', organizationId: null }],
+      skipped: [],
+      errors: [{ index: 1, fieldKey: 'udf8', error: 'nope', code: 'type-conflict' }],
+    });
+    const res = await post(COMMIT, {
+      rows: [partnerRow(), partnerRow({ fieldKey: 'udf8', type: 'text' })],
+    });
+    // runAction reads a failure body as a hard failure and would hide the row
+    // that DID import.
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.errors).toHaveLength(1);
+    expect(body.created).toHaveLength(1);
+  });
+
+  it('writes the import audits with the source system and the submitted rows', async () => {
+    commitMock.mockResolvedValue({
+      created: [{ index: 0, definitionId: DEF, fieldKey: 'udf7', ownerScope: 'partner', organizationId: null }],
+      skipped: [],
+      errors: [],
+    });
+    await post(COMMIT, { externalSystem: 'datto_rmm', rows: [partnerRow({ sourceLabel: 'udf7' })] });
+    expect(auditMock).toHaveBeenCalledTimes(1);
+    expect(auditMock.mock.calls[0]![1]).toMatchObject({
+      externalSystem: 'datto_rmm',
+      rows: [expect.objectContaining({ sourceLabel: 'udf7' })],
+    });
+  });
+
+  it('defaults externalSystem to the csv fallback', async () => {
+    await post(COMMIT, { rows: [partnerRow()] });
+    expect(auditMock.mock.calls[0]![1]).toMatchObject({ externalSystem: 'csv' });
+  });
+});

--- a/apps/api/src/routes/customFieldImport.test.ts
+++ b/apps/api/src/routes/customFieldImport.test.ts
@@ -18,6 +18,7 @@ const {
       orgId: null as string | null,
       accessibleOrgIds: null as string[] | null,
       user: { id: 'u-1', email: 'admin@example.com' },
+      token: { mfa: true } as { mfa: boolean },
     },
   },
   permissionDenied: { current: false },
@@ -52,8 +53,15 @@ vi.mock('../middleware/auth', () => ({
       await next();
     };
   },
-  requireMfa: () => async (_c: any, next: any) => {
+  // Reproduces production's rule (`hasSatisfiedMfa`: reject unless
+  // `auth.token.mfa === true`) rather than always calling next(). A stub that
+  // always allows through would let a regression that DROPS `requireMfa()`
+  // from a route pass every test in this file.
+  requireMfa: () => async (c: any, next: any) => {
     requireMfaSpy();
+    if (authRef.current.token?.mfa !== true) {
+      return c.json({ error: 'MFA required', code: 'MFA_REQUIRED' }, 403);
+    }
     await next();
   },
 }));
@@ -113,6 +121,7 @@ function setPartnerAuth(partnerOrgAccess: 'all' | 'selected') {
     orgId: null,
     accessibleOrgIds: [ORG],
     user: { id: 'u-1', email: 'admin@example.com' },
+    token: { mfa: true },
   };
 }
 
@@ -124,6 +133,20 @@ function setOrgAuth() {
     orgId: ORG,
     accessibleOrgIds: [ORG],
     user: { id: 'u-2', email: 'org-admin@example.com' },
+    token: { mfa: true },
+  };
+}
+
+/** System scope: no org allowlist at all, and partner-wide is always permitted. */
+function setSystemAuth() {
+  authRef.current = {
+    scope: 'system',
+    partnerId: PARTNER,
+    partnerOrgAccess: null,
+    orgId: null,
+    accessibleOrgIds: null,
+    user: { id: 'u-3', email: 'platform@example.com' },
+    token: { mfa: true },
   };
 }
 
@@ -162,11 +185,16 @@ describe('custom-field definition import routes', () => {
     expect(commitMock).not.toHaveBeenCalled();
   });
 
-  it('requires MFA on both routes', async () => {
+  it('403s a caller whose token has not satisfied MFA, on both routes', async () => {
+    authRef.current.token = { mfa: false };
     for (const path of BOTH) {
-      await post(path, { rows: [partnerRow()] });
+      const res = await post(path, { rows: [partnerRow()] });
+      expect(res.status).toBe(403);
+      expect(await res.json()).toMatchObject({ code: 'MFA_REQUIRED' });
     }
     expect(requireMfaSpy).toHaveBeenCalledTimes(2);
+    expect(previewMock).not.toHaveBeenCalled();
+    expect(commitMock).not.toHaveBeenCalled();
   });
 
   it('403s an org token naming another partner in the body', async () => {
@@ -252,6 +280,25 @@ describe('custom-field definition import routes', () => {
         accessibleOrgIds: [ORG],
         canManagePartnerWide: true,
       });
+    });
+
+    it('admits system scope with an unrestricted (null) org reach', async () => {
+      // `requireScope` lists system, so it must actually work: `null` reach is
+      // "every org under the partner", NOT an empty allowlist.
+      setSystemAuth();
+      const res = await post(PREVIEW, { rows: [partnerRow()] });
+      expect(res.status).toBe(200);
+      expect(previewMock.mock.calls[0]![1]).toEqual({
+        partnerId: PARTNER,
+        accessibleOrgIds: null,
+        canManagePartnerWide: true,
+      });
+    });
+
+    it('lets system scope target another partner by naming it in the body', async () => {
+      setSystemAuth();
+      await post(PREVIEW, { partnerId: OTHER_PARTNER, rows: [partnerRow()] });
+      expect(previewMock.mock.calls[0]![1]).toMatchObject({ partnerId: OTHER_PARTNER });
     });
   });
 

--- a/apps/api/src/routes/customFieldImport.ts
+++ b/apps/api/src/routes/customFieldImport.ts
@@ -74,8 +74,7 @@ const ORG_SCOPE_NEEDS_ORG_ID = 'organizationId is required when ownerScope is "o
 const ALREADY_EXISTS_NEEDS_PIN =
   'expectedDefinitionId is required when expectedAnnotation is "already-exists"';
 
-/** The base object is kept unrefined so the commit variant can extend it. */
-const definitionImportRowFields = z.object({
+const definitionImportCommonFields = {
   fieldKey: z
     .string()
     .min(1)
@@ -86,20 +85,41 @@ const definitionImportRowFields = z.object({
   options: customFieldOptionsSchema.nullish(),
   required: z.boolean().optional(),
   deviceTypes: z.array(z.enum(['windows', 'macos', 'linux'])).nullish(),
-  ownerScope: z.enum(['partner', 'organization']),
-  organizationId: z.string().guid().optional(),
   /** e.g. `udf7` — preserved in the audit, never stored. */
   sourceLabel: z.string().min(1).max(120).optional(),
-});
+};
 
-function requiresOrganizationId(value: { ownerScope: string; organizationId?: string }): boolean {
-  return value.ownerScope !== 'organization' || value.organizationId !== undefined;
-}
+const commitAcknowledgementFields = {
+  expectedAnnotation: z
+    .enum(['create', 'already-exists', 'type-conflict', 'key-shadowed', 'org-not-found', 'partner-wide-denied'])
+    .optional(),
+  expectedDefinitionId: z.string().guid().optional(),
+};
 
-const definitionImportRowSchema = definitionImportRowFields.refine(requiresOrganizationId, {
-  message: ORG_SCOPE_NEEDS_ORG_ID,
-  path: ['organizationId'],
-});
+/**
+ * A DISCRIMINATED UNION on `ownerScope`, not a flat object plus a `.refine`.
+ *
+ * The parsed output then matches `CustomFieldDefinitionImportRow`'s own union
+ * exactly, so "an organization row always has an organizationId" is carried by
+ * the type all the way to the insert instead of being re-checked (and, worse,
+ * non-null-asserted) downstream. Ownership is org XOR partner in the database
+ * too — `custom_field_definitions_one_owner_chk`, W02.
+ */
+const ownerArms = <T extends z.ZodRawShape>(extra: T) =>
+  [
+    z.object({
+      ...definitionImportCommonFields,
+      ...extra,
+      ownerScope: z.literal('organization'),
+      // `error` covers the MISSING case too, not just a malformed uuid — zod's
+      // default there is "expected string, received undefined", which does not
+      // tell a tech what to put in the column.
+      organizationId: z.string({ error: ORG_SCOPE_NEEDS_ORG_ID }).guid(ORG_SCOPE_NEEDS_ORG_ID),
+    }),
+    z.object({ ...definitionImportCommonFields, ...extra, ownerScope: z.literal('partner'), organizationId: z.undefined().optional() }),
+  ] as const;
+
+const definitionImportRowSchema = z.discriminatedUnion('ownerScope', ownerArms({}));
 
 /**
  * A row as submitted to a COMMIT. Both acknowledgements are checked against
@@ -108,16 +128,11 @@ const definitionImportRowSchema = definitionImportRowFields.refine(requiresOrgan
  * `expectedDefinitionId` is REQUIRED for `already-exists`: without it the
  * acknowledgement says "this row is already that field" without saying WHICH
  * field, so an approval given for definition A would be honoured against
- * definition B if the key changed hands between preview and commit.
+ * definition B if the key changed hands between preview and commit. Refined on
+ * the union rather than per arm, because it is orthogonal to the owner axis.
  */
-const commitDefinitionImportRowSchema = definitionImportRowFields
-  .extend({
-    expectedAnnotation: z
-      .enum(['create', 'already-exists', 'type-conflict', 'key-shadowed', 'org-not-found', 'partner-wide-denied'])
-      .optional(),
-    expectedDefinitionId: z.string().guid().optional(),
-  })
-  .refine(requiresOrganizationId, { message: ORG_SCOPE_NEEDS_ORG_ID, path: ['organizationId'] })
+const commitDefinitionImportRowSchema = z
+  .discriminatedUnion('ownerScope', ownerArms(commitAcknowledgementFields))
   .refine(
     (value) => value.expectedAnnotation !== 'already-exists' || value.expectedDefinitionId !== undefined,
     { message: ALREADY_EXISTS_NEEDS_PIN, path: ['expectedDefinitionId'] },
@@ -215,11 +230,27 @@ customFieldImportRoutes.post(
 
     // The service has no Hono context, so every route that commits an import
     // must write the audit events here.
-    writeCustomFieldDefinitionImportAudits(c, {
-      summary,
-      rows: body.rows,
-      externalSystem: body.externalSystem,
-    });
+    //
+    // Guarded, unlike a plain CRUD route's single `writeRouteAudit`: the rows
+    // are ALREADY COMMITTED by this point, and `writeAuditEventAsync` does its
+    // payload sanitisation synchronously on this stack. A throw from that
+    // prelude would escape the handler as a 500 describing a request that in
+    // fact succeeded — the exact "hide the rows that DID import" failure the
+    // always-200 contract below exists to prevent. Losing an audit event is
+    // bad; misreporting a successful import as a total failure is worse, and
+    // the loss is loud in the log either way.
+    try {
+      writeCustomFieldDefinitionImportAudits(c, {
+        summary,
+        rows: body.rows,
+        externalSystem: body.externalSystem,
+      });
+    } catch (err) {
+      console.error('[custom-field-definition-import] audit write failed', {
+        created: summary.created.length,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
 
     // Always 200, including a partial success: the web caller consumes this
     // through runAction, which reads a failure body as a hard failure and would

--- a/apps/api/src/routes/customFieldImport.ts
+++ b/apps/api/src/routes/customFieldImport.ts
@@ -1,0 +1,230 @@
+import { Hono } from 'hono';
+import { z } from 'zod';
+import { zValidator } from '../lib/validation';
+import { authMiddleware, requireMfa, requirePermission, requireScope, type AuthContext } from '../middleware/auth';
+import { PERMISSIONS } from '../services/permissions';
+import {
+  PARTNER_WIDE_WRITE_DENIED_MESSAGE,
+  canManagePartnerWidePolicies,
+} from '../services/partnerWideAccess';
+import { resolveImportPartnerId } from './importScope';
+import {
+  commitCustomFieldDefinitionImport,
+  previewCustomFieldDefinitionImport,
+  type DefinitionImportContext,
+} from '../services/customFields/import/definitionImport';
+import { writeCustomFieldDefinitionImportAudits } from '../services/customFields/import/audit';
+import { DEFAULT_IMPORT_SYSTEM, MAX_IMPORT_ROWS } from '../services/customFields/import/types';
+
+/**
+ * The DEFINITIONS half of the RMM custom-field importer (#3257 W07):
+ * `POST /custom-fields/import/preview` and `POST /custom-fields/import`.
+ *
+ * A separate Hono app mounted at the same `/custom-fields` prefix as
+ * `customFieldRoutes`, rather than registered onto it, so the importer's
+ * schemas and its partner-wide gate stay out of the CRUD file. It carries its
+ * own `authMiddleware` for the same reason `customFieldRoutes` does: mounting
+ * without one would silently skip auth.
+ *
+ * ── What is deliberately NOT here ───────────────────────────────────────────
+ * There is **no `dualAuth` / X-API-Key branch**. `dualAuth` applies `requireMfa`
+ * only on the JWT branch and skips the site allowlist for API keys, and an
+ * unattended integration is not a user of a one-off migration tool. With plain
+ * `authMiddleware` an X-API-Key-only request never authenticates at all — it is
+ * a 401, which is the intended answer.
+ *
+ * Values (W08) are a different pipeline with different tenancy and live under
+ * `/devices`.
+ */
+
+export const customFieldImportRoutes = new Hono();
+
+customFieldImportRoutes.use('*', authMiddleware);
+
+// PERMISSIONS.ORGS_WRITE would be wrong here: a custom field is device
+// metadata, and this is the same grant the sibling `POST /custom-fields`
+// create route requires.
+const requireCustomFieldWrite = requirePermission(
+  PERMISSIONS.DEVICES_WRITE.resource,
+  PERMISSIONS.DEVICES_WRITE.action,
+);
+
+// Mirrors `routes/customFields.ts` — the same enum, the same key regex and the
+// same options contract, restated locally for the same reason that file states
+// them locally rather than importing them across a rootDir boundary. A row this
+// importer accepts must be one the single-create route would also accept.
+const customFieldTypeSchema = z.enum(['text', 'number', 'boolean', 'dropdown', 'date']);
+
+const customFieldChoiceSchema = z.union([
+  z.string().min(1).max(255),
+  z.object({ label: z.string().min(1).max(255), value: z.string().min(1).max(255) }),
+]);
+
+const customFieldOptionsSchema = z.object({
+  choices: z.array(customFieldChoiceSchema).max(200).optional(),
+  min: z.number().optional(),
+  max: z.number().optional(),
+  minLength: z.number().int().nonnegative().optional(),
+  maxLength: z.number().int().positive().optional(),
+  pattern: z.string().max(512).optional(),
+  placeholder: z.string().max(255).optional(),
+});
+
+const ORG_SCOPE_NEEDS_ORG_ID = 'organizationId is required when ownerScope is "organization"';
+const ALREADY_EXISTS_NEEDS_PIN =
+  'expectedDefinitionId is required when expectedAnnotation is "already-exists"';
+
+/** The base object is kept unrefined so the commit variant can extend it. */
+const definitionImportRowFields = z.object({
+  fieldKey: z
+    .string()
+    .min(1)
+    .max(100)
+    .regex(/^[a-z][a-z0-9_]*$/, 'Field key must be lowercase alphanumeric with underscores'),
+  name: z.string().min(1).max(100),
+  type: customFieldTypeSchema,
+  options: customFieldOptionsSchema.nullish(),
+  required: z.boolean().optional(),
+  deviceTypes: z.array(z.enum(['windows', 'macos', 'linux'])).nullish(),
+  ownerScope: z.enum(['partner', 'organization']),
+  organizationId: z.string().guid().optional(),
+  /** e.g. `udf7` — preserved in the audit, never stored. */
+  sourceLabel: z.string().min(1).max(120).optional(),
+});
+
+function requiresOrganizationId(value: { ownerScope: string; organizationId?: string }): boolean {
+  return value.ownerScope !== 'organization' || value.organizationId !== undefined;
+}
+
+const definitionImportRowSchema = definitionImportRowFields.refine(requiresOrganizationId, {
+  message: ORG_SCOPE_NEEDS_ORG_ID,
+  path: ['organizationId'],
+});
+
+/**
+ * A row as submitted to a COMMIT. Both acknowledgements are checked against
+ * freshly re-derived state, so a stale one is refused rather than applied.
+ *
+ * `expectedDefinitionId` is REQUIRED for `already-exists`: without it the
+ * acknowledgement says "this row is already that field" without saying WHICH
+ * field, so an approval given for definition A would be honoured against
+ * definition B if the key changed hands between preview and commit.
+ */
+const commitDefinitionImportRowSchema = definitionImportRowFields
+  .extend({
+    expectedAnnotation: z
+      .enum(['create', 'already-exists', 'type-conflict', 'key-shadowed', 'org-not-found', 'partner-wide-denied'])
+      .optional(),
+    expectedDefinitionId: z.string().guid().optional(),
+  })
+  .refine(requiresOrganizationId, { message: ORG_SCOPE_NEEDS_ORG_ID, path: ['organizationId'] })
+  .refine(
+    (value) => value.expectedAnnotation !== 'already-exists' || value.expectedDefinitionId !== undefined,
+    { message: ALREADY_EXISTS_NEEDS_PIN, path: ['expectedDefinitionId'] },
+  );
+
+const previewImportSchema = z.object({
+  partnerId: z.string().guid().optional(),
+  /** Free-form on the wire (see IMPORT_SYSTEMS); recorded in the audit trail. */
+  externalSystem: z.string().min(1).max(64).default(DEFAULT_IMPORT_SYSTEM),
+  rows: z.array(definitionImportRowSchema).min(1).max(MAX_IMPORT_ROWS),
+});
+
+const commitImportSchema = z.object({
+  partnerId: z.string().guid().optional(),
+  externalSystem: z.string().min(1).max(64).default(DEFAULT_IMPORT_SYSTEM),
+  rows: z.array(commitDefinitionImportRowSchema).min(1).max(MAX_IMPORT_ROWS),
+});
+
+type ImportBody = { partnerId?: string; rows: Array<{ ownerScope: 'partner' | 'organization' }> };
+
+/**
+ * Resolve the partner and the caller's reach, and refuse a partner-wide import
+ * the caller may not perform.
+ *
+ * The capability refusal is a whole-request 403 rather than a per-row error,
+ * matching the sibling `POST /custom-fields` create route (epic #2135): a
+ * partner-wide field pushes config to EVERY organization under the partner,
+ * including ones created later, so "you may not do this" is an authorization
+ * answer and belongs in the same band as the scope and permission gates — not
+ * mixed into a 200 that also reports data problems. The service still derives
+ * its own `partner-wide-denied` annotation, because it is reachable directly
+ * and must fail closed there too.
+ */
+function resolveDefinitionImportContext(
+  auth: AuthContext,
+  body: ImportBody,
+): DefinitionImportContext | { error: string; status: 400 | 403 } {
+  const resolved = resolveImportPartnerId(auth, body.partnerId, 'custom fields');
+  if ('error' in resolved) return resolved;
+
+  const canManagePartnerWide = canManagePartnerWidePolicies(auth);
+  if (!canManagePartnerWide && body.rows.some((row) => row.ownerScope === 'partner')) {
+    return { error: PARTNER_WIDE_WRITE_DENIED_MESSAGE, status: 403 };
+  }
+
+  // The caller's own organization allowlist travels with the request: the
+  // importer's snapshot READ runs in a SYSTEM db context (see the service
+  // header — the table has no partner-wide RLS SELECT branch), so RLS is not
+  // the boundary on it and this is. Null is system scope; for an organization
+  // token it is the single org, which is what makes admitting that scope safe —
+  // rows naming any other organization come back `org-not-found` and write
+  // nothing.
+  return {
+    partnerId: resolved.partnerId,
+    accessibleOrgIds: auth.accessibleOrgIds ?? null,
+    canManagePartnerWide,
+  };
+}
+
+customFieldImportRoutes.post(
+  '/import/preview',
+  // `organization` must be in this list: an org-scoped token carries a
+  // partnerId and its single-org allowlist bounds the writes, matching
+  // routes/orgContacts.ts.
+  requireScope('organization', 'partner', 'system'),
+  requireCustomFieldWrite,
+  // A bulk backfill is exactly the operation that should need it.
+  requireMfa(),
+  zValidator('json', previewImportSchema),
+  async (c) => {
+    const auth = c.get('auth') as AuthContext;
+    const body = c.req.valid('json');
+    const ctx = resolveDefinitionImportContext(auth, body);
+    if ('error' in ctx) return c.json({ error: ctx.error }, ctx.status);
+
+    return c.json({ rows: await previewCustomFieldDefinitionImport(body.rows, ctx) });
+  },
+);
+
+customFieldImportRoutes.post(
+  '/import',
+  requireScope('organization', 'partner', 'system'),
+  requireCustomFieldWrite,
+  requireMfa(),
+  zValidator('json', commitImportSchema),
+  async (c) => {
+    const auth = c.get('auth') as AuthContext;
+    const body = c.req.valid('json');
+    const ctx = resolveDefinitionImportContext(auth, body);
+    if ('error' in ctx) return c.json({ error: ctx.error }, ctx.status);
+
+    const summary = await commitCustomFieldDefinitionImport(body.rows, ctx, {
+      userId: auth.user?.id ?? null,
+    });
+
+    // The service has no Hono context, so every route that commits an import
+    // must write the audit events here.
+    writeCustomFieldDefinitionImportAudits(c, {
+      summary,
+      rows: body.rows,
+      externalSystem: body.externalSystem,
+    });
+
+    // Always 200, including a partial success: the web caller consumes this
+    // through runAction, which reads a failure body as a hard failure and would
+    // hide the rows that DID import. Per-row problems are carried as typed
+    // `errors[].code` instead.
+    return c.json(summary);
+  },
+);

--- a/apps/api/src/routes/customFields.ts
+++ b/apps/api/src/routes/customFields.ts
@@ -3,7 +3,7 @@ import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { and, desc, eq, inArray, or } from 'drizzle-orm';
 import { db } from '../db';
-import { pgErrorCode, pgErrorNode } from '../utils/pgErrors';
+import { customFieldWriteConflict } from '../services/customFields/writeErrors';
 
 // Custom field schemas (defined locally to avoid rootDir issues)
 // Must match the database enum: 'text', 'number', 'boolean', 'dropdown', 'date'
@@ -363,34 +363,14 @@ customFieldRoutes.post(
         .returning();
     } catch (err) {
       // Both mapped conditions are the caller's own to fix and neither is a
-      // server fault, so neither may surface as a 500 — a 500 tells the
-      // operator nothing and hides a one-word fix (rename the key).
-      //
-      // P0001 is the anti-shadowing trigger (#3257 W03,
-      // 2026-10-11-141000-custom-field-no-cross-axis-shadowing.sql). Its
-      // message is written to be read by a human: it names the key and which
-      // axis already owns it, and deliberately discloses nothing else about the
-      // conflicting definition, so it is safe to pass through verbatim.
-      //
-      // 23505 is W02's per-axis unique index. Its driver message is NOT safe to
-      // pass through — postgres.js puts the offending column VALUES in `detail`
-      // and the constraint name in the text — so this returns fixed copy built
-      // from the request's own payload instead.
-      const code = pgErrorCode(err);
-      if (code === 'P0001') {
-        return c.json(
-          {
-            error: String(pgErrorNode(err)?.message ?? 'Custom field key conflicts with an existing field'),
-            code: 'field-key-shadowed'
-          },
-          409
-        );
-      }
-      if (code === '23505') {
-        return c.json(
-          { error: `A custom field with key "${payload.fieldKey}" already exists for this owner`, code: 'field-key-duplicate' },
-          409
-        );
+      // server fault, so neither may surface as a 500. The mapping itself lives
+      // in services/customFields/writeErrors.ts because the definitions
+      // importer (#3257 W07) needs the identical one per row — see that
+      // module's header for what each SQLSTATE means and why only one of the
+      // two messages may be passed through verbatim.
+      const conflict = customFieldWriteConflict(err, payload.fieldKey);
+      if (conflict) {
+        return c.json(conflict, 409);
       }
       throw err;
     }

--- a/apps/api/src/services/customFields/import/audit.test.ts
+++ b/apps/api/src/services/customFields/import/audit.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { writeRouteAuditMock } = vi.hoisted(() => ({ writeRouteAuditMock: vi.fn() }));
+
+vi.mock('../../auditEvents', () => ({ writeRouteAudit: writeRouteAuditMock }));
+
+import { writeCustomFieldDefinitionImportAudits } from './audit';
+import type { CustomFieldDefinitionImportRow, DefinitionImportSummary } from './types';
+
+const DEF_A = '33333333-3333-4333-8333-333333333333';
+const DEF_B = '44444444-4444-4444-8444-444444444444';
+const ORG = '11111111-1111-4111-8111-111111111111';
+
+const c = {} as never;
+
+const rows: CustomFieldDefinitionImportRow[] = [
+  { fieldKey: 'udf7', name: 'Warranty Expiry', type: 'date', ownerScope: 'partner', sourceLabel: 'udf7' },
+  { fieldKey: 'udf8', name: 'Asset Tag', type: 'text', ownerScope: 'organization', organizationId: ORG },
+  { fieldKey: 'udf9', name: 'Unchanged', type: 'text', ownerScope: 'partner' },
+];
+
+const summary: DefinitionImportSummary = {
+  created: [
+    { index: 0, definitionId: DEF_A, fieldKey: 'udf7', ownerScope: 'partner', organizationId: null },
+    { index: 1, definitionId: DEF_B, fieldKey: 'udf8', ownerScope: 'organization', organizationId: ORG },
+  ],
+  skipped: [{ index: 2, definitionId: 'def-x', fieldKey: 'udf9', reason: 'already-exists' }],
+  errors: [],
+};
+
+beforeEach(() => writeRouteAuditMock.mockReset());
+
+describe('writeCustomFieldDefinitionImportAudits', () => {
+  it('writes one event per CREATED definition, and none for skipped rows', () => {
+    writeCustomFieldDefinitionImportAudits(c, { summary, rows, externalSystem: 'datto_rmm' });
+    // Three rows in, two created: a skipped row is a row the commit left
+    // untouched, and auditing it would bury the real writes on every re-import.
+    expect(writeRouteAuditMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('carries the provenance a post-migration dispute needs', () => {
+    writeCustomFieldDefinitionImportAudits(c, { summary, rows, externalSystem: 'datto_rmm' });
+    expect(writeRouteAuditMock.mock.calls[0]![1]).toEqual({
+      orgId: null,
+      action: 'custom_field.create',
+      resourceType: 'custom_field',
+      resourceId: DEF_A,
+      resourceName: 'Warranty Expiry',
+      details: {
+        source: 'custom_field_definition_import',
+        externalSystem: 'datto_rmm',
+        // The incumbent's own name for the field. It is stored NOWHERE else —
+        // there is no column for it — so this event is its only durable home.
+        sourceLabel: 'udf7',
+        fieldKey: 'udf7',
+        ownerScope: 'partner',
+        rowCount: 3,
+      },
+    });
+  });
+
+  it("attributes an org-owned definition to the row's own organization", () => {
+    writeCustomFieldDefinitionImportAudits(c, { summary, rows, externalSystem: 'csv' });
+    expect(writeRouteAuditMock.mock.calls[1]![1]).toMatchObject({
+      orgId: ORG,
+      resourceId: DEF_B,
+      details: expect.objectContaining({ ownerScope: 'organization', externalSystem: 'csv' }),
+    });
+  });
+
+  it('omits sourceLabel entirely when the row carried none', () => {
+    writeCustomFieldDefinitionImportAudits(c, { summary, rows, externalSystem: 'csv' });
+    expect(writeRouteAuditMock.mock.calls[1]![1].details).not.toHaveProperty('sourceLabel');
+  });
+
+  it('falls back to the field key when a created row cannot be matched back', () => {
+    // Defensive: an index the caller did not supply a row for must still audit.
+    writeCustomFieldDefinitionImportAudits(c, {
+      summary: { ...summary, created: [{ index: 99, definitionId: DEF_A, fieldKey: 'udf7', ownerScope: 'partner', organizationId: null }] },
+      rows,
+      externalSystem: 'csv',
+    });
+    expect(writeRouteAuditMock.mock.calls[0]![1]).toMatchObject({ resourceName: 'udf7' });
+  });
+
+  it('writes nothing when the commit created nothing', () => {
+    writeCustomFieldDefinitionImportAudits(c, {
+      summary: { created: [], skipped: [], errors: [{ index: 0, fieldKey: 'udf7', error: 'x', code: 'type-conflict' }] },
+      rows,
+      externalSystem: 'csv',
+    });
+    expect(writeRouteAuditMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/customFields/import/audit.ts
+++ b/apps/api/src/services/customFields/import/audit.ts
@@ -1,0 +1,63 @@
+/**
+ * Audit trail for definition-import writes (#3257 W07).
+ *
+ * WHY THIS IS A SHARED HELPER, mirroring `services/contacts/audit.ts`:
+ * `commitCustomFieldDefinitionImport` has no Hono context, so it cannot
+ * attribute a write to an actor, IP or user agent. The audit loop therefore
+ * lives at the route — and a second caller that forgets it writes custom-field
+ * definitions with no trail at all. Keeping the event shape here means every
+ * caller emits the identical one.
+ *
+ * WHAT THE EVENT HAS TO CARRY, and why: after a migration off Datto RMM the
+ * question that gets asked is "where did this field come from, and who let it
+ * in?". `sourceLabel` — the incumbent's own name for the field, e.g. `udf7` —
+ * is the only thing that answers the first half, and it is deliberately NOT
+ * stored on the definition row (there is no column for it, and inventing one
+ * would make one importer's provenance a permanent part of the table's shape).
+ * The audit event is therefore its ONLY durable home.
+ *
+ * Skipped rows are deliberately not audited: they are the rows the commit left
+ * untouched, and one event per unchanged row would bury the real writes on
+ * every re-import of an unchanged file.
+ */
+
+import { writeRouteAudit, type AuthContext as AuditRouteContext } from '../../auditEvents';
+import type { CustomFieldDefinitionImportRow, DefinitionImportSummary } from './types';
+
+export interface DefinitionImportAuditInput {
+  summary: DefinitionImportSummary;
+  /**
+   * The rows as submitted, indexed the same way the summary is, so each created
+   * definition can be attributed to the source field it came from.
+   */
+  rows: readonly CustomFieldDefinitionImportRow[];
+  /** Which RMM the file was exported from, e.g. `datto_rmm`. */
+  externalSystem: string;
+}
+
+/** One event per definition the import created. */
+export function writeCustomFieldDefinitionImportAudits(
+  c: AuditRouteContext,
+  { summary, rows, externalSystem }: DefinitionImportAuditInput,
+): void {
+  const rowCount = rows.length;
+
+  for (const entry of summary.created) {
+    const row = rows[entry.index];
+    writeRouteAudit(c, {
+      orgId: entry.organizationId,
+      action: 'custom_field.create',
+      resourceType: 'custom_field',
+      resourceId: entry.definitionId,
+      resourceName: row?.name ?? entry.fieldKey,
+      details: {
+        source: 'custom_field_definition_import',
+        externalSystem,
+        ...(row?.sourceLabel ? { sourceLabel: row.sourceLabel } : {}),
+        fieldKey: entry.fieldKey,
+        ownerScope: entry.ownerScope,
+        rowCount,
+      },
+    });
+  }
+}

--- a/apps/api/src/services/customFields/import/definitionImport.test.ts
+++ b/apps/api/src/services/customFields/import/definitionImport.test.ts
@@ -1,9 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { selectQueue, insertImpl, transactionSpy } = vi.hoisted(() => ({
+const { selectQueue, insertImpl, transactionSpy, insertedValues } = vi.hoisted(() => ({
   selectQueue: [] as unknown[][],
   insertImpl: { current: null as null | ((values: Record<string, unknown>) => unknown) },
   transactionSpy: vi.fn(),
+  /** Every payload handed to `tx.insert(...).values(...)`, in order. */
+  insertedValues: [] as Array<Record<string, unknown>>,
 }));
 
 /**
@@ -28,12 +30,15 @@ vi.mock('../../../db', () => ({
       transactionSpy();
       const tx = {
         insert: () => ({
-          values: (values: Record<string, unknown>) => ({
-            returning: async () => {
-              if (!insertImpl.current) throw new Error('no insert impl queued');
-              return insertImpl.current(values);
-            },
-          }),
+          values: (values: Record<string, unknown>) => {
+            insertedValues.push(values);
+            return {
+              returning: async () => {
+                if (!insertImpl.current) throw new Error('no insert impl queued');
+                return insertImpl.current(values);
+              },
+            };
+          },
         }),
       };
       return cb(tx);
@@ -104,12 +109,26 @@ function orgDefinition(
   return { id, orgId, partnerId: null, fieldKey, type };
 }
 
-function row(overrides: Partial<CustomFieldDefinitionImportRow> = {}): CustomFieldDefinitionImportRow {
-  return { fieldKey: 'udf7', name: 'Warranty Expiry', type: 'date', ownerScope: 'partner', ...overrides };
+/**
+ * Cast on purpose. `CustomFieldDefinitionImportRow` is a discriminated union on
+ * `ownerScope`, so a partial-override helper cannot be expressed in it — and
+ * several tests below deliberately build rows the union forbids (an
+ * `organization` row with no `organizationId`) to prove the SERVICE still fails
+ * closed for a direct caller that bypassed the route's zod schema.
+ */
+function row(overrides: Record<string, unknown> = {}): CustomFieldDefinitionImportRow {
+  return {
+    fieldKey: 'udf7',
+    name: 'Warranty Expiry',
+    type: 'date',
+    ownerScope: 'partner',
+    ...overrides,
+  } as CustomFieldDefinitionImportRow;
 }
 
 beforeEach(() => {
   selectQueue.length = 0;
+  insertedValues.length = 0;
   insertImpl.current = (values) => [{ id: NEW_ID, ...values }];
   transactionSpy.mockClear();
 });
@@ -166,11 +185,11 @@ describe('previewCustomFieldDefinitionImport', () => {
   });
 
   it('reports an organization row with no organizationId as org-not-found', async () => {
+    // The route's zod schema makes this unrepresentable, and so does the type.
+    // The service is reachable directly (AI tools, W08, a future worker), so it
+    // must still fail closed rather than write a row with a null owner.
     seed([]);
-    const [r] = await previewCustomFieldDefinitionImport(
-      [{ fieldKey: 'a', name: 'A', type: 'text', ownerScope: 'organization' }],
-      ctx,
-    );
+    const [r] = await previewCustomFieldDefinitionImport([row({ fieldKey: 'a', name: 'A', type: 'text', ownerScope: 'organization' })], ctx);
     expect(r!.annotation).toBe('org-not-found');
   });
 
@@ -192,6 +211,43 @@ describe('previewCustomFieldDefinitionImport', () => {
       ctx,
     );
     expect(rows[1]!.annotation).toBe('key-shadowed');
+  });
+
+  describe('organization reach bounding', () => {
+    it('system scope (accessibleOrgIds null) resolves any org under the partner', async () => {
+      // `null` means "unrestricted within this partner" — the org query runs
+      // with no id filter and the returned orgs are the whole reach.
+      seed([], [ORG, FOREIGN_ORG]);
+      const rows = await previewCustomFieldDefinitionImport(
+        [
+          row({ fieldKey: 'a', name: 'A', type: 'text', ownerScope: 'organization', organizationId: ORG }),
+          row({ fieldKey: 'b', name: 'B', type: 'text', ownerScope: 'organization', organizationId: FOREIGN_ORG }),
+        ],
+        { ...ctx, accessibleOrgIds: null },
+      );
+      expect(rows.map((r) => r.annotation)).toEqual(['create', 'create']);
+    });
+
+    it('an EMPTY accessibleOrgIds array reaches zero orgs — it must not degrade into "no filter"', async () => {
+      // Only ONE result is queued (the definitions query): a caller who can
+      // reach nothing must not issue the org query at all. If the code ever
+      // stopped short-circuiting, it would consume this queue entry as the org
+      // list and the row below would annotate `create`.
+      selectQueue.length = 0;
+      selectQueue.push([partnerDefinition('udf7', 'date')]);
+      const [r] = await previewCustomFieldDefinitionImport(
+        [row({ fieldKey: 'a', name: 'A', type: 'text', ownerScope: 'organization', organizationId: ORG })],
+        { ...ctx, accessibleOrgIds: [] },
+      );
+      expect(r!.annotation).toBe('org-not-found');
+    });
+
+    it('an EMPTY accessibleOrgIds array can still see its own partner-wide rows', async () => {
+      selectQueue.length = 0;
+      selectQueue.push([partnerDefinition('udf7', 'date')]);
+      const [r] = await previewCustomFieldDefinitionImport([row()], { ...ctx, accessibleOrgIds: [] });
+      expect(r!.annotation).toBe('already-exists');
+    });
   });
 
   it('never resolves a row against an organization outside the caller reach', async () => {
@@ -317,6 +373,108 @@ describe('commitCustomFieldDefinitionImport', () => {
     expect(JSON.stringify(s)).not.toMatch(/boom/);
     // …but the original error is still reachable in-process for error tracking.
     expect((s.errors[0] as { cause?: unknown }).cause).toBeInstanceOf(Error);
+  });
+
+  it('writes the owner axis and the column defaults the single-create route writes', async () => {
+    // Asserted from the INSERT payload, not from the summary: the summary is
+    // built from variables computed BEFORE the write, so it would still look
+    // right if orgId/partnerId were swapped in the statement itself.
+    seed([], [ORG]);
+    await commitCustomFieldDefinitionImport(
+      [
+        { ...row(), expectedAnnotation: 'create' },
+        {
+          ...row({ fieldKey: 'udf8', name: 'Asset tag', type: 'text', ownerScope: 'organization', organizationId: ORG }),
+          expectedAnnotation: 'create',
+        },
+      ],
+      ctx,
+      actor,
+    );
+    expect(insertedValues[0]).toMatchObject({
+      orgId: null,
+      partnerId: PARTNER,
+      fieldKey: 'udf7',
+      type: 'date',
+      required: false,
+      options: null,
+      deviceTypes: null,
+    });
+    expect(insertedValues[1]).toMatchObject({ orgId: ORG, partnerId: null, fieldKey: 'udf8' });
+  });
+
+  it('reports an unmapped SQLSTATE with the generic copy, never as a success', async () => {
+    seed([]);
+    insertImpl.current = () => {
+      throw Object.assign(new Error('out of shared memory'), { code: '53200' });
+    };
+    const s = await commitCustomFieldDefinitionImport([{ ...row(), expectedAnnotation: 'create' }], ctx, actor);
+    expect(s.created).toHaveLength(0);
+    expect(s.errors[0]).toMatchObject({ code: 'write-failed' });
+    expect(s.errors[0]!.error).toMatch(/check the server log/i);
+  });
+
+  it('reports a non-Postgres throw with the generic copy too', async () => {
+    seed([]);
+    insertImpl.current = () => {
+      throw new TypeError('something in the driver blew up');
+    };
+    const s = await commitCustomFieldDefinitionImport([{ ...row(), expectedAnnotation: 'create' }], ctx, actor);
+    expect(s.errors[0]).toMatchObject({ code: 'write-failed' });
+    expect(JSON.stringify(s)).not.toMatch(/blew up/);
+  });
+
+  it('maps an RLS refusal (42501) to copy about access, not to a mystery', async () => {
+    seed([]);
+    insertImpl.current = () => {
+      throw Object.assign(new Error('new row violates row-level security policy'), { code: '42501' });
+    };
+    const s = await commitCustomFieldDefinitionImport([{ ...row(), expectedAnnotation: 'create' }], ctx, actor);
+    expect(s.errors[0]!.error).toMatch(/do not have access/i);
+  });
+
+  it('never serializes `cause` onto the wire, on any error entry', async () => {
+    seed([]);
+    insertImpl.current = () => {
+      throw Object.assign(new Error('secret query text'), { code: '23503' });
+    };
+    const s = await commitCustomFieldDefinitionImport([{ ...row(), expectedAnnotation: 'create' }], ctx, actor);
+    // The property exists in-process…
+    expect((s.errors[0] as { cause?: unknown }).cause).toBeInstanceOf(Error);
+    // …and is invisible to every serialization path a route could take.
+    expect(JSON.stringify(s.errors[0])).not.toMatch(/cause/);
+    expect(Object.keys(s.errors[0]!)).not.toContain('cause');
+  });
+
+  it('treats an insert that returns no row as a failure, never a silent success', async () => {
+    seed([]);
+    insertImpl.current = () => [];
+    const s = await commitCustomFieldDefinitionImport([{ ...row(), expectedAnnotation: 'create' }], ctx, actor);
+    expect(s.created).toHaveLength(0);
+    expect(s.errors[0]).toMatchObject({ code: 'write-failed' });
+  });
+
+  it('continues the batch after a row fails at the write', async () => {
+    seed([]);
+    let call = 0;
+    insertImpl.current = (values) => {
+      call += 1;
+      if (call === 1) throw Object.assign(new Error('boom'), { code: '23505' });
+      return [{ id: NEW_ID, ...values }];
+    };
+    const s = await commitCustomFieldDefinitionImport(
+      [
+        { ...row(), expectedAnnotation: 'create' },
+        { ...row({ fieldKey: 'udf8', name: 'B', type: 'text' }), expectedAnnotation: 'create' },
+      ],
+      ctx,
+      actor,
+    );
+    expect(s.errors.map((e) => e.index)).toEqual([0]);
+    expect(s.created.map((e) => e.index)).toEqual([1]);
+    // Each row opened its own nested transaction — that is what makes the
+    // second write reachable at all inside one request transaction.
+    expect(transactionSpy).toHaveBeenCalledTimes(2);
   });
 
   it('never lets a row land in more than one of created / skipped / errors', async () => {

--- a/apps/api/src/services/customFields/import/definitionImport.test.ts
+++ b/apps/api/src/services/customFields/import/definitionImport.test.ts
@@ -1,0 +1,350 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { selectQueue, insertImpl, transactionSpy } = vi.hoisted(() => ({
+  selectQueue: [] as unknown[][],
+  insertImpl: { current: null as null | ((values: Record<string, unknown>) => unknown) },
+  transactionSpy: vi.fn(),
+}));
+
+/**
+ * The snapshot loader issues its two SELECTs inside ONE
+ * `runOutsideDbContext(() => withSystemDbAccessContext(...))`, and every write
+ * goes through a NESTED `db.transaction` so a failing row rolls back to its own
+ * savepoint. Both shapes are modelled here so a change to either is visible as
+ * a test failure rather than as an undetected behaviour change.
+ */
+function chainable(result: unknown[]) {
+  const thenable = {
+    then: (resolve: (v: unknown) => unknown, reject?: (e: unknown) => unknown) =>
+      Promise.resolve(result).then(resolve, reject),
+  };
+  return { from: () => ({ where: () => thenable }) };
+}
+
+vi.mock('../../../db', () => ({
+  db: {
+    select: vi.fn(() => chainable(selectQueue.shift() ?? [])),
+    transaction: (cb: (tx: unknown) => Promise<unknown>) => {
+      transactionSpy();
+      const tx = {
+        insert: () => ({
+          values: (values: Record<string, unknown>) => ({
+            returning: async () => {
+              if (!insertImpl.current) throw new Error('no insert impl queued');
+              return insertImpl.current(values);
+            },
+          }),
+        }),
+      };
+      return cb(tx);
+    },
+  },
+  runOutsideDbContext: <T>(fn: () => Promise<T>) => fn(),
+  withSystemDbAccessContext: <T>(fn: () => Promise<T>) => fn(),
+}));
+
+vi.mock('../../../db/schema', () => ({
+  customFieldDefinitions: {
+    id: 'id',
+    orgId: 'orgId',
+    partnerId: 'partnerId',
+    fieldKey: 'fieldKey',
+    type: 'type',
+  },
+  organizations: { id: 'id', partnerId: 'partnerId', deletedAt: 'deletedAt' },
+}));
+
+import {
+  commitCustomFieldDefinitionImport,
+  previewCustomFieldDefinitionImport,
+  type DefinitionImportContext,
+} from './definitionImport';
+import type { CustomFieldDefinitionImportRow, CustomFieldType } from './types';
+
+const PARTNER = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const ORG = '11111111-1111-4111-8111-111111111111';
+const FOREIGN_ORG = '22222222-2222-4222-8222-222222222222';
+const DEF_A = '33333333-3333-4333-8333-333333333333';
+const DEF_B = '44444444-4444-4444-8444-444444444444';
+const NEW_ID = '55555555-5555-4555-8555-555555555555';
+
+const ctx: DefinitionImportContext = {
+  partnerId: PARTNER,
+  accessibleOrgIds: [ORG],
+  canManagePartnerWide: true,
+};
+
+const actor = { userId: 'u-1' };
+
+interface SeedDefinition {
+  id: string;
+  orgId: string | null;
+  partnerId: string | null;
+  fieldKey: string;
+  type: CustomFieldType;
+}
+
+/** Queue the two SELECT results the snapshot loader consumes, in order. */
+function seed(definitions: SeedDefinition[], orgIds: string[] = [ORG]) {
+  selectQueue.length = 0;
+  selectQueue.push(orgIds.map((id) => ({ id })));
+  selectQueue.push(definitions);
+}
+
+function partnerDefinition(fieldKey: string, type: CustomFieldType, id = DEF_A): SeedDefinition {
+  return { id, orgId: null, partnerId: PARTNER, fieldKey, type };
+}
+
+function orgDefinition(
+  fieldKey: string,
+  type: CustomFieldType,
+  id = DEF_B,
+  orgId = ORG,
+): SeedDefinition {
+  return { id, orgId, partnerId: null, fieldKey, type };
+}
+
+function row(overrides: Partial<CustomFieldDefinitionImportRow> = {}): CustomFieldDefinitionImportRow {
+  return { fieldKey: 'udf7', name: 'Warranty Expiry', type: 'date', ownerScope: 'partner', ...overrides };
+}
+
+beforeEach(() => {
+  selectQueue.length = 0;
+  insertImpl.current = (values) => [{ id: NEW_ID, ...values }];
+  transactionSpy.mockClear();
+});
+
+describe('previewCustomFieldDefinitionImport', () => {
+  it('annotates an unseen key as create', async () => {
+    seed([]);
+    const [r] = await previewCustomFieldDefinitionImport([row()], ctx);
+    expect(r).toMatchObject({ annotation: 'create', existingId: null, existingType: null });
+  });
+
+  it('annotates a key that already exists with the SAME type as already-exists', async () => {
+    seed([partnerDefinition('udf7', 'date')]);
+    const [r] = await previewCustomFieldDefinitionImport([row({ name: 'Warranty' })], ctx);
+    expect(r).toMatchObject({ annotation: 'already-exists', existingId: DEF_A, existingType: 'date' });
+  });
+
+  it('annotates a differing type as type-conflict, never a silent cast', async () => {
+    seed([partnerDefinition('udf7', 'text')]);
+    const [r] = await previewCustomFieldDefinitionImport([row()], ctx);
+    expect(r).toMatchObject({ annotation: 'type-conflict', existingType: 'text' });
+  });
+
+  it('annotates an org-owned key that shadows a partner-wide one as key-shadowed', async () => {
+    seed([partnerDefinition('udf7', 'text')]);
+    const [r] = await previewCustomFieldDefinitionImport(
+      [row({ name: 'Local', type: 'text', ownerScope: 'organization', organizationId: ORG })],
+      ctx,
+    );
+    expect(r!.annotation).toBe('key-shadowed');
+  });
+
+  it('annotates a partner-wide key that shadows an org-owned one as key-shadowed', async () => {
+    seed([orgDefinition('udf7', 'text')]);
+    const [r] = await previewCustomFieldDefinitionImport([row({ type: 'text' })], ctx);
+    expect(r!.annotation).toBe('key-shadowed');
+  });
+
+  it('refuses a partner-wide row from a caller without the capability, at PREVIEW', async () => {
+    seed([]);
+    const [r] = await previewCustomFieldDefinitionImport([row()], { ...ctx, canManagePartnerWide: false });
+    // NOT `org-not-found`: that copy would send a tech looking for a missing
+    // organization when the truth is a missing capability.
+    expect(r!.annotation).toBe('partner-wide-denied');
+  });
+
+  it('reports an org outside the caller reach as org-not-found, never an existence oracle', async () => {
+    seed([]);
+    const [r] = await previewCustomFieldDefinitionImport(
+      [row({ fieldKey: 'a', name: 'A', type: 'text', ownerScope: 'organization', organizationId: FOREIGN_ORG })],
+      ctx,
+    );
+    expect(r!.annotation).toBe('org-not-found');
+  });
+
+  it('reports an organization row with no organizationId as org-not-found', async () => {
+    seed([]);
+    const [r] = await previewCustomFieldDefinitionImport(
+      [{ fieldKey: 'a', name: 'A', type: 'text', ownerScope: 'organization' }],
+      ctx,
+    );
+    expect(r!.annotation).toBe('org-not-found');
+  });
+
+  it('detects a duplicate key WITHIN the submitted batch', async () => {
+    seed([]);
+    const rows = await previewCustomFieldDefinitionImport(
+      [row({ name: 'A', type: 'text' }), row({ name: 'B', type: 'text' })],
+      ctx,
+    );
+    expect(rows[0]!.annotation).toBe('create');
+    expect(rows[1]).toMatchObject({ annotation: 'type-conflict' });
+    expect(rows[1]!.conflictReason).toMatch(/appears more than once/i);
+  });
+
+  it('detects a CROSS-AXIS duplicate within the submitted batch as key-shadowed', async () => {
+    seed([]);
+    const rows = await previewCustomFieldDefinitionImport(
+      [row({ type: 'text' }), row({ type: 'text', ownerScope: 'organization', organizationId: ORG })],
+      ctx,
+    );
+    expect(rows[1]!.annotation).toBe('key-shadowed');
+  });
+
+  it('never resolves a row against an organization outside the caller reach', async () => {
+    // The snapshot is bounded by partnerId AND accessibleOrgIds; a foreign org
+    // is not in it, so the row can only ever be `org-not-found`.
+    seed([orgDefinition('udf7', 'text', DEF_B, ORG)], [ORG]);
+    const [r] = await previewCustomFieldDefinitionImport(
+      [row({ type: 'text', ownerScope: 'organization', organizationId: FOREIGN_ORG })],
+      ctx,
+    );
+    expect(r!.annotation).toBe('org-not-found');
+  });
+});
+
+describe('commitCustomFieldDefinitionImport', () => {
+  it('creates a partner-wide definition and reports it', async () => {
+    seed([]);
+    const s = await commitCustomFieldDefinitionImport([{ ...row(), expectedAnnotation: 'create' }], ctx, actor);
+    expect(s.errors).toHaveLength(0);
+    expect(s.created).toHaveLength(1);
+    expect(s.created[0]).toMatchObject({ fieldKey: 'udf7', ownerScope: 'partner', organizationId: null });
+  });
+
+  it('writes every row inside a nested transaction so one failure cannot poison the request', async () => {
+    seed([]);
+    await commitCustomFieldDefinitionImport([{ ...row(), expectedAnnotation: 'create' }], ctx, actor);
+    expect(transactionSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses a row whose annotation moved since preview', async () => {
+    seed([partnerDefinition('udf7', 'date')]);
+    const s = await commitCustomFieldDefinitionImport(
+      [{ ...row(), name: 'Warranty', expectedAnnotation: 'create' }],
+      ctx,
+      actor,
+    );
+    expect(s.errors[0]).toMatchObject({ code: 'annotation-changed' });
+    expect(s.created).toHaveLength(0);
+  });
+
+  it('refuses an already-exists acknowledgement pinned to a DIFFERENT definition', async () => {
+    seed([partnerDefinition('udf7', 'date', DEF_A)]);
+    const s = await commitCustomFieldDefinitionImport(
+      [{ ...row(), name: 'W', expectedAnnotation: 'already-exists', expectedDefinitionId: DEF_B }],
+      ctx,
+      actor,
+    );
+    expect(s.errors[0]).toMatchObject({ code: 'match-changed' });
+    expect(s.skipped).toHaveLength(0);
+  });
+
+  it('is idempotent: re-running an identical file creates nothing', async () => {
+    seed([partnerDefinition('udf7', 'date', DEF_A)]);
+    const again = await commitCustomFieldDefinitionImport(
+      [{ ...row(), name: 'W', expectedAnnotation: 'already-exists', expectedDefinitionId: DEF_A }],
+      ctx,
+      actor,
+    );
+    expect(again.created).toHaveLength(0);
+    expect(again.skipped).toEqual([
+      { index: 0, definitionId: DEF_A, fieldKey: 'udf7', reason: 'already-exists' },
+    ]);
+  });
+
+  it('refuses a partner-wide row from a caller without the capability', async () => {
+    seed([]);
+    const s = await commitCustomFieldDefinitionImport(
+      [{ ...row(), expectedAnnotation: 'create' }],
+      { ...ctx, canManagePartnerWide: false },
+      actor,
+    );
+    expect(s.errors[0]).toMatchObject({ code: 'partner-wide-denied' });
+    expect(s.created).toHaveLength(0);
+    expect(transactionSpy).not.toHaveBeenCalled();
+  });
+
+  it('refuses an organization row naming an org outside the caller reach', async () => {
+    seed([]);
+    const s = await commitCustomFieldDefinitionImport(
+      [{ ...row(), ownerScope: 'organization', organizationId: FOREIGN_ORG, expectedAnnotation: 'create' }],
+      ctx,
+      actor,
+    );
+    expect(s.errors[0]).toMatchObject({ code: 'org-not-found' });
+    expect(transactionSpy).not.toHaveBeenCalled();
+  });
+
+  it('turns a 23505 into a typed write-failed with FIXED copy, never the driver message', async () => {
+    seed([]);
+    insertImpl.current = () => {
+      throw Object.assign(
+        new Error(
+          'duplicate key value violates unique constraint "custom_field_definitions_partner_key_uq" '
+            + 'DETAIL: Key (partner_id, field_key)=(p, udf7) already exists.',
+        ),
+        { code: '23505' },
+      );
+    };
+    const s = await commitCustomFieldDefinitionImport([{ ...row(), expectedAnnotation: 'create' }], ctx, actor);
+    expect(s.errors[0]!.code).toBe('write-failed');
+    expect(s.errors[0]!.error).not.toMatch(/DETAIL|constraint/);
+    expect(s.errors[0]!.error).toMatch(/already exists/i);
+  });
+
+  it('surfaces the anti-shadowing trigger P0001 as key-shadowed', async () => {
+    seed([]);
+    insertImpl.current = () => {
+      throw Object.assign(
+        new Error('custom field key "udf7" already exists as an all-organizations field for this partner'),
+        { code: 'P0001' },
+      );
+    };
+    const s = await commitCustomFieldDefinitionImport([{ ...row(), expectedAnnotation: 'create' }], ctx, actor);
+    expect(s.errors[0]!.code).toBe('key-shadowed');
+  });
+
+  it('never serializes the driver error onto the response body', async () => {
+    seed([]);
+    insertImpl.current = () => {
+      throw Object.assign(new Error('boom: select * from custom_field_definitions'), { code: '23514' });
+    };
+    const s = await commitCustomFieldDefinitionImport([{ ...row(), expectedAnnotation: 'create' }], ctx, actor);
+    expect(JSON.stringify(s)).not.toMatch(/boom/);
+    // …but the original error is still reachable in-process for error tracking.
+    expect((s.errors[0] as { cause?: unknown }).cause).toBeInstanceOf(Error);
+  });
+
+  it('never lets a row land in more than one of created / skipped / errors', async () => {
+    seed([partnerDefinition('udf8', 'text', DEF_A)]);
+    const s = await commitCustomFieldDefinitionImport(
+      [
+        { ...row(), expectedAnnotation: 'create' },
+        {
+          ...row({ fieldKey: 'udf8', name: 'B', type: 'text' }),
+          expectedAnnotation: 'already-exists',
+          expectedDefinitionId: DEF_A,
+        },
+        {
+          ...row({
+            fieldKey: 'udf9',
+            name: 'C',
+            type: 'text',
+            ownerScope: 'organization',
+            organizationId: FOREIGN_ORG,
+          }),
+          expectedAnnotation: 'create',
+        },
+      ],
+      ctx,
+      actor,
+    );
+    const seen = [...s.created, ...s.skipped, ...s.errors].map((e) => e.index);
+    expect(seen.slice().sort()).toEqual([0, 1, 2]);
+    expect(new Set(seen).size).toBe(seen.length);
+  });
+});

--- a/apps/api/src/services/customFields/import/definitionImport.ts
+++ b/apps/api/src/services/customFields/import/definitionImport.ts
@@ -1,0 +1,518 @@
+/**
+ * Custom-field DEFINITION import pipeline: preview -> commit (#3257 W07).
+ *
+ * Named `customFieldDefinitionImport`, never `customFieldImport`: `tickets.
+ * custom_fields` (`db/schema/portal.ts`) and the PSA/Jira `customFields`
+ * (`services/psa/jira.ts`) are unrelated namesakes already in the tree, and the
+ * VALUES importer (W08) is a different pipeline with different tenancy.
+ *
+ * Modelled on `services/contacts/import.ts`: preview annotates every row
+ * against a snapshot; commit RE-DERIVES every annotation against freshly loaded
+ * state and refuses any row whose annotation moved, with identity pinning on
+ * the matched definition. Preview is advisory; the database is authority.
+ *
+ * ── What the annotations encode ─────────────────────────────────────────────
+ * The destination was hardened before this importer shipped, and preview must
+ * report that reality rather than a guess:
+ *
+ *  - W02 gave `custom_field_definitions` a per-axis unique index, so a
+ *    same-axis re-import is `already-exists` (skipped), not a second row.
+ *  - W02's `custom_field_definitions_one_owner_chk` makes ownership org XOR
+ *    partner, so `ownerScope` is the row's whole ownership story.
+ *  - W03's `custom_field_definitions_no_shadow` trigger forbids the same
+ *    `field_key` on both axes under one partner, so a cross-axis collision is
+ *    `key-shadowed` at preview instead of a P0001 nobody expected at commit.
+ *
+ * ── Where the snapshot comes from, and why it is a system read ──────────────
+ * `custom_field_definitions` has NO partner-wide SELECT branch on its RLS
+ * policy — it is listed in `PARTNER_WIDE_SELECT_BRANCH_EXEMPT`
+ * (`rls-coverage.integration.test.ts`, TODO #4944) — so an ORGANIZATION-scoped
+ * request context cannot see partner-wide rows at all. Reading the snapshot in
+ * the request context would therefore annotate a shadowed key as `create` for
+ * exactly the callers most likely to hit it. The snapshot is loaded in ONE
+ * system context instead, bounded by `ctx.partnerId` AND `ctx.accessibleOrgIds`
+ * — the same reasoning, and the same bound, as `contacts/import.ts:229`.
+ *
+ * Because that read has no RLS backstop, the app-layer bound is the WHOLE
+ * boundary on it: a row naming an organization absent from the snapshot is
+ * refused as `org-not-found`, the same annotation an unreachable org gets, so
+ * the response is never an existence oracle.
+ *
+ * ── Where the WRITES happen, and why that is different ──────────────────────
+ * Writes deliberately do NOT escape to a system context. Each row's insert runs
+ * in a NESTED `db.transaction` inside the request's own `withDbAccessContext`
+ * transaction, which drizzle emits as a SAVEPOINT
+ * (`dbSavepointErrorIsolation.integration.test.ts` is the proof). That buys the
+ * per-row failure isolation an importer needs — a failed statement would
+ * otherwise abort the request transaction and every later row would raise
+ * 25P02 — while keeping RLS as a real second control on every write. The
+ * failing statement MUST be issued on the nested callback's `tx`, never on the
+ * ambient `db` proxy, or the error is recorded against the OUTER scope and the
+ * isolation is lost.
+ */
+
+import { and, eq, inArray, isNull, or } from 'drizzle-orm';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../../../db';
+import { customFieldDefinitions, organizations } from '../../../db/schema';
+import { pgErrorCode, pgErrorNode } from '../../../utils/pgErrors';
+import { PARTNER_WIDE_WRITE_DENIED_MESSAGE } from '../../partnerWideAccess';
+import { customFieldWriteConflict } from '../writeErrors';
+import type {
+  AnnotatedDefinitionRow,
+  CommitDefinitionRowInput,
+  CustomFieldDefinitionImportRow,
+  CustomFieldType,
+  DefinitionAnnotation,
+  DefinitionImportErrorCode,
+  DefinitionImportErrorEntry,
+  DefinitionImportSummary,
+} from './types';
+
+export type * from './types';
+export { MAX_IMPORT_ROWS, MAX_IMPORT_VALUES } from './types';
+
+/** What the importer is allowed to see and do, resolved once at the route. */
+export interface DefinitionImportContext {
+  partnerId: string;
+  /**
+   * The caller's own organization allowlist. `null` is system scope
+   * (unrestricted within the partner); an EMPTY array is a caller who can reach
+   * no organization and must resolve to zero, never degrade into "no filter".
+   */
+  accessibleOrgIds: string[] | null;
+  /**
+   * From `canManagePartnerWidePolicies(auth)`. A partner-wide row from a caller
+   * without it is refused at PREVIEW, not just at commit, and with its own
+   * annotation — see `DefinitionAnnotation`.
+   */
+  canManagePartnerWide: boolean;
+}
+
+export interface DefinitionImportActor {
+  userId: string | null;
+}
+
+interface SnapshotDefinition {
+  id: string;
+  fieldKey: string;
+  type: CustomFieldType;
+}
+
+interface Snapshot {
+  /** Organizations under this partner the caller can actually reach. */
+  orgIds: Set<string>;
+  /** `field_key` -> the partner-wide definition owning it. */
+  partnerByKey: Map<string, SnapshotDefinition>;
+  /** `orgId \0 field_key` -> the org-owned definition owning it. */
+  orgByKey: Map<string, SnapshotDefinition>;
+  /** `field_key` -> one org-owned definition using it, for shadow reporting. */
+  anyOrgByKey: Map<string, SnapshotDefinition>;
+}
+
+// NUL separator: Postgres text cannot contain NUL, so composite keys built from
+// user data can never collide across their parts.
+const SEP = "\u0000";
+
+async function loadSnapshot(ctx: DefinitionImportContext): Promise<Snapshot> {
+  const snapshot: Snapshot = {
+    orgIds: new Set(),
+    partnerByKey: new Map(),
+    orgByKey: new Map(),
+    anyOrgByKey: new Map(),
+  };
+
+  const reach = ctx.accessibleOrgIds ?? null;
+  // An empty reach is a caller who can reach nothing. They may still own
+  // partner-wide rows, so the definition query still runs — but no organization
+  // resolves, so every `ownerScope: 'organization'` row is `org-not-found`.
+
+  // ONE escalation for both queries: two would acquire two pooled connections
+  // under the request's own transaction rather than one.
+  const { orgRows, definitionRows } = await runOutsideDbContext(() =>
+    withSystemDbAccessContext(async () => {
+      const orgs = reach !== null && reach.length === 0
+        ? []
+        : ((await db
+            .select({ id: organizations.id })
+            .from(organizations)
+            .where(
+              and(
+                eq(organizations.partnerId, ctx.partnerId),
+                isNull(organizations.deletedAt),
+                ...(reach ? [inArray(organizations.id, reach)] : []),
+              ),
+            )) as Array<{ id: string }>);
+
+      const orgIds = orgs.map((o) => o.id);
+      const definitions = (await db
+        .select({
+          id: customFieldDefinitions.id,
+          orgId: customFieldDefinitions.orgId,
+          partnerId: customFieldDefinitions.partnerId,
+          fieldKey: customFieldDefinitions.fieldKey,
+          type: customFieldDefinitions.type,
+        })
+        .from(customFieldDefinitions)
+        .where(
+          orgIds.length > 0
+            ? or(
+                eq(customFieldDefinitions.partnerId, ctx.partnerId),
+                inArray(customFieldDefinitions.orgId, orgIds),
+              )
+            : eq(customFieldDefinitions.partnerId, ctx.partnerId),
+        )) as Array<{
+          id: string;
+          orgId: string | null;
+          partnerId: string | null;
+          fieldKey: string;
+          type: CustomFieldType;
+        }>;
+
+      return { orgRows: orgs, definitionRows: definitions };
+    }, 'customFieldDefinitionImport.snapshot'),
+  );
+
+  for (const org of orgRows) snapshot.orgIds.add(org.id);
+
+  for (const def of definitionRows) {
+    const entry: SnapshotDefinition = { id: def.id, fieldKey: def.fieldKey, type: def.type };
+    if (def.orgId) {
+      // A definition on an organization outside the caller's reach can only
+      // arrive here if the partner branch of the query matched it, which it
+      // cannot: org-owned rows have a NULL partner_id (W02's XOR check).
+      if (!snapshot.orgIds.has(def.orgId)) continue;
+      snapshot.orgByKey.set(def.orgId + SEP + def.fieldKey, entry);
+      if (!snapshot.anyOrgByKey.has(def.fieldKey)) snapshot.anyOrgByKey.set(def.fieldKey, entry);
+    } else if (def.partnerId) {
+      snapshot.partnerByKey.set(def.fieldKey, entry);
+    }
+  }
+
+  return snapshot;
+}
+
+const DUPLICATE_IN_BATCH_REASON =
+  'This field key appears more than once in the submitted file — remove the duplicate row';
+
+function shadowReason(key: string, shadowedBy: 'partner' | 'organization'): string {
+  return shadowedBy === 'partner'
+    ? `Field key "${key}" already exists as an all-organizations field for this partner`
+    : `Field key "${key}" already exists as an organization-owned field under this partner`;
+}
+
+/**
+ * Annotate every row in ONE ordered pass.
+ *
+ * Pure, and deliberately order-dependent within the batch: a key's FIRST
+ * occurrence is annotated against the database, and every later occurrence is
+ * annotated against what the earlier row would leave behind. Preview and commit
+ * therefore derive identical annotations for an unchanged batch — the whole
+ * point of `expectedAnnotation` — and the "the file contradicts itself" cases
+ * (`type-conflict` on a same-axis repeat, `key-shadowed` on a cross-axis
+ * repeat) are reported instead of arriving as a bare 23505 / P0001 at commit.
+ */
+function annotateRows(
+  rows: readonly CustomFieldDefinitionImportRow[],
+  snapshot: Snapshot,
+  ctx: DefinitionImportContext,
+): AnnotatedDefinitionRow[] {
+  /** Axis keys this batch will have written by the time a later row is reached. */
+  const batchPartnerKeys = new Set<string>();
+  const batchOrgKeys = new Set<string>();
+  /** `field_key`s this batch claims on each axis, for cross-axis detection. */
+  const batchPartnerFieldKeys = new Set<string>();
+  const batchOrgFieldKeys = new Set<string>();
+
+  return rows.map((row, index) => {
+    const base = { ...row, index, existingId: null as string | null, existingType: null as CustomFieldType | null };
+    const decide = (
+      annotation: DefinitionAnnotation,
+      extra: { existingId?: string | null; existingType?: CustomFieldType | null; conflictReason?: string } = {},
+    ): AnnotatedDefinitionRow => ({ ...base, annotation, ...extra });
+
+    if (row.ownerScope === 'partner') {
+      if (!ctx.canManagePartnerWide) return decide('partner-wide-denied', { conflictReason: PARTNER_WIDE_WRITE_DENIED_MESSAGE });
+
+      if (batchPartnerKeys.has(row.fieldKey)) return decide('type-conflict', { conflictReason: DUPLICATE_IN_BATCH_REASON });
+      if (batchOrgFieldKeys.has(row.fieldKey)) {
+        return decide('key-shadowed', { conflictReason: shadowReason(row.fieldKey, 'organization') });
+      }
+
+      const sameAxis = snapshot.partnerByKey.get(row.fieldKey);
+      if (sameAxis) {
+        batchPartnerKeys.add(row.fieldKey);
+        batchPartnerFieldKeys.add(row.fieldKey);
+        return sameAxis.type === row.type
+          ? decide('already-exists', { existingId: sameAxis.id, existingType: sameAxis.type })
+          : decide('type-conflict', {
+              existingId: sameAxis.id,
+              existingType: sameAxis.type,
+              conflictReason:
+                `Field key "${row.fieldKey}" already exists with type "${sameAxis.type}"; a field's type cannot be changed`,
+            });
+      }
+
+      const shadowing = snapshot.anyOrgByKey.get(row.fieldKey);
+      if (shadowing) {
+        return decide('key-shadowed', {
+          existingId: shadowing.id,
+          existingType: shadowing.type,
+          conflictReason: shadowReason(row.fieldKey, 'organization'),
+        });
+      }
+
+      batchPartnerKeys.add(row.fieldKey);
+      batchPartnerFieldKeys.add(row.fieldKey);
+      return decide('create');
+    }
+
+    // ownerScope === 'organization'
+    const orgId = row.organizationId;
+    // "Not named", "does not exist" and "not yours" all collapse to one
+    // annotation so the response is never an existence oracle.
+    if (!orgId || !snapshot.orgIds.has(orgId)) return decide('org-not-found');
+
+    const axisKey = orgId + SEP + row.fieldKey;
+    if (batchOrgKeys.has(axisKey)) return decide('type-conflict', { conflictReason: DUPLICATE_IN_BATCH_REASON });
+    if (batchPartnerFieldKeys.has(row.fieldKey)) {
+      return decide('key-shadowed', { conflictReason: shadowReason(row.fieldKey, 'partner') });
+    }
+
+    const sameAxis = snapshot.orgByKey.get(axisKey);
+    if (sameAxis) {
+      batchOrgKeys.add(axisKey);
+      batchOrgFieldKeys.add(row.fieldKey);
+      return sameAxis.type === row.type
+        ? decide('already-exists', { existingId: sameAxis.id, existingType: sameAxis.type })
+        : decide('type-conflict', {
+            existingId: sameAxis.id,
+            existingType: sameAxis.type,
+            conflictReason:
+              `Field key "${row.fieldKey}" already exists with type "${sameAxis.type}"; a field's type cannot be changed`,
+          });
+    }
+
+    const shadowing = snapshot.partnerByKey.get(row.fieldKey);
+    if (shadowing) {
+      return decide('key-shadowed', {
+        existingId: shadowing.id,
+        existingType: shadowing.type,
+        conflictReason: shadowReason(row.fieldKey, 'partner'),
+      });
+    }
+
+    batchOrgKeys.add(axisKey);
+    batchOrgFieldKeys.add(row.fieldKey);
+    return decide('create');
+  });
+}
+
+export async function previewCustomFieldDefinitionImport(
+  rows: readonly CustomFieldDefinitionImportRow[],
+  ctx: DefinitionImportContext,
+): Promise<AnnotatedDefinitionRow[]> {
+  return annotateRows(rows, await loadSnapshot(ctx), ctx);
+}
+
+interface ExpectationProblem {
+  error: string;
+  code: DefinitionImportErrorCode;
+}
+
+/**
+ * Validate a commit row's re-derived annotation against the client's
+ * acknowledgement. The annotation guard runs first, then identity pinning.
+ *
+ * The identity pin is what stops a `create` from silently becoming a no-op and
+ * an `already-exists` acknowledgement from being transferred: an operator who
+ * approved "reuse definition X" must not have that approval applied to whatever
+ * definition took over the key since preview.
+ */
+function checkExpectation(
+  row: CommitDefinitionRowInput,
+  derived: DefinitionAnnotation,
+  existingId: string | null,
+): ExpectationProblem | null {
+  if (row.expectedAnnotation && row.expectedAnnotation !== derived) {
+    return {
+      code: 'annotation-changed',
+      error: `Annotation changed since preview: expected "${row.expectedAnnotation}", now "${derived}" — re-run preview`,
+    };
+  }
+  if (row.expectedDefinitionId && (derived !== 'already-exists' || existingId !== row.expectedDefinitionId)) {
+    return {
+      code: 'match-changed',
+      error: 'Match changed since preview: the row now resolves to a different custom field — re-run preview',
+    };
+  }
+  if (derived === 'already-exists' && row.expectedAnnotation === 'already-exists' && !row.expectedDefinitionId) {
+    // The wire schema requires the pin, so this is unreachable from the routes.
+    // It is here because the service is also reachable directly, and an
+    // unpinned acknowledgement is exactly the transfer the pin exists to refuse.
+    return {
+      code: 'match-changed',
+      error: 'An "already-exists" acknowledgement must also carry expectedDefinitionId naming that custom field',
+    };
+  }
+  return null;
+}
+
+/**
+ * Attach the original thrown error WITHOUT making it serializable: routes hand
+ * the summary straight to `c.json(...)`, and a stack trace (or a pg error
+ * carrying query text) must never reach a response body. Read `entry.cause`
+ * in-process; never serialize it.
+ */
+function withCause(entry: DefinitionImportErrorEntry, cause: unknown): DefinitionImportErrorEntry {
+  Object.defineProperty(entry, 'cause', { value: cause, enumerable: false, writable: false });
+  return entry;
+}
+
+/**
+ * Stable, non-leaking copy for a failed row.
+ *
+ * A postgres.js error's `.message` carries the failing statement's detail —
+ * column values, constraint text, sometimes the query itself — so it is
+ * customer data and schema disclosure in one string and must never reach the
+ * response body. Known SQLSTATEs get useful fixed copy; anything else, pg or
+ * not, collapses to the generic line.
+ */
+const WRITE_FAILURE_COPY: Record<string, string> = {
+  '23503': 'The organization this custom field refers to no longer exists',
+  '23514': 'A custom field must be owned by exactly one of an organization or the partner',
+  '22001': 'A value on this row is too long for the field it targets',
+  '42501': 'You do not have access to create a custom field for this owner',
+};
+const GENERIC_WRITE_FAILURE = 'Could not write this custom field — check the server log for details';
+
+function writeFailure(err: unknown, fieldKey: string): ExpectationProblem {
+  // The two conflicts W02/W03 can raise share ONE mapper with the single-create
+  // route (services/customFields/writeErrors.ts) so the copy cannot drift.
+  const conflict = customFieldWriteConflict(err, fieldKey);
+  if (conflict) {
+    return {
+      error: conflict.error,
+      // A cross-axis shadow is a distinct, fixable operator problem, so it keeps
+      // its own row code. A same-axis duplicate reaching the WRITE is a race
+      // that preview did not see, which is a write failure, not a file problem.
+      code: conflict.code === 'field-key-shadowed' ? 'key-shadowed' : 'write-failed',
+    };
+  }
+  const code = pgErrorCode(err);
+  return { error: (code && WRITE_FAILURE_COPY[code]) ?? GENERIC_WRITE_FAILURE, code: 'write-failed' };
+}
+
+/** Annotations that can never be acknowledged into a write. */
+const REFUSED_ANNOTATIONS: Record<string, DefinitionImportErrorCode> = {
+  'partner-wide-denied': 'partner-wide-denied',
+  'org-not-found': 'org-not-found',
+  'type-conflict': 'type-conflict',
+  'key-shadowed': 'key-shadowed',
+};
+
+const REFUSAL_COPY: Record<string, string> = {
+  'partner-wide-denied': PARTNER_WIDE_WRITE_DENIED_MESSAGE,
+  'org-not-found': 'That organization was not found',
+  'type-conflict': 'This custom field conflicts with one that already exists',
+  'key-shadowed': 'This custom field key is already in use on the other ownership axis',
+};
+
+export async function commitCustomFieldDefinitionImport(
+  rows: readonly CommitDefinitionRowInput[],
+  ctx: DefinitionImportContext,
+  actor: DefinitionImportActor,
+): Promise<DefinitionImportSummary> {
+  // Re-derived against state loaded NOW, not against whatever preview saw.
+  const annotated = annotateRows(rows, await loadSnapshot(ctx), ctx);
+  const summary: DefinitionImportSummary = { created: [], skipped: [], errors: [] };
+
+  for (const derived of annotated) {
+    const row = rows[derived.index] as CommitDefinitionRowInput;
+    const refusal = REFUSED_ANNOTATIONS[derived.annotation];
+    if (refusal) {
+      summary.errors.push({
+        index: derived.index,
+        fieldKey: row.fieldKey,
+        error: derived.conflictReason ?? REFUSAL_COPY[derived.annotation] ?? 'This row cannot be imported',
+        code: refusal,
+      });
+      continue;
+    }
+
+    const problem = checkExpectation(row, derived.annotation, derived.existingId);
+    if (problem) {
+      summary.errors.push({ index: derived.index, fieldKey: row.fieldKey, ...problem });
+      continue;
+    }
+
+    if (derived.annotation === 'already-exists') {
+      // The definition already says what this row says. Re-importing an
+      // unchanged file writes nothing at all, and never rewrites a field a tech
+      // may have edited since.
+      summary.skipped.push({
+        index: derived.index,
+        definitionId: derived.existingId!,
+        fieldKey: row.fieldKey,
+        reason: 'already-exists',
+      });
+      continue;
+    }
+
+    const orgId = row.ownerScope === 'organization' ? row.organizationId! : null;
+    const partnerId = row.ownerScope === 'partner' ? ctx.partnerId : null;
+
+    try {
+      // Nested transaction => SAVEPOINT: a refused row rolls back to its own
+      // savepoint and leaves the request transaction healthy for the next one.
+      // The statement MUST be issued on `tx`, never the ambient `db` proxy.
+      const inserted = (await db.transaction(async (tx) =>
+        tx
+          .insert(customFieldDefinitions)
+          .values({
+            orgId,
+            partnerId,
+            name: row.name,
+            fieldKey: row.fieldKey,
+            type: row.type,
+            options: row.options ?? null,
+            required: row.required ?? false,
+            deviceTypes: row.deviceTypes ?? null,
+          })
+          .returning(),
+      )) as Array<{ id: string }>;
+
+      const created = inserted[0];
+      if (!created) throw new Error('insert returned no row');
+
+      // Reported only after the write has resolved, so a throw can never leave
+      // a row in `created` AND `errors` both.
+      summary.created.push({
+        index: derived.index,
+        definitionId: created.id,
+        fieldKey: row.fieldKey,
+        ownerScope: row.ownerScope,
+        organizationId: orgId,
+      });
+    } catch (err) {
+      const node = pgErrorNode(err);
+      const constraint = typeof node?.constraint_name === 'string'
+        ? node.constraint_name
+        : typeof node?.constraint === 'string'
+          ? node.constraint
+          : undefined;
+      console.error('[custom-field-definition-import] row failed', {
+        partnerId: ctx.partnerId,
+        index: derived.index,
+        actorUserId: actor.userId,
+        code: pgErrorCode(err),
+        ...(constraint ? { constraint } : {}),
+        error: err instanceof Error ? err.message : String(err),
+      });
+      summary.errors.push(
+        withCause({ index: derived.index, fieldKey: row.fieldKey, ...writeFailure(err, row.fieldKey) }, err),
+      );
+    }
+  }
+
+  return summary;
+}

--- a/apps/api/src/services/customFields/import/definitionImport.ts
+++ b/apps/api/src/services/customFields/import/definitionImport.ts
@@ -402,15 +402,24 @@ function writeFailure(err: unknown, fieldKey: string): ExpectationProblem {
   return { error: (code && WRITE_FAILURE_COPY[code]) ?? GENERIC_WRITE_FAILURE, code: 'write-failed' };
 }
 
-/** Annotations that can never be acknowledged into a write. */
-const REFUSED_ANNOTATIONS: Record<string, DefinitionImportErrorCode> = {
+/**
+ * Annotations that can never be acknowledged into a write.
+ *
+ * Keyed by `DefinitionAnnotation` rather than `string` so the deliberate
+ * 4-of-6 overlap between the annotation vocabulary and the error-code
+ * vocabulary is checked by the compiler. Typed as `Record<string, …>` these
+ * four entries would be held together by coincidentally matching string
+ * literals, and renaming an annotation would silently fall through to the
+ * generic copy instead of failing the build.
+ */
+const REFUSED_ANNOTATIONS: Partial<Record<DefinitionAnnotation, DefinitionImportErrorCode>> = {
   'partner-wide-denied': 'partner-wide-denied',
   'org-not-found': 'org-not-found',
   'type-conflict': 'type-conflict',
   'key-shadowed': 'key-shadowed',
 };
 
-const REFUSAL_COPY: Record<string, string> = {
+const REFUSAL_COPY: Partial<Record<DefinitionAnnotation, string>> = {
   'partner-wide-denied': PARTNER_WIDE_WRITE_DENIED_MESSAGE,
   'org-not-found': 'That organization was not found',
   'type-conflict': 'This custom field conflicts with one that already exists',
@@ -458,7 +467,9 @@ export async function commitCustomFieldDefinitionImport(
       continue;
     }
 
-    const orgId = row.ownerScope === 'organization' ? row.organizationId! : null;
+    // No non-null assertion: `CustomFieldDefinitionImportRow` is discriminated
+    // on `ownerScope`, so narrowing gives `organizationId` as a plain string.
+    const orgId = row.ownerScope === 'organization' ? row.organizationId : null;
     const partnerId = row.ownerScope === 'partner' ? ctx.partnerId : null;
 
     try {

--- a/apps/api/src/services/customFields/import/types.ts
+++ b/apps/api/src/services/customFields/import/types.ts
@@ -145,3 +145,165 @@ export interface DeviceCustomFieldImportRow {
   hostname?: string | null;
   values: DeviceCustomFieldImportValue[];
 }
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * W07 — definitions importer (#4775)
+ *
+ * The definitions pass has its own tenancy (dual-axis config: org XOR partner),
+ * its own authorization (partner-wide rows need `canManagePartnerWidePolicies`)
+ * and its own lifecycle, so it shares the module but none of the row shapes
+ * above.
+ * ────────────────────────────────────────────────────────────────────────── */
+
+/**
+ * Same cap as the org and contact importers
+ * (`services/contacts/types.ts:43`). One number across all four import routes
+ * so the browser can chunk once and target every one of them.
+ */
+export const MAX_IMPORT_ROWS = 1000;
+
+/**
+ * A SEPARATE, lower ceiling on `sum(row.values.length)` for the VALUES importer
+ * (W08). One device row carries up to 30 values, so 1000 rows x 30 values is
+ * 30,000 writes in one request — a cap on rows alone does not bound the work.
+ * Rejected at the zod layer with copy telling the browser to split the chunk.
+ *
+ * Declared here rather than in W08 because both caps are part of the same wire
+ * contract the browser chunks against, and this module is the one place both
+ * importers already share.
+ */
+export const MAX_IMPORT_VALUES = 5000;
+
+/** Mirrors the `custom_field_type` Postgres enum (`db/schema/customFields.ts`). */
+export type CustomFieldType = 'text' | 'number' | 'boolean' | 'dropdown' | 'date';
+
+/**
+ * The shared `CustomFieldOptions` contract
+ * (`packages/shared/src/types/filters.ts`), which `routes/customFields.ts`
+ * accepts on create. Restated structurally rather than imported so this module
+ * stays dependency-free (see the header).
+ *
+ * `choices` accepts the bare-string form too, because rows already stored that
+ * way exist and `routes/customFields.ts`'s `customFieldChoiceSchema` accepts
+ * both — an importer that accepted only the object form would reject a file
+ * exported from Breeze itself.
+ */
+export interface CustomFieldImportOptions {
+  choices?: Array<string | { label: string; value: string }>;
+  min?: number;
+  max?: number;
+  minLength?: number;
+  maxLength?: number;
+  pattern?: string;
+  placeholder?: string;
+}
+
+/** One submitted row of the DEFINITIONS importer. */
+export interface CustomFieldDefinitionImportRow {
+  fieldKey: string;
+  name: string;
+  type: CustomFieldType;
+  options?: CustomFieldImportOptions | null;
+  required?: boolean;
+  deviceTypes?: Array<'windows' | 'macos' | 'linux'> | null;
+  /** Which axis owns the definition. `organizationId` is required for `organization`. */
+  ownerScope: 'partner' | 'organization';
+  organizationId?: string;
+  /**
+   * The incumbent's own name for the field, e.g. `udf7`. Preserved in the audit
+   * trail so a post-migration "where did this field come from" is answerable,
+   * and deliberately NEVER stored on the definition row — there is no column
+   * for it and inventing one would make the importer's provenance a permanent
+   * part of the table's shape.
+   */
+  sourceLabel?: string;
+}
+
+/**
+ * What preview says about a row, and what commit re-derives before writing it.
+ *
+ * - `create` — no definition owns this key on this row's axis.
+ * - `already-exists` — same axis, same key, SAME type: a re-import of a file
+ *   that already landed. Skipped, never rewritten.
+ * - `type-conflict` — same axis, same key, DIFFERENT type; or the key appears
+ *   more than once in the submitted batch. `type` is immutable on update
+ *   (`updateCustomFieldSchema` omits it), so reconciling would mean
+ *   delete-and-recreate, which orphans every value stored under the key.
+ * - `key-shadowed` — the key exists on the OTHER axis under this partner. W03's
+ *   `custom_field_definitions_no_shadow` trigger refuses the write (P0001); the
+ *   importer says so at preview instead of letting it surface as a mystery.
+ * - `org-not-found` — `ownerScope: 'organization'` naming an organization
+ *   outside the caller's reach, or none at all. Deliberately the same
+ *   annotation for "does not exist" and "not yours" so the response is never an
+ *   existence oracle.
+ * - `partner-wide-denied` — `ownerScope: 'partner'` from a caller without
+ *   `canManagePartnerWidePolicies`. Its OWN annotation, never `org-not-found`:
+ *   telling a tech "that organization does not exist" when the truth is "you
+ *   may not create all-organizations fields" sends them to fix the wrong thing.
+ */
+export type DefinitionAnnotation =
+  | 'create'
+  | 'already-exists'
+  | 'type-conflict'
+  | 'key-shadowed'
+  | 'org-not-found'
+  | 'partner-wide-denied';
+
+export interface AnnotatedDefinitionRow extends CustomFieldDefinitionImportRow {
+  index: number;
+  annotation: DefinitionAnnotation;
+  /** The existing definition this row matched, for the preview UI. */
+  existingId: string | null;
+  existingType: CustomFieldType | null;
+  conflictReason?: string;
+}
+
+export interface CommitDefinitionRowInput extends CustomFieldDefinitionImportRow {
+  /** Commit re-derives and refuses any row whose annotation moved. */
+  expectedAnnotation?: DefinitionAnnotation;
+  /** Identity pin for `already-exists`. */
+  expectedDefinitionId?: string;
+}
+
+export type DefinitionImportErrorCode =
+  | 'org-not-found'
+  | 'type-conflict'
+  | 'key-shadowed'
+  | 'annotation-changed'
+  | 'match-changed'
+  | 'partner-wide-denied'
+  | 'write-failed';
+
+export interface DefinitionImportCreatedEntry {
+  index: number;
+  definitionId: string;
+  fieldKey: string;
+  ownerScope: 'partner' | 'organization';
+  organizationId: string | null;
+}
+
+export interface DefinitionImportSkippedEntry {
+  index: number;
+  definitionId: string;
+  fieldKey: string;
+  reason: 'already-exists';
+}
+
+export interface DefinitionImportErrorEntry {
+  index: number;
+  fieldKey: string;
+  error: string;
+  code: DefinitionImportErrorCode;
+  /**
+   * Attached NON-ENUMERABLY by the service so it never reaches a JSON body —
+   * routes hand this summary straight to `c.json(...)` and a pg error carries
+   * query text and column values. Read in-process; never serialize it.
+   */
+  cause?: unknown;
+}
+
+export interface DefinitionImportSummary {
+  created: DefinitionImportCreatedEntry[];
+  skipped: DefinitionImportSkippedEntry[];
+  errors: DefinitionImportErrorEntry[];
+}

--- a/apps/api/src/services/customFields/import/types.ts
+++ b/apps/api/src/services/customFields/import/types.ts
@@ -198,17 +198,29 @@ export interface CustomFieldImportOptions {
   placeholder?: string;
 }
 
+/**
+ * Which axis owns the definition, as a DISCRIMINATED UNION rather than a
+ * `ownerScope` field plus an optional `organizationId` and a comment.
+ *
+ * `custom_field_definitions_one_owner_chk` (W02) makes ownership org XOR
+ * partner at the database level, and the type says the same thing: an
+ * `organization` row cannot be constructed without its `organizationId`, so
+ * neither the commit path nor a future caller can reach the insert with a
+ * missing one. Same reasoning as W06's `DeviceResolution` above, and the JSON
+ * shape is unchanged — every arm is literals and strings.
+ */
+export type DefinitionOwner =
+  | { ownerScope: 'organization'; organizationId: string }
+  | { ownerScope: 'partner'; organizationId?: undefined };
+
 /** One submitted row of the DEFINITIONS importer. */
-export interface CustomFieldDefinitionImportRow {
+export type CustomFieldDefinitionImportRow = DefinitionOwner & {
   fieldKey: string;
   name: string;
   type: CustomFieldType;
   options?: CustomFieldImportOptions | null;
   required?: boolean;
   deviceTypes?: Array<'windows' | 'macos' | 'linux'> | null;
-  /** Which axis owns the definition. `organizationId` is required for `organization`. */
-  ownerScope: 'partner' | 'organization';
-  organizationId?: string;
   /**
    * The incumbent's own name for the field, e.g. `udf7`. Preserved in the audit
    * trail so a post-migration "where did this field come from" is answerable,
@@ -217,7 +229,7 @@ export interface CustomFieldDefinitionImportRow {
    * part of the table's shape.
    */
   sourceLabel?: string;
-}
+};
 
 /**
  * What preview says about a row, and what commit re-derives before writing it.
@@ -249,21 +261,36 @@ export type DefinitionAnnotation =
   | 'org-not-found'
   | 'partner-wide-denied';
 
-export interface AnnotatedDefinitionRow extends CustomFieldDefinitionImportRow {
+/**
+ * Deliberately NOT discriminated on `annotation`, unlike `DeviceResolution`.
+ * `existingId`/`existingType` do not correlate 1:1 with the annotation:
+ * `type-conflict` arises both with an existing definition (same axis, different
+ * type) and without one (the key appears twice in the submitted file). Modelling
+ * that faithfully would mean inventing wire-visible annotation variants purely
+ * to carry an internal batch-vs-database distinction, widening the vocabulary
+ * every client's `expectedAnnotation` has to track. Every consumer gates on
+ * `annotation` before reading these fields.
+ */
+export type AnnotatedDefinitionRow = CustomFieldDefinitionImportRow & {
   index: number;
   annotation: DefinitionAnnotation;
   /** The existing definition this row matched, for the preview UI. */
   existingId: string | null;
   existingType: CustomFieldType | null;
   conflictReason?: string;
-}
+};
 
-export interface CommitDefinitionRowInput extends CustomFieldDefinitionImportRow {
+export type CommitDefinitionRowInput = CustomFieldDefinitionImportRow & {
   /** Commit re-derives and refuses any row whose annotation moved. */
   expectedAnnotation?: DefinitionAnnotation;
-  /** Identity pin for `already-exists`. */
+  /**
+   * Identity pin, required for `already-exists`. Not folded into the union with
+   * `expectedAnnotation`: a row may legitimately carry NO acknowledgement at all
+   * (a caller that never previewed), so a clean two-arm split does not exist.
+   * Enforced at the wire by the route schema and again by `checkExpectation`.
+   */
   expectedDefinitionId?: string;
-}
+};
 
 export type DefinitionImportErrorCode =
   | 'org-not-found'

--- a/apps/api/src/services/customFields/writeErrors.ts
+++ b/apps/api/src/services/customFields/writeErrors.ts
@@ -19,8 +19,11 @@
  *
  * Extracted from `routes/customFields.ts` when the definitions importer (W07)
  * needed the identical mapping per row. Two copies would drift, and the codes
- * (`field-key-shadowed`, `field-key-duplicate`) are part of the wire contract
- * the web client branches on.
+ * (`field-key-shadowed`, `field-key-duplicate`) are the stable, machine-readable
+ * half of the 409 body — reserved for the web client, which does not branch on
+ * them yet (the import wizard is W09). Treat them as a published contract
+ * regardless: they are already asserted by
+ * `routes/customFields_create_update_delete.test.ts`.
  */
 
 import { pgErrorCode, pgErrorNode } from '../../utils/pgErrors';

--- a/apps/api/src/services/customFields/writeErrors.ts
+++ b/apps/api/src/services/customFields/writeErrors.ts
@@ -1,0 +1,57 @@
+/**
+ * The ONE mapping from a `custom_field_definitions` write failure to
+ * operator-facing copy (#3257 W03/W07).
+ *
+ * Two database rules can refuse a definition write, and neither is a server
+ * fault, so neither may surface as a 500 — a 500 tells the operator nothing and
+ * hides a one-word fix (rename the key):
+ *
+ *  - **P0001** — W03's `custom_field_definitions_no_shadow` BEFORE-write
+ *    trigger (`2026-10-11-141000-custom-field-no-cross-axis-shadowing.sql`).
+ *    Its message is written to be read by a human: it names the key and which
+ *    axis already owns it, and deliberately discloses nothing else about the
+ *    conflicting definition, so it is safe to pass through verbatim.
+ *  - **23505** — W02's per-axis unique indexes
+ *    (`custom_field_definitions_{org,partner}_key_uq`). The driver message is
+ *    NOT safe to pass through: postgres.js puts the offending column VALUES in
+ *    `detail` and the constraint name in the text. Fixed copy is built from the
+ *    caller's own `fieldKey` instead.
+ *
+ * Extracted from `routes/customFields.ts` when the definitions importer (W07)
+ * needed the identical mapping per row. Two copies would drift, and the codes
+ * (`field-key-shadowed`, `field-key-duplicate`) are part of the wire contract
+ * the web client branches on.
+ */
+
+import { pgErrorCode, pgErrorNode } from '../../utils/pgErrors';
+
+export type CustomFieldWriteConflictCode = 'field-key-shadowed' | 'field-key-duplicate';
+
+export interface CustomFieldWriteConflict {
+  /** Safe to place in a response body — see the module header. */
+  error: string;
+  code: CustomFieldWriteConflictCode;
+}
+
+/**
+ * Map a thrown definition-write error to its conflict body, or `null` when the
+ * error is not one of the two known conflicts (callers rethrow those).
+ *
+ * @param fieldKey the key the caller asked for, used to build the 23505 copy.
+ */
+export function customFieldWriteConflict(err: unknown, fieldKey: string): CustomFieldWriteConflict | null {
+  const code = pgErrorCode(err);
+  if (code === 'P0001') {
+    return {
+      error: String(pgErrorNode(err)?.message ?? 'Custom field key conflicts with an existing field'),
+      code: 'field-key-shadowed',
+    };
+  }
+  if (code === '23505') {
+    return {
+      error: `A custom field with key "${fieldKey}" already exists for this owner`,
+      code: 'field-key-duplicate',
+    };
+  }
+  return null;
+}


### PR DESCRIPTION
Closes #4775

Wave 07 of #4768 (#3257): the **definitions** half of the RMM custom-field importer. No migration in this wave. No `apps/web`, no values importer (W08).

Depends on and builds directly on what W02 (#4991), W03 (#5028) and W06 (#4973) landed — all three verified merged on `origin/main` at `901bc6c56` before this branch was cut.

## Routes

| Method | Path | Behaviour |
|---|---|---|
| POST | `/custom-fields/import/preview` | Annotates every row against current state. Writes nothing. |
| POST | `/custom-fields/import` | Creates the acknowledged definitions. Always **200**, even with a non-empty `errors[]`. |

Both mount `requireScope('organization','partner','system')` + `requirePermission(devices:write)` (the same grant the sibling `POST /custom-fields` create route uses) + `requireMfa()`, and plain `authMiddleware` — **no `dualAuth`**, so an `X-API-Key`-only caller is a 401.

## Codes

**Preview annotations** (`DefinitionAnnotation`)

| Annotation | Meaning |
|---|---|
| `create` | No definition owns this key on the row's axis. |
| `already-exists` | Same axis, same key, **same type** — a re-import. Skipped at commit, never rewritten. |
| `type-conflict` | Same axis, same key, different type (type is immutable on update); **or** the key appears more than once in the submitted batch. |
| `key-shadowed` | The key is taken on the **other** ownership axis under this partner — W03's `custom_field_definitions_no_shadow` trigger would refuse the write. |
| `org-not-found` | `ownerScope: 'organization'` with no organizationId, or one outside the caller's reach. Same annotation for "absent" and "not yours", so the response is never an existence oracle. |
| `partner-wide-denied` | `ownerScope: 'partner'` from a caller without `canManagePartnerWidePolicies`. **Its own code** — see the deviation note below. |

**Commit error codes** (`DefinitionImportErrorCode`): `org-not-found`, `type-conflict`, `key-shadowed`, `annotation-changed`, `match-changed`, `partner-wide-denied`, `write-failed`.

## What is actually guaranteed

- **TOCTOU.** Commit re-derives *every* annotation against state loaded at commit time (never preview's) and refuses a row whose annotation moved (`annotation-changed`). An `already-exists` acknowledgement must pin `expectedDefinitionId` (enforced at the zod layer) and is refused `match-changed` if the key changed hands. An acknowledged `create` that finds a row now existing is an error, never a silent no-op.
- **Per-row isolation without losing RLS.** Each row's insert runs in a **nested `db.transaction`** — a SAVEPOINT inside the request's own `withDbAccessContext` transaction (`dbSavepointErrorIsolation.integration.test.ts` is the proof) — issued on the nested `tx`, never the ambient `db` proxy. One refused row rolls back to its own savepoint; the rest of the batch proceeds; and RLS remains a real second control on every write.
- **No driver text in a response body.** SQLSTATEs map to fixed copy; the original error rides along **non-enumerably** on `errors[].cause` so error tracking keeps the stack and `JSON.stringify` cannot leak query text or column values.
- **One `writeRouteAudit` per definition created**, carrying `externalSystem`, `sourceLabel` (e.g. `udf7`), `ownerScope`, `fieldKey` and the row count. `sourceLabel` is deliberately never stored on the definition row — the audit event is its only durable home.

## Deviations from the plan (code is truth)

1. **`routes/index.ts` does not exist** — routes are mounted in `apps/api/src/index.ts`. Mounted there, *before* `customFieldRoutes`, so `/custom-fields/import*` can never fall through to the CRUD app's `/:id` handlers.
2. **Writes stay in the request context, not a system context.** The plan had commit open each row's transaction via `runOutsideDbContext`. That would bypass RLS on the write path. A nested transaction gives the same per-row failure isolation *and* keeps RLS, so that is what shipped. The snapshot **read** does still escalate (once, for both queries) because `custom_field_definitions` has no partner-wide RLS SELECT branch — it is in `PARTNER_WIDE_SELECT_BRANCH_EXEMPT` (TODO #4944) — so an org-scoped request context cannot see partner-wide rows at all and would annotate every shadowed key as `create`. Bounded by `partnerId` AND `accessibleOrgIds`, exactly as `contacts/import.ts` does.
3. **The plan's fifth Task-2 test was deliberately wrong and is fixed**: a capability refusal is `partner-wide-denied`, not `org-not-found`. Reusing `org-not-found` would tell a tech "that organization does not exist" when the truth is "you may not create all-organizations fields".
4. **The partner-wide capability refusal is a whole-request 403 at the route**, matching the sibling `POST /custom-fields` create route (epic #2135) and the brief's integration requirement, *in addition to* the per-row service annotation. Authorization answers belong in the same band as the scope/permission gates, not mixed into a 200 that also reports data problems; the service annotation stays because the service is reachable directly and must fail closed there too.
5. **The commit route returns 200 with `errors[].code = 'key-shadowed'`, not 409**, when a shadow is submitted. The brief's integration item (b) asked for 409, but the plan's global constraint — *always 200, because the web caller reads this through `runAction`, which treats a failure body as a hard failure and would hide the rows that DID import* — wins on a batch endpoint. The 409 path is preserved and still asserted where it belongs: the single-create `POST /custom-fields` route is unchanged and still returns 409 `field-key-shadowed` / `field-key-duplicate`.
6. **The 23505/P0001 mapper was extracted, not forked** — into `services/customFields/writeErrors.ts`, now used by both `routes/customFields.ts` and the importer. This touches two files outside the brief's "files you own" list (`routes/customFields.ts`, and the new `writeErrors.ts`); both are outside W05's ownership, and the brief explicitly authorised "reuse or extract that mapper, do not fork it".
7. **Batch-aware annotation.** Beyond the plan's same-axis duplicate check, a *cross-axis* duplicate within one submitted batch is annotated `key-shadowed` too. Without it the second row would have arrived at the trigger as an unexplained P0001. The pass is deterministic and ordered, so preview and commit derive identically — which is what makes `expectedAnnotation` meaningful.
8. **`MAX_IMPORT_VALUES`** is declared here (per plan Task 1) although only W08 consumes it.

`MAX_IMPORT_ROWS = 1000` — the same cap as the org and contact importers (`services/contacts/types.ts:43`).

## Verification

- `npx vitest run src/services/customFields src/routes/customFieldImport src/routes/customFields src/openapi src/__tests__/partner-wide-write-coverage.test.ts` — **16 files, 249 tests, all pass.** (22 service tests were written red-first against a missing module; the route suite's partner-wide gate was mutation-checked — disabling the gate turns 2 tests red.)
- `npx vitest run --config vitest.integration.config.ts src/__tests__/integration/customFieldDefinitionImport` — **9/9 pass** against a real Postgres (`pnpm test-stack up` + `pnpm db:migrate`). Covers all four required scenarios plus savepoint isolation and the no-leak assertion. The trigger test confirms the live constraint name is `custom_field_definitions_no_shadow` and that the SQLSTATE is only reachable through `.cause` (a check on `err.code` would have passed vacuously).
- `NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit` — clean.
- `pnpm lint` — clean (6/6 tasks).

## Not verified

- **The full `apps/api` unit suite and the full integration suite** were not run — only the affected files listed above, plus `partner-wide-write-coverage`, `autoMigrate`, `migrationRlsScope` and `validation.imports` as contract guards. CI covers the rest.
- **`rls-coverage.integration.test.ts` / `tenantCascade` / `tenant-export-policy`** were not run: this wave adds no table, no column and no migration, so none of the six registration lists changes. Asserted by inspection, not by execution.
- **No web client exists yet** (W09), so the wire contract has not been exercised by a real browser caller, and `runAction`'s handling of these bodies is reasoned about rather than observed.
- **`X-API-Key` returns 401** is asserted against a mock of `authMiddleware` that reproduces production's Bearer-only contract, not against the real middleware; the real one has no API-key branch at all (verified by inspection: no `X-API-Key` reference in `middleware/auth.ts`).
- **Concurrency beyond the modelled race**: the TOCTOU test creates the racing row between two sequential requests. Two genuinely simultaneous commits are handled by W02's unique index and W03's trigger (mapped to typed row errors), but that was not exercised under real parallelism.
- **Performance at the 1000-row cap** was not measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7RWzDtuzApHEcg5Ri9wFt
