### PR TITLE
fix(api): serve the pinned agent version from the github-mode download route (#5159)

### DIFF
--- a/.github/workflows/ci-smoke-binary-source-github.yml
+++ b/.github/workflows/ci-smoke-binary-source-github.yml
@@ -202,6 +202,48 @@ jobs:
           jq -e '.manifest != null and (.manifest | length) > 0' /tmp/dl.json
           jq -e '.manifestSignature != null and (.manifestSignature | length) > 0' /tmp/dl.json
 
+      - name: Verify the returned URL is version-pinned and 302s to THAT release (#5159)
+        run: |
+          # #5159: the URL /agent-versions/:version/download hands back must
+          # resolve to the SAME release its checksum came from. Before the fix
+          # it was versionless and the route served whatever was promoted, so
+          # a pinned/unpromoted version got another release's bytes and the
+          # agent looped forever on a checksum mismatch it could never clear.
+          url=$(jq -er '.url' /tmp/dl.json)
+          case "$url" in
+            *"version=0.65.8"*) echo "OK — URL is pinned to the requested version" ;;
+            *)
+              echo "REGRESSION (#5159): expected ?version=0.65.8 in the returned URL, got: ${url}"
+              exit 1
+              ;;
+          esac
+
+          STATUS=$(curl -s -o /dev/null -w '%{http_code}' "$url")
+          if [ "$STATUS" != "302" ]; then
+            echo "Expected 302 from the version-pinned download URL; got ${STATUS}"
+            exit 1
+          fi
+          LOCATION=$(curl -s -o /dev/null -w '%{redirect_url}' "$url")
+          echo "Pinned redirect target: ${LOCATION}"
+          case "$LOCATION" in
+            *"/releases/download/v0.65.8/"*)
+              echo "OK — pinned URL redirects to the v0.65.8 release asset"
+              ;;
+            *)
+              echo "REGRESSION (#5159): pinned URL served a different release: ${LOCATION}"
+              exit 1
+              ;;
+          esac
+
+          # An unregistered version must 404, never fall back to the promoted
+          # release — silent substitution is the bug being fixed.
+          STATUS=$(curl -s -o /dev/null -w '%{http_code}' \
+            'http://localhost:3001/api/v1/agents/download/linux/amd64?version=0.0.0-not-registered')
+          if [ "$STATUS" != "404" ]; then
+            echo "Expected 404 for an unregistered ?version=; got ${STATUS}"
+            exit 1
+          fi
+
       - name: Verify /agents/download proxy route 302s to github
         run: |
           STATUS=$(curl -s -o /dev/null -w '%{http_code}' \

--- a/.github/workflows/ci-smoke-binary-source-github.yml
+++ b/.github/workflows/ci-smoke-binary-source-github.yml
@@ -270,6 +270,50 @@ jobs:
           esac
           shopt -u nocasematch
 
+      - name: Reproduce the #5159 divergence against a real database
+        env:
+          PGPASSWORD: breeze
+        run: |
+          # Everything above runs with ONE registered release, so the pinned
+          # and promoted versions coincide and the original bug cannot appear.
+          # Force them apart the way AGENT_AUTO_PROMOTE=false + an org
+          # agentVersionPins pilot does in production: promote a DIFFERENT
+          # version than the one the caller pins.
+          PSQL="psql -h localhost -U breeze -d breeze -v ON_ERROR_STOP=1"
+          $PSQL -c "INSERT INTO agent_versions (version, platform, architecture, component, download_url, checksum, file_size, edition, is_latest) SELECT '0.65.7', platform, architecture, component, download_url, checksum, file_size, edition, false FROM agent_versions WHERE component='agent' AND platform='linux' AND architecture='amd64' AND version='0.65.8' ON CONFLICT DO NOTHING;"
+          $PSQL -c "UPDATE agent_versions SET is_latest = (version='0.65.7') WHERE component='agent' AND platform='linux' AND architecture='amd64';"
+
+          # Guard the fixture itself: if the seed matched no row, the two
+          # assertions below would compare identical versions and pass
+          # vacuously.
+          PROMOTED=$(psql -h localhost -U breeze -d breeze -tAc \
+            "SELECT version FROM agent_versions WHERE component='agent' AND platform='linux' AND architecture='amd64' AND is_latest")
+          if [ "$PROMOTED" != "0.65.7" ]; then
+            echo "Fixture failed: expected 0.65.7 promoted, got '${PROMOTED}'"
+            exit 1
+          fi
+
+          # The versionless route follows the promotion.
+          PROMOTED_LOC=$(curl -s -o /dev/null -w '%{redirect_url}' \
+            'http://localhost:3001/api/v1/agents/download/linux/amd64')
+          echo "versionless -> ${PROMOTED_LOC}"
+          case "$PROMOTED_LOC" in
+            *"/releases/download/v0.65.7/"*) echo "OK — versionless serves the promoted release" ;;
+            *) echo "Expected the promoted v0.65.7 asset; got ${PROMOTED_LOC}"; exit 1 ;;
+          esac
+
+          # THE BUG: a pinned, deliberately UNPROMOTED version must still get
+          # its own bytes. Before the fix this returned the v0.65.7 asset
+          # while the agent held the v0.65.8 checksum, and the device sat in
+          # "Updating" forever.
+          PINNED_LOC=$(curl -s -o /dev/null -w '%{redirect_url}' \
+            'http://localhost:3001/api/v1/agents/download/linux/amd64?version=0.65.8')
+          echo "pinned -> ${PINNED_LOC}"
+          case "$PINNED_LOC" in
+            *"/releases/download/v0.65.8/"*) echo "OK — pinned, unpromoted version serves its OWN release" ;;
+            *) echo "REGRESSION (#5159): pinned v0.65.8 served ${PINNED_LOC}"; exit 1 ;;
+          esac
+
       - name: Stop API
         if: always()
         run: |

--- a/apps/api/src/routes/agentVersions.test.ts
+++ b/apps/api/src/routes/agentVersions.test.ts
@@ -832,6 +832,48 @@ describe("agentVersions routes", () => {
       }
     });
 
+    it("does NOT pin the \"unknown\" sentinel version, which is not a release tag (#5159)", async () => {
+      // binarySync stores the literal "unknown" for a locally-registered
+      // binary with no version file. Pinning it would build a URL the download
+      // route answers with a 404 ("vunknown" is not a release tag), where
+      // today it falls back to the env-resolved release and keeps working.
+      const rows = [
+        {
+          version: "unknown",
+          downloadUrl: "https://s3.example.com/agent-linux-amd64",
+          checksum: "a".repeat(64),
+          releaseManifest: null,
+          manifestSignature: null,
+          signingKeyId: null,
+          fileSize: BigInt(1),
+          releaseNotes: null,
+        },
+      ];
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue(rows),
+            }),
+          }),
+        }),
+      } as any);
+
+      process.env.PUBLIC_API_URL = "https://us.example.com";
+      try {
+        const res = await app.request(
+          "/agent-versions/latest?platform=linux&arch=amd64",
+        );
+        const body = await res.json();
+        expect(body.downloadUrl).toBe(
+          "https://us.example.com/api/v1/agents/download/linux/amd64",
+        );
+        expect(body.downloadUrl).not.toContain("unknown");
+      } finally {
+        delete process.env.PUBLIC_API_URL;
+      }
+    });
+
     it("does NOT pin the version in local mode, where the route serves one disk build (#5159)", async () => {
       // Local mode streams the single binary in the binaries volume and cannot
       // select a release; pinning there would turn a working download into a

--- a/apps/api/src/routes/agentVersions.test.ts
+++ b/apps/api/src/routes/agentVersions.test.ts
@@ -790,6 +790,90 @@ describe("agentVersions routes", () => {
       expect(body.releaseNotes).toBe("Bug fixes");
     });
 
+    it("pins the server-relative downloadUrl to the promoted row's version in github mode (#5159)", async () => {
+      // The versionless route resolves the promoted row, so this is normally
+      // the same release — but naming it removes the last way the checksum and
+      // the bytes can select different rows (a duplicate isLatest row breaking
+      // the ORDER BY tiebreak) and keeps the URL shape identical to the one
+      // /:version/download hands out.
+      const rows = [
+        {
+          version: "1.2.0",
+          downloadUrl: "https://s3.example.com/agent-1.2.0-linux-amd64",
+          checksum: "a".repeat(64),
+          releaseManifest: null,
+          manifestSignature: null,
+          signingKeyId: null,
+          fileSize: BigInt(1),
+          releaseNotes: null,
+        },
+      ];
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue(rows),
+            }),
+          }),
+        }),
+      } as any);
+
+      process.env.PUBLIC_API_URL = "https://us.example.com";
+      try {
+        const res = await app.request(
+          "/agent-versions/latest?platform=linux&arch=amd64",
+        );
+        const body = await res.json();
+        expect(body.downloadUrl).toBe(
+          "https://us.example.com/api/v1/agents/download/linux/amd64?version=1.2.0",
+        );
+      } finally {
+        delete process.env.PUBLIC_API_URL;
+      }
+    });
+
+    it("does NOT pin the version in local mode, where the route serves one disk build (#5159)", async () => {
+      // Local mode streams the single binary in the binaries volume and cannot
+      // select a release; pinning there would turn a working download into a
+      // 409 whenever the promoted row and the disk build differ.
+      const rows = [
+        {
+          version: "1.2.0",
+          downloadUrl: "https://s3.example.com/agent-1.2.0-linux-amd64",
+          checksum: "a".repeat(64),
+          releaseManifest: null,
+          manifestSignature: null,
+          signingKeyId: null,
+          fileSize: BigInt(1),
+          releaseNotes: null,
+        },
+      ];
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue(rows),
+            }),
+          }),
+        }),
+      } as any);
+
+      process.env.BINARY_SOURCE = "local";
+      process.env.PUBLIC_API_URL = "https://us.example.com";
+      try {
+        const res = await app.request(
+          "/agent-versions/latest?platform=linux&arch=amd64",
+        );
+        const body = await res.json();
+        expect(body.downloadUrl).toBe(
+          "https://us.example.com/api/v1/agents/download/linux/amd64",
+        );
+      } finally {
+        delete process.env.BINARY_SOURCE;
+        delete process.env.PUBLIC_API_URL;
+      }
+    });
+
     it("orders by created_at DESC, matching the resolver that serves the bytes (#3499)", async () => {
       // This endpoint hands out the checksum; services/promotedAgentVersion.ts
       // resolves the bytes it is verified against. Nothing in the schema
@@ -1086,7 +1170,7 @@ describe("agentVersions routes", () => {
         // passes. The actual binary is served via /agents/download/:os/:arch
         // (which 302s to github in BINARY_SOURCE=github mode).
         expect(body.url).toBe(
-          "https://us.example.com/api/v1/agents/download/windows/amd64",
+          "https://us.example.com/api/v1/agents/download/windows/amd64?version=1.0.0",
         );
         expect(body.checksum).toBe(checksum);
         // Manifest stays unmodified — its url field still references the
@@ -1144,7 +1228,7 @@ describe("agentVersions routes", () => {
         // rejects. It must resolve to the user-helper route, which is distinct
         // from the Tauri /helper app route.
         expect(body.url).toBe(
-          "https://us.example.com/api/v1/agents/download/user-helper/windows/amd64",
+          "https://us.example.com/api/v1/agents/download/user-helper/windows/amd64?version=1.0.0",
         );
         expect(body.url).not.toContain("github.com");
         expect(body.checksum).toBe(checksum);
@@ -1193,7 +1277,7 @@ describe("agentVersions routes", () => {
         expect(res.status).toBe(200);
         const body = await res.json();
         expect(body.url).toBe(
-          "https://us.example.com/api/v1/agents/download/darwin/arm64",
+          "https://us.example.com/api/v1/agents/download/darwin/arm64?version=1.0.0",
         );
       } finally {
         delete process.env.PUBLIC_API_URL;
@@ -1245,7 +1329,7 @@ describe("agentVersions routes", () => {
         // accepts it; the /agents/download/helper/:os/:arch route 302s to github
         // server-side, and the signed-manifest SHA-256 binds the bytes.
         expect(body.url).toBe(
-          "https://us.example.com/api/v1/agents/download/helper/windows/amd64",
+          "https://us.example.com/api/v1/agents/download/helper/windows/amd64?version=1.0.0",
         );
         // Manifest is unmodified; its url field still references the canonical
         // github asset. Checksum is the trust binding.
@@ -1298,7 +1382,7 @@ describe("agentVersions routes", () => {
         expect(res.status).toBe(200);
         const body = await res.json();
         expect(body.url).toBe(
-          "https://us.example.com/api/v1/agents/download/watchdog/linux/amd64",
+          "https://us.example.com/api/v1/agents/download/watchdog/linux/amd64?version=1.0.0",
         );
         expect(body.checksum).toBe(checksum);
         expect(body.manifest).toBe(signed.manifest);
@@ -1351,7 +1435,7 @@ describe("agentVersions routes", () => {
         expect(res.status).toBe(200);
         const body = await res.json();
         expect(body.url).toBe(
-          "https://us.example.com/api/v1/agents/download/backup/linux/amd64",
+          "https://us.example.com/api/v1/agents/download/backup/linux/amd64?version=1.0.0",
         );
         expect(body.checksum).toBe(checksum);
         expect(body.manifest).toBe(signed.manifest);
@@ -1426,7 +1510,7 @@ describe("agentVersions routes", () => {
         // Server-relative versionless route: it now resolves this same
         // promoted row, so the bytes it serves match this row's checksum.
         expect(body.url).toBe(
-          "https://us.example.com/api/v1/agents/download/backup/linux/amd64",
+          "https://us.example.com/api/v1/agents/download/backup/linux/amd64?version=1.0.0",
         );
         expect(body.checksum).toBe(checksum);
       } finally {
@@ -1436,15 +1520,18 @@ describe("agentVersions routes", () => {
     });
 
     // Design: breeze-backup's version is slaved to the agent's, and agents
-    // request it by EXACT version. buildServerRelativeAgentDownloadUrl points
-    // at the versionless /download/backup/:os/:arch route, which can only ever
-    // serve ONE release — since #3499, the promoted (isLatest) row. Rewriting
-    // a non-promoted backup version to that route would silently hand the
-    // agent DIFFERENT bytes than the version it pinned — the updater's
-    // checksum/manifest check then (correctly) rejects them, and the agent
-    // can never heal. So the rewrite must be gated to rows the versionless
-    // route would actually serve.
-    it("does NOT rewrite component=backup when the row is neither promoted nor the server's current version — returns the stored immutable URL untouched", async () => {
+    // request it by EXACT version. Before #5159 the rewrite pointed at the
+    // VERSIONLESS /download/backup/:os/:arch route, which can only serve ONE
+    // release (since #3499, the promoted row) — so a non-promoted backup
+    // version had to be left on its stored canonical URL, and an agent whose
+    // host check refused that URL simply never healed.
+    //
+    // In github mode the URL now carries ?version=, so the route resolves this
+    // exact row instead of the promoted one: the rewrite is safe for ANY
+    // registered version, and a pinned/unpromoted backup can finally heal
+    // over the trusted control-plane origin. (Local mode still cannot select
+    // a release — see the local-mode case below, which keeps the old guard.)
+    it("rewrites a non-promoted component=backup row to a VERSION-PINNED server-relative URL in github mode (#5159)", async () => {
       const canonical =
         "https://github.com/LanternOps/breeze/releases/download/v0.90.0/breeze-backup-linux-amd64";
       const checksum = "d".repeat(64);
@@ -1490,9 +1577,12 @@ describe("agentVersions routes", () => {
         );
         expect(res.status).toBe(200);
         const body = await res.json();
-        // Stored canonical (immutable GitHub asset) URL, NOT the
-        // server-relative versionless route.
-        expect(body.url).toBe(canonical);
+        // Version-pinned server-relative URL: the download route will
+        // resolve 0.90.0 specifically, so these bytes match this checksum
+        // even though 0.90.0 is not the promoted release.
+        expect(body.url).toBe(
+          "https://us.example.com/api/v1/agents/download/backup/linux/amd64?version=0.90.0",
+        );
         expect(body.checksum).toBe(checksum);
       } finally {
         delete process.env.PUBLIC_API_URL;
@@ -1500,14 +1590,10 @@ describe("agentVersions routes", () => {
       }
     });
 
-    // The other half of the #3499 change. Once a row IS promoted, matching the
-    // server's env version no longer makes a different row servable by the
-    // versionless route — that route serves the promoted one. So a
-    // non-promoted row keeps the stored immutable URL: the agent's
-    // host-equality check refuses the canonical github URL and simply does not
-    // heal, rather than downloading the promoted version's bytes against this
-    // row's checksum.
-    it("does NOT rewrite component=backup when the row merely matches the server's env version but another row is promoted (#3499)", async () => {
+    // The other half of the #3499 change, now resolved by the #5159 pin: it no
+    // longer matters which row is promoted, because the URL names the version
+    // the caller asked for. The promoted-row lookup is not even consulted.
+    it("rewrites component=backup to its own version even while a DIFFERENT row is promoted (#3499 → #5159)", async () => {
       const canonical =
         "https://github.com/LanternOps/breeze/releases/download/v1.0.0/breeze-backup-linux-amd64";
       const checksum = "e".repeat(64);
@@ -1535,9 +1621,9 @@ describe("agentVersions routes", () => {
                 releaseManifest: signed.manifest,
                 manifestSignature: signed.signature,
                 signingKeyId: "test-key",
-                // Matches BINARY_VERSION, but is NOT the promoted row — since
-                // #3499 the versionless route serves whatever is promoted, not
-                // this. Must NOT rewrite.
+                // Matches BINARY_VERSION, but is NOT the promoted row. Before
+                // #5159 that withheld the rewrite; the version pin makes the
+                // promotion state irrelevant.
                 isLatest: false,
 
               },
@@ -1558,9 +1644,11 @@ describe("agentVersions routes", () => {
         );
         expect(res.status).toBe(200);
         const body = await res.json();
-        // Stored canonical (immutable GitHub asset) URL, NOT the
-        // server-relative versionless route.
-        expect(body.url).toBe(canonical);
+        // Version-pinned server-relative URL naming THIS row's version;
+        // the promoted row (1.1.0) is irrelevant to what gets served.
+        expect(body.url).toBe(
+          "https://us.example.com/api/v1/agents/download/backup/linux/amd64?version=1.0.0",
+        );
         expect(body.checksum).toBe(checksum);
       } finally {
         delete process.env.PUBLIC_API_URL;
@@ -1668,7 +1756,7 @@ describe("agentVersions routes", () => {
         expect(res.status).toBe(200);
         const body = await res.json();
         expect(body.url).toBe(
-          "https://us.example.com/api/v1/agents/download/linux/amd64",
+          "https://us.example.com/api/v1/agents/download/linux/amd64?version=1.0.0",
         );
       } finally {
         delete process.env.PUBLIC_API_URL;
@@ -1724,7 +1812,7 @@ describe("agentVersions routes", () => {
         expect(res.status).toBe(200);
         const body = await res.json();
         expect(body.url).toBe(
-          "https://us.example.com/api/v1/agents/download/helper/darwin/arm64",
+          "https://us.example.com/api/v1/agents/download/helper/darwin/arm64?version=1.0.0",
         );
       } finally {
         delete process.env.PUBLIC_API_URL;

--- a/apps/api/src/routes/agentVersions.ts
+++ b/apps/api/src/routes/agentVersions.ts
@@ -470,10 +470,18 @@ function dbPlatformToRouteOs(dbPlatform: string): string {
 // is distinct from `helper` (the Tauri Helper app). It has its own route; it
 // was omitted here originally, so the agent fell back to the github URL and the
 // host check rejected the user-helper auto-update (#1878, sibling of #646).
+//
+// `version` (#5159) pins the redirect to one exact release instead of the
+// promoted one. Without it the response's checksum (read from the requested
+// agent_versions row) and the route's bytes (the promoted row) can be
+// different builds — which is precisely what happens to an org running a
+// pinned pilot version under AGENT_AUTO_PROMOTE=false, leaving every device
+// stuck in "Updating" on an unfixable size/checksum mismatch.
 function buildServerRelativeAgentDownloadUrl(
   dbPlatform: string,
   architecture: string,
   component: string,
+  version?: string,
 ): string | null {
   if (
     component !== "agent" &&
@@ -489,19 +497,34 @@ function buildServerRelativeAgentDownloadUrl(
     return null;
   }
   const os = dbPlatformToRouteOs(dbPlatform);
+  const query = version ? `?version=${encodeURIComponent(version)}` : "";
   if (component === "helper") {
-    return `${origin}/api/v1/agents/download/helper/${os}/${architecture}`;
+    return `${origin}/api/v1/agents/download/helper/${os}/${architecture}${query}`;
   }
   if (component === "user-helper") {
-    return `${origin}/api/v1/agents/download/user-helper/${os}/${architecture}`;
+    return `${origin}/api/v1/agents/download/user-helper/${os}/${architecture}${query}`;
   }
   if (component === "watchdog") {
-    return `${origin}/api/v1/agents/download/watchdog/${os}/${architecture}`;
+    return `${origin}/api/v1/agents/download/watchdog/${os}/${architecture}${query}`;
   }
   if (component === "backup") {
-    return `${origin}/api/v1/agents/download/backup/${os}/${architecture}`;
+    return `${origin}/api/v1/agents/download/backup/${os}/${architecture}${query}`;
   }
-  return `${origin}/api/v1/agents/download/${os}/${architecture}`;
+  return `${origin}/api/v1/agents/download/${os}/${architecture}${query}`;
+}
+
+// Which version (if any) to pin the server-relative download URL to.
+//
+// Only BINARY_SOURCE=github can honour a pin: that branch of the download
+// route builds a per-tag GitHub asset URL. Local mode streams the single
+// build baked into the binaries volume and has nothing to select from, so
+// passing a version there would only turn a working download into a 409.
+// The "unknown" sentinel (binarySync's locally-registered rows with no
+// version file) is not a release tag either — see getRegisteredComponentVersion.
+function downloadUrlVersionPin(version: string): string | undefined {
+  if (getBinarySource() !== "github") return undefined;
+  if (version === "unknown") return undefined;
+  return version;
 }
 
 export async function validateReleaseManifest(args: {
@@ -710,6 +733,11 @@ agentVersionRoutes.get(
       platform,
       arch,
       component,
+      // Pin to the exact row this checksum came from. The promoted row IS what
+      // the versionless route resolves, so this is normally the same release —
+      // but pinning removes the last way the two can select different rows
+      // (a duplicate isLatest row breaking the ORDER BY tiebreak).
+      downloadUrlVersionPin(latestVersion.version),
     );
 
     return c.json({
@@ -799,38 +827,33 @@ agentVersionRoutes.get(
       );
     }
 
+    // #5159: pin the server-relative URL to the version that was actually
+    // requested, so the bytes the download route redirects to are the same
+    // release as the checksum/manifest returned below. Before this, the URL
+    // was versionless and the route served the PROMOTED release — fine while
+    // the pin and the promotion agreed, and an unfixable checksum mismatch
+    // whenever they did not (an org agentVersionPins pilot under
+    // AGENT_AUTO_PROMOTE=false, which resolvePinnedUpgradeTarget deliberately
+    // allows, #2124).
+    const versionPin = downloadUrlVersionPin(versionInfo.version);
+
     // breeze-backup is version-slaved to the agent but requested by EXACT
     // version (unlike agent/helper/watchdog, which always want "latest").
-    // The versionless /download/backup/:os/:arch route can only ever serve ONE
-    // release, so rewriting a NON-servable backup version to it would hand an
-    // agent healing to an older pinned version different bytes than it asked
-    // for; the updater verifies checksum+manifest against the pinned version
-    // and fails safe, but can never actually heal. So for component=backup
-    // only, rewrite exclusively when this row IS the one that route serves.
+    // When the URL carries no version pin, the versionless route can only ever
+    // serve ONE release, so rewriting a NON-servable backup version to it
+    // would hand an agent healing to an older pinned version different bytes
+    // than it asked for; the updater verifies checksum+manifest against the
+    // pinned version and fails safe, but can never actually heal. So for
+    // component=backup only, and only when the URL cannot be pinned, rewrite
+    // exclusively when this row IS the one that route serves.
     //
-    // WHICH row that is changed in #3499, so rather than restate the route's
-    // rule here and let the two drift, ask the route's OWN resolver what it
-    // will serve and compare. Restating it is what made this guard subtly
-    // wrong twice: it used to hardcode "the env version", correct only while
-    // the route resolved BINARY_VERSION/BREEZE_VERSION; a plain `isLatest`
-    // test would be equally wrong for a never-synced deployment, where no row
-    // is promoted and the route legitimately falls back to the env version.
-    // Deriving it keeps both cases right by construction.
-    //
-    // A resolver fault throws rather than guessing, and this endpoint is
-    // already DB-dependent (it just read versionInfo), so it surfaces as a 5xx
-    // instead of a rewrite that might not match. Every other component keeps
-    // the unconditional rewrite.
+    // A version pin makes the question moot: the route then resolves that
+    // exact row (getRegisteredComponentVersion) rather than the promoted one.
+    // What remains is local mode, where the route streams the single build in
+    // the binaries volume — the env-resolved version, which is what this guard
+    // has always compared against there.
     let backupVersionIsServableByVersionlessRoute = true;
-    if (versionInfo.component === "backup") {
-      // Mirror the route's own BINARY_SOURCE branch. Only the github branch
-      // resolves the promoted row; in local mode the route streams ONE
-      // unversioned file from disk/S3 whose version is the binaries-volume
-      // build — i.e. the env version, which is what this guard has always
-      // compared against there. Deriving the promoted row in local mode would
-      // withhold the rewrite (and cost a query) whenever the promoted row and
-      // the disk build differ, e.g. AGENT_AUTO_PROMOTE=false or after a
-      // rollback via POST /agent-versions/promote.
+    if (!versionPin && versionInfo.component === "backup") {
       const versionlessRouteServes =
         getBinarySource() === "github"
           ? ((await getPromotedComponentVersion(
@@ -848,6 +871,7 @@ agentVersionRoutes.get(
           versionInfo.platform,
           versionInfo.architecture,
           versionInfo.component,
+          versionPin,
         )
       : null;
 

--- a/apps/api/src/routes/agents/download.test.ts
+++ b/apps/api/src/routes/agents/download.test.ts
@@ -11,6 +11,7 @@ vi.mock('../../services/s3Storage', () => ({
 
 vi.mock('../../services/binarySource', () => ({
   getBinarySource: vi.fn(() => 'local'),
+  getGithubReleaseVersion: vi.fn(() => 'latest'),
   getGithubAgentUrl: vi.fn(),
   getGithubAgentPkgUrl: vi.fn(),
   getGithubHelperUrl: vi.fn(),
@@ -28,6 +29,10 @@ vi.mock('../../services/promotedAgentVersion', () => ({
   // Default: no promoted row, so every pre-existing test keeps exercising the
   // historical env-resolved redirect path unchanged.
   getPromotedComponentVersion: vi.fn(async () => null),
+  // #5159: default "the requested version is not registered here", so any
+  // pre-existing test that stumbles onto the ?version= branch fails closed
+  // rather than silently reusing the promoted row.
+  getRegisteredComponentVersion: vi.fn(async () => null),
 }));
 
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync } from 'node:fs';
@@ -37,9 +42,9 @@ import type { AddressInfo } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { downloadRoutes } from './download';
-import { getBinarySource, getGithubAgentUrl, getGithubAgentPkgUrl, getGithubHelperUrl, getGithubUserHelperUrl, getGithubWatchdogUrl, getGithubBackupUrl } from '../../services/binarySource';
+import { getBinarySource, getGithubReleaseVersion, getGithubAgentUrl, getGithubAgentPkgUrl, getGithubHelperUrl, getGithubUserHelperUrl, getGithubWatchdogUrl, getGithubBackupUrl } from '../../services/binarySource';
 import { isS3Configured, getPresignedUrl } from '../../services/s3Storage';
-import { getPromotedComponentVersion } from '../../services/promotedAgentVersion';
+import { getPromotedComponentVersion, getRegisteredComponentVersion } from '../../services/promotedAgentVersion';
 
 describe('public agent binary downloads', () => {
   const originalAgentDir = process.env.AGENT_BINARY_DIR;
@@ -408,6 +413,138 @@ describe('component downloads serve the DB-promoted version (issue #3499)', () =
     const badArch = await downloadRoutes.request('/download/linux/sparc');
     expect(badArch.status).toBe(400);
     expect(getPromotedComponentVersion).not.toHaveBeenCalled();
+  });
+});
+
+describe('component downloads honour an explicit ?version= pin (issue #5159)', () => {
+  const ENV_VERSION = '0.108.0';
+  const PROMOTED_VERSION = '0.108.0'; // the globally promoted agent_versions row
+  const PINNED_VERSION = '0.110.0'; // an org agentVersionPins pilot, isLatest=false
+
+  const urlFor =
+    (component: string) =>
+    (os: string, arch: string, version?: string) =>
+      `https://github.test/releases/download/v${version ?? ENV_VERSION}/breeze-${component}-${os}-${arch}`;
+
+  beforeEach(() => {
+    vi.mocked(getBinarySource).mockReturnValue('github');
+    vi.mocked(getGithubReleaseVersion).mockReturnValue(ENV_VERSION);
+    vi.mocked(getGithubAgentUrl).mockImplementation(urlFor('agent'));
+    vi.mocked(getGithubBackupUrl).mockImplementation(urlFor('backup'));
+    vi.mocked(getGithubWatchdogUrl).mockImplementation(urlFor('watchdog'));
+    vi.mocked(getPromotedComponentVersion).mockResolvedValue(PROMOTED_VERSION);
+    vi.mocked(getRegisteredComponentVersion).mockResolvedValue(PINNED_VERSION);
+  });
+
+  afterEach(() => {
+    vi.mocked(getBinarySource).mockReturnValue('local');
+    vi.mocked(getGithubReleaseVersion).mockReset();
+    vi.mocked(getGithubReleaseVersion).mockReturnValue('latest');
+    vi.mocked(getPromotedComponentVersion).mockReset();
+    vi.mocked(getPromotedComponentVersion).mockResolvedValue(null);
+    vi.mocked(getRegisteredComponentVersion).mockReset();
+    vi.mocked(getRegisteredComponentVersion).mockResolvedValue(null);
+  });
+
+  it('redirects to the PINNED release, not the promoted one', async () => {
+    // The reporter's exact state: heartbeat targets the pinned 0.110.0 (allowed
+    // without isLatest per #2124) while agent_versions still promotes 0.108.0.
+    const res = await downloadRoutes.request(
+      `/download/windows/amd64?version=${PINNED_VERSION}`,
+    );
+
+    expect(res.status).toBe(302);
+    expect(getRegisteredComponentVersion).toHaveBeenCalledWith(
+      'agent',
+      'windows',
+      'amd64',
+      PINNED_VERSION,
+    );
+    expect(getPromotedComponentVersion).not.toHaveBeenCalled();
+    expect(res.headers.get('location')).toBe(
+      `https://github.test/releases/download/v${PINNED_VERSION}/breeze-agent-windows-amd64`,
+    );
+    // The bug: 0.110.0 checksum, 0.108.0 bytes, forever "Updating".
+    expect(res.headers.get('location')).not.toContain(PROMOTED_VERSION);
+  });
+
+  it('pins the watchdog and backup routes the same way', async () => {
+    const watchdog = await downloadRoutes.request(
+      `/download/watchdog/linux/amd64?version=${PINNED_VERSION}`,
+    );
+    expect(watchdog.headers.get('location')).toBe(
+      `https://github.test/releases/download/v${PINNED_VERSION}/breeze-watchdog-linux-amd64`,
+    );
+
+    const backup = await downloadRoutes.request(
+      `/download/backup/linux/amd64?version=${PINNED_VERSION}`,
+    );
+    expect(backup.headers.get('location')).toBe(
+      `https://github.test/releases/download/v${PINNED_VERSION}/breeze-backup-linux-amd64`,
+    );
+  });
+
+  it('404s an unregistered version instead of substituting the promoted one', async () => {
+    // These routes are public and unauthenticated: an arbitrary caller-supplied
+    // tag must never reach the release-URL builder, and silently serving the
+    // promoted build instead is the very substitution this fix removes.
+    vi.mocked(getRegisteredComponentVersion).mockResolvedValue(null);
+    vi.mocked(getGithubAgentUrl).mockClear();
+
+    const res = await downloadRoutes.request('/download/linux/amd64?version=9.9.9');
+
+    expect(res.status).toBe(404);
+    expect(getGithubAgentUrl).not.toHaveBeenCalled();
+    const body = await res.text();
+    expect(body).not.toContain('9.9.9');
+  });
+
+  it('503s when the pinned-version lookup faults', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.mocked(getRegisteredComponentVersion).mockRejectedValue(
+      new Error('connection terminated'),
+    );
+
+    const res = await downloadRoutes.request(
+      `/download/linux/amd64?version=${PINNED_VERSION}`,
+    );
+
+    expect(res.status).toBe(503);
+    expect(res.headers.get('retry-after')).toBe('30');
+  });
+
+  it('falls back to the promoted row when no ?version= is given', async () => {
+    const res = await downloadRoutes.request('/download/linux/amd64');
+
+    expect(res.status).toBe(302);
+    expect(getRegisteredComponentVersion).not.toHaveBeenCalled();
+    expect(getPromotedComponentVersion).toHaveBeenCalledWith('agent', 'linux', 'amd64');
+  });
+
+  it('409s in local mode when the requested version is not the build on disk', async () => {
+    // Local mode has exactly one build per (component, os, arch); serving it
+    // for a different requested version is the same silent substitution.
+    vi.mocked(getBinarySource).mockReturnValue('local');
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    const res = await downloadRoutes.request(
+      `/download/linux/amd64?version=${PINNED_VERSION}`,
+    );
+
+    expect(res.status).toBe(409);
+  });
+
+  it('serves normally in local mode when the requested version matches the build', async () => {
+    vi.mocked(getBinarySource).mockReturnValue('local');
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    // No binary staged in this test env, so a 404 (not a 409) proves the
+    // version guard let the request through to the normal disk path.
+    const res = await downloadRoutes.request(
+      `/download/linux/amd64?version=${ENV_VERSION}`,
+    );
+
+    expect(res.status).toBe(404);
   });
 });
 

--- a/apps/api/src/routes/agents/download.test.ts
+++ b/apps/api/src/routes/agents/download.test.ts
@@ -468,21 +468,39 @@ describe('component downloads honour an explicit ?version= pin (issue #5159)', (
     expect(res.headers.get('location')).not.toContain(PROMOTED_VERSION);
   });
 
-  it('pins the watchdog and backup routes the same way', async () => {
-    const watchdog = await downloadRoutes.request(
-      `/download/watchdog/linux/amd64?version=${PINNED_VERSION}`,
-    );
-    expect(watchdog.headers.get('location')).toBe(
-      `https://github.test/releases/download/v${PINNED_VERSION}/breeze-watchdog-linux-amd64`,
-    );
+  it.each([
+    ['watchdog', '/download/watchdog/linux/amd64', 'linux', 'amd64', 'breeze-watchdog-linux-amd64'],
+    ['backup', '/download/backup/linux/amd64', 'linux', 'amd64', 'breeze-backup-linux-amd64'],
+    ['helper', '/download/helper/darwin/arm64', 'darwin', 'arm64', 'breeze-helper-darwin'],
+    ['user-helper', '/download/user-helper/windows/amd64', 'windows', 'amd64', 'breeze-user-helper-windows-amd64'],
+  ])(
+    'pins the %s route to the requested version, resolved for ITS OWN component',
+    async (component, path, os, arch, asset) => {
+      // The component argument matters and the mock is arg-blind, so assert
+      // the call itself: a route that passed a hardcoded 'agent' (or its
+      // neighbour's component) would resolve the wrong row in production and
+      // still produce a correct-looking Location here.
+      vi.mocked(getRegisteredComponentVersion).mockClear();
+      vi.mocked(getGithubHelperUrl).mockImplementation(
+        (o: string, version?: string) =>
+          `https://github.test/releases/download/v${version ?? ENV_VERSION}/breeze-helper-${o}`,
+      );
+      vi.mocked(getGithubUserHelperUrl).mockImplementation(urlFor('user-helper'));
 
-    const backup = await downloadRoutes.request(
-      `/download/backup/linux/amd64?version=${PINNED_VERSION}`,
-    );
-    expect(backup.headers.get('location')).toBe(
-      `https://github.test/releases/download/v${PINNED_VERSION}/breeze-backup-linux-amd64`,
-    );
-  });
+      const res = await downloadRoutes.request(`${path}?version=${PINNED_VERSION}`);
+
+      expect(res.status).toBe(302);
+      expect(getRegisteredComponentVersion).toHaveBeenCalledWith(
+        component,
+        os,
+        arch,
+        PINNED_VERSION,
+      );
+      expect(res.headers.get('location')).toBe(
+        `https://github.test/releases/download/v${PINNED_VERSION}/${asset}`,
+      );
+    },
+  );
 
   it('404s an unregistered version instead of substituting the promoted one', async () => {
     // These routes are public and unauthenticated: an arbitrary caller-supplied
@@ -532,6 +550,29 @@ describe('component downloads honour an explicit ?version= pin (issue #5159)', (
     );
 
     expect(res.status).toBe(409);
+  });
+
+  it('warns instead of silently serving when local mode cannot tell which build it holds', async () => {
+    // Neither BINARY_VERSION nor BREEZE_VERSION set. Refusing would break a
+    // deployment whose disk build IS the requested one, so we serve — but the
+    // operator must be able to trace a later checksum failure back to here
+    // rather than to an unrelated cause.
+    vi.mocked(getBinarySource).mockReturnValue('local');
+    vi.mocked(getGithubReleaseVersion).mockReturnValue('latest');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    const res = await downloadRoutes.request(
+      `/download/linux/amd64?version=${PINNED_VERSION}`,
+    );
+
+    // Not a 409: the guard could not be evaluated, so it must not fire.
+    expect(res.status).toBe(404);
+    expect(
+      warn.mock.calls.some(
+        ([msg]) =>
+          typeof msg === 'string' && msg.includes('without being able to verify it'),
+      ),
+    ).toBe(true);
   });
 
   it('serves normally in local mode when the requested version matches the build', async () => {

--- a/apps/api/src/routes/agents/download.ts
+++ b/apps/api/src/routes/agents/download.ts
@@ -4,8 +4,8 @@ import { Readable } from 'node:stream';
 import { join, resolve } from 'node:path';
 import { VALID_OS, VALID_ARCH } from './schemas';
 import { isS3Configured, getPresignedUrl, isS3NotFound } from '../../services/s3Storage';
-import { getBinarySource, getGithubAgentUrl, getGithubAgentPkgUrl, getGithubHelperUrl, getGithubUserHelperUrl, getGithubWatchdogUrl, getGithubBackupUrl, HELPER_FILENAMES } from '../../services/binarySource';
-import { getPromotedComponentVersion, type PromotedComponent } from '../../services/promotedAgentVersion';
+import { getBinarySource, getGithubReleaseVersion, getGithubAgentUrl, getGithubAgentPkgUrl, getGithubHelperUrl, getGithubUserHelperUrl, getGithubWatchdogUrl, getGithubBackupUrl, HELPER_FILENAMES } from '../../services/binarySource';
+import { getPromotedComponentVersion, getRegisteredComponentVersion, type PromotedComponent } from '../../services/promotedAgentVersion';
 
 export const downloadRoutes = new Hono();
 
@@ -106,20 +106,56 @@ function registerComponentDownloadRoute(config: ComponentDownloadConfig): void {
     // is different and throws: serving the env version then would reintroduce
     // the very mismatch this fixes and report a server-side DB fault to the
     // end user as a checksum failure.
+    // #5159: an explicit `?version=` pins the redirect to that exact release
+    // instead of the promoted one. The heartbeat can legitimately target a
+    // pinned/pilot version that is NOT promoted (resolvePinnedUpgradeTarget,
+    // #2124); GET /agent-versions/:version/download hands the agent that
+    // version's checksum and now points here WITH the version, so the bytes
+    // and the checksum come from one release again. Absent the param the
+    // route behaves exactly as before (promoted row, #3499).
+    const requestedVersion = c.req.query('version')?.trim() || undefined;
+
     if (getBinarySource() === 'github') {
       let redirectUrl: string;
       try {
-        const promotedVersion = await getPromotedComponentVersion(
-          config.component,
-          os,
-          arch,
-        );
+        let resolvedVersion: string | null;
+        if (requestedVersion) {
+          resolvedVersion = await getRegisteredComponentVersion(
+            config.component,
+            os,
+            arch,
+            requestedVersion,
+          );
+          if (!resolvedVersion) {
+            // Fail closed. Degrading to the promoted release here would hand
+            // back bytes for a DIFFERENT version than the caller asked for —
+            // exactly the substitution #5159 is about — and these routes are
+            // public, so an unregistered tag must never reach the URL builder.
+            console.warn(
+              `[${config.logTag}] refusing to serve ${filename}: no registered agent_versions row for requested version`,
+              { requestedVersion, os, arch, component: config.component },
+            );
+            return c.json(
+              {
+                error: 'Version not found',
+                message: `${config.entityLabel} for the requested version is not available.`,
+              },
+              404,
+            );
+          }
+        } else {
+          resolvedVersion = await getPromotedComponentVersion(
+            config.component,
+            os,
+            arch,
+          );
+        }
         // Inside the try on purpose: the URL builder ALSO throws — on a
         // malformed release tag, which a promoted row can carry because
         // agent_versions.version has no format constraint. That is the same
         // "we cannot determine a release to serve" condition, so it belongs on
         // the same 503 rather than falling through to a bare 500.
-        redirectUrl = config.githubUrlFor(os, arch, promotedVersion ?? undefined);
+        redirectUrl = config.githubUrlFor(os, arch, resolvedVersion ?? undefined);
       } catch (err) {
         console.error(
           `[${config.logTag}] refusing to serve ${filename}: could not resolve a release to redirect to`,
@@ -136,6 +172,32 @@ function registerComponentDownloadRoute(config: ComponentDownloadConfig): void {
         );
       }
       return c.redirect(redirectUrl, 302);
+    }
+
+    // Local mode serves ONE unversioned file per (component, os, arch) — the
+    // build baked into the binaries volume, whose version is the env-resolved
+    // one. It cannot honour a pin, so refuse rather than stream bytes for a
+    // version the caller did not ask for (the #5159 failure mode again, just
+    // one layer down). Our own callers only append `?version=` in github mode,
+    // so this is a guard against a hand-crafted or future request, not a path
+    // the agent takes. When the env version is unresolvable ('latest') we
+    // genuinely cannot tell, so serve as before and let the agent's checksum
+    // check be the backstop.
+    if (requestedVersion) {
+      const localVersion = getGithubReleaseVersion();
+      if (localVersion !== 'latest' && localVersion !== requestedVersion) {
+        console.warn(
+          `[${config.logTag}] refusing to serve ${filename}: local mode has only the ${localVersion} build`,
+          { requestedVersion, localVersion },
+        );
+        return c.json(
+          {
+            error: 'Version not available',
+            message: `${config.entityLabel} for the requested version is not available from this server.`,
+          },
+          409,
+        );
+      }
     }
 
     // Local mode: try S3 presigned redirect first (bandwidth offload)

--- a/apps/api/src/routes/agents/download.ts
+++ b/apps/api/src/routes/agents/download.ts
@@ -185,6 +185,17 @@ function registerComponentDownloadRoute(config: ComponentDownloadConfig): void {
     // check be the backstop.
     if (requestedVersion) {
       const localVersion = getGithubReleaseVersion();
+      if (localVersion === 'latest') {
+        // Neither BINARY_VERSION nor BREEZE_VERSION is set, so we cannot say
+        // which build is on disk and cannot evaluate the guard. Serving is
+        // still the right call (refusing would break a deployment whose disk
+        // build IS the requested one), but say so: if the agent then reports a
+        // checksum failure, this line is what tells an operator why.
+        console.warn(
+          `[${config.logTag}] serving ${filename} for a requested version without being able to verify it: set BINARY_VERSION or BREEZE_VERSION so this server knows which build it holds`,
+          { requestedVersion },
+        );
+      }
       if (localVersion !== 'latest' && localVersion !== requestedVersion) {
         console.warn(
           `[${config.logTag}] refusing to serve ${filename}: local mode has only the ${localVersion} build`,

--- a/apps/api/src/services/promotedAgentVersion.test.ts
+++ b/apps/api/src/services/promotedAgentVersion.test.ts
@@ -80,6 +80,7 @@ vi.mock('../db/schema', () => ({
 // Import under test — AFTER all mocks are installed.
 import {
   getPromotedComponentVersion,
+  getRegisteredComponentVersion,
   PromotedVersionUnavailableError,
   __resetPromotedVersionCaptureCacheForTests,
 } from './promotedAgentVersion';
@@ -252,5 +253,91 @@ describe('getPromotedComponentVersion', () => {
       getPromotedComponentVersion('agent', 'solaris', 'amd64'),
     ).rejects.toBeInstanceOf(PromotedVersionUnavailableError);
     expect(dbMock.select).not.toHaveBeenCalled();
+  });
+});
+
+describe('getRegisteredComponentVersion (issue #5159)', () => {
+  const OLD_EDITION = process.env.BINARY_EDITION;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbMock._reset();
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    if (OLD_EDITION === undefined) delete process.env.BINARY_EDITION;
+    else process.env.BINARY_EDITION = OLD_EDITION;
+    vi.restoreAllMocks();
+  });
+
+  it('returns the version AS STORED, never the caller-supplied string', async () => {
+    // The download routes are public and unauthenticated, and the returned
+    // value is interpolated into a GitHub release-tag path. It must originate
+    // from a row this server registered, not from the query string.
+    dbMock._setResult([{ version: '0.110.0' }]);
+
+    await expect(
+      getRegisteredComponentVersion('agent', 'windows', 'amd64', '0.110.0'),
+    ).resolves.toBe('0.110.0');
+  });
+
+  it('matches on the requested version and does NOT filter on isLatest', async () => {
+    // The whole point: an org agentVersionPins pilot is deliberately allowed
+    // to be un-promoted (#2124). Requiring isLatest here would re-break it.
+    dbMock._setResult([{ version: '0.110.0' }]);
+
+    await getRegisteredComponentVersion('agent', 'darwin', 'arm64', '0.110.0');
+
+    expect(boundValueFor('av.version')).toBe('0.110.0');
+    expect(boundValueFor('av.platform')).toBe('macos');
+    const { sql, params } = compiledWhere();
+    expect(params).not.toContain('av.is_latest');
+    expect(sql).not.toMatch(/\bor\b/i);
+    expect(sql).not.toContain('<>');
+    // version, platform, architecture, component, edition — five equalities.
+    expect(sql.match(/=/g)).toHaveLength(5);
+  });
+
+  it('scopes to this server edition', async () => {
+    process.env.BINARY_EDITION = 'hosted';
+    dbMock._setResult([{ version: '0.110.0' }]);
+
+    await getRegisteredComponentVersion('backup', 'linux', 'amd64', '0.110.0');
+
+    expect(boundValueFor('av.edition')).toBe('hosted');
+  });
+
+  it('returns null when no row matches, so the route can fail closed', async () => {
+    dbMock._setResult([]);
+
+    await expect(
+      getRegisteredComponentVersion('agent', 'linux', 'amd64', '9.9.9'),
+    ).resolves.toBeNull();
+  });
+
+  it('treats the "unknown" sentinel as unresolvable', async () => {
+    // binarySync stores the literal "unknown" for locally-registered binaries
+    // with no version file; "vunknown" is not a release tag.
+    dbMock._setResult([{ version: 'unknown' }]);
+
+    await expect(
+      getRegisteredComponentVersion('agent', 'linux', 'amd64', 'unknown'),
+    ).resolves.toBeNull();
+  });
+
+  it('throws PromotedVersionUnavailableError on a lookup fault', async () => {
+    dbMock._setError(new Error('connection terminated'));
+
+    await expect(
+      getRegisteredComponentVersion('agent', 'linux', 'amd64', '0.110.0'),
+    ).rejects.toBeInstanceOf(PromotedVersionUnavailableError);
+    expect(captureException).toHaveBeenCalled();
+  });
+
+  it('throws on an unmapped route OS rather than matching no row', async () => {
+    await expect(
+      getRegisteredComponentVersion('agent', 'solaris', 'amd64', '0.110.0'),
+    ).rejects.toBeInstanceOf(PromotedVersionUnavailableError);
   });
 });

--- a/apps/api/src/services/promotedAgentVersion.ts
+++ b/apps/api/src/services/promotedAgentVersion.ts
@@ -200,3 +200,89 @@ export async function getPromotedComponentVersion(
 
   return row.version;
 }
+
+/**
+ * Resolve an EXPLICITLY REQUESTED version for a component/os/arch, for the
+ * `?version=` form of the public component-download routes.
+ *
+ * Issue #5159: `resolvePinnedUpgradeTarget()` may legitimately offer an agent a
+ * version that is NOT the promoted one — an org `agentVersionPins.agent` pilot
+ * (#2124). `GET /agent-versions/:version/download` then hands that agent the
+ * exact pinned row's checksum/size, but the URL it returns pointed at the
+ * versionless download route, which serves the PROMOTED release. Under
+ * `AGENT_AUTO_PROMOTE=false` those are different builds, so the agent
+ * downloaded bytes that could never match the checksum it held and sat in
+ * "Updating" forever. This resolver is how the download route learns which
+ * release the caller's checksum actually came from.
+ *
+ * Returns the version as stored in `agent_versions` (never the caller's raw
+ * string) so the release tag interpolated into a URL always originates from a
+ * row this server registered — the routes are public and unauthenticated, so
+ * an arbitrary caller-supplied tag must never reach the URL builder.
+ *
+ * Returns `null` when no such row exists — the caller should 404 rather than
+ * silently degrade to the promoted release, which is the very substitution
+ * this fix exists to eliminate.
+ *
+ * @throws {PromotedVersionUnavailableError} if the lookup itself fails.
+ */
+export async function getRegisteredComponentVersion(
+  component: PromotedComponent,
+  routeOs: string,
+  arch: string,
+  requestedVersion: string,
+): Promise<string | null> {
+  const platform = ROUTE_OS_TO_DB_PLATFORM[routeOs];
+  if (!platform) {
+    throw new PromotedVersionUnavailableError(
+      component,
+      routeOs,
+      arch,
+      new Error(`Unmapped route OS "${routeOs}"`),
+    );
+  }
+
+  const edition = getBinaryEdition();
+
+  let row: { version: string } | undefined;
+  try {
+    [row] = await db
+      .select({ version: agentVersions.version })
+      .from(agentVersions)
+      .where(
+        and(
+          eq(agentVersions.platform, platform),
+          eq(agentVersions.architecture, arch),
+          eq(agentVersions.component, component),
+          eq(agentVersions.version, requestedVersion),
+          // Same edition scoping as the promoted lookup and
+          // /agent-versions/:version/download, so a caller can never pull a
+          // different edition's build of the same version number (#4072).
+          eq(agentVersions.edition, edition),
+        ),
+      )
+      .limit(1);
+  } catch (err) {
+    console.error(
+      `[promotedAgentVersion] requested-version lookup failed for ${component} ` +
+        `${platform}/${arch} v${requestedVersion} (edition ${edition})`,
+      err,
+    );
+    const unavailable = new PromotedVersionUnavailableError(
+      component,
+      platform,
+      arch,
+      err,
+    );
+    captureException(unavailable);
+    throw unavailable;
+  }
+
+  // Same sentinel handling as the promoted lookup: binarySync stores the
+  // literal "unknown" for locally-registered binaries with no version file,
+  // and "vunknown" is not a release tag. Treat it as unresolvable rather than
+  // building a URL that 404s at GitHub.
+  if (!row || row.version === 'unknown') return null;
+
+  return row.version;
+}

--- a/apps/api/src/services/promotedAgentVersion.ts
+++ b/apps/api/src/services/promotedAgentVersion.ts
@@ -282,7 +282,21 @@ export async function getRegisteredComponentVersion(
   // literal "unknown" for locally-registered binaries with no version file,
   // and "vunknown" is not a release tag. Treat it as unresolvable rather than
   // building a URL that 404s at GitHub.
-  if (!row || row.version === 'unknown') return null;
+  if (!row || row.version === 'unknown') {
+    // Log HERE, not only at the call site: this resolver owns the knowledge
+    // that no row matched, and a future second caller must not have to
+    // rediscover that it needs its own logging. Mirrors the promoted lookup's
+    // no-row warning. No Sentry capture — unlike a missing promoted row (a
+    // deployment-wide fault), an unregistered version is a per-request
+    // condition an unauthenticated caller can trigger at will, so capturing it
+    // would hand anyone a quota-burn lever.
+    console.warn(
+      `[promotedAgentVersion] no ${edition}-edition agent_versions row for ` +
+        `${component} ${platform}/${arch} v${requestedVersion}; the caller ` +
+        `must fail closed rather than serve the promoted release (#5159).`,
+    );
+    return null;
+  }
 
   return row.version;
 }

--- a/apps/docs/src/content/docs/reference/api.mdx
+++ b/apps/docs/src/content/docs/reference/api.mdx
@@ -1187,7 +1187,7 @@ Canned reply templates are partner-scoped. Management operations require `partne
 | Method | Path | Auth | Description |
 |---|---|---|---|
 | `POST` | `/agents/enroll` | Enrollment secret | Enroll new device |
-| `GET` | `/agents/download/:os/:arch` | None | Download agent binary |
+| `GET` | `/agents/download/:os/:arch` | None | Download agent binary. Optional `?version=` serves that exact registered release instead of the promoted one (used for pinned/pilot versions); an unregistered version returns 404. |
 | `GET` | `/agents/install.sh` | None | One-line install script |
 
 ### Agent Versions


### PR DESCRIPTION
Closes #5159

## The bug

Self-hosted, `BINARY_SOURCE=github`, `AGENT_AUTO_PROMOTE=false`. An org pins `agentVersionPins.agent = 0.110.0` while `agent_versions` still promotes `0.108.0` (`is_latest`). Every device sits in **Updating** forever with size/checksum mismatches on Windows and Linux.

## Root cause (differs from the automated triage note in the issue)

The triage comment says the download route resolves the release purely from `BINARY_VERSION`/`BREEZE_VERSION`. That was true before #3499; it is not the current code. The route resolves the **promoted** (`isLatest`) `agent_versions` row via `getPromotedComponentVersion()`.

The actual defect is one layer up:

- `resolvePinnedUpgradeTarget()` deliberately lets a pin resolve **without** `isLatest=true`, so a partner can pilot a release without moving the fleet default (#2124). The heartbeat correctly offers `targetVersion=0.110.0`.
- `GET /agent-versions/:version/download` reads that **exact** row for checksum/size/manifest — but the URL it returns is **versionless** (`buildServerRelativeAgentDownloadUrl`), pointing at `/api/v1/agents/download/:os/:arch`.
- That route serves the **promoted** release. Pin ≠ promotion ⇒ `0.110.0` checksum, `0.108.0` bytes. The updater correctly refuses them, and retries forever — there is no terminal state. Flipping `is_latest` by hand only made the two halves agree again.

The agent needs no change: it already requests an exact version and follows the returned URL verbatim (`agent/internal/updater/updater.go` `downloadBinary`).

## The fix

Make the server-relative URL name the version it was built for.

- `buildServerRelativeAgentDownloadUrl(..., version?)` appends `?version=`, emitted from **both** `/agent-versions/:version/download` and `/agent-versions/latest`, so the URL always names the row the checksum came from. (On `/latest` this also closes the last way a duplicate `isLatest` row could make the checksum and the bytes select different rows.)
- The five component download routes honour `?version=` in github mode via the new `getRegisteredComponentVersion()`: requires a registered row for that component/platform/arch/**edition**, with **no `isLatest` predicate** (so a pilot resolves), and returns the version **as stored** — a caller-supplied string never reaches the release-tag URL builder. These routes are public and unauthenticated.
- Fails closed: an unregistered version **404s** rather than substituting the promoted build; a lookup fault **503s**, matching the promoted resolver.
- The fleet-wide default is untouched. Without `?version=` the route behaves exactly as before.
- **Local mode is unchanged.** It streams the one build in the binaries volume and cannot select a release, so no pin is emitted there. A `?version=` that reaches it anyway and disagrees with the env build **409s** instead of serving different bytes.
- The `component=backup` rewrite guard now applies only when there is no pin (i.e. local mode). In github mode a pinned backup can finally self-heal over the trusted control-plane origin instead of being stranded on a canonical github URL the agent's host check refuses.

## Signature verification is not weakened

`RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS` / `validateReleaseManifest` is untouched. `/:version/download` still validates the exact row's signed manifest before responding, and the agent still verifies manifest signature, checksum and size against the version it asked for. This change only makes the bytes match metadata that was already being verified.

## Assumption taken (no repo precedent)

Version selection is expressed as an **optional `?version=` query parameter on the existing public download routes**, rather than a new versioned path segment. Reasons: it keeps one route (and one set of auth-skip/CDN rules), it is backwards compatible for install.sh, the web UI and every already-deployed agent, and #3499 had already threaded an optional `version?` argument through `getGithubAgentUrl` and friends for exactly this shape. Flag if a `/download/:version/:os/:arch` path is preferred.

## Verification

- Red-first control: reverting `routes/agents/download.ts` to `origin/main` fails 5 of the new tests; restoring the fix passes all 71.
- `vitest run --pool=forks --maxWorkers=1` over 8 affected suites: **313 passed**, 0 failed (download, agentVersions, agentVersionsLocalModeRoundtrip, promotedAgentVersion, binarySync, installerBuilder, agentEditionAutoMigrate, agentAuthSkip).
- `tsc --noEmit` clean; `eslint` clean on touched files.
- No agent Go change, so no Go test run needed.

Two existing `component=backup` tests changed meaning (they asserted the rewrite was *withheld*); their comments now record why the pin dissolves that constraint in github mode, and the local-mode case still pins the old behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEX58GdCWkLHA9M8nfataF