### PR TITLE
fix(mobile): chat render papercuts — streaming markdown, expandable errors, honest tool labels (#5170)

### DIFF
--- a/apps/mobile/src/screens/chat/HomeScreen.tsx
+++ b/apps/mobile/src/screens/chat/HomeScreen.tsx
@@ -219,13 +219,18 @@ export function HomeScreen() {
               // collapses — content has resumed.
               dispatch(setInFlightTool(null));
               break;
-            case 'tool_use_start':
-              dispatch(setInFlightTool({ toolUseId: ev.toolUseId, toolName: ev.toolName }));
+            case 'tool_use_start': {
+              const input =
+                ev.input && typeof ev.input === 'object'
+                  ? (ev.input as Record<string, unknown>)
+                  : undefined;
+              dispatch(setInFlightTool({ toolUseId: ev.toolUseId, toolName: ev.toolName, input }));
               dispatch(appendToolEvent({
                 messageId: assistantId,
-                event: { toolUseId: ev.toolUseId, toolName: ev.toolName, state: 'started' },
+                event: { toolUseId: ev.toolUseId, toolName: ev.toolName, state: 'started', input },
               }));
               break;
+            }
             case 'tool_result':
               // The slice merges by toolUseId; the prior `tool_use_start`
               // dispatch already wrote the toolName, so the placeholder

--- a/apps/mobile/src/screens/chat/components/AiMessage.tsx
+++ b/apps/mobile/src/screens/chat/components/AiMessage.tsx
@@ -13,7 +13,7 @@ import { toolRowStatus } from './toolIndicatorLogic';
 
 interface Props {
   message: Extract<ChatMessage, { role: 'assistant' }>;
-  inFlightTool: { toolUseId: string; toolName: string } | null;
+  inFlightTool: { toolUseId: string; toolName: string; input?: Record<string, unknown> } | null;
   onRetry?: () => void;
 }
 
@@ -46,6 +46,7 @@ export function AiMessage({ message, inFlightTool, onRetry }: Props) {
                 isError={t.isError}
                 output={t.output}
                 handoff={t.handoff}
+                input={t.input}
               />
             );
           }
@@ -54,13 +55,13 @@ export function AiMessage({ message, inFlightTool, onRetry }: Props) {
             return <Fragment key={t.toolUseId}>{block}</Fragment>;
           }
           return (
-            <ToolIndicator key={t.toolUseId} toolName={t.toolName} state="completed" />
+            <ToolIndicator key={t.toolUseId} toolName={t.toolName} state="completed" input={t.input} />
           );
         })}
 
       {message.content ? (
         <View style={{ paddingHorizontal: spacing[6] }}>
-          <MarkdownBody content={message.content} />
+          <MarkdownBody content={message.content} streaming={message.isStreaming} />
         </View>
       ) : null}
 
@@ -71,7 +72,7 @@ export function AiMessage({ message, inFlightTool, onRetry }: Props) {
       ) : null}
 
       {message.isStreaming && inFlightTool ? (
-        <ToolIndicator toolName={inFlightTool.toolName} state="started" />
+        <ToolIndicator toolName={inFlightTool.toolName} state="started" input={inFlightTool.input} />
       ) : null}
 
       {message.failed ? (

--- a/apps/mobile/src/screens/chat/components/ConversationList.tsx
+++ b/apps/mobile/src/screens/chat/components/ConversationList.tsx
@@ -9,7 +9,7 @@ import { AiMessage } from './AiMessage';
 
 interface Props {
   messages: ChatMessage[];
-  inFlightTool: { toolUseId: string; toolName: string } | null;
+  inFlightTool: { toolUseId: string; toolName: string; input?: Record<string, unknown> } | null;
   onRetry?: (messageId: string) => void;
 }
 

--- a/apps/mobile/src/screens/chat/components/MarkdownBody.tsx
+++ b/apps/mobile/src/screens/chat/components/MarkdownBody.tsx
@@ -4,9 +4,15 @@ import Markdown, { type RenderRules } from 'react-native-markdown-display';
 
 import { useApprovalTheme, fontFamily, radii, spacing } from '../../../theme';
 import { parseMarkdownTable, toDisplayRows } from './markdownTable';
+import { sanitizeStreamingMarkdown } from './streamingMarkdown';
 
 interface Props {
   content: string;
+  // True only while this message is still streaming in. An unclosed inline
+  // marker (`**`, `*`, `_`, a single backtick) renders literally until its
+  // close arrives — see `sanitizeStreamingMarkdown` (#5170). A completed
+  // message is always well-formed, so this must never apply there.
+  streaming?: boolean;
 }
 
 // Markdown renderer themed to DESIGN.md tokens.
@@ -16,8 +22,9 @@ interface Props {
 // - Headings: stepped down from Display so they don't compete with the
 //   approval-card register elsewhere in the app.
 // - HR rules suppressed per the brief — they read as visual gunk on small screens.
-export function MarkdownBody({ content }: Props) {
+export function MarkdownBody({ content, streaming }: Props) {
   const theme = useApprovalTheme('dark');
+  const displayContent = streaming ? sanitizeStreamingMarkdown(content) : content;
 
   // The library expects a flat StyleSheet-like object keyed by AST node type.
   const styles = useMemo(
@@ -251,7 +258,7 @@ export function MarkdownBody({ content }: Props) {
       mergeStyle={false}
       onLinkPress={() => true}
     >
-      {content}
+      {displayContent}
     </Markdown>
   );
 }

--- a/apps/mobile/src/screens/chat/components/ToolIndicator.tsx
+++ b/apps/mobile/src/screens/chat/components/ToolIndicator.tsx
@@ -1,8 +1,10 @@
-import { Text, View } from 'react-native';
+import { useState } from 'react';
+import { Pressable, Text, View } from 'react-native';
 
 import { useApprovalTheme, spacing, type } from '../../../theme';
 import { Spinner } from '../../../components/Spinner';
-import { aiToolLabel, toolRowStatus, toolRowSuffix } from './toolIndicatorLogic';
+import { haptic } from '../../../lib/motion';
+import { aiToolLabel, toolRowErrorText, toolRowStatus, toolRowSuffix } from './toolIndicatorLogic';
 
 interface Props {
   // The raw tool name, e.g. "manage_alerts". Rendered through `aiToolLabel`,
@@ -18,10 +20,15 @@ interface Props {
   // Server-asserted approval handoff (#5107). Authoritative; `output` is only
   // a history-replay fallback because the tool controls that payload.
   handoff?: string;
+  // The tool call's arguments (#5170). Lets `aiToolLabel` read `input.action`
+  // so a read-only call ("list", "get", …) on a `manage_*` tool reads as
+  // "Checked …" rather than "Updated …".
+  input?: Record<string, unknown>;
 }
 
-export function ToolIndicator({ toolName, state, isError, output, handoff }: Props) {
+export function ToolIndicator({ toolName, state, isError, output, handoff, input }: Props) {
   const theme = useApprovalTheme('dark');
+  const [expanded, setExpanded] = useState(false);
 
   if (state === 'started') {
     return (
@@ -39,7 +46,7 @@ export function ToolIndicator({ toolName, state, isError, output, handoff }: Pro
           style={[type.metaCaps, { color: theme.textLo, flex: 1 }]}
           numberOfLines={1}
         >
-          {aiToolLabel(toolName, 'running')}
+          {aiToolLabel(toolName, 'running', input)}
         </Text>
       </View>
     );
@@ -52,11 +59,39 @@ export function ToolIndicator({ toolName, state, isError, output, handoff }: Pro
   const color =
     status === 'approved' ? theme.brand : status === 'completed' ? theme.textLo : theme.deny;
 
+  const caption = (
+    <Text style={[type.metaCaps, { color }]} numberOfLines={1}>
+      {`${aiToolLabel(toolName, 'completed', input)} · ${toolRowSuffix(status)}`}
+    </Text>
+  );
+
+  // FAILED/DENIED rows used to have no way to see why (#5170) — the comment
+  // that used to live on `toolRowStatus` above documented the gap directly.
+  // Completed/approved rows stay non-interactive; only these two get a tap
+  // affordance, and only when there's actually error text to show.
+  const errorText =
+    status === 'failed' || status === 'denied' ? toolRowErrorText(output) : null;
+
+  if (!errorText) {
+    return (
+      <View style={{ paddingHorizontal: spacing[6], paddingVertical: spacing[2] }}>{caption}</View>
+    );
+  }
+
   return (
-    <View style={{ paddingHorizontal: spacing[6], paddingVertical: spacing[2] }}>
-      <Text style={[type.metaCaps, { color }]} numberOfLines={1}>
-        {`${aiToolLabel(toolName, 'completed')} · ${toolRowSuffix(status)}`}
-      </Text>
-    </View>
+    <Pressable
+      onPress={() => {
+        haptic.tap();
+        setExpanded((v) => !v);
+      }}
+      accessibilityRole="button"
+      accessibilityLabel="Show error"
+      style={{ paddingHorizontal: spacing[6], paddingVertical: spacing[2] }}
+    >
+      {caption}
+      {expanded ? (
+        <Text style={[type.mono, { color: theme.textLo, marginTop: spacing[1] }]}>{errorText}</Text>
+      ) : null}
+    </Pressable>
   );
 }

--- a/apps/mobile/src/screens/chat/components/streamingMarkdown.test.ts
+++ b/apps/mobile/src/screens/chat/components/streamingMarkdown.test.ts
@@ -46,4 +46,21 @@ describe('sanitizeStreamingMarkdown (#5170)', () => {
   it('is a no-op on empty content', () => {
     expect(sanitizeStreamingMarkdown('')).toBe('');
   });
+
+  it('strips a dangling double-underscore bold opener', () => {
+    expect(sanitizeStreamingMarkdown('Meeting at __9 PM,')).toBe('Meeting at 9 PM,');
+  });
+
+  it('leaves a balanced double-underscore bold span untouched', () => {
+    expect(sanitizeStreamingMarkdown('This is __bold__ text')).toBe('This is __bold__ text');
+  });
+
+  it('resolves a closed span plus a dangling one of a different marker type together', () => {
+    expect(sanitizeStreamingMarkdown('This is **bold** and *italic')).toBe(
+      'This is **bold** and italic',
+    );
+    expect(sanitizeStreamingMarkdown('Run `kubectl get pods` then **check')).toBe(
+      'Run `kubectl get pods` then check',
+    );
+  });
 });

--- a/apps/mobile/src/screens/chat/components/streamingMarkdown.test.ts
+++ b/apps/mobile/src/screens/chat/components/streamingMarkdown.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeStreamingMarkdown } from './streamingMarkdown';
+
+describe('sanitizeStreamingMarkdown (#5170)', () => {
+  it('strips a dangling unmatched bold opener', () => {
+    // The symptom: `**IPFSVCHOST /` prints the literal `**` until the
+    // closing marker streams in. Strip the opener so the in-flight frame
+    // reads as plain text instead.
+    expect(sanitizeStreamingMarkdown('Fetching **IPFSVCHOST /')).toBe('Fetching IPFSVCHOST /');
+    expect(sanitizeStreamingMarkdown('Meeting at **9 PM,')).toBe('Meeting at 9 PM,');
+  });
+
+  it('leaves a balanced bold span untouched', () => {
+    expect(sanitizeStreamingMarkdown('This is **bold** text')).toBe('This is **bold** text');
+  });
+
+  it('leaves a trailing lone `*` in a list bullet line alone', () => {
+    // Streaming char-by-char, a new bullet line arrives as "*" before its
+    // trailing space — that's a list marker in progress, not a dangling
+    // emphasis opener, and must not be stripped.
+    expect(sanitizeStreamingMarkdown('- item\n*')).toBe('- item\n*');
+  });
+
+  it('strips a dangling single-asterisk italic opener outside a list context', () => {
+    expect(sanitizeStreamingMarkdown('Hello *world')).toBe('Hello world');
+  });
+
+  it('leaves a balanced italic span untouched', () => {
+    expect(sanitizeStreamingMarkdown('Hello *world* there')).toBe('Hello *world* there');
+  });
+
+  it('strips a dangling single backtick opener', () => {
+    expect(sanitizeStreamingMarkdown('Run `kubectl get pods')).toBe('Run kubectl get pods');
+  });
+
+  it('leaves an unterminated fenced code block untouched, backticks and all', () => {
+    const buffer = 'Here:\n```bash\necho "**not bold** `also not code`"\n';
+    expect(sanitizeStreamingMarkdown(buffer)).toBe(buffer);
+  });
+
+  it('leaves a completed fenced code block untouched even with dangling text after it', () => {
+    const buffer = '```js\nconst a = 1;\n```\nand then **more';
+    expect(sanitizeStreamingMarkdown(buffer)).toBe('```js\nconst a = 1;\n```\nand then more');
+  });
+
+  it('is a no-op on empty content', () => {
+    expect(sanitizeStreamingMarkdown('')).toBe('');
+  });
+});

--- a/apps/mobile/src/screens/chat/components/streamingMarkdown.ts
+++ b/apps/mobile/src/screens/chat/components/streamingMarkdown.ts
@@ -1,0 +1,95 @@
+/**
+ * Sanitizes an in-flight (still-streaming) assistant message buffer for
+ * `MarkdownBody` (#5170).
+ *
+ * `react-native-markdown-display` renders an unclosed inline marker
+ * literally: while a reply is streaming, a partial buffer like
+ * `Fetching **IPFSVCHOST /` prints the `**` as text because the closing
+ * marker hasn't arrived yet. The final buffer is always well-formed, so this
+ * must only be applied to the in-flight frame, never to a completed message.
+ *
+ * Approach: for each inline marker (`**`, `__`, `*`, `_`, a single
+ * backtick), count its occurrences in the buffer. Content before the
+ * currently-streaming token was already valid markdown in an earlier frame,
+ * so an odd count means exactly one dangling opener — the last occurrence —
+ * and it's safe to drop just that one. Fenced code blocks are left alone
+ * entirely: an open fence renders as code, which is an acceptable in-flight
+ * look, and stripping markers out of code content would be wrong anyway.
+ */
+export function sanitizeStreamingMarkdown(buffer: string): string {
+  if (!buffer) return buffer;
+
+  const fenceCount = (buffer.match(/^```/gm) ?? []).length;
+  if (fenceCount % 2 !== 0) {
+    // Inside an unterminated fenced code block — leave the whole buffer
+    // untouched, including any backticks/asterisks the code happens to contain.
+    return buffer;
+  }
+
+  // Protect *completed* fenced blocks from marker scanning too: only the
+  // text outside them can contain a dangling marker from the current turn.
+  const fenceRegex = /```[\s\S]*?```/g;
+  let result = '';
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = fenceRegex.exec(buffer))) {
+    result += stripDanglingInlineMarkers(buffer.slice(lastIndex, match.index));
+    result += match[0];
+    lastIndex = match.index + match[0].length;
+  }
+  result += stripDanglingInlineMarkers(buffer.slice(lastIndex));
+  return result;
+}
+
+function stripDanglingInlineMarkers(text: string): string {
+  let result = text;
+  result = stripIfOddCount(result, '**');
+  result = stripIfOddCount(result, '__');
+  result = stripDanglingSingleMarker(result, '*');
+  result = stripDanglingSingleMarker(result, '_');
+  result = stripIfOddCount(result, '`');
+  return result;
+}
+
+/** Non-overlapping occurrence count of `marker` in `text`. */
+function countOccurrences(text: string, marker: string): number {
+  return text.split(marker).length - 1;
+}
+
+/** Drops the LAST occurrence of `marker` when the buffer has an odd count of it. */
+function stripIfOddCount(text: string, marker: string): string {
+  const count = countOccurrences(text, marker);
+  if (count === 0 || count % 2 === 0) return text;
+  const lastIndex = text.lastIndexOf(marker);
+  return text.slice(0, lastIndex) + text.slice(lastIndex + marker.length);
+}
+
+/**
+ * Same idea as `stripIfOddCount`, but for a single-character marker (`*` or
+ * `_`) that also has to dodge two things `**`/`__` counting doesn't:
+ *  - a character that's part of a doubled run (already handled above), and
+ *  - a `*` shaped like a (possibly in-progress) list-item bullet — `* ` at
+ *    the start of a line, or just `*` at the very end of the buffer on its
+ *    own line while streaming hasn't delivered the trailing space yet. That
+ *    is a list marker, not an emphasis opener, and must not be stripped.
+ */
+function stripDanglingSingleMarker(text: string, marker: '*' | '_'): string {
+  const indices: number[] = [];
+  for (let i = 0; i < text.length; i++) {
+    if (text[i] !== marker) continue;
+    if (text[i - 1] === marker || text[i + 1] === marker) continue;
+
+    if (marker === '*') {
+      const atLineStart = i === 0 || text[i - 1] === '\n';
+      const next = text[i + 1];
+      const isBulletShape = atLineStart && (next === undefined || /\s/.test(next));
+      if (isBulletShape) continue;
+    }
+
+    indices.push(i);
+  }
+
+  if (indices.length === 0 || indices.length % 2 === 0) return text;
+  const last = indices[indices.length - 1];
+  return text.slice(0, last) + text.slice(last + 1);
+}

--- a/apps/mobile/src/screens/chat/components/toolIndicatorLogic.test.ts
+++ b/apps/mobile/src/screens/chat/components/toolIndicatorLogic.test.ts
@@ -89,9 +89,23 @@ describe('toolRowErrorText (#5170)', () => {
     expect(toolRowErrorText(undefined)).toBeNull();
     expect(toolRowErrorText(null)).toBeNull();
     expect(toolRowErrorText('a bare string output')).toBeNull();
-    expect(toolRowErrorText({ error: 42 })).toBeNull();
     expect(toolRowErrorText({ other: 'field' })).toBeNull();
     expect(toolRowErrorText({ error: '   ' })).toBeNull();
+  });
+
+  it('stringifies a nested error object instead of dropping it (#5170)', () => {
+    // A backend shape like `{ error: { code, message } }` must still produce
+    // SOMETHING tappable — silently falling back to the plain caption here
+    // reproduces the exact bug this feature exists to fix, just for
+    // object-typed errors instead of missing ones.
+    const result = toolRowErrorText({ error: { code: 'E_TIMEOUT', message: 'timed out' } });
+    expect(result).not.toBeNull();
+    expect(result).toContain('E_TIMEOUT');
+    expect(result).toContain('timed out');
+  });
+
+  it('returns null for a non-string, non-object error field (e.g. a bare number)', () => {
+    expect(toolRowErrorText({ error: 42 })).toBeNull();
   });
 
   it('trims to ~400 chars with an ellipsis', () => {
@@ -100,6 +114,15 @@ describe('toolRowErrorText (#5170)', () => {
     expect(result).not.toBeNull();
     expect(result!.length).toBeLessThanOrEqual(401);
     expect(result!.endsWith('…')).toBe(true);
+  });
+
+  it('passes exactly 400 chars through untouched, truncates at 401', () => {
+    const exactly400 = 'a'.repeat(400);
+    expect(toolRowErrorText({ error: exactly400 })).toBe(exactly400);
+
+    const exactly401 = 'a'.repeat(401);
+    const truncated = toolRowErrorText({ error: exactly401 });
+    expect(truncated).toBe(`${'a'.repeat(400)}…`);
   });
 });
 

--- a/apps/mobile/src/screens/chat/components/toolIndicatorLogic.test.ts
+++ b/apps/mobile/src/screens/chat/components/toolIndicatorLogic.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { aiToolLabel, toolRowStatus, toolRowSuffix } from './toolIndicatorLogic';
+import { aiToolLabel, toolRowErrorText, toolRowStatus, toolRowSuffix } from './toolIndicatorLogic';
 
 describe('toolRowStatus (#5107)', () => {
   it('reads a server-asserted handoff as approved, not failed', () => {
@@ -70,6 +70,39 @@ describe('toolRowSuffix', () => {
   });
 });
 
+describe('toolRowErrorText (#5170)', () => {
+  it('reads output.error', () => {
+    expect(toolRowErrorText({ error: 'restart failed: service not found' })).toBe(
+      'restart failed: service not found',
+    );
+  });
+
+  it('falls back to output.message when there is no error field', () => {
+    expect(toolRowErrorText({ message: 'connection refused' })).toBe('connection refused');
+  });
+
+  it('prefers error over message when both are present', () => {
+    expect(toolRowErrorText({ error: 'primary', message: 'secondary' })).toBe('primary');
+  });
+
+  it('returns null when there is nothing readable', () => {
+    expect(toolRowErrorText(undefined)).toBeNull();
+    expect(toolRowErrorText(null)).toBeNull();
+    expect(toolRowErrorText('a bare string output')).toBeNull();
+    expect(toolRowErrorText({ error: 42 })).toBeNull();
+    expect(toolRowErrorText({ other: 'field' })).toBeNull();
+    expect(toolRowErrorText({ error: '   ' })).toBeNull();
+  });
+
+  it('trims to ~400 chars with an ellipsis', () => {
+    const long = 'x'.repeat(500);
+    const result = toolRowErrorText({ error: long });
+    expect(result).not.toBeNull();
+    expect(result!.length).toBeLessThanOrEqual(401);
+    expect(result!.endsWith('…')).toBe(true);
+  });
+});
+
 describe('aiToolLabel (mobile mirror of packages/shared)', () => {
   it('reads as an action, not a symbol', () => {
     expect(aiToolLabel('manage_alerts', 'completed')).toBe('Updated alerts');
@@ -89,5 +122,36 @@ describe('aiToolLabel (mobile mirror of packages/shared)', () => {
       expect(aiToolLabel(name, 'completed')).not.toContain('_');
       expect(aiToolLabel(name, 'completed').length).toBeGreaterThan(0);
     }
+  });
+
+  it('reads as a check, not a mutation, when input.action is read-only (#5170)', () => {
+    // "Updated automations · DONE" when the assistant only listed automations
+    // reads as a change the tech never asked for. A read-only `action` on the
+    // call forces the `get` verb forms regardless of the leading verb.
+    expect(aiToolLabel('manage_automations', 'completed', { action: 'list' })).toBe(
+      'Checked automations',
+    );
+    expect(aiToolLabel('manage_automations', 'running', { action: 'list' })).toBe(
+      'Checking automations',
+    );
+    for (const action of ['list', 'get', 'search', 'status', 'show', 'read', 'query', 'describe', 'check', 'preview', 'view']) {
+      expect(aiToolLabel('manage_services', 'completed', { action })).toBe('Checked services');
+    }
+    // Case-insensitive.
+    expect(aiToolLabel('manage_automations', 'completed', { action: 'LIST' })).toBe(
+      'Checked automations',
+    );
+  });
+
+  it('leaves the verb alone when input.action is a mutation or absent', () => {
+    expect(aiToolLabel('manage_automations', 'completed', { action: 'create' })).toBe(
+      'Updated automations',
+    );
+    expect(aiToolLabel('manage_automations', 'completed')).toBe('Updated automations');
+    expect(aiToolLabel('manage_automations', 'completed', {})).toBe('Updated automations');
+    // A non-string action is ignored, not crashed on.
+    expect(aiToolLabel('manage_automations', 'completed', { action: 42 })).toBe(
+      'Updated automations',
+    );
   });
 });

--- a/apps/mobile/src/screens/chat/components/toolIndicatorLogic.ts
+++ b/apps/mobile/src/screens/chat/components/toolIndicatorLogic.ts
@@ -29,6 +29,27 @@ function errorText(output: unknown): string {
   return typeof value === 'string' ? value : '';
 }
 
+const MAX_TOOL_ROW_ERROR_TEXT_LENGTH = 400;
+
+/**
+ * The human-readable error text for a FAILED/DENIED tool row (#5170). Rows in
+ * those states had no expand affordance at all — see the comment on
+ * `toolRowStatus` above, written when this row was still unreachable.
+ * `output.error` wins over `output.message` since that's the field
+ * `errorText()` above already trusts as the tool's own error string.
+ */
+export function toolRowErrorText(output: unknown): string | null {
+  if (!output || typeof output !== 'object') return null;
+  const obj = output as { error?: unknown; message?: unknown };
+  const raw =
+    typeof obj.error === 'string' ? obj.error : typeof obj.message === 'string' ? obj.message : null;
+  if (raw === null) return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  if (trimmed.length <= MAX_TOOL_ROW_ERROR_TEXT_LENGTH) return trimmed;
+  return `${trimmed.slice(0, MAX_TOOL_ROW_ERROR_TEXT_LENGTH)}…`;
+}
+
 /**
  * Heuristic, and deliberately still a heuristic: a permission-style error
  * reads as DENIED, everything else as FAILED. Unlike the approval handoff
@@ -151,15 +172,47 @@ export function titleCaseToolName(toolName: string): string {
 }
 
 /**
+ * `input.action` values that mean the call only read data despite the tool's
+ * leading verb (`manage_automations` with `action: 'list'` mutates nothing).
+ * MIRROR of the same set in `packages/shared/src/utils/aiToolLabels.ts`.
+ */
+const READ_ONLY_ACTIONS = new Set([
+  'list',
+  'get',
+  'search',
+  'status',
+  'show',
+  'read',
+  'query',
+  'describe',
+  'check',
+  'preview',
+  'view',
+]);
+
+function isReadOnlyAction(input: Record<string, unknown> | undefined): boolean {
+  const action = input?.action;
+  return typeof action === 'string' && READ_ONLY_ACTIONS.has(action.toLowerCase());
+}
+
+/**
  * `aiToolLabel('manage_alerts', 'completed')` → "Updated alerts". Falls back
  * to title case for any tool that does not begin with a known verb, so a newly
  * registered tool never renders as a raw identifier again.
+ *
+ * `input` is the tool call's arguments. When `input.action` is a read-only
+ * verb (list/get/search/…), the row renders with the `get` conjugation
+ * regardless of the tool name's own leading verb (#5170).
  */
-export function aiToolLabel(toolName: string, state: AiToolLabelState): string {
+export function aiToolLabel(
+  toolName: string,
+  state: AiToolLabelState,
+  input?: Record<string, unknown>,
+): string {
   const words = toolNameWords(toolName);
   if (words.length === 0) return 'Tool';
 
-  const forms = VERB_FORMS[words[0].toLowerCase()];
+  const forms = isReadOnlyAction(input) ? VERB_FORMS.get : VERB_FORMS[words[0].toLowerCase()];
   const subject = words.slice(1).join(' ');
   if (!forms || !subject) return titleCaseToolName(toolName);
 

--- a/apps/mobile/src/screens/chat/components/toolIndicatorLogic.ts
+++ b/apps/mobile/src/screens/chat/components/toolIndicatorLogic.ts
@@ -37,17 +37,34 @@ const MAX_TOOL_ROW_ERROR_TEXT_LENGTH = 400;
  * `toolRowStatus` above, written when this row was still unreachable.
  * `output.error` wins over `output.message` since that's the field
  * `errorText()` above already trusts as the tool's own error string.
+ *
+ * A plain number/boolean error field is discarded — there's nothing readable
+ * to show. A nested object (`{ error: { code, message } }`) is stringified
+ * rather than discarded: dropping it silently would reproduce the exact bug
+ * this function exists to fix, just for object-typed errors.
  */
 export function toolRowErrorText(output: unknown): string | null {
   if (!output || typeof output !== 'object') return null;
   const obj = output as { error?: unknown; message?: unknown };
-  const raw =
-    typeof obj.error === 'string' ? obj.error : typeof obj.message === 'string' ? obj.message : null;
+  const field = obj.error !== undefined ? obj.error : obj.message;
+  const raw = stringifyErrorField(field);
   if (raw === null) return null;
   const trimmed = raw.trim();
   if (!trimmed) return null;
   if (trimmed.length <= MAX_TOOL_ROW_ERROR_TEXT_LENGTH) return trimmed;
   return `${trimmed.slice(0, MAX_TOOL_ROW_ERROR_TEXT_LENGTH)}…`;
+}
+
+function stringifyErrorField(value: unknown): string | null {
+  if (typeof value === 'string') return value;
+  if (value && typeof value === 'object') {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return null;
+    }
+  }
+  return null;
 }
 
 /**

--- a/apps/mobile/src/screens/chat/historyAdapter.test.ts
+++ b/apps/mobile/src/screens/chat/historyAdapter.test.ts
@@ -117,6 +117,53 @@ describe('historyToMessages', () => {
     expect(out[1].id).toBe('synth-tu1');
   });
 
+  it('carries toolInput onto the tool_use event (#5170)', () => {
+    // Without this, a `manage_*` read-only call reads "Updated …" again on
+    // reload/reconcile even though the live SSE path renders it correctly,
+    // because `aiToolLabel` needs `input.action` to tell the two apart.
+    const out = historyToMessages([
+      row({ id: 'a1', role: 'assistant', content: '' }),
+      row({
+        id: 'tu1',
+        role: 'tool_use',
+        toolUseId: 'tu-x',
+        toolName: 'manage_automations',
+        toolInput: { action: 'list' },
+      }),
+    ]);
+    const assistant = out[0];
+    if (assistant.role === 'assistant') {
+      expect(assistant.toolEvents[0].input).toEqual({ action: 'list' });
+    }
+  });
+
+  it('carries toolInput onto a tool_result-synthesized event too', () => {
+    const out = historyToMessages([
+      row({
+        id: 'tr1',
+        role: 'tool_result',
+        toolUseId: 'tu-x',
+        toolOutput: { ok: true },
+        toolInput: { action: 'get' },
+      }),
+    ]);
+    const placeholder = out[0];
+    if (placeholder.role === 'assistant') {
+      expect(placeholder.toolEvents[0].input).toEqual({ action: 'get' });
+    }
+  });
+
+  it('leaves input undefined when toolInput is not an object', () => {
+    const out = historyToMessages([
+      row({ id: 'a1', role: 'assistant', content: '' }),
+      row({ id: 'tu1', role: 'tool_use', toolUseId: 'tu-x', toolName: 't', toolInput: null }),
+    ]);
+    const assistant = out[0];
+    if (assistant.role === 'assistant') {
+      expect(assistant.toolEvents[0].input).toBeUndefined();
+    }
+  });
+
   it('falls back to row.id when toolUseId is missing on a tool_use row', () => {
     const out = historyToMessages([
       row({ id: 'a1', role: 'assistant', content: '' }),

--- a/apps/mobile/src/screens/chat/historyAdapter.ts
+++ b/apps/mobile/src/screens/chat/historyAdapter.ts
@@ -1,6 +1,12 @@
 import type { ChatMessage, ToolEvent } from '../../store/aiChatSlice';
 import type { ServerAiMessage } from '../../services/aiChat';
 
+// `toolInput` is `unknown` on the wire (JSON column) — narrow it the same
+// way `HomeScreen`'s live SSE handler does before it lands on a `ToolEvent`.
+function toolInputRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' ? (value as Record<string, unknown>) : undefined;
+}
+
 // Convert server-side aiMessages rows back into the slice's ChatMessage
 // shape. The server flattens role into 5 enum values (user / assistant /
 // system / tool_use / tool_result); the slice models user + assistant
@@ -55,6 +61,7 @@ export function historyToMessages(rows: ServerAiMessage[]): ChatMessage[] {
         toolUseId: row.toolUseId ?? row.id,
         toolName: row.toolName ?? 'tool',
         state: 'started',
+        input: toolInputRecord(row.toolInput),
       };
       target.toolEvents.push(evt);
     } else if (row.role === 'tool_result') {
@@ -72,6 +79,11 @@ export function historyToMessages(rows: ServerAiMessage[]): ChatMessage[] {
           toolName: row.toolName ?? 'tool',
           state: 'completed',
           output: row.toolOutput ?? undefined,
+          // A synthesized tool_result-only row (its tool_use sibling wasn't
+          // in this page of history) still carries its own toolInput on the
+          // server row — reuse it so `aiToolLabel` sees `input.action` here
+          // too (#5170).
+          input: toolInputRecord(row.toolInput),
         });
       }
     }

--- a/apps/mobile/src/store/aiChatSlice.ts
+++ b/apps/mobile/src/store/aiChatSlice.ts
@@ -14,6 +14,13 @@ export interface ToolEvent {
    * See `toolIndicatorLogic.toolRowStatus` for why the distinction matters.
    */
   handoff?: string;
+  /**
+   * The tool call's arguments, off the SSE `tool_use_start` event (#5170).
+   * Lets the row read `input.action` to tell a read-only call (`list`,
+   * `get`, …) apart from a mutation with the same leading verb — see
+   * `aiToolLabel`. Only ever set once, at `tool_use_start`.
+   */
+  input?: Record<string, unknown>;
 }
 
 export type ChatMessage =
@@ -35,7 +42,7 @@ export interface AiChatState {
   // Lets the UI render a streaming pulse on the right row without scanning.
   streamingMessageId: string | null;
   // Tracks the in-flight tool name for the mid-stream caption ("CHECKING FLEET").
-  inFlightTool: { toolUseId: string; toolName: string } | null;
+  inFlightTool: { toolUseId: string; toolName: string; input?: Record<string, unknown> } | null;
   status: ChatStatus;
   error: string | null;
 }
@@ -83,7 +90,10 @@ const aiChatSlice = createSlice({
         msg.content += action.payload.delta;
       }
     },
-    setInFlightTool(state, action: PayloadAction<{ toolUseId: string; toolName: string } | null>) {
+    setInFlightTool(
+      state,
+      action: PayloadAction<{ toolUseId: string; toolName: string; input?: Record<string, unknown> } | null>,
+    ) {
       state.inFlightTool = action.payload;
     },
     appendToolEvent(state, action: PayloadAction<{ messageId: string; event: ToolEvent }>) {
@@ -95,6 +105,7 @@ const aiChatSlice = createSlice({
           if (action.payload.event.output !== undefined) existing.output = action.payload.event.output;
           if (action.payload.event.isError !== undefined) existing.isError = action.payload.event.isError;
           if (action.payload.event.handoff !== undefined) existing.handoff = action.payload.event.handoff;
+          if (action.payload.event.input !== undefined) existing.input = action.payload.event.input;
         } else {
           msg.toolEvents.push(action.payload.event);
         }
@@ -185,7 +196,9 @@ const aiChatSlice = createSlice({
       last.isStreaming = true;
       state.streamingMessageId = last.id;
       const running = last.toolEvents.find((t) => t.state === 'started');
-      state.inFlightTool = running ? { toolUseId: running.toolUseId, toolName: running.toolName } : null;
+      state.inFlightTool = running
+        ? { toolUseId: running.toolUseId, toolName: running.toolName, input: running.input }
+        : null;
       state.status = 'streaming';
     },
   },

--- a/apps/web/src/components/ai/AiToolCallCard.tsx
+++ b/apps/web/src/components/ai/AiToolCallCard.tsx
@@ -88,7 +88,7 @@ export default function AiToolCallCard({
         )}
         <StatusIcon />
         <span className="font-medium text-gray-700 dark:text-gray-300">
-          {aiToolLabel(toolName, isExecuting ? "running" : "completed")}
+          {aiToolLabel(toolName, isExecuting ? "running" : "completed", input)}
         </span>
         {isApprovedExecuting ? (
           <span className="text-amber-400">

--- a/packages/shared/src/utils/aiToolLabels.test.ts
+++ b/packages/shared/src/utils/aiToolLabels.test.ts
@@ -53,4 +53,34 @@ describe('aiToolLabel', () => {
     expect(titleCaseToolName('mcp__breeze__manage_alerts')).toBe('Manage alerts');
     expect(titleCaseToolName('')).toBe('Tool');
   });
+
+  it('reads as a check, not a mutation, when input.action is read-only (#5170)', () => {
+    // "Updated automations · DONE" when the assistant only listed automations
+    // reads as a change the tech never asked for. A read-only `action` on the
+    // call forces the `get` verb forms regardless of the leading verb.
+    expect(aiToolLabel('manage_automations', 'completed', { action: 'list' })).toBe(
+      'Checked automations',
+    );
+    expect(aiToolLabel('manage_automations', 'running', { action: 'list' })).toBe(
+      'Checking automations',
+    );
+    for (const action of ['list', 'get', 'search', 'status', 'show', 'read', 'query', 'describe', 'check', 'preview', 'view']) {
+      expect(aiToolLabel('manage_services', 'completed', { action })).toBe('Checked services');
+    }
+    // Case-insensitive.
+    expect(aiToolLabel('manage_automations', 'completed', { action: 'LIST' })).toBe(
+      'Checked automations',
+    );
+  });
+
+  it('leaves the verb alone when input.action is a mutation or absent', () => {
+    expect(aiToolLabel('manage_automations', 'completed', { action: 'create' })).toBe(
+      'Updated automations',
+    );
+    expect(aiToolLabel('manage_automations', 'completed')).toBe('Updated automations');
+    expect(aiToolLabel('manage_automations', 'completed', {})).toBe('Updated automations');
+    expect(aiToolLabel('manage_automations', 'completed', { action: 42 })).toBe(
+      'Updated automations',
+    );
+  });
 });

--- a/packages/shared/src/utils/aiToolLabels.ts
+++ b/packages/shared/src/utils/aiToolLabels.ts
@@ -91,16 +91,51 @@ export function titleCaseToolName(toolName: string): string {
 }
 
 /**
+ * `input.action` values that mean the call only read data despite the tool's
+ * leading verb (`manage_automations` with `action: 'list'` mutates nothing).
+ * A tech reading "Updated automations" for a call that only looked something
+ * up reads it as a change they never asked for (#5170) — force the `get`
+ * verb forms whenever the call carries one of these, regardless of the tool
+ * name's own verb.
+ */
+const READ_ONLY_ACTIONS = new Set([
+  'list',
+  'get',
+  'search',
+  'status',
+  'show',
+  'read',
+  'query',
+  'describe',
+  'check',
+  'preview',
+  'view',
+]);
+
+function isReadOnlyAction(input: Record<string, unknown> | undefined): boolean {
+  const action = input?.action;
+  return typeof action === 'string' && READ_ONLY_ACTIONS.has(action.toLowerCase());
+}
+
+/**
  * The label for a tool row, e.g. `aiToolLabel('manage_alerts', 'completed')`
  * → "Updated alerts". Falls back to `titleCaseToolName` for any tool whose
  * name does not begin with a known verb, or which is nothing but a verb.
+ *
+ * `input` is the tool call's arguments. When `input.action` is a read-only
+ * verb (list/get/search/…), the row renders with the `get` conjugation
+ * ("Checking"/"Checked") no matter what the tool name's leading verb is.
  */
-export function aiToolLabel(toolName: string, state: AiToolLabelState): string {
+export function aiToolLabel(
+  toolName: string,
+  state: AiToolLabelState,
+  input?: Record<string, unknown>,
+): string {
   const words = bareToolName(toolName).split('_').filter(Boolean);
   const verb = words[0];
   if (verb === undefined) return 'Tool';
 
-  const forms = VERB_FORMS[verb.toLowerCase()];
+  const forms = isReadOnlyAction(input) ? VERB_FORMS.get : VERB_FORMS[verb.toLowerCase()];
   const subject = words.slice(1).join(' ');
   // A bare verb ("get_", "run") has no subject to attach, so "Checked" alone
   // would say nothing — fall through to the neutral name instead.


### PR DESCRIPTION
## Summary

Three mobile chat papercuts from the round-3 OliveTech iOS test (`~/Documents/ios-test-olivetech-rnd3-frames-2026-09-07/REVIEW.md`):

1. **Streaming markdown showed raw `**`.** While a reply streams, the partial buffer can end mid-token (`**IPFSVCHOST /`, `**9 PM,`) and `react-native-markdown-display` prints the unclosed marker literally. Added `apps/mobile/src/screens/chat/components/streamingMarkdown.ts` — `sanitizeStreamingMarkdown(buffer)` strips a trailing unmatched inline marker (`**`, `__`, `*`, `_`, single backtick) for the in-flight message only. Fenced code blocks are left untouched (an open fence rendering as code is acceptable). Wired via a new `streaming` prop on `MarkdownBody`, set from `message.isStreaming` in `AiMessage` — a completed message's buffer never runs through the sanitizer, so final render is byte-for-byte the same as before.

2. **FAILED/DENIED tool rows had no way to see the error.** `toolIndicatorLogic.ts` even documented the gap ("this row has no expand affordance"). Added `toolRowErrorText(output)` (reads `output.error`, falls back to `output.message`, trims to ~400 chars with an ellipsis). `ToolIndicator` now renders FAILED/DENIED rows as a `Pressable` (`accessibilityRole="button"`, `accessibilityLabel="Show error"`) that toggles a mono-font detail line underneath, following the existing `ScriptResultBlock` expand pattern (`haptic.tap()` + local `useState`). Completed/approved rows are unchanged (non-interactive).

3. **`manage_*` rows always said "Updated …", even for reads.** `aiToolLabel` conjugated on the tool name's leading verb only, never on the call's `action` argument, so `manage_automations` with `action: 'list'` rendered "Updated automations · DONE" for a read-only lookup. `aiToolLabel` (both `packages/shared/src/utils/aiToolLabels.ts` and its mobile mirror in `toolIndicatorLogic.ts`, kept in lockstep per the header comment) now takes an optional `input` and forces the `get` verb forms when `input.action` (case-insensitive) is one of `list, get, search, status, show, read, query, describe, check, preview, view`.
   - **Mobile wiring**: the SSE `tool_use_start` event already carried `input` on the wire type but it was never threaded through. Added `input` to `ToolEvent` and the `inFlightTool` slice state, forwarded it from `HomeScreen`'s stream handler through `ConversationList` → `AiMessage` → `ToolIndicator`.
   - **Web**: `AiToolCallCard.tsx` already receives `input` as a prop — now passes it into `aiToolLabel`.

## Test plan

- [x] `cd packages/shared && npx vitest run src/utils/aiToolLabels` — 9 passed (red-first: added the read-only-action tests, watched them fail, then implemented)
- [x] `cd apps/mobile && npx vitest run src/screens/chat` — 97 passed (includes new `streamingMarkdown.test.ts`, extended `toolIndicatorLogic.test.ts`)
- [x] `cd apps/mobile && npx tsc --noEmit` — clean
- [x] `cd apps/web && npx vitest run src/components/ai` — 311 passed
- [x] `pnpm --filter @breeze/web exec tsc --noEmit` — clean (ran to completion, exit 0)

No screenshots — described the behavior change above instead (per task instructions, screenshots weren't available in this environment).

Closes #5170

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ob54chDEyqe7Cm8kbB4VW