### PR TITLE
fix(mobile): ticket keyboard dismiss, toast clearance, US spelling (#5171)

### DIFF
--- a/apps/mobile/src/components/timerBarLogic.test.ts
+++ b/apps/mobile/src/components/timerBarLogic.test.ts
@@ -112,6 +112,25 @@ describe('toastClearanceOffset', () => {
     expect(toastClearanceOffset(0, 16)).toBe(16);
     expect(toastClearanceOffset(-5, 16)).toBe(16);
   });
+
+  // #5171: the composer's measured height clears it as a static card, but the
+  // keyboard LIFTS the composer off the bottom of the screen while the toast
+  // (rendered as a sibling of the KeyboardAvoidingView's scroll content, not
+  // inside it) is not lifted with it — so a toast sized only for the
+  // composer's height still paints mid-composer once the keyboard is up.
+  describe('with a keyboard height', () => {
+    it('adds the keyboard height on top of the measured element and margin', () => {
+      expect(toastClearanceOffset(120, 16, 300)).toBe(436);
+    });
+
+    it('defaults the keyboard height to 0 when omitted — unchanged behavior for existing callers', () => {
+      expect(toastClearanceOffset(120, 16)).toBe(toastClearanceOffset(120, 16, 0));
+    });
+
+    it('treats a negative keyboard height (should not happen, but guard it) as 0', () => {
+      expect(toastClearanceOffset(120, 16, -50)).toBe(136);
+    });
+  });
 });
 
 describe('isQueueWedged', () => {

--- a/apps/mobile/src/components/timerBarLogic.ts
+++ b/apps/mobile/src/components/timerBarLogic.ts
@@ -73,9 +73,22 @@ export function shouldShowWaitingToSync(input: { pendingCount: number; elapsedMs
  * measurement of 0 or less (not yet laid out, or a bogus reading) falls back
  * to `margin` alone rather than going negative, which would push the toast
  * below the screen edge instead of merely losing its clearance.
+ *
+ * `keyboardHeight` (#5171) accounts for the OS keyboard: the Toast renders as
+ * a sibling of the scrollable form content, not inside it, so it is not
+ * lifted along with a composer that `KeyboardAvoidingView`/scroll-inset
+ * logic pushes up above the keyboard. Without adding the keyboard's own
+ * height, a toast sized only for the composer's measured height still paints
+ * mid-composer once the keyboard is open. Defaults to 0 so existing callers
+ * (none of which pass a keyboard height) are unaffected, and a negative
+ * value (should never happen) is clamped rather than subtracted.
  */
-export function toastClearanceOffset(measuredHeight: number, margin: number): number {
-  return Math.max(measuredHeight, 0) + margin;
+export function toastClearanceOffset(
+  measuredHeight: number,
+  margin: number,
+  keyboardHeight = 0
+): number {
+  return Math.max(measuredHeight, 0) + margin + Math.max(keyboardHeight, 0);
 }
 
 /**

--- a/apps/mobile/src/lib/keyboardHeightEvents.test.ts
+++ b/apps/mobile/src/lib/keyboardHeightEvents.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { keyboardHideEventName, keyboardShowEventName } from './keyboardHeightEvents';
+
+// #5171: iOS reports the keyboard's final frame ahead of the animation via
+// `keyboardWillShow`/`keyboardWillHide`, so tracking that height keeps the
+// toast offset in step with the keyboard as it slides in. Android has no
+// "will" pair at all — only `keyboardDidShow`/`keyboardDidHide`, fired once
+// the keyboard has already finished animating. Picking the wrong pair per
+// platform either misses the event entirely (Android has no "will") or lags
+// a full animation behind (iOS "did").
+describe('keyboardShowEventName', () => {
+  it('uses the pre-animation event on iOS', () => {
+    expect(keyboardShowEventName('ios')).toBe('keyboardWillShow');
+  });
+
+  it('falls back to the post-animation event on every other platform', () => {
+    expect(keyboardShowEventName('android')).toBe('keyboardDidShow');
+    expect(keyboardShowEventName('web')).toBe('keyboardDidShow');
+  });
+});
+
+describe('keyboardHideEventName', () => {
+  it('uses the pre-animation event on iOS', () => {
+    expect(keyboardHideEventName('ios')).toBe('keyboardWillHide');
+  });
+
+  it('falls back to the post-animation event on every other platform', () => {
+    expect(keyboardHideEventName('android')).toBe('keyboardDidHide');
+    expect(keyboardHideEventName('web')).toBe('keyboardDidHide');
+  });
+});

--- a/apps/mobile/src/lib/keyboardHeightEvents.ts
+++ b/apps/mobile/src/lib/keyboardHeightEvents.ts
@@ -1,0 +1,21 @@
+/**
+ * Which RN `Keyboard` event pair to subscribe to per platform.
+ *
+ * Pure so it's testable under this project's vitest runtime (no RN test
+ * renderer — see `useKeyboardHeight.ts`'s comment for why the subscription
+ * itself lives in a hook this file's tests never touch).
+ *
+ * iOS fires `keyboardWill*` ahead of the slide animation, carrying the
+ * keyboard's FINAL frame — using it keeps a tracked height in step with the
+ * keyboard as it moves. Android has no "will" pair; `keyboardDid*` is the
+ * only option there; it fires once the keyboard has already finished
+ * animating, but that's Android's own show/hide timing, no worse than
+ * `KeyboardAvoidingView`'s.
+ */
+export function keyboardShowEventName(platformOS: string): 'keyboardWillShow' | 'keyboardDidShow' {
+  return platformOS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow';
+}
+
+export function keyboardHideEventName(platformOS: string): 'keyboardWillHide' | 'keyboardDidHide' {
+  return platformOS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
+}

--- a/apps/mobile/src/lib/useKeyboardHeight.ts
+++ b/apps/mobile/src/lib/useKeyboardHeight.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+import { Keyboard, Platform, type KeyboardEvent } from 'react-native';
+
+import { keyboardHideEventName, keyboardShowEventName } from './keyboardHeightEvents';
+
+/**
+ * Tracks the on-screen height of the OS keyboard, 0 when hidden.
+ *
+ * #5171: a Toast rendered as a sibling of a screen's scrollable content is
+ * NOT lifted along with a composer that `KeyboardAvoidingView`/scroll-inset
+ * logic pushes above the keyboard, so a toast cleared only for the
+ * composer's own height still paints mid-composer while the keyboard is
+ * open. Screens that can show a toast while a keyboard may be open should
+ * fold this into `toastClearanceOffset` (`components/timerBarLogic.ts`).
+ *
+ * No render-testable logic lives here — this project's vitest runtime has no
+ * React Native test renderer (see `MfaChallengeScreen.test.ts`) — so the only
+ * per-platform decision (which event pair to subscribe to) is factored out
+ * into the pure, tested `keyboardHeightEvents.ts`.
+ */
+export function useKeyboardHeight(): number {
+  const [height, setHeight] = useState(0);
+
+  useEffect(() => {
+    const platformOS = Platform.OS;
+    const onShow = (e: KeyboardEvent) => setHeight(e.endCoordinates?.height ?? 0);
+    const onHide = () => setHeight(0);
+
+    const showSub = Keyboard.addListener(keyboardShowEventName(platformOS), onShow);
+    const hideSub = Keyboard.addListener(keyboardHideEventName(platformOS), onHide);
+
+    return () => {
+      showSub.remove();
+      hideSub.remove();
+    };
+  }, []);
+
+  return height;
+}

--- a/apps/mobile/src/screens/auth/keyboardDismiss.test.ts
+++ b/apps/mobile/src/screens/auth/keyboardDismiss.test.ts
@@ -58,6 +58,15 @@ function extractCallbackBody(source: string, constName: string): string {
   );
 }
 
+/** `const <name> = async (...) => { ... }` (CreateTicketScreen, plain — no useCallback). */
+function extractArrowBody(source: string, constName: string): string {
+  return extractBraceBody(
+    source,
+    new RegExp(`const\\s+${constName}\\s*=\\s*(?:async\\s+)?\\([^)]*\\)\\s*=>\\s*\\{`),
+    `"const ${constName} = async (...) => {...`
+  );
+}
+
 function assertDismissBeforeDispatch(body: string, dispatchNeedle: string, label: string) {
   const dismissIndex = body.indexOf('Keyboard.dismiss()');
   const dispatchIndex = body.indexOf(dispatchNeedle);
@@ -83,5 +92,13 @@ describe('keyboard dismissed before navigation-triggering dispatch (#5104)', () 
   it('HomeScreen.handleSend dismisses before starting a turn', () => {
     const body = extractCallbackBody(readSource('../chat/HomeScreen.tsx'), 'handleSend');
     assertDismissBeforeDispatch(body, 'cancelTurnWork()', 'handleSend');
+  });
+
+  // #5171: the Create ticket spinner ran with the keyboard still up, then
+  // `navigation.replace('TicketDetail', …)` fired with no `Keyboard.dismiss()`
+  // — same class of bug as #5104 above, one navigator swap later.
+  it('CreateTicketScreen.submit dismisses before creating the ticket', () => {
+    const body = extractArrowBody(readSource('../tickets/CreateTicketScreen.tsx'), 'submit');
+    assertDismissBeforeDispatch(body, 'createTicket(', 'submit');
   });
 });

--- a/apps/mobile/src/screens/tickets/CreateTicketScreen.tsx
+++ b/apps/mobile/src/screens/tickets/CreateTicketScreen.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import {
   ActivityIndicator,
+  Keyboard,
   KeyboardAvoidingView,
   Platform,
   Pressable,
@@ -65,7 +66,7 @@ export function CreateTicketScreen() {
       } catch (err) {
         reportInternalError(err, 'CreateTicketScreen.loadOrgs');
         setOrgs([]);
-        setOrgError('Could not load organisations. Pull to retry.');
+        setOrgError('Could not load organizations. Pull to retry.');
       }
     },
     [user?.organizationId]
@@ -78,6 +79,11 @@ export function CreateTicketScreen() {
   const submit = async () => {
     const built = buildCreateTicketBody({ orgId, subject, description, priority });
     if (!built.ok) return;
+    // #5171: without this, the spinner ran with the keyboard still up, and
+    // `navigation.replace('TicketDetail', …)` below swapped in the next
+    // screen with the keyboard still floating over it and the note field
+    // eligible to inherit focus — same class as the MFA fix (#5104).
+    Keyboard.dismiss();
     setBusy(true);
     try {
       const created = await createTicket(built.body);
@@ -122,7 +128,7 @@ export function CreateTicketScreen() {
         // under a ~300pt keyboard with nowhere to go.
         automaticallyAdjustKeyboardInsets
       >
-        <Text style={styles.label}>ORGANISATION</Text>
+        <Text style={styles.label}>ORGANIZATION</Text>
         {orgs === null ? (
           <ActivityIndicator color={palette.dark.textLo} style={styles.spinner} />
         ) : lockedOrg ? (
@@ -132,7 +138,7 @@ export function CreateTicketScreen() {
             {showSearch ? (
               <TextInput
                 style={styles.input}
-                placeholder="Search organisations"
+                placeholder="Search organizations"
                 placeholderTextColor={palette.dark.textLo}
                 value={orgSearch}
                 onChangeText={(text) => {
@@ -141,7 +147,7 @@ export function CreateTicketScreen() {
                 }}
                 autoCorrect={false}
                 autoCapitalize="none"
-                accessibilityLabel="Search organisations"
+                accessibilityLabel="Search organizations"
               />
             ) : null}
             {orgError ? (
@@ -150,7 +156,7 @@ export function CreateTicketScreen() {
               </Pressable>
             ) : null}
             {orgs.length === 0 && !orgError ? (
-              <Text style={styles.hint}>No organisations match.</Text>
+              <Text style={styles.hint}>No organizations match.</Text>
             ) : null}
             <View style={styles.orgList}>
               {orgs.map((org) => {
@@ -173,7 +179,7 @@ export function CreateTicketScreen() {
             {selectedOrg === null && orgSearch.length > 0 && orgId ? (
               // The chosen org is filtered out of the current search results;
               // say so rather than let the selection look lost.
-              <Text style={styles.hint}>Selected organisation is not in these results.</Text>
+              <Text style={styles.hint}>Selected organization is not in these results.</Text>
             ) : null}
           </>
         )}

--- a/apps/mobile/src/screens/tickets/TicketDetailScreen.tsx
+++ b/apps/mobile/src/screens/tickets/TicketDetailScreen.tsx
@@ -939,11 +939,20 @@ export function TicketDetailScreen() {
         // "Timer stopped" never overlaps its mode tabs (#5105) — the
         // component's own default offset assumes a short, fixed-height
         // screen, not one ending in a composer that can run to 200+px. Also
-        // clears the keyboard height (#5171): the Toast is a sibling of the
-        // scroll content, not lifted along with the composer the keyboard
-        // pushes up, so without this the toast still painted mid-composer
-        // whenever the keyboard was open.
-        bottomOffset={toastClearanceOffset(composerHeight, spacing['4'], keyboardHeight)}
+        // clears the keyboard height on iOS (#5171): iOS keeps the window at
+        // full height and relies on `automaticallyAdjustKeyboardInsets`
+        // (above) to shift only the ScrollView's content, so the Toast — a
+        // sibling of that ScrollView, not inside it — is not lifted along
+        // with the composer and needs the keyboard height added explicitly.
+        // Android is intentionally excluded: with no `softwareKeyboardLayoutMode`
+        // override the OS resizes the window itself when the keyboard opens,
+        // so `bottom: 0` already lands just above the keyboard there — adding
+        // `keyboardHeight` again would double-count it and over-clear the toast.
+        bottomOffset={toastClearanceOffset(
+          composerHeight,
+          spacing['4'],
+          Platform.OS === 'ios' ? keyboardHeight : 0
+        )}
       />
     </KeyboardAvoidingView>
   );

--- a/apps/mobile/src/screens/tickets/TicketDetailScreen.tsx
+++ b/apps/mobile/src/screens/tickets/TicketDetailScreen.tsx
@@ -39,6 +39,7 @@ import {
   writeLocalTimer,
 } from '../../services/localTimer';
 import { useNetworkConnected } from '../../lib/useNetworkConnected';
+import { useKeyboardHeight } from '../../lib/useKeyboardHeight';
 import {
   addTicketComment,
   allowedQuickStatuses,
@@ -195,6 +196,7 @@ export function TicketDetailScreen() {
   }, []);
 
   const connected = useNetworkConnected();
+  const keyboardHeight = useKeyboardHeight();
   const running = useAppSelector((state) => state.time.running);
   // Sticky for the session: once the server has refused this account the
   // control is withdrawn rather than re-offered and failing (see timeSlice).
@@ -936,8 +938,12 @@ export function TicketDetailScreen() {
         // Clears the composer's full measured height so "Timer started" /
         // "Timer stopped" never overlaps its mode tabs (#5105) — the
         // component's own default offset assumes a short, fixed-height
-        // screen, not one ending in a composer that can run to 200+px.
-        bottomOffset={toastClearanceOffset(composerHeight, spacing['4'])}
+        // screen, not one ending in a composer that can run to 200+px. Also
+        // clears the keyboard height (#5171): the Toast is a sibling of the
+        // scroll content, not lifted along with the composer the keyboard
+        // pushes up, so without this the toast still painted mid-composer
+        // whenever the keyboard was open.
+        bottomOffset={toastClearanceOffset(composerHeight, spacing['4'], keyboardHeight)}
       />
     </KeyboardAvoidingView>
   );

--- a/apps/mobile/src/screens/tickets/createTicketForm.test.ts
+++ b/apps/mobile/src/screens/tickets/createTicketForm.test.ts
@@ -22,7 +22,7 @@ describe('buildCreateTicketBody', () => {
     });
   });
 
-  it('refuses without an organisation, before checking the subject', () => {
+  it('refuses without an organization, before checking the subject', () => {
     expect(buildCreateTicketBody({ orgId: null, subject: '', description: '', priority: 'normal' })).toEqual({
       ok: false,
       reason: 'org',
@@ -56,10 +56,10 @@ describe('preselectOrg', () => {
     { id: 'a', name: 'Acme' },
     { id: 'b', name: 'Bolt' },
   ];
-  it('prefers the signed-in user\'s own organisation when it is in the list', () => {
+  it('prefers the signed-in user\'s own organization when it is in the list', () => {
     expect(preselectOrg(orgs, 'b')).toBe('b');
   });
-  it('picks the only organisation when there is exactly one', () => {
+  it('picks the only organization when there is exactly one', () => {
     expect(preselectOrg([orgs[0]], undefined)).toBe('a');
   });
   it('leaves the choice to the user otherwise', () => {

--- a/apps/mobile/src/screens/tickets/createTicketForm.ts
+++ b/apps/mobile/src/screens/tickets/createTicketForm.ts
@@ -56,7 +56,7 @@ export function canSubmitTicket(input: { orgId: string | null; subject: string; 
 }
 
 /**
- * Which organisation to start on: the signed-in user's own org when it is in
+ * Which organization to start on: the signed-in user's own org when it is in
  * the list (org-scoped technicians only ever see one), else the only org when
  * there is exactly one, else nothing — a partner user with several customers
  * has to choose, and a silent default would file tickets against the wrong

--- a/apps/mobile/src/services/organizations.ts
+++ b/apps/mobile/src/services/organizations.ts
@@ -9,7 +9,7 @@ export interface OrganizationSummary {
 const PAGE_LIMIT = 100;
 
 /**
- * One page of the organisations the caller can see, for pickers. A partner
+ * One page of the organizations the caller can see, for pickers. A partner
  * with more than 100 customers narrows with `search` (server-side, so the
  * cap is on the result, not the universe). `total` says whether that was
  * needed.

--- a/apps/mobile/src/services/ticketAttachmentContract.ts
+++ b/apps/mobile/src/services/ticketAttachmentContract.ts
@@ -125,7 +125,7 @@ const ERROR_COPY: Record<AttachmentErrorCode, { message: string; retryable: bool
   EMPTY_ATTACHMENT: { message: 'That file is empty.', retryable: false },
   SHARING_UNAVAILABLE: { message: 'This device cannot open that file.', retryable: false },
   ORG_CONTEXT_REQUIRED: {
-    message: 'Your sign-in has no organisation selected. Sign out and back in.',
+    message: 'Your sign-in has no organization selected. Sign out and back in.',
     retryable: false,
   },
   UPLOAD_FAILED: { message: 'Upload failed. Check your connection and try again.', retryable: true },


### PR DESCRIPTION
## Summary
Three mobile ticket-flow papercuts from the round-3 iOS test (`ios-test-olivetech-rnd3-frames-2026-09-07/REVIEW.md`):

1. **Keyboard persists across Create ticket → Ticket detail.** `CreateTicketScreen.submit` now calls `Keyboard.dismiss()` before creating the ticket, matching the pattern from `MfaChallengeScreen.handleVerify` / `LoginScreen.handleLogin` (#5104/#5113 — `LoginScreen` already had this; only `CreateTicketScreen` was missing it). Confirmed `TicketDetailScreen`'s note input has no `autoFocus`, so nothing there needed changing.
2. **Toasts land on the composer when the keyboard is open.** Added `useKeyboardHeight()` (`apps/mobile/src/lib/`), backed by a pure, unit-tested `keyboardHeightEvents.ts` (picks `keyboardWillShow/Hide` on iOS, `keyboardDidShow/Hide` elsewhere). `toastClearanceOffset()` in `timerBarLogic.ts` gains an optional `keyboardHeight` param (default 0, so existing callers — `TimerBar.tsx` — are unaffected); `TicketDetailScreen` now passes the live keyboard height through so "Timer started" / "Comment added" clear the composer even while it's been lifted off the bottom of the screen. Other `bottomOffset=` call sites (`SettingsSheet.tsx`, `SystemsScreen.tsx`) use a fixed inset unrelated to a measured sibling and are out of scope/ownership here.
3. **Spelling.** `ORGANISATION` → `ORGANIZATION`, "Search organisations" → "Search organizations", "No organisations match." → "No organizations match.", "Could not load organisations..." → "...organizations..." in `CreateTicketScreen.tsx`; swept the rest of `apps/mobile/src` for `organis` stragglers (`createTicketForm.ts`/`.test.ts`, `services/organizations.ts`, `services/ticketAttachmentContract.ts`).

## Test plan
- [x] `cd apps/mobile && npx vitest run src/screens/tickets src/screens/auth src/components src/lib/keyboardHeightEvents.test.ts` — 12 files / 160 tests passed
- [x] `cd apps/mobile && npx tsc --noEmit` — clean
- [x] Red-first: new assertions (CreateTicketScreen dismiss-before-create, toastClearanceOffset keyboard param, keyboardHeightEvents platform selection) watched failing before implementation

Closes #5171

🤖 Generated with [Claude Code](https://claude.com/claude-code)