### PR TITLE
fix(agent): bound collector command capture, clear shipped log batches, count PIDs cheaply

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1432,6 +1432,19 @@ jobs:
           $passes = @($out | Select-String -Pattern '^--- PASS: Test').Count
           if ($passes -ne 3) { throw "expected exactly 3 top-level PASS lines, got $passes - a test in the -run filter was renamed, removed, or added without updating this count" }
 
+      # internal/collectors as a whole is not on the list above (it has never
+      # been vetted for Windows reds), but its command runners set WaitDelay so
+      # a descendant that inherits PowerShell's stdout handle cannot hang a
+      # collector forever — and handle inheritance is the one behaviour with no
+      # cross-platform equivalent. Run just the self-exec subprocess tests that
+      # cover capture bounds, cancellation, and inherited pipes on the OS they
+      # were written for.
+      - name: Run Windows collector command-runner tests
+        working-directory: agent
+        env:
+          CGO_ENABLED: "0"
+        run: go test ./internal/collectors -run '^TestCollectorCommand|^TestCappedBuffer' -v
+
       # internal/backup is the third instance of the same gap: its
       # upload_error_class_codes_windows_test.go pins the Win32 permanent-error
       # codes (#2997) against golang.org/x/sys/windows, and those codes drive

--- a/agent/internal/collectors/command_limits.go
+++ b/agent/internal/collectors/command_limits.go
@@ -4,8 +4,10 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os/exec"
 	"strings"
 	"time"
@@ -41,14 +43,50 @@ func runCollectorOutputWithContext(parent context.Context, timeout time.Duration
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, name, args...)
-	output, err := cmd.Output()
+	output := &cappedBuffer{max: collectorCommandOutputLimit}
+	stderr := &cappedBuffer{max: collectorStderrCaptureLimit}
+	cmd.Stdout = output
+	cmd.Stderr = stderr
+	cmd.WaitDelay = collectorWaitDelay
+	err := runCollectorCommand(cmd, name)
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		// Mirror exec.Cmd.Output so callers inspecting ExitError see stderr.
+		exitErr.Stderr = stderr.buf.Bytes()
+	}
 	if ctx.Err() != nil {
 		return nil, fmt.Errorf("%s timed out: %w", name, ctx.Err())
 	}
-	if len(output) > collectorCommandOutputLimit {
+	if output.exceeded {
 		return nil, fmt.Errorf("%s output too large", name)
 	}
-	return output, err
+	return output.buf.Bytes(), err
+}
+
+// collectorWaitDelay bounds how long Wait blocks on stdout/stderr pipes after
+// the command itself has exited (a descendant may have inherited them).
+const collectorWaitDelay = 10 * time.Second
+
+// collectorStderrCaptureLimit caps the diagnostic stderr retained for
+// ExitError.Stderr; stdout carries the payload, stderr only needs to be
+// enough to explain a failure.
+const collectorStderrCaptureLimit = 64 * 1024
+
+// runCollectorCommand runs cmd and normalises exec.ErrWaitDelay. os/exec only
+// returns that sentinel when the process exited successfully but a descendant
+// still held an inherited pipe past WaitDelay. By then the copy goroutines have
+// finished, so the captured output is complete and the command did not fail.
+// Callers treat any error as command failure, so surfacing the sentinel would
+// silently turn a benign orphaned handle into a permanent data gap (see
+// change_tracker.go, which clones the previous snapshot on error).
+func runCollectorCommand(cmd *exec.Cmd, name string) error {
+	err := cmd.Run()
+	if errors.Is(err, exec.ErrWaitDelay) && cmd.ProcessState != nil && cmd.ProcessState.Success() {
+		slog.Warn("collector command exited but a descendant kept its output pipe open; output captured, pipe force-closed",
+			"command", name, "waitDelay", collectorWaitDelay)
+		return nil
+	}
+	return err
 }
 
 func runCollectorCombinedOutput(timeout time.Duration, name string, args ...string) ([]byte, error) {
@@ -63,14 +101,19 @@ func runCollectorCombinedOutputWithContext(parent context.Context, timeout time.
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, name, args...)
-	output, err := cmd.CombinedOutput()
+	output := &cappedBuffer{max: collectorCommandOutputLimit}
+	// os/exec serializes writes when Stdout and Stderr are the same writer.
+	cmd.Stdout = output
+	cmd.Stderr = output
+	cmd.WaitDelay = collectorWaitDelay
+	err := runCollectorCommand(cmd, name)
 	if ctx.Err() != nil {
 		return nil, fmt.Errorf("%s timed out: %w", name, ctx.Err())
 	}
-	if len(output) > collectorCommandOutputLimit {
+	if output.exceeded {
 		return nil, fmt.Errorf("%s output too large", name)
 	}
-	return output, err
+	return output.buf.Bytes(), err
 }
 
 // runCollectorLimitedOutput runs a command and reads up to collectorCommandOutputLimit
@@ -98,14 +141,20 @@ func runCollectorLimitedOutput(timeout time.Duration, name string, args ...strin
 	return output, nil
 }
 
-// cappedBuffer captures up to max bytes and silently discards the rest,
-// always reporting a full write so the child process never sees a write error.
+// cappedBuffer captures up to max bytes and discards the rest without ever
+// failing the Write call, so the child process never sees a write error.
+// exceeded records that the limit was hit so callers can still reject
+// oversized output instead of consuming a silently truncated payload.
 type cappedBuffer struct {
-	buf bytes.Buffer
-	max int
+	buf      bytes.Buffer
+	max      int
+	exceeded bool
 }
 
 func (c *cappedBuffer) Write(p []byte) (int, error) {
+	if len(p) > c.max-c.buf.Len() {
+		c.exceeded = true
+	}
 	if remaining := c.max - c.buf.Len(); remaining > 0 {
 		if len(p) > remaining {
 			c.buf.Write(p[:remaining])
@@ -119,8 +168,8 @@ func (c *cappedBuffer) Write(p []byte) (int, error) {
 // runCollectorBoundedOutput runs a command, streaming stdout through an
 // io.LimitReader so at most collectorCommandOutputLimit+1 bytes are ever
 // buffered. Unlike runCollectorLimitedOutput it does not silently truncate:
-// output exceeding the limit is an error (matching runCollectorOutput's
-// semantics but enforced BEFORE buffering, not post-hoc), and a non-zero exit
+// output exceeding the limit is an error (runCollectorOutput now bounds memory
+// during capture too, but still runs the command to completion), and a non-zero exit
 // or read failure is surfaced — with the command's (capped) stderr included so
 // failures are diagnosable from agent logs. Use for structured output (e.g.
 // JSON) where a truncated payload would be garbage anyway.

--- a/agent/internal/collectors/command_limits_test.go
+++ b/agent/internal/collectors/command_limits_test.go
@@ -332,7 +332,11 @@ func TestCollectorCommandInheritedPipeCleanup(t *testing.T) {
 					t.Error(err)
 					return
 				}
-				defer process.Release()
+				defer func() {
+					if err := process.Release(); err != nil {
+						t.Logf("process.Release: %v", err)
+					}
+				}()
 				if err := process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
 					t.Error(err)
 				}

--- a/agent/internal/collectors/command_limits_test.go
+++ b/agent/internal/collectors/command_limits_test.go
@@ -1,8 +1,15 @@
 package collectors
 
 import (
+	"bytes"
+	"context"
+	"errors"
 	"fmt"
+	"io"
+	"os"
+	"os/exec"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -36,8 +43,7 @@ func TestRunCollectorBoundedOutputEnforcesLimitPreBuffering(t *testing.T) {
 
 	// Emit well past the cap. The bounded runner reads through an
 	// io.LimitReader, so it must reject the output while never buffering more
-	// than collectorCommandOutputLimit+1 bytes — unlike the post-hoc check in
-	// runCollectorOutput, which buffers the entire stream first (issue #2390).
+	// than collectorCommandOutputLimit+1 bytes (issue #2390).
 	emit := collectorCommandOutputLimit * 4
 	_, err := runCollectorBoundedOutput(30*time.Second, "/bin/sh", "-c",
 		fmt.Sprintf("head -c %d /dev/zero", emit))
@@ -111,6 +117,9 @@ func TestCappedBufferStopsAtMax(t *testing.T) {
 			t.Fatalf("Write = (%d, %v), want (4, nil)", n, err)
 		}
 	}
+	if !c.exceeded {
+		t.Fatal("over-limit writes were not recorded")
+	}
 	if got := c.buf.String(); got != "abcdabcd" {
 		t.Fatalf("captured %q, want %q", got, "abcdabcd")
 	}
@@ -123,5 +132,228 @@ func TestRunCollectorBoundedOutputTimesOut(t *testing.T) {
 	_, err := runCollectorBoundedOutput(200*time.Millisecond, "/bin/sh", "-c", "sleep 5")
 	if err == nil || !strings.Contains(err.Error(), "timed out") {
 		t.Fatalf("expected timeout error, got: %v", err)
+	}
+}
+
+// TestCollectorCommandHelper is a portable subprocess, including on Windows.
+func TestCollectorCommandHelper(t *testing.T) {
+	args := os.Args
+	for len(args) > 0 && args[0] != "collector-command-helper" {
+		args = args[1:]
+	}
+	if len(args) == 0 {
+		return
+	}
+	args = args[1:]
+	if args[0] == "inherit" {
+		cmd := exec.Command(os.Args[0], collectorHelperArgs("wait", args[1]+".ready")...)
+		cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+		if err := cmd.Start(); err != nil {
+			os.Exit(2)
+		}
+		if err := os.WriteFile(args[1], []byte(strconv.Itoa(cmd.Process.Pid)), 0600); err != nil {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+			os.Exit(2)
+		}
+		// Output written before a clean exit must survive the pipe cleanup.
+		_, _ = os.Stdout.WriteString("inherit-ok")
+		os.Exit(0)
+	}
+	if args[0] == "wait" {
+		// Signal readiness before blocking so cancellation tests kill a running child.
+		if err := os.WriteFile(args[1], []byte("ready"), 0600); err != nil {
+			os.Exit(2)
+		}
+		time.Sleep(time.Minute)
+		os.Exit(0)
+	}
+	for i, stream := range []io.Writer{os.Stdout, os.Stderr} {
+		n, err := strconv.Atoi(args[i])
+		if err != nil {
+			os.Exit(2)
+		}
+		chunk := bytes.Repeat([]byte{byte('a' + i)}, 32768)
+		for n > 0 {
+			count := min(n, len(chunk))
+			if _, err := stream.Write(chunk[:count]); err != nil {
+				os.Exit(2)
+			}
+			n -= count
+		}
+	}
+	code, _ := strconv.Atoi(args[2])
+	os.Exit(code)
+}
+
+func collectorHelperArgs(args ...string) []string {
+	return append([]string{"-test.run=^TestCollectorCommandHelper$", "--", "collector-command-helper"}, args...)
+}
+
+func TestCollectorCommandCapture(t *testing.T) {
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, combined := range []bool{false, true} {
+		for _, tc := range []struct {
+			name                 string
+			stdout, stderr, exit int
+			tooLarge             bool
+		}{
+			{"empty", 0, 0, 0, false},
+			{"small", 20, 30, 0, false},
+			{"exact", collectorCommandOutputLimit, 0, 0, false},
+			{"over", collectorCommandOutputLimit + 1, 0, 0, true},
+			{"drain", collectorCommandOutputLimit * 3, collectorCommandOutputLimit * 3, 0, true},
+			{"both_exact", collectorCommandOutputLimit / 2, collectorCommandOutputLimit / 2, 0, false},
+			{"both_over", collectorCommandOutputLimit / 2, collectorCommandOutputLimit/2 + 1, 0, combined},
+			{"failure", 20, 30, 3, false},
+			{"large_stderr", 20, collectorCommandOutputLimit * 2, 3, combined},
+		} {
+			t.Run(fmt.Sprintf("combined=%v/%s", combined, tc.name), func(t *testing.T) {
+				run := runCollectorOutputWithContext
+				if combined {
+					run = runCollectorCombinedOutputWithContext
+				}
+				out, err := run(context.Background(), 15*time.Second, exe, collectorHelperArgs(strconv.Itoa(tc.stdout), strconv.Itoa(tc.stderr), strconv.Itoa(tc.exit))...)
+				if tc.tooLarge {
+					if err == nil || !strings.Contains(err.Error(), "output too large") || out != nil {
+						t.Fatalf("len(out)=%d, err=%v; want rejected oversized output", len(out), err)
+					}
+					return
+				}
+				want := bytes.Repeat([]byte("a"), tc.stdout)
+				if combined {
+					want = append(want, bytes.Repeat([]byte("b"), tc.stderr)...)
+				}
+				if (!combined && !bytes.Equal(out, want)) || (combined && (len(out) != len(want) || bytes.Count(out, []byte("a")) != tc.stdout || bytes.Count(out, []byte("b")) != tc.stderr)) {
+					t.Fatalf("unexpected captured output: len=%d want=%d", len(out), len(want))
+				}
+				if tc.exit == 0 {
+					if err != nil {
+						t.Fatal(err)
+					}
+					return
+				}
+				var exitErr *exec.ExitError
+				if !errors.As(err, &exitErr) || exitErr.ExitCode() != tc.exit {
+					t.Fatalf("expected exit %d, got %v", tc.exit, err)
+				}
+				if combined {
+					if len(exitErr.Stderr) != 0 {
+						t.Fatal("combined error has separate stderr")
+					}
+				} else if want := min(tc.stderr, collectorStderrCaptureLimit); !bytes.Equal(exitErr.Stderr, bytes.Repeat([]byte("b"), want)) {
+					t.Fatalf("stderr diagnostics wrong: len=%d want=%d", len(exitErr.Stderr), want)
+				}
+			})
+		}
+	}
+}
+
+func TestCollectorCommandCancellation(t *testing.T) {
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, combined := range []bool{false, true} {
+		t.Run(fmt.Sprintf("combined=%v", combined), func(t *testing.T) {
+			run := runCollectorOutputWithContext
+			if combined {
+				run = runCollectorCombinedOutputWithContext
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			ready := t.TempDir() + "/ready"
+			done := make(chan error, 1)
+			go func() {
+				_, err := run(ctx, 15*time.Second, exe, collectorHelperArgs("wait", ready)...)
+				done <- err
+			}()
+			deadline := time.Now().Add(10 * time.Second)
+			for {
+				if _, err := os.Stat(ready); err == nil {
+					break
+				}
+				if time.Now().After(deadline) {
+					t.Fatal("helper did not start")
+				}
+				time.Sleep(10 * time.Millisecond)
+			}
+			cancel()
+			select {
+			case err := <-done:
+				if !errors.Is(err, context.Canceled) {
+					t.Fatalf("expected canceled context, got %v", err)
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("canceled child was not reaped promptly")
+			}
+			_, err := run(context.Background(), 100*time.Millisecond, exe, collectorHelperArgs("wait", ready)...)
+			if !errors.Is(err, context.DeadlineExceeded) {
+				t.Fatalf("expected timeout, got %v", err)
+			}
+		})
+	}
+}
+
+func TestCappedBufferExactLimit(t *testing.T) {
+	c := &cappedBuffer{max: 8}
+	_, _ = c.Write([]byte("12345678"))
+	_, _ = c.Write(nil)
+	if c.exceeded {
+		t.Fatal("exact-limit output rejected")
+	}
+}
+
+func TestCollectorCommandInheritedPipeCleanup(t *testing.T) {
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, combined := range []bool{false, true} {
+		t.Run(fmt.Sprintf("combined=%v", combined), func(t *testing.T) {
+			t.Parallel()
+			pidPath := t.TempDir() + "/descendant.pid"
+			t.Cleanup(func() {
+				data, err := os.ReadFile(pidPath)
+				if err != nil {
+					t.Error(err)
+					return
+				}
+				pid, err := strconv.Atoi(string(data))
+				if err != nil {
+					t.Error(err)
+					return
+				}
+				process, err := os.FindProcess(pid)
+				if err != nil {
+					t.Error(err)
+					return
+				}
+				defer process.Release()
+				if err := process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+					t.Error(err)
+				}
+			})
+			run := runCollectorOutputWithContext
+			if combined {
+				run = runCollectorCombinedOutputWithContext
+			}
+			start := time.Now()
+			out, err := run(context.Background(), 25*time.Second, exe, collectorHelperArgs("inherit", pidPath)...)
+			// The command exited 0 and its output was fully captured; a descendant
+			// holding the pipe is a cleanup concern, not a command failure.
+			if err != nil {
+				t.Fatalf("expected success after inherited pipe cleanup, got %v", err)
+			}
+			if string(out) != "inherit-ok" {
+				t.Fatalf("captured output lost: %q", out)
+			}
+			if time.Since(start) < 5*time.Second {
+				t.Fatal("WaitDelay cleanup did not engage; descendant pipe was not inherited")
+			}
+		})
 	}
 }

--- a/agent/internal/collectors/eventlogs_darwin.go
+++ b/agent/internal/collectors/eventlogs_darwin.go
@@ -85,7 +85,8 @@ func (c *EventLogCollector) collectUnifiedLogEvents(since time.Time, securityEna
 
 	// runCollectorBoundedOutput streams stdout through an io.LimitReader so the
 	// 4 MiB cap is enforced before the bytes are buffered (the old
-	// runCollectorOutput buffered everything first and checked post-hoc).
+	// runCollectorOutput previously buffered everything first and checked post-hoc;
+	// it is now memory-bounded too but still runs the command to completion).
 	output, err := runCollectorBoundedOutput(collectorLongCommandTimeout, "log", "show",
 		"--predicate", predicate,
 		"--style", "json",

--- a/agent/internal/collectors/metrics.go
+++ b/agent/internal/collectors/metrics.go
@@ -233,10 +233,10 @@ func (c *MetricsCollector) Collect() (*SystemMetrics, error) {
 
 	c.lastTime = now
 
-	// Process count
-	procs, err := process.Processes()
+	// Count the PID snapshot without allocating process objects or querying each process.
+	pids, err := process.Pids()
 	if err == nil {
-		metrics.ProcessCount = len(procs)
+		metrics.ProcessCount = len(pids)
 	}
 
 	return metrics, nil

--- a/agent/internal/logging/shipper.go
+++ b/agent/internal/logging/shipper.go
@@ -281,6 +281,7 @@ func (s *Shipper) shipLoop() {
 					batch = append(batch, entry)
 					if len(batch) >= defaultMaxBatchSize {
 						s.shipBatch(batch)
+						clear(batch)
 						batch = batch[:0]
 					}
 				default:
@@ -296,12 +297,16 @@ func (s *Shipper) shipLoop() {
 			batch = append(batch, entry)
 			if len(batch) >= defaultMaxBatchSize {
 				s.shipBatch(batch)
+				// Release strings and field maps before reusing the backing array.
+				// shipBatch has finished; any re-buffered entries are value copies.
+				clear(batch)
 				batch = batch[:0]
 			}
 
 		case <-ticker.C:
 			if len(batch) > 0 {
 				s.shipBatch(batch)
+				clear(batch)
 				batch = batch[:0]
 			}
 		}

--- a/agent/internal/logging/shipper_test.go
+++ b/agent/internal/logging/shipper_test.go
@@ -679,3 +679,84 @@ func TestShipBatchURLFormat(t *testing.T) {
 		t.Fatalf("unexpected URL path: %s", receivedPath)
 	}
 }
+
+// TestShipLoopFullBatchClearPreservesEntries drives shipLoop through the
+// in-loop full-batch flush (defaultMaxBatchSize entries) so the clear(batch)
+// reset runs, and asserts every shipped entry still carries its own message
+// and Fields map. Guards against clearing slots before shipBatch has consumed
+// them: LogEntry.Fields is a reference type, so a misplaced clear would ship
+// zeroed entries with no error anywhere.
+func TestShipLoopFullBatchClearPreservesEntries(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		received []LogEntry
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		logs := decodeShippedLogs(t, body)
+		mu.Lock()
+		received = append(received, logs...)
+		mu.Unlock()
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer server.Close()
+
+	s := NewShipper(ShipperConfig{
+		ServerURL:    func() string { return server.URL },
+		AgentID:      "test-agent",
+		AuthToken:    testToken("tok"),
+		AgentVersion: "1.0.0",
+		MinLevel:     "debug",
+		HTTPClient:   server.Client(),
+	})
+
+	s.Start()
+	defer s.Stop()
+	for i := 0; i < defaultMaxBatchSize; i++ {
+		s.Enqueue(LogEntry{
+			Timestamp: time.Now(),
+			Level:     "INFO",
+			Component: "test",
+			Message:   fmt.Sprintf("entry-%d", i),
+			Fields:    map[string]any{"seq": float64(i)},
+		})
+	}
+	if s.droppedCount.Load() != 0 {
+		t.Fatalf("buffer overflowed: dropped %d", s.droppedCount.Load())
+	}
+	// Wait for the size-threshold flush while the loop is still running, so the
+	// batch goes through the main-loop reset rather than the shutdown drain.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		mu.Lock()
+		n := len(received)
+		mu.Unlock()
+		if n >= defaultMaxBatchSize {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("full batch never shipped: %d/%d received", n, defaultMaxBatchSize)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(received) != defaultMaxBatchSize {
+		t.Fatalf("expected %d shipped entries, got %d", defaultMaxBatchSize, len(received))
+	}
+	seen := make(map[int]bool, len(received))
+	for _, e := range received {
+		seq, ok := e.Fields["seq"].(float64)
+		if !ok {
+			t.Fatalf("entry lost its Fields map: %+v", e)
+		}
+		if e.Message != fmt.Sprintf("entry-%d", int(seq)) || e.Component != "test" {
+			t.Fatalf("entry %d shipped with wrong content: %+v", int(seq), e)
+		}
+		if seen[int(seq)] {
+			t.Fatalf("entry %d shipped twice", int(seq))
+		}
+		seen[int(seq)] = true
+	}
+}

--- a/docs/research/2026-09-05-windows-agent-memory-review.md
+++ b/docs/research/2026-09-05-windows-agent-memory-review.md
@@ -1,0 +1,76 @@
+# Windows agent memory review
+
+Reviewed commit `e88f121351`, September 5, 2026. Static source review of the main agent, Windows collectors, logging, command transport, helpers, and remote desktop. No affected Windows endpoint or heap profile was available. The initial review made no runtime changes; the subsequently requested implementation is recorded below.
+
+The reported 200–300 MB deserves a baseline investigation, but this review does not establish a leak or attribute that footprint to a specific subsystem. Prioritize bounded resource use and small lifecycle cleanups. Avoid a broad optimization project or a memory target based solely on a competitor comparison.
+
+## Recommended opportunities
+
+### 1. Release references to shipped log entries — low risk, unmeasured savings
+
+`agent/internal/logging/shipper.go:271–305` allocates a reusable 500-entry batch. Each flush calls `shipBatch(batch)` and then `batch = batch[:0]`. Resetting length preserves the backing array and its references to message strings and field maps. Following a large batch, subsequent small batches leave older entries in the unused tail until overwritten.
+
+Proposed change: `clear(batch)` after the synchronous `shipBatch` returns, before reslicing, at each reset site. Re-buffered entries are struct copies, so clearing the batch slots should not erase their map contents. Preserve that ownership distinction: clear slots, not the maps themselves.
+
+This is bounded retention, not an ever-growing leak. Typical savings may be small; no credible MB estimate is available without inspecting actual entries. Validate normal shipping, auth-dead re-buffering, retry/failure handling, and shutdown under `-race`. This is the first cleanup I would consider.
+
+### 2. Enforce collector output limits while capturing — narrow hardening
+
+`agent/internal/collectors/command_limits.go:38–76` uses `cmd.Output()` / `cmd.CombinedOutput()` and checks the 4 MiB limit only after the command completes. Oversized output can consume much more than the advertised limit before rejection. Windows structured collectors use this path through `runWindowsJSON` in `change_tracker_windows.go:166`.
+
+Proposed change: use bounded capture while continuing to drain output, preserving the existing over-limit error, parent cancellation, exit errors, and process cleanup. `runCollectorBoundedOutput` in the same file provides a starting pattern, but is not a drop-in replacement for the context-aware helpers and needs lifecycle review.
+
+This protects against exceptional peaks; it is not evidence that ordinary inventory accounts for 200–300 MB. Existing bounded-runner tests require a POSIX shell and skip Windows. Add Windows coverage for excessive stdout/stderr, cancellation, nonzero exits, and inherited pipes before shipping a change.
+
+### 3. Avoid full process objects just to count processes — small benefit
+
+`agent/internal/collectors/metrics.go:237` calls `process.Processes()` and uses only its length. The installed gopsutil Windows implementation enumerates PIDs and constructs process objects, including existence/creation-time queries.
+
+`process.Pids()` could avoid those allocations and OS calls. However, it counts enumerated PIDs rather than only successfully constructed process objects; disappearing or inaccessible processes can change the count slightly. Treat this as a small allocation/CPU cleanup, not a likely explanation for the complaint. Validate count semantics and allocation differences on Windows before adopting it.
+
+### 4. Reduce overlapping collectors only if measured peaks justify it
+
+Startup dispatches inventory, hardware, and patch work concurrently (`heartbeat/heartbeat.go:1544`). Inventory itself fans out (`:1884`), and Windows event collection runs up to four PowerShell processes concurrently (`collectors/eventlogs_windows.go:44`). Reliability owns another event collector, although its reporting cadence is daily.
+
+Staggering expensive collection could reduce peak process-tree memory. It also changes inventory completion times, startup behavior, and shutdown scheduling. Measure service and child processes separately first: PowerShell memory is not the main agent PID's memory. Avoid replacing PowerShell with native APIs or sharing mutable query caches without evidence that the additional complexity is warranted.
+
+### 5. Inspect command backlog bytes before changing queues
+
+`agent/internal/websocket/client.go:184` allows 256 queued results. `SendResult` retains both the structured result and its serialized frame (`:742–788`). Queue slots are not preallocated multi-MB payloads, so capacity alone does not explain idle memory. Large results behind a slow connection can nevertheless retain substantial memory.
+
+Measure queued bytes and delivery latency during reconnects and large command results. A byte budget or reduced duplicate representation may help if this appears in profiles, but must preserve result delivery and existing outbox failure handling. Do not simply shrink queues or discard results. The script executor already caps stdout and stderr at 1 MiB each (`executor/executor.go:30,185`).
+
+### 6. Helper and codec changes — measure first, defer by default
+
+Workstations default to always-on helpers; RDS hosts default to on-demand (`sessionbroker/lifecycle_mode.go:32`). Count helpers and user sessions when reporting aggregate memory. An on-demand workstation pilot is possible, but alters session availability/startup behavior and is not a free optimization.
+
+Each desktop session manager starts OpenH264 preload (`remote/desktop/session.go:199`), including managers constructed by the main heartbeat and helpers. Encoder allocation itself is lazy. Deferring preload in a process that never captures might reduce mapped/native memory, but first prove that process never serves a fallback capture path. Preload exists to avoid first-session download timeouts; preserve that behavior in capture helpers.
+
+## Remote desktop: preserve current safeguards
+
+Active capture has an inherently different footprint from idle monitoring. One uncompressed 3840×2160 four-byte pixel buffer is approximately 31.6 MiB. The Windows GDI path has a reusable capture buffer and a separate RGBA output; GPU paths have their own textures and conversion surfaces. These calculations are buffer sizes, not measured private working set, and alternative capture paths should not be added together as if all were active.
+
+The shipping Windows build disables CGO (`.github/workflows/release.yml:131`), so the legacy `C.GoBytes` capture path is not a useful target. Current code limits desktop sessions per process, retains only the latest cached frame, caps pooled encoded buffers, streams file transfers, and releases capture/encoder resources on teardown (`remote/desktop/session.go:425–479`). No specific remote teardown leak was confirmed. Avoid changing GPU fallback, buffer ownership, or teardown to save speculative MB.
+
+## Measurement plan using existing support
+
+1. Select a few representative Windows machines, including an affected device. Record exact agent version, uptime, memory column used, RAM, active sessions, and enabled workloads. Compare equivalent features and process scope before making a Ninja comparison.
+2. Collect per-PID working set and private bytes for the main service, watchdog, user/system helpers, backup helper, and collector children. Observe startup, settled idle, a 15-minute inventory cycle, normal daily scans, and a desktop session followed by teardown. A 24–48 hour baseline distinguishes recurring peaks from sustained growth. Sum private bytes for a process-tree commit view; summed working sets can double-count shared pages. Windows working set and private committed memory are different measurements: [Microsoft working set documentation](https://learn.microsoft.com/en-us/windows/win32/memory/working-set), [memory counter definitions](https://learn.microsoft.com/en-us/windows/win32/api/psapi/ns-psapi-process_memory_counters_ex).
+3. Inspect the existing heartbeat `agentRuntime` fields: heap allocation, heap in use, released bytes, runtime system bytes, GC count, goroutines, and commands in flight. Defined in `collectors/runtime_stats.go`; persisted with metrics in `apps/api/src/routes/agents/heartbeat.ts:1053`. Verify affected versions actually send these fields. These describe the main Go process, not all helper/native/child memory.
+4. Capture an occasional `capture_pprof` command with `{"profile":"all"}` through the existing authorized command workflow. The API also exposes `capture_agent_pprof` (`apps/api/src/services/aiToolsAgentLogs.ts:239`). Save/decode the returned `heapProfileBase64` and inspect with `go tool pprof -top -inuse_space heap.pprof`; compare equivalent idle captures with `go tool pprof -top -inuse_space -base baseline.pprof later.pprof`.
+5. Record Windows counters before capturing: heap capture explicitly invokes GC and changes the observed state. The embedded runtime snapshot is taken before that GC (`heartbeat/handlers_diag.go:124–139`). Captures are throttled to one per 30 seconds; use occasional diagnostic samples, not continuous capture. A main-service heap profile cannot explain a helper's native allocations.
+6. Interpret trends: growing live heap at equivalent idle points warrants allocation investigation; a small Go heap with high process memory points toward native allocations/mappings or other runtime memory; stable idle with workload-linked peaks points toward concurrent work and temporary buffers. Validate these hypotheses against profiles, process counters, and activity timestamps.
+
+Do not introduce an arbitrary `GOMEMLIMIT`, lower `GOGC`, periodic forced collection, or additional working-set trimming as the first response. Go's memory limit is soft, excludes external/native memory, and can increase GC CPU pressure. `Sys - HeapReleased` is a runtime-managed memory measure, not Windows RSS. See the [Go GC guide](https://go.dev/doc/gc-guide). Existing desktop teardown already calls `debug.FreeOSMemory`; leave it unchanged during baseline measurement.
+
+Recommended sequence: baseline affected machines, then consider the log-reference cleanup and collector output hardening as separate small changes. Require Windows validation and stable command delivery, heartbeat latency, inventory completeness, and remote access before any broader rollout. There is no evidence yet to promise a particular reduction in MB.
+
+## Implementation follow-up
+
+At the user's request, opportunities 1–3 are now implemented in this worktree:
+
+- Clear the log batch slots after synchronous shipping and before reuse, preserving re-buffered entries.
+- Bound stdout/combined collector capture to 4 MiB while draining excess output. Preserve partial output on command failure and up to 64 KiB of stderr on `ExitError.Stderr`. Preserve parent cancellation and timeout handling. A 10-second `WaitDelay` now prevents descendants holding inherited output pipes from blocking cleanup indefinitely. When the command itself exited 0 and only a descendant kept the pipe open, the runner logs a warning and returns the captured output as success rather than surfacing `exec.ErrWaitDelay`: every caller treats an error as command failure, and the change tracker in particular clones its previous snapshot on error, so the sentinel would have turned a benign orphaned handle into a permanent detection gap. Cost: a command's worst-case wall time is now its timeout plus 10 seconds, which exceeds the change tracker's 8-second `collectWithTimeout` default.
+- Count the PID enumeration snapshot directly. Counts can include processes that would disappear or fail validation before the previous per-process object construction finished, so `ProcessCount` may step up slightly on Windows at upgrade. The saving is larger than "small": gopsutil's Windows `PidExists` re-enumerates the full PID list for most PIDs, so the old path was quadratic per metrics tick.
+
+No collector cadence, helper lifecycle, remote desktop behavior, or GC configuration was changed. Portable subprocess tests cover output boundaries, both streams, exit failures, cancellation, timeout, bounded stderr, and inherited pipes, and the Windows CI job now runs them natively. A shipper test drives the main loop through a full 500-entry flush and asserts shipped entries keep their message and `Fields` map. Actual memory savings still require endpoint validation.


### PR DESCRIPTION
## Summary

Agent memory follow-up from the 2026-09-05 Windows agent memory review.

- **Collector command runner**: `ErrWaitDelay` after a clean exit (child exited 0 but a grandchild still held the stdout pipe past `WaitDelay`) now logs a warning and returns the captured output as success, via a shared `runCollectorCommand` helper. Previously the collector treated this as a failure and dropped good output. The normalisation is race-free per the stdlib contract: `ErrWaitDelay` is only returned when the process itself exited successfully, so it can never mask a non-zero exit or a context cancellation.
- Dropped `collectorStderrBuffer` (no consumer). Stderr is now a 64 KiB `cappedBuffer` surfaced on `ExitError.Stderr`.
- **Log shipper**: clear the batch slice after a successful ship so shipped entries are released instead of pinned until the next fill.
- **Metrics**: count PIDs without materialising per-process structs.
- Stale comments fixed in `command_limits.go` and `eventlogs_darwin.go`; `cappedBuffer` doc mentions `exceeded`.
- Windows CI gains a step running the collector command-runner tests natively.
- Research doc updated with the new semantics, the +10s worst-case budget, and the ProcessCount step-up note.

## Tests

- `command_limits_test.go`: red-first test rewritten to assert success plus preserved output on `ErrWaitDelay`.
- `shipper_test.go`: full-batch test added; verified it discriminates (fails when `clear` is moved before `shipBatch`, passes restored).
- Verified locally on top of current main: `gofmt`, `go vet` on darwin/linux/windows, `CGO_ENABLED=0 go test -race` green for `internal/collectors` and `internal/logging`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QBQmjgnokbMJKGXtuJAbHY