### PR TITLE
test(web): org record page tab assertions query role=tab after OverflowTabs became a tablist

### DIFF
--- a/apps/web/src/components/organizations/record/OrganizationRecordPage.test.tsx
+++ b/apps/web/src/components/organizations/record/OrganizationRecordPage.test.tsx
@@ -241,8 +241,10 @@ describe('OrganizationRecordPage — permission gating', () => {
     });
     render(<OrganizationRecordPage orgId={RECORD_ORG} />);
     await waitFor(() => expect(screen.getByTestId('org-record-header')).toBeTruthy());
-    expect(screen.queryByRole('button', { name: 'Devices' })).toBeNull();
-    expect(screen.getByRole('button', { name: 'Overview' })).toBeTruthy();
+    // OverflowTabs renders each tab as role="tab" inside a tablist (#5090),
+    // so the tab's accessible role is "tab", not "button".
+    expect(screen.queryByRole('tab', { name: 'Devices' })).toBeNull();
+    expect(screen.getByRole('tab', { name: 'Overview' })).toBeTruthy();
   });
 
   it('falls back to Overview when the hash names a tab this user cannot see', async () => {


### PR DESCRIPTION
## Summary

Main's **Test Web** has been red since 19d7d37b3: #5086 (org record page shell, W01 of #5075) and #5090 (network device detail + unified device list) were each green on their own merge commit and red together. #5090 made `OverflowTabs` render every tab as `role="tab"` inside a `role="tablist"`; #5086's permission-gating test still queried the Overview / Devices tabs by `role="button"`.

Assertion-only change in `OrganizationRecordPage.test.tsx` (two lines). Verified locally on origin/main: 15/15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CuEEGssvpeM9HE7sQqByGE