### PR TITLE
fix(billing,accounting): refuse to void an invoice with applied payments (#5180)

### DIFF
--- a/apps/api/src/jobs/accountingSyncWorker.test.ts
+++ b/apps/api/src/jobs/accountingSyncWorker.test.ts
@@ -162,6 +162,10 @@ describe('processAccountingSyncJob', () => {
     ['not_connected', 404],
     ['reauth_required', 409],
     ['record_failed', 502],
+    // #5180: QuickBooks refusing to void an invoice a Payment settles is a
+    // RULE, not an outage — five retries got five identical refusals and five
+    // Sentry alerts in production.
+    ['void_blocked_by_payments', 409],
   ];
 
   it.each(terminalCodes)('is terminal for code=%s (%d) — logs and does NOT rethrow', async (code, status) => {
@@ -206,6 +210,24 @@ describe('processAccountingSyncJob', () => {
     await expect(
       processAccountingSyncJob({ type: 'push-invoice', invoiceId: INV_ID, partnerId: PARTNER_ID }),
     ).rejects.toBe(err);
+  });
+
+  it('does NOT rethrow a void_blocked_by_payments void failure — no retry ladder on a QuickBooks rule (#5180)', async () => {
+    // The sibling table above proves the code is terminal on the PUSH path.
+    // This is the path the production incident actually took: the void job.
+    getConnectionMock.mockResolvedValue(connectionRow());
+    voidInvoiceMock.mockRejectedValue(new AccountingInvoicePushError(
+      'void_blocked_by_payments', 409,
+      'QuickBooks will not void this invoice because a payment is applied to it there',
+    ));
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(
+      processAccountingSyncJob({ type: 'void-invoice', invoiceId: INV_ID, partnerId: PARTNER_ID }),
+    ).resolves.toBeUndefined();
+
+    expect(voidInvoiceMock).toHaveBeenCalledTimes(1);
+    errSpy.mockRestore();
   });
 
   it('a terminal void failure is also swallowed, not rethrown', async () => {

--- a/apps/api/src/jobs/accountingSyncWorker.ts
+++ b/apps/api/src/jobs/accountingSyncWorker.ts
@@ -22,8 +22,10 @@
  *     code in `TERMINAL_CODES` — `invoice_not_pushable`, `customer_not_mapped`,
  *     `home_currency_unknown`, `currency_mismatch`,
  *     `customer_currency_mismatch`, `dependency_not_ready`, `not_connected`,
- *     `reauth_required` (each a 404 or 409 — see the codes' own status in
- *     `accountingInvoicePush.ts`) PLUS `record_failed` (502 — the remote
+ *     `reauth_required`, `void_blocked_by_payments` (each a 404 or 409 — see
+ *     the codes' own status in `accountingInvoicePush.ts`; the last one is
+ *     QuickBooks refusing to void an invoice a Payment settles there, a rule
+ *     that answers the same on every attempt — #5180) PLUS `record_failed` (502 — the remote
  *     QuickBooks write already landed; only the local persist failed, so
  *     retrying would create a duplicate invoice in QuickBooks, not fix
  *     anything). Retrying any of these can never succeed: the mapping row
@@ -113,6 +115,7 @@ const TERMINAL_CODES: ReadonlySet<AccountingInvoicePushErrorCode> = new Set([
   'not_connected',
   'reauth_required',
   'record_failed',
+  'void_blocked_by_payments',
 ]);
 
 /**

--- a/apps/api/src/services/accounting/accountingInvoicePush.test.ts
+++ b/apps/api/src/services/accounting/accountingInvoicePush.test.ts
@@ -1236,6 +1236,49 @@ describe('voidInvoiceInAccounting', () => {
     expect(mapping.syncStatus).toBe('synced');
   });
 
+  // #5180 — the production incident: QuickBooks refused the void because the
+  // invoice was settled by a QuickBooks Payment, the failure was typed
+  // `quickbooks_error`, and BullMQ burned five attempts (and five Sentry
+  // alerts) on an answer that could never change.
+  it('classifies a QuickBooks "payment applied" refusal as the NON-retryable void_blocked_by_payments', async () => {
+    setup({
+      mappings: [
+        orgMappingRow(),
+        {
+          id: 'map-inv-1', integrationId: CONN_ID, partnerId: PARTNER, breezeEntityType: 'invoice', breezeEntityId: INVOICE,
+          remoteEntityType: 'Invoice', remoteEntityId: 'qb-inv-1', remoteSyncToken: '3',
+          remoteCurrencyCode: null, remoteDocNumber: null, linkStatus: 'confirmed', syncStatus: 'synced', lastError: null,
+        },
+      ],
+    });
+    voidInvoiceMock.mockRejectedValue(Object.assign(new Error('QuickBooks invoice void failed with 400'), {
+      status: 400,
+      qboFaultCode: '6000',
+      qboFaultMessage: 'Business Validation Error',
+      qboPaymentLinked: true,
+    }));
+
+    let caught: AccountingInvoicePushError | undefined;
+    try {
+      await voidInvoiceInAccounting(INVOICE, PARTNER, runCtx);
+    } catch (err) {
+      caught = err as AccountingInvoicePushError;
+    }
+
+    expect(caught?.code).toBe('void_blocked_by_payments');
+    expect(caught?.status).toBe(409);
+    // The message must name the remedy — the old one said only that something
+    // was rejected, five times, on a mapping card an operator had to act on.
+    expect(caught?.message).toBe(
+      'QuickBooks will not void this invoice because a payment is applied to it there'
+      + ' — remove or unapply that payment in QuickBooks, then void the invoice again'
+      + ' (HTTP 400: Business Validation Error)',
+    );
+    const mapping = currentMappings.find((m) => m.id === 'map-inv-1')!;
+    expect(mapping.syncStatus).toBe('error');
+    expect(mapping.lastError).toBe(caught?.message);
+  });
+
   it('on provider void failure, marks the mapping error with a sanitized message and rethrows', async () => {
     setup({
       mappings: [

--- a/apps/api/src/services/accounting/accountingInvoicePush.ts
+++ b/apps/api/src/services/accounting/accountingInvoicePush.ts
@@ -62,7 +62,7 @@ import { AccountingCurrencyContractError, assertAccountingInvoicePushCurrency, n
 import { getAccountingProvider } from './providerRegistry';
 import { fanOutOwedPayments } from './accountingPaymentPush';
 import { captureException } from '../sentry';
-import { qboFaultOf, qboFaultSuffix } from './quickbooksFault';
+import { isQboPaymentLinkedRefusal, qboFaultOf, qboFaultSuffix } from './quickbooksFault';
 import { isPgUniqueViolation } from '../../utils/pgErrors';
 import {
   INVOICE_REMOTE_DELETED_ERROR,
@@ -100,6 +100,14 @@ export type AccountingInvoicePushErrorCode =
   // a push is mid-flight. Deliberately NOT in the worker's TERMINAL_CODES:
   // BullMQ must retry with backoff until the push records its remote id.
   | 'sync_in_progress'
+  // QuickBooks refused the void because a Payment is applied to the invoice
+  // THERE (#5180). A business rule, not an outage: every retry gets the same
+  // answer, so this must not be reported as `quickbooks_error` — that code is
+  // paired with 502 and read as "safe to retry", and the five-attempt ladder
+  // burned five Sentry alerts on it in production. Terminal in the worker; the
+  // mapping row carries a message naming the fix (unapply the payment in
+  // QuickBooks, then void again).
+  | 'void_blocked_by_payments'
   | 'quickbooks_error' | 'record_failed'; // 502s; record_failed = remote ok, local persist failed (never retry)
 
 export class AccountingInvoicePushError extends Error {
@@ -368,6 +376,22 @@ function providerStatusOf(err: unknown): number | undefined {
 function sanitizeInvoiceSyncErrorMessage(err: unknown): string {
   const suffix = qboFaultSuffix(providerStatusOf(err), qboFaultOf(err));
   return `QuickBooks rejected the invoice sync${suffix}`;
+}
+
+/**
+ * The operator-visible `last_error` for a void QuickBooks refuses because the
+ * invoice is settled by a Payment there (#5180).
+ *
+ * Names the remedy, because the previous message ("QuickBooks rejected the
+ * invoice sync (HTTP 400: Business Validation Error)") left an operator with a
+ * mapping card that said only that something was rejected, five times. Carries
+ * the same sanitized fault suffix as its sibling — the fault CLASS, never
+ * Intuit's `Detail`.
+ */
+function voidBlockedByPaymentsMessage(err: unknown): string {
+  const suffix = qboFaultSuffix(providerStatusOf(err), qboFaultOf(err));
+  return 'QuickBooks will not void this invoice because a payment is applied to it there'
+    + ` — remove or unapply that payment in QuickBooks, then void the invoice again${suffix}`;
 }
 
 /** The provider's status and body to the SERVER LOG only — the one place the
@@ -986,7 +1010,14 @@ export async function voidInvoiceInAccounting(
   try {
     voidResult = await runOutsideDbContext(() => providerImpl.voidInvoice(liveConn, voidPayload, mappingSeam));
   } catch (err) {
-    const message = sanitizeInvoiceSyncErrorMessage(err);
+    // #5180: separate "QuickBooks is unhappy right now" from "QuickBooks will
+    // never allow this". A payment applied to the invoice in QuickBooks makes
+    // the void permanently impossible until an operator removes it there, so
+    // the message names that action instead of the generic sync failure.
+    const blockedByPayments = isQboPaymentLinkedRefusal(err);
+    const message = blockedByPayments
+      ? voidBlockedByPaymentsMessage(err)
+      : sanitizeInvoiceSyncErrorMessage(err);
     logProviderFault('voidInvoice', mappingRow.id, err);
     captureException(err instanceof Error ? err : new Error(String(err)), undefined, {
       service: 'accountingInvoicePush',
@@ -996,6 +1027,7 @@ export async function voidInvoiceInAccounting(
     });
     // Own short context so the marker COMMITS before the throw below.
     await markInvoiceMappingErrorInOwnContext(runInDbContext, mappingRow.id, partnerId, message);
+    if (blockedByPayments) throw new AccountingInvoicePushError('void_blocked_by_payments', 409, message);
     throw new AccountingInvoicePushError('quickbooks_error', 502, message);
   }
   // Success: sync_status/last_error are left exactly as they were (still

--- a/apps/api/src/services/accounting/quickbooksFault.test.ts
+++ b/apps/api/src/services/accounting/quickbooksFault.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { parseQboFault, qboFaultOf, qboFaultSuffix } from './quickbooksFault';
+import { isQboPaymentLinkedRefusal, parseQboFault, qboFaultOf, qboFaultSuffix } from './quickbooksFault';
 
 describe('parseQboFault', () => {
   it('reads code and Message out of a well-formed fault', () => {
     const fault = parseQboFault(JSON.stringify({
       Fault: { Error: [{ code: '5010', Message: 'Stale Object Error', Detail: 'Object Id 181 ... ' }] },
     }));
-    expect(fault).toEqual({ code: '5010', message: 'Stale Object Error' });
+    expect(fault).toEqual({ code: '5010', message: 'Stale Object Error', paymentLinked: false });
   });
 
   it('never surfaces Detail — that is where Intuit puts the offending values', () => {
@@ -25,11 +25,11 @@ describe('parseQboFault', () => {
     // A gateway or WAF can answer with HTML; a classifier that threw here would
     // turn a transient edge failure into an unhandled one.
     const fault = parseQboFault('<html>oops "code":"5010" "Message":"Stale Object Error"</html>');
-    expect(fault).toEqual({ code: '5010', message: 'Stale Object Error' });
+    expect(fault).toEqual({ code: '5010', message: 'Stale Object Error', paymentLinked: false });
   });
 
   it('returns nulls for an empty body rather than throwing', () => {
-    expect(parseQboFault('')).toEqual({ code: null, message: null });
+    expect(parseQboFault('')).toEqual({ code: null, message: null, paymentLinked: false });
   });
 
   it('caps the message so an over-long fault class cannot flood a tag or a card', () => {
@@ -41,12 +41,12 @@ describe('parseQboFault', () => {
 describe('qboFaultOf / qboFaultSuffix', () => {
   it('reads the fields qboRequest attaches', () => {
     expect(qboFaultOf(Object.assign(new Error('x'), { qboFaultCode: '610', qboFaultMessage: 'Object Not Found' })))
-      .toEqual({ code: '610', message: 'Object Not Found' });
+      .toEqual({ code: '610', message: 'Object Not Found', paymentLinked: false });
   });
 
   it('is null-safe for an error that never went through the provider', () => {
-    expect(qboFaultOf(new Error('boom'))).toEqual({ code: null, message: null });
-    expect(qboFaultOf(undefined)).toEqual({ code: null, message: null });
+    expect(qboFaultOf(new Error('boom'))).toEqual({ code: null, message: null, paymentLinked: false });
+    expect(qboFaultOf(undefined)).toEqual({ code: null, message: null, paymentLinked: false });
   });
 
   it('names the fault class beside the status', () => {
@@ -54,5 +54,63 @@ describe('qboFaultOf / qboFaultSuffix', () => {
       .toBe(' (HTTP 400: Business Validation Error)');
     expect(qboFaultSuffix(400, { code: null, message: null })).toBe(' (HTTP 400)');
     expect(qboFaultSuffix(undefined, { code: null, message: null })).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #5180 — "QuickBooks will not void an invoice that has a payment applied"
+// ---------------------------------------------------------------------------
+
+describe('payment-linked refusal classification (#5180)', () => {
+  // The reason lives in `Detail`, which storage truncates at 500 characters —
+  // so it is read off the FULL body at parse time, exactly like `code` is.
+  const paymentFault = (detail: string): string => JSON.stringify({
+    Fault: { Error: [{ code: '6000', Message: 'Business Validation Error', Detail: detail }] },
+  });
+
+  it.each([
+    'You cannot void this invoice because it has payments applied to it.',
+    'The transaction is linked to another transaction and cannot be voided.',
+    'Business Validation Error: A payment is applied to this invoice.',
+  ])('flags the fault as payment-linked: %s', (detail) => {
+    expect(parseQboFault(paymentFault(detail)).paymentLinked).toBe(true);
+  });
+
+  it.each([
+    'Object Id 181 was changed by another user',
+    'Duplicate Document Number Error : You must specify a different number.',
+    '<html>502 Bad Gateway</html>',
+  ])('does NOT flag an unrelated fault: %s', (detail) => {
+    expect(parseQboFault(paymentFault(detail)).paymentLinked).toBe(false);
+  });
+
+  it('still never surfaces Detail — the classification is a boolean, not the text', () => {
+    const fault = parseQboFault(paymentFault('Payment applied by Acme Ltd for 4200.00'));
+    expect(fault.paymentLinked).toBe(true);
+    expect(JSON.stringify(fault)).not.toContain('Acme');
+    expect(JSON.stringify(fault)).not.toContain('4200');
+  });
+
+  it('isQboPaymentLinkedRefusal reads the flag qboRequest attached', () => {
+    const err = Object.assign(new Error('QuickBooks invoice void failed with 400'), {
+      status: 400, qboFaultCode: '6000', qboFaultMessage: 'Business Validation Error', qboPaymentLinked: true,
+    });
+    expect(isQboPaymentLinkedRefusal(err)).toBe(true);
+  });
+
+  it('falls back to the stored body when no flag was attached (older fault shape)', () => {
+    const err = Object.assign(new Error('QuickBooks invoice void failed with 400'), {
+      status: 400,
+      body: paymentFault('You cannot void a transaction that has payments applied to it.'),
+    });
+    expect(isQboPaymentLinkedRefusal(err)).toBe(true);
+  });
+
+  it('is false for a plain upstream failure — the classification only ever makes a retryable error terminal', () => {
+    expect(isQboPaymentLinkedRefusal(new Error('fetch failed'))).toBe(false);
+    expect(isQboPaymentLinkedRefusal(Object.assign(new Error('boom'), {
+      status: 500, qboFaultCode: '5010', qboFaultMessage: 'Stale Object Error',
+    }))).toBe(false);
+    expect(isQboPaymentLinkedRefusal(undefined)).toBe(false);
   });
 });

--- a/apps/api/src/services/accounting/quickbooksFault.test.ts
+++ b/apps/api/src/services/accounting/quickbooksFault.test.ts
@@ -80,6 +80,13 @@ describe('payment-linked refusal classification (#5180)', () => {
     'Object Id 181 was changed by another user',
     'Duplicate Document Number Error : You must specify a different number.',
     '<html>502 Bad Gateway</html>',
+    // The boundary that matters: faults that MENTION a payment for an entirely
+    // different reason. A bare "…has payments…" pattern matched both of these,
+    // which would have turned a different (possibly retryable) fault into a
+    // terminal one carrying a wrong remedy — so the noun always needs its verb.
+    'The transaction has payments totaling 40.00 but the line amounts do not reconcile.',
+    'This estimate contains payments that must be removed before conversion.',
+    'The Payment service is temporarily unavailable, please try again.',
   ])('does NOT flag an unrelated fault: %s', (detail) => {
     expect(parseQboFault(paymentFault(detail)).paymentLinked).toBe(false);
   });
@@ -101,15 +108,51 @@ describe('payment-linked refusal classification (#5180)', () => {
   it('falls back to the stored body when no flag was attached (older fault shape)', () => {
     const err = Object.assign(new Error('QuickBooks invoice void failed with 400'), {
       status: 400,
+      qboFaultCode: '6000',
+      qboFaultMessage: 'Business Validation Error',
       body: paymentFault('You cannot void a transaction that has payments applied to it.'),
     });
     expect(isQboPaymentLinkedRefusal(err)).toBe(true);
+  });
+
+  // The two gates that stand in front of the phrase match. Both exist because a
+  // false positive costs a real outage its retry ladder AND tells the operator
+  // to delete a payment that does not exist.
+  it('refuses to classify a non-400 failure, however its body reads', () => {
+    const err = Object.assign(new Error('QuickBooks invoice void failed with 503'), {
+      status: 503,
+      qboFaultCode: '6000',
+      qboFaultMessage: 'Business Validation Error',
+      qboPaymentLinked: true,
+      body: paymentFault('You cannot void this invoice because it has payments applied to it.'),
+    });
+    expect(isQboPaymentLinkedRefusal(err)).toBe(false);
+  });
+
+  it('refuses to classify a 400 that carried no Intuit fault at all (a WAF or gateway page)', () => {
+    const err = Object.assign(new Error('QuickBooks invoice void failed with 400'), {
+      status: 400,
+      body: '<html><body>Request blocked: payments applied to it</body></html>',
+    });
+    expect(isQboPaymentLinkedRefusal(err)).toBe(false);
+  });
+
+  it('does not read the error message Breeze wrote itself', () => {
+    // `qboRequest` throws `"<operation> failed with <status>"`. It carries no
+    // Intuit text, so it must never be part of the haystack.
+    const err = Object.assign(new Error('QuickBooks payments applied void failed with 400'), {
+      status: 400, qboFaultCode: '6140', qboFaultMessage: 'Duplicate Document Number Error',
+    });
+    expect(isQboPaymentLinkedRefusal(err)).toBe(false);
   });
 
   it('is false for a plain upstream failure — the classification only ever makes a retryable error terminal', () => {
     expect(isQboPaymentLinkedRefusal(new Error('fetch failed'))).toBe(false);
     expect(isQboPaymentLinkedRefusal(Object.assign(new Error('boom'), {
       status: 500, qboFaultCode: '5010', qboFaultMessage: 'Stale Object Error',
+    }))).toBe(false);
+    expect(isQboPaymentLinkedRefusal(Object.assign(new Error('boom'), {
+      status: 400, qboFaultCode: '5010', qboFaultMessage: 'Stale Object Error',
     }))).toBe(false);
     expect(isQboPaymentLinkedRefusal(undefined)).toBe(false);
   });

--- a/apps/api/src/services/accounting/quickbooksFault.ts
+++ b/apps/api/src/services/accounting/quickbooksFault.ts
@@ -26,12 +26,49 @@
  * is what makes a failure recognisable without leaking its contents.
  */
 
-/** The two fields worth carrying off a QuickBooks fault. */
+/** The fields worth carrying off a QuickBooks fault. */
 export interface QboFault {
   /** Intuit's numeric fault code as a string, e.g. `'5010'`. */
   code: string | null;
   /** The short fault CLASS. Never `Detail`. */
   message: string | null;
+  /**
+   * The fault says the transaction is refused because a Payment is applied to
+   * it (or it is otherwise linked to another transaction). Read off the FULL
+   * body at parse time for the same reason the code is (see the module note):
+   * Intuit puts this reason in `Detail`, which is exactly the field that gets
+   * truncated away before storage. A BOOLEAN, not the text — the Detail itself
+   * still never leaves this module.
+   *
+   * Optional so a hand-built fault (a caller that only cares about
+   * `qboFaultSuffix`) does not have to say `false`.
+   */
+  paymentLinked?: boolean;
+}
+
+/**
+ * Phrases Intuit uses when a write is refused because the transaction has a
+ * Payment applied / is linked to another transaction. Matched against the FULL
+ * fault body, never against the 500-character stored copy.
+ *
+ * Deliberately phrase-based rather than fault-code-based: the production
+ * incident (#5180) was reported through Sentry, whose scrubber redacts the
+ * message, so no verified fault CODE for this rejection exists to key on. Each
+ * pattern names both a payment/linked-transaction noun and a
+ * refusal/attachment verb, so a generic `Business Validation Error` or a
+ * network/gateway failure cannot match — the classification only ever turns a
+ * retryable failure into a terminal one, so a false positive would stop a
+ * retry that might have worked.
+ */
+const PAYMENT_LINKED_PATTERNS: readonly RegExp[] = [
+  /payments?\s+(?:is|are|was|were|has\s+been|have\s+been)?\s*(?:applied|linked|associated)/i,
+  /(?:has|have|with|contains?)\s+(?:an?\s+)?(?:applied\s+)?payments?\b/i,
+  /linked\s+(?:to\s+(?:another|other|an?)\s+)?transactions?/i,
+];
+
+/** Does this raw fault body say "there is a payment applied to this thing"? */
+function bodySaysPaymentLinked(rawBody: string): boolean {
+  return PAYMENT_LINKED_PATTERNS.some((re) => re.test(rawBody));
 }
 
 /** How many characters of a fault message may reach a log or a mapping card. */
@@ -74,17 +111,42 @@ export function parseQboFault(rawBody: string): QboFault {
   return {
     code,
     message: message === null ? null : message.slice(0, FAULT_MESSAGE_MAX),
+    paymentLinked: bodySaysPaymentLinked(rawBody),
   };
 }
 
 /** The fault fields `qboRequest` attaches to a non-2xx error, if any. */
 export function qboFaultOf(err: unknown): QboFault {
-  if (!err || typeof err !== 'object') return { code: null, message: null };
-  const e = err as { qboFaultCode?: unknown; qboFaultMessage?: unknown };
+  if (!err || typeof err !== 'object') return { code: null, message: null, paymentLinked: false };
+  const e = err as { qboFaultCode?: unknown; qboFaultMessage?: unknown; qboPaymentLinked?: unknown };
   return {
     code: typeof e.qboFaultCode === 'string' ? e.qboFaultCode : null,
     message: typeof e.qboFaultMessage === 'string' ? e.qboFaultMessage : null,
+    paymentLinked: e.qboPaymentLinked === true,
   };
+}
+
+/**
+ * Did QuickBooks refuse this write because the Invoice has a Payment applied to
+ * it in QuickBooks (#5180)?
+ *
+ * This is a RULE, not an outage: QuickBooks will not void an invoice a payment
+ * settles, and it will answer identically on every retry. Callers use it to
+ * classify the failure as terminal so the BullMQ ladder does not burn five
+ * attempts (and five Sentry alerts) on a deterministic refusal.
+ *
+ * The attached flag is authoritative — it was computed from the FULL body
+ * before truncation. The stored `body` is still consulted as a fallback so a
+ * fault assembled by an older code path (or a test fixture) is not missed;
+ * that copy is truncated, so it can only ever add a match, never remove one.
+ */
+export function isQboPaymentLinkedRefusal(err: unknown): boolean {
+  if (qboFaultOf(err).paymentLinked) return true;
+  const body = err && typeof err === 'object' && typeof (err as { body?: unknown }).body === 'string'
+    ? (err as { body: string }).body
+    : '';
+  const message = err instanceof Error ? err.message : '';
+  return bodySaysPaymentLinked(`${body} ${message}`);
 }
 
 /**

--- a/apps/api/src/services/accounting/quickbooksFault.ts
+++ b/apps/api/src/services/accounting/quickbooksFault.ts
@@ -53,16 +53,20 @@ export interface QboFault {
  *
  * Deliberately phrase-based rather than fault-code-based: the production
  * incident (#5180) was reported through Sentry, whose scrubber redacts the
- * message, so no verified fault CODE for this rejection exists to key on. Each
- * pattern names both a payment/linked-transaction noun and a
- * refusal/attachment verb, so a generic `Business Validation Error` or a
- * network/gateway failure cannot match — the classification only ever turns a
- * retryable failure into a terminal one, so a false positive would stop a
- * retry that might have worked.
+ * message, so no verified fault CODE for this rejection exists to key on.
+ *
+ * BECAUSE the ground truth is a phrase and not a code, the patterns stay narrow
+ * and the CALLER is gated too (see `isQboPaymentLinkedRefusal`). Each pattern
+ * pairs a payment/linked-transaction noun with an attachment verb, so a generic
+ * `Business Validation Error`, a stale-object fault or a gateway page cannot
+ * match. A bare "…has payments…" form was deliberately NOT included: with no
+ * verb it also matches a transient failure that merely mentions a payment, and
+ * this classification only ever converts a RETRYABLE failure into a terminal
+ * one — a false positive costs a retry that might have worked and hands the
+ * operator a confidently wrong remedy.
  */
 const PAYMENT_LINKED_PATTERNS: readonly RegExp[] = [
   /payments?\s+(?:is|are|was|were|has\s+been|have\s+been)?\s*(?:applied|linked|associated)/i,
-  /(?:has|have|with|contains?)\s+(?:an?\s+)?(?:applied\s+)?payments?\b/i,
   /linked\s+(?:to\s+(?:another|other|an?)\s+)?transactions?/i,
 ];
 
@@ -135,18 +139,36 @@ export function qboFaultOf(err: unknown): QboFault {
  * classify the failure as terminal so the BullMQ ladder does not burn five
  * attempts (and five Sentry alerts) on a deterministic refusal.
  *
- * The attached flag is authoritative — it was computed from the FULL body
- * before truncation. The stored `body` is still consulted as a fallback so a
- * fault assembled by an older code path (or a test fixture) is not missed;
- * that copy is truncated, so it can only ever add a match, never remove one.
+ * TWO GATES BEFORE THE PHRASE IS CONSULTED AT ALL, because a false positive
+ * removes a real outage's retries AND tells the operator to go delete a payment
+ * that does not exist:
+ *
+ *  1. HTTP 400 — Intuit answers a business-validation refusal with 400. A 5xx,
+ *     a timeout or a gateway page is an outage and keeps its retry ladder
+ *     however its body happens to read.
+ *  2. A fault Intuit actually emitted — `code` or `Message` parsed off the
+ *     envelope. An HTML error page from a WAF has neither, so it can never
+ *     reach the phrase match no matter which words it contains.
+ *
+ * Same shape as the 5010 stale-object handling, which likewise decides on the
+ * specific fault rather than on any text that floats past.
+ *
+ * The attached flag is authoritative — computed from the FULL body before
+ * truncation. The stored `body` is still consulted as a fallback so a fault
+ * assembled by an older code path (or a test fixture) is not missed; that copy
+ * is truncated, so it can only ever add a match, never remove one. The error's
+ * own `message` is NOT consulted: it is Breeze's own "<operation> failed with
+ * <status>" string, which carries no Intuit text and would only widen the
+ * surface for a coincidental match.
  */
 export function isQboPaymentLinkedRefusal(err: unknown): boolean {
-  if (qboFaultOf(err).paymentLinked) return true;
-  const body = err && typeof err === 'object' && typeof (err as { body?: unknown }).body === 'string'
-    ? (err as { body: string }).body
-    : '';
-  const message = err instanceof Error ? err.message : '';
-  return bodySaysPaymentLinked(`${body} ${message}`);
+  if (!err || typeof err !== 'object') return false;
+  const e = err as { status?: unknown; body?: unknown };
+  if (e.status !== 400) return false;
+  const fault = qboFaultOf(err);
+  if (fault.code === null && fault.message === null) return false;
+  if (fault.paymentLinked) return true;
+  return typeof e.body === 'string' && bodySaysPaymentLinked(e.body);
 }
 
 /**

--- a/apps/api/src/services/accounting/quickbooksProvider.test.ts
+++ b/apps/api/src/services/accounting/quickbooksProvider.test.ts
@@ -9,6 +9,7 @@ import {
 } from './quickbooksProvider';
 import type { AccountingConnection } from './accountingConnectionService';
 import type { AccountingPaymentPayload } from './types';
+import { isQboPaymentLinkedRefusal } from './quickbooksFault';
 
 function conn(overrides: Partial<AccountingConnection> = {}): AccountingConnection {
   return {
@@ -532,6 +533,50 @@ describe('voidInvoice', () => {
     await expect(quickbooksProvider.voidInvoice(conn(), voidPayload(), { remoteEntityId: '310', remoteSyncToken: '4' }))
       .rejects.toThrow(/failed with 400/);
     expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  // #5180 — the seam that makes the whole terminal-classification chain work.
+  // Everything downstream (the coordinator's catch, the worker's TERMINAL_CODES)
+  // keys off the fields `qboRequest` attaches HERE. If that attachment regresses
+  // — wrong property name, inverted condition — every hand-built-error test
+  // downstream stays green while the feature never fires against real
+  // QuickBooks, which is exactly the "five identical refusals, no signal"
+  // failure this issue was about. So this test starts from a real fetch reply.
+  it('attaches the payment-linked classification off the FULL fault body, so the coordinator can call the void terminal', async () => {
+    const detail = 'Business Validation Error: You cannot void this invoice because it has payments applied to it.'
+      // Padding so the reason sits PAST the 500-character truncation point that
+      // `body` storage applies — the classification must survive that.
+      + ` ${'x'.repeat(600)}`;
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(
+      JSON.stringify({ Fault: { Error: [{ code: '6000', Message: 'Business Validation Error', Detail: detail }] } }),
+      { status: 400 },
+    ));
+
+    const err = await quickbooksProvider
+      .voidInvoice(conn(), voidPayload(), { remoteEntityId: '310', remoteSyncToken: '4' })
+      .catch((e: unknown) => e) as Error & { body?: string; qboPaymentLinked?: boolean };
+
+    // Not a 5010, so the provider does NOT re-read and retry — it propagates.
+    expect(err.message).toMatch(/failed with 400/);
+    expect(err.qboPaymentLinked).toBe(true);
+    expect(isQboPaymentLinkedRefusal(err)).toBe(true);
+    // The truncated copy stored for forensics still never carries Intuit's
+    // Detail past 500 characters, and the flag did not depend on it.
+    expect(err.body!.length).toBeLessThanOrEqual(500);
+  });
+
+  it('does NOT flag an ordinary 400 fault as payment-linked — an unrelated rejection keeps its retries', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(
+      JSON.stringify({ Fault: { Error: [{ code: '6140', Message: 'Duplicate Document Number Error', Detail: 'DocNumber INV-1 already exists.' }] } }),
+      { status: 400 },
+    ));
+
+    const err = await quickbooksProvider
+      .voidInvoice(conn(), voidPayload(), { remoteEntityId: '310', remoteSyncToken: '4' })
+      .catch((e: unknown) => e) as Error & { qboPaymentLinked?: boolean };
+
+    expect(err.qboPaymentLinked).toBeUndefined();
+    expect(isQboPaymentLinkedRefusal(err)).toBe(false);
   });
 
   it('reads the live SyncToken FIRST when the mapping has none, instead of refusing the void', async () => {

--- a/apps/api/src/services/accounting/quickbooksProvider.ts
+++ b/apps/api/src/services/accounting/quickbooksProvider.ts
@@ -821,10 +821,19 @@ export class QuickbooksProvider implements AccountingProvider {
    * QuickBooks bumps an Invoice's revision every time a Payment is applied to
    * it, so voiding a PAID invoice from Breeze always failed with a 400 on the
    * stored token and left the invoice mapping in error after five job
-   * attempts. QuickBooks *does* permit voiding an invoice that has a payment
-   * applied — it just wants the live revision — so a 5010 is re-read and
-   * retried EXACTLY ONCE. A second stale fault escapes as the retryable error
-   * it is, rather than spinning against somebody editing the invoice in a loop.
+   * attempts. A 5010 is therefore re-read and retried EXACTLY ONCE. A second
+   * stale fault escapes as the retryable error it is, rather than spinning
+   * against somebody editing the invoice in a loop.
+   *
+   * A STALE TOKEN WAS NOT THE ONLY REASON A PAID INVOICE FAILED TO VOID
+   * (#5180). An earlier revision of this comment claimed QuickBooks "does
+   * permit voiding an invoice that has a payment applied — it just wants the
+   * live revision". Production disproved that on 2026-09-06: with a live
+   * revision QuickBooks still refused, because the invoice was settled by a
+   * QuickBooks Payment. That refusal is a business RULE, so it is classified
+   * terminal by the coordinator (`isQboPaymentLinkedRefusal`) rather than
+   * retried; this method deliberately does not translate it, so the fault
+   * fields reach `voidInvoiceInAccounting` intact.
    *
    * A NULL stored token is likewise not a refusal any more. An adopted or
    * re-owned invoice mapping can legitimately carry none, and throwing left an
@@ -1213,6 +1222,10 @@ export class QuickbooksProvider implements AccountingProvider {
         body: text.slice(0, 500),
         qboFaultCode: fault.code ?? undefined,
         qboFaultMessage: fault.message ?? undefined,
+        // Boolean only — derived from the FULL text for the same reason the
+        // code is, since Intuit states this reason in the `Detail` that
+        // truncation drops. The Detail text itself is never carried (#5180).
+        qboPaymentLinked: fault.paymentLinked === true ? true : undefined,
       });
       // Server log only — `body` can carry Intuit's `Detail`, which names the
       // offending customer/amount. It never reaches Sentry (scrubbed) or a

--- a/apps/api/src/services/invoiceService.test.ts
+++ b/apps/api/src/services/invoiceService.test.ts
@@ -2283,6 +2283,11 @@ describe('voidInvoice clears paid_at (#4542)', () => {
       currencyCode: 'USD', total: '100.00', amountPaid: '100.00', balance: '0.00', dueDate: null,
       voidedAt: null, paidAt: new Date('2026-09-01T00:00:00Z'), markedOverdueAt: null,
     }]); // invoice FOR UPDATE
+    // No invoice_payments rows: the operator removed the payment first, as the
+    // #5180 guard below now requires. `paid_at` survives that removal (the
+    // recompute never clears it — see its sibling test above), which is exactly
+    // why the void still has to null it.
+    queueResult([]); // invoice_payments sum (#5180)
     queueResult([]); // invoice_lines FOR UPDATE (no source-backed lines)
     queueResult([]); // the void update itself
     queueResult([{ id: 'i1', orgId: 'org1', partnerId: 'p1', status: 'void', currencyCode: 'USD' }]); // getInvoice re-read
@@ -2291,5 +2296,63 @@ describe('voidInvoice clears paid_at (#4542)', () => {
 
     const voidPatch = setCalls.calls.find((p) => p.status === 'void')!;
     expect(voidPatch).toMatchObject({ voidedAt: expect.any(Date), voidReason: 'duplicate', paidAt: null });
+  });
+});
+
+describe('voidInvoice refuses an invoice with applied payments (#5180)', () => {
+  beforeEach(() => { results.length = 0; setCalls.calls.length = 0; vi.clearAllMocks(); });
+
+  const actor = { userId: 'u1', partnerId: 'p1', accessibleOrgIds: ['org1'] };
+  const sentInvoice = (overrides: Record<string, unknown> = {}) => ({
+    id: 'i1', orgId: 'org1', partnerId: 'p1', siteId: null, status: 'sent', invoiceNumber: 'INV-0001',
+    currencyCode: 'USD', total: '100.00', amountPaid: '0.00', balance: '100.00', dueDate: null,
+    voidedAt: null, paidAt: null, markedOverdueAt: null, ...overrides,
+  });
+
+  it('throws 409 INVOICE_HAS_PAYMENTS and writes NOTHING when a payment is applied', async () => {
+    // The production failure (#5180): the local void succeeded, QuickBooks
+    // refused it five times, and the payment pull then flagged the mapping —
+    // Breeze said void, QuickBooks said paid. It is wrong locally too: the void
+    // releases the source rows for re-invoicing while collected money stays
+    // recorded against them.
+    queueResult([sentInvoice({ status: 'partially_paid', amountPaid: '40.00', balance: '60.00' })]); // invoice FOR UPDATE
+    queueResult([{ amount: '40.00' }]); // invoice_payments
+
+    await expect(svc.voidInvoice('i1', 'duplicate', {}, actor))
+      .rejects.toMatchObject({ status: 409, code: 'INVOICE_HAS_PAYMENTS' });
+
+    // No status flip, and — the dangerous half — no source-row release.
+    expect(setCalls.calls).toEqual([]);
+  });
+
+  it('names the amount, the currency and the remedy, so the operator knows the next step', async () => {
+    queueResult([sentInvoice({ status: 'paid', currencyCode: 'EUR', amountPaid: '100.00', balance: '0.00' })]);
+    queueResult([{ amount: '60.00' }, { amount: '40.00' }]); // two partial payments
+
+    await expect(svc.voidInvoice('i1', 'duplicate', {}, actor)).rejects.toThrow(
+      /100\.00 EUR of payments applied.*Remove those payments first.*QuickBooks/s,
+    );
+  });
+
+  it('still voids an unpaid invoice — the guard is on applied payments, not on status', async () => {
+    queueResult([sentInvoice()]); // invoice FOR UPDATE
+    queueResult([]); // invoice_payments: none
+    queueResult([]); // invoice_lines FOR UPDATE
+    queueResult([]); // the void update
+    queueResult([{ id: 'i1', orgId: 'org1', partnerId: 'p1', status: 'void', currencyCode: 'USD' }]); // getInvoice re-read
+
+    await svc.voidInvoice('i1', 'duplicate', {}, actor);
+
+    expect(setCalls.calls.find((p) => p.status === 'void')).toBeTruthy();
+  });
+
+  it('refuses a fully-refunded-looking row too: any non-zero applied total blocks it', async () => {
+    // Guards the boundary the reduce() makes easy to get wrong — a single cent
+    // applied is still money against the document.
+    queueResult([sentInvoice({ status: 'partially_paid' })]);
+    queueResult([{ amount: '0.01' }]);
+
+    await expect(svc.voidInvoice('i1', 'duplicate', {}, actor))
+      .rejects.toMatchObject({ code: 'INVOICE_HAS_PAYMENTS' });
   });
 });

--- a/apps/api/src/services/invoiceService.ts
+++ b/apps/api/src/services/invoiceService.ts
@@ -1906,6 +1906,41 @@ export async function voidInvoice(invoiceId: string, reason: string, opts: { rei
     requireInvoiceAccess(actor, inv);
     if (inv.status === 'draft') throw new InvoiceServiceError('Delete drafts instead of voiding', 409, 'INVALID_STATE');
     if (inv.status === 'void') throw new InvoiceServiceError('Already void', 409, 'INVALID_STATE');
+
+    // 1b. APPLIED PAYMENTS BLOCK THE VOID (#5180).
+    //
+    // Voiding a settled invoice used to succeed locally and then fail forever
+    // downstream: QuickBooks will not void an invoice a Payment settles, so the
+    // accounting job burned its whole five-attempt ladder on a deterministic
+    // refusal, and the next payment pull flagged the mapping in error because
+    // Breeze said void while QuickBooks said paid. It is wrong locally too — the
+    // void releases the source time entries and parts for re-invoicing while
+    // money that was collected against them stays recorded, so a reissue
+    // double-counts the revenue.
+    //
+    // REFUSE rather than auto-unapply (the spec's two options, #5180). Deleting
+    // a payment row is money movement: it needs its own audit event, its own
+    // permission and its own QuickBooks delete, all of which `voidPayment`
+    // already owns. Silently performing it inside a void would make an
+    // irreversible ledger change the operator never asked for; refusing costs
+    // them one extra explicit step and leaves the invoice exactly as it was.
+    // The billing spec is silent on this case (it says only "any issued status
+    // → void"), so this is the first decision on it rather than a reversal.
+    //
+    // Authoritative under the FOR UPDATE lock taken above: every payment writer
+    // locks the invoice row before inserting, so no payment can land between
+    // this sum and the status flip below.
+    const appliedRows = await db.select({ amount: invoicePayments.amount })
+      .from(invoicePayments).where(eq(invoicePayments.invoiceId, invoiceId));
+    const appliedCents = appliedRows.reduce((sum, r) => sum + toCents(r.amount), 0);
+    if (appliedCents > 0) {
+      throw new InvoiceServiceError(
+        `This invoice has ${fromCents(appliedCents)} ${inv.currencyCode} of payments applied to it. `
+        + 'Remove those payments first (and in QuickBooks, if it is synced there), then void the invoice',
+        409, 'INVOICE_HAS_PAYMENTS'
+      );
+    }
+
     voidedOrgId = inv.orgId;
     voidedPartnerId = inv.partnerId;
 

--- a/apps/api/src/services/invoiceTypes.ts
+++ b/apps/api/src/services/invoiceTypes.ts
@@ -31,6 +31,12 @@ export type InvoiceServiceErrorCode =
   | 'SITE_DENIED'
   | 'INVOICE_NOT_FOUND'
   | 'INVOICE_LINE_NOT_FOUND'
+  // #5180: voidInvoice refused because invoice_payments rows still settle the
+  // invoice. QuickBooks will not void an invoice a Payment settles, and the
+  // void also releases the source rows for re-invoicing while the collected
+  // money stays recorded — so the payments come off first, through the
+  // audited voidPayment path, and the void is retried after.
+  | 'INVOICE_HAS_PAYMENTS'
   | 'INVALID_CURSOR'
   | 'CURRENCY_MISMATCH'
   // Draft currency immutability (#3774): the change-currency op refused because


### PR DESCRIPTION
Closes #5180
Fixes BREEZE-2H
Fixes BREEZE-2J
Fixes BREEZE-2K

## The incident

Production, US, 2026-09-06 21:08Z. Invoice `8fa47bbf…` (QuickBooks Invoice 6167) was voided in Breeze. `voidInvoice` set `status='void'`, cleared `paid_at`, and enqueued the accounting void. `QuickbooksProvider.voidInvoice` was then refused five times — QuickBooks will not void an invoice a Payment settles — and the ladder gave up at 21:09:51Z. At 21:15:02Z the payment pull saw the QuickBooks payment against the now-void Breeze invoice and put the mapping in `error`.

End state: Breeze said void, QuickBooks said paid, the mapping was in error, and the operator got three redacted Sentry alerts with no actionable message.

## What changed

**1. `voidInvoice` refuses when payments are applied** (`invoiceService.ts`)

The sum of `invoice_payments` is read under the invoice's existing `FOR UPDATE` lock (every payment writer locks the invoice row first, so the sum is authoritative), and a non-zero total throws `409 INVOICE_HAS_PAYMENTS` naming the amount, the currency and the remedy. Nothing is written — in particular the source time entries and ticket parts are *not* released.

This is wrong locally, not just downstream: the void releases source rows back to `not_billed` for re-invoicing while money collected against them stays recorded, so a reissue double-counts the revenue.

**Refuse rather than auto-unapply** (the issue's two options). Deleting a payment row is money movement: it needs its own audit event, its own permission and its own QuickBooks delete, all of which `voidPayment` already owns. Performing it silently inside a void would make an irreversible ledger change the operator never asked for. Refusing costs one explicit extra step and leaves the invoice exactly as it was. The billing spec (`2026-06-14-invoice-engine-design.md`) is silent here — it says only "any issued status → void" — so this is the first decision on the case rather than a reversal of one.

**2. A payment-blocked QuickBooks void is non-retryable** (`accountingInvoicePush.ts`, `quickbooksFault.ts`, `accountingSyncWorker.ts`)

New code `void_blocked_by_payments` (409), added to the worker's `TERMINAL_CODES`. It replaces `quickbooks_error` (502) for this case — that code is paired with 502 and read by the worker as "safe to retry", which is what burned the five attempts on an answer that can never change.

Intuit states the reason in `Detail`, the one field that must never reach an operator-visible `last_error` or a Sentry tag — and the field that storage truncates away at 500 characters. So `parseQboFault` classifies it off the **full** body at parse time (exactly as it already does for `code`, and for the same documented reason) and carries a **boolean**, `paymentLinked`. The Detail text still never leaves that module.

The mapping's `last_error` now reads:

> QuickBooks will not void this invoice because a payment is applied to it there — remove or unapply that payment in QuickBooks, then void the invoice again (HTTP 400: Business Validation Error)

instead of the previous generic "QuickBooks rejected the invoice sync (HTTP 400: Business Validation Error)", five times.

The classifier is phrase-based rather than fault-code-based on purpose: the incident was reported through Sentry, whose scrubber redacts the message, so no verified Intuit fault **code** for this rejection exists to key on. Each pattern requires both a payment/linked-transaction noun and a refusal/attachment verb, so a generic `Business Validation Error`, a stale-object 5010, or a gateway failure cannot match — the classification only ever turns a retryable failure terminal, so a false positive would stop a retry that might have worked.

**3. Corrected a load-bearing doc comment** (`quickbooksProvider.ts`)

`voidInvoice`'s comment claimed QuickBooks "*does* permit voiding an invoice that has a payment applied — it just wants the live revision". Production disproved that: with a live revision it still refused. The stale-token re-read stays (it is a real and separate failure mode); the comment now says so.

## Tests

Red-first: all 23 new/changed assertions were confirmed failing against the unfixed sources before the fix was restored.

- `invoiceService.test.ts` — refusal writes nothing (no status flip, no source release); the message names amount/currency/remedy; an unpaid invoice still voids; a single cent still blocks.
- `quickbooksFault.test.ts` — three real refusal phrasings classify true, three unrelated faults classify false, `Detail` still never surfaces, and the attached-flag / stored-body / plain-failure paths of `isQboPaymentLinkedRefusal`.
- `accountingInvoicePush.test.ts` — the refusal becomes `void_blocked_by_payments` (409) with the remedy message on both the throw and the mapping's `last_error`.
- `accountingSyncWorker.test.ts` — terminal in the shared table, plus the void path the incident actually took: one call, no rethrow.

`apps/api` affected files green (928 tests across 24 files: invoiceService, all of `services/accounting/`, `routes/invoices/`, the sync worker, the AI billing tool). `tsc --noEmit` clean on `apps/api`. `eslint` clean on all ten changed files. No migration, no schema change, no tenancy surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GCYqYhwyLnFWG3CH5wKLU2