### PR TITLE
fix(api): single permanent delete cascades in a system context like bulk purge

### DIFF
--- a/apps/api/src/__tests__/integration/deviceLifecycle.integration.test.ts
+++ b/apps/api/src/__tests__/integration/deviceLifecycle.integration.test.ts
@@ -35,8 +35,8 @@ import { eq, sql } from 'drizzle-orm';
 
 import { getTestDb } from './setup';
 import { createOrganization, createPartner, createSite, createUser } from './db-utils';
-import { db, withSystemDbAccessContext } from '../../db';
-import { deviceCommands, devices } from '../../db/schema';
+import { db, runOutsideDbContext, withDbAccessContext, withSystemDbAccessContext, type DbAccessContext } from '../../db';
+import { alerts, deviceCommands, devices } from '../../db/schema';
 import { queueDeviceUninstall } from '../../services/deviceUninstallDrain';
 import { purgeRemovedDevice, restoreRemovedDevice } from '../../services/deviceLifecycle';
 import {
@@ -124,6 +124,17 @@ async function queueRemoveUninstall(deviceId: string, actorUserId: string): Prom
       }
     }),
   );
+}
+
+/** Org-scoped RLS context, the shape `authMiddleware` builds for an org-token request. */
+function orgContext(orgId: string): DbAccessContext {
+  return {
+    scope: 'organization',
+    orgId,
+    accessibleOrgIds: [orgId],
+    accessiblePartnerIds: [],
+    userId: null,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -360,5 +371,77 @@ describe('deviceLifecycle (integration)', () => {
     expect(result.purged).toEqual([]);
     expect(result.skipped).toEqual([{ deviceId: device.id, code: 'UNINSTALL_PENDING' }]);
     expect(await deviceExists(device.id)).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // #5023 wave 05 — single permanent delete must run the cascade in a SYSTEM
+  // db context, matching this file's own `withSystemDbAccessContext` calls
+  // above and `jobs/deviceBulkPurge.ts`'s `purgeOne`. Before this wave, the
+  // route ran the cascade under the CALLER's org-scoped context instead
+  // (reproduced directly here via `orgContext`, without going through HTTP —
+  // this file already drives `purgeRemovedDevice` the same way every test
+  // above does).
+  // -------------------------------------------------------------------------
+  it('an org-scoped cascade context leaves an RLS-hidden cascade row behind and fails the whole delete; a system-scoped context (matching the route since wave 05) removes it cleanly', async () => {
+    const tenant = await seedTenant();
+    const device = await seedDevice(tenant.orgId, tenant.siteId);
+
+    // Poison the cascade with a row `tenant.orgId`'s own context cannot see:
+    // an `alerts` row stamped with a DIFFERENT org. Nothing in normal
+    // operation produces this shape (the alerts service always stamps the
+    // triggering device's own org) — it stands in for the general hazard
+    // `services/deviceDeletion.ts` documents for `abuse_endpoint_fingerprints`
+    // (a cascade table an RLS policy can hide from the deleting context),
+    // reproduced with a table whose FK is NOT `ON DELETE SET NULL`/`CASCADE`
+    // (`alerts_device_id_devices_id_fk` is NO ACTION — verified against this
+    // stack's live schema), so an invisible row actually BLOCKS the parent
+    // delete instead of being silently cleaned up by the FK regardless of
+    // RLS the way abuse_endpoint_fingerprints's detach is.
+    const otherOrg = await createOrganization({ partnerId: tenant.partnerId, status: 'active' });
+    await withSystemDbAccessContext(() =>
+      db.insert(alerts).values({
+        deviceId: device.id,
+        orgId: otherOrg.id,
+        severity: 'critical',
+        status: 'active',
+        title: 'cross-org cascade poison fixture (#5023 wave 05)',
+      }),
+    );
+
+    // OLD behaviour: the cascade runs entirely inside the CALLER's own-org
+    // context — what the route did before this wave. The poisoned alert is
+    // invisible under `tenant.orgId`'s policy, so the cascade's
+    // `DELETE FROM alerts ...` misses it, and the final `DELETE FROM devices`
+    // then hits the NO ACTION foreign key: the whole purge fails and nothing
+    // is removed, rather than silently stranding just the one row.
+    let caught: unknown;
+    try {
+      await withDbAccessContext(orgContext(tenant.orgId), () =>
+        db.transaction((tx) => purgeRemovedDevice(tx, device.id)),
+      );
+    } catch (err) {
+      caught = err;
+    }
+    // Pin the SQLSTATE, not just "it threw": a vacuous `rejects.toThrow()`
+    // would also pass if the fixture were wrong for an unrelated reason.
+    // Drizzle wraps the postgres-js PostgresError in a DrizzleQueryError
+    // whose own `.code` is undefined — the SQLSTATE lives on `.cause` (same
+    // unwrap hazard `routes/devices/core.ts` documents for this route).
+    expect((caught as { cause?: { code?: string } } | undefined)?.cause?.code).toBe('23503');
+    expect(await deviceExists(device.id)).toBe(true);
+    expect(
+      await getTestDb().select({ id: alerts.id }).from(alerts).where(eq(alerts.deviceId, device.id)),
+    ).toHaveLength(1);
+
+    // NEW behaviour: escalate exactly as the route does since this wave.
+    // System context sees every row regardless of org, so both the child
+    // delete and the parent delete succeed.
+    await runOutsideDbContext(() =>
+      withSystemDbAccessContext(() => db.transaction((tx) => purgeRemovedDevice(tx, device.id))),
+    );
+    expect(await deviceExists(device.id)).toBe(false);
+    expect(
+      await getTestDb().select({ id: alerts.id }).from(alerts).where(eq(alerts.deviceId, device.id)),
+    ).toHaveLength(0);
   });
 });

--- a/apps/api/src/routes/devices/cascadeDelete.test.ts
+++ b/apps/api/src/routes/devices/cascadeDelete.test.ts
@@ -97,7 +97,7 @@ import {
   DEVICE_LINKED_DEVICE_ID_TABLES,
   DEVICE_LINK_DEPENDENT_COLUMNS,
 } from './core';
-import { db } from '../../db';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../../db';
 import { isAgentConnected, sendCommandToAgent } from '../agentWs';
 
 const deviceCascadeDeleteTables = getDeviceCascadeDeleteTables();
@@ -755,6 +755,74 @@ describe('DELETE /devices/:id/permanent — tickets are detached, not destroyed'
 
     expect(res.status).toBe(200);
     expect(dissolveLinkGroupIfBelowMinimum).not.toHaveBeenCalled();
+  });
+
+  /**
+   * Wave 05 (#5023 follow-up, #2787) — the cascade must run in a SYSTEM DB
+   * context, matching `jobs/deviceBulkPurge.ts`'s `purgeOne`. Today the route
+   * runs `purgeRemovedDevice` under the caller's tenant RLS context, and
+   * `services/deviceDeletion.ts` documents that at least one cascade table is
+   * deliberately invisible under tenant policy — so a single permanent delete
+   * can strand rows that bulk purge removes.
+   *
+   * `runOutsideDbContext` must run FIRST (CLAUDE.md's DB context helpers
+   * contract): the route is already inside the request's `withDbAccessContext`
+   * transaction, and escalating without first exiting it would hold two
+   * pooled connections at once.
+   *
+   * Authorisation must stay exactly where it is: `getDeviceWithOrgAndSiteCheck`
+   * (the `db.select` chokepoint) and the decommissioned pre-check both run
+   * BEFORE the escalation, so a caller who fails either check never reaches a
+   * system-scoped connection at all.
+   */
+  describe('escalates the cascade to a system DB context (#5023 wave 05)', () => {
+    it('calls runOutsideDbContext and withSystemDbAccessContext exactly once on a successful purge, after the chokepoint lookup', async () => {
+      rigDeviceLookup(DEVICE);
+      rigDeleteTransaction();
+
+      const res = await app.request(`/devices/${DEVICE.id}/permanent`, {
+        method: 'DELETE',
+        headers: { Authorization: 'Bearer t' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(runOutsideDbContext).toHaveBeenCalledTimes(1);
+      expect(withSystemDbAccessContext).toHaveBeenCalledTimes(1);
+
+      // Ordering: the chokepoint's authorisation read must resolve BEFORE the
+      // escalation opens — authorised first, matching the bulk worker.
+      const selectOrder = vi.mocked(db.select).mock.invocationCallOrder[0];
+      const escalateOrder = vi.mocked(runOutsideDbContext).mock.invocationCallOrder[0];
+      expect(selectOrder).toBeDefined();
+      expect(escalateOrder).toBeDefined();
+      expect(selectOrder!).toBeLessThan(escalateOrder!);
+    });
+
+    it('does not escalate when the pre-check 400s (device not decommissioned)', async () => {
+      rigDeviceLookup({ ...DEVICE, status: 'online' });
+
+      const res = await app.request(`/devices/${DEVICE.id}/permanent`, {
+        method: 'DELETE',
+        headers: { Authorization: 'Bearer t' },
+      });
+
+      expect(res.status).toBe(400);
+      expect(runOutsideDbContext).not.toHaveBeenCalled();
+      expect(withSystemDbAccessContext).not.toHaveBeenCalled();
+    });
+
+    it('does not escalate when the chokepoint 404s (device missing)', async () => {
+      rigDeviceLookup(null);
+
+      const res = await app.request(`/devices/${DEVICE.id}/permanent`, {
+        method: 'DELETE',
+        headers: { Authorization: 'Bearer t' },
+      });
+
+      expect(res.status).toBe(404);
+      expect(runOutsideDbContext).not.toHaveBeenCalled();
+      expect(withSystemDbAccessContext).not.toHaveBeenCalled();
+    });
   });
 
   // Still `decommissioned` — the route 400s anything else BEFORE it ever

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 import { z } from 'zod';
 import { optionalJsonValidator, zValidator } from '../../lib/validation';
 import { and, eq, gte, like, sql, desc, inArray, type SQL } from 'drizzle-orm';
-import { db } from '../../db';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../../db';
 import { createHash, randomBytes } from 'crypto';
 import { getRedis } from '../../services/redis';
 import { invalidateOrgDeviceCount } from '../../services/agentOrgRateLimit';
@@ -1998,8 +1998,43 @@ coreRoutes.delete(
     //     worse than telling the operator to wait. The response therefore
     //     drops `agentUninstallSent`/`warning`: there is nothing best-effort
     //     left to report.
+    // #5023 wave 05 — the cascade runs in a SYSTEM db context, matching
+    // `jobs/deviceBulkPurge.ts`'s `purgeOne`. Before this wave, the cascade ran
+    // under the CALLER's tenant-scoped context (the one `withDbAccessContext`
+    // opened for this request), and `services/deviceDeletion.ts` documents that
+    // at least one cascade table (`abuse_endpoint_fingerprints`) is
+    // deliberately invisible under tenant RLS policy — so this single-device
+    // path could strand rows that bulk purge (which has always run in a system
+    // context) removes cleanly.
+    //
+    // Authorisation is unaffected and stays exactly where it is: both the
+    // `getDeviceWithOrgAndSiteCheck` chokepoint above and the decommissioned
+    // pre-check just above run BEFORE this escalation, entirely inside the
+    // ordinary tenant-scoped request context. A caller who fails either check
+    // never reaches a system-scoped connection.
+    //
+    // `runOutsideDbContext` MUST wrap `withSystemDbAccessContext`, not the
+    // other way around: this route is already inside the request's
+    // `withDbAccessContext` transaction (the auth middleware opens one for
+    // every request — #1105), and opening a second nested context without
+    // first exiting the first would pin two pooled connections for the
+    // duration of this call instead of one (CLAUDE.md's DB context helpers
+    // contract).
+    //
+    // `purgeRemovedDevice`'s own `SELECT ... devices FOR UPDATE` + status
+    // re-check still runs, now strictly BETTER than before: under system
+    // context the devices row is fully visible, so that lock actually holds. In
+    // the old tenant-scoped path, an RLS-filtered row would have silently
+    // locked nothing (see the `deviceDeletion.ts` comment on
+    // `deleteDeviceCascade`'s parent lock) — a hazard this escalation closes as
+    // a side effect, not just for the invisible child table it targets.
     try {
-      const purge = await db.transaction((tx) => purgeRemovedDevice(tx, deviceId));
+      const purge = await runOutsideDbContext(() =>
+        withSystemDbAccessContext(
+          () => db.transaction((tx) => purgeRemovedDevice(tx, deviceId)),
+          'devices.permanentDelete',
+        ),
+      );
       linkGroupId = purge.linkGroupId;
       linkGroupDissolved = purge.linkGroupDissolved;
     } catch (err: unknown) {

--- a/apps/api/src/services/deviceDeletion.ts
+++ b/apps/api/src/services/deviceDeletion.ts
@@ -117,11 +117,19 @@ export async function deleteDeviceCascade(
   // IMPORTANT — the guarantee is conditional, and issuing this statement is NOT
   // the same as holding the lock. FOR UPDATE locks only rows the statement can
   // SEE, so it locks nothing when the device row is already gone (a re-run, or
-  // two reapers racing) or when RLS filters it out — this cascade runs inside
-  // the caller's tenant-scoped context, and at least one table it touches is
-  // deliberately invisible under that policy (see the abuse_endpoint_fingerprints
-  // note below). In that case the child cleanup below proceeds under the OLD
-  // child-first ordering, which is the exact race this lock exists to close.
+  // two reapers racing). Historically it could ALSO lock nothing when RLS
+  // filtered the row out — before #5023 wave 05, `DELETE /devices/:id/permanent`
+  // ran this whole cascade under the CALLER's tenant-scoped request context,
+  // and at least one table it touches (abuse_endpoint_fingerprints, see the
+  // note below) is deliberately invisible under that policy. That branch no
+  // longer applies: every caller of this function — the single-device route,
+  // the bulk-purge worker's `purgeOne` (jobs/deviceBulkPurge.ts, always
+  // system-scoped), and the Quick Support reaper — now runs it inside a
+  // SYSTEM db context, so the devices row here is fully visible whenever it
+  // exists. The re-run/racing-reaper case above is the only remaining reason
+  // for a zero-row lock; the RLS-visibility hazard survives only as history.
+  // If a future caller ever invokes this from a tenant-scoped context again,
+  // the OLD child-first-ordering race this lock exists to close comes back.
   //
   // Deleting an absent device is legitimately idempotent, so a zero-row result
   // must NOT abort — two reapers racing would then error instead of one simply
@@ -248,15 +256,19 @@ export async function deleteDeviceCascade(
   // Tenant business records (tickets, support_sessions): preserve history,
   // detach the device.
   //
-  // For abuse_endpoint_fingerprints specifically, this UPDATE is a structural
-  // no-op: it's a system-only-RLS corpus table, and this cascade runs inside
-  // the caller's tenant-scoped request context, so the tenant policy filters
-  // every row out before the UPDATE ever sees one. The real detach happens
-  // via the column's `device_id` FK, declared ON DELETE SET NULL — that fires
-  // unconditionally at the DB layer once the device row below is deleted, no
-  // RLS context involved. Listed here anyway for the single detach-tables
-  // contract (getDeviceCascadeDeleteTables et al.), not because this line
-  // does the work for that table.
+  // abuse_endpoint_fingerprints is a system-only-RLS corpus table. Since
+  // #5023 wave 05, every caller of this function runs in a SYSTEM db context
+  // (see the FOR UPDATE comment above), so this UPDATE actually sees and
+  // detaches its rows here — it is no longer the structural no-op it was
+  // before that wave, when the single-device route ran this cascade under
+  // the caller's tenant-scoped request context and the tenant policy filtered
+  // every row out before the UPDATE ever saw one. Either way the detach was
+  // never load-bearing for this table: the column's `device_id` FK is
+  // declared ON DELETE SET NULL, which fires unconditionally at the DB layer
+  // once the device row below is deleted, no RLS context involved. Listed
+  // here anyway for the single detach-tables contract
+  // (getDeviceCascadeDeleteTables et al.), not because this line is the only
+  // thing that does the work for that table.
   for (const detachTable of DEVICE_DETACH_DEVICE_ID_TABLES) {
     await tx.execute(sql`UPDATE ${sql.identifier(detachTable)} SET device_id = NULL WHERE device_id = ${deviceId}`);
   }


### PR DESCRIPTION
## What changed

`DELETE /devices/:id/permanent` used to run `purgeRemovedDevice` (and therefore the whole `deleteDeviceCascade`) under the caller's tenant-scoped RLS context — whatever `withDbAccessContext` opened for that request. `jobs/deviceBulkPurge.ts`'s `purgeOne` has always escalated to a system context instead, so the two code paths that share this cascade disagreed on which db context ran it.

`services/deviceDeletion.ts` documents that at least one cascade table (`abuse_endpoint_fingerprints`) is deliberately invisible under tenant RLS policy. That specific table turns out to be harmless either way (its detach is a structural no-op under tenant scope, and the real cleanup happens via an `ON DELETE SET NULL` FK, which bypasses RLS regardless of context) — but the same class of hazard is NOT harmless for the ~90 other cascade-delete tables whose FK to `devices` is the default `NO ACTION`. For those, an RLS-invisible row isn't silently stranded — it survives the app-level `DELETE`, and the final `DELETE FROM devices` at the end of the cascade then hits the foreign key and the whole transaction aborts with `23503`. The integration test in this PR reproduces exactly that failure mode with a live Postgres instance.

### Fix

Escalate the cascade with:

```ts
const purge = await runOutsideDbContext(() =>
  withSystemDbAccessContext(
    () => db.transaction((tx) => purgeRemovedDevice(tx, deviceId)),
    'devices.permanentDelete',
  ),
);
```

- **Authorised-first.** `getDeviceWithOrgAndSiteCheck` (the org/site chokepoint) and the `status !== 'decommissioned'` pre-check both still run *before* this escalation, entirely inside the ordinary tenant-scoped request context. A caller who fails either check never reaches a system-scoped connection.
- **Matches the bulk worker.** Same escalation shape as `jobs/deviceBulkPurge.ts`'s `purgeOne`.
- **`runOutsideDbContext` wraps `withSystemDbAccessContext`, not the reverse** — per CLAUDE.md's DB context helpers contract: the route is already inside the request's `withDbAccessContext` transaction (auth middleware opens one per request, #1105), so opening a system context without first exiting would pin two pooled connections at once.
- **Side benefit:** `purgeRemovedDevice`'s own `devices FOR UPDATE` lock now actually holds. Under the old tenant-scoped path, an RLS-filtered devices row would have silently locked nothing (see the updated comment in `deviceDeletion.ts`).

Also updated the now-stale "this cascade runs inside the caller's tenant-scoped context" observations in `services/deviceDeletion.ts` to reflect that every caller (the route, the bulk-purge worker, and the Quick Support reaper) now runs the cascade in a system context.

## Tests

- **Unit** (`apps/api/src/routes/devices/cascadeDelete.test.ts`): 3 new cases — `runOutsideDbContext`/`withSystemDbAccessContext` each called exactly once on a successful purge and in the right order (chokepoint select before escalation); neither called when the pre-check 400s; neither called when the chokepoint 404s. TDD: written red (failed against the pre-fix route), then made green by the route change.
- **Integration** (`apps/api/src/__tests__/integration/deviceLifecycle.integration.test.ts`), **ran against real Postgres** (`pnpm test-stack up`/`down`, both before and after merging main — 10/10 pass each time): new case inserts an `alerts` row stamped with a *different* org than the device (simulating an RLS-hidden cascade row — `alerts_device_id_devices_id_fk` is `NO ACTION`, verified against the live schema, unlike `abuse_endpoint_fingerprints`'s `ON DELETE SET NULL`). Empirically confirmed: purging from an org-scoped context throws with `cause.code === '23503'` and leaves both the device and the poisoned row in place; purging via the new system-context escalation (matching the route) removes both cleanly. Task 3 completed — did not need to be dropped.
- `tsc --noEmit`: clean, before and after merging main.
- `pnpm lint`: clean.

Refs #2787 #5023

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZAsMVZBbCxwBUtRFmrY7A