### PR TITLE
fix(api): honor delegated key device site restrictions (RMM-QA-162)

### DIFF
--- a/apps/api/src/__tests__/integration/apiKeyDeviceSiteAccess.integration.test.ts
+++ b/apps/api/src/__tests__/integration/apiKeyDeviceSiteAccess.integration.test.ts
@@ -1,0 +1,123 @@
+/** RMM-QA-162: real JWT/key authorization, Redis invalidation and normalized values. */
+import './setup';
+import { describe, expect, it } from 'vitest';
+import { Hono } from 'hono';
+import { createHash, randomBytes, randomUUID } from 'node:crypto';
+import { and, eq, sql } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../../db';
+import { apiKeys, auditLogs, customFieldDefinitions, deviceCustomFieldValues, devices, organizationUsers, servicePrincipals } from '../../db/schema';
+import { customFieldValuesRoutes } from '../../routes/devices/customFieldValues';
+import { getRedis } from '../../services/redis';
+import { clearPermissionCache } from '../../services/permissions';
+import { createSite, setupTestEnvironment } from './db-utils';
+import { getAppDb, getTestDb } from './setup';
+
+const app = new Hono().route('/devices', customFieldValuesRoutes);
+const sys = withSystemDbAccessContext;
+
+async function fixture() {
+  const env = await setupTestEnvironment({ rolePermissions: [
+    { resource: 'devices', action: 'read' }, { resource: 'devices', action: 'write' },
+  ] });
+  const otherSite = await createSite({ orgId: env.organization.id });
+  const rows = await sys(() => db.insert(devices).values([env.site, otherSite].map((site) => ({
+    orgId: env.organization.id, siteId: site.id, agentId: randomUUID(), hostname: `site-${site.id}`,
+    osType: 'linux' as const, osVersion: 'test', architecture: 'x86_64', agentVersion: 'test',
+  }))).returning());
+  const [definition] = await sys(() => db.insert(customFieldDefinitions).values({
+    orgId: env.organization.id, fieldKey: 'asset_note', name: 'Asset note', type: 'text',
+  }).returning());
+  await sys(() => db.insert(deviceCustomFieldValues).values(rows.map((device) => ({
+    orgId: env.organization.id, deviceId: device.id, definitionId: definition!.id,
+    fieldKey: 'asset_note', valueText: 'original-site-marker', source: 'manual',
+  }))));
+  const rawKey = `brz_${randomBytes(24).toString('hex')}`;
+  const [key] = await sys(() => db.insert(apiKeys).values({
+    orgId: env.organization.id, createdBy: env.user.id, name: 'site acceptance',
+    keyHash: createHash('sha256').update(rawKey).digest('hex'), keyPrefix: rawKey.slice(0, 12),
+    scopes: ['devices:read', 'devices:write'], status: 'active',
+  }).returning());
+  const request = (deviceId: string, method = 'GET', session = false) => app.request(`/devices/${deviceId}/custom-fields`, {
+    method, headers: { ...(session ? { Authorization: `Bearer ${env.token}` } : { 'X-API-Key': rawKey }),
+      'Content-Type': 'application/json' },
+    ...(method === 'PATCH' ? { body: JSON.stringify({ asset_note: 'updated-note' }) } : {}),
+  });
+  const restrict = async (siteIds: string[]) => {
+    await getTestDb().update(organizationUsers).set({ siteIds })
+      .where(and(eq(organizationUsers.userId, env.user.id), eq(organizationUsers.orgId, env.organization.id)));
+    // Match production membership updates: invalidate Redis's versioned cache,
+    // so this proves the next request uses the new scope, not the five-minute TTL.
+    const redis = getRedis();
+    expect(redis).not.toBeNull();
+    const versionKey = `permission-cache:user-version:${env.user.id}`;
+    const before = Number(await redis!.get(versionKey) ?? 0);
+    await clearPermissionCache(env.user.id);
+    expect(Number(await redis!.get(versionKey))).toBe(before + 1);
+  };
+  return { env, own: rows[0]!, other: rows[1]!, key: key!, request, restrict };
+}
+
+describe('delegated API key device site authorization', () => {
+  it('matches session denial and blocks normalized writes and audit side effects', async () => {
+    const f = await fixture();
+    const roles = await getAppDb().execute(sql`SELECT current_user AS role, rolsuper, rolbypassrls FROM pg_roles WHERE rolname = current_user`);
+    expect(roles[0]).toMatchObject({ role: 'breeze_app', rolsuper: false, rolbypassrls: false });
+    await f.restrict([f.env.site.id]);
+    for (const session of [false, true]) {
+      const denied = await f.request(f.other.id, 'GET', session);
+      expect(denied.status).toBe(403);
+      expect(await denied.text()).not.toContain('original-site-marker');
+    }
+    const before = await sys(() => db.select().from(deviceCustomFieldValues).where(eq(deviceCustomFieldValues.deviceId, f.other.id)));
+    const deniedWrite = await f.request(f.other.id, 'PATCH');
+    expect(deniedWrite.status).toBe(403);
+    const after = await sys(() => db.select().from(deviceCustomFieldValues).where(eq(deviceCustomFieldValues.deviceId, f.other.id)));
+    expect(after).toEqual(before);
+    const audit = await sys(() => db.select().from(auditLogs).where(and(eq(auditLogs.orgId, f.env.organization.id), eq(auditLogs.action, 'device.custom_field.update'))));
+    expect(audit).toEqual([]);
+    const allowed = await f.request(f.own.id, 'PATCH');
+    expect(allowed.status).toBe(200);
+    expect(await allowed.json()).toMatchObject({ customFields: { asset_note: 'updated-note' } });
+    const allowedAudit = await sys(() => db.select().from(auditLogs).where(and(eq(auditLogs.orgId, f.env.organization.id), eq(auditLogs.action, 'device.custom_field.update'))));
+    expect(allowedAudit).toHaveLength(1);
+    expect(allowedAudit[0]).toMatchObject({ actorType: 'api_key', actorId: f.key.id });
+  });
+
+  it('applies a post-mint restriction, including deny-all, on the next request', async () => {
+    const f = await fixture();
+    expect((await f.request(f.other.id)).status).toBe(200); // warm real permission cache
+    await f.restrict([f.env.site.id]);
+    expect((await f.request(f.other.id)).status).toBe(403);
+    expect((await f.request(f.own.id)).status).toBe(200);
+    await f.restrict([]);
+    expect((await f.request(f.own.id)).status).toBe(403);
+    expect((await f.request(f.own.id, 'PATCH')).status).toBe(403);
+  });
+
+  it('keeps foreign-organization devices inaccessible for reads and writes', async () => {
+    const caller = await fixture();
+    const foreign = await fixture();
+    for (const method of ['GET', 'PATCH']) {
+      const result = await caller.request(foreign.own.id, method);
+      expect(result.status).toBe(404);
+      expect(await result.text()).not.toContain('original-site-marker');
+    }
+    const value = await sys(() => db.select({ value: deviceCustomFieldValues.valueText })
+      .from(deviceCustomFieldValues).where(eq(deviceCustomFieldValues.deviceId, foreign.own.id)));
+    expect(value).toEqual([{ value: 'original-site-marker' }]);
+  });
+
+  it('preserves intentional org-wide service-principal authority and its lifecycle gate', async () => {
+    const f = await fixture();
+    const [principal] = await sys(() => db.insert(servicePrincipals).values({
+      orgId: f.env.organization.id, createdBy: f.env.user.id, name: 'org automation',
+      scopes: ['devices:read', 'devices:write'], status: 'active',
+    }).returning());
+    await sys(() => db.update(apiKeys).set({ principalType: 'service', principalId: principal!.id }).where(eq(apiKeys.id, f.key.id)));
+    await f.restrict([]);
+    expect((await f.request(f.other.id)).status).toBe(200);
+    expect((await f.request(f.other.id, 'PATCH')).status).toBe(200);
+    await sys(() => db.update(servicePrincipals).set({ status: 'disabled' }).where(eq(servicePrincipals.id, principal!.id)));
+    expect((await f.request(f.other.id)).status).toBe(401);
+  });
+});

--- a/apps/api/src/routes/devPush.test.ts
+++ b/apps/api/src/routes/devPush.test.ts
@@ -42,13 +42,20 @@ vi.mock('../middleware/auth', () => ({
     return next();
   }),
   requireScope: vi.fn(() => async (_c: any, next: any) => next()),
-  requirePermission: vi.fn(() => async (_c: any, next: any) => next()),
+  requirePermission: vi.fn(() => async (c: any, next: any) => {
+    if (!c.req.header('x-test-drop-perms')) c.set('permissions', {});
+    return next();
+  }),
   requireMfa: vi.fn(() => async (_c: any, next: any) => next()),
 }));
 
 vi.mock('../middleware/apiKeyAuth', () => ({
   apiKeyAuthMiddleware: vi.fn((c: any, next: any) => {
-    c.set('apiKey', { orgId: '11111111-1111-1111-1111-111111111111', scopes: ['devices:write'] });
+    c.set('apiKey', {
+      orgId: '11111111-1111-1111-1111-111111111111', scopes: ['devices:execute'],
+      allowedSiteIds: c.req.header('x-test-sites') === undefined
+        ? undefined : c.req.header('x-test-sites').split(',').filter(Boolean),
+    });
     return next();
   }),
   requireApiKeyScope: vi.fn(() => async (_c: any, next: any) => next()),
@@ -91,6 +98,8 @@ vi.mock('fs', () => ({
   }),
 }));
 
+import { mkdir } from 'fs/promises';
+import { createWriteStream } from 'fs';
 import { authMiddleware } from '../middleware/auth';
 import { devPushRoutes } from './devPush';
 
@@ -125,6 +134,44 @@ describe('devPush routes', () => {
 
   afterEach(() => {
     process.env = { ...originalEnv };
+  });
+
+  it.each(['allowed-other-site', ''])('denies a restricted key before file/download/command side effects (%s)', async (sites) => {
+    process.env.NODE_ENV = 'production';
+    process.env.DEV_PUSH_ENABLED = 'true';
+    mockGetDeviceWithOrgCheck.mockResolvedValue({ id: DEVICE_ID, agentId: AGENT_ID, orgId: ORG_ID, siteId: 'denied-site' });
+    const form = new FormData();
+    form.append('agentId', AGENT_ID);
+    form.append('binary', new File(['inert-test-content'], 'fixture.bin'));
+    const mapSet = vi.spyOn(Map.prototype, 'set');
+    try {
+      const res = await app.request('/dev/push', {
+        method: 'POST', body: form, headers: { 'X-API-Key': 'test-key', 'x-test-sites': sites },
+      });
+      expect(res.status).toBe(403);
+      expect(await res.json()).toEqual({ error: 'Access to this site denied' });
+      expect(mkdir).not.toHaveBeenCalled();
+      expect(createWriteStream).not.toHaveBeenCalled();
+      expect(mockSendCommandToAgent).not.toHaveBeenCalled();
+      expect(mapSet.mock.calls.filter(([, value]) => value && typeof value === 'object'
+        && 'filePath' in value && 'agentId' in value)).toEqual([]);
+    } finally {
+      mapSet.mockRestore();
+    }
+  });
+
+  it('fails closed when a session reaches device authorization without permissions', async () => {
+    mockGetDeviceWithOrgCheck.mockResolvedValue({ id: DEVICE_ID, agentId: AGENT_ID, orgId: ORG_ID, siteId: 'site' });
+    const form = new FormData();
+    form.append('agentId', AGENT_ID);
+    form.append('binary', new File(['inert-test-content'], 'fixture.bin'));
+    const res = await app.request('/dev/push', {
+      method: 'POST', body: form, headers: { Authorization: 'Bearer token', 'x-test-drop-perms': 'true' },
+    });
+    expect(res.status).toBe(403);
+    expect(mkdir).not.toHaveBeenCalled();
+    expect(createWriteStream).not.toHaveBeenCalled();
+    expect(mockSendCommandToAgent).not.toHaveBeenCalled();
   });
 
   // ------------------------------------------------------------------

--- a/apps/api/src/routes/devPush.ts
+++ b/apps/api/src/routes/devPush.ts
@@ -12,7 +12,8 @@ import { authMiddleware, requireMfa, requirePermission, requireScope, type AuthC
 import { apiKeyAuthMiddleware, requireApiKeyScope } from '../middleware/apiKeyAuth';
 import { getDeviceByAgentWithOrgCheck } from './devices/helpers';
 import { sendCommandToAgent, type AgentCommand } from './agentWs';
-import { canAccessSite, PERMISSIONS, type UserPermissions } from '../services/permissions';
+import { PERMISSIONS } from '../services/permissions';
+import { canAccessDeviceSite, resolvePrincipalSitePermissions, type DeviceSitePermissions } from '../services/deviceSiteAccess';
 
 const TEMP_DIR = join(tmpdir(), 'breeze-dev-push');
 const TTL_MS = 5 * 60 * 1000; // 5 minutes
@@ -60,12 +61,12 @@ const MAX_BINARY_SIZE = 100 * 1024 * 1024; // 100MB
 async function getDeviceByAgentWithAccess(
   agentId: string,
   auth: Pick<AuthContext, 'scope' | 'orgId' | 'accessibleOrgIds' | 'canAccessOrg'>,
-  permissions?: UserPermissions,
+  permissions: DeviceSitePermissions | undefined,
 ) {
   const device = await getDeviceByAgentWithOrgCheck(agentId, auth);
   if (!device) return null;
 
-  if (permissions?.allowedSiteIds && (typeof device.siteId !== 'string' || !canAccessSite(permissions, device.siteId))) {
+  if (!canAccessDeviceSite(permissions, device.siteId)) {
     return 'SITE_ACCESS_DENIED' as const;
   }
 
@@ -133,8 +134,9 @@ devPushRoutes.post('/push', bodyLimit({ maxSize: 150 * 1024 * 1024, onError: (c)
     return c.json({ error: `Binary too large (max ${MAX_BINARY_SIZE / 1024 / 1024}MB)` }, 413);
   }
 
-  // Verify device access. The request field is named `agentId`, not `deviceId`.
-  const device = await getDeviceByAgentWithAccess(agentId, auth, c.get('permissions') as UserPermissions | undefined);
+  // agentId comes from multipart parsing. Authorize before copying the parsed
+  // binary into a buffer, writing files, registering a download or dispatching.
+  const device = await getDeviceByAgentWithAccess(agentId, auth, resolvePrincipalSitePermissions(c));
   if (device === 'SITE_ACCESS_DENIED') {
     return c.json({ error: 'Access to this site denied' }, 403);
   }

--- a/apps/api/src/routes/devices/customFieldValues.test.ts
+++ b/apps/api/src/routes/devices/customFieldValues.test.ts
@@ -93,6 +93,8 @@ vi.mock('../../middleware/apiKeyAuth', () => ({
       id: API_KEY_ID,
       orgId: org,
       partnerId: null,
+      allowedSiteIds: c.req.header('x-test-key-sites') === undefined
+        ? undefined : c.req.header('x-test-key-sites').split(',').filter(Boolean),
       name: 'Automation key',
       keyPrefix: 'brz_test',
       scopes,
@@ -352,6 +354,34 @@ describe('device custom-field value routes (#2066)', () => {
       expect(res.status).toBe(404);
       // The sensitive write must not be reported as audited success.
       expect(vi.mocked(createAuditLog)).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('delegated API-key site scope', () => {
+    it.each([
+      ['GET', 'allowed-other-site'], ['PATCH', 'allowed-other-site'],
+      ['GET', ''], ['PATCH', ''],
+    ])('denies %s outside the live allowlist %s without mutation', async (method, sites) => {
+      rigDeviceLookup(makeDevice({ siteId: 'denied-site' }));
+      const res = await app.request(`/devices/${DEVICE_ID}/custom-fields`, {
+        method,
+        headers: { 'X-API-Key': 'brz_test', 'x-test-scopes': 'devices:read,devices:write',
+          'x-test-key-sites': sites, 'Content-Type': 'application/json' },
+        ...(method === 'PATCH' ? { body: JSON.stringify({ note: 'unchanged' }) } : {}),
+      });
+      expect(res.status).toBe(403);
+      expect(await res.json()).toEqual({ error: 'Access to this site denied' });
+      expect(persistDeviceCustomFieldValues).not.toHaveBeenCalled();
+      expect(createAuditLog).not.toHaveBeenCalled();
+    });
+
+    it('permits an allowed-site key read', async () => {
+      rigDeviceLookup(makeDevice({ siteId: 'allowed-site' }));
+      const res = await app.request(`/devices/${DEVICE_ID}/custom-fields`, {
+        headers: { 'X-API-Key': 'brz_test', 'x-test-scopes': 'devices:read', 'x-test-key-sites': 'allowed-site' },
+      });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ customFields: { existing_field: 'keep-me' } });
     });
   });
 

--- a/apps/api/src/routes/devices/customFieldValues.ts
+++ b/apps/api/src/routes/devices/customFieldValues.ts
@@ -14,7 +14,8 @@ import {
 } from '../../middleware/auth';
 import { apiKeyAuthMiddleware, requireApiKeyScope } from '../../middleware/apiKeyAuth';
 import { getDeviceWithOrgCheck } from './helpers';
-import { canAccessSite, PERMISSIONS, type UserPermissions } from '../../services/permissions';
+import { PERMISSIONS } from '../../services/permissions';
+import { canAccessDeviceSite, resolvePrincipalSitePermissions, type DeviceSitePermissions } from '../../services/deviceSiteAccess';
 import { createAuditLog } from '../../services/auditService';
 import { ANONYMOUS_ACTOR_ID } from '../../services/auditEvents';
 import { getTrustedClientIpOrUndefined } from '../../services/clientIp';
@@ -119,7 +120,7 @@ function dualAuth(
 
 interface ResolvedAccess {
   auth: Pick<AuthContext, 'scope' | 'orgId' | 'accessibleOrgIds' | 'canAccessOrg'>;
-  permissions: UserPermissions | undefined;
+  permissions: DeviceSitePermissions | undefined;
   audit: { actorType: 'user' | 'api_key'; actorId: string | null; actorEmail: string | null };
 }
 
@@ -129,7 +130,7 @@ function resolveAccess(c: Context): ResolvedAccess {
   if (jwtAuth) {
     return {
       auth: jwtAuth,
-      permissions: c.get('permissions') as UserPermissions | undefined,
+      permissions: resolvePrincipalSitePermissions(c),
       audit: {
         actorType: 'user',
         actorId: jwtAuth.user?.id ?? null,
@@ -159,16 +160,14 @@ function resolveAccess(c: Context): ResolvedAccess {
       accessibleOrgIds: [orgId],
       canAccessOrg: (candidate: string) => candidate === orgId,
     },
-    permissions: undefined,
+    permissions: resolvePrincipalSitePermissions(c),
     audit: { actorType: 'api_key', actorId: apiKey.id, actorEmail: null },
   };
 }
 
 const SITE_DENIED = Symbol('SITE_DENIED');
 
-// Org-scoped device lookup that also honours a session's site allowlist. API
-// keys carry no `permissions` context (they're org-scoped, not site-scoped), so
-// the site check is skipped for them — same as devPush's API-key branch.
+// Both sessions and delegated keys retain their site authority after org lookup.
 async function loadAccessibleDevice(
   deviceId: string,
   access: ResolvedAccess,
@@ -176,16 +175,7 @@ async function loadAccessibleDevice(
   const device = await getDeviceWithOrgCheck(deviceId, access.auth);
   if (!device) return null;
 
-  const perms = access.permissions;
-  // Fail closed for SESSION callers: the JWT branch always runs requirePermission,
-  // which sets the permissions context, so a missing context on a user path means
-  // a site gate was dropped — deny rather than silently skip the allowlist check
-  // (mirrors the fail-loud stance of getDeviceWithOrgAndSiteCheck). An absent
-  // context is legitimate ONLY for org-scoped API keys.
-  if (access.audit.actorType !== 'api_key' && !perms) {
-    return SITE_DENIED;
-  }
-  if (perms?.allowedSiteIds && (typeof device.siteId !== 'string' || !canAccessSite(perms, device.siteId))) {
+  if (!canAccessDeviceSite(access.permissions, device.siteId)) {
     return SITE_DENIED;
   }
   return device;

--- a/apps/api/src/services/deviceSiteAccess.ts
+++ b/apps/api/src/services/deviceSiteAccess.ts
@@ -1,0 +1,25 @@
+import type { Context } from 'hono';
+import type { UserPermissions } from './permissions';
+
+/** Site authority only; an API key must never masquerade as full user permissions. */
+export type DeviceSitePermissions = Pick<UserPermissions, 'allowedSiteIds'>;
+
+export function resolvePrincipalSitePermissions(c: Context): DeviceSitePermissions | undefined {
+  const apiKey = c.get('apiKey');
+  if (apiKey) {
+    // Human keys carry the creator's live restriction. Service-principal keys
+    // intentionally have no site axis: undefined means unrestricted within
+    // their authorized org, while [] denies every site.
+    return { allowedSiteIds: apiKey.allowedSiteIds };
+  }
+  return c.get('permissions') as DeviceSitePermissions | undefined;
+}
+
+export function canAccessDeviceSite(
+  permissions: DeviceSitePermissions | undefined,
+  siteId: string | null | undefined,
+): boolean {
+  if (!permissions) return false;
+  if (permissions.allowedSiteIds === undefined) return true;
+  return typeof siteId === 'string' && permissions.allowedSiteIds.includes(siteId);
+}

--- a/docs/superpowers/plans/security-auth/2026-09-07-api-key-device-site-scope.md
+++ b/docs/superpowers/plans/security-auth/2026-09-07-api-key-device-site-scope.md
@@ -1,0 +1,31 @@
+# API-key device site authorization (RMM-QA-162)
+
+The live-creator design shipped in #2514 requires delegated keys to retain the
+creator's current site restriction. Two consumers still discard it: device
+custom-field values and dev-push. #2071's earlier org-only exception predates that
+design. Current #5044 normalized custom-field storage does not resolve this gap.
+
+Use a narrow site-permissions view for both credentials, without fabricating user
+roles or granting key scopes. Missing context denies; undefined allowedSiteIds
+means unrestricted within the already-authorized org; an empty list denies all.
+Keep session-compatible 403 responses. Service-principal keys remain org-wide as
+specified by #2527; their lifecycle and scope ceiling remain enforced upstream.
+
+Dev-push's agentId is a multipart field, so device authorization follows parsing
+and input validation. It must precede copying the parsed binary into a buffer, filesystem writes, ephemeral
+download registration and WebSocket dispatch. No parser or upload redesign.
+
+Implementation and acceptance:
+
+1. Share the narrow site view and fail-closed device gate across the two routes.
+2. Exercise route denials, empty/allowed lists, missing session context and zero
+   dev-push side effects with inert fixtures and mocked external I/O.
+3. Use a private PostgreSQL/Redis stack with unprivileged breeze_app requests to
+   verify session/key read parity, denied normalized writes and audits, successful
+   allowed writes, post-mint restriction after production cache invalidation, and
+   intentionally org-wide service-principal behavior.
+4. Run affected unit/integration checks, full bounded API, typecheck and existing
+   RLS/site contracts; independently review the exact head and finish CI.
+
+No migrations or candidate/production verification. Refs #4060; merge and formal
+QA closure remain separate from implementation evidence.


### PR DESCRIPTION
## Summary

Human-delegated API keys already carry their creator's current site restriction, but custom-field values and dev-push discarded it. Both routes now use a narrow site-permissions view: missing context fails closed, empty allowlists deny every site, and denied devices receive the existing session-compatible 403. The gate runs before custom-field persistence/audit or dev-push filesystem/download/command side effects.

Service-principal keys retain their intentional organization-wide authority and existing lifecycle/scope checks. Dev-push must parse multipart fields to obtain agentId; authorization follows input validation and precedes copying the parsed binary or creating side effects. No migration or broader authentication-policy change.

## Linked Issues

Refs #4060 — implements RMM-QA-162's two remaining API-key device-site consumers. Existing #2514 live-creator authorization and #2527 service-principal policy are preserved. Candidate/production verification and formal QA closure remain outstanding.

## Type of Change

- [x] Bug fix

## Testing

- [x] Focused API routes/middleware/authorization/permissions: 130 passed across six files.
- [x] Real PostgreSQL/Redis acceptance: nine passed across two files. New cases verify unprivileged breeze_app, JWT/key denied-read parity, denied normalized writes with unchanged rows and no audit, permitted audited writes, post-mint site/empty-list changes with a real Redis cache-version increment, cross-org denial, and service-principal positive/lifecycle behavior.
- [x] Dev-push denial tests assert zero file writes, download registrations and agent commands using inert test data and mocked external I/O.
- [x] RLS contract: 102 passed; site-scope contract: seven passed.
- [x] API typecheck passed with a command-scoped 8 GiB heap; touched-file ESLint passed.
- [x] Full API suite: 36,516 passed / 21 skipped across 1,943 passed / three skipped files, exit 0 (994.44 seconds), bounded to two workers under command-scoped caffeinate.
- [x] Exact-head CI [34153040284](https://github.com/LanternOps/breeze/actions/runs/34153040284), attempt 1: 66 checks succeeded, one expected Main Red Alert skip; no failures or pending checks.

Independent six-aspect review of `8d593b1d880ad9c8466caae36b7031d9e7effc02` against freshly verified main `00b4b237760e8e5586950de0f297440e7dfb46bd` found no actionable defects. Static/evidence review, not an independently executed test run. Design and acceptance plan: `docs/superpowers/plans/security-auth/2026-09-07-api-key-device-site-scope.md`.

## Checklist

- [x] Project conventions and tenant boundaries preserved
- [x] Independent exact-head review complete
- [x] No secrets or internal infrastructure details added

This PR remains draft and open. No merge, deployment or finding closure is part of this round.
