### PR TITLE
feat(web,api): offline work queue W02 — admission delivery, device-page queued actions, uniform queued-offline copy (#5131)

### DIFF
--- a/apps/api/src/__tests__/integration/scriptAdmission.integration.test.ts
+++ b/apps/api/src/__tests__/integration/scriptAdmission.integration.test.ts
@@ -122,6 +122,8 @@ describe('POST /scripts/:id/execute — real PostgreSQL admission isolation', ()
         admission: 'admitted',
         executionId: expect.any(String),
         commandId: expect.any(String),
+        // Device fixtures have no live socket, so admission-time delivery is always queued_offline here (W02, #5133).
+        delivery: 'queued_offline',
       }, {
         requestedDeviceId: siteDeniedDevice.id,
         admission: 'denied',

--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -656,7 +656,8 @@ API requests are rate-limited to ensure fair usage. Rate limit headers are inclu
           reasonCode: { type: 'string' },
           executionId: { type: 'string', format: 'uuid' },
           commandId: { type: 'string', format: 'uuid' },
-          batchId: { type: 'string', format: 'uuid' }
+          batchId: { type: 'string', format: 'uuid' },
+          delivery: { type: 'string', enum: ['delivered', 'queued_offline'] }
         }
       },
       ScriptAdmissionResult: {

--- a/apps/api/src/services/scriptExecution.admission.test.ts
+++ b/apps/api/src/services/scriptExecution.admission.test.ts
@@ -142,12 +142,35 @@ describe('executeScriptOnDevices admission contract', () => {
       requestId: expect.stringMatching(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i),
       status: 'queued',
       targets: [
-        { requestedDeviceId: 'A', admission: 'admitted', executionId: 'execution-A', commandId: 'command-A', batchId: 'batch-default' },
-        { requestedDeviceId: 'B', admission: 'admitted', executionId: 'execution-B', commandId: 'command-B', batchId: 'batch-default' },
-        { requestedDeviceId: 'C', admission: 'admitted', executionId: 'execution-C', commandId: 'command-C', batchId: 'batch-default' },
+        { requestedDeviceId: 'A', admission: 'admitted', executionId: 'execution-A', commandId: 'command-A', batchId: 'batch-default', delivery: 'queued_offline' },
+        { requestedDeviceId: 'B', admission: 'admitted', executionId: 'execution-B', commandId: 'command-B', batchId: 'batch-default', delivery: 'queued_offline' },
+        { requestedDeviceId: 'C', admission: 'admitted', executionId: 'execution-C', commandId: 'command-C', batchId: 'batch-default', delivery: 'queued_offline' },
       ],
     });
     expect(vi.mocked(dispatchScriptToDevice).mock.calls.map(([call]) => call.device.id)).toEqual(['A', 'B', 'C']);
+  });
+
+  it('reports delivery per admitted target from the dispatch outcome (#5128 W2)', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(scriptSelect([script()]) as never)
+      .mockReturnValueOnce(deviceSelect([device('online'), device('offline')]) as never);
+    vi.mocked(dispatchScriptToDevice)
+      .mockResolvedValueOnce({ ...dispatched('online'), delivered: true, deliveryOutcome: 'sent' })
+      .mockResolvedValueOnce({ ...dispatched('offline'), delivered: false, deliveryOutcome: 'no_agent' });
+
+    const result = await executeScriptOnDevices({
+      scriptId: 'script-1',
+      deviceIds: ['online', 'offline'],
+      auth,
+      permissions,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.admission.targets).toEqual([
+      { requestedDeviceId: 'online', admission: 'admitted', executionId: 'execution-online', commandId: 'command-online', batchId: 'batch-default', delivery: 'delivered' },
+      { requestedDeviceId: 'offline', admission: 'admitted', executionId: 'execution-offline', commandId: 'command-offline', batchId: 'batch-default', delivery: 'queued_offline' },
+    ]);
   });
 
   it('keeps every distinct requested ID and applies oracle-safe gates without side effects', async () => {
@@ -190,7 +213,7 @@ describe('executeScriptOnDevices admission contract', () => {
       { requestedDeviceId: 'os', admission: 'excluded', reasonCode: 'os_incompatible' },
       { requestedDeviceId: 'decommissioned', admission: 'excluded', reasonCode: 'device_decommissioned' },
       { requestedDeviceId: 'maintenance', admission: 'suppressed', reasonCode: 'maintenance_suppressed' },
-      { requestedDeviceId: 'ok', admission: 'admitted', executionId: 'execution-ok', commandId: 'command-ok' },
+      { requestedDeviceId: 'ok', admission: 'admitted', executionId: 'execution-ok', commandId: 'command-ok', delivery: 'queued_offline' },
     ]);
     expect(vi.mocked(dispatchScriptToDevice).mock.calls.map(([call]) => call.device.id)).toEqual(['ok']);
     expect(db.insert).not.toHaveBeenCalled();
@@ -244,7 +267,7 @@ describe('executeScriptOnDevices admission contract', () => {
     expect(result.admission.targets).toEqual([
       { requestedDeviceId: 'recorded', admission: 'excluded', reasonCode: 'agent_upgrade_required_recorded', batchId: 'batch-1' },
       { requestedDeviceId: 'race', admission: 'excluded', reasonCode: 'os_incompatible', batchId: 'batch-1' },
-      { requestedDeviceId: 'ok', admission: 'admitted', executionId: 'execution-ok', commandId: 'command-ok', batchId: 'batch-1' },
+      { requestedDeviceId: 'ok', admission: 'admitted', executionId: 'execution-ok', commandId: 'command-ok', batchId: 'batch-1', delivery: 'queued_offline' },
     ]);
     const insertChain = vi.mocked(db.insert).mock.results[0]!.value as ReturnType<typeof insertReturning>;
     expect(insertChain.values).toHaveBeenCalledTimes(2);

--- a/apps/api/src/services/scriptExecution.ts
+++ b/apps/api/src/services/scriptExecution.ts
@@ -324,6 +324,11 @@ export async function executeScriptOnDevices(input: ExecuteScriptOnDevicesInput)
       ...(dispatch.executionId ? { executionId: dispatch.executionId } : {}),
       commandId: dispatch.commandId,
       ...(batchIdByOrg.get(device.orgId) ? { batchId: batchIdByOrg.get(device.orgId) } : {}),
+      // #5128 W2 — the dispatch core's own delivery attempt, not a device
+      // status read: `delivered: false` covers every queued outcome
+      // ('no_agent' and the claim/decrypt/send-failed races alike), all of
+      // which land the row in `pending` awaiting the next heartbeat.
+      delivery: dispatch.delivered ? 'delivered' : 'queued_offline',
     });
   }
 

--- a/apps/web/src/components/devices/DeviceDetailPage.commandDelivery.test.tsx
+++ b/apps/web/src/components/devices/DeviceDetailPage.commandDelivery.test.tsx
@@ -1,0 +1,128 @@
+import '@/lib/i18n';
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import DeviceDetailPage from './DeviceDetailPage';
+
+/**
+ * #5128 W2 — the single-command toast on the device detail page now reads
+ * the dispatch core's own `delivery`/`deliverBy` fields off the POST
+ * response, rather than the pre-request `device.status` snapshot. This is a
+ * real behavior change: a device that reads 'online' in the UI (so the
+ * Reboot button is enabled) can still come back `queued_offline` from the
+ * server — a race the old status-based heuristic could not represent.
+ */
+
+const DEVICE_ID = '33333333-3333-3333-3333-333333333333';
+
+const fetchWithAuthMock = vi.hoisted(() => vi.fn());
+vi.mock('../../stores/auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../stores/auth')>();
+  return { ...actual, fetchWithAuth: fetchWithAuthMock };
+});
+
+vi.mock('../extensions/ExtensionSlotHost', () => ({
+  useExtensionSlotDescriptors: () => [],
+  default: () => <div data-testid="extension-slot-host-stub" />,
+}));
+
+vi.mock('../../hooks/useEventStream', () => ({
+  useEventStream: () => ({ subscribe: () => () => undefined }),
+}));
+vi.mock('@/stores/aiStore', () => ({
+  useAiStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({ setPageContext: () => undefined }),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+
+const showToastMock = vi.hoisted(() => vi.fn());
+vi.mock('../shared/Toast', () => ({ showToast: showToastMock }));
+
+const jsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 404): Response =>
+  ({
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload),
+  }) as unknown as Response;
+
+function deviceResponse() {
+  return jsonResponse({
+    id: DEVICE_ID,
+    hostname: 'ws-detail-01',
+    osType: 'windows',
+    osVersion: '11',
+    status: 'online',
+    orgId: 'org-1',
+    siteId: 'site-1',
+    agentVersion: '1.0.0',
+    tags: [],
+    recentMetrics: [],
+  });
+}
+
+async function rebootFromDetailPage(commandResponse: unknown) {
+  fetchWithAuthMock.mockReset();
+  showToastMock.mockReset();
+  fetchWithAuthMock.mockImplementation((url: string, init?: RequestInit) => {
+    if (url === `/devices/${DEVICE_ID}` && (!init || (init.method ?? 'GET') === 'GET')) {
+      return Promise.resolve(deviceResponse());
+    }
+    if (url === `/devices/${DEVICE_ID}/commands` && init?.method === 'POST') {
+      return Promise.resolve(jsonResponse(commandResponse));
+    }
+    return Promise.resolve(jsonResponse({}, false, 404));
+  });
+
+  render(<DeviceDetailPage deviceId={DEVICE_ID} />);
+
+  // The full (non-compact) action bar puts Reboot behind the "Power"
+  // dropdown, not the "…" overflow menu.
+  fireEvent.click(await screen.findByRole('button', { name: 'Power' }));
+  fireEvent.click(await screen.findByRole('button', { name: 'Reboot' }));
+  // The dropdown item closes on click; the ConfirmDialog's "Reboot" button
+  // is the only one left once it does.
+  fireEvent.click(await screen.findByRole('button', { name: 'Reboot' }));
+
+  await waitFor(() => expect(showToastMock).toHaveBeenCalled());
+  return showToastMock.mock.calls.map((c) => c[0]);
+}
+
+describe('DeviceDetailPage single-command toast reads delivery, not device.status (#5128 W2)', () => {
+  beforeEach(() => {
+    fetchWithAuthMock.mockReset();
+    showToastMock.mockReset();
+  });
+
+  it('reports "sent" when the server delivered the command', async () => {
+    const toasts = await rebootFromDetailPage({
+      id: 'cmd-1',
+      deviceId: DEVICE_ID,
+      type: 'reboot',
+      status: 'sent',
+      createdAt: '2026-09-01T00:00:00.000Z',
+      delivery: 'delivered',
+      deliverBy: null,
+    });
+
+    const success = toasts.find((t) => t.type === 'success');
+    expect(success?.message).toMatch(/reboot command sent to ws-detail-01/i);
+  });
+
+  it('reports the runs-when-online copy — even though the UI showed the device online — when the server queued it offline', async () => {
+    const toasts = await rebootFromDetailPage({
+      id: 'cmd-1',
+      deviceId: DEVICE_ID,
+      type: 'reboot',
+      status: 'pending',
+      createdAt: '2026-09-01T00:00:00.000Z',
+      delivery: 'queued_offline',
+      deliverBy: '2026-09-08T00:00:00.000Z',
+    });
+
+    const success = toasts.find((t) => t.type === 'success');
+    expect(success?.message).toMatch(/runs when the device is online/i);
+    expect(success?.message).not.toMatch(/command sent/i);
+  });
+});

--- a/apps/web/src/components/devices/DeviceDetailPage.commandDelivery.test.tsx
+++ b/apps/web/src/components/devices/DeviceDetailPage.commandDelivery.test.tsx
@@ -125,4 +125,39 @@ describe('DeviceDetailPage single-command toast reads delivery, not device.statu
     expect(success?.message).toMatch(/runs when the device is online/i);
     expect(success?.message).not.toMatch(/command sent/i);
   });
+
+  // #5128 W2 regression: 'queued_live' means the device IS online — only the
+  // immediate socket push missed, and the next heartbeat (seconds away)
+  // claims it. A `!== 'delivered'` check would misreport an online device as
+  // offline.
+  it('reports "sent" (not "runs when online") for queued_live — the device is online, only the immediate push missed', async () => {
+    const toasts = await rebootFromDetailPage({
+      id: 'cmd-1',
+      deviceId: DEVICE_ID,
+      type: 'reboot',
+      status: 'pending',
+      createdAt: '2026-09-01T00:00:00.000Z',
+      delivery: 'queued_live',
+      deliverBy: null,
+    });
+
+    const success = toasts.find((t) => t.type === 'success');
+    expect(success?.message).toMatch(/reboot command sent to ws-detail-01/i);
+    expect(success?.message).not.toMatch(/runs when the device is online/i);
+  });
+
+  it('omits the expiry clause when a queued_offline result carries no deliverBy', async () => {
+    const toasts = await rebootFromDetailPage({
+      id: 'cmd-1',
+      deviceId: DEVICE_ID,
+      type: 'reboot',
+      status: 'pending',
+      createdAt: '2026-09-01T00:00:00.000Z',
+      delivery: 'queued_offline',
+      deliverBy: null,
+    });
+
+    const success = toasts.find((t) => t.type === 'success');
+    expect(success?.message).toBe('Runs when the device is online');
+  });
 });

--- a/apps/web/src/components/devices/DeviceDetailPage.tsx
+++ b/apps/web/src/components/devices/DeviceDetailPage.tsx
@@ -310,9 +310,13 @@ export default function DeviceDetailPage({ deviceId }: DeviceDetailPageProps) {
           // acted"; `result.delivery` is the dispatch core's own outcome, so
           // an offline device gets the honest "runs when it reconnects" copy
           // instead of a false "command sent".
+          //
+          // 'queued_live' means the device IS online — only the immediate
+          // socket push missed, and the next heartbeat (seconds away) claims
+          // it. Only 'queued_offline' means "wait for it to reconnect".
           showToast({
             type: "success",
-            message: result.delivery === "delivered"
+            message: result.delivery !== "queued_offline"
               ? `${label} command sent to ${device.hostname}`
               : result.deliverBy
                 ? t("devicesPage.toasts.runsWhenOnline", { date: formatDateTime(result.deliverBy) })

--- a/apps/web/src/components/devices/DeviceDetailPage.tsx
+++ b/apps/web/src/components/devices/DeviceDetailPage.tsx
@@ -33,6 +33,7 @@ import { useAiStore } from "@/stores/aiStore";
 import { navigateTo } from "@/lib/navigation";
 import { deviceScriptsHash } from "@/lib/deviceScriptsLink";
 import { runAction, ActionError } from "@/lib/runAction";
+import { formatDateTime } from "@/lib/dateTimeFormat";
 import Breadcrumbs from "../layout/Breadcrumbs";
 import { useTranslation } from "react-i18next";
 import "../../lib/i18n";
@@ -300,14 +301,22 @@ export default function DeviceDetailPage({ deviceId }: DeviceDetailPageProps) {
         case "reboot_safe_mode":
         case "shutdown":
         case "lock": {
-          await sendDeviceCommand(device.id, action);
+          const result = await sendDeviceCommand(device.id, action);
           const label =
             action === "reboot_safe_mode"
               ? t("deviceDetailPage.rebootToSafeMode")
               : action.charAt(0).toUpperCase() + action.slice(1);
+          // #5128 W2 — a 201 means "a row was inserted", not "the machine
+          // acted"; `result.delivery` is the dispatch core's own outcome, so
+          // an offline device gets the honest "runs when it reconnects" copy
+          // instead of a false "command sent".
           showToast({
             type: "success",
-            message: `${label} command sent to ${device.hostname}`,
+            message: result.delivery === "delivered"
+              ? `${label} command sent to ${device.hostname}`
+              : result.deliverBy
+                ? t("devicesPage.toasts.runsWhenOnline", { date: formatDateTime(result.deliverBy) })
+                : t("devicesPage.toasts.runsWhenOnlineNoExpiry"),
           });
           break;
         }

--- a/apps/web/src/components/devices/DeviceDetails.tsx
+++ b/apps/web/src/components/devices/DeviceDetails.tsx
@@ -49,6 +49,7 @@ import DeviceOneDriveTab from "./DeviceOneDriveTab";
 import DeviceSecurityTab from "./DeviceSecurityTab";
 import DeviceAlertHistory from "./DeviceAlertHistory";
 import DeviceActivityFeed from "./DeviceActivityFeed";
+import DeviceQueuedActions from "./DeviceQueuedActions";
 import DeviceScriptHistory from "./DeviceScriptHistory";
 import DevicePerformanceGraphs from "./DevicePerformanceGraphs";
 import DeviceEventLogViewer from "./DeviceEventLogViewer";
@@ -752,6 +753,10 @@ export default function DeviceDetails({
             <DeviceWarrantyCard deviceId={device.id} compact />
 
             <DeviceBillingCard deviceId={device.id} />
+
+            {device.status !== "decommissioned" && (
+              <DeviceQueuedActions deviceId={device.id} />
+            )}
           </div>
 
           <div

--- a/apps/web/src/components/devices/DeviceQueuedActions.test.tsx
+++ b/apps/web/src/components/devices/DeviceQueuedActions.test.tsx
@@ -1,0 +1,151 @@
+import '@/lib/i18n';
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import DeviceQueuedActions from './DeviceQueuedActions';
+import { fetchWithAuth } from '@/stores/auth';
+import { showToast } from '../shared/Toast';
+
+vi.mock('@/stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+// runAction calls showToast for the cancel outcome; mock it so we can assert
+// feedback surfaces without rendering a real toast.
+vi.mock('../shared/Toast', () => ({
+  showToast: vi.fn(),
+}));
+
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+const showToastMock = vi.mocked(showToast);
+
+const deviceId = '11111111-1111-1111-1111-111111111111';
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload),
+  } as unknown as Response;
+}
+
+function queuedCommand(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'cmd-1',
+    type: 'reboot',
+    createdAt: '2026-09-01T00:00:00.000Z',
+    deliverBy: '2026-09-08T00:00:00.000Z',
+    createdBy: 'user-1',
+    ...overrides,
+  };
+}
+
+describe('DeviceQueuedActions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders one row per pending command with type label, requester, and expiry', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(
+      jsonResponse({ data: [queuedCommand()], pagination: { page: 1, limit: 50, total: 1 } }),
+    );
+
+    render(<DeviceQueuedActions deviceId={deviceId} />);
+
+    const section = await screen.findByTestId('device-queued-actions');
+    expect(section).toBeTruthy();
+    const rows = screen.getAllByTestId('queued-action-row');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].textContent).toContain('Reboot');
+    expect(rows[0].textContent).toMatch(/Requested by user-1/);
+    expect(rows[0].textContent).toMatch(/Expires/);
+
+    expect(fetchWithAuthMock).toHaveBeenCalledWith(
+      `/devices/${deviceId}/commands?status=pending&limit=50`,
+    );
+  });
+
+  it('shows "System" as the requester when createdBy is null', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(
+      jsonResponse({ data: [queuedCommand({ createdBy: null })] }),
+    );
+
+    render(<DeviceQueuedActions deviceId={deviceId} />);
+
+    const row = await screen.findByTestId('queued-action-row');
+    expect(row.textContent).toMatch(/Requested by System/);
+  });
+
+  it('is hidden entirely when the list is empty', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(jsonResponse({ data: [] }));
+
+    const { container } = render(<DeviceQueuedActions deviceId={deviceId} />);
+
+    await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalled());
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByTestId('device-queued-actions')).toBeNull();
+  });
+
+  it('swallows a 401 from the list fetch — no rows, no toast (auth redirect owns it)', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(jsonResponse({ error: 'Unauthorized' }, 401));
+
+    const { container } = render(<DeviceQueuedActions deviceId={deviceId} />);
+
+    await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalled());
+    expect(container.firstChild).toBeNull();
+    expect(showToastMock).not.toHaveBeenCalled();
+  });
+
+  it('cancel calls the endpoint through runAction and removes the row on success', async () => {
+    fetchWithAuthMock.mockImplementation(async (input: string, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url.endsWith('/commands/cmd-1/cancel') && method === 'POST') {
+        return jsonResponse({ id: 'cmd-1', status: 'cancelled' });
+      }
+      return jsonResponse({ data: [queuedCommand()] });
+    });
+
+    render(<DeviceQueuedActions deviceId={deviceId} />);
+    await screen.findByTestId('queued-action-row');
+
+    fireEvent.click(screen.getByTestId('queued-action-cancel'));
+
+    await waitFor(() => expect(screen.queryByTestId('queued-action-row')).toBeNull());
+    expect(fetchWithAuthMock).toHaveBeenCalledWith(
+      `/devices/${deviceId}/commands/cmd-1/cancel`,
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(showToastMock).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'success' }),
+    );
+    // The whole section unmounts once its only row is gone.
+    expect(screen.queryByTestId('device-queued-actions')).toBeNull();
+  });
+
+  it('reloads the list on a 409 (agent claimed it between load and click) instead of leaving a dead Cancel button', async () => {
+    let cancelAttempts = 0;
+    fetchWithAuthMock.mockImplementation(async (input: string, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url.endsWith('/commands/cmd-1/cancel') && method === 'POST') {
+        cancelAttempts += 1;
+        return jsonResponse({ error: 'Command is not pending' }, 409);
+      }
+      // The reload after the 409 finds the command already claimed —
+      // the list comes back empty.
+      return jsonResponse({ data: cancelAttempts > 0 ? [] : [queuedCommand()] });
+    });
+
+    render(<DeviceQueuedActions deviceId={deviceId} />);
+    await screen.findByTestId('queued-action-row');
+
+    fireEvent.click(screen.getByTestId('queued-action-cancel'));
+
+    await waitFor(() => expect(screen.queryByTestId('device-queued-actions')).toBeNull());
+    // GET list (initial) + POST cancel + GET list (reload after 409).
+    expect(fetchWithAuthMock).toHaveBeenCalledTimes(3);
+  });
+});

--- a/apps/web/src/components/devices/DeviceQueuedActions.test.tsx
+++ b/apps/web/src/components/devices/DeviceQueuedActions.test.tsx
@@ -31,13 +31,19 @@ function jsonResponse(payload: unknown, status = 200): Response {
   } as unknown as Response;
 }
 
+// A realistic user id — the API never returns a friendly string like
+// "user-1" here (device_commands.created_by is a bare uuid FK with no name
+// join on this endpoint), so the fixture has to look like the real shape or
+// a test could pass while still asserting on a raw, meaningless UUID.
+const REQUESTER_ID = '8400e6c1-c39f-4cf1-8d51-e6d6ce6d5f1e';
+
 function queuedCommand(overrides: Record<string, unknown> = {}) {
   return {
     id: 'cmd-1',
     type: 'reboot',
     createdAt: '2026-09-01T00:00:00.000Z',
     deliverBy: '2026-09-08T00:00:00.000Z',
-    createdBy: 'user-1',
+    createdBy: REQUESTER_ID,
     ...overrides,
   };
 }
@@ -59,7 +65,11 @@ describe('DeviceQueuedActions', () => {
     const rows = screen.getAllByTestId('queued-action-row');
     expect(rows).toHaveLength(1);
     expect(rows[0].textContent).toContain('Reboot');
-    expect(rows[0].textContent).toMatch(/Requested by user-1/);
+    // `createdBy` is a bare user id with no name join on this endpoint — the
+    // row must NEVER print the raw UUID (meaningless to an operator); it can
+    // only say a human (vs. system) requested it.
+    expect(rows[0].textContent).toMatch(/Requested by a user/);
+    expect(rows[0].textContent).not.toContain(REQUESTER_ID);
     expect(rows[0].textContent).toMatch(/Expires/);
 
     expect(fetchWithAuthMock).toHaveBeenCalledWith(
@@ -98,6 +108,43 @@ describe('DeviceQueuedActions', () => {
     expect(showToastMock).not.toHaveBeenCalled();
   });
 
+  // A non-401 failure must NEVER look identical to "nothing queued" — an
+  // operator seeing an empty card has no way to tell "checked, empty" apart
+  // from "couldn't check" unless the failure renders something.
+  it('a non-401 list-fetch failure shows a visible error with Retry, not a silent empty card', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(jsonResponse({ error: 'boom' }, 500));
+
+    render(<DeviceQueuedActions deviceId={deviceId} />);
+
+    await screen.findByTestId('device-queued-actions');
+    expect(screen.queryByTestId('queued-action-row')).toBeNull();
+    expect(screen.getByTestId('queued-actions-retry')).toBeTruthy();
+  });
+
+  it('a thrown fetch (network failure) shows the same visible error as an HTTP failure', async () => {
+    fetchWithAuthMock.mockRejectedValueOnce(new Error('network down'));
+
+    render(<DeviceQueuedActions deviceId={deviceId} />);
+
+    await screen.findByTestId('device-queued-actions');
+    expect(screen.getByTestId('queued-actions-retry')).toBeTruthy();
+  });
+
+  it('Retry re-fetches and replaces the error with the real list', async () => {
+    fetchWithAuthMock
+      .mockResolvedValueOnce(jsonResponse({ error: 'boom' }, 500))
+      .mockResolvedValueOnce(jsonResponse({ data: [queuedCommand()] }));
+
+    render(<DeviceQueuedActions deviceId={deviceId} />);
+    await screen.findByTestId('queued-actions-retry');
+
+    fireEvent.click(screen.getByTestId('queued-actions-retry'));
+
+    await screen.findByTestId('queued-action-row');
+    expect(screen.queryByTestId('queued-actions-retry')).toBeNull();
+    expect(fetchWithAuthMock).toHaveBeenCalledTimes(2);
+  });
+
   it('cancel calls the endpoint through runAction and removes the row on success', async () => {
     fetchWithAuthMock.mockImplementation(async (input: string, init?: RequestInit) => {
       const url = String(input);
@@ -123,6 +170,34 @@ describe('DeviceQueuedActions', () => {
     );
     // The whole section unmounts once its only row is gone.
     expect(screen.queryByTestId('device-queued-actions')).toBeNull();
+  });
+
+  it('a genuine cancel failure (500) leaves the row in place and surfaces an error toast, without reloading', async () => {
+    fetchWithAuthMock.mockImplementation(async (input: string, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url.endsWith('/commands/cmd-1/cancel') && method === 'POST') {
+        return jsonResponse({ error: 'database unavailable' }, 500);
+      }
+      return jsonResponse({ data: [queuedCommand()] });
+    });
+
+    render(<DeviceQueuedActions deviceId={deviceId} />);
+    await screen.findByTestId('queued-action-row');
+
+    fireEvent.click(screen.getByTestId('queued-action-cancel'));
+
+    await waitFor(() => expect(showToastMock).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'error' }),
+    ));
+    // The row survives — a 500 is not "already claimed"; the user should be
+    // able to retry the same Cancel click.
+    expect(screen.getByTestId('queued-action-row')).toBeTruthy();
+    const cancelButton = screen.getByTestId('queued-action-cancel') as HTMLButtonElement;
+    expect(cancelButton.disabled).toBe(false);
+    // Only the initial GET list + the failed POST cancel — no reload, unlike
+    // the 409 case below.
+    expect(fetchWithAuthMock).toHaveBeenCalledTimes(2);
   });
 
   it('reloads the list on a 409 (agent claimed it between load and click) instead of leaving a dead Cancel button', async () => {

--- a/apps/web/src/components/devices/DeviceQueuedActions.tsx
+++ b/apps/web/src/components/devices/DeviceQueuedActions.tsx
@@ -1,0 +1,139 @@
+import { useCallback, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Clock } from "lucide-react";
+import { fetchWithAuth } from "@/stores/auth";
+import { runAction, ActionError } from "@/lib/runAction";
+import { formatDateTime } from "@/lib/dateTimeFormat";
+import "../../lib/i18n";
+
+type QueuedCommand = {
+  id: string;
+  type: string;
+  createdAt: string;
+  deliverBy: string | null;
+  createdBy: string | null;
+};
+
+type DeviceQueuedActionsProps = {
+  deviceId: string;
+};
+
+// No i18n catalog for the raw `device_commands.type` values (dozens of them,
+// most never reach `pending` for long — see commandOfflinePolicy.ts's
+// registry) — humanize the snake_case type instead of maintaining a parallel
+// translated list that would drift from it.
+function humanizeCommandType(type: string): string {
+  return type
+    .split("_")
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+// #5128 W2 — the device page's "Queued actions" list: pending device_commands
+// rows for this device, with a Cancel affordance. Hidden entirely when there
+// is nothing queued (design §H) — including while the initial fetch is still
+// in flight, so there's no empty-frame flash on every device page load.
+export default function DeviceQueuedActions({ deviceId }: DeviceQueuedActionsProps) {
+  const { t } = useTranslation("devices");
+  const [rows, setRows] = useState<QueuedCommand[]>([]);
+  const [loaded, setLoaded] = useState(false);
+  const [cancellingIds, setCancellingIds] = useState<Set<string>>(new Set());
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetchWithAuth(`/devices/${deviceId}/commands?status=pending&limit=50`);
+      if (res.status === 401) {
+        // Session expired — the auth redirect owns telling the user, not
+        // this card. Leave the list empty rather than toast or retry.
+        return;
+      }
+      if (!res.ok) {
+        setRows([]);
+        return;
+      }
+      const json = await res.json();
+      const data: QueuedCommand[] = Array.isArray(json?.data) ? json.data : [];
+      setRows(data);
+    } catch {
+      setRows([]);
+    } finally {
+      setLoaded(true);
+    }
+  }, [deviceId]);
+
+  useEffect(() => {
+    setLoaded(false);
+    setRows([]);
+    void load();
+  }, [load]);
+
+  const handleCancel = async (commandId: string) => {
+    if (cancellingIds.has(commandId)) return;
+    setCancellingIds((prev) => new Set(prev).add(commandId));
+    try {
+      await runAction({
+        request: () => fetchWithAuth(`/devices/${deviceId}/commands/${commandId}/cancel`, { method: "POST" }),
+        errorFallback: t("queuedActions.cancelFailed"),
+        successMessage: t("queuedActions.cancelled"),
+      });
+      setRows((prev) => prev.filter((row) => row.id !== commandId));
+    } catch (err) {
+      // 409 means the agent claimed the row between this list load and the
+      // click — reload so the (no-longer-pending) row is dropped from view
+      // instead of leaving a Cancel button on work that can't be cancelled.
+      // Any other ActionError was already toasted by runAction.
+      if (err instanceof ActionError && err.status === 409) {
+        void load();
+      }
+    } finally {
+      setCancellingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(commandId);
+        return next;
+      });
+    }
+  };
+
+  if (!loaded || rows.length === 0) return null;
+
+  return (
+    <div className="rounded-lg border bg-card p-4 shadow-xs" data-testid="device-queued-actions">
+      <div className="flex items-center gap-2">
+        <Clock className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+        <h3 className="text-sm font-semibold">{t("queuedActions.title")}</h3>
+      </div>
+      <ul className="mt-3 space-y-2">
+        {rows.map((row) => (
+          <li
+            key={row.id}
+            data-testid="queued-action-row"
+            className="flex items-center justify-between gap-3 rounded-md border px-3 py-2 text-sm"
+          >
+            <div className="min-w-0">
+              <p className="truncate font-medium">{humanizeCommandType(row.type)}</p>
+              <p className="truncate text-xs text-muted-foreground">
+                {t("queuedActions.requestedBy", { who: row.createdBy ?? t("queuedActions.system") })}
+                {row.deliverBy && (
+                  <>
+                    {" · "}
+                    {t("queuedActions.expires", { date: formatDateTime(row.deliverBy) })}
+                  </>
+                )}
+              </p>
+            </div>
+            <button
+              type="button"
+              data-testid="queued-action-cancel"
+              onClick={() => handleCancel(row.id)}
+              disabled={cancellingIds.has(row.id)}
+              className="shrink-0 rounded-md border px-2 py-1 text-xs font-medium text-muted-foreground transition hover:bg-muted hover:text-foreground disabled:opacity-50"
+            >
+              {t("queuedActions.cancel")}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/src/components/devices/DeviceQueuedActions.tsx
+++ b/apps/web/src/components/devices/DeviceQueuedActions.tsx
@@ -38,24 +38,33 @@ export default function DeviceQueuedActions({ deviceId }: DeviceQueuedActionsPro
   const { t } = useTranslation("devices");
   const [rows, setRows] = useState<QueuedCommand[]>([]);
   const [loaded, setLoaded] = useState(false);
+  // A load FAILURE (non-401 HTTP error, thrown fetch, bad body) is not the
+  // same state as "this device genuinely has nothing queued" — collapsing
+  // them (both rendering nothing) would tell an operator a device has no
+  // pending work when the truth is "we couldn't check". Only the 401 case
+  // stays silent: the auth redirect owns telling the user about that one.
+  const [loadError, setLoadError] = useState(false);
   const [cancellingIds, setCancellingIds] = useState<Set<string>>(new Set());
 
   const load = useCallback(async () => {
+    setLoadError(false);
     try {
       const res = await fetchWithAuth(`/devices/${deviceId}/commands?status=pending&limit=50`);
       if (res.status === 401) {
-        // Session expired — the auth redirect owns telling the user, not
-        // this card. Leave the list empty rather than toast or retry.
         return;
       }
       if (!res.ok) {
+        console.error(`[DeviceQueuedActions] failed to load pending commands: HTTP ${res.status}`);
+        setLoadError(true);
         setRows([]);
         return;
       }
       const json = await res.json();
       const data: QueuedCommand[] = Array.isArray(json?.data) ? json.data : [];
       setRows(data);
-    } catch {
+    } catch (err) {
+      console.error('[DeviceQueuedActions] failed to load pending commands', err);
+      setLoadError(true);
       setRows([]);
     } finally {
       setLoaded(true);
@@ -64,6 +73,7 @@ export default function DeviceQueuedActions({ deviceId }: DeviceQueuedActionsPro
 
   useEffect(() => {
     setLoaded(false);
+    setLoadError(false);
     setRows([]);
     void load();
   }, [load]);
@@ -95,7 +105,11 @@ export default function DeviceQueuedActions({ deviceId }: DeviceQueuedActionsPro
     }
   };
 
-  if (!loaded || rows.length === 0) return null;
+  if (!loaded) return null;
+  // Genuinely empty (no error) stays hidden entirely (design §H). A load
+  // failure is handled below instead — it must never look identical to
+  // "nothing queued".
+  if (!loadError && rows.length === 0) return null;
 
   return (
     <div className="rounded-lg border bg-card p-4 shadow-xs" data-testid="device-queued-actions">
@@ -103,37 +117,57 @@ export default function DeviceQueuedActions({ deviceId }: DeviceQueuedActionsPro
         <Clock className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
         <h3 className="text-sm font-semibold">{t("queuedActions.title")}</h3>
       </div>
-      <ul className="mt-3 space-y-2">
-        {rows.map((row) => (
-          <li
-            key={row.id}
-            data-testid="queued-action-row"
-            className="flex items-center justify-between gap-3 rounded-md border px-3 py-2 text-sm"
+      {loadError ? (
+        <p className="mt-3 text-sm text-muted-foreground">
+          {t("queuedActions.loadFailed")}{" "}
+          <button
+            type="button"
+            data-testid="queued-actions-retry"
+            onClick={() => void load()}
+            className="font-medium text-primary hover:underline"
           >
-            <div className="min-w-0">
-              <p className="truncate font-medium">{humanizeCommandType(row.type)}</p>
-              <p className="truncate text-xs text-muted-foreground">
-                {t("queuedActions.requestedBy", { who: row.createdBy ?? t("queuedActions.system") })}
-                {row.deliverBy && (
-                  <>
-                    {" · "}
-                    {t("queuedActions.expires", { date: formatDateTime(row.deliverBy) })}
-                  </>
-                )}
-              </p>
-            </div>
-            <button
-              type="button"
-              data-testid="queued-action-cancel"
-              onClick={() => handleCancel(row.id)}
-              disabled={cancellingIds.has(row.id)}
-              className="shrink-0 rounded-md border px-2 py-1 text-xs font-medium text-muted-foreground transition hover:bg-muted hover:text-foreground disabled:opacity-50"
+            {t("common:actions.retry")}
+          </button>
+        </p>
+      ) : (
+        <ul className="mt-3 space-y-2">
+          {rows.map((row) => (
+            <li
+              key={row.id}
+              data-testid="queued-action-row"
+              className="flex items-center justify-between gap-3 rounded-md border px-3 py-2 text-sm"
             >
-              {t("queuedActions.cancel")}
-            </button>
-          </li>
-        ))}
-      </ul>
+              <div className="min-w-0">
+                <p className="truncate font-medium">{humanizeCommandType(row.type)}</p>
+                <p className="truncate text-xs text-muted-foreground">
+                  {/* `createdBy` is a bare user id (no name join on this
+                      endpoint) — a raw UUID would be meaningless to an
+                      operator, so this only distinguishes human- from
+                      system-initiated, not who specifically. */}
+                  {t("queuedActions.requestedBy", {
+                    who: row.createdBy ? t("queuedActions.aUser") : t("queuedActions.system"),
+                  })}
+                  {row.deliverBy && (
+                    <>
+                      {" · "}
+                      {t("queuedActions.expires", { date: formatDateTime(row.deliverBy) })}
+                    </>
+                  )}
+                </p>
+              </div>
+              <button
+                type="button"
+                data-testid="queued-action-cancel"
+                onClick={() => handleCancel(row.id)}
+                disabled={cancellingIds.has(row.id)}
+                className="shrink-0 rounded-md border px-2 py-1 text-xs font-medium text-muted-foreground transition hover:bg-muted hover:text-foreground disabled:opacity-50"
+              >
+                {t("queuedActions.cancel")}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/devices/DevicesPage.test.tsx
+++ b/apps/web/src/components/devices/DevicesPage.test.tsx
@@ -1357,6 +1357,50 @@ describe('DevicesPage — bulk agent commands gated on decommissioned only (#246
     expect(vi.mocked(sendBulkCommand)).not.toHaveBeenCalled();
   });
 
+  // #5128 W2 — the bulk toast reads `queuedOffline` off the W1 response
+  // shape and appends the count via `queuedOfflineTail`. Untested until now:
+  // a wrong field name, an off-by-one, or a broken interpolation key would
+  // ship silently, and bulk reboot of a partly-offline fleet is a core flow.
+  it('bulk toast reports how many of the sent commands were queued for offline devices', async () => {
+    const { sendBulkCommand } = await import('../../services/deviceActions');
+    const { showToast } = await import('../shared/Toast');
+    vi.mocked(sendBulkCommand).mockResolvedValue({
+      commands: [{}, {}, {}],
+      failed: [],
+      skipped: [],
+      queuedOffline: [DEV_2, DEV_3],
+    } as never);
+
+    render(<DevicesPage />);
+    await screen.findByTestId('device-list');
+    fireEvent.click(screen.getByTestId('bulk-reboot'));
+
+    await waitFor(() => {
+      const messages = vi.mocked(showToast).mock.calls.map(c => c[0].message ?? '');
+      expect(messages.some(m => /2 queued for offline devices/i.test(m))).toBe(true);
+    });
+  });
+
+  it('bulk toast omits the queued-offline clause when nothing was queued', async () => {
+    const { sendBulkCommand } = await import('../../services/deviceActions');
+    const { showToast } = await import('../shared/Toast');
+    vi.mocked(sendBulkCommand).mockResolvedValue({
+      commands: [{}, {}, {}],
+      failed: [],
+      skipped: [],
+      queuedOffline: [],
+    } as never);
+
+    render(<DevicesPage />);
+    await screen.findByTestId('device-list');
+    fireEvent.click(screen.getByTestId('bulk-reboot'));
+
+    await waitFor(() => {
+      const messages = vi.mocked(showToast).mock.calls.map(c => c[0].message ?? '');
+      expect(messages.some(m => /queued for offline devices/i.test(m))).toBe(false);
+    });
+  });
+
   it('refuses outright when EVERY selected device is decommissioned', async () => {
     const { sendBulkCommand } = await import('../../services/deviceActions');
     const { showToast } = await import('../shared/Toast');
@@ -1501,7 +1545,15 @@ describe('DevicesPage — bulk agent commands gated on decommissioned only (#246
     // between page load and click).
     async function rebootDeviceWithStatus(
       status: string,
-      opts: { delivered?: boolean; deliverBy?: string | null } = {},
+      opts: {
+        delivered?: boolean;
+        deliverBy?: string | null;
+        // Raw override for the 'queued_live' outcome — the device IS online,
+        // only the immediate socket push missed (no live session,
+        // preferHeartbeat); distinct from both 'delivered' and
+        // 'queued_offline'. Takes precedence over `delivered` when set.
+        delivery?: 'delivered' | 'queued_offline' | 'queued_live';
+      } = {},
     ) {
       const { sendDeviceCommand } = await import('../../services/deviceActions');
       const { showToast } = await import('../shared/Toast');
@@ -1516,7 +1568,7 @@ describe('DevicesPage — bulk agent commands gated on decommissioned only (#246
         type: 'reboot',
         status: 'pending',
         createdAt: '2026-09-01T00:00:00.000Z',
-        delivery: delivered ? 'delivered' : 'queued_offline',
+        delivery: opts.delivery ?? (delivered ? 'delivered' : 'queued_offline'),
         deliverBy,
       } as never);
 
@@ -1589,6 +1641,18 @@ describe('DevicesPage — bulk agent commands gated on decommissioned only (#246
         expect(success?.message).not.toMatch(/sent to/i);
       },
     );
+
+    // #5128 W2 regression: 'queued_live' means the device IS online — only
+    // the immediate socket push missed (no live session, preferHeartbeat),
+    // so the next heartbeat (seconds away) claims it. A `!== 'delivered'`
+    // check would misreport this as "runs when the device is online",
+    // telling the operator an online device is offline.
+    it('a queued_live result (device online, immediate push missed) reports "sent", not "runs when online"', async () => {
+      const toasts = await rebootDeviceWithStatus('online', { delivery: 'queued_live', deliverBy: null });
+      const success = toasts.find(c => c.type === 'success');
+      expect(success?.message).toMatch(/sent to host-alpha/i);
+      expect(success?.message).not.toMatch(/runs when the device is online/i);
+    });
 
     // #5128 W2 — a queued command that carries no deliverBy (a legacy row,
     // or a policy that never sets a TTL) falls back to the no-expiry copy

--- a/apps/web/src/components/devices/DevicesPage.test.tsx
+++ b/apps/web/src/components/devices/DevicesPage.test.tsx
@@ -1492,10 +1492,33 @@ describe('DevicesPage — bulk agent commands gated on decommissioned only (#246
   // notifying the user. A flat "sent" toast would therefore be a false success,
   // so the copy must name the queue.
   describe('single-device command toast tells the truth about delivery (#2630)', () => {
-    async function rebootDeviceWithStatus(status: string) {
+    // #5128 W2 — the toast now reads the dispatch core's own `delivery`
+    // outcome (and `deliverBy` for the expiry clause) off the response,
+    // rather than inferring from the pre-request device.status snapshot.
+    // `delivered` defaults to the device's status ONLY as a realistic stand-in
+    // for what the real API would answer; a case can override it to exercise
+    // the response independent of status (e.g. a device that came online
+    // between page load and click).
+    async function rebootDeviceWithStatus(
+      status: string,
+      opts: { delivered?: boolean; deliverBy?: string | null } = {},
+    ) {
       const { sendDeviceCommand } = await import('../../services/deviceActions');
       const { showToast } = await import('../shared/Toast');
-      vi.mocked(sendDeviceCommand).mockResolvedValue({ command: {} } as never);
+      const delivered = opts.delivered ?? status === 'online';
+      // `?? ` would treat an explicit `deliverBy: null` override the same as
+      // "not provided" (both are nullish) — check membership instead so the
+      // no-expiry test case actually gets null through.
+      const deliverBy = delivered ? null : ('deliverBy' in opts ? opts.deliverBy! : '2026-09-08T00:00:00.000Z');
+      vi.mocked(sendDeviceCommand).mockResolvedValue({
+        id: 'cmd-1',
+        deviceId: DEV_1,
+        type: 'reboot',
+        status: 'pending',
+        createdAt: '2026-09-01T00:00:00.000Z',
+        delivery: delivered ? 'delivered' : 'queued_offline',
+        deliverBy,
+      } as never);
 
       vi.mocked(fetchAllDevices).mockResolvedValue({
         data: [{ ...rawDevice(DEV_1, 'host-alpha'), status }],
@@ -1554,19 +1577,36 @@ describe('DevicesPage — bulk agent commands gated on decommissioned only (#246
       const toasts = await rebootDeviceWithStatus('online');
       const success = toasts.find(c => c.type === 'success');
       expect(success?.message).toMatch(/sent to host-alpha/i);
-      expect(success?.message).not.toMatch(/queued/i);
+      expect(success?.message).not.toMatch(/runs when the device is online/i);
     });
 
     it.each(['offline', 'maintenance', 'quarantined', 'updating', 'pending'])(
-      '%s device: says QUEUED and names the reconnect condition, never a bare success',
+      '%s device: reports the runs-when-online copy with its expiry, never a bare "sent"',
       async (status) => {
         const toasts = await rebootDeviceWithStatus(status);
         const success = toasts.find(c => c.type === 'success');
-        expect(success?.message).toMatch(/queued/i);
-        expect(success?.message).toMatch(/host-alpha/);
-        expect(success?.message).toMatch(/reconnect/i);
+        expect(success?.message).toMatch(/runs when the device is online/i);
+        expect(success?.message).not.toMatch(/sent to/i);
       },
     );
+
+    // #5128 W2 — a queued command that carries no deliverBy (a legacy row,
+    // or a policy that never sets a TTL) falls back to the no-expiry copy
+    // rather than rendering a literal "undefined" date.
+    it('a queued command with no deliverBy omits the expiry clause', async () => {
+      const toasts = await rebootDeviceWithStatus('offline', { deliverBy: null });
+      const success = toasts.find(c => c.type === 'success');
+      expect(success?.message).toBe('Runs when the device is online');
+    });
+
+    // `delivery` is the dispatch core's own outcome, not a re-derivation of
+    // device.status — a device that reconnected between page load and click
+    // must still report "sent", even though the row's cached status is stale.
+    it('trusts the response delivery outcome over a stale device.status snapshot', async () => {
+      const toasts = await rebootDeviceWithStatus('offline', { delivered: true });
+      const success = toasts.find(c => c.type === 'success');
+      expect(success?.message).toMatch(/sent to host-alpha/i);
+    });
   });
 
   // Every non-decommissioned status is queueable, so ALL of them must survive the

--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -4,6 +4,7 @@ import { useEventStream } from '../../hooks/useEventStream';
 import { useAdvancedFilterIds } from '../../hooks/useAdvancedFilterIds';
 import { List, Grid, Plus, AlertCircle } from 'lucide-react';
 import { showToast } from '../shared/Toast';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 import type { FilterConditionGroup } from '@breeze/shared';
 import DeviceList, { type Device, type DeviceClass, type DeviceStatus, type OSType } from './DeviceList';
 import type { DeviceRole } from '@/lib/deviceRoles';
@@ -923,7 +924,7 @@ export default function DevicesPage() {
         case 'reboot_safe_mode':
         case 'shutdown':
         case 'lock': {
-          await sendDeviceCommand(device.id, action);
+          const result = await sendDeviceCommand(device.id, action);
           const label = action === 'reboot_safe_mode'
             ? t('devicesPage.actions.rebootSafeMode')
             : t(/* i18n-dynamic */ `devicesPage.actions.${action}`, { defaultValue: action.charAt(0).toUpperCase() + action.slice(1) });
@@ -933,11 +934,18 @@ export default function DevicesPage() {
           // claims it on its next poll (or staleCommandReaper fails it later).
           // Saying "sent" for that is a false success — the user walks away
           // believing it happened. Name the queue explicitly instead.
+          //
+          // #5128 W2 — `result.delivery` is the dispatch core's own outcome,
+          // not the pre-request device.status snapshot: a device that came
+          // online between page load and click is reported correctly either
+          // way, where the old status heuristic could be stale.
           showToast({
             type: 'success',
-            message: device.status === 'online'
+            message: result.delivery === 'delivered'
               ? t('devicesPage.toasts.commandSent', { action: label, hostname: device.hostname })
-              : t('devicesPage.toasts.commandQueued', { action: label, hostname: device.hostname }),
+              : result.deliverBy
+                ? t('devicesPage.toasts.runsWhenOnline', { date: formatDateTime(result.deliverBy) })
+                : t('devicesPage.toasts.runsWhenOnlineNoExpiry'),
           });
           break;
         }
@@ -1332,15 +1340,19 @@ export default function DevicesPage() {
           const successCount = result.commands?.length ?? 0;
           const failedCount = result.failed?.length ?? 0;
           const skippedCount = result.skipped?.length ?? 0;
+          // #5128 W2 — queuedOffline is a subset of `commands`: those devices
+          // were offline, so the command was persisted but not delivered yet.
+          const queuedCount = result.queuedOffline?.length ?? 0;
           const bulkLabel = action === 'reboot_safe_mode'
             ? t('devicesPage.actions.rebootSafeMode')
             : t(/* i18n-dynamic */ `devicesPage.actions.${action}`, { defaultValue: action.charAt(0).toUpperCase() + action.slice(1) });
           const skippedTail = skippedCount > 0 ? t('devicesPage.toasts.alreadyPendingTail', { count: skippedCount }) : '';
+          const queuedTail = queuedCount > 0 ? t('devicesPage.toasts.queuedOfflineTail', { count: queuedCount }) : '';
 
           if (failedCount === 0) {
             showToast({
               type: 'success',
-              message: t('devicesPage.toasts.bulkCommandSent', { action: bulkLabel, count: successCount, skippedTail }),
+              message: t('devicesPage.toasts.bulkCommandSent', { action: bulkLabel, count: successCount, queuedTail, skippedTail }),
             });
           } else {
             const failureSummary = summarizeBulkCommandFailures(result.failed ?? []);
@@ -1349,6 +1361,7 @@ export default function DevicesPage() {
               message: t('devicesPage.toasts.bulkCommandPartialFailed', {
                 action: bulkLabel,
                 count: successCount,
+                queuedTail,
                 skippedTail,
                 failed: failedCount,
                 failureSummary,

--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -939,9 +939,16 @@ export default function DevicesPage() {
           // not the pre-request device.status snapshot: a device that came
           // online between page load and click is reported correctly either
           // way, where the old status heuristic could be stale.
+          //
+          // 'queued_live' means the device IS online — the immediate socket
+          // push just didn't land (no live session, or preferHeartbeat), so
+          // the next heartbeat (seconds away) claims it. That is NOT the
+          // "wait for it to reconnect" story `queued_offline` tells; treat it
+          // as sent, same as 'delivered', or an online device gets told it's
+          // offline.
           showToast({
             type: 'success',
-            message: result.delivery === 'delivered'
+            message: result.delivery !== 'queued_offline'
               ? t('devicesPage.toasts.commandSent', { action: label, hostname: device.hostname })
               : result.deliverBy
                 ? t('devicesPage.toasts.runsWhenOnline', { date: formatDateTime(result.deliverBy) })

--- a/apps/web/src/components/scripts/ScriptExecutionModal.test.tsx
+++ b/apps/web/src/components/scripts/ScriptExecutionModal.test.tsx
@@ -7,11 +7,14 @@ import ScriptExecutionModal, { type Device } from './ScriptExecutionModal';
 import type { ScriptParameter } from './ScriptFormSchema';
 import type { Script } from './ScriptList';
 import { fetchWithAuth } from '../../stores/auth';
+import { showToast } from '../shared/Toast';
 import type { ScriptAdmissionResult } from '@breeze/shared';
 
 vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
 
 const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+const showToastMock = vi.mocked(showToast);
 
 // The advanced-filter panel is closed on open, so `useFilterPreview` is disabled
 // and never fetches — no transport stub is needed for these cases.
@@ -300,6 +303,44 @@ describe('ScriptExecutionModal admission truth', () => {
 
     await vi.waitFor(() => expect(screen.getByText('network unavailable')).toBeInTheDocument());
     expect(screen.queryByText('No devices were admitted. Review the reasons below.')).toBeNull();
+  });
+
+  // #5128 W2 — an admitted target is not necessarily running: one dispatched
+  // while its device was offline is `queued_offline`, and the inline
+  // "admitted and queued" panel text alone doesn't say the device has to
+  // reconnect first. Surface that as a toast.
+  it('toasts the offline-queue copy when an admitted target is queued_offline', async () => {
+    const onClose = vi.fn();
+    renderModal([], vi.fn().mockResolvedValue({
+      requestId: 'dddddddd-dddd-4ddd-8ddd-dddddddddddd',
+      status: 'queued',
+      targets: [{
+        requestedDeviceId: 'd-1',
+        admission: 'admitted',
+        executionId: 'execution-1',
+        commandId: 'command-1',
+        delivery: 'queued_offline',
+      }],
+    } satisfies ScriptAdmissionResult), onClose);
+
+    await execute();
+    await act(async () => { await Promise.resolve(); });
+
+    expect(showToastMock).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Runs when the device is online' }),
+    );
+  });
+
+  it('does not toast the offline-queue copy when every admitted target was delivered', async () => {
+    renderModal([], vi.fn().mockResolvedValue({
+      ...admittedResult,
+      targets: [{ ...admittedResult.targets[0], delivery: 'delivered' }],
+    } satisfies ScriptAdmissionResult));
+
+    await execute();
+    await act(async () => { await Promise.resolve(); });
+
+    expect(showToastMock).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/src/components/scripts/ScriptExecutionModal.tsx
+++ b/apps/web/src/components/scripts/ScriptExecutionModal.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { X, Play, Loader2, Clock, AlertCircle, Filter } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { showToast } from '../shared/Toast';
 import { Dialog } from '../shared/Dialog';
 import ProgressBar from '../shared/ProgressBar';
 import type { Script } from './ScriptList';
@@ -291,6 +292,14 @@ export default function ScriptExecutionModal({
           : 'rejected';
       setExecutionState(presentationState);
       setShowConfirm(false);
+      // #5128 W2 — an admitted target isn't necessarily running yet: a
+      // target dispatched while its device was offline is `queued_offline`,
+      // and the inline admission panel alone doesn't say so. `deliverBy` isn't
+      // on the admission contract yet, so this is always the no-expiry copy
+      // for now.
+      if (result.targets.some(target => target.delivery === 'queued_offline')) {
+        showToast({ type: 'success', message: t('scriptExecutionModal.toasts.runsWhenOnline') });
+      }
       if (presentationState === 'admitted') {
         setTimeout(() => {
           onClose();

--- a/apps/web/src/components/scripts/executionStatus.test.tsx
+++ b/apps/web/src/components/scripts/executionStatus.test.tsx
@@ -55,4 +55,13 @@ describe('every execution status resolves in both status maps', () => {
   it.each(CANCEL_STATES)('every cancel state resolves a label against a terminal status: %s', (cancelState) => {
     expect(resolveExecutionStatusLabel('completed', cancelState)).toBeTruthy();
   });
+
+  // #5128 W2 — the bare "Queued" label was ambiguous about WHY nothing has
+  // happened yet; both status maps now key `queued` on the offline-aware
+  // label so the row/detail views render "Queued — device offline".
+  it('queued resolves to the offline-aware label in both status maps', () => {
+    expect(executionRowStatusConfig.queued.label).toBe('status.queuedOffline');
+    expect(executionDetailStatusConfig.queued.label).toBe('status.queuedOffline');
+    expect(resolveExecutionStatusLabel('queued', null)).toBe('status.queuedOffline');
+  });
 });

--- a/apps/web/src/components/scripts/executionStatus.ts
+++ b/apps/web/src/components/scripts/executionStatus.ts
@@ -16,7 +16,11 @@ type DetailEntry = { label: string; color: string; bgColor: string; icon: typeof
 
 export const executionRowStatusConfig: Record<ExecutionStatus, RowEntry> = {
   pending: { label: 'status.pending', color: 'bg-muted text-muted-foreground border-border', icon: Clock },
-  queued: { label: 'status.queued', color: 'bg-muted text-muted-foreground border-border', icon: Clock },
+  // #5128 W2 — a queued execution's command hasn't reached the device yet;
+  // "Queued — device offline" replaces the ambiguous bare "Queued" now that
+  // the offline work queue makes this the common, expected case rather than
+  // a transient in-flight state.
+  queued: { label: 'status.queuedOffline', color: 'bg-muted text-muted-foreground border-border', icon: Clock },
   running: { label: 'status.running', color: 'bg-blue-500/20 text-blue-700 border-blue-500/40', icon: Loader2 },
   cancelling: { label: 'status.cancelling', color: 'bg-warning/15 text-warning border-warning/30', icon: Loader2 },
   completed: { label: 'status.completed', color: 'bg-success/15 text-success border-success/30', icon: CheckCircle },
@@ -27,7 +31,7 @@ export const executionRowStatusConfig: Record<ExecutionStatus, RowEntry> = {
 
 export const executionDetailStatusConfig: Record<ExecutionStatus, DetailEntry> = {
   pending: { label: 'status.pending', color: 'text-muted-foreground', bgColor: 'bg-muted', icon: Clock },
-  queued: { label: 'status.queued', color: 'text-muted-foreground', bgColor: 'bg-muted', icon: Clock },
+  queued: { label: 'status.queuedOffline', color: 'text-muted-foreground', bgColor: 'bg-muted', icon: Clock },
   running: { label: 'status.running', color: 'text-blue-700 dark:text-blue-400', bgColor: 'bg-blue-500/10', icon: Loader2 },
   cancelling: { label: 'status.cancelling', color: 'text-warning', bgColor: 'bg-warning/10', icon: Loader2 },
   completed: { label: 'status.completed', color: 'text-success', bgColor: 'bg-success/10', icon: CheckCircle },

--- a/apps/web/src/lib/i18n/translationCoverage.test.ts
+++ b/apps/web/src/lib/i18n/translationCoverage.test.ts
@@ -476,7 +476,9 @@ const namespaceDuplicateBaselines = {
     // — both spelled identically in German.
     // +1 (2026-09-06): deviceList.tableColumns.type "Type" arrived with the
     // unified-device-list branch; re-measured after merging main.
-    'devices.json': 155,
+    // +1 (#5128 W2): queuedActions.system — "System" is the identical loanword
+    // in German.
+    'devices.json': 156,
     'discovery.json': 26,
     'integrations.json': 43,
     // +1: updateRingList.badges.os — "OS: {{severities}}" is an acronym plus an

--- a/apps/web/src/locales/de-DE/devices.json
+++ b/apps/web/src/locales/de-DE/devices.json
@@ -1857,8 +1857,8 @@
       "alreadyPendingTail": "Tail ist bereits ausstehend",
       "bulkActionFailed": "Massenaktion fehlgeschlagen",
       "bulkAllDecommissioned": "Alle {{total}} ausgewählten Geräte sind bereits entfernt.",
-      "bulkCommandPartialFailed": "Massenbefehl ist teilweise fehlgeschlagen",
-      "bulkCommandSent": "Massenbefehl gesendet",
+      "bulkCommandPartialFailed": "{{action}} an {{count}} Gerät(e) gesendet{{queuedTail}}{{skippedTail}}; {{failed}} fehlgeschlagen: {{failureSummary}}",
+      "bulkCommandSent": "{{action}} an {{count}} Gerät(e) gesendet{{queuedTail}}{{skippedTail}}",
       "bulkDecommissionAllFailed": "Entfernen für alle {{count}} Geräte fehlgeschlagen: {{devices}}",
       "bulkDecommissionFailed": "{{succeeded}} Gerät(e) entfernt; bei {{failed}} fehlgeschlagen: {{devices}}",
       "bulkDecommissioned": "{{count}} Gerät(e) entfernt",
@@ -1897,7 +1897,6 @@
       "networkSkipped_one": "1 Netzwerkgerät übersprungen — diese Aktion gilt nur für Agent-Geräte.",
       "networkSkipped_other": "{{count}} Netzwerkgeräte übersprungen — diese Aktion gilt nur für Agent-Geräte.",
       "networkSkipped": "{{count}} Netzwerkgeräte übersprungen — diese Aktion gilt nur für Agent-Geräte.",
-      "compareNeedsTwo": "Der Vergleich benötigt mindestens 2 Agent-Geräte.",
       "permanentDeleteCancelled": "Endgültiges Löschen abgebrochen",
       "permanentDeleting": "{{hostname}} wird endgültig gelöscht…",
       "permanentlyDeleted": "{{hostname}} endgültig gelöscht",
@@ -1910,7 +1909,10 @@
       "unknownAction": "Unbekannte Aktion",
       "unknownBulkAction": "Unbekannte Massenaktion",
       "wakeSentWatching": "Aufweckbefehl gesendet; Status wird überwacht",
-      "wakeTimeout": "Zeitüberschreitung beim Aufwecken"
+      "wakeTimeout": "Zeitüberschreitung beim Aufwecken",
+      "queuedOfflineTail": ", {{count}} für Offline-Geräte in die Warteschlange gestellt",
+      "runsWhenOnline": "Wird ausgeführt, sobald das Gerät online ist — läuft ab am {{date}}",
+      "runsWhenOnlineNoExpiry": "Wird ausgeführt, sobald das Gerät online ist"
     },
     "tryAgain": "Versuchen Sie es erneut",
     "unknownDevice": "Unbekannt",
@@ -2657,5 +2659,15 @@
       "manufacturer": "Hersteller"
     },
     "identityConflictNote": "Die Kennungen dieser Zeile verweisen auf unterschiedliche Geräte und können so nicht importiert werden — korrigieren Sie die Datei und führen Sie die Vorschau erneut aus. Die unten aufgeführten Kandidaten dienen nur zur Information."
+  },
+  "queuedActions": {
+    "title": "Aktionen in der Warteschlange",
+    "system": "System",
+    "requestedBy": "Angefordert von {{who}}",
+    "expires": "Läuft ab am {{date}}",
+    "cancel": "Abbrechen",
+    "cancelled": "Aktion in der Warteschlange abgebrochen",
+    "cancelFailed": "Abbrechen der Aktion in der Warteschlange fehlgeschlagen",
+    "empty": "Keine ausstehenden Aktionen"
   }
 }

--- a/apps/web/src/locales/de-DE/devices.json
+++ b/apps/web/src/locales/de-DE/devices.json
@@ -2663,11 +2663,13 @@
   "queuedActions": {
     "title": "Aktionen in der Warteschlange",
     "system": "System",
+    "aUser": "ein Benutzer",
     "requestedBy": "Angefordert von {{who}}",
     "expires": "Läuft ab am {{date}}",
     "cancel": "Abbrechen",
     "cancelled": "Aktion in der Warteschlange abgebrochen",
     "cancelFailed": "Abbrechen der Aktion in der Warteschlange fehlgeschlagen",
+    "loadFailed": "Warteschlangenaktionen konnten nicht geladen werden.",
     "empty": "Keine ausstehenden Aktionen"
   }
 }

--- a/apps/web/src/locales/de-DE/scripts.json
+++ b/apps/web/src/locales/de-DE/scripts.json
@@ -690,7 +690,8 @@
       "completedCancelTooLate": "Abgeschlossen — Ihre Abbruchanfrage kam zu spät",
       "failedCancelTooLate": "Fehlgeschlagen — Ihre Abbruchanfrage kam zu spät",
       "timeoutCancelTooLate": "Zeitüberschreitung — Ihre Abbruchanfrage kam zu spät",
-      "cancelFailed": "Abbruch fehlgeschlagen — das Gerät konnte den Prozess nicht stoppen"
+      "cancelFailed": "Abbruch fehlgeschlagen — das Gerät konnte den Prozess nicht stoppen",
+      "queuedOffline": "In Warteschlange — Gerät offline"
     }
   },
   "executionHistory": {
@@ -718,7 +719,8 @@
       "completedCancelTooLate": "Abgeschlossen — Ihre Abbruchanfrage kam zu spät",
       "failedCancelTooLate": "Fehlgeschlagen — Ihre Abbruchanfrage kam zu spät",
       "timeoutCancelTooLate": "Zeitüberschreitung — Ihre Abbruchanfrage kam zu spät",
-      "cancelFailed": "Abbruch fehlgeschlagen — das Gerät konnte den Prozess nicht stoppen"
+      "cancelFailed": "Abbruch fehlgeschlagen — das Gerät konnte den Prozess nicht stoppen",
+      "queuedOffline": "In Warteschlange — Gerät offline"
     },
     "summary": "{{shown}} von {{total}}",
     "headers": {
@@ -927,6 +929,9 @@
       "windows": "Windows",
       "macos": "macOS",
       "linux": "Linux"
+    },
+    "toasts": {
+      "runsWhenOnline": "Wird ausgeführt, sobald das Gerät online ist"
     }
   },
   "secretParameters": {

--- a/apps/web/src/locales/en/devices.json
+++ b/apps/web/src/locales/en/devices.json
@@ -2388,11 +2388,13 @@
   "queuedActions": {
     "title": "Queued actions",
     "system": "System",
+    "aUser": "a user",
     "requestedBy": "Requested by {{who}}",
     "expires": "Expires {{date}}",
     "cancel": "Cancel",
     "cancelled": "Queued action cancelled",
     "cancelFailed": "Failed to cancel queued action",
+    "loadFailed": "Couldn't load queued actions.",
     "empty": "No queued actions"
   },
   "savedViewsMenu": {

--- a/apps/web/src/locales/en/devices.json
+++ b/apps/web/src/locales/en/devices.json
@@ -1861,8 +1861,8 @@
       "alreadyPendingTail": "Already Pending Tail",
       "bulkActionFailed": "Bulk Action Failed",
       "bulkAllDecommissioned": "All {{total}} selected device(s) are already removed.",
-      "bulkCommandPartialFailed": "Bulk Command Partial Failed",
-      "bulkCommandSent": "Bulk Command Sent",
+      "bulkCommandPartialFailed": "{{action}} sent to {{count}} device(s){{queuedTail}}{{skippedTail}}; {{failed}} failed: {{failureSummary}}",
+      "bulkCommandSent": "{{action}} sent to {{count}} device(s){{queuedTail}}{{skippedTail}}",
       "bulkDecommissionAllFailed": "Failed to remove all {{count}} device(s): {{devices}}",
       "bulkDecommissionFailed": "{{succeeded}} device(s) removed; {{failed}} failed: {{devices}}",
       "bulkDecommissioned": "{{count}} device(s) removed",
@@ -1905,7 +1905,10 @@
       "permanentDeleteCancelled": "Permanent Delete Cancelled",
       "permanentDeleting": "Permanently deleting {{hostname}}…",
       "permanentlyDeleted": "{{hostname}} permanently deleted",
+      "queuedOfflineTail": ", {{count}} queued for offline devices",
       "restored": "Restored",
+      "runsWhenOnline": "Runs when the device is online — expires {{date}}",
+      "runsWhenOnlineNoExpiry": "Runs when the device is online",
       "scriptQueueFailed": "Script Queue Failed",
       "scriptQueuedMany": "Script Queued Many",
       "scriptQueuedOne": "Script Queued One",
@@ -2381,6 +2384,16 @@
       "untagged": "Untagged"
     },
     "label": "Quick filters"
+  },
+  "queuedActions": {
+    "title": "Queued actions",
+    "system": "System",
+    "requestedBy": "Requested by {{who}}",
+    "expires": "Expires {{date}}",
+    "cancel": "Cancel",
+    "cancelled": "Queued action cancelled",
+    "cancelFailed": "Failed to cancel queued action",
+    "empty": "No queued actions"
   },
   "savedViewsMenu": {
     "applyTitle": "Apply \"{{name}}\"",

--- a/apps/web/src/locales/en/scripts.json
+++ b/apps/web/src/locales/en/scripts.json
@@ -685,6 +685,7 @@
       "failed": "Failed",
       "timeout": "Timeout",
       "queued": "Queued",
+      "queuedOffline": "Queued — device offline",
       "cancelling": "Stopping…",
       "cancelled": "Cancelled",
       "completedCancelTooLate": "Completed — your stop request arrived too late",
@@ -713,6 +714,7 @@
       "failed": "Failed",
       "timeout": "Timeout",
       "queued": "Queued",
+      "queuedOffline": "Queued — device offline",
       "cancelling": "Stopping…",
       "cancelled": "Cancelled",
       "completedCancelTooLate": "Completed — your stop request arrived too late",
@@ -856,6 +858,9 @@
     "errors": {
       "selectDevice": "Please select at least one device",
       "executionFailed": "Execution failed"
+    },
+    "toasts": {
+      "runsWhenOnline": "Runs when the device is online"
     },
     "title": "Execute Script",
     "fields": {

--- a/apps/web/src/locales/es-419/devices.json
+++ b/apps/web/src/locales/es-419/devices.json
@@ -1856,8 +1856,8 @@
       "alreadyPendingTail": "Cola ya pendiente",
       "bulkActionFailed": "Error en la acción masiva",
       "bulkAllDecommissioned": "Los {{total}} dispositivo(s) seleccionados ya están quitados.",
-      "bulkCommandPartialFailed": "Error parcial del comando masivo",
-      "bulkCommandSent": "Comando masivo enviado",
+      "bulkCommandPartialFailed": "{{action}} enviado a {{count}} dispositivo(s){{queuedTail}}{{skippedTail}}; {{failed}} fallaron: {{failureSummary}}",
+      "bulkCommandSent": "{{action}} enviado a {{count}} dispositivo(s){{queuedTail}}{{skippedTail}}",
       "bulkDecommissionAllFailed": "No se pudo quitar ninguno de los {{count}} dispositivos: {{devices}}",
       "bulkDecommissionFailed": "{{succeeded}} dispositivo(s) quitado(s); {{failed}} con error: {{devices}}",
       "bulkDecommissioned": "{{count}} dispositivo(s) quitado(s)",
@@ -1896,7 +1896,6 @@
       "networkSkipped_one": "1 dispositivo de red omitido — esta acción solo aplica a dispositivos con agente.",
       "networkSkipped_other": "{{count}} dispositivos de red omitidos — esta acción solo aplica a dispositivos con agente.",
       "networkSkipped": "{{count}} dispositivos de red omitidos — esta acción solo aplica a dispositivos con agente.",
-      "compareNeedsTwo": "La comparación requiere al menos 2 dispositivos con agente.",
       "permanentDeleteCancelled": "Eliminación permanente cancelada",
       "permanentDeleting": "Eliminando permanentemente {{hostname}}…",
       "permanentlyDeleted": "{{hostname}} eliminado permanentemente",
@@ -1909,7 +1908,10 @@
       "unknownAction": "Acción desconocida",
       "unknownBulkAction": "Acción masiva desconocida",
       "wakeSentWatching": "Comando de encendido enviado; supervisando",
-      "wakeTimeout": "Tiempo de espera para despertar"
+      "wakeTimeout": "Tiempo de espera para despertar",
+      "queuedOfflineTail": ", {{count}} en cola para dispositivos sin conexión",
+      "runsWhenOnline": "Se ejecutará cuando el dispositivo esté en línea — vence el {{date}}",
+      "runsWhenOnlineNoExpiry": "Se ejecutará cuando el dispositivo esté en línea"
     },
     "tryAgain": "Intentar otra vez",
     "unknownDevice": "Desconocido",
@@ -2657,5 +2659,15 @@
       "manufacturer": "Fabricante"
     },
     "identityConflictNote": "Los identificadores de esta fila apuntan a dispositivos diferentes y no se puede importar tal cual — corrija el archivo y vuelva a ejecutar la vista previa. Los candidatos a continuación se muestran solo como referencia."
+  },
+  "queuedActions": {
+    "title": "Acciones en cola",
+    "system": "Sistema",
+    "requestedBy": "Solicitado por {{who}}",
+    "expires": "Vence el {{date}}",
+    "cancel": "Cancelar",
+    "cancelled": "Acción en cola cancelada",
+    "cancelFailed": "No se pudo cancelar la acción en cola",
+    "empty": "No hay acciones en cola"
   }
 }

--- a/apps/web/src/locales/es-419/devices.json
+++ b/apps/web/src/locales/es-419/devices.json
@@ -2663,11 +2663,13 @@
   "queuedActions": {
     "title": "Acciones en cola",
     "system": "Sistema",
+    "aUser": "un usuario",
     "requestedBy": "Solicitado por {{who}}",
     "expires": "Vence el {{date}}",
     "cancel": "Cancelar",
     "cancelled": "Acción en cola cancelada",
     "cancelFailed": "No se pudo cancelar la acción en cola",
+    "loadFailed": "No se pudieron cargar las acciones en cola.",
     "empty": "No hay acciones en cola"
   }
 }

--- a/apps/web/src/locales/es-419/scripts.json
+++ b/apps/web/src/locales/es-419/scripts.json
@@ -690,7 +690,8 @@
       "completedCancelTooLate": "Completado: tu solicitud de detención llegó demasiado tarde",
       "failedCancelTooLate": "Fallido: tu solicitud de detención llegó demasiado tarde",
       "timeoutCancelTooLate": "Tiempo de espera agotado: tu solicitud de detención llegó demasiado tarde",
-      "cancelFailed": "Error al detener: el dispositivo no pudo detener el proceso"
+      "cancelFailed": "Error al detener: el dispositivo no pudo detener el proceso",
+      "queuedOffline": "En cola — dispositivo sin conexión"
     }
   },
   "executionHistory": {
@@ -718,7 +719,8 @@
       "completedCancelTooLate": "Completado: tu solicitud de detención llegó demasiado tarde",
       "failedCancelTooLate": "Fallido: tu solicitud de detención llegó demasiado tarde",
       "timeoutCancelTooLate": "Tiempo de espera agotado: tu solicitud de detención llegó demasiado tarde",
-      "cancelFailed": "Error al detener: el dispositivo no pudo detener el proceso"
+      "cancelFailed": "Error al detener: el dispositivo no pudo detener el proceso",
+      "queuedOffline": "En cola — dispositivo sin conexión"
     },
     "summary": "{{shown}} de {{total}}",
     "headers": {
@@ -927,6 +929,9 @@
       "windows": "Windows",
       "macos": "macOS",
       "linux": "Linux"
+    },
+    "toasts": {
+      "runsWhenOnline": "Se ejecutará cuando el dispositivo esté en línea"
     }
   },
   "secretParameters": {

--- a/apps/web/src/locales/fr-CA/devices.json
+++ b/apps/web/src/locales/fr-CA/devices.json
@@ -2663,11 +2663,13 @@
   "queuedActions": {
     "title": "Actions en file d'attente",
     "system": "Système",
+    "aUser": "un utilisateur",
     "requestedBy": "Demandé par {{who}}",
     "expires": "Expire le {{date}}",
     "cancel": "Annuler",
     "cancelled": "Action en file d'attente annulée",
     "cancelFailed": "Échec de l'annulation de l'action en file d'attente",
+    "loadFailed": "Impossible de charger les actions en file d'attente.",
     "empty": "Aucune action en file d'attente"
   }
 }

--- a/apps/web/src/locales/fr-CA/devices.json
+++ b/apps/web/src/locales/fr-CA/devices.json
@@ -1856,8 +1856,8 @@
       "alreadyPendingTail": "Déjà en attente de Tail",
       "bulkActionFailed": "Échec de l’action en masse",
       "bulkAllDecommissioned": "Les {{total}} appareil(s) sélectionnés sont déjà retirés.",
-      "bulkCommandPartialFailed": "Commandement de masse partiellement échoué",
-      "bulkCommandSent": "Commandement en vrac envoyé",
+      "bulkCommandPartialFailed": "{{action}} envoyé à {{count}} appareil(s){{queuedTail}}{{skippedTail}} ; {{failed}} en échec : {{failureSummary}}",
+      "bulkCommandSent": "{{action}} envoyé à {{count}} appareil(s){{queuedTail}}{{skippedTail}}",
       "bulkDecommissionAllFailed": "Échec du retrait des {{count}} appareil(s) : {{devices}}",
       "bulkDecommissionFailed": "{{succeeded}} appareil(s) retiré(s) ; {{failed}} échoué(s) : {{devices}}",
       "bulkDecommissioned": "{{count}} appareil(s) retiré(s)",
@@ -1896,7 +1896,6 @@
       "networkSkipped_one": "1 appareil réseau ignoré — cette action s’applique uniquement aux appareils avec agent.",
       "networkSkipped_other": "{{count}} appareils réseau ignorés — cette action s’applique uniquement aux appareils avec agent.",
       "networkSkipped": "{{count}} appareils réseau ignorés — cette action s’applique uniquement aux appareils avec agent.",
-      "compareNeedsTwo": "La comparaison nécessite au moins 2 appareils avec agent.",
       "permanentDeleteCancelled": "Suppression permanente annulée",
       "permanentDeleting": "Suppression permanente de {{hostname}} en cours…",
       "permanentlyDeleted": "{{hostname}} supprimé définitivement",
@@ -1909,7 +1908,10 @@
       "unknownAction": "Action inconnue",
       "unknownBulkAction": "Action en vrac inconnue",
       "wakeSentWatching": "Commande de réveil envoyée ; surveillance en cours",
-      "wakeTimeout": "Temps d’arrêt du réveil"
+      "wakeTimeout": "Temps d’arrêt du réveil",
+      "queuedOfflineTail": ", {{count}} en file d'attente pour des appareils hors ligne",
+      "runsWhenOnline": "S'exécute quand l'appareil est en ligne — expire le {{date}}",
+      "runsWhenOnlineNoExpiry": "S'exécute quand l'appareil est en ligne"
     },
     "tryAgain": "Réessayer",
     "unknownDevice": "Inconnu",
@@ -2657,5 +2659,15 @@
       "manufacturer": "Fabricant"
     },
     "identityConflictNote": "Les identifiants de cette ligne pointent vers des appareils différents et ne peuvent pas être importés tels quels — corrigez le fichier et relancez l'aperçu. Les candidats ci-dessous sont indiqués à titre de référence uniquement."
+  },
+  "queuedActions": {
+    "title": "Actions en file d'attente",
+    "system": "Système",
+    "requestedBy": "Demandé par {{who}}",
+    "expires": "Expire le {{date}}",
+    "cancel": "Annuler",
+    "cancelled": "Action en file d'attente annulée",
+    "cancelFailed": "Échec de l'annulation de l'action en file d'attente",
+    "empty": "Aucune action en file d'attente"
   }
 }

--- a/apps/web/src/locales/fr-CA/scripts.json
+++ b/apps/web/src/locales/fr-CA/scripts.json
@@ -690,7 +690,8 @@
       "completedCancelTooLate": "Terminée — votre demande d'arrêt est arrivée trop tard",
       "failedCancelTooLate": "Échec — votre demande d'arrêt est arrivée trop tard",
       "timeoutCancelTooLate": "Délai dépassé — votre demande d'arrêt est arrivée trop tard",
-      "cancelFailed": "Échec de l'arrêt — l'appareil n'a pas pu arrêter le processus"
+      "cancelFailed": "Échec de l'arrêt — l'appareil n'a pas pu arrêter le processus",
+      "queuedOffline": "En file d'attente — appareil hors ligne"
     }
   },
   "executionHistory": {
@@ -718,7 +719,8 @@
       "completedCancelTooLate": "Terminée — votre demande d'arrêt est arrivée trop tard",
       "failedCancelTooLate": "Échec — votre demande d'arrêt est arrivée trop tard",
       "timeoutCancelTooLate": "Délai dépassé — votre demande d'arrêt est arrivée trop tard",
-      "cancelFailed": "Échec de l'arrêt — l'appareil n'a pas pu arrêter le processus"
+      "cancelFailed": "Échec de l'arrêt — l'appareil n'a pas pu arrêter le processus",
+      "queuedOffline": "En file d'attente — appareil hors ligne"
     },
     "summary": "{{shown}} sur {{total}}",
     "headers": {
@@ -927,6 +929,9 @@
       "windows": "Windows",
       "macos": "macOS",
       "linux": "Linux"
+    },
+    "toasts": {
+      "runsWhenOnline": "S'exécute quand l'appareil est en ligne"
     }
   },
   "secretParameters": {

--- a/apps/web/src/locales/fr-FR/devices.json
+++ b/apps/web/src/locales/fr-FR/devices.json
@@ -2663,11 +2663,13 @@
   "queuedActions": {
     "title": "Actions en file d'attente",
     "system": "Système",
+    "aUser": "un utilisateur",
     "requestedBy": "Demandé par {{who}}",
     "expires": "Expire le {{date}}",
     "cancel": "Annuler",
     "cancelled": "Action en file d'attente annulée",
     "cancelFailed": "Échec de l'annulation de l'action en file d'attente",
+    "loadFailed": "Impossible de charger les actions en file d'attente.",
     "empty": "Aucune action en file d'attente"
   }
 }

--- a/apps/web/src/locales/fr-FR/devices.json
+++ b/apps/web/src/locales/fr-FR/devices.json
@@ -1856,8 +1856,8 @@
       "alreadyPendingTail": "Déjà en attente de Tail",
       "bulkActionFailed": "Échec de l’action en masse",
       "bulkAllDecommissioned": "Les {{total}} appareil(s) sélectionnés sont déjà retirés.",
-      "bulkCommandPartialFailed": "Commandement de masse partiellement échoué",
-      "bulkCommandSent": "Commandement en vrac envoyé",
+      "bulkCommandPartialFailed": "{{action}} envoyé à {{count}} appareil(s){{queuedTail}}{{skippedTail}} ; {{failed}} en échec : {{failureSummary}}",
+      "bulkCommandSent": "{{action}} envoyé à {{count}} appareil(s){{queuedTail}}{{skippedTail}}",
       "bulkDecommissionAllFailed": "Échec du retrait des {{count}} appareil(s) : {{devices}}",
       "bulkDecommissionFailed": "{{succeeded}} appareil(s) retiré(s) ; {{failed}} échoué(s) : {{devices}}",
       "bulkDecommissioned": "{{count}} appareil(s) retiré(s)",
@@ -1896,7 +1896,6 @@
       "networkSkipped_one": "1 appareil réseau ignoré — cette action s’applique uniquement aux appareils avec agent.",
       "networkSkipped_other": "{{count}} appareils réseau ignorés — cette action s’applique uniquement aux appareils avec agent.",
       "networkSkipped": "{{count}} appareils réseau ignorés — cette action s’applique uniquement aux appareils avec agent.",
-      "compareNeedsTwo": "La comparaison nécessite au moins 2 appareils avec agent.",
       "permanentDeleteCancelled": "Suppression permanente annulée",
       "permanentDeleting": "Suppression permanente de {{hostname}} en cours…",
       "permanentlyDeleted": "{{hostname}} supprimé définitivement",
@@ -1909,7 +1908,10 @@
       "unknownAction": "Action inconnue",
       "unknownBulkAction": "Action en vrac inconnue",
       "wakeSentWatching": "Commande de réveil envoyée ; surveillance en cours",
-      "wakeTimeout": "Temps d’arrêt du réveil"
+      "wakeTimeout": "Temps d’arrêt du réveil",
+      "queuedOfflineTail": ", {{count}} en file d'attente pour des appareils hors ligne",
+      "runsWhenOnline": "S'exécute quand l'appareil est en ligne — expire le {{date}}",
+      "runsWhenOnlineNoExpiry": "S'exécute quand l'appareil est en ligne"
     },
     "tryAgain": "Réessayer",
     "unknownDevice": "Inconnu",
@@ -2657,5 +2659,15 @@
       "manufacturer": "Fabricant"
     },
     "identityConflictNote": "Les identifiants de cette ligne pointent vers des appareils différents et ne peuvent pas être importés tels quels — corrigez le fichier et relancez l'aperçu. Les candidats ci-dessous sont indiqués à titre de référence uniquement."
+  },
+  "queuedActions": {
+    "title": "Actions en file d'attente",
+    "system": "Système",
+    "requestedBy": "Demandé par {{who}}",
+    "expires": "Expire le {{date}}",
+    "cancel": "Annuler",
+    "cancelled": "Action en file d'attente annulée",
+    "cancelFailed": "Échec de l'annulation de l'action en file d'attente",
+    "empty": "Aucune action en file d'attente"
   }
 }

--- a/apps/web/src/locales/fr-FR/scripts.json
+++ b/apps/web/src/locales/fr-FR/scripts.json
@@ -690,7 +690,8 @@
       "completedCancelTooLate": "Terminée — votre demande d'arrêt est arrivée trop tard",
       "failedCancelTooLate": "Échec — votre demande d'arrêt est arrivée trop tard",
       "timeoutCancelTooLate": "Délai dépassé — votre demande d'arrêt est arrivée trop tard",
-      "cancelFailed": "Échec de l'arrêt — l'appareil n'a pas pu arrêter le processus"
+      "cancelFailed": "Échec de l'arrêt — l'appareil n'a pas pu arrêter le processus",
+      "queuedOffline": "En file d'attente — appareil hors ligne"
     }
   },
   "executionHistory": {
@@ -718,7 +719,8 @@
       "completedCancelTooLate": "Terminée — votre demande d'arrêt est arrivée trop tard",
       "failedCancelTooLate": "Échec — votre demande d'arrêt est arrivée trop tard",
       "timeoutCancelTooLate": "Délai dépassé — votre demande d'arrêt est arrivée trop tard",
-      "cancelFailed": "Échec de l'arrêt — l'appareil n'a pas pu arrêter le processus"
+      "cancelFailed": "Échec de l'arrêt — l'appareil n'a pas pu arrêter le processus",
+      "queuedOffline": "En file d'attente — appareil hors ligne"
     },
     "summary": "{{shown}} sur {{total}}",
     "headers": {
@@ -927,6 +929,9 @@
       "windows": "Windows",
       "macos": "macOS",
       "linux": "Linux"
+    },
+    "toasts": {
+      "runsWhenOnline": "S'exécute quand l'appareil est en ligne"
     }
   },
   "secretParameters": {

--- a/apps/web/src/locales/it-IT/devices.json
+++ b/apps/web/src/locales/it-IT/devices.json
@@ -2663,11 +2663,13 @@
   "queuedActions": {
     "title": "Azioni in coda",
     "system": "Sistema",
+    "aUser": "un utente",
     "requestedBy": "Richiesto da {{who}}",
     "expires": "Scade il {{date}}",
     "cancel": "Annulla",
     "cancelled": "Azione in coda annullata",
     "cancelFailed": "Impossibile annullare l'azione in coda",
+    "loadFailed": "Impossibile caricare le azioni in coda.",
     "empty": "Nessuna azione in coda"
   }
 }

--- a/apps/web/src/locales/it-IT/devices.json
+++ b/apps/web/src/locales/it-IT/devices.json
@@ -1860,8 +1860,8 @@
       "alreadyPendingTail": "Già in sospeso",
       "bulkActionFailed": "Azione in blocco non riuscita",
       "bulkAllDecommissioned": "Tutti i {{total}} dispositivi selezionati sono già rimossi.",
-      "bulkCommandPartialFailed": "Comando in blocco parzialmente non riuscito",
-      "bulkCommandSent": "Comando in blocco inviato",
+      "bulkCommandPartialFailed": "{{action}} inviato a {{count}} dispositivo/i{{queuedTail}}{{skippedTail}}; {{failed}} non riusciti: {{failureSummary}}",
+      "bulkCommandSent": "{{action}} inviato a {{count}} dispositivo/i{{queuedTail}}{{skippedTail}}",
       "bulkDecommissionAllFailed": "Rimozione non riuscita per tutti i {{count}} dispositivi: {{devices}}",
       "bulkDecommissionFailed": "{{succeeded}} dispositivo(i) rimosso(i); {{failed}} non riusciti: {{devices}}",
       "bulkDecommissioned": "{{count}} dispositivo(i) rimosso(i)",
@@ -1912,7 +1912,10 @@
       "unknownAction": "Azione sconosciuta",
       "unknownBulkAction": "Azione in blocco sconosciuta",
       "wakeSentWatching": "Richiesta di riattivazione inviata, monitoraggio in corso",
-      "wakeTimeout": "Timeout della riattivazione"
+      "wakeTimeout": "Timeout della riattivazione",
+      "queuedOfflineTail": ", {{count}} in coda per dispositivi offline",
+      "runsWhenOnline": "Viene eseguito quando il dispositivo è online — scade il {{date}}",
+      "runsWhenOnlineNoExpiry": "Viene eseguito quando il dispositivo è online"
     },
     "tryAgain": "Prova di nuovo",
     "unknownDevice": "Sconosciuto",
@@ -2656,5 +2659,15 @@
       "manufacturer": "Produttore"
     },
     "identityConflictNote": "Gli identificatori di questa riga puntano a dispositivi diversi e non possono essere importati così come sono — correggi il file e riesegui l'anteprima. I candidati qui sotto sono mostrati solo come riferimento."
+  },
+  "queuedActions": {
+    "title": "Azioni in coda",
+    "system": "Sistema",
+    "requestedBy": "Richiesto da {{who}}",
+    "expires": "Scade il {{date}}",
+    "cancel": "Annulla",
+    "cancelled": "Azione in coda annullata",
+    "cancelFailed": "Impossibile annullare l'azione in coda",
+    "empty": "Nessuna azione in coda"
   }
 }

--- a/apps/web/src/locales/it-IT/scripts.json
+++ b/apps/web/src/locales/it-IT/scripts.json
@@ -690,7 +690,8 @@
       "completedCancelTooLate": "Completato — la richiesta di interruzione è arrivata troppo tardi",
       "failedCancelTooLate": "Non riuscito — la richiesta di interruzione è arrivata troppo tardi",
       "timeoutCancelTooLate": "Timeout — la richiesta di interruzione è arrivata troppo tardi",
-      "cancelFailed": "Interruzione non riuscita — il dispositivo non è riuscito a interrompere il processo"
+      "cancelFailed": "Interruzione non riuscita — il dispositivo non è riuscito a interrompere il processo",
+      "queuedOffline": "In coda — dispositivo offline"
     }
   },
   "executionHistory": {
@@ -718,7 +719,8 @@
       "completedCancelTooLate": "Completato — la richiesta di interruzione è arrivata troppo tardi",
       "failedCancelTooLate": "Non riuscito — la richiesta di interruzione è arrivata troppo tardi",
       "timeoutCancelTooLate": "Timeout — la richiesta di interruzione è arrivata troppo tardi",
-      "cancelFailed": "Interruzione non riuscita — il dispositivo non è riuscito a interrompere il processo"
+      "cancelFailed": "Interruzione non riuscita — il dispositivo non è riuscito a interrompere il processo",
+      "queuedOffline": "In coda — dispositivo offline"
     },
     "summary": "{{shown}} di {{total}}",
     "headers": {
@@ -927,6 +929,9 @@
       "windows": "Windows",
       "macos": "macOS",
       "linux": "Linux"
+    },
+    "toasts": {
+      "runsWhenOnline": "Viene eseguito quando il dispositivo è online"
     }
   },
   "secretParameters": {

--- a/apps/web/src/locales/pt-BR/devices.json
+++ b/apps/web/src/locales/pt-BR/devices.json
@@ -1860,8 +1860,8 @@
       "alreadyPendingTail": "Já estava pendente",
       "bulkActionFailed": "Falha na ação em massa",
       "bulkAllDecommissioned": "Todos os {{total}} dispositivos selecionados já estão removidos.",
-      "bulkCommandPartialFailed": "Falha parcial no comando em massa",
-      "bulkCommandSent": "Comando em massa enviado",
+      "bulkCommandPartialFailed": "{{action}} enviado para {{count}} dispositivo(s){{queuedTail}}{{skippedTail}}; {{failed}} falharam: {{failureSummary}}",
+      "bulkCommandSent": "{{action}} enviado para {{count}} dispositivo(s){{queuedTail}}{{skippedTail}}",
       "bulkDecommissionAllFailed": "Falha ao remover todos os {{count}} dispositivos: {{devices}}",
       "bulkDecommissionFailed": "{{succeeded}} dispositivo(s) removido(s); {{failed}} com falha: {{devices}}",
       "bulkDecommissioned": "{{count}} dispositivo(s) removido(s)",
@@ -1900,7 +1900,6 @@
       "networkSkipped_one": "1 dispositivo de rede ignorado — esta ação se aplica apenas a dispositivos com agente.",
       "networkSkipped_other": "{{count}} dispositivos de rede ignorados — esta ação se aplica apenas a dispositivos com agente.",
       "networkSkipped": "{{count}} dispositivos de rede ignorados — esta ação se aplica apenas a dispositivos com agente.",
-      "compareNeedsTwo": "A comparação requer pelo menos 2 dispositivos com agente.",
       "permanentDeleteCancelled": "Exclusão permanente cancelada",
       "permanentDeleting": "Excluindo permanentemente {{hostname}}…",
       "permanentlyDeleted": "{{hostname}} excluído permanentemente",
@@ -1913,7 +1912,10 @@
       "unknownAction": "Ação desconhecida",
       "unknownBulkAction": "Ação em massa desconhecida",
       "wakeSentWatching": "Comando de despertar enviado; aguardando",
-      "wakeTimeout": "Tempo limite do despertar excedido"
+      "wakeTimeout": "Tempo limite do despertar excedido",
+      "queuedOfflineTail": ", {{count}} na fila para dispositivos offline",
+      "runsWhenOnline": "Executa quando o dispositivo estiver online — expira em {{date}}",
+      "runsWhenOnlineNoExpiry": "Executa quando o dispositivo estiver online"
     },
     "tryAgain": "Tentar novamente",
     "unknownDevice": "Desconhecido",
@@ -2657,5 +2659,15 @@
       "manufacturer": "Fabricante"
     },
     "identityConflictNote": "Os identificadores desta linha apontam para dispositivos diferentes e não podem ser importados como estão — corrija o arquivo e execute a pré-visualização novamente. Os candidatos abaixo são mostrados apenas como referência."
+  },
+  "queuedActions": {
+    "title": "Ações na fila",
+    "system": "Sistema",
+    "requestedBy": "Solicitado por {{who}}",
+    "expires": "Expira em {{date}}",
+    "cancel": "Cancelar",
+    "cancelled": "Ação na fila cancelada",
+    "cancelFailed": "Falha ao cancelar a ação na fila",
+    "empty": "Nenhuma ação na fila"
   }
 }

--- a/apps/web/src/locales/pt-BR/devices.json
+++ b/apps/web/src/locales/pt-BR/devices.json
@@ -2663,11 +2663,13 @@
   "queuedActions": {
     "title": "Ações na fila",
     "system": "Sistema",
+    "aUser": "um usuário",
     "requestedBy": "Solicitado por {{who}}",
     "expires": "Expira em {{date}}",
     "cancel": "Cancelar",
     "cancelled": "Ação na fila cancelada",
     "cancelFailed": "Falha ao cancelar a ação na fila",
+    "loadFailed": "Não foi possível carregar as ações na fila.",
     "empty": "Nenhuma ação na fila"
   }
 }

--- a/apps/web/src/locales/pt-BR/scripts.json
+++ b/apps/web/src/locales/pt-BR/scripts.json
@@ -690,7 +690,8 @@
       "completedCancelTooLate": "Concluído — sua solicitação de interrupção chegou tarde demais",
       "failedCancelTooLate": "Falha — sua solicitação de interrupção chegou tarde demais",
       "timeoutCancelTooLate": "Tempo limite — sua solicitação de interrupção chegou tarde demais",
-      "cancelFailed": "Falha ao interromper — o dispositivo não conseguiu interromper o processo"
+      "cancelFailed": "Falha ao interromper — o dispositivo não conseguiu interromper o processo",
+      "queuedOffline": "Na fila — dispositivo offline"
     }
   },
   "executionHistory": {
@@ -718,7 +719,8 @@
       "completedCancelTooLate": "Concluído — sua solicitação de interrupção chegou tarde demais",
       "failedCancelTooLate": "Falha — sua solicitação de interrupção chegou tarde demais",
       "timeoutCancelTooLate": "Tempo limite — sua solicitação de interrupção chegou tarde demais",
-      "cancelFailed": "Falha ao interromper — o dispositivo não conseguiu interromper o processo"
+      "cancelFailed": "Falha ao interromper — o dispositivo não conseguiu interromper o processo",
+      "queuedOffline": "Na fila — dispositivo offline"
     },
     "summary": "{{shown}} de {{total}}",
     "headers": {
@@ -927,6 +929,9 @@
       "windows": "Windows",
       "macos": "macOS",
       "linux": "Linux"
+    },
+    "toasts": {
+      "runsWhenOnline": "Executa quando o dispositivo estiver online"
     }
   },
   "secretParameters": {

--- a/apps/web/src/locales/tr-TR/devices.json
+++ b/apps/web/src/locales/tr-TR/devices.json
@@ -2663,11 +2663,13 @@
   "queuedActions": {
     "title": "Sıradaki eylemler",
     "system": "Sistem",
+    "aUser": "bir kullanıcı",
     "requestedBy": "{{who}} tarafından istendi",
     "expires": "Son geçerlilik: {{date}}",
     "cancel": "İptal",
     "cancelled": "Sıradaki eylem iptal edildi",
     "cancelFailed": "Sıradaki eylem iptal edilemedi",
+    "loadFailed": "Sıradaki eylemler yüklenemedi.",
     "empty": "Sıraya alınmış eylem yok"
   }
 }

--- a/apps/web/src/locales/tr-TR/devices.json
+++ b/apps/web/src/locales/tr-TR/devices.json
@@ -1860,8 +1860,8 @@
       "alreadyPendingTail": "Zaten Bekleyen Kuyruk",
       "bulkActionFailed": "Toplu İşlem Başarısız Oldu",
       "bulkAllDecommissioned": "Seçilen tüm {{total}} cihaz zaten çıkarılmış.",
-      "bulkCommandPartialFailed": "Toplu Komut Kısmi Başarısız",
-      "bulkCommandSent": "Toplu Komut Gönderildi",
+      "bulkCommandPartialFailed": "{{action}}, {{count}} cihaza gönderildi{{queuedTail}}{{skippedTail}}; {{failed}} başarısız oldu: {{failureSummary}}",
+      "bulkCommandSent": "{{action}}, {{count}} cihaza gönderildi{{queuedTail}}{{skippedTail}}",
       "bulkDecommissionAllFailed": "Tüm {{count}} cihaz çıkarılamadı: {{devices}}",
       "bulkDecommissionFailed": "{{succeeded}} cihaz çıkarıldı; {{failed}} başarısız: {{devices}}",
       "bulkDecommissioned": "{{count}} cihaz çıkarıldı",
@@ -1900,7 +1900,6 @@
       "networkSkipped_one": "1 ağ cihazı atlandı — bu işlem yalnızca ajanlı cihazlar için geçerlidir.",
       "networkSkipped_other": "{{count}} ağ cihazı atlandı — bu işlem yalnızca ajanlı cihazlar için geçerlidir.",
       "networkSkipped": "{{count}} ağ cihazı atlandı — bu işlem yalnızca ajanlı cihazlar için geçerlidir.",
-      "compareNeedsTwo": "Karşılaştırma en az 2 aracı cihaza ihtiyaç duyar.",
       "permanentDeleteCancelled": "Kalıcı Silme İptal Edildi",
       "permanentDeleting": "{{hostname}} kalıcı olarak siliniyor…",
       "permanentlyDeleted": "{{hostname}} kalıcı olarak silindi",
@@ -1913,7 +1912,10 @@
       "unknownAction": "Bilinmeyen Eylem",
       "unknownBulkAction": "Bilinmeyen Toplu İşlem",
       "wakeSentWatching": "Uyandırma İzlemeye Gönderildi",
-      "wakeTimeout": "Uyanma Zaman Aşımı"
+      "wakeTimeout": "Uyanma Zaman Aşımı",
+      "queuedOfflineTail": ", {{count}} çevrimdışı cihaz için sıraya alındı",
+      "runsWhenOnline": "Cihaz çevrimiçi olduğunda çalışır — son geçerlilik: {{date}}",
+      "runsWhenOnlineNoExpiry": "Cihaz çevrimiçi olduğunda çalışır"
     },
     "tryAgain": "Tekrar deneyin",
     "unknownDevice": "Bilinmiyor",
@@ -2657,5 +2659,15 @@
       "manufacturer": "Üretici"
     },
     "identityConflictNote": "Bu satırın tanımlayıcıları farklı cihazları işaret ediyor ve olduğu gibi içe aktarılamaz — dosyayı düzeltin ve önizlemeyi yeniden çalıştırın. Aşağıdaki adaylar yalnızca referans için gösterilmektedir."
+  },
+  "queuedActions": {
+    "title": "Sıradaki eylemler",
+    "system": "Sistem",
+    "requestedBy": "{{who}} tarafından istendi",
+    "expires": "Son geçerlilik: {{date}}",
+    "cancel": "İptal",
+    "cancelled": "Sıradaki eylem iptal edildi",
+    "cancelFailed": "Sıradaki eylem iptal edilemedi",
+    "empty": "Sıraya alınmış eylem yok"
   }
 }

--- a/apps/web/src/locales/tr-TR/scripts.json
+++ b/apps/web/src/locales/tr-TR/scripts.json
@@ -690,7 +690,8 @@
       "completedCancelTooLate": "Tamamlandı — durdurma isteğiniz çok geç geldi",
       "failedCancelTooLate": "Başarısız — durdurma isteğiniz çok geç geldi",
       "timeoutCancelTooLate": "Zaman aşımına uğradı — durdurma isteğiniz çok geç geldi",
-      "cancelFailed": "Durdurma başarısız — cihaz işlemi durduramadı"
+      "cancelFailed": "Durdurma başarısız — cihaz işlemi durduramadı",
+      "queuedOffline": "Sırada — cihaz çevrimdışı"
     }
   },
   "executionHistory": {
@@ -718,7 +719,8 @@
       "completedCancelTooLate": "Tamamlandı — durdurma isteğiniz çok geç geldi",
       "failedCancelTooLate": "Başarısız — durdurma isteğiniz çok geç geldi",
       "timeoutCancelTooLate": "Zaman aşımına uğradı — durdurma isteğiniz çok geç geldi",
-      "cancelFailed": "Durdurma başarısız — cihaz işlemi durduramadı"
+      "cancelFailed": "Durdurma başarısız — cihaz işlemi durduramadı",
+      "queuedOffline": "Sırada — cihaz çevrimdışı"
     },
     "summary": "{{shown}} / {{total}}",
     "headers": {
@@ -927,6 +929,9 @@
       "windows": "Windows",
       "macos": "macOS",
       "linux": "Linux"
+    },
+    "toasts": {
+      "runsWhenOnline": "Cihaz çevrimiçi olduğunda çalışır"
     }
   },
   "secretParameters": {

--- a/apps/web/src/services/deviceActions.ts
+++ b/apps/web/src/services/deviceActions.ts
@@ -8,6 +8,10 @@ export interface CommandResult {
   type: string;
   status: string;
   createdAt: string;
+  // #5128 W2 — present on the single-command POST response: how the command
+  // was handed over, and (for a queued one) when it expires undelivered.
+  delivery?: 'delivered' | 'queued_offline' | 'queued_live';
+  deliverBy?: string | null;
 }
 
 export type BulkCommandFailureCode =
@@ -33,6 +37,9 @@ export interface BulkCommandResponse {
   failed: BulkCommandFailed[];
   // Present for refresh_inventory dedup; older API responses may omit it.
   skipped?: BulkCommandSkipped[];
+  // #5128 W2 — device IDs whose command was queued for the device's next
+  // reconnect rather than delivered immediately (subset of `commands`).
+  queuedOffline?: string[];
 }
 
 /**

--- a/packages/shared/src/types/scriptAdmission.ts
+++ b/packages/shared/src/types/scriptAdmission.ts
@@ -5,6 +5,9 @@ export type ScriptTargetAdmission = {
   executionId?: string;
   commandId?: string;
   batchId?: string;
+  // #5128 W2 — only set on `admitted` targets: whether the command reached
+  // the agent immediately or was queued for the device's next reconnect.
+  delivery?: 'delivered' | 'queued_offline';
 };
 
 export type ScriptAdmissionResult = {


### PR DESCRIPTION
Closes #5133

## Summary

Wave 2 of the offline work queue feature (design doc §F/§H/§I, plan "Wave 2"). Builds on W01 (#5145, merged).

**2.1 — Admission `delivery`**
- `ScriptTargetAdmission.delivery?: 'delivered' | 'queued_offline'` (packages/shared)
- Set in `scriptExecution.ts` from `dispatchScriptToDevice`'s own `delivered` outcome
- OpenAPI `ScriptAdmissionTarget.properties.delivery` enum added

**2.2 — Device page "Queued actions" section**
- New `DeviceQueuedActions.tsx`: `GET /devices/:id/commands?status=pending&limit=50`, renders type/requester/expiry rows, Cancel via `runAction` → `POST .../cancel`
- Hidden when empty; 401 swallowed (auth redirect owns it); reloads the list on a 409 (agent claimed the row between load and click) instead of leaving a dead Cancel button
- Mounted in `DeviceDetails.tsx` for non-decommissioned devices

**2.3 — Uniform "queued — device offline" copy**
- `executionStatus.ts`: `queued` → `status.queuedOffline` = "Queued — device offline" (both row and detail maps)
- `DevicesPage.tsx` bulk toast: now reports `{{queuedTail}}` from the W1 `queuedOffline[]` response field
- Single-command toast (devices list **and** device detail page): now reads the response's own `delivery`/`deliverBy` instead of the pre-request `device.status` snapshot — correctly reports "sent" or "runs when online" even if the device's live status changed between page load and click
- `ScriptExecutionModal.tsx`: new toast "Runs when the device is online" when any admitted target is `queued_offline` (no `deliverBy` on the admission contract yet, so always the no-expiry variant for now)
- `DeploymentProgress.tsx`: no code change needed — its `queuedOffline` chip text already read "Queued — device offline"

## Deviation from the wave brief

The brief named `DeviceActions.tsx` as the file for the single-command toast, but that component is presentational only (renders buttons, calls an `onAction` prop) — it owns no fetch or toast logic. The actual single-command dispatch + toast lives in **`DeviceDetailPage.tsx`**'s `handleAction`, which is what I edited (plus `DevicesPage.tsx`'s own single-device `runDeviceAction`, already in scope, for the same fix).

## Locales

New/changed keys in `devices.json` and `scripts.json`, propagated to all 7 non-en locales with real translations (not copy-pasted English) — the `translationCoverage.test.ts` duplicate-baseline ratchet caught the copy-paste attempt. de-DE's `devices.json` baseline bumped by 1 for a legitimate cognate (`queuedActions.system` = "System", identical in German).

## Test plan
- [x] `apps/api`: `tsc --noEmit` clean; `scriptExecution` + `openapi.scriptAdmission` tests green (51 tests)
- [x] `apps/web`: `astro check` — 0 errors/warnings; targeted suites (`devices`, `scripts`, `software/DeploymentProgress`, `lib`) — 2631 tests green, including locale parity/coverage/key-usage (98 tests)
- [x] `packages/shared`: 2487 tests green
- [x] `pnpm lint` clean (api, web)
- [x] New regression tests: `DeviceQueuedActions.test.tsx` (6), `DeviceDetailPage.commandDelivery.test.tsx` (2, covers the delivery-over-status-snapshot fix), plus fixes to pre-existing `DevicesPage.test.tsx` delivery-toast tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
