### PR TITLE
fix(agent): honor the GetDIBits selection contract on the Winlogon GDI capture path (#5284)

### DIFF
--- a/agent/internal/remote/desktop/capture.go
+++ b/agent/internal/remote/desktop/capture.go
@@ -153,3 +153,44 @@ var ErrDisplayNotFound = fmt.Errorf("display not found")
 // ErrNoActiveSession is returned when CaptureScreenshot is called but no
 // WebRTC desktop session is currently active.
 var ErrNoActiveSession = fmt.Errorf("no active desktop session")
+
+// lastCaptureErrorReporter is implemented by capturers that deliberately report
+// a failed frame as (nil, nil) — "no frame yet" — instead of as an error, so a
+// transient outage does not tear down a live session. The Windows GDI fallback
+// does this for secure-desktop transitions (capture_windows_nocgo.go).
+//
+// Swallowing the error costs nothing while frames eventually arrive. It costs a
+// great deal when they never do: the startup probe gives up, and the only text
+// left is probeCapture's generic "produced no frame after N attempts", which
+// says a desktop could not be captured but not why. That is exactly how #5284
+// presented — a Winlogon console failing every single frame inside GetDIBits
+// reached the technician as "This remote session has ended", with the Win32
+// failure visible only in the endpoint's own helper log.
+type lastCaptureErrorReporter interface {
+	// LastCaptureError returns the most recent error the capturer reported as a
+	// nil frame, or nil if it has not swallowed one.
+	LastCaptureError() error
+}
+
+// describeCaptureFailure augments a probe failure with the last error the
+// capturer swallowed, when it kept one.
+//
+// The text this produces is not just for the log. The agent returns it over IPC
+// as the desktop-start failure, the API stores it in remote_sessions.errorMessage,
+// and the viewer renders it to the technician verbatim — so it is written to be
+// short and to name the failing Win32 call and its error code, and to carry no
+// handle values, which would mean nothing to the reader.
+func describeCaptureFailure(capturer ScreenCapturer, probeErr error) error {
+	if probeErr == nil {
+		return nil
+	}
+	reporter, ok := capturer.(lastCaptureErrorReporter)
+	if !ok {
+		return probeErr
+	}
+	last := reporter.LastCaptureError()
+	if last == nil {
+		return probeErr
+	}
+	return fmt.Errorf("%w (last capture error: %w)", probeErr, last)
+}

--- a/agent/internal/remote/desktop/capture_failure_detail_test.go
+++ b/agent/internal/remote/desktop/capture_failure_detail_test.go
@@ -1,0 +1,93 @@
+package desktop
+
+import (
+	"errors"
+	"fmt"
+	"image"
+	"strings"
+	"testing"
+)
+
+// No build tag — see capture_gdi.go. describeCaptureFailure is the agent-side
+// half of #5284: the GDI fallback swallows a failed frame as (nil, nil), so
+// unless the swallowed error is re-attached here the technician is shown only
+// probeCapture's generic "no frame after N attempts".
+
+type stubCapturer struct{}
+
+func (s *stubCapturer) Capture() (*image.RGBA, error) { return nil, nil }
+func (s *stubCapturer) CaptureRegion(x, y, w, h int) (*image.RGBA, error) {
+	return nil, nil
+}
+func (s *stubCapturer) GetScreenBounds() (int, int, error) { return 1920, 1080, nil }
+func (s *stubCapturer) Close() error                       { return nil }
+
+// reportingCapturer implements the optional lastCaptureErrorReporter.
+type reportingCapturer struct {
+	stubCapturer
+	lastErr error
+}
+
+func (r *reportingCapturer) LastCaptureError() error { return r.lastErr }
+
+func TestDescribeCaptureFailureAttachesSwallowedError(t *testing.T) {
+	gdiErr := gdiCallError("GetDIBits", errnoForTest(5))
+	probeErr := fmt.Errorf("screen capture produced no frame after 5 attempts")
+
+	got := describeCaptureFailure(&reportingCapturer{lastErr: gdiErr}, probeErr)
+
+	// The generic probe text must survive — callers and existing log greps
+	// match on it.
+	if !errors.Is(got, probeErr) {
+		t.Fatalf("probe error must stay wrapped, got %v", got)
+	}
+	// ...and the swallowed Win32 detail must now be present, which is the whole
+	// point: this string is what the viewer shows the technician.
+	if !strings.Contains(got.Error(), "GetDIBits failed") {
+		t.Errorf("swallowed capture error missing from %q", got)
+	}
+	if !strings.Contains(got.Error(), "5") {
+		t.Errorf("Win32 error code missing from %q", got)
+	}
+	if !errors.Is(got, gdiErr) {
+		t.Errorf("swallowed error must stay unwrappable, got %v", got)
+	}
+}
+
+// The technician-facing string must stay readable. Handle values (an HDC or
+// HBITMAP printed as a number) mean nothing to the reader and are what the
+// maintainer explicitly asked to keep out of the viewer message.
+func TestDescribeCaptureFailureStaysShortAndHandleFree(t *testing.T) {
+	got := describeCaptureFailure(
+		&reportingCapturer{lastErr: gdiCallError("GetDIBits", errnoForTest(5))},
+		fmt.Errorf("screen capture produced no frame after 5 attempts with forced desktop repaints (session may have no capturable desktop)"),
+	)
+	// The API caps remote_sessions.errorMessage at 1024 bytes; the agent's own
+	// wrapper adds ~60 more before it gets there.
+	if n := len(got.Error()); n > 400 {
+		t.Errorf("viewer-facing capture error is %d bytes, too long to read: %q", n, got)
+	}
+	for _, banned := range []string{"0x0000", "hdc", "HDC", "hBitmap", "memDC"} {
+		if strings.Contains(got.Error(), banned) {
+			t.Errorf("capture error leaks handle detail %q: %q", banned, got)
+		}
+	}
+}
+
+func TestDescribeCaptureFailurePassesThroughWhenNothingSwallowed(t *testing.T) {
+	probeErr := fmt.Errorf("screen capture produced no frame after 5 attempts")
+
+	// Capturer keeps no last error (e.g. DXGI, which returns real errors).
+	if got := describeCaptureFailure(&reportingCapturer{lastErr: nil}, probeErr); got.Error() != probeErr.Error() {
+		t.Errorf("with no swallowed error the probe error must pass through unchanged, got %q", got)
+	}
+	// Capturer does not implement the optional interface at all.
+	if got := describeCaptureFailure(&stubCapturer{}, probeErr); got.Error() != probeErr.Error() {
+		t.Errorf("non-reporting capturer must pass through unchanged, got %q", got)
+	}
+	// Nil probe error stays nil — a successful probe must never be turned into
+	// a failure just because a transient frame was swallowed on the way.
+	if got := describeCaptureFailure(&reportingCapturer{lastErr: fmt.Errorf("transient")}, nil); got != nil {
+		t.Errorf("nil probe error must stay nil, got %v", got)
+	}
+}

--- a/agent/internal/remote/desktop/capture_gdi.go
+++ b/agent/internal/remote/desktop/capture_gdi.go
@@ -184,6 +184,16 @@ type gdiFrameHandles struct {
 
 // captureGDIFrame performs exactly one GDI screen grab into dst (BGRA).
 func captureGDIFrame(ops gdiFrameOps, h gdiFrameHandles, bi *bitmapInfo, dst []byte) error {
+	// Bounds-check before handing the buffer to a syscall. GetDIBits writes
+	// width*height*4 bytes at &dst[0] with no idea how long the Go slice is, so
+	// a short buffer is heap corruption rather than an error — and an empty one
+	// panics on &dst[0]. The capturer keeps pixBuf and the BITMAPINFO in step,
+	// but this is the boundary where a mismatch would stop being recoverable.
+	if need := h.width * h.height * 4; h.width <= 0 || h.height <= 0 || len(dst) < need {
+		return fmt.Errorf("capture buffer is %d bytes, need %d for %dx%d",
+			len(dst), need, h.width, h.height)
+	}
+
 	// The errno of the CAPTUREBLT attempt is deliberately dropped: a driver
 	// that refuses CAPTUREBLT is an expected secure-desktop condition, and the
 	// errno that matters is the one from the plain-SRCCOPY retry below.

--- a/agent/internal/remote/desktop/capture_gdi.go
+++ b/agent/internal/remote/desktop/capture_gdi.go
@@ -1,0 +1,247 @@
+package desktop
+
+import (
+	"errors"
+	"fmt"
+	"syscall"
+	"unsafe"
+)
+
+// Windows GDI screen-capture support that does not itself call Win32.
+//
+// No build tag, on purpose — the same reason capture_errors.go carries none.
+// The GDI capturer is `//go:build windows && !cgo` (capture_windows_nocgo.go),
+// the Test Agent CI job runs on ubuntu-latest, and remote/desktop is one of the
+// packages explicitly EXCLUDED from the Test Agent (Windows) job's package list
+// (ci.yml, inherited red tracked in #2523). A test placed beside the capturer
+// would therefore execute on no platform at all and pass vacuously.
+//
+// Everything here is pure Go over plain structs and error values, so it
+// compiles and is exercised on the Linux runner, while capture_windows_nocgo.go
+// keeps only the syscalls themselves.
+
+// Win32 GDI constants used by the capture path.
+const (
+	srcCopy      = 0x00CC0020
+	captureBlt   = 0x40000000
+	biRGB        = 0
+	dibRGBColors = 0
+)
+
+// bitmapInfoHeaderSize is the BITMAPINFOHEADER size Win32 requires in BiSize.
+// GetDIBits and CreateDIBSection both reject a header whose BiSize does not
+// match a structure they recognise, so this is a hard ABI constant, not a
+// convenience: if bitmapInfoHeader ever gains, loses or reorders a field, the
+// Win32 call starts failing at runtime on Windows only. Asserted in
+// capture_gdi_test.go so the break surfaces on the Linux runner instead.
+const bitmapInfoHeaderSize = 40
+
+type bitmapInfoHeader struct {
+	BiSize          uint32
+	BiWidth         int32
+	BiHeight        int32
+	BiPlanes        uint16
+	BiBitCount      uint16
+	BiCompression   uint32
+	BiSizeImage     uint32
+	BiXPelsPerMeter int32
+	BiYPelsPerMeter int32
+	BiClrUsed       uint32
+	BiClrImportant  uint32
+}
+
+type bitmapInfo struct {
+	BmiHeader bitmapInfoHeader
+	BmiColors [1]uint32
+}
+
+// newCaptureBitmapInfo builds the BITMAPINFO the capture path hands to Win32.
+//
+// A NEGATIVE BiHeight is what requests a top-down DIB, so row 0 of the buffer
+// is the top row of the screen. With a positive height Win32 writes the rows
+// bottom-up and every captured frame arrives vertically mirrored.
+//
+// 32bpp BI_RGB means uncompressed BGRA, which is what bgraToRGBA expects, and
+// it means the colour table (BmiColors) is unused — for BI_RGB at 32bpp Win32
+// reads no palette entries, so leaving it zero is correct rather than merely
+// tolerated.
+func newCaptureBitmapInfo(width, height int) bitmapInfo {
+	return bitmapInfo{
+		BmiHeader: bitmapInfoHeader{
+			BiSize:        uint32(unsafe.Sizeof(bitmapInfoHeader{})),
+			BiWidth:       int32(width),
+			BiHeight:      -int32(height), // negative = top-down
+			BiPlanes:      1,
+			BiBitCount:    32,
+			BiCompression: biRGB,
+		},
+	}
+}
+
+// gdiCallError turns a failed GDI call into an error that carries the Win32
+// error code, and unwraps to the syscall.Errno so callers can match on it.
+//
+// Why this exists (#5284): every GDI call on the capture path used the
+// `ret, _, _ :=` form, discarding the errno. The Winlogon-desktop failure that
+// took remote desktop to 0 FPS at the logged-out console was therefore reported
+// to the technician as the bare string "GetDIBits failed" — no code, nothing to
+// look up, and no way to tell an access denial from an invalid parameter. This
+// path cannot be reproduced off a live secure desktop, so the error text IS the
+// diagnostic channel.
+//
+// The message reports what was OBSERVED and names no single cause, per the
+// convention capture_errors.go establishes.
+//
+// A zero errno is reported distinctly rather than as "error 0". Not every GDI
+// entry point sets extended error information on failure — BitBlt documents
+// that it does, GetDIBits does not guarantee it — so "the call failed and Win32
+// recorded no reason" is a real observation, distinct from "failed with code N",
+// and rendering it as code 0 would send the reader to look up ERROR_SUCCESS.
+//
+// The zero is trustworthy rather than stale: Go's Windows syscall trampoline
+// clears the thread's last-error before the native call and reads it back
+// afterwards, so an explicit SetLastError(0) here would be redundant.
+func gdiCallError(op string, errno error) error {
+	var e syscall.Errno
+	if errors.As(errno, &e) {
+		if e == 0 {
+			return fmt.Errorf("%s failed (Win32 recorded no error code)", op)
+		}
+		return fmt.Errorf("%s failed: Win32 error %d (0x%X): %w", op, uint32(e), uint32(e), e)
+	}
+	if errno == nil {
+		return fmt.Errorf("%s failed (Win32 recorded no error code)", op)
+	}
+	return fmt.Errorf("%s failed: %w", op, errno)
+}
+
+// shouldRebuildGDIHandles decides whether the cached GDI handles must be torn
+// down and recreated before the next frame.
+//
+// The thread check is the part that is easy to miss (#5284). GDI handles were
+// created lazily by whichever OS thread first drove a capture, and on a session
+// that starts on a secure desktop that thread is the STARTUP PROBE's thread:
+// StartSession calls newProbeRepainter, which does LockOSThread +
+// SetThreadDesktop, and then releases the pin the moment the probe returns
+// (session_webrtc.go, desktop_repaint_windows.go). The streaming loop then runs
+// on a DIFFERENT goroutine that pins and attaches ITS OWN thread
+// (prepareCaptureThread, called from captureLoop) — so every frame after the
+// probe used a display DC and bitmap created against a thread, and a desktop
+// attachment, that no longer exist. Rebuilding when the owning thread changes
+// keeps handle creation and handle use on the same attached thread.
+//
+// Passing 0 for both thread ids disables the thread check, which is what
+// non-Windows builds and tests that only care about the resolution rule do.
+func shouldRebuildGDIHandles(inited bool, haveWidth, haveHeight, wantWidth, wantHeight int, ownerThread, currentThread uint32) bool {
+	if !inited {
+		return true
+	}
+	if haveWidth != wantWidth || haveHeight != wantHeight {
+		return true
+	}
+	if ownerThread != 0 && currentThread != 0 && ownerThread != currentThread {
+		return true
+	}
+	return false
+}
+
+// errGDIHandlesUnusable marks a frame failure that left the cached GDI handle
+// set in an indeterminate state. The caller MUST release and recreate the
+// handles before the next frame rather than retrying with them.
+//
+// The case that matters is a failed RESELECT after the readback (below). The
+// capture bitmap is then no longer selected into the memory DC, so the next
+// frame's BitBlt would draw into the 1x1 monochrome bitmap every memory DC
+// starts life with — succeeding, and streaming a black frame forever. Failing
+// the frame loudly and rebuilding is the only safe response.
+var errGDIHandlesUnusable = errors.New("GDI handles are no longer usable")
+
+// gdiFrameOps is the set of Win32 calls one GDI frame makes. The Windows build
+// supplies a syscall-backed implementation (capture_windows_nocgo.go); tests
+// supply a fake.
+//
+// The indirection exists to make the GetDIBits selection contract assertable on
+// a Linux CI runner. It costs one interface dispatch per call against a
+// full-screen BitBlt and a 1920x1080x4 readback.
+type gdiFrameOps interface {
+	// SelectObject returns the previously selected object, or 0 on failure.
+	SelectObject(hdc, hgdiobj uintptr) (prev uintptr, errno error)
+	// BitBlt reports whether the blit succeeded.
+	BitBlt(dstDC uintptr, width, height int, srcDC uintptr, rop uint32) (ok bool, errno error)
+	// GetDIBits returns the number of scan lines copied, 0 on failure.
+	GetDIBits(hdc, hbm uintptr, lines int, bits *byte, bi *bitmapInfo) (copied int, errno error)
+}
+
+// gdiFrameHandles is the handle set one frame operates on.
+type gdiFrameHandles struct {
+	screenDC  uintptr
+	memDC     uintptr
+	hBitmap   uintptr
+	oldBitmap uintptr
+	width     int
+	height    int
+}
+
+// captureGDIFrame performs exactly one GDI screen grab into dst (BGRA).
+func captureGDIFrame(ops gdiFrameOps, h gdiFrameHandles, bi *bitmapInfo, dst []byte) error {
+	// The errno of the CAPTUREBLT attempt is deliberately dropped: a driver
+	// that refuses CAPTUREBLT is an expected secure-desktop condition, and the
+	// errno that matters is the one from the plain-SRCCOPY retry below.
+	ok, _ := ops.BitBlt(h.memDC, h.width, h.height, h.screenDC, srcCopy|captureBlt)
+	if !ok {
+		// Some secure-desktop transitions reject CAPTUREBLT. Retry with plain
+		// SRCCOPY before giving up.
+		var errno error
+		ok, errno = ops.BitBlt(h.memDC, h.width, h.height, h.screenDC, srcCopy)
+		if !ok {
+			return gdiCallError("BitBlt", errno)
+		}
+	}
+
+	// GetDIBits requires that the bitmap NOT be selected into a device context
+	// (MSDN, GetDIBits Remarks). The shipped code selected the capture bitmap
+	// into memDC once in ensureHandles and left it there for the capturer's
+	// whole lifetime, then handed BOTH that DC and that bitmap to GetDIBits —
+	// which is what failed every frame on the reporter's Winlogon console
+	// (#5284). The rule is categorical, so passing screenDC instead of memDC
+	// would not have been enough on its own: the bitmap has to come out of the
+	// memory DC first, and go back in before the next frame's BitBlt.
+	if prev, errno := ops.SelectObject(h.memDC, h.oldBitmap); prev == 0 {
+		return fmt.Errorf("%w: %w", errGDIHandlesUnusable,
+			gdiCallError("SelectObject (deselecting capture bitmap)", errno))
+	}
+
+	// screenDC, not memDC: the readback DC only supplies colour context here
+	// (with DIB_RGB_COLORS it resolves no palette at all), and the originating
+	// display DC is the documented choice.
+	copied, dibErrno := ops.GetDIBits(h.screenDC, h.hBitmap, h.height, &dst[0], bi)
+
+	// Reselect BEFORE acting on the readback result, so the handle set is left
+	// usable on the failure path too. dibErrno was captured above because this
+	// call overwrites the thread's last-error value.
+	if prev, errno := ops.SelectObject(h.memDC, h.hBitmap); prev == 0 {
+		return fmt.Errorf("%w: %w", errGDIHandlesUnusable,
+			gdiCallError("SelectObject (restoring capture bitmap)", errno))
+	}
+
+	if copied == 0 {
+		return gdiCallError("GetDIBits", dibErrno)
+	}
+	// GetDIBits returns the number of scan lines it copied. Anything short of
+	// the full height is a torn frame, not a frame.
+	if copied != h.height {
+		return fmt.Errorf("GetDIBits copied %d of %d scan lines", copied, h.height)
+	}
+	return nil
+}
+
+// win32ErrorCode extracts the numeric Win32 error from an error produced by
+// gdiCallError, so a log line can carry it as a structured field rather than
+// only inside a message string. Returns false when no code is present.
+func win32ErrorCode(err error) (uint32, bool) {
+	var e syscall.Errno
+	if errors.As(err, &e) && e != 0 {
+		return uint32(e), true
+	}
+	return 0, false
+}

--- a/agent/internal/remote/desktop/capture_gdi_sequence_test.go
+++ b/agent/internal/remote/desktop/capture_gdi_sequence_test.go
@@ -217,8 +217,14 @@ func TestCaptureGDIFrameReportsBitBltErrno(t *testing.T) {
 		t.Fatal("expected an error")
 	}
 	// #2160 saw this path and reported only "BitBlt failed".
-	if !strings.Contains(err.Error(), "BitBlt failed") || !strings.Contains(err.Error(), "6") {
-		t.Errorf("BitBlt failure must carry the Win32 code, got %q", err)
+	if !strings.Contains(err.Error(), "BitBlt failed") {
+		t.Errorf("BitBlt failure must name the call, got %q", err)
+	}
+	// Exact match, not strings.Contains: single-digit codes are substrings of
+	// the codes the fake injects elsewhere ("6" matches "6" in "0x6" but also
+	// any longer code), so a substring check can read green on the WRONG error.
+	if code, ok := win32ErrorCode(err); !ok || code != 6 {
+		t.Errorf("BitBlt failure must carry Win32 code 6, got %d (present=%v) in %q", code, ok, err)
 	}
 	if !errors.Is(err, syscall.Errno(6)) {
 		t.Errorf("errno must stay unwrappable, got %v", err)
@@ -239,8 +245,15 @@ func TestCaptureGDIFrameReportsGetDIBitsErrno(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error")
 	}
-	if !strings.Contains(err.Error(), "GetDIBits failed") || !strings.Contains(err.Error(), "8") {
-		t.Errorf("GetDIBits failure must carry the Win32 code, got %q", err)
+	if !strings.Contains(err.Error(), "GetDIBits failed") {
+		t.Errorf("GetDIBits failure must name the call, got %q", err)
+	}
+	// Exact match. `strings.Contains(err, "8")` is satisfied by "87" — the code
+	// the fake returns for the selection-contract violation — so the substring
+	// form read green whether the injected errno or the #5284 regression
+	// produced the failure, i.e. it did not discriminate at all.
+	if code, ok := win32ErrorCode(err); !ok || code != 8 {
+		t.Errorf("GetDIBits failure must carry Win32 code 8, got %d (present=%v) in %q", code, ok, err)
 	}
 	// The bitmap must still be put back even on the failure path, so a later
 	// retry with the same handles is not silently blitting into nowhere.

--- a/agent/internal/remote/desktop/capture_gdi_sequence_test.go
+++ b/agent/internal/remote/desktop/capture_gdi_sequence_test.go
@@ -1,0 +1,277 @@
+package desktop
+
+import (
+	"errors"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// No build tag — see capture_gdi.go. These assert the Win32 contract that
+// #5284 violated, on the Linux runner, because the real capturer is
+// `windows && !cgo` and remote/desktop is excluded from the Windows CI job.
+
+// fakeGDI models the parts of Win32 the frame sequence depends on, including
+// the rule the bug broke: GetDIBits requires that the bitmap NOT be selected
+// into a device context. MSDN, GetDIBits Remarks:
+//
+//	"The bitmap identified by the hbmp parameter must not be selected into a
+//	 device context when the application calls this function."
+//
+// The rule is categorical — it is not "not selected into the DC you pass".
+// So the fake tracks selection across ALL DCs and fails GetDIBits whenever the
+// target bitmap is selected anywhere, which is precisely how a driver is
+// entitled to behave and how the reporter's Intel UHD 630 apparently did.
+type fakeGDI struct {
+	// selected maps a DC to the bitmap currently selected into it.
+	selected map[uintptr]uintptr
+
+	calls []string
+
+	// injected failures
+	bitBltFailCaptureBlt bool // fail only the CAPTUREBLT attempt
+	bitBltFailAlways     bool
+	getDIBitsErrno       syscall.Errno
+	getDIBitsPartial     bool // copy fewer scan lines than asked
+	failSelectTo         uintptr
+	selectErrno          syscall.Errno
+
+	dibHDC uintptr // the DC actually handed to GetDIBits
+}
+
+func newFakeGDI(h gdiFrameHandles) *fakeGDI {
+	return &fakeGDI{
+		selected: map[uintptr]uintptr{h.memDC: h.hBitmap},
+	}
+}
+
+func (f *fakeGDI) SelectObject(hdc, hgdiobj uintptr) (uintptr, error) {
+	f.calls = append(f.calls, "SelectObject")
+	if f.failSelectTo != 0 && hgdiobj == f.failSelectTo {
+		return 0, f.selectErrno
+	}
+	prev := f.selected[hdc]
+	f.selected[hdc] = hgdiobj
+	if prev == 0 {
+		// A real memory DC always has something selected, so a non-zero
+		// previous object is what Win32 returns on success.
+		prev = 0xDEAD
+	}
+	return prev, syscall.Errno(0)
+}
+
+func (f *fakeGDI) BitBlt(dstDC uintptr, width, height int, srcDC uintptr, rop uint32) (bool, error) {
+	f.calls = append(f.calls, "BitBlt")
+	if f.bitBltFailAlways {
+		return false, syscall.Errno(6) // ERROR_INVALID_HANDLE
+	}
+	if f.bitBltFailCaptureBlt && rop&captureBlt != 0 {
+		return false, syscall.Errno(87) // ERROR_INVALID_PARAMETER
+	}
+	return true, syscall.Errno(0)
+}
+
+func (f *fakeGDI) GetDIBits(hdc, hbm uintptr, lines int, bits *byte, bi *bitmapInfo) (int, error) {
+	f.calls = append(f.calls, "GetDIBits")
+	f.dibHDC = hdc
+
+	// The contract. Any DC holding this bitmap makes the call illegal.
+	for dc, sel := range f.selected {
+		if sel == hbm {
+			_ = dc
+			return 0, syscall.Errno(87) // ERROR_INVALID_PARAMETER
+		}
+	}
+	if f.getDIBitsErrno != 0 {
+		return 0, f.getDIBitsErrno
+	}
+	if f.getDIBitsPartial {
+		return lines - 1, syscall.Errno(0)
+	}
+	return lines, syscall.Errno(0)
+}
+
+func testHandles() gdiFrameHandles {
+	return gdiFrameHandles{
+		screenDC:  0x100,
+		memDC:     0x200,
+		hBitmap:   0x300,
+		oldBitmap: 0x301,
+		width:     4,
+		height:    3,
+	}
+}
+
+// The regression test for #5284. Against the shipped sequence — which selects
+// the bitmap into memDC once and never deselects it — this fails, because the
+// bitmap is still selected when GetDIBits runs.
+func TestCaptureGDIFrameDeselectsBitmapBeforeReadback(t *testing.T) {
+	h := testHandles()
+	f := newFakeGDI(h)
+	bi := newCaptureBitmapInfo(h.width, h.height)
+	dst := make([]byte, h.width*h.height*4)
+
+	if err := captureGDIFrame(f, h, &bi, dst); err != nil {
+		t.Fatalf("capture failed: %v", err)
+	}
+
+	// The DC handed to GetDIBits must not be the one the bitmap lives in.
+	if f.dibHDC == h.memDC {
+		t.Errorf("GetDIBits was passed memDC (0x%X), the DC the capture bitmap is selected into", f.dibHDC)
+	}
+	if f.dibHDC != h.screenDC {
+		t.Errorf("GetDIBits hdc = 0x%X, want screenDC 0x%X", f.dibHDC, h.screenDC)
+	}
+	// And the bitmap must be back in the memory DC afterwards, or the next
+	// frame's BitBlt draws into the DC's default 1x1 monochrome bitmap.
+	if got := f.selected[h.memDC]; got != h.hBitmap {
+		t.Errorf("after the frame, memDC holds 0x%X, want the capture bitmap 0x%X", got, h.hBitmap)
+	}
+}
+
+// Ordering, stated independently of the assertions above: the deselect must
+// happen before the readback and the reselect after it.
+func TestCaptureGDIFrameCallOrder(t *testing.T) {
+	h := testHandles()
+	f := newFakeGDI(h)
+	bi := newCaptureBitmapInfo(h.width, h.height)
+
+	if err := captureGDIFrame(f, h, &bi, make([]byte, h.width*h.height*4)); err != nil {
+		t.Fatalf("capture failed: %v", err)
+	}
+
+	want := []string{"BitBlt", "SelectObject", "GetDIBits", "SelectObject"}
+	if strings.Join(f.calls, ",") != strings.Join(want, ",") {
+		t.Fatalf("call order = %v, want %v", f.calls, want)
+	}
+}
+
+// If the reselect fails, the frame must fail too — even though the pixels were
+// read successfully — and the caller must be told the handles are unusable.
+// Returning the good frame here would leave the memory DC pointing at its
+// default 1x1 bitmap and stream black frames for the rest of the session.
+func TestCaptureGDIFrameFailsWhenReselectFails(t *testing.T) {
+	h := testHandles()
+	f := newFakeGDI(h)
+	f.failSelectTo = h.hBitmap // the reselect, not the deselect
+	f.selectErrno = syscall.Errno(6)
+	bi := newCaptureBitmapInfo(h.width, h.height)
+
+	err := captureGDIFrame(f, h, &bi, make([]byte, h.width*h.height*4))
+	if err == nil {
+		t.Fatal("a failed reselect must fail the frame, got nil error")
+	}
+	if !errors.Is(err, errGDIHandlesUnusable) {
+		t.Errorf("error must mark the handles unusable so the caller rebuilds, got %v", err)
+	}
+	if !errors.Is(err, syscall.Errno(6)) {
+		t.Errorf("error must carry the Win32 code, got %v", err)
+	}
+}
+
+// A failed deselect must abort BEFORE GetDIBits — calling it anyway is the
+// exact contract violation being fixed.
+func TestCaptureGDIFrameSkipsReadbackWhenDeselectFails(t *testing.T) {
+	h := testHandles()
+	f := newFakeGDI(h)
+	f.failSelectTo = h.oldBitmap // the deselect
+	f.selectErrno = syscall.Errno(5)
+	bi := newCaptureBitmapInfo(h.width, h.height)
+
+	err := captureGDIFrame(f, h, &bi, make([]byte, h.width*h.height*4))
+	if err == nil {
+		t.Fatal("a failed deselect must fail the frame")
+	}
+	for _, c := range f.calls {
+		if c == "GetDIBits" {
+			t.Fatal("GetDIBits ran with the bitmap still selected — the #5284 contract violation")
+		}
+	}
+	if !errors.Is(err, errGDIHandlesUnusable) {
+		t.Errorf("error must mark the handles unusable, got %v", err)
+	}
+}
+
+func TestCaptureGDIFrameRetriesWithoutCaptureBlt(t *testing.T) {
+	h := testHandles()
+	f := newFakeGDI(h)
+	f.bitBltFailCaptureBlt = true
+	bi := newCaptureBitmapInfo(h.width, h.height)
+
+	if err := captureGDIFrame(f, h, &bi, make([]byte, h.width*h.height*4)); err != nil {
+		t.Fatalf("CAPTUREBLT rejection must fall back to plain SRCCOPY, got %v", err)
+	}
+	if n := countCalls(f.calls, "BitBlt"); n != 2 {
+		t.Errorf("expected 2 BitBlt attempts, got %d", n)
+	}
+}
+
+func TestCaptureGDIFrameReportsBitBltErrno(t *testing.T) {
+	h := testHandles()
+	f := newFakeGDI(h)
+	f.bitBltFailAlways = true
+	bi := newCaptureBitmapInfo(h.width, h.height)
+
+	err := captureGDIFrame(f, h, &bi, make([]byte, h.width*h.height*4))
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	// #2160 saw this path and reported only "BitBlt failed".
+	if !strings.Contains(err.Error(), "BitBlt failed") || !strings.Contains(err.Error(), "6") {
+		t.Errorf("BitBlt failure must carry the Win32 code, got %q", err)
+	}
+	if !errors.Is(err, syscall.Errno(6)) {
+		t.Errorf("errno must stay unwrappable, got %v", err)
+	}
+	// A plain blit failure does not by itself invalidate the handle set.
+	if errors.Is(err, errGDIHandlesUnusable) {
+		t.Errorf("BitBlt failure must not force a handle rebuild: %v", err)
+	}
+}
+
+func TestCaptureGDIFrameReportsGetDIBitsErrno(t *testing.T) {
+	h := testHandles()
+	f := newFakeGDI(h)
+	f.getDIBitsErrno = syscall.Errno(8) // ERROR_NOT_ENOUGH_MEMORY
+	bi := newCaptureBitmapInfo(h.width, h.height)
+
+	err := captureGDIFrame(f, h, &bi, make([]byte, h.width*h.height*4))
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), "GetDIBits failed") || !strings.Contains(err.Error(), "8") {
+		t.Errorf("GetDIBits failure must carry the Win32 code, got %q", err)
+	}
+	// The bitmap must still be put back even on the failure path, so a later
+	// retry with the same handles is not silently blitting into nowhere.
+	if got := f.selected[h.memDC]; got != h.hBitmap {
+		t.Errorf("capture bitmap not restored after a failed readback: memDC holds 0x%X", got)
+	}
+}
+
+// A short readback is a torn frame, not a good one. GetDIBits returns the
+// number of scan lines it copied; only the full height is a complete frame.
+func TestCaptureGDIFrameRejectsPartialReadback(t *testing.T) {
+	h := testHandles()
+	f := newFakeGDI(h)
+	f.getDIBitsPartial = true
+	bi := newCaptureBitmapInfo(h.width, h.height)
+
+	err := captureGDIFrame(f, h, &bi, make([]byte, h.width*h.height*4))
+	if err == nil {
+		t.Fatal("a partial scan-line copy must not be reported as a good frame")
+	}
+	if !strings.Contains(err.Error(), "scan lines") {
+		t.Errorf("error should say what was short, got %q", err)
+	}
+}
+
+func countCalls(calls []string, name string) int {
+	n := 0
+	for _, c := range calls {
+		if c == name {
+			n++
+		}
+	}
+	return n
+}

--- a/agent/internal/remote/desktop/capture_gdi_sequence_test.go
+++ b/agent/internal/remote/desktop/capture_gdi_sequence_test.go
@@ -275,3 +275,39 @@ func countCalls(calls []string, name string) int {
 	}
 	return n
 }
+
+// GetDIBits writes width*height*4 bytes at &dst[0] regardless of how long the
+// Go slice actually is, so a short buffer would be heap corruption and an empty
+// one panics. The guard must reject both before any Win32 call runs.
+func TestCaptureGDIFrameRejectsUndersizedBuffer(t *testing.T) {
+	h := testHandles()
+	bi := newCaptureBitmapInfo(h.width, h.height)
+	full := h.width * h.height * 4
+
+	for _, tc := range []struct {
+		name string
+		dst  []byte
+		h    gdiFrameHandles
+	}{
+		{"empty buffer", nil, h},
+		{"one byte short", make([]byte, full-1), h},
+		{"zero width", make([]byte, full), gdiFrameHandles{memDC: h.memDC, screenDC: h.screenDC, hBitmap: h.hBitmap, oldBitmap: h.oldBitmap, width: 0, height: h.height}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newFakeGDI(h)
+			err := captureGDIFrame(f, tc.h, &bi, tc.dst)
+			if err == nil {
+				t.Fatal("expected the frame to be rejected")
+			}
+			if len(f.calls) != 0 {
+				t.Errorf("no Win32 call may run with a bad buffer, got %v", f.calls)
+			}
+		})
+	}
+
+	// An oversized buffer is fine — pixBuf is reused across resolutions.
+	f := newFakeGDI(h)
+	if err := captureGDIFrame(f, h, &bi, make([]byte, full*2)); err != nil {
+		t.Errorf("an oversized buffer must be accepted, got %v", err)
+	}
+}

--- a/agent/internal/remote/desktop/capture_gdi_test.go
+++ b/agent/internal/remote/desktop/capture_gdi_test.go
@@ -1,0 +1,156 @@
+package desktop
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"unsafe"
+)
+
+// No build tag, on purpose — see the header of capture_gdi.go. The GDI capturer
+// is `windows && !cgo` and remote/desktop is excluded from the Test Agent
+// (Windows) job, so a windows-tagged test here would run on no platform.
+
+func TestCaptureBitmapInfoMatchesWin32ABI(t *testing.T) {
+	const (
+		width  = 1920
+		height = 1080
+	)
+	bi := newCaptureBitmapInfo(width, height)
+	h := bi.BmiHeader
+
+	if got := unsafe.Sizeof(bitmapInfoHeader{}); got != bitmapInfoHeaderSize {
+		t.Fatalf("bitmapInfoHeader is %d bytes, Win32 BITMAPINFOHEADER is %d — "+
+			"a field was added, removed, resized or reordered; GetDIBits and "+
+			"CreateDIBSection reject a header whose BiSize they do not recognise",
+			got, bitmapInfoHeaderSize)
+	}
+	if h.BiSize != bitmapInfoHeaderSize {
+		t.Errorf("BiSize = %d, want %d", h.BiSize, bitmapInfoHeaderSize)
+	}
+	if h.BiWidth != width {
+		t.Errorf("BiWidth = %d, want %d", h.BiWidth, width)
+	}
+	// The sign is the whole point: positive height means bottom-up rows and
+	// every captured frame reaches the viewer vertically mirrored.
+	if h.BiHeight != -height {
+		t.Errorf("BiHeight = %d, want %d (negative requests a top-down DIB)", h.BiHeight, -height)
+	}
+	if h.BiPlanes != 1 {
+		t.Errorf("BiPlanes = %d, want 1", h.BiPlanes)
+	}
+	if h.BiBitCount != 32 {
+		t.Errorf("BiBitCount = %d, want 32 (bgraToRGBA consumes 4 bytes per pixel)", h.BiBitCount)
+	}
+	if h.BiCompression != biRGB {
+		t.Errorf("BiCompression = %d, want BI_RGB (%d)", h.BiCompression, biRGB)
+	}
+}
+
+// A zero errno must not be reported as "Win32 error 0". Not every GDI entry
+// point calls SetLastError, so "failed, and Win32 recorded nothing" is a real
+// and distinct observation — reporting it as error code 0 sends the reader
+// looking up ERROR_SUCCESS.
+func TestGDICallErrorDistinguishesZeroErrno(t *testing.T) {
+	zero := gdiCallError("GetDIBits", syscall.Errno(0))
+	if !strings.Contains(zero.Error(), "GetDIBits failed") {
+		t.Errorf("zero-errno message lost the operation name: %q", zero)
+	}
+	if strings.Contains(zero.Error(), "error 0") || strings.Contains(zero.Error(), "0x0") {
+		t.Errorf("zero errno must not be rendered as an error code, got %q", zero)
+	}
+
+	nilErr := gdiCallError("BitBlt", nil)
+	if !strings.Contains(nilErr.Error(), "BitBlt failed") {
+		t.Errorf("nil-errno message lost the operation name: %q", nilErr)
+	}
+}
+
+// The whole point of #5284: the numeric Win32 code must survive into the error
+// text, because the failure is only reproducible on a live Winlogon console and
+// the error string is the only diagnostic channel back from the endpoint.
+func TestGDICallErrorCarriesWin32Code(t *testing.T) {
+	// 5 == ERROR_ACCESS_DENIED, 87 == ERROR_INVALID_PARAMETER on Windows. The
+	// assertions below are on the NUMBER, not on the platform's message text,
+	// so they hold on the Linux runner too.
+	for _, code := range []uint32{5, 87, 6} {
+		errno := syscall.Errno(code)
+		err := gdiCallError("GetDIBits", errno)
+
+		if !strings.Contains(err.Error(), "GetDIBits failed") {
+			t.Errorf("code %d: message lost the operation name: %q", code, err)
+		}
+		for _, want := range []string{
+			// decimal and hex both, so a log line is greppable either way
+			strconv.FormatUint(uint64(code), 10),
+			strings.ToUpper(strconv.FormatUint(uint64(code), 16)),
+		} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("code %d: message %q does not contain %q", code, err, want)
+			}
+		}
+		if !errors.Is(err, errno) {
+			t.Errorf("code %d: errors.Is must match the wrapped syscall.Errno, got %v", code, err)
+		}
+	}
+}
+
+func TestShouldRebuildGDIHandles(t *testing.T) {
+	tests := []struct {
+		name                       string
+		inited                     bool
+		haveW, haveH, wantW, wantH int
+		ownerThread, currentThread uint32
+		want                       bool
+	}{
+		{"not initialised", false, 0, 0, 1920, 1080, 0, 0, true},
+		{"same size, thread check disabled", true, 1920, 1080, 1920, 1080, 0, 0, false},
+		{"width changed", true, 1280, 1080, 1920, 1080, 7, 7, true},
+		{"height changed", true, 1920, 720, 1920, 1080, 7, 7, true},
+		{"same size, same thread", true, 1920, 1080, 1920, 1080, 7, 7, false},
+		// The #5284 case: handles were created on the startup probe's pinned
+		// thread, and the streaming loop runs on a different pinned thread.
+		{"same size, different thread", true, 1920, 1080, 1920, 1080, 7, 9, true},
+		// A thread id we could not read must not force a rebuild every frame.
+		{"owner thread unknown", true, 1920, 1080, 1920, 1080, 0, 9, false},
+		{"current thread unknown", true, 1920, 1080, 1920, 1080, 7, 0, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shouldRebuildGDIHandles(tc.inited, tc.haveW, tc.haveH, tc.wantW, tc.wantH, tc.ownerThread, tc.currentThread)
+			if got != tc.want {
+				t.Fatalf("shouldRebuildGDIHandles = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// errnoForTest builds a syscall.Errno so tests read the same on every platform.
+// The assertions that use it are on the numeric code and on unwrapping, never
+// on the host's message text for that number.
+func errnoForTest(code uint32) error { return syscall.Errno(code) }
+
+// win32ErrorCode is what puts the numeric code into the helper log as its own
+// structured field, so a reporter can grep it without parsing the message.
+func TestWin32ErrorCode(t *testing.T) {
+	if code, ok := win32ErrorCode(gdiCallError("GetDIBits", syscall.Errno(87))); !ok || code != 87 {
+		t.Errorf("win32ErrorCode = %d, %v; want 87, true", code, ok)
+	}
+	// Wrapped one level deeper, as describeCaptureFailure leaves it.
+	deep := describeCaptureFailure(
+		&reportingCapturer{lastErr: gdiCallError("GetDIBits", syscall.Errno(5))},
+		errors.New("no frame after 5 attempts"),
+	)
+	if code, ok := win32ErrorCode(deep); !ok || code != 5 {
+		t.Errorf("win32ErrorCode through a wrapped error = %d, %v; want 5, true", code, ok)
+	}
+	// A zero errno carries no code — reporting 0 would read as ERROR_SUCCESS.
+	if _, ok := win32ErrorCode(gdiCallError("GetDIBits", syscall.Errno(0))); ok {
+		t.Error("a zero errno must not be reported as a Win32 code")
+	}
+	if _, ok := win32ErrorCode(errors.New("plain error")); ok {
+		t.Error("a non-syscall error must not yield a Win32 code")
+	}
+}

--- a/agent/internal/remote/desktop/capture_windows_nocgo.go
+++ b/agent/internal/remote/desktop/capture_windows_nocgo.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"image"
 	"log/slog"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -109,6 +110,12 @@ type gdiCapturer struct {
 	consecutiveCaptureFailures int
 	lastFailureLog             time.Time
 
+	// Throttling for GDI handles Win32 refused to free. Separate from the
+	// capture-failure counters because a leak is a different problem with a
+	// different remedy, and it must not be hidden by the capture throttle.
+	teardownFailures int
+	lastTeardownLog  time.Time
+
 	// lastCaptureErr is the most recent error reported to the caller as a nil
 	// frame. Capture() deliberately swallows failures so a transient
 	// secure-desktop outage does not kill a live session; keeping the error
@@ -118,8 +125,16 @@ type gdiCapturer struct {
 }
 
 func init() {
-	if procSetProcessDPIAware.Find() == nil {
-		procSetProcessDPIAware.Call()
+	if procSetProcessDPIAware.Find() != nil {
+		return
+	}
+	// Not fatal, but not nothing either: without DPI awareness GetSystemMetrics
+	// reports scaled dimensions, which is the same class of capture/encoder size
+	// mismatch AlignEven exists to prevent (see ensureHandles). Worth a line in
+	// the helper log rather than nothing at all.
+	if ret, _, errno := procSetProcessDPIAware.Call(); ret == 0 {
+		slog.Debug("SetProcessDPIAware failed; capture dimensions may be DPI-scaled",
+			"error", gdiCallError("SetProcessDPIAware", errno).Error())
 	}
 }
 
@@ -219,33 +234,56 @@ func (c *gdiCapturer) ensureHandles() error {
 	return nil
 }
 
-// freeScreenDC releases a display DC through whichever entry point created it.
-func (c *gdiCapturer) freeScreenDC(hdc uintptr) {
+// freeScreenDC releases a display DC through whichever entry point created it,
+// and reports whether Win32 accepted the release.
+func (c *gdiCapturer) freeScreenDC(hdc uintptr) bool {
 	if hdc == 0 {
-		return
+		return true
 	}
+	var ret uintptr
 	if c.screenDCOwned {
-		procDeleteDC.Call(hdc) // CreateDC → DeleteDC
+		ret, _, _ = procDeleteDC.Call(hdc) // CreateDC → DeleteDC
 	} else {
-		procReleaseDC.Call(0, hdc) // GetDC → ReleaseDC
+		ret, _, _ = procReleaseDC.Call(0, hdc) // GetDC → ReleaseDC
 	}
+	return ret != 0
 }
 
 // releaseHandles frees all persistent GDI handles.
+//
+// Teardown results are checked rather than discarded. Handles are now rebuilt
+// on a thread change and after an unusable-handle frame, so a driver that
+// persistently rejects these calls would leak one DC and one bitmap PER FRAME
+// against the process-wide 10,000 GDI handle quota — and would do it invisibly,
+// because the capture failure itself is reported while the failed teardown
+// never was. Exhausting the quota breaks unrelated GDI calls elsewhere in the
+// agent, so the leak has to be visible before it gets there.
 func (c *gdiCapturer) releaseHandles() {
 	if !c.inited {
 		return
 	}
+	var failed []string
 	if c.oldBitmap != 0 && c.memDC != 0 {
-		procSelectObject.Call(c.memDC, c.oldBitmap)
+		if ret, _, _ := procSelectObject.Call(c.memDC, c.oldBitmap); ret == 0 {
+			failed = append(failed, "SelectObject(restore default bitmap)")
+		}
 	}
 	if c.hBitmap != 0 {
-		procDeleteObject.Call(c.hBitmap)
+		if ret, _, _ := procDeleteObject.Call(c.hBitmap); ret == 0 {
+			failed = append(failed, "DeleteObject(capture bitmap)")
+		}
 	}
 	if c.memDC != 0 {
-		procDeleteDC.Call(c.memDC)
+		if ret, _, _ := procDeleteDC.Call(c.memDC); ret == 0 {
+			failed = append(failed, "DeleteDC(memory DC)")
+		}
 	}
-	c.freeScreenDC(c.screenDC)
+	if !c.freeScreenDC(c.screenDC) {
+		failed = append(failed, "releasing the display DC")
+	}
+	if len(failed) > 0 {
+		c.recordTeardownFailureLocked(failed)
+	}
 	c.inited = false
 	c.screenDC = 0
 	c.screenDCOwned = false
@@ -298,6 +336,20 @@ func (c *gdiCapturer) recordCaptureFailureLocked(err error) {
 		}
 		slog.Warn("GDI capture unavailable (returning no frame)", attrs...)
 		c.lastFailureLog = now
+	}
+}
+
+// recordTeardownFailureLocked reports GDI handles that Win32 refused to free.
+// Throttled hard: the interesting signal is "this is happening at all" and then
+// the running total, not one line per frame.
+func (c *gdiCapturer) recordTeardownFailureLocked(failed []string) {
+	c.teardownFailures++
+	now := time.Now()
+	if c.teardownFailures == 1 || now.Sub(c.lastTeardownLog) >= 30*time.Second {
+		slog.Warn("GDI handle teardown failed; handles may be leaking",
+			"operations", strings.Join(failed, ", "),
+			"totalTeardownFailures", c.teardownFailures)
+		c.lastTeardownLog = now
 	}
 }
 

--- a/agent/internal/remote/desktop/capture_windows_nocgo.go
+++ b/agent/internal/remote/desktop/capture_windows_nocgo.go
@@ -3,6 +3,7 @@
 package desktop
 
 import (
+	"errors"
 	"fmt"
 	"image"
 	"log/slog"
@@ -32,35 +33,50 @@ var (
 )
 
 const (
-	smCxScreen   = 0
-	smCyScreen   = 1
-	srcCopy      = 0x00CC0020
-	captureBlt   = 0x40000000
-	biRGB        = 0
-	dibRGBColors = 0
+	smCxScreen = 0
+	smCyScreen = 1
 )
-
-type bitmapInfoHeader struct {
-	BiSize          uint32
-	BiWidth         int32
-	BiHeight        int32
-	BiPlanes        uint16
-	BiBitCount      uint16
-	BiCompression   uint32
-	BiSizeImage     uint32
-	BiXPelsPerMeter int32
-	BiYPelsPerMeter int32
-	BiClrUsed       uint32
-	BiClrImportant  uint32
-}
-
-type bitmapInfo struct {
-	BmiHeader bitmapInfoHeader
-	BmiColors [1]uint32
-}
 
 // displayDeviceName is L"DISPLAY" as a UTF-16 null-terminated string.
 var displayDeviceName = syscall.StringToUTF16Ptr("DISPLAY")
+
+// winGDIFrameOps is the real, syscall-backed gdiFrameOps. The frame sequence
+// itself lives in capture_gdi.go so it can be exercised on the Linux CI runner
+// — this type is only the thin Win32 binding. Every call keeps the errno from
+// LazyProc.Call and returns it; discarding it with `ret, _, _` is what left
+// #5284's Winlogon failure reported as the bare string "GetDIBits failed".
+type winGDIFrameOps struct{}
+
+func (winGDIFrameOps) SelectObject(hdc, hgdiobj uintptr) (uintptr, error) {
+	prev, _, errno := procSelectObject.Call(hdc, hgdiobj)
+	return prev, errno
+}
+
+func (winGDIFrameOps) BitBlt(dstDC uintptr, width, height int, srcDC uintptr, rop uint32) (bool, error) {
+	ret, _, errno := procBitBlt.Call(dstDC, 0, 0, uintptr(width), uintptr(height),
+		srcDC, 0, 0, uintptr(rop))
+	return ret != 0, errno
+}
+
+func (winGDIFrameOps) GetDIBits(hdc, hbm uintptr, lines int, bits *byte, bi *bitmapInfo) (int, error) {
+	copied, _, errno := procGetDIBits.Call(
+		hdc,
+		hbm,
+		0,
+		uintptr(lines),
+		uintptr(unsafe.Pointer(bits)),
+		uintptr(unsafe.Pointer(bi)),
+		dibRGBColors,
+	)
+	return int(copied), errno
+}
+
+// currentThreadID returns the calling OS thread's id, or 0 if it cannot be
+// read. See shouldRebuildGDIHandles for why the capturer tracks it.
+func currentThreadID() uint32 {
+	tid, _, _ := procGetCurrentThreadId.Call()
+	return uint32(tid)
+}
 
 // gdiCapturer implements ScreenCapturer using Windows GDI (no CGo required).
 // GDI handles are created once and reused across frames for performance.
@@ -79,12 +95,26 @@ type gdiCapturer struct {
 	height        int
 	inited        bool
 
+	// ownerThreadID is the OS thread that created the handles above. A display
+	// DC from CreateDC is documented to become invalid once its creating thread
+	// exits, and the GetDC fallback must be released on the same thread, so the
+	// handles are rebuilt when the capturing thread changes. See
+	// shouldRebuildGDIHandles.
+	ownerThreadID uint32
+
 	// Reusable pixel buffer (BGRA from GetDIBits)
 	pixBuf []byte
 
 	// Failure throttling for secure-desktop transient capture outages.
 	consecutiveCaptureFailures int
 	lastFailureLog             time.Time
+
+	// lastCaptureErr is the most recent error reported to the caller as a nil
+	// frame. Capture() deliberately swallows failures so a transient
+	// secure-desktop outage does not kill a live session; keeping the error
+	// here is what lets StartSession tell the technician WHY the startup probe
+	// found no frame (see describeCaptureFailure).
+	lastCaptureErr error
 }
 
 func init() {
@@ -108,27 +138,37 @@ func (c *gdiCapturer) ensureHandles() error {
 	// encode with "frame size 1434888 doesn't match 1512x948".
 	width, height := AlignEven(int(w), int(h))
 
-	// If handles exist and resolution hasn't changed, reuse them
-	if c.inited && c.width == width && c.height == height {
+	tid := currentThreadID()
+	if !shouldRebuildGDIHandles(c.inited, c.width, c.height, width, height, c.ownerThreadID, tid) {
 		return nil
 	}
+	if c.inited && c.width == width && c.height == height && c.ownerThreadID != tid {
+		// Worth a log line: this is the handover from the startup probe's
+		// thread to the streaming loop's thread, and it is the point at which
+		// a stale display DC would otherwise start being used (#5284).
+		slog.Info("Rebuilding GDI capture handles on the current capture thread",
+			"createdOnThread", c.ownerThreadID, "currentThread", tid)
+	}
 
-	// Release old handles if resolution changed
+	// Release old handles if resolution or owning thread changed
 	c.releaseHandles()
 
 	// Use CreateDC("DISPLAY") instead of GetDC(0). GetDC(0) returns a DC
 	// for the desktop window which fails on the Winlogon (secure) desktop.
 	// CreateDC("DISPLAY") creates a DC for the physical display directly,
 	// bypassing the window/desktop association, and works on all desktops.
-	hdc, _, _ := procCreateDCW.Call(
+	hdc, _, createDCErrno := procCreateDCW.Call(
 		uintptr(unsafe.Pointer(displayDeviceName)),
 		0, 0, 0,
 	)
 	if hdc == 0 {
 		// Fall back to GetDC(0) if CreateDC fails
-		hdc, _, _ = procGetDC.Call(0)
+		var getDCErrno error
+		hdc, _, getDCErrno = procGetDC.Call(0)
 		if hdc == 0 {
-			return fmt.Errorf("both CreateDC and GetDC failed")
+			return fmt.Errorf("no display DC available: %w; %w",
+				gdiCallError("CreateDC(DISPLAY)", createDCErrno),
+				gdiCallError("GetDC(0)", getDCErrno))
 		}
 		c.screenDCOwned = false
 	} else {
@@ -136,39 +176,31 @@ func (c *gdiCapturer) ensureHandles() error {
 	}
 
 	// Create compatible memory DC
-	memDC, _, _ := procCreateCompatibleDC.Call(hdc)
+	memDC, _, memDCErrno := procCreateCompatibleDC.Call(hdc)
 	if memDC == 0 {
-		if c.screenDCOwned {
-			procDeleteDC.Call(hdc)
-		} else {
-			procReleaseDC.Call(0, hdc)
-		}
-		return fmt.Errorf("CreateCompatibleDC failed")
+		err := gdiCallError("CreateCompatibleDC", memDCErrno)
+		c.freeScreenDC(hdc)
+		return err
 	}
 
 	// Create compatible bitmap
-	hBitmap, _, _ := procCreateCompatibleBitmap.Call(hdc, uintptr(width), uintptr(height))
+	hBitmap, _, bitmapErrno := procCreateCompatibleBitmap.Call(hdc, uintptr(width), uintptr(height))
 	if hBitmap == 0 {
+		err := gdiCallError("CreateCompatibleBitmap", bitmapErrno)
 		procDeleteDC.Call(memDC)
-		if c.screenDCOwned {
-			procDeleteDC.Call(hdc)
-		} else {
-			procReleaseDC.Call(0, hdc)
-		}
-		return fmt.Errorf("CreateCompatibleBitmap failed")
+		c.freeScreenDC(hdc)
+		return err
 	}
 
-	// Select bitmap into memory DC
-	oldBitmap, _, _ := procSelectObject.Call(memDC, hBitmap)
+	// Select bitmap into memory DC. It is deselected again around every
+	// readback — see captureGDIFrame — because GetDIBits requires it.
+	oldBitmap, _, selectErrno := procSelectObject.Call(memDC, hBitmap)
 	if oldBitmap == 0 {
+		err := gdiCallError("SelectObject", selectErrno)
 		procDeleteObject.Call(hBitmap)
 		procDeleteDC.Call(memDC)
-		if c.screenDCOwned {
-			procDeleteDC.Call(hdc)
-		} else {
-			procReleaseDC.Call(0, hdc)
-		}
-		return fmt.Errorf("SelectObject failed")
+		c.freeScreenDC(hdc)
+		return err
 	}
 
 	c.screenDC = hdc
@@ -177,22 +209,26 @@ func (c *gdiCapturer) ensureHandles() error {
 	c.oldBitmap = oldBitmap
 	c.width = width
 	c.height = height
+	c.ownerThreadID = tid
 	c.inited = true
 
 	// Pre-allocate pixel buffer and BITMAPINFO
 	c.pixBuf = make([]byte, width*height*4)
-	c.bi = bitmapInfo{
-		BmiHeader: bitmapInfoHeader{
-			BiSize:        uint32(unsafe.Sizeof(bitmapInfoHeader{})),
-			BiWidth:       int32(width),
-			BiHeight:      -int32(height), // negative = top-down
-			BiPlanes:      1,
-			BiBitCount:    32,
-			BiCompression: biRGB,
-		},
-	}
+	c.bi = newCaptureBitmapInfo(width, height)
 
 	return nil
+}
+
+// freeScreenDC releases a display DC through whichever entry point created it.
+func (c *gdiCapturer) freeScreenDC(hdc uintptr) {
+	if hdc == 0 {
+		return
+	}
+	if c.screenDCOwned {
+		procDeleteDC.Call(hdc) // CreateDC → DeleteDC
+	} else {
+		procReleaseDC.Call(0, hdc) // GetDC → ReleaseDC
+	}
 }
 
 // releaseHandles frees all persistent GDI handles.
@@ -209,46 +245,34 @@ func (c *gdiCapturer) releaseHandles() {
 	if c.memDC != 0 {
 		procDeleteDC.Call(c.memDC)
 	}
-	if c.screenDC != 0 {
-		if c.screenDCOwned {
-			procDeleteDC.Call(c.screenDC) // CreateDC → DeleteDC
-		} else {
-			procReleaseDC.Call(0, c.screenDC) // GetDC → ReleaseDC
-		}
-	}
+	c.freeScreenDC(c.screenDC)
 	c.inited = false
 	c.screenDC = 0
 	c.screenDCOwned = false
 	c.memDC = 0
 	c.hBitmap = 0
 	c.oldBitmap = 0
+	c.ownerThreadID = 0
 }
 
 func (c *gdiCapturer) captureOnceLocked() (*image.RGBA, error) {
-	// BitBlt the screen into our reusable bitmap
-	ret, _, _ := procBitBlt.Call(c.memDC, 0, 0, uintptr(c.width), uintptr(c.height),
-		c.screenDC, 0, 0, srcCopy|captureBlt)
-	if ret == 0 {
-		// Some secure-desktop transitions reject CAPTUREBLT. Retry with plain SRCCOPY.
-		ret, _, _ = procBitBlt.Call(c.memDC, 0, 0, uintptr(c.width), uintptr(c.height),
-			c.screenDC, 0, 0, srcCopy)
-		if ret == 0 {
-			return nil, fmt.Errorf("BitBlt failed")
+	err := captureGDIFrame(winGDIFrameOps{}, gdiFrameHandles{
+		screenDC:  c.screenDC,
+		memDC:     c.memDC,
+		hBitmap:   c.hBitmap,
+		oldBitmap: c.oldBitmap,
+		width:     c.width,
+		height:    c.height,
+	}, &c.bi, c.pixBuf)
+	if err != nil {
+		// A selection failure leaves the memory DC holding something other
+		// than the capture bitmap; reusing it would blit into the DC's default
+		// 1x1 monochrome bitmap and stream black. Drop the handles so the
+		// retry in Capture rebuilds them.
+		if errors.Is(err, errGDIHandlesUnusable) {
+			c.releaseHandles()
 		}
-	}
-
-	// GetDIBits into reusable pixel buffer
-	ret, _, _ = procGetDIBits.Call(
-		c.memDC,
-		c.hBitmap,
-		0,
-		uintptr(c.height),
-		uintptr(unsafe.Pointer(&c.pixBuf[0])),
-		uintptr(unsafe.Pointer(&c.bi)),
-		dibRGBColors,
-	)
-	if ret == 0 {
-		return nil, fmt.Errorf("GetDIBits failed")
+		return nil, err
 	}
 
 	// Convert BGRA to RGBA into a pooled image
@@ -260,17 +284,33 @@ func (c *gdiCapturer) captureOnceLocked() (*image.RGBA, error) {
 
 func (c *gdiCapturer) recordCaptureFailureLocked(err error) {
 	c.consecutiveCaptureFailures++
+	c.lastCaptureErr = err
 	now := time.Now()
 	if c.consecutiveCaptureFailures == 1 || now.Sub(c.lastFailureLog) >= 2*time.Second {
-		slog.Warn("GDI capture unavailable (returning no frame)",
+		attrs := []any{
 			"error", err.Error(),
-			"consecutive", c.consecutiveCaptureFailures)
+			"consecutive", c.consecutiveCaptureFailures,
+		}
+		// Surface the Win32 code as its own field so it is greppable in a
+		// helper log without parsing the message.
+		if code, ok := win32ErrorCode(err); ok {
+			attrs = append(attrs, "win32Error", code)
+		}
+		slog.Warn("GDI capture unavailable (returning no frame)", attrs...)
 		c.lastFailureLog = now
 	}
 }
 
 func (c *gdiCapturer) resetCaptureFailuresLocked() {
 	c.consecutiveCaptureFailures = 0
+	c.lastCaptureErr = nil
+}
+
+// LastCaptureError implements lastCaptureErrorReporter.
+func (c *gdiCapturer) LastCaptureError() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.lastCaptureErr
 }
 
 // Capture captures the entire screen using persistent GDI handles.
@@ -298,7 +338,9 @@ func (c *gdiCapturer) Capture() (*image.RGBA, error) {
 
 	// Secure-desktop transitions can invalidate DCs transiently. Treat this as
 	// "no frame yet" so the session loop skips without flooding error logs.
-	// The startup probe (probeCapture) retries then fails on persistent nil frames.
+	// The startup probe (probeCapture) retries then fails on persistent nil
+	// frames — and reads lastCaptureErr back out via LastCaptureError so the
+	// technician is told which Win32 call failed and with what code.
 	if lastErr != nil {
 		c.recordCaptureFailureLocked(lastErr)
 	}
@@ -351,3 +393,4 @@ func (c *gdiCapturer) Close() error {
 }
 
 var _ ScreenCapturer = (*gdiCapturer)(nil)
+var _ lastCaptureErrorReporter = (*gdiCapturer)(nil)

--- a/agent/internal/remote/desktop/dxgi_capture_windows.go
+++ b/agent/internal/remote/desktop/dxgi_capture_windows.go
@@ -57,10 +57,21 @@ func (c *dxgiCapturer) captureFromGDIFallbackLocked() (*image.RGBA, error) {
 	if c.gdiNoFrameCount >= 15 && now.Sub(c.lastGDIRepair) >= 500*time.Millisecond {
 		c.lastGDIRepair = now
 		_ = c.switchToInputDesktop()
+		// Carry the swallowed capture error onto the replacement. Recreating the
+		// fallback otherwise resets it to nil, and LastCaptureError is the only
+		// channel by which a GDI failure reaches the technician (#5284) — a
+		// repair that discards the diagnosis hands StartSession an error-less
+		// capturer and puts the generic "no frame after N attempts" message
+		// back. Today the startup probe gives up long before this threshold, so
+		// this is guarding the invariant rather than a live bug; keeping it here
+		// means the two thresholds can be tuned independently without silently
+		// re-breaking the diagnostic.
+		var carried error
 		if c.gdiFallback != nil {
+			carried = c.gdiFallback.LastCaptureError()
 			_ = c.gdiFallback.Close()
 		}
-		c.gdiFallback = &gdiCapturer{config: c.config}
+		c.gdiFallback = &gdiCapturer{config: c.config, lastCaptureErr: carried}
 		slog.Info("Recreated GDI fallback after repeated no-frame samples",
 			"count", c.gdiNoFrameCount)
 	}

--- a/agent/internal/remote/desktop/dxgi_capture_windows.go
+++ b/agent/internal/remote/desktop/dxgi_capture_windows.go
@@ -68,6 +68,24 @@ func (c *dxgiCapturer) captureFromGDIFallbackLocked() (*image.RGBA, error) {
 	return nil, nil
 }
 
+// LastCaptureError implements lastCaptureErrorReporter by delegating to the
+// GDI fallback, which is the only capturer here that reports a failed frame as
+// (nil, nil). DXGI itself returns real errors, so there is nothing to recover
+// on that path.
+//
+// This is what carries a secure-desktop capture failure out to the technician:
+// StartSession calls describeCaptureFailure with session.capturer, which is
+// this object, not the fallback (#5284).
+func (c *dxgiCapturer) LastCaptureError() error {
+	c.mu.Lock()
+	fallback := c.gdiFallback
+	c.mu.Unlock()
+	if fallback == nil {
+		return nil
+	}
+	return fallback.LastCaptureError()
+}
+
 // Capture acquires the next desktop frame via DXGI.
 // Returns nil, nil when no new frame is available (AccumulatedFrames==0).
 func (c *dxgiCapturer) Capture() (*image.RGBA, error) {
@@ -574,3 +592,5 @@ func (c *dxgiCapturer) GetD3D11Context() uintptr {
 	defer c.mu.Unlock()
 	return c.context
 }
+
+var _ lastCaptureErrorReporter = (*dxgiCapturer)(nil)

--- a/agent/internal/remote/desktop/session_webrtc.go
+++ b/agent/internal/remote/desktop/session_webrtc.go
@@ -278,7 +278,18 @@ func (m *SessionManager) StartSession(sessionID string, offer string, iceServers
 		// desktop, GDI handle churn). Abort instead of returning a WebRTC
 		// answer that will stream zero frames. The defer at line 80 calls
 		// StopSession which closes the capturer.
-		return "", fmt.Errorf("screen capture failed (display may be unavailable): %w", probeErr)
+		//
+		// describeCaptureFailure appends the last error the capturer swallowed
+		// as a nil frame, which is the only place a GDI-fallback failure is
+		// recorded. Without it the technician sees probeCapture's generic "no
+		// frame after N attempts" and nothing else: #5284 spent an entire
+		// investigation on a Winlogon console whose actual failure — a Win32
+		// error inside GetDIBits, every single frame — reached the dashboard as
+		// "This remote session has ended" and was legible only in the endpoint's
+		// own helper log. This error string is what the API stores in
+		// remote_sessions.errorMessage and the viewer shows verbatim.
+		return "", fmt.Errorf("screen capture failed (display may be unavailable): %w",
+			describeCaptureFailure(capturer, probeErr))
 	}
 	pw, ph := probeImg.Rect.Dx(), probeImg.Rect.Dy()
 	if pw != w || ph != h {

--- a/agent/internal/remote/desktop/session_webrtc.go
+++ b/agent/internal/remote/desktop/session_webrtc.go
@@ -276,8 +276,8 @@ func (m *SessionManager) StartSession(sessionID string, offer string, iceServers
 	if probeErr != nil {
 		// The display is inaccessible (disconnected Windows session, no input
 		// desktop, GDI handle churn). Abort instead of returning a WebRTC
-		// answer that will stream zero frames. The defer at line 80 calls
-		// StopSession which closes the capturer.
+		// answer that will stream zero frames. StartSession's own deferred
+		// cleanup calls StopSession, which closes the capturer.
 		//
 		// describeCaptureFailure appends the last error the capturer swallowed
 		// as a nil frame, which is the only place a GDI-fallback failure is


### PR DESCRIPTION
Closes #5284

Windows remote desktop failed at 0 FPS on a logged-out console. The helper detected the Winlogon desktop, switched to the GDI fallback, and failed **every** frame inside `GetDIBits`, so the startup probe aborted after five attempts and the technician saw only *"This remote session has ended."*

The reporter's diagnosis was precise enough to check line by line, and it holds.

## Root cause (verified in code)

`ensureHandles` selected the capture bitmap into the memory DC **once** and left it selected for the capturer's lifetime; `captureOnceLocked` then handed **both that DC and that bitmap** to `GetDIBits`. [MSDN is categorical](https://learn.microsoft.com/en-us/windows/win32/api/wingdi/nf-wingdi-getdibits#remarks): *"The bitmap identified by the hbmp parameter must not be selected into a device context when the application calls this function."* The rule is not "not the DC you pass" — it is any DC — so swapping the `hdc` argument alone would not have been enough.

The GDI fallback is only reachable on secure desktops (Winlogon/UAC), which is why this survived: the path may never have produced a frame in production. #2160 is the same path failing one call earlier, at `BitBlt`.

## What changed

**1. The selection contract (the fix).** Deselect the bitmap, read back against the originating display DC, reselect before the next frame's `BitBlt`.

A failed **reselect** now fails the frame *even when the pixels were read successfully*, and drops the handle set. This is deliberate: a memory DC that has lost its bitmap silently blits into the 1×1 monochrome bitmap every memory DC starts life with, which succeeds and streams black forever. Failing one frame and rebuilding is the only safe response.

**2. `GetDIBits` must copy every scan line.** It returns the number of lines copied; the old check only rejected `0`. A short copy is a torn frame, not a frame.

**3. The errno is no longer discarded.** Every GDI call used `ret, _, _`, which is why the reporter's log said exactly `GetDIBits failed` and nothing else — no code, nothing to look up. Failures now name the call and its Win32 code, and the code is also emitted as a `win32Error` slog field so it is greppable without parsing the message. (`SetLastError(0)` is deliberately *not* added: Go's Windows syscall trampoline already clears last-error before the native call, so a zero errno genuinely means "Win32 recorded no reason" — which is reported as such rather than as `error 0`.)

**4. Handles are rebuilt when the capturing OS thread changes.** *This is the second defect the maintainer suspected; it is real.* Handles were created lazily by whichever thread first captured. On a session that starts on Winlogon that is the **startup probe's** thread (`newProbeRepainter` → `LockOSThread` + `SetThreadDesktop`, released the moment the probe returns). The streaming loop then runs on a **different** goroutine that pins and attaches its own thread (`prepareCaptureThread`). So every frame after the probe used a display DC created against a thread and a desktop attachment that no longer applied — and a `CreateDC` display DC is [documented](https://learn.microsoft.com/en-us/windows/win32/api/wingdi/nf-wingdi-createdcw) to become invalid once its creating thread exits, while the `GetDC` fallback must be released on the same thread. This would bite *after* the probe passes, so it does not explain the reported failure, but it is latent on the same path and is fixed here.

**5. The capture error reaches the viewer.** `Capture()` reports a failed frame as `(nil, nil)` so a transient secure-desktop outage cannot kill a live session — but that meant the real error was **dropped**, and the probe could only report its generic "no frame after N attempts". The error is now retained and re-attached by `StartSession`. The rest of the plumbing already worked: agent → IPC → `remote_sessions.errorMessage` → `AgentSessionError` → displayed verbatim. No API or viewer change was needed.

## Design choice: deselect/reselect, not `CreateDIBSection`

Both repair the contract. `CreateDIBSection` is cleaner in steady state and removes a full-frame copy, but it adds GDI-owned pointer lifetime and a `GdiFlush` ordering obligation **on a path that cannot be tested here**. For a blind fix validated by the reporter on the next release, the option that adds no new failure modes wins. Second opinion sought and agreed. `CreateDIBSection` remains reasonable later.

## Tests

The capturer is `//go:build windows && !cgo`, and `remote/desktop` is one of the packages **excluded** from the Test Agent (Windows) job (inherited red, #2523). A windows-tagged test here would run on **no platform at all** — the same vacuous-gate trap `capture_errors.go` documents. So the frame sequence moved to a platform-neutral file behind a small injectable shim, and the contract is asserted on the Linux runner.

The fake models the actual Win32 rule: it tracks bitmap selection across **all** DCs and fails `GetDIBits` whenever the target bitmap is selected anywhere. Against the shipped code it fails with `GetDIBits failed: Win32 error 87` — the reported symptom.

Coverage: deselect-before-readback and reselect-after; call ordering; `screenDC` not `memDC`; failed reselect invalidates handles; failed deselect skips the readback entirely; CAPTUREBLT → SRCCOPY retry; errno propagation from `BitBlt` and `GetDIBits`; partial scan-line rejection; `BITMAPINFO` ABI (40-byte header, negative height, 32bpp BI_RGB); thread-change rebuild; and the swallowed-error propagation, asserted to stay short and free of handle values.

**Verified** (all run locally):
- `GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build ./...` — clean
- `GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go vet ./internal/remote/desktop/...` — 30 findings before and after, all pre-existing `unsafe.Pointer` notices in other files, **0 in the changed files**, no compile errors
- `CGO_ENABLED=0 go vet ./...` — clean
- `go test ./internal/remote/desktop/` and `go test -race ./internal/remote/desktop/` — pass
- Full agent suite `CGO_ENABLED=0 go test ./...` — 73 packages ok. Two `internal/monitoring` timing tests flaked under parallel load on this host; they pass when that package is run alone both with and without this change (not touched by it).
- `golangci-lint run --new-from-rev=origin/main` — 0 issues
- Both contract guards mutation-checked: reverting the deselect turns them red, restoring turns them green.

**Not verified:** no Windows host was available, so this is **untested against a live Winlogon console.** The fix corrects a documented API contract violation on the exact path the logs implicate, but the maintainer's caveat stands — it is the leading candidate, not a proven complete explanation. Driver-specific behaviour is not ruled out. If it does not resolve it, the error text now carries the Win32 code, which the original report could not.

Validation asked for on the next release: the logged-out console, sign-in/sign-out transitions, and the Ctrl+Alt+Del / UAC desktop.

## Release note

Fixed Windows remote desktop failing with a blank session at the sign-in screen: the secure-desktop (Winlogon/UAC) capture path violated a Win32 API contract and failed every frame. Capture failures now report the underlying Windows error code to the technician instead of a generic "session has ended".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGT9BJVfpG3nyM6c9koAN8
