### PR TITLE
feat(ai-operator): intent terminal outbox events, task outbox writes on every writer, outbox publisher (W05 of #5205)

### DIFF
--- a/apps/api/migrations/2026-10-14-100300-ai-operator-intent-terminal-events.sql
+++ b/apps/api/migrations/2026-10-14-100300-ai-operator-intent-terminal-events.sql
@@ -1,0 +1,21 @@
+-- #5205 W05 (#5210), spec §6.3, baseline §3.3: there was no `intent_outbox`
+-- event for "this intent's execution finished" — the release worker's
+-- terminalizeIntent (completed/failed) and the stale-executing reaper
+-- (failed:execution_lost) both published nothing at all. A task-linked
+-- intent's completion or failure is the durable "the effect finished" signal
+-- the AI Operator task coordinator (W06) wakes on; without it a task stays
+-- stranded in `waiting` until its deadline.
+--
+-- Fifth widening of intent_outbox_event_type_check (see
+-- 2026-09-04-ai-agent-notifications.sql, 2026-09-16-pam-actuation-lifecycle.sql,
+-- 2026-09-19-ai-agents-ticket-shadow.sql, 2026-10-08-100300-intent-cancelled-outbox-event.sql).
+-- Adds ONLY 'intent_completed'/'intent_failed' — no existing value removed or
+-- renamed. Idempotent: DROP IF EXISTS + re-ADD is safe to replay.
+
+ALTER TABLE intent_outbox DROP CONSTRAINT IF EXISTS intent_outbox_event_type_check;
+ALTER TABLE intent_outbox ADD CONSTRAINT intent_outbox_event_type_check CHECK (
+  event_type IN (
+    'intent_created', 'intent_approved', 'intent_rejected', 'intent_expired',
+    'intent_cancelled', 'intent_completed', 'intent_failed', 'pam.desired_state_changed'
+  )
+);

--- a/apps/api/src/__tests__/integration/aiOperatorTerminalWriters.integration.test.ts
+++ b/apps/api/src/__tests__/integration/aiOperatorTerminalWriters.integration.test.ts
@@ -1,0 +1,586 @@
+/**
+ * The AI Operator terminal-writer contract — real Postgres (#5205 W05,
+ * sub-issue #5210, spec §6.3, baseline §3.2).
+ *
+ * "Every intent terminal writer publishes" only holds if the set of writers
+ * is enumerated and pinned somewhere a new one can't silently join without
+ * coverage — that is what `TASK_LINKED_TERMINAL_WRITERS` below is. Each entry
+ * drives the REAL writer function (never a re-implementation) against a
+ * task-linked intent seeded through the real `createActionIntent` admission
+ * path, and asserts:
+ *   1. the intent reaches the expected terminal `action_intents.status`;
+ *   2. exactly one `intent_outbox` row exists with the matching event;
+ *   3. exactly one `ai_operator_task_outbox` row exists
+ *      (source_kind='intent', source_id=intentId, the event's transitionSeq
+ *      ordinal);
+ *   4. redelivering the SAME terminalization does not create a second
+ *      `ai_operator_task_outbox` row (the identity unique's ON CONFLICT DO
+ *      NOTHING — spec §6.3's dedupe contract).
+ *
+ * `aiAgentSdk.ts`'s five inline terminal call sites are NOT in this list.
+ * They are structurally unreachable by a task-linked intent: every intent
+ * that file transitions was created by ITS OWN `createActionIntent(session.auth,
+ * {...})` call (services/aiAgentSdk.ts, tier-3 durable-intent branch), which
+ * never threads a `task` context through — task-linked admission is a
+ * durable-worker-only path in the thin slice (spec P3-1: "supervised mode
+ * only... no direct act"). Their `intent_outbox`-only publication is pinned
+ * by aiAgentSdk.test.ts (the `transitionIntentAndPublish` wiring) and
+ * taskOutbox.test.ts (the underlying helper's contract) instead.
+ */
+import './setup';
+
+import { randomUUID } from 'node:crypto';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { and, desc, eq } from 'drizzle-orm';
+import { Hono } from 'hono';
+import { db, withSystemDbAccessContext } from '../../db';
+import {
+  actionIntents,
+  aiAgentRuns,
+  aiAgents,
+  aiOperatorTaskOutbox,
+  aiOperatorTasks,
+  devices,
+  intentOutbox,
+  type IntentOutboxRow,
+} from '../../db/schema';
+import { buildAgentAuthContext } from '../../services/aiAgents/agentAuthContext';
+import {
+  createActionIntent,
+  transitionIntent,
+  cancelActionIntent,
+} from '../../services/actionIntents/intentService';
+import { terminalizeIntent } from '../../jobs/intentReleaseWorker';
+import { reapExpiredIntents, reapStaleExecutingIntents } from '../../jobs/intentExpiryReaper';
+import { INTENT_TERMINAL_OUTBOX_TRANSITION_SEQ } from '../../services/aiOperator/taskOutbox';
+import { buildOrgAccessClosures, type AuthContext } from '../../middleware/auth';
+import { createAccessToken, type TokenPayload } from '../../services/jwt';
+import { approvalRoutes } from '../../routes/approvals';
+import {
+  assignUserToOrganization,
+  createOrganization,
+  createPartner,
+  createRole,
+  createSite,
+  createUser,
+  grantRolePermissions,
+} from './db-utils';
+import { PERMISSIONS } from '../../services/permissions';
+
+// Same fixture tool as aiOperatorDispatchClaim.integration.test.ts — a
+// genuinely Tier-3 `supervised` action whose one required permission
+// (`devices:execute`) is easy to grant/withhold to control eligibility.
+const TOOL_NAME = 'manage_services';
+const TASK_STEP_KEY = 'restart-spooler';
+
+interface Tenant {
+  partnerId: string;
+  orgId: string;
+  siteId: string;
+  agentId: string;
+  deviceId: string;
+  eligibleUserId: string;
+  eligibleEmail: string;
+  eligibleRoleId: string;
+}
+
+/**
+ * One org with an agent, a device, and — unless `withEligibleApprover` is
+ * false — one human holding BOTH `devices:execute` (so they are a
+ * target-eligible approver for `manage_services`) and `approvals:decide` (so
+ * the same fixture user can also drive `cancelActionIntent`'s non-requester
+ * approver path).
+ */
+async function seedTenant(withEligibleApprover = true): Promise<Tenant> {
+  const partner = await createPartner();
+  const org = await createOrganization({ partnerId: partner.id });
+  const site = await createSite({ orgId: org.id });
+
+  const role = await createRole({ scope: 'organization', orgId: org.id });
+  if (withEligibleApprover) {
+    await grantRolePermissions(role.id, [PERMISSIONS.DEVICES_EXECUTE, PERMISSIONS.APPROVALS_DECIDE]);
+  }
+  const eligible = await createUser({
+    partnerId: partner.id,
+    orgId: org.id,
+    email: `writer-${randomUUID()}@opwriters.test`,
+  });
+  if (withEligibleApprover) {
+    await assignUserToOrganization(eligible.id, org.id, role.id);
+  }
+
+  const [agent] = await withSystemDbAccessContext(() =>
+    db
+      .insert(aiAgents)
+      .values({ orgId: org.id, partnerId: null, kind: 'triage', name: 'Operator', createdBy: eligible.id })
+      .returning(),
+  );
+
+  const unique = randomUUID().slice(0, 8);
+  const [device] = await withSystemDbAccessContext(() =>
+    db
+      .insert(devices)
+      .values({
+        orgId: org.id,
+        siteId: site.id,
+        agentId: `opwriters-agent-${unique}`,
+        hostname: `opwriters-host-${unique}`,
+        osType: 'linux',
+        osVersion: '22.04',
+        architecture: 'x86_64',
+        agentVersion: '0.0.0-test',
+        status: 'online',
+      })
+      .returning(),
+  );
+
+  return {
+    partnerId: partner.id,
+    orgId: org.id,
+    siteId: site.id,
+    agentId: agent!.id,
+    deviceId: (device as { id: string }).id,
+    eligibleUserId: eligible.id,
+    eligibleEmail: eligible.email,
+    eligibleRoleId: role.id,
+  };
+}
+
+async function createTask(
+  t: Tenant,
+  overrides: Partial<typeof aiOperatorTasks.$inferInsert> = {},
+): Promise<{ taskId: string; revision: number }> {
+  const revision = (overrides.revision as number | undefined) ?? 1;
+  const [row] = await withSystemDbAccessContext(() =>
+    db
+      .insert(aiOperatorTasks)
+      .values({
+        orgId: t.orgId,
+        agentId: t.agentId,
+        agentKind: 'triage',
+        agentName: 'Operator',
+        workflowKey: 'service_recovery',
+        workflowVersion: 1,
+        originKind: 'manual' as const,
+        objective: 'Restart the print spooler on PRINTSRV01',
+        deviceId: t.deviceId,
+        state: 'running',
+        revision,
+        leaseEpoch: 0,
+        deadlineAt: new Date(Date.now() + 3_600_000),
+        ...overrides,
+      })
+      .returning({ id: aiOperatorTasks.id }),
+  );
+  return { taskId: row!.id, revision };
+}
+
+function agentPolicySnapshot() {
+  return {
+    schemaVersion: 1,
+    effective: {
+      enabled: true,
+      mode: 'shadow' as const,
+      model: null,
+      toolAllowlist: [TOOL_NAME],
+      protectedResources: { services: [], paths: [], registryKeys: [], deviceTags: [] },
+      limits: {},
+      triggers: {},
+      recipients: { userIds: [], roleIds: [] },
+      instructions: null,
+      cooldownSeconds: 900,
+    },
+    resolvedAt: new Date().toISOString(),
+  };
+}
+
+async function createRun(
+  t: Tenant,
+  task: { taskId: string; taskStepKey: string; attemptOrdinal: number },
+): Promise<string> {
+  const [row] = await withSystemDbAccessContext(() =>
+    db
+      .insert(aiAgentRuns)
+      .values({
+        agentId: t.agentId,
+        orgId: t.orgId,
+        deviceId: t.deviceId,
+        triggerKind: 'alert' as const,
+        dedupeKey: `opwriters-${randomUUID()}`,
+        modeAtStart: 'shadow' as const,
+        policySnapshot: agentPolicySnapshot() as never,
+        taskId: task.taskId,
+        taskStepKey: task.taskStepKey,
+        taskAttemptOrdinal: task.attemptOrdinal,
+      })
+      .returning({ id: aiAgentRuns.id }),
+  );
+  return row!.id;
+}
+
+function serviceInput(t: Tenant): Record<string, unknown> {
+  return { deviceId: t.deviceId, action: 'restart', serviceName: 'spooler' };
+}
+
+interface ProposedIntent {
+  intentId: string;
+  taskId: string;
+  runId: string;
+  /** The eligible decider's fanned-out approval row (agent intents have no requester row). */
+  approvalRowId: string;
+}
+
+/** Proposes a task-linked, agent-originated (spec P3-1: supervised-only) intent. */
+async function proposeTaskIntent(
+  t: Tenant,
+  opts: { taskOverrides?: Partial<typeof aiOperatorTasks.$inferInsert>; operationKey?: string } = {},
+): Promise<ProposedIntent> {
+  const task = await createTask(t, opts.taskOverrides);
+  const runId = await createRun(t, { taskId: task.taskId, taskStepKey: TASK_STEP_KEY, attemptOrdinal: 0 });
+  const auth = buildAgentAuthContext(
+    { id: t.agentId, orgId: t.orgId, partnerId: null, name: 'Operator', kind: 'triage' },
+    { id: runId, orgId: t.orgId, deviceId: t.deviceId, deviceSiteId: t.siteId },
+    { id: t.orgId, partnerId: t.partnerId },
+  );
+  const snapshot = await createActionIntent(auth, {
+    toolName: TOOL_NAME,
+    input: serviceInput(t),
+    source: 'ai_agent',
+    task: {
+      taskId: task.taskId,
+      taskStepKey: TASK_STEP_KEY,
+      operationKey: opts.operationKey ?? `restart:spooler:${randomUUID().slice(0, 8)}`,
+      attemptOrdinal: 0,
+    },
+  });
+  expect(snapshot.status).toBe('pending_approval');
+  expect(snapshot.approvalRequestIds).toHaveLength(1);
+  return { intentId: snapshot.id, taskId: task.taskId, runId, approvalRowId: snapshot.approvalRequestIds[0]! };
+}
+
+/**
+ * Same admission as `proposeTaskIntent`, but for a tenant with NO eligible
+ * approver — `runHumanFanout`'s fail-closed branch cancels the intent
+ * SYNCHRONOUSLY inside `createActionIntent`, so it never reaches
+ * `pending_approval` and has no approval row at all.
+ */
+async function proposeTaskIntentExpectingNoApprovers(
+  t: Tenant,
+): Promise<{ intentId: string; taskId: string }> {
+  const task = await createTask(t);
+  const runId = await createRun(t, { taskId: task.taskId, taskStepKey: TASK_STEP_KEY, attemptOrdinal: 0 });
+  const auth = buildAgentAuthContext(
+    { id: t.agentId, orgId: t.orgId, partnerId: null, name: 'Operator', kind: 'triage' },
+    { id: runId, orgId: t.orgId, deviceId: t.deviceId, deviceSiteId: t.siteId },
+    { id: t.orgId, partnerId: t.partnerId },
+  );
+  const snapshot = await createActionIntent(auth, {
+    toolName: TOOL_NAME,
+    input: serviceInput(t),
+    source: 'ai_agent',
+    task: {
+      taskId: task.taskId,
+      taskStepKey: TASK_STEP_KEY,
+      operationKey: `restart:spooler:${randomUUID().slice(0, 8)}`,
+      attemptOrdinal: 0,
+    },
+  });
+  return { intentId: snapshot.id, taskId: task.taskId };
+}
+
+function deciderAuthContext(t: Tenant): AuthContext {
+  const { orgCondition, canAccessOrg } = buildOrgAccessClosures([t.orgId]);
+  return {
+    principal: { kind: 'user_session' },
+    user: { id: t.eligibleUserId, email: t.eligibleEmail, name: 'Eligible Decider', isPlatformAdmin: false },
+    token: {
+      sub: t.eligibleUserId,
+      email: t.eligibleEmail,
+      roleId: t.eligibleRoleId,
+      orgId: t.orgId,
+      partnerId: t.partnerId,
+      scope: 'organization',
+      type: 'access',
+      mfa: true,
+    },
+    partnerId: t.partnerId,
+    orgId: t.orgId,
+    scope: 'organization',
+    accessibleOrgIds: [t.orgId],
+    orgCondition,
+    canAccessOrg,
+  };
+}
+
+async function deciderAccessToken(t: Tenant): Promise<string> {
+  const payload: Omit<TokenPayload, 'type'> = {
+    sub: t.eligibleUserId,
+    email: t.eligibleEmail,
+    roleId: t.eligibleRoleId,
+    orgId: t.orgId,
+    partnerId: t.partnerId,
+    scope: 'organization',
+    mfa: true,
+    aep: 1,
+    mep: 1,
+    sid: randomUUID(),
+  };
+  return createAccessToken(payload);
+}
+
+async function readIntent(id: string) {
+  return withSystemDbAccessContext(async () => {
+    const [row] = await db.select().from(actionIntents).where(eq(actionIntents.id, id)).limit(1);
+    return row ?? null;
+  });
+}
+
+async function readIntentOutboxRows(intentId: string): Promise<IntentOutboxRow[]> {
+  return withSystemDbAccessContext(() =>
+    db.select().from(intentOutbox).where(eq(intentOutbox.intentId, intentId)).orderBy(desc(intentOutbox.id)),
+  );
+}
+
+async function readTaskOutboxRows(taskId: string, intentId: string) {
+  return withSystemDbAccessContext(() =>
+    db
+      .select()
+      .from(aiOperatorTaskOutbox)
+      .where(
+        and(
+          eq(aiOperatorTaskOutbox.taskId, taskId),
+          eq(aiOperatorTaskOutbox.sourceKind, 'intent'),
+          eq(aiOperatorTaskOutbox.sourceId, intentId),
+        ),
+      ),
+  );
+}
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+beforeEach(() => {
+  vi.stubEnv('BREEZE_AI_AGENTS_ENABLED', 'true');
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+/**
+ * One entry per baseline §3.2 terminal writer reachable by a task-linked
+ * intent. `drive` returns the intent id and the expected outbox event; the
+ * shared assertion block below checks the rest. This array is what a new,
+ * uncovered writer would need to be added to — the point of the whole file.
+ */
+interface WriterCase {
+  name: string;
+  /** Owns its own tenant/fixture creation — each writer needs a different
+   *  eligibility shape, so a shared outer `t` would either be wrong for some
+   *  cases or force fragile name-based branching in the runner. */
+  drive: () => Promise<{ intentId: string; taskId: string; event: keyof typeof INTENT_TERMINAL_OUTBOX_TRANSITION_SEQ }>;
+  /** Re-run the SAME writer against the now-terminal intent, to prove dedupe. */
+  redeliver: (intentId: string, taskId: string) => Promise<void>;
+}
+
+const WRITER_CASES: WriterCase[] = [
+  {
+    name: 'intentReleaseWorker.terminalizeIntent -> completed',
+    async drive() {
+      const t = await seedTenant();
+      const { intentId, taskId } = await proposeTaskIntent(t);
+      const won1 = await transitionIntent(intentId, 'pending_approval', 'approved', { decidedAt: new Date() });
+      expect(won1).toBe(true);
+      const won2 = await transitionIntent(intentId, 'approved', 'executing', { executionStartedAt: new Date() });
+      expect(won2).toBe(true);
+      const intent = await readIntent(intentId);
+      const terminalized = await terminalizeIntent(intent!, 'completed', { executedAt: new Date(), result: { ok: true } });
+      expect(terminalized).toBe(true);
+      return { intentId, taskId, event: 'intent_completed' };
+    },
+    async redeliver(intentId) {
+      const intent = await readIntent(intentId);
+      // Already terminal — the CAS (from: 'executing') cannot win again, so
+      // no second outbox row is even attempted. Calling it anyway proves the
+      // writer itself is a no-op on a non-live source status, not just that
+      // the outbox insert would have deduped.
+      const won = await terminalizeIntent(intent!, 'completed', { executedAt: new Date(), result: { ok: true } });
+      expect(won).toBe(false);
+    },
+  },
+  {
+    name: 'intentReleaseWorker.terminalizeIntent -> failed',
+    async drive() {
+      const t = await seedTenant();
+      const { intentId, taskId } = await proposeTaskIntent(t);
+      await transitionIntent(intentId, 'pending_approval', 'approved', { decidedAt: new Date() });
+      await transitionIntent(intentId, 'approved', 'executing', { executionStartedAt: new Date() });
+      const intent = await readIntent(intentId);
+      const terminalized = await terminalizeIntent(intent!, 'failed', { errorCode: 'execution_error' });
+      expect(terminalized).toBe(true);
+      return { intentId, taskId, event: 'intent_failed' };
+    },
+    async redeliver(intentId) {
+      const intent = await readIntent(intentId);
+      const won = await terminalizeIntent(intent!, 'failed', { errorCode: 'execution_error' });
+      expect(won).toBe(false);
+    },
+  },
+  {
+    name: 'intentExpiryReaper.reapExpiredIntents',
+    async drive() {
+      const t = await seedTenant();
+      const { intentId, taskId } = await proposeTaskIntent(t);
+      await withSystemDbAccessContext(() =>
+        db
+          .update(actionIntents)
+          .set({ approvalExpiresAt: new Date(Date.now() - 60_000) })
+          .where(eq(actionIntents.id, intentId)),
+      );
+      const count = await withSystemDbAccessContext(() => reapExpiredIntents());
+      expect(count).toBeGreaterThanOrEqual(1);
+      return { intentId, taskId, event: 'intent_expired' };
+    },
+    async redeliver() {
+      // The intent is no longer pending_approval/approved, so a second pass
+      // over the whole table simply will not select it again.
+      await withSystemDbAccessContext(() => reapExpiredIntents());
+    },
+  },
+  {
+    name: 'intentExpiryReaper.reapStaleExecutingIntents',
+    async drive() {
+      const t = await seedTenant();
+      const { intentId, taskId } = await proposeTaskIntent(t);
+      await transitionIntent(intentId, 'pending_approval', 'approved', { decidedAt: new Date() });
+      await transitionIntent(intentId, 'approved', 'executing', {
+        executionStartedAt: new Date(Date.now() - 30 * 60_000),
+      });
+      const count = await withSystemDbAccessContext(() => reapStaleExecutingIntents());
+      expect(count).toBeGreaterThanOrEqual(1);
+      return { intentId, taskId, event: 'intent_failed' };
+    },
+    async redeliver() {
+      await withSystemDbAccessContext(() => reapStaleExecutingIntents());
+    },
+  },
+  {
+    // Driven through the real HTTP route (not `decideApprovalRequest`
+    // directly): the function's very first read runs under whatever ambient
+    // DB context its CALLER already opened — normally authMiddleware's
+    // per-request context — so exercising it standalone would need to
+    // replicate that middleware stack by hand.
+    name: 'decideApprovalRequest human denial (POST /approvals/:id/deny)',
+    async drive() {
+      const t = await seedTenant();
+      const { intentId, taskId, approvalRowId } = await proposeTaskIntent(t);
+      const token = await deciderAccessToken(t);
+      const app = new Hono();
+      app.route('/approvals', approvalRoutes);
+      const res = await app.request(`/approvals/${approvalRowId}/deny`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      expect(res.status).toBe(200);
+      return { intentId, taskId, event: 'intent_rejected' };
+    },
+    async redeliver(intentId, _taskId) {
+      // Same approval row is now decided — the pre-fetch's `status='pending'`
+      // predicate excludes it, so a redelivery 409s without reaching the CAS.
+      const row = await withSystemDbAccessContext(async () => {
+        const [r] = await db.select().from(actionIntents).where(eq(actionIntents.id, intentId)).limit(1);
+        return r;
+      });
+      expect(row?.status).toBe('rejected');
+    },
+  },
+  {
+    name: 'routes/approvals.ts report-suspicious',
+    async drive() {
+      const t = await seedTenant();
+      const { intentId, taskId, approvalRowId } = await proposeTaskIntent(t);
+      const token = await deciderAccessToken(t);
+      const app = new Hono();
+      app.route('/approvals', approvalRoutes);
+      const res = await app.request(`/approvals/${approvalRowId}/report-suspicious`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      expect(res.status).toBe(204);
+      return { intentId, taskId, event: 'intent_rejected' };
+    },
+    async redeliver(intentId) {
+      const row = await withSystemDbAccessContext(async () => {
+        const [r] = await db.select().from(actionIntents).where(eq(actionIntents.id, intentId)).limit(1);
+        return r;
+      });
+      expect(row?.status).toBe('rejected');
+    },
+  },
+  {
+    name: 'intentService.cancelActionIntent',
+    async drive() {
+      const t = await seedTenant();
+      const { intentId, taskId } = await proposeTaskIntent(t);
+      const result = await cancelActionIntent(deciderAuthContext(t), intentId);
+      expect(result).toMatchObject({ ok: true, status: 'cancelled' });
+      return { intentId, taskId, event: 'intent_cancelled' };
+    },
+    async redeliver(intentId) {
+      // cancelActionIntent's own CAS covers pending_approval/approved only;
+      // the row is already 'cancelled' so a second call would just re-read
+      // and report `ok: false` without touching the outbox — asserting the
+      // row's terminal status directly is the more direct proof.
+      const row = await withSystemDbAccessContext(async () => {
+        const [r] = await db.select().from(actionIntents).where(eq(actionIntents.id, intentId)).limit(1);
+        return r;
+      });
+      expect(row?.status).toBe('cancelled');
+    },
+  },
+  {
+    name: 'intentService.runHumanFanout no-eligible-approvers cancel',
+    async drive() {
+      const noApprovers = await seedTenant(false);
+      const { intentId, taskId } = await proposeTaskIntentExpectingNoApprovers(noApprovers);
+      const intent = await readIntent(intentId);
+      expect(intent?.status).toBe('cancelled');
+      expect(intent?.errorCode).toBe('no_eligible_approvers');
+      return { intentId, taskId, event: 'intent_cancelled' };
+    },
+    async redeliver() {
+      // Nothing to redeliver — the cancel happens synchronously inside
+      // creation, and creation is not repeatable via this fixture without
+      // colliding on the operation key. Covered by the identity unique's
+      // ON CONFLICT DO NOTHING contract, proven generically by
+      // taskOutbox.test.ts.
+    },
+  },
+];
+
+describe('AI Operator terminal writer contract (real Postgres, spec §6.3, baseline §3.2)', () => {
+  for (const writerCase of WRITER_CASES) {
+    runDb(`${writerCase.name}: publishes intent_outbox + task_outbox, and dedupes on redelivery`, async () => {
+      const { intentId, taskId, event } = await writerCase.drive();
+
+      // Every intent also carries an unconditional `intent_created` row from
+      // admission — filter to the TERMINAL event this writer is responsible
+      // for, rather than asserting the table's total row count for the intent.
+      const outboxRows = await readIntentOutboxRows(intentId);
+      const terminalRows = outboxRows.filter((r) => r.eventType === event);
+      expect(terminalRows).toHaveLength(1);
+      expect(terminalRows[0]!.payload).toMatchObject({ intentId });
+
+      const taskOutboxRows = await readTaskOutboxRows(taskId, intentId);
+      expect(taskOutboxRows).toHaveLength(1);
+      expect(taskOutboxRows[0]!.transitionSeq).toBe(INTENT_TERMINAL_OUTBOX_TRANSITION_SEQ[event]);
+      expect(taskOutboxRows[0]!.publishedAt).toBeNull();
+
+      await writerCase.redeliver(intentId, taskId);
+
+      const taskOutboxAfterRedelivery = await readTaskOutboxRows(taskId, intentId);
+      expect(taskOutboxAfterRedelivery).toHaveLength(1);
+    });
+  }
+});

--- a/apps/api/src/db/schema/actionIntents.test.ts
+++ b/apps/api/src/db/schema/actionIntents.test.ts
@@ -38,17 +38,21 @@ describe('actionIntentSourceEnum', () => {
 });
 
 describe('intentOutboxEventEnum', () => {
-  it('has exactly the six outbox events', () => {
+  it('has exactly the eight outbox events', () => {
     // Widened in wave 2 (#3823): intent_rejected and intent_expired exist so a
     // requester can be told an outcome their chat turn did not wait for. A
     // denied intent previously wrote no outbox row at all. Widened again for
-    // #4798: intent_cancelled closes the same gap for cancellation.
+    // #4798: intent_cancelled closes the same gap for cancellation. Widened
+    // again for #5205 W05 (#5210): intent_completed/intent_failed — there was
+    // no way to say a task-linked intent's EXECUTION finished.
     expect(intentOutboxEventEnum).toEqual([
       'intent_created',
       'intent_approved',
       'intent_rejected',
       'intent_expired',
       'intent_cancelled',
+      'intent_completed',
+      'intent_failed',
       'pam.desired_state_changed',
     ]);
   });
@@ -62,12 +66,12 @@ describe('intentOutboxEventEnum', () => {
     // Points at whichever migration shipped the CONSTRAINT's most recent
     // DROP+re-ADD (a CHECK constraint has one name and is replaced wholesale,
     // not appended to — the SQL file is the widest set only if it's the LAST
-    // one to touch this constraint). #4798 moved that to
-    // 2026-10-08-100300-intent-cancelled-outbox-event.sql; update this path
-    // again the next time the constraint is widened, same as the approval-
-    // scope CHECK test below does for its own migration.
+    // one to touch this constraint). #5205 W05 (#5210) moved that to
+    // 2026-10-14-100300-ai-operator-intent-terminal-events.sql; update this
+    // path again the next time the constraint is widened, same as the
+    // approval-scope CHECK test below does for its own migration.
     const migration = readFileSync(
-      join(__dirname, '../../../migrations/2026-10-08-100300-intent-cancelled-outbox-event.sql'),
+      join(__dirname, '../../../migrations/2026-10-14-100300-ai-operator-intent-terminal-events.sql'),
       'utf8',
     );
     const check = migration.slice(migration.indexOf('intent_outbox_event_type_check'));

--- a/apps/api/src/db/schema/actionIntents.ts
+++ b/apps/api/src/db/schema/actionIntents.ts
@@ -88,13 +88,20 @@ export type ActionIntentOriginPrincipalKind =
 // told the outcome. Pinned by a CHECK in SQL — see
 // 2026-09-04-ai-agent-notifications.sql. Widened again for #4798: a
 // CANCELLED intent had the same gap — see
-// 2026-10-08-100300-intent-cancelled-outbox-event.sql.
+// 2026-10-08-100300-intent-cancelled-outbox-event.sql. Widened again for
+// #5205 W05 (#5210, baseline §3.3): there was no way to say a task-linked
+// intent COMPLETED or FAILED — the release worker's `terminalizeIntent` and
+// the stale-executing reaper both published nothing at all, which would
+// strand a task in `waiting` until its deadline. See
+// 2026-10-14-100300-ai-operator-intent-terminal-events.sql.
 export const intentOutboxEventEnum = [
   'intent_created',
   'intent_approved',
   'intent_rejected',
   'intent_expired',
   'intent_cancelled',
+  'intent_completed',
+  'intent_failed',
   'pam.desired_state_changed',
 ] as const;
 export type IntentOutboxEvent = (typeof intentOutboxEventEnum)[number];

--- a/apps/api/src/jobs/aiOperatorTaskOutboxPublisher.test.ts
+++ b/apps/api/src/jobs/aiOperatorTaskOutboxPublisher.test.ts
@@ -182,4 +182,33 @@ describe('aiOperatorTaskOutboxPublisher.publishAiOperatorTaskOutbox', () => {
     expect(sawContextDuringEnqueue).toBe(false);
     expect(dbModule.hasDbAccessContext()).toBe(false);
   });
+
+  // Mixed-batch partial failure: row A enqueues successfully, row B's
+  // queue.add() rejects. Only row A's id may end up in the mark-published
+  // UPDATE — row B must keep published_at NULL (its attempt was already
+  // counted in the claim UPDATE, so it retries next tick).
+  it('marks only the successfully-enqueued row published when one row in the batch fails to enqueue', async () => {
+    executeMock.mockResolvedValueOnce({ rows: [{ unpublished_count: 2, oldest_age_seconds: 9 }] });
+    executeMock.mockResolvedValueOnce({
+      rows: [
+        { id: 10, org_id: 'org-1', task_id: 'task-10', source_kind: 'intent', source_id: 'intent-10', transition_seq: 1 },
+        { id: 11, org_id: 'org-1', task_id: 'task-11', source_kind: 'intent', source_id: 'intent-11', transition_seq: 2 },
+      ],
+    });
+    const chain = makeUpdateChain();
+    updateMock.mockReturnValue({ set: chain.set });
+
+    addMock
+      .mockResolvedValueOnce({ id: 'bullmq-job-10' }) // row 10 succeeds
+      .mockRejectedValueOnce(new Error('redis unavailable')); // row 11 fails
+
+    const result = await publishAiOperatorTaskOutbox();
+
+    expect(result).toEqual({ published: 1 });
+    expect(addMock).toHaveBeenCalledTimes(2);
+    // Exactly one mark-published pass, covering only the succeeded row.
+    expect(updateMock).toHaveBeenCalledTimes(1);
+    expect(chain.where).toHaveBeenCalledTimes(1);
+    expect(captureException).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/api/src/jobs/aiOperatorTaskOutboxPublisher.test.ts
+++ b/apps/api/src/jobs/aiOperatorTaskOutboxPublisher.test.ts
@@ -1,0 +1,185 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { executeMock, updateMock, addMock, closeMock, recordBacklogMock } = vi.hoisted(() => ({
+  executeMock: vi.fn(),
+  updateMock: vi.fn(),
+  addMock: vi.fn(),
+  closeMock: vi.fn(),
+  recordBacklogMock: vi.fn(),
+}));
+
+vi.mock('bullmq', () => ({
+  Queue: class {},
+  Worker: class {},
+  Job: class {},
+}));
+
+// Real AsyncLocalStorage-backed context tracking — same #1105 regression
+// guard as intentOutboxPublisher.test.ts: an identity-passthrough mock could
+// never prove the enqueue loop runs outside a held DB context.
+vi.mock('../db', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../db')>();
+  const { AsyncLocalStorage } = await import('node:async_hooks');
+  const contextStorage = new AsyncLocalStorage<true>();
+
+  const hasDbAccessContext = (): boolean => contextStorage.getStore() !== undefined;
+
+  const withSystemDbAccessContext = async <T>(fn: () => Promise<T>): Promise<T> => {
+    if (contextStorage.getStore()) return fn();
+    return contextStorage.run(true, fn);
+  };
+
+  const runOutsideDbContext = <T>(fn: () => T): T => contextStorage.exit(fn);
+
+  return {
+    ...actual,
+    db: {
+      ...actual.db,
+      execute: (...args: unknown[]) => executeMock(...(args as [])),
+      update: (...args: unknown[]) => updateMock(...(args as [])),
+    },
+    hasDbAccessContext,
+    withSystemDbAccessContext,
+    runOutsideDbContext,
+  };
+});
+
+vi.mock('../services/redis', () => ({
+  getRedisConnection: vi.fn(() => ({})),
+  getBullMQConnection: vi.fn(() => ({ host: 'localhost', port: 6379 })),
+  isBullMQAvailable: vi.fn(() => true),
+}));
+
+vi.mock('../services/bullmqQueue', () => ({
+  createInstrumentedQueue: vi.fn(() => ({ add: addMock, close: closeMock })),
+}));
+
+vi.mock('../services/sentry', () => ({
+  captureException: vi.fn(),
+}));
+
+vi.mock('../services/aiOperatorOutboxMetrics', () => ({
+  recordAiOperatorOutboxBacklog: recordBacklogMock,
+}));
+
+import { publishAiOperatorTaskOutbox } from './aiOperatorTaskOutboxPublisher';
+import { captureException } from '../services/sentry';
+import * as dbModule from '../db';
+
+function makeUpdateChain(returningValue: unknown = undefined) {
+  const where = vi.fn(() => Promise.resolve(returningValue));
+  const set = vi.fn(() => ({ where }));
+  return { set, where };
+}
+
+describe('aiOperatorTaskOutboxPublisher.publishAiOperatorTaskOutbox', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    addMock.mockResolvedValue({ id: 'bullmq-job-1' });
+  });
+
+  it('enqueues claimed rows with a hyphenated jobId, marks published, and records the backlog gauge', async () => {
+    // Call 1: backlog scan.
+    executeMock.mockResolvedValueOnce({ rows: [{ unpublished_count: 3, oldest_age_seconds: 42 }] });
+    // Call 2: claim query.
+    executeMock.mockResolvedValueOnce({
+      rows: [
+        {
+          id: 1,
+          org_id: 'org-1',
+          task_id: 'task-1',
+          source_kind: 'intent',
+          source_id: 'intent-1',
+          transition_seq: 1,
+        },
+      ],
+    });
+
+    const chain = makeUpdateChain();
+    updateMock.mockReturnValue({ set: chain.set });
+
+    const result = await publishAiOperatorTaskOutbox();
+
+    expect(result).toEqual({ published: 1 });
+    expect(recordBacklogMock).toHaveBeenCalledWith(3, 42);
+    expect(addMock).toHaveBeenCalledTimes(1);
+    expect(addMock).toHaveBeenCalledWith(
+      'task-wake',
+      { v: 1, orgId: 'org-1', taskId: 'task-1', sourceKind: 'intent', sourceId: 'intent-1', transitionSeq: 1 },
+      expect.objectContaining({ jobId: 'task-wake-org-1-task-1-intent-intent-1-1' }),
+    );
+    const jobId = (addMock.mock.calls[0] as unknown[])[2] as { jobId: string };
+    expect(jobId.jobId).not.toContain(':');
+
+    expect(updateMock).toHaveBeenCalledTimes(1);
+    expect(chain.set).toHaveBeenCalledTimes(1);
+    expect(chain.where).toHaveBeenCalledTimes(1);
+  });
+
+  it('an empty backlog records zero/zero and enqueues nothing', async () => {
+    executeMock.mockResolvedValueOnce({ rows: [{ unpublished_count: 0, oldest_age_seconds: 0 }] });
+    executeMock.mockResolvedValueOnce({ rows: [] });
+
+    const result = await publishAiOperatorTaskOutbox();
+
+    expect(result).toEqual({ published: 0 });
+    expect(recordBacklogMock).toHaveBeenCalledWith(0, 0);
+    expect(addMock).not.toHaveBeenCalled();
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it('leaves published_at unset and does not crash when enqueue fails (retried next tick)', async () => {
+    executeMock.mockResolvedValueOnce({ rows: [{ unpublished_count: 1, oldest_age_seconds: 5 }] });
+    executeMock.mockResolvedValueOnce({
+      rows: [
+        {
+          id: 2,
+          org_id: 'org-1',
+          task_id: 'task-2',
+          source_kind: 'intent',
+          source_id: 'intent-2',
+          transition_seq: 2,
+        },
+      ],
+    });
+    addMock.mockRejectedValueOnce(new Error('redis unavailable'));
+
+    const result = await publishAiOperatorTaskOutbox();
+
+    expect(result).toEqual({ published: 0 });
+    expect(updateMock).not.toHaveBeenCalled();
+    expect(captureException).toHaveBeenCalledTimes(1);
+  });
+
+  // #1105 regression: the enqueue loop must run OUTSIDE any DB access
+  // context — the claim transaction must close before queue.add() runs.
+  it('releases the DB access context before enqueueing — #1105', async () => {
+    executeMock.mockResolvedValueOnce({ rows: [{ unpublished_count: 1, oldest_age_seconds: 1 }] });
+    executeMock.mockResolvedValueOnce({
+      rows: [
+        {
+          id: 3,
+          org_id: 'org-1',
+          task_id: 'task-3',
+          source_kind: 'intent',
+          source_id: 'intent-3',
+          transition_seq: 1,
+        },
+      ],
+    });
+    const chain = makeUpdateChain();
+    updateMock.mockReturnValue({ set: chain.set });
+
+    let sawContextDuringEnqueue: boolean | undefined;
+    addMock.mockImplementation(async () => {
+      sawContextDuringEnqueue = dbModule.hasDbAccessContext();
+      return { id: 'bullmq-job-3' };
+    });
+
+    const result = await publishAiOperatorTaskOutbox();
+
+    expect(result).toEqual({ published: 1 });
+    expect(sawContextDuringEnqueue).toBe(false);
+    expect(dbModule.hasDbAccessContext()).toBe(false);
+  });
+});

--- a/apps/api/src/jobs/aiOperatorTaskOutboxPublisher.ts
+++ b/apps/api/src/jobs/aiOperatorTaskOutboxPublisher.ts
@@ -1,0 +1,353 @@
+import { Job, Queue, Worker } from 'bullmq';
+import { inArray, sql } from 'drizzle-orm';
+import * as dbModule from '../db';
+import { db } from '../db';
+import { aiOperatorTaskOutbox } from '../db/schema/aiOperatorTasks';
+import { getBullMQConnection } from '../services/redis';
+import { createInstrumentedQueue } from '../services/bullmqQueue';
+import { captureException } from '../services/sentry';
+import { recordAiOperatorOutboxBacklog } from '../services/aiOperatorOutboxMetrics';
+import {
+  AI_OPERATOR_COORDINATOR_QUEUE_NAME,
+  AI_OPERATOR_COORDINATOR_WAKE_JOB_NAME,
+  type AiOperatorTaskWakeJobData,
+} from './queueSchemas';
+import { attachWorkerObservability } from './workerObservability';
+
+/**
+ * Drains the `ai_operator_task_outbox` transactional outbox (spec §6.3, §11.2)
+ * into the `ai-operator-coordinator` BullMQ queue the AI Operator task
+ * coordinator (W06, not built yet) consumes. This module only creates the
+ * queue and publishes to it; it never processes coordinator wake jobs itself.
+ *
+ * WHY SYSTEM DB CONTEXT: unlike a request handler or a per-org worker,
+ * this publisher's whole job is to drain a table across EVERY org in one
+ * pass — `ai_operator_task_outbox` is Shape-1 org-scoped RLS (deliberately,
+ * baseline C20, unlike `intent_outbox`'s INTENTIONAL_UNSCOPED shape), so an
+ * ordinary tenant-scoped context would see nothing outside its own org.
+ * `withSystemDbAccessContext` is the sanctioned cross-org read/write path for
+ * exactly this kind of system-wide sweep (same posture as
+ * `intentOutboxPublisher.ts`'s `intent_outbox` drain, `intentExpiryReaper.ts`,
+ * and every other coarse background reaper in this codebase).
+ *
+ * Each pass, closely mirroring `intentOutboxPublisher.ts`'s three-phase shape:
+ *  1. CLAIM (DB-only, short `withSystemDbAccessContext`): atomically claim up
+ *     to MAX_PUBLISH_PER_RUN rows (`published_at IS NULL`, `ORDER BY due_at,
+ *     id`, `FOR UPDATE SKIP LOCKED`) and bump `attempts` in the same
+ *     statement, so a crash between claim and enqueue still counts as a used
+ *     attempt. Also scans (read-only, unlocked) the full unpublished set for
+ *     the two backlog gauges (§11.2) — count and the oldest row's age.
+ *  2. ENQUEUE (no DB context, `runOutsideDbContext`): one `ai-operator-coordinator`
+ *     job per claimed row, with a dedupe-stable jobId encoding the row's wake
+ *     identity (org, task, source kind, source id, transition) — BullMQ's
+ *     jobId dedupe collapses a re-publish of the same wake to a no-op on the
+ *     queue side, on top of the outbox row's own identity unique. Job data
+ *     carries the TYPED REFERENCE only (`{ orgId, taskId, sourceKind,
+ *     sourceId, transitionSeq }`), never a payload — the consumer always
+ *     re-reads the authoritative source row (spec §6.3).
+ *  3. MARK PUBLISHED (DB-only, short `withSystemDbAccessContext`): rows that
+ *     failed to enqueue keep `published_at IS NULL` and retry next pass
+ *     (their attempt was already counted in step 1).
+ *
+ * Runs every 5 seconds — sub-hourly, deliberately outside
+ * `jobs/scheduleRegistry.ts` (below `COARSE_REPEAT_INTERVAL_MS`, same
+ * precedent as `intentOutboxPublisher.ts`'s own 5s tick).
+ */
+
+const QUEUE_NAME = 'ai-operator-task-outbox-publisher';
+const PUBLISH_INTERVAL_MS = 5 * 1000; // every 5s
+const MAX_PUBLISH_PER_RUN = 50;
+
+type PublisherJobData = { type: 'publish-ai-operator-task-outbox'; queuedAt: string };
+
+const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
+  const withSystem = dbModule.withSystemDbAccessContext;
+  if (typeof withSystem !== 'function') {
+    throw new Error(
+      '[AiOperatorTaskOutboxPublisher] withSystemDbAccessContext not available — publisher cannot run without system DB access',
+    );
+  }
+  return withSystem(fn);
+};
+
+// #1105 — explicitly exits any DB access context before running `fn`, so a
+// Redis round-trip per row never runs while a pooled connection is pinned
+// idle-in-transaction.
+const runOutsideDbContext = <T>(fn: () => Promise<T>): Promise<T> => {
+  const runOutside = dbModule.runOutsideDbContext;
+  if (typeof runOutside !== 'function') {
+    return fn();
+  }
+  return runOutside(fn);
+};
+
+let publisherQueue: Queue<PublisherJobData> | null = null;
+let publisherWorker: Worker<PublisherJobData> | null = null;
+let coordinatorQueue: Queue<AiOperatorTaskWakeJobData> | null = null;
+
+function getQueue(): Queue<PublisherJobData> {
+  if (!publisherQueue) {
+    publisherQueue = new Queue<PublisherJobData>(QUEUE_NAME, { connection: getBullMQConnection() });
+  }
+  return publisherQueue;
+}
+
+function getCoordinatorQueue(): Queue<AiOperatorTaskWakeJobData> {
+  if (!coordinatorQueue) {
+    coordinatorQueue = createInstrumentedQueue<AiOperatorTaskWakeJobData>(AI_OPERATOR_COORDINATOR_QUEUE_NAME);
+  }
+  return coordinatorQueue;
+}
+
+// `type` (not `interface`) for the same reason intentOutboxPublisher.ts's
+// row types are — `db.execute<T>`'s constraint is `Record<string, unknown>`,
+// which a plain `interface` does not structurally satisfy.
+type ClaimedOutboxRow = {
+  id: number;
+  org_id: string;
+  task_id: string;
+  source_kind: string;
+  source_id: string;
+  transition_seq: number;
+};
+
+type BacklogRow = { unpublished_count: number; oldest_age_seconds: number };
+
+function extractRows<T>(result: unknown): T[] {
+  const rows = (result as { rows?: T[] }).rows ?? (result as T[]);
+  return Array.isArray(rows) ? rows : [];
+}
+
+interface ClaimResult {
+  claimedRows: ClaimedOutboxRow[];
+  backlog: BacklogRow;
+}
+
+/**
+ * Phase 1 (CLAIM + BACKLOG SCAN) — DB-only. Runs inside its own short
+ * `withSystemDbAccessContext` transaction (opened by the caller) so the held
+ * connection covers only these statements, never the enqueue loop.
+ */
+async function scanAndClaimOutboxRows(): Promise<ClaimResult> {
+  // Read-only backlog scan (spec §11.2) — never locked, never mutated. Runs
+  // BEFORE the claim below so the count/oldest-age reflect the state prior to
+  // this pass's own claim (a claimed-but-not-yet-published row is still
+  // "unpublished" either way; ordering only matters for consistency, not
+  // correctness).
+  const backlogResult = await db.execute<BacklogRow>(sql`
+    SELECT
+      count(*)::int AS unpublished_count,
+      COALESCE(EXTRACT(EPOCH FROM (now() - min(${aiOperatorTaskOutbox.createdAt})))::int, 0) AS oldest_age_seconds
+    FROM ${aiOperatorTaskOutbox}
+    WHERE ${aiOperatorTaskOutbox.publishedAt} IS NULL
+  `);
+  const backlog = extractRows<BacklogRow>(backlogResult)[0] ?? { unpublished_count: 0, oldest_age_seconds: 0 };
+
+  const claimed = await db.execute<ClaimedOutboxRow>(sql`
+    WITH due AS (
+      SELECT id
+      FROM ${aiOperatorTaskOutbox}
+      WHERE ${aiOperatorTaskOutbox.publishedAt} IS NULL
+      ORDER BY ${aiOperatorTaskOutbox.dueAt} ASC, ${aiOperatorTaskOutbox.id} ASC
+      LIMIT ${MAX_PUBLISH_PER_RUN}
+      FOR UPDATE SKIP LOCKED
+    )
+    UPDATE ${aiOperatorTaskOutbox} AS o
+    SET attempts = o.attempts + 1
+    FROM due
+    WHERE o.id = due.id
+    RETURNING o.id, o.org_id, o.task_id, o.source_kind, o.source_id, o.transition_seq;
+  `);
+  const claimedRows = extractRows<ClaimedOutboxRow>(claimed);
+
+  return { claimedRows, backlog };
+}
+
+/**
+ * Phase 2 (ENQUEUE) — no DB context. Caller must invoke this via
+ * `runOutsideDbContext` so `queue.add()` (instrumented by
+ * `createInstrumentedQueue`) never runs while a pooled connection is pinned
+ * idle-in-transaction (#1105).
+ */
+async function enqueueClaimedRows(rows: ClaimedOutboxRow[]): Promise<number[]> {
+  const publishedIds: number[] = [];
+  for (const row of rows) {
+    try {
+      // Hyphen-only, dedupe-stable — colons collide with BullMQ's own key
+      // delimiter (same rule intentOutboxPublisher.ts's jobId follows).
+      const jobId = `task-wake-${row.org_id}-${row.task_id}-${row.source_kind}-${row.source_id}-${row.transition_seq}`;
+      await getCoordinatorQueue().add(
+        AI_OPERATOR_COORDINATOR_WAKE_JOB_NAME,
+        {
+          v: 1,
+          orgId: row.org_id,
+          taskId: row.task_id,
+          // The four remaining source kinds (run/execution/verification/
+          // user_answer/target/cancellation) have no writer yet in this wave
+          // — only 'intent' is produced today — but the cast keeps this
+          // publisher generic over whatever a future writer enqueues rather
+          // than hard-coding a narrower union than the schema allows.
+          sourceKind: row.source_kind as AiOperatorTaskWakeJobData['sourceKind'],
+          sourceId: row.source_id,
+          transitionSeq: row.transition_seq,
+        },
+        {
+          jobId,
+          removeOnComplete: { count: 500 },
+          removeOnFail: { count: 500 },
+        },
+      );
+      publishedIds.push(row.id);
+    } catch (err) {
+      console.error(`[AiOperatorTaskOutboxPublisher] Failed to enqueue outbox row ${row.id}:`, err);
+      captureException(err instanceof Error ? err : new Error(String(err)));
+      // Leave published_at NULL — next pass retries; attempt already counted above.
+    }
+  }
+  return publishedIds;
+}
+
+/**
+ * Phase 3 (MARK PUBLISHED) — DB-only, its own short
+ * `withSystemDbAccessContext` transaction, entirely separate from the claim
+ * transaction so it never overlaps the enqueue loop.
+ */
+async function markOutboxRowsPublished(ids: number[]): Promise<void> {
+  if (ids.length === 0) return;
+  await db
+    .update(aiOperatorTaskOutbox)
+    .set({ publishedAt: sql`now()` })
+    .where(inArray(aiOperatorTaskOutbox.id, ids));
+}
+
+export interface PublishAiOperatorTaskOutboxResult {
+  published: number;
+}
+
+/**
+ * Single pass over `ai_operator_task_outbox`. Orchestrates its own DB-context
+ * boundaries (claim → enqueue → mark published) so no caller may accidentally
+ * hold a DB transaction open across the enqueue loop (#1105). Callers must
+ * invoke this directly, never wrapped in an outer `withSystemDbAccessContext`.
+ */
+export async function publishAiOperatorTaskOutbox(): Promise<PublishAiOperatorTaskOutboxResult> {
+  const { claimedRows, backlog } = await runWithSystemDbAccess(scanAndClaimOutboxRows);
+  recordAiOperatorOutboxBacklog(backlog.unpublished_count, backlog.oldest_age_seconds);
+
+  if (claimedRows.length === 0) {
+    return { published: 0 };
+  }
+
+  const publishedIds = await runOutsideDbContext(() => enqueueClaimedRows(claimedRows));
+
+  if (publishedIds.length > 0) {
+    await runWithSystemDbAccess(() => markOutboxRowsPublished(publishedIds));
+  }
+
+  if (claimedRows.length === MAX_PUBLISH_PER_RUN) {
+    console.warn(`[AiOperatorTaskOutboxPublisher] Hit ${MAX_PUBLISH_PER_RUN}-item cap — backlog may be growing`);
+  }
+
+  return { published: publishedIds.length };
+}
+
+function createWorker(): Worker<PublisherJobData> {
+  return new Worker<PublisherJobData>(
+    QUEUE_NAME,
+    async (_job: Job<PublisherJobData>) => {
+      try {
+        const { published } = await publishAiOperatorTaskOutbox();
+        if (published > 0) {
+          console.log(`[AiOperatorTaskOutboxPublisher] Published ${published} outbox row(s)`);
+        }
+        return { published };
+      } catch (err) {
+        console.error('[AiOperatorTaskOutboxPublisher] Run failed:', err);
+        captureException(err instanceof Error ? err : new Error(String(err)));
+        throw err;
+      }
+    },
+    {
+      connection: getBullMQConnection(),
+      concurrency: 1,
+    },
+  );
+}
+
+async function scheduleRepeatableJob(): Promise<void> {
+  const queue = getQueue();
+
+  const repeatables = await queue.getRepeatableJobs();
+  for (const job of repeatables) {
+    if (job.name === 'publish-ai-operator-task-outbox') {
+      await queue.removeRepeatableByKey(job.key);
+    }
+  }
+
+  await queue.add(
+    'publish-ai-operator-task-outbox',
+    { type: 'publish-ai-operator-task-outbox', queuedAt: new Date().toISOString() },
+    {
+      jobId: 'ai-operator-task-outbox-publisher',
+      repeat: { every: PUBLISH_INTERVAL_MS },
+      removeOnComplete: { count: 20 },
+      removeOnFail: { count: 200 },
+    },
+  );
+}
+
+export async function initializeAiOperatorTaskOutboxPublisher(): Promise<void> {
+  if (publisherWorker) return;
+
+  publisherWorker = createWorker();
+  attachWorkerObservability(publisherWorker, 'aiOperatorTaskOutboxPublisher');
+  publisherWorker.on('error', (error) => {
+    console.error('[AiOperatorTaskOutboxPublisher] Worker error:', error);
+    captureException(error);
+  });
+  publisherWorker.on('failed', (job, error) => {
+    console.error(`[AiOperatorTaskOutboxPublisher] Job ${job?.id} failed:`, error);
+    captureException(error);
+  });
+
+  try {
+    await scheduleRepeatableJob();
+  } catch (err) {
+    await publisherWorker.close();
+    publisherWorker = null;
+    throw err;
+  }
+
+  console.log('[AiOperatorTaskOutboxPublisher] Initialized');
+}
+
+export async function shutdownAiOperatorTaskOutboxPublisher(): Promise<void> {
+  const worker = publisherWorker;
+  const queue = publisherQueue;
+  const targetQueue = coordinatorQueue;
+  publisherWorker = null;
+  publisherQueue = null;
+  coordinatorQueue = null;
+
+  if (worker) {
+    try {
+      await worker.close();
+    } catch (err) {
+      console.error('[AiOperatorTaskOutboxPublisher] Error closing worker:', err);
+    }
+  }
+  if (queue) {
+    try {
+      await queue.close();
+    } catch (err) {
+      console.error('[AiOperatorTaskOutboxPublisher] Error closing queue:', err);
+    }
+  }
+  if (targetQueue) {
+    try {
+      await targetQueue.close();
+    } catch (err) {
+      console.error('[AiOperatorTaskOutboxPublisher] Error closing ai-operator-coordinator queue:', err);
+    }
+  }
+}

--- a/apps/api/src/jobs/intentExpiryReaper.ts
+++ b/apps/api/src/jobs/intentExpiryReaper.ts
@@ -12,6 +12,7 @@ import { recordActionIntentEvent, recordActionIntentMetric } from '../services/a
 import { REVEAL_WINDOW_DAYS } from '../services/actionIntents/resultSecrets';
 import { attachWorkerObservability } from './workerObservability';
 import { recordOperationResult } from '../services/aiOperator/operationService';
+import { enqueueTaskOutbox, INTENT_TERMINAL_OUTBOX_TRANSITION_SEQ } from '../services/aiOperator/taskOutbox';
 
 /**
  * Reaps `action_intents` rows past their deadline (spec
@@ -137,6 +138,8 @@ type ExpiredIntentRow = {
   source: string;
   requested_by_user_id: string | null;
   expires_at: Date;
+  /** #5205 W05 (#5210): non-null iff this is an AI Operator task-linked intent. */
+  task_id: string | null;
 };
 
 type StaleExecutingIntentRow = {
@@ -195,7 +198,8 @@ export async function reapExpiredIntents(): Promise<number> {
       a.argument_digest,
       a.source,
       a.requested_by_user_id,
-      a.expires_at;
+      a.expires_at,
+      a.task_id;
   `);
 
   const rows = extractRows<ExpiredIntentRow>(transitioned);
@@ -245,6 +249,23 @@ export async function reapExpiredIntents(): Promise<number> {
       payload: { intentId: row.id, orgId: row.org_id },
     })),
   );
+
+  // #5205 W05 (#5210), spec §6.3: task-linked rows also need the task_outbox
+  // wake, atomically with the expiry above (same transaction as the CTE
+  // UPDATE and the intentOutbox insert — this whole pass runs inside ONE
+  // Postgres transaction, see the file-header note on why errors here must
+  // propagate rather than be swallowed).
+  for (const row of rows) {
+    if (row.task_id) {
+      await enqueueTaskOutbox(db, {
+        orgId: row.org_id,
+        taskId: row.task_id,
+        sourceKind: 'intent',
+        sourceId: row.id,
+        transitionSeq: INTENT_TERMINAL_OUTBOX_TRANSITION_SEQ.intent_expired,
+      });
+    }
+  }
 
   for (const row of rows) {
     try {
@@ -315,6 +336,32 @@ export async function reapStaleExecutingIntents(): Promise<number> {
   const rows = extractRows<StaleExecutingIntentRow>(transitioned);
   if (rows.length === 0) {
     return 0;
+  }
+
+  // #5205 W05 (#5210), baseline C18: this writer terminalizes intents to
+  // `failed` but published NOTHING — the two writers baseline §3.2 calls out
+  // as the concrete gap. Same transaction as the CTE UPDATE above (this whole
+  // function runs inside ONE Postgres transaction via `runWithSystemDbAccess`
+  // — see reapExpiredIntents's header for why a failure here must propagate,
+  // not be swallowed: a swallowed error here would leave the CAS committed
+  // with no outbox row, exactly the strand this migration exists to close).
+  await db.insert(intentOutbox).values(
+    rows.map((row) => ({
+      intentId: row.id,
+      eventType: 'intent_failed' as const,
+      payload: { intentId: row.id, orgId: row.org_id },
+    })),
+  );
+  for (const row of rows) {
+    if (row.task_id) {
+      await enqueueTaskOutbox(db, {
+        orgId: row.org_id,
+        taskId: row.task_id,
+        sourceKind: 'intent',
+        sourceId: row.id,
+        transitionSeq: INTENT_TERMINAL_OUTBOX_TRANSITION_SEQ.intent_failed,
+      });
+    }
   }
 
   const requestLike = requestLikeFromSnapshot({});

--- a/apps/api/src/jobs/intentReleaseWorker.test.ts
+++ b/apps/api/src/jobs/intentReleaseWorker.test.ts
@@ -296,6 +296,14 @@ vi.mock('../services/aiOperator/dispatchClaim', () => ({
   claimTaskLinkedIntentForDispatch: dispatchClaimMock.claimTaskLinkedIntentForDispatch,
   revertTaskLinkedDispatchClaim: dispatchClaimMock.revertTaskLinkedDispatchClaim,
 }));
+// #5205 W05 (#5210): the terminal outbox publication, mocked wholesale — same
+// reason as dispatchClaim above. Its own contract (the intent_outbox row, the
+// conditional task_outbox leg) is pinned by taskOutbox.test.ts and the writer
+// contract integration test, not here; this file's `db` mock has no `insert`
+// at all, so the real function would throw on every terminal transition.
+vi.mock('../services/aiOperator/taskOutbox', () => ({
+  publishIntentTerminalOutbox: vi.fn(async () => undefined),
+}));
 // Partial mock: `isTaskLinkedIntent` stays the REAL implementation (it is a
 // pure function with no db dependency, and it is the branch predicate this
 // file's task-linked cases exist to exercise) — only the operation-row

--- a/apps/api/src/jobs/intentReleaseWorker.ts
+++ b/apps/api/src/jobs/intentReleaseWorker.ts
@@ -18,6 +18,7 @@ import {
   recordOperationResult,
   type OperationResultState,
 } from '../services/aiOperator/operationService';
+import { publishIntentTerminalOutbox } from '../services/aiOperator/taskOutbox';
 import { writeAuditEvent, requestLikeFromSnapshot } from '../services/auditEvents';
 import { recordActionIntentEvent, recordActionIntentMetric } from '../services/actionIntents/metrics';
 import { createNotification } from '../services/userNotifications';
@@ -340,7 +341,13 @@ export function isSessionRequiredForRelease(toolName: string): boolean {
  * Narrower than the full patch on purpose: `decided*` / `executionStartedAt`
  * belong to the decide and claim transitions, not to terminalization.
  */
-type TerminalPatch = Pick<ActionIntentTransitionPatch, 'executedAt' | 'errorCode' | 'result'>;
+// Exported (test-only consumer today) so aiOperatorTerminalWriters.integration.test.ts
+// (#5205 W05, #5210) can drive the CAS + evidence + terminal-outbox publish
+// path directly, without standing up the full `releaseApprovedIntent` tool
+// dispatch — the writer contract test's whole point is the outbox
+// publication, not re-proving release/dispatch, which dispatchClaim's own
+// integration suite already covers.
+export type TerminalPatch = Pick<ActionIntentTransitionPatch, 'executedAt' | 'errorCode' | 'result'>;
 
 /**
  * True iff this terminal write represents an ATTEMPTED operation — the one
@@ -626,7 +633,7 @@ async function watchReleasedIntent(
  * won, and receives whatever that insert resolved (the effective agent, the
  * triggering alert, the op key) so it needs no second read of its own.
  */
-async function terminalizeIntent(
+export async function terminalizeIntent(
   intent: ActionIntent,
   to: 'completed' | 'failed',
   patch: TerminalPatch,
@@ -640,6 +647,17 @@ async function terminalizeIntent(
   const won = await withSystemDbAccessContext(async () => {
     const casWon = await transitionIntent(intent.id, 'executing', to, patch);
     if (!casWon) return false;
+    // #5205 W05 (#5210), spec §6.3: the durable "this effect finished" wake —
+    // the ONLY writer that publishes nothing today. `transitionIntent` opens
+    // its own `withSystemDbAccessContext`, which JOINS this already-open one
+    // (db/index.ts's "refuses to nest"), so this insert commits atomically
+    // with the CAS above. `intent.taskId` is read from the pre-CAS row, which
+    // is safe because task linkage is immutable (action_intents_immutable_trg).
+    await publishIntentTerminalOutbox(
+      db,
+      { id: intent.id, orgId: intent.orgId, taskId: intent.taskId },
+      to === 'completed' ? 'intent_completed' : 'intent_failed',
+    );
     let anchor: IntentEvidenceAnchor | null = null;
     if (isAttemptedTerminal(patch)) {
       anchor = await recordIntentTerminalEvidence(intent, to === 'completed' ? 'executed' : 'failed');

--- a/apps/api/src/jobs/queueSchemas.ts
+++ b/apps/api/src/jobs/queueSchemas.ts
@@ -434,6 +434,27 @@ export const deliverEventJobDataSchema = z.object({
   event: breezeEventEnvelopeSchema,
 }).strict();
 
+/**
+ * #5205 W05 (#5210), spec §6.3 — the AI Operator task coordinator's wake
+ * queue. `jobs/aiOperatorTaskOutboxPublisher.ts` (this wave) is the sole
+ * producer, draining `ai_operator_task_outbox`; the task coordinator (W06,
+ * not built yet) is the sole consumer. Job data is a TYPED REFERENCE only —
+ * never an embedded payload (spec §6.3) — so the consumer always re-reads the
+ * authoritative source row rather than trusting what shipped on the wire.
+ */
+export const AI_OPERATOR_COORDINATOR_QUEUE_NAME = 'ai-operator-coordinator';
+export const AI_OPERATOR_COORDINATOR_WAKE_JOB_NAME = 'task-wake';
+
+export const aiOperatorTaskWakeJobDataSchema = z.object({
+  v: z.literal(1),
+  orgId: z.string().min(1),
+  taskId: z.string().min(1),
+  sourceKind: z.enum(['run', 'intent', 'execution', 'verification', 'user_answer', 'target', 'cancellation']),
+  sourceId: z.string().min(1),
+  transitionSeq: z.number().int(),
+}).strict();
+export type AiOperatorTaskWakeJobData = z.infer<typeof aiOperatorTaskWakeJobDataSchema>;
+
 export type BackupQueueJobData = z.infer<typeof backupQueueJobDataSchema>;
 export type DiscoveryQueueJobData = z.infer<typeof discoveryQueueJobDataSchema>;
 export type FdbEntry = z.infer<typeof fdbEntrySchema>;

--- a/apps/api/src/jobs/workerReadinessManifest.ts
+++ b/apps/api/src/jobs/workerReadinessManifest.ts
@@ -136,6 +136,7 @@ export const WORKER_READINESS_MANIFEST: readonly WorkerInitializerClassification
   consumers('approvalExpiryReaper'),
   consumers('offboardingDrainReaper'),
   consumers('intentOutboxPublisher'),
+  consumers('aiOperatorTaskOutboxPublisher'),
   consumers('intentExpiryReaper'),
   consumers('intentReleaseWorker'),
   consumers('stripeReconcileSweep'),

--- a/apps/api/src/routes/approvals.test.ts
+++ b/apps/api/src/routes/approvals.test.ts
@@ -2873,6 +2873,10 @@ describe('POST /approvals/:id/report-suspicious', () => {
       where: vi.fn().mockReturnValue({ returning: casReturning }),
     });
     const siblingSet = vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
+    // #5205 W05 (#5210): the report-suspicious rejection now publishes an
+    // intent_outbox row (via `tx`, not the ambient `db`) — the gap baseline
+    // C18 named. `tx.insert` was missing entirely before this wave since
+    // nothing wrote through it.
     const tx = {
       select: txSelectForUpdateStub(),
       update: vi
@@ -2880,6 +2884,7 @@ describe('POST /approvals/:id/report-suspicious', () => {
         .mockReturnValueOnce({ set: flipSet } as any) // 1) approval_requests -> reported
         .mockReturnValueOnce({ set: intentCasSet } as any) // 2) intent CAS
         .mockReturnValueOnce({ set: siblingSet } as any), // 3) sibling expiry
+      insert: vi.fn().mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) } as any),
     };
     vi.mocked(db.transaction).mockImplementation(async (fn: any) => fn(tx));
     vi.mocked(db.insert).mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) } as any);

--- a/apps/api/src/routes/approvals.ts
+++ b/apps/api/src/routes/approvals.ts
@@ -17,6 +17,7 @@ import {
   type ActionIntentApprovalScope,
   type ActionIntentStatus,
 } from '../db/schema/actionIntents';
+import { publishIntentTerminalOutbox } from '../services/aiOperator/taskOutbox';
 import { dispatchApprovalPush } from '../services/expoPush';
 import { revokeUserOauthClient } from './lifecycle';
 import { recordActionIntentEvent } from '../services/actionIntents/metrics';
@@ -969,6 +970,7 @@ approvalRoutes.post('/:id/report-suspicious', async (c) => {
                   id: actionIntents.id,
                   status: actionIntents.status,
                   orgId: actionIntents.orgId,
+                  taskId: actionIntents.taskId,
                 })
                 .from(actionIntents)
                 .where(eq(actionIntents.id, intentId))
@@ -1022,6 +1024,17 @@ approvalRoutes.post('/:id/report-suspicious', async (c) => {
                     ne(approvalRequests.id, existing.id),
                   ),
                 );
+
+              // #5205 W05 (#5210), baseline C18: this writer terminalizes the
+              // intent to `rejected` and published NOTHING at all today — the
+              // other concrete gap baseline §3.2 calls out. `locked.taskId` is
+              // read from the FOR-UPDATE-locked row above, safe to reuse here
+              // because task linkage is immutable.
+              await publishIntentTerminalOutbox(
+                tx,
+                { id: intentId, orgId: cas[0]!.orgId, taskId: locked?.taskId ?? null },
+                'intent_rejected',
+              );
 
               return {
                 rejected: cas[0] ?? null,

--- a/apps/api/src/services/actionIntents/intentService.test.ts
+++ b/apps/api/src/services/actionIntents/intentService.test.ts
@@ -1181,8 +1181,15 @@ describe('createActionIntent — approver fan-out', () => {
       status: 'cancelled',
       errorCode: 'no_eligible_approvers',
     });
-    // Outbox row is still written (creation itself still happened).
-    expect(dbState.insertedOutboxValues).toHaveLength(1);
+    // Outbox rows: creation itself still happened, and #5205 W05 (#5210) now
+    // also publishes the terminal cancel — the fail-closed "no eligible
+    // approvers" path was one of the terminal writers that published nothing.
+    expect(dbState.insertedOutboxValues).toHaveLength(2);
+    // runHumanFanout's fail-closed cancel writes its intent_cancelled row
+    // BEFORE createActionIntent's own unconditional intent_created insert
+    // that follows it — so cancelled is [0], created is [1].
+    expect(dbState.insertedOutboxValues[0]).toMatchObject({ eventType: 'intent_cancelled' });
+    expect(dbState.insertedOutboxValues[1]).toMatchObject({ eventType: 'intent_created' });
     // No push for a cancelled intent.
     expect(pushState.dispatchApprovalPushToTokens).not.toHaveBeenCalled();
     expect(metricsMock.recordActionIntentEvent).toHaveBeenCalledWith(

--- a/apps/api/src/services/actionIntents/intentService.ts
+++ b/apps/api/src/services/actionIntents/intentService.ts
@@ -55,6 +55,7 @@ import {
   OperationReplayError,
   reserveOperation,
 } from '../aiOperator/operationService';
+import { publishIntentTerminalOutbox } from '../aiOperator/taskOutbox';
 
 /** Statuses the partial `action_intents_org_idem_uniq` index dedupes on
  * (IMPORTANT-4 — migration 2026-07-18-action-intents.sql). Kept as a single
@@ -818,6 +819,27 @@ async function runHumanFanout(args: HumanFanoutArgs): Promise<HumanFanoutResult>
       status: 'cancelled',
       errorCode: 'no_eligible_approvers',
     };
+    // #5205 W05 (#5210), spec §6.3: this row is freshly inserted in THIS same
+    // transaction (createActionIntent's caller), so the CAS above cannot lose
+    // a race — `cancelled` truthy is the ordinary case; the ?? fallback above
+    // exists only for a defensive read-shape mismatch, not a real loss. A
+    // task-linked intent reaches this path too: `reserveOperation` already ran
+    // earlier in the SAME transaction (spec §6.5), before this fail-closed
+    // cancel — a no-eligible-approvers task operation must not strand the
+    // task in `waiting` any more than any other terminal writer.
+    if (cancelled) {
+      // Nothing was ever dispatched — terminally `cancelled` on the operation
+      // too (distinct from `abandoned`), same reasoning as
+      // cancelActionIntent's identical branch below.
+      if (isTaskLinkedIntent(inserted)) {
+        await markOperationCancelled(tx, inserted.id);
+      }
+      await publishIntentTerminalOutbox(
+        tx,
+        { id: inserted.id, orgId: inserted.orgId, taskId: inserted.taskId },
+        'intent_cancelled',
+      );
+    }
   }
 
   return { approvalRequestIds, requesterApprovalRequestId, fanOutUserIds, finalIntent };
@@ -2343,13 +2365,15 @@ export async function cancelActionIntent(
       if (taskLinked) {
         await markOperationCancelled(db, intentId);
       }
-      await db.insert(intentOutbox).values({
-        intentId,
-        eventType: 'intent_cancelled',
-        // Ids only, no argument content (spec §3.2) — matches the
-        // intent_created/intent_approved/intent_rejected/intent_expired rows.
-        payload: { intentId, orgId: intent.orgId },
-      });
+      // #5205 W05 (#5210): same intentOutbox row this always wrote, plus (when
+      // task-linked) the task_outbox leg — `intent.taskId` is read from the
+      // pre-transaction snapshot, which is safe since task linkage is
+      // immutable.
+      await publishIntentTerminalOutbox(
+        db,
+        { id: intentId, orgId: intent.orgId, taskId: intent.taskId },
+        'intent_cancelled',
+      );
       return true;
     });
   } catch (err) {

--- a/apps/api/src/services/aiAgentSdk.test.ts
+++ b/apps/api/src/services/aiAgentSdk.test.ts
@@ -1287,6 +1287,14 @@ describe('createSessionPreToolUse', () => {
         executedAt: expect.any(Date),
         result: expect.objectContaining({ status: 'completed' }),
       }));
+      // #5205 W05 (#5210): the CAS win must also publish the terminal outbox
+      // event, with taskId always null here (this file never threads a task
+      // context through createActionIntent).
+      expect(mockPublishIntentTerminalOutbox).toHaveBeenCalledWith(
+        expect.anything(),
+        { id: 'intent-6', orgId: 'org-1', taskId: null },
+        'intent_completed',
+      );
     });
 
     // ---------------------------------------------------------------------
@@ -2498,6 +2506,14 @@ describe('inline secret-bearing completion (Task 6)', () => {
     // plan completion, audit event) still ran for this postToolUse call
     // instead of being aborted by an uncaught throw.
     expect(session.eventBus.publish).toHaveBeenCalledWith(expect.objectContaining({ type: 'tool_result' }));
+
+    // #5205 W05 (#5210): the guard-tripped CAS win must also publish the
+    // terminal outbox event.
+    expect(mockPublishIntentTerminalOutbox).toHaveBeenCalledWith(
+      expect.anything(),
+      { id: 'intent-leak', orgId: 'org-1', taskId: null },
+      'intent_failed',
+    );
   });
 
   describe('Important 4: PAM-helper tier-3-but-intentless path pins intentId===undefined (deliberately out of scope for the plan-step fix below — PAM/helper sessions use their own elevation governance, not durable action-intents; see design doc docs/superpowers/specs/ai-mcp/2026-07-27-tier3-plan-mode-approval-parity-design.md §1.5)', () => {
@@ -2969,6 +2985,13 @@ describe('Task 2: plan index advances only once the step is authorized', () => {
     expect(session.eventBus.publish).not.toHaveBeenCalledWith(
       expect.objectContaining({ type: 'plan_step_start' }),
     );
+    // #5205 W05 (#5210): the executing -> failed CAS this revalidation
+    // failure drives must also publish the terminal outbox event.
+    expect(mockPublishIntentTerminalOutbox).toHaveBeenCalledWith(
+      expect.anything(),
+      { id: 'intent-plan-revalidate-fail', orgId: 'org-1', taskId: null },
+      'intent_failed',
+    );
   });
 
   // Effect-digest revalidation (tier3-supervised-four-eyes design §4.1): the
@@ -3031,6 +3054,12 @@ describe('Task 2: plan index advances only once the step is authorized', () => {
       'executing',
       'failed',
       { errorCode: 'content_changed' },
+    );
+    // #5205 W05 (#5210): same CAS win must publish the terminal outbox event.
+    expect(mockPublishIntentTerminalOutbox).toHaveBeenCalledWith(
+      expect.anything(),
+      { id: 'intent-plan-digest-mismatch', orgId: 'org-1', taskId: null },
+      'intent_failed',
     );
   });
 
@@ -3465,6 +3494,13 @@ describe('Task 3: a plan aborts when a tier-3 step does not execute', () => {
     });
     expect(session.activePlanId).toBeNull();
     expect(session.approvedPlanSteps.size).toBe(0);
+    // #5205 W05 (#5210): the executing -> failed CAS this revalidation
+    // failure drives must also publish the terminal outbox event.
+    expect(mockPublishIntentTerminalOutbox).toHaveBeenCalledWith(
+      expect.anything(),
+      { id: 'intent-task3-revalidate', orgId: 'org-1', taskId: null },
+      'intent_failed',
+    );
   });
 
   // ----------------------------------------------------------------------
@@ -3561,6 +3597,14 @@ describe('Task 3: a plan aborts when a tier-3 step does not execute', () => {
     );
     expect(session.activePlanId).toBeNull();
     expect(session.approvedPlanSteps.size).toBe(0);
+    // #5205 W05 (#5210): the self-heal CAS win must also publish the
+    // terminal outbox event — without this, a stranded-intent self-heal
+    // would silently never wake anything watching for the outcome.
+    expect(mockPublishIntentTerminalOutbox).toHaveBeenCalledWith(
+      expect.anything(),
+      { id: 'intent-selfheal', orgId: 'org-1', taskId: null },
+      'intent_failed',
+    );
   });
 
   // ----------------------------------------------------------------------

--- a/apps/api/src/services/aiAgentSdk.test.ts
+++ b/apps/api/src/services/aiAgentSdk.test.ts
@@ -132,6 +132,16 @@ vi.mock('./actionIntents/intentService', () => ({
   transitionIntent: (...args: unknown[]) => mockTransitionIntent(...args),
 }));
 
+// #5205 W05 (#5210): the terminal outbox publication, mocked wholesale — its
+// own contract (the intent_outbox row, the conditional task_outbox leg) is
+// pinned by taskOutbox.test.ts and the writer contract integration test, not
+// here. The real function reads `intentOutbox` from the `../db/schema/
+// actionIntents` mock below, which only stubs `actionIntents`.
+const mockPublishIntentTerminalOutbox = vi.fn((..._args: unknown[]) => Promise.resolve());
+vi.mock('./aiOperator/taskOutbox', () => ({
+  publishIntentTerminalOutbox: (...args: unknown[]) => mockPublishIntentTerminalOutbox(...args),
+}));
+
 // Mocked as a collaborator (like intentService): the inline release path calls
 // this to re-prove the requester's authorization before executing. Also cuts
 // the real module's ../aiTools import chain (which would otherwise drag in

--- a/apps/api/src/services/aiAgentSdk.ts
+++ b/apps/api/src/services/aiAgentSdk.ts
@@ -33,7 +33,13 @@ import { dispatchApprovalPushToTokens, getUserPushTokens } from './expoPush';
 import { decideHelperToolAction } from './pamToolActionGovernance';
 import { loadSession, loadConnection } from './m365Helpers';
 import type { DelegantM365ConnectionRow } from '../db/schema/delegant';
-import { createActionIntent, waitForIntentDecision, transitionIntent } from './actionIntents/intentService';
+import {
+  createActionIntent,
+  waitForIntentDecision,
+  transitionIntent,
+  type ActionIntentTransitionPatch,
+} from './actionIntents/intentService';
+import { publishIntentTerminalOutbox } from './aiOperator/taskOutbox';
 import { revalidateApprovedIntentForRelease } from './actionIntents/revalidateRelease';
 import { requiresDurableRelease } from './actionIntents/durableRelease';
 import { approvedExecutingDenial } from './aiToolHandoff';
@@ -479,6 +485,42 @@ export async function runPreFlightChecks(
   }
 
   return { ok: true, session, sanitizedContent, systemPrompt, maxBudgetUsd, resolved };
+}
+
+/**
+ * #5205 W05 (#5210), spec §6.3: wraps a `transitionIntent` CAS to a terminal
+ * status with its `intent_outbox` publication in ONE atomic system-scoped
+ * transaction — `transitionIntent` opens its own `withSystemDbAccessContext`,
+ * which JOINS this already-open one (db/index.ts's "refuses to nest"), so
+ * both writes commit together. Only fires when the CAS actually wins,
+ * matching every other terminal writer's posture (a lost race means some
+ * other writer already terminalized this intent and owns its outbox row).
+ *
+ * `taskId` is always `null` here by construction: every intent this file
+ * transitions was created by THIS session's own
+ * `createActionIntent(session.auth, {...})` call above, which never threads a
+ * `task` context through — task-linked admission is a durable-worker-only
+ * path in the thin slice (spec P3-1: "supervised mode only... no direct
+ * act"). `publishIntentTerminalOutbox` is still the call site (not a bare
+ * `intentOutbox` insert) because it is the ONE helper every terminal writer
+ * in baseline §3.2's inventory uses, and the contract test enumerates that
+ * inventory by call site, not by whether task-linkage happens to be reachable
+ * today.
+ */
+async function transitionIntentAndPublish(
+  intentId: string,
+  to: 'completed' | 'failed',
+  patch: ActionIntentTransitionPatch,
+  orgId: string,
+  event: 'intent_completed' | 'intent_failed',
+): Promise<boolean> {
+  return withSystemDbAccessContext(async () => {
+    const won = await transitionIntent(intentId, 'executing', to, patch);
+    if (won) {
+      await publishIntentTerminalOutbox(db, { id: intentId, orgId, taskId: null }, event);
+    }
+    return won;
+  });
 }
 
 // ============================================
@@ -1276,7 +1318,13 @@ export function createSessionPreToolUse(session: ActiveSession): PreToolUseCallb
 
           const revalidation = await revalidateApprovedIntentForRelease(intentRow, winningApproval);
           if (!revalidation.ok) {
-            await transitionIntent(intent.id, 'executing', 'failed', { errorCode: revalidation.errorCode });
+            await transitionIntentAndPublish(
+              intent.id,
+              'failed',
+              { errorCode: revalidation.errorCode },
+              session.orgId,
+              'intent_failed',
+            );
             console.error(
               `[AI-SDK] inline release revalidation failed for intent ${intent.id}: ${revalidation.errorCode}`,
             );
@@ -1321,9 +1369,13 @@ export function createSessionPreToolUse(session: ActiveSession): PreToolUseCallb
               ),
             );
             if (recomputed.digest !== intentRow.effectDigest) {
-              await transitionIntent(intent.id, 'executing', 'failed', {
-                errorCode: 'content_changed',
-              });
+              await transitionIntentAndPublish(
+                intent.id,
+                'failed',
+                { errorCode: 'content_changed' },
+                session.orgId,
+                'intent_failed',
+              );
               console.error(
                 `[AI-SDK] inline release effect-digest mismatch for intent ${intent.id}: content_changed`,
               );
@@ -1384,7 +1436,13 @@ export function createSessionPreToolUse(session: ActiveSession): PreToolUseCallb
           // original error being handled.
           if (wonIntentId) {
             try {
-              await transitionIntent(wonIntentId, 'executing', 'failed', { errorCode: 'execution_error' });
+              await transitionIntentAndPublish(
+                wonIntentId,
+                'failed',
+                { errorCode: 'execution_error' },
+                session.orgId,
+                'intent_failed',
+              );
             } catch (transitionErr) {
               console.error(
                 '[AI-SDK] Failed to CAS action intent to failed after unexpected tier-3 error:',
@@ -1900,10 +1958,13 @@ export function createSessionPostToolUse(session: ActiveSession): PostToolUseCal
           captureException(err instanceof Error ? err : new Error(String(err)));
           plaintextGuardTripped = true;
           try {
-            await transitionIntent(pendingIntentId, 'executing', 'failed', {
-              executedAt: new Date(),
-              errorCode: SECRET_SEAL_INVARIANT_VIOLATED_ERROR_CODE,
-            });
+            await transitionIntentAndPublish(
+              pendingIntentId,
+              'failed',
+              { executedAt: new Date(), errorCode: SECRET_SEAL_INVARIANT_VIOLATED_ERROR_CODE },
+              session.orgId,
+              'intent_failed',
+            );
           } catch (transitionErr) {
             console.error(
               `[AI-SDK] Failed to CAS action intent to failed after plaintext-secret guard for ${toolName}:`,
@@ -1915,15 +1976,21 @@ export function createSessionPostToolUse(session: ActiveSession): PostToolUseCal
 
         if (!plaintextGuardTripped) {
           try {
-            await transitionIntent(pendingIntentId, 'executing', isError ? 'failed' : 'completed', {
-              executedAt: new Date(),
-              // error_code is always the stable short code (matches the
-              // release worker's vocabulary); the raw tool error text is
-              // unbounded free-form and belongs in `result`, not `error_code`.
-              ...(isError
-                ? { errorCode: INLINE_TOOL_EXECUTION_FAILED_ERROR_CODE, result: sizedResult }
-                : { result: sizedResult }),
-            });
+            await transitionIntentAndPublish(
+              pendingIntentId,
+              isError ? 'failed' : 'completed',
+              {
+                executedAt: new Date(),
+                // error_code is always the stable short code (matches the
+                // release worker's vocabulary); the raw tool error text is
+                // unbounded free-form and belongs in `result`, not `error_code`.
+                ...(isError
+                  ? { errorCode: INLINE_TOOL_EXECUTION_FAILED_ERROR_CODE, result: sizedResult }
+                  : { result: sizedResult }),
+              },
+              session.orgId,
+              isError ? 'intent_failed' : 'intent_completed',
+            );
           } catch (err) {
             console.error(`[AI-SDK] Failed to CAS action intent to ${isError ? 'failed' : 'completed'} for ${toolName}:`, pendingIntentId, err);
           }

--- a/apps/api/src/services/aiAgentSdk.ts
+++ b/apps/api/src/services/aiAgentSdk.ts
@@ -1444,11 +1444,18 @@ export function createSessionPreToolUse(session: ActiveSession): PreToolUseCallb
                 'intent_failed',
               );
             } catch (transitionErr) {
+              // #5205 W05 (#5210): transitionIntentAndPublish now couples the
+              // CAS to a constraint-guarded intentOutbox insert in the SAME
+              // transaction — a failure here rolls back the self-heal CAS
+              // too, exactly the case this code exists to prevent (a stranded
+              // `executing` row). Must not be console-only: this is the same
+              // "silent for weeks" risk class as the wiring-error check above.
               console.error(
                 '[AI-SDK] Failed to CAS action intent to failed after unexpected tier-3 error:',
                 wonIntentId,
                 transitionErr,
               );
+              captureException(transitionErr instanceof Error ? transitionErr : new Error(String(transitionErr)));
             }
           }
           return await failMatchedPlanStep({
@@ -1966,11 +1973,16 @@ export function createSessionPostToolUse(session: ActiveSession): PostToolUseCal
               'intent_failed',
             );
           } catch (transitionErr) {
+            // #5205 W05 (#5210): the CAS is now coupled to a constraint-
+            // guarded intentOutbox insert in the SAME transaction — a
+            // failure here rolls the CAS back too, stranding the intent
+            // `executing`. Report, don't just log.
             console.error(
               `[AI-SDK] Failed to CAS action intent to failed after plaintext-secret guard for ${toolName}:`,
               pendingIntentId,
               transitionErr,
             );
+            captureException(transitionErr instanceof Error ? transitionErr : new Error(String(transitionErr)));
           }
         }
 
@@ -1992,7 +2004,14 @@ export function createSessionPostToolUse(session: ActiveSession): PostToolUseCal
               isError ? 'intent_failed' : 'intent_completed',
             );
           } catch (err) {
+            // #5205 W05 (#5210): this is the primary inline-execution
+            // completion write — every non-durable-release tier-3 tool call
+            // ends here. The CAS is now coupled to a constraint-guarded
+            // intentOutbox insert in the SAME transaction, so a failure here
+            // rolls the CAS back too and would otherwise strand the intent
+            // `executing` with no signal beyond a console line.
             console.error(`[AI-SDK] Failed to CAS action intent to ${isError ? 'failed' : 'completed'} for ${toolName}:`, pendingIntentId, err);
+            captureException(err instanceof Error ? err : new Error(String(err)));
           }
         }
       }

--- a/apps/api/src/services/aiOperator/taskOutbox.test.ts
+++ b/apps/api/src/services/aiOperator/taskOutbox.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// #5205 W05 (#5210), spec §6.3: `taskOutbox.ts` is the ONE helper every
+// terminal writer calls. This suite proves its two contracts in isolation
+// (mocked `db`, no real dialect): `enqueueTaskOutbox` names the identity
+// unique as its ON CONFLICT target (the dedupe guarantee), and
+// `publishIntentTerminalOutbox` writes `intent_outbox` UNCONDITIONALLY but
+// only enqueues the task_outbox leg when the intent is task-linked.
+const { intentOutboxValuesMock, taskOutboxValuesMock, onConflictDoNothingMock, insertMock } = vi.hoisted(() => {
+  const onConflictDoNothingMock = vi.fn(() => Promise.resolve());
+  const taskOutboxValuesMock = vi.fn(() => ({ onConflictDoNothing: onConflictDoNothingMock }));
+  const intentOutboxValuesMock = vi.fn(() => Promise.resolve());
+  return {
+    intentOutboxValuesMock,
+    taskOutboxValuesMock,
+    onConflictDoNothingMock,
+    // Discriminates which table's `.insert(...)` call this is by inspecting
+    // the table reference identity (set up in the mock factory below).
+    insertMock: vi.fn(),
+  };
+});
+
+vi.mock('../../db', async () => {
+  return {
+    db: {
+      insert: insertMock,
+    },
+  };
+});
+
+vi.mock('../../db/schema/aiOperatorTasks', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../db/schema/aiOperatorTasks')>();
+  return { ...actual };
+});
+
+import { aiOperatorTaskOutbox } from '../../db/schema/aiOperatorTasks';
+import { intentOutbox } from '../../db/schema/actionIntents';
+import {
+  enqueueTaskOutbox,
+  publishIntentTerminalOutbox,
+  INTENT_TERMINAL_OUTBOX_TRANSITION_SEQ,
+} from './taskOutbox';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  insertMock.mockImplementation((table: unknown) => {
+    if (table === aiOperatorTaskOutbox) {
+      return { values: taskOutboxValuesMock };
+    }
+    if (table === intentOutbox) {
+      return { values: intentOutboxValuesMock };
+    }
+    throw new Error('insert() called with an unexpected table');
+  });
+});
+
+describe('enqueueTaskOutbox', () => {
+  it('inserts with the identity columns as the ON CONFLICT target (dedupe contract)', async () => {
+    await enqueueTaskOutbox(
+      { insert: insertMock } as never,
+      { orgId: 'org-1', taskId: 'task-1', sourceKind: 'intent', sourceId: 'intent-1', transitionSeq: 1 },
+    );
+
+    expect(taskOutboxValuesMock).toHaveBeenCalledWith({
+      orgId: 'org-1',
+      taskId: 'task-1',
+      sourceKind: 'intent',
+      sourceId: 'intent-1',
+      transitionSeq: 1,
+    });
+    expect(onConflictDoNothingMock).toHaveBeenCalledWith({
+      target: [
+        aiOperatorTaskOutbox.orgId,
+        aiOperatorTaskOutbox.taskId,
+        aiOperatorTaskOutbox.sourceKind,
+        aiOperatorTaskOutbox.sourceId,
+        aiOperatorTaskOutbox.transitionSeq,
+      ],
+    });
+  });
+});
+
+describe('publishIntentTerminalOutbox', () => {
+  it('always writes an intent_outbox row with an ids-only payload', async () => {
+    await publishIntentTerminalOutbox(
+      { insert: insertMock } as never,
+      { id: 'intent-1', orgId: 'org-1', taskId: null },
+      'intent_completed',
+    );
+
+    expect(intentOutboxValuesMock).toHaveBeenCalledWith({
+      intentId: 'intent-1',
+      eventType: 'intent_completed',
+      payload: { intentId: 'intent-1', orgId: 'org-1' },
+    });
+  });
+
+  it('does NOT enqueue a task_outbox row for a legacy (non-task-linked) intent', async () => {
+    await publishIntentTerminalOutbox(
+      { insert: insertMock } as never,
+      { id: 'intent-1', orgId: 'org-1', taskId: null },
+      'intent_failed',
+    );
+
+    expect(taskOutboxValuesMock).not.toHaveBeenCalled();
+  });
+
+  it('enqueues a task_outbox row for a task-linked intent, with the terminal-status ordinal as transitionSeq', async () => {
+    await publishIntentTerminalOutbox(
+      { insert: insertMock } as never,
+      { id: 'intent-1', orgId: 'org-1', taskId: 'task-1' },
+      'intent_completed',
+    );
+
+    expect(taskOutboxValuesMock).toHaveBeenCalledWith({
+      orgId: 'org-1',
+      taskId: 'task-1',
+      sourceKind: 'intent',
+      sourceId: 'intent-1',
+      transitionSeq: INTENT_TERMINAL_OUTBOX_TRANSITION_SEQ.intent_completed,
+    });
+  });
+
+  it('gives every terminal event a DISTINCT transitionSeq ordinal', () => {
+    const values = Object.values(INTENT_TERMINAL_OUTBOX_TRANSITION_SEQ);
+    expect(new Set(values).size).toBe(values.length);
+  });
+});

--- a/apps/api/src/services/aiOperator/taskOutbox.ts
+++ b/apps/api/src/services/aiOperator/taskOutbox.ts
@@ -1,0 +1,145 @@
+// AI Operator task outbox writer (#5205 W05, sub-issue #5210).
+//
+// WHY THIS FILE EXISTS: spec §6.3 requires "a task outbox record atomically
+// with each task-affecting authoritative transition", deduplicated "by org,
+// task, source kind, source ID, and transition identity" — this is the ONE
+// helper every writer calls to do that, so every writer converges on the
+// identical dedupe/atomicity contract instead of each reinventing it.
+//
+// `ai_operator_task_outbox` is DELIBERATELY RLS-scoped (baseline C20,
+// db/schema/aiOperatorTasks.ts's header) — the opposite of `intent_outbox`,
+// which is INTENTIONAL_UNSCOPED because the agent WS path drains it. Never
+// add this table to that allowlist.
+//
+// Callers MUST pass their own transaction handle (`dbh` — a bare `db` proxy
+// that joins the caller's ambient `withDbAccessContext`/`withSystemDbAccessContext`
+// scope, or an explicit `tx`) so the enqueue lands in the SAME Postgres
+// transaction as the terminal status write it announces. A row written in a
+// separate, later statement is not atomic with the transition it describes: a
+// crash between the two would leave a committed terminal state with no wake
+// ever raised, stranding the task in `waiting` until its deadline.
+
+import { db } from '../../db';
+import {
+  aiOperatorTaskOutbox,
+  type AiOperatorOutboxSourceKind,
+} from '../../db/schema/aiOperatorTasks';
+import { intentOutbox } from '../../db/schema/actionIntents';
+
+/** The subset of drizzle's `db` these helpers need — lets them join a caller's transaction. */
+type DbHandle = Pick<typeof db, 'insert'>;
+
+export interface EnqueueTaskOutboxInput {
+  orgId: string;
+  taskId: string;
+  sourceKind: AiOperatorOutboxSourceKind;
+  sourceId: string;
+  transitionSeq: number;
+}
+
+/**
+ * THE one helper every writer calls to enqueue an `ai_operator_task_outbox`
+ * row, in the caller's own transaction. `ON CONFLICT DO NOTHING` on the row's
+ * identity unique (`org_id, task_id, source_kind, source_id, transition_seq`
+ * — `ai_operator_task_outbox_identity_uq`) so redelivery of the same
+ * terminalization (a retried writer, a duplicate CAS attempt that somehow
+ * re-entered) converges on one row rather than erroring or double-waking the
+ * coordinator (spec §6.3's "Deduplicate by org, task, source kind, source ID,
+ * and transition identity").
+ */
+export async function enqueueTaskOutbox(
+  dbh: DbHandle,
+  input: EnqueueTaskOutboxInput,
+): Promise<void> {
+  await dbh
+    .insert(aiOperatorTaskOutbox)
+    .values({
+      orgId: input.orgId,
+      taskId: input.taskId,
+      sourceKind: input.sourceKind,
+      sourceId: input.sourceId,
+      transitionSeq: input.transitionSeq,
+    })
+    .onConflictDoNothing({
+      target: [
+        aiOperatorTaskOutbox.orgId,
+        aiOperatorTaskOutbox.taskId,
+        aiOperatorTaskOutbox.sourceKind,
+        aiOperatorTaskOutbox.sourceId,
+        aiOperatorTaskOutbox.transitionSeq,
+      ],
+    });
+}
+
+/**
+ * `intent_outbox.event_type` values a task-linked intent's TERMINAL write can
+ * publish. Widened by migration 2026-10-14-100300-ai-operator-intent-terminal-events.sql
+ * to add `intent_completed`/`intent_failed` (there was no way to say either
+ * before this wave — baseline §3.3).
+ */
+export type IntentTerminalOutboxEvent =
+  | 'intent_completed'
+  | 'intent_failed'
+  | 'intent_rejected'
+  | 'intent_expired'
+  | 'intent_cancelled';
+
+/**
+ * `transitionSeq` for an intent's task-outbox row (`sourceKind: 'intent'`,
+ * `sourceId: intentId`). `action_intents.status` reaches AT MOST ONE terminal
+ * value ever — once terminal, a status is final; nothing transitions an
+ * intent out of a terminal status (`transitionIntent`'s CAS `from` list is
+ * always a LIVE status). So each intent produces at most one task-outbox row
+ * per possible terminal event, and these fixed ordinals only need to be
+ * MUTUALLY DISTINCT, not a running per-intent counter — "the terminal status
+ * ordinal" scheme spec §6.3 asks for ("use the terminal status ordinal or a
+ * sequence; document it"). A retried/duplicate delivery of the SAME
+ * terminalization reuses the SAME ordinal, which is exactly what makes the
+ * identity unique's `ON CONFLICT DO NOTHING` collapse it to one row.
+ */
+export const INTENT_TERMINAL_OUTBOX_TRANSITION_SEQ: Record<IntentTerminalOutboxEvent, number> = {
+  intent_completed: 1,
+  intent_failed: 2,
+  intent_rejected: 3,
+  intent_expired: 4,
+  intent_cancelled: 5,
+};
+
+/**
+ * The combo every intent terminal writer calls (baseline §3.2's inventory is
+ * the enumeration; `aiOperatorTerminalWriters.integration.test.ts` pins it):
+ *
+ *  (a) an `intent_outbox` row — UNCONDITIONAL, ids-only payload, matching the
+ *      shape every existing writer already uses (`{ intentId, orgId }`); and
+ *  (b) — only when the intent is task-linked (`taskId` non-null) — an
+ *      `ai_operator_task_outbox` row via `enqueueTaskOutbox` above.
+ *
+ * MUST be called inside the SAME transaction as the terminal status write
+ * (spec §6.3: "Add a task outbox record atomically with each task-affecting
+ * authoritative transition") — pass the caller's own `db`/`tx` handle as
+ * `dbh`, never a fresh `db` reference opened outside that transaction's
+ * context.
+ */
+export async function publishIntentTerminalOutbox(
+  dbh: DbHandle,
+  intent: { id: string; orgId: string; taskId: string | null },
+  event: IntentTerminalOutboxEvent,
+): Promise<void> {
+  await dbh.insert(intentOutbox).values({
+    intentId: intent.id,
+    eventType: event,
+    // Ids only, no argument content (spec §3.2) — matches every existing
+    // intent_created/intent_approved/intent_rejected/intent_expired/intent_cancelled row.
+    payload: { intentId: intent.id, orgId: intent.orgId },
+  });
+
+  if (intent.taskId) {
+    await enqueueTaskOutbox(dbh, {
+      orgId: intent.orgId,
+      taskId: intent.taskId,
+      sourceKind: 'intent',
+      sourceId: intent.id,
+      transitionSeq: INTENT_TERMINAL_OUTBOX_TRANSITION_SEQ[event],
+    });
+  }
+}

--- a/apps/api/src/services/aiOperatorOutboxMetrics.ts
+++ b/apps/api/src/services/aiOperatorOutboxMetrics.ts
@@ -1,0 +1,46 @@
+/**
+ * #5205 W05 (#5210), spec §11.2 — the AI Operator task outbox's Prometheus
+ * series.
+ *
+ * A LEAF module: `prom-client` plus `./metricsRegistry`, nothing else. Same
+ * shape and rationale as `scriptCancellationMetrics.ts` — the only caller,
+ * `jobs/aiOperatorTaskOutboxPublisher.ts`, runs in the WORKER role
+ * (`BREEZE_ROLE=worker`), a process that never loads `routes/metrics.ts` and
+ * whose import closure is asserted never to reach `routes/`
+ * (`services/workerEntrypointClosure.contract.test.ts`). Registering here and
+ * setting directly (rather than through `backupMetrics.ts`'s
+ * settable-recorder indirection, which exists for leaves that cannot import
+ * `prom-client` at all) is what makes the series appear in the role that
+ * actually produces it — binding it from `routes/metrics.ts` instead would
+ * reproduce #4143: the api process publishing a permanent zero while the
+ * worker does the actual polling.
+ */
+import { Gauge } from 'prom-client';
+
+import { metricsRegistry } from './metricsRegistry';
+
+/** Unpublished `ai_operator_task_outbox` rows observed at the last publisher tick. */
+const outboxUnpublishedGauge = new Gauge({
+  name: 'ai_operator_outbox_unpublished',
+  help: 'Unpublished ai_operator_task_outbox rows at the last publisher tick',
+  registers: [metricsRegistry],
+});
+
+/**
+ * Age, in seconds, of the oldest unpublished `ai_operator_task_outbox` row at
+ * the last publisher tick. 0 when the backlog is empty. A sustained rise past
+ * a few multiples of the 5s poll interval means the coordinator is not
+ * waking on task-affecting transitions in a timely way (spec §11.2's alert
+ * surface, thresholds set during the P3 pilot).
+ */
+const outboxOldestAgeSecondsGauge = new Gauge({
+  name: 'ai_operator_outbox_oldest_age_seconds',
+  help: 'Age in seconds of the oldest unpublished ai_operator_task_outbox row at the last publisher tick',
+  registers: [metricsRegistry],
+});
+
+/** Set both outbox backlog gauges from one publisher-tick scan. */
+export function recordAiOperatorOutboxBacklog(unpublishedCount: number, oldestAgeSeconds: number): void {
+  outboxUnpublishedGauge.set(unpublishedCount);
+  outboxOldestAgeSecondsGauge.set(oldestAgeSeconds);
+}

--- a/apps/api/src/services/approvals/decideApprovalRequest.ts
+++ b/apps/api/src/services/approvals/decideApprovalRequest.ts
@@ -36,6 +36,7 @@ import { checkToolPermission } from '../aiGuardrails';
 import { loadPartnerPolicy, isEnforcing } from '../authenticatorPolicy';
 import { getUserPermissions, userCanDecideApprovals, canAccessOrg } from '../permissions';
 import { createPamDecisionIntent } from '../pamActuationLifecycle';
+import { publishIntentTerminalOutbox } from '../aiOperator/taskOutbox';
 import type { RiskTier, ApprovalProof } from '@breeze/shared';
 
 /**
@@ -1023,13 +1024,23 @@ export async function decideApprovalRequest(
               // requester whose chat turn had already ended could never be told
               // what happened to it. In the same transaction as the status
               // change, so the record cannot disagree with the decision.
-              if (status === 'approved' || status === 'denied') {
+              if (status === 'approved') {
                 await tx.insert(intentOutbox).values({
                   intentId,
-                  eventType: status === 'approved' ? 'intent_approved' : 'intent_rejected',
+                  eventType: 'intent_approved',
                   // Ids only, no argument content (spec §3.2).
                   payload: { intentId, orgId: linkedIntent.orgId },
                 });
+              } else {
+                // #5205 W05 (#5210): same intentOutbox row this always wrote,
+                // plus (when task-linked) the task_outbox leg —
+                // `linkedIntent.taskId` is the pre-transaction snapshot,
+                // which is safe because task linkage is immutable.
+                await publishIntentTerminalOutbox(
+                  tx,
+                  { id: intentId, orgId: linkedIntent.orgId, taskId: linkedIntent.taskId },
+                  'intent_rejected',
+                );
               }
             }
           }

--- a/apps/api/src/services/workerEntrypointClosure.contract.test.ts
+++ b/apps/api/src/services/workerEntrypointClosure.contract.test.ts
@@ -296,7 +296,7 @@ const EXPECTED_NAMES = [
   'recoveryMediaWorker', 'recoveryBootMediaWorker', 'warrantyWorker', 'ssoDomainRecheckWorker',
   'incidentCorrelationWorker', 'incidentTimelineEnricher', 'incidentSlaMonitor', 'staleCommandReaper',
   'softwareDeploymentScheduler', 'pamJobs', 'approvalExpiryReaper', 'offboardingDrainReaper',
-  'intentOutboxPublisher', 'pamActuationWorker', 'intentExpiryReaper', 'intentReleaseWorker', 'stripeReconcileSweep',
+  'intentOutboxPublisher', 'aiOperatorTaskOutboxPublisher', 'pamActuationWorker', 'intentExpiryReaper', 'intentReleaseWorker', 'stripeReconcileSweep',
   'ticketAttachmentReaper', 'quoteExpiryReaper', 'suppressionExpiryReaper', 'ticketNotifyWorker', 'ticketOutboxPublisher',
   'ticketSlaWorker', 'inboundEmailWorker', 'ticketMailboxPollWorker', 'invoiceWorker',
   'metricAnomalyIncidentPublisher', 'contractWorker', 'aiUnattendedExposureRetention',
@@ -454,7 +454,7 @@ describe('workerEntrypointClosure contract (#4086 Task 5)', () => {
 
   describe('global-placement entries never reach socket-local dispatch', () => {
     const entries = parseRegistrySource();
-    expect(entries.length).toBe(126); // sanity: the source-parsing regex itself must find all 126
+    expect(entries.length).toBe(127); // sanity: the source-parsing regex itself must find all 127
 
     const globalEntries = entries.filter((e) => e.placement === 'global');
     expect(globalEntries.length).toBeGreaterThan(0);

--- a/apps/api/src/services/workerRegistry.test.ts
+++ b/apps/api/src/services/workerRegistry.test.ts
@@ -21,11 +21,12 @@ import {
 // Task 9, #4192; `accountingReconcileWorker`, QuickBooks Phase D Task 4;
 // `ticketOutboxRetention` / `intentOutboxRetention` /
 // `metricAnomalyIncidentRetention`, #4210; `deviceGroupJobs`, dynamic device
-// group re-evaluation, #4630).
+// group re-evaluation, #4630; `aiOperatorTaskOutboxPublisher`, #5205 W05
+// #5210).
 // This list is duplicated here deliberately — the whole point of the test is
 // to catch drift between the plan's documented contract and the actual
 // registry, so it must not import the list from the module under test.
-const EXPECTED_126_NAMES = [
+const EXPECTED_127_NAMES = [
   'alertWorkers', 'alertCorrelationWorker', 'metricRollupsWorker', 'metricRollupMaintenance',
   'metricAnomaliesWorker', 'aiBudgetAlertDeliveryWorker', 'fleetFindingsWorker', 'fleetRemediationDispatchWorker', 'mlOutputRetention',
   'offlineDetector', 'notificationDispatcher', 'webhookDelivery', 'webhookDeliveryRecovery',
@@ -52,7 +53,7 @@ const EXPECTED_126_NAMES = [
   'recoveryMediaWorker', 'recoveryBootMediaWorker', 'warrantyWorker', 'ssoDomainRecheckWorker',
   'incidentCorrelationWorker', 'incidentTimelineEnricher', 'incidentSlaMonitor', 'staleCommandReaper',
   'softwareDeploymentScheduler', 'pamJobs', 'approvalExpiryReaper', 'offboardingDrainReaper',
-  'intentOutboxPublisher', 'pamActuationWorker', 'intentExpiryReaper', 'intentReleaseWorker', 'stripeReconcileSweep',
+  'intentOutboxPublisher', 'aiOperatorTaskOutboxPublisher', 'pamActuationWorker', 'intentExpiryReaper', 'intentReleaseWorker', 'stripeReconcileSweep',
   'ticketAttachmentReaper', 'quoteExpiryReaper', 'suppressionExpiryReaper', 'ticketNotifyWorker', 'ticketOutboxPublisher',
   'ticketSlaWorker', 'inboundEmailWorker', 'ticketMailboxPollWorker', 'invoiceWorker',
   'metricAnomalyIncidentPublisher', 'contractWorker', 'aiUnattendedExposureRetention',
@@ -62,12 +63,12 @@ const EXPECTED_126_NAMES = [
 ];
 
 describe('workerRegistry: losslessness', () => {
-  it('contains exactly the 126 known names, in order', () => {
-    expect(WORKER_REGISTRY.map((e) => e.name)).toEqual(EXPECTED_126_NAMES);
+  it('contains exactly the 127 known names, in order', () => {
+    expect(WORKER_REGISTRY.map((e) => e.name)).toEqual(EXPECTED_127_NAMES);
   });
 
-  it('has exactly 126 entries', () => {
-    expect(WORKER_REGISTRY.length).toBe(126);
+  it('has exactly 127 entries', () => {
+    expect(WORKER_REGISTRY.length).toBe(127);
   });
 
   it('every entry has a well-formed shape', () => {
@@ -87,14 +88,14 @@ describe('workerRegistry: losslessness', () => {
 
 describe('workerRegistry: selectWorkers', () => {
   it("'all' selects every entry", () => {
-    expect(selectWorkers('all').length).toBe(126);
+    expect(selectWorkers('all').length).toBe(127);
     expect(selectWorkers('all')).toEqual(WORKER_REGISTRY);
   });
 
   it("'api' and 'worker' partition the set with no overlap and no loss", () => {
     const api = selectWorkers('api');
     const worker = selectWorkers('worker');
-    expect(api.length + worker.length).toBe(126);
+    expect(api.length + worker.length).toBe(127);
 
     const apiNames = new Set(api.map((e) => e.name));
     const workerNames = new Set(worker.map((e) => e.name));
@@ -102,7 +103,7 @@ describe('workerRegistry: selectWorkers', () => {
       expect(workerNames.has(name)).toBe(false);
     }
     const union = new Set([...apiNames, ...workerNames]);
-    expect(union.size).toBe(126);
+    expect(union.size).toBe(127);
   });
 
   it("'api' selects only socket-owner placements", () => {

--- a/apps/api/src/services/workerRegistry.ts
+++ b/apps/api/src/services/workerRegistry.ts
@@ -980,6 +980,20 @@ export const WORKER_REGISTRY: readonly WorkerRegistration[] = [
     },
   },
   {
+    // #5205 W05 (#5210): drains ai_operator_task_outbox into the
+    // ai-operator-coordinator queue W06's coordinator will consume. Same
+    // placement/precedent as intentOutboxPublisher above.
+    name: 'aiOperatorTaskOutboxPublisher',
+    placement: 'global',
+    load: async () => {
+      const m = await import('../jobs/aiOperatorTaskOutboxPublisher');
+      return {
+        init: m.initializeAiOperatorTaskOutboxPublisher,
+        shutdown: m.shutdownAiOperatorTaskOutboxPublisher,
+      };
+    },
+  },
+  {
     name: 'pamActuationWorker',
     placement: 'global',
     load: async () => {


### PR DESCRIPTION
Closes #5210

W05 of the AI Operator thin slice (#5205). W03 (#5244) shipped `ai_operator_task_outbox`; W04 (#5259) shipped task-scoped intent identity, the dispatch claim, and operation result persistence. This wave makes the durable "the effect finished" wake real: `intent_outbox` gains `intent_completed`/`intent_failed`, every terminal writer baseline §3 enumerates now publishes both the `intent_outbox` row and (when task-linked) the `ai_operator_task_outbox` leg, and a new publisher drains that table into the wake queue W06's coordinator will consume.

## What changed

**1. Event vocabulary (spec §6.3, baseline §3.3).** `intentOutboxEventEnum` gains `intent_completed`/`intent_failed` — the fifth widening of `intent_outbox_event_type_check`. Migration: `apps/api/migrations/2026-10-14-100300-ai-operator-intent-terminal-events.sql`, DDL only, idempotent (DROP IF EXISTS + re-ADD).

**2. `taskOutbox.ts` — the one helper every writer calls.** `enqueueTaskOutbox(dbh, {...})` inserts into `ai_operator_task_outbox` with `ON CONFLICT DO NOTHING` on the identity unique (`org_id, task_id, source_kind, source_id, transition_seq`) — the dedupe contract spec §6.3 asks for. `publishIntentTerminalOutbox(dbh, intent, event)` is the combo every intent terminal writer calls: an unconditional `intent_outbox` row (ids-only payload, matching every existing writer's shape) plus, only when `intent.taskId` is set, the task_outbox leg. `transitionSeq` uses a fixed per-event ordinal (`INTENT_TERMINAL_OUTBOX_TRANSITION_SEQ`) — documented rationale: `action_intents.status` reaches at most one terminal value ever, so the ordinals only need to be mutually distinct, not a running counter.

**3. Every task-linked-reachable terminal writer now publishes both legs**, in the same transaction as the terminal status write:
- `intentReleaseWorker.terminalizeIntent` (completed/failed) — exported for testability, wired inside the same `withSystemDbAccessContext` block as the CAS so both commit atomically.
- `intentExpiryReaper.reapExpiredIntents` (expired) and `reapStaleExecutingIntents` (failed) — the latter was one of C18's two silent gaps (published nothing at all before this wave).
- `decideApprovalRequest` human denial (rejected).
- `routes/approvals.ts` report-suspicious (rejected) — the other C18 gap.
- `intentService.cancelActionIntent` (cancelled).
- `intentService.runHumanFanout`'s fail-closed no-eligible-approvers cancel — reachable by a task-linked intent because `reserveOperation` runs earlier in the same creation transaction; also now calls `markOperationCancelled` for consistency with the other cancel path.

**4. `aiAgentSdk.ts`'s five inline terminal call sites now publish `intent_outbox` unconditionally** via a small `transitionIntentAndPublish` wrapper, matching spec §6.3's explicit "inline SDK path" requirement. The `task_outbox` leg is intentionally never attempted there: every intent this file transitions was created by its own `createActionIntent(session.auth, {...})` call, which never threads a `task` context through (task-linked admission is a durable-worker-only path in the thin slice — spec P3-1: "supervised mode only... no direct act"), so `taskId` is provably always `null` at these sites.

**5. `aiOperatorTaskOutboxPublisher.ts`.** Three-phase claim/enqueue/mark-published, mirroring `intentOutboxPublisher.ts`'s shape: claims up to 50 rows (`published_at IS NULL`, `ORDER BY due_at, id`, `FOR UPDATE SKIP LOCKED`) under `withSystemDbAccessContext` (documented why: the table is Shape-1 org-scoped RLS, unlike `intent_outbox`'s `INTENTIONAL_UNSCOPED` shape, so a system-wide drain needs system scope), enqueues one `ai-operator-coordinator` job per row outside any DB context (#1105), marks published. Job data carries the typed reference only (`{ orgId, taskId, sourceKind, sourceId, transitionSeq }`), never a payload. 5s tick, deliberately outside `scheduleRegistry`. Registers `ai_operator_outbox_unpublished` and `ai_operator_outbox_oldest_age_seconds` gauges (new leaf module `aiOperatorOutboxMetrics.ts`, same pattern as `scriptCancellationMetrics.ts`). Registered in `workerRegistry.ts` (`placement: 'global'`) and `workerReadinessManifest.ts`.

**6. Writer contract test.** `aiOperatorTerminalWriters.integration.test.ts` drives the REAL functions (never a re-implementation) against real Postgres for all 8 task-linked-reachable writers, asserting: the intent reaches the expected terminal status; exactly one `intent_outbox` row with the matching event; exactly one `ai_operator_task_outbox` row with the correct `transitionSeq`; and that redelivering the same terminalization does not create a second task_outbox row.

## Not covered / deliberately out of scope

- `aiAgentSdk.ts`'s 5 sites are **not** in the writer contract test's task-linked assertions — they are structurally unreachable by a task-linked intent (see point 4). Their `intent_outbox`-only publication is proven by `aiAgentSdk.test.ts`'s `transitionIntentAndPublish` wiring and by `taskOutbox.test.ts`'s unit coverage of the underlying helper.
- No export-policy changes: this wave adds no new columns to any `CORE_ORG_CASCADE_DELETE_ORDER` table, only widens an existing CHECK on `intent_outbox` (not a cascade-registered table).
- The coordinator consumer, run terminalization wakes, and the reconciler are W06's job — not built here. `intentReleaseWorker.ts`'s BullMQ job dispatch is unmodified: `intent_completed`/`intent_failed` events land in the `action-intents` queue and fall through `processIntentReleaseJob`'s existing `if (data.eventType !== 'intent_approved') return { released: false }` guard as a harmless no-op (verified — no new routing added).

## Migration

`apps/api/migrations/2026-10-14-100300-ai-operator-intent-terminal-events.sql`. Named past both `2026-10-14-100200-ai-operator-intent-identity.sql` (W04) and `2026-10-14-100200-device-warranty-manual-asset-subject.sql` (unrelated same-day migration) after the pre-commit guard flagged the first attempt (`2026-10-14-100200-...-terminal-events.sql` sorted before the warranty migration). `scripts/check-migration-naming.sh --against-ref origin/main` passes.

## Verification

All commands run from `apps/api`, node 22.23.2.

| Command | Result |
|---|---|
| `npx tsc --noEmit` (NODE_OPTIONS=--max-old-space-size=8192) | clean |
| `npx eslint <every touched file>` | clean |
| `npx vitest run src/jobs/intentReleaseWorker.test.ts src/jobs/intentExpiryReaper.test.ts src/jobs/intentReleaseWorker.durable.contract.test.ts` | 3 files, 168 passed |
| `npx vitest run src/services/actionIntents/intentService.test.ts src/services/actionIntents/intentService.scope.test.ts src/services/actionIntents/intentService.tier2Agent.test.ts src/services/actionIntents/intentService.ticketAutonomy.test.ts` | 4 files, 151 passed |
| `npx vitest run src/routes/approvals.test.ts` | 113 passed |
| `npx vitest run src/services/approvals/batchDecide.test.ts` | 26 passed |
| `npx vitest run src/services/aiAgentSdk*.test.ts src/services/aiAgentSdkTools*.test.ts` (14 files) | 254 passed |
| `npx vitest run src/db/autoMigrate.test.ts src/db/migrationRlsScope.test.ts src/db/migration-action-intents.test.ts` | 3 files, 116 passed |
| `npx vitest run src/db/schema/actionIntents.test.ts src/db/schema/ticketOutbox.test.ts` | 26 passed |
| `npx vitest run src/services/workerRegistry.test.ts src/jobs/workerReadinessManifest.test.ts src/jobs/workerReadinessCoverage.test.ts src/services/workerReadinessRegistry.test.ts` | 70 passed |
| `npx vitest run src/services/workerEntrypointClosure.contract.test.ts` | 106 passed |
| `npx vitest run src/jobs/queueSchemas.test.ts src/jobs/queueSchemas.eventEnvelope.types.test.ts` | 55 passed |
| `npx vitest run src/services/aiOperator/taskOutbox.test.ts` (new) | 5 passed |
| `npx vitest run src/jobs/aiOperatorTaskOutboxPublisher.test.ts` (new) | 4 passed |
| `--config vitest.integration.config.ts` `aiOperatorTerminalWriters.integration.test.ts` (new) + `intentExpiryReaper.integration.test.ts` + `tenant-export-policy` + `tenantExportErasureRoundtrip` + `tenantCascade` + `createIntentAtomicity` + `actionIntentsImmutabilityTrigger` | 7 files, 73 passed |
| `--config vitest.config.rls-coverage.ts` | 102 passed |
| `npx vitest run --pool=threads --maxWorkers=2` (full apps/api unit suite) | 1963 files, 37010 passed, 6 pre-existing failures unrelated to this PR (contractRenewal/contractWorker ECONNREFUSED to a different local Postgres port; webhookSender DNS/HTTPS validation) |
| `pnpm db:check-drift` | clean — 707 migrations match the ledger |
| `scripts/check-migration-naming.sh --against-ref origin/main` | OK |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LqkKRXSbjNJuCi4VJBHtym