### PR TITLE
ci: merge-queue janitor cancels superseded merge_group runs

### DIFF
--- a/.github/workflows/merge-queue-janitor.yml
+++ b/.github/workflows/merge-queue-janitor.yml
@@ -1,0 +1,47 @@
+name: Merge Queue Janitor
+
+# When the merge queue rebuilds (a bypass push to main, a dequeued entry ahead),
+# GitHub deletes the temporary `gh-readonly-queue/main/pr-N-<sha>` ref but does
+# NOT cancel the workflow runs that were started for it. Observed 2026-09-07:
+# 18 superseded merge_group runs sat in the runner queue ahead of the 4 live
+# ones and starved them. This job cancels any queued/in-progress merge_group
+# run whose ref no longer exists. Cheap: one API-only job every 10 minutes.
+
+on:
+  schedule:
+    - cron: '*/10 * * * *'
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: merge-queue-janitor
+  cancel-in-progress: false
+
+jobs:
+  cancel-superseded:
+    name: Cancel superseded merge-group runs
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Cancel merge_group runs whose queue ref is gone
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          cancelled=0
+          for status in queued in_progress; do
+            gh api "repos/${GITHUB_REPOSITORY}/actions/runs?event=merge_group&status=${status}&per_page=100" \
+              --jq '.workflow_runs[] | "\(.id) \(.head_branch)"' |
+            while read -r id ref; do
+              [ -n "$ref" ] || continue
+              if gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/${ref}" >/dev/null 2>&1; then
+                continue
+              fi
+              echo "cancelling run ${id}: ref ${ref} no longer exists"
+              gh api -X POST "repos/${GITHUB_REPOSITORY}/actions/runs/${id}/cancel" >/dev/null && cancelled=$((cancelled+1)) || true
+            done
+          done
+          echo "done"


### PR DESCRIPTION
## Summary

GitHub deletes the temporary `gh-readonly-queue/main/pr-N-<sha>` ref when a merge group is rebuilt (bypass push to main, dequeued entry ahead) but does **not** cancel the workflow runs started for it. Observed today right after enabling the queue: 18 superseded `merge_group` runs sat in the runner queue ahead of the 4 live ones and starved them (the live runs' `CI Success` job waited on an ubuntu slot while stale runs finished 44/45 jobs for nothing).

New scheduled workflow (every 10 min, plus `workflow_dispatch`): list queued/in-progress `merge_group` runs, check whether their ref still exists, cancel the ones whose ref is gone. API-only, ~10s per tick.

## Verification

- `actionlint` clean.
- Core loop dry-run against the live repo: the 4 live refs resolve, a superseded ref returns 404.
- `check-supply-chain-hardening.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGT9BJVfpG3nyM6c9koAN8