### PR TITLE
docs: organization record page + Service Management mode spec and plan (#5075)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,7 +305,7 @@ cd e2e-tests && pnpm test
 
 ## Codex Delegation
 
-This project uses OpenAI Codex CLI for **read-only analysis (bug-hunting, security review, design-from-plan — its strongest uses) and well-scoped single-file edits** (utilities, co-located tests, CRUD endpoints, mechanical renames). Keep with Claude: repo-wide sweeps/enumeration, cross-module refactors (codex misses existing canonical code), UI work, and the *architecture* of multi-tenant/auth changes — though codex may *execute* an RLS migration once Claude hands it the tenancy contract. Default to `medium` (2026-09-01 bench: `medium` beat `high` on bug-hunts and tied on codegen); escalate to `high` only when medium comes back thin; reserve `xhigh` for open-ended design. Model is `gpt-5.6-sol`. For commands, reasoning levels, and the benchmarked delegation matrix, use the **`delegating-to-codex`** skill.
+This project uses OpenAI Codex CLI for **read-only analysis (bug-hunting, security review, design-from-plan — its strongest uses) and well-scoped single-file edits** (utilities, co-located tests, CRUD endpoints, mechanical renames). Keep with Claude: repo-wide sweeps/enumeration, cross-module refactors (codex misses existing canonical code), UI work, and the *architecture* of multi-tenant/auth changes — though codex may *execute* an RLS migration once Claude hands it the tenancy contract. Default to `medium` (2026-09-01 bench: `medium` beat `high` on bug-hunts and tied on codegen); escalate to `high` only when medium comes back thin; reserve `xhigh` for open-ended design. Model is `gpt-6-astra` (GPT-6, switched 2026-09-06; `gpt-5.6-sol` is the fallback). For commands, reasoning levels, and the benchmarked delegation matrix, use the **`delegating-to-codex`** skill.
 
 ---
 

--- a/docs/superpowers/plans/2026-09-06-organization-record-page.md
+++ b/docs/superpowers/plans/2026-09-06-organization-record-page.md
@@ -1,0 +1,491 @@
+---
+tracking_issue: LanternOps/breeze#5075
+---
+# Organization Record Page + Service Management Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give every organization a URL-pinned record page (`/organizations/<id>`: header with a Settings action, tabs Overview, Contacts, Sites, Devices, Tickets, Contracts & Billing, Activity) reachable from the organizations list, and add a partner-level Service Management mode (`native` / `off` / `external`) with a workflow-grouped sidebar.
+
+**Architecture:** A new `org-record` route kind whose fetches carry an explicit `orgIdOverride` on `fetchWithAuth`, so the page never depends on the OrgSwitcher scope. One new read-only API route aggregates per-org counts. Tabs reuse the existing presentational list components behind thin org-pinned loaders. The mode is two typed columns on `partners`, exposed on `GET /orgs/partners/me`, gating navigation, the record's Service Management tabs, and (for `off`) new ticket creation inside `ticketService`.
+
+**Tech Stack:** Astro + React islands, zustand, i18next (auto-registered namespaces), Hono + Drizzle + Zod, hand-written SQL migration, Vitest (web jsdom + API unit + API integration), Playwright.
+
+**Spec:** `docs/superpowers/specs/web-ui/2026-09-06-organization-record-page-design.md` (approved 2026-09-06). Where this plan is more specific than the spec (summary shape, i18n namespace, org-scope handling), the plan wins and the spec was amended to point here.
+
+## Global Constraints
+
+- Web URL state for tabs is `window.location.hash` via `useHashState` (`apps/web/src/lib/useHashState.ts`); never query params.
+- Every new mutation handler in the web goes through `runAction` (`apps/web/src/lib/runAction.ts`); the `no-silent-mutations` test enforces it.
+- Every request from inside the record page passes `orgIdOverride: <record org id>` (or embeds the org in the path). Never rely on ambient injection there.
+- New i18n keys land in all 8 locales (`apps/web/src/locales/{en,de-DE,es-419,fr-CA,fr-FR,it-IT,pt-BR,tr-TR}/<ns>.json`); `apps/web/src/lib/i18n/localeParity.test.ts` enforces parity. Namespaces auto-register from the folder (`apps/web/src/lib/i18n/index.ts`), so a new `organizations.json` needs no wiring.
+- Migration filename must sort after the newest committed migration. As of 2026-09-06 that is `2026-10-12-000100-device-manual-maintenance-lease.sql`; use `2026-10-12-000200-partners-service-management-mode.sql` and re-check `ls apps/api/migrations | sort | tail -1` before committing. Idempotent, no inner `BEGIN`/`COMMIT`.
+- `partners` has no `org_id`: no cascade or export-policy registration applies. No new tenant tables anywhere in this plan.
+- The mode never changes API authorization. The single behavioural effect is `off` refusing *new* ticket creation in `ticketService.createTicket`.
+- Branch per wave: `feature/<parent#>-organization-record-page/wave-<subissue#>`; PR body carries `Closes #<sub-issue>`.
+- Model routing per CLAUDE.md: contracts here; implementation by cheap models; tsc + tests + grep before any model review.
+
+---
+
+## Critical implementation notes — read before starting
+
+1. **`fetchWithAuth` spreads `options` straight into native `fetch`** (`apps/web/src/stores/auth.ts:1370` and the retry at `:1386`). Today `skipOrgIdInjection`/`skipUnauthorizedRetry` ride along harmlessly. Task 1.1 must destructure the custom keys out before the spread, at both call sites.
+2. **`GET /orgs/organizations/:id` is `requireScope('partner','system')`** (`apps/api/src/routes/orgs.ts:1802`). Org-scoped tokens get 403, not 404. The record page is therefore a partner/system surface; for an org-scoped JWT (`getJwtClaims().scope === 'org'`, `apps/web/src/lib/authScope.ts`) the page renders the "not available in this workspace" state and links to `/`. Do not widen the API.
+3. **Partner tokens can only access `active`/`trial` orgs** (`apps/api/src/middleware/auth.ts` ~378-393). A `suspended`/`churned` org 404s on the record GET. Task 1.5 renders a lifecycle card from the list's cached row for that case; do not try to fetch tabs.
+4. **`OrganizationsPage.tsx` imports `Organization` from `./OrganizationList`**, whose status union is already correct. The drifted union is `apps/web/src/stores/orgStore.ts:19` (has `inactive`, lacks `churned`/`offboarding`). Fix only that one.
+5. **`orgs.ts` is one flat file.** Sibling route files (`orgArchive.ts`, `orgMerge.ts`) are mounted in `apps/api/src/index.ts:833-834` with `api.route('/orgs', …)`. The summary route follows that pattern; do not add to `orgs.ts`.
+6. **`aiForOfficeEnabled` is platform-only** (settable on `PATCH /partners/:id`, not `/partners/me`; `orgs.ts:171-173`). The mode is the opposite: partner-writable on `PATCH /partners/me` (`updatePartnerSettingsSchema`, `orgs.ts:811`), never on the platform route.
+7. **Every native ticket-creating surface calls `ticketService.createTicket`** (alert dialog via `createTicketFromAlert`, `manage_tickets` AI tool, portal `POST /tickets`, Outlook add-in `from-email`, email-to-ticket). One guard inside `createTicket` covers all of them (Task 4.3).
+8. **Timesheets already sits in the Billing section** (`Sidebar.tsx:284`); Tickets is a top-level item (`Sidebar.tsx:184`). The regroup moves both into a new Service Desk section.
+9. **Sidebar permission gate hides items until `/users/me` resolves** (memory: `hasPermission(undefined, …)` is false). The mode gate must not add a second flash: persist the last known mode in `orgStore` and fail open to `native`.
+
+---
+
+## File Structure
+
+### New files
+
+| File | Responsibility |
+|---|---|
+| `apps/web/src/pages/organizations/[id].astro` | Astro page → `OrganizationRecordPage` |
+| `apps/web/src/components/organizations/record/OrganizationRecordPage.tsx` | Shell: loads org + summary, lifecycle states, tab strip, renders active tab |
+| `apps/web/src/components/organizations/record/orgRecordFetch.ts` | `makeOrgFetch(orgId)` → `fetchWithAuth` with `orgIdOverride`; stale-response guard |
+| `apps/web/src/components/organizations/record/orgRecordTabs.ts` | Tab ids, permission per tab, mode gating, hash parse |
+| `apps/web/src/components/organizations/record/OrgRecordHeader.tsx` | Identity header + actions |
+| `apps/web/src/components/organizations/record/OrgOverviewTab.tsx` | Summary tiles + recent activity + open critical alerts |
+| `apps/web/src/components/organizations/record/OrgSitesTab.tsx` | `SiteList` + site modals via `useSiteCrud` |
+| `apps/web/src/components/organizations/record/OrgDevicesTab.tsx` | Loader → `DeviceList` (`forceSingleOrg`) |
+| `apps/web/src/components/organizations/record/OrgTicketsTab.tsx` | Loader → `TicketQueueList` |
+| `apps/web/src/components/organizations/record/OrgBillingTab.tsx` | `ContractsList({lockedOrgId})` + `InvoicesPage({lockedOrgId})` + `QuotesPage({lockedOrgId})` |
+| `apps/web/src/components/organizations/record/OrgActivityTab.tsx` | `AuditLogViewer({orgId})` |
+| `apps/web/src/components/settings/useSiteCrud.ts` | Site fetch/add/edit/delete state + handlers extracted from `OrganizationsPage` |
+| `apps/web/src/components/settings/PartnerModulesCard.tsx` | Service Management mode radio card on the Partner → Company tab |
+| `apps/web/src/locales/<8 locales>/organizations.json` | New namespace for the record page |
+| `apps/api/src/routes/orgSummary.ts` | `GET /orgs/organizations/:id/summary` |
+| `apps/api/src/services/serviceManagement.ts` | `getServiceManagementMode(partnerId)`, `assertTicketCreationAllowed(partnerId)`, mode types |
+| `apps/api/migrations/2026-10-12-000200-partners-service-management-mode.sql` | Two columns + CHECKs |
+
+### Modified files
+
+| File | Change |
+|---|---|
+| `apps/web/src/stores/auth.ts` | `orgIdOverride` option; URL parsing; strip custom options before `fetch` |
+| `apps/web/src/lib/routeScope.ts`, `apps/web/src/lib/orgSwitch.ts`, `apps/web/src/components/layout/ContextScopeLine.tsx` | `org-record` kind, switch redirect, no scope line on the record |
+| `apps/web/src/stores/orgStore.ts` | Status union fix; `serviceManagementMode` persisted field |
+| `apps/web/src/components/settings/OrganizationsPage.tsx` | Row link + chevron, exception-only pill, Open record button, Edit→Settings, site handlers → `useSiteCrud` |
+| `apps/web/src/components/settings/OrgSettingsPage.tsx` | `#contacts` and `#contracts` redirect to the record |
+| `apps/web/src/components/devices/DeviceDetailPage.tsx` | Org crumb → `/organizations/<id>` |
+| `apps/web/src/components/devices/DeviceList.tsx` | `forceSingleOrg?: boolean` prop |
+| `apps/web/src/components/audit/AuditLogViewer.tsx` | `orgId?: string` prop |
+| `apps/web/src/components/billing/InvoicesPage.tsx`, `apps/web/src/components/billing/quotes/QuotesPage.tsx`, `apps/web/src/lib/api/quotes.ts` (`listQuotes`) | `lockedOrgId?: string` prop; org filter on fetch; new-item default org |
+| Ticket, invoice, quote, contract detail components | Org name → record link |
+| `apps/web/src/components/layout/Sidebar.tsx` | Service Desk section, Organizations top-level, `requiresModule` gate, mode from `/partners/me` |
+| `apps/web/src/components/settings/PartnerSettingsPage.tsx` | Mount `PartnerModulesCard` in the `company` tab |
+| `apps/web/src/locales/*/common.json`, `settings.json` | Nav + settings keys |
+| `apps/api/src/index.ts` | Mount `orgSummaryRoutes` |
+| `apps/api/src/db/schema/orgs.ts` | Two partner columns |
+| `apps/api/src/routes/orgs.ts` | Projection + `updatePartnerSettingsSchema` + PATCH validation |
+| `apps/api/src/services/ticketService.ts` | `assertTicketCreationAllowed` in `createTicket` |
+
+---
+
+## Wave W01 — Record page shell, pinned fetching, summary endpoint, list affordances
+
+Deliverable: `/organizations/<id>` renders header + Overview for a partner user; the organizations list links to it; the Active pill is exception-only.
+
+### Task 1.1: `orgIdOverride` on `fetchWithAuth`
+
+**Files:** Modify `apps/web/src/stores/auth.ts:1251-1290, 1368-1390`. Test: create `apps/web/src/stores/auth.orgIdOverride.test.ts` (mock `global.fetch`, register a provider via `registerOrgIdProvider(() => 'ambient-org')`, follow the mocking style of `auth.test.ts`).
+
+**Interfaces (produces):**
+```ts
+export interface FetchWithAuthOptions extends RequestInit {
+  skipUnauthorizedRetry?: boolean;
+  skipOrgIdInjection?: boolean;           // kept as an alias of orgIdOverride: null
+  /** undefined = inject ambient scope; string = force this org; null = inject nothing. */
+  orgIdOverride?: string | null;
+}
+```
+
+**Implementation:**
+```ts
+export async function fetchWithAuth(rawUrl: string, options: FetchWithAuthOptions = {}): Promise<Response> {
+  const { skipOrgIdInjection, skipUnauthorizedRetry, orgIdOverride, ...init } = options;
+  const url = applyOrgId(rawUrl, { skipOrgIdInjection, orgIdOverride, ambient: _getOrgId?.() ?? null });
+  // ... existing token/refresh logic unchanged, but every `fetch(...)` call spreads `init`, not `options`
+}
+
+/** Exported for tests. Relative URLs only (the API base is prepended later by buildApiUrl). */
+export function applyOrgId(rawUrl: string, o: { skipOrgIdInjection?: boolean; orgIdOverride?: string | null; ambient: string | null }): string {
+  const hashIdx = rawUrl.indexOf('#');
+  const hash = hashIdx >= 0 ? rawUrl.slice(hashIdx) : '';
+  const base = hashIdx >= 0 ? rawUrl.slice(0, hashIdx) : rawUrl;
+  const qIdx = base.indexOf('?');
+  const path = qIdx >= 0 ? base.slice(0, qIdx) : base;
+  const params = new URLSearchParams(qIdx >= 0 ? base.slice(qIdx + 1) : '');
+  const existing = params.get('orgId');
+  if (o.orgIdOverride === null || o.skipOrgIdInjection) {
+    // caller owns scoping entirely
+  } else if (typeof o.orgIdOverride === 'string') {
+    if (existing && existing !== o.orgIdOverride) {
+      throw new Error(`fetchWithAuth: URL orgId=${existing} conflicts with orgIdOverride=${o.orgIdOverride}`);
+    }
+    params.set('orgId', o.orgIdOverride);
+  } else if (!existing && o.ambient) {
+    params.set('orgId', o.ambient);
+  }
+  const qs = params.toString();
+  return `${path}${qs ? `?${qs}` : ''}${hash}`;
+}
+```
+
+**Tests (write first, watch them fail):**
+- `applyOrgId('/tickets', { ambient: 'a' })` → `/tickets?orgId=a` (existing behaviour preserved).
+- `applyOrgId('/tickets?orgId=x', { ambient: 'a' })` → unchanged.
+- `applyOrgId('/tickets?status=open', { orgIdOverride: 'p', ambient: 'a' })` → `/tickets?status=open&orgId=p`.
+- `applyOrgId('/tickets?orgId=p', { orgIdOverride: 'p', ambient: 'a' })` → unchanged, no throw.
+- `applyOrgId('/tickets?orgId=x', { orgIdOverride: 'p', ambient: 'a' })` → throws with message containing both ids.
+- `applyOrgId('/fleet/findings', { orgIdOverride: null, ambient: 'a' })` → unchanged; same with `skipOrgIdInjection: true`.
+- `fetchWithAuth('/x', { orgIdOverride: 'p', skipUnauthorizedRetry: true })`: the `RequestInit` passed to `global.fetch` has no `orgIdOverride`, `skipOrgIdInjection` or `skipUnauthorizedRetry` keys.
+- Run `apps/web/src/lib/api/catalog.test.ts` and `apps/web/src/stores/orgStore.scope.test.ts` afterwards; both must still pass.
+
+Commit: `feat(web): fetchWithAuth orgIdOverride for org-pinned pages`.
+
+### Task 1.2: `org-record` route kind
+
+**Files:** Modify `apps/web/src/lib/routeScope.ts:29-53`, `apps/web/src/lib/orgSwitch.ts:38-49`, `apps/web/src/components/layout/ContextScopeLine.tsx`. Tests: `apps/web/src/lib/routeScope.test.ts`, `apps/web/src/lib/orgSwitch.test.ts` (create if absent), `apps/web/src/components/layout/ContextScopeLine.test.tsx`.
+
+**Interfaces:** `RouteScopeKind` gains `'org-record'`. `ROUTE_SCOPES` gains, above the `/settings/organizations` entries:
+```ts
+// The organization RECORD pins its org from the URL (spec D2). It neither
+// requires nor follows the OrgSwitcher; the page owns its own scoping.
+{ pattern: /^\/organizations\/[^/]+(\/.*)?$/, kind: 'org-record' },
+```
+`getOrgSwitchRedirect`: `/^\/organizations\/[^/]+\/?$/` → `'/settings/organizations'`. `ContextScopeLine`: `if (kind === 'org-record') return null;` (the record header shows scope itself, Task 1.5). `isGlobalScopeRoute` is unchanged: `org-record` does **not** suppress injection globally; the page passes `orgIdOverride` per request.
+
+**Tests:** `getRouteScope('/organizations/abc')` → `'org-record'`; `getRouteScope('/organizations')` → `null` (no list route yet); `getOrgSwitchRedirect('/organizations/abc')` → `/settings/organizations`; `getOrgSwitchRedirect('/organizations')` → `null`; `isGlobalScopeRoute('/organizations/abc')` → `false`; ContextScopeLine renders nothing at `/organizations/abc` in fleet scope.
+
+Commit: `feat(web): org-record route scope kind`.
+
+### Task 1.3: `Organization.status` union fix
+
+**Files:** Modify `apps/web/src/stores/orgStore.ts:19` to
+`status: 'active' | 'trial' | 'suspended' | 'churned' | 'offboarding' | 'merging' | 'archived' | 'purging';`
+Run `pnpm --filter @breeze/web exec tsc --noEmit`; fix any caller that compared against `'inactive'` on an `Organization` (the known `'inactive'` hits are SSO providers, partner status and device tests, which are different types and stay). Leave `Partner.status` alone.
+
+Commit: `fix(web): orgStore Organization.status matches the API enum`.
+
+### Task 1.4: `GET /orgs/organizations/:id/summary`
+
+**Files:** Create `apps/api/src/routes/orgSummary.ts`; modify `apps/api/src/index.ts` (import + `api.route('/orgs', orgSummaryRoutes)` beside line 834). Test: create `apps/api/src/routes/orgSummary.test.ts` (copy the `vi.mock('../db', …)` and `setAuthContext` scaffolding from `apps/api/src/routes/orgs.test.ts:132-160, 2752-2775`). Integration: `apps/api/src/__tests__/integration/orgSummary.integration.test.ts`.
+
+**Interfaces (produces):**
+```ts
+export const orgSummaryRoutes = new Hono<AppEnv>();
+// GET /organizations/:id/summary → 200 OrgSummary | 404 { error: 'Organization not found' }
+export interface OrgSummary {
+  orgId: string;
+  devices?:     { total: number; online: number; offline: number };
+  alerts?:      { open: number; critical: number; high: number };
+  tickets?:     { open: number; awaitingCustomer: number };
+  contracts?:   { active: number; nextRenewalAt: string | null };
+  invoices?:    { outstanding: string; currencyCode: string | null; nextDueAt: string | null; overdueCount: number };
+  sites:        { count: number };
+  contacts?:    { count: number; primary: { id: string; name: string; email: string | null; phone: string | null } | null };
+  portalUsers?: { count: number };
+  lastActivityAt: string | null;
+}
+```
+Each optional section is present only when the caller holds the matching read permission (`devices`, `alerts`, `tickets`, `contracts`, `invoices`, `contacts` (org read covers it), `portal` for portalUsers). Use the imperative check already used by `apps/api/src/routes/search.ts` (`c.get('permissions')` + `hasPermission`).
+
+**Implementation contract:** middleware chain identical to `GET /organizations/:id` (`requireScope('partner','system')`, `requireOrgRead`); `PG_UUID_REGEX` pre-check → 404; partner scope must pass `auth.canAccessOrg(id)` → else 404 (no archived branch: the summary is meaningless for a drained org). Counts (all `and(eq(t.orgId, id), <deletedAt null where the table has it>)`):
+- devices: `total`; `online` = `status = 'online'`; `offline` = `status <> 'online' AND status <> 'decommissioned'`.
+- alerts: `open` = `status IN ('active','acknowledged')`; `critical`/`high` = open with that `severity`.
+- tickets: `open` = `status IN ('new','open','pending','on_hold')` (mirror `OPEN_STATUSES`, `routes/tickets/tickets.ts:61`); `awaitingCustomer` = `status = 'pending'`; exclude soft-deleted rows the same way the list does.
+- contracts: `active` = `status = 'active'`; `nextRenewalAt` = `MIN(end_date)` among active with `end_date >= CURRENT_DATE`.
+- invoices: open set = every value of `INVOICE_STATUSES` (`packages/shared/src/validators/invoices.ts`) except `draft`, `paid`, `void` (reuse the same predicate the invoices list uses for `overdue`); `outstanding` = `SUM(total - amount_paid)` as a decimal string; `nextDueAt` = `MIN(due_date)` among open; `overdueCount` = open with `due_date < CURRENT_DATE`; `currencyCode` = the org's `currency_code`.
+- sites: count. contacts: count + the row with `is_primary AND site_id IS NULL`. portalUsers: count where not disabled. `lastActivityAt` = `MAX(audit_logs.created_at)` for the org.
+All queries run in the request's normal DB context (no system context).
+
+**Tests:** 404 for `not-a-uuid`; 404 when `canAccessOrg` is false; 200 with every section for a wildcard-permission partner; `tickets`/`invoices` omitted when those permissions are absent; org-scoped token → 403 (from `requireScope`). Integration: seed one org with 2 devices (1 online), 1 active alert (critical), 1 open ticket, verify numbers; a second partner's token gets 404.
+
+Commit: `feat(api): per-organization summary endpoint`.
+
+### Task 1.5: Record page shell, header, Overview tab
+
+**Files:** Create `apps/web/src/pages/organizations/[id].astro` (mirror `pages/settings/organizations/[id].astro`, title "Organization"), `components/organizations/record/{OrganizationRecordPage,OrgRecordHeader,OrgOverviewTab}.tsx`, `orgRecordFetch.ts`, `orgRecordTabs.ts`, `apps/web/src/locales/*/organizations.json` (8 files). Tests: `OrganizationRecordPage.test.tsx`, `OrgRecordHeader.test.tsx`, `orgRecordTabs.test.ts`.
+
+**Interfaces (produces):**
+```ts
+// orgRecordFetch.ts
+export type OrgFetch = (path: string, init?: FetchWithAuthOptions) => Promise<Response>;
+export function makeOrgFetch(orgId: string): OrgFetch;            // adds orgIdOverride: orgId
+export function useLatest<T>(): { run: (p: Promise<T>) => Promise<T | undefined> }; // drops responses from a superseded call
+
+// orgRecordTabs.ts
+export const ORG_RECORD_TABS = ['overview','contacts','sites','devices','tickets','billing','activity'] as const;
+export type OrgRecordTab = typeof ORG_RECORD_TABS[number];
+export const TAB_PERMISSION: Record<OrgRecordTab, { resource: string; action: 'read' } | null>; // overview/contacts/sites → null (org read), devices, tickets, billing → contracts/invoices (either), activity → audit
+export const SERVICE_MANAGEMENT_TABS: ReadonlySet<OrgRecordTab> = new Set(['tickets','billing']);
+export function tabFromHash(hash: string): OrgRecordTab | undefined;  // '#tickets' → 'tickets'; unknown → undefined
+export function visibleTabs(perms: UserPermissions | undefined, mode: 'native'|'off'|'external'): OrgRecordTab[];
+
+// OrganizationRecordPage.tsx
+export default function OrganizationRecordPage({ orgId }: { orgId: string });
+```
+Tab strip: `useHashState<OrgRecordTab>('overview', tabFromHash)` + `OverflowTabs` (`apps/web/src/components/shared/OverflowTabs.tsx`). W01 renders only Overview; other tab ids show a "coming in the next wave" placeholder **only in W01** and are replaced in W02/W03. `visibleTabs` takes `mode` now (default `'native'` until W04 wires the store) so W04 does not touch the shell.
+
+**Header (`OrgRecordHeader`):** name; type badge from `org.type` (`customer`/`internal`); status pill always (subdued class when `active`, else `statusColors[status]` imported from `settings/OrganizationsPage.tsx`); primary contact from `summary.contacts.primary`; `summary.sites.count`; when `useOrgScope()` is a different org than `orgId`, a chip "Workspace: <other org name>" (`data-testid="org-record-scope-chip"`). Actions: **Work in this org** → `applyOrgSwitch(orgId)` then `/`; **Settings** → `/settings/organizations/<id>`; overflow with Archive (`ArchiveOrgModal`) and Merge (`MergeOrgModal`, only when `getJwtClaims().scope === 'partner'`). `data-testid`s: `org-record-header`, `org-record-status`, `org-record-work-here`, `org-record-settings`.
+
+**Lifecycle states in the shell:**
+- org-scoped JWT → `org-record-unavailable` card, link to `/`.
+- GET 404 → look the org up in `useOrgStore().organizations`; if found and `status` is `suspended`/`churned`, render `org-record-lifecycle` card (name, status pill, created, copy `orgRecord.lifecycle.inaccessible`, link to `/settings/organizations`); otherwise `org-record-not-found`.
+- `archived: true` in the response (or `isArchiveLifecycleOrg`) → read-only banner (`org-record-archived-banner`), no Work/Archive/Merge actions, Restore via the same `POST` the settings page uses.
+- Loading → skeleton; fetch error → inline error with retry (`runAction` not needed: reads).
+
+**Overview tab:** tiles from `OrgSummary` (each tile hidden when its section is absent): Devices online/total, Open alerts (critical/high sub-line), Open tickets (awaiting customer sub-line), Active contracts (next renewal), Outstanding invoices (next due, overdue count), Contacts, Portal users. Below: "Recent activity" (last 20 rows from `GET /audit-logs?limit=20` through `orgFetch`) and "Open critical alerts" (`GET /alerts?status=active&severity=critical&limit=10` through `orgFetch`, rendered with `AlertList({ orgId })`). Tiles have `data-testid="org-overview-tile-<key>"`.
+
+**i18n:** namespace `organizations`, keys under `orgRecord.*` (header.*, tabs.*, overview.*, lifecycle.*, actions.*, unavailable.*). English copy in the PR; other 7 locales get real translations (not English copies), same as prior waves.
+
+**Tests:** shell renders header from a mocked `GET /orgs/organizations/:id` + `/summary`; `#tickets` in the URL selects that tab; 404 + store row `suspended` → lifecycle card; `archived: true` → banner and no `org-record-work-here`; org-scope claims → unavailable card; `visibleTabs` drops `devices` without `devices:read` and drops `tickets`/`billing` when `mode === 'off'`; every request URL in the test's fetch mock contains `orgId=<record id>` even with the store's `currentOrgId` set to another org.
+
+Commit: `feat(web): organization record page shell with overview`.
+
+### Task 1.6: Organizations list affordances + breadcrumb
+
+**Files:** Modify `apps/web/src/components/settings/OrganizationsPage.tsx` (row block ~1085-1160, detail header ~1284-1330, `handleEdit`), `apps/web/src/components/devices/DeviceDetailPage.tsx:639`, `apps/web/src/locales/*/settings.json` (`organizationsPage.actions.openRecord`, `organizationsPage.actions.openSettings`). Tests: extend `OrganizationsPage.test.tsx`; `DeviceDetailPage` breadcrumb test if one exists.
+
+**Changes:**
+- Row: wrap `{org.name}` in `<a href={`/organizations/${org.id}`} data-testid={`org-open-record-${org.id}`} onClick={e => e.stopPropagation()}>`; add a persistent chevron link with the same href at the row end (visible without hover, `aria-label` = openRecord).
+- Status pill: render only when `org.status !== 'active'`. The archived section is untouched.
+- Detail-pane header: primary button **Open record** (`data-testid="org-open-record"`, `navigateTo('/organizations/<id>')`) before the existing buttons; the existing Edit button label → `organizationsPage.actions.openSettings` ("Settings"). The hover pencil keeps going to settings; its `title` becomes openSettings too.
+- `DeviceDetailPage.tsx:639`: `href: `/organizations/${device.orgId}``.
+
+**Tests:** an `active` org renders no status pill, a `trial` org renders "Trial"; `org-open-record-<id>` has the record href; clicking the name does not select the row; detail header shows Open record; device breadcrumb href points at `/organizations/<orgId>`.
+
+Commit: `feat(web): organizations list opens the record; exception-only status pill`.
+
+### W01 verification
+
+- `pnpm --filter @breeze/web exec tsc --noEmit`; `cd apps/web && npx vitest run src/stores/auth.orgIdOverride src/lib/routeScope src/lib/orgSwitch src/components/organizations/record src/components/settings/OrganizationsPage src/lib/i18n/localeParity`.
+- `cd apps/api && npx vitest run src/routes/orgSummary`; integration suite for `orgSummary` against a real DB.
+- Browser: open an org from the list with the switcher on "All organizations", confirm the scope chip is absent; switch the switcher to another org, reload the record, confirm the chip names the other org and the tiles still show the record's org.
+
+---
+
+## Wave W02 — Contacts, Sites, Devices, Activity tabs
+
+Deliverable: four data tabs, sites CRUD shared with the settings list, `#contacts` on the settings page redirects to the record.
+
+### Task 2.1: `useSiteCrud(orgId)` hook
+
+**Files:** Create `apps/web/src/components/settings/useSiteCrud.ts`; modify `OrganizationsPage.tsx:191-199, 392-415, 856-990` to consume it (state + handlers move; the modals' JSX stays in the page and reads from the hook). Test: `useSiteCrud.test.ts` (renderHook + mocked `fetchWithAuth`).
+
+**Interfaces (produces):**
+```ts
+export type SiteModalMode = 'closed' | 'add' | 'edit' | 'delete';
+export interface UseSiteCrud {
+  sites: Site[]; sitesLoading: boolean; siteSubmitting: boolean;
+  siteModalMode: SiteModalMode; selectedSite: Site | null;
+  guidingFirstSite: boolean; setGuidingFirstSite: (v: boolean) => void;
+  refresh: () => Promise<Site[] | null>;          // GET /orgs/sites?organizationId=<orgId> with orgIdOverride: orgId
+  openAdd: () => void; openEdit: (s: Site) => void; openDelete: (s: Site) => void; close: () => void;
+  submit: (values: Record<string, unknown>) => Promise<void>;   // POST /orgs/sites | PATCH /orgs/sites/:id via runAction
+  confirmDelete: () => Promise<void>;                            // DELETE /orgs/sites/:id via runAction
+  getSiteFormDefaults: (s: Site & { address?: Record<string,string>; contact?: Record<string,string> }) => SiteFormDefaults;
+}
+export function useSiteCrud(orgId: string | null, opts: { onUnauthorized: () => void; t: TFunction }): UseSiteCrud;
+```
+Behaviour is a verbatim move of the existing handlers (`OrganizationsPage.tsx:392-415, 856-990`): same URLs, same `runAction` error fallbacks, same `ActionError` catch pattern. The only addition is `orgIdOverride: orgId` on the sites GET so the hook is correct inside the record.
+
+**Tests:** `refresh` calls `/orgs/sites?organizationId=<id>&orgId=<id>`; `submit` in add mode POSTs `/orgs/sites` with `orgId` in the body; edit PATCHes `/orgs/sites/<siteId>`; `confirmDelete` DELETEs; a non-401 failure surfaces a toast and leaves the modal open. `OrganizationsPage.test.tsx` must pass unchanged.
+
+Commit: `refactor(web): extract useSiteCrud from OrganizationsPage`.
+
+### Task 2.2: Contacts and Sites tabs
+
+**Files:** Create `OrgSitesTab.tsx`; modify `OrganizationRecordPage.tsx` to render `<ContactsCard orgId={orgId} />` for `contacts` and `<OrgSitesTab orgId={orgId} />` for `sites`. `OrgSitesTab` = `useSiteCrud(orgId)` + `SiteList` (`onSiteClick` → `/settings/sites/<id>`) + the add/edit/delete modals (copy the JSX from `OrganizationsPage.tsx` modals; they become shared once, so extract `SiteModals.tsx` in `components/settings/` and use it from both pages). Tests: `OrgSitesTab.test.tsx` (add flow through the hook mock), record page test selects `#contacts` and finds `ContactsCard`'s root testid.
+
+Commit: `feat(web): contacts and sites tabs on the organization record`.
+
+### Task 2.3: Devices tab + `forceSingleOrg`
+
+**Files:** Modify `apps/web/src/components/devices/DeviceList.tsx:314-365, 1040` (`forceSingleOrg?: boolean`; `const isFleetView = !forceSingleOrg && useOrgStore(...)` — keep the hook call unconditional). Create `OrgDevicesTab.tsx`: loads `GET /devices?limit=200&orgId=<id>` (via `orgFetch`), sites from the summary hook or `GET /orgs/sites?organizationId=`, renders `<DeviceList devices sites forceSingleOrg />`; filter bar limited to search/status/site. Tests: `DeviceList.test.tsx` gains "hides the Organization column when `forceSingleOrg` even in fleet scope"; `OrgDevicesTab.test.tsx` asserts the fetch URL carries the record org while the store points elsewhere.
+
+Commit: `feat(web): devices tab on the organization record`.
+
+### Task 2.4: Activity tab + `AuditLogViewer({orgId})`
+
+**Files:** Modify `apps/web/src/components/audit/AuditLogViewer.tsx:120-125, 179-180`: `interface AuditLogViewerProps { timezone?: string; orgId?: string }`; when `orgId` is set, pass `orgIdOverride: orgId` on both endpoints. Create `OrgActivityTab.tsx` → `<AuditLogViewer orgId={orgId} />`. Tests: `AuditLogViewer.test.tsx` gains a case that the request carries `orgId=<prop>` while the store has another org.
+
+Commit: `feat(web): activity tab on the organization record`.
+
+### Task 2.5: Settings `#contacts` redirect
+
+**Files:** Modify `apps/web/src/components/settings/OrgSettingsPage.tsx` (the `contacts` case ~629 and the tab list ~57): keep the nav entry but on activation call `navigateTo(`/organizations/${effectiveOrgId}#contacts`)`; remove `ContactsCard` from the settings render. Test: `OrgSettingsPage.test.tsx` asserts the redirect on `#contacts`.
+
+Commit: `feat(web): org settings #contacts hands off to the record`.
+
+### W02 verification
+
+`tsc`; `npx vitest run src/components/organizations/record src/components/settings/useSiteCrud src/components/settings/OrganizationsPage src/components/settings/OrgSettingsPage src/components/devices/DeviceList src/components/audit/AuditLogViewer src/lib/no-silent-mutations`. Browser: add a site from the record, see it in the settings list; open Activity with the switcher on another org and confirm rows belong to the record's org.
+
+---
+
+## Wave W03 — Tickets, Contracts & Billing tabs, cross-links
+
+Deliverable: the two Service Management tabs and org-name links from ticket/invoice/quote/contract detail pages into the record. Runs in parallel with W02 (file-disjoint).
+
+### Task 3.1: Tickets tab
+
+**Files:** Create `OrgTicketsTab.tsx`: status filter (open/all/closed mirroring `tabQuery` in `TicketsPage.tsx`), `GET /tickets?<params>&limit=100` via `orgFetch`, `<TicketQueueList tickets selectedId={null} onSelect={t => navigateTo(`/tickets/${t.id}`)} loading config />` (`config` from `GET /ticket-config` via `orgFetch`), **New ticket** → `/tickets/new#orgId=<id>` (confirm `TicketsPage`/new-ticket form reads `#orgId=`; if it does not, add that read in the same task). Tests: request URL carries the record org; empty state; New ticket href.
+
+Commit: `feat(web): tickets tab on the organization record`.
+
+### Task 3.2: `lockedOrgId` on invoices and quotes
+
+**Files:** Modify `apps/web/src/components/billing/InvoicesPage.tsx:98, 167-182, 233-237` and `apps/web/src/components/billing/quotes/QuotesPage.tsx:97, 150-160, 215-218`; `apps/web/src/lib/api/quotes.ts` `listQuotes` gains `orgId?: string` and passes it explicitly (pattern: `lib/api/catalog.ts` `resolveCatalogPrice`). Copy the `ContractsList` contract (`contracts/ContractsList.tsx:84-113, 173-180, 314, 446, 483`): `lockedOrgId?: string` prop; when set, `params.set('orgId', lockedOrgId)`, hide the org column and org filter, default the create-modal org to `lockedOrgId` instead of `useOrgStore.getState().currentOrgId`, and skip hash-filter writes. Tests: `InvoicesPage.test.tsx` / `QuotesPage.test.tsx` gain "locked embed fetches with the locked org and pre-fills the create modal with it while the store points elsewhere".
+
+Commit: `feat(web): lockedOrgId on invoices and quotes pages`.
+
+### Task 3.3: Contracts & Billing tab
+
+**Files:** Create `OrgBillingTab.tsx`: three stacked sections, Contracts (`<ContractsList lockedOrgId={orgId} />`), Invoices (`<InvoicesPage lockedOrgId={orgId} />`), Quotes (`<QuotesPage lockedOrgId={orgId} />`), each collapsible, contracts first. Tests: renders all three with the prop.
+
+Commit: `feat(web): contracts & billing tab on the organization record`.
+
+### Task 3.4: Org links from detail pages + `#contracts` redirect
+
+**Files:** Ticket workbench header (`components/tickets/TicketWorkbench.tsx`, the org name), `components/billing/InvoiceDetail.tsx`, `components/billing/quotes/QuoteDetail.tsx`, contracts detail (`components/contracts/*Detail*.tsx`): wrap the displayed org name in `<a href={`/organizations/${orgId}`} data-testid="org-record-link">`. `OrgSettingsPage.tsx` `contracts` case → `navigateTo(`/organizations/${effectiveOrgId}#billing`)`, remove the embedded `ContractsList` from settings. Tests: each detail test asserts the link href; settings test asserts the `#contracts` redirect. The `#billing` and `#pax8/<id>` settings deep links are untouched (grep `settings/organizations/` to confirm they still resolve).
+
+Commit: `feat(web): organization record links from ticket, invoice, quote and contract details`.
+
+### Task 3.5: Playwright spec
+
+**Files:** Create `e2e-tests/tests/organization-record.spec.ts` and `e2e-tests/pages/OrganizationRecordPage.ts` (Page Object; selectors by `data-testid` only, per `e2e-tests/README.md`). Uses the seeded partner admin and the first seeded org.
+
+**Scenarios:** (1) from `/settings/organizations`, click `org-open-record-<id>` → URL is `/organizations/<id>`, `org-record-header` shows the org name; (2) navigate to `/organizations/<id>#tickets` → the Tickets tab is active and its list container is present; (3) with the OrgSwitcher on a different org, open the record → `org-record-scope-chip` names the other org and the Devices tab rows all belong to the record org (row testids carry the device org, or the Organization column is absent); (4) click `org-record-work-here` → the switcher shows the record org after reload. Use the hydration wait helper the portal login spec uses (memory: fill-before-hydration race), never a longer timeout.
+
+Commit: `test(e2e): organization record page`.
+
+### W03 verification
+
+`tsc`; `npx vitest run src/components/organizations/record src/components/billing src/components/tickets/TicketWorkbench src/components/contracts src/components/settings/OrgSettingsPage src/lib/no-silent-mutations`. Browser: from the record's Tickets tab create a ticket and confirm it lands on the record's org while the switcher is on another org; open a quote and follow the org link back.
+
+---
+
+## Wave W04 — Sidebar regroup + Service Management mode
+
+Deliverable: Service Desk and Billing sections, Organizations top-level, the mode stored/exposed/edited, `off` hides the module and refuses new tickets.
+
+### Task 4.1: Migration + schema
+
+**Files:** Create `apps/api/migrations/2026-10-12-000200-partners-service-management-mode.sql`; modify `apps/api/src/db/schema/orgs.ts:125-143` (after `aiForOfficeEnabled`). Tests: `apps/api/src/db/autoMigrate.test.ts` (runs on its own), `scripts/check-migration-naming.sh` (pre-commit), and `apps/api/src/__tests__/integration/partnersServiceManagementMode.integration.test.ts` for the CHECKs.
+
+```sql
+-- 2026-10-12-000200-partners-service-management-mode.sql
+-- Partner-level Service Management mode (spec: docs/superpowers/specs/web-ui/2026-09-06-organization-record-page-design.md, Part 2)
+-- Idempotent. No inner BEGIN/COMMIT (autoMigrate wraps each file). No DML, so no breeze.scope elevation is needed.
+
+ALTER TABLE partners
+  ADD COLUMN IF NOT EXISTS service_management_mode text NOT NULL DEFAULT 'native',
+  ADD COLUMN IF NOT EXISTS service_management_psa_connection_id uuid
+    REFERENCES psa_connections(id) ON DELETE RESTRICT;
+
+ALTER TABLE partners DROP CONSTRAINT IF EXISTS partners_service_management_mode_chk;
+ALTER TABLE partners ADD CONSTRAINT partners_service_management_mode_chk
+  CHECK (service_management_mode IN ('native', 'external', 'off'));
+
+ALTER TABLE partners DROP CONSTRAINT IF EXISTS partners_service_management_connection_chk;
+ALTER TABLE partners ADD CONSTRAINT partners_service_management_connection_chk
+  CHECK ((service_management_mode = 'external') = (service_management_psa_connection_id IS NOT NULL));
+```
+Schema:
+```ts
+serviceManagementMode: text('service_management_mode').$type<'native' | 'external' | 'off'>().notNull().default('native'),
+serviceManagementPsaConnectionId: uuid('service_management_psa_connection_id').references(() => psaConnections.id, { onDelete: 'restrict' }),
+```
+(`psaConnections` lives in `db/schema/integrations.ts`; import it. If that creates an import cycle with `orgs.ts`, reference the FK in the migration only and keep the Drizzle column as a bare `uuid(...)` with a comment, as other cross-file FKs in this schema do.)
+
+**Integration test:** `UPDATE partners SET service_management_mode='external'` without a connection → 23514; `mode='native'` with a connection id → 23514; `mode='bogus'` → 23514; deleting a bound connection → 23503. Run `pnpm db:check-drift` after.
+
+Commit: `feat(db): partners.service_management_mode + psa connection binding`.
+
+### Task 4.2: `serviceManagement` service + `/partners/me` exposure
+
+**Files:** Create `apps/api/src/services/serviceManagement.ts`; modify `apps/api/src/routes/orgs.ts:419-458` (projection), `:811` (`updatePartnerSettingsSchema`), the `PATCH /partners/me` handler body (validation + write). Tests: `apps/api/src/services/serviceManagement.test.ts`, `apps/api/src/routes/orgs.test.ts` (new describe blocks).
+
+**Interfaces (produces):**
+```ts
+// services/serviceManagement.ts
+export type ServiceManagementMode = 'native' | 'external' | 'off';
+export const SERVICE_MANAGEMENT_MODES: readonly ServiceManagementMode[] = ['native', 'external', 'off'];
+export async function getServiceManagementMode(partnerId: string): Promise<ServiceManagementMode>; // default 'native' when the partner row is missing
+export class ServiceManagementOffError extends Error { readonly code = 'service_management_off'; readonly status = 409; }
+export async function assertTicketCreationAllowed(partnerId: string): Promise<void>; // throws ServiceManagementOffError when mode === 'off'
+```
+`updatePartnerSettingsSchema` gains:
+```ts
+serviceManagementMode: z.enum(['native', 'external', 'off']).optional(),
+serviceManagementPsaConnectionId: z.string().uuid().nullable().optional(),
+```
+PATCH validation (before the write): if `serviceManagementMode === 'external'`, `serviceManagementPsaConnectionId` must be present and must resolve to a `psa_connections` row with `partner_id = auth.partnerId` and `org_id IS NULL` → else 400 `{ error: 'External mode requires one of your partner-wide PSA connections' }`. If mode is `native`/`off`, force the connection id to `null` in the write. Until the external service desk feature ships, `external` is still accepted by the API (the UI just does not offer it). Include `serviceManagementMode` in `details.changedFields` of the existing audit write. Add both fields to `partnerPublicColumns()`.
+
+**Tests:** service: `off` → throws `ServiceManagementOffError`; `native` → resolves; missing partner → `native`. Routes: GET `/partners/me` returns `serviceManagementMode: 'native'`; PATCH `{ serviceManagementMode: 'off' }` → 200 and the update `set` received `serviceManagementPsaConnectionId: null`; PATCH `external` without id → 400; with an id owned by another partner (mock returns no row) → 400; org-scope token → 403 (existing `requireScope`).
+
+Commit: `feat(api): service management mode on /partners/me`.
+
+### Task 4.3: `off` refuses new ticket creation
+
+**Files:** Modify `apps/api/src/services/ticketService.ts:492-499` (`createTicket`: after resolving `org.partnerId`, `await assertTicketCreationAllowed(org.partnerId)`); `createTicketFromAlert` inherits (it calls `createTicket`). Map the error: `TicketServiceError('Service Management is turned off for this partner', 409, 'service_management_off')` so the alert dialog, portal and add-in routes return 409 through their existing `TicketServiceError` handling, and `aiToolsTicketing` returns `{ error }` JSON as it does for other service errors. Tests: `ticketService.test.ts` (mock `getServiceManagementMode` → `off` → 409 with the code; `native` → creates); `aiToolsTicketing.test.ts` create → error JSON mentions service management; `routes/alerts` create-ticket test → 409.
+
+Commit: `feat(api): service management off refuses new tickets`.
+
+### Task 4.4: Sidebar regroup + `requiresModule` gate + store field
+
+**Files:** Modify `apps/web/src/components/layout/Sidebar.tsx:147-169, 184, 225-241, 276-288, 312, 547-572, 694-707`; `apps/web/src/stores/orgStore.ts` (persisted `serviceManagementMode: 'native'|'off'|'external'`, default `'native'`, setter); `apps/web/src/locales/*/common.json` (`nav.sectionServiceDesk`, `nav.serviceManagement`). Tests: create `Sidebar.module.test.tsx` (copy the harness from `Sidebar.featuregate.test.tsx`); update `Sidebar.nav.test.tsx` for the new order.
+
+**Changes:**
+- `NavItem` gains `requiresModule?: 'service_management'`; `NavSection` gains the same (a section-level gate hides the whole section).
+- Remove Tickets from the top-level items (`:184`). New section after Backup:
+  ```ts
+  { id: 'service-desk', label: 'Service Desk', labelKey: 'nav.sectionServiceDesk', icon: Ticket, requiresModule: 'service_management',
+    items: [ Tickets (as today), Timesheets (moved from Billing) ] },
+  ```
+  Billing section gets `requiresModule: 'service_management'` and keeps Quotes, Invoices, Contracts, Product Catalog.
+- Top-level items gain, right after Dashboard: `{ name: 'Organizations', labelKey: 'nav.organizations', href: '/settings/organizations', icon: Building2, partnerScopeOnly: true, requiredPermission: { resource: 'organizations', action: 'read' } }`. The Settings-section Organizations entry (`:312`) is removed.
+- `/orgs/partners/me` effect (`:547-572`): also read `data.serviceManagementMode` and call `useOrgStore.getState().setServiceManagementMode(mode ?? 'native')`. On any failure leave the store as is (fail open: default `native`).
+- `isNavItemVisible`: `if (item.requiresModule === 'service_management' && mode !== 'native') return false;` where `mode = useOrgStore(s => s.serviceManagementMode)`. Same check in the section renderer before the item cascade. (`external` also hides the native sections; the follow-on feature adds its read-only list.)
+
+**Tests:** `native` → Service Desk + Billing visible; `off` → both hidden, Organizations and Reporting visible; `external` → both hidden; fetch failure → visible (store default); Organizations appears once, at the top, and not under Settings.
+
+Commit: `feat(web): service desk section, organizations top-level, service management gate`.
+
+### Task 4.5: Modules card on Partner settings
+
+**Files:** Create `apps/web/src/components/settings/PartnerModulesCard.tsx`; modify `PartnerSettingsPage.tsx:585-606` (render the card under `PartnerCompanyTab`); `apps/web/src/locales/*/settings.json` (`partnerSettingsPage.modules.*`). Test: `PartnerModulesCard.test.tsx`.
+
+**Card:** loads `GET /orgs/partners/me` (or receives `serviceManagementMode` as a prop from the page's existing partner fetch, preferred), shows a radio group with two options in this wave: **Breeze service desk & billing** (`native`) and **Off (RMM only)** (`off`), each with a two-line description of what it shows/hides; saves immediately on change via `runAction({ request: () => fetchWithAuth('/orgs/partners/me', { method: 'PATCH', body: JSON.stringify({ serviceManagementMode }) }) })`, then `useOrgStore.getState().setServiceManagementMode(mode)` so the sidebar updates without reload. `data-testid="partner-modules-card"`, radios `partner-modules-mode-<mode>`. The `external` option is not rendered (follow-on feature).
+
+**Tests:** renders the current mode checked; choosing Off PATCHes and updates the store; a failed PATCH reverts the radio and toasts (via `runAction`).
+
+Commit: `feat(web): service management mode card on partner settings`.
+
+### Task 4.6: Record page gating + web create-ticket surfaces
+
+**Files:** Modify `orgRecordTabs.ts`/`OrganizationRecordPage.tsx` to read `useOrgStore(s => s.serviceManagementMode)` and pass it to `visibleTabs`; `OrgOverviewTab.tsx` hides the tickets/contracts/invoices tiles unless `native`. `CreateTicketFromAlertDialog` trigger (alerts detail) and any "New ticket" button render only when mode is `native` (`useOrgStore` read; API 409 remains the backstop). Tests: record page test with store `off` → no Tickets/Billing tabs, no tiles; alert detail test → no create-ticket button when `off`.
+
+Commit: `feat(web): hide service management surfaces when the mode is off`.
+
+### W04 verification
+
+- API: `npx vitest run src/services/serviceManagement src/services/ticketService src/routes/orgs src/services/aiToolsTicketing`; integration `partnersServiceManagementMode`; `pnpm db:check-drift`; `scripts/check-migration-naming.sh`.
+- Web: `tsc`; `npx vitest run src/components/layout/Sidebar src/components/settings/PartnerModulesCard src/components/organizations/record src/lib/i18n/localeParity`.
+- Browser: flip the mode to Off, watch Service Desk and Billing vanish without reload, open an org record and confirm the two tabs are gone, open an alert and confirm Create ticket is gone; flip back.
+- Contract grep before PR: `grep -rn "service_management_mode" apps/api/src apps/api/migrations` shows schema, migration, service, route; `grep -rn "requiresModule" apps/web/src` shows Sidebar only.
+
+---
+
+## Out of scope (tracked in the spec's Follow-ups)
+
+External service desk (adapter wiring, shadow rows, status sync, company picker, the `external` radio), onboarding "RMM only" preset, partner access to suspended/churned records, `serviceManagementMode` for org-scoped users, operational `/organizations` list, Redis-cached summary.

--- a/docs/superpowers/specs/web-ui/2026-09-06-organization-record-page-design.md
+++ b/docs/superpowers/specs/web-ui/2026-09-06-organization-record-page-design.md
@@ -1,0 +1,392 @@
+# Organization record page and PSA module navigation
+
+Status: draft for Todd's review (2026-09-06). Advisor quorum complete: Fable,
+codex gpt-5.6-sol xhigh and codex gpt-6-astra xhigh agree on D1, D2, D3 and D5;
+D4 (column vs table) split 2:1 for the column, GPT-6 casting the tie-break. See
+"Quorum record".
+Tracking: to be registered via feature-lifecycle after approval (multi-wave).
+
+## Problem
+
+`/settings/organizations` is the only list of an MSP's customers. It is a
+master-detail admin surface: the row shows name, a status pill and a device
+count; the detail pane shows the header and Sites. The only way "into" an
+organization is a hover-only pencil icon that lands on the per-org **settings**
+page (`/settings/organizations/[id]`, 15 configuration sections). Breeze has no
+PSA-style *company record*: one page that answers "what is going on at this
+customer" (contacts, sites, devices, tickets, contracts, invoices, activity).
+
+Two further observations drive this design:
+
+- The status pill reads "Active" on nearly every row, so it carries no
+  information in the list. The field itself is load-bearing (org-token auth
+  admits only `active`/`trial`; the alert worker skips non-active orgs; the
+  stale-command reaper keys on `offboarding`), so the fix is presentational.
+- Every operational page filters by the global OrgSwitcher scope, which is
+  applied by a full page reload. Opening a customer must not require switching
+  the technician's working scope.
+
+Todd's second question, answered in Part 2: should PSA features be hideable for
+RMM-only partners, and should the sidebar be regrouped into workflow trees.
+
+## Goals
+
+1. A URL-addressable organization record at `/organizations/[id]` with an
+   overview and tabs, pinned to that org regardless of global scope.
+2. An always-visible way to open it from the organizations list, plus
+   exception-only status badges in the list.
+3. A partner-level switch that hides the PSA module for RMM-only partners, and a
+   sidebar grouped by workflow (RMM, PSA, AI) without a two-level tree rewrite.
+
+## Non-goals
+
+- Replacing `/settings/organizations` (add, bulk import, reorder, archive,
+  merge, sites CRUD stay there).
+- Moving billing configuration, Pax8 or any settings editor onto the record.
+- New tenant tables. Part 1 needs none; Part 2 needs one boolean column.
+- Custom fields on organizations (#3843), org document templates (#3844),
+  cross-org reporting (#3858). The record links out where those land later.
+- An onboarding "RMM only" preset. Follow-up once the toggle exists.
+
+## Current state (verified 2026-09-06 on origin/main 2602e045e)
+
+| Fact | Where |
+|---|---|
+| Org list = master-detail, hover pencil → settings page | `apps/web/src/components/settings/OrganizationsPage.tsx` (`handleEdit`) |
+| Per-org settings page, 15 hash sections incl. Contacts, Contracts | `apps/web/src/components/settings/OrgSettingsPage.tsx` |
+| Nothing in the sidebar links to the per-org page; deep links from quotes/invoices use `#billing`, `#pax8/<id>` | `InvoiceSendComposer.tsx`, `QuoteActions.tsx`, `QuoteDetail.tsx` |
+| Device breadcrumb already wants an org destination, points at settings | `components/devices/DeviceDetailPage.tsx` (org crumb) |
+| Global scope: zustand `useOrgStore`, `applyOrgSwitch` reloads the page | `stores/orgStore.ts`, `lib/orgSwitch.ts` |
+| `fetchWithAuth` injects `?orgId=<global>` unless the URL already has `orgId=` or `skipOrgIdInjection` is set | `stores/auth.ts` (~1251-1278) |
+| Explicit-org precedent: `ContactsCard({orgId})`, `ContractsList({lockedOrgId})`, `AlertList({orgId?})`; sites API lets `organizationId` outrank ambient `orgId` | `settings/ContactsCard.tsx`, `contracts/ContractsList.tsx`, `alerts/AlertList.tsx`, `routes/orgs.ts` (~2383) |
+| Global-scope-only pages: `DevicesPage`, `TicketsPage`, `AlertsPage`, `InvoicesPage`, `QuotesPage`, `DashboardPage` | respective components |
+| Route-scope registry; `/settings/organizations/[id]` is `org-required` | `lib/routeScope.ts` |
+| No per-org summary endpoint; `GET /orgs/organizations/:id` returns the raw row | `routes/orgs.ts` (~1802) |
+| Every list route accepts an org filter: tickets/invoices/quotes/contracts/alerts `orgId`, devices `orgId`/`orgIds[]`, sites `organizationId`, contacts by path | validators + routes |
+| Sidebar gates: `requiredPermission`, `partnerScopeOnly`, `platformAdminOnly`, `requiresAiForOffice` (partner boolean from `GET /orgs/partners/me`), extension registry | `components/layout/Sidebar.tsx` |
+| Partner-level feature precedent: `partners.ai_for_office_enabled` boolean column, platform-admin-only write | `db/schema/orgs.ts` (~143), `routes/orgs.ts` (~173, ~455) |
+| `organizations.type` enum: `customer`, `internal`, `quick_support` (hidden from lists) | `db/schema/orgs.ts` |
+| Web `Organization.status` union drifted: has `inactive`, lacks `churned`/`offboarding` | `stores/orgStore.ts:15` |
+| Tab patterns: `useHashState` + `OverflowTabs` (DeviceDetails), `SettingsSectionNav` (settings pages), `HashLink` | `lib/useHashState.ts`, `shared/OverflowTabs.tsx`, `shared/HashLink.tsx` |
+| 8 locales must stay in parity | `apps/web/src/locales/*/common.json` |
+
+## Decisions (quorum)
+
+| # | Decision | Rejected |
+|---|---|---|
+| D1 | New record page at `/organizations/[id]`; settings page stays and becomes the record's Settings tab target | Growing the settings page with operational tabs (mixes dirty-state forms with live lists); "open = switch scope + dashboard" (reload, no record) |
+| D2 | Record is URL-pinned. Opening it never changes the global OrgSwitcher scope. A secondary "Work in this org" button does | Auto-switching scope on open |
+| D3 | Both: regroup the sidebar by workflow *and* add a partner-level PSA toggle | Toggle only (nav still cluttered for PSA users); regroup only (RMM-only shops still see PSA) |
+| D4 | Toggle storage: dedicated boolean column on `partners` (see Part 2 and quorum record for the table alternative) | `partner_modules` table (a new partner-axis RLS table with allowlist + `*PartnerRls` suite for one presentation preference; no org cascade/export burden since it has no `org_id`, but still a tenant table to own) |
+| D5 | Status pill in lists shown only for non-`active` statuses; record header always shows status, subdued when active | Removing status from the list entirely |
+
+---
+
+## Part 1: Organization record page
+
+### 1.1 Route and entry points
+
+- Astro page `apps/web/src/pages/organizations/[id].astro` → `<OrganizationRecordPage orgId={id} client:load />`.
+- Register `/^\/organizations\/[^/]+(\/.*)?$/` in `lib/routeScope.ts` as a new
+  kind `org-record`: it neither requires nor follows the global scope.
+  `getOrgSwitchRedirect` sends it to `/settings/organizations` on a scope switch
+  (same treatment as other detail routes). `ContextScopeLine` renders
+  "Viewing <org name>" and, when the global scope is a *different* org, appends
+  "· workspace scope: <other org>" so the two contexts are never confused.
+- Entry points added in this feature:
+  - Organizations list row: the org name becomes a link to the record and a
+    persistent chevron sits at the row end (the hover pencil and archive icons
+    stay). Detail-pane header gains a primary **Open record** button; the
+    existing Edit button is relabelled **Settings**.
+  - Device detail breadcrumb org crumb → `/organizations/<id>`.
+  - Ticket, invoice, quote, contract detail pages: org name → record.
+  - Not in scope: the command palette (it does not list organizations today).
+- Permission: `organizations:read` for the page. Each tab is additionally gated
+  by its own resource (`tickets:read`, `invoices:read`, `contracts:read`,
+  `devices:read`, `alerts:read`, `audit:read`); a tab the user cannot read is
+  not rendered. Sidebar visibility for Part 1 is unchanged (Organizations stays
+  under Settings until Part 2).
+- Org-scoped tokens: the API already 404s `GET /orgs/organizations/:id` for a
+  foreign org, so an org user can open only their own record. No new checks.
+
+### 1.2 URL-pinned fetching
+
+Add an `orgIdOverride?: string | null` option to `fetchWithAuth`
+(`stores/auth.ts`):
+
+- `undefined` (default): current behaviour, inject the global scope.
+- `string`: set `orgId=<override>` on the URL, replacing any existing value.
+- `null`: suppress injection (equivalent to `skipOrgIdInjection`, which becomes
+  an alias and is left in place).
+
+Implementation notes: parse with `URL`/`URLSearchParams` instead of the current
+substring test; strip the custom options before spreading into native `fetch`;
+if the URL already carries a *different* `orgId=` than the override, throw (a
+conflicting explicit target is a bug, not a preference). Path-scoped endpoints
+with strict query schemas (the `OrgBillingSettings` precedent) pass `null`.
+The record page wraps this once as `orgFetch(path, init)` and passes it, or the
+`orgId` itself, down as props. No React context carries the org id into shared
+list components: explicit props are what `ContractsList`/`ContactsCard` already
+do, and they are greppable. Responses are keyed by org id and a response for a
+previous org id is discarded (navigating record to record must not paint stale
+data).
+
+Mutations, creation forms, exports and outbound links from inside the record
+(create ticket, add contact, add site, export devices) must carry the pinned org
+the same way; the global scope must never leak into a default. A code-review
+checklist item for each tab: every request, form default and link in the tab
+either uses `orgFetch`/the pinned `orgId` or a path that embeds it.
+
+### 1.3 Header
+
+Identity only, so it stays readable on narrow widths: name; type badge
+(`customer`/`internal`); status (always shown, `active` rendered subdued, other
+statuses use the existing `statusColors`); primary contact (name, email, phone;
+the contact flagged primary, else none); site count. All metrics (devices,
+alerts, tickets, contracts, invoices) live in the Overview tab tiles (1.4, 1.5).
+
+Actions: **Work in this org** (calls `applyOrgSwitch` to this org, lands on the
+dashboard), **Settings** (→ `/settings/organizations/<id>`), overflow with
+Archive and Merge (reuse `ArchiveOrgModal`/`MergeOrgModal`; Merge only when
+`canMergeOrgs`).
+
+Lifecycle:
+
+- `archived` / `offboarding` (`isArchiveLifecycleOrg`): same read-only banner
+  and drain/purge countdown as the settings page, every mutation hidden,
+  Restore offered. Tabs remain readable through the existing archived read path.
+- `suspended` / `churned`: **not in the partner token's accessible-org set**
+  (`middleware/auth.ts` admits only `active`/`trial`), so the record GET and
+  every tab fetch will 404/deny under RLS. The record renders a lifecycle card
+  from the list's cached row (name, status, created) with copy explaining that
+  the organization's data is not accessible while in that status, and a link to
+  the settings list. Same limitation the settings page has today; widening
+  partner access to suspended orgs is a follow-up, not this feature.
+
+### 1.4 Summary endpoint
+
+`GET /orgs/organizations/:id/summary` in a new file
+`apps/api/src/routes/orgs/summary.ts` (mounted from `routes/orgs.ts`), guarded
+like `GET /orgs/organizations/:id` (`requireOrgRead` + accessible-org check).
+Returns:
+
+```
+{
+  devices:   { total, online, offline, stale },
+  alerts:    { open, critical, high },
+  tickets:   { open, awaitingCustomer, overdue },
+  contracts: { active, nextRenewalAt },
+  invoices:  { outstandingCents, currencyCode, nextDueAt, overdueCount },
+  sites:     { count },
+  contacts:  { count, primary: { id, name, email } | null },
+  portalUsers: { count },
+  lastActivityAt
+}
+```
+
+Sections the caller lacks permission for are omitted (not zeroed) so the Overview
+can hide the tile. All queries run inside the request's `withDbAccessContext`;
+no system context, no new tables. Counts are cheap `COUNT` per table keyed on
+`org_id` indexes that already exist; if any proves slow at 10k devices, cache
+per org for 60s in Redis (follow-up, not in wave 1).
+
+### 1.5 Tabs
+
+Hash-keyed via `useHashState` + `OverflowTabs` (the DeviceDetails pattern).
+Each tab lazy-loads on first activation.
+
+| Tab | Renders | Change needed |
+|---|---|---|
+| Overview | Summary tiles (from 1.4), recent activity (last 20 audit events for the org), open critical alerts, upcoming renewals/invoices | New `OrgOverview` component; audit and alert lists via `orgFetch` |
+| Contacts | `ContactsCard({orgId})` | None. Settings `#contacts` section becomes a link to the record tab (one owner) |
+| Sites | `SiteList` fed by `GET /orgs/sites?organizationId=` plus add/edit/delete using the existing `SiteForm` modals | Extract the site-modal handlers from `OrganizationsPage` into a hook `useSiteCrud(orgId)` shared by both pages |
+| Devices | `DeviceList` fed by `GET /devices?orgId=`; filters limited to site/status/search; row → device detail | Parent loader; `DeviceList` is data-driven but derives `isFleetView` (org column) from the global store, so add a `forceSingleOrg`/`lockedOrgId` prop that overrides it |
+| Tickets | `TicketQueueList` fed by `GET /tickets?orgId=` + status filter; "New ticket" preselects the org | Parent loader only; `TicketQueueList` is presentational (`tickets[]`, `onSelect`) |
+| Contracts & Billing | `ContractsList({lockedOrgId})`; invoices and quotes tables filtered by `orgId` (extract `InvoiceTable`/`QuoteTable` presentational pieces from the pages or add `lockedOrgId` to the pages) | `lockedOrgId` prop on `InvoicesPage`/`QuotesPage` following `ContractsList` |
+| Activity | `AuditLogViewer` pinned to the org | Add an `orgId?: string` prop (today it takes only `timezone` and reads global scope) |
+| Settings | Link-out to `/settings/organizations/<id>` (not embedded) | None |
+
+Legacy hashes: `/settings/organizations/<id>#contacts` redirects to
+`/organizations/<id>#contacts`; `#contracts` likewise. `#billing` and
+`#pax8/<id>` are unchanged (billing config stays in settings).
+
+### 1.6 Organizations list changes (`/settings/organizations`)
+
+- Status pill rendered only when `status !== 'active'` (archived section
+  unchanged). Detail header keeps the pill always.
+- Row: name is a link to the record; persistent chevron; existing hover icons
+  stay. `data-testid="org-open-record-<id>"`.
+- Detail pane: **Open record** primary, **Settings** secondary, Archive/Merge
+  unchanged.
+- Fix `Organization.status` union in `stores/orgStore.ts` to match the API
+  (`active | trial | suspended | churned | offboarding | merging | archived | purging`),
+  and grep callers for `'inactive'`.
+
+### 1.7 Testing
+
+- `stores/auth.test.ts`: `orgIdOverride` string replaces an existing `orgId`,
+  `null` suppresses, `undefined` keeps injection; custom option is not forwarded
+  to `fetch`.
+- `lib/routeScope.test.ts`: new kind, switch redirect, scope line copy.
+- `routes/orgs/summary.test.ts` (Drizzle mock): shape, permission-omitted
+  sections, 404 for inaccessible org.
+- Integration: an org-scoped token gets 404 for another org's summary; a partner
+  token gets counts that match seeded rows.
+- Component tests for header lifecycle states, tab gating by permission, and
+  that the list hides the Active pill but shows Trial/Suspended.
+- E2E (`e2e-tests`): open record from list, switch tabs by hash, "Work in this
+  org" changes scope.
+- `no-silent-mutations`: any new mutation handler uses `runAction`.
+
+---
+
+## Part 2: Workflow navigation and the PSA module toggle
+
+### 2.1 Recommendation
+
+Do both (D3). The sidebar already has single-level collapsible sections that
+are, in effect, workflow groups (Fleet Management, Security, Backup, Billing,
+AI). A two-level tree (Module → Section → Item) is a nav rewrite for little
+gain, since sections already collapse. Instead:
+
+1. **Regroup and rename sections so the module is legible from the headers**:
+
+   | Section (new) | Items |
+   |---|---|
+   | Dashboard, Organizations | top-level, module-neutral (Organizations moves out of Settings; partner scope only, `organizations:read`) |
+   | RMM · Fleet | Devices, Discovery, Patches, Software, Scripts, Automations, Monitors, Remote, Peripherals, SNMP, Fleet Posture |
+   | RMM · Security | current Security section unchanged |
+   | RMM · Backup | current Backup section unchanged |
+   | PSA · Service Desk | Tickets, Timesheet (Approvals stays module-neutral: it is AI/PAM approvals) |
+   | PSA · Billing | Contracts, Quotes, Invoices, Product Catalog |
+   | AI | current AI section unchanged (AI Agents, AI Impact, AI Usage, AI for Office, Workspace) |
+   | Reporting | unchanged, cross-module |
+   | Settings, Administration, Extensions | unchanged |
+
+   Naming: Todd's term is PSA. Codex suggested "Service Management" because the
+   repo uses "PSA" for external PSA *connectors* (`components/psa/*`,
+   `psa_connections`). Decision for Todd; the module key in code is `psa`
+   either way.
+
+2. **Partner-level module toggle** hides the two PSA sections and the record's
+   Tickets and Contracts & Billing tabs and Overview tiles, plus their creation
+   affordances. It does **not** hide external PSA connectors on the Integrations
+   page (ConnectWise/Autotask/Halo sync): an RMM-only shop is exactly the shop
+   that pushes tickets to someone else's PSA.
+
+### 2.2 Toggle semantics
+
+- It is a **presentation preference, never authorization**. The API keeps
+  enforcing RBAC only; every PSA route keeps working when the module is off, and
+  deep links still open. No 403s are introduced by the toggle.
+- Partner-wide, no org override. An MSP either runs a service desk or it does
+  not.
+- Default **on** for existing and new partners. The setting lives on the Partner
+  settings page under a new **Modules** card in the `company` section: one
+  switch, "Service desk & billing (PSA)", with the list of what it hides.
+- Sidebar gate `requiresModule: 'psa'` evaluated in `isNavItemVisible`. Source:
+  `psaEnabled` on `GET /orgs/partners/me`, persisted in the zustand store so the
+  first paint uses the last known value (no flash, no over-hide during the
+  cold-load window that already bites `requiredPermission`). Fails open when the
+  fetch errors.
+- Org-scoped users are **not** affected by the toggle. `GET /orgs/partners/me`
+  is `requireScope('partner')`, so an org token cannot read the flag, and org
+  navigation is already narrowed by `partnerScopeOnly` (Quotes, Invoices,
+  Contracts, Catalog are partner-only) plus RBAC. The only PSA items an org
+  user can see are Tickets and Timesheet, which their role grants or not.
+  Alternative if this proves wrong in practice: expose `psaEnabled` on the
+  org-readable branding/config endpoint. Not in W4.
+
+### 2.3 Storage (D4)
+
+`partners.psa_enabled boolean NOT NULL DEFAULT true`, migration named to sort
+after the newest committed migration at implementation time (as of 2026-09-06
+that is `2026-10-12-000100-device-manual-maintenance-lease.sql`, so e.g.
+`2026-10-12-000200-partners-psa-enabled.sql`; re-check before committing, the
+ceiling runs ahead of real time). `ADD COLUMN IF NOT EXISTS`. Exposed on `GET /orgs/partners/me` next to
+`aiForOfficeEnabled`; writable on `PATCH /orgs/partners/me` by partner admins
+(unlike `aiForOfficeEnabled`, which is platform-only). `partners` is not an
+org-cascade table, so no cascade-list change; the column is a plain boolean, so
+no export-policy bucket change beyond what the partner table already has (verify
+with `tenant-export-policy.integration.test.ts`).
+
+Why a column and not a `partner_modules` table: one toggle today, and the table
+would be a new partner-axis RLS tenant table (policy, `PARTNER_TENANT_TABLES`
+allowlist entry, its own `*PartnerRls.integration.test.ts`; no org cascade or
+export-policy entries since it has no `org_id`). The typed column matches how
+every other partner preference is stored. Revisit a table when modules need
+metadata or an independent lifecycle; a third toggle is a prompt to review, not
+an automatic migration. The read path (`partners/me`) keeps its shape either way.
+
+### 2.4 Testing
+
+- `Sidebar.module.test.tsx`: PSA sections hidden when `psaEnabled=false`,
+  visible when true or when the fetch fails, Organizations visible in both.
+- `routes/orgs.test.ts`: `psaEnabled` round-trips on `/partners/me` GET and
+  PATCH; org-scope PATCH is rejected.
+- Record page: PSA tabs and tiles hidden when the flag is off.
+- Migration idempotency via `autoMigrate.test.ts`; naming guard.
+- Locale parity: new `nav.*`, `orgRecord.*`, `partnerSettingsPage.modules.*`
+  keys in all 8 locales (`keyUsage.test.ts`).
+
+---
+
+## Waves
+
+| Wave | Scope | Depends on |
+|---|---|---|
+| W1 | `orgIdOverride`, route-scope kind, summary endpoint, record page shell with header + Overview, list affordances + status-pill rule, orgStore status fix, device breadcrumb retarget | — |
+| W2 | Contacts, Sites (shared `useSiteCrud`), Devices, Activity tabs; settings `#contacts` redirect | W1 |
+| W3 | Tickets and Contracts & Billing tabs (`lockedOrgId` on invoices/quotes pages), `#contracts` redirect, org links from ticket/invoice/quote/contract details | W1 |
+| W4 | Sidebar regroup + Organizations top-level; `psa_enabled` column, `/partners/me` exposure, Modules card, `requiresModule` gate, record tab gating | W1 (for the record gating), otherwise independent |
+
+W2 and W3 are file-disjoint and can run in parallel. W4 can start after W1 in
+parallel with W2/W3.
+
+## Open questions for Todd
+
+1. Section naming: **PSA** (your term) or **Service Management** (codex's
+   suggestion, avoids collision with PSA connectors)?
+2. Should the top-level **Organizations** item point at a new operational list
+   (`/organizations`, table with online/total devices, open tickets, alerts) or
+   at the existing settings master-detail for now? Recommendation: existing
+   page in W4, new list as a follow-up once the record has shipped and we know
+   which columns techs actually use.
+3. Default for the PSA toggle on **self-hosted** installs: same default-on, or
+   off? Recommendation: same default-on; the switch is one click.
+
+## Quorum record
+
+- **codex gpt-5.6-sol xhigh (2026-09-06)**: agreed D1, D2, D3 and the
+  status-pill rule. Added: lazy-load tabs; move Contacts/Contracts to the record
+  and redirect legacy hashes; `orgIdOverride` on `fetchWithAuth` with URL
+  parsing; show both contexts when pinned org ≠ global scope; new `org-record`
+  route kind; "Service Management" naming; fail-open nav after a stable loading
+  state. Disagreed on D4 (preferred a `partner_modules` table with partner RLS).
+  Contradictions it surfaced and this spec absorbs: `quick_support` org type,
+  Organizations nav is permission-gated not `partnerScopeOnly`, `orgStore`
+  status union drift.
+- **codex gpt-6-astra xhigh (2026-09-06)**: agreed D1, D2, D3, D5 and picked
+  the column for D4 (tie-break), correcting the premise that a partner-axis
+  table would carry org cascade/export registrations (it would not; it would
+  still need partner RLS + allowlisting). Added: header too crowded, move
+  metrics to Overview; partner tokens cannot access `suspended`/`churned` orgs
+  so the record needs a lifecycle-only view for them; conflicting explicit
+  `orgId` targets should throw; path-scoped strict-schema endpoints suppress
+  injection; key caches by org and discard stale responses; `DeviceList`
+  derives `isFleetView` from the store; keep external PSA connectors visible
+  when the module is off; keep Organizations and Reporting outside the module
+  groups. Suggested exposing the flag to org users via bootstrap (deferred, see
+  2.2) and an onboarding "RMM only" choice (follow-up).
+
+## Follow-ups (not in these waves)
+
+- Onboarding "RMM only" preset that sets `psa_enabled=false` at partner signup.
+- Partner access to `suspended`/`churned` organizations' records (today the
+  partner token's org set excludes them, so their data is unreachable in both
+  the record and the settings page).
+- `psaEnabled` on an org-readable bootstrap endpoint if org users need the
+  module preference.
+- Operational `/organizations` list with online/total, open tickets, open
+  alerts columns (see open question 2).
+- Redis-cached summary if the counts prove slow at fleet scale.

--- a/docs/superpowers/specs/web-ui/2026-09-06-organization-record-page-design.md
+++ b/docs/superpowers/specs/web-ui/2026-09-06-organization-record-page-design.md
@@ -4,8 +4,8 @@ Status: **approved by Todd 2026-09-06** (open questions resolved, see below).
 Advisor quorum complete: Fable, codex gpt-5.6-sol xhigh and codex gpt-6-astra
 xhigh agree on D1, D2, D3 and D5; D4 (column vs table) split 2:1 for the
 column, GPT-6 casting the tie-break. See "Quorum record".
-Tracking: registered via feature-lifecycle once the implementation plan exists
-(multi-wave).
+Tracking: LanternOps/breeze#5075 (waves #5076 W01, #5077 W02, #5078 W03, #5079 W04).
+Plan: `docs/superpowers/plans/2026-09-06-organization-record-page.md`.
 
 ## Problem
 
@@ -116,8 +116,10 @@ RMM-only partners, and should the sidebar be regrouped into workflow trees.
   `devices:read`, `alerts:read`, `audit:read`); a tab the user cannot read is
   not rendered. Sidebar visibility for Part 1 is unchanged (Organizations stays
   under Settings until Part 2).
-- Org-scoped tokens: the API already 404s `GET /orgs/organizations/:id` for a
-  foreign org, so an org user can open only their own record. No new checks.
+- Org-scoped tokens: `GET /orgs/organizations/:id` is `requireScope('partner',
+  'system')`, so org users get 403. The record is a partner/system surface; an
+  org-scoped JWT renders a "not available in this workspace" state linking to
+  `/`. The API is not widened (plan note 2).
 
 ### 1.2 URL-pinned fetching
 
@@ -194,8 +196,11 @@ Returns:
 }
 ```
 
-Sections the caller lacks permission for are omitted (not zeroed) so the Overview
-can hide the tile. All queries run inside the request's `withDbAccessContext`;
+The shape above is illustrative; the binding shape is `OrgSummary` in the plan
+(`docs/superpowers/plans/2026-09-06-organization-record-page.md`, Task 1.4),
+which drops fields the schema cannot answer cheaply (`tickets.overdue`,
+`devices.stale`). Sections the caller lacks permission for are omitted (not
+zeroed) so the Overview can hide the tile. All queries run inside the request's `withDbAccessContext`;
 no system context, no new tables. Counts are cheap `COUNT` per table keyed on
 `org_id` indexes that already exist; if any proves slow at 10k devices, cache
 per org for 60s in Redis (follow-up, not in wave 1).
@@ -214,7 +219,7 @@ Each tab lazy-loads on first activation.
 | Tickets | `TicketQueueList` fed by `GET /tickets?orgId=` + status filter; "New ticket" preselects the org | Parent loader only; `TicketQueueList` is presentational (`tickets[]`, `onSelect`) |
 | Contracts & Billing | `ContractsList({lockedOrgId})`; invoices and quotes tables filtered by `orgId` (extract `InvoiceTable`/`QuoteTable` presentational pieces from the pages or add `lockedOrgId` to the pages) | `lockedOrgId` prop on `InvoicesPage`/`QuotesPage` following `ContractsList` |
 | Activity | `AuditLogViewer` pinned to the org | Add an `orgId?: string` prop (today it takes only `timezone` and reads global scope) |
-| Settings | Link-out to `/settings/organizations/<id>` (not embedded) | None |
+| Settings | Not a tab: a header action linking to `/settings/organizations/<id>` (plan Task 1.5) | None |
 
 Legacy hashes: `/settings/organizations/<id>#contacts` redirects to
 `/organizations/<id>#contacts`; `#contracts` likewise. `#billing` and

--- a/docs/superpowers/specs/web-ui/2026-09-06-organization-record-page-design.md
+++ b/docs/superpowers/specs/web-ui/2026-09-06-organization-record-page-design.md
@@ -1,10 +1,11 @@
-# Organization record page and PSA module navigation
+# Organization record page and Service Management navigation
 
-Status: draft for Todd's review (2026-09-06). Advisor quorum complete: Fable,
-codex gpt-5.6-sol xhigh and codex gpt-6-astra xhigh agree on D1, D2, D3 and D5;
-D4 (column vs table) split 2:1 for the column, GPT-6 casting the tie-break. See
-"Quorum record".
-Tracking: to be registered via feature-lifecycle after approval (multi-wave).
+Status: **approved by Todd 2026-09-06** (open questions resolved, see below).
+Advisor quorum complete: Fable, codex gpt-5.6-sol xhigh and codex gpt-6-astra
+xhigh agree on D1, D2, D3 and D5; D4 (column vs table) split 2:1 for the
+column, GPT-6 casting the tie-break. See "Quorum record".
+Tracking: registered via feature-lifecycle once the implementation plan exists
+(multi-wave).
 
 ## Problem
 
@@ -26,7 +27,7 @@ Two further observations drive this design:
   applied by a full page reload. Opening a customer must not require switching
   the technician's working scope.
 
-Todd's second question, answered in Part 2: should PSA features be hideable for
+Todd's second question, answered in Part 2: should the service desk and billing module be hideable for
 RMM-only partners, and should the sidebar be regrouped into workflow trees.
 
 ## Goals
@@ -35,15 +36,22 @@ RMM-only partners, and should the sidebar be regrouped into workflow trees.
    overview and tabs, pinned to that org regardless of global scope.
 2. An always-visible way to open it from the organizations list, plus
    exception-only status badges in the list.
-3. A partner-level switch that hides the PSA module for RMM-only partners, and a
-   sidebar grouped by workflow (RMM, PSA, AI) without a two-level tree rewrite.
+3. A partner-level Service Management mode (`native` / `off` / `external`) that
+   hides the service desk and billing module for RMM-only partners and is
+   already shaped for an external PSA as system of record, plus a sidebar
+   grouped by workflow without a two-level tree rewrite.
 
 ## Non-goals
 
 - Replacing `/settings/organizations` (add, bulk import, reorder, archive,
   merge, sites CRUD stay there).
 - Moving billing configuration, Pax8 or any settings editor onto the record.
-- New tenant tables. Part 1 needs none; Part 2 needs one boolean column.
+- New tenant tables. Part 1 needs none; Part 2 needs two scalar columns on
+  `partners`.
+- The external service desk itself (adapter wiring for `createTicket`, shadow
+  ticket rows, inbound status sync, org → PSA company picker). Part 2 only
+  reserves the `external` mode for it; it gets its own spec and feature after
+  this one (see D6 and Follow-ups).
 - Custom fields on organizations (#3843), org document templates (#3844),
   cross-org reporting (#3858). The record links out where those land later.
 - An onboarding "RMM only" preset. Follow-up once the toggle exists.
@@ -76,9 +84,11 @@ RMM-only partners, and should the sidebar be regrouped into workflow trees.
 |---|---|---|
 | D1 | New record page at `/organizations/[id]`; settings page stays and becomes the record's Settings tab target | Growing the settings page with operational tabs (mixes dirty-state forms with live lists); "open = switch scope + dashboard" (reload, no record) |
 | D2 | Record is URL-pinned. Opening it never changes the global OrgSwitcher scope. A secondary "Work in this org" button does | Auto-switching scope on open |
-| D3 | Both: regroup the sidebar by workflow *and* add a partner-level PSA toggle | Toggle only (nav still cluttered for PSA users); regroup only (RMM-only shops still see PSA) |
-| D4 | Toggle storage: dedicated boolean column on `partners` (see Part 2 and quorum record for the table alternative) | `partner_modules` table (a new partner-axis RLS table with allowlist + `*PartnerRls` suite for one presentation preference; no org cascade/export burden since it has no `org_id`, but still a tenant table to own) |
+| D3 | Both: regroup the sidebar by workflow *and* add a partner-level Service Management mode | Mode only (nav still cluttered for service-desk users); regroup only (RMM-only shops still see the module) |
+| D4 | Mode storage: two typed columns on `partners` (`service_management_mode`, `service_management_psa_connection_id`) | `partner_modules` table (a new partner-axis RLS table with allowlist + `*PartnerRls` suite for one preference; no org cascade/export burden since it has no `org_id`, but still a tenant table to own); a JSON blob in `partners.settings` |
 | D5 | Status pill in lists shown only for non-`active` statuses; record header always shows status, subdued when active | Removing status from the list entirely |
+| D6 | External PSA (ConnectWise, Autotask, …) as system of record = **direct create through `ticketService` via the existing adapters, a thin shadow `tickets` row with the external id/URL, and inbound sync limited to status/closure**. Approved by Todd 2026-09-06; specified in a follow-on feature | Two-way sync of the native ticketing module with the PSA (board/type/status mapping per vendor, comment and attachment mirroring, conflict resolution, two systems of record); "no local record at all" (breaks every surface that reads `tickets`: alert linked-tickets card, AI tool reads, portal, org record, reporting) |
+| D7 | The module is named **Service Management** in UI, i18n keys and the column name; "PSA" stays reserved for external connectors | "PSA" (collides with `components/psa/*`, `psa_connections`) |
 
 ---
 
@@ -240,92 +250,120 @@ Legacy hashes: `/settings/organizations/<id>#contacts` redirects to
 
 ---
 
-## Part 2: Workflow navigation and the PSA module toggle
+## Part 2: Workflow navigation and the Service Management mode
 
-### 2.1 Recommendation
+### 2.1 Recommendation (approved 2026-09-06)
 
 Do both (D3). The sidebar already has single-level collapsible sections that
 are, in effect, workflow groups (Fleet Management, Security, Backup, Billing,
 AI). A two-level tree (Module → Section → Item) is a nav rewrite for little
 gain, since sections already collapse. Instead:
 
-1. **Regroup and rename sections so the module is legible from the headers**:
+1. **Regroup sections so the module is legible from the headers.** The module
+   is called **Service Management** (Todd, 2026-09-06; "PSA" in this repo means
+   the external PSA *connectors*, `components/psa/*`, `psa_connections`).
 
-   | Section (new) | Items |
+   | Section | Items |
    |---|---|
-   | Dashboard, Organizations | top-level, module-neutral (Organizations moves out of Settings; partner scope only, `organizations:read`) |
-   | RMM · Fleet | Devices, Discovery, Patches, Software, Scripts, Automations, Monitors, Remote, Peripherals, SNMP, Fleet Posture |
-   | RMM · Security | current Security section unchanged |
-   | RMM · Backup | current Backup section unchanged |
-   | PSA · Service Desk | Tickets, Timesheet (Approvals stays module-neutral: it is AI/PAM approvals) |
-   | PSA · Billing | Contracts, Quotes, Invoices, Product Catalog |
-   | AI | current AI section unchanged (AI Agents, AI Impact, AI Usage, AI for Office, Workspace) |
+   | Dashboard, Organizations | top-level, module-neutral. Organizations moves out of Settings and points at the existing `/settings/organizations` page for now (operational list is a follow-up); partner scope only, `organizations:read` |
+   | Fleet Management, Security, Backup | unchanged (RMM; the product name, so no prefix) |
+   | Service Desk | Tickets, Timesheet (Approvals stays module-neutral: it is AI/PAM approvals) |
+   | Billing | Contracts, Quotes, Invoices, Product Catalog |
+   | AI | unchanged (AI Agents, AI Impact, AI Usage, AI for Office, Workspace) |
    | Reporting | unchanged, cross-module |
    | Settings, Administration, Extensions | unchanged |
 
-   Naming: Todd's term is PSA. Codex suggested "Service Management" because the
-   repo uses "PSA" for external PSA *connectors* (`components/psa/*`,
-   `psa_connections`). Decision for Todd; the module key in code is `psa`
-   either way.
+   Service Desk and Billing sit adjacent and are the two sections the mode
+   below hides. Section i18n keys: `nav.sectionServiceDesk`, `nav.sectionBilling`.
 
-2. **Partner-level module toggle** hides the two PSA sections and the record's
-   Tickets and Contracts & Billing tabs and Overview tiles, plus their creation
-   affordances. It does **not** hide external PSA connectors on the Integrations
-   page (ConnectWise/Autotask/Halo sync): an RMM-only shop is exactly the shop
-   that pushes tickets to someone else's PSA.
+2. **Partner-level Service Management mode** (replaces the earlier on/off
+   boolean; shaped now so the external-PSA follow-on does not retrofit it).
 
-### 2.2 Toggle semantics
+### 2.2 Mode semantics
 
-- It is a **presentation preference, never authorization**. The API keeps
-  enforcing RBAC only; every PSA route keeps working when the module is off, and
-  deep links still open. No 403s are introduced by the toggle.
+`service_management_mode` is one of:
+
+| Mode | Meaning | Nav | Org record | Ticket creation surfaces |
+|---|---|---|---|---|
+| `native` (default, hosted and self-hosted alike) | Breeze is the service desk and billing system | Service Desk + Billing shown | Tickets and Contracts & Billing tabs + tiles shown | Unchanged |
+| `off` | RMM-only partner | Both sections hidden | Both tabs and their tiles hidden | Hidden in the web (alert dialog, "New ticket"); `manage_tickets` create actions and the add-in `ticket-create` capability return a clear "service management is off" error; portal ticket submission forced off |
+| `external` | The partner's system of record is an external PSA bound to `service_management_psa_connection_id` | Both sections hidden; a read-only Tickets list of shadow rows with external links replaces the workbench | Tickets tab shows shadow rows with "Open in <PSA>" links; Contracts & Billing hidden | Route through the connection's adapter (`createTicket`), write a shadow `tickets` row (`source='psa'`, `external_ticket_id/url`), narrow inbound status sync. **Specified and built by the follow-on "External service desk" feature**; W4 ships the value in the schema and validator but the settings UI offers only `native` and `off` until that feature lands |
+
+Rules that hold in every mode:
+
+- The mode never changes API authorization. RBAC keeps enforcing every route;
+  deep links to existing tickets, invoices and contracts keep working; background
+  billing jobs are unaffected (they act only on data the partner created).
+  The single behavioural effect is that `off` refuses *new* ticket creation at
+  the service layer, so nothing can create tickets nobody will see.
 - Partner-wide, no org override. An MSP either runs a service desk or it does
   not.
-- Default **on** for existing and new partners. The setting lives on the Partner
-  settings page under a new **Modules** card in the `company` section: one
-  switch, "Service desk & billing (PSA)", with the list of what it hides.
-- Sidebar gate `requiresModule: 'psa'` evaluated in `isNavItemVisible`. Source:
-  `psaEnabled` on `GET /orgs/partners/me`, persisted in the zustand store so the
-  first paint uses the last known value (no flash, no over-hide during the
-  cold-load window that already bites `requiredPermission`). Fails open when the
-  fetch errors.
-- Org-scoped users are **not** affected by the toggle. `GET /orgs/partners/me`
-  is `requireScope('partner')`, so an org token cannot read the flag, and org
+- External PSA connectors on the Integrations page stay visible in every mode:
+  an RMM-only shop is exactly the shop that pushes tickets to someone else's
+  PSA.
+- Sidebar gate `requiresModule: 'service_management'` evaluated in
+  `isNavItemVisible`. Source: `serviceManagementMode` on
+  `GET /orgs/partners/me`, persisted in the zustand store so the first paint uses
+  the last known value (no flash, no over-hide during the cold-load window that
+  already bites `requiredPermission`). Fails open (`native`) when the fetch
+  errors.
+- Org-scoped users are **not** affected by the mode. `GET /orgs/partners/me`
+  is `requireScope('partner')`, so an org token cannot read it, and org
   navigation is already narrowed by `partnerScopeOnly` (Quotes, Invoices,
-  Contracts, Catalog are partner-only) plus RBAC. The only PSA items an org
-  user can see are Tickets and Timesheet, which their role grants or not.
-  Alternative if this proves wrong in practice: expose `psaEnabled` on the
+  Contracts, Catalog are partner-only) plus RBAC. The only Service Management
+  items an org user can see are Tickets and Timesheet, which their role grants
+  or not. Alternative if this proves wrong in practice: expose the mode on the
   org-readable branding/config endpoint. Not in W4.
+- The setting lives on the Partner settings page under a new **Modules** card
+  in the `company` section: a radio group (Breeze / Off; External appears when
+  the follow-on ships) with the list of what each choice hides.
 
 ### 2.3 Storage (D4)
 
-`partners.psa_enabled boolean NOT NULL DEFAULT true`, migration named to sort
-after the newest committed migration at implementation time (as of 2026-09-06
-that is `2026-10-12-000100-device-manual-maintenance-lease.sql`, so e.g.
-`2026-10-12-000200-partners-psa-enabled.sql`; re-check before committing, the
-ceiling runs ahead of real time). `ADD COLUMN IF NOT EXISTS`. Exposed on `GET /orgs/partners/me` next to
-`aiForOfficeEnabled`; writable on `PATCH /orgs/partners/me` by partner admins
-(unlike `aiForOfficeEnabled`, which is platform-only). `partners` is not an
-org-cascade table, so no cascade-list change; the column is a plain boolean, so
-no export-policy bucket change beyond what the partner table already has (verify
-with `tenant-export-policy.integration.test.ts`).
+Two columns on `partners`, one migration named to sort after the newest
+committed migration at implementation time (as of 2026-09-06 that is
+`2026-10-12-000100-device-manual-maintenance-lease.sql`, so e.g.
+`2026-10-12-000200-partners-service-management-mode.sql`; re-check before
+committing, the ceiling runs ahead of real time):
 
-Why a column and not a `partner_modules` table: one toggle today, and the table
+```sql
+ALTER TABLE partners
+  ADD COLUMN IF NOT EXISTS service_management_mode text NOT NULL DEFAULT 'native',
+  ADD COLUMN IF NOT EXISTS service_management_psa_connection_id uuid
+    REFERENCES psa_connections(id) ON DELETE RESTRICT;
+-- CHECK service_management_mode IN ('native','external','off')
+-- CHECK (service_management_mode <> 'external' OR service_management_psa_connection_id IS NOT NULL)
+-- CHECK (service_management_mode = 'external' OR service_management_psa_connection_id IS NULL)
+```
+
+`ON DELETE RESTRICT` so a bound connection cannot be deleted without first
+leaving external mode. The PATCH handler validates that the referenced
+connection is partner-owned by the caller's partner (`psa_connections` is org
+XOR partner owned; only partner-owned rows qualify). Exposed on
+`GET /orgs/partners/me` next to `aiForOfficeEnabled`; writable on
+`PATCH /orgs/partners/me` by partner admins (unlike `aiForOfficeEnabled`, which
+is platform-only). `partners` is a partner-axis table with no `org_id`, so no
+org cascade or export-policy registration applies; both columns are scalar.
+
+Why columns and not a `partner_modules` table: one mode today, and the table
 would be a new partner-axis RLS tenant table (policy, `PARTNER_TENANT_TABLES`
-allowlist entry, its own `*PartnerRls.integration.test.ts`; no org cascade or
-export-policy entries since it has no `org_id`). The typed column matches how
-every other partner preference is stored. Revisit a table when modules need
-metadata or an independent lifecycle; a third toggle is a prompt to review, not
-an automatic migration. The read path (`partners/me`) keeps its shape either way.
+allowlist entry, its own `*PartnerRls.integration.test.ts`). The typed column
+matches how every other partner preference is stored. Revisit a table when
+modules need metadata or an independent lifecycle.
 
 ### 2.4 Testing
 
-- `Sidebar.module.test.tsx`: PSA sections hidden when `psaEnabled=false`,
-  visible when true or when the fetch fails, Organizations visible in both.
-- `routes/orgs.test.ts`: `psaEnabled` round-trips on `/partners/me` GET and
-  PATCH; org-scope PATCH is rejected.
-- Record page: PSA tabs and tiles hidden when the flag is off.
-- Migration idempotency via `autoMigrate.test.ts`; naming guard.
+- `Sidebar.module.test.tsx`: Service Desk and Billing hidden for `off` and
+  `external`, visible for `native` and when the fetch fails; Organizations
+  visible in every mode.
+- `routes/orgs.test.ts`: mode round-trips on `/partners/me` GET and PATCH;
+  `external` without a connection is 400; a connection owned by another partner
+  or by an org is 400; org-scope PATCH is rejected.
+- `ticketService` / `aiToolsTicketing` / `officeAddin/tickets`: creation
+  refused with the mode error when `off`; unchanged when `native`.
+- Record page: Service Management tabs and tiles hidden when `off`.
+- Migration idempotency via `autoMigrate.test.ts`; naming guard; CHECK
+  constraints exercised in an integration test (23514 on an inconsistent pair).
 - Locale parity: new `nav.*`, `orgRecord.*`, `partnerSettingsPage.modules.*`
   keys in all 8 locales (`keyUsage.test.ts`).
 
@@ -338,22 +376,22 @@ an automatic migration. The read path (`partners/me`) keeps its shape either way
 | W1 | `orgIdOverride`, route-scope kind, summary endpoint, record page shell with header + Overview, list affordances + status-pill rule, orgStore status fix, device breadcrumb retarget | — |
 | W2 | Contacts, Sites (shared `useSiteCrud`), Devices, Activity tabs; settings `#contacts` redirect | W1 |
 | W3 | Tickets and Contracts & Billing tabs (`lockedOrgId` on invoices/quotes pages), `#contracts` redirect, org links from ticket/invoice/quote/contract details | W1 |
-| W4 | Sidebar regroup + Organizations top-level; `psa_enabled` column, `/partners/me` exposure, Modules card, `requiresModule` gate, record tab gating | W1 (for the record gating), otherwise independent |
+| W4 | Sidebar regroup (Service Desk + Billing sections) + Organizations top-level → `/settings/organizations`; `service_management_mode` + connection columns and CHECKs, `/partners/me` exposure + PATCH validation, Modules card (Breeze / Off), `requiresModule` gate, `off` refusal in `ticketService` + AI tool + add-in + portal, record tab gating | W1 (for the record gating), otherwise independent |
 
 W2 and W3 are file-disjoint and can run in parallel. W4 can start after W1 in
 parallel with W2/W3.
 
-## Open questions for Todd
+## Open questions (resolved by Todd 2026-09-06)
 
-1. Section naming: **PSA** (your term) or **Service Management** (codex's
-   suggestion, avoids collision with PSA connectors)?
-2. Should the top-level **Organizations** item point at a new operational list
-   (`/organizations`, table with online/total devices, open tickets, alerts) or
-   at the existing settings master-detail for now? Recommendation: existing
-   page in W4, new list as a follow-up once the record has shipped and we know
+1. Module naming → **Service Management** (D7).
+2. Top-level **Organizations** item → the existing `/settings/organizations`
+   page in W4; an operational list (`/organizations` with online/total devices,
+   open tickets, alerts) is a follow-up once the record has shipped and we know
    which columns techs actually use.
-3. Default for the PSA toggle on **self-hosted** installs: same default-on, or
-   off? Recommendation: same default-on; the switch is one click.
+3. Default mode on **self-hosted** installs → `native`, same as hosted.
+4. (Raised during review) External PSA ticketing → D6: direct create + shadow
+   row + narrow status sync, not two-way sync; amend this spec to the three-mode
+   model now, build the external service desk as its own follow-on feature.
 
 ## Quorum record
 
@@ -378,15 +416,44 @@ parallel with W2/W3.
   when the module is off; keep Organizations and Reporting outside the module
   groups. Suggested exposing the flag to org users via bootstrap (deferred, see
   2.2) and an onboarding "RMM only" choice (follow-up).
+- **External PSA ticketing (D6), 2026-09-06**: Fable position, approved by Todd
+  without a codex round (the follow-on spec gets its own quorum). Inventory
+  that grounded it: real adapters for ConnectWise, Autotask, Jira, ServiceNow,
+  Freshservice, Zendesk in `apps/api/src/services/psa/*` with
+  `createTicket`/`updateTicket`/`getTicket`/`syncTickets` never called by any
+  route or job; `POST /psa/connections/:id/sync` returns 501; `psa_ticket_mappings`
+  has no writer; `tickets.external_ticket_id/url` dormant; `ticketSourceEnum`
+  lacks `psa`; company import maps PSA company → org in
+  `organization_external_links`; every native ticket-creating surface (alert
+  dialog, `manage_tickets` AI tool, portal, Outlook add-in, email-to-ticket)
+  already funnels through `ticketService`, which emits `ticket.created/updated`
+  on the event bus; no device "create ticket" button and no automation
+  `create_ticket` action exist today.
+- **Todd's decisions, 2026-09-06**: Service Management naming; Organizations
+  top-level → existing settings list first; `native` default on self-hosted;
+  amend to the three-mode model now.
 
 ## Follow-ups (not in these waves)
 
-- Onboarding "RMM only" preset that sets `psa_enabled=false` at partner signup.
+- **External service desk** (own spec + feature, after this one): wire the
+  existing `services/psa/*` adapters' `createTicket`/`updateTicket`/`getTicket`
+  into `ticketService` behind `service_management_mode = 'external'`; shadow
+  `tickets` rows (`source='psa'` enum value, activate the dormant
+  `external_ticket_id`/`external_ticket_url` columns, fold or retire the
+  never-written `psa_ticket_mappings`); outbound note append for alert updates
+  and AI findings; inbound status/closure via PSA webhook where supported, else
+  poll on the adapters' `syncTickets`; optional alert auto-resolve on close;
+  org → PSA company picker on org settings General (company import already
+  populates `organization_external_links`); per-connection board/type/priority
+  defaults in the existing `syncSettings` JSON; unlock the External option in
+  the Modules card. Inventory of what exists is in this spec's quorum record.
+- Onboarding "RMM only" preset that sets `service_management_mode='off'` at
+  partner signup.
 - Partner access to `suspended`/`churned` organizations' records (today the
   partner token's org set excludes them, so their data is unreachable in both
   the record and the settings page).
-- `psaEnabled` on an org-readable bootstrap endpoint if org users need the
-  module preference.
+- `serviceManagementMode` on an org-readable bootstrap endpoint if org users
+  need the module preference.
 - Operational `/organizations` list with online/total, open tickets, open
   alerts columns (see open question 2).
 - Redis-cached summary if the counts prove slow at fleet scale.


### PR DESCRIPTION
## Summary

Design spec and 4-wave implementation plan for the organization record page (`/organizations/<id>`) and the partner-level Service Management mode (`native` / `off` / `external`). Docs only, no code.

- Spec: `docs/superpowers/specs/web-ui/2026-09-06-organization-record-page-design.md` (approved by Todd 2026-09-06; quorum Fable + codex 5.6 + codex GPT-6).
- Plan: `docs/superpowers/plans/2026-09-06-organization-record-page.md` (tracking #5075; waves #5076 #5077 #5078 #5079).
- CLAUDE.md: codex delegation model is now `gpt-6-astra`.

Refs #5075

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WN4dGxN2LKZUYXXoWTbTPA