### PR TITLE
fix(api): canonicalise MAC comparisons in UniFi cloud sync (#5102)

### DIFF
--- a/apps/api/src/services/unifi/unifiMac.ts
+++ b/apps/api/src/services/unifi/unifiMac.ts
@@ -1,0 +1,30 @@
+import { sql } from 'drizzle-orm';
+import { discoveredAssets } from '../../db/schema';
+
+// Canonical MAC form for cross-source matching: lowercase, colon-separated.
+// discovered_assets stores colon-lowercase; UniFi may report uppercase/hyphenated,
+// so we normalize both sides before comparing (and store the canonical form).
+//
+// Shared by unifiTelemetryService.ts and unifiSyncService.ts (#5096, #5102) —
+// every UniFi producer that writes/matches discovered_assets.mac_address must
+// use the exact same canonicalisation, or a controller reporting a different
+// casing than a previous writer will silently fail to match and either fall
+// through to the IP fallback or create a duplicate asset.
+export function normalizeMac(mac: string): string {
+  return mac.trim().toLowerCase().replace(/-/g, ':');
+}
+
+// Nullable variant for callers where mac is optional on the wire.
+// An empty/whitespace mac must collapse to null, not to '', so it never matches
+// a blank macAddress row.
+export function canonicalMac(mac: string | null | undefined): string | null {
+  if (!mac) return null;
+  const normalized = normalizeMac(mac);
+  return normalized.length > 0 ? normalized : null;
+}
+
+// Both sides of a MAC comparison must be canonicalised. discovered_assets rows
+// are written by several producers (agent discovery, UniFi sync, UniFi telemetry),
+// and only the app layer enforces the format — there is no DB CHECK — so a row
+// stored uppercase or hyphenated is possible and must still match.
+export const canonicalAssetMac = sql`lower(replace(${discoveredAssets.macAddress}, '-', ':'))`;

--- a/apps/api/src/services/unifi/unifiSyncService.test.ts
+++ b/apps/api/src/services/unifi/unifiSyncService.test.ts
@@ -419,6 +419,43 @@ describe('unifiSyncService.syncIntegration', () => {
     const assetUpdate = writes.updates.find((w) => w.table === discoveredAssets);
     expect(assetUpdate?.values.macAddress).toBe('aa:bb:cc:dd:ee:ff');
   });
+
+  // Twin of unifiTelemetryService.test.ts's "normalizes device MAC
+  // (uppercase/hyphen) for asset linking and storage" (#5096/#5087) — the
+  // OTHER direction from the test above. There the stored key was
+  // non-canonical and the incoming mac already canonical, which does not
+  // exercise canonicalMac(device.mac) on the JS side (an already-canonical
+  // input is a no-op for that call). Here the incoming mac is non-canonical
+  // and the stored row is already canonical, so only a bound query parameter
+  // that was actually run through canonicalMac() can match.
+  it('links a device when the INCOMING mac is non-canonical (#5102, twin of #5096)', async () => {
+    const { writes, db } = scriptedDb({
+      mappings: [BASE_MAPPING],
+      assetByMac: { 'aa:bb:cc:dd:ee:ff': { id: 'asset-9' } },
+    });
+    const client = fakeClient([
+      {
+        ...NET_NEW_DEVICE,
+        mac: 'AA-BB-CC-DD-EE-FF', // controller reports uppercase/hyphenated
+        ip: '10.0.0.99', // deliberately does not match any asset — mac must be what links it
+      },
+    ]);
+
+    const result = await syncIntegration({ db, client }, BASE_INTEGRATION, 'manual');
+
+    expect(result.status).toBe('success');
+
+    const assetInserts = writes.inserts.filter((w) => w.table === discoveredAssets);
+    expect(assetInserts).toHaveLength(0);
+
+    const deviceInserts = writes.inserts.filter((w) => w.table === unifiDevices);
+    expect(deviceInserts).toHaveLength(1);
+    expect(deviceInserts[0]!.values.discoveredAssetId).toBe('asset-9');
+
+    // Stored canonical (lowercase, colon-separated), matching the telemetry path.
+    const assetUpdate = writes.updates.find((w) => w.table === discoveredAssets);
+    expect(assetUpdate?.values.macAddress).toBe('aa:bb:cc:dd:ee:ff');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -523,6 +560,10 @@ describe('unifiSyncService — discovered_asset type_source precedence (#3011)',
     expect(renderSql(set.assetType)).toBe(
       `${MANUAL_GUARD_SQL}$8 else "discovered_assets"."asset_type" end`,
     );
+    // #5102: a device with no mac must not degrade into '' on the enrich write
+    // either (which would match a blank-mac row) — canonicalMac(null) is null,
+    // and macAddress: mac ?? undefined must stay undefined, not ''.
+    expect(set.macAddress).toBeUndefined();
   });
 
   it('leaves both type columns alone when the sync cannot classify the device', async () => {

--- a/apps/api/src/services/unifi/unifiSyncService.test.ts
+++ b/apps/api/src/services/unifi/unifiSyncService.test.ts
@@ -44,7 +44,31 @@ function fakeClient(devices: any[]): UnifiClient {
 
 type WriteRecord = { table: any; values: any; conflictSet?: any; conflictTarget?: any };
 
-function scriptedDb(opts: { mappings: any[]; existingDevices?: any[]; existingAsset?: any }) {
+// Recursively pull every string out of a drizzle where-clause tree (bound
+// param values AND the literal template-string chunks of any `sql` fragment),
+// so the mock can tell whether a query wrapped a column in
+// lower(replace(...)) without needing to render real SQL. Mirrors the harness
+// in unifiTelemetryService.test.ts (#5096) — kept as a local copy per that
+// file's own comment convention (helpers may be duplicated locally).
+function collectStrings(value: any, seen = new WeakSet<object>()): string[] {
+  if (typeof value === 'string') return [value];
+  if (value === null || value === undefined || typeof value !== 'object') return [];
+  if (seen.has(value)) return [];
+  seen.add(value);
+  if (Array.isArray(value)) return value.flatMap((item) => collectStrings(item, seen));
+  return Object.values(value).flatMap((item) => collectStrings(item, seen));
+}
+
+function scriptedDb(opts: {
+  mappings: any[];
+  existingDevices?: any[];
+  existingAsset?: any;
+  // Keyed by the STORED (possibly non-canonical) mac_address value. When set,
+  // a discoveredAssets select is resolved by matching bound query strings
+  // against these keys — canonicalising the key first iff the query itself
+  // wrapped the column in lower(replace(...)), exactly like Postgres would.
+  assetByMac?: Record<string, any>;
+}) {
   const writes: { inserts: WriteRecord[]; updates: WriteRecord[] } = {
     inserts: [],
     updates: [],
@@ -53,6 +77,7 @@ function scriptedDb(opts: { mappings: any[]; existingDevices?: any[]; existingAs
   function makeChain(ctx: {
     op: 'select' | 'insert' | 'update' | 'delete';
     table?: any;
+    whereArgs?: any[];
     insertValues?: any;
     setValues?: any;
     conflictSet?: any;
@@ -65,7 +90,8 @@ function scriptedDb(opts: { mappings: any[]; existingDevices?: any[]; existingAs
         ctx.table = table;
         return chain;
       },
-      where(..._args: any[]) {
+      where(...args: any[]) {
+        ctx.whereArgs = args;
         return chain;
       },
       limit(_n: number) {
@@ -117,7 +143,19 @@ function scriptedDb(opts: { mappings: any[]; existingDevices?: any[]; existingAs
               } else if (ctx.table === unifiDevices) {
                 result = opts.existingDevices ?? [];
               } else if (ctx.table === discoveredAssets) {
-                result = opts.existingAsset ? [opts.existingAsset] : [];
+                if (opts.assetByMac) {
+                  const strings = collectStrings(ctx.whereArgs);
+                  const queryCanonicalises = strings.some(
+                    (s) => typeof s === 'string' && s.includes('lower(replace('),
+                  );
+                  const canonicalise = (v: string) => v.trim().toLowerCase().replace(/-/g, ':');
+                  const matchKey = Object.keys(opts.assetByMac).find((key) =>
+                    strings.includes(queryCanonicalises ? canonicalise(key) : key),
+                  );
+                  result = matchKey ? [opts.assetByMac[matchKey]] : [];
+                } else {
+                  result = opts.existingAsset ? [opts.existingAsset] : [];
+                }
               } else {
                 // unifiSyncRuns select, or any other table
                 result = [];
@@ -343,6 +381,43 @@ describe('unifiSyncService.syncIntegration', () => {
     const deviceInserts = writes.inserts.filter((w) => w.table === unifiDevices);
     expect(deviceInserts).toHaveLength(1);
     expect(deviceInserts[0]!.values.discoveredAssetId).toBeNull();
+  });
+
+  // Twin of unifiTelemetryService.test.ts's "links a device when the STORED
+  // discovered_assets mac is non-canonical" (#5096). The cloud-sync path
+  // (this file) had the same raw eq(macAddress, device.mac) comparison and
+  // was not fixed by #5096 — #5102 closes that gap.
+  it('links a device when the STORED discovered_assets mac is non-canonical (#5102, twin of #5096)', async () => {
+    const { writes, db } = scriptedDb({
+      mappings: [BASE_MAPPING],
+      // Legacy row written before canonicalisation existed — uppercase/hyphenated.
+      assetByMac: { 'AA-BB-CC-DD-EE-FF': { id: 'asset-legacy' } },
+    });
+    const client = fakeClient([
+      {
+        ...NET_NEW_DEVICE,
+        mac: 'aa:bb:cc:dd:ee:ff', // already-canonical incoming mac
+        ip: '10.0.0.99', // deliberately does not match any asset — mac must be what links it
+      },
+    ]);
+
+    const result = await syncIntegration({ db, client }, BASE_INTEGRATION, 'manual');
+
+    expect(result.status).toBe('success');
+
+    // Linked to the existing legacy asset via the canonicalised mac match —
+    // a missed match would create a duplicate discovered_assets row.
+    const assetInserts = writes.inserts.filter((w) => w.table === discoveredAssets);
+    expect(assetInserts).toHaveLength(0);
+
+    const deviceInserts = writes.inserts.filter((w) => w.table === unifiDevices);
+    expect(deviceInserts).toHaveLength(1);
+    expect(deviceInserts[0]!.values.discoveredAssetId).toBe('asset-legacy');
+
+    // The enrich write should also store the canonical form going forward, so
+    // this row stops being the non-canonical outlier for future lookups.
+    const assetUpdate = writes.updates.find((w) => w.table === discoveredAssets);
+    expect(assetUpdate?.values.macAddress).toBe('aa:bb:cc:dd:ee:ff');
   });
 });
 

--- a/apps/api/src/services/unifi/unifiSyncService.ts
+++ b/apps/api/src/services/unifi/unifiSyncService.ts
@@ -4,6 +4,7 @@ import { unifiSiteMappings, unifiDevices, unifiSyncRuns, discoveredAssets } from
 import { buildClassificationWrite, type ClassificationWrite } from '../discoveredAssetClassification';
 import type { DbExecutor } from './unifiConnectionService';
 import type { UnifiClient, UnifiDeviceDto, UnifiIspMetrics } from './unifiClient';
+import { canonicalMac, canonicalAssetMac } from './unifiMac';
 
 export interface SyncRunResult {
   hostsSeen: number;
@@ -106,16 +107,20 @@ async function reconcileDiscoveredAsset(
   // it knows the exact model, so it outranks the agent scan's OUI vendor guess
   // that used to rewrite UniFi switches to access_point (#3187).
 
-  // 1. Match by (org_id, mac) first — the stable identifier.
+  // 1. Match by (org_id, mac) first — the stable identifier. Canonicalise both
+  // sides, exactly as the telemetry path does (#5096) — a controller reporting
+  // uppercase/hyphenated MACs, or an asset row written non-canonically by
+  // another producer, must still match.
+  const mac = canonicalMac(device.mac);
   let existing: { id: string } | null = null;
-  if (device.mac) {
+  if (mac) {
     const byMac = await db
       .select({ id: discoveredAssets.id })
       .from(discoveredAssets)
       .where(
         and(
           eq(discoveredAssets.orgId, mapping.orgId),
-          eq(discoveredAssets.macAddress, device.mac),
+          eq(canonicalAssetMac, mac),
         ),
       )
       .limit(1);
@@ -140,7 +145,10 @@ async function reconcileDiscoveredAsset(
   // asset_type is deliberately NOT in here — it is applied per-branch below so a
   // manual override survives the sync (#3011).
   const enrich = {
-    macAddress: device.mac ?? undefined,
+    // Store the canonical form: this row is the one every other producer
+    // matches against, so writing the source's casing here would poison
+    // future lookups (mirrors linkTelemetryDeviceToAsset in unifiTelemetryService.ts).
+    macAddress: mac ?? undefined,
     hostname: device.name ?? undefined,
     manufacturer: 'Ubiquiti',
     model: device.model ?? undefined,

--- a/apps/api/src/services/unifi/unifiTelemetryService.ts
+++ b/apps/api/src/services/unifi/unifiTelemetryService.ts
@@ -1,7 +1,8 @@
-import { and, eq, sql } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { unifiCollectors, unifiSiteMappings, unifiDeviceTelemetry, unifiClients, discoveredAssets } from '../../db/schema';
 import type { DbExecutor } from './unifiConnectionService';
 import { upsertControllerSites } from './unifiControllerSiteService';
+import { normalizeMac, canonicalMac, canonicalAssetMac } from './unifiMac';
 
 // Fields the wire schema marks optional are `T | null | undefined` here, matching
 // what the zod validator infers (the agent omits zero-value fields via omitempty).
@@ -30,27 +31,9 @@ export interface TelemetryPayload {
 }
 export interface ReconcileResult { devicesUpserted: number; devicesStaled: number; clientsUpserted: number; clientsStaled: number; }
 
-// Canonical MAC form for cross-source matching: lowercase, colon-separated.
-// discovered_assets stores colon-lowercase; UniFi may report uppercase/hyphenated,
-// so we normalize both sides before comparing (and store the canonical form).
-function normalizeMac(mac: string): string {
-  return mac.trim().toLowerCase().replace(/-/g, ':');
-}
-
-// Nullable variant for the device path, where mac is optional on the wire.
-// An empty/whitespace mac must collapse to null, not to '', so it never matches
-// a blank macAddress row.
-function canonicalMac(mac: string | null | undefined): string | null {
-  if (!mac) return null;
-  const normalized = normalizeMac(mac);
-  return normalized.length > 0 ? normalized : null;
-}
-
-// Both sides of a MAC comparison must be canonicalised. discovered_assets rows
-// are written by several producers (agent discovery, UniFi sync, this service),
-// and only the app layer enforces the format — there is no DB CHECK — so a row
-// stored uppercase or hyphenated is possible and must still match.
-const canonicalAssetMac = sql`lower(replace(${discoveredAssets.macAddress}, '-', ':'))`;
+// normalizeMac / canonicalMac / canonicalAssetMac now live in ./unifiMac —
+// shared with unifiSyncService.ts (#5096, #5102) so every UniFi producer
+// canonicalises discovered_assets.mac_address matches identically.
 
 // Extract IP from a telemetry device's raw payload.
 // UniFi device JSON uses `ipAddress`; guard against other field names too.


### PR DESCRIPTION
## Summary

PR #5096 introduced a MAC canonicaliser for the UniFi **telemetry** path (`trim().toLowerCase()`, `-` → `:`, wrapping the stored `discovered_assets.mac_address` column with `lower(replace(...))` in the WHERE clause) so a controller reporting a different casing than a previously-written row still matches.

The UniFi **cloud-sync** path (`apps/api/src/services/unifi/unifiSyncService.ts`) had the identical raw `eq(discoveredAssets.macAddress, device.mac)` comparison with no canonicalisation on either side, and was not covered by #5096. A controller reporting `AA-BB-CC-...` or upper-case MACs there would never match an asset stored lower-case with colons, and would fall through to the IP fallback (or create a duplicate asset).

## Changes

- Extracted `normalizeMac` / `canonicalMac` / `canonicalAssetMac` out of `unifiTelemetryService.ts` into a new shared `apps/api/src/services/unifi/unifiMac.ts` module, so both UniFi producers use the exact same canonicalisation instead of near-duplicate logic drifting apart.
- `unifiSyncService.ts`'s `reconcileDiscoveredAsset` now canonicalises both the bound MAC value and the stored column (`eq(canonicalAssetMac, mac)`), matching the telemetry path's WHERE clause.
- The sync path's enrich write now stores the canonical form on `macAddress` (mirrors `linkTelemetryDeviceToAsset`'s "store the canonical form" behavior), so a legacy non-canonical row self-heals on its next successful sync.

## Test plan

- Added `unifiSyncService.test.ts`: *"links a device when the STORED discovered_assets mac is non-canonical (#5102, twin of #5096)"* — mirrors the equivalent `unifiTelemetryService.test.ts` regression test from #5096. Confirmed red against the pre-fix code (asserted duplicate asset creation), green after the fix.
- `cd apps/api && npx vitest run src/services/unifi/` — 7 files, 60 tests, all passing.
- `cd apps/api && npx tsc --noEmit` — clean.

Closes #5102

🤖 Generated with [Claude Code](https://claude.com/claude-code)