### PR TITLE
feat(web): four-step guided create flow with server-evaluated review (W03 #5048)

### DIFF
--- a/apps/api/src/routes/aiAgents.test.ts
+++ b/apps/api/src/routes/aiAgents.test.ts
@@ -3738,10 +3738,25 @@ describe('POST /ai-agents/preview', () => {
     expect(loadPartnerBaselineCeilingMock).toHaveBeenCalledWith(PARTNER_ID, 'triage');
   });
 
-  it('does not resolve a ceiling for a partner-scope caller (its own row IS the ceiling)', async () => {
+  it('resolves the ceiling for a partner-scope caller previewing an org-owned draft (mirrors GET /ceiling\'s own scope gate)', async () => {
+    loadPartnerBaselineCeilingMock.mockResolvedValueOnce({ toolAllowlist: [], supervisedActionKeys: [] });
+
     const res = await previewRequest(
       buildApp(false, { scope: 'partner', partnerId: PARTNER_ID, orgId: null }),
-      { kind: 'triage', mode: 'shadow', toolAllowlist: ['manage_services:restart'] },
+      { kind: 'triage', mode: 'shadow', toolAllowlist: ['manage_services:restart'], ownerScope: 'organization' },
+    );
+
+    expect(res.status).toBe(200);
+    expect(loadPartnerBaselineCeilingMock).toHaveBeenCalledWith(PARTNER_ID, 'triage');
+    const body = (await res.json()) as { data: { operations: Array<{ withinCeiling: boolean }> } };
+    // ceiling's toolAllowlist is empty, so the draft's tool falls outside it.
+    expect(body.data.operations[0]!.withinCeiling).toBe(false);
+  });
+
+  it('does not resolve a ceiling for a partner-scope caller previewing its own partner-wide draft (its own row IS the ceiling)', async () => {
+    const res = await previewRequest(
+      buildApp(false, { scope: 'partner', partnerId: PARTNER_ID, orgId: null }),
+      { kind: 'triage', mode: 'shadow', toolAllowlist: ['manage_services:restart'], ownerScope: 'partner' },
     );
 
     expect(res.status).toBe(200);
@@ -3754,6 +3769,26 @@ describe('POST /ai-agents/preview', () => {
     const res = await previewRequest(
       buildApp(false, { partnerId: PARTNER_ID }),
       { kind: 'triage', mode: 'shadow', toolAllowlist: [], ownerScope: 'partner' },
+    );
+
+    expect(res.status).toBe(200);
+    expect(loadPartnerBaselineCeilingMock).not.toHaveBeenCalled();
+  });
+
+  it('does not resolve a ceiling for a system-scope caller', async () => {
+    const res = await previewRequest(
+      buildApp(false, { scope: 'system', partnerId: PARTNER_ID, orgId: null }),
+      { kind: 'triage', mode: 'shadow', toolAllowlist: [], ownerScope: 'organization' },
+    );
+
+    expect(res.status).toBe(200);
+    expect(loadPartnerBaselineCeilingMock).not.toHaveBeenCalled();
+  });
+
+  it('does not resolve a ceiling when the caller carries no partnerId at all (self-hosted)', async () => {
+    const res = await previewRequest(
+      buildApp(false, { partnerId: null }),
+      { kind: 'triage', mode: 'shadow', toolAllowlist: [], ownerScope: 'organization' },
     );
 
     expect(res.status).toBe(200);

--- a/apps/api/src/routes/aiAgents.test.ts
+++ b/apps/api/src/routes/aiAgents.test.ts
@@ -3681,6 +3681,87 @@ describe('GET /ai-agents/ceiling', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Task 11 (#5051) — POST /preview. `buildAgentPreview` is the REAL
+// implementation (not mocked, unlike `buildAgentToolCatalog`/
+// `loadPartnerBaselineCeiling` above): it is a pure function over its two
+// inputs, and its own full branch coverage (bare-entry expansion, ceiling
+// narrowing, outcome/preauthorized rules) is agentPreview.test.ts. These
+// route tests exercise only routing/auth/validation and which scope resolves
+// a ceiling — the same convention as `/tool-catalog` and `/ceiling` above.
+// ---------------------------------------------------------------------------
+function previewRequest(app: Hono, body: Record<string, unknown>) {
+  return app.request('/ai-agents/preview', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /ai-agents/preview', () => {
+  it('evaluates a draft policy against the mocked catalog', async () => {
+    loadPartnerBaselineCeilingMock.mockResolvedValueOnce(null);
+
+    const res = await previewRequest(buildApp(), { kind: 'triage', mode: 'shadow', toolAllowlist: ['manage_services:restart'] });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { operations: unknown[]; readOnlyToolCount: number } };
+    expect(body.data.operations).toEqual([{
+      key: 'manage_services:restart',
+      capability: 'services_startup',
+      outcome: 'approval_request',
+      preauthorized: false,
+      withinCeiling: true,
+    }]);
+    expect(body.data.readOnlyToolCount).toBe(0);
+  });
+
+  it('rejects a body missing the required kind field', async () => {
+    const res = await previewRequest(buildApp(), { mode: 'shadow', toolAllowlist: [] });
+    expect(res.status).toBe(400);
+  });
+
+  it('is gated on ai_agents:read', async () => {
+    hasPermMock.mockReturnValue(false);
+    const res = await previewRequest(buildApp(), { kind: 'triage', mode: 'shadow', toolAllowlist: [] });
+    expect(res.status).toBe(403);
+  });
+
+  it('resolves the ceiling for an org-scoped caller previewing an org-owned draft', async () => {
+    loadPartnerBaselineCeilingMock.mockResolvedValueOnce({ toolAllowlist: [], supervisedActionKeys: [] });
+
+    const res = await previewRequest(
+      buildApp(false, { partnerId: PARTNER_ID }),
+      { kind: 'triage', mode: 'shadow', toolAllowlist: [], ownerScope: 'organization' },
+    );
+
+    expect(res.status).toBe(200);
+    expect(loadPartnerBaselineCeilingMock).toHaveBeenCalledWith(PARTNER_ID, 'triage');
+  });
+
+  it('does not resolve a ceiling for a partner-scope caller (its own row IS the ceiling)', async () => {
+    const res = await previewRequest(
+      buildApp(false, { scope: 'partner', partnerId: PARTNER_ID, orgId: null }),
+      { kind: 'triage', mode: 'shadow', toolAllowlist: ['manage_services:restart'] },
+    );
+
+    expect(res.status).toBe(200);
+    expect(loadPartnerBaselineCeilingMock).not.toHaveBeenCalled();
+    const body = (await res.json()) as { data: { operations: Array<{ withinCeiling: boolean }> } };
+    expect(body.data.operations[0]!.withinCeiling).toBe(true);
+  });
+
+  it('does not resolve a ceiling for an org-scoped caller previewing a partner-wide draft', async () => {
+    const res = await previewRequest(
+      buildApp(false, { partnerId: PARTNER_ID }),
+      { kind: 'triage', mode: 'shadow', toolAllowlist: [], ownerScope: 'partner' },
+    );
+
+    expect(res.status).toBe(200);
+    expect(loadPartnerBaselineCeilingMock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Task 5 route half (#5049) — org rows cannot add supervisedActionKeys
 // outside the four-eyes grant executor. Mirrors the
 // InvalidSupervisedActionKeysError 422 mapping test above; the guard's own

--- a/apps/api/src/routes/aiAgents.ts
+++ b/apps/api/src/routes/aiAgents.ts
@@ -454,10 +454,16 @@ aiAgentsRoutes.get(
  * `previewAiAgentSchema` — `createAiAgentSchema` with `name` optional, since
  * the review step can run before Step 1's name is finalised. No row is
  * created or read; this never touches the database beyond the SAME
- * partner-axis ceiling projection `/ceiling` performs, and only for an
- * org-scoped caller previewing an ORG-owned draft (`ownerScope !==
- * 'partner'`) — a partner-scope caller, or an org-scope caller previewing a
- * partner-wide draft, has no ceiling to project (its own row IS the ceiling).
+ * partner-axis ceiling projection `/ceiling` performs, and only when the
+ * draft being previewed is ORG-owned (`ownerScope !== 'partner'`) — a
+ * partner-wide draft's own row IS the ceiling, so there is nothing to
+ * project onto it. This mirrors `/ceiling`'s own scope gate exactly: any
+ * non-system caller with a `partnerId` qualifies, including a partner-scope
+ * caller previewing an org-owned draft (e.g. creating a new org-scoped
+ * agent for one of its orgs) — that caller can read its own partner row
+ * directly, so projecting the ceiling exposes nothing new and just saves it
+ * a round trip, same rationale as `/ceiling`'s own docstring above. `null`
+ * for a system-scope session or a caller with no `partnerId` (self-hosted).
  */
 aiAgentsRoutes.post(
   '/preview',
@@ -467,7 +473,7 @@ aiAgentsRoutes.post(
   async (c) => {
     const auth = c.get('auth');
     const body = c.req.valid('json');
-    const ceiling = auth.scope === 'organization' && body.ownerScope !== 'partner'
+    const ceiling = auth.scope !== 'system' && auth.partnerId && body.ownerScope !== 'partner'
       ? await loadPartnerBaselineCeiling(auth.partnerId, body.kind)
       : null;
     return c.json({ data: buildAgentPreview(body, ceiling, buildAgentToolCatalog()) });

--- a/apps/api/src/routes/aiAgents.ts
+++ b/apps/api/src/routes/aiAgents.ts
@@ -21,6 +21,7 @@ import {
   impactQuerySchema,
   impactRebuildQuerySchema,
   impactWeightsSchema,
+  previewAiAgentSchema,
   promoteSupervisedKeyRequestSchema,
   triggerAgentRunSchema,
   updateAiAgentSchema,
@@ -55,6 +56,7 @@ import {
   InvalidSupervisedActionKeysError, SupervisedKeysGrantOnlyError, UnsupportedAgentModeError,
 } from '../services/aiAgents/agentService';
 import { buildAgentToolCatalog } from '../services/aiAgents/agentToolCatalog';
+import { buildAgentPreview } from '../services/aiAgents/agentPreview';
 import {
   loadPartnerBaselineCeiling,
   loadPartnerBaselineKinds,
@@ -441,6 +443,34 @@ aiAgentsRoutes.get(
     if (auth.scope === 'system' || !auth.partnerId) return c.json({ data: null });
     const { kind } = c.req.valid('query');
     return c.json({ data: await loadPartnerBaselineCeiling(auth.partnerId, kind) });
+  },
+);
+
+/**
+ * Task 11 (#5051), spec §4.6 step 4 — the guided create flow's review step
+ * evaluates a DRAFT policy server-side, through the same catalog/ceiling
+ * helpers `/tool-catalog` and `/ceiling` already expose, so the review card
+ * can never drift from what `POST /` would actually enforce. `body` is
+ * `previewAiAgentSchema` — `createAiAgentSchema` with `name` optional, since
+ * the review step can run before Step 1's name is finalised. No row is
+ * created or read; this never touches the database beyond the SAME
+ * partner-axis ceiling projection `/ceiling` performs, and only for an
+ * org-scoped caller previewing an ORG-owned draft (`ownerScope !==
+ * 'partner'`) — a partner-scope caller, or an org-scope caller previewing a
+ * partner-wide draft, has no ceiling to project (its own row IS the ceiling).
+ */
+aiAgentsRoutes.post(
+  '/preview',
+  scopes,
+  requireAiRead,
+  zValidator('json', previewAiAgentSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const body = c.req.valid('json');
+    const ceiling = auth.scope === 'organization' && body.ownerScope !== 'partner'
+      ? await loadPartnerBaselineCeiling(auth.partnerId, body.kind)
+      : null;
+    return c.json({ data: buildAgentPreview(body, ceiling, buildAgentToolCatalog()) });
   },
 );
 

--- a/apps/api/src/services/aiAgents/agentPreview.test.ts
+++ b/apps/api/src/services/aiAgents/agentPreview.test.ts
@@ -130,6 +130,24 @@ describe('buildAgentPreview', () => {
     expect(preview.operations).toEqual([]);
   });
 
+  it('a bare entry whose tool has no mutating operations goes to unrecognised, never proposed, never dropped', () => {
+    const preview = buildAgentPreview(draft({ toolAllowlist: ['query_devices'] }), null, catalog);
+    expect(preview.operations).toEqual([]);
+    expect(preview.unrecognised).toEqual(['query_devices']);
+  });
+
+  it('a scoped key naming a read-only operation goes to unrecognised, never proposed, never dropped', () => {
+    const preview = buildAgentPreview(draft({ toolAllowlist: ['manage_services:list'] }), null, catalog);
+    expect(preview.operations).toEqual([]);
+    expect(preview.unrecognised).toEqual(['manage_services:list']);
+  });
+
+  it('a bare multi-op entry both expands into operations AND is reported in unrecognised (mirrors the web\'s bare_multi_op)', () => {
+    const preview = buildAgentPreview(draft({ toolAllowlist: ['manage_services'] }), null, catalog);
+    expect(opKeys(preview)).toEqual(['manage_services:restart', 'manage_services:stop']);
+    expect(preview.unrecognised).toEqual(['manage_services']);
+  });
+
   it('computes readOnlyToolCount from the catalog, independent of the selected allowlist', () => {
     const preview = buildAgentPreview(draft({ toolAllowlist: [] }), null, catalog);
     expect(preview.readOnlyToolCount).toBe(1); // only query_devices is fully read-only

--- a/apps/api/src/services/aiAgents/agentPreview.test.ts
+++ b/apps/api/src/services/aiAgents/agentPreview.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect } from 'vitest';
+import type { AgentCeilingDto, AgentToolCatalogDto } from '@breeze/shared/types/aiAgents';
+import type { PreviewAiAgentInput } from '@breeze/shared/validators/aiAgents';
+import { previewAiAgentSchema } from '@breeze/shared/validators/aiAgents';
+import { buildAgentPreview } from './agentPreview';
+
+/**
+ * Task 11 (#5051) fixture catalog — small and hand-built (unlike the real
+ * ~185-tool registry `agentToolCatalog.contract.test.ts` pins), covering
+ * exactly the shapes `buildAgentPreview` has to branch on: a multi-operation
+ * tool with a read-only op plus two mutating ops (one act-eligible, one
+ * not), a single-operation act-eligible tool (`run_script`, mirroring the
+ * real catalog), a tier-2 tool for the logged_proposal case, and an
+ * all-read-only tool to exercise `readOnlyToolCount`.
+ */
+const catalog: AgentToolCatalogDto = {
+  capabilities: [
+    { id: 'services_startup', tone: 'standard' },
+    { id: 'scripts_commands', tone: 'standard' },
+    { id: 'alerts_monitoring', tone: 'standard' },
+    { id: 'automations_reports', tone: 'standard' },
+  ],
+  tools: [
+    {
+      name: 'manage_services',
+      capability: 'services_startup',
+      tier: 3,
+      readOnly: false,
+      operations: [
+        {
+          key: 'manage_services:list', action: 'list', tier: 1, readOnly: true,
+          policyDecidable: false, actEligible: false,
+        },
+        {
+          key: 'manage_services:restart', action: 'restart', tier: 3, readOnly: false,
+          policyDecidable: true, actEligible: true,
+        },
+        {
+          key: 'manage_services:stop', action: 'stop', tier: 3, readOnly: false,
+          policyDecidable: true, actEligible: false,
+        },
+      ],
+    },
+    {
+      name: 'run_script',
+      capability: 'scripts_commands',
+      tier: 3,
+      readOnly: false,
+      operations: [
+        { key: 'run_script', action: null, tier: 3, readOnly: false, policyDecidable: false, actEligible: true },
+      ],
+    },
+    {
+      name: 'manage_alerts',
+      capability: 'alerts_monitoring',
+      tier: 2,
+      readOnly: false,
+      operations: [
+        {
+          key: 'manage_alerts:acknowledge', action: 'acknowledge', tier: 2, readOnly: false,
+          policyDecidable: false, actEligible: false,
+        },
+      ],
+    },
+    {
+      name: 'query_devices',
+      capability: 'automations_reports',
+      tier: 1,
+      readOnly: true,
+      operations: [
+        { key: 'query_devices', action: null, tier: 1, readOnly: true, policyDecidable: false, actEligible: false },
+      ],
+    },
+  ],
+  presets: { triage: [], patch: [], helpdesk: [] },
+};
+
+/** A structurally-valid preview input, defaulted through the real schema so
+ *  every nested policy object matches what the route actually hands
+ *  `buildAgentPreview` (never hand-typed, which would drift from the schema's
+ *  defaulting rules — see `aiAgentPolicyFieldsSchema`'s docstring). */
+function draft(overrides: Partial<{
+  mode: PreviewAiAgentInput['mode'];
+  kind: PreviewAiAgentInput['kind'];
+  toolAllowlist: string[];
+  supervisedActionKeys: string[];
+}> = {}): PreviewAiAgentInput {
+  return previewAiAgentSchema.parse({
+    kind: overrides.kind ?? 'triage',
+    mode: overrides.mode ?? 'shadow',
+    toolAllowlist: overrides.toolAllowlist ?? [],
+    actAssets: { supervisedActionKeys: overrides.supervisedActionKeys ?? [] },
+  });
+}
+
+function opKeys(preview: ReturnType<typeof buildAgentPreview>): string[] {
+  return preview.operations.map((op) => op.key).sort();
+}
+
+describe('buildAgentPreview', () => {
+  it('expands a bare entry on a multi-operation tool to its mutating operations only', () => {
+    const preview = buildAgentPreview(draft({ toolAllowlist: ['manage_services'] }), null, catalog);
+    expect(opKeys(preview)).toEqual(['manage_services:restart', 'manage_services:stop']);
+  });
+
+  it('keeps a bare entry on a single-operation tool as-is', () => {
+    const preview = buildAgentPreview(draft({ toolAllowlist: ['run_script'] }), null, catalog);
+    expect(opKeys(preview)).toEqual(['run_script']);
+  });
+
+  it('dedupes an operation reached by both a bare expansion and an explicit entry', () => {
+    const preview = buildAgentPreview(
+      draft({ toolAllowlist: ['manage_services', 'manage_services:restart'] }),
+      null,
+      catalog,
+    );
+    expect(opKeys(preview)).toEqual(['manage_services:restart', 'manage_services:stop']);
+  });
+
+  it('passes unknown/unreachable entries through to unrecognised, verbatim and deduped', () => {
+    const preview = buildAgentPreview(
+      draft({ toolAllowlist: ['not_a_real_tool', 'manage_services:not_a_real_action', 'not_a_real_tool'] }),
+      null,
+      catalog,
+    );
+    expect(preview.unrecognised).toEqual(['not_a_real_tool', 'manage_services:not_a_real_action']);
+    expect(preview.operations).toEqual([]);
+  });
+
+  it('computes readOnlyToolCount from the catalog, independent of the selected allowlist', () => {
+    const preview = buildAgentPreview(draft({ toolAllowlist: [] }), null, catalog);
+    expect(preview.readOnlyToolCount).toBe(1); // only query_devices is fully read-only
+  });
+
+  it('narrows withinCeiling per-operation against the ceiling allowlist (bare-as-wildcard)', () => {
+    const ceiling: AgentCeilingDto = { toolAllowlist: ['manage_services:restart'], supervisedActionKeys: [] };
+    const preview = buildAgentPreview(draft({ toolAllowlist: ['manage_services'] }), ceiling, catalog);
+    const byKey = Object.fromEntries(preview.operations.map((op) => [op.key, op]));
+    expect(byKey['manage_services:restart']!.withinCeiling).toBe(true);
+    expect(byKey['manage_services:stop']!.withinCeiling).toBe(false);
+  });
+
+  it('withinCeiling is true unconditionally when there is no ceiling (partner draft)', () => {
+    const preview = buildAgentPreview(draft({ toolAllowlist: ['manage_services:stop'] }), null, catalog);
+    expect(preview.operations[0]!.withinCeiling).toBe(true);
+  });
+
+  it('act mode: an act-eligible operation is unattended', () => {
+    const preview = buildAgentPreview(draft({ mode: 'act', toolAllowlist: ['run_script'] }), null, catalog);
+    expect(preview.operations).toEqual([expect.objectContaining({ key: 'run_script', outcome: 'unattended' })]);
+  });
+
+  it('act mode: a non-act-eligible tier-3 operation still falls back to approval_request', () => {
+    const preview = buildAgentPreview(
+      draft({ mode: 'act', toolAllowlist: ['manage_services:stop'] }),
+      null,
+      catalog,
+    );
+    expect(preview.operations[0]).toMatchObject({ key: 'manage_services:stop', outcome: 'approval_request' });
+  });
+
+  it('shadow mode splits by tier: tier 3 is approval_request, tier 2 is logged_proposal, never unattended', () => {
+    const preview = buildAgentPreview(
+      draft({ mode: 'shadow', toolAllowlist: ['manage_services:restart', 'manage_alerts:acknowledge'] }),
+      null,
+      catalog,
+    );
+    const byKey = Object.fromEntries(preview.operations.map((op) => [op.key, op.outcome]));
+    expect(byKey['manage_services:restart']).toBe('approval_request');
+    expect(byKey['manage_alerts:acknowledge']).toBe('logged_proposal');
+  });
+
+  it('preauthorized: intersects the ceiling ceiling and the draft supervisedActionKeys (bare-as-wildcard)', () => {
+    const ceiling: AgentCeilingDto = { toolAllowlist: [], supervisedActionKeys: ['manage_services'] };
+    const admitted = buildAgentPreview(
+      draft({ toolAllowlist: ['manage_services:restart'], supervisedActionKeys: ['manage_services:restart'] }),
+      ceiling,
+      catalog,
+    );
+    expect(admitted.operations[0]!.preauthorized).toBe(true);
+
+    const notInCeiling: AgentCeilingDto = { toolAllowlist: [], supervisedActionKeys: ['manage_services:stop'] };
+    const refused = buildAgentPreview(
+      draft({ toolAllowlist: ['manage_services:restart'], supervisedActionKeys: ['manage_services:restart'] }),
+      notInCeiling,
+      catalog,
+    );
+    expect(refused.operations[0]!.preauthorized).toBe(false);
+  });
+
+  it('preauthorized: with no ceiling (partner draft), membership is against the draft\'s own supervisedActionKeys', () => {
+    const preview = buildAgentPreview(
+      draft({ toolAllowlist: ['manage_services:restart'], supervisedActionKeys: ['manage_services'] }),
+      null,
+      catalog,
+    );
+    expect(preview.operations[0]!.preauthorized).toBe(true);
+
+    const notAuthorized = buildAgentPreview(
+      draft({ toolAllowlist: ['manage_services:restart'], supervisedActionKeys: [] }),
+      null,
+      catalog,
+    );
+    expect(notAuthorized.operations[0]!.preauthorized).toBe(false);
+  });
+
+  it('carries mode/kind and the reused triggers/protectedResources/limits/recipients through unchanged', () => {
+    const input = draft({ mode: 'act', kind: 'patch' });
+    const preview = buildAgentPreview(input, null, catalog);
+    expect(preview.mode).toBe('act');
+    expect(preview.kind).toBe('patch');
+    expect(preview.triggers).toEqual({
+      alertSeverities: input.triggers.alertSeverities,
+      respectMaintenanceWindows: input.triggers.respectMaintenanceWindows,
+      ticketAutonomousWrites: input.triggers.ticketAutonomousWrites,
+    });
+    expect(preview.protectedResources).toEqual(input.protectedResources);
+    expect(preview.limits).toEqual(input.limits);
+    expect(preview.recipients).toEqual(input.recipients);
+  });
+
+  it('capability is projected from the catalog tool the operation belongs to', () => {
+    const preview = buildAgentPreview(draft({ toolAllowlist: ['manage_alerts:acknowledge'] }), null, catalog);
+    expect(preview.operations[0]).toMatchObject({ key: 'manage_alerts:acknowledge', capability: 'alerts_monitoring' });
+  });
+});

--- a/apps/api/src/services/aiAgents/agentPreview.test.ts
+++ b/apps/api/src/services/aiAgents/agentPreview.test.ts
@@ -73,6 +73,7 @@ const catalog: AgentToolCatalogDto = {
     },
   ],
   presets: { triage: [], patch: [], helpdesk: [] },
+  unreachableTools: [],
 };
 
 /** A structurally-valid preview input, defaulted through the real schema so
@@ -84,12 +85,14 @@ function draft(overrides: Partial<{
   kind: PreviewAiAgentInput['kind'];
   toolAllowlist: string[];
   supervisedActionKeys: string[];
+  cooldownSeconds: number;
 }> = {}): PreviewAiAgentInput {
   return previewAiAgentSchema.parse({
     kind: overrides.kind ?? 'triage',
     mode: overrides.mode ?? 'shadow',
     toolAllowlist: overrides.toolAllowlist ?? [],
     actAssets: { supervisedActionKeys: overrides.supervisedActionKeys ?? [] },
+    ...(overrides.cooldownSeconds === undefined ? {} : { cooldownSeconds: overrides.cooldownSeconds }),
   });
 }
 
@@ -217,6 +220,14 @@ describe('buildAgentPreview', () => {
     expect(preview.protectedResources).toEqual(input.protectedResources);
     expect(preview.limits).toEqual(input.limits);
     expect(preview.recipients).toEqual(input.recipients);
+  });
+
+  it('carries cooldownSeconds through from the draft (a sibling of limits, not one of its fields)', () => {
+    const preview = buildAgentPreview(draft({ cooldownSeconds: 1800 }), null, catalog);
+    expect(preview.cooldownSeconds).toBe(1800);
+
+    const defaulted = buildAgentPreview(draft(), null, catalog);
+    expect(defaulted.cooldownSeconds).toBe(900);
   });
 
   it('capability is projected from the catalog tool the operation belongs to', () => {

--- a/apps/api/src/services/aiAgents/agentPreview.ts
+++ b/apps/api/src/services/aiAgents/agentPreview.ts
@@ -123,6 +123,7 @@ export function buildAgentPreview(
     },
     protectedResources: input.protectedResources,
     limits: input.limits,
+    cooldownSeconds: input.cooldownSeconds,
     recipients: input.recipients,
   };
 }

--- a/apps/api/src/services/aiAgents/agentPreview.ts
+++ b/apps/api/src/services/aiAgents/agentPreview.ts
@@ -14,6 +14,7 @@ import type {
   AgentToolOperationDto,
 } from '@breeze/shared/types/aiAgents';
 import type { PreviewAiAgentInput } from '@breeze/shared/validators/aiAgents';
+import { outcomeFor } from '@breeze/shared';
 import { intersectToolRefs, isToolAllowlisted } from './toolAllowlist';
 
 /** `'manage_services:restart'` -> `{ tool: 'manage_services', action: 'restart' }`; a bare entry -> `action: null`. */
@@ -25,52 +26,46 @@ function splitEntry(entry: string): { tool: string; action: string | null } {
 }
 
 /**
- * Resolves one raw `toolAllowlist` entry against the catalog. `null` means
- * the entry could not be resolved at all (unknown tool, or an unreachable
- * action on a known tool) — the caller routes that to `unrecognised`, never
- * to a fabricated operation.
+ * Resolves one raw `toolAllowlist` entry against the catalog, mirroring the
+ * web's `entriesToSelection` (`capabilityModel.ts`) exactly so the two never
+ * classify the same entry differently. `unrecognised: true` means the entry
+ * contributes no operation and the raw entry surfaces on the review card
+ * instead — either because it could not be resolved at all (unknown tool, or
+ * an unreachable action on a known tool), because it names an operation that
+ * is always-on and read-only (a bare entry whose tool has no mutating
+ * operations, or a scoped key naming a read-only operation — neither is ever
+ * a proposed or approved operation in its own right; both are already
+ * counted in `readOnlyToolCount`), or because a bare entry needed
+ * disambiguation (the tool has more than one named action) — that case
+ * ALSO still returns its mutating operations, so the same entry can both
+ * expand into `operations` and be flagged (the web's `bare_multi_op`).
  *
- * A bare entry on a single-operation tool IS that tool's one operation
- * (`agentToolCatalog.ts`'s own invariant: `operations.length === 1 &&
- * operations[0].action === null` whenever `key === name`). A bare entry on a
- * multi-operation tool is shorthand for "every action" (spec §4.3), so it
- * expands to that tool's MUTATING operations only — its read-only operations
- * are already counted in `readOnlyToolCount` and are never a proposed or
- * approved operation in their own right.
+ * A bare entry on a genuinely single-operation tool (`operations.length ===
+ * 1 && operations[0].action === null`, `agentToolCatalog.ts`'s own
+ * invariant whenever `key === name`) IS that tool's one operation, with no
+ * flag — but only when that one operation is mutating; an all-read-only
+ * single-op tool falls into the read-only case above instead.
  */
 function resolveEntry(
   entry: string,
   toolsByName: ReadonlyMap<string, AgentToolCatalogToolDto>,
-): AgentToolOperationDto[] | null {
+): { ops: AgentToolOperationDto[]; unrecognised: boolean } {
   const { tool: toolName, action } = splitEntry(entry);
   const tool = toolsByName.get(toolName);
-  if (!tool) return null;
+  if (!tool) return { ops: [], unrecognised: true };
 
   if (action !== null) {
     const op = tool.operations.find((candidate) => candidate.action === action);
-    return op ? [op] : null;
+    if (!op || op.readOnly) return { ops: [], unrecognised: true };
+    return { ops: [op], unrecognised: false };
   }
 
-  if (tool.operations.length === 1 && tool.operations[0]!.action === null) {
-    return [tool.operations[0]!];
+  const mutatingOps = tool.operations.filter((op) => !op.readOnly);
+  if (mutatingOps.length === 0) return { ops: [], unrecognised: true };
+  if (mutatingOps.length === 1 && mutatingOps[0]!.action === null) {
+    return { ops: mutatingOps, unrecognised: false };
   }
-  return tool.operations.filter((op) => !op.readOnly);
-}
-
-/**
- * `mode === 'act' && op.actEligible` -> unattended (the run loop will
- * actually dispatch it without a human, per `ACT_MANIFEST`); otherwise the
- * guardrail tier decides whether a human approves it up front (tier 3) or it
- * is logged as an already-applied proposal (tier 2) — the same split
- * `capabilityModel.outcomeFor` computes on the web side, computed here
- * server-side so the review card cannot drift from it.
- */
-function resolveOutcome(
-  op: AgentToolOperationDto,
-  mode: PreviewAiAgentInput['mode'],
-): AgentPreviewDto['operations'][number]['outcome'] {
-  if (mode === 'act' && op.actEligible) return 'unattended';
-  return op.tier === 3 ? 'approval_request' : 'logged_proposal';
+  return { ops: mutatingOps, unrecognised: true };
 }
 
 export function buildAgentPreview(
@@ -83,12 +78,9 @@ export function buildAgentPreview(
   const unrecognised = new Set<string>();
 
   for (const entry of input.toolAllowlist) {
-    const resolved = resolveEntry(entry, toolsByName);
-    if (resolved === null) {
-      unrecognised.add(entry);
-      continue;
-    }
-    for (const op of resolved) opsByKey.set(op.key, op);
+    const { ops, unrecognised: flagged } = resolveEntry(entry, toolsByName);
+    if (flagged) unrecognised.add(entry);
+    for (const op of ops) opsByKey.set(op.key, op);
   }
 
   // No ceiling (a partner draft, or an org draft with no live partner
@@ -104,7 +96,7 @@ export function buildAgentPreview(
     return {
       key: op.key,
       capability: toolsByName.get(tool)!.capability,
-      outcome: resolveOutcome(op, input.mode),
+      outcome: outcomeFor(op, input.mode),
       preauthorized: isToolAllowlisted(supervisedCeiling, tool, action),
       withinCeiling: ceiling ? isToolAllowlisted(ceiling.toolAllowlist, tool, action) : true,
     };

--- a/apps/api/src/services/aiAgents/agentPreview.ts
+++ b/apps/api/src/services/aiAgents/agentPreview.ts
@@ -1,0 +1,128 @@
+/**
+ * Task 11 (#5051) — `POST /ai/agents/preview` (spec §4.6 step 4): evaluates a
+ * DRAFT agent policy (no row need exist yet) through the SAME catalog/ceiling
+ * shapes the capability picker and the run loop use, so the guided create
+ * flow's review card can never drift from what create/update would actually
+ * enforce. Pure — no DB access, no side effects; the route resolves the
+ * ceiling and hands it in.
+ */
+import type {
+  AgentCeilingDto,
+  AgentPreviewDto,
+  AgentToolCatalogDto,
+  AgentToolCatalogToolDto,
+  AgentToolOperationDto,
+} from '@breeze/shared/types/aiAgents';
+import type { PreviewAiAgentInput } from '@breeze/shared/validators/aiAgents';
+import { intersectToolRefs, isToolAllowlisted } from './toolAllowlist';
+
+/** `'manage_services:restart'` -> `{ tool: 'manage_services', action: 'restart' }`; a bare entry -> `action: null`. */
+function splitEntry(entry: string): { tool: string; action: string | null } {
+  const colon = entry.indexOf(':');
+  return colon === -1
+    ? { tool: entry, action: null }
+    : { tool: entry.slice(0, colon), action: entry.slice(colon + 1) };
+}
+
+/**
+ * Resolves one raw `toolAllowlist` entry against the catalog. `null` means
+ * the entry could not be resolved at all (unknown tool, or an unreachable
+ * action on a known tool) — the caller routes that to `unrecognised`, never
+ * to a fabricated operation.
+ *
+ * A bare entry on a single-operation tool IS that tool's one operation
+ * (`agentToolCatalog.ts`'s own invariant: `operations.length === 1 &&
+ * operations[0].action === null` whenever `key === name`). A bare entry on a
+ * multi-operation tool is shorthand for "every action" (spec §4.3), so it
+ * expands to that tool's MUTATING operations only — its read-only operations
+ * are already counted in `readOnlyToolCount` and are never a proposed or
+ * approved operation in their own right.
+ */
+function resolveEntry(
+  entry: string,
+  toolsByName: ReadonlyMap<string, AgentToolCatalogToolDto>,
+): AgentToolOperationDto[] | null {
+  const { tool: toolName, action } = splitEntry(entry);
+  const tool = toolsByName.get(toolName);
+  if (!tool) return null;
+
+  if (action !== null) {
+    const op = tool.operations.find((candidate) => candidate.action === action);
+    return op ? [op] : null;
+  }
+
+  if (tool.operations.length === 1 && tool.operations[0]!.action === null) {
+    return [tool.operations[0]!];
+  }
+  return tool.operations.filter((op) => !op.readOnly);
+}
+
+/**
+ * `mode === 'act' && op.actEligible` -> unattended (the run loop will
+ * actually dispatch it without a human, per `ACT_MANIFEST`); otherwise the
+ * guardrail tier decides whether a human approves it up front (tier 3) or it
+ * is logged as an already-applied proposal (tier 2) — the same split
+ * `capabilityModel.outcomeFor` computes on the web side, computed here
+ * server-side so the review card cannot drift from it.
+ */
+function resolveOutcome(
+  op: AgentToolOperationDto,
+  mode: PreviewAiAgentInput['mode'],
+): AgentPreviewDto['operations'][number]['outcome'] {
+  if (mode === 'act' && op.actEligible) return 'unattended';
+  return op.tier === 3 ? 'approval_request' : 'logged_proposal';
+}
+
+export function buildAgentPreview(
+  input: PreviewAiAgentInput,
+  ceiling: AgentCeilingDto | null,
+  catalog: AgentToolCatalogDto,
+): AgentPreviewDto {
+  const toolsByName = new Map(catalog.tools.map((tool) => [tool.name, tool]));
+  const opsByKey = new Map<string, AgentToolOperationDto>();
+  const unrecognised = new Set<string>();
+
+  for (const entry of input.toolAllowlist) {
+    const resolved = resolveEntry(entry, toolsByName);
+    if (resolved === null) {
+      unrecognised.add(entry);
+      continue;
+    }
+    for (const op of resolved) opsByKey.set(op.key, op);
+  }
+
+  // No ceiling (a partner draft, or an org draft with no live partner
+  // baseline yet) means nothing narrows the draft's own supervised keys —
+  // intersecting with itself under `intersectToolRefs` would be a no-op
+  // dedupe, so skip straight to the draft's own list rather than compute it.
+  const supervisedCeiling = ceiling
+    ? intersectToolRefs(ceiling.supervisedActionKeys, input.actAssets.supervisedActionKeys)
+    : input.actAssets.supervisedActionKeys;
+
+  const operations = [...opsByKey.values()].map((op) => {
+    const { tool, action } = splitEntry(op.key);
+    return {
+      key: op.key,
+      capability: toolsByName.get(tool)!.capability,
+      outcome: resolveOutcome(op, input.mode),
+      preauthorized: isToolAllowlisted(supervisedCeiling, tool, action),
+      withinCeiling: ceiling ? isToolAllowlisted(ceiling.toolAllowlist, tool, action) : true,
+    };
+  });
+
+  return {
+    mode: input.mode,
+    kind: input.kind,
+    readOnlyToolCount: catalog.tools.filter((tool) => tool.readOnly).length,
+    operations,
+    unrecognised: [...unrecognised],
+    triggers: {
+      alertSeverities: input.triggers.alertSeverities,
+      respectMaintenanceWindows: input.triggers.respectMaintenanceWindows,
+      ticketAutonomousWrites: input.triggers.ticketAutonomousWrites,
+    },
+    protectedResources: input.protectedResources,
+    limits: input.limits,
+    recipients: input.recipients,
+  };
+}

--- a/apps/web/src/components/settings/AiAgentForm.test.tsx
+++ b/apps/web/src/components/settings/AiAgentForm.test.tsx
@@ -27,7 +27,7 @@ vi.mock('../../stores/orgStore', () => ({
   useOrgStore: (sel?: (s: typeof orgState.current) => unknown) => (sel ? sel(orgState.current) : orgState.current),
 }));
 
-import { AI_AGENT_KINDS, type AgentToolCatalogDto } from '@breeze/shared';
+import { type AgentToolCatalogDto } from '@breeze/shared';
 import AiAgentForm, { type AiAgentDto } from './AiAgentForm';
 import { fetchWithAuth } from '../../stores/auth';
 
@@ -147,17 +147,13 @@ function mockEndpoints(registry: RegistryRow[] = []): void {
   });
 }
 
+// Task 13 (#5051): AiAgentsPage only ever opens this drawer for EDIT now
+// (`AgentCreateFlow` owns create), so `Props.agent` is a real `AiAgentDto` —
+// every test renders against one, either this default or an override.
 function renderForm(props: Partial<React.ComponentProps<typeof AiAgentForm>> = {}) {
   return render(
     <AiAgentForm
-      agent={null}
-      agents={[]}
-      // Default to "every kind already has a baseline" — the pre-#4170
-      // neutral state — so existing tests never see the new hint unless a
-      // test opts into the empty set to exercise it directly.
-      partnerBaselineKinds={new Set(AI_AGENT_KINDS)}
-      showOwnerScope={false}
-      defaultOwnerScope="organization"
+      agent={makeAgent()}
       onClose={vi.fn()}
       onSaved={vi.fn()}
       {...props}
@@ -520,86 +516,20 @@ describe('AiAgentForm — alert severities', () => {
   });
 });
 
-describe('AiAgentForm — mode cards', () => {
-  it('top-aligns the option cards so the three labels share a baseline', async () => {
-    // A <button>'s content box is vertically centred by the UA stylesheet, so
-    // three cards of unequal height put their labels on three different lines.
-    mockEndpoints();
-    renderForm();
-
-    for (const mode of ['off', 'shadow', 'act']) {
-      const card = await screen.findByTestId(`ai-agent-mode-${mode}`);
-      expect(card.className).toContain('flex-col');
-      expect(card.className).toContain('items-start');
-    }
-  });
-});
-
-// #4170 — an org-only agent overrides a partner-wide baseline of the same
-// kind; with none, the resolver treats the row as if it did not exist.
-describe('AiAgentForm — no-partner-baseline hint', () => {
-  it('warns when creating an org-only agent of a kind with no partner baseline', async () => {
-    mockEndpoints();
-    renderForm({ partnerBaselineKinds: new Set() });
-
-    expect(await screen.findByTestId('ai-agent-no-baseline-hint')).toBeInTheDocument();
-  });
-
-  it('does not warn when a partner baseline already exists for the selected kind', async () => {
-    mockEndpoints();
-    renderForm({ partnerBaselineKinds: new Set(['triage']) });
-
-    await screen.findByTestId('ai-agent-kind');
-    expect(screen.queryByTestId('ai-agent-no-baseline-hint')).toBeNull();
-  });
-
-  it('does not warn when creating a partner-wide agent', async () => {
-    mockEndpoints();
-    renderForm({ defaultOwnerScope: 'partner', partnerBaselineKinds: new Set() });
-
-    await screen.findByTestId('ai-agent-kind');
-    expect(screen.queryByTestId('ai-agent-no-baseline-hint')).toBeNull();
-  });
-
-  it('does not warn when editing an existing agent', async () => {
-    mockEndpoints();
-    renderForm({
-      agent: {
-        id: 'a-1',
-        kind: 'triage',
-        name: 'Triage',
-        enabled: true,
-        mode: 'shadow',
-        model: null,
-        orgId: 'org-1',
-        partnerId: null,
-        ownerScope: 'organization',
-        allOrgs: false,
-        supportedModes: ['off', 'shadow', 'act'],
-        toolAllowlist: [],
-        protectedResources: {},
-        limits: {},
-        triggers: {},
-        recipients: {},
-        actAssets: {},
-        instructions: null,
-        cooldownSeconds: 900,
-        disabledAt: null,
-        createdAt: '2026-08-01T00:00:00.000Z',
-        updatedAt: '2026-08-01T00:00:00.000Z',
-      } as AiAgentDto,
-      partnerBaselineKinds: new Set(),
-    });
-
-    await screen.findByTestId('ai-agent-name');
-    expect(screen.queryByTestId('ai-agent-no-baseline-hint')).toBeNull();
-  });
-});
+// Task 10 (#5051 review): "mode cards" (top-alignment) moved to
+// ModeChoice.test.tsx — a component-level assertion, not anything specific
+// to the drawer. "no-partner-baseline hint" is gone entirely: AiAgentsPage
+// now only ever opens this drawer for EDIT (Task 13, #5051), and that hint
+// was create-only (`isCreate && draft.ownerScope === 'organization' &&
+// !partnerBaselineKinds.has(draft.kind)`) — deleted along with every other
+// create-only branch now that `agent` is narrowed to a real `AiAgentDto`.
+// Its remaining coverage (including the two "does not warn" negative cases)
+// lives in AgentCreateFlow.test.tsx's "kind cards and owner scope" describe.
 
 describe('AiAgentForm — name', () => {
   it('marks the name as required and says so on blur, not only after a failed save', async () => {
     mockEndpoints();
-    renderForm();
+    renderForm({ agent: makeAgent({ name: '' }) });
 
     const input = await screen.findByTestId('ai-agent-name');
     expect(input).toBeRequired();
@@ -623,16 +553,38 @@ describe('AiAgentForm — name', () => {
   });
 });
 
+describe('AiAgentForm — numeric limits', () => {
+  it('falls back a cleared numeric limit to its minimum, never 0 (Number(\'\') is 0, not NaN)', async () => {
+    // The old guard only checked `Number.isFinite(next)` on the theory that
+    // clearing the box yields `'' -> NaN` — it does not, `Number('')` is `0`,
+    // which IS finite, so the guard never fired and a cleared limit silently
+    // stored 0 rather than falling back at all.
+    mockEndpoints();
+    renderForm({ agent: makeAgent() });
+
+    const input = await screen.findByTestId('ai-agent-limit-devices');
+    fireEvent.change(input, { target: { value: '' } });
+    expect(input).toHaveValue(1); // this field's min
+
+    fireEvent.click(screen.getByTestId('ai-agent-save'));
+    await waitFor(() =>
+      expect(fetchMock.mock.calls.some(([, init]) =>
+        (init as RequestInit | undefined)?.method === 'PATCH')).toBe(true));
+
+    expect((writeBody().limits as { maxDevicesPerRun: number }).maxDevicesPerRun).toBe(1);
+  });
+});
+
 describe('AiAgentForm — Save button', () => {
   // Review finding — the disabled Save button was missing the
   // `disabled:cursor-not-allowed` affordance already used by
   // `RunsListPage.tsx`'s Load more button.
   it('shows a not-allowed cursor while disabled, matching the rest of the AI agents UI', async () => {
     mockEndpoints();
-    // No available kinds on a create form disables Save (see the
-    // `disabled` expression below the button) without needing to wait on
-    // an async validation state.
-    renderForm();
+    // The `disabled:cursor-not-allowed` Tailwind variant is a static part of
+    // the button's className regardless of whether `disabled` is currently
+    // true, so this needs no particular disabled state to assert on.
+    renderForm({ agent: makeAgent() });
 
     const save = await screen.findByTestId('ai-agent-save');
     expect(save.className).toContain('disabled:cursor-not-allowed');

--- a/apps/web/src/components/settings/AiAgentForm.tsx
+++ b/apps/web/src/components/settings/AiAgentForm.tsx
@@ -5,13 +5,10 @@ import {
   useMemo,
   useRef,
   useState,
-  type KeyboardEvent,
 } from 'react';
 import { useTranslation } from 'react-i18next';
-import { AlertTriangle } from 'lucide-react';
 import {
   AI_AGENT_KINDS,
-  AI_AGENT_LIMIT_DEFAULTS,
   ALERT_SEVERITIES,
   SUPPORTED_AGENT_MODES,
   type AiAgentDto,
@@ -29,14 +26,25 @@ import AiAgentSchedulesSection from './AiAgentSchedulesSection';
 import AiAgentGraduationPanel from './AiAgentGraduationPanel';
 import CapabilityPicker from './aiAgents/CapabilityPicker';
 import { useAgentToolCatalog } from './aiAgents/useAgentToolCatalog';
-
-// Severities come from @breeze/shared, the same constant the server validator
-// uses. A local copy meant draftFrom() would silently DROP a stored severity
-// the two lists disagreed on, and the next save would write the truncated list.
-const SEVERITIES = ALERT_SEVERITIES;
-type Severity = (typeof ALERT_SEVERITIES)[number];
+import ModeChoice from './aiAgents/ModeChoice';
+import PolicyKeysCheckboxes, {
+  policyActionLabel,
+  sentenceCase,
+  type PolicyDecidableKeyOption,
+} from './aiAgents/PolicyKeysCheckboxes';
+import {
+  ALERT_SEVERITY_KINDS,
+  buildAgentSaveBody,
+  draftFrom,
+  firstFreeKind,
+  freeKinds,
+  lines,
+  toggle,
+  type Draft,
+} from './aiAgents/agentDraft';
 
 export type { AiAgentDto };
+export type { Draft } from './aiAgents/agentDraft';
 
 interface RoleOption {
   id: string;
@@ -54,51 +62,6 @@ function roleScope(role: RoleOption): 'partner' | 'organization' {
 
 /** Rendered in this order; a group with no roles is skipped entirely. */
 const ROLE_GROUPS = ['partner', 'organization'] as const;
-
-/** GET /ai/agents/policy-decidable-keys — the read-only POLICY_DECIDABLE_TIER3
- *  registry (wave 5 Part B, #3827). `note` is the server's one-sentence
- *  description of what the operation actually does; it is rendered as the
- *  checkbox's description below. */
-interface PolicyDecidableKeyOption {
-  key: string;
-  toolName: string;
-  action: string | null;
-  note: string;
-}
-
-/**
- * `manage_startup_items` -> "Manage startup items". Last-resort label for a
- * registry key this catalog has no translation for: the registry is
- * server-owned, so a key can ship in an API build before the web catalog
- * knows it, and the operator must still read words rather than an identifier.
- * Deliberately silent — a missing translation is a catalog gap to fix in the
- * next extraction pass, not a runtime fault worth a console line on every
- * render of this form.
- */
-function sentenceCase(token: string): string {
-  const words = token.replace(/[_:-]+/g, ' ').trim();
-  return words.charAt(0).toUpperCase() + words.slice(1);
-}
-
-/** `manage_services:restart` -> `manage_services-restart`, so the key can be
- *  spliced into a DOM id (`aria-describedby` takes an id list, and a colon in
- *  an id is legal HTML but a syntax error in any selector that reads it). */
-function idSafe(key: string): string {
-  return key.replace(/[^A-Za-z0-9_-]+/g, '-');
-}
-
-/** Groups registry entries by `toolName`, preserving the server's ordering
- *  within each group (policyDecidable.ts orders entries deliberately — see
- *  its module doc). */
-function groupByTool(entries: PolicyDecidableKeyOption[]): Map<string, PolicyDecidableKeyOption[]> {
-  const groups = new Map<string, PolicyDecidableKeyOption[]>();
-  for (const entry of entries) {
-    const list = groups.get(entry.toolName);
-    if (list) list.push(entry);
-    else groups.set(entry.toolName, [entry]);
-  }
-  return groups;
-}
 
 interface Props {
   /** null = create a new agent. */
@@ -176,149 +139,6 @@ const ACT_PREREQUISITE_COPY: Record<string, (t: (key: string) => string) => stri
 
 const inputCls = 'w-full rounded-md border bg-background px-2.5 py-1.5 text-sm';
 const INSTRUCTIONS_MAX = 2000;
-
-/**
- * Mode is the only field on this form that decides whether the agent may
- * touch a customer machine, so it is a three-card radiogroup rather than one
- * more `<select>` of the same weight as Name — and it is the FIRST decision,
- * above Kind and Name, because every field below it is read differently
- * depending on the answer.
- *
- * The order is the privilege ladder (`AI_AGENT_MODE_RANK`), which is also the
- * arrow-key order.
- */
-const MODE_ORDER: readonly AiAgentMode[] = ['off', 'shadow', 'act'];
-
-/**
- * Kinds whose runs can ever carry an alert severity — i.e. the only kinds for
- * which `triggers.alertSeverities` is read at all.
- *
- * `runService.ts` evaluates the severity list inside
- * `evaluateAgentTriggerFilters`, which runs ONLY when the admission input
- * carries an `alertContext`, and both producers of one
- * (`alertVerdictSubscriber.ts` and `automationRuntime.ts`) admit with
- * `kind: 'triage'`. A helpdesk agent is admitted from a ticket
- * (`ticketHelpdeskSubscriber.ts`, `ticketContext`), a patch agent from a
- * manual or scheduled trigger — neither carries a severity, so the list is
- * inert for both.
- *
- * Showing the control for those kinds asked the operator to make a choice
- * that could never take effect, and the client-side `.min(1)` check could
- * block a save over a field the server never reads for that kind. Hidden AND
- * omitted from the payload: on PATCH the one-level merge preserves whatever
- * is stored, and on create the server's `aiAgentTriggersSchema` supplies its
- * own `['critical', 'high']` default, so omission is never a `.min(1)` 400.
- */
-const ALERT_SEVERITY_KINDS: ReadonlySet<AiAgentKind> = new Set<AiAgentKind>(['triage']);
-
-/** Newline-separated textarea → trimmed, de-duplicated list. */
-function lines(value: string): string[] {
-  return [...new Set(value.split('\n').map((entry) => entry.trim()).filter(Boolean))];
-}
-
-/**
- * Kinds still creatable for one ownership axis. The DB enforces
- * `(partner_id, kind) WHERE org_id IS NULL` and `(org_id, kind)` as two
- * independent partial uniques, both `WHERE disabled_at IS NULL`, so a kind is
- * only taken for the owner that actually holds it.
- */
-function freeKinds(
-  agents: AiAgentDto[],
-  ownerScope: OwnerScope,
-  orgId: string | null,
-): AiAgentKind[] {
-  const taken = new Set(
-    agents
-      .filter((row) =>
-        ownerScope === 'partner'
-          ? row.ownerScope === 'partner'
-          : row.ownerScope === 'organization' && row.orgId === orgId,
-      )
-      .map((row) => row.kind),
-  );
-  return AI_AGENT_KINDS.filter((kind) => !taken.has(kind));
-}
-
-function firstFreeKind(
-  agents: AiAgentDto[],
-  ownerScope: OwnerScope,
-  orgId: string | null,
-): AiAgentKind | undefined {
-  return freeKinds(agents, ownerScope, orgId)[0];
-}
-
-function toggle<T>(list: T[], value: T): T[] {
-  return list.includes(value) ? list.filter((entry) => entry !== value) : [...list, value];
-}
-
-interface Draft {
-  ownerScope: OwnerScope;
-  kind: AiAgentKind;
-  name: string;
-  enabled: boolean;
-  mode: AiAgentMode;
-  severities: Severity[];
-  respectMaintenanceWindows: boolean;
-  toolAllowlist: string;
-  services: string;
-  paths: string;
-  registryKeys: string;
-  limits: typeof AI_AGENT_LIMIT_DEFAULTS;
-  cooldownSeconds: number;
-  roleIds: string[];
-  instructions: string;
-  /** Wave 5 Part B (#3827). Operator's per-agent opt-in to unattended
-   *  policy-decided authorization — see actAssets in save() below. */
-  supervisedActionKeys: string[];
-  /** P2-4 (#4191). Org-row-only opt-in that lifts the forced-shadow behavior
-   *  for ticket-triggered runs — same "reads ONLY the org's own override"
-   *  merge semantics as `anomalyEnabled` (never itself surfaced on this
-   *  form). See `AiAgentTriggers.ticketAutonomousWrites`'s docstring. */
-  ticketAutonomousWrites: boolean;
-}
-
-function draftFrom(
-  agent: AiAgentDto | null,
-  defaults: { ownerScope: OwnerScope; kind: AiAgentKind },
-): Draft {
-  const severities = (agent?.triggers?.alertSeverities ?? ['critical', 'high']).filter(
-    (severity): severity is Severity => (SEVERITIES as readonly string[]).includes(severity),
-  );
-  return {
-    ownerScope: agent?.ownerScope ?? defaults.ownerScope,
-    kind: agent?.kind ?? defaults.kind,
-    name: agent?.name ?? '',
-    // CREATE defaults (the `??` fallbacks only ever apply when `agent` is
-    // null): shadow, but SWITCHED OFF.
-    //
-    // `mode: 'shadow'` is what the first-run panel tells the operator to start
-    // with, and the form used to contradict it by defaulting to `off`.
-    // `enabled` was flipped to `true` in the same change and that went too far:
-    // `enabled` is the live switch, not a mode preview. `syncManagedAutomation`
-    // mirrors it onto the seeded automation the moment Save lands, and shadow
-    // passes run admission — so creating a partner-wide triage agent started
-    // real LLM runs across every org under the partner before anyone had looked
-    // at the tool allowlist, the severities or the daily budget on the very
-    // form that created it. Off is the only honest default for a switch whose
-    // first flip spends money on machines the operator has not scoped yet; the
-    // create-only hint beside the checkbox says so, so the unticked box reads
-    // as a decision rather than an oversight.
-    enabled: agent?.enabled ?? false,
-    mode: agent?.mode ?? 'shadow',
-    severities,
-    respectMaintenanceWindows: agent?.triggers?.respectMaintenanceWindows ?? true,
-    toolAllowlist: (agent?.toolAllowlist ?? []).join('\n'),
-    services: (agent?.protectedResources?.services ?? []).join('\n'),
-    paths: (agent?.protectedResources?.paths ?? []).join('\n'),
-    registryKeys: (agent?.protectedResources?.registryKeys ?? []).join('\n'),
-    limits: { ...AI_AGENT_LIMIT_DEFAULTS, ...(agent?.limits ?? {}) },
-    cooldownSeconds: agent?.cooldownSeconds ?? 900,
-    roleIds: agent?.recipients?.roleIds ?? [],
-    instructions: agent?.instructions ?? '',
-    supervisedActionKeys: agent?.actAssets?.supervisedActionKeys ?? [],
-    ticketAutonomousWrites: agent?.triggers?.ticketAutonomousWrites ?? false,
-  };
-}
 
 /**
  * Create/edit form for one AI agent policy row.
@@ -430,7 +250,6 @@ export default function AiAgentForm({
   const limitsTimingId = useId();
   const rolesGroupBaseId = useId();
   const severitiesGroupId = useId();
-  const policyKeyNoteBaseId = useId();
   const nameInputId = useId();
   const nameErrorId = useId();
   /** Name has been left at least once. Until then an empty Name is "not
@@ -442,114 +261,20 @@ export default function AiAgentForm({
 
   const usesAlertSeverities = ALERT_SEVERITY_KINDS.has(draft.kind);
 
-  /** Registry tool -> translated group heading, falling back to the
-   *  sentence-cased token (see `sentenceCase`). */
-  const policyToolLabel = (toolName: string) =>
-    t(/* i18n-dynamic */ `aiAgentsPage.policyKeys.tools.${toolName}`, {
-      defaultValue: sentenceCase(toolName),
-    });
-
-  /** Registry entry -> translated operation label. Scoped by tool, because the
-   *  bare action verb is ambiguous across the registry: "disable" appears
-   *  against a startup item and a scheduled task, "enable" likewise, and a
-   *  checkbox list of bare verbs cannot say which object it authorizes. A
-   *  bare-tool entry (`action: null`) has no verb of its own, so it reads as
-   *  the tool. */
-  const policyActionLabel = (entry: PolicyDecidableKeyOption) =>
-    entry.action === null
-      ? policyToolLabel(entry.toolName)
-      : t(/* i18n-dynamic */ `aiAgentsPage.policyKeys.actions.${entry.toolName}.${entry.action}`, {
-        defaultValue: sentenceCase(entry.action),
-      });
-
   // ---- Mode: the privileged choice --------------------------------------
-  const modeHeadingId = useId();
-  const modeRefs = useRef<Partial<Record<AiAgentMode, HTMLButtonElement | null>>>({});
   // The CREATE path has no `agent` DTO yet, so the fallback must be the shared
   // constant and never `[]` — see the long note this file already carries on
   // the old `<option disabled>`; the reasoning survived the control change.
   const actSupported = (agent?.supportedModes ?? SUPPORTED_AGENT_MODES).includes('act');
-  const modeUnavailable = (mode: AiAgentMode) => mode === 'act' && !actSupported;
 
-  // Literal keys rather than a dynamic `t()` on the token: the closed
-  // three-member union is worth spelling out so the keyUsage guard verifies
-  // every label statically (same reason as AiAgentSchedulesSection's
-  // `scheduleKindLabel`).
-  const MODE_LABEL: Record<AiAgentMode, string> = {
-    off: t('aiAgentsPage.modeChoice.off'),
-    shadow: t('aiAgentsPage.modeChoice.shadow'),
-    act: t('aiAgentsPage.modeChoice.act'),
-  };
-  // Literal keys, same reason as MODE_LABEL below: the closed two-member set
-  // is spelled out so the keyUsage guard verifies both labels statically.
+  // Literal keys, same reason ModeChoice.tsx's own label maps are: the closed
+  // two-member set is spelled out so the keyUsage guard verifies both labels
+  // statically.
   const ROLE_GROUP_LABEL: Record<(typeof ROLE_GROUPS)[number], string> = {
     partner: t('aiAgentsPage.fields.recipientRolesPartner'),
     organization: t('aiAgentsPage.fields.recipientRolesOrganization'),
   };
-  const MODE_CONSEQUENCE: Record<AiAgentMode, string> = {
-    off: t('aiAgentsPage.modeChoice.offConsequence'),
-    shadow: t('aiAgentsPage.modeChoice.shadowConsequence'),
-    act: t('aiAgentsPage.modeChoice.actConsequence'),
-  };
 
-  const selectMode = (next: AiAgentMode) => {
-    if (modeUnavailable(next) || next === draft.mode) return;
-    if (next === 'act') {
-      patch({ mode: next });
-      return;
-    }
-    // Leaving act: only the acknowledgement belongs to act mode alone — a
-    // genuine re-entry must ask again. `supervisedActionKeys` is NOT
-    // cleared: it stays in the draft so a later return to act restores the
-    // operator's selection, and `save()`'s payload is what keeps them out of
-    // effect while the mode isn't act (see `actKeysWillBeOmitted` above).
-    setActAck(false);
-    patch({ mode: next });
-  };
-
-  /** Roving-tabindex arrow navigation, per the radiogroup pattern: the group
-   *  holds one tab stop and the arrows move BOTH focus and selection.
-   *
-   *  The starting point is the option that HAS FOCUS (read off the event
-   *  target's `data-mode`), never `draft.mode`. The two are normally the same —
-   *  that is the roving contract — but they can diverge for one keystroke, and
-   *  they did: the drawer's initial focus used to land on a `tabindex="-1"`
-   *  card, so ArrowRight from Off (with Shadow selected) stepped from SHADOW
-   *  and selected `act`, skipping the option the user was actually looking at.
-   *  Deriving from focus makes the two impossible to disagree. */
-  const onModeKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-    const selectable = MODE_ORDER.filter((mode) => !modeUnavailable(mode));
-    if (selectable.length === 0) return;
-    const focused = (event.target as HTMLElement | null)?.dataset?.mode as AiAgentMode | undefined;
-    // Falls back to the selected option when the key came from the group
-    // itself rather than from one of its cards.
-    const from = focused && selectable.includes(focused) ? focused : draft.mode;
-    const current = Math.max(0, selectable.indexOf(from));
-    let target: number;
-    switch (event.key) {
-      case 'ArrowRight':
-      case 'ArrowDown':
-        target = (current + 1) % selectable.length;
-        break;
-      case 'ArrowLeft':
-      case 'ArrowUp':
-        target = (current - 1 + selectable.length) % selectable.length;
-        break;
-      case 'Home':
-        target = 0;
-        break;
-      case 'End':
-        target = selectable.length - 1;
-        break;
-      default:
-        return;
-    }
-    event.preventDefault();
-    const next = selectable[target];
-    if (!next) return;
-    selectMode(next);
-    modeRefs.current[next]?.focus();
-  };
 
   // Recipients are role IDs, never role names: `roles` is a tenant-scoped table
   // with partner-defined names, so the picker has to show the real rows.
@@ -659,68 +384,12 @@ export default function AiAgentForm({
     setIssues([]);
     setSaving(true);
 
-    // On PATCH the server merges each nested object one level onto the stored
-    // jsonb (updatePolicyColumns), so the narrowing fields this form does not
-    // expose — triggers.siteIds / deviceGroupIds / deviceTags,
-    // protectedResources.deviceTags, recipients.userIds — survive a save rather
-    // than being erased, which would silently WIDEN the agent's blast radius.
-    // One level is enough only because every sub-value is a scalar or an array
-    // today; a nested object inside one of these would need a real deep merge.
-    // On create there is nothing to merge — these are written wholesale.
-    const policy = {
-      name: draft.name.trim(),
-      enabled: draft.enabled,
-      mode: draft.mode,
-      triggers: {
-        // Omitted, not sent as the draft value, for a kind whose runs can
-        // never carry a severity (see ALERT_SEVERITY_KINDS): the form does not
-        // show the control there, and sending a value the operator was never
-        // offered would silently rewrite a stored list they cannot see. The
-        // PATCH merge keeps what is stored; create takes the server default.
-        ...(ALERT_SEVERITY_KINDS.has(draft.kind) ? { alertSeverities: draft.severities } : {}),
-        respectMaintenanceWindows: draft.respectMaintenanceWindows,
-        ticketAutonomousWrites: draft.ticketAutonomousWrites,
-      },
-      toolAllowlist: lines(draft.toolAllowlist),
-      protectedResources: {
-        services: lines(draft.services),
-        paths: lines(draft.paths),
-        registryKeys: lines(draft.registryKeys),
-      },
-      limits: draft.limits,
-      cooldownSeconds: draft.cooldownSeconds,
-      recipients: { roleIds: draft.roleIds },
-      instructions: draft.instructions.trim() ? draft.instructions.trim() : null,
-      // Wave 5 Part B (#3827): scriptIds is not this form's field to send —
-      // omitting it here relies on the SAME one-level PATCH merge the
-      // top-of-function comment already documents (updatePolicyColumns
-      // merges { ...stored.actAssets, ...input.actAssets }), so an existing
-      // scriptIds value survives a save that only ever touches
-      // supervisedActionKeys. On create, the server's createAiAgentSchema
-      // defaults the omitted scriptIds to [].
-      //
-      // P2 review fix: the draft KEEPS its supervisedActionKeys selection
-      // across a mode change (see `selectMode`'s doc), but a non-act mode
-      // can never use them — sent as [] rather than the draft's live value
-      // so leaving act genuinely revokes them server-side, not just in the
-      // UI, while still letting the operator's selection reappear if they
-      // return to act before saving.
-      //
-      // #5049: an ORG row OMITS `actAssets` entirely instead — the server
-      // now 422s (`supervised_keys_grant_only`) any org-row write that ADDS
-      // a key the row does not already hold, because a key goes live on an
-      // org row only through the four-eyes grant executor (spec §4.4). This
-      // form no longer offers an org row an editable selection (see
-      // `orgOwnedKeysReadOnly`), so there is nothing of the operator's to
-      // send; omitting the property is what "leave the stored value alone"
-      // means to the same one-level PATCH merge this function already
-      // relies on for scriptIds above, and the server defaults a create's
-      // omitted key to `[]`. Partner rows are the ceiling and are still
-      // edited directly here, so they keep the live-selection behavior.
-      ...(draft.ownerScope === 'organization'
-        ? {}
-        : { actAssets: { supervisedActionKeys: draft.mode === 'act' ? draft.supervisedActionKeys : [] } }),
-    };
+    // Task 13 (#5051), order-of-work step 1: the body is built by the SAME
+    // `buildAgentSaveBody` the guided create flow uses, so an identical draft
+    // produces an identical POST/PATCH body from either surface — see
+    // `agentDraft.ts` for the merge/omission reasoning this used to carry
+    // inline.
+    const body = buildAgentSaveBody(draft, { isCreate, orgId: orgScope.orgId });
 
     let saved = false;
     try {
@@ -728,19 +397,11 @@ export default function AiAgentForm({
         // Inline thunks: the no-silent-mutations guard is a lexical AST check,
         // so a hoisted request function reads as an unwrapped mutation (#2429).
         request: isCreate
-          ? () => {
-              const body: Record<string, unknown> = {
-                ...policy,
-                kind: draft.kind,
-                ownerScope: draft.ownerScope,
-              };
-              if (draft.ownerScope === 'organization') body.orgId = orgScope.orgId;
-              return fetchWithAuth('/ai/agents', { method: 'POST', body: JSON.stringify(body) });
-            }
+          ? () => fetchWithAuth('/ai/agents', { method: 'POST', body: JSON.stringify(body) })
           : () =>
               fetchWithAuth(`/ai/agents/${agent.id}`, {
                 method: 'PATCH',
-                body: JSON.stringify(policy),
+                body: JSON.stringify(body),
               }),
         successMessage: t('aiAgentsPage.toasts.saved'),
         errorFallback: t('aiAgentsPage.toasts.saveFailed'),
@@ -880,155 +541,21 @@ export default function AiAgentForm({
     </label>
   );
 
-  // Roving-tabindex tab stop. Normally the checked option, but a stale row
-  // can have `draft.mode` set to an option that is now disabled (an agent
-  // saved while `act` was supported, whose partner later lost act
-  // eligibility, still stores `mode: 'act'`) — falling back to the first
-  // ENABLED option keeps the group reachable by Tab at all, rather than
-  // leaving every radio at tabIndex -1.
-  const tabStopMode = modeUnavailable(draft.mode)
-    ? MODE_ORDER.find((mode) => !modeUnavailable(mode))
-    : draft.mode;
-
-  /** The mode radiogroup. Rendered as the first block of the form, before
-   *  Kind and Name: it is the only choice here that can reach a device. */
+  /** The mode radiogroup, extracted to `ModeChoice.tsx` (Task 13, #5051) so
+   *  the guided create flow's Purpose step renders the identical control —
+   *  a pure move, every test id unchanged. Rendered as the first block of
+   *  the form, before Kind and Name: it is the only choice here that can
+   *  reach a device. */
   const modeChoice = (
-    <div className="md:col-span-2" data-testid="ai-agent-mode-field">
-      <h3 id={modeHeadingId} className="text-sm font-semibold">
-        {t('aiAgentsPage.modeChoice.legend')}
-      </h3>
-      <div
-        role="radiogroup"
-        aria-labelledby={modeHeadingId}
-        onKeyDown={onModeKeyDown}
-        className="mt-2 grid gap-2 sm:grid-cols-3"
-        data-testid="ai-agent-mode"
-      >
-        {MODE_ORDER.map((mode) => {
-          const selected = draft.mode === mode;
-          const unavailable = modeUnavailable(mode);
-          return (
-            <button
-              key={mode}
-              type="button"
-              role="radio"
-              aria-checked={selected}
-              disabled={unavailable}
-              tabIndex={mode === tabStopMode ? 0 : -1}
-              ref={(node) => {
-                modeRefs.current[mode] = node;
-              }}
-              onClick={() => selectMode(mode)}
-              // Read by `onModeKeyDown` to find which card the keystroke came
-              // from — the roving group's arrow keys must step from the FOCUSED
-              // option, not from the stored one.
-              data-mode={mode}
-              // Act selected does NOT look like Off/Shadow selected. All three
-              // shared one primary-blue ring, so the one card that authorizes
-              // unattended changes on a customer machine read as no more
-              // consequential than "do nothing" — the warning tone is the same
-              // one the act warning panel and its icon already use.
-              // `flex flex-col items-start` overrides the UA stylesheet's
-              // vertical centring of a <button>'s content box. The three cards
-              // stretch to a common height in the grid but carry consequence
-              // lines of different lengths, so centred content put the three
-              // option NAMES on three different baselines — the one line a
-              // reader scans across before choosing.
-              className={`flex flex-col items-start rounded-lg border p-3 text-left transition-colors focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60 ${
-                selected
-                  ? mode === 'act'
-                    ? 'border-warning-strong bg-warning/10 ring-1 ring-warning-strong'
-                    : 'border-primary bg-primary/10 ring-1 ring-primary'
-                  : 'bg-background hover:border-primary/50 hover:bg-muted/40'
-              }`}
-              data-testid={`ai-agent-mode-${mode}`}
-            >
-              {/* `w-full`: the card is now a flex COLUMN with `items-start`,
-                  which shrinks its children to their content width — without
-                  this the act card's `ml-auto` warning icon would sit against
-                  the label instead of the card's right edge. */}
-              <span className="flex w-full items-center gap-2">
-                {/* Selection is encoded by SHAPE (a filled ring) as well as by
-                    colour, so the choice survives a colourblind read. */}
-                <span
-                  aria-hidden="true"
-                  className={`flex h-4 w-4 shrink-0 items-center justify-center rounded-full border ${
-                    selected
-                      ? mode === 'act' ? 'border-warning-strong' : 'border-primary'
-                      : 'border-muted-foreground/50'
-                  }`}
-                >
-                  {selected && (
-                    <span
-                      className={`h-2 w-2 rounded-full ${mode === 'act' ? 'bg-warning-strong' : 'bg-primary'}`}
-                    />
-                  )}
-                </span>
-                <span className="text-sm font-medium">{MODE_LABEL[mode]}</span>
-                {mode === 'act' && (
-                  <AlertTriangle className="ml-auto h-4 w-4 shrink-0 text-warning-strong" aria-hidden="true" />
-                )}
-              </span>
-              <span className="mt-1.5 block text-xs text-muted-foreground">
-                {MODE_CONSEQUENCE[mode]}
-              </span>
-              {unavailable && (
-                <span
-                  className="mt-1.5 block text-xs text-muted-foreground"
-                  data-testid="ai-agent-mode-act-unavailable"
-                >
-                  {t('aiAgentsPage.modeChoice.actUnavailable')}
-                </span>
-              )}
-            </button>
-          );
-        })}
-      </div>
-
-      {/* Attached to the choice, not floated below the rest of the fields:
-          the warning and its acknowledgement are what the act card MEANS. */}
-      {draft.mode === 'act' && (
-        <div
-          className="mt-2 space-y-2 rounded-lg border border-warning-strong/50 bg-warning/10 p-3 text-sm"
-          data-testid="ai-agent-act-warning"
-        >
-          <p className="flex items-start gap-2 font-medium">
-            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-warning-strong" aria-hidden="true" />
-            <span>{t('aiAgentsPage.actWarning.title')}</span>
-          </p>
-          <ul className="list-disc space-y-1 pl-5 text-muted-foreground">
-            <li>{t('aiAgentsPage.actWarning.unattended')}</li>
-            <li>{t('aiAgentsPage.actWarning.verification')}</li>
-            <li>{t('aiAgentsPage.actWarning.noRollback')}</li>
-            <li>{t('aiAgentsPage.actWarning.singleDevice')}</li>
-            <li>{t('aiAgentsPage.actWarning.actionCap')}</li>
-          </ul>
-          {enteringActMode && (
-            <label className="flex items-start gap-2 pt-1 text-sm font-medium">
-              <input
-                type="checkbox"
-                checked={actAck}
-                onChange={(e) => setActAck(e.target.checked)}
-                data-testid="ai-agent-act-ack"
-              />
-              <span>{t('aiAgentsPage.actWarning.ack')}</span>
-            </label>
-          )}
-        </div>
-      )}
-
-      {/* Mounted UNCONDITIONALLY — only the text toggles. An aria-live
-          region (`role="status"`) only announces changes to content that was
-          already present in the accessibility tree; mounting it on demand
-          meant the FIRST thing it ever had to say was never announced. */}
-      <p
-        className="mt-2 text-xs text-muted-foreground"
-        role="status"
-        data-testid="ai-agent-act-keys-cleared"
-      >
-        {actKeysWillBeOmitted ? t('aiAgentsPage.fields.actKeysCleared') : ''}
-      </p>
-    </div>
+    <ModeChoice
+      mode={draft.mode}
+      onChange={(mode) => patch({ mode })}
+      actSupported={actSupported}
+      enteringActMode={enteringActMode}
+      actAck={actAck}
+      onActAckChange={setActAck}
+      actKeysWillBeOmitted={actKeysWillBeOmitted}
+    />
   );
 
   /**
@@ -1071,7 +598,7 @@ export default function AiAgentForm({
         const entry = policyKeysByKey.get(key);
         return (
           <li key={key} data-testid={`ai-agent-supervised-key-${key}`}>
-            {entry ? policyActionLabel(entry) : sentenceCase(key)}
+            {entry ? policyActionLabel(t, entry) : sentenceCase(key)}
           </li>
         );
       })}
@@ -1080,54 +607,17 @@ export default function AiAgentForm({
 
   /** The registry checkboxes, grouped by tool with translated labels — the
    *  interactive rendering, now reached only for a PARTNER row (org rows
-   *  render `orgHeldKeysList` above instead; see `policyKeysBody` below). */
-  const policyKeysCheckboxes = policyKeysFailed ? (
-    <p className="text-sm text-destructive" data-testid="ai-agent-policy-keys-failed">
-      {t('aiAgentsPage.fields.supervisedActionKeysFailed')}
-    </p>
-  ) : policyKeys.length === 0 ? (
-    <p className="text-sm text-muted-foreground" data-testid="ai-agent-policy-keys-empty">
-      {t('aiAgentsPage.fields.supervisedActionKeysEmpty')}
-    </p>
-  ) : (
-    <div className="space-y-3">
-      {[...groupByTool(policyKeys).entries()].map(([toolName, entries]) => (
-        <div key={toolName}>
-          <p className="text-xs font-semibold">{policyToolLabel(toolName)}</p>
-          <div className="space-y-1.5">
-            {entries.map((entry) => {
-              // `idSafe`: a colon in `manage_services:restart` is a legal DOM
-              // id character but a syntax error in a CSS/query selector, so
-              // the registry key can't be spliced into the id raw.
-              const noteId = `${policyKeyNoteBaseId}-${idSafe(entry.key)}`;
-              return (
-                <label key={entry.key} className="flex items-start gap-2 text-sm">
-                  <input
-                    type="checkbox"
-                    className="mt-0.5"
-                    checked={draft.supervisedActionKeys.includes(entry.key)}
-                    onChange={() =>
-                      patch({ supervisedActionKeys: toggle(draft.supervisedActionKeys, entry.key) })}
-                    aria-describedby={noteId}
-                    data-testid={`ai-agent-supervised-key-${entry.key}`}
-                  />
-                  <span>
-                    <span className="block">{policyActionLabel(entry)}</span>
-                    {/* The registry's own one-sentence description of what the
-                        operation actually does — wired as the checkbox's
-                        accessible description, not just adjacent text, so a
-                        screen reader announces it as part of the control. */}
-                    <span id={noteId} className="block text-xs text-muted-foreground">
-                      {entry.note}
-                    </span>
-                  </span>
-                </label>
-              );
-            })}
-          </div>
-        </div>
-      ))}
-    </div>
+   *  render `orgHeldKeysList` above instead; see `policyKeysBody` below).
+   *  Extracted to `PolicyKeysCheckboxes.tsx` (Task 13, #5051) so the guided
+   *  create flow's `SafetyStep` can render the identical registry — a pure
+   *  move, every test id unchanged. */
+  const policyKeysCheckboxes = (
+    <PolicyKeysCheckboxes
+      policyKeys={policyKeys}
+      policyKeysFailed={policyKeysFailed}
+      selectedKeys={draft.supervisedActionKeys}
+      onToggle={(key) => patch({ supervisedActionKeys: toggle(draft.supervisedActionKeys, key) })}
+    />
   );
 
   /** Org rows get the read-only list; partner rows keep the interactive
@@ -1385,7 +875,7 @@ export default function AiAgentForm({
                 take effect. */}
             {usesAlertSeverities && (
               <div className="flex flex-wrap gap-3">
-                {SEVERITIES.map((severity) => (
+                {ALERT_SEVERITIES.map((severity) => (
                   <label key={severity} className="flex items-center gap-1 text-sm">
                     <input
                       type="checkbox"

--- a/apps/web/src/components/settings/AiAgentForm.tsx
+++ b/apps/web/src/components/settings/AiAgentForm.tsx
@@ -10,17 +10,16 @@ import { useTranslation } from 'react-i18next';
 import {
   AI_AGENT_KINDS,
   ALERT_SEVERITIES,
-  SUPPORTED_AGENT_MODES,
   type AiAgentDto,
   type AiAgentKind,
   type AiAgentMode,
 } from '@breeze/shared';
 import { fetchWithAuth } from '../../stores/auth';
-import { ActionError, handleActionError, runAction } from '@/lib/runAction';
+import { handleActionError, runAction } from '@/lib/runAction';
 import { loginPathWithNext } from '@/lib/authScope';
 import { navigateTo } from '@/lib/navigation';
 import { useOrgScope } from '@/hooks/useOrgScope';
-import { useDefaultOwnerScope, type OwnerScope } from '@/hooks/useDefaultOwnerScope';
+import { useDefaultOwnerScope } from '@/hooks/useDefaultOwnerScope';
 import { ConfirmDialog } from '../shared/ConfirmDialog';
 import AiAgentSchedulesSection from './AiAgentSchedulesSection';
 import AiAgentGraduationPanel from './AiAgentGraduationPanel';
@@ -28,16 +27,17 @@ import CapabilityPicker from './aiAgents/CapabilityPicker';
 import { useAgentToolCatalog } from './aiAgents/useAgentToolCatalog';
 import ModeChoice from './aiAgents/ModeChoice';
 import PolicyKeysCheckboxes, {
+  collapsedForCeiling,
   policyActionLabel,
   sentenceCase,
   type PolicyDecidableKeyOption,
 } from './aiAgents/PolicyKeysCheckboxes';
+import { listField, numberField, RecipientRolesFieldset, type RoleOption } from './aiAgents/agentFields';
+import { AGENT_ERROR_COPY, agentSaveIssuesFromError } from './aiAgents/agentErrors';
 import {
   ALERT_SEVERITY_KINDS,
   buildAgentSaveBody,
   draftFrom,
-  firstFreeKind,
-  freeKinds,
   lines,
   toggle,
   type Draft,
@@ -46,44 +46,8 @@ import {
 export type { AiAgentDto };
 export type { Draft } from './aiAgents/agentDraft';
 
-interface RoleOption {
-  id: string;
-  name: string;
-  /** `roles.scope` as GET /roles projects it. Optional on the type because an
-   *  older API build omits it; such a role is grouped with the organization
-   *  roles rather than dropped — a recipient must never disappear because a
-   *  field it never had is missing. */
-  scope?: 'partner' | 'organization';
-}
-
-function roleScope(role: RoleOption): 'partner' | 'organization' {
-  return role.scope === 'partner' ? 'partner' : 'organization';
-}
-
-/** Rendered in this order; a group with no roles is skipped entirely. */
-const ROLE_GROUPS = ['partner', 'organization'] as const;
-
 interface Props {
-  /** null = create a new agent. */
-  agent: AiAgentDto | null;
-  /**
-   * Every agent visible to this session. The taken-kind set must be derived
-   * against the OWNER the draft is targeting, not flattened across both axes —
-   * uniqueness is (partner_id, kind) and (org_id, kind) independently.
-   */
-  agents: AiAgentDto[];
-  /**
-   * Kinds that already have an active partner-wide baseline for this org's
-   * partner (#4170). An org-only agent is override-only by design — with no
-   * baseline for its kind, the resolver treats it as if it did not exist —
-   * so this warns BEFORE creating an org row of a kind with no baseline yet.
-   * Reported by GET /ai/agents alongside `agents`, not derivable from
-   * `agents` itself: a not-yet-created kind has no row to read it off of.
-   */
-  partnerBaselineKinds: Set<string>;
-  /** Show the partner-wide vs org-owned selector (create-only, partner-scope users). */
-  showOwnerScope: boolean;
-  defaultOwnerScope: OwnerScope;
+  agent: AiAgentDto;
   onClose: () => void;
   onSaved: () => void;
   /**
@@ -101,78 +65,39 @@ interface Props {
 
 const UNAUTHORIZED = () => void navigateTo(loginPathWithNext(), { replace: true });
 
-/**
- * Machine token -> operator-facing sentence. The API answers these with a
- * `code`, and runAction's `friendly` hook is keyed on it; without this the
- * toast shows the token verbatim.
- */
-const AGENT_ERROR_COPY: Record<string, ((t: (key: string) => string) => string) | undefined> = {
-  agent_kind_exists: (t) => t('aiAgentsPage.errors.kindExists'),
-  mode_not_supported: (t) => t('aiAgentsPage.errors.modeNotSupported'),
-  // The server's 422 (Task 6, #3826) is the authoritative gate — the
-  // structured `missing[]` it carries is rendered as issues below, this is
-  // just the toast fallback so the raw machine token never reaches the user.
-  act_prerequisites_not_met: (t) => t('aiAgentsPage.errors.actPrerequisitesNotMet'),
-  // Wave 5 Part B (#3827): the server's 422 (agentService.ts's
-  // InvalidSupervisedActionKeysError) carries a structured `rejected[]` —
-  // this is just the toast fallback; the per-key detail is rendered as
-  // issues below via ACT_PREREQUISITE_COPY's sibling handling in save()'s
-  // catch block.
-  invalid_supervised_action_keys: (t) => t('aiAgentsPage.errors.invalidSupervisedActionKeys'),
-  // #5049: the server's 422 (agentService.ts's SupervisedKeysGrantOnlyError)
-  // carries the same structured `rejected[]` shape as
-  // invalid_supervised_action_keys above — mapped as the identical toast
-  // fallback and rendered by the same per-key branch in save()'s catch block.
-  supervised_keys_grant_only: (t) => t('aiAgentsPage.errors.invalidSupervisedActionKeys'),
-};
-
-/**
- * `missing[]` entries from the server's `act_prerequisites_not_met` 422
- * (Task 6, #3826 — `ActPrerequisitesNotMetError`). Mapped to translated,
- * actionable copy so the operator sees what to fix rather than a machine
- * token.
- */
-const ACT_PREREQUISITE_COPY: Record<string, (t: (key: string) => string) => string> = {
-  recipient: (t) => t('aiAgentsPage.errors.actMissingRecipient'),
-  act_eligible_tool: (t) => t('aiAgentsPage.errors.actMissingTool'),
-};
-
 const inputCls = 'w-full rounded-md border bg-background px-2.5 py-1.5 text-sm';
 const INSTRUCTIONS_MAX = 2000;
 
 /**
- * Create/edit form for one AI agent policy row.
- *
- * `kind` and `ownerScope` are create-only: the API has no update path for
- * either (an agent's identity is `(owner, kind)`, and both unique indexes are
- * partial on `disabled_at IS NULL`), so offering them on edit would promise a
- * change the server cannot make.
+ * Edit form for one existing AI agent policy row. Create is handled entirely
+ * by the guided create flow (`AgentCreateFlow.tsx`, Task 13 #5051) —
+ * `AiAgentsPage.tsx` opens this drawer only for `openEditor`, never for
+ * "New agent" — so `kind` and `ownerScope` are fixed for the life of this
+ * form: the API has no update path for either (an agent's identity is
+ * `(owner, kind)`, and both unique indexes are partial on `disabled_at IS
+ * NULL`), which is exactly why they are rendered read-only below rather than
+ * as the editable controls the create flow's Purpose step offers.
  */
 export default function AiAgentForm({
   agent,
-  agents,
-  partnerBaselineKinds,
-  showOwnerScope,
-  defaultOwnerScope,
   onClose,
   onSaved,
   onDirtyChange,
 }: Props) {
   const { t } = useTranslation('settings');
   const orgScope = useOrgScope();
-  // Read from the single source of the partner-scope rule rather than reusing
-  // `showOwnerScope`: that prop means "offer the create-only owner selector",
-  // which happens to be the same boolean today but is not the same QUESTION —
-  // the schedules section asks whether this session may write partner-wide
-  // policy at all (canManagePartnerWidePolicies' client-side counterpart).
+  // The schedules section asks whether this session may write partner-wide
+  // policy at all (canManagePartnerWidePolicies' client-side counterpart) —
+  // independent of this agent's own `ownerScope`.
   const { isPartnerScope } = useDefaultOwnerScope();
-  const isCreate = agent === null;
 
+  // `agent.ownerScope`/`agent.kind` feed `draftFrom`'s `defaults` param only
+  // as a type-satisfying placeholder — `agent` is always present here (this
+  // form is edit-only), so `draftFrom`'s own `agent?.ownerScope ?? defaults.*`
+  // fallbacks never actually reach for it. The create flow
+  // (`AgentCreateFlow.tsx`) is the caller that exercises real defaults.
   const [draft, setDraft] = useState<Draft>(() =>
-    draftFrom(agent, {
-      ownerScope: defaultOwnerScope,
-      kind: firstFreeKind(agents, defaultOwnerScope, orgScope.orgId) ?? AI_AGENT_KINDS[0],
-    }),
+    draftFrom(agent, { ownerScope: agent.ownerScope, kind: agent.kind }),
   );
 
   // Captured once at mount (the parent keys this form by agent id, so a new
@@ -180,18 +105,10 @@ export default function AiAgentForm({
   // "does not carry a stale draft" below). The acknowledgement gate only
   // applies to a genuine transition INTO act mode, not to every subsequent
   // edit of an agent that is already acting.
-  const [initialMode] = useState<AiAgentMode>(agent?.mode ?? 'off');
+  const [initialMode] = useState<AiAgentMode>(agent.mode);
   const [actAck, setActAck] = useState(false);
   const enteringActMode = draft.mode === 'act' && initialMode !== 'act';
 
-  // Recomputed on every owner-scope flip. Flattening this across both axes is
-  // what previously hid `triage` from the PARTNER-WIDE create form as soon as
-  // any single org owned a triage agent — and with no partner baseline,
-  // resolveEffectiveAgent returns null, so triage was dead for every org.
-  const availableKinds = useMemo(
-    () => freeKinds(agents, draft.ownerScope, orgScope.orgId),
-    [agents, draft.ownerScope, orgScope.orgId],
-  );
   const [roles, setRoles] = useState<RoleOption[]>([]);
   const [rolesFailed, setRolesFailed] = useState(false);
   const [policyKeys, setPolicyKeys] = useState<PolicyDecidableKeyOption[]>([]);
@@ -248,7 +165,6 @@ export default function AiAgentForm({
   const permissionsHeadingId = useId();
   const limitsBudgetId = useId();
   const limitsTimingId = useId();
-  const rolesGroupBaseId = useId();
   const severitiesGroupId = useId();
   const nameInputId = useId();
   const nameErrorId = useId();
@@ -262,19 +178,7 @@ export default function AiAgentForm({
   const usesAlertSeverities = ALERT_SEVERITY_KINDS.has(draft.kind);
 
   // ---- Mode: the privileged choice --------------------------------------
-  // The CREATE path has no `agent` DTO yet, so the fallback must be the shared
-  // constant and never `[]` — see the long note this file already carries on
-  // the old `<option disabled>`; the reasoning survived the control change.
-  const actSupported = (agent?.supportedModes ?? SUPPORTED_AGENT_MODES).includes('act');
-
-  // Literal keys, same reason ModeChoice.tsx's own label maps are: the closed
-  // two-member set is spelled out so the keyUsage guard verifies both labels
-  // statically.
-  const ROLE_GROUP_LABEL: Record<(typeof ROLE_GROUPS)[number], string> = {
-    partner: t('aiAgentsPage.fields.recipientRolesPartner'),
-    organization: t('aiAgentsPage.fields.recipientRolesOrganization'),
-  };
-
+  const actSupported = agent.supportedModes.includes('act');
 
   // Recipients are role IDs, never role names: `roles` is a tenant-scoped table
   // with partner-defined names, so the picker has to show the real rows.
@@ -374,9 +278,6 @@ export default function AiAgentForm({
     if (ALERT_SEVERITY_KINDS.has(draft.kind) && draft.severities.length === 0) {
       problems.push(t('aiAgentsPage.issues.severities'));
     }
-    if (isCreate && draft.ownerScope === 'organization' && !orgScope.orgId) {
-      problems.push(t('aiAgentsPage.issues.org'));
-    }
     if (problems.length > 0) {
       setIssues(problems);
       return;
@@ -386,23 +287,19 @@ export default function AiAgentForm({
 
     // Task 13 (#5051), order-of-work step 1: the body is built by the SAME
     // `buildAgentSaveBody` the guided create flow uses, so an identical draft
-    // produces an identical POST/PATCH body from either surface — see
+    // produces an identical PATCH/POST body from either surface — see
     // `agentDraft.ts` for the merge/omission reasoning this used to carry
-    // inline.
-    const body = buildAgentSaveBody(draft, { isCreate, orgId: orgScope.orgId });
+    // inline. `isCreate: false` unconditionally: this form only ever edits
+    // (see the module doc) — the guided create flow is the only caller that
+    // ever passes `true`.
+    const body = buildAgentSaveBody(draft, { isCreate: false, orgId: orgScope.orgId });
 
     let saved = false;
     try {
       await runAction({
-        // Inline thunks: the no-silent-mutations guard is a lexical AST check,
+        // Inline thunk: the no-silent-mutations guard is a lexical AST check,
         // so a hoisted request function reads as an unwrapped mutation (#2429).
-        request: isCreate
-          ? () => fetchWithAuth('/ai/agents', { method: 'POST', body: JSON.stringify(body) })
-          : () =>
-              fetchWithAuth(`/ai/agents/${agent.id}`, {
-                method: 'PATCH',
-                body: JSON.stringify(body),
-              }),
+        request: () => fetchWithAuth(`/ai/agents/${agent.id}`, { method: 'PATCH', body: JSON.stringify(body) }),
         successMessage: t('aiAgentsPage.toasts.saved'),
         errorFallback: t('aiAgentsPage.toasts.saveFailed'),
         // Without this the operator sees the raw machine token the API puts in
@@ -418,51 +315,18 @@ export default function AiAgentForm({
       // The client-side ack checkbox is only a UX nudge — the server's 422
       // prerequisites (Task 6, #3826) are authoritative, e.g. the agent's
       // recipients or act-eligible tools changed between load and save.
-      // Surface exactly what it named as unmet, not just the generic toast.
-      if (err instanceof ActionError && err.code === 'act_prerequisites_not_met') {
-        const body = err.body as { missing?: unknown } | undefined;
-        const missing = Array.isArray(body?.missing)
-          ? body.missing.filter((entry): entry is string => typeof entry === 'string')
-          : [];
-        setIssues(
-          missing.map((entry) => ACT_PREREQUISITE_COPY[entry]?.(t) ?? entry),
-        );
-      }
-      // Wave 5 Part B (#3827): the server's 422 (InvalidSupervisedActionKeysError)
-      // carries a structured `rejected[]` naming exactly which keys failed and
-      // why — same "actionable, not a bare toast" pattern as the prerequisites
-      // branch above.
-      // #5049: SupervisedKeysGrantOnlyError (`supervised_keys_grant_only`)
-      // carries the identical `rejected[]` shape — this form no longer sends
-      // an org row's keys at all (see `save()`'s `actAssets` above), so this
-      // branch is defense-in-depth rather than a path this form exercises
-      // itself, same reasoning as reusing the toast copy above.
-      if (
-        err instanceof ActionError
-        && (err.code === 'invalid_supervised_action_keys' || err.code === 'supervised_keys_grant_only')
-      ) {
-        const body = err.body as { rejected?: unknown } | undefined;
-        const rejected = Array.isArray(body?.rejected)
-          ? body.rejected.filter(
-              (entry): entry is { key: string; reason: string } =>
-                typeof entry === 'object'
-                && entry !== null
-                && typeof (entry as { key?: unknown }).key === 'string'
-                && typeof (entry as { reason?: unknown }).reason === 'string',
-            )
-          : [];
-        setIssues(
-          rejected.map((entry) =>
-            t('aiAgentsPage.errors.supervisedKeyRejected', { key: entry.key, reason: entry.reason })),
-        );
-      }
+      // Surfaces exactly what the server named as unmet/rejected, not just
+      // the generic toast — same mapping the guided create flow's `create()`
+      // uses, so the two can never read a 422 differently.
+      const fieldIssues = agentSaveIssuesFromError(err, t);
+      if (fieldIssues) setIssues(fieldIssues);
     } finally {
       setSaving(false);
     }
     // Outside the try: a render error thrown by the parent's reload must not
     // be reported to the operator as "could not save the agent".
     if (saved) onSaved();
-  }, [agent, draft, isCreate, orgScope.orgId, saving, scheduleDirty, onSaved, t]);
+  }, [agent, draft, orgScope.orgId, saving, scheduleDirty, onSaved, t]);
 
   const disable = useCallback(async () => {
     // `saving` guards this too: without it a double-click fires two DELETEs and
@@ -494,52 +358,6 @@ export default function AiAgentForm({
     }
     if (disabled) onSaved();
   }, [agent, onSaved, saving, t]);
-
-  const numberField = (
-    testId: string,
-    label: string,
-    value: number,
-    min: number,
-    max: number,
-    onChange: (next: number) => void,
-  ) => (
-    <label className="space-y-1 text-sm">
-      <span className="font-medium">{label}</span>
-      <input
-        type="number"
-        className={inputCls}
-        min={min}
-        max={max}
-        value={value}
-        onChange={(e) => {
-          // Clearing a number input yields '' -> NaN, which JSON.stringify
-          // emits as null and the server rejects with a bare 400.
-          const next = Number(e.target.value);
-          onChange(Number.isFinite(next) ? next : min);
-        }}
-        data-testid={testId}
-      />
-    </label>
-  );
-
-  const listField = (
-    testId: string,
-    label: string,
-    value: string,
-    onChange: (next: string) => void,
-    rows = 3,
-  ) => (
-    <label className="space-y-1 text-sm">
-      <span className="font-medium">{label}</span>
-      <textarea
-        className={`${inputCls} font-mono`}
-        rows={rows}
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        data-testid={testId}
-      />
-    </label>
-  );
 
   /** The mode radiogroup, extracted to `ModeChoice.tsx` (Task 13, #5051) so
    *  the guided create flow's Purpose step renders the identical control —
@@ -649,8 +467,13 @@ export default function AiAgentForm({
    * always gets; the ceiling caveat still prints beneath it as a fact that
    * survives the mode, not as something act mode makes disappear. An org row
    * has no ceiling caveat to begin with and is only ever shown in act mode,
-   * so it renders the list directly with no wrapper at all. */
-  const collapsedForCeiling = draft.ownerScope === 'partner' && draft.mode !== 'act';
+   * so it renders the list directly with no wrapper at all.
+   *
+   * The collapse condition itself is `collapsedForCeiling` (imported from
+   * `PolicyKeysCheckboxes.tsx`), shared with the guided create flow's
+   * `SafetyStep.tsx` so the two surfaces can never disagree on when a
+   * partner row's registry is worth collapsing. */
+  const isCollapsedForCeiling = collapsedForCeiling(draft.ownerScope, draft.mode);
   const ceilingNote = draft.ownerScope === 'partner' && (
     <p className="text-xs text-muted-foreground" data-testid="ai-agent-supervised-keys-ceiling-hint">
       {t('aiAgentsPage.graduation.ceilingHint')}
@@ -670,7 +493,7 @@ export default function AiAgentForm({
         {t('aiAgentsPage.sections.policyDecide')}
       </legend>
       <p className="text-xs text-muted-foreground">{t('aiAgentsPage.fields.supervisedActionKeysHint')}</p>
-      {collapsedForCeiling ? (
+      {isCollapsedForCeiling ? (
         <details data-testid="ai-agent-policy-keys-details">
           <summary className="cursor-pointer text-xs font-medium">
             {t('aiAgentsPage.fields.supervisedActionKeysCeilingSummary', {
@@ -709,77 +532,28 @@ export default function AiAgentForm({
         <div className="grid gap-3 md:grid-cols-2">
           {modeChoice}
 
-          {isCreate && showOwnerScope && (
-            <fieldset className="space-y-2 rounded-md border p-3 md:col-span-2" data-testid="ai-agent-ownerscope">
-              <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">
-                {t('aiAgentsPage.editor.scopeLegend')}
-              </legend>
-              <label className="flex items-center gap-2 text-sm">
-                <input
-                  type="radio"
-                  name="ai-agent-owner"
-                  value="partner"
-                  checked={draft.ownerScope === 'partner'}
-                  onChange={() => patch({ ownerScope: 'partner', kind: firstFreeKind(agents, 'partner', orgScope.orgId) ?? draft.kind })}
-                  data-testid="ai-agent-owner-partner"
-                />
-                {t('aiAgentsPage.editor.allOrgs')}{' '}
-                <span className="text-muted-foreground">{t('aiAgentsPage.editor.allOrgsHint')}</span>
-              </label>
-              <label className="flex items-center gap-2 text-sm">
-                <input
-                  type="radio"
-                  name="ai-agent-owner"
-                  value="organization"
-                  checked={draft.ownerScope === 'organization'}
-                  onChange={() => patch({ ownerScope: 'organization', kind: firstFreeKind(agents, 'organization', orgScope.orgId) ?? draft.kind })}
-                  data-testid="ai-agent-owner-org"
-                />
-                {t('aiAgentsPage.editor.thisOrg')}
-              </label>
-            </fieldset>
-          )}
-
-          {/* #4170: an org-only agent overrides a partner-wide baseline of the
-              same kind — it is never a standalone policy. Not nested inside
-              `showOwnerScope` above: an org-scoped session's default (and
-              only) create path never renders that selector at all, and is
-              exactly the common case this warns for. */}
-          {isCreate && draft.ownerScope === 'organization' && !partnerBaselineKinds.has(draft.kind) && (
-            <p
-              className="rounded-md border border-amber-300 bg-amber-100 px-3 py-2 text-sm text-amber-800 dark:border-amber-800 dark:bg-amber-950/50 dark:text-amber-200 md:col-span-2"
-              data-testid="ai-agent-no-baseline-hint"
-            >
-              {t('aiAgentsPage.inertBadge.hint')}
-            </p>
-          )}
-
-          {isCreate && availableKinds.length === 0 && (
-            <p className="text-sm text-muted-foreground md:col-span-2" data-testid="ai-agent-kinds-exhausted">
-              {t('aiAgentsPage.issues.allKindsTaken')}
-            </p>
-          )}
-
+          {/* `kind` and `ownerScope` are create-only (see the module doc) —
+              this form only ever edits, so both render as fixed rather than
+              as the editable owner-scope selector / kind picker the create
+              flow's Purpose step offers. */}
           <label className="space-y-1 text-sm">
             <span className="font-medium">{t('aiAgentsPage.fields.kind')}</span>
             <select
               className={inputCls}
               value={draft.kind}
-              disabled={!isCreate}
+              disabled
               onChange={(e) => patch({ kind: e.target.value as AiAgentKind })}
               data-testid="ai-agent-kind"
             >
-              {(isCreate ? availableKinds : AI_AGENT_KINDS).map((kind) => (
+              {AI_AGENT_KINDS.map((kind) => (
                 <option key={kind} value={kind}>
                   {t(/* i18n-dynamic */ `aiAgentsPage.kinds.${kind}`)}
                 </option>
               ))}
             </select>
-            {!isCreate && (
-              <span className="block text-xs text-muted-foreground">
-                {t('aiAgentsPage.fields.kindImmutable')}
-              </span>
-            )}
+            <span className="block text-xs text-muted-foreground">
+              {t('aiAgentsPage.fields.kindImmutable')}
+            </span>
           </label>
 
           {/* The only required free-text field on the form, and it used to
@@ -833,34 +607,22 @@ export default function AiAgentForm({
             <p className="pl-6 text-xs text-muted-foreground" data-testid="ai-agent-enabled-hint">
               {t('aiAgentsPage.fields.enabledHint')}
             </p>
-            {/* Create only: an unticked box on a brand-new form reads as
-                something the operator forgot, not as the product's deliberate
-                choice. Naming it turns the box into the last, explicit step. */}
-            {isCreate && (
-              <p className="pl-6 text-xs text-muted-foreground" data-testid="ai-agent-enabled-create-hint">
-                {t('aiAgentsPage.fields.enabledCreateHint')}
-              </p>
-            )}
           </div>
 
-          {/* Graduation evidence (P2-5, #4192). Edit-only, for the same reason
-              the schedules section is: the evidence ledger is keyed to a
-              persisted agent that does not exist until the first save. NOT gated
-              on `draft.mode === 'act'` — evidence an agent already earned is a
-              fact about the past, so toggling an unsaved draft back to shadow
-              must not make it disappear. The panel is read-only-useful with
+          {/* Graduation evidence (P2-5, #4192). NOT gated on `draft.mode ===
+              'act'` — evidence an agent already earned is a fact about the
+              past, so toggling the draft back to shadow must not make it
+              disappear. The panel is read-only-useful with
               `BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED` off; see its module doc.
               `agent.kind` (stored), not `draft.kind`, since kind is create-only.
               An org-owned agent always reads its OWN org's evidence; a partner
               baseline follows the org switcher, and falls through to the
               partner-wide grouping when it is on "all organizations". */}
-          {!isCreate && (
-            <AiAgentGraduationPanel
-              orgId={agent.orgId ?? orgScope.orgId}
-              kind={agent.kind}
-              isPartnerScope={isPartnerScope}
-            />
-          )}
+          <AiAgentGraduationPanel
+            orgId={agent.orgId ?? orgScope.orgId}
+            kind={agent.kind}
+            isPartnerScope={isPartnerScope}
+          />
 
           <fieldset className="space-y-2 rounded-md border p-3 md:col-span-2">
             <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">
@@ -1025,60 +787,20 @@ export default function AiAgentForm({
             </div>
           </fieldset>
 
-          <fieldset className="space-y-2 rounded-md border p-3 md:col-span-2">
-            <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">
-              {t('aiAgentsPage.sections.notifications')}
-            </legend>
-            <p className="text-xs text-muted-foreground">{t('aiAgentsPage.fields.recipientRolesHint')}</p>
-            {rolesFailed ? (
-              <p className="text-sm text-destructive" data-testid="ai-agent-roles-failed">
-                {t('aiAgentsPage.fields.recipientRolesFailed')}
-              </p>
-            ) : roles.length === 0 ? (
-              <p className="text-sm text-muted-foreground" data-testid="ai-agent-roles-empty">
-                {t('aiAgentsPage.fields.recipientRolesEmpty')}
-              </p>
-            ) : (
-              // Nine flat checkboxes with partner and organization roles
-              // interleaved read as one undifferentiated list, and the two
-              // answer different questions: who at the MSP hears about this,
-              // and who at the customer does. Grouped, not filtered — every
-              // control the flat list carried is still here.
-              <div className="space-y-3">
-                {ROLE_GROUPS.map((scope) => {
-                  const group = roles.filter((role) => roleScope(role) === scope);
-                  if (group.length === 0) return null;
-                  return (
-                    <div key={scope} role="group" aria-labelledby={`${rolesGroupBaseId}-${scope}`}>
-                      <p id={`${rolesGroupBaseId}-${scope}`} className="text-xs font-medium">
-                        {ROLE_GROUP_LABEL[scope]}
-                      </p>
-                      <div className="mt-1 flex flex-wrap gap-3" data-testid={`ai-agent-roles-${scope}`}>
-                        {group.map((role) => (
-                          <label key={role.id} className="flex items-center gap-1 text-sm">
-                            <input
-                              type="checkbox"
-                              checked={draft.roleIds.includes(role.id)}
-                              onChange={() => patch({ roleIds: toggle(draft.roleIds, role.id) })}
-                              data-testid={`ai-agent-role-${role.id}`}
-                            />
-                            {role.name}
-                          </label>
-                        ))}
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            )}
-          </fieldset>
+          <RecipientRolesFieldset
+            className="space-y-2 rounded-md border p-3 md:col-span-2"
+            t={t}
+            roles={roles}
+            rolesFailed={rolesFailed}
+            roleIds={draft.roleIds}
+            onToggleRole={(id) => patch({ roleIds: toggle(draft.roleIds, id) })}
+          />
 
-          {/* Scheduled sweeps (P2-2, #4189). Edit-only, because a schedule row
-              references a persisted agent id that does not exist until the first
-              save; triage-only, because the API refuses every other kind
-              (`agent_kind_not_triage`). Gated on the STORED kind, not the draft:
-              kind is create-only, so the two cannot diverge on this form. */}
-          {!isCreate && agent.kind === 'triage' && (
+          {/* Scheduled sweeps (P2-2, #4189). Triage-only, because the API
+              refuses every other kind (`agent_kind_not_triage`). Gated on the
+              STORED kind, not the draft: kind is create-only, so the two
+              cannot diverge on this form. */}
+          {agent.kind === 'triage' && (
             <AiAgentSchedulesSection
               agentId={agent.id}
               agentOwnerScope={agent.ownerScope}
@@ -1132,7 +854,6 @@ export default function AiAgentForm({
             disabled={
               saving
               || scheduleDirty
-              || (isCreate && availableKinds.length === 0)
               || (enteringActMode && !actAck)
             }
             className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground disabled:cursor-not-allowed disabled:opacity-60"

--- a/apps/web/src/components/settings/AiAgentGraduationPanel.test.tsx
+++ b/apps/web/src/components/settings/AiAgentGraduationPanel.test.tsx
@@ -606,10 +606,6 @@ describe('AiAgentForm — partner ceiling hint', () => {
     render(
       <AiAgentForm
         agent={agent(ownerScope, mode)}
-        agents={[]}
-        partnerBaselineKinds={new Set()}
-        showOwnerScope={ownerScope === 'partner'}
-        defaultOwnerScope={ownerScope}
         onClose={() => {}}
         onSaved={() => {}}
       />,

--- a/apps/web/src/components/settings/AiAgentsPage.test.tsx
+++ b/apps/web/src/components/settings/AiAgentsPage.test.tsx
@@ -1104,6 +1104,24 @@ describe('AiAgentsPage deep link (#4187 UI critique)', () => {
     await waitFor(() => screen.getByTestId('ai-agent-row-a2'));
     expect(screen.queryByTestId('ai-agent-editor-drawer')).toBeNull();
   });
+
+  // Task 13 (#5051): the guided create flow and the edit drawer are mutually
+  // exclusive. A hash change while the flow is open must not silently
+  // discard the in-progress draft and pop the drawer open underneath/over it.
+  it('does not mount the edit drawer for a hash change while the create flow is open', async () => {
+    mockEndpoints([PARTNER_AGENT, ORG_AGENT]);
+    render(<AiAgentsPage />);
+
+    await screen.findByTestId('ai-agents-list');
+    fireEvent.click(screen.getByTestId('ai-agent-create-button'));
+    await screen.findByTestId('agent-create-flow');
+
+    window.location.hash = '#agent=a2';
+    window.dispatchEvent(new HashChangeEvent('hashchange'));
+
+    expect(screen.queryByTestId('ai-agent-editor-drawer')).toBeNull();
+    expect(screen.getByTestId('agent-create-flow')).toBeInTheDocument();
+  });
 });
 
 describe('AiAgentsPage re-enable (#4187 UI critique round 2)', () => {

--- a/apps/web/src/components/settings/AiAgentsPage.test.tsx
+++ b/apps/web/src/components/settings/AiAgentsPage.test.tsx
@@ -351,100 +351,20 @@ describe('AiAgentsPage', () => {
     ).toBeInTheDocument();
   });
 
-  it('offers the owner-scope selector on create and never on edit', async () => {
+  // Task 13 (#5051): create no longer opens this drawer at all — it opens
+  // AgentCreateFlow instead (see the `AiAgentsPage create/edit wiring`
+  // describe block below). The owner-scope selector's CREATE-side coverage
+  // (offered on a partner draft, hidden entirely for an org-scope session,
+  // only free kinds selectable) now lives in AgentCreateFlow.test.tsx, which
+  // exercises the flow directly rather than through this page. This test
+  // keeps only the half still true of the EDIT drawer.
+  it('never offers the owner-scope selector on edit', async () => {
     mockEndpoints();
     render(<AiAgentsPage />);
 
-    await openCreateForm();
-    expect(await screen.findByTestId('ai-agent-ownerscope')).toBeInTheDocument();
-
+    await waitFor(() => screen.getByTestId('ai-agent-edit-a1'));
     fireEvent.click(screen.getByTestId('ai-agent-edit-a1'));
     await waitFor(() => expect(screen.queryByTestId('ai-agent-ownerscope')).toBeNull());
-  });
-
-  it('hides the owner-scope selector entirely from an org-scope session', async () => {
-    getJwtClaimsMock.mockReturnValue({ scope: 'organization', partnerId: 'p-1', orgId: 'org-1' });
-    orgState.current = { ...orgState.current, currentOrgId: 'org-1', allOrgs: false };
-    mockEndpoints([]);
-    render(<AiAgentsPage />);
-
-    await openCreateForm();
-
-    await screen.findByTestId('ai-agent-editor');
-    expect(screen.queryByTestId('ai-agent-ownerscope')).toBeNull();
-  });
-
-  it('only offers kinds free for the OWNER being created into', async () => {
-    // Uniqueness is (partner_id, kind) and (org_id, kind) independently. A flat
-    // taken-list hid `triage` from the partner-wide form as soon as any single
-    // org owned a triage agent — and with no partner baseline,
-    // resolveEffectiveAgent returns null, so triage died for every org.
-    // A concrete org must be selected, or "this organization" has no owner to
-    // check against (save() blocks that case separately).
-    orgState.current = { ...orgState.current, currentOrgId: 'org-1', allOrgs: false };
-    mockEndpoints([PARTNER_AGENT, ORG_AGENT]);
-    render(<AiAgentsPage />);
-
-    await openCreateForm();
-
-    // Org axis (the default with an org selected): org-1 owns `patch`; the
-    // partner-wide `triage` must NOT block an org-level triage override.
-    const kind = await screen.findByTestId('ai-agent-kind');
-    expect([...kind.querySelectorAll('option')].map((o) => o.value)).toEqual(['triage', 'helpdesk']);
-
-    fireEvent.click(screen.getByTestId('ai-agent-owner-partner'));
-    // Partner axis: only the partner-wide `triage` is taken. `patch` belongs to
-    // org-1 and must still be offered for the partner-wide baseline — hiding it
-    // is what killed the baseline row the whole feature depends on.
-    expect(
-      [...screen.getByTestId('ai-agent-kind').querySelectorAll('option')].map((o) => o.value),
-    ).toEqual(['patch', 'helpdesk']);
-  });
-
-  it('refuses to save with no alert severity selected, and does not call the API', async () => {
-    mockEndpoints([]);
-    render(<AiAgentsPage />);
-
-    await openCreateForm();
-
-    fireEvent.change(await screen.findByTestId('ai-agent-name'), { target: { value: 'Triage' } });
-    // Defaults are critical + high; clearing both leaves the server-side
-    // `.min(1)` unsatisfiable.
-    fireEvent.click(screen.getByTestId('ai-agent-severity-critical'));
-    fireEvent.click(screen.getByTestId('ai-agent-severity-high'));
-    fireEvent.click(screen.getByTestId('ai-agent-save'));
-
-    await waitFor(() => expect(screen.getByTestId('ai-agent-issues')).toBeInTheDocument());
-    expect(
-      fetchMock.mock.calls.some(([, init]) => (init as RequestInit | undefined)?.method === 'POST'),
-    ).toBe(false);
-  });
-
-  it('posts a partner-wide create with no orgId and the selected role recipients', async () => {
-    mockEndpoints([]);
-    render(<AiAgentsPage />);
-
-    await openCreateForm();
-
-    fireEvent.change(await screen.findByTestId('ai-agent-name'), { target: { value: 'Triage' } });
-    fireEvent.click(screen.getByTestId('ai-agent-owner-partner'));
-    fireEvent.click(await screen.findByTestId('ai-agent-role-r-1'));
-    fireEvent.click(screen.getByTestId('ai-agent-save'));
-
-    await waitFor(() =>
-      expect(
-        fetchMock.mock.calls.some(([, init]) => (init as RequestInit | undefined)?.method === 'POST'),
-      ).toBe(true),
-    );
-    const post = fetchMock.mock.calls.find(
-      ([, init]) => (init as RequestInit | undefined)?.method === 'POST',
-    );
-    expect(post?.[0]).toBe('/ai/agents');
-    const body = JSON.parse((post?.[1] as RequestInit).body as string);
-    expect(body.ownerScope).toBe('partner');
-    expect(body.orgId).toBeUndefined();
-    // Role IDs, never role names — roles are tenant-scoped rows with custom names.
-    expect(body.recipients).toEqual({ roleIds: ['r-1'] });
   });
 
   it('does not carry a stale draft from one edit target to the next', async () => {
@@ -474,47 +394,12 @@ describe('AiAgentsPage', () => {
     expect(JSON.parse((patch?.[1] as RequestInit).body as string).name).toBe('Org patcher');
   });
 
-  it('says roles could not be loaded rather than claiming none exist', async () => {
-    // This page needs organizations:read but GET /roles needs users:read, so a
-    // 403 here is reachable. Rendering it as "no roles available" would turn an
-    // authorization error into a config decision the operator never made.
-    fetchMock.mockImplementation((url: string) => {
-      if (url.startsWith('/ai/agents/schedules')) return Promise.resolve(json({ data: [] }));
-      if (url.startsWith('/ai/agents')) return Promise.resolve(json({ data: [] }));
-      if (url === '/roles') return Promise.resolve(json({ error: 'forbidden' }, false, 403));
-      return Promise.resolve(json({ data: [] }));
-    });
-    render(<AiAgentsPage />);
-
-    await openCreateForm();
-
-    expect(await screen.findByTestId('ai-agent-roles-failed')).toBeInTheDocument();
-    expect(screen.queryByTestId('ai-agent-roles-empty')).toBeNull();
-  });
-
-  it('keeps a cleared numeric limit as a number the server will accept', async () => {
-    // Clearing a number input yields '' -> NaN, which JSON.stringify emits as
-    // null and the server rejects with a bare 400.
-    mockEndpoints([]);
-    render(<AiAgentsPage />);
-
-    await openCreateForm();
-
-    fireEvent.change(await screen.findByTestId('ai-agent-name'), { target: { value: 'Triage' } });
-    fireEvent.change(screen.getByTestId('ai-agent-limit-devices'), { target: { value: '' } });
-    fireEvent.click(screen.getByTestId('ai-agent-save'));
-
-    await waitFor(() =>
-      expect(
-        fetchMock.mock.calls.some(([, init]) => (init as RequestInit | undefined)?.method === 'POST'),
-      ).toBe(true),
-    );
-    const post = fetchMock.mock.calls.find(
-      ([, init]) => (init as RequestInit | undefined)?.method === 'POST',
-    );
-    const body = JSON.parse((post?.[1] as RequestInit).body as string);
-    expect(Number.isFinite(body.limits.maxDevicesPerRun)).toBe(true);
-  });
+  // Task 13 (#5051): "roles could not be loaded" and "a cleared numeric
+  // limit stays a number" are now exercised on CREATE against
+  // AgentCreateFlow.test.tsx directly instead — roles/limits live on its
+  // Safety step (reached by advancing through the flow), which this page's
+  // openCreateForm() helper can no longer reach in one render since create
+  // no longer opens the single-page drawer.
 
   it('renders supervisedActionKeys grouped by tool from the registry, only in act mode, and includes selections in the save body (wave 5 Part B, #3827)', async () => {
     const actAgent = { ...PARTNER_AGENT, supportedModes: ['off', 'shadow', 'act'] as const };
@@ -919,21 +804,19 @@ describe('AiAgentsPage first run and drawer (#4187 UI critique)', () => {
     // One create affordance while the empty state is showing, not two.
     expect(screen.queryByTestId('ai-agent-create-button')).toBeNull();
 
+    // Task 13 (#5051): clicking the panel's CTA now opens the guided create
+    // flow full-width, in place of the list, rather than the drawer.
     fireEvent.click(within(empty).getByTestId('ai-agents-empty-create'));
-    expect(await screen.findByTestId('ai-agent-editor')).toBeInTheDocument();
+    expect(await screen.findByTestId('agent-create-flow')).toBeInTheDocument();
+    expect(screen.queryByTestId('ai-agents-empty')).toBeNull();
     // New agents start in the safe mode the panel actually names — shadow,
     // where the agent proposes and a person approves. The form used to
     // default to `off` while the panel said "start in shadow mode".
+    // ("Start enabled" defaults to off, and the create-only footer note
+    // saying so, are covered by AgentCreateFlow.test.tsx — the drawer's
+    // `enabled` checkbox no longer exists on the guided flow's first step;
+    // spec §4.6 step 4 owns that choice instead.)
     expect(screen.getByTestId('ai-agent-mode-shadow')).toHaveAttribute('aria-checked', 'true');
-    // ...but SWITCHED OFF (P1 review finding). `enabled: true` on create armed
-    // the agent the instant Save landed: managedAutomation mirrors `enabled`
-    // onto the seeded automation, and shadow passes run admission, so a
-    // partner-wide triage create started firing LLM runs across every org
-    // before the operator had reviewed the allowlist or the limits.
-    expect(screen.getByTestId('ai-agent-enabled')).not.toBeChecked();
-    // And the form says so, rather than leaving an unticked box to be read as
-    // an oversight.
-    expect(screen.getByTestId('ai-agent-enabled-create-hint')).toBeInTheDocument();
   });
 
   it('does not show the create-only "starts switched off" hint when editing', async () => {
@@ -1607,5 +1490,76 @@ describe('AiAgentsPage header (#4187 UI critique 3)', () => {
 
     const header = await screen.findByTestId('ai-agents-page-header');
     expect(within(header).getByRole('heading', { level: 1, name: 'AI Agents' })).toBeInTheDocument();
+  });
+});
+
+// Task 13 (#5051): the guided create flow replaces the drawer for CREATE;
+// EDIT is unaffected. The flow's own step navigation, validation gates and
+// POST body are covered by AgentCreateFlow.test.tsx directly — this is the
+// page-wiring contract only.
+describe('AiAgentsPage create/edit wiring (Task 13, #5051)', () => {
+  it('"New agent" opens the guided create flow in place of the list, and Cancel returns to it', async () => {
+    mockEndpoints([PARTNER_AGENT]);
+    render(<AiAgentsPage />);
+
+    await waitFor(() => expect(screen.queryByTestId('ai-agents-loading')).toBeNull());
+    expect(screen.queryByTestId('agent-create-flow')).toBeNull();
+    expect(screen.getByTestId('ai-agents-list')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('ai-agent-create-button'));
+    expect(await screen.findByTestId('agent-create-flow')).toBeInTheDocument();
+    // The list — and the header's own create button — are gone while the
+    // flow is open, not merely hidden behind it.
+    expect(screen.queryByTestId('ai-agents-list')).toBeNull();
+    expect(screen.queryByTestId('ai-agent-create-button')).toBeNull();
+
+    fireEvent.click(screen.getByTestId('agent-create-flow-cancel'));
+    await waitFor(() => expect(screen.queryByTestId('agent-create-flow')).toBeNull());
+    expect(screen.getByTestId('ai-agents-list')).toBeInTheDocument();
+  });
+
+  it('Edit still opens AiAgentForm in the Drawer, never the guided flow', async () => {
+    mockEndpoints([PARTNER_AGENT]);
+    render(<AiAgentsPage />);
+
+    await waitFor(() => screen.getByTestId('ai-agent-edit-a1'));
+    fireEvent.click(screen.getByTestId('ai-agent-edit-a1'));
+
+    expect(await screen.findByTestId('ai-agent-editor-drawer')).toBeInTheDocument();
+    expect(screen.getByTestId('ai-agent-editor')).toBeInTheDocument();
+    expect(screen.queryByTestId('agent-create-flow')).toBeNull();
+  });
+
+  it('reloads the list and highlights the new row once the flow reports a created agent', async () => {
+    const created = { ...PARTNER_AGENT, id: 'new-agent', kind: 'patch' as const, name: 'New patch bot' };
+    let listCall = 0;
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url === '/ai/agents/policy-decidable-keys') return Promise.resolve(json({ data: [] }));
+      if (url === '/ai/agents/tool-catalog') return Promise.resolve(json({ data: null }));
+      if (url.startsWith('/ai/agents/ceiling')) return Promise.resolve(json({ data: null }));
+      if (url.startsWith('/ai/agents/schedules')) return Promise.resolve(json({ data: [] }));
+      if (url === '/ai/agents' && init?.method === 'POST') return Promise.resolve(json({ data: created }, true, 201));
+      if (url.startsWith('/ai/agents')) {
+        listCall += 1;
+        return Promise.resolve(json({ data: listCall === 1 ? [PARTNER_AGENT] : [PARTNER_AGENT, created] }));
+      }
+      if (url === '/roles') return Promise.resolve(json({ data: [] }));
+      return Promise.resolve(json({ data: [] }));
+    });
+    render(<AiAgentsPage />);
+
+    await waitFor(() => expect(screen.queryByTestId('ai-agents-loading')).toBeNull());
+    fireEvent.click(screen.getByTestId('ai-agent-create-button'));
+    await screen.findByTestId('agent-create-flow');
+
+    fireEvent.change(await screen.findByTestId('ai-agent-name'), { target: { value: 'New patch bot' } });
+    fireEvent.click(screen.getByTestId('ai-agent-kind-card-patch'));
+    fireEvent.click(screen.getByTestId('agent-create-flow-next')); // Purpose -> What it does
+    fireEvent.click(screen.getByTestId('agent-create-flow-next')); // What it does -> Safety
+    fireEvent.click(screen.getByTestId('agent-create-flow-next')); // Safety -> Review
+    fireEvent.click(await screen.findByTestId('agent-create-flow-create'));
+
+    await waitFor(() => expect(screen.queryByTestId('agent-create-flow')).toBeNull());
+    expect(await screen.findByTestId('ai-agent-row-new-agent')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/settings/AiAgentsPage.tsx
+++ b/apps/web/src/components/settings/AiAgentsPage.tsx
@@ -15,8 +15,12 @@ import { Drawer } from '../shared/Drawer';
 import { EmptyState } from '../shared/EmptyState';
 import { PageHeader } from '../shared/PageHeader';
 import AiAgentForm, { type AiAgentDto } from './AiAgentForm';
+import AgentCreateFlow from './aiAgents/AgentCreateFlow';
 
-type Editing = { agent: AiAgentDto | null } | null;
+// Task 13 (#5051): create no longer opens this drawer at all — it opens the
+// full-width `AgentCreateFlow` in place of the list instead (see `creating`
+// below) — so an open editor always names a real, persisted agent.
+type Editing = { agent: AiAgentDto } | null;
 
 const UNAUTHORIZED = () => void navigateTo(loginPathWithNext(), { replace: true });
 
@@ -64,6 +68,14 @@ export default function AiAgentsPage() {
    *  further state change — opening or closing the editor — rather than a
    *  timer, so it never lingers past the moment it stops being news. */
   const [justReenabledId, setJustReenabledId] = useState<string | null>(null);
+  /** Task 13 (#5051): "New agent" opens the four-step guided flow FULL WIDTH
+   *  in place of the list, rather than the drawer. Mutually exclusive with
+   *  `editing` (Edit still opens the drawer) — nothing opens both. */
+  const [creating, setCreating] = useState(false);
+  /** The agent `AgentCreateFlow` just created, so its row can be called out
+   *  once the list reloads and the flow closes — same "cleared by any
+   *  further state change" rule as `justReenabledId` above. */
+  const [highlightedAgentId, setHighlightedAgentId] = useState<string | null>(null);
   /** First row's Re-enable button in the Disabled section — the target the
    *  all-disabled empty state's primary CTA focuses (Finding 4). */
   const firstDisabledReenableRef = useRef<HTMLButtonElement | null>(null);
@@ -163,12 +175,22 @@ export default function AiAgentsPage() {
    * editor. Both the latch and the fragment are cleared here, together: the
    * latch alone would let the effect re-fire on the hash still in the URL.
    */
-  /** Opens the editor for an existing agent or a new one. The one place that
-   *  starts an edit, so it is also the one place that dismisses a still-open
-   *  re-enable note — opening the editor is unambiguously a "state change". */
+  /** Opens the editor for an existing agent. The one place that starts an
+   *  edit, so it is also the one place that dismisses a still-open re-enable
+   *  note and any create-flow highlight — opening the editor is unambiguously
+   *  a "state change". */
   const openEditor = useCallback((next: Editing) => {
     setJustReenabledId(null);
+    setHighlightedAgentId(null);
     setEditing(next);
+  }, []);
+
+  /** "New agent" — opens `AgentCreateFlow` full-width in place of the list
+   *  (Task 13, #5051), replacing what used to be `openEditor({ agent: null })`. */
+  const startCreate = useCallback(() => {
+    setJustReenabledId(null);
+    setHighlightedAgentId(null);
+    setCreating(true);
   }, []);
 
   const closeEditor = useCallback(() => {
@@ -284,7 +306,7 @@ export default function AiAgentsPage() {
   const createButton = (testId: string) => (
     <button
       type="button"
-      onClick={() => openEditor({ agent: null })}
+      onClick={startCreate}
       className="inline-flex h-10 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:opacity-90"
       data-testid={testId}
     >
@@ -302,14 +324,34 @@ export default function AiAgentsPage() {
         description={t('aiAgentsPage.description')}
         // One create affordance at a time: while the first-run panel is on
         // screen it owns the call to action, and a second identical button in
-        // the header just competes with it.
-        actions={!showFirstRun && !showAllDisabled ? createButton('ai-agent-create-button') : undefined}
+        // the header just competes with it. Hidden entirely while the guided
+        // create flow is open (Task 13, #5051) — it has its own Cancel.
+        actions={!showFirstRun && !showAllDisabled && !creating ? createButton('ai-agent-create-button') : undefined}
       />
 
       {error && (
         <div className="rounded-md border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive">
           {t('aiAgentsPage.errors.load')}
         </div>
+      )}
+
+      {/* Task 13 (#5051): the guided create flow replaces the list ENTIRELY
+          while open — full width, its own header/footer — rather than
+          opening in the drawer. Edit is unaffected: it still opens
+          AiAgentForm in the Drawer below. */}
+      {creating && (
+        <AgentCreateFlow
+          agents={agents}
+          partnerBaselineKinds={partnerBaselineKinds}
+          showOwnerScope={isPartnerScope}
+          defaultOwnerScope={defaultOwnerScope}
+          onCancel={() => setCreating(false)}
+          onCreated={(agent) => {
+            setCreating(false);
+            setHighlightedAgentId(agent.id);
+            void load();
+          }}
+        />
       )}
 
       {/* The editor used to render INLINE, above the list, which pushed every
@@ -352,6 +394,11 @@ export default function AiAgentsPage() {
         )}
       </Drawer>
 
+      {/* The list, first-run panel and disabled section all yield to the
+          create flow above while it is open (Task 13, #5051) — this is not
+          "hidden AND rendered underneath", it never mounts while creating. */}
+      {!creating && (
+      <>
       {loading && !loaded && (
         <p className="text-sm text-muted-foreground" data-testid="ai-agents-loading">
           {t('aiAgentsPage.loading')}
@@ -394,7 +441,7 @@ export default function AiAgentsPage() {
           action={
             <button
               type="button"
-              onClick={() => openEditor({ agent: null })}
+              onClick={startCreate}
               className="inline-flex h-10 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:opacity-90"
               data-testid="ai-agents-empty-create"
             >
@@ -438,7 +485,7 @@ export default function AiAgentsPage() {
           secondary={
             <button
               type="button"
-              onClick={() => openEditor({ agent: null })}
+              onClick={startCreate}
               className="inline-flex h-9 items-center gap-1.5 rounded-md border px-3 text-sm font-medium hover:bg-muted"
               data-testid="ai-agents-all-disabled-create"
             >
@@ -455,7 +502,13 @@ export default function AiAgentsPage() {
         <span id={inertHintId} className="sr-only">{t('aiAgentsPage.inertBadge.hint')}</span>
         <ul className="divide-y rounded-lg border" data-testid="ai-agents-list">
           {live.map((agent) => (
-            <li key={agent.id} className="flex flex-wrap items-center gap-3 p-3" data-testid={`ai-agent-row-${agent.id}`}>
+            <li
+              key={agent.id}
+              className={`flex flex-wrap items-center gap-3 p-3 ${
+                highlightedAgentId === agent.id ? 'bg-primary/5 ring-1 ring-inset ring-primary/40' : ''
+              }`}
+              data-testid={`ai-agent-row-${agent.id}`}
+            >
               <div className="min-w-0 flex-1">
                 <div className="flex flex-wrap items-center gap-2">
                   <span className="font-medium">{agent.name}</span>
@@ -635,6 +688,8 @@ export default function AiAgentsPage() {
             ))}
           </ul>
         </details>
+      )}
+      </>
       )}
     </div>
   );

--- a/apps/web/src/components/settings/AiAgentsPage.tsx
+++ b/apps/web/src/components/settings/AiAgentsPage.tsx
@@ -150,7 +150,14 @@ export default function AiAgentsPage() {
   // a re-enable) re-opened the drawer the operator had just closed.
   const appliedHashRef = useRef<string | null>(null);
   useEffect(() => {
-    if (!hashAgentId || appliedHashRef.current === hashAgentId) return;
+    // The guided create flow (Task 13, #5051) is mutually exclusive with the
+    // edit drawer — nothing opens both. Bail rather than force-close it: its
+    // own Cancel already discards the in-progress draft with no confirmation
+    // (`onCancel={() => setCreating(false)}` below), so a stray hash must not
+    // silently do the same to a draft the operator never asked to abandon.
+    // `creating` is a dependency so the link is honoured once the flow
+    // closes (Cancel or Create) and the hash is still unlatched.
+    if (creating || !hashAgentId || appliedHashRef.current === hashAgentId) return;
     // Live rows only. The list deliberately carries soft-deleted agents
     // (`includeDisabled=1`), so a stale link would otherwise open the full
     // editor on one — every field live, and a Save aimed at a PATCH the server
@@ -163,7 +170,7 @@ export default function AiAgentsPage() {
     if (!target) return;
     appliedHashRef.current = hashAgentId;
     setEditing({ agent: target });
-  }, [agents, hashAgentId]);
+  }, [agents, creating, hashAgentId]);
 
   /**
    * Closing the editor, from any affordance.
@@ -380,10 +387,6 @@ export default function AiAgentsPage() {
             // policy. Keying on the target remounts it instead.
             key={editing.agent?.id ?? 'new'}
             agent={editing.agent}
-            agents={agents}
-            partnerBaselineKinds={partnerBaselineKinds}
-            showOwnerScope={isPartnerScope}
-            defaultOwnerScope={defaultOwnerScope}
             onClose={closeEditor}
             onDirtyChange={setEditorDirty}
             onSaved={() => {

--- a/apps/web/src/components/settings/aiAgents/AgentCreateFlow.test.tsx
+++ b/apps/web/src/components/settings/aiAgents/AgentCreateFlow.test.tsx
@@ -1,0 +1,428 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+
+const orgState = {
+  current: {
+    currentOrgId: null as string | null,
+    allOrgs: true,
+    error: null as string | null,
+    organizationsLoaded: true,
+    organizations: [{ id: 'org-1', name: 'Acme' }],
+  },
+};
+vi.mock('../../../stores/orgStore', () => ({
+  useOrgStore: (sel?: (s: typeof orgState.current) => unknown) => (sel ? sel(orgState.current) : orgState.current),
+}));
+
+import { type AgentToolCatalogDto, type AiAgentDto } from '@breeze/shared';
+import AgentCreateFlow from './AgentCreateFlow';
+import { fetchWithAuth } from '../../../stores/auth';
+import { buildAgentSaveBody, draftFrom } from './agentDraft';
+
+const fetchMock = vi.mocked(fetchWithAuth);
+
+const json = (payload: unknown, ok = true, status = 200): Response =>
+  ({ ok, status, statusText: 'OK', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+const CATALOG: AgentToolCatalogDto = {
+  capabilities: [
+    { id: 'services_startup', tone: 'standard' },
+    { id: 'scripts_commands', tone: 'standard' },
+  ],
+  tools: [
+    {
+      name: 'manage_services',
+      capability: 'services_startup',
+      tier: 3,
+      readOnly: false,
+      operations: [
+        { key: 'manage_services:restart', action: 'restart', tier: 3, readOnly: false, policyDecidable: true, actEligible: true },
+        { key: 'manage_services:stop', action: 'stop', tier: 3, readOnly: false, policyDecidable: true, actEligible: false },
+      ],
+    },
+    {
+      name: 'run_script',
+      capability: 'scripts_commands',
+      tier: 3,
+      readOnly: false,
+      operations: [{ key: 'run_script', action: null, tier: 3, readOnly: false, policyDecidable: false, actEligible: true }],
+    },
+  ],
+  presets: { triage: ['manage_services:restart'], patch: [], helpdesk: [] },
+  unreachableTools: [],
+};
+
+/** `agents` fixture: `org-1` already owns a `patch` agent, so free-kind logic
+ *  has something real to narrow. */
+function makeAgents(): AiAgentDto[] {
+  return [
+    {
+      id: 'a1',
+      kind: 'patch',
+      name: 'Org patcher',
+      enabled: true,
+      mode: 'shadow',
+      model: null,
+      orgId: 'org-1',
+      partnerId: null,
+      ownerScope: 'organization',
+      allOrgs: false,
+      supportedModes: ['off', 'shadow', 'act'],
+      toolAllowlist: [],
+      protectedResources: {},
+      limits: {},
+      triggers: { alertSeverities: ['critical'], respectMaintenanceWindows: true },
+      recipients: { userIds: [], roleIds: [] },
+      actAssets: { supervisedActionKeys: [] },
+      instructions: null,
+      cooldownSeconds: 900,
+      disabledAt: null,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    } as unknown as AiAgentDto,
+  ];
+}
+
+function mockEndpoints(overrides: {
+  registry?: Array<{ key: string; toolName: string; action: string | null; note: string }>;
+  roles?: Array<{ id: string; name: string; scope?: 'partner' | 'organization' }>;
+  rolesStatus?: number;
+  preview?: unknown;
+  createStatus?: number;
+  createBody?: unknown;
+} = {}): void {
+  const { registry = [], roles = [{ id: 'r-1', name: 'Org Admin' }], rolesStatus = 200, preview, createStatus = 201, createBody } = overrides;
+  fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+    if (url === '/ai/agents/tool-catalog') return Promise.resolve(json({ data: CATALOG }));
+    if (url.startsWith('/ai/agents/ceiling')) return Promise.resolve(json({ data: null }));
+    if (url === '/ai/agents/policy-decidable-keys') return Promise.resolve(json({ data: registry }));
+    if (url === '/roles') return Promise.resolve(json(rolesStatus === 200 ? { data: roles } : { error: 'nope' }, rolesStatus === 200, rolesStatus));
+    if (url === '/ai/agents/preview') {
+      return Promise.resolve(json({ data: preview ?? buildFakePreview() }));
+    }
+    if (url === '/ai/agents' && init?.method === 'POST') {
+      return Promise.resolve(
+        json(
+          createBody ?? { data: { id: 'new-agent', ...JSON.parse(init.body as string) } },
+          createStatus < 400,
+          createStatus,
+        ),
+      );
+    }
+    return Promise.resolve(json({ data: [] }));
+  });
+}
+
+function buildFakePreview() {
+  return {
+    mode: 'shadow',
+    kind: 'triage',
+    readOnlyToolCount: 3,
+    operations: [],
+    unrecognised: [],
+    triggers: { alertSeverities: ['critical', 'high'], respectMaintenanceWindows: true, ticketAutonomousWrites: false },
+    protectedResources: { services: [], paths: [], registryKeys: [], deviceTags: [] },
+    limits: { maxDevicesPerRun: 5, maxRunsPerHour: 10, maxBudgetCentsPerDay: 1000, maxFleetPercentPerDay: 5, wallClockSeconds: 300 },
+    cooldownSeconds: 900,
+    recipients: { userIds: [], roleIds: [] },
+  };
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  orgState.current = {
+    currentOrgId: null,
+    allOrgs: true,
+    error: null,
+    organizationsLoaded: true,
+    organizations: [{ id: 'org-1', name: 'Acme' }],
+  };
+});
+
+function renderFlow(props: Partial<Parameters<typeof AgentCreateFlow>[0]> = {}) {
+  const onCancel = vi.fn();
+  const onCreated = vi.fn();
+  render(
+    <AgentCreateFlow
+      agents={makeAgents()}
+      partnerBaselineKinds={new Set()}
+      showOwnerScope
+      defaultOwnerScope="partner"
+      onCancel={onCancel}
+      onCreated={onCreated}
+      {...props}
+    />,
+  );
+  return { onCancel, onCreated };
+}
+
+const postBody = (): Record<string, unknown> => {
+  const call = fetchMock.mock.calls.find(([url, init]) => url === '/ai/agents' && (init as RequestInit | undefined)?.method === 'POST');
+  return JSON.parse((call?.[1] as RequestInit).body as string);
+};
+
+describe('AgentCreateFlow — header, footer and cancel', () => {
+  it('renders the header title, the vertical stepper and Cancel; Cancel calls onCancel', async () => {
+    mockEndpoints();
+    const { onCancel } = renderFlow();
+
+    expect(screen.getByTestId('agent-create-flow')).toBeInTheDocument();
+    expect(screen.getByTestId('setup-stepper-vertical')).toBeInTheDocument();
+    expect(screen.queryByTestId('agent-create-flow-back')).toBeNull(); // no Back on step 1
+
+    fireEvent.click(screen.getByTestId('agent-create-flow-cancel'));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('AgentCreateFlow — step navigation persists state', () => {
+  it('keeps the name typed on Purpose after navigating to What it does and back', async () => {
+    mockEndpoints();
+    renderFlow();
+
+    fireEvent.change(screen.getByTestId('ai-agent-name'), { target: { value: 'Triage bot' } });
+    fireEvent.click(screen.getByTestId('agent-create-flow-next'));
+    expect(await screen.findByTestId('ai-agent-permissions')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('setup-stepper-step-0'));
+    expect(await screen.findByTestId('ai-agent-name')).toHaveValue('Triage bot');
+  });
+
+  it('Back returns to the previous step without losing state', async () => {
+    mockEndpoints();
+    renderFlow();
+    fireEvent.change(screen.getByTestId('ai-agent-name'), { target: { value: 'Triage bot' } });
+    fireEvent.click(screen.getByTestId('agent-create-flow-next'));
+    await screen.findByTestId('ai-agent-permissions');
+
+    fireEvent.click(screen.getByTestId('agent-create-flow-back'));
+    expect(await screen.findByTestId('ai-agent-name')).toHaveValue('Triage bot');
+  });
+
+  it('only a COMPLETED step is clickable in the stepper — step 2 cannot be reached before step 1 is', async () => {
+    mockEndpoints();
+    renderFlow();
+    expect(screen.getByTestId('setup-stepper-step-1')).toBeDisabled();
+  });
+});
+
+describe('AgentCreateFlow — validation gates', () => {
+  it('blocks leaving Purpose with an empty name, and shows the issue', async () => {
+    mockEndpoints();
+    renderFlow();
+    fireEvent.change(screen.getByTestId('ai-agent-name'), { target: { value: '' } });
+    fireEvent.click(screen.getByTestId('agent-create-flow-next'));
+
+    expect(await screen.findByTestId('ai-agent-issues')).toBeInTheDocument();
+    expect(screen.queryByTestId('ai-agent-permissions')).toBeNull();
+  });
+
+  it('blocks leaving "What it does" with no severities selected for a triage agent', async () => {
+    mockEndpoints();
+    renderFlow();
+    fireEvent.change(screen.getByTestId('ai-agent-name'), { target: { value: 'Triage bot' } });
+    fireEvent.click(screen.getByTestId('agent-create-flow-next'));
+    await screen.findByTestId('ai-agent-permissions');
+
+    // Defaults are critical + high; clear both.
+    fireEvent.click(screen.getByTestId('ai-agent-severity-critical'));
+    fireEvent.click(screen.getByTestId('ai-agent-severity-high'));
+    fireEvent.click(screen.getByTestId('agent-create-flow-next'));
+
+    expect(await screen.findByTestId('ai-agent-issues')).toBeInTheDocument();
+    expect(screen.queryByTestId('ai-agent-policy-decide')).toBeNull(); // never reached Safety
+  });
+
+  it('disables Next on Purpose while entering act mode until the acknowledgement is checked', async () => {
+    mockEndpoints();
+    renderFlow();
+    fireEvent.change(screen.getByTestId('ai-agent-name'), { target: { value: 'Act bot' } });
+    fireEvent.click(screen.getByTestId('ai-agent-mode-act'));
+
+    expect(screen.getByTestId('agent-create-flow-next')).toBeDisabled();
+    fireEvent.click(screen.getByTestId('ai-agent-act-ack'));
+    expect(screen.getByTestId('agent-create-flow-next')).not.toBeDisabled();
+  });
+});
+
+describe('AgentCreateFlow — kind cards and owner scope (moved from AiAgentsPage.test.tsx)', () => {
+  it('disables a kind card already taken for the current owner scope, and re-evaluates on owner-scope switch', async () => {
+    // org-1 (via orgState) already owns `patch`; the partner-wide `triage`
+    // agent from PARTNER_AGENT-style fixtures does not exist here, so only
+    // `patch` is taken on the ORG axis.
+    orgState.current = { ...orgState.current, currentOrgId: 'org-1', allOrgs: false };
+    mockEndpoints();
+    renderFlow({ defaultOwnerScope: 'organization' });
+
+    expect(screen.getByTestId('ai-agent-kind-card-patch')).toBeDisabled();
+    expect(screen.getByTestId('ai-agent-kind-card-triage')).not.toBeDisabled();
+
+    fireEvent.click(screen.getByTestId('ai-agent-owner-partner'));
+    // Partner axis: nothing is taken there in this fixture.
+    expect(screen.getByTestId('ai-agent-kind-card-patch')).not.toBeDisabled();
+  });
+
+  it('shows the no-baseline hint for an org draft of a kind with no partner-wide baseline', async () => {
+    mockEndpoints();
+    renderFlow({ defaultOwnerScope: 'organization', partnerBaselineKinds: new Set() });
+    expect(screen.getByTestId('ai-agent-no-baseline-hint')).toBeInTheDocument();
+  });
+});
+
+describe('AgentCreateFlow — Safety step (moved from AiAgentsPage.test.tsx)', () => {
+  async function advanceToSafety(name = 'Triage bot') {
+    fireEvent.change(screen.getByTestId('ai-agent-name'), { target: { value: name } });
+    fireEvent.click(screen.getByTestId('agent-create-flow-next'));
+    await screen.findByTestId('ai-agent-permissions');
+    fireEvent.click(screen.getByTestId('agent-create-flow-next'));
+    await screen.findByTestId('ai-agent-limit-devices');
+  }
+
+  it('says roles could not be loaded rather than claiming none exist', async () => {
+    mockEndpoints({ rolesStatus: 403 });
+    renderFlow();
+    await advanceToSafety();
+    expect(screen.getByTestId('ai-agent-roles-failed')).toBeInTheDocument();
+    expect(screen.queryByTestId('ai-agent-roles-empty')).toBeNull();
+  });
+
+  it('keeps a cleared numeric limit as a finite number in the create body', async () => {
+    mockEndpoints();
+    renderFlow();
+    await advanceToSafety();
+
+    fireEvent.change(screen.getByTestId('ai-agent-limit-devices'), { target: { value: '' } });
+    fireEvent.click(screen.getByTestId('agent-create-flow-next'));
+    fireEvent.click(await screen.findByTestId('agent-create-flow-create'));
+
+    const limits = () => postBody().limits as { maxDevicesPerRun: number };
+    await waitFor(() => expect(limits().maxDevicesPerRun).toBeTypeOf('number'));
+    expect(Number.isFinite(limits().maxDevicesPerRun)).toBe(true);
+  });
+});
+
+describe('AgentCreateFlow — Create posts the same body buildAgentSaveBody would (moved from AiAgentsPage.test.tsx)', () => {
+  it('posts a partner-wide create with no orgId and the selected role recipients', async () => {
+    mockEndpoints();
+    renderFlow();
+
+    fireEvent.change(screen.getByTestId('ai-agent-name'), { target: { value: 'Triage bot' } });
+    fireEvent.click(screen.getByTestId('agent-create-flow-next'));
+    await screen.findByTestId('ai-agent-permissions');
+    fireEvent.click(screen.getByTestId('agent-create-flow-next'));
+    await screen.findByTestId('ai-agent-role-r-1');
+    fireEvent.click(screen.getByTestId('ai-agent-role-r-1'));
+    fireEvent.click(screen.getByTestId('agent-create-flow-next'));
+    fireEvent.click(await screen.findByTestId('agent-create-flow-create'));
+
+    await waitFor(() =>
+      expect(fetchMock.mock.calls.some(([url, init]) => url === '/ai/agents' && (init as RequestInit | undefined)?.method === 'POST')).toBe(true),
+    );
+    const body = postBody();
+    expect(body.ownerScope).toBe('partner');
+    expect(body.orgId).toBeUndefined();
+    expect(body.recipients).toEqual({ roleIds: ['r-1'] });
+  });
+
+  it('the final POST body matches buildAgentSaveBody for the same draft (drawer/flow parity)', async () => {
+    mockEndpoints();
+    renderFlow();
+
+    fireEvent.change(screen.getByTestId('ai-agent-name'), { target: { value: 'Parity bot' } });
+    fireEvent.click(screen.getByTestId('agent-create-flow-next'));
+    await screen.findByTestId('ai-agent-permissions');
+    fireEvent.click(screen.getByTestId('agent-create-flow-next'));
+    await screen.findByTestId('ai-agent-limit-devices');
+    fireEvent.click(screen.getByTestId('agent-create-flow-next'));
+    fireEvent.click(await screen.findByTestId('agent-create-flow-create'));
+
+    await waitFor(() =>
+      expect(fetchMock.mock.calls.some(([url, init]) => url === '/ai/agents' && (init as RequestInit | undefined)?.method === 'POST')).toBe(true),
+    );
+    const draft = { ...draftFrom(null, { ownerScope: 'partner', kind: 'triage' }), name: 'Parity bot' };
+    const expected = buildAgentSaveBody(draft, { isCreate: true, orgId: null });
+    expect(postBody()).toEqual(expected);
+  });
+});
+
+describe('AgentCreateFlow — review step preview and onCreated', () => {
+  async function advanceToReview() {
+    fireEvent.change(screen.getByTestId('ai-agent-name'), { target: { value: 'Triage bot' } });
+    fireEvent.click(screen.getByTestId('agent-create-flow-next'));
+    await screen.findByTestId('ai-agent-permissions');
+    fireEvent.click(screen.getByTestId('agent-create-flow-next'));
+    await screen.findByTestId('ai-agent-limit-devices');
+    fireEvent.click(screen.getByTestId('agent-create-flow-next'));
+  }
+
+  it('fires POST /ai/agents/preview with the draft body on reaching Review, and renders the summary card', async () => {
+    mockEndpoints();
+    renderFlow();
+    await advanceToReview();
+
+    await waitFor(
+      () => expect(fetchMock.mock.calls.some(([url, init]) => url === '/ai/agents/preview' && (init as RequestInit | undefined)?.method === 'POST')).toBe(true),
+      { timeout: 2000 },
+    );
+    expect(await screen.findByTestId('agent-summary-card')).toBeInTheDocument();
+
+    const previewCall = fetchMock.mock.calls.find(([url]) => url === '/ai/agents/preview')!;
+    const previewBody = JSON.parse((previewCall[1] as RequestInit).body as string);
+    expect(previewBody.name).toBe('Triage bot');
+    expect(previewBody.kind).toBe('triage');
+  });
+
+  it('shows an inline error on a failed preview but still allows Create', async () => {
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url === '/ai/agents/tool-catalog') return Promise.resolve(json({ data: CATALOG }));
+      if (url.startsWith('/ai/agents/ceiling')) return Promise.resolve(json({ data: null }));
+      if (url === '/ai/agents/policy-decidable-keys') return Promise.resolve(json({ data: [] }));
+      if (url === '/roles') return Promise.resolve(json({ data: [] }));
+      if (url === '/ai/agents/preview') return Promise.resolve(json({ error: 'nope' }, false, 500));
+      if (url === '/ai/agents' && init?.method === 'POST') {
+        return Promise.resolve(json({ data: { id: 'new-agent', ...JSON.parse(init.body as string) } }, true, 201));
+      }
+      return Promise.resolve(json({ data: [] }));
+    });
+    renderFlow();
+    await advanceToReview();
+
+    expect(await screen.findByTestId('agent-create-flow-preview-error', {}, { timeout: 2000 })).toBeInTheDocument();
+    expect(screen.getByTestId('agent-create-flow-create')).not.toBeDisabled();
+  });
+
+  it('calls onCreated with the server response on a successful Create', async () => {
+    mockEndpoints();
+    const { onCreated } = renderFlow();
+    await advanceToReview();
+    fireEvent.click(await screen.findByTestId('agent-create-flow-create'));
+
+    await waitFor(() => expect(onCreated).toHaveBeenCalledTimes(1));
+    expect(onCreated.mock.calls[0][0]).toMatchObject({ id: 'new-agent' });
+  });
+
+  it('onEdit from the summary card jumps back to the right step', async () => {
+    mockEndpoints();
+    renderFlow();
+    await advanceToReview();
+    await screen.findByTestId('agent-summary-card');
+
+    fireEvent.click(screen.getByTestId('agent-summary-row-mayPropose-edit')); // "does" section
+    expect(await screen.findByTestId('ai-agent-permissions')).toBeInTheDocument();
+  });
+
+  it('the "Start enabled" switch defaults to off and drives the created body\'s enabled field', async () => {
+    mockEndpoints();
+    renderFlow();
+    await advanceToReview();
+    await screen.findByTestId('agent-summary-card');
+
+    expect(screen.getByTestId('agent-create-flow-start-enabled')).not.toBeChecked();
+    fireEvent.click(screen.getByTestId('agent-create-flow-start-enabled'));
+    fireEvent.click(screen.getByTestId('agent-create-flow-create'));
+
+    await waitFor(() => expect(postBody().enabled).toBe(true));
+  });
+});

--- a/apps/web/src/components/settings/aiAgents/AgentCreateFlow.test.tsx
+++ b/apps/web/src/components/settings/aiAgents/AgentCreateFlow.test.tsx
@@ -16,7 +16,7 @@ vi.mock('../../../stores/orgStore', () => ({
   useOrgStore: (sel?: (s: typeof orgState.current) => unknown) => (sel ? sel(orgState.current) : orgState.current),
 }));
 
-import { type AgentToolCatalogDto, type AiAgentDto } from '@breeze/shared';
+import { AI_AGENT_KINDS, type AgentToolCatalogDto, type AiAgentDto } from '@breeze/shared';
 import AgentCreateFlow from './AgentCreateFlow';
 import { fetchWithAuth } from '../../../stores/auth';
 import { buildAgentSaveBody, draftFrom } from './agentDraft';
@@ -269,6 +269,42 @@ describe('AgentCreateFlow — kind cards and owner scope (moved from AiAgentsPag
     renderFlow({ defaultOwnerScope: 'organization', partnerBaselineKinds: new Set() });
     expect(screen.getByTestId('ai-agent-no-baseline-hint')).toBeInTheDocument();
   });
+
+  // Ported from AiAgentForm.test.tsx (Task 10, #5051 review): the hint is
+  // create-only and no longer rendered by the drawer at all now that it only
+  // ever edits — this is its sole remaining coverage.
+  it('does not warn when a partner baseline already exists for the selected kind', async () => {
+    mockEndpoints();
+    renderFlow({ defaultOwnerScope: 'organization', partnerBaselineKinds: new Set(['triage']) });
+    await screen.findByTestId('ai-agent-kind-card-triage');
+    expect(screen.queryByTestId('ai-agent-no-baseline-hint')).toBeNull();
+  });
+
+  it('does not warn when creating a partner-wide agent', async () => {
+    mockEndpoints();
+    renderFlow({ partnerBaselineKinds: new Set() }); // defaultOwnerScope defaults to 'partner'
+    await screen.findByTestId('ai-agent-kind-card-triage');
+    expect(screen.queryByTestId('ai-agent-no-baseline-hint')).toBeNull();
+  });
+
+  it('disables Next on Purpose (and Create) once every kind is already taken for the current owner, mirroring the drawer\'s availableKinds guard', async () => {
+    orgState.current = { ...orgState.current, currentOrgId: 'org-1', allOrgs: false };
+    const allKindsTaken: AiAgentDto[] = AI_AGENT_KINDS.map((kind, i) => ({
+      ...makeAgents()[0]!,
+      id: `taken-${i}`,
+      kind,
+    }));
+    mockEndpoints();
+    renderFlow({ defaultOwnerScope: 'organization', agents: allKindsTaken });
+
+    expect(screen.getByTestId('ai-agent-kinds-exhausted')).toBeInTheDocument();
+    expect(screen.getByTestId('agent-create-flow-next')).toBeDisabled();
+
+    // Switching to the partner axis frees it up again (nothing taken there).
+    fireEvent.click(screen.getByTestId('ai-agent-owner-partner'));
+    expect(screen.queryByTestId('ai-agent-kinds-exhausted')).toBeNull();
+    expect(screen.getByTestId('agent-create-flow-next')).not.toBeDisabled();
+  });
 });
 
 describe('AgentCreateFlow — Safety step (moved from AiAgentsPage.test.tsx)', () => {
@@ -288,18 +324,47 @@ describe('AgentCreateFlow — Safety step (moved from AiAgentsPage.test.tsx)', (
     expect(screen.queryByTestId('ai-agent-roles-empty')).toBeNull();
   });
 
-  it('keeps a cleared numeric limit as a finite number in the create body', async () => {
+  it('falls back a cleared numeric limit to its minimum, never 0 (Number(\'\') is 0, not NaN)', async () => {
+    // The old guard only checked `Number.isFinite(next)` on the theory that
+    // clearing the box yields `'' -> NaN` — it does not, `Number('')` is `0`,
+    // which IS finite, so the guard never fired and a cleared limit silently
+    // stored 0 rather than falling back at all.
     mockEndpoints();
     renderFlow();
     await advanceToSafety();
 
     fireEvent.change(screen.getByTestId('ai-agent-limit-devices'), { target: { value: '' } });
+    expect(screen.getByTestId('ai-agent-limit-devices')).toHaveValue(1); // this field's min
+
     fireEvent.click(screen.getByTestId('agent-create-flow-next'));
     fireEvent.click(await screen.findByTestId('agent-create-flow-create'));
 
     const limits = () => postBody().limits as { maxDevicesPerRun: number };
     await waitFor(() => expect(limits().maxDevicesPerRun).toBeTypeOf('number'));
-    expect(Number.isFinite(limits().maxDevicesPerRun)).toBe(true);
+    expect(limits().maxDevicesPerRun).toBe(1);
+  });
+
+  it('collapses a partner draft\'s supervised-key registry behind a summary while shadow/off, mirroring the drawer', async () => {
+    mockEndpoints();
+    renderFlow(); // defaultOwnerScope: 'partner', mode defaults to 'shadow'
+    await advanceToSafety();
+
+    const details = await screen.findByTestId('ai-agent-policy-keys-details');
+    expect(details.tagName).toBe('DETAILS');
+    expect(details).not.toHaveAttribute('open');
+
+    // Entering act mode unwraps the registry entirely — go back to Purpose,
+    // switch to act, and return.
+    fireEvent.click(screen.getByTestId('setup-stepper-step-0'));
+    fireEvent.click(screen.getByTestId('ai-agent-mode-act'));
+    fireEvent.click(screen.getByTestId('ai-agent-act-ack'));
+    fireEvent.click(screen.getByTestId('agent-create-flow-next'));
+    await screen.findByTestId('ai-agent-permissions');
+    fireEvent.click(screen.getByTestId('agent-create-flow-next'));
+    await screen.findByTestId('ai-agent-limit-devices');
+
+    expect(screen.queryByTestId('ai-agent-policy-keys-details')).toBeNull();
+    expect(screen.getByTestId('ai-agent-policy-decide')).toBeInTheDocument();
   });
 });
 

--- a/apps/web/src/components/settings/aiAgents/AgentCreateFlow.tsx
+++ b/apps/web/src/components/settings/aiAgents/AgentCreateFlow.tsx
@@ -9,7 +9,7 @@ import { useOrgScope } from '@/hooks/useOrgScope';
 import type { OwnerScope } from '@/hooks/useDefaultOwnerScope';
 import SetupStepper from '../../setup/SetupStepper';
 import { useAgentToolCatalog } from './useAgentToolCatalog';
-import { ALERT_SEVERITY_KINDS, buildAgentSaveBody, draftFrom, firstFreeKind, type Draft } from './agentDraft';
+import { ALERT_SEVERITY_KINDS, buildAgentSaveBody, draftFrom, firstFreeKind, freeKinds, type Draft } from './agentDraft';
 import type { PolicyDecidableKeyOption } from './PolicyKeysCheckboxes';
 import PurposeStep from './steps/PurposeStep';
 import WhatItDoesStep from './steps/WhatItDoesStep';
@@ -101,6 +101,11 @@ export default function AgentCreateFlow({
   const actKeysWillBeOmitted =
     draft.ownerScope !== 'organization' && draft.mode !== 'act' && draft.supervisedActionKeys.length > 0;
   const actSupported = SUPPORTED_AGENT_MODES.includes('act');
+  // Mirrors the drawer's `availableKinds.length === 0` Save guard
+  // (AiAgentForm.tsx): every kind for this owner is already taken, so
+  // there is nothing a further step could do but submit a duplicate that
+  // the server would 409 on `agent_kind_exists` anyway.
+  const kindsExhausted = freeKinds(agents, draft.ownerScope, orgScope.orgId).length === 0;
 
   const { catalog: fetchedCatalog, ceiling, loading: catalogLoading } = useAgentToolCatalog({
     kind: draft.kind,
@@ -190,7 +195,7 @@ export default function AgentCreateFlow({
   // needs the acknowledgement before the operator can move past this step —
   // there is nothing else here for "Next" to gate on for act mode, since a
   // create draft is always "entering" act the first time it's selected.
-  const nextDisabled = step === 0 && enteringActMode && !actAck;
+  const nextDisabled = step === 0 && ((enteringActMode && !actAck) || kindsExhausted);
 
   const create = useCallback(async () => {
     if (saving) return;
@@ -345,7 +350,7 @@ export default function AgentCreateFlow({
           <button
             type="button"
             onClick={() => void create()}
-            disabled={saving}
+            disabled={saving || kindsExhausted}
             className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground disabled:cursor-not-allowed disabled:opacity-60"
             data-testid="agent-create-flow-create"
           >

--- a/apps/web/src/components/settings/aiAgents/AgentCreateFlow.tsx
+++ b/apps/web/src/components/settings/aiAgents/AgentCreateFlow.tsx
@@ -1,0 +1,358 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { AI_AGENT_KINDS, SUPPORTED_AGENT_MODES, type AiAgentDto } from '@breeze/shared';
+import { fetchWithAuth } from '@/stores/auth';
+import { ActionError, handleActionError, runAction } from '@/lib/runAction';
+import { loginPathWithNext } from '@/lib/authScope';
+import { navigateTo } from '@/lib/navigation';
+import { useOrgScope } from '@/hooks/useOrgScope';
+import type { OwnerScope } from '@/hooks/useDefaultOwnerScope';
+import SetupStepper from '../../setup/SetupStepper';
+import { useAgentToolCatalog } from './useAgentToolCatalog';
+import { ALERT_SEVERITY_KINDS, buildAgentSaveBody, draftFrom, firstFreeKind, type Draft } from './agentDraft';
+import type { PolicyDecidableKeyOption } from './PolicyKeysCheckboxes';
+import PurposeStep from './steps/PurposeStep';
+import WhatItDoesStep from './steps/WhatItDoesStep';
+import SafetyStep, { type RoleOption } from './steps/SafetyStep';
+import ReviewStep from './steps/ReviewStep';
+
+export interface AgentCreateFlowProps {
+  /** Every agent visible to this session — same prop `AiAgentForm.tsx` takes,
+   *  needed to compute which kinds are still free for the chosen owner. */
+  agents: AiAgentDto[];
+  /** Kinds that already have an active partner-wide baseline for this org's
+   *  partner (#4170) — see `AiAgentForm.tsx`'s `partnerBaselineKinds` doc. */
+  partnerBaselineKinds: Set<string>;
+  /** Show the partner-wide vs org-owned selector (partner-scope sessions only). */
+  showOwnerScope: boolean;
+  defaultOwnerScope: OwnerScope;
+  onCancel: () => void;
+  onCreated: (agent: AiAgentDto) => void;
+}
+
+const STEP_KEYS = ['purpose', 'does', 'safety', 'review'] as const;
+type StepKey = (typeof STEP_KEYS)[number];
+/** `AgentSummaryCard`'s `onEdit` names three of the four steps — "review" has
+ *  no row that could ever link back to itself. */
+type EditSection = 'purpose' | 'does' | 'safety';
+
+const UNAUTHORIZED = () => void navigateTo(loginPathWithNext(), { replace: true });
+
+/**
+ * Machine token -> operator-facing sentence. Mirrors `AiAgentForm.tsx`'s
+ * `AGENT_ERROR_COPY` exactly (duplicated rather than imported: the two forms
+ * build DIFFERENT bodies — this one only ever creates — and keeping a create-
+ * only copy map here is clearer than importing a map with edit-only entries
+ * this flow can never reach, e.g. `mode_not_supported` DOES apply here too,
+ * so it stays; nothing in this list is unique to the drawer).
+ */
+const AGENT_ERROR_COPY: Record<string, ((t: (key: string) => string) => string) | undefined> = {
+  agent_kind_exists: (t) => t('aiAgentsPage.errors.kindExists'),
+  mode_not_supported: (t) => t('aiAgentsPage.errors.modeNotSupported'),
+  act_prerequisites_not_met: (t) => t('aiAgentsPage.errors.actPrerequisitesNotMet'),
+  invalid_supervised_action_keys: (t) => t('aiAgentsPage.errors.invalidSupervisedActionKeys'),
+  supervised_keys_grant_only: (t) => t('aiAgentsPage.errors.invalidSupervisedActionKeys'),
+};
+
+/** `missing[]` entries from the server's `act_prerequisites_not_met` 422 —
+ *  same mapping as `AiAgentForm.tsx`'s `ACT_PREREQUISITE_COPY`. */
+const ACT_PREREQUISITE_COPY: Record<string, (t: (key: string) => string) => string> = {
+  recipient: (t) => t('aiAgentsPage.errors.actMissingRecipient'),
+  act_eligible_tool: (t) => t('aiAgentsPage.errors.actMissingTool'),
+};
+
+/**
+ * The four-step guided create flow (spec §4.6, Task 13 #5051): Purpose and
+ * posture -> What it does -> Safety and oversight -> Review and create.
+ * Renders full-width in place of the agents list while open. Owns ONE
+ * `Draft` (the same shape `AiAgentForm.tsx`'s drawer edits) and builds its
+ * `POST /ai/agents` body through the identical `buildAgentSaveBody` — the
+ * two surfaces can never diverge on what an identical draft would submit.
+ */
+export default function AgentCreateFlow({
+  agents,
+  partnerBaselineKinds,
+  showOwnerScope,
+  defaultOwnerScope,
+  onCancel,
+  onCreated,
+}: AgentCreateFlowProps) {
+  const { t } = useTranslation('settings');
+  const orgScope = useOrgScope();
+
+  const [draft, setDraft] = useState<Draft>(() =>
+    draftFrom(null, {
+      ownerScope: defaultOwnerScope,
+      kind: firstFreeKind(agents, defaultOwnerScope, orgScope.orgId) ?? AI_AGENT_KINDS[0],
+    }),
+  );
+  const patch = useCallback((values: Partial<Draft>) => setDraft((current) => ({ ...current, ...values })), []);
+
+  const [step, setStep] = useState(0);
+  const [issues, setIssues] = useState<string[]>([]);
+  const [forceNameError, setForceNameError] = useState(false);
+  const [actAck, setActAck] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  // Create has no existing agent, so entering act is simply "mode is act" —
+  // there is no prior mode to compare against (mirrors AiAgentForm's
+  // `initialMode` always being 'off' on create).
+  const enteringActMode = draft.mode === 'act';
+  const actKeysWillBeOmitted =
+    draft.ownerScope !== 'organization' && draft.mode !== 'act' && draft.supervisedActionKeys.length > 0;
+  const actSupported = SUPPORTED_AGENT_MODES.includes('act');
+
+  const { catalog: fetchedCatalog, ceiling, loading: catalogLoading } = useAgentToolCatalog({
+    kind: draft.kind,
+    ownerScope: draft.ownerScope,
+  });
+  const catalog = fetchedCatalog && Array.isArray(fetchedCatalog.tools) && fetchedCatalog.presets ? fetchedCatalog : null;
+
+  // Same cancelled-flag fetch pattern as AiAgentForm.tsx's own roles effect —
+  // a failure must not render as "no roles configured" (see that file's doc).
+  const [roles, setRoles] = useState<RoleOption[]>([]);
+  const [rolesFailed, setRolesFailed] = useState(false);
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const response = await fetchWithAuth('/roles');
+        if (!response.ok) throw new Error(`GET /roles ${response.status}`);
+        const body = (await response.json()) as { data?: RoleOption[] };
+        if (!cancelled) setRoles(Array.isArray(body.data) ? body.data : []);
+      } catch (err) {
+        console.error('[AgentCreateFlow] could not load roles', err);
+        if (!cancelled) setRolesFailed(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Same cancelled-flag fetch pattern as AiAgentForm.tsx's own registry
+  // effect — fetched once per mount, rendered only for a partner draft
+  // (SafetyStep.tsx).
+  const [policyKeys, setPolicyKeys] = useState<PolicyDecidableKeyOption[]>([]);
+  const [policyKeysFailed, setPolicyKeysFailed] = useState(false);
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const response = await fetchWithAuth('/ai/agents/policy-decidable-keys');
+        if (!response.ok) throw new Error(`GET /ai/agents/policy-decidable-keys ${response.status}`);
+        const body = (await response.json()) as { data?: PolicyDecidableKeyOption[] };
+        const rows = Array.isArray(body.data)
+          ? body.data.filter(
+              (row): row is PolicyDecidableKeyOption =>
+                typeof row?.key === 'string' && typeof row?.toolName === 'string',
+            )
+          : [];
+        if (!cancelled) setPolicyKeys(rows);
+      } catch (err) {
+        console.error('[AgentCreateFlow] could not load policy-decidable keys', err);
+        if (!cancelled) setPolicyKeysFailed(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const stepLabel = (key: StepKey) => t(/* i18n-dynamic */ `aiAgentsPage.flow.steps.${key}.label`);
+  const stepDescription = (key: StepKey) => t(/* i18n-dynamic */ `aiAgentsPage.flow.steps.${key}.description`);
+
+  const goBack = () => setStep((current) => Math.max(0, current - 1));
+
+  const goNext = () => {
+    if (step === 0) {
+      const problems: string[] = [];
+      if (!draft.name.trim()) {
+        problems.push(t('aiAgentsPage.issues.name'));
+        setForceNameError(true);
+      }
+      if (problems.length > 0) {
+        setIssues(problems);
+        return;
+      }
+    }
+    if (step === 1 && ALERT_SEVERITY_KINDS.has(draft.kind) && draft.severities.length === 0) {
+      setIssues([t('aiAgentsPage.issues.severities')]);
+      return;
+    }
+    setIssues([]);
+    setStep((current) => Math.min(STEP_KEYS.length - 1, current + 1));
+  };
+
+  const goToSection = (section: EditSection) => setStep(STEP_KEYS.indexOf(section));
+
+  // Mirrors AiAgentForm.tsx's Save disable condition: an act-mode transition
+  // needs the acknowledgement before the operator can move past this step —
+  // there is nothing else here for "Next" to gate on for act mode, since a
+  // create draft is always "entering" act the first time it's selected.
+  const nextDisabled = step === 0 && enteringActMode && !actAck;
+
+  const create = useCallback(async () => {
+    if (saving) return;
+    const problems: string[] = [];
+    if (draft.ownerScope === 'organization' && !orgScope.orgId) {
+      problems.push(t('aiAgentsPage.issues.org'));
+    }
+    if (problems.length > 0) {
+      setIssues(problems);
+      return;
+    }
+    setIssues([]);
+    setSaving(true);
+    const body = buildAgentSaveBody(draft, { isCreate: true, orgId: orgScope.orgId });
+
+    let created: AiAgentDto | null = null;
+    try {
+      const result = await runAction<{ data: AiAgentDto }>({
+        request: () => fetchWithAuth('/ai/agents', { method: 'POST', body: JSON.stringify(body) }),
+        successMessage: t('aiAgentsPage.toasts.saved'),
+        errorFallback: t('aiAgentsPage.toasts.saveFailed'),
+        friendly: (code) => AGENT_ERROR_COPY[code]?.(t),
+        onUnauthorized: UNAUTHORIZED,
+      });
+      created = result.data;
+    } catch (err) {
+      handleActionError(err, t('aiAgentsPage.toasts.saveFailed'));
+      if (err instanceof ActionError && err.code === 'act_prerequisites_not_met') {
+        const errBody = err.body as { missing?: unknown } | undefined;
+        const missing = Array.isArray(errBody?.missing)
+          ? errBody.missing.filter((entry): entry is string => typeof entry === 'string')
+          : [];
+        setIssues(missing.map((entry) => ACT_PREREQUISITE_COPY[entry]?.(t) ?? entry));
+      }
+      if (
+        err instanceof ActionError
+        && (err.code === 'invalid_supervised_action_keys' || err.code === 'supervised_keys_grant_only')
+      ) {
+        const errBody = err.body as { rejected?: unknown } | undefined;
+        const rejected = Array.isArray(errBody?.rejected)
+          ? errBody.rejected.filter(
+              (entry): entry is { key: string; reason: string } =>
+                typeof entry === 'object'
+                && entry !== null
+                && typeof (entry as { key?: unknown }).key === 'string'
+                && typeof (entry as { reason?: unknown }).reason === 'string',
+            )
+          : [];
+        setIssues(rejected.map((entry) => t('aiAgentsPage.errors.supervisedKeyRejected', { key: entry.key, reason: entry.reason })));
+      }
+    } finally {
+      setSaving(false);
+    }
+    if (created) onCreated(created);
+  }, [draft, orgScope.orgId, saving, onCreated, t]);
+
+  const orgName = draft.ownerScope === 'organization' ? (orgScope.org?.name ?? null) : null;
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col" data-testid="agent-create-flow">
+      <div className="flex items-center justify-between border-b px-5 py-4">
+        <h2 className="text-lg font-semibold">{t('aiAgentsPage.flow.title')}</h2>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded-md border px-3 py-1.5 text-sm font-medium"
+          data-testid="agent-create-flow-cancel"
+        >
+          {t('aiAgentsPage.actions.cancel')}
+        </button>
+      </div>
+
+      <div className="grid min-h-0 flex-1 grid-cols-1 gap-6 overflow-y-auto p-5 md:grid-cols-[220px_minmax(0,1fr)]">
+        <SetupStepper
+          steps={STEP_KEYS.map((key) => ({ label: stepLabel(key), description: stepDescription(key) }))}
+          currentStep={step}
+          onStepClick={setStep}
+          orientation="vertical"
+          ariaLabel={t('aiAgentsPage.flow.stepperAriaLabel')}
+        />
+
+        <div className="min-w-0 space-y-3">
+          {issues.length > 0 && (
+            <ul
+              className="list-disc space-y-1 rounded-md border border-destructive/40 bg-destructive/10 px-6 py-2 text-sm text-destructive"
+              data-testid="ai-agent-issues"
+            >
+              {issues.map((issue) => (
+                <li key={issue}>{issue}</li>
+              ))}
+            </ul>
+          )}
+
+          {step === 0 && (
+            <PurposeStep
+              draft={draft}
+              patch={patch}
+              agents={agents}
+              orgId={orgScope.orgId}
+              showOwnerScope={showOwnerScope}
+              partnerBaselineKinds={partnerBaselineKinds}
+              actSupported={actSupported}
+              actAck={actAck}
+              onActAckChange={setActAck}
+              actKeysWillBeOmitted={actKeysWillBeOmitted}
+              forceNameError={forceNameError}
+            />
+          )}
+          {step === 1 && (
+            <WhatItDoesStep draft={draft} patch={patch} catalog={catalog} ceiling={ceiling} catalogLoading={catalogLoading} />
+          )}
+          {step === 2 && (
+            <SafetyStep
+              draft={draft}
+              patch={patch}
+              roles={roles}
+              rolesFailed={rolesFailed}
+              policyKeys={policyKeys}
+              policyKeysFailed={policyKeysFailed}
+            />
+          )}
+          {step === 3 && (
+            <ReviewStep draft={draft} patch={patch} orgId={orgScope.orgId} orgName={orgName} onEdit={goToSection} />
+          )}
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between border-t bg-card px-5 py-4">
+        <div>
+          {step > 0 && (
+            <button
+              type="button"
+              onClick={goBack}
+              className="rounded-md border px-3 py-1.5 text-sm font-medium"
+              data-testid="agent-create-flow-back"
+            >
+              {t('aiAgentsPage.flow.back')}
+            </button>
+          )}
+        </div>
+        {step < STEP_KEYS.length - 1 ? (
+          <button
+            type="button"
+            onClick={goNext}
+            disabled={nextDisabled}
+            className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground disabled:cursor-not-allowed disabled:opacity-60"
+            data-testid="agent-create-flow-next"
+          >
+            {t('aiAgentsPage.flow.next', { step: stepLabel(STEP_KEYS[step + 1]!) })}
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={() => void create()}
+            disabled={saving}
+            className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground disabled:cursor-not-allowed disabled:opacity-60"
+            data-testid="agent-create-flow-create"
+          >
+            {t('aiAgentsPage.flow.createAgent')}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/aiAgents/AgentSummaryCard.test.tsx
+++ b/apps/web/src/components/settings/aiAgents/AgentSummaryCard.test.tsx
@@ -30,6 +30,7 @@ function buildPreview(overrides: Partial<AgentPreviewDto> = {}): AgentPreviewDto
     triggers: { alertSeverities: ['critical', 'high'], respectMaintenanceWindows: true, ticketAutonomousWrites: false },
     protectedResources: { services: [], paths: [], registryKeys: [], deviceTags: [] },
     limits: { ...AI_AGENT_LIMIT_DEFAULTS },
+    cooldownSeconds: 900,
     recipients: { userIds: [], roleIds: ['role-1', 'role-2'] },
     ...overrides,
   };
@@ -117,14 +118,16 @@ describe('AgentSummaryCard', () => {
     expect(screen.getByTestId('agent-summary-never-touches-chip-C:\\Windows')).toBeInTheDocument();
   });
 
-  it('reads the six-limit sentence from preview.limits with currency and percent formatting', () => {
-    render(<AgentSummaryCard preview={buildPreview()} name="Bot" orgName="Acme" />);
+  it('reads the six-limit sentence from preview.limits plus the sibling cooldownSeconds, with currency and percent formatting', () => {
+    render(<AgentSummaryCard preview={buildPreview({ cooldownSeconds: 1800 })} name="Bot" orgName="Acme" />);
     const row = screen.getByTestId('agent-summary-row-limits');
     expect(row.textContent).toContain(String(AI_AGENT_LIMIT_DEFAULTS.maxDevicesPerRun));
     expect(row.textContent).toContain(String(AI_AGENT_LIMIT_DEFAULTS.maxRunsPerHour));
     expect(row.textContent).toContain(String(Math.round(AI_AGENT_LIMIT_DEFAULTS.wallClockSeconds / 60)));
     expect(row.textContent).toContain('$10.00');
     expect(row.textContent).toContain('5%');
+    // cooldownSeconds: 1800 -> 30 minutes between runs on the same device.
+    expect(row.textContent).toContain('30');
   });
 
   it('counts approver roles, or says none are configured', () => {

--- a/apps/web/src/components/settings/aiAgents/AgentSummaryCard.test.tsx
+++ b/apps/web/src/components/settings/aiAgents/AgentSummaryCard.test.tsx
@@ -1,0 +1,186 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { AI_AGENT_LIMIT_DEFAULTS, type AgentPreviewDto } from '@breeze/shared';
+import AgentSummaryCard from './AgentSummaryCard';
+
+/**
+ * Every tool name here is deliberately fake (`fake_tool_*`) so the assertions
+ * exercise the component's own label-formatting fallback (`sentenceCase`,
+ * mirroring CapabilityPicker's) rather than depending on the real
+ * `aiAgentsPage.catalog.tools/actions` translations staying stable.
+ */
+const baseOperations: AgentPreviewDto['operations'] = [
+  { key: 'fake_tool_a:restart', capability: 'services_startup', outcome: 'approval_request', preauthorized: false, withinCeiling: true },
+  { key: 'fake_tool_b:stop', capability: 'services_startup', outcome: 'approval_request', preauthorized: false, withinCeiling: true },
+  { key: 'fake_tool_c:approve', capability: 'patching_software', outcome: 'approval_request', preauthorized: false, withinCeiling: true },
+  { key: 'fake_tool_d:install', capability: 'patching_software', outcome: 'approval_request', preauthorized: false, withinCeiling: true },
+  { key: 'fake_tool_e:list', capability: 'files_disk', outcome: 'logged_proposal', preauthorized: false, withinCeiling: true },
+  { key: 'fake_tool_f', capability: 'files_disk', outcome: 'logged_proposal', preauthorized: false, withinCeiling: true },
+  { key: 'fake_tool_g:scan', capability: 'security_response', outcome: 'logged_proposal', preauthorized: false, withinCeiling: true },
+  { key: 'fake_tool_h:cleanup', capability: 'security_response', outcome: 'logged_proposal', preauthorized: false, withinCeiling: true },
+];
+
+function buildPreview(overrides: Partial<AgentPreviewDto> = {}): AgentPreviewDto {
+  return {
+    mode: 'shadow',
+    kind: 'triage',
+    readOnlyToolCount: 14,
+    operations: baseOperations,
+    unrecognised: [],
+    triggers: { alertSeverities: ['critical', 'high'], respectMaintenanceWindows: true, ticketAutonomousWrites: false },
+    protectedResources: { services: [], paths: [], registryKeys: [], deviceTags: [] },
+    limits: { ...AI_AGENT_LIMIT_DEFAULTS },
+    recipients: { userIds: [], roleIds: ['role-1', 'role-2'] },
+    ...overrides,
+  };
+}
+
+describe('AgentSummaryCard', () => {
+  it('renders the title row with name, kind, mode and a "Created disabled" pill by default', () => {
+    render(<AgentSummaryCard preview={buildPreview()} name="Triage bot" orgName="Acme" />);
+    expect(screen.getByTestId('agent-summary-card')).toHaveTextContent('Triage bot');
+    expect(screen.getByTestId('agent-summary-kind')).toHaveTextContent('Alert triage');
+    expect(screen.getByTestId('agent-summary-mode')).toHaveTextContent('Shadow');
+    expect(screen.getByTestId('agent-summary-org')).toHaveTextContent('Acme');
+    expect(screen.getByTestId('agent-summary-enabled-pill')).toHaveTextContent('Created disabled');
+  });
+
+  it('shows "All orgs" when orgName is null and an "Enabled" pill when enabled is true', () => {
+    render(<AgentSummaryCard preview={buildPreview()} name="Partner bot" orgName={null} enabled />);
+    expect(screen.getByTestId('agent-summary-org')).toHaveTextContent('All orgs');
+    expect(screen.getByTestId('agent-summary-enabled-pill')).toHaveTextContent('Enabled');
+  });
+
+  it('renders one chip per operation (4 approval requests + 4 logged proposals) in shadow mode', () => {
+    render(<AgentSummaryCard preview={buildPreview()} name="Triage bot" orgName="Acme" />);
+    expect(screen.getAllByTestId(/^agent-summary-chip-/)).toHaveLength(8);
+  });
+
+  it('names the org in the "Can read" sentence, or "all organizations" when partner-wide', () => {
+    const { rerender } = render(<AgentSummaryCard preview={buildPreview()} name="Bot" orgName="Acme" />);
+    expect(screen.getByTestId('agent-summary-row-canRead')).toHaveTextContent('Acme');
+    expect(screen.getByTestId('agent-summary-row-canRead')).toHaveTextContent('14');
+    expect(screen.getByTestId('agent-summary-row-canRead').textContent).not.toMatch(/everything/i);
+
+    rerender(<AgentSummaryCard preview={buildPreview()} name="Bot" orgName={null} />);
+    expect(screen.getByTestId('agent-summary-row-canRead')).toHaveTextContent('all organizations');
+  });
+
+  it('shows the shadow-mode "Nothing." sentence for executesUnattended', () => {
+    render(<AgentSummaryCard preview={buildPreview()} name="Bot" orgName="Acme" />);
+    expect(screen.getByTestId('agent-summary-row-executesUnattended').textContent).toContain('Nothing.');
+  });
+
+  it('lists unattended operation labels in act mode', () => {
+    const preview = buildPreview({
+      mode: 'act',
+      operations: [
+        ...baseOperations.slice(0, 6),
+        { key: 'fake_tool_i:restart', capability: 'services_startup', outcome: 'unattended', preauthorized: true, withinCeiling: true },
+        { key: 'fake_tool_j:cleanup', capability: 'files_disk', outcome: 'unattended', preauthorized: false, withinCeiling: true },
+      ],
+    });
+    render(<AgentSummaryCard preview={preview} name="Act bot" orgName="Acme" />);
+    const row = screen.getByTestId('agent-summary-row-executesUnattended');
+    expect(row.textContent).toContain('Fake tool i');
+    expect(row.textContent).toContain('Restart');
+    expect(row.textContent).toContain('Fake tool j');
+    expect(row.textContent).toContain('Cleanup');
+    expect(row.textContent).not.toContain('Nothing.');
+    // At least one unattended op is preauthorized -> the pre-authorized note appends.
+    expect(row.textContent?.toLowerCase()).toContain('pre-authorized');
+  });
+
+  it('flags an operation outside the partner ceiling with the not-in-ceiling badge', () => {
+    const preview = buildPreview({
+      operations: [...baseOperations.slice(0, 7), { key: 'fake_tool_k:stop', capability: 'services_startup', outcome: 'approval_request', preauthorized: false, withinCeiling: false }],
+    });
+    render(<AgentSummaryCard preview={preview} name="Bot" orgName="Acme" />);
+    expect(screen.getByTestId('agent-summary-chip-fake_tool_k:stop')).toHaveTextContent('Not in partner baseline');
+  });
+
+  it('renders unrecognised allowlist entries in mono after the chips', () => {
+    const preview = buildPreview({ unrecognised: ['restart_spooler'] });
+    render(<AgentSummaryCard preview={preview} name="Bot" orgName="Acme" />);
+    const entry = screen.getByTestId('agent-summary-unrecognised-restart_spooler');
+    expect(entry).toHaveTextContent('restart_spooler');
+    expect(entry.className).toContain('font-mono');
+  });
+
+  it('shows "Nothing is protected yet." when no resources are protected, else mono chips', () => {
+    const { rerender } = render(<AgentSummaryCard preview={buildPreview()} name="Bot" orgName="Acme" />);
+    expect(screen.getByTestId('agent-summary-row-neverTouches')).toHaveTextContent('Nothing is protected yet.');
+
+    const preview = buildPreview({ protectedResources: { services: ['spooler'], paths: ['C:\\Windows'], registryKeys: [], deviceTags: [] } });
+    rerender(<AgentSummaryCard preview={preview} name="Bot" orgName="Acme" />);
+    expect(screen.getByTestId('agent-summary-never-touches-chip-spooler')).toBeInTheDocument();
+    expect(screen.getByTestId('agent-summary-never-touches-chip-C:\\Windows')).toBeInTheDocument();
+  });
+
+  it('reads the six-limit sentence from preview.limits with currency and percent formatting', () => {
+    render(<AgentSummaryCard preview={buildPreview()} name="Bot" orgName="Acme" />);
+    const row = screen.getByTestId('agent-summary-row-limits');
+    expect(row.textContent).toContain(String(AI_AGENT_LIMIT_DEFAULTS.maxDevicesPerRun));
+    expect(row.textContent).toContain(String(AI_AGENT_LIMIT_DEFAULTS.maxRunsPerHour));
+    expect(row.textContent).toContain(String(Math.round(AI_AGENT_LIMIT_DEFAULTS.wallClockSeconds / 60)));
+    expect(row.textContent).toContain('$10.00');
+    expect(row.textContent).toContain('5%');
+  });
+
+  it('counts approver roles, or says none are configured', () => {
+    const { rerender } = render(<AgentSummaryCard preview={buildPreview()} name="Bot" orgName="Acme" />);
+    expect(screen.getByTestId('agent-summary-row-approvers')).toHaveTextContent('2 roles');
+
+    const preview = buildPreview({ recipients: { userIds: [], roleIds: [] } });
+    rerender(<AgentSummaryCard preview={preview} name="Bot" orgName="Acme" />);
+    expect(screen.getByTestId('agent-summary-row-approvers').textContent).not.toContain('0 roles');
+  });
+
+  it('calls onEdit with the section id for the title and each row, and omits Edit links when onEdit is absent', () => {
+    const onEdit = vi.fn();
+    render(<AgentSummaryCard preview={buildPreview()} name="Bot" orgName="Acme" onEdit={onEdit} />);
+
+    fireEvent.click(screen.getByTestId('agent-summary-title-edit'));
+    expect(onEdit).toHaveBeenLastCalledWith('purpose');
+
+    fireEvent.click(screen.getByTestId('agent-summary-row-runsWhen-edit'));
+    expect(onEdit).toHaveBeenLastCalledWith('does');
+    fireEvent.click(screen.getByTestId('agent-summary-row-canRead-edit'));
+    expect(onEdit).toHaveBeenLastCalledWith('does');
+    fireEvent.click(screen.getByTestId('agent-summary-row-mayPropose-edit'));
+    expect(onEdit).toHaveBeenLastCalledWith('does');
+
+    fireEvent.click(screen.getByTestId('agent-summary-row-executesUnattended-edit'));
+    expect(onEdit).toHaveBeenLastCalledWith('safety');
+    fireEvent.click(screen.getByTestId('agent-summary-row-neverTouches-edit'));
+    expect(onEdit).toHaveBeenLastCalledWith('safety');
+    fireEvent.click(screen.getByTestId('agent-summary-row-limits-edit'));
+    expect(onEdit).toHaveBeenLastCalledWith('safety');
+    fireEvent.click(screen.getByTestId('agent-summary-row-approvers-edit'));
+    expect(onEdit).toHaveBeenLastCalledWith('safety');
+
+    expect(onEdit).toHaveBeenCalledTimes(8);
+  });
+
+  it('renders no Edit links when onEdit is not provided', () => {
+    render(<AgentSummaryCard preview={buildPreview()} name="Bot" orgName="Acme" />);
+    expect(screen.queryByTestId('agent-summary-title-edit')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('agent-summary-row-runsWhen-edit')).not.toBeInTheDocument();
+  });
+
+  it('builds kind-specific "Runs when" phrasing for patch and helpdesk, appending maintenance-window and ticket-write clauses when set', () => {
+    const patchPreview = buildPreview({ kind: 'patch', triggers: { alertSeverities: [], respectMaintenanceWindows: false, ticketAutonomousWrites: false } });
+    const { rerender } = render(<AgentSummaryCard preview={patchPreview} name="Bot" orgName="Acme" />);
+    expect(screen.getByTestId('agent-summary-row-runsWhen').textContent).not.toMatch(/maintenance window/i);
+    expect(screen.getByTestId('agent-summary-row-runsWhen').textContent).toMatch(/patch/i);
+
+    const helpdeskPreview = buildPreview({
+      kind: 'helpdesk',
+      triggers: { alertSeverities: [], respectMaintenanceWindows: true, ticketAutonomousWrites: true },
+    });
+    rerender(<AgentSummaryCard preview={helpdeskPreview} name="Bot" orgName="Acme" />);
+    const row = screen.getByTestId('agent-summary-row-runsWhen');
+    expect(row.textContent).toMatch(/ticket/i);
+    expect(row.textContent).toMatch(/maintenance window/i);
+  });
+});

--- a/apps/web/src/components/settings/aiAgents/AgentSummaryCard.test.tsx
+++ b/apps/web/src/components/settings/aiAgents/AgentSummaryCard.test.tsx
@@ -114,8 +114,21 @@ describe('AgentSummaryCard', () => {
 
     const preview = buildPreview({ protectedResources: { services: ['spooler'], paths: ['C:\\Windows'], registryKeys: [], deviceTags: [] } });
     rerender(<AgentSummaryCard preview={preview} name="Bot" orgName="Acme" />);
-    expect(screen.getByTestId('agent-summary-never-touches-chip-spooler')).toBeInTheDocument();
-    expect(screen.getByTestId('agent-summary-never-touches-chip-C:\\Windows')).toBeInTheDocument();
+    expect(screen.getByTestId('agent-summary-never-touches-chip-services-spooler')).toBeInTheDocument();
+    expect(screen.getByTestId('agent-summary-never-touches-chip-paths-C:\\Windows')).toBeInTheDocument();
+  });
+
+  it('keys/test-ids "never touches" chips by category, not just the value, so the same value in two categories does not collide', () => {
+    const preview = buildPreview({
+      protectedResources: { services: ['shared'], paths: ['shared'], registryKeys: [], deviceTags: [] },
+    });
+    render(<AgentSummaryCard preview={preview} name="Bot" orgName="Acme" />);
+
+    const serviceChip = screen.getByTestId('agent-summary-never-touches-chip-services-shared');
+    const pathChip = screen.getByTestId('agent-summary-never-touches-chip-paths-shared');
+    expect(serviceChip).not.toBe(pathChip);
+    expect(serviceChip).toHaveTextContent('shared');
+    expect(pathChip).toHaveTextContent('shared');
   });
 
   it('reads the six-limit sentence from preview.limits plus the sibling cooldownSeconds, with currency and percent formatting', () => {

--- a/apps/web/src/components/settings/aiAgents/AgentSummaryCard.tsx
+++ b/apps/web/src/components/settings/aiAgents/AgentSummaryCard.tsx
@@ -103,14 +103,12 @@ function SummaryRow({
  * the entire point of evaluating the draft server-side rather than
  * re-deriving it from the picker's own client-side model).
  *
- * Deviation from the plan's literal "six exposed limits" list: `preview.limits`
- * is `AiAgentLimits`, which has no `cooldownSeconds` field — cooldown is a
- * sibling field on the agent's policy row (`AiAgentPolicy.cooldownSeconds`),
- * never threaded through `buildAgentPreview` (agentPreview.ts). Task 12 is
- * scoped to this file plus locales only, so the limits row below renders the
- * five limits `AgentPreviewDto` actually carries; adding cooldown here would
- * require widening `AgentPreviewDto`/`buildAgentPreview` in Task 11's files,
- * which is out of scope for this task.
+ * The six exposed limits (spec §4.6 step 4): the five fields of
+ * `preview.limits` (`AiAgentLimits`) plus `preview.cooldownSeconds`, a sibling
+ * field on the agent's policy row (`AiAgentPolicy.cooldownSeconds`) rather
+ * than one of `AiAgentLimits`'s own fields — `buildAgentPreview` carries it
+ * through separately (agentPreview.ts) so this card can render it alongside
+ * the other five without reaching into a differently-shaped policy row.
  */
 export default function AgentSummaryCard({ preview, name, orgName, enabled = false, onEdit }: AgentSummaryCardProps) {
   const { t } = useTranslation('settings');
@@ -191,16 +189,18 @@ export default function AgentSummaryCard({ preview, name, orgName, enabled = fal
     ...preview.protectedResources.registryKeys,
   ];
 
-  // --- Limits (deviation: cooldown omitted — see the docstring above) ---
+  // --- Limits (six exposed limits: the five in `limits` plus the sibling `cooldownSeconds`) ---
   const minutesPerRun = Math.round(preview.limits.wallClockSeconds / 60);
   const dailyBudget = formatCurrency(preview.limits.maxBudgetCentsPerDay / 100);
   const fleetPercent = formatPercent(preview.limits.maxFleetPercentPerDay / 100);
+  const cooldownMinutes = Math.round(preview.cooldownSeconds / 60);
   const limitsText = t('aiAgentsPage.summary.limits', {
     devices: preview.limits.maxDevicesPerRun,
     runsPerHour: preview.limits.maxRunsPerHour,
     minutes: minutesPerRun,
     budget: dailyBudget,
     fleetPercent,
+    cooldown: cooldownMinutes,
   });
 
   // --- Approvers ---

--- a/apps/web/src/components/settings/aiAgents/AgentSummaryCard.tsx
+++ b/apps/web/src/components/settings/aiAgents/AgentSummaryCard.tsx
@@ -1,0 +1,309 @@
+import type { ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { AgentPreviewDto } from '@breeze/shared';
+import { badgeClass, modeTone } from '../../aiAgents/statusBadge';
+import { formatCurrency, formatPercent, resolvedFormattingLocale } from '@/lib/i18n/format';
+import type { OperationOutcome } from './capabilityModel';
+
+export interface AgentSummaryCardProps {
+  preview: AgentPreviewDto;
+  name: string;
+  orgName: string | null;
+  /** Whether the agent will be created/saved enabled. Defaults to false — the
+   *  guided create flow always creates disabled (spec §4.6 step 1's footer). */
+  enabled?: boolean;
+  onEdit?: (section: 'purpose' | 'does' | 'safety') => void;
+}
+
+/** Which create-flow step (spec §4.6) owns each row's underlying setting. */
+type EditSection = 'purpose' | 'does' | 'safety';
+const ROW_SECTION: Record<
+  'runsWhen' | 'canRead' | 'mayPropose' | 'executesUnattended' | 'neverTouches' | 'limits' | 'approvers',
+  EditSection
+> = {
+  // Step 2 ("What it does"): triggers + the capability picker, including its
+  // always-on reads disclosure.
+  runsWhen: 'does',
+  canRead: 'does',
+  mayPropose: 'does',
+  // Step 3 ("Safety and oversight"): unattended-ceiling keys, protected
+  // resources, limits and recipients all live there.
+  executesUnattended: 'safety',
+  neverTouches: 'safety',
+  limits: 'safety',
+  approvers: 'safety',
+};
+
+/** Outcome -> badge tone, matching OperationRow.tsx's OUTCOME_TONE (duplicated
+ *  locally per CLAUDE.md's "helpers used by multiple files may be duplicated"
+ *  guidance — this component never imports from OperationRow, which expects
+ *  a full `AgentToolCatalogToolDto` operation, not `AgentPreviewDto`'s
+ *  server-evaluated summary shape). */
+const OUTCOME_TONE: Record<OperationOutcome, 'warning' | 'info' | 'danger'> = {
+  approval_request: 'warning',
+  logged_proposal: 'info',
+  unattended: 'danger',
+};
+
+/** `manage_startup_items` -> "Manage startup items" — last-resort label for a
+ *  tool/action this catalog namespace has no translation for yet. Mirrors
+ *  CapabilityPicker.tsx's own `sentenceCase`. */
+function sentenceCase(token: string): string {
+  const words = token.replace(/[_:-]+/g, ' ').trim();
+  return words.charAt(0).toUpperCase() + words.slice(1);
+}
+
+/** `'manage_services:restart'` -> `{ tool: 'manage_services', action: 'restart' }`; a bare entry -> `action: null`. */
+function splitOpKey(key: string): { tool: string; action: string | null } {
+  const colon = key.indexOf(':');
+  return colon === -1 ? { tool: key, action: null } : { tool: key.slice(0, colon), action: key.slice(colon + 1) };
+}
+
+function SummaryRow({
+  id,
+  label,
+  section,
+  onEdit,
+  editLabel,
+  children,
+}: {
+  id: string;
+  label: string;
+  section: EditSection;
+  onEdit?: (section: EditSection) => void;
+  editLabel: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="grid grid-cols-[180px_minmax(0,1fr)_60px] items-start gap-2 py-2" data-testid={`agent-summary-row-${id}`}>
+      <span className="text-sm font-medium text-muted-foreground">{label}</span>
+      <div className="text-sm">{children}</div>
+      <div className="text-right">
+        {onEdit && (
+          <button
+            type="button"
+            className="text-xs font-medium text-primary underline-offset-2 hover:underline focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+            onClick={() => onEdit(section)}
+            data-testid={`agent-summary-row-${id}-edit`}
+          >
+            {editLabel}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The four-step create flow's review card (spec §4.6 step 4) and the edit
+ * drawer's top-of-form summary. Renders `POST /ai/agents/preview`'s
+ * server-evaluated `AgentPreviewDto` verbatim — every number and outcome here
+ * came from the SAME guardrail/catalog helpers the run loop uses, so this
+ * card cannot drift from what create/update would actually enforce (that is
+ * the entire point of evaluating the draft server-side rather than
+ * re-deriving it from the picker's own client-side model).
+ *
+ * Deviation from the plan's literal "six exposed limits" list: `preview.limits`
+ * is `AiAgentLimits`, which has no `cooldownSeconds` field — cooldown is a
+ * sibling field on the agent's policy row (`AiAgentPolicy.cooldownSeconds`),
+ * never threaded through `buildAgentPreview` (agentPreview.ts). Task 12 is
+ * scoped to this file plus locales only, so the limits row below renders the
+ * five limits `AgentPreviewDto` actually carries; adding cooldown here would
+ * require widening `AgentPreviewDto`/`buildAgentPreview` in Task 11's files,
+ * which is out of scope for this task.
+ */
+export default function AgentSummaryCard({ preview, name, orgName, enabled = false, onEdit }: AgentSummaryCardProps) {
+  const { t } = useTranslation('settings');
+
+  const toolLabel = (toolName: string) =>
+    t(/* i18n-dynamic */ `aiAgentsPage.catalog.tools.${toolName}`, { defaultValue: sentenceCase(toolName) });
+  const actionLabel = (toolName: string, action: string | null) =>
+    action === null
+      ? toolLabel(toolName)
+      : t(/* i18n-dynamic */ `aiAgentsPage.catalog.actions.${toolName}.${action}`, { defaultValue: sentenceCase(action) });
+  /** Standalone (not tool-grouped) chip/list label: combines tool + action
+   *  since, unlike CapabilityPicker's nested rows, nothing else on this card
+   *  names the tool a bare action label belongs to. */
+  const opLabel = (key: string): string => {
+    const { tool, action } = splitOpKey(key);
+    return action === null ? toolLabel(tool) : `${toolLabel(tool)}: ${actionLabel(tool, action)}`;
+  };
+  const severityLabel = (severity: string) =>
+    t(/* i18n-dynamic */ `aiAgentsPage.severities.${severity}`, { defaultValue: sentenceCase(severity) });
+  const listFormat = (items: string[]): string =>
+    new Intl.ListFormat(resolvedFormattingLocale(), { style: 'long', type: 'conjunction' }).format(items);
+
+  const editLabel = t('aiAgentsPage.summary.edit');
+  const notInCeilingLabel = t('aiAgentsPage.catalog.notInCeiling');
+
+  // --- Title row ---
+  const kindLabel = t(/* i18n-dynamic */ `aiAgentsPage.kinds.${preview.kind}`, { defaultValue: sentenceCase(preview.kind) });
+  const modeLabel = t(/* i18n-dynamic */ `aiAgentsPage.modeChoice.${preview.mode}`, { defaultValue: sentenceCase(preview.mode) });
+
+  // --- Runs when ---
+  const runsWhenParts: string[] = [];
+  if (preview.kind === 'patch') runsWhenParts.push(t('aiAgentsPage.summary.runsWhen.patch'));
+  else if (preview.kind === 'helpdesk') runsWhenParts.push(t('aiAgentsPage.summary.runsWhen.helpdesk'));
+  else {
+    const severities = preview.triggers.alertSeverities.map(severityLabel);
+    runsWhenParts.push(
+      t('aiAgentsPage.summary.runsWhen.triage', {
+        severities: severities.length > 0 ? listFormat(severities) : t('aiAgentsPage.summary.runsWhen.anySeverity'),
+      }),
+    );
+  }
+  if (preview.triggers.respectMaintenanceWindows) runsWhenParts.push(t('aiAgentsPage.summary.runsWhen.maintenanceWindows'));
+  if (preview.triggers.ticketAutonomousWrites) runsWhenParts.push(t('aiAgentsPage.summary.runsWhen.ticketWrites'));
+  const runsWhenText = runsWhenParts.join(' ');
+
+  // --- Can read ---
+  const scope = orgName ?? t('aiAgentsPage.summary.allOrganizations');
+  const canReadText = t('aiAgentsPage.summary.canRead', { scope, count: preview.readOnlyToolCount });
+
+  // --- May propose ---
+  const mutatingOps = preview.operations;
+  const capabilitiesTouched = new Set(mutatingOps.map((op) => op.capability)).size;
+  const approvalRequests = mutatingOps.filter((op) => op.outcome === 'approval_request').length;
+  const loggedProposals = mutatingOps.filter((op) => op.outcome === 'logged_proposal').length;
+  const mayProposeText =
+    mutatingOps.length === 0
+      ? t('aiAgentsPage.summary.mayProposeNone')
+      : t('aiAgentsPage.summary.mayPropose', {
+          operations: mutatingOps.length,
+          capabilities: capabilitiesTouched,
+          approvalRequests,
+          loggedProposals,
+        });
+
+  // --- Executes unattended ---
+  const unattendedOps = mutatingOps.filter((op) => op.outcome === 'unattended');
+  const anyPreauthorized = mutatingOps.some((op) => op.preauthorized);
+  let executesUnattendedText: string;
+  if (preview.mode !== 'act') executesUnattendedText = t('aiAgentsPage.summary.executesUnattendedNone');
+  else if (unattendedOps.length === 0) executesUnattendedText = t('aiAgentsPage.summary.executesUnattendedNoneAct');
+  else executesUnattendedText = t('aiAgentsPage.summary.executesUnattendedList', { list: listFormat(unattendedOps.map((op) => opLabel(op.key))) });
+  if (anyPreauthorized) executesUnattendedText = `${executesUnattendedText} ${t('aiAgentsPage.summary.preauthorizedNote')}`;
+
+  // --- Never touches ---
+  const protectedChips = [
+    ...preview.protectedResources.services,
+    ...preview.protectedResources.paths,
+    ...preview.protectedResources.registryKeys,
+  ];
+
+  // --- Limits (deviation: cooldown omitted — see the docstring above) ---
+  const minutesPerRun = Math.round(preview.limits.wallClockSeconds / 60);
+  const dailyBudget = formatCurrency(preview.limits.maxBudgetCentsPerDay / 100);
+  const fleetPercent = formatPercent(preview.limits.maxFleetPercentPerDay / 100);
+  const limitsText = t('aiAgentsPage.summary.limits', {
+    devices: preview.limits.maxDevicesPerRun,
+    runsPerHour: preview.limits.maxRunsPerHour,
+    minutes: minutesPerRun,
+    budget: dailyBudget,
+    fleetPercent,
+  });
+
+  // --- Approvers ---
+  const approverCount = preview.recipients.roleIds.length;
+  const approversText = approverCount > 0 ? t('aiAgentsPage.summary.approvers', { count: approverCount }) : t('aiAgentsPage.summary.approversNone');
+
+  return (
+    <div className="rounded-lg border bg-card p-4" data-testid="agent-summary-card">
+      <div className="flex flex-wrap items-start justify-between gap-2 border-b pb-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-base font-semibold">{name}</span>
+          <span className={badgeClass('neutral', { size: 'sm' })} data-testid="agent-summary-kind">
+            {kindLabel}
+          </span>
+          <span className={badgeClass(orgName === null ? 'info' : 'neutral', { size: 'sm' })} data-testid="agent-summary-org">
+            {orgName ?? t('aiAgentsPage.allOrgs')}
+          </span>
+          <span className={badgeClass(modeTone(preview.mode), { size: 'sm' })} data-testid="agent-summary-mode">
+            {modeLabel}
+          </span>
+          <span className={badgeClass(enabled ? 'success' : 'muted', { size: 'sm' })} data-testid="agent-summary-enabled-pill">
+            {enabled ? t('aiAgentsPage.summary.enabled') : t('aiAgentsPage.summary.createdDisabled')}
+          </span>
+        </div>
+        {onEdit && (
+          <button
+            type="button"
+            className="text-xs font-medium text-primary underline-offset-2 hover:underline focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+            onClick={() => onEdit('purpose')}
+            data-testid="agent-summary-title-edit"
+          >
+            {editLabel}
+          </button>
+        )}
+      </div>
+
+      <div className="divide-y">
+        <SummaryRow id="runsWhen" label={t('aiAgentsPage.summary.rowLabels.runsWhen')} section={ROW_SECTION.runsWhen} onEdit={onEdit} editLabel={editLabel}>
+          {runsWhenText}
+        </SummaryRow>
+
+        <SummaryRow id="canRead" label={t('aiAgentsPage.summary.rowLabels.canRead')} section={ROW_SECTION.canRead} onEdit={onEdit} editLabel={editLabel}>
+          {canReadText}
+        </SummaryRow>
+
+        <SummaryRow id="mayPropose" label={t('aiAgentsPage.summary.rowLabels.mayPropose')} section={ROW_SECTION.mayPropose} onEdit={onEdit} editLabel={editLabel}>
+          <p>{mayProposeText}</p>
+          {mutatingOps.length > 0 && (
+            <ul className="mt-1.5 flex flex-wrap gap-1.5">
+              {mutatingOps.map((op) => (
+                <li key={op.key} className="flex items-center gap-1" data-testid={`agent-summary-chip-${op.key}`}>
+                  <span className={badgeClass(OUTCOME_TONE[op.outcome], { size: 'sm' })}>{opLabel(op.key)}</span>
+                  {!op.withinCeiling && <span className={badgeClass('muted', { size: 'sm' })}>{notInCeilingLabel}</span>}
+                </li>
+              ))}
+            </ul>
+          )}
+          {preview.unrecognised.length > 0 && (
+            <div className="mt-1.5" data-testid="agent-summary-unrecognised">
+              <p className="text-xs text-muted-foreground">{t('aiAgentsPage.summary.unrecognisedLabel')}</p>
+              <ul className="mt-1 flex flex-wrap gap-2">
+                {preview.unrecognised.map((entry) => (
+                  <li key={entry} className="font-mono text-xs text-muted-foreground" data-testid={`agent-summary-unrecognised-${entry}`}>
+                    {entry}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </SummaryRow>
+
+        <SummaryRow
+          id="executesUnattended"
+          label={t('aiAgentsPage.summary.rowLabels.executesUnattended')}
+          section={ROW_SECTION.executesUnattended}
+          onEdit={onEdit}
+          editLabel={editLabel}
+        >
+          {executesUnattendedText}
+        </SummaryRow>
+
+        <SummaryRow id="neverTouches" label={t('aiAgentsPage.summary.rowLabels.neverTouches')} section={ROW_SECTION.neverTouches} onEdit={onEdit} editLabel={editLabel}>
+          {protectedChips.length === 0 ? (
+            t('aiAgentsPage.summary.neverTouchesEmpty')
+          ) : (
+            <ul className="flex flex-wrap gap-1.5">
+              {protectedChips.map((entry) => (
+                <li key={entry} className="rounded-full border px-2 py-0.5 font-mono text-xs" data-testid={`agent-summary-never-touches-chip-${entry}`}>
+                  {entry}
+                </li>
+              ))}
+            </ul>
+          )}
+        </SummaryRow>
+
+        <SummaryRow id="limits" label={t('aiAgentsPage.summary.rowLabels.limits')} section={ROW_SECTION.limits} onEdit={onEdit} editLabel={editLabel}>
+          {limitsText}
+        </SummaryRow>
+
+        <SummaryRow id="approvers" label={t('aiAgentsPage.summary.rowLabels.approvers')} section={ROW_SECTION.approvers} onEdit={onEdit} editLabel={editLabel}>
+          {approversText}
+        </SummaryRow>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/aiAgents/AgentSummaryCard.tsx
+++ b/apps/web/src/components/settings/aiAgents/AgentSummaryCard.tsx
@@ -183,10 +183,15 @@ export default function AgentSummaryCard({ preview, name, orgName, enabled = fal
   if (anyPreauthorized) executesUnattendedText = `${executesUnattendedText} ${t('aiAgentsPage.summary.preauthorizedNote')}`;
 
   // --- Never touches ---
+  // Tagged with which list each entry came from: the three protected-resource
+  // lists are independent (a service name and a path can coincidentally be
+  // the same string), so a flat `entry` alone is not a stable React key or a
+  // unique test-id — two chips from different categories with the same value
+  // collided on both.
   const protectedChips = [
-    ...preview.protectedResources.services,
-    ...preview.protectedResources.paths,
-    ...preview.protectedResources.registryKeys,
+    ...preview.protectedResources.services.map((entry) => ({ category: 'services', entry })),
+    ...preview.protectedResources.paths.map((entry) => ({ category: 'paths', entry })),
+    ...preview.protectedResources.registryKeys.map((entry) => ({ category: 'registryKeys', entry })),
   ];
 
   // --- Limits (six exposed limits: the five in `limits` plus the sibling `cooldownSeconds`) ---
@@ -287,8 +292,12 @@ export default function AgentSummaryCard({ preview, name, orgName, enabled = fal
             t('aiAgentsPage.summary.neverTouchesEmpty')
           ) : (
             <ul className="flex flex-wrap gap-1.5">
-              {protectedChips.map((entry) => (
-                <li key={entry} className="rounded-full border px-2 py-0.5 font-mono text-xs" data-testid={`agent-summary-never-touches-chip-${entry}`}>
+              {protectedChips.map(({ category, entry }) => (
+                <li
+                  key={`${category}-${entry}`}
+                  className="rounded-full border px-2 py-0.5 font-mono text-xs"
+                  data-testid={`agent-summary-never-touches-chip-${category}-${entry}`}
+                >
                   {entry}
                 </li>
               ))}

--- a/apps/web/src/components/settings/aiAgents/ModeChoice.test.tsx
+++ b/apps/web/src/components/settings/aiAgents/ModeChoice.test.tsx
@@ -88,4 +88,19 @@ describe('ModeChoice (Task 13, #5051 — extracted from AiAgentForm)', () => {
     expect(screen.getByTestId('ai-agent-mode-off')).toHaveAttribute('tabindex', '0');
     expect(screen.getByTestId('ai-agent-mode-act')).toHaveAttribute('tabindex', '-1');
   });
+
+  // Moved from AiAgentForm.test.tsx (Task 10, #5051 review): this asserts the
+  // component's own layout, not anything specific to the drawer that used to
+  // be the only place it was tested through — the guided create flow's
+  // PurposeStep renders the identical control.
+  it('top-aligns the option cards so the three labels share a baseline', () => {
+    // A <button>'s content box is vertically centred by the UA stylesheet, so
+    // three cards of unequal height put their labels on three different lines.
+    setup();
+    for (const mode of ['off', 'shadow', 'act']) {
+      const card = screen.getByTestId(`ai-agent-mode-${mode}`);
+      expect(card.className).toContain('flex-col');
+      expect(card.className).toContain('items-start');
+    }
+  });
 });

--- a/apps/web/src/components/settings/aiAgents/ModeChoice.test.tsx
+++ b/apps/web/src/components/settings/aiAgents/ModeChoice.test.tsx
@@ -1,0 +1,91 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import ModeChoice from './ModeChoice';
+
+function setup(overrides: Partial<Parameters<typeof ModeChoice>[0]> = {}) {
+  const onChange = vi.fn();
+  const onActAckChange = vi.fn();
+  const props = {
+    mode: 'shadow' as const,
+    onChange,
+    actSupported: true,
+    enteringActMode: false,
+    actAck: false,
+    onActAckChange,
+    actKeysWillBeOmitted: false,
+    ...overrides,
+  };
+  render(<ModeChoice {...props} />);
+  return { onChange, onActAckChange };
+}
+
+describe('ModeChoice (Task 13, #5051 — extracted from AiAgentForm)', () => {
+  it('renders the three-option radiogroup and reports a click as onChange', () => {
+    const { onChange } = setup();
+    expect(screen.getByTestId('ai-agent-mode-shadow')).toHaveAttribute('aria-checked', 'true');
+    fireEvent.click(screen.getByTestId('ai-agent-mode-act'));
+    expect(onChange).toHaveBeenCalledWith('act');
+  });
+
+  it('disables the act card and explains why when actSupported is false', () => {
+    setup({ actSupported: false });
+    expect(screen.getByTestId('ai-agent-mode-act')).toBeDisabled();
+    expect(screen.getByTestId('ai-agent-mode-act-unavailable')).toBeInTheDocument();
+  });
+
+  it('shows the act warning only in act mode, and the acknowledgement only when entering it', () => {
+    const { rerender } = render(
+      <ModeChoice mode="shadow" onChange={vi.fn()} actSupported enteringActMode={false} actAck={false} onActAckChange={vi.fn()} actKeysWillBeOmitted={false} />,
+    );
+    expect(screen.queryByTestId('ai-agent-act-warning')).toBeNull();
+
+    rerender(
+      <ModeChoice mode="act" onChange={vi.fn()} actSupported enteringActMode={false} actAck={false} onActAckChange={vi.fn()} actKeysWillBeOmitted={false} />,
+    );
+    expect(screen.getByTestId('ai-agent-act-warning')).toBeInTheDocument();
+    expect(screen.queryByTestId('ai-agent-act-ack')).toBeNull();
+
+    rerender(
+      <ModeChoice mode="act" onChange={vi.fn()} actSupported enteringActMode actAck={false} onActAckChange={vi.fn()} actKeysWillBeOmitted={false} />,
+    );
+    expect(screen.getByTestId('ai-agent-act-ack')).not.toBeChecked();
+  });
+
+  it('resets the acknowledgement (onActAckChange(false)) when leaving act mode', () => {
+    const { onActAckChange, onChange } = setup({ mode: 'act', actAck: true });
+    fireEvent.click(screen.getByTestId('ai-agent-mode-shadow'));
+    expect(onActAckChange).toHaveBeenCalledWith(false);
+    expect(onChange).toHaveBeenCalledWith('shadow');
+  });
+
+  it('does not touch the acknowledgement when entering act mode', () => {
+    const { onActAckChange } = setup({ mode: 'off' });
+    fireEvent.click(screen.getByTestId('ai-agent-mode-act'));
+    expect(onActAckChange).not.toHaveBeenCalled();
+  });
+
+  it('mounts the act-keys status region unconditionally, gating only its text', () => {
+    const { rerender } = render(
+      <ModeChoice mode="shadow" onChange={vi.fn()} actSupported enteringActMode={false} actAck={false} onActAckChange={vi.fn()} actKeysWillBeOmitted={false} />,
+    );
+    expect(screen.getByTestId('ai-agent-act-keys-cleared')).toHaveTextContent('');
+
+    rerender(
+      <ModeChoice mode="shadow" onChange={vi.fn()} actSupported enteringActMode={false} actAck={false} onActAckChange={vi.fn()} actKeysWillBeOmitted />,
+    );
+    expect(screen.getByTestId('ai-agent-act-keys-cleared').textContent).not.toBe('');
+  });
+
+  it('moves the roving tab stop and selection with arrow keys, wrapping at both ends', () => {
+    const { onChange } = setup({ mode: 'off' });
+    const offCard = screen.getByTestId('ai-agent-mode-off');
+    fireEvent.keyDown(offCard, { key: 'ArrowLeft' });
+    expect(onChange).toHaveBeenCalledWith('act'); // wraps backward from the first option
+  });
+
+  it('falls back the roving tab stop to the first enabled option when the checked option is itself disabled', () => {
+    setup({ mode: 'act', actSupported: false });
+    expect(screen.getByTestId('ai-agent-mode-off')).toHaveAttribute('tabindex', '0');
+    expect(screen.getByTestId('ai-agent-mode-act')).toHaveAttribute('tabindex', '-1');
+  });
+});

--- a/apps/web/src/components/settings/aiAgents/ModeChoice.tsx
+++ b/apps/web/src/components/settings/aiAgents/ModeChoice.tsx
@@ -1,0 +1,276 @@
+import { useId, useRef, type KeyboardEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+import { AlertTriangle } from 'lucide-react';
+import type { AiAgentMode } from '@breeze/shared';
+
+/**
+ * Task 13 (#5051): extracted verbatim from `AiAgentForm.tsx` (a pure move —
+ * every test id, class name and copy key is unchanged) so the four-step
+ * guided create flow's `PurposeStep` can render the identical Mode choice the
+ * edit drawer always has. `actAck`/`enteringActMode` stay owned by the
+ * caller: both drive that caller's OWN Save/Next gating (`AiAgentForm`'s Save
+ * button, `PurposeStep`'s "leave this step" gate), so lifting them here would
+ * make this component reach back out through a second channel for exactly
+ * the value it already receives as a prop.
+ */
+
+const MODE_ORDER: readonly AiAgentMode[] = ['off', 'shadow', 'act'];
+
+export interface ModeChoiceProps {
+  mode: AiAgentMode;
+  onChange: (mode: AiAgentMode) => void;
+  /** Whether this owner/agent may use act mode at all — the CREATE path has
+   *  no `agent` DTO to read `supportedModes` off of, so the caller falls back
+   *  to the shared `SUPPORTED_AGENT_MODES` constant, never `[]`. */
+  actSupported: boolean;
+  /** A genuine transition INTO act mode (captured once at mount by the
+   *  caller) — only then does the acknowledgement checkbox appear. */
+  enteringActMode: boolean;
+  actAck: boolean;
+  onActAckChange: (checked: boolean) => void;
+  /** Riley bug (#4187 UI critique): whether leaving act will omit this
+   *  draft's supervisedActionKeys from the save payload — a derived flag
+   *  the caller computes from its OWN draft shape (ownerScope/mode/keys), so
+   *  the announcement can never drift from what Save will actually send. */
+  actKeysWillBeOmitted: boolean;
+}
+
+/** The mode radiogroup: the only choice on the form that can reach a device,
+ *  rendered first, above Kind and Name in both the edit drawer and the
+ *  guided create flow's Purpose step. */
+export default function ModeChoice({
+  mode,
+  onChange,
+  actSupported,
+  enteringActMode,
+  actAck,
+  onActAckChange,
+  actKeysWillBeOmitted,
+}: ModeChoiceProps) {
+  const { t } = useTranslation('settings');
+  const modeHeadingId = useId();
+  const modeRefs = useRef<Partial<Record<AiAgentMode, HTMLButtonElement | null>>>({});
+  const modeUnavailable = (candidate: AiAgentMode) => candidate === 'act' && !actSupported;
+
+  // Literal keys rather than a dynamic `t()` on the token: the closed
+  // three-member union is worth spelling out so the keyUsage guard verifies
+  // every label statically (same reason as AiAgentSchedulesSection's
+  // `scheduleKindLabel`).
+  const MODE_LABEL: Record<AiAgentMode, string> = {
+    off: t('aiAgentsPage.modeChoice.off'),
+    shadow: t('aiAgentsPage.modeChoice.shadow'),
+    act: t('aiAgentsPage.modeChoice.act'),
+  };
+  const MODE_CONSEQUENCE: Record<AiAgentMode, string> = {
+    off: t('aiAgentsPage.modeChoice.offConsequence'),
+    shadow: t('aiAgentsPage.modeChoice.shadowConsequence'),
+    act: t('aiAgentsPage.modeChoice.actConsequence'),
+  };
+
+  const selectMode = (next: AiAgentMode) => {
+    if (modeUnavailable(next) || next === mode) return;
+    if (next === 'act') {
+      onChange(next);
+      return;
+    }
+    // Leaving act: only the acknowledgement belongs to act mode alone — a
+    // genuine re-entry must ask again. `supervisedActionKeys` is NOT
+    // cleared here: it stays in the draft so a later return to act restores
+    // the operator's selection (the caller's save-body builder is what keeps
+    // them out of effect while the mode isn't act).
+    onActAckChange(false);
+    onChange(next);
+  };
+
+  /** Roving-tabindex arrow navigation, per the radiogroup pattern: the group
+   *  holds one tab stop and the arrows move BOTH focus and selection.
+   *
+   *  The starting point is the option that HAS FOCUS (read off the event
+   *  target's `data-mode`), never the controlled `mode`. The two are normally
+   *  the same — that is the roving contract — but they can diverge for one
+   *  keystroke, and they did: the drawer's initial focus used to land on a
+   *  `tabindex="-1"` card, so ArrowRight from Off (with Shadow selected)
+   *  stepped from SHADOW and selected `act`, skipping the option the user was
+   *  actually looking at. Deriving from focus makes the two impossible to
+   *  disagree. */
+  const onModeKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    const selectable = MODE_ORDER.filter((candidate) => !modeUnavailable(candidate));
+    if (selectable.length === 0) return;
+    const focused = (event.target as HTMLElement | null)?.dataset?.mode as AiAgentMode | undefined;
+    // Falls back to the selected option when the key came from the group
+    // itself rather than from one of its cards.
+    const from = focused && selectable.includes(focused) ? focused : mode;
+    const current = Math.max(0, selectable.indexOf(from));
+    let target: number;
+    switch (event.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+        target = (current + 1) % selectable.length;
+        break;
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        target = (current - 1 + selectable.length) % selectable.length;
+        break;
+      case 'Home':
+        target = 0;
+        break;
+      case 'End':
+        target = selectable.length - 1;
+        break;
+      default:
+        return;
+    }
+    event.preventDefault();
+    const next = selectable[target];
+    if (!next) return;
+    selectMode(next);
+    modeRefs.current[next]?.focus();
+  };
+
+  // Roving-tabindex tab stop. Normally the checked option, but a stale row
+  // can have `mode` set to an option that is now disabled (an agent saved
+  // while `act` was supported, whose partner later lost act eligibility,
+  // still stores `mode: 'act'`) — falling back to the first ENABLED option
+  // keeps the group reachable by Tab at all, rather than leaving every radio
+  // at tabIndex -1.
+  const tabStopMode = modeUnavailable(mode) ? MODE_ORDER.find((candidate) => !modeUnavailable(candidate)) : mode;
+
+  return (
+    <div className="md:col-span-2" data-testid="ai-agent-mode-field">
+      <h3 id={modeHeadingId} className="text-sm font-semibold">
+        {t('aiAgentsPage.modeChoice.legend')}
+      </h3>
+      <div
+        role="radiogroup"
+        aria-labelledby={modeHeadingId}
+        onKeyDown={onModeKeyDown}
+        className="mt-2 grid gap-2 sm:grid-cols-3"
+        data-testid="ai-agent-mode"
+      >
+        {MODE_ORDER.map((candidate) => {
+          const selected = mode === candidate;
+          const unavailable = modeUnavailable(candidate);
+          return (
+            <button
+              key={candidate}
+              type="button"
+              role="radio"
+              aria-checked={selected}
+              disabled={unavailable}
+              tabIndex={candidate === tabStopMode ? 0 : -1}
+              ref={(node) => {
+                modeRefs.current[candidate] = node;
+              }}
+              onClick={() => selectMode(candidate)}
+              // Read by `onModeKeyDown` to find which card the keystroke came
+              // from — the roving group's arrow keys must step from the FOCUSED
+              // option, not from the stored one.
+              data-mode={candidate}
+              // Act selected does NOT look like Off/Shadow selected. All three
+              // shared one primary-blue ring, so the one card that authorizes
+              // unattended changes on a customer machine read as no more
+              // consequential than "do nothing" — the warning tone is the same
+              // one the act warning panel and its icon already use.
+              // `flex flex-col items-start` overrides the UA stylesheet's
+              // vertical centring of a <button>'s content box. The three cards
+              // stretch to a common height in the grid but carry consequence
+              // lines of different lengths, so centred content put the three
+              // option NAMES on three different baselines — the one line a
+              // reader scans across before choosing.
+              className={`flex flex-col items-start rounded-lg border p-3 text-left transition-colors focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60 ${
+                selected
+                  ? candidate === 'act'
+                    ? 'border-warning-strong bg-warning/10 ring-1 ring-warning-strong'
+                    : 'border-primary bg-primary/10 ring-1 ring-primary'
+                  : 'bg-background hover:border-primary/50 hover:bg-muted/40'
+              }`}
+              data-testid={`ai-agent-mode-${candidate}`}
+            >
+              {/* `w-full`: the card is now a flex COLUMN with `items-start`,
+                  which shrinks its children to their content width — without
+                  this the act card's `ml-auto` warning icon would sit against
+                  the label instead of the card's right edge. */}
+              <span className="flex w-full items-center gap-2">
+                {/* Selection is encoded by SHAPE (a filled ring) as well as by
+                    colour, so the choice survives a colourblind read. */}
+                <span
+                  aria-hidden="true"
+                  className={`flex h-4 w-4 shrink-0 items-center justify-center rounded-full border ${
+                    selected
+                      ? candidate === 'act' ? 'border-warning-strong' : 'border-primary'
+                      : 'border-muted-foreground/50'
+                  }`}
+                >
+                  {selected && (
+                    <span
+                      className={`h-2 w-2 rounded-full ${candidate === 'act' ? 'bg-warning-strong' : 'bg-primary'}`}
+                    />
+                  )}
+                </span>
+                <span className="text-sm font-medium">{MODE_LABEL[candidate]}</span>
+                {candidate === 'act' && (
+                  <AlertTriangle className="ml-auto h-4 w-4 shrink-0 text-warning-strong" aria-hidden="true" />
+                )}
+              </span>
+              <span className="mt-1.5 block text-xs text-muted-foreground">
+                {MODE_CONSEQUENCE[candidate]}
+              </span>
+              {unavailable && (
+                <span
+                  className="mt-1.5 block text-xs text-muted-foreground"
+                  data-testid="ai-agent-mode-act-unavailable"
+                >
+                  {t('aiAgentsPage.modeChoice.actUnavailable')}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Attached to the choice, not floated below the rest of the fields:
+          the warning and its acknowledgement are what the act card MEANS. */}
+      {mode === 'act' && (
+        <div
+          className="mt-2 space-y-2 rounded-lg border border-warning-strong/50 bg-warning/10 p-3 text-sm"
+          data-testid="ai-agent-act-warning"
+        >
+          <p className="flex items-start gap-2 font-medium">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-warning-strong" aria-hidden="true" />
+            <span>{t('aiAgentsPage.actWarning.title')}</span>
+          </p>
+          <ul className="list-disc space-y-1 pl-5 text-muted-foreground">
+            <li>{t('aiAgentsPage.actWarning.unattended')}</li>
+            <li>{t('aiAgentsPage.actWarning.verification')}</li>
+            <li>{t('aiAgentsPage.actWarning.noRollback')}</li>
+            <li>{t('aiAgentsPage.actWarning.singleDevice')}</li>
+            <li>{t('aiAgentsPage.actWarning.actionCap')}</li>
+          </ul>
+          {enteringActMode && (
+            <label className="flex items-start gap-2 pt-1 text-sm font-medium">
+              <input
+                type="checkbox"
+                checked={actAck}
+                onChange={(e) => onActAckChange(e.target.checked)}
+                data-testid="ai-agent-act-ack"
+              />
+              <span>{t('aiAgentsPage.actWarning.ack')}</span>
+            </label>
+          )}
+        </div>
+      )}
+
+      {/* Mounted UNCONDITIONALLY — only the text toggles. An aria-live
+          region (`role="status"`) only announces changes to content that was
+          already present in the accessibility tree; mounting it on demand
+          meant the FIRST thing it ever had to say was never announced. */}
+      <p
+        className="mt-2 text-xs text-muted-foreground"
+        role="status"
+        data-testid="ai-agent-act-keys-cleared"
+      >
+        {actKeysWillBeOmitted ? t('aiAgentsPage.fields.actKeysCleared') : ''}
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/aiAgents/PolicyKeysCheckboxes.test.tsx
+++ b/apps/web/src/components/settings/aiAgents/PolicyKeysCheckboxes.test.tsx
@@ -1,0 +1,57 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import PolicyKeysCheckboxes, { policyActionLabel, sentenceCase, type PolicyDecidableKeyOption } from './PolicyKeysCheckboxes';
+
+const REGISTRY: PolicyDecidableKeyOption[] = [
+  { key: 'manage_services:restart', toolName: 'manage_services', action: 'restart', note: 'Restarts a service.' },
+  { key: 'manage_services:stop', toolName: 'manage_services', action: 'stop', note: 'Stops a service.' },
+];
+
+describe('PolicyKeysCheckboxes (Task 13, #5051 — extracted from AiAgentForm)', () => {
+  it('shows a failure message when the registry could not be loaded', () => {
+    render(<PolicyKeysCheckboxes policyKeys={[]} policyKeysFailed selectedKeys={[]} onToggle={vi.fn()} />);
+    expect(screen.getByTestId('ai-agent-policy-keys-failed')).toBeInTheDocument();
+  });
+
+  it('shows an empty message when the registry is empty and not a failure', () => {
+    render(<PolicyKeysCheckboxes policyKeys={[]} policyKeysFailed={false} selectedKeys={[]} onToggle={vi.fn()} />);
+    expect(screen.getByTestId('ai-agent-policy-keys-empty')).toBeInTheDocument();
+  });
+
+  it('groups entries by tool, reflects the selection, and reports a toggle by key', () => {
+    const onToggle = vi.fn();
+    render(<PolicyKeysCheckboxes policyKeys={REGISTRY} policyKeysFailed={false} selectedKeys={['manage_services:restart']} onToggle={onToggle} />);
+
+    expect(screen.getByTestId('ai-agent-supervised-key-manage_services:restart')).toBeChecked();
+    expect(screen.getByTestId('ai-agent-supervised-key-manage_services:stop')).not.toBeChecked();
+
+    fireEvent.click(screen.getByTestId('ai-agent-supervised-key-manage_services:stop'));
+    expect(onToggle).toHaveBeenCalledWith('manage_services:stop');
+  });
+
+  it('wires the registry note as the checkbox\'s accessible description', () => {
+    render(<PolicyKeysCheckboxes policyKeys={REGISTRY} policyKeysFailed={false} selectedKeys={[]} onToggle={vi.fn()} />);
+    const checkbox = screen.getByTestId('ai-agent-supervised-key-manage_services:restart');
+    const describedBy = checkbox.getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+    expect(document.getElementById(describedBy!)).toHaveTextContent('Restarts a service.');
+  });
+});
+
+describe('sentenceCase / policyActionLabel', () => {
+  it('sentence-cases a raw token', () => {
+    expect(sentenceCase('manage_startup_items')).toBe('Manage startup items');
+  });
+
+  it('falls back to the sentence-cased action when no translation exists, via a plain t function', () => {
+    const t = (_key: string, opts?: Record<string, unknown>) => (opts?.defaultValue as string) ?? _key;
+    const label = policyActionLabel(t, { key: 'manage_services:restart', toolName: 'manage_services', action: 'restart', note: '' });
+    expect(label).toBe('Restart');
+  });
+
+  it('a bare-tool entry (action: null) reads as the tool label', () => {
+    const t = (_key: string, opts?: Record<string, unknown>) => (opts?.defaultValue as string) ?? _key;
+    const label = policyActionLabel(t, { key: 'manage_services', toolName: 'manage_services', action: null, note: '' });
+    expect(label).toBe('Manage services');
+  });
+});

--- a/apps/web/src/components/settings/aiAgents/PolicyKeysCheckboxes.tsx
+++ b/apps/web/src/components/settings/aiAgents/PolicyKeysCheckboxes.tsx
@@ -1,5 +1,6 @@
 import { useId } from 'react';
 import { useTranslation } from 'react-i18next';
+import type { AiAgentMode, AiAgentOwnerScope } from '@breeze/shared';
 
 /**
  * Task 13 (#5051): extracted from `AiAgentForm.tsx` (a pure move — every test
@@ -83,6 +84,29 @@ export function policyActionLabel(t: TranslateFn, entry: PolicyDecidableKeyOptio
     : t(/* i18n-dynamic */ `aiAgentsPage.policyKeys.actions.${entry.toolName}.${entry.action}`, {
       defaultValue: sentenceCase(entry.action),
     });
+}
+
+/**
+ * A partner row's registry is collapsed behind a native `<details>` while the
+ * row is NOT acting — placed below Permissions rather than above it, since
+ * these checkboxes refine the tool allowlist Permissions already sets, not
+ * precede it. The summary counts the selection rather than repeating the
+ * full ceiling explanation (still given underneath, once opened), so a
+ * shadow-mode baseline reads as one scannable line instead of a checkbox
+ * list that authorizes nothing on its own from this row. The moment the row
+ * enters act mode the list is unwrapped entirely (not just opened) — that is
+ * the one mode where THIS row's own dispatch can be gated by these keys, so
+ * it earns the same plain treatment an org row always gets; the ceiling
+ * caveat still prints beneath it as a fact that survives the mode, not as
+ * something act mode makes disappear.
+ *
+ * Shared between `AiAgentForm.tsx` (the edit drawer) and `SafetyStep.tsx`
+ * (the guided create flow's Safety step, partner drafts only) so the two
+ * surfaces can never disagree on when a partner row's registry is worth
+ * collapsing.
+ */
+export function collapsedForCeiling(ownerScope: AiAgentOwnerScope, mode: AiAgentMode): boolean {
+  return ownerScope === 'partner' && mode !== 'act';
 }
 
 export interface PolicyKeysCheckboxesProps {

--- a/apps/web/src/components/settings/aiAgents/PolicyKeysCheckboxes.tsx
+++ b/apps/web/src/components/settings/aiAgents/PolicyKeysCheckboxes.tsx
@@ -1,0 +1,155 @@
+import { useId } from 'react';
+import { useTranslation } from 'react-i18next';
+
+/**
+ * Task 13 (#5051): extracted from `AiAgentForm.tsx` (a pure move — every test
+ * id and translation key is unchanged) so the guided create flow's
+ * `SafetyStep` can render the identical interactive registry a partner draft
+ * gets in the edit drawer. Org rows never render this component in either
+ * caller: an org row's keys are grant-only (spec §4.4), so `AiAgentForm.tsx`
+ * renders its own read-only held-keys list instead (`orgHeldKeysList`), and
+ * the guided create flow shows nothing at all for an org draft (there is
+ * nothing held yet to show).
+ */
+
+/** GET /ai/agents/policy-decidable-keys — the read-only POLICY_DECIDABLE_TIER3
+ *  registry (wave 5 Part B, #3827). `note` is the server's one-sentence
+ *  description of what the operation actually does; it is rendered as the
+ *  checkbox's description below. */
+export interface PolicyDecidableKeyOption {
+  key: string;
+  toolName: string;
+  action: string | null;
+  note: string;
+}
+
+/**
+ * `manage_startup_items` -> "Manage startup items". Last-resort label for a
+ * registry key this catalog has no translation for: the registry is
+ * server-owned, so a key can ship in an API build before the web catalog
+ * knows it, and the operator must still read words rather than an identifier.
+ * Deliberately silent — a missing translation is a catalog gap to fix in the
+ * next extraction pass, not a runtime fault worth a console line on every
+ * render of this form.
+ */
+export function sentenceCase(token: string): string {
+  const words = token.replace(/[_:-]+/g, ' ').trim();
+  return words.charAt(0).toUpperCase() + words.slice(1);
+}
+
+/** `manage_services:restart` -> `manage_services-restart`, so the key can be
+ *  spliced into a DOM id (`aria-describedby` takes an id list, and a colon in
+ *  an id is legal HTML but a syntax error in any selector that reads it). */
+function idSafe(key: string): string {
+  return key.replace(/[^A-Za-z0-9_-]+/g, '-');
+}
+
+/** Groups registry entries by `toolName`, preserving the server's ordering
+ *  within each group (policyDecidable.ts orders entries deliberately — see
+ *  its module doc). */
+function groupByTool(entries: PolicyDecidableKeyOption[]): Map<string, PolicyDecidableKeyOption[]> {
+  const groups = new Map<string, PolicyDecidableKeyOption[]>();
+  for (const entry of entries) {
+    const list = groups.get(entry.toolName);
+    if (list) list.push(entry);
+    else groups.set(entry.toolName, [entry]);
+  }
+  return groups;
+}
+
+/** Minimal shape of react-i18next's `t` this module needs — kept local so
+ *  `policyToolLabel`/`policyActionLabel` stay usable from a plain function
+ *  (AiAgentForm.tsx's `orgHeldKeysList`) without importing react-i18next's
+ *  own generic `TFunction` type. */
+type TranslateFn = (key: string, options?: Record<string, unknown>) => string;
+
+/** Registry tool -> translated group heading, falling back to the
+ *  sentence-cased token (see `sentenceCase`). */
+export function policyToolLabel(t: TranslateFn, toolName: string): string {
+  return t(/* i18n-dynamic */ `aiAgentsPage.policyKeys.tools.${toolName}`, {
+    defaultValue: sentenceCase(toolName),
+  });
+}
+
+/** Registry entry -> translated operation label. Scoped by tool, because the
+ *  bare action verb is ambiguous across the registry: "disable" appears
+ *  against a startup item and a scheduled task, "enable" likewise, and a
+ *  checkbox list of bare verbs cannot say which object it authorizes. A
+ *  bare-tool entry (`action: null`) has no verb of its own, so it reads as
+ *  the tool. */
+export function policyActionLabel(t: TranslateFn, entry: PolicyDecidableKeyOption): string {
+  return entry.action === null
+    ? policyToolLabel(t, entry.toolName)
+    : t(/* i18n-dynamic */ `aiAgentsPage.policyKeys.actions.${entry.toolName}.${entry.action}`, {
+      defaultValue: sentenceCase(entry.action),
+    });
+}
+
+export interface PolicyKeysCheckboxesProps {
+  policyKeys: PolicyDecidableKeyOption[];
+  policyKeysFailed: boolean;
+  selectedKeys: string[];
+  onToggle: (key: string) => void;
+}
+
+/** The registry checkboxes, grouped by tool with translated labels — the
+ *  interactive rendering, reached only for a PARTNER row (an org row's own
+ *  read-only or "nothing to show" rendering lives with its caller). */
+export default function PolicyKeysCheckboxes({ policyKeys, policyKeysFailed, selectedKeys, onToggle }: PolicyKeysCheckboxesProps) {
+  const { t } = useTranslation('settings');
+  const policyKeyNoteBaseId = useId();
+
+  if (policyKeysFailed) {
+    return (
+      <p className="text-sm text-destructive" data-testid="ai-agent-policy-keys-failed">
+        {t('aiAgentsPage.fields.supervisedActionKeysFailed')}
+      </p>
+    );
+  }
+  if (policyKeys.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground" data-testid="ai-agent-policy-keys-empty">
+        {t('aiAgentsPage.fields.supervisedActionKeysEmpty')}
+      </p>
+    );
+  }
+  return (
+    <div className="space-y-3">
+      {[...groupByTool(policyKeys).entries()].map(([toolName, entries]) => (
+        <div key={toolName}>
+          <p className="text-xs font-semibold">{policyToolLabel(t, toolName)}</p>
+          <div className="space-y-1.5">
+            {entries.map((entry) => {
+              // `idSafe`: a colon in `manage_services:restart` is a legal DOM
+              // id character but a syntax error in a CSS/query selector, so
+              // the registry key can't be spliced into the id raw.
+              const noteId = `${policyKeyNoteBaseId}-${idSafe(entry.key)}`;
+              return (
+                <label key={entry.key} className="flex items-start gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    className="mt-0.5"
+                    checked={selectedKeys.includes(entry.key)}
+                    onChange={() => onToggle(entry.key)}
+                    aria-describedby={noteId}
+                    data-testid={`ai-agent-supervised-key-${entry.key}`}
+                  />
+                  <span>
+                    <span className="block">{policyActionLabel(t, entry)}</span>
+                    {/* The registry's own one-sentence description of what the
+                        operation actually does — wired as the checkbox's
+                        accessible description, not just adjacent text, so a
+                        screen reader announces it as part of the control. */}
+                    <span id={noteId} className="block text-xs text-muted-foreground">
+                      {entry.note}
+                    </span>
+                  </span>
+                </label>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/aiAgents/agentDraft.test.ts
+++ b/apps/web/src/components/settings/aiAgents/agentDraft.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from 'vitest';
+import { AI_AGENT_LIMIT_DEFAULTS } from '@breeze/shared';
+import {
+  ALERT_SEVERITY_KINDS,
+  buildAgentSaveBody,
+  draftFrom,
+  firstFreeKind,
+  freeKinds,
+  lines,
+  toggle,
+  type Draft,
+} from './agentDraft';
+
+/**
+ * Task 13 (#5051), order-of-work step 1: this file pins `buildAgentSaveBody`'s
+ * output for a partner draft and an org draft, so a future edit to either
+ * `AiAgentForm.tsx`'s drawer or `AgentCreateFlow.tsx`'s guided flow cannot
+ * silently diverge the two POST/PATCH bodies — the whole point of extracting
+ * this module (spec §4.6).
+ */
+
+function baseDraft(overrides: Partial<Draft> = {}): Draft {
+  return {
+    ownerScope: 'organization',
+    kind: 'triage',
+    name: 'Triage bot',
+    enabled: false,
+    mode: 'shadow',
+    severities: ['critical', 'high'],
+    respectMaintenanceWindows: true,
+    toolAllowlist: 'manage_services:restart\nrun_script',
+    services: 'spooler',
+    paths: '',
+    registryKeys: '',
+    limits: { ...AI_AGENT_LIMIT_DEFAULTS },
+    cooldownSeconds: 900,
+    roleIds: ['role-1'],
+    instructions: '',
+    supervisedActionKeys: [],
+    ticketAutonomousWrites: false,
+    ...overrides,
+  };
+}
+
+describe('lines', () => {
+  it('trims, drops blanks and de-duplicates', () => {
+    expect(lines(' a \n\nb\na \n')).toEqual(['a', 'b']);
+  });
+});
+
+describe('toggle', () => {
+  it('adds a value not present and removes one that is', () => {
+    expect(toggle(['a'], 'b')).toEqual(['a', 'b']);
+    expect(toggle(['a', 'b'], 'a')).toEqual(['b']);
+  });
+});
+
+describe('freeKinds / firstFreeKind', () => {
+  const agents = [
+    { id: 'p1', kind: 'triage' as const, ownerScope: 'partner' as const, orgId: null },
+    { id: 'o1', kind: 'patch' as const, ownerScope: 'organization' as const, orgId: 'org-1' },
+  ] as unknown as Parameters<typeof freeKinds>[0];
+
+  it('excludes a kind already taken on the SAME ownership axis, independently per axis', () => {
+    expect(freeKinds(agents, 'partner', 'org-1')).toEqual(['patch', 'helpdesk']);
+    expect(freeKinds(agents, 'organization', 'org-1')).toEqual(['triage', 'helpdesk']);
+    expect(firstFreeKind(agents, 'partner', 'org-1')).toBe('patch');
+  });
+
+  it('never lets one org own a kind another org already owns', () => {
+    expect(freeKinds(agents, 'organization', 'org-2')).toEqual(['triage', 'patch', 'helpdesk']);
+  });
+});
+
+describe('draftFrom', () => {
+  it('defaults a create draft to shadow mode, switched off, with the given owner scope and kind', () => {
+    const draft = draftFrom(null, { ownerScope: 'partner', kind: 'patch' });
+    expect(draft.ownerScope).toBe('partner');
+    expect(draft.kind).toBe('patch');
+    expect(draft.mode).toBe('shadow');
+    expect(draft.enabled).toBe(false);
+    expect(draft.severities).toEqual(['critical', 'high']);
+    expect(draft.cooldownSeconds).toBe(900);
+  });
+
+  it('drops a stored severity the shared ALERT_SEVERITIES no longer recognises, rather than crashing', () => {
+    const draft = draftFrom(
+      {
+        kind: 'triage',
+        ownerScope: 'organization',
+        orgId: 'org-1',
+        triggers: { alertSeverities: ['critical', 'not_a_real_severity'] },
+      } as never,
+      { ownerScope: 'organization', kind: 'triage' },
+    );
+    expect(draft.severities).toEqual(['critical']);
+  });
+});
+
+describe('buildAgentSaveBody', () => {
+  it('pins the PARTNER draft body: create-only kind/ownerScope, no orgId, live actAssets', () => {
+    const draft = baseDraft({ ownerScope: 'partner', mode: 'act', supervisedActionKeys: ['manage_services:restart'] });
+    const body = buildAgentSaveBody(draft, { isCreate: true, orgId: null });
+    expect(body).toEqual({
+      name: 'Triage bot',
+      enabled: false,
+      mode: 'act',
+      triggers: {
+        alertSeverities: ['critical', 'high'],
+        respectMaintenanceWindows: true,
+        ticketAutonomousWrites: false,
+      },
+      toolAllowlist: ['manage_services:restart', 'run_script'],
+      protectedResources: { services: ['spooler'], paths: [], registryKeys: [] },
+      limits: { ...AI_AGENT_LIMIT_DEFAULTS },
+      cooldownSeconds: 900,
+      recipients: { roleIds: ['role-1'] },
+      instructions: null,
+      actAssets: { supervisedActionKeys: ['manage_services:restart'] },
+      kind: 'triage',
+      ownerScope: 'partner',
+    });
+  });
+
+  it('pins the ORG draft body: create-only orgId set, actAssets OMITTED entirely (#5049 grant-only)', () => {
+    const draft = baseDraft({ ownerScope: 'organization', mode: 'act', supervisedActionKeys: ['manage_services:restart'] });
+    const body = buildAgentSaveBody(draft, { isCreate: true, orgId: 'org-1' });
+    expect(body).toEqual({
+      name: 'Triage bot',
+      enabled: false,
+      mode: 'act',
+      triggers: {
+        alertSeverities: ['critical', 'high'],
+        respectMaintenanceWindows: true,
+        ticketAutonomousWrites: false,
+      },
+      toolAllowlist: ['manage_services:restart', 'run_script'],
+      protectedResources: { services: ['spooler'], paths: [], registryKeys: [] },
+      limits: { ...AI_AGENT_LIMIT_DEFAULTS },
+      cooldownSeconds: 900,
+      recipients: { roleIds: ['role-1'] },
+      instructions: null,
+      kind: 'triage',
+      ownerScope: 'organization',
+      orgId: 'org-1',
+    });
+    expect(body).not.toHaveProperty('actAssets');
+  });
+
+  it('a PATCH body (isCreate: false) carries the policy fields only — no kind/ownerScope/orgId', () => {
+    const draft = baseDraft();
+    const body = buildAgentSaveBody(draft, { isCreate: false, orgId: 'org-1' });
+    expect(body).not.toHaveProperty('kind');
+    expect(body).not.toHaveProperty('ownerScope');
+    expect(body).not.toHaveProperty('orgId');
+  });
+
+  it('omits triggers.alertSeverities for a kind that never reads it (ALERT_SEVERITY_KINDS)', () => {
+    expect(ALERT_SEVERITY_KINDS.has('patch')).toBe(false);
+    const draft = baseDraft({ kind: 'patch', ownerScope: 'partner' });
+    const body = buildAgentSaveBody(draft, { isCreate: true, orgId: null });
+    expect(body.triggers).not.toHaveProperty('alertSeverities');
+  });
+
+  it('sends actAssets.supervisedActionKeys as [] on a partner draft not in act mode, even if the draft holds a stale selection', () => {
+    const draft = baseDraft({ ownerScope: 'partner', mode: 'shadow', supervisedActionKeys: ['manage_services:restart'] });
+    const body = buildAgentSaveBody(draft, { isCreate: true, orgId: null });
+    expect(body.actAssets).toEqual({ supervisedActionKeys: [] });
+  });
+});

--- a/apps/web/src/components/settings/aiAgents/agentDraft.ts
+++ b/apps/web/src/components/settings/aiAgents/agentDraft.ts
@@ -1,0 +1,238 @@
+import {
+  AI_AGENT_KINDS,
+  AI_AGENT_LIMIT_DEFAULTS,
+  ALERT_SEVERITIES,
+  type AiAgentDto,
+  type AiAgentKind,
+  type AiAgentMode,
+} from '@breeze/shared';
+import type { OwnerScope } from '@/hooks/useDefaultOwnerScope';
+
+/**
+ * Task 13 (#5051), Order-of-work step 1: extracted from `AiAgentForm.tsx` so
+ * both the edit drawer and the four-step guided create flow
+ * (`AgentCreateFlow.tsx`) build the identical `Draft` shape and the identical
+ * `POST`/`PATCH` body from it — a pure move, not a behavior change. Every
+ * export here is exactly the logic `AiAgentForm.tsx` used to own directly.
+ */
+
+// Severities come from @breeze/shared, the same constant the server validator
+// uses. A local copy meant draftFrom() would silently DROP a stored severity
+// the two lists disagreed on, and the next save would write the truncated list.
+const SEVERITIES = ALERT_SEVERITIES;
+export type Severity = (typeof ALERT_SEVERITIES)[number];
+
+/**
+ * Kinds whose runs can ever carry an alert severity — i.e. the only kinds for
+ * which `triggers.alertSeverities` is read at all.
+ *
+ * `runService.ts` evaluates the severity list inside
+ * `evaluateAgentTriggerFilters`, which runs ONLY when the admission input
+ * carries an `alertContext`, and both producers of one
+ * (`alertVerdictSubscriber.ts` and `automationRuntime.ts`) admit with
+ * `kind: 'triage'`. A helpdesk agent is admitted from a ticket
+ * (`ticketHelpdeskSubscriber.ts`, `ticketContext`), a patch agent from a
+ * manual or scheduled trigger — neither carries a severity, so the list is
+ * inert for both.
+ *
+ * Showing the control for those kinds asked the operator to make a choice
+ * that could never take effect, and the client-side `.min(1)` check could
+ * block a save over a field the server never reads for that kind. Hidden AND
+ * omitted from the payload: on PATCH the one-level merge preserves whatever
+ * is stored, and on create the server's `aiAgentTriggersSchema` supplies its
+ * own `['critical', 'high']` default, so omission is never a `.min(1)` 400.
+ */
+export const ALERT_SEVERITY_KINDS: ReadonlySet<AiAgentKind> = new Set<AiAgentKind>(['triage']);
+
+/** Newline-separated textarea → trimmed, de-duplicated list. */
+export function lines(value: string): string[] {
+  return [...new Set(value.split('\n').map((entry) => entry.trim()).filter(Boolean))];
+}
+
+export function toggle<T>(list: T[], value: T): T[] {
+  return list.includes(value) ? list.filter((entry) => entry !== value) : [...list, value];
+}
+
+/**
+ * Kinds still creatable for one ownership axis. The DB enforces
+ * `(partner_id, kind) WHERE org_id IS NULL` and `(org_id, kind)` as two
+ * independent partial uniques, both `WHERE disabled_at IS NULL`, so a kind is
+ * only taken for the owner that actually holds it.
+ */
+export function freeKinds(
+  agents: AiAgentDto[],
+  ownerScope: OwnerScope,
+  orgId: string | null,
+): AiAgentKind[] {
+  const taken = new Set(
+    agents
+      .filter((row) =>
+        ownerScope === 'partner'
+          ? row.ownerScope === 'partner'
+          : row.ownerScope === 'organization' && row.orgId === orgId,
+      )
+      .map((row) => row.kind),
+  );
+  return AI_AGENT_KINDS.filter((kind) => !taken.has(kind));
+}
+
+export function firstFreeKind(
+  agents: AiAgentDto[],
+  ownerScope: OwnerScope,
+  orgId: string | null,
+): AiAgentKind | undefined {
+  return freeKinds(agents, ownerScope, orgId)[0];
+}
+
+export interface Draft {
+  ownerScope: OwnerScope;
+  kind: AiAgentKind;
+  name: string;
+  enabled: boolean;
+  mode: AiAgentMode;
+  severities: Severity[];
+  respectMaintenanceWindows: boolean;
+  toolAllowlist: string;
+  services: string;
+  paths: string;
+  registryKeys: string;
+  limits: typeof AI_AGENT_LIMIT_DEFAULTS;
+  cooldownSeconds: number;
+  roleIds: string[];
+  instructions: string;
+  /** Wave 5 Part B (#3827). Operator's per-agent opt-in to unattended
+   *  policy-decided authorization — see actAssets in `buildAgentSaveBody` below. */
+  supervisedActionKeys: string[];
+  /** P2-4 (#4191). Org-row-only opt-in that lifts the forced-shadow behavior
+   *  for ticket-triggered runs — same "reads ONLY the org's own override"
+   *  merge semantics as `anomalyEnabled` (never itself surfaced on this
+   *  form). See `AiAgentTriggers.ticketAutonomousWrites`'s docstring. */
+  ticketAutonomousWrites: boolean;
+}
+
+export function draftFrom(
+  agent: AiAgentDto | null,
+  defaults: { ownerScope: OwnerScope; kind: AiAgentKind },
+): Draft {
+  const severities = (agent?.triggers?.alertSeverities ?? ['critical', 'high']).filter(
+    (severity): severity is Severity => (SEVERITIES as readonly string[]).includes(severity),
+  );
+  return {
+    ownerScope: agent?.ownerScope ?? defaults.ownerScope,
+    kind: agent?.kind ?? defaults.kind,
+    name: agent?.name ?? '',
+    // CREATE defaults (the `??` fallbacks only ever apply when `agent` is
+    // null): shadow, but SWITCHED OFF.
+    //
+    // `mode: 'shadow'` is what the first-run panel tells the operator to start
+    // with, and the form used to contradict it by defaulting to `off`.
+    // `enabled` was flipped to `true` in the same change and that went too far:
+    // `enabled` is the live switch, not a mode preview. `syncManagedAutomation`
+    // mirrors it onto the seeded automation the moment Save lands, and shadow
+    // passes run admission — so creating a partner-wide triage agent started
+    // real LLM runs across every org under the partner before anyone had looked
+    // at the tool allowlist, the severities or the daily budget on the very
+    // form that created it. Off is the only honest default for a switch whose
+    // first flip spends money on machines the operator has not scoped yet; the
+    // create-only hint beside the checkbox says so, so the unticked box reads
+    // as a decision rather than an oversight.
+    enabled: agent?.enabled ?? false,
+    mode: agent?.mode ?? 'shadow',
+    severities,
+    respectMaintenanceWindows: agent?.triggers?.respectMaintenanceWindows ?? true,
+    toolAllowlist: (agent?.toolAllowlist ?? []).join('\n'),
+    services: (agent?.protectedResources?.services ?? []).join('\n'),
+    paths: (agent?.protectedResources?.paths ?? []).join('\n'),
+    registryKeys: (agent?.protectedResources?.registryKeys ?? []).join('\n'),
+    limits: { ...AI_AGENT_LIMIT_DEFAULTS, ...(agent?.limits ?? {}) },
+    cooldownSeconds: agent?.cooldownSeconds ?? 900,
+    roleIds: agent?.recipients?.roleIds ?? [],
+    instructions: agent?.instructions ?? '',
+    supervisedActionKeys: agent?.actAssets?.supervisedActionKeys ?? [],
+    ticketAutonomousWrites: agent?.triggers?.ticketAutonomousWrites ?? false,
+  };
+}
+
+/**
+ * Builds exactly the JSON body `AiAgentForm.tsx`'s `save()` used to construct
+ * inline — the one-level-PATCH-merge reasoning (severities/actAssets
+ * omission rules) lives here now, unchanged, so a caller never has to
+ * re-derive it. `isCreate` adds the create-only `kind`/`ownerScope`/`orgId`
+ * fields; a PATCH body is the policy object alone.
+ */
+export function buildAgentSaveBody(
+  draft: Draft,
+  opts: { isCreate: boolean; orgId: string | null },
+): Record<string, unknown> {
+  // On PATCH the server merges each nested object one level onto the stored
+  // jsonb (updatePolicyColumns), so the narrowing fields this form does not
+  // expose — triggers.siteIds / deviceGroupIds / deviceTags,
+  // protectedResources.deviceTags, recipients.userIds — survive a save rather
+  // than being erased, which would silently WIDEN the agent's blast radius.
+  // One level is enough only because every sub-value is a scalar or an array
+  // today; a nested object inside one of these would need a real deep merge.
+  // On create there is nothing to merge — these are written wholesale.
+  const policy: Record<string, unknown> = {
+    name: draft.name.trim(),
+    enabled: draft.enabled,
+    mode: draft.mode,
+    triggers: {
+      // Omitted, not sent as the draft value, for a kind whose runs can
+      // never carry a severity (see ALERT_SEVERITY_KINDS): the form does not
+      // show the control there, and sending a value the operator was never
+      // offered would silently rewrite a stored list they cannot see. The
+      // PATCH merge keeps what is stored; create takes the server default.
+      ...(ALERT_SEVERITY_KINDS.has(draft.kind) ? { alertSeverities: draft.severities } : {}),
+      respectMaintenanceWindows: draft.respectMaintenanceWindows,
+      ticketAutonomousWrites: draft.ticketAutonomousWrites,
+    },
+    toolAllowlist: lines(draft.toolAllowlist),
+    protectedResources: {
+      services: lines(draft.services),
+      paths: lines(draft.paths),
+      registryKeys: lines(draft.registryKeys),
+    },
+    limits: draft.limits,
+    cooldownSeconds: draft.cooldownSeconds,
+    recipients: { roleIds: draft.roleIds },
+    instructions: draft.instructions.trim() ? draft.instructions.trim() : null,
+    // Wave 5 Part B (#3827): scriptIds is not this form's field to send —
+    // omitting it here relies on the SAME one-level PATCH merge the
+    // top-of-function comment already documents (updatePolicyColumns
+    // merges { ...stored.actAssets, ...input.actAssets }), so an existing
+    // scriptIds value survives a save that only ever touches
+    // supervisedActionKeys. On create, the server's createAiAgentSchema
+    // defaults the omitted scriptIds to [].
+    //
+    // P2 review fix: the draft KEEPS its supervisedActionKeys selection
+    // across a mode change, but a non-act mode can never use them — sent as
+    // [] rather than the draft's live value so leaving act genuinely revokes
+    // them server-side, not just in the UI, while still letting the
+    // operator's selection reappear if they return to act before saving.
+    //
+    // #5049: an ORG row OMITS `actAssets` entirely instead — the server
+    // now 422s (`supervised_keys_grant_only`) any org-row write that ADDS
+    // a key the row does not already hold, because a key goes live on an
+    // org row only through the four-eyes grant executor (spec §4.4). Neither
+    // caller offers an org row an editable selection, so there is nothing of
+    // the operator's to send; omitting the property is what "leave the
+    // stored value alone" means to the same one-level PATCH merge this
+    // function already relies on for scriptIds above, and the server
+    // defaults a create's omitted key to `[]`. Partner rows are the ceiling
+    // and are still edited directly here, so they keep the
+    // live-selection behavior.
+    ...(draft.ownerScope === 'organization'
+      ? {}
+      : { actAssets: { supervisedActionKeys: draft.mode === 'act' ? draft.supervisedActionKeys : [] } }),
+  };
+
+  if (!opts.isCreate) return policy;
+
+  const body: Record<string, unknown> = {
+    ...policy,
+    kind: draft.kind,
+    ownerScope: draft.ownerScope,
+  };
+  if (draft.ownerScope === 'organization') body.orgId = opts.orgId;
+  return body;
+}

--- a/apps/web/src/components/settings/aiAgents/agentErrors.ts
+++ b/apps/web/src/components/settings/aiAgents/agentErrors.ts
@@ -1,0 +1,87 @@
+import { ActionError } from '@/lib/runAction';
+
+/**
+ * Task 13 (#5051 review) — the save-error mapping shared by `AiAgentForm.tsx`
+ * (the edit drawer, PATCH) and `AgentCreateFlow.tsx` (the guided create flow,
+ * POST). The two used to carry byte-identical copies with a comment arguing
+ * they should stay separate because "the two forms build DIFFERENT bodies" —
+ * true of the save request, not of how a 422 from either one is read back
+ * into operator-facing copy, so this is the one map both import.
+ */
+
+/** Minimal shape of react-i18next's `t` this module needs — kept local, same
+ *  convention as `PolicyKeysCheckboxes.tsx`'s `TranslateFn`. */
+type TranslateFn = (key: string, options?: Record<string, unknown>) => string;
+
+/**
+ * Machine token -> operator-facing sentence. The API answers a failed save
+ * with a `code`, and `runAction`'s `friendly` hook is keyed on it; without
+ * this the toast shows the raw token verbatim, e.g. "agent_kind_exists:
+ * triage".
+ */
+export const AGENT_ERROR_COPY: Record<string, ((t: TranslateFn) => string) | undefined> = {
+  agent_kind_exists: (t) => t('settings:aiAgentsPage.errors.kindExists'),
+  mode_not_supported: (t) => t('settings:aiAgentsPage.errors.modeNotSupported'),
+  // The server's 422 (Task 6, #3826) is the authoritative gate — the
+  // structured `missing[]` it carries is rendered as issues by
+  // `agentSaveIssuesFromError` below, this is just the toast fallback so the
+  // raw machine token never reaches the user.
+  act_prerequisites_not_met: (t) => t('settings:aiAgentsPage.errors.actPrerequisitesNotMet'),
+  // Wave 5 Part B (#3827): the server's 422 (agentService.ts's
+  // InvalidSupervisedActionKeysError) carries a structured `rejected[]` —
+  // this is just the toast fallback; the per-key detail is rendered by
+  // `agentSaveIssuesFromError` below.
+  invalid_supervised_action_keys: (t) => t('settings:aiAgentsPage.errors.invalidSupervisedActionKeys'),
+  // #5049: the server's 422 (agentService.ts's SupervisedKeysGrantOnlyError)
+  // carries the identical `rejected[]` shape as invalid_supervised_action_keys
+  // above — mapped as the identical toast fallback.
+  supervised_keys_grant_only: (t) => t('settings:aiAgentsPage.errors.invalidSupervisedActionKeys'),
+};
+
+/**
+ * `missing[]` entries from the server's `act_prerequisites_not_met` 422
+ * (Task 6, #3826 — `ActPrerequisitesNotMetError`). Mapped to translated,
+ * actionable copy so the operator sees what to fix rather than a machine
+ * token.
+ */
+const ACT_PREREQUISITE_COPY: Record<string, (t: TranslateFn) => string> = {
+  recipient: (t) => t('settings:aiAgentsPage.errors.actMissingRecipient'),
+  act_eligible_tool: (t) => t('settings:aiAgentsPage.errors.actMissingTool'),
+};
+
+/**
+ * The structured per-field issues a save's 422 carries, for the two shapes
+ * the API returns them in — `null` when `err` is neither, in which case the
+ * caller's generic toast (via `AGENT_ERROR_COPY` and `handleActionError`)
+ * already covers it and there is nothing further to set as an issue.
+ */
+export function agentSaveIssuesFromError(err: unknown, t: TranslateFn): string[] | null {
+  if (!(err instanceof ActionError)) return null;
+
+  if (err.code === 'act_prerequisites_not_met') {
+    const body = err.body as { missing?: unknown } | undefined;
+    const missing = Array.isArray(body?.missing)
+      ? body.missing.filter((entry): entry is string => typeof entry === 'string')
+      : [];
+    return missing.map((entry) => ACT_PREREQUISITE_COPY[entry]?.(t) ?? entry);
+  }
+
+  // Wave 5 Part B (#3827) / #5049: both codes carry the identical
+  // `rejected[]` shape naming exactly which keys failed and why.
+  if (err.code === 'invalid_supervised_action_keys' || err.code === 'supervised_keys_grant_only') {
+    const body = err.body as { rejected?: unknown } | undefined;
+    const rejected = Array.isArray(body?.rejected)
+      ? body.rejected.filter(
+          (entry): entry is { key: string; reason: string } =>
+            typeof entry === 'object'
+            && entry !== null
+            && typeof (entry as { key?: unknown }).key === 'string'
+            && typeof (entry as { reason?: unknown }).reason === 'string',
+        )
+      : [];
+    return rejected.map((entry) =>
+      t('settings:aiAgentsPage.errors.supervisedKeyRejected', { key: entry.key, reason: entry.reason }));
+  }
+
+  return null;
+}

--- a/apps/web/src/components/settings/aiAgents/agentFields.tsx
+++ b/apps/web/src/components/settings/aiAgents/agentFields.tsx
@@ -1,0 +1,181 @@
+import { useId } from 'react';
+
+/**
+ * Task 13 (#5051 review) — field helpers shared by `AiAgentForm.tsx` (the
+ * edit drawer) and the guided create flow's steps (`SafetyStep.tsx`), so the
+ * two surfaces render and validate identically rather than drifting through
+ * two hand-maintained copies. A pure move for `listField`/the role fieldset;
+ * `numberField` also fixes a real bug in both original copies (see its own
+ * doc below).
+ */
+
+const inputCls = 'w-full rounded-md border bg-background px-2.5 py-1.5 text-sm';
+
+/** Minimal shape of react-i18next's `t` these helpers need — kept local so
+ *  they stay usable from a plain function without importing react-i18next's
+ *  own generic `TFunction` type (same convention as
+ *  `PolicyKeysCheckboxes.tsx`'s `TranslateFn`). */
+type TranslateFn = (key: string, options?: Record<string, unknown>) => string;
+
+export function listField(
+  testId: string,
+  label: string,
+  value: string,
+  onChange: (next: string) => void,
+  rows = 3,
+) {
+  return (
+    <label className="space-y-1 text-sm">
+      <span className="font-medium">{label}</span>
+      <textarea
+        className={`${inputCls} font-mono`}
+        rows={rows}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        data-testid={testId}
+      />
+    </label>
+  );
+}
+
+/**
+ * A numeric limit input, clamped to `[min, max]`.
+ *
+ * Both original copies of this (`AiAgentForm.tsx` and `SafetyStep.tsx`)
+ * guarded only `Number.isFinite(next)` on the theory that clearing the input
+ * yields `'' -> NaN`. It does not: `Number('')` is `0`, which IS finite, so
+ * the guard never fired and clearing a limit silently stored `0` — a real
+ * value the server would accept and run with, not the "not set yet" the
+ * empty box suggested. An explicitly-empty string now falls back to `min`
+ * before the finite check ever runs; any other unparsable or out-of-range
+ * entry is clamped into `[min, max]` rather than passed through raw.
+ */
+export function numberField(
+  testId: string,
+  label: string,
+  value: number,
+  min: number,
+  max: number,
+  onChange: (next: number) => void,
+) {
+  return (
+    <label className="space-y-1 text-sm">
+      <span className="font-medium">{label}</span>
+      <input
+        type="number"
+        className={inputCls}
+        min={min}
+        max={max}
+        value={value}
+        onChange={(e) => {
+          const raw = e.target.value;
+          const parsed = Number(raw);
+          const next = raw.trim() === '' || !Number.isFinite(parsed) ? min : parsed;
+          onChange(Math.min(max, Math.max(min, next)));
+        }}
+        data-testid={testId}
+      />
+    </label>
+  );
+}
+
+/** GET /roles projection. */
+export interface RoleOption {
+  id: string;
+  name: string;
+  /** `roles.scope` as GET /roles projects it. Optional on the type because an
+   *  older API build omits it; such a role is grouped with the organization
+   *  roles rather than dropped — a recipient must never disappear because a
+   *  field it never had is missing. */
+  scope?: 'partner' | 'organization';
+}
+
+function roleScope(role: RoleOption): 'partner' | 'organization' {
+  return role.scope === 'partner' ? 'partner' : 'organization';
+}
+
+/** Rendered in this order; a group with no roles is skipped entirely. */
+export const ROLE_GROUPS = ['partner', 'organization'] as const;
+
+export interface RecipientRolesFieldsetProps {
+  /** The two callers render this inside a different grid (the drawer's
+   *  two-column form vs. the guided flow's single-column step), so the
+   *  outer `<fieldset>`'s className is the caller's to choose. */
+  className: string;
+  t: TranslateFn;
+  roles: RoleOption[];
+  rolesFailed: boolean;
+  roleIds: string[];
+  onToggleRole: (id: string) => void;
+}
+
+/** The "Notifications" fieldset: recipient roles grouped by partner vs.
+ *  organization, with the load-failed and empty states each caller used to
+ *  hand-maintain identically. */
+export function RecipientRolesFieldset({
+  className,
+  t,
+  roles,
+  rolesFailed,
+  roleIds,
+  onToggleRole,
+}: RecipientRolesFieldsetProps) {
+  const rolesGroupBaseId = useId();
+  // Literal keys, not a dynamic `t()` on the token: the closed two-member
+  // union is spelled out so the keyUsage guard verifies both labels
+  // statically (same reason ModeChoice.tsx's own label maps are).
+  const ROLE_GROUP_LABEL: Record<(typeof ROLE_GROUPS)[number], string> = {
+    partner: t('settings:aiAgentsPage.fields.recipientRolesPartner'),
+    organization: t('settings:aiAgentsPage.fields.recipientRolesOrganization'),
+  };
+
+  return (
+    <fieldset className={className}>
+      <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">
+        {t('settings:aiAgentsPage.sections.notifications')}
+      </legend>
+      <p className="text-xs text-muted-foreground">{t('settings:aiAgentsPage.fields.recipientRolesHint')}</p>
+      {rolesFailed ? (
+        <p className="text-sm text-destructive" data-testid="ai-agent-roles-failed">
+          {t('settings:aiAgentsPage.fields.recipientRolesFailed')}
+        </p>
+      ) : roles.length === 0 ? (
+        <p className="text-sm text-muted-foreground" data-testid="ai-agent-roles-empty">
+          {t('settings:aiAgentsPage.fields.recipientRolesEmpty')}
+        </p>
+      ) : (
+        // Nine flat checkboxes with partner and organization roles
+        // interleaved read as one undifferentiated list, and the two
+        // answer different questions: who at the MSP hears about this,
+        // and who at the customer does. Grouped, not filtered — every
+        // control the flat list carried is still here.
+        <div className="space-y-3">
+          {ROLE_GROUPS.map((scope) => {
+            const group = roles.filter((role) => roleScope(role) === scope);
+            if (group.length === 0) return null;
+            return (
+              <div key={scope} role="group" aria-labelledby={`${rolesGroupBaseId}-${scope}`}>
+                <p id={`${rolesGroupBaseId}-${scope}`} className="text-xs font-medium">
+                  {ROLE_GROUP_LABEL[scope]}
+                </p>
+                <div className="mt-1 flex flex-wrap gap-3" data-testid={`ai-agent-roles-${scope}`}>
+                  {group.map((role) => (
+                    <label key={role.id} className="flex items-center gap-1 text-sm">
+                      <input
+                        type="checkbox"
+                        checked={roleIds.includes(role.id)}
+                        onChange={() => onToggleRole(role.id)}
+                        data-testid={`ai-agent-role-${role.id}`}
+                      />
+                      {role.name}
+                    </label>
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </fieldset>
+  );
+}

--- a/apps/web/src/components/settings/aiAgents/capabilityModel.test.ts
+++ b/apps/web/src/components/settings/aiAgents/capabilityModel.test.ts
@@ -109,7 +109,13 @@ describe('capabilityModel', () => {
     expect(outcomeFor(restart, 'shadow')).toBe('approval_request');
     expect(outcomeFor(restart, 'act')).toBe('unattended');
     expect(outcomeFor({ ...restart, actEligible: false }, 'act')).toBe('approval_request');
-    expect(outcomeFor({ ...list, readOnly: false }, 'shadow')).toBe('logged_proposal');
+    // `outcomeFor`'s shared signature (packages/shared/src/utils/agentOutcome.ts)
+    // narrows its `op` parameter to just `{ tier, actEligible }`, so a fresh
+    // object literal carrying `readOnly` (a field outside that shape) trips
+    // TS's excess-property check on the literal — assign to a typed variable
+    // first, same as `restart`/`list` above.
+    const listReadWrite: typeof list = { ...list, readOnly: false };
+    expect(outcomeFor(listReadWrite, 'shadow')).toBe('logged_proposal');
   });
 
   it('treats a bare ceiling entry as a wildcard', () => {

--- a/apps/web/src/components/settings/aiAgents/capabilityModel.ts
+++ b/apps/web/src/components/settings/aiAgents/capabilityModel.ts
@@ -1,4 +1,10 @@
-import type { AgentCeilingDto, AgentToolCatalogDto, AgentToolOperationDto } from '@breeze/shared';
+import { outcomeFor, type AgentCeilingDto, type AgentToolCatalogDto } from '@breeze/shared';
+
+// Task 13 (#5051 review) — the ONE outcome rule: this used to be a local
+// copy byte-identical to `agentPreview.ts`'s server-side `resolveOutcome`.
+// Re-exported so `CapabilityPicker.tsx` and this module's own test suite
+// keep importing it from here unchanged.
+export { outcomeFor };
 
 export type OperationOutcome = 'approval_request' | 'logged_proposal' | 'unattended';
 export type AgentModeLike = 'off' | 'shadow' | 'act';
@@ -85,11 +91,6 @@ export function capabilityState(
   const checked =
     selectedCount === 0 ? 'none' : selectedCount === totalCount && allInCeilingSelected ? 'all' : 'some';
   return { checked, selectedCount, totalCount };
-}
-
-export function outcomeFor(op: AgentToolOperationDto, mode: AgentModeLike): OperationOutcome {
-  if (mode === 'act' && op.actEligible) return 'unattended';
-  return op.tier === 3 ? 'approval_request' : 'logged_proposal';
 }
 
 export function isWithinCeiling(opKey: string, ceiling: AgentCeilingDto | null): boolean {

--- a/apps/web/src/components/settings/aiAgents/steps/PurposeStep.tsx
+++ b/apps/web/src/components/settings/aiAgents/steps/PurposeStep.tsx
@@ -1,0 +1,223 @@
+import { useId, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { AI_AGENT_KINDS, type AiAgentDto, type AiAgentKind } from '@breeze/shared';
+import ModeChoice from '../ModeChoice';
+import { freeKinds, firstFreeKind, type Draft } from '../agentDraft';
+
+const inputCls = 'w-full rounded-md border bg-background px-2.5 py-1.5 text-sm';
+const INSTRUCTIONS_MAX = 2000;
+
+export interface PurposeStepProps {
+  draft: Draft;
+  patch: (values: Partial<Draft>) => void;
+  agents: AiAgentDto[];
+  orgId: string | null;
+  showOwnerScope: boolean;
+  partnerBaselineKinds: Set<string>;
+  actSupported: boolean;
+  actAck: boolean;
+  onActAckChange: (checked: boolean) => void;
+  actKeysWillBeOmitted: boolean;
+  /** Set by the flow when a "Next" click was blocked on an empty name, so the
+   *  field shows red even before the operator has focused/blurred it once. */
+  forceNameError: boolean;
+}
+
+/**
+ * Step 1 of the guided create flow (spec §4.6): Mode first — the only choice
+ * here that can reach a device — then Kind (as cards, each naming what it
+ * does, when it runs and what the recommended preset covers), owner scope,
+ * name, and instructions. Mirrors `AiAgentForm.tsx`'s field order and test
+ * ids everywhere the same control is reused (`ModeChoice`, the owner-scope
+ * fieldset, the no-baseline hint, the name field, the instructions fieldset).
+ *
+ * Deviation from spec §4.6's literal "name, model, instructions": there is no
+ * `model` field anywhere in this codebase's agent policy UI today —
+ * `AiAgentForm.tsx`'s `Draft` has never carried one, `createAiAgentSchema`'s
+ * `model` always defaults to `null` server-side, and no i18n/test-id
+ * convention exists to follow. Adding a first-of-its-kind model selector is
+ * out of scope for a task whose job is to reuse the drawer's existing
+ * fields — it would need its own design pass (an options source, a default,
+ * a save-body slot), not a copy of something that already exists.
+ */
+export default function PurposeStep({
+  draft,
+  patch,
+  agents,
+  orgId,
+  showOwnerScope,
+  partnerBaselineKinds,
+  actSupported,
+  actAck,
+  onActAckChange,
+  actKeysWillBeOmitted,
+  forceNameError,
+}: PurposeStepProps) {
+  const { t } = useTranslation('settings');
+  const nameInputId = useId();
+  const nameErrorId = useId();
+  const [nameTouched, setNameTouched] = useState(false);
+  const nameInvalid = (nameTouched || forceNameError) && draft.name.trim() === '';
+
+  const availableKinds = freeKinds(agents, draft.ownerScope, orgId);
+  // Create has no existing agent, so entering act is simply "mode is act" —
+  // there is no prior mode to compare against (mirrors AiAgentForm's
+  // `initialMode` always being 'off' on create).
+  const enteringActMode = draft.mode === 'act';
+
+  return (
+    <div className="grid gap-3 md:grid-cols-2">
+      <ModeChoice
+        mode={draft.mode}
+        onChange={(mode) => patch({ mode })}
+        actSupported={actSupported}
+        enteringActMode={enteringActMode}
+        actAck={actAck}
+        onActAckChange={onActAckChange}
+        actKeysWillBeOmitted={actKeysWillBeOmitted}
+      />
+
+      {/* Kind, as cards rather than the drawer's `<select>`: each names what
+          the kind does, when it runs, and what its recommended preset
+          covers — the picker's own "Recommended for {kind}" banner (spec
+          §4.5) is what actually applies it, on the next step. A kind already
+          taken for this owner scope renders disabled, same rule as the
+          drawer's option list (`freeKinds`). */}
+      <fieldset className="space-y-2 rounded-md border p-3 md:col-span-2" data-testid="ai-agent-kind">
+        <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">
+          {t('aiAgentsPage.fields.kind')}
+        </legend>
+        <div role="radiogroup" aria-label={t('aiAgentsPage.fields.kind')} className="grid gap-2 sm:grid-cols-3">
+          {AI_AGENT_KINDS.map((kind) => {
+            const selected = draft.kind === kind;
+            const taken = !availableKinds.includes(kind);
+            return (
+              <button
+                key={kind}
+                type="button"
+                role="radio"
+                aria-checked={selected}
+                disabled={taken}
+                onClick={() => patch({ kind })}
+                className={`flex flex-col items-start gap-1 rounded-lg border p-3 text-left transition-colors focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60 ${
+                  selected ? 'border-primary bg-primary/10 ring-1 ring-primary' : 'bg-background hover:border-primary/50 hover:bg-muted/40'
+                }`}
+                data-testid={`ai-agent-kind-card-${kind}`}
+              >
+                <span className="text-sm font-medium">{t(/* i18n-dynamic */ `aiAgentsPage.kinds.${kind}`)}</span>
+                <span className="text-xs text-muted-foreground">
+                  {t(/* i18n-dynamic */ `aiAgentsPage.flow.kinds.${kind}.blurb`)}
+                </span>
+                <span className="text-xs text-muted-foreground">
+                  {t('aiAgentsPage.flow.kindCard.runsWhenPrefix')}{' '}
+                  {t(/* i18n-dynamic */ `aiAgentsPage.flow.kinds.${kind}.runsWhen`)}
+                </span>
+                <span className="text-xs text-muted-foreground">
+                  {t('aiAgentsPage.flow.kindCard.recommendedPrefix')}{' '}
+                  {t(/* i18n-dynamic */ `aiAgentsPage.flow.kinds.${kind}.recommended`)}
+                </span>
+                {taken && (
+                  <span className="text-xs font-medium text-muted-foreground" data-testid={`ai-agent-kind-card-${kind}-taken`}>
+                    {t('aiAgentsPage.flow.kindCard.taken')}
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+        {availableKinds.length === 0 && (
+          <p className="text-sm text-muted-foreground" data-testid="ai-agent-kinds-exhausted">
+            {t('aiAgentsPage.issues.allKindsTaken')}
+          </p>
+        )}
+      </fieldset>
+
+      {showOwnerScope && (
+        <fieldset className="space-y-2 rounded-md border p-3 md:col-span-2" data-testid="ai-agent-ownerscope">
+          <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">
+            {t('aiAgentsPage.editor.scopeLegend')}
+          </legend>
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="radio"
+              name="ai-agent-owner"
+              value="partner"
+              checked={draft.ownerScope === 'partner'}
+              onChange={() => patch({ ownerScope: 'partner', kind: firstFreeKind(agents, 'partner', orgId) ?? draft.kind })}
+              data-testid="ai-agent-owner-partner"
+            />
+            {t('aiAgentsPage.editor.allOrgs')}{' '}
+            <span className="text-muted-foreground">{t('aiAgentsPage.editor.allOrgsHint')}</span>
+          </label>
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="radio"
+              name="ai-agent-owner"
+              value="organization"
+              checked={draft.ownerScope === 'organization'}
+              onChange={() => patch({ ownerScope: 'organization', kind: firstFreeKind(agents, 'organization', orgId) ?? draft.kind })}
+              data-testid="ai-agent-owner-org"
+            />
+            {t('aiAgentsPage.editor.thisOrg')}
+          </label>
+        </fieldset>
+      )}
+
+      {/* #4170: an org-only agent overrides a partner-wide baseline of the
+          same kind — it is never a standalone policy. */}
+      {draft.ownerScope === 'organization' && !partnerBaselineKinds.has(draft.kind) && (
+        <p
+          className="rounded-md border border-amber-300 bg-amber-100 px-3 py-2 text-sm text-amber-800 dark:border-amber-800 dark:bg-amber-950/50 dark:text-amber-200 md:col-span-2"
+          data-testid="ai-agent-no-baseline-hint"
+        >
+          {t('aiAgentsPage.inertBadge.hint')}
+        </p>
+      )}
+
+      <div className="space-y-1 text-sm md:col-span-2">
+        <label className="block font-medium" htmlFor={nameInputId}>
+          {t('aiAgentsPage.fields.name')}<span className="text-destructive">*</span>
+        </label>
+        <input
+          id={nameInputId}
+          className={`${inputCls} ${nameInvalid ? 'border-destructive' : ''}`}
+          maxLength={120}
+          required
+          aria-invalid={nameInvalid || undefined}
+          aria-describedby={nameInvalid ? nameErrorId : undefined}
+          value={draft.name}
+          onChange={(e) => patch({ name: e.target.value })}
+          onBlur={() => setNameTouched(true)}
+          data-testid="ai-agent-name"
+        />
+        {nameInvalid && (
+          <p id={nameErrorId} className="text-xs text-destructive" data-testid="ai-agent-name-error">
+            {t('aiAgentsPage.issues.name')}
+          </p>
+        )}
+      </div>
+
+      <fieldset className="space-y-2 rounded-md border p-3 md:col-span-2">
+        <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">
+          {t('aiAgentsPage.sections.instructions')}
+        </legend>
+        <p className="text-xs text-muted-foreground">{t('aiAgentsPage.fields.instructionsHint')}</p>
+        <textarea
+          className={inputCls}
+          rows={5}
+          maxLength={INSTRUCTIONS_MAX}
+          value={draft.instructions}
+          onChange={(e) => patch({ instructions: e.target.value })}
+          data-testid="ai-agent-instructions"
+        />
+        <p className="text-xs text-muted-foreground">
+          {t('aiAgentsPage.fields.charactersLeft', { count: INSTRUCTIONS_MAX - draft.instructions.length })}
+        </p>
+      </fieldset>
+
+      <p className="text-xs text-muted-foreground md:col-span-2" data-testid="agent-create-flow-disabled-note">
+        {t('aiAgentsPage.flow.createdDisabledNote')}
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/aiAgents/steps/ReviewStep.tsx
+++ b/apps/web/src/components/settings/aiAgents/steps/ReviewStep.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { AgentPreviewDto } from '@breeze/shared';
+import { fetchWithAuth } from '@/stores/auth';
+import AgentSummaryCard from '../AgentSummaryCard';
+import { buildAgentSaveBody, type Draft } from '../agentDraft';
+
+/** Debounced re-fetch delay for a draft change while this step is mounted —
+ *  spec §4.6 step 4: "on entry (and whenever the draft changes while on this
+ *  step, debounced 300ms) POST /ai/agents/preview". A uniform debounce (the
+ *  entry fetch waits the same 300ms) keeps this effect a single small block
+ *  instead of a first-render special case, and 300ms is imperceptible for a
+ *  review step no one is racing to see. */
+const PREVIEW_DEBOUNCE_MS = 300;
+
+export interface ReviewStepProps {
+  draft: Draft;
+  patch: (values: Partial<Draft>) => void;
+  orgId: string | null;
+  orgName: string | null;
+  onEdit: (section: 'purpose' | 'does' | 'safety') => void;
+}
+
+/**
+ * Step 4 of the guided create flow (spec §4.6): the server-evaluated review
+ * card. Posts the SAME body `buildAgentSaveBody` would send to `POST
+ * /ai/agents` to `POST /ai/agents/preview` instead, so the card is evaluated
+ * through the exact guardrail/catalog helpers the run loop uses and can never
+ * drift from what Create will actually enforce. A preview failure never
+ * blocks Create — the footer's Create button lives in `AgentCreateFlow.tsx`
+ * and does not depend on this component's fetch succeeding.
+ */
+export default function ReviewStep({ draft, patch, orgId, orgName, onEdit }: ReviewStepProps) {
+  const { t } = useTranslation('settings');
+  const [preview, setPreview] = useState<AgentPreviewDto | null>(null);
+  const [previewError, setPreviewError] = useState(false);
+  const [previewLoading, setPreviewLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setPreviewLoading(true);
+    const timer = setTimeout(() => {
+      void (async () => {
+        try {
+          const body = buildAgentSaveBody(draft, { isCreate: true, orgId });
+          const response = await fetchWithAuth('/ai/agents/preview', {
+            method: 'POST',
+            body: JSON.stringify(body),
+          });
+          if (!response.ok) throw new Error(`POST /ai/agents/preview ${response.status}`);
+          const json = (await response.json()) as { data?: AgentPreviewDto };
+          if (cancelled) return;
+          if (json.data) {
+            setPreview(json.data);
+            setPreviewError(false);
+          } else {
+            setPreviewError(true);
+          }
+        } catch (err) {
+          console.error('[ReviewStep] could not load the agent preview', err);
+          if (!cancelled) setPreviewError(true);
+        } finally {
+          if (!cancelled) setPreviewLoading(false);
+        }
+      })();
+    }, PREVIEW_DEBOUNCE_MS);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+    // Re-run on every draft change while this step is mounted — JSON.stringify
+    // is used inside the effect rather than a manual field-by-field dependency
+    // list, since the request body IS the draft, projected.
+  }, [JSON.stringify(draft), orgId]);
+
+  return (
+    <div className="space-y-3">
+      {previewError && (
+        <p
+          className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+          data-testid="agent-create-flow-preview-error"
+        >
+          {t('aiAgentsPage.flow.previewFailed')}
+        </p>
+      )}
+      {previewLoading && !preview && !previewError && (
+        <p className="text-sm text-muted-foreground" data-testid="agent-create-flow-preview-loading">
+          {t('aiAgentsPage.flow.previewLoading')}
+        </p>
+      )}
+      {preview && (
+        <AgentSummaryCard preview={preview} name={draft.name} orgName={orgName} enabled={draft.enabled} onEdit={onEdit} />
+      )}
+
+      <label className="flex items-center gap-2 text-sm" data-testid="agent-create-flow-start-enabled-field">
+        <input
+          type="checkbox"
+          checked={draft.enabled}
+          onChange={(e) => patch({ enabled: e.target.checked })}
+          data-testid="agent-create-flow-start-enabled"
+        />
+        <span className="font-medium">{t('aiAgentsPage.flow.startEnabled')}</span>
+      </label>
+      <p className="pl-6 text-xs text-muted-foreground">{t('aiAgentsPage.flow.startEnabledHint')}</p>
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/aiAgents/steps/SafetyStep.tsx
+++ b/apps/web/src/components/settings/aiAgents/steps/SafetyStep.tsx
@@ -1,0 +1,200 @@
+import { useId } from 'react';
+import { useTranslation } from 'react-i18next';
+import PolicyKeysCheckboxes, { type PolicyDecidableKeyOption } from '../PolicyKeysCheckboxes';
+import { lines, toggle, type Draft } from '../agentDraft';
+
+const inputCls = 'w-full rounded-md border bg-background px-2.5 py-1.5 text-sm';
+
+/** GET /roles projection. Duplicated from `AiAgentForm.tsx` (small, and the
+ *  two never need to stay byte-identical) rather than exported from it —
+ *  `AiAgentForm.tsx` has no reason to know this step file exists. */
+export interface RoleOption {
+  id: string;
+  name: string;
+  /** `roles.scope` as GET /roles projects it. Optional on the type because an
+   *  older API build omits it; such a role is grouped with the organization
+   *  roles rather than dropped — a recipient must never disappear because a
+   *  field it never had is missing. */
+  scope?: 'partner' | 'organization';
+}
+
+function roleScope(role: RoleOption): 'partner' | 'organization' {
+  return role.scope === 'partner' ? 'partner' : 'organization';
+}
+
+/** Rendered in this order; a group with no roles is skipped entirely. */
+const ROLE_GROUPS = ['partner', 'organization'] as const;
+
+export interface SafetyStepProps {
+  draft: Draft;
+  patch: (values: Partial<Draft>) => void;
+  roles: RoleOption[];
+  rolesFailed: boolean;
+  policyKeys: PolicyDecidableKeyOption[];
+  policyKeysFailed: boolean;
+}
+
+const listField = (
+  testId: string,
+  label: string,
+  value: string,
+  onChange: (next: string) => void,
+) => (
+  <label className="space-y-1 text-sm">
+    <span className="font-medium">{label}</span>
+    <textarea
+      className={`${inputCls} font-mono`}
+      rows={2}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      data-testid={testId}
+    />
+  </label>
+);
+
+const numberField = (
+  testId: string,
+  label: string,
+  value: number,
+  min: number,
+  max: number,
+  onChange: (next: number) => void,
+) => (
+  <label className="space-y-1 text-sm">
+    <span className="font-medium">{label}</span>
+    <input
+      type="number"
+      className={inputCls}
+      min={min}
+      max={max}
+      value={value}
+      onChange={(e) => {
+        // Clearing a number input yields '' -> NaN, which JSON.stringify
+        // emits as null and the server rejects with a bare 400.
+        const next = Number(e.target.value);
+        onChange(Number.isFinite(next) ? next : min);
+      }}
+      data-testid={testId}
+    />
+  </label>
+);
+
+/**
+ * Step 3 of the guided create flow (spec §4.6): protected resources, the six
+ * exposed limits, recipient roles and — for a PARTNER draft only — the
+ * unattended-ceiling registry (`PolicyKeysCheckboxes`, extracted from
+ * `AiAgentForm.tsx`). An ORG draft shows nothing here: a brand-new org row
+ * holds no keys yet, and a key can only go live later through the four-eyes
+ * grant executor (spec §4.4) — there is nothing to review or edit at create
+ * time.
+ */
+export default function SafetyStep({ draft, patch, roles, rolesFailed, policyKeys, policyKeysFailed }: SafetyStepProps) {
+  const { t } = useTranslation('settings');
+  const limitsBudgetId = useId();
+  const limitsTimingId = useId();
+  const rolesGroupBaseId = useId();
+
+  const ROLE_GROUP_LABEL: Record<(typeof ROLE_GROUPS)[number], string> = {
+    partner: t('aiAgentsPage.fields.recipientRolesPartner'),
+    organization: t('aiAgentsPage.fields.recipientRolesOrganization'),
+  };
+
+  return (
+    <div className="space-y-3">
+      <fieldset className="space-y-2 rounded-md border p-3">
+        <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">
+          {t('aiAgentsPage.flow.protectedResourcesLegend')}
+        </legend>
+        <p className="text-xs text-muted-foreground">{t('aiAgentsPage.fields.protectedHint')}</p>
+        <div className="grid gap-3 md:grid-cols-3">
+          {listField('ai-agent-services', t('aiAgentsPage.fields.protectedServices'), draft.services, (v) => patch({ services: v }))}
+          {listField('ai-agent-paths', t('aiAgentsPage.fields.protectedPaths'), draft.paths, (v) => patch({ paths: v }))}
+          {listField('ai-agent-registrykeys', t('aiAgentsPage.fields.protectedRegistryKeys'), draft.registryKeys, (v) => patch({ registryKeys: v }))}
+        </div>
+      </fieldset>
+
+      {draft.ownerScope === 'partner' && (
+        <fieldset className="space-y-2 rounded-md border p-3" data-testid="ai-agent-policy-decide">
+          <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">
+            {t('aiAgentsPage.sections.policyDecide')}
+          </legend>
+          <p className="text-xs text-muted-foreground">{t('aiAgentsPage.fields.supervisedActionKeysHint')}</p>
+          <p className="text-xs text-muted-foreground" data-testid="ai-agent-supervised-keys-ceiling-hint">
+            {t('aiAgentsPage.graduation.ceilingHint')}
+          </p>
+          <PolicyKeysCheckboxes
+            policyKeys={policyKeys}
+            policyKeysFailed={policyKeysFailed}
+            selectedKeys={draft.supervisedActionKeys}
+            onToggle={(key) => patch({ supervisedActionKeys: toggle(draft.supervisedActionKeys, key) })}
+          />
+        </fieldset>
+      )}
+
+      <fieldset className="space-y-3 rounded-md border p-3">
+        <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">
+          {t('aiAgentsPage.sections.limits')}
+        </legend>
+        <div role="group" aria-labelledby={limitsBudgetId} className="space-y-1.5">
+          <p id={limitsBudgetId} className="text-xs font-medium">{t('aiAgentsPage.sections.limitsBudget')}</p>
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            {numberField('ai-agent-limit-devices', t('aiAgentsPage.fields.maxDevicesPerRun'), draft.limits.maxDevicesPerRun, 1, 50, (v) => patch({ limits: { ...draft.limits, maxDevicesPerRun: v } }))}
+            {numberField('ai-agent-limit-runs', t('aiAgentsPage.fields.maxRunsPerHour'), draft.limits.maxRunsPerHour, 1, 500, (v) => patch({ limits: { ...draft.limits, maxRunsPerHour: v } }))}
+            {numberField('ai-agent-limit-budget', t('aiAgentsPage.fields.maxBudgetCentsPerDay'), draft.limits.maxBudgetCentsPerDay, 1, 100000, (v) => patch({ limits: { ...draft.limits, maxBudgetCentsPerDay: v } }))}
+            {numberField('ai-agent-limit-fleet', t('aiAgentsPage.fields.maxFleetPercentPerDay'), draft.limits.maxFleetPercentPerDay, 1, 100, (v) => patch({ limits: { ...draft.limits, maxFleetPercentPerDay: v } }))}
+          </div>
+        </div>
+        <div role="group" aria-labelledby={limitsTimingId} className="space-y-1.5">
+          <p id={limitsTimingId} className="text-xs font-medium">{t('aiAgentsPage.sections.limitsTiming')}</p>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {numberField('ai-agent-limit-wallclock', t('aiAgentsPage.fields.wallClockSeconds'), draft.limits.wallClockSeconds, 30, 1800, (v) => patch({ limits: { ...draft.limits, wallClockSeconds: v } }))}
+            {numberField('ai-agent-cooldown', t('aiAgentsPage.fields.cooldownSeconds'), draft.cooldownSeconds, 0, 86400, (v) => patch({ cooldownSeconds: v }))}
+          </div>
+        </div>
+      </fieldset>
+
+      <fieldset className="space-y-2 rounded-md border p-3">
+        <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">
+          {t('aiAgentsPage.sections.notifications')}
+        </legend>
+        <p className="text-xs text-muted-foreground">{t('aiAgentsPage.fields.recipientRolesHint')}</p>
+        {rolesFailed ? (
+          <p className="text-sm text-destructive" data-testid="ai-agent-roles-failed">
+            {t('aiAgentsPage.fields.recipientRolesFailed')}
+          </p>
+        ) : roles.length === 0 ? (
+          <p className="text-sm text-muted-foreground" data-testid="ai-agent-roles-empty">
+            {t('aiAgentsPage.fields.recipientRolesEmpty')}
+          </p>
+        ) : (
+          <div className="space-y-3">
+            {ROLE_GROUPS.map((scope) => {
+              const group = roles.filter((role) => roleScope(role) === scope);
+              if (group.length === 0) return null;
+              return (
+                <div key={scope} role="group" aria-labelledby={`${rolesGroupBaseId}-${scope}`}>
+                  <p id={`${rolesGroupBaseId}-${scope}`} className="text-xs font-medium">
+                    {ROLE_GROUP_LABEL[scope]}
+                  </p>
+                  <div className="mt-1 flex flex-wrap gap-3" data-testid={`ai-agent-roles-${scope}`}>
+                    {group.map((role) => (
+                      <label key={role.id} className="flex items-center gap-1 text-sm">
+                        <input
+                          type="checkbox"
+                          checked={draft.roleIds.includes(role.id)}
+                          onChange={() => patch({ roleIds: toggle(draft.roleIds, role.id) })}
+                          data-testid={`ai-agent-role-${role.id}`}
+                        />
+                        {role.name}
+                      </label>
+                    ))}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </fieldset>
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/aiAgents/steps/SafetyStep.tsx
+++ b/apps/web/src/components/settings/aiAgents/steps/SafetyStep.tsx
@@ -1,29 +1,14 @@
 import { useId } from 'react';
 import { useTranslation } from 'react-i18next';
-import PolicyKeysCheckboxes, { type PolicyDecidableKeyOption } from '../PolicyKeysCheckboxes';
+import PolicyKeysCheckboxes, { collapsedForCeiling, type PolicyDecidableKeyOption } from '../PolicyKeysCheckboxes';
+import { listField, numberField, RecipientRolesFieldset, type RoleOption } from '../agentFields';
 import { lines, toggle, type Draft } from '../agentDraft';
 
-const inputCls = 'w-full rounded-md border bg-background px-2.5 py-1.5 text-sm';
-
-/** GET /roles projection. Duplicated from `AiAgentForm.tsx` (small, and the
- *  two never need to stay byte-identical) rather than exported from it —
- *  `AiAgentForm.tsx` has no reason to know this step file exists. */
-export interface RoleOption {
-  id: string;
-  name: string;
-  /** `roles.scope` as GET /roles projects it. Optional on the type because an
-   *  older API build omits it; such a role is grouped with the organization
-   *  roles rather than dropped — a recipient must never disappear because a
-   *  field it never had is missing. */
-  scope?: 'partner' | 'organization';
-}
-
-function roleScope(role: RoleOption): 'partner' | 'organization' {
-  return role.scope === 'partner' ? 'partner' : 'organization';
-}
-
-/** Rendered in this order; a group with no roles is skipped entirely. */
-const ROLE_GROUPS = ['partner', 'organization'] as const;
+// Re-exported so `AgentCreateFlow.tsx`'s `import { type RoleOption } from
+// './steps/SafetyStep'` keeps resolving — `RoleOption` itself now lives in
+// `agentFields.tsx` (Task 13, #5051 review) alongside the field helpers this
+// step shares with `AiAgentForm.tsx`.
+export type { RoleOption };
 
 export interface SafetyStepProps {
   draft: Draft;
@@ -33,51 +18,6 @@ export interface SafetyStepProps {
   policyKeys: PolicyDecidableKeyOption[];
   policyKeysFailed: boolean;
 }
-
-const listField = (
-  testId: string,
-  label: string,
-  value: string,
-  onChange: (next: string) => void,
-) => (
-  <label className="space-y-1 text-sm">
-    <span className="font-medium">{label}</span>
-    <textarea
-      className={`${inputCls} font-mono`}
-      rows={2}
-      value={value}
-      onChange={(e) => onChange(e.target.value)}
-      data-testid={testId}
-    />
-  </label>
-);
-
-const numberField = (
-  testId: string,
-  label: string,
-  value: number,
-  min: number,
-  max: number,
-  onChange: (next: number) => void,
-) => (
-  <label className="space-y-1 text-sm">
-    <span className="font-medium">{label}</span>
-    <input
-      type="number"
-      className={inputCls}
-      min={min}
-      max={max}
-      value={value}
-      onChange={(e) => {
-        // Clearing a number input yields '' -> NaN, which JSON.stringify
-        // emits as null and the server rejects with a bare 400.
-        const next = Number(e.target.value);
-        onChange(Number.isFinite(next) ? next : min);
-      }}
-      data-testid={testId}
-    />
-  </label>
-);
 
 /**
  * Step 3 of the guided create flow (spec §4.6): protected resources, the six
@@ -92,12 +32,22 @@ export default function SafetyStep({ draft, patch, roles, rolesFailed, policyKey
   const { t } = useTranslation('settings');
   const limitsBudgetId = useId();
   const limitsTimingId = useId();
-  const rolesGroupBaseId = useId();
 
-  const ROLE_GROUP_LABEL: Record<(typeof ROLE_GROUPS)[number], string> = {
-    partner: t('aiAgentsPage.fields.recipientRolesPartner'),
-    organization: t('aiAgentsPage.fields.recipientRolesOrganization'),
-  };
+  // The registry rendering, shared with everything the collapsed/uncollapsed
+  // branches below both need.
+  const policyKeysCheckboxes = (
+    <PolicyKeysCheckboxes
+      policyKeys={policyKeys}
+      policyKeysFailed={policyKeysFailed}
+      selectedKeys={draft.supervisedActionKeys}
+      onToggle={(key) => patch({ supervisedActionKeys: toggle(draft.supervisedActionKeys, key) })}
+    />
+  );
+  const ceilingHint = (
+    <p className="text-xs text-muted-foreground" data-testid="ai-agent-supervised-keys-ceiling-hint">
+      {t('aiAgentsPage.graduation.ceilingHint')}
+    </p>
+  );
 
   return (
     <div className="space-y-3">
@@ -119,15 +69,30 @@ export default function SafetyStep({ draft, patch, roles, rolesFailed, policyKey
             {t('aiAgentsPage.sections.policyDecide')}
           </legend>
           <p className="text-xs text-muted-foreground">{t('aiAgentsPage.fields.supervisedActionKeysHint')}</p>
-          <p className="text-xs text-muted-foreground" data-testid="ai-agent-supervised-keys-ceiling-hint">
-            {t('aiAgentsPage.graduation.ceilingHint')}
-          </p>
-          <PolicyKeysCheckboxes
-            policyKeys={policyKeys}
-            policyKeysFailed={policyKeysFailed}
-            selectedKeys={draft.supervisedActionKeys}
-            onToggle={(key) => patch({ supervisedActionKeys: toggle(draft.supervisedActionKeys, key) })}
-          />
+          {/* Same collapse rule as the edit drawer (`AiAgentForm.tsx`'s
+              `policyDecideFieldset`, via the shared `collapsedForCeiling`
+              helper): a shadow/off partner draft's registry starts collapsed
+              behind a summary that counts the selection, since ticking a key
+              here authorizes nothing on its own until the row is acting.
+              Entering act mode unwraps it entirely. */}
+          {collapsedForCeiling(draft.ownerScope, draft.mode) ? (
+            <details data-testid="ai-agent-policy-keys-details">
+              <summary className="cursor-pointer text-xs font-medium">
+                {t('aiAgentsPage.fields.supervisedActionKeysCeilingSummary', {
+                  count: draft.supervisedActionKeys.length,
+                })}
+              </summary>
+              <div className="mt-1 space-y-2">
+                {ceilingHint}
+                {policyKeysCheckboxes}
+              </div>
+            </details>
+          ) : (
+            <>
+              {ceilingHint}
+              {policyKeysCheckboxes}
+            </>
+          )}
         </fieldset>
       )}
 
@@ -153,48 +118,14 @@ export default function SafetyStep({ draft, patch, roles, rolesFailed, policyKey
         </div>
       </fieldset>
 
-      <fieldset className="space-y-2 rounded-md border p-3">
-        <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">
-          {t('aiAgentsPage.sections.notifications')}
-        </legend>
-        <p className="text-xs text-muted-foreground">{t('aiAgentsPage.fields.recipientRolesHint')}</p>
-        {rolesFailed ? (
-          <p className="text-sm text-destructive" data-testid="ai-agent-roles-failed">
-            {t('aiAgentsPage.fields.recipientRolesFailed')}
-          </p>
-        ) : roles.length === 0 ? (
-          <p className="text-sm text-muted-foreground" data-testid="ai-agent-roles-empty">
-            {t('aiAgentsPage.fields.recipientRolesEmpty')}
-          </p>
-        ) : (
-          <div className="space-y-3">
-            {ROLE_GROUPS.map((scope) => {
-              const group = roles.filter((role) => roleScope(role) === scope);
-              if (group.length === 0) return null;
-              return (
-                <div key={scope} role="group" aria-labelledby={`${rolesGroupBaseId}-${scope}`}>
-                  <p id={`${rolesGroupBaseId}-${scope}`} className="text-xs font-medium">
-                    {ROLE_GROUP_LABEL[scope]}
-                  </p>
-                  <div className="mt-1 flex flex-wrap gap-3" data-testid={`ai-agent-roles-${scope}`}>
-                    {group.map((role) => (
-                      <label key={role.id} className="flex items-center gap-1 text-sm">
-                        <input
-                          type="checkbox"
-                          checked={draft.roleIds.includes(role.id)}
-                          onChange={() => patch({ roleIds: toggle(draft.roleIds, role.id) })}
-                          data-testid={`ai-agent-role-${role.id}`}
-                        />
-                        {role.name}
-                      </label>
-                    ))}
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-        )}
-      </fieldset>
+      <RecipientRolesFieldset
+        className="space-y-2 rounded-md border p-3"
+        t={t}
+        roles={roles}
+        rolesFailed={rolesFailed}
+        roleIds={draft.roleIds}
+        onToggleRole={(id) => patch({ roleIds: toggle(draft.roleIds, id) })}
+      />
     </div>
   );
 }

--- a/apps/web/src/components/settings/aiAgents/steps/WhatItDoesStep.tsx
+++ b/apps/web/src/components/settings/aiAgents/steps/WhatItDoesStep.tsx
@@ -1,0 +1,115 @@
+import { useTranslation } from 'react-i18next';
+import { ALERT_SEVERITIES, type AgentCeilingDto, type AgentToolCatalogDto } from '@breeze/shared';
+import CapabilityPicker from '../CapabilityPicker';
+import { ALERT_SEVERITY_KINDS, lines, toggle, type Draft } from '../agentDraft';
+
+const inputCls = 'w-full rounded-md border bg-background px-2.5 py-1.5 text-sm';
+
+export interface WhatItDoesStepProps {
+  draft: Draft;
+  patch: (values: Partial<Draft>) => void;
+  catalog: AgentToolCatalogDto | null;
+  ceiling: AgentCeilingDto | null;
+  catalogLoading: boolean;
+}
+
+/**
+ * Step 2 of the guided create flow (spec §4.6): "Runs when" (severities for
+ * triage, maintenance windows, helpdesk ticket writes) above the capability
+ * picker — same order and test ids as `AiAgentForm.tsx`'s "When it runs"
+ * fieldset and Permissions section, so an operator moving between the drawer
+ * and the guided flow finds identical controls.
+ */
+export default function WhatItDoesStep({ draft, patch, catalog, ceiling, catalogLoading }: WhatItDoesStepProps) {
+  const { t } = useTranslation('settings');
+  const usesAlertSeverities = ALERT_SEVERITY_KINDS.has(draft.kind);
+
+  return (
+    <div className="space-y-3">
+      <fieldset className="space-y-2 rounded-md border p-3">
+        <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">
+          {t('aiAgentsPage.sections.scope')}
+        </legend>
+        {usesAlertSeverities && (
+          <div className="flex flex-wrap gap-3">
+            {ALERT_SEVERITIES.map((severity) => (
+              <label key={severity} className="flex items-center gap-1 text-sm">
+                <input
+                  type="checkbox"
+                  checked={draft.severities.includes(severity)}
+                  onChange={() => patch({ severities: toggle(draft.severities, severity) })}
+                  data-testid={`ai-agent-severity-${severity}`}
+                />
+                {t(/* i18n-dynamic */ `aiAgentsPage.severities.${severity}`)}
+              </label>
+            ))}
+          </div>
+        )}
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={draft.respectMaintenanceWindows}
+            onChange={(e) => patch({ respectMaintenanceWindows: e.target.checked })}
+            data-testid="ai-agent-respect-maintenance"
+          />
+          {t('aiAgentsPage.fields.respectMaintenanceWindows')}
+        </label>
+        {draft.kind === 'helpdesk' && (
+          <div className="space-y-1">
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={draft.ticketAutonomousWrites}
+                disabled={draft.ownerScope !== 'organization'}
+                onChange={(e) => patch({ ticketAutonomousWrites: e.target.checked })}
+                data-testid="ai-agent-ticket-autonomous-writes"
+              />
+              {t('aiAgentsPage.fields.ticketAutonomousWrites')}
+            </label>
+            <p className="pl-6 text-xs text-muted-foreground">
+              {t('aiAgentsPage.fields.ticketAutonomousWritesHint')}
+            </p>
+          </div>
+        )}
+      </fieldset>
+
+      <section className="space-y-2 rounded-md border p-3" data-testid="ai-agent-permissions">
+        <div>
+          <h3 className="text-sm font-semibold">{t('aiAgentsPage.sections.permissions')}</h3>
+          <p className="mt-0.5 text-xs text-muted-foreground">{t('aiAgentsPage.sections.permissionsDescription')}</p>
+        </div>
+        {catalog ? (
+          <CapabilityPicker
+            catalog={catalog}
+            ceiling={ceiling}
+            kind={draft.kind}
+            mode={draft.mode}
+            entries={lines(draft.toolAllowlist)}
+            onChange={(next) => patch({ toolAllowlist: next.join('\n') })}
+          />
+        ) : catalogLoading ? (
+          <p className="text-xs text-muted-foreground" data-testid="ai-agent-catalog-loading">
+            {t('aiAgentsPage.catalog.loading')}
+          </p>
+        ) : (
+          <>
+            <p className="text-xs text-muted-foreground" data-testid="ai-agent-catalog-unavailable">
+              {t('aiAgentsPage.catalog.catalogUnavailable')}
+            </p>
+            <p className="text-xs text-muted-foreground">{t('aiAgentsPage.fields.toolAllowlistHint')}</p>
+            <label className="space-y-1 text-sm">
+              <span className="font-medium">{t('aiAgentsPage.fields.toolAllowlist')}</span>
+              <textarea
+                className={`${inputCls} font-mono`}
+                rows={4}
+                value={draft.toolAllowlist}
+                onChange={(e) => patch({ toolAllowlist: e.target.value })}
+                data-testid="ai-agent-toolallowlist"
+              />
+            </label>
+          </>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/components/setup/SetupStepper.test.tsx
+++ b/apps/web/src/components/setup/SetupStepper.test.tsx
@@ -1,0 +1,56 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import SetupStepper from './SetupStepper';
+
+const STEPS = [
+  { label: 'Purpose', description: 'Mode, kind and name' },
+  { label: 'What it does', description: 'Triggers and capabilities' },
+  { label: 'Safety', description: 'Limits and oversight' },
+];
+
+describe('SetupStepper', () => {
+  it('defaults the accessible name to the auth setup wizard string when ariaLabel is omitted', () => {
+    render(<SetupStepper steps={STEPS} currentStep={0} />);
+    expect(screen.getByRole('navigation', { name: 'Setup progress' })).toBeInTheDocument();
+  });
+
+  it('uses a caller-supplied ariaLabel instead of the auth default', () => {
+    render(<SetupStepper steps={STEPS} currentStep={0} ariaLabel="New agent steps" />);
+    expect(screen.getByRole('navigation', { name: 'New agent steps' })).toBeInTheDocument();
+    expect(screen.queryByRole('navigation', { name: 'Setup progress' })).toBeNull();
+  });
+
+  it('renders horizontally by default, without step descriptions', () => {
+    render(<SetupStepper steps={STEPS} currentStep={1} ariaLabel="Steps" />);
+    expect(screen.getByText('Purpose')).toBeInTheDocument();
+    expect(screen.queryByText('Mode, kind and name')).toBeNull();
+  });
+
+  it('renders vertically with a description under each step label when orientation="vertical"', () => {
+    render(<SetupStepper steps={STEPS} currentStep={1} ariaLabel="Steps" orientation="vertical" />);
+    expect(screen.getByTestId('setup-stepper-vertical')).toBeInTheDocument();
+    expect(screen.getByText('Mode, kind and name')).toBeInTheDocument();
+    expect(screen.getByText('Triggers and capabilities')).toBeInTheDocument();
+    expect(screen.getByText('Limits and oversight')).toBeInTheDocument();
+  });
+
+  it('lets a completed step be clicked, but not the current or an upcoming one', () => {
+    const onStepClick = vi.fn();
+    render(<SetupStepper steps={STEPS} currentStep={1} ariaLabel="Steps" orientation="vertical" onStepClick={onStepClick} />);
+
+    fireEvent.click(screen.getByTestId('setup-stepper-step-0'));
+    expect(onStepClick).toHaveBeenCalledWith(0);
+
+    fireEvent.click(screen.getByTestId('setup-stepper-step-1'));
+    fireEvent.click(screen.getByTestId('setup-stepper-step-2'));
+    expect(onStepClick).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('setup-stepper-step-1')).toBeDisabled();
+    expect(screen.getByTestId('setup-stepper-step-2')).toBeDisabled();
+  });
+
+  it('marks the current step with aria-current="step" only in the vertical layout', () => {
+    render(<SetupStepper steps={STEPS} currentStep={2} ariaLabel="Steps" orientation="vertical" />);
+    expect(screen.getByTestId('setup-stepper-step-2')).toHaveAttribute('aria-current', 'step');
+    expect(screen.getByTestId('setup-stepper-step-0')).not.toHaveAttribute('aria-current');
+  });
+});

--- a/apps/web/src/components/setup/SetupStepper.tsx
+++ b/apps/web/src/components/setup/SetupStepper.tsx
@@ -4,19 +4,92 @@ import { cn } from '@/lib/utils';
 
 export interface Step {
   label: string;
+  /** Shown beneath the label — only rendered in `orientation="vertical"`
+   *  (the horizontal auth wizard rail has never had room for it). */
+  description?: string;
 }
 
 interface SetupStepperProps {
   steps: Step[];
   currentStep: number;
   onStepClick?: (step: number) => void;
+  /** Overrides the nav's accessible name. Defaults to the auth setup
+   *  wizard's own string (`setup.stepper.ariaLabel`) so every existing
+   *  caller is unaffected — a caller outside that flow (the AI agent create
+   *  flow's vertical rail) names itself instead of borrowing that copy. */
+  ariaLabel?: string;
+  /** `'horizontal'` (default) is the original auth-wizard rail: circles in a
+   *  row, chevron separators, labels beside/under each circle. `'vertical'`
+   *  stacks the steps in a column with a 1px connector between circles and
+   *  the label (plus an optional `description`) beside each one — the
+   *  left-rail pattern the AI agent create flow (spec §4.6) needs. */
+  orientation?: 'horizontal' | 'vertical';
 }
 
-export default function SetupStepper({ steps, currentStep, onStepClick }: SetupStepperProps) {
+export default function SetupStepper({ steps, currentStep, onStepClick, ariaLabel, orientation = 'horizontal' }: SetupStepperProps) {
   const { t } = useTranslation('auth');
+  const label = ariaLabel ?? t('setup.stepper.ariaLabel');
+
+  if (orientation === 'vertical') {
+    return (
+      <nav aria-label={label} className="flex flex-col" data-testid="setup-stepper-vertical">
+        {steps.map((step, index) => {
+          const isCompleted = index < currentStep;
+          const isCurrent = index === currentStep;
+          const isClickable = isCompleted && !!onStepClick;
+          const isLast = index === steps.length - 1;
+
+          return (
+            <div key={step.label} className="flex gap-3">
+              <div className="flex flex-col items-center">
+                <button
+                  type="button"
+                  disabled={!isClickable}
+                  onClick={() => isClickable && onStepClick(index)}
+                  aria-current={isCurrent ? 'step' : undefined}
+                  className={cn(
+                    'flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-sm font-medium transition-colors focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring',
+                    isCompleted && 'bg-primary text-primary-foreground',
+                    isCurrent && 'bg-primary text-primary-foreground ring-2 ring-primary/30 ring-offset-2 ring-offset-background',
+                    !isCompleted && !isCurrent && 'bg-muted text-muted-foreground',
+                    isClickable && 'cursor-pointer',
+                  )}
+                  data-testid={`setup-stepper-step-${index}`}
+                >
+                  {isCompleted ? <Check className="h-4 w-4" /> : index + 1}
+                </button>
+                {/* The connector between this circle and the next — a plain
+                    1px line, not a progress bar: the circles themselves
+                    already carry the completed/current/upcoming state. */}
+                {!isLast && <div className="w-px flex-1 bg-border" aria-hidden="true" />}
+              </div>
+              <div className={cn('min-w-0', isLast ? 'pb-0' : 'pb-6')}>
+                <button
+                  type="button"
+                  disabled={!isClickable}
+                  onClick={() => isClickable && onStepClick(index)}
+                  className={cn(
+                    'text-left text-sm font-medium',
+                    (isCurrent || isCompleted) && 'text-foreground',
+                    !isCompleted && !isCurrent && 'text-muted-foreground',
+                    isClickable && 'cursor-pointer hover:underline',
+                  )}
+                >
+                  {step.label}
+                </button>
+                {step.description && (
+                  <p className="mt-0.5 text-xs text-muted-foreground">{step.description}</p>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </nav>
+    );
+  }
 
   return (
-    <nav aria-label={t('setup.stepper.ariaLabel')} className="flex items-center justify-center gap-2">
+    <nav aria-label={label} className="flex items-center justify-center gap-2">
       {steps.map((step, index) => {
         const isCompleted = index < currentStep;
         const isCurrent = index === currentStep;
@@ -32,6 +105,7 @@ export default function SetupStepper({ steps, currentStep, onStepClick }: SetupS
                 'flex items-center gap-2',
                 isClickable && 'cursor-pointer'
               )}
+              data-testid={`setup-stepper-step-${index}`}
             >
               <div
                 className={cn(

--- a/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+++ b/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
@@ -67,6 +67,10 @@ const TARGET_GLOBS = [
   // an unreported failure on the surface that governs autonomous agents.
   'src/components/settings/AiAgentsPage.tsx',
   'src/components/settings/AiAgentForm.tsx',
+  // Task 13 (#5051): the guided create flow's own POST /ai/agents — the same
+  // surface AiAgentForm.tsx's create path already guards, just reached
+  // through the four-step flow instead of the drawer.
+  'src/components/settings/aiAgents/AgentCreateFlow.tsx',
   // Sweep schedules (P2-2, #4189): the section writes partner-wide baselines
   // and per-org overrides that decide what runs against customer machines on a
   // cron, unattended. A silent create/update/delete here is invisible until the
@@ -582,9 +586,10 @@ describe('no silent mutations in targeted set', () => {
     // more (AssignmentsTab.tsx) to reach 115. A prior commit added 3 more
     // (#4767 — ExecutionHistory.tsx, ExecutionDetails.tsx,
     // ScriptExecutionsPage.tsx) to reach 118. This commit adds 1 more
-    // (AutomationRunHistory.tsx), so the count is now 119 — bump it
+    // (AutomationRunHistory.tsx), so the count was 119. Task 13 (#5051) adds
+    // 1 more (AgentCreateFlow.tsx), so the count is now 120 — bump it
     // deliberately on every merge, never by resolving the hunk.
-    expect(absoluteFiles.length).toBe(122);
+    expect(absoluteFiles.length).toBe(123);
     for (const f of absoluteFiles) {
       expect(() => statSync(f)).not.toThrow();
     }

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -2690,9 +2690,62 @@
       "executesUnattendedList": "Führt {{list}} aus, ohne auf die Genehmigung eines Technikers zu warten.",
       "preauthorizedNote": "Einige davon sind vorautorisierte Operationen, die im Voraus durch das Vier-Augen-Prüfverfahren gewährt wurden.",
       "neverTouchesEmpty": "Noch nichts geschützt.",
-      "limits": "Bis zu {{devices}} Geräte pro Lauf, {{runsPerHour}} Läufe pro Stunde, {{minutes}} Minuten pro Lauf, ein Tagesbudget von {{budget}} und höchstens {{fleetPercent}} der Flotte pro Tag.",
+      "limits": "Bis zu {{devices}} Geräte pro Lauf, {{runsPerHour}} Läufe pro Stunde, {{minutes}} Minuten pro Lauf, ein Tagesbudget von {{budget}}, höchstens {{fleetPercent}} der Flotte pro Tag und {{cooldown}} Minuten zwischen zwei Läufen auf demselben Gerät.",
       "approvers": "{{count}} Rollen werden gefragt, über Posteingang, Chat und mobile Push-Benachrichtigungen. Die erste Entscheidung zählt.",
       "approversNone": "Es sind noch keine Rollen konfiguriert, daher wird niemand benachrichtigt."
+    },
+    "flow": {
+      "title": "Neuer Agent",
+      "stepperAriaLabel": "Schritte für neuen Agenten",
+      "back": "Zurück",
+      "next": "Weiter: {{step}}",
+      "createAgent": "Agent erstellen",
+      "createdDisabledNote": "Neue Agenten werden deaktiviert erstellt. Du entscheidest im letzten Schritt, nachdem du alles überprüft hast, ob er aktiv laufen soll.",
+      "startEnabled": "Aktiviert starten",
+      "startEnabledHint": "Aus ist die sichere Standardeinstellung. Prüfe die Zusammenfassung oben und schalte dies erst ein, wenn der Agent laufen soll.",
+      "previewFailed": "Eine Live-Vorschau der Richtlinie dieses Agenten konnte nicht geladen werden. Du kannst ihn trotzdem erstellen — prüfe deine Auswahl vorher sorgfältig.",
+      "previewLoading": "Vorschau wird geladen…",
+      "protectedResourcesLegend": "Geschützte Ressourcen",
+      "steps": {
+        "purpose": {
+          "label": "Zweck und Haltung",
+          "description": "Modus, Art, Zuordnung und Name"
+        },
+        "does": {
+          "label": "Was er tut",
+          "description": "Auslöser und Fähigkeiten"
+        },
+        "safety": {
+          "label": "Sicherheit und Aufsicht",
+          "description": "Geschützte Ressourcen, Limits und Genehmiger"
+        },
+        "review": {
+          "label": "Überprüfen und erstellen",
+          "description": "Bestätige, was dieser Agent tun wird"
+        }
+      },
+      "kinds": {
+        "triage": {
+          "blurb": "Beobachtet Warnungen und schlägt Lösungen für die wichtigen vor.",
+          "runsWhen": "eine neue Warnung einen der von dir gewählten Schweregrade erreicht",
+          "recommended": "hängende Dienste neu starten und Speicherplatz freigeben"
+        },
+        "patch": {
+          "blurb": "Prüft fehlende Patches und schlägt vor, was installiert werden soll.",
+          "runsWhen": "sein Zeitplan ausgelöst wird oder du ihn manuell startest",
+          "recommended": "Patches genehmigen und installieren und dann betroffene Dienste neu starten"
+        },
+        "helpdesk": {
+          "blurb": "Bearbeitet Tickets, sobald sie erstellt, beantwortet oder gelöst werden.",
+          "runsWhen": "ein Ticket erstellt wird, seine erste Antwort erhält oder als gelöst markiert wird",
+          "recommended": "Dienste neu starten und Speicherplatz freigeben, um häufige Anfragen zu lösen"
+        }
+      },
+      "kindCard": {
+        "runsWhenPrefix": "Läuft, wenn:",
+        "recommendedPrefix": "Empfohlen:",
+        "taken": "Für diesen Eigentümer bereits vergeben"
+      }
     }
   },
   "apiKeyForm": {

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -2658,6 +2658,41 @@
       },
       "catalogUnavailable": "Der Tool-Katalog konnte nicht geladen werden. Sie können die Berechtigungsliste weiterhin direkt unten bearbeiten.",
       "loading": "Fähigkeiten werden geladen…"
+    },
+    "summary": {
+      "edit": "Bearbeiten",
+      "createdDisabled": "Deaktiviert erstellt",
+      "enabled": "Aktiviert",
+      "allOrganizations": "alle Organisationen",
+      "rowLabels": {
+        "runsWhen": "Läuft, wenn",
+        "canRead": "Kann lesen",
+        "mayPropose": "Darf vorschlagen",
+        "executesUnattended": "Führt unbeaufsichtigt aus",
+        "neverTouches": "Fasst nie an",
+        "limits": "Grenzwerte",
+        "approvers": "Fragt um Genehmigung bei"
+      },
+      "runsWhen": {
+        "triage": "Läuft bei neuen Warnungen mit Schweregrad {{severities}} auf jedem Gerät.",
+        "anySeverity": "beliebigem Schweregrad",
+        "patch": "Läuft nach Zeitplan oder bei manueller Auslösung, um fehlende Patches zu prüfen.",
+        "helpdesk": "Läuft, wenn ein Ticket erstellt wird, die erste Antwort erhält oder als gelöst markiert wird.",
+        "maintenanceWindows": "Wartet Wartungsfenster ab.",
+        "ticketWrites": "Schreibt Ticket-Updates, ohne auf einen Techniker zu warten."
+      },
+      "canRead": "Geräte-, Warnungs- und Flottendaten für {{scope}}: Inventar, Metriken, Protokolle, Patches, Backups, Tickets und Prüfhistorie ({{count}} schreibgeschützte Tools, immer aktiv).",
+      "mayPropose": "{{operations}} Operationen in {{capabilities}} Fähigkeiten: {{approvalRequests}} lösen eine Genehmigungsanfrage aus, über die ein Techniker entscheidet, und {{loggedProposals}} werden als Vorschläge protokolliert und nie ausgeführt.",
+      "mayProposeNone": "Dieser Agent schlägt noch keine Operationen vor.",
+      "unrecognisedLabel": "Vom aktuellen Tool-Katalog nicht erkannt:",
+      "executesUnattendedNone": "Nichts. Der Schattenmodus beobachtet und schlägt nur vor; ohne Genehmigung eines Technikers läuft nichts.",
+      "executesUnattendedNoneAct": "Noch nichts — keine ausgewählte Operation ist für die unbeaufsichtigte Ausführung geeignet.",
+      "executesUnattendedList": "Führt {{list}} aus, ohne auf die Genehmigung eines Technikers zu warten.",
+      "preauthorizedNote": "Einige davon sind vorautorisierte Operationen, die im Voraus durch das Vier-Augen-Prüfverfahren gewährt wurden.",
+      "neverTouchesEmpty": "Noch nichts geschützt.",
+      "limits": "Bis zu {{devices}} Geräte pro Lauf, {{runsPerHour}} Läufe pro Stunde, {{minutes}} Minuten pro Lauf, ein Tagesbudget von {{budget}} und höchstens {{fleetPercent}} der Flotte pro Tag.",
+      "approvers": "{{count}} Rollen werden gefragt, über Posteingang, Chat und mobile Push-Benachrichtigungen. Die erste Entscheidung zählt.",
+      "approversNone": "Es sind noch keine Rollen konfiguriert, daher wird niemand benachrichtigt."
     }
   },
   "apiKeyForm": {

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -2658,6 +2658,41 @@
       },
       "catalogUnavailable": "Could not load the tool catalog. You can still edit the permissions list directly below.",
       "loading": "Loading capabilities…"
+    },
+    "summary": {
+      "edit": "Edit",
+      "createdDisabled": "Created disabled",
+      "enabled": "Enabled",
+      "allOrganizations": "all organizations",
+      "rowLabels": {
+        "runsWhen": "Runs when",
+        "canRead": "Can read",
+        "mayPropose": "May propose",
+        "executesUnattended": "Executes unattended",
+        "neverTouches": "Never touches",
+        "limits": "Limits",
+        "approvers": "Asks for approval from"
+      },
+      "runsWhen": {
+        "triage": "Runs on new {{severities}} alerts on any device.",
+        "anySeverity": "any-severity",
+        "patch": "Runs on a schedule, or when triggered manually, to review missing patches.",
+        "helpdesk": "Runs when a ticket is created, gets its first reply, or is marked resolved.",
+        "maintenanceWindows": "Waits out maintenance windows.",
+        "ticketWrites": "Writes ticket updates without waiting for a technician."
+      },
+      "canRead": "Device, alert and fleet data for {{scope}}: inventory, metrics, logs, patches, backups, tickets and audit history ({{count}} read-only tools, always on).",
+      "mayPropose": "{{operations}} operations across {{capabilities}} capabilities: {{approvalRequests}} raise an approval request that a technician decides, and {{loggedProposals}} are logged as proposals and never executed.",
+      "mayProposeNone": "This agent does not propose any operations yet.",
+      "unrecognisedLabel": "Not recognized by the current tool catalog:",
+      "executesUnattendedNone": "Nothing. Shadow mode observes and proposes; nothing runs without a technician's approval.",
+      "executesUnattendedNoneAct": "Nothing yet — no selected operation is eligible to run unattended.",
+      "executesUnattendedList": "Executes {{list}} without a technician's approval.",
+      "preauthorizedNote": "Some of these are pre-authorized operations, granted ahead of time through the four-eyes review process.",
+      "neverTouchesEmpty": "Nothing is protected yet.",
+      "limits": "Up to {{devices}} devices per run, {{runsPerHour}} runs per hour, {{minutes}} minutes per run, a daily budget of {{budget}}, and no more than {{fleetPercent}} of the fleet touched per day.",
+      "approvers": "{{count}} roles are asked, via inbox, chat and mobile push. First decision wins.",
+      "approversNone": "No roles are configured yet, so nothing will be notified."
     }
   },
   "apiKeyForm": {

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -2690,9 +2690,62 @@
       "executesUnattendedList": "Executes {{list}} without a technician's approval.",
       "preauthorizedNote": "Some of these are pre-authorized operations, granted ahead of time through the four-eyes review process.",
       "neverTouchesEmpty": "Nothing is protected yet.",
-      "limits": "Up to {{devices}} devices per run, {{runsPerHour}} runs per hour, {{minutes}} minutes per run, a daily budget of {{budget}}, and no more than {{fleetPercent}} of the fleet touched per day.",
+      "limits": "Up to {{devices}} devices per run, {{runsPerHour}} runs per hour, {{minutes}} minutes per run, a daily budget of {{budget}}, no more than {{fleetPercent}} of the fleet touched per day, and {{cooldown}} minutes between runs on the same device.",
       "approvers": "{{count}} roles are asked, via inbox, chat and mobile push. First decision wins.",
       "approversNone": "No roles are configured yet, so nothing will be notified."
+    },
+    "flow": {
+      "title": "New agent",
+      "stepperAriaLabel": "New agent steps",
+      "back": "Back",
+      "next": "Next: {{step}}",
+      "createAgent": "Create agent",
+      "createdDisabledNote": "New agents are created switched off. You'll decide whether to start it running on the last step, after reviewing everything.",
+      "startEnabled": "Start enabled",
+      "startEnabledHint": "Off is the safe default. Review the summary above, then switch this on when you want the agent to start running.",
+      "previewFailed": "Could not load a live preview of this agent's policy. You can still create it — review your choices carefully first.",
+      "previewLoading": "Loading preview…",
+      "protectedResourcesLegend": "Protected resources",
+      "steps": {
+        "purpose": {
+          "label": "Purpose and posture",
+          "description": "Mode, kind, ownership and name"
+        },
+        "does": {
+          "label": "What it does",
+          "description": "Triggers and capabilities"
+        },
+        "safety": {
+          "label": "Safety and oversight",
+          "description": "Protected resources, limits and approvers"
+        },
+        "review": {
+          "label": "Review and create",
+          "description": "Confirm what this agent will do"
+        }
+      },
+      "kinds": {
+        "triage": {
+          "blurb": "Watches alerts and proposes fixes for the ones that matter.",
+          "runsWhen": "a new alert crosses the severities you choose",
+          "recommended": "restarting stuck services and clearing disk space"
+        },
+        "patch": {
+          "blurb": "Reviews missing patches and proposes what to install.",
+          "runsWhen": "its schedule fires, or you trigger it manually",
+          "recommended": "approving and installing patches, then restarting affected services"
+        },
+        "helpdesk": {
+          "blurb": "Works tickets as they're created, replied to, or resolved.",
+          "runsWhen": "a ticket is created, gets its first reply, or is marked resolved",
+          "recommended": "restarting services and clearing disk space to resolve common requests"
+        }
+      },
+      "kindCard": {
+        "runsWhenPrefix": "Runs when:",
+        "recommendedPrefix": "Recommended:",
+        "taken": "Already in use for this owner"
+      }
     }
   },
   "apiKeyForm": {

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -2690,9 +2690,62 @@
       "executesUnattendedList": "Ejecuta {{list}} sin esperar la aprobación de un técnico.",
       "preauthorizedNote": "Algunas de estas son operaciones preautorizadas, otorgadas de antemano mediante el proceso de revisión de cuatro ojos.",
       "neverTouchesEmpty": "Todavía no hay nada protegido.",
-      "limits": "Hasta {{devices}} dispositivos por ejecución, {{runsPerHour}} ejecuciones por hora, {{minutes}} minutos por ejecución, un presupuesto diario de {{budget}}, y no más del {{fleetPercent}} de la flota por día.",
+      "limits": "Hasta {{devices}} dispositivos por ejecución, {{runsPerHour}} ejecuciones por hora, {{minutes}} minutos por ejecución, un presupuesto diario de {{budget}}, no más del {{fleetPercent}} de la flota por día, y {{cooldown}} minutos entre ejecuciones en el mismo dispositivo.",
       "approvers": "Se consulta a {{count}} roles, por bandeja de entrada, chat y notificaciones push móviles. Gana la primera decisión.",
       "approversNone": "Todavía no hay roles configurados, por lo que no se notificará a nadie."
+    },
+    "flow": {
+      "title": "Nuevo agente",
+      "stepperAriaLabel": "Pasos para el nuevo agente",
+      "back": "Atrás",
+      "next": "Siguiente: {{step}}",
+      "createAgent": "Crear agente",
+      "createdDisabledNote": "Los agentes nuevos se crean apagados. Decidirás si debe empezar a ejecutarse en el último paso, después de revisar todo.",
+      "startEnabled": "Iniciar habilitado",
+      "startEnabledHint": "Apagado es la opción segura por defecto. Revisa el resumen anterior y actívalo cuando quieras que el agente empiece a ejecutarse.",
+      "previewFailed": "No se pudo cargar una vista previa en vivo de la política de este agente. Aún puedes crearlo — revisa tus opciones con cuidado primero.",
+      "previewLoading": "Cargando vista previa…",
+      "protectedResourcesLegend": "Recursos protegidos",
+      "steps": {
+        "purpose": {
+          "label": "Propósito y postura",
+          "description": "Modo, tipo, propiedad y nombre"
+        },
+        "does": {
+          "label": "Qué hace",
+          "description": "Disparadores y capacidades"
+        },
+        "safety": {
+          "label": "Seguridad y supervisión",
+          "description": "Recursos protegidos, límites y aprobadores"
+        },
+        "review": {
+          "label": "Revisar y crear",
+          "description": "Confirma qué hará este agente"
+        }
+      },
+      "kinds": {
+        "triage": {
+          "blurb": "Vigila las alertas y propone soluciones para las que importan.",
+          "runsWhen": "una nueva alerta cruza las severidades que elijas",
+          "recommended": "reiniciar servicios bloqueados y liberar espacio en disco"
+        },
+        "patch": {
+          "blurb": "Revisa los parches faltantes y propone cuáles instalar.",
+          "runsWhen": "se activa su programación, o lo activas manualmente",
+          "recommended": "aprobar e instalar parches y luego reiniciar los servicios afectados"
+        },
+        "helpdesk": {
+          "blurb": "Trabaja los tickets a medida que se crean, reciben respuesta o se resuelven.",
+          "runsWhen": "se crea un ticket, recibe su primera respuesta o se marca como resuelto",
+          "recommended": "reiniciar servicios y liberar espacio en disco para resolver solicitudes comunes"
+        }
+      },
+      "kindCard": {
+        "runsWhenPrefix": "Se ejecuta cuando:",
+        "recommendedPrefix": "Recomendado:",
+        "taken": "Ya está en uso para este propietario"
+      }
     }
   },
   "apiKeyForm": {

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -2658,6 +2658,41 @@
       },
       "catalogUnavailable": "No se pudo cargar el catálogo de herramientas. Aun así, puede editar la lista de permisos directamente abajo.",
       "loading": "Cargando capacidades…"
+    },
+    "summary": {
+      "edit": "Editar",
+      "createdDisabled": "Creado deshabilitado",
+      "enabled": "Habilitado",
+      "allOrganizations": "todas las organizaciones",
+      "rowLabels": {
+        "runsWhen": "Se ejecuta cuando",
+        "canRead": "Puede leer",
+        "mayPropose": "Puede proponer",
+        "executesUnattended": "Ejecuta sin supervisión",
+        "neverTouches": "Nunca toca",
+        "limits": "Límites",
+        "approvers": "Pide aprobación a"
+      },
+      "runsWhen": {
+        "triage": "Se ejecuta ante nuevas alertas de gravedad {{severities}} en cualquier dispositivo.",
+        "anySeverity": "cualquier gravedad",
+        "patch": "Se ejecuta según un cronograma, o cuando se activa manualmente, para revisar los parches faltantes.",
+        "helpdesk": "Se ejecuta cuando se crea un ticket, recibe su primera respuesta o se marca como resuelto.",
+        "maintenanceWindows": "Espera a que terminen las ventanas de mantenimiento.",
+        "ticketWrites": "Escribe actualizaciones del ticket sin esperar a un técnico."
+      },
+      "canRead": "Datos de dispositivos, alertas y flota para {{scope}}: inventario, métricas, registros, parches, copias de seguridad, tickets e historial de auditoría ({{count}} herramientas de solo lectura, siempre activas).",
+      "mayPropose": "{{operations}} operaciones en {{capabilities}} capacidades: {{approvalRequests}} generan una solicitud de aprobación que decide un técnico, y {{loggedProposals}} se registran como propuestas y nunca se ejecutan.",
+      "mayProposeNone": "Este agente todavía no propone ninguna operación.",
+      "unrecognisedLabel": "No reconocidas por el catálogo de herramientas actual:",
+      "executesUnattendedNone": "Nada. El modo sombra solo observa y propone; nada se ejecuta sin la aprobación de un técnico.",
+      "executesUnattendedNoneAct": "Todavía nada: ninguna operación seleccionada es apta para ejecutarse sin supervisión.",
+      "executesUnattendedList": "Ejecuta {{list}} sin esperar la aprobación de un técnico.",
+      "preauthorizedNote": "Algunas de estas son operaciones preautorizadas, otorgadas de antemano mediante el proceso de revisión de cuatro ojos.",
+      "neverTouchesEmpty": "Todavía no hay nada protegido.",
+      "limits": "Hasta {{devices}} dispositivos por ejecución, {{runsPerHour}} ejecuciones por hora, {{minutes}} minutos por ejecución, un presupuesto diario de {{budget}}, y no más del {{fleetPercent}} de la flota por día.",
+      "approvers": "Se consulta a {{count}} roles, por bandeja de entrada, chat y notificaciones push móviles. Gana la primera decisión.",
+      "approversNone": "Todavía no hay roles configurados, por lo que no se notificará a nadie."
     }
   },
   "apiKeyForm": {

--- a/apps/web/src/locales/fr-CA/settings.json
+++ b/apps/web/src/locales/fr-CA/settings.json
@@ -2690,9 +2690,62 @@
       "executesUnattendedList": "Exécute {{list}} sans attendre l'approbation d'un technicien.",
       "preauthorizedNote": "Certaines sont des opérations préautorisées, accordées à l'avance via le processus de contrôle à quatre yeux.",
       "neverTouchesEmpty": "Rien n'est encore protégé.",
-      "limits": "Jusqu'à {{devices}} appareils par exécution, {{runsPerHour}} exécutions par heure, {{minutes}} minutes par exécution, un budget quotidien de {{budget}}, et pas plus de {{fleetPercent}} du parc par jour.",
+      "limits": "Jusqu'à {{devices}} appareils par exécution, {{runsPerHour}} exécutions par heure, {{minutes}} minutes par exécution, un budget quotidien de {{budget}}, pas plus de {{fleetPercent}} du parc par jour, et {{cooldown}} minutes entre deux exécutions sur le même appareil.",
       "approvers": "{{count}} rôles sont sollicités, par boîte de réception, messagerie et notification push mobile. La première décision l'emporte.",
       "approversNone": "Aucun rôle n'est encore configuré, donc personne ne sera notifié."
+    },
+    "flow": {
+      "title": "Nouvel agent",
+      "stepperAriaLabel": "Étapes du nouvel agent",
+      "back": "Retour",
+      "next": "Suivant : {{step}}",
+      "createAgent": "Créer l'agent",
+      "createdDisabledNote": "Les nouveaux agents sont créés désactivés. Vous déciderez de le démarrer à la dernière étape, après avoir tout vérifié.",
+      "startEnabled": "Démarrer activé",
+      "startEnabledHint": "Désactivé est le choix sûr par défaut. Vérifiez le résumé ci-dessus, puis activez ceci lorsque vous voulez que l'agent commence à fonctionner.",
+      "previewFailed": "Impossible de charger un aperçu en direct de la politique de cet agent. Vous pouvez tout de même le créer — vérifiez vos choix attentivement au préalable.",
+      "previewLoading": "Chargement de l'aperçu…",
+      "protectedResourcesLegend": "Ressources protégées",
+      "steps": {
+        "purpose": {
+          "label": "Objectif et posture",
+          "description": "Mode, type, propriété et nom"
+        },
+        "does": {
+          "label": "Ce qu'il fait",
+          "description": "Déclencheurs et capacités"
+        },
+        "safety": {
+          "label": "Sécurité et supervision",
+          "description": "Ressources protégées, limites et approbateurs"
+        },
+        "review": {
+          "label": "Vérifier et créer",
+          "description": "Confirmez ce que cet agent va faire"
+        }
+      },
+      "kinds": {
+        "triage": {
+          "blurb": "Surveille les alertes et propose des correctifs pour celles qui comptent.",
+          "runsWhen": "une nouvelle alerte atteint les gravités que vous choisissez",
+          "recommended": "redémarrer les services bloqués et libérer de l'espace disque"
+        },
+        "patch": {
+          "blurb": "Examine les correctifs manquants et propose lesquels installer.",
+          "runsWhen": "son horaire se déclenche, ou vous le déclenchez manuellement",
+          "recommended": "approuver et installer les correctifs, puis redémarrer les services concernés"
+        },
+        "helpdesk": {
+          "blurb": "Traite les tickets dès leur création, leur première réponse ou leur résolution.",
+          "runsWhen": "un ticket est créé, reçoit sa première réponse, ou est marqué résolu",
+          "recommended": "redémarrer les services et libérer de l'espace disque pour résoudre les demandes courantes"
+        }
+      },
+      "kindCard": {
+        "runsWhenPrefix": "S'exécute quand :",
+        "recommendedPrefix": "Recommandé :",
+        "taken": "Déjà utilisé pour ce propriétaire"
+      }
     }
   },
   "apiKeyForm": {

--- a/apps/web/src/locales/fr-CA/settings.json
+++ b/apps/web/src/locales/fr-CA/settings.json
@@ -2658,6 +2658,41 @@
       },
       "catalogUnavailable": "Impossible de charger le catalogue d'outils. Vous pouvez toujours modifier la liste des permissions directement ci-dessous.",
       "loading": "Chargement des capacités…"
+    },
+    "summary": {
+      "edit": "Modifier",
+      "createdDisabled": "Créé désactivé",
+      "enabled": "Activé",
+      "allOrganizations": "toutes les organisations",
+      "rowLabels": {
+        "runsWhen": "S'exécute quand",
+        "canRead": "Peut lire",
+        "mayPropose": "Peut proposer",
+        "executesUnattended": "Exécute sans surveillance",
+        "neverTouches": "Ne touche jamais",
+        "limits": "Limites",
+        "approvers": "Demande l'approbation de"
+      },
+      "runsWhen": {
+        "triage": "S'exécute lors de nouvelles alertes de gravité {{severities}} sur n'importe quel appareil.",
+        "anySeverity": "toute gravité",
+        "patch": "S'exécute selon un horaire, ou lorsqu'il est déclenché manuellement, pour examiner les correctifs manquants.",
+        "helpdesk": "S'exécute quand un ticket est créé, reçoit sa première réponse ou est marqué comme résolu.",
+        "maintenanceWindows": "Attend la fin des fenêtres de maintenance.",
+        "ticketWrites": "Écrit des mises à jour de ticket sans attendre un technicien."
+      },
+      "canRead": "Données d'appareils, d'alertes et de parc pour {{scope}}: inventaire, métriques, journaux, correctifs, sauvegardes, tickets et historique d'audit ({{count}} outils en lecture seule, toujours actifs).",
+      "mayPropose": "{{operations}} opérations réparties sur {{capabilities}} capacités: {{approvalRequests}} déclenchent une demande d'approbation qu'un technicien tranche, et {{loggedProposals}} sont consignées comme propositions et ne sont jamais exécutées.",
+      "mayProposeNone": "Cet agent ne propose encore aucune opération.",
+      "unrecognisedLabel": "Non reconnues par le catalogue d'outils actuel:",
+      "executesUnattendedNone": "Rien. Le mode observation se contente d'observer et de proposer; rien ne s'exécute sans l'approbation d'un technicien.",
+      "executesUnattendedNoneAct": "Rien pour l'instant — aucune opération sélectionnée n'est éligible à une exécution sans surveillance.",
+      "executesUnattendedList": "Exécute {{list}} sans attendre l'approbation d'un technicien.",
+      "preauthorizedNote": "Certaines sont des opérations préautorisées, accordées à l'avance via le processus de contrôle à quatre yeux.",
+      "neverTouchesEmpty": "Rien n'est encore protégé.",
+      "limits": "Jusqu'à {{devices}} appareils par exécution, {{runsPerHour}} exécutions par heure, {{minutes}} minutes par exécution, un budget quotidien de {{budget}}, et pas plus de {{fleetPercent}} du parc par jour.",
+      "approvers": "{{count}} rôles sont sollicités, par boîte de réception, messagerie et notification push mobile. La première décision l'emporte.",
+      "approversNone": "Aucun rôle n'est encore configuré, donc personne ne sera notifié."
     }
   },
   "apiKeyForm": {

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -2690,9 +2690,62 @@
       "executesUnattendedList": "Exécute {{list}} sans attendre l'approbation d'un technicien.",
       "preauthorizedNote": "Certaines sont des opérations préautorisées, accordées à l'avance via le processus de contrôle à quatre yeux.",
       "neverTouchesEmpty": "Rien n'est encore protégé.",
-      "limits": "Jusqu'à {{devices}} appareils par exécution, {{runsPerHour}} exécutions par heure, {{minutes}} minutes par exécution, un budget quotidien de {{budget}}, et pas plus de {{fleetPercent}} du parc par jour.",
+      "limits": "Jusqu'à {{devices}} appareils par exécution, {{runsPerHour}} exécutions par heure, {{minutes}} minutes par exécution, un budget quotidien de {{budget}}, pas plus de {{fleetPercent}} du parc par jour, et {{cooldown}} minutes entre deux exécutions sur le même appareil.",
       "approvers": "{{count}} rôles sont sollicités, par boîte de réception, messagerie et notification push mobile. La première décision l'emporte.",
       "approversNone": "Aucun rôle n'est encore configuré, donc personne ne sera notifié."
+    },
+    "flow": {
+      "title": "Nouvel agent",
+      "stepperAriaLabel": "Étapes du nouvel agent",
+      "back": "Retour",
+      "next": "Suivant : {{step}}",
+      "createAgent": "Créer l'agent",
+      "createdDisabledNote": "Les nouveaux agents sont créés désactivés. Vous déciderez de le démarrer à la dernière étape, après avoir tout vérifié.",
+      "startEnabled": "Démarrer activé",
+      "startEnabledHint": "Désactivé est le choix sûr par défaut. Vérifiez le résumé ci-dessus, puis activez ceci lorsque vous voulez que l'agent commence à fonctionner.",
+      "previewFailed": "Impossible de charger un aperçu en direct de la politique de cet agent. Vous pouvez tout de même le créer — vérifiez vos choix attentivement au préalable.",
+      "previewLoading": "Chargement de l'aperçu…",
+      "protectedResourcesLegend": "Ressources protégées",
+      "steps": {
+        "purpose": {
+          "label": "Objectif et posture",
+          "description": "Mode, type, propriété et nom"
+        },
+        "does": {
+          "label": "Ce qu'il fait",
+          "description": "Déclencheurs et capacités"
+        },
+        "safety": {
+          "label": "Sécurité et supervision",
+          "description": "Ressources protégées, limites et approbateurs"
+        },
+        "review": {
+          "label": "Vérifier et créer",
+          "description": "Confirmez ce que cet agent va faire"
+        }
+      },
+      "kinds": {
+        "triage": {
+          "blurb": "Surveille les alertes et propose des correctifs pour celles qui comptent.",
+          "runsWhen": "une nouvelle alerte atteint les gravités que vous choisissez",
+          "recommended": "redémarrer les services bloqués et libérer de l'espace disque"
+        },
+        "patch": {
+          "blurb": "Examine les correctifs manquants et propose lesquels installer.",
+          "runsWhen": "son horaire se déclenche, ou vous le déclenchez manuellement",
+          "recommended": "approuver et installer les correctifs, puis redémarrer les services concernés"
+        },
+        "helpdesk": {
+          "blurb": "Traite les tickets dès leur création, leur première réponse ou leur résolution.",
+          "runsWhen": "un ticket est créé, reçoit sa première réponse, ou est marqué résolu",
+          "recommended": "redémarrer les services et libérer de l'espace disque pour résoudre les demandes courantes"
+        }
+      },
+      "kindCard": {
+        "runsWhenPrefix": "S'exécute quand :",
+        "recommendedPrefix": "Recommandé :",
+        "taken": "Déjà utilisé pour ce propriétaire"
+      }
     }
   },
   "apiKeyForm": {

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -2658,6 +2658,41 @@
       },
       "catalogUnavailable": "Impossible de charger le catalogue d'outils. Vous pouvez toujours modifier la liste des permissions directement ci-dessous.",
       "loading": "Chargement des capacités…"
+    },
+    "summary": {
+      "edit": "Modifier",
+      "createdDisabled": "Créé désactivé",
+      "enabled": "Activé",
+      "allOrganizations": "toutes les organisations",
+      "rowLabels": {
+        "runsWhen": "S'exécute quand",
+        "canRead": "Peut lire",
+        "mayPropose": "Peut proposer",
+        "executesUnattended": "Exécute sans surveillance",
+        "neverTouches": "Ne touche jamais",
+        "limits": "Limites",
+        "approvers": "Demande l'approbation de"
+      },
+      "runsWhen": {
+        "triage": "S'exécute lors de nouvelles alertes de gravité {{severities}} sur n'importe quel appareil.",
+        "anySeverity": "toute gravité",
+        "patch": "S'exécute selon un calendrier, ou lorsqu'il est déclenché manuellement, pour examiner les correctifs manquants.",
+        "helpdesk": "S'exécute quand un ticket est créé, reçoit sa première réponse ou est marqué comme résolu.",
+        "maintenanceWindows": "Attend la fin des fenêtres de maintenance.",
+        "ticketWrites": "Écrit des mises à jour de ticket sans attendre un technicien."
+      },
+      "canRead": "Données d'appareils, d'alertes et de parc pour {{scope}} : inventaire, métriques, journaux, correctifs, sauvegardes, tickets et historique d'audit ({{count}} outils en lecture seule, toujours actifs).",
+      "mayPropose": "{{operations}} opérations réparties sur {{capabilities}} capacités : {{approvalRequests}} déclenchent une demande d'approbation qu'un technicien tranche, et {{loggedProposals}} sont consignées comme propositions et ne sont jamais exécutées.",
+      "mayProposeNone": "Cet agent ne propose encore aucune opération.",
+      "unrecognisedLabel": "Non reconnues par le catalogue d'outils actuel :",
+      "executesUnattendedNone": "Rien. Le mode observation se contente d'observer et de proposer ; rien ne s'exécute sans l'approbation d'un technicien.",
+      "executesUnattendedNoneAct": "Rien pour l'instant — aucune opération sélectionnée n'est éligible à une exécution sans surveillance.",
+      "executesUnattendedList": "Exécute {{list}} sans attendre l'approbation d'un technicien.",
+      "preauthorizedNote": "Certaines sont des opérations préautorisées, accordées à l'avance via le processus de contrôle à quatre yeux.",
+      "neverTouchesEmpty": "Rien n'est encore protégé.",
+      "limits": "Jusqu'à {{devices}} appareils par exécution, {{runsPerHour}} exécutions par heure, {{minutes}} minutes par exécution, un budget quotidien de {{budget}}, et pas plus de {{fleetPercent}} du parc par jour.",
+      "approvers": "{{count}} rôles sont sollicités, par boîte de réception, messagerie et notification push mobile. La première décision l'emporte.",
+      "approversNone": "Aucun rôle n'est encore configuré, donc personne ne sera notifié."
     }
   },
   "apiKeyForm": {

--- a/apps/web/src/locales/it-IT/settings.json
+++ b/apps/web/src/locales/it-IT/settings.json
@@ -2658,6 +2658,41 @@
       },
       "catalogUnavailable": "Impossibile caricare il catalogo degli strumenti. È comunque possibile modificare l'elenco dei permessi direttamente qui sotto.",
       "loading": "Caricamento delle capacità…"
+    },
+    "summary": {
+      "edit": "Modifica",
+      "createdDisabled": "Creato disattivato",
+      "enabled": "Attivato",
+      "allOrganizations": "tutte le organizzazioni",
+      "rowLabels": {
+        "runsWhen": "Si esegue quando",
+        "canRead": "Può leggere",
+        "mayPropose": "Può proporre",
+        "executesUnattended": "Esegue senza supervisione",
+        "neverTouches": "Non tocca mai",
+        "limits": "Limiti",
+        "approvers": "Chiede l'approvazione a"
+      },
+      "runsWhen": {
+        "triage": "Si esegue in presenza di nuovi avvisi di gravità {{severities}} su qualsiasi dispositivo.",
+        "anySeverity": "qualsiasi gravità",
+        "patch": "Si esegue secondo una pianificazione, o quando avviato manualmente, per verificare le patch mancanti.",
+        "helpdesk": "Si esegue quando un ticket viene creato, riceve la prima risposta o viene contrassegnato come risolto.",
+        "maintenanceWindows": "Attende la fine delle finestre di manutenzione.",
+        "ticketWrites": "Scrive aggiornamenti del ticket senza attendere un tecnico."
+      },
+      "canRead": "Dati di dispositivi, avvisi e flotta per {{scope}}: inventario, metriche, log, patch, backup, ticket e cronologia di controllo ({{count}} strumenti di sola lettura, sempre attivi).",
+      "mayPropose": "{{operations}} operazioni distribuite su {{capabilities}} funzionalità: {{approvalRequests}} generano una richiesta di approvazione decisa da un tecnico, e {{loggedProposals}} vengono registrate come proposte e non vengono mai eseguite.",
+      "mayProposeNone": "Questo agente non propone ancora alcuna operazione.",
+      "unrecognisedLabel": "Non riconosciute dall'attuale catalogo di strumenti:",
+      "executesUnattendedNone": "Nulla. La modalità shadow si limita a osservare e proporre; nulla viene eseguito senza l'approvazione di un tecnico.",
+      "executesUnattendedNoneAct": "Ancora nulla: nessuna operazione selezionata è idonea per l'esecuzione senza supervisione.",
+      "executesUnattendedList": "Esegue {{list}} senza attendere l'approvazione di un tecnico.",
+      "preauthorizedNote": "Alcune di queste sono operazioni preautorizzate, concesse in anticipo tramite il processo di revisione a quattro occhi.",
+      "neverTouchesEmpty": "Non è ancora protetto nulla.",
+      "limits": "Fino a {{devices}} dispositivi per esecuzione, {{runsPerHour}} esecuzioni all'ora, {{minutes}} minuti per esecuzione, un budget giornaliero di {{budget}}, e non più del {{fleetPercent}} della flotta al giorno.",
+      "approvers": "Vengono interpellati {{count}} ruoli, tramite posta in arrivo, chat e notifiche push mobili. Vince la prima decisione.",
+      "approversNone": "Non sono ancora stati configurati ruoli, quindi nessuno verrà notificato."
     }
   },
   "apiKeyForm": {

--- a/apps/web/src/locales/it-IT/settings.json
+++ b/apps/web/src/locales/it-IT/settings.json
@@ -2690,9 +2690,62 @@
       "executesUnattendedList": "Esegue {{list}} senza attendere l'approvazione di un tecnico.",
       "preauthorizedNote": "Alcune di queste sono operazioni preautorizzate, concesse in anticipo tramite il processo di revisione a quattro occhi.",
       "neverTouchesEmpty": "Non è ancora protetto nulla.",
-      "limits": "Fino a {{devices}} dispositivi per esecuzione, {{runsPerHour}} esecuzioni all'ora, {{minutes}} minuti per esecuzione, un budget giornaliero di {{budget}}, e non più del {{fleetPercent}} della flotta al giorno.",
+      "limits": "Fino a {{devices}} dispositivi per esecuzione, {{runsPerHour}} esecuzioni all'ora, {{minutes}} minuti per esecuzione, un budget giornaliero di {{budget}}, non più del {{fleetPercent}} della flotta al giorno, e {{cooldown}} minuti tra un'esecuzione e l'altra sullo stesso dispositivo.",
       "approvers": "Vengono interpellati {{count}} ruoli, tramite posta in arrivo, chat e notifiche push mobili. Vince la prima decisione.",
       "approversNone": "Non sono ancora stati configurati ruoli, quindi nessuno verrà notificato."
+    },
+    "flow": {
+      "title": "Nuovo agente",
+      "stepperAriaLabel": "Passaggi del nuovo agente",
+      "back": "Indietro",
+      "next": "Avanti: {{step}}",
+      "createAgent": "Crea agente",
+      "createdDisabledNote": "I nuovi agenti vengono creati disattivati. Deciderai se avviarlo nell'ultimo passaggio, dopo aver rivisto tutto.",
+      "startEnabled": "Avvia attivato",
+      "startEnabledHint": "Disattivato è l'impostazione predefinita sicura. Rivedi il riepilogo sopra, poi attivalo quando vuoi che l'agente inizi a funzionare.",
+      "previewFailed": "Impossibile caricare un'anteprima live della policy di questo agente. Puoi comunque crearlo: rivedi prima con attenzione le tue scelte.",
+      "previewLoading": "Caricamento anteprima…",
+      "protectedResourcesLegend": "Risorse protette",
+      "steps": {
+        "purpose": {
+          "label": "Scopo e impostazione",
+          "description": "Modalità, tipo, proprietà e nome"
+        },
+        "does": {
+          "label": "Cosa fa",
+          "description": "Trigger e funzionalità"
+        },
+        "safety": {
+          "label": "Sicurezza e supervisione",
+          "description": "Risorse protette, limiti e approvatori"
+        },
+        "review": {
+          "label": "Rivedi e crea",
+          "description": "Conferma cosa farà questo agente"
+        }
+      },
+      "kinds": {
+        "triage": {
+          "blurb": "Monitora gli avvisi e propone soluzioni per quelli importanti.",
+          "runsWhen": "un nuovo avviso supera le severità scelte",
+          "recommended": "riavviare i servizi bloccati e liberare spazio su disco"
+        },
+        "patch": {
+          "blurb": "Esamina le patch mancanti e propone quali installare.",
+          "runsWhen": "si attiva la pianificazione, oppure lo avvii manualmente",
+          "recommended": "approvare e installare le patch, quindi riavviare i servizi interessati"
+        },
+        "helpdesk": {
+          "blurb": "Gestisce i ticket non appena vengono creati, ricevono una risposta o vengono risolti.",
+          "runsWhen": "un ticket viene creato, riceve la sua prima risposta o viene contrassegnato come risolto",
+          "recommended": "riavviare i servizi e liberare spazio su disco per risolvere le richieste comuni"
+        }
+      },
+      "kindCard": {
+        "runsWhenPrefix": "Si esegue quando:",
+        "recommendedPrefix": "Consigliato:",
+        "taken": "Già in uso per questo proprietario"
+      }
     }
   },
   "apiKeyForm": {

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -2690,9 +2690,62 @@
       "executesUnattendedList": "Executa {{list}} sem esperar a aprovação de um técnico.",
       "preauthorizedNote": "Algumas delas são operações pré-autorizadas, concedidas antecipadamente pelo processo de revisão de quatro olhos.",
       "neverTouchesEmpty": "Nada está protegido ainda.",
-      "limits": "Até {{devices}} dispositivos por execução, {{runsPerHour}} execuções por hora, {{minutes}} minutos por execução, um orçamento diário de {{budget}}, e no máximo {{fleetPercent}} da frota por dia.",
+      "limits": "Até {{devices}} dispositivos por execução, {{runsPerHour}} execuções por hora, {{minutes}} minutos por execução, um orçamento diário de {{budget}}, no máximo {{fleetPercent}} da frota por dia, e {{cooldown}} minutos entre execuções no mesmo dispositivo.",
       "approvers": "{{count}} funções são consultadas, por caixa de entrada, chat e push no celular. A primeira decisão prevalece.",
       "approversNone": "Ainda não há funções configuradas, então ninguém será notificado."
+    },
+    "flow": {
+      "title": "Novo agente",
+      "stepperAriaLabel": "Etapas do novo agente",
+      "back": "Voltar",
+      "next": "Próximo: {{step}}",
+      "createAgent": "Criar agente",
+      "createdDisabledNote": "Novos agentes são criados desativados. Você decidirá se ele deve começar a ser executado na última etapa, depois de revisar tudo.",
+      "startEnabled": "Iniciar ativado",
+      "startEnabledHint": "Desativado é o padrão seguro. Revise o resumo acima e ative isso quando quiser que o agente comece a ser executado.",
+      "previewFailed": "Não foi possível carregar uma prévia ao vivo da política deste agente. Você ainda pode criá-lo — revise suas escolhas com cuidado antes.",
+      "previewLoading": "Carregando prévia…",
+      "protectedResourcesLegend": "Recursos protegidos",
+      "steps": {
+        "purpose": {
+          "label": "Propósito e postura",
+          "description": "Modo, tipo, propriedade e nome"
+        },
+        "does": {
+          "label": "O que ele faz",
+          "description": "Gatilhos e capacidades"
+        },
+        "safety": {
+          "label": "Segurança e supervisão",
+          "description": "Recursos protegidos, limites e aprovadores"
+        },
+        "review": {
+          "label": "Revisar e criar",
+          "description": "Confirme o que este agente vai fazer"
+        }
+      },
+      "kinds": {
+        "triage": {
+          "blurb": "Observa os alertas e propõe correções para os que importam.",
+          "runsWhen": "um novo alerta atinge as severidades escolhidas por você",
+          "recommended": "reiniciar serviços travados e liberar espaço em disco"
+        },
+        "patch": {
+          "blurb": "Revisa os patches ausentes e propõe quais instalar.",
+          "runsWhen": "sua programação é disparada, ou você o aciona manualmente",
+          "recommended": "aprovar e instalar patches, depois reiniciar os serviços afetados"
+        },
+        "helpdesk": {
+          "blurb": "Trabalha os tickets à medida que são criados, recebem a primeira resposta ou são resolvidos.",
+          "runsWhen": "um ticket é criado, recebe sua primeira resposta, ou é marcado como resolvido",
+          "recommended": "reiniciar serviços e liberar espaço em disco para resolver solicitações comuns"
+        }
+      },
+      "kindCard": {
+        "runsWhenPrefix": "Executa quando:",
+        "recommendedPrefix": "Recomendado:",
+        "taken": "Já em uso para este proprietário"
+      }
     }
   },
   "apiKeyForm": {

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -2658,6 +2658,41 @@
       },
       "catalogUnavailable": "Não foi possível carregar o catálogo de ferramentas. Você ainda pode editar a lista de permissões diretamente abaixo.",
       "loading": "Carregando capacidades…"
+    },
+    "summary": {
+      "edit": "Editar",
+      "createdDisabled": "Criado desativado",
+      "enabled": "Ativado",
+      "allOrganizations": "todas as organizações",
+      "rowLabels": {
+        "runsWhen": "É executado quando",
+        "canRead": "Pode ler",
+        "mayPropose": "Pode propor",
+        "executesUnattended": "Executa sem supervisão",
+        "neverTouches": "Nunca toca em",
+        "limits": "Limites",
+        "approvers": "Pede aprovação a"
+      },
+      "runsWhen": {
+        "triage": "É executado diante de novos alertas de gravidade {{severities}} em qualquer dispositivo.",
+        "anySeverity": "qualquer gravidade",
+        "patch": "É executado conforme uma programação, ou quando acionado manualmente, para revisar patches ausentes.",
+        "helpdesk": "É executado quando um ticket é criado, recebe sua primeira resposta ou é marcado como resolvido.",
+        "maintenanceWindows": "Aguarda o fim das janelas de manutenção.",
+        "ticketWrites": "Grava atualizações do ticket sem esperar por um técnico."
+      },
+      "canRead": "Dados de dispositivos, alertas e da frota para {{scope}}: inventário, métricas, logs, patches, backups, tickets e histórico de auditoria ({{count}} ferramentas somente leitura, sempre ativas).",
+      "mayPropose": "{{operations}} operações em {{capabilities}} capacidades: {{approvalRequests}} geram uma solicitação de aprovação que um técnico decide, e {{loggedProposals}} são registradas como propostas e nunca executadas.",
+      "mayProposeNone": "Este agente ainda não propõe nenhuma operação.",
+      "unrecognisedLabel": "Não reconhecidas pelo catálogo de ferramentas atual:",
+      "executesUnattendedNone": "Nada. O modo sombra apenas observa e propõe; nada é executado sem a aprovação de um técnico.",
+      "executesUnattendedNoneAct": "Nada ainda — nenhuma operação selecionada é elegível para execução sem supervisão.",
+      "executesUnattendedList": "Executa {{list}} sem esperar a aprovação de um técnico.",
+      "preauthorizedNote": "Algumas delas são operações pré-autorizadas, concedidas antecipadamente pelo processo de revisão de quatro olhos.",
+      "neverTouchesEmpty": "Nada está protegido ainda.",
+      "limits": "Até {{devices}} dispositivos por execução, {{runsPerHour}} execuções por hora, {{minutes}} minutos por execução, um orçamento diário de {{budget}}, e no máximo {{fleetPercent}} da frota por dia.",
+      "approvers": "{{count}} funções são consultadas, por caixa de entrada, chat e push no celular. A primeira decisão prevalece.",
+      "approversNone": "Ainda não há funções configuradas, então ninguém será notificado."
     }
   },
   "apiKeyForm": {

--- a/apps/web/src/locales/tr-TR/settings.json
+++ b/apps/web/src/locales/tr-TR/settings.json
@@ -2690,9 +2690,62 @@
       "executesUnattendedList": "Bir teknisyenin onayını beklemeden {{list}} çalıştırır.",
       "preauthorizedNote": "Bunlardan bazıları, dört göz inceleme süreciyle önceden verilmiş ön yetkilendirilmiş işlemlerdir.",
       "neverTouchesEmpty": "Henüz hiçbir şey korunmuyor.",
-      "limits": "Çalıştırma başına en fazla {{devices}} cihaz, saatte {{runsPerHour}} çalıştırma, çalıştırma başına {{minutes}} dakika, günlük {{budget}} bütçe ve günde filonun en fazla {{fleetPercent}}'i.",
+      "limits": "Çalıştırma başına en fazla {{devices}} cihaz, saatte {{runsPerHour}} çalıştırma, çalıştırma başına {{minutes}} dakika, günlük {{budget}} bütçe, günde filonun en fazla {{fleetPercent}}'i ve aynı cihazda çalıştırmalar arasında {{cooldown}} dakika.",
       "approvers": "Gelen kutusu, sohbet ve mobil push aracılığıyla {{count}} rol sorulur. İlk karar geçerli olur.",
       "approversNone": "Henüz hiçbir rol yapılandırılmadı, bu yüzden kimseye bildirim gönderilmeyecek."
+    },
+    "flow": {
+      "title": "Yeni ajan",
+      "stepperAriaLabel": "Yeni ajan adımları",
+      "back": "Geri",
+      "next": "İleri: {{step}}",
+      "createAgent": "Ajan oluştur",
+      "createdDisabledNote": "Yeni ajanlar kapalı olarak oluşturulur. Her şeyi gözden geçirdikten sonra son adımda çalışmaya başlayıp başlamayacağına karar vereceksin.",
+      "startEnabled": "Etkin başlat",
+      "startEnabledHint": "Kapalı, güvenli varsayılan seçenektir. Yukarıdaki özeti incele, ardından ajanının çalışmaya başlamasını istediğinde bunu aç.",
+      "previewFailed": "Bu ajanın politikasının canlı önizlemesi yüklenemedi. Yine de oluşturabilirsin — önce seçimlerini dikkatle gözden geçir.",
+      "previewLoading": "Önizleme yükleniyor…",
+      "protectedResourcesLegend": "Korunan kaynaklar",
+      "steps": {
+        "purpose": {
+          "label": "Amaç ve duruş",
+          "description": "Mod, tür, sahiplik ve ad"
+        },
+        "does": {
+          "label": "Ne yapar",
+          "description": "Tetikleyiciler ve yetenekler"
+        },
+        "safety": {
+          "label": "Güvenlik ve gözetim",
+          "description": "Korunan kaynaklar, sınırlar ve onaylayanlar"
+        },
+        "review": {
+          "label": "Gözden geçir ve oluştur",
+          "description": "Bu ajanın ne yapacağını onayla"
+        }
+      },
+      "kinds": {
+        "triage": {
+          "blurb": "Uyarıları izler ve önemli olanlar için çözüm önerir.",
+          "runsWhen": "seçtiğin önem derecelerinden birine ulaşan yeni bir uyarı olduğunda",
+          "recommended": "takılı kalan hizmetleri yeniden başlatmak ve disk alanı boşaltmak"
+        },
+        "patch": {
+          "blurb": "Eksik yamaları gözden geçirir ve neyin kurulacağını önerir.",
+          "runsWhen": "zamanlaması tetiklendiğinde veya onu manuel olarak çalıştırdığında",
+          "recommended": "yamaları onaylayıp kurmak, ardından etkilenen hizmetleri yeniden başlatmak"
+        },
+        "helpdesk": {
+          "blurb": "Talepler oluşturuldukca, ilk yanıtı aldıkça veya çözüldükçe onlar üzerinde çalışır.",
+          "runsWhen": "bir talep oluşturulduğunda, ilk yanıtını aldığında veya çözüldü olarak işaretlendiğinde",
+          "recommended": "yaygın talepleri çözmek için hizmetleri yeniden başlatmak ve disk alanı boşaltmak"
+        }
+      },
+      "kindCard": {
+        "runsWhenPrefix": "Çalıştığı zaman:",
+        "recommendedPrefix": "Önerilen:",
+        "taken": "Bu sahip için zaten kullanımda"
+      }
     }
   },
   "apiKeyForm": {

--- a/apps/web/src/locales/tr-TR/settings.json
+++ b/apps/web/src/locales/tr-TR/settings.json
@@ -2658,6 +2658,41 @@
       },
       "catalogUnavailable": "Araç kataloğu yüklenemedi. Yine de izin listesini doğrudan aşağıdan düzenleyebilirsiniz.",
       "loading": "Yetenekler yükleniyor…"
+    },
+    "summary": {
+      "edit": "Düzenle",
+      "createdDisabled": "Devre dışı oluşturuldu",
+      "enabled": "Etkin",
+      "allOrganizations": "tüm kuruluşlar",
+      "rowLabels": {
+        "runsWhen": "Şu durumda çalışır",
+        "canRead": "Okuyabilir",
+        "mayPropose": "Önerebilir",
+        "executesUnattended": "Gözetimsiz yürütür",
+        "neverTouches": "Asla dokunmaz",
+        "limits": "Sınırlar",
+        "approvers": "Onay istediği kişiler"
+      },
+      "runsWhen": {
+        "triage": "Herhangi bir cihazda yeni {{severities}} önem düzeyindeki uyarılarda çalışır.",
+        "anySeverity": "herhangi bir önem düzeyi",
+        "patch": "Eksik yamaları incelemek için bir zamanlamaya göre veya manuel olarak tetiklendiğinde çalışır.",
+        "helpdesk": "Bir talep oluşturulduğunda, ilk yanıtını aldığında veya çözüldü olarak işaretlendiğinde çalışır.",
+        "maintenanceWindows": "Bakım pencerelerinin bitmesini bekler.",
+        "ticketWrites": "Bir teknisyeni beklemeden talep güncellemeleri yazar."
+      },
+      "canRead": "{{scope}} için cihaz, uyarı ve filo verileri: envanter, metrikler, günlükler, yamalar, yedekler, talepler ve denetim geçmişi ({{count}} salt okunur araç, her zaman etkin).",
+      "mayPropose": "{{capabilities}} yetenek genelinde {{operations}} işlem: {{approvalRequests}} tanesi bir teknisyenin karar vereceği bir onay isteği oluşturur, {{loggedProposals}} tanesi ise öneri olarak kaydedilir ve asla çalıştırılmaz.",
+      "mayProposeNone": "Bu aracı henüz herhangi bir işlem önermiyor.",
+      "unrecognisedLabel": "Geçerli araç kataloğu tarafından tanınmıyor:",
+      "executesUnattendedNone": "Hiçbir şey. Gölge modu yalnızca gözlemler ve önerir; bir teknisyenin onayı olmadan hiçbir şey çalışmaz.",
+      "executesUnattendedNoneAct": "Henüz hiçbir şey yok — seçilen hiçbir işlem gözetimsiz çalıştırma için uygun değil.",
+      "executesUnattendedList": "Bir teknisyenin onayını beklemeden {{list}} çalıştırır.",
+      "preauthorizedNote": "Bunlardan bazıları, dört göz inceleme süreciyle önceden verilmiş ön yetkilendirilmiş işlemlerdir.",
+      "neverTouchesEmpty": "Henüz hiçbir şey korunmuyor.",
+      "limits": "Çalıştırma başına en fazla {{devices}} cihaz, saatte {{runsPerHour}} çalıştırma, çalıştırma başına {{minutes}} dakika, günlük {{budget}} bütçe ve günde filonun en fazla {{fleetPercent}}'i.",
+      "approvers": "Gelen kutusu, sohbet ve mobil push aracılığıyla {{count}} rol sorulur. İlk karar geçerli olur.",
+      "approversNone": "Henüz hiçbir rol yapılandırılmadı, bu yüzden kimseye bildirim gönderilmeyecek."
     }
   },
   "apiKeyForm": {

--- a/packages/shared/src/types/aiAgents.ts
+++ b/packages/shared/src/types/aiAgents.ts
@@ -611,6 +611,55 @@ export interface AgentCeilingDto {
 }
 
 /**
+ * `POST /ai/agents/preview` response body's `data` (Task 11, #5051; spec
+ * §4.6 step 4). Evaluates a DRAFT agent policy through the SAME
+ * `AgentToolCatalogDto` and `AgentCeilingDto` the picker and run loop use, so
+ * the guided create flow's review card can never drift from what
+ * create/update would actually enforce. Built by
+ * `apps/api/src/services/aiAgents/agentPreview.ts`'s `buildAgentPreview` —
+ * pure, no DB read beyond the ceiling the route already resolved.
+ */
+export interface AgentPreviewDto {
+  mode: AiAgentMode;
+  kind: AiAgentKind;
+  /** `catalog.tools.filter(t => t.readOnly).length` — the "always on" reads, independent of `operations` below. */
+  readOnlyToolCount: number;
+  /**
+   * One entry per resolved MUTATING operation the draft's `toolAllowlist`
+   * admits, deduplicated by `key`. A bare entry on a multi-operation tool
+   * expands to every one of that tool's non-read-only operations (its
+   * always-on reads are already counted in `readOnlyToolCount`, not listed
+   * here); an entry the catalog cannot resolve — unknown tool, unreachable
+   * tool, or an action the tool does not have — contributes to
+   * `unrecognised` instead of an operation here.
+   */
+  operations: Array<{
+    key: string;
+    capability: string;
+    /**
+     * `mode === 'act' && op.actEligible` -> `'unattended'`; else tier 3 ->
+     * `'approval_request'`; else (tier 1/2, never selected alone but
+     * reachable via a bare multi-op expansion) -> `'logged_proposal'`.
+     */
+    outcome: 'approval_request' | 'logged_proposal' | 'unattended';
+    /** `key` is inside the intersection of the ceiling's and the draft's own `supervisedActionKeys` (or just the draft's own, on a partner draft with no ceiling). */
+    preauthorized: boolean;
+    /** `true` unconditionally when there is no ceiling (a partner draft, or an org draft with no live partner baseline yet). */
+    withinCeiling: boolean;
+  }>;
+  /** Raw `toolAllowlist` entries the catalog could not resolve, verbatim (never rewritten). */
+  unrecognised: string[];
+  triggers: {
+    alertSeverities: AiAgentTriggers['alertSeverities'];
+    respectMaintenanceWindows: boolean;
+    ticketAutonomousWrites: boolean;
+  };
+  protectedResources: AiAgentProtectedResources;
+  limits: AiAgentLimits;
+  recipients: AiAgentRecipients;
+}
+
+/**
  * Wave 4 Part B — act mode verdicts.
  *
  * `execution` reports the tool dispatch outcome for a manifest-matched call

--- a/packages/shared/src/types/aiAgents.ts
+++ b/packages/shared/src/types/aiAgents.ts
@@ -656,6 +656,11 @@ export interface AgentPreviewDto {
   };
   protectedResources: AiAgentProtectedResources;
   limits: AiAgentLimits;
+  /** `AiAgentPolicy.cooldownSeconds` is a sibling of `limits`, not one of its
+   *  fields — carried through separately so the review card's "six exposed
+   *  limits" (spec §4.6 step 4) can render it alongside the five in `limits`
+   *  without reaching into a differently-shaped policy row. */
+  cooldownSeconds: number;
   recipients: AiAgentRecipients;
 }
 

--- a/packages/shared/src/utils/agentOutcome.test.ts
+++ b/packages/shared/src/utils/agentOutcome.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { outcomeFor } from './agentOutcome';
+
+describe('outcomeFor', () => {
+  it('act mode: an act-eligible operation is unattended', () => {
+    expect(outcomeFor({ tier: 3, actEligible: true }, 'act')).toBe('unattended');
+    expect(outcomeFor({ tier: 1, actEligible: true }, 'act')).toBe('unattended');
+  });
+
+  it('act mode: a non-act-eligible tier-3 operation still falls back to approval_request', () => {
+    expect(outcomeFor({ tier: 3, actEligible: false }, 'act')).toBe('approval_request');
+  });
+
+  it('act mode: a non-act-eligible tier 1/2 operation falls back to logged_proposal', () => {
+    expect(outcomeFor({ tier: 1, actEligible: false }, 'act')).toBe('logged_proposal');
+    expect(outcomeFor({ tier: 2, actEligible: false }, 'act')).toBe('logged_proposal');
+  });
+
+  it('shadow/off mode splits by tier alone, never unattended even when act-eligible', () => {
+    expect(outcomeFor({ tier: 3, actEligible: true }, 'shadow')).toBe('approval_request');
+    expect(outcomeFor({ tier: 2, actEligible: true }, 'shadow')).toBe('logged_proposal');
+    expect(outcomeFor({ tier: 1, actEligible: true }, 'off')).toBe('logged_proposal');
+    expect(outcomeFor({ tier: 3, actEligible: true }, 'off')).toBe('approval_request');
+  });
+});

--- a/packages/shared/src/utils/agentOutcome.ts
+++ b/packages/shared/src/utils/agentOutcome.ts
@@ -1,0 +1,25 @@
+/**
+ * Task 13 (#5051 review) — the ONE outcome rule, shared between
+ * `apps/api/src/services/aiAgents/agentPreview.ts` (`resolveOutcome`) and
+ * `apps/web/src/components/settings/aiAgents/capabilityModel.ts`
+ * (`outcomeFor`), which used to carry byte-identical copies. Both computed
+ * the same three-way split of what happens when a policy-decidable operation
+ * actually runs — this is the single place that decides it now, so the
+ * server's preview and the web picker's summary can never drift.
+ *
+ * `mode === 'act' && op.actEligible` -> `unattended` (the run loop actually
+ * dispatches it without a human, per `ACT_MANIFEST`); otherwise the
+ * guardrail tier decides whether a human approves it up front (tier 3,
+ * `approval_request`) or it is logged as an already-applied proposal (tier
+ * 1/2, `logged_proposal`).
+ */
+
+export type AgentOutcome = 'approval_request' | 'logged_proposal' | 'unattended';
+
+export function outcomeFor(
+  op: { tier: 1 | 2 | 3; actEligible: boolean },
+  mode: 'off' | 'shadow' | 'act',
+): AgentOutcome {
+  if (mode === 'act' && op.actEligible) return 'unattended';
+  return op.tier === 3 ? 'approval_request' : 'logged_proposal';
+}

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -16,6 +16,7 @@ export * from './s3Endpoint';
 export * from './softwareFileType';
 export * from './cron';
 export * from './approvalBatchGrouping';
+export * from './agentOutcome';
 // Deliberately NOT `export *`. `compileExcludeMatcher` is a code-point port of
 // the agent's matcher and knowingly diverges from Go on mid-rune byte offsets
 // and Unicode special-casing (see matcherPortLimitations in

--- a/packages/shared/src/validators/aiAgents.ts
+++ b/packages/shared/src/validators/aiAgents.ts
@@ -227,6 +227,25 @@ export const updateAiAgentSchema = z.object({
 });
 
 /**
+ * Task 11 (#5051): `POST /ai/agents/preview` evaluates a DRAFT agent policy —
+ * exactly the body `POST /ai/agents` would accept, except a name has not
+ * necessarily been chosen yet (the guided create flow's review step, spec
+ * §4.6 step 4, runs before Step 1's name field is required to be final).
+ * Every other field keeps `createAiAgentSchema`'s validation and defaulting
+ * (`aiAgentPolicyFieldsSchema`'s `.prefault({})` transforms still fill
+ * `protectedResources`/`limits`/`triggers`/`recipients`/`actAssets`), so
+ * `buildAgentPreview` never has to special-case a partially-defaulted draft.
+ *
+ * `createAiAgentSchema` is `aiAgentPolicyFieldsSchema.extend({...})` — a
+ * plain `ZodObject` (the object itself is never `.transform()`ed, only
+ * individual field schemas are), so `.omit()`/`.extend()` chain on it
+ * directly rather than needing to be rebuilt from the fields schema.
+ */
+export const previewAiAgentSchema = createAiAgentSchema.omit({ name: true }).extend({
+  name: z.string().trim().min(1).max(120).optional(),
+});
+
+/**
  * Manual "run now" trigger body. `.strict()` so a caller cannot smuggle an
  * `orgId`/`kind`/`dedupeKey` past the route into `createAndEnqueueAgentRun` —
  * the org comes from the device row and the kind from the agent row.
@@ -237,6 +256,7 @@ export const triggerAgentRunSchema = z.object({
 
 export type CreateAiAgentInput = z.infer<typeof createAiAgentSchema>;
 export type UpdateAiAgentInput = z.infer<typeof updateAiAgentSchema>;
+export type PreviewAiAgentInput = z.infer<typeof previewAiAgentSchema>;
 export type TriggerAgentRunInput = z.infer<typeof triggerAgentRunSchema>;
 
 /**


### PR DESCRIPTION
Wave W03 of the AI agent builder (#5048), on top of W01 (#5054) and W02 (#5057).

Spec: `docs/superpowers/specs/ai-mcp/2026-09-06-ai-agent-builder-design.md` §4.6 · Plan: `docs/superpowers/plans/ai-mcp/2026-09-06-ai-agent-builder.md` Tasks 11–13 · Mockup: https://claude.ai/code/artifact/4f5b8312-74b1-4492-ad62-610dcb6dd15f

## What changed

- **`POST /ai/agents/preview`** (`services/aiAgents/agentPreview.ts`): evaluates a draft the way enforcement would. Every allowlist entry resolves through the catalog (bare multi-operation entries expand; unknown entries are reported), each operation gets its mode-aware outcome (approval request / logged proposal / unattended), the partner ceiling and the pre-authorized-key intersection are applied, and cooldown is carried through. `ai_agents:read`, registered before `/:id`.
- **`AgentSummaryCard`**: the plain-English contract in seven rows (runs when · can read · may propose with outcome chips · executes unattended · never touches · limits · who is asked), with Edit links back to the steps. Copy never says "everything".
- **`AgentCreateFlow`**: create leaves the drawer for a full-width four-step flow with a vertical stepper: Purpose and posture (mode first, kind cards with what-it-does / runs-when / recommended, owner scope, name, instructions) → What it does (triggers + `CapabilityPicker`) → Safety and oversight (protected resources, limits, approvers; partner drafts show the ceiling keys) → Review and create (the card from `/preview`, debounced, plus a Start-enabled switch). Validation gates mirror the drawer. Edit keeps the drawer.
- **Pure moves** so the drawer and the flow cannot drift: `agentDraft.ts` (`Draft`, `draftFrom`, `buildAgentSaveBody` — a test pins that both surfaces build byte-identical bodies), `ModeChoice.tsx`, `PolicyKeysCheckboxes.tsx`. `SetupStepper` gains `ariaLabel` and a vertical orientation; the auth wizard is untouched.
- **Page**: the three "New agent" affordances open the flow; the new row is highlighted after creation.
- **i18n**: `aiAgentsPage.summary.*` and `aiAgentsPage.flow.*` in all 8 locales; parity/coverage/key-usage suites green.

## Deviations from the plan
- No model selector on step 1: the drawer never had one and the server defaults `model` to null; adding a first-of-its-kind control was out of scope.

## Verification
- Web: 110 files / 1491 tests green (settings, i18n, setup, no-silent-mutations); `tsc --noEmit` and eslint clean.
- API: `agentPreview`, `routes/aiAgents`, `agentToolCatalog` contract → 204 tests green; `tsc --noEmit` clean.
- Browser walk on a worktree stack: see the review-summary comment.

Closes #5051

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CuEEGssvpeM9HE7sQqByGE