### PR TITLE
feat(api): device custom-field VALUE importer incl. the warranty target (#3257 W08) (#4776)

### DIFF
--- a/apps/api/src/__tests__/integration/deviceCustomFieldValueImport.integration.test.ts
+++ b/apps/api/src/__tests__/integration/deviceCustomFieldValueImport.integration.test.ts
@@ -260,6 +260,7 @@ describe('device custom-field VALUE import (real Postgres)', () => {
     const world = await seedWorld();
     const device = await seedDevice({ orgId: world.orgA, siteId: world.siteA, hostname: 'partial-1', serialNumber: 'sn-partial-1' });
     await seedDefinition({ partnerId: world.partnerA, fieldKey: 'bitlocker_status', type: 'text', deviceTypes: ['macos'] });
+    await seedDefinition({ partnerId: world.partnerA, fieldKey: 'rack_position', type: 'number' });
 
     const ctx: ValueImportContext = {
       partnerId: world.partnerA, accessibleOrgIds: [world.orgA], allowedSiteIds: null, mode: 'update',
@@ -273,7 +274,7 @@ describe('device custom-field VALUE import (real Postgres)', () => {
             v('asset_tag', 'AB-1'),
             v('rack_units', 4),
             v('never_defined', 'x'),
-            v('rack_units', 'not a number'),
+            v('rack_position', 'not a number'),
             v('bitlocker_status', 'on'),
           ],
         }] as CommitValueRowInput[],
@@ -376,6 +377,82 @@ describe('device custom-field VALUE import (real Postgres)', () => {
     expect(annotated[0]!.values.map((x) => x.outcome)).toEqual(['skipped-already-set', 'skipped-already-set']);
   });
 
+  runDb('re-running an identical WARRANTY file previews and commits as already-set', async () => {
+    // Preview and commit must agree on warranty exactly as they do on custom
+    // fields; before the review pass, preview promised `applied` here.
+    const world = await seedWorld();
+    const device = await seedDevice({ orgId: world.orgA, siteId: world.siteA, hostname: 'warranty-3', serialNumber: 'sn-warranty-3' });
+
+    const ctx: ValueImportContext = {
+      partnerId: world.partnerA, accessibleOrgIds: [world.orgA], allowedSiteIds: null, mode: 'update',
+    };
+    const rows = [{
+      hostname: 'warranty-3', values: [w('warrantyEndDate', inDays(30)), w('manufacturer', 'Dell')],
+    }] as CommitValueRowInput[];
+
+    const first = await withDbAccessContext(partnerCtx(world.partnerA, [world.orgA]), () =>
+      commitDeviceCustomFieldImport(rows, ctx, actor));
+    expect(first.rows[0]!.warranty).toBe('applied');
+
+    const annotated = await withDbAccessContext(partnerCtx(world.partnerA, [world.orgA]), () =>
+      previewDeviceCustomFieldImport(rows, ctx));
+    expect(annotated[0]!.values.map((x) => x.outcome)).toEqual(['skipped-already-set', 'skipped-already-set']);
+
+    const again = await withDbAccessContext(partnerCtx(world.partnerA, [world.orgA]), () =>
+      commitDeviceCustomFieldImport(rows, ctx, actor));
+    expect(again.rows[0]!.warranty).toBe('skipped-already-set');
+    expect(again.appliedValues).toBe(0);
+
+    // And nothing was rewritten.
+    const [row] = await getTestDb()
+      .select({ endDate: deviceWarranty.warrantyEndDate })
+      .from(deviceWarranty)
+      .where(eq(deviceWarranty.deviceId, device));
+    expect(row).toMatchObject({ endDate: inDays(30) });
+  });
+
+  runDb('the durable link key round-trips through externalSourceInstance', async () => {
+    const world = await seedWorld();
+    const device = await seedDevice({ orgId: world.orgA, siteId: world.siteA, hostname: 'si-1', serialNumber: 'sn-si-1' });
+
+    const ctx: ValueImportContext = {
+      partnerId: world.partnerA, accessibleOrgIds: [world.orgA], allowedSiteIds: null, mode: 'update',
+    };
+    const row = {
+      externalSystem: 'datto_rmm',
+      externalId: 'uid-si-1',
+      externalSourceInstance: 'tenant-a',
+      hostname: 'si-1',
+      values: [v('asset_tag', 'AB-1')],
+    } as CommitValueRowInput;
+
+    const first = await withDbAccessContext(partnerCtx(world.partnerA, [world.orgA]), () =>
+      commitDeviceCustomFieldImport([row], ctx, actor));
+    expect(first.rows[0]).toMatchObject({ method: 'hostname', linkCreated: true });
+
+    // Second run, same row: the link written above must be the one the resolver
+    // reads back — proving the write side and W06's read side build the SAME
+    // composite key including the reserved discriminator.
+    const second = await withDbAccessContext(partnerCtx(world.partnerA, [world.orgA]), () =>
+      commitDeviceCustomFieldImport([{ ...row, values: [v('asset_tag', 'AB-2')] }], ctx, actor));
+    expect(second.rows[0]).toMatchObject({ deviceId: device, method: 'link', linkCreated: false });
+
+    // A DIFFERENT source instance is a different key and must not match it.
+    const other = await withDbAccessContext(partnerCtx(world.partnerA, [world.orgA]), () =>
+      commitDeviceCustomFieldImport(
+        [{ ...row, externalSourceInstance: 'tenant-b', values: [v('asset_tag', 'AB-3')] }],
+        ctx,
+        actor,
+      ));
+    expect(other.rows[0]).toMatchObject({ method: 'hostname', linkCreated: true });
+
+    const links = await getTestDb()
+      .select({ sourceInstance: deviceExternalLinks.sourceInstance })
+      .from(deviceExternalLinks)
+      .where(eq(deviceExternalLinks.deviceId, device));
+    expect(links.map((l) => l.sourceInstance).sort()).toEqual(['tenant-a', 'tenant-b']);
+  });
+
   runDb('the warranty target writes a COMPUTED status, so evaluateWarrantyAlerts actually fires', async () => {
     const world = await seedWorld();
     const device = await seedDevice({ orgId: world.orgA, siteId: world.siteA, hostname: 'warranty-1', serialNumber: 'sn-warranty-1' });
@@ -460,10 +537,13 @@ describe('device custom-field VALUE import (real Postgres)', () => {
       hostname: 'warranty-2', values: [w('warrantyEndDate', inDays(30))],
     }] as CommitValueRowInput[];
 
+    const guardedPreview = await withDbAccessContext(partnerCtx(world.partnerA, [world.orgA]), () =>
+      previewDeviceCustomFieldImport(rows, base));
+    expect(guardedPreview[0]!.values[0]!.outcome).toBe('skipped-provider-owned');
+
     const guarded = await withDbAccessContext(partnerCtx(world.partnerA, [world.orgA]), () =>
       commitDeviceCustomFieldImport(rows, base, actor));
-    // The ROW-level outcome names the reason; the per-VALUE annotation says
-    // `skipped-already-set` with the warning. Reporting `none` here would tell
+    // The ROW-level outcome names the reason. Reporting `none` here would tell
     // the operator their warranty column was never mapped.
     expect(guarded.rows[0]!.warranty).toBe('skipped-provider-owned');
     let [row] = await getTestDb()

--- a/apps/api/src/__tests__/integration/deviceCustomFieldValueImport.integration.test.ts
+++ b/apps/api/src/__tests__/integration/deviceCustomFieldValueImport.integration.test.ts
@@ -1,0 +1,531 @@
+/**
+ * The value importer's contracts that only a real database can prove
+ * (#3257 W08).
+ *
+ * Five properties, each of which a mocked test would assert vacuously:
+ *
+ *  1. **Tenant isolation is app-layer, and RLS is still a second control.**
+ *     `loadDeviceResolutionSnapshot` runs under
+ *     `runOutsideDbContext(() => withSystemDbAccessContext(...))`, where
+ *     `breeze_has_org_access` returns TRUE for every row — so an appeal to RLS
+ *     on the READ path would be vacuous, and the SQL predicates are the whole
+ *     boundary. The WRITES, by contrast, deliberately stay in the request's own
+ *     context, and the second test below proves that by widening the app-layer
+ *     scope on purpose and watching Postgres refuse the write anyway.
+ *  2. **Per-row transaction isolation.** A row that fails leaves the rows before
+ *     it committed and does not stop the rows after it — the property a single
+ *     request-wide transaction cannot provide, because one failed statement
+ *     aborts it and everything later raises 25P02.
+ *  3. **Partial application inside one row.**
+ *  4. **The durable link makes a re-run exact**, including in the case that
+ *     motivates it: a hostname that has since become ambiguous.
+ *  5. **The warranty target is not inert.** It writes a COMPUTED `status`, and
+ *     `evaluateWarrantyAlerts` — which returns early on `unknown` — actually
+ *     fires afterwards. Asserting only that a row was written would pass
+ *     against exactly the bug this is guarding.
+ */
+import './setup';
+import { describe, expect, it } from 'vitest';
+import { and, eq } from 'drizzle-orm';
+import { withDbAccessContext, withSystemDbAccessContext, type DbAccessContext } from '../../db';
+import {
+  configPolicyAssignments,
+  configPolicyFeatureLinks,
+  configurationPolicies,
+  customFieldDefinitions,
+  deviceCustomFieldValues,
+  deviceExternalLinks,
+  deviceHardware,
+  deviceWarranty,
+  devices,
+} from '../../db/schema';
+import {
+  commitDeviceCustomFieldImport,
+  previewDeviceCustomFieldImport,
+  type ValueImportContext,
+} from '../../services/customFields/import/valueImport';
+import { evaluateWarrantyAlerts } from '../../services/warrantyAlertEvaluator';
+import type { CommitValueRowInput, MappingTarget } from '../../services/customFields/import/types';
+import { createOrganization, createPartner, createSite } from './db-utils';
+import { getTestDb } from './setup';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+let seq = 0;
+
+const actor = { userId: null };
+
+const v = (fieldKey: string, value: unknown) => ({
+  target: { kind: 'customField', fieldKey } as MappingTarget,
+  value,
+});
+const w = (field: 'warrantyEndDate' | 'warrantyStartDate' | 'manufacturer', value: unknown) => ({
+  target: { kind: 'warranty', field } as MappingTarget,
+  value,
+});
+
+function inDays(days: number): string {
+  return new Date(Date.now() + days * 86_400_000).toISOString().slice(0, 10);
+}
+
+/** The RLS context a partner-scoped request would establish. */
+function partnerCtx(partnerId: string, accessibleOrgIds: string[]): DbAccessContext {
+  return {
+    scope: 'partner',
+    orgId: null,
+    accessibleOrgIds,
+    accessiblePartnerIds: [partnerId],
+    currentPartnerId: partnerId,
+    userId: null,
+  };
+}
+
+async function seedDevice(input: {
+  orgId: string;
+  siteId: string;
+  hostname: string;
+  serialNumber?: string | null;
+  osType?: 'windows' | 'macos' | 'linux';
+}): Promise<string> {
+  seq += 1;
+  const db = getTestDb();
+  const [device] = await db.insert(devices).values({
+    orgId: input.orgId,
+    siteId: input.siteId,
+    agentId: `agent-w08-${Date.now()}-${seq}`,
+    hostname: input.hostname,
+    displayName: input.hostname.toUpperCase(),
+    osType: input.osType ?? 'windows',
+    osVersion: '11',
+    architecture: 'x64',
+    agentVersion: '1.0.0',
+    status: 'online',
+  }).returning({ id: devices.id });
+  if (input.serialNumber) {
+    await db.insert(deviceHardware).values({
+      deviceId: device!.id,
+      orgId: input.orgId,
+      serialNumber: input.serialNumber,
+    });
+  }
+  return device!.id;
+}
+
+/**
+ * A PARTNER-WIDE definition, deliberately: it is visible to every organization
+ * under the partner, which is what an MSP importing one incumbent field list
+ * across their whole book actually has — and it exercises the dual-axis branch
+ * of the coherence trigger rather than the trivial same-org one.
+ */
+async function seedDefinition(input: {
+  partnerId: string;
+  fieldKey: string;
+  type: 'text' | 'number' | 'boolean' | 'dropdown' | 'date';
+  deviceTypes?: string[] | null;
+}): Promise<string> {
+  const [definition] = await getTestDb().insert(customFieldDefinitions).values({
+    orgId: null,
+    partnerId: input.partnerId,
+    name: input.fieldKey,
+    fieldKey: input.fieldKey,
+    type: input.type,
+    deviceTypes: input.deviceTypes ?? null,
+  }).returning({ id: customFieldDefinitions.id });
+  return definition!.id;
+}
+
+async function storedValues(deviceId: string) {
+  return getTestDb()
+    .select({
+      fieldKey: deviceCustomFieldValues.fieldKey,
+      valueText: deviceCustomFieldValues.valueText,
+      valueNumber: deviceCustomFieldValues.valueNumber,
+      source: deviceCustomFieldValues.source,
+    })
+    .from(deviceCustomFieldValues)
+    .where(eq(deviceCustomFieldValues.deviceId, deviceId));
+}
+
+async function seedWorld() {
+  const partnerA = await createPartner();
+  const orgA = await createOrganization({ partnerId: partnerA!.id });
+  const orgA2 = await createOrganization({ partnerId: partnerA!.id });
+  const siteA = await createSite({ orgId: orgA!.id, name: 'Site A' });
+  const siteA2 = await createSite({ orgId: orgA2!.id, name: 'Site A2' });
+
+  const partnerB = await createPartner();
+  const orgB = await createOrganization({ partnerId: partnerB!.id });
+  const siteB = await createSite({ orgId: orgB!.id });
+
+  await seedDefinition({ partnerId: partnerA!.id, fieldKey: 'asset_tag', type: 'text' });
+  await seedDefinition({ partnerId: partnerA!.id, fieldKey: 'rack_units', type: 'number' });
+  await seedDefinition({ partnerId: partnerB!.id, fieldKey: 'asset_tag', type: 'text' });
+
+  return {
+    partnerA: partnerA!.id,
+    partnerB: partnerB!.id,
+    orgA: orgA!.id,
+    orgA2: orgA2!.id,
+    orgB: orgB!.id,
+    siteA: siteA!.id,
+    siteA2: siteA2!.id,
+    siteB: siteB!.id,
+  };
+}
+
+describe('device custom-field VALUE import (real Postgres)', () => {
+  runDb('refuses a cross-partner forge: another partner\'s device is not-found, never written', async () => {
+    const world = await seedWorld();
+    const mine = await seedDevice({ orgId: world.orgA, siteId: world.siteA, hostname: 'mine-1', serialNumber: 'sn-mine-1' });
+    const theirs = await seedDevice({ orgId: world.orgB, siteId: world.siteB, hostname: 'theirs-1', serialNumber: 'sn-theirs-1' });
+
+    const ctx: ValueImportContext = {
+      partnerId: world.partnerA,
+      accessibleOrgIds: [world.orgA],
+      allowedSiteIds: null,
+      mode: 'update',
+    };
+
+    const summary = await withDbAccessContext(partnerCtx(world.partnerA, [world.orgA]), () =>
+      commitDeviceCustomFieldImport(
+        [
+          { hostname: 'mine-1', values: [v('asset_tag', 'MINE')] },
+          // Every identifier the forger could reach for, all naming partner B.
+          { deviceId: theirs, values: [v('asset_tag', 'STOLEN')] },
+          { hostname: 'theirs-1', serialNumber: 'sn-theirs-1', values: [v('asset_tag', 'STOLEN')] },
+          { organizationId: world.orgB, hostname: 'theirs-1', values: [v('asset_tag', 'STOLEN')] },
+        ] as CommitValueRowInput[],
+        ctx,
+        actor,
+      ),
+    );
+
+    expect(summary.rows.map((r) => r.index)).toEqual([0]);
+    // `org-not-found` for the row that NAMED the foreign org, `not-found` for
+    // the rest — never `write-failed`, which would mean the write was tried.
+    expect(summary.errors.map((e) => ({ index: e.index, code: e.code }))).toEqual([
+      { index: 1, code: 'not-found' },
+      { index: 2, code: 'not-found' },
+      { index: 3, code: 'org-not-found' },
+    ]);
+    expect(await storedValues(theirs)).toHaveLength(0);
+    expect(await storedValues(mine)).toHaveLength(1);
+  });
+
+  runDb('RLS still refuses a write the app-layer scope wrongly admitted, and the row is isolated', async () => {
+    // The app-layer scope below is DELIBERATELY wider than the request's RLS
+    // context — the shape a caller bug would have. The resolver admits the
+    // orgA2 device, and Postgres refuses its INSERT anyway. That is the whole
+    // point of keeping the writes inside the request context instead of
+    // escaping to a system one.
+    const world = await seedWorld();
+    const first = await seedDevice({ orgId: world.orgA, siteId: world.siteA, hostname: 'row-a', serialNumber: 'sn-row-a' });
+    const outside = await seedDevice({ orgId: world.orgA2, siteId: world.siteA2, hostname: 'row-b', serialNumber: 'sn-row-b' });
+    const last = await seedDevice({ orgId: world.orgA, siteId: world.siteA, hostname: 'row-c', serialNumber: 'sn-row-c' });
+
+    const ctx: ValueImportContext = {
+      partnerId: world.partnerA,
+      accessibleOrgIds: [world.orgA, world.orgA2],
+      allowedSiteIds: null,
+      mode: 'update',
+    };
+
+    const summary = await withDbAccessContext(partnerCtx(world.partnerA, [world.orgA]), () =>
+      commitDeviceCustomFieldImport(
+        [
+          { hostname: 'row-a', values: [v('asset_tag', 'A')] },
+          { hostname: 'row-b', values: [v('asset_tag', 'B')] },
+          { hostname: 'row-c', values: [v('asset_tag', 'C')] },
+        ] as CommitValueRowInput[],
+        ctx,
+        actor,
+      ),
+    );
+
+    expect(summary.errors.map((e) => ({ index: e.index, code: e.code }))).toEqual([
+      { index: 1, code: 'write-failed' },
+    ]);
+    // The failing row rolled back to its own savepoint: the row BEFORE it is
+    // committed and the row AFTER it still ran.
+    expect(summary.rows.map((r) => r.index)).toEqual([0, 2]);
+    expect((await storedValues(first))[0]).toMatchObject({ valueText: 'A' });
+    expect(await storedValues(outside)).toHaveLength(0);
+    expect((await storedValues(last))[0]).toMatchObject({ valueText: 'C' });
+
+    // And no driver text escaped into the operator-facing copy.
+    expect(summary.errors[0]!.error).not.toMatch(/row-level security|policy|INSERT/i);
+  });
+
+  runDb('applies the good values on a row and reports the rest, in one transaction', async () => {
+    const world = await seedWorld();
+    const device = await seedDevice({ orgId: world.orgA, siteId: world.siteA, hostname: 'partial-1', serialNumber: 'sn-partial-1' });
+    await seedDefinition({ partnerId: world.partnerA, fieldKey: 'bitlocker_status', type: 'text', deviceTypes: ['macos'] });
+
+    const ctx: ValueImportContext = {
+      partnerId: world.partnerA, accessibleOrgIds: [world.orgA], allowedSiteIds: null, mode: 'update',
+    };
+
+    const summary = await withDbAccessContext(partnerCtx(world.partnerA, [world.orgA]), () =>
+      commitDeviceCustomFieldImport(
+        [{
+          hostname: 'partial-1',
+          values: [
+            v('asset_tag', 'AB-1'),
+            v('rack_units', 4),
+            v('never_defined', 'x'),
+            v('rack_units', 'not a number'),
+            v('bitlocker_status', 'on'),
+          ],
+        }] as CommitValueRowInput[],
+        ctx,
+        actor,
+      ),
+    );
+
+    expect(summary.errors).toHaveLength(0);
+    // 2 applied; no-definition, type-error and not-applicable-to-device are the
+    // three failures — and the two that DID land are still committed.
+    expect(summary.rows[0]).toMatchObject({ applied: 2, failed: 3 });
+    const stored = await storedValues(device);
+    expect(stored.map((s) => s.fieldKey).sort()).toEqual(['asset_tag', 'rack_units']);
+    expect(stored.every((s) => s.source === 'import')).toBe(true);
+
+    // The projection trigger rebuilt devices.custom_fields from the table.
+    const [projected] = await getTestDb()
+      .select({ customFields: devices.customFields })
+      .from(devices)
+      .where(eq(devices.id, device));
+    expect(projected!.customFields).toMatchObject({ asset_tag: 'AB-1', rack_units: 4 });
+  });
+
+  runDb('the durable link makes the SECOND run exact, even after the hostname turns ambiguous', async () => {
+    const world = await seedWorld();
+    const device = await seedDevice({ orgId: world.orgA, siteId: world.siteA, hostname: 'shared-name', serialNumber: 'sn-link-1' });
+
+    const ctx: ValueImportContext = {
+      partnerId: world.partnerA, accessibleOrgIds: [world.orgA], allowedSiteIds: null, mode: 'update',
+    };
+    const row = {
+      externalSystem: 'datto_rmm',
+      externalId: 'uid-link-1',
+      hostname: 'shared-name',
+      values: [v('asset_tag', 'AB-1')],
+    } as CommitValueRowInput;
+
+    const first = await withDbAccessContext(partnerCtx(world.partnerA, [world.orgA]), () =>
+      commitDeviceCustomFieldImport([row], ctx, actor));
+
+    expect(first.rows[0]).toMatchObject({ deviceId: device, method: 'hostname', linkCreated: true });
+    expect(first.linksCreated).toBe(1);
+    const [link] = await getTestDb()
+      .select({ deviceId: deviceExternalLinks.deviceId, system: deviceExternalLinks.system })
+      .from(deviceExternalLinks)
+      .where(and(
+        eq(deviceExternalLinks.partnerId, world.partnerA),
+        eq(deviceExternalLinks.externalId, 'uid-link-1'),
+      ));
+    expect(link).toMatchObject({ deviceId: device, system: 'datto_rmm' });
+
+    // A second machine takes the same hostname — the case the link exists for.
+    await seedDevice({ orgId: world.orgA, siteId: world.siteA, hostname: 'shared-name', serialNumber: 'sn-link-2' });
+
+    // CONTROL: without the external id, the row is now unresolvable and the
+    // importer refuses to guess.
+    const control = await withDbAccessContext(partnerCtx(world.partnerA, [world.orgA]), () =>
+      commitDeviceCustomFieldImport(
+        [{ hostname: 'shared-name', values: [v('asset_tag', 'AB-2')] }] as CommitValueRowInput[],
+        ctx,
+        actor,
+      ));
+    expect(control.errors.map((e) => e.code)).toEqual(['match-unconfirmed']);
+
+    // WITH the external id, the link pins it exactly — and needs no
+    // acknowledgement, because the link IS the earlier acknowledgement.
+    const second = await withDbAccessContext(partnerCtx(world.partnerA, [world.orgA]), () =>
+      commitDeviceCustomFieldImport([{ ...row, values: [v('asset_tag', 'AB-2')] }], ctx, actor));
+
+    expect(second.errors).toHaveLength(0);
+    expect(second.rows[0]).toMatchObject({ deviceId: device, method: 'link', linkCreated: false });
+    expect(second.linksCreated).toBe(0);
+    expect((await storedValues(device))[0]).toMatchObject({ valueText: 'AB-2' });
+  });
+
+  runDb('re-running an identical file in the default skip mode writes nothing', async () => {
+    const world = await seedWorld();
+    const device = await seedDevice({ orgId: world.orgA, siteId: world.siteA, hostname: 'idempotent-1', serialNumber: 'sn-idem-1' });
+
+    const ctx: ValueImportContext = {
+      partnerId: world.partnerA, accessibleOrgIds: [world.orgA], allowedSiteIds: null,
+    };
+    const rows = [{
+      hostname: 'idempotent-1',
+      values: [v('asset_tag', 'AB-1'), v('rack_units', 4)],
+    }] as CommitValueRowInput[];
+
+    await withDbAccessContext(partnerCtx(world.partnerA, [world.orgA]), () =>
+      commitDeviceCustomFieldImport(rows, ctx, actor));
+    const again = await withDbAccessContext(partnerCtx(world.partnerA, [world.orgA]), () =>
+      commitDeviceCustomFieldImport(rows, ctx, actor));
+
+    expect(again.appliedValues).toBe(0);
+    expect(again.skippedValues).toBe(2);
+    expect(await storedValues(device)).toHaveLength(2);
+
+    const annotated = await withDbAccessContext(partnerCtx(world.partnerA, [world.orgA]), () =>
+      previewDeviceCustomFieldImport(rows, ctx));
+    expect(annotated[0]!.values.map((x) => x.outcome)).toEqual(['skipped-already-set', 'skipped-already-set']);
+  });
+
+  runDb('the warranty target writes a COMPUTED status, so evaluateWarrantyAlerts actually fires', async () => {
+    const world = await seedWorld();
+    const device = await seedDevice({ orgId: world.orgA, siteId: world.siteA, hostname: 'warranty-1', serialNumber: 'sn-warranty-1' });
+
+    // Warranty alerting is opt-in: without an active, assigned warranty policy
+    // the evaluator resolves to DISABLED_SETTINGS and would return null no
+    // matter what the import wrote — which is how a vacuous version of this
+    // test passes.
+    const testDb = getTestDb();
+    const [policy] = await testDb.insert(configurationPolicies).values({
+      orgId: world.orgA, partnerId: null, name: 'Warranty', status: 'active',
+    }).returning({ id: configurationPolicies.id });
+    await testDb.insert(configPolicyFeatureLinks).values({
+      configPolicyId: policy!.id,
+      featureType: 'warranty',
+      inlineSettings: { enabled: true, warnDays: 90, criticalDays: 30 },
+    });
+    await testDb.insert(configPolicyAssignments).values({
+      configPolicyId: policy!.id, level: 'organization', targetId: world.orgA, priority: 0,
+    });
+
+    // Nothing to alert on before the import.
+    expect(await withSystemDbAccessContext(() => evaluateWarrantyAlerts(device))).toBeNull();
+
+    const ctx: ValueImportContext = {
+      partnerId: world.partnerA, accessibleOrgIds: [world.orgA], allowedSiteIds: null, mode: 'update',
+    };
+    const summary = await withDbAccessContext(partnerCtx(world.partnerA, [world.orgA]), () =>
+      commitDeviceCustomFieldImport(
+        [{
+          hostname: 'warranty-1',
+          values: [w('warrantyEndDate', inDays(30)), w('manufacturer', 'Dell')],
+        }] as CommitValueRowInput[],
+        ctx,
+        actor,
+      ));
+
+    expect(summary.errors).toHaveLength(0);
+    expect(summary.rows[0]).toMatchObject({ warranty: 'applied', applied: 2 });
+
+    const [warranty] = await testDb
+      .select({
+        status: deviceWarranty.status,
+        endDate: deviceWarranty.warrantyEndDate,
+        isSubscription: deviceWarranty.isSubscription,
+        dataSource: deviceWarranty.dataSource,
+        manufacturer: deviceWarranty.manufacturer,
+      })
+      .from(deviceWarranty)
+      .where(eq(deviceWarranty.deviceId, device));
+
+    // The status is the load-bearing column: the evaluator returns early on
+    // 'unknown', which is what this column defaults to.
+    expect(warranty).toMatchObject({
+      status: 'expiring',
+      endDate: inDays(30),
+      isSubscription: false,
+      dataSource: 'import',
+      manufacturer: 'dell',
+    });
+
+    expect(await withSystemDbAccessContext(() => evaluateWarrantyAlerts(device))).not.toBeNull();
+  });
+
+  runDb('refuses to clobber a provider-sourced warranty row without the opt-in', async () => {
+    const world = await seedWorld();
+    const device = await seedDevice({ orgId: world.orgA, siteId: world.siteA, hostname: 'warranty-2', serialNumber: 'sn-warranty-2' });
+    await getTestDb().insert(deviceWarranty).values({
+      deviceId: device,
+      orgId: world.orgA,
+      manufacturer: 'dell',
+      serialNumber: 'sn-warranty-2',
+      status: 'active',
+      warrantyEndDate: inDays(400),
+      dataSource: 'provider',
+    });
+
+    const base: ValueImportContext = {
+      partnerId: world.partnerA, accessibleOrgIds: [world.orgA], allowedSiteIds: null, mode: 'update',
+    };
+    const rows = [{
+      hostname: 'warranty-2', values: [w('warrantyEndDate', inDays(30))],
+    }] as CommitValueRowInput[];
+
+    const guarded = await withDbAccessContext(partnerCtx(world.partnerA, [world.orgA]), () =>
+      commitDeviceCustomFieldImport(rows, base, actor));
+    // The ROW-level outcome names the reason; the per-VALUE annotation says
+    // `skipped-already-set` with the warning. Reporting `none` here would tell
+    // the operator their warranty column was never mapped.
+    expect(guarded.rows[0]!.warranty).toBe('skipped-provider-owned');
+    let [row] = await getTestDb()
+      .select({ endDate: deviceWarranty.warrantyEndDate, dataSource: deviceWarranty.dataSource })
+      .from(deviceWarranty)
+      .where(eq(deviceWarranty.deviceId, device));
+    expect(row).toMatchObject({ endDate: inDays(400), dataSource: 'provider' });
+
+    const opted = await withDbAccessContext(partnerCtx(world.partnerA, [world.orgA]), () =>
+      commitDeviceCustomFieldImport(rows, { ...base, overrideProviderWarranty: true }, actor));
+    expect(opted.rows[0]!.warranty).toBe('applied');
+    [row] = await getTestDb()
+      .select({ endDate: deviceWarranty.warrantyEndDate, dataSource: deviceWarranty.dataSource })
+      .from(deviceWarranty)
+      .where(eq(deviceWarranty.deviceId, device));
+    expect(row).toMatchObject({ endDate: inDays(30), dataSource: 'import' });
+  });
+
+  runDb('honours an ambiguous acknowledgement only when it is pinned to a current candidate', async () => {
+    const world = await seedWorld();
+    const one = await seedDevice({ orgId: world.orgA, siteId: world.siteA, hostname: 'twin', serialNumber: 'sn-twin-1' });
+    const two = await seedDevice({ orgId: world.orgA, siteId: world.siteA, hostname: 'twin', serialNumber: 'sn-twin-2' });
+
+    const ctx: ValueImportContext = {
+      partnerId: world.partnerA, accessibleOrgIds: [world.orgA], allowedSiteIds: null, mode: 'update',
+    };
+
+    const annotated = await withDbAccessContext(partnerCtx(world.partnerA, [world.orgA]), () =>
+      previewDeviceCustomFieldImport([{ hostname: 'twin', values: [v('asset_tag', 'AB-1')] }], ctx));
+    expect(annotated[0]!.outcome).toBe('ambiguous');
+    expect(annotated[0]!.candidates.map((c) => c.deviceId).sort()).toEqual([one, two].sort());
+    expect(annotated[0]!.values[0]!.outcome).toBe('device-unresolved');
+
+    const stale = await withDbAccessContext(partnerCtx(world.partnerA, [world.orgA]), () =>
+      commitDeviceCustomFieldImport(
+        [{
+          hostname: 'twin',
+          expectedOutcome: 'ambiguous',
+          expectedDeviceId: '00000000-0000-4000-8000-000000000000',
+          values: [v('asset_tag', 'AB-1')],
+        }] as CommitValueRowInput[],
+        ctx,
+        actor,
+      ));
+    expect(stale.errors.map((e) => e.code)).toEqual(['match-changed']);
+    expect(await storedValues(one)).toHaveLength(0);
+    expect(await storedValues(two)).toHaveLength(0);
+
+    const pinned = await withDbAccessContext(partnerCtx(world.partnerA, [world.orgA]), () =>
+      commitDeviceCustomFieldImport(
+        [{
+          hostname: 'twin',
+          expectedOutcome: 'ambiguous',
+          expectedDeviceId: two,
+          values: [v('asset_tag', 'AB-1')],
+        }] as CommitValueRowInput[],
+        ctx,
+        actor,
+      ));
+    expect(pinned.errors).toHaveLength(0);
+    expect(pinned.rows[0]).toMatchObject({ deviceId: two, applied: 1 });
+    expect(await storedValues(one)).toHaveLength(0);
+    expect((await storedValues(two))[0]).toMatchObject({ valueText: 'AB-1' });
+  });
+});

--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -156,6 +156,106 @@ API requests are rate-limited to ensure fair usage. Rate limit headers are inclu
           }
         }
       },
+      DeviceCustomFieldImportValue: {
+        type: 'object',
+        required: ['target', 'value'],
+        properties: {
+          target: {
+            oneOf: [
+              {
+                type: 'object',
+                required: ['kind', 'fieldKey'],
+                properties: {
+                  kind: { type: 'string', enum: ['customField'] },
+                  fieldKey: { type: 'string', minLength: 1, maxLength: 100 }
+                }
+              },
+              {
+                type: 'object',
+                required: ['kind', 'field'],
+                properties: {
+                  kind: { type: 'string', enum: ['warranty'] },
+                  field: {
+                    type: 'string',
+                    enum: ['warrantyStartDate', 'warrantyEndDate', 'manufacturer'],
+                    description:
+                      'device_warranty columns an import may write. "status" is COMPUTED from the end date and never accepted; '
+                      + '"is_subscription" is never written at all — a true value suppresses expiry alerting and an import cannot know it.'
+                  }
+                }
+              }
+            ]
+          },
+          value: {
+            nullable: true,
+            oneOf: [{ type: 'string', maxLength: 10000 }, { type: 'number' }, { type: 'boolean' }],
+            description: 'null is an explicit clear, not "absent".'
+          }
+        }
+      },
+      DeviceCustomFieldImportRow: {
+        type: 'object',
+        required: ['values'],
+        description:
+          'Every identifier is optional and EVERY supplied one is resolved — a row whose identifiers point at different '
+          + 'devices is refused as identity-conflict rather than letting the first hit win. Resolution order: deviceId, '
+          + '(externalSystem, externalId) via device_external_links, serialNumber, hostname.',
+        properties: {
+          organizationId: { type: 'string', format: 'uuid', nullable: true, description: 'Narrows resolution to one organization. Out of reach ⇒ org-not-found.' },
+          deviceId: { type: 'string', format: 'uuid', nullable: true },
+          externalSystem: { type: 'string', maxLength: 64, nullable: true },
+          externalId: { type: 'string', maxLength: 255, nullable: true, description: 'Recorded as a durable device_external_links row on the first non-link match, so the next run resolves exactly.' },
+          externalSourceInstance: { type: 'string', maxLength: 255, nullable: true, description: 'Reserved; always null today.' },
+          serialNumber: { type: 'string', maxLength: 255, nullable: true },
+          hostname: { type: 'string', maxLength: 255, nullable: true },
+          values: { type: 'array', items: { $ref: '#/components/schemas/DeviceCustomFieldImportValue' } },
+          expectedOutcome: {
+            type: 'string',
+            enum: ['matched', 'link-match', 'ambiguous', 'not-found', 'org-not-found', 'identity-conflict'],
+            description: 'COMMIT only. The row outcome preview returned; the row is rejected "annotation-changed" if it has since moved.'
+          },
+          expectedDeviceId: {
+            type: 'string',
+            format: 'uuid',
+            description: 'COMMIT only. REQUIRED when expectedOutcome is "ambiguous" — pins the acknowledgement to the device the operator picked.'
+          }
+        }
+      },
+      DeviceCustomFieldImportRequest: {
+        type: 'object',
+        required: ['rows'],
+        properties: {
+          partnerId: {
+            type: 'string',
+            format: 'uuid',
+            description: 'System scope only may name a partner other than its own; anyone else supplying a different one gets 403.'
+          },
+          externalSystem: {
+            type: 'string',
+            maxLength: 64,
+            default: 'csv',
+            description: 'Which RMM the file came from. Used for the audit trail when a row does not name its own.'
+          },
+          mode: {
+            type: 'string',
+            enum: ['skip', 'update'],
+            default: 'skip',
+            description: 'What to do with a field that already holds a value. Per VALUE, not per row.'
+          },
+          overrideProviderWarranty: {
+            type: 'boolean',
+            default: false,
+            description: 'Replace warranty rows whose data_source is "provider" (a manufacturer API lookup). Off by default: a vendor answer outranks a CSV.'
+          },
+          rows: {
+            type: 'array',
+            minItems: 1,
+            maxItems: 1000,
+            description: 'Capped at 1000 rows AND 5000 total values per request — the row cap alone does not bound the work.',
+            items: { $ref: '#/components/schemas/DeviceCustomFieldImportRow' }
+          }
+        }
+      },
       // Common schemas
       Pagination: {
         type: 'object',
@@ -2707,6 +2807,157 @@ API requests are rate-limited to ensure fair usage. Rate limit headers are inclu
           },
           '400': { description: 'Invalid input (row cap exceeded, unpinned "already-exists" acknowledgement)' },
           '403': { description: 'Access denied to this partner, or partner-wide rows without full partner org access' },
+        },
+      },
+    },
+
+    // ============================================
+    // DEVICE CUSTOM FIELD VALUE IMPORT (#3257 W08)
+    // ============================================
+    '/devices/custom-fields/import/preview': {
+      post: {
+        operationId: 'previewDeviceCustomFieldImport',
+        tags: ['Devices'],
+        summary: 'Preview a device custom-field value import',
+        description:
+          'Resolve each row to a device and annotate EVERY VALUE on it, without writing anything. '
+          + 'Annotation is per value, not per row: the normal case is a row where most values land, one names a field '
+          + 'this organization has never defined, and one fails type validation. '
+          + 'Requires organization, partner or system scope, devices:write and MFA; JWT only (an X-API-Key caller gets 401).',
+        requestBody: {
+          required: true,
+          content: { 'application/json': { schema: { $ref: '#/components/schemas/DeviceCustomFieldImportRequest' } } },
+        },
+        responses: {
+          '200': {
+            description: 'Annotated rows',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    rows: {
+                      type: 'array',
+                      items: {
+                        type: 'object',
+                        properties: {
+                          index: { type: 'integer' },
+                          outcome: {
+                            type: 'string',
+                            enum: ['matched', 'link-match', 'ambiguous', 'not-found', 'org-not-found', 'identity-conflict'],
+                            description:
+                              'How the DEVICE resolved. link-match = an existing device_external_links row (needs no acknowledgement); '
+                              + 'ambiguous = several devices match and the operator must pick one explicitly — the importer never auto-selects; '
+                              + 'identity-conflict = two identifiers each pinned a different device; '
+                              + 'org-not-found = the organization is absent or out of reach (deliberately the same answer for both).',
+                          },
+                          deviceId: { type: 'string', format: 'uuid', nullable: true },
+                          method: { type: 'string', enum: ['id', 'link', 'serial', 'hostname'], nullable: true },
+                          organizationId: { type: 'string', format: 'uuid', nullable: true },
+                          candidates: { type: 'array', items: { type: 'object' }, description: 'Ranked, for ambiguous / identity-conflict. Ranking is presentational and never selects.' },
+                          conflictingMethods: { type: 'array', items: { type: 'string' } },
+                          discardedIdentifiers: { type: 'array', items: { type: 'string' }, description: 'Identifiers the row supplied that carried no information (today: a serial on the agent junk denylist).' },
+                          values: {
+                            type: 'array',
+                            items: {
+                              type: 'object',
+                              properties: {
+                                target: { type: 'object' },
+                                outcome: {
+                                  type: 'string',
+                                  enum: ['applied', 'skipped-already-set', 'no-definition', 'type-error', 'not-applicable-to-device', 'device-unresolved'],
+                                  description:
+                                    'skipped-already-set covers both an identical re-import and a differing value the default "skip" mode declines to overwrite; '
+                                    + 'no-definition = run the DEFINITIONS import first; '
+                                    + 'not-applicable-to-device = the definition is scoped to other deviceTypes; '
+                                    + 'device-unresolved = the row itself did not resolve, so no value on it can be judged.',
+                                },
+                                reason: { type: 'string', enum: ['invalid_type', 'out_of_range', 'not_a_choice', 'too_long', 'invalid_date'] },
+                                warning: { type: 'string', description: 'Advisory and orthogonal to outcome — e.g. a key that feeds the device\'s partner-integration stableIdentifiers.' },
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          '400': { description: 'Invalid input (row cap or value cap exceeded, unknown mapping target)' },
+          '403': { description: 'Access denied to this partner, MFA required, or missing devices:write' },
+        },
+      },
+    },
+    '/devices/custom-fields/import': {
+      post: {
+        operationId: 'commitDeviceCustomFieldImport',
+        tags: ['Devices'],
+        summary: 'Commit a device custom-field value import',
+        description:
+          'Write the acknowledged values. Device resolution and every value annotation are RE-DERIVED against fresh state '
+          + 'inside the request and never taken from preview: a row whose outcome moved is rejected "annotation-changed", '
+          + 'and an "ambiguous" acknowledgement must pin expectedDeviceId or it is rejected "match-unconfirmed" / "match-changed". '
+          + 'Each row is written in its own transaction — its values, its durable external link and its warranty together — '
+          + 'so a failure rolls back that device alone and later rows still commit. '
+          + 'Always responds 200, even when errors[] is non-empty: a partial import must not read as a total failure.',
+        requestBody: {
+          required: true,
+          content: { 'application/json': { schema: { $ref: '#/components/schemas/DeviceCustomFieldImportRequest' } } },
+        },
+        responses: {
+          '200': {
+            description: 'Import summary (may report per-row errors)',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    appliedValues: { type: 'integer', description: 'Counts VALUES, not rows, so the total reconciles against the file.' },
+                    skippedValues: { type: 'integer' },
+                    failedValues: { type: 'integer' },
+                    linksCreated: { type: 'integer' },
+                    rows: {
+                      type: 'array',
+                      items: {
+                        type: 'object',
+                        properties: {
+                          index: { type: 'integer' },
+                          deviceId: { type: 'string', format: 'uuid' },
+                          organizationId: { type: 'string', format: 'uuid' },
+                          method: { type: 'string', enum: ['id', 'link', 'serial', 'hostname'] },
+                          externalSystem: { type: 'string', nullable: true },
+                          applied: { type: 'integer' },
+                          skipped: { type: 'integer' },
+                          failed: { type: 'integer' },
+                          appliedFieldKeys: { type: 'array', items: { type: 'string' }, description: 'Field KEYS only — a value never enters the audit payload.' },
+                          warranty: { type: 'string', enum: ['applied', 'skipped-provider-owned', 'skipped-already-set', 'none'] },
+                          linkCreated: { type: 'boolean' },
+                        },
+                      },
+                    },
+                    errors: {
+                      type: 'array',
+                      items: {
+                        type: 'object',
+                        properties: {
+                          index: { type: 'integer' },
+                          error: { type: 'string' },
+                          code: {
+                            type: 'string',
+                            enum: ['org-not-found', 'not-found', 'identity-conflict', 'annotation-changed', 'match-changed', 'match-unconfirmed', 'write-failed'],
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          '400': { description: 'Invalid input (row cap or value cap exceeded, unpinned "ambiguous" acknowledgement)' },
+          '403': { description: 'Access denied to this partner, MFA required, or missing devices:write' },
         },
       },
     },

--- a/apps/api/src/routes/devices/customFieldImport.mountorder.test.ts
+++ b/apps/api/src/routes/devices/customFieldImport.mountorder.test.ts
@@ -1,0 +1,231 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import { HTTPException } from 'hono/http-exception';
+
+/**
+ * Mount-order guard for the VALUES importer (#3257 W08), mirroring
+ * `customFieldValues.mountorder.test.ts`.
+ *
+ * Two regressions this catches, both exercised through the FULLY-ASSEMBLED
+ * `deviceRoutes` rather than the router in isolation:
+ *
+ *  1. **The import routes stop being reachable.** `/custom-fields/import` and
+ *     `/custom-fields/import/preview` are static paths under `/devices`; a
+ *     reorder that put them behind a `/:id` matcher would 404 them.
+ *
+ *  2. **The importer grows a wildcard.** `customFieldImportRoutes` uses
+ *     PER-ROUTE middleware. If someone "simplifies" it to
+ *     `.use('*', authMiddleware)`, that wildcard attaches to every route mounted
+ *     AFTER it — and it is mounted directly after `customFieldValuesRoutes`, so
+ *     the X-API-Key PATCH those routes exist for would start being handled by
+ *     the JWT-only `authMiddleware` and 401 again (issue #2066). The API-key
+ *     assertion below is that mutation's detector.
+ */
+
+const ORG_A = '11111111-1111-4111-8111-111111111111';
+const DEVICE_ID = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
+const API_KEY_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+vi.mock('../../db', () => ({
+  runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: {
+    select: vi.fn(),
+    update: vi.fn(),
+    insert: vi.fn(),
+    delete: vi.fn(),
+    execute: vi.fn(),
+    transaction: vi.fn(),
+  },
+}));
+
+vi.mock('../../db/schema', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../db/schema')>();
+  return { ...actual };
+});
+
+// REAL-shaped authMiddleware: 401 without a Bearer header. That is what makes a
+// leaked wildcard detectable on the X-API-Key request below.
+vi.mock('../../middleware/auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../middleware/auth')>();
+  return {
+    ...actual,
+    authMiddleware: vi.fn((c: any, next: any) => {
+      const header = c.req.header('Authorization');
+      if (!header?.startsWith('Bearer ')) {
+        throw new HTTPException(401, { message: 'Missing or invalid authorization header' });
+      }
+      c.set('auth', {
+        user: { id: 'user-1', email: 't@example.com' },
+        scope: 'partner',
+        orgId: null,
+        partnerId: '22222222-2222-4222-8222-222222222222',
+        accessibleOrgIds: [ORG_A],
+        canAccessOrg: (orgId: string) => orgId === ORG_A,
+      });
+      return next();
+    }),
+    requireScope: vi.fn(() => async (_c: any, next: any) => next()),
+    requirePermission: vi.fn(() => async (c: any, next: any) => {
+      c.set('permissions', { permissions: [], orgId: ORG_A, scope: 'partner' });
+      return next();
+    }),
+    requireMfa: vi.fn(() => async (_c: any, next: any) => next()),
+  };
+});
+
+vi.mock('../../middleware/apiKeyAuth', () => ({
+  apiKeyAuthMiddleware: vi.fn((c: any, next: any) => {
+    c.set('apiKey', {
+      id: API_KEY_ID,
+      orgId: ORG_A,
+      partnerId: null,
+      name: 'Automation key',
+      keyPrefix: 'brz_test',
+      scopes: ['devices:write'],
+      rateLimit: 1000,
+      createdBy: 'user-1',
+    });
+    return next();
+  }),
+  requireApiKeyScope: vi.fn(() => async (_c: any, next: any) => next()),
+}));
+
+vi.mock('../../services/auditService', () => ({
+  createAuditLog: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../services/customFields/queries', () => ({
+  loadVisibleCustomFieldDefinitions: vi.fn().mockResolvedValue([
+    {
+      id: 'def-note', fieldKey: 'note', name: 'note', type: 'text', options: null,
+      // Literal, not ORG_A: a vi.mock factory is hoisted above the consts.
+      deviceTypes: null, required: false, scriptWrite: false,
+      orgId: '11111111-1111-4111-8111-111111111111', partnerId: null,
+    },
+  ]),
+  persistDeviceCustomFieldValues: vi.fn().mockResolvedValue([]),
+}));
+
+// The importer service itself is exercised by its own suite; here it only has
+// to prove the request REACHED the handler.
+vi.mock('../../services/customFields/import/valueImport', () => ({
+  previewDeviceCustomFieldImport: vi.fn().mockResolvedValue([]),
+  commitDeviceCustomFieldImport: vi.fn().mockResolvedValue({
+    appliedValues: 0, skippedValues: 0, failedValues: 0, rows: [], linksCreated: 0, errors: [],
+  }),
+}));
+vi.mock('../../services/customFields/import/audit', () => ({
+  writeCustomFieldDefinitionImportAudits: vi.fn(),
+  writeCustomFieldValueImportAudits: vi.fn(),
+}));
+
+// Other device sub-routers pulled in by the assembled router import these at
+// module load; stub the heavy ones so the import succeeds.
+vi.mock('../../services/auditEvents', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../services/auditEvents')>();
+  return { ...actual, writeRouteAudit: vi.fn(), writeAuditEvent: vi.fn() };
+});
+vi.mock('../../services/sentry', () => ({ captureException: vi.fn() }));
+vi.mock('../../services/remoteAccessPolicy', () => ({
+  resolveRemoteAccessForDevice: vi.fn().mockResolvedValue({ policyId: null, settings: {} }),
+}));
+vi.mock('../../services/remoteAccessLauncher', () => ({
+  resolveRemoteAccessLaunch: vi.fn().mockReturnValue({ launchUrl: null, skipReason: 'no_provider_configured' }),
+}));
+vi.mock('../agentWs', () => ({
+  sendCommandToAgent: vi.fn(),
+  isAgentConnected: vi.fn().mockReturnValue(false),
+}));
+vi.mock('../../services/commandQueue', () => ({
+  CommandTypes: { SELF_UNINSTALL: 'self_uninstall' },
+  queueCommandForExecution: vi.fn(),
+}));
+vi.mock('../agents/enrollment', () => ({
+  getGlobalEnrollmentSecret: vi.fn().mockReturnValue(null),
+}));
+
+import { deviceRoutes } from './index';
+import { db } from '../../db';
+
+function rigDeviceLookup(device: unknown) {
+  const limit = vi.fn().mockResolvedValue(device ? [device] : []);
+  const where = vi.fn().mockReturnValue({ limit });
+  const from = vi.fn().mockReturnValue({ where });
+  vi.mocked(db.select).mockReturnValueOnce({ from } as never);
+}
+
+function rigProjectionRead(updatedRow: { customFields: unknown } | null) {
+  const limit = vi.fn().mockResolvedValue(updatedRow ? [updatedRow] : []);
+  const where = vi.fn().mockReturnValue({ limit });
+  const from = vi.fn().mockReturnValue({ where });
+  vi.mocked(db.select).mockReturnValueOnce({ from } as never);
+}
+
+const IMPORT_PATHS = ['/devices/custom-fields/import/preview', '/devices/custom-fields/import'];
+
+const body = {
+  rows: [{ hostname: 'wkstn-1', values: [{ target: { kind: 'customField', fieldKey: 'note' }, value: 'hi' }] }],
+};
+
+describe('custom-field import routes mount order (#3257 W08)', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = new Hono();
+    app.route('/devices', deviceRoutes);
+  });
+
+  it('both import routes reach their handler through the assembled deviceRoutes', async () => {
+    for (const path of IMPORT_PATHS) {
+      const res = await app.request(path, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer t' },
+        body: JSON.stringify(body),
+      });
+      // A reorder behind a `/:id` matcher would 404 here.
+      expect(res.status).toBe(200);
+    }
+  });
+
+  it('a no-credentials import POST is still rejected (401)', async () => {
+    for (const path of IMPORT_PATHS) {
+      const res = await app.request(path, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      expect(res.status).toBe(401);
+    }
+  });
+
+  it('an X-API-Key import POST is rejected (401) — deliberately no dualAuth branch', async () => {
+    for (const path of IMPORT_PATHS) {
+      const res = await app.request(path, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-API-Key': 'brz_test' },
+        body: JSON.stringify(body),
+      });
+      expect(res.status).toBe(401);
+    }
+  });
+
+  it('the sibling X-API-Key custom-field PATCH still reaches its handler (no wildcard leaked)', async () => {
+    // The detector for "someone replaced the per-route middleware with
+    // `.use('*', authMiddleware)`": that wildcard would attach to every route
+    // mounted after this router and 401 this request (no Bearer header).
+    rigDeviceLookup({ id: DEVICE_ID, orgId: ORG_A, siteId: null, hostname: 'WS', displayName: 'WS', customFields: {} });
+    rigProjectionRead({ customFields: { note: 'hi' } });
+
+    const res = await app.request(`/devices/${DEVICE_ID}/custom-fields`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', 'X-API-Key': 'brz_test' },
+      body: JSON.stringify({ note: 'hi' }),
+    });
+
+    expect(res.status).not.toBe(401);
+    expect(res.status).toBe(200);
+  });
+});

--- a/apps/api/src/routes/devices/customFieldImport.test.ts
+++ b/apps/api/src/routes/devices/customFieldImport.test.ts
@@ -1,0 +1,378 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+/**
+ * Route contract for the VALUES importer (#3257 W08 Task 5).
+ *
+ * The gates are the point of this file, so every negative test is
+ * mutation-checked: deleting the middleware it guards turns it red (recorded in
+ * the PR body). The service is mocked — its behaviour has its own suite — so
+ * these tests assert exactly what the ROUTE is responsible for: the caps, the
+ * auth band, the partner bounding, and the always-200 contract.
+ */
+
+const PARTNER = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const OTHER_PARTNER = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+const ORG = '11111111-1111-4111-8111-111111111111';
+const DEVICE = 'dddddddd-dddd-4ddd-8ddd-ddddddddddd1';
+
+const {
+  authRef,
+  permissionsRef,
+  permissionDenied,
+  grantsRequested,
+  requirePermissionSpy,
+  requireMfaSpy,
+  previewMock,
+  commitMock,
+  auditMock,
+} = vi.hoisted(() => ({
+  authRef: {
+    current: {
+      scope: 'partner' as 'partner' | 'organization' | 'system',
+      partnerId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa' as string | null,
+      orgId: null as string | null,
+      accessibleOrgIds: null as string[] | null,
+      user: { id: 'u-1', email: 'admin@example.com' },
+      token: { mfa: true } as { mfa: boolean },
+    },
+  },
+  permissionsRef: { current: { allowedSiteIds: undefined } as { allowedSiteIds?: string[] } | undefined },
+  permissionDenied: { current: false },
+  /** Recorded at MODULE LOAD (that is when `requirePermission` is called), so it
+   *  is deliberately never cleared in `beforeEach`. */
+  grantsRequested: [] as Array<[string, string]>,
+  requirePermissionSpy: vi.fn(),
+  requireMfaSpy: vi.fn(),
+  previewMock: vi.fn(),
+  commitMock: vi.fn(),
+  auditMock: vi.fn(),
+}));
+
+vi.mock('../../middleware/auth', () => ({
+  // Bearer-only, exactly like production: `middleware/auth.ts` has no
+  // X-API-Key branch at all, which is what makes the API-key test meaningful.
+  authMiddleware: vi.fn(async (c: any, next: any) => {
+    if (!c.req.header('authorization')?.startsWith('Bearer ')) {
+      return c.json({ error: 'Not authenticated' }, 401);
+    }
+    c.set('auth', authRef.current);
+    await next();
+  }),
+  requireScope: () => async (_c: any, next: any) => next(),
+  requirePermission: (resource: string, action: string) => {
+    grantsRequested.push([resource, action]);
+    requirePermissionSpy(resource, action);
+    return async (c: any, next: any) => {
+      if (permissionDenied.current) return c.json({ error: 'Insufficient permissions' }, 403);
+      c.set('permissions', permissionsRef.current);
+      await next();
+    };
+  },
+  requireMfa: () => async (c: any, next: any) => {
+    requireMfaSpy();
+    if (authRef.current.token?.mfa !== true) {
+      return c.json({ error: 'MFA required', code: 'MFA_REQUIRED' }, 403);
+    }
+    await next();
+  },
+}));
+
+vi.mock('../../services/permissions', () => ({
+  PERMISSIONS: {
+    DEVICES_READ: { resource: 'devices', action: 'read' },
+    DEVICES_WRITE: { resource: 'devices', action: 'write' },
+    ORGS_WRITE: { resource: 'organizations', action: 'write' },
+  },
+}));
+
+vi.mock('../../services/customFields/import/valueImport', () => ({
+  previewDeviceCustomFieldImport: previewMock,
+  commitDeviceCustomFieldImport: commitMock,
+}));
+
+vi.mock('../../services/customFields/import/audit', () => ({
+  writeCustomFieldValueImportAudits: auditMock,
+}));
+
+import { customFieldImportRoutes } from './customFieldImport';
+import { MAX_IMPORT_ROWS, MAX_IMPORT_VALUES } from '../../services/customFields/import/types';
+
+const PREVIEW = '/devices/custom-fields/import/preview';
+const COMMIT = '/devices/custom-fields/import';
+const BOTH = [PREVIEW, COMMIT];
+
+function app() {
+  const a = new Hono();
+  a.route('/devices', customFieldImportRoutes);
+  return a;
+}
+
+function post(path: string, body: unknown, headers: Record<string, string> = {}) {
+  return app().request(path, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: 'Bearer t', ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+const value = (fieldKey: string, v: unknown) => ({ target: { kind: 'customField', fieldKey }, value: v });
+
+function row(overrides: Record<string, unknown> = {}) {
+  return { hostname: 'wkstn-1', values: [value('asset_tag', 'AB-1')], ...overrides };
+}
+
+const emptySummary = {
+  appliedValues: 0, skippedValues: 0, failedValues: 0, rows: [], linksCreated: 0, errors: [],
+};
+
+function setPartnerAuth() {
+  authRef.current = {
+    scope: 'partner', partnerId: PARTNER, orgId: null, accessibleOrgIds: [ORG],
+    user: { id: 'u-1', email: 'admin@example.com' }, token: { mfa: true },
+  };
+}
+
+function setOrgAuth() {
+  authRef.current = {
+    scope: 'organization', partnerId: PARTNER, orgId: ORG, accessibleOrgIds: [ORG],
+    user: { id: 'u-2', email: 'org-admin@example.com' }, token: { mfa: true },
+  };
+}
+
+beforeEach(() => {
+  setPartnerAuth();
+  permissionsRef.current = { allowedSiteIds: undefined };
+  permissionDenied.current = false;
+  previewMock.mockReset().mockResolvedValue([]);
+  commitMock.mockReset().mockResolvedValue(emptySummary);
+  auditMock.mockReset();
+  requireMfaSpy.mockClear();
+  requirePermissionSpy.mockClear();
+});
+
+describe('POST /devices/custom-fields/import{,/preview} — caps', () => {
+  it('rejects more rows than the row cap, with copy telling the browser to split', async () => {
+    const rows = Array.from({ length: MAX_IMPORT_ROWS + 1 }, () => row());
+    for (const path of BOTH) {
+      const res = await post(path, { rows });
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toMatch(/split/i);
+    }
+    expect(previewMock).not.toHaveBeenCalled();
+    expect(commitMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects 1000 rows x 30 values at the zod layer even though the ROW cap passes', async () => {
+    // The row cap alone does not bound the work — this is the case it misses.
+    const values = Array.from({ length: 30 }, (_, i) => value(`f_${i}`, 'x'));
+    const rows = Array.from({ length: MAX_IMPORT_ROWS }, () => row({ values }));
+    expect(rows.length).toBeLessThanOrEqual(MAX_IMPORT_ROWS);
+    expect(rows.length * 30).toBeGreaterThan(MAX_IMPORT_VALUES);
+
+    const res = await post(PREVIEW, { rows });
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/split/i);
+    expect(previewMock).not.toHaveBeenCalled();
+  });
+
+  it('accepts a batch at exactly the value cap', async () => {
+    const values = Array.from({ length: 10 }, (_, i) => value(`f_${i}`, 'x'));
+    const rows = Array.from({ length: MAX_IMPORT_VALUES / 10 }, () => row({ values }));
+    const res = await post(PREVIEW, { rows });
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects an empty batch', async () => {
+    const res = await post(PREVIEW, { rows: [] });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('POST /devices/custom-fields/import{,/preview} — auth band', () => {
+  it('rejects an X-API-Key caller on both routes', async () => {
+    for (const path of BOTH) {
+      const res = await app().request(path, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-API-Key': 'brz_test' },
+        body: JSON.stringify({ rows: [row()] }),
+      });
+      expect(res.status).toBe(401);
+    }
+    expect(previewMock).not.toHaveBeenCalled();
+    expect(commitMock).not.toHaveBeenCalled();
+  });
+
+  it('403s a caller whose token has not satisfied MFA, on both routes', async () => {
+    authRef.current.token = { mfa: false };
+    for (const path of BOTH) {
+      const res = await post(path, { rows: [row()] });
+      expect(res.status).toBe(403);
+      expect(await res.json()).toMatchObject({ code: 'MFA_REQUIRED' });
+    }
+    expect(requireMfaSpy).toHaveBeenCalledTimes(2);
+    expect(previewMock).not.toHaveBeenCalled();
+    expect(commitMock).not.toHaveBeenCalled();
+  });
+
+  it('requires the DEVICE write grant, not the organization one', async () => {
+    // Wrong grant here would make the importer a cheaper path to a device write
+    // than the endpoint it bulk-loads.
+    // One shared middleware instance, used by both routes — so this is the ONLY
+    // grant the router asks for, on either path.
+    expect(grantsRequested).toEqual([['devices', 'write']]);
+  });
+
+  it('403s a caller without the device write permission, on both routes', async () => {
+    permissionDenied.current = true;
+    for (const path of BOTH) {
+      const res = await post(path, { rows: [row()] });
+      expect(res.status).toBe(403);
+    }
+    expect(previewMock).not.toHaveBeenCalled();
+    expect(commitMock).not.toHaveBeenCalled();
+  });
+
+  it('403s an org token naming another partner in the body', async () => {
+    setOrgAuth();
+    for (const path of BOTH) {
+      const res = await post(path, { partnerId: OTHER_PARTNER, rows: [row()] });
+      expect(res.status).toBe(403);
+      expect(await res.json()).toMatchObject({ error: 'Access denied to this partner' });
+    }
+    expect(previewMock).not.toHaveBeenCalled();
+    expect(commitMock).not.toHaveBeenCalled();
+  });
+
+  it('403s when the permissions context is missing rather than importing with no site bound', async () => {
+    // RLS never covered the site axis, so an absent allowlist must deny, never
+    // degrade into "unrestricted".
+    permissionsRef.current = undefined;
+    const res = await post(PREVIEW, { rows: [row()] });
+    expect(res.status).toBe(403);
+    expect(previewMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /devices/custom-fields/import{,/preview} — context handed to the service', () => {
+  it('carries the caller partner, org allowlist and SITE allowlist', async () => {
+    permissionsRef.current = { allowedSiteIds: ['site-1'] };
+
+    await post(PREVIEW, { rows: [row()] });
+
+    expect(previewMock.mock.calls[0]![1]).toMatchObject({
+      partnerId: PARTNER,
+      accessibleOrgIds: [ORG],
+      allowedSiteIds: ['site-1'],
+      mode: 'skip',
+      overrideProviderWarranty: false,
+    });
+  });
+
+  it('passes null (not undefined) for an unrestricted site axis', async () => {
+    await post(PREVIEW, { rows: [row()] });
+    // `loadDeviceResolutionSnapshot` THROWS on undefined rather than widening.
+    expect(previewMock.mock.calls[0]![1].allowedSiteIds).toBeNull();
+  });
+
+  it('defaults the mode to skip and the warranty override to off', async () => {
+    await post(COMMIT, { rows: [row()] });
+    expect(commitMock.mock.calls[0]![1]).toMatchObject({ mode: 'skip', overrideProviderWarranty: false });
+  });
+
+  it('honours an explicit update mode and warranty override', async () => {
+    await post(COMMIT, { rows: [row()], mode: 'update', overrideProviderWarranty: true });
+    expect(commitMock.mock.calls[0]![1]).toMatchObject({ mode: 'update', overrideProviderWarranty: true });
+  });
+});
+
+describe('POST /devices/custom-fields/import — wire schema', () => {
+  it('accepts a warranty mapping target', async () => {
+    const res = await post(PREVIEW, {
+      rows: [row({ values: [{ target: { kind: 'warranty', field: 'warrantyEndDate' }, value: '2027-03-04' }] })],
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects an unknown warranty field', async () => {
+    const res = await post(PREVIEW, {
+      rows: [row({ values: [{ target: { kind: 'warranty', field: 'isSubscription' }, value: true }] })],
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects an unknown mapping kind', async () => {
+    const res = await post(PREVIEW, {
+      rows: [row({ values: [{ target: { kind: 'tags', fieldKey: 'x' }, value: 'y' }] })],
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects an ambiguous acknowledgement with no expectedDeviceId at the wire', async () => {
+    const res = await post(COMMIT, { rows: [row({ expectedOutcome: 'ambiguous' })] });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/expectedDeviceId/i);
+    expect(commitMock).not.toHaveBeenCalled();
+  });
+
+  it('accepts an ambiguous acknowledgement that carries the pin', async () => {
+    const res = await post(COMMIT, { rows: [row({ expectedOutcome: 'ambiguous', expectedDeviceId: DEVICE })] });
+    expect(res.status).toBe(200);
+  });
+
+  it('STRIPS an acknowledgement field on the PREVIEW route rather than honouring it', async () => {
+    // Preview is advisory and writes nothing. The preview row schema has no
+    // acknowledgement fields, so zod removes them — the service can never see a
+    // pin from this route and therefore cannot silently apply one.
+    const res = await post(PREVIEW, { rows: [row({ expectedDeviceId: DEVICE, expectedOutcome: 'ambiguous' })] });
+
+    expect(res.status).toBe(200);
+    expect(previewMock.mock.calls[0]![0][0]).not.toHaveProperty('expectedDeviceId');
+    expect(previewMock.mock.calls[0]![0][0]).not.toHaveProperty('expectedOutcome');
+  });
+});
+
+describe('POST /devices/custom-fields/import — response contract', () => {
+  it('returns 200 with a partial summary, never a failure body', async () => {
+    commitMock.mockResolvedValue({
+      appliedValues: 28,
+      skippedValues: 0,
+      failedValues: 2,
+      linksCreated: 1,
+      rows: [{
+        index: 0, deviceId: DEVICE, organizationId: ORG, method: 'hostname', externalSystem: 'datto_rmm',
+        applied: 28, skipped: 0, failed: 2, appliedFieldKeys: ['asset_tag'], warranty: 'applied', linkCreated: true,
+      }],
+      errors: [{ index: 1, error: 'No device in reach matches the identifiers on this row', code: 'not-found' }],
+    });
+
+    const res = await post(COMMIT, { rows: [row(), row({ hostname: 'ghost' })] });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({ appliedValues: 28, linksCreated: 1 });
+    expect(body.errors[0]).toMatchObject({ code: 'not-found' });
+    expect(body).not.toHaveProperty('success');
+  });
+
+  it('writes the audits from the summary, carrying the batch row count', async () => {
+    await post(COMMIT, { rows: [row(), row()], externalSystem: 'datto_rmm' });
+    expect(auditMock).toHaveBeenCalledTimes(1);
+    expect(auditMock.mock.calls[0]![1]).toMatchObject({ rowCount: 2, externalSystem: 'datto_rmm' });
+  });
+
+  it('still returns the summary when the audit fan-out throws', async () => {
+    // The rows are already committed by then. A 500 here would describe a
+    // request that in fact succeeded.
+    auditMock.mockImplementation(() => { throw new Error('audit down'); });
+    const res = await post(COMMIT, { rows: [row()] });
+    expect(res.status).toBe(200);
+  });
+
+  it('preview writes nothing and never audits', async () => {
+    await post(PREVIEW, { rows: [row()] });
+    expect(commitMock).not.toHaveBeenCalled();
+    expect(auditMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/routes/devices/customFieldImport.test.ts
+++ b/apps/api/src/routes/devices/customFieldImport.test.ts
@@ -302,6 +302,35 @@ describe('POST /devices/custom-fields/import — wire schema', () => {
     expect(res.status).toBe(400);
   });
 
+  it('rejects a row that maps two columns onto the same target', async () => {
+    // A duplicate is not one bad cell — the column-to-target mapping is chosen
+    // once for the whole file, so it would repeat on every row and the last
+    // column would silently win.
+    for (const path of BOTH) {
+      const res = await post(path, { rows: [row({ values: [value('asset_tag', 'A'), value('asset_tag', 'B')] })] });
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toMatch(/same custom field or warranty field/i);
+    }
+    expect(previewMock).not.toHaveBeenCalled();
+    expect(commitMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a row that maps the same WARRANTY field twice', async () => {
+    const warranty = (v: string) => ({ target: { kind: 'warranty', field: 'warrantyEndDate' }, value: v });
+    const res = await post(PREVIEW, { rows: [row({ values: [warranty('2027-01-01'), warranty('2028-01-01')] })] });
+    expect(res.status).toBe(400);
+  });
+
+  it('accepts two DIFFERENT warranty fields on one row', async () => {
+    const res = await post(PREVIEW, {
+      rows: [row({ values: [
+        { target: { kind: 'warranty', field: 'warrantyEndDate' }, value: '2027-01-01' },
+        { target: { kind: 'warranty', field: 'manufacturer' }, value: 'Dell' },
+      ] })],
+    });
+    expect(res.status).toBe(200);
+  });
+
   it('rejects an unknown mapping kind', async () => {
     const res = await post(PREVIEW, {
       rows: [row({ values: [{ target: { kind: 'tags', fieldKey: 'x' }, value: 'y' }] })],

--- a/apps/api/src/routes/devices/customFieldImport.ts
+++ b/apps/api/src/routes/devices/customFieldImport.ts
@@ -9,6 +9,7 @@ import {
   type AuthContext,
 } from '../../middleware/auth';
 import { PERMISSIONS, type UserPermissions } from '../../services/permissions';
+import { captureException } from '../../services/sentry';
 import { resolveImportPartnerId } from '../importScope';
 import {
   commitDeviceCustomFieldImport,
@@ -20,6 +21,8 @@ import {
   DEFAULT_IMPORT_SYSTEM,
   MAX_IMPORT_ROWS,
   MAX_IMPORT_VALUES,
+  type MappingTarget,
+  type WarrantyImportField,
 } from '../../services/customFields/import/types';
 
 /**
@@ -64,7 +67,20 @@ const requireDeviceWrite = requirePermission(
   PERMISSIONS.DEVICES_WRITE.action,
 );
 
-const WARRANTY_FIELDS = ['warrantyStartDate', 'warrantyEndDate', 'manufacturer'] as const;
+/**
+ * `satisfies Record<WarrantyImportField, true>` is the COMPILE-TIME TIE between
+ * this hand-written wire schema and the domain union. Without it the schema is a
+ * mirror maintained by prose: a new `WarrantyImportField` would still typecheck
+ * everywhere (a narrower literal union is always assignable to a wider one) and
+ * would simply be unselectable from the wire, silently, forever.
+ */
+const WARRANTY_FIELD_SET = {
+  warrantyStartDate: true,
+  warrantyEndDate: true,
+  manufacturer: true,
+} as const satisfies Record<WarrantyImportField, true>;
+
+const WARRANTY_FIELDS = Object.keys(WARRANTY_FIELD_SET) as [WarrantyImportField, ...WarrantyImportField[]];
 
 const ROW_CAP_MESSAGE =
   `At most ${MAX_IMPORT_ROWS} device rows per request — split the file into chunks`;
@@ -87,6 +103,34 @@ const mappingTargetSchema = z.discriminatedUnion('kind', [
   z.object({ kind: z.literal('customField'), fieldKey: z.string().min(1).max(100) }),
   z.object({ kind: z.literal('warranty'), field: z.enum(WARRANTY_FIELDS) }),
 ]);
+
+/** The other direction: the wire may never parse a target the domain cannot express. */
+type _WireTargetIsADomainTarget = z.infer<typeof mappingTargetSchema> extends MappingTarget ? true : never;
+const _wireTargetIsADomainTarget: _WireTargetIsADomainTarget = true;
+void _wireTargetIsADomainTarget;
+
+const DUPLICATE_TARGET_MESSAGE =
+  'Two columns on this row are mapped to the same custom field or warranty field — '
+  + 'each target may be mapped at most once';
+
+/**
+ * One row may not map the same target twice.
+ *
+ * Refused here, not annotated per value, because the column-to-target mapping is
+ * chosen ONCE for the whole file: a duplicate is not one bad cell, it is a
+ * mis-configured wizard step that would repeat on every row. Silently letting it
+ * through means the last column wins and the operator is never told which of
+ * their two columns the device actually holds.
+ */
+function targetsAreUnique(row: { values: Array<{ target: z.infer<typeof mappingTargetSchema> }> }): boolean {
+  const seen = new Set<string>();
+  for (const { target } of row.values) {
+    const key = target.kind === 'customField' ? `field\u0000${target.fieldKey}` : `warranty\u0000${target.field}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+  }
+  return true;
+}
 
 // Mirrors `customFieldValueSchema` in `routes/devices/customFieldValues.ts`, so
 // a bulk write cannot carry a value the single PATCH would reject on size.
@@ -113,7 +157,9 @@ const importRowFields = {
   values: z.array(importValueSchema).max(MAX_IMPORT_VALUES),
 };
 
-const previewRowSchema = z.object(importRowFields);
+const previewRowSchema = z
+  .object(importRowFields)
+  .refine(targetsAreUnique, { message: DUPLICATE_TARGET_MESSAGE, path: ['values'] });
 
 /**
  * A row as submitted to a COMMIT. Both acknowledgements are re-checked against
@@ -135,7 +181,8 @@ const commitRowSchema = z
   .refine(
     (row) => row.expectedOutcome !== 'ambiguous' || row.expectedDeviceId !== undefined,
     { message: AMBIGUOUS_NEEDS_PIN, path: ['expectedDeviceId'] },
-  );
+  )
+  .refine(targetsAreUnique, { message: DUPLICATE_TARGET_MESSAGE, path: ['values'] });
 
 /**
  * The row cap alone does not bound the work: 1000 rows x 30 values is 30,000
@@ -265,6 +312,12 @@ customFieldImportRoutes.post(
         devices: summary.rows.length,
         error: err instanceof Error ? err.message : String(err),
       });
+      // Reaching here means a bug in the fan-out itself (the persistence below
+      // it is decoupled and self-healing), and it drops the provenance trail for
+      // a whole import batch. A log line alone would need someone grepping for
+      // it; `auditService.enqueueForRetry` pages for a lost audit event for the
+      // same reason.
+      captureException(err);
     }
 
     return c.json(summary);

--- a/apps/api/src/routes/devices/customFieldImport.ts
+++ b/apps/api/src/routes/devices/customFieldImport.ts
@@ -1,0 +1,272 @@
+import { Hono } from 'hono';
+import { z } from 'zod';
+import { zValidator } from '../../lib/validation';
+import {
+  authMiddleware,
+  requireMfa,
+  requirePermission,
+  requireScope,
+  type AuthContext,
+} from '../../middleware/auth';
+import { PERMISSIONS, type UserPermissions } from '../../services/permissions';
+import { resolveImportPartnerId } from '../importScope';
+import {
+  commitDeviceCustomFieldImport,
+  previewDeviceCustomFieldImport,
+  type ValueImportContext,
+} from '../../services/customFields/import/valueImport';
+import { writeCustomFieldValueImportAudits } from '../../services/customFields/import/audit';
+import {
+  DEFAULT_IMPORT_SYSTEM,
+  MAX_IMPORT_ROWS,
+  MAX_IMPORT_VALUES,
+} from '../../services/customFields/import/types';
+
+/**
+ * The VALUES half of the RMM custom-field importer (#3257 W08):
+ * `POST /devices/custom-fields/import/preview` and
+ * `POST /devices/custom-fields/import`.
+ *
+ * Lives under `/devices` rather than beside the definitions pair
+ * (`routes/customFieldImport.ts`) because it is a different pipeline with
+ * different tenancy: definitions are dual-axis config owned by an organization
+ * XOR a partner, values are device-scoped rows in one organization.
+ *
+ * ── Auth wiring — PER-ROUTE, never `.use('*')` ──────────────────────────────
+ * A wildcard `.use('*')` in a sub-router attaches to every route mounted AFTER
+ * it in `devices/index.ts`. This router is mounted immediately after
+ * `customFieldValuesRoutes`, whose X-API-Key branch a wildcard here would
+ * shadow and whose 401 it would resurrect (issue #2066) — so the middleware is
+ * attached per route and `customFieldImport.mountorder.test.ts` proves, through
+ * the fully-assembled router, that the API-key PATCH still reaches its handler.
+ *
+ * ── What is deliberately NOT here ───────────────────────────────────────────
+ * There is **no `dualAuth` / X-API-Key branch**, matching W07. `dualAuth`
+ * applies `requireMfa` only on the JWT branch and skips the site allowlist for
+ * API keys; an unattended integration is not a user of a one-off migration
+ * tool. With plain `authMiddleware` an X-API-Key-only request never
+ * authenticates at all — a 401, which is the intended answer.
+ *
+ * ── Always 200 ─────────────────────────────────────────────────────────────
+ * Both routes answer 200 even with a non-empty `errors[]`. The web caller
+ * consumes them through `runAction`, which reads a failure body as a hard
+ * failure and would hide the rows that DID import. Per-row problems ride as
+ * typed `errors[].code`, never free text.
+ */
+
+export const customFieldImportRoutes = new Hono();
+
+// The same grant the device custom-field VALUE write path requires
+// (`routes/devices/customFieldValues.ts`). An importer must not be a cheaper
+// way to reach a write than the endpoint it bulk-loads.
+const requireDeviceWrite = requirePermission(
+  PERMISSIONS.DEVICES_WRITE.resource,
+  PERMISSIONS.DEVICES_WRITE.action,
+);
+
+const WARRANTY_FIELDS = ['warrantyStartDate', 'warrantyEndDate', 'manufacturer'] as const;
+
+const ROW_CAP_MESSAGE =
+  `At most ${MAX_IMPORT_ROWS} device rows per request — split the file into chunks`;
+const VALUE_CAP_MESSAGE =
+  `At most ${MAX_IMPORT_VALUES} values per request — split the file into smaller chunks`;
+const AMBIGUOUS_NEEDS_PIN =
+  'expectedDeviceId is required when expectedOutcome is "ambiguous"';
+
+/**
+ * Where one mapped column lands. Mirrors `MappingTarget`, so the parsed body
+ * matches the service's own union exactly and nothing downstream re-checks it.
+ *
+ * `fieldKey` deliberately carries NO `^[a-z][a-z0-9_]*$` regex, unlike the
+ * definitions importer's create rows. A key that could never own a definition
+ * simply has none, and the value is annotated `no-definition` — one bad column
+ * header in a thirty-column file must not 400 the whole batch, which is the
+ * entire reason this importer annotates per value.
+ */
+const mappingTargetSchema = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('customField'), fieldKey: z.string().min(1).max(100) }),
+  z.object({ kind: z.literal('warranty'), field: z.enum(WARRANTY_FIELDS) }),
+]);
+
+// Mirrors `customFieldValueSchema` in `routes/devices/customFieldValues.ts`, so
+// a bulk write cannot carry a value the single PATCH would reject on size.
+const importValueSchema = z.object({
+  target: mappingTargetSchema,
+  value: z.union([z.string().max(10000), z.number(), z.boolean(), z.null()]),
+});
+
+/**
+ * Identifiers are all optional and none is required. A row that supplies none
+ * resolves to `not-found` and is reported as such — the same treatment as a row
+ * whose identifiers matched nothing, and far more useful to an operator with a
+ * mis-mapped join column than a 400 naming a row index.
+ */
+const importRowFields = {
+  organizationId: z.string().guid().nullish(),
+  deviceId: z.string().guid().nullish(),
+  externalSystem: z.string().min(1).max(64).nullish(),
+  externalId: z.string().min(1).max(255).nullish(),
+  /** Reserved discriminator for the external-link key; always null today. */
+  externalSourceInstance: z.string().min(1).max(255).nullish(),
+  serialNumber: z.string().max(255).nullish(),
+  hostname: z.string().max(255).nullish(),
+  values: z.array(importValueSchema).max(MAX_IMPORT_VALUES),
+};
+
+const previewRowSchema = z.object(importRowFields);
+
+/**
+ * A row as submitted to a COMMIT. Both acknowledgements are re-checked against
+ * freshly derived state, so a stale one is refused rather than applied.
+ *
+ * `expectedDeviceId` is REQUIRED for `ambiguous`: without it the
+ * acknowledgement says "apply this" without saying to WHOM, and an approval
+ * given for device A would be honoured against device B if the candidate set
+ * moved between preview and commit.
+ */
+const commitRowSchema = z
+  .object({
+    ...importRowFields,
+    expectedOutcome: z
+      .enum(['matched', 'link-match', 'ambiguous', 'not-found', 'org-not-found', 'identity-conflict'])
+      .optional(),
+    expectedDeviceId: z.string().guid().optional(),
+  })
+  .refine(
+    (row) => row.expectedOutcome !== 'ambiguous' || row.expectedDeviceId !== undefined,
+    { message: AMBIGUOUS_NEEDS_PIN, path: ['expectedDeviceId'] },
+  );
+
+/**
+ * The row cap alone does not bound the work: 1000 rows x 30 values is 30,000
+ * writes in one request. Both caps are enforced here, with copy that tells the
+ * browser to SPLIT rather than merely refusing it.
+ */
+function rowsSchema<T extends z.ZodTypeAny>(row: T) {
+  return z
+    .array(row)
+    .min(1)
+    .max(MAX_IMPORT_ROWS, ROW_CAP_MESSAGE)
+    .refine(
+      (rows) => rows.reduce((total, r) => total + (r as { values: unknown[] }).values.length, 0) <= MAX_IMPORT_VALUES,
+      { message: VALUE_CAP_MESSAGE },
+    );
+}
+
+const importOptionFields = {
+  partnerId: z.string().guid().optional(),
+  /** Free-form on the wire (see IMPORT_SYSTEMS); recorded in the audit trail. */
+  externalSystem: z.string().min(1).max(64).default(DEFAULT_IMPORT_SYSTEM),
+  /** Verbatim from the contacts importer, including the default. */
+  mode: z.enum(['skip', 'update']).default('skip'),
+  /** Decision 7: an operator opt-in, off by default. */
+  overrideProviderWarranty: z.boolean().default(false),
+};
+
+const previewImportSchema = z.object({ ...importOptionFields, rows: rowsSchema(previewRowSchema) });
+const commitImportSchema = z.object({ ...importOptionFields, rows: rowsSchema(commitRowSchema) });
+
+type ImportBody = z.infer<typeof previewImportSchema>;
+
+/**
+ * Resolve the partner and the caller's reach.
+ *
+ * The site allowlist is carried explicitly because RLS NEVER covered the site
+ * axis — the predicate W06's snapshot loader builds from it is its only
+ * enforcement. A missing `permissions` context on this path means a gate was
+ * dropped upstream (every route here runs `requirePermission`), so it denies
+ * rather than degrading into "no site restriction", mirroring
+ * `loadAccessibleDevice`'s fail-closed stance in `customFieldValues.ts`.
+ *
+ * `accessibleOrgIds` travels with the request for the same reason it does in
+ * W07: the resolution snapshot READ runs in a SYSTEM db context, so RLS is not
+ * the boundary on it and this is. Null is system scope; for an organization
+ * token it is that single org, which is what makes admitting that scope safe —
+ * a row naming any other organization comes back `org-not-found` and writes
+ * nothing, the same answer an organization that does not exist gets, so the
+ * response is never an existence oracle.
+ */
+function resolveValueImportContext(
+  auth: AuthContext,
+  permissions: UserPermissions | undefined,
+  body: ImportBody,
+): ValueImportContext | { error: string; status: 400 | 403 } {
+  const resolved = resolveImportPartnerId(auth, body.partnerId, 'device custom fields');
+  if ('error' in resolved) return resolved;
+
+  if (!permissions) {
+    return { error: 'Access denied', status: 403 };
+  }
+
+  return {
+    partnerId: resolved.partnerId,
+    accessibleOrgIds: auth.accessibleOrgIds ?? null,
+    allowedSiteIds: permissions.allowedSiteIds ?? null,
+    mode: body.mode,
+    overrideProviderWarranty: body.overrideProviderWarranty,
+  };
+}
+
+customFieldImportRoutes.post(
+  '/custom-fields/import/preview',
+  authMiddleware,
+  // `organization` must be in this list: an org-scoped token carries a
+  // partnerId and its single-org allowlist bounds the reach, matching W07.
+  requireScope('organization', 'partner', 'system'),
+  requireDeviceWrite,
+  // A bulk backfill across a partner's whole fleet is exactly the operation
+  // that should need it.
+  requireMfa(),
+  zValidator('json', previewImportSchema),
+  async (c) => {
+    const auth = c.get('auth') as AuthContext;
+    const body = c.req.valid('json');
+    const ctx = resolveValueImportContext(auth, c.get('permissions') as UserPermissions | undefined, body);
+    if ('error' in ctx) return c.json({ error: ctx.error }, ctx.status);
+
+    return c.json({ rows: await previewDeviceCustomFieldImport(body.rows, ctx) });
+  },
+);
+
+customFieldImportRoutes.post(
+  '/custom-fields/import',
+  authMiddleware,
+  requireScope('organization', 'partner', 'system'),
+  requireDeviceWrite,
+  requireMfa(),
+  zValidator('json', commitImportSchema),
+  async (c) => {
+    const auth = c.get('auth') as AuthContext;
+    const body = c.req.valid('json');
+    const ctx = resolveValueImportContext(auth, c.get('permissions') as UserPermissions | undefined, body);
+    if ('error' in ctx) return c.json({ error: ctx.error }, ctx.status);
+
+    const summary = await commitDeviceCustomFieldImport(body.rows, ctx, { userId: auth.user?.id ?? null });
+
+    // The service has no Hono context, so the route fans the audits out from
+    // the summary.
+    //
+    // Guarded, unlike a plain CRUD route's single `writeRouteAudit`: the rows
+    // are ALREADY COMMITTED by this point and `writeAuditEventAsync` does its
+    // payload sanitisation synchronously on this stack. A throw from that
+    // prelude would escape as a 500 describing a request that in fact
+    // succeeded — the exact "hide the rows that DID import" failure the
+    // always-200 contract exists to prevent. Losing an audit event is bad;
+    // misreporting a successful import as a total failure is worse, and the
+    // loss is loud in the log either way.
+    try {
+      writeCustomFieldValueImportAudits(c, {
+        summary,
+        rowCount: body.rows.length,
+        externalSystem: body.externalSystem,
+      });
+    } catch (err) {
+      console.error('[device-custom-field-import] audit write failed', {
+        devices: summary.rows.length,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+
+    return c.json(summary);
+  },
+);

--- a/apps/api/src/routes/devices/index.ts
+++ b/apps/api/src/routes/devices/index.ts
@@ -27,6 +27,7 @@ import { softwareActionsRoutes } from './softwareActions';
 import { homebrewBootstrapRoutes } from './homebrewBootstrap';
 import { networkRoutes } from './network';
 import { customFieldValuesRoutes } from './customFieldValues';
+import { customFieldImportRoutes } from './customFieldImport';
 import { linksRoutes } from './links';
 import { statsRoutes } from './stats';
 import { postureRoutes } from './posture';
@@ -45,6 +46,17 @@ export const deviceRoutes = new Hono();
 // JWT-only `authMiddleware` and resurrect the 401. Mounting first keeps them
 // clear of every later wildcard auth middleware.
 deviceRoutes.route('/', customFieldValuesRoutes);
+
+// Mount the RMM custom-field VALUE importer (#3257 W08) immediately after them,
+// and BEFORE coreRoutes. Two reasons, both pinned by
+// customFieldImport.mountorder.test.ts:
+//  - `/custom-fields/import*` is a static path that must not be reached through
+//    any later `/:id` matcher.
+//  - This router uses PER-ROUTE auth and must never grow a `.use('*')`: a
+//    wildcard here would attach to every route mounted after it, and — mounted
+//    where it is — would be the same #2066 shadowing of the API-key branch that
+//    the comment above exists to prevent.
+deviceRoutes.route('/', customFieldImportRoutes);
 
 // Mount the server-backed selector before coreRoutes so the static `/options`
 // path cannot be consumed by core's `GET /:id` matcher.

--- a/apps/api/src/services/customFields/import/audit.test.ts
+++ b/apps/api/src/services/customFields/import/audit.test.ts
@@ -4,12 +4,18 @@ const { writeRouteAuditMock } = vi.hoisted(() => ({ writeRouteAuditMock: vi.fn()
 
 vi.mock('../../auditEvents', () => ({ writeRouteAudit: writeRouteAuditMock }));
 
-import { writeCustomFieldDefinitionImportAudits } from './audit';
-import type { CustomFieldDefinitionImportRow, DefinitionImportSummary } from './types';
+import { writeCustomFieldDefinitionImportAudits, writeCustomFieldValueImportAudits } from './audit';
+import type {
+  CustomFieldDefinitionImportRow,
+  DefinitionImportSummary,
+  ValueImportSummary,
+} from './types';
 
 const DEF_A = '33333333-3333-4333-8333-333333333333';
 const DEF_B = '44444444-4444-4444-8444-444444444444';
 const ORG = '11111111-1111-4111-8111-111111111111';
+const D1 = 'dddddddd-dddd-4ddd-8ddd-ddddddddddd1';
+const D2 = 'dddddddd-dddd-4ddd-8ddd-ddddddddddd2';
 
 const c = {} as never;
 
@@ -87,6 +93,123 @@ describe('writeCustomFieldDefinitionImportAudits', () => {
     writeCustomFieldDefinitionImportAudits(c, {
       summary: { created: [], skipped: [], errors: [{ index: 0, fieldKey: 'udf7', error: 'x', code: 'type-conflict' }] },
       rows,
+      externalSystem: 'csv',
+    });
+    expect(writeRouteAuditMock).not.toHaveBeenCalled();
+  });
+});
+
+/* ── W08: the values half (#4776) ─────────────────────────────────────────── */
+
+function valueSummary(overrides: Partial<ValueImportSummary> = {}): ValueImportSummary {
+  return {
+    appliedValues: 2,
+    skippedValues: 0,
+    failedValues: 0,
+    linksCreated: 1,
+    errors: [],
+    rows: [
+      {
+        index: 0,
+        deviceId: D1,
+        organizationId: ORG,
+        method: 'hostname',
+        externalSystem: 'datto_rmm',
+        applied: 1,
+        skipped: 0,
+        failed: 0,
+        appliedFieldKeys: ['asset_tag'],
+        warranty: 'none',
+        linkCreated: true,
+      },
+      {
+        index: 1,
+        deviceId: D2,
+        organizationId: ORG,
+        method: 'link',
+        externalSystem: null,
+        applied: 1,
+        skipped: 0,
+        failed: 0,
+        appliedFieldKeys: [],
+        warranty: 'applied',
+        linkCreated: false,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('writeCustomFieldValueImportAudits', () => {
+  it('audits every backfilled device with its resolution method', () => {
+    writeCustomFieldValueImportAudits(c, { summary: valueSummary(), rowCount: 4, externalSystem: 'csv' });
+
+    expect(writeRouteAuditMock).toHaveBeenCalledTimes(2);
+    expect(writeRouteAuditMock.mock.calls[0]![1]).toEqual({
+      orgId: ORG,
+      action: 'device.custom_field.import',
+      resourceType: 'device',
+      resourceId: D1,
+      details: {
+        source: 'device_custom_field_import',
+        externalSystem: 'datto_rmm',
+        resolutionMethod: 'hostname',
+        // Field KEYS only. A value can be anything the incumbent held and must
+        // never enter an audit payload.
+        changedFields: ['asset_tag'],
+        warranty: 'none',
+        linkCreated: true,
+        rowCount: 4,
+      },
+    });
+  });
+
+  it("falls back to the batch's external system when the row named none", () => {
+    writeCustomFieldValueImportAudits(c, { summary: valueSummary(), rowCount: 4, externalSystem: 'ninjaone' });
+    expect(writeRouteAuditMock.mock.calls[1]![1]).toMatchObject({
+      resourceId: D2,
+      details: expect.objectContaining({ externalSystem: 'ninjaone', resolutionMethod: 'link', warranty: 'applied' }),
+    });
+  });
+
+  it('never puts a VALUE in the payload — only field keys', () => {
+    writeCustomFieldValueImportAudits(c, { summary: valueSummary(), rowCount: 4, externalSystem: 'csv' });
+    const payload = JSON.stringify(writeRouteAuditMock.mock.calls.map((call) => call[1]));
+    expect(payload).toContain('asset_tag');
+    expect(payload).not.toMatch(/AB-1|serial|hostname"\s*:/i);
+  });
+
+  it('does not audit a row where nothing was applied', () => {
+    // A row the commit left untouched (a re-import of an unchanged file) is not
+    // a backfill; auditing it would bury the real writes on every re-run.
+    const summary = valueSummary();
+    summary.rows[0]!.applied = 0;
+    summary.rows[1]!.applied = 0;
+
+    writeCustomFieldValueImportAudits(c, { summary, rowCount: 4, externalSystem: 'csv' });
+
+    expect(writeRouteAuditMock).not.toHaveBeenCalled();
+  });
+
+  it('still audits a row whose only change was the warranty target', () => {
+    const summary = valueSummary({ rows: [] });
+    summary.rows = [{
+      index: 0, deviceId: D1, organizationId: ORG, method: 'serial', externalSystem: 'n_central',
+      applied: 1, skipped: 0, failed: 0, appliedFieldKeys: [], warranty: 'applied', linkCreated: false,
+    }];
+
+    writeCustomFieldValueImportAudits(c, { summary, rowCount: 1, externalSystem: 'csv' });
+
+    expect(writeRouteAuditMock).toHaveBeenCalledTimes(1);
+    expect(writeRouteAuditMock.mock.calls[0]![1]).toMatchObject({
+      details: expect.objectContaining({ changedFields: [], warranty: 'applied', resolutionMethod: 'serial' }),
+    });
+  });
+
+  it('writes nothing when the commit wrote nothing', () => {
+    writeCustomFieldValueImportAudits(c, {
+      summary: valueSummary({ rows: [], appliedValues: 0, linksCreated: 0 }),
+      rowCount: 3,
       externalSystem: 'csv',
     });
     expect(writeRouteAuditMock).not.toHaveBeenCalled();

--- a/apps/api/src/services/customFields/import/audit.ts
+++ b/apps/api/src/services/customFields/import/audit.ts
@@ -22,7 +22,11 @@
  */
 
 import { writeRouteAudit, type AuthContext as AuditRouteContext } from '../../auditEvents';
-import type { CustomFieldDefinitionImportRow, DefinitionImportSummary } from './types';
+import type {
+  CustomFieldDefinitionImportRow,
+  DefinitionImportSummary,
+  ValueImportSummary,
+} from './types';
 
 export interface DefinitionImportAuditInput {
   summary: DefinitionImportSummary;
@@ -56,6 +60,63 @@ export function writeCustomFieldDefinitionImportAudits(
         ...(row?.sourceLabel ? { sourceLabel: row.sourceLabel } : {}),
         fieldKey: entry.fieldKey,
         ownerScope: entry.ownerScope,
+        rowCount,
+      },
+    });
+  }
+}
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * W08 — the VALUES half (#4776)
+ *
+ * Same reason for living here as the definitions half above:
+ * `commitDeviceCustomFieldImport` has no Hono context, so the route fans the
+ * events out from the returned summary.
+ *
+ * WHAT THIS ONE HAS TO CARRY, and why: after a migration off Datto RMM the
+ * question is "where did this asset tag come from, and how did the importer
+ * decide it belonged to THIS device?". The answer is the resolution METHOD —
+ * an exact `id`/`link` match and a fuzzy `hostname` match are very different
+ * grounds for a value an MSP may later bill or act on — together with the
+ * system the file came from and the row count of the batch it arrived in.
+ *
+ * Field KEYS only, never values: a custom-field value can be anything the
+ * incumbent held, and `customFieldValues.ts` and `scriptWriteBack.ts` already
+ * apply the same rule on their own write paths.
+ *
+ * Rows where nothing was applied are deliberately not audited. They are the
+ * rows the commit left untouched — a re-import of an unchanged file is entirely
+ * such rows, and one event each would bury the real writes.
+ * ────────────────────────────────────────────────────────────────────────── */
+
+export interface ValueImportAuditInput {
+  summary: ValueImportSummary;
+  /** Rows SUBMITTED, not rows written — the batch an operator would recognise. */
+  rowCount: number;
+  /** The batch-level system, used when a row did not name its own. */
+  externalSystem: string;
+}
+
+/** One event per device the import actually backfilled. */
+export function writeCustomFieldValueImportAudits(
+  c: AuditRouteContext,
+  { summary, rowCount, externalSystem }: ValueImportAuditInput,
+): void {
+  for (const row of summary.rows) {
+    if (row.applied === 0) continue;
+
+    writeRouteAudit(c, {
+      orgId: row.organizationId,
+      action: 'device.custom_field.import',
+      resourceType: 'device',
+      resourceId: row.deviceId,
+      details: {
+        source: 'device_custom_field_import',
+        externalSystem: row.externalSystem ?? externalSystem,
+        resolutionMethod: row.method,
+        changedFields: row.appliedFieldKeys,
+        warranty: row.warranty,
+        linkCreated: row.linkCreated,
         rowCount,
       },
     });

--- a/apps/api/src/services/customFields/import/types.ts
+++ b/apps/api/src/services/customFields/import/types.ts
@@ -389,9 +389,17 @@ export type ValueRowOutcome = DeviceRowOutcome;
  *
  * - `applied` — written (or, at preview, would be written).
  * - `skipped-already-set` — a value is already stored for this target on this
- *   device. Covers BOTH "the stored value is identical" (a re-import: a no-op
- *   in either mode) and "the stored value differs and the mode is `skip`", so
- *   the operator sees one honest reason instead of two synonyms.
+ *   device, and writing would change nothing OR the mode is `skip`. Covers BOTH
+ *   "the stored value is identical" (a re-import: a no-op in either mode) and
+ *   "the stored value differs and the default `skip` mode declines to overwrite
+ *   it" — one honest reason instead of two synonyms for "nothing to do here".
+ * - `skipped-provider-owned` — WARRANTY only. A manufacturer API lookup
+ *   (`data_source = 'provider'`) owns this device's warranty and the operator
+ *   did not opt into overriding it. Its OWN member rather than
+ *   `skipped-already-set`: "already correct, nothing to do" and "refused, and
+ *   there is a switch you can flip" are different messages to show a tech, and
+ *   a consumer branching on `outcome` must not have to parse a warning string
+ *   to tell them apart. Mirrors `WarrantyImportOutcome` one layer up.
  * - `no-definition` — no `custom_field_definitions` row visible to this
  *   device's organization owns this key. Run the DEFINITIONS import (W07) first.
  * - `type-error` — `validateCustomFieldValue` refused it; `reason` says how.
@@ -405,6 +413,7 @@ export type ValueRowOutcome = DeviceRowOutcome;
 export type ValueOutcome =
   | 'applied'
   | 'skipped-already-set'
+  | 'skipped-provider-owned'
   | 'no-definition'
   | 'type-error'
   | 'not-applicable-to-device'
@@ -424,22 +433,36 @@ export type CustomFieldImportRejection =
   | 'too_long'
   | 'invalid_date';
 
-export interface AnnotatedImportValue {
+/**
+ * Advisory, and genuinely ORTHOGONAL to `outcome` — several outcomes can carry
+ * one, so unlike `reason` it is not folded into an arm below. Today:
+ *
+ *  - on `applied`, the partner-integration identity keys (`asset_tag`,
+ *    `inventory_id`, `external_id` and their camelCase spellings), which
+ *    `routes/partnerApi/devices.ts` republishes as a device's
+ *    `stableIdentifiers` to every integration the partner has connected.
+ *    Writing them is intended; doing it fleet-wide without being told is not.
+ *  - on `skipped-provider-owned`, how to override the refusal.
+ */
+interface ImportValueAdvice {
   target: MappingTarget;
-  outcome: ValueOutcome;
-  /** Set on `type-error`. */
-  reason?: CustomFieldImportRejection;
-  /**
-   * Advisory, and ORTHOGONAL to `outcome` — an `applied` value carries one when
-   * the write has a consequence beyond the device. Today that is the
-   * partner-integration identity keys (`asset_tag`, `inventory_id`,
-   * `external_id`), which `routes/partnerApi/devices.ts` republishes as a
-   * device's `stableIdentifiers` to every integration the partner has
-   * connected. Writing them is intended; doing it fleet-wide without being told
-   * is not, so preview says so on the value.
-   */
   warning?: string;
 }
+
+/**
+ * `reason` is DISCRIMINATED onto the one outcome that has it, rather than being
+ * an optional field beside a comment — the same reasoning (and the same JSON
+ * shape, since every arm is literals and strings) as `DeviceResolution` above.
+ * A producer cannot mint `{ outcome: 'applied', reason: 'too_long' }`, and a
+ * consumer cannot read `reason` without first narrowing to `type-error`.
+ */
+export type AnnotatedImportValue = ImportValueAdvice & (
+  | { outcome: 'type-error'; reason: CustomFieldImportRejection }
+  | {
+      outcome: Exclude<ValueOutcome, 'type-error'>;
+      reason?: never;
+    }
+);
 
 export interface AnnotatedValueRow {
   index: number;
@@ -483,11 +506,20 @@ export type ValueImportErrorCode =
   | 'match-unconfirmed'
   | 'write-failed';
 
-/** What `applyWarrantyImport` did with a row's warranty columns. */
+/**
+ * What the row's warranty columns did, at ROW level.
+ *
+ * `none` means the file mapped no warranty column at all — never "it mapped one
+ * and nothing came of it". `rejected` is that second case: a warranty column WAS
+ * mapped and every mapped cell was refused (see the per-value outcomes for
+ * which). Collapsing the two would tell an operator their warranty column was
+ * never mapped when in fact it was read and thrown away.
+ */
 export type WarrantyImportOutcome =
   | 'applied'
   | 'skipped-provider-owned'
   | 'skipped-already-set'
+  | 'rejected'
   | 'none';
 
 export interface ValueImportRowResult {
@@ -532,6 +564,11 @@ export interface ValueImportSummary {
    * Counts VALUES, not rows. An operator cannot reconcile "30,000 in the file"
    * against "1,180 imported" otherwise — and a row count would hide the very
    * partial-application behaviour this importer is built around.
+   *
+   * MIND THE UNITS when totalling problems: `failedValues` counts values inside
+   * rows that DID reach a device, while a row refused outright (resolution or a
+   * stale acknowledgement) contributes nothing to it and appears only in
+   * `errors[]`, in ROW units. The two are not addable without converting.
    */
   appliedValues: number;
   skippedValues: number;

--- a/apps/api/src/services/customFields/import/types.ts
+++ b/apps/api/src/services/customFields/import/types.ts
@@ -122,9 +122,14 @@ export type DeviceResolution = DeviceResolutionEvidence & (
  * One value assignment on an import row. W08 owns the coercion and validation
  * rules; the resolver never reads this field, and only carries it so a row can
  * be passed through resolution and commit as one object.
+ *
+ * `target` (rather than the bare `fieldKey` this shipped with in W06) is what
+ * lets one mapped CSV column land somewhere other than a custom field — see
+ * `MappingTarget` in the W08 section below. W06 reserved the field's meaning
+ * for W08 and no code outside these types ever read it.
  */
 export interface DeviceCustomFieldImportValue {
-  fieldKey: string;
+  target: MappingTarget;
   value: unknown;
 }
 
@@ -333,4 +338,205 @@ export interface DefinitionImportSummary {
   created: DefinitionImportCreatedEntry[];
   skipped: DefinitionImportSkippedEntry[];
   errors: DefinitionImportErrorEntry[];
+}
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * W08 — values importer (#4776)
+ *
+ * The values pass is org-scoped and device-scoped: there is no ownership axis
+ * to choose, but there IS a second destination. A migrating MSP's incumbent
+ * export carries warranty expiry in the same file as its custom fields, and
+ * landing that in a text custom field ships the flagship use case INERT (see
+ * `warrantyTarget.ts`), so a mapped column names a TARGET, not a field key.
+ * ────────────────────────────────────────────────────────────────────────── */
+
+/**
+ * The `device_warranty` columns an import may write.
+ *
+ * `status` is deliberately absent: it is COMPUTED from the end date
+ * (`computeWarrantyStatus`), never taken from the file. A CSV that could set
+ * `status` directly would let a stale export mark an expired machine `active`
+ * and silence its own alert. `is_subscription` is absent for the same reason
+ * plus a stronger one — a true value suppresses expiry alerting outright
+ * (`warrantyAlertEvaluator.ts:208`) and an import cannot know it.
+ */
+export type WarrantyImportField = 'warrantyStartDate' | 'warrantyEndDate' | 'manufacturer';
+
+/**
+ * Where one mapped column lands. A discriminated union rather than a nullable
+ * `fieldKey` beside an optional `warrantyField`, so "a warranty column has no
+ * field key" is carried by the TYPE — the same reasoning as `DeviceResolution`
+ * above, and the reason no downstream caller needs a non-null assertion.
+ */
+export type MappingTarget =
+  | { kind: 'customField'; fieldKey: string }
+  | { kind: 'warranty'; field: WarrantyImportField };
+
+/**
+ * Row-level: how the DEVICE resolved. An ALIAS of W06's outcome vocabulary,
+ * never a second copy — preview, commit and the wizard all branch on one set.
+ */
+export type ValueRowOutcome = DeviceRowOutcome;
+
+/**
+ * Per-VALUE: what happened to this one datum.
+ *
+ * PER VALUE, NOT PER ROW — the single most important shape decision in this
+ * wave. One device row carries up to 30 mapped columns and the normal case is
+ * mixed: 28 land, one names a field this organization has never defined, one
+ * holds `abc` in a number column. A row-level annotation cannot express that,
+ * and an all-or-nothing row would refuse a whole migration over one bad cell.
+ *
+ * - `applied` — written (or, at preview, would be written).
+ * - `skipped-already-set` — a value is already stored for this target on this
+ *   device. Covers BOTH "the stored value is identical" (a re-import: a no-op
+ *   in either mode) and "the stored value differs and the mode is `skip`", so
+ *   the operator sees one honest reason instead of two synonyms.
+ * - `no-definition` — no `custom_field_definitions` row visible to this
+ *   device's organization owns this key. Run the DEFINITIONS import (W07) first.
+ * - `type-error` — `validateCustomFieldValue` refused it; `reason` says how.
+ * - `not-applicable-to-device` — the definition is scoped to `deviceTypes` this
+ *   device's OS is not in (the gate `validateValueMap` already applies).
+ * - `device-unresolved` — the ROW did not resolve to exactly one device, so no
+ *   value on it can be judged at all: there is no organization whose definitions
+ *   to look the key up in. Without this member an ambiguous row's values would
+ *   have to borrow an annotation that means something else.
+ */
+export type ValueOutcome =
+  | 'applied'
+  | 'skipped-already-set'
+  | 'no-definition'
+  | 'type-error'
+  | 'not-applicable-to-device'
+  | 'device-unresolved';
+
+/**
+ * Why `validateCustomFieldValue` refused a value. Restated structurally rather
+ * than imported so this module keeps its no-imports rule (see the file header).
+ * `services/customFields/validateValue.ts` is the source of truth, and
+ * `valueImport.ts` carries a compile-time assertion that the two agree — so a
+ * new rejection reason there breaks the build rather than drifting silently.
+ */
+export type CustomFieldImportRejection =
+  | 'invalid_type'
+  | 'out_of_range'
+  | 'not_a_choice'
+  | 'too_long'
+  | 'invalid_date';
+
+export interface AnnotatedImportValue {
+  target: MappingTarget;
+  outcome: ValueOutcome;
+  /** Set on `type-error`. */
+  reason?: CustomFieldImportRejection;
+  /**
+   * Advisory, and ORTHOGONAL to `outcome` — an `applied` value carries one when
+   * the write has a consequence beyond the device. Today that is the
+   * partner-integration identity keys (`asset_tag`, `inventory_id`,
+   * `external_id`), which `routes/partnerApi/devices.ts` republishes as a
+   * device's `stableIdentifiers` to every integration the partner has
+   * connected. Writing them is intended; doing it fleet-wide without being told
+   * is not, so preview says so on the value.
+   */
+  warning?: string;
+}
+
+export interface AnnotatedValueRow {
+  index: number;
+  outcome: ValueRowOutcome;
+  deviceId: string | null;
+  method: DeviceMatchMethod | null;
+  organizationId: string | null;
+  /** Ranked, for `ambiguous` / `identity-conflict`. The UI must require a pick. */
+  candidates: DeviceCandidate[];
+  conflictingMethods?: DeviceMatchMethod[];
+  discardedIdentifiers?: DeviceMatchMethod[];
+  values: AnnotatedImportValue[];
+}
+
+export interface CommitValueRowInput extends DeviceCustomFieldImportRow {
+  /** Commit re-derives the row outcome and refuses any row whose outcome moved. */
+  expectedOutcome?: ValueRowOutcome;
+  /**
+   * Identity pin. REQUIRED when `expectedOutcome` is `ambiguous`: an
+   * acknowledgement that says "apply this" without saying "to WHOM" would
+   * transfer to a different device if the candidate set moved between preview
+   * and commit — the exact silent mis-assignment W06's resolver refuses to make
+   * on its own.
+   */
+  expectedDeviceId?: string;
+}
+
+/**
+ * Verbatim from the contacts importer (`ContactImportMode`), including the
+ * default (`skip`). A third importer using the same word with the same default
+ * is worth more than a marginally better one.
+ */
+export type ValueImportMode = 'skip' | 'update';
+
+export type ValueImportErrorCode =
+  | 'org-not-found'
+  | 'not-found'
+  | 'identity-conflict'
+  | 'annotation-changed'
+  | 'match-changed'
+  | 'match-unconfirmed'
+  | 'write-failed';
+
+/** What `applyWarrantyImport` did with a row's warranty columns. */
+export type WarrantyImportOutcome =
+  | 'applied'
+  | 'skipped-provider-owned'
+  | 'skipped-already-set'
+  | 'none';
+
+export interface ValueImportRowResult {
+  index: number;
+  deviceId: string;
+  organizationId: string;
+  /**
+   * How the device resolved, and which system the row came from. Both are
+   * carried on the SUMMARY because the service has no Hono context and the
+   * ROUTE writes the audits — "where did this asset tag come from" is only
+   * answerable after a migration if the resolution method is recorded.
+   */
+  method: DeviceMatchMethod;
+  externalSystem: string | null;
+  applied: number;
+  skipped: number;
+  failed: number;
+  /**
+   * Field KEYS only, for the audit's `changedFields`. A VALUE can be anything
+   * the incumbent held and must never enter an audit payload — the same rule
+   * `scriptWriteBack.ts` and `customFieldValues.ts` already apply.
+   */
+  appliedFieldKeys: string[];
+  warranty: WarrantyImportOutcome;
+  linkCreated: boolean;
+}
+
+export interface ValueImportErrorEntry {
+  index: number;
+  error: string;
+  code: ValueImportErrorCode;
+  /**
+   * Attached NON-ENUMERABLY by the service so it never reaches a JSON body —
+   * routes hand this summary straight to `c.json(...)` and a pg error carries
+   * query text and column values. Read in-process; never serialize it.
+   */
+  cause?: unknown;
+}
+
+export interface ValueImportSummary {
+  /**
+   * Counts VALUES, not rows. An operator cannot reconcile "30,000 in the file"
+   * against "1,180 imported" otherwise — and a row count would hide the very
+   * partial-application behaviour this importer is built around.
+   */
+  appliedValues: number;
+  skippedValues: number;
+  failedValues: number;
+  rows: ValueImportRowResult[];
+  linksCreated: number;
+  errors: ValueImportErrorEntry[];
 }

--- a/apps/api/src/services/customFields/import/valueImport.test.ts
+++ b/apps/api/src/services/customFields/import/valueImport.test.ts
@@ -1,0 +1,645 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Value importer (#3257 W08 Tasks 2 + 3).
+ *
+ * These tests drive the REAL resolver (`resolveDevice.ts`), the REAL definition
+ * lookup (`queries.ts`) and the REAL upsert, with only the database mocked, so
+ * they cover the module's whole pipeline rather than its orchestration alone.
+ * `db.select` is dispatched on the TABLE being read rather than on call order:
+ * the query sequence is conditional (a batch with no external ids issues no
+ * link query at all), and a positional queue would silently mis-feed a result
+ * to the wrong query the first time a test changed the row shape.
+ *
+ * `applyWarrantyImport` is stubbed — it has its own suite next door
+ * (`warrantyTarget.test.ts`, 16 tests) — but `coerceWarrantyValue` stays real,
+ * because it is what preview annotates warranty cells with.
+ */
+
+const PARTNER = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const ORG = '11111111-1111-4111-8111-111111111111';
+const D1 = 'dddddddd-dddd-4ddd-8ddd-ddddddddddd1';
+const D2 = 'dddddddd-dddd-4ddd-8ddd-ddddddddddd2';
+const GONE = 'dddddddd-dddd-4ddd-8ddd-dddddddddd99';
+const DEF_TAG = '33333333-3333-4333-8333-333333333331';
+const DEF_UNITS = '33333333-3333-4333-8333-333333333332';
+const DEF_BITLOCKER = '33333333-3333-4333-8333-333333333333';
+
+const {
+  tableQueues,
+  whereCalls,
+  selectedTables,
+  txInserts,
+  txCount,
+  insertFailures,
+  linkReturns,
+  applyWarrantyImportMock,
+} = vi.hoisted(() => ({
+  tableQueues: new Map<string, unknown[][]>(),
+  whereCalls: [] as Array<{ table: string; condition: unknown }>,
+  selectedTables: [] as string[],
+  txInserts: [] as Array<{ table: string; values: Record<string, unknown> }>,
+  txCount: { current: 0 },
+  insertFailures: { current: null as null | ((table: string, values: Record<string, unknown>) => void) },
+  linkReturns: { current: [{ id: 'link-1' }] as unknown[] },
+  applyWarrantyImportMock: vi.fn(),
+}));
+
+function tableName(table: unknown): string {
+  // Real drizzle table objects; the Symbol-keyed name is the only stable handle.
+  // Matched EXACTLY — `drizzle:OriginalName` and `drizzle:BaseName` also exist
+  // and a substring match would pick whichever was defined first.
+  const symbol = Object.getOwnPropertySymbols(table as object).find((s) => String(s) === 'Symbol(drizzle:Name)');
+  return symbol ? String((table as Record<symbol, unknown>)[symbol]) : String(table);
+}
+
+/**
+ * Per-table FIFO. The LAST queued result is sticky, so a loader called once per
+ * organization keeps answering after the queue drains.
+ */
+function nextFor(table: string): unknown[] {
+  const queue = tableQueues.get(table);
+  if (!queue || queue.length === 0) return [];
+  return queue.length === 1 ? queue[0]! : queue.shift()!;
+}
+
+function queueTable(table: string, ...results: unknown[][]): void {
+  tableQueues.set(table, results);
+}
+
+vi.mock('../../../db', () => {
+  const chain = (table: string) => {
+    const node: Record<string, unknown> = {};
+    const self = () => node;
+    node.from = (t: unknown) => {
+      const name = tableName(t);
+      selectedTables.push(name);
+      (node as { __table: string }).__table = name;
+      return node;
+    };
+    node.leftJoin = self;
+    node.innerJoin = self;
+    node.orderBy = self;
+    node.limit = self;
+    node.where = (condition: unknown) => {
+      whereCalls.push({ table: (node as { __table?: string }).__table ?? table, condition });
+      return node;
+    };
+    node.then = (resolve: (v: unknown) => unknown, reject?: (e: unknown) => unknown) =>
+      Promise.resolve(nextFor((node as { __table?: string }).__table ?? table)).then(resolve, reject);
+    return node;
+  };
+
+  const txInsert = (t: unknown) => {
+    const name = tableName(t);
+    return {
+      values: (values: Record<string, unknown>) => {
+        txInserts.push({ table: name, values });
+        insertFailures.current?.(name, values);
+        const returning = async () =>
+          name === 'device_external_links'
+            ? linkReturns.current
+            : [{ fieldKey: values.fieldKey }];
+        return {
+          onConflictDoUpdate: () => ({ returning }),
+          onConflictDoNothing: () => ({ returning }),
+        };
+      },
+    };
+  };
+
+  return {
+    db: {
+      select: () => chain('?'),
+      transaction: async (cb: (tx: unknown) => Promise<unknown>) => {
+        txCount.current += 1;
+        return cb({ insert: txInsert, select: () => chain('?') });
+      },
+    },
+    runOutsideDbContext: <T,>(fn: () => T) => fn(),
+    withSystemDbAccessContext: <T,>(fn: () => T) => fn(),
+  };
+});
+
+vi.mock('./warrantyTarget', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./warrantyTarget')>();
+  return { ...actual, applyWarrantyImport: applyWarrantyImportMock };
+});
+
+import {
+  commitDeviceCustomFieldImport,
+  previewDeviceCustomFieldImport,
+  type ValueImportContext,
+} from './valueImport';
+import type { CommitValueRowInput, DeviceCustomFieldImportRow, MappingTarget } from './types';
+
+const ctx: ValueImportContext = { partnerId: PARTNER, accessibleOrgIds: [ORG], allowedSiteIds: null };
+const actor = { userId: 'u-1' };
+
+const preview = (rows: readonly DeviceCustomFieldImportRow[], c: ValueImportContext = ctx) =>
+  previewDeviceCustomFieldImport(rows, c);
+const commit = (
+  rows: readonly CommitValueRowInput[],
+  c: ValueImportContext = ctx,
+  a = actor,
+  options?: { mode?: 'skip' | 'update' },
+) => commitDeviceCustomFieldImport(rows, c, a, options);
+
+/** A custom-field value assignment. */
+const v = (fieldKey: string, value: unknown) => ({ target: { kind: 'customField', fieldKey } as MappingTarget, value });
+/** A warranty value assignment. */
+const w = (field: 'warrantyEndDate' | 'warrantyStartDate' | 'manufacturer', value: unknown) => ({
+  target: { kind: 'warranty', field } as MappingTarget,
+  value,
+});
+
+interface DeviceSeed {
+  deviceId: string;
+  hostname?: string | null;
+  serialNumber?: string | null;
+  osType?: string | null;
+  status?: string | null;
+}
+
+function device(seed: DeviceSeed) {
+  return {
+    deviceId: seed.deviceId,
+    orgId: ORG,
+    hostname: seed.hostname ?? 'wkstn-1',
+    displayName: 'WKSTN-1',
+    osType: seed.osType ?? 'windows',
+    status: seed.status ?? 'online',
+    enrolledAt: new Date('2026-01-01T00:00:00Z'),
+    lastSeenAt: new Date('2026-09-01T00:00:00Z'),
+    siteId: null,
+    serialNumber: seed.serialNumber ?? 'SN-1',
+  };
+}
+
+const DEFINITIONS = [
+  { id: DEF_TAG, fieldKey: 'asset_tag', name: 'Asset Tag', type: 'text', options: null, deviceTypes: null, required: false, scriptWrite: false, orgId: ORG, partnerId: null },
+  { id: DEF_UNITS, fieldKey: 'rack_units', name: 'Rack Units', type: 'number', options: null, deviceTypes: null, required: false, scriptWrite: false, orgId: ORG, partnerId: null },
+  { id: DEF_BITLOCKER, fieldKey: 'bitlocker_status', name: 'BitLocker', type: 'text', options: null, deviceTypes: ['windows'], required: false, scriptWrite: false, orgId: ORG, partnerId: null },
+];
+
+interface SeedOptions {
+  devices?: ReturnType<typeof device>[];
+  links?: Array<{ deviceId: string; system: string; externalId: string; sourceInstance: string | null }>;
+  storedValues?: Array<{ deviceId: string; definitionId: string; fieldKey: string; valueText: string | null; valueNumber: number | null; valueBool: boolean | null; valueDate: string | null }>;
+  warranty?: Array<{ deviceId: string; dataSource: string | null }>;
+  definitions?: typeof DEFINITIONS;
+}
+
+function seed(options: SeedOptions = {}) {
+  tableQueues.clear();
+  // `organizations` is read TWICE: the resolver's reachable-org query, then the
+  // definition loader's partner lookup. Order is deterministic.
+  queueTable('organizations', [{ id: ORG }], [{ partnerId: PARTNER }]);
+  queueTable('devices', options.devices ?? [device({ deviceId: D1 })]);
+  queueTable('device_external_links', options.links ?? []);
+  queueTable('device_custom_field_values', options.storedValues ?? []);
+  queueTable('device_warranty', options.warranty ?? []);
+  queueTable('custom_field_definitions', options.definitions ?? DEFINITIONS);
+}
+
+beforeEach(() => {
+  tableQueues.clear();
+  whereCalls.length = 0;
+  selectedTables.length = 0;
+  txInserts.length = 0;
+  txCount.current = 0;
+  insertFailures.current = null;
+  linkReturns.current = [{ id: 'link-1' }];
+  applyWarrantyImportMock.mockReset().mockResolvedValue('applied');
+});
+
+describe('previewDeviceCustomFieldImport', () => {
+  it('annotates a link-resolved row as link-match', async () => {
+    seed({ links: [{ deviceId: D1, system: 'datto_rmm', externalId: 'uid-1', sourceInstance: null }] });
+
+    const [row] = await preview([{ externalSystem: 'datto_rmm', externalId: 'uid-1', values: [v('asset_tag', 'AB-1')] }]);
+
+    expect(row).toMatchObject({ outcome: 'link-match', method: 'link', deviceId: D1, organizationId: ORG });
+  });
+
+  it('partially annotates one row: applied, no-definition, type-error', async () => {
+    seed();
+
+    const [row] = await preview([{
+      hostname: 'wkstn-1',
+      values: [v('asset_tag', 'AB-1'), v('nope', 'x'), v('rack_units', 'abc')],
+    }]);
+
+    expect(row!.outcome).toBe('matched');
+    expect(row!.values.map((x) => x.outcome)).toEqual(['applied', 'no-definition', 'type-error']);
+    expect(row!.values[2]!.reason).toBe('invalid_type');
+  });
+
+  it('marks a value equal to the stored one as skipped-already-set', async () => {
+    seed({
+      storedValues: [{ deviceId: D1, definitionId: DEF_TAG, fieldKey: 'asset_tag', valueText: 'AB-1', valueNumber: null, valueBool: null, valueDate: null }],
+    });
+
+    const [row] = await preview([{ deviceId: D1, values: [v('asset_tag', 'AB-1')] }]);
+
+    expect(row!.values[0]!.outcome).toBe('skipped-already-set');
+  });
+
+  it('skips a DIFFERENT stored value in the default skip mode, and applies it in update mode', async () => {
+    const stored = [{ deviceId: D1, definitionId: DEF_TAG, fieldKey: 'asset_tag', valueText: 'OLD', valueNumber: null, valueBool: null, valueDate: null }];
+
+    seed({ storedValues: stored });
+    const [skipRow] = await preview([{ deviceId: D1, values: [v('asset_tag', 'AB-1')] }]);
+    expect(skipRow!.values[0]!.outcome).toBe('skipped-already-set');
+
+    seed({ storedValues: stored });
+    const [updateRow] = await preview([{ deviceId: D1, values: [v('asset_tag', 'AB-1')] }], { ...ctx, mode: 'update' });
+    expect(updateRow!.values[0]!.outcome).toBe('applied');
+  });
+
+  it('warns on a reserved partner-integration identity key without refusing it', async () => {
+    seed();
+
+    const [row] = await preview([{ deviceId: D1, values: [v('asset_tag', 'AB-1')] }]);
+
+    expect(row!.values[0]!.outcome).toBe('applied');
+    expect(row!.values[0]!.warning).toMatch(/partner integration identity/i);
+  });
+
+  it('does not warn on an ordinary key', async () => {
+    seed();
+
+    const [row] = await preview([{ deviceId: D1, values: [v('rack_units', 4)] }]);
+
+    expect(row!.values[0]!.warning).toBeUndefined();
+  });
+
+  it('marks a value whose definition excludes this device OS as not-applicable-to-device', async () => {
+    seed({ devices: [device({ deviceId: D1, osType: 'macos' })] });
+
+    const [row] = await preview([{ deviceId: D1, values: [v('bitlocker_status', 'on')] }]);
+
+    expect(row!.values[0]!.outcome).toBe('not-applicable-to-device');
+  });
+
+  it('returns ranked candidates for an ambiguous row and annotates nothing as applied', async () => {
+    seed({
+      devices: [
+        device({ deviceId: D1, hostname: 'shared-name', serialNumber: 'SN-1', status: 'offline' }),
+        device({ deviceId: D2, hostname: 'shared-name', serialNumber: 'SN-2', status: 'online' }),
+      ],
+    });
+
+    const [row] = await preview([{ hostname: 'shared-name', values: [v('asset_tag', 'AB-1')] }]);
+
+    expect(row!.outcome).toBe('ambiguous');
+    expect(row!.candidates.length).toBeGreaterThan(1);
+    expect(row!.candidates[0]!.deviceId).toBe(D2); // online ranks first
+    expect(row!.values.every((x) => x.outcome !== 'applied')).toBe(true);
+    expect(row!.values[0]!.outcome).toBe('device-unresolved');
+  });
+
+  it('annotates an unreachable organization as org-not-found without disclosing whether it exists', async () => {
+    seed();
+
+    const [row] = await preview([{
+      organizationId: '99999999-9999-4999-8999-999999999999',
+      hostname: 'wkstn-1',
+      values: [v('asset_tag', 'AB-1')],
+    }]);
+
+    expect(row!.outcome).toBe('org-not-found');
+    expect(row!.deviceId).toBeNull();
+    expect(row!.candidates).toEqual([]);
+  });
+
+  it('annotates a warranty target, and reports an unparseable date as type-error', async () => {
+    seed();
+
+    const [row] = await preview([{
+      deviceId: D1,
+      values: [w('warrantyEndDate', '2027-03-04'), w('warrantyEndDate', 'whenever')],
+    }]);
+
+    expect(row!.values[0]!.outcome).toBe('applied');
+    expect(row!.values[1]).toMatchObject({ outcome: 'type-error', reason: 'invalid_date' });
+  });
+
+  it('annotates a provider-owned warranty row as skipped-already-set unless the operator opted in', async () => {
+    seed({ warranty: [{ deviceId: D1, dataSource: 'provider' }] });
+    const [guarded] = await preview([{ deviceId: D1, values: [w('warrantyEndDate', '2027-03-04')] }]);
+    expect(guarded!.values[0]!.outcome).toBe('skipped-already-set');
+    expect(guarded!.values[0]!.warning).toMatch(/manufacturer/i);
+
+    seed({ warranty: [{ deviceId: D1, dataSource: 'provider' }] });
+    const [opted] = await preview(
+      [{ deviceId: D1, values: [w('warrantyEndDate', '2027-03-04')] }],
+      { ...ctx, overrideProviderWarranty: true },
+    );
+    expect(opted!.values[0]!.outcome).toBe('applied');
+  });
+
+  it('writes nothing at all', async () => {
+    seed();
+    await preview([{ deviceId: D1, values: [v('asset_tag', 'AB-1')] }]);
+    expect(txCount.current).toBe(0);
+    expect(txInserts).toHaveLength(0);
+  });
+});
+
+describe('commitDeviceCustomFieldImport', () => {
+  it('applies the good values on a mixed row and reports the rest, in ONE transaction', async () => {
+    seed();
+
+    const summary = await commit([{
+      deviceId: D1,
+      values: [v('asset_tag', 'AB-1'), v('nope', 'x'), v('rack_units', 'abc')],
+    }], ctx, actor, { mode: 'update' });
+
+    expect(summary.rows[0]).toMatchObject({ index: 0, deviceId: D1, applied: 1, failed: 2 });
+    expect(summary.appliedValues).toBe(1);
+    expect(summary.failedValues).toBe(2);
+    expect(txCount.current).toBe(1);
+    expect(txInserts.filter((i) => i.table === 'device_custom_field_values')).toHaveLength(1);
+  });
+
+  it('a row that fails to write does not poison its neighbours', async () => {
+    seed({ devices: [device({ deviceId: D1, hostname: 'a' }), device({ deviceId: D2, hostname: 'b' })] });
+    let call = 0;
+    insertFailures.current = (table) => {
+      if (table !== 'device_custom_field_values') return;
+      call += 1;
+      if (call === 2) throw Object.assign(new Error('boom'), { code: '23503' });
+    };
+
+    const summary = await commit([
+      { deviceId: D1, values: [v('asset_tag', 'A')] },
+      { deviceId: D2, values: [v('asset_tag', 'B')] },
+      { deviceId: D1, values: [v('asset_tag', 'C')] },
+    ], ctx, actor, { mode: 'update' });
+
+    expect(summary.errors.map((e) => e.index)).toEqual([1]);
+    expect(summary.errors[0]!.code).toBe('write-failed');
+    expect(summary.rows.map((r) => r.index)).toEqual([0, 2]);
+    // One nested transaction per row — the mechanism the isolation depends on.
+    expect(txCount.current).toBe(3);
+  });
+
+  it('never leaks driver text into the error body, but keeps the cause in-process', async () => {
+    seed();
+    insertFailures.current = (table) => {
+      if (table === 'device_custom_field_values') {
+        throw Object.assign(new Error('duplicate key value violates unique constraint "x" DETAIL: Key (a)=(secret)'), { code: '23505' });
+      }
+    };
+
+    const summary = await commit([{ deviceId: D1, values: [v('asset_tag', 'A')] }], ctx, actor, { mode: 'update' });
+
+    expect(summary.errors[0]!.error).not.toMatch(/DETAIL|secret|constraint/);
+    expect(summary.errors[0]!.cause).toBeInstanceOf(Error);
+    expect(JSON.stringify(summary.errors[0])).not.toMatch(/secret/);
+    expect(Object.keys(summary.errors[0]!)).not.toContain('cause');
+  });
+
+  it('records a device_external_links row on the first match by hostname', async () => {
+    seed();
+
+    const summary = await commit([{
+      externalSystem: 'datto_rmm',
+      externalId: 'uid-9',
+      hostname: 'wkstn-1',
+      values: [v('asset_tag', 'AB-1')],
+    }], ctx, actor, { mode: 'update' });
+
+    expect(summary.linksCreated).toBe(1);
+    expect(summary.rows[0]!.linkCreated).toBe(true);
+    const link = txInserts.find((i) => i.table === 'device_external_links');
+    expect(link!.values).toMatchObject({
+      deviceId: D1, orgId: ORG, partnerId: PARTNER, system: 'datto_rmm', externalId: 'uid-9', createdBy: 'u-1',
+    });
+  });
+
+  it('does not re-create the link when the row already resolved BY link', async () => {
+    seed({ links: [{ deviceId: D1, system: 'datto_rmm', externalId: 'uid-9', sourceInstance: null }] });
+
+    const summary = await commit([{
+      externalSystem: 'datto_rmm', externalId: 'uid-9', values: [v('asset_tag', 'AB-1')],
+    }], ctx, actor, { mode: 'update' });
+
+    expect(summary.linksCreated).toBe(0);
+    expect(txInserts.some((i) => i.table === 'device_external_links')).toBe(false);
+    expect(summary.rows[0]!.method).toBe('link');
+  });
+
+  it('the SECOND run resolves by link and issues NO hostname predicate', async () => {
+    // The durable link is what makes a re-run exact. Proven on the SQL the
+    // resolver actually builds: with only an external id supplied, the device
+    // query carries no `lower(hostname)` term at all. The control below is the
+    // mutation check — the same assertion goes red when a hostname is present.
+    seed({ links: [{ deviceId: D1, system: 'datto_rmm', externalId: 'uid-9', sourceInstance: null }] });
+
+    const summary = await commit([{
+      externalSystem: 'datto_rmm', externalId: 'uid-9', values: [v('asset_tag', 'AB-1')],
+    }], ctx, actor, { mode: 'update' });
+
+    expect(summary.rows[0]).toMatchObject({ deviceId: D1, method: 'link' });
+    expect(deviceQuerySql()).not.toMatch(/lower\(/);
+  });
+
+  it('CONTROL: a first run that must fall back to the hostname DOES issue the hostname predicate', async () => {
+    seed();
+
+    await commit([{
+      externalSystem: 'datto_rmm', externalId: 'uid-9', hostname: 'wkstn-1', values: [v('asset_tag', 'AB-1')],
+    }], ctx, actor, { mode: 'update' });
+
+    expect(deviceQuerySql()).toMatch(/lower\(/);
+  });
+
+  it('re-running an identical file in the default skip mode writes nothing', async () => {
+    seed({
+      storedValues: [
+        { deviceId: D1, definitionId: DEF_TAG, fieldKey: 'asset_tag', valueText: 'AB-1', valueNumber: null, valueBool: null, valueDate: null },
+        { deviceId: D1, definitionId: DEF_UNITS, fieldKey: 'rack_units', valueText: null, valueNumber: 4, valueBool: null, valueDate: null },
+      ],
+    });
+
+    const summary = await commit([{ deviceId: D1, values: [v('asset_tag', 'AB-1'), v('rack_units', 4)] }]);
+
+    expect(summary.appliedValues).toBe(0);
+    expect(summary.skippedValues).toBe(2);
+    expect(txInserts.filter((i) => i.table === 'device_custom_field_values')).toHaveLength(0);
+  });
+
+  it('refuses an ambiguous acknowledgement with no expectedDeviceId', async () => {
+    seed({
+      devices: [
+        device({ deviceId: D1, hostname: 'shared-name', serialNumber: 'SN-1' }),
+        device({ deviceId: D2, hostname: 'shared-name', serialNumber: 'SN-2' }),
+      ],
+    });
+
+    const summary = await commit([{ hostname: 'shared-name', expectedOutcome: 'ambiguous', values: [v('asset_tag', 'x')] }]);
+
+    expect(summary.errors[0]!.code).toBe('match-unconfirmed');
+    expect(summary.rows).toHaveLength(0);
+    expect(txCount.current).toBe(0);
+  });
+
+  it('refuses an acknowledgement pinned to a device the row no longer resolves to', async () => {
+    seed({
+      devices: [
+        device({ deviceId: D1, hostname: 'shared-name', serialNumber: 'SN-1' }),
+        device({ deviceId: D2, hostname: 'shared-name', serialNumber: 'SN-2' }),
+      ],
+    });
+
+    const summary = await commit([{
+      hostname: 'shared-name', expectedOutcome: 'ambiguous', expectedDeviceId: GONE, values: [v('asset_tag', 'x')],
+    }]);
+
+    expect(summary.errors[0]!.code).toBe('match-changed');
+    expect(txCount.current).toBe(0);
+  });
+
+  it('honours an ambiguous acknowledgement pinned to a device still in the candidate set', async () => {
+    seed({
+      devices: [
+        device({ deviceId: D1, hostname: 'shared-name', serialNumber: 'SN-1' }),
+        device({ deviceId: D2, hostname: 'shared-name', serialNumber: 'SN-2' }),
+      ],
+    });
+
+    const summary = await commit([{
+      hostname: 'shared-name', expectedOutcome: 'ambiguous', expectedDeviceId: D2, values: [v('asset_tag', 'x')],
+    }], ctx, actor, { mode: 'update' });
+
+    expect(summary.errors).toHaveLength(0);
+    expect(summary.rows[0]).toMatchObject({ deviceId: D2, applied: 1 });
+  });
+
+  it('refuses a row whose outcome moved since preview', async () => {
+    seed(); // resolves `matched`, not `link-match`
+
+    const summary = await commit([{ deviceId: D1, expectedOutcome: 'link-match', values: [v('asset_tag', 'x')] }]);
+
+    expect(summary.errors[0]!.code).toBe('annotation-changed');
+    expect(summary.errors[0]!.error).toMatch(/re-run preview/i);
+  });
+
+  it('a link-match needs no acknowledgement — the durable link IS the acknowledgement', async () => {
+    seed({ links: [{ deviceId: D1, system: 'datto_rmm', externalId: 'uid-1', sourceInstance: null }] });
+
+    const summary = await commit([{
+      externalSystem: 'datto_rmm', externalId: 'uid-1', values: [v('asset_tag', 'AB-1')],
+    }], ctx, actor, { mode: 'update' });
+
+    expect(summary.errors).toHaveLength(0);
+    expect(summary.rows[0]!.applied).toBe(1);
+  });
+
+  it('reports an unresolved row with the resolution code, never a write-failed', async () => {
+    seed({ devices: [] });
+
+    const summary = await commit([
+      { hostname: 'ghost', values: [v('asset_tag', 'x')] },
+      { organizationId: '99999999-9999-4999-8999-999999999999', hostname: 'ghost', values: [v('asset_tag', 'x')] },
+    ]);
+
+    expect(summary.errors.map((e) => e.code)).toEqual(['not-found', 'org-not-found']);
+  });
+
+  it('refuses a row whose identifiers disagree', async () => {
+    seed({
+      devices: [device({ deviceId: D1, hostname: 'wkstn-1', serialNumber: 'SN-1' }), device({ deviceId: D2, hostname: 'other', serialNumber: 'SN-2' })],
+    });
+
+    const summary = await commit([{ deviceId: D2, hostname: 'wkstn-1', values: [v('asset_tag', 'x')] }]);
+
+    expect(summary.errors[0]!.code).toBe('identity-conflict');
+  });
+
+  it('applies the warranty target inside the SAME transaction as the values', async () => {
+    seed();
+
+    const summary = await commit([{
+      deviceId: D1,
+      values: [v('asset_tag', 'AB-1'), w('warrantyEndDate', '2027-03-04'), w('manufacturer', 'Dell')],
+    }], ctx, actor, { mode: 'update' });
+
+    expect(txCount.current).toBe(1);
+    expect(applyWarrantyImportMock).toHaveBeenCalledTimes(1);
+    expect(applyWarrantyImportMock.mock.calls[0]![1]).toMatchObject({
+      deviceId: D1, orgId: ORG, warrantyEndDate: '2027-03-04', manufacturer: 'Dell',
+    });
+    expect(applyWarrantyImportMock.mock.calls[0]![2]).toEqual({ overrideProvider: false });
+    expect(summary.rows[0]).toMatchObject({ warranty: 'applied', applied: 3 });
+  });
+
+  it('rolls the whole row back when the warranty write throws', async () => {
+    seed();
+    applyWarrantyImportMock.mockRejectedValue(Object.assign(new Error('nope'), { code: '23503' }));
+
+    const summary = await commit([{
+      deviceId: D1, values: [v('asset_tag', 'AB-1'), w('warrantyEndDate', '2027-03-04')],
+    }], ctx, actor, { mode: 'update' });
+
+    expect(summary.errors[0]).toMatchObject({ index: 0, code: 'write-failed' });
+    expect(summary.rows).toHaveLength(0);
+  });
+
+  it('carries the resolution method, external system and applied field keys for the audit', async () => {
+    seed();
+
+    const summary = await commit([{
+      externalSystem: 'datto_rmm', hostname: 'wkstn-1', values: [v('asset_tag', 'AB-1')],
+    }], ctx, actor, { mode: 'update' });
+
+    expect(summary.rows[0]).toMatchObject({
+      method: 'hostname',
+      externalSystem: 'datto_rmm',
+      organizationId: ORG,
+      appliedFieldKeys: ['asset_tag'],
+    });
+  });
+
+  it('RE-DERIVES resolution at commit rather than trusting the client', async () => {
+    // The row names a hostname; commit must run the resolver again. A client
+    // that posted a deviceId it was never given cannot smuggle one in, because
+    // every identifier is re-resolved against a freshly loaded snapshot.
+    seed();
+    await commit([{ hostname: 'wkstn-1', values: [v('asset_tag', 'A')] }], ctx, actor, { mode: 'update' });
+    expect(selectedTables.filter((t) => t === 'devices')).toHaveLength(1);
+    expect(selectedTables).toContain('organizations');
+  });
+
+  it('reaches nothing when the caller can reach no organization', async () => {
+    seed();
+
+    const summary = await commit(
+      [{ deviceId: D1, values: [v('asset_tag', 'A')] }],
+      { partnerId: PARTNER, accessibleOrgIds: [], allowedSiteIds: null },
+    );
+
+    expect(summary.errors.map((e) => e.code)).toEqual(['not-found']);
+    expect(txCount.current).toBe(0);
+  });
+});
+
+/** The SQL text of the `devices` query the resolver built, for shape assertions. */
+function deviceQuerySql(): string {
+  const call = whereCalls.find((c) => c.table === 'devices');
+  return call ? sqlText(call.condition) : '';
+}
+
+function sqlText(node: unknown, depth = 0): string {
+  if (node === null || node === undefined || depth > 12) return '';
+  if (typeof node === 'string') return node;
+  if (Array.isArray(node)) return node.map((n) => sqlText(n, depth + 1)).join(' ');
+  if (typeof node !== 'object') return '';
+  const record = node as Record<string, unknown>;
+  const parts: string[] = [];
+  if (Array.isArray(record.value)) parts.push(record.value.join(''));
+  if (record.queryChunks) parts.push(sqlText(record.queryChunks, depth + 1));
+  return parts.join(' ');
+}

--- a/apps/api/src/services/customFields/import/valueImport.test.ts
+++ b/apps/api/src/services/customFields/import/valueImport.test.ts
@@ -576,6 +576,19 @@ describe('commitDeviceCustomFieldImport', () => {
     expect(summary.rows[0]).toMatchObject({ warranty: 'applied', applied: 3 });
   });
 
+  it('reports a declined warranty column as skipped-provider-owned, never as "none"', async () => {
+    // `none` means "this row mapped no warranty column at all". Collapsing the
+    // two would tell an operator their warranty column was never mapped.
+    seed({ warranty: [{ deviceId: D1, dataSource: 'provider' }] });
+
+    const summary = await commit([{
+      deviceId: D1, values: [v('asset_tag', 'AB-1'), w('warrantyEndDate', '2027-03-04')],
+    }], ctx, actor, { mode: 'update' });
+
+    expect(applyWarrantyImportMock).not.toHaveBeenCalled();
+    expect(summary.rows[0]).toMatchObject({ warranty: 'skipped-provider-owned', applied: 1, skipped: 1 });
+  });
+
   it('rolls the whole row back when the warranty write throws', async () => {
     seed();
     applyWarrantyImportMock.mockRejectedValue(Object.assign(new Error('nope'), { code: '23503' }));

--- a/apps/api/src/services/customFields/import/valueImport.test.ts
+++ b/apps/api/src/services/customFields/import/valueImport.test.ts
@@ -33,6 +33,7 @@ const {
   txCount,
   insertFailures,
   linkReturns,
+  fieldReturns,
   applyWarrantyImportMock,
 } = vi.hoisted(() => ({
   tableQueues: new Map<string, unknown[][]>(),
@@ -42,6 +43,7 @@ const {
   txCount: { current: 0 },
   insertFailures: { current: null as null | ((table: string, values: Record<string, unknown>) => void) },
   linkReturns: { current: [{ id: 'link-1' }] as unknown[] },
+  fieldReturns: { current: null as null | ((values: Record<string, unknown>) => unknown[]) },
   applyWarrantyImportMock: vi.fn(),
 }));
 
@@ -99,7 +101,7 @@ vi.mock('../../../db', () => {
         const returning = async () =>
           name === 'device_external_links'
             ? linkReturns.current
-            : [{ fieldKey: values.fieldKey }];
+            : (fieldReturns.current?.(values) ?? [{ fieldKey: values.fieldKey }]);
         return {
           onConflictDoUpdate: () => ({ returning }),
           onConflictDoNothing: () => ({ returning }),
@@ -176,6 +178,11 @@ function device(seed: DeviceSeed) {
   };
 }
 
+/** A calendar date `days` in the future, as the `date` column stores it. */
+function futureDate(days: number): string {
+  return new Date(Date.now() + days * 86_400_000).toISOString().slice(0, 10);
+}
+
 const DEFINITIONS = [
   { id: DEF_TAG, fieldKey: 'asset_tag', name: 'Asset Tag', type: 'text', options: null, deviceTypes: null, required: false, scriptWrite: false, orgId: ORG, partnerId: null },
   { id: DEF_UNITS, fieldKey: 'rack_units', name: 'Rack Units', type: 'number', options: null, deviceTypes: null, required: false, scriptWrite: false, orgId: ORG, partnerId: null },
@@ -186,7 +193,14 @@ interface SeedOptions {
   devices?: ReturnType<typeof device>[];
   links?: Array<{ deviceId: string; system: string; externalId: string; sourceInstance: string | null }>;
   storedValues?: Array<{ deviceId: string; definitionId: string; fieldKey: string; valueText: string | null; valueNumber: number | null; valueBool: boolean | null; valueDate: string | null }>;
-  warranty?: Array<{ deviceId: string; dataSource: string | null }>;
+  warranty?: Array<{
+    deviceId: string;
+    dataSource: string | null;
+    status?: string;
+    warrantyStartDate?: string | null;
+    warrantyEndDate?: string | null;
+    manufacturer?: string | null;
+  }>;
   definitions?: typeof DEFINITIONS;
 }
 
@@ -198,7 +212,13 @@ function seed(options: SeedOptions = {}) {
   queueTable('devices', options.devices ?? [device({ deviceId: D1 })]);
   queueTable('device_external_links', options.links ?? []);
   queueTable('device_custom_field_values', options.storedValues ?? []);
-  queueTable('device_warranty', options.warranty ?? []);
+  queueTable('device_warranty', (options.warranty ?? []).map((row) => ({
+    status: 'unknown',
+    warrantyStartDate: null,
+    warrantyEndDate: null,
+    manufacturer: null,
+    ...row,
+  })));
   queueTable('custom_field_definitions', options.definitions ?? DEFINITIONS);
 }
 
@@ -210,6 +230,7 @@ beforeEach(() => {
   txCount.current = 0;
   insertFailures.current = null;
   linkReturns.current = [{ id: 'link-1' }];
+  fieldReturns.current = null;
   applyWarrantyImportMock.mockReset().mockResolvedValue('applied');
 });
 
@@ -255,6 +276,19 @@ describe('previewDeviceCustomFieldImport', () => {
     seed({ storedValues: stored });
     const [updateRow] = await preview([{ deviceId: D1, values: [v('asset_tag', 'AB-1')] }], { ...ctx, mode: 'update' });
     expect(updateRow!.values[0]!.outcome).toBe('applied');
+  });
+
+  it('skips an IDENTICAL stored value even in update mode', async () => {
+    // Update mode means "overwrite a differing value", not "rewrite everything":
+    // a no-op UPDATE still takes the per-org export lock through the projection
+    // trigger, which is exactly what the compare-before-write exists to avoid.
+    seed({
+      storedValues: [{ deviceId: D1, definitionId: DEF_TAG, fieldKey: 'asset_tag', valueText: 'AB-1', valueNumber: null, valueBool: null, valueDate: null }],
+    });
+
+    const [row] = await preview([{ deviceId: D1, values: [v('asset_tag', 'AB-1')] }], { ...ctx, mode: 'update' });
+
+    expect(row!.values[0]!.outcome).toBe('skipped-already-set');
   });
 
   it('warns on a reserved partner-integration identity key without refusing it', async () => {
@@ -325,10 +359,13 @@ describe('previewDeviceCustomFieldImport', () => {
     expect(row!.values[1]).toMatchObject({ outcome: 'type-error', reason: 'invalid_date' });
   });
 
-  it('annotates a provider-owned warranty row as skipped-already-set unless the operator opted in', async () => {
+  it('gives a provider-owned warranty its OWN outcome, not skipped-already-set', async () => {
+    // "already correct, nothing to do" and "refused, and there is a switch you
+    // can flip" are different messages to show a tech. A consumer must not have
+    // to parse a warning string to tell them apart.
     seed({ warranty: [{ deviceId: D1, dataSource: 'provider' }] });
     const [guarded] = await preview([{ deviceId: D1, values: [w('warrantyEndDate', '2027-03-04')] }]);
-    expect(guarded!.values[0]!.outcome).toBe('skipped-already-set');
+    expect(guarded!.values[0]!.outcome).toBe('skipped-provider-owned');
     expect(guarded!.values[0]!.warning).toMatch(/manufacturer/i);
 
     seed({ warranty: [{ deviceId: D1, dataSource: 'provider' }] });
@@ -337,6 +374,55 @@ describe('previewDeviceCustomFieldImport', () => {
       { ...ctx, overrideProviderWarranty: true },
     );
     expect(opted!.values[0]!.outcome).toBe('applied');
+  });
+
+  it('previews an unchanged warranty cell as skipped-already-set, the way commit will treat it', async () => {
+    // Preview's whole job is to predict commit. Before this, a re-import of an
+    // unchanged file previewed every warranty cell as `applied` and then
+    // committed it as skipped.
+    const end = futureDate(200);
+    seed({ warranty: [{ deviceId: D1, dataSource: 'import', status: 'active', warrantyEndDate: end, manufacturer: 'dell' }] });
+
+    const [row] = await preview([{
+      deviceId: D1, values: [w('warrantyEndDate', end), w('manufacturer', 'Dell'), w('warrantyStartDate', '2020-01-01')],
+    }], { ...ctx, mode: 'update' });
+
+    expect(row!.values.map((x) => x.outcome)).toEqual(['skipped-already-set', 'skipped-already-set', 'applied']);
+  });
+
+  it('treats an unchanged end date whose STORED STATUS has gone stale as a change', async () => {
+    // The status is derived from the date and decays with time. If an unchanged
+    // date short-circuited the write, the import would quietly stop being the
+    // thing that refreshes a stale status.
+    const end = futureDate(30);
+    seed({ warranty: [{ deviceId: D1, dataSource: 'import', status: 'active', warrantyEndDate: end, manufacturer: null }] });
+
+    const [row] = await preview([{ deviceId: D1, values: [w('warrantyEndDate', end)] }], { ...ctx, mode: 'update' });
+
+    expect(row!.values[0]!.outcome).toBe('applied');
+  });
+
+  it('annotates every value on an unresolved row as device-unresolved, whatever the row outcome', async () => {
+    seed({ devices: [] });
+
+    const [notFound] = await preview([{ hostname: 'ghost', values: [v('asset_tag', 'x'), w('warrantyEndDate', '2027-03-04')] }]);
+    expect(notFound!.outcome).toBe('not-found');
+    expect(notFound!.values.map((x) => x.outcome)).toEqual(['device-unresolved', 'device-unresolved']);
+
+    seed({ devices: [] });
+    const [orgNotFound] = await preview([{
+      organizationId: '99999999-9999-4999-8999-999999999999', hostname: 'ghost', values: [v('asset_tag', 'x')],
+    }]);
+    expect(orgNotFound!.outcome).toBe('org-not-found');
+    expect(orgNotFound!.values[0]!.outcome).toBe('device-unresolved');
+  });
+
+  it('handles a row that maps no values at all', async () => {
+    // Legal on the wire: an external-id-only row exists to mint the durable link.
+    seed();
+    const [row] = await preview([{ deviceId: D1, values: [] }]);
+    expect(row).toMatchObject({ outcome: 'matched', deviceId: D1 });
+    expect(row!.values).toEqual([]);
   });
 
   it('writes nothing at all', async () => {
@@ -574,6 +660,90 @@ describe('commitDeviceCustomFieldImport', () => {
     });
     expect(applyWarrantyImportMock.mock.calls[0]![2]).toEqual({ overrideProvider: false });
     expect(summary.rows[0]).toMatchObject({ warranty: 'applied', applied: 3 });
+  });
+
+  it('counts a value the DATABASE declined as skipped, not applied', async () => {
+    // `persistDeviceCustomFieldValues`' compare-before-write returns no row when
+    // a concurrent writer already stored the same value. The tally must follow
+    // what the database DID, not what the annotator predicted.
+    seed();
+    linkReturns.current = [];
+    const returnNothing = { current: true };
+    insertFailures.current = () => { /* no throw; the empty return is rigged below */ };
+    fieldReturns.current = () => (returnNothing.current ? [] : [{ fieldKey: 'asset_tag' }]);
+
+    const summary = await commit([{ deviceId: D1, values: [v('asset_tag', 'AB-1')] }], ctx, actor, { mode: 'update' });
+
+    expect(summary.rows[0]).toMatchObject({ applied: 0, skipped: 1, appliedFieldKeys: [] });
+    expect(summary.appliedValues).toBe(0);
+    expect(summary.skippedValues).toBe(1);
+  });
+
+  it('does not count the same target twice when a row maps it twice', async () => {
+    // The wire schema refuses this, but the service is reachable directly and
+    // must not inflate the count an operator reconciles the file against: two
+    // columns onto one target write ONE datum (last wins).
+    seed();
+
+    const summary = await commit([{
+      deviceId: D1, values: [v('asset_tag', 'FIRST'), v('asset_tag', 'SECOND')],
+    }], ctx, actor, { mode: 'update' });
+
+    expect(summary.rows[0]).toMatchObject({ applied: 1, skipped: 1 });
+    expect(summary.appliedValues).toBe(1);
+  });
+
+  it('refuses a stale pin on a row that resolves unambiguously', async () => {
+    seed();
+
+    const summary = await commit([{
+      deviceId: D1, expectedDeviceId: GONE, values: [v('asset_tag', 'x')],
+    }]);
+
+    expect(summary.errors.map((e) => e.code)).toEqual(['match-changed']);
+    expect(txCount.current).toBe(0);
+  });
+
+  it('round-trips externalSourceInstance through the link key it writes', async () => {
+    // The reserved discriminator is part of the composite link key. If the
+    // write side and the resolver's read side ever disagreed about it, a second
+    // run would mint a duplicate link instead of matching.
+    seed();
+    const row = {
+      externalSystem: 'datto_rmm',
+      externalId: 'uid-si',
+      externalSourceInstance: 'tenant-a',
+      hostname: 'wkstn-1',
+      values: [v('asset_tag', 'AB-1')],
+    } as CommitValueRowInput;
+
+    const first = await commit([row], ctx, actor, { mode: 'update' });
+    expect(first.linksCreated).toBe(1);
+    expect(txInserts.find((i) => i.table === 'device_external_links')!.values)
+      .toMatchObject({ sourceInstance: 'tenant-a', externalId: 'uid-si' });
+
+    // Feed that exact link back and the row must resolve BY LINK, proving both
+    // sides build the same key. A different sourceInstance must NOT match.
+    seed({ links: [{ deviceId: D1, system: 'datto_rmm', externalId: 'uid-si', sourceInstance: 'tenant-a' }] });
+    const second = await commit([row], ctx, actor, { mode: 'update' });
+    expect(second.rows[0]).toMatchObject({ method: 'link', linkCreated: false });
+
+    seed({ links: [{ deviceId: D1, system: 'datto_rmm', externalId: 'uid-si', sourceInstance: 'tenant-b' }] });
+    const other = await commit([row], ctx, actor, { mode: 'update' });
+    expect(other.rows[0]).toMatchObject({ method: 'hostname', linkCreated: true });
+  });
+
+  it('reports a warranty column whose every cell was refused as rejected, not "none"', async () => {
+    // `none` means "no warranty column was mapped". Saying it here would tell an
+    // operator their column was never read, when it was read and thrown away.
+    seed();
+
+    const summary = await commit([{
+      deviceId: D1, values: [v('asset_tag', 'AB-1'), w('warrantyEndDate', 'whenever')],
+    }], ctx, actor, { mode: 'update' });
+
+    expect(applyWarrantyImportMock).not.toHaveBeenCalled();
+    expect(summary.rows[0]).toMatchObject({ warranty: 'rejected', applied: 1, failed: 1 });
   });
 
   it('reports a declined warranty column as skipped-provider-owned, never as "none"', async () => {

--- a/apps/api/src/services/customFields/import/valueImport.ts
+++ b/apps/api/src/services/customFields/import/valueImport.ts
@@ -15,12 +15,24 @@
  * are all per VALUE; only device resolution is per row.
  *
  * ── Where the reads happen ──────────────────────────────────────────────────
- * Device resolution (W06's `loadDeviceResolutionSnapshot`) escalates to a SYSTEM
- * context because a partner's import legitimately spans organizations and
- * `custom_field_definitions` has no partner-wide RLS SELECT branch. RLS is
- * therefore NOT the boundary on that read — the organization and site predicates
- * W06 carries in its SQL are the whole of it, and this module never widens the
- * scope it is handed.
+ * TWO separate escalations to a SYSTEM db context, for two different reasons.
+ * They are easy to conflate and the distinction matters, so:
+ *
+ *  1. **Device resolution** — W06's `loadDeviceResolutionSnapshot`. It escalates
+ *     because a partner's import legitimately spans that partner's
+ *     organizations; see its own header. It reads `organizations`, `devices`,
+ *     `device_hardware` and `device_external_links`, and touches
+ *     `custom_field_definitions` not at all. RLS is NOT the boundary on that
+ *     read — the organization and site predicates W06 carries IN ITS SQL are
+ *     the whole of it, and this module never widens the scope it is handed.
+ *  2. **Visible definitions** — W04's `loadVisibleCustomFieldDefinitions`,
+ *     called once per resolved organization below. It escalates for an
+ *     unrelated reason: `custom_field_definitions` has no partner-wide RLS
+ *     SELECT branch (it is in `PARTNER_WIDE_SELECT_BRANCH_EXEMPT`, TODO #4944),
+ *     so an org-scoped request context cannot see a partner-wide definition at
+ *     all and every value naming one would be annotated `no-definition`. That
+ *     rationale belongs to THAT function and would stop applying the day #4944
+ *     lands; it says nothing about (1).
  *
  * Everything else — the already-stored values, the existing warranty rows — is
  * read in the REQUEST's own context, deliberately. Those reads are bounded to
@@ -74,7 +86,14 @@ import {
   resolveDeviceRow,
   type DeviceResolutionScope,
 } from './resolveDevice';
-import { applyWarrantyImport, coerceWarrantyValue, type WarrantyImportWrite } from './warrantyTarget';
+import {
+  applyWarrantyImport,
+  coerceWarrantyValue,
+  warrantyCellUnchanged,
+  type ExistingWarrantyRow,
+  type WarrantyImportWrite,
+} from './warrantyTarget';
+import { captureException } from '../../sentry';
 import {
   DEFAULT_IMPORT_SYSTEM,
   type AnnotatedImportValue,
@@ -85,6 +104,7 @@ import {
   type DeviceCustomFieldImportValue,
   type DeviceMatchMethod,
   type DeviceResolution,
+  type MappingTarget,
   type ValueImportErrorCode,
   type ValueImportErrorEntry,
   type ValueImportMode,
@@ -144,6 +164,11 @@ interface StoredValue extends CustomFieldValueColumns {
   definitionId: string;
 }
 
+/** Identity of a mapped target, for de-duplicating within one row. */
+function targetKey(target: MappingTarget): string {
+  return target.kind === 'customField' ? `field\u0000${target.fieldKey}` : `warranty\u0000${target.field}`;
+}
+
 /** The device a row will actually be written to, once resolution and any pin agree. */
 interface RowTarget {
   deviceId: string;
@@ -157,8 +182,12 @@ interface AnnotationState {
   definitionsByOrg: Map<string, Map<string, VisibleCustomFieldDefinition>>;
   /** `deviceId` -> `definitionId` -> the value already stored. */
   storedByDevice: Map<string, Map<string, StoredValue>>;
-  /** `deviceId` -> the existing warranty row's provenance. */
-  warrantyByDevice: Map<string, string | null>;
+  /**
+   * `deviceId` -> the existing warranty row. The whole row, not just its
+   * provenance: preview compares each mapped cell against it so it annotates a
+   * re-import the way commit will actually treat it.
+   */
+  warrantyByDevice: Map<string, ExistingWarrantyRow>;
   mode: ValueImportMode;
   overrideProviderWarranty: boolean;
 }
@@ -255,11 +284,18 @@ async function loadAnnotationState(
   }
 
   const warranty = (await db
-    .select({ deviceId: deviceWarranty.deviceId, dataSource: deviceWarranty.dataSource })
+    .select({
+      deviceId: deviceWarranty.deviceId,
+      dataSource: deviceWarranty.dataSource,
+      status: deviceWarranty.status,
+      warrantyStartDate: deviceWarranty.warrantyStartDate,
+      warrantyEndDate: deviceWarranty.warrantyEndDate,
+      manufacturer: deviceWarranty.manufacturer,
+    })
     .from(deviceWarranty)
-    .where(inArray(deviceWarranty.deviceId, deviceIds))) as Array<{ deviceId: string; dataSource: string | null }>;
+    .where(inArray(deviceWarranty.deviceId, deviceIds))) as Array<ExistingWarrantyRow & { deviceId: string }>;
 
-  for (const row of warranty) state.warrantyByDevice.set(row.deviceId, row.dataSource);
+  for (const row of warranty) state.warrantyByDevice.set(row.deviceId, row);
 
   return state;
 }
@@ -302,10 +338,19 @@ function decideValue(
     if (!coerced.ok) {
       return { annotation: { target: mapping, outcome: 'type-error', reason: coerced.reason } };
     }
-    if (state.warrantyByDevice.get(target.deviceId) === 'provider' && !state.overrideProviderWarranty) {
+    const existing = state.warrantyByDevice.get(target.deviceId);
+    if (existing?.dataSource === 'provider' && !state.overrideProviderWarranty) {
       return {
-        annotation: { target: mapping, outcome: 'skipped-already-set', warning: PROVIDER_WARRANTY_WARNING },
+        annotation: { target: mapping, outcome: 'skipped-provider-owned', warning: PROVIDER_WARRANTY_WARNING },
       };
+    }
+    // Compared against the STORED row, exactly as the custom-field branch does
+    // below. Without this, a re-import of an unchanged file previews every
+    // warranty cell as `applied` and then commits it as skipped — preview and
+    // commit disagreeing on the one surface whose whole job is to predict the
+    // other.
+    if (existing && warrantyCellUnchanged(mapping.field, existing, coerced.value)) {
+      return { annotation: { target: mapping, outcome: 'skipped-already-set' } };
     }
     return {
       annotation: { target: mapping, outcome: 'applied' },
@@ -517,10 +562,22 @@ async function writeRow(
     warrantyWrite[decision.warrantyWrite.field] = decision.warrantyWrite.value;
     hasWarranty = true;
   }
-  /** A warranty column WAS mapped, and the annotator declined it. */
-  const warrantyDeclined = decisions.some(
-    (d) => d.annotation.target.kind === 'warranty' && d.annotation.outcome === 'skipped-already-set',
-  );
+  // A warranty column WAS mapped and produced no write. WHY it produced none is
+  // the operator-facing answer, and each reason is a different next step:
+  // provider-owned (flip the override), already-set (nothing to do), or every
+  // mapped cell refused (fix the file). `none` is reserved for "no warranty
+  // column was mapped at all".
+  const warrantyAnnotations = decisions
+    .filter((d) => d.annotation.target.kind === 'warranty')
+    .map((d) => d.annotation.outcome);
+  const declinedWarranty: WarrantyImportOutcome | null =
+    warrantyAnnotations.length === 0
+      ? null
+      : warrantyAnnotations.includes('skipped-provider-owned')
+        ? 'skipped-provider-owned'
+        : warrantyAnnotations.includes('skipped-already-set')
+          ? 'skipped-already-set'
+          : 'rejected';
 
   const externalId = row.externalId?.trim();
   // Only mint a link when the row was resolved some OTHER way — a link-match
@@ -564,16 +621,9 @@ async function writeRow(
       linkCreated = created.length > 0;
     }
 
-    // A warranty target the annotator already declined (today: the row is
-    // provider-owned and the operator did not opt in) is reported as the REASON
-    // it was declined, not as `none`. `none` means "this row mapped no warranty
-    // column at all", and collapsing the two would tell an operator their
-    // warranty column was never mapped when in fact it was refused.
     const warranty = hasWarranty
       ? await applyWarrantyImport(tx, warrantyWrite, { overrideProvider: ctx.overrideProviderWarranty ?? false })
-      : warrantyDeclined
-        ? ('skipped-provider-owned' as const)
-        : ('none' as const);
+      : (declinedWarranty ?? 'none');
 
     return { changedFieldKeys, linkCreated, warranty };
   });
@@ -591,12 +641,35 @@ function tallyRow(
   let skipped = 0;
   let failed = 0;
 
-  for (const decision of decisions) {
+  // A row that maps two columns onto the SAME target writes one datum — the
+  // last one wins, in the database and here. Without this, both decisions would
+  // find their key in `changed` and `applied` would be inflated by one per
+  // duplicate, corrupting the very count an operator reconciles the file
+  // against. The wire schema refuses such a row outright
+  // (`routes/devices/customFieldImport.ts`); this keeps the tally honest for a
+  // direct caller of the service, which is reachable and must fail safe.
+  // Only a decision that would actually WRITE can supersede an earlier one — a
+  // later column that failed validation wrote nothing and must not demote the
+  // value that did land.
+  const lastWriterByTarget = new Map<string, number>();
+  decisions.forEach((decision, index) => {
+    if (decision.annotation.outcome === 'applied') {
+      lastWriterByTarget.set(targetKey(decision.annotation.target), index);
+    }
+  });
+
+  for (const [index, decision] of decisions.entries()) {
     const outcome = decision.annotation.outcome;
-    if (outcome === 'skipped-already-set') {
+    const superseded = outcome === 'applied'
+      && lastWriterByTarget.get(targetKey(decision.annotation.target)) !== index;
+    if (outcome === 'skipped-already-set' || outcome === 'skipped-provider-owned') {
       skipped += 1;
     } else if (outcome === 'applied') {
-      if (decision.fieldWrite) {
+      if (superseded) {
+        // Overwritten within this same row by a later column mapped to the same
+        // target: exactly one datum landed, so exactly one is counted applied.
+        skipped += 1;
+      } else if (decision.fieldWrite) {
         // The database's compare-before-write can still decline an UPDATE that
         // would change nothing — a concurrent writer got there first. Counted as
         // skipped rather than applied so the totals describe what happened.
@@ -705,6 +778,13 @@ export async function commitDeviceCustomFieldImport(
         ...(constraint ? { constraint } : {}),
         error: err instanceof Error ? err.message : String(err),
       });
+      // A console line alone is only visible to whoever is grepping. An
+      // UNRECOGNISED sqlstate (or a plain JS error from a future refactor) is a
+      // code-level regression that would hit every row in the batch while the
+      // operator reads "check the server log" on all of them — page it.
+      // Recognised, expected refusals stay log-only so a bad CSV cannot flood
+      // Sentry.
+      if (!pgErrorCode(err) || !WRITE_FAILURE_COPY[pgErrorCode(err)!]) captureException(err);
       summary.errors.push(withCause({ index, ...writeFailure(err) }, err));
     }
   }

--- a/apps/api/src/services/customFields/import/valueImport.ts
+++ b/apps/api/src/services/customFields/import/valueImport.ts
@@ -1,0 +1,702 @@
+/**
+ * Custom-field VALUE import pipeline: preview -> commit (#3257 W08).
+ *
+ * The second and larger half of the RMM importer. W07 created the DEFINITIONS;
+ * this backfills their values onto enrolled devices, plus the `warranty`
+ * mapping target that makes the flagship migration use case actually work.
+ *
+ * ── Per VALUE, not per row ──────────────────────────────────────────────────
+ * The shape decision everything else follows from. One device row carries up to
+ * thirty mapped columns, and the NORMAL case is mixed: twenty-eight land, one
+ * names a field this organization never defined, one holds `abc` in a number
+ * column. A row-level annotation cannot express that, and an all-or-nothing row
+ * would refuse a whole migration over one bad cell. So `no-definition`,
+ * `type-error`, `skipped-already-set` and the `skip`/`update` conflict policy
+ * are all per VALUE; only device resolution is per row.
+ *
+ * ── Where the reads happen ──────────────────────────────────────────────────
+ * Device resolution (W06's `loadDeviceResolutionSnapshot`) escalates to a SYSTEM
+ * context because a partner's import legitimately spans organizations and
+ * `custom_field_definitions` has no partner-wide RLS SELECT branch. RLS is
+ * therefore NOT the boundary on that read — the organization and site predicates
+ * W06 carries in its SQL are the whole of it, and this module never widens the
+ * scope it is handed.
+ *
+ * Everything else — the already-stored values, the existing warranty rows — is
+ * read in the REQUEST's own context, deliberately. Those reads are bounded to
+ * devices the snapshot already admitted, and running them under RLS keeps a
+ * second, independent control on exactly the rows the writes will later touch:
+ * if the request context cannot see a device, it cannot write it either, and the
+ * two agree by construction rather than by review.
+ *
+ * ── Where the WRITES happen ─────────────────────────────────────────────────
+ * Each row's writes run in a NESTED `db.transaction` — a SAVEPOINT inside the
+ * request's own `withDbAccessContext` transaction
+ * (`dbSavepointErrorIsolation.integration.test.ts` is the proof), the same shape
+ * W07 shipped. That buys per-row failure isolation (without it, one failed
+ * statement aborts the request transaction and every later row raises 25P02)
+ * while keeping RLS a real control on every write.
+ *
+ * The plan called for `runOutsideDbContext` here. That would have bypassed RLS
+ * on the write path for a bulk cross-organization tool, which is precisely where
+ * it is least affordable — so this follows W07's shipped pattern instead.
+ *
+ * EVERY statement inside a row transaction MUST be issued on that callback's
+ * `tx`. The ambient `db` proxy still resolves to the OUTER transaction, whose
+ * postgres.js scope would record the error and poison the request — which is why
+ * `persistDeviceCustomFieldValues` takes an executor rather than being forked.
+ *
+ * ── TOCTOU ──────────────────────────────────────────────────────────────────
+ * Commit re-derives resolution and every annotation against state loaded at
+ * commit time and never trusts preview's. A row whose outcome moved is refused
+ * (`annotation-changed`); an ambiguous row must carry an identity PIN naming the
+ * device the operator chose, and the pin is re-checked against the candidate set
+ * as it stands now (`match-unconfirmed` / `match-changed`). A link-match needs no
+ * acknowledgement — the durable `device_external_links` row IS the operator's
+ * earlier acknowledgement, made once and reused on every subsequent run.
+ */
+
+import { inArray } from 'drizzle-orm';
+import { db } from '../../../db';
+import { deviceCustomFieldValues, deviceExternalLinks, deviceWarranty } from '../../../db/schema';
+import { pgErrorCode, pgErrorNode } from '../../../utils/pgErrors';
+import {
+  loadVisibleCustomFieldDefinitions,
+  persistDeviceCustomFieldValues,
+  valueColumnsFor,
+  type CustomFieldValueColumns,
+  type CustomFieldValueWrite,
+  type VisibleCustomFieldDefinition,
+} from '../queries';
+import { validateCustomFieldValue, type CustomFieldValueRejection } from '../validateValue';
+import {
+  loadDeviceResolutionSnapshot,
+  resolveDeviceRow,
+  type DeviceResolutionScope,
+} from './resolveDevice';
+import { applyWarrantyImport, coerceWarrantyValue, type WarrantyImportWrite } from './warrantyTarget';
+import {
+  DEFAULT_IMPORT_SYSTEM,
+  type AnnotatedImportValue,
+  type AnnotatedValueRow,
+  type CommitValueRowInput,
+  type CustomFieldImportRejection,
+  type DeviceCustomFieldImportRow,
+  type DeviceCustomFieldImportValue,
+  type DeviceMatchMethod,
+  type DeviceResolution,
+  type ValueImportErrorCode,
+  type ValueImportErrorEntry,
+  type ValueImportMode,
+  type ValueImportRowResult,
+  type ValueImportSummary,
+  type WarrantyImportField,
+  type WarrantyImportOutcome,
+} from './types';
+
+export type * from './types';
+export { MAX_IMPORT_ROWS, MAX_IMPORT_VALUES } from './types';
+
+/**
+ * `types.ts` restates the rejection vocabulary structurally to keep its
+ * no-imports rule. This conversion is the compile-time proof that the two agree:
+ * a new reason in `validateValue.ts` that nobody added to the wire type fails
+ * the build HERE, instead of reaching a client as an unmodelled string.
+ */
+function asImportRejection(reason: CustomFieldValueRejection): CustomFieldImportRejection {
+  return reason;
+}
+
+/** What the importer is allowed to see and do, resolved once at the route. */
+export interface ValueImportContext extends DeviceResolutionScope {
+  /** Default `skip`, verbatim from the contacts importer. */
+  mode?: ValueImportMode;
+  /** Decision 7: an operator opt-in, off by default. */
+  overrideProviderWarranty?: boolean;
+}
+
+export interface ValueImportActor {
+  userId: string | null;
+}
+
+/**
+ * Custom-field keys `routes/partnerApi/devices.ts` republishes as a device's
+ * `stableIdentifiers` to every integration the partner has connected
+ * (`stringCustomIdentifier(row.customFields, [...])`). Importing one is
+ * intended — that IS the migration — but doing it fleet-wide without being told
+ * is not, so preview says so on the value rather than after the fact.
+ */
+const RESERVED_IDENTITY_KEYS = new Set([
+  'assetTag', 'asset_tag',
+  'inventoryId', 'inventory_id',
+  'externalId', 'external_id',
+]);
+
+const RESERVED_IDENTITY_WARNING =
+  'This key feeds the device\'s partner integration identity (stableIdentifiers), '
+  + 'which is republished to every connected integration';
+
+const PROVIDER_WARRANTY_WARNING =
+  'A manufacturer warranty lookup already owns this device\'s warranty data — '
+  + 'enable "override provider warranty" to replace it';
+
+interface StoredValue extends CustomFieldValueColumns {
+  definitionId: string;
+}
+
+/** The device a row will actually be written to, once resolution and any pin agree. */
+interface RowTarget {
+  deviceId: string;
+  orgId: string;
+  method: DeviceMatchMethod;
+  osType: string | null;
+}
+
+interface AnnotationState {
+  /** `orgId` -> `field_key` -> definition visible to that organization. */
+  definitionsByOrg: Map<string, Map<string, VisibleCustomFieldDefinition>>;
+  /** `deviceId` -> `definitionId` -> the value already stored. */
+  storedByDevice: Map<string, Map<string, StoredValue>>;
+  /** `deviceId` -> the existing warranty row's provenance. */
+  warrantyByDevice: Map<string, string | null>;
+  mode: ValueImportMode;
+  overrideProviderWarranty: boolean;
+}
+
+/**
+ * Resolution plus the device it settles on. `target` is null whenever no single
+ * device is established — including an ambiguous row whose pin does not name a
+ * current candidate, which the commit loop then reports precisely.
+ */
+interface ResolvedRow {
+  resolution: DeviceResolution;
+  target: RowTarget | null;
+}
+
+function pinnedDeviceId(row: DeviceCustomFieldImportRow): string | undefined {
+  return (row as CommitValueRowInput).expectedDeviceId;
+}
+
+function resolveRows(
+  rows: readonly DeviceCustomFieldImportRow[],
+  snapshot: Awaited<ReturnType<typeof loadDeviceResolutionSnapshot>>,
+): ResolvedRow[] {
+  return rows.map((row) => {
+    const resolution = resolveDeviceRow(row, snapshot);
+
+    const toTarget = (deviceId: string, method: DeviceMatchMethod): RowTarget | null => {
+      const record = snapshot.devices.get(deviceId);
+      return record ? { deviceId, orgId: record.orgId, method, osType: record.osType } : null;
+    };
+
+    if (resolution.deviceId && resolution.method) {
+      return { resolution, target: toTarget(resolution.deviceId, resolution.method) };
+    }
+
+    // An ambiguous row is writable ONLY against an explicit, still-valid pick.
+    if (resolution.outcome === 'ambiguous') {
+      const pin = pinnedDeviceId(row);
+      const candidate = pin ? resolution.candidates.find((c) => c.deviceId === pin) : undefined;
+      if (candidate) return { resolution, target: toTarget(candidate.deviceId, candidate.method) };
+    }
+
+    return { resolution, target: null };
+  });
+}
+
+async function loadAnnotationState(
+  resolved: readonly ResolvedRow[],
+  ctx: ValueImportContext,
+): Promise<AnnotationState> {
+  const state: AnnotationState = {
+    definitionsByOrg: new Map(),
+    storedByDevice: new Map(),
+    warrantyByDevice: new Map(),
+    mode: ctx.mode ?? 'skip',
+    overrideProviderWarranty: ctx.overrideProviderWarranty ?? false,
+  };
+
+  const deviceIds = [...new Set(resolved.map((r) => r.target?.deviceId).filter((id): id is string => !!id))];
+  const orgIds = [...new Set(resolved.map((r) => r.target?.orgId).filter((id): id is string => !!id))];
+  if (deviceIds.length === 0) return state;
+
+  // ONE call per DISTINCT organization, not per row. `loadVisibleCustomFieldDefinitions`
+  // (W04) is reused rather than re-implemented as a batched query, because it
+  // owns the org-XOR-partner visibility rule and a second copy of that rule is
+  // exactly the kind of drift the partner-wide retrofits cost us. It does open a
+  // system context per call (#1105); a file spanning dozens of organizations
+  // would be worth batching, and this is where that would go.
+  for (const orgId of orgIds) {
+    const definitions = await loadVisibleCustomFieldDefinitions(orgId);
+    state.definitionsByOrg.set(orgId, new Map(definitions.map((d) => [d.fieldKey, d])));
+  }
+
+  // Ambient REQUEST context (see the module header): bounded to devices the
+  // snapshot already admitted, and under the same RLS the writes will run.
+  const stored = (await db
+    .select({
+      deviceId: deviceCustomFieldValues.deviceId,
+      definitionId: deviceCustomFieldValues.definitionId,
+      valueText: deviceCustomFieldValues.valueText,
+      valueNumber: deviceCustomFieldValues.valueNumber,
+      valueBool: deviceCustomFieldValues.valueBool,
+      valueDate: deviceCustomFieldValues.valueDate,
+    })
+    .from(deviceCustomFieldValues)
+    .where(inArray(deviceCustomFieldValues.deviceId, deviceIds))) as Array<StoredValue & { deviceId: string }>;
+
+  for (const row of stored) {
+    let byDefinition = state.storedByDevice.get(row.deviceId);
+    if (!byDefinition) {
+      byDefinition = new Map();
+      state.storedByDevice.set(row.deviceId, byDefinition);
+    }
+    byDefinition.set(row.definitionId, row);
+  }
+
+  const warranty = (await db
+    .select({ deviceId: deviceWarranty.deviceId, dataSource: deviceWarranty.dataSource })
+    .from(deviceWarranty)
+    .where(inArray(deviceWarranty.deviceId, deviceIds))) as Array<{ deviceId: string; dataSource: string | null }>;
+
+  for (const row of warranty) state.warrantyByDevice.set(row.deviceId, row.dataSource);
+
+  return state;
+}
+
+function sameStoredValue(stored: CustomFieldValueColumns, columns: CustomFieldValueColumns): boolean {
+  const date = (value: string | null): string | null => (value === null ? null : String(value).slice(0, 10));
+  return (
+    (stored.valueText ?? null) === columns.valueText
+    && (stored.valueNumber ?? null) === columns.valueNumber
+    && (stored.valueBool ?? null) === columns.valueBool
+    && date(stored.valueDate ?? null) === date(columns.valueDate)
+  );
+}
+
+/**
+ * One value's annotation plus, when it would be written, the resolved payload.
+ * Kept together so commit never re-derives (and never re-validates) what preview
+ * already decided for that row in the same pass.
+ */
+interface ValueDecision {
+  annotation: AnnotatedImportValue;
+  fieldWrite?: CustomFieldValueWrite;
+  warrantyWrite?: { field: WarrantyImportField; value: string | null };
+}
+
+function decideValue(
+  entry: DeviceCustomFieldImportValue,
+  target: RowTarget | null,
+  state: AnnotationState,
+): ValueDecision {
+  const { target: mapping } = entry;
+
+  // No single device means no organization, and therefore no definitions to
+  // judge this value against. Saying so is more useful than borrowing an
+  // annotation that means something else.
+  if (!target) return { annotation: { target: mapping, outcome: 'device-unresolved' } };
+
+  if (mapping.kind === 'warranty') {
+    const coerced = coerceWarrantyValue(mapping.field, entry.value);
+    if (!coerced.ok) {
+      return { annotation: { target: mapping, outcome: 'type-error', reason: coerced.reason } };
+    }
+    if (state.warrantyByDevice.get(target.deviceId) === 'provider' && !state.overrideProviderWarranty) {
+      return {
+        annotation: { target: mapping, outcome: 'skipped-already-set', warning: PROVIDER_WARRANTY_WARNING },
+      };
+    }
+    return {
+      annotation: { target: mapping, outcome: 'applied' },
+      warrantyWrite: { field: mapping.field, value: coerced.value },
+    };
+  }
+
+  const definition = state.definitionsByOrg.get(target.orgId)?.get(mapping.fieldKey);
+  if (!definition) return { annotation: { target: mapping, outcome: 'no-definition' } };
+
+  // The same gate `validateValueMap` applies on the PATCH paths: a null
+  // (unknown) osType is treated as non-matching, never as a wildcard.
+  if (
+    Array.isArray(definition.deviceTypes)
+    && definition.deviceTypes.length > 0
+    && (target.osType === null || !definition.deviceTypes.includes(target.osType))
+  ) {
+    return { annotation: { target: mapping, outcome: 'not-applicable-to-device' } };
+  }
+
+  // ONE validator, shared with the script write-back and both PATCH paths.
+  const result = validateCustomFieldValue(definition, entry.value);
+  if (!result.ok) {
+    return { annotation: { target: mapping, outcome: 'type-error', reason: asImportRejection(result.reason) } };
+  }
+
+  const columns = valueColumnsFor(definition.type, result.value);
+  const stored = state.storedByDevice.get(target.deviceId)?.get(definition.id);
+  if (stored && (state.mode === 'skip' || sameStoredValue(stored, columns))) {
+    // Both readings of "already set": an identical re-import (a no-op in either
+    // mode) and a differing value the default `skip` mode declines to overwrite.
+    return { annotation: { target: mapping, outcome: 'skipped-already-set' } };
+  }
+
+  return {
+    annotation: {
+      target: mapping,
+      outcome: 'applied',
+      ...(RESERVED_IDENTITY_KEYS.has(mapping.fieldKey) ? { warning: RESERVED_IDENTITY_WARNING } : {}),
+    },
+    fieldWrite: {
+      definitionId: definition.id,
+      fieldKey: definition.fieldKey,
+      type: definition.type,
+      value: result.value,
+    },
+  };
+}
+
+function annotateRow(
+  index: number,
+  { resolution, target }: ResolvedRow,
+  decisions: readonly ValueDecision[],
+): AnnotatedValueRow {
+  return {
+    index,
+    outcome: resolution.outcome,
+    deviceId: target?.deviceId ?? resolution.deviceId,
+    method: target?.method ?? resolution.method,
+    organizationId: target?.orgId ?? null,
+    candidates: resolution.candidates,
+    ...(resolution.conflictingMethods ? { conflictingMethods: resolution.conflictingMethods } : {}),
+    ...(resolution.discardedIdentifiers ? { discardedIdentifiers: resolution.discardedIdentifiers } : {}),
+    values: decisions.map((d) => d.annotation),
+  };
+}
+
+/** Resolve, load and annotate in one pass. Shared verbatim by preview and commit. */
+async function deriveRows(
+  rows: readonly DeviceCustomFieldImportRow[],
+  ctx: ValueImportContext,
+): Promise<Array<{ resolved: ResolvedRow; decisions: ValueDecision[]; annotated: AnnotatedValueRow }>> {
+  const snapshot = await loadDeviceResolutionSnapshot(rows, ctx);
+  const resolved = resolveRows(rows, snapshot);
+  const state = await loadAnnotationState(resolved, ctx);
+
+  return rows.map((row, index) => {
+    const decisions = row.values.map((entry) => decideValue(entry, resolved[index]!.target, state));
+    return { resolved: resolved[index]!, decisions, annotated: annotateRow(index, resolved[index]!, decisions) };
+  });
+}
+
+export async function previewDeviceCustomFieldImport(
+  rows: readonly DeviceCustomFieldImportRow[],
+  ctx: ValueImportContext,
+): Promise<AnnotatedValueRow[]> {
+  return (await deriveRows(rows, ctx)).map((r) => r.annotated);
+}
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * Commit
+ * ────────────────────────────────────────────────────────────────────────── */
+
+interface RowProblem {
+  error: string;
+  code: ValueImportErrorCode;
+}
+
+/**
+ * Resolution outcomes that can never be acknowledged into a write, mapped to the
+ * error code that says why. Keyed by the outcome union rather than `string` so
+ * renaming an outcome fails the build instead of falling through.
+ */
+const REFUSED_OUTCOMES: Partial<Record<DeviceResolution['outcome'], ValueImportErrorCode>> = {
+  'not-found': 'not-found',
+  'org-not-found': 'org-not-found',
+  'identity-conflict': 'identity-conflict',
+};
+
+const REFUSAL_COPY: Partial<Record<DeviceResolution['outcome'], string>> = {
+  'not-found': 'No device in reach matches the identifiers on this row',
+  'org-not-found': 'That organization was not found',
+  'identity-conflict': 'The identifiers on this row point at different devices — correct the file and re-run preview',
+};
+
+/**
+ * Validate the client's acknowledgement against the freshly re-derived
+ * resolution. Order matters: the outcome guard runs first, then identity
+ * pinning, so a row whose whole story changed says so before it is asked about
+ * a device it no longer resolves to.
+ */
+function checkExpectation(row: CommitValueRowInput, { resolution, target }: ResolvedRow): RowProblem | null {
+  if (row.expectedOutcome && row.expectedOutcome !== resolution.outcome) {
+    return {
+      code: 'annotation-changed',
+      error: `Match changed since preview: expected "${row.expectedOutcome}", now "${resolution.outcome}" — re-run preview`,
+    };
+  }
+
+  if (resolution.outcome === 'ambiguous') {
+    if (!row.expectedDeviceId) {
+      return {
+        code: 'match-unconfirmed',
+        error: 'Several devices match this row — pick one and resubmit it with expectedDeviceId',
+      };
+    }
+    if (!target) {
+      return {
+        code: 'match-changed',
+        error: 'The device this row was pinned to is no longer one of its candidates — re-run preview',
+      };
+    }
+    return null;
+  }
+
+  if (row.expectedDeviceId && row.expectedDeviceId !== resolution.deviceId) {
+    return {
+      code: 'match-changed',
+      error: 'This row now resolves to a different device than the one it was pinned to — re-run preview',
+    };
+  }
+  return null;
+}
+
+/**
+ * Fixed copy per SQLSTATE. A postgres.js `.message` carries the failing
+ * statement's detail — column values, constraint text, sometimes the query — so
+ * it is customer data and schema disclosure in one string and must never reach a
+ * response body.
+ */
+const WRITE_FAILURE_COPY: Record<string, string> = {
+  '23503': 'This device, or a custom field it names, no longer exists',
+  '23505': 'Another write to this device raced this import — re-run it for this row',
+  '23514': 'A value on this row violates a constraint on the field it targets',
+  '22001': 'A value on this row is too long for the field it targets',
+  '42501': 'You do not have access to write values for this device',
+};
+const GENERIC_WRITE_FAILURE = 'Could not write this device — check the server log for details';
+
+function writeFailure(err: unknown): RowProblem {
+  const code = pgErrorCode(err);
+  return { error: (code && WRITE_FAILURE_COPY[code]) ?? GENERIC_WRITE_FAILURE, code: 'write-failed' };
+}
+
+/**
+ * Attach the thrown error WITHOUT making it serializable: routes hand this
+ * summary straight to `c.json(...)`. Read `entry.cause` in-process; never
+ * serialize it.
+ */
+function withCause(entry: ValueImportErrorEntry, cause: unknown): ValueImportErrorEntry {
+  Object.defineProperty(entry, 'cause', { value: cause, enumerable: false, writable: false });
+  return entry;
+}
+
+interface RowWriteResult {
+  changedFieldKeys: string[];
+  linkCreated: boolean;
+  warranty: WarrantyImportOutcome;
+}
+
+/**
+ * ONE transaction for one device row: its values, its durable link, and its
+ * warranty. A failure anywhere rolls back that device only — one row, one atom —
+ * and the rows after it still commit.
+ */
+async function writeRow(
+  row: CommitValueRowInput,
+  target: RowTarget,
+  decisions: readonly ValueDecision[],
+  ctx: ValueImportContext,
+  actor: ValueImportActor,
+): Promise<RowWriteResult> {
+  const fieldWrites = decisions.map((d) => d.fieldWrite).filter((w): w is CustomFieldValueWrite => !!w);
+
+  const warrantyWrite: WarrantyImportWrite = { deviceId: target.deviceId, orgId: target.orgId };
+  let hasWarranty = false;
+  for (const decision of decisions) {
+    if (!decision.warrantyWrite) continue;
+    warrantyWrite[decision.warrantyWrite.field] = decision.warrantyWrite.value;
+    hasWarranty = true;
+  }
+
+  const externalId = row.externalId?.trim();
+  // Only mint a link when the row was resolved some OTHER way — a link-match
+  // already has one, and re-asserting it would be a write per row per run.
+  const needsLink = !!externalId && target.method !== 'link';
+  // The SAME key derivation W06's resolver uses, so the row the next run looks
+  // up is the row this one wrote. A batch-level default here would silently
+  // break re-resolution.
+  const linkSystem = row.externalSystem?.trim() || DEFAULT_IMPORT_SYSTEM;
+
+  return db.transaction(async (tx) => {
+    // Every statement below is issued on `tx`. Issuing on the ambient `db` proxy
+    // would record a failure against the OUTER request transaction and destroy
+    // the per-row isolation this whole structure exists for.
+    const changedFieldKeys = await persistDeviceCustomFieldValues(
+      target.deviceId,
+      target.orgId,
+      fieldWrites,
+      'import',
+      tx,
+    );
+
+    let linkCreated = false;
+    if (needsLink) {
+      const created = await tx
+        .insert(deviceExternalLinks)
+        .values({
+          deviceId: target.deviceId,
+          orgId: target.orgId,
+          partnerId: ctx.partnerId,
+          system: linkSystem,
+          sourceInstance: row.externalSourceInstance ?? null,
+          externalId: externalId!,
+          createdBy: actor.userId,
+        })
+        // Untargeted on purpose: the shipped unique index keys on
+        // `COALESCE(source_instance, '')`, and a concurrent run that minted the
+        // same link first is a no-op, not a failure.
+        .onConflictDoNothing()
+        .returning({ id: deviceExternalLinks.id });
+      linkCreated = created.length > 0;
+    }
+
+    const warranty = hasWarranty
+      ? await applyWarrantyImport(tx, warrantyWrite, { overrideProvider: ctx.overrideProviderWarranty ?? false })
+      : ('none' as const);
+
+    return { changedFieldKeys, linkCreated, warranty };
+  });
+}
+
+function tallyRow(
+  index: number,
+  row: CommitValueRowInput,
+  target: RowTarget,
+  decisions: readonly ValueDecision[],
+  written: RowWriteResult,
+): ValueImportRowResult {
+  const changed = new Set(written.changedFieldKeys);
+  let applied = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (const decision of decisions) {
+    const outcome = decision.annotation.outcome;
+    if (outcome === 'skipped-already-set') {
+      skipped += 1;
+    } else if (outcome === 'applied') {
+      if (decision.fieldWrite) {
+        // The database's compare-before-write can still decline an UPDATE that
+        // would change nothing — a concurrent writer got there first. Counted as
+        // skipped rather than applied so the totals describe what happened.
+        if (changed.has(decision.fieldWrite.fieldKey)) applied += 1;
+        else skipped += 1;
+      } else if (written.warranty === 'applied') {
+        applied += 1;
+      } else {
+        skipped += 1;
+      }
+    } else {
+      // no-definition / type-error / not-applicable-to-device. `device-unresolved`
+      // cannot reach here — the row would not have a target.
+      failed += 1;
+    }
+  }
+
+  return {
+    index,
+    deviceId: target.deviceId,
+    organizationId: target.orgId,
+    method: target.method,
+    externalSystem: row.externalSystem?.trim() || null,
+    applied,
+    skipped,
+    failed,
+    appliedFieldKeys: written.changedFieldKeys,
+    warranty: written.warranty,
+    linkCreated: written.linkCreated,
+  };
+}
+
+export async function commitDeviceCustomFieldImport(
+  rows: readonly CommitValueRowInput[],
+  ctx: ValueImportContext,
+  actor: ValueImportActor,
+  options: { mode?: ValueImportMode } = {},
+): Promise<ValueImportSummary> {
+  const effectiveCtx: ValueImportContext = { ...ctx, mode: options.mode ?? ctx.mode };
+  // Re-derived against state loaded NOW, never against whatever preview saw.
+  const derived = await deriveRows(rows, effectiveCtx);
+
+  const summary: ValueImportSummary = {
+    appliedValues: 0,
+    skippedValues: 0,
+    failedValues: 0,
+    rows: [],
+    linksCreated: 0,
+    errors: [],
+  };
+
+  for (let index = 0; index < derived.length; index += 1) {
+    const { resolved, decisions } = derived[index]!;
+    const row = rows[index]!;
+
+    const refusal = REFUSED_OUTCOMES[resolved.resolution.outcome];
+    if (refusal) {
+      summary.errors.push({
+        index,
+        error: REFUSAL_COPY[resolved.resolution.outcome] ?? 'This row cannot be imported',
+        code: refusal,
+      });
+      continue;
+    }
+
+    const problem = checkExpectation(row, resolved);
+    if (problem) {
+      summary.errors.push({ index, ...problem });
+      continue;
+    }
+
+    if (!resolved.target) {
+      // Unreachable: every non-refused, expectation-clean outcome establishes a
+      // target. Fails closed rather than asserting non-null.
+      summary.errors.push({
+        index,
+        error: 'This row did not resolve to a single device — re-run preview',
+        code: 'match-unconfirmed',
+      });
+      continue;
+    }
+
+    try {
+      const written = await writeRow(row, resolved.target, decisions, effectiveCtx, actor);
+      const result = tallyRow(index, row, resolved.target, decisions, written);
+      // Pushed only after the write resolved, so a throw can never leave a row
+      // in both `rows` and `errors`.
+      summary.rows.push(result);
+      summary.appliedValues += result.applied;
+      summary.skippedValues += result.skipped;
+      summary.failedValues += result.failed;
+      if (result.linkCreated) summary.linksCreated += 1;
+    } catch (err) {
+      const node = pgErrorNode(err);
+      const constraint = typeof node?.constraint_name === 'string'
+        ? node.constraint_name
+        : typeof node?.constraint === 'string'
+          ? node.constraint
+          : undefined;
+      console.error('[custom-field-value-import] row failed', {
+        partnerId: ctx.partnerId,
+        index,
+        deviceId: resolved.target.deviceId,
+        actorUserId: actor.userId,
+        code: pgErrorCode(err),
+        ...(constraint ? { constraint } : {}),
+        error: err instanceof Error ? err.message : String(err),
+      });
+      summary.errors.push(withCause({ index, ...writeFailure(err) }, err));
+    }
+  }
+
+  return summary;
+}

--- a/apps/api/src/services/customFields/import/valueImport.ts
+++ b/apps/api/src/services/customFields/import/valueImport.ts
@@ -517,6 +517,10 @@ async function writeRow(
     warrantyWrite[decision.warrantyWrite.field] = decision.warrantyWrite.value;
     hasWarranty = true;
   }
+  /** A warranty column WAS mapped, and the annotator declined it. */
+  const warrantyDeclined = decisions.some(
+    (d) => d.annotation.target.kind === 'warranty' && d.annotation.outcome === 'skipped-already-set',
+  );
 
   const externalId = row.externalId?.trim();
   // Only mint a link when the row was resolved some OTHER way — a link-match
@@ -560,9 +564,16 @@ async function writeRow(
       linkCreated = created.length > 0;
     }
 
+    // A warranty target the annotator already declined (today: the row is
+    // provider-owned and the operator did not opt in) is reported as the REASON
+    // it was declined, not as `none`. `none` means "this row mapped no warranty
+    // column at all", and collapsing the two would tell an operator their
+    // warranty column was never mapped when in fact it was refused.
     const warranty = hasWarranty
       ? await applyWarrantyImport(tx, warrantyWrite, { overrideProvider: ctx.overrideProviderWarranty ?? false })
-      : ('none' as const);
+      : warrantyDeclined
+        ? ('skipped-provider-owned' as const)
+        : ('none' as const);
 
     return { changedFieldKeys, linkCreated, warranty };
   });

--- a/apps/api/src/services/customFields/import/warrantyTarget.test.ts
+++ b/apps/api/src/services/customFields/import/warrantyTarget.test.ts
@@ -1,0 +1,301 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The `warranty` mapping target (#3257 W08 Task 4, Open Decision 7).
+ *
+ * The property under test that everything else hangs off: the import must write
+ * a COMPUTED `status`, not just the date. `evaluateWarrantyAlerts` returns early
+ * on `status === 'unknown'` (`warrantyAlertEvaluator.ts:200`) and the column
+ * defaults to `'unknown'`, so a date-only write ships the flagship use case
+ * inert — and a test that only asserted "a row was written" would pass
+ * vacuously against exactly that bug.
+ */
+
+const insertMock = vi.fn();
+const selectMock = vi.fn();
+
+vi.mock('../../../db', () => ({
+  db: {
+    insert: (...args: unknown[]) => insertMock(...args),
+    select: (...args: unknown[]) => selectMock(...args),
+  },
+  runOutsideDbContext: <T,>(fn: () => T) => fn(),
+  withSystemDbAccessContext: <T,>(fn: () => T) => fn(),
+}));
+
+vi.mock('../../../db/schema', () => ({
+  deviceWarranty: {
+    deviceId: 'deviceWarranty.deviceId',
+    dataSource: 'deviceWarranty.dataSource',
+  },
+  deviceHardware: {
+    deviceId: 'deviceHardware.deviceId',
+    serialNumber: 'deviceHardware.serialNumber',
+    manufacturer: 'deviceHardware.manufacturer',
+    model: 'deviceHardware.model',
+  },
+  devices: {
+    id: 'devices.id',
+    orgId: 'devices.orgId',
+    isEphemeral: 'devices.isEphemeral',
+    isVirtual: 'devices.isVirtual',
+  },
+}));
+
+// warrantySync pulls these in at module load; the real `computeWarrantyStatus`
+// is deliberately NOT mocked — it is the function under test's whole point.
+vi.mock('../../warrantyProviders', () => ({
+  getProviderForManufacturer: vi.fn(),
+  normalizeManufacturer: (m: string) => m.trim().toLowerCase(),
+}));
+vi.mock('../../warrantyAlertEvaluator', () => ({
+  evaluateWarrantyAlerts: vi.fn().mockResolvedValue(null),
+}));
+
+import { applyWarrantyImport, coerceWarrantyValue } from './warrantyTarget';
+
+const DEVICE = '44444444-4444-4444-8444-444444444444';
+const ORG = '11111111-1111-4111-8111-111111111111';
+
+function inDays(days: number): string {
+  return new Date(Date.now() + days * 86_400_000).toISOString().slice(0, 10);
+}
+
+interface ExistingWarranty {
+  dataSource: string | null;
+  warrantyStartDate: string | null;
+  warrantyEndDate: string | null;
+  manufacturer: string | null;
+  status: string;
+}
+
+/** Rigs `tx.select(...).from(...).where(...).limit(1)` to return `existing`. */
+function rigExisting(existing: ExistingWarranty | null) {
+  const limit = vi.fn().mockResolvedValue(existing ? [existing] : []);
+  const where = vi.fn().mockReturnValue({ limit });
+  const from = vi.fn().mockReturnValue({ where });
+  selectMock.mockReturnValue({ from });
+}
+
+/** Captures `tx.insert(...).values(v).onConflictDoUpdate(c).returning()`. */
+function captureUpsert(returned: unknown[] = [{ id: 'w-1' }]) {
+  const returning = vi.fn().mockResolvedValue(returned);
+  const onConflictDoUpdate = vi.fn().mockReturnValue({ returning });
+  const values = vi.fn().mockReturnValue({ onConflictDoUpdate });
+  insertMock.mockReturnValue({ values });
+  return { values, onConflictDoUpdate, returning };
+}
+
+// The executor the service receives is the nested-transaction handle. Here it
+// is the same pair of spies, which is what lets these tests assert the exact
+// column payload without a database.
+const tx = {
+  select: (...args: unknown[]) => selectMock(...args),
+  insert: (...args: unknown[]) => insertMock(...args),
+} as never;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('applyWarrantyImport', () => {
+  it('writes a COMPUTED status alongside the imported end date, sourced as import', async () => {
+    rigExisting(null);
+    const upsert = captureUpsert();
+
+    const outcome = await applyWarrantyImport(
+      tx,
+      { deviceId: DEVICE, orgId: ORG, warrantyEndDate: inDays(30) },
+      { overrideProvider: false },
+    );
+
+    expect(outcome).toBe('applied');
+    expect(upsert.values).toHaveBeenCalledTimes(1);
+    expect(upsert.values.mock.calls[0]![0]).toMatchObject({
+      deviceId: DEVICE,
+      orgId: ORG,
+      status: 'expiring',
+      warrantyEndDate: inDays(30),
+      dataSource: 'import',
+    });
+  });
+
+  it('computes expired and active from the same end date column', async () => {
+    rigExisting(null);
+    const past = captureUpsert();
+    await applyWarrantyImport(tx, { deviceId: DEVICE, orgId: ORG, warrantyEndDate: inDays(-5) }, { overrideProvider: false });
+    expect(past.values.mock.calls[0]![0]).toMatchObject({ status: 'expired' });
+
+    rigExisting(null);
+    const future = captureUpsert();
+    await applyWarrantyImport(tx, { deviceId: DEVICE, orgId: ORG, warrantyEndDate: inDays(400) }, { overrideProvider: false });
+    expect(future.values.mock.calls[0]![0]).toMatchObject({ status: 'active' });
+  });
+
+  it('NEVER sets is_subscription — an import cannot know it, and true suppresses expiry alerts', async () => {
+    rigExisting(null);
+    const upsert = captureUpsert();
+
+    await applyWarrantyImport(tx, { deviceId: DEVICE, orgId: ORG, warrantyEndDate: inDays(30) }, { overrideProvider: false });
+
+    expect(upsert.values.mock.calls[0]![0]).not.toHaveProperty('isSubscription');
+    expect(upsert.onConflictDoUpdate.mock.calls[0]![0].set).not.toHaveProperty('isSubscription');
+  });
+
+  it('refuses to clobber a provider-sourced row without an explicit opt-in, and writes nothing', async () => {
+    rigExisting({
+      dataSource: 'provider',
+      warrantyStartDate: null,
+      warrantyEndDate: inDays(400),
+      manufacturer: 'dell',
+      status: 'active',
+    });
+    const upsert = captureUpsert();
+
+    const outcome = await applyWarrantyImport(
+      tx,
+      { deviceId: DEVICE, orgId: ORG, warrantyEndDate: inDays(30) },
+      { overrideProvider: false },
+    );
+
+    expect(outcome).toBe('skipped-provider-owned');
+    expect(upsert.values).not.toHaveBeenCalled();
+  });
+
+  it('overrides a provider row when the operator opted in', async () => {
+    rigExisting({
+      dataSource: 'provider',
+      warrantyStartDate: null,
+      warrantyEndDate: inDays(400),
+      manufacturer: 'dell',
+      status: 'active',
+    });
+    const upsert = captureUpsert();
+
+    const outcome = await applyWarrantyImport(
+      tx,
+      { deviceId: DEVICE, orgId: ORG, warrantyEndDate: inDays(30) },
+      { overrideProvider: true },
+    );
+
+    expect(outcome).toBe('applied');
+    expect(upsert.values.mock.calls[0]![0]).toMatchObject({ status: 'expiring', dataSource: 'import' });
+  });
+
+  it('keeps the provider guard on the WRITE too, so a row that turns provider-owned mid-transaction is still refused', async () => {
+    // The read above is advisory; the setWhere is the authority. A statement
+    // that the guard blocks returns no row, and that must not read as applied.
+    rigExisting(null);
+    const upsert = captureUpsert([]);
+
+    const outcome = await applyWarrantyImport(
+      tx,
+      { deviceId: DEVICE, orgId: ORG, warrantyEndDate: inDays(30) },
+      { overrideProvider: false },
+    );
+
+    expect(outcome).toBe('skipped-provider-owned');
+    expect(upsert.onConflictDoUpdate.mock.calls[0]![0].setWhere).toBeDefined();
+  });
+
+  it('drops the guard from the statement when the operator opted in', async () => {
+    rigExisting(null);
+    const upsert = captureUpsert();
+
+    await applyWarrantyImport(tx, { deviceId: DEVICE, orgId: ORG, warrantyEndDate: inDays(30) }, { overrideProvider: true });
+
+    expect(upsert.onConflictDoUpdate.mock.calls[0]![0].setWhere).toBeUndefined();
+  });
+
+  it('reports an identical re-import as skipped-already-set and issues no write', async () => {
+    const end = inDays(30);
+    rigExisting({
+      dataSource: 'import',
+      warrantyStartDate: null,
+      warrantyEndDate: end,
+      manufacturer: null,
+      status: 'expiring',
+    });
+    const upsert = captureUpsert();
+
+    const outcome = await applyWarrantyImport(tx, { deviceId: DEVICE, orgId: ORG, warrantyEndDate: end }, { overrideProvider: false });
+
+    expect(outcome).toBe('skipped-already-set');
+    expect(upsert.values).not.toHaveBeenCalled();
+  });
+
+  it('recomputes status from the MERGED end date when only the manufacturer is imported', async () => {
+    // A file that maps only a manufacturer column must not blank the stored
+    // dates, and must not leave a status that contradicts them.
+    rigExisting({
+      dataSource: 'import',
+      warrantyStartDate: null,
+      warrantyEndDate: inDays(10),
+      manufacturer: null,
+      status: 'unknown',
+    });
+    const upsert = captureUpsert();
+
+    const outcome = await applyWarrantyImport(tx, { deviceId: DEVICE, orgId: ORG, manufacturer: 'Dell  ' }, { overrideProvider: false });
+
+    expect(outcome).toBe('applied');
+    expect(upsert.values.mock.calls[0]![0]).toMatchObject({
+      manufacturer: 'dell',
+      warrantyEndDate: inDays(10),
+      status: 'expiring',
+    });
+  });
+
+  it('does nothing at all when the row carries no warranty columns', async () => {
+    rigExisting(null);
+    const upsert = captureUpsert();
+
+    const outcome = await applyWarrantyImport(tx, { deviceId: DEVICE, orgId: ORG }, { overrideProvider: false });
+
+    expect(outcome).toBe('none');
+    expect(selectMock).not.toHaveBeenCalled();
+    expect(upsert.values).not.toHaveBeenCalled();
+  });
+
+  it('clears a date when the file explicitly maps an empty cell, and recomputes status to unknown', async () => {
+    rigExisting({
+      dataSource: 'import',
+      warrantyStartDate: null,
+      warrantyEndDate: inDays(30),
+      manufacturer: null,
+      status: 'expiring',
+    });
+    const upsert = captureUpsert();
+
+    const outcome = await applyWarrantyImport(tx, { deviceId: DEVICE, orgId: ORG, warrantyEndDate: null }, { overrideProvider: false });
+
+    expect(outcome).toBe('applied');
+    expect(upsert.values.mock.calls[0]![0]).toMatchObject({ warrantyEndDate: null, status: 'unknown' });
+  });
+});
+
+describe('coerceWarrantyValue', () => {
+  it('normalises a date cell to a plain calendar date', () => {
+    expect(coerceWarrantyValue('warrantyEndDate', '2027-03-04T00:00:00Z')).toEqual({ ok: true, value: '2027-03-04' });
+    expect(coerceWarrantyValue('warrantyStartDate', '2027-03-04')).toEqual({ ok: true, value: '2027-03-04' });
+  });
+
+  it('rejects an unparseable date with invalid_date', () => {
+    expect(coerceWarrantyValue('warrantyEndDate', 'not a date')).toEqual({ ok: false, reason: 'invalid_date' });
+    expect(coerceWarrantyValue('warrantyEndDate', 42)).toEqual({ ok: false, reason: 'invalid_date' });
+  });
+
+  it('treats an empty cell as an explicit clear, not an error', () => {
+    expect(coerceWarrantyValue('warrantyEndDate', '')).toEqual({ ok: true, value: null });
+    expect(coerceWarrantyValue('manufacturer', null)).toEqual({ ok: true, value: null });
+  });
+
+  it('accepts a manufacturer string and rejects a non-scalar', () => {
+    expect(coerceWarrantyValue('manufacturer', 'Dell')).toEqual({ ok: true, value: 'Dell' });
+    expect(coerceWarrantyValue('manufacturer', { a: 1 })).toEqual({ ok: false, reason: 'invalid_type' });
+  });
+
+  it('rejects a manufacturer longer than the column', () => {
+    expect(coerceWarrantyValue('manufacturer', 'x'.repeat(101))).toEqual({ ok: false, reason: 'too_long' });
+  });
+});

--- a/apps/api/src/services/customFields/import/warrantyTarget.ts
+++ b/apps/api/src/services/customFields/import/warrantyTarget.ts
@@ -1,0 +1,212 @@
+/**
+ * The `warranty` mapping target for the RMM value importer (#3257 W08 Task 4).
+ *
+ * WHY THIS EXISTS AT ALL (Open Decision 7). Warranty expiry is the flagship
+ * column of an incumbent export, and importing it into a text custom field
+ * ships the feature INERT: `device_warranty` — not `devices.custom_fields` — is
+ * what feeds `warrantyAlertEvaluator.ts`, the warranty dashboard and
+ * `routes/partnerApi/inventory.ts`, and `filterEngine` has no warranty field at
+ * all. A migrating MSP would see their expiry dates land somewhere and no alert
+ * ever fire.
+ *
+ * THE RULE THAT MAKES IT WORK: **compute and write `status`.**
+ * `evaluateWarrantyAlerts` returns early on `status === 'unknown'`
+ * (`warrantyAlertEvaluator.ts:200`) and the column DEFAULTS to `'unknown'`, so
+ * writing `warranty_end_date` alone changes nothing an operator can see. The
+ * status comes from `computeWarrantyStatus`, exported from `warrantySync.ts`
+ * rather than copied, so the provider sync and the importer can never disagree
+ * about what "expiring" means.
+ *
+ * TWO THINGS THIS DELIBERATELY WILL NOT DO:
+ *
+ *  1. **Clobber provider data without being asked.** `data_source = 'provider'`
+ *     means a manufacturer's own API answered for this serial; that is more
+ *     trustworthy than a hand-edited CSV. The refusal is enforced twice — the
+ *     read below decides the reported outcome, and a `setWhere` on the
+ *     statement is the authority, so a row that becomes provider-owned between
+ *     the read and the write is still refused rather than silently overwritten.
+ *  2. **Set `is_subscription`.** An import cannot know it, and a true value
+ *     suppresses expiry alerting outright (`warrantyAlertEvaluator.ts:208`) —
+ *     the exact failure this whole module exists to prevent, arrived at from
+ *     the other direction.
+ *
+ * Called from inside the value importer's PER-ROW transaction, on that
+ * transaction's handle, so a warranty failure rolls back that device's custom
+ * field values too: one row, one atom.
+ */
+
+import { and, eq, sql } from 'drizzle-orm';
+import { db } from '../../../db';
+import { deviceWarranty } from '../../../db/schema';
+import { computeWarrantyStatus } from '../../warrantySync';
+import { normalizeManufacturer } from '../../warrantyProviders';
+import type {
+  CustomFieldImportRejection,
+  WarrantyImportField,
+  WarrantyImportOutcome,
+} from './types';
+
+/**
+ * The nested-transaction handle. Every statement here MUST be issued on it and
+ * never on the ambient `db` proxy: the proxy resolves (via AsyncLocalStorage) to
+ * the OUTER request transaction, whose postgres.js scope would record the error
+ * and poison the whole request — see `dbSavepointErrorIsolation.integration.test.ts`.
+ */
+export type WarrantyImportExecutor = Pick<
+  Parameters<Parameters<typeof db.transaction>[0]>[0],
+  'select' | 'insert'
+>;
+
+export interface WarrantyImportWrite {
+  deviceId: string;
+  orgId: string;
+  /**
+   * Present-but-undefined means "this file did not map that column" and leaves
+   * the stored value alone. Present-and-null is an explicit clear. The two are
+   * distinguished with `in`, never with a truthiness check, because clearing a
+   * date has to remain expressible.
+   */
+  warrantyStartDate?: string | null;
+  warrantyEndDate?: string | null;
+  manufacturer?: string | null;
+}
+
+export type WarrantyValueResult =
+  | { ok: true; value: string | null }
+  | { ok: false; reason: CustomFieldImportRejection };
+
+/** `device_warranty.manufacturer` is `varchar(100)`. */
+const MAX_MANUFACTURER_LENGTH = 100;
+
+/**
+ * Validate and coerce ONE mapped warranty cell, mirroring what
+ * `validateCustomFieldValue` does for a custom field: total, never throws, and
+ * the only place that decides whether a warranty cell is acceptable.
+ *
+ * An empty cell is an explicit clear rather than an error, matching
+ * `validateCustomFieldValue`'s treatment of a blank date input — a CSV column
+ * that is populated for some rows and blank for others is the normal shape of
+ * an incumbent export, not a file the operator has to repair first.
+ */
+export function coerceWarrantyValue(field: WarrantyImportField, raw: unknown): WarrantyValueResult {
+  if (raw === null || raw === undefined) return { ok: true, value: null };
+
+  if (field === 'manufacturer') {
+    if (typeof raw !== 'string' && typeof raw !== 'number') return { ok: false, reason: 'invalid_type' };
+    const value = String(raw).trim();
+    if (value === '') return { ok: true, value: null };
+    if (value.length > MAX_MANUFACTURER_LENGTH) return { ok: false, reason: 'too_long' };
+    return { ok: true, value };
+  }
+
+  // A date column. Numbers are refused rather than parsed: a bare epoch or an
+  // Excel serial number in a date column is a mis-mapped column, and guessing
+  // which of the two it is would silently date a warranty decades wrong.
+  if (typeof raw !== 'string') return { ok: false, reason: 'invalid_date' };
+  const trimmed = raw.trim();
+  if (trimmed === '') return { ok: true, value: null };
+  const parsed = new Date(trimmed);
+  if (Number.isNaN(parsed.getTime())) return { ok: false, reason: 'invalid_date' };
+  // Stored as a plain calendar date, matching the `date` column type and
+  // `validateCustomFieldValue`'s own date handling.
+  return { ok: true, value: parsed.toISOString().slice(0, 10) };
+}
+
+/** True when the write names at least one warranty column. */
+export function hasWarrantyColumns(write: WarrantyImportWrite): boolean {
+  return 'warrantyStartDate' in write || 'warrantyEndDate' in write || 'manufacturer' in write;
+}
+
+interface ExistingWarrantyRow {
+  dataSource: string | null;
+  warrantyStartDate: string | null;
+  warrantyEndDate: string | null;
+  manufacturer: string | null;
+  status: string;
+}
+
+function merge<T>(write: WarrantyImportWrite, key: keyof WarrantyImportWrite, existing: T): T {
+  return key in write ? (write[key] as unknown as T) : existing;
+}
+
+export async function applyWarrantyImport(
+  tx: WarrantyImportExecutor,
+  write: WarrantyImportWrite,
+  options: { overrideProvider: boolean },
+): Promise<WarrantyImportOutcome> {
+  if (!hasWarrantyColumns(write)) return 'none';
+
+  const [existing] = (await tx
+    .select({
+      dataSource: deviceWarranty.dataSource,
+      warrantyStartDate: deviceWarranty.warrantyStartDate,
+      warrantyEndDate: deviceWarranty.warrantyEndDate,
+      manufacturer: deviceWarranty.manufacturer,
+      status: deviceWarranty.status,
+    })
+    .from(deviceWarranty)
+    .where(eq(deviceWarranty.deviceId, write.deviceId))
+    .limit(1)) as ExistingWarrantyRow[];
+
+  // A manufacturer lookup outranks a hand-typed CSV. Refused here so the
+  // operator gets `skipped-provider-owned` rather than a silent no-op.
+  if (existing && existing.dataSource === 'provider' && !options.overrideProvider) {
+    return 'skipped-provider-owned';
+  }
+
+  const rawManufacturer = merge<string | null>(write, 'manufacturer', existing?.manufacturer ?? null);
+  const manufacturer = rawManufacturer === null ? null : normalizeManufacturer(rawManufacturer);
+  const warrantyStartDate = merge<string | null>(write, 'warrantyStartDate', existing?.warrantyStartDate ?? null);
+  const warrantyEndDate = merge<string | null>(write, 'warrantyEndDate', existing?.warrantyEndDate ?? null);
+  // Recomputed from the MERGED end date, not from this file's cell: a row that
+  // maps only a manufacturer must not leave a status contradicting the dates
+  // already stored.
+  const status = computeWarrantyStatus(warrantyEndDate);
+
+  if (
+    existing &&
+    existing.warrantyStartDate === warrantyStartDate &&
+    existing.warrantyEndDate === warrantyEndDate &&
+    existing.manufacturer === manufacturer &&
+    existing.status === status
+  ) {
+    // Nothing would change. Reported honestly, and — as with
+    // `persistDeviceCustomFieldValues`' compare-before-write — no UPDATE is
+    // issued, so a re-imported file does not take a per-org export lock per
+    // device for a no-op.
+    return 'skipped-already-set';
+  }
+
+  const columns = {
+    manufacturer,
+    warrantyStartDate,
+    warrantyEndDate,
+    status,
+    // 'import' is a distinct provenance from 'provider' and 'agent_plist', so
+    // the NEXT provider sync can tell it apart. `is_subscription` is never set
+    // here — see the module header.
+    dataSource: 'import' as const,
+  };
+
+  const written = await tx
+    .insert(deviceWarranty)
+    .values({ deviceId: write.deviceId, orgId: write.orgId, ...columns })
+    .onConflictDoUpdate({
+      target: deviceWarranty.deviceId,
+      set: { ...columns, orgId: write.orgId, updatedAt: new Date() },
+      // The AUTHORITY on the provider rule; the read above is advisory. A row
+      // that turns provider-owned between the two matches no target here and
+      // the statement writes nothing rather than clobbering it.
+      ...(options.overrideProvider
+        ? {}
+        : {
+            setWhere: and(
+              sql`${deviceWarranty.dataSource} IS DISTINCT FROM 'provider'`,
+            ),
+          }),
+    })
+    .returning({ id: deviceWarranty.id });
+
+  // No row means the guard blocked the update. Never report that as applied.
+  return written.length > 0 ? 'applied' : 'skipped-provider-owned';
+}

--- a/apps/api/src/services/customFields/import/warrantyTarget.ts
+++ b/apps/api/src/services/customFields/import/warrantyTarget.ts
@@ -117,12 +117,40 @@ export function hasWarrantyColumns(write: WarrantyImportWrite): boolean {
   return 'warrantyStartDate' in write || 'warrantyEndDate' in write || 'manufacturer' in write;
 }
 
-interface ExistingWarrantyRow {
+export interface ExistingWarrantyRow {
   dataSource: string | null;
   warrantyStartDate: string | null;
   warrantyEndDate: string | null;
   manufacturer: string | null;
   status: string;
+}
+
+/**
+ * Would writing `value` into `field` change anything?
+ *
+ * PREVIEW uses this so it annotates a warranty cell the way commit will treat
+ * it, instead of promising `applied` for a re-import of an unchanged file. It
+ * lives here, beside `applyWarrantyImport`, because the two must agree — and
+ * the end-date case is the reason it cannot be a naive equality check: the
+ * stored `status` is derived from that date and DECAYS with time, so a row
+ * whose date is unchanged but whose status has since gone stale ('active' that
+ * should now read 'expiring') must still be treated as a change, or the import
+ * would quietly stop being the thing that refreshes it.
+ */
+export function warrantyCellUnchanged(
+  field: WarrantyImportField,
+  existing: ExistingWarrantyRow,
+  value: string | null,
+): boolean {
+  if (field === 'manufacturer') {
+    const incoming = value === null ? null : normalizeManufacturer(value);
+    return (existing.manufacturer ?? null) === incoming;
+  }
+  if (field === 'warrantyStartDate') {
+    return (existing.warrantyStartDate ?? null) === value;
+  }
+  return (existing.warrantyEndDate ?? null) === value
+    && existing.status === computeWarrantyStatus(value);
 }
 
 function merge<T>(write: WarrantyImportWrite, key: keyof WarrantyImportWrite, existing: T): T {

--- a/apps/api/src/services/customFields/queries.ts
+++ b/apps/api/src/services/customFields/queries.ts
@@ -131,6 +131,13 @@ export interface CustomFieldValueWrite {
   value: string | number | boolean | null;
 }
 
+/**
+ * Whatever issues the upsert: the ambient `db` proxy by default, or a nested
+ * transaction handle for a caller that needs per-row failure isolation. See the
+ * `executor` note on `persistDeviceCustomFieldValues`.
+ */
+export type CustomFieldValueExecutor = Pick<typeof db, 'insert'>;
+
 /** The four typed columns; exactly one non-null, or all null for a clear. */
 export interface CustomFieldValueColumns {
   valueText: string | null;
@@ -201,18 +208,30 @@ export function valueColumnsFor(
  * every row again — WAL and a row lock per device — which is the exact cost this
  * comparison exists to avoid. Provenance is informational; the write amplification
  * is not. Do not "fix" this without that trade in front of you.
+ *
+ * `executor` defaults to the ambient `db` proxy, which is what every request
+ * path wants. The RMM value importer (#3257 W08) passes the handle of its
+ * PER-ROW nested transaction instead: a statement issued on the ambient proxy
+ * from inside a nested transaction still resolves to the OUTER request
+ * transaction, so a failure is recorded against the outer postgres.js scope and
+ * poisons the whole request instead of rolling back to that row's savepoint
+ * (`dbSavepointErrorIsolation.integration.test.ts` is the proof). The parameter
+ * exists so the importer gets per-row failure isolation WITHOUT forking this
+ * upsert — the compare-before-write `setWhere` below is subtle and load-bearing,
+ * and a second copy of it would drift.
  */
 export async function persistDeviceCustomFieldValues(
   deviceId: string,
   orgId: string,
   writes: CustomFieldValueWrite[],
   source: 'manual' | 'api' | 'script' | 'import',
+  executor: CustomFieldValueExecutor = db,
 ): Promise<string[]> {
   if (writes.length === 0) return [];
   const changed: string[] = [];
   for (const write of writes) {
     const columns = valueColumnsFor(write.type, write.value);
-    const updated = await db
+    const updated = await executor
       .insert(deviceCustomFieldValues)
       .values({
         deviceId,

--- a/apps/api/src/services/warrantySync.ts
+++ b/apps/api/src/services/warrantySync.ts
@@ -5,9 +5,17 @@ import { getProviderForManufacturer, normalizeManufacturer } from './warrantyPro
 import type { WarrantyLookupResult } from './warrantyProviders';
 import { evaluateWarrantyAlerts } from './warrantyAlertEvaluator';
 
-type WarrantyStatus = 'active' | 'expiring' | 'expired' | 'unknown' | 'subscription_active';
+export type WarrantyStatus = 'active' | 'expiring' | 'expired' | 'unknown' | 'subscription_active';
 
-function computeWarrantyStatus(endDate: string | null, warnDays = 90): WarrantyStatus {
+/**
+ * EXPORTED for `services/customFields/import/warrantyTarget.ts` (#3257 W08),
+ * which writes `device_warranty` from an imported CSV and must derive `status`
+ * the same way every other writer does. `evaluateWarrantyAlerts` returns early
+ * on `status === 'unknown'` and the column defaults to it, so a writer that
+ * computed its own status — or skipped it — would ship warranty alerting inert
+ * for every imported device. One function, one rule; do not copy it.
+ */
+export function computeWarrantyStatus(endDate: string | null, warnDays = 90): WarrantyStatus {
   if (!endDate) return 'unknown';
   const now = new Date();
   const end = new Date(endDate);


### PR DESCRIPTION
Closes #4776

Wave 08 of #4768 (#3257): the **values** half of the RMM custom-field importer, including the `warranty` mapping target. **No migration in this wave.** No `apps/web` (W09), no docs (W10), no changes to W05's table/triggers/registration lists.

Premise verified on disk at `origin/main` before branching (`f02c7f8d0`), not assumed: W04 (`validateCustomFieldValue`, `loadVisibleCustomFieldDefinitions`), W05 (`device_custom_field_values`, `persistDeviceCustomFieldValues`, `2026-10-11-160000-device-custom-field-values.sql`), W06 (`import/{types,resolveDevice,deviceIdentity}.ts`, `device_external_links`), W07 (`import/{definitionImport,audit}.ts`, `customFields/writeErrors.ts`, `MAX_IMPORT_VALUES`) — all four present.

## Routes

| Method | Path | Behaviour |
|---|---|---|
| POST | `/devices/custom-fields/import/preview` | Resolves each row to a device and annotates **every value on it**. Writes nothing. |
| POST | `/devices/custom-fields/import` | Writes the acknowledged values, links and warranty. Always **200**, even with a non-empty `errors[]`. |

Both: `authMiddleware` (per route, never `.use('*')`) + `requireScope('organization','partner','system')` + `requirePermission(devices:write)` — the same grant `routes/devices/customFieldValues.ts` requires — + `requireMfa()`. **No `dualAuth`**, so an `X-API-Key`-only caller is a 401. Mounted immediately after `customFieldValuesRoutes` and before `coreRoutes`.

## Codes

**Row outcome** (`ValueRowOutcome`, aliased from W06's `DeviceRowOutcome` — not a second copy): `matched`, `link-match`, `ambiguous`, `not-found`, `org-not-found`, `identity-conflict`.

**Per-VALUE outcome** (`ValueOutcome`)

| Outcome | Meaning |
|---|---|
| `applied` | Written (or, at preview, would be). |
| `skipped-already-set` | A value is already stored and writing would change nothing, **or** it differs and the default `skip` mode declines to overwrite it. |
| `skipped-provider-owned` | Warranty only: a manufacturer API lookup owns this device's warranty and the operator did not opt into overriding it. |
| `no-definition` | No `custom_field_definitions` row visible to this device's org owns the key — run the definitions import (W07) first. |
| `type-error` | `validateCustomFieldValue` refused it; `reason` says how. |
| `not-applicable-to-device` | The definition is scoped to `deviceTypes` this device's OS is not in. |
| `device-unresolved` | The **row** did not resolve, so no value on it can be judged. |

**Commit error codes** (`ValueImportErrorCode`): `org-not-found`, `not-found`, `identity-conflict`, `annotation-changed`, `match-changed`, `match-unconfirmed`, `write-failed`.

**Warranty row outcome** (`WarrantyImportOutcome`): `applied`, `skipped-provider-owned`, `skipped-already-set`, `rejected` (a warranty column was mapped and every mapped cell was refused), `none` (no warranty column mapped at all).

## The four proofs the plan requires

All against real Postgres in `deviceCustomFieldValueImport.integration.test.ts` (10/10), which does **not** appeal to RLS on the resolution read — `loadDeviceResolutionSnapshot` runs under system scope where `breeze_has_org_access` is TRUE for every row, so an RLS assertion there would be vacuous.

1. **Isolation.** Under a partner-A context, four rows reaching for partner B's device by `deviceId`, by `hostname` + `serialNumber`, and by naming partner B's org all come back `not-found` / `org-not-found` — **never `write-failed`**, which would mean the write was attempted — and nothing lands on the foreign device while the legitimate row does.
2. **Transaction isolation.** With the app-layer scope deliberately widened past the request's RLS context (the shape a caller bug would take), the middle row's INSERT is refused by Postgres, the row **before** it stays committed and the row **after** it still runs: `errors = [{index: 1, write-failed}]`, `rows = [0, 2]`. That is simultaneously the proof that the writes really do stay inside the request context, and the proof that the per-row savepoint holds.
3. **Partial application.** One row, five values → 2 applied and stored, 3 reported (`no-definition`, `type-error`, `not-applicable-to-device`), and `devices.custom_fields` reprojected by W05's trigger with exactly the two.
4. **Second-run link resolution.** Run 1 resolves by `hostname` and mints the `device_external_links` row. A second device then takes the same hostname. Run 2 resolves `link-match` / `method: 'link'` with `linksCreated: 0`, while the control row — same hostname, no external id — is refused `match-unconfirmed`. Query-shape half in `valueImport.test.ts`: with only an external id supplied the resolver's `devices` query carries **no `lower(hostname)` predicate at all**, with the opposite case as the mutation control.

Plus: the warranty write flips `device_warranty.status` to `expiring` (with `is_subscription` false and `data_source: 'import'`) and `evaluateWarrantyAlerts` then returns an alert id where it returned `null` before — proven with the config-policy chain seeded, because warranty alerting is opt-in and a test without it would pass vacuously against `DISABLED_SETTINGS`.

## Deviations from the plan (code is truth)

1. **Writes stay in the request context, not `runOutsideDbContext`.** The plan opened each row's transaction outside the request context. That bypasses RLS on the write path of a bulk cross-organization tool — the place it is least affordable. This follows **W07's shipped pattern**: a nested `db.transaction` (a SAVEPOINT inside the request transaction, per `dbSavepointErrorIsolation.integration.test.ts`), which gives the same per-row failure isolation *and* keeps RLS as a real second control. Proof #2 above is the evidence that it does.
2. **`persistDeviceCustomFieldValues` gained an optional `executor` parameter** (`queries.ts`, one file outside the brief's "files you own"). The savepoint contract requires every statement to be issued on the nested `tx` — the ambient `db` proxy resolves to the OUTER transaction and would poison the request. The only alternatives were forking W05's upsert (its compare-before-write `setWhere` is subtle, load-bearing and would drift) or losing the isolation. The parameter defaults to `db`, so all three existing call sites are unchanged.
3. **`DeviceCustomFieldImportValue` changed from `{ fieldKey, value }` to `{ target, value }`**, per the plan's W08 Task 1 `MappingTarget`. W06 shipped the placeholder shape with a comment explicitly reserving the field's meaning for W08, and nothing outside these types ever read it (`resolveDeviceRow` does not touch `.values`).
4. **`ValueOutcome` drops the plan's `reserved-key` and adds `device-unresolved` + `skipped-provider-owned`.** The plan declared `reserved-key` but its own Task-2 test specifies the behaviour as *applied, with a warning* — a dead arm every W09 branch would carry. Meanwhile the plan's ambiguous-row test requires every value on an unresolved row to be non-`applied` and offers no member for it (`device-unresolved`), and the review pass established that a provider-owned warranty refusal must not wear the same badge as "nothing to do" (`skipped-provider-owned`, mirroring the row-level vocabulary). Every member is produced by the code.
5. **A declined warranty column reports `skipped-provider-owned` at the row level, not `none`.** Caught by the integration suite: `none` means "this row mapped no warranty column at all", and collapsing the two tells an operator their warranty column was never mapped when in fact it was refused.
6. **A row may not map two columns onto the same target** (zod refine, both routes). A duplicate is not one bad cell: the column-to-target mapping is chosen once for the whole file, so it would repeat on every row and the last column would silently win with the operator never told which value the device holds. The service's tally dedupes as well, so a direct caller cannot inflate `appliedValues` either.
7. **The `fieldKey` on a value row carries no `^[a-z][a-z0-9_]*$` regex**, unlike W07's definition-create rows. A key that could never own a definition simply gets `no-definition`; 400-ing a 30-column file over one bad header would defeat the per-value annotation this wave exists for.
8. **`loadVisibleCustomFieldDefinitions` is called once per DISTINCT organization** rather than replaced by a batched query. It owns the org-XOR-partner visibility rule and a second copy of that rule is the drift the partner-wide retrofits already cost us; the per-call system context (#1105) is noted at the call site as the place to batch if a file ever spans dozens of orgs.
9. **Preview strips acknowledgement fields** (`expectedOutcome` / `expectedDeviceId`) rather than 400-ing on them — zod's default object behaviour — so the service can never see a pin from the preview route and cannot silently honour one. Asserted.

## Caps and mutation checks

`MAX_IMPORT_ROWS = 1000` **and** `MAX_IMPORT_VALUES = 5000` total values, both at the zod layer with copy telling the browser to **split** (the row cap alone does not bound the work: 1000 × 30 = 30,000 writes). Asserted at exactly the cap and one over.

Every gate has a mutation check, run and recorded:
- delete `requireMfa()` → the MFA test goes red (1 failure);
- delete `requireDeviceWrite` → 8 tests go red;
- neutralise the duplicate-target dedupe in `tallyRow` → 1 test goes red;
- replace the per-route middleware with a wildcard → the sibling X-API-Key PATCH guard in `customFieldImport.mountorder.test.ts` is the detector;
- flip the `skip`-mode branch in `decideValue` → 1 test goes red;
- omit the `tx` executor → the whole service suite throws (the mocked ambient `db` has no `insert`).

## Verification

- `npx vitest run src/services/customFields src/services/warrantySync src/routes/devices/customFieldImport src/routes/devices/customFieldValues src/routes/devices/index src/routes/customFieldImport src/openapi` — **20 files, 355 tests, all pass**, re-run after merging `origin/main` and after the review-fix pass.
- `npx vitest run --config vitest.integration.config.ts src/__tests__/integration/{deviceCustomFieldValueImport,deviceCustomFieldValues,customFieldDefinitionImport,deviceCustomFieldImportIsolation,scriptCustomFieldWriteBack,deviceExternalLinks}` — **6 files, 96 tests, all pass** against a real Postgres (private `pnpm test-stack`, since the shared :5433 stack had another worktree's unmerged migration in its ledger).
- `NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit` — clean. `pnpm lint` — clean (6/6).
- `origin/main` merged into the branch before the final verification run.

## Not verified

- **The full `apps/api` unit suite and the full integration suite** were not run — only the affected files above. CI covers the rest.
- **`rls-coverage` / `tenantCascade` / `tenant-export-policy`** were not run: this wave adds no table, no column and no migration, so none of the six registration lists changes. Asserted by inspection, not by execution.
- **No web client exists yet** (W09), so the wire contract has not been exercised by a real browser caller and `runAction`'s handling of these bodies is reasoned about rather than observed.
- **`X-API-Key` → 401** is asserted against a mock of `authMiddleware` reproducing production's Bearer-only contract, not the real middleware (which has no API-key branch at all — verified by inspection).
- **Concurrency**: the TOCTOU and race paths are exercised as sequential state changes between two requests, not under real parallelism. The `setWhere` guards on both the value upsert and the warranty upsert are the authority there and are asserted, but not raced.
- **Performance at the 1000-row / 5000-value cap** was not measured. Each row is one transaction, so a full batch is up to 1000 sequential transactions.
- **The audit fan-out** is asserted through `writeCustomFieldValueImportAudits` unit tests and the route wiring; no test observes the rows actually landing in `audit_logs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DR1Q8zCfWEAAiJshvXv1HR
