### PR TITLE
fix(billing): show a live QuickBooks sync state on the invoice card after Issue

### DIFF
--- a/apps/web/src/components/billing/AccountingSyncCard.test.tsx
+++ b/apps/web/src/components/billing/AccountingSyncCard.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import AccountingSyncCard from './AccountingSyncCard';
 import type { AccountingSyncSummary } from './invoiceTypes';
@@ -296,5 +296,140 @@ describe('AccountingSyncCard', () => {
       expect.objectContaining({ type: 'error', message: expect.stringContaining('deleted') }),
     ));
     expect(onChanged).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Live sync status after Issue (paper cut, prod v0.110.0). The auto-push
+ * worker lands a second or two AFTER the issue response, so the card used to
+ * sit on the stale "Not pushed yet" + "Push to QuickBooks" it was rendered
+ * with until the operator hand-reloaded — inviting a double submit or a
+ * "auto-push is broken" bug report. The card now watches the invoice's own
+ * draft -> issued transition (works no matter which copy of InvoiceActions
+ * owns the Issue button) and polls the invoice refetch until the mapping row
+ * reaches a terminal status, then falls back to the old view on timeout.
+ */
+describe('AccountingSyncCard live sync watch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const issued = (onChanged: () => void, initialSync: AccountingSyncSummary | null = null) => {
+    const view = render(
+      <AccountingSyncCard invoiceId="inv-1" sync={initialSync} invoiceStatus="draft" canPush onChanged={onChanged} />,
+    );
+    const show = (next: AccountingSyncSummary | null) =>
+      act(() => {
+        view.rerender(
+          <AccountingSyncCard invoiceId="inv-1" sync={next} invoiceStatus="sent" canPush onChanged={onChanged} />,
+        );
+      });
+    // The Issue action flips the invoice out of draft and the refetch brings
+    // back the freshly-claimed (still pending) mapping row.
+    show(sync());
+    return { ...view, show };
+  };
+
+  it('shows Syncing and hides the Push button once the invoice leaves draft', () => {
+    issued(vi.fn());
+
+    expect(screen.getByTestId('invoice-accounting-sync-status')).toHaveTextContent('Syncing');
+    expect(screen.queryByTestId('invoice-accounting-sync-push')).not.toBeInTheDocument();
+  });
+
+  it('polls the invoice every 3s while syncing and stops as soon as the row reads synced', () => {
+    const onChanged = vi.fn();
+    const { show } = issued(onChanged);
+
+    act(() => { vi.advanceTimersByTime(3000); });
+    expect(onChanged).toHaveBeenCalledTimes(1);
+
+    show(sync({ syncStatus: 'synced', remoteDocNumber: 'QB-1042', lastSyncedAt: '2026-09-01T10:00:00Z' }));
+    expect(screen.getByTestId('invoice-accounting-sync-status')).toHaveTextContent('Synced');
+    expect(screen.getByTestId('invoice-accounting-sync-docnumber')).toHaveTextContent('QB-1042');
+
+    act(() => { vi.advanceTimersByTime(30000); });
+    expect(onChanged).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops polling and surfaces the failure when the row reads error', () => {
+    const onChanged = vi.fn();
+    const { show } = issued(onChanged);
+
+    act(() => { vi.advanceTimersByTime(3000); });
+    expect(onChanged).toHaveBeenCalledTimes(1);
+
+    show(sync({ syncStatus: 'error', lastError: 'QuickBooks rejected the invoice sync (HTTP 500)' }));
+    expect(screen.getByTestId('invoice-accounting-sync-status')).toHaveTextContent('Sync failed');
+    expect(screen.getByTestId('invoice-accounting-sync-error')).toHaveTextContent('HTTP 500');
+    // Error is a retryable state, so the manual affordance comes back.
+    expect(screen.getByTestId('invoice-accounting-sync-push')).toBeInTheDocument();
+
+    act(() => { vi.advanceTimersByTime(30000); });
+    expect(onChanged).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to Not pushed yet with the Push button when the watch times out', () => {
+    const onChanged = vi.fn();
+    issued(onChanged);
+
+    act(() => { vi.advanceTimersByTime(60000); });
+
+    expect(screen.getByTestId('invoice-accounting-sync-status')).toHaveTextContent('Not pushed yet');
+    expect(screen.getByTestId('invoice-accounting-sync-push')).toBeInTheDocument();
+    const calls = onChanged.mock.calls.length;
+    // Discriminating: the fallback must be reached by the watch EXPIRING, not
+    // by a watch that never polled in the first place.
+    expect(calls).toBeGreaterThan(1);
+    act(() => { vi.advanceTimersByTime(30000); });
+    expect(onChanged).toHaveBeenCalledTimes(calls);
+  });
+
+  it('clears the poll timer on unmount', () => {
+    const onChanged = vi.fn();
+    const { unmount } = issued(onChanged);
+    // Control: the watch really did install a timer, so the post-unmount
+    // assertions below discriminate instead of passing on an empty queue.
+    expect(vi.getTimerCount()).toBe(1);
+
+    unmount();
+    act(() => { vi.advanceTimersByTime(30000); });
+    expect(onChanged).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('starts the watch after a manual push so the card does not offer a second submit', async () => {
+    const onChanged = vi.fn();
+    fetchMock.mockResolvedValue(json({ syncStatus: 'pending' }));
+
+    render(<AccountingSyncCard invoiceId="inv-1" sync={sync()} invoiceStatus="sent" canPush onChanged={onChanged} />);
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('invoice-accounting-sync-push'));
+    });
+
+    expect(screen.getByTestId('invoice-accounting-sync-status')).toHaveTextContent('Syncing');
+    expect(screen.queryByTestId('invoice-accounting-sync-push')).not.toBeInTheDocument();
+  });
+
+  it('gives up quickly when no QuickBooks mapping row ever appears', () => {
+    const onChanged = vi.fn();
+    const view = render(
+      <AccountingSyncCard invoiceId="inv-1" sync={null} invoiceStatus="draft" canPush onChanged={onChanged} />,
+    );
+    act(() => {
+      view.rerender(
+        <AccountingSyncCard invoiceId="inv-1" sync={null} invoiceStatus="sent" canPush onChanged={onChanged} />,
+      );
+    });
+
+    act(() => { vi.advanceTimersByTime(60000); });
+    // Two probes, then the watch gives up: a partner with no QuickBooks
+    // connection must not refetch the invoice for a full minute per issue.
+    expect(onChanged).toHaveBeenCalledTimes(2);
+    expect(vi.getTimerCount()).toBe(0);
   });
 });

--- a/apps/web/src/components/billing/AccountingSyncCard.test.tsx
+++ b/apps/web/src/components/billing/AccountingSyncCard.test.tsx
@@ -2,7 +2,7 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import AccountingSyncCard from './AccountingSyncCard';
-import type { AccountingSyncSummary } from './invoiceTypes';
+import type { AccountingSyncSummary, InvoiceStatus } from './invoiceTypes';
 import { fetchWithAuth } from '../../stores/auth';
 
 vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
@@ -322,10 +322,10 @@ describe('AccountingSyncCard live sync watch', () => {
     const view = render(
       <AccountingSyncCard invoiceId="inv-1" sync={initialSync} invoiceStatus="draft" canPush onChanged={onChanged} />,
     );
-    const show = (next: AccountingSyncSummary | null) =>
+    const show = (next: AccountingSyncSummary | null, status: InvoiceStatus = 'sent') =>
       act(() => {
         view.rerender(
-          <AccountingSyncCard invoiceId="inv-1" sync={next} invoiceStatus="sent" canPush onChanged={onChanged} />,
+          <AccountingSyncCard invoiceId="inv-1" sync={next} invoiceStatus={status} canPush onChanged={onChanged} />,
         );
       });
     // The Issue action flips the invoice out of draft and the refetch brings
@@ -373,11 +373,14 @@ describe('AccountingSyncCard live sync watch', () => {
     expect(onChanged).toHaveBeenCalledTimes(1);
   });
 
-  it('falls back to Not pushed yet with the Push button when the watch times out', () => {
+  // `advanceTimersByTimeAsync` (not the sync form) because each poll only
+  // releases the next one when its refetch promise settles — a microtask,
+  // which the synchronous form never flushes.
+  it('falls back to Not pushed yet with the Push button when the watch times out', async () => {
     const onChanged = vi.fn();
     issued(onChanged);
 
-    act(() => { vi.advanceTimersByTime(60000); });
+    await act(async () => { await vi.advanceTimersByTimeAsync(60000); });
 
     expect(screen.getByTestId('invoice-accounting-sync-status')).toHaveTextContent('Not pushed yet');
     expect(screen.getByTestId('invoice-accounting-sync-push')).toBeInTheDocument();
@@ -402,34 +405,240 @@ describe('AccountingSyncCard live sync watch', () => {
     expect(vi.getTimerCount()).toBe(0);
   });
 
-  it('starts the watch after a manual push so the card does not offer a second submit', async () => {
+  // The manual push route is SYNCHRONOUS — it awaits the QuickBooks call and
+  // returns the settled syncStatus (routes/accounting/index.ts) — so the
+  // refetch that follows already reads the outcome. Arming the watch here
+  // would strand a retry from an `error` row on a 60s spinner, because the
+  // row's status never changes again to end it.
+  it('does not arm the watch after a manual push — the route is synchronous', async () => {
     const onChanged = vi.fn();
-    fetchMock.mockResolvedValue(json({ syncStatus: 'pending' }));
+    fetchMock.mockResolvedValue(json({ syncStatus: 'synced', docNumber: 'QB-1042', taxVarianceCents: null }));
 
-    render(<AccountingSyncCard invoiceId="inv-1" sync={sync()} invoiceStatus="sent" canPush onChanged={onChanged} />);
+    render(
+      <AccountingSyncCard
+        invoiceId="inv-1"
+        sync={sync({ syncStatus: 'error', lastError: 'QuickBooks rejected the invoice sync (HTTP 500)' })}
+        invoiceStatus="sent"
+        canPush
+        onChanged={onChanged}
+      />,
+    );
     await act(async () => {
       fireEvent.click(screen.getByTestId('invoice-accounting-sync-push'));
     });
 
-    expect(screen.getByTestId('invoice-accounting-sync-status')).toHaveTextContent('Syncing');
-    expect(screen.queryByTestId('invoice-accounting-sync-push')).not.toBeInTheDocument();
+    expect(onChanged).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('invoice-accounting-sync-status')).not.toHaveTextContent('Syncing');
+    expect(vi.getTimerCount()).toBe(0);
   });
 
-  it('gives up quickly when no QuickBooks mapping row ever appears', () => {
+  it('stops the watch when the invoice is voided mid-window', () => {
     const onChanged = vi.fn();
+    const { show } = issued(onChanged);
+    expect(screen.getByTestId('invoice-accounting-sync-status')).toHaveTextContent('Syncing');
+
+    // The operator voids the invoice while the push is still in flight — a
+    // spinning "Syncing…" over the "nothing to push" hint is a contradiction.
+    show(sync(), 'void');
+    expect(screen.getByTestId('invoice-accounting-sync-status')).toHaveTextContent('Not pushed yet');
+    expect(screen.getByTestId('invoice-accounting-sync-voided-hint')).toBeInTheDocument();
+
+    const calls = onChanged.mock.calls.length;
+    act(() => { vi.advanceTimersByTime(30000); });
+    expect(onChanged).toHaveBeenCalledTimes(calls);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  // The watch must not give up early on a mapping row that has not appeared
+  // yet: under a worker backlog the row is claimed well after the issue
+  // response, and nothing else would restart the watch.
+  it('keeps polling the whole window while no mapping row has appeared yet', async () => {
+    const onChanged = vi.fn();
+    const view = render(
+      <AccountingSyncCard invoiceId="inv-1" sync={null} invoiceStatus="draft" canPush onChanged={onChanged} />,
+    );
+    const show = (next: AccountingSyncSummary | null) =>
+      act(() => {
+        view.rerender(
+          <AccountingSyncCard invoiceId="inv-1" sync={next} invoiceStatus="sent" canPush onChanged={onChanged} />,
+        );
+      });
+    show(null);
+
+    // 30s of a backlogged worker: no row yet, still polling.
+    await act(async () => { await vi.advanceTimersByTimeAsync(30000); });
+    expect(onChanged.mock.calls.length).toBeGreaterThanOrEqual(9);
+    // Nothing is rendered while there is no row to show...
+    expect(screen.queryByTestId('invoice-detail-accounting-sync')).not.toBeInTheDocument();
+
+    // ...and the late row is still picked up by the same live watch.
+    show(sync());
+    expect(screen.getByTestId('invoice-accounting-sync-status')).toHaveTextContent('Syncing');
+    show(sync({ syncStatus: 'synced' }));
+    expect(screen.getByTestId('invoice-accounting-sync-status')).toHaveTextContent('Synced');
+  });
+
+  it('skips a tick while the previous refetch is still in flight', async () => {
+    let resolveRefetch: (() => void) | undefined;
+    const onChanged = vi.fn(() => new Promise<void>((resolve) => { resolveRefetch = resolve; }));
     const view = render(
       <AccountingSyncCard invoiceId="inv-1" sync={null} invoiceStatus="draft" canPush onChanged={onChanged} />,
     );
     act(() => {
       view.rerender(
-        <AccountingSyncCard invoiceId="inv-1" sync={null} invoiceStatus="sent" canPush onChanged={onChanged} />,
+        <AccountingSyncCard invoiceId="inv-1" sync={sync()} invoiceStatus="sent" canPush onChanged={onChanged} />,
       );
     });
 
-    act(() => { vi.advanceTimersByTime(60000); });
-    // Two probes, then the watch gives up: a partner with no QuickBooks
-    // connection must not refetch the invoice for a full minute per issue.
+    await act(async () => { await vi.advanceTimersByTimeAsync(3000); });
+    expect(onChanged).toHaveBeenCalledTimes(1);
+
+    // Three more ticks pass while the first refetch is still pending — a slow
+    // response must not queue up refetches that can land out of order.
+    await act(async () => { await vi.advanceTimersByTimeAsync(9000); });
+    expect(onChanged).toHaveBeenCalledTimes(1);
+
+    // Once it settles the cadence resumes.
+    await act(async () => { resolveRefetch?.(); });
+    await act(async () => { await vi.advanceTimersByTimeAsync(3000); });
     expect(onChanged).toHaveBeenCalledTimes(2);
+  });
+});
+
+/**
+ * The primary prod flow never sees the draft -> issued transition at all:
+ * InvoiceWorkspace opens a draft on the Editor tab and only renders
+ * InvoiceDetail when the Detail tab is active, so a header Issue click flips
+ * the status, unmounts the editor and mounts the Detail tab (and this card)
+ * FRESH — already in the issued state. The card therefore also arms the watch
+ * on mount for an invoice that was touched seconds ago and has no settled
+ * mapping row.
+ */
+describe('AccountingSyncCard live sync watch on a fresh mount', () => {
+  const NOW = Date.parse('2026-09-06T12:00:00.000Z');
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const at = (msAgo: number) => new Date(NOW - msAgo).toISOString();
+
+  it('shows Syncing on mount when the invoice was just issued', () => {
+    render(
+      <AccountingSyncCard
+        invoiceId="inv-1"
+        sync={sync()}
+        invoiceStatus="sent"
+        invoiceTouchedAt={at(2000)}
+        canPush
+        onChanged={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('invoice-accounting-sync-status')).toHaveTextContent('Syncing');
+    expect(screen.queryByTestId('invoice-accounting-sync-push')).not.toBeInTheDocument();
+  });
+
+  it('polls on a fresh mount and settles on the pushed row', () => {
+    const onChanged = vi.fn();
+    const view = render(
+      <AccountingSyncCard
+        invoiceId="inv-1"
+        sync={sync()}
+        invoiceStatus="sent"
+        invoiceTouchedAt={at(2000)}
+        canPush
+        onChanged={onChanged}
+      />,
+    );
+
+    act(() => { vi.advanceTimersByTime(3000); });
+    expect(onChanged).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      view.rerender(
+        <AccountingSyncCard
+          invoiceId="inv-1"
+          sync={sync({ syncStatus: 'synced', remoteDocNumber: 'QB-1042' })}
+          invoiceStatus="sent"
+          invoiceTouchedAt={at(2000)}
+          canPush
+          onChanged={onChanged}
+        />,
+      );
+    });
+    expect(screen.getByTestId('invoice-accounting-sync-status')).toHaveTextContent('Synced');
+    act(() => { vi.advanceTimersByTime(30000); });
+    expect(onChanged).toHaveBeenCalledTimes(1);
+  });
+
+  // Control for the case above: an old invoice with a pending row is a
+  // settled fact (manual push mode, or a push that never happened), not a
+  // push in flight — it must mount straight to the actionable view.
+  it('mounts straight to Not pushed yet for an invoice issued an hour ago', () => {
+    const onChanged = vi.fn();
+    render(
+      <AccountingSyncCard
+        invoiceId="inv-1"
+        sync={sync()}
+        invoiceStatus="sent"
+        invoiceTouchedAt={at(3600000)}
+        canPush
+        onChanged={onChanged}
+      />,
+    );
+
+    expect(screen.getByTestId('invoice-accounting-sync-status')).toHaveTextContent('Not pushed yet');
+    expect(screen.getByTestId('invoice-accounting-sync-push')).toBeInTheDocument();
+    act(() => { vi.advanceTimersByTime(60000); });
+    expect(onChanged).not.toHaveBeenCalled();
+  });
+
+  it('does not arm the mount watch for a settled row or a draft', () => {
+    const { unmount } = render(
+      <AccountingSyncCard
+        invoiceId="inv-1"
+        sync={sync({ syncStatus: 'synced' })}
+        invoiceStatus="sent"
+        invoiceTouchedAt={at(2000)}
+        canPush
+        onChanged={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('invoice-accounting-sync-status')).toHaveTextContent('Synced');
     expect(vi.getTimerCount()).toBe(0);
+    unmount();
+
+    render(
+      <AccountingSyncCard
+        invoiceId="inv-1"
+        sync={sync()}
+        invoiceStatus="draft"
+        invoiceTouchedAt={at(2000)}
+        canPush
+        onChanged={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('invoice-accounting-sync-status')).toHaveTextContent('Not pushed yet');
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  // Deploy skew: `updatedAt` is not declared on the web's InvoiceSummary today,
+  // so an older payload can omit it entirely. No timestamp = no mount watch,
+  // never a watch armed on a guess.
+  it('does not arm the mount watch without a timestamp', () => {
+    const onChanged = vi.fn();
+    render(
+      <AccountingSyncCard invoiceId="inv-1" sync={sync()} invoiceStatus="sent" canPush onChanged={onChanged} />,
+    );
+
+    expect(screen.getByTestId('invoice-accounting-sync-status')).toHaveTextContent('Not pushed yet');
+    act(() => { vi.advanceTimersByTime(60000); });
+    expect(onChanged).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/billing/AccountingSyncCard.tsx
+++ b/apps/web/src/components/billing/AccountingSyncCard.tsx
@@ -27,10 +27,30 @@ interface Props {
    * hide the push affordance on a voided invoice.
    */
   invoiceStatus: InvoiceStatus;
+  /**
+   * When the invoice row was last written, used ONLY to decide whether a fresh
+   * mount should arm the live sync watch (see `shouldWatchOnMount`).
+   *
+   * The detail payload carries no issue timestamp: `issueDate` is a DATE (day
+   * precision) and `sentAt` is null for a plain Issue that sent no email, so
+   * the caller passes the invoice row's `updatedAt`, which the issue write
+   * bumps. It is a proxy, deliberately: any other write in the last 90s (an
+   * inline due-date edit, say) also reads as "recent", which at worst costs a
+   * pending-row invoice one poll window and never shows a wrong status.
+   *
+   * Optional because `updatedAt` is not declared on the web's InvoiceSummary
+   * today — an older payload can omit it, and a missing timestamp means no
+   * mount watch rather than a watch armed on a guess.
+   */
+  invoiceTouchedAt?: string | null;
   /** `can('invoices','write')` — the same permission the push route requires. */
   canPush: boolean;
-  /** Refetch the invoice so the card re-renders off the persisted mapping row. */
-  onChanged: () => void;
+  /**
+   * Refetch the invoice so the card re-renders off the persisted mapping row.
+   * May return a promise (InvoiceWorkspace's `reload` does); the watch awaits
+   * it so a slow refetch never has a second one stacked behind it.
+   */
+  onChanged: () => void | Promise<void>;
 }
 
 /** Pushing is a remedy only for a row that is not (successfully) in QuickBooks
@@ -58,21 +78,51 @@ function isSettled(status: AccountingSyncSummary['syncStatus']): boolean {
  *  than spin forever. */
 const POLL_INTERVAL_MS = 3000;
 const POLL_TIMEOUT_MS = 60000;
-/** How many probes to spend waiting for a mapping row to appear at all. A
- *  partner with no QuickBooks connection has no row and never will, so the
- *  watch gives up after two probes instead of refetching the invoice twenty
- *  times for every invoice they issue. */
-const MAX_PROBES_WITHOUT_ROW = 2;
+/** How recently the invoice must have been written for a FRESH MOUNT to arm
+ *  the watch. Wider than the poll window so a mount a few seconds after the
+ *  issue write still catches the tail of the push; anything older is a settled
+ *  fact (manual push mode, or a push that never happened), not a push in
+ *  flight, and must render the actionable view immediately. */
+const MOUNT_WATCH_MAX_AGE_MS = 90000;
 
-export default function AccountingSyncCard({ invoiceId, sync, invoiceStatus, canPush, onChanged }: Props) {
+/** Whether a fresh mount should arm the watch. The prod flow needs this and
+ *  the draft -> issued transition does NOT cover it: InvoiceWorkspace opens a
+ *  draft on the Editor tab and only renders InvoiceDetail on the Detail tab,
+ *  so a header Issue click flips the status, unmounts the editor and mounts
+ *  this card FRESH — already issued, with no transition to observe. It also
+ *  re-arms correctly after a tab switch (which likewise unmounts the card),
+ *  so no watch state has to move up into InvoiceWorkspace. */
+function shouldWatchOnMount(
+  invoiceStatus: InvoiceStatus,
+  sync: AccountingSyncSummary | null | undefined,
+  touchedAt: string | null | undefined,
+): boolean {
+  if (invoiceStatus === 'draft' || invoiceStatus === 'void') return false;
+  if (sync && sync.syncStatus !== 'pending') return false;
+  if (!touchedAt) return false;
+  const touched = Date.parse(touchedAt);
+  if (Number.isNaN(touched)) return false;
+  const age = Date.now() - touched;
+  // A clock-skewed future timestamp reads as age < 0; treat it as recent
+  // rather than as ancient — the failure mode is a spinner that times out,
+  // not a stale button that invites a double push.
+  return age < MOUNT_WATCH_MAX_AGE_MS;
+}
+
+export default function AccountingSyncCard({ invoiceId, sync, invoiceStatus, invoiceTouchedAt, canPush, onChanged }: Props) {
   const { t } = useTranslation('billing');
   const [pushing, setPushing] = useState(false);
   // The push is in flight somewhere server-side; poll the invoice until the
-  // mapping row settles. Started by the draft -> issued transition (auto push
-  // mode) and by a successful manual push.
-  const [watching, setWatching] = useState(false);
-  const deadlineRef = useRef(0);
-  const probesRef = useRef(0);
+  // mapping row settles. Armed on a fresh mount of a just-issued invoice and
+  // on the draft -> issued transition. NOT armed by the manual push button:
+  // that route awaits the QuickBooks call and returns the settled status, so
+  // the refetch behind it already reads the outcome.
+  const [watching, setWatching] = useState(() => shouldWatchOnMount(invoiceStatus, sync, invoiceTouchedAt));
+  const deadlineRef = useRef(Date.now() + POLL_TIMEOUT_MS);
+  // True from the moment a poll's refetch is dispatched until it resolves, so
+  // a slow response cannot have a second refetch stacked behind it and land
+  // out of order.
+  const refetchInFlightRef = useRef(false);
   // Keep the latest `onChanged` reachable from the interval without making the
   // interval's identity depend on it — the parent re-creates the callback on
   // every render, which would otherwise tear down and restart the timer (and
@@ -82,14 +132,13 @@ export default function AccountingSyncCard({ invoiceId, sync, invoiceStatus, can
 
   const startWatch = useCallback(() => {
     deadlineRef.current = Date.now() + POLL_TIMEOUT_MS;
-    probesRef.current = 0;
     setWatching(true);
   }, []);
 
-  // Watch the invoice's own lifecycle rather than being told about the Issue
-  // click: the primary actions live in two places (the detail rail and the
-  // workspace header), and both funnel through the same detail refetch, so the
-  // draft -> non-draft prop transition is the one signal that covers both.
+  // Second trigger: the invoice's own lifecycle, for the case where the card
+  // is already mounted when Issue lands (the Detail tab's own rail copy of
+  // InvoiceActions). Keyed off the status prop rather than an Issue callback
+  // so it covers both copies of the actions without new plumbing.
   const prevStatusRef = useRef(invoiceStatus);
   useEffect(() => {
     const previous = prevStatusRef.current;
@@ -97,15 +146,13 @@ export default function AccountingSyncCard({ invoiceId, sync, invoiceStatus, can
     if (previous === 'draft' && invoiceStatus !== 'draft' && invoiceStatus !== 'void') startWatch();
   }, [invoiceStatus, startWatch]);
 
-  // Stop as soon as the refetched row reports a settled outcome.
-  const settled = !!sync && isSettled(sync.syncStatus);
+  // Stop on a settled row, and on a void: a spinning "Syncing…" over the
+  // "nothing to push" hint is a contradiction, and the void already tells the
+  // operator everything the watch was going to.
+  const done = invoiceStatus === 'void' || (!!sync && isSettled(sync.syncStatus));
   useEffect(() => {
-    if (settled) setWatching(false);
-  }, [settled]);
-
-  // Read inside the interval (which must not restart when `sync` changes).
-  const syncRef = useRef(sync);
-  syncRef.current = sync;
+    if (done) setWatching(false);
+  }, [done]);
 
   useEffect(() => {
     if (!watching) return;
@@ -113,11 +160,10 @@ export default function AccountingSyncCard({ invoiceId, sync, invoiceStatus, can
       // Clear the interval imperatively as well as flipping state: the state
       // update only tears the timer down on the NEXT commit, and a stop
       // decided from inside the callback must not get one more tick in.
-      const stop = () => { clearInterval(timer); setWatching(false); };
-      probesRef.current += 1;
-      if (Date.now() >= deadlineRef.current) { stop(); return; }
-      onChangedRef.current();
-      if (!syncRef.current && probesRef.current >= MAX_PROBES_WITHOUT_ROW) stop();
+      if (Date.now() >= deadlineRef.current) { clearInterval(timer); setWatching(false); return; }
+      if (refetchInFlightRef.current) return;
+      refetchInFlightRef.current = true;
+      void Promise.resolve(onChangedRef.current()).finally(() => { refetchInFlightRef.current = false; });
     }, POLL_INTERVAL_MS);
     return () => clearInterval(timer);
   }, [watching]);
@@ -171,10 +217,11 @@ export default function AccountingSyncCard({ invoiceId, sync, invoiceStatus, can
         successMessage: t('invoiceDetail.accountingSync.pushed'),
         onUnauthorized: UNAUTHORIZED,
       });
-      // The route only enqueues the job, so the fresh refetch will still read
-      // `pending` — start the same watch the auto-push path uses rather than
-      // dropping the operator back onto a button they just pressed.
-      startWatch();
+      // No watch here: unlike the auto-push path, this route AWAITS the
+      // QuickBooks call and returns the settled syncStatus, so the refetch
+      // already reads the outcome. Arming the watch would strand a retry from
+      // an `error` row on a 60s spinner — the row's status would never change
+      // again to end it.
       onChanged();
     } catch (err) {
       // A typed 409 (currency_mismatch, customer_not_mapped, …) has already

--- a/apps/web/src/components/billing/AccountingSyncCard.tsx
+++ b/apps/web/src/components/billing/AccountingSyncCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { AlertTriangle, CheckCircle2, Clock, Loader2 } from 'lucide-react';
 import '../../lib/i18n';
@@ -43,10 +43,88 @@ function isPushable(status: AccountingSyncSummary['syncStatus']): boolean {
   return status === 'pending' || status === 'error';
 }
 
+/** The QuickBooks push is asynchronous: `/invoices/:id/issue` (auto push mode)
+ *  and `/accounting/quickbooks/invoices/:id/push` both return as soon as the
+ *  job is enqueued, and the worker lands a beat later. Anything below is a
+ *  settled outcome — the watch stops the moment the refetched mapping row
+ *  reads one of them. */
+function isSettled(status: AccountingSyncSummary['syncStatus']): boolean {
+  return status === 'synced' || status === 'synced_with_tax_variance' || status === 'error';
+}
+
+/** Poll cadence and ceiling for the post-issue / post-push watch. The ceiling
+ *  matters more than the cadence: the watch is a courtesy, and on timeout the
+ *  card must fall back to the honest "Not pushed yet" + manual button rather
+ *  than spin forever. */
+const POLL_INTERVAL_MS = 3000;
+const POLL_TIMEOUT_MS = 60000;
+/** How many probes to spend waiting for a mapping row to appear at all. A
+ *  partner with no QuickBooks connection has no row and never will, so the
+ *  watch gives up after two probes instead of refetching the invoice twenty
+ *  times for every invoice they issue. */
+const MAX_PROBES_WITHOUT_ROW = 2;
+
 export default function AccountingSyncCard({ invoiceId, sync, invoiceStatus, canPush, onChanged }: Props) {
   const { t } = useTranslation('billing');
   const [pushing, setPushing] = useState(false);
+  // The push is in flight somewhere server-side; poll the invoice until the
+  // mapping row settles. Started by the draft -> issued transition (auto push
+  // mode) and by a successful manual push.
+  const [watching, setWatching] = useState(false);
+  const deadlineRef = useRef(0);
+  const probesRef = useRef(0);
+  // Keep the latest `onChanged` reachable from the interval without making the
+  // interval's identity depend on it — the parent re-creates the callback on
+  // every render, which would otherwise tear down and restart the timer (and
+  // reset the cadence) on each poll's own refetch.
+  const onChangedRef = useRef(onChanged);
+  useEffect(() => { onChangedRef.current = onChanged; });
 
+  const startWatch = useCallback(() => {
+    deadlineRef.current = Date.now() + POLL_TIMEOUT_MS;
+    probesRef.current = 0;
+    setWatching(true);
+  }, []);
+
+  // Watch the invoice's own lifecycle rather than being told about the Issue
+  // click: the primary actions live in two places (the detail rail and the
+  // workspace header), and both funnel through the same detail refetch, so the
+  // draft -> non-draft prop transition is the one signal that covers both.
+  const prevStatusRef = useRef(invoiceStatus);
+  useEffect(() => {
+    const previous = prevStatusRef.current;
+    prevStatusRef.current = invoiceStatus;
+    if (previous === 'draft' && invoiceStatus !== 'draft' && invoiceStatus !== 'void') startWatch();
+  }, [invoiceStatus, startWatch]);
+
+  // Stop as soon as the refetched row reports a settled outcome.
+  const settled = !!sync && isSettled(sync.syncStatus);
+  useEffect(() => {
+    if (settled) setWatching(false);
+  }, [settled]);
+
+  // Read inside the interval (which must not restart when `sync` changes).
+  const syncRef = useRef(sync);
+  syncRef.current = sync;
+
+  useEffect(() => {
+    if (!watching) return;
+    const timer = setInterval(() => {
+      // Clear the interval imperatively as well as flipping state: the state
+      // update only tears the timer down on the NEXT commit, and a stop
+      // decided from inside the callback must not get one more tick in.
+      const stop = () => { clearInterval(timer); setWatching(false); };
+      probesRef.current += 1;
+      if (Date.now() >= deadlineRef.current) { stop(); return; }
+      onChangedRef.current();
+      if (!syncRef.current && probesRef.current >= MAX_PROBES_WITHOUT_ROW) stop();
+    }, POLL_INTERVAL_MS);
+    return () => clearInterval(timer);
+  }, [watching]);
+
+  // A watch with no mapping row to show yet renders nothing — a partner with
+  // no QuickBooks connection must not see a QuickBooks card appear just
+  // because they issued an invoice.
   if (!sync) return null;
 
   const { syncStatus } = sync;
@@ -59,20 +137,25 @@ export default function AccountingSyncCard({ invoiceId, sync, invoiceStatus, can
   // the mapping row's own status doesn't change when the invoice is voided.
   const voided = invoiceStatus === 'void';
   const statusPushable = isPushable(syncStatus);
-  const pushable = canPush && statusPushable && !voided && !remoteDeleted;
-  const statusLabel = t(
-    /* i18n-dynamic */ `invoiceDetail.accountingSync.status.${syncStatus}`,
-  );
-  const pillTone =
-    syncStatus === 'synced'
+  // While the watch is live the push is already in flight server-side: the
+  // affordance has to go, or the operator double-submits the very push they
+  // are waiting on.
+  const pushable = canPush && statusPushable && !voided && !remoteDeleted && !watching;
+  const statusLabel = watching
+    ? t('invoiceDetail.accountingSync.syncing')
+    : t(/* i18n-dynamic */ `invoiceDetail.accountingSync.status.${syncStatus}`);
+  const pillTone = watching
+    ? 'border-sky-200 bg-sky-50 text-sky-700'
+    : syncStatus === 'synced'
       ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
       : syncStatus === 'error'
         ? 'border-red-200 bg-red-50 text-red-700'
         : syncStatus === 'synced_with_tax_variance'
           ? 'border-amber-200 bg-amber-50 text-amber-800'
           : 'border-slate-200 bg-slate-50 text-slate-600';
-  const PillIcon =
-    syncStatus === 'synced'
+  const PillIcon = watching
+    ? Loader2
+    : syncStatus === 'synced'
       ? CheckCircle2
       : syncStatus === 'pending'
         ? Clock
@@ -88,6 +171,10 @@ export default function AccountingSyncCard({ invoiceId, sync, invoiceStatus, can
         successMessage: t('invoiceDetail.accountingSync.pushed'),
         onUnauthorized: UNAUTHORIZED,
       });
+      // The route only enqueues the job, so the fresh refetch will still read
+      // `pending` — start the same watch the auto-push path uses rather than
+      // dropping the operator back onto a button they just pressed.
+      startWatch();
       onChanged();
     } catch (err) {
       // A typed 409 (currency_mismatch, customer_not_mapped, …) has already
@@ -109,7 +196,7 @@ export default function AccountingSyncCard({ invoiceId, sync, invoiceStatus, can
           data-testid="invoice-accounting-sync-status"
           className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs ${pillTone}`}
         >
-          <PillIcon className="h-3.5 w-3.5" /> {statusLabel}
+          <PillIcon className={`h-3.5 w-3.5 ${watching ? 'animate-spin' : ''}`} /> {statusLabel}
         </span>
 
         {syncStatus === 'synced_with_tax_variance' && (

--- a/apps/web/src/components/billing/InvoiceDetail.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.tsx
@@ -36,7 +36,9 @@ const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
 
 interface Props {
   detail: InvoiceDetailData;
-  onChanged: () => void;
+  /** Refetch the invoice. May return a promise — AccountingSyncCard's sync
+   *  watch awaits it so its polls cannot overlap. */
+  onChanged: () => void | Promise<void>;
   /** The workspace header owns the primary actions (Issue / Issue & Send /
    *  Download PDF / Delete draft) — suppress the rail copy so the two don't
    *  render at once (mirrors QuoteDetail.actionsInHeader). */
@@ -563,6 +565,7 @@ export default function InvoiceDetail({ detail, onChanged, actionsInHeader = fal
             invoiceId={invoice.id}
             sync={detail.accountingSync}
             invoiceStatus={invoice.status}
+            invoiceTouchedAt={invoice.updatedAt}
             canPush={can('invoices', 'write')}
             onChanged={onChanged}
           />

--- a/apps/web/src/components/billing/InvoiceWorkspace.tsx
+++ b/apps/web/src/components/billing/InvoiceWorkspace.tsx
@@ -239,8 +239,11 @@ export default function InvoiceWorkspace({ id }: Props) {
       {activeTab === 'preview' && (
         <InvoiceDocumentPreview detail={detail} />
       )}
+      {/* `reload` is passed through unwrapped (not `() => void reload()`) so
+          the accounting-sync watch can await the refetch it triggers and never
+          overlap two polls — see AccountingSyncCard. */}
       {activeTab === 'detail' && (
-        <InvoiceDetail detail={detail} onChanged={() => void reload()} actionsInHeader />
+        <InvoiceDetail detail={detail} onChanged={reload} actionsInHeader />
       )}
     </DocumentWorkspace>
   );

--- a/apps/web/src/components/billing/invoiceTypes.ts
+++ b/apps/web/src/components/billing/invoiceTypes.ts
@@ -62,6 +62,15 @@ export interface InvoiceSummary {
   termsAndConditions: string | null;
   sellerSnapshot: SellerSnapshot | null;
   createdAt: string;
+  /**
+   * Last write to the invoice row. Always present on the detail payload (the
+   * API returns the whole row), but optional here because it was undeclared
+   * until now and list projections may omit it. Used by AccountingSyncCard as
+   * the only sub-minute "was this just issued?" signal the payload has —
+   * `issueDate` is a DATE and `sentAt` is null for an Issue that sent no
+   * email.
+   */
+  updatedAt?: string | null;
   /** null identifies an invoice created before device evidence was recorded. */
   evidenceVersion?: number | null;
 }

--- a/apps/web/src/locales/de-DE/billing.json
+++ b/apps/web/src/locales/de-DE/billing.json
@@ -1838,6 +1838,7 @@
       "taxVarianceHint": "QuickBooks hat eine abweichende Steuersumme berechnet. Vergleichen Sie beide Datensätze, bevor Sie die Periode abschließen.",
       "docNumber": "QuickBooks-Beleg {{docNumber}}",
       "lastSynced": "Zuletzt synchronisiert am {{when}}",
+      "syncing": "Wird übertragen…",
       "push": "An QuickBooks übertragen",
       "pushed": "Rechnung an QuickBooks übertragen.",
       "pushFailed": "Die Rechnung konnte nicht an QuickBooks übertragen werden.",

--- a/apps/web/src/locales/en/billing.json
+++ b/apps/web/src/locales/en/billing.json
@@ -1838,6 +1838,7 @@
       "taxVarianceHint": "QuickBooks calculated a different tax total. Compare both records before closing the period.",
       "docNumber": "QuickBooks document {{docNumber}}",
       "lastSynced": "Last synced {{when}}",
+      "syncing": "Syncing…",
       "push": "Push to QuickBooks",
       "pushed": "Invoice pushed to QuickBooks.",
       "pushFailed": "Failed to push the invoice to QuickBooks.",

--- a/apps/web/src/locales/es-419/billing.json
+++ b/apps/web/src/locales/es-419/billing.json
@@ -1838,6 +1838,7 @@
       "taxVarianceHint": "QuickBooks calculó un total de impuestos diferente. Compara ambos registros antes de cerrar el período.",
       "docNumber": "Documento de QuickBooks {{docNumber}}",
       "lastSynced": "Última sincronización: {{when}}",
+      "syncing": "Sincronizando…",
       "push": "Enviar a QuickBooks",
       "pushed": "Factura enviada a QuickBooks.",
       "pushFailed": "No se pudo enviar la factura a QuickBooks.",

--- a/apps/web/src/locales/fr-CA/billing.json
+++ b/apps/web/src/locales/fr-CA/billing.json
@@ -1838,6 +1838,7 @@
       "taxVarianceHint": "QuickBooks a calculé un total de taxes différent. Comparez les deux enregistrements avant de clôturer la période.",
       "docNumber": "Document QuickBooks nº {{docNumber}}",
       "lastSynced": "Dernière synchronisation : {{when}}",
+      "syncing": "Synchronisation…",
       "push": "Envoyer vers QuickBooks",
       "pushed": "Facture envoyée vers QuickBooks.",
       "pushFailed": "Échec de l'envoi de la facture vers QuickBooks.",

--- a/apps/web/src/locales/fr-FR/billing.json
+++ b/apps/web/src/locales/fr-FR/billing.json
@@ -1838,6 +1838,7 @@
       "taxVarianceHint": "QuickBooks a calculé un total de taxes différent. Comparez les deux enregistrements avant de clôturer la période.",
       "docNumber": "Document QuickBooks nº {{docNumber}}",
       "lastSynced": "Dernière synchronisation : {{when}}",
+      "syncing": "Synchronisation…",
       "push": "Envoyer vers QuickBooks",
       "pushed": "Facture envoyée vers QuickBooks.",
       "pushFailed": "Échec de l'envoi de la facture vers QuickBooks.",

--- a/apps/web/src/locales/it-IT/billing.json
+++ b/apps/web/src/locales/it-IT/billing.json
@@ -1838,6 +1838,7 @@
       "taxVarianceHint": "QuickBooks ha calcolato un totale imposte diverso. Confronta entrambi i record prima di chiudere il periodo.",
       "docNumber": "Documento QuickBooks {{docNumber}}",
       "lastSynced": "Ultima sincronizzazione: {{when}}",
+      "syncing": "Sincronizzazione…",
       "push": "Invia a QuickBooks",
       "pushed": "Fattura inviata a QuickBooks.",
       "pushFailed": "Impossibile inviare la fattura a QuickBooks.",

--- a/apps/web/src/locales/pt-BR/billing.json
+++ b/apps/web/src/locales/pt-BR/billing.json
@@ -1838,6 +1838,7 @@
       "taxVarianceHint": "O QuickBooks calculou um total de impostos diferente. Compare os dois registros antes de fechar o período.",
       "docNumber": "Documento do QuickBooks {{docNumber}}",
       "lastSynced": "Última sincronização em {{when}}",
+      "syncing": "Sincronizando…",
       "push": "Enviar ao QuickBooks",
       "pushed": "Fatura enviada ao QuickBooks.",
       "pushFailed": "Falha ao enviar a fatura ao QuickBooks.",

--- a/apps/web/src/locales/tr-TR/billing.json
+++ b/apps/web/src/locales/tr-TR/billing.json
@@ -1838,6 +1838,7 @@
       "taxVarianceHint": "QuickBooks farklı bir vergi toplamı hesapladı. Dönemi kapatmadan önce iki kaydı karşılaştırın.",
       "docNumber": "QuickBooks belgesi {{docNumber}}",
       "lastSynced": "Son eşitleme: {{when}}",
+      "syncing": "Eşitleniyor…",
       "push": "QuickBooks'a gönder",
       "pushed": "Fatura QuickBooks'a gönderildi.",
       "pushFailed": "Fatura QuickBooks'a gönderilemedi.",


### PR DESCRIPTION
## Repro (prod v0.110.0)

1. Partner has QuickBooks connected with invoice push mode **Automatic on issue**.
2. Open a draft invoice at `/billing/invoices/:id` and press **Issue**.
3. The **QuickBooks sync** card reads **"Not pushed yet"** with a live **"Push to QuickBooks"** button — even though the worker pushes the invoice ~2s later.
4. Only a manual page reload flips it to **Synced / Last synced …**.

The card renders off the invoice-detail payload that came back with the issue action, and `/invoices/:id/issue` only *enqueues* the push job. An operator who trusts the card presses "Push to QuickBooks" and double-submits, or concludes auto-push is broken.

## Behaviour shipped (web only)

`AccountingSyncCard` runs a short live watch, armed by two triggers:

- **On a fresh mount** of an invoice that is non-draft/non-void, whose mapping row is absent or `pending`, and which was written in the last 90s. **This is the trigger that covers the prod flow**: `InvoiceWorkspace` opens a draft on the Editor tab and renders `InvoiceDetail` only when the Detail tab is active, so a header **Issue** flips the status, unmounts the editor and mounts the card *fresh* — already issued, with no transition to observe. It also re-arms correctly after a tab switch (which likewise unmounts the card), so no watch state has to move up into `InvoiceWorkspace`.
- **On the `draft -> issued` prop transition**, for the case where the card is already mounted when Issue lands (the Detail tab's own rail copy of `InvoiceActions`).

While watching: a `Syncing…` pill (spinner) and the "Push to QuickBooks" button is hidden, so the in-flight push cannot be double-submitted. The watch polls the existing invoice refetch every 3s and stops on `synced` / `synced_with_tax_variance` / `error`, on a **void** (a spinning "Syncing…" over the "nothing to push" hint is a contradiction), or at a 60s timeout — which falls back to the current honest "Not pushed yet" + button. Timers are cleared on unmount and imperatively at the stop decision.

**No API routes were added** — there is no lighter status endpoint under `routes/invoices` or `routes/accounting`, so the poll reuses the invoice GET the card already drives. A tick is **skipped while the previous refetch is still pending**, so a slow response cannot have another stacked behind it and land out of order; `InvoiceWorkspace` now passes `reload` through unwrapped (was `() => void reload()`) so the promise is observable, and `onChanged` is typed `() => void | Promise<void>` on both `InvoiceDetail` and the card.

**No watch after a manual push.** `POST /accounting/:provider/invoices/:invoiceId/push` is synchronous — it awaits `pushInvoiceToAccounting` and returns the settled `syncStatus` — so the refetch behind it already reads the outcome. Arming the watch there stranded a retry from an `error` row on a 60s spinner that nothing could end.

### Timestamp field

The detail payload carries **no issue timestamp**: `issueDate` is a DATE (day precision) and `sentAt` is null for a plain Issue that sent no email. The mount trigger therefore uses the invoice row's **`updatedAt`**, which the API returns (it selects the whole row) but the web's `InvoiceSummary` had never declared — now added as optional, so an older payload that omits it simply means *no mount watch*, never a watch armed on a guess. It is a proxy, deliberately: any other write in the last 90s (an inline due-date edit, say) also reads as "recent", which at worst costs a pending-row invoice one poll window and never shows a wrong status.

New i18n key `invoiceDetail.accountingSync.syncing` added to all 8 locales.

## Test evidence

**Round 1** — the 7 original cases failed 5/7 against the unchanged component (the timeout and unmount cases passed vacuously, so both gained a discriminating control: the timeout case asserts polling actually happened, the unmount case asserts a timer existed before unmount).

**Round 2 (this review)** — 6 new/changed cases red first against the round-1 component:

```
× does not arm the watch after a manual push — the route is synchronous   (item 5)
× stops the watch when the invoice is voided mid-window                   (item 6)
× keeps polling the whole window while no mapping row has appeared yet    (item 2)
× skips a tick while the previous refetch is still in flight              (item 3)
× shows Syncing on mount when the invoice was just issued                 (item 1)
× polls on a fresh mount and settles on the pushed row                    (item 1)
Tests  6 failed | 24 passed (30)
```

Controls that passed at red and pin the boundaries: an invoice issued an hour ago mounts straight to "Not pushed yet" and never polls; a settled row and a draft arm no mount watch; a payload with no timestamp arms no mount watch.

Green after the fix:

- `npx vitest run src/components/billing/AccountingSyncCard.test.tsx` → **30 passed**
- `npx vitest run src/components/billing` → **99 files / 926 tests passed**
- `npx vitest run src/lib/i18n` (locale parity / extraction quality) → **8 files / 146 tests passed**
- `npx eslint` on all 5 changed source files → clean
- `npx tsc --noEmit -p apps/web/tsconfig.json` → clean

Note on the count-based tests: they use `vi.advanceTimersByTimeAsync`, because each poll only releases the next one when its refetch promise settles — a microtask the synchronous form never flushes.

## Not covered

- Push mode (`automatic` vs `manual`) is not exposed on the invoice detail payload or anywhere the card can see, so the card polls either way; on a manual-mode partner the watch times out at 60s and lands back on "Not pushed yet". Same for a partner with no QuickBooks connection at all: the watch spends its window and the card renders nothing throughout, as today.
- No API change, so no tenancy/cascade/RLS surface is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012aUFjmAQBPfhv1G5wm9Kri
