### PR TITLE
fix(web): keep the network-asset modal mounted across the post-create refresh (#5265)

### DIFF
--- a/apps/web/src/components/devices/DevicesPage.postCreateHandoff.test.tsx
+++ b/apps/web/src/components/devices/DevicesPage.postCreateHandoff.test.tsx
@@ -6,7 +6,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import DevicesPage from './DevicesPage';
 import { fetchWithAuth } from '../../stores/auth';
-import { fetchAllDevices, fetchAllNetworkDevices } from '../../lib/devicesFetch';
+import { fetchAllDevices, fetchAllNetworkDevices, fetchAllManualAssets } from '../../lib/devicesFetch';
 
 // #5265 — regression for "post-create HTTP-check hand-off panel never
 // renders". Root cause: AddNetworkAssetModal.onCreated triggers
@@ -36,6 +36,7 @@ vi.mock('../../stores/auth', () => ({
 vi.mock('../../lib/devicesFetch', () => ({
   fetchAllDevices: vi.fn(),
   fetchAllNetworkDevices: vi.fn(),
+  fetchAllManualAssets: vi.fn(),
 }));
 
 vi.mock('../../hooks/useEventStream', () => ({
@@ -104,6 +105,7 @@ vi.mock('./filterUrl', () => ({
 vi.mock('./ScriptPickerModal', () => ({ default: () => null }));
 vi.mock('./DeviceSettingsModal', () => ({ default: () => null }));
 vi.mock('./AddDeviceModal', () => ({ default: () => null }));
+vi.mock('./ManualAssetModal', () => ({ default: () => null }));
 vi.mock('./CreateGroupModal', () => ({ default: () => null }));
 vi.mock('../filters/DeviceFilterBar', () => ({ DeviceFilterBar: () => null }));
 vi.mock('./DeviceFilterToolbar', () => ({ DeviceFilterToolbar: () => null }));
@@ -169,6 +171,8 @@ beforeEach(() => {
   window.location.hash = '';
 
   vi.mocked(fetchAllNetworkDevices).mockResolvedValue({ data: [], total: 0, pagesWalked: 1 } as never);
+  // W04 (#4622) added the manual arm; without this the page's Promise.all rejects into the error branch.
+  vi.mocked(fetchAllManualAssets).mockResolvedValue({ data: [], total: 0, pagesWalked: 1 } as never);
   vi.mocked(fetchWithAuth).mockImplementation(async () => jsonResponse({ data: [] }));
 });
 

--- a/apps/web/src/components/devices/DevicesPage.postCreateHandoff.test.tsx
+++ b/apps/web/src/components/devices/DevicesPage.postCreateHandoff.test.tsx
@@ -1,0 +1,215 @@
+import '@/lib/i18n';
+
+import { useState } from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import DevicesPage from './DevicesPage';
+import { fetchWithAuth } from '../../stores/auth';
+import { fetchAllDevices, fetchAllNetworkDevices } from '../../lib/devicesFetch';
+
+// #5265 — regression for "post-create HTTP-check hand-off panel never
+// renders". Root cause: AddNetworkAssetModal.onCreated triggers
+// DevicesPage.refreshDevices(), which flips `loading` back to true; every
+// render branch in DevicesPage used to be a SEPARATE `return`, so the
+// `loading` branch rendered a skeleton WITHOUT mounting <AddNetworkAssetModal>
+// at all — unmounting the real modal and resetting its internal
+// `createdAsset` state to null the instant the hand-off panel
+// (`data-testid="asset-post-create"`) was supposed to appear.
+//
+// This suite does not exercise the real AddNetworkAssetModal (that lives in
+// AddNetworkAssetModal.test.tsx) — it stands in a stateful fake in its place
+// so a remount is observable: the fake's own `created` state can only survive
+// a `loading` flip if the SAME component instance stays mounted, exactly the
+// property DevicesPage.tsx must now guarantee.
+
+const flagState = vi.hoisted(() => ({
+  ENABLE_NETWORK_DEVICES_IN_LIST: false,
+  ENABLE_ENDPOINT_AV_FEATURES: false,
+}));
+vi.mock('@/lib/featureFlags', () => flagState);
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+vi.mock('../../lib/devicesFetch', () => ({
+  fetchAllDevices: vi.fn(),
+  fetchAllNetworkDevices: vi.fn(),
+}));
+
+vi.mock('../../hooks/useEventStream', () => ({
+  useEventStream: () => ({ subscribe: vi.fn() }),
+}));
+
+vi.mock('../../services/deviceActions', () => ({
+  sendDeviceCommand: vi.fn(),
+  sendBulkCommand: vi.fn(),
+  executeScript: vi.fn(),
+  exitMaintenanceMode: vi.fn(),
+  decommissionDevice: vi.fn(),
+  bulkDecommissionDevices: vi.fn(),
+  restoreDevice: vi.fn(),
+  permanentDeleteDevice: vi.fn(),
+  sendWakeCommand: vi.fn(),
+  sendBulkWakeCommand: vi.fn(),
+  summarizeBulkWakeFailures: vi.fn(() => ''),
+  summarizeBulkCommandFailures: vi.fn(() => ''),
+  watchWakeOutcome: vi.fn(),
+  WakeCommandError: class WakeCommandError extends Error { code = 'x'; },
+  wakeFriendlyErrorMessage: vi.fn(() => null),
+  linkDevicesMultiboot: vi.fn(),
+  linkDevicesVmHost: vi.fn(),
+  fetchRemovalConfig: vi.fn(async () => ({ uninstallDrainWindowHours: 72 })),
+  bulkRestoreDevices: vi.fn(),
+  startBulkPurge: vi.fn(),
+  fetchPurgeRun: vi.fn(),
+  PURGE_POLL_INTERVAL_MS: 2000,
+  BulkPurgeRejectedError: class BulkPurgeRejectedError extends Error {
+    rejected: unknown[] = [];
+  },
+}));
+
+vi.mock('@/lib/navigation', () => ({
+  navigateTo: vi.fn(),
+}));
+
+vi.mock('../shared/Toast', () => ({
+  showToast: vi.fn(),
+}));
+
+const orgStoreState = vi.hoisted(() => ({
+  currentOrgId: null as string | null,
+  currentPartnerId: null as string | null,
+  allOrgs: true,
+  lastOrgId: null as string | null,
+  organizations: [] as Array<{ id: string; name: string }>,
+  organizationsLoaded: true,
+  error: null as string | null,
+}));
+vi.mock('../../stores/orgStore', () => ({
+  useOrgStore: Object.assign(
+    (selector?: (s: typeof orgStoreState) => unknown) =>
+      selector ? selector(orgStoreState) : orgStoreState,
+    { getState: () => orgStoreState }
+  )
+}));
+
+vi.mock('./filterUrl', () => ({
+  decodeFilterFromHash: vi.fn(() => undefined),
+  writeFilterToHash: vi.fn(),
+  isFiltersV2Enabled: vi.fn(() => false),
+}));
+
+vi.mock('./ScriptPickerModal', () => ({ default: () => null }));
+vi.mock('./DeviceSettingsModal', () => ({ default: () => null }));
+vi.mock('./AddDeviceModal', () => ({ default: () => null }));
+vi.mock('./CreateGroupModal', () => ({ default: () => null }));
+vi.mock('../filters/DeviceFilterBar', () => ({ DeviceFilterBar: () => null }));
+vi.mock('./DeviceFilterToolbar', () => ({ DeviceFilterToolbar: () => null }));
+vi.mock('../shared/ProgressBar', () => ({ default: () => null }));
+vi.mock('./DeviceCard', () => ({ default: () => null }));
+vi.mock('./DeviceList', () => ({
+  default: () => <div data-testid="device-list" />,
+}));
+
+// The stateful fake at the center of this test — see file header.
+vi.mock('./AddNetworkAssetModal', () => ({
+  default: ({
+    isOpen,
+    onCreated,
+  }: {
+    isOpen: boolean;
+    onClose: () => void;
+    onCreated?: (assetId: string) => void;
+  }) => {
+    const [created, setCreated] = useState(false);
+    if (!isOpen) return null;
+    if (created) {
+      return <div data-testid="asset-post-create">hand-off panel</div>;
+    }
+    return (
+      <button
+        type="button"
+        data-testid="fake-asset-create"
+        onClick={() => {
+          setCreated(true);
+          onCreated?.('asset-1');
+        }}
+      >
+        create
+      </button>
+    );
+  },
+}));
+
+const DEV_1 = '11111111-1111-1111-1111-111111111111';
+
+function rawDevice(id: string, hostname: string) {
+  return {
+    id,
+    hostname,
+    osType: 'windows',
+    osVersion: '11',
+    status: 'online',
+    lastSeenAt: new Date().toISOString(),
+    orgId: 'org-1',
+    siteId: 'site-1',
+    agentVersion: '0.68.0',
+    tags: [],
+  };
+}
+
+function jsonResponse(payload: unknown) {
+  return { ok: true, json: async () => payload } as unknown as Response;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.location.hash = '';
+
+  vi.mocked(fetchAllNetworkDevices).mockResolvedValue({ data: [], total: 0, pagesWalked: 1 } as never);
+  vi.mocked(fetchWithAuth).mockImplementation(async () => jsonResponse({ data: [] }));
+});
+
+describe('DevicesPage — post-create hand-off survives the refresh (#5265)', () => {
+  it('keeps the network-asset modal mounted (and its hand-off panel visible) when refreshDevices() flips the page back into loading', async () => {
+    vi.mocked(fetchAllDevices).mockResolvedValueOnce({
+      data: [rawDevice(DEV_1, 'host-alpha')],
+    } as never);
+
+    render(<DevicesPage />);
+    await screen.findByTestId('device-list');
+
+    // Open the "Add network asset" modal the same way the header split menu does.
+    fireEvent.click(screen.getByTestId('devices-page-add-menu-trigger'));
+    fireEvent.click(screen.getByTestId('devices-page-add-menu-network-asset'));
+
+    const createButton = await screen.findByTestId('fake-asset-create');
+
+    // The post-create refresh's fetchAllDevices call never resolves during
+    // this test, so DevicesPage stays in its `loading` branch — exactly the
+    // window in which the bug unmounted the modal.
+    type DevicesResult = Awaited<ReturnType<typeof fetchAllDevices>>;
+    let resolveRefresh!: (value: DevicesResult) => void;
+    vi.mocked(fetchAllDevices).mockImplementationOnce(
+      () => new Promise<DevicesResult>((resolve) => { resolveRefresh = resolve; })
+    );
+
+    fireEvent.click(createButton);
+
+    // Confirm we are actually in the `loading` branch (the device list is
+    // gone), not merely that the refresh resolved instantly.
+    await waitFor(() => expect(screen.queryByTestId('device-list')).toBeNull());
+
+    // The hand-off panel must still be on screen — this is the assertion
+    // that fails on unfixed DevicesPage.tsx (the modal remounts and its
+    // `created` state resets to false).
+    expect(screen.getByTestId('asset-post-create')).toBeTruthy();
+
+    // Let the pending refresh resolve so the test doesn't leak a dangling
+    // promise/act warning.
+    resolveRefresh({ data: [rawDevice(DEV_1, 'host-alpha')], pagesWalked: 1 } as DevicesResult);
+    await screen.findByTestId('device-list');
+  });
+});

--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -1697,7 +1697,7 @@ export default function DevicesPage() {
   // into a Fragment that wraps EVERY branch — always at the same child
   // position — keeps it mounted across the refresh; only the second child
   // (skeleton / error / real content) swaps out underneath it. Covered by
-  // DevicesPage.test.tsx ("keeps the network-asset modal mounted...").
+  // DevicesPage.postCreateHandoff.test.tsx ("keeps the network-asset modal mounted...").
   const addNetworkAssetModal = (
     <AddNetworkAssetModal
       isOpen={showAddNetworkAsset}

--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -1686,75 +1686,116 @@ export default function DevicesPage() {
   // and MonitoringAssetsDashboard. Only reachable when there is NO selection at
   // all: deriveOrgScope gives a concrete currentOrgId precedence over a later
   // refetch failure, so a warm session keeps working.
+  // #5265: AddNetworkAssetModal's post-create hand-off panel
+  // (data-testid="asset-post-create") lets a tech add an HTTP check right
+  // after creating the asset. onCreated fires refreshDevices(), which flips
+  // `loading` back to true — and every branch below is a SEPARATE `return`,
+  // so if the modal were only rendered inside the final (non-loading) branch,
+  // that `loading` flip would unmount it along with everything else,
+  // resetting AddNetworkAssetModal's internal `createdAsset` state to null
+  // and losing the hand-off panel the tech was just shown. Hoisting the modal
+  // into a Fragment that wraps EVERY branch — always at the same child
+  // position — keeps it mounted across the refresh; only the second child
+  // (skeleton / error / real content) swaps out underneath it. Covered by
+  // DevicesPage.test.tsx ("keeps the network-asset modal mounted...").
+  const addNetworkAssetModal = (
+    <AddNetworkAssetModal
+      isOpen={showAddNetworkAsset}
+      onClose={() => {
+        window.location.hash = '';
+        setShowAddNetworkAsset(false);
+      }}
+      onCreated={() => { void refreshDevices(); }}
+    />
+  );
+
   if (orgContextFailed) {
-    return <OrgLoadFailedState error={orgScope.error} />;
+    return (
+      <>
+        {addNetworkAssetModal}
+        <OrgLoadFailedState error={orgScope.error} />
+      </>
+    );
   }
 
   if (loading) {
     return (
-      <div className="space-y-6">
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <div className="h-6 w-32 rounded bg-muted animate-pulse mb-2" />
-            <div className="h-4 w-48 rounded bg-muted animate-pulse" />
+      <>
+        {addNetworkAssetModal}
+        <div className="space-y-6">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <div className="h-6 w-32 rounded bg-muted animate-pulse mb-2" />
+              <div className="h-4 w-48 rounded bg-muted animate-pulse" />
+            </div>
+            <div className="flex items-center gap-3">
+              <div className="h-10 w-20 rounded-md bg-muted animate-pulse" />
+              <div className="h-10 w-28 rounded-md bg-muted animate-pulse" />
+            </div>
           </div>
-          <div className="flex items-center gap-3">
-            <div className="h-10 w-20 rounded-md bg-muted animate-pulse" />
-            <div className="h-10 w-28 rounded-md bg-muted animate-pulse" />
+          <div className="rounded-lg border bg-card p-6 shadow-xs">
+            <div className="flex items-center justify-between mb-6">
+              <div className="h-5 w-20 rounded bg-muted animate-pulse" />
+              <div className="h-10 w-56 rounded-md bg-muted animate-pulse" />
+            </div>
+            <div className="space-y-0 divide-y">
+              {[1, 2, 3, 4, 5].map(i => (
+                <div key={i} className="flex items-center gap-4 py-3">
+                  <div className="h-4 w-4 rounded bg-muted animate-pulse" />
+                  <div className="h-4 w-40 rounded bg-muted animate-pulse" />
+                  <div className="h-4 w-20 rounded bg-muted animate-pulse" />
+                  <div className="h-4 w-16 rounded bg-muted animate-pulse" />
+                  <div className="hidden md:block h-4 w-16 rounded bg-muted animate-pulse" />
+                  <div className="hidden md:block h-4 w-16 rounded bg-muted animate-pulse" />
+                  <div className="h-4 w-20 rounded bg-muted animate-pulse" />
+                </div>
+              ))}
+            </div>
           </div>
         </div>
-        <div className="rounded-lg border bg-card p-6 shadow-xs">
-          <div className="flex items-center justify-between mb-6">
-            <div className="h-5 w-20 rounded bg-muted animate-pulse" />
-            <div className="h-10 w-56 rounded-md bg-muted animate-pulse" />
-          </div>
-          <div className="space-y-0 divide-y">
-            {[1, 2, 3, 4, 5].map(i => (
-              <div key={i} className="flex items-center gap-4 py-3">
-                <div className="h-4 w-4 rounded bg-muted animate-pulse" />
-                <div className="h-4 w-40 rounded bg-muted animate-pulse" />
-                <div className="h-4 w-20 rounded bg-muted animate-pulse" />
-                <div className="h-4 w-16 rounded bg-muted animate-pulse" />
-                <div className="hidden md:block h-4 w-16 rounded bg-muted animate-pulse" />
-                <div className="hidden md:block h-4 w-16 rounded bg-muted animate-pulse" />
-                <div className="h-4 w-20 rounded bg-muted animate-pulse" />
-              </div>
-            ))}
-          </div>
-        </div>
-      </div>
+      </>
     );
   }
 
   // A 403 is a permission denial, not a transient load failure — render the
   // access-denied state (no misleading "session expired / try again" UI).
   if (error && isAccessDenied(error)) {
-    return <AccessDenied message={t('devicesPage.accessDenied')} />;
+    return (
+      <>
+        {addNetworkAssetModal}
+        <AccessDenied message={t('devicesPage.accessDenied')} />
+      </>
+    );
   }
 
   if (error) {
     return (
-      <div className="rounded-lg border bg-card p-6">
-        <div className="flex flex-col items-center justify-center py-12 text-center">
-          <div className="rounded-full bg-destructive/10 p-3 mb-3">
-            <AlertCircle className="h-5 w-5 text-destructive" />
+      <>
+        {addNetworkAssetModal}
+        <div className="rounded-lg border bg-card p-6">
+          <div className="flex flex-col items-center justify-center py-12 text-center">
+            <div className="rounded-full bg-destructive/10 p-3 mb-3">
+              <AlertCircle className="h-5 w-5 text-destructive" />
+            </div>
+            <p className="text-sm font-medium text-foreground mb-1">{getErrorTitle(error)}</p>
+            <p className="text-xs text-muted-foreground mb-3">{getErrorMessage(error)}</p>
+            <button
+              type="button"
+              onClick={() => void refreshDevices()}
+              className="text-xs font-medium text-primary hover:underline"
+            >
+              {t('devicesPage.tryAgain')}
+            </button>
           </div>
-          <p className="text-sm font-medium text-foreground mb-1">{getErrorTitle(error)}</p>
-          <p className="text-xs text-muted-foreground mb-3">{getErrorMessage(error)}</p>
-          <button
-            type="button"
-            onClick={() => void refreshDevices()}
-            className="text-xs font-medium text-primary hover:underline"
-          >
-            {t('devicesPage.tryAgain')}
-          </button>
         </div>
-      </div>
+      </>
     );
   }
 
   return (
-    <div className="space-y-6">
+    <>
+      {addNetworkAssetModal}
+      <div className="space-y-6">
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h1 className="text-xl font-semibold tracking-tight">{t('devicesPage.title')}</h1>
@@ -2026,14 +2067,6 @@ export default function DevicesPage() {
       )}
 
       <AddDeviceModal isOpen={showAddDevice} onClose={() => setShowAddDevice(false)} />
-      <AddNetworkAssetModal
-        isOpen={showAddNetworkAsset}
-        onClose={() => {
-          window.location.hash = '';
-          setShowAddNetworkAsset(false);
-        }}
-        onCreated={() => { void refreshDevices(); }}
-      />
 
       {showRmmImport && (
         <RmmCustomFieldImport
@@ -2238,6 +2271,7 @@ export default function DevicesPage() {
           onAction={handleDeviceAction}
         />
       )}
-    </div>
+      </div>
+    </>
   );
 }

--- a/e2e-tests/tests/manual-network-asset.spec.ts
+++ b/e2e-tests/tests/manual-network-asset.spec.ts
@@ -24,6 +24,22 @@ test.describe('manual network asset — website target', () => {
     const label = `E2E Shop ${Date.now()}`;
     const url = `https://shop-${Date.now()}.example`;
 
+    // The 'source' column is opt-in (columnVisibility.ts DEFAULT_VISIBLE_COLUMNS
+    // deliberately excludes it — agent rows have no source, so default-on would
+    // show a column of dashes for the common agent-only fleet). The Columns menu
+    // that toggles it carries no data-testid (out of this wave's file-ownership
+    // scope — see the header comment above), so seed the persisted preference
+    // directly instead of driving that menu with a brittle non-testid selector.
+    // A single-entry list still gets every OTHER column its own catalog default
+    // via columnVisibility.ts's merge-on-read, so this only adds 'source' — it
+    // doesn't touch any other column's visibility.
+    await authedPage.addInitScript(() => {
+      window.localStorage.setItem(
+        'breeze.devices.columns',
+        JSON.stringify({ v: 1, columns: [{ id: 'source', visible: true }] }),
+      );
+    });
+
     await authedPage.goto('/devices');
     await authedPage.getByTestId('devices-page-add-menu-trigger').waitFor();
     await authedPage.getByTestId('devices-page-add-menu-trigger').click();


### PR DESCRIPTION
## Root cause

`AddNetworkAssetModal.onCreated` calls `DevicesPage.refreshDevices()`, which flips `loading` back to `true`. Every DevicesPage render branch (org-context-failed, loading, access-denied, error, main) was a **separate `return`**, so the loading skeleton unmounted `<AddNetworkAssetModal>` entirely instead of swapping only the content underneath it — resetting the modal's internal `createdAsset` state to `null` the instant the post-create HTTP-check hand-off panel (`data-testid="asset-post-create"`) was supposed to appear.

## Fix

Hoisted `<AddNetworkAssetModal>` into a `Fragment` that wraps **every** branch, always as the first child at the same tree position, so React preserves the component instance across the `loading` transition — only the second child (skeleton / error state / real content) swaps out underneath it. This is the "move the modal above the early return" shape from the issue's proposed fix, chosen over restructuring the loading skeleton into the page body (would have required guarding a much larger swath of JSX across four branches) and over lifting `createdAsset` into page state (would have duplicated state the modal already owns correctly — the bug is only that DevicesPage discards the component, not that the state model is wrong).

Also fixed `e2e-tests/tests/manual-network-asset.spec.ts`: its final assertion checks a `device-<id>-source` cell, but `source` is an opt-in column (`columnVisibility.ts`) that predates this fix branch — the opt-in decision shipped in W02 (#5258), two commits before the spec was added in W03 (#5260), so the assertion was inconsistent with the shipped default from the start and unrelated to the #5265 bug itself. Seeded the persisted column-visibility preference via `addInitScript` (the Columns menu that would toggle it in the UI carries no `data-testid`, out of that wave's file-ownership scope) rather than touch that menu.

## Test evidence

- **New regression test** (`DevicesPage.postCreateHandoff.test.tsx`): reproduces the exact remount via a stateful fake `AddNetworkAssetModal` whose internal `created` flag can only survive a `loading` flip if the real component instance stays mounted. Verified **red** against the pre-fix `DevicesPage.tsx` (panel disappears), **green** after.
- `apps/web` full suite: **828 files / 9311 tests passed**.
- `npx tsc --noEmit -p .`: clean.
- **E2E** (`e2e-tests/tests/manual-network-asset.spec.ts`) against a fresh `worktree-stack`: first run confirmed the actual #5265 behavior — hand-off panel appeared and survived the create → refresh flow correctly — but failed on the unrelated pre-existing `source`-column gap described above. After the spec fix, re-ran end-to-end: **1 passed**, including that final assertion.

Closes #5265
Refs #5228

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTMowR8XgvbgZakWhtbiDv