### PR TITLE
feat(ai-operator): task-scoped intent identity, dispatch claim on the release CAS, cancel/kill-switch extension, operation result persistence (W04 of #5205)

### DIFF
--- a/apps/api/migrations/2026-10-14-100200-ai-operator-intent-identity.sql
+++ b/apps/api/migrations/2026-10-14-100200-ai-operator-intent-identity.sql
@@ -1,0 +1,148 @@
+-- AI Operator W04 (#5205, sub-issue #5209): operation identity on the intent.
+--
+-- W03 (2026-10-14-100000-ai-operator-thin-slice.sql) created the tables and
+-- the three nullable `action_intents` task columns. This migration closes the
+-- three gaps W04's code needs and W03's PR body named as deviations:
+--
+--  1. The `action_intents` immutability trigger's deny-list does NOT yet
+--     mention `task_id` / `task_step_key` / `operation_key`, so today a plain
+--     UPDATE could re-point a live intent at a DIFFERENT task or rewrite its
+--     operation key. That is the whole identity the operation row is keyed
+--     on, so it must be as immutable as `argument_digest` and
+--     `idempotency_key` already are. All three are set at INSERT and never
+--     written again: `action_intents_task_org_fk` is ON DELETE RESTRICT (see
+--     the W03 header — SET NULL would strand `task_step_key`/`operation_key`
+--     and instantly violate `action_intents_task_link_chk`), so unlike
+--     `scope_device_id` / `scope_ticket_id` there is NO non-null -> NULL
+--     tombstone transition to carve out. Strict immutability is therefore
+--     correct here, not over-tight.
+--
+--  2. `ai_operator_operations` needs four columns W04 writes:
+--       - `plan_revision`        the task revision the approval covers, pinned
+--                                at reservation. The dispatch claim requires
+--                                `ai_operator_tasks.revision = plan_revision`
+--                                in the SAME conditional UPDATE, so a task
+--                                whose plan was revised after approval cannot
+--                                dispatch the stale operation (spec §7.1,
+--                                "revising plan arguments creates a new
+--                                operation and approval").
+--       - `claimed_lease_epoch`  the scheduler epoch OBSERVED when the claim
+--                                was won. Recorded, not fenced on, on the
+--                                intent-release path: that path holds no lease,
+--                                and spec §6.3 requires results from an
+--                                operation a superseded epoch dispatched to be
+--                                accepted under their ORIGINAL identity. This
+--                                column is how W06 recognises one.
+--       - `cancel_requested_at`  cancel-during-`executing` (spec §7.3). The
+--                                intent stays `executing` and the effect is
+--                                reconciled; this is the durable record that a
+--                                human asked for it to stop.
+--       - `dispatch_detail`      why a claim was refused (revalidation error
+--                                code, tightened policy, lost claim). Bounded
+--                                text, never a jsonb container: every jsonb
+--                                column is `excludedOpen` in the tenant export
+--                                policy, and a refusal reason must be
+--                                exportable.
+--
+--  3. `dispatch_state` gains 'cancelled'. W03's four values
+--     ('reserved','dispatched','dispatch_failed','abandoned') cannot express
+--     "a human cancelled this before it ever dispatched". Folding that into
+--     'abandoned' would make the reconciler's "terminal task with an unsettled
+--     operation" scan unable to tell a deliberate cancel from a leaked
+--     reservation. 'in_flight' is deliberately NOT added: it would be an exact
+--     synonym of the existing 'dispatched', and two names for one state is how
+--     a vocabulary rots.
+--
+-- DDL only. No UPDATE/DELETE/INSERT runs here, so no `breeze.scope` election
+-- is required (and none is added — see migrationRlsScope.test.ts).
+-- Idempotent throughout. No new RLS policy: `action_intents` and
+-- `ai_operator_operations` are both Shape 1 with `breeze_has_org_access(org_id)`
+-- policies already declared in their creating migrations, and adding columns
+-- does not change a policy.
+
+-- ---------------------------------------------------------------------------
+-- 1. ai_operator_operations: the four W04 columns
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE ai_operator_operations
+  ADD COLUMN IF NOT EXISTS plan_revision integer;
+ALTER TABLE ai_operator_operations
+  ADD COLUMN IF NOT EXISTS claimed_lease_epoch bigint;
+ALTER TABLE ai_operator_operations
+  ADD COLUMN IF NOT EXISTS cancel_requested_at timestamptz;
+ALTER TABLE ai_operator_operations
+  ADD COLUMN IF NOT EXISTS dispatch_detail text;
+
+-- Bounded like every other exportable text column on this table's siblings.
+ALTER TABLE ai_operator_operations
+  DROP CONSTRAINT IF EXISTS ai_operator_operations_dispatch_detail_len_chk;
+ALTER TABLE ai_operator_operations
+  ADD CONSTRAINT ai_operator_operations_dispatch_detail_len_chk
+  CHECK (dispatch_detail IS NULL OR length(dispatch_detail) <= 500);
+
+COMMENT ON COLUMN ai_operator_operations.plan_revision IS
+  'ai_operator_tasks.revision pinned at reservation. The dispatch claim requires the task''s CURRENT revision to still equal this, in the same conditional UPDATE — a revised plan refuses the stale operation rather than dispatching it (spec §7.1).';
+COMMENT ON COLUMN ai_operator_operations.claimed_lease_epoch IS
+  'The ai_operator_tasks.lease_epoch OBSERVED when the dispatch claim was won. Recorded for lineage, not fenced on from the intent-release path (which holds no lease): spec §6.3 requires a result from an operation dispatched by a superseded epoch to be accepted under its ORIGINAL identity.';
+COMMENT ON COLUMN ai_operator_operations.cancel_requested_at IS
+  'Set when a human cancelled a task-linked intent that had already reached `executing`. The intent deliberately STAYS `executing` (spec §7.3: already-executing commands may finish, are shown in flight, and transition only after reconciliation) — this column is the durable "cancel asked for, reconciliation pending" record.';
+COMMENT ON COLUMN ai_operator_operations.dispatch_detail IS
+  'Why a dispatch claim was refused or a dispatch failed (revalidation error code, tightened policy, lost claim). Bounded text rather than jsonb because every jsonb column is excludedOpen in CORE_TENANT_EXPORT_POLICY and a refusal reason must stay exportable.';
+
+-- ---------------------------------------------------------------------------
+-- 2. dispatch_state gains 'cancelled'
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE ai_operator_operations
+  DROP CONSTRAINT IF EXISTS ai_operator_operations_dispatch_state_chk;
+ALTER TABLE ai_operator_operations
+  ADD CONSTRAINT ai_operator_operations_dispatch_state_chk CHECK (dispatch_state IN (
+    'reserved', 'dispatched', 'dispatch_failed', 'cancelled', 'abandoned'
+  ));
+
+-- ---------------------------------------------------------------------------
+-- 3. action_intents immutability: the three operation-identity columns
+-- ---------------------------------------------------------------------------
+-- Extend the ONE immutable-content function. Body copied verbatim from its
+-- most recent definition (2026-09-25-ai-agents-ticket-triage.sql, which itself
+-- copied 2026-09-23-ai-agents-scheduled-sweeps.sql) plus the three task
+-- columns. Strict `IS DISTINCT FROM` for all three — no null-transition carve
+-- out, see the header.
+
+CREATE OR REPLACE FUNCTION action_intents_block_content_update()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.org_id IS DISTINCT FROM OLD.org_id
+     OR NEW.requested_by_user_id IS DISTINCT FROM OLD.requested_by_user_id
+     OR NEW.requesting_api_key_id IS DISTINCT FROM OLD.requesting_api_key_id
+     OR NEW.requesting_agent_run_id IS DISTINCT FROM OLD.requesting_agent_run_id
+     OR NEW.source IS DISTINCT FROM OLD.source
+     OR NEW.origin_principal_kind IS DISTINCT FROM OLD.origin_principal_kind
+     OR NEW.origin_principal_id IS DISTINCT FROM OLD.origin_principal_id
+     OR NEW.action_name IS DISTINCT FROM OLD.action_name
+     OR NEW.action_version IS DISTINCT FROM OLD.action_version
+     OR NEW.arguments IS DISTINCT FROM OLD.arguments
+     OR NEW.argument_digest IS DISTINCT FROM OLD.argument_digest
+     OR NEW.target_summary IS DISTINCT FROM OLD.target_summary
+     OR NEW.impact_summary IS DISTINCT FROM OLD.impact_summary
+     OR NEW.reason IS DISTINCT FROM OLD.reason
+     OR NEW.risk_tier IS DISTINCT FROM OLD.risk_tier
+     OR NEW.connection_id IS DISTINCT FROM OLD.connection_id
+     OR NEW.tenant_id IS DISTINCT FROM OLD.tenant_id
+     OR NEW.idempotency_key IS DISTINCT FROM OLD.idempotency_key
+     OR NEW.correlation_id IS DISTINCT FROM OLD.correlation_id
+     OR NEW.created_at IS DISTINCT FROM OLD.created_at
+     OR NEW.expires_at IS DISTINCT FROM OLD.expires_at
+     OR NEW.approval_scope IS DISTINCT FROM OLD.approval_scope
+     OR NEW.classification_version IS DISTINCT FROM OLD.classification_version
+     OR NEW.effect_digest IS DISTINCT FROM OLD.effect_digest
+     OR NEW.scope_kind IS DISTINCT FROM OLD.scope_kind
+     OR NEW.task_id IS DISTINCT FROM OLD.task_id
+     OR NEW.task_step_key IS DISTINCT FROM OLD.task_step_key
+     OR NEW.operation_key IS DISTINCT FROM OLD.operation_key
+     OR (NEW.scope_device_id IS DISTINCT FROM OLD.scope_device_id AND NEW.scope_device_id IS NOT NULL)
+     OR (NEW.scope_ticket_id IS DISTINCT FROM OLD.scope_ticket_id AND NEW.scope_ticket_id IS NOT NULL) THEN
+    RAISE EXCEPTION 'action_intents content is immutable';
+  END IF;
+  RETURN NEW;
+END $$ LANGUAGE plpgsql;

--- a/apps/api/migrations/2026-10-14-100200-ai-operator-intent-identity.sql
+++ b/apps/api/migrations/2026-10-14-100200-ai-operator-intent-identity.sql
@@ -104,10 +104,12 @@ ALTER TABLE ai_operator_operations
 -- 3. action_intents immutability: the three operation-identity columns
 -- ---------------------------------------------------------------------------
 -- Extend the ONE immutable-content function. Body copied verbatim from its
--- most recent definition (2026-09-25-ai-agents-ticket-triage.sql, which itself
--- copied 2026-09-23-ai-agents-scheduled-sweeps.sql) plus the three task
--- columns. Strict `IS DISTINCT FROM` for all three — no null-transition carve
--- out, see the header.
+-- most recent definition, 2026-09-25-ai-agents-ticket-triage.sql, plus the
+-- three task columns. (That file is the CURRENT definition; it is not itself
+-- byte-identical to the 2026-09-23 one before it, which is why it — and not
+-- the original 2026-07-18 creation — is the file to diff against.)
+-- Strict `IS DISTINCT FROM` for all three — no null-transition carve-out, see
+-- the header.
 
 CREATE OR REPLACE FUNCTION action_intents_block_content_update()
 RETURNS TRIGGER AS $$

--- a/apps/api/src/__tests__/integration/actionIntentsImmutabilityTrigger.integration.test.ts
+++ b/apps/api/src/__tests__/integration/actionIntentsImmutabilityTrigger.integration.test.ts
@@ -229,6 +229,16 @@ describe('action_intents immutability trigger (live DB)', () => {
     // direction; the allowed tombstone (non-null -> NULL) is exercised
     // elsewhere once a Task A3/A6 fixture seeds a non-null starting value.
     scope_ticket_id: { scopeTicketId: randomUUID() },
+    // 2026-10-14-100200 (#5205 W04, #5209): AI Operator operation identity.
+    // Unconditional guards — no tombstone direction to permit, because
+    // `action_intents_task_org_fk` is ON DELETE RESTRICT. The seeded intent
+    // starts with all three NULL, so setting any one of them is the blocked
+    // direction, and the BEFORE UPDATE trigger raises before either the
+    // all-or-none CHECK (`action_intents_task_link_chk`) or the FK gets to
+    // complain — which is what makes a single-column patch a valid probe here.
+    task_id: { taskId: randomUUID() },
+    task_step_key: { taskStepKey: 'restart-service' },
+    operation_key: { operationKey: 'restart:spooler:1' },
   };
 
   it('has a behavioral case for every column on the trigger deny-list', () => {

--- a/apps/api/src/__tests__/integration/aiOperatorDispatchClaim.integration.test.ts
+++ b/apps/api/src/__tests__/integration/aiOperatorDispatchClaim.integration.test.ts
@@ -1,0 +1,623 @@
+/**
+ * The AI Operator dispatch claim — real Postgres (#5205 W04, sub-issue #5209,
+ * spec §7.3, baseline C8/H3).
+ *
+ * Drives the REAL `claimTaskLinkedIntentForDispatch`, `revertTaskLinkedDispatchClaim`,
+ * `recordOperationResult`, and `reapStaleExecutingIntents`. `dispatchClaim.test.ts`
+ * already proves `evaluateTaskClaimPredicate`'s truth table as a pure function —
+ * what only a real database can prove is that the SQL wired around it (the
+ * `FOR UPDATE` lock order, the intent CAS re-stating the SAME predicate, the
+ * concurrent-claim serialisation, the rank-ordered result write) actually
+ * behaves the way the module's own header says it does.
+ *
+ * Fixtures are seeded per-test (not in beforeAll): setup.ts TRUNCATEs core
+ * tenant tables in a global beforeEach, and every table here hangs off
+ * organizations.
+ */
+import './setup';
+import { getTestDb } from './setup';
+
+import { randomUUID } from 'node:crypto';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../../db';
+import {
+  actionIntents,
+  aiAgentRuns,
+  aiAgents,
+  aiOperatorOperations,
+  aiOperatorTasks,
+  devices,
+} from '../../db/schema';
+import { buildAgentAuthContext } from '../../services/aiAgents/agentAuthContext';
+import { createActionIntent, transitionIntent } from '../../services/actionIntents/intentService';
+import {
+  claimTaskLinkedIntentForDispatch,
+  revertTaskLinkedDispatchClaim,
+  type TaskLinkedIntentRef,
+} from '../../services/aiOperator/dispatchClaim';
+import { recordOperationResult } from '../../services/aiOperator/operationService';
+import { reapStaleExecutingIntents } from '../../jobs/intentExpiryReaper';
+import {
+  assignUserToOrganization,
+  createOrganization,
+  createPartner,
+  createRole,
+  createSite,
+  createUser,
+  grantRolePermissions,
+} from './db-utils';
+import { PERMISSIONS } from '../../services/permissions';
+
+/** Same fixture tool as aiOperatorIntentIdentity.integration.test.ts —
+ * `manage_services` `restart`, genuinely Tier-3 `supervised`, `shadow` mode
+ * proposes (never auto-executes). See that file's header for the full
+ * rationale. */
+const TOOL_NAME = 'manage_services';
+const TASK_STEP_KEY = 'restart-spooler';
+const OPERATION_KEY = 'restart:spooler';
+
+interface Tenant {
+  partnerId: string;
+  orgId: string;
+  siteId: string;
+  requesterId: string;
+  agentId: string;
+  deviceId: string;
+}
+
+/** Seeds one tenant with a target-eligible human (`devices:execute`) so the
+ * supervised fan-out on intent creation does not auto-cancel the proposal
+ * with `no_eligible_approvers` before this suite ever gets to a claim. */
+async function seedTenant(): Promise<Tenant> {
+  const partner = await createPartner();
+  const org = await createOrganization({ partnerId: partner.id });
+  const site = await createSite({ orgId: org.id });
+
+  const requester = await createUser({
+    partnerId: partner.id,
+    orgId: org.id,
+    email: `requester-${randomUUID()}@opclaim.test`,
+  });
+
+  const eligibleRole = await createRole({ scope: 'organization', orgId: org.id });
+  await grantRolePermissions(eligibleRole.id, [PERMISSIONS.DEVICES_EXECUTE]);
+  const eligible = await createUser({
+    partnerId: partner.id,
+    orgId: org.id,
+    email: `eligible-${randomUUID()}@opclaim.test`,
+  });
+  await assignUserToOrganization(eligible.id, org.id, eligibleRole.id);
+
+  const [agent] = await withSystemDbAccessContext(() =>
+    db
+      .insert(aiAgents)
+      .values({ orgId: org.id, partnerId: null, kind: 'triage', name: 'Operator', createdBy: requester.id })
+      .returning(),
+  );
+
+  const adminDb = getTestDb() as unknown as typeof db;
+  const unique = randomUUID().slice(0, 8);
+  const [device] = await adminDb
+    .insert(devices)
+    .values({
+      orgId: org.id,
+      siteId: site.id,
+      agentId: `opclaim-agent-${unique}`,
+      hostname: `opclaim-host-${unique}`,
+      osType: 'linux',
+      osVersion: '22.04',
+      architecture: 'x86_64',
+      agentVersion: '0.0.0-test',
+      status: 'online',
+    })
+    .returning();
+
+  return {
+    partnerId: partner.id,
+    orgId: org.id,
+    siteId: site.id,
+    requesterId: requester.id,
+    agentId: agent!.id,
+    deviceId: (device as { id: string }).id,
+  };
+}
+
+async function createTask(
+  t: Tenant,
+  overrides: Partial<typeof aiOperatorTasks.$inferInsert> = {},
+): Promise<{ taskId: string; revision: number }> {
+  const revision = (overrides.revision as number | undefined) ?? 1;
+  const [row] = await withSystemDbAccessContext(() =>
+    db
+      .insert(aiOperatorTasks)
+      .values({
+        orgId: t.orgId,
+        agentId: t.agentId,
+        agentKind: 'triage',
+        agentName: 'Operator',
+        workflowKey: 'service_recovery',
+        workflowVersion: 1,
+        originKind: 'manual' as const,
+        requesterUserId: t.requesterId,
+        objective: 'Restart the print spooler on PRINTSRV01',
+        deviceId: t.deviceId,
+        state: 'running',
+        revision,
+        leaseEpoch: 0,
+        deadlineAt: new Date(Date.now() + 3_600_000),
+        targetDetachedAt: null,
+        ...overrides,
+      })
+      .returning({ id: aiOperatorTasks.id }),
+  );
+  return { taskId: row!.id, revision };
+}
+
+function agentPolicySnapshot() {
+  return {
+    schemaVersion: 1,
+    effective: {
+      enabled: true,
+      mode: 'shadow' as const,
+      model: null,
+      toolAllowlist: [TOOL_NAME],
+      protectedResources: { services: [], paths: [], registryKeys: [], deviceTags: [] },
+      limits: {},
+      triggers: {},
+      recipients: { userIds: [], roleIds: [] },
+      instructions: null,
+      cooldownSeconds: 900,
+    },
+    resolvedAt: new Date().toISOString(),
+  };
+}
+
+async function createRun(t: Tenant, task: { taskId: string; taskStepKey: string; attemptOrdinal: number }): Promise<string> {
+  const [row] = await withSystemDbAccessContext(() =>
+    db
+      .insert(aiAgentRuns)
+      .values({
+        agentId: t.agentId,
+        orgId: t.orgId,
+        deviceId: t.deviceId,
+        triggerKind: 'alert' as const,
+        dedupeKey: `opclaim-${randomUUID()}`,
+        modeAtStart: 'shadow' as const,
+        policySnapshot: agentPolicySnapshot() as never,
+        taskId: task.taskId,
+        taskStepKey: task.taskStepKey,
+        taskAttemptOrdinal: task.attemptOrdinal,
+      })
+      .returning({ id: aiAgentRuns.id }),
+  );
+  return row!.id;
+}
+
+function serviceInput(t: Tenant): Record<string, unknown> {
+  return { deviceId: t.deviceId, action: 'restart', serviceName: 'spooler' };
+}
+
+/**
+ * Creates the full real chain — task, run, `createActionIntent` proposal — and
+ * hand-approves it (`transitionIntent` is the shared CAS primitive; the
+ * approve ROUTE's own authorization/notification machinery is not what this
+ * suite is about) so the fixture lands exactly where the dispatch claim's
+ * precondition starts: `approved`, with a `reserved` operation and a known
+ * `release_by`. Returns everything a claim needs.
+ */
+async function seedApprovedTaskIntent(
+  t: Tenant,
+  opts: { taskOverrides?: Partial<typeof aiOperatorTasks.$inferInsert>; releaseBy?: Date } = {},
+): Promise<{ intentId: string; taskId: string; revision: number; runId: string }> {
+  const task = await createTask(t, opts.taskOverrides);
+  const runId = await createRun(t, { taskId: task.taskId, taskStepKey: TASK_STEP_KEY, attemptOrdinal: 0 });
+  const auth = buildAgentAuthContext(
+    { id: t.agentId, orgId: t.orgId, partnerId: null, name: 'Operator', kind: 'triage' },
+    { id: runId, orgId: t.orgId, deviceId: t.deviceId, deviceSiteId: t.siteId },
+    { id: t.orgId, partnerId: t.partnerId },
+  );
+  const snapshot = await createActionIntent(auth, {
+    toolName: TOOL_NAME,
+    input: serviceInput(t),
+    source: 'ai_agent',
+    task: { taskId: task.taskId, taskStepKey: TASK_STEP_KEY, operationKey: OPERATION_KEY, attemptOrdinal: 0 },
+  });
+  expect(snapshot.status).toBe('pending_approval');
+
+  const releaseBy = opts.releaseBy ?? new Date(Date.now() + 600_000);
+  const won = await transitionIntent(snapshot.id, 'pending_approval', 'approved', {
+    decidedAt: new Date(),
+  });
+  expect(won).toBe(true);
+  // `release_by` is not part of `ActionIntentTransitionPatch` — the real
+  // approve fan-in stamps it in its own CAS (routes/approvals.ts). Stamped
+  // directly here rather than widening a production type for a fixture; the
+  // lease is what the claim's deadline predicate reads, so it has to be real.
+  await withSystemDbAccessContext(async () => {
+    await db.update(actionIntents).set({ releaseBy }).where(eq(actionIntents.id, snapshot.id));
+  });
+
+  return { intentId: snapshot.id, taskId: task.taskId, revision: task.revision, runId };
+}
+
+async function readIntent(id: string) {
+  return withSystemDbAccessContext(async () => {
+    const [row] = await db.select().from(actionIntents).where(eq(actionIntents.id, id)).limit(1);
+    return row ?? null;
+  });
+}
+
+async function readOperationByIntent(intentId: string) {
+  return withSystemDbAccessContext(async () => {
+    const [row] = await db.select().from(aiOperatorOperations).where(eq(aiOperatorOperations.intentId, intentId)).limit(1);
+    return row ?? null;
+  });
+}
+
+async function readTask(taskId: string) {
+  return withSystemDbAccessContext(async () => {
+    const [row] = await db.select().from(aiOperatorTasks).where(eq(aiOperatorTasks.id, taskId)).limit(1);
+    return row ?? null;
+  });
+}
+
+async function updateTask(taskId: string, patch: Partial<typeof aiOperatorTasks.$inferInsert>) {
+  await withSystemDbAccessContext(() =>
+    db.update(aiOperatorTasks).set(patch).where(eq(aiOperatorTasks.id, taskId)),
+  );
+}
+
+async function updateOperation(intentId: string, patch: Partial<typeof aiOperatorOperations.$inferInsert>) {
+  await withSystemDbAccessContext(() =>
+    db.update(aiOperatorOperations).set(patch).where(eq(aiOperatorOperations.intentId, intentId)),
+  );
+}
+
+function ref(t: Tenant, intentId: string, taskId: string): TaskLinkedIntentRef {
+  return { id: intentId, orgId: t.orgId, taskId };
+}
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+beforeEach(() => {
+  vi.stubEnv('BREEZE_AI_AGENTS_ENABLED', 'true');
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('claimTaskLinkedIntentForDispatch (real Postgres, spec §7.3)', () => {
+  runDb('happy claim: intent -> executing, operation -> dispatched with the observed lease epoch', async () => {
+    const t = await seedTenant();
+    const fixture = await seedApprovedTaskIntent(t, { taskOverrides: { leaseEpoch: 42 } });
+
+    const result = await claimTaskLinkedIntentForDispatch(ref(t, fixture.intentId, fixture.taskId));
+    expect(result).toMatchObject({ won: true, leaseEpoch: 42 });
+
+    const intentRow = await readIntent(fixture.intentId);
+    expect(intentRow!.status).toBe('executing');
+    expect(intentRow!.executionStartedAt).not.toBeNull();
+
+    const opRow = await readOperationByIntent(fixture.intentId);
+    expect(opRow!.dispatchState).toBe('dispatched');
+    expect(opRow!.dispatchedAt).not.toBeNull();
+    expect(opRow!.claimedLeaseEpoch).toBe(42);
+  });
+
+  runDb('concurrent double claim on the SAME intent: exactly one wins, exactly one operation ends dispatched', async () => {
+    const t = await seedTenant();
+    const fixture = await seedApprovedTaskIntent(t);
+    const claimRef = ref(t, fixture.intentId, fixture.taskId);
+
+    // Each call opens its OWN transaction (withSystemDbAccessContext) and
+    // takes the task row FOR UPDATE first — that lock is what must serialise
+    // these rather than letting both read 'approved'/'reserved' and both win.
+    const [a, b] = await Promise.all([
+      claimTaskLinkedIntentForDispatch(claimRef),
+      claimTaskLinkedIntentForDispatch(claimRef),
+    ]);
+
+    const wins = [a, b].filter((r) => r.won);
+    const losses = [a, b].filter((r) => !r.won);
+    expect(wins).toHaveLength(1);
+    expect(losses).toHaveLength(1);
+
+    const intentRow = await readIntent(fixture.intentId);
+    expect(intentRow!.status).toBe('executing');
+    const opRow = await readOperationByIntent(fixture.intentId);
+    expect(opRow!.dispatchState).toBe('dispatched');
+  });
+
+  describe('refused when the task cannot admit a new effect', () => {
+    runDb.each(['paused', 'stopping', 'completed'] as const)('task state = %s', async (state) => {
+      const t = await seedTenant();
+      const fixture = await seedApprovedTaskIntent(t);
+      await updateTask(fixture.taskId, { state });
+
+      const result = await claimTaskLinkedIntentForDispatch(ref(t, fixture.intentId, fixture.taskId));
+      expect(result).toMatchObject({ won: false, refusal: 'task_not_claimable' });
+
+      // Nothing moved — a lost/refused claim writes nothing at all.
+      const intentRow = await readIntent(fixture.intentId);
+      expect(intentRow!.status).toBe('approved');
+      const opRow = await readOperationByIntent(fixture.intentId);
+      expect(opRow!.dispatchState).toBe('reserved');
+    });
+  });
+
+  runDb('refused when the task deadline has passed', async () => {
+    const t = await seedTenant();
+    const fixture = await seedApprovedTaskIntent(t);
+    await updateTask(fixture.taskId, { deadlineAt: new Date(Date.now() - 60_000) });
+
+    const result = await claimTaskLinkedIntentForDispatch(ref(t, fixture.intentId, fixture.taskId));
+    expect(result).toMatchObject({ won: false, refusal: 'task_not_claimable' });
+    expect((result as { detail: string }).detail).toContain('deadline');
+
+    expect((await readIntent(fixture.intentId))!.status).toBe('approved');
+    expect((await readOperationByIntent(fixture.intentId))!.dispatchState).toBe('reserved');
+  });
+
+  runDb('FAIL CLOSED: refused when the task has no deadline at all', async () => {
+    const t = await seedTenant();
+    const fixture = await seedApprovedTaskIntent(t);
+    await updateTask(fixture.taskId, { deadlineAt: null });
+
+    const result = await claimTaskLinkedIntentForDispatch(ref(t, fixture.intentId, fixture.taskId));
+    expect(result).toMatchObject({ won: false, refusal: 'task_not_claimable' });
+    expect((result as { detail: string }).detail).toContain('no deadline_at');
+
+    expect((await readIntent(fixture.intentId))!.status).toBe('approved');
+    expect((await readOperationByIntent(fixture.intentId))!.dispatchState).toBe('reserved');
+  });
+
+  runDb('refused when the target is detached (device moved/deleted)', async () => {
+    const t = await seedTenant();
+    const fixture = await seedApprovedTaskIntent(t);
+    await updateTask(fixture.taskId, { targetDetachedAt: new Date(), targetDetachedReason: 'device_moved' });
+
+    const result = await claimTaskLinkedIntentForDispatch(ref(t, fixture.intentId, fixture.taskId));
+    expect(result).toMatchObject({ won: false, refusal: 'task_not_claimable' });
+    expect((result as { detail: string }).detail).toContain('detached');
+
+    expect((await readIntent(fixture.intentId))!.status).toBe('approved');
+    expect((await readOperationByIntent(fixture.intentId))!.dispatchState).toBe('reserved');
+  });
+
+  runDb('refused when the plan revision moved after the operation was reserved', async () => {
+    const t = await seedTenant();
+    const fixture = await seedApprovedTaskIntent(t);
+    // The operation pinned revision 1 at reservation; bump the task forward —
+    // spec §7.1's "a revised plan creates a new operation and approval; a
+    // stale one must not dispatch."
+    await updateTask(fixture.taskId, { revision: fixture.revision + 1 });
+
+    const result = await claimTaskLinkedIntentForDispatch(ref(t, fixture.intentId, fixture.taskId));
+    expect(result).toMatchObject({ won: false, refusal: 'task_not_claimable' });
+    expect((result as { detail: string }).detail).toContain('revision moved');
+
+    expect((await readIntent(fixture.intentId))!.status).toBe('approved');
+    expect((await readOperationByIntent(fixture.intentId))!.dispatchState).toBe('reserved');
+  });
+
+  runDb("refused when the intent's release lease has passed", async () => {
+    const t = await seedTenant();
+    const fixture = await seedApprovedTaskIntent(t, { releaseBy: new Date(Date.now() - 60_000) });
+
+    const result = await claimTaskLinkedIntentForDispatch(ref(t, fixture.intentId, fixture.taskId));
+    expect(result).toMatchObject({ won: false, refusal: 'intent_not_claimable' });
+
+    // The task predicate passed (it's still running/in-revision/in-deadline);
+    // it is specifically the intent CAS's own release-lease guard that fired.
+    expect((await readIntent(fixture.intentId))!.status).toBe('approved');
+    expect((await readOperationByIntent(fixture.intentId))!.dispatchState).toBe('reserved');
+  });
+});
+
+describe('revertTaskLinkedDispatchClaim (kill-switch reversal, real Postgres)', () => {
+  runDb('a won claim reverses cleanly: executing -> approved, dispatched -> reserved with dispatched_at cleared', async () => {
+    const t = await seedTenant();
+    const fixture = await seedApprovedTaskIntent(t);
+    const won = await claimTaskLinkedIntentForDispatch(ref(t, fixture.intentId, fixture.taskId));
+    expect(won.won).toBe(true);
+
+    const reverted = await revertTaskLinkedDispatchClaim(fixture.intentId, 'kill_switch_engaged');
+    expect(reverted).toBe(true);
+
+    const intentRow = await readIntent(fixture.intentId);
+    expect(intentRow!.status).toBe('approved');
+
+    const opRow = await readOperationByIntent(fixture.intentId);
+    expect(opRow!.dispatchState).toBe('reserved');
+    expect(opRow!.dispatchedAt).toBeNull();
+  });
+
+  runDb('reverting an already-approved (not executing) intent returns false and touches nothing', async () => {
+    const t = await seedTenant();
+    const fixture = await seedApprovedTaskIntent(t);
+    const won = await claimTaskLinkedIntentForDispatch(ref(t, fixture.intentId, fixture.taskId));
+    expect(won.won).toBe(true);
+    const firstRevert = await revertTaskLinkedDispatchClaim(fixture.intentId, 'kill_switch_engaged');
+    expect(firstRevert).toBe(true);
+
+    // Intent is now 'approved' again — a second reversal call (a duplicate
+    // delivery, or the kill switch firing twice) must lose its CAS and leave
+    // the operation exactly as the first reversal left it.
+    const secondRevert = await revertTaskLinkedDispatchClaim(fixture.intentId, 'kill_switch_engaged');
+    expect(secondRevert).toBe(false);
+
+    const opRow = await readOperationByIntent(fixture.intentId);
+    expect(opRow!.dispatchState).toBe('reserved');
+    expect(opRow!.dispatchedAt).toBeNull();
+  });
+});
+
+describe('recordOperationResult (real Postgres, independent of the intent CAS)', () => {
+  runDb('persists the execution reference and result while the intent is still executing', async () => {
+    const t = await seedTenant();
+    const fixture = await seedApprovedTaskIntent(t);
+    const claim = await claimTaskLinkedIntentForDispatch(ref(t, fixture.intentId, fixture.taskId));
+    expect(claim.won).toBe(true);
+
+    const execRefId = randomUUID();
+    await recordOperationResult({
+      intentId: fixture.intentId,
+      resultState: 'succeeded',
+      result: { status: 'completed', note: 'first' },
+      executionRef: { kind: 'device_command', id: execRefId },
+    });
+
+    const opRow = await readOperationByIntent(fixture.intentId);
+    expect(opRow!.executionRefKind).toBe('device_command');
+    expect(opRow!.executionRefId).toBe(execRefId);
+    expect(opRow!.resultState).toBe('succeeded');
+    expect(opRow!.result).toMatchObject({ status: 'completed', note: 'first' });
+    expect(opRow!.resultAt).not.toBeNull();
+
+    // The intent itself is untouched by this call — recordOperationResult
+    // never CASes action_intents.
+    expect((await readIntent(fixture.intentId))!.status).toBe('executing');
+  });
+
+  runDb('still lands after the intent is flipped to failed BY HAND — the write does not depend on winning a CAS', async () => {
+    const t = await seedTenant();
+    const fixture = await seedApprovedTaskIntent(t);
+    const claim = await claimTaskLinkedIntentForDispatch(ref(t, fixture.intentId, fixture.taskId));
+    expect(claim.won).toBe(true);
+
+    // First write: a low-rank 'unknown' (the reaper's own outcome shape),
+    // recorded while everything is still nominally in flight.
+    await recordOperationResult({
+      intentId: fixture.intentId,
+      resultState: 'unknown',
+      result: { note: 'reaper-shaped' },
+    });
+    expect((await readOperationByIntent(fixture.intentId))!.resultState).toBe('unknown');
+
+    // Flip the intent's OWN status to a terminal one by hand — simulating
+    // the stale-executing reaper (or any other writer) having already moved
+    // it. The intent's CAS state has nothing to do with whether the
+    // operation row can still be written.
+    await transitionIntent(fixture.intentId, 'executing', 'failed', { errorCode: 'execution_lost' });
+
+    const execRefId = randomUUID();
+    await recordOperationResult({
+      intentId: fixture.intentId,
+      resultState: 'succeeded',
+      result: { status: 'completed', note: 'late-real-result' },
+      executionRef: { kind: 'device_command', id: execRefId },
+    });
+
+    const opRow = await readOperationByIntent(fixture.intentId);
+    expect(opRow!.resultState).toBe('succeeded');
+    expect(opRow!.result).toMatchObject({ status: 'completed', note: 'late-real-result' });
+    expect(opRow!.executionRefKind).toBe('device_command');
+    expect(opRow!.executionRefId).toBe(execRefId);
+
+    // The intent stays exactly where the hand-flip left it — recordOperationResult
+    // does not (and must not) touch action_intents.
+    expect((await readIntent(fixture.intentId))!.status).toBe('failed');
+  });
+
+  describe('rank ordering (unknown < succeeded/failed < nothing overwrites a definite outcome)', () => {
+    runDb.each(['succeeded', 'failed'] as const)(
+      "'unknown' does NOT overwrite a recorded '%s'",
+      async (definiteState) => {
+        const t = await seedTenant();
+        const fixture = await seedApprovedTaskIntent(t);
+        await claimTaskLinkedIntentForDispatch(ref(t, fixture.intentId, fixture.taskId));
+
+        await recordOperationResult({
+          intentId: fixture.intentId,
+          resultState: definiteState,
+          result: { note: 'definite-first' },
+        });
+        const before = await readOperationByIntent(fixture.intentId);
+        expect(before!.resultState).toBe(definiteState);
+        const resultAtBefore = before!.resultAt;
+
+        // A late 'unknown' (e.g. the reaper firing after a real result
+        // already landed) must not clobber the definite outcome.
+        await recordOperationResult({
+          intentId: fixture.intentId,
+          resultState: 'unknown',
+          result: { note: 'stale-unknown' },
+        });
+
+        const after = await readOperationByIntent(fixture.intentId);
+        expect(after!.resultState).toBe(definiteState);
+        expect(after!.result).toMatchObject({ note: 'definite-first' });
+        expect(after!.resultAt?.getTime()).toBe(resultAtBefore?.getTime());
+      },
+    );
+
+    runDb("a definite 'succeeded' DOES overwrite a recorded 'unknown'", async () => {
+      const t = await seedTenant();
+      const fixture = await seedApprovedTaskIntent(t);
+      await claimTaskLinkedIntentForDispatch(ref(t, fixture.intentId, fixture.taskId));
+
+      await recordOperationResult({
+        intentId: fixture.intentId,
+        resultState: 'unknown',
+        result: { note: 'reaper-first' },
+      });
+      expect((await readOperationByIntent(fixture.intentId))!.resultState).toBe('unknown');
+
+      const execRefId = randomUUID();
+      await recordOperationResult({
+        intentId: fixture.intentId,
+        resultState: 'succeeded',
+        result: { status: 'completed', note: 'late-real-result' },
+        executionRef: { kind: 'device_command', id: execRefId },
+      });
+
+      const after = await readOperationByIntent(fixture.intentId);
+      expect(after!.resultState).toBe('succeeded');
+      expect(after!.result).toMatchObject({ status: 'completed', note: 'late-real-result' });
+      expect(after!.executionRefId).toBe(execRefId);
+    });
+  });
+});
+
+describe('reapStaleExecutingIntents (real Postgres, spec §7.3 "three clocks")', () => {
+  runDb(
+    "marks a stale-executing task-linked intent failed/execution_lost, and its operation 'unknown' (NEVER 'failed')",
+    async () => {
+      const t = await seedTenant();
+      const fixture = await seedApprovedTaskIntent(t);
+      const claim = await claimTaskLinkedIntentForDispatch(ref(t, fixture.intentId, fixture.taskId));
+      expect(claim.won).toBe(true);
+
+      // Backdate execution_started_at past the 20-minute stale-executing
+      // threshold (jobs/intentExpiryReaper.ts's STALE_EXECUTING_TIMEOUT_MINUTES).
+      await withSystemDbAccessContext(() =>
+        db
+          .update(actionIntents)
+          .set({ executionStartedAt: new Date(Date.now() - 25 * 60 * 1000) })
+          .where(eq(actionIntents.id, fixture.intentId)),
+      );
+
+      // reapStaleExecutingIntents() opens no context of its own — the
+      // scheduled loop's own runWithSystemDbAccess wrapper supplies it
+      // (intentExpiryReaper.ts:390-391); replicate that here rather than
+      // calling it bare.
+      const reaped = await withSystemDbAccessContext(() => reapStaleExecutingIntents());
+      expect(reaped).toBeGreaterThanOrEqual(1);
+
+      const intentRow = await readIntent(fixture.intentId);
+      expect(intentRow!.status).toBe('failed');
+      expect(intentRow!.errorCode).toBe('execution_lost');
+
+      // THE property spec §7.3 forbids getting backwards: the server giving
+      // up after 20 minutes is not proof the effect failed — the device
+      // command itself stays open to a late agent result past its own
+      // 5-minute reap. 'unknown', never 'failed'.
+      const opRow = await readOperationByIntent(fixture.intentId);
+      expect(opRow!.resultState).toBe('unknown');
+      expect(opRow!.resultState).not.toBe('failed');
+      expect(opRow!.resultAt).not.toBeNull();
+    },
+  );
+});

--- a/apps/api/src/__tests__/integration/aiOperatorDispatchClaim.integration.test.ts
+++ b/apps/api/src/__tests__/integration/aiOperatorDispatchClaim.integration.test.ts
@@ -330,6 +330,29 @@ describe('claimTaskLinkedIntentForDispatch (real Postgres, spec §7.3)', () => {
     expect(opRow!.dispatchState).toBe('dispatched');
   });
 
+  // NOTE FOR THE NEXT WAVE — the lock order is NOT covered by a test here, on
+  // purpose (review finding, PR #5259).
+  //
+  // The claim takes task -> operation -> intent; the reversal and
+  // `cancelActionIntent`'s task-linked branch originally took intent ->
+  // operation, an AB-BA cycle on {operation, intent} that Postgres resolves by
+  // aborting one side with 40P01. Both now take the operation row `FOR UPDATE`
+  // before touching the intent. Two ways to test that were tried and both
+  // rejected:
+  //
+  //   - Racing the two paths with `Promise.all`: the window between the two
+  //     locks is microseconds. Eight attempts against the deliberately BROKEN
+  //     ordering all came back green, so it proves nothing.
+  //   - Asserting the order directly by holding the intent row locked from a
+  //     second connection and probing the operation row with `FOR UPDATE
+  //     NOWAIT`: this is genuinely discriminating, but a held row lock in this
+  //     file leaks into the shared `./setup` TRUNCATE hook and took the rest of
+  //     the suite down with it (17 unrelated failures).
+  //
+  // So the ordering is enforced by the code and its comments at all three
+  // sites, not by an assertion. If you touch any of them, re-read
+  // `dispatchClaim.ts`'s header before you move a lock.
+
   describe('refused when the task cannot admit a new effect', () => {
     runDb.each(['paused', 'stopping', 'completed'] as const)('task state = %s', async (state) => {
       const t = await seedTenant();

--- a/apps/api/src/__tests__/integration/aiOperatorIntentIdentity.integration.test.ts
+++ b/apps/api/src/__tests__/integration/aiOperatorIntentIdentity.integration.test.ts
@@ -1,0 +1,662 @@
+/**
+ * AI Operator task/operation identity — real Postgres (#5205 W04, sub-issue
+ * #5209, baseline C6/H1/H4).
+ *
+ * Drives the REAL `createActionIntent` (never a mock of it or of the
+ * guardrail path it re-verifies) against `manage_services` `restart` — a
+ * genuinely Tier-3 `supervised` tool an `ai_agent` principal in `shadow` mode
+ * is allowed to PROPOSE (never auto-execute) — and asserts the row contents
+ * `deriveIntentIdempotencyKey` / `isSameTaskOperationReuse` / the
+ * `reserveOperation` reservation exist to produce. A mocked unit suite
+ * (`intentOperationIdentity.test.ts`) already proves the two pure helpers'
+ * truth table in isolation; what only a real database can prove is that the
+ * SQL wired around them — the partial live-only unique on
+ * `action_intents_org_idem_uniq`, the permanent `(org_id, task_id,
+ * operation_key)` unique on `ai_operator_operations`, and the one transaction
+ * spanning both — actually behaves the way the contract says it does.
+ *
+ * Fixtures are seeded per-test (not in beforeAll): setup.ts TRUNCATEs core
+ * tenant tables in a global beforeEach, and every table here hangs off
+ * organizations.
+ */
+import './setup';
+import { getTestDb } from './setup';
+
+import { randomUUID } from 'node:crypto';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { and, eq } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../../db';
+import {
+  actionIntents,
+  aiAgentRuns,
+  aiAgents,
+  aiOperatorOperations,
+  aiOperatorTasks,
+  devices,
+} from '../../db/schema';
+import { buildOrgAccessClosures, type AuthContext } from '../../middleware/auth';
+import { buildAgentAuthContext } from '../../services/aiAgents/agentAuthContext';
+import {
+  cancelActionIntent,
+  createActionIntent,
+  deriveIdempotencyKey,
+  deriveIntentIdempotencyKey,
+  transitionIntent,
+} from '../../services/actionIntents/intentService';
+import { canonicalizeArguments, computeArgumentDigest } from '../../services/actionIntents/canonicalize';
+import { PERMISSIONS } from '../../services/permissions';
+import {
+  assignUserToOrganization,
+  createOrganization,
+  createPartner,
+  createRole,
+  createSite,
+  createUser,
+  grantRolePermissions,
+} from './db-utils';
+
+/**
+ * `manage_services` `restart` — TIER3_SUPERVISED_ACTIONS (aiGuardrails.ts),
+ * genuinely mutating, device-bound. Verified against
+ * `intentOperationIdentity.test.ts` (same tool) and
+ * `agentIntentLifecycle.integration.test.ts` (same tool, proves the fan-out
+ * populates for exactly this action). `checkAgentGuardrails` returns
+ * `disposition: 'propose'` for it under `mode: 'shadow'` — never `deny`
+ * (would need `tool_not_tier3`/`agent_policy_denied` reclassification to pick
+ * a different tool) and never `act` (shadow mode never auto-executes).
+ */
+const TOOL_NAME = 'manage_services';
+const TASK_STEP_KEY = 'restart-spooler';
+const OPERATION_KEY = 'restart:spooler';
+
+interface Tenant {
+  partnerId: string;
+  orgId: string;
+  siteId: string;
+  requesterId: string;
+  approverId: string;
+  approverEmail: string;
+  approverRoleId: string;
+  agentId: string;
+  deviceId: string;
+}
+
+/**
+ * Seeds one tenant: an org-owned agent (so `assertRunOwnership`'s org-agent
+ * branch applies), a device the run/proposals target, and ONE human who
+ * holds both `devices:execute` (the action-and-target authority
+ * `resolveAgentIntentApprovers` requires to be fanned a supervised agent
+ * proposal — without this the intent's fan-out pool is empty and
+ * `runHumanFanout` auto-cancels it with `no_eligible_approvers` before this
+ * suite's assertions ever run) and `approvals:decide` (what `cancelActionIntent`
+ * requires of a non-requester canceller; agent-originated intents have no
+ * requester at all, so this is the ONLY door in).
+ */
+async function seedTenant(): Promise<Tenant> {
+  const partner = await createPartner();
+  const org = await createOrganization({ partnerId: partner.id });
+  const site = await createSite({ orgId: org.id });
+
+  const requester = await createUser({
+    partnerId: partner.id,
+    orgId: org.id,
+    email: `requester-${randomUUID()}@opintent.test`,
+  });
+
+  const approverRole = await createRole({ scope: 'organization', orgId: org.id });
+  await grantRolePermissions(approverRole.id, [PERMISSIONS.DEVICES_EXECUTE, PERMISSIONS.APPROVALS_DECIDE]);
+  const approver = await createUser({
+    partnerId: partner.id,
+    orgId: org.id,
+    email: `approver-${randomUUID()}@opintent.test`,
+  });
+  await assignUserToOrganization(approver.id, org.id, approverRole.id);
+
+  const [agent] = await withSystemDbAccessContext(() =>
+    db
+      .insert(aiAgents)
+      .values({ orgId: org.id, partnerId: null, kind: 'triage', name: 'Operator', createdBy: requester.id })
+      .returning(),
+  );
+
+  const adminDb = getTestDb() as unknown as typeof db;
+  const unique = randomUUID().slice(0, 8);
+  const [device] = await adminDb
+    .insert(devices)
+    .values({
+      orgId: org.id,
+      siteId: site.id,
+      agentId: `opintent-agent-${unique}`,
+      hostname: `opintent-host-${unique}`,
+      osType: 'linux',
+      osVersion: '22.04',
+      architecture: 'x86_64',
+      agentVersion: '0.0.0-test',
+      status: 'online',
+    })
+    .returning();
+
+  return {
+    partnerId: partner.id,
+    orgId: org.id,
+    siteId: site.id,
+    requesterId: requester.id,
+    approverId: approver.id,
+    approverEmail: approver.email,
+    approverRoleId: approverRole.id,
+    agentId: agent!.id,
+    deviceId: (device as { id: string }).id,
+  };
+}
+
+async function createTask(
+  t: Tenant,
+  overrides: Partial<typeof aiOperatorTasks.$inferInsert> = {},
+): Promise<{ taskId: string; revision: number }> {
+  const revision = (overrides.revision as number | undefined) ?? 1;
+  const [row] = await withSystemDbAccessContext(() =>
+    db
+      .insert(aiOperatorTasks)
+      .values({
+        orgId: t.orgId,
+        agentId: t.agentId,
+        agentKind: 'triage',
+        agentName: 'Operator',
+        workflowKey: 'service_recovery',
+        workflowVersion: 1,
+        originKind: 'manual' as const,
+        requesterUserId: t.requesterId,
+        objective: 'Restart the print spooler on PRINTSRV01',
+        deviceId: t.deviceId,
+        state: 'running',
+        revision,
+        leaseEpoch: 0,
+        deadlineAt: new Date(Date.now() + 3_600_000),
+        targetDetachedAt: null,
+        ...overrides,
+      })
+      .returning({ id: aiOperatorTasks.id }),
+  );
+  return { taskId: row!.id, revision };
+}
+
+/** The run's own effective policy: shadow mode, `manage_services` allowlisted
+ * — the shape `checkAgentGuardrails` must resolve to `disposition: 'propose'`
+ * for a mutating call (never `deny`, never `act`). Mirrors
+ * `agentIntentLifecycle.integration.test.ts`'s `effectivePolicyFields`. */
+function agentPolicySnapshot() {
+  return {
+    schemaVersion: 1,
+    effective: {
+      enabled: true,
+      mode: 'shadow' as const,
+      model: null,
+      toolAllowlist: [TOOL_NAME],
+      protectedResources: { services: [], paths: [], registryKeys: [], deviceTags: [] },
+      limits: {},
+      triggers: {},
+      recipients: { userIds: [], roleIds: [] },
+      instructions: null,
+      cooldownSeconds: 900,
+    },
+    resolvedAt: new Date().toISOString(),
+  };
+}
+
+/** `task: null` seeds a LEGACY run (all three task columns NULL) — the shape
+ * an ordinary, non-task agent proposal (test 9) needs, and the shape whose
+ * OWN task linkage a forged task context (test 8c) must be checked against. */
+async function createRun(
+  t: Tenant,
+  task: { taskId: string; taskStepKey: string; attemptOrdinal: number } | null,
+): Promise<string> {
+  const [row] = await withSystemDbAccessContext(() =>
+    db
+      .insert(aiAgentRuns)
+      .values({
+        agentId: t.agentId,
+        orgId: t.orgId,
+        deviceId: t.deviceId,
+        triggerKind: 'alert' as const,
+        dedupeKey: `opintent-${randomUUID()}`,
+        modeAtStart: 'shadow' as const,
+        policySnapshot: agentPolicySnapshot() as never,
+        ...(task
+          ? { taskId: task.taskId, taskStepKey: task.taskStepKey, taskAttemptOrdinal: task.attemptOrdinal }
+          : {}),
+      })
+      .returning({ id: aiAgentRuns.id }),
+  );
+  return row!.id;
+}
+
+function authForRun(t: Tenant, runId: string): AuthContext {
+  return buildAgentAuthContext(
+    { id: t.agentId, orgId: t.orgId, partnerId: null, name: 'Operator', kind: 'triage' },
+    { id: runId, orgId: t.orgId, deviceId: t.deviceId, deviceSiteId: t.siteId },
+    { id: t.orgId, partnerId: t.partnerId },
+  );
+}
+
+/** Same AuthContext shape `authMiddleware` produces (reuses
+ * `buildOrgAccessClosures`, mirrors `createIntentAtomicity.integration.test.ts`'s
+ * `requesterAuth`) — for the human canceller and the "untrusted principal"
+ * cases. */
+function humanAuth(t: Tenant, user: { id: string; email: string }, roleId: string): AuthContext {
+  const { orgCondition, canAccessOrg } = buildOrgAccessClosures([t.orgId]);
+  return {
+    principal: { kind: 'user_session' },
+    user: { id: user.id, email: user.email, name: 'Human', isPlatformAdmin: false },
+    token: {
+      sub: user.id,
+      email: user.email,
+      roleId,
+      orgId: t.orgId,
+      partnerId: t.partnerId,
+      scope: 'organization',
+      type: 'access',
+      mfa: true,
+    },
+    partnerId: t.partnerId,
+    orgId: t.orgId,
+    scope: 'organization',
+    accessibleOrgIds: [t.orgId],
+    orgCondition,
+    canAccessOrg,
+  };
+}
+
+function serviceInput(t: Tenant, overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return { deviceId: t.deviceId, action: 'restart', serviceName: 'spooler', ...overrides };
+}
+
+function taskCtx(taskId: string, taskStepKey: string, operationKey: string, attemptOrdinal: number) {
+  return { taskId, taskStepKey, operationKey, attemptOrdinal };
+}
+
+async function propose(
+  t: Tenant,
+  runId: string,
+  opts: {
+    task?: ReturnType<typeof taskCtx>;
+    input?: Record<string, unknown>;
+    idempotencyKey?: string;
+  } = {},
+) {
+  return createActionIntent(authForRun(t, runId), {
+    toolName: TOOL_NAME,
+    input: opts.input ?? serviceInput(t),
+    source: 'ai_agent',
+    ...(opts.task ? { task: opts.task } : {}),
+    ...(opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : {}),
+  });
+}
+
+async function readIntent(id: string) {
+  return withSystemDbAccessContext(async () => {
+    const [row] = await db.select().from(actionIntents).where(eq(actionIntents.id, id)).limit(1);
+    return row ?? null;
+  });
+}
+
+async function readOperation(taskId: string, operationKey: string) {
+  return withSystemDbAccessContext(async () => {
+    const [row] = await db
+      .select()
+      .from(aiOperatorOperations)
+      .where(and(eq(aiOperatorOperations.taskId, taskId), eq(aiOperatorOperations.operationKey, operationKey)))
+      .limit(1);
+    return row ?? null;
+  });
+}
+
+async function countIntents(taskId: string, operationKey: string): Promise<number> {
+  return withSystemDbAccessContext(async () => {
+    const rows = await db
+      .select({ id: actionIntents.id })
+      .from(actionIntents)
+      .where(and(eq(actionIntents.taskId, taskId), eq(actionIntents.operationKey, operationKey)));
+    return rows.length;
+  });
+}
+
+async function countOperations(taskId: string, operationKey: string): Promise<number> {
+  return withSystemDbAccessContext(async () => {
+    const rows = await db
+      .select({ id: aiOperatorOperations.id })
+      .from(aiOperatorOperations)
+      .where(and(eq(aiOperatorOperations.taskId, taskId), eq(aiOperatorOperations.operationKey, operationKey)));
+    return rows.length;
+  });
+}
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+beforeEach(() => {
+  // The kill switch defaults OFF; checkAgentGuardrails reads it at call time
+  // on every proposal this suite drives (mirrors agentIntentLifecycle.integration.test.ts).
+  vi.stubEnv('BREEZE_AI_AGENTS_ENABLED', 'true');
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('createActionIntent — AI Operator task/operation identity (real Postgres)', () => {
+  runDb('writes task_id/task_step_key/operation_key and never yields a null operation_key (baseline H4)', async () => {
+    const t = await seedTenant();
+    const task = await createTask(t);
+    const runId = await createRun(t, { taskId: task.taskId, taskStepKey: TASK_STEP_KEY, attemptOrdinal: 0 });
+
+    const snapshot = await propose(t, runId, {
+      task: taskCtx(task.taskId, TASK_STEP_KEY, OPERATION_KEY, 0),
+    });
+
+    const row = await readIntent(snapshot.id);
+    expect(row).not.toBeNull();
+    expect(row!.taskId).toBe(task.taskId);
+    expect(row!.taskStepKey).toBe(TASK_STEP_KEY);
+    expect(row!.operationKey).toBe(OPERATION_KEY);
+    expect(row!.operationKey).not.toBeNull();
+  });
+
+  runDb('reserves exactly ONE ai_operator_operations row in the SAME transaction as the intent insert', async () => {
+    const t = await seedTenant();
+    const task = await createTask(t);
+    const runId = await createRun(t, { taskId: task.taskId, taskStepKey: TASK_STEP_KEY, attemptOrdinal: 0 });
+
+    const snapshot = await propose(t, runId, {
+      task: taskCtx(task.taskId, TASK_STEP_KEY, OPERATION_KEY, 0),
+    });
+
+    const digest = computeArgumentDigest(canonicalizeArguments(serviceInput(t)));
+    const ops = await withSystemDbAccessContext(() =>
+      db.select().from(aiOperatorOperations).where(eq(aiOperatorOperations.taskId, task.taskId)),
+    );
+    expect(ops).toHaveLength(1);
+    expect(ops[0]!.intentId).toBe(snapshot.id);
+    expect(ops[0]!.dispatchState).toBe('reserved');
+    expect(ops[0]!.resultState).toBe('pending');
+    expect(ops[0]!.planRevision).toBe(task.revision);
+    expect(ops[0]!.argumentDigest).toBe(digest);
+  });
+
+  runDb('idempotency_key equals the TASK-derived key, NOT the run-derived one', async () => {
+    const t = await seedTenant();
+    const task = await createTask(t);
+    const runId = await createRun(t, { taskId: task.taskId, taskStepKey: TASK_STEP_KEY, attemptOrdinal: 0 });
+
+    const snapshot = await propose(t, runId, {
+      task: taskCtx(task.taskId, TASK_STEP_KEY, OPERATION_KEY, 0),
+    });
+    const row = await readIntent(snapshot.id);
+
+    const digest = computeArgumentDigest(canonicalizeArguments(serviceInput(t)));
+    const expectedTaskKey = deriveIntentIdempotencyKey({
+      taskContext: { taskId: task.taskId, operationKey: OPERATION_KEY },
+      explicitKey: undefined,
+      toolName: TOOL_NAME,
+      argumentDigest: digest,
+      actorId: runId,
+      scopeId: null,
+    });
+    const wouldBeRunDerivedKey = deriveIdempotencyKey(runId, TOOL_NAME, digest, null);
+
+    expect(row!.idempotencyKey).toBe(expectedTaskKey);
+    expect(row!.idempotencyKey).not.toBe(wouldBeRunDerivedKey);
+  });
+
+  runDb('a continuation run re-proposing the SAME operation ATTACHES to the existing intent (no duplicate)', async () => {
+    const t = await seedTenant();
+    const task = await createTask(t);
+
+    const run1 = await createRun(t, { taskId: task.taskId, taskStepKey: TASK_STEP_KEY, attemptOrdinal: 0 });
+    const first = await propose(t, run1, { task: taskCtx(task.taskId, TASK_STEP_KEY, OPERATION_KEY, 0) });
+
+    // A SECOND run on the same task/step — the shape of attempt 2 after a
+    // reasoning-loop restart — re-proposes the identical tool + arguments +
+    // operationKey.
+    const run2 = await createRun(t, { taskId: task.taskId, taskStepKey: TASK_STEP_KEY, attemptOrdinal: 1 });
+    const second = await propose(t, run2, { task: taskCtx(task.taskId, TASK_STEP_KEY, OPERATION_KEY, 1) });
+
+    expect(second.id).toBe(first.id);
+    expect(await countIntents(task.taskId, OPERATION_KEY)).toBe(1);
+    expect(await countOperations(task.taskId, OPERATION_KEY)).toBe(1);
+  });
+
+  // NOTE ON THE ERROR CODE (see the "contract I could not test as literally
+  // described" note in the suite's final report): `deriveIntentIdempotencyKey`
+  // hashes `argumentDigest` INTO the task-derived key material itself
+  // (`task:<taskId>:<toolName>:<digest>:<operationKey>`), so a different
+  // digest always produces a DIFFERENT idempotency key — it can never collide
+  // with the first proposal's LIVE row on `(org_id, idempotency_key)`, and so
+  // never reaches the `idempotency_conflict` branch at all (that branch's
+  // argumentDigest/actionName checks are for the LEGACY explicit-key path,
+  // where two unrelated tool calls really can share a caller-chosen key; a
+  // task-derived key can't, by construction — see the `task:` prefix note in
+  // intentService.ts). The INSERT with the new key succeeds, and it is
+  // `reserveOperation`'s PERMANENT `(org_id, task_id, operation_key)` unique —
+  // which carries no digest predicate — that refuses the second proposal,
+  // with `operation_replay`. Verified against the real error live below;
+  // this is in fact the STRONGER guarantee: it refuses a mismatched-argument
+  // re-proposal even while the first operation is still `reserved` (not yet
+  // terminal), which is the scenario this test exercises and #7 below does
+  // not (there the first intent is already `completed`).
+  runDb('the SAME operationKey with DIFFERENT arguments is refused as operation_replay (digest is in the key)', async () => {
+    const t = await seedTenant();
+    const task = await createTask(t);
+
+    const run1 = await createRun(t, { taskId: task.taskId, taskStepKey: TASK_STEP_KEY, attemptOrdinal: 0 });
+    const first = await propose(t, run1, { task: taskCtx(task.taskId, TASK_STEP_KEY, OPERATION_KEY, 0) });
+
+    const run2 = await createRun(t, { taskId: task.taskId, taskStepKey: TASK_STEP_KEY, attemptOrdinal: 1 });
+    await expect(
+      propose(t, run2, {
+        task: taskCtx(task.taskId, TASK_STEP_KEY, OPERATION_KEY, 1),
+        input: serviceInput(t, { serviceName: 'a-completely-different-service' }),
+      }),
+    ).rejects.toMatchObject({ code: 'operation_replay' });
+
+    // Only the first intent/operation exist — the mismatched proposal's own
+    // (successfully inserted, then rolled back) intent row left no trace,
+    // and the operation row still points at the FIRST intent.
+    expect(await countIntents(task.taskId, OPERATION_KEY)).toBe(1);
+    expect(await countOperations(task.taskId, OPERATION_KEY)).toBe(1);
+    const op = await readOperation(task.taskId, OPERATION_KEY);
+    expect(op!.intentId).toBe(first.id);
+  });
+
+  runDb('two DIFFERENT tasks with identical arguments each get their OWN intent and operation', async () => {
+    const t = await seedTenant();
+    const taskA = await createTask(t);
+    const taskB = await createTask(t);
+
+    const runA = await createRun(t, { taskId: taskA.taskId, taskStepKey: TASK_STEP_KEY, attemptOrdinal: 0 });
+    const runB = await createRun(t, { taskId: taskB.taskId, taskStepKey: TASK_STEP_KEY, attemptOrdinal: 0 });
+
+    const a = await propose(t, runA, { task: taskCtx(taskA.taskId, TASK_STEP_KEY, OPERATION_KEY, 0) });
+    const b = await propose(t, runB, { task: taskCtx(taskB.taskId, TASK_STEP_KEY, OPERATION_KEY, 0) });
+
+    expect(a.id).not.toBe(b.id);
+
+    const opA = await readOperation(taskA.taskId, OPERATION_KEY);
+    const opB = await readOperation(taskB.taskId, OPERATION_KEY);
+    expect(opA?.intentId).toBe(a.id);
+    expect(opB?.intentId).toBe(b.id);
+    expect(await countIntents(taskA.taskId, OPERATION_KEY)).toBe(1);
+    expect(await countIntents(taskB.taskId, OPERATION_KEY)).toBe(1);
+  });
+
+  runDb(
+    'a sequential replay after the first intent terminalizes is refused, rolling back the WHOLE admission',
+    async () => {
+      const t = await seedTenant();
+      const task = await createTask(t);
+
+      const run1 = await createRun(t, { taskId: task.taskId, taskStepKey: TASK_STEP_KEY, attemptOrdinal: 0 });
+      const first = await propose(t, run1, { task: taskCtx(task.taskId, TASK_STEP_KEY, OPERATION_KEY, 0) });
+
+      // Terminalize the first intent. This FREES the live idempotency key
+      // (the partial unique only covers pending_approval/approved/executing),
+      // which is exactly the gap `ai_operator_operations`'s permanent unique
+      // exists to close — the intent-level guard alone would let this replay
+      // straight through.
+      await transitionIntent(first.id, 'pending_approval', 'completed');
+
+      const run2 = await createRun(t, { taskId: task.taskId, taskStepKey: TASK_STEP_KEY, attemptOrdinal: 1 });
+      await expect(
+        propose(t, run2, { task: taskCtx(task.taskId, TASK_STEP_KEY, OPERATION_KEY, 1) }),
+      ).rejects.toMatchObject({ code: 'operation_replay' });
+
+      // No new intent for this operation — the whole creation transaction
+      // (including the fresh action_intents insert that briefly succeeded
+      // before the operation reservation tripped) rolled back.
+      expect(await countIntents(task.taskId, OPERATION_KEY)).toBe(1);
+      // Exactly one operation row, STILL pointing at the ORIGINAL (completed)
+      // intent — a confirmed effect is never replayed onto a new one.
+      const ops = await withSystemDbAccessContext(() =>
+        db
+          .select()
+          .from(aiOperatorOperations)
+          .where(and(eq(aiOperatorOperations.taskId, task.taskId), eq(aiOperatorOperations.operationKey, OPERATION_KEY))),
+      );
+      expect(ops).toHaveLength(1);
+      expect(ops[0]!.intentId).toBe(first.id);
+    },
+  );
+
+  describe('untrusted task context is refused', () => {
+    runDb('(a) a user_session principal passing task throws task_context_not_allowed', async () => {
+      const t = await seedTenant();
+      const task = await createTask(t);
+      const auth = humanAuth(t, { id: t.approverId, email: t.approverEmail }, t.approverRoleId);
+
+      await expect(
+        createActionIntent(auth, {
+          toolName: TOOL_NAME,
+          input: serviceInput(t),
+          source: 'chat',
+          task: taskCtx(task.taskId, TASK_STEP_KEY, OPERATION_KEY, 0),
+        }),
+      ).rejects.toMatchObject({ code: 'task_context_not_allowed' });
+
+      // Refused before anything was written.
+      expect(await countIntents(task.taskId, OPERATION_KEY)).toBe(0);
+    });
+
+    runDb(
+      '(b) an ai_agent principal passing task WITH an explicit idempotencyKey throws task_context_not_allowed',
+      async () => {
+        const t = await seedTenant();
+        const task = await createTask(t);
+        const runId = await createRun(t, { taskId: task.taskId, taskStepKey: TASK_STEP_KEY, attemptOrdinal: 0 });
+
+        await expect(
+          propose(t, runId, {
+            task: taskCtx(task.taskId, TASK_STEP_KEY, OPERATION_KEY, 0),
+            idempotencyKey: 'explicit-key-must-not-combine-with-task-context',
+          }),
+        ).rejects.toMatchObject({ code: 'task_context_not_allowed' });
+
+        expect(await countIntents(task.taskId, OPERATION_KEY)).toBe(0);
+      },
+    );
+
+    runDb(
+      "(c) a run whose OWN ai_agent_runs.task_id does not match the supplied task.taskId throws task_context_invalid",
+      async () => {
+        const t = await seedTenant();
+        const taskA = await createTask(t);
+        const taskB = await createTask(t);
+        // The run is linked to task A ...
+        const runId = await createRun(t, { taskId: taskA.taskId, taskStepKey: TASK_STEP_KEY, attemptOrdinal: 0 });
+
+        // ...but the proposal claims task B's identity. The caller ASSERTING a
+        // task id proves nothing — only the run's own admitted linkage does.
+        await expect(
+          propose(t, runId, { task: taskCtx(taskB.taskId, TASK_STEP_KEY, OPERATION_KEY, 0) }),
+        ).rejects.toMatchObject({ code: 'task_context_invalid' });
+
+        expect(await countIntents(taskA.taskId, OPERATION_KEY)).toBe(0);
+        expect(await countIntents(taskB.taskId, OPERATION_KEY)).toBe(0);
+      },
+    );
+  });
+
+  runDb('an ordinary (non-task) agent intent still gets the run-derived key and creates NO operation row', async () => {
+    const t = await seedTenant();
+    const runId = await createRun(t, null); // legacy run: no task/step/attempt linkage at all
+
+    const snapshot = await propose(t, runId); // no `task` field — the pre-W04 shape
+
+    const row = await readIntent(snapshot.id);
+    expect(row!.taskId).toBeNull();
+    expect(row!.taskStepKey).toBeNull();
+    expect(row!.operationKey).toBeNull();
+
+    const digest = computeArgumentDigest(canonicalizeArguments(serviceInput(t)));
+    expect(row!.idempotencyKey).toBe(deriveIdempotencyKey(runId, TOOL_NAME, digest, null));
+
+    const ops = await withSystemDbAccessContext(() =>
+      db.select({ id: aiOperatorOperations.id }).from(aiOperatorOperations).where(eq(aiOperatorOperations.intentId, snapshot.id)),
+    );
+    expect(ops).toHaveLength(0);
+  });
+
+  runDb('cancel on a task-linked pending_approval intent: ok:true, operation terminally cancelled', async () => {
+    const t = await seedTenant();
+    const task = await createTask(t);
+    const runId = await createRun(t, { taskId: task.taskId, taskStepKey: TASK_STEP_KEY, attemptOrdinal: 0 });
+    const snapshot = await propose(t, runId, { task: taskCtx(task.taskId, TASK_STEP_KEY, OPERATION_KEY, 0) });
+    expect(snapshot.status).toBe('pending_approval');
+
+    const auth = humanAuth(t, { id: t.approverId, email: t.approverEmail }, t.approverRoleId);
+    const result = await cancelActionIntent(auth, snapshot.id);
+    expect(result).toMatchObject({ ok: true, status: 'cancelled' });
+
+    const intentRow = await readIntent(snapshot.id);
+    expect(intentRow!.status).toBe('cancelled');
+
+    // Nothing was ever dispatched — terminally 'cancelled', distinct from
+    // 'abandoned' (a leaked reservation the reconciler must find separately).
+    const op = await readOperation(task.taskId, OPERATION_KEY);
+    expect(op!.dispatchState).toBe('cancelled');
+    expect(op!.cancelRequestedAt).not.toBeNull();
+  });
+
+  runDb(
+    "cancel while EXECUTING: records cancel_requested_at but does NOT flip the intent or the operation (in flight, will be reconciled)",
+    async () => {
+      const t = await seedTenant();
+      const task = await createTask(t);
+      const runId = await createRun(t, { taskId: task.taskId, taskStepKey: TASK_STEP_KEY, attemptOrdinal: 0 });
+      const snapshot = await propose(t, runId, { task: taskCtx(task.taskId, TASK_STEP_KEY, OPERATION_KEY, 0) });
+
+      // Move the intent straight to `executing` — the claim mechanics that
+      // normally do this are Suite 2's job; here only the STATE matters.
+      await transitionIntent(snapshot.id, 'pending_approval', 'executing', { executionStartedAt: new Date() });
+      // "seed it so" (brief): the operation must independently read
+      // `dispatched` for the cancel-request path to have a real in-flight
+      // effect to record against, rather than a reserved one.
+      await withSystemDbAccessContext(() =>
+        db
+          .update(aiOperatorOperations)
+          .set({ dispatchState: 'dispatched', dispatchedAt: new Date() })
+          .where(eq(aiOperatorOperations.intentId, snapshot.id)),
+      );
+
+      const auth = humanAuth(t, { id: t.approverId, email: t.approverEmail }, t.approverRoleId);
+      const result = await cancelActionIntent(auth, snapshot.id);
+      expect(result).toMatchObject({ ok: false, status: 'executing', inFlight: true });
+
+      const intentRow = await readIntent(snapshot.id);
+      // The intent must NOT have moved — an already-dispatched effect may
+      // still finish, and §7.3 forbids ever claiming "nothing happened".
+      expect(intentRow!.status).toBe('executing');
+
+      const op = await readOperation(task.taskId, OPERATION_KEY);
+      expect(op!.dispatchState).toBe('dispatched');
+      expect(op!.cancelRequestedAt).not.toBeNull();
+    },
+  );
+});

--- a/apps/api/src/__tests__/integration/aiOperatorIntentIdentity.integration.test.ts
+++ b/apps/api/src/__tests__/integration/aiOperatorIntentIdentity.integration.test.ts
@@ -581,6 +581,66 @@ describe('createActionIntent — AI Operator task/operation identity (real Postg
         expect(await countIntents(taskB.taskId, OPERATION_KEY)).toBe(0);
       },
     );
+
+    // #5205 W04 (#5209), Gap 3 (PR #5259 review): (c) above proves the run's
+    // own admitted linkage — not the caller's assertion — gates the task
+    // context WITHIN one org. This is the cross-tenant variant: a second
+    // partner/org/agent/run/task, entirely separate seed data, so the
+    // assertion is not "these two tasks happen to differ" but "an org A run
+    // cannot mint a task-linked intent against an org B task" — the composite
+    // `(task_id, org_id) -> ai_operator_tasks(id, org_id)` FK on
+    // `ai_agent_runs` means org A's run can NEVER legitimately carry org B's
+    // task id, so `agentRun.taskId !== taskContext.taskId` (intentService.ts)
+    // refuses it the same way, but this proves that holds across the tenant
+    // boundary rather than assuming it from the same-org case alone.
+    runDb(
+      "(d) org A's agent auth cannot mint a task-linked intent against org B's task — task_context_invalid, no row written",
+      async () => {
+        const orgA = await seedTenant();
+        const orgB = await seedTenant();
+        const taskA = await createTask(orgA);
+        const taskB = await createTask(orgB);
+        const runA = await createRun(orgA, { taskId: taskA.taskId, taskStepKey: TASK_STEP_KEY, attemptOrdinal: 0 });
+        // Parallel fixture on org B, unused directly — establishes org B as a
+        // genuinely independent tenant with its own agent/run, not merely a
+        // second task row under org A.
+        await createRun(orgB, { taskId: taskB.taskId, taskStepKey: TASK_STEP_KEY, attemptOrdinal: 0 });
+
+        const crossTenantOperationKey = 'restart:spooler-cross-tenant';
+        await expect(
+          propose(orgA, runA, { task: taskCtx(taskB.taskId, TASK_STEP_KEY, crossTenantOperationKey, 0) }),
+        ).rejects.toMatchObject({ code: 'task_context_invalid' });
+
+        // No action_intents row for the forged task/operation identity, and no
+        // ai_operator_operations row reserved against org B's task either —
+        // the whole creation transaction never got far enough to write either.
+        expect(await countIntents(taskB.taskId, crossTenantOperationKey)).toBe(0);
+        expect(await countOperations(taskB.taskId, crossTenantOperationKey)).toBe(0);
+      },
+    );
+
+    // #5205 W04 (#5209), Gap 5 (PR #5259 review): the zod bounds on
+    // `actionIntentTaskContextSchema` (@breeze/shared/validators/aiOperator.ts)
+    // deliberately mirror the DB CHECK constraints on
+    // `ai_operator_operations.operation_key` (200 chars) — proving the zod
+    // bound fires FIRST, as a typed rejection at the seam, rather than
+    // surfacing as a raw 23514 mid-transaction.
+    runDb(
+      '(e) an operationKey over the 200-char bound is refused as task_context_invalid, before any row is written',
+      async () => {
+        const t = await seedTenant();
+        const task = await createTask(t);
+        const runId = await createRun(t, { taskId: task.taskId, taskStepKey: TASK_STEP_KEY, attemptOrdinal: 0 });
+        const overlongOperationKey = 'x'.repeat(201);
+
+        await expect(
+          propose(t, runId, { task: taskCtx(task.taskId, TASK_STEP_KEY, overlongOperationKey, 0) }),
+        ).rejects.toMatchObject({ code: 'task_context_invalid' });
+
+        expect(await countIntents(task.taskId, overlongOperationKey)).toBe(0);
+        expect(await countOperations(task.taskId, overlongOperationKey)).toBe(0);
+      },
+    );
   });
 
   runDb('an ordinary (non-task) agent intent still gets the run-derived key and creates NO operation row', async () => {

--- a/apps/api/src/db/migration-action-intents.test.ts
+++ b/apps/api/src/db/migration-action-intents.test.ts
@@ -122,6 +122,18 @@ describe('Action intents migration', () => {
     // the non-null->NULL tombstone transition (the ticket-delete FK's ON
     // DELETE SET NULL, or a moveOrg detach step), never a retarget.
     'scope_ticket_id',
+    // 2026-10-14-100200 (#5205 W04, #5209): AI Operator operation identity.
+    // UNCONDITIONAL, unlike the two scope columns above — there is no
+    // tombstone direction to permit. `action_intents_task_org_fk` is ON DELETE
+    // RESTRICT precisely because SET NULL would strand `task_step_key` /
+    // `operation_key` and instantly violate `action_intents_task_link_chk`, so
+    // all three are set at INSERT and never written again. They are the
+    // identity `ai_operator_operations` is keyed on: an editable `task_id`
+    // would let a live intent be re-pointed at a different task after
+    // approval.
+    'task_id',
+    'task_step_key',
+    'operation_key',
   ] as const;
 
   // Deliberately MUTABLE. release_by is written by the approve fan-in

--- a/apps/api/src/db/schema/aiOperatorTasks.ts
+++ b/apps/api/src/db/schema/aiOperatorTasks.ts
@@ -257,10 +257,21 @@ export const aiOperatorOperations = pgTable(
     executionRefKind: text('execution_ref_kind').$type<AiOperatorExecutionRefKind>(),
     executionRefId: uuid('execution_ref_id'),
 
+    // W04 (#5209). `plan_revision` is `ai_operator_tasks.revision` pinned at
+    // reservation; the dispatch claim requires the task's CURRENT revision to
+    // still equal it, in the same conditional UPDATE. `claimed_lease_epoch` is
+    // the epoch OBSERVED at claim time — recorded for lineage, never fenced on
+    // from the intent-release path (spec §6.3: results from a superseded
+    // epoch's operation are accepted under their original identity).
+    planRevision: integer('plan_revision'),
+    claimedLeaseEpoch: bigint('claimed_lease_epoch', { mode: 'number' }),
+
     dispatchState: text('dispatch_state')
-      .$type<'reserved' | 'dispatched' | 'dispatch_failed' | 'abandoned'>()
+      .$type<'reserved' | 'dispatched' | 'dispatch_failed' | 'cancelled' | 'abandoned'>()
       .notNull()
       .default('reserved'),
+    /** Why a claim was refused / a dispatch failed. Bounded text, never jsonb. */
+    dispatchDetail: text('dispatch_detail'),
     // 'unknown' is a first-class result, not an error: between the tool's 30 s
     // wait and the device command's 5-minute reap the effect may still land
     // (spec §6.5, "three clocks").
@@ -271,6 +282,13 @@ export const aiOperatorOperations = pgTable(
     result: jsonb('result').$type<Record<string, unknown>>().notNull().default({}),
 
     dispatchedAt: timestamp('dispatched_at', { withTimezone: true }),
+    /**
+     * W04 (#5209): a human cancelled a task-linked intent that had already
+     * reached `executing`. The intent deliberately STAYS `executing` — spec
+     * §7.3 requires already-executing work to be shown in flight and settled
+     * only after reconciliation, never silently reported as "nothing happened".
+     */
+    cancelRequestedAt: timestamp('cancel_requested_at', { withTimezone: true }),
     resultAt: timestamp('result_at', { withTimezone: true }),
     createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),

--- a/apps/api/src/jobs/intentExpiryReaper.ts
+++ b/apps/api/src/jobs/intentExpiryReaper.ts
@@ -11,6 +11,7 @@ import { writeAuditEvent, requestLikeFromSnapshot } from '../services/auditEvent
 import { recordActionIntentEvent, recordActionIntentMetric } from '../services/actionIntents/metrics';
 import { REVEAL_WINDOW_DAYS } from '../services/actionIntents/resultSecrets';
 import { attachWorkerObservability } from './workerObservability';
+import { recordOperationResult } from '../services/aiOperator/operationService';
 
 /**
  * Reaps `action_intents` rows past their deadline (spec
@@ -126,6 +127,8 @@ type StaleExecutingIntentRow = {
   source: string;
   execution_started_at: Date | string | null;
   decided_at: Date | null;
+  /** #5205 W04 (#5209): non-null iff this is an AI Operator task-linked intent. */
+  task_id: string | null;
 };
 
 function extractRows<T>(result: unknown): T[] {
@@ -285,7 +288,8 @@ export async function reapStaleExecutingIntents(): Promise<number> {
       a.argument_digest,
       a.source,
       a.execution_started_at,
-      a.decided_at;
+      a.decided_at,
+      a.task_id;
   `);
 
   const rows = extractRows<StaleExecutingIntentRow>(transitioned);
@@ -321,6 +325,29 @@ export async function reapStaleExecutingIntents(): Promise<number> {
     } catch (err) {
       console.error('[IntentExpiryReaper] Failed to write stale-executing audit event:', err);
       captureException(err instanceof Error ? err : new Error(String(err)));
+    }
+
+    // #5205 W04 (#5209): `failed:execution_lost` on the intent means THIS
+    // SERVER gave up after 20 minutes. It does NOT mean the effect failed — the
+    // device command reaps at 5 minutes but stays open to a genuine late agent
+    // result (`commandAcceptsAgentResultCondition`), so the operation records
+    // `unknown`, never `failed`, and W06 reconciles it from the execution
+    // reference. Writing `failed` here would assert a non-effect the system
+    // cannot prove, which spec §7.3 forbids ("must never display 'nothing
+    // happened' if a change may still finish").
+    //
+    // `recordOperationResult` is rank-ordered, so this `unknown` cannot clobber
+    // a definite outcome the release worker already recorded, and a definite
+    // outcome arriving afterwards still overwrites this one.
+    if (row.task_id) {
+      await recordOperationResult({
+        intentId: row.id,
+        resultState: 'unknown',
+        result: {
+          errorCode: 'execution_lost',
+          staleExecutingTimeoutMinutes: STALE_EXECUTING_TIMEOUT_MINUTES,
+        },
+      });
     }
   }
 

--- a/apps/api/src/jobs/intentExpiryReaper.ts
+++ b/apps/api/src/jobs/intentExpiryReaper.ts
@@ -93,6 +93,26 @@ const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
   return withSystem(fn);
 };
 
+/**
+ * Detaches from any ambient DB context so the callback genuinely opens its own
+ * transaction. Resolved off the module object for the same reason
+ * `runWithSystemDbAccess` above is: the unit suite mocks `../db`, and a missing
+ * export must fail loudly here rather than silently degrade into "ran inside
+ * the caller's transaction after all" — which is precisely the failure this
+ * helper exists to prevent (see its call site in reapStaleExecutingIntents).
+ */
+const runDetached = async <T>(fn: () => Promise<T>): Promise<T> => {
+  const outside = dbModule.runOutsideDbContext;
+  if (typeof outside !== 'function') {
+    throw new Error(
+      '[IntentExpiryReaper] runOutsideDbContext not available — refusing to write the operation '
+      + 'result inside the reaper transaction (a swallowed failure there would silently roll the '
+      + 'whole batch back)',
+    );
+  }
+  return outside(fn);
+};
+
 let reaperQueue: Queue<ReaperJobData> | null = null;
 let reaperWorker: Worker<ReaperJobData> | null = null;
 
@@ -339,15 +359,36 @@ export async function reapStaleExecutingIntents(): Promise<number> {
     // `recordOperationResult` is rank-ordered, so this `unknown` cannot clobber
     // a definite outcome the release worker already recorded, and a definite
     // outcome arriving afterwards still overwrites this one.
+    //
+    // `runDetached` (runOutsideDbContext) is LOAD-BEARING, not tidiness. This function runs
+    // inside `runWithSystemDbAccess`, i.e. inside ONE Postgres transaction that
+    // also carries the CTE UPDATE above. `withSystemDbAccessContext` is a
+    // PASSTHROUGH when a context is already active (db/index.ts's "refuses to
+    // nest"), so without this wrapper `recordOperationResult` would join that
+    // transaction — and `runOperationWrite` SWALLOWS write failures by design.
+    // A swallowed error inside a shared transaction is exactly the trap this
+    // file's own `reapExpiredIntents` header documents: the backend is left in
+    // 25P02, every later statement fails, and the final COMMIT is silently
+    // converted to ROLLBACK without raising. The batch's `failed:execution_lost`
+    // transitions would be discarded while the caller still logged a success
+    // count, leaving those intents stuck in `executing` forever.
+    //
+    // Detaching gives the operation write its own transaction, which is also
+    // what the result contract wants: it must never be gated on the intent's
+    // status CAS (baseline §4). It costs a second pooled connection held
+    // briefly alongside this one — acceptable in a single background reaper
+    // lane, and not the request path the double-hold warning is about.
     if (row.task_id) {
-      await recordOperationResult({
-        intentId: row.id,
-        resultState: 'unknown',
-        result: {
-          errorCode: 'execution_lost',
-          staleExecutingTimeoutMinutes: STALE_EXECUTING_TIMEOUT_MINUTES,
-        },
-      });
+      await runDetached(() =>
+        recordOperationResult({
+          intentId: row.id,
+          resultState: 'unknown',
+          result: {
+            errorCode: 'execution_lost',
+            staleExecutingTimeoutMinutes: STALE_EXECUTING_TIMEOUT_MINUTES,
+          },
+        }),
+      );
     }
   }
 

--- a/apps/api/src/jobs/intentReleaseWorker.test.ts
+++ b/apps/api/src/jobs/intentReleaseWorker.test.ts
@@ -10,7 +10,7 @@ import type { AgentReleaseAuthority } from '../services/actionIntents/agentRelea
  *  THIS through to the evidence row rather than rebuilding a key itself. */
 const CANONICAL_OP_KEY = 'run_script:execute';
 
-const { schema, dbState, dbMock, intentServiceMock, actorContextMock, tenantStatusMock, aiToolsMock, aiGuardrailsMock, agentReleaseAuthorityMock, authMock, auditMock, metricsMock, sentryMock, toolTimeoutsMock, googleHeadlessMock, m365HeadlessMock, effectDigestMock, notifyMock, recipientsMock, policyDecideMock, killStateMock, opEvidenceMock, canonicalKeyMock, fixWatchMock, demoteMock } = vi.hoisted(() => {
+const { schema, dbState, dbMock, intentServiceMock, actorContextMock, tenantStatusMock, aiToolsMock, aiGuardrailsMock, agentReleaseAuthorityMock, authMock, auditMock, metricsMock, sentryMock, toolTimeoutsMock, googleHeadlessMock, m365HeadlessMock, effectDigestMock, notifyMock, recipientsMock, policyDecideMock, killStateMock, opEvidenceMock, canonicalKeyMock, fixWatchMock, demoteMock, dispatchClaimMock, operationServiceMock } = vi.hoisted(() => {
   const col = (name: string) => ({ name });
   const actionIntentsTbl = { id: col('id') };
   const approvalRequestsTbl = { id: col('id'), intentId: col('intent_id'), status: col('status') };
@@ -191,6 +191,24 @@ const { schema, dbState, dbMock, intentServiceMock, actorContextMock, tenantStat
         typeof intent.effectDigest === 'string' && intent.effectDigest.length > 0,
       ),
     },
+    // #5205 W04 (#5209): the ONE durable dispatch claim for a task-linked
+    // intent (dispatchClaim.ts) and the operation-row writers it and the
+    // worker share (operationService.ts). Both are mocked at the module
+    // boundary — neither can load for real here (they pull in the db/schema
+    // barrel this file's narrow per-table db mock doesn't cover) — but
+    // `isTaskLinkedIntent` is re-exported from the REAL module below (see the
+    // `vi.mock('../services/aiOperator/operationService', ...)` factory): it
+    // is the branch predicate every case in this section exercises, and
+    // mocking it to a constant would make every one of them vacuous.
+    dispatchClaimMock: {
+      claimTaskLinkedIntentForDispatch: vi.fn(),
+      revertTaskLinkedDispatchClaim: vi.fn(),
+    },
+    operationServiceMock: {
+      markOperationDispatchFailed: vi.fn(async () => undefined),
+      recordOperationExecutionRef: vi.fn(async () => undefined),
+      recordOperationResult: vi.fn(async () => undefined),
+    },
   };
 });
 
@@ -268,6 +286,29 @@ vi.mock('../services/actionIntents/metrics', () => ({
 vi.mock('../services/actionIntents/intentService', () => ({
   transitionIntent: intentServiceMock.transitionIntent,
 }));
+// #5205 W04 (#5209): the task-linked dispatch claim, mocked wholesale — same
+// reason as intentService above, and neither collaborator's own contract
+// (the FOR-UPDATE lock order, the EXISTS predicate) belongs in THIS file;
+// those are pinned where they live (dispatchClaim's own future integration
+// coverage). What this file proves is that the worker calls the right one
+// for the right kind of intent and reacts correctly to each result shape.
+vi.mock('../services/aiOperator/dispatchClaim', () => ({
+  claimTaskLinkedIntentForDispatch: dispatchClaimMock.claimTaskLinkedIntentForDispatch,
+  revertTaskLinkedDispatchClaim: dispatchClaimMock.revertTaskLinkedDispatchClaim,
+}));
+// Partial mock: `isTaskLinkedIntent` stays the REAL implementation (it is a
+// pure function with no db dependency, and it is the branch predicate this
+// file's task-linked cases exist to exercise) — only the operation-row
+// writers are swapped for spies, same treatment as opEvidence/fixWatch below.
+vi.mock('../services/aiOperator/operationService', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../services/aiOperator/operationService')>();
+  return {
+    ...actual,
+    markOperationDispatchFailed: operationServiceMock.markOperationDispatchFailed,
+    recordOperationExecutionRef: operationServiceMock.recordOperationExecutionRef,
+    recordOperationResult: operationServiceMock.recordOperationResult,
+  };
+});
 vi.mock('../services/actionIntents/policyDecide', () => {
   // A local (not imported-from-real) `PolicyDecisionTransientError` — the
   // real module pulls in the full db/schema graph transitively, which this
@@ -2799,6 +2840,309 @@ describe('releaseApprovedIntent', () => {
 
         expect(sentryMock.captureException).toHaveBeenCalled();
       });
+    });
+  });
+
+  // #5205 W04 (#5209): `baseIntent()`'s taskId/taskStepKey/operationKey are
+  // all unset (undefined), so `isTaskLinkedIntent(intent)` was always false
+  // and every branch below ran zero times until this block — neither the
+  // task-linked dispatch claim (`dispatchClaim.ts`) nor the operation-row
+  // writers (`operationService.ts`) were ever exercised through the worker.
+  // `isTaskLinkedIntent` itself stays the REAL implementation (see the
+  // `vi.mock('../services/aiOperator/operationService', ...)` factory
+  // above) — it is the predicate every case here discriminates on.
+  describe('task-linked intents (#5205 W04)', () => {
+    const COMMAND_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+    function taskIntent(overrides: Partial<ActionIntent> = {}): ActionIntent {
+      return baseIntent({
+        taskId: 'task-1',
+        taskStepKey: 'plan.step-1',
+        operationKey: 'op-1',
+        ...overrides,
+      } as Partial<ActionIntent>);
+    }
+
+    /** Task-linked equivalent of `primeThroughRevalidation`: primes a WON
+     *  dispatch claim (instead of the legacy CAS) and the rest of the shared
+     *  revalidation chain through to `executeTool`. */
+    function primeTaskLinkedThroughClaim(intent: ActionIntent) {
+      dbState.selectActionIntentsResults.push([intent]);
+      dbState.selectApprovalRequestsResults.push([
+        { id: 'approval-1', status: 'approved', boundArgumentDigest: intent.argumentDigest },
+      ]);
+      dispatchClaimMock.claimTaskLinkedIntentForDispatch.mockResolvedValueOnce({ won: true, leaseEpoch: 1 });
+      aiToolsMock.getToolTier.mockReturnValue(intent.riskTier);
+      actorContextMock.buildAuthContextForIntent.mockResolvedValueOnce(fakeAuth);
+      tenantStatusMock.getActiveOrgTenant.mockResolvedValueOnce({ orgId: intent.orgId, partnerId: 'partner-1' });
+      aiGuardrailsMock.checkToolPermission.mockResolvedValueOnce(null);
+      toolTimeoutsMock.getToolTimeout.mockReturnValue(60_000);
+    }
+
+    it('claim branch taken: calls claimTaskLinkedIntentForDispatch with {id, orgId, taskId} and never the legacy transitionIntent CAS', async () => {
+      const intent = taskIntent();
+      primeTaskLinkedThroughClaim(intent);
+      aiToolsMock.executeTool.mockResolvedValueOnce(JSON.stringify({ ok: true }));
+      intentServiceMock.transitionIntent.mockResolvedValueOnce(true); // executing -> completed
+
+      await releaseApprovedIntent(intent.id);
+
+      expect(dispatchClaimMock.claimTaskLinkedIntentForDispatch).toHaveBeenCalledWith({
+        id: intent.id,
+        orgId: intent.orgId,
+        taskId: intent.taskId,
+      });
+      // Without the branch (isTaskLinkedIntent inverted or missing), the
+      // worker would fall through to the legacy claim — assert it never runs.
+      expect(intentServiceMock.transitionIntent).not.toHaveBeenCalledWith(
+        intent.id, 'approved', 'executing', expect.anything(), expect.anything(),
+      );
+    });
+
+    it('legacy branch preserved: a NON-task intent still uses transitionIntent for the claim, never the task-linked claim', async () => {
+      const intent = baseIntent();
+      primeThroughRevalidation(intent);
+      aiToolsMock.executeTool.mockResolvedValueOnce(JSON.stringify({ ok: true }));
+      intentServiceMock.transitionIntent.mockResolvedValueOnce(true); // executing -> completed
+
+      await releaseApprovedIntent(intent.id);
+
+      expect(intentServiceMock.transitionIntent).toHaveBeenCalledWith(
+        intent.id, 'approved', 'executing', expect.anything(), expect.anything(),
+      );
+      expect(dispatchClaimMock.claimTaskLinkedIntentForDispatch).not.toHaveBeenCalled();
+    });
+
+    it('refused claim (task_not_claimable): markOperationDispatchFailed records refusal+detail, executeTool never runs, no terminal transition', async () => {
+      const intent = taskIntent();
+      // Only the load is primed beyond the claim — a refused claim must not
+      // reach anything downstream (same discipline as the legacy "release
+      // lease" refused-claim tests above).
+      dbState.selectActionIntentsResults.push([intent]);
+      dbState.selectApprovalRequestsResults.push([]);
+      dispatchClaimMock.claimTaskLinkedIntentForDispatch.mockResolvedValueOnce({
+        won: false,
+        refusal: 'task_not_claimable',
+        detail: "task state 'stopping' cannot admit a new effect",
+      });
+
+      await releaseApprovedIntent(intent.id);
+
+      expect(operationServiceMock.markOperationDispatchFailed).toHaveBeenCalledWith(
+        intent.id,
+        "task_not_claimable: task state 'stopping' cannot admit a new effect",
+      );
+      expect(aiToolsMock.executeTool).not.toHaveBeenCalled();
+      expect(intentServiceMock.transitionIntent).not.toHaveBeenCalled();
+    });
+
+    it("refusal 'operation_already_claimed' does NOT write — another claimant owns the row", async () => {
+      const intent = taskIntent();
+      dbState.selectActionIntentsResults.push([intent]);
+      dbState.selectApprovalRequestsResults.push([]);
+      dispatchClaimMock.claimTaskLinkedIntentForDispatch.mockResolvedValueOnce({
+        won: false,
+        refusal: 'operation_already_claimed',
+        detail: 'operation op-1 is \'dispatched\', not \'reserved\'',
+      });
+
+      await releaseApprovedIntent(intent.id);
+
+      // Writing here would clobber the WINNER's bookkeeping. This is a healthy
+      // race, so it is also not raised to Sentry — contrast the case below.
+      expect(operationServiceMock.markOperationDispatchFailed).not.toHaveBeenCalled();
+      expect(sentryMock.captureException).not.toHaveBeenCalled();
+      expect(aiToolsMock.executeTool).not.toHaveBeenCalled();
+      expect(intentServiceMock.transitionIntent).not.toHaveBeenCalled();
+    });
+
+    it("refusal 'operation_missing' IS raised to Sentry — a task-linked intent with no operation row is a broken invariant", async () => {
+      // `reserveOperation` commits in the same transaction as the intent
+      // insert, so this should be unreachable. If it ever happens there is no
+      // operation row to record the reason ON, and the intent would otherwise
+      // sit `approved` until an unrelated deadline reaper noticed — up to 24 h
+      // later for an `mcp_api` source — with nothing naming what went wrong.
+      const intent = taskIntent();
+      dbState.selectActionIntentsResults.push([intent]);
+      dbState.selectApprovalRequestsResults.push([]);
+      dispatchClaimMock.claimTaskLinkedIntentForDispatch.mockResolvedValueOnce({
+        won: false,
+        refusal: 'operation_missing',
+        detail: `no operation row reserved for intent ${intent.id}`,
+      });
+
+      await releaseApprovedIntent(intent.id);
+
+      expect(sentryMock.captureException).toHaveBeenCalledTimes(1);
+      expect(aiToolsMock.executeTool).not.toHaveBeenCalled();
+      expect(intentServiceMock.transitionIntent).not.toHaveBeenCalled();
+    });
+
+    it('kill switch: reverts the dispatch claim, never the legacy executing->approved transitionIntent', async () => {
+      const intent = taskIntent({ requestingAgentRunId: 'run-1' } as Partial<ActionIntent>);
+      dbState.selectActionIntentsResults.push([intent]);
+      dbState.selectApprovalRequestsResults.push([
+        { id: 'approval-1', status: 'approved', boundArgumentDigest: intent.argumentDigest },
+      ]);
+      dispatchClaimMock.claimTaskLinkedIntentForDispatch.mockResolvedValueOnce({ won: true, leaseEpoch: 1 });
+      aiToolsMock.getToolTier.mockReturnValue(intent.riskTier);
+      // (c)/(d) — actor + org active — must resolve truthy to reach the
+      // agent-authority branch (e), same as the legacy kill-switch tests.
+      actorContextMock.buildAuthContextForIntent.mockResolvedValueOnce(fakeAuth);
+      tenantStatusMock.getActiveOrgTenant.mockResolvedValueOnce({ orgId: intent.orgId, partnerId: 'partner-1' });
+      agentReleaseAuthorityMock.checkAgentReleaseAuthority.mockResolvedValueOnce({
+        ok: false,
+        errorCode: 'kill_switch_engaged',
+        details: { policy: 'snapshot', epoch: 7, reason: 'kill-switched' },
+      });
+      dispatchClaimMock.revertTaskLinkedDispatchClaim.mockResolvedValueOnce(true);
+
+      await releaseApprovedIntent(intent.id);
+
+      expect(dispatchClaimMock.revertTaskLinkedDispatchClaim).toHaveBeenCalledWith(intent.id, 'kill_switch_engaged');
+      expect(aiToolsMock.executeTool).not.toHaveBeenCalled();
+      expect(intentServiceMock.transitionIntent).not.toHaveBeenCalledWith(intent.id, 'executing', 'approved');
+    });
+
+    it('failIntent, NOT executed (digest_mismatch): markOperationDispatchFailed is called, recordOperationResult is not', async () => {
+      const intent = taskIntent();
+      dbState.selectActionIntentsResults.push([intent]);
+      dbState.selectApprovalRequestsResults.push([]); // no winning approval -> digest_mismatch, before execution
+      dispatchClaimMock.claimTaskLinkedIntentForDispatch.mockResolvedValueOnce({ won: true, leaseEpoch: 1 });
+      intentServiceMock.transitionIntent.mockResolvedValueOnce(true); // executing -> failed
+
+      await releaseApprovedIntent(intent.id);
+
+      expect(operationServiceMock.markOperationDispatchFailed).toHaveBeenCalledWith(intent.id, 'digest_mismatch');
+      expect(operationServiceMock.recordOperationResult).not.toHaveBeenCalled();
+      expect(aiToolsMock.executeTool).not.toHaveBeenCalled();
+    });
+
+    it('failIntent, executed (execution_error): recordOperationResult gets resultState unknown; markOperationDispatchFailed is not called', async () => {
+      const intent = taskIntent();
+      primeTaskLinkedThroughClaim(intent);
+      aiToolsMock.executeTool.mockRejectedValueOnce(new Error('boom'));
+      intentServiceMock.transitionIntent.mockResolvedValueOnce(true); // executing -> failed
+
+      await releaseApprovedIntent(intent.id);
+
+      expect(operationServiceMock.recordOperationResult).toHaveBeenCalledWith(
+        expect.objectContaining({ intentId: intent.id, resultState: 'unknown' }),
+      );
+      expect(operationServiceMock.markOperationDispatchFailed).not.toHaveBeenCalled();
+    });
+
+    it('completed happy path: recordOperationExecutionRef gets the device_command ref, recordOperationResult gets succeeded + that same ref', async () => {
+      const intent = taskIntent();
+      primeTaskLinkedThroughClaim(intent);
+      aiToolsMock.executeTool.mockResolvedValueOnce(
+        JSON.stringify({ status: 'completed', commandId: COMMAND_ID }),
+      );
+      intentServiceMock.transitionIntent.mockResolvedValueOnce(true); // executing -> completed
+
+      await releaseApprovedIntent(intent.id);
+
+      expect(operationServiceMock.recordOperationExecutionRef).toHaveBeenCalledWith(
+        intent.id,
+        { kind: 'device_command', id: COMMAND_ID },
+      );
+      expect(operationServiceMock.recordOperationResult).toHaveBeenCalledWith(
+        expect.objectContaining({
+          intentId: intent.id,
+          resultState: 'succeeded',
+          executionRef: { kind: 'device_command', id: COMMAND_ID },
+        }),
+      );
+    });
+
+    it("TIMEOUT MAPS TO 'unknown', NEVER 'failed' — the single most important mapping in the file", async () => {
+      const intent = taskIntent();
+      primeTaskLinkedThroughClaim(intent);
+      aiToolsMock.executeTool.mockResolvedValueOnce(
+        JSON.stringify({ status: 'timeout', commandId: COMMAND_ID }),
+      );
+      intentServiceMock.transitionIntent.mockResolvedValueOnce(true); // executing -> completed
+
+      await releaseApprovedIntent(intent.id);
+
+      expect(operationServiceMock.recordOperationResult).toHaveBeenCalledWith(
+        expect.objectContaining({ intentId: intent.id, resultState: 'unknown' }),
+      );
+      // Asserted as an explicit NOT-'failed' as well as the positive match
+      // above: `timeout` silently becoming `failed` is the one mapping spec
+      // §7.3 forbids getting backwards, so it gets its own negative assertion.
+      const calls = operationServiceMock.recordOperationResult.mock.calls as unknown as Array<[{ resultState: string }]>;
+      expect(calls[0]?.[0].resultState).not.toBe('failed');
+    });
+
+    it("status:'failed' maps to resultState 'failed'", async () => {
+      const intent = taskIntent();
+      primeTaskLinkedThroughClaim(intent);
+      aiToolsMock.executeTool.mockResolvedValueOnce(
+        JSON.stringify({ status: 'failed', commandId: COMMAND_ID }),
+      );
+      intentServiceMock.transitionIntent.mockResolvedValueOnce(true); // executing -> completed
+
+      await releaseApprovedIntent(intent.id);
+
+      expect(operationServiceMock.recordOperationResult).toHaveBeenCalledWith(
+        expect.objectContaining({ intentId: intent.id, resultState: 'failed' }),
+      );
+    });
+
+    it('no commandId: recordOperationExecutionRef is never called (a refusal before the command row existed), but recordOperationResult still is', async () => {
+      const intent = taskIntent();
+      primeTaskLinkedThroughClaim(intent);
+      aiToolsMock.executeTool.mockResolvedValueOnce(JSON.stringify({ status: 'failed' }));
+      intentServiceMock.transitionIntent.mockResolvedValueOnce(true); // executing -> completed
+
+      await releaseApprovedIntent(intent.id);
+
+      expect(operationServiceMock.recordOperationExecutionRef).not.toHaveBeenCalled();
+      expect(operationServiceMock.recordOperationResult).toHaveBeenCalledWith(
+        expect.objectContaining({ intentId: intent.id, resultState: 'failed', executionRef: null }),
+      );
+    });
+
+    it('a non-uuid commandId is ignored (the extractor is uuid-validated): recordOperationExecutionRef is never called', async () => {
+      const intent = taskIntent();
+      primeTaskLinkedThroughClaim(intent);
+      aiToolsMock.executeTool.mockResolvedValueOnce(
+        JSON.stringify({ status: 'failed', commandId: 'not-a-uuid' }),
+      );
+      intentServiceMock.transitionIntent.mockResolvedValueOnce(true); // executing -> completed
+
+      await releaseApprovedIntent(intent.id);
+
+      expect(operationServiceMock.recordOperationExecutionRef).not.toHaveBeenCalled();
+    });
+
+    it('losing terminal CAS still records the outcome TWICE (baseline §4 — the hole this second write closes)', async () => {
+      const intent = taskIntent();
+      primeTaskLinkedThroughClaim(intent);
+      aiToolsMock.executeTool.mockResolvedValueOnce(
+        JSON.stringify({ status: 'completed', commandId: COMMAND_ID }),
+      );
+      intentServiceMock.transitionIntent.mockResolvedValueOnce(false); // lost executing -> completed CAS
+
+      await releaseApprovedIntent(intent.id);
+
+      const resultCalls = operationServiceMock.recordOperationResult.mock.calls as unknown as Array<[{ resultState: string }]>;
+      const succeededCalls = resultCalls.filter(([input]) => input.resultState === 'succeeded');
+      expect(succeededCalls.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('a NON-task intent writes NOTHING to the operation module on the completed path', async () => {
+      const intent = baseIntent();
+      primeThroughRevalidation(intent);
+      aiToolsMock.executeTool.mockResolvedValueOnce(JSON.stringify({ ok: true }));
+      intentServiceMock.transitionIntent.mockResolvedValueOnce(true); // executing -> completed
+
+      await releaseApprovedIntent(intent.id);
+
+      expect(operationServiceMock.recordOperationResult).not.toHaveBeenCalled();
+      expect(operationServiceMock.recordOperationExecutionRef).not.toHaveBeenCalled();
+      expect(operationServiceMock.markOperationDispatchFailed).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/jobs/intentReleaseWorker.test.ts
+++ b/apps/api/src/jobs/intentReleaseWorker.test.ts
@@ -576,6 +576,12 @@ describe('releaseApprovedIntent', () => {
   });
 
   it('double delivery: CAS approved->executing returns false — exits without touching anything else', async () => {
+    // #5205 W04 (#5209): the intent row is now loaded BEFORE the claim (so the
+    // claim can branch on `task_id` without a second read), so a test that
+    // exercises a refused claim has to make the load succeed first. The claim's
+    // own semantics are unchanged — that is what the assertions below still pin.
+    dbState.selectActionIntentsResults.push([baseIntent()]);
+    dbState.selectApprovalRequestsResults.push([]);
     intentServiceMock.transitionIntent.mockResolvedValueOnce(false);
 
     await releaseApprovedIntent('intent-1');
@@ -682,9 +688,13 @@ describe('releaseApprovedIntent', () => {
         approvalExpiresAt: new Date(Date.now() + 60 * 60_000),
         releaseBy: new Date(Date.now() - 1_000),
       } as Partial<ActionIntent>);
-      // Only the claim is primed: a refused claim must not reach anything
-      // downstream, so priming past it would both weaken the test and leak
-      // unconsumed `*Once` stubs into the next one.
+      // Only the claim is primed BEYOND the load: a refused claim must not
+      // reach anything downstream, so priming past it would both weaken the
+      // test and leak unconsumed `*Once` stubs into the next one. The load
+      // itself must succeed — see the double-delivery case above for why it
+      // now runs first (#5205 W04, #5209).
+      dbState.selectActionIntentsResults.push([intent]);
+      dbState.selectApprovalRequestsResults.push([]);
       leaseAwareClaimOnce(intent);
 
       await releaseApprovedIntent(intent.id);
@@ -697,16 +707,35 @@ describe('releaseApprovedIntent', () => {
   });
 
   it('stamps execution_started_at when it claims the intent (approved -> executing)', async () => {
-    intentServiceMock.transitionIntent.mockResolvedValueOnce(true); // claim CAS
-    dbState.selectActionIntentsResults.push([]); // short-circuit: intent row missing after CAS
+    // #5205 W04 (#5209): the load now runs before the claim, so this drives the
+    // WHOLE happy path rather than short-circuiting on a missing row — which
+    // also keeps every `*Once` stub consumed instead of leaking into the next
+    // test. The assertion is unchanged: the claim patch is what this pins.
+    const intent = baseIntent();
+    primeThroughRevalidation(intent);
+    aiToolsMock.executeTool.mockResolvedValueOnce(JSON.stringify({ ok: true }));
+    intentServiceMock.transitionIntent.mockResolvedValueOnce(true); // executing -> completed
 
-    await releaseApprovedIntent('intent-3');
+    await releaseApprovedIntent(intent.id);
 
     expect(intentServiceMock.transitionIntent).toHaveBeenCalledWith(
-      'intent-3', 'approved', 'executing',
+      intent.id, 'approved', 'executing',
       expect.objectContaining({ executedAt: null, executionStartedAt: expect.any(Date) }),
       { requireNotExpired: 'release' },
     );
+  });
+
+  it('never claims — and never dispatches — when the intent row is gone', async () => {
+    // #5205 W04 (#5209): the load moved ahead of the claim, so a deleted or
+    // erased intent short-circuits BEFORE anything is claimed. Previously the
+    // worker CASed the row to `executing` and only then discovered it was
+    // missing, which is a claim taken on a row that does not exist.
+    dbState.selectActionIntentsResults.push([]);
+
+    await releaseApprovedIntent('intent-gone');
+
+    expect(intentServiceMock.transitionIntent).not.toHaveBeenCalled();
+    expect(aiToolsMock.executeTool).not.toHaveBeenCalled();
   });
 
   it('happy path: CAS -> revalidate -> executeTool -> CAS completed, with a JSON result', async () => {
@@ -1852,8 +1881,21 @@ describe('releaseApprovedIntent', () => {
         metric: null,
         expectedTerminal: { kind: 'claim_lost' },
         unclaimed: true,
+        // #5205 W04 (#5209): the intent row must be primed so the pre-claim
+        // load succeeds and the claim is genuinely ATTEMPTED and lost — which
+        // is the branch this case is about. Without the row the worker would
+        // short-circuit at the load and never claim at all, and the queued
+        // claim result would leak into the next test unconsumed.
         arrange: () => {
-          intentServiceMock.transitionIntent.mockResolvedValueOnce(false);
+          // `mockReset` + a STANDING `false`, not a `*Once`: `vi.clearAllMocks()`
+          // clears recorded calls but NOT queued one-shot results, so an
+          // unconsumed `*Once` left by an earlier case in this file can be
+          // handed to this claim instead. A standing implementation makes the
+          // branch deterministic regardless of what ran before it, and the
+          // reset runs before the call under test so `transitions` still
+          // records exactly the claim.
+          intentServiceMock.transitionIntent.mockReset();
+          intentServiceMock.transitionIntent.mockResolvedValue(false);
         },
       },
       {
@@ -1990,10 +2032,20 @@ describe('releaseApprovedIntent', () => {
         expect(intentServiceMock.transitionIntent).toHaveBeenCalledWith(
           intent.id, 'approved', 'executing', expect.anything(), expect.anything(),
         );
-        // And the intent row itself was never even read: step 2's load runs
-        // only after a WON claim. Without this the case is satisfied by any
-        // flow that exits after one transition for some other reason.
-        expect((dbMock.ambient as { select: Mock }).select).not.toHaveBeenCalled();
+        // This used to assert `dbMock.ambient.select` was never called, on the
+        // grounds that step 2's load ran only after a WON claim. #5205 W04
+        // (#5209) swapped that order — the row is loaded first so the claim can
+        // branch on `task_id` — so the load now runs on every delivery and that
+        // assertion is no longer true of correct code.
+        //
+        // Its PURPOSE survives and is asserted more directly here: the guard
+        // existed so this case could not be satisfied "by any flow that exits
+        // after one transition for some other reason". A lost claim must do
+        // nothing OBSERVABLE — no tool execution, no terminal transaction, no
+        // evidence row. A read is not an effect; these three are.
+        expect(aiToolsMock.executeTool).not.toHaveBeenCalled();
+        expect(dbMock.transaction).not.toHaveBeenCalled();
+        expect((dbMock.executor as { insert: Mock }).insert).not.toHaveBeenCalled();
         return;
       }
       // Every other branch claimed first, then reached exactly one more
@@ -2021,7 +2073,16 @@ describe('releaseApprovedIntent', () => {
 
     it.each(BRANCHES)('$name', async (branch) => {
       const intent = agentIntent(branch.intent);
-      if (!branch.unclaimed) primeAgentThroughRevalidation(intent);
+      if (!branch.unclaimed) {
+        primeAgentThroughRevalidation(intent);
+      } else {
+        // #5205 W04 (#5209): the pre-claim load runs on EVERY delivery now, so
+        // even the lost-claim branch needs its row — and it must be THIS
+        // branch's intent, not a generic one, or the flow continues past the
+        // claim against a mismatched row.
+        dbState.selectActionIntentsResults.push([intent]);
+        dbState.selectApprovalRequestsResults.push([]);
+      }
       branch.arrange();
 
       await releaseApprovedIntent(intent.id);
@@ -2065,6 +2126,12 @@ describe('releaseApprovedIntent', () => {
 
       // BullMQ redelivers: the row is terminal now, so the claim CAS returns
       // false and the whole body — evidence included — is skipped.
+      // #5205 W04 (#5209): the load now runs before the claim on EVERY
+      // delivery, so the redelivered call needs its own primed row too — else
+      // the load itself short-circuits on a missing row, the claim is never
+      // even attempted, and this `false` stub leaks unconsumed into whatever
+      // test runs next.
+      dbState.selectActionIntentsResults.push([intent]);
       intentServiceMock.transitionIntent.mockResolvedValueOnce(false);
       await releaseApprovedIntent(intent.id);
 
@@ -2925,6 +2992,10 @@ describe('processIntentReleaseJob', () => {
   describe('intent_created — ticket_autonomy recovery (P2-4 Task A3, #4191)', () => {
     it('routes a ticket_autonomy-decided row straight to release, never attemptPolicyDecision', async () => {
       dbState.selectActionIntentsResults.push([{ decidedVia: 'ticket_autonomy' }]);
+      // #5205 W04 (#5209): releaseApprovedIntent now does its OWN pre-claim
+      // load (this row is separate from the `decidedVia` lookup above), so it
+      // needs its own queued row or the claim below is never even attempted.
+      dbState.selectActionIntentsResults.push([{ decidedVia: 'ticket_autonomy' }]);
       intentServiceMock.transitionIntent.mockResolvedValueOnce(false); // lost race / already claimed — release path exits early, which is fine, we're proving ROUTING here
 
       const result = await processIntentReleaseJob({ intentId: 'intent-1', eventType: 'intent_created' });
@@ -3008,6 +3079,10 @@ describe('processIntentReleaseJob', () => {
     // failed closed because the approver's permission was revoked is an
     // outright false statement about a privileged action.
     intentServiceMock.transitionIntent.mockResolvedValueOnce(false);
+    // #5205 W04 (#5209): releaseApprovedIntent's own pre-claim load consumes
+    // the FIRST queued row now, ahead of the outcome notifier's read below —
+    // prime both, in that order, or the notifier's read comes back empty.
+    dbState.selectActionIntentsResults.push([{ ...FOUR_EYES_INTENT, status: 'failed' }]);
     dbState.selectActionIntentsResults.push([{ ...FOUR_EYES_INTENT, status: 'failed' }]);
 
     await processIntentReleaseJob({ intentId: 'intent-1', eventType: 'intent_approved' });
@@ -3024,6 +3099,9 @@ describe('processIntentReleaseJob', () => {
     // see the truth table on outcomeNotificationClass, and the #4465 block at
     // the bottom of this file for the other half of the property.
     intentServiceMock.transitionIntent.mockResolvedValueOnce(false);
+    // #5205 W04 (#5209): same ordering as THE LIE GUARD above — release's own
+    // pre-claim load consumes the first row, the notifier's re-read the second.
+    dbState.selectActionIntentsResults.push([{ ...FOUR_EYES_INTENT, status: 'expired' }]);
     dbState.selectActionIntentsResults.push([{ ...FOUR_EYES_INTENT, status: 'expired' }]);
 
     await processIntentReleaseJob({ intentId: 'intent-1', eventType: 'intent_approved' });
@@ -3114,6 +3192,11 @@ describe('processIntentReleaseJob', () => {
 
   it('a failed outcome notification never undoes a committed release', async () => {
     intentServiceMock.transitionIntent.mockResolvedValueOnce(false);
+    // #5205 W04 (#5209): releaseApprovedIntent's own pre-claim load consumes
+    // the first row; the outcome notifier's re-read (the one that actually
+    // calls createNotification, below) needs its own second row, or the
+    // queued rejection is never consumed here and leaks into a later test.
+    dbState.selectActionIntentsResults.push([FOUR_EYES_INTENT]);
     dbState.selectActionIntentsResults.push([FOUR_EYES_INTENT]);
     notifyMock.createNotification.mockRejectedValueOnce(new Error('notify boom'));
 
@@ -3126,6 +3209,9 @@ describe('processIntentReleaseJob', () => {
   });
 
   it('dispatches intent_approved to releaseApprovedIntent', async () => {
+    // #5205 W04 (#5209): releaseApprovedIntent's own pre-claim load needs a
+    // row before the claim it exercises below is even attempted.
+    dbState.selectActionIntentsResults.push([FOUR_EYES_INTENT]);
     intentServiceMock.transitionIntent.mockResolvedValueOnce(false); // exits immediately via double-delivery guard
 
     const result = await processIntentReleaseJob({ intentId: 'intent-1', eventType: 'intent_approved' });
@@ -3248,6 +3334,9 @@ describe('agent-originated outcome notifications', () => {
     // intent_approved arrives but the release did not run (lost CAS) and the
     // row now says failed — recipients must hear the truth, at high priority.
     intentServiceMock.transitionIntent.mockResolvedValueOnce(false);
+    // #5205 W04 (#5209): releaseApprovedIntent's own pre-claim load consumes
+    // the first row now, ahead of the outcome notifier's re-read below.
+    dbState.selectActionIntentsResults.push([{ ...AGENT_INTENT, status: 'failed' }]);
     dbState.selectActionIntentsResults.push([{ ...AGENT_INTENT, status: 'failed' }]);
     dbState.selectAgentRunsResults.push([RUN_ROW]);
     dbState.selectAgentsResults.push([AGENT_ROW]);
@@ -3357,6 +3446,11 @@ describe('outcome notification dedupe identity (#4465)', () => {
    *  duplicate-delivery case), observing the intent at `status`. */
   async function deliverApprovedObserving(status: string): Promise<void> {
     intentServiceMock.transitionIntent.mockResolvedValueOnce(false);
+    // #5205 W04 (#5209): releaseApprovedIntent's own pre-claim load now reads
+    // the intent BEFORE the claim, ahead of the outcome notifier's re-read
+    // below — both queue off the same actionIntents SELECT mock, in call
+    // order, so this needs two rows where one used to do.
+    dbState.selectActionIntentsResults.push([{ ...FOUR_EYES_INTENT, status }]);
     dbState.selectActionIntentsResults.push([{ ...FOUR_EYES_INTENT, status }]);
     await processIntentReleaseJob({ intentId: 'intent-1', eventType: 'intent_approved' });
   }
@@ -3443,6 +3537,11 @@ describe('outcome notification dedupe identity (#4465)', () => {
     async function deliverCreatedObserving(status: string): Promise<void> {
       intentServiceMock.transitionIntent.mockResolvedValueOnce(false);
       dbState.selectActionIntentsResults.push([{ decidedVia: 'ticket_autonomy' }]);
+      // #5205 W04 (#5209): releaseApprovedIntent's own pre-claim load is a
+      // SECOND read, between the decidedVia lookup above and the outcome
+      // notifier's re-read below — three rows off the same mock now, in call
+      // order, where two used to do.
+      dbState.selectActionIntentsResults.push([{ ...FOUR_EYES_INTENT, status }]);
       dbState.selectActionIntentsResults.push([{ ...FOUR_EYES_INTENT, status }]);
       await processIntentReleaseJob({ intentId: 'intent-1', eventType: 'intent_created' });
     }
@@ -3545,6 +3644,10 @@ describe('outcome notification dedupe identity (#4465)', () => {
 
     async function deliverAgentApprovedObserving(status: string): Promise<void> {
       intentServiceMock.transitionIntent.mockResolvedValueOnce(false);
+      // #5205 W04 (#5209): releaseApprovedIntent's own pre-claim load is a
+      // second read ahead of the outcome notifier's re-read (same reasoning
+      // as deliverApprovedObserving above).
+      dbState.selectActionIntentsResults.push([{ ...AGENT_INTENT_4465, status }]);
       dbState.selectActionIntentsResults.push([{ ...AGENT_INTENT_4465, status }]);
       dbState.selectAgentRunsResults.push([RUN_ROW_4465]);
       dbState.selectAgentsResults.push([AGENT_ROW_4465]);

--- a/apps/api/src/jobs/intentReleaseWorker.ts
+++ b/apps/api/src/jobs/intentReleaseWorker.ts
@@ -861,16 +861,26 @@ export async function releaseApprovedIntent(intentId: string): Promise<void> {
     if (!claim.won) {
       // A lost claim NEVER dispatches and NEVER writes a result. Record why on
       // the operation so the coordinator sees a reason rather than a stall —
-      // except when the refusal was the operation itself not being `reserved`,
-      // which means another claimant already owns it and this worker must not
-      // overwrite their bookkeeping.
-      if (claim.refusal !== 'operation_missing') {
+      // except when another claimant already owns the row, where writing would
+      // overwrite the winner's bookkeeping.
+      if (claim.refusal !== 'operation_already_claimed') {
         await markOperationDispatchFailed(intent.id, `${claim.refusal}: ${claim.detail}`);
       }
-      console.warn(
+      const message =
         `[IntentReleaseWorker] task-linked intent ${intentId} refused the dispatch claim `
-        + `(${claim.refusal}): ${claim.detail}`,
-      );
+        + `(${claim.refusal}): ${claim.detail}`;
+      if (claim.refusal === 'operation_missing') {
+        // A task-linked intent with NO operation row is a broken invariant, not
+        // a race: `reserveOperation` commits in the same transaction as the
+        // intent insert. There is also no operation row to record the reason
+        // ON, so without this the intent would sit `approved` until an
+        // unrelated deadline reaper noticed — up to 24 h later for an
+        // `mcp_api` source — with nothing naming what actually went wrong.
+        console.error(message);
+        captureException(new Error(message));
+      } else {
+        console.warn(message);
+      }
     }
   } else {
     claimed = await transitionIntent(

--- a/apps/api/src/jobs/intentReleaseWorker.ts
+++ b/apps/api/src/jobs/intentReleaseWorker.ts
@@ -7,6 +7,17 @@ import { aiAgentRuns, aiAgents } from '../db/schema/aiAgents';
 import { approvalRequests } from '../db/schema/approvals';
 import { getBullMQConnection } from '../services/redis';
 import { captureException } from '../services/sentry';
+import {
+  claimTaskLinkedIntentForDispatch,
+  revertTaskLinkedDispatchClaim,
+} from '../services/aiOperator/dispatchClaim';
+import {
+  isTaskLinkedIntent,
+  markOperationDispatchFailed,
+  recordOperationExecutionRef,
+  recordOperationResult,
+  type OperationResultState,
+} from '../services/aiOperator/operationService';
 import { writeAuditEvent, requestLikeFromSnapshot } from '../services/auditEvents';
 import { recordActionIntentEvent, recordActionIntentMetric } from '../services/actionIntents/metrics';
 import { createNotification } from '../services/userNotifications';
@@ -115,6 +126,89 @@ function normalizeToolResult(raw: string): Record<string, unknown> {
 }
 
 /**
+ * #5205 W04 (#5209), baseline §2.5: pulls the typed execution reference out of
+ * a tool result. `manage_services` returns `JSON.stringify(CommandResult)`
+ * verbatim (aiToolsScripts.ts, the `manage_services` handler), and
+ * `CommandResult.commandId` IS the `device_commands` row id, attached by
+ * `executeCommand` "once a command row exists (success or failure)"
+ * (commandQueue.ts:76-83). Nothing has to be threaded through: the id is
+ * already in the result the release worker holds.
+ *
+ * `commandId` is OPTIONAL and absent on failures that happen before the row is
+ * created (device missing/offline, insert failure), so a null return is a real,
+ * expected case — a refusal with no reference — not a parse bug.
+ *
+ * Deliberately shape-based rather than keyed off the tool name: any tool whose
+ * result carries a `commandId` is dispatching a device command, and hard-coding
+ * `manage_services` here would silently stop capturing references the day a
+ * second device-command tool joins the slice.
+ */
+function executionRefFromToolResult(
+  result: Record<string, unknown>,
+): { kind: 'device_command'; id: string } | null {
+  const commandId = result.commandId;
+  return typeof commandId === 'string' && UUID_RE.test(commandId)
+    ? { kind: 'device_command', id: commandId }
+    : null;
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Writes the execution reference and the bounded result onto a task-linked
+ * intent's operation row. A no-op for a legacy intent. Never throws: it runs
+ * after the tool already had its real-world effect, so a bookkeeping failure
+ * must not fail an action that already happened (see `recordOperationResult`).
+ *
+ * The reference is attached first and separately: it is what makes an UNKNOWN
+ * effect reconcilable at all, so it must land even if the result write is later
+ * out-ranked or the process dies between the two.
+ */
+async function persistTaskOperationOutcome(
+  intent: ActionIntent,
+  result: Record<string, unknown>,
+  isError: boolean,
+): Promise<void> {
+  if (!isTaskLinkedIntent(intent)) return;
+  const ref = executionRefFromToolResult(result);
+  if (ref) await recordOperationExecutionRef(intent.id, ref);
+  await recordOperationResult({
+    intentId: intent.id,
+    resultState: operationResultStateFromToolResult(result, isError),
+    result,
+    executionRef: ref,
+  });
+}
+
+/**
+ * Maps a tool result onto an operation `result_state`.
+ *
+ * `CommandResult.status` is `'completed' | 'failed' | 'timeout'`
+ * (commandQueue.ts:67-84). **`timeout` becomes `unknown`, never `failed`** —
+ * that is the single most important mapping in this file. The tool waits 30 s
+ * while the device command itself reaps at 5 min (baseline §2.6), so between
+ * those two clocks a `timeout` means "the effect may still be landing", and
+ * `commandAcceptsAgentResultCondition` deliberately keeps the device row open
+ * to a genuine late agent result. Recording `failed` there would assert a
+ * non-effect the system cannot prove, which §7.3 forbids.
+ *
+ * `isError` is the caller's own returned-error detection, which is a real
+ * failure of the tool call itself.
+ */
+function operationResultStateFromToolResult(
+  result: Record<string, unknown>,
+  isError: boolean,
+): Exclude<OperationResultState, 'pending'> {
+  if (result.status === 'timeout') return 'unknown';
+  if (isError || result.status === 'failed') return 'failed';
+  if (result.status === 'completed') return 'succeeded';
+  // No recognisable device-command status (a non-command tool, or a truncated
+  // result): the call returned without error, so the dispatch succeeded, but
+  // say nothing stronger than that.
+  return isError ? 'failed' : 'succeeded';
+}
+
+/**
  * Wave-5A review fix (#3827): CAS `executing -> approved` (undoing the claim
  * `releaseApprovedIntent` took at step 1) instead of `failIntent`'s
  * `executing -> failed`. `agentReleaseAuthority.ts`'s 'kill_switch_engaged'
@@ -136,7 +230,13 @@ async function pauseIntentForKillSwitch(
   intent: ActionIntent,
   details?: Record<string, unknown>,
 ): Promise<void> {
-  const won = await transitionIntent(intent.id, 'executing', 'approved');
+  // #5205 W04 (#5209), spec §7.3: for a task-linked intent the reversal also
+  // puts the operation back to `reserved`, in the SAME transaction. Leaving it
+  // `dispatched` would tell the reconciler an effect is in flight when the
+  // claim was explicitly undone and the intent is claimable again.
+  const won = isTaskLinkedIntent(intent)
+    ? await revertTaskLinkedDispatchClaim(intent.id, 'kill_switch_engaged')
+    : await transitionIntent(intent.id, 'executing', 'approved');
   if (!won) return;
   const message = `[IntentReleaseWorker] intent ${intent.id} release paused — kill switch engaged`;
   console.warn(message, details);
@@ -598,6 +698,27 @@ async function failIntent(
   // revalidation/digest/session refusal) pass no `executedAt` and so write
   // nothing, which is the whole point: an agent is never graded down for an
   // action it was refused permission to try.
+  // #5205 W04 (#5209): the operation row is written BEFORE the CAS and
+  // regardless of whether the CAS is won — that independence is the whole
+  // reason the row exists (baseline §4). `options.executed` is the repo's own
+  // attempted-ness discriminator and maps exactly onto the two cases here:
+  //   - not executed (every revalidation/digest/session/connection refusal):
+  //     nothing was ever sent, so the operation is a terminal dispatch failure.
+  //   - executed (execution_error, secret_seal_invariant_violated): the
+  //     provider-side call DID happen and its outcome is unknowable from here,
+  //     so `unknown` — never `failed`. A device command may still finish and
+  //     W06 reconciles it (baseline §2.6, the three clocks).
+  if (isTaskLinkedIntent(intent)) {
+    if (options.executed) {
+      await recordOperationResult({
+        intentId: intent.id,
+        resultState: 'unknown',
+        result: { errorCode, ...(options.details ?? {}) },
+      });
+    } else {
+      await markOperationDispatchFailed(intent.id, errorCode);
+    }
+  }
   const won = await terminalizeIntent(intent, 'failed', {
     errorCode,
     ...(options.executed ? { executedAt: new Date() } : {}),
@@ -658,33 +779,7 @@ async function failOnPlaintextSecretGuard(intent: ActionIntent, err: unknown): P
  * testing without spinning up a real BullMQ Worker.
  */
 export async function releaseApprovedIntent(intentId: string): Promise<void> {
-  // Step 1 (spec §5.1): the single-use release guard. Zero rows = lost race
-  // (expiry, cancel, a prior delivery of this exact job, or the stale-
-  // executing reaper already claimed it) — exit silently. This is what
-  // makes repeated/duplicate `intent_approved` enqueues safe.
-  // requireNotExpired folds the deadline into the claim: an approved intent
-  // cannot be claimed for execution once past its release_by lease (falling
-  // back to expires_at for legacy rows with no lease — see
-  // intentService.ts's transitionIntent). release_by, not
-  // approval_expires_at, is what governs an already-approved intent — an
-  // intent approved just before approval_expires_at gets a FRESH lease
-  // starting at approval time (the "59:59 trap" — jobs/intentExpiryReaper.ts's
-  // header), so it stays claimable here even though approval_expires_at has
-  // since passed. Once release_by itself passes, the 30s expiry reaper
-  // terminalizes the leftover approved row. Without this check an action
-  // could execute after its authorization window closed.
-  const claimed = await transitionIntent(
-    intentId,
-    'approved',
-    'executing',
-    { executedAt: null, executionStartedAt: new Date() },
-    { requireNotExpired: 'release' },
-  );
-  if (!claimed) {
-    return;
-  }
-
-  // Step 2: load the intent + its winning approval row. Both are fast local
+  // Step 1: load the intent + its winning approval row. Both are fast local
   // reads with no external I/O, so they share one short system-scoped
   // transaction — mirrors intentOutboxPublisher.ts's phase discipline
   // (DB-only work gets its own short context; the network/tool-execution
@@ -720,10 +815,73 @@ export async function releaseApprovedIntent(intentId: string): Promise<void> {
   });
 
   if (!intent) {
-    // Unreachable in practice — the CAS above requires the row to exist —
-    // but there is nothing to CAS to failed if the row itself is gone, so
-    // just log and stop rather than throwing out of a BullMQ processor.
-    console.error(`[IntentReleaseWorker] intent ${intentId} not found after CAS to executing`);
+    // The row is gone (erased, or an outbox row outliving its intent). There is
+    // nothing to claim and nothing to CAS to failed, so log and stop rather
+    // than throwing out of a BullMQ processor. #5205 W04 moved this check ahead
+    // of the claim — it used to read "not found after CAS to executing".
+    console.error(`[IntentReleaseWorker] intent ${intentId} not found`);
+    return;
+  }
+
+  // Step 2 (spec §5.1): the single-use release guard. Zero rows = lost race
+  // (expiry, cancel, a prior delivery of this exact job, or the stale-
+  // executing reaper already claimed it) — exit silently. This is what
+  // makes repeated/duplicate `intent_approved` enqueues safe.
+  // requireNotExpired folds the deadline into the claim: an approved intent
+  // cannot be claimed for execution once past its release_by lease (falling
+  // back to expires_at for legacy rows with no lease — see
+  // intentService.ts's transitionIntent). release_by, not
+  // approval_expires_at, is what governs an already-approved intent — an
+  // intent approved just before approval_expires_at gets a FRESH lease
+  // starting at approval time (the "59:59 trap" — jobs/intentExpiryReaper.ts's
+  // header), so it stays claimable here even though approval_expires_at has
+  // since passed. Once release_by itself passes, the 30s expiry reaper
+  // terminalizes the leftover approved row. Without this check an action
+  // could execute after its authorization window closed.
+  //
+  // #5205 W04 (#5209), spec §7.3: for a TASK-LINKED intent this same claim
+  // additionally carries the task's state, plan revision, deadline and target
+  // detachment — one conditional UPDATE inside one transaction that also flips
+  // the operation to `dispatched`, not a second claim taken afterwards.
+  //
+  // The load above used to sit AFTER the claim. It was moved in front of it so
+  // the claim can branch on `intent.taskId` without a second read: the row's
+  // content columns are DB-immutable, and nothing below reads its `status`
+  // (the outcome notifier re-reads the live status itself). Query count on the
+  // won path is unchanged; the lost-claim path now pays one read it did not
+  // pay before, which is a path that does nothing else.
+  let claimed: boolean;
+  if (isTaskLinkedIntent(intent) && intent.taskId) {
+    const claim = await claimTaskLinkedIntentForDispatch({
+      id: intent.id,
+      orgId: intent.orgId,
+      taskId: intent.taskId,
+    });
+    claimed = claim.won;
+    if (!claim.won) {
+      // A lost claim NEVER dispatches and NEVER writes a result. Record why on
+      // the operation so the coordinator sees a reason rather than a stall —
+      // except when the refusal was the operation itself not being `reserved`,
+      // which means another claimant already owns it and this worker must not
+      // overwrite their bookkeeping.
+      if (claim.refusal !== 'operation_missing') {
+        await markOperationDispatchFailed(intent.id, `${claim.refusal}: ${claim.detail}`);
+      }
+      console.warn(
+        `[IntentReleaseWorker] task-linked intent ${intentId} refused the dispatch claim `
+        + `(${claim.refusal}): ${claim.detail}`,
+      );
+    }
+  } else {
+    claimed = await transitionIntent(
+      intentId,
+      'approved',
+      'executing',
+      { executedAt: null, executionStartedAt: new Date() },
+      { requireNotExpired: 'release' },
+    );
+  }
+  if (!claimed) {
     return;
   }
 
@@ -1005,6 +1163,9 @@ export async function releaseApprovedIntent(intentId: string): Promise<void> {
       await failOnPlaintextSecretGuard(intent, err);
       return;
     }
+    // #5205 W04 (#5209): the operation row records the outcome BEFORE the CAS
+    // is attempted, so a lost race cannot discard it (baseline §4).
+    await persistTaskOperationOutcome(intent, storedResult, true);
     const failed = await terminalizeIntent(intent, 'failed', {
       executedAt: new Date(),
       errorCode: 'tool_returned_error',
@@ -1014,6 +1175,8 @@ export async function releaseApprovedIntent(intentId: string): Promise<void> {
       auditReleaseFailure(intent, 'tool_returned_error', { returnedError: true });
     } else {
       // Lost the CAS after the tool ran — the side effect happened; surface it.
+      // The operation row above already holds the result, so this is now a
+      // reporting gap on the INTENT only, not a lost outcome.
       console.error(
         `[IntentReleaseWorker] Lost the executing->failed CAS for intent ${intent.id} after a returned tool error`,
       );
@@ -1041,6 +1204,12 @@ export async function releaseApprovedIntent(intentId: string): Promise<void> {
     await failOnPlaintextSecretGuard(intent, err);
     return;
   }
+  // #5205 W04 (#5209), spec §6.3 / baseline §4: execution reference + bounded
+  // result land on the operation row in their own write, BEFORE the intent CAS
+  // is attempted. The intent is terminal-and-immutable the moment it moves, and
+  // the losing-CAS path below used to drop the result entirely.
+  await persistTaskOperationOutcome(intent, finalResult, false);
+
   let fixWatchId: string | null = null;
   const completed = await terminalizeIntent(
     intent,
@@ -1065,6 +1234,13 @@ export async function releaseApprovedIntent(intentId: string): Promise<void> {
       + 'a reaper or duplicate delivery likely already terminalized it; the tool DID execute',
     );
     captureException(new Error(`intent ${intent.id} executed but lost the completed CAS`));
+    // #5205 W04 (#5209): write the outcome AGAIN on the losing path. It already
+    // landed above, but repeating it here is deliberate — the reaper may have
+    // stamped `unknown` in between, and `recordOperationResult` is rank-ordered
+    // so a definite outcome overwrites `unknown` while `unknown` never
+    // overwrites a definite one. This is the exact hole baseline §4 documented:
+    // "the result this execution produced is not recorded anywhere".
+    await persistTaskOperationOutcome(intent, finalResult, false);
     return;
   }
 

--- a/apps/api/src/services/actionIntents/intentOperationIdentity.test.ts
+++ b/apps/api/src/services/actionIntents/intentOperationIdentity.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createHash } from 'crypto';
+
+// intentService's import graph reaches the postgres pool and the whole AI tool
+// registry. These cases exercise two PURE exports, so the graph is stubbed to
+// whatever shape import-time evaluation needs and nothing more.
+vi.mock('../../db', () => ({
+  db: {},
+  runOutsideDbContext: (fn: () => unknown) => fn(),
+  withDbAccessContext: (_ctx: unknown, fn: () => unknown) => fn(),
+  withSystemDbAccessContext: (fn: () => unknown) => fn(),
+}));
+
+import {
+  deriveIdempotencyKey,
+  deriveIntentIdempotencyKey,
+  isSameTaskOperationReuse,
+} from './intentService';
+
+const TASK_A = '11111111-1111-4111-8111-111111111111';
+const TASK_B = '22222222-2222-4222-8222-222222222222';
+const RUN_A = '33333333-3333-4333-8333-333333333333';
+const RUN_B = '44444444-4444-4444-8444-444444444444';
+const DIGEST = 'a'.repeat(64);
+
+const sha = (material: string) => createHash('sha256').update(material).digest('hex');
+
+describe('deriveIntentIdempotencyKey (baseline C6/H1 — one arbiter)', () => {
+  const base = {
+    explicitKey: undefined,
+    toolName: 'manage_services',
+    argumentDigest: DIGEST,
+    actorId: RUN_A,
+    scopeId: null as string | null,
+  };
+
+  it('keys a task-linked intent on TASK identity, not run identity', () => {
+    const key = deriveIntentIdempotencyKey({
+      ...base,
+      taskContext: { taskId: TASK_A, operationKey: 'restart:spooler:1' },
+    });
+    // Spelled out rather than round-tripped through the helper: this is the
+    // hashed material contract, and a test that just calls the same function
+    // twice would pass on any material at all.
+    expect(key).toBe(sha(`task:${TASK_A}:manage_services:${DIGEST}:restart:spooler:1`));
+  });
+
+  it('yields the SAME key for a continuation run re-proposing the same operation', () => {
+    const forRunA = deriveIntentIdempotencyKey({
+      ...base,
+      actorId: RUN_A,
+      taskContext: { taskId: TASK_A, operationKey: 'restart:spooler:1' },
+    });
+    const forRunB = deriveIntentIdempotencyKey({
+      ...base,
+      actorId: RUN_B,
+      taskContext: { taskId: TASK_A, operationKey: 'restart:spooler:1' },
+    });
+    // This is the whole point: attempt 2 of a task converges on attempt 1's
+    // live intent through the EXISTING partial unique index rather than
+    // minting a second intent.
+    expect(forRunB).toBe(forRunA);
+  });
+
+  it('yields DIFFERENT keys for two tasks proposing byte-identical arguments', () => {
+    const a = deriveIntentIdempotencyKey({
+      ...base,
+      taskContext: { taskId: TASK_A, operationKey: 'restart:spooler:1' },
+    });
+    const b = deriveIntentIdempotencyKey({
+      ...base,
+      taskContext: { taskId: TASK_B, operationKey: 'restart:spooler:1' },
+    });
+    expect(b).not.toBe(a);
+  });
+
+  it('yields DIFFERENT keys for two operations of the SAME task', () => {
+    const a = deriveIntentIdempotencyKey({
+      ...base,
+      taskContext: { taskId: TASK_A, operationKey: 'restart:spooler:1' },
+    });
+    const b = deriveIntentIdempotencyKey({
+      ...base,
+      taskContext: { taskId: TASK_A, operationKey: 'restart:spooler:2' },
+    });
+    expect(b).not.toBe(a);
+  });
+
+  it('leaves the legacy run-scoped derivation byte-identical', () => {
+    expect(deriveIntentIdempotencyKey({ ...base, taskContext: null }))
+      .toBe(deriveIdempotencyKey(RUN_A, 'manage_services', DIGEST, null));
+    expect(deriveIntentIdempotencyKey({ ...base, taskContext: null, scopeId: 'dev-1' }))
+      .toBe(deriveIdempotencyKey(RUN_A, 'manage_services', DIGEST, 'dev-1'));
+  });
+
+  it('honours an explicit key on the legacy path only', () => {
+    expect(deriveIntentIdempotencyKey({ ...base, taskContext: null, explicitKey: 'mine' }))
+      .toBe('mine');
+    // On the task path an explicit key is rejected by createActionIntent before
+    // this function is reached; if one ever arrives here, task identity wins so
+    // the single-arbiter invariant cannot be bypassed by a coding error.
+    expect(
+      deriveIntentIdempotencyKey({
+        ...base,
+        explicitKey: 'mine',
+        taskContext: { taskId: TASK_A, operationKey: 'op' },
+      }),
+    ).not.toBe('mine');
+  });
+
+  it('cannot be collided by a legacy caller, because a UUID actor cannot carry the task: prefix', () => {
+    const taskKey = deriveIntentIdempotencyKey({
+      ...base,
+      taskContext: { taskId: TASK_A, operationKey: 'op' },
+    });
+    // The nearest legacy shape: same tool, same digest, the task id as the
+    // actor and the operation key as the scope. Different material, because
+    // the legacy branch has no `task:` prefix.
+    const legacyLookalike = deriveIntentIdempotencyKey({
+      ...base,
+      taskContext: null,
+      actorId: TASK_A,
+      scopeId: 'op',
+    });
+    expect(legacyLookalike).not.toBe(taskKey);
+  });
+});
+
+describe('isSameTaskOperationReuse (baseline §5.2 — the relaxation predicate)', () => {
+  const ctx = { taskId: TASK_A, operationKey: 'restart:spooler:1' };
+
+  it('is true only when both the task and the operation match', () => {
+    expect(isSameTaskOperationReuse({ taskId: TASK_A, operationKey: 'restart:spooler:1' }, ctx))
+      .toBe(true);
+  });
+
+  it.each([
+    ['a different task', { taskId: TASK_B, operationKey: 'restart:spooler:1' }],
+    ['a different operation', { taskId: TASK_A, operationKey: 'restart:spooler:2' }],
+    ['a LEGACY task-less intent', { taskId: null, operationKey: null }],
+    ['a task-less intent that somehow carries an operation key', { taskId: null, operationKey: 'restart:spooler:1' }],
+  ])('is false for %s', (_label, existing) => {
+    expect(isSameTaskOperationReuse(existing, ctx)).toBe(false);
+  });
+
+  it('is false for every existing row when the caller supplied no task context', () => {
+    expect(isSameTaskOperationReuse({ taskId: TASK_A, operationKey: 'restart:spooler:1' }, null))
+      .toBe(false);
+    expect(isSameTaskOperationReuse({ taskId: null, operationKey: null }, null)).toBe(false);
+  });
+});

--- a/apps/api/src/services/actionIntents/intentService.ts
+++ b/apps/api/src/services/actionIntents/intentService.ts
@@ -1,7 +1,7 @@
 import { buildActionLabel } from './actionLabel';
 import { randomUUID, createHash } from 'crypto';
 import { and, eq, inArray, sql } from 'drizzle-orm';
-import type { AssuranceLevel } from '@breeze/shared';
+import { actionIntentTaskContextSchema, type ActionIntentTaskContext, type AssuranceLevel } from '@breeze/shared';
 import { db, runOutsideDbContext, withDbAccessContext, withSystemDbAccessContext, type Database, type DbAccessContext } from '../../db';
 import { createNotification } from '../userNotifications';
 import { captureException } from '../sentry';
@@ -47,6 +47,14 @@ import {
   IntentScopeArgumentMismatchError,
 } from './intentTargetScope';
 import { evaluateTicketAutonomy } from './ticketAutonomy';
+import { aiOperatorTasks } from '../../db/schema/aiOperatorTasks';
+import {
+  isTaskLinkedIntent,
+  markOperationCancelled,
+  markOperationCancelRequested,
+  OperationReplayError,
+  reserveOperation,
+} from '../aiOperator/operationService';
 
 /** Statuses the partial `action_intents_org_idem_uniq` index dedupes on
  * (IMPORTANT-4 — migration 2026-07-18-action-intents.sql). Kept as a single
@@ -66,6 +74,13 @@ type AgentRunRef = {
   agentId: string;
   orgId: string;
   deviceId: string | null;
+  /**
+   * #5205 W04: the run's OWN task linkage, read from `ai_agent_runs`. This is
+   * the TRUSTED evidence that a caller-supplied `input.task` really belongs to
+   * this run — the caller asserting a task id proves nothing on its own.
+   */
+  taskId: string | null;
+  taskStepKey: string | null;
 } | null;
 
 // Action intents & durable approval layer — core intent service (spec
@@ -179,6 +194,23 @@ export interface CreateActionIntentInput {
    * an `autonomyDenied` breadcrumb on its `result` column.
    */
   autonomy?: { kind: 'ticket_autonomy' };
+  /**
+   * #5205 W04 (#5209): AI Operator task context. TRUSTED, INTERNAL-ONLY —
+   * never accepted from an HTTP body (see `actionIntentTaskContextSchema`'s
+   * header in @breeze/shared and `assertTaskContextTrusted` below).
+   *
+   * When present the intent's `idempotency_key` is derived from TASK identity
+   * instead of run identity, so the existing partial unique
+   * `action_intents_org_idem_uniq` stays the SINGLE ON CONFLICT arbiter
+   * (baseline C6/H1) and a continuation run re-proposing the same operation
+   * converges on the live intent instead of minting a second one. The matching
+   * `ai_operator_operations` row is reserved in the SAME transaction as the
+   * intent insert (spec §6.5).
+   *
+   * Only valid for the `ai_agent` principal, and only when the calling run's
+   * own `ai_agent_runs.task_id` matches.
+   */
+  task?: ActionIntentTaskContext;
 }
 
 export type ActionIntentSnapshot = {
@@ -432,7 +464,7 @@ export function buildImpactSummary(toolName: string, input: Record<string, unkno
  * must land on DIFFERENT keys or the partial unique index would collapse the
  * whole sweep to one live intent.
  */
-function deriveIdempotencyKey(
+export function deriveIdempotencyKey(
   actorId: string,
   actionName: string,
   digest: string,
@@ -442,6 +474,61 @@ function deriveIdempotencyKey(
     ? `${actorId}:${actionName}:${digest}:${scopeDeviceId}`
     : `${actorId}:${actionName}:${digest}`;
   return createHash('sha256').update(material).digest('hex');
+}
+
+/**
+ * #5205 W04 (#5209), baseline §5.2. The predicate that decides whether an
+ * existing LIVE intent found by an idempotency-key conflict is the SAME task
+ * operation being re-proposed — the only condition under which the "reused by
+ * another run" rejection relaxes its run-identity clause.
+ *
+ * Exported so its truth table is unit-testable directly: this predicate is the
+ * hinge of the continuation contract, and every false-positive is a
+ * cross-run/cross-task attachment.
+ *
+ * `existing.taskId !== null` is redundant with the equality below (a null can
+ * never equal a non-null uuid) and is kept only to state the invariant a
+ * reader needs: a task-linked proposal must never attach to a LEGACY task-less
+ * intent. Do not "simplify" it away without leaving that sentence behind.
+ */
+export function isSameTaskOperationReuse(
+  existing: { taskId: string | null; operationKey: string | null },
+  taskContext: { taskId: string; operationKey: string } | null,
+): boolean {
+  return (
+    taskContext !== null
+    && existing.taskId !== null
+    && existing.taskId === taskContext.taskId
+    && existing.operationKey === taskContext.operationKey
+  );
+}
+
+/**
+ * #5205 W04 (#5209), baseline C6/H1: the ONE place an intent's idempotency key
+ * is chosen. A task-linked intent keys on TASK identity so
+ * `action_intents_org_idem_uniq` stays the single ON CONFLICT arbiter; every
+ * other intent keeps the byte-identical legacy derivation.
+ *
+ * Exported for direct unit coverage of both branches and their disjointness.
+ */
+export function deriveIntentIdempotencyKey(args: {
+  taskContext: { taskId: string; operationKey: string } | null;
+  explicitKey: string | undefined;
+  toolName: string;
+  argumentDigest: string;
+  actorId: string;
+  scopeId: string | null;
+}): string {
+  if (args.taskContext) {
+    return deriveIdempotencyKey(
+      `task:${args.taskContext.taskId}`,
+      args.toolName,
+      args.argumentDigest,
+      args.taskContext.operationKey,
+    );
+  }
+  return args.explicitKey
+    ?? deriveIdempotencyKey(args.actorId, args.toolName, args.argumentDigest, args.scopeId);
 }
 
 function computeExpiresAt(source: ActionIntentSource, approvalScope: ActionIntentApprovalScope): Date {
@@ -864,6 +951,39 @@ export async function createActionIntent(
       'agent_source_mismatch',
     );
   }
+  // #5205 W04 (#5209): task context is agent-principal only, for the same
+  // reason `scope` is — and more sharply, because it selects the intent's
+  // idempotency key material. A human/MCP caller supplying one could mint an
+  // intent that a task it does not own is then obliged to reconcile.
+  let taskContext: ActionIntentTaskContext | null = null;
+  if (input.task !== undefined) {
+    if (auth.principal.kind !== 'ai_agent') {
+      throw new ActionIntentError(
+        `task context is only valid for the ai_agent principal (got principal '${auth.principal.kind}')`,
+        'task_context_not_allowed',
+      );
+    }
+    // An explicit key and a task context are mutually exclusive, and this is a
+    // REJECTION, not a precedence rule (Codex quorum D1c, adopted). Letting the
+    // explicit key win would silently reinstate the two-arbiter hazard C6
+    // exists to prevent; letting the task win silently would hide a real caller
+    // contract error. `!= null` catches the empty string too.
+    if (input.idempotencyKey != null && input.idempotencyKey !== '') {
+      throw new ActionIntentError(
+        'An explicit idempotencyKey cannot be combined with task context — the task identity IS the key',
+        'task_context_not_allowed',
+      );
+    }
+    const parsed = actionIntentTaskContextSchema.safeParse(input.task);
+    if (!parsed.success) {
+      throw new ActionIntentError(
+        `Malformed task context: ${parsed.error.issues.map((i) => i.path.join('.') + ' ' + i.message).join('; ')}`,
+        'task_context_invalid',
+      );
+    }
+    taskContext = parsed.data;
+  }
+
   // P2-2 (#4189): an explicit device scope is the SWEEP path's way of minting
   // a device-bound intent from a device-less run. It is agent-principal only —
   // a human/MCP caller's target already comes from the tool arguments the
@@ -999,6 +1119,8 @@ export async function createActionIntent(
             orgId: aiAgentRuns.orgId,
             deviceId: aiAgentRuns.deviceId,
             policySnapshot: aiAgentRuns.policySnapshot,
+            taskId: aiAgentRuns.taskId,
+            taskStepKey: aiAgentRuns.taskStepKey,
           })
           .from(aiAgentRuns)
           .where(eq(aiAgentRuns.id, principal.runId))
@@ -1070,6 +1192,22 @@ export async function createActionIntent(
     }
     agentRun = loaded.run;
     agentRow = loaded.agent;
+
+    // #5205 W04 (#5209), Codex quorum D1b (adopted): the caller ASSERTING a
+    // task id proves nothing. `ai_agent_runs.task_id` / `task_step_key` are
+    // written by task admission (W03 schema, W06 writer) and are the only
+    // trusted evidence that this run is a legitimate participant in that task.
+    // Without this check, any agent run in the org could propose an operation
+    // against any task and — via the same-task relaxation below — attach to an
+    // intent minted under a different run's policy snapshot.
+    if (taskContext) {
+      if (agentRun.taskId !== taskContext.taskId || agentRun.taskStepKey !== taskContext.taskStepKey) {
+        throw new ActionIntentError(
+          'Task context does not match the calling run\'s own task linkage',
+          'task_context_invalid',
+        );
+      }
+    }
     scopedDeviceHostname = loaded.scopedDevice
       ? (loaded.scopedDevice.displayName ?? loaded.scopedDevice.hostname)
       : null;
@@ -1183,19 +1321,33 @@ export async function createActionIntent(
   // id): two runs of the same agent proposing identical arguments must
   // yield DISTINCT intents — an intent is immutably attributed to one run,
   // whose policy snapshot the release path evaluates (review major 4).
-  const idempotencyKey = input.idempotencyKey
-    ?? deriveIdempotencyKey(
-      agentRun ? agentRun.id : requesterId,
-      input.toolName,
-      argumentDigest,
-      // The two scope variants are mutually exclusive; either one (or
-      // neither) folds into the SAME hashed-material parameter that has
-      // always carried the device scope — a ticket-scoped fan-out (multiple
-      // ticket-triage proposals for the same tool+args, one per ticket) must
-      // land on distinct keys for exactly the same reason a device sweep
-      // fan-out does.
-      scopeDeviceId ?? scopeTicketId ?? null,
-    );
+  // #5205 W04 (#5209), baseline C6/H1: a task-linked intent derives its key
+  // from TASK identity, so `action_intents_org_idem_uniq` remains the SINGLE
+  // ON CONFLICT arbiter. Adding a second partial unique on
+  // (org_id, task_id, operation_key) would raise a bare 23505 that the
+  // onConflictDoNothing below cannot absorb — Postgres suppresses conflicts on
+  // the NAMED inference target only. The `task:` prefix cannot collide with the
+  // legacy keyspace: legacy actor ids are UUIDs (a run id or a user id) and a
+  // UUID cannot contain a colon, so no legacy caller can produce this material.
+  // An explicit key alongside a task is rejected outright above, which is what
+  // closes the remaining forge path.
+  const idempotencyKey = deriveIntentIdempotencyKey({
+    taskContext,
+    explicitKey: input.idempotencyKey,
+    toolName: input.toolName,
+    argumentDigest,
+    // Agent default key is RUN-scoped (run id, not the synthetic agent user
+    // id): two runs of the same agent proposing identical arguments must
+    // yield DISTINCT intents — an intent is immutably attributed to one run,
+    // whose policy snapshot the release path evaluates (review major 4).
+    actorId: agentRun ? agentRun.id : requesterId,
+    // The two scope variants are mutually exclusive; either one (or neither)
+    // folds into the SAME hashed-material parameter that has always carried
+    // the device scope — a ticket-scoped fan-out (multiple ticket-triage
+    // proposals for the same tool+args, one per ticket) must land on distinct
+    // keys for exactly the same reason a device sweep fan-out does.
+    scopeId: scopeDeviceId ?? scopeTicketId ?? null,
+  });
   const targetSummary = buildTargetSummary(input.toolName, input.input);
   const impactSummary = buildImpactSummary(input.toolName, input.input, guardrail);
   // What the approver READS. `targetSummary` stays the audit signature.
@@ -1431,6 +1583,11 @@ export async function createActionIntent(
           scopeKind: scopeDeviceId ? ('device' as const) : scopeTicketId ? ('ticket' as const) : null,
           scopeDeviceId,
           scopeTicketId,
+          // #5205 W04: all three or none — `action_intents_task_link_chk`.
+          // Immutable from here on (2026-10-14-100200 extends the deny-list).
+          taskId: taskContext?.taskId ?? null,
+          taskStepKey: taskContext?.taskStepKey ?? null,
+          operationKey: taskContext?.operationKey ?? null,
           source: input.source,
           requestingClientLabel,
           actionName: input.toolName,
@@ -1524,10 +1681,28 @@ export async function createActionIntent(
         // key AND a byte-identical canonical argument shape (e.g. both take
         // only {deviceId}), and treating tool B as a replay of tool A would
         // silently drop proposal B (review finding 2).
+        // #5205 W04 (#5209), baseline §5.2: the run-identity clause — and ONLY
+        // that clause — is relaxed when this is the same task proposing the
+        // same operation. That is the continuation case the whole slice exists
+        // for: attempt 2 of a task re-proposes the operation attempt 1 left in
+        // flight and must ATTACH to the live intent, never mint a second one.
+        //
+        // Action name, source and argument digest still all have to match, so a
+        // continuation cannot attach to an intent for different arguments —
+        // that is what makes the relaxation safe at all.
+        //
+        // H3: release then evaluates the EARLIER run's policy snapshot, so this
+        // relaxation ships only alongside the live-authority recheck at the
+        // dispatch claim — `checkAgentReleaseAuthority` evaluates the snapshot
+        // AND the current effective policy and denies if either denies
+        // (agentReleaseAuthority.ts, the `candidates` loop). Do not relax this
+        // further without re-reading that.
+        const sameTaskReuse = isSameTaskOperationReuse(existing, taskContext);
         if (
           existing.actionName !== input.toolName ||
           existing.source !== input.source ||
-          (existing.requestingAgentRunId ?? null) !== (agentRun?.id ?? null) ||
+          (!sameTaskReuse
+            && (existing.requestingAgentRunId ?? null) !== (agentRun?.id ?? null)) ||
           existing.argumentDigest !== argumentDigest
         ) {
           throw new ActionIntentError(
@@ -1561,6 +1736,47 @@ export async function createActionIntent(
       // inertness proof. Once Part B's real resolvePolicyDecisionState can
       // return 'authorized', this becomes the seam that skips fan-out
       // entirely for a policy-decided intent.
+      // #5205 W04 (#5209), spec §6.5: reserve the operation row in the SAME
+      // transaction as the intent insert. "Attaching the task only after the
+      // intent commits is insufficient" — a crash in that window would leave an
+      // approvable intent that no task owns and no reconciler can find.
+      //
+      // `plan_revision` is pinned from the task's revision AS READ HERE, i.e.
+      // by the admission the approval will cover. The dispatch claim later
+      // requires the task's CURRENT revision to still equal it, which is how
+      // spec §7.1's "revising plan arguments creates a new operation and
+      // approval" is enforced against a stale approval.
+      //
+      // A conflict on the operation's PERMANENT unique throws
+      // OperationReplayError, which rolls this whole transaction back — no
+      // second intent is minted for an operation whose effect may already have
+      // landed (baseline C7/H2: the intent's live-only index cannot guard
+      // sequential replay because a completed intent frees its key).
+      if (taskContext) {
+        const [taskRow] = await db
+          .select({ revision: aiOperatorTasks.revision })
+          .from(aiOperatorTasks)
+          .where(and(eq(aiOperatorTasks.id, taskContext.taskId), eq(aiOperatorTasks.orgId, orgId)))
+          .limit(1);
+        if (!taskRow) {
+          throw new ActionIntentError(
+            `AI Operator task ${taskContext.taskId} not found in org ${orgId}`,
+            'task_context_invalid',
+          );
+        }
+        await reserveOperation(db, {
+          orgId,
+          taskId: taskContext.taskId,
+          taskStepKey: taskContext.taskStepKey,
+          operationKey: taskContext.operationKey,
+          attemptOrdinal: taskContext.attemptOrdinal,
+          intentId: inserted.id,
+          originatingRunId: agentRun?.id ?? null,
+          argumentDigest,
+          planRevision: taskRow.revision,
+        });
+      }
+
       let approvalRequestIds: string[] = [];
       let requesterApprovalRequestId: string | null = null;
       let fanOutUserIds: string[] = [];
@@ -1643,6 +1859,12 @@ export async function createActionIntent(
     // DB/RLS fault in the insert, fan-out, or outbox) as fanout_failed so the
     // caller (chat SDK / MCP) sees a real failure, never a false success.
     if (err instanceof ActionIntentError) throw err;
+    // #5205 W04: the sequential-replay guard tripping is a DELIBERATE refusal,
+    // not a fault — surface it with its own code so the coordinator can tell
+    // "this operation already happened" from "the database broke".
+    if (err instanceof OperationReplayError) {
+      throw new ActionIntentError(err.message, 'operation_replay');
+    }
     console.error('[intentService] action intent creation transaction failed (rolled back):', err);
     throw new ActionIntentError(
       'Failed to create action intent (approval fan-out / outbox)',
@@ -1879,7 +2101,17 @@ export async function runDeferredHumanFanout(intentId: string): Promise<void> {
   // `deviceId` here is inert for targeting — AgentRunRef carries it, but the
   // fan-out reads only `agentRun.id` (and its truthiness). The TARGET device
   // was resolved above, through resolveIntentTargetDevice.
-  const agentRun: AgentRunRef = { id: run.id, agentId: run.agentId, orgId: run.orgId, deviceId: run.deviceId };
+  // #5205 W04: the deferred fan-out never re-derives task context (it acts on
+  // an already-created intent), so the linkage is carried as null here — the
+  // fan-out reads only `agentRun.id`.
+  const agentRun: AgentRunRef = {
+    id: run.id,
+    agentId: run.agentId,
+    orgId: run.orgId,
+    deviceId: run.deviceId,
+    taskId: null,
+    taskStepKey: null,
+  };
 
   const fanoutResult = await withSystemDbAccessContext(async (): Promise<HumanFanoutResult | null> => {
     // The CAS: only the caller that actually flips unattempted -> human_required
@@ -2000,10 +2232,29 @@ export async function getActionIntent(auth: AuthContext, intentId: string): Prom
 // cancelActionIntent
 // ---------------------------------------------------------------------------
 
+export interface CancelActionIntentResult {
+  /** True only when the intent itself moved to `cancelled`. */
+  ok: boolean;
+  status: ActionIntentStatus;
+  /**
+   * #5205 W04 (#5209), spec §7.3. True when the intent is a task-linked one
+   * that had already reached `executing`: the cancellation request was RECORDED
+   * on the operation row (`cancel_requested_at`) and the effect is still in
+   * flight. `ok` stays false because the intent did not move — every existing
+   * caller therefore keeps reading this as "not cancelled", which is the honest
+   * answer — but a task-aware caller can now say "in flight, will be
+   * reconciled" instead of the silent no-op this returned before. Cancellation
+   * is not rollback; an already-dispatched device command may still finish, and
+   * §7.3 forbids ever displaying "nothing happened" when a change may still
+   * land.
+   */
+  inFlight?: boolean;
+}
+
 export async function cancelActionIntent(
   auth: AuthContext,
   intentId: string,
-): Promise<{ ok: boolean; status: ActionIntentStatus }> {
+): Promise<CancelActionIntentResult> {
   const dbContext = dbAccessContextFromAuth(auth);
   const intent = await withDbAccessContext(dbContext, async () => {
     const [row] = await db.select().from(actionIntents).where(eq(actionIntents.id, intentId)).limit(1);
@@ -2038,7 +2289,9 @@ export async function cancelActionIntent(
   // requester already told "approved and is now running" was never told a
   // subsequent cancel happened, because intentReleaseWorker.ts's outbox
   // consumer never saw an event for it.
+  const taskLinked = isTaskLinkedIntent(intent);
   let ok: boolean;
+  let inFlight = false;
   try {
     ok = await withSystemDbAccessContext(async () => {
       const rows = await db
@@ -2046,7 +2299,34 @@ export async function cancelActionIntent(
         .set({ status: 'cancelled' })
         .where(and(eq(actionIntents.id, intentId), inArray(actionIntents.status, ['pending_approval', 'approved'])))
         .returning({ id: actionIntents.id });
-      if (rows.length === 0) return false;
+      if (rows.length === 0) {
+        // #5205 W04 (#5209): the CAS above covers `pending_approval` and
+        // `approved` only, and that stays true — an `executing` intent must NOT
+        // be flipped to `cancelled`, because the effect it dispatched may still
+        // land and §7.3 forbids claiming nothing happened. For a TASK-LINKED
+        // intent the request is instead recorded on the operation row, in this
+        // same transaction, so the coordinator can fence further admissions and
+        // reconcile the in-flight command. Re-read the status inside the
+        // transaction rather than trusting the pre-CAS snapshot: the intent may
+        // have moved from `approved` to `executing` between the two.
+        if (!taskLinked) return false;
+        const [live] = await db
+          .select({ status: actionIntents.status })
+          .from(actionIntents)
+          .where(eq(actionIntents.id, intentId))
+          .limit(1);
+        if (live?.status !== 'executing') return false;
+        await markOperationCancelRequested(db, intentId);
+        inFlight = true;
+        return false;
+      }
+      // Nothing was ever dispatched for a pending/approved intent, so its
+      // operation is terminally `cancelled` — distinct from `abandoned`, which
+      // is a leaked reservation. The reconciler's "terminal task with an
+      // unsettled operation" scan needs to tell the two apart.
+      if (taskLinked) {
+        await markOperationCancelled(db, intentId);
+      }
       await db.insert(intentOutbox).values({
         intentId,
         eventType: 'intent_cancelled',
@@ -2078,7 +2358,7 @@ export async function cancelActionIntent(
     const [row] = await db.select({ status: actionIntents.status }).from(actionIntents).where(eq(actionIntents.id, intentId)).limit(1);
     return row?.status ?? intent.status;
   });
-  return { ok: false, status: current };
+  return { ok: false, status: current, ...(inFlight ? { inFlight: true } : {}) };
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/api/src/services/actionIntents/intentService.ts
+++ b/apps/api/src/services/actionIntents/intentService.ts
@@ -47,7 +47,7 @@ import {
   IntentScopeArgumentMismatchError,
 } from './intentTargetScope';
 import { evaluateTicketAutonomy } from './ticketAutonomy';
-import { aiOperatorTasks } from '../../db/schema/aiOperatorTasks';
+import { aiOperatorOperations, aiOperatorTasks } from '../../db/schema/aiOperatorTasks';
 import {
   isTaskLinkedIntent,
   markOperationCancelled,
@@ -2294,6 +2294,22 @@ export async function cancelActionIntent(
   let inFlight = false;
   try {
     ok = await withSystemDbAccessContext(async () => {
+      // LOCK ORDER — operation BEFORE intent, matching
+      // `claimTaskLinkedIntentForDispatch` (services/aiOperator/dispatchClaim.ts,
+      // which takes task -> operation -> intent). Without this line the cancel
+      // path would take intent -> operation and the two would form an AB-BA
+      // cycle on {operation, intent}: a human cancelling while a release worker
+      // claims the same still-`approved` intent would deadlock, and Postgres
+      // would abort one side with 40P01. Read-only on its own; it exists purely
+      // to order the locks.
+      if (taskLinked) {
+        await db
+          .select({ id: aiOperatorOperations.id })
+          .from(aiOperatorOperations)
+          .where(eq(aiOperatorOperations.intentId, intentId))
+          .for('update')
+          .limit(1);
+      }
       const rows = await db
         .update(actionIntents)
         .set({ status: 'cancelled' })

--- a/apps/api/src/services/aiOperator/dispatchClaim.test.ts
+++ b/apps/api/src/services/aiOperator/dispatchClaim.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// The module under test only needs its PURE predicate here, but importing it
+// pulls in `../../db` (a real postgres pool at import time). Stub it: nothing
+// in these cases touches the database.
+vi.mock('../../db', () => ({
+  db: {},
+  withSystemDbAccessContext: (fn: () => unknown) => fn(),
+}));
+
+import { evaluateTaskClaimPredicate, type ClaimTaskSnapshot } from './dispatchClaim';
+
+const NOW = new Date('2026-10-14T12:00:00.000Z');
+const FUTURE = new Date('2026-10-14T13:00:00.000Z');
+const PAST = new Date('2026-10-14T11:00:00.000Z');
+
+function task(overrides: Partial<ClaimTaskSnapshot> = {}): ClaimTaskSnapshot {
+  return {
+    state: 'running',
+    revision: 3,
+    leaseEpoch: 7,
+    deadlineAt: FUTURE,
+    targetDetachedAt: null,
+    ...overrides,
+  };
+}
+
+describe('evaluateTaskClaimPredicate (spec §7.3 dispatch claim)', () => {
+  it('permits a claim on a live, in-revision, in-deadline, attached task', () => {
+    expect(evaluateTaskClaimPredicate(task(), 3, { now: NOW })).toBeNull();
+  });
+
+  it("permits a claim while the task is 'waiting' — the approval case the slice exists for", () => {
+    expect(evaluateTaskClaimPredicate(task({ state: 'waiting' }), 3, { now: NOW })).toBeNull();
+  });
+
+  // The refusal table. Each row names a state a task can be in that must NOT
+  // admit a new effect (spec §7.3: "No new effect may claim while paused,
+  // stopping, expired, handed_off, or otherwise terminal").
+  it.each([
+    ['paused', 'paused'],
+    ['stopping', 'stopping'],
+    ['queued', 'queued'],
+    ['completed', 'completed'],
+    ['cancelled', 'cancelled'],
+    ['failed', 'failed'],
+    ['expired', 'expired'],
+    ['handed_off', 'handed_off'],
+    ['partial', 'partial'],
+  ])('refuses a claim while the task is %s', (_label, state) => {
+    const refusal = evaluateTaskClaimPredicate(task({ state }), 3, { now: NOW });
+    expect(refusal).toContain('cannot admit a new effect');
+  });
+
+  it('refuses when the plan revision moved after approval (spec §7.1)', () => {
+    // The operation pinned revision 3 at reservation; the task is now on 4.
+    expect(evaluateTaskClaimPredicate(task({ revision: 4 }), 3, { now: NOW }))
+      .toContain('plan revision moved');
+  });
+
+  it('refuses when the operation never pinned a plan revision', () => {
+    expect(evaluateTaskClaimPredicate(task(), null, { now: NOW }))
+      .toContain('plan revision moved');
+  });
+
+  it('refuses when the task deadline has passed', () => {
+    expect(evaluateTaskClaimPredicate(task({ deadlineAt: PAST }), 3, { now: NOW }))
+      .toContain('deadline has passed');
+  });
+
+  it('refuses at exactly the deadline instant — the bound is exclusive', () => {
+    expect(evaluateTaskClaimPredicate(task({ deadlineAt: NOW }), 3, { now: NOW }))
+      .toContain('deadline has passed');
+  });
+
+  // FAIL CLOSED. A nullable column read into a WHERE clause silently refusing
+  // is not the same as a deliberate refusal, and this is the deliberate one:
+  // absence of a bound is not permission to act indefinitely.
+  it('refuses when the task has no deadline at all', () => {
+    expect(evaluateTaskClaimPredicate(task({ deadlineAt: null }), 3, { now: NOW }))
+      .toContain('no deadline_at');
+  });
+
+  it('refuses when the target has been detached (device moved or deleted)', () => {
+    expect(evaluateTaskClaimPredicate(task({ targetDetachedAt: PAST }), 3, { now: NOW }))
+      .toContain('target is detached');
+  });
+
+  describe('lease epoch', () => {
+    it('does not fence when the caller supplies no expectation (the intent-release path)', () => {
+      // Spec §6.3: a coordinator takeover while a human was deciding must not
+      // strand the approval. The release worker holds no lease, so it passes
+      // none, and the intent CAS is its fence.
+      expect(evaluateTaskClaimPredicate(task({ leaseEpoch: 99 }), 3, { now: NOW })).toBeNull();
+      expect(
+        evaluateTaskClaimPredicate(task({ leaseEpoch: 99 }), 3, { now: NOW, expectedLeaseEpoch: null }),
+      ).toBeNull();
+    });
+
+    it('fences a lease holder whose epoch was superseded', () => {
+      expect(
+        evaluateTaskClaimPredicate(task({ leaseEpoch: 8 }), 3, { now: NOW, expectedLeaseEpoch: 7 }),
+      ).toContain('lease epoch moved');
+    });
+
+    it('permits a lease holder whose epoch still matches', () => {
+      expect(
+        evaluateTaskClaimPredicate(task({ leaseEpoch: 7 }), 3, { now: NOW, expectedLeaseEpoch: 7 }),
+      ).toBeNull();
+    });
+
+    it('fences epoch 0 rather than treating it as "no expectation"', () => {
+      // `lease_epoch` defaults to 0, so a falsy-check here would silently
+      // disable fencing for every freshly-admitted task.
+      expect(
+        evaluateTaskClaimPredicate(task({ leaseEpoch: 1 }), 3, { now: NOW, expectedLeaseEpoch: 0 }),
+      ).toContain('lease epoch moved');
+    });
+  });
+});

--- a/apps/api/src/services/aiOperator/dispatchClaim.ts
+++ b/apps/api/src/services/aiOperator/dispatchClaim.ts
@@ -11,6 +11,14 @@
 // The task row is taken `FOR UPDATE` first, and the intent CAS then re-states
 // the whole task predicate as an `EXISTS` over that same locked row.
 //
+// EVERY path that touches both an operation and its intent must take them in
+// that relative order — operation before intent — or it forms an AB-BA cycle
+// with this claim and deadlocks (40P01) under ordinary concurrency. The two
+// other such paths are `revertTaskLinkedDispatchClaim` below and
+// `cancelActionIntent`'s task-linked branch in intentService.ts; both take an
+// explicit `FOR UPDATE` on the operation row before touching the intent for
+// exactly this reason. If you add a third, do the same.
+//
 // Why the lock and not just the join (the Codex quorum's one substantive
 // disagreement, adopted): under READ COMMITTED an `UPDATE action_intents ...
 // FROM ai_operator_tasks` re-reads and re-checks only the row it is UPDATING
@@ -42,8 +50,23 @@ import { markOperationDispatched, revertOperationToReserved } from './operationS
  * facing contract, not just log text.
  */
 export type DispatchClaimRefusal =
-  /** No `ai_operator_operations` row for this intent — reservation never committed. */
+  /**
+   * No `ai_operator_operations` row exists for this intent at all. A BROKEN
+   * INVARIANT, not a race: `reserveOperation` runs in the same transaction as
+   * the intent insert, so a task-linked intent without an operation row should
+   * be unreachable. Kept distinct from `operation_already_claimed` so the
+   * caller can raise it to Sentry instead of logging it like an ordinary lost
+   * race — otherwise an intent would sit `approved` until an unrelated deadline
+   * reaper noticed, up to 24 h later for an `mcp_api` source, with no error
+   * code naming what went wrong.
+   */
   | 'operation_missing'
+  /**
+   * The operation row exists but is no longer `reserved` — another claimant
+   * already owns it. An ordinary, healthy race. The caller must NOT overwrite
+   * the winner's bookkeeping, and must not page anyone.
+   */
+  | 'operation_already_claimed'
   /** The task is not in a state that may admit a new effect, or its plan moved on. */
   | 'task_not_claimable'
   /** The intent itself was not `approved`, or its release lease had passed. */
@@ -171,7 +194,7 @@ export async function claimTaskLinkedIntentForDispatch(
     }
     if (operation.dispatchState !== 'reserved') {
       return refuse(
-        'operation_missing',
+        'operation_already_claimed',
         `operation ${operation.id} is '${operation.dispatchState}', not 'reserved'`,
       );
     }
@@ -229,18 +252,34 @@ export async function claimTaskLinkedIntentForDispatch(
 }
 
 /**
- * The kill-switch reversal (`executing -> approved`,
- * intentReleaseWorker.ts:139) extended for a task-linked intent: the operation
+ * The kill-switch reversal (`executing -> approved`, `pauseIntentForKillSwitch`
+ * in intentReleaseWorker.ts) extended for a task-linked intent: the operation
  * goes back to `reserved` in the SAME transaction, so the row never claims a
  * dispatch that was undone. Returns whether the reversal CAS was won — a lost
  * CAS means something else (a reaper, a duplicate delivery) already moved the
  * row and there is nothing to revert.
+ *
+ * LOCK ORDER — operation BEFORE intent, matching the claim. This `FOR UPDATE`
+ * is not decorative. `claimTaskLinkedIntentForDispatch` takes
+ * task -> operation -> intent; without this line the reversal would take
+ * intent -> operation, and the two paths would form an AB-BA cycle on
+ * {operation, intent}. That is reachable in ordinary operation: a kill switch
+ * engaging mid-release while a redelivered `intent_approved` job claims the
+ * same intent (a redelivery this worker is explicitly designed to tolerate)
+ * would deadlock, and Postgres would abort one side with 40P01. Take the
+ * operation lock first and the cycle cannot form.
  */
 export async function revertTaskLinkedDispatchClaim(
   intentId: string,
   detail: string,
 ): Promise<boolean> {
   return withSystemDbAccessContext(async () => {
+    await db
+      .select({ id: aiOperatorOperations.id })
+      .from(aiOperatorOperations)
+      .where(eq(aiOperatorOperations.intentId, intentId))
+      .for('update')
+      .limit(1);
     const rows = await db
       .update(actionIntents)
       .set({ status: 'approved' })

--- a/apps/api/src/services/aiOperator/dispatchClaim.ts
+++ b/apps/api/src/services/aiOperator/dispatchClaim.ts
@@ -1,0 +1,257 @@
+// The ONE durable dispatch claim for a task-linked action intent
+// (#5205 W04, sub-issue #5209; spec §7.3, baseline C8/H3).
+//
+// Spec §7.3 is explicit that for intents this claim **is** the existing
+// `approved -> executing` CAS with the task checks folded in — not a second
+// claim taken afterwards. That is what this module implements, and it lives
+// here rather than inline in `intentReleaseWorker.ts` so W06 can reuse the same
+// linearization point for direct act.
+//
+// ONE TRANSACTION, THREE ROWS, ONE LOCK ORDER: task -> operation -> intent.
+// The task row is taken `FOR UPDATE` first, and the intent CAS then re-states
+// the whole task predicate as an `EXISTS` over that same locked row.
+//
+// Why the lock and not just the join (the Codex quorum's one substantive
+// disagreement, adopted): under READ COMMITTED an `UPDATE action_intents ...
+// FROM ai_operator_tasks` re-reads and re-checks only the row it is UPDATING
+// when a concurrent writer touches it. The JOINED task row is read from the
+// statement's snapshot and is never locked, so a concurrent `stopping` /
+// revision bump / detach committing between snapshot and update is invisible
+// and the claim wins anyway. Locking the task first makes the predicate
+// evaluate against the committed-latest task and holds it that way until the
+// claim commits. The predicate is ALSO kept in the UPDATE's own WHERE so the
+// SQL states the invariant rather than relying on a lock the next reader has to
+// know about.
+//
+// Fail-closed on a NULL deadline (also adopted from the quorum). `deadline_at`
+// is nullable in the W03 schema, but spec §7.3 gives every task a bounded
+// deadline and "expiry stops new effects like cancellation". A runnable task
+// with no deadline is an admission bug, and an authority predicate must refuse
+// on missing authority rather than treat absence as permission. Task admission
+// (W06) MUST populate `deadline_at`.
+
+import { and, eq, sql } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../../db';
+import { actionIntents } from '../../db/schema/actionIntents';
+import { aiOperatorOperations, aiOperatorTasks } from '../../db/schema/aiOperatorTasks';
+import { markOperationDispatched, revertOperationToReserved } from './operationService';
+
+/**
+ * Why a claim was refused. These land verbatim in
+ * `ai_operator_operations.dispatch_detail`, so they are part of the operator-
+ * facing contract, not just log text.
+ */
+export type DispatchClaimRefusal =
+  /** No `ai_operator_operations` row for this intent — reservation never committed. */
+  | 'operation_missing'
+  /** The task is not in a state that may admit a new effect, or its plan moved on. */
+  | 'task_not_claimable'
+  /** The intent itself was not `approved`, or its release lease had passed. */
+  | 'intent_not_claimable';
+
+export type DispatchClaimResult =
+  | { won: true; leaseEpoch: number }
+  | { won: false; refusal: DispatchClaimRefusal; detail: string };
+
+export interface TaskLinkedIntentRef {
+  id: string;
+  orgId: string;
+  taskId: string;
+}
+
+export interface DispatchClaimOptions {
+  /**
+   * Fence the claim on the caller's own scheduler lease epoch. Supplied by a
+   * LEASE HOLDER (W06's direct-act path). Omitted on the intent-release path,
+   * which holds no lease: its fencing is the intent's own single-use
+   * `approved -> executing` CAS, and spec §6.3 requires a result from an
+   * operation a superseded epoch dispatched to be accepted under its ORIGINAL
+   * identity — so refusing an approval merely because the coordinator was
+   * reclaimed while a human was deciding would strand the task, not protect it.
+   * The observed epoch is recorded on the operation either way.
+   */
+  expectedLeaseEpoch?: number | null;
+}
+
+/** Task states that may still admit a NEW effect. */
+export const CLAIMABLE_TASK_STATES = ['running', 'waiting'] as const;
+
+export interface ClaimTaskSnapshot {
+  state: string | null;
+  revision: number;
+  leaseEpoch: number;
+  deadlineAt: Date | null;
+  targetDetachedAt: Date | null;
+}
+
+/**
+ * The claim's task-side predicate as a PURE function, so every refusal branch
+ * is unit-testable without a database. `claimTaskLinkedIntentForDispatch`
+ * evaluates this against the row it holds `FOR UPDATE`, and the intent CAS then
+ * re-states the same predicate in SQL.
+ *
+ * Returns null when the claim may proceed, or the refusal detail when it may
+ * not. Order matters only for which reason a reader sees first.
+ */
+export function evaluateTaskClaimPredicate(
+  task: ClaimTaskSnapshot,
+  planRevision: number | null,
+  opts: { now: Date; expectedLeaseEpoch?: number | null },
+): string | null {
+  if (!(CLAIMABLE_TASK_STATES as readonly string[]).includes(task.state ?? '')) {
+    return `task state '${task.state}' cannot admit a new effect`;
+  }
+  if (planRevision === null || planRevision !== task.revision) {
+    return `plan revision moved: approved ${planRevision}, task now ${task.revision}`;
+  }
+  // Fail closed on a missing deadline: absence of a bound is not permission.
+  if (task.deadlineAt === null) {
+    return 'task has no deadline_at — admission did not bound it';
+  }
+  if (task.deadlineAt.getTime() <= opts.now.getTime()) {
+    return 'task deadline has passed';
+  }
+  if (task.targetDetachedAt !== null) {
+    return 'task target is detached';
+  }
+  const expectedEpoch = opts.expectedLeaseEpoch ?? null;
+  if (expectedEpoch !== null && task.leaseEpoch !== expectedEpoch) {
+    return `lease epoch moved: claimant ${expectedEpoch}, task now ${task.leaseEpoch}`;
+  }
+  return null;
+}
+
+/**
+ * Wins (or refuses) the single dispatch claim for a task-linked intent.
+ *
+ * On a win the intent is `executing` and the operation is `dispatched` with
+ * `dispatched_at` and the observed `claimed_lease_epoch` — atomically. A lost
+ * claim writes nothing at all and dispatches nothing.
+ */
+export async function claimTaskLinkedIntentForDispatch(
+  intent: TaskLinkedIntentRef,
+  options: DispatchClaimOptions = {},
+): Promise<DispatchClaimResult> {
+  return withSystemDbAccessContext(async () => {
+    // Lock order 1/3 — the task. FOR UPDATE, so every predicate below reads the
+    // committed-latest row and holds it until this transaction commits.
+    const [task] = await db
+      .select({
+        id: aiOperatorTasks.id,
+        state: aiOperatorTasks.state,
+        revision: aiOperatorTasks.revision,
+        leaseEpoch: aiOperatorTasks.leaseEpoch,
+        deadlineAt: aiOperatorTasks.deadlineAt,
+        targetDetachedAt: aiOperatorTasks.targetDetachedAt,
+      })
+      .from(aiOperatorTasks)
+      .where(and(eq(aiOperatorTasks.id, intent.taskId), eq(aiOperatorTasks.orgId, intent.orgId)))
+      .for('update')
+      .limit(1);
+
+    if (!task) {
+      return refuse('task_not_claimable', `task ${intent.taskId} not found in org ${intent.orgId}`);
+    }
+
+    // Lock order 2/3 — the operation. Locked before the intent so the reversal,
+    // cancel and stop paths can take the same order and never deadlock.
+    const [operation] = await db
+      .select({
+        id: aiOperatorOperations.id,
+        planRevision: aiOperatorOperations.planRevision,
+        dispatchState: aiOperatorOperations.dispatchState,
+      })
+      .from(aiOperatorOperations)
+      .where(eq(aiOperatorOperations.intentId, intent.id))
+      .for('update')
+      .limit(1);
+
+    if (!operation) {
+      return refuse('operation_missing', `no operation row reserved for intent ${intent.id}`);
+    }
+    if (operation.dispatchState !== 'reserved') {
+      return refuse(
+        'operation_missing',
+        `operation ${operation.id} is '${operation.dispatchState}', not 'reserved'`,
+      );
+    }
+
+    // `plan_revision` was pinned when the operation was reserved, i.e. by the
+    // admission that the approval covers. A revised plan means a new operation
+    // and a new approval (spec §7.1), so a stale one must not dispatch.
+    const refusalDetail = evaluateTaskClaimPredicate(task, operation.planRevision, {
+      now: new Date(),
+      expectedLeaseEpoch: options.expectedLeaseEpoch,
+    });
+    if (refusalDetail) {
+      return refuse('task_not_claimable', refusalDetail);
+    }
+
+    // Lock order 3/3 — the intent CAS. Deliberately re-states the whole task
+    // predicate as an EXISTS over the row already locked above: the checks
+    // belong in the claim's own SQL (spec §7.3), and this is also what makes
+    // the claim correct for a reader who arrives without taking the lock.
+    const claimed = await db
+      .update(actionIntents)
+      .set({ status: 'executing', executedAt: null, executionStartedAt: new Date() })
+      .where(
+        and(
+          eq(actionIntents.id, intent.id),
+          eq(actionIntents.status, 'approved'),
+          sql`COALESCE(${actionIntents.releaseBy}, ${actionIntents.expiresAt}) > now()`,
+          sql`EXISTS (
+                SELECT 1 FROM ai_operator_tasks t
+                 WHERE t.id = ${actionIntents.taskId}
+                   AND t.org_id = ${actionIntents.orgId}
+                   AND t.state IN ('running', 'waiting')
+                   AND t.revision = ${operation.planRevision}
+                   AND t.deadline_at IS NOT NULL
+                   AND t.deadline_at > now()
+                   AND t.target_detached_at IS NULL
+              )`,
+        ),
+      )
+      .returning({ id: actionIntents.id });
+
+    if (claimed.length === 0) {
+      return refuse(
+        'intent_not_claimable',
+        `intent ${intent.id} was not 'approved' within its release lease`,
+      );
+    }
+
+    // Same transaction as the claim — a won claim and an in-flight operation
+    // commit together or not at all. `markOperationDispatched` writes through
+    // the ambient `db`, which IS this transaction.
+    await markOperationDispatched(db, intent.id, task.leaseEpoch);
+    return { won: true, leaseEpoch: task.leaseEpoch };
+  });
+}
+
+/**
+ * The kill-switch reversal (`executing -> approved`,
+ * intentReleaseWorker.ts:139) extended for a task-linked intent: the operation
+ * goes back to `reserved` in the SAME transaction, so the row never claims a
+ * dispatch that was undone. Returns whether the reversal CAS was won — a lost
+ * CAS means something else (a reaper, a duplicate delivery) already moved the
+ * row and there is nothing to revert.
+ */
+export async function revertTaskLinkedDispatchClaim(
+  intentId: string,
+  detail: string,
+): Promise<boolean> {
+  return withSystemDbAccessContext(async () => {
+    const rows = await db
+      .update(actionIntents)
+      .set({ status: 'approved' })
+      .where(and(eq(actionIntents.id, intentId), eq(actionIntents.status, 'executing')))
+      .returning({ id: actionIntents.id });
+    if (rows.length === 0) return false;
+    await revertOperationToReserved(db, intentId, detail);
+    return true;
+  });
+}
+
+function refuse(refusal: DispatchClaimRefusal, detail: string): DispatchClaimResult {
+  return { won: false, refusal, detail };
+}

--- a/apps/api/src/services/aiOperator/operationService.test.ts
+++ b/apps/api/src/services/aiOperator/operationService.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// #5205 W04 (#5209), baseline §4: `recordOperationResult` / `recordOperationExecutionRef` /
+// `markOperationDispatchFailed` run AFTER a real-world side effect has
+// already happened (a device command dispatched, a result arrived, a claim
+// was lost). Throwing out of one of them would fail an action that already
+// succeeded, so `runOperationWrite` (operationService.ts) swallows the
+// underlying write's rejection, logs it, and reports it to Sentry instead.
+// This file is the one place that proves the SWALLOW itself — every other
+// operationService test exercises these functions through the release
+// worker, where a rejection would otherwise be invisible (the worker never
+// awaits-and-catches these calls; it relies on them never throwing).
+//
+// `../../db` is stubbed rather than imported for real: these functions issue
+// exactly one `db.update(...).set(...).where(...)` statement each, and what
+// this file needs to control is whether THAT final promise resolves or
+// rejects — not drizzle-orm's query-builder behavior, which the real
+// dialect/integration suites already cover.
+const { updateWhereMock, sentryMock } = vi.hoisted(() => ({
+  /** The mocked terminal `.where(...)` call every writer here ends on. Each
+   *  test sets its own resolution via `mockResolvedValueOnce`/
+   *  `mockRejectedValueOnce` — no shared default, so a forgotten prime fails
+   *  loud (unhandled mock call) rather than silently passing either way. */
+  updateWhereMock: vi.fn(),
+  sentryMock: { captureException: vi.fn() },
+}));
+
+vi.mock('../../db', () => ({
+  db: {
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: updateWhereMock,
+      })),
+    })),
+  },
+  // Real callers wrap every write in its own system-scoped context
+  // (runOperationWrite); the mock just runs the callback inline, which is
+  // enough to prove the try/catch around it, not the context boundary
+  // itself (that belongs to db/index.ts's own tests).
+  withSystemDbAccessContext: vi.fn((fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock('../sentry', () => ({
+  captureException: sentryMock.captureException,
+}));
+
+import {
+  recordOperationResult,
+  recordOperationExecutionRef,
+  markOperationDispatchFailed,
+} from './operationService';
+
+const INTENT_ID = 'intent-1';
+
+describe('operationService: runOperationWrite swallow contract (#5205 W04, baseline §4)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('recordOperationResult', () => {
+    it('resolves rather than throws when the underlying update REJECTS, and reports it to Sentry', async () => {
+      updateWhereMock.mockRejectedValueOnce(new Error('connection reset'));
+
+      await expect(
+        recordOperationResult({ intentId: INTENT_ID, resultState: 'succeeded', result: { ok: true } }),
+      ).resolves.toBeUndefined();
+
+      expect(sentryMock.captureException).toHaveBeenCalledTimes(1);
+    });
+
+    it('positive control: a successful write resolves and does NOT call captureException', async () => {
+      // Without this control, the rejection case above could pass on a
+      // stubbed no-op writer that never really calls captureException on
+      // ANY input — this proves the mock (and the real function) actually
+      // discriminates between the two outcomes.
+      updateWhereMock.mockResolvedValueOnce(undefined);
+
+      await expect(
+        recordOperationResult({ intentId: INTENT_ID, resultState: 'succeeded', result: { ok: true } }),
+      ).resolves.toBeUndefined();
+
+      expect(sentryMock.captureException).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('recordOperationExecutionRef', () => {
+    it('resolves rather than throws when the underlying update REJECTS, and reports it to Sentry', async () => {
+      updateWhereMock.mockRejectedValueOnce(new Error('connection reset'));
+
+      await expect(
+        recordOperationExecutionRef(INTENT_ID, { kind: 'device_command', id: 'cmd-1' }),
+      ).resolves.toBeUndefined();
+
+      expect(sentryMock.captureException).toHaveBeenCalledTimes(1);
+    });
+
+    it('positive control: a successful write resolves and does NOT call captureException', async () => {
+      updateWhereMock.mockResolvedValueOnce(undefined);
+
+      await expect(
+        recordOperationExecutionRef(INTENT_ID, { kind: 'device_command', id: 'cmd-1' }),
+      ).resolves.toBeUndefined();
+
+      expect(sentryMock.captureException).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('markOperationDispatchFailed', () => {
+    it('resolves rather than throws when the underlying update REJECTS, and reports it to Sentry', async () => {
+      updateWhereMock.mockRejectedValueOnce(new Error('connection reset'));
+
+      await expect(markOperationDispatchFailed(INTENT_ID, 'claim_refused')).resolves.toBeUndefined();
+
+      expect(sentryMock.captureException).toHaveBeenCalledTimes(1);
+    });
+
+    it('positive control: a successful write resolves and does NOT call captureException', async () => {
+      updateWhereMock.mockResolvedValueOnce(undefined);
+
+      await expect(markOperationDispatchFailed(INTENT_ID, 'claim_refused')).resolves.toBeUndefined();
+
+      expect(sentryMock.captureException).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/services/aiOperator/operationService.ts
+++ b/apps/api/src/services/aiOperator/operationService.ts
@@ -1,0 +1,410 @@
+// AI Operator operation rows (#5205 W04, sub-issue #5209).
+//
+// WHY THIS FILE EXISTS, in one sentence: the truth about an effect survives at
+// the execution reference and is destroyed at the intent, so the operation row
+// must be written from the reference on its own schedule and must never be
+// gated on winning the intent's status CAS (baseline §4, spec §6.3).
+//
+// Two guards, deliberately different shapes (baseline C7/H2):
+//   - `action_intents_org_idem_uniq` is PARTIAL over live statuses and guards
+//     CONCURRENT duplication. A `completed` intent leaves that set and frees
+//     its key while the device command may still be running.
+//   - `ai_operator_operations_org_task_op_uq` is PERMANENT with no status
+//     predicate and guards SEQUENTIAL replay. `reserveOperation` below is the
+//     only writer that can trip it, and it turns the 23505 into a typed
+//     refusal rather than letting a second intent be minted for an operation
+//     whose effect may already have landed.
+//
+// Every function here runs under system scope. The rows are Shape-1 org-scoped
+// with forced RLS, and the callers (the release worker, the expiry reaper, the
+// creation transaction) hold either no ambient context or a system one.
+
+import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../../db';
+import {
+  aiOperatorOperations,
+  type AiOperatorExecutionRefKind,
+} from '../../db/schema/aiOperatorTasks';
+import { captureException } from '../sentry';
+
+/** Mirrors `ai_operator_operations_result_size_chk` (pg_column_size <= 64 KiB). */
+const MAX_OPERATION_RESULT_BYTES = 48 * 1024;
+
+export type OperationResultState = 'pending' | 'succeeded' | 'failed' | 'unknown' | 'superseded';
+
+/**
+ * Definite outcomes outrank `unknown`, which outranks `pending`. This is what
+ * makes the writers order-independent, which they have to be: the stale-
+ * executing reaper (20 min) and a late device-command result race each other by
+ * construction (baseline §2.6, the three clocks). A real outcome may therefore
+ * arrive AFTER the reaper wrote `unknown` and must still land; `unknown` must
+ * never overwrite a recorded outcome.
+ */
+const RESULT_STATE_RANK: Record<OperationResultState, number> = {
+  pending: 0,
+  unknown: 1,
+  superseded: 1,
+  succeeded: 2,
+  failed: 2,
+};
+
+/** The subset of drizzle's `db` these helpers need — lets them join a caller's transaction. */
+type DbHandle = Pick<typeof db, 'insert' | 'update' | 'select'>;
+
+export class OperationReplayError extends Error {
+  readonly code = 'operation_replay';
+  constructor(message: string) {
+    super(message);
+    this.name = 'OperationReplayError';
+  }
+}
+
+export interface ReserveOperationInput {
+  orgId: string;
+  taskId: string;
+  taskStepKey: string;
+  operationKey: string;
+  attemptOrdinal: number;
+  intentId: string;
+  originatingRunId: string | null;
+  argumentDigest: string;
+  /** `ai_operator_tasks.revision` read in the same transaction. */
+  planRevision: number;
+}
+
+/**
+ * Reserves the operation row in the SAME transaction as the intent insert
+ * (spec §6.5: "bind an intent atomically during intent creation"; attaching
+ * after the intent commits is explicitly insufficient).
+ *
+ * Pass the caller's transaction handle as `dbh` — this function opens no
+ * context of its own precisely so a throw rolls the intent back with it.
+ *
+ * A conflict on `(org_id, task_id, operation_key)` means an operation with this
+ * identity has ALREADY been reserved. Two cases:
+ *   - it points at this same intent: a redelivery of the creation call, no-op.
+ *   - it points at a different intent (the sequential-replay case: the first
+ *     intent terminalized, freeing the live idempotency key, and a continuation
+ *     run re-proposed the same operation): refuse. The first effect may still
+ *     be in flight and confirmed effects are never blindly replayed (spec §6.5).
+ */
+export async function reserveOperation(
+  dbh: DbHandle,
+  input: ReserveOperationInput,
+): Promise<void> {
+  const [inserted] = await dbh
+    .insert(aiOperatorOperations)
+    .values({
+      orgId: input.orgId,
+      taskId: input.taskId,
+      taskStepKey: input.taskStepKey,
+      operationKey: input.operationKey,
+      attemptOrdinal: input.attemptOrdinal,
+      intentId: input.intentId,
+      originatingRunId: input.originatingRunId,
+      argumentDigest: input.argumentDigest,
+      planRevision: input.planRevision,
+      dispatchState: 'reserved',
+      resultState: 'pending',
+    })
+    .onConflictDoNothing({
+      target: [
+        aiOperatorOperations.orgId,
+        aiOperatorOperations.taskId,
+        aiOperatorOperations.operationKey,
+      ],
+    })
+    .returning({ id: aiOperatorOperations.id });
+
+  if (inserted) return;
+
+  const [existing] = await dbh
+    .select({ id: aiOperatorOperations.id, intentId: aiOperatorOperations.intentId })
+    .from(aiOperatorOperations)
+    .where(
+      and(
+        eq(aiOperatorOperations.orgId, input.orgId),
+        eq(aiOperatorOperations.taskId, input.taskId),
+        eq(aiOperatorOperations.operationKey, input.operationKey),
+      ),
+    )
+    .limit(1);
+
+  if (existing && existing.intentId === input.intentId) return;
+
+  throw new OperationReplayError(
+    `Operation ${input.operationKey} on task ${input.taskId} is already reserved`
+      + `${existing?.intentId ? ` by intent ${existing.intentId}` : ''}`
+      + ' — a confirmed effect is never replayed (spec §6.5)',
+  );
+}
+
+/**
+ * Marks the operation dispatched. Called from INSIDE the dispatch-claim
+ * transaction, so it shares the claim's atomicity: a won claim and an
+ * `in flight` operation commit together or not at all. `claimedLeaseEpoch` is
+ * the epoch OBSERVED at claim time, recorded so W06 can recognise a result
+ * produced by a superseded epoch's operation and accept it under its original
+ * identity (spec §6.3).
+ */
+export async function markOperationDispatched(
+  dbh: DbHandle,
+  intentId: string,
+  claimedLeaseEpoch: number | null,
+): Promise<void> {
+  const rows = await dbh
+    .update(aiOperatorOperations)
+    .set({
+      dispatchState: 'dispatched',
+      dispatchedAt: new Date(),
+      claimedLeaseEpoch,
+      dispatchDetail: null,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(aiOperatorOperations.intentId, intentId),
+        eq(aiOperatorOperations.dispatchState, 'reserved'),
+      ),
+    )
+    .returning({ id: aiOperatorOperations.id });
+
+  // Exactly one, or the claim it belongs to must not commit. The caller took
+  // the operation row FOR UPDATE and checked `reserved` first, so zero rows
+  // here means a genuinely broken invariant (a missing row, a concurrent writer
+  // that bypassed the lock order), never an ordinary race. Throwing rolls the
+  // intent claim back with it rather than leaving an `executing` intent whose
+  // operation still reads `reserved`.
+  if (rows.length !== 1) {
+    throw new Error(
+      `[aiOperator] dispatch claim for intent ${intentId} matched ${rows.length} reserved operations, expected 1`,
+    );
+  }
+}
+
+/**
+ * A claim that was never won, or a revalidation stop that refused to dispatch.
+ * Terminal for the operation: nothing was sent, so there is no effect to
+ * reconcile. `detail` is the reason a reader needs — a revalidation error code,
+ * `claim_refused`, `policy_denied`.
+ */
+export async function markOperationDispatchFailed(
+  intentId: string,
+  detail: string,
+): Promise<void> {
+  await runOperationWrite('markOperationDispatchFailed', intentId, async () => {
+    await db
+      .update(aiOperatorOperations)
+      .set({
+        dispatchState: 'dispatch_failed',
+        dispatchDetail: boundedDetail(detail),
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(aiOperatorOperations.intentId, intentId),
+          inArray(aiOperatorOperations.dispatchState, ['reserved', 'dispatched']),
+          // `dispatched` is allowed here for one narrow, real case: the claim is
+          // won BEFORE revalidation runs (that ordering is what makes the claim
+          // the single-use fence), so a revalidation stop terminalizes an intent
+          // whose operation already reads `dispatched` even though nothing was
+          // ever sent. `execution_ref_id IS NULL` is the proof that nothing was:
+          // the reference is written the moment dispatch returns one. Once a
+          // reference exists the effect is real and only a RESULT may settle the
+          // operation — never a dispatch failure.
+          isNull(aiOperatorOperations.executionRefId),
+        ),
+      );
+  });
+}
+
+/**
+ * The kill-switch reversal (`executing -> approved`). The operation goes back to
+ * `reserved` because the intent is claimable again by the next delivery — it is
+ * NOT a dispatch failure, and calling it one would make the reconciler treat a
+ * pausable, still-live operation as settled.
+ *
+ * Shares the reversal's transaction handle for the same reason
+ * `markOperationDispatched` shares the claim's.
+ */
+export async function revertOperationToReserved(
+  dbh: DbHandle,
+  intentId: string,
+  detail: string,
+): Promise<void> {
+  await dbh
+    .update(aiOperatorOperations)
+    .set({
+      dispatchState: 'reserved',
+      dispatchedAt: null,
+      dispatchDetail: boundedDetail(detail),
+      updatedAt: new Date(),
+    })
+    .where(eq(aiOperatorOperations.intentId, intentId));
+}
+
+/**
+ * A task-linked intent cancelled from `pending_approval` / `approved`: nothing
+ * was ever dispatched, so the operation is terminally `cancelled` (distinct
+ * from `abandoned`, which is a leaked reservation — the reconciler's
+ * "terminal task with an unsettled operation" scan needs to tell them apart).
+ * Shares the cancel CAS's transaction.
+ */
+export async function markOperationCancelled(dbh: DbHandle, intentId: string): Promise<void> {
+  await dbh
+    .update(aiOperatorOperations)
+    .set({
+      dispatchState: 'cancelled',
+      cancelRequestedAt: new Date(),
+      updatedAt: new Date(),
+    })
+    .where(eq(aiOperatorOperations.intentId, intentId));
+}
+
+/**
+ * A task-linked intent cancelled while already `executing`. The intent stays
+ * `executing` and `dispatch_state` stays `dispatched`: the effect is in flight
+ * and cancellation is not rollback (spec §7.3). This records that a human asked
+ * for it to stop so the caller can honestly answer "in flight, will be
+ * reconciled" instead of the silent no-op the pre-W04 code returned.
+ */
+export async function markOperationCancelRequested(
+  dbh: DbHandle,
+  intentId: string,
+): Promise<boolean> {
+  const rows = await dbh
+    .update(aiOperatorOperations)
+    .set({ cancelRequestedAt: new Date(), updatedAt: new Date() })
+    .where(and(eq(aiOperatorOperations.intentId, intentId), isNull(aiOperatorOperations.cancelRequestedAt)))
+    .returning({ id: aiOperatorOperations.id });
+  return rows.length > 0;
+}
+
+export interface RecordOperationResultInput {
+  intentId: string;
+  resultState: Exclude<OperationResultState, 'pending'>;
+  result: Record<string, unknown>;
+  executionRef?: { kind: AiOperatorExecutionRefKind; id: string } | null;
+}
+
+/**
+ * Persists the execution reference and the bounded result on the operation row
+ * in ITS OWN statement, independent of the intent's status CAS — the whole
+ * point of the row (baseline §4). Callers invoke it BEFORE attempting the
+ * intent CAS and again on the losing-CAS path, so a lost race no longer
+ * discards the result.
+ *
+ * Monotonic in `RESULT_STATE_RANK`: a definite outcome overwrites `unknown`,
+ * `unknown` overwrites only `pending`, and nothing overwrites a definite
+ * outcome. Without this the 20-minute reaper's `unknown` and a late device
+ * result would clobber each other depending on arrival order.
+ *
+ * Never throws: this runs after a real-world side effect has already happened,
+ * and failing the caller at that point would be strictly worse than a logged,
+ * captured write failure that the reconciler picks up from the source rows.
+ */
+export async function recordOperationResult(input: RecordOperationResultInput): Promise<void> {
+  await runOperationWrite('recordOperationResult', input.intentId, async () => {
+    const incomingRank = RESULT_STATE_RANK[input.resultState];
+    await db
+      .update(aiOperatorOperations)
+      .set({
+        resultState: input.resultState,
+        result: boundedResult(input.result),
+        resultAt: new Date(),
+        ...(input.executionRef
+          ? { executionRefKind: input.executionRef.kind, executionRefId: input.executionRef.id }
+          : {}),
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(aiOperatorOperations.intentId, input.intentId),
+          // Rank comparison in SQL, not in JS: two writers race here by
+          // construction and a read-then-write would lose one of them.
+          sql`CASE ${aiOperatorOperations.resultState}
+                WHEN 'pending' THEN 0
+                WHEN 'unknown' THEN 1
+                WHEN 'superseded' THEN 1
+                ELSE 2
+              END < ${incomingRank}`,
+        ),
+      );
+  });
+}
+
+/**
+ * Attaches the execution reference alone, the moment dispatch returns it and
+ * before any result exists. Separate from `recordOperationResult` because the
+ * reference is what makes an UNKNOWN effect reconcilable at all: if the process
+ * dies between dispatch and result, the reference is the only thing that can
+ * find the device command again.
+ */
+export async function recordOperationExecutionRef(
+  intentId: string,
+  ref: { kind: AiOperatorExecutionRefKind; id: string },
+): Promise<void> {
+  await runOperationWrite('recordOperationExecutionRef', intentId, async () => {
+    await db
+      .update(aiOperatorOperations)
+      .set({ executionRefKind: ref.kind, executionRefId: ref.id, updatedAt: new Date() })
+      .where(
+        and(
+          eq(aiOperatorOperations.intentId, intentId),
+          isNull(aiOperatorOperations.executionRefId),
+        ),
+      );
+  });
+}
+
+/** True when the intent carries a full task linkage. */
+export function isTaskLinkedIntent(intent: {
+  taskId?: string | null;
+  taskStepKey?: string | null;
+  operationKey?: string | null;
+}): boolean {
+  // `!= null` on purpose, not `!== null`: callers hand this partially-projected
+  // rows and test doubles where an absent column is `undefined`, and
+  // `undefined !== null` is TRUE — which would classify every legacy intent as
+  // task-linked and send it down the operation-write path. Treat absent and
+  // null identically.
+  return intent.taskId != null && intent.taskStepKey != null && intent.operationKey != null;
+}
+
+// ---------------------------------------------------------------------------
+
+function boundedDetail(detail: string): string {
+  return detail.length > 500 ? `${detail.slice(0, 497)}...` : detail;
+}
+
+function boundedResult(result: Record<string, unknown>): Record<string, unknown> {
+  try {
+    if (Buffer.byteLength(JSON.stringify(result), 'utf8') <= MAX_OPERATION_RESULT_BYTES) {
+      return result;
+    }
+  } catch {
+    return { truncated: true, reason: 'unserializable' };
+  }
+  return { truncated: true };
+}
+
+/**
+ * Standalone operation writes run in their own system-scoped context and
+ * swallow failures. Every caller is post-effect (a result arrived, a claim was
+ * lost, the reaper gave up); throwing would convert a bookkeeping failure into
+ * a failed action that already happened. The failure is logged and captured so
+ * it is visible, and the reconciler re-derives the same fact from the
+ * authoritative source row.
+ */
+async function runOperationWrite(
+  label: string,
+  intentId: string,
+  fn: () => Promise<void>,
+): Promise<void> {
+  try {
+    await withSystemDbAccessContext(fn);
+  } catch (err) {
+    console.error(`[aiOperator] ${label} failed for intent ${intentId}:`, err);
+    captureException(err instanceof Error ? err : new Error(String(err)));
+  }
+}

--- a/apps/api/src/services/tenantExportPolicyRegistry.ts
+++ b/apps/api/src/services/tenantExportPolicyRegistry.ts
@@ -85,7 +85,7 @@ export const CORE_TENANT_EXPORT_POLICY: TenantExportPolicyRegistry = {
   // embed credentials or capabilities. Everything a customer must be able to
   // export therefore lives in a bounded text column here (objective,
   // outcome_detail, handoff_summary, target_label) and is `included`.
-  "ai_operator_operations": tablePolicy("org_id", {"included":["id","org_id","task_id","task_step_key","operation_key","attempt_ordinal","intent_id","originating_run_id","argument_digest","execution_ref_kind","execution_ref_id","dispatch_state","result_state","dispatched_at","result_at","created_at","updated_at"],"reviewedIncluded":[],"excludedSensitive":[],"excludedOpen":["result"]}),
+  "ai_operator_operations": tablePolicy("org_id", {"included":["id","org_id","task_id","task_step_key","operation_key","attempt_ordinal","intent_id","originating_run_id","argument_digest","execution_ref_kind","execution_ref_id","plan_revision","claimed_lease_epoch","dispatch_state","dispatch_detail","result_state","dispatched_at","cancel_requested_at","result_at","created_at","updated_at"],"reviewedIncluded":[],"excludedSensitive":[],"excludedOpen":["result"]}),
   "ai_operator_task_outbox": tablePolicy("org_id", {"included":["id","org_id","task_id","source_kind","source_id","transition_seq","due_at","published_at","attempts","created_at"],"reviewedIncluded":[],"excludedSensitive":[],"excludedOpen":[]}),
   // lease_owner is a coordinator instance label, not credential material, but
   // it does not trip SUSPICIOUS_NAME_PARTS either — plain `included`.

--- a/packages/shared/src/validators/aiOperator.ts
+++ b/packages/shared/src/validators/aiOperator.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+
+/**
+ * AI Operator task context carried into `createActionIntent` (#5205 W04,
+ * sub-issue #5209).
+ *
+ * INTERNAL ONLY — this is TRUSTED input. It is the identity under which an
+ * operation reserves its `ai_operator_operations` row and from which the
+ * intent's `idempotency_key` is derived, so accepting it from an HTTP body
+ * would let a caller (a) mint an intent that a task it does not own is then
+ * obliged to reconcile, and (b) choose the single ON CONFLICT arbiter's key
+ * material directly. Every HTTP intent surface must therefore build its
+ * `CreateActionIntentInput` WITHOUT this field; the coordinator (W06) is the
+ * only producer.
+ *
+ * The schema exists so that the one internal seam that does construct it
+ * validates shape and bounds at the boundary rather than trusting a
+ * hand-built object literal. The `max()` bounds mirror the CHECK constraints
+ * on `ai_operator_operations.task_step_key` (128) and `.operation_key` (200)
+ * declared in 2026-10-14-100000-ai-operator-thin-slice.sql, so an over-long
+ * key is a typed rejection at the seam instead of a 23514 mid-transaction.
+ */
+export const actionIntentTaskContextSchema = z.object({
+  taskId: z.string().uuid(),
+  taskStepKey: z.string().min(1).max(128),
+  operationKey: z.string().min(1).max(200),
+  /**
+   * The reasoning attempt this proposal came from. Recorded on the operation
+   * row for lineage; it is deliberately NOT part of the operation identity —
+   * a continuation run re-proposing the SAME operation must converge on the
+   * existing row, which is precisely what makes attempt 2 attach instead of
+   * duplicating (spec §6.5).
+   */
+  attemptOrdinal: z.number().int().min(0),
+}).strict();
+
+export type ActionIntentTaskContext = z.infer<typeof actionIntentTaskContextSchema>;

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -1150,6 +1150,7 @@ export * from './ai';
 export * from './aiAgents';
 export * from './aiAgentGraduation';
 export * from './aiAgentSchedules';
+export * from './aiOperator';
 export * from './orgNarrative';
 export * from './ticketTriage';
 export * from './aiAgentImpact';


### PR DESCRIPTION
Closes #5209

W04 of the AI Operator thin slice (#5205). W03 (#5244) shipped the tables and the three nullable `action_intents` task columns; this wave makes them mean something: task-scoped intent identity, the dispatch claim, cancel/kill-switch extension, and operation result persistence.

## What changed

**1. Task-scoped intent creation, one arbiter (spec §6.5, baseline C6/H1/H4).**
`CreateActionIntentInput` gains an optional, TRUSTED `task: { taskId, taskStepKey, operationKey, attemptOrdinal }` (`packages/shared/src/validators/aiOperator.ts`, internal only). When present the intent's `idempotency_key` is derived from `task:<taskId>` + tool + argument digest + `operationKey`, so the existing partial unique `action_intents_org_idem_uniq` stays the **single** `ON CONFLICT` arbiter — no second arbiter index is added. The three task columns are written on the insert, and the matching `ai_operator_operations` row is reserved in the **same transaction** (`reserveOperation`), pinning `plan_revision` from the task's revision. The same-task relaxation of the "key reused by another run" rejection matches baseline §5.2 exactly: run identity is relaxed only when `task_id` **and** `operation_key` both match; action, source and argument digest must still all match.

Legacy (non-task) creation is byte-for-byte unchanged — `deriveIntentIdempotencyKey`'s legacy branch is the original expression, and every existing intent suite is green.

**2. Immutability deny-list.** `task_id`, `task_step_key`, `operation_key` added to `action_intents_block_content_update()`, **unconditionally** (no null-transition carve-out): `action_intents_task_org_fk` is `ON DELETE RESTRICT` precisely because `SET NULL` would strand the two text columns and violate `action_intents_task_link_chk`, so there is no tombstone direction to permit.

**3. Dispatch claim (spec §7.3, baseline C8/H3).** `services/aiOperator/dispatchClaim.ts` — one transaction, one lock order (task → operation → intent). The task row is taken `FOR UPDATE`, the predicate (state ∈ {running, waiting}, `revision = plan_revision`, deadline in the future, target attached, optional lease-epoch fence) is evaluated against it, and the intent CAS re-states the whole predicate as an `EXISTS` in its own `WHERE`. On a won claim the operation flips to `dispatched` with `dispatched_at` and the observed `claimed_lease_epoch` in the same transaction. A lost claim never dispatches and never writes a result.

The kill-switch reversal (`executing → approved`) reverts the operation to `reserved` in the same transaction.

**4. Cancellation covers `executing`.** `cancelActionIntent`'s CAS still covers `pending_approval`/`approved` only — an `executing` intent must not be flipped to `cancelled`, because the effect may still land. For a task-linked `executing` intent it now records `cancel_requested_at` on the operation and returns `{ ok: false, status: 'executing', inFlight: true }`, so the caller can say "in flight, will be reconciled" instead of the silent no-op it returned before. A cancelled pending/approved task-linked intent sets the operation `dispatch_state = 'cancelled'`.

**5. Result persistence independent of the intent CAS (spec §6.3, baseline §4).** The execution reference and the bounded result are written onto the operation row in their own statements, before the intent's terminal CAS is attempted **and again on the losing-CAS path** (`intentReleaseWorker.ts` ~:1054), which previously discarded the result to a Sentry event. `manage_services` already returns `CommandResult.commandId` verbatim, so nothing had to be threaded through `executeCommand`. Writes are rank-ordered (`succeeded`/`failed` > `unknown` > `pending`), so the 20-minute reaper and a late device result are order-independent. The reaper's `failed:execution_lost` path sets the operation `result_state = 'unknown'`, never `failed`.

## Migration

`apps/api/migrations/2026-10-14-100200-ai-operator-intent-identity.sql` — DDL only (no `breeze.scope` election needed), idempotent. Adds `plan_revision`, `claimed_lease_epoch`, `cancel_requested_at`, `dispatch_detail` to `ai_operator_operations`; widens `dispatch_state` with `'cancelled'`; `CREATE OR REPLACE`s the immutability trigger function. The four new columns are classified `included` in `CORE_TENANT_EXPORT_POLICY` in this PR.

## Codex quorum (read-only, `medium`, on the claim UPDATE and the key derivation)

| Question | Verdict | Action |
|---|---|---|
| D1a — task-key collision safety | AGREE (legacy actor ids are UUIDs; a UUID cannot carry `task:`) | kept |
| D1b — caller-asserted task id is insufficient evidence | **DISAGREE with the proposal** | **adopted**: the calling run's own `ai_agent_runs.task_id` / `task_step_key` must match, or `task_context_invalid` |
| D1c — reject explicit key + task | AGREE | kept |
| D2a — unlocked `UPDATE … FROM` | **DISAGREE** — the joined task row is read from the statement snapshot and never locked, so a concurrent `stopping`/revision bump/detach is invisible | **adopted**: task row `FOR UPDATE` first, predicate also restated in the CAS's own `WHERE` |
| D2b — NULL `deadline_at` | **DISAGREE** — absence of a bound is not permission | **adopted**: fail closed; task admission (W06) must populate `deadline_at` |
| D2c — operation flip in the claim transaction | AGREE, and require exactly one `reserved → dispatched` row or roll the claim back | adopted |
| D2d — is `checkAgentReleaseAuthority` enough for "tightened policy refuses"? | AGREE it already evaluates snapshot **and** current effective policy; DISAGREE that it is claim-time | see deviation 3 below |
| D2e — pin revision/epoch to admission evidence, not today's values | AGREE | `plan_revision` is pinned at reservation |

## Deviations from the brief, with reasons

1. **`dispatch_state = 'in_flight'` → `'dispatched'`.** W03 already ships `'dispatched'` with exactly that meaning. Adding `in_flight` would be a synonym, and two names for one state is how a vocabulary rots. `'cancelled'` genuinely did not exist and was added.
2. **`result_state = 'timeout'` → `'unknown'`.** W03's CHECK has no `timeout`, and its own column comment says `unknown` exists precisely for the 30 s-tool-wait / 5 min-command-reap window. Mapping `CommandResult.status === 'timeout'` to `unknown` is the contract, not a compromise.
3. **The live-authority recheck stays after the claim, not inside it.** `revalidateApprovedIntentForRelease` → `checkAgentReleaseAuthority` already evaluates the run's frozen `policySnapshot` **and** the current effective policy and denies if either denies, which is exactly what H3 asks for. Moving it in front of the claim would remove the single-use fence that stops two workers both revalidating and both dispatching. A refusal now records itself on the operation (`dispatch_state = 'dispatch_failed'` + `dispatch_detail`, or `reserved` again for the pausable kill-switch code), so the coordinator sees a reason rather than a stall.
4. **Lease epoch is recorded, not fenced, on the intent-release path.** The release worker holds no lease, and spec §6.3 requires a result from an operation a superseded epoch dispatched to be accepted under its original identity — refusing an approval because the coordinator was reclaimed while a human was deciding would strand the task. `dispatchClaim` accepts an `expectedLeaseEpoch` for a real lease holder (W06's direct-act path) and fences on it there.
5. **The intent load moved ahead of the claim in `releaseApprovedIntent`.** The claim has to branch on `task_id`, and the row's content columns are DB-immutable, so loading first costs no extra query on the won path (it removes one) and short-circuits a deleted intent before anything is claimed. Nothing downstream reads the local row's `status`.

## One contract the brief asked for that does not exist as written

"The same operation key with different arguments raises `idempotency_conflict`" is unreachable for a task-linked intent, and that is correct rather than a gap. `argumentDigest` is hashed **into** the task-derived key material, so a different digest yields a different `idempotency_key` and can never collide with the first proposal's live row on `(org_id, idempotency_key)`. The `idempotency_conflict` branch exists for the legacy explicit-key MCP path, where two unrelated tool calls can share a caller-chosen key.

The real refusal is `operation_replay`, raised by `reserveOperation` against the operation row's **permanent** `(org_id, task_id, operation_key)` unique — and it is a strictly stronger guarantee: it refuses a mismatched re-proposal even while the first operation is still `reserved`, not only after the first intent terminalizes. The integration test asserts that, with the reasoning inline.

## Verification

Run from `apps/api`, node 22.20.0. Unit: `npx vitest run <path>`; integration: `npx vitest run --config vitest.integration.config.ts <path>`.

| Command | Result |
|---|---|
| `vitest run src/services/actionIntents src/services/aiOperator src/jobs/intentReleaseWorker src/jobs/intentExpiryReaper src/db/migration-action-intents.test.ts src/db/autoMigrate.test.ts src/db/migrationRlsScope.test.ts` | **34 files, 884 passed** |
| `--config vitest.integration.config.ts src/__tests__/integration/aiOperatorIntentIdentity...` + `aiOperatorDispatchClaim...` + `actionIntentsImmutabilityTrigger...` | **3 files, 67 passed** (13 + 18 new, immutability 33 → 36) |
| `--config vitest.integration.config.ts tenant-export-policy` + `tenantExportErasureRoundtrip` + `tenantCascade` + `intentExpiryReaper.integration` + `createIntentAtomicity.integration` | **5 files, 29 passed** |
| `--config vitest.config.rls-coverage.ts` | **102 passed** |
| `--config vitest.config.integration-suite-coverage.ts` | **5 passed** |
| `--config vitest.config.rls.ts` | 26 passed, 5 skipped |
| `packages/shared`: `vitest run src/validators` | 282 passed |
| `npx tsc --noEmit` (apps/api) | clean |
| `pnpm lint` on every touched path | clean |
| `pnpm db:check-drift` | clean — 704 migrations match the ledger |
| `scripts/check-migration-naming.sh --against-ref origin/main` | OK |

Red-first evidence, not just green-at-the-end:

- `src/db/migration-action-intents.test.ts` went RED on its own (the deny-list is discovered from the migrations and asserted against a hand-written list) the moment the trigger gained three columns — `expected [29] to deeply equal [26]` — and the integration suite's "one behavioral case per deny-listed column" gate went red with it. Both are green only after the cases were added.
- The two new unit suites were mutation-checked: making `evaluateTaskClaimPredicate` fail OPEN on a null deadline, and dropping the `task:` prefix from the key material, each turned the relevant cases red.
- The two new integration suites were mutation-checked against six separate implementation mutations (relaxation predicate stubbed to `false`; `OperationReplayError` swallowed; `inFlight` dropped; null-deadline fail-open; the result rank predicate replaced with `true`; the reaper writing `failed` instead of `unknown`) — every one was caught.

### One existing assertion changed, deliberately

`intentReleaseWorker.test.ts`'s lost-claim branch asserted `db.select` was never called, on the grounds that the intent load ran only after a won claim. Deviation 5 makes that untrue of correct code. Its stated purpose — "this case must not be satisfied by any flow that exits after one transition for some other reason" — is now asserted more directly and more strictly: no tool execution, no terminal transaction, no evidence row. A read is not an effect; those three are. No other assertion in that file was changed, and the remaining edits are priming rows so the pre-claim load succeeds.

## Not in this PR

Outbox event vocabulary and terminal publication (W05), the coordinator and run admission (W06), routes and web (W07). No `intent_completed` / `intent_failed` events; `routes/approvals.ts` untouched.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PMBC9WeLY3YDJHLHEneuZ
