### PR TITLE
fix(mobile): new-ticket org selector row + assignee picker (#5188)

### DIFF
--- a/apps/mobile/src/screens/tickets/CreateTicketScreen.tsx
+++ b/apps/mobile/src/screens/tickets/CreateTicketScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
   Keyboard,
@@ -18,25 +18,28 @@ import { palette, radii, spacing, type } from '../../theme';
 import { useAppSelector } from '../../store';
 import { createTicket, type TicketPriority } from '../../services/tickets';
 import { listOrganizations } from '../../services/organizations';
+import { listAssignableUsers } from '../../services/users';
 import type { TicketsStackParamList } from '../../navigation/MainNavigator';
 import { Toast } from '../../components/Toast';
 import { reportInternalError } from '../../lib/errorReporting';
 
 import { priorityColor, priorityLabel } from './ticketCopy';
 import {
+  assigneeOptions,
   buildCreateTicketBody,
   canSubmitTicket,
+  defaultAssigneeId,
   DEFAULT_TICKET_PRIORITY,
   preselectOrg,
   SUBJECT_MAX_LENGTH,
   TICKET_PRIORITY_OPTIONS,
+  type AssigneeUser,
   type OrgOption,
 } from './createTicketForm';
+import { OrgPickerSheet } from './components/OrgPickerSheet';
+import { AssigneePickerSheet } from './components/AssigneePickerSheet';
 
 type Nav = NativeStackNavigationProp<TicketsStackParamList, 'CreateTicket'>;
-
-/** Above this many orgs the picker gets a search box (server-side search). */
-const SEARCH_THRESHOLD = 8;
 
 export function CreateTicketScreen() {
   const navigation = useNavigation<Nav>();
@@ -47,6 +50,12 @@ export function CreateTicketScreen() {
   const [orgSearch, setOrgSearch] = useState('');
   const [orgError, setOrgError] = useState<string | null>(null);
   const [orgId, setOrgId] = useState<string | null>(null);
+  const [orgSheetVisible, setOrgSheetVisible] = useState(false);
+
+  const [staff, setStaff] = useState<AssigneeUser[]>([]);
+  const [assigneeId, setAssigneeId] = useState<string | null>(() => defaultAssigneeId(user));
+  const [assigneeSheetVisible, setAssigneeSheetVisible] = useState(false);
+
   const [subject, setSubject] = useState('');
   const [description, setDescription] = useState('');
   const [priority, setPriority] = useState<TicketPriority>(DEFAULT_TICKET_PRIORITY);
@@ -76,8 +85,30 @@ export function CreateTicketScreen() {
     void loadOrgs('');
   }, [loadOrgs]);
 
+  // #5188: assignable staff for the picker. Degrades silently to
+  // Unassigned + "(you)" on failure (403 for a tech without `users:read`,
+  // network error, …) — `assigneeOptions` already handles an empty list, so
+  // there is no error state or toast here, only a Sentry breadcrumb.
+  useEffect(() => {
+    let cancelled = false;
+    listAssignableUsers()
+      .then((users) => {
+        if (!cancelled) setStaff(users);
+      })
+      .catch((err) => {
+        reportInternalError(err, 'CreateTicketScreen.loadAssignableUsers');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const me: AssigneeUser | null = user ? { id: user.id, name: user.name, email: user.email } : null;
+  const assigneeChoices = useMemo(() => assigneeOptions(staff, me), [staff, me]);
+  const assigneeLabel = assigneeChoices.find((o) => o.id === assigneeId)?.label ?? 'Unassigned';
+
   const submit = async () => {
-    const built = buildCreateTicketBody({ orgId, subject, description, priority });
+    const built = buildCreateTicketBody({ orgId, subject, description, priority, assigneeId });
     if (!built.ok) return;
     // #5171: without this, the spinner ran with the keyboard still up, and
     // `navigation.replace('TicketDetail', …)` below swapped in the next
@@ -99,7 +130,6 @@ export function CreateTicketScreen() {
   };
 
   const sendable = canSubmitTicket({ orgId, subject, busy });
-  const showSearch = orgTotal > SEARCH_THRESHOLD || orgSearch.length > 0;
   const selectedOrg = orgs?.find((o) => o.id === orgId) ?? null;
   // The user's own org is the only one an org-scoped technician can see, so
   // the picker is noise for them; show the name and move on.
@@ -135,51 +165,28 @@ export function CreateTicketScreen() {
           <Text style={styles.lockedOrg}>{orgs[0].name}</Text>
         ) : (
           <>
-            {showSearch ? (
-              <TextInput
-                style={styles.input}
-                placeholder="Search organizations"
-                placeholderTextColor={palette.dark.textLo}
-                value={orgSearch}
-                onChangeText={(text) => {
-                  setOrgSearch(text);
-                  void loadOrgs(text);
-                }}
-                autoCorrect={false}
-                autoCapitalize="none"
-                accessibilityLabel="Search organizations"
-              />
-            ) : null}
+            {/*
+              #5188: was every org rendered as a full-width row (15+ on a
+              5-org MSP plus test orgs), pushing Subject/Description off the
+              fold — now a single row that opens the search + list in a sheet.
+            */}
+            <Pressable
+              onPress={() => setOrgSheetVisible(true)}
+              accessibilityRole="button"
+              style={styles.selectorRow}
+            >
+              <Text
+                style={[styles.selectorText, !selectedOrg && styles.selectorPlaceholder]}
+                numberOfLines={1}
+              >
+                {selectedOrg ? selectedOrg.name : 'Choose organization'}
+              </Text>
+              <Text style={styles.chevron}>{'›'}</Text>
+            </Pressable>
             {orgError ? (
               <Pressable onPress={() => void loadOrgs(orgSearch)} accessibilityRole="button">
                 <Text style={styles.error}>{orgError}</Text>
               </Pressable>
-            ) : null}
-            {orgs.length === 0 && !orgError ? (
-              <Text style={styles.hint}>No organizations match.</Text>
-            ) : null}
-            <View style={styles.orgList}>
-              {orgs.map((org) => {
-                const active = org.id === orgId;
-                return (
-                  <Pressable
-                    key={org.id}
-                    onPress={() => setOrgId(org.id)}
-                    accessibilityRole="button"
-                    accessibilityState={{ selected: active }}
-                    style={[styles.orgRow, active && styles.orgRowActive]}
-                  >
-                    <Text style={[styles.orgName, active && styles.orgNameActive]} numberOfLines={1}>
-                      {org.name}
-                    </Text>
-                  </Pressable>
-                );
-              })}
-            </View>
-            {selectedOrg === null && orgSearch.length > 0 && orgId ? (
-              // The chosen org is filtered out of the current search results;
-              // say so rather than let the selection look lost.
-              <Text style={styles.hint}>Selected organization is not in these results.</Text>
             ) : null}
           </>
         )}
@@ -226,6 +233,18 @@ export function CreateTicketScreen() {
           })}
         </View>
 
+        <Text style={styles.label}>ASSIGNEE</Text>
+        <Pressable
+          onPress={() => setAssigneeSheetVisible(true)}
+          accessibilityRole="button"
+          style={styles.selectorRow}
+        >
+          <Text style={styles.selectorText} numberOfLines={1}>
+            {assigneeLabel}
+          </Text>
+          <Text style={styles.chevron}>{'›'}</Text>
+        </Pressable>
+
         <Pressable
           onPress={() => void submit()}
           disabled={!sendable}
@@ -245,6 +264,34 @@ export function CreateTicketScreen() {
         text={toast?.text ?? ''}
         kind={toast?.kind ?? 'error'}
         onHidden={() => setToast(null)}
+      />
+      <OrgPickerSheet
+        visible={orgSheetVisible}
+        orgs={orgs}
+        orgTotal={orgTotal}
+        orgSearch={orgSearch}
+        orgError={orgError}
+        selectedOrgId={orgId}
+        onSearchChange={(text) => {
+          setOrgSearch(text);
+          void loadOrgs(text);
+        }}
+        onRetry={() => void loadOrgs(orgSearch)}
+        onSelect={(id) => {
+          setOrgId(id);
+          setOrgSheetVisible(false);
+        }}
+        onCancel={() => setOrgSheetVisible(false)}
+      />
+      <AssigneePickerSheet
+        visible={assigneeSheetVisible}
+        options={assigneeChoices}
+        selectedId={assigneeId}
+        onSelect={(id) => {
+          setAssigneeId(id);
+          setAssigneeSheetVisible(false);
+        }}
+        onCancel={() => setAssigneeSheetVisible(false)}
       />
     </KeyboardAvoidingView>
   );
@@ -271,19 +318,21 @@ const styles = StyleSheet.create({
     marginTop: spacing['2'],
   },
   multiline: { minHeight: 112, textAlignVertical: 'top' },
-  orgList: { marginTop: spacing['2'], gap: spacing['1'] },
-  orgRow: {
+  selectorRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
     paddingHorizontal: spacing['3'],
     paddingVertical: spacing['3'],
     borderRadius: radii.md,
     borderWidth: 1,
     borderColor: palette.dark.border,
     backgroundColor: palette.dark.bg1,
+    marginTop: spacing['2'],
   },
-  orgRowActive: { borderColor: palette.brand.base, backgroundColor: palette.dark.bg2 },
-  orgName: { ...type.body, color: palette.dark.textMd },
-  orgNameActive: { color: palette.dark.textHi },
-  hint: { ...type.meta, color: palette.dark.textLo, marginTop: spacing['2'] },
+  selectorText: { ...type.body, color: palette.dark.textHi, flex: 1, marginRight: spacing['2'] },
+  selectorPlaceholder: { color: palette.dark.textLo },
+  chevron: { ...type.body, color: palette.dark.textLo },
   error: { ...type.meta, color: palette.deny.base, marginTop: spacing['2'] },
   priorityRow: { flexDirection: 'row', flexWrap: 'wrap', gap: spacing['2'], marginTop: spacing['2'] },
   chip: {

--- a/apps/mobile/src/screens/tickets/CreateTicketScreen.tsx
+++ b/apps/mobile/src/screens/tickets/CreateTicketScreen.tsx
@@ -30,6 +30,7 @@ import {
   canSubmitTicket,
   defaultAssigneeId,
   DEFAULT_TICKET_PRIORITY,
+  isExpectedAssigneeLoadFailure,
   preselectOrg,
   SUBJECT_MAX_LENGTH,
   TICKET_PRIORITY_OPTIONS,
@@ -86,9 +87,10 @@ export function CreateTicketScreen() {
   }, [loadOrgs]);
 
   // #5188: assignable staff for the picker. Degrades silently to
-  // Unassigned + "(you)" on failure (403 for a tech without `users:read`,
-  // network error, …) — `assigneeOptions` already handles an empty list, so
-  // there is no error state or toast here, only a Sentry breadcrumb.
+  // Unassigned + "(you)" on failure — `assigneeOptions` already handles an
+  // empty list, so there is no error state or toast here. A 403 (tech without
+  // `users:read`) is the permission model working and is not reported at all;
+  // anything else goes to Sentry via reportInternalError.
   useEffect(() => {
     let cancelled = false;
     listAssignableUsers()
@@ -96,6 +98,7 @@ export function CreateTicketScreen() {
         if (!cancelled) setStaff(users);
       })
       .catch((err) => {
+        if (isExpectedAssigneeLoadFailure(err)) return;
         reportInternalError(err, 'CreateTicketScreen.loadAssignableUsers');
       });
     return () => {

--- a/apps/mobile/src/screens/tickets/components/AssigneePickerSheet.tsx
+++ b/apps/mobile/src/screens/tickets/components/AssigneePickerSheet.tsx
@@ -1,0 +1,85 @@
+import { FlatList, Modal, Pressable, Text, View } from 'react-native';
+
+import { useApprovalTheme, radii, spacing, type } from '../../../theme';
+import type { AssigneeOption } from '../createTicketForm';
+
+interface Props {
+  visible: boolean;
+  options: readonly AssigneeOption[];
+  selectedId: string | null;
+  onSelect: (id: string | null) => void;
+  onCancel: () => void;
+}
+
+/**
+ * #5188: who the ticket is assigned to, defaulting to the signed-in tech.
+ * `options` already encodes the degrade — when `GET /users` fails or the
+ * tech lacks `users:read`, `createTicketForm.assigneeOptions` still returns
+ * "Unassigned" + "(you)", so this component never needs its own error state.
+ */
+export function AssigneePickerSheet({ visible, options, selectedId, onSelect, onCancel }: Props) {
+  const theme = useApprovalTheme('dark');
+
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onCancel}>
+      <Pressable
+        style={{ flex: 1, backgroundColor: 'rgba(0,0,0,0.55)', justifyContent: 'flex-end' }}
+        onPress={onCancel}
+      >
+        <Pressable
+          onPress={(e) => e.stopPropagation()}
+          style={{
+            backgroundColor: theme.bg1,
+            borderTopLeftRadius: radii.xl,
+            borderTopRightRadius: radii.xl,
+            paddingTop: spacing[5],
+            paddingBottom: spacing[10],
+            maxHeight: '70%',
+          }}
+        >
+          <View
+            style={{
+              alignSelf: 'center',
+              width: 36,
+              height: 4,
+              borderRadius: 2,
+              backgroundColor: theme.bg3,
+              marginBottom: spacing[4],
+            }}
+          />
+          <Text style={[type.title, { color: theme.textHi, paddingHorizontal: spacing[6] }]}>
+            Assignee
+          </Text>
+
+          <FlatList
+            data={options}
+            keyExtractor={(o) => o.id ?? 'unassigned'}
+            style={{ marginTop: spacing[3] }}
+            renderItem={({ item }) => {
+              const active = item.id === selectedId;
+              return (
+                <Pressable
+                  onPress={() => onSelect(item.id)}
+                  accessibilityRole="button"
+                  accessibilityState={{ selected: active }}
+                  style={({ pressed }) => ({
+                    paddingHorizontal: spacing[6],
+                    paddingVertical: spacing[3],
+                    backgroundColor: pressed || active ? theme.bg2 : 'transparent',
+                  })}
+                >
+                  <Text
+                    style={[type.bodyMd, { color: active ? theme.textHi : theme.textMd }]}
+                    numberOfLines={1}
+                  >
+                    {item.label}
+                  </Text>
+                </Pressable>
+              );
+            }}
+          />
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}

--- a/apps/mobile/src/screens/tickets/components/OrgPickerSheet.tsx
+++ b/apps/mobile/src/screens/tickets/components/OrgPickerSheet.tsx
@@ -1,0 +1,151 @@
+import { ActivityIndicator, FlatList, Modal, Pressable, Text, TextInput, View } from 'react-native';
+
+import { useApprovalTheme, radii, spacing, type } from '../../../theme';
+import type { OrgOption } from '../createTicketForm';
+
+/** Above this many orgs the picker gets a search box (server-side search). */
+const SEARCH_THRESHOLD = 8;
+
+interface Props {
+  visible: boolean;
+  orgs: OrgOption[] | null;
+  orgTotal: number;
+  orgSearch: string;
+  orgError: string | null;
+  selectedOrgId: string | null;
+  onSearchChange: (text: string) => void;
+  onRetry: () => void;
+  onSelect: (orgId: string) => void;
+  onCancel: () => void;
+}
+
+/**
+ * #5188: the organization list used to render inline on `CreateTicketScreen`
+ * (every org as a full-width row), pushing Subject/Description off the fold
+ * on any MSP with more than a handful of orgs. It now lives behind a
+ * selector row + this bottom sheet — same `Modal` pattern as `SearchSheet` /
+ * `SessionsSheet`, same search-and-list contents as before.
+ */
+export function OrgPickerSheet({
+  visible,
+  orgs,
+  orgTotal,
+  orgSearch,
+  orgError,
+  selectedOrgId,
+  onSearchChange,
+  onRetry,
+  onSelect,
+  onCancel,
+}: Props) {
+  const theme = useApprovalTheme('dark');
+  const showSearch = orgTotal > SEARCH_THRESHOLD || orgSearch.length > 0;
+
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onCancel}>
+      <Pressable
+        style={{ flex: 1, backgroundColor: 'rgba(0,0,0,0.55)', justifyContent: 'flex-end' }}
+        onPress={onCancel}
+      >
+        <Pressable
+          onPress={(e) => e.stopPropagation()}
+          style={{
+            backgroundColor: theme.bg1,
+            borderTopLeftRadius: radii.xl,
+            borderTopRightRadius: radii.xl,
+            paddingTop: spacing[5],
+            paddingBottom: spacing[10],
+            maxHeight: '80%',
+          }}
+        >
+          <View
+            style={{
+              alignSelf: 'center',
+              width: 36,
+              height: 4,
+              borderRadius: 2,
+              backgroundColor: theme.bg3,
+              marginBottom: spacing[4],
+            }}
+          />
+          <Text style={[type.title, { color: theme.textHi, paddingHorizontal: spacing[6] }]}>
+            Organization
+          </Text>
+
+          {showSearch ? (
+            <View style={{ paddingHorizontal: spacing[6], marginTop: spacing[4] }}>
+              <TextInput
+                style={[
+                  type.body,
+                  {
+                    color: theme.textHi,
+                    backgroundColor: theme.bg2,
+                    borderRadius: radii.md,
+                    paddingHorizontal: spacing[3],
+                    paddingVertical: spacing[3],
+                  },
+                ]}
+                placeholder="Search organizations"
+                placeholderTextColor={theme.textLo}
+                value={orgSearch}
+                onChangeText={onSearchChange}
+                autoCorrect={false}
+                autoCapitalize="none"
+                accessibilityLabel="Search organizations"
+              />
+            </View>
+          ) : null}
+
+          {orgError ? (
+            <Pressable
+              onPress={onRetry}
+              accessibilityRole="button"
+              style={{ paddingHorizontal: spacing[6], paddingTop: spacing[4] }}
+            >
+              <Text style={[type.meta, { color: theme.deny }]}>{orgError}</Text>
+            </Pressable>
+          ) : null}
+
+          {orgs === null ? (
+            <View style={{ paddingVertical: spacing[8], alignItems: 'center' }}>
+              <ActivityIndicator color={theme.brand} />
+            </View>
+          ) : orgs.length === 0 && !orgError ? (
+            <View style={{ paddingHorizontal: spacing[6], paddingTop: spacing[4] }}>
+              <Text style={[type.meta, { color: theme.textLo }]}>No organizations match.</Text>
+            </View>
+          ) : (
+            <FlatList
+              data={orgs}
+              keyExtractor={(o) => o.id}
+              keyboardShouldPersistTaps="handled"
+              style={{ marginTop: spacing[3] }}
+              renderItem={({ item }) => {
+                const active = item.id === selectedOrgId;
+                return (
+                  <Pressable
+                    onPress={() => onSelect(item.id)}
+                    accessibilityRole="button"
+                    accessibilityState={{ selected: active }}
+                    style={({ pressed }) => ({
+                      paddingHorizontal: spacing[6],
+                      paddingVertical: spacing[3],
+                      backgroundColor: pressed || active ? theme.bg2 : 'transparent',
+                    })}
+                  >
+                    <Text
+                      style={[type.bodyMd, { color: active ? theme.textHi : theme.textMd }]}
+                      numberOfLines={1}
+                    >
+                      {item.name}
+                    </Text>
+                  </Pressable>
+                );
+              }}
+            />
+          )}
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}

--- a/apps/mobile/src/screens/tickets/createTicketForm.test.ts
+++ b/apps/mobile/src/screens/tickets/createTicketForm.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import {
+  assigneeDisplayName,
+  assigneeOptions,
   buildCreateTicketBody,
   canSubmitTicket,
+  defaultAssigneeId,
   DEFAULT_TICKET_PRIORITY,
   preselectOrg,
   TICKET_PRIORITY_OPTIONS,
@@ -12,6 +15,31 @@ describe('buildCreateTicketBody', () => {
     expect(
       buildCreateTicketBody({ orgId: 'o1', subject: '  Printer offline ', description: '   ', priority: 'high' })
     ).toEqual({ ok: true, body: { orgId: 'o1', subject: 'Printer offline', priority: 'high' } });
+  });
+
+  it('includes assigneeId when set', () => {
+    const r = buildCreateTicketBody({
+      orgId: 'o1',
+      subject: 'x',
+      description: '',
+      priority: 'normal',
+      assigneeId: 'u1',
+    });
+    expect(r).toEqual({ ok: true, body: { orgId: 'o1', subject: 'x', priority: 'normal', assigneeId: 'u1' } });
+  });
+
+  it('omits assigneeId when null or absent (Unassigned)', () => {
+    const withNull = buildCreateTicketBody({
+      orgId: 'o1',
+      subject: 'x',
+      description: '',
+      priority: 'normal',
+      assigneeId: null,
+    });
+    expect(withNull).toEqual({ ok: true, body: { orgId: 'o1', subject: 'x', priority: 'normal' } });
+
+    const withoutField = buildCreateTicketBody({ orgId: 'o1', subject: 'x', description: '', priority: 'normal' });
+    expect(withoutField).toEqual({ ok: true, body: { orgId: 'o1', subject: 'x', priority: 'normal' } });
   });
 
   it('keeps a trimmed description when present', () => {
@@ -73,5 +101,65 @@ describe('priority options', () => {
   it('offers every API priority in escalation order and defaults to normal', () => {
     expect(TICKET_PRIORITY_OPTIONS).toEqual(['low', 'normal', 'high', 'urgent']);
     expect(DEFAULT_TICKET_PRIORITY).toBe('normal');
+  });
+});
+
+describe('assigneeDisplayName', () => {
+  it('uses the name when present', () => {
+    expect(assigneeDisplayName({ name: 'Casey Tech', email: 'casey@example.com' })).toBe('Casey Tech');
+  });
+
+  it('falls back to email when name is blank or missing', () => {
+    expect(assigneeDisplayName({ name: '  ', email: 'casey@example.com' })).toBe('casey@example.com');
+    expect(assigneeDisplayName({ name: null, email: 'casey@example.com' })).toBe('casey@example.com');
+  });
+});
+
+describe('defaultAssigneeId', () => {
+  it('defaults to the signed-in user', () => {
+    expect(defaultAssigneeId({ id: 'me-1' })).toBe('me-1');
+  });
+
+  it('is null when signed out', () => {
+    expect(defaultAssigneeId(null)).toBeNull();
+    expect(defaultAssigneeId(undefined)).toBeNull();
+  });
+});
+
+describe('assigneeOptions', () => {
+  const me = { id: 'me-1', name: 'Casey Tech', email: 'casey@example.com' };
+  const staff = [
+    { id: 'u2', name: 'Bailey Ops', email: 'bailey@example.com' },
+    { id: 'u3', name: null, email: 'alex@example.com' },
+  ];
+
+  it('leads with Unassigned, then the signed-in user labeled "(you)", then staff sorted by display name', () => {
+    expect(assigneeOptions(staff, me)).toEqual([
+      { id: null, label: 'Unassigned' },
+      { id: 'me-1', label: 'Casey Tech (you)' },
+      { id: 'u3', label: 'alex@example.com' },
+      { id: 'u2', label: 'Bailey Ops' },
+    ]);
+  });
+
+  it('dedupes the signed-in user out of the fetched staff list', () => {
+    const withMeDuplicated = [...staff, { id: 'me-1', name: 'Casey Tech', email: 'casey@example.com' }];
+    const options = assigneeOptions(withMeDuplicated, me);
+    expect(options.filter((o) => o.id === 'me-1')).toHaveLength(1);
+  });
+
+  it('degrades to Unassigned + you when the staff fetch failed (empty list)', () => {
+    expect(assigneeOptions([], me)).toEqual([
+      { id: null, label: 'Unassigned' },
+      { id: 'me-1', label: 'Casey Tech (you)' },
+    ]);
+  });
+
+  it('offers only Unassigned when signed out', () => {
+    expect(assigneeOptions(staff, null)).toEqual([
+      { id: null, label: 'Unassigned' },
+      { id: 'u3', label: 'alex@example.com' },
+      { id: 'u2', label: 'Bailey Ops' },
+    ]);
   });
 });

--- a/apps/mobile/src/screens/tickets/createTicketForm.test.ts
+++ b/apps/mobile/src/screens/tickets/createTicketForm.test.ts
@@ -6,6 +6,7 @@ import {
   canSubmitTicket,
   defaultAssigneeId,
   DEFAULT_TICKET_PRIORITY,
+  isExpectedAssigneeLoadFailure,
   preselectOrg,
   TICKET_PRIORITY_OPTIONS,
 } from './createTicketForm';
@@ -101,6 +102,20 @@ describe('priority options', () => {
   it('offers every API priority in escalation order and defaults to normal', () => {
     expect(TICKET_PRIORITY_OPTIONS).toEqual(['low', 'normal', 'high', 'urgent']);
     expect(DEFAULT_TICKET_PRIORITY).toBe('normal');
+  });
+});
+
+describe('isExpectedAssigneeLoadFailure', () => {
+  it('treats a 403 from GET /users as the expected no-users:read case (not reported)', () => {
+    expect(isExpectedAssigneeLoadFailure({ statusCode: 403, message: 'Forbidden' })).toBe(true);
+  });
+  it('reports everything else — server errors, network failures, garbage', () => {
+    expect(isExpectedAssigneeLoadFailure({ statusCode: 500, message: 'boom' })).toBe(false);
+    expect(isExpectedAssigneeLoadFailure({ statusCode: 404, message: 'gone' })).toBe(false);
+    expect(isExpectedAssigneeLoadFailure(new TypeError('Network request failed'))).toBe(false);
+    expect(isExpectedAssigneeLoadFailure(null)).toBe(false);
+    expect(isExpectedAssigneeLoadFailure(undefined)).toBe(false);
+    expect(isExpectedAssigneeLoadFailure('403')).toBe(false);
   });
 });
 

--- a/apps/mobile/src/screens/tickets/createTicketForm.test.ts
+++ b/apps/mobile/src/screens/tickets/createTicketForm.test.ts
@@ -148,6 +148,26 @@ describe('assigneeOptions', () => {
     expect(options.filter((o) => o.id === 'me-1')).toHaveLength(1);
   });
 
+  it('dedupes a repeated id WITHIN the fetched staff list itself (e.g. paginated overlap)', () => {
+    const withInternalDuplicate = [...staff, { id: 'u2', name: 'Bailey Ops', email: 'bailey@example.com' }];
+    const options = assigneeOptions(withInternalDuplicate, me);
+    expect(options.filter((o) => o.id === 'u2')).toHaveLength(1);
+  });
+
+  it('drops a staff row with an empty id', () => {
+    const withBlankId = [...staff, { id: '', name: 'Ghost Row', email: 'ghost@example.com' }];
+    const options = assigneeOptions(withBlankId, me);
+    expect(options.some((o) => o.label === 'Ghost Row')).toBe(false);
+  });
+
+  it('labels the signed-in user by email, not "(you)" alone, when their name is blank', () => {
+    const meWithNoName = { id: 'me-1', name: '', email: 'casey@example.com' };
+    expect(assigneeOptions([], meWithNoName)).toEqual([
+      { id: null, label: 'Unassigned' },
+      { id: 'me-1', label: 'casey@example.com (you)' },
+    ]);
+  });
+
   it('degrades to Unassigned + you when the staff fetch failed (empty list)', () => {
     expect(assigneeOptions([], me)).toEqual([
       { id: null, label: 'Unassigned' },
@@ -155,7 +175,7 @@ describe('assigneeOptions', () => {
     ]);
   });
 
-  it('offers only Unassigned when signed out', () => {
+  it('omits the "(you)" row when signed out, but still lists fetched staff', () => {
     expect(assigneeOptions(staff, null)).toEqual([
       { id: null, label: 'Unassigned' },
       { id: 'u3', label: 'alex@example.com' },

--- a/apps/mobile/src/screens/tickets/createTicketForm.ts
+++ b/apps/mobile/src/screens/tickets/createTicketForm.ts
@@ -24,6 +24,7 @@ export interface CreateTicketBody {
   subject: string;
   description?: string;
   priority: TicketPriority;
+  assigneeId?: string;
 }
 
 export type BuildResult =
@@ -34,12 +35,15 @@ export type BuildResult =
  * The exact JSON the screen POSTs to `/tickets`, or the first reason it must
  * not. Priority is always sent: the server falls back to 'normal' when absent,
  * but the chip row shows a selection, so what is on screen is what is sent.
+ * `assigneeId` is omitted (not sent as null) for "Unassigned" — the server
+ * only ever sees the field when a real user id was picked.
  */
 export function buildCreateTicketBody(input: {
   orgId: string | null;
   subject: string;
   description: string;
   priority: TicketPriority;
+  assigneeId?: string | null;
 }): BuildResult {
   if (!input.orgId) return { ok: false, reason: 'org' };
   const subject = input.subject.trim();
@@ -47,6 +51,7 @@ export function buildCreateTicketBody(input: {
   const description = input.description.trim();
   const body: CreateTicketBody = { orgId: input.orgId, subject, priority: input.priority };
   if (description) body.description = description;
+  if (input.assigneeId) body.assigneeId = input.assigneeId;
   return { ok: true, body };
 }
 
@@ -66,4 +71,54 @@ export function preselectOrg(orgs: readonly OrgOption[], userOrgId: string | und
   if (userOrgId && orgs.some((o) => o.id === userOrgId)) return userOrgId;
   if (orgs.length === 1) return orgs[0].id;
   return null;
+}
+
+/** A row from `GET /users`, trimmed to what the assignee picker needs. */
+export interface AssigneeUser {
+  id: string;
+  name: string | null;
+  email: string;
+}
+
+export interface AssigneeOption {
+  /** `null` is the "Unassigned" row — sent as an omitted field, not literal null. */
+  id: string | null;
+  label: string;
+}
+
+/** Display name for a user row: the name, or the email when it is blank. */
+export function assigneeDisplayName(user: { name: string | null | undefined; email: string }): string {
+  const name = user.name?.trim();
+  return name ? name : user.email;
+}
+
+/** #5188: the signed-in tech is the default assignee on a new ticket. */
+export function defaultAssigneeId(me: { id: string } | null | undefined): string | null {
+  return me?.id ?? null;
+}
+
+/**
+ * Assignee sheet contents: "Unassigned" first, the signed-in tech pinned
+ * second labeled "(you)", then the rest of `staff` sorted by display name.
+ * `staff` may be empty — the `GET /users` fetch failed (403 for a tech without
+ * `users:read`, network error, …) — in which case the sheet still offers
+ * Unassigned + you rather than erroring.
+ */
+export function assigneeOptions(
+  staff: readonly AssigneeUser[],
+  me: AssigneeUser | null | undefined
+): AssigneeOption[] {
+  const options: AssigneeOption[] = [{ id: null, label: 'Unassigned' }];
+  if (me) options.push({ id: me.id, label: `${assigneeDisplayName(me)} (you)` });
+
+  const seen = new Set<string>(me ? [me.id] : []);
+  const rest: AssigneeOption[] = [];
+  for (const user of staff) {
+    if (!user.id || seen.has(user.id)) continue;
+    seen.add(user.id);
+    rest.push({ id: user.id, label: assigneeDisplayName(user) });
+  }
+  rest.sort((a, b) => a.label.localeCompare(b.label));
+
+  return [...options, ...rest];
 }

--- a/apps/mobile/src/screens/tickets/createTicketForm.ts
+++ b/apps/mobile/src/screens/tickets/createTicketForm.ts
@@ -98,6 +98,19 @@ export function defaultAssigneeId(me: { id: string } | null | undefined): string
 }
 
 /**
+ * Whether a failed `GET /users` is the EXPECTED case for this screen — a tech
+ * whose role lacks `users:read` gets a 403 every time they open New ticket.
+ * That is a permission model working as designed, not a defect, so it must
+ * not become a Sentry event per screen open (same precedent as
+ * `DEVICE_BLOCKED_CODE` in `lib/errorReporting.ts`). Anything else — 5xx,
+ * network failure, a non-ApiError throw — is still worth reporting.
+ */
+export function isExpectedAssigneeLoadFailure(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  return (err as { statusCode?: unknown }).statusCode === 403;
+}
+
+/**
  * Assignee sheet contents: "Unassigned" first, the signed-in tech pinned
  * second labeled "(you)", then the rest of `staff` sorted by display name.
  * `staff` may be empty — the `GET /users` fetch failed (403 for a tech without

--- a/apps/mobile/src/services/tickets.ts
+++ b/apps/mobile/src/services/tickets.ts
@@ -144,6 +144,8 @@ export interface CreateTicketInput {
   subject: string;
   description?: string;
   priority: TicketPriority;
+  /** Omitted (not `null`) for Unassigned — see `buildCreateTicketBody`. */
+  assigneeId?: string;
 }
 
 /**

--- a/apps/mobile/src/services/users.test.ts
+++ b/apps/mobile/src/services/users.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const coreRequest = vi.fn();
+// `../lib/errorReporting` imports DEVICE_BLOCKED_CODE from this module too —
+// it must be present on the mock even though listAssignableUsers itself never
+// uses it.
+vi.mock('./api', () => ({
+  coreRequest: (...args: unknown[]) => coreRequest(...args),
+  DEVICE_BLOCKED_CODE: 'DEVICE_BLOCKED',
+}));
+
+// Indirected through an object (not a bare top-level `vi.fn()`) to satisfy
+// vitest's mock-factory hoisting rule — same pattern as csrfToken.test.ts.
+const sentry = { captureException: vi.fn(), captureMessage: vi.fn() };
+vi.mock('@sentry/react-native', () => ({
+  captureException: (...a: unknown[]) => sentry.captureException(...a),
+  captureMessage: (...a: unknown[]) => sentry.captureMessage(...a),
+}));
+
+import { listAssignableUsers } from './users';
+
+beforeEach(() => {
+  coreRequest.mockReset();
+  sentry.captureException.mockReset();
+});
+
+describe('listAssignableUsers', () => {
+  it('narrows a bare array body to id/name/email', async () => {
+    coreRequest.mockResolvedValue([
+      { id: 'u1', name: 'Casey Tech', email: 'casey@example.com', role: 'tech' },
+      { id: 'u2', name: null, email: 'alex@example.com' },
+    ]);
+    const r = await listAssignableUsers();
+    expect(coreRequest).toHaveBeenCalledWith('/users');
+    expect(r).toEqual([
+      { id: 'u1', name: 'Casey Tech', email: 'casey@example.com' },
+      { id: 'u2', name: null, email: 'alex@example.com' },
+    ]);
+    expect(sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it('narrows a { data: [...] } body the same way', async () => {
+    coreRequest.mockResolvedValue({ data: [{ id: 'u1', name: 'Casey Tech', email: 'casey@example.com' }] });
+    const r = await listAssignableUsers();
+    expect(r).toEqual([{ id: 'u1', name: 'Casey Tech', email: 'casey@example.com' }]);
+  });
+
+  it('drops rows without an id', async () => {
+    coreRequest.mockResolvedValue([{ name: 'No Id', email: 'x@example.com' }, { id: 'u2', name: 'Has Id', email: 'y@example.com' }]);
+    const r = await listAssignableUsers();
+    expect(r).toEqual([{ id: 'u2', name: 'Has Id', email: 'y@example.com' }]);
+  });
+
+  it('degrades to an empty list without reporting when the fetch rejects (403/network)', async () => {
+    coreRequest.mockRejectedValue(new Error('403 Forbidden'));
+    await expect(listAssignableUsers()).rejects.toThrow('403 Forbidden');
+    // The reject is left to the caller (CreateTicketScreen) to catch and
+    // report with its own area tag — this function only reports a 200 that
+    // fails to parse, not a rejected request.
+    expect(sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it('reports and degrades to an empty list on an unexpected 200 body shape', async () => {
+    coreRequest.mockResolvedValue({ users: [{ id: 'u1' }] }); // wrong envelope key
+    const r = await listAssignableUsers();
+    expect(r).toEqual([]);
+    expect(sentry.captureException).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports and degrades to an empty list on a null body', async () => {
+    coreRequest.mockResolvedValue(null);
+    const r = await listAssignableUsers();
+    expect(r).toEqual([]);
+    expect(sentry.captureException).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/mobile/src/services/users.ts
+++ b/apps/mobile/src/services/users.ts
@@ -1,5 +1,18 @@
 import { coreRequest } from './api';
-import type { AssigneeUser } from '../screens/tickets/createTicketForm';
+import { reportInternalError } from '../lib/errorReporting';
+
+/**
+ * A `GET /users` row, trimmed to what the assignee picker needs. Kept local
+ * to this service rather than imported from `screens/tickets/createTicketForm`
+ * — services here (see `organizations.ts`'s `OrganizationSummary` vs.
+ * `createTicketForm.ts`'s `OrgOption`) define their own row shape and stay
+ * screen-agnostic; the two line up structurally.
+ */
+export interface AssignableUserRow {
+  id: string;
+  name: string | null;
+  email: string;
+}
 
 /**
  * Staff assignable to a ticket. Mirrors the fetch in web's
@@ -10,14 +23,23 @@ import type { AssigneeUser } from '../screens/tickets/createTicketForm';
  * Callers must degrade gracefully on failure (403 for a tech without
  * `users:read`, network error, older server) rather than surface an error —
  * see `assigneeOptions` in `createTicketForm.ts`, which already produces a
- * usable "Unassigned" + "(you)" picker from an empty list.
+ * usable "Unassigned" + "(you)" picker from an empty list. A 200 response
+ * that fails to parse into a usable array (unexpected shape) looks the same
+ * to the caller, but IS reported here — unlike an auth/network failure, that
+ * case is a real contract break and should not vanish without a trace.
  */
-export async function listAssignableUsers(): Promise<AssigneeUser[]> {
+export async function listAssignableUsers(): Promise<AssignableUserRow[]> {
   const response = await coreRequest<unknown>('/users');
   const rows = Array.isArray(response)
     ? response
     : (response as { data?: unknown } | null)?.data;
-  if (!Array.isArray(rows)) return [];
+  if (!Array.isArray(rows)) {
+    reportInternalError(
+      new Error(`listAssignableUsers: unexpected /users response shape (${typeof response})`),
+      'listAssignableUsers.parse'
+    );
+    return [];
+  }
   return (rows as Array<{ id?: string; name?: string | null; email?: string }>)
     .filter((u): u is { id: string; name?: string | null; email?: string } => Boolean(u && u.id))
     .map((u) => ({ id: u.id, name: u.name ?? null, email: u.email ?? '' }));

--- a/apps/mobile/src/services/users.ts
+++ b/apps/mobile/src/services/users.ts
@@ -1,0 +1,24 @@
+import { coreRequest } from './api';
+import type { AssigneeUser } from '../screens/tickets/createTicketForm';
+
+/**
+ * Staff assignable to a ticket. Mirrors the fetch in web's
+ * `TicketWorkbench.tsx` (~line 436): the response body may be a bare array or
+ * `{ data: [...] }` depending on route version, and rows without an `id` are
+ * dropped defensively.
+ *
+ * Callers must degrade gracefully on failure (403 for a tech without
+ * `users:read`, network error, older server) rather than surface an error —
+ * see `assigneeOptions` in `createTicketForm.ts`, which already produces a
+ * usable "Unassigned" + "(you)" picker from an empty list.
+ */
+export async function listAssignableUsers(): Promise<AssigneeUser[]> {
+  const response = await coreRequest<unknown>('/users');
+  const rows = Array.isArray(response)
+    ? response
+    : (response as { data?: unknown } | null)?.data;
+  if (!Array.isArray(rows)) return [];
+  return (rows as Array<{ id?: string; name?: string | null; email?: string }>)
+    .filter((u): u is { id: string; name?: string | null; email?: string } => Boolean(u && u.id))
+    .map((u) => ({ id: u.id, name: u.name ?? null, email: u.email ?? '' }));
+}


### PR DESCRIPTION
## Summary

`CreateTicketScreen` (mobile) rendered every organization as a full-width row under ORGANIZATION — 15+ rows on a 5-org MSP plus test orgs — pushing Subject/Description off the fold. There was also no way to assign a tech at creation time; every new ticket landed Unassigned.

## Layout (top → bottom)

```
ORGANIZATION            [Acme Corp                    ›]
SUBJECT                 [What is wrong?              ]
DESCRIPTION             [Optional details...          ]
PRIORITY                (Low) (Normal) (High) (Urgent)
ASSIGNEE                [Casey Tech (you)             ›]
                         [       Create ticket        ]
```

Subject is now visible above the fold on an iPhone-15-class screen without scrolling.

## Changes

- **Organization row**: collapsed the inline org list into a single selector row (selected org name, or "Choose organization" placeholder) with a chevron. Tapping opens `OrgPickerSheet` — a `Modal` bottom sheet (same pattern as `SearchSheet.tsx` / `SessionsSheet.tsx`, no new dependency) containing the existing "Search organizations" input and list. The single-org `lockedOrg` case (org-scoped techs) is unchanged — a non-interactive row, no chevron, no sheet. `orgError` + retry copy unchanged.
- **Assignee row** (new, between Priority and Create): defaults to the signed-in tech, rendered `"<name> (you)"` (falls back to email when name is blank). Tapping opens `AssigneePickerSheet`, listing Unassigned first, the signed-in user pinned second, then `GET /users` staff sorted by name — same source and same graceful degrade as web's `TicketWorkbench.tsx` (~line 436): on 403/network failure the sheet still offers Unassigned + "(you)", no error toast, just a Sentry report via the existing `reportInternalError` helper.
- `buildCreateTicketBody` / `CreateTicketInput` gain an optional `assigneeId`, sent only when a real user id is picked (omitted, not `null`, for Unassigned). `createTicketSchema` in `@breeze/shared` already accepts `assigneeId` — no schema change.
- New `apps/mobile/src/services/users.ts` (`listAssignableUsers`) for `GET /users`, tolerant of an array or `{ data: [...] }` response body.
- Pure logic (`createTicketForm.ts`): `defaultAssigneeId`, `assigneeDisplayName`, `assigneeOptions` (ordering/dedupe/"(you)" rule) — red-first vitest coverage, no RN test renderer needed.

## Test plan

- [x] `cd apps/mobile && npx vitest run src/screens/tickets src/services` — 48 files, 678 passed, 3 skipped
- [x] `cd apps/mobile && npx tsc --noEmit` — clean
- [ ] Manual verify on device/simulator (no screenshots possible from this environment)

Closes #5188

🤖 Generated with [Claude Code](https://claude.com/claude-code)