### PR TITLE
fix(api): validate :id as a UUID on fleet findings routes (#5179)

### DIFF
--- a/apps/api/src/routes/fleetFindings.test.ts
+++ b/apps/api/src/routes/fleetFindings.test.ts
@@ -588,6 +588,16 @@ describe('GET /fleet/findings/counts', () => {
 });
 
 describe('GET /fleet/findings/:id', () => {
+  // Sentry BREEZE-2M: a non-UUID id reached `eq(fleetFindings.id, id)`
+  // unvalidated and Postgres rejected it with 22P02 (invalid_text_representation),
+  // surfacing as a 500. The param must be validated before it ever reaches the
+  // DB mock.
+  it('rejects a non-UUID id with 400 before touching the database (BREEZE-2M)', async () => {
+    const res = await get(makeAuth(), '/not-a-uuid');
+    expect(res.status).toBe(400);
+    expect(h.mockSelect).not.toHaveBeenCalled();
+  });
+
   it('returns 404 for an unknown id', async () => {
     h.selectQueue.push([]);
     const res = await get(makeAuth(), `/${FINDING_1}`);
@@ -723,6 +733,12 @@ describe('GET /fleet/findings/:id', () => {
 });
 
 describe('PATCH /fleet/findings/:id — lifecycle transitions', () => {
+  it('rejects a non-UUID id with 400 before touching the database (BREEZE-2M)', async () => {
+    const res = await patch(makeAuth(), '/not-a-uuid', { action: 'acknowledge' });
+    expect(res.status).toBe(400);
+    expect(h.mockSelect).not.toHaveBeenCalled();
+  });
+
   it('returns 404 for an unknown id', async () => {
     h.selectQueue.push([]);
     const res = await patch(makeAuth(), `/${FINDING_1}`, { action: 'acknowledge' });
@@ -984,6 +1000,12 @@ describe('GET /fleet/findings/runs/:runId', () => {
 });
 
 describe('GET /fleet/findings/:id/runs', () => {
+  it('rejects a non-UUID id with 400 before touching the database (BREEZE-2M)', async () => {
+    const res = await get(makeAuth(), '/not-a-uuid/runs');
+    expect(res.status).toBe(400);
+    expect(h.mockSelect).not.toHaveBeenCalled();
+  });
+
   it('returns 404 for an unknown finding id', async () => {
     h.selectQueue.push([]);
     const res = await get(makeAuth(), `/${FINDING_1}/runs`);
@@ -1003,6 +1025,16 @@ describe('GET /fleet/findings/:id/runs', () => {
 });
 
 describe('POST /fleet/findings/:id/remediate', () => {
+  it('rejects a non-UUID id with 400 before dispatching a remediation run (BREEZE-2M)', async () => {
+    const res = await post(makeAuth(), '/not-a-uuid/remediate', {
+      actionKind: 'command',
+      commandType: 'reboot',
+      parameters: {},
+    });
+    expect(res.status).toBe(400);
+    expect(createRemediationRunMock).not.toHaveBeenCalled();
+  });
+
   it('rejects a non-allowlisted commandType at the zod validation layer (400)', async () => {
     const res = await post(makeAuth(), `/${FINDING_1}/remediate`, {
       actionKind: 'command',

--- a/apps/api/src/routes/fleetFindings.test.ts
+++ b/apps/api/src/routes/fleetFindings.test.ts
@@ -197,6 +197,7 @@ const DEVICE_2 = 'd2222222-2222-4222-8222-222222222222';
 const SITE_1 = 's1111111-1111-4111-8111-111111111111';
 const SITE_2 = 's2222222-2222-4222-8222-222222222222';
 const SCRIPT_1 = 'c1111111-1111-4111-8111-111111111111';
+const RUN_1 = 'e1111111-1111-4111-8111-111111111111';
 
 interface AuthOverrides {
   scope?: 'organization' | 'partner' | 'system';
@@ -595,6 +596,8 @@ describe('GET /fleet/findings/:id', () => {
   it('rejects a non-UUID id with 400 before touching the database (BREEZE-2M)', async () => {
     const res = await get(makeAuth(), '/not-a-uuid');
     expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.details.fieldErrors).toHaveProperty('id');
     expect(h.mockSelect).not.toHaveBeenCalled();
   });
 
@@ -736,6 +739,8 @@ describe('PATCH /fleet/findings/:id — lifecycle transitions', () => {
   it('rejects a non-UUID id with 400 before touching the database (BREEZE-2M)', async () => {
     const res = await patch(makeAuth(), '/not-a-uuid', { action: 'acknowledge' });
     expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.details.fieldErrors).toHaveProperty('id');
     expect(h.mockSelect).not.toHaveBeenCalled();
   });
 
@@ -896,7 +901,7 @@ describe('PATCH /fleet/findings/:id — lifecycle transitions', () => {
 
 function runRow(overrides: Record<string, unknown> = {}) {
   return {
-    id: 'run-1',
+    id: RUN_1,
     orgId: ORG_1,
     findingId: FINDING_1,
     findingRevision: 1,
@@ -918,15 +923,26 @@ function runRow(overrides: Record<string, unknown> = {}) {
 }
 
 describe('GET /fleet/findings/runs/:runId', () => {
+  // Sentry BREEZE-2M: the same unvalidated-uuid-into-Postgres shape as the
+  // finding-id routes below, just keyed on `runId` against
+  // `fleetRemediationRuns.id` (also a uuid column) instead of `fleetFindings.id`.
+  it('rejects a non-UUID runId with 400 before touching the database (BREEZE-2M)', async () => {
+    const res = await get(makeAuth(), '/runs/not-a-uuid');
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.details.fieldErrors).toHaveProperty('runId');
+    expect(h.mockSelect).not.toHaveBeenCalled();
+  });
+
   it('returns 404 for an unknown run id', async () => {
     h.selectQueue.push([]);
-    const res = await get(makeAuth(), '/runs/run-1');
+    const res = await get(makeAuth(), `/runs/${RUN_1}`);
     expect(res.status).toBe(404);
   });
 
   it('org token cannot see a run belonging to a foreign org (404, org-condition applied)', async () => {
     h.selectQueue.push([]);
-    const res = await get(makeAuth({ scope: 'organization', orgId: ORG_1 }), '/runs/run-1');
+    const res = await get(makeAuth({ scope: 'organization', orgId: ORG_1 }), `/runs/${RUN_1}`);
     expect(res.status).toBe(404);
 
     const where = h.capturedWheres[0] as { args: unknown[] };
@@ -937,7 +953,7 @@ describe('GET /fleet/findings/runs/:runId', () => {
     h.selectQueue.push([runRow()]);
     h.selectQueue.push([
       {
-        runId: 'run-1',
+        runId: RUN_1,
         orgId: ORG_1,
         targetDeviceUuid: DEVICE_1,
         hostnameSnapshot: 'WS-01',
@@ -951,10 +967,10 @@ describe('GET /fleet/findings/runs/:runId', () => {
       },
     ]);
 
-    const res = await get(makeAuth(), '/runs/run-1');
+    const res = await get(makeAuth(), `/runs/${RUN_1}`);
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.id).toBe('run-1');
+    expect(body.id).toBe(RUN_1);
     expect(body.targets).toEqual([
       expect.objectContaining({ deviceId: DEVICE_1, hostname: 'WS-01', status: 'queued' }),
     ]);
@@ -964,7 +980,7 @@ describe('GET /fleet/findings/runs/:runId', () => {
     h.selectQueue.push([runRow()]);
     h.selectQueue.push([
       {
-        runId: 'run-1',
+        runId: RUN_1,
         orgId: ORG_1,
         targetDeviceUuid: DEVICE_1,
         hostnameSnapshot: 'WS-01',
@@ -977,7 +993,7 @@ describe('GET /fleet/findings/runs/:runId', () => {
         completedAt: null,
       },
       {
-        runId: 'run-1',
+        runId: RUN_1,
         orgId: ORG_1,
         targetDeviceUuid: DEVICE_2,
         hostnameSnapshot: 'WS-02',
@@ -991,7 +1007,7 @@ describe('GET /fleet/findings/runs/:runId', () => {
       },
     ]);
 
-    const res = await get(makeAuth({ allowedSiteIds: [SITE_1] }), '/runs/run-1');
+    const res = await get(makeAuth({ allowedSiteIds: [SITE_1] }), `/runs/${RUN_1}`);
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.targets).toHaveLength(1);
@@ -1003,6 +1019,8 @@ describe('GET /fleet/findings/:id/runs', () => {
   it('rejects a non-UUID id with 400 before touching the database (BREEZE-2M)', async () => {
     const res = await get(makeAuth(), '/not-a-uuid/runs');
     expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.details.fieldErrors).toHaveProperty('id');
     expect(h.mockSelect).not.toHaveBeenCalled();
   });
 
@@ -1032,6 +1050,8 @@ describe('POST /fleet/findings/:id/remediate', () => {
       parameters: {},
     });
     expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.details.fieldErrors).toHaveProperty('id');
     expect(createRemediationRunMock).not.toHaveBeenCalled();
   });
 

--- a/apps/api/src/routes/fleetFindings.ts
+++ b/apps/api/src/routes/fleetFindings.ts
@@ -50,6 +50,15 @@ function parseStatusCsv(raw: string | undefined): StatusValue[] | null {
   return items as StatusValue[];
 }
 
+// Sentry BREEZE-2M: every route below took `c.req.param('id')!` straight into
+// `eq(fleetFindings.id, id)` / `eq(fleetRemediationRuns.findingId, id)` calls
+// on a uuid column with no validation, so a non-UUID id reached Postgres and
+// came back 22P02 (invalid_text_representation) as an unhandled 500. Mirrors
+// `filterIdParamSchema` in `routes/filters.ts`.
+const findingIdParamSchema = z.object({
+  id: z.string().guid(),
+});
+
 const listQuerySchema = z.object({
   orgId: z.string().guid().optional(),
   kind: z.enum(KIND_VALUES).optional(),
@@ -168,30 +177,37 @@ fleetFindingsRoutes.get('/runs/:runId', requireScope('organization', 'partner', 
   return c.json(run);
 });
 
-fleetFindingsRoutes.get('/:id/runs', requireScope('organization', 'partner', 'system'), requireFindingsRead, async (c) => {
-  const auth = c.get('auth');
-  const id = c.req.param('id')!;
+fleetFindingsRoutes.get(
+  '/:id/runs',
+  requireScope('organization', 'partner', 'system'),
+  requireFindingsRead,
+  zValidator('param', findingIdParamSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const { id } = c.req.valid('param');
 
-  const finding = await getFleetFinding(auth, id);
-  if (!finding) {
-    return c.json({ error: 'Finding not found' }, 404);
+    const finding = await getFleetFinding(auth, id);
+    if (!finding) {
+      return c.json({ error: 'Finding not found' }, 404);
+    }
+
+    // `getFleetFinding` already caps this at the last 10 runs; that's fine for
+    // this endpoint's purpose (recent remediation history alongside the
+    // finding), not a general paginated run listing.
+    return c.json({ runs: finding.runs });
   }
-
-  // `getFleetFinding` already caps this at the last 10 runs; that's fine for
-  // this endpoint's purpose (recent remediation history alongside the
-  // finding), not a general paginated run listing.
-  return c.json({ runs: finding.runs });
-});
+);
 
 fleetFindingsRoutes.post(
   '/:id/remediate',
   requireScope('organization', 'partner', 'system'),
   requireFindingsExecute,
   requireMfa(),
+  zValidator('param', findingIdParamSchema),
   zValidator('json', remediateBodySchema),
   async (c) => {
     const auth = c.get('auth');
-    const id = c.req.param('id')!;
+    const { id } = c.req.valid('param');
     const body = c.req.valid('json') as RemediateRequest;
 
     let result;
@@ -280,26 +296,33 @@ fleetFindingsRoutes.post(
   }
 );
 
-fleetFindingsRoutes.get('/:id', requireScope('organization', 'partner', 'system'), requireFindingsRead, async (c) => {
-  const auth = c.get('auth');
-  const id = c.req.param('id')!;
+fleetFindingsRoutes.get(
+  '/:id',
+  requireScope('organization', 'partner', 'system'),
+  requireFindingsRead,
+  zValidator('param', findingIdParamSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const { id } = c.req.valid('param');
 
-  const finding = await getFleetFinding(auth, id);
-  if (!finding) {
-    return c.json({ error: 'Finding not found' }, 404);
+    const finding = await getFleetFinding(auth, id);
+    if (!finding) {
+      return c.json({ error: 'Finding not found' }, 404);
+    }
+
+    return c.json(finding);
   }
-
-  return c.json(finding);
-});
+);
 
 fleetFindingsRoutes.patch(
   '/:id',
   requireScope('organization', 'partner', 'system'),
   requireFindingsWrite,
+  zValidator('param', findingIdParamSchema),
   zValidator('json', patchBodySchema),
   async (c) => {
     const auth = c.get('auth');
-    const id = c.req.param('id')!;
+    const { id } = c.req.valid('param');
     const body = c.req.valid('json');
 
     const result = await applyFleetFindingLifecycle(

--- a/apps/api/src/routes/fleetFindings.ts
+++ b/apps/api/src/routes/fleetFindings.ts
@@ -59,6 +59,12 @@ const findingIdParamSchema = z.object({
   id: z.string().guid(),
 });
 
+// Same defect, same fix, different param name: `getRemediationRun` runs
+// `eq(fleetRemediationRuns.id, runId)` against the same kind of uuid column.
+const runIdParamSchema = z.object({
+  runId: z.string().guid(),
+});
+
 const listQuerySchema = z.object({
   orgId: z.string().guid().optional(),
   kind: z.enum(KIND_VALUES).optional(),
@@ -165,17 +171,23 @@ fleetFindingsRoutes.get('/counts', requireScope('organization', 'partner', 'syst
 // registered first anyway (and any NEW single-segment static route, e.g. a
 // bare `/runs`, MUST be registered before `/:id`, to avoid Hono matching it
 // as an id).
-fleetFindingsRoutes.get('/runs/:runId', requireScope('organization', 'partner', 'system'), requireFindingsRead, async (c) => {
-  const auth = c.get('auth');
-  const runId = c.req.param('runId')!;
+fleetFindingsRoutes.get(
+  '/runs/:runId',
+  requireScope('organization', 'partner', 'system'),
+  requireFindingsRead,
+  zValidator('param', runIdParamSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const { runId } = c.req.valid('param');
 
-  const run = await getRemediationRun(auth, runId);
-  if (!run) {
-    return c.json({ error: 'Remediation run not found' }, 404);
+    const run = await getRemediationRun(auth, runId);
+    if (!run) {
+      return c.json({ error: 'Remediation run not found' }, 404);
+    }
+
+    return c.json(run);
   }
-
-  return c.json(run);
-});
+);
 
 fleetFindingsRoutes.get(
   '/:id/runs',


### PR DESCRIPTION
## Summary

Sentry BREEZE-2M (2026-09-07, 5 events from one partner-scoped user, US, release 0.110.0): `GET /api/v1/fleet/findings/:id` returned 500 with `pg_code=22P02` (invalid_text_representation). The route reads `c.req.param('id')!` and passes it straight into `eq(fleetFindings.id, id)`, so any non-UUID id reaches the uuid column and Postgres rejects it. The sibling routes `/:id/runs`, `/:id/remediate`, `PATCH /:id`, and (found during PR review) `GET /runs/:runId` all had the same shape.

- Added `findingIdParamSchema = z.object({ id: z.string().guid() })` to `apps/api/src/routes/fleetFindings.ts`, mirroring `filterIdParamSchema` in `apps/api/src/routes/filters.ts:33-35`.
- Wired it as `zValidator('param', findingIdParamSchema)` on all four `:id`-bearing routes: `GET /:id`, `GET /:id/runs`, `POST /:id/remediate`, `PATCH /:id`. A malformed id is now a 400 before it ever reaches `getFleetFinding` / `applyFleetFindingLifecycle` / `createRemediationRun`.
- Also added `runIdParamSchema = z.object({ runId: z.string().guid() })` and wired it on `GET /runs/:runId` (same defect on `fleetRemediationRuns.id`, flagged independently by two review agents during this PR's review — fixed inline rather than deferred).
- Added a red-first regression test per endpoint (`src/routes/fleetFindings.test.ts`) asserting a non-UUID id/runId returns 400, the response body's `details.fieldErrors` names the offending param, and the DB mock (`db.select`) / `createRemediationRun` is never invoked.
- The pre-existing `GET /runs/:runId` test suite used a non-UUID placeholder (`'run-1'`) as the path param; introduced a real-UUID `RUN_1` constant for the path-param call sites while leaving unrelated `'run-1'`/`'run-9'` data-value usages (mock return values, JSON body fields) untouched.

## Test plan

- [x] `cd apps/api && npx vitest run src/routes/fleetFindings.test.ts` — 76 passed (5 new BREEZE-2M regression tests, confirmed red before each fix, green after)
- [x] `NODE_OPTIONS="--max-old-space-size=8192" npx tsc --noEmit` — clean
- [x] `npx eslint apps/api/src/routes/fleetFindings.ts apps/api/src/routes/fleetFindings.test.ts` — clean

Closes #5179
Fixes BREEZE-2M

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GCYqYhwyLnFWG3CH5wKLU2