### PR TITLE
ci: enable merge-queue support (merge_group trigger, docs-only CI Success fallback, merge guidance)

### DIFF
--- a/.claude/skills/feature-delivery/SKILL.md
+++ b/.claude/skills/feature-delivery/SKILL.md
@@ -111,11 +111,19 @@ preflight before it is safe on main.
 Then, in order:
 
 ```bash
-gh pr merge <N> --repo LanternOps/breeze --squash --admin
+gh pr merge <N> --repo LanternOps/breeze --squash        # enqueues; NEVER --admin
 ```
-`mcp__feature-lifecycle__complete_wave` → wait for the post-merge `main` run to finish
-before the next merge in a train → dispatch the next unblocked wave → when every
-wave is merged, `mcp__feature-lifecycle__close_feature` with the not-verified list.
+`main` is behind GitHub's **merge queue** (since 2026-09-07). `--squash` without
+`--admin` enqueues the PR; the queue rebuilds it on top of whatever is ahead, runs the
+full `CI Success` gate under `merge_group` (no path filters, smoke jobs blocking), and
+lands it serially. `--admin` bypasses the queue and is what caused the 09-06/09-07
+pile-ups (59 of 80 main runs cancelled, siblings CONFLICTING mid-sweep) — emergency
+only, and say so on the PR. If the queue run fails the PR is dequeued with a comment:
+fix and re-enqueue. Watch for the merge (`gh pr view <N> --json state`), then
+`mcp__feature-lifecycle__complete_wave` → dispatch the next unblocked wave (no need to
+wait for the post-merge `main` run yourself any more; the queue already evaluated
+that ref) → when every wave is merged, `mcp__feature-lifecycle__close_feature` with
+the not-verified list.
 Closing a `p`-labelled feature is what moves it to "Recently shipped" — confirm the
 label is still on the parent (not only on the roadmap item it came from) before
 closing.

--- a/.github/workflows/ci-docs-only.yml
+++ b/.github/workflows/ci-docs-only.yml
@@ -1,0 +1,32 @@
+name: CI (docs-only)
+
+# `ci.yml` path-ignores docs and Markdown, so a docs-only PR never gets a
+# `CI Success` check and could not enter the merge queue (the queue requires the
+# PR itself to satisfy every required check before it is enqueued). This
+# workflow triggers on the inverse path set and reports a passing `CI Success`
+# for those PRs. It is NOT a substitute for the real suite: the merge queue
+# runs `ci.yml` on every queue entry with no path filter, so a mixed docs+code
+# PR still gets the full suite before it reaches main.
+#
+# Recommended by GitHub for required checks on path-filtered workflows:
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'apps/docs/**'
+      - '**/*.md'
+      - '**/*.mdx'
+
+permissions:
+  contents: read
+
+jobs:
+  ci-success:
+    name: CI Success
+    runs-on: ubuntu-latest
+    steps:
+      - name: Docs-only change — no code suite to run on the PR
+        run: echo "Docs-only PR; the merge queue will run the full CI suite before merge."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,10 @@ name: CI
 
 on:
   workflow_dispatch:
+  # Merge queue: the queue builds a temporary merge ref and needs the same
+  # `CI Success` check as a PR. No path filters here on purpose — the queue is
+  # the last gate before main and always runs the full suite.
+  merge_group:
   push:
     branches: [main]
     paths-ignore:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -378,10 +378,12 @@ docker compose up --build -d
 
 **Deleting a config file? Sweep the Compose mounts in the same PR.** Docker creates a missing bind-mount source as an empty **directory** on the host, which then gets `COPY`d into dev images where Vite/PostCSS discovery dies on it (`EISDIR`) — `breeze-web` comes up permanently unhealthy on a fresh clone. `apps/api/src/config/composeBindMounts.test.ts` (required **Test API** job) parses every tracked compose file and fails when a file-shaped, repo-relative bind-mount source doesn't exist — or has already become a phantom directory. Extensionless sources (`./agent/bin`) are exempt as intended build outputs; out-of-repo sources (`../breeze-billing/…`) can't be asserted and are skipped. Shipped three times before the guard existed: #1999 (postcss), #2208 (partial tailwind), #2012 (the mounts #2208 missed).
 
-### PR Merge Process
-- Branch protection requires status checks, but the repo owner uses `--admin` to bypass when CI is green
-- Use `gh pr merge --squash --admin` (merge commits are disabled on this repo)
-- This is the normal workflow — do not wait for branch protection rules to be satisfied
+### PR Merge Process — merge queue (since 2026-09-07)
+- `main` uses GitHub's **merge queue**. Merge with `gh pr merge <N> --squash` (no `--admin`): the PR is enqueued, the queue rebuilds it on top of whatever is ahead of it, runs the full `CI Success` gate on that merge ref, and lands it serially. `--auto` is implied by the queue; `--squash` only (merge commits are disabled).
+- **Never `--admin`.** Admin bypass skips the queue and lands the commit directly, which is exactly what produced the 09-06/09-07 pile-ups: concurrent sessions each admin-merging cancelled 59 of 80 main CI runs in 48h, so main's true state was never evaluated, and sibling PRs went CONFLICTING mid-sweep. Reserve `--admin` for a genuine emergency (main red and the fix itself cannot pass the queue), and say so in the PR.
+- No reviewer approval is required by the ruleset any more; the review round is the `/pr-review-toolkit:review-pr` pass recorded on the PR, not a GitHub approval. Required check is `CI Success` only. Docs-only PRs get a passing `CI Success` from `ci-docs-only.yml` so they can enter the queue.
+- Queue semantics to know: a PR must be green on its own head to be enqueued; the queue then runs `ci.yml` under the `merge_group` event with **no path filters** and with the smoke jobs blocking (they are non-blocking on `pull_request` only). If the queue run fails, the PR is dequeued with a comment — fix and re-enqueue, do not bypass.
+- Any session may enqueue its own reviewed, green PR. Serialisation is the queue's job now, not a single-merger rule.
 
 ### Production Deploy (EU + US droplets)
 


### PR DESCRIPTION
## Summary

Prerequisite for turning on GitHub's **merge queue** on `main`.

- `ci.yml`: add the `merge_group` trigger. No path filters on it by design: the queue is the last gate before main and runs the full suite, with `smoke-test` / `guided-setup-smoke` blocking (they are `continue-on-error` on `pull_request` only, and `IS_PR` is false under `merge_group`).
- `ci-docs-only.yml` (new): docs/Markdown PRs are path-ignored by `ci.yml`, so they would never get the required `CI Success` check and could not be enqueued. This workflow reports a passing `CI Success` on the inverse path set. A mixed docs+code PR still gets the real suite on the queue's merge ref.
- `CLAUDE.md`: merge with `gh pr merge <N> --squash` (enqueues); **never `--admin`**. Rationale recorded inline.

## Why

Several sessions admin-merging concurrently over the last two days: 59 of the last 80 `CI` runs on `main` were cancelled by the next merge (main's real state was almost never evaluated), sibling PRs went CONFLICTING mid-sweep, and the dependabot sweep conflicted on the lockfile after the first 8 merges. The queue serialises this instead of a "single merger session" convention.

## Follow-up (applied via API right after this merges, not in this PR)

Ruleset "Protect main branch": `required_approving_review_count` 1 → 0, drop last-push approval and thread resolution, add `merge_queue` rule (SQUASH, ALLGREEN). Admin bypass stays for emergencies only.

## Verification

- `ciSuccessGatingContract.test.ts` 8/8; `apps/api/src/config/` 25 files / 640 tests pass.
- `actionlint` on both workflows: only the pre-existing SC2155 at ci.yml:1215.
- `scripts/security/check-supply-chain-hardening.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGT9BJVfpG3nyM6c9koAN8