### PR TITLE
feat(mobile,api): Device Details v1 fields — IP, logged-in user, OS version, open alerts/tickets (#5140)

### DIFF
--- a/apps/api/src/routes/mobile.test.ts
+++ b/apps/api/src/routes/mobile.test.ts
@@ -147,6 +147,19 @@ const mockSelectWhereChain = (result: unknown) => ({
   })
 });
 
+// GET /mobile/devices' batched open-alert / open-ticket counts (#5140): a
+// plain SELECT ... WHERE ... GROUP BY, one row per device that has at least
+// one matching row (never per-alert/per-ticket) — this is what keeps the
+// device-list page from fanning out even though a device can have many
+// alerts/tickets.
+const mockSelectGroupByChain = (result: unknown) => ({
+  from: vi.fn().mockReturnValue({
+    where: vi.fn().mockReturnValue({
+      groupBy: vi.fn().mockResolvedValue(result)
+    })
+  })
+});
+
 const mockSelectOrderChain = (result: unknown) => ({
   from: vi.fn().mockReturnValue({
     where: vi.fn().mockReturnValue({
@@ -1379,7 +1392,11 @@ describe('mobile routes', () => {
               organizationName: 'Acme Corp'
             }
           ]) as any
-        );
+        )
+        // Device Details v1 fields (#5140): LAN IP + open alert/ticket counts.
+        .mockReturnValueOnce(mockSelectWhereChain([]) as any)
+        .mockReturnValueOnce(mockSelectGroupByChain([]) as any)
+        .mockReturnValueOnce(mockSelectGroupByChain([]) as any);
 
       const res = await app.request('/mobile/devices?status=online&search=host', {
         method: 'GET'
@@ -1392,6 +1409,115 @@ describe('mobile routes', () => {
       // #5104: the mobile app's row meta line ("org · site") and Device
       // Details org row both depend on this field actually being returned.
       expect(body.data[0].organizationName).toBe('Acme Corp');
+    });
+
+    // #5140: Device Details v1 fields (decision #5117-2) — osVersion,
+    // lastUser, lanIp, publicIp, openAlertCount, openTicketCount.
+    describe('Device Details v1 fields (#5140)', () => {
+      const DEVICE_ID = '11111111-2222-4333-8444-555555555555';
+
+      it('a device with none of the new fields still serialises with null/0 defaults', async () => {
+        vi.mocked(db.select)
+          .mockReturnValueOnce(mockSelectWhereChain([{ count: 1 }]) as any)
+          .mockReturnValueOnce(
+            mockSelectLeftJoinChain([
+              {
+                id: DEVICE_ID,
+                orgId: 'org-123',
+                siteId: 'site-1',
+                hostname: 'host-1',
+                displayName: 'Host 1',
+                osType: 'linux',
+                osVersion: null,
+                lastUser: null,
+                lastSeenIp: null,
+                status: 'online',
+                lastSeenAt: new Date(),
+                organizationName: 'Acme Corp'
+              }
+            ]) as any
+          )
+          // device_network lateral-equivalent (LAN IP)
+          .mockReturnValueOnce(mockSelectWhereChain([]) as any)
+          // open alert count (GROUP BY)
+          .mockReturnValueOnce(mockSelectGroupByChain([]) as any)
+          // open ticket count (GROUP BY)
+          .mockReturnValueOnce(mockSelectGroupByChain([]) as any);
+
+        const res = await app.request('/mobile/devices', { method: 'GET' });
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.data).toHaveLength(1);
+        const row = body.data[0];
+        expect(row.osVersion).toBeNull();
+        expect(row.lastUser).toBeNull();
+        expect(row.lanIp).toBeNull();
+        expect(row.publicIp).toBeNull();
+        expect(row.openAlertCount).toBe(0);
+        expect(row.openTicketCount).toBe(0);
+      });
+
+      it('surfaces osVersion, lastUser, publicIp, ranked lanIp, and open alert/ticket counts without fanning out the row', async () => {
+        vi.mocked(db.select)
+          .mockReturnValueOnce(mockSelectWhereChain([{ count: 1 }]) as any)
+          .mockReturnValueOnce(
+            mockSelectLeftJoinChain([
+              {
+                id: DEVICE_ID,
+                orgId: 'org-123',
+                siteId: 'site-1',
+                hostname: 'host-1',
+                displayName: 'Host 1',
+                osType: 'linux',
+                osVersion: '22.04',
+                lastUser: 'jdoe',
+                lastSeenIp: '203.0.113.9',
+                status: 'online',
+                lastSeenAt: new Date(),
+                organizationName: 'Acme Corp'
+              }
+            ]) as any
+          )
+          // Two network interfaces for the SAME device — a non-primary IPv6
+          // link-local row and a primary routable IPv4 row. The primary IPv4
+          // row must win the ranking (mirrors devices/core.ts's #2503 lateral).
+          .mockReturnValueOnce(
+            mockSelectWhereChain([
+              {
+                deviceId: DEVICE_ID,
+                ipAddress: 'fe80::1',
+                ipType: 'ipv6',
+                isPrimary: false,
+                interfaceName: 'eth1'
+              },
+              {
+                deviceId: DEVICE_ID,
+                ipAddress: '10.0.0.5',
+                ipType: 'ipv4',
+                isPrimary: true,
+                interfaceName: 'eth0'
+              }
+            ]) as any
+          )
+          .mockReturnValueOnce(mockSelectGroupByChain([{ deviceId: DEVICE_ID, count: 3 }]) as any)
+          .mockReturnValueOnce(mockSelectGroupByChain([{ deviceId: DEVICE_ID, count: 2 }]) as any);
+
+        const res = await app.request('/mobile/devices', { method: 'GET' });
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        // Multiple network/alert/ticket rows for the one device must NOT fan
+        // the page out — still exactly one row.
+        expect(body.data).toHaveLength(1);
+        const row = body.data[0];
+        expect(row.osVersion).toBe('22.04');
+        expect(row.lastUser).toBe('jdoe');
+        expect(row.publicIp).toBe('203.0.113.9');
+        expect(row.lanIp).toBe('10.0.0.5');
+        expect(row.openAlertCount).toBe(3);
+        expect(row.openTicketCount).toBe(2);
+      });
     });
 
     it('should return empty list when partner has no orgs', async () => {
@@ -1460,7 +1586,11 @@ describe('mobile routes', () => {
               })
             })
           })
-        } as any);
+        } as any)
+        // Device Details v1 fields (#5140): LAN IP + open alert/ticket counts.
+        .mockReturnValueOnce(mockSelectWhereChain([]) as any)
+        .mockReturnValueOnce(mockSelectGroupByChain([]) as any)
+        .mockReturnValueOnce(mockSelectGroupByChain([]) as any);
 
       const res = await app.request('/mobile/devices', { method: 'GET' });
 
@@ -1521,7 +1651,11 @@ describe('mobile routes', () => {
               })
             })
           })
-        } as any);
+        } as any)
+        // Device Details v1 fields (#5140): LAN IP + open alert/ticket counts.
+        .mockReturnValueOnce(mockSelectWhereChain([]) as any)
+        .mockReturnValueOnce(mockSelectGroupByChain([]) as any)
+        .mockReturnValueOnce(mockSelectGroupByChain([]) as any);
 
       const res = await app.request('/mobile/devices', { method: 'GET' });
 
@@ -1557,7 +1691,11 @@ describe('mobile routes', () => {
         const rows = [row('dddddddd-0000-4000-8000-00000000000a', 'a-host'), row('dddddddd-0000-4000-8000-00000000000b', 'b-host'), row('dddddddd-0000-4000-8000-00000000000c', 'c-host')];
         vi.mocked(db.select)
           .mockReturnValueOnce(mockSelectWhereChain([{ count: 3 }]) as any)
-          .mockReturnValueOnce(mockSelectLeftJoinChainCapturing(rows, captured) as any); // 3 rows for limit=2 => hasMore
+          .mockReturnValueOnce(mockSelectLeftJoinChainCapturing(rows, captured) as any) // 3 rows for limit=2 => hasMore
+          // Device Details v1 fields (#5140): LAN IP + open alert/ticket counts.
+          .mockReturnValueOnce(mockSelectWhereChain([]) as any)
+          .mockReturnValueOnce(mockSelectGroupByChain([]) as any)
+          .mockReturnValueOnce(mockSelectGroupByChain([]) as any);
 
         const res = await app.request('/mobile/devices?limit=2', { method: 'GET' });
 
@@ -1580,7 +1718,11 @@ describe('mobile routes', () => {
           .mockReturnValueOnce(mockSelectWhereChain([{ count: 3 }]) as any)
           .mockReturnValueOnce(
             mockSelectLeftJoinChain([row('dddddddd-0000-4000-8000-00000000000a', 'a-host'), row('dddddddd-0000-4000-8000-00000000000b', 'b-host'), row('dddddddd-0000-4000-8000-00000000000c', 'c-host')]) as any
-          );
+          )
+          // Device Details v1 fields (#5140): LAN IP + open alert/ticket counts.
+          .mockReturnValueOnce(mockSelectWhereChain([]) as any)
+          .mockReturnValueOnce(mockSelectGroupByChain([]) as any)
+          .mockReturnValueOnce(mockSelectGroupByChain([]) as any);
 
         const page1 = await app.request('/mobile/devices?limit=2', { method: 'GET' });
         const page1Body = await page1.json();
@@ -1590,7 +1732,11 @@ describe('mobile routes', () => {
         const captured: { where?: unknown; orderByArgs?: unknown[] } = {};
         vi.mocked(db.select)
           .mockReturnValueOnce(mockSelectWhereChain([{ count: 3 }]) as any)
-          .mockReturnValueOnce(mockSelectLeftJoinChainCapturing([row('dddddddd-0000-4000-8000-00000000000c', 'c-host')], captured) as any);
+          .mockReturnValueOnce(mockSelectLeftJoinChainCapturing([row('dddddddd-0000-4000-8000-00000000000c', 'c-host')], captured) as any)
+          // Device Details v1 fields (#5140): LAN IP + open alert/ticket counts.
+          .mockReturnValueOnce(mockSelectWhereChain([]) as any)
+          .mockReturnValueOnce(mockSelectGroupByChain([]) as any)
+          .mockReturnValueOnce(mockSelectGroupByChain([]) as any);
 
         const page2 = await app.request(`/mobile/devices?limit=2&cursor=${encodeURIComponent(cursor)}`, {
           method: 'GET'
@@ -1613,7 +1759,11 @@ describe('mobile routes', () => {
           .mockReturnValueOnce(mockSelectWhereChain([{ count: 3 }]) as any)
           .mockReturnValueOnce(
             mockSelectLeftJoinChainCapturing([row('dddddddd-0000-4000-8000-00000000000a', 'a-host'), row('dddddddd-0000-4000-8000-00000000000b', 'b-host')], captured) as any
-          );
+          )
+          // Device Details v1 fields (#5140): LAN IP + open alert/ticket counts.
+          .mockReturnValueOnce(mockSelectWhereChain([]) as any)
+          .mockReturnValueOnce(mockSelectGroupByChain([]) as any)
+          .mockReturnValueOnce(mockSelectGroupByChain([]) as any);
 
         const res = await app.request('/mobile/devices?page=1&limit=1', { method: 'GET' });
 

--- a/apps/api/src/routes/mobile.test.ts
+++ b/apps/api/src/routes/mobile.test.ts
@@ -160,6 +160,39 @@ const mockSelectGroupByChain = (result: unknown) => ({
   })
 });
 
+// Same shape as mockSelectGroupByChain, but records the `where` condition so
+// a test can assert the query actually filters to the "open" status set
+// rather than merely returning whatever the mock hands back regardless of
+// what was queried.
+const mockSelectGroupByChainCapturing = (
+  result: unknown,
+  capture: { where?: unknown }
+) => ({
+  from: vi.fn().mockReturnValue({
+    where: vi.fn((where: unknown) => {
+      capture.where = where;
+      return {
+        groupBy: vi.fn().mockResolvedValue(result)
+      };
+    })
+  })
+});
+
+// Rejects instead of resolving, for the fault-isolation tests below.
+const mockSelectGroupByChainRejecting = (error: unknown) => ({
+  from: vi.fn().mockReturnValue({
+    where: vi.fn().mockReturnValue({
+      groupBy: vi.fn().mockRejectedValue(error)
+    })
+  })
+});
+
+const mockSelectWhereChainRejecting = (error: unknown) => ({
+  from: vi.fn().mockReturnValue({
+    where: vi.fn().mockRejectedValue(error)
+  })
+});
+
 const mockSelectOrderChain = (result: unknown) => ({
   from: vi.fn().mockReturnValue({
     where: vi.fn().mockReturnValue({
@@ -249,6 +282,30 @@ const objectContains = (value: unknown, needle: string, seen = new WeakSet<objec
   seen.add(value);
   return Object.values(value as Record<string, unknown>).some((child) => objectContains(child, needle, seen));
 };
+
+// A plain deep search like objectContains() is UNSAFE for asserting the
+// literal values bound into a drizzle `inArray(enumColumn, [...])` filter:
+// every column object on the tree also carries the enum's FULL declared
+// value set on `column.enumValues` (e.g. alerts.status's enumValues includes
+// 'resolved'/'suppressed'/'dismissed' even when the query filters to just
+// ['active','acknowledged']), so objectContains would report a match for a
+// status that was never actually queried. This walks only `.queryChunks`
+// (drizzle SQL nodes) and arrays, and stops at a `Param` node's own `.value`
+// without following its `.encoder`/`.table` back into that enum metadata —
+// so it reports only what was genuinely bound into the query.
+function extractBoundParamValues(node: unknown, seen = new Set<unknown>()): unknown[] {
+  if (node == null || typeof node !== 'object') return [];
+  if (seen.has(node)) return [];
+  seen.add(node);
+  if ((node as { constructor?: { name?: string } }).constructor?.name === 'Param') {
+    return [(node as { value: unknown }).value];
+  }
+  if (Array.isArray(node)) {
+    return node.flatMap((item) => extractBoundParamValues(item, seen));
+  }
+  const chunks = (node as { queryChunks?: unknown[] }).queryChunks;
+  return Array.isArray(chunks) ? chunks.flatMap((item) => extractBoundParamValues(item, seen)) : [];
+}
 
 const mockInsertReturning = (result: unknown) => ({
   values: vi.fn().mockReturnValue({
@@ -1416,7 +1473,7 @@ describe('mobile routes', () => {
     describe('Device Details v1 fields (#5140)', () => {
       const DEVICE_ID = '11111111-2222-4333-8444-555555555555';
 
-      it('a device with none of the new fields still serialises with null/0 defaults', async () => {
+      it('a device with none of the genuinely-optional new fields still serialises with null/0 defaults', async () => {
         vi.mocked(db.select)
           .mockReturnValueOnce(mockSelectWhereChain([{ count: 1 }]) as any)
           .mockReturnValueOnce(
@@ -1428,7 +1485,10 @@ describe('mobile routes', () => {
                 hostname: 'host-1',
                 displayName: 'Host 1',
                 osType: 'linux',
-                osVersion: null,
+                // devices.os_version is NOT NULL at the DB level — every real
+                // row has one. lastUser/lastSeenIp ARE nullable, so those are
+                // what a genuinely-sparse device looks like.
+                osVersion: '22.04',
                 lastUser: null,
                 lastSeenIp: null,
                 status: 'online',
@@ -1450,7 +1510,7 @@ describe('mobile routes', () => {
         const body = await res.json();
         expect(body.data).toHaveLength(1);
         const row = body.data[0];
-        expect(row.osVersion).toBeNull();
+        expect(row.osVersion).toBe('22.04');
         expect(row.lastUser).toBeNull();
         expect(row.lanIp).toBeNull();
         expect(row.publicIp).toBeNull();
@@ -1517,6 +1577,224 @@ describe('mobile routes', () => {
         expect(row.lanIp).toBe('10.0.0.5');
         expect(row.openAlertCount).toBe(3);
         expect(row.openTicketCount).toBe(2);
+      });
+
+      it('filters the alert and ticket count queries to the "open" status sets', async () => {
+        const alertCapture: { where?: unknown } = {};
+        const ticketCapture: { where?: unknown } = {};
+        vi.mocked(db.select)
+          .mockReturnValueOnce(mockSelectWhereChain([{ count: 1 }]) as any)
+          .mockReturnValueOnce(
+            mockSelectLeftJoinChain([
+              {
+                id: DEVICE_ID,
+                orgId: 'org-123',
+                siteId: 'site-1',
+                hostname: 'host-1',
+                displayName: 'Host 1',
+                osType: 'linux',
+                osVersion: '22.04',
+                status: 'online',
+                lastSeenAt: new Date()
+              }
+            ]) as any
+          )
+          .mockReturnValueOnce(mockSelectWhereChain([]) as any)
+          .mockReturnValueOnce(mockSelectGroupByChainCapturing([], alertCapture) as any)
+          .mockReturnValueOnce(mockSelectGroupByChainCapturing([], ticketCapture) as any);
+
+        const res = await app.request('/mobile/devices', { method: 'GET' });
+
+        expect(res.status).toBe(200);
+        // extractBoundParamValues, not objectContains — see its comment for
+        // why a plain deep search is vacuous against an enum-typed column.
+        const alertValues = extractBoundParamValues(alertCapture.where);
+        expect(alertValues).toEqual(expect.arrayContaining(['active', 'acknowledged']));
+        expect(alertValues).not.toContain('resolved');
+        expect(alertValues).not.toContain('suppressed');
+        expect(alertValues).not.toContain('dismissed');
+
+        const ticketValues = extractBoundParamValues(ticketCapture.where);
+        expect(ticketValues).toEqual(expect.arrayContaining(['new', 'open', 'pending', 'on_hold']));
+        expect(ticketValues).not.toContain('resolved');
+        expect(ticketValues).not.toContain('closed');
+      });
+
+      it('ranks a same-priority IPv4 address over IPv6, independent of the is_primary tier', async () => {
+        vi.mocked(db.select)
+          .mockReturnValueOnce(mockSelectWhereChain([{ count: 1 }]) as any)
+          .mockReturnValueOnce(
+            mockSelectLeftJoinChain([
+              { id: DEVICE_ID, orgId: 'org-123', siteId: 'site-1', hostname: 'host-1', displayName: 'Host 1', osType: 'linux', osVersion: '22.04', status: 'online', lastSeenAt: new Date() }
+            ]) as any
+          )
+          // Neither is primary — the tiebreak must fall through to the
+          // IPv4-before-IPv6 tier, not stop at the (tied) is_primary tier.
+          .mockReturnValueOnce(
+            mockSelectWhereChain([
+              { deviceId: DEVICE_ID, ipAddress: 'fd00::1', ipType: 'ipv6', isPrimary: false, interfaceName: 'eth0' },
+              { deviceId: DEVICE_ID, ipAddress: '10.0.0.9', ipType: 'ipv4', isPrimary: false, interfaceName: 'eth1' }
+            ]) as any
+          )
+          .mockReturnValueOnce(mockSelectGroupByChain([]) as any)
+          .mockReturnValueOnce(mockSelectGroupByChain([]) as any);
+
+        const res = await app.request('/mobile/devices', { method: 'GET' });
+        const body = await res.json();
+        expect(body.data[0].lanIp).toBe('10.0.0.9');
+      });
+
+      it('ranks a routable address over an APIPA/link-local one, independent of the is_primary/ipType tiers', async () => {
+        vi.mocked(db.select)
+          .mockReturnValueOnce(mockSelectWhereChain([{ count: 1 }]) as any)
+          .mockReturnValueOnce(
+            mockSelectLeftJoinChain([
+              { id: DEVICE_ID, orgId: 'org-123', siteId: 'site-1', hostname: 'host-1', displayName: 'Host 1', osType: 'linux', osVersion: '22.04', status: 'online', lastSeenAt: new Date() }
+            ]) as any
+          )
+          // Same is_primary, same ipType (both ipv4) — the tiebreak must fall
+          // through to the routable-before-unroutable tier.
+          .mockReturnValueOnce(
+            mockSelectWhereChain([
+              { deviceId: DEVICE_ID, ipAddress: '169.254.1.2', ipType: 'ipv4', isPrimary: false, interfaceName: 'eth0' },
+              { deviceId: DEVICE_ID, ipAddress: '192.168.1.5', ipType: 'ipv4', isPrimary: false, interfaceName: 'eth1' }
+            ]) as any
+          )
+          .mockReturnValueOnce(mockSelectGroupByChain([]) as any)
+          .mockReturnValueOnce(mockSelectGroupByChain([]) as any);
+
+        const res = await app.request('/mobile/devices', { method: 'GET' });
+        const body = await res.json();
+        expect(body.data[0].lanIp).toBe('192.168.1.5');
+      });
+
+      it('breaks a full tie (same is_primary, ipType, routability) on interface name, ascending', async () => {
+        vi.mocked(db.select)
+          .mockReturnValueOnce(mockSelectWhereChain([{ count: 1 }]) as any)
+          .mockReturnValueOnce(
+            mockSelectLeftJoinChain([
+              { id: DEVICE_ID, orgId: 'org-123', siteId: 'site-1', hostname: 'host-1', displayName: 'Host 1', osType: 'linux', osVersion: '22.04', status: 'online', lastSeenAt: new Date() }
+            ]) as any
+          )
+          .mockReturnValueOnce(
+            mockSelectWhereChain([
+              { deviceId: DEVICE_ID, ipAddress: '10.0.0.9', ipType: 'ipv4', isPrimary: false, interfaceName: 'eth1' },
+              { deviceId: DEVICE_ID, ipAddress: '10.0.0.5', ipType: 'ipv4', isPrimary: false, interfaceName: 'eth0' }
+            ]) as any
+          )
+          .mockReturnValueOnce(mockSelectGroupByChain([]) as any)
+          .mockReturnValueOnce(mockSelectGroupByChain([]) as any);
+
+        const res = await app.request('/mobile/devices', { method: 'GET' });
+        const body = await res.json();
+        // eth0 sorts before eth1 — the row from the interface named first
+        // wins, regardless of array order in the network-rows result.
+        expect(body.data[0].lanIp).toBe('10.0.0.5');
+      });
+
+      it('attributes LAN IP and open counts to the correct device on a multi-device page, never mixing rows up', async () => {
+        const DEVICE_A = '11111111-2222-4333-8444-555555555555';
+        const DEVICE_B = '22222222-2222-4333-8444-555555555555';
+        vi.mocked(db.select)
+          .mockReturnValueOnce(mockSelectWhereChain([{ count: 2 }]) as any)
+          .mockReturnValueOnce(
+            mockSelectLeftJoinChain([
+              { id: DEVICE_A, orgId: 'org-123', siteId: 'site-1', hostname: 'host-a', displayName: 'Host A', osType: 'linux', osVersion: '22.04', status: 'online', lastSeenAt: new Date() },
+              { id: DEVICE_B, orgId: 'org-123', siteId: 'site-1', hostname: 'host-b', displayName: 'Host B', osType: 'windows', osVersion: '10', status: 'online', lastSeenAt: new Date() }
+            ]) as any
+          )
+          .mockReturnValueOnce(
+            mockSelectWhereChain([
+              { deviceId: DEVICE_A, ipAddress: '10.0.0.1', ipType: 'ipv4', isPrimary: true, interfaceName: 'eth0' },
+              { deviceId: DEVICE_B, ipAddress: '10.0.0.2', ipType: 'ipv4', isPrimary: true, interfaceName: 'eth0' }
+            ]) as any
+          )
+          .mockReturnValueOnce(
+            mockSelectGroupByChain([
+              { deviceId: DEVICE_A, count: 1 },
+              { deviceId: DEVICE_B, count: 9 }
+            ]) as any
+          )
+          .mockReturnValueOnce(
+            mockSelectGroupByChain([{ deviceId: DEVICE_B, count: 4 }]) as any
+          );
+
+        const res = await app.request('/mobile/devices', { method: 'GET' });
+        const body = await res.json();
+        const byId = Object.fromEntries(body.data.map((d: { id: string }) => [d.id, d]));
+
+        expect(byId[DEVICE_A].lanIp).toBe('10.0.0.1');
+        expect(byId[DEVICE_A].openAlertCount).toBe(1);
+        expect(byId[DEVICE_A].openTicketCount).toBe(0);
+
+        expect(byId[DEVICE_B].lanIp).toBe('10.0.0.2');
+        expect(byId[DEVICE_B].openAlertCount).toBe(9);
+        expect(byId[DEVICE_B].openTicketCount).toBe(4);
+      });
+
+      it('degrades LAN IP to null (not a 500) when the device_network lookup query fails', async () => {
+        vi.mocked(db.select)
+          .mockReturnValueOnce(mockSelectWhereChain([{ count: 1 }]) as any)
+          .mockReturnValueOnce(
+            mockSelectLeftJoinChain([
+              { id: DEVICE_ID, orgId: 'org-123', siteId: 'site-1', hostname: 'host-1', displayName: 'Host 1', osType: 'linux', osVersion: '22.04', status: 'online', lastSeenAt: new Date() }
+            ]) as any
+          )
+          .mockReturnValueOnce(mockSelectWhereChainRejecting(new Error('connection reset')) as any)
+          .mockReturnValueOnce(mockSelectGroupByChain([{ deviceId: DEVICE_ID, count: 2 }]) as any)
+          .mockReturnValueOnce(mockSelectGroupByChain([]) as any);
+
+        const res = await app.request('/mobile/devices', { method: 'GET' });
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.data[0].lanIp).toBeNull();
+        // The other two lookups are unaffected by the LAN-IP failure.
+        expect(body.data[0].openAlertCount).toBe(2);
+        expect(body.data[0].openTicketCount).toBe(0);
+      });
+
+      it('sends null (never a false 0) for openAlertCount when the alert-count query fails, without 500ing the list', async () => {
+        vi.mocked(db.select)
+          .mockReturnValueOnce(mockSelectWhereChain([{ count: 1 }]) as any)
+          .mockReturnValueOnce(
+            mockSelectLeftJoinChain([
+              { id: DEVICE_ID, orgId: 'org-123', siteId: 'site-1', hostname: 'host-1', displayName: 'Host 1', osType: 'linux', osVersion: '22.04', status: 'online', lastSeenAt: new Date() }
+            ]) as any
+          )
+          .mockReturnValueOnce(mockSelectWhereChain([]) as any)
+          .mockReturnValueOnce(mockSelectGroupByChainRejecting(new Error('statement timeout')) as any)
+          .mockReturnValueOnce(mockSelectGroupByChain([{ deviceId: DEVICE_ID, count: 5 }]) as any);
+
+        const res = await app.request('/mobile/devices', { method: 'GET' });
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.data).toHaveLength(1);
+        // NOT 0 — a device with several real open alerts must never read as
+        // a confident, wrong zero just because the count query blipped.
+        expect(body.data[0].openAlertCount).toBeNull();
+        expect(body.data[0].openTicketCount).toBe(5);
+      });
+
+      it('sends null for openTicketCount when the ticket-count query fails, without 500ing the list', async () => {
+        vi.mocked(db.select)
+          .mockReturnValueOnce(mockSelectWhereChain([{ count: 1 }]) as any)
+          .mockReturnValueOnce(
+            mockSelectLeftJoinChain([
+              { id: DEVICE_ID, orgId: 'org-123', siteId: 'site-1', hostname: 'host-1', displayName: 'Host 1', osType: 'linux', osVersion: '22.04', status: 'online', lastSeenAt: new Date() }
+            ]) as any
+          )
+          .mockReturnValueOnce(mockSelectWhereChain([]) as any)
+          .mockReturnValueOnce(mockSelectGroupByChain([{ deviceId: DEVICE_ID, count: 3 }]) as any)
+          .mockReturnValueOnce(mockSelectGroupByChainRejecting(new Error('statement timeout')) as any);
+
+        const res = await app.request('/mobile/devices', { method: 'GET' });
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.data[0].openAlertCount).toBe(3);
+        expect(body.data[0].openTicketCount).toBeNull();
       });
     });
 

--- a/apps/api/src/routes/mobile.ts
+++ b/apps/api/src/routes/mobile.ts
@@ -111,59 +111,90 @@ function compareLanCandidates(a: LanIpCandidate, b: LanIpCandidate): number {
  * device with many network interfaces, alerts, or tickets can never fan the
  * page's row count out — verified by
  * "...without fanning out the row" in mobile.test.ts.
+ *
+ * Each of the three lookups is independently fault-isolated: a failure in
+ * any one (a lock/timeout blip on `device_network`/`alerts`/`tickets`, say)
+ * must not 500 the whole device list when the core device-row query already
+ * succeeded — this is pure enrichment on top of an otherwise-working page.
+ * The count maps are `| null` on failure (never silently coerced to an empty
+ * map) specifically so the caller can tell "the query failed" apart from
+ * "the query succeeded and found zero open alerts/tickets" — collapsing
+ * those into the same `0` would render a false "Open alerts · 0" for a
+ * device that may have several unresolved critical alerts.
  */
 async function loadDeviceDetailsV1Fields(deviceIds: string[]): Promise<{
   lanIpByDevice: Map<string, string>;
-  openAlertCountByDevice: Map<string, number>;
-  openTicketCountByDevice: Map<string, number>;
+  openAlertCountByDevice: Map<string, number> | null;
+  openTicketCountByDevice: Map<string, number> | null;
 }> {
   const lanIpByDevice = new Map<string, string>();
-  const openAlertCountByDevice = new Map<string, number>();
-  const openTicketCountByDevice = new Map<string, number>();
 
   if (deviceIds.length === 0) {
-    return { lanIpByDevice, openAlertCountByDevice, openTicketCountByDevice };
+    return { lanIpByDevice, openAlertCountByDevice: new Map(), openTicketCountByDevice: new Map() };
   }
 
-  const networkRows = await db
-    .select({
-      deviceId: deviceNetwork.deviceId,
-      ipAddress: deviceNetwork.ipAddress,
-      ipType: deviceNetwork.ipType,
-      isPrimary: deviceNetwork.isPrimary,
-      interfaceName: deviceNetwork.interfaceName
-    })
-    .from(deviceNetwork)
-    .where(and(inArray(deviceNetwork.deviceId, deviceIds), sql`${deviceNetwork.ipAddress} IS NOT NULL`));
+  try {
+    const networkRows = await db
+      .select({
+        deviceId: deviceNetwork.deviceId,
+        ipAddress: deviceNetwork.ipAddress,
+        ipType: deviceNetwork.ipType,
+        isPrimary: deviceNetwork.isPrimary,
+        interfaceName: deviceNetwork.interfaceName
+      })
+      .from(deviceNetwork)
+      .where(and(inArray(deviceNetwork.deviceId, deviceIds), sql`${deviceNetwork.ipAddress} IS NOT NULL`));
 
-  const candidatesByDevice = new Map<string, LanIpCandidate[]>();
-  for (const row of networkRows) {
-    if (!row.ipAddress) continue;
-    const list = candidatesByDevice.get(row.deviceId) ?? [];
-    list.push(row as LanIpCandidate);
-    candidatesByDevice.set(row.deviceId, list);
-  }
-  for (const [deviceId, candidates] of candidatesByDevice) {
-    const best = candidates.slice().sort(compareLanCandidates)[0];
-    if (best?.ipAddress) lanIpByDevice.set(deviceId, best.ipAddress);
-  }
-
-  const alertCountRows = await db
-    .select({ deviceId: alerts.deviceId, count: sql<number>`count(*)::int` })
-    .from(alerts)
-    .where(and(inArray(alerts.deviceId, deviceIds), inArray(alerts.status, OPEN_ALERT_STATUSES)))
-    .groupBy(alerts.deviceId);
-  for (const row of alertCountRows) {
-    openAlertCountByDevice.set(row.deviceId, Number(row.count));
+    const candidatesByDevice = new Map<string, LanIpCandidate[]>();
+    for (const row of networkRows) {
+      if (!row.ipAddress) continue;
+      const list = candidatesByDevice.get(row.deviceId) ?? [];
+      list.push(row as LanIpCandidate);
+      candidatesByDevice.set(row.deviceId, list);
+    }
+    for (const [deviceId, candidates] of candidatesByDevice) {
+      const best = candidates.slice().sort(compareLanCandidates)[0];
+      if (best?.ipAddress) lanIpByDevice.set(deviceId, best.ipAddress);
+    }
+  } catch (error) {
+    // Degrades to "no LAN IP known" for this page — indistinguishable from a
+    // device that genuinely has none, which is an acceptable fallback (unlike
+    // the counts below, there's no "confirmed zero" reading for an IP).
+    console.error('[MobileRoutes] Failed to load LAN IPs for device list:', error);
   }
 
-  const ticketCountRows = await db
-    .select({ deviceId: tickets.deviceId, count: sql<number>`count(*)::int` })
-    .from(tickets)
-    .where(and(inArray(tickets.deviceId, deviceIds), inArray(tickets.status, OPEN_TICKET_STATUSES)))
-    .groupBy(tickets.deviceId);
-  for (const row of ticketCountRows) {
-    if (row.deviceId) openTicketCountByDevice.set(row.deviceId, Number(row.count));
+  let openAlertCountByDevice: Map<string, number> | null = new Map();
+  try {
+    const alertCountRows = await db
+      .select({ deviceId: alerts.deviceId, count: sql<number>`count(*)::int` })
+      .from(alerts)
+      .where(and(inArray(alerts.deviceId, deviceIds), inArray(alerts.status, OPEN_ALERT_STATUSES)))
+      .groupBy(alerts.deviceId);
+    for (const row of alertCountRows) {
+      openAlertCountByDevice.set(row.deviceId, Number(row.count));
+    }
+  } catch (error) {
+    console.error('[MobileRoutes] Failed to load open alert counts for device list:', error);
+    openAlertCountByDevice = null;
+  }
+
+  let openTicketCountByDevice: Map<string, number> | null = new Map();
+  try {
+    const ticketCountRows = await db
+      .select({ deviceId: tickets.deviceId, count: sql<number>`count(*)::int` })
+      .from(tickets)
+      .where(and(inArray(tickets.deviceId, deviceIds), inArray(tickets.status, OPEN_TICKET_STATUSES)))
+      .groupBy(tickets.deviceId);
+    for (const row of ticketCountRows) {
+      // tickets.deviceId is nullable in general, but inArray(...) above
+      // already excludes NULL rows (`NULL IN (...)` is never true in SQL) —
+      // this guard can't actually trip today. Kept as defense-in-depth
+      // against a future refactor (e.g. a LEFT JOIN) loosening that filter.
+      if (row.deviceId) openTicketCountByDevice.set(row.deviceId, Number(row.count));
+    }
+  } catch (error) {
+    console.error('[MobileRoutes] Failed to load open ticket counts for device list:', error);
+    openTicketCountByDevice = null;
   }
 
   return { lanIpByDevice, openAlertCountByDevice, openTicketCountByDevice };
@@ -1417,8 +1448,11 @@ mobileRoutes.get(
         ...rest,
         publicIp: lastSeenIp ?? null,
         lanIp: lanIpByDevice.get(d.id) ?? null,
-        openAlertCount: openAlertCountByDevice.get(d.id) ?? 0,
-        openTicketCount: openTicketCountByDevice.get(d.id) ?? 0
+        // `null` map = the count query itself failed for this page — send
+        // `null` (never a false `0`) so the client renders "unknown" rather
+        // than a confident, wrong zero. See loadDeviceDetailsV1Fields.
+        openAlertCount: openAlertCountByDevice === null ? null : (openAlertCountByDevice.get(d.id) ?? 0),
+        openTicketCount: openTicketCountByDevice === null ? null : (openTicketCountByDevice.get(d.id) ?? 0)
       };
     });
 

--- a/apps/api/src/routes/mobile.ts
+++ b/apps/api/src/routes/mobile.ts
@@ -11,10 +11,12 @@ import {
   alertRules,
   alertTemplates,
   deviceCommands,
+  deviceNetwork,
   devices,
   mobileDevices,
   organizations,
-  sites
+  sites,
+  tickets
 } from '../db/schema';
 import { authMiddleware, requireMfa, requirePermission, requireScope, type AuthContext } from '../middleware/auth';
 import { userRateLimit } from '../middleware/userRateLimit';
@@ -56,6 +58,116 @@ const requireMobileAlertAcknowledge = requirePermission(PERMISSIONS.ALERTS_ACKNO
 const requireMobileAlertWrite = requirePermission(PERMISSIONS.ALERTS_WRITE.resource, PERMISSIONS.ALERTS_WRITE.action);
 const requireMobileDeviceRead = requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action);
 const requireMobileDeviceExecute = requirePermission(PERMISSIONS.DEVICES_EXECUTE.resource, PERMISSIONS.DEVICES_EXECUTE.action);
+
+// Device Details v1 fields (#5140, decision #5117-2): "open" for the
+// mobile device row's alert/ticket counts means "still needs attention" —
+// mirrors the /summary endpoint's active+acknowledged bucket, not the full
+// history (excludes resolved/dismissed/suppressed).
+const OPEN_ALERT_STATUSES = ['active', 'acknowledged'] as const;
+// Same status set as services/portal/ticketReadModel.ts's OPEN_TICKET_STATUSES
+// and services/ticketService.ts's ADDIN_OPEN_STATUSES — both module-private,
+// so kept local here rather than importing either.
+const OPEN_TICKET_STATUSES = ['new', 'open', 'pending', 'on_hold'] as const;
+
+/** One device_network row as read for LAN-IP ranking below. */
+interface LanIpCandidate {
+  deviceId: string;
+  ipAddress: string | null;
+  ipType: string;
+  isPrimary: boolean;
+  interfaceName: string;
+}
+
+// APIPA/link-local/loopback — worse than useless in a scan column. Mirrors
+// the ILIKE/LIKE set in devices/core.ts's LAN-IP lateral (#2503).
+function isUnroutableIp(ip: string): boolean {
+  return ip.startsWith('169.254.') || ip.startsWith('127.') || ip.toLowerCase().startsWith('fe80:') || ip === '::1';
+}
+
+/**
+ * Best-first comparator for a device's candidate LAN addresses: is_primary
+ * first, IPv4 before IPv6, routable before APIPA/link-local/loopback,
+ * interface name as a stable tiebreak. Same ranking as devices/core.ts's
+ * per-page LATERAL join (#2503), done here in application code (over a plain
+ * batched SELECT) rather than a second SQL LATERAL, since device_network rows
+ * per page are few enough that ranking in JS avoids a raw sql`` query in this
+ * route.
+ */
+function compareLanCandidates(a: LanIpCandidate, b: LanIpCandidate): number {
+  if (a.isPrimary !== b.isPrimary) return a.isPrimary ? -1 : 1;
+  const aV4 = a.ipType === 'ipv4';
+  const bV4 = b.ipType === 'ipv4';
+  if (aV4 !== bV4) return aV4 ? -1 : 1;
+  const aUnroutable = isUnroutableIp(a.ipAddress!);
+  const bUnroutable = isUnroutableIp(b.ipAddress!);
+  if (aUnroutable !== bUnroutable) return aUnroutable ? 1 : -1;
+  return a.interfaceName.localeCompare(b.interfaceName);
+}
+
+/**
+ * Batched lookups for the Device Details v1 fields (#5140) — one LAN-IP pick
+ * plus two GROUP BY counts per page, keyed by device id. Each is a SEPARATE
+ * query from the main device-row select (never a LEFT JOIN on it), so a
+ * device with many network interfaces, alerts, or tickets can never fan the
+ * page's row count out — verified by
+ * "...without fanning out the row" in mobile.test.ts.
+ */
+async function loadDeviceDetailsV1Fields(deviceIds: string[]): Promise<{
+  lanIpByDevice: Map<string, string>;
+  openAlertCountByDevice: Map<string, number>;
+  openTicketCountByDevice: Map<string, number>;
+}> {
+  const lanIpByDevice = new Map<string, string>();
+  const openAlertCountByDevice = new Map<string, number>();
+  const openTicketCountByDevice = new Map<string, number>();
+
+  if (deviceIds.length === 0) {
+    return { lanIpByDevice, openAlertCountByDevice, openTicketCountByDevice };
+  }
+
+  const networkRows = await db
+    .select({
+      deviceId: deviceNetwork.deviceId,
+      ipAddress: deviceNetwork.ipAddress,
+      ipType: deviceNetwork.ipType,
+      isPrimary: deviceNetwork.isPrimary,
+      interfaceName: deviceNetwork.interfaceName
+    })
+    .from(deviceNetwork)
+    .where(and(inArray(deviceNetwork.deviceId, deviceIds), sql`${deviceNetwork.ipAddress} IS NOT NULL`));
+
+  const candidatesByDevice = new Map<string, LanIpCandidate[]>();
+  for (const row of networkRows) {
+    if (!row.ipAddress) continue;
+    const list = candidatesByDevice.get(row.deviceId) ?? [];
+    list.push(row as LanIpCandidate);
+    candidatesByDevice.set(row.deviceId, list);
+  }
+  for (const [deviceId, candidates] of candidatesByDevice) {
+    const best = candidates.slice().sort(compareLanCandidates)[0];
+    if (best?.ipAddress) lanIpByDevice.set(deviceId, best.ipAddress);
+  }
+
+  const alertCountRows = await db
+    .select({ deviceId: alerts.deviceId, count: sql<number>`count(*)::int` })
+    .from(alerts)
+    .where(and(inArray(alerts.deviceId, deviceIds), inArray(alerts.status, OPEN_ALERT_STATUSES)))
+    .groupBy(alerts.deviceId);
+  for (const row of alertCountRows) {
+    openAlertCountByDevice.set(row.deviceId, Number(row.count));
+  }
+
+  const ticketCountRows = await db
+    .select({ deviceId: tickets.deviceId, count: sql<number>`count(*)::int` })
+    .from(tickets)
+    .where(and(inArray(tickets.deviceId, deviceIds), inArray(tickets.status, OPEN_TICKET_STATUSES)))
+    .groupBy(tickets.deviceId);
+  for (const row of ticketCountRows) {
+    if (row.deviceId) openTicketCountByDevice.set(row.deviceId, Number(row.count));
+  }
+
+  return { lanIpByDevice, openAlertCountByDevice, openTicketCountByDevice };
+}
 
 async function requireScriptExecuteForRunScript(c: import('hono').Context, next: import('hono').Next) {
   const data = (c.req as unknown as { valid: (target: 'json') => { action?: string } }).valid('json');
@@ -1258,6 +1370,14 @@ mobileRoutes.get(
         hostname: devices.hostname,
         displayName: devices.displayName,
         osType: devices.osType,
+        // Device Details v1 fields (#5140): plain columns, no extra query.
+        osVersion: devices.osVersion,
+        lastUser: devices.lastUser,
+        // Public/WAN address the agent last authenticated from — device_network's
+        // own public_ip column is never written by any code path (see its
+        // schema comment), so this is the only real source. Renamed to
+        // publicIp in the response below.
+        lastSeenIp: devices.lastSeenIp,
         status: devices.status,
         lastSeenAt: devices.lastSeenAt,
         // #5104: the mobile row meta line needs the org name on a
@@ -1286,8 +1406,24 @@ mobileRoutes.get(
       }
     }
 
+    // Device Details v1 fields (#5140): batched once for this page, not
+    // per-row — see loadDeviceDetailsV1Fields for why this can't fan out.
+    const { lanIpByDevice, openAlertCountByDevice, openTicketCountByDevice } =
+      await loadDeviceDetailsV1Fields(items.map((d) => d.id));
+
+    const data = items.map((d) => {
+      const { lastSeenIp, ...rest } = d;
+      return {
+        ...rest,
+        publicIp: lastSeenIp ?? null,
+        lanIp: lanIpByDevice.get(d.id) ?? null,
+        openAlertCount: openAlertCountByDevice.get(d.id) ?? 0,
+        openTicketCount: openTicketCountByDevice.get(d.id) ?? 0
+      };
+    });
+
     return c.json({
-      data: items,
+      data,
       pagination: { page, limit, total, nextCursor }
     });
   }

--- a/apps/mobile/src/screens/devices/DeviceDetailScreen.tsx
+++ b/apps/mobile/src/screens/devices/DeviceDetailScreen.tsx
@@ -20,6 +20,7 @@ import { Spinner } from '../../components/Spinner';
 import { reportInternalError } from '../../lib/errorReporting';
 import { osLabel } from '../../lib/osLabel';
 import { relativeTime } from '../../lib/relativeTime';
+import { formatCountLabel, formatDetailValue, formatIpValue, formatOsVersionValue } from './deviceDetailFields';
 
 interface Props {
   route: { params: { device: Device } };
@@ -89,6 +90,38 @@ function DetailRow({
         selectable
       >
         {value}
+      </Text>
+    </View>
+  );
+}
+
+/**
+ * A single-line row for the Open alerts / Open tickets counts (#5140):
+ * the label lives inside the text itself ("Open alerts · 3"), unlike
+ * DetailRow's caps-label-then-value shape, since neither count links to a
+ * filtered list yet (no such screen exists on mobile — see
+ * formatCountLabel's caller) and a bare label/value split would read oddly
+ * for a value that's already a full sentence fragment.
+ */
+function SummaryRow({
+  text,
+  textHi,
+  border,
+}: {
+  text: string;
+  textHi: string;
+  border: string;
+}) {
+  return (
+    <View
+      style={{
+        paddingVertical: spacing[3],
+        borderBottomWidth: 1,
+        borderBottomColor: border,
+      }}
+    >
+      <Text style={[type.body, { color: textHi }]} selectable>
+        {text}
       </Text>
     </View>
   );
@@ -281,24 +314,43 @@ export function DeviceDetailScreen({ route }: Props) {
             border={theme.border}
           />
         ) : null}
-        {device.ipAddress ? (
-          <DetailRow
-            label="IP ADDRESS"
-            value={device.ipAddress}
-            textHi={theme.textHi}
-            textLo={theme.textLo}
-            border={theme.border}
-          />
-        ) : null}
+        {/* Device Details v1 fields (#5140, decision #5117-2): IP,
+            logged-in user, OS version and the open alert/ticket counts
+            always render — "—" for absent values — unlike the rows above,
+            which hide entirely when the underlying field is unset. */}
+        <DetailRow
+          label="IP ADDRESS"
+          value={formatIpValue(device.lanIp, device.publicIp)}
+          textHi={theme.textHi}
+          textLo={theme.textLo}
+          border={theme.border}
+        />
+        <DetailRow
+          label="LOGGED-IN USER"
+          value={formatDetailValue(device.lastUser)}
+          textHi={theme.textHi}
+          textLo={theme.textLo}
+          border={theme.border}
+        />
         {device.os ? (
           <DetailRow
             label="OPERATING SYSTEM"
-            value={osLabel(device.os)}
+            value={formatOsVersionValue(osLabel(device.os), device.osVersion)}
             textHi={theme.textHi}
             textLo={theme.textLo}
             border={theme.border}
           />
         ) : null}
+        <SummaryRow
+          text={formatCountLabel('Open alerts', device.openAlertCount)}
+          textHi={theme.textHi}
+          border={theme.border}
+        />
+        <SummaryRow
+          text={formatCountLabel('Open tickets', device.openTicketCount)}
+          textHi={theme.textHi}
+          border={theme.border}
+        />
         {device.agentVersion ? (
           <DetailRow
             label="AGENT VERSION"

--- a/apps/mobile/src/screens/devices/deviceDetailFields.test.ts
+++ b/apps/mobile/src/screens/devices/deviceDetailFields.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatCountLabel, formatDetailValue, formatIpValue, formatOsVersionValue } from './deviceDetailFields';
+
+// #5140: Device Details v1 fields (decision #5117-2) — pure formatting rules
+// so DeviceDetailScreen's render logic stays a straight prop-to-JSX mapping.
+// "Empty values render '—', never blank" per the decision doc.
+
+describe('formatDetailValue', () => {
+  it('returns the value unchanged when present', () => {
+    expect(formatDetailValue('jdoe')).toBe('jdoe');
+  });
+
+  it('returns an em dash for null', () => {
+    expect(formatDetailValue(null)).toBe('—');
+  });
+
+  it('returns an em dash for undefined', () => {
+    expect(formatDetailValue(undefined)).toBe('—');
+  });
+
+  it('returns an em dash for an empty/whitespace string', () => {
+    expect(formatDetailValue('   ')).toBe('—');
+  });
+});
+
+describe('formatIpValue', () => {
+  it('shows just the LAN IP when there is no public IP', () => {
+    expect(formatIpValue('10.0.0.5', null)).toBe('10.0.0.5');
+  });
+
+  it('puts the public IP on a second line when present', () => {
+    expect(formatIpValue('10.0.0.5', '203.0.113.9')).toBe('10.0.0.5\n203.0.113.9');
+  });
+
+  it('em-dashes the LAN line when absent, but still appends a present public IP', () => {
+    expect(formatIpValue(null, '203.0.113.9')).toBe('—\n203.0.113.9');
+  });
+
+  it('em-dashes when neither is present', () => {
+    expect(formatIpValue(null, null)).toBe('—');
+  });
+});
+
+describe('formatOsVersionValue', () => {
+  it('appends the version next to the OS label when present', () => {
+    expect(formatOsVersionValue('Linux', '22.04')).toBe('Linux · 22.04');
+  });
+
+  it('falls back to the bare OS label when no version is known', () => {
+    expect(formatOsVersionValue('Linux', null)).toBe('Linux');
+  });
+
+  it('falls back to the bare OS label for a blank version string', () => {
+    expect(formatOsVersionValue('Linux', '  ')).toBe('Linux');
+  });
+});
+
+describe('formatCountLabel', () => {
+  it('renders a real zero as a zero, not an em dash', () => {
+    expect(formatCountLabel('Open alerts', 0)).toBe('Open alerts · 0');
+  });
+
+  it('renders a positive count', () => {
+    expect(formatCountLabel('Open tickets', 4)).toBe('Open tickets · 4');
+  });
+
+  it('em-dashes a genuinely absent (undefined) count', () => {
+    expect(formatCountLabel('Open alerts', undefined)).toBe('Open alerts · —');
+  });
+
+  it('em-dashes a null count', () => {
+    expect(formatCountLabel('Open tickets', null)).toBe('Open tickets · —');
+  });
+});

--- a/apps/mobile/src/screens/devices/deviceDetailFields.ts
+++ b/apps/mobile/src/screens/devices/deviceDetailFields.ts
@@ -1,0 +1,53 @@
+/**
+ * Pure formatting rules for the Device Details v1 fields (#5140, decision
+ * #5117-2): IP (LAN, with public on a second line when present), logged-in
+ * user, OS version alongside OS, and the open alert/ticket counts.
+ *
+ * "Empty values render '—', never blank" per the decision doc — kept here as
+ * pure string functions (no react-native import) so DeviceDetailScreen's JSX
+ * stays a straight prop-to-JSX mapping and this stays node-testable, matching
+ * lib/osLabel.ts's rationale.
+ */
+
+const EM_DASH = '—';
+
+function isBlank(value: string | null | undefined): value is null | undefined {
+  return value == null || value.trim().length === 0;
+}
+
+/** A single detail-row value: the string itself, or an em dash when absent. */
+export function formatDetailValue(value: string | null | undefined): string {
+  return isBlank(value) ? EM_DASH : value;
+}
+
+/**
+ * The IP detail row's value: LAN IP on the first line (em-dashed if absent),
+ * with the public/WAN IP appended on a second line only when present. A
+ * device with neither collapses to a single em dash rather than a dangling
+ * blank second line.
+ */
+export function formatIpValue(lanIp: string | null | undefined, publicIp: string | null | undefined): string {
+  const lanLine = formatDetailValue(lanIp);
+  if (isBlank(publicIp)) return lanLine;
+  return `${lanLine}\n${publicIp}`;
+}
+
+/**
+ * The OPERATING SYSTEM row's value: the OS label with its version appended
+ * when known. Unlike the other new fields, an absent version falls back to
+ * the bare OS label rather than an em dash — "Linux · —" reads as broken data
+ * where "Linux" reads as simply not yet reported.
+ */
+export function formatOsVersionValue(osLabel: string, osVersion: string | null | undefined): string {
+  return isBlank(osVersion) ? osLabel : `${osLabel} · ${osVersion}`;
+}
+
+/**
+ * "Open alerts · N" / "Open tickets · N". A real zero renders as `· 0` (the
+ * device genuinely has none open); only a missing count (undefined/null —
+ * the field hasn't been backfilled yet, or this is a stale cached record)
+ * em-dashes.
+ */
+export function formatCountLabel(label: string, count: number | null | undefined): string {
+  return `${label} · ${count == null ? EM_DASH : count}`;
+}

--- a/apps/mobile/src/services/api.deviceMapping.test.ts
+++ b/apps/mobile/src/services/api.deviceMapping.test.ts
@@ -104,3 +104,63 @@ describe('organization mapping', () => {
     expect(device!.organizationName).toBe('Acme Corp');
   });
 });
+
+// #5140: Device Details v1 fields (decision #5117-2) — osVersion, lastUser,
+// lanIp, publicIp, openAlertCount, openTicketCount.
+describe('Device Details v1 fields (#5140)', () => {
+  it('maps all six fields when present', async () => {
+    fetchWithTimeout.mockImplementationOnce(() =>
+      jsonResponse({
+        data: [
+          {
+            id: 'device-1',
+            hostname: 'host-1',
+            status: 'online',
+            orgId: 'org-1',
+            osVersion: '22.04',
+            lastUser: 'jdoe',
+            lanIp: '10.0.0.5',
+            publicIp: '203.0.113.9',
+            openAlertCount: 3,
+            openTicketCount: 2,
+          },
+        ],
+        pagination: { page: 1, limit: 100, total: 1, nextCursor: null },
+      })
+    );
+
+    const [device] = await getDevices();
+
+    expect(device!.osVersion).toBe('22.04');
+    expect(device!.lastUser).toBe('jdoe');
+    expect(device!.lanIp).toBe('10.0.0.5');
+    expect(device!.publicIp).toBe('203.0.113.9');
+    expect(device!.openAlertCount).toBe(3);
+    expect(device!.openTicketCount).toBe(2);
+  });
+
+  it('a device with none of the new fields still maps without throwing', async () => {
+    fetchWithTimeout.mockImplementationOnce(() =>
+      jsonResponse({
+        data: [
+          {
+            id: 'device-1',
+            hostname: 'host-1',
+            status: 'online',
+            orgId: 'org-1',
+          },
+        ],
+        pagination: { page: 1, limit: 100, total: 1, nextCursor: null },
+      })
+    );
+
+    const [device] = await getDevices();
+
+    expect(device!.osVersion).toBeUndefined();
+    expect(device!.lastUser).toBeUndefined();
+    expect(device!.lanIp).toBeUndefined();
+    expect(device!.publicIp).toBeUndefined();
+    expect(device!.openAlertCount).toBeUndefined();
+    expect(device!.openTicketCount).toBeUndefined();
+  });
+});

--- a/apps/mobile/src/services/api.deviceMapping.test.ts
+++ b/apps/mobile/src/services/api.deviceMapping.test.ts
@@ -139,6 +139,33 @@ describe('Device Details v1 fields (#5140)', () => {
     expect(device!.openTicketCount).toBe(2);
   });
 
+  it('maps an explicit null count (server-side count query failed) to undefined, not 0', async () => {
+    fetchWithTimeout.mockImplementationOnce(() =>
+      jsonResponse({
+        data: [
+          {
+            id: 'device-1',
+            hostname: 'host-1',
+            status: 'online',
+            orgId: 'org-1',
+            openAlertCount: null,
+            openTicketCount: 4,
+          },
+        ],
+        pagination: { page: 1, limit: 100, total: 1, nextCursor: null },
+      })
+    );
+
+    const [device] = await getDevices();
+
+    // formatCountLabel (deviceDetailFields.ts) treats undefined the same as
+    // null — an em dash, not a false "0" — so mapDevice normalizing an
+    // explicit API-side null to undefined here is the correct behavior, not
+    // a lossy simplification.
+    expect(device!.openAlertCount).toBeUndefined();
+    expect(device!.openTicketCount).toBe(4);
+  });
+
   it('a device with none of the new fields still maps without throwing', async () => {
     fetchWithTimeout.mockImplementationOnce(() =>
       jsonResponse({

--- a/apps/mobile/src/services/api.ts
+++ b/apps/mobile/src/services/api.ts
@@ -109,6 +109,15 @@ export interface Device {
   };
   createdAt: string;
   updatedAt: string;
+  /** Device Details v1 fields (#5140, decision #5117-2). */
+  osVersion?: string;
+  lastUser?: string;
+  /** Best current LAN address (ranked, see mobile.ts's #2503-style pick). */
+  lanIp?: string;
+  /** WAN address the agent last authenticated from. */
+  publicIp?: string;
+  openAlertCount?: number;
+  openTicketCount?: number;
 }
 
 export interface User {
@@ -322,6 +331,16 @@ type MobileDeviceRecord = {
   // same value under `orgName`. Both are read in mapDevice() below (#5104).
   organizationName?: string | null;
   orgName?: string | null;
+  // Device Details v1 fields (#5140, decision #5117-2). Sent by the list
+  // endpoint (`GET /mobile/devices`, routes/mobile.ts) today — see that
+  // route's loadDeviceDetailsV1Fields for how each is computed. Absent
+  // (rather than null) on any response shape that doesn't send them yet.
+  osVersion?: string | null;
+  lastUser?: string | null;
+  lanIp?: string | null;
+  publicIp?: string | null;
+  openAlertCount?: number;
+  openTicketCount?: number;
 };
 
 // Token management
@@ -636,7 +655,16 @@ function mapDevice(device: MobileDeviceRecord): Device {
     siteName: device.siteName || undefined,
     metrics: device.metrics,
     createdAt,
-    updatedAt
+    updatedAt,
+    // Device Details v1 fields (#5140). `?? undefined` rather than `||`:
+    // openAlertCount/openTicketCount are legitimately 0, which `||` would
+    // discard the same as a missing field.
+    osVersion: device.osVersion ?? undefined,
+    lastUser: device.lastUser ?? undefined,
+    lanIp: device.lanIp ?? undefined,
+    publicIp: device.publicIp ?? undefined,
+    openAlertCount: device.openAlertCount ?? undefined,
+    openTicketCount: device.openTicketCount ?? undefined
   };
 }
 

--- a/apps/mobile/src/services/api.ts
+++ b/apps/mobile/src/services/api.ts
@@ -335,12 +335,14 @@ type MobileDeviceRecord = {
   // endpoint (`GET /mobile/devices`, routes/mobile.ts) today — see that
   // route's loadDeviceDetailsV1Fields for how each is computed. Absent
   // (rather than null) on any response shape that doesn't send them yet.
+  // The counts are also explicitly `null` (never a false `0`) when the
+  // server-side count query itself failed — see loadDeviceDetailsV1Fields.
   osVersion?: string | null;
   lastUser?: string | null;
   lanIp?: string | null;
   publicIp?: string | null;
-  openAlertCount?: number;
-  openTicketCount?: number;
+  openAlertCount?: number | null;
+  openTicketCount?: number | null;
 };
 
 // Token management


### PR DESCRIPTION
## Summary

Implements decision #5117-2 (Device Details v1 field set): `GET /mobile/devices` now carries `osVersion`, `lastUser`, `lanIp`, `publicIp`, `openAlertCount`, and `openTicketCount`, and `DeviceDetailScreen` renders them.

**API (`apps/api/src/routes/mobile.ts`, `GET /devices`)**
- `osVersion` / `lastUser` / `publicIp` (aliased from `devices.lastSeenIp`) are plain columns — no extra query.
- `lanIp`: batched per-page lookup. Rather than a second SQL `LATERAL` (like `devices/core.ts`'s #2503 list column), this fetches all matching `device_network` rows for the page in one plain `SELECT ... WHERE device_id IN (...)` and ranks them in application code (same tiers: `is_primary` → IPv4 before IPv6 → routable before APIPA/link-local/loopback → interface name tiebreak). Keeps the route free of a raw `sql\`\`` LATERAL and the mocking that would require.
- `openAlertCount` / `openTicketCount`: two batched `GROUP BY` count queries. "Open" = `active`/`acknowledged` for alerts (mirrors `/summary`'s bucket), `new`/`open`/`pending`/`on_hold` for tickets (same set as `ticketReadModel.ts`'s `OPEN_TICKET_STATUSES` / `ticketService.ts`'s `ADDIN_OPEN_STATUSES`, both module-private so kept local here).
- All three new lookups are **separate queries from the main device-row select — never a LEFT JOIN on it** — so a device with many network interfaces/alerts/tickets can't fan the page out. Verified by a dedicated test.
- RLS/tenant scoping unchanged: everything runs inside the same request-scoped `withDbAccessContext` as the rest of the route.

**Design choice — enriched the list, not a new detail endpoint.** `getDevice()` in `apps/mobile/src/services/api.ts` calls `GET /devices/:id` on `devices/core.ts` (outside this PR's ownership), but no mobile screen actually calls `getDevice()` today — `DeviceDetailScreen` renders entirely from the `device` object handed to it via navigation params from the list fetch. So the fields were added to the list endpoint (batched once per page, ~100 devices), which is what the screen already depends on, rather than adding a new mobile-only detail route or touching the core web endpoint. Flagged for visibility — happy to add a lean detail endpoint instead if preferred.

**Mobile (`apps/mobile/src/services/api.ts`, `DeviceDetailScreen.tsx`)**
- `MobileDeviceRecord` / `Device` / `mapDevice()` carry the six new optional fields (`?? undefined`, not `||`, so a real `0` open-count survives).
- New pure helper `apps/mobile/src/screens/devices/deviceDetailFields.ts` (pattern: `lib/osLabel.ts`) — `formatDetailValue`, `formatIpValue`, `formatOsVersionValue`, `formatCountLabel` — keeps the "—" fallback and two-line IP rules out of JSX, node-testable without React Native.
- Rows: IP (LAN, public on a second line when present), Logged-in user, and OS version (appended to the existing OS row) always render with "—" for absent values, per the decision doc — unlike the pre-existing rows, which hide entirely when unset. "Open alerts · N" / "Open tickets · N" render as plain text (no navigation): no alerts-list or device-filtered tickets-list screen exists on mobile yet to link to.

## Test plan
- [x] `cd apps/api && npx vitest run src/routes/mobile.test.ts` — 80 passed (2 pre-existing skips), including two new tests: no-fields-present defaults to null/0, and a fan-out guard (2 network rows + count>1 alerts/tickets still yield exactly 1 response row).
- [x] `cd apps/api && NODE_OPTIONS=--max-old-space-size=12288 npx tsc --noEmit` — clean.
- [x] `cd apps/mobile && npx vitest run` — 1314 passed / 3 pre-existing skips (full suite), including new `deviceDetailFields.test.ts` (15 cases) and extended `api.deviceMapping.test.ts`.
- [x] `cd apps/mobile && npx tsc --noEmit` — clean.
- [x] `npx eslint` on all changed API files — clean. (No `eslint.config.*` exists for `apps/mobile`, so it isn't linted this way.)

Closes #5140

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvApTe8M34RiVxBafdJGBm