### PR TITLE
refactor(web): AI agent edit drawer renders the create flow's step components (#5063)

### DIFF
--- a/apps/web/src/components/settings/AiAgentForm.test.tsx
+++ b/apps/web/src/components/settings/AiAgentForm.test.tsx
@@ -477,6 +477,34 @@ describe('AiAgentForm — capability picker wiring (#5050)', () => {
   // duplicated here.
 });
 
+// #5063: the drawer renders the guided create flow's own step components, so
+// every setting from "When it runs" through recipients has exactly one
+// rendering. The step roots carry test ids so this stays asserted rather
+// than implied by the individual field ids still resolving.
+describe('AiAgentForm — renders the create flow\'s step components (#5063)', () => {
+  it('mounts WhatItDoesStep and SafetyStep, in that order, with the edit-only pieces around them', async () => {
+    mockEndpoints(REGISTRY);
+    renderForm({ agent: makeAgent({ mode: 'act' }) });
+
+    const does = await screen.findByTestId('agent-step-does');
+    const safety = screen.getByTestId('agent-step-safety');
+    expect(does.compareDocumentPosition(safety) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+
+    // The settings live INSIDE the steps, not beside them.
+    expect(within(does).getByTestId('ai-agent-permissions')).toBeInTheDocument();
+    expect(within(does).getByTestId('ai-agent-respect-maintenance')).toBeInTheDocument();
+    expect(within(safety).getByTestId('ai-agent-services')).toBeInTheDocument();
+    expect(within(safety).getByTestId('ai-agent-policy-decide')).toBeInTheDocument();
+    expect(within(safety).getByTestId('ai-agent-limit-devices')).toBeInTheDocument();
+    expect(within(safety).getByTestId('ai-agent-role-r-1')).toBeInTheDocument();
+
+    // Edit-only pieces stay the drawer's own.
+    expect(screen.getByTestId('ai-agent-kind')).toBeDisabled();
+    expect(screen.getByTestId('ai-agent-enabled')).toBeInTheDocument();
+    expect(screen.getByTestId('ai-agent-disable')).toBeInTheDocument();
+  });
+});
+
 describe('AiAgentForm — alert severities', () => {
   it('offers alert severities to an alert-triage agent', async () => {
     mockEndpoints();

--- a/apps/web/src/components/settings/AiAgentForm.test.tsx
+++ b/apps/web/src/components/settings/AiAgentForm.test.tsx
@@ -488,15 +488,24 @@ describe('AiAgentForm — renders the create flow\'s step components (#5063)', (
 
     const does = await screen.findByTestId('agent-step-does');
     const safety = screen.getByTestId('agent-step-safety');
-    expect(does.compareDocumentPosition(safety) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    // Siblings in order — FOLLOWING alone is also true for a nested node, so
+    // rule containment out explicitly.
+    const position = does.compareDocumentPosition(safety);
+    expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(position & Node.DOCUMENT_POSITION_CONTAINED_BY).toBeFalsy();
 
-    // The settings live INSIDE the steps, not beside them.
+    // The settings live INSIDE the steps, not beside them — and exactly once
+    // in the drawer. The role row arrives after the /roles fetch, so it is
+    // awaited rather than assumed to have flushed.
     expect(within(does).getByTestId('ai-agent-permissions')).toBeInTheDocument();
     expect(within(does).getByTestId('ai-agent-respect-maintenance')).toBeInTheDocument();
     expect(within(safety).getByTestId('ai-agent-services')).toBeInTheDocument();
     expect(within(safety).getByTestId('ai-agent-policy-decide')).toBeInTheDocument();
     expect(within(safety).getByTestId('ai-agent-limit-devices')).toBeInTheDocument();
-    expect(within(safety).getByTestId('ai-agent-role-r-1')).toBeInTheDocument();
+    expect(await within(safety).findByTestId('ai-agent-role-r-1')).toBeInTheDocument();
+    for (const id of ['ai-agent-permissions', 'ai-agent-services', 'ai-agent-policy-decide', 'ai-agent-limit-devices', 'ai-agent-role-r-1']) {
+      expect(screen.getAllByTestId(id)).toHaveLength(1);
+    }
 
     // Edit-only pieces stay the drawer's own.
     expect(screen.getByTestId('ai-agent-kind')).toBeDisabled();

--- a/apps/web/src/components/settings/AiAgentForm.tsx
+++ b/apps/web/src/components/settings/AiAgentForm.tsx
@@ -2,14 +2,12 @@ import {
   useCallback,
   useEffect,
   useId,
-  useMemo,
   useRef,
   useState,
 } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   AI_AGENT_KINDS,
-  ALERT_SEVERITIES,
   type AiAgentDto,
   type AiAgentKind,
   type AiAgentMode,
@@ -23,23 +21,17 @@ import { useDefaultOwnerScope } from '@/hooks/useDefaultOwnerScope';
 import { ConfirmDialog } from '../shared/ConfirmDialog';
 import AiAgentSchedulesSection from './AiAgentSchedulesSection';
 import AiAgentGraduationPanel from './AiAgentGraduationPanel';
-import CapabilityPicker from './aiAgents/CapabilityPicker';
 import { useAgentToolCatalog } from './aiAgents/useAgentToolCatalog';
 import ModeChoice from './aiAgents/ModeChoice';
-import PolicyKeysCheckboxes, {
-  collapsedForCeiling,
-  policyActionLabel,
-  sentenceCase,
-  type PolicyDecidableKeyOption,
-} from './aiAgents/PolicyKeysCheckboxes';
-import { listField, numberField, RecipientRolesFieldset, type RoleOption } from './aiAgents/agentFields';
+import type { PolicyDecidableKeyOption } from './aiAgents/PolicyKeysCheckboxes';
+import type { RoleOption } from './aiAgents/agentFields';
 import { AGENT_ERROR_COPY, agentSaveIssuesFromError } from './aiAgents/agentErrors';
+import WhatItDoesStep from './aiAgents/steps/WhatItDoesStep';
+import SafetyStep from './aiAgents/steps/SafetyStep';
 import {
   ALERT_SEVERITY_KINDS,
   buildAgentSaveBody,
   draftFrom,
-  lines,
-  toggle,
   type Draft,
 } from './aiAgents/agentDraft';
 
@@ -162,10 +154,6 @@ export default function AiAgentForm({
 
   const patch = (values: Partial<Draft>) => setDraft((current) => ({ ...current, ...values }));
 
-  const permissionsHeadingId = useId();
-  const limitsBudgetId = useId();
-  const limitsTimingId = useId();
-  const severitiesGroupId = useId();
   const nameInputId = useId();
   const nameErrorId = useId();
   /** Name has been left at least once. Until then an empty Name is "not
@@ -174,8 +162,6 @@ export default function AiAgentForm({
    *  way to. */
   const [nameTouched, setNameTouched] = useState(false);
   const nameInvalid = nameTouched && draft.name.trim() === '';
-
-  const usesAlertSeverities = ALERT_SEVERITY_KINDS.has(draft.kind);
 
   // ---- Mode: the privileged choice --------------------------------------
   const actSupported = agent.supportedModes.includes('act');
@@ -382,143 +368,18 @@ export default function AiAgentForm({
   );
 
   /**
-   * #5049: the API now rejects any org-row create/PATCH that ADDS a
-   * supervisedActionKeys entry the row does not already hold — a key goes
-   * live on an org row only through the four-eyes grant executor (spec
-   * §4.4). Toggling a checkbox here for an org row can therefore never be
-   * honored by Save, so the whole registry renders disabled rather than
-   * offering a control that silently no-ops (or, before this fix, sends a
-   * payload the server now 422s on). Partner rows are the ceiling and are
-   * still edited directly here, so they stay interactive.
+   * #5063: everything from "When it runs" through recipients is rendered by
+   * the guided create flow's own step components (`WhatItDoesStep`,
+   * `SafetyStep`) so each setting has exactly one rendering and one test
+   * surface. The org-row read-only registry and the partner-ceiling collapse
+   * (#5049, P2-5) live in `SafetyStep` now. Only the edit-only pieces stay
+   * here: the fixed kind, the enabled switch, graduation, schedules and the
+   * Save/Cancel/Disable footer.
    */
-  const orgOwnedKeysReadOnly = draft.ownerScope === 'organization';
-
-  /** Registry entries keyed by their `key`, so an org row's read-only list
-   *  below can translate its currently-held keys without walking the full
-   *  registry-grouped-by-tool structure `policyKeysBody` builds for the
-   *  interactive (partner) rendering. */
-  const policyKeysByKey = useMemo(
-    () => new Map(policyKeys.map((entry) => [entry.key, entry] as const)),
-    [policyKeys],
-  );
-
-  /**
-   * #5049: an org row can never change its own supervisedActionKeys through
-   * this form (a save can only narrow the list — see the comment on
-   * `orgOwnedKeysReadOnly` — so there is nothing here for a checkbox to DO).
-   * A read-only `<ul>` of the row's own currently-held keys replaces the full
-   * registry-as-disabled-checkboxes rendering: showing every OTHER
-   * registered operation, unselected and disabled, described a control that
-   * cannot be operated either way, which is not information — it's noise.
-   */
-  const orgHeldKeysList = draft.supervisedActionKeys.length === 0 ? (
-    <p className="text-sm text-muted-foreground" data-testid="ai-agent-policy-keys-empty">
-      {t('aiAgentsPage.fields.supervisedActionKeysNoneHeld')}
-    </p>
-  ) : (
-    <ul className="list-disc space-y-1 pl-5 text-sm" data-testid="ai-agent-supervised-keys-readonly-list">
-      {draft.supervisedActionKeys.map((key) => {
-        const entry = policyKeysByKey.get(key);
-        return (
-          <li key={key} data-testid={`ai-agent-supervised-key-${key}`}>
-            {entry ? policyActionLabel(t, entry) : sentenceCase(key)}
-          </li>
-        );
-      })}
-    </ul>
-  );
-
-  /** The registry checkboxes, grouped by tool with translated labels — the
-   *  interactive rendering, now reached only for a PARTNER row (org rows
-   *  render `orgHeldKeysList` above instead; see `policyKeysBody` below).
-   *  Extracted to `PolicyKeysCheckboxes.tsx` (Task 13, #5051) so the guided
-   *  create flow's `SafetyStep` can render the identical registry — a pure
-   *  move, every test id unchanged. */
-  const policyKeysCheckboxes = (
-    <PolicyKeysCheckboxes
-      policyKeys={policyKeys}
-      policyKeysFailed={policyKeysFailed}
-      selectedKeys={draft.supervisedActionKeys}
-      onToggle={(key) => patch({ supervisedActionKeys: toggle(draft.supervisedActionKeys, key) })}
-    />
-  );
-
-  /** Org rows get the read-only list; partner rows keep the interactive
-   *  checkbox registry — see the two blocks above. */
-  const policyKeysBody = orgOwnedKeysReadOnly ? orgHeldKeysList : policyKeysCheckboxes;
-
-  /* Wave 5 Part B (#3827). Gated the same way as the act-warning block above
-   * (draft.mode === 'act' only) for ORG rows — the "act acknowledgement
-   * pattern": this is additional unattended authority an operator is opting
-   * into only once they are already looking at the act-mode warning, never
-   * offered for shadow/off.
-   * PARTNER rows are the exception (#4583): per P2-5 (#4192) a partner row's
-   * keys are a CEILING on org grants, not authority the partner row exercises
-   * itself — ticking a key here authorizes nothing on its own regardless of
-   * the partner row's own mode, so gating the editor (and its ceiling hint)
-   * behind the partner row's act mode hid the warning precisely when it
-   * mattered: while editing a Shadow-mode baseline.
-   *
-   * A partner row's registry is collapsed behind a native `<details>` while
-   * the row is NOT acting — placed BELOW Permissions rather than above it,
-   * since these checkboxes refine the tool allowlist Permissions already
-   * sets, not precede it. The summary counts the selection rather than
-   * repeating the full ceiling explanation (still given underneath, once
-   * opened), so a shadow-mode baseline reads as one scannable line instead of
-   * a checkbox list that authorizes nothing on its own from this row. The
-   * moment the row enters act mode the list is unwrapped entirely (not just
-   * opened) — that is the one mode where THIS row's own dispatch can be
-   * gated by these keys, so it earns the same plain treatment an org row
-   * always gets; the ceiling caveat still prints beneath it as a fact that
-   * survives the mode, not as something act mode makes disappear. An org row
-   * has no ceiling caveat to begin with and is only ever shown in act mode,
-   * so it renders the list directly with no wrapper at all.
-   *
-   * The collapse condition itself is `collapsedForCeiling` (imported from
-   * `PolicyKeysCheckboxes.tsx`), shared with the guided create flow's
-   * `SafetyStep.tsx` so the two surfaces can never disagree on when a
-   * partner row's registry is worth collapsing. */
-  const isCollapsedForCeiling = collapsedForCeiling(draft.ownerScope, draft.mode);
-  const ceilingNote = draft.ownerScope === 'partner' && (
-    <p className="text-xs text-muted-foreground" data-testid="ai-agent-supervised-keys-ceiling-hint">
-      {t('aiAgentsPage.graduation.ceilingHint')}
-    </p>
-  );
-  /** #5049: the org-row counterpart of `ceilingNote` above — an org row is
-   *  only ever shown here in act mode (see `policyDecideFieldset`'s
-   *  condition below), so this never needs its own collapsed form. */
-  const grantOnlyNote = orgOwnedKeysReadOnly && (
-    <p className="text-xs text-muted-foreground" data-testid="ai-agent-supervised-keys-grant-only-hint">
-      {t('aiAgentsPage.graduation.grantOnlyHint')}
-    </p>
-  );
-  const policyDecideFieldset = (draft.mode === 'act' || draft.ownerScope === 'partner') && (
-    <fieldset className="space-y-2 rounded-md border p-3 md:col-span-2" data-testid="ai-agent-policy-decide">
-      <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">
-        {t('aiAgentsPage.sections.policyDecide')}
-      </legend>
-      <p className="text-xs text-muted-foreground">{t('aiAgentsPage.fields.supervisedActionKeysHint')}</p>
-      {isCollapsedForCeiling ? (
-        <details data-testid="ai-agent-policy-keys-details">
-          <summary className="cursor-pointer text-xs font-medium">
-            {t('aiAgentsPage.fields.supervisedActionKeysCeilingSummary', {
-              count: draft.supervisedActionKeys.length,
-            })}
-          </summary>
-          <div className="mt-1 space-y-2">
-            {ceilingNote}
-            {policyKeysBody}
-          </div>
-        </details>
-      ) : (
-        <>
-          {ceilingNote}
-          {grantOnlyNote}
-          {policyKeysBody}
-        </>
-      )}
-    </fieldset>
-  );
+  // The row's own scriptIds, narrowed by the partner ceiling the way
+  // effectivePolicy.ts computes the effective list (partner ∩ org) — a
+  // script only the org row lists is never dispatched unattended.
+  const authorizedScriptCount = (agent.actAssets?.scriptIds ?? []).filter((id) => !ceiling || ceiling.scriptIds.includes(id)).length;
 
   return (
     <div className="flex min-h-0 flex-1 flex-col" data-testid="ai-agent-editor">
@@ -629,183 +490,30 @@ export default function AiAgentForm({
             isPartnerScope={isPartnerScope}
           />
 
-          <fieldset className="space-y-2 rounded-md border p-3 md:col-span-2">
-            <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">
-              {t('aiAgentsPage.sections.scope')}
-            </legend>
-            {/* Hidden — never just left unread — for a kind whose runs can
-                never carry a severity (see ALERT_SEVERITY_KINDS's docstring):
-                runService only evaluates `triggers.alertSeverities` when the
-                admission input carries an `alertContext`, which only a
-                triage-kind run ever does. Offering the control for helpdesk
-                or patch asked the operator to make a choice that could never
-                take effect. */}
-            {usesAlertSeverities && (
-              <div className="flex flex-wrap gap-3">
-                {ALERT_SEVERITIES.map((severity) => (
-                  <label key={severity} className="flex items-center gap-1 text-sm">
-                    <input
-                      type="checkbox"
-                      checked={draft.severities.includes(severity)}
-                      onChange={() => patch({ severities: toggle(draft.severities, severity) })}
-                      data-testid={`ai-agent-severity-${severity}`}
-                    />
-                    {t(/* i18n-dynamic */ `aiAgentsPage.severities.${severity}`)}
-                  </label>
-                ))}
-              </div>
-            )}
-            <label className="flex items-center gap-2 text-sm">
-              <input
-                type="checkbox"
-                checked={draft.respectMaintenanceWindows}
-                onChange={(e) => patch({ respectMaintenanceWindows: e.target.checked })}
-                data-testid="ai-agent-respect-maintenance"
-              />
-              {t('aiAgentsPage.fields.respectMaintenanceWindows')}
-            </label>
-
-            {/* P2-4 (#4191) review fix — ticket-triggered runs are admitted
-                with `kind: 'helpdesk'` (ticketHelpdeskSubscriber.ts's
-                `admitTriageRun`: `createAndEnqueueAgentRun({ kind: 'helpdesk',
-                triggerKind: 'ticket', profile: 'triage', ... })`), and
-                runService.ts's `resolveEffectiveAgentSystem(orgId, kind)`
-                resolves the effective policy off THAT `kind` field — never
-                `triage`, which is a different agent kind entirely (the
-                scheduled-sweeps gate a few lines below IS genuinely
-                triage-only; do not copy this gate from that one again).
-                Disabled — never hidden — on a partner-wide row: the merge
-                reads ONLY the org's own override (effectivePolicy.ts), so a
-                partner baseline value can never take effect; hiding it
-                outright would look like the field vanished rather than
-                explain why it cannot be set here. */}
-            {draft.kind === 'helpdesk' && (
-              <div className="space-y-1">
-                <label className="flex items-center gap-2 text-sm">
-                  <input
-                    type="checkbox"
-                    checked={draft.ticketAutonomousWrites}
-                    disabled={draft.ownerScope !== 'organization'}
-                    onChange={(e) => patch({ ticketAutonomousWrites: e.target.checked })}
-                    data-testid="ai-agent-ticket-autonomous-writes"
-                  />
-                  {t('aiAgentsPage.fields.ticketAutonomousWrites')}
-                </label>
-                <p className="pl-6 text-xs text-muted-foreground">
-                  {t('aiAgentsPage.fields.ticketAutonomousWritesHint')}
-                </p>
-              </div>
-            )}
-          </fieldset>
-
-          {/* Permissions carries the widest blast radius of the remaining
-              sections, so it gets a real heading rather than one more 12px
-              uppercase legend of the same weight as "Limits". A <section> and
-              not a <fieldset>: <legend>'s content model is phrasing content, so
-              an <h3> cannot live inside one. */}
-          <section
-            className="space-y-2 rounded-md border p-3 md:col-span-2"
-            aria-labelledby={permissionsHeadingId}
-            data-testid="ai-agent-permissions"
-          >
-            <div>
-              <h3 id={permissionsHeadingId} className="text-sm font-semibold">
-                {t('aiAgentsPage.sections.permissions')}
-              </h3>
-              <p className="mt-0.5 text-xs text-muted-foreground">
-                {t('aiAgentsPage.sections.permissionsDescription')}
-              </p>
-            </div>
-            {/* Task 10 (#5050): the free-text tool-allowlist textarea and its
-                autocomplete datalist are replaced by the server-backed
-                capability picker (spec §4.5) — it lists only tools this
-                agent can actually reach, grouped by capability, with
-                per-operation outcome and ceiling badges. `entries`/`onChange`
-                round-trip through the SAME newline-string draft field the
-                textarea used, so the save body at `policy.toolAllowlist`
-                above is untouched.
-                The picker's own catalog+ceiling fetch (`useAgentToolCatalog`)
-                never blocks this form: while the fetch is still in flight, a
-                muted loading line replaces the picker rather than flashing
-                the textarea fallback first — the fallback is reserved for an
-                actual failure (or an unusable shape), not the normal time it
-                takes the catalog to arrive. */}
-            {catalog ? (
-              <CapabilityPicker
-                catalog={catalog}
-                ceiling={ceiling}
-                kind={draft.kind}
-                mode={draft.mode}
-                entries={lines(draft.toolAllowlist)}
-                onChange={(next) => patch({ toolAllowlist: next.join('\n') })}
-                // The row's own scriptIds, narrowed by the partner ceiling the way
-                // effectivePolicy.ts computes the effective list (partner ∩ org) —
-                // a script only the org row lists is never dispatched unattended.
-                authorizedScriptCount={
-                  (agent.actAssets?.scriptIds ?? []).filter((id) => !ceiling || ceiling.scriptIds.includes(id)).length
-                }
-              />
-            ) : catalogLoading ? (
-              <p className="text-xs text-muted-foreground" data-testid="ai-agent-catalog-loading">
-                {t('aiAgentsPage.catalog.loading')}
-              </p>
-            ) : (
-              <>
-                <p className="text-xs text-muted-foreground" data-testid="ai-agent-catalog-unavailable">
-                  {t('aiAgentsPage.catalog.catalogUnavailable')}
-                </p>
-                <p className="text-xs text-muted-foreground">{t('aiAgentsPage.fields.toolAllowlistHint')}</p>
-                {listField('ai-agent-toolallowlist', t('aiAgentsPage.fields.toolAllowlist'), draft.toolAllowlist, (v) => patch({ toolAllowlist: v }), 4)}
-              </>
-            )}
-            <p className="text-xs text-muted-foreground">{t('aiAgentsPage.fields.protectedHint')}</p>
-            <div className="grid gap-3 md:grid-cols-3">
-              {listField('ai-agent-services', t('aiAgentsPage.fields.protectedServices'), draft.services, (v) => patch({ services: v }), 2)}
-              {listField('ai-agent-paths', t('aiAgentsPage.fields.protectedPaths'), draft.paths, (v) => patch({ paths: v }), 2)}
-              {listField('ai-agent-registrykeys', t('aiAgentsPage.fields.protectedRegistryKeys'), draft.registryKeys, (v) => patch({ registryKeys: v }), 2)}
-            </div>
-          </section>
-
-          {policyDecideFieldset}
-
-          {/* Six unlabelled number inputs in one 3-column grid read as one
-              undifferentiated wall. Split into the two questions they actually
-              answer — how much may it spend and reach, and how long may it take
-              — with every control and every test id unchanged. */}
-          <fieldset className="space-y-3 rounded-md border p-3 md:col-span-2">
-            <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">
-              {t('aiAgentsPage.sections.limits')}
-            </legend>
-            <div role="group" aria-labelledby={limitsBudgetId} className="space-y-1.5">
-              <p id={limitsBudgetId} className="text-xs font-medium">
-                {t('aiAgentsPage.sections.limitsBudget')}
-              </p>
-              <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-                {numberField('ai-agent-limit-devices', t('aiAgentsPage.fields.maxDevicesPerRun'), draft.limits.maxDevicesPerRun, 1, 50, (v) => patch({ limits: { ...draft.limits, maxDevicesPerRun: v } }))}
-                {numberField('ai-agent-limit-runs', t('aiAgentsPage.fields.maxRunsPerHour'), draft.limits.maxRunsPerHour, 1, 500, (v) => patch({ limits: { ...draft.limits, maxRunsPerHour: v } }))}
-                {numberField('ai-agent-limit-budget', t('aiAgentsPage.fields.maxBudgetCentsPerDay'), draft.limits.maxBudgetCentsPerDay, 1, 100000, (v) => patch({ limits: { ...draft.limits, maxBudgetCentsPerDay: v } }))}
-                {numberField('ai-agent-limit-fleet', t('aiAgentsPage.fields.maxFleetPercentPerDay'), draft.limits.maxFleetPercentPerDay, 1, 100, (v) => patch({ limits: { ...draft.limits, maxFleetPercentPerDay: v } }))}
-              </div>
-            </div>
-            <div role="group" aria-labelledby={limitsTimingId} className="space-y-1.5">
-              <p id={limitsTimingId} className="text-xs font-medium">
-                {t('aiAgentsPage.sections.limitsTiming')}
-              </p>
-              <div className="grid gap-3 sm:grid-cols-2">
-                {numberField('ai-agent-limit-wallclock', t('aiAgentsPage.fields.wallClockSeconds'), draft.limits.wallClockSeconds, 30, 1800, (v) => patch({ limits: { ...draft.limits, wallClockSeconds: v } }))}
-                {numberField('ai-agent-cooldown', t('aiAgentsPage.fields.cooldownSeconds'), draft.cooldownSeconds, 0, 86400, (v) => patch({ cooldownSeconds: v }))}
-              </div>
-            </div>
-          </fieldset>
-
-          <RecipientRolesFieldset
-            className="space-y-2 rounded-md border p-3 md:col-span-2"
-            t={t}
-            roles={roles}
-            rolesFailed={rolesFailed}
-            roleIds={draft.roleIds}
-            onToggleRole={(id) => patch({ roleIds: toggle(draft.roleIds, id) })}
-          />
+          {/* #5063: the same step components the guided create flow renders —
+              "What it does" (runs-when + capability picker) and "Safety and
+              oversight" (protected resources, unattended authorization,
+              limits, recipients). See the note above `authorizedScriptCount`. */}
+          <div className="md:col-span-2">
+            <WhatItDoesStep
+              draft={draft}
+              patch={patch}
+              catalog={catalog}
+              ceiling={ceiling}
+              catalogLoading={catalogLoading}
+              authorizedScriptCount={authorizedScriptCount}
+            />
+          </div>
+          <div className="md:col-span-2">
+            <SafetyStep
+              draft={draft}
+              patch={patch}
+              roles={roles}
+              rolesFailed={rolesFailed}
+              policyKeys={policyKeys}
+              policyKeysFailed={policyKeysFailed}
+            />
+          </div>
 
           {/* Scheduled sweeps (P2-2, #4189). Triage-only, because the API
               refuses every other kind (`agent_kind_not_triage`). Gated on the

--- a/apps/web/src/components/settings/AiAgentForm.tsx
+++ b/apps/web/src/components/settings/AiAgentForm.tsx
@@ -23,8 +23,7 @@ import AiAgentSchedulesSection from './AiAgentSchedulesSection';
 import AiAgentGraduationPanel from './AiAgentGraduationPanel';
 import { useAgentToolCatalog } from './aiAgents/useAgentToolCatalog';
 import ModeChoice from './aiAgents/ModeChoice';
-import type { PolicyDecidableKeyOption } from './aiAgents/PolicyKeysCheckboxes';
-import type { RoleOption } from './aiAgents/agentFields';
+import { useAgentFormLists } from './aiAgents/useAgentFormLists';
 import { AGENT_ERROR_COPY, agentSaveIssuesFromError } from './aiAgents/agentErrors';
 import WhatItDoesStep from './aiAgents/steps/WhatItDoesStep';
 import SafetyStep from './aiAgents/steps/SafetyStep';
@@ -101,10 +100,10 @@ export default function AiAgentForm({
   const [actAck, setActAck] = useState(false);
   const enteringActMode = draft.mode === 'act' && initialMode !== 'act';
 
-  const [roles, setRoles] = useState<RoleOption[]>([]);
-  const [rolesFailed, setRolesFailed] = useState(false);
-  const [policyKeys, setPolicyKeys] = useState<PolicyDecidableKeyOption[]>([]);
-  const [policyKeysFailed, setPolicyKeysFailed] = useState(false);
+  // Recipient roles + the policy-decidable registry — one hook, shared with
+  // the guided create flow (#5063 review), so the two forms cannot drift on
+  // how a failed fetch is told apart from a genuinely empty list.
+  const { roles, rolesFailed, policyKeys, policyKeysFailed } = useAgentFormLists();
   const [issues, setIssues] = useState<string[]>([]);
   const [saving, setSaving] = useState(false);
   const [confirmDisable, setConfirmDisable] = useState(false);
@@ -166,75 +165,13 @@ export default function AiAgentForm({
   // ---- Mode: the privileged choice --------------------------------------
   const actSupported = agent.supportedModes.includes('act');
 
-  // Recipients are role IDs, never role names: `roles` is a tenant-scoped table
-  // with partner-defined names, so the picker has to show the real rows.
-  //
-  // A failure here must NOT render as "no roles exist". This page is gated on
-  // organizations:read but GET /roles is gated on users:read, so a technician
-  // holding the former and not the latter gets a 403 — and telling them their
-  // tenant has no roles would turn an authorization error into a configuration
-  // decision they never made, saving an agent that notifies nobody.
-  useEffect(() => {
-    let cancelled = false;
-    void (async () => {
-      try {
-        const response = await fetchWithAuth('/roles');
-        if (!response.ok) throw new Error(`GET /roles ${response.status}`);
-        const body = (await response.json()) as { data?: RoleOption[] };
-        if (!cancelled) setRoles(Array.isArray(body.data) ? body.data : []);
-      } catch (err) {
-        console.error('[AiAgentForm] could not load roles', err);
-        if (!cancelled) setRolesFailed(true);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  // The POLICY_DECIDABLE_TIER3 registry (wave 5 Part B, #3827) — a static,
-  // read-only list, so no dependency on mode/agent; fetched once per mount
-  // exactly like roles above, and rendered only inside the act-mode section
-  // below. A failure must say so rather than rendering an empty registry,
-  // same "authorization/outage vs. genuinely empty" distinction the roles
-  // fetch above draws (this route needs only ai_agents:read, which this page
-  // is already gated on, so a 403 here is unexpected — but the failure state
-  // still must not lie and claim the registry is empty).
-  useEffect(() => {
-    let cancelled = false;
-    void (async () => {
-      try {
-        const response = await fetchWithAuth('/ai/agents/policy-decidable-keys');
-        if (!response.ok) throw new Error(`GET /ai/agents/policy-decidable-keys ${response.status}`);
-        const body = (await response.json()) as { data?: PolicyDecidableKeyOption[] };
-        // Defensive, not just a type assertion: `key`/`toolName` drive both
-        // the DOM id splice (`idSafe`) and the translated-label fallback
-        // (`sentenceCase`), and this registry is server-owned — a shape drift
-        // must degrade to "skip the row", never crash the whole form.
-        const rows = Array.isArray(body.data)
-          ? body.data.filter(
-              (row): row is PolicyDecidableKeyOption =>
-                typeof row?.key === 'string' && typeof row?.toolName === 'string',
-            )
-          : [];
-        if (!cancelled) setPolicyKeys(rows);
-      } catch (err) {
-        console.error('[AiAgentForm] could not load policy-decidable keys', err);
-        if (!cancelled) setPolicyKeysFailed(true);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
   // Task 10 (#5050): the capability picker replaces the free-text tool
   // allowlist textarea. `catalog` is fetched once per mount; `ceiling`
   // re-fetches whenever kind or ownerScope changes (only meaningful for an
   // organization-owned draft — see the hook's own doc). Neither fetch ever
   // blocks this form: a failed/absent catalog falls back to the old
   // textarea below (see the Permissions section).
-  const { catalog: fetchedCatalog, ceiling, loading: catalogLoading } = useAgentToolCatalog({
+  const { catalog: fetchedCatalog, ceiling, ceilingResolved, loading: catalogLoading } = useAgentToolCatalog({
     kind: draft.kind,
     ownerScope: draft.ownerScope,
   });
@@ -367,19 +304,16 @@ export default function AiAgentForm({
     />
   );
 
-  /**
-   * #5063: everything from "When it runs" through recipients is rendered by
-   * the guided create flow's own step components (`WhatItDoesStep`,
-   * `SafetyStep`) so each setting has exactly one rendering and one test
-   * surface. The org-row read-only registry and the partner-ceiling collapse
-   * (#5049, P2-5) live in `SafetyStep` now. Only the edit-only pieces stay
-   * here: the fixed kind, the enabled switch, graduation, schedules and the
-   * Save/Cancel/Disable footer.
-   */
   // The row's own scriptIds, narrowed by the partner ceiling the way
   // effectivePolicy.ts computes the effective list (partner ∩ org) — a
-  // script only the org row lists is never dispatched unattended.
-  const authorizedScriptCount = (agent.actAssets?.scriptIds ?? []).filter((id) => !ceiling || ceiling.scriptIds.includes(id)).length;
+  // script only the org row lists is never dispatched unattended. Until an
+  // org row's ceiling has actually resolved, nothing counts as authorized:
+  // `ceiling === null` would otherwise read as "no ceiling" while the fetch
+  // is still in flight (or failed) and badge run_script as unattended
+  // (#5063 review).
+  const authorizedScriptCount = !ceilingResolved
+    ? 0
+    : (agent.actAssets?.scriptIds ?? []).filter((id) => !ceiling || ceiling.scriptIds.includes(id)).length;
 
   return (
     <div className="flex min-h-0 flex-1 flex-col" data-testid="ai-agent-editor">
@@ -490,10 +424,16 @@ export default function AiAgentForm({
             isPartnerScope={isPartnerScope}
           />
 
-          {/* #5063: the same step components the guided create flow renders —
-              "What it does" (runs-when + capability picker) and "Safety and
-              oversight" (protected resources, unattended authorization,
-              limits, recipients). See the note above `authorizedScriptCount`. */}
+          {/* #5063: everything from "When it runs" through recipients is the
+              guided create flow's own step components — "What it does"
+              (runs-when + capability picker) and "Safety and oversight"
+              (protected resources, unattended authorization, limits,
+              recipients) — so each of those settings has exactly one
+              rendering and one test surface; the org-row read-only registry
+              and the partner-ceiling collapse (#5049, P2-5) live in
+              SafetyStep. What stays the drawer's own: the mode choice, the
+              fixed kind, Name, the enabled switch, graduation, schedules,
+              Instructions and the Save/Cancel/Disable footer. */}
           <div className="md:col-span-2">
             <WhatItDoesStep
               draft={draft}
@@ -508,6 +448,7 @@ export default function AiAgentForm({
             <SafetyStep
               draft={draft}
               patch={patch}
+              editing
               roles={roles}
               rolesFailed={rolesFailed}
               policyKeys={policyKeys}

--- a/apps/web/src/components/settings/aiAgents/AgentCreateFlow.test.tsx
+++ b/apps/web/src/components/settings/aiAgents/AgentCreateFlow.test.tsx
@@ -477,6 +477,23 @@ describe('AgentCreateFlow — Safety step (moved from AiAgentsPage.test.tsx)', (
     expect(limits().maxDevicesPerRun).toBe(1);
   });
 
+  it('shows no unattended-authorization registry for an organization-owned act-mode CREATE draft — it holds no keys and the grant path lives in the drawer (#5063 review)', async () => {
+    orgState.current = { ...orgState.current, currentOrgId: 'org-1', allOrgs: false };
+    mockEndpoints({ registry: [{ key: 'manage_services:restart', toolName: 'manage_services', action: 'restart', note: '' }] });
+    renderFlow({ defaultOwnerScope: 'organization', partnerBaselineKinds: new Set(['triage']) });
+    expect(screen.getByTestId('ai-agent-owner-org')).toBeChecked();
+    fireEvent.change(screen.getByTestId('ai-agent-name'), { target: { value: 'Org act bot' } });
+    fireEvent.click(screen.getByTestId('ai-agent-mode-act'));
+    fireEvent.click(screen.getByTestId('ai-agent-act-ack'));
+    fireEvent.click(screen.getByTestId('agent-create-flow-next'));
+    await screen.findByTestId('ai-agent-permissions');
+    fireEvent.click(screen.getByTestId('agent-create-flow-next'));
+    await screen.findByTestId('ai-agent-limit-devices');
+
+    expect(screen.queryByTestId('ai-agent-policy-decide')).toBeNull();
+    expect(screen.queryByTestId('ai-agent-supervised-keys-grant-only-hint')).toBeNull();
+  });
+
   it('collapses a partner draft\'s supervised-key registry behind a summary while shadow/off, mirroring the drawer', async () => {
     mockEndpoints();
     renderFlow(); // defaultOwnerScope: 'partner', mode defaults to 'shadow'

--- a/apps/web/src/components/settings/aiAgents/AgentCreateFlow.tsx
+++ b/apps/web/src/components/settings/aiAgents/AgentCreateFlow.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { AI_AGENT_KINDS, SUPPORTED_AGENT_MODES, type AiAgentDto } from '@breeze/shared';
 import { fetchWithAuth } from '@/stores/auth';
@@ -9,12 +9,12 @@ import { useOrgScope } from '@/hooks/useOrgScope';
 import type { OwnerScope } from '@/hooks/useDefaultOwnerScope';
 import SetupStepper from '../../setup/SetupStepper';
 import { useAgentToolCatalog } from './useAgentToolCatalog';
+import { useAgentFormLists } from './useAgentFormLists';
 import { ALERT_SEVERITY_KINDS, buildAgentSaveBody, draftFrom, firstFreeKind, freeKinds, type Draft } from './agentDraft';
 import { AGENT_ERROR_COPY, agentSaveIssuesFromError } from './agentErrors';
-import type { PolicyDecidableKeyOption } from './PolicyKeysCheckboxes';
 import PurposeStep from './steps/PurposeStep';
 import WhatItDoesStep from './steps/WhatItDoesStep';
-import SafetyStep, { type RoleOption } from './steps/SafetyStep';
+import SafetyStep from './steps/SafetyStep';
 import ReviewStep from './steps/ReviewStep';
 
 export interface AgentCreateFlowProps {
@@ -107,56 +107,10 @@ export default function AgentCreateFlow({
   });
   const catalog = fetchedCatalog && Array.isArray(fetchedCatalog.tools) && fetchedCatalog.presets ? fetchedCatalog : null;
 
-  // Same cancelled-flag fetch pattern as AiAgentForm.tsx's own roles effect —
-  // a failure must not render as "no roles configured" (see that file's doc).
-  const [roles, setRoles] = useState<RoleOption[]>([]);
-  const [rolesFailed, setRolesFailed] = useState(false);
-  useEffect(() => {
-    let cancelled = false;
-    void (async () => {
-      try {
-        const response = await fetchWithAuth('/roles');
-        if (!response.ok) throw new Error(`GET /roles ${response.status}`);
-        const body = (await response.json()) as { data?: RoleOption[] };
-        if (!cancelled) setRoles(Array.isArray(body.data) ? body.data : []);
-      } catch (err) {
-        console.error('[AgentCreateFlow] could not load roles', err);
-        if (!cancelled) setRolesFailed(true);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  // Same cancelled-flag fetch pattern as AiAgentForm.tsx's own registry
-  // effect — fetched once per mount, rendered only for a partner draft
-  // (SafetyStep.tsx).
-  const [policyKeys, setPolicyKeys] = useState<PolicyDecidableKeyOption[]>([]);
-  const [policyKeysFailed, setPolicyKeysFailed] = useState(false);
-  useEffect(() => {
-    let cancelled = false;
-    void (async () => {
-      try {
-        const response = await fetchWithAuth('/ai/agents/policy-decidable-keys');
-        if (!response.ok) throw new Error(`GET /ai/agents/policy-decidable-keys ${response.status}`);
-        const body = (await response.json()) as { data?: PolicyDecidableKeyOption[] };
-        const rows = Array.isArray(body.data)
-          ? body.data.filter(
-              (row): row is PolicyDecidableKeyOption =>
-                typeof row?.key === 'string' && typeof row?.toolName === 'string',
-            )
-          : [];
-        if (!cancelled) setPolicyKeys(rows);
-      } catch (err) {
-        console.error('[AgentCreateFlow] could not load policy-decidable keys', err);
-        if (!cancelled) setPolicyKeysFailed(true);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+  // Recipient roles + the policy-decidable registry — one hook, shared with
+  // the edit drawer (#5063 review). SafetyStep renders the registry for a
+  // partner draft (as a ceiling) and, in act mode, an org draft's held keys.
+  const { roles, rolesFailed, policyKeys, policyKeysFailed } = useAgentFormLists();
 
   const stepLabel = (key: StepKey) => t(/* i18n-dynamic */ `aiAgentsPage.flow.steps.${key}.label`);
   const stepDescription = (key: StepKey) => t(/* i18n-dynamic */ `aiAgentsPage.flow.steps.${key}.description`);

--- a/apps/web/src/components/settings/aiAgents/PolicyKeysCheckboxes.tsx
+++ b/apps/web/src/components/settings/aiAgents/PolicyKeysCheckboxes.tsx
@@ -6,11 +6,11 @@ import type { AiAgentMode, AiAgentOwnerScope } from '@breeze/shared';
  * Task 13 (#5051): extracted from `AiAgentForm.tsx` (a pure move — every test
  * id and translation key is unchanged) so the guided create flow's
  * `SafetyStep` can render the identical interactive registry a partner draft
- * gets in the edit drawer. Org rows never render this component in either
- * caller: an org row's keys are grant-only (spec §4.4), so `AiAgentForm.tsx`
- * renders its own read-only held-keys list instead (`orgHeldKeysList`), and
- * the guided create flow shows nothing at all for an org draft (there is
- * nothing held yet to show).
+ * gets in the edit drawer. Since #5063 `SafetyStep` is the ONE renderer for
+ * both surfaces: a partner row gets this interactive registry; an org row's
+ * keys are grant-only (spec §4.4), so in act mode SafetyStep renders a
+ * read-only list of the keys the row already holds instead, and outside act
+ * mode nothing at all.
  */
 
 /** GET /ai/agents/policy-decidable-keys — the read-only POLICY_DECIDABLE_TIER3
@@ -60,8 +60,8 @@ function groupByTool(entries: PolicyDecidableKeyOption[]): Map<string, PolicyDec
 
 /** Minimal shape of react-i18next's `t` this module needs — kept local so
  *  `policyToolLabel`/`policyActionLabel` stay usable from a plain function
- *  (AiAgentForm.tsx's `orgHeldKeysList`) without importing react-i18next's
- *  own generic `TFunction` type. */
+ *  (SafetyStep.tsx's read-only held-keys list) without importing
+ *  react-i18next's own generic `TFunction` type. */
 type TranslateFn = (key: string, options?: Record<string, unknown>) => string;
 
 /** Registry tool -> translated group heading, falling back to the
@@ -100,10 +100,9 @@ export function policyActionLabel(t: TranslateFn, entry: PolicyDecidableKeyOptio
  * caveat still prints beneath it as a fact that survives the mode, not as
  * something act mode makes disappear.
  *
- * Shared between `AiAgentForm.tsx` (the edit drawer) and `SafetyStep.tsx`
- * (the guided create flow's Safety step, partner drafts only) so the two
- * surfaces can never disagree on when a partner row's registry is worth
- * collapsing.
+ * Read by `SafetyStep.tsx`, which renders the registry for BOTH the edit
+ * drawer and the guided create flow (#5063), so the two surfaces can never
+ * disagree on when a partner row's registry is worth collapsing.
  */
 export function collapsedForCeiling(ownerScope: AiAgentOwnerScope, mode: AiAgentMode): boolean {
   return ownerScope === 'partner' && mode !== 'act';

--- a/apps/web/src/components/settings/aiAgents/agentFields.tsx
+++ b/apps/web/src/components/settings/aiAgents/agentFields.tsx
@@ -1,12 +1,12 @@
 import { useId } from 'react';
 
 /**
- * Task 13 (#5051 review) — field helpers shared by `AiAgentForm.tsx` (the
- * edit drawer) and the guided create flow's steps (`SafetyStep.tsx`), so the
- * two surfaces render and validate identically rather than drifting through
- * two hand-maintained copies. A pure move for `listField`/the role fieldset;
- * `numberField` also fixes a real bug in both original copies (see its own
- * doc below).
+ * Task 13 (#5051 review) — field helpers for the agent forms. Since #5063
+ * the edit drawer renders the guided create flow's own step components, so
+ * the callers are `SafetyStep.tsx` (list/number fields, the role fieldset)
+ * and `WhatItDoesStep.tsx` (the catalog-unavailable allowlist fallback).
+ * A pure move for `listField`/the role fieldset; `numberField` also fixed a
+ * real bug in both original copies (see its own doc below).
  */
 
 const inputCls = 'w-full rounded-md border bg-background px-2.5 py-1.5 text-sm';
@@ -105,9 +105,8 @@ function roleScope(role: RoleOption): 'partner' | 'organization' {
 export const ROLE_GROUPS = ['partner', 'organization'] as const;
 
 export interface RecipientRolesFieldsetProps {
-  /** The two callers render this inside a different grid (the drawer's
-   *  two-column form vs. the guided flow's single-column step), so the
-   *  outer `<fieldset>`'s className is the caller's to choose. */
+  /** The outer `<fieldset>`'s className is the caller's to choose, so the
+   *  fieldset can sit in whichever grid its host lays out. */
   className: string;
   t: TranslateFn;
   roles: RoleOption[];

--- a/apps/web/src/components/settings/aiAgents/steps/SafetyStep.tsx
+++ b/apps/web/src/components/settings/aiAgents/steps/SafetyStep.tsx
@@ -1,8 +1,13 @@
-import { useId } from 'react';
+import { useId, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import PolicyKeysCheckboxes, { collapsedForCeiling, type PolicyDecidableKeyOption } from '../PolicyKeysCheckboxes';
+import PolicyKeysCheckboxes, {
+  collapsedForCeiling,
+  policyActionLabel,
+  sentenceCase,
+  type PolicyDecidableKeyOption,
+} from '../PolicyKeysCheckboxes';
 import { listField, numberField, RecipientRolesFieldset, type RoleOption } from '../agentFields';
-import { lines, toggle, type Draft } from '../agentDraft';
+import { toggle, type Draft } from '../agentDraft';
 
 // Re-exported so `AgentCreateFlow.tsx`'s `import { type RoleOption } from
 // './steps/SafetyStep'` keeps resolving — `RoleOption` itself now lives in
@@ -20,21 +25,59 @@ export interface SafetyStepProps {
 }
 
 /**
- * Step 3 of the guided create flow (spec §4.6): protected resources, the six
- * exposed limits, recipient roles and — for a PARTNER draft only — the
- * unattended-ceiling registry (`PolicyKeysCheckboxes`, extracted from
- * `AiAgentForm.tsx`). An ORG draft shows nothing here: a brand-new org row
- * holds no keys yet, and a key can only go live later through the four-eyes
- * grant executor (spec §4.4) — there is nothing to review or edit at create
- * time.
+ * "Safety and oversight" — step 3 of the guided create flow (spec §4.6) AND
+ * the same block of the edit drawer (`AiAgentForm.tsx`, #5063): protected
+ * resources, the six exposed limits, recipient roles and the unattended
+ * policy authorization registry. One rendering per setting, so the two
+ * surfaces cannot drift.
+ *
+ * The registry has three shapes, all driven by the draft alone:
+ * - PARTNER row: the interactive checkbox registry — a partner row's keys are
+ *   a CEILING on what its organizations may be granted (P2-5, #4192), so it
+ *   is offered regardless of the row's own mode, collapsed behind a summary
+ *   while the row is not acting (`collapsedForCeiling`).
+ * - ORG row in act mode: a read-only list of the keys the row already holds.
+ *   #5049: the API refuses any org-row write that ADDS a key — a key goes live
+ *   on an org row only through the four-eyes grant executor — so a checkbox
+ *   here could never be honored by Save, and the rest of the registry
+ *   (never held) is noise, not information. A brand-new org draft holds none.
+ * - ORG row not in act mode: nothing — the "act acknowledgement pattern":
+ *   additional unattended authority is only shown once the operator is
+ *   already looking at the act-mode warning.
  */
 export default function SafetyStep({ draft, patch, roles, rolesFailed, policyKeys, policyKeysFailed }: SafetyStepProps) {
   const { t } = useTranslation('settings');
   const limitsBudgetId = useId();
   const limitsTimingId = useId();
 
-  // The registry rendering, shared with everything the collapsed/uncollapsed
-  // branches below both need.
+  const orgOwned = draft.ownerScope === 'organization';
+  const showPolicyDecide = draft.mode === 'act' || draft.ownerScope === 'partner';
+
+  /** Registry entries keyed by their `key`, so an org row's read-only list
+   *  can translate its currently-held keys without walking the full
+   *  registry-grouped-by-tool structure the checkboxes build. */
+  const policyKeysByKey = useMemo(
+    () => new Map(policyKeys.map((entry) => [entry.key, entry] as const)),
+    [policyKeys],
+  );
+
+  const orgHeldKeysList = draft.supervisedActionKeys.length === 0 ? (
+    <p className="text-sm text-muted-foreground" data-testid="ai-agent-policy-keys-empty">
+      {t('aiAgentsPage.fields.supervisedActionKeysNoneHeld')}
+    </p>
+  ) : (
+    <ul className="list-disc space-y-1 pl-5 text-sm" data-testid="ai-agent-supervised-keys-readonly-list">
+      {draft.supervisedActionKeys.map((key) => {
+        const entry = policyKeysByKey.get(key);
+        return (
+          <li key={key} data-testid={`ai-agent-supervised-key-${key}`}>
+            {entry ? policyActionLabel(t, entry) : sentenceCase(key)}
+          </li>
+        );
+      })}
+    </ul>
+  );
+
   const policyKeysCheckboxes = (
     <PolicyKeysCheckboxes
       policyKeys={policyKeys}
@@ -43,14 +86,21 @@ export default function SafetyStep({ draft, patch, roles, rolesFailed, policyKey
       onToggle={(key) => patch({ supervisedActionKeys: toggle(draft.supervisedActionKeys, key) })}
     />
   );
-  const ceilingHint = (
+  const policyKeysBody = orgOwned ? orgHeldKeysList : policyKeysCheckboxes;
+
+  const ceilingHint = draft.ownerScope === 'partner' && (
     <p className="text-xs text-muted-foreground" data-testid="ai-agent-supervised-keys-ceiling-hint">
       {t('aiAgentsPage.graduation.ceilingHint')}
     </p>
   );
+  const grantOnlyHint = orgOwned && (
+    <p className="text-xs text-muted-foreground" data-testid="ai-agent-supervised-keys-grant-only-hint">
+      {t('aiAgentsPage.graduation.grantOnlyHint')}
+    </p>
+  );
 
   return (
-    <div className="space-y-3">
+    <div className="space-y-3" data-testid="agent-step-safety">
       <fieldset className="space-y-2 rounded-md border p-3">
         <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">
           {t('aiAgentsPage.flow.protectedResourcesLegend')}
@@ -63,18 +113,16 @@ export default function SafetyStep({ draft, patch, roles, rolesFailed, policyKey
         </div>
       </fieldset>
 
-      {draft.ownerScope === 'partner' && (
+      {showPolicyDecide && (
         <fieldset className="space-y-2 rounded-md border p-3" data-testid="ai-agent-policy-decide">
           <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">
             {t('aiAgentsPage.sections.policyDecide')}
           </legend>
           <p className="text-xs text-muted-foreground">{t('aiAgentsPage.fields.supervisedActionKeysHint')}</p>
-          {/* Same collapse rule as the edit drawer (`AiAgentForm.tsx`'s
-              `policyDecideFieldset`, via the shared `collapsedForCeiling`
-              helper): a shadow/off partner draft's registry starts collapsed
-              behind a summary that counts the selection, since ticking a key
-              here authorizes nothing on its own until the row is acting.
-              Entering act mode unwraps it entirely. */}
+          {/* A shadow/off partner row's registry starts collapsed behind a
+              summary that counts the selection, since ticking a key here
+              authorizes nothing on its own until an organization's row is
+              acting. Entering act mode unwraps it entirely. */}
           {collapsedForCeiling(draft.ownerScope, draft.mode) ? (
             <details data-testid="ai-agent-policy-keys-details">
               <summary className="cursor-pointer text-xs font-medium">
@@ -84,13 +132,14 @@ export default function SafetyStep({ draft, patch, roles, rolesFailed, policyKey
               </summary>
               <div className="mt-1 space-y-2">
                 {ceilingHint}
-                {policyKeysCheckboxes}
+                {policyKeysBody}
               </div>
             </details>
           ) : (
             <>
               {ceilingHint}
-              {policyKeysCheckboxes}
+              {grantOnlyHint}
+              {policyKeysBody}
             </>
           )}
         </fieldset>

--- a/apps/web/src/components/settings/aiAgents/steps/SafetyStep.tsx
+++ b/apps/web/src/components/settings/aiAgents/steps/SafetyStep.tsx
@@ -22,6 +22,11 @@ export interface SafetyStepProps {
   rolesFailed: boolean;
   policyKeys: PolicyDecidableKeyOption[];
   policyKeysFailed: boolean;
+  /** Rendered inside the edit drawer (an existing row) rather than the
+   *  guided create flow. An org row's read-only held-keys list is only
+   *  meaningful there: a brand-new org draft holds no keys and the grant path
+   *  it points at (the Graduation panel) is mounted by the drawer alone. */
+  editing?: boolean;
 }
 
 /**
@@ -36,22 +41,36 @@ export interface SafetyStepProps {
  *   a CEILING on what its organizations may be granted (P2-5, #4192), so it
  *   is offered regardless of the row's own mode, collapsed behind a summary
  *   while the row is not acting (`collapsedForCeiling`).
- * - ORG row in act mode: a read-only list of the keys the row already holds.
- *   #5049: the API refuses any org-row write that ADDS a key — a key goes live
- *   on an org row only through the four-eyes grant executor — so a checkbox
- *   here could never be honored by Save, and the rest of the registry
- *   (never held) is noise, not information. A brand-new org draft holds none.
+ * - ORG row in act mode, EDITING an existing row (or a draft that somehow
+ *   holds keys): a read-only list of the keys the row already holds. #5049:
+ *   the API refuses any org-row write that ADDS a key — a key goes live on an
+ *   org row only through the four-eyes grant executor — so a checkbox here
+ *   could never be honored by Save, and the rest of the registry (never
+ *   held) is noise, not information.
+ * - ORG row in act mode on a brand-new create draft: nothing — it holds no
+ *   keys, and the grant path the read-only list points at (the Graduation
+ *   panel) is mounted by the drawer only (#5063 review).
  * - ORG row not in act mode: nothing — the "act acknowledgement pattern":
  *   additional unattended authority is only shown once the operator is
  *   already looking at the act-mode warning.
  */
-export default function SafetyStep({ draft, patch, roles, rolesFailed, policyKeys, policyKeysFailed }: SafetyStepProps) {
+export default function SafetyStep({
+  draft,
+  patch,
+  roles,
+  rolesFailed,
+  policyKeys,
+  policyKeysFailed,
+  editing = false,
+}: SafetyStepProps) {
   const { t } = useTranslation('settings');
   const limitsBudgetId = useId();
   const limitsTimingId = useId();
 
   const orgOwned = draft.ownerScope === 'organization';
-  const showPolicyDecide = draft.mode === 'act' || draft.ownerScope === 'partner';
+  const showPolicyDecide =
+    draft.ownerScope === 'partner'
+    || (draft.mode === 'act' && (editing || draft.supervisedActionKeys.length > 0));
 
   /** Registry entries keyed by their `key`, so an org row's read-only list
    *  can translate its currently-held keys without walking the full
@@ -132,7 +151,12 @@ export default function SafetyStep({ draft, patch, roles, rolesFailed, policyKey
               </summary>
               <div className="mt-1 space-y-2">
                 {ceilingHint}
-                {policyKeysBody}
+                {/* Only a PARTNER row ever collapses (`collapsedForCeiling`),
+                    so this is always the interactive registry — spelled out
+                    rather than routed through `policyKeysBody`, so a later
+                    widening of the collapse rule cannot silently tuck an org
+                    row's read-only list under the partner-ceiling summary. */}
+                {policyKeysCheckboxes}
               </div>
             </details>
           ) : (

--- a/apps/web/src/components/settings/aiAgents/steps/WhatItDoesStep.tsx
+++ b/apps/web/src/components/settings/aiAgents/steps/WhatItDoesStep.tsx
@@ -1,9 +1,9 @@
+import { useId } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ALERT_SEVERITIES, type AgentCeilingDto, type AgentToolCatalogDto } from '@breeze/shared';
 import CapabilityPicker from '../CapabilityPicker';
+import { listField } from '../agentFields';
 import { ALERT_SEVERITY_KINDS, lines, toggle, type Draft } from '../agentDraft';
-
-const inputCls = 'w-full rounded-md border bg-background px-2.5 py-1.5 text-sm';
 
 export interface WhatItDoesStepProps {
   draft: Draft;
@@ -34,6 +34,7 @@ export default function WhatItDoesStep({
   authorizedScriptCount = 0,
 }: WhatItDoesStepProps) {
   const { t } = useTranslation('settings');
+  const permissionsHeadingId = useId();
   const usesAlertSeverities = ALERT_SEVERITY_KINDS.has(draft.kind);
 
   return (
@@ -66,6 +67,19 @@ export default function WhatItDoesStep({
           />
           {t('aiAgentsPage.fields.respectMaintenanceWindows')}
         </label>
+        {/* P2-4 (#4191) review fix — ticket-triggered runs are admitted with
+            `kind: 'helpdesk'` (ticketHelpdeskSubscriber.ts's `admitTriageRun`:
+            `createAndEnqueueAgentRun({ kind: 'helpdesk', triggerKind:
+            'ticket', profile: 'triage', ... })`), and runService.ts's
+            `resolveEffectiveAgentSystem(orgId, kind)` resolves the effective
+            policy off THAT `kind` field — never `triage`, which is a different
+            agent kind entirely (the drawer's scheduled-sweeps gate IS
+            genuinely triage-only; do not copy this gate from that one again).
+            Disabled — never hidden — on a partner-wide row: the merge reads
+            ONLY the org's own override (effectivePolicy.ts), so a partner
+            baseline value can never take effect; hiding it outright would
+            look like the field vanished rather than explain why it cannot be
+            set here. */}
         {draft.kind === 'helpdesk' && (
           <div className="space-y-1">
             <label className="flex items-center gap-2 text-sm">
@@ -85,9 +99,19 @@ export default function WhatItDoesStep({
         )}
       </fieldset>
 
-      <section className="space-y-2 rounded-md border p-3" data-testid="ai-agent-permissions">
+      {/* Permissions carries the widest blast radius of the sections, so it
+          gets a real heading rather than one more 12px uppercase legend of
+          the same weight as "Limits". A <section> named by its <h3> — a
+          `region` landmark screen readers can jump to — and not a
+          <fieldset>: <legend>'s content model is phrasing content, so an
+          <h3> cannot live inside one. */}
+      <section
+        className="space-y-2 rounded-md border p-3"
+        aria-labelledby={permissionsHeadingId}
+        data-testid="ai-agent-permissions"
+      >
         <div>
-          <h3 className="text-sm font-semibold">{t('aiAgentsPage.sections.permissions')}</h3>
+          <h3 id={permissionsHeadingId} className="text-sm font-semibold">{t('aiAgentsPage.sections.permissions')}</h3>
           <p className="mt-0.5 text-xs text-muted-foreground">{t('aiAgentsPage.sections.permissionsDescription')}</p>
         </div>
         {catalog ? (
@@ -110,16 +134,7 @@ export default function WhatItDoesStep({
               {t('aiAgentsPage.catalog.catalogUnavailable')}
             </p>
             <p className="text-xs text-muted-foreground">{t('aiAgentsPage.fields.toolAllowlistHint')}</p>
-            <label className="space-y-1 text-sm">
-              <span className="font-medium">{t('aiAgentsPage.fields.toolAllowlist')}</span>
-              <textarea
-                className={`${inputCls} font-mono`}
-                rows={4}
-                value={draft.toolAllowlist}
-                onChange={(e) => patch({ toolAllowlist: e.target.value })}
-                data-testid="ai-agent-toolallowlist"
-              />
-            </label>
+            {listField('ai-agent-toolallowlist', t('aiAgentsPage.fields.toolAllowlist'), draft.toolAllowlist, (v) => patch({ toolAllowlist: v }), 4)}
           </>
         )}
       </section>

--- a/apps/web/src/components/settings/aiAgents/steps/WhatItDoesStep.tsx
+++ b/apps/web/src/components/settings/aiAgents/steps/WhatItDoesStep.tsx
@@ -11,21 +11,33 @@ export interface WhatItDoesStepProps {
   catalog: AgentToolCatalogDto | null;
   ceiling: AgentCeilingDto | null;
   catalogLoading: boolean;
+  /** Scripts the row is effectively authorized to run unattended
+   *  (`actAssets.scriptIds` ∩ the partner ceiling), for the picker's
+   *  `run_script` outcome. The create flow cannot authorize scripts, so it
+   *  leaves this at 0; the edit drawer passes the row's real count. */
+  authorizedScriptCount?: number;
 }
 
 /**
- * Step 2 of the guided create flow (spec §4.6): "Runs when" (severities for
- * triage, maintenance windows, helpdesk ticket writes) above the capability
- * picker — same order and test ids as `AiAgentForm.tsx`'s "When it runs"
- * fieldset and Permissions section, so an operator moving between the drawer
- * and the guided flow finds identical controls.
+ * "What it does" — step 2 of the guided create flow (spec §4.6) AND the same
+ * block of the edit drawer (`AiAgentForm.tsx`, #5063): "Runs when"
+ * (severities for triage, maintenance windows, helpdesk ticket writes) above
+ * the capability picker. One rendering per setting, so the two surfaces
+ * cannot drift.
  */
-export default function WhatItDoesStep({ draft, patch, catalog, ceiling, catalogLoading }: WhatItDoesStepProps) {
+export default function WhatItDoesStep({
+  draft,
+  patch,
+  catalog,
+  ceiling,
+  catalogLoading,
+  authorizedScriptCount = 0,
+}: WhatItDoesStepProps) {
   const { t } = useTranslation('settings');
   const usesAlertSeverities = ALERT_SEVERITY_KINDS.has(draft.kind);
 
   return (
-    <div className="space-y-3">
+    <div className="space-y-3" data-testid="agent-step-does">
       <fieldset className="space-y-2 rounded-md border p-3">
         <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">
           {t('aiAgentsPage.sections.scope')}
@@ -86,6 +98,7 @@ export default function WhatItDoesStep({ draft, patch, catalog, ceiling, catalog
             mode={draft.mode}
             entries={lines(draft.toolAllowlist)}
             onChange={(next) => patch({ toolAllowlist: next.join('\n') })}
+            authorizedScriptCount={authorizedScriptCount}
           />
         ) : catalogLoading ? (
           <p className="text-xs text-muted-foreground" data-testid="ai-agent-catalog-loading">

--- a/apps/web/src/components/settings/aiAgents/useAgentFormLists.ts
+++ b/apps/web/src/components/settings/aiAgents/useAgentFormLists.ts
@@ -1,0 +1,88 @@
+import { useEffect, useState } from 'react';
+import { fetchWithAuth } from '../../../stores/auth';
+import type { PolicyDecidableKeyOption } from './PolicyKeysCheckboxes';
+import type { RoleOption } from './agentFields';
+
+export interface UseAgentFormListsResult {
+  roles: RoleOption[];
+  /** GET /roles failed — render "could not load", never "no roles". */
+  rolesFailed: boolean;
+  policyKeys: PolicyDecidableKeyOption[];
+  /** GET /ai/agents/policy-decidable-keys failed — render "could not load", never an empty registry. */
+  policyKeysFailed: boolean;
+}
+
+/**
+ * The two static lists both agent forms feed into `SafetyStep` (#5063 review):
+ * recipient roles and the POLICY_DECIDABLE_TIER3 registry. Fetched once per
+ * mount; the edit drawer and the guided create flow used to carry a verbatim
+ * copy of each effect, so a fix to one silently missed the other.
+ *
+ * Roles: recipients are role IDs, never role names — `roles` is a
+ * tenant-scoped table with partner-defined names, so the picker has to show
+ * the real rows. A failure must NOT render as "no roles exist": the agents
+ * page is gated on organizations:read but GET /roles is gated on users:read,
+ * so a technician holding the former and not the latter gets a 403 — telling
+ * them their tenant has no roles would turn an authorization error into a
+ * configuration decision they never made, saving an agent that notifies
+ * nobody.
+ *
+ * Registry (wave 5 Part B, #3827): a static, read-only list, so no dependency
+ * on mode/agent. Defensive row filter, not just a type assertion: `key` /
+ * `toolName` drive both the DOM id splice and the translated-label fallback,
+ * and this registry is server-owned — a shape drift must degrade to "skip
+ * the row", never crash the whole form. This route needs only
+ * ai_agents:read, which the page is already gated on, so a 403 here is
+ * unexpected — but the failure state still must not claim the registry is
+ * empty.
+ */
+export function useAgentFormLists(): UseAgentFormListsResult {
+  const [roles, setRoles] = useState<RoleOption[]>([]);
+  const [rolesFailed, setRolesFailed] = useState(false);
+  const [policyKeys, setPolicyKeys] = useState<PolicyDecidableKeyOption[]>([]);
+  const [policyKeysFailed, setPolicyKeysFailed] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const response = await fetchWithAuth('/roles');
+        if (!response.ok) throw new Error(`GET /roles ${response.status}`);
+        const body = (await response.json()) as { data?: RoleOption[] };
+        if (!cancelled) setRoles(Array.isArray(body.data) ? body.data : []);
+      } catch (err) {
+        console.error('[useAgentFormLists] could not load roles', err);
+        if (!cancelled) setRolesFailed(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const response = await fetchWithAuth('/ai/agents/policy-decidable-keys');
+        if (!response.ok) throw new Error(`GET /ai/agents/policy-decidable-keys ${response.status}`);
+        const body = (await response.json()) as { data?: PolicyDecidableKeyOption[] };
+        const rows = Array.isArray(body.data)
+          ? body.data.filter(
+              (row): row is PolicyDecidableKeyOption =>
+                typeof row?.key === 'string' && typeof row?.toolName === 'string',
+            )
+          : [];
+        if (!cancelled) setPolicyKeys(rows);
+      } catch (err) {
+        console.error('[useAgentFormLists] could not load policy-decidable keys', err);
+        if (!cancelled) setPolicyKeysFailed(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { roles, rolesFailed, policyKeys, policyKeysFailed };
+}

--- a/apps/web/src/components/settings/aiAgents/useAgentToolCatalog.test.ts
+++ b/apps/web/src/components/settings/aiAgents/useAgentToolCatalog.test.ts
@@ -124,6 +124,28 @@ describe('useAgentToolCatalog', () => {
     expect(result.current.catalog).toEqual(CATALOG);
   });
 
+  it('reports ceilingResolved only once an org draft\'s ceiling fetch has settled, and immediately for a partner draft (#5063 review)', async () => {
+    let resolveCeiling: (value: Response) => void = () => {};
+    fetchMock.mockImplementation((url: string) => {
+      if (url === '/ai/agents/tool-catalog') return Promise.resolve(json({ data: CATALOG }));
+      if (url.startsWith('/ai/agents/ceiling')) return new Promise<Response>((resolve) => { resolveCeiling = resolve; });
+      return Promise.resolve(json({ data: null }));
+    });
+    const { result, rerender } = renderHook(
+      ({ ownerScope }: { ownerScope: 'organization' | 'partner' }) => useAgentToolCatalog({ kind: 'triage', ownerScope }),
+      { initialProps: { ownerScope: 'organization' as 'organization' | 'partner' } },
+    );
+    await waitFor(() => expect(result.current.catalog).not.toBeNull());
+    expect(result.current.ceilingResolved).toBe(false);
+    expect(result.current.ceiling).toBeNull();
+
+    resolveCeiling(json({ data: null }));
+    await waitFor(() => expect(result.current.ceilingResolved).toBe(true));
+
+    rerender({ ownerScope: 'partner' });
+    await waitFor(() => expect(result.current.ceilingResolved).toBe(true));
+  });
+
   it('reports loading false once the catalog fetch fails', async () => {
     fetchMock.mockImplementation((url: string) => {
       if (url === '/ai/agents/tool-catalog') return Promise.resolve(json({ error: 'boom' }, false, 500));

--- a/apps/web/src/components/settings/aiAgents/useAgentToolCatalog.ts
+++ b/apps/web/src/components/settings/aiAgents/useAgentToolCatalog.ts
@@ -13,6 +13,12 @@ export interface UseAgentToolCatalogResult {
   error: boolean;
   /** True while the catalog fetch is in flight — independent of the (secondary, org-only) ceiling fetch. */
   loading: boolean;
+  /** True once the ceiling question is settled: a partner draft (no ceiling
+   *  applies), or an org draft whose fetch has resolved — success OR failure.
+   *  While false, `ceiling === null` means "not known yet", not "no
+   *  baseline", and a caller must not treat the draft as unconstrained
+   *  (#5063 review: the drawer over-reported authorized scripts otherwise). */
+  ceilingResolved: boolean;
 }
 
 /**
@@ -33,6 +39,7 @@ export function useAgentToolCatalog({ kind, ownerScope }: UseAgentToolCatalogOpt
   const [catalogError, setCatalogError] = useState(false);
   const [ceiling, setCeiling] = useState<AgentCeilingDto | null>(null);
   const [ceilingError, setCeilingError] = useState(false);
+  const [ceilingSettled, setCeilingSettled] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -58,8 +65,10 @@ export function useAgentToolCatalog({ kind, ownerScope }: UseAgentToolCatalogOpt
     if (ownerScope !== 'organization') {
       setCeiling(null);
       setCeilingError(false);
+      setCeilingSettled(true);
       return;
     }
+    setCeilingSettled(false);
     let cancelled = false;
     void (async () => {
       try {
@@ -69,9 +78,13 @@ export function useAgentToolCatalog({ kind, ownerScope }: UseAgentToolCatalogOpt
         if (cancelled) return;
         setCeiling(body.data ?? null);
         setCeilingError(false);
+        setCeilingSettled(true);
       } catch (err) {
         console.error('[useAgentToolCatalog] could not load agent ceiling', err);
-        if (!cancelled) setCeilingError(true);
+        if (!cancelled) {
+          setCeilingError(true);
+          setCeilingSettled(true);
+        }
       }
     })();
     return () => {
@@ -79,5 +92,11 @@ export function useAgentToolCatalog({ kind, ownerScope }: UseAgentToolCatalogOpt
     };
   }, [kind, ownerScope]);
 
-  return { catalog, ceiling, error: catalogError || ceilingError, loading: catalog === null && !catalogError };
+  return {
+    catalog,
+    ceiling,
+    error: catalogError || ceilingError,
+    loading: catalog === null && !catalogError,
+    ceilingResolved: ceilingSettled,
+  };
 }

--- a/docs/release-notes/next-release-draft.md
+++ b/docs/release-notes/next-release-draft.md
@@ -12,4 +12,21 @@ Last release: **v0.110.0** (2026-09-05).
 
 ---
 
-_No entries yet for the next release._
+## AI agent builder (#5048 W01–W03, #5064, #5063)
+
+**Operator-facing (Added / Improved).**
+- Settings → AI agents → **New agent** is now a four-step guided flow: Purpose and posture (mode first, kind cards, owner scope) → What it does (triggers + capability picker) → Safety and oversight → Review and create. The review card is evaluated **server-side** (`POST /ai/agents/preview`) with the same guardrail and catalog helpers the run loop uses, so what it says is what enforcement does.
+- The tool allowlist textarea is replaced by a **capability picker**: 15 capabilities, per-operation outcome badges (Approval request / Logged proposal / Executes unattended), a "Recommended for <kind>" preset, search across labels and literal names, and an "Always on: read-only tools" disclosure. Organization agents see operations outside the partner baseline as **Not in partner baseline**.
+- Truthful act-mode outcomes: **Run a script** stays an approval request until a script is authorized for the agent (`actAssets.scriptIds`); the picker and the review card say so instead of promising an unattended run.
+- Recipient roles with no active members are marked in the form, and the act-mode "recipient" error now says the selected roles have no active members instead of "add a recipient".
+- The edit drawer renders the same step components as the create flow (one rendering per setting).
+
+**Self-Hosting / Upgrade Notes.**
+- No new env vars, no migrations. The whole feature is still behind `BREEZE_AI_AGENTS_ENABLED` (default `false`); `BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED` unchanged.
+- API additions, all additive: `GET /ai/agents/tool-catalog`, `GET /ai/agents/ceiling?kind=` (now also carries the baseline's `scriptIds`), `POST /ai/agents/preview`; `GET /roles` gains `activeUserCount` beside `userCount`; catalog operations gain `actRequiresAuthorizedScripts`.
+- Behaviour change (API): a PATCH/POST on an **organization-owned** agent that adds a `supervisedActionKeys` entry the row does not already hold is now refused with `422 supervised_keys_grant_only` — keys reach org rows only through the four-eyes graduation grant. Partner rows are unaffected.
+- Behaviour change (API): the partner ∩ org policy merge is now wildcard-aware for `toolAllowlist` / `supervisedActionKeys` (a bare `manage_services` on the baseline no longer erases an org's `manage_services:restart`).
+- Known gap: there is no UI yet to authorize scripts for unattended act mode (#5065); until it ships, `actAssets.scriptIds` is set through the API.
+
+---
+

--- a/docs/release-notes/next-release-draft.md
+++ b/docs/release-notes/next-release-draft.md
@@ -19,7 +19,7 @@ Last release: **v0.110.0** (2026-09-05).
 - The tool allowlist textarea is replaced by a **capability picker**: 15 capabilities, per-operation outcome badges (Approval request / Logged proposal / Executes unattended), a "Recommended for <kind>" preset, search across labels and literal names, and an "Always on: read-only tools" disclosure. Organization agents see operations outside the partner baseline as **Not in partner baseline**.
 - Truthful act-mode outcomes: **Run a script** stays an approval request until a script is authorized for the agent (`actAssets.scriptIds`); the picker and the review card say so instead of promising an unattended run.
 - Recipient roles with no active members are marked in the form, and the act-mode "recipient" error now says the selected roles have no active members instead of "add a recipient".
-- The edit drawer renders the same step components as the create flow (one rendering per setting).
+- The edit drawer now lays out an agent the way the create flow does: "When it runs" and Permissions first, then a **Safety and oversight** block with protected services / paths / registry keys, unattended authorization, limits and notification roles. Protected resources moved out of the Permissions section into that block.
 
 **Self-Hosting / Upgrade Notes.**
 - No new env vars, no migrations. The whole feature is still behind `BREEZE_AI_AGENTS_ENABLED` (default `false`); `BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED` unchanged.


### PR DESCRIPTION
Closes #5063 (follow-up from the W03 review on #5062, #5048).

## What changed
- `AiAgentForm` (the edit drawer) now mounts `steps/WhatItDoesStep` and `steps/SafetyStep` with the same `draft`/`patch` the guided create flow uses, so every setting from "When it runs" through recipients has exactly one rendering and one test surface. The drawer keeps only its edit-only pieces: the fixed kind, the enabled switch, the graduation panel, schedules, and the Save/Cancel/Disable footer. 941 → 649 lines.
- `SafetyStep` absorbs the drawer's org-row rule (#5049): partner row → interactive registry (collapsed while not acting); org row in act mode → read-only list of held keys plus the grant-only hint; org row not in act mode → nothing. Every test id is unchanged.
- `WhatItDoesStep` takes `authorizedScriptCount` so the drawer's real script count (row ∩ ceiling) still reaches the capability picker.
- Step roots carry `agent-step-does` / `agent-step-safety`; a new drawer test asserts the settings render inside them, in order, with the edit-only pieces around them.
- `docs/release-notes/next-release-draft.md`: running entry for the agent builder (#5048, #5064, #5063) — operator notes plus the Self-Hosting section (flags unchanged, additive API fields, the two API behaviour changes, the #5065 gap). `/release` Step 1 reads this file.

## Verification
- `apps/web`: `AiAgentForm.test.tsx` + `src/components/settings/aiAgents` → 12 files / 260 tests green (all pre-existing drawer assertions — org-row read-only registry, partner-ceiling collapse, picker wiring, loading/fallback, severities, limits — pass unchanged against the shared steps).
- `tsc --noEmit` clean; eslint clean on the four touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CuEEGssvpeM9HE7sQqByGE
