### PR TITLE
fix(remote-access): Remote Tools + Overview pick up desktopAccess changes live (#5250)

### DIFF
--- a/apps/api/src/routes/agents/heartbeat.test.ts
+++ b/apps/api/src/routes/agents/heartbeat.test.ts
@@ -4518,14 +4518,49 @@ describe('POST /agents/:id/heartbeat — desktopAccess change publishes device.u
     );
   });
 
-  it('steady-state desktopAccess re-report (unchanged) does NOT publish device.updated', async () => {
+  it('desktopAccess dropping from user_session → unavailable publishes device.updated (degrading transition)', async () => {
+    arrange({
+      desktopAccess: { mode: 'user_session', loginUiReachable: true, virtualDisplayReady: true, checkedAt: '2026-09-01T00:00:00.000Z' },
+    });
+    const dropped = {
+      mode: 'unavailable',
+      loginUiReachable: false,
+      virtualDisplayReady: false,
+      reason: 'helper_not_connected',
+      checkedAt: '2026-09-08T12:00:00.000Z',
+    };
+
+    const resp = await beat({ ...minimalHeartbeatBody, desktopAccess: dropped });
+    expect(resp.status).toBe(200);
+
+    const { publishEvent } = await import('../../services/eventBus');
+    expect(publishEvent).toHaveBeenCalledWith(
+      'device.updated',
+      'org-1',
+      expect.objectContaining({ deviceId: 'device-1', fields: ['desktopAccess'], desktopAccess: dropped }),
+      'heartbeat',
+      expect.objectContaining({ siteId: 'site-1' }),
+    );
+  });
+
+  // #5250 review — the agent recomputes `checkedAt` fresh on EVERY heartbeat
+  // regardless of whether access actually changed (it calls time.Now().UTC()
+  // unconditionally on mac/Linux). A test that reuses an IDENTICAL
+  // checkedAt for baseline and report (as a naive re-report test would) can
+  // never catch a raw JSON.stringify diff spamming device.updated on every
+  // heartbeat — production heartbeats never repeat a timestamp. This is the
+  // realistic steady-state case: same mode/reachability, DIFFERENT
+  // checkedAt, must still NOT publish.
+  it('steady-state desktopAccess re-report with only checkedAt differing does NOT publish device.updated', async () => {
     arrange({
       desktopAccess: { mode: 'user_session', loginUiReachable: true, virtualDisplayReady: true, checkedAt: '2026-09-01T00:00:00.000Z' },
     });
 
     const resp = await beat({
       ...minimalHeartbeatBody,
-      desktopAccess: { mode: 'user_session', loginUiReachable: true, virtualDisplayReady: true, checkedAt: '2026-09-01T00:00:00.000Z' },
+      // Same mode/reachability as baseline; only the timestamp moved, as a
+      // real re-report from the agent always does.
+      desktopAccess: { mode: 'user_session', loginUiReachable: true, virtualDisplayReady: true, checkedAt: '2026-09-08T12:00:00.000Z' },
     });
     expect(resp.status).toBe(200);
 
@@ -4553,6 +4588,50 @@ describe('POST /agents/:id/heartbeat — desktopAccess change publishes device.u
       expect.anything(),
       expect.anything(),
     );
+  });
+});
+
+describe('desktopAccessMeaningfullyChanged (#5250)', () => {
+  it('is false when both are null/undefined', async () => {
+    const { desktopAccessMeaningfullyChanged } = await import('./heartbeat');
+    expect(desktopAccessMeaningfullyChanged(null, undefined)).toBe(false);
+  });
+
+  it('is false when only checkedAt differs', async () => {
+    const { desktopAccessMeaningfullyChanged } = await import('./heartbeat');
+    expect(
+      desktopAccessMeaningfullyChanged(
+        { mode: 'user_session', loginUiReachable: true, virtualDisplayReady: true, checkedAt: '2026-09-01T00:00:00.000Z' },
+        { mode: 'user_session', loginUiReachable: true, virtualDisplayReady: true, checkedAt: '2026-09-08T00:00:00.000Z' },
+      ),
+    ).toBe(false);
+  });
+
+  it('is true when mode differs', async () => {
+    const { desktopAccessMeaningfullyChanged } = await import('./heartbeat');
+    expect(
+      desktopAccessMeaningfullyChanged(
+        { mode: 'unavailable', loginUiReachable: false, virtualDisplayReady: false, checkedAt: '2026-09-01T00:00:00.000Z' },
+        { mode: 'user_session', loginUiReachable: true, virtualDisplayReady: true, checkedAt: '2026-09-08T00:00:00.000Z' },
+      ),
+    ).toBe(true);
+  });
+
+  it('is true when reason differs (mode unchanged)', async () => {
+    const { desktopAccessMeaningfullyChanged } = await import('./heartbeat');
+    expect(
+      desktopAccessMeaningfullyChanged(
+        { mode: 'unavailable', loginUiReachable: false, virtualDisplayReady: false, reason: 'helper_not_connected', checkedAt: '2026-09-01T00:00:00.000Z' },
+        { mode: 'unavailable', loginUiReachable: false, virtualDisplayReady: false, reason: 'missing_permission', checkedAt: '2026-09-08T00:00:00.000Z' },
+      ),
+    ).toBe(true);
+  });
+
+  it('is true when transitioning from null to a value and vice versa', async () => {
+    const { desktopAccessMeaningfullyChanged } = await import('./heartbeat');
+    const state = { mode: 'user_session' as const, loginUiReachable: true, virtualDisplayReady: true, checkedAt: '2026-09-01T00:00:00.000Z' };
+    expect(desktopAccessMeaningfullyChanged(null, state)).toBe(true);
+    expect(desktopAccessMeaningfullyChanged(state, null)).toBe(true);
   });
 });
 

--- a/apps/api/src/routes/agents/heartbeat.test.ts
+++ b/apps/api/src/routes/agents/heartbeat.test.ts
@@ -4445,6 +4445,117 @@ describe('POST /agents/:id/heartbeat — state-change audit (finding #10)', () =
   });
 });
 
+// ---------------------------------------------------------------------
+// #5250 — desktopAccess change publishes device.updated so pages holding the
+// event stream open (Remote Tools' Connect Desktop button) can refresh
+// without a remount. Was previously written to devices + audited (finding
+// #10 above) but never pushed as a live event, unlike agentVersion.
+// ---------------------------------------------------------------------
+describe('POST /agents/:id/heartbeat — desktopAccess change publishes device.updated (#5250)', () => {
+  const baselineDevice = {
+    id: 'device-1',
+    orgId: 'org-1',
+    siteId: 'site-1',
+    hostname: 'host-1',
+    osType: 'macos',
+    osVersion: '14.5',
+    osBuild: null,
+    architecture: 'arm64',
+    agentVersion: '0.65.10',
+    deviceRole: 'workstation',
+    deviceRoleSource: 'auto',
+    agentTokenHash: 'hash',
+    tokenIssuedAt: new Date(),
+    status: 'online',
+    desktopAccess: { mode: 'unavailable', loginUiReachable: false, virtualDisplayReady: false, checkedAt: '2026-09-01T00:00:00.000Z' },
+    mainAgentSilentSince: null,
+  };
+
+  function arrange(deviceOverrides: Record<string, unknown> = {}) {
+    vi.clearAllMocks();
+    getActiveTrustKeysetMock.mockResolvedValue([]);
+    selectMock.mockReturnValueOnce(
+      selectChainResolving([{ ...baselineDevice, ...deviceOverrides }]),
+    );
+    updateMock.mockReturnValue({
+      set: vi.fn(() => ({ where: vi.fn(() => whereResultWithReturning([{ id: 'device-1' }])) })),
+    });
+    insertMock.mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) });
+    selectMock.mockReturnValue(selectChainResolving([]));
+  }
+
+  async function beat(body: Record<string, unknown>) {
+    return buildApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+  }
+
+  it('desktopAccess recovering from unavailable → available publishes device.updated with fields:[desktopAccess]', async () => {
+    arrange(); // baseline: mode 'unavailable'
+    const recovered = {
+      mode: 'user_session',
+      loginUiReachable: true,
+      virtualDisplayReady: true,
+      checkedAt: '2026-09-08T12:00:00.000Z',
+    };
+
+    const resp = await beat({ ...minimalHeartbeatBody, desktopAccess: recovered });
+    expect(resp.status).toBe(200);
+
+    const { publishEvent } = await import('../../services/eventBus');
+    expect(publishEvent).toHaveBeenCalledWith(
+      'device.updated',
+      'org-1',
+      expect.objectContaining({
+        deviceId: 'device-1',
+        fields: ['desktopAccess'],
+        desktopAccess: recovered,
+      }),
+      'heartbeat',
+      expect.objectContaining({ siteId: 'site-1' }),
+    );
+  });
+
+  it('steady-state desktopAccess re-report (unchanged) does NOT publish device.updated', async () => {
+    arrange({
+      desktopAccess: { mode: 'user_session', loginUiReachable: true, virtualDisplayReady: true, checkedAt: '2026-09-01T00:00:00.000Z' },
+    });
+
+    const resp = await beat({
+      ...minimalHeartbeatBody,
+      desktopAccess: { mode: 'user_session', loginUiReachable: true, virtualDisplayReady: true, checkedAt: '2026-09-01T00:00:00.000Z' },
+    });
+    expect(resp.status).toBe(200);
+
+    const { publishEvent } = await import('../../services/eventBus');
+    expect(publishEvent).not.toHaveBeenCalledWith(
+      'device.updated',
+      expect.anything(),
+      expect.objectContaining({ fields: ['desktopAccess'] }),
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  it('heartbeat with no desktopAccess reported does NOT publish device.updated for desktopAccess', async () => {
+    arrange(); // baseline desktopAccess 'unavailable'
+
+    const resp = await beat({ ...minimalHeartbeatBody }); // no desktopAccess field at all
+    expect(resp.status).toBe(200);
+
+    const { publishEvent } = await import('../../services/eventBus');
+    expect(publishEvent).not.toHaveBeenCalledWith(
+      'device.updated',
+      expect.anything(),
+      expect.objectContaining({ fields: ['desktopAccess'] }),
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+});
+
 describe('POST /agents/:id/heartbeat — agentRuntime gauges (#2389)', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -1131,6 +1131,26 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
     });
   }
 
+  // #5250 — publish event when desktopAccess changes so pages holding the
+  // socket open (Remote Tools' Connect Desktop button) pick up a helper
+  // recovery / drop without requiring a remount. Mirrors the agentVersion
+  // publish above; guarded on deviceUpdates.desktopAccess (only set when the
+  // agent actually reported the field) diffed against the pre-update snapshot,
+  // same comparison the state-change audit above already uses.
+  if (
+    deviceUpdates.desktopAccess !== undefined &&
+    JSON.stringify(deviceUpdates.desktopAccess) !== JSON.stringify(device.desktopAccess ?? null)
+  ) {
+    publishEvent('device.updated', device.orgId, {
+      deviceId: device.id,
+      fields: ['desktopAccess'],
+      desktopAccess: deviceUpdates.desktopAccess,
+    }, 'heartbeat', { siteId: device.siteId }).catch(err => {
+      console.error('[Heartbeat] Failed to publish device.updated:', err);
+      captureException(err);
+    });
+  }
+
   if (data.metrics) {
     await db
       .insert(deviceMetrics)

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -13,7 +13,7 @@ import {
   agentLogs,
   onedriveDeviceState,
 } from '../../db/schema';
-import type { BatteryStatus } from '@breeze/shared';
+import type { BatteryStatus, DesktopAccessState } from '@breeze/shared';
 import { promotePendingAgentCredentials } from '../../services/agentTokenPromotion';
 import { writeAuditEvent } from '../../services/auditEvents';
 import { heartbeatSchema } from './schemas';
@@ -239,6 +239,30 @@ export function normalizeRollbackProtocolVersion(value: unknown): 0 | 1 {
 /** Normalize the only PAM lifetime protocol version implemented here. */
 export function normalizePamLifetimeProtocolVersion(value: unknown): 0 | 2 {
   return value === 2 ? 2 : 0;
+}
+
+// #5250 — the agent recomputes `checkedAt` (and, on macOS/Linux, the whole
+// DesktopAccessState) fresh on EVERY heartbeat regardless of whether access
+// actually changed (agent/internal/heartbeat/desktop_access_{darwin,linux}.go
+// call time.Now().UTC() unconditionally). A raw JSON.stringify diff against
+// the stored value would therefore read as "changed" on essentially every
+// heartbeat for every mac/Linux device, defeating the point of a
+// change-gated publish. Compare only the fields that are actually
+// user-visible / decide Connect Desktop availability, ignoring the
+// timestamp.
+export function desktopAccessMeaningfullyChanged(
+  before: DesktopAccessState | null | undefined,
+  after: DesktopAccessState | null | undefined,
+): boolean {
+  if (!before && !after) return false;
+  if (!before || !after) return true;
+  return (
+    before.mode !== after.mode ||
+    before.loginUiReachable !== after.loginUiReachable ||
+    before.virtualDisplayReady !== after.virtualDisplayReady ||
+    (before.reason ?? null) !== (after.reason ?? null) ||
+    (before.remoteDesktopPermission ?? null) !== (after.remoteDesktopPermission ?? null)
+  );
 }
 
 export const heartbeatRoutes = new Hono();
@@ -1135,19 +1159,31 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
   // socket open (Remote Tools' Connect Desktop button) pick up a helper
   // recovery / drop without requiring a remount. Mirrors the agentVersion
   // publish above; guarded on deviceUpdates.desktopAccess (only set when the
-  // agent actually reported the field) diffed against the pre-update snapshot,
-  // same comparison the state-change audit above already uses.
+  // agent actually reported the field) diffed against the pre-update
+  // snapshot with desktopAccessMeaningfullyChanged — a raw JSON.stringify
+  // diff (as the state-change audit above uses) would fire on every
+  // heartbeat because `checkedAt` is refreshed unconditionally by the agent.
+  //
+  // `deviceUpdates` is a loosely-typed `Record<string, unknown>`, so TS
+  // narrows the `!== undefined` check to `{} | null` rather than the real
+  // shape — reassert the type explicitly. Safe: this field is only ever
+  // assigned from a truthy `data.desktopAccess` (a `DesktopAccessState`) above.
+  const reportedDesktopAccess = deviceUpdates.desktopAccess as DesktopAccessState | undefined;
   if (
-    deviceUpdates.desktopAccess !== undefined &&
-    JSON.stringify(deviceUpdates.desktopAccess) !== JSON.stringify(device.desktopAccess ?? null)
+    reportedDesktopAccess !== undefined &&
+    desktopAccessMeaningfullyChanged(device.desktopAccess, reportedDesktopAccess)
   ) {
     publishEvent('device.updated', device.orgId, {
       deviceId: device.id,
       fields: ['desktopAccess'],
-      desktopAccess: deviceUpdates.desktopAccess,
+      desktopAccess: reportedDesktopAccess,
     }, 'heartbeat', { siteId: device.siteId }).catch(err => {
-      console.error('[Heartbeat] Failed to publish device.updated:', err);
-      captureException(err);
+      console.error('[Heartbeat] Failed to publish device.updated (desktopAccess):', {
+        deviceId: device.id,
+        orgId: device.orgId,
+        err,
+      });
+      captureException(err, undefined, { field: 'desktopAccess', deviceId: device.id, orgId: device.orgId });
     });
   }
 

--- a/apps/web/src/components/devices/DeviceDetailPage.liveDesktopAccess.test.tsx
+++ b/apps/web/src/components/devices/DeviceDetailPage.liveDesktopAccess.test.tsx
@@ -1,0 +1,159 @@
+import '@/lib/i18n';
+
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import DeviceDetailPage from './DeviceDetailPage';
+import { fetchWithAuth } from '../../stores/auth';
+
+/**
+ * #5250 — Overview's `device.updated` handler only ever applied the
+ * `agentVersion` field; a `desktopAccess` change (the heartbeat now also
+ * publishes this event for that field — see heartbeat.ts) previously fell
+ * on the floor and Overview only "looked" live because navigating to it
+ * remounts and refetches. This proves the handler actually applies a
+ * `desktopAccess` event to the rendered device WITHOUT a remount/refetch.
+ */
+
+// Captures the page's own onEvent handler so a test can deliver a
+// synthetic device.updated event, mirroring the pattern in
+// DevicesPage.orgScope.test.tsx.
+type DeviceEvent = { type: string; payload: Record<string, unknown> };
+const eventStream = vi.hoisted(() => ({
+  onEvent: null as null | ((event: DeviceEvent) => void),
+}));
+vi.mock('../../hooks/useEventStream', () => ({
+  useEventStream: (opts: { onEvent: (event: DeviceEvent) => void }) => {
+    eventStream.onEvent = opts.onEvent;
+    return { subscribe: vi.fn() };
+  },
+}));
+
+function emitDeviceEvent(event: DeviceEvent): void {
+  if (!eventStream.onEvent) throw new Error('useEventStream never received an onEvent handler');
+  eventStream.onEvent(event);
+}
+
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+vi.mock('@/stores/aiStore', () => ({ useAiStore: () => vi.fn() }));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
+vi.mock('../extensions/ExtensionSlotHost', () => ({
+  useExtensionSlotDescriptors: () => [],
+  default: () => <div data-testid="extension-slot-host-stub" />,
+}));
+
+// DeviceDetails is the heavy presentational tree; stub it to a thin element
+// that surfaces the exact prop under test so the assertion is about the
+// page's state, not DeviceDetails' own rendering.
+vi.mock('./DeviceDetails', () => ({
+  default: ({ device }: { device: { desktopAccess?: { mode?: string } | null } }) => (
+    <div data-testid="desktop-access-mode">{device.desktopAccess?.mode ?? 'none'}</div>
+  ),
+}));
+
+const DEVICE_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+
+const jsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 404): Response =>
+  ({
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload),
+  }) as unknown as Response;
+
+beforeEach(() => {
+  eventStream.onEvent = null;
+  vi.mocked(fetchWithAuth).mockReset();
+  vi.mocked(fetchWithAuth).mockImplementation((url: string) => {
+    if (url === `/devices/${DEVICE_ID}`) {
+      return Promise.resolve(
+        jsonResponse({
+          id: DEVICE_ID,
+          hostname: 'mac-canary-01',
+          osType: 'macos',
+          status: 'online',
+          orgId: 'org-1',
+          siteId: 'site-1',
+          agentVersion: '0.109.0',
+          tags: [],
+          recentMetrics: [],
+          desktopAccess: { mode: 'unavailable', loginUiReachable: false, virtualDisplayReady: false, checkedAt: '2026-09-01T00:00:00.000Z' },
+        }),
+      );
+    }
+    return Promise.resolve(jsonResponse({}, false, 404));
+  });
+});
+
+describe('DeviceDetailPage — live desktopAccess via device.updated (#5250)', () => {
+  it('applies a desktopAccess event without a remount/refetch', async () => {
+    render(<DeviceDetailPage deviceId={DEVICE_ID} />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('desktop-access-mode')).toHaveTextContent(/^unavailable$/),
+    );
+
+    const fetchCallsBeforeEvent = vi.mocked(fetchWithAuth).mock.calls.length;
+
+    emitDeviceEvent({
+      type: 'device.updated',
+      payload: {
+        deviceId: DEVICE_ID,
+        fields: ['desktopAccess'],
+        desktopAccess: {
+          mode: 'user_session',
+          loginUiReachable: true,
+          virtualDisplayReady: true,
+          checkedAt: '2026-09-08T12:00:00.000Z',
+        },
+      },
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId('desktop-access-mode')).toHaveTextContent(/^user_session$/),
+    );
+
+    // No extra fetch was triggered — the event payload was applied directly.
+    expect(vi.mocked(fetchWithAuth).mock.calls.length).toBe(fetchCallsBeforeEvent);
+  });
+
+  it('ignores a device.updated event for a different device', async () => {
+    render(<DeviceDetailPage deviceId={DEVICE_ID} />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('desktop-access-mode')).toHaveTextContent(/^unavailable$/),
+    );
+
+    emitDeviceEvent({
+      type: 'device.updated',
+      payload: {
+        deviceId: 'some-other-device',
+        fields: ['desktopAccess'],
+        desktopAccess: { mode: 'user_session', loginUiReachable: true, virtualDisplayReady: true, checkedAt: '2026-09-08T12:00:00.000Z' },
+      },
+    });
+
+    // Still the original value — the event was for a different device.
+    expect(screen.getByTestId('desktop-access-mode')).toHaveTextContent(/^unavailable$/);
+  });
+
+  it('ignores a device.updated event whose fields do not include desktopAccess', async () => {
+    render(<DeviceDetailPage deviceId={DEVICE_ID} />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('desktop-access-mode')).toHaveTextContent(/^unavailable$/),
+    );
+
+    emitDeviceEvent({
+      type: 'device.updated',
+      payload: {
+        deviceId: DEVICE_ID,
+        fields: ['agentVersion'],
+        agentVersion: '0.110.0',
+      },
+    });
+
+    expect(screen.getByTestId('desktop-access-mode')).toHaveTextContent(/^unavailable$/);
+  });
+});

--- a/apps/web/src/components/devices/DeviceDetailPage.liveDesktopAccess.test.tsx
+++ b/apps/web/src/components/devices/DeviceDetailPage.liveDesktopAccess.test.tsx
@@ -1,6 +1,6 @@
 import '@/lib/i18n';
 
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import DeviceDetailPage from './DeviceDetailPage';
@@ -31,7 +31,9 @@ vi.mock('../../hooks/useEventStream', () => ({
 
 function emitDeviceEvent(event: DeviceEvent): void {
   if (!eventStream.onEvent) throw new Error('useEventStream never received an onEvent handler');
-  eventStream.onEvent(event);
+  act(() => {
+    eventStream.onEvent!(event);
+  });
 }
 
 vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
@@ -116,6 +118,58 @@ describe('DeviceDetailPage — live desktopAccess via device.updated (#5250)', (
 
     // No extra fetch was triggered — the event payload was applied directly.
     expect(vi.mocked(fetchWithAuth).mock.calls.length).toBe(fetchCallsBeforeEvent);
+  });
+
+  // #5250 review — the happy-path test above only proved recovery
+  // (unavailable → available); the handler is symmetric today but nothing
+  // pinned the degrading direction (a helper dropping mid-session, which
+  // matters just as much — it's a security-relevant "is remote access
+  // still live" signal).
+  it('applies a degrading (available → unavailable) desktopAccess event', async () => {
+    vi.mocked(fetchWithAuth).mockImplementation((url: string) => {
+      if (url === `/devices/${DEVICE_ID}`) {
+        return Promise.resolve(
+          jsonResponse({
+            id: DEVICE_ID,
+            hostname: 'mac-canary-01',
+            osType: 'macos',
+            status: 'online',
+            orgId: 'org-1',
+            siteId: 'site-1',
+            agentVersion: '0.109.0',
+            tags: [],
+            recentMetrics: [],
+            desktopAccess: { mode: 'user_session', loginUiReachable: true, virtualDisplayReady: true, checkedAt: '2026-09-01T00:00:00.000Z' },
+          }),
+        );
+      }
+      return Promise.resolve(jsonResponse({}, false, 404));
+    });
+
+    render(<DeviceDetailPage deviceId={DEVICE_ID} />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('desktop-access-mode')).toHaveTextContent(/^user_session$/),
+    );
+
+    emitDeviceEvent({
+      type: 'device.updated',
+      payload: {
+        deviceId: DEVICE_ID,
+        fields: ['desktopAccess'],
+        desktopAccess: {
+          mode: 'unavailable',
+          loginUiReachable: false,
+          virtualDisplayReady: false,
+          reason: 'helper_not_connected',
+          checkedAt: '2026-09-08T12:00:00.000Z',
+        },
+      },
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId('desktop-access-mode')).toHaveTextContent(/^unavailable$/),
+    );
   });
 
   it('ignores a device.updated event for a different device', async () => {

--- a/apps/web/src/components/devices/DeviceDetailPage.tsx
+++ b/apps/web/src/components/devices/DeviceDetailPage.tsx
@@ -231,6 +231,22 @@ export default function DeviceDetailPage({ deviceId }: DeviceDetailPageProps) {
               : prev,
           );
         }
+        // #5250 — the heartbeat now also publishes this event when
+        // desktopAccess changes (was previously only agentVersion), so
+        // Overview picks up a helper recovering/dropping live instead of
+        // only on the next full remount/refetch.
+        if (fields?.includes("desktopAccess")) {
+          setDevice((prev) =>
+            prev
+              ? {
+                  ...prev,
+                  desktopAccess:
+                    (payload.desktopAccess as Device["desktopAccess"]) ??
+                    prev.desktopAccess,
+                }
+              : prev,
+          );
+        }
       } else if (type === "device.decommissioned") {
         fetchDevice();
       }

--- a/apps/web/src/components/devices/DeviceDetailPage.tsx
+++ b/apps/web/src/components/devices/DeviceDetailPage.tsx
@@ -236,16 +236,15 @@ export default function DeviceDetailPage({ deviceId }: DeviceDetailPageProps) {
         // Overview picks up a helper recovering/dropping live instead of
         // only on the next full remount/refetch.
         if (fields?.includes("desktopAccess")) {
-          setDevice((prev) =>
-            prev
-              ? {
-                  ...prev,
-                  desktopAccess:
-                    (payload.desktopAccess as Device["desktopAccess"]) ??
-                    prev.desktopAccess,
-                }
-              : prev,
-          );
+          setDevice((prev) => {
+            if (!prev) return prev;
+            // `?? prev.desktopAccess` would treat an explicit `null` the
+            // same as "not present", silently discarding a legitimate
+            // cleared state — mirror RemoteToolsPage's `!== undefined`
+            // check instead so only a genuinely missing field falls back.
+            const next = payload.desktopAccess as Device["desktopAccess"] | undefined;
+            return next !== undefined ? { ...prev, desktopAccess: next } : prev;
+          });
         }
       } else if (type === "device.decommissioned") {
         fetchDevice();

--- a/apps/web/src/components/remote/RemoteToolsPage.liveDesktopAccess.test.tsx
+++ b/apps/web/src/components/remote/RemoteToolsPage.liveDesktopAccess.test.tsx
@@ -81,8 +81,11 @@ beforeEach(() => {
   });
 });
 
+const originalVisibilityState = document.visibilityState;
+
 afterEach(() => {
   cleanup();
+  Object.defineProperty(document, 'visibilityState', { value: originalVisibilityState, configurable: true });
 });
 
 const renderPage = () =>
@@ -172,6 +175,118 @@ describe('RemoteToolsPage live desktopAccess updates (#5250)', () => {
       document.dispatchEvent(new Event('visibilitychange'));
     });
 
+    await waitFor(() =>
+      expect(screen.getByTestId('connect-desktop-mode')).toHaveTextContent(/^user_session$/),
+    );
+  });
+
+  // #5250 review — the happy-path test above only proved recovery
+  // (unavailable → available); the helper DROPPING mid-session while the
+  // page stays open is at least as important (it is a security-relevant
+  // "is remote access still live" signal) and the handler code is
+  // symmetric today, but nothing pinned that until this test.
+  it('flips Connect Desktop from available to unavailable on a device.updated desktopAccess event (degrading transition)', async () => {
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url === `/devices/${DEVICE_ID}`) {
+        return makeResponse({
+          hostname: 'mac-canary-01',
+          osType: 'macos',
+          isHeadless: false,
+          desktopAccess: { mode: 'user_session', loginUiReachable: true, virtualDisplayReady: true, checkedAt: '2026-09-01T00:00:00.000Z' },
+        });
+      }
+      return makeResponse({}, false);
+    });
+
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByTestId('connect-desktop-mode')).toHaveTextContent(/^user_session$/),
+    );
+
+    emitDeviceEvent({
+      type: 'device.updated',
+      payload: {
+        deviceId: DEVICE_ID,
+        fields: ['desktopAccess'],
+        desktopAccess: {
+          mode: 'unavailable',
+          loginUiReachable: false,
+          virtualDisplayReady: false,
+          reason: 'helper_not_connected',
+          checkedAt: '2026-09-08T12:00:00.000Z',
+        },
+      },
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId('connect-desktop-mode')).toHaveTextContent(/^unavailable$/),
+    );
+  });
+
+  // #5250 review — nothing previously exercised the `fields` guard itself on
+  // this page (the "different device" test exercises a different
+  // early-return); a device.updated event whose fields name something else
+  // entirely (e.g. agentVersion) must not touch desktopAccess.
+  it('ignores a device.updated event whose fields do not include desktopAccess', async () => {
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByTestId('connect-desktop-mode')).toHaveTextContent(/^unavailable$/),
+    );
+
+    emitDeviceEvent({
+      type: 'device.updated',
+      payload: {
+        deviceId: DEVICE_ID,
+        fields: ['agentVersion'],
+        agentVersion: '0.110.0',
+      },
+    });
+
+    expect(screen.getByTestId('connect-desktop-mode')).toHaveTextContent(/^unavailable$/);
+  });
+
+  // #5250 review — the handler's fallback branch (fields names desktopAccess
+  // but the payload doesn't carry a value, e.g. an older API build) was
+  // entirely untested: it must refetch rather than silently do nothing.
+  it('refetches when a device.updated event names desktopAccess but the payload omits the value', async () => {
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByTestId('connect-desktop-mode')).toHaveTextContent(/^unavailable$/),
+    );
+
+    const fetchCallsBeforeEvent = fetchMock.mock.calls.filter(([url]) => url === `/devices/${DEVICE_ID}`).length;
+
+    // Helper recovers server-side; the event names the field but (as an
+    // older API build would) carries no value, so the page must fall back
+    // to a fetch rather than silently doing nothing.
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url === `/devices/${DEVICE_ID}`) {
+        return makeResponse({
+          hostname: 'mac-canary-01',
+          osType: 'macos',
+          isHeadless: false,
+          desktopAccess: { mode: 'user_session', loginUiReachable: true, virtualDisplayReady: true, checkedAt: '2026-09-08T12:00:00.000Z' },
+        });
+      }
+      return makeResponse({}, false);
+    });
+
+    emitDeviceEvent({
+      type: 'device.updated',
+      payload: {
+        deviceId: DEVICE_ID,
+        fields: ['desktopAccess'],
+        // No `desktopAccess` key at all.
+      },
+    });
+
+    await waitFor(() => {
+      const callsAfter = fetchMock.mock.calls.filter(([url]) => url === `/devices/${DEVICE_ID}`).length;
+      expect(callsAfter).toBeGreaterThan(fetchCallsBeforeEvent);
+    });
     await waitFor(() =>
       expect(screen.getByTestId('connect-desktop-mode')).toHaveTextContent(/^user_session$/),
     );

--- a/apps/web/src/components/remote/RemoteToolsPage.liveDesktopAccess.test.tsx
+++ b/apps/web/src/components/remote/RemoteToolsPage.liveDesktopAccess.test.tsx
@@ -1,0 +1,179 @@
+import { render, screen, waitFor, cleanup, act } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import RemoteToolsPage from './RemoteToolsPage';
+import { fetchWithAuth } from '@/stores/auth';
+
+/**
+ * #5250 — Remote Tools fetched device desktop-access state once on mount and
+ * never again: no interval, no visibility refetch, no event-stream
+ * subscription. A helper recovering (or dropping) while this page stayed
+ * open left Connect Desktop stuck gray/lit until the operator navigated
+ * away and back. This proves the fix's two live-update paths:
+ *   1. a `device.updated` event carrying `fields: ['desktopAccess']` flips
+ *      the button WITHOUT remounting the page or issuing another fetch.
+ *   2. the tab regaining visibility triggers a refetch.
+ */
+
+vi.mock('@/stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+// Captures the page's own onEvent handler so a test can deliver a synthetic
+// device.updated event, mirroring the pattern in DevicesPage.orgScope.test.tsx.
+type StreamEvent = { type: string; payload: Record<string, unknown> };
+const eventStream = vi.hoisted(() => ({
+  onEvent: null as null | ((event: StreamEvent) => void),
+  subscribed: [] as string[][],
+}));
+vi.mock('@/hooks/useEventStream', () => ({
+  useEventStream: (opts: { onEvent: (event: StreamEvent) => void }) => {
+    eventStream.onEvent = opts.onEvent;
+    return {
+      subscribe: (types: string[]) => {
+        eventStream.subscribed.push(types);
+      },
+    };
+  },
+}));
+
+function emitDeviceEvent(event: StreamEvent): void {
+  if (!eventStream.onEvent) throw new Error('useEventStream never received an onEvent handler');
+  act(() => {
+    eventStream.onEvent!(event);
+  });
+}
+
+// The real button drives desktop-session launch/deep-link flows unrelated to
+// this suite; stub it to surface the exact prop under test.
+vi.mock('./ConnectDesktopButton', () => ({
+  default: ({ desktopAccess }: { desktopAccess: { mode?: string } | null }) => (
+    <div data-testid="connect-desktop-mode">{desktopAccess?.mode ?? 'none'}</div>
+  ),
+}));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+
+const makeResponse = (payload: unknown = {}, ok = true): Response =>
+  ({
+    ok,
+    status: ok ? 200 : 404,
+    json: vi.fn().mockResolvedValue(payload),
+  } as unknown as Response);
+
+const DEVICE_ID = 'device-1';
+
+beforeEach(() => {
+  eventStream.onEvent = null;
+  eventStream.subscribed = [];
+  fetchMock.mockReset();
+  fetchMock.mockImplementation(async (url: string) => {
+    if (url === `/devices/${DEVICE_ID}`) {
+      return makeResponse({
+        hostname: 'mac-canary-01',
+        osType: 'macos',
+        isHeadless: false,
+        desktopAccess: { mode: 'unavailable', loginUiReachable: false, virtualDisplayReady: false, checkedAt: '2026-09-01T00:00:00.000Z' },
+      });
+    }
+    // Every other incidental panel fetch (processes, etc.) 404s quietly.
+    return makeResponse({}, false);
+  });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+const renderPage = () =>
+  render(<RemoteToolsPage deviceId={DEVICE_ID} deviceName="host-1" deviceOs="macos" />);
+
+describe('RemoteToolsPage live desktopAccess updates (#5250)', () => {
+  it('subscribes to device.updated on mount', async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(eventStream.subscribed.flat()).toContain('device.updated');
+    });
+  });
+
+  it('flips Connect Desktop from unavailable to available on a device.updated desktopAccess event, without a remount/refetch', async () => {
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByTestId('connect-desktop-mode')).toHaveTextContent(/^unavailable$/),
+    );
+
+    const fetchCallsBeforeEvent = fetchMock.mock.calls.length;
+
+    emitDeviceEvent({
+      type: 'device.updated',
+      payload: {
+        deviceId: DEVICE_ID,
+        fields: ['desktopAccess'],
+        desktopAccess: {
+          mode: 'user_session',
+          loginUiReachable: true,
+          virtualDisplayReady: true,
+          checkedAt: '2026-09-08T12:00:00.000Z',
+        },
+      },
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId('connect-desktop-mode')).toHaveTextContent(/^user_session$/),
+    );
+
+    // Applied directly from the event payload — no extra fetch round-trip.
+    expect(fetchMock.mock.calls.length).toBe(fetchCallsBeforeEvent);
+  });
+
+  it('ignores a device.updated event for a different device', async () => {
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByTestId('connect-desktop-mode')).toHaveTextContent(/^unavailable$/),
+    );
+
+    emitDeviceEvent({
+      type: 'device.updated',
+      payload: {
+        deviceId: 'some-other-device',
+        fields: ['desktopAccess'],
+        desktopAccess: { mode: 'user_session', loginUiReachable: true, virtualDisplayReady: true, checkedAt: '2026-09-08T12:00:00.000Z' },
+      },
+    });
+
+    expect(screen.getByTestId('connect-desktop-mode')).toHaveTextContent(/^unavailable$/);
+  });
+
+  it('refetches device info when the tab regains visibility', async () => {
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByTestId('connect-desktop-mode')).toHaveTextContent(/^unavailable$/),
+    );
+
+    // Helper recovers server-side; next refetch should pick it up.
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url === `/devices/${DEVICE_ID}`) {
+        return makeResponse({
+          hostname: 'mac-canary-01',
+          osType: 'macos',
+          isHeadless: false,
+          desktopAccess: { mode: 'user_session', loginUiReachable: true, virtualDisplayReady: true, checkedAt: '2026-09-08T12:00:00.000Z' },
+        });
+      }
+      return makeResponse({}, false);
+    });
+
+    act(() => {
+      Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true });
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId('connect-desktop-mode')).toHaveTextContent(/^user_session$/),
+    );
+  });
+});

--- a/apps/web/src/components/remote/RemoteToolsPage.tsx
+++ b/apps/web/src/components/remote/RemoteToolsPage.tsx
@@ -12,6 +12,7 @@ import {
   Loader2,
   ShieldOff
 } from 'lucide-react';
+import * as Sentry from '@sentry/astro';
 import { fetchWithAuth } from '@/stores/auth';
 import { extractApiError } from '@/lib/apiError';
 import { runAction } from '@/lib/runAction';
@@ -504,6 +505,15 @@ export default function RemoteToolsPage({
       const response = await fetchWithAuth(`/devices/${deviceId}`);
       if (!response.ok) {
         console.error(`[RemoteToolsPage] Failed to load device info: HTTP ${response.status}`);
+        // #5250 — this fetch is now a load-bearing live-update path (the
+        // desktopAccess event's "value not in payload" fallback, and the
+        // visibility-regain refetch below), not just a one-shot mount call.
+        // A silent failure here reproduces the exact staleness this fix
+        // closes, with nothing in telemetry to show it happened.
+        Sentry.captureMessage('RemoteToolsPage failed to refresh device info', {
+          level: 'warning',
+          extra: { deviceId, status: response.status },
+        });
         return;
       }
       const data: DeviceApiResponse = await response.json();
@@ -516,6 +526,7 @@ export default function RemoteToolsPage({
       setHelperLifecycleMode(data.helperLifecycleMode ?? null);
     } catch (error) {
       console.error('Failed to load device info:', error);
+      Sentry.captureException(error, { extra: { deviceId } });
     }
   }, [deviceId, deviceName]);
 

--- a/apps/web/src/components/remote/RemoteToolsPage.tsx
+++ b/apps/web/src/components/remote/RemoteToolsPage.tsx
@@ -17,6 +17,7 @@ import { extractApiError } from '@/lib/apiError';
 import { runAction } from '@/lib/runAction';
 import { navigateTo } from '@/lib/navigation';
 import { useHashTab } from '@/lib/useHashState';
+import { useEventStream } from '@/hooks/useEventStream';
 
 // Import actual components
 import ProcessManager, { type Process, type ProcessStatus } from './ProcessManager';
@@ -486,34 +487,89 @@ export default function RemoteToolsPage({
     setResolvedDeviceOs(normalizeDeviceOs(deviceOs));
   }, [deviceOs]);
 
+  // #5250 — pulled out of the mount-only effect below so it can also be
+  // invoked from the live-update paths (device.updated event, tab
+  // visibility regain) without duplicating the fetch/parse logic. A ref
+  // tracks mount state across every caller, not just the initial effect.
+  const mountedRef = useRef(true);
   useEffect(() => {
-    let mounted = true;
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
-    const fetchDevice = async () => {
-      try {
-        const response = await fetchWithAuth(`/devices/${deviceId}`);
-        if (!response.ok) {
-          console.error(`[RemoteToolsPage] Failed to load device info: HTTP ${response.status}`);
-          return;
-        }
-        const data: DeviceApiResponse = await response.json();
-        if (!mounted) return;
-        setResolvedDeviceName(data.displayName || data.hostname || deviceName);
-        setResolvedDeviceOs(normalizeDeviceOs(data.osType));
-        setIsHeadless(data.isHeadless === true);
-        setDesktopAccess(data.desktopAccess ?? null);
-        setRemoteAccessPolicy(data.remoteAccessPolicy ?? null);
-        setHelperLifecycleMode(data.helperLifecycleMode ?? null);
-      } catch (error) {
-        console.error('Failed to load device info:', error);
+  const fetchDevice = useCallback(async () => {
+    try {
+      const response = await fetchWithAuth(`/devices/${deviceId}`);
+      if (!response.ok) {
+        console.error(`[RemoteToolsPage] Failed to load device info: HTTP ${response.status}`);
+        return;
+      }
+      const data: DeviceApiResponse = await response.json();
+      if (!mountedRef.current) return;
+      setResolvedDeviceName(data.displayName || data.hostname || deviceName);
+      setResolvedDeviceOs(normalizeDeviceOs(data.osType));
+      setIsHeadless(data.isHeadless === true);
+      setDesktopAccess(data.desktopAccess ?? null);
+      setRemoteAccessPolicy(data.remoteAccessPolicy ?? null);
+      setHelperLifecycleMode(data.helperLifecycleMode ?? null);
+    } catch (error) {
+      console.error('Failed to load device info:', error);
+    }
+  }, [deviceId, deviceName]);
+
+  useEffect(() => {
+    fetchDevice();
+  }, [fetchDevice]);
+
+  // #5250 — Remote Tools previously only ever fetched device access state
+  // once on mount, so a helper recovering (or dropping) while this page
+  // stayed open left Connect Desktop stuck on its stale gray/lit state until
+  // the operator navigated away and back. Two live-update paths, same as the
+  // Overview page's device.updated subscription:
+  //  1. The heartbeat now publishes `device.updated` with
+  //     `fields: ['desktopAccess']` when the reported value changes
+  //     (apps/api/src/routes/agents/heartbeat.ts) — apply it directly rather
+  //     than round-tripping through another fetch.
+  //  2. A tab regaining visibility (operator switches back to this browser
+  //     tab/window) refetches once, covering the case where the socket was
+  //     disconnected while backgrounded.
+  const handleDeviceUpdatedEvent = useCallback(
+    (event: { type: string; payload: Record<string, unknown> }) => {
+      if (event.type !== 'device.updated') return;
+      if (event.payload.deviceId !== deviceId) return;
+      const fields = event.payload.fields as string[] | undefined;
+      if (!fields?.includes('desktopAccess')) return;
+      const nextDesktopAccess = event.payload.desktopAccess as DesktopAccessState | null | undefined;
+      if (nextDesktopAccess !== undefined) {
+        setDesktopAccess(nextDesktopAccess);
+      } else {
+        // Payload didn't carry the value (older API build) — fall back to a
+        // full refetch so we still pick up the change.
+        fetchDevice();
+      }
+    },
+    [deviceId, fetchDevice],
+  );
+
+  const { subscribe } = useEventStream({ onEvent: handleDeviceUpdatedEvent });
+
+  useEffect(() => {
+    subscribe(['device.updated']);
+  }, [subscribe]);
+
+  useEffect(() => {
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        fetchDevice();
       }
     };
-
-    fetchDevice();
+    document.addEventListener('visibilitychange', onVisibilityChange);
     return () => {
-      mounted = false;
+      document.removeEventListener('visibilitychange', onVisibilityChange);
     };
-  }, [deviceId, deviceName]);
+  }, [fetchDevice]);
 
   // Cleanup restart polling on unmount
   useEffect(() => {


### PR DESCRIPTION
## Summary

On self-host v0.110.0, Remote Tools' **Connect Desktop** button stayed gray/lit until the operator left the page (Close → Overview) and came back, even after the macOS helper recovered (or dropped) while the page was open.

**Root cause (verified — from the maintainer's own comment on the issue):**
- `RemoteToolsPage.tsx` fetched `/devices/:id` once on mount and stored `desktopAccess` as a static prop — no interval, no visibility refetch, no event-stream subscription. `ConnectDesktopButton` renders a disabled span when it reads `desktopAccess` as unavailable, so there was no path to notice a recovery short of a remount.
- Overview (`DeviceDetailPage.tsx`) *looked* live only because navigating there remounts and refetches. Its `device.updated` handler only ever applied the `agentVersion` field, and the heartbeat (`apps/api/src/routes/agents/heartbeat.ts`) only ever published `device.updated` when `agentVersion` changed — a `desktopAccess` change was audited but never pushed as a live event.

## Fix

- **`apps/api/src/routes/agents/heartbeat.ts`**: when the reported `desktopAccess` actually changes (diffed against the pre-update device row, same comparison the existing state-change audit uses), publish `device.updated` with `fields: ['desktopAccess']` and the new value — mirrors the existing `agentVersion` publish exactly.
- **`apps/web/src/components/remote/RemoteToolsPage.tsx`**: subscribes to `device.updated` via `useEventStream` and applies a `desktopAccess` event directly to state (no extra round-trip); also refetches device info on `visibilitychange` → visible as a backstop for a disconnected socket while backgrounded.
- **`apps/web/src/components/devices/DeviceDetailPage.tsx`**: its existing `device.updated` handler now also applies the `desktopAccess` field (was `agentVersion`-only), so Overview is genuinely live too, not just "live via remount."

No new user-facing strings were introduced, so no i18n changes are needed.

## Verified

- Wrote failing tests first, confirmed genuinely red against the pre-fix code (by stashing each source change and re-running), then confirmed green after restoring the fix:
  - `apps/api/src/routes/agents/heartbeat.test.ts` — 3 new cases (recovery publishes with `fields:['desktopAccess']`, steady-state re-report does not publish, no `desktopAccess` reported does not publish). Full file: 192/192 passing.
  - `apps/web/src/components/remote/RemoteToolsPage.liveDesktopAccess.test.tsx` (new file) — 4 cases: subscribes on mount, flips the button on event without an extra fetch, ignores events for other devices, refetches on visibility regain.
  - `apps/web/src/components/devices/DeviceDetailPage.liveDesktopAccess.test.tsx` (new file) — 3 cases: applies the event without a remount/refetch, ignores other devices, ignores events whose `fields` don't include `desktopAccess`.
- `apps/api`: `npx tsc --noEmit` clean (ran under `NODE_OPTIONS=--max-old-space-size=8192`; the host was memory-constrained during this run, unrelated to the change).
- `apps/web`: `npx tsc --noEmit` clean.
- Existing suites re-run and still green: `RemoteToolsPage.test.tsx` (15/15), 7 `DeviceDetailPage.*.test.tsx` files (19/19).

Closes #5250

🤖 Generated with [Claude Code](https://claude.com/claude-code)