### PR TITLE
fix(mobile): degrade findings 404 silently, stop approval empty-state flash (#5172)

### DIFF
--- a/apps/mobile/src/navigation/ApprovalGate.tsx
+++ b/apps/mobile/src/navigation/ApprovalGate.tsx
@@ -5,6 +5,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { logoutAsync } from '../store/authSlice';
 import { approverBannerCopy, type ApproverBannerSeverity } from './approverBannerCopy';
+import { selectFocusedApproval, selectTakeoverVisible } from './approvalTakeover';
 import { useAppDispatch, useAppSelector } from '../store';
 import {
   clearApprovalsError,
@@ -48,9 +49,10 @@ export const LAST_HANDLED_APPROVAL_RESPONSE_KEY = 'notif:lastHandledApprovalResp
  */
 export function ApprovalGate({ children }: Props) {
   const dispatch = useAppDispatch();
-  const focused = useAppSelector((s) =>
-    s.approvals.pending.find((a) => a.id === s.approvals.focusId && a.status === 'pending')
-  );
+  // #5172: shared with ApprovalScreen so the takeover Modal's visibility and
+  // the screen's own "focused" can never drift apart — see approvalTakeover.ts.
+  const focused = useAppSelector((s) => selectFocusedApproval(s.approvals));
+  const takeoverVisible = useAppSelector((s) => selectTakeoverVisible(s.approvals));
   const error = useAppSelector((s) => s.approvals.error);
   const pushRegistration = useAppSelector((s) => s.auth.pushRegistration);
   const approverRegistration = useAppSelector((s) => s.auth.approverRegistration);
@@ -157,7 +159,7 @@ export function ApprovalGate({ children }: Props) {
     <>
       {children}
       <Modal
-        visible={!!focused}
+        visible={takeoverVisible}
         animationType="none"
         presentationStyle="fullScreen"
         statusBarTranslucent
@@ -166,11 +168,11 @@ export function ApprovalGate({ children }: Props) {
       >
         <ApprovalScreen />
       </Modal>
-      {focused ? null : error ? (
+      {takeoverVisible ? null : error ? (
         <ApprovalErrorBanner message={error} onDismiss={() => dispatch(clearApprovalsError())} />
       ) : null}
-      {!focused && showPush ? <PushFailedBanner onDismiss={() => setDismissedPush(true)} /> : null}
-      {!focused && showApprover && approverSeverity ? (
+      {!takeoverVisible && showPush ? <PushFailedBanner onDismiss={() => setDismissedPush(true)} /> : null}
+      {!takeoverVisible && showApprover && approverSeverity ? (
         <ApproverSetupBanner
           severity={approverSeverity}
           reason={approverReason}

--- a/apps/mobile/src/navigation/ApprovalGate.tsx
+++ b/apps/mobile/src/navigation/ApprovalGate.tsx
@@ -5,7 +5,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { logoutAsync } from '../store/authSlice';
 import { approverBannerCopy, type ApproverBannerSeverity } from './approverBannerCopy';
-import { selectFocusedApproval, selectTakeoverVisible } from './approvalTakeover';
+import { selectFocusedApproval } from './approvalTakeover';
 import { useAppDispatch, useAppSelector } from '../store';
 import {
   clearApprovalsError,
@@ -52,7 +52,9 @@ export function ApprovalGate({ children }: Props) {
   // #5172: shared with ApprovalScreen so the takeover Modal's visibility and
   // the screen's own "focused" can never drift apart — see approvalTakeover.ts.
   const focused = useAppSelector((s) => selectFocusedApproval(s.approvals));
-  const takeoverVisible = useAppSelector((s) => selectTakeoverVisible(s.approvals));
+  // Derived from `focused` itself (not a second store subscription) so the
+  // two can never disagree — see the module doc in approvalTakeover.ts.
+  const takeoverVisible = !!focused;
   const error = useAppSelector((s) => s.approvals.error);
   const pushRegistration = useAppSelector((s) => s.auth.pushRegistration);
   const approverRegistration = useAppSelector((s) => s.auth.approverRegistration);

--- a/apps/mobile/src/navigation/approvalTakeover.test.ts
+++ b/apps/mobile/src/navigation/approvalTakeover.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+
+import { selectFocusedApproval, selectTakeoverVisible, type ApprovalTakeoverQueueState } from './approvalTakeover';
+import type { ApprovalRequest } from '../services/approvals';
+
+function makeApproval(overrides: Partial<ApprovalRequest> = {}): ApprovalRequest {
+  return {
+    id: 'req-1',
+    requestingClientLabel: 'Claude Web',
+    requestingMachineLabel: null,
+    actionLabel: 'Restart agent on box-1',
+    actionToolName: 'restart_agent',
+    actionArguments: {},
+    riskTier: 'medium',
+    riskSummary: 'Will reboot the agent service',
+    customerTenant: null,
+    status: 'pending',
+    expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    decidedAt: null,
+    decisionReason: null,
+    isRecursive: false,
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+/**
+ * #5172: ApprovalGate (Modal.visible) and ApprovalScreen (its content
+ * branch) used to each recompute "is there a focused pending approval"
+ * with their own independently-written inline selector. This module is the
+ * single shared derivation both must call instead, so there is no way for
+ * one to say visible while the other says hidden.
+ */
+describe('selectFocusedApproval / selectTakeoverVisible', () => {
+  it('pending with one row → visible+focused', () => {
+    const row = makeApproval({ id: 'a' });
+    const state: ApprovalTakeoverQueueState = { pending: [row], focusId: 'a' };
+
+    expect(selectFocusedApproval(state)).toBe(row);
+    expect(selectTakeoverVisible(state)).toBe(true);
+  });
+
+  it('after dropAndRefocus → both hidden in the same state', () => {
+    // Simulates the reducer transition approve.fulfilled/deny.fulfilled run:
+    // the decided row is filtered out of `pending` and, since nothing else
+    // is left pending, `focusId` rolls to null in the SAME state update.
+    const state: ApprovalTakeoverQueueState = { pending: [], focusId: null };
+
+    expect(selectFocusedApproval(state)).toBeUndefined();
+    expect(selectTakeoverVisible(state)).toBe(false);
+  });
+
+  it('rolls to the next pending row when one is dropped but another remains', () => {
+    const next = makeApproval({ id: 'b' });
+    const state: ApprovalTakeoverQueueState = { pending: [next], focusId: 'b' };
+
+    expect(selectFocusedApproval(state)).toBe(next);
+    expect(selectTakeoverVisible(state)).toBe(true);
+  });
+
+  it('ignores a focusId that points at a non-pending (e.g. expired) row', () => {
+    const row = makeApproval({ id: 'a', status: 'expired' });
+    const state: ApprovalTakeoverQueueState = { pending: [row], focusId: 'a' };
+
+    expect(selectFocusedApproval(state)).toBeUndefined();
+    expect(selectTakeoverVisible(state)).toBe(false);
+  });
+});

--- a/apps/mobile/src/navigation/approvalTakeover.ts
+++ b/apps/mobile/src/navigation/approvalTakeover.ts
@@ -1,0 +1,34 @@
+import type { ApprovalRequest } from '../services/approvals';
+
+/** The slice of `state.approvals` this module needs. */
+export interface ApprovalTakeoverQueueState {
+  pending: ApprovalRequest[];
+  focusId: string | null;
+}
+
+/**
+ * The single derivation of "is there a focused pending approval right now",
+ * shared by BOTH `ApprovalGate` (drives its takeover `Modal`'s `visible`
+ * prop) and `ApprovalScreen` (drives its content branch) — #5172.
+ *
+ * Before this module existed, the two components each wrote their own
+ * inline `state.approvals.pending.find(...)` selector. The formulas were
+ * identical, so this was never a redux-level race — `dropAndRefocus` clears
+ * `pending` membership and `focusId` in the same reducer update, so any
+ * subscriber reads a consistent snapshot. The bug this module exists to
+ * make impossible to reintroduce is a maintenance one: a future edit to one
+ * copy (e.g. adding an extra status check) silently drifting from the
+ * other, which would let the Modal's visibility and the screen's own idea
+ * of "focused" disagree for a render.
+ */
+export function selectFocusedApproval(
+  state: ApprovalTakeoverQueueState
+): ApprovalRequest | undefined {
+  return state.pending.find((a) => a.id === state.focusId && a.status === 'pending');
+}
+
+/** Whether the takeover `Modal` should be visible. Derived from the same
+ * selector as `selectFocusedApproval` so the two can never disagree. */
+export function selectTakeoverVisible(state: ApprovalTakeoverQueueState): boolean {
+  return selectFocusedApproval(state) !== undefined;
+}

--- a/apps/mobile/src/screens/approvals/ApprovalScreen.tsx
+++ b/apps/mobile/src/screens/approvals/ApprovalScreen.tsx
@@ -16,7 +16,7 @@ import { useApprovalTheme, type, spacing, palette } from '../../theme';
 import { duration, ease, haptic } from '../../lib/motion';
 import { track } from '../../lib/analytics';
 
-import { shouldShowEmptyApprovalState } from './approvalDecidedTransition';
+import { isDecisionToastVisible, shouldShowEmptyApprovalState } from './approvalDecidedTransition';
 import { CountdownRing } from './components/CountdownRing';
 import { RequesterAvatar } from './components/RequesterAvatar';
 import { RequesterRow } from './components/RequesterRow';
@@ -53,8 +53,12 @@ export function ApprovalScreen() {
   // focus in the same tick the "Approved · …" toast is queued — so without
   // the key, A's success toast renders over B's Approve/Deny buttons. The
   // success/deny confirmations are therefore deliberately dropped once focus
-  // has moved on (the wash / shake animation is the feedback that survives);
-  // outcome ERRORS use `approvalId: null` and stay visible regardless.
+  // rolls onto a DIFFERENT pending request (the wash/shake animation is the
+  // feedback that survives that case). When focus instead rolls to NOTHING
+  // (A was the last pending row), the toast is exactly what rescues the
+  // takeover from flashing "No pending approvals" before it — see
+  // `isDecisionToastVisible` (#5172). Outcome ERRORS use `approvalId: null`
+  // and stay visible regardless of focus either way.
   const [toast, setToast] = useState<{
     approvalId: string | null;
     kind: 'success' | 'error';
@@ -63,6 +67,22 @@ export function ApprovalScreen() {
   const [reportSheetOpen, setReportSheetOpen] = useState(false);
   const [reportBusy, setReportBusy] = useState(false);
   const expiredHandledRef = useRef<string | null>(null);
+
+  // Safety net for the neutral holding view below (#5172): the ONLY other
+  // path that clears `toast` is <Toast>'s own exit-animation completion
+  // callback (`onHidden`), which Reanimated only calls when the animation
+  // actually finishes (`finished === true`) — an interruption (app
+  // backgrounded mid-exit, a fast remount) can skip it. Before this fix a
+  // stuck `toast` was harmless noise; now, while nothing is focused, it is
+  // the one thing standing between the holding view and the genuine empty
+  // state, so a plain JS backstop guarantees this can't wedge open forever.
+  // Toast's own lifecycle is enter (240ms) + hold (1800ms) + exit (180ms);
+  // comfortably doubled here.
+  useEffect(() => {
+    if (!toast) return;
+    const t = setTimeout(() => setToast(null), 4500);
+    return () => clearTimeout(t);
+  }, [toast]);
 
   // When does the user "see" the approval? When ApprovalScreen mounts onto a
   // focused approval — that's the takeover moment. We stamp it per approval
@@ -224,7 +244,7 @@ export function ApprovalScreen() {
   // Computed before the `!focused` branch below (#5172): the decision that
   // just cleared `focused` is exactly what queues this toast, so the toast's
   // liveness has to be known before deciding what "no focused row" renders.
-  const toastVisible = !!toast && (toast.approvalId === null || toast.approvalId === focused?.id);
+  const toastVisible = isDecisionToastVisible(toast, focused?.id);
 
   if (!focused) {
     if (shouldShowEmptyApprovalState({ focused: false, decisionToastPending: toastVisible })) {

--- a/apps/mobile/src/screens/approvals/ApprovalScreen.tsx
+++ b/apps/mobile/src/screens/approvals/ApprovalScreen.tsx
@@ -11,10 +11,12 @@ import { ScrollView } from 'react-native-gesture-handler';
 
 import { useAppDispatch, useAppSelector } from '../../store';
 import { approve, deny, markExpired, reportSuspicious } from '../../store/approvalsSlice';
+import { selectFocusedApproval } from '../../navigation/approvalTakeover';
 import { useApprovalTheme, type, spacing, palette } from '../../theme';
 import { duration, ease, haptic } from '../../lib/motion';
 import { track } from '../../lib/analytics';
 
+import { shouldShowEmptyApprovalState } from './approvalDecidedTransition';
 import { CountdownRing } from './components/CountdownRing';
 import { RequesterAvatar } from './components/RequesterAvatar';
 import { RequesterRow } from './components/RequesterRow';
@@ -35,9 +37,9 @@ export function ApprovalScreen() {
   const theme = useApprovalTheme('dark');
   const dispatch = useAppDispatch();
 
-  const focused = useAppSelector((s) =>
-    s.approvals.pending.find((a) => a.id === s.approvals.focusId && a.status === 'pending')
-  );
+  // #5172: shared with ApprovalGate so the takeover Modal's visibility and
+  // this screen's content branch can never drift apart — see approvalTakeover.ts.
+  const focused = useAppSelector((s) => selectFocusedApproval(s.approvals));
   const inFlight = useAppSelector((s) =>
     focused ? (s.approvals.decisionInFlight[focused.id] ?? null) : null
   );
@@ -217,13 +219,40 @@ export function ApprovalScreen() {
     dispatch(markExpired(focused.id));
   }
 
+  // A toast bound to a request that is no longer on screen is stale; a toast
+  // with no approval id (report outcome, focus-swap guard) is screen-global.
+  // Computed before the `!focused` branch below (#5172): the decision that
+  // just cleared `focused` is exactly what queues this toast, so the toast's
+  // liveness has to be known before deciding what "no focused row" renders.
+  const toastVisible = !!toast && (toast.approvalId === null || toast.approvalId === focused?.id);
+
   if (!focused) {
+    if (shouldShowEmptyApprovalState({ focused: false, decisionToastPending: toastVisible })) {
+      return (
+        <View style={{ flex: 1, backgroundColor: theme.bg0, paddingTop: insets.top + spacing[10], paddingHorizontal: spacing[6] }}>
+          <Text style={[type.title, { color: theme.textHi }]}>No pending approvals</Text>
+          <Text style={[type.body, { color: theme.textMd, marginTop: spacing[2] }]}>
+            You're all caught up.
+          </Text>
+        </View>
+      );
+    }
+    // A decision (approve/deny/report) was just confirmed on the last
+    // pending row and its outcome toast is still owed. Hold on a neutral
+    // background instead of flashing "No pending approvals" while the
+    // takeover Modal's native dismiss transition is still in flight (#5172)
+    // — the toast clears this itself via `onHidden`, at which point
+    // `shouldShowEmptyApprovalState` above takes the branch that renders
+    // the genuine empty state (or ApprovalGate has finished dismissing the
+    // Modal and this has already stopped being visible to the user).
     return (
-      <View style={{ flex: 1, backgroundColor: theme.bg0, paddingTop: insets.top + spacing[10], paddingHorizontal: spacing[6] }}>
-        <Text style={[type.title, { color: theme.textHi }]}>No pending approvals</Text>
-        <Text style={[type.body, { color: theme.textMd, marginTop: spacing[2] }]}>
-          You're all caught up.
-        </Text>
+      <View style={{ flex: 1, backgroundColor: theme.bg0 }}>
+        <Toast
+          visible={toastVisible}
+          text={toast?.text ?? ''}
+          kind={toast?.kind ?? 'success'}
+          onHidden={() => setToast(null)}
+        />
       </View>
     );
   }
@@ -238,9 +267,6 @@ export function ApprovalScreen() {
   // other flow keeps the existing actionLabel + generic JSON details.
   const flowType = resolveApprovalFlowType(focused);
   const copy = getApprovalCopy(focused);
-  // A toast bound to a request that is no longer on screen is stale; a toast
-  // with no approval id (report outcome, focus-swap guard) is screen-global.
-  const toastVisible = !!toast && (toast.approvalId === null || toast.approvalId === focused.id);
 
   return (
     <View style={{ flex: 1, backgroundColor: theme.bg0 }}>

--- a/apps/mobile/src/screens/approvals/approvalDecidedTransition.test.ts
+++ b/apps/mobile/src/screens/approvals/approvalDecidedTransition.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { shouldShowEmptyApprovalState } from './approvalDecidedTransition';
+import { isDecisionToastVisible, shouldShowEmptyApprovalState } from './approvalDecidedTransition';
 
 /**
  * #5172: ApprovalScreen's `!focused` branch rendered "No pending approvals /
@@ -24,5 +24,41 @@ describe('shouldShowEmptyApprovalState', () => {
 
   it('shows the genuine empty state once nothing is focused and no toast is owed', () => {
     expect(shouldShowEmptyApprovalState({ focused: false, decisionToastPending: false })).toBe(true);
+  });
+});
+
+/**
+ * #5172 root cause, precisely: `approve`/`deny` queue their confirmation
+ * toast with `approvalId: <the just-decided row's own id>` — never `null` —
+ * so a naive `toast.approvalId === focusedId` check goes false the instant
+ * `dropAndRefocus` clears focus on the LAST pending row (focusedId becomes
+ * undefined, but the toast's approvalId is a real, non-null string). That
+ * silently dropped the primary approve/deny confirmation in exactly the
+ * case this fix targets, while an `approvalId: null` toast (report outcome,
+ * expiry, focus-swap guard) was unaffected. `isDecisionToastVisible` is the
+ * single source of truth `ApprovalScreen` calls instead of an inline check,
+ * so this contract can be tested directly.
+ */
+describe('isDecisionToastVisible', () => {
+  it('is false with no toast', () => {
+    expect(isDecisionToastVisible(null, 'a')).toBe(false);
+    expect(isDecisionToastVisible(null, undefined)).toBe(false);
+  });
+
+  it('a screen-global toast (approvalId: null) is always visible', () => {
+    expect(isDecisionToastVisible({ approvalId: null }, 'a')).toBe(true);
+    expect(isDecisionToastVisible({ approvalId: null }, undefined)).toBe(true);
+  });
+
+  it('a toast for the currently-focused row is visible', () => {
+    expect(isDecisionToastVisible({ approvalId: 'a' }, 'a')).toBe(true);
+  });
+
+  it('a toast for a DIFFERENT row than the one now focused is dropped (rolled to the next request)', () => {
+    expect(isDecisionToastVisible({ approvalId: 'a' }, 'b')).toBe(false);
+  });
+
+  it('#5172: a toast for the just-decided row is visible when NOTHING is now focused (last item)', () => {
+    expect(isDecisionToastVisible({ approvalId: 'a' }, undefined)).toBe(true);
   });
 });

--- a/apps/mobile/src/screens/approvals/approvalDecidedTransition.test.ts
+++ b/apps/mobile/src/screens/approvals/approvalDecidedTransition.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+
+import { shouldShowEmptyApprovalState } from './approvalDecidedTransition';
+
+/**
+ * #5172: ApprovalScreen's `!focused` branch rendered "No pending approvals /
+ * You're all caught up." the instant a decision (approve/deny) resolved on
+ * the LAST pending row — dropAndRefocus clears `focused` in the same tick
+ * the "Approved · …" toast is queued, so the takeover flashed the empty
+ * copy for as long as the Modal's native dismiss takes, and the decision
+ * confirmation never appeared at all (the toast lived below this early
+ * return). The genuine empty state (nothing pending, no toast owed) must
+ * still render correctly.
+ */
+describe('shouldShowEmptyApprovalState', () => {
+  it('never shows empty state while a row is focused', () => {
+    expect(shouldShowEmptyApprovalState({ focused: true, decisionToastPending: false })).toBe(false);
+    expect(shouldShowEmptyApprovalState({ focused: true, decisionToastPending: true })).toBe(false);
+  });
+
+  it('holds off the empty state while a decision toast is still owed', () => {
+    expect(shouldShowEmptyApprovalState({ focused: false, decisionToastPending: true })).toBe(false);
+  });
+
+  it('shows the genuine empty state once nothing is focused and no toast is owed', () => {
+    expect(shouldShowEmptyApprovalState({ focused: false, decisionToastPending: false })).toBe(true);
+  });
+});

--- a/apps/mobile/src/screens/approvals/approvalDecidedTransition.ts
+++ b/apps/mobile/src/screens/approvals/approvalDecidedTransition.ts
@@ -1,0 +1,22 @@
+/**
+ * #5172: ApprovalScreen's early-return "No pending approvals / You're all
+ * caught up." branch used to fire the instant `focused` went missing — which
+ * happens in the SAME tick a decision (approve/deny/report) resolves on the
+ * last pending row (`dropAndRefocus` rolls `focusId` to null). The
+ * "Approved · …" / "Denied · logged" toast is queued in that same moment,
+ * but the toast lives below the early return in the component, so it never
+ * rendered at all: the takeover just flashed the generic empty copy for as
+ * long as the Modal's native dismiss transition takes, then disappeared.
+ *
+ * This is the single decision point for which branch ApprovalScreen renders.
+ * The genuine empty state (nothing focused, no decision confirmation still
+ * owed) is unaffected — it renders exactly when it used to.
+ */
+export function shouldShowEmptyApprovalState(inputs: {
+  /** Is there currently a focused pending approval (see `approvalTakeover.ts`)? */
+  focused: boolean;
+  /** Is a just-decided approval's outcome toast still owed to the user? */
+  decisionToastPending: boolean;
+}): boolean {
+  return !inputs.focused && !inputs.decisionToastPending;
+}

--- a/apps/mobile/src/screens/approvals/approvalDecidedTransition.ts
+++ b/apps/mobile/src/screens/approvals/approvalDecidedTransition.ts
@@ -20,3 +20,31 @@ export function shouldShowEmptyApprovalState(inputs: {
 }): boolean {
   return !inputs.focused && !inputs.decisionToastPending;
 }
+
+/**
+ * Whether a queued toast should be shown right now.
+ *
+ * `approve`/`deny` queue their confirmation with `approvalId: <the decided
+ * row's own id>` — a real, non-null string, never `null`. A naive
+ * `toast.approvalId === focusedId` check therefore goes false the instant
+ * `dropAndRefocus` clears focus on the LAST pending row (`focusedId` becomes
+ * `undefined`, but the toast's id is not) — silently dropping the exact
+ * confirmation #5172 is about. `approvalId: null` is reserved for toasts
+ * that are screen-global by design (report-suspicious outcome, expiry,
+ * focus-swap guard) and are always shown regardless of focus.
+ *
+ * The remaining case — a toast for a row OTHER than the one now focused
+ * (focus rolled forward to the NEXT pending request, not to nothing) — stays
+ * dropped on purpose: see the `toast` state doc in ApprovalScreen.tsx for why
+ * (the wash/shake animation is the confirmation that survives a focus swap,
+ * not the toast).
+ */
+export function isDecisionToastVisible(
+  toast: { approvalId: string | null } | null,
+  focusedId: string | undefined
+): boolean {
+  if (!toast) return false;
+  if (toast.approvalId === null) return true;
+  if (focusedId === undefined) return true;
+  return toast.approvalId === focusedId;
+}

--- a/apps/mobile/src/screens/systems/mergeSystemsResults.test.ts
+++ b/apps/mobile/src/screens/systems/mergeSystemsResults.test.ts
@@ -213,6 +213,21 @@ describe('rejectionReasons', () => {
   it('is empty when nothing failed', () => {
     expect(rejectionReasons(allOk)).toEqual([]);
   });
+
+  it('excludes a 404 on findings (#5172) — expected + permanent on an older server, not a Sentry-worthy error', () => {
+    // Reported via useSystemsData's `for (const reason of rejectionReasons(...))
+    // reportInternalError(...)` loop. Without this exclusion, every self-hoster
+    // a release behind spams Sentry with the exact condition mergeSystemsResults
+    // already treats as "feature unavailable", forever, on every fetch.
+    expect(
+      rejectionReasons({ ...allOk, findings: bad(apiError(404, 'not found')) })
+    ).toEqual([]);
+  });
+
+  it('still reports a 500 on findings — that IS a real failure', () => {
+    const reason = apiError(500, 'server error');
+    expect(rejectionReasons({ ...allOk, findings: bad(reason) })).toEqual([reason]);
+  });
 });
 
 

--- a/apps/mobile/src/screens/systems/mergeSystemsResults.test.ts
+++ b/apps/mobile/src/screens/systems/mergeSystemsResults.test.ts
@@ -5,18 +5,26 @@ import {
   ORG_NAME_UNAVAILABLE,
   ORG_NAME_UNKNOWN,
   PARTIAL_FAILED_MESSAGE,
+  isUnsupportedSlice,
   mergeSystemsResults,
   rejectionReasons,
   resolveOrgName,
   type SystemsSlices,
 } from './mergeSystemsResults';
-import type { Alert, Device, FleetFindingCounts } from '../../services/api';
+import type { Alert, ApiError, Device, FleetFindingCounts } from '../../services/api';
 
 const device = (id: string) => ({ id, name: id } as unknown as Device);
 const alert = (id: string) => ({ id } as unknown as Alert);
 
 const ok = <T,>(value: T): PromiseSettledResult<T> => ({ status: 'fulfilled', value });
 const bad = (reason: unknown): PromiseSettledResult<never> => ({ status: 'rejected', reason });
+
+// Simulated without importing the real ApiError class — this file must not
+// force a runtime import of services/api.ts, which pulls in
+// expo-secure-store / @sentry/react-native and cannot load under the node
+// vitest runtime (same pattern as lib/errorReporting.test.ts).
+const apiError = (statusCode: number, message: string): Partial<ApiError> =>
+  Object.assign(new Error(message), { name: 'ApiError', statusCode }) as Partial<ApiError>;
 
 const previous: SystemsSlices = {
   summary: { online: 1 } as never,
@@ -123,6 +131,73 @@ describe('mergeSystemsResults', () => {
     });
     expect(slices.devices).toEqual([]);
     expect(error).toBeNull();
+  });
+});
+
+describe('isUnsupportedSlice (#5172 — findings 404 degrades silently)', () => {
+  it('is true for findings rejected with a 404 ApiError', () => {
+    const result = bad(apiError(404, 'not found'));
+    expect(isUnsupportedSlice('findings', result)).toBe(true);
+  });
+
+  it('is false for findings rejected with a 500 ApiError', () => {
+    const result = bad(apiError(500, 'server error'));
+    expect(isUnsupportedSlice('findings', result)).toBe(false);
+  });
+
+  it('is false for findings rejected with a plain network error (no statusCode)', () => {
+    const result = bad(new TypeError('Network request failed'));
+    expect(isUnsupportedSlice('findings', result)).toBe(false);
+  });
+
+  it('is false for devices rejected with a 404 — only optional slices get the exemption', () => {
+    const result = bad(apiError(404, 'not found'));
+    expect(isUnsupportedSlice('devices', result)).toBe(false);
+  });
+
+  it('is false when the result is fulfilled', () => {
+    expect(isUnsupportedSlice('findings', ok({ total: 0, byOrg: {} }))).toBe(false);
+  });
+});
+
+describe('mergeSystemsResults — findings 404 degrade (#5172)', () => {
+  it('a 404 on findings: null result, no banner, not in failed', () => {
+    const { slices, error, failed } = mergeSystemsResults(previous, {
+      ...allOk,
+      findings: bad(apiError(404, 'not found')),
+    });
+    expect(slices.findings).toBeNull();
+    expect(error).toBeNull();
+    expect(failed).toEqual([]);
+  });
+
+  it('a 500 on findings: keeps last-known value and still shows the banner', () => {
+    const { slices, error, failed } = mergeSystemsResults(previous, {
+      ...allOk,
+      findings: bad(apiError(500, 'server error')),
+    });
+    expect(slices.findings).toEqual(previous.findings);
+    expect(error).toBe(PARTIAL_FAILED_MESSAGE);
+    expect(failed).toEqual(['findings']);
+  });
+
+  it('a network error on findings: still shows the banner', () => {
+    const { error, failed } = mergeSystemsResults(previous, {
+      ...allOk,
+      findings: bad(new TypeError('Network request failed')),
+    });
+    expect(error).toBe(PARTIAL_FAILED_MESSAGE);
+    expect(failed).toEqual(['findings']);
+  });
+
+  it('a 404 on devices is STILL a banner — devices is not an optional slice', () => {
+    const { slices, error, failed } = mergeSystemsResults(previous, {
+      ...allOk,
+      devices: bad(apiError(404, 'not found')),
+    });
+    expect(slices.devices).toEqual(previous.devices); // stale, not nulled
+    expect(error).toBe(PARTIAL_FAILED_MESSAGE);
+    expect(failed).toEqual(['devices']);
   });
 });
 

--- a/apps/mobile/src/screens/systems/mergeSystemsResults.ts
+++ b/apps/mobile/src/screens/systems/mergeSystemsResults.ts
@@ -133,14 +133,22 @@ export function mergeSystemsResults(
   return { slices, error, failed };
 }
 
-/** The rejection reasons, for Sentry. Empty when nothing failed. */
+/**
+ * The rejection reasons worth reporting to Sentry. Empty when nothing failed.
+ *
+ * Mirrors `mergeSystemsResults`' own `failed` classification exactly (via
+ * `isUnsupportedSlice`) rather than every raw rejection: a 404 on `findings`
+ * is expected and permanent on a server a release behind, not a bug — same
+ * precedent as `DEVICE_BLOCKED_CODE` in `lib/errorReporting.ts` for another
+ * expected, recurring condition. Reporting it anyway would spam Sentry on
+ * every fetch for the lifetime of that server (#5172).
+ */
 export function rejectionReasons(results: {
   [K in keyof SystemsSlices]: PromiseSettledResult<unknown>;
 }): unknown[] {
   return (['summary', 'alerts', 'activeAlerts', 'devices', 'orgs', 'findings'] as const)
-    .map((k) => results[k])
-    .filter((r): r is PromiseRejectedResult => r.status === 'rejected')
-    .map((r) => r.reason);
+    .filter((k) => results[k].status === 'rejected' && !isUnsupportedSlice(k, results[k]))
+    .map((k) => (results[k] as PromiseRejectedResult).reason);
 }
 
 /**

--- a/apps/mobile/src/screens/systems/mergeSystemsResults.ts
+++ b/apps/mobile/src/screens/systems/mergeSystemsResults.ts
@@ -1,4 +1,4 @@
-import type { Alert, Device, FleetFindingCounts } from '../../services/api';
+import type { Alert, ApiError, Device, FleetFindingCounts } from '../../services/api';
 import type { MobileSummary, OrganizationSummary } from '../../services/systems';
 
 /**
@@ -46,6 +46,41 @@ function take<T>(result: PromiseSettledResult<T>, previous: T): T {
 }
 
 /**
+ * Slices that are allowed to disappear entirely on an older server. #5172:
+ * `GET /fleet/findings/counts` (#5143) doesn't exist on prod v0.110.0, so a
+ * self-hoster a release behind sees the findings fetch 404 forever — that is
+ * "feature not on this server", not a transient failure, and must not trip
+ * the partial-failure banner or block pull-to-refresh from ever clearing it.
+ * Every other slice (devices, orgs, alerts, summary) is load-bearing for the
+ * screen and keeps today's behavior even on a 404.
+ */
+const OPTIONAL_SLICES: ReadonlySet<keyof SystemsSlices> = new Set(['findings']);
+
+/**
+ * True when `key` is an optional slice (see `OPTIONAL_SLICES`) that rejected
+ * with a 404 — "route missing on this server", to be degraded silently
+ * rather than counted as a failure. Any other status code (5xx), a network
+ * error (no `statusCode` at all), or a non-optional slice still counts as a
+ * real failure.
+ *
+ * Duck-types the rejection reason via `Partial<ApiError>` rather than
+ * `instanceof ApiError` — this module (and its test) must not force a
+ * runtime import of `services/api.ts`, which pulls in `expo-secure-store` /
+ * `@sentry/react-native` and cannot load under the node vitest runtime (see
+ * `lib/errorReporting.ts` for the same pattern).
+ */
+export function isUnsupportedSlice(
+  key: keyof SystemsSlices,
+  result: PromiseSettledResult<unknown>
+): boolean {
+  if (!OPTIONAL_SLICES.has(key) || result.status !== 'rejected') return false;
+  const reason = result.reason;
+  const statusCode =
+    reason && typeof reason === 'object' ? (reason as Partial<ApiError>).statusCode : undefined;
+  return statusCode === 404;
+}
+
+/**
  * Merge the settled results of the six Systems fetches over the previously
  * rendered data.
  *
@@ -70,7 +105,7 @@ export function mergeSystemsResults(
 ): MergeOutcome {
   const failed: Array<keyof SystemsSlices> = [];
   for (const key of ['summary', 'alerts', 'activeAlerts', 'devices', 'orgs', 'findings'] as const) {
-    if (results[key].status === 'rejected') failed.push(key);
+    if (results[key].status === 'rejected' && !isUnsupportedSlice(key, results[key])) failed.push(key);
   }
 
   const slices: SystemsSlices = {
@@ -79,7 +114,12 @@ export function mergeSystemsResults(
     activeAlerts: take(results.activeAlerts, previous.activeAlerts),
     devices: take(results.devices, previous.devices),
     orgs: take(results.orgs, previous.orgs),
-    findings: take(results.findings, previous.findings),
+    // A 404 degrades to null (fulfilled-with-null), not the stale previous
+    // value — this is "the server has never had this feature", so there is
+    // no last-known value worth preserving.
+    findings: isUnsupportedSlice('findings', results.findings)
+      ? null
+      : take(results.findings, previous.findings),
   };
 
   const total = 6;


### PR DESCRIPTION
## Summary

Two resilience papercuts surfaced by round-3 iOS testing against prod v0.110.0 (a release behind the TestFlight/main build):

**1. Systems screen permanent red banner against an older API**

`GET /fleet/findings/counts` (#5143) 404s on prod v0.110.0. The findings slice's rejection tripped `mergeSystemsResults`' `PARTIAL_FAILED_MESSAGE` banner forever on an otherwise-healthy screen, and pull-to-refresh could never clear it.

Fix: a pure classifier `isUnsupportedSlice(key, result)` in `mergeSystemsResults.ts` treats a **404 on an optional slice** (currently just `findings`, via an explicit `OPTIONAL_SLICES` constant) as "feature not on this server" — degrades to `findings: null`, not counted in `failed`, no banner. Any other status code (5xx), a network error, or a 404 on a **non-optional** slice (e.g. `devices`) still trips the banner exactly as before. Table-driven tests cover all four cases.

**2. Approve → "No pending approvals / You're all caught up." flashes ~1s before Home returns**

`approve.fulfilled`/`deny.fulfilled` run `dropAndRefocus`, which clears `focused` in the same tick the "Approved · …" toast is queued. `ApprovalScreen`'s `!focused` early return painted the generic empty-state copy for as long as the takeover `Modal`'s native dismiss transition took — and the decision's own outcome toast, which lived below that early return, never rendered at all when it was the last pending item.

Fix:
- `ApprovalGate` and `ApprovalScreen` now derive "is there a focused pending approval" from one shared selector (`navigation/approvalTakeover.ts`) instead of two independently-written inline lambdas, so the Modal's visibility and the screen's content branch can never drift apart.
- `ApprovalScreen` computes `toastVisible` before deciding what to render when nothing is focused. A pure `shouldShowEmptyApprovalState({ focused, decisionToastPending })` (`screens/approvals/approvalDecidedTransition.ts`) decides the branch: genuine empty state only when nothing is focused **and** no decision toast is still owed; otherwise a neutral background (with any still-owed toast) instead of the confusing "No pending approvals" text.
- Decision semantics, retry, and 409/410 handling are unchanged.

## Test plan
- [x] `cd apps/mobile && npx vitest run src/screens/systems src/store src/navigation src/screens/approvals` — 26 files / 338 tests passed
- [x] `cd apps/mobile && npx tsc --noEmit` — clean
- [x] Red-first: both `mergeSystemsResults.test.ts` additions and the two new pure modules' tests were written and confirmed failing before implementation

Closes #5172

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4u165ZaTFxNBTjEepErYn