### PR TITLE
feat(mobile): Home empty state fleet strip (#5117 decision 3)

### DIFF
--- a/apps/mobile/src/screens/chat/HomeScreen.tsx
+++ b/apps/mobile/src/screens/chat/HomeScreen.tsx
@@ -46,6 +46,7 @@ import { ChatHeader } from './components/ChatHeader';
 import { ColdOpenChips } from './components/ColdOpenChips';
 import { Composer } from './components/Composer';
 import { ConversationList } from './components/ConversationList';
+import { HomeFleetStrip } from './components/HomeFleetStrip';
 import { SessionsSheet } from './components/SessionsSheet';
 import { SettingsSheet } from './components/SettingsSheet';
 import { historyToMessages } from './historyAdapter';
@@ -404,6 +405,7 @@ export function HomeScreen() {
       >
         {isCold ? (
           <View style={{ flex: 1, justifyContent: 'flex-end' }}>
+            <HomeFleetStrip />
             <ColdOpenChips onPick={handleChip} />
           </View>
         ) : (

--- a/apps/mobile/src/screens/chat/components/HomeFleetStrip.tsx
+++ b/apps/mobile/src/screens/chat/components/HomeFleetStrip.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useState } from 'react';
+import { Pressable, Text, View } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import type { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
+
+import { useApprovalTheme, radii, spacing, type } from '../../../theme';
+import { haptic } from '../../../lib/motion';
+import { FleetBar } from '../../../components/FleetBar';
+import { getMobileSummary, type MobileSummary } from '../../../services/systems';
+import type { MainTabParamList } from '../../../navigation/MainNavigator';
+import { formatFleetStripCopy } from './homeFleetStripCopy';
+
+/**
+ * Compact online/offline/issues strip shown above the cold-open chips on a
+ * new conversation (#5141, decision 3 of #5117). Reuses the same
+ * `/mobile/summary` fetch the Systems tab hero is built from (via
+ * `getMobileSummary`, `services/systems.ts`) — no new endpoint. The parent
+ * (HomeScreen) only mounts this while the conversation is empty, so it
+ * disappears the instant the first message lands; no visibility prop needed
+ * here.
+ *
+ * Fails soft: a skeleton covers the fetch, and any rejection hides the strip
+ * entirely rather than showing a red banner above the composer — Home is not
+ * the place to surface a Systems-tab data error.
+ */
+export function HomeFleetStrip() {
+  const theme = useApprovalTheme('dark');
+  const navigation = useNavigation<BottomTabNavigationProp<MainTabParamList>>();
+  const [summary, setSummary] = useState<MobileSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    getMobileSummary()
+      .then((s) => {
+        if (cancelled) return;
+        setSummary(s);
+        setLoading(false);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setFailed(true);
+        setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (failed) return null;
+
+  if (loading || !summary) {
+    return (
+      <View style={{ paddingHorizontal: spacing[6], marginBottom: spacing[4] }}>
+        <View
+          style={{
+            height: 54,
+            borderRadius: radii.lg,
+            backgroundColor: theme.bg2,
+          }}
+        />
+      </View>
+    );
+  }
+
+  const { online, offline } = summary.devices;
+  const issues = summary.alerts.active;
+
+  return (
+    <View style={{ paddingHorizontal: spacing[6], marginBottom: spacing[4] }}>
+      <Pressable
+        onPress={() => {
+          haptic.tap();
+          navigation.navigate('SystemsTab');
+        }}
+        style={({ pressed }) => ({
+          backgroundColor: theme.bg2,
+          borderRadius: radii.lg,
+          padding: spacing[4],
+          borderWidth: 1,
+          borderColor: pressed ? theme.brand : 'transparent',
+        })}
+      >
+        <FleetBar segments={{ healthy: online, warning: issues, critical: offline }} />
+        <Text style={[type.bodyMd, { color: theme.textHi, marginTop: spacing[3] }]}>
+          {formatFleetStripCopy(summary)}
+        </Text>
+      </Pressable>
+    </View>
+  );
+}

--- a/apps/mobile/src/screens/chat/components/HomeFleetStrip.tsx
+++ b/apps/mobile/src/screens/chat/components/HomeFleetStrip.tsx
@@ -5,6 +5,7 @@ import type { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
 
 import { useApprovalTheme, radii, spacing, type } from '../../../theme';
 import { haptic } from '../../../lib/motion';
+import { reportInternalError } from '../../../lib/errorReporting';
 import { FleetBar } from '../../../components/FleetBar';
 import { getMobileSummary, type MobileSummary } from '../../../services/systems';
 import type { MainTabParamList } from '../../../navigation/MainNavigator';
@@ -38,8 +39,14 @@ export function HomeFleetStrip() {
         setSummary(s);
         setLoading(false);
       })
-      .catch(() => {
+      .catch((err) => {
         if (cancelled) return;
+        // Hidden from the user by design (never a red banner on Home), but
+        // still worth a Sentry breadcrumb — otherwise the strip going quiet
+        // for every user (expired token, endpoint regression) has zero
+        // signal anywhere. Mirrors useSystemsData.ts's handling of the same
+        // getMobileSummary() call.
+        reportInternalError(err, 'home-fleet-strip');
         setFailed(true);
         setLoading(false);
       });

--- a/apps/mobile/src/screens/chat/components/homeFleetStripCopy.test.ts
+++ b/apps/mobile/src/screens/chat/components/homeFleetStripCopy.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import type { MobileSummary } from '../../../services/systems';
+import { formatFleetStripCopy } from './homeFleetStripCopy';
+
+function summary(
+  devices: Partial<MobileSummary['devices']> = {},
+  alerts: Partial<MobileSummary['alerts']> = {},
+): MobileSummary {
+  return {
+    devices: { total: 0, online: 0, offline: 0, maintenance: 0, ...devices },
+    alerts: { total: 0, active: 0, acknowledged: 0, resolved: 0, critical: 0, ...alerts },
+  };
+}
+
+describe('formatFleetStripCopy', () => {
+  it('formats plural counts', () => {
+    expect(formatFleetStripCopy(summary({ online: 34, offline: 23 }, { active: 2 }))).toBe(
+      '34 online · 23 offline · 2 issues',
+    );
+  });
+
+  it('singularizes exactly one issue', () => {
+    expect(formatFleetStripCopy(summary({ online: 1, offline: 0 }, { active: 1 }))).toBe(
+      '1 online · 0 offline · 1 issue',
+    );
+  });
+
+  it('collapses zero issues to "no issues"', () => {
+    expect(formatFleetStripCopy(summary({ online: 10, offline: 0 }, { active: 0 }))).toBe(
+      '10 online · 0 offline · no issues',
+    );
+  });
+
+  it('does not pluralize online/offline counts (they have no unit word)', () => {
+    expect(formatFleetStripCopy(summary({ online: 1, offline: 1 }, { active: 0 }))).toBe(
+      '1 online · 1 offline · no issues',
+    );
+  });
+});

--- a/apps/mobile/src/screens/chat/components/homeFleetStripCopy.test.ts
+++ b/apps/mobile/src/screens/chat/components/homeFleetStripCopy.test.ts
@@ -37,4 +37,10 @@ describe('formatFleetStripCopy', () => {
       '1 online · 1 offline · no issues',
     );
   });
+
+  it('shows a zero online count plainly rather than collapsing it like issues', () => {
+    expect(formatFleetStripCopy(summary({ online: 0, offline: 5 }, { active: 0 }))).toBe(
+      '0 online · 5 offline · no issues',
+    );
+  });
 });

--- a/apps/mobile/src/screens/chat/components/homeFleetStripCopy.ts
+++ b/apps/mobile/src/screens/chat/components/homeFleetStripCopy.ts
@@ -1,0 +1,14 @@
+import type { MobileSummary } from '../../../services/systems';
+
+// Pure copy for the Home empty-state fleet strip (#5141, decision 3 of
+// #5117): "{online} online · {offline} offline · {issues}", where the issues
+// clause pluralizes and collapses to "no issues" at zero. `issues` is
+// `alerts.active` (unacknowledged active alerts) — the same field the
+// Systems hero's breakdown is built from, so the count on Home never reads
+// higher than what tapping through actually shows.
+export function formatFleetStripCopy(summary: MobileSummary): string {
+  const { online, offline } = summary.devices;
+  const issues = summary.alerts.active;
+  const issuesPart = issues === 0 ? 'no issues' : `${issues} ${issues === 1 ? 'issue' : 'issues'}`;
+  return `${online} online · ${offline} offline · ${issuesPart}`;
+}


### PR DESCRIPTION
## Summary

Adds a compact online/offline/issues fleet strip to the Home tab's empty state (new conversation, zero messages), per decision 3 of #5117 — replacing the black void above the three cold-open prompt chips.

- `apps/mobile/src/screens/chat/components/HomeFleetStrip.tsx`: fetches `getMobileSummary()` (`services/systems.ts` — the same call the Systems tab hero uses; no new endpoint), shows a skeleton while loading, renders nothing on fetch error, and taps through to the Systems tab.
- `apps/mobile/src/screens/chat/components/homeFleetStripCopy.ts`: pure copy helper — `"{online} online · {offline} offline · {issues}"`, singularizing "1 issue" and collapsing to "no issues" at zero.
- `apps/mobile/src/screens/chat/HomeScreen.tsx`: renders `<HomeFleetStrip />` above `<ColdOpenChips />`, inside the existing `isCold` conditional — so it mounts only while the conversation is empty and unmounts the instant the first message is sent (no extra visibility logic needed).

## Test plan

- [x] `homeFleetStripCopy.test.ts` — plural, singular, and zero-issue copy forms (red first, then implementation)
- [x] `npx vitest run src/screens/chat` — 8 files / 80 tests passed (no regressions)
- [x] `npx tsc --noEmit` — clean
- [ ] Manual/UI verification in a running app (no RN test renderer configured in this repo's vitest setup — see `StatusPill.test.ts`'s note)

Closes #5141

🤖 Generated with [Claude Code](https://claude.com/claude-code)