### PR TITLE
test(ai-agents): pin the web tool-category ↔ API capability contract (#5056)

### DIFF
--- a/apps/api/src/services/aiAgents/agentToolCatalog.categoryParity.test.ts
+++ b/apps/api/src/services/aiAgents/agentToolCatalog.categoryParity.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Contract test: category/capability parity between the two hand-maintained
+ * AI-tool grouping tables (issue #5056).
+ *
+ * `apps/web/src/components/ai-risk/tierConfig.ts` groups tools into DISPLAY
+ * categories (`ToolCategory`) for the customer-facing AI Risk page — "what is
+ * this AI capable of, grouped the way an MSP tech thinks about their fleet".
+ *
+ * `apps/api/src/services/aiAgents/agentToolCatalog.ts` groups the same tools
+ * into PERMISSION capabilities (`AgentCapabilityId`) for the agent-builder
+ * picker — "what RBAC-shaped bundle of access does granting this tool
+ * require". These are DELIBERATELY two different axes over the same tool set
+ * (per #5056: "the two UIs serve different questions — risk posture vs what
+ * an agent may change"). A 1:1 mapping is NOT the goal and this test does not
+ * enforce one — it enforces three narrower things instead:
+ *
+ *   1. Every `TOOL_CAPABILITY` tool is represented somewhere in tierConfig.ts,
+ *      except a documented pre-existing gap
+ *      (`TOOL_CAPABILITY_NOT_YET_IN_TIER_CONFIG`) of newer feature families
+ *      the risk page has never been updated to cover. That gap is pinned
+ *      EXACTLY, the same discipline as the unreachable-tools snapshot in
+ *      `agentToolCatalog.contract.test.ts`: it can only shrink by actually
+ *      adding the tool to tierConfig.ts (and deleting the entry here), and it
+ *      can only grow via a deliberate edit to this file — never silently, by
+ *      a new tool landing in the picker but never the risk page.
+ *   2. Every agent-reachable tool tierConfig.ts DOES reference has a
+ *      `TOOL_CAPABILITY` entry (catches a typo'd or retired tool name
+ *      surviving in tierConfig.ts after the capability map moves on).
+ *   3. The (web category, API capability) pair for every tool present in BOTH
+ *      tables is a member of the hand-authored `CATEGORY_CAPABILITY_PAIRS`
+ *      allowlist below, so a new tool can't land in a category that makes no
+ *      sense for its permission shape without a deliberate edit here.
+ *
+ * Reuses `parseToolLabel` from the tier-parity shared module (the
+ * `tool (action/action)` grammar tierConfig.ts entries already use) rather
+ * than re-deriving a base-name regex, so both parity tests treat an
+ * unparseable label the same way.
+ */
+import { describe, it, expect } from 'vitest';
+import '../aiTools'; // populates the registry
+
+import {
+  TOOL_CAPABILITY,
+  listAgentReachableTools,
+  type AgentCapabilityId,
+} from './agentToolCatalog';
+import { parseToolLabel } from '../aiGuardrailsTierParity.shared';
+import { TIER_DEFINITIONS, type ToolCategory } from '../../../../web/src/components/ai-risk/tierConfig';
+
+// ── Derive base-tool-name -> web category from tierConfig.ts ───────────────
+// Tier 4 lists concepts ("Cross-org access", "Unknown tools"), not tools.
+const tierConfigCategoryByTool = new Map<string, ToolCategory>();
+const duplicateCategoryConflicts: string[] = [];
+
+for (const tier of TIER_DEFINITIONS) {
+  if (tier.tier === 4) continue;
+  for (const entry of tier.tools) {
+    // tierConfig.ts lists the same tool once per action group (e.g.
+    // `manage_alerts (list/get)` in Tier 1, `manage_alerts (acknowledge)` in
+    // Tier 2); parseToolLabel strips the `(...)` suffix to the bare tool name.
+    const parsed = parseToolLabel(entry.name);
+    const base = parsed?.tool ?? entry.name;
+    const existing = tierConfigCategoryByTool.get(base);
+    if (existing !== undefined && existing !== entry.category) {
+      duplicateCategoryConflicts.push(
+        `"${base}" is listed under both "${existing}" and "${entry.category}" — ` +
+        'a tool must sit in exactly one display category across all tiers.',
+      );
+    }
+    tierConfigCategoryByTool.set(base, entry.category);
+  }
+}
+
+const reachableTools = new Set(listAgentReachableTools());
+
+/**
+ * `TOOL_CAPABILITY` entries with no representation anywhere in tierConfig.ts
+ * — a pre-existing gap this test discovered, not a design decision. These
+ * cover feature families added to the agent-builder capability map after
+ * tierConfig.ts was last swept: SentinelOne containment, CIS baseline
+ * remediation, Huntress, PAM/just-in-time elevation, user risk scoring,
+ * Hyper-V and MSSQL backup/DR, backup vaults + SLA reporting, cloud-to-cloud
+ * (M365/Google) backup, browser/peripheral device policy, patch update
+ * rings, script/catalog listing helpers, quotes/invoices/contracts/catalog
+ * business objects, tenancy management, and M365 typed Graph reads. Closing
+ * this gap means authoring a tier + description + category per tool — a
+ * content-authoring task, not a category fix — tracked as a follow-up, not
+ * silently accepted here forever.
+ *
+ * Pinned EXACTLY (see the completeness test below): shrinking it requires
+ * actually adding the tool to tierConfig.ts and deleting the entry here;
+ * growing it requires a deliberate edit, so a brand-new capability-only tool
+ * can't land in the picker without this test forcing a decision about
+ * whether the risk page needs it too.
+ */
+const TOOL_CAPABILITY_NOT_YET_IN_TIER_CONFIG: readonly string[] = [
+  'apply_cis_remediation',
+  'assign_security_training',
+  'collect_evidence',
+  'configure_backup_sla',
+  'configure_vault',
+  'create_incident',
+  'delete_tenant',
+  'execute_containment',
+  'execute_dr_plan',
+  'generate_incident_report',
+  'get_browser_security',
+  'get_catalog_item',
+  'get_cis_compliance',
+  'get_cis_device_report',
+  'get_contract',
+  'get_device_vulnerabilities',
+  'get_dr_execution_status',
+  'get_dr_plan_details',
+  'get_elevation_history',
+  'get_fleet_status',
+  'get_huntress_incidents',
+  'get_huntress_status',
+  'get_hyperv_vm_details',
+  'get_incident_timeline',
+  'get_invoice',
+  'get_mssql_backup_status',
+  'get_peripheral_activity',
+  'get_quote',
+  'get_s1_status',
+  'get_s1_threats',
+  'get_sensitive_data_overview',
+  'get_service_monitoring_status',
+  'get_sla_breaches',
+  'get_sla_compliance_report',
+  'get_user_risk_detail',
+  'get_user_risk_scores',
+  'get_vault_status',
+  'get_vm_restore_estimate',
+  'get_vulnerability_report',
+  'instant_boot_vm',
+  'list_contracts',
+  'list_invoices',
+  'list_organizations',
+  'list_quotes',
+  'list_script_templates',
+  'list_scripts',
+  'lookup_distributor_product',
+  'm365_query_groups',
+  'm365_query_intune_devices',
+  'm365_query_org',
+  'm365_query_signins',
+  'm365_query_sites',
+  'm365_query_users',
+  'manage_backup_configs',
+  'manage_backup_profiles',
+  'manage_browser_policy',
+  'manage_catalog',
+  'manage_contracts',
+  'manage_dr_plan',
+  'manage_hyperv_checkpoints',
+  'manage_hyperv_vm',
+  'manage_invoices',
+  'manage_organizations',
+  'manage_peripheral_policies',
+  'manage_peripheral_policy',
+  'manage_policy_feature_link',
+  'manage_quotes',
+  'manage_service_monitors',
+  'manage_software_policies',
+  'manage_update_rings',
+  'query_backup_sla',
+  'query_c2c_connections',
+  'query_c2c_jobs',
+  'query_dr_plans',
+  'query_hyperv_vms',
+  'query_mssql_instances',
+  'query_vaults',
+  'remediate_sensitive_data',
+  'remediate_vulnerability',
+  'request_elevation',
+  'restore_as_vm',
+  'restore_c2c_items',
+  'restore_hyperv_vm',
+  'restore_mssql_database',
+  'revoke_elevation',
+  's1_isolate_device',
+  's1_threat_action',
+  'search_c2c_items',
+  'search_catalog',
+  'search_documentation',
+  'sync_huntress_data',
+  'trigger_c2c_sync',
+  'trigger_hyperv_backup',
+  'trigger_mssql_backup',
+  'trigger_vault_sync',
+  'verify_mssql_backup',
+];
+
+/**
+ * The contract: which API permission capabilities a web display category may
+ * legitimately contain. Hand-authored from the CURRENT tables (after fixing
+ * the plainly-wrong placements #5056 called out — `manage_alert_rules` and
+ * the `*_device_context` tools moved categories rather than being allowlisted
+ * here; see the PR for the one-line reason on each). Every other
+ * (category, capability) pair below is a deliberate judgment call that the
+ * display grouping is coherent even though it doesn't match the API's finer
+ * permission axis — e.g. "Files, Disk & Registry" reads as one bucket to an
+ * MSP tech even though the API separates plain file ops (`files_disk`) from
+ * registry edits (`scripts_commands`) as a permission matter.
+ *
+ * A pair NOT in this list fails the test below with the offending tool,
+ * category, and capability named — so a new tool landing in a nonsensical
+ * category/capability combination is a deliberate edit, not a silent drift.
+ */
+const CATEGORY_CAPABILITY_PAIRS: Record<ToolCategory, AgentCapabilityId[]> = {
+  'Devices & Hardware': [
+    'automations_reports', // device/fleet lookups, metrics, device-context resolution
+    'alerts_monitoring', // get_fleet_findings: fleet hygiene findings display next to fleet health
+  ],
+  'Network & DNS': ['network', 'config_policies'],
+  'Security & Compliance': ['security_response', 'patching_software'],
+  'Alerts & Notifications': ['alerts_monitoring'],
+  'Files, Disk & Registry': ['files_disk', 'scripts_commands'],
+  'Logs & Audit': ['alerts_monitoring', 'automations_reports', 'endpoint_agent'],
+  'Services & Processes': ['services_startup', 'scripts_commands'],
+  'Scripts & Automation': ['scripts_commands'],
+  'Configuration Policies': ['config_policies'],
+  'Fleet Operations': [
+    'automations_reports',
+    'patching_software',
+    'alerts_monitoring', // manage_maintenance_windows: a fleet-wide scheduling construct on display, even though its main effect is alert suppression permission-wise
+  ],
+  'Backup & Recovery': ['backup_recovery'],
+  'Monitoring & Analytics': ['alerts_monitoring', 'automations_reports'],
+  'Remote Access & Control': ['remote_access', 'scripts_commands'],
+  Integrations: ['endpoint_agent', 'tenancy'],
+  Ticketing: ['tickets'],
+  'AI Governance': ['tenancy'],
+  Other: ['automations_reports'],
+};
+
+describe('tierConfig.ts ↔ agentToolCatalog.ts category/capability parity (#5056)', () => {
+  it('tierConfig.ts assigns exactly one display category per tool across all tiers', () => {
+    expect(duplicateCategoryConflicts).toEqual([]);
+  });
+
+  it('every TOOL_CAPABILITY tool appears in tierConfig.ts, except the documented pre-existing gap', () => {
+    const missing = Object.keys(TOOL_CAPABILITY)
+      .filter((name) => !tierConfigCategoryByTool.has(name))
+      .sort();
+    expect(
+      missing,
+      'A tool was added to (or removed from) TOOL_CAPABILITY without a matching tierConfig.ts ' +
+      'update. Either add the tool to tierConfig.ts (and drop it from ' +
+      'TOOL_CAPABILITY_NOT_YET_IN_TIER_CONFIG), or add it to that list deliberately.',
+    ).toEqual([...TOOL_CAPABILITY_NOT_YET_IN_TIER_CONFIG].sort());
+  });
+
+  it('every agent-reachable tool referenced in tierConfig.ts has a TOOL_CAPABILITY entry', () => {
+    const missing = [...tierConfigCategoryByTool.keys()]
+      .filter((name) => reachableTools.has(name) && !(name in TOOL_CAPABILITY));
+    expect(missing).toEqual([]);
+  });
+
+  it('every (web category, API capability) pair in use is in the CATEGORY_CAPABILITY_PAIRS allowlist', () => {
+    const mismatches: string[] = [];
+    for (const [tool, category] of tierConfigCategoryByTool) {
+      const capability = TOOL_CAPABILITY[tool];
+      // Absence is covered by the completeness test above; nothing new to
+      // assert about a pairing that doesn't exist.
+      if (!capability) continue;
+      const allowed = CATEGORY_CAPABILITY_PAIRS[category];
+      if (!allowed.includes(capability)) {
+        mismatches.push(
+          `${tool}: tierConfig.ts category "${category}" paired with TOOL_CAPABILITY "${capability}" ` +
+          'is not in CATEGORY_CAPABILITY_PAIRS',
+        );
+      }
+    }
+    expect(
+      mismatches,
+      'apps/web/src/components/ai-risk/tierConfig.ts and ' +
+      'apps/api/src/services/aiAgents/agentToolCatalog.ts have drifted (#5056): a tool landed in a ' +
+      '(category, capability) combination this test has never approved. Either fix the tierConfig.ts ' +
+      'category if it is plainly wrong for what the tool does, or add the pair to ' +
+      'CATEGORY_CAPABILITY_PAIRS if the display grouping is a deliberate, coherent choice.\n' +
+      mismatches.map((m) => `  • ${m}`).join('\n'),
+    ).toEqual([]);
+  });
+
+  it('CATEGORY_CAPABILITY_PAIRS carries no stale (category, capability) entries', () => {
+    const used = new Set<string>();
+    for (const [tool, category] of tierConfigCategoryByTool) {
+      const capability = TOOL_CAPABILITY[tool];
+      if (capability) used.add(`${category}::${capability}`);
+    }
+    const unused: string[] = [];
+    for (const category of Object.keys(CATEGORY_CAPABILITY_PAIRS) as ToolCategory[]) {
+      for (const capability of CATEGORY_CAPABILITY_PAIRS[category]) {
+        if (!used.has(`${category}::${capability}`)) unused.push(`${category} -> ${capability}`);
+      }
+    }
+    expect(unused).toEqual([]);
+  });
+});

--- a/apps/web/src/components/ai-risk/tierConfig.ts
+++ b/apps/web/src/components/ai-risk/tierConfig.ts
@@ -70,6 +70,7 @@ export const TIER_DEFINITIONS: TierDefinition[] = [
       { name: 'get_fleet_findings', description: 'Deduplicated fleet hygiene findings', category: 'Devices & Hardware' },
       { name: 'analyze_fleet_metrics', description: 'Fleet-wide metric aggregation from rollups', category: 'Devices & Hardware' },
       { name: 'analyze_boot_performance', description: 'Boot performance analysis', category: 'Devices & Hardware' },
+      { name: 'get_device_context', description: 'Brain device context lookup', category: 'Devices & Hardware' },
       // Network & DNS
       { name: 'get_network_changes', description: 'Network change detection', category: 'Network & DNS' },
       { name: 'get_ip_history', description: 'IP address history', category: 'Network & DNS' },
@@ -83,6 +84,7 @@ export const TIER_DEFINITIONS: TierDefinition[] = [
       // Alerts & Notifications
       { name: 'manage_alerts (list/get)', description: 'View alerts', category: 'Alerts & Notifications' },
       { name: 'manage_notification_channels (list)', description: 'List notification channels', category: 'Alerts & Notifications' },
+      { name: 'manage_alert_rules (list_rules/get_rule/test_rule)', description: 'View alert rules', category: 'Alerts & Notifications' },
       // Files, Disk & Registry
       { name: 'analyze_disk_usage', description: 'Filesystem analysis', category: 'Files, Disk & Registry' },
       { name: 'disk_cleanup (preview)', description: 'Preview cleanup candidates', category: 'Files, Disk & Registry' },
@@ -115,7 +117,6 @@ export const TIER_DEFINITIONS: TierDefinition[] = [
       { name: 'manage_groups (list/get/preview)', description: 'View device groups', category: 'Fleet Operations' },
       { name: 'manage_maintenance_windows (list/get)', description: 'View maintenance windows', category: 'Fleet Operations' },
       { name: 'manage_automations (list/get/history)', description: 'View automations', category: 'Fleet Operations' },
-      { name: 'manage_alert_rules (list_rules/get_rule/test_rule)', description: 'View alert rules', category: 'Fleet Operations' },
       { name: 'generate_report (list/data/history/download)', description: 'View and download reports', category: 'Fleet Operations' },
       // Backup & Recovery
       { name: 'query_backups', description: 'List backup configs, jobs, and policies', category: 'Backup & Recovery' },
@@ -128,7 +129,6 @@ export const TIER_DEFINITIONS: TierDefinition[] = [
       { name: 'get_executive_summary', description: 'Executive summary metrics', category: 'Monitoring & Analytics' },
       // Remote Access & Control
       { name: 'list_remote_sessions', description: 'List remote sessions', category: 'Remote Access & Control' },
-      { name: 'get_device_context', description: 'Brain device context lookup', category: 'Remote Access & Control' },
       // Integrations
       { name: 'query_webhooks', description: 'List webhooks and delivery status', category: 'Integrations' },
       { name: 'query_psa_status', description: 'PSA connection status', category: 'Integrations' },
@@ -154,6 +154,9 @@ export const TIER_DEFINITIONS: TierDefinition[] = [
       { name: 'manage_alerts (resolve)', description: 'Resolve alerts', category: 'Alerts & Notifications' },
       { name: 'manage_alerts (suppress)', description: 'Suppress alerts temporarily', category: 'Alerts & Notifications' },
       { name: 'manage_notification_channels (test)', description: 'Test notification channel', category: 'Alerts & Notifications' },
+      // Devices & Hardware
+      { name: 'set_device_context', description: 'Set brain device context', category: 'Devices & Hardware' },
+      { name: 'resolve_device_context', description: 'Resolve brain device context', category: 'Devices & Hardware' },
       // Services & Processes
       { name: 'manage_services (list)', description: 'List services on device', category: 'Services & Processes' },
       // Network & DNS
@@ -161,8 +164,6 @@ export const TIER_DEFINITIONS: TierDefinition[] = [
       { name: 'configure_network_baseline', description: 'Configure network baseline', category: 'Network & DNS' },
       { name: 'manage_dns_policy', description: 'DNS policy management', category: 'Network & DNS' },
       // Remote Access & Control
-      { name: 'set_device_context', description: 'Set brain device context', category: 'Remote Access & Control' },
-      { name: 'resolve_device_context', description: 'Resolve brain device context', category: 'Remote Access & Control' },
       { name: 'execute_command (list_processes/file_list/event_logs_list)', description: 'Read-only device commands (process list, directory listings, event log channel list)', category: 'Remote Access & Control' },
       // Files, Disk & Registry
       { name: 'file_operations (list)', description: 'List directory contents on device', category: 'Files, Disk & Registry' },
@@ -285,8 +286,8 @@ export const RATE_LIMIT_CONFIGS: RateLimitConfig[] = [
   { toolName: 'take_screenshot', limit: 10, windowSeconds: 300, tier: 3, permission: 'devices.execute', category: 'Remote Access & Control' },
   { toolName: 'analyze_screen', limit: 10, windowSeconds: 300, tier: 3, permission: 'devices.execute', category: 'Remote Access & Control' },
   { toolName: 'create_remote_session', limit: 10, windowSeconds: 300, tier: 3, permission: 'devices.execute', category: 'Remote Access & Control' },
-  { toolName: 'set_device_context', limit: 20, windowSeconds: 300, tier: 2, permission: 'devices.write', category: 'Remote Access & Control' },
-  { toolName: 'resolve_device_context', limit: 20, windowSeconds: 300, tier: 2, permission: 'devices.write', category: 'Remote Access & Control' },
+  { toolName: 'set_device_context', limit: 20, windowSeconds: 300, tier: 2, permission: 'devices.write', category: 'Devices & Hardware' },
+  { toolName: 'resolve_device_context', limit: 20, windowSeconds: 300, tier: 2, permission: 'devices.write', category: 'Devices & Hardware' },
   // Services & Processes
   { toolName: 'manage_services', limit: 10, windowSeconds: 300, tier: 3, permission: 'devices.execute', category: 'Services & Processes' },
   { toolName: 'manage_processes', limit: 15, windowSeconds: 300, tier: 1, permission: 'devices.read', category: 'Services & Processes' },
@@ -334,7 +335,7 @@ export const RATE_LIMIT_CONFIGS: RateLimitConfig[] = [
   { toolName: 'manage_groups', limit: 20, windowSeconds: 300, tier: 1, permission: 'groups.write', category: 'Fleet Operations' },
   { toolName: 'manage_maintenance_windows', limit: 15, windowSeconds: 300, tier: 1, permission: 'maintenance.write', category: 'Fleet Operations' },
   { toolName: 'manage_automations', limit: 10, windowSeconds: 600, tier: 1, permission: 'automations.write', category: 'Fleet Operations' },
-  { toolName: 'manage_alert_rules', limit: 15, windowSeconds: 300, tier: 1, permission: 'alerts.write', category: 'Fleet Operations' },
+  { toolName: 'manage_alert_rules', limit: 15, windowSeconds: 300, tier: 1, permission: 'alerts.write', category: 'Alerts & Notifications' },
   { toolName: 'generate_report', limit: 10, windowSeconds: 300, tier: 1, permission: 'reports.write', category: 'Fleet Operations' },
 ];
 


### PR DESCRIPTION
Closes #5056.

## What changed
- New `apps/api/src/services/aiAgents/agentToolCatalog.categoryParity.test.ts`: the two hand-maintained maps (`tierConfig.ts` display categories for the AI Risk page, `TOOL_CAPABILITY` permission capabilities for the agent builder) are intentionally different taxonomies, so the contract is an explicit allowlist rather than a 1:1 mapping. The test asserts: one web category per tool; every `TOOL_CAPABILITY` tool appears in tierConfig; every agent-reachable tierConfig tool has a capability; every (category, capability) pair in use is in `CATEGORY_CAPABILITY_PAIRS`; and the allowlist carries no stale entries. A new tool can no longer land in only one table, or in a nonsensical pair, without a deliberate edit.
- `tierConfig.ts`: four display-category moves, `category` only (tiers/descriptions untouched; mirrored in `RATE_LIMIT_CONFIGS`): `manage_alert_rules` → Alerts & Notifications; `get_device_context`, `set_device_context`, `resolve_device_context` → Devices & Hardware. `manage_maintenance_windows`, `get_fleet_findings`, `manage_tags` are allowlisted as legitimate display-vs-permission differences.

## Found on the way
`TOOL_CAPABILITY` has 190 tools; tierConfig covers 94. The 96 never authored into the AI Risk page (SentinelOne, CIS, Huntress, PAM, Hyper-V, MSSQL, DR, backup vaults/SLA, C2C, browser/peripheral policy, billing objects, tenancy, M365 typed reads) are pinned as `TOOL_CAPABILITY_NOT_YET_IN_TIER_CONFIG` in the test with a comment. Filling them in is a content task tracked separately.

## Verification
- `apps/api`: `agentToolCatalog.categoryParity.test.ts` + `aiGuardrailsTierConfig.parity.test.ts` → 9/9 green.
- `apps/web`: `src/components/ai-risk` → 4/4 green. eslint clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CuEEGssvpeM9HE7sQqByGE
