### PR TITLE
test(integration): fix shard-2 red from #5099's config-policy owner guard

### DIFF
--- a/apps/api/src/__tests__/integration/configPolicyReferenceGateConcurrency.integration.test.ts
+++ b/apps/api/src/__tests__/integration/configPolicyReferenceGateConcurrency.integration.test.ts
@@ -323,6 +323,12 @@ runDb('serializes reverse writes to sensitive-data candidates with one UUID', as
       'sensitive-data mover',
     );
     secondWork = sqlState(() => second.begin(async (tx) => {
+      // #5099's ownership-immutable guard rejects a configuration_policies
+      // owner change outside system scope (23514) before this statement ever
+      // reaches the reference-gate race this test exercises. Elect system
+      // scope so the pre-existing FK/gate serialization (23503) is still
+      // what's under test here, not the newer guard.
+      await tx`SELECT pg_catalog.set_config('breeze.scope', 'system', true)`;
       const [backend] = await tx<{ pid: number }[]>`SELECT pg_catalog.pg_backend_pid() AS pid`;
       if (!backend) throw new Error('missing sensitive fallback backend');
       secondEntered.resolve(backend.pid);

--- a/apps/api/src/__tests__/integration/partnerApiRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/partnerApiRls.integration.test.ts
@@ -590,12 +590,18 @@ describe('partner reconstruction export RLS traversal', () => {
     expect(await captureSqlState(() => admin.delete(devices)
       .where(eq(devices.id, movableDevice.id))))
       .toBe('23503');
-    expect(await captureSqlState(() => admin.update(configurationPolicies)
+    // #5099 (2026-10-12-100000-config-policy-inheritance.sql) added a
+    // constraint trigger that rejects ANY non-system-scope owner change on
+    // configuration_policies before the composite-FK below gets a chance to
+    // fire. `admin` never elects system scope, so the ownership-immutable
+    // guard is now the fastest failure path for these two forges — assert
+    // the guard's outcome (23514 + its named constraint) rather than the FK.
+    expect(await captureSqlError(() => admin.update(configurationPolicies)
       .set({ orgId: partnerA.orgs[1]!.id }).where(eq(configurationPolicies.id, orgPolicy.id))))
-      .toBe('23503');
-    expect(await captureSqlState(() => admin.update(configurationPolicies)
+      .toEqual({ code: '23514', constraint: 'configuration_policies_owner_immutable' });
+    expect(await captureSqlError(() => admin.update(configurationPolicies)
       .set({ partnerId: partnerB.partner.id }).where(eq(configurationPolicies.id, partnerPolicy.id))))
-      .toBe('23503');
+      .toEqual({ code: '23514', constraint: 'configuration_policies_owner_immutable' });
 
     const [updatableAssignment] = await withDbAccessContext(contextA, () =>
       db.insert(configPolicyAssignments).values({
@@ -671,6 +677,13 @@ describe('partner reconstruction export RLS traversal', () => {
       }).returning();
       if (!movingPolicy) throw new Error('concurrent owner policy seed failed');
       const policyMover = admin.transaction(async (tx) => {
+        // #5099's ownership-immutable guard rejects a configuration_policies
+        // owner change outside system scope (23514) — org merge is the only
+        // real-world mover, and it always runs in system scope. Elect it here
+        // so this in-flight move still holds its row lock the way a merge
+        // would, letting the assignment insert below serialize against it
+        // instead of the update failing before `ownerMove` ever resolves.
+        await tx.execute(sql`SELECT pg_catalog.set_config('breeze.scope', 'system', true)`);
         await tx.update(configurationPolicies).set({ orgId: target.orgs[0]!.id })
           .where(eq(configurationPolicies.id, movingPolicy.id));
         ownerMove.resolve();
@@ -772,12 +785,19 @@ describe('partner reconstruction export RLS traversal', () => {
       { partnerId: second.partner.id, name: 'Bulk partner policy B' },
     ]).returning();
     if (!policyA || !policyB) throw new Error('bulk policy seed failed');
-    await expect(admin.update(configurationPolicies).set({
-      partnerId: sql`CASE
-        WHEN ${configurationPolicies.id} = ${policyA.id}::uuid THEN ${second.partner.id}::uuid
-        ELSE ${first.partner.id}::uuid
-      END`,
-    }).where(inArray(configurationPolicies.id, [policyA.id, policyB.id]))).resolves.toBeDefined();
+    // #5099's ownership-immutable guard rejects a configuration_policies
+    // owner change outside system scope (23514) — this bulk owner set is a
+    // legitimate move (org merge shape) and must elect system scope to reach
+    // the FK/RLS-plumbing this assertion actually exercises.
+    await expect(admin.transaction(async (tx) => {
+      await tx.execute(sql`SELECT pg_catalog.set_config('breeze.scope', 'system', true)`);
+      return tx.update(configurationPolicies).set({
+        partnerId: sql`CASE
+          WHEN ${configurationPolicies.id} = ${policyA.id}::uuid THEN ${second.partner.id}::uuid
+          ELSE ${first.partner.id}::uuid
+        END`,
+      }).where(inArray(configurationPolicies.id, [policyA.id, policyB.id]));
+    })).resolves.toBeDefined();
     await expect(admin.delete(configurationPolicies)
       .where(inArray(configurationPolicies.id, [policyA.id, policyB.id]))).resolves.toBeDefined();
 
@@ -1230,5 +1250,26 @@ async function captureSqlState(work: () => Promise<unknown>): Promise<string | u
   } catch (error) {
     const wrapped = error as { code?: string; cause?: { code?: string } };
     return wrapped.cause?.code ?? wrapped.code;
+  }
+}
+
+// Sibling to captureSqlState that also captures the constraint name, so a
+// SQLSTATE shared by multiple constraints (e.g. 23514) still discriminates
+// which one fired — see configPolicyInheritance.integration.test.ts's
+// expectSqlState for the same shape.
+async function captureSqlError(
+  work: () => Promise<unknown>,
+): Promise<{ code?: string; constraint?: string }> {
+  try {
+    await work();
+    return {};
+  } catch (error) {
+    const wrapped = error as {
+      code?: string;
+      constraint_name?: string;
+      cause?: { code?: string; constraint_name?: string };
+    };
+    const node = wrapped.cause?.code ? wrapped.cause : wrapped;
+    return { code: node.code, constraint: node.constraint_name };
   }
 }


### PR DESCRIPTION
## Root cause

Main has been red on **Integration Tests shard 2/4** since #5099 (`f6ec8a33f8`, config-policy inheritance W01 of #5080). That PR's migration `2026-10-12-100000-config-policy-inheritance.sql` adds constraint trigger `configuration_policies_parent_guard` (function `breeze_config_policy_parent_guard()`), which now raises **`23514`** (`CONSTRAINT = configuration_policies_owner_immutable`) whenever `configuration_policies.org_id`/`partner_id` changes outside system scope ("configuration policy ownership can only change in system context").

Two pre-existing integration suites forge configuration-policy owner moves as a non-system actor and expected the composite-FK sqlstate `23503` — the new trigger now pre-empts that FK check, so those assertions (and one dependent 30s test timeout) went red.

## Per-assertion decisions

- **`partnerApiRls.integration.test.ts` — "enforces every target level and rejects reverse owner forges"**: the two `configuration_policies` owner-forge assertions (`admin.update(...).set({orgId/partnerId})`, run without system scope) now legitimately hit the new guard first. Kept the test's intent (forge rejected) but reasserted the actual outcome — added a `captureSqlError` sibling helper (mirrors `configPolicyInheritance.integration.test.ts`'s `expectSqlState` shape) that checks both sqlstate `23514` *and* `constraint_name: 'configuration_policies_owner_immutable'`, so the assertion still discriminates from an unrelated 23514.
- **`partnerApiRls.integration.test.ts` — "serializes concurrent target and policy owner moves before assignment validation"**: the `policyMover` sub-block moves a policy's `org_id` and expects that move to **succeed** (an org-merge shape) so it can hold the row lock while a concurrent assignment insert serializes against it. Without system scope the update now throws before `ownerMove.resolve()` runs — explaining the observed 30s timeout, not a real hang. Fixed by electing `breeze.scope = system` inside the transaction before the update, matching org merge's real code path (org merge always runs in system context per the tenancy contract).
- **`partnerApiRls.integration.test.ts` — "serializes complete bulk owner sets across partners and descending organizations"**: same shape — a bulk `partner_id` update on `configuration_policies` expected to resolve. Wrapped it in a transaction that elects system scope first.
- **`configPolicyReferenceGateConcurrency.integration.test.ts` — "serializes reverse writes to sensitive-data candidates with one UUID"**: this test's actual purpose is exercising the pre-existing (2026-08-01) feature-reference advisory-gate race, not the new ownership guard (confirmed by the advisory-lock class/backend-PID wait it asserts on). Elected system scope for the second writer's `configuration_policies` update so the original FK-based race (`23503`) is still what's under test — consistent with the sibling test earlier in the same file, which already elects `breeze.scope=system` for its writers.

## Design note

No production code was changed. The new guard's precedence over the composite FK looks correct as shipped: a non-system-actor ownership move should fail fast and specifically (`23514` with a named constraint) rather than only incidentally via whatever FK happens to reference the row. These suites were asserting the older, less specific failure mode from before #5099 existed.

## Test output (real Postgres, `pnpm test-stack up`)

```
partnerApiRls.integration.test.ts + configPolicyReferenceGateConcurrency.integration.test.ts
 Test Files  2 passed (2)
      Tests  20 passed (20)

configPolicyInheritance.integration.test.ts (#5099's own suite — no regression)
 Test Files  1 passed (1)
      Tests  40 passed (40)

All three together: 60/60 passed
```

`npx tsc --noEmit` on `apps/api` shows no errors in either touched file.

Refs #5080

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGT9BJVfpG3nyM6c9koAN8