### PR TITLE
test(web): deflake the NetworkDeviceDetailPage identical-live-region test

### DIFF
--- a/apps/web/src/components/devices/NetworkDeviceDetailPage.test.tsx
+++ b/apps/web/src/components/devices/NetworkDeviceDetailPage.test.tsx
@@ -1475,7 +1475,14 @@ describe('NetworkDeviceDetailPage', () => {
       fireEvent.click(screen.getByTestId('proxy-popover-connect'));
 
       await waitFor(() => expect(mutationCount).toBeGreaterThan(0));
-      expect(screen.getByTestId('network-detail-live').textContent).toBe('Web UI opened in a new tab');
+      // announce() clears the region synchronously and re-sets the message on
+      // a 0ms timer, so the first observed mutation is the CLEAR. Reading the
+      // text synchronously here raced that timer and read '' under CI load
+      // (reddened a main run on 2026-09-08) — wait for the re-set instead.
+      await waitFor(() => expect(liveRegion.textContent).toBe('Web UI opened in a new tab'));
+      // Two mutations = clear + re-set: proves the repeat was a real DOM change,
+      // not a bailed-out no-op state update.
+      expect(mutationCount).toBeGreaterThanOrEqual(2);
 
       observer.disconnect();
       openSpy.mockRestore();


### PR DESCRIPTION
## Summary
- `announce()` clears the live region synchronously and re-sets it on a 0ms timer, so the first observed mutation is the clear. The "re-announces an identical live-region message" test read the text synchronously after the first mutation and raced the timer — it reddened a main run on 2026-09-08 (run 34181434792) with `expected '' to be 'Web UI opened in a new tab'`.
- Now waits for the re-set and asserts ≥2 mutations, so the test still proves the repeat was a real DOM change (the #reviewFix8 intent), without the race.

## Verification
- Slowed the hook's timer to 80ms locally: old assertion reproduces the exact CI error, new assertion passes. Probe reverted.
- 3/3 green at the real timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGT9BJVfpG3nyM6c9koAN8