### PR TITLE
fix(web): devices list — 'show removed' adds rows; Compare stays visible past 4 selected (#5023 paper cuts)

### DIFF
--- a/apps/web/src/components/devices/DecommissionedHiddenHint.tsx
+++ b/apps/web/src/components/devices/DecommissionedHiddenHint.tsx
@@ -2,36 +2,38 @@
 // Devices page by default, and nothing on the page used to say so — the only
 // unhide mechanism was knowing the status filter has a "Removed" option.
 // This renders a lightweight "N removed hidden — show" line next to the
-// device count (list view) / above the grid (grid view), where "show"
-// applies the existing decommissioned status filter upstream. The upstream
-// count memos return 0 when decommissioned devices are already visible
-// (includeDecommissioned), and the component renders nothing for count <= 0
-// — so it self-dismisses once the rows are shown.
+// device count (list view) / above the grid (grid view). "show" flips a
+// page-level showRemoved flag upstream, which ADDS the removed rows to
+// whatever is on screen (#5023 paper cut: it used to swap the view to a
+// removed-only status filter). Once the rows are visible the same slot
+// renders the mirror line, "N removed shown — hide", so the default view is
+// one click away again. The component renders nothing for count <= 0.
 import { useTranslation } from 'react-i18next';
 
-export default function DecommissionedHiddenHint({
-  count,
-  onShow,
-}: {
-  count: number;
-  onShow: () => void;
-}) {
+type Props =
+  | { mode?: 'hidden'; count: number; onShow: () => void; onHide?: never }
+  | { mode: 'shown'; count: number; onHide: () => void; onShow?: never };
+
+export default function DecommissionedHiddenHint(props: Props) {
   const { t } = useTranslation('devices');
-  if (count <= 0) return null;
+  if (props.count <= 0) return null;
+  const shown = props.mode === 'shown';
   return (
     <span
-      data-testid="decommissioned-hidden-hint"
+      data-testid={shown ? 'decommissioned-shown-hint' : 'decommissioned-hidden-hint'}
       className="text-sm text-muted-foreground"
     >
-      {t('decommissionedHiddenHint.label', { count })}
+      {shown
+        ? t('decommissionedHiddenHint.shownLabel', { count: props.count })
+        : t('decommissionedHiddenHint.label', { count: props.count })}
       {' — '}
       <button
         type="button"
-        data-testid="decommissioned-hidden-show"
-        onClick={onShow}
+        data-testid={shown ? 'decommissioned-hidden-hide' : 'decommissioned-hidden-show'}
+        onClick={shown ? props.onHide : props.onShow}
         className="underline underline-offset-2 transition hover:text-foreground"
       >
-        {t('decommissionedHiddenHint.show')}
+        {shown ? t('decommissionedHiddenHint.hide') : t('decommissionedHiddenHint.show')}
       </button>
     </span>
   );

--- a/apps/web/src/components/devices/DeviceList.test.tsx
+++ b/apps/web/src/components/devices/DeviceList.test.tsx
@@ -1002,6 +1002,41 @@ describe('DeviceList — hidden-decommissioned hint (#2251)', () => {
     expect(screen.getByText(/2 of 2 devices/)).toBeInTheDocument();
   });
 
+  // #5023 paper cut: "show" now ADDS the removed rows to the current view
+  // instead of swapping to a removed-only filter, so the line flips to a
+  // "N removed shown — hide" affordance that puts the default view back.
+  it('renders "N removed shown — hide" once the rows are visible and calls onHideDecommissioned', () => {
+    const onHide = vi.fn();
+    render(
+      <DeviceList
+        devices={[baseDevice, decomDevice]}
+        includeDecommissioned
+        onShowDecommissioned={vi.fn()}
+        onHideDecommissioned={onHide}
+      />
+    );
+
+    expect(screen.queryByTestId('decommissioned-hidden-hint')).toBeNull();
+    const hint = screen.getByTestId('decommissioned-shown-hint');
+    expect(hint).toHaveTextContent('1 removed shown');
+    // Both rows render — the active one was not filtered out by "show".
+    expect(screen.getByText(/2 of 2 devices/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('decommissioned-hidden-hide'));
+    expect(onHide).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders no "shown" line when the rows are visible via an explicit status filter (no onHideDecommissioned)', () => {
+    render(
+      <DeviceList
+        devices={[baseDevice, decomDevice]}
+        includeDecommissioned
+        onShowDecommissioned={vi.fn()}
+      />
+    );
+    expect(screen.queryByTestId('decommissioned-shown-hint')).toBeNull();
+  });
+
   it('renders no hint when there are no decommissioned devices', () => {
     render(<DeviceList devices={[baseDevice]} onShowDecommissioned={vi.fn()} />);
     expect(screen.queryByTestId('decommissioned-hidden-hint')).toBeNull();
@@ -1583,12 +1618,33 @@ describe('DeviceList — Compare bulk action gating', () => {
     expect(screen.queryByTestId('bulk-compare')).toBeNull();
   });
 
-  it('hides Compare above the 4-device limit (DeviceCompare cap)', () => {
-    render(<DeviceList devices={fleet(5)} onBulkAction={vi.fn()} />);
+  // #5023 paper cut: Compare used to vanish silently at 5+ selected. It now
+  // stays in the menu, disabled, with the cap spelled out so the tech knows
+  // to trim the selection rather than wondering where the item went.
+  it('keeps Compare in the menu but disabled above the 4-device limit (DeviceCompare cap)', () => {
+    const onBulkAction = vi.fn();
+    render(<DeviceList devices={fleet(5)} onBulkAction={onBulkAction} />);
     selectAllAndOpenMenu();
-    expect(screen.queryByTestId('bulk-compare')).toBeNull();
+    const compare = screen.getByTestId('bulk-compare');
+    expect(compare).toBeDisabled();
+    expect(compare).toHaveAttribute('title', 'Compare supports up to 4 devices');
+    expect(compare).toHaveTextContent('Compare supports up to 4 devices');
+    fireEvent.click(compare);
+    expect(onBulkAction).not.toHaveBeenCalled();
     // The uncapped 2+ actions are still offered on the same selection.
     expect(screen.getByTestId('bulk-link-multiboot')).toBeInTheDocument();
+  });
+
+  it('keeps Compare disabled above the cap for an all-removed selection too', () => {
+    const onBulkAction = vi.fn();
+    const removed = fleet(5).map(d => ({ ...d, status: 'decommissioned' as const }));
+    render(<DeviceList devices={removed} includeDecommissioned onBulkAction={onBulkAction} />);
+    selectAllAndOpenMenu();
+    const compare = screen.getByTestId('bulk-compare');
+    expect(compare).toBeDisabled();
+    fireEvent.click(compare);
+    expect(onBulkAction).not.toHaveBeenCalled();
+    expect(screen.getByTestId('bulk-restore')).toBeInTheDocument();
   });
 });
 

--- a/apps/web/src/components/devices/DeviceList.test.tsx
+++ b/apps/web/src/components/devices/DeviceList.test.tsx
@@ -1037,6 +1037,43 @@ describe('DeviceList — hidden-decommissioned hint (#2251)', () => {
     expect(screen.queryByTestId('decommissioned-shown-hint')).toBeNull();
   });
 
+  // Codex review on #5066: a removed device the server-side advanced filter
+  // already excludes is not "hidden by default" — "show" could not reveal it,
+  // so the hint must not count it. Same for the "shown" line.
+  it('counts only removed devices the active server filter admits', () => {
+    const { rerender } = render(
+      <DeviceList
+        devices={[baseDevice, decomDevice]}
+        serverFilterIds={new Set([baseDevice.id])}
+        onShowDecommissioned={vi.fn()}
+        onHideDecommissioned={vi.fn()}
+      />
+    );
+    expect(screen.queryByTestId('decommissioned-hidden-hint')).toBeNull();
+    // Denominator still excludes the hidden removed row.
+    expect(screen.getByText(/1 of 1 devices/)).toBeInTheDocument();
+
+    rerender(
+      <DeviceList
+        devices={[baseDevice, decomDevice]}
+        serverFilterIds={new Set([baseDevice.id])}
+        includeDecommissioned
+        onShowDecommissioned={vi.fn()}
+        onHideDecommissioned={vi.fn()}
+      />
+    );
+    expect(screen.queryByTestId('decommissioned-shown-hint')).toBeNull();
+
+    rerender(
+      <DeviceList
+        devices={[baseDevice, decomDevice]}
+        serverFilterIds={new Set([baseDevice.id, decomDevice.id])}
+        onShowDecommissioned={vi.fn()}
+      />
+    );
+    expect(screen.getByTestId('decommissioned-hidden-hint')).toHaveTextContent('1 removed hidden');
+  });
+
   it('renders no hint when there are no decommissioned devices', () => {
     render(<DeviceList devices={[baseDevice]} onShowDecommissioned={vi.fn()} />);
     expect(screen.queryByTestId('decommissioned-hidden-hint')).toBeNull();

--- a/apps/web/src/components/devices/DeviceList.tsx
+++ b/apps/web/src/components/devices/DeviceList.tsx
@@ -781,17 +781,15 @@ export default function DeviceList({
     setCurrentPage(1);
   }, [query, classFilter, vpnFilter, serverFilterIds]);
 
-  const filteredDevices = useMemo(() => {
+  // Every filter EXCEPT the hidden-by-default decommissioned rule. Split out
+  // so the removed-hint counts (#2251/#5023) can be taken from the rows the
+  // tech's filters would actually let through — a decommissioned device the
+  // server filter or search already excludes is not "hidden by default" and
+  // must not be counted as showable.
+  const matchingDevices = useMemo(() => {
     const normalizedQuery = query.trim().toLowerCase();
 
     return devices.filter((device) => {
-      // Hide decommissioned by default — preserves the old list's hygiene
-      // (status='all' implicitly excluded them). Filtering FOR decommissioned
-      // via a status chip flips includeDecommissioned true upstream.
-      if (!includeDecommissioned && device.status === "decommissioned") {
-        return false;
-      }
-
       // Apply server-side advanced filter (status/os/role/org/site/group/… all
       // resolve through this id set now — they are no longer client-side).
       if (serverFilterIds !== null && !serverFilterIds.has(device.id)) {
@@ -822,23 +820,37 @@ export default function DeviceList({
 
       return matchesClass && matchesVpn && matchesQuery;
     });
-  }, [
-    devices,
-    query,
-    classFilter,
-    vpnFilter,
-    serverFilterIds,
-    includeDecommissioned,
-  ]);
+  }, [devices, query, classFilter, vpnFilter, serverFilterIds]);
 
-  // How many decommissioned devices the default view is hiding (#2251). Zero
-  // when they're already visible (includeDecommissioned) so the hint and the
-  // count math below stay consistent with what the table actually shows.
+  // Hide decommissioned by default — preserves the old list's hygiene
+  // (status='all' implicitly excluded them). Filtering FOR decommissioned via
+  // a status chip, or "show" on the hint, flips includeDecommissioned upstream.
+  const filteredDevices = useMemo(
+    () =>
+      includeDecommissioned
+        ? matchingDevices
+        : matchingDevices.filter((d) => d.status !== "decommissioned"),
+    [matchingDevices, includeDecommissioned]
+  );
+
+  // Removed devices the current filters would let through (#2251/#5023) —
+  // the ones "show" can actually reveal / "hide" actually removes. Zero on
+  // the hidden side once they're visible (and vice versa) so the hint and
+  // the count line stay consistent with what the table actually shows.
   const decommissionedCount = useMemo(
-    () => devices.filter(d => d.status === 'decommissioned').length,
-    [devices]
+    () => matchingDevices.filter((d) => d.status === "decommissioned").length,
+    [matchingDevices]
   );
   const hiddenDecommissionedCount = includeDecommissioned ? 0 : decommissionedCount;
+  // Count-line denominator: the fleet minus every decommissioned row while
+  // they're hidden (regardless of whether the filters would admit them).
+  const countLineTotal = useMemo(
+    () =>
+      includeDecommissioned
+        ? devices.length
+        : devices.filter((d) => d.status !== "decommissioned").length,
+    [devices, includeDecommissioned]
+  );
 
   // Providers present across the loaded set — drives the VPN facet options so
   // techs only see providers that actually exist in their fleet.
@@ -1954,7 +1966,7 @@ export default function DeviceList({
         <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <p className="text-sm text-muted-foreground">
             {filteredDevices.length} {t("deviceList.of")}{" "}
-            {devices.length - hiddenDecommissionedCount}{" "}
+            {countLineTotal}{" "}
             {t("deviceList.devices")}{" "}
             {serverFilterError ? (
               <span

--- a/apps/web/src/components/devices/DeviceList.tsx
+++ b/apps/web/src/components/devices/DeviceList.tsx
@@ -91,6 +91,10 @@ import {
 import { groupLinkedDevices } from "./linkedDevices";
 import { useOrgStore } from "@/stores/orgStore";
 import DecommissionedHiddenHint from "./DecommissionedHiddenHint";
+
+// DeviceCompare's selection limit (see DeviceCompare.tsx). Kept here so the
+// bulk menu can explain the cap instead of silently dropping the item.
+const COMPARE_MAX_DEVICES = 4;
 import { OSIcon } from "./osIcons";
 import { formatDeviceOsVersion } from "./osDisplay";
 import { type ListFilters, DEFAULT_LIST_FILTERS } from "./deviceListFilters";
@@ -352,6 +356,12 @@ type DeviceListProps = {
   // true only when the active filter group explicitly targets the
   // 'decommissioned' status, so filtering FOR decommissioned still shows them.
   includeDecommissioned?: boolean;
+  /**
+   * Offered only while the rows are visible via the page-level showRemoved
+   * flag (not via an explicit Decommissioned status filter, where hiding
+   * would be a no-op) — renders the "N removed shown — hide" line (#5023).
+   */
+  onHideDecommissioned?: () => void;
   // Applies the Decommissioned status filter upstream (#2251) — the existing
   // unhide mechanism. Wired by DevicesPage; when absent (standalone renders /
   // tests) the "N decommissioned hidden — show" hint is not rendered.
@@ -592,6 +602,7 @@ export default function DeviceList({
   onBulkAction,
   pageSize = 10,
   includeDecommissioned = false,
+  onHideDecommissioned,
   onShowDecommissioned,
   serverFilterIds = null,
   serverFilterLoading = false,
@@ -823,13 +834,11 @@ export default function DeviceList({
   // How many decommissioned devices the default view is hiding (#2251). Zero
   // when they're already visible (includeDecommissioned) so the hint and the
   // count math below stay consistent with what the table actually shows.
-  const hiddenDecommissionedCount = useMemo(
-    () =>
-      includeDecommissioned
-        ? 0
-        : devices.filter(d => d.status === 'decommissioned').length,
-    [devices, includeDecommissioned]
+  const decommissionedCount = useMemo(
+    () => devices.filter(d => d.status === 'decommissioned').length,
+    [devices]
   );
+  const hiddenDecommissionedCount = includeDecommissioned ? 0 : decommissionedCount;
 
   // Providers present across the loaded set — drives the VPN facet options so
   // techs only see providers that actually exist in their fleet.
@@ -1918,6 +1927,27 @@ export default function DeviceList({
     },
   };
 
+  // Bulk-menu Compare item. DeviceCompare accepts at most COMPARE_MAX_DEVICES,
+  // so above that the item renders disabled with the cap as its label + title
+  // instead of disappearing (#5023 paper cut). Shared by the active and the
+  // all-removed branches of the menu.
+  const renderCompareItem = () => {
+    const overCap = selectedIds.size > COMPARE_MAX_DEVICES;
+    const capLabel = t("deviceList.compareMaxDevices", { count: COMPARE_MAX_DEVICES });
+    return (
+      <button
+        type="button"
+        data-testid="bulk-compare"
+        disabled={overCap}
+        title={overCap ? capLabel : undefined}
+        onClick={() => handleBulkAction("compare")}
+        className="w-full px-4 py-2 text-left text-sm hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent"
+      >
+        {overCap ? capLabel : t("deviceList.compareSelected")}
+      </button>
+    );
+  };
+
   return (
     <div>
       <div className="flex flex-col gap-3">
@@ -1951,6 +1981,15 @@ export default function DeviceList({
                 <DecommissionedHiddenHint
                   count={hiddenDecommissionedCount}
                   onShow={onShowDecommissioned}
+                />
+              </span>
+            )}
+            {onHideDecommissioned && includeDecommissioned && decommissionedCount > 0 && (
+              <span className="ml-2">
+                <DecommissionedHiddenHint
+                  mode="shown"
+                  count={decommissionedCount}
+                  onHide={onHideDecommissioned}
                 />
               </span>
             )}
@@ -2193,18 +2232,10 @@ export default function DeviceList({
                 >
                   {t("deviceList.wakeSelected")}{" "}
                 </button>
-                {/* Compare caps at 4 devices (DeviceCompare's selection limit),
-                    so the item only shows for a 2-4 selection. */}
-                {selectedIds.size >= 2 && selectedIds.size <= 4 && (
-                  <button
-                    type="button"
-                    data-testid="bulk-compare"
-                    onClick={() => handleBulkAction("compare")}
-                    className="w-full px-4 py-2 text-left text-sm hover:bg-muted"
-                  >
-                    {t("deviceList.compareSelected")}{" "}
-                  </button>
-                )}
+                {/* Compare caps at 4 devices (DeviceCompare's selection limit).
+                    Above the cap the item stays put but disabled with the cap
+                    spelled out — it used to vanish silently (#5023). */}
+                {selectedIds.size >= 2 && renderCompareItem()}
                 {selectedIds.size >= 2 && (
                   <button
                     type="button"
@@ -2249,16 +2280,7 @@ export default function DeviceList({
                     {/* Same 2-4 cap as the active branch — DeviceCompare's own
                         selection limit. A removed device is a legitimate (if
                         approximate) comparison subject. */}
-                    {selectedIds.size >= 2 && selectedIds.size <= 4 && (
-                      <button
-                        type="button"
-                        data-testid="bulk-compare"
-                        onClick={() => handleBulkAction("compare")}
-                        className="w-full px-4 py-2 text-left text-sm hover:bg-muted"
-                      >
-                        {t("deviceList.compareSelected")}
-                      </button>
-                    )}
+                    {selectedIds.size >= 2 && renderCompareItem()}
                     <hr className="my-1" />
                     <button
                       type="button"

--- a/apps/web/src/components/devices/DevicesPage.test.tsx
+++ b/apps/web/src/components/devices/DevicesPage.test.tsx
@@ -1004,6 +1004,42 @@ describe('DevicesPage — hidden-decommissioned hint (#2251, #5023)', () => {
     expect(screen.getByTestId('decommissioned-hidden-hint')).toHaveTextContent('2 removed hidden');
   });
 
+  it('grid view: the hint counts only removed devices the advanced filter admits', async () => {
+    const { decodeFilterFromHash } = await import('./filterUrl');
+    vi.mocked(decodeFilterFromHash).mockReturnValueOnce({
+      operator: 'AND',
+      conditions: [{ field: 'os', operator: 'equals', value: 'windows' }],
+    });
+    vi.mocked(fetchAllDevices).mockResolvedValue({
+      data: [
+        rawDevice(DEV_1, 'host-alpha'),
+        { ...rawDevice(DEV_2, 'host-beta'), status: 'decommissioned' },
+        { ...rawDevice(DEV_3, 'host-gamma'), status: 'decommissioned' },
+      ],
+    } as never);
+    // The os filter admits the active device and ONE of the two removed ones.
+    vi.mocked(fetchWithAuth).mockImplementation(async (url: string) => {
+      if (url.startsWith('/filters/preview')) {
+        return jsonResponse({
+          data: { totalCount: 2, deviceIds: [DEV_1, DEV_2], evaluatedAt: new Date().toISOString() },
+        });
+      }
+      return jsonResponse({ data: [] });
+    });
+
+    render(<DevicesPage />);
+    fireEvent.click(await screen.findByLabelText('Grid view'));
+
+    const hint = await screen.findByTestId('decommissioned-hidden-hint');
+    await waitFor(() => expect(hint).toHaveTextContent('1 removed hidden'));
+
+    fireEvent.click(screen.getByTestId('decommissioned-hidden-show'));
+    expect(await screen.findByTestId(`device-card-${DEV_2}`)).toBeTruthy();
+    // DEV_3 is excluded by the filter, not by the hidden-by-default rule.
+    expect(screen.queryByTestId(`device-card-${DEV_3}`)).toBeNull();
+    expect(screen.getByTestId('decommissioned-shown-hint')).toHaveTextContent('1 removed shown');
+  });
+
   it('grid view renders no hint when no decommissioned devices exist', async () => {
     const { decodeFilterFromHash } = await import('./filterUrl');
     vi.mocked(decodeFilterFromHash).mockReturnValueOnce(null);

--- a/apps/web/src/components/devices/DevicesPage.test.tsx
+++ b/apps/web/src/components/devices/DevicesPage.test.tsx
@@ -201,11 +201,12 @@ vi.mock('./DeviceCard', () => ({
 // the per-action buttons to drive DevicesPage.handleBulkAction directly.
 type StubDevice = { id: string; deviceClass?: string; hostname?: string; displayName?: string; watchdogVersion?: string | null; status?: string; wanIp?: string | null; lanIp?: string | null };
 vi.mock('./DeviceList', () => ({
-  default: ({ devices, serverFilterIds, onBulkAction, onAction, onSelect, onShowDecommissioned, includeDecommissioned }: { devices: StubDevice[]; serverFilterIds?: Set<string> | null; onBulkAction?: (action: string, devices: StubDevice[]) => void; onAction?: (action: string, device: StubDevice) => void; onSelect?: (device: StubDevice) => void; onShowDecommissioned?: () => void; includeDecommissioned?: boolean }) => (
+  default: ({ devices, serverFilterIds, onBulkAction, onAction, onSelect, onShowDecommissioned, onHideDecommissioned, includeDecommissioned }: { devices: StubDevice[]; serverFilterIds?: Set<string> | null; onBulkAction?: (action: string, devices: StubDevice[]) => void; onAction?: (action: string, device: StubDevice) => void; onSelect?: (device: StubDevice) => void; onShowDecommissioned?: () => void; onHideDecommissioned?: () => void; includeDecommissioned?: boolean }) => (
     <div
       data-testid="device-list"
       data-device-count={devices.length}
       data-include-decommissioned={includeDecommissioned ? 'true' : 'false'}
+      data-can-hide-decommissioned={onHideDecommissioned ? 'true' : 'false'}
       data-filter-ids={serverFilterIds ? [...serverFilterIds].sort().join(',') : ''}
       data-hostnames={devices.map(d => d.hostname ?? '').join(',')}
       data-display-names={devices.map(d => d.displayName ?? '').join(',')}
@@ -289,6 +290,15 @@ vi.mock('./DeviceList', () => ({
           onClick={() => onShowDecommissioned()}
         >
           show decommissioned
+        </button>
+      )}
+      {onHideDecommissioned && (
+        <button
+          type="button"
+          data-testid="stub-hide-decommissioned"
+          onClick={() => onHideDecommissioned()}
+        >
+          hide decommissioned
         </button>
       )}
     </div>
@@ -943,13 +953,13 @@ describe('DevicesPage — row selection routes by device class (#1424)', () => {
 });
 
 // #2251 — decommissioned devices are hidden by default with no cue that they
-// exist. The page must surface a "N decommissioned hidden — show" hint in both
-// views, and "show" applies the Decommissioned status filter (the existing
-// unhide mechanism — includeDecommissioned flips true when the active filter
-// targets that status).
-describe('DevicesPage — hidden-decommissioned hint (#2251)', () => {
-  it('grid view shows the hint; clicking "show" applies the Decommissioned filter and reveals the rows', async () => {
-    const { decodeFilterFromHash } = await import('./filterUrl');
+// exist. The page must surface a "N removed hidden — show" hint in both
+// views. #5023 paper cut: "show" ADDS the removed rows to whatever is on
+// screen (page-level showRemoved flag) instead of swapping the view to a
+// removed-only status filter; the hint then flips to "N removed shown — hide".
+describe('DevicesPage — hidden-decommissioned hint (#2251, #5023)', () => {
+  it('grid view: "show" adds the removed cards alongside the active one, leaves the filter alone, and offers "hide"', async () => {
+    const { decodeFilterFromHash, writeFilterToHash } = await import('./filterUrl');
     vi.mocked(decodeFilterFromHash).mockReturnValueOnce(null);
     vi.mocked(fetchAllDevices).mockResolvedValue({
       data: [
@@ -958,15 +968,6 @@ describe('DevicesPage — hidden-decommissioned hint (#2251)', () => {
         { ...rawDevice(DEV_3, 'host-gamma'), status: 'decommissioned' },
       ],
     } as never);
-    // The decommissioned status filter resolves to the two decommissioned rows.
-    vi.mocked(fetchWithAuth).mockImplementation(async (url: string) => {
-      if (url.startsWith('/filters/preview')) {
-        return jsonResponse({
-          data: { totalCount: 2, deviceIds: [DEV_2, DEV_3], evaluatedAt: new Date().toISOString() },
-        });
-      }
-      return jsonResponse({ data: [] });
-    });
 
     render(<DevicesPage />);
     fireEvent.click(await screen.findByLabelText('Grid view'));
@@ -979,25 +980,28 @@ describe('DevicesPage — hidden-decommissioned hint (#2251)', () => {
 
     fireEvent.click(screen.getByTestId('decommissioned-hidden-show'));
 
-    // The status filter now targets decommissioned → those cards render, the
-    // online card drops out (filtered), and the hint disappears.
+    // The removed cards are ADDED — the active card stays, the hidden hint
+    // gives way to the "shown — hide" line.
     expect(await screen.findByTestId(`device-card-${DEV_2}`)).toBeTruthy();
     expect(screen.getByTestId(`device-card-${DEV_3}`)).toBeTruthy();
-    await waitFor(() => {
-      expect(screen.queryByTestId(`device-card-${DEV_1}`)).toBeNull();
-    });
+    expect(screen.getByTestId(`device-card-${DEV_1}`)).toBeTruthy();
     expect(screen.queryByTestId('decommissioned-hidden-hint')).toBeNull();
+    const shown = screen.getByTestId('decommissioned-shown-hint');
+    expect(shown).toHaveTextContent('2 removed shown');
 
-    // The applied condition is the toolbar-equivalent status filter.
-    const previewCall = vi.mocked(fetchWithAuth).mock.calls.find(([url]) =>
-      String(url).startsWith('/filters/preview')
-    );
-    expect(previewCall).toBeDefined();
-    const body = JSON.parse(previewCall![1]?.body as string);
-    expect(body.conditions).toEqual({
-      operator: 'AND',
-      conditions: [{ field: 'status', operator: 'equals', value: 'decommissioned' }],
+    // No filter was applied or rewritten — the advanced filter is untouched.
+    expect(vi.mocked(writeFilterToHash).mock.calls.some(([f]) => f !== null)).toBe(false);
+    expect(
+      vi.mocked(fetchWithAuth).mock.calls.some(([url]) => String(url).startsWith('/filters/preview'))
+    ).toBe(false);
+
+    // "hide" restores the default view.
+    fireEvent.click(screen.getByTestId('decommissioned-hidden-hide'));
+    await waitFor(() => {
+      expect(screen.queryByTestId(`device-card-${DEV_2}`)).toBeNull();
     });
+    expect(screen.getByTestId(`device-card-${DEV_1}`)).toBeTruthy();
+    expect(screen.getByTestId('decommissioned-hidden-hint')).toHaveTextContent('2 removed hidden');
   });
 
   it('grid view renders no hint when no decommissioned devices exist', async () => {
@@ -1011,111 +1015,54 @@ describe('DevicesPage — hidden-decommissioned hint (#2251)', () => {
     expect(screen.queryByTestId('decommissioned-hidden-hint')).toBeNull();
   });
 
-  it('list view: onShowDecommissioned replaces an existing status value and keeps other conditions', async () => {
+  it('list view: "show" flips includeDecommissioned without rewriting the existing filter; "hide" flips it back', async () => {
     const { decodeFilterFromHash, writeFilterToHash } = await import('./filterUrl');
-    vi.mocked(decodeFilterFromHash).mockReturnValueOnce({
-      operator: 'AND',
+    const existing = {
+      operator: 'AND' as const,
       conditions: [
-        { field: 'os', operator: 'equals', value: 'windows' },
-        { field: 'status', operator: 'equals', value: 'online' },
+        { field: 'os', operator: 'equals' as const, value: 'windows' },
+        { field: 'status', operator: 'equals' as const, value: 'online' },
       ],
-    });
+    };
+    vi.mocked(decodeFilterFromHash).mockReturnValueOnce(existing);
 
     render(<DevicesPage />);
     const list = await screen.findByTestId('device-list');
     expect(list.getAttribute('data-include-decommissioned')).toBe('false');
-
-    fireEvent.click(screen.getByTestId('stub-show-decommissioned'));
-
-    // status=online is REPLACED (single-select per field, like the toolbar);
-    // the os condition is preserved.
-    await waitFor(() => {
-      const last = vi.mocked(writeFilterToHash).mock.calls.at(-1)?.[0];
-      expect(last).toEqual({
-        operator: 'AND',
-        conditions: [
-          { field: 'os', operator: 'equals', value: 'windows' },
-          { field: 'status', operator: 'equals', value: 'decommissioned' },
-        ],
-      });
-    });
-    expect(list.getAttribute('data-include-decommissioned')).toBe('true');
-  });
-});
-
-// #2251 — the two trickier handleShowDecommissioned branches: an OR sentence
-// from the Advanced drawer must be nested (not rewritten to AND, and the
-// status condition must stay top-level where the includeDecommissioned memo
-// looks), and a multi-select `in` status condition must be replaced, not
-// stacked into a contradictory AND.
-describe('DevicesPage — show-decommissioned filter rewrite edge cases (#2251)', () => {
-  it('nests an OR group and keeps the status condition top-level', async () => {
-    const { decodeFilterFromHash, writeFilterToHash } = await import('./filterUrl');
-    const orGroup = {
-      operator: 'OR' as const,
-      conditions: [
-        { field: 'os', operator: 'equals' as const, value: 'windows' },
-        { field: 'os', operator: 'equals' as const, value: 'macos' },
-      ],
-    };
-    vi.mocked(decodeFilterFromHash).mockReturnValueOnce(orGroup);
-
-    render(<DevicesPage />);
-    const list = await screen.findByTestId('device-list');
-    expect(list.getAttribute('data-include-decommissioned')).toBe('false');
+    expect(list.getAttribute('data-can-hide-decommissioned')).toBe('false');
 
     fireEvent.click(screen.getByTestId('stub-show-decommissioned'));
 
     await waitFor(() => {
-      const last = vi.mocked(writeFilterToHash).mock.calls.at(-1)?.[0];
-      expect(last).toEqual({
-        operator: 'AND',
-        conditions: [
-          orGroup,
-          { field: 'status', operator: 'equals', value: 'decommissioned' },
-        ],
-      });
+      expect(list.getAttribute('data-include-decommissioned')).toBe('true');
     });
-    // The top-level status condition is what flips includeDecommissioned —
-    // a condition buried inside the nested group would leave the rows hidden.
-    expect(list.getAttribute('data-include-decommissioned')).toBe('true');
+    expect(list.getAttribute('data-can-hide-decommissioned')).toBe('true');
+    // status=online is NOT replaced — the tech's filter survives "show".
+    const lastWritten = vi.mocked(writeFilterToHash).mock.calls.at(-1)?.[0];
+    expect(lastWritten).toEqual(existing);
+
+    fireEvent.click(screen.getByTestId('stub-hide-decommissioned'));
+    await waitFor(() => {
+      expect(list.getAttribute('data-include-decommissioned')).toBe('false');
+    });
+    expect(list.getAttribute('data-can-hide-decommissioned')).toBe('false');
   });
 
-  it('replaces a multi-select `in` status condition and preserves nested subgroups', async () => {
-    const { decodeFilterFromHash, writeFilterToHash } = await import('./filterUrl');
-    const nestedGroup = {
-      operator: 'OR' as const,
-      conditions: [
-        { field: 'os', operator: 'equals' as const, value: 'windows' },
-        { field: 'os', operator: 'equals' as const, value: 'linux' },
-      ],
-    };
+  it('list view: an explicit Decommissioned status filter shows the rows with no "hide" affordance', async () => {
+    const { decodeFilterFromHash } = await import('./filterUrl');
     vi.mocked(decodeFilterFromHash).mockReturnValueOnce({
       operator: 'AND',
-      conditions: [
-        nestedGroup,
-        { field: 'status', operator: 'in', value: ['online', 'offline'] },
-      ],
+      conditions: [{ field: 'status', operator: 'equals', value: 'decommissioned' }],
     });
 
     render(<DevicesPage />);
     const list = await screen.findByTestId('device-list');
-
-    fireEvent.click(screen.getByTestId('stub-show-decommissioned'));
-
-    // A leftover `status in [...]` would AND with the new equals to an
-    // always-empty result; it must be replaced. The nested subgroup survives.
     await waitFor(() => {
-      const last = vi.mocked(writeFilterToHash).mock.calls.at(-1)?.[0];
-      expect(last).toEqual({
-        operator: 'AND',
-        conditions: [
-          nestedGroup,
-          { field: 'status', operator: 'equals', value: 'decommissioned' },
-        ],
-      });
+      expect(list.getAttribute('data-include-decommissioned')).toBe('true');
     });
-    expect(list.getAttribute('data-include-decommissioned')).toBe('true');
+    // The filter (not the showRemoved flag) is what unhid them, so "hide"
+    // would be a no-op — it must not be offered.
+    expect(list.getAttribute('data-can-hide-decommissioned')).toBe('false');
   });
 });
 

--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -368,22 +368,30 @@ export default function DevicesPage() {
     () => filterDevicesByClass(devices, deviceClassFilter),
     [devices, deviceClassFilter]
   );
-  const gridDevices = useMemo(
-    () => {
-      const base = includeDecommissioned
+  // Rows the advanced filter admits, before the hidden-by-default
+  // decommissioned rule — the removed-hint counts come from this set so they
+  // only promise rows "show" can actually reveal (#2251/#5023).
+  const gridMatchingDevices = useMemo(
+    () =>
+      advancedFilterIds === null
         ? classFilteredDevices
-        : classFilteredDevices.filter(d => d.status !== 'decommissioned');
-      return advancedFilterIds === null ? base : base.filter(d => advancedFilterIds.has(d.id));
-    },
-    [classFilteredDevices, advancedFilterIds, includeDecommissioned]
+        : classFilteredDevices.filter(d => advancedFilterIds.has(d.id)),
+    [classFilteredDevices, advancedFilterIds]
   );
-  // How many decommissioned devices the default view is hiding (#2251) — drives
-  // the grid view's hint line (the list view computes its own from the same
-  // classFilteredDevices set, so the two stay in lockstep). The page fetches
-  // with includeDecommissioned: true, so this is a cheap client-side count.
+  const gridDevices = useMemo(
+    () =>
+      includeDecommissioned
+        ? gridMatchingDevices
+        : gridMatchingDevices.filter(d => d.status !== 'decommissioned'),
+    [gridMatchingDevices, includeDecommissioned]
+  );
+  // How many decommissioned devices the grid is hiding / showing (#2251) —
+  // drives the grid view's hint line (the list view computes its own from the
+  // same inputs, so the two stay in lockstep). The page fetches with
+  // includeDecommissioned: true, so this is a cheap client-side count.
   const decommissionedCount = useMemo(
-    () => classFilteredDevices.filter(d => d.status === 'decommissioned').length,
-    [classFilteredDevices]
+    () => gridMatchingDevices.filter(d => d.status === 'decommissioned').length,
+    [gridMatchingDevices]
   );
   const hiddenDecommissionedCount = includeDecommissioned ? 0 : decommissionedCount;
   const shownDecommissionedCount = includeDecommissioned ? decommissionedCount : 0;

--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -4,7 +4,7 @@ import { useEventStream } from '../../hooks/useEventStream';
 import { useAdvancedFilterIds } from '../../hooks/useAdvancedFilterIds';
 import { List, Grid, Plus, AlertCircle } from 'lucide-react';
 import { showToast } from '../shared/Toast';
-import type { FilterCondition, FilterConditionGroup } from '@breeze/shared';
+import type { FilterConditionGroup } from '@breeze/shared';
 import DeviceList, { type Device, type DeviceClass, type DeviceStatus, type OSType } from './DeviceList';
 import type { DeviceRole } from '@/lib/deviceRoles';
 import DeviceCard from './DeviceCard';
@@ -329,10 +329,17 @@ export default function DevicesPage() {
   // set into DeviceList, which combines it with its local quick-filters
   // (search/status/os/etc. stay list-only).
   //
-  // Decommissioned devices are hidden by default (old list behavior). Show them
-  // only when the active filter group explicitly targets the 'decommissioned'
-  // status, so a user filtering FOR decommissioned still sees them.
-  const includeDecommissioned = useMemo(() => {
+  // Decommissioned devices are hidden by default (old list behavior). They
+  // become visible in two ways: the active filter group explicitly targets
+  // the 'decommissioned' status (a user filtering FOR removed devices still
+  // sees them), or the tech clicked "show" on the hidden-removed hint, which
+  // flips the page-level showRemoved flag. The flag ADDS the removed rows to
+  // whatever is on screen — it does not touch the advanced filter (#5023
+  // paper cut: "show" used to swap the view to a removed-only status filter,
+  // dropping every active device the tech was looking at). Transient session
+  // state on purpose: a reload returns to the hidden-by-default view.
+  const [showRemoved, setShowRemoved] = useState(false);
+  const filterTargetsDecommissioned = useMemo(() => {
     const conds = advancedFilter?.conditions ?? [];
     return conds.some(c => {
       if ('conditions' in c) return false; // nested groups: ignore (rare)
@@ -342,30 +349,14 @@ export default function DevicesPage() {
         : c.value === 'decommissioned';
     });
   }, [advancedFilter]);
+  const includeDecommissioned = showRemoved || filterTargetsDecommissioned;
 
-  // "Show" action for the hidden-decommissioned hint (#2251): applies the
-  // Decommissioned status filter — the same unhide mechanism the toolbar's
-  // status picker uses — replacing any other status equals/in value. Same
-  // single-select-per-field semantics as DeviceFilterToolbar's addCondition
-  // (independent implementation; chip order may differ — the replacement is
-  // appended rather than placed in the replaced condition's slot). Other
-  // filter conditions are preserved. If the current group is an OR sentence
-  // built in the Advanced drawer, nest it instead of rewriting it so its
-  // meaning is kept and the status condition stays top-level (where the
-  // includeDecommissioned memo looks); the AND intersection can be empty if
-  // the OR sentence itself constrains status — the rows still unhide, but
-  // zero of them may match.
-  const handleShowDecommissioned = useCallback(() => {
-    setAdvancedFilter(prev => {
-      const statusCond: FilterCondition = { field: 'status', operator: 'equals', value: 'decommissioned' };
-      if (!prev) return { operator: 'AND', conditions: [statusCond] };
-      if (prev.operator === 'OR') return { operator: 'AND', conditions: [prev, statusCond] };
-      const rest = prev.conditions.filter(
-        c => 'conditions' in c || c.field !== 'status' || (c.operator !== 'equals' && c.operator !== 'in')
-      );
-      return { operator: 'AND', conditions: [...rest, statusCond] };
-    });
-  }, []);
+  const handleShowDecommissioned = useCallback(() => setShowRemoved(true), []);
+  const handleHideDecommissioned = useCallback(() => setShowRemoved(false), []);
+  // "hide" is only meaningful while the flag (not an explicit status filter)
+  // is what unhid the rows; otherwise clicking it would visibly do nothing.
+  const onHideDecommissioned =
+    showRemoved && !filterTargetsDecommissioned ? handleHideDecommissioned : undefined;
 
   // Per-segment counts come from the full merged fleet so each segment shows its
   // true total regardless of which one is active. Gated to the network arm; with
@@ -390,13 +381,12 @@ export default function DevicesPage() {
   // the grid view's hint line (the list view computes its own from the same
   // classFilteredDevices set, so the two stay in lockstep). The page fetches
   // with includeDecommissioned: true, so this is a cheap client-side count.
-  const hiddenDecommissionedCount = useMemo(
-    () =>
-      includeDecommissioned
-        ? 0
-        : classFilteredDevices.filter(d => d.status === 'decommissioned').length,
-    [classFilteredDevices, includeDecommissioned]
+  const decommissionedCount = useMemo(
+    () => classFilteredDevices.filter(d => d.status === 'decommissioned').length,
+    [classFilteredDevices]
   );
+  const hiddenDecommissionedCount = includeDecommissioned ? 0 : decommissionedCount;
+  const shownDecommissionedCount = includeDecommissioned ? decommissionedCount : 0;
 
   const fetchDevices = useCallback(async (signal?: AbortSignal) => {
     try {
@@ -1734,6 +1724,7 @@ export default function DevicesPage() {
           serverFilterError={advancedFilterError}
           includeDecommissioned={includeDecommissioned}
           onShowDecommissioned={handleShowDecommissioned}
+          onHideDecommissioned={onHideDecommissioned}
           listFilters={listFilters}
           onListFiltersChange={setListFilters}
           onCreateGroup={() => setShowCreateGroup(true)}
@@ -1765,6 +1756,15 @@ export default function DevicesPage() {
               <DecommissionedHiddenHint
                 count={hiddenDecommissionedCount}
                 onShow={handleShowDecommissioned}
+              />
+            </p>
+          )}
+          {onHideDecommissioned && shownDecommissionedCount > 0 && (
+            <p>
+              <DecommissionedHiddenHint
+                mode="shown"
+                count={shownDecommissionedCount}
+                onHide={onHideDecommissioned}
               />
             </p>
           )}

--- a/apps/web/src/locales/de-DE/devices.json
+++ b/apps/web/src/locales/de-DE/devices.json
@@ -147,7 +147,9 @@
   },
   "decommissionedHiddenHint": {
     "label": "{{count}} Entfernte ausgeblendet",
-    "show": "anzeigen"
+    "show": "anzeigen",
+    "shownLabel": "{{count}} entfernte angezeigt",
+    "hide": "ausblenden"
   },
   "deviceActions": {
     "unavailable": {
@@ -1142,6 +1144,7 @@
     "disableMaintenance": "Wartungsmodus deaktivieren",
     "wakeSelected": "Ausgewählte Geräte aufwecken",
     "compareSelected": "Ausgewählte vergleichen",
+    "compareMaxDevices": "Vergleich unterstützt bis zu {{count}} Geräte",
     "linkAsMultiBoot": "Link als Multiboot",
     "decommissionSelected": "Auswahl entfernen",
     "restoreSelected": "Auswahl wiederherstellen",

--- a/apps/web/src/locales/en/devices.json
+++ b/apps/web/src/locales/en/devices.json
@@ -147,7 +147,9 @@
   },
   "decommissionedHiddenHint": {
     "label": "{{count}} removed hidden",
-    "show": "show"
+    "show": "show",
+    "shownLabel": "{{count}} removed shown",
+    "hide": "hide"
   },
   "deviceActions": {
     "unavailable": {
@@ -1142,6 +1144,7 @@
     "disableMaintenance": "Disable Maintenance",
     "wakeSelected": "Wake Selected",
     "compareSelected": "Compare Selected",
+    "compareMaxDevices": "Compare supports up to {{count}} devices",
     "linkAsMultiBoot": "Link as multi-boot",
     "decommissionSelected": "Remove Selected",
     "restoreSelected": "Restore Selected",

--- a/apps/web/src/locales/es-419/devices.json
+++ b/apps/web/src/locales/es-419/devices.json
@@ -147,7 +147,9 @@
   },
   "decommissionedHiddenHint": {
     "label": "{{count}} quitados ocultos",
-    "show": "mostrar"
+    "show": "mostrar",
+    "shownLabel": "{{count}} eliminados mostrados",
+    "hide": "ocultar"
   },
   "deviceActions": {
     "unavailable": {
@@ -1142,6 +1144,7 @@
     "disableMaintenance": "Desactivar mantenimiento",
     "wakeSelected": "Despertar seleccionado",
     "compareSelected": "Comparar seleccionados",
+    "compareMaxDevices": "La comparación admite hasta {{count}} dispositivos",
     "linkAsMultiBoot": "Enlace como arranque múltiple",
     "decommissionSelected": "Quitar seleccionados",
     "restoreSelected": "Restaurar seleccionados",

--- a/apps/web/src/locales/fr-CA/devices.json
+++ b/apps/web/src/locales/fr-CA/devices.json
@@ -147,7 +147,9 @@
   },
   "decommissionedHiddenHint": {
     "label": "{{count}} retirés masqués",
-    "show": "afficher"
+    "show": "afficher",
+    "shownLabel": "{{count}} supprimés affichés",
+    "hide": "masquer"
   },
   "deviceActions": {
     "unavailable": {
@@ -1142,6 +1144,7 @@
     "disableMaintenance": "Désactiver la maintenance",
     "wakeSelected": "Wake sélectionné",
     "compareSelected": "Comparer la sélection",
+    "compareMaxDevices": "La comparaison prend en charge jusqu'à {{count}} appareils",
     "linkAsMultiBoot": "Liaison en tant que multi-boot",
     "decommissionSelected": "Retirer la sélection",
     "restoreSelected": "Restaurer la sélection",

--- a/apps/web/src/locales/fr-FR/devices.json
+++ b/apps/web/src/locales/fr-FR/devices.json
@@ -147,7 +147,9 @@
   },
   "decommissionedHiddenHint": {
     "label": "{{count}} retirés masqués",
-    "show": "afficher"
+    "show": "afficher",
+    "shownLabel": "{{count}} supprimés affichés",
+    "hide": "masquer"
   },
   "deviceActions": {
     "unavailable": {
@@ -1142,6 +1144,7 @@
     "disableMaintenance": "Désactiver la maintenance",
     "wakeSelected": "Wake sélectionné",
     "compareSelected": "Comparer la sélection",
+    "compareMaxDevices": "La comparaison prend en charge jusqu'à {{count}} appareils",
     "linkAsMultiBoot": "Liaison en tant que multi-boot",
     "decommissionSelected": "Retirer la sélection",
     "restoreSelected": "Restaurer la sélection",

--- a/apps/web/src/locales/it-IT/devices.json
+++ b/apps/web/src/locales/it-IT/devices.json
@@ -147,7 +147,9 @@
   },
   "decommissionedHiddenHint": {
     "label": "{{count}} rimossi nascosti",
-    "show": "mostra"
+    "show": "mostra",
+    "shownLabel": "{{count}} rimossi mostrati",
+    "hide": "nascondi"
   },
   "deviceActions": {
     "unavailable": {
@@ -1142,6 +1144,7 @@
     "disableMaintenance": "Disabilita manutenzione",
     "wakeSelected": "Riattiva selezionati",
     "compareSelected": "Confronta selezionati",
+    "compareMaxDevices": "Il confronto supporta fino a {{count}} dispositivi",
     "linkAsMultiBoot": "Collega come multi-boot",
     "decommissionSelected": "Rimuovi selezionati",
     "restoreSelected": "Ripristina selezionati",

--- a/apps/web/src/locales/pt-BR/devices.json
+++ b/apps/web/src/locales/pt-BR/devices.json
@@ -147,7 +147,9 @@
   },
   "decommissionedHiddenHint": {
     "label": "{{count}} removidos ocultos",
-    "show": "mostrar"
+    "show": "mostrar",
+    "shownLabel": "{{count}} removidos exibidos",
+    "hide": "ocultar"
   },
   "deviceActions": {
     "unavailable": {
@@ -1142,6 +1144,7 @@
     "disableMaintenance": "Desativar manutenção",
     "wakeSelected": "Acordar selecionados",
     "compareSelected": "Comparar selecionados",
+    "compareMaxDevices": "A comparação suporta até {{count}} dispositivos",
     "linkAsMultiBoot": "Vincular como multi-boot",
     "decommissionSelected": "Remover selecionados",
     "restoreSelected": "Restaurar selecionados",

--- a/apps/web/src/locales/tr-TR/devices.json
+++ b/apps/web/src/locales/tr-TR/devices.json
@@ -147,7 +147,9 @@
   },
   "decommissionedHiddenHint": {
     "label": "{{count}} çıkarılan gizlendi",
-    "show": "göster"
+    "show": "göster",
+    "shownLabel": "{{count}} kaldırılmış gösteriliyor",
+    "hide": "gizle"
   },
   "deviceActions": {
     "unavailable": {
@@ -1142,6 +1144,7 @@
     "disableMaintenance": "Bakımı Devre Dışı Bırak",
     "wakeSelected": "Uyandırma Seçilen",
     "compareSelected": "Seçilenleri Karşılaştır",
+    "compareMaxDevices": "Karşılaştırma en fazla {{count}} cihazı destekler",
     "linkAsMultiBoot": "Çoklu önyükleme olarak bağlantı",
     "decommissionSelected": "Seçilenleri Çıkar",
     "restoreSelected": "Seçilenleri Geri Yükle",


### PR DESCRIPTION
Two of the three paper cuts noted on #5023's browser walk (the third — inherited-policy state only shown with `?linked=` — is a missing backend feature, not a UI fix; see the follow-up note on the issue).

## "N removed hidden — show" swapped the view instead of adding rows

`handleShowDecommissioned` used to rewrite the advanced filter to `status = decommissioned`, so clicking **show** dropped every active device the tech was looking at and became a removed-only view. It now flips a page-level `showRemoved` flag:

- `includeDecommissioned = showRemoved || filterTargetsDecommissioned` — the removed rows are **added** to whatever is on screen; the advanced filter is never touched.
- Once shown, the same slot renders the mirror line **"N removed shown — hide"** (list view count line + grid view), so the default view is one click away.
- An explicit Decommissioned status filter still unhides on its own and gets no **hide** affordance (it would be a no-op there).
- Transient session state on purpose: a reload returns to hidden-by-default.

## Compare vanished silently at 5+ selected

Bulk Actions → Compare stays in the menu, disabled, labelled/titled "Compare supports up to 4 devices" (both the active and the all-removed menu branches). Cap lives in `COMPARE_MAX_DEVICES` next to DeviceCompare's own limit.

## Tests

- `DeviceList.test.tsx`: shown/hide line renders with `onHideDecommissioned` and not under an explicit filter; Compare disabled above the cap (active + removed selections), click does not fire.
- `DevicesPage.test.tsx`: grid "show" keeps the active card, adds the removed ones, never writes a filter or calls `/filters/preview`, "hide" restores; list "show"/"hide" flips `includeDecommissioned` while the existing filter is preserved verbatim; explicit Decommissioned filter → no hide affordance. The old filter-rewrite edge-case suite is gone with the rewrite.
- New i18n keys (`decommissionedHiddenHint.shownLabel`/`hide`, `deviceList.compareMaxDevices`) added to all 8 locales.

`tsc` clean, eslint clean, devices + i18n suites green (396 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZAsMVZBbCxwBUtRFmrY7A