### PR TITLE
docs(config-policy): inheritance design spec + W01–W03 implementation plans (#5080)

### DIFF
--- a/docs/superpowers/plans/config-policy/2026-09-06-config-policy-inheritance-01-api-foundation.md
+++ b/docs/superpowers/plans/config-policy/2026-09-06-config-policy-inheritance-01-api-foundation.md
@@ -1,0 +1,908 @@
+# Config Policy Inheritance — W01 API Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist a validated, tenant-safe `parent_policy_id` on `configuration_policies`, ship the `config_policy_effective_feature_links` view, and expose the parent on the configuration-policy API, without yet switching any resolver.
+
+**Architecture:** One idempotent migration adds the column, self-FK, CHECK, partial index, a `SECURITY DEFINER` compatibility function, two deferrable constraint triggers, and the `security_invoker` view. The service validates the parent inside the insert transaction (friendly 400), the triggers are the authority (23514). `GET /:id` embeds the parent (assembled links, read through RLS, not through `policyAccessCondition`) and the children; a names-only `eligible-parents` endpoint feeds the create picker; delete of a parent with children is 409.
+
+**Tech Stack:** Hono, Drizzle ORM (`pgView(...).existing()`), PostgreSQL 16 (`security_invoker` views, constraint triggers), Vitest (unit with Drizzle mocks; integration against real Postgres via `apps/api/src/__tests__/integration/setup`).
+
+**Spec:** `docs/superpowers/specs/config-policy/2026-09-06-config-policy-inheritance-design.md`
+
+**Tracking:** feature issue and wave sub-issue numbers are added to this header by `register_feature` (feature-lifecycle). Branch: `feature/<parent#>-config-policy-inheritance/wave-<subissue#>`.
+
+## Global Constraints
+
+- Migration filename `2026-10-12-100000-config-policy-inheritance.sql`; before pushing, confirm it sorts after the newest file in `apps/api/migrations` on `origin/main` (`ls apps/api/migrations | sort | tail -1`), rename later in the day if not.
+- Migration is idempotent, contains **no DML**, no inner `BEGIN`/`COMMIT`.
+- FK on `parent_policy_id` is the default `NO ACTION`. Not `RESTRICT`, not `SET NULL`.
+- `parent_policy_id` is immutable after insert (any change, including `NULL → value`, is rejected). Ownership (`org_id`, `partner_id`) changes are rejected unless `public.breeze_current_scope() = 'system'`.
+- Ownership rule: org child → parent in the same org **or** partner-wide of the org's partner; partner-wide child → partner-wide parent of the same partner. Parent must have `parent_policy_id IS NULL`. `parent.id <> child.id`.
+- View is `WITH (security_invoker = true)`, granted `SELECT` to `breeze_app`, declared in Drizzle with `.existing()`. An inherited row keeps the **parent link's `id`**.
+- Error codes: `400 { error: 'INVALID_PARENT_POLICY' }`, `409 { error: 'POLICY_HAS_CHILDREN', children: [{ id, name }] }`, `403 { error: 'MFA required' }`.
+- `policyAccessCondition` is **not** relaxed. The parent embed and the eligible-parents list are the only new read paths, both read-only.
+- Every task: red test first, `pnpm --filter @breeze/api exec tsc --noEmit`, targeted tests, commit. Before the PR: the live-DB suites listed in Task 12.
+
+---
+
+### Task 1: Migration — column, FK, CHECK, index, compatibility function, constraint triggers, view
+
+**Files:**
+- Create: `apps/api/migrations/2026-10-12-100000-config-policy-inheritance.sql`
+- Test: `apps/api/src/db/autoMigrate.test.ts` (existing, auto-discovers), `apps/api/src/db/migrationRlsScope.test.ts` (existing, must stay green: no DML)
+
+**Interfaces:**
+- Produces: column `configuration_policies.parent_policy_id uuid NULL`; constraints `configuration_policies_parent_policy_id_fkey`, `configuration_policies_not_own_parent_chk`; index `config_policies_parent_policy_id_idx`; function `public.breeze_config_policy_parent_compatible(child_org uuid, child_partner uuid, parent_org uuid, parent_partner uuid) RETURNS boolean`; constraint names raised by the triggers: `configuration_policies_parent_immutable`, `configuration_policies_owner_immutable`, `configuration_policies_parent_guard`, `organizations_partner_config_policy_guard`; view `public.config_policy_effective_feature_links` with columns `id, config_policy_id, source_policy_id, feature_type, feature_policy_id, inline_settings, created_at, updated_at, inherited`.
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- Configuration policy inheritance (spec: docs/superpowers/specs/config-policy/
+-- 2026-09-06-config-policy-inheritance-design.md).
+--
+-- 1. `configuration_policies.parent_policy_id` — one-level, create-only parent.
+-- 2. Ownership rule enforced by a DEFERRABLE constraint trigger (org merge runs
+--    SET CONSTRAINTS ALL DEFERRED and re-points parent and child in separate
+--    statements; validation therefore happens at commit).
+-- 3. `config_policy_effective_feature_links` — the child's own links plus the
+--    parent's links for feature types the child lacks. security_invoker so the
+--    base tables' RLS (incl. the *_partner_wide_select branches) applies to the
+--    caller. An inherited row keeps the PARENT link's id: the normalized
+--    per-feature settings tables are keyed by feature_link_id.
+--
+-- No DML, so no breeze.scope election. Idempotent.
+
+ALTER TABLE public.configuration_policies
+  ADD COLUMN IF NOT EXISTS parent_policy_id uuid;
+
+ALTER TABLE public.configuration_policies
+  DROP CONSTRAINT IF EXISTS configuration_policies_parent_policy_id_fkey;
+ALTER TABLE public.configuration_policies
+  ADD CONSTRAINT configuration_policies_parent_policy_id_fkey
+  FOREIGN KEY (parent_policy_id) REFERENCES public.configuration_policies(id);
+
+ALTER TABLE public.configuration_policies
+  DROP CONSTRAINT IF EXISTS configuration_policies_not_own_parent_chk;
+ALTER TABLE public.configuration_policies
+  ADD CONSTRAINT configuration_policies_not_own_parent_chk
+  CHECK (parent_policy_id IS NULL OR parent_policy_id <> id);
+
+CREATE INDEX IF NOT EXISTS config_policies_parent_policy_id_idx
+  ON public.configuration_policies (parent_policy_id)
+  WHERE parent_policy_id IS NOT NULL;
+
+-- Ownership compatibility. SECURITY DEFINER like breeze_guard_pam_device_org_move:
+-- the RULE rejects cross-tenant edges; the service layer masks "not found".
+CREATE OR REPLACE FUNCTION public.breeze_config_policy_parent_compatible(
+  child_org uuid, child_partner uuid, parent_org uuid, parent_partner uuid
+) RETURNS boolean
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $$
+  SELECT CASE
+    WHEN child_org IS NOT NULL THEN
+      parent_org = child_org
+      OR (parent_org IS NULL AND parent_partner IS NOT NULL
+          AND parent_partner = (SELECT o.partner_id FROM public.organizations o WHERE o.id = child_org))
+    WHEN child_partner IS NOT NULL THEN
+      parent_org IS NULL AND parent_partner = child_partner
+    ELSE false
+  END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.breeze_config_policy_parent_guard()
+RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $$
+DECLARE
+  p RECORD;
+BEGIN
+  IF TG_OP = 'UPDATE' THEN
+    IF NEW.parent_policy_id IS DISTINCT FROM OLD.parent_policy_id THEN
+      RAISE EXCEPTION USING ERRCODE = '23514',
+        CONSTRAINT = 'configuration_policies_parent_immutable',
+        MESSAGE = 'configuration policy parent is set at create time and cannot change';
+    END IF;
+    IF (NEW.org_id IS DISTINCT FROM OLD.org_id OR NEW.partner_id IS DISTINCT FROM OLD.partner_id)
+       AND public.breeze_current_scope() <> 'system' THEN
+      RAISE EXCEPTION USING ERRCODE = '23514',
+        CONSTRAINT = 'configuration_policies_owner_immutable',
+        MESSAGE = 'configuration policy ownership can only change in system context';
+    END IF;
+  END IF;
+
+  -- Outgoing edge: this row's parent.
+  IF NEW.parent_policy_id IS NOT NULL THEN
+    SELECT org_id, partner_id, parent_policy_id INTO p
+      FROM public.configuration_policies WHERE id = NEW.parent_policy_id;
+    IF NOT FOUND
+       OR p.parent_policy_id IS NOT NULL
+       OR NOT public.breeze_config_policy_parent_compatible(NEW.org_id, NEW.partner_id, p.org_id, p.partner_id) THEN
+      RAISE EXCEPTION USING ERRCODE = '23514',
+        CONSTRAINT = 'configuration_policies_parent_guard',
+        MESSAGE = 'parent configuration policy not found or not eligible';
+    END IF;
+  END IF;
+
+  -- Incoming edges: rows that name this row as parent (ownership moves, one level).
+  IF TG_OP = 'UPDATE' THEN
+    IF NEW.parent_policy_id IS NOT NULL
+       AND EXISTS (SELECT 1 FROM public.configuration_policies c WHERE c.parent_policy_id = NEW.id) THEN
+      RAISE EXCEPTION USING ERRCODE = '23514',
+        CONSTRAINT = 'configuration_policies_parent_guard',
+        MESSAGE = 'a configuration policy with children cannot have a parent';
+    END IF;
+    IF EXISTS (
+      SELECT 1 FROM public.configuration_policies c
+       WHERE c.parent_policy_id = NEW.id
+         AND NOT public.breeze_config_policy_parent_compatible(c.org_id, c.partner_id, NEW.org_id, NEW.partner_id)
+    ) THEN
+      RAISE EXCEPTION USING ERRCODE = '23514',
+        CONSTRAINT = 'configuration_policies_parent_guard',
+        MESSAGE = 'ownership change would orphan child configuration policies';
+    END IF;
+  END IF;
+
+  RETURN NULL;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS configuration_policies_parent_guard ON public.configuration_policies;
+CREATE CONSTRAINT TRIGGER configuration_policies_parent_guard
+  AFTER INSERT OR UPDATE OF parent_policy_id, org_id, partner_id
+  ON public.configuration_policies
+  DEFERRABLE INITIALLY IMMEDIATE
+  FOR EACH ROW EXECUTE FUNCTION public.breeze_config_policy_parent_guard();
+
+-- An org changing partner would orphan its children of partner-wide parents.
+-- No code path does this today; the guard keeps the invariant independent of that.
+CREATE OR REPLACE FUNCTION public.breeze_config_policy_org_partner_guard()
+RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $$
+BEGIN
+  IF NEW.partner_id IS DISTINCT FROM OLD.partner_id AND EXISTS (
+    SELECT 1
+      FROM public.configuration_policies c
+      JOIN public.configuration_policies p ON p.id = c.parent_policy_id
+     WHERE c.org_id = NEW.id
+       AND p.org_id IS NULL
+       AND p.partner_id IS DISTINCT FROM NEW.partner_id
+  ) THEN
+    RAISE EXCEPTION USING ERRCODE = '23514',
+      CONSTRAINT = 'organizations_partner_config_policy_guard',
+      MESSAGE = 'organization partner change would orphan child configuration policies';
+  END IF;
+  RETURN NULL;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS organizations_partner_config_policy_guard ON public.organizations;
+CREATE CONSTRAINT TRIGGER organizations_partner_config_policy_guard
+  AFTER UPDATE OF partner_id ON public.organizations
+  DEFERRABLE INITIALLY IMMEDIATE
+  FOR EACH ROW EXECUTE FUNCTION public.breeze_config_policy_org_partner_guard();
+
+CREATE OR REPLACE VIEW public.config_policy_effective_feature_links
+  WITH (security_invoker = true) AS
+  SELECT l.id, l.config_policy_id, l.config_policy_id AS source_policy_id,
+         l.feature_type, l.feature_policy_id, l.inline_settings, l.created_at, l.updated_at,
+         false AS inherited
+    FROM public.config_policy_feature_links l
+  UNION ALL
+  SELECT pl.id, c.id AS config_policy_id, pl.config_policy_id AS source_policy_id,
+         pl.feature_type, pl.feature_policy_id, pl.inline_settings, pl.created_at, pl.updated_at,
+         true AS inherited
+    FROM public.configuration_policies c
+    JOIN public.config_policy_feature_links pl ON pl.config_policy_id = c.parent_policy_id
+   WHERE c.parent_policy_id IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1 FROM public.config_policy_feature_links own
+        WHERE own.config_policy_id = c.id AND own.feature_type = pl.feature_type
+     );
+
+GRANT SELECT ON public.config_policy_effective_feature_links TO breeze_app;
+```
+
+- [ ] **Step 2: Run the migration guards**
+
+Run: `cd apps/api && npx vitest run src/db/autoMigrate.test.ts src/db/migrationRlsScope.test.ts`
+Expected: PASS (the file sorts last; no DML so the scope guard has nothing to flag).
+
+Run: `bash scripts/check-migration-naming.sh --against-ref origin/main`
+Expected: `check-migration-naming: OK`.
+
+- [ ] **Step 3: Apply to a local database and replay**
+
+Run (with the wt-stack or test-stack Postgres up, `DATABASE_URL` set): `pnpm db:migrate && pnpm db:migrate`
+Expected: second run is a no-op (no errors, `NOTICE`s at most).
+
+Run: `pnpm db:check-drift`
+Expected: passes. If it reports the view, fix `apps/api/scripts/check-drift.ts` to ignore `relkind = 'v'`; never remove the view from the migration.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/migrations/2026-10-12-100000-config-policy-inheritance.sql
+git commit -m "feat(config-policy): parent_policy_id + effective-links view migration"
+```
+
+---
+
+### Task 2: Drizzle schema — column, self-reference, existing view
+
+**Files:**
+- Modify: `apps/api/src/db/schema/configurationPolicies.ts:1-16` (imports), `:70-86` (table), append view after `configPolicyFeatureLinks`
+- Test: `apps/api/src/db/schema/configurationPolicies.inheritance.test.ts` (create)
+
+**Interfaces:**
+- Produces: `configurationPolicies.parentPolicyId` (nullable uuid column); `export const configPolicyEffectiveFeatureLinks` (pgView, `.existing()`), columns `id, configPolicyId, sourcePolicyId, featureType, featurePolicyId, inlineSettings, createdAt, updatedAt, inherited`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// apps/api/src/db/schema/configurationPolicies.inheritance.test.ts
+import { describe, expect, it } from 'vitest';
+import { getTableColumns, getViewSelectedFields } from 'drizzle-orm';
+import { configurationPolicies, configPolicyEffectiveFeatureLinks } from './configurationPolicies';
+
+describe('configuration policy inheritance schema', () => {
+  it('declares parent_policy_id as a nullable uuid', () => {
+    const col = getTableColumns(configurationPolicies).parentPolicyId;
+    expect(col.name).toBe('parent_policy_id');
+    expect(col.notNull).toBe(false);
+  });
+
+  it('declares the effective-links view with the contract columns', () => {
+    const fields = getViewSelectedFields(configPolicyEffectiveFeatureLinks);
+    expect(Object.keys(fields).sort()).toEqual([
+      'configPolicyId', 'createdAt', 'featurePolicyId', 'featureType', 'id',
+      'inherited', 'inlineSettings', 'sourcePolicyId', 'updatedAt',
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/api && npx vitest run src/db/schema/configurationPolicies.inheritance.test.ts`
+Expected: FAIL — `configPolicyEffectiveFeatureLinks` is not exported / `parentPolicyId` undefined.
+
+- [ ] **Step 3: Implement**
+
+In the import block add `pgView` and `type AnyPgColumn` to the `drizzle-orm/pg-core` import. In the `configurationPolicies` table, after `partnerId`:
+
+```ts
+  // One-level, create-only parent (config-policy inheritance). Lazy
+  // `(): AnyPgColumn =>` self-reference, same pattern as aiAgents.scheduleId.
+  // Default FK action (NO ACTION): a parent with children cannot be deleted
+  // alone; org cascade deletes parent and children in one statement.
+  parentPolicyId: uuid('parent_policy_id').references((): AnyPgColumn => configurationPolicies.id),
+```
+
+and in the index callback: `parentPolicyIdIdx: index('config_policies_parent_policy_id_idx').on(table.parentPolicyId).where(sql\`${table.parentPolicyId} IS NOT NULL\`),`.
+
+After `configPolicyFeatureLinks`:
+
+```ts
+// The child's own feature links plus the parent's links for feature types the
+// child has no link of its own. Managed by migration
+// 2026-10-12-100000-config-policy-inheritance.sql (security_invoker), hence
+// `.existing()` — drizzle-kit never touches it. `id` is the UNDERLYING link id:
+// an inherited row keeps the parent link's id so joins on
+// config_policy_*_settings.feature_link_id keep working. Resolvers, agent
+// delivery, and workers read THIS; link CRUD keeps reading
+// configPolicyFeatureLinks (contract test: services/featureLinkReaders.contract.test.ts, W02).
+export const configPolicyEffectiveFeatureLinks = pgView('config_policy_effective_feature_links', {
+  id: uuid('id').notNull(),
+  configPolicyId: uuid('config_policy_id').notNull(),
+  sourcePolicyId: uuid('source_policy_id').notNull(),
+  featureType: configFeatureTypeEnum('feature_type').notNull(),
+  featurePolicyId: uuid('feature_policy_id'),
+  inlineSettings: jsonb('inline_settings'),
+  createdAt: timestamp('created_at').notNull(),
+  updatedAt: timestamp('updated_at').notNull(),
+  inherited: boolean('inherited').notNull(),
+}).existing();
+```
+
+- [ ] **Step 4: Run the test and typecheck**
+
+Run: `cd apps/api && npx vitest run src/db/schema/configurationPolicies.inheritance.test.ts && npx tsc --noEmit`
+Expected: PASS, no type errors. If `getViewSelectedFields` is not exported by the installed drizzle version, assert on `Object.keys(configPolicyEffectiveFeatureLinks)` filtered to the nine column names instead.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/db/schema/configurationPolicies.ts apps/api/src/db/schema/configurationPolicies.inheritance.test.ts
+git commit -m "feat(config-policy): schema — parentPolicyId column + existing effective-links view"
+```
+
+---
+
+### Task 3: Ownership compatibility helper + error classes
+
+**Files:**
+- Modify: `apps/api/src/services/configPolicyOwnership.ts` (append)
+- Test: `apps/api/src/services/configPolicyOwnership.test.ts` (existing file; append a describe)
+
+**Interfaces:**
+- Produces:
+  ```ts
+  export type PolicyOwnerRef = { orgId: string | null; partnerId: string | null };
+  export function isCompatibleParent(
+    child: PolicyOwnerRef & { orgPartnerId: string | null },
+    parent: PolicyOwnerRef & { parentPolicyId: string | null; id: string },
+    childId?: string,
+  ): boolean;
+  export class InvalidParentPolicyError extends Error { readonly code = 'INVALID_PARENT_POLICY' }
+  export class PolicyHasChildrenError extends Error {
+    readonly code = 'POLICY_HAS_CHILDREN';
+    constructor(public readonly children: { id: string; name: string }[]) { ... }
+  }
+  ```
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+describe('isCompatibleParent', () => {
+  const P = 'partner-1', O = 'org-1', O2 = 'org-2';
+  const root = (o: string | null, p: string | null, id = 'parent') => ({ id, orgId: o, partnerId: p, parentPolicyId: null });
+  it.each([
+    ['org child ← same-org parent', { orgId: O, partnerId: null, orgPartnerId: P }, root(O, null), true],
+    ['org child ← partner-wide parent of own partner', { orgId: O, partnerId: null, orgPartnerId: P }, root(null, P), true],
+    ['org child ← other-org parent', { orgId: O, partnerId: null, orgPartnerId: P }, root(O2, null), false],
+    ['org child ← other partner-wide', { orgId: O, partnerId: null, orgPartnerId: P }, root(null, 'partner-2'), false],
+    ['partner child ← same partner-wide', { orgId: null, partnerId: P, orgPartnerId: null }, root(null, P), true],
+    ['partner child ← org parent', { orgId: null, partnerId: P, orgPartnerId: null }, root(O, null), false],
+    ['parent that has a parent', { orgId: O, partnerId: null, orgPartnerId: P }, { ...root(O, null), parentPolicyId: 'grand' }, false],
+  ])('%s → %s', (_n, child, parent, expected) => {
+    expect(isCompatibleParent(child, parent)).toBe(expected);
+  });
+  it('rejects self-parenting', () => {
+    expect(isCompatibleParent({ orgId: O, partnerId: null, orgPartnerId: P }, root(O, null, 'me'), 'me')).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/api && npx vitest run src/services/configPolicyOwnership.test.ts`
+Expected: FAIL — `isCompatibleParent` is not a function.
+
+- [ ] **Step 3: Implement**
+
+```ts
+export type PolicyOwnerRef = { orgId: string | null; partnerId: string | null };
+
+/** Mirror of public.breeze_config_policy_parent_compatible (migration 2026-10-12-100000). */
+export function isCompatibleParent(
+  child: PolicyOwnerRef & { orgPartnerId: string | null },
+  parent: PolicyOwnerRef & { parentPolicyId: string | null; id: string },
+  childId?: string,
+): boolean {
+  if (childId && parent.id === childId) return false;
+  if (parent.parentPolicyId !== null) return false; // one level
+  if (child.orgId) {
+    return parent.orgId === child.orgId
+      || (parent.orgId === null && parent.partnerId !== null && parent.partnerId === child.orgPartnerId);
+  }
+  if (child.partnerId) return parent.orgId === null && parent.partnerId === child.partnerId;
+  return false;
+}
+
+export class InvalidParentPolicyError extends Error {
+  readonly code = 'INVALID_PARENT_POLICY' as const;
+  constructor() { super('Parent configuration policy not found or not eligible'); this.name = 'InvalidParentPolicyError'; }
+}
+
+export class PolicyHasChildrenError extends Error {
+  readonly code = 'POLICY_HAS_CHILDREN' as const;
+  constructor(public readonly children: { id: string; name: string }[]) {
+    super('Configuration policy has child policies that inherit from it');
+    this.name = 'PolicyHasChildrenError';
+  }
+}
+```
+
+- [ ] **Step 4: Run and commit**
+
+Run: `cd apps/api && npx vitest run src/services/configPolicyOwnership.test.ts` → PASS.
+
+```bash
+git add apps/api/src/services/configPolicyOwnership.ts apps/api/src/services/configPolicyOwnership.test.ts
+git commit -m "feat(config-policy): isCompatibleParent + inheritance error classes"
+```
+
+---
+
+### Task 4: Shared validator — `parentPolicyId` on create only
+
+**Files:**
+- Modify: `packages/shared/src/validators/index.ts:528-544`
+- Test: `packages/shared/src/validators/configPolicy.test.ts` (create if no existing test covers `createConfigPolicySchema`; otherwise append)
+
+- [ ] **Step 1: Failing test**
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { createConfigPolicySchema, updateConfigPolicySchema } from './index';
+
+describe('config policy inheritance validators', () => {
+  it('accepts an optional guid parentPolicyId on create', () => {
+    const ok = createConfigPolicySchema.safeParse({ name: 'child', parentPolicyId: '0b8f2c1e-1111-4a2b-9c3d-000000000001' });
+    expect(ok.success).toBe(true);
+    expect(createConfigPolicySchema.safeParse({ name: 'child', parentPolicyId: 'nope' }).success).toBe(false);
+  });
+  it('update schema strips/rejects parentPolicyId (immutable)', () => {
+    const parsed = updateConfigPolicySchema.parse({ name: 'x', parentPolicyId: '0b8f2c1e-1111-4a2b-9c3d-000000000001' } as never);
+    expect('parentPolicyId' in parsed).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run → FAIL** (`cd packages/shared && npx vitest run src/validators/configPolicy.test.ts`).
+
+- [ ] **Step 3: Implement** — add to `createConfigPolicySchema`:
+
+```ts
+  // One-level, create-only inheritance. Validated server-side against the
+  // ownership rule (same org, or partner-wide of the org's partner). Absent from
+  // updateConfigPolicySchema on purpose: parent_policy_id is immutable.
+  parentPolicyId: z.string().guid().optional(),
+```
+
+`updateConfigPolicySchema` is unchanged (zod objects strip unknown keys by default; the test asserts that).
+
+- [ ] **Step 4: Run → PASS; commit**
+
+```bash
+git add packages/shared/src/validators/index.ts packages/shared/src/validators/configPolicy.test.ts
+git commit -m "feat(shared): parentPolicyId on createConfigPolicySchema"
+```
+
+---
+
+### Task 5: Service — create with parent validation, delete 409, parent/children embeds, eligible parents
+
+**Files:**
+- Modify: `apps/api/src/services/configurationPolicy.ts` — `createConfigPolicy` (:234-252), `getConfigPolicy` (:254-273), `listConfigPolicies` (:275+, ensure `parentPolicyId` is in each row), `deleteConfigPolicy` (:411-433); add `listEligibleParentPolicies`, `getParentLinkFeatureTypes`
+- Test: `apps/api/src/services/configurationPolicy.inheritance.test.ts` (create; Drizzle mock pattern from `configurationPolicy.test.ts`)
+
+**Interfaces:**
+- Consumes: Task 3 helpers/errors; Task 2 column.
+- Produces:
+  ```ts
+  createConfigPolicy(owner, data: { name; description?; status?; parentPolicyId?: string }, userId)
+  getConfigPolicy(id, auth) → { ...policy, parentPolicyId, featureLinks,
+      parentPolicy: { id, name, status, orgId, featureLinks } | null, childPolicies: { id, name }[] }
+  listEligibleParentPolicies(auth, sel: { ownerScope: 'organization'; orgId: string } | { ownerScope: 'partner' })
+      → { id: string; name: string; ownerScope: 'organization' | 'partner' }[]
+  getParentLinkFeatureTypes(parentId: string) → string[]        // RLS read, no access condition
+  deleteConfigPolicy(id, auth)  // throws PolicyHasChildrenError
+  ```
+
+- [ ] **Step 1: Failing tests** (mock `db` per the existing file's pattern; assert on behaviour, not SQL text)
+
+```ts
+describe('createConfigPolicy with parentPolicyId', () => {
+  it('inserts parentPolicyId when the parent is compatible', async () => { /* parent row: same org, parentPolicyId null → insert values include parentPolicyId */ });
+  it('throws InvalidParentPolicyError when the parent is not visible', async () => { /* select returns [] */ });
+  it('throws InvalidParentPolicyError when the parent belongs to another org', async () => {});
+  it('throws InvalidParentPolicyError when the parent itself has a parent', async () => {});
+  it('maps a 23503 on configuration_policies_parent_policy_id_fkey to InvalidParentPolicyError', async () => { /* insert rejects with {code:'23503', constraint_name:'configuration_policies_parent_policy_id_fkey'} */ });
+});
+describe('deleteConfigPolicy', () => {
+  it('throws PolicyHasChildrenError listing children before deleting', async () => {});
+  it('maps a 23503 on the self-FK to PolicyHasChildrenError', async () => {});
+});
+describe('getConfigPolicy', () => {
+  it('embeds parentPolicy with assembled links and childPolicies', async () => {});
+  it('returns parentPolicy null and childPolicies [] for a root policy', async () => {});
+});
+describe('listEligibleParentPolicies', () => {
+  it('organization scope: root policies of that org plus partner-wide of its partner', async () => {});
+  it('partner scope: root partner-wide policies of the caller partner only', async () => {});
+});
+```
+
+Fill each body with the mock chain the existing `configurationPolicy.test.ts` uses (`vi.mock('../db')` + `mockDb.select.mockReturnValueOnce(chain([...]))`); the assertions are: `insert(...).values` receives `parentPolicyId`; the right error class is thrown; the returned object has the fields above.
+
+- [ ] **Step 2: Run → FAIL** (`cd apps/api && npx vitest run src/services/configurationPolicy.inheritance.test.ts`).
+
+- [ ] **Step 3: Implement**
+
+`createConfigPolicy`:
+
+```ts
+export async function createConfigPolicy(
+  owner: { orgId: string; partnerId?: null } | { orgId?: null; partnerId: string },
+  data: { name: string; description?: string; status?: 'active' | 'inactive' | 'archived'; parentPolicyId?: string },
+  userId: string
+) {
+  return db.transaction(async (tx) => {
+    if (data.parentPolicyId) {
+      // Read through the caller's RLS context (an org token sees a partner-wide
+      // parent via configuration_policies_partner_wide_select). No row lock: a
+      // FOR KEY SHARE would apply the UPDATE policy, which that branch does not
+      // satisfy; the FK closes the delete race (23503 → same 400 below).
+      const [parent] = await tx
+        .select({ id: configurationPolicies.id, orgId: configurationPolicies.orgId,
+                  partnerId: configurationPolicies.partnerId, parentPolicyId: configurationPolicies.parentPolicyId })
+        .from(configurationPolicies)
+        .where(eq(configurationPolicies.id, data.parentPolicyId))
+        .limit(1);
+      let orgPartnerId: string | null = null;
+      if (owner.orgId) {
+        const [org] = await tx.select({ partnerId: organizations.partnerId })
+          .from(organizations).where(eq(organizations.id, owner.orgId)).limit(1);
+        orgPartnerId = org?.partnerId ?? null;
+      }
+      if (!parent || !isCompatibleParent(
+        { orgId: owner.orgId ?? null, partnerId: owner.partnerId ?? null, orgPartnerId }, parent)) {
+        throw new InvalidParentPolicyError();
+      }
+    }
+    try {
+      const [policy] = await tx.insert(configurationPolicies).values({
+        orgId: owner.orgId ?? null, partnerId: owner.partnerId ?? null,
+        name: data.name, description: data.description ?? null,
+        status: data.status ?? 'active', createdBy: userId,
+        parentPolicyId: data.parentPolicyId ?? null,
+      }).returning();
+      if (!policy) throw new Error('Failed to create configuration policy');
+      return policy;
+    } catch (err) {
+      const code = pgErrorCode(err);
+      const constraint = String((pgErrorNode(err) as { constraint_name?: string } | undefined)?.constraint_name ?? '');
+      if ((code === '23503' && constraint === 'configuration_policies_parent_policy_id_fkey')
+          || (code === '23514' && constraint.startsWith('configuration_policies_parent'))) {
+        throw new InvalidParentPolicyError();
+      }
+      throw err;
+    }
+  });
+}
+```
+
+(`pgErrorCode` / `pgErrorNode` come from `../utils/pgErrors`. If `pgErrorNode` does not expose `constraint_name` for Drizzle-wrapped errors, extend it there the way `isPgUniqueViolation` reads the constraint — do not hand-roll a second walker.)
+
+`getConfigPolicy` — after `featureLinks`:
+
+```ts
+  let parentPolicy: { id: string; name: string; status: string; orgId: string | null; featureLinks: Awaited<ReturnType<typeof listFeatureLinks>> } | null = null;
+  if (policy.parentPolicyId) {
+    // Deliberately NOT through policyAccessCondition: that gate hides partner-wide
+    // policies from org-scoped get/list so the org UI never offers to EDIT the
+    // MSP's shared policies. This embed is read-only, exists only for a policy the
+    // caller can already see, and the parent's rows are already SELECT-visible
+    // under RLS (the same visibility the agent path relies on).
+    const [parent] = await db.select({ id: configurationPolicies.id, name: configurationPolicies.name,
+                                       status: configurationPolicies.status, orgId: configurationPolicies.orgId })
+      .from(configurationPolicies).where(eq(configurationPolicies.id, policy.parentPolicyId)).limit(1);
+    if (parent) parentPolicy = { ...parent, featureLinks: await listFeatureLinks(parent.id) };
+  }
+  const childPolicies = await db.select({ id: configurationPolicies.id, name: configurationPolicies.name })
+    .from(configurationPolicies).where(eq(configurationPolicies.parentPolicyId, id)).orderBy(asc(configurationPolicies.name));
+  return { ...policy, featureLinks, parentPolicy, childPolicies };
+```
+
+`listConfigPolicies`: confirm the row select includes `parentPolicyId` (it uses `getTableColumns` or an explicit list — if explicit, add `parentPolicyId: configurationPolicies.parentPolicyId`).
+
+`deleteConfigPolicy` — between the ownership gate and the delete:
+
+```ts
+  const children = await db.select({ id: configurationPolicies.id, name: configurationPolicies.name })
+    .from(configurationPolicies).where(eq(configurationPolicies.parentPolicyId, id));
+  if (children.length > 0) throw new PolicyHasChildrenError(children);
+  try {
+    const [deleted] = await db.delete(configurationPolicies).where(and(...conditions)).returning();
+    return deleted ?? null;
+  } catch (err) {
+    if (pgErrorCode(err) === '23503') throw new PolicyHasChildrenError([]); // race: child created after the check
+    throw err;
+  }
+```
+
+New functions:
+
+```ts
+export async function listEligibleParentPolicies(
+  auth: AuthContext,
+  sel: { ownerScope: 'organization'; orgId: string } | { ownerScope: 'partner' },
+): Promise<{ id: string; name: string; ownerScope: 'organization' | 'partner' }[]> {
+  const rootOnly = isNull(configurationPolicies.parentPolicyId);
+  let where: SQL;
+  if (sel.ownerScope === 'partner') {
+    if (!auth.partnerId) return [];
+    where = and(rootOnly, isNull(configurationPolicies.orgId), eq(configurationPolicies.partnerId, auth.partnerId))!;
+  } else {
+    const [org] = await db.select({ partnerId: organizations.partnerId }).from(organizations)
+      .where(eq(organizations.id, sel.orgId)).limit(1);
+    const own = eq(configurationPolicies.orgId, sel.orgId);
+    where = org?.partnerId
+      ? and(rootOnly, or(own, and(isNull(configurationPolicies.orgId), eq(configurationPolicies.partnerId, org.partnerId))))!
+      : and(rootOnly, own)!;
+  }
+  // Names only. RLS is the visibility authority here (an org token sees its
+  // partner's partner-wide rows through the SELECT-only branch); the app-layer
+  // filter above narrows to the ownership rule.
+  const rows = await db.select({ id: configurationPolicies.id, name: configurationPolicies.name, orgId: configurationPolicies.orgId })
+    .from(configurationPolicies).where(where).orderBy(asc(configurationPolicies.name));
+  return rows.map(r => ({ id: r.id, name: r.name, ownerScope: r.orgId === null ? 'partner' : 'organization' }));
+}
+
+/** Feature types linked on a prospective parent (RLS read). Used by the MFA-by-effectiveness gate. */
+export async function getParentLinkFeatureTypes(parentId: string): Promise<string[]> {
+  const rows = await db.select({ featureType: configPolicyFeatureLinks.featureType })
+    .from(configPolicyFeatureLinks).where(eq(configPolicyFeatureLinks.configPolicyId, parentId));
+  return rows.map(r => r.featureType);
+}
+```
+
+- [ ] **Step 4: Run → PASS; typecheck; commit**
+
+```bash
+git add apps/api/src/services/configurationPolicy.ts apps/api/src/services/configurationPolicy.inheritance.test.ts
+git commit -m "feat(config-policy): service — parent validation, 409 on children, parent/children embeds, eligible parents"
+```
+
+---
+
+### Task 6: Routes — POST with parent (+ MFA gate), DELETE 409, GET embeds, eligible-parents endpoint
+
+**Files:**
+- Modify: `apps/api/src/routes/configurationPolicies/crud.ts` (POST :52-152, DELETE :212-244; add `GET /eligible-parents` **before** `GET /:id`)
+- Modify: `apps/api/src/routes/configurationPolicies/schemas.ts` (add `eligibleParentsQuerySchema`)
+- Test: `apps/api/src/routes/configurationPolicies/crud.test.ts` (append)
+
+**Interfaces:**
+- Consumes: Task 5 service functions and errors; `hasSatisfiedMfa` from `../../middleware/auth`; `MFA_GATED_FEATURE_TYPES` from `./featureLinks`.
+- Produces: `GET /configuration-policies/eligible-parents?ownerScope=organization&orgId=<uuid>` | `?ownerScope=partner` → `{ data: { id, name, ownerScope }[] }`.
+
+- [ ] **Step 1: Failing tests** (existing crud.test.ts harness)
+
+```ts
+it('POST with parentPolicyId passes it to createConfigPolicy', ...);           // expect service called with data.parentPolicyId
+it('POST maps InvalidParentPolicyError to 400 INVALID_PARENT_POLICY', ...);
+it('POST with a parent that has a maintenance link requires MFA (403)', ...);  // getParentLinkFeatureTypes → ['maintenance'], hasSatisfiedMfa false
+it('DELETE maps PolicyHasChildrenError to 409 POLICY_HAS_CHILDREN with children', ...);
+it('GET /eligible-parents (organization) requires canAccessOrg and returns names only', ...);
+it('GET /eligible-parents (partner) requires partner scope', ...);
+```
+
+- [ ] **Step 2: Run → FAIL.**
+
+- [ ] **Step 3: Implement**
+
+`schemas.ts`:
+
+```ts
+export const eligibleParentsQuerySchema = z.discriminatedUnion('ownerScope', [
+  z.object({ ownerScope: z.literal('organization'), orgId: z.string().guid() }),
+  z.object({ ownerScope: z.literal('partner') }),
+]);
+```
+
+`crud.ts` POST — after the owner-scope checks and before either `createConfigPolicy` call:
+
+```ts
+    // MFA follows effectiveness: creating a child of a parent that carries a
+    // patch/maintenance link makes that link effective on the new policy.
+    if (data.parentPolicyId) {
+      const parentTypes = await getParentLinkFeatureTypes(data.parentPolicyId);
+      if (parentTypes.some((t) => MFA_GATED_FEATURE_TYPES.has(t)) && !hasSatisfiedMfa(auth)) {
+        return c.json({ error: 'MFA required' }, 403);
+      }
+    }
+```
+
+Wrap both `createConfigPolicy(...)` calls: pass `data` through (it now carries `parentPolicyId`) and catch `InvalidParentPolicyError` → `return c.json({ error: 'INVALID_PARENT_POLICY', message: err.message }, 400)`. Add `parentPolicyId: policy.parentPolicyId ?? null` to the audit `details`.
+
+DELETE — extend the catch:
+
+```ts
+      if (err instanceof PolicyHasChildrenError) {
+        return c.json({ error: 'POLICY_HAS_CHILDREN', children: err.children }, 409);
+      }
+```
+
+New route, placed **above** `GET /:id` so `eligible-parents` is not captured as an id:
+
+```ts
+crudRoutes.get(
+  '/eligible-parents',
+  requireScope('organization', 'partner', 'system'),
+  requireConfigPolicyRead,
+  zValidator('query', eligibleParentsQuerySchema),
+  async (c) => {
+    const auth = c.get('auth') as AuthContext;
+    const sel = c.req.valid('query');
+    if (sel.ownerScope === 'partner') {
+      if (!auth.partnerId || auth.scope === 'organization') return c.json({ error: 'Partner scope required' }, 403);
+    } else if (!auth.canAccessOrg(sel.orgId)) {
+      return c.json({ error: 'Access to this organization denied' }, 403);
+    }
+    return c.json({ data: await listEligibleParentPolicies(auth, sel) });
+  }
+);
+```
+
+- [ ] **Step 4: Run → PASS; typecheck; commit**
+
+```bash
+git add apps/api/src/routes/configurationPolicies/crud.ts apps/api/src/routes/configurationPolicies/schemas.ts apps/api/src/routes/configurationPolicies/crud.test.ts
+git commit -m "feat(config-policy): routes — create with parent, 409 on children, eligible-parents"
+```
+
+---
+
+### Task 7: Feature-link DELETE — maintenance revert gate
+
+**Files:**
+- Modify: `apps/api/src/routes/configurationPolicies/featureLinks.ts:66-80` (comment), `:483` (gate)
+- Test: `apps/api/src/routes/configurationPolicies/featureLinks.test.ts` (append)
+
+- [ ] **Step 1: Failing tests**
+
+```ts
+it('DELETE of a maintenance override whose parent has a maintenance link requires MFA', ...); // policy.parentPolicy.featureLinks has maintenance; hasSatisfiedMfa false → 403
+it('DELETE of a maintenance link on a root policy stays ungated', ...);
+it('DELETE of a patch link stays gated regardless of parent', ...);
+```
+
+- [ ] **Step 2: Run → FAIL.**
+
+- [ ] **Step 3: Implement** — replace line 483's condition:
+
+```ts
+    // Patch removal stays unconditionally gated. Maintenance removal used to be
+    // exempt because removal ENDS suppression; with inheritance, removing a
+    // child's maintenance override RESTORES the parent's window, so that one
+    // transition is gated too (spec: MFA follows effectiveness).
+    const parentHasSameType = !!policy.parentPolicy?.featureLinks?.some(
+      (l: { featureType: string }) => l.featureType === existingLink.featureType,
+    );
+    const revertRestoresGatedParent = existingLink.featureType === 'maintenance' && parentHasSameType;
+    if ((existingLink.featureType === 'patch' || revertRestoresGatedParent) && !hasSatisfiedMfa(auth)) {
+      return c.json({ error: 'MFA required' }, 403);
+    }
+```
+
+Update the "REMOVAL IS DELIBERATELY NOT GATED" paragraph at lines 76-79 to state the exception.
+
+- [ ] **Step 4: Run → PASS; commit**
+
+```bash
+git add apps/api/src/routes/configurationPolicies/featureLinks.ts apps/api/src/routes/configurationPolicies/featureLinks.test.ts
+git commit -m "feat(config-policy): gate maintenance-override revert when the parent has a window"
+```
+
+---
+
+### Task 8: Export-policy registry + partner API shape
+
+**Files:**
+- Modify: `apps/api/src/services/tenantExportPolicyRegistry.ts:138` (add `"parent_policy_id"` to `included`)
+- Modify: `apps/api/src/routes/partnerApi/configuration.ts:236-285` (`policySource`)
+- Test: `apps/api/src/routes/partnerApi/configuration.test.ts` (existing; append) and the live suites in Task 12
+
+- [ ] **Step 1: Failing test** — in `configuration.test.ts` assert the compiled `policySource` SQL contains `'parentPolicyId', cp.parent_policy_id` and a `parent_closure` CTE.
+
+- [ ] **Step 2: Run → FAIL.**
+
+- [ ] **Step 3: Implement**
+
+Registry: append `"parent_policy_id"` to the `included` array of the `configuration_policies` entry, with a comment: `// parent_policy_id may point at a partner-wide parent outside an org export; there is no import path, documented in the spec`.
+
+`policySource`: add `'parentPolicyId', cp.parent_policy_id,` to the `jsonb_build_object`, and include the parent closure so an unassigned baseline is exported alongside its children. Replace the `JOIN ( SELECT policy_id, org_id, ... FROM assignment_orgs GROUP BY policy_id, org_id ) ao` with:
+
+```sql
+    JOIN (
+      SELECT policy_id, org_id, MAX(partner_export_updated_at) AS partner_export_updated_at,
+             MAX(material_updated_at) AS material_updated_at
+      FROM (
+        SELECT policy_id, org_id, partner_export_updated_at, material_updated_at FROM assignment_orgs
+        UNION ALL
+        -- Parent closure: a child's parent is exported for the same org binding
+        -- even when the parent has no assignment of its own.
+        SELECT child.parent_policy_id AS policy_id, ao.org_id, ao.partner_export_updated_at, ao.material_updated_at
+        FROM assignment_orgs ao
+        JOIN public.configuration_policies child ON child.id = ao.policy_id
+        WHERE child.parent_policy_id IS NOT NULL
+      ) u GROUP BY policy_id, org_id
+    ) ao ON ao.policy_id = cp.id
+```
+
+If the partner-API DTO in `packages/shared` (search `sourceScope` under `packages/shared/src`) is strict, add `parentPolicyId: z.string().uuid().nullable()`.
+
+- [ ] **Step 4: Run → PASS; commit**
+
+```bash
+git add apps/api/src/services/tenantExportPolicyRegistry.ts apps/api/src/routes/partnerApi/configuration.ts apps/api/src/routes/partnerApi/configuration.test.ts
+git commit -m "feat(config-policy): export classification + partner export parentPolicyId and parent closure"
+```
+
+---
+
+### Task 9: Integration suite — ownership, triggers, view, delete, cascade
+
+**Files:**
+- Create: `apps/api/src/__tests__/integration/configPolicyInheritance.integration.test.ts`
+
+**Interfaces:**
+- Consumes: `withDbAccessContext`, `DbAccessContext` from `../../db`; the `partnerContext` / `orgContext` / `SYSTEM_CTX` helpers copied from `configPolicyPartnerWideSelect.integration.test.ts:80-110`; `createConfigPolicy`, `deleteConfigPolicy` from the service; `configPolicyEffectiveFeatureLinks` from the schema.
+
+- [ ] **Step 1: Write the suite** (each `it` is one property; seed two partners P1/P2, orgs A1, A2 under P1, B1 under P2; clean up in `afterEach` under `SYSTEM_CTX`)
+
+```ts
+describe('config policy inheritance (live DB)', () => {
+  it('org token: child of same-org parent and of own partner-wide parent succeed', ...);
+  it('org token: parent in another org, another partner-wide, or a parent that has a parent → InvalidParentPolicyError', ...);
+  it('forged insert as breeze_app bypassing the service: cross-org parent → 23514 configuration_policies_parent_guard', ...);
+  it('UPDATE parent_policy_id NULL→value is rejected (configuration_policies_parent_immutable)', ...);
+  it('UPDATE org_id outside system scope is rejected; in system scope with the whole family moving it succeeds at commit', ...);
+  it('view: child sees own link for overridden type, parent link (inherited=true, parent link id) otherwise; parent sees only its own', ...);
+  it('view under org context: partner-wide parent links are visible to the org child (partner_wide_select branch)', ...);
+  it('view under agent-shaped context (currentPartnerId set): same visibility', ...);
+  it('delete parent alone → PolicyHasChildrenError; delete child then parent → ok', ...);
+  it('org cascade: single DELETE WHERE org_id removes parent and child together', ...);
+});
+```
+
+For the forged insert use `withDbAccessContext(orgContext(A1, P1), () => db.execute(sql\`INSERT INTO configuration_policies (org_id, name, parent_policy_id) VALUES (...)\`))` and assert `pgErrorCode(err) === '23514'` and the constraint name. For the system-scope family move, run inside one `db.transaction` with `SET CONSTRAINTS ALL DEFERRED` and `set_config('breeze.scope','system',true)`, update the child's `org_id` first, then the parent's, then commit; assert both rows moved.
+
+- [ ] **Step 2: Run it against the test stack**
+
+Run: `pnpm test-stack up` (see `worktree-stack` skill) then `cd apps/api && npx vitest run --config vitest.integration.config.ts src/__tests__/integration/configPolicyInheritance.integration.test.ts`
+Expected: all PASS. Confirm in the output that the file **ran** (test count > 0), not skipped.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/__tests__/integration/configPolicyInheritance.integration.test.ts
+git commit -m "test(config-policy): inheritance integration suite — ownership, triggers, view, delete, cascade"
+```
+
+---
+
+### Task 10: AI tools and other `createConfigPolicy` callers compile-check
+
+**Files:**
+- Modify only if `tsc` demands: `apps/api/src/services/aiToolsConfigPolicy.ts`, `apps/api/src/scripts/migrateToConfigPolicies.ts`, `apps/api/src/routes/softwareInventory.ts` (`ensureDefaultConfigPolicyLink`)
+
+- [ ] **Step 1:** `grep -rn "createConfigPolicy(" apps/api/src --include='*.ts' | grep -v test` and `grep -rn "deleteConfigPolicy(" ...`. For each caller confirm the new optional field and the new error do not change behaviour (AI tools do not pass `parentPolicyId`; callers of `deleteConfigPolicy` in AI tools must surface `PolicyHasChildrenError` as a tool error string, not a crash — add the `instanceof` branch where they already handle `PartnerWideWriteDeniedError`).
+- [ ] **Step 2:** `cd apps/api && npx tsc --noEmit` → clean. Run `npx vitest run src/services/aiToolsConfigPolicy.test.ts`.
+- [ ] **Step 3:** Commit if anything changed: `git commit -m "chore(config-policy): surface PolicyHasChildrenError in AI tool delete"`.
+
+---
+
+### Task 11: OpenAPI / docs touch (API only)
+
+**Files:**
+- Modify: the OpenAPI/route doc for configuration policies if one exists (`grep -rln "configuration-policies" apps/api/src/openapi apps/docs/src/content 2>/dev/null`); add `parentPolicyId` to the create body and the GET response, the `eligible-parents` endpoint, and the 409.
+
+- [ ] **Step 1:** Make the doc edits (no code). W03 owns the user-facing docs page; this task is only the API reference if it is generated from or checked against source.
+- [ ] **Step 2:** Commit: `git commit -m "docs(api): configuration policy inheritance fields and endpoints"`.
+
+---
+
+### Task 12: Live-DB contract suites, then PR
+
+- [ ] **Step 1:** With the test stack up, run and confirm each **ran** and passed:
+
+```bash
+cd apps/api
+npx vitest run --config vitest.integration.config.ts src/__tests__/integration/rls-coverage.integration.test.ts
+npx vitest run --config vitest.integration.config.ts src/__tests__/integration/tenantCascade.integration.test.ts
+npx vitest run --config vitest.integration.config.ts src/__tests__/integration/tenant-export-policy.integration.test.ts src/__tests__/integration/tenantExportErasureRoundtrip.integration.test.ts
+npx vitest run --config vitest.integration.config.ts src/__tests__/integration/orgLifecycleFoundations.integration.test.ts src/__tests__/integration/orgMerge
+npx vitest run --config vitest.integration.config.ts src/__tests__/integration/configPolicyPartnerWideSelect.integration.test.ts src/__tests__/integration/configurationPoliciesPartnerRls.integration.test.ts
+```
+
+- [ ] **Step 2:** As `breeze_app`, forge a cross-tenant parent and confirm the failure (`docker exec -it <test-postgres> psql -U breeze_app -d breeze` → `INSERT ... parent_policy_id = <other org's policy>` → `23514`).
+- [ ] **Step 3:** `pnpm --filter @breeze/api test --run src/routes/configurationPolicies src/services/configurationPolicy src/services/configPolicyOwnership` green; `pnpm lint`.
+- [ ] **Step 4:** Merge `origin/main` into the branch, re-run Step 3, push, open the PR with `Closes #<wave sub-issue>`, run `pr-review-toolkit:review-pr`, fix confirmed findings inline, and **stop at the open PR** (orchestrator merges on green).

--- a/docs/superpowers/plans/config-policy/2026-09-06-config-policy-inheritance-01-api-foundation.md
+++ b/docs/superpowers/plans/config-policy/2026-09-06-config-policy-inheritance-01-api-foundation.md
@@ -1,3 +1,9 @@
+---
+tracking_issue: LanternOps/breeze#5080
+wave_issue: LanternOps/breeze#5081
+branch: feature/5080-config-policy-inheritance/wave-5081
+---
+
 # Config Policy Inheritance — W01 API Foundation Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
@@ -10,7 +16,7 @@
 
 **Spec:** `docs/superpowers/specs/config-policy/2026-09-06-config-policy-inheritance-design.md`
 
-**Tracking:** feature issue and wave sub-issue numbers are added to this header by `register_feature` (feature-lifecycle). Branch: `feature/<parent#>-config-policy-inheritance/wave-<subissue#>`.
+**Tracking:** feature LanternOps/breeze#5080, wave #5081. Branch `feature/5080-config-policy-inheritance/wave-5081`.
 
 ## Global Constraints
 

--- a/docs/superpowers/plans/config-policy/2026-09-06-config-policy-inheritance-02-resolver-sweep.md
+++ b/docs/superpowers/plans/config-policy/2026-09-06-config-policy-inheritance-02-resolver-sweep.md
@@ -1,0 +1,302 @@
+# Config Policy Inheritance — W02 Resolver Sweep Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Every reader that decides what a device gets, delivers config to an agent, or schedules work reads `config_policy_effective_feature_links` instead of `config_policy_feature_links`, carries the assigned policy id wherever a link id used to stand alone, and a contract test keeps it that way.
+
+**Architecture:** The view has the same join shape as the base table (`config_policy_id = configuration_policies.id AND feature_type = X`), so most sites change one identifier. Three families need more: (1) the generic effective-config resolver adds provenance; (2) automation scheduling gains an execution identity `(automation id, assigned policy id)` through grouping, job payload, job ids, the run-time ownership clamp, and a one-execution-per-device filter; (3) patch uses the resolver's `configPolicyId` instead of reverse-mapping a link id, and the policy-local patch loader reads the view. A source-tree contract test fails on any new direct reader outside the CRUD allowlist.
+
+**Tech Stack:** Drizzle ORM, BullMQ, Vitest (unit with the `vi.mock('../db')` chain pattern from `featureConfigResolver.test.ts`; integration against real Postgres).
+
+**Spec:** `docs/superpowers/specs/config-policy/2026-09-06-config-policy-inheritance-design.md` (sections *Semantics*, *Resolver sweep*, *Risks*)
+
+**Depends on:** W01 merged (view + column exist; `configPolicyEffectiveFeatureLinks` exported from the schema).
+
+## Global Constraints
+
+- Readers that **edit or report a policy's own links** keep `configPolicyFeatureLinks`. Readers that **resolve, deliver, or schedule** switch to `configPolicyEffectiveFeatureLinks`. The allowlist in Task 1 is the authority; a reader not on it that imports the base table fails **Test API**.
+- An inherited link competes at the **child's** assignment level and priority; `sourcePolicyId` (existing field) stays the assigned child; new `inheritedFromPolicyId` / `inheritedFromPolicyName` are set only when `inherited = true`.
+- Wherever a `featureLinkId` identified a policy on its own, the **assigned `configPolicyId` travels with it**. No `.limit(1)` reverse map from link id to policy remains on the switched paths.
+- One execution per device per tick: a per-policy automation dispatch keeps only devices whose winning automation assignment is that dispatch's policy.
+- Before the PR, `EXPLAIN (ANALYZE, BUFFERS)` for `resolveDeviceEventLogSettings` as `breeze_app` before/after; no sequential scan on `config_policy_feature_links` introduced.
+- Every task: red test first, `tsc`, targeted tests, commit.
+
+---
+
+### Task 1: Contract test — no direct feature-link readers outside the allowlist
+
+**Files:**
+- Create: `apps/api/src/services/featureLinkReaders.contract.test.ts`
+
+- [ ] **Step 1: Write the test (it is red until the sweep completes; land it first, keep it red-listed in the PR description until Task 9)**
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+// Files allowed to read config_policy_feature_links DIRECTLY: they edit or
+// report a policy's OWN (authored) links. Everything that resolves, delivers,
+// or schedules must read config_policy_effective_feature_links (the view) so a
+// child policy inherits its parent's links. Adding a resolver here is a
+// design decision, not a fix — see the spec's Resolver sweep section.
+const DIRECT_READ_ALLOWLIST = new Set([
+  'db/schema/configurationPolicies.ts',
+  'db/schema/backup.ts',
+  'db/schema/onedriveHelper.ts',
+  'services/configurationPolicy.ts',          // link CRUD + listFeatureLinks; its resolver imports the view
+  'services/configPolicyPatching.ts',          // authored-vs-effective split inside (Task 6)
+  'services/alertCorrelationRca.ts',           // evidence naming only
+  'services/aiToolsConfigPolicy.ts',
+  'services/aiToolsFleet.ts',
+  'services/aiToolsBackup.ts',
+  'routes/configurationPolicies/featureLinks.ts',
+  'routes/updateRingsHelpers.ts',
+  'routes/policyManagement/helpers.ts',
+  'routes/policyManagement/compliance.ts',
+  'routes/scripts.ts',
+  'routes/backup/profiles.ts',
+  'routes/softwareInventory.ts',
+  'routes/partnerApi/configuration.ts',
+  'scripts/migrateToConfigPolicies.ts',
+]);
+
+const SRC = join(__dirname, '..');
+function walk(dir: string, out: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) { if (name !== '__tests__' && name !== 'node_modules') walk(p, out); }
+    else if (p.endsWith('.ts') && !p.endsWith('.test.ts') && !p.endsWith('.d.ts')) out.push(p);
+  }
+  return out;
+}
+
+describe('feature-link readers contract', () => {
+  it('only allowlisted files read config_policy_feature_links directly', () => {
+    const offenders: string[] = [];
+    for (const file of walk(SRC)) {
+      const rel = relative(SRC, file).replace(/\\/g, '/');
+      const src = readFileSync(file, 'utf8');
+      const readsBase = /\bconfigPolicyFeatureLinks\b/.test(src) || /config_policy_feature_links\b/.test(src);
+      if (readsBase && !DIRECT_READ_ALLOWLIST.has(rel)) offenders.push(rel);
+    }
+    expect(offenders, `switch these to configPolicyEffectiveFeatureLinks or add them to the allowlist with a reason:\n${offenders.join('\n')}`).toEqual([]);
+  });
+
+  it('every allowlist entry still exists (stale entries hide regressions)', () => {
+    const missing = [...DIRECT_READ_ALLOWLIST].filter((rel) => { try { statSync(join(SRC, rel)); return false; } catch { return true; } });
+    expect(missing).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run** — `cd apps/api && npx vitest run src/services/featureLinkReaders.contract.test.ts` → FAIL listing every reader from the spec's sweep list (this is the work queue for Tasks 2–8). Tune the allowlist only for files the spec names as "keep the base table".
+
+- [ ] **Step 3: Commit** — `git commit -m "test(config-policy): feature-link reader contract (red until the sweep lands)"`.
+
+---
+
+### Task 2: Generic effective-config resolver + provenance
+
+**Files:**
+- Modify: `apps/api/src/services/configurationPolicy.ts` — `ResolvedFeature` (:154-163), `resolveEffectiveConfigWithExecutor` (:1814-2031)
+- Modify: `packages/shared/src/types` effective-configuration type if one exists (`grep -rn "sourcePolicyName" packages/shared/src`)
+- Test: `apps/api/src/routes/configurationPolicies/resolution.test.ts` (append)
+
+**Interfaces:**
+- Produces: `ResolvedFeature.inheritedFromPolicyId: string | null`, `ResolvedFeature.inheritedFromPolicyName: string | null` on `GET /configuration-policies/effective/:deviceId` and the diff preview.
+
+- [ ] **Step 1: Failing test** — with the mocked select returning a row `{ ..., inherited: true, sourcePolicyId: 'parent-1', inheritedFromPolicyName: 'Baseline' }`, expect `features.event_log.inheritedFromPolicyId === 'parent-1'` and `sourcePolicyId === '<assigned child id>'`; with `inherited: false` both new fields are `null`.
+
+- [ ] **Step 2: Run → FAIL.**
+
+- [ ] **Step 3: Implement** — in the query at ~:1900-1935: replace `configPolicyFeatureLinks` with `configPolicyEffectiveFeatureLinks` (alias `efl`), add `inherited: efl.inherited, linkSourcePolicyId: efl.sourcePolicyId` to the select, and a `leftJoin(aliasedTable(configurationPolicies, 'parent_policy'), eq(parent.id, efl.sourcePolicyId))` selecting `inheritedFromPolicyName: parent.name`. In the first-match block (:1965-1977):
+
+```ts
+        sourcePolicyId: row.policyId,            // the ASSIGNED policy (unchanged)
+        sourcePolicyName: row.policyName,
+        sourcePriority: row.assignmentPriority,
+        inheritedFromPolicyId: row.inherited ? row.linkSourcePolicyId : null,
+        inheritedFromPolicyName: row.inherited ? row.inheritedFromPolicyName : null,
+```
+
+Extend `ResolvedFeature` accordingly. If a shared type mirrors it, extend it too (optional fields, additive).
+
+- [ ] **Step 4: Run → PASS; commit** — `git commit -m "feat(config-policy): effective-config resolver reads the view, reports inheritedFrom provenance"`.
+
+---
+
+### Task 3: `featureConfigResolver.ts` — mechanical switch
+
+**Files:**
+- Modify: `apps/api/src/services/featureConfigResolver.ts` — every function in the spec list: `resolveGoverningAlertRulePolicyForDevice`, `resolveAlertRulesForDevice`, `resolveAutomationsForDevice`, `resolvePatchConfigDetailsForDevice`, `resolveBackupConfigForDevice`, `resolveMaintenanceConfigForDevice`, `resolveComplianceRulesForDevice`, `resolveSoftwarePolicyForDevice`, `resolveDeviceIdsForSoftwarePolicy`, `resolveVulnerabilityEnabledForDevice`, `resolveAllVulnerabilityEnabledDevices`, `resolveAllBackupAssignedDevices`, `resolveBackupProtectionForDevice`, `scanScheduledAutomations`, `scanDueComplianceChecks`
+- Test: `apps/api/src/services/featureConfigResolver.test.ts` (existing mocks stub `../db/schema` as string maps — add `configPolicyEffectiveFeatureLinks` to that stub with the same keys plus `sourcePolicyId`, `inherited`)
+
+- [ ] **Step 1: Failing test** — one representative per join shape:
+  - `resolveAlertRulesForDevice` builds its join against `configPolicyEffectiveFeatureLinks` (assert the mocked `innerJoin` receives the view stub).
+  - `scanScheduledAutomations` returns `policyId` = the assigned policy while joining `configPolicyAutomations.featureLinkId = efl.id` (an inherited row's id is the parent link's id, so the automation row is found through the child).
+
+- [ ] **Step 2: Run → FAIL.**
+
+- [ ] **Step 3: Implement** — import `configPolicyEffectiveFeatureLinks`; in each listed function replace the table in `.from(...)`/`.innerJoin(...)` and in every `eq(configPolicyFeatureLinks.<col>, ...)`. Where a function's `select` exposes `featureLinkId: configPolicyFeatureLinks.id`, keep the same column from the view (it is the parent link id when inherited, which downstream settings joins need). For `scanScheduledAutomations` the join order becomes `configPolicyAutomations → efl (on featureLinkId = efl.id) → configurationPolicies (on efl.configPolicyId = policies.id, status active) → assignments`. Do **not** touch `resolveDeviceIdsForSoftwarePolicy` if its only caller is the software-policy delete guard; if it feeds the compliance worker (check `grep -rn resolveDeviceIdsForSoftwarePolicy apps/api/src`), switch it.
+
+- [ ] **Step 4: Run** the whole file's suites: `npx vitest run src/services/featureConfigResolver` → PASS. Commit — `git commit -m "feat(config-policy): featureConfigResolver reads effective links"`.
+
+---
+
+### Task 4: Agent config delivery — `routes/agents/helpers.ts`, `routes/remote/helpers.ts`, lifecycle, helper permissions, warranty
+
+**Files:**
+- Modify: `apps/api/src/routes/agents/helpers.ts` (event_log :1818-1840, monitoring :2092, helper :2619-2625, pam :2777-2783, onedrive_helper :2961-2965), `apps/api/src/routes/remote/helpers.ts:453-459`, `apps/api/src/services/deviceLifecyclePolicy.ts:94-104`, `apps/api/src/services/helperPermissions.ts:80-92`, `apps/api/src/services/warrantyAlertEvaluator.ts:136-147`
+- Test: the co-located tests for each (`helpers.test.ts` variants, `deviceLifecyclePolicy.test.ts`, `helperPermissions.test.ts`, `warrantyAlertEvaluator.test.ts`) — add the view to their schema stubs and one assertion per file that the join target is the view.
+
+- [ ] **Step 1: Failing tests** (one per file, same shape as Task 3).
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement** — identifier swap in each join; the settings joins (`configPolicyEventLogSettings.featureLinkId = efl.id`, etc.) are unchanged.
+- [ ] **Step 4: Run → PASS; commit** — `git commit -m "feat(config-policy): agent delivery, remote prompt, lifecycle, helper, warranty read effective links"`.
+
+---
+
+### Task 5: Automation execution identity
+
+**Files:**
+- Modify: `apps/api/src/jobs/queueSchemas.ts:264-284` (`trigger-config-policy-schedule` gains `configPolicyId`; `execute-config-policy-run` gains `configPolicyId`)
+- Modify: `apps/api/src/jobs/automationWorker.ts` — `collectDueConfigPolicyScheduleDispatches` (:196-235: group key), the enqueue at :421 (jobId), `processTriggerConfigPolicySchedule` (:769-866: ownership clamp, per-device winner filter, run jobId), `processExecuteConfigPolicyRun` (pass `configPolicyId` through)
+- Modify: `apps/api/src/services/automationRuntime.ts:2835-2875` — `resolveConfigPolicyAutomationContext(tx, featureLinkId, configPolicyId)`
+- Test: `apps/api/src/jobs/automationWorker.test.ts`, `apps/api/src/services/automationRuntime.configPolicy.test.ts`
+
+**Interfaces:**
+- Produces: `DueConfigPolicyScheduleDispatch.policyId` is the **assigned** policy; job ids `cp-automation-schedule-<automationId>-<policyId>-<slotKey>` and `cp-automation-run:<automationId>:<policyId>:<slotKey>`; `ExecuteConfigPolicyRunJobData.configPolicyId: string`.
+
+- [ ] **Step 1: Failing tests**
+
+```ts
+it('groups due schedules by (automation id, assigned policy id)', () => {
+  // two candidates, same automation, policyId 'child-a' and 'child-b' → two dispatches
+});
+it('schedule job id includes the assigned policy id', ...);
+it('run-time clamp reads ownership from the ASSIGNED policy, not from the link', ...);   // db mock: configurationPolicies select by id, no configPolicyFeatureLinks join
+it('keeps only devices whose winning automation assignment is this dispatch\'s policy', ...); // resolveAutomationsForDevice mocked: device-1 wins with child-a, device-2 wins with child-b → dispatch child-a keeps device-1 only
+it('resolveConfigPolicyAutomationContext verifies the link is effective for the given policy through the view', ...);
+```
+
+- [ ] **Step 2: Run → FAIL.**
+
+- [ ] **Step 3: Implement**
+
+`collectDueConfigPolicyScheduleDispatches`: `const key = \`${cpAutomation.id}:${candidate.policyId}\`; let entry = grouped.get(key); ... grouped.set(key, entry);`.
+
+Enqueue (:421): `jobId: \`cp-automation-schedule-${dispatch.configPolicyAutomationId}-${dispatch.policyId}-${slotKey}\`` and add `configPolicyId: dispatch.policyId` to the payload (the existing `policyId` field stays for back-compat; new code reads `configPolicyId ?? policyId`).
+
+`processTriggerConfigPolicySchedule`:
+
+```ts
+  const assignedPolicyId = data.configPolicyId ?? data.policyId;
+  // Ownership clamp re-reads the ASSIGNED policy (#2286). Through the effective
+  // view one link id belongs to the parent AND every child, so a link→policy
+  // reverse map would pick an arbitrary owner.
+  const [policyOwner] = await db
+    .select({ orgId: configurationPolicies.orgId, partnerId: configurationPolicies.partnerId, status: configurationPolicies.status })
+    .from(configurationPolicies).where(eq(configurationPolicies.id, assignedPolicyId)).limit(1);
+  if (!policyOwner || policyOwner.status !== 'active') return { skipped: 'config_policy_not_found' };
+  const [effective] = await db.select({ id: configPolicyEffectiveFeatureLinks.id })
+    .from(configPolicyEffectiveFeatureLinks)
+    .where(and(eq(configPolicyEffectiveFeatureLinks.id, cpAutomation.featureLinkId),
+               eq(configPolicyEffectiveFeatureLinks.configPolicyId, assignedPolicyId))).limit(1);
+  if (!effective) return { skipped: 'automation_not_effective_for_policy' };
+```
+
+After the maintenance filter, add the winner filter:
+
+```ts
+  // One execution per device per tick: a device covered by two assigned policies
+  // that both carry this (inherited) automation runs it under the WINNING policy only.
+  const winners: string[] = [];
+  for (const deviceId of eligibleDeviceIds) {
+    const automations = await resolveAutomationsForDevice(deviceId);
+    const winner = automations.find((a) => a.automation.id === cpAutomation.id);
+    if (winner && winner.policyId === assignedPolicyId) winners.push(deviceId);
+  }
+  if (winners.length === 0) return { skipped: 'no_winning_devices' };
+```
+
+(`resolveAutomationsForDevice` already returns per-automation rows with the winning `policyId`; if its return shape lacks `policyId`, add it in Task 3.) Run enqueue: `configPolicyId: assignedPolicyId`, `targetDeviceIds: winners.sort()`, stable id `cp-automation-run:${cpAutomation.id}:${assignedPolicyId}:${data.slotKey}`.
+
+`resolveConfigPolicyAutomationContext(tx, featureLinkId, configPolicyId)`: select from `configPolicyEffectiveFeatureLinks` joined to `configurationPolicies` on `efl.configPolicyId = policies.id`, `where(and(eq(efl.id, featureLinkId), eq(efl.configPolicyId, configPolicyId)))`. Its caller at :2870 passes `options.configPolicyId` (thread it from the run job data through `admitConfigPolicyAutomationRun`'s options).
+
+- [ ] **Step 4: Run → PASS; typecheck; commit** — `git commit -m "feat(config-policy): automation execution identity = (automation, assigned policy); one run per device per tick"`.
+
+---
+
+### Task 6: Patch — effective loader and resolver-provided policy id
+
+**Files:**
+- Modify: `apps/api/src/services/configPolicyPatching.ts:282-345` (`loadPolicyLocalPatchConfig`), `apps/api/src/services/patchJobService.ts:113-135`, `apps/api/src/jobs/patchSchedulerWorker.ts:496-530`
+- Test: `apps/api/src/services/configPolicyPatching.test.ts`, `apps/api/src/services/patchJobService.test.ts`, `apps/api/src/jobs/patchSchedulerWorker.test.ts`
+
+**Interfaces:**
+- Produces: `PolicyLocalPatchConfig.sourcePolicyId: string` and `.inherited: boolean`; `loadPolicyLocalPatchConfig(configPolicyId)` returns the parent's patch link for a child that has none of its own.
+
+- [ ] **Step 1: Failing tests**
+  - `loadPolicyLocalPatchConfig('child')` with the view mock returning the parent's link (`inherited: true, sourcePolicyId: 'parent'`) returns a config with `configPolicyId: 'child'`, `sourcePolicyId: 'parent'`, `inherited: true`, and the patch settings joined by the parent link id.
+  - `createPatchJobForDeviceFromPolicy` calls `createPatchJobFromConfigPolicy(deviceId, settings, orgId, resolved.configPolicyId)` with no `configPolicyFeatureLinks` select.
+  - `scanAndCreateJobs` enumerates through the view (a child of a parent with a patch link is a candidate).
+
+- [ ] **Step 2: Run → FAIL.**
+
+- [ ] **Step 3: Implement**
+  - `loadPolicyLocalPatchConfig`: switch the inner join to `configPolicyEffectiveFeatureLinks` (alias `efl`), select `sourcePolicyId: efl.sourcePolicyId, inherited: efl.inherited`, keep `leftJoin(configPolicyPatchSettings, eq(configPolicyPatchSettings.featureLinkId, efl.id))`, add the two fields to `PolicyLocalPatchConfig`. The authored-only readers in this file (reference classification for the editor, if any) keep the base table — that is why the file stays on the allowlist; mark each query with a one-line `// authored` or `// effective` comment.
+  - `createPatchJobForDeviceFromPolicy`: replace the `resolvePatchConfigForDevice` + reverse map with `const resolved = await resolvePatchConfigDetailsForDevice(deviceId); if (!resolved) return null; return createPatchJobFromConfigPolicy(deviceId, resolved.settings, orgId, resolved.configPolicyId);`.
+  - `scanAndCreateJobs`: switch the `configPolicyFeatureLinks` join to the view.
+
+- [ ] **Step 4: Run → PASS; commit** — `git commit -m "feat(config-policy): patch scheduler and job creation inherit through the effective loader"`.
+
+---
+
+### Task 7: Remaining workers — backup scheduler
+
+**Files:**
+- Modify: `apps/api/src/jobs/backupWorker.ts:149-180` (`processCheckSchedules`)
+- Test: `apps/api/src/jobs/backupWorker.test.ts`
+
+- [ ] **Step 1: Failing test** — the schedule scan joins the view; `config_policy_backup_settings.feature_link_id = efl.id` unchanged.
+- [ ] **Step 2: Run → FAIL.** **Step 3:** identifier swap. **Step 4:** PASS; commit — `git commit -m "feat(config-policy): backup schedule scan reads effective links"`.
+
+---
+
+### Task 8: Contract test green
+
+- [ ] **Step 1:** `cd apps/api && npx vitest run src/services/featureLinkReaders.contract.test.ts` → PASS with **zero** allowlist additions beyond Task 1's list. If a file still fails, it is either a missed resolver (switch it) or an authored-only reader the spec named (add it with a reason comment). `npx tsc --noEmit` clean.
+- [ ] **Step 2:** Commit — `git commit -m "test(config-policy): reader contract green"`.
+
+---
+
+### Task 9: Integration proof — inheritance reaches devices and agents
+
+**Files:**
+- Modify: `apps/api/src/__tests__/integration/configPolicyInheritance.integration.test.ts` (W01 suite; add a `describe('resolution')`)
+
+- [ ] **Step 1: Write the cases** (seed: partner P1, orgs A1, A2; parent partner-wide `Baseline` with `event_log` + `alert_rule` + one scheduled `automation` link; child `A1-child` in A1 assigned at org level with its own `alert_rule` link; child `A2-child` in A2 assigned at org level; device D1 in A1, D2 in A2)
+
+```ts
+it('generic resolver: D1 gets event_log from Baseline (inheritedFromPolicyId = Baseline) and alert_rule from A1-child (inheritedFromPolicyId null)', ...);
+it('featureConfigResolver.resolveAlertRulesForDevice(D2) returns Baseline rules through A2-child at org priority', ...);
+it('agent helper resolveDeviceEventLogSettings(D1) under the AGENT context (org A1, currentPartnerId P1) returns Baseline settings', ...);
+it('automation tick: two children → two schedule dispatches with distinct job ids, each run scoped to its own org devices', ...);
+it('overlapping assignments (Baseline also assigned at org A1, A1-child at site) → D1 runs the automation once, under A1-child', ...);
+it('provenance: only the inherited feature carries inheritedFromPolicyId', ...);
+```
+
+Use `withDbAccessContext(orgContext(A1, P1), ...)` for the agent-shaped case and `SYSTEM_CTX` for worker paths; for the automation cases call `collectDueConfigPolicyScheduleDispatches(await scanScheduledAutomations(), due)` and `processTriggerConfigPolicySchedule` directly with a fake queue (the existing automationWorker integration test shows the harness; if none exists, assert on the enqueue call via `vi.spyOn`).
+
+- [ ] **Step 2: Run** with the test stack up: `npx vitest run --config vitest.integration.config.ts src/__tests__/integration/configPolicyInheritance.integration.test.ts` → PASS, test count matches.
+- [ ] **Step 3: Commit** — `git commit -m "test(config-policy): inheritance resolution proof — resolver, agent context, automation identity"`.
+
+---
+
+### Task 10: EXPLAIN check, full suites, PR
+
+- [ ] **Step 1:** As `breeze_app` on the test stack, `EXPLAIN (ANALYZE, BUFFERS)` the event_log resolver query (copy it from `resolveDeviceEventLogSettings` with real ids) before (checkout main) and after; paste both plans into the PR description. No new seq scan on the links table; if the planner does not push `feature_type` into the view's second arm, add `CREATE INDEX IF NOT EXISTS config_feature_links_policy_type_idx ON config_policy_feature_links (config_policy_id, feature_type)` in a small follow-up migration (the unique index `config_feature_links_unique` already covers this pair; verify before adding anything).
+- [ ] **Step 2:** `pnpm --filter @breeze/api test --run src/services src/jobs src/routes/agents src/routes/configurationPolicies` green; `npx tsc --noEmit`; `pnpm lint`.
+- [ ] **Step 3:** Live suites: `configPolicyInheritance`, `configPolicyAutomationRunRls`, `configurationPolicyPartnerResolution`, `configPolicyPartnerWideSelect`, `rls-coverage` (all under `vitest.integration.config.ts`) — each must show it ran.
+- [ ] **Step 4:** Merge `origin/main`, re-run, push, open the PR with `Closes #<wave sub-issue>`, run `pr-review-toolkit:review-pr`, fix confirmed findings inline, **stop at the open PR**.

--- a/docs/superpowers/plans/config-policy/2026-09-06-config-policy-inheritance-02-resolver-sweep.md
+++ b/docs/superpowers/plans/config-policy/2026-09-06-config-policy-inheritance-02-resolver-sweep.md
@@ -1,3 +1,9 @@
+---
+tracking_issue: LanternOps/breeze#5080
+wave_issue: LanternOps/breeze#5082
+branch: feature/5080-config-policy-inheritance/wave-5082
+---
+
 # Config Policy Inheritance — W02 Resolver Sweep Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/plans/config-policy/2026-09-06-config-policy-inheritance-03-web-and-docs.md
+++ b/docs/superpowers/plans/config-policy/2026-09-06-config-policy-inheritance-03-web-and-docs.md
@@ -1,0 +1,227 @@
+# Config Policy Inheritance — W03 Web and Docs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** The web app derives every inheritance state from the API (`parentPolicyId`, `parentPolicy`, `childPolicies`, `inheritedFromPolicyId`), the create flow persists the parent, the feature tabs stop conflating id kinds, and the docs describe the feature.
+
+**Architecture:** `ConfigPolicyCreatePage` posts `parentPolicyId` and fills its picker from `GET /configuration-policies/eligible-parents`. `ConfigPolicyDetailPage` seeds `linkedPolicyId`, the parent name, and `parentFeatureLinks` from `policy.parentPolicy` and deletes both the `?linked=` initializer and the direct parent fetch. `FeatureTabShell` is unchanged; three tabs adopt it for inheritance and two re-sync selection when the parent arrives. The list page badges children and renders the 409 children list on delete. `DeviceEffectiveConfigTab` shows "inherited from".
+
+**Tech Stack:** React (Astro islands), react-i18next (8 locales), Vitest + Testing Library (jsdom), `runAction` for mutations.
+
+**Spec:** `docs/superpowers/specs/config-policy/2026-09-06-config-policy-inheritance-design.md` (sections *API*, *Web*)
+
+**Depends on:** W01 merged (API shapes). Independent of W02 except the provenance fields in Task 8, which render as absent until W02 lands.
+
+## Global Constraints
+
+- No `window.location.search` reads for inheritance anywhere in `apps/web/src/components/configurationPolicies/`.
+- Every new string is added to all 8 locales: `en, de-DE, fr-FR, fr-CA, es-419, it-IT, pt-BR, tr-TR` (`apps/web/src/locales/<loc>/policies.json`, and `devices.json` for the effective-config tab). Reuse `configPolicyDetailPage.inheritingFrom`, `.parentPolicy`, `.overrideIndividualTabsToCustomizeSettings`.
+- Mutation handlers go through `runAction`; the delete 409 is surfaced inside the confirm modal, not as a toast alone.
+- Tests use `data-testid` (add them where a test needs a hook); one red test before each behaviour change.
+- Per-tab payload matrix (Task 5) is the authority for what `featurePolicyId` each tab may send. A tab not in the matrix is a plan failure; complete the matrix before touching tabs.
+
+---
+
+### Task 1: Client types
+
+**Files:**
+- Modify: `apps/web/src/components/configurationPolicies/ConfigPolicyList.tsx:15-31` (`ConfigPolicy`), `apps/web/src/components/configurationPolicies/ConfigPolicyDetailPage.tsx:66-79` (`PolicyDetail`), `apps/web/src/components/configurationPolicies/featureTabs/types.ts` (export a `ParentPolicySummary`)
+- Test: none (types); `tsc` in Task 9 covers it
+
+- [ ] **Step 1:** Add to `ConfigPolicy`: `parentPolicyId?: string | null;`. Add to `PolicyDetail`:
+
+```ts
+  parentPolicyId: string | null;
+  parentPolicy: ParentPolicySummary | null;
+  childPolicies: { id: string; name: string }[];
+```
+
+and in `types.ts`:
+
+```ts
+/** GET /configuration-policies/:id → parentPolicy (read-only embed; see spec "API"). */
+export type ParentPolicySummary = {
+  id: string;
+  name: string;
+  status: 'active' | 'inactive' | 'archived';
+  orgId: string | null; // null = partner-wide parent
+  featureLinks: FeatureLink[];
+};
+```
+
+- [ ] **Step 2:** Commit — `git commit -m "feat(web): config policy parent/child types"`.
+
+---
+
+### Task 2: Create page — post `parentPolicyId`, eligible-parent picker, no `?linked=`
+
+**Files:**
+- Modify: `apps/web/src/components/configurationPolicies/ConfigPolicyCreatePage.tsx:82-102, 243-247`
+- Modify: `apps/web/src/components/configurationPolicies/featureTabs/PolicyLinkSelector.tsx` (accept `options` override or a `fetchUrl` with query; simplest: pass the full eligible-parents URL)
+- Test: `apps/web/src/components/configurationPolicies/ConfigPolicyCreatePage.test.tsx` (append)
+
+- [ ] **Step 1: Failing tests**
+
+```ts
+it('linked mode: fetches eligible parents for the chosen owner scope and posts parentPolicyId', async () => {
+  // org-scoped: expect fetchWithAuth called with '/configuration-policies/eligible-parents?ownerScope=organization&orgId=<org>'
+  // select a parent, submit → POST body contains parentPolicyId; navigation target has NO '?linked='
+});
+it('partner-wide linked mode: fetches eligible parents with ownerScope=partner', async () => {});
+it('linked mode without a selected parent keeps Create disabled and does not POST', async () => {});
+```
+
+- [ ] **Step 2: Run → FAIL** (`cd apps/web && npx vitest run src/components/configurationPolicies/ConfigPolicyCreatePage.test.tsx`).
+
+- [ ] **Step 3: Implement**
+  - Compute the picker URL: `const eligibleUrl = usePartnerOwner ? '/configuration-policies/eligible-parents?ownerScope=partner' : orgScopedOrgId ? \`/configuration-policies/eligible-parents?ownerScope=organization&orgId=${orgScopedOrgId}\` : null;` and render `PolicyLinkSelector` only when `eligibleUrl` is set (an org-scoped creator with no org chosen sees the "select an organization" hint instead). Reset `linkedPolicyId` to `null` whenever `eligibleUrl` changes (a parent valid for org A is not valid for org B).
+  - POST body: `const body = { ...values, ...(usePartnerOwner ? { ownerScope: 'partner' as const } : { orgId: orgScopedOrgId }), ...(mode === 'linked' && linkedPolicyId ? { parentPolicyId: linkedPolicyId } : {}) };`
+  - Redirect: `void navigateTo(\`/configuration-policies/${policy.id}\`);` (delete the `params` line).
+  - Map a `400 INVALID_PARENT_POLICY` and a `403 'MFA required'` to inline errors using the existing `extractApiError` path; no new copy needed for the 400 (server message is user-readable); for the 403 reuse whatever key the patch tab uses for its MFA message (`grep -rn "MFA required" apps/web/src/locales/en/policies.json`).
+  - `PolicyLinkSelector`: it already takes a `fetchUrl` and reads `json.data`; the eligible-parents response is `{ data: [...] }`, so no change is required beyond passing the new URL. Show `ownerScope === 'partner'` options with an "All orgs" suffix (reuse the existing badge copy key from `PolicyForm.tsx`'s "All orgs" pattern).
+
+- [ ] **Step 4: Run → PASS; commit** — `git commit -m "feat(web): linked policy create posts parentPolicyId from eligible parents"`.
+
+---
+
+### Task 3: Detail page — inheritance from the API, children list, no direct parent fetch
+
+**Files:**
+- Modify: `apps/web/src/components/configurationPolicies/ConfigPolicyDetailPage.tsx:186-193` (initializer), `:259-285` (effect), `:592-620` (banner), Overview tab section (children line)
+- Test: `apps/web/src/components/configurationPolicies/ConfigPolicyDetailPage.test.tsx` (append)
+
+- [ ] **Step 1: Failing tests**
+
+```ts
+it('renders the Inheriting-from banner and inherited tabs from policy.parentPolicy with no URL param and no second fetch', async () => {
+  // fetchWithAuth('/configuration-policies/child') → { ..., parentPolicyId: 'p', parentPolicy: { id: 'p', name: 'Baseline', status: 'active', featureLinks: [{ id: 'l1', featureType: 'device_lifecycle', featurePolicyId: null, inlineSettings: { enabled: true, purgeRemovedAfterDays: 45 } }] }, childPolicies: [] }
+  // expect banner text 'Inheriting from' + 'Baseline'; expect fetchWithAuth NOT called with '/configuration-policies/p'
+});
+it('banner links to the parent only when the caller can open it (partner scope or same-org parent); otherwise shows the MSP hint', ...);
+it('Overview shows "Inherited by N policies" with links when childPolicies is non-empty', ...);
+it('a policy with parentPolicyId null renders no banner', ...);
+```
+
+- [ ] **Step 2: Run → FAIL.**
+
+- [ ] **Step 3: Implement**
+  - Delete the `window.location.search` initializer; `const linkedPolicyId = policy?.parentPolicyId ?? null;` (derive, not state). Delete the parent-fetch effect; `const parentFeatureLinks = policy?.parentPolicy?.featureLinks ?? []; const linkedPolicyName = policy?.parentPolicy?.name ?? null;`.
+  - Banner condition unchanged except it reads the derived values. Link rule: `const canOpenParent = isPartnerScope || policy.parentPolicy?.orgId === policy.orgId` (the W01 embed carries `orgId`; a partner-wide parent has `orgId === null`, which an org-scoped caller cannot open). Render `<a>` when `canOpenParent`, else `<span>` + `configPolicyDetailPage.managedByYourMsp` ("Managed by your MSP").
+  - Overview tab: under the description card, `configPolicyDetailPage.inheritedByPolicies` ("Inherited by {{count}} policies") with a list of `<a href="/configuration-policies/{id}">{name}</a>`; hidden when `childPolicies.length === 0`.
+  - i18n: `managedByYourMsp`, `inheritedByPolicies` in all 8 locales.
+
+- [ ] **Step 4: Run → PASS; commit** — `git commit -m "feat(web): detail page derives inheritance from the API; children list; no URL param"`.
+
+---
+
+### Task 4: List page — child badge and delete 409
+
+**Files:**
+- Modify: `apps/web/src/components/configurationPolicies/ConfigPolicyList.tsx` (row badge), `apps/web/src/components/configurationPolicies/ConfigurationPoliciesPage.tsx:66-95` (`handleConfirmDelete`)
+- Test: `apps/web/src/components/configurationPolicies/ConfigurationPoliciesPage.test.tsx` (append; create if absent following `ConfigPolicyCreatePage.test.tsx`'s harness)
+
+- [ ] **Step 1: Failing tests**
+
+```ts
+it('shows an "inherits" badge on rows with parentPolicyId', ...);                       // data-testid="config-policy-inherits-badge"
+it('delete 409 POLICY_HAS_CHILDREN renders the children inside the confirm modal and keeps it open', ...); // data-testid="config-policy-delete-children"
+```
+
+- [ ] **Step 2: Run → FAIL.**
+
+- [ ] **Step 3: Implement**
+  - Badge: next to the status pill, when `policy.parentPolicyId`, `<span data-testid="config-policy-inherits-badge" className="...">{t('configurationPoliciesPage.inheritsBadge')}</span>` ("Inherits").
+  - Delete: `runAction` throws an `ActionError` carrying `status` and the parsed body (check `apps/web/src/lib/runAction.ts` for the body accessor; if the body is not retained, read it in `request` before rethrowing). On `status === 409 && body.error === 'POLICY_HAS_CHILDREN'`, set `deleteBlockedChildren = body.children` state rendered inside the modal under `configurationPoliciesPage.deleteBlockedByChildren` ("Delete the policies that inherit from this one first:"), keep the modal open, and skip the generic error toast for that case (it is already shown inline). Clear the state on close.
+  - i18n: `inheritsBadge`, `deleteBlockedByChildren` in all 8 locales.
+
+- [ ] **Step 4: Run → PASS; commit** — `git commit -m "feat(web): inherits badge; delete blocked-by-children modal state"`.
+
+---
+
+### Task 5: Per-tab payload matrix and the `featurePolicyId` fix
+
+**Files:**
+- Create: `docs/superpowers/plans/config-policy/2026-09-06-config-policy-inheritance-03-tab-matrix.md` (18 rows, committed with the code)
+- Modify: every tab under `apps/web/src/components/configurationPolicies/featureTabs/*Tab.tsx` that sends `featurePolicyId: linkedPolicyId`
+- Test: one assertion per changed tab in its existing `*.test.tsx` (save payload `featurePolicyId` is `null`)
+
+- [ ] **Step 1: Build the matrix** — `grep -n "featurePolicyId" apps/web/src/components/configurationPolicies/featureTabs/*Tab.tsx`. For each of the 18 tabs record: `featurePolicyId meaning` (one of `none — inline settings`, `update ring`, `backup profile`, `software policy`, `peripheral profile`, `other: <what>`), `sends today`, `sends after`. Known rows: Patch → update ring (keep); Backup → profile (keep); Software Policy → software policy (keep, copies `parentLink.featurePolicyId` on override); Peripheral Control → same (keep); Alert Rule, Automation, Compliance, Device Lifecycle, Event Log, Helper, Maintenance, Monitoring, OneDrive Helper, Pam, Warranty, Vulnerability, Security, Sensitive Data, Remote Access → verify each; the ones that are inline-only send `null` after. Any tab whose `FEATURE_META.fetchUrl` is non-null and whose UI has a picker for a standalone entity is a "keep" row.
+
+- [ ] **Step 2: Failing tests** — for each "inline-only" row, in the tab's test: render with `linkedPolicyId="parent-1"` and a parent link, click Override (or Save), assert `saveMock.mock.calls[0][1].featurePolicyId === null`.
+
+- [ ] **Step 3: Run → FAIL** for each.
+
+- [ ] **Step 4: Implement** — replace `featurePolicyId: linkedPolicyId` with `featurePolicyId: null` in those tabs (and remove the now-unused `linkedPolicyId` destructure where only that used it; keep it where `onRemove`/`onRevert` gating reads it). Do not touch the "keep" rows.
+
+- [ ] **Step 5: Run → PASS; commit** — `git commit -m "fix(web): inline-settings tabs no longer stamp the parent policy id into featurePolicyId"`.
+
+---
+
+### Task 6: Inheritance display for Security, Sensitive Data, Remote Access
+
+**Files:**
+- Modify: `apps/web/src/components/configurationPolicies/featureTabs/SecurityTab.tsx`, `SensitiveDataTab.tsx`, `RemoteAccessTab.tsx`
+- Test: their `*.test.tsx` files (pattern: `DeviceLifecycleTab.test.tsx:129` "shows the inherited … read-only when only a parent link exists" and `OneDriveHelperTab.test.tsx:347` "inherited (parentLink only) shows Override and no direct Save")
+
+- [ ] **Step 1: Failing tests** (per tab)
+
+```ts
+it('shows Configured (inherited) and seeds the form from parentLink when only a parent link exists', () => {
+  render(<SecurityTab {...baseProps} parentLink={parentLinkWith({ /* one distinctive setting */ })} />);
+  expect(screen.getByText(/Configured \(inherited\)/i)).toBeTruthy();
+  // assert the distinctive setting is rendered read-only
+});
+it('Override saves a copy of the inherited settings as the policy\'s own link', () => {
+  // click the Override button → saveMock called with (null, { featureType: 'security', featurePolicyId: null, inlineSettings: <parent settings> })
+});
+it('Revert to Parent removes the override', () => { /* existingLink + parentLink → Revert → removeMock called with existingLink.id */ });
+```
+
+- [ ] **Step 2: Run → FAIL.**
+
+- [ ] **Step 3: Implement** — mirror `PamTab.tsx:22-40`: destructure `parentLink`; `const isInherited = !!parentLink && !existingLink; const effectiveLink = existingLink ?? parentLink;` seed state from `effectiveLink` in the load effect (depend on `[existingLink, parentLink]`); pass `isConfigured={!!existingLink || isInherited} isInherited={isInherited} onOverride={isInherited ? handleSave : undefined} onRevert={!isInherited && parentLink && existingLink ? () => remove(existingLink.id) : undefined} onRemove={!parentLink ? handleRemove : undefined}` to `FeatureTabShell`.
+
+- [ ] **Step 4: Run → PASS; commit** — `git commit -m "feat(web): security, sensitive-data, remote-access tabs render inheritance"`.
+
+---
+
+### Task 7: Software Policy and Peripheral Control re-sync when the parent arrives
+
+**Files:**
+- Modify: `apps/web/src/components/configurationPolicies/featureTabs/SoftwarePolicyTab.tsx:29-33`, `PeripheralControlTab.tsx:~40-50`
+- Test: their `*.test.tsx`
+
+- [ ] **Step 1: Failing test** — render with `parentLink={undefined}`, then `rerender` with `parentLink={{ featurePolicyId: 'sp-parent', ... }}` and no `existingLink`; expect the selection to become `sp-parent` (the inherited summary is fetched / rendered).
+- [ ] **Step 2: Run → FAIL.** **Step 3:** add `useEffect(() => { if (!existingLink) setSelectedPolicyId(parentLink?.featurePolicyId ?? null); }, [existingLink, parentLink]);`. With the embedded parent (Task 3) the parent arrives with the policy, so this is belt-and-braces, and it fixes the stale state on `handleLinkChanged` reverts too. **Step 4:** PASS; commit — `git commit -m "fix(web): reference tabs re-sync inherited selection"`.
+
+---
+
+### Task 8: Effective configuration tab — "inherited from"
+
+**Files:**
+- Modify: `apps/web/src/components/devices/DeviceEffectiveConfigTab.tsx:62-72` (type), render block near `:352-366`
+- Test: `apps/web/src/components/devices/DeviceEffectiveConfigTab.test.tsx` (append)
+
+- [ ] **Step 1: Failing test** — a feature with `inheritedFromPolicyId: 'p1', inheritedFromPolicyName: 'Baseline'` renders `data-testid="effective-config-inherited-from"` containing "Baseline"; a feature without it renders nothing.
+- [ ] **Step 2: Run → FAIL.** **Step 3:** add `inheritedFromPolicyId?: string | null; inheritedFromPolicyName?: string | null;` to `ResolvedFeature`; render `<p data-testid="effective-config-inherited-from">{t('deviceEffectiveConfigTab.inheritedFrom', { name })}</p>` ("Inherited from {{name}}") under the source-policy line; add the key to all 8 `devices.json`. **Step 4:** PASS; commit — `git commit -m "feat(web): effective config shows inherited-from provenance"`.
+
+---
+
+### Task 9: Docs and release notes
+
+**Files:**
+- Modify: the configuration-policies page under `apps/docs/src/content` (`grep -rli "configuration polic" apps/docs/src/content | head`), following the `update-breeze-docs` skill
+- Modify: the release-notes draft per the `update-breeze-release-notes` skill (next unreleased version entry)
+
+- [ ] **Step 1:** Docs: a "Baseline policies (inheritance)" section: what a parent is, the ownership rule in one table, one level only, override/revert, parent status does not gate inheritance, delete blocked while children exist, MFA on transitions that enable patch/maintenance. Screenshots optional.
+- [ ] **Step 2:** Release notes: the two bullets from the spec's *Release notes* section, plus "PostgreSQL 15+ required (`security_invoker` view)".
+- [ ] **Step 3:** Commit — `git commit -m "docs: configuration policy inheritance"`.
+
+---
+
+### Task 10: Typecheck, full web suites, PR
+
+- [ ] **Step 1:** `cd apps/web && npx tsc --noEmit -p tsconfig.json && npx eslint src/components/configurationPolicies src/components/devices/DeviceEffectiveConfigTab.tsx`.
+- [ ] **Step 2:** `npx vitest run src/components/configurationPolicies src/components/devices/DeviceEffectiveConfigTab src/lib/i18n --pool=threads --maxWorkers=2` green (the i18n suite catches locale gaps).
+- [ ] **Step 3:** Browser walk on a wt-stack (`worktree-stack` skill): create a partner-wide baseline with an event-log link; as a partner user create an org child linked to it; reload the child → banner present; override one tab, revert it; open the parent → "Inherited by 1 policies"; try to delete the parent → blocked list; device effective-config tab shows "Inherited from" once W02 is merged. Record PASS/FAIL per step in the PR body.
+- [ ] **Step 4:** Merge `origin/main`, re-run Step 2, push, open the PR with `Closes #<wave sub-issue>`, run `pr-review-toolkit:review-pr`, fix confirmed findings inline, **stop at the open PR**.

--- a/docs/superpowers/plans/config-policy/2026-09-06-config-policy-inheritance-03-web-and-docs.md
+++ b/docs/superpowers/plans/config-policy/2026-09-06-config-policy-inheritance-03-web-and-docs.md
@@ -1,3 +1,9 @@
+---
+tracking_issue: LanternOps/breeze#5080
+wave_issue: LanternOps/breeze#5083
+branch: feature/5080-config-policy-inheritance/wave-5083
+---
+
 # Config Policy Inheritance — W03 Web and Docs Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/specs/config-policy/2026-09-06-config-policy-inheritance-design.md
+++ b/docs/superpowers/specs/config-policy/2026-09-06-config-policy-inheritance-design.md
@@ -92,14 +92,24 @@ Enforced twice:
    parent being deleted between check and insert, is closed by the FK: the insert fails with
    23503 and is mapped to the same 400 as "parent not found". The other race, the parent gaining
    a parent, cannot happen because `parent_policy_id` is immutable after create.
-2. **Database trigger** `configuration_policies_parent_guard` (BEFORE INSERT, and BEFORE UPDATE
-   OF `parent_policy_id`) as defense in depth. It re-checks the rule by selecting the parent as
-   the invoking role, so under FORCE RLS a parent the caller cannot see is treated as not found.
-   It also rejects any UPDATE that changes a non-null `parent_policy_id` (immutability). It
-   deliberately does **not** fire on `UPDATE OF org_id`: org merge re-points `org_id` on parent
-   and child in separate statements inside one transaction, and both rows move to the same
-   target org, so the rule holds again by commit. The guard raises SQLSTATE 23514 with a fixed
-   constraint name so the route can map it to a 400 with a stable error code.
+2. **Database constraint trigger** `configuration_policies_parent_guard`: an AFTER ROW
+   **constraint trigger**, `DEFERRABLE INITIALLY IMMEDIATE`, on `configuration_policies` for
+   `INSERT` and `UPDATE OF parent_policy_id, org_id, partner_id`. It validates **both directions**
+   of the edge for the affected row: the row's own parent (outgoing) and every row that names
+   this row as parent (incoming), against the ownership rule and the one-level rule. It also
+   enforces immutability: any UPDATE where `parent_policy_id IS DISTINCT FROM` the old value is
+   rejected, including `NULL → value`, so an existing baseline can never acquire a parent later.
+   It reads the other rows as the invoking role, so under FORCE RLS a parent the caller cannot see
+   is treated as not found. Because it is a constraint trigger, org merge's
+   `SET CONSTRAINTS ALL DEFERRED` postpones it to commit, by which time parent and child have both
+   moved to the target org and the rule holds again; no `org_id` exclusion is needed. A matching
+   constraint trigger on `organizations` for `UPDATE OF partner_id` re-validates that org's
+   children of partner-wide parents (no code path changes an org's partner today; the trigger is
+   cheap insurance so the invariant does not depend on that staying true). Both raise SQLSTATE
+   23514 with a fixed constraint name so the route maps it to a 400 with a stable error code.
+   Residual race: a child created concurrently with a system-context ownership move of its parent
+   is validated in each transaction's own snapshot; ownership moves are org merges, which already
+   serialize the orgs they touch, so this is accepted and documented rather than locked against.
 
 Error surface: `400 { error: 'INVALID_PARENT_POLICY' }` for not-found / not-eligible /
 cross-tenant / has-its-own-parent, one message for all of them so it is not an existence oracle.
@@ -138,7 +148,8 @@ ALTER TABLE configuration_policies ADD CONSTRAINT configuration_policies_not_own
   CHECK (parent_policy_id IS NULL OR parent_policy_id <> id);
 CREATE INDEX IF NOT EXISTS config_policies_parent_policy_id_idx
   ON configuration_policies (parent_policy_id) WHERE parent_policy_id IS NOT NULL;
--- trigger function + trigger: see Ownership rule. CREATE OR REPLACE FUNCTION, DROP TRIGGER IF EXISTS, CREATE TRIGGER.
+-- constraint triggers: see Ownership rule. CREATE OR REPLACE FUNCTION, DROP TRIGGER IF EXISTS,
+-- CREATE CONSTRAINT TRIGGER ... DEFERRABLE INITIALLY IMMEDIATE ... FOR EACH ROW.
 ```
 
 **Effective-links view** (first view in the repo; the reasons it is a view and not a helper are
@@ -168,9 +179,16 @@ GRANT SELECT ON config_policy_effective_feature_links TO breeze_app;
   `config_policy_feature_links_partner_wide_select` branch, which is also populated on the
   agent-auth path (`currentPartnerId`), so agent config delivery inherits correctly without any
   system-context escalation.
-- Drizzle: declare with `pgView(...).existing()` so drizzle-kit never tries to manage it; the
-  `id` column is the underlying link id (an inherited row reuses the parent link's id, which is
-  what feature-link-id keyed readers such as the automation schedule trigger already expect).
+- Drizzle: declare with `pgView(...).existing()` so drizzle-kit never tries to manage it.
+- **An inherited row keeps the parent link's `id` on purpose.** The normalized per-feature
+  settings tables (`config_policy_patch_settings`, `config_policy_backup_settings`,
+  `config_policy_onedrive_settings`, `config_policy_automations`, ...) are keyed by
+  `feature_link_id`, and every resolver that needs them joins on `links.id`
+  (`featureConfigResolver.ts` L683 for patch). A synthetic id would break those joins. The
+  consequence, that one link id now maps to the parent **and** its children, is handled by the
+  execution-identity rule in Resolver sweep. `inline_settings` is a compatibility mirror that some
+  migrated links omit; readers that need assembled settings keep joining their normalized table
+  through `id`, exactly as they do today, so the view changes nothing about assembly.
 - `pnpm db:check-drift` must be run in W01 to confirm the drift checker is view-neutral; if it is
   not, the fix is in `scripts/check-drift.ts`, not in the migration.
 - `rls-coverage.integration.test.ts` enumerates tables; a view carries no RLS of its own and must
@@ -192,18 +210,43 @@ so this is documented on the registry entry, not handled.
   `createConfigPolicySchema`). Validated per Ownership rule. `updateConfigPolicySchema` does not
   accept it.
 - `GET /configuration-policies/:id`: adds `parentPolicyId: string | null`,
-  `parentPolicy: { id, name, status } | null`, `childPolicies: { id, name }[]`. `featureLinks`
-  stays the policy's **own** links (the editor must never show inherited rows as authored).
-- `GET /configuration-policies` (list): adds `parentPolicyId` per row (and `parentName` when
-  cheap via the existing join) so the list can badge children and the create page can filter
-  eligible parents client-side (`parentPolicyId === null` and owner-compatible).
+  `parentPolicy: { id, name, status, featureLinks } | null` (the parent's **assembled** links, the
+  same shape `listFeatureLinks` returns), `childPolicies: { id, name }[]`. `featureLinks` stays
+  the policy's **own** links (the editor must never show inherited rows as authored).
+  The parent embed is fetched server-side through RLS, **not** through `policyAccessCondition`:
+  that condition deliberately hides partner-wide policies from org-scoped get/list so the org UI
+  never offers to edit the MSP's shared policies, and it stays that way. The embed is read-only,
+  is only ever the parent of a policy the caller can already see, and the parent's rows are
+  already SELECT-visible under RLS (the same visibility the agent path relies on). The web
+  renders it read-only and links to the parent page only when the caller can open it.
+- `GET /configuration-policies/eligible-parents?ownerScope=organization&orgId=…` (or
+  `ownerScope=partner`): `{ id, name, ownerScope }[]`, filtered server-side by the ownership rule
+  and `parent_policy_id IS NULL`. For an org-scoped caller this includes the partner-wide
+  policies of their partner by name only; no links, no other partner's rows (tested). This is the
+  one narrow, names-only widening of org-scoped read visibility, and it exists so an org tech can
+  inherit the MSP baseline, which is the product story.
+- `GET /configuration-policies` (list): adds `parentPolicyId` per row so the list can badge
+  children. The create page uses the eligible-parents endpoint, not the list.
+- **MFA gate follows effectiveness, not the verb.** Today POST/PATCH of a `patch` or
+  `maintenance` link requires a satisfied-MFA session and DELETE does not, because removing a
+  link ends suppression (`featureLinks.ts` L66-80). With inheritance a DELETE of a child's
+  override can *restore* the parent's suppression, and creating a child of a parent that has such
+  a link *enables* it. Rule: any transition that makes an MFA-gated feature type effective on a
+  policy requires the same session-MFA check: POST/PATCH of that type (unchanged), DELETE of an
+  override whose parent has a link of that type, and `POST /configuration-policies` with a
+  `parentPolicyId` whose parent has a link of that type.
 - `GET /configuration-policies/effective/:deviceId` and the diff preview: each resolved feature
   adds `inheritedFromPolicyId: string | null` and `inheritedFromPolicyName: string | null`.
 - `DELETE /configuration-policies/:id`: `409 POLICY_HAS_CHILDREN` as above.
 - Partner API configuration export (`routes/partnerApi/configuration.ts`): add `parentPolicyId`
-  to the policy shape. Links remain the authored form (own links only) plus the parent pointer;
-  consumers derive the effective set. This keeps the per-org export clocks correct without fanning
-  a partner-wide parent's change out to every child org.
+  to the policy shape, and export the **parent closure**: `policySource` selects policies through
+  their assignments, so an unassigned baseline would vanish while its exported children reference
+  it. Parents of exported policies are included (as `sourceScope` rows with no assignment org
+  binding beyond the child's) so a consumer can reconstruct inheritance. Links remain the authored
+  form (own links only); consumers derive the effective set. The material clocks already fan a
+  partner-wide policy's change out to every org under the partner (the clock triggers join
+  `organizations` on `org_id IS NULL AND partner_id`), so no clock change is needed. Full and
+  incremental export tests cover a parent edit surfacing on the child's org.
 
 ## Resolver sweep
 
@@ -231,15 +274,31 @@ Readers that must switch (file → functions):
 - `services/helperPermissions.ts` → `resolveHelperPermissionLevelForDevice`
 - `services/warrantyAlertEvaluator.ts` → `resolveWarrantySettings`, `evaluateWarrantyAlerts`
 - `routes/remote/helpers.ts` → `resolveRemoteSessionPromptConfig`
-- `jobs/automationWorker.ts` → `processTriggerConfigPolicySchedule` (**id-keyed**: it resolves a
-  `featureLinkId` to a policy; through the view one link id maps to the parent **and** every
-  child, so the plan must decide per call site whether the dispatch fans out per assigned
-  policy or stays keyed on the authoring policy. Do not switch it blindly.)
 - `jobs/backupWorker.ts` → `processCheckSchedules`
 - `jobs/patchSchedulerWorker.ts` → `scanAndCreateJobs`
+- `services/configPolicyPatching.ts` → `loadPolicyLocalPatchConfig(configPolicyId)` (joins the
+  authored links; after the scheduler scan switches, an inherited child would be discovered and
+  then skipped as `null` here). Becomes an **effective** loader through the view, returning
+  `sourcePolicyId`. Its other callers, `services/patchJobSnapshot.ts` and the manual patch
+  operations in `routes/configurationPolicies/patchJobs.ts`, get inheritance through it.
 - `services/patchJobService.ts` → `createPatchJobFromConfigPolicy`,
-  `createPatchJobForDeviceFromPolicy`
-- `services/automationRuntime.ts` → `resolveConfigPolicyAutomationContext`
+  `createPatchJobForDeviceFromPolicy` (see execution identity)
+- `jobs/automationWorker.ts` → `scanScheduledAutomations` grouping and
+  `processTriggerConfigPolicySchedule`; `services/automationRuntime.ts` →
+  `resolveConfigPolicyAutomationContext` (see execution identity)
+
+**Execution identity.** Three call sites reverse-map a link id to "the" policy with `LIMIT 1`
+(`automationRuntime.ts` L2835, `automationWorker.ts` L769, `patchJobService.ts` L126), and the
+automation scan groups candidates by automation id (`automationWorker.ts` L209). Through the view
+one link id belongs to the parent and every child, so a reverse map picks an arbitrary policy and
+the run-time ownership clamp (#2286) would clamp to the wrong org. Rule: **the assigned policy id
+travels with the link id.** Resolver results already return `configPolicyId`
+(`ResolvedPatchConfigDetails`); patch job creation consumes that instead of the reverse map.
+Automation schedule grouping keys on `(automation id, assigned policy id)`, the job payload
+carries `configPolicyId`, and the run-time clamp re-reads ownership from `configuration_policies`
+by that id and verifies the link is effective for that policy through the view. Integration test:
+one partner-wide parent with an automation link, two children in two orgs, one scheduled tick →
+two runs, each scoped to its own org's devices.
 
 Readers that keep the base table (they edit or report a policy's **own** links):
 `configurationPolicy.ts` link CRUD (`addFeatureLink`, `updateFeatureLink`, `removeFeatureLink`,
@@ -285,11 +344,15 @@ that adds its own resolver against the base table goes red in **Test API**, not 
   "Inherited by N policies" line with links on a parent's Overview tab.
 - **List page**: a small "inherits ← <parent>" badge on child rows. Delete of a parent shows the
   409 children list in the confirm modal's error state.
-- **Feature tabs**: the 13 inline-settings tabs send `featurePolicyId: null` (not
-  `linkedPolicyId`). Security, Sensitive Data, and Remote Access gain the same
-  `isInherited` / `effectiveLink` / Override / Revert treatment via `FeatureTabShell`. Backup,
-  Peripheral Control, and Software Policy already handle the feature entity id correctly and
-  stay as they are.
+- **Feature tabs**: the plan carries a per-tab payload matrix (18 rows: what `featurePolicyId`
+  legitimately means for that tab, if anything). Inline-settings tabs send `featurePolicyId:
+  null` instead of `linkedPolicyId`; tabs whose `featurePolicyId` is a real entity (Patch = update
+  ring, Backup = profile, Software Policy, Peripheral Control) keep it. Security, Sensitive Data,
+  and Remote Access gain the same `isInherited` / `effectiveLink` / Override / Revert treatment
+  via `FeatureTabShell`. Software Policy and Peripheral Control initialise their selection once
+  from `effectiveLink` before the parent's links have loaded (`SoftwarePolicyTab.tsx` L31,
+  `PeripheralControlTab.tsx` L46); they must re-sync when `parentLink` arrives, with a
+  delayed-parent-load test.
 - **Effective configuration tab** (`DeviceEffectiveConfigTab.tsx`): when a feature carries
   `inheritedFromPolicyId`, render "via <child> ← inherited from <parent>".
 - i18n: new keys in all 8 locales; the existing `inheritingFrom` / `parentPolicy` /
@@ -326,8 +389,25 @@ Each wave: TDD, `tsc`, targeted tests, then the contract suites that a live DB n
   one agent helper before/after as `breeze_app`.
 - **Org merge.** Trigger excluded from `UPDATE OF org_id`; `orgLifecycleFoundations` and
   `orgMerge` integration suites run in W01.
+- **Execution identity.** A missed reverse map silently runs a child's automation under the
+  parent's org clamp. The contract test forbids direct base-table reads; the plan additionally
+  greps for `.limit(1)` against the view and requires the assigned policy id at each site.
 - **Semantics surprise: archived parent still inherited.** Surfaced in the UI (children count on
   the parent, "inherited from <parent> (inactive)" banner state on the child) and in docs.
+
+## Review log
+
+- 2026-09-06 quorum on the approach (Fable + Codex gpt-5.6-sol xhigh): option A, one level.
+- 2026-09-06 spec review (Codex gpt-6-astra xhigh, read-only against the repo), 9 findings, all
+  verified in code and folded in: immutability must reject `NULL → value` (Ownership 2);
+  ownership must stay valid after insert → constraint trigger on both directions, deferrable for
+  merge (Ownership 2); shared link ids need an explicit execution identity (Resolver sweep);
+  `configPolicyPatching.loadPolicyLocalPatchConfig` was missing from the sweep; the view keeps
+  the parent link id for normalized-table joins (Data model); `policyAccessCondition` hides
+  partner-wide parents from org-scoped reads → parent embed + eligible-parents endpoint (API);
+  maintenance-link removal is MFA-exempt on a premise inheritance breaks (API); partner export
+  selects through assignments and its clocks already fan out (API); Software Policy and Peripheral
+  Control tabs initialise before parent links load (Web).
 
 ## Release notes
 

--- a/docs/superpowers/specs/config-policy/2026-09-06-config-policy-inheritance-design.md
+++ b/docs/superpowers/specs/config-policy/2026-09-06-config-policy-inheritance-design.md
@@ -99,8 +99,10 @@ Enforced twice:
    this row as parent (incoming), against the ownership rule and the one-level rule. It also
    enforces immutability: any UPDATE where `parent_policy_id IS DISTINCT FROM` the old value is
    rejected, including `NULL → value`, so an existing baseline can never acquire a parent later.
-   It reads the other rows as the invoking role, so under FORCE RLS a parent the caller cannot see
-   is treated as not found. Any UPDATE that changes `org_id` or `partner_id` is rejected outright
+   The trigger function is `SECURITY DEFINER` like the existing PAM move guard
+   (`breeze_guard_pam_device_org_move`): the ownership **rule** is what rejects a cross-tenant
+   edge, and the service layer masks "not visible" as "not found" before the insert ever reaches
+   the trigger. Any UPDATE that changes `org_id` or `partner_id` is rejected outright
    unless `breeze_current_scope() = 'system'`: the HTTP API never changes ownership, org merge
    runs in system context, and this closes the blind spot where a partner-scoped invoker could
    move a baseline while RLS hides some of its children from the incoming-edge check. Because it is a constraint trigger, org merge's
@@ -213,7 +215,7 @@ so this is documented on the registry entry, not handled.
   `createConfigPolicySchema`). Validated per Ownership rule. `updateConfigPolicySchema` does not
   accept it.
 - `GET /configuration-policies/:id`: adds `parentPolicyId: string | null`,
-  `parentPolicy: { id, name, status, featureLinks } | null` (the parent's **assembled** links, the
+  `parentPolicy: { id, name, status, orgId, featureLinks } | null` (the parent's **assembled** links, the
   same shape `listFeatureLinks` returns), `childPolicies: { id, name }[]`. `featureLinks` stays
   the policy's **own** links (the editor must never show inherited rows as authored).
   The parent embed is fetched server-side through RLS, **not** through `policyAccessCondition`:

--- a/docs/superpowers/specs/config-policy/2026-09-06-config-policy-inheritance-design.md
+++ b/docs/superpowers/specs/config-policy/2026-09-06-config-policy-inheritance-design.md
@@ -100,7 +100,10 @@ Enforced twice:
    enforces immutability: any UPDATE where `parent_policy_id IS DISTINCT FROM` the old value is
    rejected, including `NULL → value`, so an existing baseline can never acquire a parent later.
    It reads the other rows as the invoking role, so under FORCE RLS a parent the caller cannot see
-   is treated as not found. Because it is a constraint trigger, org merge's
+   is treated as not found. Any UPDATE that changes `org_id` or `partner_id` is rejected outright
+   unless `breeze_current_scope() = 'system'`: the HTTP API never changes ownership, org merge
+   runs in system context, and this closes the blind spot where a partner-scoped invoker could
+   move a baseline while RLS hides some of its children from the incoming-edge check. Because it is a constraint trigger, org merge's
    `SET CONSTRAINTS ALL DEFERRED` postpones it to commit, by which time parent and child have both
    moved to the target org and the rule holds again; no `org_id` exclusion is needed. A matching
    constraint trigger on `organizations` for `UPDATE OF partner_id` re-validates that org's
@@ -228,13 +231,15 @@ so this is documented on the registry entry, not handled.
 - `GET /configuration-policies` (list): adds `parentPolicyId` per row so the list can badge
   children. The create page uses the eligible-parents endpoint, not the list.
 - **MFA gate follows effectiveness, not the verb.** Today POST/PATCH of a `patch` or
-  `maintenance` link requires a satisfied-MFA session and DELETE does not, because removing a
-  link ends suppression (`featureLinks.ts` L66-80). With inheritance a DELETE of a child's
-  override can *restore* the parent's suppression, and creating a child of a parent that has such
-  a link *enables* it. Rule: any transition that makes an MFA-gated feature type effective on a
-  policy requires the same session-MFA check: POST/PATCH of that type (unchanged), DELETE of an
-  override whose parent has a link of that type, and `POST /configuration-policies` with a
-  `parentPolicyId` whose parent has a link of that type.
+  `maintenance` link requires a satisfied-MFA session; DELETE of a `patch` link is gated
+  unconditionally (`featureLinks.ts` L483) and DELETE of a `maintenance` link is deliberately
+  exempt because removal ends suppression (`featureLinks.ts` L66-80). With inheritance a DELETE
+  of a child's maintenance override can *restore* the parent's suppression, and creating a child
+  of a parent that has a gated link *enables* it. Rule: every existing gate stays exactly as it
+  is (patch DELETE remains unconditional), and two transitions are added: DELETE of a
+  `maintenance` override whose parent has a `maintenance` link, and `POST /configuration-policies`
+  with a `parentPolicyId` whose parent has a link of any `MFA_GATED_FEATURE_TYPES` type. Both use
+  `hasSatisfiedMfa` (session-claim strength, matching the adjacent gates).
 - `GET /configuration-policies/effective/:deviceId` and the diff preview: each resolved feature
   adds `inheritedFromPolicyId: string | null` and `inheritedFromPolicyName: string | null`.
 - `DELETE /configuration-policies/:id`: `409 POLICY_HAS_CHILDREN` as above.
@@ -296,9 +301,18 @@ travels with the link id.** Resolver results already return `configPolicyId`
 (`ResolvedPatchConfigDetails`); patch job creation consumes that instead of the reverse map.
 Automation schedule grouping keys on `(automation id, assigned policy id)`, the job payload
 carries `configPolicyId`, and the run-time clamp re-reads ownership from `configuration_policies`
-by that id and verifies the link is effective for that policy through the view. Integration test:
-one partner-wide parent with an automation link, two children in two orgs, one scheduled tick →
-two runs, each scoped to its own org's devices.
+by that id and verifies the link is effective for that policy through the view. Both BullMQ job
+ids gain the assigned policy id as well
+(`cp-automation-schedule-<automation>-<policy>-<slot>`, `cp-automation-run:<automation>:<policy>:<slot>`;
+`automationWorker.ts` L421 and L862 key on automation + slot today, which would collapse the
+children's dispatches onto one job). Splitting dispatches per assigned policy can then run the
+same inherited automation twice for a device covered by two assigned policies (parent assigned at
+org level, child at site level): each dispatch keeps only the devices whose **winning** automation
+assignment, per the existing hierarchy resolution, is the dispatch's assigned policy, so it is one
+execution per device per tick. Integration tests: one partner-wide parent with an automation
+link, two children in two orgs, one scheduled tick → two runs, each scoped to its own org's
+devices, distinct job ids through both queue stages, replay-deduplicated; and an overlapping
+parent/child assignment → the device runs once.
 
 Readers that keep the base table (they edit or report a policy's **own** links):
 `configurationPolicy.ts` link CRUD (`addFeatureLink`, `updateFeatureLink`, `removeFeatureLink`,
@@ -338,10 +352,15 @@ that adds its own resolver against the base table goes red in **Test API**, not 
   and owner-compatible with the chosen owner scope (same org, or partner-wide; partner-wide child
   → partner-wide parents only), excluding the policy being created. Server validation is the
   authority; the filter is a courtesy.
-- **Detail page**: `linkedPolicyId` comes from `policy.parentPolicyId`; the parent name from
-  `policy.parentPolicy`. The existing second fetch of the parent's feature links stays (RLS lets
-  an org user read a partner-wide parent). The `?linked=` initializer is deleted. New: a
-  "Inherited by N policies" line with links on a parent's Overview tab.
+- **Detail page**: `linkedPolicyId`, the parent name, and `parentFeatureLinks` all come from
+  `policy.parentPolicyId` / `policy.parentPolicy` (with its assembled `featureLinks`). The
+  existing direct fetch of `/configuration-policies/<parent>` is **removed**: for an org-scoped
+  caller of a partner-wide parent it 404s under `policyAccessCondition` and today's code swallows
+  that failure silently. The `?linked=` initializer is deleted. The banner links to the parent
+  page only when the caller can open it (partner scope, or same-org parent); otherwise it shows
+  the name with a "managed by your MSP" hint. New: an "Inherited by N policies" line with links
+  on a parent's Overview tab. Test: an org caller viewing a child of a partner-wide parent sees
+  inherited tabs populated with no extra request.
 - **List page**: a small "inherits ← <parent>" badge on child rows. Delete of a parent shows the
   409 children list in the confirm modal's error state.
 - **Feature tabs**: the plan carries a per-tab payload matrix (18 rows: what `featurePolicyId`
@@ -408,6 +427,13 @@ Each wave: TDD, `tsc`, targeted tests, then the contract suites that a live DB n
   maintenance-link removal is MFA-exempt on a premise inheritance breaks (API); partner export
   selects through assignments and its clocks already fan out (API); Software Policy and Peripheral
   Control tabs initialise before parent links load (Web).
+- 2026-09-06 second pass on the amended sections (gpt-6-astra xhigh): approve with changes, all
+  folded in: BullMQ job ids for both automation queue stages must carry the assigned policy id;
+  ownership changes are system-context only (closes the partner-scope incoming-edge blind spot);
+  per-policy dispatch must keep one execution per device per tick; the web must use the embedded
+  parent instead of the direct fetch; the unconditional patch-DELETE gate stays. Confirmed sound:
+  merge timing vs. the deferred constraint trigger, parent-read isolation, `hasSatisfiedMfa`,
+  run-record and idempotency identities once the assigned policy id reaches the runtime.
 
 ## Release notes
 

--- a/docs/superpowers/specs/config-policy/2026-09-06-config-policy-inheritance-design.md
+++ b/docs/superpowers/specs/config-policy/2026-09-06-config-policy-inheritance-design.md
@@ -1,7 +1,8 @@
 ---
 title: Configuration policy inheritance (persisted parent, one level)
-status: draft
+status: approved
 date: 2026-09-06
+tracking_issue: LanternOps/breeze#5080
 origin: "#5023 browser walk paper cut: 'inherited policy state only shows with ?linked='"
 ---
 

--- a/docs/superpowers/specs/config-policy/2026-09-06-config-policy-inheritance-design.md
+++ b/docs/superpowers/specs/config-policy/2026-09-06-config-policy-inheritance-design.md
@@ -1,0 +1,338 @@
+---
+title: Configuration policy inheritance (persisted parent, one level)
+status: draft
+date: 2026-09-06
+origin: "#5023 browser walk paper cut: 'inherited policy state only shows with ?linked='"
+---
+
+# Configuration policy inheritance
+
+## Problem
+
+The configuration-policy editor sells inheritance it does not have. "Link to Existing" on the
+create page picks a "Master Policy", POSTs an ordinary policy, and redirects to
+`/configuration-policies/<id>?linked=<parentId>`. The detail page reads `?linked=` from
+`window.location`, fetches the parent, and renders every feature tab as *Configured (inherited)*
+with an **Override** button. Nothing is persisted and nothing is resolved:
+
+- `configuration_policies` has no parent column. The link lives only in the URL, so a reload,
+  a bookmark, or the list page loses it. That is the symptom reported on #5023.
+- Every effective-config reader (the generic resolver, `featureConfigResolver.ts`, the agent
+  config-payload builders in `routes/agents/helpers.ts`, the lifecycle/helper/warranty resolvers,
+  the backup/patch/automation schedulers) joins `config_policy_feature_links` on the **assigned
+  policy's own id**. A device assigned to a "linked" child receives **nothing** for any tab the
+  tech did not explicitly override, while the UI says it is inherited.
+- Thirteen of the eighteen feature tabs stamp the parent *configuration policy* id into
+  `featurePolicyId` on save. `featurePolicyId` means a standalone feature entity (update ring,
+  backup profile, software policy). The value is never read back for inline-settings features,
+  but it is the wrong kind of id in a persisted column.
+- Three tabs (Security, Sensitive Data, Remote Access) ignore the parent entirely, so even the
+  display is inconsistent.
+
+Advisor quorum (Fable + Codex xhigh, 2026-09-06) agreed: persist the parent and make resolution
+honour it. Persisting the parent for display only was rejected (it persists a lie); copying the
+parent's links at create time was rejected unless the product becomes "duplicate policy".
+
+## Goals
+
+1. A policy's parent is a persisted, validated, tenant-safe fact returned by the API.
+2. Every reader that decides what a device gets sees the child's own links **plus** the parent's
+   links for feature types the child lacks. One definition, used everywhere, with a contract test
+   that keeps it that way.
+3. The web app derives all inheritance state from the API. No URL parameter.
+4. The feature-tab save payloads stop conflating id kinds.
+
+## Non-goals
+
+- Multi-level chains. A parent cannot itself have a parent (enforced).
+- Changing or detaching a parent after create. `parent_policy_id` is set at create only.
+  A "detach"/"re-parent" affordance is a natural follow-up once the invariants below exist.
+- Field-level merging. A child link is a complete override of the parent's link for that feature.
+- Backfill. No persisted state exists today, so there is nothing to migrate. Policies created
+  through the old "linked" flow were never linked; they stay plain policies.
+- AI tool support for creating linked policies (`aiToolsConfigPolicy.ts`). Follow-up.
+
+## Semantics
+
+**Effective links of a policy P** = P's own `config_policy_feature_links` rows, plus, when P has
+a parent, the parent's rows whose `feature_type` P has no row for.
+
+- An inherited link competes at the **child's** assignment level and priority. The parent's own
+  assignments are unaffected and unrelated.
+- The parent's `status` does not gate inheritance. Archiving a baseline does not silently strip
+  security, patch, or backup configuration from every child; only the assigned child's own
+  `status = active` matters, as today. The parent's detail page shows how many policies inherit
+  from it so the operator can see the blast radius.
+- A parent's link change propagates live. That is the point of a baseline.
+- Provenance: the resolved feature carries `sourcePolicyId` = the assigned child (which
+  assignment won) and, when the link came from the parent, `inheritedFromPolicyId` /
+  `inheritedFromPolicyName`.
+- Override = the child gains its own link for that feature (today's tabs already do this by
+  POSTing the parent-seeded form state). Revert = delete the child's link, falling back to the
+  parent (today's "Revert to Parent"). Both keep working unchanged.
+
+## Ownership rule (tenancy)
+
+`configuration_policies` is org-XOR-partner owned (`configuration_policies_one_owner_chk`). A
+child may reference a parent only when:
+
+| child | allowed parent |
+|---|---|
+| org-owned (`org_id = O`, org O belongs to partner P) | same org (`parent.org_id = O`), **or** partner-wide of the same partner (`parent.org_id IS NULL AND parent.partner_id = P`) |
+| partner-wide (`partner_id = P`) | partner-wide of the same partner only |
+
+Plus: `parent.parent_policy_id IS NULL` (one level), `parent.id <> child.id`.
+
+Enforced twice:
+
+1. **App layer** in `createConfigPolicy`, inside the insert's transaction: read the parent through
+   the request's RLS context, check the rule, then insert. No row lock: an org token cannot take
+   `FOR KEY SHARE` on a partner-wide parent (row locks apply the UPDATE policy, which the
+   partner-wide SELECT-only branch does not satisfy). The race that a lock would close, the
+   parent being deleted between check and insert, is closed by the FK: the insert fails with
+   23503 and is mapped to the same 400 as "parent not found". The other race, the parent gaining
+   a parent, cannot happen because `parent_policy_id` is immutable after create.
+2. **Database trigger** `configuration_policies_parent_guard` (BEFORE INSERT, and BEFORE UPDATE
+   OF `parent_policy_id`) as defense in depth. It re-checks the rule by selecting the parent as
+   the invoking role, so under FORCE RLS a parent the caller cannot see is treated as not found.
+   It also rejects any UPDATE that changes a non-null `parent_policy_id` (immutability). It
+   deliberately does **not** fire on `UPDATE OF org_id`: org merge re-points `org_id` on parent
+   and child in separate statements inside one transaction, and both rows move to the same
+   target org, so the rule holds again by commit. The guard raises SQLSTATE 23514 with a fixed
+   constraint name so the route can map it to a 400 with a stable error code.
+
+Error surface: `400 { error: 'INVALID_PARENT_POLICY' }` for not-found / not-eligible /
+cross-tenant / has-its-own-parent, one message for all of them so it is not an existence oracle.
+
+## Deletion
+
+- `DELETE /configuration-policies/:id` on a policy that has children returns
+  `409 { error: 'POLICY_HAS_CHILDREN', children: [{ id, name }] }`. The FK is the backstop: a
+  23503 from the self-FK maps to the same 409.
+- FK action is the default `NO ACTION` (not `RESTRICT`, not `SET NULL`). Verified on
+  PostgreSQL 16.15 (the prod version): a single `DELETE ... WHERE org_id = X` that removes parent
+  and children together succeeds under both, and deleting a parent alone is refused. `NO ACTION`
+  is the repo convention and stays deferrable-compatible for org merge. `SET NULL` was rejected
+  because a baseline deletion would silently un-configure every child.
+- Org cascade (`tenantCascade`) deletes all of an org's policies in one statement, so parents and
+  children in the same org go together. A partner-wide parent with children in the erased org:
+  the children go, the parent stays. Partner erasure deletes partner-wide rows after every org's
+  rows, so no child can outlive its parent there either. No change to the cascade lists is
+  needed (no new table); `tenantCascade.integration.test.ts` must still pass.
+
+## Data model
+
+Migration `apps/api/migrations/2026-10-12-100000-config-policy-inheritance.sql` (name must sort
+after the newest committed migration at the time it is written; verify against `origin/main`).
+Idempotent, no DML, so no `breeze.scope` election is needed.
+
+```sql
+ALTER TABLE configuration_policies
+  ADD COLUMN IF NOT EXISTS parent_policy_id uuid;
+-- self-FK, default NO ACTION
+ALTER TABLE configuration_policies DROP CONSTRAINT IF EXISTS configuration_policies_parent_policy_id_fkey;
+ALTER TABLE configuration_policies ADD CONSTRAINT configuration_policies_parent_policy_id_fkey
+  FOREIGN KEY (parent_policy_id) REFERENCES configuration_policies(id);
+ALTER TABLE configuration_policies DROP CONSTRAINT IF EXISTS configuration_policies_not_own_parent_chk;
+ALTER TABLE configuration_policies ADD CONSTRAINT configuration_policies_not_own_parent_chk
+  CHECK (parent_policy_id IS NULL OR parent_policy_id <> id);
+CREATE INDEX IF NOT EXISTS config_policies_parent_policy_id_idx
+  ON configuration_policies (parent_policy_id) WHERE parent_policy_id IS NOT NULL;
+-- trigger function + trigger: see Ownership rule. CREATE OR REPLACE FUNCTION, DROP TRIGGER IF EXISTS, CREATE TRIGGER.
+```
+
+**Effective-links view** (first view in the repo; the reasons it is a view and not a helper are
+in Resolver sweep):
+
+```sql
+CREATE OR REPLACE VIEW config_policy_effective_feature_links
+  WITH (security_invoker = true) AS
+  SELECT l.id, l.config_policy_id, l.config_policy_id AS source_policy_id,
+         l.feature_type, l.feature_policy_id, l.inline_settings, l.created_at, l.updated_at,
+         false AS inherited
+    FROM config_policy_feature_links l
+  UNION ALL
+  SELECT pl.id, c.id AS config_policy_id, pl.config_policy_id AS source_policy_id,
+         pl.feature_type, pl.feature_policy_id, pl.inline_settings, pl.created_at, pl.updated_at,
+         true AS inherited
+    FROM configuration_policies c
+    JOIN config_policy_feature_links pl ON pl.config_policy_id = c.parent_policy_id
+   WHERE c.parent_policy_id IS NOT NULL
+     AND NOT EXISTS (SELECT 1 FROM config_policy_feature_links own
+                      WHERE own.config_policy_id = c.id AND own.feature_type = pl.feature_type);
+GRANT SELECT ON config_policy_effective_feature_links TO breeze_app;
+```
+
+- `security_invoker = true` (PostgreSQL 15+; prod is 16.15) makes the base tables' RLS apply to
+  the caller. An org-scoped context sees a partner-wide parent's links through the existing
+  `config_policy_feature_links_partner_wide_select` branch, which is also populated on the
+  agent-auth path (`currentPartnerId`), so agent config delivery inherits correctly without any
+  system-context escalation.
+- Drizzle: declare with `pgView(...).existing()` so drizzle-kit never tries to manage it; the
+  `id` column is the underlying link id (an inherited row reuses the parent link's id, which is
+  what feature-link-id keyed readers such as the automation schedule trigger already expect).
+- `pnpm db:check-drift` must be run in W01 to confirm the drift checker is view-neutral; if it is
+  not, the fix is in `scripts/check-drift.ts`, not in the migration.
+- `rls-coverage.integration.test.ts` enumerates tables; a view carries no RLS of its own and must
+  not be added to any allowlist. W01 runs the suite to confirm.
+
+Drizzle schema: `parentPolicyId: uuid('parent_policy_id')` on `configurationPolicies` with the
+self-reference declared via the `AnyPgColumn` pattern.
+
+Registries: `tenantExportPolicyRegistry.ts` → add `parent_policy_id` to the `included` bucket of
+`configuration_policies` (a plain tenant identifier). No cascade-list change (no new table, no new
+`device_id`). Org merge: `configuration_policies` is already in `REPOINT_TABLES`; nothing to add.
+Export note: an org export may carry a `parent_policy_id` that points at a partner-wide parent
+outside the export set. There is no import path today (the roundtrip suite exports and erases),
+so this is documented on the registry entry, not handled.
+
+## API
+
+- `POST /configuration-policies`: `parentPolicyId?: uuid` (shared validator
+  `createConfigPolicySchema`). Validated per Ownership rule. `updateConfigPolicySchema` does not
+  accept it.
+- `GET /configuration-policies/:id`: adds `parentPolicyId: string | null`,
+  `parentPolicy: { id, name, status } | null`, `childPolicies: { id, name }[]`. `featureLinks`
+  stays the policy's **own** links (the editor must never show inherited rows as authored).
+- `GET /configuration-policies` (list): adds `parentPolicyId` per row (and `parentName` when
+  cheap via the existing join) so the list can badge children and the create page can filter
+  eligible parents client-side (`parentPolicyId === null` and owner-compatible).
+- `GET /configuration-policies/effective/:deviceId` and the diff preview: each resolved feature
+  adds `inheritedFromPolicyId: string | null` and `inheritedFromPolicyName: string | null`.
+- `DELETE /configuration-policies/:id`: `409 POLICY_HAS_CHILDREN` as above.
+- Partner API configuration export (`routes/partnerApi/configuration.ts`): add `parentPolicyId`
+  to the policy shape. Links remain the authored form (own links only) plus the parent pointer;
+  consumers derive the effective set. This keeps the per-org export clocks correct without fanning
+  a partner-wide parent's change out to every child org.
+
+## Resolver sweep
+
+Every reader classified as *effective-config resolver*, *agent-facing delivery*, or
+*worker/scheduler* in the 2026-09-06 inventory switches its join from `configPolicyFeatureLinks`
+to the view (`configPolicyEffectiveFeatureLinks`). The join shape is identical
+(`config_policy_id = configuration_policies.id AND feature_type = X`), which is why a view beats a
+TypeScript helper here: 25 independently coded queries change one identifier each instead of being
+restructured around a post-fetch merge.
+
+Readers that must switch (file → functions):
+
+- `services/configurationPolicy.ts` → `resolveEffectiveConfigWithExecutor` (+ provenance fields)
+- `services/featureConfigResolver.ts` → `resolveGoverningAlertRulePolicyForDevice`,
+  `resolveAlertRulesForDevice`, `resolveAutomationsForDevice`, `resolvePatchConfigForDevice`,
+  `resolvePatchConfigDetailsForDevice`, `resolveBackupConfigForDevice`,
+  `resolveMaintenanceConfigForDevice`, `resolveComplianceRulesForDevice`,
+  `resolveSoftwarePolicyForDevice`, `resolveDeviceIdsForSoftwarePolicy`,
+  `resolveVulnerabilityEnabledForDevice`, `resolveAllVulnerabilityEnabledDevices`,
+  `resolveAllBackupAssignedDevices`, `resolveBackupProtectionForDevice`,
+  `scanScheduledAutomations`, `scanDueComplianceChecks`
+- `routes/agents/helpers.ts` → event_log, monitoring, helper, pam, onedrive_helper resolvers and
+  their `build*ConfigUpdate` callers
+- `services/deviceLifecyclePolicy.ts` → `getOrgPurgeRemovedAfterDays`
+- `services/helperPermissions.ts` → `resolveHelperPermissionLevelForDevice`
+- `services/warrantyAlertEvaluator.ts` → `resolveWarrantySettings`, `evaluateWarrantyAlerts`
+- `routes/remote/helpers.ts` → `resolveRemoteSessionPromptConfig`
+- `jobs/automationWorker.ts` → `processTriggerConfigPolicySchedule` (**id-keyed**: it resolves a
+  `featureLinkId` to a policy; through the view one link id maps to the parent **and** every
+  child, so the plan must decide per call site whether the dispatch fans out per assigned
+  policy or stays keyed on the authoring policy. Do not switch it blindly.)
+- `jobs/backupWorker.ts` → `processCheckSchedules`
+- `jobs/patchSchedulerWorker.ts` → `scanAndCreateJobs`
+- `services/patchJobService.ts` → `createPatchJobFromConfigPolicy`,
+  `createPatchJobForDeviceFromPolicy`
+- `services/automationRuntime.ts` → `resolveConfigPolicyAutomationContext`
+
+Readers that keep the base table (they edit or report a policy's **own** links):
+`configurationPolicy.ts` link CRUD (`addFeatureLink`, `updateFeatureLink`, `removeFeatureLink`,
+`listFeatureLinks`), `routes/updateRingsHelpers.ts`, `routes/policyManagement/*`,
+`routes/scripts.ts` delete guard, `routes/backup/profiles.ts` delete guard,
+`routes/softwareInventory.ts` `ensureDefaultConfigPolicyLink`, `aiTools*.ts`,
+`routes/partnerApi/configuration.ts`, `scripts/migrateToConfigPolicies.ts`,
+`services/alertCorrelationRca.ts` (evidence naming). Where a "which devices does this standalone
+policy govern" reverse lookup exists (`resolveDeviceIdsForSoftwarePolicy`, update-ring device
+counts, backup profile `referencingPolicies`), it switches to the view too when it feeds
+enforcement, and stays on the base table when it only guards deletion of the standalone entity.
+The plan lists each with its classification.
+
+**Contract test** `apps/api/src/services/featureLinkReaders.contract.test.ts` (unit job): reads
+the source tree, and fails if any file outside a fixed allowlist imports `configPolicyFeatureLinks`
+or mentions `config_policy_feature_links` in a query. The allowlist is the "keep the base table"
+set above. This is the mechanical guard, in the spirit of the cascade lists: a new feature type
+that adds its own resolver against the base table goes red in **Test API**, not in production.
+
+**Integration proof** `configPolicyInheritance.integration.test.ts` (real Postgres):
+1. Org-scoped token creates a child of a same-org parent; a child of a partner-wide parent of the
+   same partner; both succeed. A child of another org's parent, a child of another partner's
+   partner-wide policy, and a child of a policy that already has a parent all fail with
+   `INVALID_PARENT_POLICY`. A forged insert as `breeze_app` bypassing the route hits the trigger.
+2. A device assigned to the child receives the parent's link for an un-overridden feature and the
+   child's link for an overridden one, through the generic resolver, through one
+   `featureConfigResolver` function, and through one agent helper (event_log) under the **agent
+   auth context** with a partner-wide parent.
+3. Deleting the parent alone → 409; deleting the child, then the parent → ok; org cascade with
+   parent and child in the org → ok.
+4. Effective-config provenance reports `inheritedFromPolicyId` on the inherited feature only.
+
+## Web
+
+- **Create page**: "Link to Existing" sends `parentPolicyId` in the POST and no longer appends
+  `?linked=`. `PolicyLinkSelector` gets an `eligibleParent` filter: `parentPolicyId === null`
+  and owner-compatible with the chosen owner scope (same org, or partner-wide; partner-wide child
+  → partner-wide parents only), excluding the policy being created. Server validation is the
+  authority; the filter is a courtesy.
+- **Detail page**: `linkedPolicyId` comes from `policy.parentPolicyId`; the parent name from
+  `policy.parentPolicy`. The existing second fetch of the parent's feature links stays (RLS lets
+  an org user read a partner-wide parent). The `?linked=` initializer is deleted. New: a
+  "Inherited by N policies" line with links on a parent's Overview tab.
+- **List page**: a small "inherits ← <parent>" badge on child rows. Delete of a parent shows the
+  409 children list in the confirm modal's error state.
+- **Feature tabs**: the 13 inline-settings tabs send `featurePolicyId: null` (not
+  `linkedPolicyId`). Security, Sensitive Data, and Remote Access gain the same
+  `isInherited` / `effectiveLink` / Override / Revert treatment via `FeatureTabShell`. Backup,
+  Peripheral Control, and Software Policy already handle the feature entity id correctly and
+  stay as they are.
+- **Effective configuration tab** (`DeviceEffectiveConfigTab.tsx`): when a feature carries
+  `inheritedFromPolicyId`, render "via <child> ← inherited from <parent>".
+- i18n: new keys in all 8 locales; the existing `inheritingFrom` / `parentPolicy` /
+  `overrideIndividualTabsToCustomizeSettings` keys are reused.
+- Tests: create page posts `parentPolicyId` and filters the selector; detail page renders the
+  banner from API data with no URL param and lists children; list badge; a tab test proving the
+  save payload carries `featurePolicyId: null`; the three newly inheriting tabs each get an
+  "inherited → Override" test (pattern: `DeviceLifecycleTab.test.tsx:129`).
+
+## Waves
+
+| wave | scope | depends on |
+|---|---|---|
+| W01 API foundation | migration (column, FK, CHECK, index, trigger, view, grant), Drizzle schema + existing-view, shared validator, create validation + delete 409, GET/list/partner-API shapes, export-policy bucket, unit tests, integration suite parts 1, 3 | — |
+| W02 Resolver sweep | switch every listed reader to the view, provenance fields, contract test, integration suite parts 2, 4 | W01 |
+| W03 Web + docs | create/detail/list/tabs/effective tab, i18n, web tests, `apps/docs` configuration-policies page, release-notes entry | W01 (API shape); parallel with W02 |
+
+Rigor: high on W01 and W02 (migration, RLS-adjacent trigger, agent-shipped config). W03 is UI.
+Each wave: TDD, `tsc`, targeted tests, then the contract suites that a live DB needs
+(`rls-coverage`, `tenantCascade`, `tenant-export-policy`, the new inheritance suite) before PR.
+
+## Risks and mitigations
+
+- **First view in the repo.** Unknowns are the drift checker and any test that enumerates
+  relations. Both are checked in W01 before anything depends on the view. There is no fallback
+  to a plain view: without `security_invoker` a view runs as its owner and bypasses RLS. The
+  repo already requires PostgreSQL 15+ (the #3258 pre-release gate confirmed prod is on 16);
+  the release notes restate it.
+- **Missed reader.** The contract test turns a missed reader into a unit-job failure. The plan's
+  reader list is the inventory above; W02 re-greps at start.
+- **Performance.** Policies number in the dozens per tenant; the view is a `UNION ALL` with a
+  correlated `NOT EXISTS` on an indexed `(config_policy_id, feature_type)` unique index. Agent
+  config delivery already runs several of these joins per heartbeat; W02 compares `EXPLAIN` for
+  one agent helper before/after as `breeze_app`.
+- **Org merge.** Trigger excluded from `UPDATE OF org_id`; `orgLifecycleFoundations` and
+  `orgMerge` integration suites run in W01.
+- **Semantics surprise: archived parent still inherited.** Surfaced in the UI (children count on
+  the parent, "inherited from <parent> (inactive)" banner state on the child) and in docs.
+
+## Release notes
+
+- New: configuration policies can inherit from a baseline policy (same org or partner-wide).
+  Migration adds `configuration_policies.parent_policy_id` and a view
+  `config_policy_effective_feature_links`; requires PostgreSQL 15+ (`security_invoker`).
+- Behaviour: policies created earlier through "Link to Existing" were never linked; re-create
+  them as linked policies to get inheritance.


### PR DESCRIPTION
Spec and three wave plans for configuration policy inheritance (feature #5080; waves #5081 API foundation, #5082 resolver sweep, #5083 web + docs).

Origin: the third #5023 browser-walk paper cut ("inherited policy state only shows with `?linked=`") turned out to be a missing feature: nothing is persisted and no resolver inherits. Advisor quorum (Fable + codex gpt-5.6 xhigh) chose persisted one-level inheritance; the written spec was then reviewed twice by codex gpt-6-astra xhigh (9 + 5 findings, all verified in code and folded in; review log in the spec).

Docs only. No code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZAsMVZBbCxwBUtRFmrY7A