### PR TITLE
feat(automations,commands): offline work queue W04 — whenOffline action option, queued step state, requireOnline removed, flag default ON (#5131)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1338,3 +1338,23 @@ AUTOMATION_WEBHOOK_ALLOW_LEGACY_SECRET=false
 # QBO_REDIRECT_URI=https://your-domain.example.com/api/v1/accounting/quickbooks/callback
 # QBO_ENVIRONMENT=production
 # QBO_WEBHOOK_VERIFIER_TOKEN=
+
+# --------------------------------------------
+# Offline work queue (#5128)
+# --------------------------------------------
+# Work targeted at an OFFLINE device is persisted with a delivery deadline and
+# claimed by the agent on its next successful heartbeat, instead of failing
+# immediately. This covers patch jobs, automation `run_script` /
+# `execute_command` actions, and scan/rollback commands; manual scripts and
+# software installs already queued and are not governed by this flag.
+#
+# Default: ON. Set to `false` to restore the pre-#5128 behaviour, where those
+# callers hard-fail with `device_offline` the moment the device is not
+# connected. This escape hatch is removed in a later release.
+# DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED=false
+#
+# How long a queued row may wait for its device before it expires undelivered.
+# Per TTL class, in hours; the defaults below apply when unset.
+# DEVICE_COMMAND_QUEUE_TTL_HOURS=168
+# DEVICE_COMMAND_QUEUE_SHORT_TTL_HOURS=24
+# DEVICE_COMMAND_QUEUE_POWER_STATE_TTL_HOURS=24

--- a/apps/api/src/jobs/patchJobExecutor.ts
+++ b/apps/api/src/jobs/patchJobExecutor.ts
@@ -1168,9 +1168,11 @@ async function prepareDeviceExecution(
     .where(inArray(patches.id, patchIds));
 
   // #5128 W3: through the single enqueue seam so an offline device can be
-  // QUEUED instead of skipped. `previouslyRejected: true` keeps the flag gate in
-  // charge — this caller hard-rejected offline devices before #5128, so with
-  // DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED unset it still does.
+  // QUEUED instead of skipped. `previouslyRejected: true` keeps the flag gate
+  // in charge for the case where `resolvePatchOfflinePolicy` returns undefined
+  // (an explicit policy would win over the gate outright). W4 flipped that
+  // gate's default ON, so an UNSET DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED now
+  // queues rather than hard-rejecting; `=false` restores the old behaviour.
   //
   // `patchJobId` is now in the payload: it is what lets a result arriving days
   // later (or the reaper, or a cancel) find the job this command belongs to.

--- a/apps/api/src/services/aiToolsScripts.runScript.orgEquality.test.ts
+++ b/apps/api/src/services/aiToolsScripts.runScript.orgEquality.test.ts
@@ -212,7 +212,7 @@ describe('run_script enforces script-device org equality', () => {
         triggerType: 'manual',
         triggeredBy: 'user-1',
         createdBy: 'user-1',
-        requireOnline: true,
+        offlinePolicy: { kind: 'reject' },
       }),
     );
 

--- a/apps/api/src/services/aiToolsScripts.ts
+++ b/apps/api/src/services/aiToolsScripts.ts
@@ -484,7 +484,11 @@ export function registerScriptTools(aiTools: Map<string, AiTool>): void {
                 // it always did.
                 runAs: runContext.data.runAs,
                 targetSessionId: runContext.data.targetSessionId,
-                requireOnline: true,
+                // #5128 W4 — the AI run_script tool answers synchronously and
+                // has no way to surface a later result, so it keeps the hard
+                // offline rejection the `requireOnline` alias used to give it.
+                // W5 softens the error TEXT, not the behaviour.
+                offlinePolicy: { kind: 'reject' },
                 variableScope,
               });
             })

--- a/apps/api/src/services/automationActionResults.test.ts
+++ b/apps/api/src/services/automationActionResults.test.ts
@@ -57,6 +57,30 @@ describe('automation action-result state machine', () => {
     },
   );
 
+  /**
+   * #5128 W4. `message` answers "why is this not finished yet"; once the action
+   * IS finished, `output`/`error` own the story. `aggregateActionDetails` falls
+   * back to `message` for both (`output ?? message`, `failed.error ??
+   * failed.message`), so a message left over from dispatch leaks into the
+   * device row — a run_script that queued while its device was offline, then
+   * reconnected and succeeded printing nothing, would report its OUTPUT as
+   * "Queued — device offline", and one that later failed with no stderr would
+   * show that same string as the red failure reason for a run that
+   * demonstrably executed.
+   */
+  it('clears the dispatch-time message on every terminal transition', () => {
+    const queued = { ...pending, status: 'queued' as const, message: 'Queued — device offline' };
+    for (const terminalStatus of ['succeeded', 'failed', 'timed_out', 'cancelled'] as const) {
+      expect(__testOnly.decideTerminalTransition(queued, {
+        source: 'command',
+        terminalStatus,
+        output: null,
+        error: null,
+        completedAt: new Date('2026-08-24T12:00:00Z'),
+      })).toMatchObject({ status: terminalStatus, message: null });
+    }
+  });
+
   it('keeps terminal rows immutable except for real evidence replacing a provisional reaper timeout', () => {
     const provisional = { ...pending, status: 'timed_out' as const, terminalSource: 'reaper' as const };
     const real = {

--- a/apps/api/src/services/automationActionResults.ts
+++ b/apps/api/src/services/automationActionResults.ts
@@ -143,6 +143,18 @@ function decideTerminalTransition(
     terminalSource: input.source,
     output: input.output ?? null,
     error: input.error ?? null,
+    // #5128 W4: clear the dispatch-time message, exactly as
+    // `decideDispatchTransition`'s terminal branch already does. `message` is
+    // the "why is this not finished yet" field; once the action IS finished,
+    // `output`/`error` own the story. Leaving it set matters because
+    // `aggregateActionDetails` falls back to it (`output ?? message`, and
+    // `failed.error ?? failed.message`), so a stale value leaks into the
+    // device row: a script that queued while the device was offline, then
+    // reconnected and succeeded printing nothing, would report its output as
+    // "Queued — device offline", and one that later failed with no stderr
+    // would show that string as the red failure reason for a run that
+    // demonstrably executed.
+    message: null,
     completedAt: input.completedAt,
   };
 }

--- a/apps/api/src/services/automationRuntime.cancelFence.test.ts
+++ b/apps/api/src/services/automationRuntime.cancelFence.test.ts
@@ -341,4 +341,45 @@ describe('executeAutomationActionsInOrder — mid-flight cancellation', () => {
     expect(dispatchMock).toHaveBeenCalledTimes(2);
     expect(out.hasNonterminalActions).toBe(true);
   });
+
+  /**
+   * #5128 W4, END TO END. Every other assertion about the queued path stops at
+   * `executeRunScriptAction`'s return value. This is the one that drives the
+   * whole chain — `automationOfflinePolicy()` → `dispatchScriptToDevice` →
+   * `delivered: false` → outcome `queued` → `hasNonterminalActions` → run status
+   * — and it is the assertion that matters most: W4 flipped the flag default ON
+   * for every existing customer, so if a queued step failed the run, every
+   * nightly automation over a fleet with sleeping laptops would go red at once.
+   */
+  it('a queued (offline) dispatch does NOT fail the run and does not skip trailing actions', async () => {
+    vi.stubEnv('DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED', 'true');
+    dispatchMock.mockResolvedValue({
+      ok: true, commandId: 'cmd-1', executionId: null, delivered: false,
+      deliveryOutcome: 'no_agent', deliverBy: new Date('2026-09-14T00:00:00.000Z'),
+      executedAt: null, ignoredParameters: [],
+    });
+    fenceSees();
+
+    // args() defaults are exactly what this needs: ONE device, TWO run_script
+    // actions, and onFailure: 'stop' — so a queued first action wrongly treated
+    // as a failure would stop the run and skip the second.
+    const out = await __testOnly.executeAutomationActionsInOrder(args());
+
+    expect(out.cancelled).toBe(false);
+    expect(out.devicesFailed).toBe(0);
+    // Non-terminal, so the run stays 'running' and waits for the agent rather
+    // than being computed as completed or failed.
+    expect(out.hasNonterminalActions).toBe(true);
+    // onFailure: 'stop' must NOT trigger — the SECOND action still dispatched.
+    expect(dispatchMock).toHaveBeenCalledTimes(2);
+    expect(recordActionDispatchMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'failed' }),
+    );
+    expect(recordActionDispatchMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'skipped' }),
+    );
+    expect(recordActionDispatchMock).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'queued', message: 'Queued — device offline' }),
+    );
+  });
 });

--- a/apps/api/src/services/automationRuntime.runScript.test.ts
+++ b/apps/api/src/services/automationRuntime.runScript.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // #3162: automation `run_script` actions must queue the command against a REAL
 // script_executions row so handleScriptResult can persist the agent's stdout.
@@ -112,6 +112,13 @@ function buildContext() {
 beforeEach(() => {
   updatedValues = [];
 
+  // #5128 W4: this suite predates the offline queue and asserts the legacy
+  // reject semantics, which are now only reachable with the flag off. Pin it
+  // explicitly rather than leaning on a default that flipped in W4 — the
+  // queue-arm behaviour has its own suite
+  // (automationRuntime.whenOffline.test.ts).
+  vi.stubEnv('DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED', 'false');
+
   updateMock.mockReset().mockImplementation(() => ({
     set: (vals: Record<string, unknown>) => {
       updatedValues.push(vals);
@@ -134,6 +141,10 @@ beforeEach(() => {
     notificationChannelsById: new Map(),
   });
   vi.mocked(db.transaction).mockImplementation(async (fn: any) => fn(db as any));
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
 });
 
 describe('createAutomationRunRecord — ownership admission', () => {
@@ -212,7 +223,7 @@ describe('executeRunScriptAction — dispatch via scriptDispatch core (#3409 PR0
     expect(input.triggeredBy).toBe('user-1');
     expect(input.createdBy).toBe('user-1');
     expect(input.runAs).toBe('system');
-    expect(input.requireOnline).toBe(true);
+    expect(input.offlinePolicy).toEqual({ kind: 'reject' });
   });
 
   it('logs success with the core-assigned commandId and executionId once delivered', async () => {
@@ -254,6 +265,8 @@ describe('executeRunScriptAction — dispatch via scriptDispatch core (#3409 PR0
       status: 'queued',
       commandId: 'cmd-1',
       scriptExecutionId: EXECUTION_ID,
+      // #5128 W4 — the operator-facing reason the step has not started.
+      message: 'Queued — device offline',
     });
     expect(updatedValues).toEqual([{ status: 'queued' }]);
   });
@@ -312,7 +325,7 @@ describe('executeRunScriptAction — dispatch via scriptDispatch core (#3409 PR0
     expect(updatedValues).toEqual([]);
   });
 
-  it('logs failure with the core error when the device is offline (requireOnline gate)', async () => {
+  it('logs failure with the core error when the device is offline (reject policy)', async () => {
     dispatchMock.mockResolvedValue({
       ok: false,
       code: 'device_offline',
@@ -331,7 +344,7 @@ describe('executeRunScriptAction — dispatch via scriptDispatch core (#3409 PR0
       scriptId: 'script-1',
     });
     // No status write to make — the core never inserted an execution row for
-    // an offline device (requireOnline is checked before any insert).
+    // an offline device (the reject policy is checked before any insert).
     expect(updatedValues).toEqual([]);
   });
 

--- a/apps/api/src/services/automationRuntime.test.ts
+++ b/apps/api/src/services/automationRuntime.test.ts
@@ -122,7 +122,8 @@ describe('automationRuntime', () => {
     ]);
 
     expect(actions).toEqual([
-      { type: 'run_script', scriptId: 'script-1', parameters: { s: 'a', n: 3, b: true }, runAs: undefined },
+      // #5128 W4 — whenOffline is normalised to its default on every stored action.
+      { type: 'run_script', scriptId: 'script-1', parameters: { s: 'a', n: 3, b: true }, runAs: undefined, whenOffline: 'queue' },
     ]);
   });
 

--- a/apps/api/src/services/automationRuntime.ts
+++ b/apps/api/src/services/automationRuntime.ts
@@ -453,8 +453,27 @@ function automationOfflinePolicy(whenOffline: 'queue' | 'skip' | undefined): Off
   return { kind: 'queue', deliverWithinMs: deliveryTtlMs('standard') };
 }
 
-/** #5128 W4 — the one operator-facing string for a step waiting on a device. */
+/** #5128 W4 — the operator-facing string for a step waiting on an OFFLINE device. */
 const QUEUED_OFFLINE_MESSAGE = 'Queued — device offline';
+
+/**
+ * #5128 W4 — the same, for a device we DID have a socket to and still failed to
+ * reach ('claim_lost' / 'decrypt_failed' / 'send_failed'). The command is
+ * queued either way, but telling a tech "device offline" about a device that is
+ * plainly online sends them chasing a connectivity problem that does not exist.
+ * `scriptDispatch`'s `deliveryOutcome` is the only thing that distinguishes the
+ * two, so the message has to be derived from it rather than from `delivered`.
+ */
+const QUEUED_UNDELIVERED_MESSAGE = 'Queued — delivery to the agent failed; will retry on its next check-in';
+
+function queuedMessageFor(deliveryOutcome: string | undefined): string {
+  // `undefined` is treated as the offline case: it is what the pre-W4 result
+  // shape carried, and 'no_agent' is overwhelmingly the reason a dispatch is
+  // undelivered.
+  return deliveryOutcome === undefined || deliveryOutcome === 'no_agent'
+    ? QUEUED_OFFLINE_MESSAGE
+    : QUEUED_UNDELIVERED_MESSAGE;
+}
 
 function asNonEmptyString(value: unknown): string | undefined {
   if (typeof value !== 'string') return undefined;
@@ -1492,7 +1511,7 @@ export async function executeRunScriptAction(
       status: dispatch.delivered ? 'delivered' : 'queued',
       commandId: dispatch.commandId,
       ...(dispatch.executionId ? { scriptExecutionId: dispatch.executionId } : {}),
-      ...(dispatch.delivered ? {} : { message: QUEUED_OFFLINE_MESSAGE }),
+      ...(dispatch.delivered ? {} : { message: queuedMessageFor(dispatch.deliveryOutcome) }),
     },
     log: logEntry('Queued run_script action', 'info', {
       actionType: action.type,
@@ -1576,7 +1595,7 @@ export async function executeCommandAction(
     outcome: {
       status: dispatch.delivered ? 'delivered' : 'queued',
       commandId: dispatch.commandId,
-      ...(dispatch.delivered ? {} : { message: QUEUED_OFFLINE_MESSAGE }),
+      ...(dispatch.delivered ? {} : { message: queuedMessageFor(dispatch.deliveryOutcome) }),
     },
     log: logEntry('Queued execute_command action', 'info', {
       actionType: action.type,

--- a/apps/api/src/services/automationRuntime.ts
+++ b/apps/api/src/services/automationRuntime.ts
@@ -23,6 +23,7 @@ import {
 import { resolveDeploymentTargets } from './deploymentEngine';
 import { canAccessSite, type UserPermissions } from './permissions';
 import { dispatchScriptToDevice } from './scriptDispatch';
+import { deliveryTtlMs, isOfflineQueueEnabled, type OfflinePolicy } from './commandOfflinePolicy';
 import { loadTenantVariableScope, type TenantVariableScope } from './tenantVariableResolution';
 import { scriptNeedsVariableScope } from './sourcedParameters';
 import { publishEvent } from './eventBus';
@@ -302,6 +303,12 @@ export type RunScriptAction = {
    * drops rather than throws.
    */
   runAs?: 'system' | 'user' | 'elevated';
+  /**
+   * #5128 W4 — what happens when the device is offline at dispatch time.
+   * Absent means 'queue' (the shared validator defaults it), so a stored
+   * action authored before this field existed queues like a new one.
+   */
+  whenOffline?: 'queue' | 'skip';
 };
 
 export type SendNotificationAction = {
@@ -323,6 +330,8 @@ export type ExecuteCommandAction = {
   type: 'execute_command';
   command: string;
   shell?: 'bash' | 'powershell' | 'cmd';
+  /** #5128 W4 — see RunScriptAction.whenOffline. */
+  whenOffline?: 'queue' | 'skip';
 };
 
 export type DeploySoftwareAction = {
@@ -420,6 +429,32 @@ function asString(value: unknown): string | undefined {
 function asRunAs(value: unknown): 'system' | 'user' | 'elevated' | undefined {
   return value === 'system' || value === 'user' || value === 'elevated' ? value : undefined;
 }
+
+/**
+ * #5128 W4. Mirrors `asRunAs`: an unrecognised stored value falls back to the
+ * schema default rather than throwing mid-run. 'queue' is the conservative
+ * fallback in the sense that matters here — the work is not silently dropped;
+ * it waits for the device and expires on the delivery deadline.
+ */
+function asWhenOffline(value: unknown): 'queue' | 'skip' {
+  return value === 'skip' ? 'skip' : 'queue';
+}
+
+/**
+ * #5128 W4. Automations rejected offline devices outright before this wave, so
+ * their queue arm is gated on `DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED` (default
+ * on since W4, removed in W5). With the flag off, or with the action set to
+ * 'skip', the dispatch keeps today's `device_offline` failure verbatim.
+ */
+function automationOfflinePolicy(whenOffline: 'queue' | 'skip' | undefined): OfflinePolicy {
+  if (asWhenOffline(whenOffline) === 'skip' || !isOfflineQueueEnabled()) {
+    return { kind: 'reject' };
+  }
+  return { kind: 'queue', deliverWithinMs: deliveryTtlMs('standard') };
+}
+
+/** #5128 W4 — the one operator-facing string for a step waiting on a device. */
+const QUEUED_OFFLINE_MESSAGE = 'Queued — device offline';
 
 function asNonEmptyString(value: unknown): string | undefined {
   if (typeof value !== 'string') return undefined;
@@ -582,6 +617,7 @@ export function normalizeAutomationActions(input: unknown): AutomationAction[] {
         scriptId,
         parameters,
         runAs: asRunAs(action.runAs),
+        whenOffline: asWhenOffline(action.whenOffline),
       });
       continue;
     }
@@ -627,6 +663,7 @@ export function normalizeAutomationActions(input: unknown): AutomationAction[] {
         type: 'execute_command',
         command,
         shell: shell === 'bash' || shell === 'powershell' || shell === 'cmd' ? shell : undefined,
+        whenOffline: asWhenOffline(action.whenOffline),
       });
       continue;
     }
@@ -1289,6 +1326,12 @@ type ActionExecutionOutcome =
       status: 'queued' | 'delivered' | 'running';
       commandId?: string;
       scriptExecutionId?: string;
+      /**
+       * #5128 W4 — operator-facing reason this step is not running yet. Only
+       * set on the queued-because-offline path; everything else keeps falling
+       * back to the run-log message in `persistActionExecutionOutcome`.
+       */
+      message?: string;
     }
   | { status: 'succeeded' }
   | { status: 'failed'; message?: string };
@@ -1399,9 +1442,11 @@ export async function executeRunScriptAction(
   // payload build, sensitive-field encryption, queueCommand, and claim/decrypt/
   // WS-send. On a queueCommand throw it deletes its own pending execution row
   // before rethrowing (the old discardQueuelessExecution catch, now inside the
-  // core). requireOnline:true reproduces queueCommandForExecution's online gate
-  // — offline devices short-circuit before any insert, so there is no orphan
-  // row to discard on that path either.
+  // core). #5128 W4: the offline policy now comes from the action's
+  // `whenOffline` option — 'skip' (or the queue flag being off) reproduces
+  // queueCommandForExecution's online gate, in which case offline devices
+  // short-circuit before any insert, so there is no orphan row to discard on
+  // that path either.
   const dispatch = await dispatchScriptToDevice({
     device: context.device,
     source: { kind: 'saved', script, automationRunId: context.runId },
@@ -1414,7 +1459,7 @@ export async function executeRunScriptAction(
     // longer forwards unchecked user input and needs no cast. The `??` is the
     // whole contract the automation form's "Script default" option relies on.
     runAs: action.runAs ?? script.runAs,
-    requireOnline: true,
+    offlinePolicy: automationOfflinePolicy(action.whenOffline),
     variableScope,
   });
 
@@ -1447,6 +1492,7 @@ export async function executeRunScriptAction(
       status: dispatch.delivered ? 'delivered' : 'queued',
       commandId: dispatch.commandId,
       ...(dispatch.executionId ? { scriptExecutionId: dispatch.executionId } : {}),
+      ...(dispatch.delivered ? {} : { message: QUEUED_OFFLINE_MESSAGE }),
     },
     log: logEntry('Queued run_script action', 'info', {
       actionType: action.type,
@@ -1487,7 +1533,7 @@ function chooseShellForDevice(deviceOsType: 'windows' | 'macos' | 'linux', reque
   return 'bash';
 }
 
-async function executeCommandAction(
+export async function executeCommandAction(
   action: ExecuteCommandAction,
   actionIndex: number,
   context: ActionExecutionContext,
@@ -1511,7 +1557,7 @@ async function executeCommandAction(
     timeoutSeconds: 300,
     runAs: 'system',
     createdBy: context.automation.createdBy ?? null,
-    requireOnline: true,
+    offlinePolicy: automationOfflinePolicy(action.whenOffline),
   });
 
   if (!dispatch.ok) {
@@ -1530,6 +1576,7 @@ async function executeCommandAction(
     outcome: {
       status: dispatch.delivered ? 'delivered' : 'queued',
       commandId: dispatch.commandId,
+      ...(dispatch.delivered ? {} : { message: QUEUED_OFFLINE_MESSAGE }),
     },
     log: logEntry('Queued execute_command action', 'info', {
       actionType: action.type,
@@ -1935,7 +1982,7 @@ async function executeAction(
   };
 }
 
-async function persistActionExecutionOutcome(
+export async function persistActionExecutionOutcome(
   runId: string,
   deviceId: string,
   actionIndex: number,
@@ -1951,8 +1998,8 @@ async function persistActionExecutionOutcome(
     ...('scriptExecutionId' in outcome && outcome.scriptExecutionId
       ? { scriptExecutionId: outcome.scriptExecutionId }
       : {}),
-    message: outcome.status === 'failed'
-      ? outcome.message ?? result.log.message
+    message: 'message' in outcome && outcome.message
+      ? outcome.message
       : result.log.message,
   });
 }

--- a/apps/api/src/services/automationRuntime.whenOffline.test.ts
+++ b/apps/api/src/services/automationRuntime.whenOffline.test.ts
@@ -223,6 +223,28 @@ describe('executeRunScriptAction — offline policy', () => {
     });
   });
 
+  // A device we HAD a socket to and still failed to reach is queued too, but it
+  // is not offline. Reporting "device offline" for it sends a tech chasing a
+  // connectivity problem that does not exist.
+  it.each(['claim_lost', 'decrypt_failed', 'send_failed'] as const)(
+    'does not claim "device offline" when delivery failed with %s on a reachable agent',
+    async (deliveryOutcome) => {
+      vi.stubEnv('DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED', 'true');
+      dispatchMock.mockResolvedValue({ ...queuedDispatch(), deliveryOutcome });
+
+      const result = await executeRunScriptAction(
+        { type: 'run_script', scriptId: 'script-1' },
+        0,
+        buildContext(),
+      );
+
+      expect(result.outcome.status).toBe('queued');
+      const message = (result.outcome as { message?: string }).message;
+      expect(message).not.toContain('offline');
+      expect(message).toBe('Queued — delivery to the agent failed; will retry on its next check-in');
+    },
+  );
+
   it("skip reproduces today's failure message byte-for-byte", async () => {
     vi.stubEnv('DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED', 'true');
     dispatchMock.mockResolvedValue({

--- a/apps/api/src/services/automationRuntime.whenOffline.test.ts
+++ b/apps/api/src/services/automationRuntime.whenOffline.test.ts
@@ -1,0 +1,299 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/**
+ * #5128 W4 — the `whenOffline` automation-action option and the `queued` step
+ * state it produces.
+ *
+ * Four axes are asserted here because each is independently load-bearing: the
+ * ACTION's choice ('queue'/'skip'), the FLAG
+ * (`DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED`), the OUTCOME written to
+ * `automation_action_results`, and the fact that a queued step does NOT fail
+ * the run — which is what would silently break every existing automation the
+ * moment the flag default flipped on.
+ */
+
+const { updateMock, dispatchMock, recordDispatchMock } = vi.hoisted(() => ({
+  updateMock: vi.fn(),
+  dispatchMock: vi.fn(),
+  recordDispatchMock: vi.fn(),
+}));
+
+vi.mock('./automationReferenceAuthorization', () => ({
+  AutomationReferenceAuthorizationError: class extends Error {},
+  resolveOwnedAutomationReferences: vi.fn(),
+}));
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: updateMock,
+    delete: vi.fn(),
+    transaction: vi.fn(),
+  },
+}));
+
+vi.mock('./sentry', () => ({ captureException: vi.fn() }));
+
+vi.mock('../db/schema', () => ({
+  automationRuns: { id: 'id', automationId: 'automationId', status: 'status' },
+  automationRunDeviceResults: { runId: 'runId', deviceId: 'deviceId' },
+  automationResourceBindings: { automationId: 'automationId', state: 'state', resourceKind: 'resourceKind', resourceId: 'resourceId' },
+  configPolicyAutomations: { featureLinkId: 'featureLinkId' },
+  configurationPolicies: { id: 'id', orgId: 'orgId' },
+  devices: { id: 'id', hostname: 'hostname', osType: 'osType', status: 'status', displayName: 'displayName', agentId: 'agentId' },
+  organizations: { id: 'id', partnerId: 'partnerId' },
+  scripts: { id: 'id', deletedAt: 'deletedAt' },
+  scriptExecutions: { id: 'id', deviceId: 'deviceId', automationRunId: 'automationRunId', status: 'status' },
+  notificationChannels: { id: 'id', orgId: 'orgId' },
+  automations: { id: 'id', runCount: 'runCount', lastRunAt: 'lastRunAt', updatedAt: 'updatedAt' },
+  alerts: { id: 'id' },
+  alertRules: { id: 'id', orgId: 'orgId', name: 'name', targetType: 'targetType', targetId: 'targetId' },
+  alertTemplates: { id: 'id', orgId: 'orgId', name: 'name' },
+  deviceGroupMemberships: { deviceId: 'deviceId', groupId: 'groupId' },
+}));
+
+vi.mock('./eventBus', () => ({ publishEvent: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('./deploymentEngine', () => ({ resolveDeploymentTargets: vi.fn().mockResolvedValue([]) }));
+vi.mock('./scriptDispatch', () => ({ dispatchScriptToDevice: dispatchMock }));
+vi.mock('./notificationSenders', () => ({
+  getEmailRecipients: vi.fn().mockReturnValue([]),
+  sendEmailNotification: vi.fn().mockResolvedValue({ success: false }),
+  sendWebhookNotification: vi.fn().mockResolvedValue({ success: false }),
+}));
+vi.mock('./automationActionResults', () => ({
+  recordAutomationActionDispatch: recordDispatchMock,
+  seedAutomationActionResults: vi.fn(),
+  applyAutomationActionTerminal: vi.fn(),
+  aggregateAutomationDeviceResultStatus: vi.fn(),
+}));
+
+import {
+  executeRunScriptAction,
+  executeCommandAction,
+  normalizeAutomationActions,
+  persistActionExecutionOutcome,
+} from './automationRuntime';
+import { deliveryTtlMs } from './commandOfflinePolicy';
+
+const EXECUTION_ID = '11111111-2222-4333-8444-555555555555';
+const RUN_ID = '99999999-8888-4777-8666-555555555555';
+
+const SCRIPT = {
+  id: 'script-1',
+  name: 'Collect logs',
+  language: 'powershell',
+  content: 'Get-Date',
+  osTypes: ['windows'],
+  timeoutSeconds: 300,
+  runAs: 'system',
+} as never;
+
+const DEVICE = {
+  id: 'device-1',
+  orgId: 'org-1',
+  hostname: 'HOST-1',
+  displayName: null,
+  osType: 'windows' as const,
+  status: 'offline',
+  agentId: 'agent-1',
+};
+
+function buildContext() {
+  return {
+    automation: { id: 'automation-1', name: 'Nightly', createdBy: 'user-1' },
+    runId: RUN_ID,
+    device: DEVICE,
+    scriptsById: new Map([['script-1', SCRIPT]]),
+    channelsById: new Map(),
+  } as never;
+}
+
+/** The dispatch core's "row persisted, agent not reached" shape. */
+function queuedDispatch() {
+  return {
+    ok: true,
+    commandId: 'cmd-1',
+    executionId: EXECUTION_ID,
+    delivered: false,
+    deliveryOutcome: 'no_agent',
+    deliverBy: new Date('2026-09-14T00:00:00.000Z'),
+    executedAt: null,
+    ignoredParameters: [],
+  };
+}
+
+beforeEach(() => {
+  updateMock.mockReset().mockImplementation(() => ({
+    set: () => ({ where: async () => undefined }),
+  }));
+  dispatchMock.mockReset().mockResolvedValue(queuedDispatch());
+  recordDispatchMock.mockReset().mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+function policyOf(callIndex = 0) {
+  return (dispatchMock.mock.calls[callIndex]![0] as Record<string, unknown>).offlinePolicy;
+}
+
+describe('whenOffline normalisation', () => {
+  it('defaults run_script and execute_command to queue when the field is absent', () => {
+    const [runScript, execCommand] = normalizeAutomationActions([
+      { type: 'run_script', scriptId: 'script-1' },
+      { type: 'execute_command', command: 'whoami' },
+    ]);
+    expect(runScript).toMatchObject({ type: 'run_script', whenOffline: 'queue' });
+    expect(execCommand).toMatchObject({ type: 'execute_command', whenOffline: 'queue' });
+  });
+
+  it('accepts an explicit skip on both action types', () => {
+    const [runScript, execCommand] = normalizeAutomationActions([
+      { type: 'run_script', scriptId: 'script-1', whenOffline: 'skip' },
+      { type: 'execute_command', command: 'whoami', whenOffline: 'skip' },
+    ]);
+    expect(runScript).toMatchObject({ whenOffline: 'skip' });
+    expect(execCommand).toMatchObject({ whenOffline: 'skip' });
+  });
+
+  it('falls back to queue for an unrecognised stored value rather than throwing mid-run', () => {
+    const [action] = normalizeAutomationActions([
+      { type: 'run_script', scriptId: 'script-1', whenOffline: 'explode' },
+    ]);
+    expect(action).toMatchObject({ whenOffline: 'queue' });
+  });
+});
+
+describe('executeRunScriptAction — offline policy', () => {
+  it('passes a standard-TTL queue policy when the flag is on and whenOffline is queue', async () => {
+    vi.stubEnv('DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED', 'true');
+
+    await executeRunScriptAction(
+      { type: 'run_script', scriptId: 'script-1', whenOffline: 'queue' },
+      0,
+      buildContext(),
+    );
+
+    expect(policyOf()).toEqual({ kind: 'queue', deliverWithinMs: deliveryTtlMs('standard') });
+  });
+
+  it('passes a reject policy when whenOffline is skip, even with the flag on', async () => {
+    vi.stubEnv('DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED', 'true');
+
+    await executeRunScriptAction(
+      { type: 'run_script', scriptId: 'script-1', whenOffline: 'skip' },
+      0,
+      buildContext(),
+    );
+
+    expect(policyOf()).toEqual({ kind: 'reject' });
+  });
+
+  it('passes a reject policy when the flag is OFF, even though the action says queue', async () => {
+    vi.stubEnv('DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED', 'false');
+
+    await executeRunScriptAction(
+      { type: 'run_script', scriptId: 'script-1', whenOffline: 'queue' },
+      0,
+      buildContext(),
+    );
+
+    expect(policyOf()).toEqual({ kind: 'reject' });
+  });
+
+  it('reports the queued step as queued (not failed) with the offline message', async () => {
+    vi.stubEnv('DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED', 'true');
+
+    const result = await executeRunScriptAction(
+      { type: 'run_script', scriptId: 'script-1' },
+      0,
+      buildContext(),
+    );
+
+    expect(result.outcome).toEqual({
+      status: 'queued',
+      commandId: 'cmd-1',
+      scriptExecutionId: EXECUTION_ID,
+      message: 'Queued — device offline',
+    });
+  });
+
+  it("skip reproduces today's failure message byte-for-byte", async () => {
+    vi.stubEnv('DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED', 'true');
+    dispatchMock.mockResolvedValue({
+      ok: false,
+      code: 'device_offline',
+      error: 'Device is offline, cannot execute command',
+    });
+
+    const result = await executeRunScriptAction(
+      { type: 'run_script', scriptId: 'script-1', whenOffline: 'skip' },
+      0,
+      buildContext(),
+    );
+
+    expect(result.outcome).toEqual({
+      status: 'failed',
+      message: 'Device is offline, cannot execute command',
+    });
+  });
+});
+
+describe('executeCommandAction — offline policy', () => {
+  it('queues with a standard TTL when the flag is on', async () => {
+    vi.stubEnv('DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED', 'true');
+
+    const result = await executeCommandAction(
+      { type: 'execute_command', command: 'whoami' },
+      0,
+      buildContext(),
+    );
+
+    expect(policyOf()).toEqual({ kind: 'queue', deliverWithinMs: deliveryTtlMs('standard') });
+    expect(result.outcome).toEqual({
+      status: 'queued',
+      commandId: 'cmd-1',
+      message: 'Queued — device offline',
+    });
+  });
+
+  it('rejects when whenOffline is skip', async () => {
+    vi.stubEnv('DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED', 'true');
+
+    await executeCommandAction(
+      { type: 'execute_command', command: 'whoami', whenOffline: 'skip' },
+      0,
+      buildContext(),
+    );
+
+    expect(policyOf()).toEqual({ kind: 'reject' });
+  });
+});
+
+describe('persistActionExecutionOutcome — queued row', () => {
+  it('writes the automation_action_results row as queued with the offline message', async () => {
+    vi.stubEnv('DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED', 'true');
+
+    const result = await executeRunScriptAction(
+      { type: 'run_script', scriptId: 'script-1' },
+      0,
+      buildContext(),
+    );
+    await persistActionExecutionOutcome(RUN_ID, DEVICE.id, 0, result);
+
+    expect(recordDispatchMock).toHaveBeenCalledWith(expect.objectContaining({
+      runId: RUN_ID,
+      deviceId: DEVICE.id,
+      actionIndex: 0,
+      status: 'queued',
+      commandId: 'cmd-1',
+      scriptExecutionId: EXECUTION_ID,
+      message: 'Queued — device offline',
+    }));
+  });
+});

--- a/apps/api/src/services/commandOfflinePolicy.test.ts
+++ b/apps/api/src/services/commandOfflinePolicy.test.ts
@@ -157,6 +157,18 @@ describe('commandOfflinePolicy registry (#5128 W1)', () => {
     expect(deliveryTtlMs('live')).toBe(REJECT_RACE_GRACE_MS);
   });
 
+  // #5128 W4 flipped the default. This is the ONLY test that asserts the
+  // unset-env behaviour — every other flag test stubs the value explicitly, so
+  // without this one the default could flip back unnoticed.
+  it('defaults ON when the env var is unset, and only an explicit "false" opts out', () => {
+    vi.stubEnv('DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED', undefined);
+    expect(isOfflineQueueEnabled()).toBe(true);
+    vi.stubEnv('DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED', '');
+    expect(isOfflineQueueEnabled()).toBe(true);
+    vi.stubEnv('DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED', 'false');
+    expect(isOfflineQueueEnabled()).toBe(false);
+  });
+
   it('flag off + previouslyRejected keeps reject; flag on lets the registry queue', () => {
     vi.stubEnv('DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED', 'false');
     expect(isOfflineQueueEnabled()).toBe(false);

--- a/apps/api/src/services/commandOfflinePolicy.ts
+++ b/apps/api/src/services/commandOfflinePolicy.ts
@@ -61,10 +61,16 @@ export function deliveryTtlMs(cls: DeliveryTtlClass): number {
  * Gates the `queue` arm for callers that hard-rejected offline devices before
  * #5128 (patch executor, automations, scan/rollback, AI tools). Scripts,
  * software installs and the generic device-command routes already queued and
- * are NOT gated. Defaults on once W3/W4 ship; removed the release after.
+ * are NOT gated.
+ *
+ * #5128 W4 flipped the default ON: only an explicit
+ * `DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED=false` opts back out, which is the
+ * documented escape hatch for an operator who wants the pre-#5128 hard
+ * rejection while they adjust their automations. The flag and this function
+ * are removed entirely in W5.
  */
 export function isOfflineQueueEnabled(): boolean {
-  return process.env.DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED === 'true';
+  return process.env.DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED !== 'false';
 }
 
 const C = CommandTypes;

--- a/apps/api/src/services/commandQueue.ts
+++ b/apps/api/src/services/commandQueue.ts
@@ -700,10 +700,10 @@ export async function waitForCommandResult(
  * #5128: this is now a thin adapter over `dispatchDeviceCommand`, the single
  * enqueue seam. Every caller of this function hard-rejected offline devices
  * before #5128, so it passes `previouslyRejected: true` — the
- * DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED flag (default off) is what decides
- * whether their offline devices reject as today or queue with a deadline.
- * The error strings are unchanged, so callers that surface `error` verbatim
- * behave identically while the flag is off.
+ * DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED flag (default ON since W4; set it to
+ * `false` to opt out) is what decides whether their offline devices reject as
+ * they used to or queue with a deadline. The error strings are unchanged, so
+ * callers that surface `error` verbatim behave identically with the flag off.
  */
 export async function queueCommandForExecution(
   deviceId: string,

--- a/apps/api/src/services/scriptDispatch.test.ts
+++ b/apps/api/src/services/scriptDispatch.test.ts
@@ -123,7 +123,7 @@ const mockDiscardDelete = (rows: unknown[] | (() => Promise<unknown[]>)) => {
   return del;
 };
 
-// Mocks the live `devices.status` re-read the requireOnline gate performs.
+// Mocks the live `devices.status` re-read the reject-policy gate performs.
 // Pass `undefined` to model a device row that no longer exists.
 const mockLiveDeviceStatus = (status: string | undefined) => {
   vi.mocked(db.select).mockReturnValue({
@@ -216,9 +216,9 @@ describe('dispatchScriptToDevice — invariants', () => {
     expect(db.select).not.toHaveBeenCalled();
   });
 
-  it('rejects offline device when requireOnline (snapshot and live read agree)', async () => {
+  it('rejects offline device under a reject policy (snapshot and live read agree)', async () => {
     mockLiveDeviceStatus('offline');
-    const r = await dispatchScriptToDevice({ device: device({ status: 'offline' }), requireOnline: true, source: { kind: 'saved', script: savedScript() } });
+    const r = await dispatchScriptToDevice({ device: device({ status: 'offline' }), offlinePolicy: { kind: 'reject' }, source: { kind: 'saved', script: savedScript() } });
     expect(r.ok).toBe(false);
     if (!r.ok) {
       expect(r.code).toBe('device_offline');
@@ -226,15 +226,15 @@ describe('dispatchScriptToDevice — invariants', () => {
     }
   });
 
-  it('queues for an offline device when requireOnline is not set (manual semantics)', async () => {
+  it('queues for an offline device when no policy is passed (manual semantics)', async () => {
     const r = await dispatchScriptToDevice({ device: device({ status: 'offline' }), source: { kind: 'saved', script: savedScript() } });
     expect(r.ok).toBe(true);
-    // requireOnline:false is deliberate offline-queueing (manual/route
-    // semantics) — no live re-read should fire for it.
+    // The registry default for `script` is deliberate offline-queueing
+    // (manual/route semantics) — no live re-read should fire for it.
     expect(db.select).not.toHaveBeenCalled();
   });
 
-  it('requireOnline gate re-reads live status: rejects a stale-online snapshot when the live read says offline', async () => {
+  it('reject policy re-reads live status: rejects a stale-online snapshot when the live read says offline', async () => {
     // Automation fleet runs snapshot device status once at run start
     // (automationRuntime.ts:1712/2269) and can dispatch minutes later — the
     // snapshot passed in here says 'online', but the live devices row has
@@ -242,7 +242,7 @@ describe('dispatchScriptToDevice — invariants', () => {
     // snapshot, or it would dispatch to a device that's actually offline.
     mockLiveDeviceStatus('offline');
     const r = await dispatchScriptToDevice({
-      device: device({ status: 'online' }), requireOnline: true, source: { kind: 'saved', script: savedScript() },
+      device: device({ status: 'online' }), offlinePolicy: { kind: 'reject' }, source: { kind: 'saved', script: savedScript() },
     });
     expect(r.ok).toBe(false);
     if (!r.ok) {
@@ -252,19 +252,19 @@ describe('dispatchScriptToDevice — invariants', () => {
     expect(db.select).toHaveBeenCalledTimes(1);
   });
 
-  it('requireOnline gate proceeds when the live read says online, even off a stale non-online snapshot', async () => {
+  it('reject policy proceeds when the live read says online, even off a stale non-online snapshot', async () => {
     mockLiveDeviceStatus('online');
     const r = await dispatchScriptToDevice({
-      device: device({ status: 'offline' }), requireOnline: true, source: { kind: 'saved', script: savedScript() },
+      device: device({ status: 'offline' }), offlinePolicy: { kind: 'reject' }, source: { kind: 'saved', script: savedScript() },
     });
     expect(r.ok).toBe(true);
     expect(db.select).toHaveBeenCalledTimes(1);
   });
 
-  it('requireOnline gate rejects with "Device not found" when the live row is gone', async () => {
+  it('reject policy rejects with "Device not found" when the live row is gone', async () => {
     mockLiveDeviceStatus(undefined);
     const r = await dispatchScriptToDevice({
-      device: device({ status: 'online' }), requireOnline: true, source: { kind: 'saved', script: savedScript() },
+      device: device({ status: 'online' }), offlinePolicy: { kind: 'reject' }, source: { kind: 'saved', script: savedScript() },
     });
     expect(r.ok).toBe(false);
     if (!r.ok) {
@@ -319,11 +319,11 @@ describe('dispatchScriptToDevice — #5128 offline policy', () => {
     }
   });
 
-  it('requireOnline: true is still an alias for a reject policy', async () => {
+  it('an explicit reject policy short-circuits before any queueCommand', async () => {
     mockLiveDeviceStatus('offline');
     const r = await dispatchScriptToDevice({
       device: device({ status: 'offline' }),
-      requireOnline: true,
+      offlinePolicy: { kind: 'reject' },
       source: { kind: 'saved', script: savedScript() },
     });
     expect(r.ok).toBe(false);
@@ -331,17 +331,17 @@ describe('dispatchScriptToDevice — #5128 offline policy', () => {
     expect(queueCommand).not.toHaveBeenCalled();
   });
 
-  it('an explicit offlinePolicy reject wins over the absence of requireOnline', async () => {
+  it('an explicit offlinePolicy reject wins over the queueing registry default', async () => {
     mockLiveDeviceStatus('offline');
     const r = await dispatchScriptToDevice({
       device: device({ status: 'offline' }),
-      // requireOnline is NOT set — only the explicit policy should gate this.
+      // No implicit gate remains (#5128 W4) — only the explicit policy gates this.
       offlinePolicy: { kind: 'reject' },
       source: { kind: 'saved', script: savedScript() },
     });
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.code).toBe('device_offline');
-    // The reject path re-reads live status, same as requireOnline.
+    // The reject path re-reads live status.
     expect(db.select).toHaveBeenCalledTimes(1);
     expect(queueCommand).not.toHaveBeenCalled();
   });
@@ -1120,7 +1120,7 @@ describe('dispatchScriptToDevice — sourced parameters', () => {
 
   describe('builtin name lookups', () => {
     // `loadBuiltinNameContext` is the only db.select this codepath makes
-    // (requireOnline is off in these tests), so one chain models both.
+    // (no reject policy in these tests), so one chain models both.
     const mockNameSelect = (rows: unknown[]) => {
       vi.mocked(db.select).mockReturnValue({
         from: vi.fn().mockReturnValue({

--- a/apps/api/src/services/scriptDispatch.ts
+++ b/apps/api/src/services/scriptDispatch.ts
@@ -80,11 +80,6 @@ export type DispatchScriptInput = {
   targetSessionId?: number;
   batchId?: string | null;
   /**
-   * @deprecated #5128 — alias for `offlinePolicy: { kind: 'reject' }`. Removed
-   * in W4 once automations pass an explicit policy.
-   */
-  requireOnline?: boolean;
-  /**
    * #5128 — explicit offline policy. Omit to take the registry default for
    * `script` (queue, standard TTL), which is what manual Run Script has always
    * done in practice.
@@ -208,7 +203,7 @@ export async function dispatchScriptToDevice(input: DispatchScriptInput): Promis
     return { ok: false, code: 'device_decommissioned', error: 'Device is decommissioned' };
   }
   const offlinePolicy: OfflinePolicy =
-    input.offlinePolicy ?? (input.requireOnline ? { kind: 'reject' } : defaultOfflinePolicy(CommandTypes.SCRIPT));
+    input.offlinePolicy ?? defaultOfflinePolicy(CommandTypes.SCRIPT);
   // A `reject` row is only created against a device we just observed online, so
   // it gets the short race grace rather than a queue window.
   const deliverBy = deliverByFor(offlinePolicy);

--- a/apps/web/src/components/automations/AutomationEditPage.test.tsx
+++ b/apps/web/src/components/automations/AutomationEditPage.test.tsx
@@ -163,4 +163,51 @@ describe('AutomationEditPage — run_script run context (#4888)', () => {
     expect((screen.getByTestId('action-0-run-as-select') as HTMLSelectElement).value).toBe('elevated');
     expect((putBody().actions as Array<Record<string, unknown>>)[0]).toMatchObject({ runAs: 'elevated' });
   });
+
+  /**
+   * #5128 W4 — `whenOffline` is the second field to go through the field-by-field
+   * `buildActionPayload`, so it carries exactly the drop risk the block comment
+   * above describes. `AutomationForm.test.tsx` asserts on that component's own
+   * `onSubmit` prop, which is one layer ABOVE where such a drop happens; these
+   * assert on the PUT body that actually leaves the browser.
+   */
+  it('sends the chosen offline behaviour in the PUT body (run_script)', async () => {
+    await editAndSave({ type: 'run_script', scriptId: 's1' }, () => {
+      fireEvent.change(screen.getByTestId('action-0-when-offline-select'), { target: { value: 'skip' } });
+    });
+
+    expect((putBody().actions as Array<Record<string, unknown>>)[0]).toMatchObject({
+      type: 'run_script',
+      whenOffline: 'skip',
+    });
+  });
+
+  it('sends the chosen offline behaviour in the PUT body (execute_command)', async () => {
+    await editAndSave({ type: 'execute_command', command: 'whoami' }, () => {
+      fireEvent.change(screen.getByTestId('action-0-when-offline-select'), { target: { value: 'skip' } });
+    });
+
+    expect((putBody().actions as Array<Record<string, unknown>>)[0]).toMatchObject({
+      type: 'execute_command',
+      command: 'whoami',
+      whenOffline: 'skip',
+    });
+  });
+
+  it('omits whenOffline entirely for an automation authored before the field existed', async () => {
+    await editAndSave({ type: 'run_script', scriptId: 's1' });
+
+    // The control SHOWS Queue (the server's default), but the payload must not
+    // gain a field the operator never chose — a pre-#5128 action has to
+    // round-trip byte-identically through an unrelated edit.
+    expect((screen.getByTestId('action-0-when-offline-select') as HTMLSelectElement).value).toBe('queue');
+    expect((putBody().actions as Array<Record<string, unknown>>)[0]).not.toHaveProperty('whenOffline');
+  });
+
+  it('reads a stored skip back into the form and round-trips it through an unrelated edit', async () => {
+    await editAndSave({ type: 'run_script', scriptId: 's1', whenOffline: 'skip' });
+
+    expect((screen.getByTestId('action-0-when-offline-select') as HTMLSelectElement).value).toBe('skip');
+    expect((putBody().actions as Array<Record<string, unknown>>)[0]).toMatchObject({ whenOffline: 'skip' });
+  });
 });

--- a/apps/web/src/components/automations/AutomationEditPage.tsx
+++ b/apps/web/src/components/automations/AutomationEditPage.tsx
@@ -52,6 +52,16 @@ function asRunAs(value: unknown): 'system' | 'user' | 'elevated' | undefined {
   return value === 'system' || value === 'user' || value === 'elevated' ? value : undefined;
 }
 
+/**
+ * #5128 W4 — read the stored offline behaviour back so opening an automation
+ * for edit shows what is actually in effect. Absent stays absent: an action
+ * saved before the field existed must round-trip byte-identically until the
+ * operator changes it (the API defaults it to 'queue').
+ */
+function asWhenOffline(value: unknown): 'queue' | 'skip' | undefined {
+  return value === 'queue' || value === 'skip' ? value : undefined;
+}
+
 function normalizeActionForForm(value: unknown): ActionFormValues {
   const action = isPlainRecord(value) ? value : {};
   const type = asString(action.type);
@@ -74,7 +84,8 @@ function normalizeActionForForm(value: unknown): ActionFormValues {
   if (type === 'execute_command') {
     return {
       type,
-      command: asString(action.command) ?? ''
+      command: asString(action.command) ?? '',
+      whenOffline: asWhenOffline(action.whenOffline)
     };
   }
 
@@ -92,7 +103,8 @@ function normalizeActionForForm(value: unknown): ActionFormValues {
     // automation for edit shows the choice that is actually in effect.
     // Without this the form would render "Script default" for an action that
     // overrides it, and the next save would erase the override.
-    runAs: asRunAs(action.runAs)
+    runAs: asRunAs(action.runAs),
+    whenOffline: asWhenOffline(action.whenOffline)
   };
 }
 
@@ -108,7 +120,11 @@ function buildActionPayload(action: ActionFormValues) {
       // (the Fix flow's discarded run-as select), so it must not be
       // reintroduced one layer below the form. `undefined` is omitted by
       // JSON.stringify, which is what "Script default" has to serialise to.
-      ...(action.runAs ? { runAs: action.runAs } : {})
+      ...(action.runAs ? { runAs: action.runAs } : {}),
+      // #5128 W4 — same field-by-field discipline as runAs above: omitted when
+      // the operator never touched the control, so an untouched pre-#5128
+      // action still serialises exactly as it did.
+      ...(action.whenOffline ? { whenOffline: action.whenOffline } : {})
     };
   }
 
@@ -136,7 +152,8 @@ function buildActionPayload(action: ActionFormValues) {
 
   return {
     type: action.type,
-    command: action.command
+    command: action.command,
+    ...(action.whenOffline ? { whenOffline: action.whenOffline } : {})
   };
 }
 

--- a/apps/web/src/components/automations/AutomationForm.test.tsx
+++ b/apps/web/src/components/automations/AutomationForm.test.tsx
@@ -82,3 +82,66 @@ describe('AutomationForm — run_script runAs override (#4888)', () => {
     expect(values.actions[0].runAs).toBe('user');
   });
 });
+
+describe('AutomationForm — whenOffline (#5128 W4)', () => {
+  const SCRIPTS = [{ id: 'script-1', name: 'Cleanup temp files' }];
+
+  it('renders the offline control on a run_script action, defaulting to Queue', () => {
+    render(
+      <AutomationForm onSubmit={vi.fn()} defaultValues={{ name: 'A' }} scripts={SCRIPTS} />,
+    );
+
+    const select = screen.getByTestId('action-0-when-offline-select') as HTMLSelectElement;
+    expect(select.value).toBe('queue');
+    expect(screen.getByRole('option', { name: 'Queue (default)' })).toBeTruthy();
+    expect(screen.getByRole('option', { name: 'Skip' })).toBeTruthy();
+  });
+
+  it('renders the offline control on an execute_command action too', () => {
+    render(<AutomationForm onSubmit={vi.fn()} defaultValues={{ name: 'A' }} />);
+
+    fireEvent.change(screen.getByDisplayValue('Run Script'), {
+      target: { value: 'execute_command' },
+    });
+
+    const select = screen.getByTestId('action-0-when-offline-select') as HTMLSelectElement;
+    expect(select.value).toBe('queue');
+  });
+
+  it('does not render the offline control on a deploy_software action', () => {
+    render(<AutomationForm onSubmit={vi.fn()} defaultValues={{ name: 'A' }} />);
+
+    fireEvent.change(screen.getByDisplayValue('Run Script'), {
+      target: { value: 'deploy_software' },
+    });
+
+    expect(screen.queryByTestId('action-0-when-offline-select')).toBeNull();
+  });
+
+  it('omits whenOffline from the payload when the operator never touches it', async () => {
+    const onSubmit = vi.fn();
+    render(
+      <AutomationForm onSubmit={onSubmit} defaultValues={{ name: 'A' }} scripts={SCRIPTS} />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Save automation/i }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    expect('whenOffline' in onSubmit.mock.calls[0][0].actions[0]).toBe(false);
+  });
+
+  it('submits whenOffline: "skip" once the operator picks Skip', async () => {
+    const onSubmit = vi.fn();
+    render(
+      <AutomationForm onSubmit={onSubmit} defaultValues={{ name: 'A' }} scripts={SCRIPTS} />,
+    );
+
+    fireEvent.change(screen.getByTestId('action-0-when-offline-select'), {
+      target: { value: 'skip' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Save automation/i }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    expect(onSubmit.mock.calls[0][0].actions[0].whenOffline).toBe('skip');
+  });
+});

--- a/apps/web/src/components/automations/AutomationForm.tsx
+++ b/apps/web/src/components/automations/AutomationForm.tsx
@@ -71,6 +71,11 @@ const createAutomationSchema = (t: ScriptsT) => {
     // stripped by the schema on the way through — RunContextSelect renders it
     // as a disabled option.
     runAs: z.enum(['system', 'user', 'elevated']).optional(),
+    // #5128 W4 — offline behaviour for run_script / execute_command.
+    // Optional here so an action loaded from a pre-#5128 automation keeps a
+    // byte-identical payload until the operator actually touches the control;
+    // the API defaults an absent value to 'queue'.
+    whenOffline: z.enum(['queue', 'skip']).optional(),
     notificationChannelId: z.string().optional(),
     alertSeverity: z.enum(['critical', 'high', 'medium', 'low', 'info']).optional(),
     alertMessage: z.string().optional(),
@@ -715,6 +720,32 @@ export default function AutomationForm({
                           id={`action-${index}-run-as`}
                           testId={`action-${index}-run-as-select`}
                         />
+
+                        <label
+                          htmlFor={`action-${index}-when-offline`}
+                          className="text-xs font-medium text-muted-foreground"
+                        >
+                          {t('automationForm.fields.whenOffline')}
+                        </label>
+                        <select
+                          id={`action-${index}-when-offline`}
+                          data-testid={`action-${index}-when-offline-select`}
+                          className="h-9 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
+                          value={watchActions?.[index]?.whenOffline ?? 'queue'}
+                          onChange={event =>
+                            setValue(
+                              `actions.${index}.whenOffline`,
+                              event.target.value as 'queue' | 'skip',
+                              { shouldDirty: true },
+                            )
+                          }
+                        >
+                          <option value="queue">{t('automationForm.options.whenOffline.queue')}</option>
+                          <option value="skip">{t('automationForm.options.whenOffline.skip')}</option>
+                        </select>
+                        <p className="text-xs text-muted-foreground">
+                          {t('automationForm.hints.whenOffline')}
+                        </p>
                       </div>
                     )}
 
@@ -771,6 +802,32 @@ export default function AutomationForm({
                           className="h-9 w-full rounded-md border bg-background px-3 text-sm font-mono focus:outline-hidden focus:ring-2 focus:ring-ring"
                           {...register(`actions.${index}.command`)}
                         />
+
+                        <label
+                          htmlFor={`action-${index}-when-offline`}
+                          className="text-xs font-medium text-muted-foreground"
+                        >
+                          {t('automationForm.fields.whenOffline')}
+                        </label>
+                        <select
+                          id={`action-${index}-when-offline`}
+                          data-testid={`action-${index}-when-offline-select`}
+                          className="h-9 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
+                          value={watchActions?.[index]?.whenOffline ?? 'queue'}
+                          onChange={event =>
+                            setValue(
+                              `actions.${index}.whenOffline`,
+                              event.target.value as 'queue' | 'skip',
+                              { shouldDirty: true },
+                            )
+                          }
+                        >
+                          <option value="queue">{t('automationForm.options.whenOffline.queue')}</option>
+                          <option value="skip">{t('automationForm.options.whenOffline.skip')}</option>
+                        </select>
+                        <p className="text-xs text-muted-foreground">
+                          {t('automationForm.hints.whenOffline')}
+                        </p>
                       </div>
                     )}
 

--- a/apps/web/src/locales/de-DE/scripts.json
+++ b/apps/web/src/locales/de-DE/scripts.json
@@ -154,8 +154,18 @@
       "severity": "Schweregrad",
       "message": "Nachricht",
       "command": "Befehl",
+      "whenOffline": "Wenn das Gerät offline ist",
       "software": "Software",
       "failureNotificationChannel": "Fehlerbenachrichtigungskanal"
+    },
+    "options": {
+      "whenOffline": {
+        "queue": "In die Warteschlange (Standard)",
+        "skip": "Überspringen"
+      }
+    },
+    "hints": {
+      "whenOffline": "Eingereihte Aufgaben warten auf das Gerät und werden bei der nächsten Verbindung ausgeführt oder verfallen nach 7 Tagen. Überspringen lässt den Schritt sofort fehlschlagen."
     },
     "placeholders": {
       "name": "Tägliche Wartungskontrolle",

--- a/apps/web/src/locales/en/scripts.json
+++ b/apps/web/src/locales/en/scripts.json
@@ -154,8 +154,18 @@
       "severity": "Severity",
       "message": "Message",
       "command": "Command",
+      "whenOffline": "If the device is offline",
       "software": "Software",
       "failureNotificationChannel": "Failure Notification Channel"
+    },
+    "options": {
+      "whenOffline": {
+        "queue": "Queue (default)",
+        "skip": "Skip"
+      }
+    },
+    "hints": {
+      "whenOffline": "Queued work waits for the device and runs on its next check-in, or expires after 7 days. Skip fails the step immediately."
     },
     "placeholders": {
       "name": "Daily maintenance check",

--- a/apps/web/src/locales/es-419/scripts.json
+++ b/apps/web/src/locales/es-419/scripts.json
@@ -154,8 +154,18 @@
       "severity": "Gravedad",
       "message": "Mensaje",
       "command": "Comando",
+      "whenOffline": "Si el dispositivo está sin conexión",
       "software": "Software",
       "failureNotificationChannel": "Canal de notificación de fallos"
+    },
+    "options": {
+      "whenOffline": {
+        "queue": "Poner en cola (predeterminado)",
+        "skip": "Omitir"
+      }
+    },
+    "hints": {
+      "whenOffline": "El trabajo en cola espera al dispositivo y se ejecuta en su próxima conexión, o vence a los 7 días. Omitir hace que el paso falle de inmediato."
     },
     "placeholders": {
       "name": "Control de mantenimiento diario",

--- a/apps/web/src/locales/fr-CA/scripts.json
+++ b/apps/web/src/locales/fr-CA/scripts.json
@@ -154,8 +154,18 @@
       "severity": "Gravité",
       "message": "Message",
       "command": "Commande",
+      "whenOffline": "Si l'appareil est hors ligne",
       "software": "Logiciel",
       "failureNotificationChannel": "Canal de notification d’échec"
+    },
+    "options": {
+      "whenOffline": {
+        "queue": "Mettre en file d'attente (par défaut)",
+        "skip": "Ignorer"
+      }
+    },
+    "hints": {
+      "whenOffline": "Le travail en file d'attente attend l'appareil et s'exécute à sa prochaine connexion, ou expire après 7 jours. Ignorer fait échouer l'étape immédiatement."
     },
     "placeholders": {
       "name": "Contrôle de maintenance quotidien",

--- a/apps/web/src/locales/fr-FR/scripts.json
+++ b/apps/web/src/locales/fr-FR/scripts.json
@@ -154,8 +154,18 @@
       "severity": "Gravité",
       "message": "Message",
       "command": "Commande",
+      "whenOffline": "Si l'appareil est hors ligne",
       "software": "Logiciel",
       "failureNotificationChannel": "Canal de notification d’échec"
+    },
+    "options": {
+      "whenOffline": {
+        "queue": "Mettre en file d'attente (par défaut)",
+        "skip": "Ignorer"
+      }
+    },
+    "hints": {
+      "whenOffline": "Le travail en file d'attente attend l'appareil et s'exécute à sa prochaine connexion, ou expire après 7 jours. Ignorer fait échouer l'étape immédiatement."
     },
     "placeholders": {
       "name": "Contrôle de maintenance quotidien",

--- a/apps/web/src/locales/it-IT/scripts.json
+++ b/apps/web/src/locales/it-IT/scripts.json
@@ -154,8 +154,18 @@
       "severity": "Gravità",
       "message": "Messaggio",
       "command": "Comando",
+      "whenOffline": "Se il dispositivo è offline",
       "software": "Software",
       "failureNotificationChannel": "Canale di notifica errore"
+    },
+    "options": {
+      "whenOffline": {
+        "queue": "Accoda (predefinito)",
+        "skip": "Salta"
+      }
+    },
+    "hints": {
+      "whenOffline": "Il lavoro in coda attende il dispositivo e viene eseguito alla connessione successiva, oppure scade dopo 7 giorni. Salta fa fallire subito il passaggio."
     },
     "placeholders": {
       "name": "Controllo manutenzione giornaliero",

--- a/apps/web/src/locales/pt-BR/scripts.json
+++ b/apps/web/src/locales/pt-BR/scripts.json
@@ -154,8 +154,18 @@
       "severity": "Gravidade",
       "message": "Mensagem",
       "command": "Comando",
+      "whenOffline": "Se o dispositivo estiver offline",
       "software": "Software",
       "failureNotificationChannel": "Canal de notificação de falha"
+    },
+    "options": {
+      "whenOffline": {
+        "queue": "Enfileirar (padrão)",
+        "skip": "Ignorar"
+      }
+    },
+    "hints": {
+      "whenOffline": "O trabalho na fila aguarda o dispositivo e é executado na próxima conexão, ou expira após 7 dias. Ignorar faz a etapa falhar imediatamente."
     },
     "placeholders": {
       "name": "Verificação diária de manutenção",

--- a/apps/web/src/locales/tr-TR/scripts.json
+++ b/apps/web/src/locales/tr-TR/scripts.json
@@ -154,8 +154,18 @@
       "severity": "Önem",
       "message": "Mesaj",
       "command": "Komut",
+      "whenOffline": "Cihaz çevrimdışıysa",
       "software": "Yazılım",
       "failureNotificationChannel": "Arıza Bildirim Kanalı"
+    },
+    "options": {
+      "whenOffline": {
+        "queue": "Kuyruğa al (varsayılan)",
+        "skip": "Atla"
+      }
+    },
+    "hints": {
+      "whenOffline": "Kuyruğa alınan iş cihazı bekler ve bir sonraki bağlantısında çalışır ya da 7 gün sonra sona erer. Atla adımı hemen başarısız kılar."
     },
     "placeholders": {
       "name": "Günlük bakım kontrolü",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -312,6 +312,15 @@ x-api-env: &api-env
   PARTNER_API_ENROLLMENT_KEY_WRITE_RATE_LIMIT: ${PARTNER_API_ENROLLMENT_KEY_WRITE_RATE_LIMIT:-}
   PARTNER_API_ENROLLMENT_KEY_WRITE_PARTNER_RATE_LIMIT: ${PARTNER_API_ENROLLMENT_KEY_WRITE_PARTNER_RATE_LIMIT:-}
   AUTOMATION_WEBHOOK_ALLOW_LEGACY_SECRET: ${AUTOMATION_WEBHOOK_ALLOW_LEGACY_SECRET:-}
+  # Offline work queue (#5128). Queueing for previously-rejecting callers
+  # (patches, automations, scan/rollback) is ON by default since W4 — pass
+  # `false` to opt back out. The TTL vars are per delivery class, in hours;
+  # left empty so services/commandOfflinePolicy.ts owns the defaults
+  # (168 / 24 / 24) in exactly one place.
+  DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED: ${DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED:-}
+  DEVICE_COMMAND_QUEUE_TTL_HOURS: ${DEVICE_COMMAND_QUEUE_TTL_HOURS:-}
+  DEVICE_COMMAND_QUEUE_SHORT_TTL_HOURS: ${DEVICE_COMMAND_QUEUE_SHORT_TTL_HOURS:-}
+  DEVICE_COMMAND_QUEUE_POWER_STATE_TTL_HOURS: ${DEVICE_COMMAND_QUEUE_POWER_STATE_TTL_HOURS:-}
   # Email — SMTP extras + Mailgun provider
   SMTP_FROM: ${SMTP_FROM:-}
   SMTP_SECURE: ${SMTP_SECURE:-}

--- a/packages/shared/src/validators/automationActions.test.ts
+++ b/packages/shared/src/validators/automationActions.test.ts
@@ -74,3 +74,45 @@ describe('automationActionSchema - ai_triage', () => {
     expect(parsed.success).toBe(true);
   });
 });
+
+// #5128 W4 — offline behaviour on the two device-command action types.
+describe('automationActionSchema - whenOffline', () => {
+  const SCRIPT_ID = '11111111-2222-4333-8444-555555555555';
+
+  it('defaults run_script whenOffline to queue', () => {
+    const parsed = automationActionSchema.safeParse({ type: 'run_script', scriptId: SCRIPT_ID });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) expect(parsed.data).toMatchObject({ whenOffline: 'queue' });
+  });
+
+  it('defaults execute_command whenOffline to queue', () => {
+    const parsed = automationActionSchema.safeParse({ type: 'execute_command', command: 'whoami' });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) expect(parsed.data).toMatchObject({ whenOffline: 'queue' });
+  });
+
+  it('accepts an explicit skip', () => {
+    const parsed = automationActionSchema.safeParse({
+      type: 'run_script', scriptId: SCRIPT_ID, whenOffline: 'skip',
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) expect(parsed.data).toMatchObject({ whenOffline: 'skip' });
+  });
+
+  it('rejects a value outside the enum', () => {
+    const parsed = automationActionSchema.safeParse({
+      type: 'execute_command', command: 'whoami', whenOffline: 'defer',
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it('carries whenOffline through the real create path', () => {
+    const parsed = createAutomationSchema.safeParse({
+      name: 'A',
+      trigger: { type: 'schedule', cron: '0 0 * * *' },
+      actions: [{ type: 'run_script', scriptId: SCRIPT_ID, whenOffline: 'skip' }],
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) expect(parsed.data.actions[0]).toMatchObject({ whenOffline: 'skip' });
+  });
+});

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -242,6 +242,13 @@ export const automationActionSchema = z.discriminatedUnion('type', [
     // carry it (it is a real value of the `script_run_as` enum), even though
     // the form only offers system/user.
     runAs: z.enum(['system', 'user', 'elevated']).optional(),
+    // #5128 W4 — what to do when the target device is offline at dispatch
+    // time. 'queue' (the default) persists the command with a delivery
+    // deadline and the agent claims it on its next successful heartbeat;
+    // 'skip' reproduces the pre-#5128 behaviour of failing the step with
+    // `device_offline`. Defaulted rather than optional so a stored action
+    // authored before this field existed reads as 'queue'.
+    whenOffline: z.enum(['queue', 'skip']).default('queue'),
   }),
   z.object({
     type: z.literal('send_notification'),
@@ -260,6 +267,8 @@ export const automationActionSchema = z.discriminatedUnion('type', [
     type: z.literal('execute_command'),
     command: z.string(),
     shell: z.enum(['bash', 'powershell', 'cmd']).optional(),
+    // #5128 W4 — see the run_script arm above.
+    whenOffline: z.enum(['queue', 'skip']).default('queue'),
   }),
   z.object({
     type: z.literal('deploy_software'),


### PR DESCRIPTION
Closes #5135 — Wave W04 of #5131 (spec #5128).

Three commits, in order, so 4.3 is revertable on its own:

1. `feat(automations): whenOffline action option; queued step state`
2. `feat(web): automation action offline behaviour`
3. `feat(commands): enable offline queueing for patches and automations by default`

## Release note (operators)

**Work aimed at an offline device now waits instead of failing.** Patch jobs, automation `run_script` / `execute_command` actions and scan/rollback commands are persisted with a delivery deadline and claimed by the agent on its next successful heartbeat, rather than failing immediately with `device_offline`. A step waiting on a device reports as **Queued — device offline** instead of Failed, so a nightly automation over a fleet with sleeping laptops no longer shows a wall of red. Queued work expires undelivered after its TTL (7 days standard; 24 hours for inventory and power-state work) and is cancellable from the device page.

Automations get a per-action **"If the device is offline"** control — *Queue* (default) or *Skip*. `Skip` reproduces the previous behaviour exactly, for a step that is only meaningful against a live device. Existing automations have no stored value and therefore queue; their saved payload is unchanged until an operator touches the control.

**Opting out:** set `DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED=false` in `.env`. That restores the pre-#5128 hard rejection for every gated caller. The flag is documented in `.env.example` alongside the three TTL knobs and is removed in a later release. Manual Run Script and software installs already queued today and are unaffected either way.

## What changed

**4.1 — validator + runtime.** `run_script` and `execute_command` automation actions gain `whenOffline: 'queue' | 'skip'` (`.default('queue')` in the shared validator, normalised by `normalizeAutomationActions`). `automationRuntime` translates it into an explicit `offlinePolicy` for `dispatchScriptToDevice`: `{ kind: 'queue', deliverWithinMs: deliveryTtlMs('standard') }` when the action says queue **and** the flag is on, otherwise `{ kind: 'reject' }`. `dispatch.ok && !dispatch.delivered` yields outcome `{ status: 'queued', message: 'Queued — device offline' }`, and `persistActionExecutionOutcome` writes that message onto the `automation_action_results` row; W01's reaper closes it with `expired` if the deadline passes. `deploy_software` gets no field — software already queues.

**4.2 — form control.** A select on `run_script` / `execute_command` actions in `AutomationForm`, wired through `AutomationEditPage`'s `normalizeActionForForm` / `buildActionPayload`. The field stays **optional** in the form schema and is omitted from the payload when untouched, so a pre-#5128 action round-trips byte-identically — the same discipline the #4888 `runAs` override established one layer down. Locale keys `automationForm.{fields,options,hints}.whenOffline` with real translations in all 8 locales (en, de-DE, es-419, fr-CA, fr-FR, it-IT, pt-BR, tr-TR).

**4.3 — flag default.** `isOfflineQueueEnabled()` reads `!== 'false'`.

## `requireOnline` removal

`grep -rn requireOnline apps/api/src`: **47 before → 21 after** (26 non-test → 0 non-test for the dispatch alias).

The deprecated `DispatchScriptInput.requireOnline` alias and its resolution branch are gone, along with all three dispatch call sites (two in `automationRuntime`, one in the AI `run_script` tool — which keeps an explicit `{ kind: 'reject' }` because it answers synchronously and has no way to surface a later result; W5 softens its error *text*, not its behaviour).

**Deviation from the brief:** the brief asked for a grep count of 0. The 21 remaining hits are an **unrelated** `requireOnline` parameter on the `resolveDevice`-style helper in `aiTools*.ts` (`if (requireOnline && device.status !== 'online')` — the AI tools' own device-status precheck), not the dispatch alias. Removing those would gut AI-tool online gating, which is out of this wave's scope and explicitly W5's subject. No `requireOnline` reaches `dispatchScriptToDevice` any more.

## Unplanned fix caught by a contract test

Documenting the flag in `.env.example` reddened `apps/api/src/config/envComposeParity.test.ts`: all four `DEVICE_COMMAND_*` vars were documented but never mapped into a container, so setting them in `.env` would have been a silent no-op. Fixed properly by mapping them in the `api` service's `environment:` block of `docker-compose.yml`, with empty defaults so `services/commandOfflinePolicy.ts` remains the single source of the values (168 / 24 / 24 hours). Not an allowlist entry — the guard was right.

## Verification (all foreground)

| Check | Result |
|---|---|
| `apps/api` `tsc --noEmit` | clean |
| `apps/api` **full** unit suite (`vitest run`, threads/3) | 36,786 passed, 21 skipped, **1 failed → fixed** (the compose-parity guard above; re-run green) |
| targeted API suites (automationRuntime, scriptDispatch, commandOfflinePolicy, staleCommandReaper, patchJobExecutor, automationActionResults, aiToolsScripts, routes/automations) | 584 + 221 passed |
| `packages/shared` validators | 13 passed (5 new `whenOffline` cases) |
| `apps/web` `vitest run src/components/automations src/lib/i18n` | 203 passed (15 files) |
| `apps/web` `astro check` | 0 errors, 0 warnings |
| `eslint` on every touched file | clean |

**Integration on a real Postgres — yes, this ran.** Private per-worktree stack (`test-stack up`, ephemeral port 33739), then:

```
npx vitest run --config vitest.integration.config.ts \
  src/__tests__/integration/deviceCommandOfflineQueue \
  src/__tests__/integration/scriptAdmission \
  src/__tests__/integration/deviceUninstallDrain
→ Test Files 3 passed (3) · Tests 40 passed (40)
```

Stack torn down afterwards (`docker compose ls -a` clean).

## No migration

Wave 4 adds no migration, as planned. `automation_action_results.status` already carried `'queued'` from W01; `deliveryTtlMs` / `isOfflineQueueEnabled` already existed in `commandOfflinePolicy.ts`. All three premise checks in the wave brief held.

## Notes for review

- `executeCommandAction` and `persistActionExecutionOutcome` were exported from `automationRuntime.ts` so the new suite can drive them directly, matching `executeRunScriptAction`, which was already exported for the same reason.
- `automationRuntime.runScript.test.ts` now pins `DEVICE_COMMAND_OFFLINE_QUEUE_ENABLED=false` in its `beforeEach`: that suite predates the queue and asserts the legacy reject semantics, which after 4.3 are only reachable with the flag off. Leaning on the implicit default there would have made it silently assert the wrong thing.
- `commandOfflinePolicy.test.ts` gains the only test that exercises the **unset** env var, so the default cannot flip back unnoticed. Every other flag test stubs the value explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JUGjJxEn6BBAbrDxzf63St
