### PR TITLE
fix(agent): clean up macOS package artifacts on uninstall (#4060)

### DIFF
--- a/agent/internal/agentapp/service_cmd_darwin.go
+++ b/agent/internal/agentapp/service_cmd_darwin.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/breeze-rmm/agent/internal/config"
 	"github.com/breeze-rmm/agent/internal/launchdplist"
+	"github.com/breeze-rmm/agent/internal/macosuninstall"
 	"github.com/breeze-rmm/agent/internal/sessionbroker"
 	"github.com/spf13/cobra"
 )
@@ -273,44 +274,11 @@ var serviceUninstallCmd = &cobra.Command{
 		if os.Geteuid() != 0 {
 			return fmt.Errorf("must run as root (sudo breeze-agent service uninstall)")
 		}
-
-		// Stop and unload the daemon
-		if isLaunchdLoaded(darwinLabel) {
-			out, err := exec.Command("launchctl", "bootout", "system/"+darwinLabel).CombinedOutput()
-			if err != nil {
-				// Fallback to legacy unload
-				out2, err2 := exec.Command("launchctl", "unload", darwinPlistDst).CombinedOutput()
-				if err2 != nil {
-					fmt.Fprintf(os.Stderr, "Warning: failed to stop service: %s / %s\n",
-						strings.TrimSpace(string(out)), strings.TrimSpace(string(out2)))
-				}
-			} else {
-				_ = out
-			}
-			fmt.Println("Service stopped.")
+		if err := uninstallDarwinService(func(name string, args ...string) ([]byte, error) {
+			return exec.Command(name, args...).CombinedOutput()
+		}); err != nil {
+			return err
 		}
-
-		uninstallDarwinWatchdog()
-
-		// Remove plists
-		if err := os.Remove(darwinPlistDst); err != nil && !os.IsNotExist(err) {
-			fmt.Fprintf(os.Stderr, "Warning: failed to remove %s: %v\n", darwinPlistDst, err)
-		}
-		if err := os.Remove(darwinDesktopUserPlistDst); err != nil && !os.IsNotExist(err) {
-			fmt.Fprintf(os.Stderr, "Warning: failed to remove %s: %v\n", darwinDesktopUserPlistDst, err)
-		}
-		if err := os.Remove(darwinDesktopLoginWindowPlistDst); err != nil && !os.IsNotExist(err) {
-			fmt.Fprintf(os.Stderr, "Warning: failed to remove %s: %v\n", darwinDesktopLoginWindowPlistDst, err)
-		}
-
-		// Remove binary
-		if err := os.Remove(darwinBinaryPath); err != nil && !os.IsNotExist(err) {
-			fmt.Fprintf(os.Stderr, "Warning: failed to remove %s: %v\n", darwinBinaryPath, err)
-		}
-		if err := os.Remove(darwinDesktopHelperBinaryPath); err != nil && !os.IsNotExist(err) {
-			fmt.Fprintf(os.Stderr, "Warning: failed to remove %s: %v\n", darwinDesktopHelperBinaryPath, err)
-		}
-
 		fmt.Println("Breeze Agent service uninstalled.")
 		fmt.Printf("Config at %s was preserved.\n", darwinConfigDir)
 		fmt.Printf("To remove config: sudo rm -rf '%s'\n", darwinConfigDir)
@@ -318,25 +286,12 @@ var serviceUninstallCmd = &cobra.Command{
 	},
 }
 
-func uninstallDarwinWatchdog() {
-	if isLaunchdLoaded(darwinWatchdogLabel) {
-		out, err := exec.Command("launchctl", "bootout", "system/"+darwinWatchdogLabel).CombinedOutput()
-		if err != nil {
-			out2, err2 := exec.Command("launchctl", "unload", darwinWatchdogPlistDst).CombinedOutput()
-			if err2 != nil {
-				fmt.Fprintf(os.Stderr, "Warning: failed to stop watchdog service: %s / %s\n",
-					strings.TrimSpace(string(out)), strings.TrimSpace(string(out2)))
-			}
-		} else {
-			_ = out
-		}
+func uninstallDarwinService(run func(string, ...string) ([]byte, error)) error {
+	out, err := run("/bin/sh", "-c", macosuninstall.Script())
+	if err != nil {
+		return fmt.Errorf("uninstall package artifacts: %w: %s", err, strings.TrimSpace(string(out)))
 	}
-	if err := os.Remove(darwinWatchdogPlistDst); err != nil && !os.IsNotExist(err) {
-		fmt.Fprintf(os.Stderr, "Warning: failed to remove %s: %v\n", darwinWatchdogPlistDst, err)
-	}
-	if err := os.Remove(darwinWatchdogBinaryPath); err != nil && !os.IsNotExist(err) {
-		fmt.Fprintf(os.Stderr, "Warning: failed to remove %s: %v\n", darwinWatchdogBinaryPath, err)
-	}
+	return nil
 }
 
 var serviceStartCmd = &cobra.Command{

--- a/agent/internal/agentapp/service_uninstall_darwin_test.go
+++ b/agent/internal/agentapp/service_uninstall_darwin_test.go
@@ -1,0 +1,33 @@
+//go:build darwin
+
+package agentapp
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/macosuninstall"
+)
+
+func TestServiceUninstallUsesPackageCleanup(t *testing.T) {
+	for _, failed := range []bool{false, true} {
+		calls := 0
+		err := uninstallDarwinService(func(name string, args ...string) ([]byte, error) {
+			calls++
+			if name != "/bin/sh" || len(args) != 2 || args[0] != "-c" || args[1] != macosuninstall.Script() {
+				t.Fatalf("unexpected runner invocation %q %v", name, args)
+			}
+			if failed {
+				return []byte("could not stop gui/502 helper"), errors.New("exit 1")
+			}
+			return nil, nil
+		})
+		if calls != 1 || (err != nil) != failed {
+			t.Fatalf("calls=%d err=%v", calls, err)
+		}
+		if failed && !strings.Contains(err.Error(), "could not stop gui/502 helper") {
+			t.Fatalf("lost failure: %v", err)
+		}
+	}
+}

--- a/agent/internal/heartbeat/handlers_uninstall.go
+++ b/agent/internal/heartbeat/handlers_uninstall.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/breeze-rmm/agent/internal/macosuninstall"
 	"github.com/breeze-rmm/agent/internal/remote/tools"
 )
 
@@ -169,12 +170,15 @@ type darwinUninstallScriptOptions struct {
 // freshly-deleted directory.
 func buildDarwinUninstallScript(opts darwinUninstallScriptOptions) string {
 	lines := []string{
+		macosuninstall.Functions,
 		fmt.Sprintf("sleep %d", opts.DelaySeconds),
-		fmt.Sprintf("launchctl bootout system/%s", shQuote(opts.WatchdogLabel)),
+		fmt.Sprintf("breeze_bootout system/%s || exit 1", shQuote(opts.WatchdogLabel)),
 		fmt.Sprintf("pkill -x %s", shQuote(opts.WatchdogProcess)),
-		fmt.Sprintf("launchctl bootout system/%s || launchctl unload %s", shQuote(opts.Label), shQuote(opts.PlistPath)),
-		fmt.Sprintf("rm -f %s", shQuote(opts.PlistPath)),
-		fmt.Sprintf("rm -f %s", shQuote(opts.BinaryPath)),
+		"breeze_stop_helpers || exit 1",
+		fmt.Sprintf("breeze_bootout system/%s || exit 1", shQuote(opts.Label)),
+		fmt.Sprintf("rm -f %s || exit 1", shQuote(opts.PlistPath)),
+		fmt.Sprintf("rm -f %s || exit 1", shQuote(opts.BinaryPath)),
+		"breeze_remove_auxiliary || exit 1",
 	}
 	if opts.RemoveConfig && opts.ConfigDir != "" {
 		lines = append(lines, fmt.Sprintf("rm -rf %s", shQuote(opts.ConfigDir)))
@@ -182,16 +186,13 @@ func buildDarwinUninstallScript(opts darwinUninstallScriptOptions) string {
 	return strings.Join(lines, "\n")
 }
 
-// prepareSelfUninstallDarwin removes the watchdog, user helper, plists, the
-// watchdog binary, and (optionally) config in-process, then hands the removal
-// of the agent's own daemon + binary to a detached shell.
+// prepareSelfUninstallDarwin neutralizes the watchdog in-process, then hands
+// helper jobs, package artifacts and optional config removal to a detached shell.
 func prepareSelfUninstallDarwin(removeConfig bool) error {
 	const (
 		label            = "com.breeze.agent"
-		userLabel        = "com.breeze.agent-user"
 		watchdogLabel    = "com.breeze.watchdog"
 		plistDst         = "/Library/LaunchDaemons/com.breeze.agent.plist"
-		userPlistDst     = "/Library/LaunchAgents/com.breeze.agent-user.plist"
 		watchdogPlistDst = "/Library/LaunchDaemons/com.breeze.watchdog.plist"
 		binaryPath       = "/usr/local/bin/breeze-agent"
 		watchdogBinary   = "/usr/local/bin/breeze-watchdog"
@@ -204,9 +205,6 @@ func prepareSelfUninstallDarwin(removeConfig bool) error {
 		log.Warn("launchctl bootout watchdog failed, trying legacy unload", "error", err.Error())
 		_ = exec.Command("launchctl", "unload", watchdogPlistDst).Run()
 	}
-	if err := exec.Command("launchctl", "bootout", "system/"+userLabel).Run(); err != nil {
-		_ = exec.Command("launchctl", "unload", userPlistDst).Run()
-	}
 
 	// Disable our own daemon (safe while running) so that if the detached
 	// helper never runs — blocked, reboot inside the window — the host comes
@@ -216,7 +214,6 @@ func prepareSelfUninstallDarwin(removeConfig bool) error {
 	}
 
 	removeFileLogged(watchdogPlistDst)
-	removeFileLogged(userPlistDst)
 	removeFileLogged(watchdogBinary)
 
 	// Booting out our own daemon kills this process, so it (plus the removal

--- a/agent/internal/heartbeat/handlers_uninstall_test.go
+++ b/agent/internal/heartbeat/handlers_uninstall_test.go
@@ -2,6 +2,10 @@ package heartbeat
 
 import (
 	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -182,9 +186,9 @@ func TestBuildDarwinUninstallScript(t *testing.T) {
 			opts: base,
 			wantOrder: []string{
 				"sleep 5",
-				"launchctl bootout system/'com.breeze.watchdog'",
+				"breeze_bootout system/'com.breeze.watchdog' || exit 1",
 				"pkill -x 'breeze-watchdog'",
-				"launchctl bootout system/'com.breeze.agent' || launchctl unload '/Library/LaunchDaemons/com.breeze.agent.plist'",
+				"breeze_bootout system/'com.breeze.agent' || exit 1",
 				"rm -f '/Library/LaunchDaemons/com.breeze.agent.plist'",
 				"rm -f '/usr/local/bin/breeze-agent'",
 				"rm -rf '/Library/Application Support/Breeze'",
@@ -404,6 +408,54 @@ func TestPsQuote(t *testing.T) {
 	for _, tt := range tests {
 		if got := psQuote(tt.in); got != tt.want {
 			t.Errorf("psQuote(%q) = %s, want %s", tt.in, got, tt.want)
+		}
+	}
+}
+
+// Execute the detached script with all endpoint effects replaced by recorders.
+// This proves the acknowledgement delay and optional data policy survive the
+// package cleanup, without invoking launchctl, pkill, pkgutil or rm on the host.
+func TestDarwinUninstallScriptExecutable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shell fixture")
+	}
+	for _, removeConfig := range []bool{false, true} {
+		root := t.TempDir()
+		calls := filepath.Join(root, "calls")
+		for _, name := range []string{"launchctl", "pkill", "pkgutil", "rm", "ps", "sleep"} {
+			body := "#!/bin/sh\nprintf '%s %s\\n' \"${0##*/}\" \"$*\" >> \"$FIXTURE_CALLS\"\n"
+			switch name {
+			case "ps":
+				body += "printf '101 501 loginwindow\\n102 502 loginwindow\\n'\n"
+			case "pkgutil":
+				body += "[ \"$1\" != --pkgs ] || echo com.breeze.agent\n"
+			}
+			if err := os.WriteFile(filepath.Join(root, name), []byte(body), 0700); err != nil {
+				t.Fatal(err)
+			}
+		}
+		script := buildDarwinUninstallScript(darwinUninstallScriptOptions{Label: "com.breeze.agent", WatchdogLabel: "com.breeze.watchdog", WatchdogProcess: "breeze-watchdog", PlistPath: "/Library/LaunchDaemons/com.breeze.agent.plist", BinaryPath: "/usr/local/bin/breeze-agent", ConfigDir: "/Library/Application Support/Breeze", RemoveConfig: removeConfig, DelaySeconds: 5})
+		cmd := exec.Command("/bin/sh", "-c", script)
+		cmd.Env = append(os.Environ(), "PATH="+root+":/usr/bin:/bin", "FIXTURE_CALLS="+calls)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v: %s", err, out)
+		}
+		b, err := os.ReadFile(calls)
+		if err != nil {
+			t.Fatal(err)
+		}
+		s := string(b)
+		assertOrder(t, s, "sleep 5", "launchctl bootout system/com.breeze.watchdog", "pkill -x breeze-watchdog", "launchctl bootout gui/501/com.breeze.desktop-helper-user", "launchctl bootout gui/502/com.breeze.desktop-helper-user", "launchctl bootout pid/101/com.breeze.desktop-helper-loginwindow", "launchctl bootout pid/102/com.breeze.desktop-helper-loginwindow", "launchctl bootout system/com.breeze.agent", "rm -f /Library/LaunchDaemons/com.breeze.agent.plist", "pkgutil --forget com.breeze.agent")
+		for _, artifact := range []string{"/usr/local/bin/breeze-desktop-helper", "/usr/local/bin/breeze-backup", "/Library/LaunchAgents/com.breeze.desktop-helper-user.plist", "/Library/LaunchAgents/com.breeze.desktop-helper-loginwindow.plist"} {
+			if !strings.Contains(s, artifact) {
+				t.Errorf("missing %s", artifact)
+			}
+		}
+		if strings.Contains(s, "rm -rf /Library/Application Support/Breeze") != removeConfig {
+			t.Errorf("changed optional config policy: %s", s)
+		}
+		if strings.Contains(s, "com.breeze.agent-user") || strings.Contains(s, "com.breeze.helper") {
+			t.Errorf("unowned label: %s", s)
 		}
 	}
 }

--- a/agent/internal/macosuninstall/functions.sh
+++ b/agent/internal/macosuninstall/functions.sh
@@ -1,0 +1,51 @@
+# Package-owned macOS teardown. Embedded in Go; copied into download scripts.
+# BEGIN BREEZE MACOS UNINSTALL FUNCTIONS
+breeze_bootout() {
+  target="$1"
+  command -v launchctl >/dev/null 2>&1 || return 1
+  if launchctl bootout "$target" 2>/dev/null; then
+    return 0
+  fi
+  # An absent job is already stopped; a job that remains loaded is a failure.
+  status=0
+  launchctl print "$target" >/dev/null 2>&1 || status=$?
+  # launchctl uses 113 (service not found) for an absent service target.
+  if [ "$status" -ne 113 ]; then
+    echo "Error: could not confirm $target stopped (launchctl status $status)" >&2
+    return 1
+  fi
+}
+
+breeze_stop_watchdog() {
+  breeze_bootout system/com.breeze.watchdog
+}
+
+breeze_stop_helpers() {
+  # Include fast-user-switched sessions, not just the foreground console user.
+  sessions="$(ps -axo pid=,uid=,comm=)" || return 1
+  uids="$(printf '%s\n' "$sessions" | awk '$1 ~ /^[0-9]+$/ && $2 ~ /^[0-9]+$/ && $2 >= 500 && $NF ~ /(^|\/)loginwindow$/ {print $2}' | sort -u)"
+  for uid in $uids; do
+    breeze_bootout "gui/$uid/com.breeze.desktop-helper-user" || return 1
+  done
+  # LoginWindow is a session type, not a launchctl domain name. Address each
+  # actual loginwindow process's domain, including the root login-screen session.
+  pids="$(printf '%s\n' "$sessions" | awk '$1 ~ /^[0-9]+$/ && $1 > 0 && $2 ~ /^[0-9]+$/ && $NF ~ /(^|\/)loginwindow$/ {print $1}' | sort -u)"
+  for pid in $pids; do
+    breeze_bootout "pid/$pid/com.breeze.desktop-helper-loginwindow" || return 1
+  done
+}
+
+breeze_remove_auxiliary() {
+  rm -f /Library/LaunchDaemons/com.breeze.watchdog.plist \
+    /Library/LaunchAgents/com.breeze.desktop-helper-user.plist \
+    /Library/LaunchAgents/com.breeze.desktop-helper-loginwindow.plist \
+    /usr/local/bin/breeze-watchdog /usr/local/bin/breeze-desktop-helper \
+    /usr/local/bin/breeze-backup \
+    "/Library/Application Support/Breeze/agent.sock" || return 1
+  # Only forget this package's receipt; configuration and logs retain their policy.
+  receipts="$(pkgutil --pkgs)" || return 1
+  if printf '%s\n' "$receipts" | grep -Fxq com.breeze.agent; then
+    pkgutil --forget com.breeze.agent || return 1
+  fi
+}
+# END BREEZE MACOS UNINSTALL FUNCTIONS

--- a/agent/internal/macosuninstall/functions.sh
+++ b/agent/internal/macosuninstall/functions.sh
@@ -44,7 +44,8 @@ breeze_remove_auxiliary() {
     "/Library/Application Support/Breeze/agent.sock" || return 1
   # Only forget this package's receipt; configuration and logs retain their policy.
   receipts="$(pkgutil --pkgs)" || return 1
-  if printf '%s\n' "$receipts" | grep -Fxq com.breeze.agent; then
+  # Consume all input: grep -q can SIGPIPE printf under Bash pipefail.
+  if printf '%s\n' "$receipts" | grep -Fx com.breeze.agent >/dev/null; then
     pkgutil --forget com.breeze.agent || return 1
   fi
 }

--- a/agent/internal/macosuninstall/script.go
+++ b/agent/internal/macosuninstall/script.go
@@ -1,0 +1,23 @@
+// Package macosuninstall holds the package-owned teardown shared by local and
+// detached macOS uninstall paths. Its shell source is embedded, never read from
+// a mutable installation manifest on the endpoint.
+package macosuninstall
+
+import _ "embed"
+
+// Functions stops only jobs and removes artifacts owned by the main agent pkg.
+// Config, logs, the breeze group and the separately installed Assist are excluded.
+//
+//go:embed functions.sh
+var Functions string
+
+// Script preserves configuration, matching the service CLI's existing policy.
+func Script() string {
+	return Functions + `
+breeze_stop_watchdog || exit 1
+breeze_stop_helpers || exit 1
+breeze_bootout system/com.breeze.agent || exit 1
+rm -f /Library/LaunchDaemons/com.breeze.agent.plist /usr/local/bin/breeze-agent || exit 1
+breeze_remove_auxiliary || exit 1
+`
+}

--- a/agent/internal/macosuninstall/script_test.go
+++ b/agent/internal/macosuninstall/script_test.go
@@ -27,7 +27,7 @@ func TestPackageCleanup(t *testing.T) {
 	}
 	// The socket is volatile runtime state, not part of the pkg payload.
 	artifacts["/Library/Application Support/Breeze/agent.sock"] = true
-	for _, failure := range []string{"", "absent", "no_sessions", "helper", "query", "ps", "receipt", "receipt_list", "rm"} {
+	for _, failure := range []string{"", "absent", "no_sessions", "many_receipts", "helper", "query", "ps", "receipt", "receipt_list", "rm"} {
 		t.Run("failure="+failure, func(t *testing.T) {
 			root := t.TempDir()
 			bin := filepath.Join(root, "bin")
@@ -61,6 +61,8 @@ elif name=='launchctl':
 elif name=='pkgutil':
  if fail=='receipt_list': sys.exit(1)
  if args[0]=='--pkgs':
+  if fail=='many_receipts':
+   print('com.breeze.agent\n' + ('com.example.other-receipt\n' * 20000)); sys.exit(0)
   print('com.breeze.helper' if fail=='absent' else 'com.breeze.helper\ncom.breeze.agent'); sys.exit(0)
  if fail=='receipt': sys.exit(1)
 elif name=='rm':
@@ -77,10 +79,10 @@ else: sys.exit(91)
 					t.Fatal(err)
 				}
 			}
-			cmd := exec.Command("/bin/sh", "-c", Script())
+			cmd := exec.Command("/bin/bash", "-o", "pipefail", "-c", Script())
 			cmd.Env = append(os.Environ(), "PATH="+bin+":/usr/bin:/bin", "FIXTURE_ROOT="+root, "FAIL_COMMAND="+failure)
 			out, err := cmd.CombinedOutput()
-			failed := failure != "" && failure != "absent" && failure != "no_sessions"
+			failed := failure != "" && failure != "absent" && failure != "no_sessions" && failure != "many_receipts"
 			if (err != nil) != failed {
 				t.Fatalf("exit=%v output=%s", err, out)
 			}

--- a/agent/internal/macosuninstall/script_test.go
+++ b/agent/internal/macosuninstall/script_test.go
@@ -1,0 +1,137 @@
+//go:build !windows
+
+package macosuninstall
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// All teardown commands are intercepted; the rm shim operates only in TempDir.
+func TestPackageCleanup(t *testing.T) {
+	build, err := os.ReadFile("../../installer/macos/build-pkg.sh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	matches := regexp.MustCompile(`\$PAYLOAD(/(?:usr/local/bin|Library/LaunchAgents|Library/LaunchDaemons)/[^"\s]+)`).FindAllStringSubmatch(string(build), -1)
+	artifacts := map[string]bool{}
+	for _, m := range matches {
+		artifacts[m[1]] = true
+	}
+	if len(artifacts) != 8 {
+		t.Fatalf("package artifacts: %v", artifacts)
+	}
+	// The socket is volatile runtime state, not part of the pkg payload.
+	artifacts["/Library/Application Support/Breeze/agent.sock"] = true
+	for _, failure := range []string{"", "absent", "no_sessions", "helper", "query", "ps", "receipt", "receipt_list", "rm"} {
+		t.Run("failure="+failure, func(t *testing.T) {
+			root := t.TempDir()
+			bin := filepath.Join(root, "bin")
+			if err := os.Mkdir(bin, 0700); err != nil {
+				t.Fatal(err)
+			}
+			kept := []string{"/Library/Application Support/Breeze/config.yaml", "/Library/Application Support/Breeze/secrets.yaml", "/Library/Logs/Breeze/agent.log", "/Library/LaunchDaemons/com.breeze.helper.plist", "/usr/local/bin/unrelated"}
+			paths := append([]string{}, kept...)
+			for p := range artifacts {
+				paths = append(paths, p)
+			}
+			for _, p := range paths {
+				if err := os.MkdirAll(filepath.Dir(root+p), 0700); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(root+p, []byte("retained"), 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			shim := `#!/usr/bin/python3
+import os,sys,pathlib
+name=pathlib.Path(sys.argv[0]).name; args=sys.argv[1:]; root=os.environ['FIXTURE_ROOT']; fail=os.environ['FAIL_COMMAND']
+with open(root+'/calls','a') as f: f.write(name+' '+' '.join(args)+'\n')
+if name=='ps':
+ if fail=='ps': sys.exit(1)
+ if fail=='no_sessions': sys.exit(0)
+ print('100 0 loginwindow\n101 501 /System/Library/CoreServices/loginwindow.app/Contents/MacOS/loginwindow\n102 502 loginwindow\n101 501 loginwindow\n103 503 unrelated\nBAD 501 loginwindow')
+elif name=='launchctl':
+ if args[0]=='print': sys.exit(5 if fail=='query' else (0 if fail=='helper' and 'gui/502/' in args[1] else 113))
+ if fail in ['absent','query'] or (fail=='helper' and 'gui/502/' in args[1]): sys.exit(1)
+elif name=='pkgutil':
+ if fail=='receipt_list': sys.exit(1)
+ if args[0]=='--pkgs':
+  print('com.breeze.helper' if fail=='absent' else 'com.breeze.helper\ncom.breeze.agent'); sys.exit(0)
+ if fail=='receipt': sys.exit(1)
+elif name=='rm':
+ if fail=='rm': sys.exit(1)
+ for p in args:
+  if p.startswith('-'): continue
+  if not p.startswith('/') or '..' in pathlib.Path(p).parts: sys.exit(90)
+  target=pathlib.Path(root+p)
+  if target.is_file(): target.unlink()
+else: sys.exit(91)
+`
+			for _, name := range []string{"launchctl", "ps", "pkgutil", "rm"} {
+				if err := os.WriteFile(filepath.Join(bin, name), []byte(shim), 0700); err != nil {
+					t.Fatal(err)
+				}
+			}
+			cmd := exec.Command("/bin/sh", "-c", Script())
+			cmd.Env = append(os.Environ(), "PATH="+bin+":/usr/bin:/bin", "FIXTURE_ROOT="+root, "FAIL_COMMAND="+failure)
+			out, err := cmd.CombinedOutput()
+			failed := failure != "" && failure != "absent" && failure != "no_sessions"
+			if (err != nil) != failed {
+				t.Fatalf("exit=%v output=%s", err, out)
+			}
+			calls, _ := os.ReadFile(filepath.Join(root, "calls"))
+			log := string(calls)
+			for _, p := range kept {
+				if b, err := os.ReadFile(root + p); err != nil || string(b) != "retained" {
+					t.Errorf("preserved %s changed: %v", p, err)
+				}
+			}
+			if failed {
+				return
+			}
+			for p := range artifacts {
+				if _, err := os.Stat(root + p); !os.IsNotExist(err) {
+					t.Errorf("survived: %s", p)
+				}
+			}
+			want := []string{"launchctl bootout system/com.breeze.watchdog", "launchctl bootout gui/501/com.breeze.desktop-helper-user", "launchctl bootout gui/502/com.breeze.desktop-helper-user", "launchctl bootout pid/100/com.breeze.desktop-helper-loginwindow", "launchctl bootout pid/101/com.breeze.desktop-helper-loginwindow", "launchctl bootout pid/102/com.breeze.desktop-helper-loginwindow", "launchctl bootout system/com.breeze.agent"}
+			if failure == "no_sessions" {
+				want = []string{want[0], want[len(want)-1]}
+			}
+			prev := -1
+			for _, s := range want {
+				i := strings.Index(log, s)
+				if i <= prev {
+					t.Errorf("missing/order %q: %s", s, log)
+				}
+				prev = i
+			}
+			if failure != "no_sessions" && strings.Count(log, want[1]) != 1 {
+				t.Errorf("duplicate session: %s", log)
+			}
+			if strings.Contains(log, "gui/503") || strings.Contains(log, "com.breeze.agent-user") || strings.Contains(log, "com.breeze.helper") {
+				t.Errorf("unowned job: %s", log)
+			}
+			if strings.Contains(log, "pkgutil --forget com.breeze.agent") == (failure == "absent") {
+				t.Errorf("receipt handling: %s", log)
+			}
+		})
+	}
+}
+
+func TestDistributedFunctionsMatchEmbeddedSource(t *testing.T) {
+	for _, p := range []string{"../../scripts/install/uninstall.sh", "../../../apps/web/public/scripts/uninstall.sh"} {
+		b, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(b), Functions) {
+			t.Errorf("%s differs from embedded functions", p)
+		}
+	}
+}

--- a/agent/scripts/install/uninstall.sh
+++ b/agent/scripts/install/uninstall.sh
@@ -20,27 +20,65 @@ require_root() {
   fi
 }
 
-uninstall_macos() {
-  local agent_plist="/Library/LaunchDaemons/com.breeze.agent.plist"
-  local watchdog_plist="/Library/LaunchDaemons/com.breeze.watchdog.plist"
-  local user_plist="/Library/LaunchAgents/com.breeze.agent-user.plist"
-
-  echo "Uninstalling Breeze Agent for macOS..."
-
-  if command -v launchctl >/dev/null 2>&1; then
-    launchctl bootout system/com.breeze.agent 2>/dev/null || launchctl unload "$agent_plist" 2>/dev/null || true
-    launchctl bootout system/com.breeze.watchdog 2>/dev/null || launchctl unload "$watchdog_plist" 2>/dev/null || true
-    launchctl unload "$user_plist" 2>/dev/null || true
-  else
-    warn "launchctl not found; skipping service stop"
+# Package-owned macOS teardown. Embedded in Go; copied into download scripts.
+# BEGIN BREEZE MACOS UNINSTALL FUNCTIONS
+breeze_bootout() {
+  target="$1"
+  command -v launchctl >/dev/null 2>&1 || return 1
+  if launchctl bootout "$target" 2>/dev/null; then
+    return 0
   fi
+  # An absent job is already stopped; a job that remains loaded is a failure.
+  status=0
+  launchctl print "$target" >/dev/null 2>&1 || status=$?
+  # launchctl uses 113 (service not found) for an absent service target.
+  if [ "$status" -ne 113 ]; then
+    echo "Error: could not confirm $target stopped (launchctl status $status)" >&2
+    return 1
+  fi
+}
 
-  rm -f "$agent_plist"
-  rm -f "$watchdog_plist"
-  rm -f "$user_plist"
-  rm -f "$AGENT_BINARY"
-  rm -f "$WATCHDOG_BINARY"
-  rm -f "$BACKUP_BINARY"
+breeze_stop_watchdog() {
+  breeze_bootout system/com.breeze.watchdog
+}
+
+breeze_stop_helpers() {
+  # Include fast-user-switched sessions, not just the foreground console user.
+  sessions="$(ps -axo pid=,uid=,comm=)" || return 1
+  uids="$(printf '%s\n' "$sessions" | awk '$1 ~ /^[0-9]+$/ && $2 ~ /^[0-9]+$/ && $2 >= 500 && $NF ~ /(^|\/)loginwindow$/ {print $2}' | sort -u)"
+  for uid in $uids; do
+    breeze_bootout "gui/$uid/com.breeze.desktop-helper-user" || return 1
+  done
+  # LoginWindow is a session type, not a launchctl domain name. Address each
+  # actual loginwindow process's domain, including the root login-screen session.
+  pids="$(printf '%s\n' "$sessions" | awk '$1 ~ /^[0-9]+$/ && $1 > 0 && $2 ~ /^[0-9]+$/ && $NF ~ /(^|\/)loginwindow$/ {print $1}' | sort -u)"
+  for pid in $pids; do
+    breeze_bootout "pid/$pid/com.breeze.desktop-helper-loginwindow" || return 1
+  done
+}
+
+breeze_remove_auxiliary() {
+  rm -f /Library/LaunchDaemons/com.breeze.watchdog.plist \
+    /Library/LaunchAgents/com.breeze.desktop-helper-user.plist \
+    /Library/LaunchAgents/com.breeze.desktop-helper-loginwindow.plist \
+    /usr/local/bin/breeze-watchdog /usr/local/bin/breeze-desktop-helper \
+    /usr/local/bin/breeze-backup \
+    "/Library/Application Support/Breeze/agent.sock" || return 1
+  # Only forget this package's receipt; configuration and logs retain their policy.
+  receipts="$(pkgutil --pkgs)" || return 1
+  if printf '%s\n' "$receipts" | grep -Fxq com.breeze.agent; then
+    pkgutil --forget com.breeze.agent || return 1
+  fi
+}
+# END BREEZE MACOS UNINSTALL FUNCTIONS
+
+uninstall_macos() {
+  echo "Uninstalling Breeze Agent for macOS..."
+  breeze_stop_watchdog || return 1
+  breeze_stop_helpers || return 1
+  breeze_bootout system/com.breeze.agent || return 1
+  rm -f /Library/LaunchDaemons/com.breeze.agent.plist "$AGENT_BINARY" || return 1
+  breeze_remove_auxiliary || return 1
 
   echo "Breeze Agent uninstalled."
   echo "Config at /Library/Application Support/Breeze/ was preserved."

--- a/agent/scripts/install/uninstall.sh
+++ b/agent/scripts/install/uninstall.sh
@@ -66,7 +66,8 @@ breeze_remove_auxiliary() {
     "/Library/Application Support/Breeze/agent.sock" || return 1
   # Only forget this package's receipt; configuration and logs retain their policy.
   receipts="$(pkgutil --pkgs)" || return 1
-  if printf '%s\n' "$receipts" | grep -Fxq com.breeze.agent; then
+  # Consume all input: grep -q can SIGPIPE printf under Bash pipefail.
+  if printf '%s\n' "$receipts" | grep -Fx com.breeze.agent >/dev/null; then
     pkgutil --forget com.breeze.agent || return 1
   fi
 }

--- a/apps/api/src/routes/agents/download.test.ts
+++ b/apps/api/src/routes/agents/download.test.ts
@@ -778,7 +778,7 @@ describe('GET /uninstall.sh — generated uninstaller script', () => {
     const script = await fetchScript();
     expect(script).toContain('Darwin*) uninstall_macos');
     expect(script).toContain('Linux*) uninstall_linux');
-    expect(script).toContain('launchctl bootout system/com.breeze.agent');
+    expect(script).toContain('breeze_bootout system/com.breeze.agent');
     expect(script).toContain('systemctl stop breeze-agent');
   });
 
@@ -790,7 +790,8 @@ describe('GET /uninstall.sh — generated uninstaller script', () => {
       script.indexOf('uninstall_macos()'),
       script.indexOf('uninstall_linux()'),
     );
-    expect(macosBlock).toContain('rm -f "$BACKUP_BINARY"');
+    expect(macosBlock).toContain('breeze_remove_auxiliary || return 1');
+    expect(script).toContain('/usr/local/bin/breeze-backup');
 
     const linuxStart = script.indexOf('uninstall_linux()');
     const linuxBlock = script.slice(
@@ -798,6 +799,47 @@ describe('GET /uninstall.sh — generated uninstaller script', () => {
       script.indexOf('require_root', linuxStart),
     );
     expect(linuxBlock).toContain('rm -f "$BACKUP_BINARY"');
+  });
+
+  it('executes macOS package cleanup with intercepted endpoint commands', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'breeze-uninstall-exec-'));
+    const calls = join(tmp, 'calls');
+    try {
+      for (const name of ['id', 'uname', 'launchctl', 'pkgutil', 'rm', 'ps']) {
+        let body = '#!/bin/sh\nprintf "%s %s\\n" "${0##*/}" "$*" >> "$FIXTURE_CALLS"\n';
+        if (name === 'id') body += 'echo 0\n';
+        if (name === 'uname') body += 'echo Darwin\n';
+        if (name === 'ps') body += "printf '101 501 loginwindow\\n102 502 loginwindow\\n101 501 loginwindow\\n'\n";
+        if (name === 'pkgutil') body += '[ "$1" != --pkgs ] || echo com.breeze.agent\n';
+        writeFileSync(join(tmp, name), body, { mode: 0o755 });
+      }
+      const script = join(tmp, 'uninstall.sh');
+      writeFileSync(script, await fetchScript());
+      execFileSync('/bin/bash', [script], { env: { ...process.env, PATH: `${tmp}:/usr/bin:/bin`, FIXTURE_CALLS: calls } });
+      const commands = readFileSync(calls, 'utf8');
+      const ordered = [
+        'launchctl bootout system/com.breeze.watchdog',
+        'launchctl bootout gui/501/com.breeze.desktop-helper-user',
+        'launchctl bootout gui/502/com.breeze.desktop-helper-user',
+        'launchctl bootout pid/101/com.breeze.desktop-helper-loginwindow',
+        'launchctl bootout pid/102/com.breeze.desktop-helper-loginwindow',
+        'launchctl bootout system/com.breeze.agent',
+        'pkgutil --forget com.breeze.agent',
+      ];
+      let previous = -1;
+      for (const call of ordered) {
+        expect(commands.indexOf(call)).toBeGreaterThan(previous);
+        previous = commands.indexOf(call);
+      }
+      for (const binary of ['breeze-agent', 'breeze-watchdog', 'breeze-backup', 'breeze-desktop-helper']) {
+        expect(commands).toContain(`/usr/local/bin/${binary}`);
+      }
+      expect(commands).not.toContain('rm -rf');
+      expect(commands).not.toContain('com.breeze.agent-user');
+      expect(commands).not.toContain('com.breeze.helper');
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
   });
 
   it('matches the checked-in web and agent script copies', async () => {

--- a/apps/api/src/routes/agents/download.ts
+++ b/apps/api/src/routes/agents/download.ts
@@ -518,27 +518,65 @@ require_root() {
   fi
 }
 
-uninstall_macos() {
-  local agent_plist="/Library/LaunchDaemons/com.breeze.agent.plist"
-  local watchdog_plist="/Library/LaunchDaemons/com.breeze.watchdog.plist"
-  local user_plist="/Library/LaunchAgents/com.breeze.agent-user.plist"
-
-  echo "Uninstalling Breeze Agent for macOS..."
-
-  if command -v launchctl >/dev/null 2>&1; then
-    launchctl bootout system/com.breeze.agent 2>/dev/null || launchctl unload "$agent_plist" 2>/dev/null || true
-    launchctl bootout system/com.breeze.watchdog 2>/dev/null || launchctl unload "$watchdog_plist" 2>/dev/null || true
-    launchctl unload "$user_plist" 2>/dev/null || true
-  else
-    warn "launchctl not found; skipping service stop"
+# Package-owned macOS teardown. Embedded in Go; copied into download scripts.
+# BEGIN BREEZE MACOS UNINSTALL FUNCTIONS
+breeze_bootout() {
+  target="$1"
+  command -v launchctl >/dev/null 2>&1 || return 1
+  if launchctl bootout "$target" 2>/dev/null; then
+    return 0
   fi
+  # An absent job is already stopped; a job that remains loaded is a failure.
+  status=0
+  launchctl print "$target" >/dev/null 2>&1 || status=$?
+  # launchctl uses 113 (service not found) for an absent service target.
+  if [ "$status" -ne 113 ]; then
+    echo "Error: could not confirm $target stopped (launchctl status $status)" >&2
+    return 1
+  fi
+}
 
-  rm -f "$agent_plist"
-  rm -f "$watchdog_plist"
-  rm -f "$user_plist"
-  rm -f "$AGENT_BINARY"
-  rm -f "$WATCHDOG_BINARY"
-  rm -f "$BACKUP_BINARY"
+breeze_stop_watchdog() {
+  breeze_bootout system/com.breeze.watchdog
+}
+
+breeze_stop_helpers() {
+  # Include fast-user-switched sessions, not just the foreground console user.
+  sessions="$(ps -axo pid=,uid=,comm=)" || return 1
+  uids="$(printf '%s\\n' "$sessions" | awk '$1 ~ /^[0-9]+$/ && $2 ~ /^[0-9]+$/ && $2 >= 500 && $NF ~ /(^|\\/)loginwindow$/ {print $2}' | sort -u)"
+  for uid in $uids; do
+    breeze_bootout "gui/$uid/com.breeze.desktop-helper-user" || return 1
+  done
+  # LoginWindow is a session type, not a launchctl domain name. Address each
+  # actual loginwindow process's domain, including the root login-screen session.
+  pids="$(printf '%s\\n' "$sessions" | awk '$1 ~ /^[0-9]+$/ && $1 > 0 && $2 ~ /^[0-9]+$/ && $NF ~ /(^|\\/)loginwindow$/ {print $1}' | sort -u)"
+  for pid in $pids; do
+    breeze_bootout "pid/$pid/com.breeze.desktop-helper-loginwindow" || return 1
+  done
+}
+
+breeze_remove_auxiliary() {
+  rm -f /Library/LaunchDaemons/com.breeze.watchdog.plist \\
+    /Library/LaunchAgents/com.breeze.desktop-helper-user.plist \\
+    /Library/LaunchAgents/com.breeze.desktop-helper-loginwindow.plist \\
+    /usr/local/bin/breeze-watchdog /usr/local/bin/breeze-desktop-helper \\
+    /usr/local/bin/breeze-backup \\
+    "/Library/Application Support/Breeze/agent.sock" || return 1
+  # Only forget this package's receipt; configuration and logs retain their policy.
+  receipts="$(pkgutil --pkgs)" || return 1
+  if printf '%s\\n' "$receipts" | grep -Fxq com.breeze.agent; then
+    pkgutil --forget com.breeze.agent || return 1
+  fi
+}
+# END BREEZE MACOS UNINSTALL FUNCTIONS
+
+uninstall_macos() {
+  echo "Uninstalling Breeze Agent for macOS..."
+  breeze_stop_watchdog || return 1
+  breeze_stop_helpers || return 1
+  breeze_bootout system/com.breeze.agent || return 1
+  rm -f /Library/LaunchDaemons/com.breeze.agent.plist "$AGENT_BINARY" || return 1
+  breeze_remove_auxiliary || return 1
 
   echo "Breeze Agent uninstalled."
   echo "Config at /Library/Application Support/Breeze/ was preserved."

--- a/apps/api/src/routes/agents/download.ts
+++ b/apps/api/src/routes/agents/download.ts
@@ -564,7 +564,8 @@ breeze_remove_auxiliary() {
     "/Library/Application Support/Breeze/agent.sock" || return 1
   # Only forget this package's receipt; configuration and logs retain their policy.
   receipts="$(pkgutil --pkgs)" || return 1
-  if printf '%s\\n' "$receipts" | grep -Fxq com.breeze.agent; then
+  # Consume all input: grep -q can SIGPIPE printf under Bash pipefail.
+  if printf '%s\\n' "$receipts" | grep -Fx com.breeze.agent >/dev/null; then
     pkgutil --forget com.breeze.agent || return 1
   fi
 }

--- a/apps/web/public/scripts/uninstall.sh
+++ b/apps/web/public/scripts/uninstall.sh
@@ -20,27 +20,65 @@ require_root() {
   fi
 }
 
-uninstall_macos() {
-  local agent_plist="/Library/LaunchDaemons/com.breeze.agent.plist"
-  local watchdog_plist="/Library/LaunchDaemons/com.breeze.watchdog.plist"
-  local user_plist="/Library/LaunchAgents/com.breeze.agent-user.plist"
-
-  echo "Uninstalling Breeze Agent for macOS..."
-
-  if command -v launchctl >/dev/null 2>&1; then
-    launchctl bootout system/com.breeze.agent 2>/dev/null || launchctl unload "$agent_plist" 2>/dev/null || true
-    launchctl bootout system/com.breeze.watchdog 2>/dev/null || launchctl unload "$watchdog_plist" 2>/dev/null || true
-    launchctl unload "$user_plist" 2>/dev/null || true
-  else
-    warn "launchctl not found; skipping service stop"
+# Package-owned macOS teardown. Embedded in Go; copied into download scripts.
+# BEGIN BREEZE MACOS UNINSTALL FUNCTIONS
+breeze_bootout() {
+  target="$1"
+  command -v launchctl >/dev/null 2>&1 || return 1
+  if launchctl bootout "$target" 2>/dev/null; then
+    return 0
   fi
+  # An absent job is already stopped; a job that remains loaded is a failure.
+  status=0
+  launchctl print "$target" >/dev/null 2>&1 || status=$?
+  # launchctl uses 113 (service not found) for an absent service target.
+  if [ "$status" -ne 113 ]; then
+    echo "Error: could not confirm $target stopped (launchctl status $status)" >&2
+    return 1
+  fi
+}
 
-  rm -f "$agent_plist"
-  rm -f "$watchdog_plist"
-  rm -f "$user_plist"
-  rm -f "$AGENT_BINARY"
-  rm -f "$WATCHDOG_BINARY"
-  rm -f "$BACKUP_BINARY"
+breeze_stop_watchdog() {
+  breeze_bootout system/com.breeze.watchdog
+}
+
+breeze_stop_helpers() {
+  # Include fast-user-switched sessions, not just the foreground console user.
+  sessions="$(ps -axo pid=,uid=,comm=)" || return 1
+  uids="$(printf '%s\n' "$sessions" | awk '$1 ~ /^[0-9]+$/ && $2 ~ /^[0-9]+$/ && $2 >= 500 && $NF ~ /(^|\/)loginwindow$/ {print $2}' | sort -u)"
+  for uid in $uids; do
+    breeze_bootout "gui/$uid/com.breeze.desktop-helper-user" || return 1
+  done
+  # LoginWindow is a session type, not a launchctl domain name. Address each
+  # actual loginwindow process's domain, including the root login-screen session.
+  pids="$(printf '%s\n' "$sessions" | awk '$1 ~ /^[0-9]+$/ && $1 > 0 && $2 ~ /^[0-9]+$/ && $NF ~ /(^|\/)loginwindow$/ {print $1}' | sort -u)"
+  for pid in $pids; do
+    breeze_bootout "pid/$pid/com.breeze.desktop-helper-loginwindow" || return 1
+  done
+}
+
+breeze_remove_auxiliary() {
+  rm -f /Library/LaunchDaemons/com.breeze.watchdog.plist \
+    /Library/LaunchAgents/com.breeze.desktop-helper-user.plist \
+    /Library/LaunchAgents/com.breeze.desktop-helper-loginwindow.plist \
+    /usr/local/bin/breeze-watchdog /usr/local/bin/breeze-desktop-helper \
+    /usr/local/bin/breeze-backup \
+    "/Library/Application Support/Breeze/agent.sock" || return 1
+  # Only forget this package's receipt; configuration and logs retain their policy.
+  receipts="$(pkgutil --pkgs)" || return 1
+  if printf '%s\n' "$receipts" | grep -Fxq com.breeze.agent; then
+    pkgutil --forget com.breeze.agent || return 1
+  fi
+}
+# END BREEZE MACOS UNINSTALL FUNCTIONS
+
+uninstall_macos() {
+  echo "Uninstalling Breeze Agent for macOS..."
+  breeze_stop_watchdog || return 1
+  breeze_stop_helpers || return 1
+  breeze_bootout system/com.breeze.agent || return 1
+  rm -f /Library/LaunchDaemons/com.breeze.agent.plist "$AGENT_BINARY" || return 1
+  breeze_remove_auxiliary || return 1
 
   echo "Breeze Agent uninstalled."
   echo "Config at /Library/Application Support/Breeze/ was preserved."

--- a/apps/web/public/scripts/uninstall.sh
+++ b/apps/web/public/scripts/uninstall.sh
@@ -66,7 +66,8 @@ breeze_remove_auxiliary() {
     "/Library/Application Support/Breeze/agent.sock" || return 1
   # Only forget this package's receipt; configuration and logs retain their policy.
   receipts="$(pkgutil --pkgs)" || return 1
-  if printf '%s\n' "$receipts" | grep -Fxq com.breeze.agent; then
+  # Consume all input: grep -q can SIGPIPE printf under Bash pipefail.
+  if printf '%s\n' "$receipts" | grep -Fx com.breeze.agent >/dev/null; then
     pkgutil --forget com.breeze.agent || return 1
   fi
 }

--- a/docs/superpowers/plans/installer-enrollment/2026-09-07-macos-uninstall-artifacts.md
+++ b/docs/superpowers/plans/installer-enrollment/2026-09-07-macos-uninstall-artifacts.md
@@ -1,0 +1,12 @@
+# macOS uninstall artifact implementation plan
+
+1. Verify fresh main and all-state PR coverage; inspect the package payload and all
+   three supported uninstall entry paths. Preserve existing data/ack policies.
+2. Implement fixed embedded cleanup functions, all current launchd domains,
+   package file/receipt removal, and propagated cleanup failures.
+3. Connect service CLI and detached self-uninstall; synchronize public/API scripts.
+4. Prove installer artifact coverage and preserved files with isolated executable
+   fixtures; test optional remote config deletion and delayed ordering. Run Go
+   race tests, API script tests, typecheck and required CI with bounded concurrency.
+5. Obtain independent six-aspect exact-head review; publish a draft referencing
+   #4060/RMM-QA-184, with candidate and full-finding closure explicitly outstanding.

--- a/docs/superpowers/specs/installer-enrollment/2026-09-07-macos-uninstall-artifacts-design.md
+++ b/docs/superpowers/specs/installer-enrollment/2026-09-07-macos-uninstall-artifacts-design.md
@@ -1,0 +1,58 @@
+# macOS package artifact cleanup (RMM-QA-184, #4060)
+
+## Remaining product gap
+
+The pkg builder installs four binaries and four launchd plists, but the shell and
+remote uninstall paths still reference the obsolete agent-user helper label.
+Service CLI uninstall removes current helper files without stopping their GUI and
+loginwindow jobs. The paths also omit package receipt removal and some binaries.
+
+This bounded change aligns package-owned teardown across public shell downloads,
+the service CLI, and detached remote uninstall. Existing device-removal plans
+separate delivered commands from verified removal; this change preserves that
+boundary. It does not close the full QA finding.
+
+## Implementation
+
+Embed fixed shell functions in a small Go package used by service CLI and detached
+teardown. The same functions appear in the agent/public/API scripts, with parity
+checks. No endpoint-readable manifest supplies privileged deletion targets.
+Tests derive the eight owned file paths from the existing pkg builder.
+
+Stop watchdog before helper jobs and agent. Enumerate loginwindow process UIDs to
+cover fast user switching; only numeric human UIDs are used. Stop the current
+helper in each GUI domain and the LoginWindow helper through each actual
+loginwindow PID domain, including root. Local launchctl(1) documents pid/<pid>
+service targets; LoginWindow is a session type, not a literal domain. The
+installer currently attempts the latter best-effort; cleanup must not inherit
+that assumption. Native candidate verification of loaded session jobs remains
+required. Delete
+four binaries, four plists and the fixed volatile agent socket; forget only receipt
+com.breeze.agent. Keep separate Breeze Assist and the breeze group untouched.
+
+A bootout failure is tolerated only when launchctl print reports service-not-found
+(113). Other query failures or a still-loaded job fail cleanup. Failure to enumerate
+sessions, remove files, list receipts or forget an existing receipt also fails.
+An absent receipt is idempotent success. Failures can leave partial removal and
+should be retried; this is not an atomic operation.
+
+The shell and CLI retain configuration and logs. Remote uninstall retains its
+existing removeConfig option and delayed detached execution after command
+acknowledgement. Its initial watchdog neutralization and agent disable remain.
+Socket cleanup removes only volatile agent.sock, not configuration or secrets.
+Credentials, revocation, teardown acknowledgements, retained-data policy,
+group ownership and separately installed Assist lifecycle are outside this slice.
+
+## Verification and limits
+
+Run actual cleanup scripts with fake launchctl/ps/pkgutil/rm commands. File removal
+is redirected to a temporary fixture root; assert all builder-owned files disappear
+and config, secrets, logs and unrelated artifacts survive. Cover active/multiple
+sessions, absent jobs/receipt, enumeration failure, loaded-job stop failure,
+file/receipt failures and command ordering. Execute the generated API script and
+remote script through recording commands; CLI wiring propagates runner failures.
+Run Go race tests and API tests/typecheck, then independent exact-head review/CI.
+
+No install/uninstall command runs against the developer host. Real signed-package
+install/uninstall on a disposable Mac, candidate verification, credential teardown
+and formal QA closure remain outstanding. No migration or database change exists.


### PR DESCRIPTION
## Summary

macOS uninstall paths left the desktop helper, current LaunchAgent plists, loaded helper jobs and package receipt behind. The shell downloads, service CLI and detached self-uninstall now share fixed cleanup functions that stop the watchdog before helpers and agent, remove all eight package-owned files plus the volatile socket, and forget only the agent receipt. Failures to stop a loaded job, enumerate sessions, remove files or update receipts fail cleanup.

Helper targets use GUI user domains and the documented PID domains of actual loginwindow processes, including the root login screen. The old literal `loginwindow` target is not a documented launchctl domain. Fixed shell source is embedded in Go and checked against public/API copies; no mutable endpoint manifest controls deletion.

## Linked Issues

Refs #4060 — bounded RMM-QA-184 artifact cleanup only. Shell/CLI configuration and logs stay preserved; remote uninstall keeps its existing optional config deletion and delayed acknowledgement sequence. The separately installed Assist and breeze group remain untouched.

Credential revocation, teardown receipts, retained-data/group policy decisions, native signed-package install/uninstall verification, candidate readiness and formal finding closure remain outstanding. Static review establishes supported domain syntax; actual LoginWindow helper resolution through PID namespaces still needs native candidate verification. No host install/uninstall, deployment or merge was performed.

## Type of Change

- [x] Bug fix

## Testing

- Go 1.26.6 race tests passed across cleanup, heartbeat and agentapp packages, with bounded compilation and an explicit uninstall-only selection for existing packages. Ten executable cleanup scenarios intercept every endpoint command and confine file removal to temporary fixtures; eight owned paths are derived from the pkg builder. Tests cover retained config/secrets/logs/unrelated files, multiple sessions, idempotency, query/stop/removal failures, CLI error propagation and detached ordering/config policy.
- A 20,000-receipt regression first failed because early-exit grep caused SIGPIPE under Bash pipefail and skipped receipt removal; consuming the complete inventory fixes it.
- API download tests: 65 passed, including execution of the actual generated script with intercepted commands and three-copy parity.
- API typecheck passed with pinned Node 22.23.2 and command-scoped 8 GiB heap. Affected lint and diff checks passed.
- Independent six-aspect exact-head review cleared `3589100035fe0fe48b3c0146017c72aaf9713ec1` against integrated main `00b4b237760e8e5586950de0f297440e7dfb46bd`, no actionable findings. Reviewer inspected source/logs and did not independently execute tests.
- Final API typecheck passed on the reviewed head. Full API at the reviewed head: **36,509 passed / 21 skipped**, 1,943 files passed / 3 skipped, exit 0 in 618.91 seconds with two workers. Exact-head [CI run 34154718617](https://github.com/LanternOps/breeze/actions/runs/34154718617) completed successfully on attempt 1: **68 checks passed, one expected Main Red Alert skip**, no failures. The initial local full-suite run was explicitly stopped for the receipt correction; initial CI is superseded. This remains an open, unmerged draft; native candidate verification and full finding closure remain outstanding.

## Checklist

- [x] Existing affected tests pass
- [x] Added meaningful regression tests
- [x] No secrets, credentials or internal infrastructure details included
