### PR TITLE
fix(api): passkey register/delete must keep the caller's session (#5038)

### DIFF
--- a/apps/api/src/routes/auth.passkeys.test.ts
+++ b/apps/api/src/routes/auth.passkeys.test.ts
@@ -410,6 +410,7 @@ vi.mock('../middleware/auth', () => ({
 }));
 
 import {
+  AuthBindingRotationRequiredError,
   AuthIssuanceCapabilityError,
   AuthIssuanceConflictError,
   beginAuthIssuance,
@@ -2014,6 +2015,48 @@ describe('passkey MFA auth routes', () => {
       expect(body.success).toBe(true);
       expect(bindIssuedUserSession).toHaveBeenCalledTimes(1);
       expect(body.tokens).toBeUndefined();
+    });
+
+    // Every other beginAuthIssuance caller in this repo asserts the 428 the
+    // shared admission helper answers when the client's auth binding must be
+    // rotated before a session can be issued (login.test.ts, invite.test.ts,
+    // cfAccessRedirectLogin.test.ts). These two call sites are new, so they get
+    // the same guard: a regression in the wiring — a dropped
+    // `if (!response) throw error` fallback, or a branch that forgets to cancel
+    // the capability — would otherwise go unnoticed.
+    it('answers 428 and writes nothing when the binding must be rotated before registration', async () => {
+      queueProtectedRegisterReads();
+      vi.mocked(beginAuthIssuance).mockRejectedValueOnce(
+        // The real constructor takes (replacement, reason); this suite's mock
+        // class only stores the first, so the reason is a placeholder.
+        new AuthBindingRotationRequiredError({ id: 'binding-2' } as never, 'rotation-required' as never),
+      );
+
+      const res = await registerSecondPasskey();
+
+      expect(res.status).toBe(428);
+      expect(await res.json()).toMatchObject({ reason: 'auth_binding_rotation_required' });
+      expect(completeAdditionalMfaFactorEnrollment).not.toHaveBeenCalled();
+      // Nothing was admitted, so there is no capability to cancel.
+      expect(cancelAuthIssuance).not.toHaveBeenCalled();
+      expect(dbState.updateSets).toHaveLength(0);
+    });
+
+    it('answers 428 and deletes nothing when the binding must be rotated before deletion', async () => {
+      queueDeleteReads();
+      vi.mocked(beginAuthIssuance).mockRejectedValueOnce(
+        // The real constructor takes (replacement, reason); this suite's mock
+        // class only stores the first, so the reason is a placeholder.
+        new AuthBindingRotationRequiredError({ id: 'binding-2' } as never, 'rotation-required' as never),
+      );
+
+      const res = await deletePasskey();
+
+      expect(res.status).toBe(428);
+      expect(await res.json()).toMatchObject({ reason: 'auth_binding_rotation_required' });
+      expect(completeMfaFactorRemoval).not.toHaveBeenCalled();
+      expect(cancelAuthIssuance).not.toHaveBeenCalled();
+      expect(dbState.updateSets).toHaveLength(0);
     });
 
     it('surfaces a lost issuance race on deletion as 409 without deleting the passkey', async () => {

--- a/apps/api/src/routes/auth.passkeys.test.ts
+++ b/apps/api/src/routes/auth.passkeys.test.ts
@@ -76,6 +76,42 @@ vi.mock('../services', () => {
     await bindRefreshJtiToFamily(tokens.refreshJti, familyId);
     return { ...tokens, familyId };
   });
+  const runFactorWrite = async (input: any) => {
+    const tx: any = {
+      insert: vi.fn(() => ({
+        values: vi.fn(() => ({
+          returning: vi.fn(() => Promise.resolve(dbState.insertReturning)),
+        })),
+      })),
+      update: vi.fn(() => ({
+        set: vi.fn((values: Record<string, unknown>) => {
+          dbState.updateSets.push(values);
+          const whereResult: any = Promise.resolve(undefined);
+          whereResult.returning = vi.fn(() => Promise.resolve([{ id: 'user-123' }]));
+          return { where: vi.fn(() => whereResult) };
+        }),
+      })),
+      delete: vi.fn(() => ({
+        where: vi.fn(() => Promise.resolve(undefined)),
+      })),
+    };
+    const value = await input.persistFactor(tx, input.recoveryCodeHashes ?? []);
+    return {
+      value,
+      recoveryCodes: [...(input.recoveryCodes ?? [])],
+      issued: {
+        accessToken: 'replacement-access-token',
+        refreshToken: 'replacement-refresh-token',
+        refreshJti: 'replacement-jti',
+        expiresInSeconds: 900,
+        familyId: 'replacement-family',
+        transitionId: 'transition-1',
+        generation: 1,
+      },
+      mfaEpoch: 2,
+      cleanup: { redisOk: true, permissionCacheOk: true, oauthOk: true, remoteSessionsTerminated: 0 },
+    };
+  };
   class AuthBindingRotationRequiredError extends Error {
     status = 428;
     constructor(readonly replacement: unknown) { super('rotation required'); }
@@ -131,39 +167,17 @@ vi.mock('../services', () => {
   AuthIssuanceConflictError,
   AuthIssuanceCapabilityError,
   issueUserSession: vi.fn(async (identity: any) => issueLegacy(identity)),
-  completeInitialMfaEnrollment: vi.fn(async (input: any) => {
-    const tx: any = {
-      insert: vi.fn(() => ({
-        values: vi.fn(() => ({
-          returning: vi.fn(() => Promise.resolve(dbState.insertReturning)),
-        })),
-      })),
-      update: vi.fn(() => ({
-        set: vi.fn((values: Record<string, unknown>) => {
-          dbState.updateSets.push(values);
-          const whereResult: any = Promise.resolve(undefined);
-          whereResult.returning = vi.fn(() => Promise.resolve([{ id: 'user-123' }]));
-          return { where: vi.fn(() => whereResult) };
-        }),
-      })),
-    };
-    const value = await input.persistFactor(tx, input.recoveryCodeHashes);
-    return {
-      value,
-      recoveryCodes: [...input.recoveryCodes],
-      issued: {
-        accessToken: 'replacement-access-token',
-        refreshToken: 'replacement-refresh-token',
-        refreshJti: 'replacement-jti',
-        expiresInSeconds: 900,
-        familyId: 'replacement-family',
-        transitionId: 'transition-1',
-        generation: 1,
-      },
-      mfaEpoch: 2,
-      cleanup: { redisOk: true, permissionCacheOk: true, oauthOk: true, remoteSessionsTerminated: 0 },
-    };
-  }),
+  // All three session-replacing factor writes share one body: run the caller's
+  // `persistFactor` against a queue-backed transaction stub and hand back a
+  // replacement session. They differ only in whether a recovery-code pair rides
+  // along — a REMOVAL (#4934 /mfa/disable, #5038 passkey delete) and a
+  // SECONDARY ADDITION (#5038 passkey register on a protected account) install
+  // none, so the real service omits those fields from the input type entirely
+  // and the mock must default them rather than read `input.recoveryCodeHashes`
+  // off an object that never carries it.
+  completeInitialMfaEnrollment: vi.fn(async (input: any) => runFactorWrite(input)),
+  completeMfaFactorRemoval: vi.fn(async (input: any) => runFactorWrite(input)),
+  completeAdditionalMfaFactorEnrollment: vi.fn(async (input: any) => runFactorWrite(input)),
   issueUserSessionLegacyDuringTransition: issueLegacy,
   bindIssuedUserSession: vi.fn(async () => undefined),
   authBrowserTransitionsEnforced: vi.fn(() => process.env.AUTH_BROWSER_TRANSITIONS_ENFORCED === 'true'),
@@ -397,8 +411,12 @@ vi.mock('../middleware/auth', () => ({
 
 import {
   AuthIssuanceCapabilityError,
+  AuthIssuanceConflictError,
   beginAuthIssuance,
+  bindIssuedUserSession,
   cancelAuthIssuance,
+  completeAdditionalMfaFactorEnrollment,
+  completeMfaFactorRemoval,
   createTokenPair,
   finishAuthIssuance,
   getRedis,
@@ -409,6 +427,7 @@ import {
   verifyPassword,
 } from '../services';
 import { PasskeyChallengeError } from '../services/passkeys';
+import { authMiddleware } from '../middleware/auth';
 import { withSystemDbAccessContext } from '../db';
 import { getEffectiveMfaPolicy } from '../services/mfaPolicy';
 import { validateStepUpGrant, consumeStepUpGrant } from '../services/mfaStepUpGrant';
@@ -1763,6 +1782,249 @@ describe('passkey MFA auth routes', () => {
       mfaEnabled: false,
       mfaMethod: null,
     }));
+  });
+
+  // #5038: adding a passkey to an ALREADY-PROTECTED account and deleting a
+  // passkey both used to run through invalidateMfaAssuranceAfterFactorChange,
+  // which bumps mfa_epoch and revokes every refresh family WITHOUT re-issuing
+  // the actor. The caller's own next request then 401s on the stale `mep`, its
+  // refresh fails against a family revoked in the same transaction, and the web
+  // client hard-redirects to /login?reason=session-expired — the user is signed
+  // out by the very action they just took. Same class #4934/#5008 fixed for
+  // /mfa/disable: evict every OTHER session, keep the caller.
+  describe('#5038 passkey factor writes keep the calling session', () => {
+    // Query order for register/verify on a protected account: the
+    // userIsMfaProtected gate, #4018's resolveEnrollmentStepUp passwordHash
+    // read, then the terminal route's live enrollment-state read.
+    function queueProtectedRegisterReads() {
+      dbState.selectQueue.push([{ mfaEnabled: true, passkeyCount: 1 }]);
+      dbState.selectQueue.push([{ passwordHash: '$argon2id$hash' }]);
+      dbState.selectQueue.push([{ mfaEnabled: true, mfaSecret: 'enc-secret', mfaMethod: 'totp' }]);
+      vi.mocked(consumeStepUpGrant).mockResolvedValueOnce(true);
+    }
+
+    function registerSecondPasskey() {
+      return app.request('/auth/passkeys/register/verify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer access-token' },
+        body: JSON.stringify({ credential: { id: 'credential-1', response: {} }, stepUpGrantId: 'grant-1' }),
+      });
+    }
+
+    // Query order for DELETE: the password step-up hash, the owned-passkey
+    // lookup, then the factor-state count.
+    function queueDeleteReads(state: Record<string, unknown> = {}) {
+      vi.mocked(verifyPassword).mockResolvedValueOnce(true);
+      dbState.selectQueue.push(
+        [{ passwordHash: '$argon2id$hash' }],
+        [{ id: 'credential-1', userId: 'user-123' }],
+        [{ passkeyCount: 2, hasTotp: true, hasSms: false, currentMfaMethod: 'totp', forceMfa: false, orgRequiresMfa: false, ...state }],
+      );
+    }
+
+    function deletePasskey() {
+      return app.request('/auth/passkeys/credential-1', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer access-token' },
+        body: JSON.stringify({ currentPassword: 'correct-password' }),
+      });
+    }
+
+    it('re-issues the caller when a second passkey is added to a protected account', async () => {
+      queueProtectedRegisterReads();
+
+      const res = await registerSecondPasskey();
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toMatchObject({
+        success: true,
+        passkey: { id: 'passkey-credential-1' },
+        // The replacement access token is what keeps the caller authenticated
+        // past its own epoch bump.
+        tokens: { accessToken: 'replacement-access-token', expiresInSeconds: 900 },
+      });
+      // Adding a SECOND factor must not rotate the account's existing recovery
+      // codes — there is no one-time secret in this response.
+      expect(body.recoveryCodes).toBeUndefined();
+      // ...and the rotated refresh cookie is what survives the family revoke.
+      expect(res.headers.get('set-cookie') ?? '').toContain('replacement-refresh-token');
+
+      expect(completeAdditionalMfaFactorEnrollment).toHaveBeenCalledTimes(1);
+      const input = vi.mocked(completeAdditionalMfaFactorEnrollment).mock.calls[0]?.[0] as any;
+      expect(input).toMatchObject({ userId: 'user-123', revokeReason: 'passkey-register' });
+      // A secondary addition installs NO code set.
+      expect(input.recoveryCodes).toBeUndefined();
+      expect(input.recoveryCodeHashes).toBeUndefined();
+    });
+
+    it('does not clear the session cookies when a second passkey is added', async () => {
+      queueProtectedRegisterReads();
+
+      const res = await registerSecondPasskey();
+
+      expect(res.status).toBe(200);
+      const cookies = res.headers.getSetCookie?.() ?? [];
+      expect(cookies.length).toBeGreaterThan(0);
+      for (const cookie of cookies) {
+        // A cleared cookie is `<name>=; ... Max-Age=0` — the shape the eviction
+        // path used to leave the browser with.
+        expect(cookie).not.toContain('Max-Age=0');
+        expect(cookie).not.toMatch(/breeze_(refresh|csrf)_token=;/);
+      }
+      expect(cookies.find((cookie) => cookie.startsWith('breeze_refresh_token=')))
+        .toContain('replacement-refresh-token');
+    });
+
+    // SR-001 + the "carry forward, never elevate" rule: the replacement inherits
+    // the SIGNED `mdid` binding (never the forgeable header) and the caller's
+    // own assurance claim.
+    it('carries the signed binding and the caller assurance into the replacement', async () => {
+      vi.mocked(authMiddleware).mockImplementationOnce(((c: any, next: any) => {
+        c.set('auth', {
+          user: { id: 'user-123', email: 'test@example.com', name: 'Test User' },
+          orgId: 'org-5',
+          partnerId: 'partner-2',
+          scope: 'organization',
+          token: { sid: 'session-123', mfa: true, aep: 4, mep: 9, mdid: 'signed-device-1', roleId: 'role-7' },
+        });
+        return next();
+      }) as never);
+      queueProtectedRegisterReads();
+
+      const res = await app.request('/auth/passkeys/register/verify', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer access-token',
+          'x-breeze-mobile-device-id': 'forged-device-header',
+        },
+        body: JSON.stringify({ credential: { id: 'credential-1', response: {} }, stepUpGrantId: 'grant-1' }),
+      });
+
+      expect(res.status).toBe(200);
+      const input = vi.mocked(completeAdditionalMfaFactorEnrollment).mock.calls[0]?.[0] as any;
+      expect(input.expectedAuthEpoch).toBe(4);
+      expect(input.expectedMfaEpoch).toBe(9);
+      expect(input.identity).toMatchObject({
+        userId: 'user-123',
+        roleId: 'role-7',
+        orgId: 'org-5',
+        partnerId: 'partner-2',
+        scope: 'organization',
+        mfa: true,
+        mobileDeviceId: 'signed-device-1',
+      });
+      expect(input.identity.mobileDeviceId).not.toBe('forged-device-header');
+    });
+
+    // Post-commit: the passkey is already registered and every other session is
+    // already dead, so a failure installing the replacement must not turn a
+    // completed registration into a 500 the user retries.
+    it('still reports the registration when the replacement session install fails', async () => {
+      queueProtectedRegisterReads();
+      vi.mocked(bindIssuedUserSession).mockRejectedValueOnce(new Error('redis down'));
+
+      const res = await registerSecondPasskey();
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.success).toBe(true);
+      // Discriminating even though a pre-fix route also answers 200 with no
+      // tokens: the install has to have been ATTEMPTED for its failure to be
+      // the reason they are missing.
+      expect(bindIssuedUserSession).toHaveBeenCalledTimes(1);
+      // The refresh JTI was never bound, so the access token would die at its
+      // first refresh — withhold it rather than sell the caller a few minutes.
+      expect(body.tokens).toBeUndefined();
+    });
+
+    it('surfaces a lost issuance race on registration as 409', async () => {
+      queueProtectedRegisterReads();
+      vi.mocked(completeAdditionalMfaFactorEnrollment).mockRejectedValueOnce(new AuthIssuanceConflictError());
+
+      const res = await registerSecondPasskey();
+
+      expect(res.status).toBe(409);
+      expect(cancelAuthIssuance).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-issues the caller when a passkey is deleted', async () => {
+      queueDeleteReads();
+
+      const res = await deletePasskey();
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toMatchObject({
+        success: true,
+        tokens: { accessToken: 'replacement-access-token', expiresInSeconds: 900 },
+      });
+      expect(res.headers.get('set-cookie') ?? '').toContain('replacement-refresh-token');
+
+      expect(completeMfaFactorRemoval).toHaveBeenCalledTimes(1);
+      const input = vi.mocked(completeMfaFactorRemoval).mock.calls[0]?.[0] as any;
+      expect(input).toMatchObject({ userId: 'user-123', revokeReason: 'passkey-delete' });
+      expect(input.recoveryCodes).toBeUndefined();
+      expect(input.recoveryCodeHashes).toBeUndefined();
+    });
+
+    it('does not clear the session cookies when a passkey is deleted', async () => {
+      queueDeleteReads();
+
+      const res = await deletePasskey();
+
+      expect(res.status).toBe(200);
+      const cookies = res.headers.getSetCookie?.() ?? [];
+      expect(cookies.length).toBeGreaterThan(0);
+      for (const cookie of cookies) {
+        expect(cookie).not.toContain('Max-Age=0');
+        expect(cookie).not.toMatch(/breeze_(refresh|csrf)_token=;/);
+      }
+      expect(cookies.find((cookie) => cookie.startsWith('breeze_refresh_token=')))
+        .toContain('replacement-refresh-token');
+    });
+
+    // Removing the LAST factor leaves the account unprotected — the caller keeps
+    // whatever assurance it already had (a fresh login would mint `mfa` true
+    // vacuously once mfa_enabled is false), and is still not evicted.
+    it('re-issues the caller when the last passkey is deleted and MFA turns off', async () => {
+      queueDeleteReads({ passkeyCount: 1, hasTotp: false, hasSms: false, currentMfaMethod: 'passkey' });
+
+      const res = await deletePasskey();
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toMatchObject({
+        success: true,
+        tokens: { accessToken: 'replacement-access-token' },
+      });
+      expect(dbState.updateSets).toContainEqual(expect.objectContaining({
+        mfaEnabled: false,
+        mfaMethod: null,
+      }));
+    });
+
+    it('still reports the deletion when the replacement session install fails', async () => {
+      queueDeleteReads();
+      vi.mocked(bindIssuedUserSession).mockRejectedValueOnce(new Error('redis down'));
+
+      const res = await deletePasskey();
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.success).toBe(true);
+      expect(bindIssuedUserSession).toHaveBeenCalledTimes(1);
+      expect(body.tokens).toBeUndefined();
+    });
+
+    it('surfaces a lost issuance race on deletion as 409 without deleting the passkey', async () => {
+      queueDeleteReads();
+      vi.mocked(completeMfaFactorRemoval).mockRejectedValueOnce(new AuthIssuanceConflictError());
+
+      const res = await deletePasskey();
+
+      expect(res.status).toBe(409);
+      expect(cancelAuthIssuance).toHaveBeenCalledTimes(1);
+    });
   });
 
   // mfa.ts guard: a passkey pending session must be routed to passkey verification.

--- a/apps/api/src/routes/auth/passkeys.ts
+++ b/apps/api/src/routes/auth/passkeys.ts
@@ -23,7 +23,9 @@ import {
   bindIssuedUserSession,
   authBrowserTransitionsEnforced,
   recordAuthTransitionLegacyIssuer,
+  completeAdditionalMfaFactorEnrollment,
   completeInitialMfaEnrollment,
+  completeMfaFactorRemoval,
   generateRecoveryCodes,
   type AuthIssuanceCapability,
   type AuthorizedUserSession,
@@ -38,11 +40,11 @@ import {
   verifyPasskeyAuthentication,
   verifyPasskeyRegistration
 } from '../../services/passkeys';
-import { readMobileDeviceId } from '../../services/mobileDeviceBinding';
+import { carryForwardBinding, readMobileDeviceId } from '../../services/mobileDeviceBinding';
 import { getEffectiveMfaPolicy } from '../../services/mfaPolicy';
-import { invalidateMfaAssuranceAfterFactorChange } from '../../services/mfaAssurance';
+import { captureException } from '../../services/sentry';
 import { TEARDOWN_FAILED } from '../../services/remoteSessionTeardown';
-import { EpochAdvancePreconditionError, type Tx } from '../../services/authLifecycle';
+import { type Tx } from '../../services/authLifecycle';
 import { ENABLE_2FA } from './schemas';
 import {
   auditLogin,
@@ -87,6 +89,39 @@ function authIssuanceAdmissionError(c: Context, error: unknown): Response | null
     return c.json({ error: 'Authentication issuance unavailable' }, 409);
   }
   return null;
+}
+
+/**
+ * POST-COMMIT session install for the factor writes that replace the caller's
+ * session (#5038). The factor write is already committed and every OTHER
+ * session is already dead by the time this runs, so a failure here must NOT be
+ * turned into an error the user retries — a retried passkey registration
+ * duplicates a credential, and a retried delete answers 404. Report it, step
+ * over, and let the caller withhold the tokens it would otherwise return: the
+ * refresh JTI was never bound, so the access token would die at its first
+ * refresh anyway. Same rule /mfa/disable and /mfa/recovery-codes follow.
+ *
+ * Returns whether the replacement is safe to hand back.
+ */
+async function installReplacementSession(
+  c: Context,
+  issued: AuthorizedUserSession,
+  userId: string,
+  factorChange: string,
+): Promise<boolean> {
+  try {
+    await bindIssuedUserSession(issued);
+    installAuthorizedUserSessionCookies(c, issued);
+    return true;
+  } catch (error) {
+    captureException(error, c, { factorChange });
+    console.error('[auth] passkey factor write committed but the replacement session could not be installed', {
+      userId,
+      factorChange,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return false;
+  }
 }
 
 // WebAuthn assertion/attestation payloads are large nested objects validated
@@ -318,7 +353,8 @@ passkeyRoutes.post('/passkeys/register/verify', authMiddleware, zValidator('json
 
   let mfaEpoch: number;
   let teardownFailed: boolean;
-  let replacement: { recoveryCodes: string[]; issued: AuthorizedUserSession } | null = null;
+  let sessionInstalled = true;
+  let replacement: { recoveryCodes: string[] | null; issued: AuthorizedUserSession | null } | null = null;
   if (!enrollmentState.mfaEnabled) {
     const recoveryCodes = generateRecoveryCodes();
     const recoveryCodeHashes = hashRecoveryCodes(recoveryCodes);
@@ -371,37 +407,84 @@ passkeyRoutes.post('/passkeys/register/verify', authMiddleware, zValidator('json
       if (!response) throw error;
       return response;
     }
-    await bindIssuedUserSession(result.issued);
-    installAuthorizedUserSessionCookies(c, result.issued);
+    sessionInstalled = await installReplacementSession(c, result.issued, auth.user.id, 'passkey_register');
     mfaEpoch = result.mfaEpoch;
     teardownFailed = result.cleanup.remoteSessionsTerminated === TEARDOWN_FAILED;
-    replacement = { recoveryCodes: result.recoveryCodes, issued: result.issued };
+    // The one-time recovery codes are reported even when the session install
+    // failed — they are already the account's only valid set, and swallowing
+    // them would lock the user out of their own new factor.
+    replacement = { recoveryCodes: result.recoveryCodes, issued: sessionInstalled ? result.issued : null };
   } else {
-    // Secondary-factor addition keeps the existing invalidation behavior and
-    // does not rotate recovery codes or replace the already-assured session.
+    // #5038: a SECONDARY factor addition still advances mfa_epoch and revokes
+    // every refresh family — no other live session may keep an assurance minted
+    // before the account's factor set changed (SR2-07) — but it must not evict
+    // the ACTOR. The old path did exactly that: the caller's access token went
+    // stale on its own bump and the refresh cookie it would retry with belonged
+    // to a family revoked in the same transaction, so the web client
+    // hard-redirected to /login?reason=session-expired the moment the user
+    // added a second passkey. Same road /mfa/disable took in #4934/#5008.
+    // The account's existing recovery-code set is untouched: adding a factor
+    // reveals no new one-time secret, so none is rotated.
+    let capability: AuthIssuanceCapability;
+    try {
+      capability = await beginAuthIssuance(requestAuthBinding(c));
+    } catch (error) {
+      const response = authIssuanceAdmissionError(c, error);
+      if (!response) throw error;
+      return response;
+    }
     let result;
     try {
-      result = await invalidateMfaAssuranceAfterFactorChange(auth.user.id, 'passkey-register', async (tx) => {
-        await persistPasskey(tx);
-        const hasExistingFactor = Boolean(enrollmentState.mfaSecret) || enrollmentState.mfaMethod === 'sms';
+      result = await completeAdditionalMfaFactorEnrollment({
+        userId: auth.user.id,
+        identity: {
+          userId: auth.user.id,
+          email: auth.user.email,
+          roleId: auth.token?.roleId ?? null,
+          orgId: auth.orgId ?? null,
+          partnerId: auth.partnerId ?? null,
+          scope: auth.scope,
+          // Carry the caller's OWN assurance forward, never elevate it: this
+          // endpoint's step-up gate proves an existing factor, not that the
+          // session itself was MFA-assured.
+          mfa: auth.token?.mfa === true,
+          // SR-001: a RE-MINT takes its device binding from the previously
+          // signed `mdid` claim, never the forgeable request header.
+          mobileDeviceId: carryForwardBinding(auth.token ?? {}),
+        },
+        capability,
+        expectedAuthEpoch: auth.token?.aep as number,
+        expectedMfaEpoch: auth.token?.mep as number,
+        revokeReason: 'passkey-register',
+        persistFactor: async (tx) => {
+          await persistPasskey(tx);
+          const hasExistingFactor = Boolean(enrollmentState.mfaSecret) || enrollmentState.mfaMethod === 'sms';
 
-        await tx
-          .update(users)
-          .set({
-            mfaEnabled: true,
-            ...(hasExistingFactor ? {} : { mfaMethod: 'passkey' }),
-            updatedAt: new Date()
-          })
-          .where(eq(users.id, auth.user.id));
-      }, { authEpoch: auth.token?.aep as number, mfaEpoch: auth.token?.mep as number, status: 'active' });
+          const rows = await tx
+            .update(users)
+            .set({
+              mfaEnabled: true,
+              ...(hasExistingFactor ? {} : { mfaMethod: 'passkey' }),
+              updatedAt: new Date()
+            })
+            .where(eq(users.id, auth.user.id))
+            .returning({ id: users.id });
+          if (rows.length !== 1) throw new Error('Passkey registration user disappeared');
+          return undefined;
+        },
+      });
     } catch (error) {
-      if (error instanceof EpochAdvancePreconditionError) {
-        return c.json({ error: 'Authentication changed. Please sign in again.' }, 409);
-      }
-      throw error;
+      await cancelAuthIssuance(capability).catch(() => undefined);
+      const response = authIssuanceAdmissionError(c, error);
+      if (!response) throw error;
+      return response;
     }
+
+    sessionInstalled = await installReplacementSession(c, result.issued, auth.user.id, 'passkey_register');
     mfaEpoch = result.mfaEpoch;
-    teardownFailed = result.remoteSessionsTerminated === TEARDOWN_FAILED;
+    teardownFailed = result.cleanup.remoteSessionsTerminated === TEARDOWN_FAILED;
+    // No recovery codes: the account already holds its own set.
+    replacement = { recoveryCodes: null, issued: sessionInstalled ? result.issued : null };
   }
 
   if (!inserted) {
@@ -418,19 +501,19 @@ passkeyRoutes.post('/passkeys/register/verify', authMiddleware, zValidator('json
       method: 'passkey',
       credentialId: fields.credentialId,
       mfaEpoch,
-      teardownFailed
+      teardownFailed,
+      sessionInstalled
     }
   });
 
   return c.json({
     success: true,
     passkey: toPublicPasskey(inserted),
-    ...(replacement
-      ? {
-          recoveryCodes: replacement.recoveryCodes,
-          tokens: toPublicTokens(replacement.issued),
-        }
-      : {}),
+    // Recovery codes appear only on the INITIAL enrollment that minted them.
+    ...(replacement?.recoveryCodes ? { recoveryCodes: replacement.recoveryCodes } : {}),
+    // Withheld when the post-commit install failed: the refresh JTI was never
+    // bound, so the access token would die at its first refresh.
+    ...(replacement?.issued ? { tokens: toPublicTokens(replacement.issued) } : {}),
   });
 });
 
@@ -913,31 +996,79 @@ passkeyRoutes.delete('/passkeys/:id', authMiddleware, zValidator('json', deleteP
     return c.json({ error: 'Cannot remove the last MFA factor while your role or organization requires MFA' }, 403);
   }
 
-  const result = await invalidateMfaAssuranceAfterFactorChange(auth.user.id, 'passkey-delete', async (tx) => {
-    await tx
-      .delete(userPasskeys)
-      .where(eq(userPasskeys.id, id));
+  // #5038: removing a factor advances mfa_epoch and revokes every refresh
+  // family so no OTHER live session survives the account's factor set changing
+  // (SR2-07) — but the caller must not be evicted by its own request. The old
+  // path bumped the epoch without re-issuing, so deleting a passkey bounced the
+  // user to /login?reason=session-expired. Same primitive #4934/#5008 gave
+  // /mfa/disable: every other session dies, the actor's is replaced in the same
+  // response.
+  let capability: AuthIssuanceCapability;
+  try {
+    capability = await beginAuthIssuance(requestAuthBinding(c));
+  } catch (error) {
+    const response = authIssuanceAdmissionError(c, error);
+    if (!response) throw error;
+    return response;
+  }
+  let result;
+  try {
+    result = await completeMfaFactorRemoval({
+      userId: auth.user.id,
+      identity: {
+        userId: auth.user.id,
+        email: auth.user.email,
+        roleId: auth.token?.roleId ?? null,
+        orgId: auth.orgId ?? null,
+        partnerId: auth.partnerId ?? null,
+        scope: auth.scope,
+        // Carried forward, never elevated. This route already requires an
+        // MFA-assured caller, and a fresh login after the LAST factor is gone
+        // would mint `mfa` true vacuously anyway.
+        mfa: auth.token?.mfa === true,
+        // SR-001: the binding comes from the previously-signed `mdid` claim,
+        // never the forgeable request header.
+        mobileDeviceId: carryForwardBinding(auth.token ?? {}),
+      },
+      capability,
+      expectedAuthEpoch: auth.token?.aep as number,
+      expectedMfaEpoch: auth.token?.mep as number,
+      revokeReason: 'passkey-delete',
+      persistFactor: async (tx) => {
+        await tx
+          .delete(userPasskeys)
+          .where(eq(userPasskeys.id, id));
 
-    if (remainingFactorCount === 0) {
-      await tx
-        .update(users)
-        .set({
-          mfaEnabled: false,
-          mfaMethod: null,
-          updatedAt: new Date()
-        })
-        .where(eq(users.id, auth.user.id));
-    } else if (factorState.currentMfaMethod === 'passkey' && factorState.passkeyCount - 1 === 0) {
-      await tx
-        .update(users)
-        .set({
-          mfaEnabled: true,
-          mfaMethod: factorState.hasTotp ? 'totp' : 'sms',
-          updatedAt: new Date()
-        })
-        .where(eq(users.id, auth.user.id));
-    }
-  });
+        if (remainingFactorCount === 0) {
+          await tx
+            .update(users)
+            .set({
+              mfaEnabled: false,
+              mfaMethod: null,
+              updatedAt: new Date()
+            })
+            .where(eq(users.id, auth.user.id));
+        } else if (factorState.currentMfaMethod === 'passkey' && factorState.passkeyCount - 1 === 0) {
+          await tx
+            .update(users)
+            .set({
+              mfaEnabled: true,
+              mfaMethod: factorState.hasTotp ? 'totp' : 'sms',
+              updatedAt: new Date()
+            })
+            .where(eq(users.id, auth.user.id));
+        }
+        return undefined;
+      },
+    });
+  } catch (error) {
+    await cancelAuthIssuance(capability).catch(() => undefined);
+    const response = authIssuanceAdmissionError(c, error);
+    if (!response) throw error;
+    return response;
+  }
+
+  const sessionInstalled = await installReplacementSession(c, result.issued, auth.user.id, 'passkey_delete');
 
   writeAuthAudit(c, {
     orgId: auth.orgId ?? undefined,
@@ -949,11 +1080,15 @@ passkeyRoutes.delete('/passkeys/:id', authMiddleware, zValidator('json', deleteP
       method: 'passkey',
       passkeyId: id,
       mfaEpoch: result.mfaEpoch,
-      teardownFailed: result.remoteSessionsTerminated === TEARDOWN_FAILED
+      teardownFailed: result.cleanup.remoteSessionsTerminated === TEARDOWN_FAILED,
+      sessionInstalled
     }
   });
 
-  return c.json({ success: true });
+  return c.json({
+    success: true,
+    ...(sessionInstalled ? { tokens: toPublicTokens(result.issued) } : {}),
+  });
 });
 
 async function readPendingPasskeyMfa(tempToken: string): Promise<PendingMfaRecord | null> {

--- a/apps/api/src/services/mfaEnrollmentSession.test.ts
+++ b/apps/api/src/services/mfaEnrollmentSession.test.ts
@@ -41,7 +41,12 @@ vi.mock('./remoteSessionTeardown', () => ({
   terminateUserRemoteSessions: terminateUserRemoteSessionsMock,
 }));
 
-import { completeInitialMfaEnrollment, completeMfaFactorRemoval, replaceSessionOnMfaFactorWrite } from './mfaEnrollmentSession';
+import {
+  completeAdditionalMfaFactorEnrollment,
+  completeInitialMfaEnrollment,
+  completeMfaFactorRemoval,
+  replaceSessionOnMfaFactorWrite,
+} from './mfaEnrollmentSession';
 import type { AuthIssuanceCapability } from './authBrowserTransition';
 import { EpochAdvancePreconditionError } from './authLifecycle';
 import type { AuthorizedUserSession, UserSessionIdentity } from './userSession';
@@ -553,5 +558,124 @@ describe('replaceSessionOnMfaFactorWrite — factor removal with no recovery cod
     } as never)).rejects.toThrow(/recovery-code/i);
 
     expect(finishAuthIssuanceMock).not.toHaveBeenCalled();
+  });
+});
+
+// #5038: a SECONDARY factor ADDITION is the fourth shape. Like a removal it
+// carries no code pair — the account keeps the recovery-code set it already
+// holds, and nothing one-time is revealed — but unlike an initial enrollment it
+// is predicated on the factor set ALREADY existing. Adding a passkey used to
+// bump the epoch without re-issuing the actor, so the user was bounced to
+// /login?reason=session-expired by their own request.
+describe('completeAdditionalMfaFactorEnrollment — secondary factor with no recovery codes (#5038)', () => {
+  const tx = { marker: 'transaction' } as never;
+  const capability = { marker: 'capability' } as unknown as AuthIssuanceCapability;
+  const identity: UserSessionIdentity = {
+    userId: 'user-123',
+    email: 'user@example.com',
+    roleId: 'role-123',
+    orgId: 'org-123',
+    partnerId: 'partner-123',
+    scope: 'organization',
+    mfa: true,
+  };
+  const issued = {
+    accessToken: 'access',
+    refreshToken: 'refresh',
+    refreshJti: 'refresh-jti',
+    expiresInSeconds: 900,
+    familyId: 'family-new',
+    transitionId: 'transition-123',
+    generation: 4,
+  } as unknown as AuthorizedUserSession;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    finishAuthIssuanceMock.mockImplementation(
+      async (_capability: unknown, callback: (value: unknown) => Promise<unknown>) => callback(tx),
+    );
+    advanceUserEpochsMock.mockResolvedValue({
+      authEpoch: 3,
+      mfaEpoch: 8,
+      emailEpoch: 1,
+      passwordResetEpoch: 1,
+    });
+    revokeAllRefreshFamiliesMock.mockResolvedValue(undefined);
+    issueUserSessionMock.mockResolvedValue(issued);
+    runPostCommitCleanupMock.mockResolvedValue({ redisOk: true, permissionCacheOk: true, oauthOk: true });
+    terminateUserRemoteSessionsMock.mockResolvedValue(0);
+  });
+
+  it('revokes every family and re-issues the caller while installing no codes', async () => {
+    const persistFactor = vi.fn(async (suppliedTx: unknown, hashes: readonly string[]) => {
+      expect(suppliedTx).toBe(tx);
+      expect(hashes).toEqual([]);
+      return 'passkey-row';
+    });
+
+    const result = await completeAdditionalMfaFactorEnrollment({
+      userId: identity.userId,
+      identity,
+      capability,
+      expectedAuthEpoch: 3,
+      expectedMfaEpoch: 7,
+      revokeReason: 'passkey-register',
+      persistFactor,
+    });
+
+    expect(persistFactor).toHaveBeenCalledTimes(1);
+    // The wrapper, not the caller, fixes the precondition: an account with NO
+    // factor yet is initial enrollment (which must mint a code set), so this
+    // shape is pinned to mfaEnabled: true and a concurrent disable loses.
+    expect(advanceUserEpochsMock).toHaveBeenCalledWith(
+      tx,
+      identity.userId,
+      { mfa: true },
+      { authEpoch: 3, mfaEpoch: 7, mfaEnabled: true, status: 'active' },
+    );
+    expect(revokeAllRefreshFamiliesMock).toHaveBeenCalledWith(tx, identity.userId, 'passkey-register');
+    expect(issueUserSessionMock).toHaveBeenCalledWith(identity, {
+      tx,
+      capability,
+      expectedEpochs: { authEpoch: 3, mfaEpoch: 8 },
+    });
+    expect(result.value).toBe('passkey-row');
+    // No set is revealed: the account's existing codes are untouched.
+    expect(result.recoveryCodes).toEqual([]);
+    expect(result.issued).toBe(issued);
+    // The replacement token must survive its own post-commit revocation cutoff.
+    expect(runPostCommitCleanupMock).toHaveBeenCalledTimes(1);
+    expect(runPostCommitCleanupMock.mock.calls[0]?.[1]?.preserveTokensIssuedAtOrAfter)
+      .toBeLessThanOrEqual(Math.floor(Date.now() / 1000));
+  });
+
+  it('refuses a code pair — installing one here would wipe the set the account already holds', async () => {
+    await expect(completeAdditionalMfaFactorEnrollment({
+      userId: identity.userId,
+      identity,
+      capability,
+      expectedAuthEpoch: 3,
+      expectedMfaEpoch: 7,
+      revokeReason: 'passkey-register',
+      recoveryCodes: ['code-1'],
+      recoveryCodeHashes: ['hash-1'],
+      persistFactor: vi.fn(),
+    } as never)).rejects.toThrow(/recovery codes/i);
+
+    expect(finishAuthIssuanceMock).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a lost precondition race as an issuance conflict', async () => {
+    advanceUserEpochsMock.mockRejectedValueOnce(new EpochAdvancePreconditionError('stale'));
+
+    await expect(completeAdditionalMfaFactorEnrollment({
+      userId: identity.userId,
+      identity,
+      capability,
+      expectedAuthEpoch: 3,
+      expectedMfaEpoch: 7,
+      revokeReason: 'passkey-register',
+      persistFactor: vi.fn(),
+    })).rejects.toMatchObject({ name: 'AuthIssuanceConflictError' });
   });
 });

--- a/apps/api/src/services/mfaEnrollmentSession.test.ts
+++ b/apps/api/src/services/mfaEnrollmentSession.test.ts
@@ -666,7 +666,7 @@ describe('completeAdditionalMfaFactorEnrollment — secondary factor with no rec
   });
 
   it('surfaces a lost precondition race as an issuance conflict', async () => {
-    advanceUserEpochsMock.mockRejectedValueOnce(new EpochAdvancePreconditionError('stale'));
+    advanceUserEpochsMock.mockRejectedValueOnce(new EpochAdvancePreconditionError());
 
     await expect(completeAdditionalMfaFactorEnrollment({
       userId: identity.userId,

--- a/apps/api/src/services/mfaEnrollmentSession.ts
+++ b/apps/api/src/services/mfaEnrollmentSession.ts
@@ -42,10 +42,13 @@ export interface ReplaceSessionOnMfaFactorWriteInput<T> {
    * `recoveryCodeHashes` (which is what actually lands in the row). REQUIRED
    * and non-empty on this shape: a supplied set is the account's only valid
    * one from this commit on, so an empty or missing pair would be a silent
-   * lockout. A factor REMOVAL (#4934 `/mfa/disable`) installs no codes and
-   * must go through `completeMfaFactorRemoval`, which omits these fields by
-   * TYPE rather than by convention — the #5008 review found that an optional
-   * pair here let a rotation caller forget it and persist `[]` unnoticed.
+   * lockout. The two writes that install NO codes — a factor REMOVAL (#4934
+   * `/mfa/disable`, #5038 passkey delete) and a SECONDARY factor ADDITION on an
+   * account that already holds a code set (#5038 passkey register) — go through
+   * `completeMfaFactorRemoval` / `completeAdditionalMfaFactorEnrollment`, which
+   * omit these fields by TYPE rather than by convention — the #5008 review
+   * found that an optional pair here let a rotation caller forget it and
+   * persist `[]` unnoticed.
    */
   recoveryCodes: readonly string[];
   recoveryCodeHashes: readonly string[];
@@ -66,10 +69,19 @@ export type CompleteMfaFactorRemovalInput<T> = Omit<
   'expectedMfaEnabled' | 'recoveryCodes' | 'recoveryCodeHashes'
 >;
 
-/** Internal: the union both public entry points funnel into. */
+/**
+ * SECONDARY-factor addition shape (#5038 passkey register on an account that is
+ * already protected): the account keeps the recovery-code set it already holds,
+ * so this write installs none and reveals none. `expectedMfaEnabled` is fixed at
+ * `true` — an account with no factor yet is INITIAL enrollment, which must mint
+ * a code set and therefore goes through `completeInitialMfaEnrollment`.
+ */
+export type CompleteAdditionalMfaFactorEnrollmentInput<T> = CompleteMfaFactorRemovalInput<T>;
+
+/** Internal: the union every public entry point funnels into. */
 type MfaFactorWriteCoreInput<T> =
   | (ReplaceSessionOnMfaFactorWriteInput<T> & { factorWrite: 'install' | 'rotate' })
-  | (CompleteMfaFactorRemovalInput<T> & { expectedMfaEnabled: true; factorWrite: 'remove' });
+  | (CompleteMfaFactorRemovalInput<T> & { expectedMfaEnabled: true; factorWrite: 'remove' | 'add' });
 
 export interface MfaFactorSessionReplacement<T> {
   value: T;
@@ -90,14 +102,16 @@ export interface MfaFactorSessionReplacement<T> {
  * when the response body carries a one-time secret the user has to read
  * (recovery codes, #4480): a caller signed out by its own request never sees it.
  *
- * Three shapes exist, differing only in `expectedMfaEnabled` and whether a code
+ * Four shapes exist, differing only in `expectedMfaEnabled` and whether a code
  * set accompanies the write, and each has its own entry point: this function
  * is ROTATION on a protected account (factor must still exist, codes required);
  * `completeInitialMfaEnrollment` is INSTALL (factor must not exist yet, codes
  * required); `completeMfaFactorRemoval` is REMOVAL (factor must still exist, no
  * codes — a self-disable that evicted its own caller bounced the user to
- * /login?reason=session-expired the moment they turned MFA off, #4934). All
- * three funnel into the same private core.
+ * /login?reason=session-expired the moment they turned MFA off, #4934); and
+ * `completeAdditionalMfaFactorEnrollment` is a SECONDARY ADDITION (factor must
+ * still exist, no codes — the account's existing set stays valid, #5038). All
+ * four funnel into the same private core.
  *
  * Expensive recovery-code generation and hashing belong before this call; every
  * authority-bearing write happens inside finishAuthIssuance's supplied
@@ -124,7 +138,26 @@ export async function replaceSessionOnMfaFactorWrite<T>(
 }
 
 /**
- * Factor-removal specialization (#4934 `/mfa/disable`): the account must still
+ * Secondary-factor-addition specialization (#5038 passkey register on an
+ * already-protected account): the account must still be protected when the bump
+ * lands, the recovery-code set it already holds is untouched, and the caller's
+ * own assurance is carried forward. Adding a factor still evicts every OTHER
+ * live session (SR2-07) — what it must not do is evict the actor.
+ */
+export async function completeAdditionalMfaFactorEnrollment<T>(
+  input: CompleteAdditionalMfaFactorEnrollmentInput<T>,
+): Promise<MfaFactorSessionReplacement<T>> {
+  if ('recoveryCodes' in input || 'recoveryCodeHashes' in input) {
+    throw new Error(
+      'A secondary factor addition installs no recovery codes; use replaceSessionOnMfaFactorWrite to rotate them',
+    );
+  }
+  return replaceSessionOnMfaFactorWriteCore({ ...input, expectedMfaEnabled: true, factorWrite: 'add' });
+}
+
+/**
+ * Factor-removal specialization (#4934 `/mfa/disable`, #5038 passkey delete):
+ * the account must still
  * be protected when the bump lands, no code set is installed, and the caller's
  * own assurance is carried forward. The only sanctioned way to call the
  * primitive without recovery codes.
@@ -144,15 +177,20 @@ async function replaceSessionOnMfaFactorWriteCore<T>(
   if (input.identity.userId !== input.userId) {
     throw new Error('Factor-write identity does not match the target user');
   }
-  const recoveryCodes = input.factorWrite === 'remove' ? [] : input.recoveryCodes;
-  const recoveryCodeHashes = input.factorWrite === 'remove' ? [] : input.recoveryCodeHashes;
+  // Only INSTALL and ROTATE carry a code pair; REMOVE and ADD leave the
+  // account's own set (empty or existing) exactly as it was.
+  const codePair = input.factorWrite === 'install' || input.factorWrite === 'rotate'
+    ? { codes: input.recoveryCodes, hashes: input.recoveryCodeHashes }
+    : null;
+  const recoveryCodes = codePair?.codes ?? [];
+  const recoveryCodeHashes = codePair?.hashes ?? [];
   if (
     !Number.isInteger(input.expectedAuthEpoch)
     || input.expectedAuthEpoch < 0
     || !Number.isInteger(input.expectedMfaEpoch)
     || input.expectedMfaEpoch < 0
     || recoveryCodes.length !== recoveryCodeHashes.length
-    || (input.factorWrite !== 'remove' && recoveryCodes.length === 0)
+    || (codePair !== null && recoveryCodes.length === 0)
   ) {
     throw new Error('Expected auth/MFA epochs and recovery-code counts must be valid');
   }

--- a/apps/web/src/components/settings/ProfilePage.passkeySession.test.tsx
+++ b/apps/web/src/components/settings/ProfilePage.passkeySession.test.tsx
@@ -128,7 +128,11 @@ describe('ProfilePage — passkey writes adopt the replacement session (#5038)',
     render(<ProfilePage initialUser={USER} />);
     await addPasskey();
 
-    expect(await screen.findByText('Passkey added')).toBeTruthy();
+    // The API withholds `tokens` only when its own post-commit install failed —
+    // the refresh families are already revoked, so this tab's session is dead.
+    // Say so with the success message instead of letting the user discover it as
+    // a disconnected /login?reason=session-expired on some later screen.
+    expect(await screen.findByText('Passkey added. Sign in again to continue.')).toBeTruthy();
     expect(commitReissuedSessionIfCurrentMock).not.toHaveBeenCalled();
   });
 
@@ -170,6 +174,9 @@ describe('ProfilePage — passkey writes adopt the replacement session (#5038)',
     });
     fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
 
+    // A refused commit is not the install-failure case: the store refuses only on
+    // a stale generation, which means a logout already moved the session on. No
+    // re-auth notice — the plain success message stands.
     expect(await screen.findByText('Passkey deleted')).toBeTruthy();
   });
 
@@ -187,7 +194,7 @@ describe('ProfilePage — passkey writes adopt the replacement session (#5038)',
     });
     fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
 
-    expect(await screen.findByText('Passkey deleted')).toBeTruthy();
+    expect(await screen.findByText('Passkey deleted. Sign in again to continue.')).toBeTruthy();
     expect(commitReissuedSessionIfCurrentMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/settings/ProfilePage.passkeySession.test.tsx
+++ b/apps/web/src/components/settings/ProfilePage.passkeySession.test.tsx
@@ -1,0 +1,193 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * #5038 — registering or deleting a passkey rotates the caller's SESSION too.
+ *
+ * Either write advances `mfa_epoch` and revokes every refresh family (no other
+ * live session may survive the account's factor set changing), then hands the
+ * actor a replacement session back in the same response. The page has to ADOPT
+ * that replacement: keeping the pre-write access token means the next request
+ * 401s on the stale `mep` claim, the refresh cookie it would retry with belongs
+ * to a revoked family, and the user is bounced to /login?reason=session-expired
+ * by the very action they just took. Same contract /mfa/disable adopted in
+ * #4934/#5008 and recovery-code rotation in #4480/#4646.
+ */
+
+const {
+  fetchWithAuthMock,
+  createPasskeyCredentialMock,
+  commitReissuedSessionIfCurrentMock,
+  sessionGeneration,
+} = vi.hoisted(() => ({
+  fetchWithAuthMock: vi.fn(),
+  createPasskeyCredentialMock: vi.fn(),
+  commitReissuedSessionIfCurrentMock: vi.fn(() => true),
+  sessionGeneration: 11,
+}));
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: fetchWithAuthMock,
+  createPasskeyCredential: createPasskeyCredentialMock,
+  useAuthStore: Object.assign(
+    (selector: (state: Record<string, unknown>) => unknown) => selector({ updateUser: vi.fn() }),
+    {
+      getState: () => ({
+        updateUser: vi.fn(),
+        sessionGeneration,
+        commitReissuedSessionIfCurrent: commitReissuedSessionIfCurrentMock,
+      }),
+    },
+  ),
+}));
+
+vi.mock('@/lib/avatarBlobCache', () => ({
+  useAvatarBlobUrl: (url: string | null | undefined) => url ?? null,
+}));
+
+// Both stubbed so they don't consume from this file's ordered fetchWithAuth
+// sequence; their own behavior is covered by their own suites.
+vi.mock('./ApproverDevicesSection', () => ({ default: () => null }));
+vi.mock('./ConnectSsoCard', () => ({ default: () => null }));
+
+import ProfilePage from './ProfilePage';
+
+const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload),
+  }) as unknown as Response;
+
+const USER = {
+  id: 'user-1',
+  name: 'Casey Admin',
+  email: 'casey@example.com',
+  mfaEnabled: true,
+  hasPassword: true,
+};
+
+const REPLACEMENT = { accessToken: 'reissued-access-token', expiresInSeconds: 900 };
+
+const registrationOptions = { challenge: 'register-challenge', rp: { name: 'Breeze' } };
+const credential = { id: 'credential-2', rawId: 'credential-2', type: 'public-key', response: {} };
+
+/** Fill the add-passkey form and submit it. */
+async function addPasskey() {
+  await screen.findByLabelText(/Passkey name/i);
+  fireEvent.change(screen.getByLabelText(/Passkey name/i), { target: { value: 'iPhone' } });
+  fireEvent.change(screen.getByLabelText(/Current password/i, { selector: '#passkey-password' }), {
+    target: { value: 'current-password' },
+  });
+  fireEvent.click(screen.getByRole('button', { name: 'Add passkey' }));
+}
+
+describe('ProfilePage — passkey writes adopt the replacement session (#5038)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    commitReissuedSessionIfCurrentMock.mockReturnValue(true);
+    sessionStorage.clear();
+    globalThis.URL.createObjectURL = vi.fn(() => 'blob:fake');
+    globalThis.URL.revokeObjectURL = vi.fn();
+  });
+
+  it('installs the replacement session returned by register/verify', async () => {
+    fetchWithAuthMock
+      .mockResolvedValueOnce(makeJsonResponse({ passkeys: [] }))
+      .mockResolvedValueOnce(makeJsonResponse({ options: registrationOptions }))
+      .mockResolvedValueOnce(makeJsonResponse({
+        success: true,
+        passkey: { id: 'credential-2', name: 'iPhone' },
+        tokens: REPLACEMENT,
+      }))
+      .mockResolvedValueOnce(makeJsonResponse({ passkeys: [{ id: 'credential-2', name: 'iPhone', lastUsedAt: null }] }));
+    createPasskeyCredentialMock.mockResolvedValueOnce(credential);
+
+    render(<ProfilePage initialUser={USER} />);
+    await addPasskey();
+
+    await waitFor(() => {
+      expect(commitReissuedSessionIfCurrentMock).toHaveBeenCalledWith(sessionGeneration, REPLACEMENT);
+    });
+    expect(await screen.findByText('Passkey added')).toBeTruthy();
+  });
+
+  // Covers both ways the API can omit `tokens`: an older build that never
+  // returned one, and the post-commit install failure where it deliberately
+  // withholds the replacement (the refresh JTI was never bound, so the access
+  // token would die at its first refresh).
+  it('does not try to adopt a registration session the API did not return', async () => {
+    fetchWithAuthMock
+      .mockResolvedValueOnce(makeJsonResponse({ passkeys: [] }))
+      .mockResolvedValueOnce(makeJsonResponse({ options: registrationOptions }))
+      .mockResolvedValueOnce(makeJsonResponse({ success: true, passkey: { id: 'credential-2', name: 'iPhone' } }))
+      .mockResolvedValueOnce(makeJsonResponse({ passkeys: [{ id: 'credential-2', name: 'iPhone', lastUsedAt: null }] }));
+    createPasskeyCredentialMock.mockResolvedValueOnce(credential);
+
+    render(<ProfilePage initialUser={USER} />);
+    await addPasskey();
+
+    expect(await screen.findByText('Passkey added')).toBeTruthy();
+    expect(commitReissuedSessionIfCurrentMock).not.toHaveBeenCalled();
+  });
+
+  it('installs the replacement session returned by the passkey delete', async () => {
+    fetchWithAuthMock
+      .mockResolvedValueOnce(makeJsonResponse({
+        passkeys: [{ id: 'credential-1', name: 'MacBook Touch ID', lastUsedAt: null }],
+      }))
+      .mockResolvedValueOnce(makeJsonResponse({ success: true, tokens: REPLACEMENT }));
+
+    render(<ProfilePage initialUser={USER} />);
+    await screen.findByText('MacBook Touch ID');
+    fireEvent.change(screen.getByLabelText(/Current password/i, { selector: '#passkey-password' }), {
+      target: { value: 'current-password' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => {
+      expect(commitReissuedSessionIfCurrentMock).toHaveBeenCalledWith(sessionGeneration, REPLACEMENT);
+    });
+    expect(await screen.findByText('Passkey deleted')).toBeTruthy();
+  });
+
+  it('still reports the deletion when the session moved on and the replacement is refused', async () => {
+    // A logout/re-login raced the request: the store refuses the stale-generation
+    // commit. The passkey is already gone server-side, so the outcome still has
+    // to be shown rather than surfaced as a failure the user would retry.
+    commitReissuedSessionIfCurrentMock.mockReturnValue(false);
+    fetchWithAuthMock
+      .mockResolvedValueOnce(makeJsonResponse({
+        passkeys: [{ id: 'credential-1', name: 'MacBook Touch ID', lastUsedAt: null }],
+      }))
+      .mockResolvedValueOnce(makeJsonResponse({ success: true, tokens: REPLACEMENT }));
+
+    render(<ProfilePage initialUser={USER} />);
+    await screen.findByText('MacBook Touch ID');
+    fireEvent.change(screen.getByLabelText(/Current password/i, { selector: '#passkey-password' }), {
+      target: { value: 'current-password' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    expect(await screen.findByText('Passkey deleted')).toBeTruthy();
+  });
+
+  it('does not try to adopt a delete session the API did not return', async () => {
+    fetchWithAuthMock
+      .mockResolvedValueOnce(makeJsonResponse({
+        passkeys: [{ id: 'credential-1', name: 'MacBook Touch ID', lastUsedAt: null }],
+      }))
+      .mockResolvedValueOnce(makeJsonResponse({ success: true }));
+
+    render(<ProfilePage initialUser={USER} />);
+    await screen.findByText('MacBook Touch ID');
+    fireEvent.change(screen.getByLabelText(/Current password/i, { selector: '#passkey-password' }), {
+      target: { value: 'current-password' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    expect(await screen.findByText('Passkey deleted')).toBeTruthy();
+    expect(commitReissuedSessionIfCurrentMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/settings/ProfilePage.passkeys.test.tsx
+++ b/apps/web/src/components/settings/ProfilePage.passkeys.test.tsx
@@ -82,7 +82,11 @@ describe('ProfilePage passkey management', () => {
     fetchWithAuthMock
       .mockResolvedValueOnce(makeJsonResponse({ passkeys: [] }))
       .mockResolvedValueOnce(makeJsonResponse({ options: registrationOptions }))
-      .mockResolvedValueOnce(makeJsonResponse({ passkey: { id: 'credential-1', name: 'MacBook Touch ID' } }))
+      // #5038: register/verify now always returns a replacement session.
+      .mockResolvedValueOnce(makeJsonResponse({
+        passkey: { id: 'credential-1', name: 'MacBook Touch ID' },
+        tokens: { accessToken: 'reissued-access-token', expiresInSeconds: 900 },
+      }))
       .mockResolvedValueOnce(makeJsonResponse({
         passkeys: [{ id: 'credential-1', name: 'MacBook Touch ID', lastUsedAt: null }],
       }));
@@ -133,7 +137,11 @@ describe('ProfilePage passkey management', () => {
       .mockResolvedValueOnce(makeJsonResponse({
         passkeys: [{ id: 'credential-1', name: 'MacBook Touch ID', lastUsedAt: null }],
       }))
-      .mockResolvedValueOnce(makeJsonResponse({ success: true }));
+      // #5038: the delete now returns a replacement session too.
+      .mockResolvedValueOnce(makeJsonResponse({
+        success: true,
+        tokens: { accessToken: 'reissued-access-token', expiresInSeconds: 900 },
+      }));
 
     render(
       <ProfilePage
@@ -211,7 +219,11 @@ describe('ProfilePage passkey management', () => {
         if (u === '/auth/mfa/setup') return makeJsonResponse({ qrCodeDataUrl: 'data:image/png;base64,abc' });
         if (u === '/auth/passkeys/register/options') return makeJsonResponse({ options: REGISTRATION_OPTIONS });
         if (u === '/auth/passkeys/register/verify') {
-          return makeJsonResponse({ passkey: { id: 'credential-1', name: 'YubiKey' } });
+          // #5038: register/verify now always returns a replacement session.
+          return makeJsonResponse({
+            passkey: { id: 'credential-1', name: 'YubiKey' },
+            tokens: { accessToken: 'reissued-access-token', expiresInSeconds: 900 },
+          });
         }
         return makeJsonResponse({});
       });

--- a/apps/web/src/components/settings/ProfilePage.tsx
+++ b/apps/web/src/components/settings/ProfilePage.tsx
@@ -685,6 +685,20 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
     }
   };
 
+  /**
+   * #5038: these factor writes revoke every refresh family and hand the caller a
+   * REPLACEMENT session in the same response. The API withholds `tokens` only
+   * when its own post-commit install failed — the families are already gone, so
+   * THIS tab's session is dead even though the write succeeded. Say so with the
+   * success message rather than letting the user discover it as a disconnected
+   * /login?reason=session-expired on some later screen.
+   *
+   * A REFUSED commit is different and needs no notice: the store refuses only on
+   * a stale generation, which means a logout already moved the session on.
+   */
+  const withReauthNotice = (message: string, replacementAdopted: boolean) =>
+    (replacementAdopted ? message : `${message}. ${t('profilePage.signInAgainToContinue')}`);
+
   const handleMfaDisable = async (code: string, currentPassword: string): Promise<boolean> => {
     setMfaError(undefined);
     setMfaSuccess(undefined);
@@ -714,12 +728,13 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
       // /login?reason=session-expired by the very action they just took.
       // A refused commit (a logout raced the request) is not an error: MFA is
       // already off, so the success message still has to be shown.
-      if (data.tokens?.accessToken) {
+      const disableReplacementAdopted = Boolean(data.tokens?.accessToken);
+      if (disableReplacementAdopted) {
         useAuthStore.getState().commitReissuedSessionIfCurrent(generation, data.tokens);
       }
       setUser(prev => (prev ? { ...prev, mfaEnabled: false } : null));
       setRecoveryCodes(undefined);
-      setMfaSuccess(t('profilePage.multiFactorAuthenticationDisabled'));
+      setMfaSuccess(withReauthNotice(t('profilePage.multiFactorAuthenticationDisabled'), disableReplacementAdopted));
       return true;
     } catch (error) {
       setMfaError(error instanceof Error ? error.message : t('profilePage.failedToDisableMFA'));
@@ -854,7 +869,8 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
       // bounced to /login?reason=session-expired by the very action they just
       // took. A refused commit (a logout raced the request) is not an error —
       // the passkey is already registered, so success still has to be shown.
-      if (verifyData.tokens?.accessToken) {
+      const registerReplacementAdopted = Boolean(verifyData.tokens?.accessToken);
+      if (registerReplacementAdopted) {
         useAuthStore.getState().commitReissuedSessionIfCurrent(generation, verifyData.tokens);
       }
       setUser(prev => (prev ? { ...prev, mfaEnabled: true } : null));
@@ -868,7 +884,7 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
       if (Array.isArray(verifyData.recoveryCodes)) {
         setRecoveryCodes(verifyData.recoveryCodes);
       }
-      setPasskeySuccess(t('profilePage.passkeyAdded'));
+      setPasskeySuccess(withReauthNotice(t('profilePage.passkeyAdded'), registerReplacementAdopted));
       await loadPasskeys();
     } catch (error) {
       if (error instanceof Error && error.name === 'NotAllowedError') {
@@ -931,12 +947,13 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
       }
       // #5038: same contract as registration above — deleting a factor rotates
       // the caller's session rather than evicting it.
-      if (data.tokens?.accessToken) {
+      const deleteReplacementAdopted = Boolean(data.tokens?.accessToken);
+      if (deleteReplacementAdopted) {
         useAuthStore.getState().commitReissuedSessionIfCurrent(generation, data.tokens);
       }
       setPasskeys(prev => prev.filter(passkey => passkey.id !== passkeyId));
       setPasskeyPassword('');
-      setPasskeySuccess(t('profilePage.passkeyDeleted'));
+      setPasskeySuccess(withReauthNotice(t('profilePage.passkeyDeleted'), deleteReplacementAdopted));
     } catch (error) {
       setPasskeyError(error instanceof Error ? error.message : t('profilePage.failedToDeletePasskey'));
     } finally {

--- a/apps/web/src/components/settings/ProfilePage.tsx
+++ b/apps/web/src/components/settings/ProfilePage.tsx
@@ -808,6 +808,9 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
       // (the server calls resolveEnrollmentStepUp there with
       // `passwordAlreadyProven`), so re-sending the plaintext password would be
       // a second exposure buying nothing.
+      // Captured before the requests so a logout that races them is detectable
+      // when the replacement session comes back (#5038).
+      const generation = useAuthStore.getState().sessionGeneration;
       const optionsProof = isPasswordless
         ? { ssoReauthGrantId }
         : { currentPassword: passkeyPassword };
@@ -842,6 +845,18 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
         );
       }
 
+      // #5038: registering a passkey rotates the SESSION too — the API advances
+      // mfa_epoch and revokes every refresh family so no OTHER session survives
+      // the account's factor set changing, and hands this caller a replacement
+      // in the same response. Adopt it (the refresh/CSRF cookies came with it);
+      // keeping the pre-registration token means the next request 401s on the
+      // stale `mep`, its refresh fails against a revoked family, and the user is
+      // bounced to /login?reason=session-expired by the very action they just
+      // took. A refused commit (a logout raced the request) is not an error —
+      // the passkey is already registered, so success still has to be shown.
+      if (verifyData.tokens?.accessToken) {
+        useAuthStore.getState().commitReissuedSessionIfCurrent(generation, verifyData.tokens);
+      }
       setUser(prev => (prev ? { ...prev, mfaEnabled: true } : null));
       setPasskeyName('');
       setPasskeyPassword('');
@@ -902,6 +917,8 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
       setPasskeyError(t('profilePage.currentPasswordIsRequiredToDeleteAPasskey'));
       return;
     }
+    // Captured before the request so a logout that races it is detectable.
+    const generation = useAuthStore.getState().sessionGeneration;
     try {
       setMutatingPasskeyId(passkeyId);
       const response = await fetchWithAuth(`/auth/passkeys/${encodeURIComponent(passkeyId)}`, {
@@ -911,6 +928,11 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
       const data = await response.json().catch(() => ({}));
       if (!response.ok) {
         throw new Error(data.error ?? data.message ?? t('profilePage.failedToDeletePasskeyHttp', { status: response.status }));
+      }
+      // #5038: same contract as registration above — deleting a factor rotates
+      // the caller's session rather than evicting it.
+      if (data.tokens?.accessToken) {
+        useAuthStore.getState().commitReissuedSessionIfCurrent(generation, data.tokens);
       }
       setPasskeys(prev => prev.filter(passkey => passkey.id !== passkeyId));
       setPasskeyPassword('');

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -3320,6 +3320,7 @@
     "passkeyRenamed": "Passkey umbenannt",
     "currentPasswordIsRequiredToDeleteAPasskey": "Zum Löschen eines Passkeys ist das aktuelle Passwort erforderlich",
     "passkeyDeleted": "Passkey gelöscht",
+    "signInAgainToContinue": "Melden Sie sich erneut an, um fortzufahren.",
     "failedToLoadPasskeys": "Passkeys konnten nicht geladen werden",
     "failedToUpdateProfile": "Profil konnte nicht aktualisiert werden",
     "failedToUploadAvatar": "Avatar konnte nicht hochgeladen werden",

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -3320,6 +3320,7 @@
     "passkeyRenamed": "Passkey renamed",
     "currentPasswordIsRequiredToDeleteAPasskey": "Current password is required to delete a passkey",
     "passkeyDeleted": "Passkey deleted",
+    "signInAgainToContinue": "Sign in again to continue.",
     "failedToLoadPasskeys": "Failed to load passkeys",
     "failedToUpdateProfile": "Failed to update profile",
     "failedToUploadAvatar": "Failed to upload avatar",

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -3320,6 +3320,7 @@
     "passkeyRenamed": "Clave de acceso renombrada",
     "currentPasswordIsRequiredToDeleteAPasskey": "Se requiere la contraseña actual para eliminar una clave de acceso",
     "passkeyDeleted": "Clave de acceso eliminada",
+    "signInAgainToContinue": "Inicia sesión de nuevo para continuar.",
     "failedToLoadPasskeys": "No se pudieron cargar las claves de acceso",
     "failedToUpdateProfile": "No se pudo actualizar el perfil",
     "failedToUploadAvatar": "No se pudo cargar el avatar",

--- a/apps/web/src/locales/fr-CA/settings.json
+++ b/apps/web/src/locales/fr-CA/settings.json
@@ -3315,6 +3315,7 @@
     "passkeyRenamed": "Passkey renommé",
     "currentPasswordIsRequiredToDeleteAPasskey": "Un mot de passe actuel est nécessaire pour supprimer une clé d’accès",
     "passkeyDeleted": "Clé d’accès supprimée",
+    "signInAgainToContinue": "Connectez-vous de nouveau pour continuer.",
     "failedToLoadPasskeys": "Impossible de charger les clés d’accès",
     "failedToUpdateProfile": "Impossible de mettre à jour le profil",
     "failedToUploadAvatar": "Impossible de téléverser l’avatar",

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -3320,6 +3320,7 @@
     "passkeyRenamed": "Passkey renommé",
     "currentPasswordIsRequiredToDeleteAPasskey": "Un mot de passe actuel est nécessaire pour supprimer une clé d’accès",
     "passkeyDeleted": "Clé d’accès supprimée",
+    "signInAgainToContinue": "Reconnectez-vous pour continuer.",
     "failedToLoadPasskeys": "Impossible de charger les clés d’accès",
     "failedToUpdateProfile": "Impossible de mettre à jour le profil",
     "failedToUploadAvatar": "Impossible de télécharger l’avatar",

--- a/apps/web/src/locales/it-IT/settings.json
+++ b/apps/web/src/locales/it-IT/settings.json
@@ -3315,6 +3315,7 @@
     "passkeyRenamed": "Passkey rinominata",
     "currentPasswordIsRequiredToDeleteAPasskey": "La password attuale è obbligatoria per eliminare una passkey",
     "passkeyDeleted": "Passkey eliminata",
+    "signInAgainToContinue": "Accedi di nuovo per continuare.",
     "failedToLoadPasskeys": "Caricamento passkey non riuscito",
     "failedToUpdateProfile": "Aggiornamento profilo non riuscito",
     "failedToUploadAvatar": "Caricamento avatar non riuscito",

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -3320,6 +3320,7 @@
     "passkeyRenamed": "Chave de acesso renomeada",
     "currentPasswordIsRequiredToDeleteAPasskey": "A senha atual é necessária para excluir uma chave de acesso",
     "passkeyDeleted": "Chave de acesso excluída",
+    "signInAgainToContinue": "Entre novamente para continuar.",
     "failedToLoadPasskeys": "Falha ao carregar as chaves de acesso",
     "failedToUpdateProfile": "Falha ao atualizar o perfil",
     "failedToUploadAvatar": "Falha ao enviar avatar",

--- a/apps/web/src/locales/tr-TR/settings.json
+++ b/apps/web/src/locales/tr-TR/settings.json
@@ -3320,6 +3320,7 @@
     "passkeyRenamed": "Geçiş anahtarı yeniden adlandırıldı",
     "currentPasswordIsRequiredToDeleteAPasskey": "Bir şifreyi silmek için mevcut şifre gerekli",
     "passkeyDeleted": "Şifre silindi",
+    "signInAgainToContinue": "Devam etmek için yeniden oturum açın.",
     "failedToLoadPasskeys": "Şifre anahtarları yüklenemedi",
     "failedToUpdateProfile": "Profil güncellenemedi",
     "failedToUploadAvatar": "Avatar yüklenemedi",

--- a/docs/release-notes/next-release-draft.md
+++ b/docs/release-notes/next-release-draft.md
@@ -184,3 +184,10 @@ bookkeeper instead of rewriting a QuickBooks receipt.
 
 ---
 
+## Passkey register/delete keeps the caller signed in (#5038)
+
+**Self-Hosting / Upgrade Notes.**
+- Behaviour change (API), no migration and no new env vars: registering or deleting a passkey still advances `mfa_epoch` and revokes every refresh family — every OTHER session is signed out — but the calling session is now REPLACED in the same response instead of evicted (it previously bounced the user to `/login?reason=session-expired` by their own action). `POST /auth/passkeys/register/verify` now returns `tokens.accessToken` on **both** branches (previously only on the first-factor enrollment) and `DELETE /auth/passkeys/:id` now returns it too, alongside rotated refresh/CSRF cookies the client must adopt; both can now answer **409** (another authentication issuance is in flight, or the factor set changed concurrently — nothing was written) and **428** (the client auth binding must be rotated first) from the shared auth-issuance admission path, replacing register's old bespoke 409. `tokens` is withheld on the rare post-commit install failure, in which case the client must re-authenticate.
+
+---
+


### PR DESCRIPTION
## Problem

`apps/api/src/routes/auth/passkeys.ts` still routed the passkey **register** (secondary-factor branch) and **delete** writes through `invalidateMfaAssuranceAfterFactorChange`. That primitive advances `mfa_epoch` and revokes every refresh family — correct, SR2-07 — but it never re-issues the **actor**. The caller's own access token goes stale on its own bump, the refresh cookie it would retry with belongs to a family revoked in the same transaction, so `fetchWithAuth`'s refresh fails and the web client hard-redirects to `/login?reason=session-expired` the moment the user adds or removes a passkey.

Exactly the class #4934 / #5008 fixed for `/mfa/disable`.

## Fix

Both routes now go through the session-replacement primitives in `services/mfaEnrollmentSession.ts`. Every **other** session still dies; the caller's is replaced in the same response (rotated refresh/CSRF cookies plus `tokens.accessToken`).

- **New entry point `completeAdditionalMfaFactorEnrollment`** — the fourth factor-write shape: a SECONDARY addition on an already-protected account (`expectedMfaEnabled: true`, no code set). Like the removal shape it installs no recovery codes — the account keeps the set it already holds — so the code pair is absent from its input **type** rather than by convention, per the #5008 review's rule. The private core's install/rotate/remove discriminant gains `add`.
- **Passkey delete** uses the existing `completeMfaFactorRemoval`.
- Both new call sites **carry the caller's own assurance forward, never elevate it**, and take the device binding from the previously-signed `mdid` claim, never the forgeable request header (SR-001).
- **Post-commit install guarded on all three passkey factor writes** via one `installReplacementSession` helper. The factor write is already committed by then, so an install failure must not become a 500 the user retries — a retried registration duplicates a credential, a retried delete answers 404. It reports (Sentry + log) and steps over; the tokens are then withheld, because the refresh JTI was never bound and the access token would die at its first refresh. The initial-enrollment branch previously left this unguarded, which could have swallowed a one-time recovery-code set behind a 500; it now still returns the codes.
- **Web**: `ProfilePage` adopts the replacement on both add-passkey and delete-passkey, mirroring the `/mfa/disable` and recovery-code rotation handlers. A refused commit (a logout raced the request) is not an error — the write already landed, so the outcome is still shown.

## Wire contract (needs a release note)

- `POST /auth/passkeys/register/verify` now returns `tokens: { accessToken, expiresInSeconds }` on **both** branches (previously only on initial enrollment).
- `DELETE /auth/passkeys/:id` now returns `tokens` too.
- Both can now answer **409** (lost issuance race / concurrent factor write) and **428** (auth-binding rotation required) from the auth-issuance admission path. The register branch's old bespoke `409 "Authentication changed. Please sign in again."` is replaced by the shared admission response.

Client sweep: the only production consumers are `ProfilePage.tsx` (both endpoints, updated here) and `stores/auth.ts`'s `apiEnrollPasskey` (register/verify, forced-MFA enrollment — initial-enrollment branch only, still receives `recoveryCodes` + `tokens`, unchanged). No mobile/portal/viewer/helper/agent/e2e consumers. Neither endpoint is in `openapi.ts`, so there is no spec to update.

## Tests

Red-first: 10 new API route tests and 5 new web tests were written against the unfixed code and watched fail (8 API failures plus 2 that only became discriminating once `bindIssuedUserSession` call assertions were added; both web token-adoption tests fail on a reverted `ProfilePage.tsx`).

- `apps/api/src/routes/auth.passkeys.test.ts` — new `#5038` describe: caller re-issued on both writes, cookies not cleared and carrying the replacement refresh token, no recovery-code rotation on a secondary add, signed-binding + assurance carry-forward (with a forged `x-breeze-mobile-device-id` header ignored), post-commit install failure still reports success with tokens withheld, lost issuance race → 409 + `cancelAuthIssuance`, and the last-passkey delete that turns MFA off.
- `apps/web/src/components/settings/ProfilePage.passkeySession.test.tsx` — new file: replacement adopted on register and delete, refused stale-generation commit still shows the outcome, and no adoption attempt when the API omits `tokens`.

Green: `auth.passkeys.test.ts` 59/59; `auth.test.ts` + `phone.test.ts` + `mfaFactorReset` + `mfaAssurance` 167/167; `mfaEnrollmentSession.test.ts` + `userSession.callers.test.ts` 29/29; web `ProfilePage*` 64/64. `tsc --noEmit` clean on `apps/api`.

## Follow-up (not in scope)

`routes/auth/phone.ts` (`phone-replacement`) is the last route still on `invalidateMfaAssuranceAfterFactorChange` for a caller-facing factor write, and the three enrollment call sites still read `mobileDeviceId` from the request header rather than `carryForwardBinding`. Both are pre-existing and left alone here.

Closes #5038

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEX58GdCWkLHA9M8nfataF
