### PR TITLE
fix(api): Android KeyStore attestation challenge cannot embed the SPKI — add pre-key keygen digest (#4707)

### DIFF
--- a/apps/api/src/routes/authenticator.test.ts
+++ b/apps/api/src/routes/authenticator.test.ts
@@ -76,6 +76,7 @@ const {
       issueRegistrationAttempt: vi.fn(),
       consumeRegistrationAttempt: vi.fn(),
       registrationTranscript: vi.fn(),
+      androidKeyGenChallenge: vi.fn(),
       verifyPlatformAttestation: vi.fn(),
     },
     // The per-user rate limiter is mocked as a REAL counter keyed exactly as the
@@ -1119,6 +1120,7 @@ describe('attested mobile registration (#1374 W02)', () => {
     attestationMocks.issueRegistrationAttempt.mockResolvedValue(ATTEMPT);
     attestationMocks.consumeRegistrationAttempt.mockResolvedValue(ATTEMPT);
     attestationMocks.registrationTranscript.mockReturnValue(Buffer.alloc(32, 9));
+    attestationMocks.androidKeyGenChallenge.mockReturnValue(Buffer.alloc(32, 5));
     attestationMocks.verifyPlatformAttestation.mockResolvedValue({
       basis: 'unattested',
       verifiedAt: null,
@@ -1280,6 +1282,24 @@ describe('attested mobile registration (#1374 W02)', () => {
         signatureB64: 'pop-sig',
         alg: 'ES256',
       });
+    });
+
+    it('hands the verifier the SERVER-derived keygen challenge alongside the transcript', async () => {
+      // Android's KeyStore challenge is fixed at key generation, before the
+      // SPKI exists, so it is a separate digest from the transcript — and like
+      // the transcript it is built from the CONSUMED attempt, never the body.
+      await post('/devices/mobile/verify', validBody);
+      expect(attestationMocks.androidKeyGenChallenge).toHaveBeenCalledWith({
+        attemptId: 'attempt-1',
+        challenge: 'challenge-abc',
+        publicKeyAlg: 'ES256',
+      });
+      expect(attestationMocks.verifyPlatformAttestation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          transcript: Buffer.alloc(32, 9),
+          keyGenChallenge: Buffer.alloc(32, 5),
+        }),
+      );
     });
 
     it('403s when the grant is rejected AFTER a valid PoP — nothing is inserted', async () => {

--- a/apps/api/src/routes/authenticator.ts
+++ b/apps/api/src/routes/authenticator.ts
@@ -23,6 +23,7 @@ import {
   ATTEMPT_TTL_SECONDS,
   consumeRegistrationAttempt,
   issueRegistrationAttempt,
+  androidKeyGenChallenge,
   registrationTranscript,
   verifyPlatformAttestation,
 } from '../services/authenticatorAttestation';
@@ -598,6 +599,11 @@ authenticatorRoutes.post(
     const attested = await verifyPlatformAttestation({
       attestation: body.attestation,
       transcript,
+      keyGenChallenge: androidKeyGenChallenge({
+        attemptId: attempt.attemptId,
+        challenge: attempt.challenge,
+        publicKeyAlg: body.publicKeyAlg,
+      }),
       publicKeySpkiB64: body.publicKey,
       // The declared algorithm is inside the signed transcript and the PoP
       // above already verified under it, so by this point it is a proven

--- a/apps/api/src/services/attestation/androidAttestationEndToEnd.test.ts
+++ b/apps/api/src/services/attestation/androidAttestationEndToEnd.test.ts
@@ -1,3 +1,4 @@
+import crypto from 'node:crypto';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { SecurityLevel } from '@peculiar/asn1-android';
 import type { MobileAttestation } from '@breeze/shared';
@@ -57,8 +58,10 @@ describe('Android attestation end to end (#1374 W04)', () => {
         platform: 'android',
         certificateChain: fixture.certificateChainDerB64,
       } as MobileAttestation,
-      // The fixture's challenge IS the transcript the client committed to.
-      transcript: fixture.challenge,
+      // The fixture's challenge IS the keygen digest the client minted the
+      // key with; the transcript (which embeds the SPKI) is a separate value.
+      transcript: crypto.randomBytes(32),
+      keyGenChallenge: fixture.challenge,
       publicKeySpkiB64: fixture.attestedPublicKeyB64,
       publicKeyAlg: 'ES256',
     });
@@ -88,7 +91,8 @@ describe('Android attestation end to end (#1374 W04)', () => {
         platform: 'android',
         certificateChain: fixture.certificateChainDerB64,
       } as MobileAttestation,
-      transcript: fixture.challenge,
+      transcript: crypto.randomBytes(32),
+      keyGenChallenge: fixture.challenge,
       publicKeySpkiB64: attackerKey.attestedPublicKeyB64,
       publicKeyAlg: 'ES256',
     });
@@ -100,7 +104,7 @@ describe('Android attestation end to end (#1374 W04)', () => {
     });
   });
 
-  it('refuses a chain whose challenge is not the transcript', async () => {
+  it('refuses a chain whose challenge is not the keygen digest', async () => {
     const fixture = await mintAndroidKeyAttestationFixture();
     __setPinnedRootsForTests([fixture.rootPem]);
 
@@ -109,7 +113,8 @@ describe('Android attestation end to end (#1374 W04)', () => {
         platform: 'android',
         certificateChain: fixture.certificateChainDerB64,
       } as MobileAttestation,
-      transcript: Buffer.alloc(32, 7),
+      transcript: crypto.randomBytes(32),
+      keyGenChallenge: Buffer.alloc(32, 7),
       publicKeySpkiB64: fixture.attestedPublicKeyB64,
       publicKeyAlg: 'ES256',
     });
@@ -131,7 +136,8 @@ describe('Android attestation end to end (#1374 W04)', () => {
         platform: 'android',
         certificateChain: fixture.certificateChainDerB64,
       } as MobileAttestation,
-      transcript: fixture.challenge,
+      transcript: crypto.randomBytes(32),
+      keyGenChallenge: fixture.challenge,
       publicKeySpkiB64: fixture.attestedPublicKeyB64,
       publicKeyAlg: 'ES256',
     });
@@ -151,7 +157,8 @@ describe('Android attestation end to end (#1374 W04)', () => {
         platform: 'android',
         certificateChain: fixture.certificateChainDerB64,
       } as MobileAttestation,
-      transcript: fixture.challenge,
+      transcript: crypto.randomBytes(32),
+      keyGenChallenge: fixture.challenge,
       publicKeySpkiB64: 'not-a-key',
       publicKeyAlg: 'ES256',
     });

--- a/apps/api/src/services/attestation/androidKeyAttestation.ts
+++ b/apps/api/src/services/attestation/androidKeyAttestation.ts
@@ -91,7 +91,11 @@ export interface AndroidKeyAttestationResult {
 export interface VerifyAndroidKeyAttestationInput {
   /** base64 DER certificates, leaf first, as `KeyStore.getCertificateChain()` returns. */
   certificateChainDerB64: string[];
-  /** The registration transcript. Compared byte-exact against `attestationChallenge`. */
+  /**
+   * `androidKeyGenChallenge(...)` for this attempt — NOT the registration
+   * transcript, which embeds the SPKI and so cannot exist at key generation.
+   * Compared byte-exact against `attestationChallenge`.
+   */
   expectedChallenge: Buffer;
   expectedPackageName: string;
   /** Defaults to the pinned Google hardware attestation roots. Tests inject their own. */

--- a/apps/api/src/services/attestation/androidPlatformAttestation.test.ts
+++ b/apps/api/src/services/attestation/androidPlatformAttestation.test.ts
@@ -61,6 +61,7 @@ const otherKey = crypto.generateKeyPairSync('ec', { namedCurve: 'prime256v1' });
 const OTHER_SPKI_DER = otherKey.publicKey.export({ format: 'der', type: 'spki' });
 
 const TRANSCRIPT = crypto.randomBytes(32);
+const KEYGEN_CHALLENGE = crypto.randomBytes(32);
 
 function keyAttestationResult(overrides: Record<string, unknown> = {}) {
   return {
@@ -82,6 +83,7 @@ const run = (attestation: MobileAttestation = androidAttestation()) =>
   verifyPlatformAttestation({
     attestation,
     transcript: TRANSCRIPT,
+    keyGenChallenge: KEYGEN_CHALLENGE,
     publicKeySpkiB64: REGISTERED_SPKI_B64,
     publicKeyAlg: 'ES256',
   });
@@ -118,11 +120,13 @@ describe('verifyPlatformAttestation — Android branch (#1374 W04)', () => {
     expect((await run()).basis).toBe('android_strongbox_key_attestation');
   });
 
-  it('binds the attestation to the registration transcript and our package', async () => {
+  it('binds the certificate to the KEYGEN challenge (not the transcript) and our package', async () => {
+    // The KeyStore challenge is fixed before the key — and therefore the
+    // transcript's SPKI — exists, so the cert carries the keygen digest.
     await run();
     expect(androidMock.verifyAndroidKeyAttestation).toHaveBeenCalledWith({
       certificateChainDerB64: ['leaf', 'ca'],
-      expectedChallenge: TRANSCRIPT,
+      expectedChallenge: KEYGEN_CHALLENGE,
       expectedPackageName: 'com.breeze.rmm',
     });
   });
@@ -252,6 +256,7 @@ describe('verifyPlatformAttestation — Android branch (#1374 W04)', () => {
     const result = await verifyPlatformAttestation({
       attestation: { platform: 'ios', attestationObject: 'cbor', keyId: 'kid' },
       transcript: TRANSCRIPT,
+      keyGenChallenge: KEYGEN_CHALLENGE,
       publicKeySpkiB64: REGISTERED_SPKI_B64,
       publicKeyAlg: 'ES256',
     });

--- a/apps/api/src/services/attestation/playIntegrity.test.ts
+++ b/apps/api/src/services/attestation/playIntegrity.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import crypto from 'node:crypto';
+import { decodeJwt } from 'jose';
 import {
   __resetPlayIntegrityForTests,
   isPlayIntegrityConfigured,
@@ -199,5 +201,49 @@ describe('parsePlayIntegrityServiceAccount', () => {
 
   it('returns null when the required fields are missing', () => {
     expect(parsePlayIntegrityServiceAccount(JSON.stringify({ project_id: 'x' }))).toBeNull();
+  });
+});
+
+describe('accessToken — service-account JWT-bearer assertion', () => {
+  const ORIGINAL = process.env.PLAY_INTEGRITY_SERVICE_ACCOUNT;
+  const rsa = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 });
+  const account = {
+    ...SERVICE_ACCOUNT,
+    private_key: rsa.privateKey.export({ type: 'pkcs8', format: 'pem' }).toString(),
+  };
+
+  beforeEach(() => {
+    __resetPlayIntegrityForTests();
+    process.env.PLAY_INTEGRITY_SERVICE_ACCOUNT = JSON.stringify(account);
+  });
+
+  afterEach(() => {
+    if (ORIGINAL === undefined) delete process.env.PLAY_INTEGRITY_SERVICE_ACCOUNT;
+    else process.env.PLAY_INTEGRITY_SERVICE_ACCOUNT = ORIGINAL;
+    __resetPlayIntegrityForTests();
+    vi.unstubAllGlobals();
+  });
+
+  it('sends a plain service-account assertion: iss/aud/scope set, NO sub (delegation-only claim)', async () => {
+    // Exercised through the REAL google-managed decoder (no decodeIntegrityToken
+    // seam) so the assertion builder is actually invoked. The exchange is cut
+    // short after the token request; that is enough to capture the JWT.
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 599 });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await verifyPlayIntegrityToken('opaque-token', {
+      packageName: 'com.breeze.rmm',
+      expectedRequestHash: 'h',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, { body: URLSearchParams }];
+    expect(url).toBe('https://oauth2.googleapis.com/token');
+    expect(init.body.get('grant_type')).toBe('urn:ietf:params:oauth:grant-type:jwt-bearer');
+    const claims = decodeJwt(init.body.get('assertion')!);
+    expect(claims.iss).toBe(account.client_email);
+    expect(claims.aud).toBe('https://oauth2.googleapis.com/token');
+    expect(claims.scope).toBe('https://www.googleapis.com/auth/playintegrity');
+    expect(claims).not.toHaveProperty('sub');
   });
 });

--- a/apps/api/src/services/attestation/playIntegrity.ts
+++ b/apps/api/src/services/attestation/playIntegrity.ts
@@ -214,7 +214,8 @@ async function accessToken(account: PlayIntegrityServiceAccount): Promise<string
   const assertion = await new SignJWT({ scope: PLAY_INTEGRITY_SCOPE })
     .setProtectedHeader({ alg: 'RS256' })
     .setIssuer(account.clientEmail)
-    .setSubject(account.clientEmail)
+    // No `sub`: that claim is for domain-wide delegation (impersonating a
+    // Workspace user). A plain service-account exchange omits it.
     .setAudience(OAUTH_TOKEN_URL)
     .setIssuedAt(Math.floor(nowMs / 1000))
     .setExpirationTime(Math.floor(nowMs / 1000) + 3600)

--- a/apps/api/src/services/authenticatorAssurance.test.ts
+++ b/apps/api/src/services/authenticatorAssurance.test.ts
@@ -1025,6 +1025,7 @@ describe('verifyPlatformAttestation is fail-closed against the L4 trusted set (#
         const result = await verifyPlatformAttestation({
           attestation,
           transcript,
+          keyGenChallenge: transcript,
           publicKeySpkiB64: 'spki',
           publicKeyAlg,
         });

--- a/apps/api/src/services/authenticatorAttestation.test.ts
+++ b/apps/api/src/services/authenticatorAttestation.test.ts
@@ -52,6 +52,7 @@ import {
   ATTEMPT_TTL_SECONDS,
   consumeRegistrationAttempt,
   issueRegistrationAttempt,
+  androidKeyGenChallenge,
   registrationTranscript,
   verifyPlatformAttestation,
 } from './authenticatorAttestation';
@@ -62,6 +63,42 @@ beforeEach(() => {
   vi.clearAllMocks();
   redisStore.clear();
   getRedisMock.mockReturnValue(redisMock as never);
+});
+
+describe('androidKeyGenChallenge', () => {
+  const base = { attemptId: 'a1', challenge: 'c1', publicKeyAlg: 'ES256' as const };
+
+  it('matches the exact documented pre-image — W06 Kotlin passes this to setAttestationChallenge', () => {
+    // The KeyStore attestation challenge is fixed at KEY GENERATION, before the
+    // SPKI exists, so it cannot be the registration transcript (which embeds the
+    // SPKI). This digest is what the leaf certificate carries; the key itself is
+    // bound to the registration by the attested-leaf-key == registered-SPKI
+    // check in verifyAndroid.
+    expect(androidKeyGenChallenge(base)).toEqual(
+      crypto
+        .createHash('sha256')
+        .update(['breeze.authenticator.mobile-register.keygen.v1', 'a1', 'c1', 'ES256'].join('\n'), 'utf8')
+        .digest(),
+    );
+  });
+
+  it('is 32 bytes (Android caps the attestation challenge at 128)', () => {
+    expect(androidKeyGenChallenge(base)).toHaveLength(32);
+  });
+
+  it('is domain-separated from the registration transcript', () => {
+    expect(androidKeyGenChallenge(base)).not.toEqual(
+      registrationTranscript({ ...base, publicKeySpkiB64: '' }),
+    );
+  });
+
+  it.each([
+    ['attemptId', { attemptId: 'a2' }],
+    ['challenge', { challenge: 'c2' }],
+    ['publicKeyAlg', { publicKeyAlg: 'RS256' as const }],
+  ])('changes when %s changes', (_name, patch) => {
+    expect(androidKeyGenChallenge({ ...base, ...patch })).not.toEqual(androidKeyGenChallenge(base));
+  });
 });
 
 describe('registrationTranscript', () => {
@@ -198,6 +235,7 @@ describe('verifyPlatformAttestation', () => {
     const result = await verifyPlatformAttestation({
       attestation: iosAttestation,
       transcript,
+      keyGenChallenge: transcript,
       publicKeySpkiB64: 'spki',
       publicKeyAlg: 'ES256',
     });
@@ -212,6 +250,7 @@ describe('verifyPlatformAttestation', () => {
     const result = await verifyPlatformAttestation({
       attestation: iosAttestation,
       transcript,
+      keyGenChallenge: transcript,
       publicKeySpkiB64: 'spki',
       publicKeyAlg: 'RS256',
     });
@@ -227,6 +266,7 @@ describe('verifyPlatformAttestation', () => {
     await verifyPlatformAttestation({
       attestation: iosAttestation,
       transcript,
+      keyGenChallenge: transcript,
       publicKeySpkiB64: 'spki',
       publicKeyAlg: 'ES256',
     });
@@ -253,6 +293,7 @@ describe('verifyPlatformAttestation', () => {
     const result = await verifyPlatformAttestation({
       attestation: iosAttestation,
       transcript,
+      keyGenChallenge: transcript,
       publicKeySpkiB64: 'spki',
       publicKeyAlg: 'ES256',
     });
@@ -278,6 +319,7 @@ describe('verifyPlatformAttestation', () => {
     const result = await verifyPlatformAttestation({
       attestation: iosAttestation,
       transcript,
+      keyGenChallenge: transcript,
       publicKeySpkiB64: 'spki',
       publicKeyAlg: 'ES256',
     });
@@ -308,6 +350,7 @@ describe('verifyPlatformAttestation', () => {
     const result = await verifyPlatformAttestation({
       attestation: iosAttestation,
       transcript,
+      keyGenChallenge: transcript,
       publicKeySpkiB64: 'spki',
       publicKeyAlg: 'ES256',
     });
@@ -331,6 +374,7 @@ describe('verifyPlatformAttestation', () => {
         typeof verifyPlatformAttestation
       >[0]['attestation'],
       transcript,
+      keyGenChallenge: transcript,
       publicKeySpkiB64: 'spki',
       publicKeyAlg: 'ES256',
     });
@@ -347,6 +391,7 @@ describe('verifyPlatformAttestation', () => {
     const result = await verifyPlatformAttestation({
       attestation: { platform: 'android', certificateChain: ['a', 'b'] },
       transcript,
+      keyGenChallenge: transcript,
       publicKeySpkiB64: 'spki',
       publicKeyAlg: 'ES256',
     });
@@ -359,6 +404,7 @@ describe('verifyPlatformAttestation', () => {
     const result = await verifyPlatformAttestation({
       attestation: iosAttestation,
       transcript,
+      keyGenChallenge: transcript,
       publicKeySpkiB64: 'spki',
       publicKeyAlg: 'ES256',
     });
@@ -369,6 +415,7 @@ describe('verifyPlatformAttestation', () => {
     const result = await verifyPlatformAttestation({
       attestation: { platform: 'android', certificateChain: ['a', 'b'] },
       transcript,
+      keyGenChallenge: transcript,
       publicKeySpkiB64: 'spki',
       publicKeyAlg: 'ES256',
     });
@@ -384,6 +431,7 @@ describe('verifyPlatformAttestation', () => {
     const first = await verifyPlatformAttestation({
       attestation: iosAttestation,
       transcript,
+      keyGenChallenge: transcript,
       publicKeySpkiB64: 'spki',
       publicKeyAlg: 'ES256',
     });
@@ -391,6 +439,7 @@ describe('verifyPlatformAttestation', () => {
     const second = await verifyPlatformAttestation({
       attestation: iosAttestation,
       transcript,
+      keyGenChallenge: transcript,
       publicKeySpkiB64: 'spki',
       publicKeyAlg: 'ES256',
     });

--- a/apps/api/src/services/authenticatorAttestation.ts
+++ b/apps/api/src/services/authenticatorAttestation.ts
@@ -44,6 +44,13 @@ export const ATTEMPT_TTL_SECONDS = 300;
  */
 const TRANSCRIPT_DOMAIN = 'breeze.authenticator.mobile-register.v1';
 
+/**
+ * Domain tag for the Android KEY-GENERATION challenge — see
+ * `androidKeyGenChallenge`. Deliberately distinct from `TRANSCRIPT_DOMAIN` so
+ * the two digests can never be confused for one another.
+ */
+const ANDROID_KEYGEN_CHALLENGE_DOMAIN = 'breeze.authenticator.mobile-register.keygen.v1';
+
 const attemptKey = (attemptId: string) => `authenticator-attest:${attemptId}`;
 
 export interface RegistrationAttempt {
@@ -57,13 +64,16 @@ export interface RegistrationAttempt {
 }
 
 /**
- * The bytes both the platform attestation and the registration
- * proof-of-possession are computed over.
+ * The bytes the registration proof-of-possession, the iOS App Attest
+ * `clientDataHash`, and the Android Play Integrity `requestHash` are computed
+ * over. All three are produced AFTER the key exists, so all three can embed
+ * the SPKI.
  *
- * iOS passes this as App Attest's `clientDataHash`; Android passes it as the
- * KeyStore `setAttestationChallenge`; and the client also signs it with the new
- * approval key under a biometric prompt. One digest, three bindings — which is
- * what makes "this attestation vouches for THIS key in THIS attempt" checkable
+ * The one binding this digest cannot serve is the Android KeyStore attestation
+ * challenge, which is fixed at key generation — before the SPKI exists. That
+ * uses `androidKeyGenChallenge` instead; the attested leaf key is then tied to
+ * the registered key by `verifyAndroid`'s SPKI-digest equality check. Together:
+ * "this attestation vouches for THIS key in THIS attempt" stays checkable
  * rather than merely asserted.
  *
  * Domain-separated and newline-delimited so a signature minted for any other
@@ -90,6 +100,32 @@ export function registrationTranscript(input: {
         input.publicKeyAlg,
         input.publicKeySpkiB64,
       ].join('\n'),
+      'utf8',
+    )
+    .digest();
+}
+
+/**
+ * The Android KeyStore attestation challenge (`KeyGenParameterSpec.Builder
+ * .setAttestationChallenge`). It is an input to key GENERATION, so — unlike
+ * `registrationTranscript` — it cannot include the key's own SPKI. It binds
+ * the attempt (freshness) and the declared algorithm; key identity is bound
+ * separately by `verifyAndroid` comparing the attested leaf key with the
+ * registered SPKI. 32 bytes, well under Android's 128-byte challenge cap.
+ *
+ * The exact pre-image is pinned by a test: W06's Kotlin mints this on-device.
+ */
+export function androidKeyGenChallenge(input: {
+  attemptId: string;
+  challenge: string;
+  publicKeyAlg: MobileKeyAlg;
+}): Buffer {
+  return crypto
+    .createHash('sha256')
+    .update(
+      [ANDROID_KEYGEN_CHALLENGE_DOMAIN, input.attemptId, input.challenge, input.publicKeyAlg].join(
+        '\n',
+      ),
       'utf8',
     )
     .digest();
@@ -222,11 +258,14 @@ const ANDROID_PACKAGE_NAME = 'com.breeze.rmm';
 async function verifyAndroid(input: {
   attestation: Extract<MobileAttestation, { platform: 'android' }>;
   transcript: Buffer;
+  keyGenChallenge: Buffer;
   publicKeySpkiB64: string;
 }): Promise<AttestationResult> {
   const key = verifyAndroidKeyAttestation({
     certificateChainDerB64: input.attestation.certificateChain,
-    expectedChallenge: input.transcript,
+    // The cert carries the KEYGEN digest, not the transcript: the challenge is
+    // fixed before the key (and so the transcript's SPKI) exists.
+    expectedChallenge: input.keyGenChallenge,
     expectedPackageName: ANDROID_PACKAGE_NAME,
   });
 
@@ -295,6 +334,8 @@ async function verifyAndroid(input: {
 export async function verifyPlatformAttestation(input: {
   attestation: MobileAttestation;
   transcript: Buffer;
+  /** `androidKeyGenChallenge(...)` for this attempt. Unused on iOS. */
+  keyGenChallenge: Buffer;
   publicKeySpkiB64: string;
   publicKeyAlg: MobileKeyAlg;
 }): Promise<AttestationResult> {

--- a/docs/superpowers/plans/security-auth/2026-09-02-mobile-platform-attestation-l4.md
+++ b/docs/superpowers/plans/security-auth/2026-09-02-mobile-platform-attestation-l4.md
@@ -1096,13 +1096,15 @@ export interface RegistrationAttempt {
 }
 
 /**
- * The bytes both the platform attestation and the registration proof-of-
- * possession are computed over.
+ * The bytes the registration proof-of-possession, the iOS App Attest
+ * `clientDataHash`, and the Android Play Integrity `requestHash` are computed
+ * over — all produced AFTER the key exists, so all may embed the SPKI.
  *
- * iOS passes this as App Attest's `clientDataHash`; Android passes it as the
- * KeyStore `setAttestationChallenge`; and the client also signs it with the
- * approval key under a biometric prompt. One digest, three bindings — which is
- * what makes "this attestation vouches for THIS key in THIS attempt" checkable.
+ * NOT the Android KeyStore `setAttestationChallenge`: that is fixed at key
+ * generation, before the SPKI exists, so it uses `androidKeyGenChallenge`
+ * (SHA256 over `breeze.authenticator.mobile-register.keygen.v1\n<attemptId>\n<challenge>\n<alg>`)
+ * and the attested leaf key is bound to the registered key by SPKI-digest
+ * equality in `verifyAndroid` (resolved 2026-09-07 before W06, quorum-approved).
  *
  * Domain-separated and newline-delimited so a signature minted for any other
  * Breeze flow, or a different field split with the same concatenation, cannot
@@ -1963,7 +1965,7 @@ pnpm --filter breeze-mobile test && pnpm --filter breeze-mobile exec tsc --noEmi
 
 Branch: `feature/1374-mobile-attestation/w06-android-client`. Base: `main`. **Requires W02 + W04 deployed.** Mirrors W05 task-for-task.
 
-- [ ] **Task 1:** Kotlin side of `modules/breeze-attestation`. `KeyGenParameterSpec.Builder(alias, PURPOSE_SIGN)` with `setAlgorithmParameterSpec(ECGenParameterSpec("secp256r1"))`, `setDigests(DIGEST_SHA256)`, `setAttestationChallenge(transcript)`, `setUserAuthenticationRequired(true)`, `setInvalidatedByBiometricEnrollment(true)`, and `setIsStrongBoxBacked(true)` with a **documented** catch-and-retry on `StrongBoxUnavailableException` falling back to TEE (which yields `android_tee_key_attestation`, still L4-trusted). Export `KeyStore.getCertificateChain(alias)` as base64 DER, leaf first. Play Integrity via `com.google.android.play:integrity`.
+- [ ] **Task 1:** Kotlin side of `modules/breeze-attestation`. `KeyGenParameterSpec.Builder(alias, PURPOSE_SIGN)` with `setAlgorithmParameterSpec(ECGenParameterSpec("secp256r1"))`, `setDigests(DIGEST_SHA256)`, `setAttestationChallenge(androidKeyGenChallenge)` (the pre-key keygen digest — see W02 Task 2; the full transcript is only computable after the SPKI exists and is used for the PoP signature and the Play Integrity `requestHash`), `setUserAuthenticationRequired(true)`, `setInvalidatedByBiometricEnrollment(true)`, and `setIsStrongBoxBacked(true)` with a **documented** catch-and-retry on `StrongBoxUnavailableException` falling back to TEE (which yields `android_tee_key_attestation`, still L4-trusted). Export `KeyStore.getCertificateChain(alias)` as base64 DER, leaf first. Play Integrity via `com.google.android.play:integrity`.
 - [ ] **Task 2:** Extend `attestingSigner.ts` with the Android branch; the client-side flow is identical to W05 Task 2 (the transcript comes from `packages/shared/src/utils/authenticatorTranscript.ts`), plus the Play Integrity token. Same test list.
 - [ ] **Task 3:** On-device verification on (a) a StrongBox device (Pixel 6+) and (b) a TEE-only device. Confirm the two bases land distinctly and both reach L4. Confirm an unlocked-bootloader device is **refused** (`deviceLocked` check, W04 Task 1 check 6).
 


### PR DESCRIPTION
Part of #4707 (mobile platform attestation for L4). Unblocks W06 (#5161).

## Defect
`verifyAndroid` passed `registrationTranscript` (which embeds the key's SPKI) as the expected KeyStore `attestationChallenge`. Android fixes that challenge at **key generation** (`KeyGenParameterSpec.setAttestationChallenge`), before the SPKI exists — no real client can produce it. iOS is unaffected (App Attest `clientDataHash` is computed after the key exists).

## Fix
- New `androidKeyGenChallenge({attemptId, challenge, publicKeyAlg})` = `SHA256('breeze.authenticator.mobile-register.keygen.v1\n…')`, pinned by a pre-image test (W06 Kotlin mints it on-device). 32 bytes, under Android's 128-byte cap.
- `verifyPlatformAttestation` takes `keyGenChallenge`; the route derives it from the CONSUMED attempt (test added). Android cert challenge compares against it; PoP signature and Play Integrity `requestHash` keep the full transcript.
- Key identity remains bound by the existing attested-leaf-key == registered-SPKI digest check.
- Play Integrity: drop `sub` from the service-account JWT (delegation-only claim). **Not verified against live Google** — aligns with the documented non-delegated flow.
- Plan doc + stale "one digest, three bindings" comments updated.

## Security argument (advisor quorum: Fable + codex xhigh, agreed)
Attempt is single-use (`GETDEL`); reusing one keygen challenge for K1 and K2 yields two independently attested candidates, `cert(K1)+SPKI(K2)` fails equality, only one submission can consume the attempt. No replay or mix-and-match opened.

## Verified
- `npx vitest run` on attestation/assurance/authenticator suites: 8 files, 245 tests pass (10 new/changed tests were red first).
- `tsc --noEmit` clean, eslint clean.

## Follow-ups (quorum findings, out of scope here)
- `androidKeyAttestation.ts` package check reads only the first package name and ignores `signatureDigests`.
- Certificate revocation status list not checked (documented as unimplemented).
- User-auth check only rejects `noAuthRequired`, does not verify hardware-enforced auth type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LVfXHssL5fG9RUTYcedpPn
