### PR TITLE
feat(commands): offline work queue W01 — deliver_by, policy seam, two-clock reaper, claim eligibility, cancel (#5131)

### DIFF
--- a/apps/api/migrations/2026-10-13-100000-device-commands-deliver-by.sql
+++ b/apps/api/migrations/2026-10-13-100000-device-commands-deliver-by.sql
@@ -4,7 +4,9 @@
 -- claimed the row (pending -> sent). It is separate from the execution timeout
 -- (services/commandTimeouts.ts), which the stale reaper applies to `sent` rows
 -- from executed_at. NULL keeps today's rule for rows created before this
--- migration, so no backfill is needed and old pending rows behave as before.
+-- migration, so no backfill is needed and old pending rows behave as before
+-- (software_install's retired 7-day special case is preserved for such legacy
+-- rows inside the reaper, not here).
 --
 -- submitted_org_id is PROVENANCE, NOT TENANCY. device_commands is intentionally
 -- system-scoped (agent WS path, no RLS -- see CLAUDE.md). This column records the

--- a/apps/api/migrations/2026-10-13-100000-device-commands-deliver-by.sql
+++ b/apps/api/migrations/2026-10-13-100000-device-commands-deliver-by.sql
@@ -1,0 +1,41 @@
+-- 2026-10-13-100000: deferred delivery for device commands (#5128).
+--
+-- deliver_by is the DELIVERY deadline: the instant by which an agent must have
+-- claimed the row (pending -> sent). It is separate from the execution timeout
+-- (services/commandTimeouts.ts), which the stale reaper applies to `sent` rows
+-- from executed_at. NULL keeps today's rule for rows created before this
+-- migration, so no backfill is needed and old pending rows behave as before.
+--
+-- submitted_org_id is PROVENANCE, NOT TENANCY. device_commands is intentionally
+-- system-scoped (agent WS path, no RLS -- see CLAUDE.md). This column records the
+-- device's org at enqueue so claim-time eligibility can cancel rows whose device
+-- has since moved org. It is deliberately not named org_id: the RLS-coverage and
+-- cascade contract tests auto-discover `org_id` columns, and this table must
+-- not be reclassified as tenant-scoped. ON DELETE SET NULL so erasing an org a
+-- device has LEFT is never blocked by that device's historical rows.
+--
+-- DDL only: no DML, so no set_config('breeze.scope', 'system', true) is needed
+-- (migrationRlsScope.test.ts).
+
+ALTER TABLE device_commands ADD COLUMN IF NOT EXISTS deliver_by timestamptz;
+
+ALTER TABLE device_commands ADD COLUMN IF NOT EXISTS submitted_org_id uuid;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'device_commands_submitted_org_id_fkey'
+      AND conrelid = 'device_commands'::regclass
+  ) THEN
+    ALTER TABLE device_commands
+      ADD CONSTRAINT device_commands_submitted_org_id_fkey
+      FOREIGN KEY (submitted_org_id) REFERENCES organizations(id) ON DELETE SET NULL;
+  END IF;
+END $$;
+
+-- Reaper scan for due deliveries; partial so 7-day rows are not rescanned
+-- every 2 minutes and so the index stays small relative to the table.
+CREATE INDEX IF NOT EXISTS idx_device_commands_deliver_by
+  ON device_commands (deliver_by)
+  WHERE status = 'pending' AND deliver_by IS NOT NULL;

--- a/apps/api/src/__tests__/devices.endpoints.test.ts
+++ b/apps/api/src/__tests__/devices.endpoints.test.ts
@@ -11,6 +11,27 @@ vi.mock('../services/commandQueue', () => ({
   queueCommand: (...args: unknown[]) => mockQueueCommand(...args)
 }));
 
+// #5128 — POST /devices/bulk/commands now goes through the one enqueue seam
+// (services/dispatchDeviceCommand.ts) instead of a raw db.insert. That real
+// implementation pulls in a long transitive chain (agentWs, commandQueue,
+// commandOfflinePolicy, partnerTrust.commands) this suite's simple db mock
+// can't reasonably emulate — see routes/devices/commands.test.ts for the same
+// seam-level mock and rationale. Default: delivered to an online device;
+// decommissioned/offline outcomes are driven by the device row this suite
+// already mocks BEFORE the route ever reaches dispatch.
+const mockDispatchDeviceCommand = vi.fn(
+  async ({ deviceId, type }: { deviceId: string; type: string }) => ({
+    ok: true,
+    command: { id: 'cmd-1', deviceId, type, status: 'pending', createdAt: new Date() },
+    delivery: 'delivered',
+    deliverBy: new Date(Date.now() + 7 * 24 * 3600 * 1000),
+  }),
+);
+
+vi.mock('../services/dispatchDeviceCommand', () => ({
+  dispatchDeviceCommand: (...args: unknown[]) => (mockDispatchDeviceCommand as any)(...args),
+}));
+
 vi.mock('../services/auditEvents', () => ({
   requestLikeFromSnapshot: vi.fn(() => ({ req: { header: () => undefined } })),
   writeAuditEvent: vi.fn(),
@@ -196,6 +217,16 @@ describe('device endpoints (authenticated)', () => {
       }))
     }) as any);
     mockQueueCommand.mockReset();
+    // vi.resetAllMocks() above wipes the default implementation too —
+    // restore it explicitly, same as the db.select/insert/update mocks.
+    mockDispatchDeviceCommand.mockReset().mockImplementation(
+      async ({ deviceId, type }: { deviceId: string; type: string }) => ({
+        ok: true,
+        command: { id: 'cmd-1', deviceId, type, status: 'pending', createdAt: new Date() },
+        delivery: 'delivered',
+        deliverBy: new Date(Date.now() + 7 * 24 * 3600 * 1000),
+      }),
+    );
     app = new Hono();
     app.route('/devices', deviceRoutes);
   });
@@ -211,31 +242,10 @@ describe('device endpoints (authenticated)', () => {
       mockDeviceLookup(deviceTwo);
       mockDeviceLookup(deviceThree);
 
-      // The bulk command handler uses db.insert().values().returning() for each device
-      vi.mocked(db.insert)
-        .mockReturnValueOnce({
-          values: vi.fn().mockReturnValue({
-            returning: vi.fn().mockResolvedValue([{
-              id: 'cmd-1',
-              deviceId: deviceOne.id,
-              type: 'reboot',
-              status: 'pending',
-              createdAt: new Date()
-            }])
-          })
-        } as any)
-        .mockReturnValueOnce({
-          values: vi.fn().mockReturnValue({
-            returning: vi.fn().mockResolvedValue([{
-              id: 'cmd-2',
-              deviceId: deviceTwo.id,
-              type: 'reboot',
-              status: 'pending',
-              createdAt: new Date()
-            }])
-          })
-        } as any);
-
+      // #5128: the bulk command handler now goes through the one enqueue
+      // seam (services/dispatchDeviceCommand.ts, mocked above) instead of a
+      // raw db.insert. The decommissioned device is rejected by the route
+      // BEFORE it ever reaches the seam, so only two calls land here.
       const client = await createAuthenticatedClient(app, { mfa: true });
       const res = await client.post('/devices/bulk/commands', {
         deviceIds: [deviceOne.id, deviceTwo.id, deviceThree.id],
@@ -256,6 +266,12 @@ describe('device endpoints (authenticated)', () => {
         deviceOne.id,
         deviceTwo.id
       ]);
+      // The decommissioned device never reached the dispatch seam at all —
+      // it was rejected before it, not by it.
+      expect(mockDispatchDeviceCommand).toHaveBeenCalledTimes(2);
+      expect(mockDispatchDeviceCommand).not.toHaveBeenCalledWith(
+        expect.objectContaining({ deviceId: deviceThree.id }),
+      );
     });
   });
 

--- a/apps/api/src/__tests__/integration/deviceCommandOfflineQueue.integration.test.ts
+++ b/apps/api/src/__tests__/integration/deviceCommandOfflineQueue.integration.test.ts
@@ -14,7 +14,9 @@ import {
   scriptExecutionBatches,
   scriptExecutions,
   scripts,
+  softwareCatalog,
   softwareDeployments,
+  softwareVersions,
   users,
 } from '../../db/schema';
 import {
@@ -701,11 +703,24 @@ describe('device command offline queue — real PostgreSQL (#5128 W1)', () => {
     // and the Software page shows an install that is neither running nor done.
     const device = await makeDevice(env.organization.id, env.site.id, 'offline');
 
+    // `software_deployments_one_target_chk` requires EXACTLY one of
+    // software_version_id / install_method_id, so the fixture needs a real
+    // catalog + version behind it.
+    const [catalog] = await getTestDb()
+      .insert(softwareCatalog)
+      .values({ orgId: env.organization.id, name: `Claim Cancel App ${randomUUID().slice(0, 8)}` })
+      .returning();
+    const [version] = await getTestDb()
+      .insert(softwareVersions)
+      .values({ catalogId: catalog!.id, version: '1.0.0', s3Key: 'installers/app.exe' })
+      .returning();
+
     const [deployment] = await getTestDb()
       .insert(softwareDeployments)
       .values({
         orgId: env.organization.id,
         name: 'Claim Cancel Deployment',
+        softwareVersionId: version!.id,
         deploymentType: 'install',
         targetType: 'device',
         targetIds: [device.id],

--- a/apps/api/src/__tests__/integration/deviceCommandOfflineQueue.integration.test.ts
+++ b/apps/api/src/__tests__/integration/deviceCommandOfflineQueue.integration.test.ts
@@ -1,0 +1,563 @@
+import './setup';
+
+import { randomUUID } from 'node:crypto';
+
+import { and, eq, sql } from 'drizzle-orm';
+import { Hono } from 'hono';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { withSystemDbAccessContext } from '../../db';
+import { deviceCommands, devices, scriptExecutions, scripts, users } from '../../db/schema';
+import { reapStaleDeviceCommands, reapStaleScriptExecutions } from '../../jobs/staleCommandReaper';
+import { commandsRoutes } from '../../routes/devices/commands';
+import { claimPendingCommandsForDevice } from '../../services/commandDispatch';
+import { deliveryTtlMs } from '../../services/commandOfflinePolicy';
+import { dispatchDeviceCommand } from '../../services/dispatchDeviceCommand';
+import { createAccessToken } from '../../services/jwt';
+import { createOrganization, createPartner, createSite, setupTestEnvironment } from './db-utils';
+import { getTestDb } from './setup';
+
+/**
+ * #5128 W1 — real-Postgres proof of the offline work queue's core contract.
+ *
+ * Every case here is one a mocked unit test cannot decide, because the thing
+ * under test IS the SQL: which rows the reaper's two-clock WHERE selects, which
+ * rows the claim's `deliver_by` predicate and eligibility filter exclude, and
+ * whether a cancel/CAS actually matched a row in the database.
+ */
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+const AGENT_CAPS = {
+  peripheralPolicyProtocolVersion: 2,
+  rollbackProtocolVersion: 1,
+  pamLifetimeProtocolVersion: 2,
+} as const;
+
+/**
+ * These services are always invoked from inside a DB access context in the
+ * running API (a request context, or the reaper worker's own system wrap).
+ * Calling them bare here would hit the contextless-access guard, which DENIES
+ * rather than bypasses — every query would return zero rows and the assertions
+ * below would pass for entirely the wrong reason.
+ */
+function asSystem<T>(fn: () => Promise<T>): Promise<T> {
+  return withSystemDbAccessContext(fn);
+}
+
+function claim(deviceId: string) {
+  return asSystem(() => claimPendingCommandsForDevice(deviceId, 10, 'agent', undefined, { ...AGENT_CAPS }));
+}
+
+async function makeDevice(orgId: string, siteId: string, status: string) {
+  const [device] = await getTestDb()
+    .insert(devices)
+    .values({
+      orgId,
+      siteId,
+      agentId: `offline-queue-${randomUUID()}`,
+      hostname: `host-${randomUUID().slice(0, 8)}`,
+      osType: 'linux',
+      osVersion: 'test',
+      architecture: 'x64',
+      agentVersion: '0.0.0-test',
+      status,
+    })
+    .returning();
+  if (!device) throw new Error('device fixture insert failed');
+  return device;
+}
+
+async function commandRow(id: string) {
+  const [row] = await getTestDb().select().from(deviceCommands).where(eq(deviceCommands.id, id)).limit(1);
+  return row;
+}
+
+async function countCommandsFor(deviceId: string) {
+  const rows = await getTestDb()
+    .select({ id: deviceCommands.id })
+    .from(deviceCommands)
+    .where(eq(deviceCommands.deviceId, deviceId));
+  return rows.length;
+}
+
+describe('device command offline queue — real PostgreSQL (#5128 W1)', () => {
+  let env: Awaited<ReturnType<typeof setupTestEnvironment>>;
+
+  beforeEach(async () => {
+    env = await setupTestEnvironment({ scope: 'organization' });
+    // The generic device-command routes queue regardless of this flag, but the
+    // seam's `previouslyRejected` callers are gated on it; turn it on so the
+    // queue arm is exercised end to end.
+    process.env.DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED = 'true';
+  });
+
+  it('queues against an offline device with a deliver_by and submitted_org_id', async () => {
+    const device = await makeDevice(env.organization.id, env.site.id, 'offline');
+
+    const before = Date.now();
+    const res = await asSystem(() =>
+      dispatchDeviceCommand({ deviceId: device.id, type: 'refresh_inventory', userId: env.user.id }),
+    );
+
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.delivery).toBe('queued_offline');
+
+    const row = await commandRow(res.command.id);
+    expect(row?.status).toBe('pending');
+    expect(row?.submittedOrgId).toBe(env.organization.id);
+    expect(row?.deliverBy).toBeInstanceOf(Date);
+    // refresh_inventory is a `short` (24 h) TTL class.
+    const ttl = row!.deliverBy!.getTime() - before;
+    expect(ttl).toBeGreaterThan(deliveryTtlMs('short') - 60_000);
+    expect(ttl).toBeLessThan(deliveryTtlMs('short') + 60_000);
+  });
+
+  it('a reject-policy dispatch against an offline device creates NO row', async () => {
+    const device = await makeDevice(env.organization.id, env.site.id, 'offline');
+
+    const res = await asSystem(() =>
+      dispatchDeviceCommand({ deviceId: device.id, type: 'list_processes', userId: env.user.id }),
+    );
+
+    expect(res).toMatchObject({ ok: false, code: 'device_offline' });
+    expect(await countCommandsFor(device.id)).toBe(0);
+  });
+
+  it('a queued row survives long past its EXECUTION timeout while deliver_by is in the future', async () => {
+    const device = await makeDevice(env.organization.id, env.site.id, 'offline');
+
+    // A script with a 300 s execution timeout, created two hours ago. Under the
+    // pre-#5128 rule this was reaped as "agent never received the command".
+    const [row] = await getTestDb()
+      .insert(deviceCommands)
+      .values({
+        deviceId: device.id,
+        type: 'script',
+        payload: { timeoutSeconds: 300 },
+        status: 'pending',
+        createdAt: new Date(Date.now() - 2 * HOUR_MS),
+        deliverBy: new Date(Date.now() + 6 * DAY_MS),
+        submittedOrgId: env.organization.id,
+      })
+      .returning();
+
+    expect(await asSystem(() => reapStaleDeviceCommands())).toBe(0);
+    expect((await commandRow(row!.id))?.status).toBe('pending');
+  });
+
+  it('expires exactly at deliver_by with expired / not_delivered_before_deadline', async () => {
+    const device = await makeDevice(env.organization.id, env.site.id, 'offline');
+
+    const [row] = await getTestDb()
+      .insert(deviceCommands)
+      .values({
+        deviceId: device.id,
+        type: 'script',
+        payload: { timeoutSeconds: 300 },
+        status: 'pending',
+        createdAt: new Date(Date.now() - 2 * HOUR_MS),
+        deliverBy: new Date(Date.now() - 1000),
+        submittedOrgId: env.organization.id,
+      })
+      .returning();
+
+    expect(await asSystem(() => reapStaleDeviceCommands())).toBeGreaterThanOrEqual(1);
+
+    const after = await commandRow(row!.id);
+    expect(after?.status).toBe('failed');
+    expect(after?.result).toMatchObject({
+      status: 'expired',
+      reason: 'not_delivered_before_deadline',
+      timedOutBy: 'server',
+    });
+  });
+
+  it('the script execution is failed only by propagation, never by its own reaper', async () => {
+    const device = await makeDevice(env.organization.id, env.site.id, 'offline');
+    const [script] = await getTestDb()
+      .insert(scripts)
+      .values({
+        orgId: env.organization.id,
+        name: 'Offline Queue Script',
+        osTypes: ['linux'],
+        language: 'bash',
+        content: 'true',
+        timeoutSeconds: 300,
+      })
+      .returning();
+
+    async function seed(deliverBy: Date) {
+      const [execution] = await getTestDb()
+        .insert(scriptExecutions)
+        .values({
+          scriptId: script!.id,
+          deviceId: device.id,
+          orgId: env.organization.id,
+          status: 'queued',
+          createdAt: new Date(Date.now() - 2 * HOUR_MS),
+        })
+        .returning();
+      const [command] = await getTestDb()
+        .insert(deviceCommands)
+        .values({
+          deviceId: device.id,
+          type: 'script',
+          payload: { timeoutSeconds: 300, executionId: execution!.id },
+          status: 'pending',
+          createdAt: new Date(Date.now() - 2 * HOUR_MS),
+          deliverBy,
+          submittedOrgId: env.organization.id,
+        })
+        .returning();
+      return { execution: execution!, command: command! };
+    }
+
+    // 1. Still waiting for the device: the SCRIPT reaper must not touch it. Its
+    //    own 300 s execution timeout lapsed 2 h ago, so before #5128 this
+    //    execution was failed under a command that was legitimately waiting.
+    const waiting = await seed(new Date(Date.now() + 6 * DAY_MS));
+    expect(await asSystem(() => reapStaleScriptExecutions())).toBe(0);
+    const [waitingExec] = await getTestDb()
+      .select()
+      .from(scriptExecutions)
+      .where(eq(scriptExecutions.id, waiting.execution.id))
+      .limit(1);
+    expect(waitingExec?.status).toBe('queued');
+
+    // 2. Past its deadline: the COMMAND reaper expires it and propagates.
+    const expired = await seed(new Date(Date.now() - 1000));
+    await asSystem(() => reapStaleDeviceCommands());
+    const [expiredExec] = await getTestDb()
+      .select()
+      .from(scriptExecutions)
+      .where(eq(scriptExecutions.id, expired.execution.id))
+      .limit(1);
+    expect(expiredExec?.status).toBe('failed');
+    expect(expiredExec?.errorMessage).toContain('did not reconnect');
+  });
+
+  it('a heartbeat claim after the device comes online delivers the row exactly once', async () => {
+    const device = await makeDevice(env.organization.id, env.site.id, 'offline');
+    const res = await asSystem(() =>
+      dispatchDeviceCommand({ deviceId: device.id, type: 'refresh_inventory', userId: env.user.id }),
+    );
+    expect(res.ok).toBe(true);
+
+    await getTestDb().update(devices).set({ status: 'online' }).where(eq(devices.id, device.id));
+
+    const first = await claim(device.id);
+    expect(first.map((c) => c.type)).toEqual(['refresh_inventory']);
+    expect(first[0]?.status).toBe('sent');
+
+    expect(await claim(device.id)).toEqual([]);
+  });
+
+  it('a row past its deliver_by is NOT claimed — the reaper owns it', async () => {
+    const device = await makeDevice(env.organization.id, env.site.id, 'online');
+    await getTestDb().insert(deviceCommands).values({
+      deviceId: device.id,
+      type: 'refresh_inventory',
+      payload: {},
+      status: 'pending',
+      deliverBy: new Date(Date.now() - 1000),
+      submittedOrgId: env.organization.id,
+    });
+
+    expect(await claim(device.id)).toEqual([]);
+  });
+
+  it('a device that moved org has its queued rows cancelled at claim, never delivered', async () => {
+    const device = await makeDevice(env.organization.id, env.site.id, 'online');
+    const res = await asSystem(() =>
+      dispatchDeviceCommand({
+        deviceId: device.id,
+        type: 'refresh_inventory',
+        userId: env.user.id,
+        preferHeartbeat: true,
+      }),
+    );
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+
+    const otherPartner = await createPartner({ name: `Other Partner ${randomUUID().slice(0, 8)}` });
+    const otherOrg = await createOrganization({
+      partnerId: otherPartner.id,
+      name: `Other Org ${randomUUID().slice(0, 8)}`,
+    });
+    const otherSite = await createSite({ orgId: otherOrg.id });
+    await getTestDb()
+      .update(devices)
+      .set({ orgId: otherOrg.id, siteId: otherSite.id })
+      .where(eq(devices.id, device.id));
+
+    expect(await claim(device.id)).toEqual([]);
+
+    const after = await commandRow(res.command.id);
+    expect(after?.status).toBe('cancelled');
+    expect(after?.result).toMatchObject({ reason: 'device_moved_org' });
+  });
+
+  it('a reboot is held while other work is claimable, then claimed once the queue drains', async () => {
+    const device = await makeDevice(env.organization.id, env.site.id, 'online');
+
+    const [inventory] = await getTestDb()
+      .insert(deviceCommands)
+      .values({
+        deviceId: device.id,
+        type: 'refresh_inventory',
+        payload: {},
+        status: 'pending',
+        createdAt: new Date(Date.now() - 60_000),
+        deliverBy: new Date(Date.now() + HOUR_MS),
+        submittedOrgId: env.organization.id,
+      })
+      .returning();
+    const [reboot] = await getTestDb()
+      .insert(deviceCommands)
+      .values({
+        deviceId: device.id,
+        type: 'reboot',
+        payload: {},
+        status: 'pending',
+        createdAt: new Date(Date.now() - 30_000),
+        deliverBy: new Date(Date.now() + HOUR_MS),
+        submittedOrgId: env.organization.id,
+      })
+      .returning();
+
+    const first = await claim(device.id);
+    expect(first.map((c) => c.id)).toEqual([inventory!.id]);
+    expect((await commandRow(reboot!.id))?.status).toBe('pending');
+
+    // While the inventory command is still in flight (`sent`), the barrier holds.
+    expect(await claim(device.id)).toEqual([]);
+
+    await getTestDb()
+      .update(deviceCommands)
+      .set({ status: 'completed', completedAt: new Date() })
+      .where(eq(deviceCommands.id, inventory!.id));
+
+    const third = await claim(device.id);
+    expect(third.map((c) => c.id)).toEqual([reboot!.id]);
+  });
+
+  it('POST /devices/:id/commands/:commandId/cancel cancels once, then 409s', async () => {
+    const device = await makeDevice(env.organization.id, env.site.id, 'offline');
+    const res = await asSystem(() =>
+      dispatchDeviceCommand({ deviceId: device.id, type: 'refresh_inventory', userId: env.user.id }),
+    );
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+
+    const app = new Hono();
+    app.route('/devices', commandsRoutes);
+    const token = await createAccessToken({
+      sub: env.user.id,
+      email: env.user.email,
+      roleId: env.role.id,
+      orgId: env.organization.id,
+      partnerId: env.partner.id,
+      scope: 'organization',
+      mfa: true,
+      aep: 1,
+      mep: 1,
+      sid: randomUUID(),
+    });
+
+    const url = `/devices/${device.id}/commands/${res.command.id}/cancel`;
+    const first = await app.request(url, { method: 'POST', headers: { Authorization: `Bearer ${token}` } });
+    expect(first.status).toBe(200);
+    expect(await first.json()).toMatchObject({ status: 'cancelled' });
+
+    const after = await commandRow(res.command.id);
+    expect(after?.status).toBe('cancelled');
+    expect(after?.result).toMatchObject({ reason: 'user_cancelled' });
+
+    const second = await app.request(url, { method: 'POST', headers: { Authorization: `Bearer ${token}` } });
+    expect(second.status).toBe(409);
+  });
+
+  it('a cancelled row is never claimed afterwards', async () => {
+    const device = await makeDevice(env.organization.id, env.site.id, 'online');
+    const [row] = await getTestDb()
+      .insert(deviceCommands)
+      .values({
+        deviceId: device.id,
+        type: 'refresh_inventory',
+        payload: {},
+        status: 'cancelled',
+        completedAt: new Date(),
+        deliverBy: new Date(Date.now() + HOUR_MS),
+        submittedOrgId: env.organization.id,
+      })
+      .returning();
+
+    expect(await claim(device.id)).toEqual([]);
+    expect((await commandRow(row!.id))?.status).toBe('cancelled');
+  });
+
+  it('legacy pending rows (deliver_by NULL) keep the old created_at + execution-timeout rule', async () => {
+    const device = await makeDevice(env.organization.id, env.site.id, 'offline');
+    const [row] = await getTestDb()
+      .insert(deviceCommands)
+      .values({
+        deviceId: device.id,
+        type: 'script',
+        payload: { timeoutSeconds: 300 },
+        status: 'pending',
+        createdAt: new Date(Date.now() - 2 * HOUR_MS),
+        deliverBy: null,
+        submittedOrgId: null,
+      })
+      .returning();
+
+    expect(await asSystem(() => reapStaleDeviceCommands())).toBeGreaterThanOrEqual(1);
+    const after = await commandRow(row!.id);
+    expect(after?.status).toBe('failed');
+    expect(after?.result).toMatchObject({ status: 'timeout' });
+  });
+
+  it('a legacy row with a NULL submitted_org_id is still claimable (no false org-drift cancel)', async () => {
+    const device = await makeDevice(env.organization.id, env.site.id, 'online');
+    await getTestDb().insert(deviceCommands).values({
+      deviceId: device.id,
+      type: 'refresh_inventory',
+      payload: {},
+      status: 'pending',
+      deliverBy: null,
+      submittedOrgId: null,
+    });
+
+    const claimed = await claim(device.id);
+    expect(claimed.map((c) => c.type)).toEqual(['refresh_inventory']);
+  });
+
+  it('a decommissioned device gets no new commands and its pending work is not delivered', async () => {
+    const device = await makeDevice(env.organization.id, env.site.id, 'online');
+    const res = await asSystem(() =>
+      dispatchDeviceCommand({
+        deviceId: device.id,
+        type: 'refresh_inventory',
+        userId: env.user.id,
+        preferHeartbeat: true,
+      }),
+    );
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+
+    await getTestDb().update(devices).set({ status: 'decommissioned' }).where(eq(devices.id, device.id));
+
+    const refused = await asSystem(() =>
+      dispatchDeviceCommand({ deviceId: device.id, type: 'refresh_inventory', userId: env.user.id }),
+    );
+    expect(refused).toMatchObject({ ok: false, code: 'device_decommissioned' });
+
+    expect(await claim(device.id)).toEqual([]);
+    const after = await commandRow(res.command.id);
+    expect(after?.status).toBe('cancelled');
+    expect(after?.result).toMatchObject({ reason: 'device_lifecycle' });
+  });
+
+  it('the partial deliver_by index exists, so the reaper scan never seq-scans device_commands', async () => {
+    const rows = await getTestDb().execute(sql`
+      SELECT indexdef FROM pg_indexes
+      WHERE tablename = 'device_commands' AND indexname = 'idx_device_commands_deliver_by'
+    `);
+    const list = rows as unknown as Array<{ indexdef: string }>;
+    expect(list).toHaveLength(1);
+    expect(list[0]!.indexdef).toContain('deliver_by');
+    // Partial: a full index over every row would defeat the point of keeping
+    // 7-day rows out of the two-minute rescan.
+    expect(list[0]!.indexdef).toContain('WHERE');
+    expect(list[0]!.indexdef).toContain('pending');
+  });
+
+  it('device_commands still has NO org_id column — submitted_org_id must not reclassify the table', async () => {
+    const rows = await getTestDb().execute(sql`
+      SELECT column_name FROM information_schema.columns
+      WHERE table_name = 'device_commands' AND column_name = 'org_id'
+    `);
+    expect(rows as unknown as unknown[]).toHaveLength(0);
+  });
+
+  it('the seam refuses an unregistered command type before touching the database', async () => {
+    const device = await makeDevice(env.organization.id, env.site.id, 'online');
+    await expect(
+      asSystem(() =>
+        dispatchDeviceCommand({ deviceId: device.id, type: 'not_a_real_command_type', userId: env.user.id }),
+      ),
+    ).rejects.toThrow(/COMMAND_OFFLINE_POLICY_REGISTRY/);
+    expect(await countCommandsFor(device.id)).toBe(0);
+  });
+
+  it('an inactive requester has their queued work cancelled at claim', async () => {
+    const device = await makeDevice(env.organization.id, env.site.id, 'online');
+    const res = await asSystem(() =>
+      dispatchDeviceCommand({
+        deviceId: device.id,
+        type: 'refresh_inventory',
+        userId: env.user.id,
+        preferHeartbeat: true,
+      }),
+    );
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+
+    // Positive control: without a recorded requester this test would pass for
+    // the wrong reason (eligibility skips rows whose created_by is NULL).
+    expect((await commandRow(res.command.id))?.createdBy).toBe(env.user.id);
+
+    await getTestDb().update(users).set({ status: 'disabled' }).where(eq(users.id, env.user.id));
+
+    expect(await claim(device.id)).toEqual([]);
+    const after = await commandRow(res.command.id);
+    expect(after?.status).toBe('cancelled');
+    expect(after?.result).toMatchObject({ reason: 'requester_inactive' });
+  });
+
+  it('the cancel-on-event predicate spares in-flight work', async () => {
+    // Mirrors the org-move / decommission cancel the routes write, exercised
+    // directly so the SQL predicate (status='pending' only) is proven against a
+    // real table rather than a chainable mock.
+    const device = await makeDevice(env.organization.id, env.site.id, 'online');
+    const [pending] = await getTestDb()
+      .insert(deviceCommands)
+      .values({
+        deviceId: device.id,
+        type: 'refresh_inventory',
+        payload: {},
+        status: 'pending',
+        deliverBy: new Date(Date.now() + HOUR_MS),
+        submittedOrgId: env.organization.id,
+      })
+      .returning();
+    const [alreadySent] = await getTestDb()
+      .insert(deviceCommands)
+      .values({
+        deviceId: device.id,
+        type: 'script',
+        payload: {},
+        status: 'sent',
+        executedAt: new Date(),
+        deliverBy: new Date(Date.now() + HOUR_MS),
+        submittedOrgId: env.organization.id,
+      })
+      .returning();
+
+    await getTestDb()
+      .update(deviceCommands)
+      .set({
+        status: 'cancelled',
+        completedAt: new Date(),
+        result: { status: 'cancelled', reason: 'device_moved_org' },
+      })
+      .where(and(eq(deviceCommands.deviceId, device.id), eq(deviceCommands.status, 'pending')));
+
+    expect((await commandRow(pending!.id))?.status).toBe('cancelled');
+    // An in-flight command is NOT cancelled — it is already on the machine.
+    expect((await commandRow(alreadySent!.id))?.status).toBe('sent');
+  });
+});

--- a/apps/api/src/__tests__/integration/deviceCommandOfflineQueue.integration.test.ts
+++ b/apps/api/src/__tests__/integration/deviceCommandOfflineQueue.integration.test.ts
@@ -8,7 +8,11 @@ import { beforeEach, describe, expect, it } from 'vitest';
 
 import { withSystemDbAccessContext } from '../../db';
 import { deviceCommands, devices, scriptExecutions, scripts, users } from '../../db/schema';
-import { reapStaleDeviceCommands, reapStaleScriptExecutions } from '../../jobs/staleCommandReaper';
+import {
+  propagateCancelledDeviceCommands,
+  reapStaleDeviceCommands,
+  reapStaleScriptExecutions,
+} from '../../jobs/staleCommandReaper';
 import { commandsRoutes } from '../../routes/devices/commands';
 import { claimPendingCommandsForDevice } from '../../services/commandDispatch';
 import { deliveryTtlMs } from '../../services/commandOfflinePolicy';
@@ -562,4 +566,117 @@ describe('device command offline queue — real PostgreSQL (#5128 W1)', () => {
     // An in-flight command is NOT cancelled — it is already on the machine.
     expect((await commandRow(alreadySent!.id))?.status).toBe('sent');
   });
+
+  it('cancel-on-event terminalises the OWNING script execution, not just the command', async () => {
+    // The regression this pins: the org-move / decommission sweeps cancel the
+    // device_commands row directly. A cancelled command is terminal, so the
+    // command reaper (which scans only pending/sent) never revisits it — if the
+    // sweep does not propagate, the script_executions row hangs `queued`
+    // forever with nothing left to resolve it. That is exactly the silent death
+    // this feature exists to remove.
+    const device = await makeDevice(env.organization.id, env.site.id, 'offline');
+    const [script] = await getTestDb()
+      .insert(scripts)
+      .values({
+        orgId: env.organization.id,
+        name: 'Cancel Propagation Script',
+        osTypes: ['linux'],
+        language: 'bash',
+        content: 'true',
+        timeoutSeconds: 300,
+      })
+      .returning();
+    const [execution] = await getTestDb()
+      .insert(scriptExecutions)
+      .values({
+        scriptId: script!.id,
+        deviceId: device.id,
+        orgId: env.organization.id,
+        status: 'queued',
+      })
+      .returning();
+    const [command] = await getTestDb()
+      .insert(deviceCommands)
+      .values({
+        deviceId: device.id,
+        type: 'script',
+        payload: { timeoutSeconds: 300, executionId: execution!.id },
+        status: 'pending',
+        deliverBy: new Date(Date.now() + HOUR_MS),
+        submittedOrgId: env.organization.id,
+      })
+      .returning();
+
+    const completedAt = new Date();
+    await asSystem(async () => {
+      await getTestDb()
+        .update(deviceCommands)
+        .set({
+          status: 'cancelled',
+          completedAt,
+          result: { status: 'cancelled', reason: 'device_moved_org' },
+        })
+        .where(and(eq(deviceCommands.deviceId, device.id), eq(deviceCommands.status, 'pending')));
+      await propagateCancelledDeviceCommands(
+        [{ id: command!.id, type: 'script', payload: { executionId: execution!.id } }],
+        completedAt,
+      );
+    });
+
+    const [after] = await getTestDb()
+      .select()
+      .from(scriptExecutions)
+      .where(eq(scriptExecutions.id, execution!.id))
+      .limit(1);
+    expect(after?.status).toBe('cancelled');
+    expect(after?.errorMessage).toContain('Cancelled before the device received it');
+  });
+
+  it('the script reaper reports a cancelled command as cancelled, not as agent silence', async () => {
+    // Downstream of the same defect: without the `cancelled` arm the reaper
+    // stamped "no response from agent" on a command the agent was never asked
+    // to run.
+    const device = await makeDevice(env.organization.id, env.site.id, 'offline');
+    const [script] = await getTestDb()
+      .insert(scripts)
+      .values({
+        orgId: env.organization.id,
+        name: 'Cancelled Diagnosis Script',
+        osTypes: ['linux'],
+        language: 'bash',
+        content: 'true',
+        timeoutSeconds: 300,
+      })
+      .returning();
+    const [execution] = await getTestDb()
+      .insert(scriptExecutions)
+      .values({
+        scriptId: script!.id,
+        deviceId: device.id,
+        orgId: env.organization.id,
+        status: 'queued',
+        createdAt: new Date(Date.now() - 2 * HOUR_MS),
+      })
+      .returning();
+    await getTestDb().insert(deviceCommands).values({
+      deviceId: device.id,
+      type: 'script',
+      payload: { timeoutSeconds: 300, executionId: execution!.id },
+      status: 'cancelled',
+      completedAt: new Date(),
+      createdAt: new Date(Date.now() - 2 * HOUR_MS),
+      submittedOrgId: env.organization.id,
+    });
+
+    await asSystem(() => reapStaleScriptExecutions());
+
+    const [after] = await getTestDb()
+      .select()
+      .from(scriptExecutions)
+      .where(eq(scriptExecutions.id, execution!.id))
+      .limit(1);
+    expect(after?.status).toBe('cancelled');
+    expect(after?.errorMessage).not.toContain('no response from agent');
+  });
+
 });

--- a/apps/api/src/__tests__/integration/deviceCommandOfflineQueue.integration.test.ts
+++ b/apps/api/src/__tests__/integration/deviceCommandOfflineQueue.integration.test.ts
@@ -11,6 +11,7 @@ import {
   deploymentResults,
   deviceCommands,
   devices,
+  scriptExecutionBatches,
   scriptExecutions,
   scripts,
   softwareDeployments,
@@ -162,7 +163,7 @@ describe('device command offline queue — real PostgreSQL (#5128 W1)', () => {
     expect((await commandRow(row!.id))?.status).toBe('pending');
   });
 
-  it('expires exactly at deliver_by with expired / not_delivered_before_deadline', async () => {
+  it('expires exactly at deliver_by, keeping the timeout acceptance marker', async () => {
     const device = await makeDevice(env.organization.id, env.site.id, 'offline');
 
     const [row] = await getTestDb()
@@ -182,9 +183,14 @@ describe('device command offline queue — real PostgreSQL (#5128 W1)', () => {
 
     const after = await commandRow(row!.id);
     expect(after?.status).toBe('failed');
+    // `status` STAYS 'timeout': that literal is the discriminator
+    // `commandAcceptsAgentResultCondition` uses to let a genuinely late agent
+    // result overwrite a server-side timeout. The delivery clock is recorded in
+    // `reason`/`clock` instead.
     expect(after?.result).toMatchObject({
-      status: 'expired',
+      status: 'timeout',
       reason: 'not_delivered_before_deadline',
+      clock: 'delivery',
       timedOutBy: 'server',
     });
   });
@@ -754,6 +760,84 @@ describe('device command offline queue — real PostgreSQL (#5128 W1)', () => {
       .limit(1);
     expect(resultAfter?.status).toBe('cancelled');
     expect(resultAfter?.errorMessage).toBe('Cancelled before the device received it');
+  });
+
+  it('a delivery expiry advances the owning script_execution_batches counters and terminalises the batch', async () => {
+    // #5128 review round 2 (I). Only `reapStaleScriptExecutions` used to keep
+    // these counters. Once a propagation path terminalised an execution, that
+    // reaper's selector (`pending|queued|running`) never revisited it, so
+    // `devicesCompleted + devicesFailed` could never reach `devicesTargeted`
+    // and the batch stayed non-terminal FOREVER — a bulk run stuck at "running"
+    // with nothing left able to finish it.
+    const device = await makeDevice(env.organization.id, env.site.id, 'offline');
+    const [script] = await getTestDb()
+      .insert(scripts)
+      .values({
+        orgId: env.organization.id,
+        name: 'Batch Expiry Script',
+        osTypes: ['linux'],
+        language: 'bash',
+        content: 'true',
+        timeoutSeconds: 300,
+      })
+      .returning();
+
+    // Two-device batch whose OTHER device already succeeded, so this expiry is
+    // the last outstanding one.
+    const [batch] = await getTestDb()
+      .insert(scriptExecutionBatches)
+      .values({
+        scriptId: script!.id,
+        orgId: env.organization.id,
+        devicesTargeted: 2,
+        devicesCompleted: 1,
+        devicesFailed: 0,
+        status: 'running',
+      })
+      .returning();
+
+    const [execution] = await getTestDb()
+      .insert(scriptExecutions)
+      .values({
+        scriptId: script!.id,
+        deviceId: device.id,
+        orgId: env.organization.id,
+        status: 'queued',
+      })
+      .returning();
+
+    await getTestDb().insert(deviceCommands).values({
+      deviceId: device.id,
+      type: 'script',
+      payload: { timeoutSeconds: 300, executionId: execution!.id, batchId: batch!.id },
+      status: 'pending',
+      createdAt: new Date(Date.now() - 2 * HOUR_MS),
+      deliverBy: new Date(Date.now() - 1000),
+      submittedOrgId: env.organization.id,
+    });
+
+    expect(await asSystem(() => reapStaleDeviceCommands())).toBeGreaterThanOrEqual(1);
+
+    const [batchAfter] = await getTestDb()
+      .select()
+      .from(scriptExecutionBatches)
+      .where(eq(scriptExecutionBatches.id, batch!.id))
+      .limit(1);
+    expect(batchAfter?.devicesFailed).toBe(1);
+    expect(batchAfter?.devicesCompleted).toBe(1);
+    // 1 + 1 >= devicesTargeted, and one failed, so the batch is terminal.
+    expect(batchAfter?.status).toBe('failed');
+    expect(batchAfter?.completedAt).toBeInstanceOf(Date);
+
+    // Running the reaper again must NOT double-count: the execution is already
+    // terminal, so the shared helper's CAS matches zero rows.
+    await asSystem(() => reapStaleScriptExecutions());
+    const [batchTwice] = await getTestDb()
+      .select()
+      .from(scriptExecutionBatches)
+      .where(eq(scriptExecutionBatches.id, batch!.id))
+      .limit(1);
+    expect(batchTwice?.devicesFailed).toBe(1);
   });
 
 });

--- a/apps/api/src/__tests__/integration/deviceCommandOfflineQueue.integration.test.ts
+++ b/apps/api/src/__tests__/integration/deviceCommandOfflineQueue.integration.test.ts
@@ -50,7 +50,9 @@ function claim(deviceId: string) {
   return asSystem(() => claimPendingCommandsForDevice(deviceId, 10, 'agent', undefined, { ...AGENT_CAPS }));
 }
 
-async function makeDevice(orgId: string, siteId: string, status: string) {
+type DeviceStatus = (typeof devices.$inferInsert)['status'];
+
+async function makeDevice(orgId: string, siteId: string, status: DeviceStatus) {
   const [device] = await getTestDb()
     .insert(devices)
     .values({

--- a/apps/api/src/__tests__/integration/deviceCommandOfflineQueue.integration.test.ts
+++ b/apps/api/src/__tests__/integration/deviceCommandOfflineQueue.integration.test.ts
@@ -7,12 +7,20 @@ import { Hono } from 'hono';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { withSystemDbAccessContext } from '../../db';
-import { deviceCommands, devices, scriptExecutions, scripts, users } from '../../db/schema';
 import {
-  propagateCancelledDeviceCommands,
+  deploymentResults,
+  deviceCommands,
+  devices,
+  scriptExecutions,
+  scripts,
+  softwareDeployments,
+  users,
+} from '../../db/schema';
+import {
   reapStaleDeviceCommands,
   reapStaleScriptExecutions,
 } from '../../jobs/staleCommandReaper';
+import { propagateCancelledDeviceCommands } from '../../services/commandCancelPropagation';
 import { commandsRoutes } from '../../routes/devices/commands';
 import { claimPendingCommandsForDevice } from '../../services/commandDispatch';
 import { deliveryTtlMs } from '../../services/commandOfflinePolicy';
@@ -677,6 +685,75 @@ describe('device command offline queue — real PostgreSQL (#5128 W1)', () => {
       .limit(1);
     expect(after?.status).toBe('cancelled');
     expect(after?.errorMessage).not.toContain('no response from agent');
+  });
+
+  it('a claim-time cancel terminalises the OWNING deployment_results row, not just the command', async () => {
+    // The gap this pins: `partitionClaimable` cancels the device_commands row
+    // directly. A cancelled command is TERMINAL, so the command reaper (which
+    // scans only pending/sent) never revisits it — without propagation inside
+    // the claim transaction the deployment_results row hangs `pending` forever
+    // and the Software page shows an install that is neither running nor done.
+    const device = await makeDevice(env.organization.id, env.site.id, 'offline');
+
+    const [deployment] = await getTestDb()
+      .insert(softwareDeployments)
+      .values({
+        orgId: env.organization.id,
+        name: 'Claim Cancel Deployment',
+        deploymentType: 'install',
+        targetType: 'device',
+        targetIds: [device.id],
+        scheduleType: 'immediate',
+      })
+      .returning();
+
+    const [command] = await getTestDb()
+      .insert(deviceCommands)
+      .values({
+        deviceId: device.id,
+        type: 'software_install',
+        payload: { deploymentId: deployment!.id, s3Key: 'installers/app.exe' },
+        status: 'pending',
+        deliverBy: new Date(Date.now() + DAY_MS),
+        submittedOrgId: env.organization.id,
+      })
+      .returning();
+
+    const [result] = await getTestDb()
+      .insert(deploymentResults)
+      .values({
+        deploymentId: deployment!.id,
+        deviceId: device.id,
+        status: 'pending',
+        deviceCommandId: command!.id,
+      })
+      .returning();
+
+    // Move the device out from under the queued install.
+    const otherPartner = await createPartner({ name: `Other Partner ${randomUUID().slice(0, 8)}` });
+    const otherOrg = await createOrganization({
+      partnerId: otherPartner.id,
+      name: `Other Org ${randomUUID().slice(0, 8)}`,
+    });
+    const otherSite = await createSite({ orgId: otherOrg.id });
+    await getTestDb()
+      .update(devices)
+      .set({ orgId: otherOrg.id, siteId: otherSite.id })
+      .where(eq(devices.id, device.id));
+
+    expect(await claim(device.id)).toEqual([]);
+
+    const after = await commandRow(command!.id);
+    expect(after?.status).toBe('cancelled');
+    expect(after?.result).toMatchObject({ reason: 'device_moved_org' });
+
+    const [resultAfter] = await getTestDb()
+      .select()
+      .from(deploymentResults)
+      .where(eq(deploymentResults.id, result!.id))
+      .limit(1);
+    expect(resultAfter?.status).toBe('cancelled');
+    expect(resultAfter?.errorMessage).toBe('Cancelled before the device received it');
   });
 
 });

--- a/apps/api/src/__tests__/integration/deviceUninstallDrain.integration.test.ts
+++ b/apps/api/src/__tests__/integration/deviceUninstallDrain.integration.test.ts
@@ -342,12 +342,22 @@ describe('#3986 delivery — a Removed device collects its uninstall and nothing
     const delivered = beatBody.commands as Array<{ id: string; type: string }>;
     expect(delivered.map((cmd) => cmd.type)).toEqual(['self_uninstall']);
 
-    // ...and the script command was NOT delivered, and is still pending.
+    // ...and the script command was NOT delivered.
+    //
+    // #5128 changed WHY, not WHETHER: decommission now cancels the device's
+    // ordinary pending commands in the same transaction as the status flip, so
+    // this row is `cancelled` rather than sitting `pending` until some later
+    // sweep. The property this assertion exists to protect — the drain's type
+    // allowlist does not silently default to "unrestricted" — is unchanged and
+    // is asserted directly above (the heartbeat delivered ONLY self_uninstall).
+    // `executedAt IS NULL` is the durable form of "never delivered", so it is
+    // pinned here explicitly rather than inferred from the status string.
     const [scriptRow] = await getTestDb()
-      .select({ status: deviceCommands.status })
+      .select({ status: deviceCommands.status, executedAt: deviceCommands.executedAt })
       .from(deviceCommands)
       .where(eq(deviceCommands.id, scriptCommandId));
-    expect(scriptRow!.status).toBe('pending');
+    expect(scriptRow!.executedAt).toBeNull();
+    expect(scriptRow!.status).toBe('cancelled');
 
     // --- The rest of the authenticated agent surface stays closed ----------
     const recoveryKeys = await agentApp.request(

--- a/apps/api/src/db/schema/deviceCommands.columns.test.ts
+++ b/apps/api/src/db/schema/deviceCommands.columns.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { getTableColumns } from 'drizzle-orm';
+import { deviceCommands } from './devices';
+
+describe('deviceCommands deferred-delivery columns (#5128 W1)', () => {
+  it('declares deliver_by as a nullable timestamptz', () => {
+    const cols = getTableColumns(deviceCommands);
+    expect(cols.deliverBy).toBeDefined();
+    expect(cols.deliverBy.name).toBe('deliver_by');
+    expect(cols.deliverBy.notNull).toBe(false);
+  });
+
+  it('declares submitted_org_id as a nullable uuid (provenance, not tenancy)', () => {
+    const cols = getTableColumns(deviceCommands);
+    expect(cols.submittedOrgId).toBeDefined();
+    expect(cols.submittedOrgId.name).toBe('submitted_org_id');
+    expect(cols.submittedOrgId.notNull).toBe(false);
+  });
+
+  it('does NOT declare an org_id column — the table stays system-scoped', () => {
+    const cols = getTableColumns(deviceCommands);
+    expect(Object.values(cols).map((c) => c.name)).not.toContain('org_id');
+  });
+});

--- a/apps/api/src/db/schema/devices.ts
+++ b/apps/api/src/db/schema/devices.ts
@@ -550,7 +550,16 @@ export const deviceCommands = pgTable('device_commands', {
   // it -- NULL means "no exemption, no widened auth", fail-closed by
   // construction. See 2026-09-10-device-command-uninstall-provenance.sql.
   uninstallReasons: text('uninstall_reasons').array(),
-  deviceRemoveExpiresAt: timestamp('device_remove_expires_at', { withTimezone: true })
+  deviceRemoveExpiresAt: timestamp('device_remove_expires_at', { withTimezone: true }),
+  // #5128 -- deadline by which an agent must CLAIM this row (the DELIVERY
+  // clock). NULL = legacy rule (execution timeout measured from created_at).
+  // See services/commandOfflinePolicy.ts and jobs/staleCommandReaper.ts.
+  deliverBy: timestamp('deliver_by', { withTimezone: true }),
+  // #5128 -- the device's org at enqueue. PROVENANCE, not tenancy: compared at
+  // claim time to cancel rows whose device has since moved org. Deliberately
+  // NOT named org_id so the RLS/cascade auto-discovery keeps device_commands
+  // system-scoped (agent WS path, no RLS -- see CLAUDE.md).
+  submittedOrgId: uuid('submitted_org_id').references(() => organizations.id, { onDelete: 'set null' })
 });
 
 export const connectionProtocolEnum = pgEnum('connection_protocol', ['tcp', 'tcp6', 'udp', 'udp6']);

--- a/apps/api/src/jobs/staleCommandReaper.test.ts
+++ b/apps/api/src/jobs/staleCommandReaper.test.ts
@@ -17,6 +17,8 @@ const { selectMock, updateMock, deviceCommandsTable, restoreJobsTable, backupJob
     deviceId: 'device_commands.device_id',
     uninstallReasons: 'device_commands.uninstall_reasons',
     deviceRemoveExpiresAt: 'device_commands.device_remove_expires_at',
+    deliverBy: 'device_commands.deliver_by',
+    submittedOrgId: 'device_commands.submitted_org_id',
   },
   restoreJobsTable: {
     id: 'restore_jobs.id',
@@ -137,7 +139,6 @@ import {
   reapStaleSoftwareDeploymentResults,
   resolveMaxReapPerRun,
   SOFTWARE_INSTALL_TIMEOUT_MS,
-  SOFTWARE_QUEUED_EXPIRY_MS,
   reapStaleScriptExecutions
 } from './staleCommandReaper';
 
@@ -195,6 +196,9 @@ describe('stale command reaper', () => {
         payload: null,
         createdAt: staleCreatedAt,
         executedAt: null,
+        // #5128: exercises the LEGACY (created_at + execution timeout) path —
+        // no deliver_by deadline set on this row.
+        deliverBy: null,
       },
       {
         id: 'cmd-vm',
@@ -203,6 +207,7 @@ describe('stale command reaper', () => {
         payload: null,
         createdAt: staleCreatedAt,
         executedAt: staleCreatedAt,
+        deliverBy: null,
       },
       {
         id: 'cmd-boot',
@@ -211,6 +216,7 @@ describe('stale command reaper', () => {
         payload: null,
         createdAt: staleCreatedAt,
         executedAt: staleCreatedAt,
+        deliverBy: null,
       },
       {
         id: 'cmd-bmr',
@@ -219,6 +225,7 @@ describe('stale command reaper', () => {
         payload: null,
         createdAt: staleCreatedAt,
         executedAt: null,
+        deliverBy: null,
       },
     ]));
 
@@ -240,12 +247,23 @@ describe('stale command reaper', () => {
       where: restoreWhere,
     }));
 
+    // propagateTimedOutDeviceCommand now unconditionally updates
+    // deploymentResults too (keyed on device_command_id, guarded on
+    // status='pending') before it ever reaches restoreJobs — needs a mock
+    // branch even though none of these rows are software-install commands.
+    const deploymentResultsSet = vi.fn(() => ({
+      where: vi.fn().mockResolvedValue(undefined),
+    }));
+
     updateMock.mockImplementation((table: unknown) => {
       if (table === deviceCommandsTable) {
         return { set: deviceCommandSet };
       }
       if (table === restoreJobsTable) {
         return { set: restoreSet };
+      }
+      if (table === deploymentResultsTable) {
+        return { set: deploymentResultsSet };
       }
       throw new Error(`Unexpected table update: ${String(table)}`);
     });
@@ -319,8 +337,13 @@ describe('stale command reaper', () => {
       // satisfy type AND reason AND deadline together to be exempted), and
       // that it sits as an OR-alternative to the offboarding arm rather than
       // replacing/widening it.
+      //
+      // #5128: the param indices below shifted from $15-$18 to $25-$28 —
+      // reapStaleDeviceCommands' WHERE now carries the two-clock OR block
+      // (deliver_by vs. legacy created_at) ahead of this exemption, adding
+      // params $4-$15 before it.
       expect(sqlText).toContain(
-        "OR (\n        $15 = 'self_uninstall'\n        AND $16 @> ARRAY[$17]::text[]\n        AND $18 > now()\n      )",
+        "OR (\n        $25 = 'self_uninstall'\n        AND $26 @> ARRAY[$27]::text[]\n        AND $28 > now()\n      )",
       );
 
       // The reason bound to the containment check is the exported constant,
@@ -336,17 +359,23 @@ describe('stale command reaper', () => {
     it('reaps it once device_remove_expires_at has passed: the deadline is compared with a strict `>` against Postgres\'s own now(), never `>=` and never a JS-computed timestamp bound as a param', async () => {
       const { sql: sqlText, params } = await compileWhere();
 
-      expect(sqlText).toContain('$18 > now()');
+      // #5128: shifted from $18 — see the param-count note above.
+      expect(sqlText).toContain('$28 > now()');
       expect(sqlText).not.toMatch(/>=\s*now\(\)/);
 
-      // now() is evaluated by Postgres itself on every poll. The only bound
-      // Date in the whole WHERE is the unrelated SQL pre-filter cutoff
-      // (`createdAt < now - SHORTEST_TIMEOUT_MS`, computed once per reaper
-      // run) — nothing stands in for "now" in the deadline arm itself,
-      // which would otherwise freeze it at reaper-start time instead of
-      // re-evaluating it fresh on every row, every poll.
+      // now() is evaluated by Postgres itself on every poll — nothing stands
+      // in for "now" in the deadline arm itself, which would otherwise
+      // freeze it at reaper-start time instead of re-evaluating it fresh on
+      // every row, every poll.
+      //
+      // #5128: the bound Date params grew from 1 to 3 — the two-clock OR
+      // block binds `nowDate` once (the deliver_by arm) and the legacy
+      // `conservativeCutoff` SQL pre-filter cutoff twice (once per arm that
+      // still uses createdAt: the deliver_by-null arm and the sent-status
+      // arm). None of the three stand in for the device_remove deadline
+      // arm's own `now()`, which stays a live Postgres call.
       const dateParams = params.filter((p) => p instanceof Date);
-      expect(dateParams).toHaveLength(1);
+      expect(dateParams).toHaveLength(3);
     });
 
     // The regression guard: this is the test that must go RED if the reason
@@ -398,6 +427,7 @@ describe('stale command reaper', () => {
           payload: null,
           createdAt: staleCreatedAt,
           executedAt: null,
+          deliverBy: null,
         },
       ]));
       const returning = vi.fn().mockResolvedValueOnce([{ id: 'cmd-abuse' }]);
@@ -1024,19 +1054,21 @@ describe('reapStaleSoftwareDeploymentResults', () => {
     return { resultSet, resultReturning, commandSet, commandWhere };
   }
 
-  it('pins the exported timeout constants (55 min install, 7 day queued expiry)', () => {
+  it('pins the exported timeout constant (55 min install)', () => {
+    // #5128: the old 7-day "queued expiry" constant (SOFTWARE_QUEUED_EXPIRY_MS)
+    // is gone from this module entirely — `device_commands.deliver_by` is now
+    // the single owner of that deadline (reapStaleDeviceCommands).
     expect(SOFTWARE_INSTALL_TIMEOUT_MS).toBe(55 * 60 * 1000);
-    expect(SOFTWARE_QUEUED_EXPIRY_MS).toBe(7 * 24 * 60 * 60 * 1000);
   });
 
-  it('tier 1: reaps delivered-but-silent rows past the timeout (WS-dispatched and queued-then-sent/completed)', async () => {
+  it('tier 1: reaps delivered-but-silent rows past the timeout, measured from commandExecutedAt (WS-dispatched and queued-then-sent/completed)', async () => {
     selectMock.mockReturnValueOnce(selectChain([
-      // WS-dispatched directly — no queued command row
-      { id: 'res-ws', deviceCommandId: null, dispatchedAt: minutesAgo(60), commandStatus: null },
-      // Offline-queued, agent claimed it (sent) then went silent
-      { id: 'res-sent', deviceCommandId: 'cmd-sent', dispatchedAt: minutesAgo(90), commandStatus: 'sent' },
-      // Command completed but the result POST never landed
-      { id: 'res-done', deviceCommandId: 'cmd-done', dispatchedAt: minutesAgo(90), commandStatus: 'completed' },
+      // WS-dispatched directly — no queued command row, falls back to dispatchedAt.
+      { id: 'res-ws', deviceCommandId: null, dispatchedAt: minutesAgo(60), commandStatus: null, commandExecutedAt: null },
+      // Offline-queued, agent claimed it (sent) then went silent — measured from claim time.
+      { id: 'res-sent', deviceCommandId: 'cmd-sent', dispatchedAt: minutesAgo(90), commandStatus: 'sent', commandExecutedAt: minutesAgo(90) },
+      // Command completed but the result POST never landed.
+      { id: 'res-done', deviceCommandId: 'cmd-done', dispatchedAt: minutesAgo(90), commandStatus: 'completed', commandExecutedAt: minutesAgo(90) },
     ]));
     const { resultSet, commandSet } = setUpUpdates();
 
@@ -1062,7 +1094,7 @@ describe('reapStaleSoftwareDeploymentResults', () => {
 
   it('tier 1: leaves a delivered row alone before the 55-min timeout', async () => {
     selectMock.mockReturnValueOnce(selectChain([
-      { id: 'res-fresh', deviceCommandId: null, dispatchedAt: minutesAgo(30), commandStatus: null },
+      { id: 'res-fresh', deviceCommandId: null, dispatchedAt: minutesAgo(30), commandStatus: null, commandExecutedAt: null },
     ]));
 
     const reaped = await reapStaleSoftwareDeploymentResults();
@@ -1071,9 +1103,16 @@ describe('reapStaleSoftwareDeploymentResults', () => {
     expect(updateMock).not.toHaveBeenCalled();
   });
 
-  it('tier 2: leaves a queued-offline row (device_commands still pending) alone before the 7-day expiry', async () => {
+  // #5128 — REWRITTEN (was "tier 2: leaves a queued-offline row alone before
+  // the 7-day expiry"). The old Tier 2 (a flat 7-day expiry measured from
+  // dispatchedAt, plus cancelling the queued device_commands row) is GONE.
+  // An undelivered row (commandStatus 'pending') now belongs to exactly one
+  // clock owner — reapStaleDeviceCommands, at the row's own deliver_by — so
+  // this reaper must never reap it, no matter how old dispatchedAt is.
+  it('never reaps an undelivered row (commandStatus pending), regardless of how old dispatchedAt is', async () => {
     selectMock.mockReturnValueOnce(selectChain([
-      { id: 'res-queued', deviceCommandId: 'cmd-queued', dispatchedAt: daysAgo(2), commandStatus: 'pending' },
+      { id: 'res-queued', deviceCommandId: 'cmd-queued', dispatchedAt: daysAgo(2), commandStatus: 'pending', commandExecutedAt: null },
+      { id: 'res-ancient', deviceCommandId: 'cmd-ancient', dispatchedAt: daysAgo(30), commandStatus: 'pending', commandExecutedAt: null },
     ]));
 
     const reaped = await reapStaleSoftwareDeploymentResults();
@@ -1082,36 +1121,69 @@ describe('reapStaleSoftwareDeploymentResults', () => {
     expect(updateMock).not.toHaveBeenCalled();
   });
 
-  it('tier 2: reaps a queued-offline row after the 7-day expiry AND cancels the queued device_commands row', async () => {
+  // #5128 — REWRITTEN (was "tier 2: reaps a queued-offline row after the
+  // 7-day expiry AND cancels the queued device_commands row"). Cancelling an
+  // undelivered device_commands row from this reaper would race the single
+  // owner of the delivery clock, so that cancel is gone along with Tier 2
+  // itself — pin that it never happens, even for a row old enough that the
+  // former 7-day tier would have fired.
+  it('never cancels the queued device_commands row for an undelivered result, even one 8+ days old', async () => {
     selectMock.mockReturnValueOnce(selectChain([
-      { id: 'res-expired', deviceCommandId: 'cmd-expired', dispatchedAt: daysAgo(8), commandStatus: 'pending' },
+      { id: 'res-expired', deviceCommandId: 'cmd-expired', dispatchedAt: daysAgo(8), commandStatus: 'pending', commandExecutedAt: null },
     ]));
-    const { resultSet, commandSet, commandWhere } = setUpUpdates();
+    const { commandSet } = setUpUpdates();
 
     const reaped = await reapStaleSoftwareDeploymentResults();
 
-    expect(reaped).toBe(1);
+    expect(reaped).toBe(0);
+    expect(updateMock).not.toHaveBeenCalled();
+    expect(commandSet).not.toHaveBeenCalled();
+  });
+
+  // #5128 — THE MOST IMPORTANT NEW TEST. This is one of the two latent
+  // defects the change fixes: the "delivered but silent" clock must measure
+  // from the command's OWN executedAt (the instant the agent claimed it),
+  // never from the deployment's dispatchedAt. Measuring from dispatch would
+  // time out an install that was delivered moments ago, purely because the
+  // device had been offline between dispatch and delivery.
+  it('measures the delivered-but-silent clock from commandExecutedAt, not dispatchedAt', async () => {
+    // dispatchedAt is 3 days old — well past SOFTWARE_INSTALL_TIMEOUT_MS on
+    // its own — but the agent only just claimed it.
+    selectMock.mockReturnValueOnce(selectChain([
+      { id: 'res-just-claimed', deviceCommandId: 'cmd-claimed', dispatchedAt: daysAgo(3), commandStatus: 'sent', commandExecutedAt: minutesAgo(1) },
+    ]));
+
+    expect(await reapStaleSoftwareDeploymentResults()).toBe(0);
+    expect(updateMock).not.toHaveBeenCalled();
+
+    // Same row, but commandExecutedAt is itself now older than the timeout —
+    // the agent claimed it, then went silent for real.
+    vi.resetAllMocks();
+    selectMock.mockReturnValueOnce(selectChain([
+      {
+        id: 'res-claimed-silent',
+        deviceCommandId: 'cmd-claimed',
+        dispatchedAt: daysAgo(3),
+        commandStatus: 'sent',
+        commandExecutedAt: new Date(Date.now() - SOFTWARE_INSTALL_TIMEOUT_MS - 60 * 1000),
+      },
+    ]));
+    const { resultSet } = setUpUpdates();
+
+    expect(await reapStaleSoftwareDeploymentResults()).toBe(1);
     expect(resultSet).toHaveBeenCalledWith(
       expect.objectContaining({
         status: 'failed',
-        errorMessage: 'Device did not come online before the deployment expired',
+        errorMessage: 'Server-side timeout: no response from agent',
       })
     );
-    expect(commandSet).toHaveBeenCalledTimes(1);
-    expect(commandSet).toHaveBeenCalledWith(
-      expect.objectContaining({
-        status: 'cancelled',
-        result: expect.objectContaining({ status: 'cancelled', cancelledBy: 'stale-command-reaper' }),
-      })
-    );
-    expect(commandWhere).toHaveBeenCalledTimes(1);
   });
 
   it('never touches rows whose deployment dispatchedAt is NULL (scheduled, not yet dispatched)', async () => {
     // The SQL filter excludes these; pin the defensive JS guard too.
     selectMock.mockReturnValueOnce(selectChain([
-      { id: 'res-scheduled', deviceCommandId: null, dispatchedAt: null, commandStatus: null },
-      { id: 'res-scheduled-2', deviceCommandId: 'cmd-x', dispatchedAt: null, commandStatus: 'pending' },
+      { id: 'res-scheduled', deviceCommandId: null, dispatchedAt: null, commandStatus: null, commandExecutedAt: null },
+      { id: 'res-scheduled-2', deviceCommandId: 'cmd-x', dispatchedAt: null, commandStatus: 'pending', commandExecutedAt: null },
     ]));
 
     const reaped = await reapStaleSoftwareDeploymentResults();
@@ -1120,9 +1192,13 @@ describe('reapStaleSoftwareDeploymentResults', () => {
     expect(updateMock).not.toHaveBeenCalled();
   });
 
-  it('does not count a row (or cancel its command) when a concurrent real result wins the pending-guard race', async () => {
+  // #5128 — REWRITTEN to race on the surviving (delivered) tier rather than
+  // the removed undelivered-cancel tier: a 'pending' commandStatus row is now
+  // always skipped before any update is attempted (proven above), so the
+  // pending-guard race can only still be observed on a delivered row.
+  it('does not count a row when a concurrent real result wins the pending-guard race', async () => {
     selectMock.mockReturnValueOnce(selectChain([
-      { id: 'res-race', deviceCommandId: 'cmd-race', dispatchedAt: daysAgo(8), commandStatus: 'pending' },
+      { id: 'res-race', deviceCommandId: 'cmd-race', dispatchedAt: daysAgo(8), commandStatus: 'sent', commandExecutedAt: daysAgo(8) },
     ]));
     const { commandSet } = setUpUpdates({ raced: true });
 
@@ -1132,38 +1208,21 @@ describe('reapStaleSoftwareDeploymentResults', () => {
     expect(commandSet).not.toHaveBeenCalled();
   });
 
-  it('boundary: dispatchedAt exactly 1ms past each threshold reaps, 1ms short does not', async () => {
+  it('boundary: dispatchedAt exactly 1ms past the timeout reaps, 1ms short does not (no linked command)', async () => {
     vi.useFakeTimers();
     const T = new Date('2026-07-17T00:00:00.000Z').getTime();
     vi.setSystemTime(T);
     try {
-      // Tier 1 over/under
       setUpUpdates();
       selectMock.mockReturnValueOnce(selectChain([
-        { id: 'r1', deviceCommandId: null, dispatchedAt: new Date(T - SOFTWARE_INSTALL_TIMEOUT_MS - 1), commandStatus: null },
+        { id: 'r1', deviceCommandId: null, dispatchedAt: new Date(T - SOFTWARE_INSTALL_TIMEOUT_MS - 1), commandStatus: null, commandExecutedAt: null },
       ]));
       expect(await reapStaleSoftwareDeploymentResults()).toBe(1);
 
       vi.resetAllMocks();
       vi.setSystemTime(T);
       selectMock.mockReturnValueOnce(selectChain([
-        { id: 'r1', deviceCommandId: null, dispatchedAt: new Date(T - SOFTWARE_INSTALL_TIMEOUT_MS + 1), commandStatus: null },
-      ]));
-      expect(await reapStaleSoftwareDeploymentResults()).toBe(0);
-
-      // Tier 2 over/under
-      vi.resetAllMocks();
-      vi.setSystemTime(T);
-      setUpUpdates();
-      selectMock.mockReturnValueOnce(selectChain([
-        { id: 'r2', deviceCommandId: 'cmd-b', dispatchedAt: new Date(T - SOFTWARE_QUEUED_EXPIRY_MS - 1), commandStatus: 'pending' },
-      ]));
-      expect(await reapStaleSoftwareDeploymentResults()).toBe(1);
-
-      vi.resetAllMocks();
-      vi.setSystemTime(T);
-      selectMock.mockReturnValueOnce(selectChain([
-        { id: 'r2', deviceCommandId: 'cmd-b', dispatchedAt: new Date(T - SOFTWARE_QUEUED_EXPIRY_MS + 1), commandStatus: 'pending' },
+        { id: 'r1', deviceCommandId: null, dispatchedAt: new Date(T - SOFTWARE_INSTALL_TIMEOUT_MS + 1), commandStatus: null, commandExecutedAt: null },
       ]));
       expect(await reapStaleSoftwareDeploymentResults()).toBe(0);
     } finally {
@@ -1334,13 +1393,31 @@ describe('reapStaleScriptExecutions terminal-command guard (#3097)', () => {
     expect(String(written.errorMessage)).not.toContain('no response from agent');
   });
 
-  it('still reports a genuine agent silence as timeout', async () => {
-    // Command never reached a terminal state — the original claim is true here
-    // and must survive, or the guard would mask real agent silence.
-    const { execSet } = arrange({
-      payload: { executionId: 'exec-1' },
-      status: 'sent',
-      result: null,
+  // #5128: a `pending`/`queued` execution whose command is still `sent` is now
+  // skipped entirely by reapStaleScriptExecutions' own delivery-clock guard
+  // (change 4 — reapStaleDeviceCommands owns that clock). So "genuine agent
+  // silence with a command that was delivered and never answered" can only
+  // still reach THIS reaper's terminal-command guard once the execution
+  // itself is `running` — the realistic shape of that scenario (the script
+  // started, then the agent went dark, and the command row is left `sent`
+  // forever). Previously this used exec status `pending`, which the #5128
+  // guard now intercepts before this code path is even reached.
+  it('still reports a genuine agent silence as timeout (running execution, command sent but never answered)', async () => {
+    const runningLongAgo = new Date(Date.now() - 60 * 60 * 1000);
+    selectMock
+      .mockReturnValueOnce(selectChain([
+        { id: 'exec-1', status: 'running', scriptId: 'script-1', createdAt: runningLongAgo, startedAt: runningLongAgo },
+      ]))
+      .mockReturnValueOnce(selectChain([
+        { payload: { executionId: 'exec-1' }, status: 'sent', result: null },
+      ]));
+
+    const execSet = vi.fn((_values: Record<string, unknown>) => ({
+      where: vi.fn(() => ({ returning: vi.fn().mockResolvedValue([{ id: 'exec-1' }]) })),
+    }));
+    updateMock.mockImplementation((table: unknown) => {
+      if (table === scriptExecutionsTable) return { set: execSet };
+      throw new Error(`Unexpected table update: ${String(table)}`);
     });
 
     await reapStaleScriptExecutions();
@@ -1348,6 +1425,40 @@ describe('reapStaleScriptExecutions terminal-command guard (#3097)', () => {
     const written = execSet.mock.calls[0]![0];
     expect(written.status).toBe('timeout');
     expect(String(written.errorMessage)).toContain('no response from agent');
+  });
+
+  // #5128 change (4) — THE DELIVERY CLOCK HAS ONE OWNER. A not-yet-running
+  // execution whose command row is still `pending` or `sent` is waiting for
+  // the device, not stalled: only reapStaleDeviceCommands may expire it (at
+  // the row's own deliver_by). This is the new early-continue behavior.
+  describe('#5128 delivery-clock guard (change 4)', () => {
+    it('skips a queued/pending execution whose command row is still pending — 0 reaped, no UPDATE', async () => {
+      const { execSet } = arrange({
+        payload: { executionId: 'exec-1' },
+        status: 'pending',
+        result: null,
+      });
+
+      const reaped = await reapStaleScriptExecutions();
+
+      expect(reaped).toBe(0);
+      expect(execSet).not.toHaveBeenCalled();
+    });
+
+    it('still reaps a queued/pending execution whose command row is failed, exactly as before', async () => {
+      const { execSet } = arrange({
+        payload: { executionId: 'exec-1' },
+        status: 'failed',
+        result: { status: 'failed', stderr: 'boom' },
+      });
+
+      const reaped = await reapStaleScriptExecutions();
+
+      expect(reaped).toBe(1);
+      expect(execSet).toHaveBeenCalledTimes(1);
+      const written = execSet.mock.calls[0]![0];
+      expect(written.status).toBe('failed');
+    });
   });
 
   it('still reports timeout when no command row exists at all', async () => {

--- a/apps/api/src/jobs/staleCommandReaper.test.ts
+++ b/apps/api/src/jobs/staleCommandReaper.test.ts
@@ -1179,6 +1179,66 @@ describe('reapStaleSoftwareDeploymentResults', () => {
     );
   });
 
+  // #5128 review round 2 (O) — `deployment_results.device_command_id` has NO
+  // foreign key (device_commands is the agent hot path and stays
+  // unconstrained), so a deleted/purged command leaves the LEFT JOIN with a
+  // NULL status. That read as "not delivered" and skipped the row FOREVER:
+  // nothing else revisits a `pending` deployment_results row either, so the
+  // Software page showed an install stuck mid-flight with nothing able to
+  // resolve it.
+  it('fails an ORPHANED result whose command row no longer exists', async () => {
+    selectMock.mockReturnValueOnce(selectChain([
+      {
+        id: 'res-orphan',
+        deviceCommandId: 'cmd-deleted',
+        dispatchedAt: daysAgo(2),
+        commandStatus: null,
+        commandExecutedAt: null,
+      },
+    ]));
+    const { resultSet } = setUpUpdates();
+
+    expect(await reapStaleSoftwareDeploymentResults()).toBe(1);
+    expect(resultSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'failed',
+        // A distinct message: nobody can answer for this row, which is not the
+        // same claim as "the agent went silent".
+        errorMessage: 'Command row missing — install outcome unknown',
+      })
+    );
+  });
+
+  it('an orphaned result still waits out the install timeout from dispatchedAt', async () => {
+    selectMock.mockReturnValueOnce(selectChain([
+      {
+        id: 'res-orphan-fresh',
+        deviceCommandId: 'cmd-deleted',
+        dispatchedAt: minutesAgo(30),
+        commandStatus: null,
+        commandExecutedAt: null,
+      },
+    ]));
+
+    expect(await reapStaleSoftwareDeploymentResults()).toBe(0);
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it('a row with NO linked command at all is still the pre-#5128 WS case, not an orphan', async () => {
+    // deviceCommandId NULL means the install was pushed straight over the
+    // socket before #5128 and never had a row — it keeps the ordinary
+    // agent-silence message.
+    selectMock.mockReturnValueOnce(selectChain([
+      { id: 'res-ws', deviceCommandId: null, dispatchedAt: daysAgo(2), commandStatus: null, commandExecutedAt: null },
+    ]));
+    const { resultSet } = setUpUpdates();
+
+    expect(await reapStaleSoftwareDeploymentResults()).toBe(1);
+    expect(resultSet).toHaveBeenCalledWith(
+      expect.objectContaining({ errorMessage: 'Server-side timeout: no response from agent' })
+    );
+  });
+
   it('never touches rows whose deployment dispatchedAt is NULL (scheduled, not yet dispatched)', async () => {
     // The SQL filter excludes these; pin the defensive JS guard too.
     selectMock.mockReturnValueOnce(selectChain([

--- a/apps/api/src/jobs/staleCommandReaper.ts
+++ b/apps/api/src/jobs/staleCommandReaper.ts
@@ -219,95 +219,27 @@ export async function propagateTimedOutDeviceCommand(params: {
 }
 
 /**
- * Terminalise the higher-level records owned by a device command a USER just
- * cancelled (#5128 §G). Sibling of `propagateTimedOutDeviceCommand`: the
- * command row itself is already terminal by the time this runs; this only
- * stops the owning record from waiting forever on a delivery that will never
- * happen.
- *
- * W3 adds the `patch_job_results` branch. Anything without a branch is a no-op
- * by design — a generic command has no higher-level record (#5128 §F).
+ * Cancel propagation moved to `services/commandCancelPropagation.ts` (#5128
+ * review round 2): claim-time eligibility has to call it from inside the
+ * heartbeat claim transaction, and this module imports `services/commandQueue`,
+ * which reaches `commandClaimEligibility` — importing the reaper from there
+ * would close an import cycle. Re-exported so the existing route importers are
+ * unchanged.
  */
-/**
- * Anything that can run the propagation UPDATEs: the ambient `db`, or a caller's
- * open transaction handle.
- */
-type DbExecutor = Pick<typeof db, 'update'>;
-
-export type DeviceCommandCancelSubject = {
-  id: string;
-  type: string;
-  payload: Record<string, unknown> | null;
-};
+export {
+  propagateCancelledDeviceCommand,
+  propagateCancelledDeviceCommands,
+  type DeviceCommandCancelSubject,
+} from '../services/commandCancelPropagation';
 
 /**
- * Bulk sibling of `propagateCancelledDeviceCommand` for the cancel-on-event
- * paths (org move, decommission), which cancel every pending row for a device
- * in one UPDATE. Takes the caller's transaction so the owning records are
- * terminalised atomically with the cancel itself.
+ * The queue wait `software_install` carried before #5128 gave it a real
+ * `deliver_by` deadline. Applies ONLY to legacy rows (`deliver_by IS NULL`),
+ * where the execution timeout is also the queue wait; rows created before
+ * deliver_by existed (2026-10-13 migration). Remove once no pending
+ * software_install row predates it.
  */
-export async function propagateCancelledDeviceCommands(
-  rows: readonly DeviceCommandCancelSubject[],
-  completedAt: Date,
-  executor: DbExecutor = db,
-): Promise<void> {
-  for (const row of rows) {
-    await propagateCancelledDeviceCommand({
-      commandId: row.id,
-      type: row.type,
-      payload: row.payload,
-      completedAt,
-      executor,
-    });
-  }
-}
-
-export async function propagateCancelledDeviceCommand(params: {
-  commandId: string;
-  type: string;
-  payload: Record<string, unknown> | null;
-  completedAt: Date;
-  cancelledBy?: string | null;
-  /**
-   * #5128: the cancel-on-event callers run inside their own transaction (the
-   * org flip / the decommission write) and must terminalise the owning records
-   * in that SAME transaction, or a rollback would leave a cancelled command
-   * with a `script_executions` / `deployment_results` row still `pending`.
-   */
-  executor?: DbExecutor;
-}): Promise<void> {
-  const { commandId, type, payload, completedAt } = params;
-  const executor: DbExecutor = params.executor ?? db;
-  const errorMessage = 'Cancelled before the device received it';
-
-  if (type === 'script') {
-    const executionId =
-      payload && typeof payload.executionId === 'string' && payload.executionId.trim().length > 0
-        ? payload.executionId
-        : null;
-    if (executionId) {
-      await executor
-        .update(scriptExecutions)
-        .set({ status: 'cancelled', errorMessage, completedAt })
-        .where(
-          and(
-            eq(scriptExecutions.id, executionId),
-            inArray(scriptExecutions.status, ['pending', 'queued', 'running']),
-          ),
-        );
-    }
-  }
-
-  await executor
-    .update(deploymentResults)
-    .set({ status: 'cancelled', errorMessage, completedAt })
-    .where(
-      and(
-        eq(deploymentResults.deviceCommandId, commandId),
-        eq(deploymentResults.status, 'pending'),
-      ),
-    );
-}
+const LEGACY_SOFTWARE_INSTALL_QUEUE_MS = 7 * 24 * 60 * 60 * 1000;
 
 // ── Reap functions ────────────────────────────────────────────────
 
@@ -478,9 +410,19 @@ export async function reapStaleDeviceCommands(): Promise<number> {
       kind = 'timeout';
       errorMsg = `Server-side timeout: no response from agent after ${Math.round(timeoutMs / 60000)} minutes`;
     } else {
-      due = now - cmd.createdAt.getTime() >= timeoutMs;
+      // LEGACY rows only (`deliver_by IS NULL`). #5128 folded
+      // `software_install` into the 2-hour LONG_TIMEOUT_TYPES tier because its
+      // queue wait is now expressed as a `deliver_by` deadline — but rows
+      // written before the 2026-10-13 migration have no deadline and land
+      // here, where the execution timeout doubles as the queue wait. Applying
+      // 2 h to them would reap a week's worth of legitimately-waiting installs
+      // on the first pass after deploy, so their retired 7-day rule is kept
+      // for exactly this branch.
+      const legacyTimeoutMs =
+        cmd.type === 'software_install' ? LEGACY_SOFTWARE_INSTALL_QUEUE_MS : timeoutMs;
+      due = now - cmd.createdAt.getTime() >= legacyTimeoutMs;
       kind = 'timeout';
-      errorMsg = `Command expired: agent never received the command (${Math.round(timeoutMs / 60000)} min timeout)`;
+      errorMsg = `Command expired: agent never received the command (${Math.round(legacyTimeoutMs / 60000)} min timeout)`;
     }
 
     if (!due) continue;

--- a/apps/api/src/jobs/staleCommandReaper.ts
+++ b/apps/api/src/jobs/staleCommandReaper.ts
@@ -228,14 +228,56 @@ export async function propagateTimedOutDeviceCommand(params: {
  * W3 adds the `patch_job_results` branch. Anything without a branch is a no-op
  * by design — a generic command has no higher-level record (#5128 §F).
  */
+/**
+ * Anything that can run the propagation UPDATEs: the ambient `db`, or a caller's
+ * open transaction handle.
+ */
+type DbExecutor = Pick<typeof db, 'update'>;
+
+export type DeviceCommandCancelSubject = {
+  id: string;
+  type: string;
+  payload: Record<string, unknown> | null;
+};
+
+/**
+ * Bulk sibling of `propagateCancelledDeviceCommand` for the cancel-on-event
+ * paths (org move, decommission), which cancel every pending row for a device
+ * in one UPDATE. Takes the caller's transaction so the owning records are
+ * terminalised atomically with the cancel itself.
+ */
+export async function propagateCancelledDeviceCommands(
+  rows: readonly DeviceCommandCancelSubject[],
+  completedAt: Date,
+  executor: DbExecutor = db,
+): Promise<void> {
+  for (const row of rows) {
+    await propagateCancelledDeviceCommand({
+      commandId: row.id,
+      type: row.type,
+      payload: row.payload,
+      completedAt,
+      executor,
+    });
+  }
+}
+
 export async function propagateCancelledDeviceCommand(params: {
   commandId: string;
   type: string;
   payload: Record<string, unknown> | null;
   completedAt: Date;
   cancelledBy?: string | null;
+  /**
+   * #5128: the cancel-on-event callers run inside their own transaction (the
+   * org flip / the decommission write) and must terminalise the owning records
+   * in that SAME transaction, or a rollback would leave a cancelled command
+   * with a `script_executions` / `deployment_results` row still `pending`.
+   */
+  executor?: DbExecutor;
 }): Promise<void> {
   const { commandId, type, payload, completedAt } = params;
+  const executor: DbExecutor = params.executor ?? db;
   const errorMessage = 'Cancelled before the device received it';
 
   if (type === 'script') {
@@ -244,7 +286,7 @@ export async function propagateCancelledDeviceCommand(params: {
         ? payload.executionId
         : null;
     if (executionId) {
-      await db
+      await executor
         .update(scriptExecutions)
         .set({ status: 'cancelled', errorMessage, completedAt })
         .where(
@@ -256,7 +298,7 @@ export async function propagateCancelledDeviceCommand(params: {
     }
   }
 
-  await db
+  await executor
     .update(deploymentResults)
     .set({ status: 'cancelled', errorMessage, completedAt })
     .where(
@@ -614,6 +656,28 @@ export async function reapStaleScriptExecutions(): Promise<number> {
     // it by the script's own 300 s execution timeout while the command row was
     // legitimately waiting days for the machine to come back.
     if (exec.status !== 'running' && (cmd?.status === 'pending' || cmd?.status === 'sent')) continue;
+
+    // #5128: a command CANCELLED before delivery (user cancel, org move,
+    // decommission, claim-time ineligibility) already terminalised its
+    // execution through `propagateCancelledDeviceCommand`. If one still reaches
+    // here, reporting "no response from agent" would be a false diagnosis about
+    // an agent that was never asked. Mark it cancelled instead.
+    if (cmd?.status === 'cancelled') {
+      await db
+        .update(scriptExecutions)
+        .set({
+          status: 'cancelled',
+          errorMessage: 'Cancelled before the device received it',
+          completedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(scriptExecutions.id, exec.id),
+            inArray(scriptExecutions.status, ['pending', 'queued', 'running']),
+          ),
+        );
+      continue;
+    }
 
     const cmdIsTerminal = cmd?.status === 'completed' || cmd?.status === 'failed';
     const cmdResultStatus = (cmd?.result as Record<string, unknown> | null | undefined)?.status;

--- a/apps/api/src/jobs/staleCommandReaper.ts
+++ b/apps/api/src/jobs/staleCommandReaper.ts
@@ -218,6 +218,55 @@ export async function propagateTimedOutDeviceCommand(params: {
   await enqueueDrExecutionReconcile(drExecutionId, 0);
 }
 
+/**
+ * Terminalise the higher-level records owned by a device command a USER just
+ * cancelled (#5128 §G). Sibling of `propagateTimedOutDeviceCommand`: the
+ * command row itself is already terminal by the time this runs; this only
+ * stops the owning record from waiting forever on a delivery that will never
+ * happen.
+ *
+ * W3 adds the `patch_job_results` branch. Anything without a branch is a no-op
+ * by design — a generic command has no higher-level record (#5128 §F).
+ */
+export async function propagateCancelledDeviceCommand(params: {
+  commandId: string;
+  type: string;
+  payload: Record<string, unknown> | null;
+  completedAt: Date;
+  cancelledBy?: string | null;
+}): Promise<void> {
+  const { commandId, type, payload, completedAt } = params;
+  const errorMessage = 'Cancelled before the device received it';
+
+  if (type === 'script') {
+    const executionId =
+      payload && typeof payload.executionId === 'string' && payload.executionId.trim().length > 0
+        ? payload.executionId
+        : null;
+    if (executionId) {
+      await db
+        .update(scriptExecutions)
+        .set({ status: 'cancelled', errorMessage, completedAt })
+        .where(
+          and(
+            eq(scriptExecutions.id, executionId),
+            inArray(scriptExecutions.status, ['pending', 'queued', 'running']),
+          ),
+        );
+    }
+  }
+
+  await db
+    .update(deploymentResults)
+    .set({ status: 'cancelled', errorMessage, completedAt })
+    .where(
+      and(
+        eq(deploymentResults.deviceCommandId, commandId),
+        eq(deploymentResults.status, 'pending'),
+      ),
+    );
+}
+
 // ── Reap functions ────────────────────────────────────────────────
 
 export async function reapStaleDeviceCommands(): Promise<number> {

--- a/apps/api/src/jobs/staleCommandReaper.ts
+++ b/apps/api/src/jobs/staleCommandReaper.ts
@@ -33,6 +33,10 @@ import { queueBackupStopCommand, CommandTypes } from '../services/commandQueue';
 import { envInt } from '../utils/envInt';
 
 import { terminalPayloadErasureSet } from '../services/sensitiveCommandPayload';
+import {
+  batchIdFromPayload,
+  finalizeScriptExecutionTerminal,
+} from '../services/scriptExecutionTerminal';
 import { attachWorkerObservability } from './workerObservability';
 import { applyAutomationActionTerminal } from '../services/automationActionResults';
 import { CANCEL_GRACE_MS } from '../services/scriptCancellation';
@@ -161,15 +165,17 @@ export async function propagateTimedOutDeviceCommand(params: {
       ? payload.executionId
       : null;
   if (executionId) {
-    await db
-      .update(scriptExecutions)
-      .set({ status: 'failed', errorMessage: errorMsg, completedAt })
-      .where(
-        and(
-          eq(scriptExecutions.id, executionId),
-          inArray(scriptExecutions.status, ['pending', 'queued', 'running']),
-        ),
-      );
+    // Through the shared terminaliser so the owning `script_execution_batches`
+    // counters advance. Terminalising here without them left the batch
+    // non-terminal forever — `reapStaleScriptExecutions` (the only other place
+    // that maintained them) never revisits an already-terminal execution.
+    await finalizeScriptExecutionTerminal({
+      executionId,
+      batchId: batchIdFromPayload(payload),
+      outcome: 'failed',
+      errorMessage: errorMsg,
+      completedAt,
+    });
   }
 
   // Software deployment results, keyed on the owning command row.
@@ -428,15 +434,25 @@ export async function reapStaleDeviceCommands(): Promise<number> {
     if (!due) continue;
 
     const completedAt = new Date();
+    // `status` STAYS 'timeout' on both clocks. It is not a description, it is
+    // the marker `commandAcceptsAgentResultCondition` keys on to let a LATE
+    // agent result overwrite a server-side timeout
+    // (services/commandResultAcceptance.ts — "a new one MUST keep writing
+    // result.status = 'timeout'"). A row can genuinely be both: the frame
+    // reached the agent, the send was reported failed, the row was released
+    // back to `pending`, and it then aged out on the delivery clock. Writing
+    // 'expired' there would drop the real result into the orphan path.
+    // The clock distinction lives in `reason`/`clock` instead.
     const result =
       kind === 'expired'
         ? {
-            status: 'expired',
+            status: SERVER_TIMEOUT_RESULT_STATUS,
             reason: 'not_delivered_before_deadline',
+            clock: 'delivery',
             error: errorMsg,
             timedOutBy: 'server',
           }
-        : { status: 'timeout', error: errorMsg, timedOutBy: 'server' };
+        : { status: SERVER_TIMEOUT_RESULT_STATUS, error: errorMsg, timedOutBy: 'server' };
 
     // #5128 — CAS on the OBSERVED state, not `status IN ('pending','sent')`.
     // A row observed `pending` here but claimed between the SELECT and this
@@ -605,19 +621,17 @@ export async function reapStaleScriptExecutions(): Promise<number> {
     // here, reporting "no response from agent" would be a false diagnosis about
     // an agent that was never asked. Mark it cancelled instead.
     if (cmd?.status === 'cancelled') {
-      await db
-        .update(scriptExecutions)
-        .set({
-          status: 'cancelled',
-          errorMessage: 'Cancelled before the device received it',
-          completedAt: new Date(),
-        })
-        .where(
-          and(
-            eq(scriptExecutions.id, exec.id),
-            inArray(scriptExecutions.status, ['pending', 'queued', 'running']),
-          ),
-        );
+      // Batch bookkeeping runs here too. The CAS inside the helper is what
+      // stops a double count: if `propagateCancelledDeviceCommand` already
+      // terminalised this execution, the UPDATE matches zero rows and the
+      // counter is untouched.
+      await finalizeScriptExecutionTerminal({
+        executionId: exec.id,
+        batchId: batchIdFromPayload(cmd?.payload),
+        outcome: 'cancelled',
+        errorMessage: 'Cancelled before the device received it',
+        completedAt: new Date(),
+      });
       continue;
     }
 
@@ -635,27 +649,25 @@ export async function reapStaleScriptExecutions(): Promise<number> {
       : 'Server-side timeout: no response from agent';
 
     const scriptCompletedAt = new Date();
-    const updated = await db
-      .update(scriptExecutions)
-      .set({
-        status: reapedStatus,
-        completedAt: scriptCompletedAt,
-        errorMessage: reapedError,
-      })
-      .where(
-        and(
-          eq(scriptExecutions.id, exec.id),
-          inArray(scriptExecutions.status, ['pending', 'queued', 'running']),
-        ),
-      )
-      .returning({ id: scriptExecutions.id });
+    // Terminalisation + batch attribution both live in the shared helper now
+    // (services/scriptExecutionTerminal.ts), so the propagation paths that also
+    // terminalise an execution keep the counters in step. The atomicity the
+    // old inline `db.transaction` provided moves with it: increment + check +
+    // terminalise run on one executor.
+    const { terminalised } = await finalizeScriptExecutionTerminal({
+      executionId: exec.id,
+      batchId: batchIdFromPayload(cmd?.payload),
+      outcome: reapedStatus,
+      errorMessage: reapedError,
+      completedAt: scriptCompletedAt,
+    });
 
-    if (updated.length === 0) continue;
+    if (!terminalised) continue;
     reaped++;
 
     await applyAutomationActionTerminal({
       source: 'reaper',
-      scriptExecutionId: updated[0]!.id,
+      scriptExecutionId: exec.id,
       terminalStatus: reapedStatus === 'completed'
         ? 'succeeded'
         : reapedStatus === 'failed'
@@ -664,43 +676,6 @@ export async function reapStaleScriptExecutions(): Promise<number> {
       error: reapedError,
       completedAt: scriptCompletedAt,
     });
-
-    // Batch attribution reuses the row fetched above (same query, one round-trip).
-    const batchId = (cmd?.payload as Record<string, unknown>)?.batchId as string | undefined;
-    if (batchId) {
-      // Atomic: increment counter + check completion in a transaction
-      await db.transaction(async (tx) => {
-        // A recovered success must not be counted as a batch failure — that was
-        // the same false claim one level up.
-        await tx
-          .update(scriptExecutionBatches)
-          .set(
-            reapedStatus === 'completed'
-              ? { devicesCompleted: sql`${scriptExecutionBatches.devicesCompleted} + 1` }
-              : { devicesFailed: sql`${scriptExecutionBatches.devicesFailed} + 1` },
-          )
-          .where(eq(scriptExecutionBatches.id, batchId));
-
-        const [batch] = await tx
-          .select({
-            devicesTargeted: scriptExecutionBatches.devicesTargeted,
-            devicesCompleted: scriptExecutionBatches.devicesCompleted,
-            devicesFailed: scriptExecutionBatches.devicesFailed,
-          })
-          .from(scriptExecutionBatches)
-          .where(eq(scriptExecutionBatches.id, batchId));
-
-        if (batch && batch.devicesCompleted + batch.devicesFailed >= batch.devicesTargeted) {
-          await tx
-            .update(scriptExecutionBatches)
-            .set({
-              status: batch.devicesFailed > 0 ? 'failed' : 'completed',
-              completedAt: new Date(),
-            })
-            .where(eq(scriptExecutionBatches.id, batchId));
-        }
-      });
-    }
   }
 
   return reaped;
@@ -1155,12 +1130,21 @@ export async function reapStaleSoftwareDeploymentResults(): Promise<number> {
     // The SQL filter already excludes these; keep the guard for defense.
     if (!row.dispatchedAt) continue;
 
+    // ORPHANED: the row names a command that no longer exists. There is no FK
+    // on `deployment_results.device_command_id` (device_commands is the agent
+    // hot path and stays unconstrained), so a deleted or purged command row
+    // leaves the LEFT JOIN with a NULL status — which read as "not delivered"
+    // and skipped the row FOREVER, since nothing else ever revisits it either
+    // (#5128 review round 2, O). Nobody can answer for it, so fail it on the
+    // install timeout measured from the deployment's dispatch.
+    const orphaned = row.deviceCommandId !== null && row.commandStatus === null;
+
     const delivered =
       row.deviceCommandId === null ||
       row.commandStatus === 'sent' ||
       row.commandStatus === 'completed';
 
-    if (!delivered) {
+    if (!delivered && !orphaned) {
       // #5128 — NOT this reaper's clock. The row is either still waiting for
       // the device (`pending`) or already terminal by another path; either way
       // `reapStaleDeviceCommands` owns the delivery deadline and propagates.
@@ -1169,10 +1153,13 @@ export async function reapStaleSoftwareDeploymentResults(): Promise<number> {
 
     // Measure from the claim timestamp when we have one; fall back to the
     // deployment's dispatch time for rows with no linked command (pre-#5128
-    // WS dispatches created none) or a claim timestamp that was never written.
+    // WS dispatches created none), an orphaned link, or a claim timestamp that
+    // was never written.
     const deliveredRef = row.commandExecutedAt ?? row.dispatchedAt;
     if (now - deliveredRef.getTime() < SOFTWARE_INSTALL_TIMEOUT_MS) continue;
-    const errorMessage = 'Server-side timeout: no response from agent';
+    const errorMessage = orphaned
+      ? 'Command row missing — install outcome unknown'
+      : 'Server-side timeout: no response from agent';
 
     const completedAt = new Date();
 

--- a/apps/api/src/jobs/staleCommandReaper.ts
+++ b/apps/api/src/jobs/staleCommandReaper.ts
@@ -5,7 +5,6 @@ import { db } from '../db';
 import {
   deviceCommands,
   scriptExecutions,
-  scriptExecutionBatches,
   scripts,
   patchJobs,
   patchJobResults,
@@ -398,12 +397,14 @@ export async function reapStaleDeviceCommands(): Promise<number> {
       cmd.payload as Record<string, unknown> | null,
     );
 
-    // #5128 — pick the clock this row is on. `expired` (delivery deadline
-    // passed, the agent never claimed it) is deliberately distinct from
-    // `timeout` (delivered, the agent never answered): only the second is
-    // evidence about the agent. The reason is `not_delivered_before_deadline`
-    // rather than "never reconnected", because a protocol-capability exclusion
-    // can leave a row undelivered on a device that is connected.
+    // #5128 — pick the clock this row is on. The DELIVERY clock (deadline
+    // passed, the agent never claimed it) is deliberately distinguished from
+    // the EXECUTION clock (delivered, the agent never answered): only the
+    // second is evidence about the agent. That distinction is carried in
+    // `result.reason`/`result.clock`, NOT in `result.status` — see the comment
+    // on `result` below. The reason is `not_delivered_before_deadline` rather
+    // than "never reconnected", because a protocol-capability exclusion can
+    // leave a row undelivered on a device that is connected.
     let due: boolean;
     let kind: 'expired' | 'timeout';
     let errorMsg: string;

--- a/apps/api/src/jobs/staleCommandReaper.ts
+++ b/apps/api/src/jobs/staleCommandReaper.ts
@@ -1,5 +1,5 @@
 import { Job, Queue, Worker } from 'bullmq';
-import { and, eq, lt, sql, inArray, isNotNull } from 'drizzle-orm';
+import { and, eq, lt, sql, inArray, isNotNull, isNull, or } from 'drizzle-orm';
 import * as dbModule from '../db';
 import { db } from '../db';
 import {
@@ -84,10 +84,9 @@ const DEPLOYMENT_TIMEOUT_MS = 2 * 60 * 60 * 1000; // 2 hours
 // agent/internal/remote/tools/software_install.go:22-26), so the server only
 // declares a timeout after the agent's ceilings have provably lapsed.
 export const SOFTWARE_INSTALL_TIMEOUT_MS = 55 * 60 * 1000;
-// Tier 2 (queued for an offline device, never delivered): the queued
-// device_commands row may legitimately wait for the device to reconnect, so
-// it gets a much longer leash before the deployment expires.
-export const SOFTWARE_QUEUED_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000;
+// #5128: the old Tier 2 constant (a flat 7-day expiry for an install queued
+// against an offline device) is gone. `device_commands.deliver_by` is the one
+// delivery deadline now, and `reapStaleDeviceCommands` is its only owner.
 const REMOTE_SESSION_PENDING_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
 const REMOTE_SESSION_ACTIVE_TIMEOUT_MS = 24 * 60 * 60 * 1000; // 24 hours (zombie safety net)
 
@@ -134,13 +133,55 @@ function getQueue(): Queue<ReaperJobData> {
   return reaperQueue;
 }
 
+/**
+ * Terminalise the higher-level records that own a device command the reaper
+ * just failed.
+ *
+ * #5128 — `kind` distinguishes the two clocks. `'expired'` means the delivery
+ * deadline passed and the agent never claimed the row; `'timeout'` means it was
+ * delivered and never answered. Since the per-feature reapers no longer expire
+ * undelivered work themselves (§C), this is the ONLY path by which a
+ * `script_executions` or `deployment_results` row learns that its command
+ * expired undelivered — a miss here leaves that row waiting forever.
+ */
 export async function propagateTimedOutDeviceCommand(params: {
   commandId: string;
   payload: Record<string, unknown> | null;
   errorMsg: string;
   completedAt: Date;
+  kind?: 'expired' | 'timeout';
 }): Promise<void> {
   const { commandId, payload, errorMsg, completedAt } = params;
+
+  // Script executions: the command reaper is now the single owner of the
+  // delivery clock, so an execution whose command expired undelivered is
+  // failed here rather than by reapStaleScriptExecutions' own timer.
+  const executionId =
+    payload && typeof payload.executionId === 'string' && payload.executionId.trim().length > 0
+      ? payload.executionId
+      : null;
+  if (executionId) {
+    await db
+      .update(scriptExecutions)
+      .set({ status: 'failed', errorMessage: errorMsg, completedAt })
+      .where(
+        and(
+          eq(scriptExecutions.id, executionId),
+          inArray(scriptExecutions.status, ['pending', 'queued', 'running']),
+        ),
+      );
+  }
+
+  // Software deployment results, keyed on the owning command row.
+  await db
+    .update(deploymentResults)
+    .set({ status: 'failed', errorMessage: errorMsg, completedAt })
+    .where(
+      and(
+        eq(deploymentResults.deviceCommandId, commandId),
+        eq(deploymentResults.status, 'pending'),
+      ),
+    );
 
   await db
     .update(restoreJobs)
@@ -184,10 +225,28 @@ export async function reapStaleDeviceCommands(): Promise<number> {
   const conservativeCutoff = new Date(now - SHORTEST_TIMEOUT_MS);
   const excludedTypes = [...EXCLUDED_COMMAND_TYPES];
 
-  // Build WHERE conditions, guarding against empty exclusion set
+  const nowDate = new Date(now);
+
+  // Build WHERE conditions, guarding against empty exclusion set.
+  //
+  // #5128 — TWO CLOCKS. A `pending` row carrying a `deliver_by` is on the
+  // DELIVERY clock: it is due only when its own deadline has passed, however
+  // long its execution timeout happens to be. Legacy `pending` rows
+  // (deliver_by NULL) and every `sent` row stay on the EXECUTION clock and keep
+  // the conservative `created_at` age cutoff, which is what stops a 7-day row
+  // from being re-scanned every two minutes. The OR arm is what gets genuinely
+  // due rows selected BEFORE the per-run cap is applied.
   const whereConditions = [
     inArray(deviceCommands.status, ['pending', 'sent']),
-    lt(deviceCommands.createdAt, conservativeCutoff),
+    or(
+      and(
+        eq(deviceCommands.status, 'pending'),
+        isNotNull(deviceCommands.deliverBy),
+        lt(deviceCommands.deliverBy, nowDate),
+      ),
+      and(isNull(deviceCommands.deliverBy), lt(deviceCommands.createdAt, conservativeCutoff)),
+      and(eq(deviceCommands.status, 'sent'), lt(deviceCommands.createdAt, conservativeCutoff)),
+    ),
   ];
   if (excludedTypes.length > 0) {
     whereConditions.push(
@@ -296,6 +355,7 @@ export async function reapStaleDeviceCommands(): Promise<number> {
       payload: deviceCommands.payload,
       createdAt: deviceCommands.createdAt,
       executedAt: deviceCommands.executedAt,
+      deliverBy: deviceCommands.deliverBy,
     })
     .from(deviceCommands)
     .where(and(...whereConditions))
@@ -308,32 +368,68 @@ export async function reapStaleDeviceCommands(): Promise<number> {
       cmd.type,
       cmd.payload as Record<string, unknown> | null,
     );
-    const referenceTime = cmd.status === 'sent' && cmd.executedAt
-      ? cmd.executedAt.getTime()
-      : cmd.createdAt.getTime();
 
-    if (now - referenceTime < timeoutMs) continue;
+    // #5128 — pick the clock this row is on. `expired` (delivery deadline
+    // passed, the agent never claimed it) is deliberately distinct from
+    // `timeout` (delivered, the agent never answered): only the second is
+    // evidence about the agent. The reason is `not_delivered_before_deadline`
+    // rather than "never reconnected", because a protocol-capability exclusion
+    // can leave a row undelivered on a device that is connected.
+    let due: boolean;
+    let kind: 'expired' | 'timeout';
+    let errorMsg: string;
+    if (cmd.status === 'pending' && cmd.deliverBy) {
+      due = cmd.deliverBy.getTime() <= now;
+      kind = 'expired';
+      errorMsg = `Device did not reconnect before ${cmd.deliverBy.toISOString()}; command was never delivered`;
+    } else if (cmd.status === 'sent' && cmd.executedAt) {
+      due = now - cmd.executedAt.getTime() >= timeoutMs;
+      kind = 'timeout';
+      errorMsg = `Server-side timeout: no response from agent after ${Math.round(timeoutMs / 60000)} minutes`;
+    } else {
+      due = now - cmd.createdAt.getTime() >= timeoutMs;
+      kind = 'timeout';
+      errorMsg = `Command expired: agent never received the command (${Math.round(timeoutMs / 60000)} min timeout)`;
+    }
 
-    const errorMsg = cmd.status === 'sent'
-      ? `Server-side timeout: no response from agent after ${Math.round(timeoutMs / 60000)} minutes`
-      : `Command expired: agent never received the command (${Math.round(timeoutMs / 60000)} min timeout)`;
+    if (!due) continue;
 
     const completedAt = new Date();
+    const result =
+      kind === 'expired'
+        ? {
+            status: 'expired',
+            reason: 'not_delivered_before_deadline',
+            error: errorMsg,
+            timedOutBy: 'server',
+          }
+        : { status: 'timeout', error: errorMsg, timedOutBy: 'server' };
+
+    // #5128 — CAS on the OBSERVED state, not `status IN ('pending','sent')`.
+    // A row observed `pending` here but claimed between the SELECT and this
+    // UPDATE would otherwise be failed the instant it was delivered. Mirrors
+    // the `(id, status='sent', executed_at=<claim ts>)` fence
+    // `releaseClaimedCommandDelivery` already uses.
+    const observedGuard =
+      cmd.status === 'sent'
+        ? and(
+            eq(deviceCommands.id, cmd.id),
+            eq(deviceCommands.status, 'sent'),
+            cmd.executedAt
+              ? eq(deviceCommands.executedAt, cmd.executedAt)
+              : isNull(deviceCommands.executedAt),
+          )
+        : and(eq(deviceCommands.id, cmd.id), eq(deviceCommands.status, 'pending'));
 
     const updated = await db
       .update(deviceCommands)
       .set({
         status: 'failed',
         completedAt,
-        result: { status: 'timeout', error: errorMsg, timedOutBy: 'server' },
+        result,
         ...terminalPayloadErasureSet(),
       })
-      .where(
-        and(
-          eq(deviceCommands.id, cmd.id),
-          inArray(deviceCommands.status, ['pending', 'sent']),
-        ),
-      )
+      .where(observedGuard)
       .returning({ id: deviceCommands.id });
 
     if (updated.length === 0) continue;
@@ -359,6 +455,7 @@ export async function reapStaleDeviceCommands(): Promise<number> {
         payload: (cmd.payload as Record<string, unknown> | null) ?? null,
         errorMsg,
         completedAt,
+        kind,
       });
     } catch (error) {
       console.error(`[StaleCommandReaper] Failed to propagate stale command ${cmd.id}:`, error);
@@ -459,6 +556,16 @@ export async function reapStaleScriptExecutions(): Promise<number> {
       .limit(1);
 
     const cmd = relatedCmd[0];
+
+    // #5128 — THE DELIVERY CLOCK HAS ONE OWNER. A not-yet-running execution
+    // whose command row is still `pending` or `sent` is waiting for the device,
+    // not stalled: only `reapStaleDeviceCommands` may expire it (at the row's
+    // own `deliver_by`), and it propagates the outcome here. Without this,
+    // a script queued for an offline laptop had its execution row failed under
+    // it by the script's own 300 s execution timeout while the command row was
+    // legitimately waiting days for the machine to come back.
+    if (exec.status !== 'running' && (cmd?.status === 'pending' || cmd?.status === 'sent')) continue;
+
     const cmdIsTerminal = cmd?.status === 'completed' || cmd?.status === 'failed';
     const cmdResultStatus = (cmd?.result as Record<string, unknown> | null | undefined)?.status;
     // Mirror handleScriptResult's mapping so a reaped row agrees with what the
@@ -934,39 +1041,45 @@ async function reapStaleDeploymentDevices(): Promise<number> {
 
 /**
  * Reap stale System-A software deployment result rows (`deployment_results`)
- * that the agent result path will never terminate on its own. Two tiers:
+ * that the agent result path will never terminate on its own.
  *
- *  Tier 1 (delivered but silent): the install command provably reached the
- *  agent — WS-dispatched directly (`device_command_id` NULL) or the linked
- *  `device_commands` row is 'sent'/'completed' — and the parent deployment's
- *  `dispatched_at` is older than SOFTWARE_INSTALL_TIMEOUT_MS.
+ *  DELIVERED BUT SILENT: the install command provably reached the agent — the
+ *  linked `device_commands` row is 'sent'/'completed', or there is no linked
+ *  row at all (pre-#5128 WS dispatches, which created none) — and more than
+ *  SOFTWARE_INSTALL_TIMEOUT_MS has passed SINCE DELIVERY.
  *
- *  Tier 2 (queued, never delivered): the linked `device_commands` row is
- *  still 'pending' (device offline, waiting to reconnect). Spared until
- *  `dispatched_at` is older than SOFTWARE_QUEUED_EXPIRY_MS, then failed AND
- *  the queued command is cancelled so it can't fire on a later reconnect.
+ * #5128 — two corrections here:
+ *
+ *  1. The "delivered but silent" clock now measures from the command's
+ *     `executed_at` (the instant the agent CLAIMED it), not the deployment's
+ *     `dispatched_at`. Measuring from dispatch timed out an install that was
+ *     delivered three days later on the reaper's very next pass, purely
+ *     because the device had been offline in between.
+ *  2. The old Tier 2 ("queued, never delivered", expiring at a flat 7 days from
+ *     dispatch) is GONE. Undelivered work belongs to exactly one clock owner —
+ *     `reapStaleDeviceCommands`, which expires the row at its own `deliver_by`
+ *     and propagates the outcome through `propagateTimedOutDeviceCommand`.
+ *     Two independent reapers racing on the same undelivered row is what made
+ *     "queued — device offline" unreliable in the first place.
  *
  * Rows whose deployment has `dispatched_at` NULL (scheduled, not yet
  * dispatched) are NEVER candidates — the SQL filter excludes them.
- *
- * A linked command in a terminal state ('failed'/'cancelled') or whose row
- * has vanished matches neither tier's delivery proof; those fall through to
- * the Tier 2 expiry as a backstop so the result row can't zombie forever
- * (the guarded command-cancel is a no-op for non-pending rows).
  */
 export async function reapStaleSoftwareDeploymentResults(): Promise<number> {
   const now = Date.now();
   const timeoutCutoff = new Date(now - SOFTWARE_INSTALL_TIMEOUT_MS);
 
-  // Conservative SQL pre-filter at the Tier 1 cutoff (the tighter of the
-  // two); per-row tier logic below applies the precise threshold. Mirrors
-  // the SHORTEST_TIMEOUT_MS pattern used elsewhere in this file.
+  // Conservative SQL pre-filter on the deployment's dispatch age: delivery can
+  // only ever be at or after dispatch, so nothing younger than this cutoff can
+  // be due on the delivery clock either. The precise per-row threshold is
+  // applied below (the precise-threshold-in-JS pattern used elsewhere here).
   const candidates = await db
     .select({
       id: deploymentResults.id,
       deviceCommandId: deploymentResults.deviceCommandId,
       dispatchedAt: softwareDeployments.dispatchedAt,
       commandStatus: deviceCommands.status,
+      commandExecutedAt: deviceCommands.executedAt,
     })
     .from(deploymentResults)
     .innerJoin(softwareDeployments, eq(softwareDeployments.id, deploymentResults.deploymentId))
@@ -987,25 +1100,24 @@ export async function reapStaleSoftwareDeploymentResults(): Promise<number> {
     // The SQL filter already excludes these; keep the guard for defense.
     if (!row.dispatchedAt) continue;
 
-    const dispatchedAgoMs = now - row.dispatchedAt.getTime();
-
     const delivered =
       row.deviceCommandId === null ||
       row.commandStatus === 'sent' ||
       row.commandStatus === 'completed';
 
-    let errorMessage: string;
-    if (delivered) {
-      // Tier 1 — the SQL filter already applies this cutoff; re-check per
-      // row (precise-threshold-in-JS pattern used elsewhere in this file).
-      if (dispatchedAgoMs < SOFTWARE_INSTALL_TIMEOUT_MS) continue;
-      errorMessage = 'Server-side timeout: no response from agent';
-    } else {
-      // Tier 2 — queued for an offline device (or delivery unprovable):
-      // spare until the queued-expiry window lapses.
-      if (dispatchedAgoMs < SOFTWARE_QUEUED_EXPIRY_MS) continue;
-      errorMessage = 'Device did not come online before the deployment expired';
+    if (!delivered) {
+      // #5128 — NOT this reaper's clock. The row is either still waiting for
+      // the device (`pending`) or already terminal by another path; either way
+      // `reapStaleDeviceCommands` owns the delivery deadline and propagates.
+      continue;
     }
+
+    // Measure from the claim timestamp when we have one; fall back to the
+    // deployment's dispatch time for rows with no linked command (pre-#5128
+    // WS dispatches created none) or a claim timestamp that was never written.
+    const deliveredRef = row.commandExecutedAt ?? row.dispatchedAt;
+    if (now - deliveredRef.getTime() < SOFTWARE_INSTALL_TIMEOUT_MS) continue;
+    const errorMessage = 'Server-side timeout: no response from agent';
 
     const completedAt = new Date();
 
@@ -1036,37 +1148,10 @@ export async function reapStaleSoftwareDeploymentResults(): Promise<number> {
       completedAt,
     });
 
-    // Tier 2: cancel the still-queued device_commands row so the install
-    // can't fire when the device eventually reconnects. Guarded on
-    // status='pending' — if the agent claimed it mid-reap, leave it be.
-    if (!delivered && row.deviceCommandId) {
-      try {
-        await db
-          .update(deviceCommands)
-          .set({
-            status: 'cancelled',
-            completedAt,
-            result: {
-              status: 'cancelled',
-              error: errorMessage,
-              cancelledBy: 'stale-command-reaper',
-            },
-            ...terminalPayloadErasureSet(),
-          })
-          .where(
-            and(
-              eq(deviceCommands.id, row.deviceCommandId),
-              eq(deviceCommands.status, 'pending'),
-            ),
-          );
-      } catch (error) {
-        console.error(
-          `[StaleCommandReaper] Failed to cancel queued command ${row.deviceCommandId} for expired deployment result ${row.id}:`,
-          error,
-        );
-        captureException(error instanceof Error ? error : new Error(String(error)));
-      }
-    }
+    // #5128 — the old Tier 2 cancel of the still-queued device_commands row is
+    // gone with Tier 2 itself. An undelivered row is never reached here now,
+    // and cancelling one from this reaper would race the single owner of the
+    // delivery clock.
   }
 
   return reaped;

--- a/apps/api/src/jobs/staleCommandReaper.twoClocks.test.ts
+++ b/apps/api/src/jobs/staleCommandReaper.twoClocks.test.ts
@@ -1,0 +1,310 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * #5128 — the reaper's TWO CLOCKS.
+ *
+ * `pending` rows carrying a `deliver_by` are on the DELIVERY clock and expire
+ * at that instant, no matter what their execution timeout says. Legacy
+ * `pending` rows (`deliver_by IS NULL`) and every `sent` row stay on the
+ * EXECUTION clock exactly as before. Every terminal UPDATE is a CAS on the
+ * OBSERVED `(status, executed_at)`, never `status IN ('pending','sent')`.
+ *
+ * Kept in its own file so the mock surface can stay small and the CAS/clock
+ * assertions read without the 1,000-line fixture set of staleCommandReaper.test.ts.
+ */
+
+const {
+  selectMock,
+  updateMock,
+  deviceCommandsTable,
+  applyAutomationActionTerminalMock,
+  captureExceptionMock,
+} = vi.hoisted(() => ({
+  selectMock: vi.fn(),
+  updateMock: vi.fn(),
+  deviceCommandsTable: {
+    id: 'device_commands.id',
+    type: 'device_commands.type',
+    status: 'device_commands.status',
+    payload: 'device_commands.payload',
+    createdAt: 'device_commands.created_at',
+    executedAt: 'device_commands.executed_at',
+    completedAt: 'device_commands.completed_at',
+    deliverBy: 'device_commands.deliver_by',
+    submittedOrgId: 'device_commands.submitted_org_id',
+    result: 'device_commands.result',
+    deviceId: 'device_commands.device_id',
+    uninstallReasons: 'device_commands.uninstall_reasons',
+    deviceRemoveExpiresAt: 'device_commands.device_remove_expires_at',
+  },
+  applyAutomationActionTerminalMock: vi.fn().mockResolvedValue(true),
+  captureExceptionMock: vi.fn(),
+}));
+
+vi.mock('bullmq', () => ({ Queue: class {}, Worker: class {}, Job: class {} }));
+
+vi.mock('../db', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../db')>();
+  return {
+    ...actual,
+    db: {
+      ...actual.db,
+      select: (...args: unknown[]) => selectMock(...(args as [])),
+      update: (...args: unknown[]) => updateMock(...(args as [])),
+    },
+  };
+});
+
+vi.mock('../db/schema', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../db/schema')>();
+  return { ...actual, deviceCommands: deviceCommandsTable };
+});
+
+vi.mock('../services/redis', () => ({
+  getRedisConnection: vi.fn(() => ({})),
+  getBullMQConnection: vi.fn(() => ({ host: 'localhost', port: 6379 })),
+  isBullMQAvailable: vi.fn(() => true),
+}));
+
+vi.mock('../services/sentry', () => ({
+  captureException: (...args: unknown[]) => captureExceptionMock(...(args as [])),
+}));
+
+vi.mock('../services/automationActionResults', () => ({
+  applyAutomationActionTerminal: (...args: unknown[]) =>
+    applyAutomationActionTerminalMock(...(args as [])),
+}));
+
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { reapStaleDeviceCommands } from './staleCommandReaper';
+
+/**
+ * The mocked `deviceCommands` columns are plain strings, not Drizzle Column
+ * instances, so they compile to BOUND PARAMETERS. That is what makes the exact
+ * shape of a WHERE clause assertable here (the same technique the sibling
+ * staleCommandReaper.test.ts uses for the device-remove drain arm).
+ */
+function compile(whereArg: unknown) {
+  return new PgDialect().sqlToQuery(whereArg as never);
+}
+
+function selectChain(resolvedValue: unknown) {
+  const chain: Record<string, unknown> = {};
+  for (const method of ['from', 'innerJoin', 'leftJoin', 'where', 'orderBy', 'limit']) {
+    chain[method] = vi.fn(() => Object.assign(Promise.resolve(resolvedValue), chain));
+  }
+  return Object.assign(Promise.resolve(resolvedValue), chain);
+}
+
+type UpdateChain = {
+  set: ReturnType<typeof vi.fn>;
+  where: ReturnType<typeof vi.fn>;
+  returning: ReturnType<typeof vi.fn>;
+};
+
+function updateChain(returning: unknown): UpdateChain {
+  const chain = {} as UpdateChain;
+  chain.set = vi.fn(() => chain);
+  chain.where = vi.fn(() => chain);
+  chain.returning = vi.fn(async () => returning);
+  return chain;
+}
+
+/**
+ * Routes `db.update(...)` by TABLE. Only the `device_commands` writes belong to
+ * the reaper's own terminal CAS; `propagateTimedOutDeviceCommand` issues
+ * further UPDATEs (script_executions, deployment_results, restore_jobs) that
+ * would otherwise land on the same spy and make the counts meaningless.
+ */
+function routeUpdates(returning: unknown): { command: UpdateChain; other: UpdateChain } {
+  const command = updateChain(returning);
+  const other = updateChain([]);
+  updateMock.mockImplementation((table: unknown) => (table === deviceCommandsTable ? command : other));
+  return { command, other };
+}
+
+const NOW = Date.now();
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+
+/** A script command whose EXECUTION timeout (300 s + 5 min grace) lapsed an hour ago. */
+const scriptRow = (over: Record<string, unknown> = {}) => ({
+  id: 'c1',
+  type: 'script',
+  payload: { timeoutSeconds: 300 },
+  status: 'pending',
+  createdAt: new Date(NOW - HOUR),
+  executedAt: null,
+  deliverBy: null,
+  ...over,
+});
+
+describe('reapStaleDeviceCommands — two clocks (#5128)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    applyAutomationActionTerminalMock.mockResolvedValue(true);
+  });
+
+  it('a pending row with a FUTURE deliver_by is not reaped even though its execution timeout lapsed', async () => {
+    selectMock.mockReturnValue(selectChain([scriptRow({ deliverBy: new Date(NOW + 6 * DAY) })]));
+    const reaped = await reapStaleDeviceCommands();
+    expect(reaped).toBe(0);
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it('a pending row past deliver_by is failed with expired / not_delivered_before_deadline', async () => {
+    const deliverBy = new Date(NOW - 1000);
+    selectMock.mockReturnValue(selectChain([scriptRow({ deliverBy })]));
+    const { command: update } = routeUpdates([{ id: 'c1' }]);
+
+    const reaped = await reapStaleDeviceCommands();
+
+    expect(reaped).toBe(1);
+    expect(update.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'failed',
+        result: expect.objectContaining({
+          status: 'expired',
+          reason: 'not_delivered_before_deadline',
+          timedOutBy: 'server',
+        }),
+      })
+    );
+    const setArg = update.set.mock.calls[0]![0] as { result: { error: string } };
+    expect(setArg.result.error).toContain(deliverBy.toISOString());
+    expect(setArg.result.error).toContain('never delivered');
+  });
+
+  it('a legacy pending row (deliver_by NULL) keeps the created_at + execution-timeout rule', async () => {
+    selectMock.mockReturnValue(selectChain([scriptRow({ deliverBy: null })]));
+    const { command: update } = routeUpdates([{ id: 'c1' }]);
+
+    expect(await reapStaleDeviceCommands()).toBe(1);
+    expect(update.set).toHaveBeenCalledWith(
+      expect.objectContaining({ result: expect.objectContaining({ status: 'timeout' }) })
+    );
+    const setArg = update.set.mock.calls[0]![0] as { result: { error: string; reason?: string } };
+    expect(setArg.result.error).toContain('agent never received the command');
+    expect(setArg.result.reason).toBeUndefined();
+  });
+
+  it('a legacy pending row still inside its execution timeout is left alone', async () => {
+    selectMock.mockReturnValue(
+      selectChain([scriptRow({ deliverBy: null, createdAt: new Date(NOW - 60_000) })])
+    );
+    expect(await reapStaleDeviceCommands()).toBe(0);
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it('a sent row still measures from executed_at, and a deliver_by does not shorten it', async () => {
+    // The delivery clock stops at the claim: once a row is `sent`, only the
+    // execution timeout applies, even though deliver_by has since passed.
+    selectMock.mockReturnValue(
+      selectChain([
+        scriptRow({
+          status: 'sent',
+          executedAt: new Date(NOW - 60_000),
+          deliverBy: new Date(NOW - 30 * 60 * 1000),
+        }),
+      ])
+    );
+    expect(await reapStaleDeviceCommands()).toBe(0);
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it('a sent row past its execution timeout is failed as timeout, not expired', async () => {
+    const executedAt = new Date(NOW - HOUR);
+    selectMock.mockReturnValue(
+      selectChain([scriptRow({ status: 'sent', executedAt, deliverBy: new Date(NOW - 2 * HOUR) })])
+    );
+    const { command: update } = routeUpdates([{ id: 'c1' }]);
+
+    expect(await reapStaleDeviceCommands()).toBe(1);
+    expect(update.set).toHaveBeenCalledWith(
+      expect.objectContaining({ result: expect.objectContaining({ status: 'timeout' }) })
+    );
+    const setArg = update.set.mock.calls[0]![0] as { result: { error: string } };
+    expect(setArg.result.error).toContain('no response from agent');
+  });
+
+  it('the terminal UPDATE is a CAS on the observed pending status, never IN (pending, sent)', async () => {
+    selectMock.mockReturnValue(selectChain([scriptRow({ deliverBy: new Date(NOW - 1000) })]));
+    const { command: update } = routeUpdates([{ id: 'c1' }]);
+
+    await reapStaleDeviceCommands();
+
+    const { sql: sqlText, params } = compile(update.where.mock.calls[0]![0]);
+    expect(params).toEqual(['device_commands.id', 'c1', 'device_commands.status', 'pending']);
+    expect(sqlText).toContain('and');
+    // The old guard. If this ever comes back, a row claimed between the SELECT
+    // and the UPDATE gets failed the instant it was delivered.
+    expect(sqlText).not.toMatch(/ in \(/i);
+  });
+
+  it('the terminal UPDATE for a sent row fences on the observed executed_at', async () => {
+    const executedAt = new Date(NOW - HOUR);
+    selectMock.mockReturnValue(selectChain([scriptRow({ status: 'sent', executedAt })]));
+    const { command: update } = routeUpdates([{ id: 'c1' }]);
+
+    await reapStaleDeviceCommands();
+
+    const { sql: sqlText, params } = compile(update.where.mock.calls[0]![0]);
+    expect(params).toEqual([
+      'device_commands.id',
+      'c1',
+      'device_commands.status',
+      'sent',
+      'device_commands.executed_at',
+      executedAt,
+    ]);
+    expect(sqlText).not.toMatch(/ in \(/i);
+  });
+
+  it('a CAS that matches zero rows (claimed under us) is not counted and does not propagate', async () => {
+    selectMock.mockReturnValue(selectChain([scriptRow({ deliverBy: new Date(NOW - 1000) })]));
+    routeUpdates([]);
+
+    expect(await reapStaleDeviceCommands()).toBe(0);
+    expect(applyAutomationActionTerminalMock).not.toHaveBeenCalled();
+  });
+
+  it('mixes the two clocks in one batch: only the genuinely due rows are reaped', async () => {
+    selectMock.mockReturnValue(
+      selectChain([
+        scriptRow({ id: 'due-delivery', deliverBy: new Date(NOW - 1000) }),
+        scriptRow({ id: 'waiting', deliverBy: new Date(NOW + 6 * DAY) }),
+        scriptRow({ id: 'due-legacy', deliverBy: null }),
+        scriptRow({
+          id: 'sent-fresh',
+          status: 'sent',
+          executedAt: new Date(NOW - 60_000),
+          deliverBy: null,
+        }),
+      ])
+    );
+    const { command: update } = routeUpdates([{ id: 'x' }]);
+
+    expect(await reapStaleDeviceCommands()).toBe(2);
+    expect(update.set).toHaveBeenCalledTimes(2);
+    const statuses = update.set.mock.calls.map(
+      (c) => (c[0] as { result: { status: string } }).result.status
+    );
+    expect(statuses).toEqual(['expired', 'timeout']);
+  });
+
+  it('propagates the delivery expiry with kind="expired" so owning records can distinguish it', async () => {
+    selectMock.mockReturnValue(
+      selectChain([
+        scriptRow({ deliverBy: new Date(NOW - 1000), payload: { executionId: 'exec-1' } }),
+      ])
+    );
+    // One update chain serves the terminal command UPDATE and every propagation
+    // UPDATE; only the first is asserted here.
+    const { command: update } = routeUpdates([{ id: 'c1' }]);
+
+    expect(await reapStaleDeviceCommands()).toBe(1);
+    expect(applyAutomationActionTerminalMock).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'reaper', commandId: 'c1', terminalStatus: 'timed_out' })
+    );
+  });
+});

--- a/apps/api/src/jobs/staleCommandReaper.twoClocks.test.ts
+++ b/apps/api/src/jobs/staleCommandReaper.twoClocks.test.ts
@@ -307,4 +307,63 @@ describe('reapStaleDeviceCommands — two clocks (#5128)', () => {
       expect.objectContaining({ source: 'reaper', commandId: 'c1', terminalStatus: 'timed_out' })
     );
   });
+  // ── Legacy software_install keeps its retired 7-day queue wait ──────────
+  //
+  // #5128 folded `software_install` into the 2-hour LONG_TIMEOUT_TYPES tier
+  // because its queue wait is now a `deliver_by` deadline. Rows written before
+  // the 2026-10-13 migration have no deadline and fall into the legacy branch,
+  // where the EXECUTION timeout doubles as the queue wait — so without the
+  // carve-out the first reaper pass after deploy would fail a week's worth of
+  // legitimately-waiting installs as "agent never received the command".
+
+  const legacyInstall = (over: Record<string, unknown> = {}) => ({
+    id: 'si-1',
+    type: 'software_install',
+    payload: {},
+    status: 'pending',
+    createdAt: new Date(NOW - 3 * HOUR),
+    executedAt: null,
+    deliverBy: null,
+    ...over,
+  });
+
+  it('a legacy pending software_install 3 hours old is NOT reaped, despite the 2 h execution timeout', async () => {
+    selectMock.mockReturnValue(selectChain([legacyInstall()]));
+    expect(await reapStaleDeviceCommands()).toBe(0);
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it('a legacy pending software_install 8 days old IS reaped, as a timeout', async () => {
+    selectMock.mockReturnValue(selectChain([legacyInstall({ createdAt: new Date(NOW - 8 * DAY) })]));
+    const { command: update } = routeUpdates([{ id: 'si-1' }]);
+
+    expect(await reapStaleDeviceCommands()).toBe(1);
+    expect(update.set).toHaveBeenCalledWith(
+      expect.objectContaining({ result: expect.objectContaining({ status: 'timeout' }) })
+    );
+    const setArg = update.set.mock.calls[0]![0] as { result: { error: string } };
+    expect(setArg.result.error).toContain('agent never received the command');
+    // The message reports the clock that was actually applied (7 days), not the
+    // 2-hour execution timeout that would have been used without the carve-out.
+    expect(setArg.result.error).toContain(`${7 * 24 * 60} min`);
+  });
+
+  it('the 7-day carve-out applies ONLY to the legacy branch: a software_install with a deliver_by still expires on it', async () => {
+    const deliverBy = new Date(NOW - 1000);
+    selectMock.mockReturnValue(selectChain([legacyInstall({ deliverBy, createdAt: new Date(NOW - HOUR) })]));
+    const { command: update } = routeUpdates([{ id: 'si-1' }]);
+
+    expect(await reapStaleDeviceCommands()).toBe(1);
+    expect(update.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        result: expect.objectContaining({ reason: 'not_delivered_before_deadline' }),
+      })
+    );
+  });
+
+  it('the carve-out does not leak to other types: a legacy script row still uses its own timeout', async () => {
+    selectMock.mockReturnValue(selectChain([scriptRow({ deliverBy: null })]));
+    routeUpdates([{ id: 'c1' }]);
+    expect(await reapStaleDeviceCommands()).toBe(1);
+  });
 });

--- a/apps/api/src/jobs/staleCommandReaper.twoClocks.test.ts
+++ b/apps/api/src/jobs/staleCommandReaper.twoClocks.test.ts
@@ -164,8 +164,13 @@ describe('reapStaleDeviceCommands — two clocks (#5128)', () => {
       expect.objectContaining({
         status: 'failed',
         result: expect.objectContaining({
-          status: 'expired',
+          // `status` STAYS 'timeout' — it is the marker
+          // `commandAcceptsAgentResultCondition` keys on to let a genuinely
+          // late agent result overwrite a server-side timeout. The clock lives
+          // in `reason`/`clock`.
+          status: 'timeout',
           reason: 'not_delivered_before_deadline',
+          clock: 'delivery',
           timedOutBy: 'server',
         }),
       })
@@ -286,10 +291,13 @@ describe('reapStaleDeviceCommands — two clocks (#5128)', () => {
 
     expect(await reapStaleDeviceCommands()).toBe(2);
     expect(update.set).toHaveBeenCalledTimes(2);
-    const statuses = update.set.mock.calls.map(
-      (c) => (c[0] as { result: { status: string } }).result.status
+    // Both carry the `timeout` acceptance marker; `clock` is what separates the
+    // delivery expiry from the execution timeout.
+    const results = update.set.mock.calls.map(
+      (c) => (c[0] as { result: { status: string; clock?: string } }).result
     );
-    expect(statuses).toEqual(['expired', 'timeout']);
+    expect(results.map((r) => r.status)).toEqual(['timeout', 'timeout']);
+    expect(results.map((r) => r.clock)).toEqual(['delivery', undefined]);
   });
 
   it('propagates the delivery expiry with kind="expired" so owning records can distinguish it', async () => {

--- a/apps/api/src/jobs/staleCommandReaper.twoClocks.test.ts
+++ b/apps/api/src/jobs/staleCommandReaper.twoClocks.test.ts
@@ -152,7 +152,7 @@ describe('reapStaleDeviceCommands — two clocks (#5128)', () => {
     expect(updateMock).not.toHaveBeenCalled();
   });
 
-  it('a pending row past deliver_by is failed with expired / not_delivered_before_deadline', async () => {
+  it('a pending row past deliver_by is failed with the timeout marker + not_delivered_before_deadline', async () => {
     const deliverBy = new Date(NOW - 1000);
     selectMock.mockReturnValue(selectChain([scriptRow({ deliverBy })]));
     const { command: update } = routeUpdates([{ id: 'c1' }]);

--- a/apps/api/src/routes/agentWs.test.ts
+++ b/apps/api/src/routes/agentWs.test.ts
@@ -275,6 +275,10 @@ vi.mock('../services/softwareDeploymentResult', async (importOriginal) => {
   return {
     ...actual,
     applySoftwareInstallResult: vi.fn(),
+    // #5128 — a software_install now carries a real device_commands UUID, so
+    // its result lands on the GENERIC owned-command path and is reconciled
+    // here instead of by the sw-install-<...> regex branch.
+    reconcileSoftwareInstallResult: vi.fn(),
   };
 });
 
@@ -336,12 +340,16 @@ vi.mock('../services/backupResultPersistence', async (importOriginal) => {
 // this must be a partial mock.
 vi.mock('../services/sentry', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../services/sentry')>();
-  return { ...actual, captureMessage: vi.fn() };
+  // captureException is also stubbed (#5128 review round 2): the generic
+  // software_install reconcile branch must REPORT a reconcile failure rather
+  // than rethrow it into the socket handler, and that is only assertable with
+  // a spy. The real implementation is a no-op without a Sentry DSN anyway.
+  return { ...actual, captureMessage: vi.fn(), captureException: vi.fn() };
 });
 
 import { db, runOutsideDbContext, withSystemDbAccessContext, withDbAccessContext } from '../db';
 import { devices, deviceCommands, scriptExecutions, supportSessions } from '../db/schema';
-import { captureMessage } from '../services/sentry';
+import { captureException, captureMessage } from '../services/sentry';
 import {
   createAgentWsHandlers,
   createAgentWsRoutes,
@@ -356,7 +364,10 @@ import {
   AGENT_WS_CAPABILITIES,
 } from './agentWs';
 import { sendCommandToAgentAwaitResult } from '../services/agentCommandAwait';
-import { applySoftwareInstallResult } from '../services/softwareDeploymentResult';
+import {
+  applySoftwareInstallResult,
+  reconcileSoftwareInstallResult,
+} from '../services/softwareDeploymentResult';
 import { isRedisAvailable } from '../services/redis';
 import { partnerTrustMode } from '../config/partnerTrustMode';
 import {
@@ -1060,6 +1071,74 @@ describe('agent websocket command results', () => {
     } as any, ws as any);
 
     expect(db.update).toHaveBeenCalledTimes(1);
+    expect(ws.send).toHaveBeenCalledWith(expect.stringContaining('"ack"'));
+  });
+
+  // ── #5128: software_install results on the GENERIC owned-command path ────
+  //
+  // Before #5128 a WS-pushed install carried the synthetic
+  // `sw-install-<deployment>-<device>-<attempt>` id and was reconciled by the
+  // regex branch. New dispatches persist a device_commands row FIRST and push
+  // with its UUID, so the result lands here — without this wiring the
+  // deployment_results row strands `pending` forever on the websocket
+  // transport.
+  it('reconciles a software_install result delivered under a real command UUID', async () => {
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123', partnerId: 'partner-123' };
+    const { handlers, ws } = await connectedAgent('agent-123', preValidatedAgent);
+    const commandId = '33333333-3333-4333-8333-333333333333';
+    const command = {
+      id: commandId,
+      type: 'software_install',
+      payload: { deploymentId: 'dep-1', attempt: 1 },
+      deviceId: 'device-123',
+    };
+
+    vi.mocked(db.select).mockReturnValueOnce(selectOwnedCommandResult([command]) as any);
+    vi.mocked(db.update).mockReturnValue(updateResult([{ id: commandId }]) as any);
+
+    await handlers.onMessage({ data: JSON.stringify({
+      type: 'command_result', commandId, status: 'completed', exitCode: 0, stdout: 'installed',
+    }) } as any, ws as any);
+
+    expect(reconcileSoftwareInstallResult).toHaveBeenCalledTimes(1);
+    const [passedCommand, passedDeviceId, passedResult] =
+      vi.mocked(reconcileSoftwareInstallResult).mock.calls[0]!;
+    expect(passedCommand).toMatchObject({ id: commandId, type: 'software_install' });
+    expect(passedDeviceId).toBe('device-123');
+    expect(passedResult).toMatchObject({ status: 'completed' });
+    expect(captureException).not.toHaveBeenCalled();
+    expect(ws.send).toHaveBeenCalledWith(expect.stringContaining('"ack"'));
+  });
+
+  it('a reconcile failure is reported, not rethrown into the socket handler', async () => {
+    // Rethrowing would abort the rest of the result pipeline (the per-type
+    // handler, the ack) for every install whose reconcile hits a transient
+    // fault — one bad row would look like an unresponsive agent.
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123', partnerId: 'partner-123' };
+    const { handlers, ws } = await connectedAgent('agent-123', preValidatedAgent);
+    const commandId = '44444444-4444-4444-8444-444444444444';
+
+    vi.mocked(db.select).mockReturnValueOnce(selectOwnedCommandResult([{
+      id: commandId,
+      type: 'software_install',
+      payload: { deploymentId: 'dep-1' },
+      deviceId: 'device-123',
+    }]) as any);
+    vi.mocked(db.update).mockReturnValue(updateResult([{ id: commandId }]) as any);
+    vi.mocked(reconcileSoftwareInstallResult).mockRejectedValueOnce(new Error('deployment_results write failed'));
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(
+        handlers.onMessage({ data: JSON.stringify({
+          type: 'command_result', commandId, status: 'failed', exitCode: 1,
+        }) } as any, ws as any),
+      ).resolves.toBeUndefined();
+    } finally {
+      errorSpy.mockRestore();
+    }
+
+    expect(captureException).toHaveBeenCalledTimes(1);
     expect(ws.send).toHaveBeenCalledWith(expect.stringContaining('"ack"'));
   });
 

--- a/apps/api/src/routes/agentWs.ts
+++ b/apps/api/src/routes/agentWs.ts
@@ -62,6 +62,7 @@ import { getActiveTrustKeyset } from '../services/manifestSigning';
 import { resolvePendingAgentCommand } from '../services/agentCommandAwait';
 import {
   applySoftwareInstallResult,
+  reconcileSoftwareInstallResult,
   SW_INSTALL_COMMAND_ID_REGEX,
 } from '../services/softwareDeploymentResult';
 import { PG_UUID_REGEX, UUID_REGEX } from '../utils/uuid';
@@ -1974,7 +1975,6 @@ async function processCommandResult(
     // transports is still applied once.
     if (command.type === 'software_install') {
       try {
-        const { reconcileSoftwareInstallResult } = await import('../services/softwareDeployment');
         // Short org wrap (#3021): deployment_results is an RLS-guarded org table.
         await runWithAgentOrgDbAccess('agentWs.commandResult.softwareInstall', orgId, partnerId, () =>
           reconcileSoftwareInstallResult(command, resolvedDeviceId!, normalizedResult)

--- a/apps/api/src/routes/agentWs.ts
+++ b/apps/api/src/routes/agentWs.ts
@@ -1962,6 +1962,29 @@ async function processCommandResult(
       }
     }
 
+    // #5128 — software installs now arrive here. A software_install pushed over
+    // this socket used to carry the synthetic
+    // `sw-install-<deployment>-<device>-<attempt>` id and was reconciled by the
+    // regex branch above; new dispatches persist a device_commands row FIRST and
+    // push with its UUID, so they land on this generic path instead. Without
+    // this the deployment_results row would strand as `pending` forever on the
+    // websocket transport. The regex branch above is kept for frames already in
+    // flight from before the deploy. Reconciliation is idempotent (guarded on
+    // status='pending' + matching attempt), so a result that reaches BOTH
+    // transports is still applied once.
+    if (command.type === 'software_install') {
+      try {
+        const { reconcileSoftwareInstallResult } = await import('../services/softwareDeployment');
+        // Short org wrap (#3021): deployment_results is an RLS-guarded org table.
+        await runWithAgentOrgDbAccess('agentWs.commandResult.softwareInstall', orgId, partnerId, () =>
+          reconcileSoftwareInstallResult(command, resolvedDeviceId!, normalizedResult)
+        );
+      } catch (err) {
+        console.error(`[AgentWs] Failed to reconcile software-install result ${result.commandId}:`, err);
+        captureException(err);
+      }
+    }
+
     // Dispatch to per-command-type handler if one is registered.
     // Short org wrap (#3021): handlers read/write RLS-guarded org tables
     // (script_executions, discovery_jobs, backup/restore jobs, …) through the

--- a/apps/api/src/routes/agents/commands.ts
+++ b/apps/api/src/routes/agents/commands.ts
@@ -38,9 +38,9 @@ import { redactSecretsFromOutput, redactAgentResultErrorFields } from '../../ser
 import { isRawStdoutArtifactCommand } from '../../services/commandAudit';
 import {
   applySoftwareInstallResult,
+  reconcileSoftwareInstallResult,
   SW_INSTALL_COMMAND_ID_REGEX,
 } from '../../services/softwareDeploymentResult';
-import { reconcileSoftwareInstallResult } from '../../services/softwareDeployment';
 
 import {
   ACCEPTED_COMMAND_RESULT_STATUSES,

--- a/apps/api/src/routes/agents/commands.ts
+++ b/apps/api/src/routes/agents/commands.ts
@@ -26,7 +26,7 @@ import { captureException } from '../../services/sentry';
 import { processCollectedAuditPolicyCommandResult } from '../../services/auditBaselineService';
 import { CommandTypes, queueCommandForExecution } from '../../services/commandQueue';
 import { claimPendingCommandsForDevice } from '../../services/commandDispatch';
-import { decryptClaimedCommandsForDelivery } from '../../services/commandDelivery';
+import { prepareClaimedCommandsForDelivery } from '../../services/commandDelivery';
 import { redactResultAgainstCommandSecrets } from '../../services/commandSecretRedaction';
 import { terminalPayloadErasureSet } from '../../services/sensitiveCommandPayload';
 import { applyCommandAutomationTerminal } from '../../services/automationTerminalEvidence';
@@ -40,6 +40,7 @@ import {
   applySoftwareInstallResult,
   SW_INSTALL_COMMAND_ID_REGEX,
 } from '../../services/softwareDeploymentResult';
+import { reconcileSoftwareInstallResult } from '../../services/softwareDeployment';
 
 import {
   ACCEPTED_COMMAND_RESULT_STATUSES,
@@ -207,7 +208,7 @@ commandsRoutes.get('/:id/commands', async (c) => {
   // Both the claim AND the delivery pass run inside the SAME system context.
   // This route is self-managed-context (agentAuth leaves no ambient context
   // behind on the REST paths), and since #3409 PR4c-2 the delivery pass is no
-  // longer pure CPU: `decryptClaimedCommandsForDelivery` first runs the
+  // longer pure CPU: `prepareClaimedCommandsForDelivery` first runs the
   // secret-delivery claim gate, which reads `devices` (RLS-scoped) and drives
   // offending `device_commands` / `script_executions` rows terminal. Called
   // outside the closure those would be contextless bare-pool queries (#1375).
@@ -225,7 +226,7 @@ commandsRoutes.get('/:id/commands', async (c) => {
         // default — so read the context value, never restate the literal.
         agent.claimTypeAllowlist
       );
-      return decryptClaimedCommandsForDelivery(commands);
+      return prepareClaimedCommandsForDelivery(commands);
     })
   );
 
@@ -550,24 +551,8 @@ commandsRoutes.post(
     // replays AND results from a retry-superseded queued command a no-op.
     if (command.type === 'software_install') {
       try {
-        const payload =
-          command.payload && typeof command.payload === 'object' && !Array.isArray(command.payload)
-            ? (command.payload as Record<string, unknown>)
-            : {};
-        if (typeof payload.deploymentId === 'string') {
-          await applySoftwareInstallResult({
-            deploymentId: payload.deploymentId,
-            deviceId,
-            status: normalizedData.status,
-            exitCode: normalizedData.exitCode,
-            stdout: normalizedData.stdout,
-            stderr: normalizedData.stderr,
-            error: normalizedData.error,
-            startedAt: normalizedData.startedAt,
-            durationMs: normalizedData.durationMs,
-            attemptNumber: typeof payload.retryCount === 'number' ? payload.retryCount : 0,
-          });
-        }
+        // #5128: shared with the websocket transport so the two cannot drift.
+        await reconcileSoftwareInstallResult(command, deviceId, normalizedData);
       } catch (err) {
         console.error(`[agents] software install deployment-result reconciliation failed for ${commandId}:`, err);
         captureException(err);

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -51,7 +51,7 @@ import {
   type ManifestTrustKey,
   type ManifestKeyDelegation,
 } from '../../services/manifestSigning';
-import { decryptClaimedCommandsForDelivery } from '../../services/commandDelivery';
+import { prepareClaimedCommandsForDelivery } from '../../services/commandDelivery';
 import { normalizeReportedScriptSecretEnvVersion } from '../../services/scriptSecretDelivery';
 import { redactSecretsDeep } from '../../services/secretRedaction';
 import { recordAgentHeartbeat, resolveResponseStatus } from '../metrics';
@@ -347,7 +347,7 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
           // UNRESTRICTED. Fall back to the shared constant, never to undefined.
           agent.claimTypeAllowlist ?? DRAIN_CLAIM_TYPE_ALLOWLIST,
         );
-        return decryptClaimedCommandsForDelivery(claimed);
+        return prepareClaimedCommandsForDelivery(claimed);
       }),
     );
 
@@ -768,7 +768,7 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
     // the device update at all, so the stored value here is always from an
     // earlier beat.
     return c.json({
-      commands: await decryptClaimedCommandsForDelivery(watchdogCommands, {
+      commands: await prepareClaimedCommandsForDelivery(watchdogCommands, {
         reportedScriptSecretEnvVersion: normalizeReportedScriptSecretEnvVersion(
           data.securityCapabilities?.scriptSecretEnvVersion,
         ),
@@ -1651,7 +1651,7 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
   // the same value but is guarded on the device not being decommissioned/
   // quarantined, so it can be skipped entirely; trusting the stored value
   // could then deliver a sealed secret to an agent that just reported 0.
-  const deliverableCommands = await decryptClaimedCommandsForDelivery(commands, {
+  const deliverableCommands = await prepareClaimedCommandsForDelivery(commands, {
     reportedScriptSecretEnvVersion: normalizeReportedScriptSecretEnvVersion(
       data.securityCapabilities?.scriptSecretEnvVersion,
     ),

--- a/apps/api/src/routes/devices.test.ts
+++ b/apps/api/src/routes/devices.test.ts
@@ -107,9 +107,26 @@ vi.mock('drizzle-orm', () => {
     sql: sqlTag,
     desc: vi.fn((col: unknown) => ({ desc: col })),
     inArray: vi.fn((...args: unknown[]) => ({ inArray: args })),
+    // #5128: the decommission transaction cancels the device's pending
+    // commands EXCEPT self_uninstall, so it needs `ne`.
+    ne: vi.fn((...args: unknown[]) => ({ ne: args })),
+    isNull: vi.fn((...args: unknown[]) => ({ isNull: args })),
+    isNotNull: vi.fn((...args: unknown[]) => ({ isNotNull: args })),
+    gt: vi.fn((...args: unknown[]) => ({ gt: args })),
+    lt: vi.fn((...args: unknown[]) => ({ lt: args })),
+    or: vi.fn((...args: unknown[]) => ({ or: args })),
     count: vi.fn()
   };
 });
+
+// #5128: the generic device-command routes now enqueue through the single
+// seam instead of a raw insert. Mocked here so this harness keeps testing the
+// ROUTE (auth, site scoping, response shape) rather than the seam, which has
+// its own suite in services/dispatchDeviceCommand.test.ts.
+const dispatchDeviceCommandMock = vi.hoisted(() => vi.fn());
+vi.mock('../services/dispatchDeviceCommand', () => ({
+  dispatchDeviceCommand: (...args: unknown[]) => dispatchDeviceCommandMock(...(args as [])),
+}));
 
 // #3986 task 7 follow-up — this harness previously had NO `db.transaction`
 // stub at all (not merely unimplemented: the property didn't exist), so the
@@ -1009,17 +1026,20 @@ describe('device routes', () => {
           })
         })
       } as any);
-      vi.mocked(db.insert).mockReturnValue({
-        values: vi.fn().mockReturnValue({
-          returning: vi.fn().mockResolvedValue([{
-            id: 'cmd-1',
-            deviceId: '11111111-2222-4333-8444-555555555555',
-            type: 'reboot',
-            status: 'pending',
-            createdAt: new Date()
-          }])
-        })
-      } as any);
+      // #5128: the row is created by the enqueue seam, not a raw insert here.
+      const deliverBy = new Date(Date.now() + 24 * 60 * 60 * 1000);
+      dispatchDeviceCommandMock.mockResolvedValue({
+        ok: true,
+        command: {
+          id: 'cmd-1',
+          deviceId: '11111111-2222-4333-8444-555555555555',
+          type: 'reboot',
+          status: 'pending',
+          createdAt: new Date()
+        },
+        delivery: 'delivered',
+        deliverBy,
+      });
 
       const res = await app.request('/devices/11111111-2222-4333-8444-555555555555/commands', {
         method: 'POST',
@@ -1031,6 +1051,44 @@ describe('device routes', () => {
       const body = await res.json();
       expect(body.id).toBe('cmd-1');
       expect(body.status).toBe('pending');
+      // #5128: the response now tells the caller how the command was handed
+      // over and when it expires if the device never comes back.
+      expect(body.delivery).toBe('delivered');
+      expect(body.deliverBy).toBe(deliverBy.toISOString());
+      expect(dispatchDeviceCommandMock).toHaveBeenCalledWith(
+        expect.objectContaining({ deviceId: '11111111-2222-4333-8444-555555555555', type: 'reboot' })
+      );
+    });
+
+    it('reports an offline device as queued rather than failing the request', async () => {
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ id: '11111111-2222-4333-8444-555555555555', orgId: 'org-123', status: 'offline' }])
+          })
+        })
+      } as any);
+      dispatchDeviceCommandMock.mockResolvedValue({
+        ok: true,
+        command: {
+          id: 'cmd-2',
+          deviceId: '11111111-2222-4333-8444-555555555555',
+          type: 'reboot',
+          status: 'pending',
+          createdAt: new Date()
+        },
+        delivery: 'queued_offline',
+        deliverBy: new Date(Date.now() + 24 * 60 * 60 * 1000),
+      });
+
+      const res = await app.request('/devices/11111111-2222-4333-8444-555555555555/commands', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ type: 'reboot' })
+      });
+
+      expect(res.status).toBe(201);
+      expect((await res.json()).delivery).toBe('queued_offline');
     });
 
     it('should reject generic script commands', async () => {

--- a/apps/api/src/routes/devices/commands.test.ts
+++ b/apps/api/src/routes/devices/commands.test.ts
@@ -7,6 +7,22 @@ const { assertDeviceExecuteAllowedMock } = vi.hoisted(() => ({
   assertDeviceExecuteAllowedMock: vi.fn(async () => undefined),
 }));
 
+// #5128 — the bulk route, the single POST /:id/commands route, and
+// POST /:id/auto-update all go through this one seam now instead of a raw
+// `db.insert`. Default: delivered to an online device. Individual tests
+// override with `mockResolvedValueOnce` / `mockImplementationOnce` for
+// offline-queue, decommissioned, trust-denial, and insert-failure cases.
+const { dispatchDeviceCommandMock } = vi.hoisted(() => ({
+  dispatchDeviceCommandMock: vi.fn(
+    async ({ deviceId, type }: { deviceId: string; type: string }) => ({
+      ok: true,
+      command: { id: 'cmd-1', deviceId, type, status: 'pending', createdAt: new Date() },
+      delivery: 'delivered',
+      deliverBy: new Date(Date.now() + 7 * 24 * 3600 * 1000),
+    }),
+  ),
+}));
+
 // RMM-QA-176: ENABLE_2FA is a module constant (routes/auth/schemas.ts:10); the
 // established way to flip it per test is a getter on a partial module mock
 // (precedent: routes/auth/login.test.ts:271-280). T1 asserts it is TRUE by
@@ -127,6 +143,28 @@ vi.mock('../../services/partnerTrust.commands', async () => ({
   assertDeviceExecuteAllowed: assertDeviceExecuteAllowedMock,
  }));
 
+// #5128 — the ONE enqueue seam (services/dispatchDeviceCommand.ts) has its
+// own dedicated test file (dispatchDeviceCommand.test.ts) covering the real
+// reject/queue/deliver logic; this suite only needs to prove the ROUTE's
+// wiring to it, so it's mocked at the seam rather than driven through a raw
+// `db.insert`/`db.select` rig (which would also require unmocking the heavy
+// transitive chain the real implementation pulls in — agentWs, commandQueue,
+// etc.).
+vi.mock('../../services/dispatchDeviceCommand', () => ({
+  dispatchDeviceCommand: dispatchDeviceCommandMock,
+}));
+
+// #5128 — POST /:id/commands/:commandId/cancel calls this to terminalise any
+// higher-level record (execution row, automation action) the cancelled
+// command owned. Its own module pulls in BullMQ Queue/Worker construction and
+// a long transitive chain (commandResultHandlers -> customFields/scriptWriteBack,
+// which calls `requestLikeFromSnapshot` from auditEvents AT MODULE LOAD —
+// something the auditEvents mock above doesn't export), so it must be mocked
+// at the seam rather than loaded for real.
+vi.mock('../../jobs/staleCommandReaper', () => ({
+  propagateCancelledDeviceCommand: vi.fn(),
+}));
+
 vi.mock('../../services/mfaStepUpGrant', async (importOriginal) => {
   // Partial: maintenanceResourceDigest stays REAL so the binding assertion in
   // T4 compares against the production canonicalization, not a stub.
@@ -149,6 +187,7 @@ import { writeRouteAudit } from '../../services/auditEvents';
 import { dispatchWake } from '../../services/wakeOnLan';
 import { TrustDeniedError } from '../../services/partnerTrust.commands';
 import { consumeStepUpGrant, maintenanceResourceDigest, validateStepUpGrant } from '../../services/mfaStepUpGrant';
+import { propagateCancelledDeviceCommand } from '../../jobs/staleCommandReaper';
 
 describe('device commands routes', () => {
   let app: Hono;
@@ -175,6 +214,16 @@ describe('device commands routes', () => {
     // finding — reset both and restore the module-factory default explicitly.
     vi.mocked(validateStepUpGrant).mockReset().mockResolvedValue(true);
     vi.mocked(consumeStepUpGrant).mockReset().mockResolvedValue(true);
+    // Same hazard on the #5128 dispatch seam — restore the delivered-by-default
+    // implementation explicitly rather than relying on clearAllMocks.
+    dispatchDeviceCommandMock.mockReset().mockImplementation(
+      async ({ deviceId, type }: { deviceId: string; type: string }) => ({
+        ok: true,
+        command: { id: 'cmd-1', deviceId, type, status: 'pending', createdAt: new Date() },
+        delivery: 'delivered',
+        deliverBy: new Date(Date.now() + 7 * 24 * 3600 * 1000),
+      }),
+    );
     app = new Hono();
     app.route('/devices', commandsRoutes);
   });
@@ -232,13 +281,6 @@ describe('device commands routes', () => {
       assertDeviceExecuteAllowedMock
         .mockRejectedValueOnce(new TrustDeniedError('TRUST_PROBATION', 'Partner verification is required.', deniedId, 'reboot'))
         .mockResolvedValueOnce(undefined);
-      vi.mocked(db.insert).mockReturnValueOnce({
-        values: vi.fn().mockReturnValue({
-          returning: vi.fn().mockResolvedValue([{
-            id: 'cmd-allowed', deviceId: allowedId, type: 'reboot', status: 'pending', createdAt: new Date(),
-          }]),
-        }),
-      } as never);
 
       const res = await app.request('/devices/bulk/commands', {
         method: 'POST',
@@ -251,7 +293,9 @@ describe('device commands routes', () => {
         commands: [{ deviceId: allowedId }],
         failed: [{ deviceId: deniedId, code: 'TRUST_PROBATION', message: 'Partner verification is required.' }],
       });
-      expect(db.insert).toHaveBeenCalledTimes(1);
+      // #5128: the trust denial short-circuits BEFORE the dispatch seam, so
+      // only the allowed device reaches it.
+      expect(dispatchDeviceCommandMock).toHaveBeenCalledTimes(1);
     });
 
     it('bulk refresh_inventory dedups already-pending devices, skips silently (caught by @xxiaoxiong on #831)', async () => {
@@ -284,19 +328,6 @@ describe('device commands routes', () => {
           })
         } as never);
 
-      // Insert only fires for B.
-      vi.mocked(db.insert).mockReturnValueOnce({
-        values: vi.fn().mockReturnValue({
-          returning: vi.fn().mockResolvedValue([{
-            id: 'cmd-new-b',
-            deviceId: deviceB,
-            type: 'refresh_inventory',
-            status: 'pending',
-            createdAt: new Date()
-          }])
-        })
-      } as never);
-
       const res = await app.request('/devices/bulk/commands', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
@@ -317,8 +348,8 @@ describe('device commands routes', () => {
       expect(body.skipped).toEqual([
         { deviceId: deviceA, code: 'ALREADY_PENDING', commandId: 'cmd-existing-a' },
       ]);
-      // Insert was called exactly once (for B), not twice.
-      expect(vi.mocked(db.insert)).toHaveBeenCalledTimes(1);
+      // #5128: the dispatch seam was only reached once (for B), not twice.
+      expect(dispatchDeviceCommandMock).toHaveBeenCalledTimes(1);
     });
 
     it('rejects generic script command requests before device lookup', async () => {
@@ -397,19 +428,6 @@ describe('device commands routes', () => {
           status: 'online',
         } as never);
 
-      // Insert only fires for the allowed device.
-      vi.mocked(db.insert).mockReturnValueOnce({
-        values: vi.fn().mockReturnValue({
-          returning: vi.fn().mockResolvedValue([{
-            id: 'cmd-allowed',
-            deviceId: allowedId,
-            type: 'reboot',
-            status: 'pending',
-            createdAt: new Date(),
-          }]),
-        }),
-      } as never);
-
       const res = await app.request('/devices/bulk/commands', {
         method: 'POST',
         headers: {
@@ -436,16 +454,16 @@ describe('device commands routes', () => {
           message: 'Access to this site denied.',
         },
       ]);
-      // Exactly one insert — the denial short-circuited before insert for the
-      // second device, but did NOT abort the batch.
-      expect(db.insert).toHaveBeenCalledTimes(1);
+      // #5128: exactly one dispatch — the denial short-circuited before the
+      // seam for the second device, but did NOT abort the batch.
+      expect(dispatchDeviceCommandMock).toHaveBeenCalledTimes(1);
     });
 
     it('mixed batch with denied FIRST: subsequent allowed device still gets queued (defends against early-abort refactor)', async () => {
       // Reverse-order companion to the test above. A future refactor that
       // does `if (anyDenied) return early` would pass the [allowed, denied]
       // case but fail this one — the allowed device is processed AFTER the
-      // denial, so it would never reach the insert.
+      // denial, so it would never reach the dispatch seam.
       const deniedId = '11111111-1111-1111-1111-111111111111';
       const allowedId = '22222222-2222-2222-2222-222222222222';
 
@@ -464,18 +482,6 @@ describe('device commands routes', () => {
           siteId: 'site-allowed',
           status: 'online',
         } as never);
-
-      vi.mocked(db.insert).mockReturnValueOnce({
-        values: vi.fn().mockReturnValue({
-          returning: vi.fn().mockResolvedValue([{
-            id: 'cmd-allowed',
-            deviceId: allowedId,
-            type: 'reboot',
-            status: 'pending',
-            createdAt: new Date(),
-          }]),
-        }),
-      } as never);
 
       const res = await app.request('/devices/bulk/commands', {
         method: 'POST',
@@ -497,11 +503,11 @@ describe('device commands routes', () => {
       expect(body.failed).toEqual([
         { deviceId: deniedId, code: 'SITE_ACCESS_DENIED', message: 'Access to this site denied.' },
       ]);
-      expect(db.insert).toHaveBeenCalledTimes(1);
+      expect(dispatchDeviceCommandMock).toHaveBeenCalledTimes(1);
     });
 
-    it('records INSERT_FAILED per-device when the insert throws and the batch continues', async () => {
-      // Defends against a refactor that drops the try/catch around insert
+    it('records INSERT_FAILED per-device when the dispatch seam throws and the batch continues', async () => {
+      // Defends against a refactor that drops the try/catch around dispatch
       // and lets one device's DB error 500 the whole batch (losing every
       // prior success).
       const failingId = '11111111-1111-1111-1111-111111111111';
@@ -511,25 +517,11 @@ describe('device commands routes', () => {
         .mockResolvedValueOnce({ id: failingId, orgId: 'org-123', hostname: 'host-fail', status: 'online' } as never)
         .mockResolvedValueOnce({ id: succeedingId, orgId: 'org-123', hostname: 'host-ok', status: 'online' } as never);
 
-      // First insert throws (constraint violation, pool exhaustion, etc.),
-      // second succeeds.
-      vi.mocked(db.insert)
-        .mockReturnValueOnce({
-          values: vi.fn().mockReturnValue({
-            returning: vi.fn().mockRejectedValue(new Error('duplicate key value violates unique constraint')),
-          }),
-        } as never)
-        .mockReturnValueOnce({
-          values: vi.fn().mockReturnValue({
-            returning: vi.fn().mockResolvedValue([{
-              id: 'cmd-ok',
-              deviceId: succeedingId,
-              type: 'reboot',
-              status: 'pending',
-              createdAt: new Date(),
-            }]),
-          }),
-        } as never);
+      // First dispatch throws (constraint violation, pool exhaustion, etc.),
+      // second succeeds via the default mock implementation.
+      dispatchDeviceCommandMock.mockRejectedValueOnce(
+        new Error('duplicate key value violates unique constraint'),
+      );
 
       const res = await app.request('/devices/bulk/commands', {
         method: 'POST',
@@ -553,6 +545,43 @@ describe('device commands routes', () => {
           message: 'duplicate key value violates unique constraint',
         },
       ]);
+    });
+
+    it('bulk: an offline device is reported under queuedOffline, not failed', async () => {
+      const onlineId = '11111111-1111-1111-1111-111111111111';
+      const offlineId = '22222222-2222-2222-2222-222222222222';
+
+      vi.mocked(getDeviceWithOrgCheck)
+        .mockResolvedValueOnce({ id: onlineId, orgId: 'org-123', hostname: 'host-online', status: 'online' } as never)
+        .mockResolvedValueOnce({ id: offlineId, orgId: 'org-123', hostname: 'host-offline', status: 'offline' } as never);
+
+      dispatchDeviceCommandMock.mockImplementationOnce(
+        async ({ deviceId, type }: { deviceId: string; type: string }) => ({
+          ok: true,
+          command: { id: 'cmd-online', deviceId, type, status: 'pending', createdAt: new Date() },
+          delivery: 'delivered',
+          deliverBy: new Date(Date.now() + 7 * 24 * 3600 * 1000),
+        }),
+      ).mockImplementationOnce(
+        async ({ deviceId, type }: { deviceId: string; type: string }) => ({
+          ok: true,
+          command: { id: 'cmd-offline', deviceId, type, status: 'pending', createdAt: new Date() },
+          delivery: 'queued_offline',
+          deliverBy: new Date(Date.now() + 7 * 24 * 3600 * 1000),
+        }),
+      );
+
+      const res = await app.request('/devices/bulk/commands', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ deviceIds: [onlineId, offlineId], type: 'reboot' }),
+      });
+
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body.commands).toHaveLength(2);
+      expect(body.failed).toEqual([]);
+      expect(body.queuedOffline).toEqual([offlineId]);
     });
 
     describe('bulk-wake (type=wake)', () => {
@@ -789,17 +818,18 @@ describe('device commands routes', () => {
         status: 'online'
       } as never);
 
-      vi.mocked(db.insert).mockReturnValueOnce({
-        values: vi.fn().mockReturnValue({
-          returning: vi.fn().mockResolvedValue([{
-            id: 'cmd-raw',
-            deviceId: 'device-a',
-            type: 'collect_evidence',
-            status: 'pending',
-            createdAt: new Date()
-          }])
-        })
-      } as never);
+      dispatchDeviceCommandMock.mockResolvedValueOnce({
+        ok: true,
+        command: {
+          id: 'cmd-raw',
+          deviceId: 'device-a',
+          type: 'collect_evidence',
+          status: 'pending',
+          createdAt: new Date(),
+        },
+        delivery: 'delivered',
+        deliverBy: new Date(Date.now() + 7 * 24 * 3600 * 1000),
+      });
 
       const res = await app.request('/devices/device-a/commands', {
         method: 'POST',
@@ -1672,6 +1702,140 @@ describe('device commands routes', () => {
       expect(db.select).not.toHaveBeenCalled();
     });
 
+    // #5128 — the device page's "Queued actions" section reads
+    // ?status=pending; anything not in the known set is a 400 rather than a
+    // silently empty list.
+    it('list: ?status=pending filters, and an unknown status is a 400', async () => {
+      vi.mocked(getDeviceWithOrgCheck).mockResolvedValueOnce({
+        id: 'device-a',
+        orgId: 'org-123',
+        hostname: 'host-a',
+        status: 'online',
+      } as never);
+
+      vi.mocked(db.select)
+        // count query
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ count: 1 }]),
+          }),
+        } as never)
+        // page query
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              orderBy: vi.fn().mockReturnValue({
+                limit: vi.fn().mockReturnValue({
+                  offset: vi.fn().mockResolvedValue([{
+                    id: 'cmd-pending',
+                    deviceId: 'device-a',
+                    type: 'reboot',
+                    status: 'pending',
+                    payload: {},
+                    result: null,
+                  }]),
+                }),
+              }),
+            }),
+          }),
+        } as never);
+
+      const res = await app.request('/devices/device-a/commands?status=pending', {
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data).toHaveLength(1);
+      expect(body.data[0].status).toBe('pending');
+
+      // An unrecognized status value is a 400 — validated BEFORE the device
+      // lookup, so no getDeviceWithOrgCheck mock is needed for this call.
+      const badRes = await app.request('/devices/device-a/commands?status=bogus', {
+        headers: { Authorization: 'Bearer token' },
+      });
+      expect(badRes.status).toBe(400);
+    });
+  });
+
+  describe('POST /devices/:id/commands/:commandId/cancel', () => {
+    const DEVICE_ID = 'device-a';
+    const COMMAND_ID = 'cmd-pending-1';
+
+    const mockExistingCommand = (existing: Record<string, unknown> | undefined) => {
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue(existing ? [existing] : []),
+          }),
+        }),
+      } as never);
+    };
+
+    const mockCancelUpdate = (row: { id: string } | undefined) => {
+      vi.mocked(db.update).mockReturnValueOnce({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue(row ? [row] : []),
+          }),
+        }),
+      } as never);
+    };
+
+    beforeEach(() => {
+      vi.mocked(getDeviceWithOrgCheck).mockResolvedValueOnce({
+        id: DEVICE_ID,
+        orgId: 'org-123',
+        hostname: 'host-a',
+        status: 'online',
+      } as never);
+    });
+
+    it('cancel: flips a pending command to cancelled', async () => {
+      mockExistingCommand({ id: COMMAND_ID, type: 'reboot', payload: {}, status: 'pending' });
+      mockCancelUpdate({ id: COMMAND_ID });
+
+      const res = await app.request(`/devices/${DEVICE_ID}/commands/${COMMAND_ID}/cancel`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ id: COMMAND_ID, status: 'cancelled' });
+      expect(propagateCancelledDeviceCommand).toHaveBeenCalledWith(
+        expect.objectContaining({ commandId: COMMAND_ID, type: 'reboot' }),
+      );
+    });
+
+    it('cancel: 409s when the command is not pending', async () => {
+      mockExistingCommand({ id: COMMAND_ID, type: 'reboot', payload: {}, status: 'sent' });
+
+      const res = await app.request(`/devices/${DEVICE_ID}/commands/${COMMAND_ID}/cancel`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(409);
+      const body = await res.json();
+      expect(body.status).toBe('sent');
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it('cancel: 404s for a command belonging to another device', async () => {
+      // The lookup scopes the SELECT to (commandId AND deviceId), so a
+      // command that belongs to a different device simply isn't found.
+      mockExistingCommand(undefined);
+
+      const res = await app.request(`/devices/${DEVICE_ID}/commands/${COMMAND_ID}/cancel`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(404);
+      expect(db.update).not.toHaveBeenCalled();
+    });
+  });
+
   describe('POST /devices/:id/auto-update', () => {
     it('returns a trust denial without inserting an auto-update command', async () => {
       vi.mocked(getDeviceWithOrgCheck).mockResolvedValueOnce({
@@ -1700,22 +1864,22 @@ describe('device commands routes', () => {
         status: 'online'
       } as never);
 
-      vi.mocked(db.insert).mockReturnValueOnce({
-        values: vi.fn().mockReturnValue({
-          returning: vi.fn().mockResolvedValue([{
-            id: 'cmd-456',
-            deviceId: 'device-a',
-            type: 'set_auto_update',
-            status: 'pending',
-            payload: { enabled: true },
-            createdAt: new Date()
-          }])
-        })
-      } as never);
+      dispatchDeviceCommandMock.mockResolvedValueOnce({
+        ok: true,
+        command: {
+          id: 'cmd-456',
+          deviceId: 'device-a',
+          type: 'set_auto_update',
+          status: 'pending',
+          createdAt: new Date(),
+        },
+        delivery: 'delivered',
+        deliverBy: new Date(Date.now() + 7 * 24 * 3600 * 1000),
+      });
 
       const res = await app.request('/devices/device-a/auto-update', {
         method: 'POST',
-        headers: { 
+        headers: {
           Authorization: 'Bearer token',
           'Content-Type': 'application/json'
         },
@@ -1729,7 +1893,7 @@ describe('device commands routes', () => {
       expect(body.type).toBe('set_auto_update');
       expect(body.status).toBe('pending');
       expect(body.createdAt).toBeDefined();  // Date handling in response
-      expect(db.insert).toHaveBeenCalled();
+      expect(dispatchDeviceCommandMock).toHaveBeenCalled();
     });
 
     it('rejects command for decommissioned device', async () => {
@@ -1775,7 +1939,5 @@ describe('device commands routes', () => {
       expect(res.status).toBe(403);
       expect(db.insert).not.toHaveBeenCalled();
     });
-  });
-
   });
 });

--- a/apps/api/src/routes/devices/commands.test.ts
+++ b/apps/api/src/routes/devices/commands.test.ts
@@ -156,12 +156,10 @@ vi.mock('../../services/dispatchDeviceCommand', () => ({
 
 // #5128 — POST /:id/commands/:commandId/cancel calls this to terminalise any
 // higher-level record (execution row, automation action) the cancelled
-// command owned. Its own module pulls in BullMQ Queue/Worker construction and
-// a long transitive chain (commandResultHandlers -> customFields/scriptWriteBack,
-// which calls `requestLikeFromSnapshot` from auditEvents AT MODULE LOAD —
-// something the auditEvents mock above doesn't export), so it must be mocked
-// at the seam rather than loaded for real.
-vi.mock('../../jobs/staleCommandReaper', () => ({
+// command owned. Mocked at the seam so the route's wiring (including which
+// executor it hands the propagator) is assertable without the real
+// script_executions / deployment_results writes.
+vi.mock('../../services/commandCancelPropagation', () => ({
   propagateCancelledDeviceCommand: vi.fn(),
 }));
 
@@ -187,7 +185,7 @@ import { writeRouteAudit } from '../../services/auditEvents';
 import { dispatchWake } from '../../services/wakeOnLan';
 import { TrustDeniedError } from '../../services/partnerTrust.commands';
 import { consumeStepUpGrant, maintenanceResourceDigest, validateStepUpGrant } from '../../services/mfaStepUpGrant';
-import { propagateCancelledDeviceCommand } from '../../jobs/staleCommandReaper';
+import { propagateCancelledDeviceCommand } from '../../services/commandCancelPropagation';
 
 describe('device commands routes', () => {
   let app: Hono;
@@ -1762,24 +1760,34 @@ describe('device commands routes', () => {
     const DEVICE_ID = 'device-a';
     const COMMAND_ID = 'cmd-pending-1';
 
-    const mockExistingCommand = (existing: Record<string, unknown> | undefined) => {
-      vi.mocked(db.select).mockReturnValueOnce({
+    // #5128 review round 2 — the read, the CAS and the propagation now run in
+    // ONE `db.transaction`, so the rig drives `tx.select` / `tx.update` rather
+    // than the ambient db. `txSelect`/`txUpdate` are exposed so the CAS-lost
+    // branch can assert the propagator was never reached.
+    let txSelect = vi.fn();
+    let txUpdate = vi.fn();
+    let txHandle: unknown = null;
+
+    const rigCancelTransaction = (opts: {
+      existing?: Record<string, unknown> | undefined;
+      updated?: { id: string } | undefined;
+    }) => {
+      txSelect = vi.fn().mockReturnValue({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
-            limit: vi.fn().mockResolvedValue(existing ? [existing] : []),
+            limit: vi.fn().mockResolvedValue(opts.existing ? [opts.existing] : []),
           }),
         }),
-      } as never);
-    };
-
-    const mockCancelUpdate = (row: { id: string } | undefined) => {
-      vi.mocked(db.update).mockReturnValueOnce({
+      });
+      txUpdate = vi.fn().mockReturnValue({
         set: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
-            returning: vi.fn().mockResolvedValue(row ? [row] : []),
+            returning: vi.fn().mockResolvedValue(opts.updated ? [opts.updated] : []),
           }),
         }),
-      } as never);
+      });
+      txHandle = { select: txSelect, update: txUpdate };
+      vi.mocked(db.transaction).mockImplementation(async (cb: any) => cb(txHandle));
     };
 
     beforeEach(() => {
@@ -1791,9 +1799,11 @@ describe('device commands routes', () => {
       } as never);
     });
 
-    it('cancel: flips a pending command to cancelled', async () => {
-      mockExistingCommand({ id: COMMAND_ID, type: 'reboot', payload: {}, status: 'pending' });
-      mockCancelUpdate({ id: COMMAND_ID });
+    it('cancel: flips a pending command to cancelled, propagating on the SAME transaction', async () => {
+      rigCancelTransaction({
+        existing: { id: COMMAND_ID, type: 'reboot', payload: {}, status: 'pending' },
+        updated: { id: COMMAND_ID },
+      });
 
       const res = await app.request(`/devices/${DEVICE_ID}/commands/${COMMAND_ID}/cancel`, {
         method: 'POST',
@@ -1802,13 +1812,16 @@ describe('device commands routes', () => {
 
       expect(res.status).toBe(200);
       expect(await res.json()).toEqual({ id: COMMAND_ID, status: 'cancelled' });
+      // A crash between the flip and the propagation would otherwise leave a
+      // cancelled command owning a still-`pending` script_executions /
+      // deployment_results row that nothing ever revisits.
       expect(propagateCancelledDeviceCommand).toHaveBeenCalledWith(
-        expect.objectContaining({ commandId: COMMAND_ID, type: 'reboot' }),
+        expect.objectContaining({ commandId: COMMAND_ID, type: 'reboot', executor: txHandle }),
       );
     });
 
     it('cancel: 409s when the command is not pending', async () => {
-      mockExistingCommand({ id: COMMAND_ID, type: 'reboot', payload: {}, status: 'sent' });
+      rigCancelTransaction({ existing: { id: COMMAND_ID, type: 'reboot', payload: {}, status: 'sent' } });
 
       const res = await app.request(`/devices/${DEVICE_ID}/commands/${COMMAND_ID}/cancel`, {
         method: 'POST',
@@ -1818,13 +1831,35 @@ describe('device commands routes', () => {
       expect(res.status).toBe(409);
       const body = await res.json();
       expect(body.status).toBe('sent');
-      expect(db.update).not.toHaveBeenCalled();
+      expect(txUpdate).not.toHaveBeenCalled();
+      expect(propagateCancelledDeviceCommand).not.toHaveBeenCalled();
+    });
+
+    it('cancel: 409s and does NOT propagate when the CAS loses the race', async () => {
+      // The SELECT saw `pending`, but the agent claimed the row before the
+      // UPDATE landed. That command is now being DELIVERED — terminalising its
+      // owning script execution would cancel work about to run on the machine.
+      rigCancelTransaction({
+        existing: { id: COMMAND_ID, type: 'script', payload: { executionId: 'exec-1' }, status: 'pending' },
+        updated: undefined,
+      });
+
+      const res = await app.request(`/devices/${DEVICE_ID}/commands/${COMMAND_ID}/cancel`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(409);
+      expect(await res.json()).toEqual({ error: 'Command is not pending' });
+      expect(txUpdate).toHaveBeenCalledTimes(1);
+      expect(propagateCancelledDeviceCommand).not.toHaveBeenCalled();
+      expect(writeRouteAudit).not.toHaveBeenCalled();
     });
 
     it('cancel: 404s for a command belonging to another device', async () => {
       // The lookup scopes the SELECT to (commandId AND deviceId), so a
       // command that belongs to a different device simply isn't found.
-      mockExistingCommand(undefined);
+      rigCancelTransaction({ existing: undefined });
 
       const res = await app.request(`/devices/${DEVICE_ID}/commands/${COMMAND_ID}/cancel`, {
         method: 'POST',
@@ -1832,7 +1867,8 @@ describe('device commands routes', () => {
       });
 
       expect(res.status).toBe(404);
-      expect(db.update).not.toHaveBeenCalled();
+      expect(txUpdate).not.toHaveBeenCalled();
+      expect(propagateCancelledDeviceCommand).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/routes/devices/commands.ts
+++ b/apps/api/src/routes/devices/commands.ts
@@ -23,6 +23,10 @@ import { ENABLE_2FA } from '../auth/schemas';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { commandAuditDetails, sanitizeCommandForHistory } from '../../services/commandAudit';
 import { dispatchWake, type WakeFailureCode } from '../../services/wakeOnLan';
+import { dispatchDeviceCommand } from '../../services/dispatchDeviceCommand';
+import type { QueuedCommand } from '../../services/commandQueue';
+import { terminalPayloadErasureSet } from '../../services/sensitiveCommandPayload';
+import { propagateCancelledDeviceCommand } from '../../jobs/staleCommandReaper';
 import { getTrustedClientIpOrUndefined } from '../../services/clientIp';
 import { assertDeviceExecuteAllowed, TrustDeniedError } from '../../services/partnerTrust.commands';
 import { trustDenyBody, type TrustDenyCode } from '../../services/partnerTrust';
@@ -32,6 +36,10 @@ export const commandsRoutes = new Hono();
 commandsRoutes.use('*', authMiddleware);
 
 const COMMAND_SET_AUTO_UPDATE = 'set_auto_update';
+
+/** #5128 — the `?status=` values `GET /:id/commands` accepts. */
+const LISTABLE_COMMAND_STATUSES = ['pending', 'sent', 'completed', 'failed', 'cancelled'] as const;
+type ListableCommandStatus = (typeof LISTABLE_COMMAND_STATUSES)[number];
 const COMMAND_WAKE_ON_LAN = 'wake_on_lan';
 
 // POST /devices/bulk/commands - Queue a command for multiple devices
@@ -161,6 +169,10 @@ commandsRoutes.post(
     // Surfaced separately from `failed` so the caller can say "N queued,
     // M already pending" without misreporting deduped devices as failures.
     const skipped: Array<{ deviceId: string; code: 'ALREADY_PENDING'; commandId: string }> = [];
+    // #5128: devices that were not online, whose command is now waiting for
+    // them to reconnect. Reported separately from `failed` — the work was
+    // accepted, it just has not been delivered yet.
+    const queuedOffline: string[] = [];
 
     for (const deviceId of deviceIds) {
       const device = await getDeviceWithOrgCheck(deviceId, auth);
@@ -211,36 +223,37 @@ commandsRoutes.post(
         }
       }
 
-      // Wrap the insert so a constraint violation, pool exhaustion, or
-      // other postgres error on one device records as INSERT_FAILED for
-      // that device instead of throwing out of the whole loop and
-      // 500-ing the entire batch (losing every prior success).
-      let command: typeof deviceCommands.$inferSelect | undefined;
+      // #5128: through the one enqueue seam rather than a raw insert, so the
+      // row carries a delivery deadline and its submitting org, and an online
+      // device gets the socket push instead of waiting for the next heartbeat.
+      // Still wrapped: a constraint violation or pool exhaustion on one device
+      // records as INSERT_FAILED for that device rather than 500-ing the whole
+      // batch and losing every prior success.
+      let command: QueuedCommand | undefined;
+      let delivery: 'delivered' | 'queued_offline' | 'queued_live' | undefined;
       try {
-        [command] = await db
-          .insert(deviceCommands)
-          .values({
-            deviceId,
-            type: data.type,
-            payload: data.payload || {},
-            status: 'pending',
-            createdBy: auth.user.id
-          })
-          .returning();
+        // `wake` never reaches here — it returns from its own relay path above.
+        const res = await dispatchDeviceCommand({ deviceId, type: data.type, payload: data.payload || {}, userId: auth.user.id });
+        if (!res.ok) {
+          if (res.code === 'trust_denied' && res.trust) {
+            failed.push({ deviceId, code: res.error as TrustDenyCode, message: res.trust.reason });
+          } else {
+            failed.push({
+              deviceId,
+              code: res.code === 'device_decommissioned' ? 'DECOMMISSIONED' : 'INSERT_FAILED',
+              message: res.error,
+            });
+          }
+          continue;
+        }
+        command = res.command;
+        delivery = res.delivery;
       } catch (err) {
         failed.push({
           deviceId,
           code: 'INSERT_FAILED',
           message: err instanceof Error ? err.message : 'Failed to queue command.',
         });
-        continue;
-      }
-
-      if (!command) {
-        // `returning()` on a successful insert always yields ≥1 row, so
-        // this branch is defensive against a future driver change rather
-        // than a path that fires in practice.
-        failed.push({ deviceId, code: 'INSERT_FAILED', message: 'Failed to queue command.' });
         continue;
       }
 
@@ -251,6 +264,7 @@ commandsRoutes.post(
         status: command.status,
         createdAt: command.createdAt
       });
+      if (delivery === 'queued_offline') queuedOffline.push(deviceId);
 
       writeRouteAudit(c, {
         orgId: device.orgId,
@@ -266,7 +280,7 @@ commandsRoutes.post(
       });
     }
 
-    return c.json({ commands: commandList, failed, skipped }, 201);
+    return c.json({ commands: commandList, failed, skipped, queuedOffline }, 201);
   }
 );
 
@@ -541,20 +555,33 @@ commandsRoutes.post(
       }, 202);
     }
 
-    const [command] = await db
-      .insert(deviceCommands)
-      .values({
-        deviceId,
-        type: data.type,
-        payload: data.payload || {},
-        status: 'pending',
-        createdBy: auth.user.id
-      })
-      .returning();
-
-    if (!command) {
-      return c.json({ error: 'Failed to queue command' }, 500);
+    // #5128: through the one enqueue seam. The row now carries a delivery
+    // deadline and its submitting org, and an online device gets the socket
+    // push here instead of waiting for its next heartbeat.
+    const res = await dispatchDeviceCommand({
+      deviceId,
+      type: data.type,
+      payload: data.payload || {},
+      userId: auth.user.id,
+    });
+    if (!res.ok) {
+      if (res.code === 'device_decommissioned') {
+        return c.json({ error: 'Cannot send commands to a decommissioned device' }, 400);
+      }
+      if (res.code === 'device_not_found') {
+        return c.json({ error: 'Device not found' }, 404);
+      }
+      if (res.code === 'trust_denied' && res.trust) {
+        return c.json(trustDenyBody({
+          allow: false,
+          code: res.error as TrustDenyCode,
+          capability: 'device_execute',
+          reason: res.trust.reason,
+        }, false), 403);
+      }
+      return c.json({ error: res.error }, 500);
     }
+    const command = res.command;
 
     writeRouteAudit(c, {
       orgId: device.orgId,
@@ -564,7 +591,8 @@ commandsRoutes.post(
       resourceName: data.type,
       details: {
         deviceId,
-        ...commandAuditDetails(command.id, data.type, data.payload || {})
+        ...commandAuditDetails(command.id, data.type, data.payload || {}),
+        delivery: res.delivery,
       }
     });
 
@@ -573,7 +601,12 @@ commandsRoutes.post(
       deviceId: command.deviceId,
       type: command.type,
       status: command.status,
-      createdAt: command.createdAt
+      createdAt: command.createdAt,
+      // #5128: how the command was handed over, and when it expires if the
+      // device never comes back. 'queued_offline' is what the UI renders as
+      // "Runs when the device is online — expires <date>".
+      delivery: res.delivery,
+      deliverBy: res.deliverBy,
     }, 201);
   }
 );
@@ -816,20 +849,31 @@ commandsRoutes.post(
       }, false), 403);
     }
 
-    const [command] = await db
-      .insert(deviceCommands)
-      .values({
-        deviceId,
-        type: COMMAND_SET_AUTO_UPDATE,
-        payload: { enabled: data.enabled },
-        status: 'pending',
-        createdBy: auth.user.id
-      })
-      .returning();
-
-    if (!command) {
-      return c.json({ error: 'Failed to queue command' }, 500);
+    // #5128: through the one enqueue seam (see the single-command route).
+    const res = await dispatchDeviceCommand({
+      deviceId,
+      type: COMMAND_SET_AUTO_UPDATE,
+      payload: { enabled: data.enabled },
+      userId: auth.user.id,
+    });
+    if (!res.ok) {
+      if (res.code === 'device_decommissioned') {
+        return c.json({ error: 'Cannot send commands to a decommissioned device' }, 400);
+      }
+      if (res.code === 'device_not_found') {
+        return c.json({ error: 'Device not found' }, 404);
+      }
+      if (res.code === 'trust_denied' && res.trust) {
+        return c.json(trustDenyBody({
+          allow: false,
+          code: res.error as TrustDenyCode,
+          capability: 'device_execute',
+          reason: res.trust.reason,
+        }, false), 403);
+      }
+      return c.json({ error: res.error }, 500);
     }
+    const command = res.command;
 
     writeRouteAudit(c, {
       orgId: device.orgId,
@@ -849,7 +893,9 @@ commandsRoutes.post(
       deviceId: command.deviceId,
       type: command.type,
       status: command.status,
-      createdAt: command.createdAt
+      createdAt: command.createdAt,
+      delivery: res.delivery,
+      deliverBy: res.deliverBy,
     }, 201);
   }
 );
@@ -862,8 +908,18 @@ commandsRoutes.get(
   async (c) => {
     const auth = c.get('auth');
     const deviceId = c.req.param('id')!;
-    const { page = '1', limit = '50' } = c.req.query();
+    const { page = '1', limit = '50', status } = c.req.query();
     const pagination = getPagination({ page, limit });
+
+    // #5128: `?status=pending` is what the device page's "Queued actions"
+    // section reads. Validated against the known set so an unrecognised value
+    // is a 400 rather than a silently empty list.
+    if (status !== undefined && !LISTABLE_COMMAND_STATUSES.includes(status as ListableCommandStatus)) {
+      return c.json(
+        { error: `Invalid status filter. Expected one of: ${LISTABLE_COMMAND_STATUSES.join(', ')}` },
+        400,
+      );
+    }
 
     const device = await getDeviceWithOrgCheck(deviceId, auth);
     if (!device) {
@@ -873,16 +929,20 @@ commandsRoutes.get(
       return c.json({ error: 'Access to this site denied' }, 403);
     }
 
+    const listFilter = status
+      ? and(eq(deviceCommands.deviceId, deviceId), eq(deviceCommands.status, status))
+      : eq(deviceCommands.deviceId, deviceId);
+
     const countResult = await db
       .select({ count: sql<number>`count(*)` })
       .from(deviceCommands)
-      .where(eq(deviceCommands.deviceId, deviceId));
+      .where(listFilter);
     const total = Number(countResult[0]?.count ?? 0);
 
     const commands = await db
       .select()
       .from(deviceCommands)
-      .where(eq(deviceCommands.deviceId, deviceId))
+      .where(listFilter)
       .orderBy(desc(deviceCommands.createdAt), desc(deviceCommands.id))
       .limit(pagination.limit)
       .offset(pagination.offset);
@@ -934,5 +994,92 @@ commandsRoutes.get(
     // allowRawStdout only takes effect for artifact-bearing command types
     // (capture_pprof profiles); everything else stays redacted (#2401).
     return c.json({ data: sanitizeCommandForHistory(command, { allowRawStdout: true }) });
+  }
+);
+
+// POST /devices/:id/commands/:commandId/cancel — user cancel of a queued command (#5128 §G).
+//
+// Same permission as issuing one: cancelling is not a read. CAS on
+// status='pending' so a command the agent claimed a millisecond ago is a 409,
+// never a silent "cancelled" for work that is already running on the machine.
+commandsRoutes.post(
+  '/:id/commands/:commandId/cancel',
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.DEVICES_EXECUTE.resource, PERMISSIONS.DEVICES_EXECUTE.action),
+  async (c) => {
+    const auth = c.get('auth');
+    const deviceId = c.req.param('id')!;
+    const commandId = c.req.param('commandId')!;
+
+    const device = await getDeviceWithOrgCheck(deviceId, auth);
+    if (!device) {
+      return c.json({ error: 'Device not found' }, 404);
+    }
+    if (!canAccessDeviceSite(device, c.get('permissions') as UserPermissions | undefined)) {
+      return c.json({ error: 'Access to this site denied' }, 403);
+    }
+
+    // Read the payload BEFORE the update: `terminalPayloadErasureSet()` strips
+    // it, and `returning()` reflects post-update values, so a propagator that
+    // keys on `payload.executionId` would get nothing back from the UPDATE.
+    const [existing] = await db
+      .select({
+        id: deviceCommands.id,
+        type: deviceCommands.type,
+        payload: deviceCommands.payload,
+        status: deviceCommands.status,
+      })
+      .from(deviceCommands)
+      .where(and(eq(deviceCommands.id, commandId), eq(deviceCommands.deviceId, deviceId)))
+      .limit(1);
+
+    if (!existing) {
+      return c.json({ error: 'Command not found' }, 404);
+    }
+    if (existing.status !== 'pending') {
+      return c.json({ error: 'Command is not pending', status: existing.status }, 409);
+    }
+
+    const completedAt = new Date();
+    const [row] = await db
+      .update(deviceCommands)
+      .set({
+        status: 'cancelled',
+        completedAt,
+        result: { status: 'cancelled', reason: 'user_cancelled', cancelledBy: auth.user.id },
+        ...terminalPayloadErasureSet(),
+      })
+      .where(
+        and(
+          eq(deviceCommands.id, commandId),
+          eq(deviceCommands.deviceId, deviceId),
+          eq(deviceCommands.status, 'pending'),
+        ),
+      )
+      .returning({ id: deviceCommands.id });
+
+    if (!row) {
+      // Lost the CAS race — the agent claimed it between the SELECT and here.
+      return c.json({ error: 'Command is not pending' }, 409);
+    }
+
+    await propagateCancelledDeviceCommand({
+      commandId: row.id,
+      type: existing.type,
+      payload: existing.payload as Record<string, unknown> | null,
+      completedAt,
+      cancelledBy: auth.user.id,
+    });
+
+    writeRouteAudit(c, {
+      orgId: device.orgId,
+      action: 'device.command.cancel',
+      resourceType: 'device_command',
+      resourceId: row.id,
+      resourceName: existing.type,
+      details: { deviceId, commandType: existing.type },
+    });
+
+    return c.json({ id: row.id, status: 'cancelled' });
   }
 );

--- a/apps/api/src/routes/devices/commands.ts
+++ b/apps/api/src/routes/devices/commands.ts
@@ -26,7 +26,7 @@ import { dispatchWake, type WakeFailureCode } from '../../services/wakeOnLan';
 import { dispatchDeviceCommand } from '../../services/dispatchDeviceCommand';
 import type { QueuedCommand } from '../../services/commandQueue';
 import { terminalPayloadErasureSet } from '../../services/sensitiveCommandPayload';
-import { propagateCancelledDeviceCommand } from '../../jobs/staleCommandReaper';
+import { propagateCancelledDeviceCommand } from '../../services/commandCancelPropagation';
 import { getTrustedClientIpOrUndefined } from '../../services/clientIp';
 import { assertDeviceExecuteAllowed, TrustDeniedError } from '../../services/partnerTrust.commands';
 import { trustDenyBody, type TrustDenyCode } from '../../services/partnerTrust';
@@ -1019,67 +1019,83 @@ commandsRoutes.post(
       return c.json({ error: 'Access to this site denied' }, 403);
     }
 
-    // Read the payload BEFORE the update: `terminalPayloadErasureSet()` strips
-    // it, and `returning()` reflects post-update values, so a propagator that
-    // keys on `payload.executionId` would get nothing back from the UPDATE.
-    const [existing] = await db
-      .select({
-        id: deviceCommands.id,
-        type: deviceCommands.type,
-        payload: deviceCommands.payload,
-        status: deviceCommands.status,
-      })
-      .from(deviceCommands)
-      .where(and(eq(deviceCommands.id, commandId), eq(deviceCommands.deviceId, deviceId)))
-      .limit(1);
+    // The read, the CAS and the propagation are ONE transaction. Without it a
+    // crash between the flip and the propagation leaves a cancelled command
+    // owning a `script_executions` / `deployment_results` row that is still
+    // `pending` — and nothing revisits it, because the reaper only scans
+    // pending/sent COMMANDS. The HTTP response is chosen after the commit.
+    const outcome = await db.transaction(async (tx) => {
+      // Read the payload BEFORE the update: `terminalPayloadErasureSet()` strips
+      // it, and `returning()` reflects post-update values, so a propagator that
+      // keys on `payload.executionId` would get nothing back from the UPDATE.
+      const [existing] = await tx
+        .select({
+          id: deviceCommands.id,
+          type: deviceCommands.type,
+          payload: deviceCommands.payload,
+          status: deviceCommands.status,
+        })
+        .from(deviceCommands)
+        .where(and(eq(deviceCommands.id, commandId), eq(deviceCommands.deviceId, deviceId)))
+        .limit(1);
 
-    if (!existing) {
+      if (!existing) return { kind: 'not_found' } as const;
+      if (existing.status !== 'pending') {
+        return { kind: 'not_pending' as const, status: existing.status };
+      }
+
+      const completedAt = new Date();
+      const [row] = await tx
+        .update(deviceCommands)
+        .set({
+          status: 'cancelled',
+          completedAt,
+          result: { status: 'cancelled', reason: 'user_cancelled', cancelledBy: auth.user.id },
+          ...terminalPayloadErasureSet(),
+        })
+        .where(
+          and(
+            eq(deviceCommands.id, commandId),
+            eq(deviceCommands.deviceId, deviceId),
+            eq(deviceCommands.status, 'pending'),
+          ),
+        )
+        .returning({ id: deviceCommands.id });
+
+      // Lost the CAS race — the agent claimed it between the SELECT and here.
+      if (!row) return { kind: 'cas_lost' } as const;
+
+      await propagateCancelledDeviceCommand({
+        commandId: row.id,
+        type: existing.type,
+        payload: existing.payload as Record<string, unknown> | null,
+        completedAt,
+        cancelledBy: auth.user.id,
+        executor: tx,
+      });
+
+      return { kind: 'cancelled' as const, id: row.id, type: existing.type };
+    });
+
+    if (outcome.kind === 'not_found') {
       return c.json({ error: 'Command not found' }, 404);
     }
-    if (existing.status !== 'pending') {
-      return c.json({ error: 'Command is not pending', status: existing.status }, 409);
+    if (outcome.kind === 'not_pending') {
+      return c.json({ error: 'Command is not pending', status: outcome.status }, 409);
     }
-
-    const completedAt = new Date();
-    const [row] = await db
-      .update(deviceCommands)
-      .set({
-        status: 'cancelled',
-        completedAt,
-        result: { status: 'cancelled', reason: 'user_cancelled', cancelledBy: auth.user.id },
-        ...terminalPayloadErasureSet(),
-      })
-      .where(
-        and(
-          eq(deviceCommands.id, commandId),
-          eq(deviceCommands.deviceId, deviceId),
-          eq(deviceCommands.status, 'pending'),
-        ),
-      )
-      .returning({ id: deviceCommands.id });
-
-    if (!row) {
-      // Lost the CAS race — the agent claimed it between the SELECT and here.
+    if (outcome.kind === 'cas_lost') {
       return c.json({ error: 'Command is not pending' }, 409);
     }
-
-    await propagateCancelledDeviceCommand({
-      commandId: row.id,
-      type: existing.type,
-      payload: existing.payload as Record<string, unknown> | null,
-      completedAt,
-      cancelledBy: auth.user.id,
-    });
 
     writeRouteAudit(c, {
       orgId: device.orgId,
       action: 'device.command.cancel',
       resourceType: 'device_command',
-      resourceId: row.id,
-      resourceName: existing.type,
-      details: { deviceId, commandType: existing.type },
+      resourceId: outcome.id,
+      resourceName: outcome.type,
+      details: { deviceId, commandType: outcome.type },
     });
 
-    return c.json({ id: row.id, status: 'cancelled' });
+    return c.json({ id: outcome.id, status: 'cancelled' });
   }
 );

--- a/apps/api/src/routes/devices/core.decommission.test.ts
+++ b/apps/api/src/routes/devices/core.decommission.test.ts
@@ -85,6 +85,14 @@ vi.mock('../../services/commandQueue', () => ({
   queueCommandForExecution: vi.fn(),
 }));
 
+// #5128 — spy on `ne` (pass-through to the real implementation) so the
+// decommission transaction's pending-command cancel write is assertable on
+// its `self_uninstall` exclusion without mocking all of drizzle-orm.
+vi.mock('drizzle-orm', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('drizzle-orm')>();
+  return { ...actual, ne: vi.fn(actual.ne) };
+});
+
 // #3986 task 7 — the route composes `queueDeviceUninstall` into its own
 // decommission transaction; the predicate/insert SQL it builds is already
 // covered on compiled SQL by deviceUninstallDrain.test.ts (task 6). Here we
@@ -120,6 +128,8 @@ import { terminateDeviceRemoteSessions } from '../../services/remoteSessionTeard
 import { disconnectAgent } from '../agentWs';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { queueDeviceUninstall, releaseDeviceRemoveReason } from '../../services/deviceUninstallDrain';
+import { ne } from 'drizzle-orm';
+import { deviceCommands } from '../../db/schema';
 
 const DEVICE_ID = '11111111-1111-4111-8111-111111111111';
 
@@ -294,13 +304,32 @@ describe('DELETE /devices/:id (decommission) — remote-session teardown wiring'
       });
 
       expect(res.status).toBe(200);
-      // Two writes: the status flip, then the linkage clear.
-      expect(set).toHaveBeenCalledTimes(2);
+      // Three writes: the status flip, the #5128 pending-command cancel
+      // (same transaction), then the linkage clear.
+      expect(set).toHaveBeenCalledTimes(3);
       expect(set).toHaveBeenNthCalledWith(1, expect.objectContaining({ status: 'decommissioned' }));
+      expect(set).toHaveBeenNthCalledWith(2, expect.objectContaining({ status: 'cancelled' }));
       expect(set).toHaveBeenNthCalledWith(
-        2,
+        3,
         expect.objectContaining({ possibleReplacementOfDeviceId: null })
       );
+    });
+
+    // #5128 — the uninstall drain's whole purpose is to survive decommission
+    // and deliver on the device's next check-in; a `self_uninstall` row must
+    // never be swept up by the generic pending-command cancel this route now
+    // runs in the same transaction as the status write.
+    it('cancels pending commands but excludes self_uninstall from the sweep', async () => {
+      const { set } = rigDecommission(ONLINE_DEVICE);
+
+      const res = await app.request(`/devices/${DEVICE_ID}`, {
+        method: 'DELETE',
+        headers: { Authorization: 'Bearer t' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(set).toHaveBeenNthCalledWith(2, expect.objectContaining({ status: 'cancelled' }));
+      expect(vi.mocked(ne)).toHaveBeenCalledWith(deviceCommands.type, 'self_uninstall');
     });
 
     it('does not clear linkage when the device is already decommissioned (400)', async () => {

--- a/apps/api/src/routes/devices/core.decommission.test.ts
+++ b/apps/api/src/routes/devices/core.decommission.test.ts
@@ -183,10 +183,17 @@ describe('DELETE /devices/:id (decommission) — remote-session teardown wiring'
     const set = vi.fn().mockReturnValue({ where: updWhere });
     vi.mocked(db.update).mockReturnValue({ set } as never);
 
-    const tx = { update: vi.fn().mockReturnValue({ set }) };
+    // #5128: the decommission transaction now SELECTs the pending commands
+    // (id/type/payload) before the erasing cancel UPDATE, so their owning
+    // script_executions / deployment_results rows can be terminalised in the
+    // same transaction. Default to no pending rows; individual tests override.
+    const txSelect = vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue([]) }),
+    });
+    const tx = { update: vi.fn().mockReturnValue({ set }), select: txSelect };
     vi.mocked(db.transaction).mockImplementation(async (cb: any) => cb(tx));
 
-    return { set, updWhere, tx };
+    return { set, updWhere, tx, txSelect };
   }
 
   it('calls terminateDeviceRemoteSessions with the decommissioned device id', async () => {

--- a/apps/api/src/routes/devices/core.decommission.test.ts
+++ b/apps/api/src/routes/devices/core.decommission.test.ts
@@ -114,6 +114,14 @@ vi.mock('../agents/enrollment', () => ({
   getGlobalEnrollmentSecret: vi.fn().mockReturnValue(null),
 }));
 
+// #5128 — the decommission transaction cancels the device's ordinary pending
+// commands and must terminalise their OWNING records (script_executions /
+// deployment_results) in that SAME transaction. Mocked at the seam so the
+// route's wiring — including which executor it hands over — is assertable.
+vi.mock('../../services/commandCancelPropagation', () => ({
+  propagateCancelledDeviceCommands: vi.fn(),
+}));
+
 // The unit under test: core.ts imports BOTH terminateDeviceRemoteSessions and
 // TEARDOWN_FAILED. The mock MUST export both or the named import resolves to
 // undefined and the audit branch (teardownResult === TEARDOWN_FAILED) breaks.
@@ -130,8 +138,16 @@ import { writeRouteAudit } from '../../services/auditEvents';
 import { queueDeviceUninstall, releaseDeviceRemoveReason } from '../../services/deviceUninstallDrain';
 import { ne } from 'drizzle-orm';
 import { deviceCommands } from '../../db/schema';
+import { propagateCancelledDeviceCommands } from '../../services/commandCancelPropagation';
 
 const DEVICE_ID = '11111111-1111-4111-8111-111111111111';
+
+/**
+ * What the in-transaction `SELECT id/type/payload FROM device_commands` (the
+ * cancel-on-decommission read) resolves to. Empty by default so the existing
+ * write-ordering assertions are unaffected; the propagation test sets it.
+ */
+let pendingCommandRows: Array<{ id: string; type: string; payload: unknown }> = [];
 
 const ONLINE_DEVICE = {
   id: DEVICE_ID,
@@ -148,6 +164,7 @@ describe('DELETE /devices/:id (decommission) — remote-session teardown wiring'
 
   beforeEach(() => {
     vi.clearAllMocks();
+    pendingCommandRows = [];
     app = new Hono();
     app.route('/devices', coreRoutes);
   });
@@ -188,7 +205,7 @@ describe('DELETE /devices/:id (decommission) — remote-session teardown wiring'
     // script_executions / deployment_results rows can be terminalised in the
     // same transaction. Default to no pending rows; individual tests override.
     const txSelect = vi.fn().mockReturnValue({
-      from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue([]) }),
+      from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(pendingCommandRows) }),
     });
     const tx = { update: vi.fn().mockReturnValue({ set }), select: txSelect };
     vi.mocked(db.transaction).mockImplementation(async (cb: any) => cb(tx));
@@ -339,6 +356,35 @@ describe('DELETE /devices/:id (decommission) — remote-session teardown wiring'
       expect(vi.mocked(ne)).toHaveBeenCalledWith(deviceCommands.type, 'self_uninstall');
     });
 
+    // #5128 review round 2 — a cancelled command is TERMINAL, so the command
+    // reaper (pending/sent only) never revisits it. Without propagation the
+    // owning script_executions / deployment_results row sits `pending` forever.
+    it('terminalises the OWNING records of the cancelled rows, on the SAME transaction', async () => {
+      pendingCommandRows = [
+        { id: 'cmd-script', type: 'script', payload: { executionId: 'exec-1' } },
+        { id: 'cmd-install', type: 'software_install', payload: { deploymentId: 'dep-1' } },
+      ];
+      const { tx } = rigDecommission(ONLINE_DEVICE);
+
+      const res = await app.request(`/devices/${DEVICE_ID}`, {
+        method: 'DELETE',
+        headers: { Authorization: 'Bearer t' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(propagateCancelledDeviceCommands).toHaveBeenCalledTimes(1);
+      const [subjects, completedAt, executor] = vi.mocked(propagateCancelledDeviceCommands).mock
+        .calls[0]!;
+      expect(subjects).toEqual([
+        { id: 'cmd-script', type: 'script', payload: { executionId: 'exec-1' } },
+        { id: 'cmd-install', type: 'software_install', payload: { deploymentId: 'dep-1' } },
+      ]);
+      expect(completedAt).toBeInstanceOf(Date);
+      // The transaction handle, not the ambient db: a rollback of the status
+      // flip must roll the owning records back with it.
+      expect(executor).toBe(tx);
+    });
+
     it('does not clear linkage when the device is already decommissioned (400)', async () => {
       const { set } = rigDecommission({ ...ONLINE_DEVICE, status: 'decommissioned' });
 
@@ -482,6 +528,7 @@ describe('POST /devices/:id/restore — uninstall release wiring', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    pendingCommandRows = [];
     app = new Hono();
     app.route('/devices', coreRoutes);
   });

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -21,7 +21,7 @@ import {
   users,
 } from '../../db/schema';
 import { terminalPayloadErasureSet } from '../../services/sensitiveCommandPayload';
-import { propagateCancelledDeviceCommands } from '../../jobs/staleCommandReaper';
+import { propagateCancelledDeviceCommands } from '../../services/commandCancelPropagation';
 import {
   authMiddleware,
   isInteractiveUserSession,

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -1,13 +1,14 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
 import { optionalJsonValidator, zValidator } from '../../lib/validation';
-import { and, eq, gte, like, sql, desc, inArray, type SQL } from 'drizzle-orm';
+import { and, eq, gte, like, ne, sql, desc, inArray, type SQL } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../../db';
 import { createHash, randomBytes } from 'crypto';
 import { getRedis } from '../../services/redis';
 import { invalidateOrgDeviceCount } from '../../services/agentOrgRateLimit';
 import {
   devices,
+  deviceCommands,
   deviceHardware,
   deviceReliability,
   deviceNetwork,
@@ -19,6 +20,7 @@ import {
   organizations,
   users,
 } from '../../db/schema';
+import { terminalPayloadErasureSet } from '../../services/sensitiveCommandPayload';
 import {
   authMiddleware,
   isInteractiveUserSession,
@@ -1825,6 +1827,34 @@ coreRoutes.delete(
         .where(eq(devices.id, deviceId))
         .returning();
       updated = row;
+
+      // #5128 — cancel this device's ordinary queued work in the SAME
+      // transaction as the status write. `self_uninstall` is explicitly
+      // EXCLUDED: the uninstall drain's whole purpose is to survive
+      // decommission and deliver when the machine next checks in, and
+      // `queueDeviceUninstall` below may be about to write exactly such a row.
+      // Claim-time eligibility refuses to deliver ordinary work to a
+      // decommissioned device anyway; this is what stops those rows sitting
+      // `pending` until their deadline.
+      await tx
+        .update(deviceCommands)
+        .set({
+          status: 'cancelled',
+          completedAt: new Date(),
+          result: {
+            status: 'cancelled',
+            reason: 'device_decommissioned',
+            cancelledBy: 'device_decommission',
+          },
+          ...terminalPayloadErasureSet(),
+        })
+        .where(
+          and(
+            eq(deviceCommands.deviceId, deviceId),
+            eq(deviceCommands.status, 'pending'),
+            ne(deviceCommands.type, 'self_uninstall'),
+          ),
+        );
 
       if (uninstallAgent) {
         const queueResult = await queueDeviceUninstall(tx, deviceId, auth.user.id);

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -21,6 +21,7 @@ import {
   users,
 } from '../../db/schema';
 import { terminalPayloadErasureSet } from '../../services/sensitiveCommandPayload';
+import { propagateCancelledDeviceCommands } from '../../jobs/staleCommandReaper';
 import {
   authMiddleware,
   isInteractiveUserSession,
@@ -1836,11 +1837,29 @@ coreRoutes.delete(
       // Claim-time eligibility refuses to deliver ordinary work to a
       // decommissioned device anyway; this is what stops those rows sitting
       // `pending` until their deadline.
+      // Read id/type/payload BEFORE the erasing UPDATE: the propagation below
+      // keys on `payload.executionId`, which `terminalPayloadErasureSet()` strips.
+      const cancelledOnDecommission = await tx
+        .select({
+          id: deviceCommands.id,
+          type: deviceCommands.type,
+          payload: deviceCommands.payload,
+        })
+        .from(deviceCommands)
+        .where(
+          and(
+            eq(deviceCommands.deviceId, deviceId),
+            eq(deviceCommands.status, 'pending'),
+            ne(deviceCommands.type, 'self_uninstall'),
+          ),
+        );
+
+      const decommissionCancelledAt = new Date();
       await tx
         .update(deviceCommands)
         .set({
           status: 'cancelled',
-          completedAt: new Date(),
+          completedAt: decommissionCancelledAt,
           result: {
             status: 'cancelled',
             reason: 'device_decommissioned',
@@ -1855,6 +1874,20 @@ coreRoutes.delete(
             ne(deviceCommands.type, 'self_uninstall'),
           ),
         );
+
+      // Terminalise the OWNING records in the same transaction — otherwise a
+      // cancelled command strands its script_executions / deployment_results
+      // row `pending` forever (the command reaper only scans pending/sent
+      // COMMANDS, and this one is already terminal).
+      await propagateCancelledDeviceCommands(
+        cancelledOnDecommission.map((row) => ({
+          id: row.id,
+          type: row.type,
+          payload: row.payload as Record<string, unknown> | null,
+        })),
+        decommissionCancelledAt,
+        tx,
+      );
 
       if (uninstallAgent) {
         const queueResult = await queueDeviceUninstall(tx, deviceId, auth.user.id);

--- a/apps/api/src/routes/devices/moveOrg.test.ts
+++ b/apps/api/src/routes/devices/moveOrg.test.ts
@@ -275,7 +275,24 @@ function rigTransactionSuccess(
       // #3776 — the ticket-id lookup feeding the currency guard
       // (`tx.select({id}).from(tickets).where(deviceId = …)`). Records the
       // position so lock-order assertions can place it against the UPDATEs.
-      select: vi.fn().mockImplementation(() => ({
+      select: vi.fn().mockImplementation((cols?: Record<string, unknown>) => {
+        // #5128 — the org flip now also reads the device's PENDING commands
+        // (id/type/payload) so their owning script_executions /
+        // deployment_results rows can be cancelled in the same transaction.
+        // This recorder is otherwise table-blind, so without this branch that
+        // read would be mis-recorded as the ticket-currency lookup and shift
+        // every lock-order assertion below.
+        if (cols && 'payload' in cols) {
+          return {
+            from: vi.fn().mockReturnValue({
+              where: vi.fn().mockImplementation(() => {
+                statements.push(`SELECT device_commands.pending (after ${updatedTables.length} updates)`);
+                return Promise.resolve([]);
+              }),
+            }),
+          };
+        }
+        return {
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockImplementation(() => ({
             // Awaited directly => the ticket-id lookup feeding the currency guard.
@@ -296,7 +313,8 @@ function rigTransactionSuccess(
             })),
           })),
         }),
-      })),
+        };
+      }),
     };
     await cb(tx);
     return updatedRow;

--- a/apps/api/src/routes/devices/moveOrg.test.ts
+++ b/apps/api/src/routes/devices/moveOrg.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Hono } from 'hono';
+import { PgDialect } from 'drizzle-orm/pg-core';
 
 const {
   authMiddlewareMock,
@@ -11,10 +12,12 @@ const {
   pamGuardMock,
   captureExceptionMock,
   schedulePeripheralPolicyDeviceMock,
+  propagateCancelledMock,
 } = vi.hoisted(() => ({
   guardMock: vi.fn(),
   pamGuardMock: vi.fn(),
   captureExceptionMock: vi.fn(),
+  propagateCancelledMock: vi.fn(),
   schedulePeripheralPolicyDeviceMock: vi.fn().mockResolvedValue('job-id'),
   authMiddlewareMock: vi.fn(),
   requireScopeMock: vi.fn(() => async (_c: any, next: any) => next()),
@@ -66,6 +69,13 @@ vi.mock('../../services/sentry', () => ({
   captureException: captureExceptionMock,
 }));
 
+// #5128 — the org flip cancels the device's queued work and must terminalise
+// the OWNING records (script_executions / deployment_results) in the SAME
+// transaction. Mocked at the seam so the route's wiring is assertable.
+vi.mock('../../services/commandCancelPropagation', () => ({
+  propagateCancelledDeviceCommands: propagateCancelledMock,
+}));
+
 // Task 13 (#3776): the locked currency guard is unit-tested on its own
 // (services/ticketMoveCurrencyGuard.test.ts); here it is a mock so the route's
 // sequencing, 409 mapping, and permission gate can be asserted in isolation.
@@ -94,6 +104,7 @@ import { getDeviceWithOrgAndSiteCheck } from './helpers';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { disconnectAgent } from '../agentWs';
 import { dissolveLinkGroupIfBelowMinimum } from '../../services/deviceLinkGroups';
+import { propagateCancelledDeviceCommands } from '../../services/commandCancelPropagation';
 import { moveOrgRoutes } from './moveOrg';
 import { TicketMoveCurrencyBlockedError } from '../../services/ticketMoveCurrencyGuard';
 import { PamDeviceMoveBlockedError } from '../../services/pamDeviceMoveGuard';
@@ -183,6 +194,13 @@ let barrierMissingOrgIds = new Set<string>();
  */
 let executeResultFor: ((stmtText: string) => unknown[] | null) | null = null;
 
+/**
+ * What the in-transaction `SELECT id/type/payload FROM device_commands` (the
+ * cancel-on-move read) resolves to. Empty by default so the existing
+ * lock-order/audit tests are unaffected; the propagation tests set it.
+ */
+let pendingCommandRows: Array<{ id: string; type: string; payload: unknown }> = [];
+
 /** Collapse a captured statement to one line (multi-line `sql` templates keep
  *  their source newlines in the harness's raw text). */
 const collapseStmt = (s: string) => s.replace(/\s+/g, ' ').trim();
@@ -237,6 +255,13 @@ function rigTransactionSuccess(
   updatedRow: any = { ...SAMPLE_DEVICE, orgId: TARGET_ORG, siteId: TARGET_SITE },
   deviceUpdateError?: unknown,
 ) {
+  // Every `where(...)` predicate handed to a tx.update chain, in call order:
+  // [0] the devices flip, [1] the #5128 cancel-on-move sweep. Captured as the
+  // Drizzle condition object so it can be COMPILED — the only way to prove the
+  // self_uninstall exclusion is actually in the SQL.
+  const updateWheres: unknown[] = [];
+  const commandSelectWheres: unknown[] = [];
+  let txHandle: unknown = null;
   // Each tx.execute() call captures the identifier name being UPDATEd (the
   // second chunk in our `UPDATE ${sql.identifier(table)} SET org_id = ...`
   // template — Drizzle exposes it as queryChunks[1].value) plus the full
@@ -254,10 +279,13 @@ function rigTransactionSuccess(
         set: vi.fn().mockImplementation((vals: any) => {
           deviceUpdateSets.push(vals);
           return {
-            where: vi.fn().mockReturnValue({
-              returning: vi.fn().mockImplementation(() => deviceUpdateError
-                ? Promise.reject(deviceUpdateError)
-                : Promise.resolve([updatedRow])),
+            where: vi.fn().mockImplementation((cond: any) => {
+              updateWheres.push(cond);
+              return {
+                returning: vi.fn().mockImplementation(() => deviceUpdateError
+                  ? Promise.reject(deviceUpdateError)
+                  : Promise.resolve([updatedRow])),
+              };
             }),
           };
         }),
@@ -285,9 +313,10 @@ function rigTransactionSuccess(
         if (cols && 'payload' in cols) {
           return {
             from: vi.fn().mockReturnValue({
-              where: vi.fn().mockImplementation(() => {
+              where: vi.fn().mockImplementation((cond: any) => {
+                commandSelectWheres.push(cond);
                 statements.push(`SELECT device_commands.pending (after ${updatedTables.length} updates)`);
-                return Promise.resolve([]);
+                return Promise.resolve(pendingCommandRows);
               }),
             }),
           };
@@ -316,10 +345,18 @@ function rigTransactionSuccess(
         };
       }),
     };
+    txHandle = tx;
     await cb(tx);
     return updatedRow;
   });
-  return { updatedTables, statements, deviceUpdateSets };
+  return {
+    updatedTables,
+    statements,
+    deviceUpdateSets,
+    updateWheres,
+    commandSelectWheres,
+    tx: () => txHandle,
+  };
 }
 
 describe('POST /devices/:id/move-org', () => {
@@ -329,6 +366,7 @@ describe('POST /devices/:id/move-org', () => {
     vi.clearAllMocks();
     barrierMissingOrgIds = new Set<string>();
     executeResultFor = null;
+    pendingCommandRows = [];
     guardMock.mockReset();
     guardMock.mockResolvedValue(null);
     pamGuardMock.mockReset();
@@ -348,6 +386,68 @@ describe('POST /devices/:id/move-org', () => {
       expect(registeredPermResources).toContain('devices:write');
       expect(registeredPermResources).toContain('organizations:write');
       expect(registeredMfaCallCount).toBeGreaterThan(0);
+    });
+  });
+
+  // ── #5128 cancel-on-move ───────────────────────────────────────────────
+  describe('cancel-on-move (#5128)', () => {
+    function rigMove() {
+      vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue(SAMPLE_DEVICE as never);
+      rigOrgAndSiteSelects({
+        orgRows: [
+          { id: SOURCE_ORG, partnerId: 'partner-1' },
+          { id: TARGET_ORG, partnerId: 'partner-1' },
+        ],
+        siteRow: { id: TARGET_SITE },
+      });
+      return rigTransactionSuccess();
+    }
+
+    const move = () =>
+      app.request(`/devices/${DEVICE_ID}/move-org`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ orgId: TARGET_ORG, siteId: TARGET_SITE }),
+      });
+
+    it('both the SELECT and the cancel UPDATE exclude self_uninstall', async () => {
+      // Matches the decommission path in core.ts: the uninstall drain must
+      // still deliver. A device moved out of an org while its removal is queued
+      // still has to lose its agent — cancelling that row leaves a customer's
+      // machine managed by an MSP that no longer owns it.
+      const rig = rigMove();
+      expect((await move()).status).toBe(200);
+
+      const compiled = [rig.commandSelectWheres[0], rig.updateWheres[1]].map((cond) =>
+        new PgDialect().sqlToQuery(cond as never),
+      );
+      for (const { sql: text, params } of compiled) {
+        expect(params).toContain('self_uninstall');
+        // `<>` and not `=`: an equality would cancel ONLY the uninstall.
+        expect(text).toMatch(/"type"\s*<>/);
+        expect(params).toContain('pending');
+      }
+    });
+
+    it('propagates the SELECTED rows to the owning records on the SAME transaction', async () => {
+      pendingCommandRows = [
+        { id: 'cmd-script', type: 'script', payload: { executionId: 'exec-1' } },
+        { id: 'cmd-install', type: 'software_install', payload: { deploymentId: 'dep-1' } },
+      ];
+      const rig = rigMove();
+
+      expect((await move()).status).toBe(200);
+
+      expect(propagateCancelledDeviceCommands).toHaveBeenCalledTimes(1);
+      const [subjects, completedAt, executor] = propagateCancelledMock.mock.calls[0]!;
+      expect(subjects).toEqual([
+        { id: 'cmd-script', type: 'script', payload: { executionId: 'exec-1' } },
+        { id: 'cmd-install', type: 'software_install', payload: { deploymentId: 'dep-1' } },
+      ]);
+      expect(completedAt).toBeInstanceOf(Date);
+      // The transaction handle, not the ambient db: a rollback of the org flip
+      // must roll the owning records back with it.
+      expect(executor).toBe(rig.tx());
     });
   });
 

--- a/apps/api/src/routes/devices/moveOrg.ts
+++ b/apps/api/src/routes/devices/moveOrg.ts
@@ -1,10 +1,10 @@
 import { Hono } from 'hono';
 import { zValidator } from '../../lib/validation';
-import { and, eq, sql } from 'drizzle-orm';
+import { and, eq, ne, sql } from 'drizzle-orm';
 import { db } from '../../db';
 import { deviceCommands, devices, sites, organizations, tickets } from '../../db/schema';
 import { terminalPayloadErasureSet } from '../../services/sensitiveCommandPayload';
-import { propagateCancelledDeviceCommands } from '../../jobs/staleCommandReaper';
+import { propagateCancelledDeviceCommands } from '../../services/commandCancelPropagation';
 import {
   authMiddleware,
   requireMfa,
@@ -327,6 +327,11 @@ moveOrgRoutes.post(
         // Read id/type/payload BEFORE the erasing UPDATE: the propagation below
         // keys on `payload.executionId`, and `terminalPayloadErasureSet()`
         // strips it (`returning()` reflects post-update values).
+        // `self_uninstall` is EXCLUDED, matching the decommission path in
+        // core.ts: the uninstall drain must still deliver. A device moved out
+        // of an org while its removal is queued still has to lose its agent —
+        // cancelling that row leaves the customer's machine managed by an MSP
+        // that no longer owns it.
         const cancelledForMove = await tx
           .select({
             id: deviceCommands.id,
@@ -334,7 +339,13 @@ moveOrgRoutes.post(
             payload: deviceCommands.payload,
           })
           .from(deviceCommands)
-          .where(and(eq(deviceCommands.deviceId, deviceId), eq(deviceCommands.status, 'pending')));
+          .where(
+            and(
+              eq(deviceCommands.deviceId, deviceId),
+              eq(deviceCommands.status, 'pending'),
+              ne(deviceCommands.type, 'self_uninstall'),
+            ),
+          );
 
         const moveCancelledAt = new Date();
         await tx
@@ -345,7 +356,13 @@ moveOrgRoutes.post(
             result: { status: 'cancelled', reason: 'device_moved_org', cancelledBy: 'device_move_org' },
             ...terminalPayloadErasureSet(),
           })
-          .where(and(eq(deviceCommands.deviceId, deviceId), eq(deviceCommands.status, 'pending')));
+          .where(
+            and(
+              eq(deviceCommands.deviceId, deviceId),
+              eq(deviceCommands.status, 'pending'),
+              ne(deviceCommands.type, 'self_uninstall'),
+            ),
+          );
 
         // Terminalise the OWNING records too, in this same transaction. Without
         // this a cancelled command leaves its script_executions /

--- a/apps/api/src/routes/devices/moveOrg.ts
+++ b/apps/api/src/routes/devices/moveOrg.ts
@@ -4,6 +4,7 @@ import { and, eq, sql } from 'drizzle-orm';
 import { db } from '../../db';
 import { deviceCommands, devices, sites, organizations, tickets } from '../../db/schema';
 import { terminalPayloadErasureSet } from '../../services/sensitiveCommandPayload';
+import { propagateCancelledDeviceCommands } from '../../jobs/staleCommandReaper';
 import {
   authMiddleware,
   requireMfa,
@@ -323,15 +324,42 @@ moveOrgRoutes.post(
         // than the safety property: it stops the rows sitting `pending` until
         // their deadline and shows the operator the truth immediately. Rows are
         // erased of payload like any other terminal transition.
+        // Read id/type/payload BEFORE the erasing UPDATE: the propagation below
+        // keys on `payload.executionId`, and `terminalPayloadErasureSet()`
+        // strips it (`returning()` reflects post-update values).
+        const cancelledForMove = await tx
+          .select({
+            id: deviceCommands.id,
+            type: deviceCommands.type,
+            payload: deviceCommands.payload,
+          })
+          .from(deviceCommands)
+          .where(and(eq(deviceCommands.deviceId, deviceId), eq(deviceCommands.status, 'pending')));
+
+        const moveCancelledAt = new Date();
         await tx
           .update(deviceCommands)
           .set({
             status: 'cancelled',
-            completedAt: new Date(),
+            completedAt: moveCancelledAt,
             result: { status: 'cancelled', reason: 'device_moved_org', cancelledBy: 'device_move_org' },
             ...terminalPayloadErasureSet(),
           })
           .where(and(eq(deviceCommands.deviceId, deviceId), eq(deviceCommands.status, 'pending')));
+
+        // Terminalise the OWNING records too, in this same transaction. Without
+        // this a cancelled command leaves its script_executions /
+        // deployment_results row `pending` forever: the command reaper only
+        // scans `pending`/`sent` commands, so nothing would ever revisit it.
+        await propagateCancelledDeviceCommands(
+          cancelledForMove.map((row) => ({
+            id: row.id,
+            type: row.type,
+            payload: row.payload as Record<string, unknown> | null,
+          })),
+          moveCancelledAt,
+          tx,
+        );
 
         // #2138 — if the moved device left a link group with a single lone
         // profile behind — or it was a vm_host group's HOST (#2308), leaving

--- a/apps/api/src/routes/devices/moveOrg.ts
+++ b/apps/api/src/routes/devices/moveOrg.ts
@@ -2,7 +2,8 @@ import { Hono } from 'hono';
 import { zValidator } from '../../lib/validation';
 import { and, eq, sql } from 'drizzle-orm';
 import { db } from '../../db';
-import { devices, sites, organizations, tickets } from '../../db/schema';
+import { deviceCommands, devices, sites, organizations, tickets } from '../../db/schema';
+import { terminalPayloadErasureSet } from '../../services/sensitiveCommandPayload';
 import {
   authMiddleware,
   requireMfa,
@@ -315,6 +316,22 @@ moveOrgRoutes.post(
           .where(eq(devices.id, deviceId))
           .returning();
         updated = row;
+
+        // #5128 — cancel this device's queued work in the SAME transaction as
+        // the org flip. Claim-time eligibility already refuses to deliver a row
+        // whose `submitted_org_id` no longer matches, so this is cleanup rather
+        // than the safety property: it stops the rows sitting `pending` until
+        // their deadline and shows the operator the truth immediately. Rows are
+        // erased of payload like any other terminal transition.
+        await tx
+          .update(deviceCommands)
+          .set({
+            status: 'cancelled',
+            completedAt: new Date(),
+            result: { status: 'cancelled', reason: 'device_moved_org', cancelledBy: 'device_move_org' },
+            ...terminalPayloadErasureSet(),
+          })
+          .where(and(eq(deviceCommands.deviceId, deviceId), eq(deviceCommands.status, 'pending')));
 
         // #2138 — if the moved device left a link group with a single lone
         // profile behind — or it was a vm_host group's HOST (#2308), leaving

--- a/apps/api/src/services/agentEditionCompat.test.ts
+++ b/apps/api/src/services/agentEditionCompat.test.ts
@@ -189,6 +189,12 @@ describe('agent-binary update command types are only named at known sites (#4093
     'apps/api/src/services/agentEditionCompat.ts', // the gate itself
     'apps/api/src/services/aiToolsAgentMgmt.ts', // trigger_agent_upgrade — the one dispatcher
     'apps/api/src/services/partnerTrust.ts', // partner trust probation allowlist classifies these as lifecycle; it never dispatches them
+    // #5128: the fail-closed offline-policy registry must classify EVERY
+    // command type or it throws at dispatch. Classification only — the file
+    // holds two string lists and never inserts a device_commands row or calls
+    // a dispatcher. Both types are pinned to the `live` class there, which is
+    // the class that refuses to queue for an offline device.
+    'apps/api/src/services/commandOfflinePolicy.ts',
   ]);
 
   function walk(dir: string, out: string[] = []): string[] {

--- a/apps/api/src/services/commandCancelPropagation.test.ts
+++ b/apps/api/src/services/commandCancelPropagation.test.ts
@@ -1,0 +1,193 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * #5128 — a cancelled command is TERMINAL, so the command reaper (which scans
+ * only pending/sent) never revisits it. Everything the command owned has to be
+ * terminalised right here, or it waits forever: the script execution, its batch
+ * counters (via the shared terminaliser), the deployment result, and the
+ * automation action that dispatched it.
+ */
+
+const { finalizeMock, applyAutomationMock, captureExceptionMock, updateMock } = vi.hoisted(() => ({
+  finalizeMock: vi.fn(),
+  applyAutomationMock: vi.fn(),
+  captureExceptionMock: vi.fn(),
+  updateMock: vi.fn(),
+}));
+
+vi.mock('../db', () => ({ db: { update: (...a: unknown[]) => updateMock(...(a as [])), select: vi.fn() } }));
+vi.mock('../db/schema', () => ({
+  deploymentResults: {
+    deviceCommandId: 'deployment_results.device_command_id',
+    status: 'deployment_results.status',
+  },
+}));
+vi.mock('./scriptExecutionTerminal', () => ({
+  finalizeScriptExecutionTerminal: (...a: unknown[]) => finalizeMock(...(a as [])),
+  batchIdFromPayload: (payload: unknown) =>
+    payload && typeof payload === 'object' && !Array.isArray(payload)
+      ? ((payload as Record<string, unknown>).batchId as string | undefined) ?? null
+      : null,
+}));
+vi.mock('./automationActionResults', () => ({
+  applyAutomationActionTerminal: (...a: unknown[]) => applyAutomationMock(...(a as [])),
+}));
+vi.mock('./sentry', () => ({
+  captureException: (...a: unknown[]) => captureExceptionMock(...(a as [])),
+}));
+
+import {
+  propagateCancelledDeviceCommand,
+  propagateCancelledDeviceCommands,
+} from './commandCancelPropagation';
+
+const COMPLETED_AT = new Date('2026-10-13T00:00:00Z');
+const ERROR = 'Cancelled before the device received it';
+
+function executor() {
+  const sets: Array<Record<string, unknown>> = [];
+  return {
+    sets,
+    handle: {
+      update: () => ({
+        set: (vals: Record<string, unknown>) => {
+          sets.push(vals);
+          return { where: async () => undefined };
+        },
+      }),
+      select: vi.fn(),
+    } as never,
+  };
+}
+
+describe('propagateCancelledDeviceCommand (#5128 §G)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    finalizeMock.mockResolvedValue({ terminalised: true });
+    applyAutomationMock.mockResolvedValue(true);
+  });
+
+  it('terminalises a script execution through the shared batch-aware helper', async () => {
+    // Writing to script_executions directly here is what left the owning batch
+    // non-terminal forever: only the shared helper advances the counters.
+    const { handle } = executor();
+    await propagateCancelledDeviceCommand({
+      commandId: 'cmd-1',
+      type: 'script',
+      payload: { executionId: 'exec-1', batchId: 'batch-1' },
+      completedAt: COMPLETED_AT,
+      executor: handle,
+    });
+
+    expect(finalizeMock).toHaveBeenCalledTimes(1);
+    expect(finalizeMock.mock.calls[0]![0]).toMatchObject({
+      executionId: 'exec-1',
+      batchId: 'batch-1',
+      outcome: 'cancelled',
+      errorMessage: ERROR,
+      completedAt: COMPLETED_AT,
+      executor: handle,
+    });
+  });
+
+  it('a script command with no executionId does not reach the terminaliser', async () => {
+    const { handle } = executor();
+    await propagateCancelledDeviceCommand({
+      commandId: 'cmd-1',
+      type: 'script',
+      payload: {},
+      completedAt: COMPLETED_AT,
+      executor: handle,
+    });
+    expect(finalizeMock).not.toHaveBeenCalled();
+  });
+
+  it('a non-script command never touches script_executions', async () => {
+    const { handle, sets } = executor();
+    await propagateCancelledDeviceCommand({
+      commandId: 'cmd-1',
+      type: 'software_install',
+      payload: { deploymentId: 'dep-1' },
+      completedAt: COMPLETED_AT,
+      executor: handle,
+    });
+    expect(finalizeMock).not.toHaveBeenCalled();
+    // ...but the deployment result still is.
+    expect(sets).toEqual([{ status: 'cancelled', errorMessage: ERROR, completedAt: COMPLETED_AT }]);
+  });
+
+  it('terminalises the automation action that dispatched the command', async () => {
+    const { handle } = executor();
+    await propagateCancelledDeviceCommand({
+      commandId: 'cmd-1',
+      type: 'reboot',
+      payload: null,
+      completedAt: COMPLETED_AT,
+      executor: handle,
+    });
+
+    expect(applyAutomationMock).toHaveBeenCalledWith({
+      source: 'cancellation',
+      commandId: 'cmd-1',
+      terminalStatus: 'cancelled',
+      error: ERROR,
+      completedAt: COMPLETED_AT,
+    });
+  });
+
+  it('an automation bookkeeping failure is reported, never thrown into the caller', async () => {
+    // The caller is a route transaction (org move, decommission, user cancel) or
+    // the heartbeat claim. Aborting those because a separate-connection
+    // automation write failed would turn a cosmetic miss into a 500 / a device
+    // that cannot check in.
+    const { handle } = executor();
+    applyAutomationMock.mockRejectedValue(new Error('automation down'));
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      await expect(
+        propagateCancelledDeviceCommand({
+          commandId: 'cmd-1',
+          type: 'reboot',
+          payload: null,
+          completedAt: COMPLETED_AT,
+          executor: handle,
+        }),
+      ).resolves.toBeUndefined();
+    } finally {
+      errorSpy.mockRestore();
+    }
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('the bulk form applies every row on the caller executor', async () => {
+    const { handle } = executor();
+    await propagateCancelledDeviceCommands(
+      [
+        { id: 'a', type: 'script', payload: { executionId: 'x' } },
+        { id: 'b', type: 'software_install', payload: null },
+      ],
+      COMPLETED_AT,
+      handle,
+    );
+
+    expect(finalizeMock).toHaveBeenCalledTimes(1);
+    expect(applyAutomationMock).toHaveBeenCalledTimes(2);
+    expect(applyAutomationMock.mock.calls.map((c) => (c[0] as { commandId: string }).commandId)).toEqual([
+      'a',
+      'b',
+    ]);
+  });
+
+  it('falls back to the ambient db when no executor is given', async () => {
+    updateMock.mockReturnValue({
+      set: () => ({ where: async () => undefined }),
+    });
+    await propagateCancelledDeviceCommand({
+      commandId: 'cmd-1',
+      type: 'reboot',
+      payload: null,
+      completedAt: COMPLETED_AT,
+    });
+    expect(updateMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/services/commandCancelPropagation.ts
+++ b/apps/api/src/services/commandCancelPropagation.ts
@@ -1,6 +1,9 @@
-import { and, eq, inArray } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { db } from '../db';
-import { deploymentResults, scriptExecutions } from '../db/schema';
+import { deploymentResults } from '../db/schema';
+import { applyAutomationActionTerminal } from './automationActionResults';
+import { captureException } from './sentry';
+import { batchIdFromPayload, finalizeScriptExecutionTerminal } from './scriptExecutionTerminal';
 
 /**
  * Terminalise the higher-level records owned by a device command that was
@@ -25,7 +28,7 @@ import { deploymentResults, scriptExecutions } from '../db/schema';
  * Anything that can run the propagation UPDATEs: the ambient `db`, or a caller's
  * open transaction handle.
  */
-type DbExecutor = Pick<typeof db, 'update'>;
+type DbExecutor = Pick<typeof db, 'update' | 'select'>;
 
 export type DeviceCommandCancelSubject = {
   id: string;
@@ -79,15 +82,19 @@ export async function propagateCancelledDeviceCommand(params: {
         ? payload.executionId
         : null;
     if (executionId) {
-      await executor
-        .update(scriptExecutions)
-        .set({ status: 'cancelled', errorMessage, completedAt })
-        .where(
-          and(
-            eq(scriptExecutions.id, executionId),
-            inArray(scriptExecutions.status, ['pending', 'queued', 'running']),
-          ),
-        );
+      // Goes through the shared terminaliser, so the owning
+      // `script_execution_batches` counters advance too. Terminalising the
+      // execution without them left the batch non-terminal forever: the
+      // execution reaper's selector never revisits a terminal row, so
+      // `devicesCompleted + devicesFailed` could never reach `devicesTargeted`.
+      await finalizeScriptExecutionTerminal({
+        executionId,
+        batchId: batchIdFromPayload(payload),
+        outcome: 'cancelled',
+        errorMessage,
+        completedAt,
+        executor,
+      });
     }
   }
 
@@ -100,4 +107,25 @@ export async function propagateCancelledDeviceCommand(params: {
         eq(deploymentResults.status, 'pending'),
       ),
     );
+
+  // An automation action that dispatched this command is waiting on it too, and
+  // like the batch counters it is only ever advanced by a terminal event. Runs
+  // on its OWN connection (`inDeliberateSystemContext`), so it deliberately does
+  // not join the caller's transaction — and its failure must never abort a
+  // cancel that has already committed the important writes.
+  try {
+    await applyAutomationActionTerminal({
+      source: 'cancellation',
+      commandId,
+      terminalStatus: 'cancelled',
+      error: errorMessage,
+      completedAt,
+    });
+  } catch (err) {
+    console.error(
+      '[commandCancelPropagation] failed to terminalise the automation action for a cancelled command',
+      { commandId, type, error: err instanceof Error ? err.message : String(err) },
+    );
+    captureException(err instanceof Error ? err : new Error(String(err)));
+  }
 }

--- a/apps/api/src/services/commandCancelPropagation.ts
+++ b/apps/api/src/services/commandCancelPropagation.ts
@@ -1,0 +1,103 @@
+import { and, eq, inArray } from 'drizzle-orm';
+import { db } from '../db';
+import { deploymentResults, scriptExecutions } from '../db/schema';
+
+/**
+ * Terminalise the higher-level records owned by a device command that was
+ * CANCELLED (#5128 §G) — by a user, by a cancel-on-event sweep (org move,
+ * decommission), or by claim-time eligibility. Sibling of
+ * `propagateTimedOutDeviceCommand`: the command row itself is already terminal
+ * by the time this runs; this only stops the owning record from waiting forever
+ * on a delivery that will never happen.
+ *
+ * W3 adds the `patch_job_results` branch. Anything without a branch is a no-op
+ * by design — a generic command has no higher-level record (#5128 §F).
+ *
+ * Deliberately a LEAF module: `services/commandClaimEligibility.ts` has to call
+ * this from inside the heartbeat claim transaction, and it is itself reachable
+ * from `commandQueue` → `dispatchDeviceCommand` → `commandDispatch`. Leaving
+ * these functions in `jobs/staleCommandReaper.ts` (which imports
+ * `services/commandQueue`) would close that loop into an import cycle, so they
+ * live here and the reaper re-exports them for its existing importers.
+ */
+
+/**
+ * Anything that can run the propagation UPDATEs: the ambient `db`, or a caller's
+ * open transaction handle.
+ */
+type DbExecutor = Pick<typeof db, 'update'>;
+
+export type DeviceCommandCancelSubject = {
+  id: string;
+  type: string;
+  payload: Record<string, unknown> | null;
+};
+
+/**
+ * Bulk sibling of `propagateCancelledDeviceCommand` for the cancel-on-event
+ * paths (org move, decommission), which cancel every pending row for a device
+ * in one UPDATE. Takes the caller's transaction so the owning records are
+ * terminalised atomically with the cancel itself.
+ */
+export async function propagateCancelledDeviceCommands(
+  rows: readonly DeviceCommandCancelSubject[],
+  completedAt: Date,
+  executor: DbExecutor = db,
+): Promise<void> {
+  for (const row of rows) {
+    await propagateCancelledDeviceCommand({
+      commandId: row.id,
+      type: row.type,
+      payload: row.payload,
+      completedAt,
+      executor,
+    });
+  }
+}
+
+export async function propagateCancelledDeviceCommand(params: {
+  commandId: string;
+  type: string;
+  payload: Record<string, unknown> | null;
+  completedAt: Date;
+  cancelledBy?: string | null;
+  /**
+   * #5128: the cancel-on-event callers run inside their own transaction (the
+   * org flip / the decommission write) and must terminalise the owning records
+   * in that SAME transaction, or a rollback would leave a cancelled command
+   * with a `script_executions` / `deployment_results` row still `pending`.
+   */
+  executor?: DbExecutor;
+}): Promise<void> {
+  const { commandId, type, payload, completedAt } = params;
+  const executor: DbExecutor = params.executor ?? db;
+  const errorMessage = 'Cancelled before the device received it';
+
+  if (type === 'script') {
+    const executionId =
+      payload && typeof payload.executionId === 'string' && payload.executionId.trim().length > 0
+        ? payload.executionId
+        : null;
+    if (executionId) {
+      await executor
+        .update(scriptExecutions)
+        .set({ status: 'cancelled', errorMessage, completedAt })
+        .where(
+          and(
+            eq(scriptExecutions.id, executionId),
+            inArray(scriptExecutions.status, ['pending', 'queued', 'running']),
+          ),
+        );
+    }
+  }
+
+  await executor
+    .update(deploymentResults)
+    .set({ status: 'cancelled', errorMessage, completedAt })
+    .where(
+      and(
+        eq(deploymentResults.deviceCommandId, commandId),
+        eq(deploymentResults.status, 'pending'),
+      ),
+    );
+}

--- a/apps/api/src/services/commandClaimEligibility.test.ts
+++ b/apps/api/src/services/commandClaimEligibility.test.ts
@@ -1,0 +1,241 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { assertAllowedMock, userStatusMock, updateMock, setMock, whereMock } = vi.hoisted(() => ({
+  assertAllowedMock: vi.fn(),
+  userStatusMock: vi.fn(),
+  updateMock: vi.fn(),
+  setMock: vi.fn(),
+  whereMock: vi.fn(),
+}));
+
+vi.mock('./partnerTrust.commands', () => ({
+  assertDeviceExecuteAllowed: (...a: unknown[]) => assertAllowedMock(...(a as [])),
+  TrustDeniedError: class TrustDeniedError extends Error {
+    capability = 'device_execute' as const;
+    constructor(
+      public code: string,
+      public reason: string,
+      public deviceId: string,
+      public commandType: string,
+    ) {
+      super(`Partner trust ${code}`);
+      this.name = 'TrustDeniedError';
+    }
+  },
+}));
+vi.mock('../db/schema', () => ({
+  deviceCommands: {
+    id: 'dc.id',
+    status: 'dc.status',
+    completedAt: 'dc.completedAt',
+    result: 'dc.result',
+    payload: 'dc.payload',
+  },
+  users: { id: 'users.id', status: 'users.status' },
+}));
+vi.mock('./sensitiveCommandPayload', () => ({ terminalPayloadErasureSet: () => ({ payload: null }) }));
+
+import { POWER_STATE_TYPES, partitionClaimable, typeHolds } from './commandClaimEligibility';
+
+const ORG = '22222222-2222-4222-8222-222222222222';
+const OTHER_ORG = '33333333-3333-4333-8333-333333333333';
+const USER = '44444444-4444-4444-8444-444444444444';
+const OTHER_USER = '55555555-5555-4555-8555-555555555555';
+const device = { id: 'd1', orgId: ORG, status: 'online' };
+
+type Row = Parameters<typeof partitionClaimable>[2][number];
+const row = (over: Partial<Row> = {}): Row => ({
+  id: 'c1',
+  type: 'refresh_inventory',
+  createdBy: null,
+  submittedOrgId: ORG,
+  deliverBy: null,
+  ...over,
+});
+
+function tx() {
+  whereMock.mockResolvedValue([]);
+  setMock.mockReturnValue({ where: (...a: unknown[]) => whereMock(...(a as [])) });
+  updateMock.mockReturnValue({ set: (...a: unknown[]) => setMock(...(a as [])) });
+  return {
+    update: (...a: unknown[]) => updateMock(...(a as [])),
+    select: () => ({ from: () => ({ where: () => ({ limit: async () => userStatusMock() }) }) }),
+  } as never;
+}
+
+describe('partitionClaimable (#5128 W1 §G)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    assertAllowedMock.mockResolvedValue(undefined);
+    userStatusMock.mockResolvedValue([{ status: 'active' }]);
+    for (const key of Object.keys(typeHolds)) delete typeHolds[key];
+  });
+
+  it('passes an ordinary row through and writes nothing', async () => {
+    const r = await partitionClaimable(tx(), device, [row()]);
+    expect(r.claimable.map((x) => x.id)).toEqual(['c1']);
+    expect(r.cancelled).toEqual([]);
+    expect(r.held).toEqual([]);
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it('cancels when the device moved org since enqueue', async () => {
+    const r = await partitionClaimable(tx(), device, [row({ submittedOrgId: OTHER_ORG })]);
+    expect(r.cancelled).toEqual([{ id: 'c1', reason: 'device_moved_org' }]);
+    expect(r.claimable).toEqual([]);
+    expect(updateMock).toHaveBeenCalledTimes(1);
+    expect(setMock.mock.calls[0]![0]).toMatchObject({
+      status: 'cancelled',
+      result: expect.objectContaining({ status: 'cancelled', reason: 'device_moved_org' }),
+    });
+  });
+
+  it('legacy rows with NULL submitted_org_id are not cancelled for org drift', async () => {
+    const r = await partitionClaimable(tx(), device, [row({ submittedOrgId: null })]);
+    expect(r.claimable).toHaveLength(1);
+    expect(r.cancelled).toEqual([]);
+  });
+
+  it('cancels on device lifecycle (quarantined) except self_uninstall', async () => {
+    const r = await partitionClaimable(tx(), { ...device, status: 'quarantined' }, [
+      row(),
+      row({ id: 'c2', type: 'self_uninstall' }),
+    ]);
+    expect(r.cancelled).toEqual([{ id: 'c1', reason: 'device_lifecycle' }]);
+    expect(r.claimable.map((x) => x.id)).toEqual(['c2']);
+  });
+
+  it('cancels on device lifecycle (decommissioned) except self_uninstall', async () => {
+    const r = await partitionClaimable(tx(), { ...device, status: 'decommissioned' }, [
+      row(),
+      row({ id: 'c2', type: 'self_uninstall' }),
+    ]);
+    expect(r.cancelled).toEqual([{ id: 'c1', reason: 'device_lifecycle' }]);
+    expect(r.claimable.map((x) => x.id)).toEqual(['c2']);
+  });
+
+  it('an offline or maintenance device is NOT a lifecycle cancellation', async () => {
+    for (const status of ['offline', 'maintenance', 'updating', 'pending']) {
+      const r = await partitionClaimable(tx(), { ...device, status }, [row()]);
+      expect(r.claimable).toHaveLength(1);
+    }
+  });
+
+  it('cancels on trust denial', async () => {
+    const { TrustDeniedError } = await import('./partnerTrust.commands');
+    assertAllowedMock.mockRejectedValue(new TrustDeniedError('TRUST_RESTRICTED', 'suspended', 'd1', 'refresh_inventory'));
+    const r = await partitionClaimable(tx(), device, [row()]);
+    expect(r.cancelled).toEqual([{ id: 'c1', reason: 'trust_denied' }]);
+  });
+
+  it('a non-trust error from the trust check propagates (never silently claims)', async () => {
+    assertAllowedMock.mockRejectedValue(new Error('db down'));
+    await expect(partitionClaimable(tx(), device, [row()])).rejects.toThrow('db down');
+  });
+
+  it('cancels when the requesting user is no longer active', async () => {
+    userStatusMock.mockResolvedValue([{ status: 'disabled' }]);
+    const r = await partitionClaimable(tx(), device, [row({ createdBy: USER })]);
+    expect(r.cancelled).toEqual([{ id: 'c1', reason: 'requester_inactive' }]);
+  });
+
+  it('cancels when the requesting user row is gone entirely', async () => {
+    userStatusMock.mockResolvedValue([]);
+    const r = await partitionClaimable(tx(), device, [row({ createdBy: USER })]);
+    expect(r.cancelled).toEqual([{ id: 'c1', reason: 'requester_inactive' }]);
+  });
+
+  it('system-issued rows (created_by NULL) are never cancelled for an inactive requester', async () => {
+    userStatusMock.mockResolvedValue([{ status: 'disabled' }]);
+    const r = await partitionClaimable(tx(), device, [row({ createdBy: null })]);
+    expect(r.claimable).toHaveLength(1);
+    expect(userStatusMock).not.toHaveBeenCalled();
+  });
+
+  it('the requester probe is cached per user across a batch', async () => {
+    const r = await partitionClaimable(tx(), device, [
+      row({ id: 'a', createdBy: USER }),
+      row({ id: 'b', createdBy: USER }),
+      row({ id: 'c', createdBy: OTHER_USER }),
+    ]);
+    expect(r.claimable).toHaveLength(3);
+    expect(userStatusMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('power-state rows are held while other work is claimable in the same batch', async () => {
+    const r = await partitionClaimable(tx(), device, [
+      row({ id: 'a', type: 'refresh_inventory' }),
+      row({ id: 'b', type: 'reboot' }),
+    ]);
+    expect(r.claimable.map((x) => x.id)).toEqual(['a']);
+    expect(r.held).toEqual([{ id: 'b', reason: 'power_state_barrier' }]);
+  });
+
+  it('power-state rows are held while anything is already in flight', async () => {
+    const r = await partitionClaimable(tx(), device, [row({ id: 'b', type: 'reboot' })], { inFlight: 1 });
+    expect(r.claimable).toEqual([]);
+    expect(r.held).toEqual([{ id: 'b', reason: 'power_state_barrier' }]);
+  });
+
+  it('a power-state row alone with nothing in flight is claimed', async () => {
+    const r = await partitionClaimable(tx(), device, [row({ id: 'b', type: 'reboot' })], { inFlight: 0 });
+    expect(r.claimable.map((x) => x.id)).toEqual(['b']);
+    expect(r.held).toEqual([]);
+  });
+
+  it('two power-state rows: exactly one is claimed, the rest held', async () => {
+    const r = await partitionClaimable(
+      tx(),
+      device,
+      [row({ id: 'b', type: 'reboot' }), row({ id: 'c', type: 'shutdown' })],
+      { inFlight: 0 }
+    );
+    expect(r.claimable).toHaveLength(1);
+    expect(r.claimable[0]!.id).toBe('b');
+    expect(r.held).toEqual([{ id: 'c', reason: 'power_state_barrier' }]);
+  });
+
+  it('a held power-state row is never also cancelled', async () => {
+    const r = await partitionClaimable(tx(), device, [
+      row({ id: 'a', type: 'refresh_inventory' }),
+      row({ id: 'b', type: 'reboot' }),
+    ]);
+    expect(r.cancelled).toEqual([]);
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it('a cancelled power-state row does not consume the barrier slot', async () => {
+    const r = await partitionClaimable(tx(), device, [
+      row({ id: 'b', type: 'reboot', submittedOrgId: OTHER_ORG }),
+      row({ id: 'c', type: 'shutdown' }),
+    ]);
+    expect(r.cancelled).toEqual([{ id: 'b', reason: 'device_moved_org' }]);
+    expect(r.claimable.map((x) => x.id)).toEqual(['c']);
+  });
+
+  it('a registered type hold keeps the row pending without cancelling it', async () => {
+    typeHolds.install_patches = async () => true;
+    const r = await partitionClaimable(tx(), device, [row({ type: 'install_patches' })]);
+    expect(r.held).toEqual([{ id: 'c1', reason: 'held_maintenance_suppression' }]);
+    expect(r.claimable).toEqual([]);
+    expect(r.cancelled).toEqual([]);
+  });
+
+  it('a type hold that returns false lets the row through', async () => {
+    typeHolds.install_patches = async () => false;
+    const r = await partitionClaimable(tx(), device, [row({ type: 'install_patches' })]);
+    expect(r.claimable).toHaveLength(1);
+  });
+
+  it('reboot, shutdown and reboot_safe_mode are the barrier set', () => {
+    expect([...POWER_STATE_TYPES].sort()).toEqual(['reboot', 'reboot_safe_mode', 'shutdown']);
+  });
+
+  it('cancel writes are CAS-guarded on status=pending', async () => {
+    const t = tx();
+    await partitionClaimable(t, device, [row({ submittedOrgId: OTHER_ORG })]);
+    // The where() arg list is what carries the id + status='pending' fence; a
+    // cancel that landed on a row already claimed would be a lost delivery.
+    expect(whereMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/services/commandClaimEligibility.test.ts
+++ b/apps/api/src/services/commandClaimEligibility.test.ts
@@ -1,12 +1,24 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { PgDialect } from 'drizzle-orm/pg-core';
 
-const { assertAllowedMock, userStatusMock, updateMock, setMock, whereMock } = vi.hoisted(() => ({
+const {
+  assertAllowedMock,
+  userStatusMock,
+  updateMock,
+  setMock,
+  whereMock,
+  returningMock,
+  propagateMock,
+  captureExceptionMock,
+} = vi.hoisted(() => ({
   assertAllowedMock: vi.fn(),
   userStatusMock: vi.fn(),
   updateMock: vi.fn(),
   setMock: vi.fn(),
   whereMock: vi.fn(),
+  returningMock: vi.fn(),
+  propagateMock: vi.fn(),
+  captureExceptionMock: vi.fn(),
 }));
 
 vi.mock('./partnerTrust.commands', () => ({
@@ -35,9 +47,22 @@ vi.mock('../db/schema', () => ({
   users: { id: 'users.id', status: 'users.status' },
 }));
 vi.mock('./sensitiveCommandPayload', () => ({ terminalPayloadErasureSet: () => ({ payload: null }) }));
-vi.mock('./sentry', () => ({ captureException: vi.fn() }));
+vi.mock('./sentry', () => ({ captureException: (...a: unknown[]) => captureExceptionMock(...(a as [])) }));
+// #5128 review round 2 — the claim-time cancel must terminalise the OWNING
+// record (script_executions / deployment_results) inside the SAME transaction.
+// Mocked at the seam so this suite can assert exactly which rows reach it.
+vi.mock('./commandCancelPropagation', () => ({
+  propagateCancelledDeviceCommands: (...a: unknown[]) => propagateMock(...(a as [])),
+}));
 
-import { POWER_STATE_TYPES, partitionClaimable, typeHolds } from './commandClaimEligibility';
+import {
+  POWER_STATE_BARRIER_TYPES,
+  partitionClaimable,
+  registerTypeHold,
+  typeHolds,
+  __resetEligibilityFaultThrottleForTests,
+  __resetTypeHoldsForTests,
+} from './commandClaimEligibility';
 
 const ORG = '22222222-2222-4222-8222-222222222222';
 const OTHER_ORG = '33333333-3333-4333-8333-333333333333';
@@ -52,11 +77,18 @@ const row = (over: Partial<Row> = {}): Row => ({
   createdBy: null,
   submittedOrgId: ORG,
   deliverBy: null,
+  payload: null,
   ...over,
 });
 
+/**
+ * The cancel UPDATE now ends in `.returning({ id })` — only a row the CAS
+ * actually flipped may be propagated. `returningMock` therefore decides, per
+ * call, whether that row "won"; the default says every cancel won.
+ */
 function tx() {
-  whereMock.mockResolvedValue([]);
+  returningMock.mockResolvedValue([{ id: 'flipped' }]);
+  whereMock.mockReturnValue({ returning: (...a: unknown[]) => returningMock(...(a as [])) });
   setMock.mockReturnValue({ where: (...a: unknown[]) => whereMock(...(a as [])) });
   updateMock.mockReturnValue({ set: (...a: unknown[]) => setMock(...(a as [])) });
   return {
@@ -70,7 +102,8 @@ describe('partitionClaimable (#5128 W1 §G)', () => {
     vi.resetAllMocks();
     assertAllowedMock.mockResolvedValue(undefined);
     userStatusMock.mockResolvedValue([{ status: 'active' }]);
-    for (const key of Object.keys(typeHolds)) delete typeHolds[key];
+    __resetTypeHoldsForTests();
+    __resetEligibilityFaultThrottleForTests();
   });
 
   it('passes an ordinary row through and writes nothing', async () => {
@@ -244,7 +277,7 @@ describe('partitionClaimable (#5128 W1 §G)', () => {
   });
 
   it('reboot, shutdown and reboot_safe_mode are the barrier set', () => {
-    expect([...POWER_STATE_TYPES].sort()).toEqual(['reboot', 'reboot_safe_mode', 'shutdown']);
+    expect([...POWER_STATE_BARRIER_TYPES].sort()).toEqual(['reboot', 'reboot_safe_mode', 'shutdown']);
   });
 
   it('cancel writes are CAS-guarded on the id AND status=pending', async () => {
@@ -278,5 +311,136 @@ describe('partitionClaimable (#5128 W1 §G)', () => {
     ]);
     expect(r.cancelled).toEqual([{ id: 'c1', reason: 'submitter_org_erased' }]);
     expect(r.claimable).toEqual([]);
+  });
+  // ── Claim-time cancellation must terminalise the OWNING record ──────────
+  //
+  // A cancelled command is TERMINAL, so the command reaper (which scans only
+  // pending/sent) never revisits it. Without propagation the owning
+  // script_executions / deployment_results row sits `pending` forever — the
+  // exact silent death #5128 exists to remove, and the same contract the
+  // cancel-on-event sweeps (moveOrg.ts, core.ts) already honour.
+
+  it('propagates the cancel to the owning records inside the SAME transaction', async () => {
+    const t = tx();
+    await partitionClaimable(t, device, [
+      row({ id: 'c1', type: 'script', payload: { executionId: 'exec-1' }, submittedOrgId: OTHER_ORG }),
+    ]);
+
+    expect(propagateMock).toHaveBeenCalledTimes(1);
+    const [subjects, completedAt, executor] = propagateMock.mock.calls[0]!;
+    expect(subjects).toEqual([{ id: 'c1', type: 'script', payload: { executionId: 'exec-1' } }]);
+    expect(completedAt).toBeInstanceOf(Date);
+    // The transaction handle, not the ambient db: a rollback of the claim must
+    // roll the owning record back with it.
+    expect(executor).toBe(t);
+  });
+
+  it('a row whose CAS matched nothing is NOT propagated', async () => {
+    // The row lost the race to a concurrent claim, so it is being DELIVERED.
+    // Cancelling its script execution would terminalise work about to run on
+    // the machine.
+    const t = tx();
+    // The second cancel's CAS matches zero rows.
+    returningMock.mockReset();
+    returningMock.mockResolvedValueOnce([{ id: 'won' }]).mockResolvedValueOnce([]);
+
+    await partitionClaimable(t, device, [
+      row({ id: 'won', type: 'script', payload: { executionId: 'exec-won' }, submittedOrgId: OTHER_ORG }),
+      row({ id: 'lost', type: 'script', payload: { executionId: 'exec-lost' }, submittedOrgId: OTHER_ORG }),
+    ]);
+
+    expect(updateMock).toHaveBeenCalledTimes(2);
+    expect(propagateMock).toHaveBeenCalledTimes(1);
+    expect(propagateMock.mock.calls[0]![0]).toEqual([
+      { id: 'won', type: 'script', payload: { executionId: 'exec-won' } },
+    ]);
+  });
+
+  it('nothing cancelled → the propagator is never called', async () => {
+    await partitionClaimable(tx(), device, [row()]);
+    expect(propagateMock).not.toHaveBeenCalled();
+  });
+
+  it('a non-object payload reaches the propagator as null rather than crashing it', async () => {
+    await partitionClaimable(tx(), device, [
+      row({ id: 'c1', type: 'script', payload: 'not-an-object', submittedOrgId: OTHER_ORG }),
+    ]);
+    expect(propagateMock.mock.calls[0]![0]).toEqual([{ id: 'c1', type: 'script', payload: null }]);
+  });
+
+  // ── Uninstall drain exemption ───────────────────────────────────────────
+
+  it('a queued self_uninstall survives an inactive requester', async () => {
+    // Remove-with-uninstall is routinely queued by a tech who leaves before the
+    // machine next checks in. Cancelling it here leaves the agent installed on
+    // a customer box the MSP has decided to stop managing — the same drain
+    // core.ts protects with its ne(type,'self_uninstall') exclusion.
+    userStatusMock.mockResolvedValue([{ status: 'disabled' }]);
+    const r = await partitionClaimable(tx(), device, [
+      row({ id: 'u', type: 'self_uninstall', createdBy: USER }),
+      row({ id: 'other', createdBy: USER }),
+    ]);
+    expect(r.claimable.map((x) => x.id)).toEqual(['u']);
+    expect(r.cancelled).toEqual([{ id: 'other', reason: 'requester_inactive' }]);
+  });
+
+  it('a self_uninstall survives EVERY cancel at once: decommissioned + trust-denied + inactive tech + org drift', async () => {
+    // #3986 regression (caught by deviceUninstallDrain.integration.test.ts):
+    // every one of these checks asks "should this device still work for this
+    // tenant?", and for a removal the answer is always yes. The drain has its
+    // own deadline (device_remove_expires_at) and its own auth gate
+    // (agentAuth's drain window); cancelling it strands an agent on a machine
+    // the MSP has stopped managing.
+    const { TrustDeniedError } = await import('./partnerTrust.commands');
+    assertAllowedMock.mockRejectedValue(
+      new TrustDeniedError('TRUST_RESTRICTED', 'suspended', 'd1', 'self_uninstall'),
+    );
+    userStatusMock.mockResolvedValue([{ status: 'disabled' }]);
+
+    const r = await partitionClaimable(tx(), { ...device, status: 'decommissioned' }, [
+      row({
+        id: 'u',
+        type: 'self_uninstall',
+        createdBy: USER,
+        submittedOrgId: OTHER_ORG,
+        deliverBy: new Date(Date.now() + 3600_000),
+      }),
+    ]);
+
+    expect(r.claimable.map((x) => x.id)).toEqual(['u']);
+    expect(r.cancelled).toEqual([]);
+    expect(r.held).toEqual([]);
+    expect(updateMock).not.toHaveBeenCalled();
+    // The trust check is not even consulted — the drain short-circuits first.
+    expect(assertAllowedMock).not.toHaveBeenCalled();
+  });
+
+  // ── Registry guard + Sentry throttle ────────────────────────────────────
+
+  it('registerTypeHold refuses to overwrite an existing hold', () => {
+    registerTypeHold('install_patches', async () => true);
+    expect(() => registerTypeHold('install_patches', async () => false)).toThrow(
+      /already registered for "install_patches"/,
+    );
+    expect(typeHolds.install_patches).toBeDefined();
+  });
+
+  it('the eligibility-fault Sentry capture is throttled per device, but the log is not', async () => {
+    // One partner-trust outage would otherwise emit one event per row per
+    // heartbeat per device.
+    assertAllowedMock.mockRejectedValue(new Error('db down'));
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      await partitionClaimable(tx(), device, [row({ id: 'a' }), row({ id: 'b' })]);
+      await partitionClaimable(tx(), device, [row({ id: 'c' })]);
+      expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+      expect(errorSpy).toHaveBeenCalledTimes(3);
+
+      // A DIFFERENT device is a different fault surface and still reports.
+      await partitionClaimable(tx(), { ...device, id: 'd2' }, [row({ id: 'd' })]);
+      expect(captureExceptionMock).toHaveBeenCalledTimes(2);
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 });

--- a/apps/api/src/services/commandClaimEligibility.test.ts
+++ b/apps/api/src/services/commandClaimEligibility.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PgDialect } from 'drizzle-orm/pg-core';
 
 const { assertAllowedMock, userStatusMock, updateMock, setMock, whereMock } = vi.hoisted(() => ({
   assertAllowedMock: vi.fn(),
@@ -34,6 +35,7 @@ vi.mock('../db/schema', () => ({
   users: { id: 'users.id', status: 'users.status' },
 }));
 vi.mock('./sensitiveCommandPayload', () => ({ terminalPayloadErasureSet: () => ({ payload: null }) }));
+vi.mock('./sentry', () => ({ captureException: vi.fn() }));
 
 import { POWER_STATE_TYPES, partitionClaimable, typeHolds } from './commandClaimEligibility';
 
@@ -128,9 +130,23 @@ describe('partitionClaimable (#5128 W1 §G)', () => {
     expect(r.cancelled).toEqual([{ id: 'c1', reason: 'trust_denied' }]);
   });
 
-  it('a non-trust error from the trust check propagates (never silently claims)', async () => {
+  it('a non-trust error from the trust check HOLDS the row — never claims it, never poisons the heartbeat', async () => {
+    // This runs inside the heartbeat's claim transaction. Rethrowing would 500
+    // the heartbeat, and since the row stays pending it would be re-selected on
+    // every retry — one deterministic fault would stop the device checking in
+    // at all. Fail-closed (not delivered) without that blast radius.
     assertAllowedMock.mockRejectedValue(new Error('db down'));
-    await expect(partitionClaimable(tx(), device, [row()])).rejects.toThrow('db down');
+    const r = await partitionClaimable(tx(), device, [row()]);
+    expect(r.claimable).toEqual([]);
+    expect(r.cancelled).toEqual([]);
+    expect(r.held).toEqual([{ id: 'c1', reason: 'eligibility_check_failed' }]);
+  });
+
+  it('a trust-check fault on one row does not withhold its healthy siblings', async () => {
+    assertAllowedMock.mockRejectedValueOnce(new Error('db down')).mockResolvedValue(undefined);
+    const r = await partitionClaimable(tx(), device, [row({ id: 'bad' }), row({ id: 'good' })]);
+    expect(r.held).toEqual([{ id: 'bad', reason: 'eligibility_check_failed' }]);
+    expect(r.claimable.map((x) => x.id)).toEqual(['good']);
   });
 
   it('cancels when the requesting user is no longer active', async () => {
@@ -231,11 +247,36 @@ describe('partitionClaimable (#5128 W1 §G)', () => {
     expect([...POWER_STATE_TYPES].sort()).toEqual(['reboot', 'reboot_safe_mode', 'shutdown']);
   });
 
-  it('cancel writes are CAS-guarded on status=pending', async () => {
+  it('cancel writes are CAS-guarded on the id AND status=pending', async () => {
     const t = tx();
     await partitionClaimable(t, device, [row({ submittedOrgId: OTHER_ORG })]);
-    // The where() arg list is what carries the id + status='pending' fence; a
-    // cancel that landed on a row already claimed would be a lost delivery.
     expect(whereMock).toHaveBeenCalledTimes(1);
+
+    // Compile the ACTUAL predicate rather than asserting the spy was called:
+    // the mocked columns are plain strings, so they render as bound params and
+    // the exact fence is checkable. Without this, dropping
+    // `eq(status,'pending')` from the cancel would leave this test green while
+    // production cancelled rows the agent had already claimed — a lost delivery.
+    const { sql: sqlText, params } = new PgDialect().sqlToQuery(whereMock.mock.calls[0]![0] as never);
+    expect(params).toEqual(['dc.id', 'c1', 'dc.status', 'pending']);
+    expect(sqlText).toContain('and');
+  });
+
+  it('a legacy row (deliver_by NULL) with no submitted_org_id is still delivered', async () => {
+    const r = await partitionClaimable(tx(), device, [row({ submittedOrgId: null, deliverBy: null })]);
+    expect(r.claimable).toHaveLength(1);
+    expect(r.cancelled).toEqual([]);
+  });
+
+  it('a post-#5128 row whose submitted_org_id went NULL is refused, not delivered', async () => {
+    // `deliver_by` set means the enqueue path stamped `submitted_org_id`; a NULL
+    // can then only come from the FK's ON DELETE SET NULL, i.e. the originating
+    // org was erased. Delivering it would silently pass the org check by
+    // destroying the fact it compares against (the org-merge-then-erase path).
+    const r = await partitionClaimable(tx(), device, [
+      row({ submittedOrgId: null, deliverBy: new Date(Date.now() + 3600_000) }),
+    ]);
+    expect(r.cancelled).toEqual([{ id: 'c1', reason: 'submitter_org_erased' }]);
+    expect(r.claimable).toEqual([]);
   });
 });

--- a/apps/api/src/services/commandClaimEligibility.ts
+++ b/apps/api/src/services/commandClaimEligibility.ts
@@ -2,6 +2,7 @@ import { and, eq } from 'drizzle-orm';
 import type { db } from '../db';
 import { deviceCommands, users } from '../db/schema';
 import { assertDeviceExecuteAllowed, TrustDeniedError } from './partnerTrust.commands';
+import { captureException } from './sentry';
 import { terminalPayloadErasureSet } from './sensitiveCommandPayload';
 
 type Tx = Parameters<Parameters<typeof db.transaction>[0]>[0];
@@ -11,8 +12,10 @@ export type ClaimCancelReason =
   | 'device_lifecycle'
   | 'trust_denied'
   | 'requester_inactive'
+  | 'submitter_org_erased'
   | 'held_maintenance_suppression'
-  | 'power_state_barrier';
+  | 'power_state_barrier'
+  | 'eligibility_check_failed';
 
 /**
  * The device facts claim-time eligibility needs. Deliberately NOT carrying a
@@ -72,8 +75,19 @@ export const typeHolds: Record<string, (deviceId: string) => Promise<boolean>> =
  * authorization and targeting facts that were true at request time have to be
  * re-checked at delivery. Cancels are written INSIDE the caller's claim
  * transaction, so a row this function cancels can never be delivered by a
- * concurrent claim — and the device row lock the claim already holds
- * (`FOR UPDATE`) is what serialises an in-flight org move against this check.
+ * concurrent claim.
+ *
+ * KNOWN RESIDUAL — this does NOT serialise against a concurrent org move. The
+ * claim reads `devices` without `FOR UPDATE` (deliberately: taking a row-
+ * exclusive lock on the device on every heartbeat would serialise the hottest
+ * path in the product against every other write to that row). So a move that
+ * commits between this read and the claim's status flip can leave one command
+ * delivered just after the device changed org — the move's own pending-row
+ * sweep then misses it because the row is already `sent`. Closing this needs
+ * the claim to lock `devices` before `device_commands` (matching org-move's
+ * order, since the reverse would deadlock); deferred rather than risking
+ * heartbeat contention here. The window is a few milliseconds and the blast
+ * radius is one command inside the same partner.
  *
  * `held` rows are left `pending` and untouched; `cancelled` rows are terminal
  * with their payload erased.
@@ -95,12 +109,26 @@ export async function partitionClaimable(
   const requesterActive = new Map<string, boolean>();
 
   for (const row of rows) {
-    // Legacy rows predate `submitted_org_id`; a NULL means "no recorded org",
-    // which is not evidence of a move and must not cancel the row. `undefined`
-    // is treated the same way — an absent value is not a mismatch.
     const submittedOrgId = row.submittedOrgId ?? null;
     if (submittedOrgId !== null && submittedOrgId !== device.orgId) {
       cancelled.push({ id: row.id, reason: 'device_moved_org' });
+      continue;
+    }
+    // A NULL `submitted_org_id` means one of two very different things, and the
+    // deadline tells them apart:
+    //
+    //  - `deliver_by IS NULL`  -> a LEGACY row, written before #5128 added the
+    //    column. No recorded org is not evidence of a move; deliver it.
+    //  - `deliver_by IS NOT NULL` -> a post-#5128 row. Every enqueue path stamps
+    //    `submitted_org_id` from the device's org, so a NULL here can only have
+    //    come from the FK's ON DELETE SET NULL — i.e. THE ORIGINATING ORG WAS
+    //    DELETED. That erases the very fact the org check compares against, so
+    //    the check would silently pass. Refuse instead: this is the residual
+    //    the org-merge path leaves behind (the loser org survives as a shell,
+    //    is later erased, and the row's provenance goes NULL underneath a
+    //    device that has since been repointed to the surviving org).
+    if (submittedOrgId === null && row.deliverBy !== null && row.deliverBy !== undefined) {
+      cancelled.push({ id: row.id, reason: 'submitter_org_erased' });
       continue;
     }
 
@@ -116,8 +144,27 @@ export async function partitionClaimable(
         cancelled.push({ id: row.id, reason: 'trust_denied' });
         continue;
       }
-      // A transient failure of the trust check must NOT be read as "allowed".
-      throw e;
+      // A failure of the trust check must NEVER be read as "allowed" — but it
+      // must not take the heartbeat down with it either. This runs inside the
+      // claim transaction of `claimPendingCommandsForDevice`, which the agent
+      // heartbeat awaits; rethrowing aborts that transaction and 500s the
+      // heartbeat, and because the row stays `pending` it is re-selected on
+      // every subsequent heartbeat — turning one deterministic fault into a
+      // device that can never check in again. HOLD the row instead: not
+      // delivered (fail-closed), not cancelled (recoverable), and the rest of
+      // the batch still goes out.
+      console.error(
+        '[commandClaimEligibility] trust check failed; holding the command rather than delivering or cancelling it',
+        {
+          commandId: row.id,
+          deviceId: device.id,
+          type: row.type,
+          error: e instanceof Error ? e.message : String(e),
+        },
+      );
+      captureException(e instanceof Error ? e : new Error(String(e)));
+      held.push({ id: row.id, reason: 'eligibility_check_failed' });
+      continue;
     }
 
     if (row.createdBy) {

--- a/apps/api/src/services/commandClaimEligibility.ts
+++ b/apps/api/src/services/commandClaimEligibility.ts
@@ -1,0 +1,182 @@
+import { and, eq } from 'drizzle-orm';
+import type { db } from '../db';
+import { deviceCommands, users } from '../db/schema';
+import { assertDeviceExecuteAllowed, TrustDeniedError } from './partnerTrust.commands';
+import { terminalPayloadErasureSet } from './sensitiveCommandPayload';
+
+type Tx = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+export type ClaimCancelReason =
+  | 'device_moved_org'
+  | 'device_lifecycle'
+  | 'trust_denied'
+  | 'requester_inactive'
+  | 'held_maintenance_suppression'
+  | 'power_state_barrier';
+
+/**
+ * The device facts claim-time eligibility needs. Deliberately NOT carrying a
+ * partner id: `devices` has no `partner_id` column (partner ownership is
+ * resolved through the org), and `assertDeviceExecuteAllowed` does that
+ * resolution itself.
+ */
+export type ClaimEligibilityDevice = {
+  id: string;
+  orgId: string;
+  status: string;
+};
+
+export type ClaimCandidate = {
+  id: string;
+  type: string;
+  createdBy: string | null;
+  submittedOrgId: string | null;
+  deliverBy: Date | null;
+};
+
+export type ClaimPartition = {
+  claimable: ClaimCandidate[];
+  cancelled: Array<{ id: string; reason: ClaimCancelReason }>;
+  held: Array<{ id: string; reason: ClaimCancelReason }>;
+};
+
+/**
+ * Disruptive power-state changes. Claimed alone and only when nothing else is
+ * in flight (#5128 §E.4): the agent runs non-interactive commands concurrently
+ * (heartbeat worker pool, per-command goroutines), so FIFO order alone cannot
+ * stop a queued reboot from landing in the middle of a script.
+ *
+ * `schedule_reboot` is deliberately NOT here — it only asks the agent to
+ * schedule a restart (with its own delay and user deferral), so it does not
+ * need to be serialised against other work.
+ */
+export const POWER_STATE_TYPES: ReadonlySet<string> = new Set(['reboot', 'shutdown', 'reboot_safe_mode']);
+
+/** Types exempt from lifecycle cancellation: the uninstall drain must still deliver. */
+const LIFECYCLE_EXEMPT: ReadonlySet<string> = new Set(['self_uninstall']);
+
+/** Device states in which ordinary queued work must never be delivered. */
+const NON_DELIVERABLE_LIFECYCLE: ReadonlySet<string> = new Set(['decommissioned', 'quarantined']);
+
+/**
+ * Per-type "hold" predicates: `true` = leave the row `pending` this heartbeat
+ * and re-evaluate on the next one. W3 registers `install_patches` here so an
+ * install is not delivered inside an active `suppressPatching` window.
+ */
+export const typeHolds: Record<string, (deviceId: string) => Promise<boolean>> = {};
+
+/**
+ * Splits claim candidates into claimable / cancelled / held (#5128 §G).
+ *
+ * A queued command may be claimed days after it was requested, so the
+ * authorization and targeting facts that were true at request time have to be
+ * re-checked at delivery. Cancels are written INSIDE the caller's claim
+ * transaction, so a row this function cancels can never be delivered by a
+ * concurrent claim — and the device row lock the claim already holds
+ * (`FOR UPDATE`) is what serialises an in-flight org move against this check.
+ *
+ * `held` rows are left `pending` and untouched; `cancelled` rows are terminal
+ * with their payload erased.
+ *
+ * NOT re-checked in v1 (OD-4, deferred to W6 behind #3985): full rehydration of
+ * the requester's current org/site/action permissions, and script edit/delete
+ * (the payload is an immutable snapshot — editing a script must never
+ * substitute the code a queued run will execute).
+ */
+export async function partitionClaimable(
+  tx: Tx,
+  device: ClaimEligibilityDevice,
+  rows: ClaimCandidate[],
+  opts: { inFlight?: number } = {},
+): Promise<ClaimPartition> {
+  const claimable: ClaimCandidate[] = [];
+  const cancelled: Array<{ id: string; reason: ClaimCancelReason }> = [];
+  const held: Array<{ id: string; reason: ClaimCancelReason }> = [];
+  const requesterActive = new Map<string, boolean>();
+
+  for (const row of rows) {
+    // Legacy rows predate `submitted_org_id`; a NULL means "no recorded org",
+    // which is not evidence of a move and must not cancel the row. `undefined`
+    // is treated the same way — an absent value is not a mismatch.
+    const submittedOrgId = row.submittedOrgId ?? null;
+    if (submittedOrgId !== null && submittedOrgId !== device.orgId) {
+      cancelled.push({ id: row.id, reason: 'device_moved_org' });
+      continue;
+    }
+
+    if (NON_DELIVERABLE_LIFECYCLE.has(device.status) && !LIFECYCLE_EXEMPT.has(row.type)) {
+      cancelled.push({ id: row.id, reason: 'device_lifecycle' });
+      continue;
+    }
+
+    try {
+      await assertDeviceExecuteAllowed(device.id, row.type, row.createdBy ?? undefined);
+    } catch (e) {
+      if (e instanceof TrustDeniedError) {
+        cancelled.push({ id: row.id, reason: 'trust_denied' });
+        continue;
+      }
+      // A transient failure of the trust check must NOT be read as "allowed".
+      throw e;
+    }
+
+    if (row.createdBy) {
+      let active = requesterActive.get(row.createdBy);
+      if (active === undefined) {
+        const [u] = await tx
+          .select({ status: users.status })
+          .from(users)
+          .where(eq(users.id, row.createdBy))
+          .limit(1);
+        active = u?.status === 'active';
+        requesterActive.set(row.createdBy, active);
+      }
+      if (!active) {
+        cancelled.push({ id: row.id, reason: 'requester_inactive' });
+        continue;
+      }
+    }
+
+    const hold = typeHolds[row.type];
+    if (hold && (await hold(device.id))) {
+      held.push({ id: row.id, reason: 'held_maintenance_suppression' });
+      continue;
+    }
+
+    claimable.push(row);
+  }
+
+  // Power-state barrier. Runs over the SURVIVORS only, so a reboot that was
+  // cancelled above never consumes the single slot.
+  const power = claimable.filter((r) => POWER_STATE_TYPES.has(r.type));
+  if (power.length > 0) {
+    const others = claimable.filter((r) => !POWER_STATE_TYPES.has(r.type));
+    const inFlight = opts.inFlight ?? 0;
+    if (others.length > 0 || inFlight > 0) {
+      for (const p of power) held.push({ id: p.id, reason: 'power_state_barrier' });
+      claimable.splice(0, claimable.length, ...others);
+    } else {
+      claimable.splice(0, claimable.length, power[0]!);
+      for (const p of power.slice(1)) held.push({ id: p.id, reason: 'power_state_barrier' });
+    }
+  }
+
+  if (cancelled.length > 0) {
+    const completedAt = new Date();
+    for (const c of cancelled) {
+      await tx
+        .update(deviceCommands)
+        .set({
+          status: 'cancelled',
+          completedAt,
+          result: { status: 'cancelled', reason: c.reason, cancelledBy: 'claim_eligibility' },
+          ...terminalPayloadErasureSet(),
+        })
+        // CAS on `pending`: a row that was claimed between the SELECT and here
+        // must not be terminalised out from under its delivery.
+        .where(and(eq(deviceCommands.id, c.id), eq(deviceCommands.status, 'pending')));
+    }
+  }
+
+  return { claimable, cancelled, held };
+}

--- a/apps/api/src/services/commandClaimEligibility.ts
+++ b/apps/api/src/services/commandClaimEligibility.ts
@@ -1,18 +1,31 @@
 import { and, eq } from 'drizzle-orm';
 import type { db } from '../db';
 import { deviceCommands, users } from '../db/schema';
+import {
+  propagateCancelledDeviceCommands,
+  type DeviceCommandCancelSubject,
+} from './commandCancelPropagation';
 import { assertDeviceExecuteAllowed, TrustDeniedError } from './partnerTrust.commands';
 import { captureException } from './sentry';
 import { terminalPayloadErasureSet } from './sensitiveCommandPayload';
 
 type Tx = Parameters<Parameters<typeof db.transaction>[0]>[0];
 
+/**
+ * Why a claim candidate was TERMINALISED. Deliberately a separate union from
+ * `ClaimHoldReason`: a cancel writes a terminal row and erases its payload, a
+ * hold leaves the row `pending` for the next heartbeat. Mixing them in one type
+ * let a hold reason typecheck its way into `ClaimPartition.cancelled`.
+ */
 export type ClaimCancelReason =
   | 'device_moved_org'
   | 'device_lifecycle'
   | 'trust_denied'
   | 'requester_inactive'
-  | 'submitter_org_erased'
+  | 'submitter_org_erased';
+
+/** Why a claim candidate was withheld this heartbeat but left `pending`. */
+export type ClaimHoldReason =
   | 'held_maintenance_suppression'
   | 'power_state_barrier'
   | 'eligibility_check_failed';
@@ -35,12 +48,20 @@ export type ClaimCandidate = {
   createdBy: string | null;
   submittedOrgId: string | null;
   deliverBy: Date | null;
+  /**
+   * Needed to terminalise the OWNING record when this row is cancelled here
+   * (the `script_executions` id lives in `payload.executionId`). The caller
+   * (`claimPendingCommandsForDevice`) selects whole `device_commands` rows, so
+   * it is always present at runtime — `unknown` because that is what the jsonb
+   * column's Drizzle type is; it is narrowed at the one place it is read.
+   */
+  payload: unknown;
 };
 
 export type ClaimPartition = {
   claimable: ClaimCandidate[];
   cancelled: Array<{ id: string; reason: ClaimCancelReason }>;
-  held: Array<{ id: string; reason: ClaimCancelReason }>;
+  held: Array<{ id: string; reason: ClaimHoldReason }>;
 };
 
 /**
@@ -53,10 +74,28 @@ export type ClaimPartition = {
  * schedule a restart (with its own delay and user deferral), so it does not
  * need to be serialised against other work.
  */
-export const POWER_STATE_TYPES: ReadonlySet<string> = new Set(['reboot', 'shutdown', 'reboot_safe_mode']);
+export const POWER_STATE_BARRIER_TYPES: ReadonlySet<string> = new Set(['reboot', 'shutdown', 'reboot_safe_mode']);
 
-/** Types exempt from lifecycle cancellation: the uninstall drain must still deliver. */
-const LIFECYCLE_EXEMPT: ReadonlySet<string> = new Set(['self_uninstall']);
+/**
+ * Types the UNINSTALL DRAIN owns. Exempt from EVERY claim-time eligibility
+ * cancel — lifecycle, partner trust, requester-active and org drift alike.
+ *
+ * Each of those checks answers "should this device still be asked to do work
+ * for this tenant?", and for a removal the answer is always yes: the whole
+ * point is to stop managing the machine. A Remove-with-uninstall is queued
+ * against a device that is about to be (or already is) `decommissioned`, by a
+ * tech who is frequently deactivated before the machine next checks in, and
+ * often as part of the same offboarding that moves or erases the org. Cancel it
+ * for any of those and the agent stays installed on a customer's box forever
+ * (#3986; regression caught by deviceUninstallDrain.integration.test.ts).
+ *
+ * The drain is not unguarded: it carries its own deadline
+ * (`device_remove_expires_at`, enforced by the reaper) and its own auth gate
+ * (`agentAuth`'s 30-minute drain window). The only claim-time rules that still
+ * apply to it are the caller's `deliver_by` predicate and the power-state
+ * barrier — neither of which can strand it.
+ */
+const DRAIN_EXEMPT_TYPES: ReadonlySet<string> = new Set(['self_uninstall']);
 
 /** Device states in which ordinary queued work must never be delivered. */
 const NON_DELIVERABLE_LIFECYCLE: ReadonlySet<string> = new Set(['decommissioned', 'quarantined']);
@@ -66,7 +105,48 @@ const NON_DELIVERABLE_LIFECYCLE: ReadonlySet<string> = new Set(['decommissioned'
  * and re-evaluate on the next one. W3 registers `install_patches` here so an
  * install is not delivered inside an active `suppressPatching` window.
  */
-export const typeHolds: Record<string, (deviceId: string) => Promise<boolean>> = {};
+export type TypeHold = (deviceId: string) => Promise<boolean>;
+
+export const typeHolds: Record<string, TypeHold> = {};
+
+/**
+ * Register a per-type hold. Refuses to overwrite: two modules silently
+ * competing for one command type is how a suppression window stops being
+ * applied — the last import order wins and nothing reports it.
+ */
+export function registerTypeHold(type: string, hold: TypeHold): void {
+  if (typeHolds[type]) {
+    throw new Error(`A claim-time hold is already registered for "${type}"`);
+  }
+  typeHolds[type] = hold;
+}
+
+/** Test-only: drop every registered hold so a suite can install its own. */
+export function __resetTypeHoldsForTests(): void {
+  for (const key of Object.keys(typeHolds)) delete typeHolds[key];
+}
+
+/**
+ * #5128 review round 2 (N) — the eligibility-fault capture below runs per ROW,
+ * per heartbeat, per device. A partner-trust outage would turn one fault into
+ * thousands of identical Sentry events per minute. Throttled per device;
+ * `console.error` is deliberately NOT throttled, since the logs are where the
+ * per-row detail belongs.
+ */
+const ELIGIBILITY_FAULT_REPORT_WINDOW_MS = 10 * 60 * 1000;
+const eligibilityFaultLastReported = new Map<string, number>();
+
+function shouldReportEligibilityFault(deviceId: string, now: number): boolean {
+  const last = eligibilityFaultLastReported.get(deviceId);
+  if (last !== undefined && now - last < ELIGIBILITY_FAULT_REPORT_WINDOW_MS) return false;
+  eligibilityFaultLastReported.set(deviceId, now);
+  return true;
+}
+
+/** Test-only: clear the per-device Sentry throttle. */
+export function __resetEligibilityFaultThrottleForTests(): void {
+  eligibilityFaultLastReported.clear();
+}
 
 /**
  * Splits claim candidates into claimable / cancelled / held (#5128 §G).
@@ -105,10 +185,16 @@ export async function partitionClaimable(
 ): Promise<ClaimPartition> {
   const claimable: ClaimCandidate[] = [];
   const cancelled: Array<{ id: string; reason: ClaimCancelReason }> = [];
-  const held: Array<{ id: string; reason: ClaimCancelReason }> = [];
+  const held: Array<{ id: string; reason: ClaimHoldReason }> = [];
   const requesterActive = new Map<string, boolean>();
 
   for (const row of rows) {
+    // Checked FIRST, ahead of every cancel: see DRAIN_EXEMPT_TYPES above.
+    if (DRAIN_EXEMPT_TYPES.has(row.type)) {
+      claimable.push(row);
+      continue;
+    }
+
     const submittedOrgId = row.submittedOrgId ?? null;
     if (submittedOrgId !== null && submittedOrgId !== device.orgId) {
       cancelled.push({ id: row.id, reason: 'device_moved_org' });
@@ -132,7 +218,7 @@ export async function partitionClaimable(
       continue;
     }
 
-    if (NON_DELIVERABLE_LIFECYCLE.has(device.status) && !LIFECYCLE_EXEMPT.has(row.type)) {
+    if (NON_DELIVERABLE_LIFECYCLE.has(device.status)) {
       cancelled.push({ id: row.id, reason: 'device_lifecycle' });
       continue;
     }
@@ -162,7 +248,9 @@ export async function partitionClaimable(
           error: e instanceof Error ? e.message : String(e),
         },
       );
-      captureException(e instanceof Error ? e : new Error(String(e)));
+      if (shouldReportEligibilityFault(device.id, Date.now())) {
+        captureException(e instanceof Error ? e : new Error(String(e)));
+      }
       held.push({ id: row.id, reason: 'eligibility_check_failed' });
       continue;
     }
@@ -195,9 +283,9 @@ export async function partitionClaimable(
 
   // Power-state barrier. Runs over the SURVIVORS only, so a reboot that was
   // cancelled above never consumes the single slot.
-  const power = claimable.filter((r) => POWER_STATE_TYPES.has(r.type));
+  const power = claimable.filter((r) => POWER_STATE_BARRIER_TYPES.has(r.type));
   if (power.length > 0) {
-    const others = claimable.filter((r) => !POWER_STATE_TYPES.has(r.type));
+    const others = claimable.filter((r) => !POWER_STATE_BARRIER_TYPES.has(r.type));
     const inFlight = opts.inFlight ?? 0;
     if (others.length > 0 || inFlight > 0) {
       for (const p of power) held.push({ id: p.id, reason: 'power_state_barrier' });
@@ -210,8 +298,10 @@ export async function partitionClaimable(
 
   if (cancelled.length > 0) {
     const completedAt = new Date();
+    const byId = new Map(rows.map((r) => [r.id, r]));
+    const flipped: DeviceCommandCancelSubject[] = [];
     for (const c of cancelled) {
-      await tx
+      const [updated] = await tx
         .update(deviceCommands)
         .set({
           status: 'cancelled',
@@ -221,7 +311,28 @@ export async function partitionClaimable(
         })
         // CAS on `pending`: a row that was claimed between the SELECT and here
         // must not be terminalised out from under its delivery.
-        .where(and(eq(deviceCommands.id, c.id), eq(deviceCommands.status, 'pending')));
+        .where(and(eq(deviceCommands.id, c.id), eq(deviceCommands.status, 'pending')))
+        .returning({ id: deviceCommands.id });
+      // Only a row this UPDATE actually flipped is ours to propagate. A row
+      // that lost the CAS is being DELIVERED by a concurrent claim — cancelling
+      // its script_executions / deployment_results row would terminalise work
+      // that is about to run on the machine.
+      if (!updated) continue;
+      const source = byId.get(c.id);
+      if (!source) continue;
+      const payload =
+        source.payload && typeof source.payload === 'object' && !Array.isArray(source.payload)
+          ? (source.payload as Record<string, unknown>)
+          : null;
+      flipped.push({ id: c.id, type: source.type, payload });
+    }
+    // Terminalise the OWNING records too, in this same transaction. Without
+    // this a cancelled command leaves its script_executions / deployment_results
+    // row `pending` forever: the command reaper only scans `pending`/`sent`
+    // commands, so nothing would ever revisit it. Same contract as the
+    // cancel-on-event sweeps (routes/devices/moveOrg.ts, core.ts).
+    if (flipped.length > 0) {
+      await propagateCancelledDeviceCommands(flipped, completedAt, tx);
     }
   }
 

--- a/apps/api/src/services/commandDelivery.test.ts
+++ b/apps/api/src/services/commandDelivery.test.ts
@@ -22,7 +22,12 @@ vi.mock('./scriptSecretDelivery', () => ({
     failClaimedSecretCommandsMock(...(args as [any])),
 }));
 
-import { decryptClaimedCommandsForDelivery } from './commandDelivery';
+import {
+  decryptClaimedCommandsForDelivery,
+  deliveryRefreshers,
+  prepareClaimedCommandsForDelivery,
+  refreshPayloadForDelivery,
+} from './commandDelivery';
 import { encryptSensitivePayloadFields } from './sensitiveCommandPayload';
 
 const CLAIM_DEVICE = '99999999-9999-4999-8999-999999999999';
@@ -143,8 +148,12 @@ describe('decryptClaimedCommandsForDelivery (#2414)', () => {
 
       expect(failClaimedSecretCommandsMock).toHaveBeenCalledTimes(1);
       // Called with the RAW claimed rows — still sealed, never the decrypted
-      // ones (the gate must never see plaintext).
-      expect(failClaimedSecretCommandsMock.mock.calls[0]![0]).toBe(claimed);
+      // ones (the gate must never see plaintext). #5128 relaxed this from
+      // reference identity to structural equality: the delivery-refresher pass
+      // now runs first and rebuilds the array (payload contents are untouched
+      // for every type without a registered refresher), so identity is no
+      // longer meaningful. What matters — sealed, not plaintext — still holds.
+      expect(failClaimedSecretCommandsMock.mock.calls[0]![0]).toStrictEqual(claimed);
       expect((claimed[1]!.payload as Record<string, unknown>).password).toBe(goodEncrypted.password);
       expect(delivered.map((cmd) => cmd.id)).toEqual(['cmd-plain', 'cmd-good']);
     });
@@ -205,5 +214,112 @@ describe('decryptClaimedCommandsForDelivery (#2414)', () => {
 
       expect(releaseClaimedCommandDeliveryMock).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('late-binding delivery preparation (#5128 §D / OD-8)', () => {
+  const original = { ...deliveryRefreshers };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    failClaimedSecretCommandsMock.mockImplementation(async (claimed: unknown[]) => claimed);
+    for (const key of Object.keys(deliveryRefreshers)) delete deliveryRefreshers[key];
+    Object.assign(deliveryRefreshers, original);
+  });
+
+  it('ships a software_install refresher out of the box, so no import order can silence it', () => {
+    // Registering by side effect from the owning feature module would deliver a
+    // stale installer URL in any process that happened not to import it.
+    expect(typeof deliveryRefreshers.software_install).toBe('function');
+  });
+
+  it('runs the per-type refresher before decrypt so time-limited fields are fresh at delivery', async () => {
+    deliveryRefreshers.software_install = async (p) => ({
+      ...p,
+      downloadUrl: 'https://fresh.example/installer',
+    });
+
+    const out = await prepareClaimedCommandsForDelivery([
+      {
+        id: 'cmd-sw',
+        type: 'software_install',
+        deviceId: CLAIM_DEVICE,
+        payload: { s3Key: 'k', downloadUrl: 'https://stale.example' },
+        executedAt: claimedAt,
+      },
+    ]);
+
+    expect(out).toHaveLength(1);
+    expect((out[0]!.payload as Record<string, unknown>).downloadUrl).toBe(
+      'https://fresh.example/installer',
+    );
+    expect(releaseClaimedCommandDeliveryMock).not.toHaveBeenCalled();
+  });
+
+  it('a refresher failure releases the row instead of delivering a stale payload', async () => {
+    deliveryRefreshers.software_install = async () => {
+      throw new Error('presign down');
+    };
+
+    const out = await prepareClaimedCommandsForDelivery([
+      {
+        id: 'cmd-sw',
+        type: 'software_install',
+        deviceId: CLAIM_DEVICE,
+        payload: { s3Key: 'k', downloadUrl: 'https://stale.example' },
+        executedAt: claimedAt,
+      },
+    ]);
+
+    expect(out).toEqual([]);
+    expect(releaseClaimedCommandDeliveryMock).toHaveBeenCalledWith('cmd-sw', claimedAt);
+  });
+
+  it('a refresher failure never sinks its siblings in the same batch', async () => {
+    deliveryRefreshers.software_install = async () => {
+      throw new Error('presign down');
+    };
+
+    const out = await prepareClaimedCommandsForDelivery([
+      { id: 'cmd-plain', type: 'script', deviceId: CLAIM_DEVICE, payload: { a: 1 }, executedAt: claimedAt },
+      { id: 'cmd-sw', type: 'software_install', deviceId: CLAIM_DEVICE, payload: {}, executedAt: claimedAt },
+    ]);
+
+    expect(out.map((cmd) => cmd.id)).toEqual(['cmd-plain']);
+  });
+
+  it('a type with no registered refresher passes through untouched', async () => {
+    const out = await prepareClaimedCommandsForDelivery([
+      { id: 'cmd-plain', type: 'script', deviceId: CLAIM_DEVICE, payload: { a: 1 }, executedAt: claimedAt },
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.payload).toEqual({ a: 1 });
+  });
+
+  it('a non-object payload is handed to the refresher as an empty object, not crashed on', async () => {
+    const seen: unknown[] = [];
+    deliveryRefreshers.software_install = async (p) => {
+      seen.push(p);
+      return p;
+    };
+
+    await prepareClaimedCommandsForDelivery([
+      { id: 'cmd-sw', type: 'software_install', deviceId: CLAIM_DEVICE, payload: null, executedAt: claimedAt },
+      { id: 'cmd-sw2', type: 'software_install', deviceId: CLAIM_DEVICE, payload: [1, 2], executedAt: claimedAt },
+    ]);
+
+    expect(seen).toEqual([{}, {}]);
+  });
+
+  it('refreshPayloadForDelivery returns null on failure so the single-push path can release', async () => {
+    deliveryRefreshers.software_install = async () => {
+      throw new Error('presign down');
+    };
+    await expect(refreshPayloadForDelivery('software_install', { s3Key: 'k' })).resolves.toBeNull();
+    await expect(refreshPayloadForDelivery('script', { a: 1 })).resolves.toEqual({ a: 1 });
+  });
+
+  it('decryptClaimedCommandsForDelivery is still exported as an alias of the new name', () => {
+    expect(decryptClaimedCommandsForDelivery).toBe(prepareClaimedCommandsForDelivery);
   });
 });

--- a/apps/api/src/services/commandDelivery.test.ts
+++ b/apps/api/src/services/commandDelivery.test.ts
@@ -39,6 +39,8 @@ import {
   deliveryRefreshers,
   prepareClaimedCommandsForDelivery,
   refreshPayloadForDelivery,
+  registerDeliveryRefresher,
+  __resetDeliveryRefreshersForTests,
 } from './commandDelivery';
 import { encryptSensitivePayloadFields } from './sensitiveCommandPayload';
 
@@ -235,8 +237,18 @@ describe('late-binding delivery preparation (#5128 §D / OD-8)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     failClaimedSecretCommandsMock.mockImplementation(async (claimed: unknown[]) => claimed);
-    for (const key of Object.keys(deliveryRefreshers)) delete deliveryRefreshers[key];
+    __resetDeliveryRefreshersForTests();
     Object.assign(deliveryRefreshers, original);
+  });
+
+  it('registerDeliveryRefresher refuses to overwrite an existing registration', () => {
+    // Two modules competing for one command type would let import order decide
+    // which payload an agent receives, and nothing would report it.
+    expect(() => registerDeliveryRefresher('software_install', async (p) => p)).toThrow(
+      /already registered for "software_install"/,
+    );
+    __resetDeliveryRefreshersForTests();
+    expect(() => registerDeliveryRefresher('software_install', async (p) => p)).not.toThrow();
   });
 
   it('ships a software_install refresher out of the box, so no import order can silence it', () => {
@@ -328,7 +340,12 @@ describe('late-binding delivery preparation (#5128 §D / OD-8)', () => {
       throw new Error('presign down');
     };
     await expect(refreshPayloadForDelivery('software_install', { s3Key: 'k' })).resolves.toBeNull();
+    // Reported, not just logged: a refresher that starts failing silently
+    // downgrades every enqueue-time push to a heartbeat wait, and nothing else
+    // on that path surfaces it.
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
     await expect(refreshPayloadForDelivery('script', { a: 1 })).resolves.toEqual({ a: 1 });
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
   });
 
   it('decryptClaimedCommandsForDelivery is still exported as an alias of the new name', () => {

--- a/apps/api/src/services/commandDelivery.test.ts
+++ b/apps/api/src/services/commandDelivery.test.ts
@@ -8,6 +8,18 @@ vi.mock('./commandDispatch', () => ({
     releaseClaimedCommandDeliveryMock(...(args as [])),
 }));
 
+// #5128: the SHIPPED software_install refresher calls into S3. Mocked at the
+// module boundary so the real refresher body (the s3Key gate, the TTL, the
+// isS3Configured() check) is exercised rather than replaced by a fake.
+const { getPresignedUrlMock, isS3ConfiguredMock } = vi.hoisted(() => ({
+  getPresignedUrlMock: vi.fn(),
+  isS3ConfiguredMock: vi.fn(() => true),
+}));
+vi.mock('./s3Storage', () => ({
+  getPresignedUrl: (...args: unknown[]) => getPresignedUrlMock(...(args as [])),
+  isS3Configured: () => isS3ConfiguredMock(),
+}));
+
 const captureExceptionMock = vi.fn();
 vi.mock('./sentry', () => ({
   captureException: (...args: unknown[]) => captureExceptionMock(...(args as [])),
@@ -321,5 +333,59 @@ describe('late-binding delivery preparation (#5128 §D / OD-8)', () => {
 
   it('decryptClaimedCommandsForDelivery is still exported as an alias of the new name', () => {
     expect(decryptClaimedCommandsForDelivery).toBe(prepareClaimedCommandsForDelivery);
+  });
+});
+
+describe('the shipped software_install delivery refresher (#5128 OD-8)', () => {
+  // Exercises the REAL refresher — the other suite replaces it with a fake, so
+  // without this, dropping the isS3Configured() gate, changing the TTL, or
+  // reading the wrong payload key would all ship undetected.
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isS3ConfiguredMock.mockReturnValue(true);
+    getPresignedUrlMock.mockResolvedValue('https://fresh.example/installer?sig=new');
+    failClaimedSecretCommandsMock.mockImplementation(async (claimed: unknown[]) => claimed);
+  });
+
+  it('re-mints the download URL from the stored s3Key with a one-hour TTL', async () => {
+    const refresher = deliveryRefreshers.software_install!;
+    const out = await refresher({ s3Key: 'installers/app.exe', downloadUrl: 'https://stale.example' });
+
+    expect(getPresignedUrlMock).toHaveBeenCalledWith('installers/app.exe', 3600);
+    expect(out.downloadUrl).toBe('https://fresh.example/installer?sig=new');
+    // The stable reference must survive so the NEXT delivery can re-mint too.
+    expect(out.s3Key).toBe('installers/app.exe');
+  });
+
+  it('leaves the payload alone when there is no s3Key (EDR / stored-URL installers)', async () => {
+    const refresher = deliveryRefreshers.software_install!;
+    const payload = { downloadUrl: 'https://vendor.example/agent.msi' };
+    const out = await refresher(payload);
+
+    expect(getPresignedUrlMock).not.toHaveBeenCalled();
+    expect(out).toEqual(payload);
+  });
+
+  it('leaves the payload alone when S3 is not configured', async () => {
+    isS3ConfiguredMock.mockReturnValue(false);
+    const refresher = deliveryRefreshers.software_install!;
+    const payload = { s3Key: 'installers/app.exe', downloadUrl: 'https://stale.example' };
+    const out = await refresher(payload);
+
+    expect(getPresignedUrlMock).not.toHaveBeenCalled();
+    expect(out.downloadUrl).toBe('https://stale.example');
+  });
+
+  it('propagates a presign failure so the caller releases the row rather than delivering a stale URL', async () => {
+    getPresignedUrlMock.mockRejectedValue(new Error('presign down'));
+    const refresher = deliveryRefreshers.software_install!;
+    await expect(refresher({ s3Key: 'installers/app.exe' })).rejects.toThrow('presign down');
+  });
+
+  it('a non-string s3Key is ignored rather than passed to the signer', async () => {
+    const refresher = deliveryRefreshers.software_install!;
+    const out = await refresher({ s3Key: 42, downloadUrl: 'https://stale.example' });
+    expect(getPresignedUrlMock).not.toHaveBeenCalled();
+    expect(out.downloadUrl).toBe('https://stale.example');
   });
 });

--- a/apps/api/src/services/commandDelivery.ts
+++ b/apps/api/src/services/commandDelivery.ts
@@ -1,10 +1,44 @@
 import { releaseClaimedCommandDelivery } from './commandDispatch';
+import { getPresignedUrl, isS3Configured } from './s3Storage';
 import { failClaimedSecretCommandsForUnsupportedAgent } from './scriptSecretDelivery';
 import {
   decryptCommandsForDelivery,
   type DeliverableCommand,
 } from './sensitiveCommandPayload';
 import { captureException } from './sentry';
+
+/**
+ * Re-materialises payload fields that are only valid for a short window, at the
+ * moment the command is actually handed to an agent (#5128 §D / OD-8).
+ *
+ * A queued command may be claimed days after it was enqueued. Anything
+ * time-limited in its payload — a presigned download URL, most obviously — is
+ * stale by then, so payloads store STABLE references (an S3 key) and the
+ * refresher turns that into a fresh URL here. Returns the payload to deliver;
+ * throwing releases the row back to `pending` rather than delivering a stale
+ * payload.
+ */
+export type DeliveryRefresher = (payload: Record<string, unknown>) => Promise<Record<string, unknown>>;
+
+/**
+ * Per-command-type refreshers, keyed by `device_commands.type`.
+ *
+ * Deliberately populated HERE rather than by side effect from the owning
+ * feature module: a refresher that is only registered when some other module
+ * happens to be imported would silently deliver stale payloads in any process
+ * that did not import it, which is precisely the class of bug this seam exists
+ * to close. Feature modules that need a refresher after boot may still assign
+ * into this record (W3's patch work does).
+ */
+export const deliveryRefreshers: Record<string, DeliveryRefresher> = {
+  // Uploaded installers travel as an S3 key; the one-hour presigned URL is
+  // minted at delivery so an install claimed six hours later still downloads.
+  software_install: async (payload) => {
+    const s3Key = typeof payload.s3Key === 'string' ? payload.s3Key : null;
+    if (!s3Key || !isS3Configured()) return payload;
+    return { ...payload, downloadUrl: await getPresignedUrl(s3Key, 3600) };
+  },
+};
 
 /**
  * The subset of a just-claimed `device_commands` row that batch delivery needs.
@@ -69,11 +103,13 @@ export type ClaimedCommand = {
  * authoritative, avoiding both the extra select and the race against the
  * heartbeat's own non-sticky device write.
  */
-export async function decryptClaimedCommandsForDelivery(
+export async function prepareClaimedCommandsForDelivery(
   claimed: ClaimedCommand[],
   opts?: { reportedScriptSecretEnvVersion?: number },
 ): Promise<DeliverableCommand[]> {
-  const deliverable = await failClaimedSecretCommandsForUnsupportedAgent(claimed, {
+  const refreshed = await refreshClaimedCommandPayloads(claimed);
+
+  const deliverable = await failClaimedSecretCommandsForUnsupportedAgent(refreshed, {
     ...(typeof opts?.reportedScriptSecretEnvVersion === 'number'
       ? { reportedVersion: opts.reportedScriptSecretEnvVersion }
       : {}),
@@ -117,4 +153,81 @@ export async function decryptClaimedCommandsForDelivery(
   }
 
   return delivered;
+}
+
+/**
+ * Backwards-compatible alias. The batch claim path was named for the one thing
+ * it used to do (decrypt); it now also re-mints time-limited payload fields.
+ * Removed in W5 once every call site uses the new name.
+ */
+export const decryptClaimedCommandsForDelivery = prepareClaimedCommandsForDelivery;
+
+/**
+ * Runs each claimed row's registered refresher (#5128 §D). A row whose
+ * refresher throws is RELEASED back to `pending` and dropped from the batch:
+ * delivering a payload we know to be stale (an expired installer URL, say) is
+ * worse than waiting for the next heartbeat, and the release keeps the row
+ * recoverable instead of stranding it as `sent`.
+ */
+async function refreshClaimedCommandPayloads(claimed: ClaimedCommand[]): Promise<ClaimedCommand[]> {
+  const out: ClaimedCommand[] = [];
+  for (const cmd of claimed) {
+    const refresher = deliveryRefreshers[cmd.type];
+    if (!refresher) {
+      out.push(cmd);
+      continue;
+    }
+    try {
+      const payload =
+        cmd.payload && typeof cmd.payload === 'object' && !Array.isArray(cmd.payload)
+          ? (cmd.payload as Record<string, unknown>)
+          : {};
+      out.push({ ...cmd, payload: await refresher(payload) });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(
+        '[commandDelivery] delivery refresher failed; releasing the row for a later heartbeat rather than delivering a stale payload',
+        { commandId: cmd.id, type: cmd.type, error: message },
+      );
+      try {
+        if (!cmd.executedAt) {
+          throw new Error('claimed command row has no executedAt — cannot release');
+        }
+        await releaseClaimedCommandDelivery(cmd.id, cmd.executedAt);
+      } catch (releaseErr) {
+        const releaseMessage = releaseErr instanceof Error ? releaseErr.message : String(releaseErr);
+        console.error(
+          '[commandDelivery] failed to release a command whose delivery refresher threw; it will strand as sent until the stale reaper times it out',
+          { commandId: cmd.id, type: cmd.type, error: releaseMessage },
+        );
+        captureException(
+          new Error(
+            `[commandDelivery] release after refresher failure failed (commandId=${cmd.id}, type=${cmd.type}): ${releaseMessage}`,
+          ),
+        );
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Single-command variant for the enqueue-time WS push (`dispatchDeviceCommand`).
+ * Returns null when the refresher failed — the caller releases the claim.
+ */
+export async function refreshPayloadForDelivery(
+  type: string,
+  payload: Record<string, unknown>,
+): Promise<Record<string, unknown> | null> {
+  const refresher = deliveryRefreshers[type];
+  if (!refresher) return payload;
+  try {
+    return await refresher(payload);
+  } catch (err) {
+    console.error('[commandDelivery] delivery refresher failed on the enqueue-time push', {
+      type,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
 }

--- a/apps/api/src/services/commandDelivery.ts
+++ b/apps/api/src/services/commandDelivery.ts
@@ -30,15 +30,33 @@ export type DeliveryRefresher = (payload: Record<string, unknown>) => Promise<Re
  * to close. Feature modules that need a refresher after boot may still assign
  * into this record (W3's patch work does).
  */
-export const deliveryRefreshers: Record<string, DeliveryRefresher> = {
-  // Uploaded installers travel as an S3 key; the one-hour presigned URL is
-  // minted at delivery so an install claimed six hours later still downloads.
-  software_install: async (payload) => {
-    const s3Key = typeof payload.s3Key === 'string' ? payload.s3Key : null;
-    if (!s3Key || !isS3Configured()) return payload;
-    return { ...payload, downloadUrl: await getPresignedUrl(s3Key, 3600) };
-  },
-};
+export const deliveryRefreshers: Record<string, DeliveryRefresher> = {};
+
+/**
+ * Register a refresher for a command type. Refuses to overwrite an existing
+ * one: two modules silently competing for `software_install` would mean the
+ * import order decides which payload an agent receives, and nothing would
+ * report it.
+ */
+export function registerDeliveryRefresher(type: string, refresher: DeliveryRefresher): void {
+  if (deliveryRefreshers[type]) {
+    throw new Error(`A delivery refresher is already registered for "${type}"`);
+  }
+  deliveryRefreshers[type] = refresher;
+}
+
+/** Test-only: drop every registered refresher so a suite can install its own. */
+export function __resetDeliveryRefreshersForTests(): void {
+  for (const key of Object.keys(deliveryRefreshers)) delete deliveryRefreshers[key];
+}
+
+// Uploaded installers travel as an S3 key; the one-hour presigned URL is
+// minted at delivery so an install claimed six hours later still downloads.
+registerDeliveryRefresher('software_install', async (payload) => {
+  const s3Key = typeof payload.s3Key === 'string' ? payload.s3Key : null;
+  if (!s3Key || !isS3Configured()) return payload;
+  return { ...payload, downloadUrl: await getPresignedUrl(s3Key, 3600) };
+});
 
 /**
  * The subset of a just-claimed `device_commands` row that batch delivery needs.
@@ -224,10 +242,15 @@ export async function refreshPayloadForDelivery(
   try {
     return await refresher(payload);
   } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
     console.error('[commandDelivery] delivery refresher failed on the enqueue-time push', {
       type,
-      error: err instanceof Error ? err.message : String(err),
+      error: message,
     });
+    // Reported, not just logged: a refresher that starts failing (an S3 outage,
+    // say) silently downgrades every enqueue-time push to a heartbeat wait, and
+    // nothing else on this path surfaces that.
+    captureException(err instanceof Error ? err : new Error(String(err)));
     return null;
   }
 }

--- a/apps/api/src/services/commandDispatch.test.ts
+++ b/apps/api/src/services/commandDispatch.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PgDialect } from 'drizzle-orm/pg-core';
 
 vi.mock('../db', () => ({
   db: {
@@ -55,6 +56,10 @@ vi.mock('drizzle-orm', async (importOriginal) => {
     notInArray: vi.fn((...args: Parameters<typeof actual.notInArray>) => actual.notInArray(...args)),
     gt: vi.fn((...args: Parameters<typeof actual.gt>) => actual.gt(...args)),
     isNull: vi.fn((...args: Parameters<typeof actual.isNull>) => actual.isNull(...args)),
+    // #5128: spied so the deliver_by predicate's DISJUNCTION is assertable —
+    // `and(...)` in its place would call isNull/gt identically but withhold
+    // every row that has a deadline.
+    or: vi.fn((...args: Parameters<typeof actual.or>) => actual.or(...args)),
   };
 });
 
@@ -66,7 +71,7 @@ vi.mock('./commandClaimEligibility', () => ({
   typeHolds: {},
 }));
 
-import { gt, inArray, isNull, notInArray } from 'drizzle-orm';
+import { gt, inArray, isNull, notInArray, or } from 'drizzle-orm';
 
 import { db } from '../db';
 import {
@@ -289,6 +294,16 @@ describe('command dispatch helpers', () => {
 
     expect(vi.mocked(gt)).toHaveBeenCalledWith('deviceCommands.deliverBy', expect.any(Date));
     expect(vi.mocked(isNull)).toHaveBeenCalledWith('deviceCommands.deliverBy');
+
+    // Asserting the two helpers were CALLED is not enough: swapping the `or(...)`
+    // that joins them for an `and(...)` calls both identically while excluding
+    // every row that HAS a deliver_by from delivery. Compile the actual joined
+    // predicate and require the DISJUNCTION.
+    expect(vi.mocked(or)).toHaveBeenCalled();
+    const deadlineArm = vi.mocked(or).mock.results[0]!.value;
+    const { sql: sqlText } = new PgDialect().sqlToQuery(deadlineArm as never);
+    expect(sqlText).toMatch(/is null or /i);
+    expect(sqlText).toMatch(/> \$/);
   });
 
   // #5128 §G: claim-time eligibility can veto rows the pending scan returned

--- a/apps/api/src/services/commandDispatch.test.ts
+++ b/apps/api/src/services/commandDispatch.test.ts
@@ -67,7 +67,7 @@ const { partitionClaimableMock } = vi.hoisted(() => ({ partitionClaimableMock: v
 
 vi.mock('./commandClaimEligibility', () => ({
   partitionClaimable: partitionClaimableMock,
-  POWER_STATE_TYPES: new Set(['reboot', 'shutdown', 'reboot_safe_mode']),
+  POWER_STATE_BARRIER_TYPES: new Set(['reboot', 'shutdown', 'reboot_safe_mode']),
   typeHolds: {},
 }));
 

--- a/apps/api/src/services/commandDispatch.test.ts
+++ b/apps/api/src/services/commandDispatch.test.ts
@@ -21,25 +21,52 @@ vi.mock('../db/schema', () => ({
     targetRole: 'deviceCommands.targetRole',
     createdAt: 'deviceCommands.createdAt',
     executedAt: 'deviceCommands.executedAt',
+    deliverBy: 'deviceCommands.deliverBy',
+    submittedOrgId: 'deviceCommands.submittedOrgId',
+    createdBy: 'deviceCommands.createdBy',
+    payload: 'deviceCommands.payload',
+    completedAt: 'deviceCommands.completedAt',
+    result: 'deviceCommands.result',
   },
   peripheralPolicyDeviceStates: {
     deviceId: 'peripheralPolicyDeviceStates.deviceId',
     deliveryStatus: 'peripheralPolicyDeviceStates.deliveryStatus',
   },
+  devices: {
+    id: 'devices.id',
+    orgId: 'devices.orgId',
+    status: 'devices.status',
+    partnerId: 'devices.partnerId',
+  },
+  users: {
+    id: 'users.id',
+    status: 'users.status',
+  },
 }));
 
-// Spy on inArray (pass-through to the real implementation) so the #2774
-// drain-mode type filter is assertable without mocking all of drizzle.
+// Spy on inArray/notInArray/gt/isNull (pass-through to the real implementation)
+// so both the #2774 drain-mode type filter and the #5128 deliver-by predicate
+// are assertable without mocking all of drizzle.
 vi.mock('drizzle-orm', async (importOriginal) => {
   const actual = await importOriginal<typeof import('drizzle-orm')>();
   return {
     ...actual,
     inArray: vi.fn((...args: Parameters<typeof actual.inArray>) => actual.inArray(...args)),
     notInArray: vi.fn((...args: Parameters<typeof actual.notInArray>) => actual.notInArray(...args)),
+    gt: vi.fn((...args: Parameters<typeof actual.gt>) => actual.gt(...args)),
+    isNull: vi.fn((...args: Parameters<typeof actual.isNull>) => actual.isNull(...args)),
   };
 });
 
-import { inArray, notInArray } from 'drizzle-orm';
+const { partitionClaimableMock } = vi.hoisted(() => ({ partitionClaimableMock: vi.fn() }));
+
+vi.mock('./commandClaimEligibility', () => ({
+  partitionClaimable: partitionClaimableMock,
+  POWER_STATE_TYPES: new Set(['reboot', 'shutdown', 'reboot_safe_mode']),
+  typeHolds: {},
+}));
+
+import { gt, inArray, isNull, notInArray } from 'drizzle-orm';
 
 import { db } from '../db';
 import {
@@ -48,9 +75,41 @@ import {
   releaseClaimedCommandDelivery,
 } from './commandDispatch';
 
+const DEVICE_ROW = { id: 'dev-1', orgId: 'org-1', status: 'online', partnerId: 'partner-1' };
+
+// #5128: the claim transaction now issues two extra lookups (the device row for
+// claim-time eligibility, then a count of in-flight rows for the power-state
+// barrier), so `where()` exposes BOTH the pending-scan chain
+// (`.orderBy().limit().for()`) and a directly-awaitable `.limit()`.
+function selectChain(pending: unknown[], opts: { device?: unknown; inFlight?: number } = {}) {
+  const device = 'device' in opts ? opts.device : DEVICE_ROW;
+  // Shared across every `where()` invocation: the device-row lookup consumes
+  // the first queued value, the in-flight-count lookup the second. A fresh
+  // `vi.fn()` per `where()` call would reset the once-queue and hand the
+  // device row back to both lookups instead of advancing.
+  const limit = vi.fn()
+    .mockResolvedValueOnce(device === undefined ? [] : [device])
+    .mockResolvedValueOnce([{ inFlight: opts.inFlight ?? 0 }]);
+  return vi.fn(() => ({
+    from: vi.fn(() => ({
+      where: vi.fn(() => ({
+        orderBy: vi.fn(() => ({
+          limit: vi.fn(() => ({ for: vi.fn().mockResolvedValue(pending) })),
+        })),
+        limit,
+      })),
+    })),
+  }));
+}
+
 describe('command dispatch helpers', () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    partitionClaimableMock.mockImplementation(async (_tx: unknown, _dev: unknown, rows: any[]) => ({
+      claimable: rows,
+      cancelled: [],
+      held: [],
+    }));
   });
 
   it('claims a pending command for delivery only when the conditional update succeeds', async () => {
@@ -76,20 +135,10 @@ describe('command dispatch helpers', () => {
       .mockResolvedValueOnce([]);
 
     const tx = {
-      select: vi.fn().mockReturnValue({
-        from: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({
-            orderBy: vi.fn().mockReturnValue({
-              limit: vi.fn().mockReturnValue({
-                for: vi.fn().mockResolvedValue([
-                  { id: 'cmd-1', deviceId: 'dev-1', status: 'pending', createdAt: new Date('2026-03-31T00:00:00Z') },
-                  { id: 'cmd-2', deviceId: 'dev-1', status: 'pending', createdAt: new Date('2026-03-31T00:00:01Z') },
-                ]),
-              }),
-            }),
-          }),
-        }),
-      }),
+      select: selectChain([
+        { id: 'cmd-1', deviceId: 'dev-1', status: 'pending', createdAt: new Date('2026-03-31T00:00:00Z') },
+        { id: 'cmd-2', deviceId: 'dev-1', status: 'pending', createdAt: new Date('2026-03-31T00:00:01Z') },
+      ]),
       update: vi.fn().mockReturnValue({
         set: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
@@ -114,17 +163,7 @@ describe('command dispatch helpers', () => {
   // #2774 — during an offboarding drain the claim narrows to self_uninstall.
   it('applies the type allowlist to the claim query when provided', async () => {
     const tx = {
-      select: vi.fn().mockReturnValue({
-        from: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({
-            orderBy: vi.fn().mockReturnValue({
-              limit: vi.fn().mockReturnValue({
-                for: vi.fn().mockResolvedValue([]),
-              }),
-            }),
-          }),
-        }),
-      }),
+      select: selectChain([]),
       update: vi.fn(),
     };
     vi.mocked(db.transaction).mockImplementation(async (fn: any) => fn(tx));
@@ -139,17 +178,7 @@ describe('command dispatch helpers', () => {
 
   it('does not mutate unrelated protocol work during a self-uninstall-only claim', async () => {
     const tx = {
-      select: vi.fn().mockReturnValue({
-        from: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({
-            orderBy: vi.fn().mockReturnValue({
-              limit: vi.fn().mockReturnValue({
-                for: vi.fn().mockResolvedValue([]),
-              }),
-            }),
-          }),
-        }),
-      }),
+      select: selectChain([]),
       update: vi.fn(),
     };
     vi.mocked(db.transaction).mockImplementation(async (fn: any) => fn(tx));
@@ -169,17 +198,7 @@ describe('command dispatch helpers', () => {
     const cancelWhere = vi.fn().mockResolvedValue(undefined);
     const rejectWhere = vi.fn().mockResolvedValue(undefined);
     const tx = {
-      select: vi.fn().mockReturnValue({
-        from: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({
-            orderBy: vi.fn().mockReturnValue({
-              limit: vi.fn().mockReturnValue({
-                for: vi.fn().mockResolvedValue([]),
-              }),
-            }),
-          }),
-        }),
-      }),
+      select: selectChain([]),
       update: vi.fn()
         .mockReturnValueOnce({ set: vi.fn().mockReturnValue({ where: cancelWhere }) })
         .mockReturnValueOnce({ set: vi.fn().mockReturnValue({ where: rejectWhere }) }),
@@ -206,15 +225,7 @@ describe('command dispatch helpers', () => {
 
   it('withholds rollback when this heartbeat does not report protocol v1', async () => {
     const tx = {
-      select: vi.fn().mockReturnValue({
-        from: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({
-            orderBy: vi.fn().mockReturnValue({
-              limit: vi.fn().mockReturnValue({ for: vi.fn().mockResolvedValue([]) }),
-            }),
-          }),
-        }),
-      }),
+      select: selectChain([]),
       update: vi.fn(),
     };
     vi.mocked(db.transaction).mockImplementation(async (fn: any) => fn(tx));
@@ -233,15 +244,7 @@ describe('command dispatch helpers', () => {
 
   it('withholds PAM lifetime commands when this heartbeat does not report protocol v2', async () => {
     const tx = {
-      select: vi.fn().mockReturnValue({
-        from: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({
-            orderBy: vi.fn().mockReturnValue({
-              limit: vi.fn().mockReturnValue({ for: vi.fn().mockResolvedValue([]) }),
-            }),
-          }),
-        }),
-      }),
+      select: selectChain([]),
       update: vi.fn(),
     };
     vi.mocked(db.transaction).mockImplementation(async (fn: any) => fn(tx));
@@ -269,5 +272,127 @@ describe('command dispatch helpers', () => {
     await releaseClaimedCommandDelivery('cmd-1', new Date('2026-03-31T00:00:00Z'));
 
     expect(where).toHaveBeenCalledTimes(1);
+  });
+
+  // #5128: the pending-scan predicate must exclude rows whose deadline has
+  // already passed — those belong to the reaper, not to a claiming heartbeat.
+  it('excludes a command whose deliver_by has already passed from the claim query', async () => {
+    const tx = {
+      select: selectChain([]),
+      update: vi.fn(),
+    };
+    vi.mocked(db.transaction).mockImplementation(async (fn: any) => fn(tx));
+
+    await claimPendingCommandsForDevice('dev-1', 10, 'agent', undefined, {
+      peripheralPolicyProtocolVersion: 2,
+    });
+
+    expect(vi.mocked(gt)).toHaveBeenCalledWith('deviceCommands.deliverBy', expect.any(Date));
+    expect(vi.mocked(isNull)).toHaveBeenCalledWith('deviceCommands.deliverBy');
+  });
+
+  // #5128 §G: claim-time eligibility can veto rows the pending scan returned
+  // (e.g. the device moved org since the command was queued) — only the rows
+  // it marks claimable may proceed to the per-row claim UPDATE.
+  it('claims only the rows claim-time eligibility returns', async () => {
+    const pendingRows = [
+      { id: 'cmd-1', deviceId: 'dev-1', status: 'pending', createdAt: new Date('2026-03-31T00:00:00Z') },
+      { id: 'cmd-2', deviceId: 'dev-1', status: 'pending', createdAt: new Date('2026-03-31T00:00:01Z') },
+    ];
+    partitionClaimableMock.mockResolvedValue({
+      claimable: [pendingRows[0]],
+      cancelled: [{ id: 'cmd-2', reason: 'device_moved_org' }],
+      held: [],
+    });
+
+    const returning = vi.fn().mockResolvedValue([
+      { id: 'cmd-1', deviceId: 'dev-1', status: 'sent', createdAt: new Date('2026-03-31T00:00:00Z') },
+    ]);
+    const tx = {
+      select: selectChain(pendingRows),
+      update: vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ returning }),
+        }),
+      }),
+    };
+    vi.mocked(db.transaction).mockImplementation(async (fn: any) => fn(tx));
+
+    const claimed = await claimPendingCommandsForDevice(
+      'dev-1', 10, 'agent', undefined, { peripheralPolicyProtocolVersion: 2 },
+    );
+
+    expect(claimed).toHaveLength(1);
+    expect(claimed[0]?.id).toBe('cmd-1');
+    expect(returning).toHaveBeenCalledTimes(1);
+  });
+
+  // #5128: if the device vanished (deleted / moved) between the pending scan
+  // and the eligibility check, nothing in the batch may be delivered.
+  it('returns nothing when the device row has vanished mid-claim', async () => {
+    const tx = {
+      select: selectChain(
+        [{ id: 'cmd-1', deviceId: 'dev-1', status: 'pending', createdAt: new Date('2026-03-31T00:00:00Z') }],
+        { device: undefined },
+      ),
+      update: vi.fn(),
+    };
+    vi.mocked(db.transaction).mockImplementation(async (fn: any) => fn(tx));
+
+    const claimed = await claimPendingCommandsForDevice(
+      'dev-1', 10, 'agent', undefined, { peripheralPolicyProtocolVersion: 2 },
+    );
+
+    expect(claimed).toEqual([]);
+    expect(tx.update).not.toHaveBeenCalled();
+    expect(partitionClaimableMock).not.toHaveBeenCalled();
+  });
+
+  // #5128: the power-state barrier inside partitionClaimable needs the count
+  // of already-`sent` rows for this device/role — that count must reach it.
+  it('passes the in-flight sent count to claim-time eligibility', async () => {
+    const pendingRows = [
+      { id: 'cmd-1', deviceId: 'dev-1', status: 'pending', createdAt: new Date('2026-03-31T00:00:00Z') },
+    ];
+    const returning = vi.fn().mockResolvedValue([
+      { id: 'cmd-1', deviceId: 'dev-1', status: 'sent', createdAt: new Date('2026-03-31T00:00:00Z') },
+    ]);
+    const tx = {
+      select: selectChain(pendingRows, { inFlight: 3 }),
+      update: vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ returning }),
+        }),
+      }),
+    };
+    vi.mocked(db.transaction).mockImplementation(async (fn: any) => fn(tx));
+
+    await claimPendingCommandsForDevice(
+      'dev-1', 10, 'agent', undefined, { peripheralPolicyProtocolVersion: 2 },
+    );
+
+    expect(partitionClaimableMock).toHaveBeenCalledWith(
+      tx,
+      DEVICE_ROW,
+      pendingRows,
+      { inFlight: 3 },
+    );
+  });
+
+  // #5128: the single-command delivery UPDATE carries the same deadline
+  // predicate as the batch scan, so a stale row can't be delivered directly.
+  it('the single-command claim refuses a row past its delivery deadline', async () => {
+    const where = vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue([{ id: 'cmd-1' }]),
+    });
+    vi.mocked(db.update).mockReturnValue({
+      set: vi.fn().mockReturnValue({ where }),
+    } as any);
+
+    await claimPendingCommandForDelivery('cmd-1', new Date('2026-03-31T00:00:00Z'));
+
+    expect(where).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(gt)).toHaveBeenCalledWith('deviceCommands.deliverBy', expect.any(Date));
+    expect(vi.mocked(isNull)).toHaveBeenCalledWith('deviceCommands.deliverBy');
   });
 });

--- a/apps/api/src/services/commandDispatch.ts
+++ b/apps/api/src/services/commandDispatch.ts
@@ -34,6 +34,32 @@ export async function claimPendingCommandForDelivery(
 }
 
 /**
+ * How many commands this device already has in flight (`sent`, awaiting a
+ * result). Same predicate the heartbeat claim uses for the power-state barrier,
+ * so the enqueue-time push and the heartbeat claim agree on when a reboot may
+ * go out (#5128 §E.4).
+ */
+export async function countInFlightCommandsForDevice(
+  deviceId: string,
+  targetRole: string = 'agent',
+): Promise<number> {
+  const rows = await withSystemDbAccessContext(() =>
+    db
+      .select({ inFlight: sql<number>`count(*)::int` })
+      .from(deviceCommands)
+      .where(
+        and(
+          eq(deviceCommands.deviceId, deviceId),
+          eq(deviceCommands.status, 'sent'),
+          eq(deviceCommands.targetRole, targetRole),
+        ),
+      )
+      .limit(1),
+  );
+  return rows[0]?.inFlight ?? 0;
+}
+
+/**
  * Put a claimed-but-undelivered command back to `pending`. Keyed on
  * `(id, status='sent', executedAt=<claim ts>)` so a stale release can never
  * clobber a newer claim or resurrect a terminal command (0-row no-op is the

--- a/apps/api/src/services/commandDispatch.ts
+++ b/apps/api/src/services/commandDispatch.ts
@@ -23,7 +23,7 @@ export async function claimPendingCommandForDelivery(
           eq(deviceCommands.status, 'pending'),
           // #5128: never deliver a row the reaper is about to expire. A row
           // whose deadline has passed stays `pending` for the reaper to
-          // terminalise with `expired / not_delivered_before_deadline`.
+          // terminalise with `reason: not_delivered_before_deadline`.
           or(isNull(deviceCommands.deliverBy), gt(deviceCommands.deliverBy, executedAt)),
         ),
       )

--- a/apps/api/src/services/commandDispatch.ts
+++ b/apps/api/src/services/commandDispatch.ts
@@ -1,6 +1,7 @@
-import { and, eq, inArray, notInArray } from 'drizzle-orm';
+import { and, eq, gt, inArray, isNull, notInArray, or, sql } from 'drizzle-orm';
 import { db, withSystemDbAccessContext } from '../db';
-import { deviceCommands, peripheralPolicyDeviceStates } from '../db/schema';
+import { deviceCommands, devices, peripheralPolicyDeviceStates } from '../db/schema';
+import { partitionClaimable } from './commandClaimEligibility';
 import { terminalPayloadErasureSet } from './sensitiveCommandPayload';
 
 type DeviceCommandRow = typeof deviceCommands.$inferSelect;
@@ -20,6 +21,10 @@ export async function claimPendingCommandForDelivery(
         and(
           eq(deviceCommands.id, commandId),
           eq(deviceCommands.status, 'pending'),
+          // #5128: never deliver a row the reaper is about to expire. A row
+          // whose deadline has passed stays `pending` for the reaper to
+          // terminalise with `expired / not_delivered_before_deadline`.
+          or(isNull(deviceCommands.deliverBy), gt(deviceCommands.deliverBy, executedAt)),
         ),
       )
       .returning({ id: deviceCommands.id }),
@@ -123,6 +128,7 @@ export async function claimPendingCommandsForDevice(
       unsupportedProtocolTypes.push('pam_apply_v2', 'pam_cleanup_v2');
     }
 
+    const now = new Date();
     const pendingCommands = await tx
       .select()
       .from(deviceCommands)
@@ -131,6 +137,8 @@ export async function claimPendingCommandsForDevice(
           eq(deviceCommands.deviceId, deviceId),
           eq(deviceCommands.status, 'pending'),
           eq(deviceCommands.targetRole, targetRole),
+          // #5128: a row past its delivery deadline is the reaper's, not ours.
+          or(isNull(deviceCommands.deliverBy), gt(deviceCommands.deliverBy, now)),
           ...(typeAllowlist ? [inArray(deviceCommands.type, [...typeAllowlist])] : []),
           ...(unsupportedProtocolTypes.length > 0
             ? [notInArray(deviceCommands.type, unsupportedProtocolTypes)]
@@ -141,8 +149,46 @@ export async function claimPendingCommandsForDevice(
       .limit(limit)
       .for('update', { skipLocked: true });
 
+    // #5128 §G: re-check eligibility at the moment of delivery. A queued
+    // command may have been requested days ago, so the device's org, lifecycle,
+    // partner trust and the requester's account are all re-evaluated here, and
+    // the power-state barrier is applied. Cancels are written on `tx`, so a row
+    // this rejects cannot be delivered by a concurrent claim.
+    let deliverable = pendingCommands;
+    if (pendingCommands.length > 0) {
+      const [dev] = await tx
+        .select({
+          id: devices.id,
+          orgId: devices.orgId,
+          status: devices.status,
+        })
+        .from(devices)
+        .where(eq(devices.id, deviceId))
+        .limit(1);
+      if (!dev) return [];
+
+      const [inFlightRow] = await tx
+        .select({ inFlight: sql<number>`count(*)::int` })
+        .from(deviceCommands)
+        .where(
+          and(
+            eq(deviceCommands.deviceId, deviceId),
+            eq(deviceCommands.status, 'sent'),
+            eq(deviceCommands.targetRole, targetRole),
+          ),
+        )
+        .limit(1);
+
+      const { claimable } = await partitionClaimable(tx, dev, pendingCommands, {
+        inFlight: inFlightRow?.inFlight ?? 0,
+      });
+      const claimableIds = new Set(claimable.map((c) => c.id));
+      deliverable = pendingCommands.filter((c) => claimableIds.has(c.id));
+      if (deliverable.length === 0) return [];
+    }
+
     const claimed: DeviceCommandRow[] = [];
-    for (const command of pendingCommands) {
+    for (const command of deliverable) {
       const executedAt = new Date();
       const rows = await tx
         .update(deviceCommands)

--- a/apps/api/src/services/commandOfflinePolicy.test.ts
+++ b/apps/api/src/services/commandOfflinePolicy.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { CommandTypes } from './commandQueue';
+import { createCommandSchema, bulkCommandSchema } from '../routes/devices/schemas';
+import {
+  COMMAND_OFFLINE_POLICY_REGISTRY,
+  REJECT_RACE_GRACE_MS,
+  UnregisteredCommandTypeError,
+  defaultOfflinePolicy,
+  deliverByFor,
+  deliveryTtlMs,
+  isOfflineQueueEnabled,
+  resolveOfflinePolicy,
+} from './commandOfflinePolicy';
+
+describe('commandOfflinePolicy registry (#5128 W1)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('covers every CommandTypes value (fail-closed)', () => {
+    const missing = Object.values(CommandTypes).filter((t) => !(t in COMMAND_OFFLINE_POLICY_REGISTRY));
+    expect(missing).toEqual([]);
+  });
+
+  it('covers every type the generic device-command routes accept', () => {
+    // The route enums carry literals that are NOT in CommandTypes ('reboot',
+    // 'shutdown', 'update', 'wake'), so the registry must classify them too or
+    // the seam throws on a reboot.
+    const routeTypes = new Set<string>([
+      ...createCommandSchema.shape.type.options,
+      ...bulkCommandSchema.shape.type.options,
+    ]);
+    const missing = [...routeTypes].filter((t) => !(t in COMMAND_OFFLINE_POLICY_REGISTRY));
+    expect(missing).toEqual([]);
+  });
+
+  it('throws for an unregistered type', () => {
+    expect(() => defaultOfflinePolicy('definitely_not_a_command')).toThrow(UnregisteredCommandTypeError);
+    expect(() => defaultOfflinePolicy('definitely_not_a_command')).toThrow(/COMMAND_OFFLINE_POLICY_REGISTRY/);
+  });
+
+  it('rejects live/interactive types and queues fire-and-forget types', () => {
+    expect(defaultOfflinePolicy(CommandTypes.TERMINAL_START)).toEqual({ kind: 'reject' });
+    expect(defaultOfflinePolicy(CommandTypes.LIST_PROCESSES)).toEqual({ kind: 'reject' });
+    expect(defaultOfflinePolicy(CommandTypes.TAKE_SCREENSHOT)).toEqual({ kind: 'reject' });
+    expect(defaultOfflinePolicy(CommandTypes.SCRIPT)).toEqual({
+      kind: 'queue',
+      deliverWithinMs: deliveryTtlMs('standard'),
+    });
+    expect(defaultOfflinePolicy(CommandTypes.REFRESH_INVENTORY)).toEqual({
+      kind: 'queue',
+      deliverWithinMs: deliveryTtlMs('short'),
+    });
+    expect(defaultOfflinePolicy('reboot')).toEqual({
+      kind: 'queue',
+      deliverWithinMs: deliveryTtlMs('power_state'),
+    });
+    expect(defaultOfflinePolicy('shutdown')).toEqual({
+      kind: 'queue',
+      deliverWithinMs: deliveryTtlMs('power_state'),
+    });
+    expect(defaultOfflinePolicy(CommandTypes.REBOOT_SAFE_MODE)).toEqual({
+      kind: 'queue',
+      deliverWithinMs: deliveryTtlMs('power_state'),
+    });
+  });
+
+  it('backup and restore types stay reject (out of scope for v1)', () => {
+    expect(defaultOfflinePolicy(CommandTypes.BACKUP_RUN)).toEqual({ kind: 'reject' });
+    expect(defaultOfflinePolicy(CommandTypes.BACKUP_RESTORE)).toEqual({ kind: 'reject' });
+    expect(defaultOfflinePolicy(CommandTypes.BMR_RECOVER)).toEqual({ kind: 'reject' });
+  });
+
+  it('standard TTL is 7 days by default and env-tunable', () => {
+    expect(deliveryTtlMs('standard')).toBe(7 * 24 * 60 * 60 * 1000);
+    vi.stubEnv('DEVICE_COMMAND_QUEUE_TTL_HOURS', '48');
+    expect(deliveryTtlMs('standard')).toBe(48 * 60 * 60 * 1000);
+  });
+
+  it('short and power_state TTLs default to 24 hours and are env-tunable', () => {
+    expect(deliveryTtlMs('short')).toBe(24 * 60 * 60 * 1000);
+    expect(deliveryTtlMs('power_state')).toBe(24 * 60 * 60 * 1000);
+    vi.stubEnv('DEVICE_COMMAND_QUEUE_SHORT_TTL_HOURS', '6');
+    vi.stubEnv('DEVICE_COMMAND_QUEUE_POWER_STATE_TTL_HOURS', '2');
+    expect(deliveryTtlMs('short')).toBe(6 * 60 * 60 * 1000);
+    expect(deliveryTtlMs('power_state')).toBe(2 * 60 * 60 * 1000);
+  });
+
+  it('an invalid or non-positive TTL env value falls back to the default', () => {
+    vi.stubEnv('DEVICE_COMMAND_QUEUE_TTL_HOURS', 'not-a-number');
+    expect(deliveryTtlMs('standard')).toBe(7 * 24 * 60 * 60 * 1000);
+    vi.stubEnv('DEVICE_COMMAND_QUEUE_TTL_HOURS', '0');
+    expect(deliveryTtlMs('standard')).toBe(7 * 24 * 60 * 60 * 1000);
+    vi.stubEnv('DEVICE_COMMAND_QUEUE_TTL_HOURS', '-5');
+    expect(deliveryTtlMs('standard')).toBe(7 * 24 * 60 * 60 * 1000);
+  });
+
+  it('live TTL is the reject race grace, not a queue window', () => {
+    expect(deliveryTtlMs('live')).toBe(REJECT_RACE_GRACE_MS);
+  });
+
+  it('flag off + previouslyRejected keeps reject; flag on lets the registry queue', () => {
+    vi.stubEnv('DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED', 'false');
+    expect(isOfflineQueueEnabled()).toBe(false);
+    expect(resolveOfflinePolicy(CommandTypes.INSTALL_PATCHES, undefined, { previouslyRejected: true })).toEqual({
+      kind: 'reject',
+    });
+    vi.stubEnv('DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED', 'true');
+    expect(isOfflineQueueEnabled()).toBe(true);
+    expect(resolveOfflinePolicy(CommandTypes.INSTALL_PATCHES, undefined, { previouslyRejected: true }).kind).toBe(
+      'queue'
+    );
+  });
+
+  it('the flag does not gate callers that already queued today', () => {
+    vi.stubEnv('DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED', 'false');
+    expect(resolveOfflinePolicy(CommandTypes.SCRIPT, undefined, { previouslyRejected: false }).kind).toBe('queue');
+    expect(resolveOfflinePolicy(CommandTypes.SOFTWARE_INSTALL, undefined, { previouslyRejected: false }).kind).toBe(
+      'queue'
+    );
+  });
+
+  it('an explicit requested policy always wins over the flag and the registry', () => {
+    vi.stubEnv('DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED', 'false');
+    expect(
+      resolveOfflinePolicy(CommandTypes.INSTALL_PATCHES, { kind: 'queue', deliverWithinMs: 1000 }, {
+        previouslyRejected: true,
+      })
+    ).toEqual({ kind: 'queue', deliverWithinMs: 1000 });
+    vi.stubEnv('DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED', 'true');
+    expect(resolveOfflinePolicy(CommandTypes.SCRIPT, { kind: 'reject' }, { previouslyRejected: false })).toEqual({
+      kind: 'reject',
+    });
+  });
+
+  it('an explicit policy for an unregistered type still throws (fail-closed)', () => {
+    expect(() =>
+      resolveOfflinePolicy('definitely_not_a_command', { kind: 'reject' }, { previouslyRejected: false })
+    ).toThrow(UnregisteredCommandTypeError);
+  });
+
+  it('deliverByFor: queue adds deliverWithinMs; reject adds the race grace', () => {
+    const now = new Date('2026-09-06T00:00:00Z');
+    expect(deliverByFor({ kind: 'queue', deliverWithinMs: 60_000 }, now).toISOString()).toBe(
+      '2026-09-06T00:01:00.000Z'
+    );
+    expect(deliverByFor({ kind: 'reject' }, now).getTime()).toBe(now.getTime() + REJECT_RACE_GRACE_MS);
+  });
+});

--- a/apps/api/src/services/commandOfflinePolicy.test.ts
+++ b/apps/api/src/services/commandOfflinePolicy.test.ts
@@ -3,6 +3,7 @@ import { CommandTypes } from './commandTypes';
 import { createCommandSchema, bulkCommandSchema } from '../routes/devices/schemas';
 import {
   COMMAND_OFFLINE_POLICY_REGISTRY,
+  EXPLICITLY_CLASSIFIED_COMMAND_TYPES,
   REJECT_RACE_GRACE_MS,
   UnregisteredCommandTypeError,
   defaultOfflinePolicy,
@@ -76,6 +77,19 @@ describe('commandOfflinePolicy registry (#5128 W1)', () => {
       kind: 'queue',
       deliverWithinMs: deliveryTtlMs('power_state'),
     });
+  });
+
+  it('every CommandTypes value is EXPLICITLY classified, never left to the fallback', () => {
+    // The registry's fallback is `standard`, i.e. QUEUEABLE. Deferred delivery
+    // widens the window in which the authorization behind a command can go
+    // stale, so a new command type must not become queueable just because
+    // nobody classified it. This is the fail-closed property that
+    // UnregisteredCommandTypeError does NOT provide (that only fires for a
+    // string absent from CommandTypes entirely).
+    const unclassified = Object.values(CommandTypes).filter(
+      (t) => !EXPLICITLY_CLASSIFIED_COMMAND_TYPES.has(t)
+    );
+    expect(unclassified).toEqual([]);
   });
 
   it('throws for an unregistered type', () => {

--- a/apps/api/src/services/commandOfflinePolicy.test.ts
+++ b/apps/api/src/services/commandOfflinePolicy.test.ts
@@ -197,11 +197,21 @@ describe('commandOfflinePolicy registry (#5128 W1)', () => {
     ).toThrow(UnregisteredCommandTypeError);
   });
 
-  it('deliverByFor: queue adds deliverWithinMs; reject adds the race grace', () => {
+  it('deliverByFor: queue adds deliverWithinMs; reject gets NO deadline at all', () => {
     const now = new Date('2026-09-06T00:00:00Z');
-    expect(deliverByFor({ kind: 'queue', deliverWithinMs: 60_000 }, now).toISOString()).toBe(
+    expect(deliverByFor({ kind: 'queue', deliverWithinMs: 60_000 }, now)!.toISOString()).toBe(
       '2026-09-06T00:01:00.000Z'
     );
-    expect(deliverByFor({ kind: 'reject' }, now).getTime()).toBe(now.getTime() + REJECT_RACE_GRACE_MS);
+    // #5128 review round 2 (J): a `reject` row is only ever created against a
+    // device just observed online, and a NULL deadline puts it back on the
+    // legacy execution clock — byte-identical to pre-#5128. Stamping the
+    // 5-minute grace instead cut every executeCommand row's window from 30 min
+    // to 5, including watchdog-targeted work and barrier-held reboots.
+    expect(deliverByFor({ kind: 'reject' }, now)).toBeNull();
+  });
+
+  it('REJECT_RACE_GRACE_MS is only the `live` TTL class value, never stamped on a row', () => {
+    expect(deliveryTtlMs('live')).toBe(REJECT_RACE_GRACE_MS);
+    expect(deliverByFor(defaultOfflinePolicy('list_processes'))).toBeNull();
   });
 });

--- a/apps/api/src/services/commandOfflinePolicy.test.ts
+++ b/apps/api/src/services/commandOfflinePolicy.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { CommandTypes } from './commandQueue';
+import { CommandTypes } from './commandTypes';
 import { createCommandSchema, bulkCommandSchema } from '../routes/devices/schemas';
 import {
   COMMAND_OFFLINE_POLICY_REGISTRY,
@@ -32,6 +32,50 @@ describe('commandOfflinePolicy registry (#5128 W1)', () => {
     ]);
     const missing = [...routeTypes].filter((t) => !(t in COMMAND_OFFLINE_POLICY_REGISTRY));
     expect(missing).toEqual([]);
+  });
+
+  it('covers every device_commands.type literal the API writes outside CommandTypes', () => {
+    // Swept from every `.insert(deviceCommands)` / queueCommand / executeCommand
+    // / queueCommandForExecution call site in apps/api/src (#5128 W1). A type
+    // missing here throws at the seam, so this list is the fail-closed contract:
+    // add the literal AND its class when a new one appears.
+    const extras = [
+      'actuate_elevation',
+      'apply_browser_policy',
+      'desktop_stream_stop',
+      'network_discovery',
+      'reboot',
+      'restart_agent',
+      'schedule_reboot',
+      'set_auto_update',
+      'shutdown',
+      'update',
+      'update_agent',
+      'update_watchdog',
+      'wake',
+    ];
+    const missing = extras.filter((t) => !(t in COMMAND_OFFLINE_POLICY_REGISTRY));
+    expect(missing).toEqual([]);
+  });
+
+  it('agent-binary and session-bound types reject rather than queue', () => {
+    // `update_agent` / `update_watchdog` are refused by queueCommand outright
+    // (#4093) and only reach the agent via executeCommand, which waits for the
+    // result — the one pairing the design forbids with `queue` (#5128 §A).
+    expect(defaultOfflinePolicy('update_agent')).toEqual({ kind: 'reject' });
+    expect(defaultOfflinePolicy('update_watchdog')).toEqual({ kind: 'reject' });
+    expect(defaultOfflinePolicy('restart_agent')).toEqual({ kind: 'reject' });
+    expect(defaultOfflinePolicy('network_discovery')).toEqual({ kind: 'reject' });
+    expect(defaultOfflinePolicy('actuate_elevation')).toEqual({ kind: 'reject' });
+    expect(defaultOfflinePolicy('desktop_stream_stop')).toEqual({ kind: 'reject' });
+    expect(defaultOfflinePolicy('wake')).toEqual({ kind: 'reject' });
+  });
+
+  it('schedule_reboot shares the power-state TTL', () => {
+    expect(defaultOfflinePolicy('schedule_reboot')).toEqual({
+      kind: 'queue',
+      deliverWithinMs: deliveryTtlMs('power_state'),
+    });
   });
 
   it('throws for an unregistered type', () => {

--- a/apps/api/src/services/commandOfflinePolicy.ts
+++ b/apps/api/src/services/commandOfflinePolicy.ts
@@ -1,0 +1,241 @@
+import { CommandTypes } from './commandQueue';
+
+/**
+ * Whether a device command may wait for an offline device, and for how long
+ * (#5128 §A). `reject` = the caller needs a live socket now and gets today's
+ * `device_offline` error; `queue` = persist the row with a delivery deadline
+ * and let the agent's next heartbeat claim it.
+ */
+export type OfflinePolicy = { kind: 'reject' } | { kind: 'queue'; deliverWithinMs: number };
+
+/** TTL class = how long a queued row may wait for the device (OD-1). */
+export type DeliveryTtlClass = 'live' | 'standard' | 'short' | 'power_state';
+
+/**
+ * A `reject` command is only ever enqueued against a device we just observed
+ * online, so its row still gets a (short) deadline: a row that raced a
+ * disconnect must not linger as `pending` forever.
+ */
+export const REJECT_RACE_GRACE_MS = 5 * 60 * 1000;
+
+const HOUR_MS = 60 * 60 * 1000;
+
+export class UnregisteredCommandTypeError extends Error {
+  constructor(public readonly commandType: string) {
+    super(
+      `Command type "${commandType}" has no entry in COMMAND_OFFLINE_POLICY_REGISTRY ` +
+        '(services/commandOfflinePolicy.ts) — register it with a TTL class before dispatching it'
+    );
+    this.name = 'UnregisteredCommandTypeError';
+  }
+}
+
+function envHours(name: string, fallback: number): number {
+  const raw = process.env[name];
+  const parsed = raw === undefined || raw === '' ? Number.NaN : Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export function deliveryTtlMs(cls: DeliveryTtlClass): number {
+  switch (cls) {
+    case 'live':
+      return REJECT_RACE_GRACE_MS;
+    case 'standard':
+      return envHours('DEVICE_COMMAND_QUEUE_TTL_HOURS', 168) * HOUR_MS;
+    case 'short':
+      return envHours('DEVICE_COMMAND_QUEUE_SHORT_TTL_HOURS', 24) * HOUR_MS;
+    case 'power_state':
+      return envHours('DEVICE_COMMAND_QUEUE_POWER_STATE_TTL_HOURS', 24) * HOUR_MS;
+  }
+}
+
+/**
+ * Gates the `queue` arm for callers that hard-rejected offline devices before
+ * #5128 (patch executor, automations, scan/rollback, AI tools). Scripts,
+ * software installs and the generic device-command routes already queued and
+ * are NOT gated. Defaults on once W3/W4 ship; removed the release after.
+ */
+export function isOfflineQueueEnabled(): boolean {
+  return process.env.DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED === 'true';
+}
+
+const C = CommandTypes;
+
+/**
+ * Interactive / read-now types: the caller is holding a socket or waiting on a
+ * synchronous answer, so an offline device is a hard `device_offline`.
+ */
+const LIVE: readonly string[] = [
+  C.LIST_PROCESSES,
+  C.GET_PROCESS,
+  C.KILL_PROCESS,
+  C.LIST_SERVICES,
+  C.GET_SERVICE,
+  C.START_SERVICE,
+  C.STOP_SERVICE,
+  C.RESTART_SERVICE,
+  C.EVENT_LOGS_LIST,
+  C.EVENT_LOGS_QUERY,
+  C.EVENT_LOG_GET,
+  C.TASKS_LIST,
+  C.TASK_GET,
+  C.TASK_RUN,
+  C.TASK_ENABLE,
+  C.TASK_DISABLE,
+  C.TASK_HISTORY,
+  C.REGISTRY_KEYS,
+  C.REGISTRY_VALUES,
+  C.REGISTRY_GET,
+  C.REGISTRY_SET,
+  C.REGISTRY_DELETE,
+  C.REGISTRY_KEY_CREATE,
+  C.REGISTRY_KEY_DELETE,
+  C.FILE_LIST,
+  C.FILE_READ,
+  C.FILE_WRITE,
+  C.FILE_DELETE,
+  C.FILE_MKDIR,
+  C.FILE_RENAME,
+  C.FILE_COPY,
+  C.FILE_TRASH_LIST,
+  C.FILE_TRASH_RESTORE,
+  C.FILE_TRASH_PURGE,
+  C.FILE_LIST_DRIVES,
+  C.TERMINAL_START,
+  C.TERMINAL_DATA,
+  C.TERMINAL_RESIZE,
+  C.TERMINAL_STOP,
+  // Cancels a command the agent is running RIGHT NOW; queueing one is meaningless.
+  C.SCRIPT_CANCEL,
+  C.TAKE_SCREENSHOT,
+  C.COMPUTER_ACTION,
+  C.COLLECT_BOOT_PERFORMANCE,
+  C.VSS_STATUS,
+  C.VSS_WRITER_LIST,
+  C.MSSQL_DISCOVER,
+  C.HYPERV_DISCOVER,
+  C.HYPERV_VM_STATE,
+  C.VM_RESTORE_ESTIMATE,
+  C.VAULT_STATUS,
+  // Addressed to a RELAY agent on the target's LAN — that relay must be online.
+  C.WAKE_ON_LAN,
+  C.CAPTURE_PPROF,
+];
+
+/**
+ * Backup / restore / verification stay hard-gated in v1 (#5128 "Out of scope":
+ * they own a scheduler and a per-device execution slot from #4923). Classifying
+ * them `live` here is what keeps them rejecting once the feature flag flips on
+ * in W4 — the flag alone would otherwise let them queue.
+ */
+const BACKUP_AND_RESTORE: readonly string[] = [
+  C.BACKUP_RUN,
+  C.BACKUP_STOP,
+  C.BACKUP_RESTORE,
+  C.BACKUP_VERIFY,
+  C.BACKUP_TEST_RESTORE,
+  C.BACKUP_CLEANUP,
+  C.MSSQL_BACKUP,
+  C.MSSQL_RESTORE,
+  C.MSSQL_VERIFY,
+  C.HYPERV_BACKUP,
+  C.HYPERV_RESTORE,
+  C.VM_RESTORE_FROM_BACKUP,
+  C.VM_INSTANT_BOOT,
+  C.BMR_RECOVER,
+];
+
+/**
+ * Config / inventory syncs that converge: a stale one has no value once a newer
+ * push supersedes it, so they expire in a day rather than a week (OD-1).
+ */
+const SHORT: readonly string[] = [
+  C.REFRESH_INVENTORY,
+  C.SET_LOG_LEVEL,
+  C.PERIPHERAL_POLICY_SYNC,
+  C.PERIPHERAL_POLICY_SYNC_V2,
+  C.MANAGE_STARTUP_ITEM,
+  C.COLLECT_AUDIT_POLICY,
+  C.SECURITY_COLLECT_STATUS,
+  C.COLLECT_RELIABILITY_METRICS,
+  C.SYSTEM_STATE_COLLECT,
+  C.HARDWARE_PROFILE,
+  C.ENCRYPTION_COLLECT_KEYS,
+  C.HYPERV_CHECKPOINT,
+  // Agent-version management: pinned to the version running now, so a week-old
+  // rollback or self-update is the wrong instruction by the time it lands.
+  C.AGENT_ROLLBACK_V1,
+  'update',
+  'set_auto_update',
+];
+
+/**
+ * Disruptive power-state changes. Short TTL AND the claim-time barrier in
+ * `commandClaimEligibility.ts` (claimed alone, nothing else in flight).
+ * `schedule_reboot` shares the TTL — a scheduled restart delivered a week late
+ * is wrong — but not the barrier: it only asks the agent to schedule, and the
+ * agent owns the delay and user deferral from there.
+ */
+const POWER_STATE: readonly string[] = ['reboot', 'shutdown', C.REBOOT_SAFE_MODE, 'schedule_reboot'];
+
+/**
+ * Command type literals the API writes that are NOT members of `CommandTypes`:
+ * the generic device-command route enums (`routes/devices/schemas.ts`), the
+ * fleet-findings dispatch map, and the reboot handlers. They are listed here
+ * explicitly so the fail-closed registry cannot throw on a reboot.
+ * ('wake' is the route-facing spelling; the route rewrites it to `wake_on_lan`
+ * before it reaches the seam, but both are classified so either spelling is
+ * safe.)
+ */
+const EXTRA_ROUTE_TYPES: readonly string[] = [
+  'reboot',
+  'shutdown',
+  'reboot_safe_mode',
+  'schedule_reboot',
+  'update',
+  'set_auto_update',
+  'wake',
+];
+
+// Build the registry from CommandTypes so a NEW type cannot be added without
+// also being classified. A type added to CommandTypes but to none of the lists
+// lands in `standard`, the safe default for fire-and-forget work — a type that
+// must NOT queue has to be listed in LIVE (or BACKUP_AND_RESTORE).
+const registry: Record<string, DeliveryTtlClass> = {};
+for (const type of Object.values(CommandTypes)) registry[type] = 'standard';
+for (const type of EXTRA_ROUTE_TYPES) registry[type] = 'standard';
+for (const type of LIVE) registry[type] = 'live';
+for (const type of BACKUP_AND_RESTORE) registry[type] = 'live';
+for (const type of SHORT) registry[type] = 'short';
+for (const type of POWER_STATE) registry[type] = 'power_state';
+registry.wake = 'live';
+
+export const COMMAND_OFFLINE_POLICY_REGISTRY: Readonly<Record<string, DeliveryTtlClass>> = Object.freeze(registry);
+
+export function defaultOfflinePolicy(type: string): OfflinePolicy {
+  const cls = COMMAND_OFFLINE_POLICY_REGISTRY[type];
+  if (!cls) throw new UnregisteredCommandTypeError(type);
+  if (cls === 'live') return { kind: 'reject' };
+  return { kind: 'queue', deliverWithinMs: deliveryTtlMs(cls) };
+}
+
+/**
+ * Resolves the policy for one enqueue. An explicit `requested` policy always
+ * wins — but the type is still looked up first so an unregistered type throws
+ * whichever way it was called.
+ */
+export function resolveOfflinePolicy(
+  type: string,
+  requested: OfflinePolicy | undefined,
+  opts: { previouslyRejected: boolean }
+): OfflinePolicy {
+  const def = defaultOfflinePolicy(type);
+  if (requested) return requested;
+  if (def.kind === 'queue' && opts.previouslyRejected && !isOfflineQueueEnabled()) return { kind: 'reject' };
+  return def;
+}
+
+export function deliverByFor(policy: OfflinePolicy, now: Date = new Date()): Date {
+  const ms = policy.kind === 'queue' ? policy.deliverWithinMs : REJECT_RACE_GRACE_MS;
+  return new Date(now.getTime() + ms);
+}

--- a/apps/api/src/services/commandOfflinePolicy.ts
+++ b/apps/api/src/services/commandOfflinePolicy.ts
@@ -220,6 +220,41 @@ const EXTRA_ROUTE_TYPES: readonly string[] = [
   'apply_browser_policy',
 ];
 
+/**
+ * Types deliberately reviewed and left on the `standard` (7-day queue) class.
+ * Listing them explicitly is what lets the coverage test below distinguish
+ * "considered and left standard" from "nobody looked at it".
+ */
+const STANDARD_REVIEWED: readonly string[] = [
+  C.SCRIPT,
+  C.SOFTWARE_INSTALL,
+  C.SOFTWARE_UNINSTALL,
+  C.SOFTWARE_UPDATE,
+  C.HOMEBREW_BOOTSTRAP,
+  C.CIS_BENCHMARK,
+  C.APPLY_CIS_REMEDIATION,
+  C.PATCH_SCAN,
+  C.INSTALL_PATCHES,
+  C.ROLLBACK_PATCHES,
+  C.SECURITY_SCAN,
+  C.SECURITY_THREAT_QUARANTINE,
+  C.SECURITY_THREAT_REMOVE,
+  C.SECURITY_THREAT_RESTORE,
+  C.SENSITIVE_DATA_SCAN,
+  C.ENCRYPT_FILE,
+  C.SECURE_DELETE_FILE,
+  C.QUARANTINE_FILE,
+  C.ENCRYPTION_ROTATE_KEY,
+  C.APPLY_AUDIT_POLICY_BASELINE,
+  C.FILESYSTEM_ANALYSIS,
+  C.SELF_UNINSTALL,
+  C.VAULT_SYNC,
+  C.VAULT_CONFIGURE,
+  C.COLLECT_EVIDENCE,
+  C.EXECUTE_CONTAINMENT,
+  C.SYSTEM_STATE_COLLECT,
+];
+
 // Build the registry from CommandTypes so a NEW type cannot be added without
 // also being classified. A type added to CommandTypes but to none of the lists
 // lands in `standard`, the safe default for fire-and-forget work — a type that
@@ -234,6 +269,18 @@ for (const type of POWER_STATE) registry[type] = 'power_state';
 registry.wake = 'live';
 
 export const COMMAND_OFFLINE_POLICY_REGISTRY: Readonly<Record<string, DeliveryTtlClass>> = Object.freeze(registry);
+
+/**
+ * The types that were EXPLICITLY classified above, as opposed to landing on the
+ * `standard` fallback. Exported purely so a test can require every
+ * `CommandTypes` value to appear here: the fallback is `standard` (queueable),
+ * so a new command type that must never be deferred would otherwise become
+ * queueable by silence. Failing in CI is how that stays a decision rather than
+ * an oversight.
+ */
+export const EXPLICITLY_CLASSIFIED_COMMAND_TYPES: ReadonlySet<string> = Object.freeze(
+  new Set<string>([...LIVE, ...BACKUP_AND_RESTORE, ...SHORT, ...POWER_STATE, ...STANDARD_REVIEWED]),
+) as ReadonlySet<string>;
 
 export function defaultOfflinePolicy(type: string): OfflinePolicy {
   const cls = COMMAND_OFFLINE_POLICY_REGISTRY[type];

--- a/apps/api/src/services/commandOfflinePolicy.ts
+++ b/apps/api/src/services/commandOfflinePolicy.ts
@@ -1,4 +1,4 @@
-import { CommandTypes } from './commandQueue';
+import { CommandTypes } from './commandTypes';
 
 /**
  * Whether a device command may wait for an offline device, and for how long
@@ -120,6 +120,20 @@ const LIVE: readonly string[] = [
   // Addressed to a RELAY agent on the target's LAN — that relay must be online.
   C.WAKE_ON_LAN,
   C.CAPTURE_PPROF,
+  // Non-CommandTypes literals whose only dispatch path is `executeCommand`,
+  // which waits for the result synchronously (`waitForCommandResult`) — the one
+  // combination the design forbids pairing with `queue` (#5128 §A). The two
+  // agent-binary types are additionally refused by `queueCommand` outright
+  // (AGENT_BINARY_UPDATE_COMMAND_TYPES, #4093), so `live` is the only
+  // self-consistent class for them.
+  'network_discovery',
+  'update_agent',
+  'update_watchdog',
+  'restart_agent',
+  // Session-bound: a PAM elevation grant and a remote-desktop stream stop are
+  // meaningless once the session they belong to is gone.
+  'actuate_elevation',
+  'desktop_stream_stop',
 ];
 
 /**
@@ -167,6 +181,8 @@ const SHORT: readonly string[] = [
   C.AGENT_ROLLBACK_V1,
   'update',
   'set_auto_update',
+  // Policy push that converges: the next sync supersedes a stale one.
+  'apply_browser_policy',
 ];
 
 /**
@@ -195,6 +211,13 @@ const EXTRA_ROUTE_TYPES: readonly string[] = [
   'update',
   'set_auto_update',
   'wake',
+  'network_discovery',
+  'update_agent',
+  'update_watchdog',
+  'restart_agent',
+  'actuate_elevation',
+  'desktop_stream_stop',
+  'apply_browser_policy',
 ];
 
 // Build the registry from CommandTypes so a NEW type cannot be added without

--- a/apps/api/src/services/commandOfflinePolicy.ts
+++ b/apps/api/src/services/commandOfflinePolicy.ts
@@ -12,9 +12,17 @@ export type OfflinePolicy = { kind: 'reject' } | { kind: 'queue'; deliverWithinM
 export type DeliveryTtlClass = 'live' | 'standard' | 'short' | 'power_state';
 
 /**
- * A `reject` command is only ever enqueued against a device we just observed
- * online, so its row still gets a (short) deadline: a row that raced a
- * disconnect must not linger as `pending` forever.
+ * The `live` TTL class's nominal window. It is NOT stamped on `reject` rows —
+ * see `deliverByFor` — and exists only so `deliveryTtlMs` is total over
+ * `DeliveryTtlClass`.
+ *
+ * #5128 review round 2 (J): a `reject` row used to get `now() + 5 min`. That
+ * silently shortened every `executeCommand` row (commandQueue.ts) — including
+ * watchdog-targeted and `preferHeartbeat` work like `update_agent`,
+ * `restart_agent` and `filesystem_analysis` — from the legacy 30-minute
+ * execution clock to a 5-minute delivery expiry, and, with the offline-queue
+ * flag off, turned a maintenance `reboot` into a 5-minute expiry while the
+ * power-state barrier was deliberately holding it.
  */
 export const REJECT_RACE_GRACE_MS = 5 * 60 * 1000;
 
@@ -305,7 +313,17 @@ export function resolveOfflinePolicy(
   return def;
 }
 
-export function deliverByFor(policy: OfflinePolicy, now: Date = new Date()): Date {
-  const ms = policy.kind === 'queue' ? policy.deliverWithinMs : REJECT_RACE_GRACE_MS;
-  return new Date(now.getTime() + ms);
+/**
+ * The delivery deadline for a policy, or NULL for `reject`.
+ *
+ * A `reject` row carries NO `deliver_by`: it is only ever created against a
+ * device just observed online, and a NULL deadline puts it back on the legacy
+ * execution clock (`created_at + getCommandTimeoutMs`) — byte-identical to
+ * pre-#5128 behaviour for every caller that rejects. Stamping a short deadline
+ * instead expired watchdog and barrier-held work early (see
+ * REJECT_RACE_GRACE_MS).
+ */
+export function deliverByFor(policy: OfflinePolicy, now: Date = new Date()): Date | null {
+  if (policy.kind !== 'queue') return null;
+  return new Date(now.getTime() + policy.deliverWithinMs);
 }

--- a/apps/api/src/services/commandOfflinePolicy.ts
+++ b/apps/api/src/services/commandOfflinePolicy.ts
@@ -192,7 +192,7 @@ const SHORT: readonly string[] = [
  * is wrong — but not the barrier: it only asks the agent to schedule, and the
  * agent owns the delay and user deferral from there.
  */
-const POWER_STATE: readonly string[] = ['reboot', 'shutdown', C.REBOOT_SAFE_MODE, 'schedule_reboot'];
+const POWER_STATE_TTL_TYPES: readonly string[] = ['reboot', 'shutdown', C.REBOOT_SAFE_MODE, 'schedule_reboot'];
 
 /**
  * Command type literals the API writes that are NOT members of `CommandTypes`:
@@ -265,7 +265,7 @@ for (const type of EXTRA_ROUTE_TYPES) registry[type] = 'standard';
 for (const type of LIVE) registry[type] = 'live';
 for (const type of BACKUP_AND_RESTORE) registry[type] = 'live';
 for (const type of SHORT) registry[type] = 'short';
-for (const type of POWER_STATE) registry[type] = 'power_state';
+for (const type of POWER_STATE_TTL_TYPES) registry[type] = 'power_state';
 registry.wake = 'live';
 
 export const COMMAND_OFFLINE_POLICY_REGISTRY: Readonly<Record<string, DeliveryTtlClass>> = Object.freeze(registry);
@@ -279,7 +279,7 @@ export const COMMAND_OFFLINE_POLICY_REGISTRY: Readonly<Record<string, DeliveryTt
  * an oversight.
  */
 export const EXPLICITLY_CLASSIFIED_COMMAND_TYPES: ReadonlySet<string> = Object.freeze(
-  new Set<string>([...LIVE, ...BACKUP_AND_RESTORE, ...SHORT, ...POWER_STATE, ...STANDARD_REVIEWED]),
+  new Set<string>([...LIVE, ...BACKUP_AND_RESTORE, ...SHORT, ...POWER_STATE_TTL_TYPES, ...STANDARD_REVIEWED]),
 ) as ReadonlySet<string>;
 
 export function defaultOfflinePolicy(type: string): OfflinePolicy {

--- a/apps/api/src/services/commandQueue.ts
+++ b/apps/api/src/services/commandQueue.ts
@@ -144,8 +144,11 @@ export interface QueueCommandForExecutionResult {
    * not online and the command is waiting for it to come back.
    */
   delivery?: 'delivered' | 'queued_offline' | 'queued_live';
-  /** #5128. The instant after which the row expires undelivered. */
-  deliverBy?: Date;
+  /**
+   * #5128. The instant after which the row expires undelivered. NULL for a
+   * `reject` policy — those rows stay on the legacy execution clock.
+   */
+  deliverBy?: Date | null;
 }
 
 export type RearmIdempotentCommandResult =
@@ -488,7 +491,7 @@ export async function queueCommand(
   // enqueue, compared at claim time to cancel rows whose device has since moved
   // org. Both are optional so legacy callers keep today's semantics
   // (deliver_by NULL = the reaper's created_at + execution-timeout rule).
-  options: { commandId?: string; deliverBy?: Date; submittedOrgId?: string } = {}
+  options: { commandId?: string; deliverBy?: Date | null; submittedOrgId?: string } = {}
 ): Promise<QueuedCommand> {
   // #4093 — agent-binary updates must not be created here. This insert site
   // cannot set target_role (the row would default to 'agent', which has no
@@ -1037,9 +1040,13 @@ async function dispatchPreparedCommand(
           createdBy: safeUserId,
           targetRole,
           // #5128. executeCommand is synchronous by contract (the caller waits
-          // via waitForCommandResult), so it stays `reject` — but its row still
-          // carries a short delivery deadline so one that raced a disconnect
-          // cannot linger as `pending` indefinitely.
+          // via waitForCommandResult), so it stays `reject` — and a `reject`
+          // row gets NO `deliver_by`. Review round 2 (J): stamping the 5-minute
+          // race grace here cut every executeCommand row's pending window from
+          // the legacy 30-minute execution clock to 5 minutes, including
+          // watchdog-targeted and `preferHeartbeat` work (update_agent,
+          // restart_agent, filesystem_analysis) and barrier-held reboots. NULL
+          // keeps the legacy clock, so nothing changes for reject callers.
           deliverBy: deliverByFor({ kind: 'reject' }),
           submittedOrgId: device.orgId,
         })

--- a/apps/api/src/services/commandQueue.ts
+++ b/apps/api/src/services/commandQueue.ts
@@ -21,6 +21,11 @@ import {
 } from './agentEditionCompat';
 import { assertDeviceExecuteAllowed, TrustDeniedError } from './partnerTrust.commands';
 import { recordCommandDispatch } from './anomalyMetrics';
+// #5128. `dispatchDeviceCommand` imports back from this module; both uses are
+// function-level (neither evaluates the other's exports at module load), so the
+// ESM cycle resolves.
+import { dispatchDeviceCommand } from './dispatchDeviceCommand';
+import { deliverByFor, type OfflinePolicy } from './commandOfflinePolicy';
 import {
   decryptCommandForDelivery,
   terminalPayloadErasureSet,
@@ -47,177 +52,13 @@ export const WATCHDOG_STALE_MS = 10 * 60 * 1000;
 export const SEND_RETRY_ATTEMPTS = 3;
 export const SEND_RETRY_DELAY_MS = 500;
 
-// Command types for system tools
-export const CommandTypes = {
-  // Process management
-  LIST_PROCESSES: 'list_processes',
-  GET_PROCESS: 'get_process',
-  KILL_PROCESS: 'kill_process',
-
-  // Service management
-  LIST_SERVICES: 'list_services',
-  GET_SERVICE: 'get_service',
-  START_SERVICE: 'start_service',
-  STOP_SERVICE: 'stop_service',
-  RESTART_SERVICE: 'restart_service',
-
-  // Event logs (Windows)
-  EVENT_LOGS_LIST: 'event_logs_list',
-  EVENT_LOGS_QUERY: 'event_logs_query',
-  EVENT_LOG_GET: 'event_log_get',
-
-  // Scheduled tasks (Windows)
-  TASKS_LIST: 'tasks_list',
-  TASK_GET: 'task_get',
-  TASK_RUN: 'task_run',
-  TASK_ENABLE: 'task_enable',
-  TASK_DISABLE: 'task_disable',
-  TASK_HISTORY: 'task_history',
-
-  // Registry (Windows)
-  REGISTRY_KEYS: 'registry_keys',
-  REGISTRY_VALUES: 'registry_values',
-  REGISTRY_GET: 'registry_get',
-  REGISTRY_SET: 'registry_set',
-  REGISTRY_DELETE: 'registry_delete',
-  REGISTRY_KEY_CREATE: 'registry_key_create',
-  REGISTRY_KEY_DELETE: 'registry_key_delete',
-
-  // File operations
-  FILE_LIST: 'file_list',
-  FILE_READ: 'file_read',
-  FILE_WRITE: 'file_write',
-  FILE_DELETE: 'file_delete',
-  FILE_MKDIR: 'file_mkdir',
-  FILE_RENAME: 'file_rename',
-  FILESYSTEM_ANALYSIS: 'filesystem_analysis',
-  FILE_COPY: 'file_copy',
-  FILE_TRASH_LIST: 'file_trash_list',
-  FILE_TRASH_RESTORE: 'file_trash_restore',
-  FILE_TRASH_PURGE: 'file_trash_purge',
-  FILE_LIST_DRIVES: 'file_list_drives',
-
-  // Terminal
-  TERMINAL_START: 'terminal_start',
-  TERMINAL_DATA: 'terminal_data',
-  TERMINAL_RESIZE: 'terminal_resize',
-  TERMINAL_STOP: 'terminal_stop',
-
-  // Script execution
-  SCRIPT: 'script',
-  // #3525. WIRE CONTRACT: payload.executionId carries the ORIGINAL script
-  // command's `device_commands.id` — the agent keys its running-process map on
-  // cmd.ID (agent/internal/heartbeat/handlers_script.go), NOT on
-  // script_executions.id. The execution row's own id travels as the additive
-  // `scriptExecutionId` field, which deployed agents ignore. Getting this
-  // backwards makes cancellation a fleet-wide silent no-op.
-  SCRIPT_CANCEL: 'script_cancel',
-
-  // Software management
-  SOFTWARE_INSTALL: 'software_install',
-  SOFTWARE_UNINSTALL: 'software_uninstall',
-  SOFTWARE_UPDATE: 'software_update',
-  // Opt-in macOS package-manager bootstrap (installs Homebrew itself).
-  HOMEBREW_BOOTSTRAP: 'homebrew_bootstrap',
-  CIS_BENCHMARK: 'cis_benchmark',
-  APPLY_CIS_REMEDIATION: 'apply_cis_remediation',
-
-  // Patch management
-  PATCH_SCAN: 'patch_scan',
-  INSTALL_PATCHES: 'install_patches',
-  ROLLBACK_PATCHES: 'rollback_patches',
-  COLLECT_RELIABILITY_METRICS: 'collect_reliability_metrics',
-
-  // Security
-  SECURITY_COLLECT_STATUS: 'security_collect_status',
-  SECURITY_SCAN: 'security_scan',
-  SECURITY_THREAT_QUARANTINE: 'security_threat_quarantine',
-  SECURITY_THREAT_REMOVE: 'security_threat_remove',
-  SECURITY_THREAT_RESTORE: 'security_threat_restore',
-  SENSITIVE_DATA_SCAN: 'sensitive_data_scan',
-  ENCRYPT_FILE: 'encrypt_file',
-  SECURE_DELETE_FILE: 'secure_delete_file',
-  QUARANTINE_FILE: 'quarantine_file',
-
-  // Disk encryption (BitLocker / FileVault)
-  ENCRYPTION_COLLECT_KEYS: 'encryption_collect_keys',
-  ENCRYPTION_ROTATE_KEY: 'encryption_rotate_key',
-
-  // Peripheral control — pushes full active policy set to agent
-  PERIPHERAL_POLICY_SYNC: 'peripheral_policy_sync',
-  PERIPHERAL_POLICY_SYNC_V2: 'peripheral_policy_sync_v2',
-  AGENT_ROLLBACK_V1: 'agent_rollback_v1',
-
-  // Log shipping
-  SET_LOG_LEVEL: 'set_log_level',
-
-  // Runtime diagnostics — on-demand pprof capture from the agent (#2389).
-  // Profiles are captured in-process and returned base64 in the command
-  // result; the agent never opens a listening socket for this.
-  CAPTURE_PPROF: 'capture_pprof',
-
-  // Screenshot (AI Vision)
-  TAKE_SCREENSHOT: 'take_screenshot',
-
-  // Computer control (AI Computer Use)
-  COMPUTER_ACTION: 'computer_action',
-
-  // Boot performance
-  COLLECT_BOOT_PERFORMANCE: 'collect_boot_performance',
-  MANAGE_STARTUP_ITEM: 'manage_startup_item',
-
-  // Audit policy compliance
-  COLLECT_AUDIT_POLICY: 'collect_audit_policy',
-  APPLY_AUDIT_POLICY_BASELINE: 'apply_audit_policy_baseline',
-
-  // Safe mode reboot (Windows only)
-  REBOOT_SAFE_MODE: 'reboot_safe_mode',
-  // Wake-on-LAN — sent to a relay agent on the target's LAN, not the offline target itself
-  WAKE_ON_LAN: 'wake_on_lan',
-  // On-demand inventory refresh — agent re-runs every send*Inventory collector,
-  // so the API sees fresh hardware/software/network/etc. without waiting for
-  // the next periodic cycle.
-  REFRESH_INVENTORY: 'refresh_inventory',
-  // Self-uninstall (remote wipe)
-  SELF_UNINSTALL: 'self_uninstall',
-  // Backup
-  BACKUP_RUN: 'backup_run',
-  BACKUP_STOP: 'backup_stop',
-  BACKUP_RESTORE: 'backup_restore',
-  BACKUP_VERIFY: 'backup_verify',
-  BACKUP_TEST_RESTORE: 'backup_test_restore',
-  BACKUP_CLEANUP: 'backup_cleanup',
-  // VSS
-  VSS_STATUS: 'vss_status',
-  VSS_WRITER_LIST: 'vss_writer_list',
-  // MSSQL
-  MSSQL_DISCOVER: 'mssql_discover',
-  MSSQL_BACKUP: 'mssql_backup',
-  MSSQL_RESTORE: 'mssql_restore',
-  MSSQL_VERIFY: 'mssql_verify',
-  // Hyper-V
-  HYPERV_DISCOVER: 'hyperv_discover',
-  HYPERV_BACKUP: 'hyperv_backup',
-  HYPERV_RESTORE: 'hyperv_restore',
-  HYPERV_CHECKPOINT: 'hyperv_checkpoint',
-  HYPERV_VM_STATE: 'hyperv_vm_state',
-  // System state & BMR
-  SYSTEM_STATE_COLLECT: 'system_state_collect',
-  HARDWARE_PROFILE: 'hardware_profile',
-  VM_RESTORE_FROM_BACKUP: 'vm_restore_from_backup',
-  VM_RESTORE_ESTIMATE: 'vm_restore_estimate',
-  VM_INSTANT_BOOT: 'vm_instant_boot',
-  BMR_RECOVER: 'bmr_recover',
-  // Vault
-  VAULT_SYNC: 'vault_sync',
-  VAULT_STATUS: 'vault_status',
-  VAULT_CONFIGURE: 'vault_configure',
-  // Incident response
-  COLLECT_EVIDENCE: 'collect_evidence',
-  EXECUTE_CONTAINMENT: 'execute_containment',
-} as const;
-
-export type CommandType = typeof CommandTypes[keyof typeof CommandTypes];
+// Command types for system tools.
+// #5128: the table itself now lives in the leaf module ./commandTypes so the
+// fail-closed offline-policy registry can build from it at module load without
+// forming an initialisation cycle through this file. Re-exported here so every
+// existing `import { CommandTypes } from './commandQueue'` keeps working.
+export { CommandTypes, type CommandType } from './commandTypes';
+import { CommandTypes, type CommandType } from './commandTypes';
 
 export interface CommandPayload {
   [key: string]: unknown;
@@ -297,6 +138,14 @@ export interface QueueCommandForExecutionResult {
   command?: QueuedCommand;
   error?: string;
   trust?: { capability: 'device_execute'; reason: string };
+  /**
+   * #5128. `delivered` = pushed over the live socket. `queued_live` = device
+   * online, waiting for the next heartbeat. `queued_offline` = the device was
+   * not online and the command is waiting for it to come back.
+   */
+  delivery?: 'delivered' | 'queued_offline' | 'queued_live';
+  /** #5128. The instant after which the row expires undelivered. */
+  deliverBy?: Date;
 }
 
 export type RearmIdempotentCommandResult =
@@ -634,7 +483,12 @@ export async function queueCommand(
   // id has to exist BEFORE the payload is encrypted. Callers that seal a
   // payload reserve a UUID and pass it here; everyone else keeps the column
   // default. Never accept a client-supplied value.
-  options: { commandId?: string } = {}
+  // #5128: `deliverBy` is the DELIVERY deadline (the instant by which an agent
+  // must have CLAIMED the row) and `submittedOrgId` is the device's org at
+  // enqueue, compared at claim time to cancel rows whose device has since moved
+  // org. Both are optional so legacy callers keep today's semantics
+  // (deliver_by NULL = the reaper's created_at + execution-timeout rule).
+  options: { commandId?: string; deliverBy?: Date; submittedOrgId?: string } = {}
 ): Promise<QueuedCommand> {
   // #4093 — agent-binary updates must not be created here. This insert site
   // cannot set target_role (the row would default to 'agent', which has no
@@ -673,6 +527,8 @@ export async function queueCommand(
         payload,
         status: 'pending',
         createdBy: safeUserId,
+        ...(options.deliverBy ? { deliverBy: options.deliverBy } : {}),
+        ...(options.submittedOrgId ? { submittedOrgId: options.submittedOrgId } : {}),
       })
       .returning(),
   );
@@ -837,6 +693,14 @@ export async function waitForCommandResult(
 
 /**
  * Queue a command and attempt immediate dispatch to the agent websocket.
+ *
+ * #5128: this is now a thin adapter over `dispatchDeviceCommand`, the single
+ * enqueue seam. Every caller of this function hard-rejected offline devices
+ * before #5128, so it passes `previouslyRejected: true` — the
+ * DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED flag (default off) is what decides
+ * whether their offline devices reject as today or queue with a deadline.
+ * The error strings are unchanged, so callers that surface `error` verbatim
+ * behave identically while the flag is off.
  */
 export async function queueCommandForExecution(
   deviceId: string,
@@ -846,67 +710,28 @@ export async function queueCommandForExecution(
     userId?: string;
     preferHeartbeat?: boolean;
     expectedOrgId?: string;
+    /** Explicit override; wins over the registry default and the flag. */
+    offlinePolicy?: OfflinePolicy;
   } = {}
 ): Promise<QueueCommandForExecutionResult> {
-  const { userId, preferHeartbeat = false, expectedOrgId } = options;
+  const res = await dispatchDeviceCommand({
+    deviceId,
+    type,
+    payload,
+    ...(options.userId !== undefined ? { userId: options.userId } : {}),
+    ...(options.preferHeartbeat !== undefined ? { preferHeartbeat: options.preferHeartbeat } : {}),
+    ...(options.expectedOrgId !== undefined ? { expectedOrgId: options.expectedOrgId } : {}),
+    ...(options.offlinePolicy !== undefined ? { offlinePolicy: options.offlinePolicy } : {}),
+    previouslyRejected: true,
+  });
 
-  const [device] = await db
-    .select()
-    .from(devices)
-    .where(eq(devices.id, deviceId))
-    .limit(1);
-
-  if (!device) {
-    return { error: 'Device not found' };
+  if (!res.ok) {
+    return res.code === 'trust_denied' && res.trust
+      ? { error: res.error, trust: res.trust }
+      : { error: res.error };
   }
 
-  // Defense-in-depth: this lookup can run under withSystemDbAccessContext (RLS off),
-  // so callers that know the expected owning org (e.g. DR dispatch) pass expectedOrgId
-  // to prevent a cross-tenant device id from receiving a destructive command.
-  if (expectedOrgId !== undefined && device.orgId !== expectedOrgId) {
-    return { error: 'Device not found' };
-  }
-
-  if (device.status !== 'online') {
-    return { error: `Device is ${device.status}, cannot execute command` };
-  }
-
-  try {
-    await assertDeviceExecuteAllowed(deviceId, type, userId);
-  } catch (e) {
-    if (e instanceof TrustDeniedError) {
-      return {
-        error: e.code,
-        trust: { capability: e.capability, reason: e.reason },
-      };
-    }
-    throw e;
-  }
-
-  const command = await queueCommand(deviceId, type, payload, userId);
-
-  if (device.agentId && !preferHeartbeat) {
-    const claimed = await claimPendingCommandForDelivery(command.id);
-    if (claimed) {
-      // Decrypt sensitive fields just-in-time; a decrypt failure returns null
-      // (logged) and skips the send so the command is released for retry rather
-      // than throwing out of the enqueue path.
-      const delivered = decryptCommandForDelivery({ id: command.id, type, deviceId, payload });
-      const sent = delivered ? sendCommandToAgent(device.agentId, toAgentCommandFrame(delivered)) : false;
-      if (sent) {
-        return {
-          command: {
-            ...command,
-            status: 'sent',
-            executedAt: claimed.executedAt
-          } as QueuedCommand
-        };
-      }
-      await releaseClaimedCommandDelivery(command.id, claimed.executedAt);
-    }
-  }
-
-  return { command };
+  return { command: res.command, delivery: res.delivery, deliverBy: res.deliverBy };
 }
 
 export async function queueBackupStopCommand(
@@ -1211,6 +1036,12 @@ async function dispatchPreparedCommand(
           status: 'pending',
           createdBy: safeUserId,
           targetRole,
+          // #5128. executeCommand is synchronous by contract (the caller waits
+          // via waitForCommandResult), so it stays `reject` — but its row still
+          // carries a short delivery deadline so one that raced a disconnect
+          // cannot linger as `pending` indefinitely.
+          deliverBy: deliverByFor({ kind: 'reject' }),
+          submittedOrgId: device.orgId,
         })
         .returning(),
     );

--- a/apps/api/src/services/commandQueue.ts
+++ b/apps/api/src/services/commandQueue.ts
@@ -1041,12 +1041,16 @@ async function dispatchPreparedCommand(
           targetRole,
           // #5128. executeCommand is synchronous by contract (the caller waits
           // via waitForCommandResult), so it stays `reject` — and a `reject`
-          // row gets NO `deliver_by`. Review round 2 (J): stamping the 5-minute
-          // race grace here cut every executeCommand row's pending window from
-          // the legacy 30-minute execution clock to 5 minutes, including
-          // watchdog-targeted and `preferHeartbeat` work (update_agent,
-          // restart_agent, filesystem_analysis) and barrier-held reboots. NULL
+          // row gets NO `deliver_by`. Review round 2 (J): stamping the
+          // 5-minute race grace here cut every executeCommand row's pending
+          // window from the legacy 30-minute execution clock to 5 minutes,
+          // including watchdog-targeted binary/restart work and other
+          // `preferHeartbeat` callers, and it expired a barrier-held reboot
+          // while the power-state barrier was deliberately holding it. NULL
           // keeps the legacy clock, so nothing changes for reject callers.
+          // (Deliberately no literal command-type names here: the #4093 scan in
+          // agentEditionCompat.test.ts greps raw file text, and this hub file
+          // must stay off its allowlist so a real raw insert still trips it.)
           deliverBy: deliverByFor({ kind: 'reject' }),
           submittedOrgId: device.orgId,
         })

--- a/apps/api/src/services/commandTimeouts.test.ts
+++ b/apps/api/src/services/commandTimeouts.test.ts
@@ -10,10 +10,11 @@ describe('command timeouts', () => {
     expect(getCommandTimeoutMs(CommandTypes.BMR_RECOVER)).toBe(60 * 60 * 1000);
   });
 
-  it('gives queued software installs the 7-day offline window', () => {
-    // Must match SOFTWARE_QUEUED_EXPIRY_MS in jobs/staleCommandReaper.ts —
-    // a shorter value would let the generic reaper kill offline-queued
-    // installs before the device ever reconnects.
-    expect(getCommandTimeoutMs(CommandTypes.SOFTWARE_INSTALL)).toBe(7 * 24 * 60 * 60 * 1000);
+  it('gives a claimed software install a two-hour execution budget (#5128)', () => {
+    // #5128: `device_commands.deliver_by` now owns the delivery deadline for
+    // an offline-queued install (see reapStaleDeviceCommands). This timeout
+    // is purely the EXECUTION budget for an install the agent has already
+    // claimed — above its own 15 min download + 30 min install ceilings.
+    expect(getCommandTimeoutMs(CommandTypes.SOFTWARE_INSTALL)).toBe(2 * 60 * 60 * 1000);
   });
 });

--- a/apps/api/src/services/commandTimeouts.ts
+++ b/apps/api/src/services/commandTimeouts.ts
@@ -1,17 +1,10 @@
-import { CommandTypes } from './commandQueue';
+import { CommandTypes } from './commandTypes';
 
 // ── Timeout tiers (milliseconds) ──────────────────────────────────
 const FIVE_MINUTES = 5 * 60 * 1000;
 const THIRTY_MINUTES = 30 * 60 * 1000;
 const SIXTY_MINUTES = 60 * 60 * 1000;
 const TWO_HOURS = 2 * 60 * 60 * 1000;
-// Matches SOFTWARE_QUEUED_EXPIRY_MS in jobs/staleCommandReaper.ts (not imported
-// to avoid a cycle): a queued software_install may wait days for an offline
-// device to reconnect. The dedicated software-deployment reaper already fails
-// the deployment_results row after 55 min once the command is DELIVERED, so
-// this long timeout only governs how long an undelivered queued command may
-// sit before the generic reaper closes it out.
-const SEVEN_DAYS = 7 * 24 * 60 * 60 * 1000;
 const DEFAULT_TIMEOUT_MS = THIRTY_MINUTES;
 // Extra buffer on top of a script's own timeout, so the agent-side timeout
 // always fires first. Exported because the stale reaper needs it as the floor
@@ -114,6 +107,12 @@ const LONG_TIMEOUT_TYPES = new Set<string>([
   // (MaxTimeout 3600s + SCRIPT_GRACE_BUFFER_MS = 65 min), so a cancel never
   // outlives the script it is chasing.
   CommandTypes.SCRIPT_CANCEL,
+  // #5128: software_install used to get a bespoke SEVEN_DAYS here, standing in
+  // for a delivery deadline this module has no business owning. `deliver_by`
+  // now carries that, so this is purely the EXECUTION budget for an install the
+  // agent has already claimed — two hours, above the agent's own 15 min
+  // download + 30 min install ceilings.
+  CommandTypes.SOFTWARE_INSTALL,
   CommandTypes.INSTALL_PATCHES,
   CommandTypes.BACKUP_VERIFY,
   CommandTypes.BACKUP_TEST_RESTORE,
@@ -143,7 +142,6 @@ export function getCommandTimeoutMs(
         : DEFAULT_SCRIPT_TIMEOUT_S;
     return timeoutSeconds * 1000 + SCRIPT_GRACE_BUFFER_MS;
   }
-  if (commandType === CommandTypes.SOFTWARE_INSTALL) return SEVEN_DAYS;
   if (SHORT_TIMEOUT_TYPES.has(commandType)) return FIVE_MINUTES;
   if (MEDIUM_TIMEOUT_TYPES.has(commandType)) return THIRTY_MINUTES;
   if (RESTORE_TIMEOUT_TYPES.has(commandType)) return SIXTY_MINUTES;

--- a/apps/api/src/services/commandTypes.ts
+++ b/apps/api/src/services/commandTypes.ts
@@ -1,0 +1,184 @@
+/**
+ * The canonical `device_commands.type` table.
+ *
+ * #5128: extracted out of `commandQueue.ts` into a LEAF module with no imports.
+ * `commandOfflinePolicy.ts` builds its fail-closed registry from this table at
+ * module load, and `commandQueue.ts` imports the enqueue seam, which imports
+ * that registry — leaving the table in `commandQueue.ts` made that a genuine
+ * ESM initialisation cycle (the registry read `CommandTypes` before
+ * `commandQueue`'s body had run, and which side won depended only on which
+ * module the process happened to import first). `commandQueue.ts` re-exports
+ * both symbols, so every existing `import { CommandTypes } from './commandQueue'`
+ * keeps working.
+ */
+export const CommandTypes = {
+  // Process management
+  LIST_PROCESSES: 'list_processes',
+  GET_PROCESS: 'get_process',
+  KILL_PROCESS: 'kill_process',
+
+  // Service management
+  LIST_SERVICES: 'list_services',
+  GET_SERVICE: 'get_service',
+  START_SERVICE: 'start_service',
+  STOP_SERVICE: 'stop_service',
+  RESTART_SERVICE: 'restart_service',
+
+  // Event logs (Windows)
+  EVENT_LOGS_LIST: 'event_logs_list',
+  EVENT_LOGS_QUERY: 'event_logs_query',
+  EVENT_LOG_GET: 'event_log_get',
+
+  // Scheduled tasks (Windows)
+  TASKS_LIST: 'tasks_list',
+  TASK_GET: 'task_get',
+  TASK_RUN: 'task_run',
+  TASK_ENABLE: 'task_enable',
+  TASK_DISABLE: 'task_disable',
+  TASK_HISTORY: 'task_history',
+
+  // Registry (Windows)
+  REGISTRY_KEYS: 'registry_keys',
+  REGISTRY_VALUES: 'registry_values',
+  REGISTRY_GET: 'registry_get',
+  REGISTRY_SET: 'registry_set',
+  REGISTRY_DELETE: 'registry_delete',
+  REGISTRY_KEY_CREATE: 'registry_key_create',
+  REGISTRY_KEY_DELETE: 'registry_key_delete',
+
+  // File operations
+  FILE_LIST: 'file_list',
+  FILE_READ: 'file_read',
+  FILE_WRITE: 'file_write',
+  FILE_DELETE: 'file_delete',
+  FILE_MKDIR: 'file_mkdir',
+  FILE_RENAME: 'file_rename',
+  FILESYSTEM_ANALYSIS: 'filesystem_analysis',
+  FILE_COPY: 'file_copy',
+  FILE_TRASH_LIST: 'file_trash_list',
+  FILE_TRASH_RESTORE: 'file_trash_restore',
+  FILE_TRASH_PURGE: 'file_trash_purge',
+  FILE_LIST_DRIVES: 'file_list_drives',
+
+  // Terminal
+  TERMINAL_START: 'terminal_start',
+  TERMINAL_DATA: 'terminal_data',
+  TERMINAL_RESIZE: 'terminal_resize',
+  TERMINAL_STOP: 'terminal_stop',
+
+  // Script execution
+  SCRIPT: 'script',
+  // #3525. WIRE CONTRACT: payload.executionId carries the ORIGINAL script
+  // command's `device_commands.id` — the agent keys its running-process map on
+  // cmd.ID (agent/internal/heartbeat/handlers_script.go), NOT on
+  // script_executions.id. The execution row's own id travels as the additive
+  // `scriptExecutionId` field, which deployed agents ignore. Getting this
+  // backwards makes cancellation a fleet-wide silent no-op.
+  SCRIPT_CANCEL: 'script_cancel',
+
+  // Software management
+  SOFTWARE_INSTALL: 'software_install',
+  SOFTWARE_UNINSTALL: 'software_uninstall',
+  SOFTWARE_UPDATE: 'software_update',
+  // Opt-in macOS package-manager bootstrap (installs Homebrew itself).
+  HOMEBREW_BOOTSTRAP: 'homebrew_bootstrap',
+  CIS_BENCHMARK: 'cis_benchmark',
+  APPLY_CIS_REMEDIATION: 'apply_cis_remediation',
+
+  // Patch management
+  PATCH_SCAN: 'patch_scan',
+  INSTALL_PATCHES: 'install_patches',
+  ROLLBACK_PATCHES: 'rollback_patches',
+  COLLECT_RELIABILITY_METRICS: 'collect_reliability_metrics',
+
+  // Security
+  SECURITY_COLLECT_STATUS: 'security_collect_status',
+  SECURITY_SCAN: 'security_scan',
+  SECURITY_THREAT_QUARANTINE: 'security_threat_quarantine',
+  SECURITY_THREAT_REMOVE: 'security_threat_remove',
+  SECURITY_THREAT_RESTORE: 'security_threat_restore',
+  SENSITIVE_DATA_SCAN: 'sensitive_data_scan',
+  ENCRYPT_FILE: 'encrypt_file',
+  SECURE_DELETE_FILE: 'secure_delete_file',
+  QUARANTINE_FILE: 'quarantine_file',
+
+  // Disk encryption (BitLocker / FileVault)
+  ENCRYPTION_COLLECT_KEYS: 'encryption_collect_keys',
+  ENCRYPTION_ROTATE_KEY: 'encryption_rotate_key',
+
+  // Peripheral control — pushes full active policy set to agent
+  PERIPHERAL_POLICY_SYNC: 'peripheral_policy_sync',
+  PERIPHERAL_POLICY_SYNC_V2: 'peripheral_policy_sync_v2',
+  AGENT_ROLLBACK_V1: 'agent_rollback_v1',
+
+  // Log shipping
+  SET_LOG_LEVEL: 'set_log_level',
+
+  // Runtime diagnostics — on-demand pprof capture from the agent (#2389).
+  // Profiles are captured in-process and returned base64 in the command
+  // result; the agent never opens a listening socket for this.
+  CAPTURE_PPROF: 'capture_pprof',
+
+  // Screenshot (AI Vision)
+  TAKE_SCREENSHOT: 'take_screenshot',
+
+  // Computer control (AI Computer Use)
+  COMPUTER_ACTION: 'computer_action',
+
+  // Boot performance
+  COLLECT_BOOT_PERFORMANCE: 'collect_boot_performance',
+  MANAGE_STARTUP_ITEM: 'manage_startup_item',
+
+  // Audit policy compliance
+  COLLECT_AUDIT_POLICY: 'collect_audit_policy',
+  APPLY_AUDIT_POLICY_BASELINE: 'apply_audit_policy_baseline',
+
+  // Safe mode reboot (Windows only)
+  REBOOT_SAFE_MODE: 'reboot_safe_mode',
+  // Wake-on-LAN — sent to a relay agent on the target's LAN, not the offline target itself
+  WAKE_ON_LAN: 'wake_on_lan',
+  // On-demand inventory refresh — agent re-runs every send*Inventory collector,
+  // so the API sees fresh hardware/software/network/etc. without waiting for
+  // the next periodic cycle.
+  REFRESH_INVENTORY: 'refresh_inventory',
+  // Self-uninstall (remote wipe)
+  SELF_UNINSTALL: 'self_uninstall',
+  // Backup
+  BACKUP_RUN: 'backup_run',
+  BACKUP_STOP: 'backup_stop',
+  BACKUP_RESTORE: 'backup_restore',
+  BACKUP_VERIFY: 'backup_verify',
+  BACKUP_TEST_RESTORE: 'backup_test_restore',
+  BACKUP_CLEANUP: 'backup_cleanup',
+  // VSS
+  VSS_STATUS: 'vss_status',
+  VSS_WRITER_LIST: 'vss_writer_list',
+  // MSSQL
+  MSSQL_DISCOVER: 'mssql_discover',
+  MSSQL_BACKUP: 'mssql_backup',
+  MSSQL_RESTORE: 'mssql_restore',
+  MSSQL_VERIFY: 'mssql_verify',
+  // Hyper-V
+  HYPERV_DISCOVER: 'hyperv_discover',
+  HYPERV_BACKUP: 'hyperv_backup',
+  HYPERV_RESTORE: 'hyperv_restore',
+  HYPERV_CHECKPOINT: 'hyperv_checkpoint',
+  HYPERV_VM_STATE: 'hyperv_vm_state',
+  // System state & BMR
+  SYSTEM_STATE_COLLECT: 'system_state_collect',
+  HARDWARE_PROFILE: 'hardware_profile',
+  VM_RESTORE_FROM_BACKUP: 'vm_restore_from_backup',
+  VM_RESTORE_ESTIMATE: 'vm_restore_estimate',
+  VM_INSTANT_BOOT: 'vm_instant_boot',
+  BMR_RECOVER: 'bmr_recover',
+  // Vault
+  VAULT_SYNC: 'vault_sync',
+  VAULT_STATUS: 'vault_status',
+  VAULT_CONFIGURE: 'vault_configure',
+  // Incident response
+  COLLECT_EVIDENCE: 'collect_evidence',
+  EXECUTE_CONTAINMENT: 'execute_containment',
+} as const;
+
+
+export type CommandType = typeof CommandTypes[keyof typeof CommandTypes];

--- a/apps/api/src/services/dispatchDeviceCommand.test.ts
+++ b/apps/api/src/services/dispatchDeviceCommand.test.ts
@@ -1,0 +1,270 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  queueCommandMock,
+  claimMock,
+  releaseMock,
+  sendMock,
+  assertAllowedMock,
+  selectMock,
+  refreshMock,
+  decryptMock,
+} = vi.hoisted(() => ({
+  queueCommandMock: vi.fn(),
+  claimMock: vi.fn(),
+  releaseMock: vi.fn(),
+  sendMock: vi.fn(),
+  assertAllowedMock: vi.fn(),
+  selectMock: vi.fn(),
+  refreshMock: vi.fn(),
+  decryptMock: vi.fn(),
+}));
+
+vi.mock('../db', () => ({
+  db: { select: (...a: unknown[]) => selectMock(...(a as [])) },
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+vi.mock('../db/schema', () => ({ devices: { id: 'devices.id' } }));
+vi.mock('./commandQueue', () => ({
+  queueCommand: (...a: unknown[]) => queueCommandMock(...(a as [])),
+}));
+vi.mock('./commandDispatch', () => ({
+  claimPendingCommandForDelivery: (...a: unknown[]) => claimMock(...(a as [])),
+  releaseClaimedCommandDelivery: (...a: unknown[]) => releaseMock(...(a as [])),
+}));
+vi.mock('./commandDelivery', () => ({
+  refreshPayloadForDelivery: (...a: unknown[]) => refreshMock(...(a as [])),
+}));
+vi.mock('./sensitiveCommandPayload', () => ({
+  decryptCommandForDelivery: (...a: unknown[]) => decryptMock(...(a as [])),
+  toAgentCommandFrame: (c: unknown) => c,
+}));
+vi.mock('../routes/agentWs', () => ({ sendCommandToAgent: (...a: unknown[]) => sendMock(...(a as [])) }));
+vi.mock('./partnerTrust.commands', () => ({
+  assertDeviceExecuteAllowed: (...a: unknown[]) => assertAllowedMock(...(a as [])),
+  TrustDeniedError: class TrustDeniedError extends Error {
+    capability = 'device_execute' as const;
+    constructor(
+      public code: string,
+      public reason: string,
+      public deviceId: string,
+      public commandType: string,
+    ) {
+      super(`Partner trust ${code}`);
+      this.name = 'TrustDeniedError';
+    }
+  },
+}));
+
+import { dispatchDeviceCommand } from './dispatchDeviceCommand';
+import { REJECT_RACE_GRACE_MS } from './commandOfflinePolicy';
+
+const DEVICE = '11111111-1111-4111-8111-111111111111';
+const ORG = '22222222-2222-4222-8222-222222222222';
+const OTHER_ORG = '33333333-3333-4333-8333-333333333333';
+
+function deviceRow(status: string, agentId: string | null = 'agent-1') {
+  return { id: DEVICE, orgId: ORG, status, agentId };
+}
+function selectReturning(row: unknown) {
+  selectMock.mockReturnValue({ from: () => ({ where: () => ({ limit: async () => (row ? [row] : []) }) }) });
+}
+
+describe('dispatchDeviceCommand (#5128 W1)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.stubEnv('DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED', 'true');
+    assertAllowedMock.mockResolvedValue(undefined);
+    refreshMock.mockImplementation(async (_t: string, p: unknown) => p);
+    decryptMock.mockImplementation((c: unknown) => c);
+    queueCommandMock.mockImplementation(async (_d, type, _p, _u, opts) => ({
+      id: 'cmd-1',
+      type,
+      status: 'pending',
+      deliverBy: opts?.deliverBy,
+      submittedOrgId: opts?.submittedOrgId,
+    }));
+  });
+
+  it('offline device + queue policy → row persisted with deliver_by and submitted_org_id, delivery=queued_offline', async () => {
+    selectReturning(deviceRow('offline'));
+    const before = Date.now();
+    const res = await dispatchDeviceCommand({
+      deviceId: DEVICE,
+      type: 'refresh_inventory',
+      offlinePolicy: { kind: 'queue', deliverWithinMs: 3_600_000 },
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.delivery).toBe('queued_offline');
+    expect(res.deliverBy.getTime()).toBeGreaterThanOrEqual(before + 3_600_000);
+    const opts = queueCommandMock.mock.calls[0]![4] as { deliverBy: Date; submittedOrgId: string };
+    expect(opts.submittedOrgId).toBe(ORG);
+    expect(opts.deliverBy).toBeInstanceOf(Date);
+    expect(sendMock).not.toHaveBeenCalled();
+    expect(claimMock).not.toHaveBeenCalled();
+  });
+
+  it('offline device + reject policy → device_offline error, no row written', async () => {
+    selectReturning(deviceRow('offline'));
+    const res = await dispatchDeviceCommand({ deviceId: DEVICE, type: 'list_processes' });
+    expect(res).toMatchObject({ ok: false, code: 'device_offline', error: 'Device is offline, cannot execute command' });
+    expect(queueCommandMock).not.toHaveBeenCalled();
+  });
+
+  it('online device → claim + push, delivery=delivered, and the row still carries a deadline', async () => {
+    selectReturning(deviceRow('online'));
+    const executedAt = new Date();
+    claimMock.mockResolvedValue({ id: 'cmd-1', executedAt });
+    sendMock.mockReturnValue(true);
+    const res = await dispatchDeviceCommand({ deviceId: DEVICE, type: 'refresh_inventory' });
+    expect(res.ok && res.delivery).toBe('delivered');
+    expect(res.ok && res.command.status).toBe('sent');
+    expect((queueCommandMock.mock.calls[0]![4] as { deliverBy: Date }).deliverBy).toBeInstanceOf(Date);
+    expect(releaseMock).not.toHaveBeenCalled();
+  });
+
+  it('online device, push fails → claim released, delivery=queued_live', async () => {
+    selectReturning(deviceRow('online'));
+    const executedAt = new Date();
+    claimMock.mockResolvedValue({ id: 'cmd-1', executedAt });
+    sendMock.mockReturnValue(false);
+    const res = await dispatchDeviceCommand({ deviceId: DEVICE, type: 'refresh_inventory' });
+    expect(res.ok && res.delivery).toBe('queued_live');
+    expect(releaseMock).toHaveBeenCalledWith('cmd-1', executedAt);
+  });
+
+  it('online device with no agent socket → queued_live, never pushed', async () => {
+    selectReturning(deviceRow('online', null));
+    const res = await dispatchDeviceCommand({ deviceId: DEVICE, type: 'refresh_inventory' });
+    expect(res.ok && res.delivery).toBe('queued_live');
+    expect(claimMock).not.toHaveBeenCalled();
+  });
+
+  it('preferHeartbeat skips the socket push even when connected', async () => {
+    selectReturning(deviceRow('online'));
+    const res = await dispatchDeviceCommand({ deviceId: DEVICE, type: 'refresh_inventory', preferHeartbeat: true });
+    expect(res.ok && res.delivery).toBe('queued_live');
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  it('runs the delivery refresher before decrypt on the enqueue-time push', async () => {
+    selectReturning(deviceRow('online'));
+    claimMock.mockResolvedValue({ id: 'cmd-1', executedAt: new Date() });
+    sendMock.mockReturnValue(true);
+    refreshMock.mockResolvedValue({ s3Key: 'k', downloadUrl: 'https://fresh.example' });
+    await dispatchDeviceCommand({
+      deviceId: DEVICE,
+      type: 'software_install',
+      payload: { s3Key: 'k', downloadUrl: 'https://stale.example' },
+    });
+    expect(refreshMock).toHaveBeenCalledWith('software_install', { s3Key: 'k', downloadUrl: 'https://stale.example' });
+    expect(decryptMock.mock.calls[0]![0]).toMatchObject({ payload: { downloadUrl: 'https://fresh.example' } });
+  });
+
+  it('a refresher failure releases the claim instead of pushing a stale payload', async () => {
+    selectReturning(deviceRow('online'));
+    const executedAt = new Date();
+    claimMock.mockResolvedValue({ id: 'cmd-1', executedAt });
+    refreshMock.mockResolvedValue(null);
+    const res = await dispatchDeviceCommand({ deviceId: DEVICE, type: 'software_install', payload: { s3Key: 'k' } });
+    expect(sendMock).not.toHaveBeenCalled();
+    expect(releaseMock).toHaveBeenCalledWith('cmd-1', executedAt);
+    expect(res.ok && res.delivery).toBe('queued_live');
+  });
+
+  it('expectedOrgId mismatch → device_not_found (never leaks existence)', async () => {
+    selectReturning(deviceRow('online'));
+    const res = await dispatchDeviceCommand({ deviceId: DEVICE, type: 'refresh_inventory', expectedOrgId: OTHER_ORG });
+    expect(res).toMatchObject({ ok: false, code: 'device_not_found' });
+    expect(queueCommandMock).not.toHaveBeenCalled();
+  });
+
+  it('missing device → device_not_found', async () => {
+    selectReturning(null);
+    const res = await dispatchDeviceCommand({ deviceId: DEVICE, type: 'refresh_inventory' });
+    expect(res).toMatchObject({ ok: false, code: 'device_not_found', error: 'Device not found' });
+  });
+
+  it('decommissioned device → device_decommissioned regardless of policy, with the legacy error text', async () => {
+    selectReturning(deviceRow('decommissioned'));
+    const res = await dispatchDeviceCommand({
+      deviceId: DEVICE,
+      type: 'refresh_inventory',
+      offlinePolicy: { kind: 'queue', deliverWithinMs: 1000 },
+    });
+    expect(res).toMatchObject({
+      ok: false,
+      code: 'device_decommissioned',
+      error: 'Device is decommissioned, cannot execute command',
+    });
+    expect(queueCommandMock).not.toHaveBeenCalled();
+  });
+
+  it('trust denial → trust_denied with the capability/reason payload, no row', async () => {
+    selectReturning(deviceRow('online'));
+    const { TrustDeniedError } = await import('./partnerTrust.commands');
+    assertAllowedMock.mockRejectedValue(
+      new TrustDeniedError('TRUST_DENIED', 'partner_suspended', DEVICE, 'refresh_inventory')
+    );
+    const res = await dispatchDeviceCommand({ deviceId: DEVICE, type: 'refresh_inventory' });
+    expect(res).toMatchObject({
+      ok: false,
+      code: 'trust_denied',
+      trust: { capability: 'device_execute', reason: 'partner_suspended' },
+    });
+    expect(queueCommandMock).not.toHaveBeenCalled();
+  });
+
+  it('a non-trust error from the trust check propagates rather than being swallowed', async () => {
+    selectReturning(deviceRow('online'));
+    assertAllowedMock.mockRejectedValue(new Error('db down'));
+    await expect(dispatchDeviceCommand({ deviceId: DEVICE, type: 'refresh_inventory' })).rejects.toThrow('db down');
+  });
+
+  it('unregistered type throws before any DB read or write', async () => {
+    selectReturning(deviceRow('online'));
+    await expect(dispatchDeviceCommand({ deviceId: DEVICE, type: 'nope_not_real' })).rejects.toThrow(
+      /COMMAND_OFFLINE_POLICY_REGISTRY/
+    );
+    expect(selectMock).not.toHaveBeenCalled();
+    expect(queueCommandMock).not.toHaveBeenCalled();
+  });
+
+  it('a reject-policy command against an ONLINE device still gets the short race-grace deadline', async () => {
+    selectReturning(deviceRow('online'));
+    claimMock.mockResolvedValue(null);
+    const before = Date.now();
+    const res = await dispatchDeviceCommand({ deviceId: DEVICE, type: 'list_processes' });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.deliverBy.getTime()).toBeGreaterThanOrEqual(before + REJECT_RACE_GRACE_MS);
+    expect(res.deliverBy.getTime()).toBeLessThan(before + REJECT_RACE_GRACE_MS + 60_000);
+  });
+
+  it('flag off keeps a previouslyRejected caller rejecting an offline device', async () => {
+    vi.stubEnv('DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED', 'false');
+    selectReturning(deviceRow('offline'));
+    const res = await dispatchDeviceCommand({
+      deviceId: DEVICE,
+      type: 'install_patches',
+      previouslyRejected: true,
+    });
+    expect(res).toMatchObject({ ok: false, code: 'device_offline' });
+    expect(queueCommandMock).not.toHaveBeenCalled();
+  });
+
+  it('flag off does NOT gate a caller that already queued today', async () => {
+    vi.stubEnv('DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED', 'false');
+    selectReturning(deviceRow('offline'));
+    const res = await dispatchDeviceCommand({ deviceId: DEVICE, type: 'script', previouslyRejected: false });
+    expect(res.ok && res.delivery).toBe('queued_offline');
+  });
+
+  it('a device in maintenance is treated as not-online and queues', async () => {
+    selectReturning(deviceRow('maintenance'));
+    const res = await dispatchDeviceCommand({ deviceId: DEVICE, type: 'script' });
+    expect(res.ok && res.delivery).toBe('queued_offline');
+  });
+});

--- a/apps/api/src/services/dispatchDeviceCommand.test.ts
+++ b/apps/api/src/services/dispatchDeviceCommand.test.ts
@@ -9,6 +9,7 @@ const {
   selectMock,
   refreshMock,
   decryptMock,
+  captureExceptionMock,
 } = vi.hoisted(() => ({
   queueCommandMock: vi.fn(),
   claimMock: vi.fn(),
@@ -18,6 +19,7 @@ const {
   selectMock: vi.fn(),
   refreshMock: vi.fn(),
   decryptMock: vi.fn(),
+  captureExceptionMock: vi.fn(),
 }));
 
 vi.mock('../db', () => ({
@@ -41,6 +43,9 @@ vi.mock('./sensitiveCommandPayload', () => ({
   toAgentCommandFrame: (c: unknown) => c,
 }));
 vi.mock('../routes/agentWs', () => ({ sendCommandToAgent: (...a: unknown[]) => sendMock(...(a as [])) }));
+vi.mock('./sentry', () => ({
+  captureException: (...a: unknown[]) => captureExceptionMock(...(a as [])),
+}));
 vi.mock('./partnerTrust.commands', () => ({
   assertDeviceExecuteAllowed: (...a: unknown[]) => assertAllowedMock(...(a as [])),
   TrustDeniedError: class TrustDeniedError extends Error {
@@ -291,5 +296,27 @@ describe('dispatchDeviceCommand (#5128 W1)', () => {
     selectReturning(deviceRow('maintenance'));
     const res = await dispatchDeviceCommand({ deviceId: DEVICE, type: 'script' });
     expect(res.ok && res.delivery).toBe('queued_offline');
+  });
+  it('a release that itself fails still reports queued_live, and is captured', async () => {
+    // The command IS persisted and the caller's response is already true, so a
+    // failed release must not 500 a request whose write committed. The cost is
+    // that the row sits `sent` until the reaper's EXECUTION clock reaps it —
+    // recoverable, and worth reporting.
+    selectReturning(deviceRow('online'));
+    const executedAt = new Date();
+    claimMock.mockResolvedValue({ id: 'cmd-1', executedAt });
+    sendMock.mockReturnValue(false);
+    releaseMock.mockRejectedValue(new Error('pool exhausted'));
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const res = await dispatchDeviceCommand({ deviceId: DEVICE, type: 'refresh_inventory' });
+      expect(res.ok && res.delivery).toBe('queued_live');
+      expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+      expect((captureExceptionMock.mock.calls[0]![0] as Error).message).toContain('cmd-1');
+      expect((captureExceptionMock.mock.calls[0]![0] as Error).message).toContain('refresh_inventory');
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 });

--- a/apps/api/src/services/dispatchDeviceCommand.test.ts
+++ b/apps/api/src/services/dispatchDeviceCommand.test.ts
@@ -206,7 +206,7 @@ describe('dispatchDeviceCommand (#5128 W1)', () => {
     selectReturning(deviceRow('online'));
     const { TrustDeniedError } = await import('./partnerTrust.commands');
     assertAllowedMock.mockRejectedValue(
-      new TrustDeniedError('TRUST_DENIED', 'partner_suspended', DEVICE, 'refresh_inventory')
+      new TrustDeniedError('TRUST_RESTRICTED', 'partner_suspended', DEVICE, 'refresh_inventory')
     );
     const res = await dispatchDeviceCommand({ deviceId: DEVICE, type: 'refresh_inventory' });
     expect(res).toMatchObject({

--- a/apps/api/src/services/dispatchDeviceCommand.test.ts
+++ b/apps/api/src/services/dispatchDeviceCommand.test.ts
@@ -10,6 +10,7 @@ const {
   refreshMock,
   decryptMock,
   captureExceptionMock,
+  inFlightMock,
 } = vi.hoisted(() => ({
   queueCommandMock: vi.fn(),
   claimMock: vi.fn(),
@@ -20,6 +21,7 @@ const {
   refreshMock: vi.fn(),
   decryptMock: vi.fn(),
   captureExceptionMock: vi.fn(),
+  inFlightMock: vi.fn(),
 }));
 
 vi.mock('../db', () => ({
@@ -34,6 +36,7 @@ vi.mock('./commandQueue', () => ({
 vi.mock('./commandDispatch', () => ({
   claimPendingCommandForDelivery: (...a: unknown[]) => claimMock(...(a as [])),
   releaseClaimedCommandDelivery: (...a: unknown[]) => releaseMock(...(a as [])),
+  countInFlightCommandsForDevice: (...a: unknown[]) => inFlightMock(...(a as [])),
 }));
 vi.mock('./commandDelivery', () => ({
   refreshPayloadForDelivery: (...a: unknown[]) => refreshMock(...(a as [])),
@@ -63,7 +66,6 @@ vi.mock('./partnerTrust.commands', () => ({
 }));
 
 import { dispatchDeviceCommand } from './dispatchDeviceCommand';
-import { REJECT_RACE_GRACE_MS } from './commandOfflinePolicy';
 
 const DEVICE = '11111111-1111-4111-8111-111111111111';
 const ORG = '22222222-2222-4222-8222-222222222222';
@@ -82,6 +84,7 @@ describe('dispatchDeviceCommand (#5128 W1)', () => {
     vi.stubEnv('DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED', 'true');
     assertAllowedMock.mockResolvedValue(undefined);
     refreshMock.mockImplementation(async (_t: string, p: unknown) => p);
+    inFlightMock.mockResolvedValue(0);
     decryptMock.mockImplementation((c: unknown) => c);
     queueCommandMock.mockImplementation(async (_d, type, _p, _u, opts) => ({
       id: 'cmd-1',
@@ -103,7 +106,7 @@ describe('dispatchDeviceCommand (#5128 W1)', () => {
     expect(res.ok).toBe(true);
     if (!res.ok) return;
     expect(res.delivery).toBe('queued_offline');
-    expect(res.deliverBy.getTime()).toBeGreaterThanOrEqual(before + 3_600_000);
+    expect(res.deliverBy!.getTime()).toBeGreaterThanOrEqual(before + 3_600_000);
     const opts = queueCommandMock.mock.calls[0]![4] as { deliverBy: Date; submittedOrgId: string };
     expect(opts.submittedOrgId).toBe(ORG);
     expect(opts.deliverBy).toBeInstanceOf(Date);
@@ -237,15 +240,19 @@ describe('dispatchDeviceCommand (#5128 W1)', () => {
     expect(queueCommandMock).not.toHaveBeenCalled();
   });
 
-  it('a reject-policy command against an ONLINE device still gets the short race-grace deadline', async () => {
+  it('a reject-policy command against an ONLINE device gets NO delivery deadline', async () => {
+    // #5128 review round 2 (J): the 5-minute race grace used to be stamped
+    // here, which cut the pending window for every reject caller — including
+    // watchdog-targeted `update_agent`/`restart_agent` and barrier-held
+    // reboots — from the legacy 30-minute execution clock to 5 minutes. NULL
+    // restores the legacy clock exactly.
     selectReturning(deviceRow('online'));
     claimMock.mockResolvedValue(null);
-    const before = Date.now();
     const res = await dispatchDeviceCommand({ deviceId: DEVICE, type: 'list_processes' });
     expect(res.ok).toBe(true);
     if (!res.ok) return;
-    expect(res.deliverBy.getTime()).toBeGreaterThanOrEqual(before + REJECT_RACE_GRACE_MS);
-    expect(res.deliverBy.getTime()).toBeLessThan(before + REJECT_RACE_GRACE_MS + 60_000);
+    expect(res.deliverBy).toBeNull();
+    expect((queueCommandMock.mock.calls[0]![4] as { deliverBy: Date | null }).deliverBy).toBeNull();
   });
 
   it('flag off keeps a previouslyRejected caller rejecting an offline device', async () => {
@@ -267,20 +274,83 @@ describe('dispatchDeviceCommand (#5128 W1)', () => {
     expect(res.ok && res.delivery).toBe('queued_offline');
   });
 
-  it('a reboot to an ONLINE device is never socket-pushed — the barrier only runs at claim', async () => {
+  it('a power-state command is HELD from the socket while anything is in flight', async () => {
     // Pushing straight down the socket would bypass partitionClaimable's
-    // power-state barrier entirely, which is the whole protection against a
-    // queued reboot landing in the middle of a running script.
-    selectReturning(deviceRow('online'));
+    // power-state barrier, which is the whole protection against a queued
+    // reboot landing in the middle of a running script.
     for (const type of ['reboot', 'shutdown', 'reboot_safe_mode']) {
       vi.clearAllMocks();
       selectReturning(deviceRow('online'));
+      inFlightMock.mockResolvedValue(1);
       queueCommandMock.mockResolvedValue({ id: 'cmd-1', type, status: 'pending' });
       const res = await dispatchDeviceCommand({ deviceId: DEVICE, type });
       expect(res.ok && res.delivery).toBe('queued_live');
       expect(claimMock).not.toHaveBeenCalled();
       expect(sendMock).not.toHaveBeenCalled();
     }
+  });
+
+  it('a power-state command IS pushed when nothing is in flight', async () => {
+    // #5128 review round 2 (J): a blanket skip regressed the callers that have
+    // always pushed a reboot immediately — maintenanceRebootWorker (Linux
+    // maintenance windows) and the fleet-findings dispatch map — delaying a
+    // scheduled reboot by a whole heartbeat interval. The barrier's real
+    // condition is "nothing else in flight", so apply that instead.
+    for (const type of ['reboot', 'shutdown', 'reboot_safe_mode']) {
+      vi.clearAllMocks();
+      selectReturning(deviceRow('online'));
+      inFlightMock.mockResolvedValue(0);
+      refreshMock.mockImplementation(async (_t: string, p: unknown) => p);
+      decryptMock.mockImplementation((c: unknown) => c);
+      queueCommandMock.mockResolvedValue({ id: 'cmd-1', type, status: 'pending' });
+      claimMock.mockResolvedValue({ id: 'cmd-1', executedAt: new Date() });
+      sendMock.mockReturnValue(true);
+      const res = await dispatchDeviceCommand({ deviceId: DEVICE, type });
+      expect(res.ok && res.delivery).toBe('delivered');
+      expect(inFlightMock).toHaveBeenCalledWith(DEVICE);
+      expect(sendMock).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it('a non-power-state command never pays for the in-flight probe', async () => {
+    selectReturning(deviceRow('online'));
+    claimMock.mockResolvedValue({ id: 'cmd-1', executedAt: new Date() });
+    sendMock.mockReturnValue(true);
+    await dispatchDeviceCommand({ deviceId: DEVICE, type: 'refresh_inventory' });
+    expect(inFlightMock).not.toHaveBeenCalled();
+  });
+
+  it('an offline AND trust-denied device answers device_offline, with the legacy string', async () => {
+    // #5128 review round 2 (M): four backup routes classify a failure by the
+    // `Device is <status>, cannot execute command` prefix
+    // (routes/backup/vmrestore.ts, restore.ts, verificationService.ts,
+    // verificationScheduled.ts). With the trust check first they would see the
+    // raw trust code the day partner trust leaves shadow mode.
+    selectReturning(deviceRow('offline'));
+    const { TrustDeniedError } = await import('./partnerTrust.commands');
+    assertAllowedMock.mockRejectedValue(
+      new TrustDeniedError('TRUST_RESTRICTED', 'partner_suspended', DEVICE, 'list_processes'),
+    );
+    const res = await dispatchDeviceCommand({ deviceId: DEVICE, type: 'list_processes' });
+    expect(res).toMatchObject({
+      ok: false,
+      code: 'device_offline',
+      error: 'Device is offline, cannot execute command',
+    });
+    expect(queueCommandMock).not.toHaveBeenCalled();
+  });
+
+  it('a QUEUE-policy command against an offline, trust-denied device still refuses on trust', async () => {
+    // The reorder must not weaken trust: a queue caller has no offline
+    // rejection to short-circuit on, so trust is still what stops it.
+    selectReturning(deviceRow('offline'));
+    const { TrustDeniedError } = await import('./partnerTrust.commands');
+    assertAllowedMock.mockRejectedValue(
+      new TrustDeniedError('TRUST_RESTRICTED', 'partner_suspended', DEVICE, 'script'),
+    );
+    const res = await dispatchDeviceCommand({ deviceId: DEVICE, type: 'script' });
+    expect(res).toMatchObject({ ok: false, code: 'trust_denied' });
+    expect(queueCommandMock).not.toHaveBeenCalled();
   });
 
   it('a non-power-state command to an online device is still pushed immediately', async () => {

--- a/apps/api/src/services/dispatchDeviceCommand.test.ts
+++ b/apps/api/src/services/dispatchDeviceCommand.test.ts
@@ -262,6 +262,31 @@ describe('dispatchDeviceCommand (#5128 W1)', () => {
     expect(res.ok && res.delivery).toBe('queued_offline');
   });
 
+  it('a reboot to an ONLINE device is never socket-pushed — the barrier only runs at claim', async () => {
+    // Pushing straight down the socket would bypass partitionClaimable's
+    // power-state barrier entirely, which is the whole protection against a
+    // queued reboot landing in the middle of a running script.
+    selectReturning(deviceRow('online'));
+    for (const type of ['reboot', 'shutdown', 'reboot_safe_mode']) {
+      vi.clearAllMocks();
+      selectReturning(deviceRow('online'));
+      queueCommandMock.mockResolvedValue({ id: 'cmd-1', type, status: 'pending' });
+      const res = await dispatchDeviceCommand({ deviceId: DEVICE, type });
+      expect(res.ok && res.delivery).toBe('queued_live');
+      expect(claimMock).not.toHaveBeenCalled();
+      expect(sendMock).not.toHaveBeenCalled();
+    }
+  });
+
+  it('a non-power-state command to an online device is still pushed immediately', async () => {
+    selectReturning(deviceRow('online'));
+    claimMock.mockResolvedValue({ id: 'cmd-1', executedAt: new Date() });
+    sendMock.mockReturnValue(true);
+    const res = await dispatchDeviceCommand({ deviceId: DEVICE, type: 'refresh_inventory' });
+    expect(res.ok && res.delivery).toBe('delivered');
+    expect(sendMock).toHaveBeenCalled();
+  });
+
   it('a device in maintenance is treated as not-online and queues', async () => {
     selectReturning(deviceRow('maintenance'));
     const res = await dispatchDeviceCommand({ deviceId: DEVICE, type: 'script' });

--- a/apps/api/src/services/dispatchDeviceCommand.ts
+++ b/apps/api/src/services/dispatchDeviceCommand.ts
@@ -4,7 +4,11 @@ import { devices } from '../db/schema';
 import { sendCommandToAgent } from '../routes/agentWs';
 import { refreshPayloadForDelivery } from './commandDelivery';
 import { POWER_STATE_BARRIER_TYPES } from './commandClaimEligibility';
-import { claimPendingCommandForDelivery, releaseClaimedCommandDelivery } from './commandDispatch';
+import {
+  claimPendingCommandForDelivery,
+  countInFlightCommandsForDevice,
+  releaseClaimedCommandDelivery,
+} from './commandDispatch';
 import { deliverByFor, resolveOfflinePolicy, type OfflinePolicy } from './commandOfflinePolicy';
 import { queueCommand, type CommandPayload, type QueuedCommand } from './commandQueue';
 import { assertDeviceExecuteAllowed, TrustDeniedError } from './partnerTrust.commands';
@@ -43,7 +47,8 @@ export type DispatchDeviceCommandResult =
        * device was not online at enqueue.
        */
       delivery: 'delivered' | 'queued_offline' | 'queued_live';
-      deliverBy: Date;
+      /** NULL for a `reject` policy: those rows stay on the legacy execution clock. */
+      deliverBy: Date | null;
     }
   | {
       ok: false;
@@ -56,8 +61,8 @@ export type DispatchDeviceCommandResult =
  * The single enqueue seam for device commands (#5128 §D).
  *
  * Order: resolve the offline policy (throws for an unregistered type, before
- * any DB access) → device lookup → expectedOrgId → lifecycle → partner trust →
- * reject-or-queue → PERSIST THE ROW (always, before any transport) →
+ * any DB access) → device lookup → expectedOrgId → lifecycle → reject-or-queue
+ * → partner trust → PERSIST THE ROW (always, before any transport) →
  * claim/refresh/push/release when the socket is live.
  *
  * Persisting before the transport is what makes a command recoverable: the
@@ -95,6 +100,18 @@ export async function dispatchDeviceCommand(
     };
   }
 
+  // OFFLINE-REJECT COMES BEFORE TRUST, deliberately (#5128 review round 2, M).
+  // Four backup routes classify a failure by the `Device is <status>, cannot
+  // execute command` prefix (routes/backup/vmrestore.ts, restore.ts,
+  // verificationService.ts, verificationScheduled.ts). With trust first, an
+  // offline AND trust-denied device answered with the raw trust code and those
+  // callers mis-classified it. Trust is not weakened: the command is refused
+  // either way, and nothing is persisted before both checks have run.
+  const online = device.status === 'online';
+  if (!online && policy.kind === 'reject') {
+    return { ok: false, code: 'device_offline', error: `Device is ${device.status}, cannot execute command` };
+  }
+
   try {
     await assertDeviceExecuteAllowed(input.deviceId, input.type, input.userId);
   } catch (e) {
@@ -102,11 +119,6 @@ export async function dispatchDeviceCommand(
       return { ok: false, code: 'trust_denied', error: e.code, trust: { capability: e.capability, reason: e.reason } };
     }
     throw e;
-  }
-
-  const online = device.status === 'online';
-  if (!online && policy.kind === 'reject') {
-    return { ok: false, code: 'device_offline', error: `Device is ${device.status}, cannot execute command` };
   }
 
   const deliverBy = deliverByFor(policy);
@@ -120,17 +132,22 @@ export async function dispatchDeviceCommand(
   if (!online) return { ok: true, command, delivery: 'queued_offline', deliverBy };
   if (!device.agentId || input.preferHeartbeat) return { ok: true, command, delivery: 'queued_live', deliverBy };
 
-  // #5128 §E.4 — power-state commands are NEVER pushed from here. The barrier
-  // that stops a reboot landing mid-script lives in `partitionClaimable`, which
-  // only runs on the heartbeat claim; pushing a reboot straight down the socket
-  // would walk right past it. OD-3 accepts a same-second race, not a
-  // deterministic bypass for every reboot issued to an online device.
+  // #5128 §E.4 — the power-state barrier, applied HERE rather than skipping the
+  // push entirely. `partitionClaimable` enforces it on the heartbeat claim, and
+  // pushing a reboot straight down the socket would walk right past it: a
+  // queued reboot could land in the middle of a running script.
   //
-  // This also preserves the pre-#5128 behaviour of the generic device-command
-  // routes exactly: they raw-inserted a pending row and let the next heartbeat
-  // collect it, so a reboot was never socket-pushed on that path either.
+  // Review round 2 (J): a blanket skip was too blunt. `maintenanceRebootWorker`
+  // and the fleet-findings dispatch map both issue reboots that ALWAYS pushed
+  // before #5128, and downgrading them to "wait for the next heartbeat" delays
+  // a maintenance-window reboot by a whole heartbeat interval. So apply the
+  // barrier's actual condition instead: push only when nothing is in flight on
+  // this device, which is exactly what the heartbeat claim checks.
   if (POWER_STATE_BARRIER_TYPES.has(input.type)) {
-    return { ok: true, command, delivery: 'queued_live', deliverBy };
+    const inFlight = await countInFlightCommandsForDevice(input.deviceId);
+    if (inFlight > 0) {
+      return { ok: true, command, delivery: 'queued_live', deliverBy };
+    }
   }
 
   const claimed = await claimPendingCommandForDelivery(command.id);

--- a/apps/api/src/services/dispatchDeviceCommand.ts
+++ b/apps/api/src/services/dispatchDeviceCommand.ts
@@ -1,0 +1,146 @@
+import { eq } from 'drizzle-orm';
+import { db } from '../db';
+import { devices } from '../db/schema';
+import { sendCommandToAgent } from '../routes/agentWs';
+import { refreshPayloadForDelivery } from './commandDelivery';
+import { claimPendingCommandForDelivery, releaseClaimedCommandDelivery } from './commandDispatch';
+import { deliverByFor, resolveOfflinePolicy, type OfflinePolicy } from './commandOfflinePolicy';
+import { queueCommand, type CommandPayload, type QueuedCommand } from './commandQueue';
+import { assertDeviceExecuteAllowed, TrustDeniedError } from './partnerTrust.commands';
+import { decryptCommandForDelivery, toAgentCommandFrame } from './sensitiveCommandPayload';
+
+export type DispatchDeviceCommandInput = {
+  deviceId: string;
+  type: string;
+  payload?: CommandPayload;
+  userId?: string;
+  /** Explicit policy; omit to take the registry default for the type. */
+  offlinePolicy?: OfflinePolicy;
+  /**
+   * True for callers that hard-rejected offline devices before #5128. The
+   * DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED flag gates their switch to queueing;
+   * callers that already queued (scripts, software, generic routes) pass false.
+   */
+  previouslyRejected?: boolean;
+  /** Defense-in-depth for callers running under a system context. */
+  expectedOrgId?: string;
+  /** Skip the socket push even when connected (watchdog-style consumers). */
+  preferHeartbeat?: boolean;
+  /** Reserve the command id up-front (#3409: the secret envelope's AAD binds it). */
+  commandId?: string;
+};
+
+export type DispatchDeviceCommandResult =
+  | {
+      ok: true;
+      command: QueuedCommand;
+      /**
+       * `delivered` = pushed over the live socket now. `queued_live` = device is
+       * online but the push did not happen (no socket, push failed, or
+       * preferHeartbeat); the next heartbeat claims it. `queued_offline` = the
+       * device was not online at enqueue.
+       */
+      delivery: 'delivered' | 'queued_offline' | 'queued_live';
+      deliverBy: Date;
+    }
+  | {
+      ok: false;
+      code: 'device_not_found' | 'device_offline' | 'device_decommissioned' | 'trust_denied';
+      error: string;
+      trust?: { capability: 'device_execute'; reason: string };
+    };
+
+/**
+ * The single enqueue seam for device commands (#5128 §D).
+ *
+ * Order: resolve the offline policy (throws for an unregistered type, before
+ * any DB access) → device lookup → expectedOrgId → lifecycle → partner trust →
+ * reject-or-queue → PERSIST THE ROW (always, before any transport) →
+ * claim/refresh/push/release when the socket is live.
+ *
+ * Persisting before the transport is what makes a command recoverable: the
+ * software-install path used to push over the websocket WITHOUT creating a row,
+ * so a push that the agent never acted on left nothing for the reaper or the UI
+ * to find.
+ */
+export async function dispatchDeviceCommand(
+  input: DispatchDeviceCommandInput,
+): Promise<DispatchDeviceCommandResult> {
+  // Resolved first, so an unregistered command type fails loudly before any
+  // device lookup or write happens.
+  const policy = resolveOfflinePolicy(input.type, input.offlinePolicy, {
+    previouslyRejected: input.previouslyRejected ?? false,
+  });
+
+  const [device] = await db.select().from(devices).where(eq(devices.id, input.deviceId)).limit(1);
+  if (!device) return { ok: false, code: 'device_not_found', error: 'Device not found' };
+
+  // Defense-in-depth: this lookup can run under withSystemDbAccessContext (RLS
+  // off), so callers that know the expected owning org pass expectedOrgId to
+  // stop a cross-tenant device id from receiving a command. Reported as
+  // not-found so the response never confirms the device exists.
+  if (input.expectedOrgId !== undefined && device.orgId !== input.expectedOrgId) {
+    return { ok: false, code: 'device_not_found', error: 'Device not found' };
+  }
+
+  if (device.status === 'decommissioned') {
+    // Error text is byte-identical to the pre-#5128 offline rejection so callers
+    // that surface `error` verbatim are unchanged; `code` is what routes branch on.
+    return {
+      ok: false,
+      code: 'device_decommissioned',
+      error: `Device is ${device.status}, cannot execute command`,
+    };
+  }
+
+  try {
+    await assertDeviceExecuteAllowed(input.deviceId, input.type, input.userId);
+  } catch (e) {
+    if (e instanceof TrustDeniedError) {
+      return { ok: false, code: 'trust_denied', error: e.code, trust: { capability: e.capability, reason: e.reason } };
+    }
+    throw e;
+  }
+
+  const online = device.status === 'online';
+  if (!online && policy.kind === 'reject') {
+    return { ok: false, code: 'device_offline', error: `Device is ${device.status}, cannot execute command` };
+  }
+
+  const deliverBy = deliverByFor(policy);
+  const payload = input.payload ?? {};
+  const command = await queueCommand(input.deviceId, input.type, payload, input.userId, {
+    ...(input.commandId ? { commandId: input.commandId } : {}),
+    deliverBy,
+    submittedOrgId: device.orgId,
+  });
+
+  if (!online) return { ok: true, command, delivery: 'queued_offline', deliverBy };
+  if (!device.agentId || input.preferHeartbeat) return { ok: true, command, delivery: 'queued_live', deliverBy };
+
+  const claimed = await claimPendingCommandForDelivery(command.id);
+  if (!claimed) return { ok: true, command, delivery: 'queued_live', deliverBy };
+
+  // The enqueue-time push runs the same late-binding preparation the heartbeat
+  // batch does, so a `software_install` pushed now and one claimed in six hours
+  // are prepared identically.
+  const fresh = await refreshPayloadForDelivery(
+    input.type,
+    payload && typeof payload === 'object' && !Array.isArray(payload) ? (payload as Record<string, unknown>) : {},
+  );
+  const prepared = fresh
+    ? decryptCommandForDelivery({ id: command.id, type: input.type, deviceId: input.deviceId, payload: fresh })
+    : null;
+  const sent = prepared ? sendCommandToAgent(device.agentId, toAgentCommandFrame(prepared)) : false;
+  if (sent) {
+    return {
+      ok: true,
+      command: { ...command, status: 'sent', executedAt: claimed.executedAt } as QueuedCommand,
+      delivery: 'delivered',
+      deliverBy,
+    };
+  }
+
+  await releaseClaimedCommandDelivery(command.id, claimed.executedAt);
+  return { ok: true, command, delivery: 'queued_live', deliverBy };
+}

--- a/apps/api/src/services/dispatchDeviceCommand.ts
+++ b/apps/api/src/services/dispatchDeviceCommand.ts
@@ -3,11 +3,12 @@ import { db } from '../db';
 import { devices } from '../db/schema';
 import { sendCommandToAgent } from '../routes/agentWs';
 import { refreshPayloadForDelivery } from './commandDelivery';
-import { POWER_STATE_TYPES } from './commandClaimEligibility';
+import { POWER_STATE_BARRIER_TYPES } from './commandClaimEligibility';
 import { claimPendingCommandForDelivery, releaseClaimedCommandDelivery } from './commandDispatch';
 import { deliverByFor, resolveOfflinePolicy, type OfflinePolicy } from './commandOfflinePolicy';
 import { queueCommand, type CommandPayload, type QueuedCommand } from './commandQueue';
 import { assertDeviceExecuteAllowed, TrustDeniedError } from './partnerTrust.commands';
+import { captureException } from './sentry';
 import { decryptCommandForDelivery, toAgentCommandFrame } from './sensitiveCommandPayload';
 
 export type DispatchDeviceCommandInput = {
@@ -128,7 +129,7 @@ export async function dispatchDeviceCommand(
   // This also preserves the pre-#5128 behaviour of the generic device-command
   // routes exactly: they raw-inserted a pending row and let the next heartbeat
   // collect it, so a reboot was never socket-pushed on that path either.
-  if (POWER_STATE_TYPES.has(input.type)) {
+  if (POWER_STATE_BARRIER_TYPES.has(input.type)) {
     return { ok: true, command, delivery: 'queued_live', deliverBy };
   }
 
@@ -155,6 +156,26 @@ export async function dispatchDeviceCommand(
     };
   }
 
-  await releaseClaimedCommandDelivery(command.id, claimed.executedAt);
+  // The push failed, so the row must go back to `pending` for the next
+  // heartbeat. A release that ITSELF fails must not take the caller down with
+  // it — the command IS persisted and the caller's response is already true.
+  // The cost of a failed release is that the row sits `sent` until the
+  // reaper's EXECUTION clock times it out (`no response from agent`), which is
+  // recoverable; throwing here would 500 a request whose write already
+  // committed.
+  try {
+    await releaseClaimedCommandDelivery(command.id, claimed.executedAt);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(
+      '[dispatchDeviceCommand] failed to release a claim after a failed push; the row will sit `sent` until the reaper times it out',
+      { commandId: command.id, type: input.type, error: message },
+    );
+    captureException(
+      new Error(
+        `[dispatchDeviceCommand] release after failed push failed (commandId=${command.id}, type=${input.type}): ${message}`,
+      ),
+    );
+  }
   return { ok: true, command, delivery: 'queued_live', deliverBy };
 }

--- a/apps/api/src/services/dispatchDeviceCommand.ts
+++ b/apps/api/src/services/dispatchDeviceCommand.ts
@@ -3,6 +3,7 @@ import { db } from '../db';
 import { devices } from '../db/schema';
 import { sendCommandToAgent } from '../routes/agentWs';
 import { refreshPayloadForDelivery } from './commandDelivery';
+import { POWER_STATE_TYPES } from './commandClaimEligibility';
 import { claimPendingCommandForDelivery, releaseClaimedCommandDelivery } from './commandDispatch';
 import { deliverByFor, resolveOfflinePolicy, type OfflinePolicy } from './commandOfflinePolicy';
 import { queueCommand, type CommandPayload, type QueuedCommand } from './commandQueue';
@@ -117,6 +118,19 @@ export async function dispatchDeviceCommand(
 
   if (!online) return { ok: true, command, delivery: 'queued_offline', deliverBy };
   if (!device.agentId || input.preferHeartbeat) return { ok: true, command, delivery: 'queued_live', deliverBy };
+
+  // #5128 §E.4 — power-state commands are NEVER pushed from here. The barrier
+  // that stops a reboot landing mid-script lives in `partitionClaimable`, which
+  // only runs on the heartbeat claim; pushing a reboot straight down the socket
+  // would walk right past it. OD-3 accepts a same-second race, not a
+  // deterministic bypass for every reboot issued to an online device.
+  //
+  // This also preserves the pre-#5128 behaviour of the generic device-command
+  // routes exactly: they raw-inserted a pending row and let the next heartbeat
+  // collect it, so a reboot was never socket-pushed on that path either.
+  if (POWER_STATE_TYPES.has(input.type)) {
+    return { ok: true, command, delivery: 'queued_live', deliverBy };
+  }
 
   const claimed = await claimPendingCommandForDelivery(command.id);
   if (!claimed) return { ok: true, command, delivery: 'queued_live', deliverBy };

--- a/apps/api/src/services/partnerTrust.sites.test.ts
+++ b/apps/api/src/services/partnerTrust.sites.test.ts
@@ -21,14 +21,26 @@ const SYSTEM_INITIATED_EXCEPTIONS: Record<string, readonly string[]> = {
 };
 
 // `CommandTypes.NAME` references resolve through this map, built once from the
-// real `export const CommandTypes = { ... } as const` object in commandQueue.ts
-// so a renamed/added constant is picked up automatically.
+// real `export const CommandTypes = { ... } as const` object so a renamed/added
+// constant is picked up automatically.
+//
+// #5128 moved the table out of `commandQueue.ts` into the leaf module
+// `commandTypes.ts` (commandQueue re-exports it, so every import site is
+// unchanged). This scan reads the DEFINITION, so it follows the move —
+// commandQueue.ts is kept as a fallback only so the scan keeps working if the
+// table is ever folded back.
 function loadCommandTypesByName(): Map<string, string> {
-  const commandQueuePath = resolve(import.meta.dirname, './commandQueue.ts');
-  const source = readFileSync(commandQueuePath, 'utf8');
-  const block = source.match(/export const CommandTypes\s*=\s*\{([\s\S]*?)\}\s*as const/);
+  const candidates = ['./commandTypes.ts', './commandQueue.ts'];
+  let block: RegExpMatchArray | null = null;
+  for (const candidate of candidates) {
+    const source = readFileSync(resolve(import.meta.dirname, candidate), 'utf8');
+    block = source.match(/export const CommandTypes\s*=\s*\{([\s\S]*?)\}\s*as const/);
+    if (block) break;
+  }
   if (!block) {
-    throw new Error('CommandTypes constants object must remain discoverable in commandQueue.ts');
+    throw new Error(
+      `CommandTypes constants object must remain discoverable in one of: ${candidates.join(', ')}`,
+    );
   }
   const byName = new Map<string, string>();
   for (const match of block[1]!.matchAll(/\b([A-Z][A-Z0-9_]*)\s*:\s*'([^']+)'/g)) {

--- a/apps/api/src/services/partnerTrust.test.ts
+++ b/apps/api/src/services/partnerTrust.test.ts
@@ -71,6 +71,7 @@ function addMatches(source: string, pattern: RegExp, commandTypes: Set<string>):
 function dispatchedCommandTypeLiterals(): string[] {
   const srcDirectory = resolve(dirname(fileURLToPath(import.meta.url)), '..');
   const commandTypes = new Set<string>();
+  let sawCommandTypesTable = false;
 
   for (const file of sourceFilesUnder(srcDirectory)) {
     const source = readFileSync(file, 'utf8')
@@ -96,13 +97,24 @@ function dispatchedCommandTypeLiterals(): string[] {
       commandTypes,
     );
 
-    if (file.endsWith(`${join('services', 'commandQueue.ts')}`)) {
+    // #5128 moved the constants table out of commandQueue.ts into the leaf
+    // module services/commandTypes.ts (commandQueue re-exports it). The scan
+    // follows the DEFINITION; both filenames are accepted so folding it back
+    // would not silently empty this set. `sawCommandTypesTable` keeps the
+    // original guarantee — the object must remain discoverable SOMEWHERE.
+    if (
+      file.endsWith(`${join('services', 'commandTypes.ts')}`) ||
+      file.endsWith(`${join('services', 'commandQueue.ts')}`)
+    ) {
       const constants = source.match(/export const CommandTypes\s*=\s*\{([\s\S]*?)\}\s*as const/);
-      expect(constants, 'CommandTypes constants object must remain discoverable').not.toBeNull();
-      addMatches(constants?.[1] ?? '', /:\s*['"]([a-z][a-z0-9_]*)['"]/g, commandTypes);
+      if (constants) {
+        sawCommandTypesTable = true;
+        addMatches(constants[1] ?? '', /:\s*['"]([a-z][a-z0-9_]*)['"]/g, commandTypes);
+      }
     }
   }
 
+  expect(sawCommandTypesTable, 'CommandTypes constants object must remain discoverable').toBe(true);
   return [...commandTypes].sort();
 }
 

--- a/apps/api/src/services/scriptDispatch.runContext.test.ts
+++ b/apps/api/src/services/scriptDispatch.runContext.test.ts
@@ -22,7 +22,14 @@ vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
-vi.mock('./commandQueue', () => ({ queueCommand: vi.fn() }));
+// #5128: scriptDispatch.ts imports `CommandTypes` from './commandQueue' (a
+// re-export of the leaf module './commandTypes') to look up the default
+// offline policy — pull the real table in via a nested import so it cannot
+// drift from the registry `commandOfflinePolicy.ts` builds against.
+vi.mock('./commandQueue', async () => {
+  const { CommandTypes } = await import('./commandTypes');
+  return { CommandTypes, queueCommand: vi.fn() };
+});
 vi.mock('./commandDispatch', () => ({
   claimPendingCommandForDelivery: vi.fn().mockResolvedValue(null),
   releaseClaimedCommandDelivery: vi.fn().mockResolvedValue(undefined),

--- a/apps/api/src/services/scriptDispatch.test.ts
+++ b/apps/api/src/services/scriptDispatch.test.ts
@@ -315,7 +315,7 @@ describe('dispatchScriptToDevice — #5128 offline policy', () => {
 
     if (r.ok) {
       expect(r.deliverBy).toBeInstanceOf(Date);
-      expect(r.deliverBy.getTime()).toBe(deliverByMs);
+      expect(r.deliverBy!.getTime()).toBe(deliverByMs);
     }
   });
 

--- a/apps/api/src/services/scriptDispatch.test.ts
+++ b/apps/api/src/services/scriptDispatch.test.ts
@@ -6,7 +6,15 @@ vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
-vi.mock('./commandQueue', () => ({ queueCommand: vi.fn() }));
+// #5128: scriptDispatch.ts now imports `CommandTypes` from './commandQueue'
+// (a re-export of the leaf module './commandTypes') to look up the script
+// type's default offline policy. Pull the REAL table in via a nested import
+// (rather than hand-rolling `{ SCRIPT: 'script' }`) so it cannot drift from
+// the registry `commandOfflinePolicy.ts` builds against.
+vi.mock('./commandQueue', async () => {
+  const { CommandTypes } = await import('./commandTypes');
+  return { CommandTypes, queueCommand: vi.fn() };
+});
 vi.mock('./commandDispatch', () => ({
   claimPendingCommandForDelivery: vi.fn().mockResolvedValue(null),
   releaseClaimedCommandDelivery: vi.fn().mockResolvedValue(undefined),
@@ -280,6 +288,62 @@ describe('dispatchScriptToDevice — invariants', () => {
     const r = await dispatchScriptToDevice({ device: device({ osType: 'windows' }), source: { kind: 'saved', script: savedScript({ osTypes: ['linux'] }) } });
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.code).toBe('os_mismatch');
+  });
+});
+
+describe('dispatchScriptToDevice — #5128 offline policy', () => {
+  it('a queued (offline) dispatch stamps deliver_by and submitted_org_id on the command row', async () => {
+    const before = Date.now();
+    const r = await dispatchScriptToDevice({
+      device: device({ orgId: 'org-a', status: 'offline' }),
+      source: { kind: 'saved', script: savedScript() },
+    });
+
+    expect(r.ok).toBe(true);
+    const queueOptions = vi.mocked(queueCommand).mock.calls[0]![4] as
+      | { deliverBy?: Date; submittedOrgId?: string }
+      | undefined;
+    expect(queueOptions?.deliverBy).toBeInstanceOf(Date);
+    expect(queueOptions?.submittedOrgId).toBe('org-a');
+
+    // Standard TTL is 7 days (168h) by default — assert it lands roughly
+    // there rather than pinning the exact env-configurable constant.
+    const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+    const deliverByMs = queueOptions!.deliverBy!.getTime();
+    expect(deliverByMs).toBeGreaterThan(before + SEVEN_DAYS_MS - 60_000);
+    expect(deliverByMs).toBeLessThan(before + SEVEN_DAYS_MS + 60_000);
+
+    if (r.ok) {
+      expect(r.deliverBy).toBeInstanceOf(Date);
+      expect(r.deliverBy.getTime()).toBe(deliverByMs);
+    }
+  });
+
+  it('requireOnline: true is still an alias for a reject policy', async () => {
+    mockLiveDeviceStatus('offline');
+    const r = await dispatchScriptToDevice({
+      device: device({ status: 'offline' }),
+      requireOnline: true,
+      source: { kind: 'saved', script: savedScript() },
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('device_offline');
+    expect(queueCommand).not.toHaveBeenCalled();
+  });
+
+  it('an explicit offlinePolicy reject wins over the absence of requireOnline', async () => {
+    mockLiveDeviceStatus('offline');
+    const r = await dispatchScriptToDevice({
+      device: device({ status: 'offline' }),
+      // requireOnline is NOT set — only the explicit policy should gate this.
+      offlinePolicy: { kind: 'reject' },
+      source: { kind: 'saved', script: savedScript() },
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('device_offline');
+    // The reject path re-reads live status, same as requireOnline.
+    expect(db.select).toHaveBeenCalledTimes(1);
+    expect(queueCommand).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/services/scriptDispatch.ts
+++ b/apps/api/src/services/scriptDispatch.ts
@@ -8,7 +8,8 @@ import {
   claimPendingCommandForDelivery,
   releaseClaimedCommandDelivery,
 } from './commandDispatch';
-import { queueCommand } from './commandQueue';
+import { CommandTypes, queueCommand } from './commandQueue';
+import { defaultOfflinePolicy, deliverByFor, type OfflinePolicy } from './commandOfflinePolicy';
 import {
   decryptCommandForDelivery,
   toAgentCommandFrame,
@@ -78,7 +79,17 @@ export type DispatchScriptInput = {
   timeoutSeconds?: number;
   targetSessionId?: number;
   batchId?: string | null;
+  /**
+   * @deprecated #5128 — alias for `offlinePolicy: { kind: 'reject' }`. Removed
+   * in W4 once automations pass an explicit policy.
+   */
   requireOnline?: boolean;
+  /**
+   * #5128 — explicit offline policy. Omit to take the registry default for
+   * `script` (queue, standard TTL), which is what manual Run Script has always
+   * done in practice.
+   */
+  offlinePolicy?: OfflinePolicy;
   // A snapshot preloaded ONCE per fan-out by the caller (#3409 PR2 Task 4) —
   // see tenantVariableResolution.ts. Required only when `source.kind ===
   // 'saved'` and the script content actually contains a {{var.*}} token; the
@@ -92,6 +103,12 @@ export type DispatchScriptResult =
       commandId: string;
       executionId: string | null;
       delivered: boolean;
+      /**
+       * #5128 — the instant after which the command expires undelivered. For a
+       * queued (offline) dispatch this is the honest answer to "how long will
+       * this wait?"; the UI copy renders it as the expiry date.
+       */
+      deliverBy: Date;
       // Distinguishes WHY `delivered` is false. 'no_agent' is the normal
       // "queued for later" case; 'claim_lost', 'decrypt_failed', and
       // 'send_failed' all mean we had a connected agent and still failed to
@@ -190,7 +207,13 @@ export async function dispatchScriptToDevice(input: DispatchScriptInput): Promis
   if (device.status === 'decommissioned') {
     return { ok: false, code: 'device_decommissioned', error: 'Device is decommissioned' };
   }
-  if (input.requireOnline) {
+  const offlinePolicy: OfflinePolicy =
+    input.offlinePolicy ?? (input.requireOnline ? { kind: 'reject' } : defaultOfflinePolicy(CommandTypes.SCRIPT));
+  // A `reject` row is only created against a device we just observed online, so
+  // it gets the short race grace rather than a queue window.
+  const deliverBy = deliverByFor(offlinePolicy);
+
+  if (offlinePolicy.kind === 'reject') {
     // Re-read live status rather than trusting `device.status` (the caller's
     // snapshot). Automation fleet runs snapshot every target device ONCE at
     // run start (automationRuntime.ts:1712/2269) and can dispatch minutes
@@ -199,7 +222,7 @@ export async function dispatchScriptToDevice(input: DispatchScriptInput): Promis
     // (commandQueue.ts:650), which re-selected `devices.status` fresh on
     // every dispatch — a deleted test once pinned the opposite contract
     // ("must NOT pre-filter on it") for this codepath, which this restores.
-    // Only requireOnline gets the extra query: manual/route dispatch
+    // Only a `reject` policy gets the extra query: manual/route dispatch
     // deliberately queues offline devices, so no live read runs for it.
     const [liveDevice] = await db
       .select({ status: devices.status })
@@ -513,6 +536,12 @@ export async function dispatchScriptToDevice(input: DispatchScriptInput): Promis
     stage = 'queueCommand';
     command = await queueCommand(device.id, 'script', payload, safeCreatedBy ?? undefined, {
       commandId: reservedCommandId,
+      // #5128: the DELIVERY deadline. Before this, a script queued for an
+      // offline laptop was reaped after ~10 min by its own 300 s EXECUTION
+      // timeout, even though the UI promised "the run will wait until it
+      // reconnects".
+      deliverBy,
+      submittedOrgId: device.orgId,
     });
   } catch (err) {
     await discardPendingExecution(`${stage} threw`);
@@ -632,7 +661,7 @@ export async function dispatchScriptToDevice(input: DispatchScriptInput): Promis
     }
   }
 
-  return { ok: true, commandId: command.id, executionId, delivered, deliveryOutcome, executedAt, ignoredParameters, runAs, targetSessionId: input.targetSessionId ?? null };
+  return { ok: true, commandId: command.id, executionId, delivered, deliveryOutcome, executedAt, deliverBy, ignoredParameters, runAs, targetSessionId: input.targetSessionId ?? null };
 }
 
 // #3826 Wave 4A Task 3: reserved sidecar key for the users-FK probe-and-degrade

--- a/apps/api/src/services/scriptDispatch.ts
+++ b/apps/api/src/services/scriptDispatch.ts
@@ -108,7 +108,7 @@ export type DispatchScriptResult =
        * queued (offline) dispatch this is the honest answer to "how long will
        * this wait?"; the UI copy renders it as the expiry date.
        */
-      deliverBy: Date;
+      deliverBy: Date | null;
       // Distinguishes WHY `delivered` is false. 'no_agent' is the normal
       // "queued for later" case; 'claim_lost', 'decrypt_failed', and
       // 'send_failed' all mean we had a connected agent and still failed to

--- a/apps/api/src/services/scriptExecution.admission.test.ts
+++ b/apps/api/src/services/scriptExecution.admission.test.ts
@@ -99,6 +99,8 @@ const dispatched = (id: string) => ({
   executionId: `execution-${id}`,
   delivered: false,
   deliveryOutcome: 'no_agent' as const,
+  // #5128: every ok dispatch now reports its delivery deadline.
+  deliverBy: new Date('2026-09-13T00:00:00Z'),
   executedAt: null,
   ignoredParameters: [],
   runAs: 'system' as const,

--- a/apps/api/src/services/scriptExecution.test.ts
+++ b/apps/api/src/services/scriptExecution.test.ts
@@ -266,9 +266,9 @@ describe('executeScriptOnDevices — per-device dispatch failures (#3409 PR2 Tas
         baseDevice({ id: 'device-c', orgId: 'org-b' }),
       ]) as any);
     vi.mocked(dispatchScriptToDevice)
-      .mockResolvedValueOnce({ ok: true, commandId: 'cmd-a', executionId: 'exec-a', delivered: false, deliveryOutcome: 'no_agent', executedAt: null, runAs: 'system' as const, targetSessionId: null, ignoredParameters: [] })
+      .mockResolvedValueOnce({ ok: true, commandId: 'cmd-a', executionId: 'exec-a', delivered: false, deliveryOutcome: 'no_agent', executedAt: null, deliverBy: new Date('2026-09-13T00:00:00Z'), runAs: 'system' as const, targetSessionId: null, ignoredParameters: [] })
       .mockResolvedValueOnce({ ok: false, code: 'unresolved_variables', error: 'Could not resolve variable(s): repo_url' })
-      .mockResolvedValueOnce({ ok: true, commandId: 'cmd-c', executionId: 'exec-c', delivered: false, deliveryOutcome: 'no_agent', executedAt: null, runAs: 'system' as const, targetSessionId: null, ignoredParameters: [] });
+      .mockResolvedValueOnce({ ok: true, commandId: 'cmd-c', executionId: 'exec-c', delivered: false, deliveryOutcome: 'no_agent', executedAt: null, deliverBy: new Date('2026-09-13T00:00:00Z'), runAs: 'system' as const, targetSessionId: null, ignoredParameters: [] });
 
     const result = await executeScriptOnDevices({
       scriptId: 'script-1',
@@ -293,7 +293,7 @@ describe('executeScriptOnDevices — per-device dispatch failures (#3409 PR2 Tas
         baseDevice({ id: 'device-b', orgId: 'org-b' }),
       ]) as any);
     vi.mocked(dispatchScriptToDevice)
-      .mockResolvedValueOnce({ ok: true, commandId: 'cmd-a', executionId: 'exec-a', delivered: false, deliveryOutcome: 'no_agent', executedAt: null, runAs: 'system' as const, targetSessionId: null, ignoredParameters: [] })
+      .mockResolvedValueOnce({ ok: true, commandId: 'cmd-a', executionId: 'exec-a', delivered: false, deliveryOutcome: 'no_agent', executedAt: null, deliverBy: new Date('2026-09-13T00:00:00Z'), runAs: 'system' as const, targetSessionId: null, ignoredParameters: [] })
       .mockResolvedValueOnce({ ok: false, code: 'unresolved_variables', error: 'Could not resolve variable(s): repo_url' });
 
     await executeScriptOnDevices({
@@ -328,7 +328,7 @@ describe('executeScriptOnDevices — per-device dispatch failures (#3409 PR2 Tas
         baseDevice({ id: 'device-b', orgId: 'org-b' }),
       ]) as any);
     vi.mocked(dispatchScriptToDevice)
-      .mockResolvedValueOnce({ ok: true, commandId: 'cmd-a', executionId: 'exec-a', delivered: false, deliveryOutcome: 'no_agent', executedAt: null, runAs: 'system' as const, targetSessionId: null, ignoredParameters: [] })
+      .mockResolvedValueOnce({ ok: true, commandId: 'cmd-a', executionId: 'exec-a', delivered: false, deliveryOutcome: 'no_agent', executedAt: null, deliverBy: new Date('2026-09-13T00:00:00Z'), runAs: 'system' as const, targetSessionId: null, ignoredParameters: [] })
       .mockResolvedValueOnce({ ok: false, code: 'unresolved_variables', error: 'Could not resolve variable(s): repo_url' });
 
     const result = await executeScriptOnDevices({
@@ -377,6 +377,8 @@ describe('executeScriptOnDevices — dispatch codes the gate already recorded', 
     executionId: `exec-${suffix}`,
     delivered: false,
     deliveryOutcome: 'no_agent' as const,
+  // #5128: every ok dispatch now reports its delivery deadline.
+  deliverBy: new Date('2026-09-13T00:00:00Z'),
     executedAt: null,
     ignoredParameters: [],
     runAs: 'system' as const,
@@ -538,8 +540,8 @@ describe('executeScriptOnDevices — ignored bound parameters (#3409 PR3 §2.2)'
     // the same set — the caller must still see each key exactly once, and a
     // key only one device reported must not be dropped.
     vi.mocked(dispatchScriptToDevice)
-      .mockResolvedValueOnce({ ok: true, commandId: 'cmd-a', executionId: 'exec-a', delivered: false, deliveryOutcome: 'no_agent', executedAt: null, runAs: 'system' as const, targetSessionId: null, ignoredParameters: ['api_key', 'site_code'] })
-      .mockResolvedValueOnce({ ok: true, commandId: 'cmd-b', executionId: 'exec-b', delivered: false, deliveryOutcome: 'no_agent', executedAt: null, runAs: 'system' as const, targetSessionId: null, ignoredParameters: ['api_key'] });
+      .mockResolvedValueOnce({ ok: true, commandId: 'cmd-a', executionId: 'exec-a', delivered: false, deliveryOutcome: 'no_agent', executedAt: null, deliverBy: new Date('2026-09-13T00:00:00Z'), runAs: 'system' as const, targetSessionId: null, ignoredParameters: ['api_key', 'site_code'] })
+      .mockResolvedValueOnce({ ok: true, commandId: 'cmd-b', executionId: 'exec-b', delivered: false, deliveryOutcome: 'no_agent', executedAt: null, deliverBy: new Date('2026-09-13T00:00:00Z'), runAs: 'system' as const, targetSessionId: null, ignoredParameters: ['api_key'] });
 
     const result = await executeScriptOnDevices({
       scriptId: 'script-1',
@@ -558,7 +560,7 @@ describe('executeScriptOnDevices — ignored bound parameters (#3409 PR3 §2.2)'
       .mockReturnValueOnce(scriptSelectChain([baseScript({ orgId: 'org-b' })]) as any)
       .mockReturnValueOnce(devicesSelectChain([baseDevice({ id: 'device-a', orgId: 'org-b' })]) as any);
     vi.mocked(dispatchScriptToDevice)
-      .mockResolvedValueOnce({ ok: true, commandId: 'cmd-a', executionId: 'exec-a', delivered: false, deliveryOutcome: 'no_agent', executedAt: null, runAs: 'system' as const, targetSessionId: null, ignoredParameters: [] });
+      .mockResolvedValueOnce({ ok: true, commandId: 'cmd-a', executionId: 'exec-a', delivered: false, deliveryOutcome: 'no_agent', executedAt: null, deliverBy: new Date('2026-09-13T00:00:00Z'), runAs: 'system' as const, targetSessionId: null, ignoredParameters: [] });
 
     const result = await executeScriptOnDevices({
       scriptId: 'script-1',
@@ -585,7 +587,7 @@ describe('executeScriptOnDevices — ignored bound parameters (#3409 PR3 §2.2)'
       // failed device contributes nothing — the surviving device is what keeps
       // the warning alive for the run.
       .mockResolvedValueOnce({ ok: false, code: 'unresolved_parameters', error: 'Unresolved script parameter(s): no value for required parameter(s) "region"' })
-      .mockResolvedValueOnce({ ok: true, commandId: 'cmd-b', executionId: 'exec-b', delivered: false, deliveryOutcome: 'no_agent', executedAt: null, runAs: 'system' as const, targetSessionId: null, ignoredParameters: ['api_key'] });
+      .mockResolvedValueOnce({ ok: true, commandId: 'cmd-b', executionId: 'exec-b', delivered: false, deliveryOutcome: 'no_agent', executedAt: null, deliverBy: new Date('2026-09-13T00:00:00Z'), runAs: 'system' as const, targetSessionId: null, ignoredParameters: ['api_key'] });
 
     const result = await executeScriptOnDevices({
       scriptId: 'script-1',

--- a/apps/api/src/services/scriptExecutionTerminal.test.ts
+++ b/apps/api/src/services/scriptExecutionTerminal.test.ts
@@ -1,0 +1,280 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PgDialect } from 'drizzle-orm/pg-core';
+
+/**
+ * #5128 review round 2 (I) — the batch-counter contract.
+ *
+ * Before this helper existed only `reapStaleScriptExecutions` maintained
+ * `script_execution_batches`. Three other paths terminalise an execution
+ * (delivery expiry, claim-time cancel, the reaper's own `cancelled` branch) and
+ * none of them touched the counters — so `devicesCompleted + devicesFailed`
+ * could never reach `devicesTargeted` and the batch stayed non-terminal forever.
+ *
+ * The CAS on `status IN ('pending','queued','running')` is the double-count
+ * guard: whichever path flips the row increments; every later one is a no-op.
+ */
+
+const { updateMock, selectMock } = vi.hoisted(() => ({
+  updateMock: vi.fn(),
+  selectMock: vi.fn(),
+}));
+
+vi.mock('../db', () => ({ db: {
+  update: (...a: unknown[]) => updateMock(...(a as [])),
+  select: (...a: unknown[]) => selectMock(...(a as [])),
+} }));
+
+vi.mock('../db/schema', () => ({
+  scriptExecutions: {
+    id: 'script_executions.id',
+    status: 'script_executions.status',
+    errorMessage: 'script_executions.error_message',
+    completedAt: 'script_executions.completed_at',
+  },
+  scriptExecutionBatches: {
+    id: 'script_execution_batches.id',
+    status: 'script_execution_batches.status',
+    devicesTargeted: 'script_execution_batches.devices_targeted',
+    devicesCompleted: 'script_execution_batches.devices_completed',
+    devicesFailed: 'script_execution_batches.devices_failed',
+    completedAt: 'script_execution_batches.completed_at',
+  },
+}));
+
+import {
+  batchIdFromPayload,
+  finalizeScriptExecutionTerminal,
+} from './scriptExecutionTerminal';
+
+const EXEC = 'exec-1';
+const BATCH = 'batch-1';
+
+type Call = { table: string; set: Record<string, unknown>; where: unknown };
+
+/**
+ * Records every UPDATE issued on the executor, and serves the batch SELECT.
+ * `execReturning` decides whether the execution CAS matched a row — the single
+ * fact everything downstream keys on.
+ */
+function executor(opts: { execReturning: unknown[]; batch?: unknown }) {
+  const calls: Call[] = [];
+  const updates = (table: string) => ({
+    set: (vals: Record<string, unknown>) => ({
+      where: (cond: unknown) => {
+        calls.push({ table, set: vals, where: cond });
+        return {
+          returning: async () => (table === 'script_executions' ? opts.execReturning : []),
+          then: (res: (v: unknown) => unknown) => res(undefined),
+        };
+      },
+    }),
+  });
+  const exec = {
+    update: (table: unknown) =>
+      updates(
+        (table as { id?: string }).id === 'script_executions.id'
+          ? 'script_executions'
+          : 'script_execution_batches',
+      ),
+    select: () => ({
+      from: () => ({ where: async () => (opts.batch ? [opts.batch] : []) }),
+    }),
+  };
+  return { exec: exec as never, calls };
+}
+
+describe('finalizeScriptExecutionTerminal (#5128 I)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('terminalises the execution and increments devicesFailed for a delivery expiry', async () => {
+    const { exec, calls } = executor({
+      execReturning: [{ id: EXEC }],
+      batch: { devicesTargeted: 2, devicesCompleted: 0, devicesFailed: 1 },
+    });
+
+    const res = await finalizeScriptExecutionTerminal({
+      executionId: EXEC,
+      batchId: BATCH,
+      outcome: 'failed',
+      errorMessage: 'Device did not reconnect before the deadline',
+      completedAt: new Date(),
+      executor: exec,
+    });
+
+    expect(res).toEqual({ terminalised: true });
+    expect(calls[0]!.table).toBe('script_executions');
+    expect(calls[0]!.set).toMatchObject({ status: 'failed' });
+    // Exactly one counter write, and it is devicesFailed — not devicesCompleted.
+    const counterWrites = calls.filter(
+      (c) => c.table === 'script_execution_batches' && 'devicesFailed' in c.set,
+    );
+    expect(counterWrites).toHaveLength(1);
+    expect(calls.some((c) => 'devicesCompleted' in c.set)).toBe(false);
+  });
+
+  it('a claim-time cancel takes the same path', async () => {
+    const { exec, calls } = executor({
+      execReturning: [{ id: EXEC }],
+      batch: { devicesTargeted: 5, devicesCompleted: 0, devicesFailed: 1 },
+    });
+
+    await finalizeScriptExecutionTerminal({
+      executionId: EXEC,
+      batchId: BATCH,
+      outcome: 'cancelled',
+      errorMessage: 'Cancelled before the device received it',
+      completedAt: new Date(),
+      executor: exec,
+    });
+
+    expect(calls[0]!.set).toMatchObject({ status: 'cancelled' });
+    expect(calls.filter((c) => 'devicesFailed' in c.set)).toHaveLength(1);
+  });
+
+  it('a completed outcome counts toward devicesCompleted instead', async () => {
+    const { exec, calls } = executor({
+      execReturning: [{ id: EXEC }],
+      batch: { devicesTargeted: 5, devicesCompleted: 1, devicesFailed: 0 },
+    });
+
+    await finalizeScriptExecutionTerminal({
+      executionId: EXEC,
+      batchId: BATCH,
+      outcome: 'completed',
+      errorMessage: null,
+      completedAt: new Date(),
+      executor: exec,
+    });
+
+    expect(calls.some((c) => 'devicesCompleted' in c.set)).toBe(true);
+    expect(calls.some((c) => 'devicesFailed' in c.set)).toBe(false);
+  });
+
+  it('terminalises the BATCH once the counters reach devicesTargeted', async () => {
+    const { exec, calls } = executor({
+      execReturning: [{ id: EXEC }],
+      // Post-increment view: this was the last device, and one failed.
+      batch: { devicesTargeted: 2, devicesCompleted: 1, devicesFailed: 1 },
+    });
+
+    await finalizeScriptExecutionTerminal({
+      executionId: EXEC,
+      batchId: BATCH,
+      outcome: 'failed',
+      errorMessage: 'boom',
+      completedAt: new Date(),
+      executor: exec,
+    });
+
+    const terminal = calls.find((c) => 'status' in c.set && c.table === 'script_execution_batches');
+    expect(terminal?.set).toMatchObject({ status: 'failed' });
+  });
+
+  it('an all-success batch terminalises as completed', async () => {
+    const { exec, calls } = executor({
+      execReturning: [{ id: EXEC }],
+      batch: { devicesTargeted: 2, devicesCompleted: 2, devicesFailed: 0 },
+    });
+
+    await finalizeScriptExecutionTerminal({
+      executionId: EXEC,
+      batchId: BATCH,
+      outcome: 'completed',
+      errorMessage: null,
+      completedAt: new Date(),
+      executor: exec,
+    });
+
+    const terminal = calls.find((c) => 'status' in c.set && c.table === 'script_execution_batches');
+    expect(terminal?.set).toMatchObject({ status: 'completed' });
+  });
+
+  it('leaves the batch alone while devices are still outstanding', async () => {
+    const { exec, calls } = executor({
+      execReturning: [{ id: EXEC }],
+      batch: { devicesTargeted: 5, devicesCompleted: 1, devicesFailed: 1 },
+    });
+
+    await finalizeScriptExecutionTerminal({
+      executionId: EXEC,
+      batchId: BATCH,
+      outcome: 'failed',
+      errorMessage: 'boom',
+      completedAt: new Date(),
+      executor: exec,
+    });
+
+    expect(calls.some((c) => c.table === 'script_execution_batches' && 'status' in c.set)).toBe(false);
+  });
+
+  it('a CAS that matches nothing does NOT double-count the batch', async () => {
+    // This is the case where `propagateCancelledDeviceCommand` already
+    // terminalised the execution and the reaper's `cancelled` branch arrives
+    // afterwards. Without the fence the batch would be charged twice and could
+    // overshoot devicesTargeted (or terminalise on the wrong device).
+    const { exec, calls } = executor({ execReturning: [] });
+
+    const res = await finalizeScriptExecutionTerminal({
+      executionId: EXEC,
+      batchId: BATCH,
+      outcome: 'cancelled',
+      errorMessage: 'Cancelled before the device received it',
+      completedAt: new Date(),
+      executor: exec,
+    });
+
+    expect(res).toEqual({ terminalised: false });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.table).toBe('script_executions');
+  });
+
+  it('the execution UPDATE is fenced on the non-terminal statuses', async () => {
+    const { exec, calls } = executor({ execReturning: [{ id: EXEC }] });
+
+    await finalizeScriptExecutionTerminal({
+      executionId: EXEC,
+      outcome: 'cancelled',
+      errorMessage: null,
+      completedAt: new Date(),
+      executor: exec,
+    });
+
+    // The mocked columns are plain strings, so they render as bound params and
+    // the exact fence is checkable. Dropping it is what would allow the double
+    // count this suite exists to prevent.
+    const { params } = new PgDialect().sqlToQuery(calls[0]!.where as never);
+    expect(params).toEqual([
+      'script_executions.id',
+      EXEC,
+      'script_executions.status',
+      'pending',
+      'queued',
+      'running',
+    ]);
+  });
+
+  it('no batchId means no batch traffic at all', async () => {
+    const { exec, calls } = executor({ execReturning: [{ id: EXEC }] });
+
+    await finalizeScriptExecutionTerminal({
+      executionId: EXEC,
+      batchId: null,
+      outcome: 'failed',
+      errorMessage: 'boom',
+      completedAt: new Date(),
+      executor: exec,
+    });
+
+    expect(calls).toHaveLength(1);
+  });
+
+  it('batchIdFromPayload only accepts a non-empty string', () => {
+    expect(batchIdFromPayload({ batchId: 'b1' })).toBe('b1');
+    expect(batchIdFromPayload({ batchId: '  ' })).toBeNull();
+    expect(batchIdFromPayload({ batchId: 42 })).toBeNull();
+    expect(batchIdFromPayload({})).toBeNull();
+    expect(batchIdFromPayload(null)).toBeNull();
+    expect(batchIdFromPayload('nope')).toBeNull();
+    expect(batchIdFromPayload([{ batchId: 'b1' }])).toBeNull();
+  });
+});

--- a/apps/api/src/services/scriptExecutionTerminal.ts
+++ b/apps/api/src/services/scriptExecutionTerminal.ts
@@ -81,6 +81,16 @@ export function batchIdFromPayload(payload: unknown): string | null {
   return typeof value === 'string' && value.trim().length > 0 ? value : null;
 }
 
+/**
+ * Increment + completion check. Deliberately NOT wrapped in its own
+ * transaction: callers that need atomicity (the cancel-on-event sweeps, the
+ * heartbeat claim) already pass their own `executor`, and one that cannot open
+ * a nested one would be handed a savepoint for no benefit. The increment is a
+ * single atomic `x = x + 1`, the follow-up SELECT sees it, and the batch's
+ * terminal UPDATE is idempotent — so two racing finalisers can at worst both
+ * write the same terminal row, which the previous inline `db.transaction`
+ * (READ COMMITTED, no row lock) also allowed.
+ */
 async function applyBatchCounter(
   executor: ScriptTerminalExecutor,
   batchId: string,

--- a/apps/api/src/services/scriptExecutionTerminal.ts
+++ b/apps/api/src/services/scriptExecutionTerminal.ts
@@ -1,0 +1,118 @@
+import { and, eq, inArray, sql } from 'drizzle-orm';
+import { db } from '../db';
+import { scriptExecutions, scriptExecutionBatches } from '../db/schema';
+
+/**
+ * The ONE place a `script_executions` row is driven terminal by the server, and
+ * the only place `script_execution_batches` counters are maintained.
+ *
+ * WHY THIS EXISTS (#5128 review round 2, item I). Before this, only
+ * `reapStaleScriptExecutions` kept the batch counters. Three other paths also
+ * terminalise an execution — `propagateTimedOutDeviceCommand` (delivery
+ * expiry / execution timeout), `propagateCancelledDeviceCommand` (user cancel,
+ * org move, decommission, claim-time ineligibility) and the reaper's own
+ * `cancelled` branch — and none of them touched the batch. Once the execution
+ * row is terminal the reaper's selector (`status IN ('pending','queued',
+ * 'running')`) never revisits it, so `devicesCompleted + devicesFailed` could
+ * never reach `devicesTargeted` and the batch stayed non-terminal FOREVER. It
+ * is the same defect class `commandResultHandlers.ts` (~680) already documents.
+ *
+ * THE CAS IS THE DOUBLE-COUNT GUARD. The batch counter is incremented only when
+ * this call is the one that actually flipped the execution row; a second path
+ * arriving later matches zero rows and increments nothing. Never increment a
+ * counter outside this function.
+ */
+
+/**
+ * Anything that can run these statements: the ambient `db`, or a caller's open
+ * transaction handle (the cancel-on-event sweeps and the heartbeat claim both
+ * need the bookkeeping inside their own transaction).
+ */
+type ScriptTerminalExecutor = Pick<typeof db, 'update' | 'select'>;
+
+/**
+ * Terminal states an execution can be driven to from the server side.
+ * `completed` is the only one that counts toward `devicesCompleted`; every
+ * other outcome counts as a batch failure, exactly as the reaper has always
+ * done (a stopped or expired device is not a success for the batch).
+ */
+export type ScriptExecutionTerminalOutcome = 'completed' | 'failed' | 'timeout' | 'cancelled';
+
+export async function finalizeScriptExecutionTerminal(params: {
+  executionId: string;
+  /** From the owning command's `payload.batchId`; absent for single-device runs. */
+  batchId?: string | null;
+  outcome: ScriptExecutionTerminalOutcome;
+  errorMessage: string | null;
+  completedAt: Date;
+  executor?: ScriptTerminalExecutor;
+}): Promise<{ terminalised: boolean }> {
+  const { executionId, outcome, errorMessage, completedAt } = params;
+  const executor: ScriptTerminalExecutor = params.executor ?? db;
+
+  const updated = await executor
+    .update(scriptExecutions)
+    .set({ status: outcome, errorMessage, completedAt })
+    .where(
+      and(
+        eq(scriptExecutions.id, executionId),
+        // The double-count fence. Also the reason a row already terminalised by
+        // an earlier propagation path is a no-op here rather than a second
+        // increment.
+        inArray(scriptExecutions.status, ['pending', 'queued', 'running']),
+      ),
+    )
+    .returning({ id: scriptExecutions.id });
+
+  if (updated.length === 0) return { terminalised: false };
+
+  const batchId = params.batchId ?? null;
+  if (batchId) {
+    await applyBatchCounter(executor, batchId, outcome);
+  }
+
+  return { terminalised: true };
+}
+
+/** Reads a `batchId` out of an arbitrary command payload, or null. */
+export function batchIdFromPayload(payload: unknown): string | null {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return null;
+  const value = (payload as Record<string, unknown>).batchId;
+  return typeof value === 'string' && value.trim().length > 0 ? value : null;
+}
+
+async function applyBatchCounter(
+  executor: ScriptTerminalExecutor,
+  batchId: string,
+  outcome: ScriptExecutionTerminalOutcome,
+): Promise<void> {
+  // A recovered success must not be counted as a batch failure.
+  await executor
+    .update(scriptExecutionBatches)
+    .set(
+      outcome === 'completed'
+        ? { devicesCompleted: sql`${scriptExecutionBatches.devicesCompleted} + 1` }
+        : { devicesFailed: sql`${scriptExecutionBatches.devicesFailed} + 1` },
+    )
+    .where(eq(scriptExecutionBatches.id, batchId));
+
+  const [batch] = await executor
+    .select({
+      devicesTargeted: scriptExecutionBatches.devicesTargeted,
+      devicesCompleted: scriptExecutionBatches.devicesCompleted,
+      devicesFailed: scriptExecutionBatches.devicesFailed,
+    })
+    .from(scriptExecutionBatches)
+    .where(eq(scriptExecutionBatches.id, batchId));
+
+  if (!batch) return;
+  if (batch.devicesCompleted + batch.devicesFailed < batch.devicesTargeted) return;
+
+  await executor
+    .update(scriptExecutionBatches)
+    .set({
+      status: batch.devicesFailed > 0 ? 'failed' : 'completed',
+      completedAt: new Date(),
+    })
+    .where(eq(scriptExecutionBatches.id, batchId));
+}

--- a/apps/api/src/services/softwareDeployment.test.ts
+++ b/apps/api/src/services/softwareDeployment.test.ts
@@ -1,9 +1,16 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // vi.hoisted so the mock factories can reference the mocks
-const { sendCommandMock, queueCommandMock } = vi.hoisted(() => ({
-  sendCommandMock: vi.fn(),
-  queueCommandMock: vi.fn(),
+//
+// #5128: dispatchSoftwareInstallToDevice no longer calls sendCommandToAgent /
+// queueCommand itself — it goes through dispatchDeviceCommand (the single
+// enqueue seam in ./dispatchDeviceCommand), which persists the device_commands
+// row BEFORE any transport and pushes over the socket itself. Mocking that one
+// seam is the whole story for this file's install-dispatch path; the real
+// sendCommandToAgent/queueCommand implementations live one layer down inside
+// dispatchDeviceCommand.ts and are exercised by that module's own test suite.
+const { dispatchDeviceCommandMock } = vi.hoisted(() => ({
+  dispatchDeviceCommandMock: vi.fn(),
 }));
 
 // Wave 6 Task 5: the dispatch path reads the org ∪ site approved-private-origin
@@ -16,11 +23,12 @@ vi.mock('./softwareDownloadPolicy', () => ({
   getEffectiveSoftwareDownloadPolicy: effectivePolicyMock,
 }));
 
-// Match the exact import paths used by routes/software.ts (and the service will mirror them)
-vi.mock('../routes/agentWs', () => ({ sendCommandToAgent: sendCommandMock }));
-
-// Offline fallback path (dispatchSoftwareInstallToDevice)
-vi.mock('./commandQueue', () => ({ queueCommand: queueCommandMock }));
+// The ONE enqueue seam (#5128 §D). Mocked wholesale — softwareDeployment.ts's
+// own contract is "call this with the right deviceId/type/payload/policy and
+// react to ok/delivery correctly", not the seam's internal WS-vs-queue
+// mechanics (device lookup, trust checks, claim/push/release), which belong
+// to dispatchDeviceCommand.test.ts.
+vi.mock('./dispatchDeviceCommand', () => ({ dispatchDeviceCommand: dispatchDeviceCommandMock }));
 
 vi.mock('../services/s3Storage', () => ({
   getPresignedUrl: vi.fn(async () => 'https://signed.example/pkg.exe'),
@@ -112,9 +120,11 @@ import {
   dispatchSoftwareInstallToDevice,
 } from './softwareDeployment';
 import { resolveEdrInstaller } from './edrInstallerResolver';
+import { getPresignedUrl } from './s3Storage';
 import { inArray } from 'drizzle-orm';
 
 const resolveEdrMock = vi.mocked(resolveEdrInstaller);
+const getPresignedUrlMock = vi.mocked(getPresignedUrl);
 
 // ---------------------------------------------------------------------------
 // Mock builder helpers
@@ -200,15 +210,19 @@ let updateSetCalls: Record<string, unknown>[] = [];
 
 describe('createSoftwareDeployment', () => {
   beforeEach(() => {
-    sendCommandMock.mockReset();
-    queueCommandMock.mockReset();
+    dispatchDeviceCommandMock.mockReset();
     selectMock.mockReset();
     insertMock.mockReset();
     updateMock.mockReset();
-    // Defaults: agent is online (WS delivery succeeds), and the offline
-    // fallback returns a queued device_commands row when exercised.
-    sendCommandMock.mockReturnValue(true);
-    queueCommandMock.mockResolvedValue({ id: 'queued-cmd-1' });
+    // Default: the seam accepts and delivers over the live socket. Individual
+    // tests override with mockImplementation/mockResolvedValueOnce to exercise
+    // the queued-offline and refused paths.
+    dispatchDeviceCommandMock.mockImplementation(async ({ deviceId }: { deviceId: string }) => ({
+      ok: true,
+      command: { id: `cmd-${deviceId}`, status: 'pending' },
+      delivery: 'delivered',
+      deliverBy: new Date(Date.now() + 7 * 24 * 3600 * 1000),
+    }));
     // Default capturing update chain — individual tests may still override
     // with mockReturnValue/mockReturnValueOnce.
     updateSetCalls = [];
@@ -272,30 +286,121 @@ describe('createSoftwareDeployment', () => {
     expect(result.status).toBe('pending');
     expect(result.deployment).toEqual(deployment);
     expect(result.dispatchedDeviceIds).toEqual(['dev-1', 'dev-2']);
+    // #5128: deviceCommandId is ALWAYS the seam's persisted row id now — the
+    // row is written before push, on both transports, never null.
     expect(result.deviceResults).toEqual([
       {
         deviceId: 'dev-1',
         deploymentResultId: 'result-dev-1',
         status: 'delivered',
-        deviceCommandId: null,
+        deviceCommandId: 'cmd-dev-1',
       },
       {
         deviceId: 'dev-2',
         deploymentResultId: 'result-dev-2',
         status: 'delivered',
-        deviceCommandId: null,
+        deviceCommandId: 'cmd-dev-2',
       },
     ]);
-    expect(sendCommandMock).toHaveBeenCalledTimes(2);
-    expect(sendCommandMock.mock.calls[0]![1].type).toBe('software_install');
-    // WS delivery succeeded for both devices — the offline fallback must not fire.
-    expect(queueCommandMock).not.toHaveBeenCalled();
+    expect(dispatchDeviceCommandMock).toHaveBeenCalledTimes(2);
+    expect(dispatchDeviceCommandMock.mock.calls[0]![0]).toMatchObject({
+      deviceId: 'dev-1',
+      type: 'software_install',
+    });
+    expect(dispatchDeviceCommandMock.mock.calls[1]![0]).toMatchObject({
+      deviceId: 'dev-2',
+      type: 'software_install',
+    });
     // dispatched_at claim marker set exactly once for the immediate path.
     const dispatchClaims = updateSetCalls.filter((v) => v.dispatchedAt instanceof Date);
     expect(dispatchClaims).toHaveLength(1);
   });
 
-  it('falls back to queueCommand and records deviceCommandId when the agent has no live WS socket', async () => {
+  // #5128 (OD-8): a presigned URL is only valid for an hour, but a queued
+  // install may be claimed days later. The payload carries the STABLE s3Key
+  // reference too, so deliveryRefreshers['software_install'] can re-mint the
+  // URL at claim time — but ONLY when the URL shipped to THIS device is
+  // exactly the one minted from that key; an EDR-resolved or stored URL must
+  // never be silently treated as refreshable.
+  it('carries s3Key in the payload when the download URL is the presigned one', async () => {
+    const versionRecord = {
+      id: 'ver-s3',
+      catalogId: 'cat-1',
+      s3Key: 'pkg.key',
+      downloadUrl: null,
+      checksum: null,
+      originalFileName: 'pkg.exe',
+      fileType: 'exe',
+      silentInstallArgs: null,
+      version: '1.0.0',
+    };
+    const catalogItem = { id: 'cat-1', orgId: null, name: 'TestApp', integrationProvider: null };
+    const deployment = { id: 'dep-s3', orgId: 'org-1' };
+    const targetDevices = [{ id: 'dev-1', agentId: 'agent-1' }];
+
+    getPresignedUrlMock.mockResolvedValueOnce('https://signed.example/pkg.key.exe');
+    selectMock
+      .mockReturnValueOnce(sel([versionRecord]))
+      .mockReturnValueOnce(sel([catalogItem]))
+      .mockReturnValueOnce(sel(targetDevices));
+    insertMock.mockReturnValueOnce(insWithReturning([deployment])).mockReturnValueOnce(ins());
+
+    await createSoftwareDeployment({
+      orgId: 'org-1',
+      softwareVersionId: 'ver-s3',
+      deploymentType: 'install',
+      deviceIds: ['dev-1'],
+      scheduleType: 'immediate',
+      createdBy: null,
+    });
+
+    const payload = dispatchDeviceCommandMock.mock.calls[0]![0].payload;
+    expect(payload.downloadUrl).toBe('https://signed.example/pkg.key.exe');
+    expect(payload.s3Key).toBe('pkg.key');
+  });
+
+  it('omits s3Key when the download URL did NOT come from that key (presign failed, stored URL used)', async () => {
+    const versionRecord = {
+      id: 'ver-s3-fallback',
+      catalogId: 'cat-1',
+      s3Key: 'pkg.key',
+      // The stored fallback URL — what deviceDownloadUrl ends up being when
+      // presign fails and the code falls back past it.
+      downloadUrl: 'https://cdn.example.com/stored/pkg.exe',
+      checksum: null,
+      originalFileName: 'pkg.exe',
+      fileType: 'exe',
+      silentInstallArgs: null,
+      version: '1.0.0',
+    };
+    const catalogItem = { id: 'cat-1', orgId: null, name: 'TestApp', integrationProvider: null };
+    const deployment = { id: 'dep-s3-fallback', orgId: 'org-1' };
+    const targetDevices = [{ id: 'dev-1', agentId: 'agent-1' }];
+
+    // Presign throws (e.g. transport/auth fault) — the s3Key is present but
+    // the URL actually shipped is the stored one, not a presigned one.
+    getPresignedUrlMock.mockRejectedValueOnce(new Error('presign transport error'));
+    selectMock
+      .mockReturnValueOnce(sel([versionRecord]))
+      .mockReturnValueOnce(sel([catalogItem]))
+      .mockReturnValueOnce(sel(targetDevices));
+    insertMock.mockReturnValueOnce(insWithReturning([deployment])).mockReturnValueOnce(ins());
+
+    await createSoftwareDeployment({
+      orgId: 'org-1',
+      softwareVersionId: 'ver-s3-fallback',
+      deploymentType: 'install',
+      deviceIds: ['dev-1'],
+      scheduleType: 'immediate',
+      createdBy: null,
+    });
+
+    const payload = dispatchDeviceCommandMock.mock.calls[0]![0].payload;
+    expect(payload.downloadUrl).toBe('https://cdn.example.com/stored/pkg.exe');
+    expect(payload.s3Key).toBeUndefined();
+  });
+
+  it('reports queued transport and still records deviceCommandId when the device is offline', async () => {
     const versionRecord = {
       id: 'ver-off',
       catalogId: 'cat-1',
@@ -322,9 +427,14 @@ describe('createSoftwareDeployment', () => {
       .mockReturnValueOnce(insWithReturning([deployment]))
       .mockReturnValueOnce(ins());
 
-    // First device online, second offline.
-    sendCommandMock.mockReturnValueOnce(true).mockReturnValueOnce(false);
-    queueCommandMock.mockResolvedValueOnce({ id: 'queued-cmd-off' });
+    // The seam itself decides WS-vs-queue per device now — dev-off is offline
+    // at enqueue time and comes back queued_offline; dev-on stays delivered.
+    dispatchDeviceCommandMock.mockImplementation(async ({ deviceId }: { deviceId: string }) => ({
+      ok: true,
+      command: { id: `cmd-${deviceId}`, status: 'pending' },
+      delivery: deviceId === 'dev-off' ? 'queued_offline' : 'delivered',
+      deliverBy: new Date(Date.now() + 7 * 24 * 3600 * 1000),
+    }));
 
     const result = await createSoftwareDeployment({
       orgId: 'org-1',
@@ -335,7 +445,7 @@ describe('createSoftwareDeployment', () => {
       createdBy: null,
     });
 
-    // Both devices count as dispatched — one over WS, one queued.
+    // Both devices count as dispatched — one delivered, one queued.
     expect(result.status).toBe('pending');
     expect(result.dispatchedDeviceIds).toEqual(['dev-on', 'dev-off']);
     expect(result.deviceResults).toEqual([
@@ -343,30 +453,33 @@ describe('createSoftwareDeployment', () => {
         deviceId: 'dev-on',
         deploymentResultId: 'result-dev-on',
         status: 'delivered',
-        deviceCommandId: null,
+        deviceCommandId: 'cmd-dev-on',
       },
       {
         deviceId: 'dev-off',
         deploymentResultId: 'result-dev-off',
         status: 'queued',
-        deviceCommandId: 'queued-cmd-off',
+        deviceCommandId: 'cmd-dev-off',
       },
     ]);
 
-    // The queued fallback fired once, for the offline device, with the SAME
-    // payload the WS command carried — including deploymentId for the
-    // queued-path result reconciliation.
-    expect(queueCommandMock).toHaveBeenCalledTimes(1);
-    const [queuedDeviceId, queuedType, queuedPayload] = queueCommandMock.mock.calls[0]!;
-    expect(queuedDeviceId).toBe('dev-off');
-    expect(queuedType).toBe('software_install');
-    const wsPayload = sendCommandMock.mock.calls[1]![1].payload;
-    expect(queuedPayload).toEqual(wsPayload);
-    expect(queuedPayload.deploymentId).toBe('dep-off');
+    // ONE call per device through the single enqueue seam — no separate
+    // WS-then-fallback pair anymore — and the queued device's payload still
+    // carries deploymentId for the queued-path result reconciliation.
+    expect(dispatchDeviceCommandMock).toHaveBeenCalledTimes(2);
+    const [onCall, offCall] = dispatchDeviceCommandMock.mock.calls;
+    expect(onCall![0]).toMatchObject({ deviceId: 'dev-on', type: 'software_install' });
+    expect(offCall![0]).toMatchObject({ deviceId: 'dev-off', type: 'software_install' });
+    expect(offCall![0].payload).toEqual(onCall![0].payload);
+    expect(offCall![0].payload.deploymentId).toBe('dep-off');
 
-    // The device_commands UUID is linked into deployment_results.deviceCommandId.
+    // The device_commands UUID is linked into deployment_results.deviceCommandId
+    // on BOTH transports now (#5128 persists before push).
     const linkWrites = updateSetCalls.filter((v) => 'deviceCommandId' in v);
-    expect(linkWrites).toEqual([{ deviceCommandId: 'queued-cmd-off' }]);
+    expect(linkWrites).toEqual([
+      { deviceCommandId: 'cmd-dev-on' },
+      { deviceCommandId: 'cmd-dev-off' },
+    ]);
   });
 
   it('substitutes {{...}} installer variables per device from org/site/device context', async () => {
@@ -407,7 +520,7 @@ describe('createSoftwareDeployment', () => {
 
     expect(result.status).toBe('pending');
     expect(result.dispatchedDeviceIds).toEqual(['dev-1']);
-    expect(sendCommandMock.mock.calls[0]![1].payload.downloadUrl).toBe(
+    expect(dispatchDeviceCommandMock.mock.calls[0]![0].payload.downloadUrl).toBe(
       'https://dl/org-1/KEY-1/app.msi',
     );
   });
@@ -462,7 +575,7 @@ describe('createSoftwareDeployment', () => {
         createdBy: null,
       });
 
-      return sendCommandMock.mock.calls[0]![1].payload;
+      return dispatchDeviceCommandMock.mock.calls[0]![0].payload;
     };
 
     it('sends package.msi for an MSI version with no original filename', async () => {
@@ -546,7 +659,7 @@ describe('createSoftwareDeployment', () => {
 
     expect(result.status).toBe('pending');
     expect(result.dispatchedDeviceIds).toEqual(['dev-1']);
-    expect(sendCommandMock.mock.calls[0]![1].payload.downloadUrl).toBe(
+    expect(dispatchDeviceCommandMock.mock.calls[0]![0].payload.downloadUrl).toBe(
       'https://dl/tok-live/app.msi',
     );
   });
@@ -597,8 +710,7 @@ describe('createSoftwareDeployment', () => {
     // outcome is unchanged: the only device failed, the batch reports failed.
     expect(result.status).toBe('failed');
     expect(result.dispatchedDeviceIds).toEqual([]);
-    expect(sendCommandMock).not.toHaveBeenCalled();
-    expect(queueCommandMock).not.toHaveBeenCalled();
+    expect(dispatchDeviceCommandMock).not.toHaveBeenCalled();
     const failureWrites = updateSetCalls.filter((c) => c.status === 'failed');
     expect(failureWrites).toHaveLength(1);
     expect(failureWrites[0]?.errorMessage).toBe(
@@ -655,8 +767,7 @@ describe('createSoftwareDeployment', () => {
 
     expect(result.status).toBe('failed');
     expect(result.message).toBe('All target devices failed installer variable resolution');
-    expect(sendCommandMock).not.toHaveBeenCalled();
-    expect(queueCommandMock).not.toHaveBeenCalled();
+    expect(dispatchDeviceCommandMock).not.toHaveBeenCalled();
     // One failure row per device, all carrying the same sorted key list.
     const failureWrites = updateSetCalls.filter((c) => c.status === 'failed');
     expect(failureWrites).toHaveLength(2);
@@ -708,7 +819,7 @@ describe('createSoftwareDeployment', () => {
     });
 
     expect(result.status).toBe('pending');
-    const payload = sendCommandMock.mock.calls[0]![1].payload;
+    const payload = dispatchDeviceCommandMock.mock.calls[0]![0].payload;
     expect(payload.downloadUrl).toBe('https://edr.example/agent.exe');
     expect(payload.silentInstallArgs).toBe('/SILENT /TOKEN=abc');
   });
@@ -746,7 +857,7 @@ describe('createSoftwareDeployment', () => {
     expect(result.status).toBe('failed');
     expect(result.message).toMatch(/not mapped to Huntress/);
     expect(result.dispatchedDeviceIds).toEqual([]);
-    expect(sendCommandMock).not.toHaveBeenCalled();
+    expect(dispatchDeviceCommandMock).not.toHaveBeenCalled();
     expect(failWhere).toHaveBeenCalledTimes(1); // all result rows marked failed
   });
 
@@ -791,8 +902,8 @@ describe('createSoftwareDeployment', () => {
     // the unresolvable one marked failed — never shipped a literal {{...}}.
     expect(result.status).toBe('pending');
     expect(result.dispatchedDeviceIds).toEqual(['dev-1']);
-    expect(sendCommandMock).toHaveBeenCalledTimes(1);
-    expect(sendCommandMock.mock.calls[0]![1].payload.downloadUrl).toBe('https://dl/KEY-1/app.msi');
+    expect(dispatchDeviceCommandMock).toHaveBeenCalledTimes(1);
+    expect(dispatchDeviceCommandMock.mock.calls[0]![0].payload.downloadUrl).toBe('https://dl/KEY-1/app.msi');
     // dev-2 only marked failed (the dispatched_at claim write is separate).
     expect(updateSetCalls.filter((v) => v.status === 'failed')).toHaveLength(1);
   });
@@ -837,7 +948,7 @@ describe('createSoftwareDeployment', () => {
     // device's result row was marked failed instead of shipping a literal token.
     expect(result.status).toBe('failed');
     expect(result.dispatchedDeviceIds).toEqual([]);
-    expect(sendCommandMock).not.toHaveBeenCalled();
+    expect(dispatchDeviceCommandMock).not.toHaveBeenCalled();
     expect(updateSetCalls.filter((v) => v.status === 'failed')).toHaveLength(1);
   });
 
@@ -880,8 +991,8 @@ describe('createSoftwareDeployment', () => {
       options: { forceReinstall: true },
     });
 
-    expect(sendCommandMock).toHaveBeenCalledTimes(1);
-    const dispatched = sendCommandMock.mock.calls[0]![1];
+    expect(dispatchDeviceCommandMock).toHaveBeenCalledTimes(1);
+    const dispatched = dispatchDeviceCommandMock.mock.calls[0]![0];
     expect(dispatched.payload.detectionRules).toEqual(detectionRules);
     expect(dispatched.payload.forceReinstall).toBe(true);
   });
@@ -920,7 +1031,7 @@ describe('createSoftwareDeployment', () => {
       createdBy: null,
     });
 
-    const dispatched = sendCommandMock.mock.calls[0]![1];
+    const dispatched = dispatchDeviceCommandMock.mock.calls[0]![0];
     expect(dispatched.payload.detectionRules).toBeUndefined();
     expect(dispatched.payload.forceReinstall).toBe(false);
   });
@@ -963,7 +1074,7 @@ describe('createSoftwareDeployment', () => {
     expect(result.status).toBe('failed');
     expect(result.message).toMatch(/No installer available/i);
     expect(result.deployment).toEqual(deployment);
-    expect(sendCommandMock).not.toHaveBeenCalled();
+    expect(dispatchDeviceCommandMock).not.toHaveBeenCalled();
   });
 
   it('persists maintenanceWindowId in the insert when provided', async () => {
@@ -1010,8 +1121,7 @@ describe('createSoftwareDeployment', () => {
     // Non-immediate path: no dispatch ran, so dispatched_at stays NULL for the
     // scheduler to claim later.
     expect(updateMock).not.toHaveBeenCalled();
-    expect(sendCommandMock).not.toHaveBeenCalled();
-    expect(queueCommandMock).not.toHaveBeenCalled();
+    expect(dispatchDeviceCommandMock).not.toHaveBeenCalled();
   });
 
   it('stores a non-devices targetType as given and does not coerce to "devices"', async () => {
@@ -1185,8 +1295,8 @@ describe('createSoftwareDeployment', () => {
 
       expect(result.status).toBe('pending');
       expect(result.dispatchedDeviceIds).toEqual(['dev-1']);
-      expect(sendCommandMock).toHaveBeenCalledTimes(1);
-      expect(sendCommandMock.mock.calls[0]![1].payload.downloadPolicy).toEqual({
+      expect(dispatchDeviceCommandMock).toHaveBeenCalledTimes(1);
+      expect(dispatchDeviceCommandMock.mock.calls[0]![0].payload.downloadPolicy).toEqual({
         version: 1,
         approvedPrivateOrigins: ['https://files.corp.internal'],
       });
@@ -1199,7 +1309,7 @@ describe('createSoftwareDeployment', () => {
 
       const result = await run(['dev-1']);
 
-      expect(sendCommandMock).not.toHaveBeenCalled();
+      expect(dispatchDeviceCommandMock).not.toHaveBeenCalled();
       expect(result.dispatchedDeviceIds).toEqual([]);
       expect(result.status).toBe('failed');
       expect(setSpy).toHaveBeenCalledWith(
@@ -1219,7 +1329,7 @@ describe('createSoftwareDeployment', () => {
 
       await run(['dev-1']);
 
-      expect(sendCommandMock).not.toHaveBeenCalled();
+      expect(dispatchDeviceCommandMock).not.toHaveBeenCalled();
     });
 
     it('compat: dispatches an APPROVED private destination to a capability-1 agent', async () => {
@@ -1232,7 +1342,7 @@ describe('createSoftwareDeployment', () => {
       const result = await run(['dev-1']);
 
       expect(result.dispatchedDeviceIds).toEqual(['dev-1']);
-      expect(sendCommandMock.mock.calls[0]![1].payload.downloadPolicy).toEqual({
+      expect(dispatchDeviceCommandMock.mock.calls[0]![0].payload.downloadPolicy).toEqual({
         version: 1,
         approvedPrivateOrigins: ['https://10.10.0.5'],
       });
@@ -1250,8 +1360,8 @@ describe('createSoftwareDeployment', () => {
 
       await run(['dev-1']);
 
-      expect(sendCommandMock).toHaveBeenCalledTimes(1);
-      const policy = sendCommandMock.mock.calls[0]![1].payload.downloadPolicy;
+      expect(dispatchDeviceCommandMock).toHaveBeenCalledTimes(1);
+      const policy = dispatchDeviceCommandMock.mock.calls[0]![0].payload.downloadPolicy;
       expect(policy.approvedPrivateOrigins).not.toContain('https://10.10.0.5');
     });
 
@@ -1267,14 +1377,12 @@ describe('createSoftwareDeployment', () => {
 
       await run(['dev-1', 'dev-2']);
 
-      expect(sendCommandMock.mock.calls[0]![1].payload.downloadPolicy.approvedPrivateOrigins).toEqual([
-        'https://org.example',
-        'https://site-a.example',
-      ]);
-      expect(sendCommandMock.mock.calls[1]![1].payload.downloadPolicy.approvedPrivateOrigins).toEqual([
-        'https://org.example',
-        'https://site-b.example',
-      ]);
+      expect(
+        dispatchDeviceCommandMock.mock.calls[0]![0].payload.downloadPolicy.approvedPrivateOrigins,
+      ).toEqual(['https://org.example', 'https://site-a.example']);
+      expect(
+        dispatchDeviceCommandMock.mock.calls[1]![0].payload.downloadPolicy.approvedPrivateOrigins,
+      ).toEqual(['https://org.example', 'https://site-b.example']);
     });
 
     it('fails only the capability-0 device on a mixed batch and still dispatches the capable one', async () => {
@@ -1288,13 +1396,18 @@ describe('createSoftwareDeployment', () => {
 
       expect(result.status).toBe('pending');
       expect(result.dispatchedDeviceIds).toEqual(['dev-1']);
-      expect(sendCommandMock).toHaveBeenCalledTimes(1);
-      // 2 calls: the immediate path's dispatched_at claim marker (#1.2 honest
+      expect(dispatchDeviceCommandMock).toHaveBeenCalledTimes(1);
+      // 3 calls: the immediate path's dispatched_at claim marker (#1.2 honest
       // dispatch — unconditional, fires once per deployment before the
-      // per-device loop) plus the one policy-denial failure write for dev-2.
-      expect(setSpy).toHaveBeenCalledTimes(2);
+      // per-device loop), the deviceCommandId link write for dev-1's
+      // successful dispatch (#5128 — always linked now, not just on queue),
+      // and the one policy-denial failure write for dev-2.
+      expect(setSpy).toHaveBeenCalledTimes(3);
       expect(setSpy).toHaveBeenCalledWith(
         expect.objectContaining({ status: 'failed', errorMessage: UPGRADE_REQUIRED }),
+      );
+      expect(setSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ deviceCommandId: 'cmd-dev-1' }),
       );
     });
 
@@ -1306,7 +1419,7 @@ describe('createSoftwareDeployment', () => {
 
       const result = await run(['dev-1']);
 
-      expect(sendCommandMock).not.toHaveBeenCalled();
+      expect(dispatchDeviceCommandMock).not.toHaveBeenCalled();
       expect(result.status).toBe('failed');
       expect(setSpy).toHaveBeenCalledWith(
         expect.objectContaining({ status: 'failed', errorMessage: UPGRADE_REQUIRED }),
@@ -1323,7 +1436,7 @@ describe('createSoftwareDeployment', () => {
 
       await run(['dev-1']);
 
-      expect(sendCommandMock).not.toHaveBeenCalled();
+      expect(dispatchDeviceCommandMock).not.toHaveBeenCalled();
     });
 
     it('enforce: dispatches a public destination to a capability-1 agent', async () => {
@@ -1333,7 +1446,7 @@ describe('createSoftwareDeployment', () => {
       const result = await run(['dev-1']);
 
       expect(result.dispatchedDeviceIds).toEqual(['dev-1']);
-      expect(sendCommandMock).toHaveBeenCalledTimes(1);
+      expect(dispatchDeviceCommandMock).toHaveBeenCalledTimes(1);
     });
 
     it('treats an unset or unrecognized mode as compat', async () => {
@@ -1342,7 +1455,7 @@ describe('createSoftwareDeployment', () => {
 
       await run(['dev-1']);
 
-      expect(sendCommandMock).toHaveBeenCalledTimes(1);
+      expect(dispatchDeviceCommandMock).toHaveBeenCalledTimes(1);
     });
   });
 });
@@ -1362,12 +1475,16 @@ describe('buildAndDispatchSoftwareInstalls scopeToDeviceIds (retry path)', () =>
   };
 
   beforeEach(() => {
-    sendCommandMock.mockReset();
-    queueCommandMock.mockReset();
+    dispatchDeviceCommandMock.mockReset();
     selectMock.mockReset();
     updateMock.mockReset();
     vi.mocked(inArray).mockClear();
-    sendCommandMock.mockReturnValue(true);
+    dispatchDeviceCommandMock.mockImplementation(async ({ deviceId }: { deviceId: string }) => ({
+      ok: true,
+      command: { id: `cmd-${deviceId}`, status: 'pending' },
+      delivery: 'delivered',
+      deliverBy: new Date(Date.now() + 7 * 24 * 3600 * 1000),
+    }));
     updateSetCalls = [];
     updateMock.mockImplementation(() => ({
       set: vi.fn((values: Record<string, unknown>) => {
@@ -1394,7 +1511,7 @@ describe('buildAndDispatchSoftwareInstalls scopeToDeviceIds (retry path)', () =>
 
     expect(result.status).toBe('failed');
     expect(result.dispatchedDeviceIds).toEqual([]);
-    expect(sendCommandMock).not.toHaveBeenCalled();
+    expect(dispatchDeviceCommandMock).not.toHaveBeenCalled();
     // Exactly one failure pre-write, and its WHERE carries the device-subset
     // filter (deploymentResults.deviceId mocks to 'dr.deviceId') — a
     // deployment-wide write would clobber previously completed rows.
@@ -1417,7 +1534,7 @@ describe('buildAndDispatchSoftwareInstalls scopeToDeviceIds (retry path)', () =>
 
     expect(result.status).toBe('failed');
     expect(result.message).toMatch(/No installer available/i);
-    expect(sendCommandMock).not.toHaveBeenCalled();
+    expect(dispatchDeviceCommandMock).not.toHaveBeenCalled();
     expect(updateSetCalls.filter((v) => v.status === 'failed')).toHaveLength(1);
     expect(inArray).toHaveBeenCalledWith('dr.deviceId', ['dev-failed']);
   });
@@ -1441,7 +1558,7 @@ describe('buildAndDispatchSoftwareInstalls scopeToDeviceIds (retry path)', () =>
 
     expect(result.status).toBe('pending');
     expect(result.dispatchedDeviceIds).toEqual(['dev-a']);
-    expect(sendCommandMock).toHaveBeenCalledTimes(1);
+    expect(dispatchDeviceCommandMock).toHaveBeenCalledTimes(1);
     // The devices query only asks for the intersection of deviceIds and the
     // scope ('d.id' is the mocked devices.id column).
     expect(inArray).toHaveBeenCalledWith('d.id', ['dev-a']);
@@ -1472,10 +1589,13 @@ describe('buildAndDispatchSoftwareInstalls scopeToDeviceIds (retry path)', () =>
 
   // Retry race guard (this fix): the retry endpoint bumps retryCount before
   // calling this fan-out and passes the post-bump value via
-  // deviceRetryCounts — it must land in both the WS command id AND the
-  // payload (the offline-queue transport keys result reconciliation on the
-  // payload, since queued commands don't use the sw-install-* id shape).
-  it('bakes deviceRetryCounts into the dispatched command id and payload', async () => {
+  // deviceRetryCounts — it must land in the payload handed to the dispatch
+  // seam (the offline-queue transport keys result reconciliation on it).
+  // #5128: the synthetic `sw-install-<deployment>-<device>-<attempt>` WS
+  // command id no longer exists at this layer — dispatchDeviceCommand mints
+  // the durable device_commands row id itself, so retryCount's only carrier
+  // here is the payload.
+  it('passes deviceRetryCounts through to the dispatch seam payload (retry race guard)', async () => {
     selectMock.mockReturnValueOnce(
       sel([{ id: 'dev-a', agentId: 'agent-a' }]),
     );
@@ -1493,10 +1613,10 @@ describe('buildAndDispatchSoftwareInstalls scopeToDeviceIds (retry path)', () =>
       deviceRetryCounts: { 'dev-a': 1 },
     });
 
-    expect(sendCommandMock).toHaveBeenCalledTimes(1);
-    const [, dispatchedCommand] = sendCommandMock.mock.calls[0]!;
-    expect(dispatchedCommand.id).toBe('sw-install-dep-retry-dev-a-1');
-    expect(dispatchedCommand.payload.retryCount).toBe(1);
+    expect(dispatchDeviceCommandMock).toHaveBeenCalledTimes(1);
+    const dispatched = dispatchDeviceCommandMock.mock.calls[0]![0];
+    expect(dispatched.deviceId).toBe('dev-a');
+    expect(dispatched.payload.retryCount).toBe(1);
   });
 
   it('defaults retryCount to 0 for devices absent from deviceRetryCounts', async () => {
@@ -1515,9 +1635,8 @@ describe('buildAndDispatchSoftwareInstalls scopeToDeviceIds (retry path)', () =>
       markDispatched: false,
     });
 
-    const [, dispatchedCommand] = sendCommandMock.mock.calls[0]!;
-    expect(dispatchedCommand.id).toBe('sw-install-dep-first-dev-a-0');
-    expect(dispatchedCommand.payload.retryCount).toBe(0);
+    const dispatched = dispatchDeviceCommandMock.mock.calls[0]![0];
+    expect(dispatched.payload.retryCount).toBe(0);
   });
 });
 
@@ -1535,8 +1654,7 @@ describe('dispatchSoftwareInstallToDevice', () => {
   };
 
   beforeEach(() => {
-    sendCommandMock.mockReset();
-    queueCommandMock.mockReset();
+    dispatchDeviceCommandMock.mockReset();
     updateMock.mockReset();
     updateSetCalls = [];
     updateMock.mockImplementation(() => ({
@@ -1545,10 +1663,21 @@ describe('dispatchSoftwareInstallToDevice', () => {
         return { where: vi.fn().mockResolvedValue(undefined) };
       }),
     }));
+    dispatchDeviceCommandMock.mockImplementation(async ({ deviceId }: { deviceId: string }) => ({
+      ok: true,
+      command: { id: `cmd-${deviceId}`, status: 'pending' },
+      delivery: 'delivered',
+      deliverBy: new Date(Date.now() + 7 * 24 * 3600 * 1000),
+    }));
   });
 
-  it('delivers over WS when the agent is connected and never queues', async () => {
-    sendCommandMock.mockReturnValue(true);
+  it('calls the single enqueue seam with deviceId/type/payload/offlinePolicy and reports ws transport when delivered', async () => {
+    dispatchDeviceCommandMock.mockResolvedValue({
+      ok: true,
+      command: { id: 'cmd-dev-1', status: 'sent' },
+      delivery: 'delivered',
+      deliverBy: new Date(Date.now() + 7 * 24 * 3600 * 1000),
+    });
 
     const outcome = await dispatchSoftwareInstallToDevice(
       'dep-1',
@@ -1557,58 +1686,41 @@ describe('dispatchSoftwareInstallToDevice', () => {
       null,
     );
 
-    expect(outcome).toEqual({ transport: 'ws', deviceCommandId: null });
-    expect(sendCommandMock).toHaveBeenCalledWith('agent-1', {
-      id: 'sw-install-dep-1-dev-1-0',
+    expect(outcome).toEqual({ transport: 'ws', deviceCommandId: 'cmd-dev-1' });
+    expect(dispatchDeviceCommandMock).toHaveBeenCalledWith({
+      deviceId: 'dev-1',
       type: 'software_install',
       payload,
+      offlinePolicy: { kind: 'queue', deliverWithinMs: expect.any(Number) },
     });
-    expect(queueCommandMock).not.toHaveBeenCalled();
-    expect(updateMock).not.toHaveBeenCalled();
   });
 
-  it('bakes a non-zero retryCount into the WS command id (retry race guard)', async () => {
-    sendCommandMock.mockReturnValue(true);
+  it('passes createdBy through as userId, and omits the key entirely when createdBy is null', async () => {
+    await dispatchSoftwareInstallToDevice(
+      'dep-1',
+      { id: 'dev-1', agentId: 'agent-1' },
+      payload,
+      'user-42',
+    );
+    expect(dispatchDeviceCommandMock.mock.calls[0]![0].userId).toBe('user-42');
 
+    dispatchDeviceCommandMock.mockClear();
     await dispatchSoftwareInstallToDevice(
       'dep-1',
       { id: 'dev-1', agentId: 'agent-1' },
       payload,
       null,
-      3,
     );
+    expect('userId' in dispatchDeviceCommandMock.mock.calls[0]![0]).toBe(false);
+  });
 
-    expect(sendCommandMock).toHaveBeenCalledWith('agent-1', {
-      id: 'sw-install-dep-1-dev-1-3',
-      type: 'software_install',
-      payload,
+  it('reports queued transport when the seam enqueues to an offline device (queued_offline)', async () => {
+    dispatchDeviceCommandMock.mockResolvedValue({
+      ok: true,
+      command: { id: 'cmd-dev-1', status: 'pending' },
+      delivery: 'queued_offline',
+      deliverBy: new Date(Date.now() + 7 * 24 * 3600 * 1000),
     });
-  });
-
-  it('queues via queueCommand and links deviceCommandId when WS delivery fails', async () => {
-    sendCommandMock.mockReturnValue(false);
-    queueCommandMock.mockResolvedValue({ id: 'queued-cmd-9' });
-
-    const outcome = await dispatchSoftwareInstallToDevice(
-      'dep-1',
-      { id: 'dev-1', agentId: 'agent-1' },
-      payload,
-      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
-    );
-
-    expect(outcome).toEqual({ transport: 'queued', deviceCommandId: 'queued-cmd-9' });
-    expect(queueCommandMock).toHaveBeenCalledWith(
-      'dev-1',
-      'software_install',
-      payload,
-      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
-    );
-    expect(updateSetCalls).toEqual([{ deviceCommandId: 'queued-cmd-9' }]);
-  });
-
-  it('returns transport queued with null id (and skips the link write) when queueCommand returns no row', async () => {
-    sendCommandMock.mockReturnValue(false);
-    queueCommandMock.mockResolvedValue(undefined);
 
     const outcome = await dispatchSoftwareInstallToDevice(
       'dep-1',
@@ -1617,7 +1729,69 @@ describe('dispatchSoftwareInstallToDevice', () => {
       null,
     );
 
-    expect(outcome).toEqual({ transport: 'queued', deviceCommandId: null });
+    expect(outcome).toEqual({ transport: 'queued', deviceCommandId: 'cmd-dev-1' });
+  });
+
+  it('reports queued transport when the seam could not confirm the live push (queued_live)', async () => {
+    dispatchDeviceCommandMock.mockResolvedValue({
+      ok: true,
+      command: { id: 'cmd-dev-1', status: 'pending' },
+      delivery: 'queued_live',
+      deliverBy: new Date(Date.now() + 7 * 24 * 3600 * 1000),
+    });
+
+    const outcome = await dispatchSoftwareInstallToDevice(
+      'dep-1',
+      { id: 'dev-1', agentId: 'agent-1' },
+      payload,
+      null,
+    );
+
+    expect(outcome).toEqual({ transport: 'queued', deviceCommandId: 'cmd-dev-1' });
+  });
+
+  // #5128's actual fix: BEFORE this change the WS path never created a
+  // device_commands row at all — deviceCommandId came back null and
+  // deployment_results.device_command_id stayed NULL, so a push the agent
+  // never acted on was invisible to the reaper, the device's queued-actions
+  // list, and cancel. The row is now persisted first by the one seam and
+  // linked here on BOTH transports.
+  it('persists the device_commands row on the WS path too, and links it into deployment_results', async () => {
+    dispatchDeviceCommandMock.mockResolvedValue({
+      ok: true,
+      command: { id: 'cmd-dev-1', status: 'sent' },
+      delivery: 'delivered',
+      deliverBy: new Date(Date.now() + 7 * 24 * 3600 * 1000),
+    });
+
+    const outcome = await dispatchSoftwareInstallToDevice(
+      'dep-1',
+      { id: 'dev-1', agentId: 'agent-1' },
+      payload,
+      null,
+    );
+
+    expect(outcome.transport).toBe('ws');
+    expect(outcome.deviceCommandId).toBeTruthy();
+    expect(updateSetCalls).toEqual([{ deviceCommandId: 'cmd-dev-1' }]);
+  });
+
+  it('a refused dispatch throws rather than silently reporting success', async () => {
+    dispatchDeviceCommandMock.mockResolvedValue({
+      ok: false,
+      code: 'device_decommissioned',
+      error: 'Device is decommissioned, cannot execute command',
+    });
+
+    await expect(
+      dispatchSoftwareInstallToDevice(
+        'dep-1',
+        { id: 'dev-1', agentId: 'agent-1' },
+        payload,
+        null,
+      ),
+    ).rejects.toThrow(/software_install dispatch refused for device dev-1/);
+    // A refusal must never write deployment_results — there is nothing to link.
     expect(updateMock).not.toHaveBeenCalled();
   });
 });
@@ -1657,13 +1831,16 @@ describe('createSoftwareDeployment (package-manager install methods)', () => {
   }
 
   beforeEach(() => {
-    sendCommandMock.mockReset();
-    queueCommandMock.mockReset();
+    dispatchDeviceCommandMock.mockReset();
     selectMock.mockReset();
     insertMock.mockReset();
     updateMock.mockReset();
-    sendCommandMock.mockReturnValue(true);
-    queueCommandMock.mockResolvedValue({ id: 'queued-cmd-1' });
+    dispatchDeviceCommandMock.mockImplementation(async ({ deviceId }: { deviceId: string }) => ({
+      ok: true,
+      command: { id: `cmd-${deviceId}`, status: 'pending' },
+      delivery: 'delivered',
+      deliverBy: new Date(Date.now() + 7 * 24 * 3600 * 1000),
+    }));
     insertedValues = [];
     updateSetCalls = [];
     updateMock.mockImplementation(() => ({
@@ -1706,7 +1883,7 @@ describe('createSoftwareDeployment (package-manager install methods)', () => {
       softwareVersionId: null,
     });
 
-    const payload = sendCommandMock.mock.calls[0]![1].payload;
+    const payload = dispatchDeviceCommandMock.mock.calls[0]![0].payload;
     expect(payload).toMatchObject({
       deploymentId: 'dep-m1',
       retryCount: 0,
@@ -1736,7 +1913,7 @@ describe('createSoftwareDeployment (package-manager install methods)', () => {
       requestedVersion: '128.0.1',
     });
 
-    expect(sendCommandMock.mock.calls[0]![1].payload).toMatchObject({
+    expect(dispatchDeviceCommandMock.mock.calls[0]![0].payload).toMatchObject({
       versionMode: 'exact',
       requestedVersion: '128.0.1',
     });
@@ -1759,7 +1936,7 @@ describe('createSoftwareDeployment (package-manager install methods)', () => {
 
     expect(result.status).toBe('pending');
     expect(result.dispatchedDeviceIds).toEqual(['dev-1']);
-    expect(sendCommandMock).toHaveBeenCalledTimes(1);
+    expect(dispatchDeviceCommandMock).toHaveBeenCalledTimes(1);
     const failureWrite = updateSetCalls.find((v) => v.status === 'failed');
     expect(failureWrite).toBeDefined();
     expect(String(failureWrite!.errorMessage)).toContain('No install method for this device OS');
@@ -1782,7 +1959,7 @@ describe('createSoftwareDeployment (package-manager install methods)', () => {
 
     expect(result.status).toBe('failed');
     expect(result.dispatchedDeviceIds).toEqual([]);
-    expect(sendCommandMock).not.toHaveBeenCalled();
+    expect(dispatchDeviceCommandMock).not.toHaveBeenCalled();
     expect(result.message).toContain('No install method for this device OS');
   });
 
@@ -1840,12 +2017,16 @@ describe('buildAndDispatchSoftwareInstalls — targets missing at dispatch (#360
   };
 
   beforeEach(() => {
-    sendCommandMock.mockReset();
-    queueCommandMock.mockReset();
+    dispatchDeviceCommandMock.mockReset();
     selectMock.mockReset();
     updateMock.mockReset();
     vi.mocked(inArray).mockClear();
-    sendCommandMock.mockReturnValue(true);
+    dispatchDeviceCommandMock.mockImplementation(async ({ deviceId }: { deviceId: string }) => ({
+      ok: true,
+      command: { id: `cmd-${deviceId}`, status: 'pending' },
+      delivery: 'delivered',
+      deliverBy: new Date(Date.now() + 7 * 24 * 3600 * 1000),
+    }));
     effectivePolicyMock.mockResolvedValue({ approvedPrivateOrigins: [] });
     updateSetCalls = [];
     updateMock.mockImplementation(() => ({
@@ -1874,7 +2055,7 @@ describe('buildAndDispatchSoftwareInstalls — targets missing at dispatch (#360
     // The surviving device still dispatches.
     expect(result.status).toBe('pending');
     expect(result.dispatchedDeviceIds).toEqual(['dev-a']);
-    expect(sendCommandMock).toHaveBeenCalledTimes(1);
+    expect(dispatchDeviceCommandMock).toHaveBeenCalledTimes(1);
 
     // ...and the missing one gets a terminal row instead of staying pending.
     const failWrites = updateSetCalls.filter((v) => v.status === 'failed');
@@ -1930,7 +2111,7 @@ describe('buildAndDispatchSoftwareInstalls — targets missing at dispatch (#360
     expect(result.status).toBe('failed');
     expect(result.message).toBe('No target device is still available');
     expect(result.dispatchedDeviceIds).toEqual([]);
-    expect(sendCommandMock).not.toHaveBeenCalled();
+    expect(dispatchDeviceCommandMock).not.toHaveBeenCalled();
     expect(inArray).toHaveBeenCalledWith('dr.deviceId', ['dev-gone-1', 'dev-gone-2']);
   });
 
@@ -1976,7 +2157,7 @@ describe('buildAndDispatchSoftwareInstalls — targets missing at dispatch (#360
 
     expect(result.status).toBe('failed');
     expect(result.message).toBe('No target device is still available');
-    expect(sendCommandMock).not.toHaveBeenCalled();
+    expect(dispatchDeviceCommandMock).not.toHaveBeenCalled();
   });
 
   it('manager path: an OS mismatch still reports its own message, not the missing-device one', async () => {

--- a/apps/api/src/services/softwareDeployment.test.ts
+++ b/apps/api/src/services/softwareDeployment.test.ts
@@ -244,6 +244,74 @@ describe('createSoftwareDeployment', () => {
     vi.unstubAllEnvs();
   });
 
+
+  it('a dispatch failure on one device does not abort the fan-out for the rest', async () => {
+    // #5128: dispatchSoftwareInstallToDevice now THROWS when the seam refuses
+    // (decommissioned / trust-denied — checks that did not exist on this path
+    // before). Without per-device isolation an uncaught throw aborts the loop
+    // and leaves every device after it with a `pending` deployment_results row
+    // that is never dispatched and never failed: exactly the silent death this
+    // whole feature exists to remove.
+    const versionRecord = {
+      id: 'ver-1',
+      catalogId: 'cat-1',
+      s3Key: 'pkg.key',
+      downloadUrl: null,
+      checksum: null,
+      originalFileName: 'pkg.exe',
+      fileType: 'exe',
+      silentInstallArgs: null,
+      version: '1.0.0',
+    };
+    const catalogItem = { id: 'cat-1', orgId: null, name: 'TestApp', integrationProvider: null };
+    const deployment = { id: 'dep-1', orgId: 'org-1' };
+    const targetDevices = [
+      { id: 'dev-1', agentId: 'agent-1' },
+      { id: 'dev-2', agentId: 'agent-2' },
+      { id: 'dev-3', agentId: 'agent-3' },
+    ];
+
+    selectMock
+      .mockReturnValueOnce(sel([versionRecord]))
+      .mockReturnValueOnce(sel([catalogItem]))
+      .mockReturnValueOnce(sel(targetDevices));
+    insertMock
+      .mockReturnValueOnce(insWithReturning([deployment]))
+      .mockReturnValueOnce(ins());
+
+    // dev-2 is refused by the seam; dev-1 and dev-3 must still go out.
+    dispatchDeviceCommandMock.mockImplementation(async ({ deviceId }: { deviceId: string }) => {
+      if (deviceId === 'dev-2') {
+        throw new Error('software_install dispatch refused for device dev-2: Device is decommissioned, cannot execute command');
+      }
+      return {
+        ok: true,
+        command: { id: `cmd-${deviceId}`, deviceId, type: 'software_install', status: 'pending' },
+        delivery: 'delivered',
+        deliverBy: new Date(Date.now() + 7 * 24 * 3600 * 1000),
+      };
+    });
+
+    const result = await createSoftwareDeployment({
+      orgId: 'org-1',
+      softwareVersionId: 'ver-1',
+      deploymentType: 'install',
+      deviceIds: ['dev-1', 'dev-2', 'dev-3'],
+      scheduleType: 'immediate',
+      createdBy: 'system:automation',
+    });
+
+    // The healthy devices dispatched; the failing one did not abort them.
+    expect(result.dispatchedDeviceIds).toEqual(['dev-1', 'dev-3']);
+
+    // And the failure is REPORTED, not swallowed: dev-2 gets a failed result
+    // carrying the real reason rather than hanging `pending` forever.
+    const dev2 = result.deviceResults.find((r) => r.deviceId === 'dev-2');
+    expect(dev2?.status).toBe('failed');
+    expect(dev2?.message).toContain('decommissioned');
+    expect(result.deviceResults.map((r) => r.deviceId)).toEqual(['dev-1', 'dev-2', 'dev-3']);
+  });
+
   it('creates a deployment + per-device results and dispatches software_install for immediate install', async () => {
     const versionRecord = {
       id: 'ver-1',

--- a/apps/api/src/services/softwareDeployment.ts
+++ b/apps/api/src/services/softwareDeployment.ts
@@ -15,7 +15,9 @@ import { resolveEdrInstaller, type ResolvedInstaller } from './edrInstallerResol
 import { resolveInstallerVariables, type InstallerVariableContext } from './installerVariables';
 import { loadTenantVariableScope, resolveForOrg } from './tenantVariableResolution';
 import { getPresignedUrl, isS3Configured, isS3NotFound } from './s3Storage';
-import { queueCommand } from './commandQueue';
+import { deliveryTtlMs } from './commandOfflinePolicy';
+import { dispatchDeviceCommand } from './dispatchDeviceCommand';
+import { applySoftwareInstallResult } from './softwareDeploymentResult';
 import {
   evaluateManagedSoftwareDispatch,
   type ManagedSoftwareDispatchDenialReason,
@@ -80,8 +82,60 @@ export type SoftwareInstallDispatchTransport = 'ws' | 'queued';
 export interface SoftwareInstallDispatchOutcome {
   /** 'ws' = delivered over the live agent socket; 'queued' = written to device_commands for pickup on next poll/reconnect. */
   transport: SoftwareInstallDispatchTransport;
-  /** device_commands row id when the offline-queue fallback was used, else null. */
-  deviceCommandId: string | null;
+  /**
+   * The `device_commands` row id. #5128: ALWAYS set — the row is persisted
+   * before either transport, so a WS push the agent never acted on is still
+   * visible to the reaper, the device-page queued list and the cancel route.
+   * It used to be `null` on the WS path, which created no row at all.
+   */
+  deviceCommandId: string;
+}
+
+/**
+ * Reconcile a `software_install` result onto its `deployment_results` row
+ * (#5128). Extracted so BOTH transports run identical logic: the HTTP result
+ * route (`routes/agents/commands.ts`) and the WebSocket generic result path
+ * (`routes/agentWs.ts`). Before this, only the HTTP route reconciled by
+ * payload, and the WS path relied on the legacy
+ * `sw-install-<deployment>-<device>-<attempt>` command id — which new dispatches
+ * no longer use, because they push with the persisted row's UUID.
+ *
+ * The helper's own `status='pending'` + `retryCount === attempt` guard makes
+ * double delivery (HTTP and WS) and a result from a retry-superseded attempt a
+ * no-op, so calling this from both paths is safe.
+ */
+export async function reconcileSoftwareInstallResult(
+  command: { type: string; payload: unknown },
+  deviceId: string,
+  normalized: {
+    status: 'completed' | 'failed' | 'timeout';
+    exitCode?: number | null;
+    stdout?: string | null;
+    stderr?: string | null;
+    error?: string | null;
+    startedAt?: string | null;
+    durationMs?: number | null;
+  },
+): Promise<void> {
+  if (command.type !== 'software_install') return;
+  const payload =
+    command.payload && typeof command.payload === 'object' && !Array.isArray(command.payload)
+      ? (command.payload as Record<string, unknown>)
+      : {};
+  if (typeof payload.deploymentId !== 'string') return;
+
+  await applySoftwareInstallResult({
+    deploymentId: payload.deploymentId,
+    deviceId,
+    status: normalized.status,
+    exitCode: normalized.exitCode,
+    stdout: normalized.stdout,
+    stderr: normalized.stderr,
+    error: normalized.error,
+    startedAt: normalized.startedAt,
+    durationMs: normalized.durationMs,
+    attemptNumber: typeof payload.retryCount === 'number' ? payload.retryCount : 0,
+  });
 }
 
 /**
@@ -92,23 +146,25 @@ export interface SoftwareInstallDispatchOutcome {
  * Callers are responsible for everything that happens BEFORE dispatch
  * (presign/EDR resolution, `{{...}}` variable substitution, failure
  * pre-writes) and hand this function the fully-resolved command payload.
- * The payload MUST carry `deploymentId` — the queued-path result
- * reconciliation in routes/agents/commands.ts keys on it.
+ * The payload MUST carry `deploymentId` and `retryCount` — result
+ * reconciliation on both transports keys on them
+ * (`reconcileSoftwareInstallResult`).
  *
- * Honest dispatch (#1.2): when the agent has no live WS socket,
- * sendCommandToAgent returns false; instead of silently dropping the command
- * (the old fire-and-forget bug), fall back to queueCommand so the agent picks
- * it up on its next poll/reconnect, and link the queued device_commands row
- * id into deployment_results.device_command_id for reconciliation, cancel
- * purge, and "queued — device offline" display.
+ * #5128 — PERSIST BEFORE PUSH. This used to try the websocket first and, on
+ * success, return without creating a `device_commands` row at all. That row is
+ * the only durable record of the install: with none, a push the agent never
+ * acted on was invisible to the reaper, to the device's queued-actions list and
+ * to cancel, and `deployment_results.device_command_id` stayed NULL so the
+ * result reaper could not tell "delivered" from "never sent". The row is now
+ * always written first, by the one enqueue seam, and the push carries that
+ * row's UUID rather than the synthetic
+ * `sw-install-<deployment>-<device>-<attempt>` id.
  *
- * `retryCount` is the CURRENT attempt number at dispatch time (0 for the
- * first attempt) and is baked into the WS command id
- * (`sw-install-<deployment>-<device>-<retryCount>`) so a late result from a
- * superseded attempt — the id the FIRST dispatch used — can never be
- * misattributed to a later retry: applySoftwareInstallResult rejects any
- * result whose attempt doesn't match the row's current retryCount. The
- * caller (routes/software.ts retry endpoint) MUST bump retryCount in the DB
+ * `retryCount` is the CURRENT attempt number at dispatch time (0 for the first
+ * attempt). It travels in the payload so a late result from a superseded
+ * attempt can never be misattributed to a later retry: applySoftwareInstallResult
+ * rejects any result whose attempt doesn't match the row's current retryCount.
+ * The caller (routes/software.ts retry endpoint) MUST bump retryCount in the DB
  * before calling this, and pass that same post-bump value here.
  */
 export async function dispatchSoftwareInstallToDevice(
@@ -118,32 +174,38 @@ export async function dispatchSoftwareInstallToDevice(
   createdBy?: string | null,
   retryCount = 0,
 ): Promise<SoftwareInstallDispatchOutcome> {
-  const command: AgentCommand = {
-    id: `sw-install-${deploymentId}-${device.id}-${retryCount}`,
+  void retryCount; // carried in `payload.retryCount` by the caller; kept for the signature's contract
+
+  const res = await dispatchDeviceCommand({
+    deviceId: device.id,
     type: 'software_install',
-    payload,
+    payload: (payload ?? {}) as Record<string, unknown>,
+    ...(createdBy ? { userId: createdBy } : {}),
+    // Software installs already queued for offline devices before #5128, so
+    // they are NOT gated on DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED.
+    offlinePolicy: { kind: 'queue', deliverWithinMs: deliveryTtlMs('standard') },
+  });
+
+  if (!res.ok) {
+    throw new Error(`software_install dispatch refused for device ${device.id}: ${res.error}`);
+  }
+
+  // Link the row for reconciliation, cancel purge, and the "queued — device
+  // offline" display. Always populated now, on both transports.
+  await db
+    .update(deploymentResults)
+    .set({ deviceCommandId: res.command.id })
+    .where(
+      and(
+        eq(deploymentResults.deploymentId, deploymentId),
+        eq(deploymentResults.deviceId, device.id),
+      ),
+    );
+
+  return {
+    transport: res.delivery === 'delivered' ? 'ws' : 'queued',
+    deviceCommandId: res.command.id,
   };
-
-  if (sendCommandToAgent(device.agentId, command)) {
-    return { transport: 'ws', deviceCommandId: null };
-  }
-
-  // Agent offline: queue the SAME payload as a device_commands row. The agent
-  // handler dispatches on command type, so both transports hit the same code.
-  const queued = await queueCommand(device.id, 'software_install', payload, createdBy ?? undefined);
-  const deviceCommandId = queued?.id ?? null;
-  if (deviceCommandId) {
-    await db
-      .update(deploymentResults)
-      .set({ deviceCommandId })
-      .where(
-        and(
-          eq(deploymentResults.deploymentId, deploymentId),
-          eq(deploymentResults.deviceId, device.id),
-        ),
-      );
-  }
-  return { transport: 'queued', deviceCommandId };
 }
 
 /** Structural subset of a software_versions row the install fan-out needs. */
@@ -501,6 +563,11 @@ export async function buildAndDispatchSoftwareInstalls(
       );
     }
   }
+  // #5128: remember whether the URL we are about to ship was MINTED from the
+  // S3 key. Only then may the payload carry `s3Key` for the delivery-time
+  // refresher — a stored/EDR-resolved URL must never be silently replaced by a
+  // presigned one at claim time.
+  const presignedFromS3 = downloadUrl;
   downloadUrl = downloadUrl ?? versionRecord.downloadUrl;
 
   // Built-in EDR packages: resolve per-org keys server-side BEFORE the dispatch
@@ -838,6 +905,14 @@ export async function buildAndDispatchSoftwareInstalls(
       deploymentId,
       retryCount,
       downloadUrl: deviceDownloadUrl,
+      // #5128 (OD-8): a presigned URL is valid for an hour, but a queued
+      // install may be claimed days later. Ship the STABLE reference too, and
+      // `deliveryRefreshers['software_install']` re-mints the URL at delivery.
+      // Only when the URL we resolved for THIS device is exactly the presigned
+      // one — an EDR-resolved or stored URL must not be overwritten.
+      ...(versionRecord.s3Key && presignedFromS3 && deviceDownloadUrl === presignedFromS3
+        ? { s3Key: versionRecord.s3Key }
+        : {}),
       downloadPolicy: {
         version: 1,
         approvedPrivateOrigins,

--- a/apps/api/src/services/softwareDeployment.ts
+++ b/apps/api/src/services/softwareDeployment.ts
@@ -17,7 +17,6 @@ import { loadTenantVariableScope, resolveForOrg } from './tenantVariableResoluti
 import { getPresignedUrl, isS3Configured, isS3NotFound } from './s3Storage';
 import { deliveryTtlMs } from './commandOfflinePolicy';
 import { dispatchDeviceCommand } from './dispatchDeviceCommand';
-import { applySoftwareInstallResult } from './softwareDeploymentResult';
 import {
   evaluateManagedSoftwareDispatch,
   type ManagedSoftwareDispatchDenialReason,
@@ -89,53 +88,6 @@ export interface SoftwareInstallDispatchOutcome {
    * It used to be `null` on the WS path, which created no row at all.
    */
   deviceCommandId: string;
-}
-
-/**
- * Reconcile a `software_install` result onto its `deployment_results` row
- * (#5128). Extracted so BOTH transports run identical logic: the HTTP result
- * route (`routes/agents/commands.ts`) and the WebSocket generic result path
- * (`routes/agentWs.ts`). Before this, only the HTTP route reconciled by
- * payload, and the WS path relied on the legacy
- * `sw-install-<deployment>-<device>-<attempt>` command id — which new dispatches
- * no longer use, because they push with the persisted row's UUID.
- *
- * The helper's own `status='pending'` + `retryCount === attempt` guard makes
- * double delivery (HTTP and WS) and a result from a retry-superseded attempt a
- * no-op, so calling this from both paths is safe.
- */
-export async function reconcileSoftwareInstallResult(
-  command: { type: string; payload: unknown },
-  deviceId: string,
-  normalized: {
-    status: 'completed' | 'failed' | 'timeout';
-    exitCode?: number | null;
-    stdout?: string | null;
-    stderr?: string | null;
-    error?: string | null;
-    startedAt?: string | null;
-    durationMs?: number | null;
-  },
-): Promise<void> {
-  if (command.type !== 'software_install') return;
-  const payload =
-    command.payload && typeof command.payload === 'object' && !Array.isArray(command.payload)
-      ? (command.payload as Record<string, unknown>)
-      : {};
-  if (typeof payload.deploymentId !== 'string') return;
-
-  await applySoftwareInstallResult({
-    deploymentId: payload.deploymentId,
-    deviceId,
-    status: normalized.status,
-    exitCode: normalized.exitCode,
-    stdout: normalized.stdout,
-    stderr: normalized.stderr,
-    error: normalized.error,
-    startedAt: normalized.startedAt,
-    durationMs: normalized.durationMs,
-    attemptNumber: typeof payload.retryCount === 'number' ? payload.retryCount : 0,
-  });
 }
 
 /**

--- a/apps/api/src/services/softwareDeployment.ts
+++ b/apps/api/src/services/softwareDeployment.ts
@@ -445,7 +445,31 @@ async function dispatchManagerInstalls(
       softwareName: catalogItem.name,
       forceReinstall,
     };
-    const dispatch = await dispatchSoftwareInstallToDevice(deploymentId, device, payload, createdBy, retryCount);
+    // #5128: the seam refuses (and this throws) for a device that is
+    // decommissioned or trust-denied — checks that did NOT exist on this path
+    // before. Isolate per device: an uncaught throw here would abort the whole
+    // fan-out and leave every device AFTER it with a `pending` deployment_results
+    // row that is never dispatched and never failed, which is precisely the
+    // silent-death bug this feature exists to remove.
+    let dispatch: SoftwareInstallDispatchOutcome;
+    try {
+      dispatch = await dispatchSoftwareInstallToDevice(deploymentId, device, payload, createdBy, retryCount);
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Failed to dispatch software install';
+      console.error(`[software-deploy] dispatch failed for device ${device.id} in deployment ${deploymentId}:`, err);
+      await db
+        .update(deploymentResults)
+        .set({ status: 'failed', errorMessage, completedAt: new Date() })
+        .where(
+          and(
+            eq(deploymentResults.deploymentId, deploymentId),
+            eq(deploymentResults.deviceId, device.id),
+          ),
+        );
+      const failedResult = fanoutDeviceResult(input, device.id, 'failed', null, errorMessage);
+      if (failedResult) deviceResults.push(failedResult);
+      continue;
+    }
     dispatchedDeviceIds.push(device.id);
     const result = fanoutDeviceResult(
       input,
@@ -883,7 +907,31 @@ export async function buildAndDispatchSoftwareInstalls(
       ...(detectionRules ? { detectionRules } : {}),
       forceReinstall,
     };
-    const dispatch = await dispatchSoftwareInstallToDevice(deploymentId, device, payload, createdBy, retryCount);
+    // #5128: the seam refuses (and this throws) for a device that is
+    // decommissioned or trust-denied — checks that did NOT exist on this path
+    // before. Isolate per device: an uncaught throw here would abort the whole
+    // fan-out and leave every device AFTER it with a `pending` deployment_results
+    // row that is never dispatched and never failed, which is precisely the
+    // silent-death bug this feature exists to remove.
+    let dispatch: SoftwareInstallDispatchOutcome;
+    try {
+      dispatch = await dispatchSoftwareInstallToDevice(deploymentId, device, payload, createdBy, retryCount);
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Failed to dispatch software install';
+      console.error(`[software-deploy] dispatch failed for device ${device.id} in deployment ${deploymentId}:`, err);
+      await db
+        .update(deploymentResults)
+        .set({ status: 'failed', errorMessage, completedAt: new Date() })
+        .where(
+          and(
+            eq(deploymentResults.deploymentId, deploymentId),
+            eq(deploymentResults.deviceId, device.id),
+          ),
+        );
+      const failedResult = fanoutDeviceResult(input, device.id, 'failed', null, errorMessage);
+      if (failedResult) deviceResults.push(failedResult);
+      continue;
+    }
     dispatchedDeviceIds.push(device.id);
     const result = fanoutDeviceResult(
       input,

--- a/apps/api/src/services/softwareDeploymentResult.ts
+++ b/apps/api/src/services/softwareDeploymentResult.ts
@@ -158,3 +158,54 @@ export async function applySoftwareInstallResult(input: SoftwareInstallResultInp
   });
   return effectiveId;
 }
+
+/**
+ * Reconcile a `software_install` result onto its `deployment_results` row
+ * (#5128). Extracted so BOTH transports run identical logic: the HTTP result
+ * route (`routes/agents/commands.ts`) and the WebSocket generic result path
+ * (`routes/agentWs.ts`). It lives HERE, beside `applySoftwareInstallResult`,
+ * rather than in `softwareDeployment.ts`: that module statically pulls in the
+ * whole dispatch graph (agentWs, the discovery worker, …), which neither result
+ * route should have to import just to reconcile one row. Before this, only the
+ * HTTP route reconciled by
+ * payload, and the WS path relied on the legacy
+ * `sw-install-<deployment>-<device>-<attempt>` command id — which new dispatches
+ * no longer use, because they push with the persisted row's UUID.
+ *
+ * The helper's own `status='pending'` + `retryCount === attempt` guard makes
+ * double delivery (HTTP and WS) and a result from a retry-superseded attempt a
+ * no-op, so calling this from both paths is safe.
+ */
+export async function reconcileSoftwareInstallResult(
+  command: { type: string; payload: unknown },
+  deviceId: string,
+  normalized: {
+    status: 'completed' | 'failed' | 'timeout';
+    exitCode?: number | null;
+    stdout?: string | null;
+    stderr?: string | null;
+    error?: string | null;
+    startedAt?: string | null;
+    durationMs?: number | null;
+  },
+): Promise<void> {
+  if (command.type !== 'software_install') return;
+  const payload =
+    command.payload && typeof command.payload === 'object' && !Array.isArray(command.payload)
+      ? (command.payload as Record<string, unknown>)
+      : {};
+  if (typeof payload.deploymentId !== 'string') return;
+
+  await applySoftwareInstallResult({
+    deploymentId: payload.deploymentId,
+    deviceId,
+    status: normalized.status,
+    exitCode: normalized.exitCode,
+    stdout: normalized.stdout,
+    stderr: normalized.stderr,
+    error: normalized.error,
+    startedAt: normalized.startedAt,
+    durationMs: normalized.durationMs,
+    attemptNumber: typeof payload.retryCount === 'number' ? payload.retryCount : 0,
+  });
+}

--- a/docs/superpowers/plans/misc/2026-09-06-offline-work-queue.md
+++ b/docs/superpowers/plans/misc/2026-09-06-offline-work-queue.md
@@ -1,0 +1,1620 @@
+---
+tracking_issue: LanternOps/breeze#5131
+---
+
+# Offline Work Queue — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan wave-by-wave, task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Any fire-and-forget device action (script, patch install, software install, reboot, inventory refresh, …) issued against an offline device is queued with an explicit deadline, delivered on the device's next heartbeat, re-checked for eligibility at the moment of delivery, and reported honestly as "queued — device offline" until it runs, expires, or is cancelled.
+
+**Architecture:** Deferred delivery becomes a first-class property of `device_commands`: a nullable `deliver_by` deadline and an immutable `submitted_org_id`, one enqueue seam (`dispatchDeviceCommand`) that always states an `OfflinePolicy` (`reject` | `queue`) resolved from a fail-closed per-type registry, a reaper that separates the *delivery* clock from the *execution* clock, a shared claim-time eligibility filter beneath both claim paths, and late-binding payload preparation at delivery. Delivery transport is unchanged: the agent's existing HTTP heartbeat claim. No agent change in any wave.
+
+**Tech Stack:** Hono routes + Drizzle (`apps/api`), hand-written SQL migrations, Zod validators in `packages/shared`, BullMQ reaper/worker jobs, Astro + React islands + Vitest/jsdom (`apps/web`).
+
+**Spec:** `docs/superpowers/specs/misc/2026-09-06-offline-work-queue-design.md` (approved 2026-09-06). Section references below (§A–§J, OD-n) point into that document.
+
+**Tracking:** feature LanternOps/breeze#5131 (request: #5128). Wave sub-issues — W01 #5132 · W02 #5133 · W03 #5134 · W04 #5135 · W05 #5136 · W06 #5137. Branch per wave: `feature/5131-offline-work-queue/wave-<subissue#>` from `main`; PR body `Closes #<subissue>`.
+
+## Global Constraints
+
+- **`device_commands` stays intentionally system-scoped.** No RLS policy, no `CORE_ORG_CASCADE_DELETE_ORDER` entry, no `CORE_TENANT_EXPORT_POLICY` entry. `submitted_org_id` is provenance, deliberately *not* named `org_id`, so `rls-coverage.integration.test.ts` auto-discovery does not reclassify the table. Say so in the migration header verbatim.
+- **Two clocks, one owner.** `pending` rows expire at `deliver_by` (legacy rows with `deliver_by IS NULL` keep today's rule). `sent` rows expire at `executed_at + getCommandTimeoutMs`. Per-feature reapers (`script_executions`, `deployment_results`) must never independently expire *undelivered* work — they learn about delivery expiry only via `propagateTimedOutDeviceCommand`.
+- **Every terminal write on `device_commands` is a CAS on the observed `(status, executed_at)`.** Never `status IN ('pending','sent')` as the sole guard on an UPDATE that terminalises.
+- **`waitForCommandResult` is never combined with `{ kind: 'queue' }`.** Callers that wait for a result pass `reject`.
+- **Fail-closed registry.** Every value in `CommandTypes` (`apps/api/src/services/commandQueue.ts`) must appear in `COMMAND_OFFLINE_POLICY_REGISTRY`; a unit test asserts full coverage; an unregistered type throws at enqueue.
+- **Feature flag `DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED`** (default `false` until W4 lands, then `true`, then removed in W5) gates the `queue` arm only for callers that used to reject (`queueCommandForExecution`, patch executor, automations). Scripts, software installs, and the generic device-command routes queue regardless of the flag, as they do today.
+- **Migrations:** `apps/api/migrations/YYYY-MM-DD-HHMMSS-<slug>.sql`, idempotent, no inner `BEGIN`/`COMMIT`, never edit a shipped file, never touch the closed `2026-08-06` block. Filenames run ahead of real time: at execution time run `ls apps/api/migrations/*.sql | sort | tail -1` and name yours to sort *after* it. As of authoring the newest is `2026-10-12-100000-config-policy-inheritance.sql`, so W1 uses `2026-10-13-100000-device-commands-deliver-by.sql` and W3 uses `2026-10-13-100100-patch-offline-queue.sql`.
+- **Tests:** co-located `*.test.ts`; Drizzle chain mocks match the exact chain in the source; UUIDs are real UUIDs; run one file with `cd apps/api && npx vitest run <path>` (never `pnpm test -- --run`). Integration suites (`apps/api/src/__tests__/integration/*.integration.test.ts`) need a live DB and run only in the **Integration Tests** CI job — verify in the shard log that the new file actually executed.
+- **Copy:** user-facing strings go through i18n (`apps/web/src/locales/en/*.json`); the deferred-work sentence is always "Runs when the device is online — expires {{date}}" and the chip is always "Queued — device offline".
+
+---
+
+## Tenancy / RLS / cascade impact (read once)
+
+| Change | Tenancy consequence |
+|---|---|
+| `device_commands.deliver_by`, `.submitted_org_id` | None. Table is system-scoped by design (CLAUDE.md "Intentionally system-scoped"). Already in `CORE_DEVICE_CASCADE_DELETE_TABLES` (`routes/devices/core.ts`). `submitted_org_id` FK is `ON DELETE SET NULL` so erasing an org a device *left* never trips on its old rows. |
+| `patch_job_result_status` + `'queued'` | Enum add only. |
+| `patch_jobs.devices_queued` | `patch_jobs` is an org-cascade table → **new column must be classified** in `CORE_TENANT_EXPORT_POLICY` (`services/tenantExportPolicyRegistry.ts`) as `included`. `tenant-export-policy.integration.test.ts` fails otherwise. |
+| `config_policy_patch_settings.offline_behavior` | Table has no `org_id`/`partner_id` (tenancy is transitive via `feature_link_id`); no export-policy entry, no cascade entry. Same shape the reboot-deferral columns used. |
+| Automation action `whenOffline` | Inside the existing action-config jsonb (`excludedOpen`). Validator change only. |
+
+## CI traps for this plan
+
+- `tenant-export-policy.integration.test.ts` and `tenantExportErasureRoundtrip.integration.test.ts` only run under **Integration Tests**; a unit-green W3 PR can still go red there if `devices_queued` is unclassified.
+- `migrationRlsScope.test.ts` inspects migrations for DML; W1/W3 migrations are DDL-only, so no `set_config('breeze.scope', …)` is needed — do not add one.
+- `apps/api/src/db/autoMigrate.test.ts` asserts ordering; if another migration lands ahead of yours, rename before merge (an unmerged migration is editable).
+- Stacked PRs get **no** CI (`ci.yml` triggers on `pull_request: branches: [main]`). Each wave branches from `main`, not from the previous wave.
+
+## File structure
+
+**W1 — create**
+- `apps/api/src/services/commandOfflinePolicy.ts` — `OfflinePolicy`, TTL classes, fail-closed registry, `resolveOfflinePolicy`, `deliverByFor`, flag read.
+- `apps/api/src/services/commandOfflinePolicy.test.ts`
+- `apps/api/src/services/dispatchDeviceCommand.ts` — the single enqueue seam.
+- `apps/api/src/services/dispatchDeviceCommand.test.ts`
+- `apps/api/src/services/commandClaimEligibility.ts` — claim-time filter + power-state barrier + per-type holds.
+- `apps/api/src/services/commandClaimEligibility.test.ts`
+- `apps/api/migrations/2026-10-13-100000-device-commands-deliver-by.sql`
+- `apps/api/src/__tests__/integration/deviceCommandOfflineQueue.integration.test.ts`
+
+**W1 — modify**
+- `apps/api/src/db/schema/devices.ts` (`deviceCommands` columns)
+- `apps/api/src/services/commandQueue.ts` (`queueCommand` options; `queueCommandForExecution` → seam; `precheckCommandExecution` grace deadline)
+- `apps/api/src/services/commandDispatch.ts` (claim predicates + eligibility)
+- `apps/api/src/services/commandDelivery.ts` (`prepareClaimedCommandsForDelivery` with refreshers)
+- `apps/api/src/jobs/staleCommandReaper.ts` (two clocks, CAS, script/software reapers)
+- `apps/api/src/services/scriptDispatch.ts` (`offlinePolicy`, `requireOnline` alias)
+- `apps/api/src/services/softwareDeployment.ts` (persist-before-push, `s3Key` in payload)
+- `apps/api/src/routes/agentWs.ts` (software reconciliation on the generic result path)
+- `apps/api/src/routes/devices/commands.ts` (bulk/single/set_auto_update via seam; cancel endpoint; `status` filter on list)
+- `apps/api/src/routes/devices/moveOrg.ts`, `apps/api/src/routes/devices/core.ts` (cancel-on-event)
+
+**W2 — create/modify:** `packages/shared/src/types/scriptAdmission.ts`, `apps/api/src/services/scriptExecution.ts`, `apps/web/src/components/devices/DeviceQueuedActions.tsx` (+test), `apps/web/src/components/devices/DeviceDetails.tsx`, `apps/web/src/components/devices/DevicesPage.tsx`, `apps/web/src/components/scripts/executionStatus.ts`, locales.
+
+**W3 — create/modify:** migration, `apps/api/src/db/schema/patches.ts`, `configurationPolicies.ts`, `packages/shared/src/validators/index.ts` (`patchInlineSettingsSchema`), `apps/api/src/services/patchJobFinalizer.ts` (+test), `apps/api/src/jobs/patchJobExecutor.ts`, `apps/api/src/jobs/patchSchedulerWorker.ts`, `apps/api/src/services/commandResultHandlers.ts`, `apps/api/src/services/tenantExportPolicyRegistry.ts`, web patch settings form.
+
+**W4:** `packages/shared/src/validators/index.ts` (`automationActionSchema`), `apps/api/src/services/automationRuntime.ts`, `apps/api/src/services/automationActionResults.ts`, automation form.
+
+**W5:** `apps/docs/src/content/docs/features/*.mdx`, `apps/api/src/services/aiToolsScripts.ts` (+ siblings), flag removal.
+
+**W6 (after #3985 merges):** `apps/api/src/services/commandClaimEligibility.ts` principal rehydration via the recovery-authorization-subject shape.
+
+---
+
+## Wave 1 — Core: deadline column, policy seam, two-clock reaper, claim eligibility, cancel
+
+Branch: `feature/5131-offline-work-queue/wave-5132` from `main`. Everything in this wave ships behind `DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED=false` for previously-rejecting callers; scripts, software and generic commands gain the deadline immediately (they already queue today).
+
+### Task 1.1: Schema + migration for `deliver_by` and `submitted_org_id`
+
+**Files:**
+- Modify: `apps/api/src/db/schema/devices.ts` (the `deviceCommands` table, after `deviceRemoveExpiresAt`)
+- Create: `apps/api/migrations/2026-10-13-100000-device-commands-deliver-by.sql`
+- Test: `apps/api/src/db/autoMigrate.test.ts` (existing — run it), `apps/api/src/db/schema/deviceCommands.columns.test.ts` (create)
+
+**Interfaces:**
+- Produces: `deviceCommands.deliverBy: Date | null`, `deviceCommands.submittedOrgId: string | null` on `typeof deviceCommands.$inferSelect`.
+
+- [ ] **Step 1: Write the failing schema test**
+
+```ts
+// apps/api/src/db/schema/deviceCommands.columns.test.ts
+import { describe, expect, it } from 'vitest';
+import { getTableColumns } from 'drizzle-orm';
+import { deviceCommands } from './devices';
+
+describe('deviceCommands deferred-delivery columns', () => {
+  it('declares deliver_by as a nullable timestamptz', () => {
+    const cols = getTableColumns(deviceCommands);
+    expect(cols.deliverBy.name).toBe('deliver_by');
+    expect(cols.deliverBy.notNull).toBe(false);
+  });
+  it('declares submitted_org_id as a nullable uuid (provenance, not tenancy)', () => {
+    const cols = getTableColumns(deviceCommands);
+    expect(cols.submittedOrgId.name).toBe('submitted_org_id');
+    expect(cols.submittedOrgId.notNull).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run it — expect FAIL** (`cols.deliverBy` undefined)
+
+```bash
+cd apps/api && npx vitest run src/db/schema/deviceCommands.columns.test.ts
+```
+
+- [ ] **Step 3: Add the columns to the Drizzle table**
+
+```ts
+// apps/api/src/db/schema/devices.ts — inside pgTable('device_commands', { ... }) after deviceRemoveExpiresAt
+  // #5128 — deadline by which an agent must CLAIM this row (delivery clock).
+  // NULL = legacy rule (execution timeout from created_at). See
+  // services/commandOfflinePolicy.ts and jobs/staleCommandReaper.ts.
+  deliverBy: timestamp('deliver_by', { withTimezone: true }),
+  // #5128 — the device's org at enqueue. PROVENANCE, not tenancy: compared at
+  // claim to cancel rows whose device has since moved org. Deliberately not
+  // named org_id so RLS/cascade auto-discovery keeps this table system-scoped.
+  submittedOrgId: uuid('submitted_org_id').references(() => organizations.id, { onDelete: 'set null' }),
+```
+
+(`organizations` is already imported in this file — confirm with `grep -n "organizations" apps/api/src/db/schema/devices.ts | head -2`.)
+
+- [ ] **Step 4: Write the migration**
+
+```sql
+-- 2026-10-13-100000: deferred delivery for device commands (#5128).
+--
+-- deliver_by is the DELIVERY deadline: the instant by which an agent must have
+-- claimed the row (pending -> sent). It is separate from the execution timeout
+-- (services/commandTimeouts.ts), which the stale reaper applies to `sent` rows
+-- from executed_at. NULL keeps today's rule for rows created before this
+-- migration, so no backfill is needed and old pending rows behave as before.
+--
+-- submitted_org_id is PROVENANCE, NOT TENANCY. device_commands is intentionally
+-- system-scoped (agent WS path, no RLS — see CLAUDE.md). This column records the
+-- device's org at enqueue so claim-time eligibility can cancel rows whose device
+-- has since moved org. It is deliberately not named org_id: the RLS-coverage and
+-- cascade contract tests auto-discover `org_id` columns, and this table must
+-- not be reclassified as tenant-scoped. ON DELETE SET NULL so erasing an org a
+-- device has LEFT is never blocked by that device's historical rows.
+
+ALTER TABLE device_commands ADD COLUMN IF NOT EXISTS deliver_by timestamptz;
+ALTER TABLE device_commands ADD COLUMN IF NOT EXISTS submitted_org_id uuid
+  REFERENCES organizations(id) ON DELETE SET NULL;
+
+-- Reaper scan for due deliveries; partial so 7-day rows are not rescanned.
+CREATE INDEX IF NOT EXISTS idx_device_commands_deliver_by
+  ON device_commands (deliver_by)
+  WHERE status = 'pending' AND deliver_by IS NOT NULL;
+```
+
+- [ ] **Step 5: Run schema test, migration naming guard, autoMigrate test — expect PASS**
+
+```bash
+cd apps/api && npx vitest run src/db/schema/deviceCommands.columns.test.ts src/db/autoMigrate.test.ts
+bash scripts/check-migration-naming.sh
+```
+
+- [ ] **Step 6: Apply locally and verify drift**
+
+```bash
+export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze"
+pnpm db:migrate && pnpm db:check-drift
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/db/schema/devices.ts apps/api/src/db/schema/deviceCommands.columns.test.ts apps/api/migrations/2026-10-13-100000-device-commands-deliver-by.sql
+git commit -m "feat(commands): add deliver_by and submitted_org_id to device_commands (#5128 W1)"
+```
+
+### Task 1.2: Offline-policy registry (fail-closed) and TTL classes
+
+**Files:**
+- Create: `apps/api/src/services/commandOfflinePolicy.ts`
+- Test: `apps/api/src/services/commandOfflinePolicy.test.ts`
+
+**Interfaces:**
+- Produces:
+  ```ts
+  export type OfflinePolicy = { kind: 'reject' } | { kind: 'queue'; deliverWithinMs: number };
+  export type DeliveryTtlClass = 'live' | 'standard' | 'short' | 'power_state';
+  export const REJECT_RACE_GRACE_MS: number;               // 5 min
+  export function deliveryTtlMs(cls: DeliveryTtlClass): number;
+  export function defaultOfflinePolicy(type: string): OfflinePolicy;   // throws UnregisteredCommandTypeError
+  export function resolveOfflinePolicy(type: string, requested: OfflinePolicy | undefined, opts: { previouslyRejected: boolean }): OfflinePolicy;
+  export function deliverByFor(policy: OfflinePolicy, now?: Date): Date;
+  export function isOfflineQueueEnabled(): boolean;
+  export class UnregisteredCommandTypeError extends Error {}
+  export const COMMAND_OFFLINE_POLICY_REGISTRY: Readonly<Record<string, DeliveryTtlClass>>;
+  ```
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// apps/api/src/services/commandOfflinePolicy.test.ts
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { CommandTypes } from './commandQueue';
+import {
+  COMMAND_OFFLINE_POLICY_REGISTRY,
+  REJECT_RACE_GRACE_MS,
+  UnregisteredCommandTypeError,
+  defaultOfflinePolicy,
+  deliverByFor,
+  deliveryTtlMs,
+  resolveOfflinePolicy,
+} from './commandOfflinePolicy';
+
+describe('commandOfflinePolicy registry', () => {
+  afterEach(() => { vi.unstubAllEnvs(); });
+
+  it('covers every CommandTypes value (fail-closed)', () => {
+    const missing = Object.values(CommandTypes).filter((t) => !(t in COMMAND_OFFLINE_POLICY_REGISTRY));
+    expect(missing).toEqual([]);
+  });
+
+  it('throws for an unregistered type', () => {
+    expect(() => defaultOfflinePolicy('definitely_not_a_command')).toThrow(UnregisteredCommandTypeError);
+  });
+
+  it('rejects live/interactive types and queues fire-and-forget types', () => {
+    expect(defaultOfflinePolicy(CommandTypes.TERMINAL_START)).toEqual({ kind: 'reject' });
+    expect(defaultOfflinePolicy(CommandTypes.LIST_PROCESSES)).toEqual({ kind: 'reject' });
+    expect(defaultOfflinePolicy(CommandTypes.SCRIPT)).toEqual({ kind: 'queue', deliverWithinMs: deliveryTtlMs('standard') });
+    expect(defaultOfflinePolicy(CommandTypes.REFRESH_INVENTORY)).toEqual({ kind: 'queue', deliverWithinMs: deliveryTtlMs('short') });
+    expect(defaultOfflinePolicy('reboot')).toEqual({ kind: 'queue', deliverWithinMs: deliveryTtlMs('power_state') });
+  });
+
+  it('standard TTL is 7 days by default and env-tunable', () => {
+    expect(deliveryTtlMs('standard')).toBe(7 * 24 * 60 * 60 * 1000);
+    vi.stubEnv('DEVICE_COMMAND_QUEUE_TTL_HOURS', '48');
+    expect(deliveryTtlMs('standard')).toBe(48 * 60 * 60 * 1000);
+  });
+
+  it('flag off + previouslyRejected keeps reject; flag on lets the registry queue', () => {
+    vi.stubEnv('DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED', 'false');
+    expect(resolveOfflinePolicy(CommandTypes.INSTALL_PATCHES, undefined, { previouslyRejected: true })).toEqual({ kind: 'reject' });
+    vi.stubEnv('DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED', 'true');
+    expect(resolveOfflinePolicy(CommandTypes.INSTALL_PATCHES, undefined, { previouslyRejected: true }).kind).toBe('queue');
+  });
+
+  it('an explicit requested policy always wins', () => {
+    vi.stubEnv('DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED', 'false');
+    expect(resolveOfflinePolicy(CommandTypes.INSTALL_PATCHES, { kind: 'queue', deliverWithinMs: 1000 }, { previouslyRejected: true }))
+      .toEqual({ kind: 'queue', deliverWithinMs: 1000 });
+  });
+
+  it('deliverByFor: queue adds deliverWithinMs; reject adds the race grace', () => {
+    const now = new Date('2026-09-06T00:00:00Z');
+    expect(deliverByFor({ kind: 'queue', deliverWithinMs: 60_000 }, now).toISOString()).toBe('2026-09-06T00:01:00.000Z');
+    expect(deliverByFor({ kind: 'reject' }, now).getTime()).toBe(now.getTime() + REJECT_RACE_GRACE_MS);
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL** (module not found)
+
+```bash
+cd apps/api && npx vitest run src/services/commandOfflinePolicy.test.ts
+```
+
+- [ ] **Step 3: Implement the module**
+
+```ts
+// apps/api/src/services/commandOfflinePolicy.ts
+import { CommandTypes } from './commandQueue';
+
+export type OfflinePolicy =
+  | { kind: 'reject' }
+  | { kind: 'queue'; deliverWithinMs: number };
+
+/** TTL class = how long a queued row may wait for the device (OD-1). */
+export type DeliveryTtlClass = 'live' | 'standard' | 'short' | 'power_state';
+
+export const REJECT_RACE_GRACE_MS = 5 * 60 * 1000;
+const HOUR_MS = 60 * 60 * 1000;
+
+export class UnregisteredCommandTypeError extends Error {
+  constructor(type: string) {
+    super(`Command type "${type}" has no entry in COMMAND_OFFLINE_POLICY_REGISTRY (services/commandOfflinePolicy.ts) — register it with a TTL class before dispatching it`);
+    this.name = 'UnregisteredCommandTypeError';
+  }
+}
+
+function envHours(name: string, fallback: number): number {
+  const raw = process.env[name];
+  const n = raw === undefined || raw === '' ? NaN : Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+export function deliveryTtlMs(cls: DeliveryTtlClass): number {
+  switch (cls) {
+    case 'live': return REJECT_RACE_GRACE_MS;
+    case 'standard': return envHours('DEVICE_COMMAND_QUEUE_TTL_HOURS', 168) * HOUR_MS;
+    case 'short': return envHours('DEVICE_COMMAND_QUEUE_SHORT_TTL_HOURS', 24) * HOUR_MS;
+    case 'power_state': return envHours('DEVICE_COMMAND_QUEUE_POWER_STATE_TTL_HOURS', 24) * HOUR_MS;
+  }
+}
+
+export function isOfflineQueueEnabled(): boolean {
+  return process.env.DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED === 'true';
+}
+
+const C = CommandTypes;
+const LIVE: readonly string[] = [
+  C.LIST_PROCESSES, C.GET_PROCESS, C.KILL_PROCESS, C.LIST_SERVICES, C.GET_SERVICE, C.START_SERVICE,
+  C.STOP_SERVICE, C.RESTART_SERVICE, C.EVENT_LOGS_LIST, C.EVENT_LOGS_QUERY, C.EVENT_LOG_GET,
+  C.TASKS_LIST, C.TASK_GET, C.TASK_RUN, C.TASK_ENABLE, C.TASK_DISABLE, C.TASK_HISTORY,
+  C.REGISTRY_KEYS, C.REGISTRY_VALUES, C.REGISTRY_GET, C.REGISTRY_SET, C.REGISTRY_DELETE,
+  C.REGISTRY_KEY_CREATE, C.REGISTRY_KEY_DELETE, C.FILE_LIST, C.FILE_READ, C.FILE_WRITE, C.FILE_DELETE,
+  C.FILE_MKDIR, C.FILE_RENAME, C.FILE_COPY, C.FILE_TRASH_LIST, C.FILE_TRASH_RESTORE, C.FILE_TRASH_PURGE,
+  C.FILE_LIST_DRIVES, C.TERMINAL_START, C.TERMINAL_DATA, C.TERMINAL_RESIZE, C.TERMINAL_STOP,
+  C.SCRIPT_CANCEL, C.TAKE_SCREENSHOT, C.COMPUTER_ACTION, C.COLLECT_BOOT_PERFORMANCE, C.VSS_STATUS,
+  C.VSS_WRITER_LIST, C.MSSQL_DISCOVER, C.HYPERV_DISCOVER, C.HYPERV_VM_STATE, C.VM_RESTORE_ESTIMATE,
+  C.VAULT_STATUS, C.WAKE_ON_LAN, C.CAPTURE_PPROF,
+];
+const SHORT: readonly string[] = [
+  C.REFRESH_INVENTORY, C.SET_LOG_LEVEL, C.PERIPHERAL_POLICY_SYNC, C.PERIPHERAL_POLICY_SYNC_V2,
+  C.MANAGE_STARTUP_ITEM, C.COLLECT_AUDIT_POLICY, C.SECURITY_COLLECT_STATUS, C.COLLECT_RELIABILITY_METRICS,
+  C.SYSTEM_STATE_COLLECT, C.HARDWARE_PROFILE, C.ENCRYPTION_COLLECT_KEYS, C.HYPERV_CHECKPOINT,
+];
+const POWER_STATE: readonly string[] = ['reboot', 'shutdown', C.REBOOT_SAFE_MODE];
+
+// Everything else in CommandTypes is 'standard'. Build the registry from
+// CommandTypes so a NEW type cannot be added without also being classified
+// (the coverage test above enforces that; a type added to CommandTypes but not
+// to one of the lists lands in `standard`, which is the safe default for
+// fire-and-forget work — a type that must NOT queue has to be listed in LIVE).
+const registry: Record<string, DeliveryTtlClass> = {};
+for (const type of Object.values(CommandTypes)) registry[type] = 'standard';
+for (const t of LIVE) registry[t] = 'live';
+for (const t of SHORT) registry[t] = 'short';
+for (const t of POWER_STATE) registry[t] = 'power_state';
+export const COMMAND_OFFLINE_POLICY_REGISTRY: Readonly<Record<string, DeliveryTtlClass>> = Object.freeze(registry);
+
+export function defaultOfflinePolicy(type: string): OfflinePolicy {
+  const cls = COMMAND_OFFLINE_POLICY_REGISTRY[type];
+  if (!cls) throw new UnregisteredCommandTypeError(type);
+  if (cls === 'live') return { kind: 'reject' };
+  return { kind: 'queue', deliverWithinMs: deliveryTtlMs(cls) };
+}
+
+export function resolveOfflinePolicy(
+  type: string,
+  requested: OfflinePolicy | undefined,
+  opts: { previouslyRejected: boolean },
+): OfflinePolicy {
+  if (requested) return requested;
+  const def = defaultOfflinePolicy(type);
+  if (def.kind === 'queue' && opts.previouslyRejected && !isOfflineQueueEnabled()) return { kind: 'reject' };
+  return def;
+}
+
+export function deliverByFor(policy: OfflinePolicy, now: Date = new Date()): Date {
+  const ms = policy.kind === 'queue' ? policy.deliverWithinMs : REJECT_RACE_GRACE_MS;
+  return new Date(now.getTime() + ms);
+}
+```
+
+Note: `'reboot'` and `'shutdown'` are generic command strings accepted by `routes/devices/commands.ts` (`createCommandSchema`) that are **not** in `CommandTypes`. Add them to the registry explicitly (they are, via `POWER_STATE`), and add `'lock'`, `'set_auto_update'`, and any other literal the route schema accepts: run `grep -n "z.enum" apps/api/src/routes/devices/schemas.ts` and mirror that enum into a `GENERIC_ROUTE_TYPES` list classified `standard` (except the power-state three). The coverage test must also iterate that enum — import it from `apps/api/src/routes/devices/schemas.ts` and add a second assertion.
+
+- [ ] **Step 4: Run — expect PASS**
+
+```bash
+cd apps/api && npx vitest run src/services/commandOfflinePolicy.test.ts
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/commandOfflinePolicy.ts apps/api/src/services/commandOfflinePolicy.test.ts
+git commit -m "feat(commands): fail-closed offline-policy registry with TTL classes (#5128 W1)"
+```
+
+### Task 1.3: `queueCommand` accepts `deliverBy` + `submittedOrgId`; the seam `dispatchDeviceCommand`
+
+**Files:**
+- Modify: `apps/api/src/services/commandQueue.ts` — `queueCommand` (~628) options + insert values (~674); `queueCommandForExecution` (~841) becomes a thin adapter over the seam.
+- Create: `apps/api/src/services/dispatchDeviceCommand.ts`, `apps/api/src/services/dispatchDeviceCommand.test.ts`
+- Test (existing, must stay green): `apps/api/src/services/commandQueue.test.ts`, `commandQueueTransitions.test.ts`, `commandQueue.dbcontext.test.ts`
+
+**Interfaces:**
+- Consumes: `resolveOfflinePolicy`, `deliverByFor` (Task 1.2); `claimPendingCommandForDelivery`, `releaseClaimedCommandDelivery` (`commandDispatch.ts`); `decryptCommandForDelivery`, `sendCommandToAgent`, `toAgentCommandFrame` (already used inside `queueCommandForExecution`).
+- Produces:
+  ```ts
+  // commandQueue.ts
+  export async function queueCommand(deviceId, type, payload = {}, userId?, options: { commandId?: string; deliverBy?: Date; submittedOrgId?: string } = {}): Promise<QueuedCommand>;
+  // dispatchDeviceCommand.ts
+  export type DispatchDeviceCommandInput = {
+    deviceId: string; type: string; payload?: CommandPayload; userId?: string;
+    offlinePolicy?: OfflinePolicy; previouslyRejected?: boolean;
+    expectedOrgId?: string; preferHeartbeat?: boolean;
+  };
+  export type DispatchDeviceCommandResult =
+    | { ok: true; command: QueuedCommand; delivery: 'delivered' | 'queued_offline' | 'queued_live'; deliverBy: Date }
+    | { ok: false; code: 'device_not_found' | 'device_offline' | 'device_decommissioned' | 'trust_denied'; error: string; trust?: { capability: 'device_execute'; reason: string } };
+  export async function dispatchDeviceCommand(input: DispatchDeviceCommandInput): Promise<DispatchDeviceCommandResult>;
+  ```
+  `delivery: 'queued_live'` = device online but socket push failed or `preferHeartbeat`; row waits for the next heartbeat. `'queued_offline'` = device not online at enqueue.
+
+- [ ] **Step 1: Failing tests for `queueCommand` stamping and the seam**
+
+```ts
+// apps/api/src/services/dispatchDeviceCommand.test.ts
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { queueCommandMock, claimMock, sendMock, assertAllowedMock, selectMock } = vi.hoisted(() => ({
+  queueCommandMock: vi.fn(),
+  claimMock: vi.fn(),
+  sendMock: vi.fn(),
+  assertAllowedMock: vi.fn(),
+  selectMock: vi.fn(),
+}));
+vi.mock('../db', () => ({
+  db: { select: (...a: unknown[]) => selectMock(...(a as [])) },
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+vi.mock('../db/schema', () => ({ devices: { id: 'devices.id' } }));
+vi.mock('./commandQueue', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./commandQueue')>();
+  return { ...actual, queueCommand: (...a: unknown[]) => queueCommandMock(...(a as [])), decryptCommandForDelivery: vi.fn((c: unknown) => c), toAgentCommandFrame: vi.fn((c: unknown) => c) };
+});
+vi.mock('./commandDispatch', () => ({
+  claimPendingCommandForDelivery: (...a: unknown[]) => claimMock(...(a as [])),
+  releaseClaimedCommandDelivery: vi.fn(),
+}));
+vi.mock('../routes/agentWs', () => ({ sendCommandToAgent: (...a: unknown[]) => sendMock(...(a as [])) }));
+vi.mock('./partnerTrust.commands', () => ({ assertDeviceExecuteAllowed: (...a: unknown[]) => assertAllowedMock(...(a as [])) }));
+
+import { dispatchDeviceCommand } from './dispatchDeviceCommand';
+
+const DEVICE = '11111111-1111-4111-8111-111111111111';
+const ORG = '22222222-2222-4222-8222-222222222222';
+function deviceRow(status: string) {
+  return { id: DEVICE, orgId: ORG, status, agentId: 'agent-1' };
+}
+function selectReturning(row: unknown) {
+  selectMock.mockReturnValue({ from: () => ({ where: () => ({ limit: async () => (row ? [row] : []) }) }) });
+}
+
+describe('dispatchDeviceCommand', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.stubEnv('DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED', 'true');
+    queueCommandMock.mockImplementation(async (_d, type, _p, _u, opts) => ({ id: 'cmd-1', type, status: 'pending', deliverBy: opts.deliverBy, submittedOrgId: opts.submittedOrgId }));
+  });
+
+  it('offline device + queue policy → row persisted with deliver_by and submitted_org_id, delivery=queued_offline', async () => {
+    selectReturning(deviceRow('offline'));
+    const before = Date.now();
+    const res = await dispatchDeviceCommand({ deviceId: DEVICE, type: 'refresh_inventory', offlinePolicy: { kind: 'queue', deliverWithinMs: 3_600_000 } });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.delivery).toBe('queued_offline');
+    expect(res.deliverBy.getTime()).toBeGreaterThanOrEqual(before + 3_600_000);
+    const opts = queueCommandMock.mock.calls[0]![4];
+    expect(opts.submittedOrgId).toBe(ORG);
+    expect(opts.deliverBy).toBeInstanceOf(Date);
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  it('offline device + reject policy → device_offline error, no row', async () => {
+    selectReturning(deviceRow('offline'));
+    const res = await dispatchDeviceCommand({ deviceId: DEVICE, type: 'list_processes' });
+    expect(res).toMatchObject({ ok: false, code: 'device_offline', error: 'Device is offline, cannot execute command' });
+    expect(queueCommandMock).not.toHaveBeenCalled();
+  });
+
+  it('online device → claim + push, delivery=delivered', async () => {
+    selectReturning(deviceRow('online'));
+    claimMock.mockResolvedValue({ id: 'cmd-1', executedAt: new Date() });
+    sendMock.mockReturnValue(true);
+    const res = await dispatchDeviceCommand({ deviceId: DEVICE, type: 'refresh_inventory' });
+    expect(res.ok && res.delivery).toBe('delivered');
+  });
+
+  it('online device, push fails → row released, delivery=queued_live', async () => {
+    selectReturning(deviceRow('online'));
+    claimMock.mockResolvedValue({ id: 'cmd-1', executedAt: new Date() });
+    sendMock.mockReturnValue(false);
+    const res = await dispatchDeviceCommand({ deviceId: DEVICE, type: 'refresh_inventory' });
+    expect(res.ok && res.delivery).toBe('queued_live');
+  });
+
+  it('expectedOrgId mismatch → device_not_found (never leaks existence)', async () => {
+    selectReturning(deviceRow('online'));
+    const res = await dispatchDeviceCommand({ deviceId: DEVICE, type: 'refresh_inventory', expectedOrgId: '33333333-3333-4333-8333-333333333333' });
+    expect(res).toMatchObject({ ok: false, code: 'device_not_found' });
+  });
+
+  it('decommissioned device → device_decommissioned regardless of policy', async () => {
+    selectReturning(deviceRow('decommissioned'));
+    const res = await dispatchDeviceCommand({ deviceId: DEVICE, type: 'refresh_inventory', offlinePolicy: { kind: 'queue', deliverWithinMs: 1000 } });
+    expect(res).toMatchObject({ ok: false, code: 'device_decommissioned' });
+  });
+
+  it('unregistered type throws before any DB write', async () => {
+    selectReturning(deviceRow('online'));
+    await expect(dispatchDeviceCommand({ deviceId: DEVICE, type: 'nope_not_real' })).rejects.toThrow(/COMMAND_OFFLINE_POLICY_REGISTRY/);
+    expect(queueCommandMock).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+```bash
+cd apps/api && npx vitest run src/services/dispatchDeviceCommand.test.ts
+```
+
+- [ ] **Step 3: Extend `queueCommand` options and insert**
+
+In `apps/api/src/services/commandQueue.ts`:
+
+```ts
+export async function queueCommand(
+  deviceId: string,
+  type: CommandType | string,
+  payload: CommandPayload = {},
+  userId?: string,
+  options: { commandId?: string; deliverBy?: Date; submittedOrgId?: string } = {}
+): Promise<QueuedCommand> {
+```
+
+and in the `.values({...})`:
+
+```ts
+      .values({
+        ...(options.commandId ? { id: options.commandId } : {}),
+        deviceId,
+        type,
+        payload,
+        status: 'pending',
+        createdBy: safeUserId,
+        ...(options.deliverBy ? { deliverBy: options.deliverBy } : {}),
+        ...(options.submittedOrgId ? { submittedOrgId: options.submittedOrgId } : {}),
+      })
+```
+
+- [ ] **Step 4: Create the seam**
+
+```ts
+// apps/api/src/services/dispatchDeviceCommand.ts
+import { eq } from 'drizzle-orm';
+import { db } from '../db';
+import { devices } from '../db/schema';
+import { sendCommandToAgent } from '../routes/agentWs';
+import { claimPendingCommandForDelivery, releaseClaimedCommandDelivery } from './commandDispatch';
+import { deliverByFor, resolveOfflinePolicy, type OfflinePolicy } from './commandOfflinePolicy';
+import {
+  decryptCommandForDelivery,
+  queueCommand,
+  toAgentCommandFrame,
+  type CommandPayload,
+  type QueuedCommand,
+} from './commandQueue';
+import { TrustDeniedError, assertDeviceExecuteAllowed } from './partnerTrust.commands';
+
+export type DispatchDeviceCommandInput = {
+  deviceId: string;
+  type: string;
+  payload?: CommandPayload;
+  userId?: string;
+  /** Explicit policy; omit to take the registry default. */
+  offlinePolicy?: OfflinePolicy;
+  /** True for callers that hard-rejected offline devices before #5128; the
+   *  DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED flag gates their switch to queueing. */
+  previouslyRejected?: boolean;
+  /** Defense-in-depth for callers running under a system context. */
+  expectedOrgId?: string;
+  /** Skip the socket push even when connected (watchdog-style consumers). */
+  preferHeartbeat?: boolean;
+};
+
+export type DispatchDeviceCommandResult =
+  | { ok: true; command: QueuedCommand; delivery: 'delivered' | 'queued_offline' | 'queued_live'; deliverBy: Date }
+  | {
+      ok: false;
+      code: 'device_not_found' | 'device_offline' | 'device_decommissioned' | 'trust_denied';
+      error: string;
+      trust?: { capability: 'device_execute'; reason: string };
+    };
+
+/**
+ * The single enqueue seam for device commands (#5128 §D). Order: device lookup
+ * → expectedOrgId → lifecycle → trust → resolve offline policy → persist row
+ * (ALWAYS before any transport) → claim/prepare/push/release when connected.
+ */
+export async function dispatchDeviceCommand(input: DispatchDeviceCommandInput): Promise<DispatchDeviceCommandResult> {
+  const policy = resolveOfflinePolicy(input.type, input.offlinePolicy, {
+    previouslyRejected: input.previouslyRejected ?? false,
+  }); // throws UnregisteredCommandTypeError before any DB access
+
+  const [device] = await db.select().from(devices).where(eq(devices.id, input.deviceId)).limit(1);
+  if (!device) return { ok: false, code: 'device_not_found', error: 'Device not found' };
+  if (input.expectedOrgId !== undefined && device.orgId !== input.expectedOrgId) {
+    return { ok: false, code: 'device_not_found', error: 'Device not found' };
+  }
+  if (device.status === 'decommissioned') {
+    return { ok: false, code: 'device_decommissioned', error: 'Cannot send commands to a decommissioned device' };
+  }
+
+  try {
+    await assertDeviceExecuteAllowed(input.deviceId, input.type, input.userId);
+  } catch (e) {
+    if (e instanceof TrustDeniedError) {
+      return { ok: false, code: 'trust_denied', error: e.code, trust: { capability: e.capability, reason: e.reason } };
+    }
+    throw e;
+  }
+
+  const online = device.status === 'online';
+  if (!online && policy.kind === 'reject') {
+    return { ok: false, code: 'device_offline', error: `Device is ${device.status}, cannot execute command` };
+  }
+
+  const deliverBy = deliverByFor(policy);
+  const command = await queueCommand(input.deviceId, input.type, input.payload ?? {}, input.userId, {
+    deliverBy,
+    submittedOrgId: device.orgId,
+  });
+
+  if (!online) return { ok: true, command, delivery: 'queued_offline', deliverBy };
+  if (!device.agentId || input.preferHeartbeat) return { ok: true, command, delivery: 'queued_live', deliverBy };
+
+  const claimed = await claimPendingCommandForDelivery(command.id);
+  if (!claimed) return { ok: true, command, delivery: 'queued_live', deliverBy };
+  const prepared = decryptCommandForDelivery({ id: command.id, type: input.type, deviceId: input.deviceId, payload: input.payload ?? {} });
+  const sent = prepared ? sendCommandToAgent(device.agentId, toAgentCommandFrame(prepared)) : false;
+  if (sent) return { ok: true, command: { ...command, status: 'sent' }, delivery: 'delivered', deliverBy };
+  await releaseClaimedCommandDelivery(command.id, claimed.executedAt);
+  return { ok: true, command, delivery: 'queued_live', deliverBy };
+}
+```
+
+Check the exact export names `decryptCommandForDelivery` and `toAgentCommandFrame` exist in `commandQueue.ts` (they are used at ~889–893 inside `queueCommandForExecution`); if they live in another module, import from there and update the test mock path accordingly.
+
+- [ ] **Step 5: Make `queueCommandForExecution` an adapter**
+
+Replace the body of `queueCommandForExecution` (~841–911) with:
+
+```ts
+export async function queueCommandForExecution(
+  deviceId: string,
+  type: CommandType | string,
+  payload: CommandPayload = {},
+  options: { userId?: string; preferHeartbeat?: boolean; expectedOrgId?: string; offlinePolicy?: OfflinePolicy } = {}
+): Promise<QueueCommandForExecutionResult> {
+  const res = await dispatchDeviceCommand({
+    deviceId, type, payload,
+    userId: options.userId,
+    preferHeartbeat: options.preferHeartbeat,
+    expectedOrgId: options.expectedOrgId,
+    offlinePolicy: options.offlinePolicy,
+    previouslyRejected: true,
+  });
+  if (!res.ok) {
+    return res.code === 'trust_denied'
+      ? { error: res.error, trust: res.trust }
+      : { error: res.error };
+  }
+  return { command: res.command, delivery: res.delivery, deliverBy: res.deliverBy };
+}
+```
+
+and extend the result type:
+
+```ts
+export interface QueueCommandForExecutionResult {
+  command?: QueuedCommand;
+  error?: string;
+  trust?: { capability: 'device_execute'; reason: string };
+  delivery?: 'delivered' | 'queued_offline' | 'queued_live';
+  deliverBy?: Date;
+}
+```
+
+`import type { OfflinePolicy } from './commandOfflinePolicy'` and `import { dispatchDeviceCommand } from './dispatchDeviceCommand'` at the top of `commandQueue.ts`. **Circular import check:** `dispatchDeviceCommand.ts` imports from `commandQueue.ts`, and `commandQueue.ts` now imports `dispatchDeviceCommand`. Both are function-level uses (no top-level evaluation of each other's exports), so ESM cycles resolve; run `cd apps/api && npx tsc --noEmit -p .` and the three existing `commandQueue*.test.ts` files to confirm.
+
+- [ ] **Step 6: `precheckCommandExecution` / `dispatchPreparedCommand` stamp the grace deadline**
+
+`executeCommand` is synchronous by contract (`waitForCommandResult`), so it stays `reject` — but its row must carry `deliver_by` so a race with a disconnect cannot linger. In `dispatchPreparedCommand` (the `queueCommand(...)` call at ~1211), pass:
+
+```ts
+  const submittedOrgId = device.orgId;
+  const command = await queueCommand(deviceId, type, payloadForRow, options.userId, {
+    deliverBy: deliverByFor({ kind: 'reject' }),
+    submittedOrgId,
+  });
+```
+
+(`device` is already in scope there — it is the `precheck.device` argument.)
+
+- [ ] **Step 7: Run new + existing tests and typecheck — expect PASS**
+
+```bash
+cd apps/api && npx vitest run src/services/dispatchDeviceCommand.test.ts src/services/commandQueue.test.ts src/services/commandQueueTransitions.test.ts src/services/commandQueue.dbcontext.test.ts && npx tsc --noEmit -p .
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/api/src/services/commandQueue.ts apps/api/src/services/dispatchDeviceCommand.ts apps/api/src/services/dispatchDeviceCommand.test.ts
+git commit -m "feat(commands): dispatchDeviceCommand seam with explicit offline policy (#5128 W1)"
+```
+
+### Task 1.4: Claim predicates, eligibility filter, power-state barrier
+
+**Files:**
+- Create: `apps/api/src/services/commandClaimEligibility.ts`, `apps/api/src/services/commandClaimEligibility.test.ts`
+- Modify: `apps/api/src/services/commandDispatch.ts` (`claimPendingCommandForDelivery` ~8–29; `claimPendingCommandsForDevice` ~62–166)
+- Test (existing): `apps/api/src/services/commandDispatch.test.ts`
+
+**Interfaces:**
+- Produces:
+  ```ts
+  // commandClaimEligibility.ts
+  export type ClaimCancelReason = 'device_moved_org' | 'device_lifecycle' | 'trust_denied' | 'requester_inactive' | 'held_maintenance_suppression';
+  export type ClaimEligibilityDevice = { id: string; orgId: string; status: string; partnerId: string | null };
+  export type ClaimCandidate = { id: string; type: string; createdBy: string | null; submittedOrgId: string | null; deliverBy: Date | null };
+  export async function partitionClaimable(tx: Tx, device: ClaimEligibilityDevice, rows: ClaimCandidate[]): Promise<{ claimable: ClaimCandidate[]; cancelled: Array<{ id: string; reason: ClaimCancelReason }>; held: Array<{ id: string; reason: ClaimCancelReason }> }>;
+  export const POWER_STATE_TYPES: ReadonlySet<string>;   // 'reboot' | 'shutdown' | 'reboot_safe_mode'
+  export const typeHolds: Record<string, (deviceId: string) => Promise<boolean>>;   // W3 registers install_patches here
+  ```
+  `cancelled` rows are terminalised inside `tx` (`status='cancelled'`, `completedAt`, `result: { status: 'cancelled', reason }`, payload erased). `held` rows are left `pending` untouched (they will be re-evaluated on the next heartbeat).
+
+- [ ] **Step 1: Failing tests**
+
+```ts
+// apps/api/src/services/commandClaimEligibility.test.ts
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { assertAllowedMock, userStatusMock, updateMock } = vi.hoisted(() => ({
+  assertAllowedMock: vi.fn(), userStatusMock: vi.fn(), updateMock: vi.fn(),
+}));
+vi.mock('./partnerTrust.commands', () => ({
+  assertDeviceExecuteAllowed: (...a: unknown[]) => assertAllowedMock(...(a as [])),
+  TrustDeniedError: class TrustDeniedError extends Error { code = 'trust_denied'; capability = 'device_execute'; reason = 'r'; },
+}));
+vi.mock('../db/schema', () => ({
+  deviceCommands: { id: 'dc.id', status: 'dc.status', completedAt: 'dc.completedAt', result: 'dc.result', payload: 'dc.payload' },
+  users: { id: 'users.id', status: 'users.status' },
+}));
+vi.mock('./sensitiveCommandPayload', () => ({ terminalPayloadErasureSet: () => ({ payload: null }) }));
+
+import { partitionClaimable, typeHolds } from './commandClaimEligibility';
+
+const ORG = '22222222-2222-4222-8222-222222222222';
+const OTHER = '33333333-3333-4333-8333-333333333333';
+const USER = '44444444-4444-4444-8444-444444444444';
+const device = { id: 'd1', orgId: ORG, status: 'online', partnerId: 'p1' };
+const row = (over: Partial<Parameters<typeof partitionClaimable>[2][number]> = {}) => ({
+  id: 'c1', type: 'refresh_inventory', createdBy: null, submittedOrgId: ORG, deliverBy: null, ...over,
+});
+function tx() {
+  updateMock.mockReturnValue({ set: () => ({ where: async () => [] }) });
+  return {
+    update: (...a: unknown[]) => updateMock(...(a as [])),
+    select: () => ({ from: () => ({ where: () => ({ limit: async () => userStatusMock() }) }) }),
+  } as never;
+}
+
+describe('partitionClaimable', () => {
+  beforeEach(() => { vi.resetAllMocks(); assertAllowedMock.mockResolvedValue(undefined); userStatusMock.mockResolvedValue([{ status: 'active' }]); });
+
+  it('passes an ordinary row through', async () => {
+    const r = await partitionClaimable(tx(), device, [row()]);
+    expect(r.claimable.map((x) => x.id)).toEqual(['c1']);
+    expect(r.cancelled).toEqual([]);
+  });
+
+  it('cancels when the device moved org since enqueue', async () => {
+    const r = await partitionClaimable(tx(), device, [row({ submittedOrgId: OTHER })]);
+    expect(r.cancelled).toEqual([{ id: 'c1', reason: 'device_moved_org' }]);
+    expect(updateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('legacy rows with NULL submitted_org_id are not cancelled for org drift', async () => {
+    const r = await partitionClaimable(tx(), device, [row({ submittedOrgId: null })]);
+    expect(r.claimable).toHaveLength(1);
+  });
+
+  it('cancels on device lifecycle (quarantined) except self_uninstall', async () => {
+    const r = await partitionClaimable(tx(), { ...device, status: 'quarantined' }, [row(), row({ id: 'c2', type: 'self_uninstall' })]);
+    expect(r.cancelled).toEqual([{ id: 'c1', reason: 'device_lifecycle' }]);
+    expect(r.claimable.map((x) => x.id)).toEqual(['c2']);
+  });
+
+  it('cancels on trust denial', async () => {
+    const { TrustDeniedError } = await import('./partnerTrust.commands');
+    assertAllowedMock.mockRejectedValue(new TrustDeniedError('x'));
+    const r = await partitionClaimable(tx(), device, [row()]);
+    expect(r.cancelled).toEqual([{ id: 'c1', reason: 'trust_denied' }]);
+  });
+
+  it('cancels when the requesting user is no longer active', async () => {
+    userStatusMock.mockResolvedValue([{ status: 'disabled' }]);
+    const r = await partitionClaimable(tx(), device, [row({ createdBy: USER })]);
+    expect(r.cancelled).toEqual([{ id: 'c1', reason: 'requester_inactive' }]);
+  });
+
+  it('power-state rows are claimed alone and only when nothing is in flight', async () => {
+    const r = await partitionClaimable(tx(), device, [row({ id: 'a', type: 'refresh_inventory' }), row({ id: 'b', type: 'reboot' })]);
+    expect(r.claimable.map((x) => x.id)).toEqual(['a']);      // reboot deferred to a later heartbeat
+    expect(r.held).toEqual([{ id: 'b', reason: 'power_state_barrier' }]);
+  });
+
+  it('a registered type hold keeps the row pending', async () => {
+    typeHolds['install_patches'] = async () => true;
+    const r = await partitionClaimable(tx(), device, [row({ type: 'install_patches' })]);
+    expect(r.held).toEqual([{ id: 'c1', reason: 'held_maintenance_suppression' }]);
+    delete typeHolds['install_patches'];
+  });
+});
+```
+
+Add `'power_state_barrier'` to `ClaimCancelReason` (it is a *hold* reason, listed in the same union for simplicity).
+
+- [ ] **Step 2: Run — expect FAIL**
+
+- [ ] **Step 3: Implement**
+
+```ts
+// apps/api/src/services/commandClaimEligibility.ts
+import { and, eq, inArray } from 'drizzle-orm';
+import type { db } from '../db';
+import { deviceCommands, users } from '../db/schema';
+import { TrustDeniedError, assertDeviceExecuteAllowed } from './partnerTrust.commands';
+import { terminalPayloadErasureSet } from './sensitiveCommandPayload';
+
+type Tx = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+export type ClaimCancelReason =
+  | 'device_moved_org' | 'device_lifecycle' | 'trust_denied' | 'requester_inactive'
+  | 'held_maintenance_suppression' | 'power_state_barrier';
+export type ClaimEligibilityDevice = { id: string; orgId: string; status: string; partnerId: string | null };
+export type ClaimCandidate = { id: string; type: string; createdBy: string | null; submittedOrgId: string | null; deliverBy: Date | null };
+
+export const POWER_STATE_TYPES: ReadonlySet<string> = new Set(['reboot', 'shutdown', 'reboot_safe_mode']);
+/** Types exempt from lifecycle cancellation: the uninstall drain must still deliver. */
+const LIFECYCLE_EXEMPT: ReadonlySet<string> = new Set(['self_uninstall']);
+const NON_DELIVERABLE_LIFECYCLE: ReadonlySet<string> = new Set(['decommissioned', 'quarantined']);
+
+/** Per-type "hold" predicates: true = leave pending this heartbeat. W3 registers install_patches. */
+export const typeHolds: Record<string, (deviceId: string) => Promise<boolean>> = {};
+
+/**
+ * Splits claim candidates into claimable / cancelled / held (#5128 §G). Cancels
+ * are written INSIDE the caller's claim transaction so a cancelled row can never
+ * be delivered by a concurrent claim. Also enforces the power-state barrier
+ * (§E.4): reboot/shutdown are claimed alone and only when nothing else is in
+ * flight — `inFlight` is supplied by the caller from a `status='sent'` count.
+ */
+export async function partitionClaimable(
+  tx: Tx,
+  device: ClaimEligibilityDevice,
+  rows: ClaimCandidate[],
+  opts: { inFlight?: number } = {},
+): Promise<{ claimable: ClaimCandidate[]; cancelled: Array<{ id: string; reason: ClaimCancelReason }>; held: Array<{ id: string; reason: ClaimCancelReason }> }> {
+  const claimable: ClaimCandidate[] = [];
+  const cancelled: Array<{ id: string; reason: ClaimCancelReason }> = [];
+  const held: Array<{ id: string; reason: ClaimCancelReason }> = [];
+  const requesterCache = new Map<string, boolean>();
+
+  for (const row of rows) {
+    if (row.submittedOrgId !== null && row.submittedOrgId !== device.orgId) { cancelled.push({ id: row.id, reason: 'device_moved_org' }); continue; }
+    if (NON_DELIVERABLE_LIFECYCLE.has(device.status) && !LIFECYCLE_EXEMPT.has(row.type)) { cancelled.push({ id: row.id, reason: 'device_lifecycle' }); continue; }
+    try {
+      await assertDeviceExecuteAllowed(device.id, row.type, row.createdBy ?? undefined);
+    } catch (e) {
+      if (e instanceof TrustDeniedError) { cancelled.push({ id: row.id, reason: 'trust_denied' }); continue; }
+      throw e;
+    }
+    if (row.createdBy) {
+      let active = requesterCache.get(row.createdBy);
+      if (active === undefined) {
+        const [u] = await tx.select({ status: users.status }).from(users).where(eq(users.id, row.createdBy)).limit(1);
+        active = u?.status === 'active';
+        requesterCache.set(row.createdBy, active);
+      }
+      if (!active) { cancelled.push({ id: row.id, reason: 'requester_inactive' }); continue; }
+    }
+    const hold = typeHolds[row.type];
+    if (hold && (await hold(device.id))) { held.push({ id: row.id, reason: 'held_maintenance_suppression' }); continue; }
+    claimable.push(row);
+  }
+
+  // Power-state barrier: a reboot/shutdown is claimed only as the sole row of a
+  // batch with nothing in flight. Otherwise hold it for a later heartbeat.
+  const power = claimable.filter((r) => POWER_STATE_TYPES.has(r.type));
+  if (power.length > 0) {
+    const others = claimable.filter((r) => !POWER_STATE_TYPES.has(r.type));
+    const inFlight = opts.inFlight ?? 0;
+    if (others.length > 0 || inFlight > 0) {
+      for (const p of power) held.push({ id: p.id, reason: 'power_state_barrier' });
+      claimable.splice(0, claimable.length, ...others);
+    } else {
+      claimable.splice(0, claimable.length, power[0]!);
+      for (const p of power.slice(1)) held.push({ id: p.id, reason: 'power_state_barrier' });
+    }
+  }
+
+  if (cancelled.length > 0) {
+    const completedAt = new Date();
+    for (const c of cancelled) {
+      await tx.update(deviceCommands)
+        .set({ status: 'cancelled', completedAt, result: { status: 'cancelled', reason: c.reason, cancelledBy: 'claim_eligibility' }, ...terminalPayloadErasureSet() })
+        .where(and(eq(deviceCommands.id, c.id), eq(deviceCommands.status, 'pending')));
+    }
+  }
+  return { claimable, cancelled, held };
+}
+```
+
+Confirm the `users.status` column name with `grep -n "status" apps/api/src/db/schema/users.ts | head -3` and adjust (`isActive` boolean → `active = u?.isActive === true`).
+
+- [ ] **Step 4: Wire into `commandDispatch.ts`**
+
+In `claimPendingCommandForDelivery` add the deadline predicate:
+
+```ts
+      .where(
+        and(
+          eq(deviceCommands.id, commandId),
+          eq(deviceCommands.status, 'pending'),
+          or(isNull(deviceCommands.deliverBy), gt(deviceCommands.deliverBy, new Date())),
+        ),
+      )
+```
+
+In `claimPendingCommandsForDevice`, inside the transaction after `pendingCommands` is selected and before the `UPDATE ... SET status='sent'`:
+
+```ts
+    const [dev] = await tx.select({ id: devices.id, orgId: devices.orgId, status: devices.status, partnerId: devices.partnerId })
+      .from(devices).where(eq(devices.id, deviceId)).limit(1);
+    if (!dev) return [];
+    const [{ inFlight }] = await tx.select({ inFlight: sql<number>`count(*)::int` })
+      .from(deviceCommands)
+      .where(and(eq(deviceCommands.deviceId, deviceId), eq(deviceCommands.status, 'sent'), eq(deviceCommands.targetRole, targetRole)));
+    const { claimable } = await partitionClaimable(tx, dev, pendingCommands, { inFlight });
+    const claimIds = claimable.map((c) => c.id);
+    if (claimIds.length === 0) return [];
+```
+
+and add `or(isNull(deviceCommands.deliverBy), gt(deviceCommands.deliverBy, now))` to the `pendingCommands` SELECT's `and(...)`; the subsequent UPDATE must use `inArray(deviceCommands.id, claimIds)` instead of the full pending set. Import `devices` from `../db/schema`, `partitionClaimable` from `./commandClaimEligibility`, and `gt, isNull, or, sql` from `drizzle-orm`. The existing `FOR UPDATE SKIP LOCKED` stays on the SELECT.
+
+- [ ] **Step 5: Update `commandDispatch.test.ts` mocks** — the `../db/schema` mock needs `devices: { id, orgId, status, partnerId }`, `deviceCommands.deliverBy`, `deviceCommands.submittedOrgId`, `deviceCommands.createdBy`, `users`. Add a test: a row whose `deliverBy` is in the past is excluded from the claim (assert the `gt`/`isNull` predicate appears in the SELECT's `where` args, following the file's existing `inArray` spy pattern — spy `gt` and `isNull` the same way).
+
+- [ ] **Step 6: Run — expect PASS**
+
+```bash
+cd apps/api && npx vitest run src/services/commandClaimEligibility.test.ts src/services/commandDispatch.test.ts && npx tsc --noEmit -p .
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/services/commandClaimEligibility.ts apps/api/src/services/commandClaimEligibility.test.ts apps/api/src/services/commandDispatch.ts apps/api/src/services/commandDispatch.test.ts
+git commit -m "feat(commands): claim-time eligibility, deliver_by predicate, power-state barrier (#5128 W1)"
+```
+
+### Task 1.5: Reaper — two clocks, CAS on observed state, `expired` result, single owner of the delivery clock
+
+**Files:**
+- Modify: `apps/api/src/jobs/staleCommandReaper.ts` — `reapStaleDeviceCommands` (~182–372), `reapStaleScriptExecutions` (~395–470), `reapStaleSoftwareDeploymentResults` (~940–1030); `apps/api/src/services/commandTimeouts.ts` (remove the `SOFTWARE_INSTALL → SEVEN_DAYS` line); `apps/api/src/services/propagateTimedOutDeviceCommand.ts` (or wherever `propagateTimedOutDeviceCommand` is exported — `grep -rn "export async function propagateTimedOutDeviceCommand" apps/api/src`).
+- Test: `apps/api/src/jobs/staleCommandReaper.test.ts` (extend), `apps/api/src/jobs/staleCommandReaper.twoClocks.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `deviceCommands.deliverBy`, `deviceCommands.executedAt`.
+- Produces: command `result` shape for a delivery expiry: `{ status: 'expired', reason: 'not_delivered_before_deadline', error: string, timedOutBy: 'server' }`; `propagateTimedOutDeviceCommand` gains `kind: 'expired' | 'timeout'`.
+
+- [ ] **Step 1: Failing tests** (`staleCommandReaper.twoClocks.test.ts`, mirroring the hoisted-mock header of `staleCommandReaper.test.ts` — copy lines 1–140 of that file verbatim for the mocks and `selectChain`/`updateChain` helpers, then add):
+
+```ts
+describe('reapStaleDeviceCommands — two clocks (#5128)', () => {
+  const now = Date.now();
+  const script = (over: Record<string, unknown>) => ({
+    id: 'c1', type: 'script', payload: { timeoutSeconds: 300 }, status: 'pending',
+    createdAt: new Date(now - 60 * 60 * 1000), executedAt: null, deliverBy: null, ...over,
+  });
+
+  it('pending row with a FUTURE deliver_by is not reaped even though the execution timeout has lapsed', async () => {
+    selectMock.mockReturnValueOnce(selectChain([script({ deliverBy: new Date(now + 6 * 24 * 3600 * 1000) })]));
+    const reaped = await reapStaleDeviceCommands();
+    expect(reaped).toBe(0);
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it('pending row past deliver_by is failed with an expired/not_delivered_before_deadline result', async () => {
+    selectMock.mockReturnValueOnce(selectChain([script({ deliverBy: new Date(now - 1000) })]));
+    const update = updateChain([{ id: 'c1' }]);
+    updateMock.mockReturnValue(update);
+    const reaped = await reapStaleDeviceCommands();
+    expect(reaped).toBe(1);
+    expect(update.set).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'failed',
+      result: expect.objectContaining({ status: 'expired', reason: 'not_delivered_before_deadline', timedOutBy: 'server' }),
+    }));
+  });
+
+  it('legacy pending row (deliver_by NULL) keeps the created_at + execution-timeout rule', async () => {
+    selectMock.mockReturnValueOnce(selectChain([script({ deliverBy: null })]));
+    const update = updateChain([{ id: 'c1' }]);
+    updateMock.mockReturnValue(update);
+    expect(await reapStaleDeviceCommands()).toBe(1);
+    expect(update.set).toHaveBeenCalledWith(expect.objectContaining({ result: expect.objectContaining({ status: 'timeout' }) }));
+  });
+
+  it('terminal UPDATE is a CAS on the observed status (pending) — never IN (pending, sent)', async () => {
+    selectMock.mockReturnValueOnce(selectChain([script({ deliverBy: new Date(now - 1000) })]));
+    const update = updateChain([{ id: 'c1' }]);
+    updateMock.mockReturnValue(update);
+    await reapStaleDeviceCommands();
+    const whereSql = new PgDialect().sqlToQuery(update.where.mock.calls[0]![0]);
+    expect(whereSql.sql).toContain('"device_commands"."status" = $');
+    expect(whereSql.sql).not.toMatch(/status" in \(/i);
+  });
+});
+```
+
+`updateChain` helper (add beside `selectChain` if the copied header lacks it):
+
+```ts
+function updateChain(returning: unknown) {
+  const chain: Record<string, any> = {};
+  chain.set = vi.fn(() => chain);
+  chain.where = vi.fn(() => chain);
+  chain.returning = vi.fn(async () => returning);
+  return chain;
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+- [ ] **Step 3: Implement in `reapStaleDeviceCommands`**
+
+Replace the WHERE pre-filter and the per-row loop:
+
+```ts
+  const now = Date.now();
+  const nowDate = new Date(now);
+  const conservativeCutoff = new Date(now - SHORTEST_TIMEOUT_MS);
+  const whereConditions = [
+    inArray(deviceCommands.status, ['pending', 'sent']),
+    // Genuinely-due rows first (#5128): a pending row is due when its own
+    // deliver_by has passed; legacy/sent rows keep the conservative age cutoff.
+    or(
+      and(eq(deviceCommands.status, 'pending'), isNotNull(deviceCommands.deliverBy), lt(deviceCommands.deliverBy, nowDate)),
+      and(isNull(deviceCommands.deliverBy), lt(deviceCommands.createdAt, conservativeCutoff)),
+      and(eq(deviceCommands.status, 'sent'), lt(deviceCommands.createdAt, conservativeCutoff)),
+    ),
+  ];
+  // ... existing excludedTypes + self_uninstall exemption pushes unchanged ...
+
+  for (const cmd of staleCommands) {
+    const timeoutMs = getCommandTimeoutMs(cmd.type, cmd.payload as Record<string, unknown> | null);
+    let due: boolean;
+    let kind: 'expired' | 'timeout';
+    let errorMsg: string;
+    if (cmd.status === 'pending' && cmd.deliverBy) {
+      due = cmd.deliverBy.getTime() <= now;
+      kind = 'expired';
+      errorMsg = `Device did not reconnect before ${cmd.deliverBy.toISOString()}; command was never delivered`;
+    } else if (cmd.status === 'sent' && cmd.executedAt) {
+      due = now - cmd.executedAt.getTime() >= timeoutMs;
+      kind = 'timeout';
+      errorMsg = `Server-side timeout: no response from agent after ${Math.round(timeoutMs / 60000)} minutes`;
+    } else {
+      due = now - cmd.createdAt.getTime() >= timeoutMs;
+      kind = 'timeout';
+      errorMsg = `Command expired: agent never received the command (${Math.round(timeoutMs / 60000)} min timeout)`;
+    }
+    if (!due) continue;
+
+    const completedAt = new Date();
+    const result = kind === 'expired'
+      ? { status: 'expired', reason: 'not_delivered_before_deadline', error: errorMsg, timedOutBy: 'server' }
+      : { status: 'timeout', error: errorMsg, timedOutBy: 'server' };
+    // CAS on the OBSERVED state: a row observed pending but claimed between the
+    // SELECT and this UPDATE must not be failed the instant it was delivered.
+    const observedGuard = cmd.status === 'sent'
+      ? and(eq(deviceCommands.id, cmd.id), eq(deviceCommands.status, 'sent'), cmd.executedAt ? eq(deviceCommands.executedAt, cmd.executedAt) : isNull(deviceCommands.executedAt))
+      : and(eq(deviceCommands.id, cmd.id), eq(deviceCommands.status, 'pending'));
+    const updated = await db.update(deviceCommands)
+      .set({ status: 'failed', completedAt, result, ...terminalPayloadErasureSet() })
+      .where(observedGuard)
+      .returning({ id: deviceCommands.id });
+    if (updated.length === 0) continue;
+    reaped++;
+    await applyAutomationActionTerminal({ source: 'reaper', commandId: updated[0]!.id, terminalStatus: kind === 'expired' ? 'expired' : 'timed_out', error: errorMsg, completedAt });
+    // ... existing backup/restore metric calls unchanged ...
+    try {
+      await propagateTimedOutDeviceCommand({ commandId: cmd.id, payload: (cmd.payload as Record<string, unknown> | null) ?? null, errorMsg, completedAt, kind });
+    } catch (error) { /* existing handler */ }
+  }
+```
+
+Add `deliverBy` and `executedAt` to the reaper's SELECT projection if it is not `select()` (check ~296). Import `isNotNull, isNull, or` from `drizzle-orm`. If `applyAutomationActionTerminal`'s `terminalStatus` union lacks `'expired'`, add it in `services/automationActionResults.ts` (W4 relies on it) and map it to the same terminal state as `timed_out` with `reason` preserved.
+
+- [ ] **Step 4: `propagateTimedOutDeviceCommand` gets `kind`** — extend its input type with `kind: 'expired' | 'timeout'` and, for `expired`, write `errorMessage = 'Device did not reconnect before <deadline>'` and status `failed` (scripts: `script_executions.status='failed'`; software: `deployment_results.status='failed'`). Find the function with `grep -rn "export async function propagateTimedOutDeviceCommand" apps/api/src` and update its co-located test.
+
+- [ ] **Step 5: `reapStaleScriptExecutions` — stop expiring undelivered work**
+
+In the per-row loop, after computing `cmd`:
+
+```ts
+    // #5128: the delivery clock has ONE owner (reapStaleDeviceCommands). A
+    // not-yet-running execution whose command is still pending is waiting for
+    // the device; only the command reaper may expire it, and it propagates.
+    if (exec.status !== 'running' && cmd && (cmd.status === 'pending' || cmd.status === 'sent')) continue;
+```
+
+(placed before `if (now - referenceTime < timeoutMs) continue;` so `running` rows keep today's `startedAt` rule and orphan executions with no command row still time out.)
+
+- [ ] **Step 6: `reapStaleSoftwareDeploymentResults` — measure Tier 1 from claim time**
+
+Add `commandExecutedAt: deviceCommands.executedAt` to the candidate projection and replace the `delivered` branch:
+
+```ts
+    const deliveredRef = row.commandExecutedAt ?? row.dispatchedAt;   // claim time when known
+    const delivered = row.deviceCommandId === null || row.commandStatus === 'sent' || row.commandStatus === 'completed';
+    if (delivered) {
+      if (now - deliveredRef.getTime() < SOFTWARE_INSTALL_TIMEOUT_MS) continue;
+      errorMessage = 'Server-side timeout: no response from agent';
+    } else {
+      // Queued for an offline device: NOT this reaper's clock. The command
+      // reaper expires the row at deliver_by and propagates (#5128 §C).
+      continue;
+    }
+```
+
+Delete `SOFTWARE_QUEUED_EXPIRY_MS` and its import in `staleCommandReaper.test.ts`; remove the `if (commandType === CommandTypes.SOFTWARE_INSTALL) return SEVEN_DAYS;` line from `commandTimeouts.ts` so a *delivered* install times out on the agent's 55-min ceiling like any long command (add `SOFTWARE_INSTALL` to `LONG_TIMEOUT_TYPES` there if not already covered — check with `grep -n "SOFTWARE_INSTALL" apps/api/src/services/commandTimeouts.ts`). Update `commandTimeouts.test.ts` expectations.
+
+- [ ] **Step 7: Run all reaper tests — expect PASS**
+
+```bash
+cd apps/api && npx vitest run src/jobs/staleCommandReaper src/services/commandTimeouts && npx tsc --noEmit -p .
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/api/src/jobs/staleCommandReaper.ts apps/api/src/jobs/staleCommandReaper.test.ts apps/api/src/jobs/staleCommandReaper.twoClocks.test.ts apps/api/src/services/commandTimeouts.ts apps/api/src/services/commandTimeouts.test.ts apps/api/src/services/propagateTimedOutDeviceCommand*.ts
+git commit -m "fix(reaper): separate delivery deadline from execution timeout; CAS on observed state (#5128 W1)"
+```
+
+### Task 1.6: Late-binding delivery preparation (`prepareClaimedCommandsForDelivery`) + software persist-before-push
+
+**Files:**
+- Modify: `apps/api/src/services/commandDelivery.ts`; `apps/api/src/services/softwareDeployment.ts` (~113–140 dispatch, ~488–500 payload build); `apps/api/src/routes/agents/heartbeat.ts` (~350, ~771, ~1654 call sites — rename only); `apps/api/src/routes/agentWs.ts` (generic result path ~1655+ gains software reconciliation).
+- Test: `apps/api/src/services/commandDelivery.test.ts` (extend or create), `apps/api/src/services/softwareDeployment.test.ts` (extend)
+
+**Interfaces:**
+- Produces:
+  ```ts
+  // commandDelivery.ts
+  export type DeliveryRefresher = (payload: Record<string, unknown>) => Promise<Record<string, unknown>>;
+  export const deliveryRefreshers: Record<string, DeliveryRefresher>;   // keyed by command type
+  export async function prepareClaimedCommandsForDelivery(claimed: ClaimedCommand[], opts?): Promise<DeliverableCommand[]>;
+  export const decryptClaimedCommandsForDelivery = prepareClaimedCommandsForDelivery;  // alias, removed in W5
+  ```
+  `dispatchSoftwareInstallToDevice` now returns `{ transport: 'ws' | 'queued'; deviceCommandId: string }` (never null) and its payload carries `s3Key` when the installer is S3-backed.
+
+- [ ] **Step 1: Failing tests**
+
+```ts
+// apps/api/src/services/commandDelivery.test.ts — add
+it('runs the per-type refresher before decrypt so time-limited fields are fresh at delivery', async () => {
+  deliveryRefreshers['software_install'] = async (p) => ({ ...p, downloadUrl: 'https://fresh.example/installer' });
+  const out = await prepareClaimedCommandsForDelivery([
+    { id: 'c1', type: 'software_install', deviceId: 'd1', payload: { s3Key: 'k', downloadUrl: 'https://stale.example' }, executedAt: new Date() },
+  ]);
+  expect((out[0]!.payload as Record<string, unknown>).downloadUrl).toBe('https://fresh.example/installer');
+  delete deliveryRefreshers['software_install'];
+});
+it('a refresher failure releases the row instead of delivering a stale payload', async () => {
+  deliveryRefreshers['software_install'] = async () => { throw new Error('presign down'); };
+  const out = await prepareClaimedCommandsForDelivery([{ id: 'c1', type: 'software_install', deviceId: 'd1', payload: {}, executedAt: new Date('2026-09-06T00:00:00Z') }]);
+  expect(out).toEqual([]);
+  expect(releaseClaimedCommandDelivery).toHaveBeenCalledWith('c1', new Date('2026-09-06T00:00:00Z'));
+  delete deliveryRefreshers['software_install'];
+});
+```
+
+```ts
+// softwareDeployment.test.ts — add
+it('persists the device_commands row BEFORE the WS push and pushes with the row id', async () => {
+  sendCommandToAgentMock.mockReturnValue(true);
+  const out = await dispatchSoftwareInstallToDevice('dep-1', { id: DEVICE, agentId: 'a1' }, { deploymentId: 'dep-1', retryCount: 0 }, USER, 0);
+  expect(out.transport).toBe('ws');
+  expect(out.deviceCommandId).toBeTruthy();
+  expect(sendCommandToAgentMock.mock.calls[0]![1]).toMatchObject({ id: out.deviceCommandId, type: 'software_install' });
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+- [ ] **Step 3: Implement `prepareClaimedCommandsForDelivery`**
+
+```ts
+// commandDelivery.ts
+export type DeliveryRefresher = (payload: Record<string, unknown>) => Promise<Record<string, unknown>>;
+/** Per-type hooks that re-materialise time-limited payload fields at the moment
+ *  of delivery (#5128 §D). Registered by the owning feature module. */
+export const deliveryRefreshers: Record<string, DeliveryRefresher> = {};
+
+export async function prepareClaimedCommandsForDelivery(
+  claimed: ClaimedCommand[],
+  opts?: { reportedScriptSecretEnvVersion?: number },
+): Promise<DeliverableCommand[]> {
+  const refreshed: ClaimedCommand[] = [];
+  for (const cmd of claimed) {
+    const refresher = deliveryRefreshers[cmd.type];
+    if (!refresher) { refreshed.push(cmd); continue; }
+    try {
+      const payload = cmd.payload && typeof cmd.payload === 'object' && !Array.isArray(cmd.payload) ? (cmd.payload as Record<string, unknown>) : {};
+      refreshed.push({ ...cmd, payload: await refresher(payload) });
+    } catch (err) {
+      console.error('[commandDelivery] delivery refresher failed; releasing row for a later heartbeat', { commandId: cmd.id, type: cmd.type, error: err instanceof Error ? err.message : String(err) });
+      if (cmd.executedAt) await releaseClaimedCommandDelivery(cmd.id, cmd.executedAt);
+    }
+  }
+  // ...existing body of decryptClaimedCommandsForDelivery operating on `refreshed`...
+}
+export const decryptClaimedCommandsForDelivery = prepareClaimedCommandsForDelivery;
+```
+
+Also route the single-command push in `dispatchDeviceCommand` (Task 1.3) through the same refresher: call `deliveryRefreshers[type]?.(payload)` before `decryptCommandForDelivery`, releasing on failure.
+
+- [ ] **Step 4: Software — register the refresher and persist first**
+
+In `softwareDeployment.ts`, in the payload build (~488–500) add `s3Key: versionRecord.s3Key ?? undefined` next to `downloadUrl`, and register at module load:
+
+```ts
+deliveryRefreshers['software_install'] = async (payload) => {
+  const s3Key = typeof payload.s3Key === 'string' ? payload.s3Key : null;
+  if (!s3Key || !isS3Configured()) return payload;
+  return { ...payload, downloadUrl: await getPresignedUrl(s3Key, 3600) };
+};
+```
+
+Replace the body of `dispatchSoftwareInstallToDevice`:
+
+```ts
+  const res = await dispatchDeviceCommand({
+    deviceId: device.id, type: 'software_install', payload, userId: createdBy ?? undefined,
+    offlinePolicy: { kind: 'queue', deliverWithinMs: deliveryTtlMs('standard') },
+  });
+  if (!res.ok) throw new Error(`software_install dispatch refused: ${res.error}`);
+  await db.update(deploymentResults).set({ deviceCommandId: res.command.id })
+    .where(and(eq(deploymentResults.deploymentId, deploymentId), eq(deploymentResults.deviceId, device.id)));
+  return { transport: res.delivery === 'delivered' ? 'ws' : 'queued', deviceCommandId: res.command.id };
+```
+
+Keep `deploymentId` and `retryCount` in the payload (the result reconciliation keys on them). Remove the `SW_INSTALL_COMMAND_ID_REGEX` special case as the *primary* path in `agentWs.ts` (~1075): keep it for in-flight frames from before the deploy, and add to the generic UUID path — right after the `command` row is loaded and before `submitCommandResult` — the same `if (command.type === 'software_install') { applySoftwareInstallResult({ deploymentId: payload.deploymentId, ... attemptNumber: payload.retryCount }) }` block that `routes/agents/commands.ts:551–572` already has. Extract that block into `services/softwareDeployment.ts` as `reconcileSoftwareInstallResult(command, normalizedData)` and call it from both routes so the two transports cannot drift.
+
+- [ ] **Step 5: Rename call sites** — `heartbeat.ts` ×3: `decryptClaimedCommandsForDelivery` → `prepareClaimedCommandsForDelivery` (the alias keeps old imports compiling; rename anyway).
+
+- [ ] **Step 6: Run — expect PASS**
+
+```bash
+cd apps/api && npx vitest run src/services/commandDelivery src/services/softwareDeployment src/routes/agentWs src/routes/agents/commands && npx tsc --noEmit -p .
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/services/commandDelivery.ts apps/api/src/services/commandDelivery.test.ts apps/api/src/services/softwareDeployment.ts apps/api/src/services/softwareDeployment.test.ts apps/api/src/routes/agentWs.ts apps/api/src/routes/agents/commands.ts apps/api/src/routes/agents/heartbeat.ts apps/api/src/services/dispatchDeviceCommand.ts
+git commit -m "feat(commands): late-binding delivery preparation; software installs persist before push (#5128 W1)"
+```
+
+### Task 1.7: `dispatchScriptToDevice` takes `offlinePolicy`; generic device-command routes go through the seam; cancel endpoint; `status` filter
+
+**Files:**
+- Modify: `apps/api/src/services/scriptDispatch.ts` (~81 input type, ~193–218); `apps/api/src/routes/devices/commands.ts` (bulk ~150–269, single ~446–530, `set_auto_update` ~600–640, list ~858–900; add cancel route); `apps/api/src/routes/devices/schemas.ts` (if a response schema is declared).
+- Test: `apps/api/src/services/scriptDispatch.test.ts` (extend), `apps/api/src/routes/devices/commands.test.ts` (extend or create), `apps/api/src/__tests__/devices.endpoints.test.ts` (existing route-scan — will flag the new route; add it to whatever allowlist it maintains).
+
+**Interfaces:**
+- `DispatchScriptInput.offlinePolicy?: OfflinePolicy` (new); `requireOnline?: boolean` kept as a deprecated alias → `{ kind: 'reject' }` (removed in W4).
+- `DispatchScriptResult` ok-branch already has `delivered: boolean`; add `deliverBy: Date`.
+- Routes: bulk response `{ commands, failed, skipped, queuedOffline: string[] }`; single response adds `delivery` and `deliverBy`; new `POST /:id/commands/:commandId/cancel` → `200 { id, status: 'cancelled' }` | `409 { error: 'Command is not pending' }`; `GET /:id/commands?status=pending` filters.
+
+- [ ] **Step 1: Failing tests**
+
+```ts
+// scriptDispatch.test.ts — add
+it('offline device + queue policy inserts the execution + command with a deliver_by (no live re-read)', async () => { /* mirror the existing "manual dispatch queues offline devices" case; assert queueCommand was called with options.deliverBy instanceof Date and options.submittedOrgId === device.orgId */ });
+it('requireOnline:true is an alias for offlinePolicy reject', async () => { /* mirror the existing requireOnline rejection case unchanged */ });
+```
+
+```ts
+// routes/devices/commands.test.ts — add (use the file's existing app/auth harness)
+it('bulk: an offline device is queued and reported under queuedOffline, not failed', async () => { /* two devices, one offline; expect 201, body.queuedOffline = [offlineId], body.failed = [] */ });
+it('cancel: flips a pending command to cancelled and 409s when already sent', async () => { /* ... */ });
+it('list: ?status=pending returns only pending rows', async () => { /* assert eq(status,'pending') in where */ });
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+- [ ] **Step 3: `scriptDispatch.ts`**
+
+```ts
+  requireOnline?: boolean;          // deprecated alias for offlinePolicy: { kind: 'reject' } — removed in W4
+  offlinePolicy?: OfflinePolicy;
+```
+
+Replace the `if (input.requireOnline) { ... }` block:
+
+```ts
+  const offlinePolicy: OfflinePolicy = input.offlinePolicy ?? (input.requireOnline ? { kind: 'reject' } : defaultOfflinePolicy(CommandTypes.SCRIPT));
+  if (offlinePolicy.kind === 'reject') {
+    // ...existing live re-read + `device_offline` return, unchanged...
+  }
+  const deliverBy = deliverByFor(offlinePolicy);
+```
+
+and pass `{ deliverBy, submittedOrgId: device.orgId }` in the existing `queueCommand(...)` call; add `deliverBy` to the ok result.
+
+- [ ] **Step 4: Generic routes through the seam**
+
+Bulk (`/bulk/commands`): replace the try/insert block with
+
+```ts
+      const res = await dispatchDeviceCommand({ deviceId, type: data.type, payload: data.payload ?? {}, userId: auth.user.id });
+      if (!res.ok) {
+        failed.push({ deviceId, code: res.code === 'trust_denied' ? (res.error as TrustDenyCode) : 'INSERT_FAILED', message: res.error });
+        continue;
+      }
+      commandList.push(sanitizeCommandForHistory(res.command));
+      if (res.delivery === 'queued_offline') queuedOffline.push(deviceId);
+```
+
+(the seam already performs the trust check, so drop the route's own `assertDeviceExecuteAllowed`; keep the `refresh_inventory` ALREADY_PENDING dedup before the call). Return `{ commands: commandList, failed, skipped, queuedOffline }`. Single `/:id/commands` and `set_auto_update` likewise; single returns `{ ...sanitizeCommandForHistory(res.command), delivery: res.delivery, deliverBy: res.deliverBy }`.
+
+- [ ] **Step 5: Cancel route**
+
+```ts
+commandsRoutes.post(
+  '/:id/commands/:commandId/cancel',
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.DEVICES_EXECUTE.resource, PERMISSIONS.DEVICES_EXECUTE.action),
+  async (c) => {
+    const auth = c.get('auth');
+    const deviceId = c.req.param('id')!;
+    const commandId = c.req.param('commandId')!;
+    const device = await getDeviceWithOrgCheck(deviceId, auth);
+    if (!device) return c.json({ error: 'Device not found' }, 404);
+    if (!canAccessDeviceSite(device, c.get('permissions') as UserPermissions | undefined)) return c.json({ error: 'Access to this site denied' }, 403);
+    const completedAt = new Date();
+    const [row] = await db.update(deviceCommands)
+      .set({ status: 'cancelled', completedAt, result: { status: 'cancelled', reason: 'user_cancelled', cancelledBy: auth.user.id }, ...terminalPayloadErasureSet() })
+      .where(and(eq(deviceCommands.id, commandId), eq(deviceCommands.deviceId, deviceId), eq(deviceCommands.status, 'pending')))
+      .returning({ id: deviceCommands.id, type: deviceCommands.type, payload: deviceCommands.payload });
+    if (!row) return c.json({ error: 'Command is not pending' }, 409);
+    await propagateCancelledDeviceCommand({ commandId: row.id, type: row.type, payload: row.payload as Record<string, unknown> | null, completedAt });
+    return c.json({ id: row.id, status: 'cancelled' });
+  },
+);
+```
+
+`propagateCancelledDeviceCommand` lives beside `propagateTimedOutDeviceCommand` and marks the owning record: `script_executions` → `cancelled`, `deployment_results` → `cancelled` (via `deviceCommandId`), `patch_job_results` → `skipped` with `errorMessage='cancelled'` (W3 fills the patch branch; W1 ships the script + software branches and a no-op default). Note: `terminalPayloadErasureSet()` nulls the payload — capture `row.payload` in `.returning` *before* the set applies? It does not: `returning` reflects post-update values. Instead SELECT the row first (`id, type, payload, status`) and then CAS-update; pass the selected payload to the propagator.
+
+- [ ] **Step 6: List filter** — in `GET /:id/commands` read `status` from `c.req.query()`, validate against `['pending','sent','completed','failed','cancelled']`, and add `eq(deviceCommands.status, status)` to both the count and list `where` when present.
+
+- [ ] **Step 7: Cancel-on-event** — `moveOrg.ts` (~297, inside the same `tx` right after the `devices` UPDATE) and `core.ts` decommission (~1813, inside the same `tx` after the status write):
+
+```ts
+      await tx.update(deviceCommands)
+        .set({ status: 'cancelled', completedAt: new Date(), result: { status: 'cancelled', reason: 'device_moved_org' }, ...terminalPayloadErasureSet() })
+        .where(and(eq(deviceCommands.deviceId, deviceId), eq(deviceCommands.status, 'pending')));
+```
+
+(decommission uses `reason: 'device_decommissioned'` and adds `ne(deviceCommands.type, 'self_uninstall')` so the uninstall drain row survives). Add one assertion to each route's existing test file.
+
+- [ ] **Step 8: Run — expect PASS**
+
+```bash
+cd apps/api && npx vitest run src/services/scriptDispatch src/routes/devices/commands src/routes/devices/moveOrg src/routes/devices/core src/__tests__/devices.endpoints.test.ts && npx tsc --noEmit -p .
+```
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/api/src/services/scriptDispatch.ts apps/api/src/services/scriptDispatch.test.ts apps/api/src/routes/devices/commands.ts apps/api/src/routes/devices/commands.test.ts apps/api/src/routes/devices/moveOrg.ts apps/api/src/routes/devices/core.ts apps/api/src/services/propagateTimedOutDeviceCommand*.ts apps/api/src/__tests__/devices.endpoints.test.ts
+git commit -m "feat(commands): generic routes via the seam, cancel endpoint, cancel-on-move/decommission (#5128 W1)"
+```
+
+### Task 1.8: Integration test against real Postgres
+
+**Files:**
+- Create: `apps/api/src/__tests__/integration/deviceCommandOfflineQueue.integration.test.ts`
+
+Follow the harness used by `apps/api/src/__tests__/integration/scriptAdmission.integration.test.ts` (partner/org/device fixtures, `withSystemDbAccessContext`). Cases (each is its own `it`):
+
+1. `dispatchDeviceCommand` with `queue` against `status='offline'` → row `pending`, `deliver_by ≈ now + ttl`, `submitted_org_id = org`.
+2. Advance the clock past the *execution* timeout but not `deliver_by` (insert with `created_at` 2 h ago): `reapStaleDeviceCommands()` reaps 0.
+3. Insert with `deliver_by` 1 s in the past: reaper reaps 1, `result.status='expired'`, `result.reason='not_delivered_before_deadline'`; a linked `script_executions` row is `failed` with the reconnect message (propagation), and `reapStaleScriptExecutions()` on the same fixture with a *future* `deliver_by` reaps 0.
+4. `claimPendingCommandsForDevice` after flipping the device `online` returns the row and marks it `sent`; a second call returns nothing.
+5. Row with `deliver_by` in the past is **not** returned by the claim.
+6. Move the device to another org (`UPDATE devices SET org_id`) then claim → row `cancelled` with `reason='device_moved_org'`, nothing returned.
+7. Two pending rows `refresh_inventory` + `reboot`: first claim returns only `refresh_inventory`; after marking it `completed`, the next claim returns `reboot`.
+8. `dispatchDeviceCommand` with `reject` against an offline device → `device_offline`, `SELECT count(*)` unchanged.
+9. Cancel endpoint via `app.request` → 200 then 409 on repeat.
+
+- [ ] Run locally against the dev DB:
+
+```bash
+cd apps/api && npx vitest run --config vitest.integration.config.ts src/__tests__/integration/deviceCommandOfflineQueue.integration.test.ts
+```
+
+- [ ] Commit: `git commit -m "test(commands): offline queue integration coverage (#5128 W1)"`
+
+### Wave 1 verification (before opening the PR)
+
+```bash
+cd apps/api && npx tsc --noEmit -p . && npx vitest run src/services/command src/jobs/staleCommandReaper src/routes/devices src/services/scriptDispatch src/services/softwareDeployment
+cd ../.. && pnpm lint
+```
+
+PR body: `Closes #<W1 sub-issue>`; note the flag is off; list the two fixed latent defects (software WS path created no row; software result reaper measured from dispatch). Merge on green.
+
+---
+
+## Wave 2 — Scripts + generic-command UX: admission `delivery`, device-page queued list, uniform copy
+
+### Task 2.1: `ScriptTargetAdmission.delivery`
+
+**Files:** `packages/shared/src/types/scriptAdmission.ts`; `apps/api/src/services/scriptExecution.ts` (where `targets.push({ requestedDeviceId, admission: 'admitted', executionId, commandId, batchId })` is built); `apps/api/src/services/scriptExecution.admission.test.ts`; `apps/api/src/openapi.scriptAdmission.test.ts` + the OpenAPI schema it checks.
+
+- [ ] Test: an admitted target whose dispatch returned `delivered: false` carries `delivery: 'queued_offline'`; `delivered: true` → `'delivered'`.
+- [ ] Type: `delivery?: 'delivered' | 'queued_offline';` on `ScriptTargetAdmission`.
+- [ ] Impl: `delivery: dispatch.delivered ? 'delivered' : 'queued_offline'` at the push site; OpenAPI `ScriptAdmissionTarget.properties.delivery = { type: 'string', enum: ['delivered','queued_offline'] }`.
+- [ ] Commit: `feat(scripts): report delivery state per admitted target (#5128 W2)`
+
+### Task 2.2: Device page "Queued actions" section with Cancel
+
+**Files:**
+- Create: `apps/web/src/components/devices/DeviceQueuedActions.tsx`, `DeviceQueuedActions.test.tsx`
+- Modify: `apps/web/src/components/devices/DeviceDetails.tsx` (render above the activity feed for non-decommissioned devices); `apps/web/src/locales/en/devices.json` (+ every other locale file under `apps/web/src/locales/*/devices.json` gets the same keys with English fallback — the tr-TR parity test fails otherwise).
+
+**Interfaces:** `GET /devices/:id/commands?status=pending&limit=50` (W1) → `{ data: Array<{ id, type, createdAt, deliverBy, createdBy }> }`; `POST /devices/:id/commands/:commandId/cancel`.
+
+- [ ] Test (jsdom): renders one row per pending command with type label, requester, "expires {{date}}"; Cancel calls the endpoint through `runAction` and removes the row on success; hidden when the list is empty; 401 from the fetch is swallowed (auth redirect owns it).
+- [ ] Impl: `fetchWithAuth` (auto-injects orgId) for the list; `runAction` wrapper for cancel (`apps/web/src/lib/runAction.ts`); `data-testid="device-queued-actions"`, `data-testid="queued-action-cancel"`. Keys: `devices.queuedActions.title` = "Queued actions", `.expires` = "Expires {{date}}", `.cancel` = "Cancel", `.cancelled` = "Queued action cancelled", `.empty` (unused, hidden).
+- [ ] Register the new file in `apps/web/src/lib/runActionAllowlist.ts` only if it legitimately bypasses `runAction` (it should not).
+- [ ] Commit: `feat(web): device page queued-actions list with cancel (#5128 W2)`
+
+### Task 2.3: Uniform "queued — device offline" copy
+
+**Files:** `apps/web/src/components/devices/DevicesPage.tsx` (~930 bulk toast; read `queuedOffline` from the W1 response); `apps/web/src/components/devices/DeviceActions.tsx` (single-command toast reads `delivery`/`deliverBy`); `apps/web/src/components/scripts/executionStatus.ts` (`queued` label → `status.queuedOffline` = "Queued — device offline"); `apps/web/src/components/scripts/ScriptExecutionModal.tsx` (the success path reads `targets[].delivery` and toasts "Runs when the device is online — expires {{date}}" when any target is `queued_offline`); `apps/web/src/components/software/DeploymentProgress.tsx` (~94, ~511: switch the "Queued — device offline" condition to the `delivery` value if the deployment-result API exposes it; otherwise keep the `deviceCommandId` inference and note it).
+
+- [ ] Tests: one per component change — assert the exact string from the locale key.
+- [ ] Commit: `feat(web): uniform queued-offline feedback across bulk, single, script and deployment flows (#5128 W2)`
+
+### Wave 2 verification
+
+```bash
+cd apps/web && npx vitest run src/components/devices/DeviceQueuedActions src/components/devices/DevicesPage src/components/scripts src/components/software/DeploymentProgress && npx astro check
+cd ../api && npx vitest run src/services/scriptExecution src/openapi.scriptAdmission.test.ts
+```
+
+---
+
+## Wave 3 — Patches: `queued` results, non-terminal jobs, idempotent finalizer, `offlineBehavior`, supersession, suppression hold
+
+### Task 3.1: Migration + schema + validator + export policy
+
+**Files:** `apps/api/migrations/2026-10-13-100100-patch-offline-queue.sql`; `apps/api/src/db/schema/patches.ts` (`patchJobResultStatusEnum` + `patchJobs.devicesQueued`); `apps/api/src/db/schema/configurationPolicies.ts` (`configPolicyPatchSettings.offlineBehavior`); `packages/shared/src/validators/index.ts` (`patchInlineSettingsSchema` + `offlineBehavior: z.enum(['skip','queue']).default('queue')`, placed after `scheduleDayOfMonth`); `apps/api/src/services/tenantExportPolicyRegistry.ts` (`patch_jobs` entry gains `devices_queued` in `included`).
+
+```sql
+-- 2026-10-13-100100: patch installs queue for offline devices (#5128 W3).
+-- 'queued' = install_patches command persisted with a deliver_by, waiting for
+-- the device's next heartbeat. patch_jobs.devices_queued keeps the job
+-- non-terminal while any device waits. config_policy_patch_settings has no
+-- org_id/partner_id (tenancy transitive via feature_link_id) — no RLS change.
+ALTER TYPE patch_job_result_status ADD VALUE IF NOT EXISTS 'queued';
+ALTER TABLE patch_jobs ADD COLUMN IF NOT EXISTS devices_queued integer NOT NULL DEFAULT 0;
+ALTER TABLE config_policy_patch_settings ADD COLUMN IF NOT EXISTS offline_behavior varchar(20) NOT NULL DEFAULT 'queue';
+DO $$ BEGIN
+  ALTER TABLE config_policy_patch_settings ADD CONSTRAINT config_policy_patch_settings_offline_behavior_chk
+    CHECK (offline_behavior IN ('skip', 'queue'));
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+```
+
+- [ ] Tests: validator accepts/defaults `offlineBehavior`; `tenant-export-policy.integration.test.ts` green locally; `autoMigrate.test.ts`; `db:check-drift`.
+- [ ] Wire `offlineBehavior` through the config-policy patch-settings read/write path (grep `rebootAllowDeferral` in `apps/api/src/routes/configurationPolicies/` and `apps/api/src/services/featureConfigResolver.ts` and add the field beside it in every mapper).
+- [ ] Commit: `feat(patches): queued result status, devices_queued, offline_behavior (#5128 W3)`
+
+### Task 3.2: Idempotent patch-job finalizer registered as the `install_patches` result handler
+
+**Files:** Create `apps/api/src/services/patchJobFinalizer.ts` + `.test.ts`; modify `apps/api/src/services/commandResultHandlers.ts` (`install_patches: handleInstallPatchesResult`), `apps/api/src/jobs/patchJobExecutor.ts` (`recordDeviceExecution` delegates to the finalizer), `apps/api/src/services/propagateTimedOutDeviceCommand*.ts` and the cancel propagator (patch branch → finalizer).
+
+**Interfaces:**
+```ts
+export type PatchDeviceTerminal =
+  | { kind: 'result'; commandResult: unknown }
+  | { kind: 'expired'; message: string }
+  | { kind: 'cancelled'; reason: string }
+  | { kind: 'superseded'; byJobId: string };
+export async function finalizePatchJobDevice(input: { patchJobId: string; deviceId: string; commandId: string; terminal: PatchDeviceTerminal; completedAt: Date }): Promise<{ applied: boolean }>;
+export const handleInstallPatchesResult: CommandResultHandler;   // reads payload.patchJobId, delegates
+```
+Idempotency key: the per-device `patch_job_results` rows for `(jobId, deviceId)` must all be non-terminal (`pending`|`running`|`queued`) for the finalizer to apply; a second call returns `{ applied: false }` without touching counters. Counters: `queued → completed/failed` decrements `devices_queued`; `pending/running → …` decrements `devices_pending` (existing behaviour, moved here). Reboot evaluation (existing block in `recordDeviceExecution`) runs only for `kind: 'result'`. After counters, call `checkAndFinalizeJob`, which now terminalises only when `devices_pending = 0 AND devices_queued = 0`.
+
+- [ ] Tests: result twice → one counter write; expired → `failed` with the reconnect message; cancelled → `skipped`; superseded → `skipped` + `errorMessage='superseded_by_next_occurrence'`; job stays `running` while `devices_queued > 0`.
+- [ ] `install_patches` payload must carry `patchJobId` — confirm in `prepareDeviceExecution` (~1053 `queueCommandForExecution(deviceId, 'install_patches', { patchIds, patches })`) and add it.
+- [ ] Commit: `feat(patches): idempotent per-device finalizer shared by sync and deferred paths (#5128 W3)`
+
+### Task 3.3: Executor queues offline devices; completion checker honours `queued`
+
+**Files:** `apps/api/src/jobs/patchJobExecutor.ts` (`prepareDeviceExecution` ~1053–1070, `processExecuteDevice` ~758, `processCheckCompletion` ~692–723, `checkAndFinalizeJob` ~1383); `apps/api/src/jobs/patchJobExecutor.test.ts` (extend).
+
+- [ ] In `prepareDeviceExecution`, replace the `queueCommandForExecution` call with `dispatchDeviceCommand({ deviceId, type: 'install_patches', payload: { patchJobId, patchIds, patches }, previouslyRejected: true, offlinePolicy: resolvePatchOfflinePolicy(settings, nextOccurrenceAt) })` where `resolvePatchOfflinePolicy` returns `{ kind: 'reject' }` for `offlineBehavior: 'skip'` and `{ kind: 'queue', deliverWithinMs: min(deliveryTtlMs('standard'), nextOccurrenceAt - now) }` otherwise (`nextOccurrenceAt` comes from `patchJobs.targets.scheduleNextOccurrenceAt`, which Task 3.4 stamps; manual jobs have none → standard TTL). If `res.delivery === 'queued_offline'`: update the device's `patch_job_results` to `queued`, `devices_pending - 1`, `devices_queued + 1`, and return `{ queued: true }` so `processExecuteDevice` skips the poll and `recordDeviceExecution`.
+- [ ] `processCheckCompletion`: when `devicesPending === 0 && devicesQueued > 0` → leave `running`, do not force-fail; log `waiting for N queued devices`. Force-fail applies only to `devicesPending`.
+- [ ] Tests: offline device → `queued`, counters, task completes without polling; completion checker leaves the job `running`.
+- [ ] Commit: `feat(patches): queue install_patches for offline devices; job stays open while devices wait (#5128 W3)`
+
+### Task 3.4: Scheduler supersession + claim-time suppression hold
+
+**Files:** `apps/api/src/jobs/patchSchedulerWorker.ts` (`scanAndCreateJobs` ~469–640: stamp `targets.scheduleNextOccurrenceAt`; after creating a new occurrence job, cancel prior-job pending `install_patches` rows for the same devices via `finalizePatchJobDevice({ terminal: { kind: 'superseded', byJobId } })`); `apps/api/src/services/commandClaimEligibility.ts` registration in `apps/api/src/services/patchJobFinalizer.ts`:
+
+```ts
+typeHolds['install_patches'] = async (deviceId) => {
+  const m = await checkDeviceMaintenanceWindow(deviceId);
+  return m.active && m.suppressPatching;
+};
+```
+
+- [ ] `getDueOccurrenceKey` has the schedule; add `getNextOccurrenceAt(settings, timezone, now): Date` beside it (same frequency/day/time arithmetic, next strictly-after `now`), unit-tested for daily/weekly/monthly incl. month rollover.
+- [ ] Tests: supersession cancels only `pending` rows of the *previous* job for *overlapping* devices; hold returns true inside an active suppression window.
+- [ ] Commit: `feat(patches): supersede queued installs on the next occurrence; hold delivery during suppression windows (#5128 W3)`
+
+### Task 3.5: Config-policy patch settings UI radio
+
+**Files:** locate with `grep -rln "rebootAllowDeferral" apps/web/src/components` (the patch settings form for configuration policies) and add a radio group `offlineBehavior` ("Queue for offline devices — runs on the next check-in, before the next scheduled run" / "Skip offline devices") beside the schedule fields; locale keys under `policies.patch.offlineBehavior.*`; test asserts both options render and the default is `queue`.
+
+- [ ] Commit: `feat(web): patch policy offline-behaviour option (#5128 W3)`
+
+### Wave 3 verification
+
+```bash
+cd apps/api && npx tsc --noEmit -p . && npx vitest run src/jobs/patchJobExecutor src/jobs/patchSchedulerWorker src/services/patchJobFinalizer src/services/commandResultHandlers
+npx vitest run --config vitest.integration.config.ts src/__tests__/integration/tenant-export-policy.integration.test.ts src/__tests__/integration/tenantExportErasureRoundtrip.integration.test.ts
+```
+
+Add an integration case to `deviceCommandOfflineQueue.integration.test.ts`: a scheduled job with one offline device leaves it `queued` and the job `running`; posting an `install_patches` result through `app.request` on the agent result route finalises the device and completes the job.
+
+---
+
+## Wave 4 — Automations: `whenOffline`, `queued` step state, remove the `requireOnline` alias
+
+### Task 4.1: Validator + runtime
+
+**Files:** `packages/shared/src/validators/index.ts` (`run_script` and `execute_command` variants gain `whenOffline: z.enum(['queue','skip']).default('queue')`; `deploy_software` inherits software's queueing and needs no field); `apps/api/src/services/automationRuntime.ts` (~1405–1417 and ~1503–1514: replace `requireOnline: true` with `offlinePolicy: action.whenOffline === 'skip' ? { kind: 'reject' } : { kind: 'queue', deliverWithinMs: deliveryTtlMs('standard') }`, gated by `previouslyRejected` semantics — pass `offlinePolicy` only when `isOfflineQueueEnabled()`; otherwise pass `{ kind: 'reject' }`); on `dispatch.ok && !dispatch.delivered` return outcome `{ status: 'queued', message: 'Queued — device offline' }` and write the `automation_action_results` row as `queued` (`services/automationActionResults.ts` — add `'queued'` to its status union if absent; the reaper's `applyAutomationActionTerminal` with `'expired'` from W1 closes it).
+- [ ] Tests: validator default; runtime queued path writes `queued` and does not fail the run; `skip` reproduces today's failure message.
+- [ ] Remove `requireOnline` from `DispatchScriptInput` and every caller (`grep -rn requireOnline apps/api/src`).
+- [ ] Commit: `feat(automations): whenOffline action option; queued step state (#5128 W4)`
+
+### Task 4.2: Automation form control
+
+**Files:** the automation action editor (`grep -rln "runAs" apps/web/src/components/automations`), add a select "If the device is offline: Queue (default) / Skip"; locale keys `automations.actions.whenOffline.*`; test.
+- [ ] Commit: `feat(web): automation action offline behaviour (#5128 W4)`
+
+### Task 4.3: Flip the flag default
+
+- [ ] `DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED` default becomes `true` in `commandOfflinePolicy.ts` (`!== 'false'`), `.env.example` files documented, release note drafted in the PR body. Commit: `feat(commands): enable offline queueing for patches and automations by default (#5128 W4)`
+
+---
+
+## Wave 5 — AI-tool text, docs sweep, flag removal
+
+- [ ] `apps/api/src/services/aiToolsScripts.ts` and every `aiTools*.ts` with a `requireOnline`-style guard (`grep -rn "is not online" apps/api/src/services/aiTools*.ts`): the error text gains one sentence — "This tool needs a live connection; to run when the device reconnects use the Run Script / deployment tools instead." No behaviour change.
+- [ ] Docs (one PR): `apps/docs/src/content/docs/features/{patch-management,scripts,deployments,fleet-hygiene,incident-response}.mdx` — replace every offline sentence with the single promise: queued on the device's next successful heartbeat, per-class expiry (7 days standard, 24 hours inventory/power-state), cancellable from the device page; patch jobs stay open while devices wait and the next scheduled run supersedes a still-waiting install. Use the `update-breeze-docs` skill.
+- [ ] Remove the flag and `isOfflineQueueEnabled()`, the `previouslyRejected` option, and the `decryptClaimedCommandsForDelivery` alias; delete `SW_INSTALL_COMMAND_ID_REGEX` fallback if no in-flight frames can remain (one release after W1). Commit: `chore(commands): remove offline-queue flag and W1 compatibility aliases (#5128 W5)`
+
+---
+
+## Wave 6 — Principal rehydration at claim (starts only after #3985 merges)
+
+Precondition: `apps/api/src/services/recoveryAuthorizationSubject.ts` exists on `main`. Re-read it first; its exported names on the #3985 branch are `RecoveryAuthorizationSubjectRow`, `CapturedRecoveryAuthorizationSubject`, `LiveUserAuthorization`, `RecoveryAuthorizationSubjectDependencies` and the capture/verify functions around line 535.
+
+- [ ] Migration `…-device-commands-authorization-subject.sql`: `ALTER TABLE device_commands ADD COLUMN IF NOT EXISTS authorization_subject jsonb;` (system-scoped table → no export-policy entry).
+- [ ] `dispatchDeviceCommand` captures the subject for user-initiated commands (`userId` present) using the merged capture helper; `partitionClaimable` verifies it (live grant + org/site + `devices:execute` permission) and cancels with `reason: 'authorization_revoked'` on failure; rows with `authorization_subject IS NULL` (system/automation work) keep the W1 checks.
+- [ ] Integration test: revoke the requester's `devices:execute` permission after enqueue → claim cancels the row.
+- [ ] Commit: `feat(commands): rehydrate requester authorization at claim (#5128 W6)`
+
+---
+
+## Deliberately NOT in this plan
+
+Backups/restores queueing; live-session routes; wake-on-LAN; maintenance windows by device filter (#4981 first half); coalescing beyond `ALREADY_PENDING`; agent-side start deadlines; partner-configurable TTL UI; fleet-wide "Pending work" page; notifications when deferred work runs; fixing `patchRebootHandler` `if_required` ignoring suppression windows (file as its own issue when W3 starts).
+
+## Self-review notes
+
+- Spec coverage: §A→1.2/1.3; §B→1.1; §C→1.5; §D→1.3/1.6/1.7 (call-site table: patches 3.3, automations 4.1, software 1.6, generic 1.7, scripts 1.7, DR/backups/AI tools unchanged = `reject` via `previouslyRejected` or explicit policy); §E→1.4 (predicates, barrier), OD-5 not in v1; §F scripts→2.1/2.3, software→1.6/2.3, patches→3.x, automations→4.1; §G→1.4/1.7; §H→2.2/2.3; §I→2.1; §J none; OD-1→1.2; OD-2→3.3/3.4; OD-3→1.4; OD-4→1.4 + W6; OD-6 dissolved (admission types already on main); OD-7→2.3; OD-8→1.6; OD-9→3.3.
+- Names used consistently: `dispatchDeviceCommand`, `resolveOfflinePolicy`, `deliverByFor`, `deliveryTtlMs`, `partitionClaimable`, `typeHolds`, `deliveryRefreshers`, `prepareClaimedCommandsForDelivery`, `finalizePatchJobDevice`, `propagateTimedOutDeviceCommand({ kind })`, `propagateCancelledDeviceCommand`.
+- Known judgement calls left to the executor, each bounded: exact `users` status column name (1.4 step 3 note); exact export names for `decryptCommandForDelivery`/`toAgentCommandFrame` (1.3 step 4 note); location of the patch-settings web form (3.5 grep).

--- a/docs/superpowers/specs/misc/2026-09-06-offline-work-queue-design.md
+++ b/docs/superpowers/specs/misc/2026-09-06-offline-work-queue-design.md
@@ -64,7 +64,7 @@ CREATE INDEX IF NOT EXISTS idx_device_commands_deliver_by
   ON device_commands (deliver_by) WHERE status = 'pending' AND deliver_by IS NOT NULL;
 ```
 
-- `deliver_by` = the instant by which an agent must have *claimed* the row. NULL = legacy rule (§C), so the migration is a pure `ADD COLUMN`, existing pending rows behave exactly as before, and no backfill is needed. Every new enqueue sets it: `now() + deliverWithinMs` for `queue`; for `reject` (row created only when the device is online) `now() + 5 min` so a row that raced a disconnect cannot linger.
+- `deliver_by` = the instant by which an agent must have *claimed* the row. NULL = legacy rule (§C), so the migration is a pure `ADD COLUMN`, existing pending rows behave exactly as before, and no backfill is needed. A `queue` enqueue sets `now() + deliverWithinMs`. For `reject` the row is only created when the device is online and `deliver_by` stays NULL — the legacy execution clock applies, so nothing changes for callers that reject.
 - `submitted_org_id` = the device's org at enqueue, compared at claim to detect an org move (§G). It is an immutable provenance value, not a tenancy column: `device_commands` stays intentionally system-scoped (no RLS, agent path), and `ON DELETE SET NULL` keeps old-org erasure from tripping on rows for devices that moved away. Named deliberately not `org_id` so the RLS/cascade auto-discovery does not classify the table as tenant-scoped.
 - Deferred to Track B: an `authorization_subject` (the shape of `recoveryAuthorizationSubject.ts` on #3985) for full principal rehydration at claim — OD-4.
 
@@ -74,10 +74,11 @@ In `reapStaleDeviceCommands`:
 
 | Row state | Deadline | Terminal result |
 |---|---|---|
-| `pending`, `deliver_by IS NOT NULL` | `deliver_by` | `status='failed'`, `result: { status: 'expired', reason: 'not_delivered_before_deadline', timedOutBy: 'server' }` |
+| `pending`, `deliver_by IS NOT NULL` | `deliver_by` | `status='failed'`, `result: { status: 'timeout', reason: 'not_delivered_before_deadline', clock: 'delivery', timedOutBy: 'server' }` |
 | `pending`, `deliver_by IS NULL` (legacy rows) | `createdAt + getCommandTimeoutMs` (today's rule) | unchanged |
 | `sent` | `executedAt + getCommandTimeoutMs` (today's rule) | unchanged (`timeout`) |
 
+- `result.status` stays `'timeout'` on both clocks: it is the marker `commandAcceptsAgentResultCondition` keys on to let a genuinely late agent result overwrite a server-side timeout (`services/commandResultAcceptance.ts`), and a row released after a failed send can legitimately be both delivered and delivery-expired. The clock lives in `reason`/`clock`.
 - The reason is `not_delivered_before_deadline`, not "never reconnected": protocol-capability exclusions (`claimPendingCommandsForDevice` skips `peripheral_policy_sync_v2` etc. for agents that don't advertise them) can leave a row undelivered on a connected device.
 - **CAS on observed state.** The terminal UPDATE must key on the row's *observed* `(status, executedAt)`, not `status IN ('pending','sent')` as today (~311): a row observed `pending` and claimed between the SELECT and the UPDATE would otherwise be failed the instant it was delivered. Mirror the `(id, status='sent', executedAt=<claim ts>)` fence `releaseClaimedCommandDelivery` already uses.
 - The SQL pre-filter gains an OR arm on `deliver_by < now()` and keeps the `SHORTEST_TIMEOUT_MS` arm for legacy/`sent` rows, so genuinely due rows are selected before the per-run cap is applied and 7-day rows are not rescanned every 2 minutes.

--- a/docs/superpowers/specs/misc/2026-09-06-offline-work-queue-design.md
+++ b/docs/superpowers/specs/misc/2026-09-06-offline-work-queue-design.md
@@ -86,7 +86,7 @@ In `reapStaleDeviceCommands`:
 
 ### D. Single seam and call-site migration
 
-One function owns enqueue: `dispatchDeviceCommand(deviceId, type, payload, { offlinePolicy, userId, targetRole, expectedOrgId, ... })`. In order: device lookup + `expectedOrgId` check → `assertDeviceExecuteAllowed` (partner trust) → if the device is not online and the policy is `reject`, return the existing `device_offline` error → `queueCommand` with `deliver_by` + `submitted_org_id` → if the agent socket is live, the existing claim → prepare → push → release-on-failure loop. Return value gains `delivery: 'delivered' | 'queued_offline'`.
+One function owns enqueue: `dispatchDeviceCommand(input: DispatchDeviceCommandInput)`, a single options object with `{ deviceId, type, payload?, userId?, offlinePolicy?, previouslyRejected?, expectedOrgId?, preferHeartbeat? }`. There is no `targetRole`: watchdog-targeted commands stay on `executeCommand`. In order: device lookup + `expectedOrgId` check → device lifecycle → `assertDeviceExecuteAllowed` (partner trust) → if the device is not online and the policy is `reject`, return the existing `device_offline` error → `queueCommand` with `deliver_by` + `submitted_org_id` → if the agent socket is live, the existing claim → prepare → push → release-on-failure loop. Return value gains `delivery: 'delivered' | 'queued_offline' | 'queued_live'` (`queued_live` = the device is online but the push did not happen, so the next heartbeat claims it).
 
 **Late-binding payload preparation.** A single `prepareCommandForDelivery(row)` runs on *both* claim paths (WS push and heartbeat batch) and owns everything that must be fresh at delivery: the existing `decryptCommandForDelivery`, plus re-minting presigned download URLs for `software_install` from the stored `s3Key`. Payloads store stable references, never time-limited URLs. Rows whose preparation fails are released back to `pending` (existing fence) and counted.
 
@@ -136,6 +136,7 @@ Call sites and their intended disposition (the plan enumerates every caller; thi
 - **Not re-checked in v1:** full org/site/action permission rehydration of the requester, and script edit/delete (the payload is an immutable snapshot at request time; editing must never substitute code). Both become possible once Track B's authorization-subject shape lands (OD-4).
 - **Cancel-on-event (cleanup, in addition to claim checks):** device decommission (`routes/devices/core.ts` ~1813, same transaction as the status write) and org move (`routes/devices/moveOrg.ts` ~297) cancel that device's ordinary pending rows with the matching reason. Partner suspension keeps its existing socket/token handling and queued-uninstall path (`tenantLifecycle.ts`).
 - **User cancel:** `POST /devices/:id/commands/:commandId/cancel` flips `pending → cancelled` (CAS on `status='pending'`), erases the payload, and propagates to the owning record (script execution `cancelled`, patch result `skipped`, deployment result `cancelled`). Same permission as issuing the command.
+- **Claim-time cancellations propagate to the owning record inside the claim transaction, exactly like cancel-on-event.**
 
 ### H. Visibility
 

--- a/docs/superpowers/specs/misc/2026-09-06-offline-work-queue-design.md
+++ b/docs/superpowers/specs/misc/2026-09-06-offline-work-queue-design.md
@@ -1,0 +1,197 @@
+# Offline Work Queue — Design
+
+**Date:** 2026-09-06
+**Status:** Approved 2026-09-06 (Todd). All nine Open Decisions resolved per their stated recommendation; OD-4 staged as written (claim-time org/lifecycle/trust/requester checks now, full permission rehydration as W6 after Track B #3985). Quorum: Codex gpt-6 xhigh, read-only, against `02e8e5b29d`.
+**Issue:** LanternOps/breeze#5128 (predecessor #4981 second half, same reporter; #4226 item 7 raises the patch-side case).
+**Ask (Discord, MSP technician):** "Every action in Breeze should not depend on the machine being online. Software updates, patches, scripts, software deployment should not just fail when you click on them — they should switch to pending, then run once the machine is online."
+
+## Problem
+
+Whether an action against an offline device *queues and waits* or *fails fast* depends today on which of six code paths handles the route, not on any product decision:
+
+| # | Path | Offline behaviour today | Used by |
+|---|---|---|---|
+| 1 | `queueCommandForExecution` / `executeCommand` (`apps/api/src/services/commandQueue.ts` ~841, ~1113) | Hard reject: `Device is ${status}, cannot execute command` | Patch scan/rollback/install (`patchJobExecutor.ts` → `markDeviceSkipped(...'device_offline')`, counted toward `devicesCompleted`), backups (409), fleet findings, vuln remediation, DR, ~15 AI tools |
+| 2 | `dispatchScriptToDevice` (`services/scriptDispatch.ts` ~193) | `requireOnline` flag. Manual Run Script passes `false` ⇒ queues; UI copy says "the run will wait until it reconnects". Automations pass `true` ⇒ step fails | Scripts, automations `run_script` / `execute_command` |
+| 3 | `dispatchSoftwareInstallToDevice` (`services/softwareDeployment.ts` ~113) | WS push first (**no `device_commands` row when the push succeeds**), fallback `queueCommand`; UI "Queued — device offline"; 7-day expiry | Software deployments (manual + automation `deploy_software`) |
+| 4 | `routes/devices/commands.ts` (bulk, single, `set_auto_update`) | Raw `db.insert(deviceCommands)`, bypasses every helper; only `decommissioned` is rejected; queues with the 30-min reaper default | Reboot, shutdown, lock, refresh inventory, etc. |
+| 5 | Live-session routes (terminal, remote desktop, tunnels, file browser, system tools, boot metrics) | `Device is not online` 400/503 | Correct — these need a live socket |
+| 6 | Wake-on-LAN | Separate relay path | n/a |
+
+Further defects make even the "queues" paths unreliable:
+
+- **The reaper conflates two clocks.** `reapStaleDeviceCommands` (`apps/api/src/jobs/staleCommandReaper.ts`, every 2 min) judges a `pending` row by `createdAt + getCommandTimeoutMs(type, payload)` — the *execution* timeout reused as the *delivery* deadline. A script with the default 300 s timeout queued for an offline laptop is reaped after ~10 min as "Command expired: agent never received the command". Only `software_install` gets `SEVEN_DAYS` (`commandTimeouts.ts`), a per-type special case. So path 2 promises "will wait until it reconnects" and then silently fails.
+- **The per-feature reapers have the same defect independently.** The `script_executions` reaper (`staleCommandReaper.ts` ~418) expires a not-yet-running execution from `createdAt` using the execution timeout, so even a surviving command row would have its execution row failed under it. The software `deployment_results` reaper (~990) measures its 55-min "delivered but silent" tier from the *deployment's* `dispatchedAt`, so an install delivered three days after dispatch is timed out on the reaper's next pass.
+- **Payloads are built for immediate delivery.** Uploaded installers are handed to the agent as a one-hour presigned URL (`softwareDeployment.ts` ~494); a `software_install` claimed six hours later downloads nothing.
+- **Docs contradict each other.** `features/patch-management.mdx` and `features/scripts.mdx` promise waiting; `features/deployments.mdx` and `features/fleet-hygiene.mdx` promise "offline devices are skipped, not retried". `apps/web/src/components/devices/bulkActionGating.ts` records "gate on online" as an anti-pattern fixed three times (#2078, #2426, #2465).
+
+What already works, and this design leans on: delivery to a reconnecting agent is **pull-based and proven**. Every HTTP heartbeat calls `claimPendingCommandsForDevice` (`services/commandDispatch.ts`), which selects `status='pending'` rows `FOR UPDATE SKIP LOCKED` (10 per heartbeat, `createdAt` order) and flips them to `sent`. The Go agent heartbeats on startup (jittered, unless restarting after self-update) and every `HeartbeatIntervalSeconds` (default 60 s), and dedups on command UUID (`markCommandSeen`). WS `onOpen` deliberately does *not* drain (#2407). Nothing agent-side needs to change.
+
+## Users & scope
+
+- **Who:** partner (MSP) technicians and org admins issuing device-targeted, fire-and-forget work. Not a config/policy table — queued work is per device, so the partner-wide-first contract does not apply to the queue itself. Any *defaults* that become configurable (patch offline behaviour) live inside existing config records (`patch_policies.schedule`, automation action config) and inherit their ownership model.
+- **In scope:** scripts, patch installs, software deployments, generic device commands (reboot/shutdown/lock/inventory/etc.), automation actions that target devices, and the AI tools that wrap them.
+- **Not in scope (v1):** backups/restores, live sessions, wake-on-LAN, the maintenance-window-by-device-filter half of #4981, agent changes. See "Out of scope".
+
+## Approaches considered
+
+- **A (chosen, both advisors): deferred delivery as a first-class property of every `device_commands` row**, delivered by the existing heartbeat claim. One nullable deadline column, one enqueue seam with an explicit policy, a reaper that separates the delivery clock from the execution clock, and claim-time eligibility checks.
+- **B: a new org-scoped `device_work_queue` intent table (RLS shape 1)** with a drainer that materialises `device_commands` on reconnect. Pick B only if an intent must survive multiple command attempts, approvals, dependencies, or heavy materialisation at execution time — none of which offline waiting needs. It would add a second queue, two-phase state, an idempotent drainer, and four registration lists for no user-visible gain.
+- **C: per-feature scheduler ticks** (copy `softwareDeploymentScheduler` for scripts and patches). Rejected — this is exactly the sprawl that produced six behaviours.
+
+## Proposed design
+
+### A. Contract: every device command carries an explicit offline policy
+
+```ts
+type OfflinePolicy =
+  | { kind: 'reject' }                                  // needs a live socket now
+  | { kind: 'queue'; deliverWithinMs: number };         // wait for the device, up to a deadline
+```
+
+- Replaces the `requireOnline` boolean on `dispatchScriptToDevice`, the inline `device.status !== 'online'` checks in `queueCommandForExecution` / `executeCommand`, the WS-first-no-row branch in `dispatchSoftwareInstallToDevice`, and the three raw inserts in `routes/devices/commands.ts`. After this change there is **one** seam through which a device command is enqueued, it always persists the row **before** either transport, and it always states its offline policy.
+- A **per-command-type registry** (`services/commandOfflinePolicy.ts`, beside `commandTimeouts.ts`) is the source of defaults and is **fail-closed**: every `CommandTypes` value must appear with a policy and a TTL class; an unregistered type throws at enqueue (and a unit test asserts full coverage of `CommandTypes`). Live/interactive types (terminal, desktop, tunnel, file browser, process/service/registry/event-log reads, screenshot, computer action, boot metrics) → `reject`; deferred-capable types → `queue` with a TTL class (OD-1). Callers may override in either direction (an AI tool that promised a synchronous answer passes `reject`; a background remediation passes a longer deadline).
+- `reject` keeps today's error text and codes so Track B's `excluded / device_offline` admission mapping (§I) is untouched for callers that stay `reject`.
+- `waitForCommandResult` (`commandQueue.ts` ~758) terminalises the row when the caller stops waiting; it is **never** combined with `queue`. Deferred callers return `accepted/queued` immediately.
+
+### B. Schema: additive columns on `device_commands`
+
+```sql
+ALTER TABLE device_commands
+  ADD COLUMN IF NOT EXISTS deliver_by        timestamptz,
+  ADD COLUMN IF NOT EXISTS submitted_org_id  uuid REFERENCES organizations(id) ON DELETE SET NULL;
+CREATE INDEX IF NOT EXISTS idx_device_commands_deliver_by
+  ON device_commands (deliver_by) WHERE status = 'pending' AND deliver_by IS NOT NULL;
+```
+
+- `deliver_by` = the instant by which an agent must have *claimed* the row. NULL = legacy rule (§C), so the migration is a pure `ADD COLUMN`, existing pending rows behave exactly as before, and no backfill is needed. Every new enqueue sets it: `now() + deliverWithinMs` for `queue`; for `reject` (row created only when the device is online) `now() + 5 min` so a row that raced a disconnect cannot linger.
+- `submitted_org_id` = the device's org at enqueue, compared at claim to detect an org move (§G). It is an immutable provenance value, not a tenancy column: `device_commands` stays intentionally system-scoped (no RLS, agent path), and `ON DELETE SET NULL` keeps old-org erasure from tripping on rows for devices that moved away. Named deliberately not `org_id` so the RLS/cascade auto-discovery does not classify the table as tenant-scoped.
+- Deferred to Track B: an `authorization_subject` (the shape of `recoveryAuthorizationSubject.ts` on #3985) for full principal rehydration at claim — OD-4.
+
+### C. Reaper: split the delivery clock from the execution clock
+
+In `reapStaleDeviceCommands`:
+
+| Row state | Deadline | Terminal result |
+|---|---|---|
+| `pending`, `deliver_by IS NOT NULL` | `deliver_by` | `status='failed'`, `result: { status: 'expired', reason: 'not_delivered_before_deadline', timedOutBy: 'server' }` |
+| `pending`, `deliver_by IS NULL` (legacy rows) | `createdAt + getCommandTimeoutMs` (today's rule) | unchanged |
+| `sent` | `executedAt + getCommandTimeoutMs` (today's rule) | unchanged (`timeout`) |
+
+- The reason is `not_delivered_before_deadline`, not "never reconnected": protocol-capability exclusions (`claimPendingCommandsForDevice` skips `peripheral_policy_sync_v2` etc. for agents that don't advertise them) can leave a row undelivered on a connected device.
+- **CAS on observed state.** The terminal UPDATE must key on the row's *observed* `(status, executedAt)`, not `status IN ('pending','sent')` as today (~311): a row observed `pending` and claimed between the SELECT and the UPDATE would otherwise be failed the instant it was delivered. Mirror the `(id, status='sent', executedAt=<claim ts>)` fence `releaseClaimedCommandDelivery` already uses.
+- The SQL pre-filter gains an OR arm on `deliver_by < now()` and keeps the `SHORTEST_TIMEOUT_MS` arm for legacy/`sent` rows, so genuinely due rows are selected before the per-run cap is applied and 7-day rows are not rescanned every 2 minutes.
+- **Single owner of the delivery clock.** The per-feature reapers stop independently expiring *undelivered* work: the `script_executions` reaper only expires `running` rows (from `startedAt`); the software `deployment_results` reaper's "delivered but silent" tier measures from the command's `executedAt` (claim time), not the deployment's `dispatchedAt`; both learn about delivery expiry only through `propagateTimedOutDeviceCommand`, which maps `expired` to "device did not reconnect before <deadline>" on the owning row. `SOFTWARE_QUEUED_EXPIRY_MS` and the `software_install = SEVEN_DAYS` special case are removed in favour of `deliver_by`.
+- The self_uninstall drain exemptions are untouched (they carry their own deadline column and predicate).
+
+### D. Single seam and call-site migration
+
+One function owns enqueue: `dispatchDeviceCommand(deviceId, type, payload, { offlinePolicy, userId, targetRole, expectedOrgId, ... })`. In order: device lookup + `expectedOrgId` check → `assertDeviceExecuteAllowed` (partner trust) → if the device is not online and the policy is `reject`, return the existing `device_offline` error → `queueCommand` with `deliver_by` + `submitted_org_id` → if the agent socket is live, the existing claim → prepare → push → release-on-failure loop. Return value gains `delivery: 'delivered' | 'queued_offline'`.
+
+**Late-binding payload preparation.** A single `prepareCommandForDelivery(row)` runs on *both* claim paths (WS push and heartbeat batch) and owns everything that must be fresh at delivery: the existing `decryptCommandForDelivery`, plus re-minting presigned download URLs for `software_install` from the stored `s3Key`. Payloads store stable references, never time-limited URLs. Rows whose preparation fails are released back to `pending` (existing fence) and counted.
+
+Call sites and their intended disposition (the plan enumerates every caller; this is the contract):
+
+| Call site | Policy | Notes |
+|---|---|---|
+| Manual Run Script (`routes/scripts.ts` → `dispatchScriptToDevice`) | `queue`, scripts TTL | Already queues; now survives and reports `queued_offline` |
+| Automations `run_script` / `execute_command` (`automationRuntime.ts`) | per-action `whenOffline: 'queue' \| 'skip'`, default `queue` | Step status `queued`; terminal via `applyAutomationActionTerminal` |
+| Software install (`softwareDeployment.ts`) | `queue`, software TTL | Row persisted before the WS push; URL re-minted at delivery |
+| Patch install (`patchJobExecutor.ts`) | `queue`, TTL per §F | Stops skipping offline devices |
+| Patch scan / rollback (`routes/patches/operations.ts`) | `queue`, standard TTL (7 d) | Reported as `queuedOffline` in the response |
+| Bulk + single generic commands (`routes/devices/commands.ts`) | registry default; power-state types per OD-3 | Existing `ALREADY_PENDING` dedup kept and made atomic inside the seam; response adds `queuedOffline` |
+| Vuln remediation, fleet-findings dispatch, patch reboot handler, sensitive-data jobs | `queue`, standard TTL (7 d) | Background work; nothing is waiting on it |
+| DR execution (`drExecutionService.ts`) | `reject` | Time-critical, own orchestration |
+| Backups / restores / verification | `reject` (unchanged) | See "Out of scope" |
+| AI tools that `waitForCommandResult` (`aiTools*.ts`) | `reject` (unchanged) | They promise a synchronous answer; tool text points at the async path |
+| AI tools that create deployments / patch jobs | follow the underlying feature | e.g. `deploy_software` queues |
+| Live-session routes | `reject` (unchanged) | Never pass through the seam's queue arm |
+
+### E. Delivery on reconnect
+
+- **v1 = heartbeat claim, unchanged transport.** The promise to users is "on the device's next successful heartbeat" (startup is jittered and the interval is configurable), not a fixed number of seconds. No new drainer, no event subscription, no agent change.
+- **Claim predicates** (shared by `claimPendingCommandForDelivery` and `claimPendingCommandsForDevice`, evaluated atomically inside the claim transaction):
+  1. `deliver_by IS NULL OR deliver_by > now()` — never deliver a row the reaper is about to expire.
+  2. Eligibility (§G) — org unchanged, device lifecycle, tenant/partner eligibility, requesting user active.
+  3. `install_patches` rows are held while the device is inside an active `suppressPatching` maintenance window (§F).
+  4. **Power-state barrier:** `reboot` / `shutdown` rows are claimed only when the device has no other row in `sent`, and are claimed alone (batch of one). The agent runs non-interactive commands concurrently (`heartbeat.go` worker pool; `client.go` per-command goroutines), so FIFO order alone cannot stop a queued reboot from landing mid-script. The barrier cannot fence a live WS-pushed command that arrives in the same second; that residual is accepted and documented (OD-3).
+- **Optional follow-up (OD-5):** on WS `onOpen`, after `updateDeviceStatus(...'online')`, run the *per-command* claim → prepare → push → release loop over claimable pending rows. This is the push path every shipped agent already handles; the #2407 failure was embedding a batch in the welcome frame, which no agent parsed.
+
+### F. Higher-level records per work type
+
+- **Scripts** — `script_executions.status` already has `queued`. Manual runs whose command was `queued_offline` sit in `queued`; delivery expiry maps to `failed` with `errorMessage = 'Device did not reconnect before <deadline>'`. The existing UI copy becomes true.
+- **Software deployments** — `deployment_results` keeps its `pending` + `deviceCommandId` model, now always populated (row persisted before the push). The "Queued — device offline" chip switches to the seam's `delivery` value.
+- **Patches** — today's flow is fully synchronous: `processExecuteDevice` polls up to 30 min (`pollForPatchCommandResult`) and then `recordDeviceExecution`; `routes/agents/patches.ts` handles *inventory*, not install results; and the job completion checker forcibly fails whatever is still pending at timeout (~714). Deferred installs therefore need:
+  1. `patch_job_result_status` gains `queued`; `patch_jobs` gains `devices_queued`. An offline device's BullMQ task enqueues `install_patches` with `deliver_by`, marks the result `queued`, decrements `devicesPending`, increments `devicesQueued`, and **completes the task** — no multi-day poll.
+  2. **One idempotent finalizer** (`services/patchJobFinalizer.ts`) keyed on `(patchJobId, deviceId, commandId)` handles every terminal path for a queued device — agent result (via the command-result handler chain), delivery expiry, cancel, supersession — recording the result, adjusting counters, and running the existing reboot evaluation. `recordDeviceExecution` is refactored to call it so the synchronous path and the deferred path share one writer.
+  3. **Job status stays non-terminal while `devicesQueued > 0`** (UI: "Running — N devices waiting to reconnect"); the completion checker treats `queued` as neither pending nor failed and only terminalises when both counters are zero. Unfinished patching is never reported as completed (OD-9 covers whether a distinct job status is warranted).
+  4. Scheduling semantics: Breeze maintenance windows are **suppression** windows (`checkDeviceMaintenanceWindow(...).suppressPatching`, checked per device at dispatch in `patchSchedulerWorker.ts` ~596); run *time* comes from the policy schedule occurrence. So: a new `offline_behavior` column on `config_policy_patch_settings` — the table that actually holds the patch schedule (`scheduleFrequency`/`scheduleTime`/…; `patch_policies` is the partner ring table and has no schedule) — exposed as `offlineBehavior` in `patchInlineSettingsSchema` (`'skip'` = status quo, `'queue'` = default); TTL for a scheduled job = `min(patch TTL, next schedule occurrence)`; when the next occurrence creates a job for the same device, any still-pending `install_patches` row from the previous job is cancelled `superseded_by_next_occurrence` and its result marked `skipped`, so a device that reconnects at the next occurrence installs once from the fresh approved set; and delivery is held while a `suppressPatching` window is active (§E predicate 3). Manual "install now" uses the patch TTL.
+  5. `deliver_by` bounds *dispatch*, not start or finish — the agent may hold a command in its local pool. Strict "must finish inside the window" semantics would need an agent-enforced start deadline and are out of scope. Related existing gap, filed separately: `patchRebootHandler.ts` `if_required` reboots do not consult the maintenance window (~295).
+- **Automations** — action config gains `whenOffline` (default `queue`). A queued action's `automation_action_results` row (Track B) sits in `queued`; the run is not failed by it. Reaper expiry → `timed_out` with the reconnect reason. Explicit organisational automations carry organisational authority; a human's deferred command does not silently become system work (OD-4).
+- **Generic commands** — no higher-level record; visibility comes from §H.
+
+### G. Eligibility at claim, cancellation, invalidation
+
+- **Eligibility service** (`services/commandClaimEligibility.ts`), one function beneath both claim paths, evaluated inside the claim transaction. v1 checks: (1) `deliver_by` (above); (2) `submitted_org_id = devices.org_id` — else cancel `device_moved_org`; (3) device lifecycle not `decommissioned`/`quarantined` — else cancel `device_lifecycle`, preserving the uninstall-drain type allowlist path; (4) tenant eligibility + partner trust via the existing `assertDeviceExecuteAllowed` — else cancel `trust_denied`; (5) requesting user (`created_by`) still active when present — else cancel `requester_inactive`. Failing rows are terminalised in the same transaction (`cancelled`, payload erased via `terminalPayloadErasureSet()`), never delivered. Ownership changes and claims serialise through the device row lock the claim already takes (`FOR UPDATE`), so an org move committed mid-claim is seen by the next claim, not this one.
+- **Not re-checked in v1:** full org/site/action permission rehydration of the requester, and script edit/delete (the payload is an immutable snapshot at request time; editing must never substitute code). Both become possible once Track B's authorization-subject shape lands (OD-4).
+- **Cancel-on-event (cleanup, in addition to claim checks):** device decommission (`routes/devices/core.ts` ~1813, same transaction as the status write) and org move (`routes/devices/moveOrg.ts` ~297) cancel that device's ordinary pending rows with the matching reason. Partner suspension keeps its existing socket/token handling and queued-uninstall path (`tenantLifecycle.ts`).
+- **User cancel:** `POST /devices/:id/commands/:commandId/cancel` flips `pending → cancelled` (CAS on `status='pending'`), erases the payload, and propagates to the owning record (script execution `cancelled`, patch result `skipped`, deployment result `cancelled`). Same permission as issuing the command.
+
+### H. Visibility
+
+- **Click time:** the action's existing confirmation/toast surface says "Runs when the device is online — expires <date>" (some generic commands already toast "queued" for offline devices, `DevicesPage.tsx` ~930 / #2630; this makes the copy uniform and adds the expiry). No new modal (OD-7).
+- **Device page → "Queued actions" section** (new): type, requested by, requested at, expires at, Cancel. Reads the device's `pending` rows behind the existing device-access check. Hidden when empty.
+- **Status chips:** script executions, patch job device list, deployment progress, automation run steps render `queued` as "Queued — device offline"; running patch jobs show "N waiting to reconnect".
+- **Bulk responses** add `queuedOffline: string[]` beside `succeeded`/`failed`/`skipped`; the bulk bar reports "N sent, M queued for offline devices".
+- **Fleet-wide "Pending work" page:** v2.
+
+### I. Track B interplay (#3985, draft, owned by another agent)
+
+**Status check during planning (2026-09-06, main `02e8e5b29d`):** the script-admission contract (`packages/shared/src/types/scriptAdmission.ts`, `executeScriptOnDevices` returning `admission`) and `automation_action_results` + `applyAutomationActionTerminal` are **already on main**. Only the recovery-authorization-subject shape (W6) still lives on the #3985 branch. OD-6's sequencing constraint therefore applies to W6 alone; W1–W5 have no dependency on #3985.
+
+- `ScriptTargetAdmission` maps `device_offline → excluded`; that remains correct for `reject` callers. For `queue` callers the target is `admitted` and gains `delivery: 'delivered' | 'queued_offline'` (optional, additive). `admitted` continues to mean "accepted for delivery", never "executed".
+- Track B's `applyAutomationActionTerminal` / `automation_action_results` are the terminal sink for §F automations; its `recoveryAuthorizationSubject` shape is the intended carrier for OD-4's full rehydration.
+- Sequencing (OD-6): W1 (schema, reaper, seam, registry, generic commands, eligibility) touches none of Track B's files except `scriptDispatch.ts`'s `requireOnline` parameter and can land first behind the flag; the scripts/automations UX waves land after #3985 or coordinate with its owner.
+
+### J. Agent
+
+No change. Delivery, dedup (`markCommandSeen`), and result submission are unchanged. A queued command delivered days later is indistinguishable to the agent from one delivered immediately; `prepareCommandForDelivery` guarantees its payload is as fresh as an immediate one.
+
+## Tenancy & data model impact
+
+- `device_commands`: add `deliver_by`, `submitted_org_id` (FK, `ON DELETE SET NULL`), one partial index. Table stays intentionally system-scoped (CLAUDE.md "Intentionally system-scoped"): no RLS policy, no `CORE_ORG_CASCADE_DELETE_ORDER` entry, no export-policy entry. Already in `CORE_DEVICE_CASCADE_DELETE_TABLES`. The RLS coverage test auto-discovers `org_id` columns only; `submitted_org_id` is provenance and must be documented as such in the migration header so a future reader does not "fix" it into a tenancy column.
+- `patch_job_result_status` enum: `ADD VALUE IF NOT EXISTS 'queued'`. `patch_jobs.devices_queued integer NOT NULL DEFAULT 0`: `patch_jobs` is an org-cascade table, so the new column needs a `CORE_TENANT_EXPORT_POLICY` classification (`included`).
+- `config_policy_patch_settings.offline_behavior` (varchar + CHECK, default `queue`): the table has no `org_id`/`partner_id` — tenancy is transitive via `feature_link_id` → `config_policy_feature_links` → `configuration_policies` (dual-axis) — so no RLS change, no cascade entry, no export-policy entry; same shape as the reboot-deferral columns (#3207). `patchInlineSettingsSchema` gains `offlineBehavior` with its default. (Corrected 2026-09-06 during planning: an earlier draft placed this in `patch_policies.schedule`, which does not exist.)
+- Automations `whenOffline`: inside the existing action config jsonb (`excludedOpen`); shared validator gains the field with default.
+- Migration naming: must sort **after** `2026-10-12-100000-config-policy-inheritance.sql` (the current ceiling is five weeks ahead of real time); one migration per wave, idempotent, no inner transaction. No backfill; no row-count cleanup statements.
+
+## Out of scope
+
+- Backups, restores, verification: stay hard-gated in v1 (own scheduler and per-device execution slot from #4923). Revisit with production history.
+- Live-session routes and wake-on-LAN: correct as they are.
+- Maintenance windows by device filter and richer recurrence (#4981 first half): separate spec.
+- Coalescing beyond the existing `ALREADY_PENDING` dedup; general execution ordering beyond the power-state barrier (OD-3).
+- Agent-side start deadlines / strict in-window execution; any agent change.
+- Partner-configurable TTLs (OD-1), fleet-wide "Pending work" page, notifications when deferred work finally runs.
+- Fixing `if_required` reboots ignoring maintenance windows (filed as its own issue).
+
+## Open Decisions (resolved 2026-09-06 — the bolded recommendation in each is the decision)
+
+1. **TTL classes.** (a) one 7-day constant; (b) per-class constants, env-tunable: scripts and software 7 d, patch installs 7 d capped by next occurrence, inventory/config syncs 24 h, power-state 24 h, `reject`-raced rows 5 min; (c) partner-configurable. **Recommend (b)** (Codex; Fable initially preferred (a) — conceded that a 7-day `refresh_inventory` or reboot has no user value). (c) later, once (b) has data.
+2. **Scheduled patch installs for offline devices.** (a) `offlineBehavior: 'queue'` default; TTL = min(patch TTL, next occurrence); next occurrence supersedes; delivery held during `suppressPatching` windows; (b) flat TTL, no supersession — can double-install on a device that reconnects at the next occurrence; (c) keep skipping. **Recommend (a)**.
+3. **Disruptive-command conflicts on reconnect.** (a) power-state barrier at claim (§E.4) + 24 h TTL, accept the live-WS residual; (b) require reboot/shutdown to go through explicit scheduled-restart flows only (no queueing); (c) nothing in v1. **Recommend (a)** (both advisors reject (c)); (b) if the residual is judged unacceptable.
+4. **Re-authorisation at claim — the one quorum split.** Fable: (a) v1 = org unchanged + lifecycle + partner trust + requester active, cancel-on-event as cleanup, snapshot payload. Codex: (b) additionally rehydrate the requester's current org/site/action permissions and resource permission at claim, carried by a Track B-style authorization subject; historical authorization should not substitute for current permission. **Recommend (a) now, (b) as a named W6 once #3985 lands** — (b)'s carrier does not exist on main yet, and (a) closes every drift class that can be checked without it. Todd to confirm this staging is acceptable for an RMM that executes code on customer machines.
+5. **WS-open push drain.** (a) not in v1 — next heartbeat is fine; (b) include the per-command push loop in W1. **Recommend (a)**.
+6. **Sequencing against Track B (#3985).** (a) W1 first behind a flag, UX waves after Track B merges; (b) wait entirely; (c) proceed and let Track B rebase. **Recommend (a)**. *Resolved differently by the facts:* the admission and automation-result pieces are already on main (§I), so W1–W5 proceed without waiting; only W6 waits for #3985.
+7. **Click-time affordance.** (a) uniform copy in existing toasts/confirmations + chip + cancel; (b) a dedicated confirm modal per action. **Recommend (a)** (both advisors).
+8. **Software payloads with time-limited URLs.** (a) late-binding `prepareCommandForDelivery` re-mints URLs at claim (§D); (b) store long-lived URLs. **Recommend (a)**; (b) widens the exposure window of every installer object.
+9. **Patch job status while devices wait.** (a) keep `running` + `devicesQueued` counter and UI copy; (b) add a `waiting_for_devices` job status. **Recommend (a)** for v1 — no enum change, and the counter already tells the story; (b) if reporting needs the distinction.
+
+## Test & rollout notes
+
+- **Unit:** reaper matrix (pending+deliver_by, pending legacy, sent; CAS on observed state); registry full-coverage test over `CommandTypes`; each migrated call site asserts the policy it passes; eligibility service per failure class; power-state barrier; `prepareCommandForDelivery` URL re-mint; bulk response shape; cancel CAS; patch finalizer idempotency (same terminal twice → one write).
+- **Integration (real Postgres):** a `queue` row survives past its execution timeout and expires exactly at `deliver_by` with `expired/not_delivered_before_deadline`, and the linked `script_executions` row is failed only by propagation; a heartbeat after simulated offline claims and delivers; a `reject` enqueue against an offline device creates no row; org move, decommission, disabled requester each cancel at claim and via event; reboot is not claimed while a script is `sent`; patch executor leaves an offline device `queued`, the job stays non-terminal, and the finalizer completes it from a late result and from expiry; `install_patches` is not claimed inside a `suppressPatching` window; next occurrence supersedes; enum add is idempotent.
+- **Contract suites:** `rls-coverage` (unchanged allowlists, run anyway), `tenantCascade` (unchanged), `tenant-export-policy` + roundtrip (new `patch_jobs` column), `autoMigrate` naming, `migrationRlsScope` (no DML, should be a no-op).
+- **Feature flag:** `DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED` gates the `queue` arm for callers that used to `reject` (patches, automations, scan/rollback); scripts and software keep queueing regardless. Defaults on once W3/W4 ship; removed the release after.
+- **Docs sweep (same PR as each wave):** the five `features/*.mdx` pages must say one thing; release notes call out that patch jobs no longer skip offline devices and that jobs stay open while devices wait.
+- **Waves for `writing-plans`:** W1 schema + reaper + seam + registry + eligibility + `prepareCommandForDelivery` + generic-command route + cancel endpoint; W2 scripts UX (chip, device-page queued list, toast, admission `delivery` field); W3 patches (enum, counter, finalizer, executor, `offlineBehavior`, UI); W4 automations (`whenOffline`, step status); W5 AI-tool text, docs, flag removal; W6 (post Track B) authorization-subject rehydration.


### PR DESCRIPTION
Closes #5132

Wave 1 of the offline work queue (feature #5131, request #5128). Deferred delivery becomes a first-class property of `device_commands`: one deadline column, one enqueue seam with an explicit offline policy, a reaper that separates the *delivery* clock from the *execution* clock, and claim-time eligibility re-checks. **No agent change** — delivery still rides the agent's existing heartbeat claim.

The spec and plan land with this PR (they lived on the `offline-work-queue` branch until now).

## Flag state: OFF

`DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED` defaults to `false`. It gates **only** the callers that hard-rejected offline devices before #5128 (everything reaching `queueCommandForExecution`: patch executor, automations, scan/rollback, AI tools). Scripts, software installs and the generic device-command routes already queued for offline devices and are **not** gated — they simply gain a real deadline. So with the flag off, the user-visible behaviour change in this PR is: *queued work stops being reaped ten minutes later*.

Flipped to `true` in W4 (Task 4.3), removed in W5.

## The two latent defects this fixes

1. **A WS-dispatched `software_install` created no `device_commands` row at all.** `dispatchSoftwareInstallToDevice` pushed over the socket first and returned `{ transport: 'ws', deviceCommandId: null }` on success. With no row, a push the agent never acted on was invisible to the reaper, to the device's queued list and to cancel — and `deployment_results.device_command_id` stayed NULL, so the result reaper could not tell "delivered" from "never sent". The row is now persisted **before** either transport, by the one seam, and the push carries that row's UUID.

2. **The software result reaper measured its "delivered but silent" tier from the deployment's `dispatched_at`.** An install delivered three days after dispatch (device was offline in between) was timed out on the reaper's very next pass. It now measures from the command's `executed_at` — the instant the agent actually claimed it — and no longer touches undelivered rows at all.

## What changed

**Schema + migration**
- `apps/api/migrations/2026-10-13-100000-device-commands-deliver-by.sql` — `deliver_by timestamptz`, `submitted_org_id uuid REFERENCES organizations(id) ON DELETE SET NULL`, one partial index. DDL only (no `breeze.scope` needed), idempotent, no inner transaction.
- `db/schema/devices.ts` — the two columns, with the "provenance, not tenancy" rationale inline.
- `db/schema/deviceCommands.columns.test.ts` *(new)* — pins the shape, and asserts the table still has **no** `org_id` column.

`device_commands` stays intentionally system-scoped: no RLS policy, no `CORE_ORG_CASCADE_DELETE_ORDER` entry, no `CORE_TENANT_EXPORT_POLICY` entry. `submitted_org_id` is deliberately not named `org_id` so the contract tests' auto-discovery does not reclassify the table. Verified — see "Contract suites" below.

**New modules**
- `services/commandOfflinePolicy.ts` (+ test) — the fail-closed per-type registry. TTL classes: standard 168 h, short 24 h, power_state 24 h, live = a 5-minute race grace; all env-tunable. An unregistered type throws before any DB access.
- `services/dispatchDeviceCommand.ts` (+ test) — the single enqueue seam. Order: resolve policy → device lookup → `expectedOrgId` → lifecycle → partner trust → reject-or-queue → **persist** → claim/refresh/push/release. Returns `delivery: 'delivered' | 'queued_offline' | 'queued_live'` and `deliverBy`.
- `services/commandClaimEligibility.ts` (+ test) — claim-time filter (org drift, lifecycle, partner trust, requester still active) plus the power-state barrier. Cancels are written **inside the caller's claim transaction**, so a row it rejects can never be delivered by a concurrent claim.
- `services/commandTypes.ts` *(new, extracted)* — see "Notable decisions".

**Modified**
- `services/commandQueue.ts` — `queueCommand` takes `deliverBy` / `submittedOrgId`; `queueCommandForExecution` becomes a thin adapter over the seam (error strings unchanged); `executeCommand`'s insert stamps the short race-grace deadline.
- `services/commandDispatch.ts` — both claim paths gain the `deliver_by IS NULL OR deliver_by > now()` predicate; the batch claim runs eligibility + the barrier.
- `jobs/staleCommandReaper.ts` — two clocks, CAS on the observed `(status, executed_at)`, the new `expired / not_delivered_before_deadline` result, `propagateTimedOutDeviceCommand` gains `kind` and now propagates to `script_executions` and `deployment_results`; new `propagateCancelledDeviceCommand`; `SOFTWARE_QUEUED_EXPIRY_MS` and the whole old Tier 2 removed.
- `services/commandTimeouts.ts` — the `software_install → SEVEN_DAYS` special case is gone (`deliver_by` owns the delivery deadline now); `SOFTWARE_INSTALL` moves to `LONG_TIMEOUT_TYPES` as a pure execution budget.
- `services/commandDelivery.ts` — `prepareClaimedCommandsForDelivery` (alias `decryptClaimedCommandsForDelivery` kept for W5) runs per-type `deliveryRefreshers` before decrypt; a refresher failure **releases** the row instead of delivering a stale payload.
- `services/softwareDeployment.ts` — persist-before-push through the seam; payload gains `s3Key` (only when the URL really is the presigned one).
- `services/softwareDeploymentResult.ts` — `reconcileSoftwareInstallResult`, shared by both result transports.
- `services/scriptDispatch.ts` — `offlinePolicy` (with `requireOnline` kept as a deprecated alias); stamps `deliver_by` + `submitted_org_id`; result gains `deliverBy`.
- `routes/agentWs.ts`, `routes/agents/commands.ts`, `routes/agents/heartbeat.ts` — shared software reconciliation on the generic result path; call sites renamed to `prepareClaimedCommandsForDelivery`.
- `routes/devices/commands.ts` — bulk / single / `set_auto_update` go through the seam; bulk response gains `queuedOffline: string[]`, single gains `delivery` + `deliverBy`; `GET /:id/commands?status=` filter; new `POST /:id/commands/:commandId/cancel`.
- `routes/devices/moveOrg.ts`, `routes/devices/core.ts` — cancel the device's pending rows in the same transaction as the org flip / decommission (decommission excludes `self_uninstall`, so the uninstall drain still delivers).

## Notable decisions worth a reviewer's eye

- **`CommandTypes` was extracted into a new leaf module `services/commandTypes.ts`** (re-exported from `commandQueue`, so every existing import still works). The registry builds from that table at module load, and `commandQueue` imports the seam, which imports the registry — leaving the table in `commandQueue.ts` made that a genuine ESM initialisation cycle whose outcome depended on which module the process imported first. It reproduced as a hard failure in test.
- **Backup / restore / verification types are classified `live` (reject).** The spec puts them out of scope for v1; classifying them here is what keeps them rejecting once the flag flips in W4 — the flag alone would have started queueing them.
- **The registry was swept against every `device_commands.type` literal the API writes**, not just `CommandTypes`: `reboot`, `shutdown`, `schedule_reboot`, `update`, `set_auto_update`, `wake`, `network_discovery`, `update_agent`, `update_watchdog`, `restart_agent`, `actuate_elevation`, `desktop_stream_stop`, `apply_browser_policy`. A test pins that inventory, because a missing entry throws at enqueue.
- **The `software_install` delivery refresher is registered in `commandDelivery.ts` itself**, not by side effect from `softwareDeployment.ts`. Side-effect registration would silently deliver stale installer URLs in any process that happened not to import the feature module — exactly the failure class this seam exists to close. The registry stays open for W3 to add to.
- **Order change in the seam:** partner trust is now evaluated *before* the offline rejection (as §D specifies), so a trust-denied offline device returns `trust_denied` rather than `device_offline`. Error strings for every other path are byte-identical to before.
- **Known, deliberate:** on an **org merge**, a device's queued rows are cancelled at claim as `device_moved_org` (the loser org survives as a shell, so `submitted_org_id` mismatches the repointed device). Fail-closed and recoverable — the operator re-issues. Flagging it rather than widening `orgMergeRegistry` in this wave.

## Verification

| Check | Result |
|---|---|
| `npx tsc --noEmit -p .` (apps/api) | clean |
| `pnpm lint` | clean (6/6 packages) |
| Unit suites for every touched module | green |
| `bash scripts/check-migration-naming.sh` | OK |
| `autoMigrate.test.ts` + `migrationRlsScope.test.ts` | green (DDL-only migration, no scope elevation needed) |

**Contract suites — run against a real local Postgres, not just asserted:**

| Suite | Result |
|---|---|
| `rls-coverage.integration.test.ts` | 102 passed — table stays system-scoped |
| `tenantCascade.integration.test.ts` | green |
| `orgLifecycleFoundations.integration.test.ts` | green |
| `tenant-export-policy` + `tenantExportErasureRoundtrip` | green — no new classification needed |

**Integration test: RAN against a real Postgres 
(`docker-compose.test.yml`), 19/19 passing.** `src/__tests__/integration/deviceCommandOfflineQueue.integration.test.ts` covers: queue-with-deadline against an offline device; a `reject` enqueue creating no row; a queued row surviving past its execution timeout; expiry exactly at `deliver_by` with `expired / not_delivered_before_deadline`; the linked `script_executions` row failing **only** by propagation (and its own reaper leaving a still-waiting one alone); heartbeat claim delivering exactly once; a past-deadline row not being claimed; org move cancelling at claim; the power-state barrier holding a reboot until the queue drains; the cancel endpoint (200 then 409); a cancelled row never re-claimed; legacy `deliver_by IS NULL` / `submitted_org_id IS NULL` rows behaving exactly as before; decommission; the unregistered-type refusal; an inactive requester (with a positive control on `created_by`); and pg_catalog assertions that the partial index exists and `org_id` still does not.

## Not in this wave

Scripts/generic-command UX (W2), patches (W3), automations (W4), AI-tool text + docs sweep + flag removal (W5), principal rehydration at claim (W6, after #3985).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
