### PR TITLE
fix(security): site-scoped software and SentinelOne summaries (RMM-QA-221)

### DIFF
--- a/apps/api/src/__tests__/integration/site-scope-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/site-scope-coverage.integration.test.ts
@@ -225,8 +225,6 @@ const SITE_SCOPE_INPUT_EXEMPT: ReadonlySet<string> = new Set<string>([
   // predicate to every aggregate and GET /trends denies site-restricted
   // callers outright, so the ratchet correctly demands these entries go.
   'routes/huntress.ts:GET /status',
-  'routes/sentinelOne.ts:GET /status',
-  'routes/softwarePolicies.ts:GET /compliance/overview',
   'routes/updateRings.ts:GET /:id/compliance',
   // Org-scoped compliance list, identical posture to its sibling routes
   // (/firewall, /trends) which resolve rows through the same org-scoped

--- a/apps/api/src/__tests__/integration/site-scope-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/site-scope-coverage.integration.test.ts
@@ -215,15 +215,9 @@ const SITE_SCOPE_INPUT_EXEMPT: ReadonlySet<string> = new Set<string>([
   // site-restricted caller sees no sessions here in the first place.
   'routes/remote/supportSessions.ts:GET /support-sessions',
   'routes/remote/supportSessions.ts:GET /support-sessions/:id',
-  // ---- Org-wide AGGREGATE reads: return only counts/summaries (no
-  // per-device rows), so no cross-site device data is disclosed (returns
-  // re-verified 2026-05-31). NB: totals still span the org incl. other
-  // sites — site-scoping the aggregates themselves is a separate product call.
-  // routes/metrics.ts:GET / and GET /trends were exempted here as org-wide
-  // aggregates with the note that site-scoping them was "a separate product
-  // call". Wave 2 made that call: GET / now applies the allowed-site
-  // predicate to every aggregate and GET /trends denies site-restricted
-  // callers outright, so the ratchet correctly demands these entries go.
+  // ---- Partner/system-only aggregates: organization site-restricted roles
+  // cannot reach these handlers. User-reachable software/SentinelOne summaries
+  // apply site scope directly (RMM-QA-221), as do the earlier metrics fixes.
   'routes/huntress.ts:GET /status',
   'routes/updateRings.ts:GET /:id/compliance',
   // Org-scoped compliance list, identical posture to its sibling routes
@@ -277,14 +271,9 @@ const SITE_SCOPE_INPUT_EXEMPT_USER_SESSION_OK: ReadonlySet<string> = new Set<str
   // all, let alone reach a device through them.
   'routes/remote/supportSessions.ts:GET /support-sessions',
   'routes/remote/supportSessions.ts:GET /support-sessions/:id',
-  // Org-wide AGGREGATE reads: return only counts/summaries (no per-device rows),
-  // so no cross-site device data is disclosed. Reached via user auth but exempt
-  // for the aggregate reason rather than non-user auth — recorded here so the
-  // re-verification test (added in #1041) accepts them. (Site-scoping the
-  // aggregate totals themselves is a separate product call.)
+  // Partner/system-only aggregates use user auth but cannot be reached by
+  // organization site-restricted roles; see SITE_SCOPE_INPUT_EXEMPT above.
   'routes/huntress.ts:GET /status',
-  'routes/sentinelOne.ts:GET /status',
-  'routes/softwarePolicies.ts:GET /compliance/overview',
   'routes/updateRings.ts:GET /:id/compliance',
   // Org-scoped compliance list (see note in SITE_SCOPE_INPUT_EXEMPT). Reached
   // via user auth (requireScope) but exempt because the escrow enrichment is

--- a/apps/api/src/__tests__/integration/siteAggregateScope.integration.test.ts
+++ b/apps/api/src/__tests__/integration/siteAggregateScope.integration.test.ts
@@ -1,0 +1,262 @@
+/** RMM-QA-221: mounted summaries under real JWT/RBAC and breeze_app RLS. */
+import './setup';
+import { randomUUID } from 'node:crypto';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { Hono } from 'hono';
+import { eq, sql } from 'drizzle-orm';
+import { getAppDb, getTestDb } from './setup';
+import { createOrganization, createPartner, createRole, createSite, createUser, grantRolePermissions } from './db-utils';
+import { createAccessToken } from '../../services/jwt';
+import { clearPermissionCache } from '../../services/permissions';
+import {
+  devices, organizationUsers, partnerUsers, users, s1Agents, s1Threats,
+  s1Actions, s1Integrations, s1OrgMappings, softwarePolicies, softwareComplianceStatus,
+} from '../../db/schema';
+import { softwarePoliciesRoutes } from '../../routes/softwarePolicies';
+import { sentinelOneRoutes } from '../../routes/sentinelOne';
+
+const app = new Hono();
+app.route('/software-policies', softwarePoliciesRoutes);
+app.route('/sentinel-one', sentinelOneRoutes);
+const overviewPath = '/software-policies/compliance/overview';
+const statusPath = '/sentinel-one/status';
+const threatsPath = '/sentinel-one/threats';
+const zeroSoftware = { total: 0, compliant: 0, violations: 0, unknown: 0 };
+const zeroSecurity = {
+  totalAgents: 0, mappedDevices: 0, infectedAgents: 0, activeThreats: 0,
+  highOrCriticalThreats: 0, pendingActions: 0, reportedThreatCount: 0,
+};
+
+async function request(path: string, token: string) {
+  return app.request(path, { headers: { Authorization: `Bearer ${token}` } });
+}
+
+async function read(path: string, token: string) {
+  const response = await request(path, token);
+  const body = await response.json();
+  expect(response.status, JSON.stringify(body)).toBe(200);
+  return body;
+}
+
+async function fixture() {
+  const partner = await createPartner();
+  const foreignPartner = await createPartner();
+  const org = await createOrganization({ partnerId: partner.id });
+  const otherOrg = await createOrganization({ partnerId: partner.id });
+  const foreignOrg = await createOrganization({ partnerId: foreignPartner.id });
+  const siteA = await createSite({ orgId: org.id });
+  const siteB = await createSite({ orgId: org.id });
+  const otherSite = await createSite({ orgId: otherOrg.id });
+  const foreignSite = await createSite({ orgId: foreignOrg.id });
+  const role = await createRole({ scope: 'organization', orgId: org.id, partnerId: partner.id });
+  await grantRolePermissions(role.id, [{ resource: 'devices', action: 'read' }]);
+  const noRead = await createRole({ scope: 'organization', orgId: org.id, partnerId: partner.id });
+  const partnerRole = await createRole({ scope: 'partner', partnerId: partner.id, name: 'Partner Admin' });
+  await grantRolePermissions(partnerRole.id, [{ resource: '*', action: '*' }]);
+  const partnerNoRead = await createRole({ scope: 'partner', partnerId: partner.id });
+
+  async function principal(scope: 'organization' | 'partner' | 'system', siteIds: string[] | null, canRead = true) {
+    const user = await createUser({ partnerId: partner.id, email: `${randomUUID()}@example.com` });
+    const roleId = scope === 'organization'
+      ? (canRead ? role.id : noRead.id)
+      : (canRead ? partnerRole.id : partnerNoRead.id);
+    if (scope === 'organization') {
+      await getTestDb().insert(organizationUsers).values({ userId: user.id, orgId: org.id, roleId, siteIds });
+    } else {
+      await getTestDb().insert(partnerUsers).values({ userId: user.id, partnerId: partner.id, roleId, orgAccess: 'all' });
+      if (scope === 'system') await getTestDb().update(users).set({ isPlatformAdmin: true }).where(eq(users.id, user.id));
+    }
+    const token = await createAccessToken({
+      sub: user.id, email: user.email, roleId, orgId: scope === 'organization' ? org.id : null,
+      partnerId: partner.id, scope, mfa: false, aep: 1, mep: 1, sid: randomUUID(),
+    });
+    return { token, id: user.id };
+  }
+
+  async function device(orgId: string, siteId: string) {
+    const [row] = await getTestDb().insert(devices).values({
+      orgId, siteId, agentId: randomUUID(), hostname: `host-${randomUUID()}`,
+      osType: 'windows', osVersion: '11', architecture: 'x86_64', status: 'online', agentVersion: '0.0.0-test',
+    }).returning();
+    return row!;
+  }
+  const allowed = await device(org.id, siteA.id);
+  const denied = await device(org.id, siteB.id);
+  const other = await device(otherOrg.id, otherSite.id);
+  const foreign = await device(foreignOrg.id, foreignSite.id);
+  const [policy] = await getTestDb().insert(softwarePolicies).values({
+    orgId: org.id, name: 'Site aggregate fixture', mode: 'audit', rules: { software: [] },
+  }).returning();
+  const [integration] = await getTestDb().insert(s1Integrations).values({
+    partnerId: partner.id, name: 'Fixture integration', apiTokenEncrypted: 'unused-fixture',
+    managementUrl: 'https://fixture.sentinelone.net', isActive: true,
+  }).returning();
+  await getTestDb().insert(s1OrgMappings).values([org, otherOrg].map((o) => ({
+    partnerId: partner.id, integrationId: integration!.id, orgId: o.id, s1SiteId: randomUUID(),
+  })));
+
+  async function facts(deviceId: string | null, orgId = org.id, threatCount = 2) {
+    if (deviceId) await getTestDb().insert(softwareComplianceStatus).values({
+      deviceId, policyId: policy!.id, status: 'violation', lastChecked: new Date(),
+    });
+    await getTestDb().insert(s1Agents).values({
+      integrationId: integration!.id, orgId, deviceId, s1AgentId: randomUUID(), infected: true, threatCount,
+    });
+    await getTestDb().insert(s1Threats).values({
+      integrationId: integration!.id, orgId, deviceId, s1ThreatId: randomUUID(), status: 'active', severity: 'high',
+    });
+    await getTestDb().insert(s1Actions).values({ orgId, deviceId, action: 'isolate', status: 'queued' });
+  }
+  await facts(allowed.id);
+  const restricted = await principal('organization', [siteA.id]);
+  return { partner, foreignPartner, org, otherOrg, foreignOrg, siteA, siteB, allowed, denied, other, foreign,
+    role, policy: policy!, integration: integration!, restricted, principal, facts, device };
+}
+
+describe('RMM-QA-221 site-scoped aggregate acceptance', () => {
+  beforeEach(() => clearPermissionCache());
+
+  it('uses an unprivileged application connection', async () => {
+    const rows = await getAppDb().execute(sql`SELECT current_user AS name, rolsuper, rolbypassrls FROM pg_roles WHERE rolname = current_user`);
+    expect(rows[0]).toMatchObject({ name: 'breeze_app', rolsuper: false, rolbypassrls: false });
+  });
+
+  it('denied-site and unmapped facts cannot change any summary or sibling list', async () => {
+    const f = await fixture();
+    const beforeSoftware = await read(overviewPath, f.restricted.token);
+    const beforeSecurity = (await read(statusPath, f.restricted.token)).summary;
+    expect(beforeSoftware).toEqual({ total: 1, compliant: 0, violations: 1, unknown: 0 });
+    expect(beforeSecurity).toEqual({ totalAgents: 1, mappedDevices: 1, infectedAgents: 1, activeThreats: 1,
+      highOrCriticalThreats: 1, pendingActions: 1, reportedThreatCount: 2 });
+    await f.facts(f.denied.id, f.org.id, 100);
+    await f.facts(null, f.org.id, 200);
+    await f.facts(f.other.id, f.otherOrg.id, 300);
+    expect(await read(overviewPath, f.restricted.token)).toEqual(beforeSoftware);
+    expect((await read(statusPath, f.restricted.token)).summary).toEqual(beforeSecurity);
+    const violations = await read('/software-policies/violations', f.restricted.token);
+    expect(violations.data.map((row: { device: { id: string } }) => row.device.id)).toEqual([f.allowed.id]);
+    const threats = await read(threatsPath, f.restricted.token);
+    expect(threats.pagination.total).toBe(beforeSecurity.activeThreats);
+    expect(threats.data.map((row: { deviceId: string }) => row.deviceId)).toEqual([f.allowed.id]);
+    // Positive control: all hidden facts really exist and unrestricted org reads see them.
+    const unrestricted = await f.principal('organization', null);
+    expect((await read(overviewPath, unrestricted.token)).total).toBe(2);
+    expect((await read(statusPath, unrestricted.token)).summary).toEqual({
+      totalAgents: 3, mappedDevices: 2, infectedAgents: 3, activeThreats: 3,
+      highOrCriticalThreats: 3, pendingActions: 3, reportedThreatCount: 302,
+    });
+  });
+
+  it('empty live allowlists return zero summaries and no unmapped threats', async () => {
+    const f = await fixture();
+    await f.facts(f.denied.id);
+    await f.facts(null);
+    const empty = await f.principal('organization', []);
+    expect(await read(overviewPath, empty.token)).toEqual(zeroSoftware);
+    expect((await read(statusPath, empty.token)).summary).toEqual(zeroSecurity);
+    expect((await read(threatsPath, empty.token)).data).toEqual([]);
+    expect((await read('/software-policies/violations', empty.token)).total).toBe(0);
+  });
+
+  it('software overview keeps distinct-device worst status semantics within allowed sites', async () => {
+    const f = await fixture();
+    const [secondPolicy] = await getTestDb().insert(softwarePolicies).values({
+      orgId: f.org.id, name: 'Second policy', mode: 'audit', rules: { software: [] },
+    }).returning();
+    const compliant = await f.device(f.org.id, f.siteA.id);
+    const unknown = await f.device(f.org.id, f.siteA.id);
+    await getTestDb().insert(softwareComplianceStatus).values([
+      { deviceId: f.allowed.id, policyId: secondPolicy!.id, status: 'violation', lastChecked: new Date() },
+      { deviceId: compliant.id, policyId: f.policy.id, status: 'compliant', lastChecked: new Date() },
+      { deviceId: unknown.id, policyId: f.policy.id, status: 'unknown', lastChecked: new Date() },
+      { deviceId: unknown.id, policyId: secondPolicy!.id, status: 'compliant', lastChecked: new Date() },
+    ]);
+    await f.facts(f.denied.id);
+    expect(await read(overviewPath, f.restricted.token)).toEqual({ total: 3, compliant: 1, violations: 1, unknown: 1 });
+    const violations = await read('/software-policies/violations', f.restricted.token);
+    expect(violations.total).toBe(2);
+    expect(new Set(violations.data.map((row: { device: { id: string } }) => row.device.id))).toEqual(new Set([f.allowed.id]));
+  });
+
+  it.each([overviewPath, statusPath, threatsPath])('requires authentication and devices:read on %s', async (path) => {
+    const f = await fixture();
+    expect((await app.request(path)).status).toBe(401);
+    const denied = await f.principal('organization', null, false);
+    expect((await request(path, denied.token)).status).toBe(403);
+  });
+
+  it('fresh membership scope changes affect subsequent reads using the same token', async () => {
+    const f = await fixture();
+    await f.facts(f.denied.id, f.org.id, 19);
+    expect((await read(statusPath, f.restricted.token)).summary.reportedThreatCount).toBe(2);
+    await getTestDb().update(organizationUsers).set({ siteIds: [f.siteB.id] }).where(eq(organizationUsers.userId, f.restricted.id));
+    await clearPermissionCache(f.restricted.id);
+    expect((await read(statusPath, f.restricted.token)).summary.reportedThreatCount).toBe(19);
+    expect((await read(threatsPath, f.restricted.token)).data[0].deviceId).toBe(f.denied.id);
+    await getTestDb().update(organizationUsers).set({ siteIds: [] }).where(eq(organizationUsers.userId, f.restricted.id));
+    await clearPermissionCache(f.restricted.id);
+    expect(await read(overviewPath, f.restricted.token)).toEqual(zeroSoftware);
+    expect((await read(statusPath, f.restricted.token)).summary).toEqual(zeroSecurity);
+  });
+
+  it.each(['partner', 'system'] as const)('preserves unrestricted %s roles with devices:read via wildcard grant', async (scope) => {
+    const f = await fixture();
+    await f.facts(f.denied.id);
+    await f.facts(null);
+    await f.facts(f.other.id, f.otherOrg.id);
+    // A selected partner status must not absorb another partner's actions,
+    // even when a system reader is entitled to see both partners separately.
+    await getTestDb().insert(s1Actions).values({ orgId: f.foreignOrg.id, deviceId: f.foreign.id, action: 'isolate', status: 'queued' });
+    const principal = await f.principal(scope, null);
+    const query = `?partnerId=${f.partner.id}`;
+    const status = await read(statusPath + query, principal.token);
+    expect(status.summary.totalAgents).toBe(4);
+    expect(status.summary.pendingActions).toBe(4);
+    expect((await read(threatsPath + query, principal.token)).pagination.total).toBe(4);
+    expect((await read(overviewPath, principal.token)).total).toBe(3);
+    expect((await read(statusPath + query + `&orgId=${f.org.id}`, principal.token)).summary.totalAgents).toBe(3);
+  });
+
+  it('partner members using organization context inherit the live restricted membership', async () => {
+    const f = await fixture();
+    await f.facts(f.denied.id);
+    const partner = await f.principal('partner', null);
+    await getTestDb().insert(organizationUsers).values({
+      userId: partner.id, orgId: f.org.id, roleId: f.role.id, siteIds: [f.siteA.id],
+    });
+    const token = await createAccessToken({
+      sub: partner.id, email: 'partner@example.com', roleId: f.role.id,
+      orgId: f.org.id, partnerId: f.partner.id, scope: 'organization',
+      mfa: false, aep: 1, mep: 1, sid: randomUUID(),
+    });
+    expect((await read(statusPath, token)).summary.totalAgents).toBe(1);
+    expect((await read(overviewPath, token)).total).toBe(1);
+    expect((await read(threatsPath, token)).pagination.total).toBe(1);
+  });
+
+  it.each(['partner', 'system'] as const)('requires a real devices:read grant for %s status', async (scope) => {
+    const f = await fixture();
+    const denied = await f.principal(scope, null, false);
+    expect((await request(`${statusPath}?partnerId=${f.partner.id}`, denied.token)).status).toBe(403);
+  });
+
+  it('unmapped organization status does not expose partner integration metadata', async () => {
+    const f = await fixture();
+    await getTestDb().delete(s1OrgMappings).where(eq(s1OrgMappings.orgId, f.org.id));
+    const status = await read(statusPath, f.restricted.token);
+    expect(status.integration).toBeNull();
+    expect(status.summary).toEqual(zeroSecurity);
+  });
+
+  it('rejects foreign org/partner and denied explicit device selectors', async () => {
+    const f = await fixture();
+    for (const path of [statusPath, threatsPath]) {
+      expect((await request(`${path}?orgId=${f.foreignOrg.id}`, f.restricted.token)).status).toBe(403);
+    }
+    expect((await request(`${statusPath}?partnerId=${f.foreignPartner.id}`, f.restricted.token)).status).toBe(403);
+    expect((await request(`${threatsPath}?deviceId=${f.denied.id}`, f.restricted.token)).status).toBe(403);
+    expect((await request(`${threatsPath}?deviceId=${f.allowed.id}`, f.restricted.token)).status).toBe(200);
+    const partner = await f.principal('partner', null);
+    expect((await request(`${statusPath}?orgId=${f.foreignOrg.id}`, partner.token)).status).toBe(403);
+  });
+});

--- a/apps/api/src/__tests__/integration/siteAggregateScope.integration.test.ts
+++ b/apps/api/src/__tests__/integration/siteAggregateScope.integration.test.ts
@@ -54,12 +54,14 @@ async function fixture() {
   const partnerRole = await createRole({ scope: 'partner', partnerId: partner.id, name: 'Partner Admin' });
   await grantRolePermissions(partnerRole.id, [{ resource: '*', action: '*' }]);
   const partnerNoRead = await createRole({ scope: 'partner', partnerId: partner.id });
+  const partnerReader = await createRole({ scope: 'partner', partnerId: partner.id });
+  await grantRolePermissions(partnerReader.id, [{ resource: 'devices', action: 'read' }]);
 
-  async function principal(scope: 'organization' | 'partner' | 'system', siteIds: string[] | null, canRead = true) {
+  async function principal(scope: 'organization' | 'partner' | 'system', siteIds: string[] | null, canRead = true, readOnly = false) {
     const user = await createUser({ partnerId: partner.id, email: `${randomUUID()}@example.com` });
     const roleId = scope === 'organization'
       ? (canRead ? role.id : noRead.id)
-      : (canRead ? partnerRole.id : partnerNoRead.id);
+      : (canRead ? (readOnly ? partnerReader.id : partnerRole.id) : partnerNoRead.id);
     if (scope === 'organization') {
       await getTestDb().insert(organizationUsers).values({ userId: user.id, orgId: org.id, roleId, siteIds });
     } else {
@@ -238,6 +240,23 @@ describe('RMM-QA-221 site-scoped aggregate acceptance', () => {
     const f = await fixture();
     const denied = await f.principal(scope, null, false);
     expect((await request(`${statusPath}?partnerId=${f.partner.id}`, denied.token)).status).toBe(403);
+  });
+
+  it('a partner custom role with only devices:read can read summaries without an org grant', async () => {
+    const f = await fixture();
+    const reader = await f.principal('partner', null, true, true);
+    expect((await read(statusPath, reader.token)).summary.totalAgents).toBe(1);
+    expect((await read(overviewPath, reader.token)).total).toBe(1);
+    expect((await read(threatsPath, reader.token)).pagination.total).toBe(1);
+  });
+
+  it('moving a device to a denied site immediately removes its existing facts', async () => {
+    const f = await fixture();
+    expect((await read(statusPath, f.restricted.token)).summary.totalAgents).toBe(1);
+    await getTestDb().update(devices).set({ siteId: f.siteB.id }).where(eq(devices.id, f.allowed.id));
+    expect((await read(statusPath, f.restricted.token)).summary).toEqual(zeroSecurity);
+    expect(await read(overviewPath, f.restricted.token)).toEqual(zeroSoftware);
+    expect((await read(threatsPath, f.restricted.token)).data).toEqual([]);
   });
 
   it('unmapped organization status does not expose partner integration metadata', async () => {

--- a/apps/api/src/routes/sentinelOne.test.ts
+++ b/apps/api/src/routes/sentinelOne.test.ts
@@ -833,13 +833,7 @@ describe('sentinel one routes', () => {
       authState.scope = 'organization';
       authState.partnerId = PARTNER_ID;
 
-      vi.mocked(db.select).mockReturnValueOnce({
-        from: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({
-            limit: vi.fn().mockResolvedValue([])
-          })
-        })
-      } as any);
+      vi.mocked(getActiveS1IntegrationForOrg).mockResolvedValueOnce(null);
 
       const res = await app.request('/s1/status');
       expect(res.status).toBe(200);
@@ -856,37 +850,17 @@ describe('sentinel one routes', () => {
       authState.orgId = ORG_ID;
       authState.partnerId = PARTNER_ID;
 
-      // Integration found
-      vi.mocked(db.select).mockReturnValueOnce({
-        from: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({
-            limit: vi.fn().mockResolvedValue([{
-              id: INTEGRATION_ID,
-              partnerId: PARTNER_ID,
-              name: 'S1',
-              managementUrl: 'https://example.sentinelone.net',
-              isActive: true,
-              lastSyncAt: null,
-              lastSyncStatus: null,
-              lastSyncError: null,
-            }])
-          })
-        })
-      } as any);
-      // No mapping for this org
-      vi.mocked(db.select).mockReturnValueOnce({
-        from: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({
-            limit: vi.fn().mockResolvedValue([])
-          })
-        })
-      } as any);
+      // The org-authorized metadata helper requires a mapping before exposing
+      // the integration. No partner-axis route query or aggregate should run.
+      vi.mocked(getActiveS1IntegrationForOrg).mockResolvedValueOnce(null);
 
       const res = await app.request('/s1/status');
       expect(res.status).toBe(200);
       const body = await res.json();
-      expect(body.mapped).toBe(false);
+      expect(body.integration).toBeNull();
       expect(body.summary.totalAgents).toBe(0);
+      expect(getActiveS1IntegrationForOrg).toHaveBeenCalledWith(ORG_ID);
+      expect(db.select).not.toHaveBeenCalled();
     });
 
     it('partner scope returns cross-org coverage', async () => {

--- a/apps/api/src/routes/sentinelOne.ts
+++ b/apps/api/src/routes/sentinelOne.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { zValidator } from '../lib/validation';
 import { z } from 'zod';
-import { and, desc, eq, gte, inArray, isNull, lte, or, sql, type SQL } from 'drizzle-orm';
+import { and, desc, eq, gte, inArray, lte, or, sql, type SQL } from 'drizzle-orm';
 import { db } from '../db';
 import { devices, organizations, s1Actions, s1Agents, s1Integrations, s1OrgMappings, s1Threats } from '../db/schema';
 import { authMiddleware, requireMfa, requirePermission, requireScope, type AuthContext } from '../middleware/auth';
@@ -483,6 +483,7 @@ sentinelOneRoutes.post(
 sentinelOneRoutes.get(
   '/status',
   requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action),
   zValidator('query', statusQuerySchema),
   async (c) => {
     const auth = c.get('auth');
@@ -499,7 +500,12 @@ sentinelOneRoutes.get(
     }
     const scopedOrgId = orgResult && 'orgId' in orgResult ? orgResult.orgId : null;
 
-    const [integration] = await db
+    // The org-authorized helper reads only non-secret integration metadata
+    // across the partner RLS axis and confirms the org mapping. Device counts
+    // below remain in the caller's request context under forced RLS.
+    const integration = auth.scope === 'organization' && scopedOrgId
+      ? await getActiveS1IntegrationForOrg(scopedOrgId)
+      : (await db
       .select({
         id: s1Integrations.id,
         partnerId: s1Integrations.partnerId,
@@ -515,7 +521,7 @@ sentinelOneRoutes.get(
         eq(s1Integrations.partnerId, partnerResult.partnerId),
         eq(s1Integrations.isActive, true)
       ))
-      .limit(1);
+      .limit(1))[0];
 
     if (!integration) {
       return c.json({
@@ -532,8 +538,9 @@ sentinelOneRoutes.get(
       });
     }
 
-    // For org-scope callers, confirm the org is mapped before returning data
-    if (scopedOrgId) {
+    // The org helper already checked its mapping. Partner/system callers
+    // selecting an org must also confirm it belongs to this integration.
+    if (scopedOrgId && auth.scope !== 'organization') {
       const [mapping] = await db
         .select({ id: s1OrgMappings.id })
         .from(s1OrgMappings)
@@ -551,6 +558,8 @@ sentinelOneRoutes.get(
             mappedDevices: 0,
             infectedAgents: 0,
             activeThreats: 0,
+            highOrCriticalThreats: 0,
+            reportedThreatCount: 0,
             pendingActions: 0
           }
         });
@@ -572,6 +581,32 @@ sentinelOneRoutes.get(
       if (agentOrgCondition) agentConditions.push(agentOrgCondition);
       if (threatOrgCondition) threatConditions.push(threatOrgCondition);
       if (actionOrgCondition) actionConditions.push(actionOrgCondition);
+      // Actions have no integration FK; system orgCondition is unrestricted,
+      // so explicitly retain the selected partner axis for this component.
+      if (auth.scope === 'system') {
+        actionConditions.push(inArray(s1Actions.orgId, db
+          .select({ id: organizations.id })
+          .from(organizations)
+          .where(eq(organizations.partnerId, partnerResult.partnerId))));
+      }
+    }
+
+    const perms = c.get('permissions') as UserPermissions | undefined;
+    if (perms?.allowedSiteIds && scopedOrgId) {
+      if (perms.allowedSiteIds.length === 0) {
+        return c.json({ integration, mapped: true, summary: {
+          totalAgents: 0, mappedDevices: 0, infectedAgents: 0, activeThreats: 0,
+          highOrCriticalThreats: 0, pendingActions: 0, reportedThreatCount: 0,
+        } });
+      }
+      // Each security table has its own nullable device FK. SQL membership
+      // excludes unmapped rows and avoids materializing a fleet-sized ID list.
+      const siteDevices = db.select({ id: devices.id }).from(devices).where(and(
+        eq(devices.orgId, scopedOrgId), inArray(devices.siteId, perms.allowedSiteIds),
+      ));
+      agentConditions.push(inArray(s1Agents.deviceId, siteDevices));
+      threatConditions.push(inArray(s1Threats.deviceId, siteDevices));
+      actionConditions.push(inArray(s1Actions.deviceId, siteDevices));
     }
 
     const [agentSummary, threatSummary, actionSummary] = await Promise.all([
@@ -672,13 +707,11 @@ sentinelOneRoutes.get(
       if (query.deviceId && !allowedDeviceIds!.includes(query.deviceId)) {
         return c.json({ error: 'Device not found or access denied' }, 403);
       }
-      // s1_threats.device_id is nullable; keep non-device-bound threat rows
-      // visible (they carry no site to gate on).
-      conditions.push(
-        allowedDeviceIds && allowedDeviceIds.length > 0
-          ? (or(isNull(s1Threats.deviceId), inArray(s1Threats.deviceId, allowedDeviceIds)) as SQL)
-          : isNull(s1Threats.deviceId),
-      );
+      // Unmapped threats have no authorized site, matching /status counts.
+      if (!allowedDeviceIds?.length) {
+        return c.json({ data: [], pagination: { total: 0, limit: query.limit ?? 100, offset: query.offset ?? 0 } });
+      }
+      conditions.push(inArray(s1Threats.deviceId, allowedDeviceIds));
     }
 
     if (query.integrationId) conditions.push(eq(s1Threats.integrationId, query.integrationId));

--- a/apps/api/src/routes/softwarePolicies.ts
+++ b/apps/api/src/routes/softwarePolicies.ts
@@ -390,10 +390,17 @@ softwarePoliciesRoutes.post(
 
 softwarePoliciesRoutes.get('/compliance/overview', requireSoftwarePolicyRead, async (c) => {
   const auth = c.get('auth');
+  const perms = c.get('permissions') as UserPermissions | undefined;
 
   const conditions: SQL[] = [];
   const orgCondition = auth.orgCondition(devices.orgId);
   if (orgCondition) conditions.push(orgCondition);
+  if (perms?.allowedSiteIds && auth.orgId) {
+    if (perms.allowedSiteIds.length === 0) {
+      return c.json({ total: 0, compliant: 0, violations: 0, unknown: 0 });
+    }
+    conditions.push(inArray(devices.siteId, perms.allowedSiteIds));
+  }
 
   const worstStatusSq = db
     .select({

--- a/docs/superpowers/plans/security-auth/2026-09-06-qa-221-site-summaries.md
+++ b/docs/superpowers/plans/security-auth/2026-09-06-qa-221-site-summaries.md
@@ -14,10 +14,14 @@ The current schema differs from the brief: threats and actions have their own nu
 
 The sibling SentinelOne threats route currently retains NULL device rows even for an empty allowlist. Align this restricted list with the same direct-device scope predicate, preserving explicit denied-device rejection. Remove exactly the two relevant ratchet exemptions. No migration or external SentinelOne access is required.
 
+Real-database positive controls also exposed that organization status returns `integration: null` because direct partner-axis metadata queries are hidden by RLS. Reuse `getActiveS1IntegrationForOrg`: it first authorizes the organization under caller RLS, reads only non-secret metadata with a narrow system context, and requires the integration's organization mapping. All counts stay in caller context. An unmapped organization gets no integration metadata. The organization response uses this helper's minimal metadata shape (no management URL or credential material).
+
+The selected-partner system status also needs an explicit organization-partner fence on actions: unlike agents/threats, actions have no integration ID, and system `orgCondition` is intentionally unrestricted. This keeps every summary component within the selected partner.
+
 ## Executable verification plan
 
 1. Create a private stack with `pnpm test-stack up`; use Node from `.node-version` and verify the request pool is `breeze_app` with neither superuser nor BYPASSRLS.
 2. Add real-database mounted-route acceptance using real auth and custom roles. Seed allowed/denied sites, another organization/partner, NULL-mapped security rows, multiple software policies and statuses. Prove denied-site additions cannot change any summary, restricted-empty returns zeros and empty threats, and allowed rows remain visible. Exercise missing permission, cross-org selection, live site changes, unrestricted organization, partner and system roles.
-3. Run `caffeinate -i pnpm --filter @breeze/api exec vitest run --config vitest.integration.config.ts src/__tests__/integration/siteAggregateScope.integration.test.ts` against the private stack, plus site-scope and relevant RLS contracts. Confirm regression failures before handler edits.
+3. Run `caffeinate -i pnpm --filter @breeze/api exec vitest run --config vitest.integration.config.ts src/__tests__/integration/siteAggregateScope.integration.test.ts` against the private stack, plus relevant RLS contracts. Run the static ratchet separately with `pnpm --filter @breeze/api test:site-scope-coverage` (the database config intentionally excludes it). Confirm regression failures before handler edits.
 4. Run affected route unit suites, API typecheck and the required full API unit suite with at most two workers, coordinating heavy work with the other implementation worker.
 5. Obtain independent review of the exact commit, address findings, publish one draft PR and monitor exact-head CI. Stop at an open reviewed PR; no merge, deployment or finding closure.

--- a/docs/superpowers/plans/security-auth/2026-09-06-qa-221-site-summaries.md
+++ b/docs/superpowers/plans/security-auth/2026-09-06-qa-221-site-summaries.md
@@ -1,0 +1,23 @@
+# RMM-QA-221: site-scoped software and SentinelOne summaries
+
+Refs #4060. Implementation scope only; candidate verification and QA closure remain separate.
+
+## Evidence and design
+
+At base `0fc5464a858c9882d9c6ba138a2d79931d156720`, software-policy overview counts use only the organization predicate. SentinelOne status lacks `devices:read` and every count uses only organization scope. Both retain site-scope ratchet exemptions. The QA closure brief and backlog require denied-site facts to have no effect, restricted-empty counts to be zero, and mounted summaries to reconcile sibling lists.
+
+Apply `devices:read` to SentinelOne status, matching threats and software-policy reads. Existing partner/system role permission resolution remains authoritative. Narrow organization-context callers with an explicit site allowlist; preserve unrestricted callers, including partner/system roles with the required permission.
+
+Software overview adds the same device-site predicate as violations before grouping worst status per device. Empty allowlists return all-zero counts. Overview counts devices, while violations lists policy-device rows; parity means identical eligible devices, not equating totals when devices have multiple policies or non-violation status.
+
+The current schema differs from the brief: threats and actions have their own nullable `deviceId` and no agent foreign key. Use each table's direct device relationship and an organization/site-constrained device subquery. Exclude NULL/unmapped devices for restricted readers. Do not join through an invented agent relation or materialize a fleet-sized ID list for aggregate counts.
+
+The sibling SentinelOne threats route currently retains NULL device rows even for an empty allowlist. Align this restricted list with the same direct-device scope predicate, preserving explicit denied-device rejection. Remove exactly the two relevant ratchet exemptions. No migration or external SentinelOne access is required.
+
+## Executable verification plan
+
+1. Create a private stack with `pnpm test-stack up`; use Node from `.node-version` and verify the request pool is `breeze_app` with neither superuser nor BYPASSRLS.
+2. Add real-database mounted-route acceptance using real auth and custom roles. Seed allowed/denied sites, another organization/partner, NULL-mapped security rows, multiple software policies and statuses. Prove denied-site additions cannot change any summary, restricted-empty returns zeros and empty threats, and allowed rows remain visible. Exercise missing permission, cross-org selection, live site changes, unrestricted organization, partner and system roles.
+3. Run `caffeinate -i pnpm --filter @breeze/api exec vitest run --config vitest.integration.config.ts src/__tests__/integration/siteAggregateScope.integration.test.ts` against the private stack, plus site-scope and relevant RLS contracts. Confirm regression failures before handler edits.
+4. Run affected route unit suites, API typecheck and the required full API unit suite with at most two workers, coordinating heavy work with the other implementation worker.
+5. Obtain independent review of the exact commit, address findings, publish one draft PR and monitor exact-head CI. Stop at an open reviewed PR; no merge, deployment or finding closure.


### PR DESCRIPTION
## Summary

Site-restricted users now get software-compliance and SentinelOne totals derived only from devices in their allowed sites. Empty allowlists return zero, and unmapped SentinelOne threats are excluded from restricted lists to match the summary. SentinelOne status now requires `devices:read`.

Real-database acceptance also exposed two related defects: organization status could not resolve partner-owned integration metadata under RLS, and system status included other partners' pending actions. Status now uses the existing org-authorized metadata helper and fences actions to the selected partner. Credentials are never selected; count queries remain under request RLS. Unrestricted partner/system roles with valid grants retain access.

## Linked Issues

Refs #4060 — implements RMM-QA-221 product remediation. Candidate verification, scale/readiness measurements and formal QA closure remain outstanding. No migration is needed. Organization status returns the existing helper's minimal integration metadata shape; unmapped organizations receive no integration metadata.

## Type of Change

- [x] Bug fix

## Testing

- [x] 33 real PostgreSQL tests: 17 mounted JWT/RBAC aggregate acceptance cases plus existing software-policy and SentinelOne partner-RLS suites. Private stack with all 691 current migrations, verified `breeze_app` is neither superuser nor BYPASSRLS. Includes live membership/device-site changes and a devices:read-only partner role.
- [x] 89 affected route unit tests and 7 site-scope ratchet tests.
- [x] Regression tests demonstrated failures before implementation, including selected-partner system pending actions changing when another partner gained an action.
- [x] API typecheck (`NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @breeze/api exec tsc --noEmit`). Default-heap attempt exhausted memory; the explicit-heap run passed.
- [x] Full API unit suite: **35,782 passed, 21 skipped** across **1,920 passed, 3 skipped files**, terminal exit 0 in 808.61 seconds. Ran with command-scoped caffeinate, an 8 GiB Node heap and max two workers.
- [x] Independent review of `f06b245a41d928a63aa25f0cf4e089ae493cb298`: code, tests, errors, types, comments and simplification; no outstanding substantive findings. Reviewer inspected evidence but did not rerun suites.
- [x] Exact-head CI on `f06b245a41d928a63aa25f0cf4e089ae493cb298`: **66 checks succeeded, one expected Main Red Alert skip, no failures or pending checks**. [Core CI run](https://github.com/LanternOps/breeze/actions/runs/34052401656).

## Checklist

- [x] My code follows the project's code style
- [x] I have reviewed my own changes
- [x] I have tested on the relevant platforms (API/PostgreSQL)
- [x] No secrets, credentials, or personal data included

This PR stays draft and open for maintainer review. No merge, deployment or finding closure is part of this execution round.
