### PR TITLE
docs(monitoring): Monitoring & Automation unification design spec (#4984)

### DIFF
--- a/docs/superpowers/plans/monitoring/2026-09-08-monitoring-automation-unification-01-discoverability.md
+++ b/docs/superpowers/plans/monitoring/2026-09-08-monitoring-automation-unification-01-discoverability.md
@@ -1,0 +1,680 @@
+---
+tracking_issue: LanternOps/breeze#5287
+wave_issue: LanternOps/breeze#5288
+branch: feature/5287-monitoring-automation-unification/wave-5288
+---
+
+# Monitoring & Automation Unification — W01 Discoverability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give Automations a left-nav home as **Jobs** (`/jobs`, with trigger-type tabs) and turn the "Network Monitor" nav entry into the **Monitoring** hub (Network + Delivery tabs), without touching the database or any API.
+
+**Architecture:** Pure web wave. New `/jobs/*` Astro pages render the existing `AutomationsPage` / `AutomationEditPage`; the old `/automations/*` pages become 301 redirects. `AutomationsPage` gains hash tabs that drive `AutomationList`'s trigger filter as a controlled prop. A new path-based `MonitoringTabStrip` (copy of `AlertsTabStrip`) sits above the existing network `MonitoringPage` and above a new `/monitoring/delivery` page that hosts `NotificationChannelsPage`. Two nav entries change in `Sidebar.tsx`; locale keys are added to all eight locales.
+
+**Tech Stack:** Astro pages + React islands, react-i18next (8 locales, parity test), `useHashTab` from `@/lib/useHashState`, Vitest + jsdom + Testing Library.
+
+**Spec:** `docs/superpowers/specs/monitoring/2026-09-08-monitoring-automation-unification-design.md` (§Navigation and web, §Waves W1)
+
+**Tracking:** feature LanternOps/breeze#5287, wave #5288. Branch `feature/5287-monitoring-automation-unification/wave-5288`.
+
+## Global Constraints
+
+- **No schema, no API changes.** Only `apps/web/**` and `apps/docs/**`.
+- Nav item `name` must equal its English label (`Sidebar.nav.test.tsx:212` asserts `i18n.t(labelKey, { lng: 'en' }) === item.name`).
+- Every new locale key exists in all 8 locale dirs (`de-DE, en, es-419, fr-CA, fr-FR, it-IT, pt-BR, tr-TR`) or `apps/web/src/lib/i18n/localeParity.test.ts` fails. Translations are given in each task; do not leave English in non-English files.
+- Keep `nav.networkMonitor` as a key (other code may reference it); the Sidebar simply stops using it.
+- `/monitoring` keeps rendering the network page in this wave. The Monitors tab arrives in W02; this wave does **not** add placeholder tabs.
+- Hash state for tabs (`window.location.hash`), never query params (CLAUDE.md URL-state rule). The Monitoring strip is **path**-based (like `AlertsTabStrip`) because the network `MonitoringPage` already owns the hash for its own tabs.
+- Redirects are `Astro.redirect(target, 301)` in the page frontmatter (pattern: `apps/web/src/pages/alerts/rules/index.astro`).
+- Deviation from the spec recorded here: the Jobs tabs are `all | scheduled | on-demand | webhooks | event-rules` (an `all` default so nothing is hidden on first visit); `#history` is not a tab — run history stays the per-row modal.
+- Every task: red test first, `pnpm --filter @breeze/web test --run <file>` (no `--` before `--run`), commit. Before the PR: `pnpm --filter @breeze/web lint`, the locale parity and Sidebar suites, and `pnpm --filter @breeze/web build`.
+
+---
+
+### Task 1: Sidebar — add Jobs, rename Network Monitor to Monitoring, locale keys
+
+**Files:**
+- Modify: `apps/web/src/components/layout/Sidebar.tsx:192-200` (top-level nav), `:256` (fleet-management item), `:430-433` (`pathAliases`)
+- Modify: `apps/web/src/locales/{de-DE,en,es-419,fr-CA,fr-FR,it-IT,pt-BR,tr-TR}/common.json` (`nav` block)
+- Test: `apps/web/src/components/layout/Sidebar.nav.test.tsx`
+
+**Interfaces:**
+- Produces: nav hrefs `/jobs` (top-level, after `/scripts`) and `/monitoring` (fleet-management, label "Monitoring"); `pathAliases['/monitoring/delivery'] = '/monitoring'`.
+
+- [ ] **Step 1: Write the failing tests** (append to the `navSections structure` describe in `Sidebar.nav.test.tsx`)
+
+```tsx
+  it('exposes Jobs at top level right after Scripts (#5288)', () => {
+    const hrefs = topLevelNav.map((i) => i.href);
+    expect(hrefs.indexOf('/jobs')).toBe(hrefs.indexOf('/scripts') + 1);
+    const jobs = topLevelNav.find((i) => i.href === '/jobs')!;
+    expect(jobs.name).toBe('Jobs');
+    expect(jobs.labelKey).toBe('nav.jobs');
+    expect(jobs.requiredPermission).toEqual({ resource: 'automations', action: 'read' });
+  });
+
+  it('labels /monitoring as Monitoring, not Network Monitor (#5288)', () => {
+    const item = navSections
+      .find((s) => s.id === 'fleet-management')!
+      .items.find((i) => i.href === '/monitoring')!;
+    expect(item.name).toBe('Monitoring');
+    expect(item.labelKey).toBe('nav.monitoring');
+  });
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `pnpm --filter @breeze/web test --run src/components/layout/Sidebar.nav.test.tsx`
+Expected: FAIL — `indexOf('/jobs')` is `-1`; name is `'Network Monitor'`.
+
+- [ ] **Step 3: Edit `Sidebar.tsx`**
+
+After the `Scripts` entry in `topLevelNav` (line ~203, `href: '/scripts'`), add:
+
+```tsx
+  // #5288 — Automations finally get a nav home, as Jobs. /automations redirects here.
+  { name: 'Jobs', labelKey: 'nav.jobs', href: '/jobs', icon: CalendarClock, requiredPermission: { resource: 'automations', action: 'read' } },
+```
+
+Import `CalendarClock` from `lucide-react` alongside the other icons at the top of the file.
+
+Replace the fleet-management entry at line 256:
+
+```tsx
+      // #5288 — the Monitoring hub: Network today, Monitors (W02) and Delivery tabs.
+      { name: 'Monitoring', labelKey: 'nav.monitoring', href: '/monitoring', icon: Activity, requiredPermission: { resource: 'devices', action: 'read' } },
+```
+
+Extend `pathAliases`:
+
+```tsx
+const pathAliases: Record<string, string> = {
+  '/software-inventory': '/software',
+  '/software-policies': '/software',
+  '/monitoring/delivery': '/monitoring',
+};
+```
+
+- [ ] **Step 4: Add locale keys** — in every locale's `common.json` `nav` block, next to `"networkMonitor"`:
+
+| locale | `nav.jobs` | `nav.monitoring` |
+|---|---|---|
+| en | `"Jobs"` | `"Monitoring"` |
+| de-DE | `"Aufträge"` | `"Überwachung"` |
+| es-419 | `"Trabajos"` | `"Monitoreo"` |
+| fr-CA | `"Tâches"` | `"Surveillance"` |
+| fr-FR | `"Tâches"` | `"Supervision"` |
+| it-IT | `"Attività"` | `"Monitoraggio"` |
+| pt-BR | `"Jobs"` | `"Monitoramento"` |
+| tr-TR | `"İşler"` | `"İzleme"` |
+
+- [ ] **Step 5: Run the Sidebar suite and the parity suite**
+
+Run: `pnpm --filter @breeze/web test --run src/components/layout/Sidebar.nav.test.tsx src/lib/i18n/localeParity.test.ts`
+Expected: PASS (both). If `hrefsOf('fleet-management')` at line 101 fails, it should not — the href `/monitoring` is unchanged; if it does, you edited the href by mistake.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/layout/Sidebar.tsx apps/web/src/components/layout/Sidebar.nav.test.tsx apps/web/src/locales/*/common.json
+git commit -m "feat(web): Jobs nav entry + Monitoring hub label (#5288)"
+```
+
+---
+
+### Task 2: `/jobs` pages, `/automations` redirects, internal links, Jobs copy
+
+**Files:**
+- Create: `apps/web/src/pages/jobs/index.astro`, `apps/web/src/pages/jobs/new.astro`, `apps/web/src/pages/jobs/[id].astro`
+- Modify: `apps/web/src/pages/automations/index.astro`, `apps/web/src/pages/automations/new.astro`, `apps/web/src/pages/automations/[id].astro` (become redirects)
+- Modify: `apps/web/src/components/automations/AutomationsPage.tsx:255` (`navigateTo`), `:369` (`href="/automations/new"`)
+- Modify: `apps/web/src/components/automations/AutomationEditPage.tsx:317` (save-success URL), `:330`, `:339` (`navigateTo('/automations')`), `:371` (breadcrumb href), `:376` (back link href)
+- Modify: `apps/web/src/components/layout/NotificationCenter.tsx:147` (`case 'automation'`)
+- Modify: `apps/web/src/locales/*/scripts.json` (`automationsPage.title`, `automationsPage.description`; `automationEditPage.breadcrumb.automations`)
+- Test: `apps/web/src/components/automations/AutomationsPage.managed.test.tsx` (extend), `apps/web/src/components/layout/NotificationCenter.test.tsx` (extend if it exists; otherwise create the assertion in a new `NotificationCenter.targetPath.test.tsx`)
+
+**Interfaces:**
+- Produces: web routes `/jobs`, `/jobs/new`, `/jobs/:id`; every in-app link to automations points at `/jobs*`.
+- Leaves alone: `FleetOrchestrationPage.tsx:86` — `{ name: 'automations', path: '/automations' }` is an **API** endpoint path, not a web route.
+
+- [ ] **Step 1: Write the failing test** — in `AutomationsPage.managed.test.tsx` add:
+
+```tsx
+it('links "new" and row edit to /jobs, not /automations (#5288)', async () => {
+  vi.mocked(fetchWithAuth).mockResolvedValueOnce(
+    new Response(JSON.stringify({ data: [{ id: 'a1', name: 'Nightly cleanup', enabled: true, triggerType: 'schedule', trigger: { type: 'schedule', cron: '0 2 * * *' }, actions: [], runCount: 0 }] }), { status: 200 })
+  );
+  render(<AutomationsPage />);
+  const newLink = await screen.findByRole('link', { name: /new/i });
+  expect(newLink).toHaveAttribute('href', '/jobs/new');
+});
+```
+
+(Match the existing mock shape in that file for `fetchWithAuth` — copy how its first test builds the response.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm --filter @breeze/web test --run src/components/automations/AutomationsPage.managed.test.tsx`
+Expected: FAIL — href is `/automations/new`.
+
+- [ ] **Step 3: Create the Jobs pages**
+
+`apps/web/src/pages/jobs/index.astro`:
+
+```astro
+---
+import DashboardLayout from '../../layouts/DashboardLayout.astro';
+import AutomationsPage from '../../components/automations/AutomationsPage';
+---
+
+<DashboardLayout title="Jobs">
+  <AutomationsPage client:load />
+</DashboardLayout>
+```
+
+`apps/web/src/pages/jobs/new.astro` and `apps/web/src/pages/jobs/[id].astro`: copy the current `automations/new.astro` and `automations/[id].astro` verbatim (same component, same props) and change only the `title` to `"New Job"` / `"Job"`.
+
+- [ ] **Step 4: Turn the old pages into redirects**
+
+`apps/web/src/pages/automations/index.astro`:
+
+```astro
+---
+return Astro.redirect('/jobs', 301);
+---
+```
+
+`apps/web/src/pages/automations/new.astro`:
+
+```astro
+---
+return Astro.redirect('/jobs/new', 301);
+---
+```
+
+`apps/web/src/pages/automations/[id].astro`:
+
+```astro
+---
+return Astro.redirect(`/jobs/${Astro.params.id}`, 301);
+---
+```
+
+- [ ] **Step 5: Repoint the internal links**
+
+- `AutomationsPage.tsx:255` → `` void navigateTo(`/jobs/${automation.id}`); ``
+- `AutomationsPage.tsx:369` → `href="/jobs/new"`
+- `AutomationEditPage.tsx:317` → `` const url = isNew ? '/jobs' : `/jobs/${automationId}`; `` — **check first**: if this `url` is the API path passed to `fetchWithAuth`, leave it alone; only change it if it is used with `navigateTo`/`href`. Lines 330, 339, 371, 376 are navigation and must become `/jobs`.
+- `NotificationCenter.tsx:147` → `return '/jobs';`
+
+- [ ] **Step 6: Jobs copy** — in every locale's `scripts.json`:
+
+| locale | `automationsPage.title` | `automationsPage.description` | `automationEditPage.breadcrumb.automations` |
+|---|---|---|---|
+| en | `"Jobs"` | `"Scheduled, on-demand, webhook and event-driven automations."` | `"Jobs"` |
+| de-DE | `"Aufträge"` | `"Geplante, manuelle, Webhook- und ereignisgesteuerte Automatisierungen."` | `"Aufträge"` |
+| es-419 | `"Trabajos"` | `"Automatizaciones programadas, bajo demanda, por webhook y por eventos."` | `"Trabajos"` |
+| fr-CA | `"Tâches"` | `"Automatisations planifiées, sur demande, par webhook et par événement."` | `"Tâches"` |
+| fr-FR | `"Tâches"` | `"Automatisations planifiées, à la demande, par webhook et par événement."` | `"Tâches"` |
+| it-IT | `"Attività"` | `"Automazioni pianificate, su richiesta, via webhook e basate su eventi."` | `"Attività"` |
+| pt-BR | `"Jobs"` | `"Automações agendadas, sob demanda, por webhook e por evento."` | `"Jobs"` |
+| tr-TR | `"İşler"` | `"Zamanlanmış, isteğe bağlı, webhook ve olay tabanlı otomasyonlar."` | `"İşler"` |
+
+Only values change; no keys are added or removed, so the parity test is unaffected.
+
+- [ ] **Step 7: Run the tests**
+
+Run: `pnpm --filter @breeze/web test --run src/components/automations src/components/layout/NotificationCenter`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/web/src/pages/jobs apps/web/src/pages/automations apps/web/src/components/automations/AutomationsPage.tsx apps/web/src/components/automations/AutomationEditPage.tsx apps/web/src/components/layout/NotificationCenter.tsx apps/web/src/components/automations/AutomationsPage.managed.test.tsx apps/web/src/locales/*/scripts.json
+git commit -m "feat(web): /jobs pages, /automations redirects, Jobs copy (#5288)"
+```
+
+---
+
+### Task 3: Jobs trigger tabs (hash) driving the list filter
+
+**Files:**
+- Modify: `apps/web/src/components/automations/AutomationList.tsx:62-71` (props), `:136` (state), `:189-201` (select)
+- Modify: `apps/web/src/components/automations/AutomationsPage.tsx` (tab strip above the list; `useHashTab`)
+- Modify: `apps/web/src/locales/*/scripts.json` (`automationsPage.tabs.*`)
+- Test: `apps/web/src/components/automations/AutomationList.test.tsx` (extend), `apps/web/src/components/automations/AutomationsPage.tabs.test.tsx` (create)
+
+**Interfaces:**
+- Produces on `AutomationList`: optional controlled props `triggerFilter?: TriggerFilter` and `onTriggerFilterChange?: (value: TriggerFilter) => void` where `export type TriggerFilter = 'all' | 'schedule' | 'event' | 'webhook' | 'manual'`. When `triggerFilter` is provided the internal state is bypassed.
+- Produces on `AutomationsPage`: `export const JOB_TABS = ['all', 'scheduled', 'on-demand', 'webhooks', 'event-rules'] as const; export type JobTab = typeof JOB_TABS[number];` and `export function triggerFilterForTab(tab: JobTab): TriggerFilter` mapping `all→all, scheduled→schedule, on-demand→manual, webhooks→webhook, event-rules→event`.
+
+- [ ] **Step 1: Write the failing list test** — append to `AutomationList.test.tsx` (reuse that file's `makeAutomation`/fixture helper if it has one; otherwise build objects with the `Automation` shape from `AutomationList.tsx:36`):
+
+```tsx
+it('honours a controlled triggerFilter prop and reports select changes (#5288)', () => {
+  const onChange = vi.fn();
+  render(
+    <AutomationList
+      automations={[
+        makeAutomation({ id: '1', name: 'Nightly', triggerType: 'schedule' }),
+        makeAutomation({ id: '2', name: 'On alert', triggerType: 'event' }),
+      ]}
+      triggerFilter="event"
+      onTriggerFilterChange={onChange}
+    />
+  );
+  expect(screen.queryByText('Nightly')).toBeNull();
+  expect(screen.getByText('On alert')).toBeInTheDocument();
+  fireEvent.change(screen.getByDisplayValue(/event/i), { target: { value: 'schedule' } });
+  expect(onChange).toHaveBeenCalledWith('schedule');
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm --filter @breeze/web test --run src/components/automations/AutomationList.test.tsx`
+Expected: FAIL — both rows render (prop ignored) and `onChange` is never called.
+
+- [ ] **Step 3: Make `AutomationList` controllable**
+
+```tsx
+export type TriggerFilter = 'all' | 'schedule' | 'event' | 'webhook' | 'manual';
+
+type AutomationListProps = {
+  automations: Automation[];
+  onEdit?: (automation: Automation) => void;
+  onDelete?: (automation: Automation) => void;
+  onRun?: (automation: Automation) => void;
+  onToggle?: (automation: Automation, enabled: boolean) => void;
+  onViewHistory?: (automation: Automation) => void;
+  pageSize?: number;
+  timezone?: string;
+  /** #5288: when provided, the trigger filter is controlled by the parent (Jobs tabs). */
+  triggerFilter?: TriggerFilter;
+  onTriggerFilterChange?: (value: TriggerFilter) => void;
+};
+```
+
+Inside the component replace the state line:
+
+```tsx
+  const [internalTriggerFilter, setInternalTriggerFilter] = useState<TriggerFilter>('all');
+  const triggerFilter = controlledTriggerFilter ?? internalTriggerFilter;
+  const setTriggerFilter = (value: TriggerFilter) => {
+    if (onTriggerFilterChange) onTriggerFilterChange(value);
+    if (controlledTriggerFilter === undefined) setInternalTriggerFilter(value);
+  };
+```
+
+(destructure `triggerFilter: controlledTriggerFilter, onTriggerFilterChange` from props). In the `<select onChange>` cast: `setTriggerFilter(event.target.value as TriggerFilter); setCurrentPage(1);`.
+
+- [ ] **Step 4: Run the list test — PASS.** Then write the failing page test `AutomationsPage.tabs.test.tsx`:
+
+```tsx
+import '@/lib/i18n';
+import { render, screen, waitFor } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../../stores/auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../stores/auth')>();
+  return { ...actual, fetchWithAuth: vi.fn() };
+});
+import AutomationsPage, { JOB_TABS, triggerFilterForTab } from './AutomationsPage';
+import { fetchWithAuth } from '../../stores/auth';
+
+const rows = [
+  { id: '1', name: 'Nightly cleanup', enabled: true, triggerType: 'schedule', trigger: { type: 'schedule', cron: '0 2 * * *' }, actions: [], runCount: 0 },
+  { id: '2', name: 'Inbound webhook', enabled: true, triggerType: 'webhook', trigger: { type: 'webhook' }, actions: [], runCount: 0 },
+  { id: '3', name: 'On disk alert', enabled: true, triggerType: 'event', trigger: { type: 'event', event: 'alert.triggered' }, actions: [], runCount: 0 },
+];
+
+describe('Jobs tabs (#5288)', () => {
+  beforeEach(() => {
+    vi.mocked(fetchWithAuth).mockResolvedValue(new Response(JSON.stringify({ data: rows }), { status: 200 }));
+  });
+
+  it('maps every tab to a trigger filter', () => {
+    expect(JOB_TABS).toEqual(['all', 'scheduled', 'on-demand', 'webhooks', 'event-rules']);
+    expect(triggerFilterForTab('scheduled')).toBe('schedule');
+    expect(triggerFilterForTab('on-demand')).toBe('manual');
+    expect(triggerFilterForTab('webhooks')).toBe('webhook');
+    expect(triggerFilterForTab('event-rules')).toBe('event');
+    expect(triggerFilterForTab('all')).toBe('all');
+  });
+
+  it('#webhooks shows only webhook jobs', async () => {
+    window.location.hash = '#webhooks';
+    render(<AutomationsPage />);
+    await waitFor(() => expect(screen.getByText('Inbound webhook')).toBeInTheDocument());
+    expect(screen.queryByText('Nightly cleanup')).toBeNull();
+    expect(screen.queryByText('On disk alert')).toBeNull();
+    window.location.hash = '';
+  });
+});
+```
+
+- [ ] **Step 5: Run to verify the page test fails**
+
+Run: `pnpm --filter @breeze/web test --run src/components/automations/AutomationsPage.tabs.test.tsx`
+Expected: FAIL — `JOB_TABS` is not exported / all three rows render.
+
+- [ ] **Step 6: Implement the tabs in `AutomationsPage.tsx`**
+
+Near the top of the file:
+
+```tsx
+import { useHashTab } from '@/lib/useHashState';
+import type { TriggerFilter } from './AutomationList';
+
+export const JOB_TABS = ['all', 'scheduled', 'on-demand', 'webhooks', 'event-rules'] as const;
+export type JobTab = typeof JOB_TABS[number];
+
+const TAB_TO_FILTER: Record<JobTab, TriggerFilter> = {
+  all: 'all',
+  scheduled: 'schedule',
+  'on-demand': 'manual',
+  webhooks: 'webhook',
+  'event-rules': 'event',
+};
+const FILTER_TO_TAB: Record<TriggerFilter, JobTab> = {
+  all: 'all',
+  schedule: 'scheduled',
+  manual: 'on-demand',
+  webhook: 'webhooks',
+  event: 'event-rules',
+};
+
+export function triggerFilterForTab(tab: JobTab): TriggerFilter {
+  return TAB_TO_FILTER[tab];
+}
+```
+
+Inside the component: `const [tab, setTab] = useHashTab<JobTab>(JOB_TABS, 'all');` and a writer
+
+```tsx
+  const switchTab = (next: JobTab) => {
+    window.location.hash = next;
+    setTab(next);
+  };
+```
+
+Render the strip between the header and the error block:
+
+```tsx
+      <nav className="flex gap-1 border-b" aria-label={t('automationsPage.tabs.ariaLabel')}>
+        {JOB_TABS.map((key) => (
+          <button
+            key={key}
+            type="button"
+            onClick={() => switchTab(key)}
+            aria-current={tab === key ? 'page' : undefined}
+            className={`-mb-px border-b-2 px-3 py-2 text-sm ${tab === key ? 'border-primary font-medium text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground'}`}
+          >
+            {t(/* i18n-dynamic */ `automationsPage.tabs.${key}`)}
+          </button>
+        ))}
+      </nav>
+```
+
+Pass to the list: `triggerFilter={triggerFilterForTab(tab)}` and `onTriggerFilterChange={(value) => switchTab(FILTER_TO_TAB[value])}`.
+
+- [ ] **Step 7: Locale keys** — `automationsPage.tabs` object in every locale's `scripts.json`:
+
+| locale | ariaLabel | all | scheduled | on-demand | webhooks | event-rules |
+|---|---|---|---|---|---|---|
+| en | `"Job types"` | `"All"` | `"Scheduled"` | `"On demand"` | `"Webhooks"` | `"Event rules"` |
+| de-DE | `"Auftragstypen"` | `"Alle"` | `"Geplant"` | `"Manuell"` | `"Webhooks"` | `"Ereignisregeln"` |
+| es-419 | `"Tipos de trabajo"` | `"Todos"` | `"Programados"` | `"Bajo demanda"` | `"Webhooks"` | `"Reglas de eventos"` |
+| fr-CA | `"Types de tâches"` | `"Toutes"` | `"Planifiées"` | `"Sur demande"` | `"Webhooks"` | `"Règles d'événement"` |
+| fr-FR | `"Types de tâches"` | `"Toutes"` | `"Planifiées"` | `"À la demande"` | `"Webhooks"` | `"Règles d'événement"` |
+| it-IT | `"Tipi di attività"` | `"Tutte"` | `"Pianificate"` | `"Su richiesta"` | `"Webhook"` | `"Regole evento"` |
+| pt-BR | `"Tipos de job"` | `"Todos"` | `"Agendados"` | `"Sob demanda"` | `"Webhooks"` | `"Regras de evento"` |
+| tr-TR | `"İş türleri"` | `"Tümü"` | `"Zamanlanmış"` | `"İsteğe bağlı"` | `"Webhook'lar"` | `"Olay kuralları"` |
+
+JSON keys are `"ariaLabel"`, `"all"`, `"scheduled"`, `"on-demand"`, `"webhooks"`, `"event-rules"`.
+
+- [ ] **Step 8: Run the automations suites and parity**
+
+Run: `pnpm --filter @breeze/web test --run src/components/automations src/lib/i18n/localeParity.test.ts`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/web/src/components/automations apps/web/src/locales/*/scripts.json
+git commit -m "feat(web): Jobs trigger tabs via hash state (#5288)"
+```
+
+---
+
+### Task 4: Monitoring tab strip and the Delivery page
+
+**Files:**
+- Create: `apps/web/src/components/monitoring/MonitoringTabStrip.tsx`, `apps/web/src/components/monitoring/MonitoringTabStrip.test.tsx`
+- Create: `apps/web/src/pages/monitoring/delivery.astro`
+- Modify: `apps/web/src/components/monitoring/MonitoringPage.tsx` (render the strip above the `<h1>` at line 59)
+- Modify: `apps/web/src/components/alerts/NotificationChannelsPage.tsx:504` (strip selection prop)
+- Modify: `apps/web/src/locales/*/common.json` (`monitoringTabs` block)
+- Test: `apps/web/src/components/alerts/NotificationChannelsPage.tabStrip.test.tsx` (create)
+
+**Interfaces:**
+- Produces: `MonitoringTabStrip({ currentPath?: string })` with tabs `[{ href: '/monitoring', labelKey: 'network' }, { href: '/monitoring/delivery', labelKey: 'delivery' }]`, labels from `common:monitoringTabs.*`. Active tab: `/monitoring/delivery` when `path.startsWith('/monitoring/delivery')`, else `/monitoring`.
+- Produces on `NotificationChannelsPage`: prop `tabStrip?: 'alerts' | 'monitoring'` (default `'alerts'` → unchanged `/alerts/channels`; `'monitoring'` renders `MonitoringTabStrip` with `currentPath="/monitoring/delivery"`).
+
+- [ ] **Step 1: Write the failing strip test** `MonitoringTabStrip.test.tsx`
+
+```tsx
+import '@/lib/i18n';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import MonitoringTabStrip from './MonitoringTabStrip';
+
+describe('MonitoringTabStrip (#5288)', () => {
+  it('renders Network and Delivery and marks the current path active', () => {
+    render(<MonitoringTabStrip currentPath="/monitoring/delivery" />);
+    const network = screen.getByRole('link', { name: 'Network' });
+    const delivery = screen.getByRole('link', { name: 'Delivery' });
+    expect(network).toHaveAttribute('href', '/monitoring');
+    expect(delivery).toHaveAttribute('href', '/monitoring/delivery');
+    expect(delivery).toHaveAttribute('aria-current', 'page');
+    expect(network).not.toHaveAttribute('aria-current');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm --filter @breeze/web test --run src/components/monitoring/MonitoringTabStrip.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Create `MonitoringTabStrip.tsx`** — copy `apps/web/src/components/alerts/AlertsTabStrip.tsx` and change: the `TABS` constant, the namespace, the active-href resolver, and drop the ML-flag logic.
+
+```tsx
+import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import '../../lib/i18n';
+
+const TABS = [
+  { href: '/monitoring', labelKey: 'network' },
+  { href: '/monitoring/delivery', labelKey: 'delivery' },
+] as const;
+
+interface MonitoringTabStripProps {
+  // SSR-correct current path so server and client agree on the active tab.
+  currentPath?: string;
+}
+
+function useCurrentPath(initialPath: string): string {
+  const [path, setPath] = useState(initialPath);
+  useEffect(() => {
+    const update = () => setPath(window.location.pathname);
+    document.addEventListener('astro:after-swap', update);
+    window.addEventListener('popstate', update);
+    return () => {
+      document.removeEventListener('astro:after-swap', update);
+      window.removeEventListener('popstate', update);
+    };
+  }, []);
+  return path;
+}
+
+export default function MonitoringTabStrip({ currentPath = '/monitoring' }: MonitoringTabStripProps) {
+  const { t } = useTranslation('common');
+  const path = useCurrentPath(currentPath);
+  const activeHref = useMemo(
+    () => (path.startsWith('/monitoring/delivery') ? '/monitoring/delivery' : '/monitoring'),
+    [path],
+  );
+  return (
+    <nav className="flex gap-1 border-b" aria-label={t('monitoringTabs.ariaLabel')}>
+      {TABS.map((tab) => (
+        <a
+          key={tab.href}
+          href={tab.href}
+          aria-current={activeHref === tab.href ? 'page' : undefined}
+          className={`-mb-px border-b-2 px-3 py-2 text-sm ${activeHref === tab.href ? 'border-primary font-medium text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground'}`}
+        >
+          {t(/* i18n-dynamic */ `monitoringTabs.${tab.labelKey}`)}
+        </a>
+      ))}
+    </nav>
+  );
+}
+```
+
+Copy the exact class names `AlertsTabStrip` uses for its links so the two strips look identical.
+
+- [ ] **Step 4: Locale keys** — `monitoringTabs` object in every locale's `common.json` (top level, next to `nav`):
+
+| locale | ariaLabel | network | delivery |
+|---|---|---|---|
+| en | `"Monitoring sections"` | `"Network"` | `"Delivery"` |
+| de-DE | `"Überwachungsbereiche"` | `"Netzwerk"` | `"Zustellung"` |
+| es-419 | `"Secciones de monitoreo"` | `"Red"` | `"Entrega"` |
+| fr-CA | `"Sections de surveillance"` | `"Réseau"` | `"Livraison"` |
+| fr-FR | `"Sections de supervision"` | `"Réseau"` | `"Diffusion"` |
+| it-IT | `"Sezioni di monitoraggio"` | `"Rete"` | `"Consegna"` |
+| pt-BR | `"Seções de monitoramento"` | `"Rede"` | `"Entrega"` |
+| tr-TR | `"İzleme bölümleri"` | `"Ağ"` | `"Teslimat"` |
+
+- [ ] **Step 5: Run the strip test — PASS.** Then write the failing channels-page test `NotificationChannelsPage.tabStrip.test.tsx` (copy the auth/fetch mocking preamble from `NotificationChannelList.pagination.test.tsx` or `AutomationsPage.managed.test.tsx`; the page fetches channels on mount, so mock `fetchWithAuth` to resolve `{ data: [] }`):
+
+```tsx
+it('renders the Monitoring strip when tabStrip="monitoring" (#5288)', async () => {
+  render(<NotificationChannelsPage tabStrip="monitoring" />);
+  expect(await screen.findByRole('link', { name: 'Delivery' })).toHaveAttribute('aria-current', 'page');
+  expect(screen.queryByRole('link', { name: 'Correlations' })).toBeNull();
+});
+
+it('keeps the Alerts strip by default', async () => {
+  render(<NotificationChannelsPage />);
+  expect(await screen.findByRole('link', { name: 'Channels' })).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 6: Run to verify it fails**
+
+Run: `pnpm --filter @breeze/web test --run src/components/alerts/NotificationChannelsPage.tabStrip.test.tsx`
+Expected: FAIL — no `Delivery` link.
+
+- [ ] **Step 7: Add the prop to `NotificationChannelsPage`**
+
+```tsx
+import MonitoringTabStrip from '../monitoring/MonitoringTabStrip';
+
+interface NotificationChannelsPageProps {
+  /** #5288: which hub the page is mounted under. */
+  tabStrip?: 'alerts' | 'monitoring';
+}
+
+export default function NotificationChannelsPage({ tabStrip = 'alerts' }: NotificationChannelsPageProps) {
+```
+
+and at line 504:
+
+```tsx
+      {tabStrip === 'monitoring'
+        ? <MonitoringTabStrip currentPath="/monitoring/delivery" />
+        : <AlertsTabStrip currentPath="/alerts/channels" />}
+```
+
+- [ ] **Step 8: Create `apps/web/src/pages/monitoring/delivery.astro`**
+
+```astro
+---
+import DashboardLayout from '../../layouts/DashboardLayout.astro';
+import NotificationChannelsPage from '../../components/alerts/NotificationChannelsPage';
+import Breadcrumbs from '../../components/layout/Breadcrumbs';
+---
+
+<DashboardLayout title="Monitoring">
+  <Breadcrumbs client:load items={[
+    { label: 'Monitoring', href: '/monitoring' },
+    { label: 'Delivery' }
+  ]} />
+  <NotificationChannelsPage client:load tabStrip="monitoring" />
+</DashboardLayout>
+```
+
+- [ ] **Step 9: Mount the strip on the network page** — in `MonitoringPage.tsx`, import `MonitoringTabStrip` and render `<MonitoringTabStrip currentPath="/monitoring" />` as the first child of the page's outer `<div className="space-y-6">` (directly above the header containing the `<h1>` at line 59). Do not touch the page's own `useHashTab` tabs.
+
+- [ ] **Step 10: Run the affected suites**
+
+Run: `pnpm --filter @breeze/web test --run src/components/monitoring src/components/alerts/NotificationChannelsPage src/lib/i18n/localeParity.test.ts`
+Expected: PASS. If an existing `MonitoringPage` test asserts the first rendered element, update it to account for the strip.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add apps/web/src/components/monitoring apps/web/src/components/alerts/NotificationChannelsPage.tsx apps/web/src/components/alerts/NotificationChannelsPage.tabStrip.test.tsx apps/web/src/pages/monitoring/delivery.astro apps/web/src/locales/*/common.json
+git commit -m "feat(web): Monitoring hub tab strip + Delivery page (#5288)"
+```
+
+---
+
+### Task 5: Docs
+
+**Files:**
+- Modify: `apps/docs/src/content/docs/features/automations.mdx` (wherever it tells the reader where Automations live / links `/automations`)
+- Modify: `apps/docs/src/content/docs/features/network-monitors.mdx` (nav path "Fleet Management → Network Monitor")
+- Modify: any other file from `grep -rln -E "Network Monitor|/automations" apps/docs/src/content/docs` that names the nav entry (the grep on 2026-09-08 also hit `index.mdx`, `configuration-policies.mdx`, `scripts.mdx`, `maintenance-windows.mdx`, `ai.mdx`, `ai-agents.mdx`, `mcp-server.mdx`, `edr-integrations.mdx`, `unifi-integration.mdx`, `security/overview.mdx` — most mention the *feature* "automations", which is still the right word; change only navigation instructions and `/automations` URLs).
+
+- [ ] **Step 1: Edit** — replace navigation instructions with "**Jobs** in the left nav (`/jobs`)" and "**Fleet Management → Monitoring → Network**". Add one sentence to `automations.mdx` near the top: "Automations appear in the left nav as **Jobs**. Older `/automations` links redirect."
+
+- [ ] **Step 2: Build the docs site**
+
+Run: `pnpm --filter @breeze/docs build`
+Expected: succeeds with no broken-link warnings for `/jobs`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/docs/src/content/docs
+git commit -m "docs: Jobs nav and Monitoring hub (#5288)"
+```
+
+---
+
+### Task 6: Verification and PR
+
+- [ ] **Step 1: Lint and the full web suites that touch this wave**
+
+```bash
+pnpm --filter @breeze/web lint
+pnpm --filter @breeze/web test --run src/components/layout src/components/automations src/components/monitoring src/components/alerts src/lib/i18n
+```
+
+Expected: lint clean, all PASS.
+
+- [ ] **Step 2: Build the web app** (catches Astro page/redirect errors that vitest cannot)
+
+```bash
+pnpm --filter @breeze/web build
+```
+
+Expected: succeeds. Then, with a local stack (`worktree-stack` skill), confirm in a browser: `/automations` → `/jobs` (301), `/automations/<id>` → `/jobs/<id>`, `#webhooks` filters the list, `/monitoring/delivery` shows the channels page with the Monitoring strip, the sidebar highlights **Monitoring** on `/monitoring/delivery` and **Jobs** on `/jobs/new`.
+
+- [ ] **Step 3: Open the PR**
+
+Title: `feat(web): Jobs nav + Monitoring hub — W01 discoverability (#5287)`. Body: what changed per task, the spec path, "Closes #5288", the deviation note (Jobs tabs include `all`; no history tab). Run `/pr-review-toolkit:review-pr`, fix confirmed findings inline, then `gh pr merge <N> --squash` (merge queue; never `--admin`).

--- a/docs/superpowers/plans/monitoring/2026-09-08-monitoring-automation-unification-02-api-foundation.md
+++ b/docs/superpowers/plans/monitoring/2026-09-08-monitoring-automation-unification-02-api-foundation.md
@@ -1,0 +1,1190 @@
+---
+tracking_issue: LanternOps/breeze#5287
+wave_issue: LanternOps/breeze#5289
+branch: feature/5287-monitoring-automation-unification/wave-5289
+---
+
+# Monitoring & Automation Unification — W02 API Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist monitor definitions (org XOR partner), attach them to configuration policies through a new `monitors` feature type, and compile every definition into managed alert-template / alert-rule / automation rows that the existing sweep, dispatcher and automation worker execute unchanged.
+
+**Architecture:** One idempotent migration adds the `monitor_kind` enum, `monitor_definitions` (dual-axis RLS), `config_policy_monitors` (parent-FK-join RLS), `managed_by_monitor_id` on the three compiled tables, `alerts.monitor_id`, and the two delivery columns the config-policy alert path was missing. A kind registry (`services/monitors/kinds/`) turns a definition's `condition` into the root condition the `alertConditions` registry already validates and evaluates. `saveMonitorDefinition` compiles in one transaction and is the only writer of managed rows; the routes for alert rules, templates and automations refuse edits to managed rows with `409`. `getApplicableRules` gains a `'monitor'` target type resolved through `resolveMonitorsForDevice`, which unions every assigned policy's (and its parent's) attachments and applies per-attachment overrides. Web and MCP surfaces are the companion plan `…-02-web-and-tools.md`.
+
+**Tech Stack:** Hono, Drizzle ORM, PostgreSQL 16 (constraint triggers, dual-axis RLS), zod in `packages/shared`, Vitest (unit with Drizzle mocks; integration against real Postgres via `apps/api/src/__tests__/integration/setup`).
+
+**Spec:** `docs/superpowers/specs/monitoring/2026-09-08-monitoring-automation-unification-design.md` (§Ownership rule, §Data model, §Compile contract, §Targeting and inheritance, §Delivery, §Monitor types)
+
+**Tracking:** feature LanternOps/breeze#5287, wave #5289. Branch `feature/5287-monitoring-automation-unification/wave-5289`. Two PRs are expected from this wave: this plan (`Refs #5289`) and the web/tools plan (`Closes #5289`).
+
+## Global Constraints
+
+- Migration filename `2026-10-14-100600-monitor-definitions.sql`. Before pushing, `ls apps/api/migrations | sort | tail -1` on `origin/main` must sort **before** it (newest at planning time: `2026-10-14-100500-ai-operator-task-client-idempotency.sql`); bump the `HHMMSS` if not. Never name it for today's real date — shipped names run ahead of the calendar.
+- Migration is idempotent (`IF NOT EXISTS`, `DO $$ … $$` guards, `pg_policies` checks), contains **no DML**, no inner `BEGIN`/`COMMIT`. `ALTER TYPE config_feature_type ADD VALUE 'monitors'` is fine inside the runner's transaction because nothing in the same file consumes the value.
+- **The new feature type is `monitors`, not `monitor`.** `monitoring` already exists (service/process watches) and the two must not be confusable in code or SQL.
+- SQL guards are two-valued: `COALESCE(…, false)` inside every boolean guard function, `IS NOT TRUE` at call sites. A lookup miss in an ownership decision is a deny.
+- `monitor_definitions`: `org_id` XOR `partner_id` (`monitor_definitions_one_owner_chk`), one dual-axis RLS policy, partner index. Partner-wide writes gate on `canManagePartnerWidePolicies(auth)`; create takes `ownerScope`; update schema `.omit({ ownerScope: true })`.
+- Managed rows (`managed_by_monitor_id IS NOT NULL`) are written **only** by `services/monitors/monitorCompiler.ts`. Every other writer returns `409 { error: '<table>_managed_by_monitor', monitorId }`.
+- `alert_templates.conditions` for a compiled template is a **single root condition object**, never an array.
+- The compiled automation trigger is stored as `{ type: 'event', event: 'alert.triggered', filter: { ruleId: <compiled rule id> } }` — the shape `automationTriggerSchema` validates; `normalizeAutomationTrigger` already reads `filter`.
+- Worker-created rows take the **device's** org. Compiled rows take the **definition's** owner.
+- Registration lists are part of the migration task, not an afterthought: cascade order, export policy (new tables **and** new columns on `alerts`, `alert_rules`, `alert_templates`, `automations`, `config_policy_alert_rules`), `DUAL_AXIS_TENANT_TABLES`, `PARENT_FK_JOIN_POLICY_TABLES`, `REPOINT_TABLES`.
+- Every task: red test first, `pnpm --filter @breeze/api exec tsc --noEmit`, targeted tests (`cd apps/api && npx vitest run <file>`), commit. Before the PR: the live-DB suites in Task 12.
+
+---
+
+### Task 1: Migration — enum, feature type, tables, managed-row columns, delivery parity columns, RLS, compatibility trigger
+
+**Files:**
+- Create: `apps/api/migrations/2026-10-14-100600-monitor-definitions.sql`
+- Test: `apps/api/src/db/autoMigrate.test.ts` (existing, auto-discovers), `apps/api/src/db/migrationRlsScope.test.ts` (existing; stays green because the file has no DML)
+
+**Interfaces:**
+- Produces: enum `monitor_kind`; tables `monitor_definitions`, `config_policy_monitors`; columns `alert_templates.managed_by_monitor_id`, `alert_rules.managed_by_monitor_id`, `automations.managed_by_monitor_id`, `alerts.monitor_id`, `config_policy_alert_rules.escalation_policy_id`, `config_policy_alert_rules.notification_channel_ids`; function `breeze_monitor_attachment_compatible(uuid, uuid) → boolean`; constraint trigger `config_policy_monitors_compat_trg`.
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- Monitoring & Automation unification, W02 (#5287 / #5289).
+-- Monitor definitions (org XOR partner), policy attachments, managed-row provenance,
+-- and the delivery columns the config-policy alert path never had.
+
+-- 1. Kinds shipped in W02: each maps onto an existing alertConditions handler.
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'monitor_kind') THEN
+    CREATE TYPE monitor_kind AS ENUM (
+      'cpu', 'memory', 'disk', 'offline', 'event_log', 'patch_compliance',
+      'service', 'process', 'process_resource', 'cert_expiry',
+      'bandwidth', 'disk_io', 'network_errors'
+    );
+  END IF;
+END $$;
+
+-- 2. New configuration-policy feature type. 'monitoring' (service/process watches)
+--    already exists; this one is deliberately the plural.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_enum
+    WHERE enumlabel = 'monitors'
+      AND enumtypid = (SELECT oid FROM pg_type WHERE typname = 'config_feature_type')
+  ) THEN
+    ALTER TYPE config_feature_type ADD VALUE 'monitors';
+  END IF;
+END $$;
+
+-- 3. monitor_definitions — a config table: org XOR partner.
+CREATE TABLE IF NOT EXISTS monitor_definitions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id uuid REFERENCES organizations(id),
+  partner_id uuid REFERENCES partners(id),
+  name varchar(200) NOT NULL,
+  description text,
+  kind monitor_kind NOT NULL,
+  enabled boolean NOT NULL DEFAULT true,
+  condition jsonb NOT NULL,
+  severity alert_severity NOT NULL,
+  cooldown_minutes integer NOT NULL DEFAULT 5,
+  auto_resolve boolean NOT NULL DEFAULT false,
+  auto_resolve_conditions jsonb,
+  responses jsonb NOT NULL DEFAULT '[]'::jsonb,
+  delivery_mode varchar(16) NOT NULL DEFAULT 'inherit',
+  delivery_channel_ids jsonb NOT NULL DEFAULT '[]'::jsonb,
+  escalation_policy_id uuid REFERENCES escalation_policies(id) ON DELETE SET NULL,
+  recurrence_threshold integer,
+  recurrence_window_hours integer,
+  recurrence_actions jsonb NOT NULL DEFAULT '[]'::jsonb,
+  pause_responses_on_escalation boolean NOT NULL DEFAULT true,
+  ai_agent_id uuid REFERENCES ai_agents(id) ON DELETE SET NULL,
+  compiled_alert_template_id uuid,
+  compiled_alert_rule_id uuid,
+  compiled_automation_id uuid,
+  compiled_hash text,
+  compiled_at timestamptz,
+  created_by uuid REFERENCES users(id),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'monitor_definitions_one_owner_chk') THEN
+    ALTER TABLE monitor_definitions
+      ADD CONSTRAINT monitor_definitions_one_owner_chk CHECK ((org_id IS NULL) <> (partner_id IS NULL));
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'monitor_definitions_delivery_mode_chk') THEN
+    ALTER TABLE monitor_definitions
+      ADD CONSTRAINT monitor_definitions_delivery_mode_chk CHECK (delivery_mode IN ('none', 'inherit', 'channels'));
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'monitor_definitions_recurrence_chk') THEN
+    ALTER TABLE monitor_definitions
+      ADD CONSTRAINT monitor_definitions_recurrence_chk CHECK (
+        (recurrence_threshold IS NULL) = (recurrence_window_hours IS NULL)
+        AND (recurrence_threshold IS NULL OR recurrence_threshold >= 2)
+        AND (recurrence_window_hours IS NULL OR recurrence_window_hours >= 1)
+      );
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS monitor_definitions_org_id_idx ON monitor_definitions(org_id);
+CREATE INDEX IF NOT EXISTS monitor_definitions_partner_id_idx ON monitor_definitions(partner_id);
+CREATE UNIQUE INDEX IF NOT EXISTS monitor_definitions_owner_name_uidx
+  ON monitor_definitions (COALESCE(org_id, partner_id), lower(name));
+
+ALTER TABLE monitor_definitions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE monitor_definitions FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS monitor_definitions_isolation ON monitor_definitions;
+CREATE POLICY monitor_definitions_isolation
+  ON monitor_definitions
+  USING (
+    public.breeze_current_scope() = 'system'
+    OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+    OR (partner_id IS NOT NULL AND public.breeze_has_partner_access(partner_id))
+  )
+  WITH CHECK (
+    public.breeze_current_scope() = 'system'
+    OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+    OR (partner_id IS NOT NULL AND public.breeze_has_partner_access(partner_id))
+  );
+GRANT SELECT, INSERT, UPDATE, DELETE ON monitor_definitions TO breeze_app;
+
+-- 4. config_policy_monitors — attachment rows under a 'monitors' feature link.
+CREATE TABLE IF NOT EXISTS config_policy_monitors (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  feature_link_id uuid NOT NULL REFERENCES config_policy_feature_links(id) ON DELETE CASCADE,
+  monitor_id uuid NOT NULL REFERENCES monitor_definitions(id) ON DELETE CASCADE,
+  enabled boolean NOT NULL DEFAULT true,
+  overrides jsonb,
+  sort_order integer NOT NULL DEFAULT 0,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS config_policy_monitors_link_monitor_uidx
+  ON config_policy_monitors(feature_link_id, monitor_id);
+CREATE INDEX IF NOT EXISTS config_policy_monitors_monitor_id_idx ON config_policy_monitors(monitor_id);
+
+ALTER TABLE config_policy_monitors ENABLE ROW LEVEL SECURITY;
+ALTER TABLE config_policy_monitors FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS config_policy_monitors_isolation ON config_policy_monitors;
+CREATE POLICY config_policy_monitors_isolation
+  ON config_policy_monitors
+  USING (
+    public.breeze_current_scope() = 'system'
+    OR EXISTS (
+      SELECT 1 FROM config_policy_feature_links fl
+      JOIN configuration_policies cp ON cp.id = fl.config_policy_id
+      WHERE fl.id = config_policy_monitors.feature_link_id
+        AND (
+          (cp.org_id IS NOT NULL AND public.breeze_has_org_access(cp.org_id))
+          OR (cp.partner_id IS NOT NULL AND public.breeze_has_partner_access(cp.partner_id))
+        )
+    )
+  )
+  WITH CHECK (
+    public.breeze_current_scope() = 'system'
+    OR EXISTS (
+      SELECT 1 FROM config_policy_feature_links fl
+      JOIN configuration_policies cp ON cp.id = fl.config_policy_id
+      WHERE fl.id = config_policy_monitors.feature_link_id
+        AND (
+          (cp.org_id IS NOT NULL AND public.breeze_has_org_access(cp.org_id))
+          OR (cp.partner_id IS NOT NULL AND public.breeze_has_partner_access(cp.partner_id))
+        )
+    )
+  );
+GRANT SELECT, INSERT, UPDATE, DELETE ON config_policy_monitors TO breeze_app;
+
+-- 5. Attachment compatibility: a policy may attach a monitor only when the monitor is
+--    owned by the policy's org, by the policy's partner, or is partner-wide under the
+--    org's partner. Two-valued (COALESCE) so a NULL never passes. Mirrors
+--    breeze_config_policy_parent_compatible (#5080).
+CREATE OR REPLACE FUNCTION public.breeze_monitor_attachment_compatible(p_monitor_id uuid, p_feature_link_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT COALESCE((
+    SELECT
+      CASE
+        WHEN m.org_id IS NOT NULL AND cp.org_id IS NOT NULL THEN m.org_id = cp.org_id
+        WHEN m.partner_id IS NOT NULL AND cp.partner_id IS NOT NULL THEN m.partner_id = cp.partner_id
+        WHEN m.partner_id IS NOT NULL AND cp.org_id IS NOT NULL THEN m.partner_id = o.partner_id
+        ELSE false
+      END
+    FROM monitor_definitions m
+    CROSS JOIN config_policy_feature_links fl
+    JOIN configuration_policies cp ON cp.id = fl.config_policy_id
+    LEFT JOIN organizations o ON o.id = cp.org_id
+    WHERE m.id = p_monitor_id AND fl.id = p_feature_link_id
+  ), false);
+$$;
+REVOKE ALL ON FUNCTION public.breeze_monitor_attachment_compatible(uuid, uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.breeze_monitor_attachment_compatible(uuid, uuid) TO breeze_app;
+
+CREATE OR REPLACE FUNCTION public.breeze_config_policy_monitors_compat_guard()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF public.breeze_monitor_attachment_compatible(NEW.monitor_id, NEW.feature_link_id) IS NOT TRUE THEN
+    RAISE EXCEPTION 'monitor % cannot be attached to feature link %: owner mismatch', NEW.monitor_id, NEW.feature_link_id
+      USING ERRCODE = '23514', CONSTRAINT = 'config_policy_monitors_compat';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'config_policy_monitors_compat_trg') THEN
+    CREATE CONSTRAINT TRIGGER config_policy_monitors_compat_trg
+      AFTER INSERT OR UPDATE OF monitor_id, feature_link_id ON config_policy_monitors
+      DEFERRABLE INITIALLY DEFERRED
+      FOR EACH ROW EXECUTE FUNCTION public.breeze_config_policy_monitors_compat_guard();
+  END IF;
+END $$;
+
+-- 6. Managed-row provenance on the compiled tables + alert linkage.
+ALTER TABLE alert_templates ADD COLUMN IF NOT EXISTS managed_by_monitor_id uuid REFERENCES monitor_definitions(id) ON DELETE CASCADE;
+ALTER TABLE alert_rules     ADD COLUMN IF NOT EXISTS managed_by_monitor_id uuid REFERENCES monitor_definitions(id) ON DELETE CASCADE;
+ALTER TABLE automations     ADD COLUMN IF NOT EXISTS managed_by_monitor_id uuid REFERENCES monitor_definitions(id) ON DELETE CASCADE;
+ALTER TABLE alerts          ADD COLUMN IF NOT EXISTS monitor_id uuid REFERENCES monitor_definitions(id) ON DELETE SET NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS alert_templates_managed_by_monitor_uidx ON alert_templates(managed_by_monitor_id) WHERE managed_by_monitor_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS alert_rules_managed_by_monitor_uidx     ON alert_rules(managed_by_monitor_id)     WHERE managed_by_monitor_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS automations_managed_by_monitor_uidx     ON automations(managed_by_monitor_id)     WHERE managed_by_monitor_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS alerts_monitor_id_idx ON alerts(monitor_id) WHERE monitor_id IS NOT NULL;
+
+-- 7. Delivery parity for the config-policy alert path (spec §Delivery).
+ALTER TABLE config_policy_alert_rules ADD COLUMN IF NOT EXISTS escalation_policy_id uuid REFERENCES escalation_policies(id) ON DELETE SET NULL;
+ALTER TABLE config_policy_alert_rules ADD COLUMN IF NOT EXISTS notification_channel_ids jsonb;
+```
+
+- [ ] **Step 2: Run the migration guards**
+
+Run: `cd apps/api && npx vitest run src/db/autoMigrate.test.ts src/db/migrationRlsScope.test.ts`
+Expected: PASS (ordering, checksum references, no-DML scope rule).
+
+- [ ] **Step 3: Apply locally and verify as `breeze_app`**
+
+```bash
+export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze"
+pnpm db:migrate
+docker exec -it breeze-postgres psql -U breeze_app -d breeze -c "select set_config('breeze.scope','organization',false); insert into monitor_definitions (org_id, name, kind, condition, severity) values ('00000000-0000-0000-0000-000000000001','forge','cpu','{}','high');"
+```
+Expected: `new row violates row-level security policy`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/migrations/2026-10-14-100600-monitor-definitions.sql
+git commit -m "feat(monitors): migration — monitor_definitions, config_policy_monitors, managed-row provenance (#5289)"
+```
+
+---
+
+### Task 2: Drizzle schema + shared validators
+
+**Files:**
+- Create: `apps/api/src/db/schema/monitorDefinitions.ts`
+- Modify: `apps/api/src/db/schema/index.ts` (add `export * from './monitorDefinitions';`)
+- Modify: `apps/api/src/db/schema/alerts.ts:44-60` (`alertTemplates`), `:73-87` (`alertRules`), `:90-111` (`alerts`)
+- Modify: `apps/api/src/db/schema/automations.ts:41-66`
+- Modify: `apps/api/src/db/schema/configurationPolicies.ts:32-52` (enum), `:186-200` (`configPolicyAlertRules`)
+- Modify: `packages/shared/src/validators/index.ts:213-232` (trigger), `:634` (`addFeatureLinkSchema.featureType`), `:1036` (`alertRuleInlineSettingsSchema`)
+- Create: `packages/shared/src/validators/monitors.ts`, `packages/shared/src/validators/monitors.test.ts`
+- Modify: `packages/shared/src/validators/index.ts` (re-export `./monitors`)
+
+**Interfaces:**
+- Produces (Drizzle): `monitorKindEnum`, `monitorDefinitions`, `configPolicyMonitors`; new columns `managedByMonitorId` on `alertTemplates`/`alertRules`/`automations`, `monitorId` on `alerts`, `escalationPolicyId` + `notificationChannelIds` on `configPolicyAlertRules`.
+- Produces (zod, `@breeze/shared`): `MONITOR_KINDS`, `monitorKindSchema`, `monitorConditionSchemas: Record<MonitorKind, ZodObject>`, `monitorResponsesSchema` (= `z.array(automationActionSchema).max(10)`), `createMonitorDefinitionSchema`, `updateMonitorDefinitionSchema`, `monitorsInlineSettingsSchema` (`{ items: [{ monitorId, enabled, overrides?, sortOrder? }] }`), `automationTriggerSchema` event branch gains `filter`.
+
+- [ ] **Step 1: Write the failing validator tests** (`packages/shared/src/validators/monitors.test.ts`)
+
+```ts
+import { describe, it, expect } from 'vitest';
+import {
+  createMonitorDefinitionSchema,
+  updateMonitorDefinitionSchema,
+  monitorConditionSchemas,
+  monitorsInlineSettingsSchema,
+  MONITOR_KINDS,
+} from './monitors';
+import { automationTriggerSchema } from './index';
+
+describe('monitor definition validators (#5289)', () => {
+  it('lists the W02 kinds', () => {
+    expect(MONITOR_KINDS).toEqual([
+      'cpu', 'memory', 'disk', 'offline', 'event_log', 'patch_compliance',
+      'service', 'process', 'process_resource', 'cert_expiry', 'bandwidth', 'disk_io', 'network_errors',
+    ]);
+  });
+
+  it('accepts a cpu monitor with a threshold condition and rejects an unknown key', () => {
+    const ok = createMonitorDefinitionSchema.safeParse({
+      ownerScope: 'organization', name: 'High CPU', kind: 'cpu', severity: 'high',
+      condition: { operator: 'gt', value: 90, durationMinutes: 10 }, responses: [],
+    });
+    expect(ok.success).toBe(true);
+    const bad = monitorConditionSchemas.cpu.safeParse({ operator: 'gt', value: 90, metric: 'ramPercent' });
+    expect(bad.success).toBe(false);
+  });
+
+  it('requires recurrence threshold and window together', () => {
+    const r = createMonitorDefinitionSchema.safeParse({
+      ownerScope: 'organization', name: 'x', kind: 'offline', severity: 'high',
+      condition: { durationMinutes: 15 }, responses: [], recurrenceThreshold: 3,
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('update strips ownerScope', () => {
+    const r = updateMonitorDefinitionSchema.safeParse({ ownerScope: 'partner', name: 'renamed' });
+    expect(r.success).toBe(true);
+    expect(r.success && 'ownerScope' in r.data).toBe(false);
+  });
+
+  it('inline settings carry attachment items', () => {
+    const r = monitorsInlineSettingsSchema.safeParse({
+      items: [{ monitorId: '6b1f2b3a-0000-4000-8000-000000000001', enabled: false, overrides: { value: 95 } }],
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('event trigger accepts filter', () => {
+    const r = automationTriggerSchema.safeParse({ type: 'event', event: 'alert.triggered', filter: { ruleId: 'abc' } });
+    expect(r.success).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd packages/shared && npx vitest run src/validators/monitors.test.ts`
+Expected: FAIL — module `./monitors` not found.
+
+- [ ] **Step 3: Write `packages/shared/src/validators/monitors.ts`**
+
+```ts
+import { z } from 'zod';
+import { automationActionSchema } from './index';
+
+export const MONITOR_KINDS = [
+  'cpu', 'memory', 'disk', 'offline', 'event_log', 'patch_compliance',
+  'service', 'process', 'process_resource', 'cert_expiry', 'bandwidth', 'disk_io', 'network_errors',
+] as const;
+export type MonitorKind = typeof MONITOR_KINDS[number];
+export const monitorKindSchema = z.enum(MONITOR_KINDS);
+
+const operator = z.enum(['gt', 'gte', 'lt', 'lte', 'eq', 'neq']);
+const durationMinutes = z.number().int().min(1).max(1440).optional();
+const thresholdCondition = z.object({ operator, value: z.number().min(0).max(100), durationMinutes }).strict();
+
+export const monitorConditionSchemas = {
+  cpu: thresholdCondition,
+  memory: thresholdCondition,
+  disk: thresholdCondition,
+  offline: z.object({ durationMinutes: z.number().int().min(1).max(10080).default(5) }).strict(),
+  event_log: z.object({
+    category: z.enum(['security', 'hardware', 'application', 'system']),
+    level: z.enum(['warning', 'error', 'critical']),
+    sourcePattern: z.string().max(200).optional(),
+    messagePattern: z.string().max(500).optional(),
+    countThreshold: z.number().int().min(1).default(1),
+    windowMinutes: z.number().int().min(1).max(1440).default(60),
+  }).strict(),
+  patch_compliance: z.object({ operator, value: z.number().min(0).max(100) }).strict(),
+  service: z.object({ serviceName: z.string().min(1).max(255), consecutiveFailures: z.number().int().min(1).max(20).optional() }).strict(),
+  process: z.object({ processName: z.string().min(1).max(255), consecutiveFailures: z.number().int().min(1).max(20).optional() }).strict(),
+  process_resource: z.object({ resource: z.enum(['cpu', 'memory']), processName: z.string().min(1).max(255), operator, value: z.number().min(0), durationMinutes }).strict(),
+  cert_expiry: z.object({ withinDays: z.number().int().min(1).max(365) }).strict(),
+  bandwidth: z.object({ direction: z.enum(['in', 'out', 'total']), operator, value: z.number().min(0), durationMinutes }).strict(),
+  disk_io: z.object({ direction: z.enum(['read', 'write', 'total']), operator, value: z.number().min(0), durationMinutes }).strict(),
+  network_errors: z.object({ interfaceName: z.string().max(100).optional(), errorType: z.enum(['in', 'out', 'total']), operator, value: z.number().min(0), windowMinutes: z.number().int().min(1).max(1440).optional() }).strict(),
+} satisfies Record<MonitorKind, z.ZodTypeAny>;
+
+export const monitorResponsesSchema = z.array(automationActionSchema).max(10);
+export const deliveryModeSchema = z.enum(['none', 'inherit', 'channels']);
+
+const baseDefinition = z.object({
+  name: z.string().min(1).max(200),
+  description: z.string().max(2000).optional(),
+  kind: monitorKindSchema,
+  enabled: z.boolean().default(true),
+  condition: z.record(z.unknown()),
+  severity: z.enum(['critical', 'high', 'medium', 'low', 'info']),
+  cooldownMinutes: z.number().int().min(0).max(1440).default(5),
+  autoResolve: z.boolean().default(false),
+  autoResolveConditions: z.record(z.unknown()).optional(),
+  responses: monitorResponsesSchema.default([]),
+  deliveryMode: deliveryModeSchema.default('inherit'),
+  deliveryChannelIds: z.array(z.string().uuid()).max(20).default([]),
+  escalationPolicyId: z.string().uuid().nullable().optional(),
+  recurrenceThreshold: z.number().int().min(2).max(100).nullable().optional(),
+  recurrenceWindowHours: z.number().int().min(1).max(8760).nullable().optional(),
+  recurrenceActions: monitorResponsesSchema.default([]),
+  pauseResponsesOnEscalation: z.boolean().default(true),
+  aiAgentId: z.string().uuid().nullable().optional(),
+});
+
+function refineDefinition<T extends z.ZodTypeAny>(schema: T) {
+  return schema
+    .refine((v: z.infer<typeof baseDefinition>) => {
+      if (!v.kind) return true;
+      return monitorConditionSchemas[v.kind as MonitorKind].safeParse(v.condition).success;
+    }, { message: 'condition does not match kind', path: ['condition'] })
+    .refine((v: z.infer<typeof baseDefinition>) =>
+      (v.recurrenceThreshold == null) === (v.recurrenceWindowHours == null),
+      { message: 'recurrenceThreshold and recurrenceWindowHours must be set together', path: ['recurrenceThreshold'] })
+    .refine((v: z.infer<typeof baseDefinition>) =>
+      v.deliveryMode !== 'channels' || (v.deliveryChannelIds?.length ?? 0) > 0,
+      { message: 'deliveryChannelIds required when deliveryMode is channels', path: ['deliveryChannelIds'] })
+    .refine((v: z.infer<typeof baseDefinition>) =>
+      !(v.responses ?? []).some((a) => a.type === 'ai_triage') || !!v.aiAgentId,
+      { message: 'ai_triage responses require aiAgentId', path: ['responses'] });
+}
+
+export const createMonitorDefinitionSchema = refineDefinition(
+  baseDefinition.extend({ ownerScope: z.enum(['organization', 'partner']).default('organization'), orgId: z.string().uuid().optional() })
+);
+export const updateMonitorDefinitionSchema = refineDefinition(baseDefinition.partial());   // no ownerScope in the base; zod strips it if sent
+export type CreateMonitorDefinitionInput = z.infer<typeof createMonitorDefinitionSchema>;
+export type UpdateMonitorDefinitionInput = z.infer<typeof updateMonitorDefinitionSchema>;
+
+export const monitorsInlineSettingsSchema = z.object({
+  items: z.array(z.object({
+    monitorId: z.string().uuid(),
+    enabled: z.boolean().default(true),
+    overrides: z.record(z.unknown()).optional(),
+    sortOrder: z.number().int().min(0).optional(),
+  })).max(200),
+});
+export type MonitorsInlineSettings = z.infer<typeof monitorsInlineSettingsSchema>;
+```
+
+Note on `updateMonitorDefinitionSchema`: `baseDefinition` has no `ownerScope`, and zod strips unknown keys, so an update can never change the owner (the test pins this). Because a partial update may omit `kind`, the refine reads `v.kind` and skips the condition check when absent; the service re-validates the merged definition (Task 4).
+
+In `packages/shared/src/validators/index.ts`: add `filter: z.record(z.unknown()).optional()` to the `event` object of `automationTriggerSchema`; add `'monitors'` to `addFeatureLinkSchema.featureType`; add to `alertRuleInlineSettingsSchema` items `escalationPolicyId: z.string().uuid().nullable().optional(), notificationChannelIds: z.array(z.string().uuid()).optional()`; and `export * from './monitors';` at the bottom (after `automationActionSchema` is defined, to avoid a circular-init problem — `monitors.ts` imports from `./index`, so keep the re-export last).
+
+- [ ] **Step 4: Drizzle schema `apps/api/src/db/schema/monitorDefinitions.ts`**
+
+```ts
+import { pgTable, pgEnum, uuid, varchar, text, boolean, integer, jsonb, timestamp, index, uniqueIndex } from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
+import { organizations, partners } from './organizations';
+import { users } from './users';
+import { alertSeverityEnum, escalationPolicies } from './alerts';
+import { aiAgents } from './aiAgents';
+import { configPolicyFeatureLinks } from './configurationPolicies';
+
+export const monitorKindEnum = pgEnum('monitor_kind', [
+  'cpu', 'memory', 'disk', 'offline', 'event_log', 'patch_compliance',
+  'service', 'process', 'process_resource', 'cert_expiry', 'bandwidth', 'disk_io', 'network_errors',
+]);
+
+export const monitorDefinitions = pgTable('monitor_definitions', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id').references(() => organizations.id),
+  partnerId: uuid('partner_id').references(() => partners.id),
+  name: varchar('name', { length: 200 }).notNull(),
+  description: text('description'),
+  kind: monitorKindEnum('kind').notNull(),
+  enabled: boolean('enabled').notNull().default(true),
+  condition: jsonb('condition').notNull().$type<Record<string, unknown>>(),
+  severity: alertSeverityEnum('severity').notNull(),
+  cooldownMinutes: integer('cooldown_minutes').notNull().default(5),
+  autoResolve: boolean('auto_resolve').notNull().default(false),
+  autoResolveConditions: jsonb('auto_resolve_conditions'),
+  responses: jsonb('responses').notNull().default([]).$type<unknown[]>(),
+  deliveryMode: varchar('delivery_mode', { length: 16 }).notNull().default('inherit'),
+  deliveryChannelIds: jsonb('delivery_channel_ids').notNull().default([]).$type<string[]>(),
+  escalationPolicyId: uuid('escalation_policy_id').references(() => escalationPolicies.id, { onDelete: 'set null' }),
+  recurrenceThreshold: integer('recurrence_threshold'),
+  recurrenceWindowHours: integer('recurrence_window_hours'),
+  recurrenceActions: jsonb('recurrence_actions').notNull().default([]).$type<unknown[]>(),
+  pauseResponsesOnEscalation: boolean('pause_responses_on_escalation').notNull().default(true),
+  aiAgentId: uuid('ai_agent_id').references(() => aiAgents.id, { onDelete: 'set null' }),
+  compiledAlertTemplateId: uuid('compiled_alert_template_id'),
+  compiledAlertRuleId: uuid('compiled_alert_rule_id'),
+  compiledAutomationId: uuid('compiled_automation_id'),
+  compiledHash: text('compiled_hash'),
+  compiledAt: timestamp('compiled_at', { withTimezone: true }),
+  createdBy: uuid('created_by').references(() => users.id),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+}, (table) => ({
+  orgIdIdx: index('monitor_definitions_org_id_idx').on(table.orgId),
+  partnerIdIdx: index('monitor_definitions_partner_id_idx').on(table.partnerId),
+  ownerNameUidx: uniqueIndex('monitor_definitions_owner_name_uidx').on(sql`COALESCE(${table.orgId}, ${table.partnerId})`, sql`lower(${table.name})`),
+}));
+
+export const configPolicyMonitors = pgTable('config_policy_monitors', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  featureLinkId: uuid('feature_link_id').notNull().references(() => configPolicyFeatureLinks.id, { onDelete: 'cascade' }),
+  monitorId: uuid('monitor_id').notNull().references(() => monitorDefinitions.id, { onDelete: 'cascade' }),
+  enabled: boolean('enabled').notNull().default(true),
+  overrides: jsonb('overrides').$type<Record<string, unknown> | null>(),
+  sortOrder: integer('sort_order').notNull().default(0),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+}, (table) => ({
+  linkMonitorUidx: uniqueIndex('config_policy_monitors_link_monitor_uidx').on(table.featureLinkId, table.monitorId),
+  monitorIdIdx: index('config_policy_monitors_monitor_id_idx').on(table.monitorId),
+}));
+
+export type MonitorDefinitionRow = typeof monitorDefinitions.$inferSelect;
+export type ConfigPolicyMonitorRow = typeof configPolicyMonitors.$inferSelect;
+```
+
+Check the actual import paths for `organizations`, `partners`, `users`, `aiAgents` against neighbouring schema files (e.g. how `automations.ts` imports `aiAgents`) and adjust.
+
+Add to the existing tables (use `AnyPgColumn` for the forward reference to avoid an import cycle, as `configurationPolicies.ts:88` does):
+- `alerts.ts` `alertTemplates`, `alertRules`: `managedByMonitorId: uuid('managed_by_monitor_id')`; `alerts`: `monitorId: uuid('monitor_id')`.
+- `automations.ts` `automations`: `managedByMonitorId: uuid('managed_by_monitor_id')`.
+- `configurationPolicies.ts`: add `'monitors'` to `configFeatureTypeEnum`; `configPolicyAlertRules` gains `escalationPolicyId: uuid('escalation_policy_id')`, `notificationChannelIds: jsonb('notification_channel_ids').$type<string[] | null>()`.
+
+(Plain `uuid(...)` columns without `.references()` are acceptable here because the FK exists in SQL and the cycle `alerts ↔ monitorDefinitions` would otherwise need `AnyPgColumn` on both sides; the drift check compares columns, not FK declarations.)
+
+- [ ] **Step 5: Run validators, tsc, drift**
+
+```bash
+cd packages/shared && npx vitest run src/validators/monitors.test.ts
+pnpm --filter @breeze/shared build   # if index re-exports need a build for api to see them; check how api consumes shared
+pnpm --filter @breeze/api exec tsc --noEmit
+export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze" && pnpm db:check-drift
+```
+Expected: PASS / clean / no drift.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/shared/src/validators apps/api/src/db/schema
+git commit -m "feat(monitors): drizzle schema + shared validators (#5289)"
+```
+
+---
+
+### Task 3: Kind registry
+
+**Files:**
+- Create: `apps/api/src/services/monitors/kinds/types.ts`, `…/kinds/index.ts` (hub), one file per kind: `cpu.ts`, `memory.ts`, `disk.ts`, `offline.ts`, `eventLog.ts`, `patchCompliance.ts`, `service.ts`, `process.ts`, `processResource.ts`, `certExpiry.ts`, `bandwidth.ts`, `diskIo.ts`, `networkErrors.ts`
+- Test: `apps/api/src/services/monitors/kinds/index.test.ts`
+
+**Interfaces:**
+- Produces:
+
+```ts
+export interface MonitorKindSpec<C = Record<string, unknown>> {
+  kind: MonitorKind;
+  conditionSchema: z.ZodType<C>;             // from @breeze/shared monitorConditionSchemas
+  overridableKeys: readonly (keyof C & string)[];
+  defaultSeverity: 'critical' | 'high' | 'medium' | 'low' | 'info';
+  toAlertCondition(condition: C): RootCondition;   // handler-shaped object incl. `type`
+  titleTemplate: string;                     // e.g. '{{ruleName}} on {{deviceName}}'
+  messageTemplate: string;
+  agentDelivered: boolean;                   // service/process = true (watch must exist until W4)
+}
+export const MONITOR_KIND_SPECS: Record<MonitorKind, MonitorKindSpec>;
+export function getMonitorKindSpec(kind: string): MonitorKindSpec;   // throws MonitorValidationError for unknown
+export function applyOverrides<C>(spec: MonitorKindSpec<C>, condition: C, overrides: Record<string, unknown> | null | undefined): C;  // only overridableKeys, re-validated
+```
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { MONITOR_KINDS } from '@breeze/shared';
+import { validateConditions } from '../../alertConditions';
+import { MONITOR_KIND_SPECS, applyOverrides, getMonitorKindSpec } from './index';
+
+const SAMPLES: Record<string, Record<string, unknown>> = {
+  cpu: { operator: 'gt', value: 90, durationMinutes: 10 },
+  memory: { operator: 'gte', value: 85 },
+  disk: { operator: 'gt', value: 80 },
+  offline: { durationMinutes: 15 },
+  event_log: { category: 'system', level: 'error', countThreshold: 3, windowMinutes: 60 },
+  patch_compliance: { operator: 'lt', value: 80 },
+  service: { serviceName: 'Spooler', consecutiveFailures: 2 },
+  process: { processName: 'sqlservr.exe' },
+  process_resource: { resource: 'memory', processName: 'chrome.exe', operator: 'gt', value: 2048 },
+  cert_expiry: { withinDays: 14 },
+  bandwidth: { direction: 'total', operator: 'gt', value: 100 },
+  disk_io: { direction: 'write', operator: 'gt', value: 50 },
+  network_errors: { errorType: 'total', operator: 'gt', value: 100, windowMinutes: 15 },
+};
+
+describe('monitor kind registry (#5289)', () => {
+  it('has a spec for every kind and every compiled condition validates against alertConditions', () => {
+    for (const kind of MONITOR_KINDS) {
+      const spec = MONITOR_KIND_SPECS[kind];
+      expect(spec, kind).toBeDefined();
+      const condition = spec.conditionSchema.parse(SAMPLES[kind]);
+      const compiled = spec.toAlertCondition(condition);
+      expect(validateConditions(compiled), `${kind}: ${JSON.stringify(compiled)}`).toEqual([]);
+    }
+  });
+
+  it('cpu compiles to a threshold on cpuPercent', () => {
+    expect(MONITOR_KIND_SPECS.cpu.toAlertCondition({ operator: 'gt', value: 90, durationMinutes: 10 }))
+      .toEqual({ type: 'threshold', metric: 'cpuPercent', operator: 'gt', value: 90, durationMinutes: 10 });
+  });
+
+  it('process_resource picks the handler type from resource', () => {
+    expect(MONITOR_KIND_SPECS.process_resource.toAlertCondition({ resource: 'memory', processName: 'x', operator: 'gt', value: 1 }).type)
+      .toBe('process_memory_high');
+  });
+
+  it('applyOverrides only touches overridable keys and re-validates', () => {
+    const out = applyOverrides(MONITOR_KIND_SPECS.disk, { operator: 'gt', value: 80 }, { value: 95, operator: 'lt', metric: 'ramPercent' });
+    expect(out).toEqual({ operator: 'lt', value: 95 });
+    expect(() => applyOverrides(MONITOR_KIND_SPECS.disk, { operator: 'gt', value: 80 }, { value: 500 })).toThrow();
+  });
+
+  it('unknown kind throws', () => {
+    expect(() => getMonitorKindSpec('wmi_query')).toThrow(/unknown monitor kind/);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/api && npx vitest run src/services/monitors/kinds/index.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement** — `types.ts` holds the interface above plus `export class MonitorValidationError extends Error {}`. Two kinds in full; the rest follow the same shape with the field mapping from `apps/api/src/services/alertConditions/types.ts:14-101`:
+
+`cpu.ts` (memory/disk identical with `ramPercent` / `diskPercent`, default severities `high` / `high`):
+
+```ts
+import { monitorConditionSchemas } from '@breeze/shared';
+import type { MonitorKindSpec } from './types';
+
+type C = { operator: 'gt' | 'gte' | 'lt' | 'lte' | 'eq' | 'neq'; value: number; durationMinutes?: number };
+
+export const cpuKind: MonitorKindSpec<C> = {
+  kind: 'cpu',
+  conditionSchema: monitorConditionSchemas.cpu,
+  overridableKeys: ['operator', 'value', 'durationMinutes'],
+  defaultSeverity: 'high',
+  agentDelivered: false,
+  titleTemplate: 'High CPU on {{deviceName}}',
+  messageTemplate: '{{ruleName}}: CPU {{actualValue}}% ({{operator}} {{threshold}}%)',
+  toAlertCondition: (c) => ({ type: 'threshold', metric: 'cpuPercent', operator: c.operator, value: c.value, ...(c.durationMinutes ? { durationMinutes: c.durationMinutes } : {}) }),
+};
+```
+
+`processResource.ts`:
+
+```ts
+toAlertCondition: (c) => ({
+  type: c.resource === 'cpu' ? 'process_cpu_high' : 'process_memory_high',
+  processName: c.processName, operator: c.operator, value: c.value,
+  ...(c.durationMinutes ? { durationMinutes: c.durationMinutes } : {}),
+}),
+overridableKeys: ['operator', 'value', 'durationMinutes'],
+agentDelivered: true,
+```
+
+Mapping table for the rest (kind → handler `type`, passthrough fields, overridable keys, agentDelivered):
+
+| kind | type | fields | overridable | agent |
+|---|---|---|---|---|
+| offline | `offline` | durationMinutes | durationMinutes | no |
+| event_log | `event_log` | category, level, sourcePattern?, messagePattern?, countThreshold, windowMinutes | countThreshold, windowMinutes, level | no |
+| patch_compliance | `patch_compliance` | operator, value | operator, value | no |
+| service | `service_stopped` | serviceName, consecutiveFailures? | consecutiveFailures | **yes** |
+| process | `process_stopped` | processName, consecutiveFailures? | consecutiveFailures | **yes** |
+| cert_expiry | `cert_expiry` | withinDays | withinDays | no |
+| bandwidth | `bandwidth_high` | direction, operator, value, durationMinutes? | operator, value, durationMinutes | no |
+| disk_io | `disk_io_high` | direction, operator, value, durationMinutes? | operator, value, durationMinutes | no |
+| network_errors | `network_errors` | interfaceName?, errorType, operator, value, windowMinutes? | operator, value, windowMinutes | no |
+
+`index.ts` hub:
+
+```ts
+export const MONITOR_KIND_SPECS = { cpu: cpuKind, memory: memoryKind, /* … all 13 */ } as const satisfies Record<MonitorKind, MonitorKindSpec<any>>;
+
+export function getMonitorKindSpec(kind: string): MonitorKindSpec {
+  const spec = (MONITOR_KIND_SPECS as Record<string, MonitorKindSpec>)[kind];
+  if (!spec) throw new MonitorValidationError(`unknown monitor kind: ${kind}`);
+  return spec;
+}
+
+export function applyOverrides<C extends Record<string, unknown>>(spec: MonitorKindSpec<C>, condition: C, overrides: Record<string, unknown> | null | undefined): C {
+  if (!overrides) return condition;
+  const merged: Record<string, unknown> = { ...condition };
+  for (const key of spec.overridableKeys) if (key in overrides) merged[key] = overrides[key];
+  return spec.conditionSchema.parse(merged);   // zod throws on out-of-range → surfaces as 400 at the API
+}
+```
+
+- [ ] **Step 4: Run the test — PASS. Commit**
+
+```bash
+git add apps/api/src/services/monitors/kinds
+git commit -m "feat(monitors): kind registry over existing alert-condition handlers (#5289)"
+```
+
+---
+
+### Task 4: Compiler service — the only writer of managed rows
+
+**Files:**
+- Create: `apps/api/src/services/monitors/monitorCompiler.ts`, `apps/api/src/services/monitors/monitorCompiler.test.ts`
+- Create: `apps/api/src/services/monitors/monitorService.ts` (CRUD + ownership + compile orchestration), `monitorService.test.ts`
+
+**Interfaces:**
+- Produces (`monitorCompiler.ts`):
+
+```ts
+export interface CompiledRefs { alertTemplateId: string; alertRuleId: string; automationId: string; hash: string }
+export function computeCompiledHash(def: MonitorDefinitionRow): string;     // sha256 of a canonical JSON of the compile-relevant fields (everything except compiled_*, created_*, updated_at)
+export function buildCompiledTemplate(def): typeof alertTemplates.$inferInsert;   // pure
+export function buildCompiledRule(def, templateId: string): typeof alertRules.$inferInsert;   // pure; targetType 'monitor', targetId def.id, overrideSettings { notificationChannelIds, escalationPolicyId, deliveryMode }
+export function buildCompiledAutomation(def, ruleId: string): typeof automations.$inferInsert; // pure; trigger { type:'event', event:'alert.triggered', filter:{ ruleId } }, actions def.responses, managedByAgentId def.aiAgentId, managedByMonitorId def.id, enabled def.enabled, onFailure 'stop', name `[monitor] ${def.name}`
+export async function compileMonitorInTx(tx: DbTx, def: MonitorDefinitionRow): Promise<CompiledRefs>;  // upserts by managed_by_monitor_id, writes compiled_* + hash on the definition
+export async function verifyCompiled(def): Promise<{ inSync: boolean; diff: string[] }>;   // recompute pure builders and compare to stored rows (used by the contract test + reconcile job in W3)
+```
+
+- Produces (`monitorService.ts`):
+
+```ts
+export class MonitorNotFoundError extends Error {}
+export class MonitorOwnershipError extends Error {}           // → 403
+export class MonitorValidationError extends Error {}          // re-export from kinds/types → 400
+export async function listMonitorDefinitions(auth: AuthContext, filters?: { kind?: MonitorKind; enabled?: boolean }): Promise<MonitorDefinitionRow[]>;   // ownership: org rows the auth can access OR partner-wide rows when auth.scope === 'partner'
+export async function getMonitorDefinition(id: string, auth: AuthContext): Promise<MonitorDefinitionRow | null>;
+export async function createMonitorDefinition(input: CreateMonitorDefinitionInput, auth: AuthContext): Promise<MonitorDefinitionRow>;   // owner from ownerScope (canManagePartnerWidePolicies gate), kind/condition validation via registry, responses validated through the automation binding check, then compileMonitorInTx in the same transaction
+export async function updateMonitorDefinition(id: string, input: UpdateMonitorDefinitionInput, auth: AuthContext): Promise<MonitorDefinitionRow>;   // merge, re-validate the merged condition, recompile
+export async function deleteMonitorDefinition(id: string, auth: AuthContext): Promise<void>;   // cascade handles managed rows + attachments
+```
+
+- [ ] **Step 1: Write the failing pure-builder tests** (`monitorCompiler.test.ts`, no db)
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { buildCompiledTemplate, buildCompiledRule, buildCompiledAutomation, computeCompiledHash } from './monitorCompiler';
+
+const def = {
+  id: 'd0000000-0000-4000-8000-000000000001', orgId: 'o0000000-0000-4000-8000-000000000001', partnerId: null,
+  name: 'Disk over 80%', description: null, kind: 'disk', enabled: true,
+  condition: { operator: 'gt', value: 80, durationMinutes: 15 }, severity: 'high', cooldownMinutes: 30,
+  autoResolve: true, autoResolveConditions: null,
+  responses: [{ type: 'run_script', scriptId: 's0000000-0000-4000-8000-000000000001', runAs: 'system' }],
+  deliveryMode: 'channels', deliveryChannelIds: ['c0000000-0000-4000-8000-000000000001'], escalationPolicyId: null,
+  recurrenceThreshold: 3, recurrenceWindowHours: 240, recurrenceActions: [], pauseResponsesOnEscalation: true,
+  aiAgentId: null, compiledAlertTemplateId: null, compiledAlertRuleId: null, compiledAutomationId: null,
+  compiledHash: null, compiledAt: null, createdBy: null, createdAt: new Date(), updatedAt: new Date(),
+} as const;
+
+describe('monitor compiler builders (#5289)', () => {
+  it('template is built-in, managed, single root condition', () => {
+    const t = buildCompiledTemplate(def as never);
+    expect(t.isBuiltIn).toBe(true);
+    expect(t.managedByMonitorId).toBe(def.id);
+    expect(t.orgId).toBe(def.orgId); expect(t.partnerId).toBeNull();
+    expect(t.conditions).toEqual({ type: 'threshold', metric: 'diskPercent', operator: 'gt', value: 80, durationMinutes: 15 });
+    expect(Array.isArray(t.conditions)).toBe(false);
+  });
+
+  it('rule targets the monitor and carries delivery overrides', () => {
+    const r = buildCompiledRule(def as never, 't0000000-0000-4000-8000-000000000001');
+    expect(r.targetType).toBe('monitor'); expect(r.targetId).toBe(def.id);
+    expect(r.isActive).toBe(true);
+    expect(r.overrideSettings).toEqual({ notificationChannelIds: def.deliveryChannelIds, escalationPolicyId: null, deliveryMode: 'channels' });
+  });
+
+  it('automation is event-triggered on the compiled rule only, device-bound, managed', () => {
+    const a = buildCompiledAutomation(def as never, 'r0000000-0000-4000-8000-000000000001');
+    expect(a.trigger).toEqual({ type: 'event', event: 'alert.triggered', filter: { ruleId: 'r0000000-0000-4000-8000-000000000001' } });
+    expect(a.actions).toEqual(def.responses);
+    expect(a.managedByMonitorId).toBe(def.id);
+    expect(a.managedByAgentId).toBeNull();
+  });
+
+  it('hash is stable across compiled_* changes and changes with the condition', () => {
+    const h1 = computeCompiledHash(def as never);
+    const h2 = computeCompiledHash({ ...def, compiledHash: 'x', compiledAt: new Date(0) } as never);
+    const h3 = computeCompiledHash({ ...def, condition: { ...def.condition, value: 81 } } as never);
+    expect(h1).toBe(h2); expect(h1).not.toBe(h3);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails.** Run: `cd apps/api && npx vitest run src/services/monitors/monitorCompiler.test.ts`. Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the builders and `compileMonitorInTx`**
+
+```ts
+import { createHash } from 'node:crypto';
+import { eq } from 'drizzle-orm';
+import { alertTemplates, alertRules, automations, monitorDefinitions } from '../../db/schema';
+import type { MonitorDefinitionRow } from '../../db/schema/monitorDefinitions';
+import { getMonitorKindSpec } from './kinds';
+
+const COMPILE_FIELDS = ['orgId','partnerId','name','description','kind','enabled','condition','severity','cooldownMinutes','autoResolve','autoResolveConditions','responses','deliveryMode','deliveryChannelIds','escalationPolicyId','recurrenceThreshold','recurrenceWindowHours','recurrenceActions','pauseResponsesOnEscalation','aiAgentId'] as const;
+
+function canonical(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonical).join(',')}]`;
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value as object).sort().map((k) => `${JSON.stringify(k)}:${canonical((value as Record<string, unknown>)[k])}`).join(',')}}`;
+  }
+  return JSON.stringify(value ?? null);
+}
+
+export function computeCompiledHash(def: MonitorDefinitionRow): string {
+  const picked: Record<string, unknown> = {};
+  for (const f of COMPILE_FIELDS) picked[f] = def[f];
+  return createHash('sha256').update(canonical(picked)).digest('hex');
+}
+
+export function buildCompiledTemplate(def: MonitorDefinitionRow) {
+  const spec = getMonitorKindSpec(def.kind);
+  const condition = spec.conditionSchema.parse(def.condition);
+  return {
+    orgId: def.orgId, partnerId: def.partnerId,
+    name: `[monitor] ${def.name}`, description: def.description, category: 'monitor',
+    conditions: spec.toAlertCondition(condition),
+    severity: def.severity, titleTemplate: spec.titleTemplate, messageTemplate: spec.messageTemplate,
+    targets: null, autoResolve: def.autoResolve, autoResolveConditions: def.autoResolveConditions ?? null,
+    cooldownMinutes: def.cooldownMinutes, isBuiltIn: true, managedByMonitorId: def.id,
+  } satisfies typeof alertTemplates.$inferInsert;
+}
+
+export function buildCompiledRule(def: MonitorDefinitionRow, templateId: string) {
+  return {
+    orgId: def.orgId, partnerId: def.partnerId, templateId, name: def.name,
+    targetType: 'monitor', targetId: def.id,
+    overrideSettings: { notificationChannelIds: def.deliveryMode === 'channels' ? def.deliveryChannelIds : [], escalationPolicyId: def.escalationPolicyId ?? null, deliveryMode: def.deliveryMode },
+    isActive: def.enabled, managedByMonitorId: def.id,
+  } satisfies typeof alertRules.$inferInsert;
+}
+
+export function buildCompiledAutomation(def: MonitorDefinitionRow, ruleId: string) {
+  return {
+    orgId: def.orgId, partnerId: def.partnerId, name: `[monitor] ${def.name}`, description: def.description,
+    enabled: def.enabled && (def.responses as unknown[]).length > 0,
+    trigger: { type: 'event', event: 'alert.triggered', filter: { ruleId } },
+    conditions: null, actions: def.responses, onFailure: 'stop', notificationTargets: null,
+    managedByAgentId: def.aiAgentId ?? null, managedByMonitorId: def.id,
+  } satisfies typeof automations.$inferInsert;
+}
+
+export async function compileMonitorInTx(tx: DbTx, def: MonitorDefinitionRow) {
+  const template = buildCompiledTemplate(def);
+  const [t] = await tx.insert(alertTemplates).values(template)
+    .onConflictDoUpdate({ target: alertTemplates.managedByMonitorId, targetWhere: sql`managed_by_monitor_id IS NOT NULL`, set: { ...template, updatedAt: new Date() } })
+    .returning({ id: alertTemplates.id });
+  const rule = buildCompiledRule(def, t.id);
+  const [r] = await tx.insert(alertRules).values(rule)
+    .onConflictDoUpdate({ target: alertRules.managedByMonitorId, targetWhere: sql`managed_by_monitor_id IS NOT NULL`, set: rule })
+    .returning({ id: alertRules.id });
+  const automation = buildCompiledAutomation(def, r.id);
+  const [a] = await tx.insert(automations).values(automation)
+    .onConflictDoUpdate({ target: automations.managedByMonitorId, targetWhere: sql`managed_by_monitor_id IS NOT NULL`, set: { ...automation, updatedAt: new Date() } })
+    .returning({ id: automations.id });
+  const hash = computeCompiledHash(def);
+  await tx.update(monitorDefinitions).set({ compiledAlertTemplateId: t.id, compiledAlertRuleId: r.id, compiledAutomationId: a.id, compiledHash: hash, compiledAt: new Date(), updatedAt: new Date() }).where(eq(monitorDefinitions.id, def.id));
+  return { alertTemplateId: t.id, alertRuleId: r.id, automationId: a.id, hash };
+}
+```
+
+`DbTx` is `Parameters<Parameters<typeof db.transaction>[0]>[0]` (the same alias `configurationPolicy.ts:705` uses). Drizzle's `onConflictDoUpdate` with a partial unique index needs `targetWhere`; if the installed Drizzle version lacks it, do `select … where managedByMonitorId = def.id` then insert/update explicitly — same semantics, one extra query.
+
+The automation's `actions` must pass `normalizeAutomationActions` (`automationRuntime.ts:598`) — call it in `createMonitorDefinition` before compiling so a bad action is a `400 MonitorValidationError`, not a worker-time failure. Also run the `automationResourceBindings` ownership check the automations route performs on create (find it in `routes/automations.ts` POST handler around the `ownerScope` block) so a partner-wide monitor cannot reference an org-owned script.
+
+- [ ] **Step 4: `monitorService.ts`** — follow `routes/alerts/rules.ts:305` for the `ownerScope` → owner resolution and `canManagePartnerWidePolicies`; the transaction wraps `insert monitor_definitions` → `compileMonitorInTx`. `updateMonitorDefinition` loads the row with ownership check, merges `input`, validates `condition` via `getMonitorKindSpec(merged.kind).conditionSchema.parse`, updates, recompiles. `listMonitorDefinitions` reads: `or(auth.orgCondition(monitorDefinitions.orgId), auth.scope === 'partner' && auth.partnerId ? and(isNull(monitorDefinitions.orgId), eq(monitorDefinitions.partnerId, auth.partnerId)) : sql\`false\`)` — the dual-axis read pattern from the CLAUDE.md playbook step 3.
+
+Unit test (`monitorService.test.ts`, Drizzle mocks per `automationRuntime.test.ts:7-9` style): partner-wide create by an org-scoped auth → `MonitorOwnershipError`; `ai_triage` response without `aiAgentId` → `MonitorValidationError`; condition failing the kind schema → `MonitorValidationError`.
+
+- [ ] **Step 5: Run, tsc, commit**
+
+```bash
+cd apps/api && npx vitest run src/services/monitors && pnpm --filter @breeze/api exec tsc --noEmit
+git add apps/api/src/services/monitors
+git commit -m "feat(monitors): compiler + service — managed template/rule/automation rows (#5289)"
+```
+
+---
+
+### Task 5: Managed-row guards on every other writer
+
+**Files:**
+- Modify: `apps/api/src/routes/automations.ts:1160-1166` (update), `:1349-1352` (delete), the manual-run handler (grep `automationRoutes.post('/:id/run'`), and enable/disable if they are separate handlers
+- Modify: `apps/api/src/routes/alerts/rules.ts:505-514` (PUT), `:729-733` (DELETE)
+- Modify: `apps/api/src/routes/alertTemplates/templates.ts:360-368` (PATCH), `:421-429` (DELETE)
+- Modify: `apps/api/src/services/aiToolsFleet.ts:1614-1641` (`manage_automations` enable/disable/run actions)
+- Create: `apps/api/src/services/monitors/managedRowGuard.ts`
+- Test: `apps/api/src/routes/automations.managedByMonitor.test.ts`, `apps/api/src/routes/alerts/rules.managedByMonitor.test.ts`, `apps/api/src/routes/alertTemplates/templates.managedByMonitor.test.ts` (create; copy the request/mocking preamble from the nearest existing `*.test.ts` in each folder)
+
+**Interfaces:**
+- Produces: `export const MANAGED_BY_MONITOR_ERROR = { automations: 'automation_managed_by_monitor', alert_rules: 'alert_rule_managed_by_monitor', alert_templates: 'alert_template_managed_by_monitor' } as const;` and `export function managedByMonitorResponse(c: Context, table: keyof typeof MANAGED_BY_MONITOR_ERROR, monitorId: string)` returning `c.json({ error: MANAGED_BY_MONITOR_ERROR[table], monitorId }, 409)`.
+
+- [ ] **Step 1: Write the failing route tests** — one representative (`automations.managedByMonitor.test.ts`):
+
+```ts
+it('PUT /automations/:id on a monitor-managed automation is 409 automation_managed_by_monitor', async () => {
+  mockSelectAutomation({ id: 'a1', orgId: ORG, partnerId: null, managedByAgentId: null, managedByMonitorId: 'm1', enabled: true, trigger: {}, actions: [] });
+  const res = await app.request('/automations/a1', { method: 'PUT', headers: authHeaders(), body: JSON.stringify({ name: 'x' }) });
+  expect(res.status).toBe(409);
+  expect(await res.json()).toEqual({ error: 'automation_managed_by_monitor', monitorId: 'm1' });
+});
+```
+
+Equivalent tests for DELETE and `POST /:id/run`, for alert rules PUT/DELETE (`alert_rule_managed_by_monitor`), templates PATCH/DELETE (`alert_template_managed_by_monitor`), and for `manage_automations` with `action: 'disable'` returning `{ error: 'automation_managed_by_monitor', monitorId }`.
+
+- [ ] **Step 2: Run to verify they fail** (status 200/204 today).
+
+- [ ] **Step 3: Implement** — in each handler, immediately after the row is loaded and before the ownership/MFA branches:
+
+```ts
+if (automation.managedByMonitorId) return managedByMonitorResponse(c, 'automations', automation.managedByMonitorId);
+```
+
+(`rule.managedByMonitorId` / `existing.managedByMonitorId` for the alert tables.) The `GET` handlers are untouched; list responses include `managedByMonitorId` so the web can render read-only rows.
+
+- [ ] **Step 4: Run all three suites + tsc, commit**
+
+```bash
+git commit -m "feat(monitors): refuse edits to monitor-managed rules, templates, automations (#5289)"
+```
+
+---
+
+### Task 6: Resolver — cumulative attachments per device, `'monitor'` target type, per-device overrides, `alerts.monitor_id`
+
+**Files:**
+- Create: `apps/api/src/services/monitors/monitorResolver.ts`, `monitorResolver.test.ts`
+- Modify: `apps/api/src/services/alertService.ts:591-670` (`getApplicableRules`), `:31-38` (`CreateAlertParams`), `:124-127` (insert), `:700-735` (`evaluateDeviceAlerts` loop)
+- Modify: `apps/api/src/db/schema/configurationPolicies.ts` (nothing new; the resolver reads `configPolicyAssignments`, `configPolicyFeatureLinks`, `configurationPolicies.parentPolicyId`)
+
+**Interfaces:**
+- Produces:
+
+```ts
+export type AssignmentLevel = 'partner' | 'organization' | 'site' | 'device_group' | 'device';
+export interface EffectiveMonitor {
+  monitorId: string;
+  enabled: boolean;
+  overrides: Record<string, unknown> | null;
+  sourcePolicyId: string;      // the policy whose attachment row won
+  sourceLevel: AssignmentLevel;
+  inheritedFromParent: boolean;
+}
+export async function resolveMonitorsForDevice(deviceId: string, executor?: DbExecutor): Promise<EffectiveMonitor[]>;   // system-context read (runs in the sweep); see algorithm
+export async function resolveMonitorOverrideForDevice(deviceId: string, monitorId: string): Promise<Record<string, unknown> | null>;
+```
+
+Algorithm for `resolveMonitorsForDevice` (copy the assignment collection from `resolveEffectiveConfigWithExecutor`, `configurationPolicy.ts` — the block that queries `configPolicyAssignments` per level using `deviceGroupMemberships`, `device.siteId`, `device.orgId`, `organizations.partnerId`, and honours `roleFilter`/`osFilter` the same way):
+
+1. Collect `{ policyId, level, priority }` for every assignment matching the device at all five levels.
+2. For each policy, also load `parentPolicyId`; add `{ policyId: parent, level, priority, inheritedFromParent: true }` when non-null.
+3. Load `config_policy_feature_links` where `configPolicyId IN (…)` and `featureType = 'monitors'`; load `config_policy_monitors` for those links.
+4. Group rows by `monitorId`; rank each candidate by `(levelRank, inheritedFromParent ? 1 : 0, -priority)` with `levelRank` device=0, device_group=1, site=2, organization=3, partner=4; the lowest wins.
+5. Return the winners (including `enabled: false` winners — callers filter; the API's "effective monitors" view wants to show a disabled override).
+
+- [ ] **Step 1: Write the failing resolver unit test** (pure ranking, extract `pickWinner(candidates)` so it is testable without a db):
+
+```ts
+it('site override beats org baseline; child beats its parent at the same level (#5289)', () => {
+  const winner = pickWinner([
+    { monitorId: 'm', enabled: true, overrides: null, sourcePolicyId: 'org-base', sourceLevel: 'organization', inheritedFromParent: false, priority: 0 },
+    { monitorId: 'm', enabled: false, overrides: null, sourcePolicyId: 'site-x', sourceLevel: 'site', inheritedFromParent: false, priority: 0 },
+    { monitorId: 'm', enabled: true, overrides: { value: 95 }, sourcePolicyId: 'site-x-parent', sourceLevel: 'site', inheritedFromParent: true, priority: 0 },
+  ]);
+  expect(winner.sourcePolicyId).toBe('site-x');
+  expect(winner.enabled).toBe(false);
+});
+```
+
+- [ ] **Step 2: Run to verify it fails; implement; PASS.**
+
+- [ ] **Step 3: Hook into `getApplicableRules`** — write the failing test in `alertService.test.ts` (existing file; find its mocking preamble): mock `resolveMonitorsForDevice` to return `[{ monitorId: 'm1', enabled: true, overrides: { value: 95 } }]`, mock the rules select to return a rule `{ targetType: 'monitor', targetId: 'm1', managedByMonitorId: 'm1' }` with a template whose `conditions` is `{ type: 'threshold', metric: 'diskPercent', operator: 'gt', value: 80 }` and a `monitor_definitions` row of kind `disk`; assert the returned `effectiveConditions.value === 95` and that a second effective monitor with `enabled: false` yields **no** rule.
+
+Implementation in `getApplicableRules` (after `targetConditions` is built, before the query):
+
+```ts
+const effectiveMonitors = await resolveMonitorsForDevice(deviceId);
+const enabledMonitorIds = effectiveMonitors.filter((m) => m.enabled).map((m) => m.monitorId);
+if (enabledMonitorIds.length > 0) {
+  targetConditions.push(and(eq(alertRules.targetType, 'monitor'), inArray(alertRules.targetId, enabledMonitorIds)));
+}
+```
+
+and when building each `result.push({...})`, for rules with `rule.managedByMonitorId`:
+
+```ts
+const effective = effectiveMonitors.find((m) => m.monitorId === rule.managedByMonitorId);
+if (effective?.overrides) {
+  const def = monitorDefinitionsById.get(rule.managedByMonitorId);   // one batched select for the managed rules in this call
+  const spec = getMonitorKindSpec(def.kind);
+  effectiveConditions = spec.toAlertCondition(applyOverrides(spec, spec.conditionSchema.parse(def.condition), effective.overrides));
+  effectiveSeverity = (effective.overrides.severity as AlertSeverity | undefined) ?? effectiveSeverity;
+}
+```
+
+Add `monitorId?: string | null` to `CreateAlertParams`, write it in the `alerts` insert, and pass `monitorId: rule.managedByMonitorId ?? null` from the `evaluateDeviceAlerts` loop. `RuleWithTemplate` gains `monitorId: string | null`.
+
+Ownership: `alertRuleOwnershipConditionForOrg(device.orgId)` already admits partner-wide rules for the device's partner, so a partner-wide compiled rule is visible; the `'monitor'` target branch then restricts it to devices whose attachment resolution includes it.
+
+- [ ] **Step 4: Run `alertService` suites + resolver tests + tsc, commit**
+
+```bash
+git commit -m "feat(monitors): cumulative attachment resolver + 'monitor' target type in the alert sweep (#5289)"
+```
+
+---
+
+### Task 7: `monitors` feature type — decompose / assemble / delete, route validation
+
+**Files:**
+- Modify: `apps/api/src/services/configurationPolicy.ts:701-731` (`decomposeInlineSettings`), `:1120-1130` (delete-by-link block that clears `configPolicyAlertRules`), `:1188-1215` (`assembleInlineSettings`), `:2417` (`PARTNER_LINKABLE_FEATURE_TYPES` — leave; monitors use inline items, not `featurePolicyId`)
+- Modify: `apps/api/src/routes/configurationPolicies/featureLinks.ts:107-155` (POST), `:302-330` (PATCH) — per-type inline validation: parse `monitorsInlineSettingsSchema` and verify every `monitorId` is visible to `auth` via `getMonitorDefinition`
+- Modify: `packages/shared/src/constants/index.ts` — confirm `ORG_SCOPED_ONLY_FEATURE_TYPES` does **not** include `'monitors'` (partner-wide policies may attach monitors)
+- Test: `apps/api/src/services/configurationPolicy.monitors.test.ts` (create), `apps/api/src/routes/configurationPolicies/featureLinks.monitors.test.ts` (create)
+
+- [ ] **Step 1: Failing tests** — `decomposeInlineSettings('link1', 'monitors', { items: [{ monitorId: 'm1', enabled: false, overrides: { value: 95 } }] }, tx)` inserts one `config_policy_monitors` row with those fields; `assembleInlineSettings('monitors', 'link1')` returns `{ items: [...] }` ordered by `sortOrder`; POST `/configuration-policies/:id/features` with `featureType: 'monitors'` and a `monitorId` the auth cannot see → `400 { error: 'Unknown monitorId' }`.
+
+- [ ] **Step 2: Run to verify they fail; implement** — mirror the `alert_rule` cases exactly (`insert … values(items.map(...))`, `delete … where featureLinkId`, `select … orderBy(asc(sortOrder))`). Include `monitorId, enabled, overrides, sortOrder` in the assembled items. In the route, the attachment-compatibility trigger is the authority (23514 → map to `400 { error: 'MONITOR_NOT_ATTACHABLE' }` in the existing pg-error mapping the file uses for #5080's 23514).
+
+- [ ] **Step 3: Run, tsc, commit** — `git commit -m "feat(monitors): 'monitors' config-policy feature type (#5289)"`.
+
+---
+
+### Task 8: Routes — `/monitors` and `convert-to-monitor`
+
+**Files:**
+- Create: `apps/api/src/routes/monitors.ts`, `apps/api/src/routes/monitors.test.ts`
+- Modify: `apps/api/src/index.ts:794` area — `api.route('/monitors', monitorRoutes);`
+- Modify: `apps/api/src/routes/alerts/rules.ts` — add `POST /rules/:id/convert-to-monitor`
+- Modify: `apps/api/src/openapi.ts` (register the new paths the way `/automations` is registered; grep `automations` in that file)
+
+**Interfaces (all `requireScope('organization', 'partner', 'system')`; reads `requirePermission('alerts','read')`, writes `requirePermission('alerts','write')` + `requireMfa()`):**
+
+| route | body / response |
+|---|---|
+| `GET /monitors?kind=&enabled=` | `{ data: (MonitorDefinitionRow & { attachmentCount: number })[] }` — `attachmentCount` via a `count(*)` subquery on `config_policy_monitors`; the web list renders it |
+| `GET /monitors/kinds` | `{ data: [{ kind, overridableKeys, defaultSeverity, agentDelivered, conditionSchema: zodToJsonSchema(spec.conditionSchema) }] }` (`zod-to-json-schema` is already a dependency if `openapi.ts` uses it; otherwise return `conditionSchema: null` and let the web use its own copy of `monitorConditionSchemas` from `@breeze/shared`) |
+| `POST /monitors` | `createMonitorDefinitionSchema` → `201 { data }`; `403 PARTNER_WIDE_WRITE_DENIED_MESSAGE`; `400 { error: 'INVALID_MONITOR', details }` |
+| `GET /monitors/:id` | `{ data: { ...row, attachments: [{ id, configPolicyId, policyName, enabled, overrides }], compiled: { alertRuleId, automationId } } }` |
+| `PATCH /monitors/:id` | `updateMonitorDefinitionSchema` → `{ data }` |
+| `DELETE /monitors/:id` | `204` |
+| `POST /monitors/:id/attachments` | `{ configPolicyId } \| { createPolicyFor: { level: 'site' \| 'device_group' \| 'organization', targetId, name? } }` → `201 { data: attachment }`; uses `addFeatureLink`/`updateFeatureLink` with `featureType: 'monitors'` (append the item) and `createConfigPolicy` + `assignPolicy` for the create form |
+| `DELETE /monitors/:id/attachments/:attachmentId` | `204` (removes the item; removes the feature link when empty) |
+| `GET /monitors/:id/devices` | `{ data: [{ deviceId, deviceName, enabled, overrides, sourcePolicyId, sourceLevel }] }` — W2 returns resolution only; W3 adds state/episodes |
+| `POST /monitors/:id/test` | `{ deviceId }` → `{ data: EvaluationResult }` via `evaluateConditions(compiledCondition, deviceId)` |
+| `POST /alerts/rules/:id/convert-to-monitor` | builds a definition from the rule + template when the template's root condition maps to a single kind (`threshold` with a known metric, `offline`, `event_log`, `patch_compliance`, `service_stopped`, `process_stopped`, `cert_expiry`, `bandwidth_high`, `disk_io_high`, `network_errors`; groups → `409 { error: 'RULE_NOT_CONVERTIBLE' }`), creates the monitor, creates a policy named `Converted: <rule name>` assigned like the rule's `targetType/targetId` (`all` → organization-level on the rule's org, or partner-level for partner-wide), attaches, sets the old rule `isActive = false` and `overrideSettings.convertedToMonitorId`. All in one transaction. Response `201 { data: { monitorId, configPolicyId } }` |
+
+- [ ] **Step 1: Failing route tests** — create/list/get/patch/delete happy paths with Drizzle mocks; `POST /monitors` with `ownerScope: 'partner'` from an org-scoped auth → 403; `PATCH` with a condition that fails the kind schema → 400; `POST /alerts/rules/:id/convert-to-monitor` on a group-conditioned template → 409.
+
+- [ ] **Step 2: Run to verify they fail; implement** following `routes/alerts/rules.ts` for middleware order, `getAlertRuleWithOrgCheck`-style ownership helper (`getMonitorDefinition(id, auth)` returning null → 404), and `extractApiError`-friendly error bodies. Mount in `index.ts`.
+
+- [ ] **Step 3: Run, tsc, commit** — `git commit -m "feat(monitors): /monitors routes + convert-to-monitor (#5289)"`.
+
+---
+
+### Task 9: Delivery parity for config-policy alerts
+
+**Files:**
+- Modify: `apps/api/src/services/notificationDispatcher.ts:257-266` (rule overrides lookup), `:372-374` (escalation)
+- Modify: `apps/api/src/services/configurationPolicy.ts` `decomposeInlineSettings` / `assembleInlineSettings` `alert_rule` cases (carry `escalationPolicyId`, `notificationChannelIds`)
+- Test: `apps/api/src/services/notificationDispatcher.configPolicyOverrides.test.ts` (create)
+
+- [ ] **Step 1: Failing test** — an alert with `ruleId: null`, `configPolicyId: 'cpar1'` (the `config_policy_alert_rules` id — that column name is historical) whose row has `escalationPolicyId: 'e1'` and `notificationChannelIds: ['c1']` → dispatcher sends to `c1` and calls `scheduleEscalation(alertId, 'e1', …)`.
+
+- [ ] **Step 2: Implement** — in the dispatcher, after the `if (alert.ruleId)` block:
+
+```ts
+} else if (alert.configPolicyId) {
+  const [cpRule] = await db.select({ escalationPolicyId: configPolicyAlertRules.escalationPolicyId, notificationChannelIds: configPolicyAlertRules.notificationChannelIds })
+    .from(configPolicyAlertRules).where(eq(configPolicyAlertRules.id, alert.configPolicyId)).limit(1);
+  if (cpRule) {
+    ruleOverrides = { escalationPolicyId: cpRule.escalationPolicyId ?? undefined, notificationChannelIds: cpRule.notificationChannelIds ?? [] };
+    channelIds = cpRule.notificationChannelIds ?? [];
+  }
+}
+```
+
+so the existing `escalationPolicyId = ruleOverrides?.escalationPolicyId` line at `:372` works unchanged.
+
+- [ ] **Step 3: Run, tsc, commit** — `git commit -m "fix(alerts): config-policy alert rules honour escalation policy and channel overrides (#5289)"`.
+
+---
+
+### Task 10: Tenancy registrations and export policy
+
+**Files:**
+- Modify: `apps/api/src/services/tenantCascade.ts:67+` (`CORE_ORG_CASCADE_DELETE_ORDER`): insert `'monitor_definitions'` alphabetically. (`config_policy_monitors` has no `org_id`; FK cascade handles it.) Check FK direction: `alert_templates`, `alert_rules`, `automations`, `alerts` reference `monitor_definitions` with `ON DELETE CASCADE`/`SET NULL`, and `monitor_definitions` references `escalation_policies`, `ai_agents`, `users`, `organizations`, `partners` — alphabetical `monitor_definitions` sits after `alert_*`/`automations`/`alerts` and before `organizations`/`partners`; because the referencing tables cascade on delete of the definition, either order works, but the contract test's FK-children-before-parents check must pass — run it.
+- Modify: `apps/api/src/services/tenantExportPolicyRegistry.ts`: add
+
+```ts
+"monitor_definitions": tablePolicy("org_id", {"included":["id","org_id","partner_id","name","description","kind","enabled","severity","cooldown_minutes","auto_resolve","delivery_mode","escalation_policy_id","recurrence_threshold","recurrence_window_hours","pause_responses_on_escalation","ai_agent_id","compiled_alert_template_id","compiled_alert_rule_id","compiled_automation_id","compiled_hash","compiled_at","created_by","created_at","updated_at"],"reviewedIncluded":[],"excludedSensitive":[],"excludedOpen":["condition","auto_resolve_conditions","responses","delivery_channel_ids","recurrence_actions"]}),
+```
+
+and extend the existing entries: `alerts` `included` += `monitor_id`; `alert_rules`, `alert_templates`, `automations` `included` += `managed_by_monitor_id`; `config_policy_alert_rules` (if registered — it has no `org_id`, so likely not; verify with grep) `included` += `escalation_policy_id`, `excludedOpen` += `notification_channel_ids`.
+- Modify: `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts:315` `DUAL_AXIS_TENANT_TABLES` += `'monitor_definitions'`; `:679` `PARENT_FK_JOIN_POLICY_TABLES` += `['config_policy_monitors', ['configuration_policies']]`.
+- Modify: `apps/api/src/services/orgMergeRegistry.ts:518+` `REPOINT_TABLES` += `'monitor_definitions'`.
+- Modify: `apps/api/src/routes/devices/core.ts`: nothing this wave (no device-keyed tables until W3).
+
+- [ ] **Step 1: Run the static contract tests that do not need a DB**
+
+Run: `cd apps/api && npx vitest run src/routes/devices/cascadeDelete.test.ts src/services/tenantExportPolicyRegistry`
+Expected: PASS.
+
+- [ ] **Step 2: Commit** — `git commit -m "chore(monitors): tenancy registrations — cascade, export policy, RLS lists, org merge (#5289)"`.
+
+---
+
+### Task 11: Integration suites (real Postgres)
+
+**Files:**
+- Create: `apps/api/src/__tests__/integration/monitorDefinitionsPartnerRls.integration.test.ts` (copy the shape of `ssoProvidersPartnerRls.integration.test.ts`)
+- Create: `apps/api/src/__tests__/integration/monitorCompiler.integration.test.ts`
+- Create: `apps/api/src/__tests__/integration/monitorResolver.integration.test.ts`
+
+There are **no** device / config-policy / alert fixture helpers in `db-utils.ts` (only partner, org, site, user, role, catalog). Build fixtures with the real services: `createConfigPolicy`, `addFeatureLink`, `assignPolicy` from `services/configurationPolicy.ts`, a direct `db.insert(devices)` inside `withSystemDbAccessContext` for devices (copy the minimal device insert another integration suite uses — grep `insert(devices)` under `__tests__/integration`), and `createMonitorDefinition` from Task 4.
+
+- [ ] **Step 1: `monitorDefinitionsPartnerRls`** — `describe('monitor_definitions RLS — dual-axis (#5289)')`:
+  - partner A inserts a partner-axis definition (org_id NULL) — ok;
+  - partner B forging partner A's `partner_id` → `42501`;
+  - both axes set / neither set → `23514`;
+  - org-scope caller under partner A cannot see A's partner-wide row via org context, and **can** when the read goes through the partner context (documents the app-layer gate);
+  - attaching partner A's definition to a policy owned by an org under partner **B** → `23514` with constraint `config_policy_monitors_compat` (the deferred trigger fires at commit; assert on the thrown pg error after the transaction).
+
+- [ ] **Step 2: `monitorCompiler.integration`** — create a `disk` monitor with one `run_script` response and `deliveryMode: 'channels'`; assert exactly one `alert_templates`, `alert_rules`, `automations` row with `managed_by_monitor_id`; `verifyCompiled(def).inSync === true`; update the threshold → the same three ids, new `compiled_hash`, rule template conditions updated; `PUT /alerts/rules/:compiledRuleId` through the app → 409; delete the monitor → all three rows gone and no orphan attachment.
+
+- [ ] **Step 3: `monitorResolver.integration`** — partner-wide parent policy (attached: monitors M1, M2) → org child policy with `parentPolicyId` = parent (attached: M3, and M2 with `enabled: false`) assigned at organization level → site policy (attached: M1 with `overrides: { value: 95 }`) assigned at site level → a device in that site resolves `{ M1: enabled, overrides value 95, sourceLevel site }, { M2: disabled, sourcePolicy child }, { M3: enabled }`; a device in another site of the same org resolves M1 enabled without overrides, M2 disabled, M3 enabled; a device in an org under a different partner resolves nothing. Then run `getApplicableRules(deviceId)` and assert the M1 compiled rule appears with `effectiveConditions.value === 95` and the M2 rule does not appear.
+
+- [ ] **Step 4: Run the three suites**
+
+```bash
+cd apps/api && npx vitest run -c vitest.integration.config.ts src/__tests__/integration/monitorDefinitionsPartnerRls src/__tests__/integration/monitorCompiler src/__tests__/integration/monitorResolver
+```
+Expected: PASS. Commit — `git commit -m "test(monitors): partner RLS, compile round-trip, cumulative resolver (#5289)"`.
+
+---
+
+### Task 12: Live-DB contract suites, docs touch, PR
+
+- [ ] **Step 1: Contract suites that guard registrations (need a DB)**
+
+```bash
+cd apps/api && npx vitest run -c vitest.integration.config.ts src/__tests__/integration/rls-coverage.integration.test.ts src/__tests__/integration/tenantCascade.integration.test.ts src/__tests__/integration/tenant-export-policy.integration.test.ts src/__tests__/integration/tenantExportErasureRoundtrip.integration.test.ts
+npx vitest run -c vitest.config.rls.ts
+```
+Expected: all PASS. A red here is a missed registration from Task 10, not a reason to skip.
+
+- [ ] **Step 2: Docs** — `apps/docs/src/content/docs/api/` (or wherever the REST reference lives; grep `alert-templates` under `apps/docs`) gains a `/monitors` section listing the routes from Task 8; `features/alerts.mdx` (or the page that documents config-policy alert rules) notes the new `escalationPolicyId` / `notificationChannelIds` fields. Keep it to what shipped; the Monitors UI page is documented in the web plan.
+
+- [ ] **Step 3: Full unit suite for the API, lint, tsc**
+
+```bash
+pnpm --filter @breeze/api exec tsc --noEmit
+cd apps/api && npx vitest run
+pnpm lint
+```
+
+- [ ] **Step 4: Open the PR** — title `feat(monitors): W02 API foundation — definitions, attachments, compiler, resolver (#5287)`; body per task, spec path, `Refs #5289` (the web/tools PR closes the wave), the note that `manage_automations` already refused create/update/delete and now also refuses enable/disable/run on managed rows, and the #5240 dependency for responses. Run `/pr-review-toolkit:review-pr`; fix confirmed findings inline; `gh pr merge <N> --squash` on green.

--- a/docs/superpowers/plans/monitoring/2026-09-08-monitoring-automation-unification-02-web-and-tools.md
+++ b/docs/superpowers/plans/monitoring/2026-09-08-monitoring-automation-unification-02-web-and-tools.md
@@ -1,0 +1,299 @@
+---
+tracking_issue: LanternOps/breeze#5287
+wave_issue: LanternOps/breeze#5289
+branch: feature/5287-monitoring-automation-unification/wave-5289-web
+---
+
+# Monitoring & Automation Unification — W02 Web and Tools Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give technicians the Monitors page, the monitor editor, the config-policy Monitors tab, legacy-rule conversion, and the AI/MCP tools on top of the W02 API (`…-02-api-foundation.md`), and make every managed row read-only in the existing UIs.
+
+**Architecture:** `/monitoring` becomes the Monitors list (the network page moves to `/monitoring/network`; the W01 tab strip gains Monitors and Legacy rules). A `MonitorEditor` composes six cards over one react-hook-form; the Respond card reuses an `ActionsEditor` extracted from `AutomationForm` so both forms share one action UI. Condition fields render from a per-kind field map that mirrors `monitorConditionSchemas` in `@breeze/shared`. The config-policy `MonitorsTab` follows `VulnerabilityTab` (`useFeatureLink` + `onLinkChanged`) and stores `{ items: [{ monitorId, enabled, overrides }] }`. Managed automations/templates render read-only with a link to their monitor. MCP gets `list_monitors` / `get_monitor` (Tier 1) and `manage_monitors` (Tier 3).
+
+**Tech Stack:** Astro pages + React islands, react-hook-form + zod (`@breeze/shared` validators), react-i18next with a new `monitoring` namespace (auto-registered from `locales/<locale>/monitoring.json`), Vitest + jsdom; Hono `registerTool` pattern for AI tools.
+
+**Spec:** `docs/superpowers/specs/monitoring/2026-09-08-monitoring-automation-unification-design.md` (§Navigation and web, §API, §AI)
+
+**Tracking:** feature LanternOps/breeze#5287, wave #5289. Branch `feature/5287-monitoring-automation-unification/wave-5289-web`, cut from the API plan's branch once its PR is merged (or rebased onto main after). PR body `Closes #5289`.
+
+## Global Constraints
+
+- Depends on the API plan's routes: `GET/POST /monitors`, `GET /monitors/kinds`, `GET/PATCH/DELETE /monitors/:id`, `POST /monitors/:id/attachments`, `DELETE /monitors/:id/attachments/:attachmentId`, `GET /monitors/:id/devices`, `POST /monitors/:id/test`, `POST /alerts/rules/:id/convert-to-monitor`, and `managedByMonitorId` on automation / rule / template payloads.
+- New namespace file `apps/web/src/locales/<locale>/monitoring.json` in all 8 locales (`de-DE, en, es-419, fr-CA, fr-FR, it-IT, pt-BR, tr-TR`). `keyUsage.test.ts` fails on any `t('…')` key missing from `en`; `localeParity.test.ts` fails on any key missing from a locale. Dynamic keys need the `/* i18n-dynamic */` marker.
+- Mutations go through `runAction` (`apps/web/src/lib/runAction.ts`); the `no-silent-mutations` test guards the handler set.
+- Hash state for in-page tabs; path-based tab strip for the hub (W01 decision).
+- Managed rows (`managedByMonitorId` set) are never editable from the automation, alert-rule, or template UIs — the API returns 409, and the UI must not offer the button.
+- Every task: red test first, `pnpm --filter @breeze/web test --run <file>`, commit. Before the PR: lint, the i18n suites, `pnpm --filter @breeze/web build`.
+
+---
+
+### Task 1: Extract `ActionsEditor` from `AutomationForm`
+
+**Files:**
+- Create: `apps/web/src/components/automations/ActionsEditor.tsx`, `ActionsEditor.test.tsx`
+- Modify: `apps/web/src/components/automations/AutomationForm.tsx:62-84` (`actionSchema` → export), `:280-284` (`useFieldArray` for actions), `:648-700` (the rendered actions section)
+- Test: `apps/web/src/components/automations/AutomationForm.test.tsx` (existing; must stay green)
+
+**Interfaces:**
+- Produces: `export const actionSchema` (moved, unchanged shape, now also accepts `'ai_triage'` **only** when the `allowAiTriage` prop is set — see below) and
+
+```tsx
+export interface ActionsEditorProps {
+  /** react-hook-form field-array name, e.g. 'actions' or 'recurrenceActions' */
+  name: string;
+  /** Show the ai_triage option (monitor editor with an AI agent selected). Default false. */
+  allowAiTriage?: boolean;
+  /** Hide the "when offline" selector (monitor responses are always device-bound; queueing still applies). Default false. */
+  compact?: boolean;
+}
+export default function ActionsEditor(props: ActionsEditorProps): JSX.Element;   // uses useFormContext(); parent must wrap in <FormProvider>
+```
+
+- [ ] **Step 1: Write the failing test** (`ActionsEditor.test.tsx`)
+
+```tsx
+import '@/lib/i18n';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { describe, it, expect } from 'vitest';
+import ActionsEditor from './ActionsEditor';
+
+function Host({ allowAiTriage = false }: { allowAiTriage?: boolean }) {
+  const form = useForm({ defaultValues: { actions: [{ type: 'run_script' }] } });
+  return (
+    <FormProvider {...form}>
+      <ActionsEditor name="actions" allowAiTriage={allowAiTriage} />
+      <output data-testid="count">{form.watch('actions').length}</output>
+    </FormProvider>
+  );
+}
+
+describe('ActionsEditor (#5289)', () => {
+  it('adds and removes actions through the form context', () => {
+    render(<Host />);
+    fireEvent.click(screen.getByRole('button', { name: /add action/i }));
+    expect(screen.getByTestId('count').textContent).toBe('2');
+    fireEvent.click(screen.getAllByRole('button', { name: /remove action/i })[0]);
+    expect(screen.getByTestId('count').textContent).toBe('1');
+  });
+
+  it('offers ai_triage only when allowed', () => {
+    const { unmount } = render(<Host />);
+    expect(screen.queryByRole('option', { name: /ai triage/i })).toBeNull();
+    unmount();
+    render(<Host allowAiTriage />);
+    expect(screen.getByRole('option', { name: /ai triage/i })).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails** — `pnpm --filter @breeze/web test --run src/components/automations/ActionsEditor.test.tsx` → module not found.
+
+- [ ] **Step 3: Extract** — move the JSX between the actions `<h3>` (line ~651) and the end of the actions list into `ActionsEditor`, replacing `register`/`control`/`errors`/`watch` with `const { register, control, formState: { errors }, watch } = useFormContext();` and `useFieldArray({ control, name })`. Keep every existing i18n key (`automationForm.actions.*`, `automationForm.sections.*`) so no locale changes are needed. The remove button gets `aria-label={t('automationForm.actions.removeAction')}` (add this key to `scripts.json` in all 8 locales if it does not exist: en `"Remove action"`, de-DE `"Aktion entfernen"`, es-419 `"Quitar acción"`, fr-CA/fr-FR `"Retirer l'action"`, it-IT `"Rimuovi azione"`, pt-BR `"Remover ação"`, tr-TR `"Eylemi kaldır"`). In `AutomationForm`, wrap the `<form>` in `<FormProvider {...formMethods}>` and render `<ActionsEditor name="actions" />` where the section was. Add `'ai_triage'` to `actionSchema`'s enum; `ActionsEditor` filters it out of the `<select>` options unless `allowAiTriage`.
+
+- [ ] **Step 4: Run both suites — PASS.** `pnpm --filter @breeze/web test --run src/components/automations`. Commit: `git commit -m "refactor(web): extract ActionsEditor from AutomationForm (#5289)"`.
+
+---
+
+### Task 2: `monitoring` locale namespace + kind field map
+
+**Files:**
+- Create: `apps/web/src/locales/{8 locales}/monitoring.json`
+- Create: `apps/web/src/components/monitoring/monitorKindFields.ts`, `monitorKindFields.test.ts`
+
+**Interfaces:**
+- Produces:
+
+```ts
+export type FieldKind = 'number' | 'text' | 'select' | 'operator';
+export interface KindField { key: string; labelKey: string; kind: FieldKind; options?: readonly string[]; min?: number; max?: number; step?: number; optional?: boolean; unit?: string }
+export const MONITOR_KIND_FIELDS: Record<MonitorKind, readonly KindField[]>;   // MonitorKind from @breeze/shared
+export function defaultConditionFor(kind: MonitorKind): Record<string, unknown>;  // first valid values, e.g. cpu → { operator: 'gt', value: 90, durationMinutes: 5 }
+```
+
+Field map (keys must match `monitorConditionSchemas` in `packages/shared/src/validators/monitors.ts` exactly):
+
+| kind | fields |
+|---|---|
+| cpu, memory, disk | `operator` (operator), `value` (number 0–100, unit `%`), `durationMinutes` (number 1–1440, optional) |
+| offline | `durationMinutes` (number 1–10080) |
+| event_log | `category` (select security/hardware/application/system), `level` (select warning/error/critical), `sourcePattern` (text, optional), `messagePattern` (text, optional), `countThreshold` (number ≥1), `windowMinutes` (number 1–1440) |
+| patch_compliance | `operator`, `value` (0–100, `%`) |
+| service | `serviceName` (text), `consecutiveFailures` (number 1–20, optional) |
+| process | `processName` (text), `consecutiveFailures` (optional) |
+| process_resource | `resource` (select cpu/memory), `processName` (text), `operator`, `value` (number ≥0), `durationMinutes` (optional) |
+| cert_expiry | `withinDays` (number 1–365) |
+| bandwidth | `direction` (select in/out/total), `operator`, `value` (number, unit `Mbps`), `durationMinutes` (optional) |
+| disk_io | `direction` (select read/write/total), `operator`, `value` (unit `MB/s`), `durationMinutes` (optional) |
+| network_errors | `interfaceName` (text, optional), `errorType` (select in/out/total), `operator`, `value` (number ≥0), `windowMinutes` (optional) |
+
+- [ ] **Step 1: Failing test** — for every `MonitorKind`, `monitorConditionSchemas[kind].safeParse(defaultConditionFor(kind)).success === true`, and every `KindField.key` is a key of the schema's shape.
+
+- [ ] **Step 2: Implement the map and `en/monitoring.json`** with these top-level blocks (every key referenced by later tasks lives here):
+
+```json
+{
+  "hub": { "title": "Monitoring & Automation", "tabs": { "monitors": "Monitors", "network": "Network", "delivery": "Delivery", "legacyRules": "Legacy rules" } },
+  "list": { "title": "Monitors", "description": "Watch a condition, respond on the device, notify, and escalate when it keeps happening.", "new": "New monitor", "empty": "No monitors yet.", "columns": { "name": "Name", "kind": "Kind", "severity": "Severity", "deployedTo": "Deployed to", "enabled": "Enabled", "owner": "Owner" }, "allOrgs": "All orgs", "policiesCount_one": "{{count}} policy", "policiesCount_other": "{{count}} policies", "notDeployed": "Not deployed", "errors": { "fetch": "Failed to load monitors", "delete": "Failed to delete monitor" }, "deleteConfirm": "Delete monitor {{name}}? Its alert rule and response automation are removed too." },
+  "editor": { "titleNew": "New monitor", "titleEdit": "Edit monitor", "sections": { "watch": "What to watch", "noise": "Severity & noise", "respond": "Respond", "notify": "Notify", "escalate": "Escalate to a human", "deployed": "Deployed to" }, "fields": { "name": "Name", "description": "Description", "kind": "Kind", "severity": "Severity", "cooldownMinutes": "Cooldown (minutes)", "autoResolve": "Auto-resolve when the condition clears", "deliveryMode": "Delivery", "channels": "Channels", "escalationPolicy": "Escalation policy", "recurrenceThreshold": "Escalate after", "recurrenceWindowDays": "episodes within (days)", "pauseResponses": "Pause automatic responses until a person resets", "aiAgent": "AI agent (enables AI triage responses)" }, "deliveryModes": { "inherit": "Use routing rules", "channels": "Routing rules plus these channels", "none": "Do not notify" }, "responsesHint": "Responses run on the device that breached, in order.", "recurrenceHint": "Counted in breach episodes: a new episode starts only after the condition recovered.", "ownerScope": { "legend": "Owner", "partner": "All organizations (partner-wide)", "organization": "This organization only" }, "actions": { "save": "Save monitor", "saving": "Saving…", "test": "Test on a device", "deploy": "Deploy to…", "delete": "Delete" }, "errors": { "load": "Failed to load monitor", "save": "Failed to save monitor", "test": "Test failed" }, "testResult": { "triggered": "Condition met on {{device}}", "notTriggered": "Condition not met on {{device}}" } },
+  "kinds": { "cpu": "CPU usage", "memory": "Memory usage", "disk": "Disk usage", "offline": "Device offline", "event_log": "Event log", "patch_compliance": "Patch compliance", "service": "Service stopped", "process": "Process stopped", "process_resource": "Process resource", "cert_expiry": "Certificate expiry", "bandwidth": "Bandwidth", "disk_io": "Disk I/O", "network_errors": "Network errors" },
+  "fields": { "operator": "Comparison", "value": "Value", "durationMinutes": "For at least (minutes)", "category": "Category", "level": "Level", "sourcePattern": "Source matches", "messagePattern": "Message matches", "countThreshold": "Occurrences", "windowMinutes": "Within (minutes)", "serviceName": "Service name", "processName": "Process name", "consecutiveFailures": "Consecutive failures", "resource": "Resource", "withinDays": "Expires within (days)", "direction": "Direction", "errorType": "Error direction", "interfaceName": "Interface (optional)" },
+  "operators": { "gt": "greater than", "gte": "at least", "lt": "less than", "lte": "at most", "eq": "equal to", "neq": "not equal to" },
+  "deploy": { "title": "Deploy monitor", "existingPolicy": "Attach to an existing configuration policy", "newPolicy": "Create a policy for", "levels": { "organization": "this organization", "site": "a site", "device_group": "a device group" }, "policyName": "Policy name", "attach": "Attach", "detachConfirm": "Detach from {{policy}}?", "errors": { "attach": "Failed to attach monitor", "detach": "Failed to detach monitor" } },
+  "policyTab": { "title": "Monitors", "description": "Monitors attached to this policy. Disabled rows switch a monitor off for this policy's scope; overrides change thresholds for it.", "attachExisting": "Attach existing", "createNew": "Create monitor", "empty": "No monitors attached.", "columns": { "monitor": "Monitor", "kind": "Kind", "enabled": "Enabled", "overrides": "Overrides", "source": "Source" }, "inherited": "Inherited from parent", "overrideEditor": { "title": "Override for this policy", "clear": "Clear overrides" }, "save": "Save", "errors": { "save": "Failed to save monitors" } },
+  "legacy": { "title": "Legacy alert rules", "description": "Standalone alert rules that are not managed by a monitor. Convert them to get responses, delivery and escalation in one place.", "empty": "No legacy rules.", "convert": "Convert to monitor", "converted": "Converted", "notConvertible": "This rule's conditions cannot be expressed as a single monitor.", "errors": { "fetch": "Failed to load alert rules", "convert": "Failed to convert rule" } },
+  "managed": { "badge": "Managed by monitor", "readOnly": "This {{kind}} is generated from a monitor and cannot be edited here.", "open": "Open monitor" },
+  "devices": { "title": "Devices", "columns": { "device": "Device", "enabled": "Enabled", "overrides": "Overrides", "source": "Source policy" }, "empty": "No devices are covered by this monitor yet." }
+}
+```
+
+Translate every key for the other seven locales (same structure). Use the vocabulary already in each locale's `alerts.json` / `scripts.json` for severity, channel, and policy terms so the product reads consistently.
+
+- [ ] **Step 3: Run** `pnpm --filter @breeze/web test --run src/components/monitoring/monitorKindFields.test.ts src/lib/i18n/localeParity.test.ts` → PASS. Commit: `git commit -m "feat(web): monitoring locale namespace + monitor kind field map (#5289)"`.
+
+---
+
+### Task 3: Monitors list at `/monitoring`; network page moves to `/monitoring/network`; strip gains Monitors and Legacy rules
+
+**Files:**
+- Create: `apps/web/src/components/monitoring/MonitorsListPage.tsx`, `MonitorsListPage.test.tsx`
+- Create: `apps/web/src/pages/monitoring/network.astro` (renders the existing `MonitoringPage` with title "Monitoring")
+- Modify: `apps/web/src/pages/monitoring/index.astro` (renders `MonitorsListPage`)
+- Modify: `apps/web/src/components/monitoring/MonitoringTabStrip.tsx` (W01): `TABS` becomes `[{ href: '/monitoring', labelKey: 'monitors' }, { href: '/monitoring/network', labelKey: 'network' }, { href: '/monitoring/delivery', labelKey: 'delivery' }, { href: '/monitoring/rules', labelKey: 'legacyRules' }]`; labels move from `common:monitoringTabs.*` to `monitoring:hub.tabs.*` (delete the W01 `monitoringTabs` block from all 8 `common.json` files in the same commit); active resolution: longest matching prefix, with `/monitoring/monitors/*` mapping to `/monitoring`
+- Modify: `apps/web/src/components/monitoring/MonitoringPage.tsx` (its strip `currentPath` becomes `/monitoring/network`)
+- Modify: `apps/web/src/components/layout/Sidebar.tsx` `pathAliases` += `'/monitoring/network': '/monitoring', '/monitoring/rules': '/monitoring'` (prefix matching already covers `/monitoring/monitors/...`)
+- Test: `MonitoringTabStrip.test.tsx` (update), `Sidebar.nav.test.tsx` (no change expected)
+
+**Interfaces:**
+- `MonitorsListPage` fetches `GET /monitors`, renders `ResponsiveTable` rows (name → `/monitoring/monitors/:id`, kind label from `monitoring:kinds.*`, severity, deployed-to count from `attachments.length` when the list payload includes it — if the API list omits attachments, show `—` and fetch counts lazily per row on hover is **not** allowed; ask the API plan owner to include `attachmentCount` in the list payload and assert it here), enabled toggle (`PATCH /monitors/:id { enabled }` via `runAction`), `ScopeBadge`-style "All orgs" chip when `partnerId` is set, delete via `ConfirmDialog` + `runAction`. "New monitor" → `/monitoring/monitors/new`.
+
+- [ ] **Step 1: Failing tests** — list renders two rows from a mocked `fetchWithAuth('/monitors')`; "All orgs" chip only on the partner-wide row; delete calls `DELETE /monitors/:id` and refetches; strip marks `/monitoring/monitors/abc` as Monitors active.
+
+- [ ] **Step 2: Implement; run** `pnpm --filter @breeze/web test --run src/components/monitoring src/components/layout src/lib/i18n` → PASS. Commit: `git commit -m "feat(web): Monitors list at /monitoring; network page at /monitoring/network (#5289)"`.
+
+---
+
+### Task 4: Monitor editor
+
+**Files:**
+- Create: `apps/web/src/components/monitoring/MonitorEditor.tsx`, `MonitorEditor.test.tsx`, `MonitorConditionFields.tsx`, `DeployMonitorDialog.tsx`, `DeployMonitorDialog.test.tsx`, `MonitorDevicesTable.tsx`
+- Create: `apps/web/src/pages/monitoring/monitors/new.astro`, `apps/web/src/pages/monitoring/monitors/[id].astro` (pattern: `pages/settings/alert-templates/[id].astro`, passing `monitorId={id}`)
+
+**Interfaces:**
+- `MonitorEditor({ monitorId?: string })`. Form schema: `createMonitorDefinitionSchema` from `@breeze/shared` for create (with `ownerScope`), `updateMonitorDefinitionSchema` for edit; `zodResolver`. Loads `GET /monitors/kinds` once (for `overridableKeys` display and `agentDelivered` warning) and `GET /monitors/:id` in edit mode.
+- Cards, in order, each a `<section>` with a heading from `monitoring:editor.sections.*`:
+  1. **What to watch** — name, description, kind `<select>` (changing kind resets `condition` to `defaultConditionFor(kind)`), `MonitorConditionFields kind=… name="condition"` rendering from `MONITOR_KIND_FIELDS` (operator → `<select>` of `monitoring:operators.*`; number/text/select inputs with `register(\`condition.${key}\`, { valueAsNumber })`). When `agentDelivered` is true show a one-line hint that the service/process watch must exist in the policy's Service & Process Monitoring tab until W4.
+  2. **Severity & noise** — severity select, cooldownMinutes, autoResolve toggle.
+  3. **Respond** — `<ActionsEditor name="responses" compact allowAiTriage={!!watch('aiAgentId')} />` + hint `monitoring:editor.responsesHint`; AI agent select (`GET /ai-agents`, existing endpoint used by `AutomationForm`/agent pickers — reuse its component if one exists, else a plain select).
+  4. **Notify** — deliveryMode radio (`inherit | channels | none`), channel checkboxes (`GET /alerts/channels`, same list shape `RoutingRuleForm` uses) shown when `channels`, escalation policy select (`GET /alerts/policies`).
+  5. **Escalate to a human** — recurrenceThreshold (number ≥2), recurrenceWindowDays (number; the form stores days and submits `recurrenceWindowHours = days * 24`), `<ActionsEditor name="recurrenceActions" compact />`, pause toggle, hint `monitoring:editor.recurrenceHint`. All optional; empty = counter off.
+  6. **Deployed to** (edit mode only) — attachments table (policy name → `/configuration-policies/:id`, enabled, overrides summary, detach button) + **Deploy to…** opens `DeployMonitorDialog`.
+- Create-only `ownerScope` radio (copy `PolicyForm.tsx:86-117`; show when `useDefaultOwnerScope().isPartnerScope`), defaulting to `defaultOwnerScope`.
+- Header actions: **Test on a device** (device picker → `POST /monitors/:id/test { deviceId }`; edit mode only; result toast from `monitoring:editor.testResult.*`), **Save** (`POST /monitors` → navigate to `/monitoring/monitors/:id`; `PATCH /monitors/:id`), **Delete** (`ConfirmDialog`).
+- `DeployMonitorDialog({ monitorId, onDeployed })`: radio "existing policy" (select from `GET /configuration-policies?limit=200`) vs "create a policy for" (level select organization/site/device_group, target select from `/sites` / `/groups`, name defaulting to `Monitors — <target name>`), submits `POST /monitors/:id/attachments`.
+- `MonitorDevicesTable({ monitorId })`: `GET /monitors/:id/devices` (W2 shape), rendered under the Deployed card as a collapsible "Devices" list.
+
+- [ ] **Step 1: Failing tests** (`MonitorEditor.test.tsx`, mock `fetchWithAuth`):
+  - create mode: choosing kind `disk` renders `operator`, `value`, `durationMinutes` fields with defaults; submitting posts a body whose `condition` equals `{ operator: 'gt', value: 90, durationMinutes: 5 }` and `ownerScope: 'organization'`;
+  - setting recurrence threshold 3 and window 10 days submits `recurrenceWindowHours: 240`;
+  - `ai_triage` option is absent until an AI agent is selected;
+  - edit mode: loads `GET /monitors/m1`, shows the Deployed card with one attachment, detach calls `DELETE /monitors/m1/attachments/a1`.
+  - `DeployMonitorDialog.test.tsx`: existing-policy path posts `{ configPolicyId }`; create path posts `{ createPolicyFor: { level: 'site', targetId, name } }`.
+
+- [ ] **Step 2: Implement; run** `pnpm --filter @breeze/web test --run src/components/monitoring` → PASS. Commit: `git commit -m "feat(web): monitor editor with deploy dialog (#5289)"`.
+
+---
+
+### Task 5: Config-policy `Monitors` tab
+
+**Files:**
+- Create: `apps/web/src/components/configurationPolicies/featureTabs/MonitorsTab.tsx`, `MonitorsTab.test.tsx` (copy the `useFeatureLink` mock preamble from `VulnerabilityTab.test.tsx:1-30`)
+- Modify: `apps/web/src/components/configurationPolicies/featureTabs/types.ts:55-79` `FEATURE_META` += `monitors: { label: 'Monitors', fetchUrl: '/monitors', description: 'Monitors attached to this policy: condition, response, delivery and escalation in one object' }` (insert after `alert_rule` so the tab order reads Alerts → Monitors)
+- Modify: `apps/web/src/components/configurationPolicies/ConfigPolicyDetailPage.tsx:108-128` (`featureTabIcons.monitors = <Radar className="h-4 w-4" />`), `:418-446` (`case 'monitors': return <MonitorsTab {...props} />;`)
+- Modify: `packages/shared` `ConfigFeatureType` already includes `'monitors'` from the API plan; the web `FeatureType` derives from it (`types.ts:18`), so the exhaustive `featureTabIcons` record fails to compile until the icon is added — that is the intended tripwire.
+
+**Interfaces:** `MonitorsTab(props: FeatureTabProps)`. State = `items: { monitorId, enabled, overrides, sortOrder }[]` seeded from `existingLink?.inlineSettings.items`; rows joined with `GET /monitors` for name/kind/`overridableKeys` (from `GET /monitors/kinds`). Parent-link rows (`props.parentLink?.inlineSettings.items`) are shown with the `inherited` badge and an **Override here** action that copies the row into `items` with `enabled: false` or opens the override editor. Save → `save(existingLink?.id ?? null, { featureType: 'monitors', featurePolicyId: null, inlineSettings: { items } })` then `onLinkChanged(result, 'monitors')`. Empty `items` → `remove(existingLink.id)` then `onLinkChanged(null, 'monitors')`.
+
+- [ ] **Step 1: Failing tests** — attach existing monitor from the picker and save → `saveMock` called with `inlineSettings.items[0] = { monitorId: 'm1', enabled: true, overrides: undefined, sortOrder: 0 }`; toggle enabled off and set override `value: 95` → saved payload reflects both; a parent-link row renders with the inherited badge and is not in `items` until overridden.
+
+- [ ] **Step 2: Implement; run** `pnpm --filter @breeze/web test --run src/components/configurationPolicies` → PASS (the existing `ConfigPolicyDetailPage` tests must still pass with the new tab in the list). Commit: `git commit -m "feat(web): config-policy Monitors tab (#5289)"`.
+
+---
+
+### Task 6: Legacy rules tab with Convert to monitor
+
+**Files:**
+- Create: `apps/web/src/components/monitoring/LegacyRulesPage.tsx`, `LegacyRulesPage.test.tsx`
+- Create: `apps/web/src/pages/monitoring/rules.astro`
+- Modify: `apps/web/src/components/alerts/AlertsTabStrip.tsx:9` — the `rules` tab href becomes `/monitoring/rules` (it currently points at `/alerts/rules`, which 301s to `/configuration-policies`); update `AlertsTabStrip.test.tsx` accordingly
+
+**Interfaces:** lists `GET /alerts/rules` filtered client-side to `managedByMonitorId == null`; columns name, template, target (`targetType/targetId`), owner chip, active; row action **Convert to monitor** → `POST /alerts/rules/:id/convert-to-monitor` via `runAction`; `201` → `navigateTo('/monitoring/monitors/<monitorId>')`; `409 RULE_NOT_CONVERTIBLE` → inline message `monitoring:legacy.notConvertible` on that row (this is a partial-success style handler, so it is a legitimate `runActionAllowlist.ts` entry only if `runAction` cannot express it — prefer `runAction` with a custom `onError`). Converted rules (`overrideSettings.convertedToMonitorId`) show the `converted` badge and no action.
+
+- [ ] **Step 1: Failing tests** — two rules render, one managed rule is hidden; convert posts to the right path and navigates; 409 shows the not-convertible message.
+
+- [ ] **Step 2: Implement; run** `pnpm --filter @breeze/web test --run src/components/monitoring/LegacyRulesPage.test.tsx src/components/alerts/AlertsTabStrip.test.tsx` → PASS. Commit: `git commit -m "feat(web): legacy alert rules tab with convert-to-monitor (#5289)"`.
+
+---
+
+### Task 7: Managed rows are read-only everywhere else
+
+**Files:**
+- Modify: `apps/web/src/components/automations/AutomationsPage.tsx` (filter out `managedByMonitorId` rows from the Jobs list), `AutomationList.tsx:36` (`Automation` type += `managedByMonitorId?: string | null`), `AutomationEditPage.tsx` (when the loaded automation has `managedByMonitorId`, render a read-only banner `monitoring:managed.readOnly` with `monitoring:managed.open` link to `/monitoring/monitors/:id` instead of the form)
+- Modify: `apps/web/src/components/alerts/AlertTemplateList.tsx:90` (scope/badge cell: when `managedByMonitorId`, show `monitoring:managed.badge` and disable edit/delete like built-ins), `AlertTemplateEditor.tsx` (same banner as automations)
+- Modify: `apps/web/src/components/alerts/AlertDetails.tsx` — when `alert.monitorId` is present, show a "Monitor" row linking to `/monitoring/monitors/:id`
+- Test: `AutomationsPage.managed.test.tsx` (extend: a managed-by-monitor automation is not listed), `AutomationEditPage.test.tsx` (extend: banner instead of form), `AlertTemplateList.test.tsx` (extend)
+
+- [ ] **Step 1: Failing tests; Step 2: implement; Step 3: run** `pnpm --filter @breeze/web test --run src/components/automations src/components/alerts` → PASS. Commit: `git commit -m "feat(web): monitor-managed automations, templates and alerts link back to their monitor (#5289)"`.
+
+---
+
+### Task 8: AI / MCP tools
+
+**Files:**
+- Create: `apps/api/src/services/aiToolsMonitors.ts`, `aiToolsMonitors.test.ts`
+- Modify: `apps/api/src/services/aiTools.ts:274` area — `registerMonitorTools(aiTools);`
+- Docs: `apps/docs/src/content/docs/features/mcp-server.mdx` (tool table)
+
+**Interfaces** (follow `registerFleetTools` at `aiToolsFleet.ts:441-460` for `registerTool`/`safeHandler` shape and `pgErrorCode` mapping):
+
+| tool | tier | input | behaviour |
+|---|---|---|---|
+| `list_monitors` | 1 | `{ kind?, enabled?, limit? }` | `listMonitorDefinitions(auth, filters)`; returns id, name, kind, severity, enabled, ownerScope, attachmentCount |
+| `get_monitor` | 1 | `{ monitorId }` | definition + attachments + compiled ids + `GET /monitors/:id/devices` resolution summary |
+| `manage_monitors` | 3 | `{ action: 'create' \| 'update' \| 'delete' \| 'enable' \| 'disable' \| 'attach' \| 'detach', monitorId?, definition?, configPolicyId?, attachmentId? }` | calls the Task-4/8 service functions; `create` requires the full `createMonitorDefinitionSchema` body; partner-wide only when `canManagePartnerWidePolicies(auth)` |
+
+Also add the read-only guard to `manage_automations` (`aiToolsFleet.ts:1614-1641`) for `enable`/`disable`/`run` on `managedByMonitorId` rows if the API plan did not already (it should have — verify, do not duplicate).
+
+- [ ] **Step 1: Failing tests** — `list_monitors` returns the mocked rows; `manage_monitors` `create` with an org-scoped auth and `ownerScope: 'partner'` returns `{ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }`; `manage_monitors` is registered with `tier: 3`.
+
+- [ ] **Step 2: Implement; run** `cd apps/api && npx vitest run src/services/aiToolsMonitors.test.ts src/services/aiTools.test.ts` (the registry test that counts/validates tools, if present) → PASS. Commit: `git commit -m "feat(ai): list_monitors / get_monitor / manage_monitors tools (#5289)"`.
+
+---
+
+### Task 9: Docs
+
+**Files:**
+- Create: `apps/docs/src/content/docs/features/monitors.mdx` — what a monitor is, the six cards, deploying through policies (cumulative inheritance with disable/override), delivery modes, the recurrence counter (episodes; pause until reset), converting legacy rules, what is read-only and why. Link from `features/alerts.mdx`, `features/automations.mdx` ("responses that used to be alert-triggered automations are now authored on the monitor; existing ones keep working as event rules under Jobs"), `features/configuration-policies.mdx` (Monitors tab), `features/service-monitoring.mdx` (service/process kinds evaluate through monitors; the watch still comes from this tab until W4).
+- Modify: `apps/docs/astro.config.mjs` sidebar — add `{ slug: 'features/monitors' }` next to `features/alerts`.
+- Update the release-notes source per the `update-breeze-release-notes` skill conventions only if that skill says the current cycle is open; otherwise leave notes to the release run.
+
+- [ ] **Step 1: Write; Step 2:** `pnpm --filter @breeze/docs build` → no broken links. Commit: `git commit -m "docs: Monitors feature page + cross-links (#5289)"`.
+
+---
+
+### Task 10: Verification and PR
+
+- [ ] **Step 1:**
+
+```bash
+pnpm --filter @breeze/web lint
+pnpm --filter @breeze/web test --run src/components/monitoring src/components/automations src/components/alerts src/components/configurationPolicies src/components/layout src/lib/i18n src/lib/__tests__/no-silent-mutations.test.ts
+pnpm --filter @breeze/web build
+pnpm --filter @breeze/api exec tsc --noEmit && cd apps/api && npx vitest run src/services/aiToolsMonitors.test.ts
+```
+
+- [ ] **Step 2: Browser walk on a local stack** (`worktree-stack` skill): create a disk monitor with a run_script response and channel delivery → deploy to a site policy → open the policy's Monitors tab and disable it → `/monitoring` shows "1 policy" → Jobs does not list the managed automation → `/settings/alert-templates` shows the managed template as read-only → convert a legacy rule → `/monitoring/network` still works → sidebar highlights Monitoring on every `/monitoring/*` path.
+
+- [ ] **Step 3: PR** — title `feat(web): W02 Monitors UI, policy tab, legacy conversion, MCP tools (#5287)`; body per task, spec path, `Closes #5289`. Run `/pr-review-toolkit:review-pr`; fix confirmed findings inline; `gh pr merge <N> --squash` on green; then `complete_wave` W02 and write the W03 plan from spec §Evaluation and recurrence.

--- a/docs/superpowers/specs/monitoring/2026-09-08-monitoring-automation-unification-design.md
+++ b/docs/superpowers/specs/monitoring/2026-09-08-monitoring-automation-unification-design.md
@@ -233,17 +233,19 @@ transaction:
 1. Validate `condition` against the kind's schema; validate `responses` against
    `automationActionSchema` with the monitor restrictions.
 2. Upsert `alert_templates` row (`is_built_in = true`, `managed_by_monitor_id`), with
-   `conditions = [kindToConditionHandler(kind, condition)]`, severity, cooldown, auto-resolve,
-   title/message templates derived from the kind.
+   `conditions = kindToAlertCondition(kind, condition)` — a single root condition object
+   (`alertTemplates.conditions` holds one condition or one group, never an array), severity,
+   cooldown, auto-resolve, title/message templates derived from the kind.
 3. Upsert `alert_rules` row (`managed_by_monitor_id`, `template_id`, `is_active = enabled`,
    `target_type = 'monitor'`, `target_id = monitor_id`). The sweep already evaluates rules through
    `evaluateDeviceAlerts`; a new `target_type` resolver maps `'monitor'` to the devices the
    attachment resolution yields (see *Targeting*), so no second evaluator is introduced.
 4. Upsert `automations` row (`managed_by_monitor_id`; `managed_by_agent_id = ai_agent_id`;
    `trigger = { type: 'event', event: 'alert.triggered', filter: { ruleId: <compiled rule id> } }`;
-   `actions = responses`; `enabled`). The optional `filter: { ruleId }` field is added to the
-   `event` branch of `automationTriggerSchema` (`packages/shared/src/validators/index.ts`) and
-   honoured by `shouldTriggerEventAutomation` (today it matches on event type only).
+   `actions = responses`; `enabled`). The runtime already honours `trigger.filter` as key/value
+   equality against the event payload (`matchesEventFilter` in `automationWorker.ts`); only the
+   `event` branch of `automationTriggerSchema` (`packages/shared/src/validators/index.ts`) lacks the
+   field, so the validator gains `filter: z.record(z.unknown()).optional()`.
 5. Write `compiled_*` pointers and `compiled_hash = sha256(canonical(definition))`.
 
 Every compiled row is deterministic from the definition; the contract test recompiles every
@@ -389,17 +391,19 @@ Left nav (`Sidebar.tsx`):
 
 - **Alerts** → `/alerts` — unchanged (inbox, acknowledge, suppress, resolve, correlations,
   Incidents).
-- **Monitoring** → `/monitoring` (new entry under Fleet Management, replaces the "Network Monitor"
-  entry). Hash tabs: `#monitors` (default), `#network` (the existing network-monitor page moves here
-  unchanged), `#delivery` (notification channels, routing rules, escalation policies — the pages
-  that exist today under `/alerts/*` without nav), `#legacy-rules` (standalone alert rules with no
-  `managed_by_monitor_id`, each with **Convert to monitor**). Page title "Monitoring & Automation".
-  Existing bookmarks to `/monitoring` land on the hub with `#monitors` selected; `#network` is the
-  old page unchanged.
-- **Jobs** → `/jobs` (new entry). Hash tabs: `#scheduled`, `#on-demand` (manual), `#webhooks`,
-  `#event-rules` (unmanaged event-trigger automations, so nothing a customer built disappears),
-  `#history`. `/automations` and `/automations/:id` become redirects to `/jobs`. Monitor-managed
-  automations are hidden from Jobs and shown inside their monitor.
+- **Monitoring** → `/monitoring` (renamed "Network Monitor" entry under Fleet Management). The hub
+  uses a **path-based** tab strip (the `AlertsTabStrip` pattern) because the existing network page
+  already owns `window.location.hash` for its own tabs: **Monitors** `/monitoring` (default from W2;
+  in W1 the network page stays at `/monitoring`), **Network** `/monitoring/network` (the existing
+  page, moved in W2), **Delivery** `/monitoring/delivery` (notification channels; routing rules and
+  escalation policies join when they get a UI), **Legacy rules** `/monitoring/rules` (standalone
+  alert rules with no `managed_by_monitor_id`, each with **Convert to monitor**; W2). Page title
+  "Monitoring & Automation".
+- **Jobs** → `/jobs` (new entry, top level after Scripts, permission `automations:read`). Hash tabs:
+  `#all` (default), `#scheduled`, `#on-demand`, `#webhooks`, `#event-rules` (unmanaged event-trigger
+  automations, so nothing a customer built disappears). Run history stays the per-row modal.
+  `/automations`, `/automations/new` and `/automations/:id` become 301 redirects to `/jobs*`.
+  Monitor-managed automations are hidden from Jobs (W2) and shown inside their monitor.
 - Config-policy editor: new **Monitors** tab (attachment list with enable/override per row, plus
   "Attach existing" and "Create monitor"). Existing Monitoring / Alert / Automation tabs remain
   and gain a one-line banner pointing at Monitors for fleet-wide rules.
@@ -456,7 +460,7 @@ MCP: `list_monitors`, `get_monitor_activity`, `reset_monitor_escalation` (Tier 2
 
 | wave | ships | must not break |
 |---|---|---|
-| **W1 — discoverability** (no schema) | Jobs nav entry + `/jobs` page over existing automations with the hash tabs; `/automations` redirects; Monitoring nav entry with `#network` and `#delivery` tabs hosting the existing pages; Alert Rules listed under `#legacy-rules` | every existing URL (redirects), permissions |
+| **W1 — discoverability** (no schema) | Jobs nav entry + `/jobs` pages over existing automations with the trigger tabs; `/automations` redirects; "Network Monitor" nav entry becomes **Monitoring** with a path tab strip (Network, Delivery) | every existing URL (redirects), permissions, the network page's own hash tabs |
 | **W2 — definitions and compile** | `monitor_definitions`, `config_policy_monitors`, `monitor` feature type, kind registry for the eleven existing handler kinds, compiler + managed-row guards + drift contract test, `'monitor'` target resolver, cumulative resolution, escalation lookup on the policy alert path, monitor editor + policy Monitors tab, "Deploy to…", convert-to-monitor. **Prerequisite: #5240 (device-bound event automations).** | alert sweep, correlation, cooldown, routing, escalation policies, partner fan-out, #5080 inheritance, AI verdicts, MCP `manage_automations` (now refuses managed rows) |
 | **W3 — episodes and recurrence** | `monitor_device_state`, `monitor_episodes`, episode open/close in the sweep hook, latch + requires-human alert + pause + reset API, Activity tab, `response_outcome` from terminal run state (fixes queued-as-success), `requires_human` handling in auto-resolve and the verdict subscriber | AI admission and loop guards, delivery dedupe, escalation cancellation |
 | **W4 — coverage** | handler-only kinds (antivirus, software_presence, backup_continuity), script monitor, network_check adapter (after #5241) with partner-wide `networkMonitors`, service/process watch delivery from `resolveMonitorsForDevice` (heartbeat builder reads monitors first, config-policy tab second) | agent config payload shape (`monitoring_settings` unchanged on the wire), local auto-restart |

--- a/docs/superpowers/specs/monitoring/2026-09-08-monitoring-automation-unification-design.md
+++ b/docs/superpowers/specs/monitoring/2026-09-08-monitoring-automation-unification-design.md
@@ -72,7 +72,7 @@ already exist and are good; what is missing is one authoring object and a naviga
 |---|---|---|
 | D1 | Product boundary | **Alerts stays a separate inbox.** Monitoring (authoring) and Jobs are new nav entries. The community's single "Monitoring & Automation" that swallows Alerts was rejected: the inbox is the most-used page and must stay one click away. |
 | D2 | Recurrence semantics | **Breach episodes**, not response runs or polls. A new episode requires an observed recovery in between. On the Nth episode inside the window: requires-human alert, notify, pause auto-remediation until reset. |
-| D3 | Targeting | **Through configuration-policy attachment** (a `monitor` feature type), reusing assignments, priority and one-level inheritance (#5080). No direct target column on the monitor. The editor offers a "Deploy to…" shortcut that creates or updates the attachment. |
+| D3 | Targeting | **Through configuration-policy attachment** (a `monitors` feature type — plural, because `monitoring` already names the service/process watch tab), reusing assignments, priority and one-level inheritance (#5080). No direct target column on the monitor. The editor offers a "Deploy to…" shortcut that creates or updates the attachment. |
 | D4 | Inheritance for the monitor feature | **Cumulative** across every assigned policy and its parent, with overrides keyed by the stable monitor id (disable or parameter override). Other feature types keep whole-feature replacement. |
 | D5 | Ambition | Existing eleven condition types first, then handler-only additions (antivirus, software presence, backup continuity) and a first-class **script monitor**. Agent-collector types are deferred to separate specs. |
 
@@ -174,13 +174,13 @@ Unique `(coalesce(org_id, partner_id), name)`.
 | column | notes |
 |---|---|
 | id | uuid pk |
-| feature_link_id | → `config_policy_feature_links(id)` ON DELETE CASCADE; the link's `feature_type = 'monitor'` |
+| feature_link_id | → `config_policy_feature_links(id)` ON DELETE CASCADE; the link's `feature_type = 'monitors'` |
 | monitor_id | → `monitor_definitions(id)` ON DELETE CASCADE |
 | enabled | bool; `false` = this policy switches the monitor off for its scope (cumulative override) |
 | overrides | jsonb null; subset of `condition` and `severity` permitted by the kind's `overridableKeys` |
 | sort_order | |
 
-Unique `(feature_link_id, monitor_id)`. The `monitor` value is added to `config_feature_type`.
+Unique `(feature_link_id, monitor_id)`. The `monitors` value is added to `config_feature_type`.
 
 ### `monitor_device_state`
 
@@ -257,7 +257,7 @@ with `monitor_detached`; the escalation alert (if any) is left open for the huma
 
 ## Targeting and inheritance (D3, D4)
 
-A monitor reaches a device through: definition → attachment (in a policy's `monitor` feature
+A monitor reaches a device through: definition → attachment (in a policy's `monitors` feature
 link) → the policy's assignments (`partner | organization | site | device_group | device`, dynamic
 groups included) → the device. Parent policies (#5080, one level) contribute their attachments to
 the child.
@@ -265,7 +265,7 @@ the child.
 Resolution for a device, `resolveMonitorsForDevice(deviceId)`:
 
 1. Collect every policy assigned to the device at any level, plus each policy's parent.
-2. Collect every `config_policy_monitors` row under those policies' `monitor` feature links.
+2. Collect every `config_policy_monitors` row under those policies' `monitors` feature links.
 3. Group by `monitor_id`. For each monitor, the row from the **most specific** source wins
    (device > device_group > site > organization > partner; within one policy, child before
    parent). That row's `enabled` and `overrides` apply.
@@ -277,10 +277,10 @@ This union is deliberately different from every other feature type, which resolv
 winning link (`config_policy_effective_feature_links`). The view is untouched; the monitor resolver
 is a separate function with its own contract test (partner-wide parent + org child + site override:
 the site override disables one monitor and changes one threshold; every other monitor is still
-active). Existing readers of the effective-links view never see `feature_type = 'monitor'` links
+active). Existing readers of the effective-links view never see `feature_type = 'monitors'` links
 because nothing else reads that type.
 
-"Deploy to…" in the editor: pick an existing policy (creates or reuses its `monitor` feature link
+"Deploy to…" in the editor: pick an existing policy (creates or reuses its `monitors` feature link
 and inserts the attachment) or "New policy for <site | group>" (creates a policy assigned at that
 level with the attachment). The editor lists every policy the monitor is attached to.
 
@@ -461,7 +461,7 @@ MCP: `list_monitors`, `get_monitor_activity`, `reset_monitor_escalation` (Tier 2
 | wave | ships | must not break |
 |---|---|---|
 | **W1 — discoverability** (no schema) | Jobs nav entry + `/jobs` pages over existing automations with the trigger tabs; `/automations` redirects; "Network Monitor" nav entry becomes **Monitoring** with a path tab strip (Network, Delivery) | every existing URL (redirects), permissions, the network page's own hash tabs |
-| **W2 — definitions and compile** | `monitor_definitions`, `config_policy_monitors`, `monitor` feature type, kind registry for the eleven existing handler kinds, compiler + managed-row guards + drift contract test, `'monitor'` target resolver, cumulative resolution, escalation lookup on the policy alert path, monitor editor + policy Monitors tab, "Deploy to…", convert-to-monitor. **Prerequisite: #5240 (device-bound event automations).** | alert sweep, correlation, cooldown, routing, escalation policies, partner fan-out, #5080 inheritance, AI verdicts, MCP `manage_automations` (now refuses managed rows) |
+| **W2 — definitions and compile** | `monitor_definitions`, `config_policy_monitors`, `monitors` feature type, kind registry for the eleven existing handler kinds, compiler + managed-row guards + drift contract test, `'monitor'` target resolver, cumulative resolution, escalation lookup on the policy alert path, monitor editor + policy Monitors tab, "Deploy to…", convert-to-monitor. **Prerequisite: #5240 (device-bound event automations).** | alert sweep, correlation, cooldown, routing, escalation policies, partner fan-out, #5080 inheritance, AI verdicts, MCP `manage_automations` (now refuses managed rows) |
 | **W3 — episodes and recurrence** | `monitor_device_state`, `monitor_episodes`, episode open/close in the sweep hook, latch + requires-human alert + pause + reset API, Activity tab, `response_outcome` from terminal run state (fixes queued-as-success), `requires_human` handling in auto-resolve and the verdict subscriber | AI admission and loop guards, delivery dedupe, escalation cancellation |
 | **W4 — coverage** | handler-only kinds (antivirus, software_presence, backup_continuity), script monitor, network_check adapter (after #5241) with partner-wide `networkMonitors`, service/process watch delivery from `resolveMonitorsForDevice` (heartbeat builder reads monitors first, config-policy tab second) | agent config payload shape (`monitoring_settings` unchanged on the wire), local auto-restart |
 | **W5 — retirement decisions** (separate program) | whether the config-policy Alert/Automation/Monitoring tabs become thin pointers; SNMP and agent-acquisition kinds get their own specs | — |

--- a/docs/superpowers/specs/monitoring/2026-09-08-monitoring-automation-unification-design.md
+++ b/docs/superpowers/specs/monitoring/2026-09-08-monitoring-automation-unification-design.md
@@ -1,0 +1,513 @@
+---
+title: Monitoring & Automation unification (monitors as the authoring object)
+status: approved
+date: 2026-09-08
+tracking_issue: LanternOps/breeze#4984
+origin: "#4984 community proposal (Discord, MSP migrating from Datto RMM); escalation counter #4672"
+---
+
+# Monitoring & Automation unification
+
+## Problem
+
+A technician who wants "when disk usage on servers passes 80%, run the cleanup script, tell the
+helpdesk on Teams, and get a human involved if it keeps happening" has to touch four surfaces
+today, and two of them are hidden:
+
+- **Alert Rules** (`/alerts/rules`, a sub-route with no nav entry) hold the condition, severity,
+  cooldown and auto-resolve. The rule form has **no action field**: an alert rule cannot run
+  anything.
+- **Automations** (`/automations`, **no left-nav entry at all** — reachable only through the Fleet
+  Orchestration page or a typed URL) hold the response. A "run the cleanup script" automation is
+  wired with an `event` trigger on `alert.triggered`. Verified on main: an ordinary automation with
+  that trigger runs its actions on **every device its conditions match**, not on the device that
+  alerted — only AI-managed automations bind to `payload.deviceId` (#5240).
+- **Service & Process Monitoring** is a tab inside the Configuration Policy editor
+  (`configPolicyMonitoringWatches`: service and process only). Its results are polled by the alert
+  sweep through the `service_stopped` / `process_stopped` condition handlers; the real-time
+  `monitoring.check_failed` events it publishes have no consumer.
+- **Network Monitor** (`/monitoring`, nav entry under Fleet Management) is a fourth engine with its
+  own rules and severity model. Verified on main: its alerts are inserted straight into `alerts`
+  without `alert.triggered`, so they never notify, escalate, trigger automations, or get an AI
+  verdict (#5241).
+- Nothing counts recurrences. The 80% → cleanup → 78% → 85% → cleanup loop can run forever and no
+  human ever hears about it. The only counter is `automations.run_count`, global and unwindowed.
+
+The community proposal (#4984) is a Datto-shaped single object — *monitor = condition + response +
+alert delivery* — plus "Automations should be called Jobs". Two independent design reviews
+(Fable and Codex xhigh, 2026-09-07, see *Review log*) reached the same verdict: the runtime pieces
+already exist and are good; what is missing is one authoring object and a navigation that shows it.
+
+## Goals
+
+1. One object, **Monitor**, that a technician authors in one form: what to watch, how bad it is,
+   what to run when it breaks, who to tell, and when to escalate to a human.
+2. Monitors deploy through the existing configuration-policy assignment and inheritance machinery
+   — no second targeting model.
+3. A **recurrence counter** with teeth: N breach episodes in M days raises a requires-human alert and
+   pauses automatic remediation for that device until a person resets it (#4672).
+4. Device-bound responses: a monitor's actions run on the device that breached, never fleet-wide.
+5. Navigation that matches the mental model: **Alerts** (what is wrong now), **Monitoring** (what we
+   watch and how we respond), **Jobs** (what runs on a schedule or on demand).
+6. Every existing consumer keeps working untouched: alert sweep, correlation, cooldown/flapping,
+   notification routing, escalation policies, AI alert verdicts, AI-managed automations, mobile,
+   MCP tools, partner-wide fan-out.
+
+## Non-goals
+
+- A new evaluation runtime. Monitors **compile into** existing alert-rule and automation rows; the
+  BullMQ sweep, `alertConditions/` handlers, `automationWorker`, and `notificationDispatcher` are
+  unchanged in shape.
+- Datto feature parity on day one. Generic WMI queries, Windows performance counters, file/folder
+  size watches and hardware sensors need agent work and get their own specs (see *Monitor types*).
+- Retiring the config-policy Alert / Automation / Monitoring tabs. They stay as compatibility
+  views; a later program decides their fate once monitors have adoption.
+- Ticket delivery (#5238), saved-group targeting for scripts (#5237), maintenance-window work
+  (#5234–#5236). Referenced, not built here.
+- Migrating existing alert rules automatically. Conversion is explicit and per rule.
+
+## Decisions (approved 2026-09-08)
+
+| # | Decision | Chosen |
+|---|---|---|
+| D1 | Product boundary | **Alerts stays a separate inbox.** Monitoring (authoring) and Jobs are new nav entries. The community's single "Monitoring & Automation" that swallows Alerts was rejected: the inbox is the most-used page and must stay one click away. |
+| D2 | Recurrence semantics | **Breach episodes**, not response runs or polls. A new episode requires an observed recovery in between. On the Nth episode inside the window: requires-human alert, notify, pause auto-remediation until reset. |
+| D3 | Targeting | **Through configuration-policy attachment** (a `monitor` feature type), reusing assignments, priority and one-level inheritance (#5080). No direct target column on the monitor. The editor offers a "Deploy to…" shortcut that creates or updates the attachment. |
+| D4 | Inheritance for the monitor feature | **Cumulative** across every assigned policy and its parent, with overrides keyed by the stable monitor id (disable or parameter override). Other feature types keep whole-feature replacement. |
+| D5 | Ambition | Existing eleven condition types first, then handler-only additions (antivirus, software presence, backup continuity) and a first-class **script monitor**. Agent-collector types are deferred to separate specs. |
+
+Deferred (not rejected): a `monitor_revisions` history table. Wave 1 records `compiled_hash` /
+`compiled_at` on managed rows; if audit demand appears, revisions can be added without changing
+the compile contract.
+
+## Concepts
+
+- **Monitor definition** — the authored object. Owned by an org XOR a partner. Has a *kind* (what is
+  watched), a *condition* (kind-specific parameters), *severity*, *cooldown*, *auto-resolve*,
+  ordered *responses* (automation actions), *delivery* (channels / routing / escalation policy), and
+  a *recurrence policy* (N episodes in M days → escalate).
+- **Attachment** — a row that puts a monitor into a configuration policy (`config_policy_monitors`).
+  Deployment = attachment × assignment. An attachment can disable the monitor or override
+  parameters for that policy's scope.
+- **Compiled rows** — the alert rule and automation the platform derives from a definition. They
+  carry `managed_by_monitor_id` and are read-only everywhere except the compiler.
+- **Episode** — one continuous breach of a monitor on one device: starts when the condition first
+  evaluates true after being false or unknown; ends on observed recovery. Unknown or stale data
+  never ends an episode.
+- **Recurrence escalation** — the state a (monitor, device) pair enters when episodes-in-window ≥ N.
+
+## Ownership rule (tenancy)
+
+`monitor_definitions` is a **config table**: `org_id` XOR `partner_id`, `monitor_definitions_one_owner_chk`,
+one dual-axis RLS policy (`system OR org-access OR partner-access`), partner index, exactly as the
+`2026-07-01-*-partner-ownership.sql` playbook. Partner-wide writes gate on
+`canManagePartnerWidePolicies(auth)`; create takes `ownerScope`; update omits it.
+
+`config_policy_monitors` (the attachment) is policy-derived: it references a feature link, and the
+feature link's policy carries the ownership. It has no owner columns of its own, matching
+`configPolicyAlertRules` / `configPolicyAutomations`. RLS: `EXISTS` join through the feature link to
+`configuration_policies`, registered in `PARENT_FK_JOIN_POLICY_TABLES` in
+`rls-coverage.integration.test.ts` as `['config_policy_monitors', ['configuration_policies']]`,
+exactly like `config_policy_alert_rules`.
+
+Attachment validation: a policy may attach a definition only if the definition is owned by the
+policy's org, by the policy's partner (partner-wide definition), or is partner-wide under the org's
+partner. Cross-partner attachment is rejected at the API and by a constraint trigger, mirroring
+`breeze_config_policy_parent_compatible` from #5080 (COALESCE to false; fail closed).
+
+Operational tables (`monitor_episodes`, `monitor_device_state`) take the **device's** `org_id`
+(Shape 1), never the definition's — a partner-wide monitor produces org-scoped episodes.
+
+Compiled rows inherit ownership from the definition: a partner-wide definition compiles to a
+partner-wide `alertRules` / `automations` pair, so existing partner fan-out applies without new code.
+
+Registration checklist (same PR as the migration):
+
+- `CORE_ORG_CASCADE_DELETE_ORDER` (`services/tenantCascade.ts`): `monitor_definitions`,
+  `monitor_device_state`, `monitor_episodes` (the three tables with `org_id`). `config_policy_monitors`
+  has no `org_id` and cascades through its feature-link FK, so it is not listed.
+- `CORE_TENANT_EXPORT_POLICY` (`services/tenantExportPolicyRegistry.ts`): entries for the three
+  `org_id` tables with every column classified — `condition`, `responses`, `recurrence_actions`,
+  `delivery_channel_ids`, `overrides` are `excludedOpen`. **Also** the new columns on already-registered
+  tables: `alerts.monitor_id`, `alerts.episode_id`, `alerts.requires_human`, and
+  `managed_by_monitor_id` on `alert_rules`, `alert_templates`, `automations` go into `included`.
+- `DUAL_AXIS_TENANT_TABLES` (`rls-coverage.integration.test.ts`): `monitor_definitions`;
+  `PARENT_FK_JOIN_POLICY_TABLES`: `config_policy_monitors`.
+- `orgMergeRegistry`: `monitor_definitions` (owner repoint), `monitor_device_state` and
+  `monitor_episodes` (device-org restamp).
+- `CORE_DEVICE_CASCADE_DELETE_TABLES` + `CORE_DEVICE_ORG_DENORMALIZED_TABLES`
+  (`routes/devices/core.ts`): `monitor_device_state`, `monitor_episodes`.
+
+## Data model
+
+### `monitor_definitions`
+
+| column | type | notes |
+|---|---|---|
+| id | uuid pk | |
+| org_id / partner_id | uuid null | XOR |
+| name, description | | |
+| kind | `monitor_kind` enum | see *Monitor types* |
+| enabled | bool | master switch; disabled compiles to inactive rule + disabled automation |
+| condition | jsonb | kind-specific; validated by the same zod schema the matching `alertConditions` handler uses |
+| severity | `alert_severity` | |
+| cooldown_minutes | int | mirrors `alertTemplates.cooldownMinutes` |
+| auto_resolve, auto_resolve_conditions | bool, jsonb | mirrors templates |
+| responses | jsonb `AutomationAction[]` | existing action union; `ai_triage` allowed only when `ai_agent_id` is set (see *AI*) |
+| response_scope | enum `triggering_device` | fixed in this program; exists so #5240's `all_matching` never applies to monitors |
+| delivery_mode | enum `none \| inherit \| channels` | `inherit` = routing rules decide (today's default); `channels` = explicit list |
+| delivery_channel_ids | jsonb `string[]` | when `channels` |
+| escalation_policy_id | uuid null → `escalation_policies` | |
+| recurrence_threshold | int null | N; null = counter off |
+| recurrence_window_hours | int null | M × 24 |
+| recurrence_actions | jsonb `AutomationAction[]` | run once when escalation latches (e.g. `send_notification` to a human channel; later `create_ticket`) |
+| pause_responses_on_escalation | bool default true | D2 |
+| ai_agent_id | uuid null → `ai_agents` | when set, the compiled automation is AI-managed |
+| compiled_alert_template_id, compiled_alert_rule_id, compiled_automation_id | uuid null | provenance pointers |
+| compiled_hash, compiled_at | text, timestamptz | drift detection |
+| created_by, created_at, updated_at | | |
+
+Unique `(coalesce(org_id, partner_id), name)`.
+
+### `config_policy_monitors` (attachment)
+
+| column | notes |
+|---|---|
+| id | uuid pk |
+| feature_link_id | → `config_policy_feature_links(id)` ON DELETE CASCADE; the link's `feature_type = 'monitor'` |
+| monitor_id | → `monitor_definitions(id)` ON DELETE CASCADE |
+| enabled | bool; `false` = this policy switches the monitor off for its scope (cumulative override) |
+| overrides | jsonb null; subset of `condition` and `severity` permitted by the kind's `overridableKeys` |
+| sort_order | |
+
+Unique `(feature_link_id, monitor_id)`. The `monitor` value is added to `config_feature_type`.
+
+### `monitor_device_state`
+
+One row per (monitor, device). `org_id` = device org.
+
+| column | notes |
+|---|---|
+| monitor_id, device_id | composite pk |
+| org_id | device's |
+| current_episode_id | null when healthy |
+| episodes_in_window | int, maintained by the evaluator |
+| window_started_at | |
+| escalated_at, escalation_alert_id | set when recurrence latches |
+| responses_paused | bool |
+| reset_at, reset_by | audit of the human reset |
+| last_evaluated_at, last_state | `ok \| breach \| unknown` |
+
+### `monitor_episodes`
+
+Append-only. `org_id` = device org.
+
+| column | notes |
+|---|---|
+| id | |
+| monitor_id, device_id, org_id | |
+| started_at, ended_at | `ended_at` null while open |
+| alert_id | the alert the sweep raised for this breach |
+| response_run_id | the automation run the response produced, null if paused/none |
+| response_outcome | `queued \| completed \| failed \| skipped_paused \| skipped_no_response` |
+| end_reason | `recovered \| device_deleted \| monitor_detached` |
+
+Retention: 400 days (covers a one-year window); pruned by the existing retention worker pattern.
+
+### Additions to existing tables
+
+- `alert_rules`, `alert_templates`, `automations`: `managed_by_monitor_id uuid null → monitor_definitions(id)`
+  ON DELETE CASCADE, partial index where not null. Service-layer guard: `updateAlertRule`,
+  `updateAutomation`, the MCP `manage_automations` tool and the AI-agent automation path reject
+  writes to rows with `managed_by_monitor_id` set (`409 managed_by_monitor`). UI renders them
+  read-only with a link to the monitor.
+- `alerts`: `monitor_id uuid null`, `episode_id uuid null`, `requires_human bool default false`.
+  `requires_human` is read by the AI verdict subscriber and by auto-resolve: a requires-human alert
+  is never auto-resolved and never auto-suppressed by a verdict.
+
+## Compile contract
+
+The compiler is the **only writer** of managed rows. `saveMonitorDefinition(input)` runs in one
+transaction:
+
+1. Validate `condition` against the kind's schema; validate `responses` against
+   `automationActionSchema` with the monitor restrictions.
+2. Upsert `alert_templates` row (`is_built_in = true`, `managed_by_monitor_id`), with
+   `conditions = [kindToConditionHandler(kind, condition)]`, severity, cooldown, auto-resolve,
+   title/message templates derived from the kind.
+3. Upsert `alert_rules` row (`managed_by_monitor_id`, `template_id`, `is_active = enabled`,
+   `target_type = 'monitor'`, `target_id = monitor_id`). The sweep already evaluates rules through
+   `evaluateDeviceAlerts`; a new `target_type` resolver maps `'monitor'` to the devices the
+   attachment resolution yields (see *Targeting*), so no second evaluator is introduced.
+4. Upsert `automations` row (`managed_by_monitor_id`; `managed_by_agent_id = ai_agent_id`;
+   `trigger = { type: 'event', event: 'alert.triggered', filter: { ruleId: <compiled rule id> } }`;
+   `actions = responses`; `enabled`). The optional `filter: { ruleId }` field is added to the
+   `event` branch of `automationTriggerSchema` (`packages/shared/src/validators/index.ts`) and
+   honoured by `shouldTriggerEventAutomation` (today it matches on event type only).
+5. Write `compiled_*` pointers and `compiled_hash = sha256(canonical(definition))`.
+
+Every compiled row is deterministic from the definition; the contract test recompiles every
+definition and asserts zero diff against the stored rows. A nightly reconcile job does the same in
+production and logs drift as a `platform.monitor_drift` event (never silently repairs).
+
+Delete: deleting a definition cascades the managed rows and attachments; open episodes are ended
+with `monitor_detached`; the escalation alert (if any) is left open for the human.
+
+## Targeting and inheritance (D3, D4)
+
+A monitor reaches a device through: definition → attachment (in a policy's `monitor` feature
+link) → the policy's assignments (`partner | organization | site | device_group | device`, dynamic
+groups included) → the device. Parent policies (#5080, one level) contribute their attachments to
+the child.
+
+Resolution for a device, `resolveMonitorsForDevice(deviceId)`:
+
+1. Collect every policy assigned to the device at any level, plus each policy's parent.
+2. Collect every `config_policy_monitors` row under those policies' `monitor` feature links.
+3. Group by `monitor_id`. For each monitor, the row from the **most specific** source wins
+   (device > device_group > site > organization > partner; within one policy, child before
+   parent). That row's `enabled` and `overrides` apply.
+4. The result is the set of enabled monitors with their effective parameters. This is the set the
+   `'monitor'` target-type resolver returns for the compiled alert rule, and the set the heartbeat
+   config builder uses for agent-side kinds (Wave 4).
+
+This union is deliberately different from every other feature type, which resolves to the single
+winning link (`config_policy_effective_feature_links`). The view is untouched; the monitor resolver
+is a separate function with its own contract test (partner-wide parent + org child + site override:
+the site override disables one monitor and changes one threshold; every other monitor is still
+active). Existing readers of the effective-links view never see `feature_type = 'monitor'` links
+because nothing else reads that type.
+
+"Deploy to…" in the editor: pick an existing policy (creates or reuses its `monitor` feature link
+and inserts the attachment) or "New policy for <site | group>" (creates a policy assigned at that
+level with the attachment). The editor lists every policy the monitor is attached to.
+
+## Evaluation and recurrence (D2)
+
+Evaluation is the existing sweep. When the compiled rule's condition handler returns true for a
+device, the sweep already creates or dedupes the alert. The monitor layer hooks the same point:
+
+- `on breach(monitor, device)`: if `monitor_device_state.current_episode_id` is null → open an
+  episode (`monitor_episodes` insert, `alerts.monitor_id/episode_id` stamped, state updated). If an
+  episode is already open → nothing (a continuous breach is one episode, regardless of how many
+  sweeps see it).
+- `on recovery(monitor, device)`: evidence must be a fresh evaluation returning false. Close the
+  episode (`ended_at`, `recovered`), clear `current_episode_id`. Stale heartbeat, device offline, or
+  handler `unknown` **do not** close an episode.
+- `on episode open`: increment `episodes_in_window` after pruning episodes older than the window;
+  if `episodes_in_window >= recurrence_threshold` and not already escalated → **latch**:
+  - create one alert `requires_human = true`, severity = max(monitor severity + 1, high), title
+    "<monitor> recurred N times in M days on <device>", linked to the episode;
+  - run `recurrence_actions` once (device-bound);
+  - route through the monitor's delivery and start its escalation policy;
+  - set `responses_paused = true` when `pause_responses_on_escalation`.
+- Responses: the compiled automation still fires on `alert.triggered`; `automationWorker` checks
+  `monitor_device_state.responses_paused` for the (monitor, device) and records
+  `skipped_paused` on the episode instead of running. The escalation latch and the pause are set in
+  the same transaction as the episode insert, so a response cannot slip through between them.
+- Reset: `POST /monitors/:id/devices/:deviceId/reset` (permission `alerts:write`) clears
+  `escalated_at`, `responses_paused`, resets the window, records `reset_by`. Acknowledging the
+  requires-human alert stops paging (existing behaviour) but does **not** reset — the two are
+  separately audited.
+
+Interactions:
+
+- **Cooldown / flapping** gate alert creation, not episodes. If the sweep evaluates true while an
+  alert is in cooldown, the episode still opens (or stays open). Noise controls cannot hide a loop.
+- **Correlation** groups alerts for presentation and delivery; it never merges or suppresses
+  episodes. A requires-human alert is always its own correlation root.
+- **AI verdicts** may still run on ordinary monitor alerts. On a `requires_human` alert the verdict
+  subscriber records advisory analysis only; it cannot auto-resolve or downgrade it.
+- **Maintenance windows** suppress delivery as today; episodes are still recorded and flagged
+  `in_maintenance` in `alerts.context` so a post-window report can show them.
+
+Idempotency: episode open/close and the latch use `SELECT … FOR UPDATE` on the
+`monitor_device_state` row; the automation run id is written to the episode, so a BullMQ retry
+of the response cannot count twice.
+
+## Responses
+
+- Actions are the existing `AutomationAction` union. The compiled automation always runs
+  **device-bound** to `payload.deviceId`; this is the `triggering_device` scope from #5240, which
+  is a hard prerequisite of Wave 2.
+- Ordered actions execute in array order per device; `on_failure = 'stop'` default. Completion is
+  tracked per action through the existing `automationRunDeviceResults`; the episode's
+  `response_outcome` is set from the run's terminal state (Wave 3 also fixes the "queued reported
+  as success" gap in `automationRuntime.ts` so `completed` means completed).
+- `ai_triage` is allowed only when the definition names an `ai_agent_id`; the compiler then sets
+  `managed_by_agent_id` so the existing admission, loop guards and approval tiers apply unchanged.
+  Unmanaged `ai_triage` stays refused (today's behaviour).
+- `execute_command` responses of kind `restart_service` on a `service` monitor supersede the
+  agent-side `auto_restart` flag: Wave 4 compiles a service monitor with that response to
+  `auto_restart = true` on the delivered watch so the restart still happens locally and offline;
+  the agent reports the attempt and the episode records it as a response with
+  `response_outcome` from the agent's result.
+
+## Delivery
+
+- `delivery_mode = inherit` reproduces today's behaviour: `notificationRoutingRules` pick channels
+  by severity/site/tags. `channels` sends to the listed channels *in addition to* routing rules
+  (never fewer than routing would send). `none` suppresses delivery for this monitor (still in the
+  inbox).
+- `escalation_policy_id` is applied on the compiled rule's overrides. Verified on main: the
+  config-policy alert path (`evaluateDeviceAlertsFromPolicy`) does not look up an escalation policy
+  the way `evaluateDeviceAlerts` does. Monitors compile to `alert_rules` (the standalone path), so
+  they get escalation for free; Wave 2 adds the missing lookup to the policy path anyway so the
+  compatibility tabs are not worse than monitors.
+- Ticket delivery arrives with #5238 as a channel type and a `create_ticket` action; the
+  `recurrence_actions` slot is where it plugs in for "open a ticket when a human is needed".
+
+## Monitor types (D5)
+
+`monitor_kind` enum and where each evaluates:
+
+| kind | evaluates via | wave |
+|---|---|---|
+| `cpu`, `memory`, `disk` | `threshold` handler (metric, operator, value, duration) | 1 |
+| `offline` | `offline` handler | 1 |
+| `event_log` | `event_log` handler | 1 |
+| `patch_compliance` | `patch_compliance` handler | 1 |
+| `service`, `process` | `service_stopped` / `process_stopped` handlers over `serviceProcessCheckResults`; the watch itself still comes from the config-policy Monitoring tab until Wave 4 | 1 (evaluate), 4 (deliver) |
+| `process_resource` | `processResource` handler | 1 |
+| `cert_expiry`, `bandwidth`, `disk_io`, `network_errors` | existing handlers | 1 |
+| `antivirus` | new handler over security-center / Defender status (`agent/internal/security`) | 3 |
+| `software_presence` | new handler over software inventory (installed / not installed / version below) | 3 |
+| `backup_continuity` | new handler over native backup job age and `backupSlaWorker` results | 3 |
+| `script` | first-class: a diagnostic script runs on the monitor's interval through the existing script dispatch; exit code ≠ 0 or a `::breeze:monitor:: {"state":"breach","detail":"…"}` marker = breach; timeout = `unknown`. The diagnostic script is distinct from response scripts. | 3 |
+| `network_check` (ping, tcp, http, dns) | adapter over `networkMonitors` + `networkMonitorAlertRules`; requires #5241 first and adds partner-wide ownership to those tables | 4 |
+| `snmp`, `snmp_throughput` | separate SNMP poller; OID threshold + rate-normalised deltas with counter-wrap handling | later spec |
+| `wmi_query`, `perf_counter`, `file_size`, `hardware_sensor` | new agent acquisition contracts | later specs |
+
+Each kind declares: `conditionSchema` (zod), `overridableKeys`, `toAlertCondition(condition)` (the
+handler payload), `titleTemplate`, `defaultSeverity`, `supportsResponses`, and `agentDelivered`
+(service/process/script/network). The registry lives in `apps/api/src/services/monitors/kinds/`,
+one file per kind, hub file for the map — the `aiTools*.ts` pattern.
+
+## Navigation and web
+
+Left nav (`Sidebar.tsx`):
+
+- **Alerts** → `/alerts` — unchanged (inbox, acknowledge, suppress, resolve, correlations,
+  Incidents).
+- **Monitoring** → `/monitoring` (new entry under Fleet Management, replaces the "Network Monitor"
+  entry). Hash tabs: `#monitors` (default), `#network` (the existing network-monitor page moves here
+  unchanged), `#delivery` (notification channels, routing rules, escalation policies — the pages
+  that exist today under `/alerts/*` without nav), `#legacy-rules` (standalone alert rules with no
+  `managed_by_monitor_id`, each with **Convert to monitor**). Page title "Monitoring & Automation".
+  Existing bookmarks to `/monitoring` land on the hub with `#monitors` selected; `#network` is the
+  old page unchanged.
+- **Jobs** → `/jobs` (new entry). Hash tabs: `#scheduled`, `#on-demand` (manual), `#webhooks`,
+  `#event-rules` (unmanaged event-trigger automations, so nothing a customer built disappears),
+  `#history`. `/automations` and `/automations/:id` become redirects to `/jobs`. Monitor-managed
+  automations are hidden from Jobs and shown inside their monitor.
+- Config-policy editor: new **Monitors** tab (attachment list with enable/override per row, plus
+  "Attach existing" and "Create monitor"). Existing Monitoring / Alert / Automation tabs remain
+  and gain a one-line banner pointing at Monitors for fleet-wide rules.
+
+Monitor editor (`/monitoring/monitors/:id`, `MonitorEditor.tsx`), sections in this order, each a
+card: **What to watch** (kind picker + condition fields from the kind's schema) · **Severity &
+noise** (severity, cooldown, auto-resolve) · **Respond** (ordered actions, same `useFieldArray`
+component as `AutomationForm`, device-bound note) · **Notify** (delivery mode, channels,
+escalation policy) · **Escalate to a human** (threshold N, window days, actions, pause toggle) ·
+**Deployed to** (policies, "Deploy to…"). Create-only `ownerScope` selector and "All orgs" badge
+per the partner-wide playbook. Detail view adds an **Activity** tab: episodes per device, current
+escalations, reset button.
+
+Device page: the existing Monitoring hash-tab lists the device's effective monitors with state and
+open episode, replacing the watches-only view.
+
+Copy: the phrase "Service & Process Monitoring" disappears from nav and page titles; it survives as
+the config-policy tab label until that tab is retired.
+
+## API
+
+All under `/monitors`, org- or partner-scoped through the usual auth context; partner-wide writes
+gate on `canManagePartnerWidePolicies`.
+
+| route | purpose |
+|---|---|
+| `GET /monitors` | list (filters: kind, enabled, ownerScope) |
+| `POST /monitors` | create (`ownerScope`, definition); compiles |
+| `GET /monitors/:id` | definition + compiled pointers + attachments + state summary |
+| `PATCH /monitors/:id` | update; recompiles; `ownerScope` omitted |
+| `DELETE /monitors/:id` | cascade |
+| `GET /monitors/kinds` | registry: schemas, overridable keys, availability per platform |
+| `POST /monitors/:id/attachments` | `{ configPolicyId }` or `{ createPolicyFor: { level, targetId } }` |
+| `DELETE /monitors/:id/attachments/:attachmentId` | |
+| `PATCH /config-policies/:id/monitors/:attachmentId` | enable / overrides |
+| `GET /monitors/:id/devices` | per-device state, open episode, escalation |
+| `POST /monitors/:id/devices/:deviceId/reset` | clear escalation, resume responses |
+| `POST /monitors/:id/test` | dry-run the condition against one device, returns the handler verdict |
+| `POST /alert-rules/:id/convert-to-monitor` | legacy conversion: builds a definition from the rule + template, attaches to a new policy assigned like the rule's `targetType/targetId`, marks the old rule inactive with `converted_to_monitor_id` |
+
+MCP: `list_monitors`, `get_monitor_activity`, `reset_monitor_escalation` (Tier 2). `manage_monitors`
+(create/update) is Tier 3 like `manage_automations`.
+
+## AI
+
+- The AI alert-verdict subscriber keeps running on ordinary monitor alerts; `requires_human`
+  alerts get advisory analysis only.
+- A monitor with `ai_agent_id` compiles to an AI-managed automation; AI Operator (feature #5205)
+  sees it as any other managed automation. No new admission path.
+- `get_monitor_activity` gives the AI the episode history it needs to explain "this has recurred
+  three times" instead of reasoning from raw alerts.
+
+## Waves
+
+| wave | ships | must not break |
+|---|---|---|
+| **W1 — discoverability** (no schema) | Jobs nav entry + `/jobs` page over existing automations with the hash tabs; `/automations` redirects; Monitoring nav entry with `#network` and `#delivery` tabs hosting the existing pages; Alert Rules listed under `#legacy-rules` | every existing URL (redirects), permissions |
+| **W2 — definitions and compile** | `monitor_definitions`, `config_policy_monitors`, `monitor` feature type, kind registry for the eleven existing handler kinds, compiler + managed-row guards + drift contract test, `'monitor'` target resolver, cumulative resolution, escalation lookup on the policy alert path, monitor editor + policy Monitors tab, "Deploy to…", convert-to-monitor. **Prerequisite: #5240 (device-bound event automations).** | alert sweep, correlation, cooldown, routing, escalation policies, partner fan-out, #5080 inheritance, AI verdicts, MCP `manage_automations` (now refuses managed rows) |
+| **W3 — episodes and recurrence** | `monitor_device_state`, `monitor_episodes`, episode open/close in the sweep hook, latch + requires-human alert + pause + reset API, Activity tab, `response_outcome` from terminal run state (fixes queued-as-success), `requires_human` handling in auto-resolve and the verdict subscriber | AI admission and loop guards, delivery dedupe, escalation cancellation |
+| **W4 — coverage** | handler-only kinds (antivirus, software_presence, backup_continuity), script monitor, network_check adapter (after #5241) with partner-wide `networkMonitors`, service/process watch delivery from `resolveMonitorsForDevice` (heartbeat builder reads monitors first, config-policy tab second) | agent config payload shape (`monitoring_settings` unchanged on the wire), local auto-restart |
+| **W5 — retirement decisions** (separate program) | whether the config-policy Alert/Automation/Monitoring tabs become thin pointers; SNMP and agent-acquisition kinds get their own specs | — |
+
+Each wave is its own plan and PR set; W1 can ship before the others are planned.
+
+## Risks and mitigations
+
+- **Managed-row drift** through a writer the guard misses (AI agents, MCP, portal, seeds). The
+  guard is in the service layer, the contract test recompiles everything, and the nightly
+  reconcile logs drift as an event. Any writer that bypasses the service layer is a bug.
+- **Double evaluation** if a converted legacy rule is left active. Conversion marks the rule
+  inactive in the same transaction and the UI hides converted rules by default.
+- **Cumulative inheritance surprises**: a site policy that only wanted to *add* a monitor also
+  inherits the org baseline. This is the intended model (D4); the policy Monitors tab shows
+  effective rows with their source badge, and `disable` is a one-click override.
+- **Partner-wide monitors fan out to every org**; responses run scripts per device org (existing
+  automation semantics). The `automationResourceBindings` drift guard already refuses a partner
+  automation that references an org-owned script; the compiler validates `responses` through the
+  same binding check at save time so the failure is at authoring, not at 3 a.m.
+- **Episode semantics under stale data**: a device that goes offline mid-breach keeps its episode
+  open; the offline monitor (a separate kind) covers the outage. Documented in the editor copy.
+- **Service/process shim** between W2 and W4: service/process monitors evaluate through the sweep
+  but the watch still comes from the policy Monitoring tab, so a `service` monitor without a
+  matching watch never breaches. W2's editor warns when no watch delivers the named service to the
+  monitor's scope; W4 removes the gap.
+- **Stale worktree during design**: the exploration for this spec ran partly on a checkout 307
+  commits behind main; every claim in this document was re-verified on `origin/main`
+  (`df36bc667a`) before writing.
+
+## Review log
+
+- 2026-09-07 — Fable position and Codex (gpt-6-astra, xhigh, read-only) position written
+  independently from the same context pack. Agreement: authoring-layer unification over existing
+  engines; Alerts stays the inbox; Jobs rename plus the missing nav entry; script monitor
+  first-class; existing handlers first. Codex improvements adopted: breach-episode counting,
+  targeting through policy attachment, cumulative inheritance, explicit delivery mode, device-bound
+  responses as a prerequisite. Codex proposal deferred: `monitor_revisions`. Two bugs found and
+  filed from the review: #5240 (event automations fan out), #5241 (network-monitor alerts never
+  publish `alert.triggered`).
+- 2026-09-08 — D1–D5 approved by the product owner ("go with recommendations").
+
+## Release notes
+
+- New **Monitoring** and **Jobs** entries in the left nav. Automations are now called Jobs;
+  existing links redirect.
+- **Monitors**: watch a condition, run a response on the affected device, notify, and escalate to a
+  human when the same problem recurs N times in M days. Deploy monitors through configuration
+  policies, including partner-wide.
+- Alert rules you already have keep working; each can be converted to a monitor from
+  Monitoring → Legacy rules.
+- Fixed: event-triggered automations now act on the device that raised the event (#5240);
+  network-monitor alerts now notify and escalate like every other alert (#5241).

--- a/docs/superpowers/specs/monitoring/2026-09-08-monitoring-automation-unification-design.md
+++ b/docs/superpowers/specs/monitoring/2026-09-08-monitoring-automation-unification-design.md
@@ -2,8 +2,8 @@
 title: Monitoring & Automation unification (monitors as the authoring object)
 status: approved
 date: 2026-09-08
-tracking_issue: LanternOps/breeze#4984
-origin: "#4984 community proposal (Discord, MSP migrating from Datto RMM); escalation counter #4672"
+tracking_issue: LanternOps/breeze#5287
+origin: "#4984 community proposal (feature tracker #5287, waves #5288–#5291) (Discord, MSP migrating from Datto RMM); escalation counter #4672"
 ---
 
 # Monitoring & Automation unification


### PR DESCRIPTION
Design spec for #4984 (Refs #4984, #4672). No code.

**Verdict:** unify at the authoring layer. A new `monitor_definitions` object (org XOR partner) compiles into managed `alert_rules` / `alert_templates` / `automations` rows it alone may write; the sweep, correlation, cooldown, routing, escalation policies and AI verdict paths are untouched. Recurrence is counted in **breach episodes** (N in M days → requires-human alert, notify, pause auto-remediation until reset). Monitors deploy through a new `monitor` config-policy feature type with **cumulative** inheritance. Nav becomes **Alerts** (inbox) · **Monitoring** (monitors, network, delivery, legacy rules) · **Jobs** (renamed automations, which currently have no nav entry).

Decisions D1–D5 approved by the product owner 2026-09-08. Review log records the independent Fable + Codex (xhigh) positions and what was adopted from each. Two bugs surfaced by the review are filed separately and are prerequisites: #5240 (event automations fan out to the whole scope), #5241 (network-monitor alerts never publish `alert.triggered`).

Waves: W1 discoverability (no schema) → W2 definitions + compile → W3 episodes + recurrence → W4 coverage (antivirus, software, backup, script monitor, network adapter, service/process delivery). Plans follow in a separate PR; feature registration after that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LREBrJguZ5ACnoB9nqABnw