### PR TITLE
feat(api,mobile): Systems tab issue count includes open fleet findings (#5139)

### DIFF
--- a/apps/api/src/routes/fleetFindings.test.ts
+++ b/apps/api/src/routes/fleetFindings.test.ts
@@ -522,6 +522,71 @@ describe('GET /fleet/findings — resolved-history fetch is bounded', () => {
   });
 });
 
+describe('GET /fleet/findings/counts', () => {
+  it('counts only open findings, grouped by org, excluding resolved (#5139)', async () => {
+    h.selectQueue.push([
+      { id: FINDING_1, orgId: ORG_1 },
+      { id: 'finding-2', orgId: ORG_1 },
+      { id: 'finding-3', orgId: ORG_2 },
+    ]);
+
+    const res = await get(
+      makeAuth({ scope: 'partner', orgId: null, accessibleOrgIds: [ORG_1, ORG_2] }),
+      '/counts'
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ total: 3, byOrg: { [ORG_1]: 2, [ORG_2]: 1 } });
+
+    const where = h.capturedWheres[0] as { args: unknown[] };
+    expect(where.args).toContainEqual({ op: 'eq', column: fleetFindings.status, value: 'open' });
+    expect(where.args).toContainEqual({ op: 'inArray', column: fleetFindings.orgId, values: [ORG_1, ORG_2] });
+  });
+
+  it('a resolved finding never reaches the query — only status=open is fetched', async () => {
+    // The mock DB has already applied the WHERE server-side in reality; here
+    // we assert the route only ever queries the open set, so a resolved
+    // finding sitting in the same org can never be counted even if a future
+    // refactor loosens the WHERE clause upstream.
+    h.selectQueue.push([{ id: FINDING_1, orgId: ORG_1 }]);
+    const res = await get(makeAuth({ scope: 'organization', orgId: ORG_1 }), '/counts');
+    const body = await res.json();
+    expect(body).toEqual({ total: 1, byOrg: { [ORG_1]: 1 } });
+
+    const where = h.capturedWheres[0] as { args: unknown[] };
+    expect(where.args).toContainEqual({ op: 'eq', column: fleetFindings.status, value: 'open' });
+  });
+
+  it('org-scope token with no access sees an empty count, not an error', async () => {
+    h.selectQueue.push([]);
+    const res = await get(makeAuth({ scope: 'organization', orgId: ORG_1 }), '/counts');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ total: 0, byOrg: {} });
+  });
+
+  it('site-restricted caller only counts findings with an in-scope member device', async () => {
+    h.selectQueue.push([
+      { id: FINDING_1, orgId: ORG_1 },
+      { id: 'finding-2', orgId: ORG_1 },
+    ]);
+    // Only FINDING_1 has an in-site member.
+    h.selectQueue.push([{ findingId: FINDING_1 }]);
+
+    const res = await get(makeAuth({ allowedSiteIds: [SITE_1] }), '/counts');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ total: 1, byOrg: { [ORG_1]: 1 } });
+  });
+
+  it('fails closed with an empty allowedSiteIds array (no membership query issued)', async () => {
+    h.selectQueue.push([{ id: FINDING_1, orgId: ORG_1 }]);
+
+    const res = await get(makeAuth({ allowedSiteIds: [] }), '/counts');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ total: 0, byOrg: {} });
+    expect(h.mockSelect).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('GET /fleet/findings/:id', () => {
   it('returns 404 for an unknown id', async () => {
     h.selectQueue.push([]);

--- a/apps/api/src/routes/fleetFindings.ts
+++ b/apps/api/src/routes/fleetFindings.ts
@@ -14,6 +14,7 @@ import {
 import {
   applyFleetFindingLifecycle,
   getFleetFinding,
+  getFleetFindingCounts,
   getRemediationRun,
   listFleetFindings,
   type FleetFindingLifecycleAction,
@@ -139,6 +140,15 @@ fleetFindingsRoutes.get(
     return c.json(result);
   }
 );
+
+// `GET /counts` is a single path segment, so it MUST be registered before
+// `/:id` below to avoid Hono matching "counts" as a finding id (mirroring
+// the constraint documented for `/runs/:runId` etc. right below).
+fleetFindingsRoutes.get('/counts', requireScope('organization', 'partner', 'system'), requireFindingsRead, async (c) => {
+  const auth = c.get('auth');
+  const result = await getFleetFindingCounts(auth);
+  return c.json(result);
+});
 
 // `GET /runs/:runId` (top-level) and `GET /:id/runs` / `POST /:id/remediate`
 // are all two path segments, so none of them can be swallowed by the

--- a/apps/api/src/services/fleetFindings/query.ts
+++ b/apps/api/src/services/fleetFindings/query.ts
@@ -313,6 +313,66 @@ export async function listFleetFindings(
   return { findings: page.map(serializeFinding), total };
 }
 
+export interface FleetFindingCounts {
+  total: number;
+  byOrg: Record<string, number>;
+}
+
+/**
+ * Open-finding counts per org (+ fleet total), for the mobile Systems tab
+ * (#5139 / #5117 decision 1): folds fleet-hygiene findings into the same
+ * "issue count" the AI's `get_fleet_findings` tool already reports, so a
+ * technician opening Systems sees the same picture.
+ *
+ * Only `status = 'open'` counts — acknowledged/dismissed/resolved findings
+ * are already being worked or closed out and must not inflate the count a
+ * technician is triaging against.
+ *
+ * Scoping mirrors `listFleetFindings`: `auth.orgCondition` narrows the SQL
+ * fetch, and a site-restricted caller (`auth.allowedSiteIds` set) gets the
+ * result narrowed further to findings with at least one member device in an
+ * allowed site — same fail-closed semantics (a finding with zero in-scope
+ * members must not inflate a count the caller cannot otherwise see).
+ */
+export async function getFleetFindingCounts(auth: AuthContext): Promise<FleetFindingCounts> {
+  const conditions: SQL[] = [eq(fleetFindings.status, 'open')];
+  const orgCondition = auth.orgCondition(fleetFindings.orgId);
+  if (orgCondition) conditions.push(orgCondition);
+
+  const rows = (await db
+    .select({ id: fleetFindings.id, orgId: fleetFindings.orgId })
+    .from(fleetFindings)
+    .where(and(...conditions))) as Array<{ id: string; orgId: string }>;
+
+  let scoped = rows;
+
+  if (auth.allowedSiteIds !== undefined) {
+    const allowedSiteIds = auth.allowedSiteIds;
+    if (allowedSiteIds.length === 0 || rows.length === 0) {
+      return { total: 0, byOrg: {} };
+    }
+
+    const candidateIds = rows.map((r) => r.id);
+    const memberRows = (await db
+      .select({ findingId: fleetFindingDevices.findingId })
+      .from(fleetFindingDevices)
+      .innerJoin(devices, eq(fleetFindingDevices.deviceId, devices.id))
+      .where(
+        and(inArray(fleetFindingDevices.findingId, candidateIds), inArray(devices.siteId, allowedSiteIds))
+      )) as Array<{ findingId: string }>;
+
+    const visibleFindingIds = new Set(memberRows.map((m) => m.findingId));
+    scoped = rows.filter((r) => visibleFindingIds.has(r.id));
+  }
+
+  const byOrg: Record<string, number> = {};
+  for (const r of scoped) {
+    byOrg[r.orgId] = (byOrg[r.orgId] ?? 0) + 1;
+  }
+
+  return { total: scoped.length, byOrg };
+}
+
 /**
  * Fetch a single finding + live member devices + last 10 runs, scoped to
  * `auth`. Returns `null` when the finding doesn't exist, isn't in an

--- a/apps/api/src/services/fleetFindings/query.ts
+++ b/apps/api/src/services/fleetFindings/query.ts
@@ -220,6 +220,38 @@ function serializeFinding(row: RawFindingRow): FleetFindingRow {
   };
 }
 
+/**
+ * Fetch member deviceIds-in-scope per finding for a site-restricted caller,
+ * shared by `listFleetFindings` and `getFleetFindingCounts` so the two don't
+ * drift (both apply the exact same "member device in an allowed site" test —
+ * see the module doc's warning about dual-map drift between call sites).
+ *
+ * Returns `null` — with NO query issued — when there is nothing to check
+ * (`allowedSiteIds` empty, or no candidate findings): callers must treat that
+ * as "nothing visible" and return their own empty result, matching the
+ * existing fail-closed contract (an empty site allowlist can never match).
+ */
+async function findingDeviceIdsBySite(
+  candidateFindingIds: readonly string[],
+  allowedSiteIds: readonly string[]
+): Promise<Map<string, Set<string>> | null> {
+  if (allowedSiteIds.length === 0 || candidateFindingIds.length === 0) return null;
+
+  const memberRows = await db
+    .select({ findingId: fleetFindingDevices.findingId, deviceId: fleetFindingDevices.deviceId })
+    .from(fleetFindingDevices)
+    .innerJoin(devices, eq(fleetFindingDevices.deviceId, devices.id))
+    .where(and(inArray(fleetFindingDevices.findingId, candidateFindingIds), inArray(devices.siteId, allowedSiteIds)));
+
+  const deviceIdsByFinding = new Map<string, Set<string>>();
+  for (const m of memberRows) {
+    const set = deviceIdsByFinding.get(m.findingId) ?? new Set<string>();
+    set.add(m.deviceId);
+    deviceIdsByFinding.set(m.findingId, set);
+  }
+  return deviceIdsByFinding;
+}
+
 function buildOrgCondition(auth: AuthContext, requestedOrgId: string | undefined): SQL | undefined {
   if (requestedOrgId) {
     return eq(fleetFindings.orgId, requestedOrgId);
@@ -282,24 +314,11 @@ export async function listFleetFindings(
   let scoped = rows;
 
   if (auth.allowedSiteIds !== undefined) {
-    const allowedSiteIds = auth.allowedSiteIds;
     const candidateIds = rows.map((r) => r.id);
+    const deviceIdsByFinding = await findingDeviceIdsBySite(candidateIds, auth.allowedSiteIds);
 
-    if (allowedSiteIds.length === 0 || candidateIds.length === 0) {
+    if (deviceIdsByFinding === null) {
       return { findings: [], total: 0 };
-    }
-
-    const memberRows = await db
-      .select({ findingId: fleetFindingDevices.findingId, deviceId: fleetFindingDevices.deviceId })
-      .from(fleetFindingDevices)
-      .innerJoin(devices, eq(fleetFindingDevices.deviceId, devices.id))
-      .where(and(inArray(fleetFindingDevices.findingId, candidateIds), inArray(devices.siteId, allowedSiteIds)));
-
-    const deviceIdsByFinding = new Map<string, Set<string>>();
-    for (const m of memberRows) {
-      const set = deviceIdsByFinding.get(m.findingId) ?? new Set<string>();
-      set.add(m.deviceId);
-      deviceIdsByFinding.set(m.findingId, set);
     }
 
     scoped = rows
@@ -347,22 +366,14 @@ export async function getFleetFindingCounts(auth: AuthContext): Promise<FleetFin
   let scoped = rows;
 
   if (auth.allowedSiteIds !== undefined) {
-    const allowedSiteIds = auth.allowedSiteIds;
-    if (allowedSiteIds.length === 0 || rows.length === 0) {
+    const candidateIds = rows.map((r) => r.id);
+    const deviceIdsByFinding = await findingDeviceIdsBySite(candidateIds, auth.allowedSiteIds);
+
+    if (deviceIdsByFinding === null) {
       return { total: 0, byOrg: {} };
     }
 
-    const candidateIds = rows.map((r) => r.id);
-    const memberRows = (await db
-      .select({ findingId: fleetFindingDevices.findingId })
-      .from(fleetFindingDevices)
-      .innerJoin(devices, eq(fleetFindingDevices.deviceId, devices.id))
-      .where(
-        and(inArray(fleetFindingDevices.findingId, candidateIds), inArray(devices.siteId, allowedSiteIds))
-      )) as Array<{ findingId: string }>;
-
-    const visibleFindingIds = new Set(memberRows.map((m) => m.findingId));
-    scoped = rows.filter((r) => visibleFindingIds.has(r.id));
+    scoped = rows.filter((r) => (deviceIdsByFinding.get(r.id)?.size ?? 0) > 0);
   }
 
   const byOrg: Record<string, number> = {};

--- a/apps/mobile/src/screens/systems/SystemsScreen.tsx
+++ b/apps/mobile/src/screens/systems/SystemsScreen.tsx
@@ -43,6 +43,7 @@ import {
 } from './undoAck';
 import { UndoToast } from '../../components/UndoToast';
 import { FilterChip } from './components/FilterChip';
+import { FindingsRow } from './components/FindingsRow';
 import { Hero } from './components/Hero';
 import { IssueRow } from './components/IssueRow';
 import { OrgRow } from './components/OrgRow';
@@ -156,6 +157,8 @@ export function SystemsScreen() {
     activeIssues,
     recent,
     orgRollups,
+    findingsCount,
+    activeFindingsSummary,
     filterOrgId,
     filterOrgName,
     filterOrgDeviceCounts,
@@ -205,6 +208,7 @@ export function SystemsScreen() {
           devices: filterOrgDeviceCounts ?? { total: 0, online: 0, offline: 0, maintenance: 0 },
         }
       : null,
+    findingsCount,
   );
 
   useFocusEffect(
@@ -562,8 +566,8 @@ export function SystemsScreen() {
 
   const showOrgs = !filterOrgId && orgRollups.length > 0;
   const showRecent = recent.length > 0;
-  const showActiveIssues = visibleIssues.length > 0;
-  const showActiveSkeleton = loading && activeIssues.length === 0;
+  const showActiveIssues = visibleIssues.length > 0 || activeFindingsSummary.length > 0;
+  const showActiveSkeleton = loading && activeIssues.length === 0 && activeFindingsSummary.length === 0;
   // Every section can hide independently, and the org filter suppresses the
   // Organizations list outright — so a filtered org with nothing outstanding
   // rendered a completely blank page under the chip, indistinguishable from a
@@ -746,7 +750,23 @@ export function SystemsScreen() {
                 onSwipeAcknowledge={() => scheduleAcknowledge([alert.id])}
                 selectable={selecting}
                 selected={selected.has(alert.id)}
-                showDivider={idx < visibleIssues.length - 1}
+                showDivider={idx < visibleIssues.length - 1 || activeFindingsSummary.length > 0}
+                dividerColor={theme.border}
+              />
+            ))}
+            {/*
+              Open fleet-hygiene findings (#5139 / #5117 decision 1) — one
+              summary row per org, visually distinct from alert rows (no
+              severity dot, "Finding" label). The counts endpoint returns
+              aggregate counts rather than individual finding records, so
+              there is no per-finding row or tap-through yet (later item).
+            */}
+            {activeFindingsSummary.map((finding, idx) => (
+              <FindingsRow
+                key={finding.orgId}
+                orgName={finding.orgName}
+                count={finding.count}
+                showDivider={idx < activeFindingsSummary.length - 1}
                 dividerColor={theme.border}
               />
             ))}

--- a/apps/mobile/src/screens/systems/SystemsScreen.tsx
+++ b/apps/mobile/src/screens/systems/SystemsScreen.tsx
@@ -158,6 +158,7 @@ export function SystemsScreen() {
     recent,
     orgRollups,
     findingsCount,
+    findingsOrgIds,
     activeFindingsSummary,
     filterOrgId,
     filterOrgName,
@@ -209,6 +210,7 @@ export function SystemsScreen() {
         }
       : null,
     findingsCount,
+    findingsOrgIds,
   );
 
   useFocusEffect(

--- a/apps/mobile/src/screens/systems/components/FindingsRow.tsx
+++ b/apps/mobile/src/screens/systems/components/FindingsRow.tsx
@@ -1,0 +1,74 @@
+import { Text, View } from 'react-native';
+import Animated, { FadeIn, FadeOut, LinearTransition } from 'react-native-reanimated';
+
+import { useApprovalTheme, spacing, type } from '../../../theme';
+
+interface Props {
+  orgName: string;
+  count: number;
+  showDivider?: boolean;
+  dividerColor?: string;
+}
+
+/**
+ * One ACTIVE ISSUES row summarizing an org's open fleet-hygiene findings
+ * (#5139 / #5117 decision 1) — VSS/Universal Print/Intel ME/SCEP failures,
+ * the same findings `get_fleet_findings` reports to the AI. Visually
+ * distinct from `IssueRow` (alerts): a "Finding" label instead of a severity
+ * dot, and no swipe-to-acknowledge or selection — findings are acted on from
+ * the AI/web flow today. Display-only; tap-through to a findings detail
+ * screen is a later item (#5117).
+ */
+export function FindingsRow({ orgName, count, showDivider, dividerColor }: Props) {
+  const theme = useApprovalTheme('dark');
+
+  return (
+    <Animated.View
+      entering={FadeIn.duration(180)}
+      exiting={FadeOut.duration(180)}
+      layout={LinearTransition.duration(220)}
+    >
+      <View
+        style={{
+          paddingHorizontal: spacing[6],
+          paddingVertical: spacing[3],
+          flexDirection: 'row',
+          alignItems: 'center',
+        }}
+      >
+        <View
+          accessibilityRole="text"
+          style={{
+            paddingHorizontal: spacing[2],
+            paddingVertical: 2,
+            borderRadius: 4,
+            backgroundColor: theme.bg2,
+            marginRight: spacing[3],
+          }}
+        >
+          <Text style={[type.meta, { color: theme.textMd, fontSize: 10 }]}>Finding</Text>
+        </View>
+        <View style={{ flex: 1, marginRight: spacing[3] }}>
+          <Text style={[type.bodyMd, { color: theme.textHi }]} numberOfLines={1}>
+            {count} open {count === 1 ? 'finding' : 'findings'}
+          </Text>
+          <Text
+            style={[type.meta, { color: theme.textMd, marginTop: spacing[1] }]}
+            numberOfLines={1}
+          >
+            {orgName}
+          </Text>
+        </View>
+      </View>
+      {showDivider ? (
+        <View
+          style={{
+            height: 1,
+            backgroundColor: dividerColor ?? theme.border,
+            marginLeft: spacing[6],
+          }}
+        />
+      ) : null}
+    </Animated.View>
+  );
+}

--- a/apps/mobile/src/screens/systems/components/orgRowCopy.test.ts
+++ b/apps/mobile/src/screens/systems/components/orgRowCopy.test.ts
@@ -31,4 +31,13 @@ describe('orgRowSubtitle', () => {
   it('prioritizes offline over issues when both are present', () => {
     expect(orgRowSubtitle({ deviceCount: 10, offlineCount: 3, issueCount: 4 })).toBe('10 devices · 3 offline');
   });
+
+  // #5139: `issueCount` already folds open fleet findings alongside active
+  // alerts upstream (see useSystemsData's `orgRollups` / `foldFindingsIntoOrgRollups`)
+  // — this function has no opinion on the split, it only formats whatever
+  // total it's handed.
+  it('does not distinguish alert-sourced issues from finding-sourced ones — it formats the total', () => {
+    // 1 alert + 2 findings folded upstream into issueCount = 3.
+    expect(orgRowSubtitle({ deviceCount: 5, offlineCount: 0, issueCount: 3 })).toBe('5 devices · 3 issues');
+  });
 });

--- a/apps/mobile/src/screens/systems/heroCopy.test.ts
+++ b/apps/mobile/src/screens/systems/heroCopy.test.ts
@@ -228,4 +228,41 @@ describe('deriveHeroState', () => {
       expect(s.legend).toBeNull();
     });
   });
+
+  describe('open fleet findings fold into the issue count (#5139)', () => {
+    it('a lone open finding, with zero active alerts, still reads as "1 issue."', () => {
+      const s = deriveHeroState(summary({ total: 5, online: 5 }), [], null, 1);
+      expect(s.copy).toBe('1 issue.');
+    });
+
+    it('findings add to the active-alert count rather than replacing it', () => {
+      const s = deriveHeroState(
+        summary({ total: 10, online: 10 }),
+        [alert({ id: 'a1', metadata: { orgId: 'org-1' } })],
+        null,
+        2,
+      );
+      expect(s.copy).toBe('3 issues.');
+    });
+
+    it('defaults to 0 findings when the argument is omitted (back-compat with existing callers)', () => {
+      const s = deriveHeroState(summary({ total: 5, online: 5 }), []);
+      expect(s.copy).toBe('5 devices, all healthy.');
+    });
+
+    it('zero findings and zero alerts still reads "all healthy"', () => {
+      const s = deriveHeroState(summary({ total: 5, online: 5 }), [], null, 0);
+      expect(s.copy).toBe('5 devices, all healthy.');
+    });
+
+    it('org-scoped hero folds in that org\'s own findings count', () => {
+      const s = deriveHeroState(
+        summary({ total: 500, online: 500 }),
+        [],
+        { name: 'Morning Fresh Dairy', devices: { total: 12, online: 12, offline: 0, maintenance: 0 } },
+        1,
+      );
+      expect(s.copy).toBe('Morning Fresh Dairy: 1 issue.');
+    });
+  });
 });

--- a/apps/mobile/src/screens/systems/heroCopy.test.ts
+++ b/apps/mobile/src/screens/systems/heroCopy.test.ts
@@ -264,5 +264,34 @@ describe('deriveHeroState', () => {
       );
       expect(s.copy).toBe('Morning Fresh Dairy: 1 issue.');
     });
+
+    it('a findings-only spread across multiple orgs still says "across N organizations" (no active alerts to derive it from)', () => {
+      // Regression: orgCount used to be derived from activeIssues alone, so a
+      // fleet with 0 active alerts but 3 open findings spread across 3 orgs
+      // rendered "3 issues." instead of "3 issues across 3 organizations." —
+      // the copy ladder's "across N organizations" promise silently broke for
+      // a findings-only fleet.
+      const s = deriveHeroState(
+        summary({ total: 10, online: 10 }),
+        [],
+        null,
+        3,
+        ['org-1', 'org-2', 'org-3'],
+      );
+      expect(s.copy).toBe('3 issues across 3 organizations.');
+    });
+
+    it('merges alert orgs and findings orgs into one unique count, not a sum', () => {
+      const s = deriveHeroState(
+        summary({ total: 10, online: 10 }),
+        [alert({ id: 'a1', metadata: { orgId: 'org-1' } })],
+        null,
+        1,
+        ['org-1'], // same org as the alert — must not double-count to 2 orgs
+      );
+      // orgCount resolves to 1 (both issues are in org-1), so the copy ladder
+      // takes the single-org branch, not "across N organizations."
+      expect(s.copy).toBe('2 issues.');
+    });
   });
 });

--- a/apps/mobile/src/screens/systems/heroCopy.ts
+++ b/apps/mobile/src/screens/systems/heroCopy.ts
@@ -38,6 +38,14 @@ export function deriveHeroState(
   // copy ladder but do NOT contribute to the critical/warning bar segments
   // below, which stay alert-severity-driven.
   findingsCount = 0,
+  // Org ids the findings above belong to (fleet-wide only — pass [] when
+  // `orgScope` is set, since `orgCount` is forced to 1 there regardless).
+  // Merged with `activeIssues`' own org ids to compute "across N
+  // organizations": deriving `orgCount` from `activeIssues` alone undercounts
+  // a fleet with open findings but zero active alerts, e.g. 0 alerts + 3
+  // findings across 3 orgs used to render "3 issues." instead of "3 issues
+  // across 3 organizations."
+  findingsOrgIds: readonly string[] = [],
 ): HeroState {
   const deviceCounts = orgScope ? orgScope.devices : summary?.devices ?? null;
   if (!deviceCounts) {
@@ -63,7 +71,7 @@ export function deriveHeroState(
   const issueCount = activeIssues.length + findingsCount;
   // Scoped to a single org by construction — "issues across N organizations"
   // never applies once a filter is active.
-  const orgCount = orgScope ? 1 : uniqueOrgCount(activeIssues);
+  const orgCount = orgScope ? 1 : uniqueOrgCount(activeIssues, findingsOrgIds);
 
   // Bar segments must match the headline. We derive critical / warning
   // from the *unacked* activeIssues (same source the headline counts), not
@@ -140,13 +148,14 @@ export function deriveHeroState(
   };
 }
 
-function uniqueOrgCount(alerts: Alert[]): number {
+function uniqueOrgCount(alerts: Alert[], findingsOrgIds: readonly string[] = []): number {
   const orgs = new Set<string>();
   for (const a of alerts) {
     const orgId = (a.metadata as Record<string, unknown> | undefined)?.orgId;
     if (typeof orgId === 'string') orgs.add(orgId);
   }
-  // Fallback when alerts don't carry orgId metadata: assume single org so
+  for (const orgId of findingsOrgIds) orgs.add(orgId);
+  // Fallback when neither source carries an org id: assume single org so
   // copy reads "{n} issues" rather than "{n} issues across 0 organizations".
   return orgs.size === 0 ? 1 : orgs.size;
 }

--- a/apps/mobile/src/screens/systems/heroCopy.ts
+++ b/apps/mobile/src/screens/systems/heroCopy.ts
@@ -30,6 +30,14 @@ export function deriveHeroState(
   summary: MobileSummary | null,
   activeIssues: Alert[],
   orgScope: OrgHeroScope | null = null,
+  // Open fleet-hygiene finding count (#5139 / #5117 decision 1), already
+  // scoped by the caller to match `orgScope` (fleet-wide total when
+  // `orgScope` is null, that org's own count otherwise) — this function does
+  // no org filtering of its own, same contract as `activeIssues`. Findings
+  // carry no severity here (only a count), so they add to the issue count and
+  // copy ladder but do NOT contribute to the critical/warning bar segments
+  // below, which stay alert-severity-driven.
+  findingsCount = 0,
 ): HeroState {
   const deviceCounts = orgScope ? orgScope.devices : summary?.devices ?? null;
   if (!deviceCounts) {
@@ -52,7 +60,7 @@ export function deriveHeroState(
   const online = deviceCounts.online;
   const offline = deviceCounts.offline;
   const maintenance = deviceCounts.maintenance;
-  const issueCount = activeIssues.length;
+  const issueCount = activeIssues.length + findingsCount;
   // Scoped to a single org by construction — "issues across N organizations"
   // never applies once a filter is active.
   const orgCount = orgScope ? 1 : uniqueOrgCount(activeIssues);

--- a/apps/mobile/src/screens/systems/mergeSystemsResults.test.ts
+++ b/apps/mobile/src/screens/systems/mergeSystemsResults.test.ts
@@ -10,7 +10,7 @@ import {
   resolveOrgName,
   type SystemsSlices,
 } from './mergeSystemsResults';
-import type { Alert, Device } from '../../services/api';
+import type { Alert, Device, FleetFindingCounts } from '../../services/api';
 
 const device = (id: string) => ({ id, name: id } as unknown as Device);
 const alert = (id: string) => ({ id } as unknown as Alert);
@@ -24,6 +24,7 @@ const previous: SystemsSlices = {
   activeAlerts: [alert('act-old')],
   devices: [device('d-old')],
   orgs: [{ id: 'o1', name: 'Org One' }],
+  findings: { total: 1, byOrg: { o1: 1 } } as FleetFindingCounts,
 };
 
 const allOk = {
@@ -32,15 +33,17 @@ const allOk = {
   activeAlerts: ok([alert('act-new')]),
   devices: ok([device('d1'), device('d2')]),
   orgs: ok([{ id: 'o2', name: 'Org Two' }]),
+  findings: ok({ total: 2, byOrg: { o2: 2 } } as FleetFindingCounts),
 };
 
 describe('mergeSystemsResults', () => {
-  it('takes every fresh value when all four succeed, and reports no error', () => {
+  it('takes every fresh value when all six succeed, and reports no error', () => {
     const { slices, error, failed } = mergeSystemsResults(previous, allOk);
     expect(slices.devices).toHaveLength(2);
     expect(slices.alerts[0].id).toBe('a-new');
     expect(slices.activeAlerts[0].id).toBe('act-new');
     expect(slices.orgs[0].id).toBe('o2');
+    expect(slices.findings).toEqual({ total: 2, byOrg: { o2: 2 } });
     expect(error).toBeNull();
     expect(failed).toEqual([]);
   });
@@ -77,11 +80,38 @@ describe('mergeSystemsResults', () => {
       activeAlerts: bad(new Error('x')),
       devices: bad(new Error('x')),
       orgs: bad(new Error('x')),
+      findings: bad(new Error('x')),
     });
     expect(error).toBe(ALL_FAILED_MESSAGE);
-    expect(failed).toHaveLength(5);
+    expect(failed).toHaveLength(6);
     // Nothing is blanked even in the total-failure case — stale beats empty.
     expect(slices).toEqual(previous);
+  });
+
+  it('does NOT report all-failed when only five of the six reject (regression: stale slice-count threshold)', () => {
+    // If the "everything failed" total were still hardcoded at 5, a findings
+    // rejection landing alongside four others would have wrongly tripped
+    // ALL_FAILED_MESSAGE even though `orgs` came back fine.
+    const { error, failed } = mergeSystemsResults(previous, {
+      summary: bad(new Error('x')),
+      alerts: bad(new Error('x')),
+      activeAlerts: bad(new Error('x')),
+      devices: bad(new Error('x')),
+      orgs: ok([{ id: 'o2', name: 'Org Two' }]),
+      findings: bad(new Error('x')),
+    });
+    expect(failed).toHaveLength(5);
+    expect(error).toBe(PARTIAL_FAILED_MESSAGE);
+  });
+
+  it('degrades findings to the last-known value (alerts-only view) when the findings fetch fails', () => {
+    const { slices, error } = mergeSystemsResults(previous, {
+      ...allOk,
+      findings: bad(new Error('getFleetFindingCounts failed: 500')),
+    });
+    expect(slices.findings).toEqual(previous.findings);
+    expect(slices.alerts[0].id).toBe('a-new'); // unaffected
+    expect(error).toBe(PARTIAL_FAILED_MESSAGE);
   });
 
   it('treats an empty successful result as real data, not a failure', () => {

--- a/apps/mobile/src/screens/systems/mergeSystemsResults.ts
+++ b/apps/mobile/src/screens/systems/mergeSystemsResults.ts
@@ -1,8 +1,8 @@
-import type { Alert, Device } from '../../services/api';
+import type { Alert, Device, FleetFindingCounts } from '../../services/api';
 import type { MobileSummary, OrganizationSummary } from '../../services/systems';
 
 /**
- * The five independent fetches behind the Systems screen, in the order
+ * The six independent fetches behind the Systems screen, in the order
  * `fetchAll` issues them.
  */
 export interface SystemsSlices {
@@ -21,6 +21,13 @@ export interface SystemsSlices {
   activeAlerts: Alert[];
   devices: Device[];
   orgs: OrganizationSummary[];
+  /**
+   * Open fleet-hygiene finding counts (#5139 / #5117 decision 1), folded into
+   * the same issue count active alerts drive. `null` until the first
+   * successful fetch — every consumer treats that the same as "0 findings"
+   * (alerts-only), never a crash, matching the degrade-gracefully contract.
+   */
+  findings: FleetFindingCounts | null;
 }
 
 export interface MergeOutcome {
@@ -57,10 +64,11 @@ export function mergeSystemsResults(
     activeAlerts: PromiseSettledResult<Alert[]>;
     devices: PromiseSettledResult<Device[]>;
     orgs: PromiseSettledResult<OrganizationSummary[]>;
+    findings: PromiseSettledResult<FleetFindingCounts | null>;
   }
 ): MergeOutcome {
   const failed: Array<keyof SystemsSlices> = [];
-  for (const key of ['summary', 'alerts', 'activeAlerts', 'devices', 'orgs'] as const) {
+  for (const key of ['summary', 'alerts', 'activeAlerts', 'devices', 'orgs', 'findings'] as const) {
     if (results[key].status === 'rejected') failed.push(key);
   }
 
@@ -70,9 +78,10 @@ export function mergeSystemsResults(
     activeAlerts: take(results.activeAlerts, previous.activeAlerts),
     devices: take(results.devices, previous.devices),
     orgs: take(results.orgs, previous.orgs),
+    findings: take(results.findings, previous.findings),
   };
 
-  const total = 5;
+  const total = 6;
   let error: string | null = null;
   if (failed.length === total) {
     error = ALL_FAILED_MESSAGE;
@@ -87,7 +96,7 @@ export function mergeSystemsResults(
 export function rejectionReasons(results: {
   [K in keyof SystemsSlices]: PromiseSettledResult<unknown>;
 }): unknown[] {
-  return (['summary', 'alerts', 'activeAlerts', 'devices', 'orgs'] as const)
+  return (['summary', 'alerts', 'activeAlerts', 'devices', 'orgs', 'findings'] as const)
     .map((k) => results[k])
     .filter((r): r is PromiseRejectedResult => r.status === 'rejected')
     .map((r) => r.reason);

--- a/apps/mobile/src/screens/systems/mergeSystemsResults.ts
+++ b/apps/mobile/src/screens/systems/mergeSystemsResults.ts
@@ -46,12 +46,13 @@ function take<T>(result: PromiseSettledResult<T>, previous: T): T {
 }
 
 /**
- * Merge the settled results of the five Systems fetches over the previously
+ * Merge the settled results of the six Systems fetches over the previously
  * rendered data.
  *
- * The screen used to issue these through `Promise.all`, so a single rejection
- * discarded ALL FIVE results — a transient failure on, say, the summary call
- * blanked a fleet of devices that had loaded perfectly well, and the user saw an
+ * The screen used to issue these through `Promise.all` (back when there were
+ * five), so a single rejection discarded ALL of them — a transient failure
+ * on, say, the summary call blanked a fleet of devices that had loaded
+ * perfectly well, and the user saw an
  * empty screen with a generic error. Each slice now stands on its own: whatever
  * arrived is rendered, whatever failed keeps its last-known value, and the error
  * line distinguishes "nothing loaded" from "some of this is stale".

--- a/apps/mobile/src/screens/systems/orgFindingsRollup.test.ts
+++ b/apps/mobile/src/screens/systems/orgFindingsRollup.test.ts
@@ -16,6 +16,7 @@ describe('foldFindingsIntoOrgRollups (#5139)', () => {
       name: 'Acme',
       deviceCount: 3,
       issueCount: 1,
+      offlineCount: 0,
       nameUnavailable: false,
       ...overrides,
     };
@@ -29,7 +30,9 @@ describe('foldFindingsIntoOrgRollups (#5139)', () => {
   it('creates a rollup for an org with open findings but no devices/alerts', () => {
     const result = foldFindingsIntoOrgRollups([], { 'org-2': 4 }, ORGS, false);
     expect(result).toEqual([
-      expect.objectContaining({ id: 'org-2', name: 'Beta Corp', deviceCount: 0, issueCount: 4 }),
+      // offlineCount: 0 — #5115's field, folded in here too since this org
+      // has no device data at all to report as offline.
+      expect.objectContaining({ id: 'org-2', name: 'Beta Corp', deviceCount: 0, issueCount: 4, offlineCount: 0 }),
     ]);
   });
 

--- a/apps/mobile/src/screens/systems/orgFindingsRollup.test.ts
+++ b/apps/mobile/src/screens/systems/orgFindingsRollup.test.ts
@@ -78,4 +78,13 @@ describe('buildFindingsSummary (#5139)', () => {
     const result = buildFindingsSummary({ 'org-3': 1 }, [], true, null);
     expect(result[0].orgName).toBe('Organization unavailable');
   });
+
+  it('labels an org id genuinely absent from a successfully-loaded orgs list as "unknown", not "unavailable"', () => {
+    // orgsFailed=false here — the orgs list loaded fine, it just doesn't
+    // contain this id (visibility/pagination mismatch between the findings
+    // counts response and the orgs list), which is a different case from the
+    // orgsFailed=true test above and must render distinctly.
+    const result = buildFindingsSummary({ 'org-9': 1 }, ORGS, false, null);
+    expect(result[0].orgName).toBe('Unknown organization');
+  });
 });

--- a/apps/mobile/src/screens/systems/orgFindingsRollup.test.ts
+++ b/apps/mobile/src/screens/systems/orgFindingsRollup.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildFindingsSummary, foldFindingsIntoOrgRollups } from './orgFindingsRollup';
+import type { OrgRollup } from './useSystemsData';
+import type { OrganizationSummary } from '../../services/systems';
+
+const ORGS: OrganizationSummary[] = [
+  { id: 'org-1', name: 'Acme' },
+  { id: 'org-2', name: 'Beta Corp' },
+];
+
+describe('foldFindingsIntoOrgRollups (#5139)', () => {
+  function rollup(overrides: Partial<OrgRollup> = {}): OrgRollup {
+    return {
+      id: 'org-1',
+      name: 'Acme',
+      deviceCount: 3,
+      issueCount: 1,
+      nameUnavailable: false,
+      ...overrides,
+    };
+  }
+
+  it('adds the finding count onto an existing rollup issueCount', () => {
+    const result = foldFindingsIntoOrgRollups([rollup({ issueCount: 1 })], { 'org-1': 2 }, ORGS, false);
+    expect(result).toEqual([expect.objectContaining({ id: 'org-1', issueCount: 3 })]);
+  });
+
+  it('creates a rollup for an org with open findings but no devices/alerts', () => {
+    const result = foldFindingsIntoOrgRollups([], { 'org-2': 4 }, ORGS, false);
+    expect(result).toEqual([
+      expect.objectContaining({ id: 'org-2', name: 'Beta Corp', deviceCount: 0, issueCount: 4 }),
+    ]);
+  });
+
+  it('ignores a zero count entry', () => {
+    const result = foldFindingsIntoOrgRollups([rollup({ issueCount: 0 })], { 'org-1': 0 }, ORGS, false);
+    expect(result).toEqual([expect.objectContaining({ id: 'org-1', issueCount: 0 })]);
+  });
+
+  it('is a no-op (returns the input unchanged) when byOrg is undefined — degrade to alerts-only', () => {
+    const input = [rollup({ issueCount: 1 })];
+    expect(foldFindingsIntoOrgRollups(input, undefined, ORGS, false)).toEqual(input);
+  });
+
+  it('re-sorts by the NEW issueCount, highest first', () => {
+    const result = foldFindingsIntoOrgRollups(
+      [rollup({ id: 'org-1', name: 'Acme', issueCount: 1 }), rollup({ id: 'org-2', name: 'Beta Corp', issueCount: 1 })],
+      { 'org-2': 5 },
+      ORGS,
+      false,
+    );
+    expect(result.map((r) => r.id)).toEqual(['org-2', 'org-1']);
+  });
+});
+
+describe('buildFindingsSummary (#5139)', () => {
+  it('returns one entry per org with a positive open-finding count', () => {
+    const result = buildFindingsSummary({ 'org-1': 2, 'org-2': 0 }, ORGS, false, null);
+    expect(result).toEqual([{ orgId: 'org-1', orgName: 'Acme', count: 2 }]);
+  });
+
+  it('is empty when byOrg is undefined', () => {
+    expect(buildFindingsSummary(undefined, ORGS, false, null)).toEqual([]);
+  });
+
+  it('scopes to the active org filter', () => {
+    const result = buildFindingsSummary({ 'org-1': 2, 'org-2': 3 }, ORGS, false, 'org-2');
+    expect(result).toEqual([{ orgId: 'org-2', orgName: 'Beta Corp', count: 3 }]);
+  });
+
+  it('sorts by count descending', () => {
+    const result = buildFindingsSummary({ 'org-1': 1, 'org-2': 9 }, ORGS, false, null);
+    expect(result.map((r) => r.orgId)).toEqual(['org-2', 'org-1']);
+  });
+
+  it('labels an unresolved org name as unavailable rather than "unknown" when the orgs fetch failed', () => {
+    const result = buildFindingsSummary({ 'org-3': 1 }, [], true, null);
+    expect(result[0].orgName).toBe('Organization unavailable');
+  });
+});

--- a/apps/mobile/src/screens/systems/orgFindingsRollup.ts
+++ b/apps/mobile/src/screens/systems/orgFindingsRollup.ts
@@ -34,6 +34,9 @@ export function foldFindingsIntoOrgRollups(
         name: resolved.name,
         deviceCount: 0,
         issueCount: count,
+        // #5115: an org that has open findings but no devices/alerts of its
+        // own has nothing to report as offline either.
+        offlineCount: 0,
         nameUnavailable: resolved.unavailable,
       });
     }

--- a/apps/mobile/src/screens/systems/orgFindingsRollup.ts
+++ b/apps/mobile/src/screens/systems/orgFindingsRollup.ts
@@ -1,0 +1,78 @@
+import { resolveOrgName } from './mergeSystemsResults';
+import type { OrgRollup } from './useSystemsData';
+import type { OrganizationSummary } from '../../services/systems';
+
+/**
+ * Fold open fleet-hygiene finding counts (#5139 / #5117 decision 1) into the
+ * per-org rollups `useSystemsData` already builds from devices + active
+ * alerts. Kept as a standalone pure function (rather than inline in the
+ * `orgRollups` useMemo) so it can be unit-tested without importing
+ * `useSystemsData.ts` itself, which pulls in React Native transitively.
+ *
+ * Creates a rollup for an org that has open findings but no devices/alerts
+ * of its own — such an org would otherwise never appear in ORGANIZATIONS
+ * even though it now has something to triage.
+ */
+export function foldFindingsIntoOrgRollups(
+  rollups: readonly OrgRollup[],
+  byOrg: Record<string, number> | undefined,
+  orgs: ReadonlyArray<{ id: string; name: string }>,
+  orgsFailed: boolean,
+): OrgRollup[] {
+  if (!byOrg) return [...rollups];
+
+  const byId = new Map<string, OrgRollup>(rollups.map((r) => [r.id, { ...r }]));
+  for (const [orgId, count] of Object.entries(byOrg)) {
+    if (count <= 0) continue;
+    const existing = byId.get(orgId);
+    if (existing) {
+      existing.issueCount += count;
+    } else {
+      const resolved = resolveOrgName(orgs, orgId, orgsFailed);
+      byId.set(orgId, {
+        id: orgId,
+        name: resolved.name,
+        deviceCount: 0,
+        issueCount: count,
+        nameUnavailable: resolved.unavailable,
+      });
+    }
+  }
+
+  return Array.from(byId.values()).sort((a, b) => {
+    if (b.issueCount !== a.issueCount) return b.issueCount - a.issueCount;
+    return a.name.localeCompare(b.name);
+  });
+}
+
+export interface FindingsOrgSummary {
+  orgId: string;
+  orgName: string;
+  count: number;
+}
+
+/**
+ * Per-org open-finding summaries for the Systems ACTIVE ISSUES list (#5139):
+ * one row per org with open findings, scoped to the active org filter when
+ * one is set. Findings have no per-row detail here (only a count) — the
+ * screen renders one summary row per org rather than one row per finding,
+ * since the counts endpoint intentionally does not return individual finding
+ * records (see routes/fleetFindings.ts's `/counts`).
+ */
+export function buildFindingsSummary(
+  byOrg: Record<string, number> | undefined,
+  orgs: ReadonlyArray<{ id: string; name: string }>,
+  orgsFailed: boolean,
+  filterOrgId: string | null,
+): FindingsOrgSummary[] {
+  const entries = Object.entries(byOrg ?? {}).filter(([, count]) => count > 0);
+  const scoped = filterOrgId ? entries.filter(([orgId]) => orgId === filterOrgId) : entries;
+
+  return scoped
+    .map(([orgId, count]) => ({
+      orgId,
+      orgName: resolveOrgName(orgs, orgId, orgsFailed).name,
+      count,
+    }))
+    .sort((a, b) => b.count - a.count || a.orgName.localeCompare(b.orgName));
+}

--- a/apps/mobile/src/screens/systems/useSystemsData.ts
+++ b/apps/mobile/src/screens/systems/useSystemsData.ts
@@ -2,8 +2,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { reportInternalError } from '../../lib/errorReporting';
 
-import type { Alert, Device } from '../../services/api';
-import { getAlerts, getAlertsPaged, getDevicesPaged } from '../../services/api';
+import type { Alert, Device, FleetFindingCounts } from '../../services/api';
+import { getAlerts, getAlertsPaged, getDevicesPaged, getFleetFindingCounts } from '../../services/api';
 import {
   addNotificationReceivedListener,
   parseAlertNotification,
@@ -23,6 +23,13 @@ import {
   resolveOrgName,
   type SystemsSlices,
 } from './mergeSystemsResults';
+import {
+  buildFindingsSummary,
+  foldFindingsIntoOrgRollups,
+  type FindingsOrgSummary,
+} from './orgFindingsRollup';
+
+export type { FindingsOrgSummary } from './orgFindingsRollup';
 
 export interface OrgRollup {
   id: string;
@@ -46,6 +53,8 @@ export interface SystemsData {
   activeAlerts: Alert[];
   devices: Device[];
   orgs: OrganizationSummary[];
+  /** Open fleet-hygiene finding counts (#5139). Null until the first fetch lands. */
+  findings: FleetFindingCounts | null;
   loading: boolean;
   refreshing: boolean;
   error: string | null;
@@ -90,9 +99,10 @@ function alertOrgId(a: Alert): string | undefined {
   return typeof id === 'string' ? id : undefined;
 }
 
-// Fetches summary, alerts, activeAlerts, devices and orgs in parallel — five,
-// matching `const total = 5` in mergeSystemsResults. Miscounting here is not
-// cosmetic: that total is the threshold for "everything failed". Owns the local
+// Fetches summary, alerts, activeAlerts, devices, orgs and findings in
+// parallel — six, matching `const total = 6` in mergeSystemsResults.
+// Miscounting here is not cosmetic: that total is the threshold for
+// "everything failed". Owns the local
 // org-filter state so the screen reads filtered slices straight from the
 // hook. Failures keep last-known data; only the in-section error banner
 // flips.
@@ -103,6 +113,7 @@ export function useSystemsData() {
     activeAlerts: [],
     devices: [],
     orgs: [],
+    findings: null,
     loading: true,
     refreshing: false,
     error: null,
@@ -169,7 +180,7 @@ export function useSystemsData() {
       // still deserves it.
       let activeTruncated: boolean | null = null;
       let devicesTruncated: boolean | null = null;
-      const [summary, alerts, activeAlerts, devices, orgs] = await Promise.allSettled([
+      const [summary, alerts, activeAlerts, devices, orgs, findings] = await Promise.allSettled([
         getMobileSummary(),
         getAlerts('all'),
         getAlertsPaged('active').then((r) => {
@@ -181,8 +192,9 @@ export function useSystemsData() {
           return r.items;
         }),
         listOrganizations(),
+        getFleetFindingCounts(),
       ]);
-      const results = { summary, alerts, activeAlerts, devices, orgs };
+      const results = { summary, alerts, activeAlerts, devices, orgs, findings };
       // Bump BEFORE the reportInternalError loop below, which can throw and
       // is caught by the outer catch (see its comment): activeAlerts already
       // genuinely arrived by this point regardless of what happens next, so
@@ -237,7 +249,7 @@ export function useSystemsData() {
       });
       // Only count as a successful fetch when something arrived; an all-failed
       // round must not suppress the next focus refresh for a full minute.
-      const arrived = failedCount < 5;
+      const arrived = failedCount < 6;
       if (arrived) lastFetchAt.current = Date.now();
       return arrived;
     } catch (err) {
@@ -400,14 +412,18 @@ export function useSystemsData() {
       }
     }
 
-    return Array.from(byId.values()).sort((a, b) => {
-      if (b.issueCount !== a.issueCount) return b.issueCount - a.issueCount;
-      return a.name.localeCompare(b.name);
-    });
+    const base = Array.from(byId.values());
+    // Fold in open fleet findings (#5139) — same failed-fetch degrade as the
+    // rest of this memo: a failed findings fetch means `data.findings` is
+    // whatever last successfully loaded (or null on a first-load failure),
+    // and `foldFindingsIntoOrgRollups` treats an undefined byOrg as a no-op,
+    // so the rollup degrades to alerts-only rather than crashing or zeroing
+    // out real alert-derived counts.
+    return foldFindingsIntoOrgRollups(base, data.findings?.byOrg, data.orgs, orgsFailed);
     // `data.failed` belongs here: a failed orgs fetch keeps the SAME
     // `data.orgs` reference, so without it the memo never recomputes and the
     // rows keep their old authoritative labels.
-  }, [data.activeAlerts, data.devices, data.orgs, data.failed, filterOrgId]);
+  }, [data.activeAlerts, data.devices, data.orgs, data.findings, data.failed, filterOrgId]);
 
   const filterOrgName = useMemo(() => {
     if (!filterOrgId) return null;
@@ -434,11 +450,32 @@ export function useSystemsData() {
     return { total, online, offline, maintenance };
   }, [filterOrgId, data.devices]);
 
+  // Open-finding count for the hero (#5139): fleet-wide total, or that org's
+  // own count when a filter is active. `data.findings` stays null/stale on a
+  // failed fetch, which this naturally degrades to 0 — alerts-only, per the
+  // contract that a failed findings fetch must never crash the hero.
+  const findingsCount = useMemo(() => {
+    if (!data.findings) return 0;
+    if (filterOrgId) return data.findings.byOrg[filterOrgId] ?? 0;
+    return data.findings.total;
+  }, [data.findings, filterOrgId]);
+
+  // Per-org open-finding summary rows for ACTIVE ISSUES (#5139) — distinct
+  // from `activeIssues` (alerts): the findings counts endpoint returns
+  // aggregate counts, not individual finding records, so this renders one
+  // summary row per org rather than one row per finding.
+  const activeFindingsSummary = useMemo<FindingsOrgSummary[]>(
+    () => buildFindingsSummary(data.findings?.byOrg, data.orgs, data.failed.includes('orgs'), filterOrgId),
+    [data.findings, data.orgs, data.failed, filterOrgId],
+  );
+
   return {
     ...data,
     activeIssues,
     recent,
     orgRollups,
+    findingsCount,
+    activeFindingsSummary,
     filterOrgId,
     filterOrgName,
     filterOrgDeviceCounts,

--- a/apps/mobile/src/screens/systems/useSystemsData.ts
+++ b/apps/mobile/src/screens/systems/useSystemsData.ts
@@ -460,6 +460,18 @@ export function useSystemsData() {
     return data.findings.total;
   }, [data.findings, filterOrgId]);
 
+  // Org ids the fleet-wide findings above belong to, for the hero's "across N
+  // organizations" copy (#5139 follow-up: deriving that from `activeIssues`
+  // alone undercounted a fleet with open findings but zero active alerts).
+  // Empty when a filter is active — `deriveHeroState` forces `orgCount` to 1
+  // in that case regardless, same as it already does for `activeIssues`.
+  const findingsOrgIds = useMemo(() => {
+    if (!data.findings || filterOrgId) return [];
+    return Object.entries(data.findings.byOrg)
+      .filter(([, count]) => count > 0)
+      .map(([orgId]) => orgId);
+  }, [data.findings, filterOrgId]);
+
   // Per-org open-finding summary rows for ACTIVE ISSUES (#5139) — distinct
   // from `activeIssues` (alerts): the findings counts endpoint returns
   // aggregate counts, not individual finding records, so this renders one
@@ -475,6 +487,7 @@ export function useSystemsData() {
     recent,
     orgRollups,
     findingsCount,
+    findingsOrgIds,
     activeFindingsSummary,
     filterOrgId,
     filterOrgName,

--- a/apps/mobile/src/services/api.ts
+++ b/apps/mobile/src/services/api.ts
@@ -1129,6 +1129,24 @@ export async function getDevice(id: string): Promise<Device> {
   return mapDevice(response);
 }
 
+export interface FleetFindingCounts {
+  total: number;
+  byOrg: Record<string, number>;
+}
+
+/**
+ * Calls GET /api/v1/fleet/findings/counts — open fleet-hygiene finding
+ * counts per org, plus the fleet total (#5139 / #5117 decision 1). Folds
+ * fleet findings (VSS/Universal Print/Intel ME/SCEP failures, etc.) into the
+ * same "issue count" the AI's get_fleet_findings tool already reports, so
+ * the Systems tab shows the same picture. This route lives outside the
+ * `/mobile` surface, so it goes through the core `/api/v1` prefix like
+ * `getDevice` above, not the `/mobile`-prefixed `request()` helper.
+ */
+export async function getFleetFindingCounts(): Promise<FleetFindingCounts> {
+  return requestWithPrefix<FleetFindingCounts>('/fleet/findings/counts', API_CORE_PREFIX);
+}
+
 export async function getDeviceMetrics(id: string): Promise<Device['metrics']> {
   // GET /devices/:id/metrics (apps/api/src/routes/devices/metrics.ts) returns
   // buckets keyed `cpu`/`ram`/`disk` (aggregateMetricsByInterval), not


### PR DESCRIPTION
## Summary

Decision 1 of #5117 (Todd, 2026-09-06): fold open fleet findings into the Systems tab's issue count so a technician opening Systems sees the same picture the AI gives via `get_fleet_findings`.

- **API**: `GET /fleet/findings/counts` returns `{ total, byOrg: { [orgId]: count } }` for OPEN findings visible to the caller (`getFleetFindingCounts` in `services/fleetFindings/query.ts`), reusing `listFleetFindings`' org-scoping (`auth.orgCondition`) and site-axis narrowing (fail-closed for site-restricted callers). Only `status = 'open'` counts — acknowledged/dismissed/resolved never inflate it.
- **Mobile**: `useSystemsData` adds findings as a sixth parallel fetch (`mergeSystemsResults`'s slice-count threshold updated 5→6, with a regression test guarding the "everything failed" boundary). A failed findings fetch degrades to alerts-only via the existing partial-failure UI — never a crash.
  - `heroCopy.deriveHeroState` takes a new optional `findingsCount` param (default `0`, fully back-compat) that folds into the issue-count copy ladder for both the fleet-wide and org-filtered hero.
  - Org rows and the ORGANIZATIONS list fold findings counts into `issueCount` via `orgFindingsRollup.ts` (`foldFindingsIntoOrgRollups` / `buildFindingsSummary`), including creating a rollup for an org that has open findings but no devices/alerts of its own.
  - ACTIVE ISSUES renders one `FindingsRow` per org with open findings — visually distinct from `IssueRow` (a "Finding" label instead of a severity dot, no swipe-to-acknowledge/selection since the counts endpoint returns aggregates, not individual finding records; tap-through is a later item per #5117).
  - Extracted `OrgRow`'s subtitle string-building into `orgRowCopy.ts` for direct unit testing.

## Test plan

- [x] API: `cd apps/api && npx vitest run src/routes/fleetFindings.test.ts` — 71 passed (5 new `/counts` tests: org/partner scoping, resolved-exclusion, site-restriction, empty-allowlist fail-closed).
- [x] API: `NODE_OPTIONS=--max-old-space-size=12288 npx tsc --noEmit` — clean.
- [x] Mobile: `npx vitest run src/screens/systems/` — 127 passed across all systems-screen test files (new: `orgFindingsRollup.test.ts`, `orgRowCopy.test.ts`; updated: `heroCopy.test.ts`, `mergeSystemsResults.test.ts`).
- [x] Mobile: `npx tsc --noEmit` — clean.
- [x] Red-first: watched each new/updated test fail before implementing (query.ts counts route, mergeSystemsResults slice-count threshold, heroCopy findingsCount, orgRowCopy, orgFindingsRollup).

Closes #5139

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mm2mUGomTFJKG2Eb6gzNL1