### PR TITLE
fix(mobile): runaway timer warning, MFA auto-submit, approval header, org offline count (#5115)

### DIFF
--- a/apps/mobile/src/components/TimerBar.tsx
+++ b/apps/mobile/src/components/TimerBar.tsx
@@ -48,6 +48,7 @@ import { stopRunningTimer } from '../screens/tickets/timerActions';
 import { stopOutcomeEffects } from '../screens/tickets/timerOutcomeEffects';
 import {
   isQueueWedged,
+  isRunningTimerLong,
   isTimerBarVisible,
   shouldReplayNow,
   shouldShowWaitingToSync,
@@ -55,7 +56,7 @@ import {
   WAITING_TO_SYNC_GRACE_MS,
 } from './timerBarLogic';
 import { useNetworkConnected } from '../lib/useNetworkConnected';
-import { formatElapsed } from '../lib/timeFormat';
+import { formatElapsed, formatMinutes } from '../lib/timeFormat';
 import { ticketRef } from '../screens/tickets/ticketCopy';
 import { Toast } from './Toast';
 
@@ -423,6 +424,12 @@ export function TimerBar({ onOpenTimesheet }: { onOpenTimesheet?: () => void } =
   });
   if (!visible) return null;
 
+  // Runaway-timer guard (#5115): a timer nobody stopped showed up as a
+  // 12h31m entry on the timesheet. Warns only — never auto-stops, since only
+  // the technician knows when the work actually ended.
+  const runningElapsedSeconds = running !== null ? elapsedSeconds(running, now) : 0;
+  const showsLongRunningWarning = running !== null && isRunningTimerLong(runningElapsedSeconds);
+
   const ticket = running?.ticketId
     ? tickets.find((candidate) => candidate.id === running.ticketId)
     : undefined;
@@ -495,6 +502,11 @@ export function TimerBar({ onOpenTimesheet }: { onOpenTimesheet?: () => void } =
 
   const notices = (
     <>
+      {showsLongRunningWarning ? (
+        <Text style={styles.noticeAlarm} accessibilityLabel={`Still running — ${formatMinutes(runningElapsedSeconds / 60)}`}>
+          Still running — {formatMinutes(runningElapsedSeconds / 60)}
+        </Text>
+      ) : null}
       {startUnconfirmed ? (
         <Text style={styles.notice}>
           Start not confirmed — a timer may also be running on the server.

--- a/apps/mobile/src/components/timerBarLogic.test.ts
+++ b/apps/mobile/src/components/timerBarLogic.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect } from 'vitest';
 
 import {
   isQueueWedged,
+  isRunningTimerLong,
   isTimerBarVisible,
+  LONG_RUNNING_TIMER_WARNING_SECONDS,
   shouldReplayNow,
   shouldShowWaitingToSync,
   toastClearanceOffset,
@@ -128,5 +130,23 @@ describe('isQueueWedged', () => {
 
   it('is false once the queue has drained, however many attempts it took', () => {
     expect(isQueueWedged({ remaining: 0, headAttempts: 99 })).toBe(false);
+  });
+});
+
+describe('isRunningTimerLong', () => {
+  it('is false for a fresh start', () => {
+    expect(isRunningTimerLong(0)).toBe(false);
+  });
+
+  it('is false one second before the 4h threshold', () => {
+    expect(isRunningTimerLong(LONG_RUNNING_TIMER_WARNING_SECONDS - 1)).toBe(false);
+  });
+
+  it('is true exactly at the 4h threshold', () => {
+    expect(isRunningTimerLong(LONG_RUNNING_TIMER_WARNING_SECONDS)).toBe(true);
+  });
+
+  it('stays true well past the threshold — issue #5115 saw a 12h31m entry', () => {
+    expect(isRunningTimerLong(12 * 3600 + 31 * 60)).toBe(true);
   });
 });

--- a/apps/mobile/src/components/timerBarLogic.ts
+++ b/apps/mobile/src/components/timerBarLogic.ts
@@ -100,3 +100,20 @@ export const WEDGED_ATTEMPTS = 3;
 export function isQueueWedged(input: { remaining: number; headAttempts: number }): boolean {
   return input.remaining > 0 && input.headAttempts >= WEDGED_ATTEMPTS;
 }
+
+/**
+ * Elapsed seconds past which a running timer is flagged as runaway.
+ *
+ * Issue #5115: a timesheet showed a 12h31m entry from a timer nobody
+ * stopped. 4h is deliberately conservative — long enough that an ordinary
+ * uninterrupted work session never trips it, short enough to catch a
+ * forgotten timer well before it becomes a full-day billing error. This
+ * warns; it never auto-stops, since only the technician knows when the
+ * work actually ended.
+ */
+export const LONG_RUNNING_TIMER_WARNING_SECONDS = 4 * 60 * 60;
+
+/** Whether a running timer has been going long enough to warn about. */
+export function isRunningTimerLong(elapsedSeconds: number): boolean {
+  return elapsedSeconds >= LONG_RUNNING_TIMER_WARNING_SECONDS;
+}

--- a/apps/mobile/src/screens/approvals/ApprovalScreen.tsx
+++ b/apps/mobile/src/screens/approvals/ApprovalScreen.tsx
@@ -16,6 +16,7 @@ import { duration, ease, haptic } from '../../lib/motion';
 import { track } from '../../lib/analytics';
 
 import { CountdownRing } from './components/CountdownRing';
+import { RequesterAvatar } from './components/RequesterAvatar';
 import { RequesterRow } from './components/RequesterRow';
 import { ActionHeadline } from './components/ActionHeadline';
 import { DetailsCollapse } from './components/DetailsCollapse';
@@ -256,12 +257,15 @@ export function ApprovalScreen() {
           <CountdownRing
             expiresAt={focused.expiresAt}
             onExpire={handleExpire}
-          />
+          >
+            <RequesterAvatar clientLabel={focused.requestingClientLabel} />
+          </CountdownRing>
           <Pressable
             onPress={() => setReportSheetOpen(true)}
             hitSlop={12}
             accessibilityRole="button"
             accessibilityLabel="Report this approval as suspicious"
+            accessibilityHint="Flags this request as malicious and revokes the requesting app's access"
           >
             <Text style={[type.meta, { color: theme.textMd }]}>Report</Text>
           </Pressable>

--- a/apps/mobile/src/screens/approvals/components/CountdownRing.tsx
+++ b/apps/mobile/src/screens/approvals/components/CountdownRing.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, type ReactNode } from 'react';
 import { View } from 'react-native';
 import Svg, { Circle } from 'react-native-svg';
 import Animated, {
@@ -18,9 +18,17 @@ interface Props {
   size?: number;
   stroke?: number;
   onExpire?: () => void;
+  /**
+   * Content centered inside the ring (#5115). Previously this component
+   * rendered as a bare outline with nothing inside it — reported as looking
+   * like a stray loading spinner rather than an expiry indicator. Passing
+   * the requester avatar here keeps the countdown visual while making the
+   * ring read as decoration around an identity, not content of its own.
+   */
+  children?: ReactNode;
 }
 
-export function CountdownRing({ expiresAt, size = 56, stroke = 3, onExpire }: Props) {
+export function CountdownRing({ expiresAt, size = 56, stroke = 3, onExpire, children }: Props) {
   const theme = useApprovalTheme('dark');
   const radius = (size - stroke) / 2;
   const circumference = 2 * Math.PI * radius;
@@ -48,7 +56,7 @@ export function CountdownRing({ expiresAt, size = 56, stroke = 3, onExpire }: Pr
   }));
 
   return (
-    <View>
+    <View style={{ width: size, height: size }}>
       <Svg width={size} height={size}>
         <Circle
           cx={size / 2}
@@ -71,6 +79,22 @@ export function CountdownRing({ expiresAt, size = 56, stroke = 3, onExpire }: Pr
           transform={`rotate(-90 ${size / 2} ${size / 2})`}
         />
       </Svg>
+      {children ? (
+        <View
+          pointerEvents="none"
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          {children}
+        </View>
+      ) : null}
     </View>
   );
 }

--- a/apps/mobile/src/screens/approvals/components/RequesterAvatar.tsx
+++ b/apps/mobile/src/screens/approvals/components/RequesterAvatar.tsx
@@ -1,0 +1,53 @@
+import { View } from 'react-native';
+import Svg, { Path } from 'react-native-svg';
+
+import { palette, radii } from '../../../theme';
+import { Avatar } from '../../chat/components/Avatar';
+import { isBreezeAiRequester } from './requesterAvatarKind';
+
+interface Props {
+  clientLabel: string;
+  size?: number;
+}
+
+// A four-point sparkle — the same mark used to signal "this is Breeze AI,
+// not a person" wherever the app needs one glyph rather than a photo/initial.
+function SparkleGlyph({ size, color }: { size: number; color: string }) {
+  return (
+    <Svg width={size} height={size} viewBox="0 0 24 24">
+      <Path
+        d="M12 2 L14.2 9.8 L22 12 L14.2 14.2 L12 22 L9.8 14.2 L2 12 L9.8 9.8 Z"
+        fill={color}
+      />
+    </Svg>
+  );
+}
+
+/**
+ * Requester identity for the approval takeover header (#5115). Previously
+ * this slot held only the countdown ring — a bare animated circle that read
+ * as a loading spinner rather than "who is asking". Chat's AI flow always
+ * sends the literal label 'Breeze AI' (see requesterAvatarKind.ts); every
+ * other requester is an app or agent name, shown as initials via the same
+ * Avatar used in the chat header.
+ */
+export function RequesterAvatar({ clientLabel, size = 32 }: Props) {
+  if (isBreezeAiRequester(clientLabel)) {
+    return (
+      <View
+        style={{
+          width: size,
+          height: size,
+          borderRadius: radii.full,
+          backgroundColor: palette.brand.deep,
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+        accessibilityLabel="Breeze AI"
+      >
+        <SparkleGlyph size={size * 0.5} color={palette.dark.textHi} />
+      </View>
+    );
+  }
+  return <Avatar name={clientLabel} size={size} />;
+}

--- a/apps/mobile/src/screens/approvals/components/requesterAvatarKind.test.ts
+++ b/apps/mobile/src/screens/approvals/components/requesterAvatarKind.test.ts
@@ -21,4 +21,12 @@ describe('isBreezeAiRequester', () => {
   it('is false for an empty label', () => {
     expect(isBreezeAiRequester('')).toBe(false);
   });
+
+  it('is case-sensitive — the server always sends the exact literal', () => {
+    // Locks in the exact-match contract documented above: a future casing
+    // drift on either side (server or here) should fail a test, not
+    // silently start showing the wrong avatar for a real AI approval.
+    expect(isBreezeAiRequester('breeze ai')).toBe(false);
+    expect(isBreezeAiRequester('BREEZE AI')).toBe(false);
+  });
 });

--- a/apps/mobile/src/screens/approvals/components/requesterAvatarKind.test.ts
+++ b/apps/mobile/src/screens/approvals/components/requesterAvatarKind.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+
+import { isBreezeAiRequester } from './requesterAvatarKind';
+
+describe('isBreezeAiRequester', () => {
+  it('is true for the chat flow\'s exact label', () => {
+    expect(isBreezeAiRequester('Breeze AI')).toBe(true);
+  });
+
+  it('is false for other agent/app labels', () => {
+    expect(isBreezeAiRequester('Breeze Agent')).toBe(false);
+    expect(isBreezeAiRequester('Claude Desktop')).toBe(false);
+    expect(isBreezeAiRequester('Patch Hygiene Agent')).toBe(false);
+    expect(isBreezeAiRequester('MCP API client')).toBe(false);
+  });
+
+  it('tolerates incidental whitespace', () => {
+    expect(isBreezeAiRequester('  Breeze AI  ')).toBe(true);
+  });
+
+  it('is false for an empty label', () => {
+    expect(isBreezeAiRequester('')).toBe(false);
+  });
+});

--- a/apps/mobile/src/screens/approvals/components/requesterAvatarKind.ts
+++ b/apps/mobile/src/screens/approvals/components/requesterAvatarKind.ts
@@ -1,0 +1,14 @@
+/**
+ * Which avatar treatment the approval takeover header shows for a requester.
+ *
+ * Pure module (no React) so it stays unit-testable — the same pattern as
+ * timerBarLogic.ts. `requestingClientLabel` is server-issued free text (see
+ * `services/approvals.ts`); the AI chat flow is the one caller that always
+ * sends the literal string 'Breeze AI' (apps/api/src/services/aiAgentSdk.ts).
+ * Every other caller — agent elevation requests, MCP/desktop clients, patch
+ * and hygiene agents — sends the requesting app or agent's own name, which
+ * reads better as initials than as a generic icon.
+ */
+export function isBreezeAiRequester(clientLabel: string): boolean {
+  return clientLabel.trim() === 'Breeze AI';
+}

--- a/apps/mobile/src/screens/auth/MfaChallengeScreen.tsx
+++ b/apps/mobile/src/screens/auth/MfaChallengeScreen.tsx
@@ -23,6 +23,7 @@ import {
   getSupportedNativeMfaMethods,
   normalizeNativeMfaInput,
   normalizeNativeMfaSubmission,
+  shouldAutoSubmitMfa,
   type NativeMfaMethod,
 } from './mfaChallengePresentation';
 
@@ -46,6 +47,7 @@ export function MfaChallengeScreen() {
     : 'totp';
   const [selectedMethod, setSelectedMethod] = useState<NativeMfaMethod>(initialMethod);
   const inputRef = useRef<ComponentRef<typeof TextInput>>(null);
+  const autoSubmittedRef = useRef(false);
 
   const isSms = selectedMethod === 'sms';
   const isRecovery = selectedMethod === 'recovery';
@@ -77,6 +79,30 @@ export function MfaChallengeScreen() {
     const t = setTimeout(() => inputRef.current?.focus(), 250);
     return () => clearTimeout(t);
   }, []);
+
+  // #5115: submit automatically once a full authenticator code is present,
+  // instead of requiring a manual Verify tap after the sixth digit.
+  // `autoSubmittedRef` is the debounce — it stops paste/autofill (which can
+  // deliver all 6 digits in a single onChangeText call) from firing twice,
+  // and resets once the code is no longer complete so a retry after a
+  // failed verify can still auto-submit.
+  useEffect(() => {
+    if (code.length !== 6) {
+      autoSubmittedRef.current = false;
+      return;
+    }
+    if (
+      !shouldAutoSubmitMfa({
+        method: selectedMethod,
+        codeLength: code.length,
+        alreadyAutoSubmitted: autoSubmittedRef.current,
+      })
+    ) {
+      return;
+    }
+    autoSubmittedRef.current = true;
+    void handleVerify();
+  }, [code, selectedMethod]);
 
   if (!mfaChallenge) {
     return null;

--- a/apps/mobile/src/screens/auth/mfaChallengePresentation.test.ts
+++ b/apps/mobile/src/screens/auth/mfaChallengePresentation.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+
+import { shouldAutoSubmitMfa } from './mfaChallengePresentation';
+
+describe('shouldAutoSubmitMfa', () => {
+  it('submits once the authenticator code reaches 6 digits', () => {
+    expect(shouldAutoSubmitMfa({ method: 'totp', codeLength: 6, alreadyAutoSubmitted: false })).toBe(true);
+  });
+
+  it('does not submit before 6 digits', () => {
+    expect(shouldAutoSubmitMfa({ method: 'totp', codeLength: 5, alreadyAutoSubmitted: false })).toBe(false);
+  });
+
+  it('debounces — does not re-submit the same 6-digit code twice (paste/autofill)', () => {
+    expect(shouldAutoSubmitMfa({ method: 'totp', codeLength: 6, alreadyAutoSubmitted: true })).toBe(false);
+  });
+
+  it('never auto-submits for SMS — only the authenticator method', () => {
+    expect(shouldAutoSubmitMfa({ method: 'sms', codeLength: 6, alreadyAutoSubmitted: false })).toBe(false);
+  });
+
+  it('never auto-submits recovery codes', () => {
+    expect(shouldAutoSubmitMfa({ method: 'recovery', codeLength: 6, alreadyAutoSubmitted: false })).toBe(false);
+  });
+});

--- a/apps/mobile/src/screens/auth/mfaChallengePresentation.ts
+++ b/apps/mobile/src/screens/auth/mfaChallengePresentation.ts
@@ -26,3 +26,24 @@ export function normalizeNativeMfaInput(method: NativeMfaMethod, value: string):
 export function normalizeNativeMfaSubmission(method: NativeMfaMethod, value: string): string {
   return method === 'recovery' ? value.trim() : value;
 }
+
+/**
+ * Whether a full authenticator code should trigger an automatic submit.
+ *
+ * Authenticator (`totp`) only — SMS is left as a manual tap (the code just
+ * arrived and a stray 6th digit typo is easy) and recovery codes are
+ * variable-length so "6 digits" isn't even a valid completion signal for
+ * them. `alreadyAutoSubmitted` is the debounce: a paste or platform autofill
+ * can deliver all 6 digits in one `onChangeText` call, and without it every
+ * character of a SLOWER manual paste that still lands as one change event
+ * would otherwise be indistinguishable from a second complete code — the
+ * caller sets it once a submit has fired for the current code and clears it
+ * when the code changes.
+ */
+export function shouldAutoSubmitMfa(input: {
+  method: NativeMfaMethod;
+  codeLength: number;
+  alreadyAutoSubmitted: boolean;
+}): boolean {
+  return input.method === 'totp' && input.codeLength === 6 && !input.alreadyAutoSubmitted;
+}

--- a/apps/mobile/src/screens/systems/SystemsScreen.tsx
+++ b/apps/mobile/src/screens/systems/SystemsScreen.tsx
@@ -641,7 +641,7 @@ export function SystemsScreen() {
               orgName: filterOrgName,
             })
           }
-          accessibilityRole="button"
+          accessibilityRole="link"
           accessibilityLabel="View all devices"
           style={{
             marginHorizontal: spacing[6],
@@ -660,7 +660,13 @@ export function SystemsScreen() {
           <Text style={{ ...type.bodyMd, color: theme.textHi }}>
             {filterOrgName ? `${filterOrgName} devices` : 'All devices'}
           </Text>
-          <Text style={{ ...type.meta, color: theme.textLo }}>View</Text>
+          {/* #5115: this row navigates like a link, but "View" in low-emphasis
+              textLo read as inert label text rather than a tappable
+              affordance — brand color + a chevron make the link legible. */}
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: spacing[1] }}>
+            <Text style={{ ...type.meta, color: theme.brand }}>View</Text>
+            <Text style={{ ...type.meta, color: theme.brand }}>›</Text>
+          </View>
         </Pressable>
 
         {filterOrgId && filterOrgName ? (

--- a/apps/mobile/src/screens/systems/components/OrgRow.tsx
+++ b/apps/mobile/src/screens/systems/components/OrgRow.tsx
@@ -4,6 +4,7 @@ import Animated, { FadeIn, FadeOut, LinearTransition } from 'react-native-reanim
 import { useApprovalTheme, spacing, type } from '../../../theme';
 import { haptic } from '../../../lib/motion';
 import type { OrgRollup } from '../useSystemsData';
+import { orgRowSubtitle } from './orgRowCopy';
 
 interface Props {
   org: OrgRollup;
@@ -14,10 +15,7 @@ interface Props {
 
 export function OrgRow({ org, onPress, showDivider, dividerColor }: Props) {
   const theme = useApprovalTheme('dark');
-  const sub =
-    org.issueCount === 0
-      ? `${org.deviceCount} ${org.deviceCount === 1 ? 'device' : 'devices'}, healthy`
-      : `${org.deviceCount} ${org.deviceCount === 1 ? 'device' : 'devices'} · ${org.issueCount} ${org.issueCount === 1 ? 'issue' : 'issues'}`;
+  const sub = orgRowSubtitle(org);
 
   return (
     <Animated.View

--- a/apps/mobile/src/screens/systems/components/orgRowCopy.test.ts
+++ b/apps/mobile/src/screens/systems/components/orgRowCopy.test.ts
@@ -3,6 +3,10 @@ import { describe, it, expect } from 'vitest';
 import { orgRowSubtitle } from './orgRowCopy';
 
 describe('orgRowSubtitle', () => {
+  it('reads "healthy, 0 devices" for an org with no device presence', () => {
+    expect(orgRowSubtitle({ deviceCount: 0, offlineCount: 0, issueCount: 0 })).toBe('0 devices, healthy');
+  });
+
   it('reads "healthy" for a single healthy device with no issues', () => {
     expect(orgRowSubtitle({ deviceCount: 1, offlineCount: 0, issueCount: 0 })).toBe('1 device, healthy');
   });
@@ -15,7 +19,7 @@ describe('orgRowSubtitle', () => {
     expect(orgRowSubtitle({ deviceCount: 7, offlineCount: 2, issueCount: 0 })).toBe('7 devices · 2 offline');
   });
 
-  it('singularizes "offline" is not a thing — the noun stays "offline", only the device count pluralizes', () => {
+  it('pluralizes only the device count when offline — "offline" itself never pluralizes', () => {
     expect(orgRowSubtitle({ deviceCount: 1, offlineCount: 1, issueCount: 0 })).toBe('1 device · 1 offline');
   });
 

--- a/apps/mobile/src/screens/systems/components/orgRowCopy.test.ts
+++ b/apps/mobile/src/screens/systems/components/orgRowCopy.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+
+import { orgRowSubtitle } from './orgRowCopy';
+
+describe('orgRowSubtitle', () => {
+  it('reads "healthy" for a single healthy device with no issues', () => {
+    expect(orgRowSubtitle({ deviceCount: 1, offlineCount: 0, issueCount: 0 })).toBe('1 device, healthy');
+  });
+
+  it('pluralizes devices when healthy', () => {
+    expect(orgRowSubtitle({ deviceCount: 3, offlineCount: 0, issueCount: 0 })).toBe('3 devices, healthy');
+  });
+
+  it('shows the offline count instead of "healthy" once any device is offline', () => {
+    expect(orgRowSubtitle({ deviceCount: 7, offlineCount: 2, issueCount: 0 })).toBe('7 devices · 2 offline');
+  });
+
+  it('singularizes "offline" is not a thing — the noun stays "offline", only the device count pluralizes', () => {
+    expect(orgRowSubtitle({ deviceCount: 1, offlineCount: 1, issueCount: 0 })).toBe('1 device · 1 offline');
+  });
+
+  it('falls back to the issue count when nothing is offline but issues exist', () => {
+    expect(orgRowSubtitle({ deviceCount: 5, offlineCount: 0, issueCount: 1 })).toBe('5 devices · 1 issue');
+    expect(orgRowSubtitle({ deviceCount: 5, offlineCount: 0, issueCount: 2 })).toBe('5 devices · 2 issues');
+  });
+
+  it('prioritizes offline over issues when both are present', () => {
+    expect(orgRowSubtitle({ deviceCount: 10, offlineCount: 3, issueCount: 4 })).toBe('10 devices · 3 offline');
+  });
+});

--- a/apps/mobile/src/screens/systems/components/orgRowCopy.ts
+++ b/apps/mobile/src/screens/systems/components/orgRowCopy.ts
@@ -1,0 +1,22 @@
+/**
+ * Subtitle line for an org row on the Systems screen (#5115).
+ *
+ * Pure module so the plural/priority rules stay unit-testable without a
+ * component runtime. Offline takes priority over open issues when both are
+ * present — an offline device is the more urgent signal, and showing both
+ * counts in one short line reads as cluttered on a list row.
+ */
+export function orgRowSubtitle(input: {
+  deviceCount: number;
+  offlineCount: number;
+  issueCount: number;
+}): string {
+  const deviceLabel = `${input.deviceCount} ${input.deviceCount === 1 ? 'device' : 'devices'}`;
+  if (input.offlineCount > 0) {
+    return `${deviceLabel} · ${input.offlineCount} offline`;
+  }
+  if (input.issueCount > 0) {
+    return `${deviceLabel} · ${input.issueCount} ${input.issueCount === 1 ? 'issue' : 'issues'}`;
+  }
+  return `${deviceLabel}, healthy`;
+}

--- a/apps/mobile/src/screens/systems/useSystemsData.ts
+++ b/apps/mobile/src/screens/systems/useSystemsData.ts
@@ -29,6 +29,8 @@ export interface OrgRollup {
   name: string;
   deviceCount: number;
   issueCount: number;
+  /** #5115: devices currently reporting `status: 'offline'` for this org. */
+  offlineCount: number;
   /**
    * True when the name could not be resolved BECAUSE the `orgs` fetch failed,
    * as opposed to the org genuinely not being in the list. Without the
@@ -374,6 +376,7 @@ export function useSystemsData() {
           name: resolved.name,
           deviceCount: 0,
           issueCount: 0,
+          offlineCount: 0,
           nameUnavailable: resolved.unavailable,
         };
         byId.set(id, row);
@@ -382,7 +385,10 @@ export function useSystemsData() {
     };
 
     for (const d of data.devices) {
-      if (d.organizationId) ensure(d.organizationId).deviceCount++;
+      if (!d.organizationId) continue;
+      const row = ensure(d.organizationId);
+      row.deviceCount++;
+      if (d.status === 'offline') row.offlineCount++;
     }
     // Issue counts come from the active page for the same reason the section
     // does: the unfiltered page is recency-ordered and can contain no

--- a/apps/mobile/src/screens/time/TimesheetScreen.tsx
+++ b/apps/mobile/src/screens/time/TimesheetScreen.tsx
@@ -25,6 +25,7 @@ import {
 import { classifyTimeEntryDenial, isAccountLevelDenial } from '../../services/timeEntryAccess';
 import { Toast } from '../../components/Toast';
 import { formatMinutes } from '../../lib/timeFormat';
+import { isLongEntry } from './timesheetLongEntry';
 import { reportInternalError } from '../../lib/errorReporting';
 import { ticketRef } from '../tickets/ticketCopy';
 
@@ -276,6 +277,7 @@ export function TimesheetScreen({ navigation }: TimesheetProps = {}) {
       ? tickets.find((candidate) => candidate.id === entry.ticketId)
       : undefined;
     const isEditing = editingId === entry.id;
+    const long = isLongEntry(entry.durationMinutes);
 
     return (
       <View key={entry.id} style={styles.entry}>
@@ -288,7 +290,12 @@ export function TimesheetScreen({ navigation }: TimesheetProps = {}) {
                 'Ticket')
               : 'No ticket'}
           </Text>
-          <Text style={styles.entryDuration}>{formatMinutes(entry.durationMinutes)}</Text>
+          <Text
+            style={[styles.entryDuration, long && styles.entryDurationLong]}
+            accessibilityLabel={long ? `${formatMinutes(entry.durationMinutes)}, long entry` : undefined}
+          >
+            {formatMinutes(entry.durationMinutes)}
+          </Text>
         </View>
         <Text style={styles.entryMeta}>
           {startTimeLabel(entry.startedAt)}
@@ -531,6 +538,7 @@ const styles = StyleSheet.create({
   entryHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
   entryRef: { ...type.monoMd, color: palette.dark.textMd },
   entryDuration: { ...type.bodyMd, color: palette.dark.textHi },
+  entryDurationLong: { color: palette.warning.base },
   entryMeta: { ...type.meta, color: palette.dark.textLo, marginTop: spacing['1'] },
   entryBody: { ...type.body, color: palette.dark.textHi, marginTop: spacing['2'] },
   lockNote: { ...type.meta, color: palette.warning.base, marginTop: spacing['2'] },

--- a/apps/mobile/src/screens/time/timesheetLongEntry.test.ts
+++ b/apps/mobile/src/screens/time/timesheetLongEntry.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+
+import { isLongEntry, LONG_ENTRY_WARNING_MINUTES } from './timesheetLongEntry';
+
+describe('isLongEntry', () => {
+  it('is false for a null duration — the entry is still running', () => {
+    expect(isLongEntry(null)).toBe(false);
+  });
+
+  it('is false for an undefined duration', () => {
+    expect(isLongEntry(undefined)).toBe(false);
+  });
+
+  it('is false one minute under the threshold', () => {
+    expect(isLongEntry(LONG_ENTRY_WARNING_MINUTES - 1)).toBe(false);
+  });
+
+  it('is true at the threshold', () => {
+    expect(isLongEntry(LONG_ENTRY_WARNING_MINUTES)).toBe(true);
+  });
+
+  it('is true well past the threshold', () => {
+    expect(isLongEntry(12 * 60 + 31)).toBe(true);
+  });
+
+  it('is false for an ordinary entry', () => {
+    expect(isLongEntry(45)).toBe(false);
+  });
+});

--- a/apps/mobile/src/screens/time/timesheetLongEntry.ts
+++ b/apps/mobile/src/screens/time/timesheetLongEntry.ts
@@ -1,0 +1,17 @@
+/**
+ * Whether a logged time entry is long enough to carry the "long entry" flag
+ * on the week list.
+ *
+ * Pure module so the rule is unit-testable without the app's component test
+ * runtime (see timerBarLogic.ts for the same pattern). Shares its threshold
+ * with the running-timer warning (#5115) — a timer that trips that warning
+ * while running should still read as flagged once it lands as a logged
+ * entry here.
+ */
+import { LONG_RUNNING_TIMER_WARNING_SECONDS } from '../../components/timerBarLogic';
+
+export const LONG_ENTRY_WARNING_MINUTES = LONG_RUNNING_TIMER_WARNING_SECONDS / 60;
+
+export function isLongEntry(durationMinutes: number | null | undefined): boolean {
+  return typeof durationMinutes === 'number' && durationMinutes >= LONG_ENTRY_WARNING_MINUTES;
+}


### PR DESCRIPTION
## Summary
Round-2 mobile papercuts batch 2 (leftovers from the 2026-09-06 OliveTech review not covered by #5103–#5107):

1. **Runaway timer guard.** `TimerBar`/`timerBarLogic.ts` now warn once a running timer passes 4h ("Still running — 4h 12m"), pure-tested at 3h59/4h00/fresh-start. `TimesheetScreen` flags week entries at or over the same threshold (`timesheetLongEntry.ts`) with a warning-colored duration + accessibility label. No auto-stop anywhere.
2. **MFA auto-submit.** `MfaChallengeScreen` submits automatically once a full 6-digit authenticator (`totp`) code is present, debounced via a ref so paste/autofill (which can deliver all 6 digits in one `onChangeText`) submits exactly once. SMS and recovery codes are unchanged — manual submit only. Pure decision logic in `mfaChallengePresentation.ts::shouldAutoSubmitMfa`.
3. **Approval sheet header.** The takeover previously showed a bare `CountdownRing` (an animated outline with nothing inside) where the requester should be — reported as looking like a stray loading spinner. `CountdownRing` now accepts children and wraps a new `RequesterAvatar`: a Breeze AI sparkle glyph when `requestingClientLabel === 'Breeze AI'` (the chat flow's literal label), initials otherwise (reusing the chat header's `Avatar`). `Report` gets an `accessibilityHint` explaining what it does (it already had an `accessibilityLabel`).
4. **Systems org rows.** `OrgRow` now shows "N devices · M offline" instead of "N devices, healthy" once any device is offline (falls back to the existing issue count when nothing is offline), via a new `offlineCount` aggregate on `OrgRollup` in `useSystemsData.ts`. The "All devices · View" row on `SystemsScreen` is restyled to read as a link (brand color, chevron, `accessibilityRole="link"`).

## Design notes
- Offline count takes priority over open-issue count when both are present on an org row (more urgent signal, keeps the line short) — noted in `orgRowCopy.ts`'s doc comment.
- Kept the countdown ring rather than removing it: wrapping the avatar inside it preserves the visual expiry cue while eliminating the "content-less ring" bug.

## Test plan
- [x] `npx vitest run` on all new/changed pure-logic test files (`timerBarLogic`, `timesheetLongEntry`, `mfaChallengePresentation`, `MfaChallengeScreen`, `requesterAvatarKind`, `orgRowCopy`) — 48 passed.
- [x] Broader regression sweep: `npx vitest run src/screens/systems src/screens/approvals src/screens/time src/screens/auth src/components/...` — 209 passed, 22 files, no regressions.
- [x] `npx tsc --noEmit` clean.

Closes #5115

🤖 Generated with [Claude Code](https://claude.com/claude-code)