### PR TITLE
fix(agent): start the service `service install` stopped, and let the watchdog recover a stranded agent (#5252)

### DIFF
--- a/agent/cmd/breeze-watchdog/main.go
+++ b/agent/cmd/breeze-watchdog/main.go
@@ -503,6 +503,13 @@ func runWatchdog(stopCh <-chan struct{}) {
 	standbyWindow := watchdog.StandbyWindow("", 0, wdCfg.StandbyGrace, wdCfg.StandbyTimeout)
 	standbyReason := ""
 	standbyRecognized := true
+	// A hold is deliberately not journaled per tick (the process ticker runs
+	// every few seconds), but a long hold must not look like a dead watchdog
+	// in the diagnostics bundle: an unrecognized reason can legitimately hold
+	// out to the 30-minute ceiling, and the journal is what
+	// collect_diagnostics ships. One heartbeat every few minutes is the
+	// difference between "waiting on purpose" and "process died".
+	var lastStandbyHoldLog time.Time
 
 	// agentLooksHealthy requires live IPC AND a fresh heartbeat — the same
 	// evidence the FAILOVER self-recovery block uses. IsConnected() alone is
@@ -520,6 +527,24 @@ func runWatchdog(stopCh <-chan struct{}) {
 	// applyStandby evaluates the standby policy once and acts on it. It is
 	// the ONLY place STANDBY leaves its state, so the per-tick check and the
 	// unhealthy-signal funnel below cannot drift apart (#5252).
+	// fireStandbyEvent applies a standby decision and refuses to let a
+	// rejected transition pass silently. HandleEvent logs nothing of its own
+	// on a rejected event, and this whole function exists to guarantee STANDBY
+	// never drifts without a trace.
+	fireStandbyEvent := func(event string, fields map[string]any) bool {
+		if _, ok := wd.HandleEvent(event); ok {
+			return true
+		}
+		rejected := make(map[string]any, len(fields)+2)
+		for k, v := range fields {
+			rejected[k] = v
+		}
+		rejected["event"] = event
+		rejected["state"] = wd.State()
+		journal.Log(watchdog.LevelError, "standby.transition_rejected", rejected)
+		return false
+	}
+
 	applyStandby := func() {
 		elapsed := time.Since(wd.LastTransitionTime())
 		decision := watchdog.EvaluateStandby(watchdog.StandbyInput{
@@ -537,18 +562,22 @@ func runWatchdog(stopCh <-chan struct{}) {
 		}
 		switch decision {
 		case watchdog.StandbyHold:
+			if time.Since(lastStandbyHoldLog) >= standbyHoldLogInterval {
+				lastStandbyHoldLog = time.Now()
+				journal.Log(watchdog.LevelInfo, "standby.holding", fields)
+			}
 			return
 		case watchdog.StandbyResume:
 			// The announced shutdown never completed — the agent is still
 			// there and healthy. Restarting it would be gratuitous.
 			journal.Log(watchdog.LevelInfo, "standby.agent_still_healthy", fields)
-			wd.HandleEvent(watchdog.EventAgentRecovered)
+			fireStandbyEvent(watchdog.EventAgentRecovered, fields)
 		case watchdog.StandbyRecover:
 			// The window closed with the agent gone. Hand off to the normal
 			// recovery ladder, which owns the restart budget, flap detection
 			// and its own ensure-start before FAILOVER.
 			journal.Log(watchdog.LevelWarn, "standby.window_expired", fields)
-			wd.HandleEvent(watchdog.EventAgentUnhealthy)
+			fireStandbyEvent(watchdog.EventAgentUnhealthy, fields)
 		case watchdog.StandbyFailover:
 			journal.Log(watchdog.LevelWarn, "standby.timeout", fields)
 			// Transition FIRST and only ensure-start on an ACCEPTED
@@ -556,9 +585,17 @@ func runWatchdog(stopCh <-chan struct{}) {
 			// ahead of a transition that did not happen would repeat it on
 			// every tick. Entering FAILOVER with the agent stopped is what
 			// stranded the host in #5252.
-			if _, ok := wd.HandleEvent(watchdog.EventStandbyTimeout); ok {
+			if fireStandbyEvent(watchdog.EventStandbyTimeout, fields) {
 				ensureAgentStartedBeforeFailover(runCtx, recovery, journal)
 			}
+		default:
+			// Go has no exhaustiveness check on this switch, so a decision
+			// added later would otherwise fall through as a no-op — i.e. the
+			// watchdog holds in STANDBY forever, which IS the #5252 failure.
+			// Escalate instead: starting an agent that did not need it is
+			// recoverable, leaving a remote host offline is not.
+			journal.Log(watchdog.LevelError, "standby.unknown_decision", fields)
+			fireStandbyEvent(watchdog.EventAgentUnhealthy, fields)
 		}
 	}
 
@@ -673,10 +710,15 @@ func runWatchdog(stopCh <-chan struct{}) {
 				standbyRecognized = watchdog.RecognizedShutdownReason(intent.Reason)
 				standbyWindow = watchdog.StandbyWindow(
 					intent.Reason, intent.ExpectedDuration, wdCfg.StandbyGrace, wdCfg.StandbyTimeout)
+				lastStandbyHoldLog = time.Now()
 				journal.Log(watchdog.LevelInfo, "standby.window", map[string]any{
-					"reason":         standbyReason,
-					"recognized":     standbyRecognized,
-					"window_seconds": int(standbyWindow.Seconds()),
+					"reason":     standbyReason,
+					"recognized": standbyRecognized,
+					// Both, so a declared duration that was clamped (or was
+					// corrupt) is visible in the shipped journal rather than
+					// showing up as a plausible-looking window with no trace.
+					"declared_seconds": intent.ExpectedDuration,
+					"window_seconds":   int(standbyWindow.Seconds()),
 				})
 			}
 
@@ -863,9 +905,11 @@ func runWatchdog(stopCh <-chan struct{}) {
 }
 
 // handleIPCMessage dispatches IPC envelope messages from the agent. It returns
-// the shutdown intent it handled, if any, so the caller can size the standby
-// window from the reason and declared duration the agent sent (#5252); nil for
-// every other message type and for an intent that failed to parse.
+// the shutdown intent that actually moved the watchdog into STANDBY, so the
+// caller can size the standby window from the reason and declared duration the
+// agent sent (#5252). It returns nil for every other message type, for an
+// intent that failed to parse, and for an intent that did not cause a
+// transition.
 func handleIPCMessage(env *ipc.Envelope, wd *watchdog.Watchdog, journal *watchdog.Journal, cfg *config.Config, tokens *tokenHolder, health *watchdog.HealthChecker) *ipc.ShutdownIntent {
 	switch env.Type {
 	case ipc.TypeShutdownIntent:
@@ -880,8 +924,14 @@ func handleIPCMessage(env *ipc.Envelope, wd *watchdog.Watchdog, journal *watchdo
 			"reason":   intent.Reason,
 			"duration": intent.ExpectedDuration,
 		})
-		wd.HandleEvent(watchdog.EventShutdownIntent)
-		return &intent
+		// Report the intent ONLY when it actually moved us into STANDBY.
+		// shutdown_intent is a valid edge from MONITORING alone, so an intent
+		// that arrives while RECOVERING or in FAILOVER changes nothing — and
+		// must not resize a standby window that this intent did not open.
+		if _, ok := wd.HandleEvent(watchdog.EventShutdownIntent); ok {
+			return &intent
+		}
+		return nil
 
 	case ipc.TypeTokenUpdate:
 		var update ipc.TokenUpdate

--- a/agent/cmd/breeze-watchdog/main.go
+++ b/agent/cmd/breeze-watchdog/main.go
@@ -338,6 +338,7 @@ func runWatchdog(stopCh <-chan struct{}) {
 		MaxRecoveryAttempts:     cfg.Watchdog.MaxRecoveryAttempts,
 		RecoveryCooldown:        cfg.Watchdog.RecoveryCooldown,
 		StandbyTimeout:          cfg.Watchdog.StandbyTimeout,
+		StandbyGrace:            cfg.Watchdog.StandbyGrace,
 		FailoverPollInterval:    cfg.Watchdog.FailoverPollInterval,
 	}
 
@@ -495,6 +496,84 @@ func runWatchdog(stopCh <-chan struct{}) {
 	var failoverFailures int
 	var lastDiskServerURL string
 
+	// --- STANDBY policy (#5252) ---------------------------------------
+	// Details of the shutdown the agent last announced. Only meaningful
+	// while the state is STANDBY; refreshed on every shutdown intent. The
+	// defaults describe an intent that arrived with no reason at all.
+	standbyWindow := watchdog.StandbyWindow("", 0, wdCfg.StandbyGrace, wdCfg.StandbyTimeout)
+	standbyReason := ""
+	standbyRecognized := true
+
+	// agentLooksHealthy requires live IPC AND a fresh heartbeat — the same
+	// evidence the FAILOVER self-recovery block uses. IsConnected() alone is
+	// only a socket flag and can still describe the connection of an agent
+	// that is on its way out, so on its own it would cancel the very standby
+	// the agent just asked for.
+	agentLooksHealthy := func() bool {
+		if !ipcClient.IsConnected() {
+			return false
+		}
+		hb := healthChecker.LastKnownHeartbeat(agentState)
+		return !hb.IsZero() && time.Since(hb) <= wdCfg.HeartbeatStaleThreshold
+	}
+
+	// applyStandby evaluates the standby policy once and acts on it. It is
+	// the ONLY place STANDBY leaves its state, so the per-tick check and the
+	// unhealthy-signal funnel below cannot drift apart (#5252).
+	applyStandby := func() {
+		elapsed := time.Since(wd.LastTransitionTime())
+		decision := watchdog.EvaluateStandby(watchdog.StandbyInput{
+			Elapsed:      elapsed,
+			Window:       standbyWindow,
+			Ceiling:      wdCfg.StandbyTimeout,
+			Recognized:   standbyRecognized,
+			AgentHealthy: agentLooksHealthy(),
+		})
+		fields := map[string]any{
+			"reason":          standbyReason,
+			"elapsed_seconds": int(elapsed.Seconds()),
+			"window_seconds":  int(standbyWindow.Seconds()),
+			"decision":        decision.String(),
+		}
+		switch decision {
+		case watchdog.StandbyHold:
+			return
+		case watchdog.StandbyResume:
+			// The announced shutdown never completed — the agent is still
+			// there and healthy. Restarting it would be gratuitous.
+			journal.Log(watchdog.LevelInfo, "standby.agent_still_healthy", fields)
+			wd.HandleEvent(watchdog.EventAgentRecovered)
+		case watchdog.StandbyRecover:
+			// The window closed with the agent gone. Hand off to the normal
+			// recovery ladder, which owns the restart budget, flap detection
+			// and its own ensure-start before FAILOVER.
+			journal.Log(watchdog.LevelWarn, "standby.window_expired", fields)
+			wd.HandleEvent(watchdog.EventAgentUnhealthy)
+		case watchdog.StandbyFailover:
+			journal.Log(watchdog.LevelWarn, "standby.timeout", fields)
+			// Transition FIRST and only ensure-start on an ACCEPTED
+			// transition: the ensure-start is budget-free, so running it
+			// ahead of a transition that did not happen would repeat it on
+			// every tick. Entering FAILOVER with the agent stopped is what
+			// stranded the host in #5252.
+			if _, ok := wd.HandleEvent(watchdog.EventStandbyTimeout); ok {
+				ensureAgentStartedBeforeFailover(runCtx, recovery, journal)
+			}
+		}
+	}
+
+	// noteAgentUnhealthy funnels EVERY "the agent looks dead" signal through
+	// one place. In STANDBY such a signal is EXPECTED — the agent announced
+	// it was going away — so the standby policy decides what happens rather
+	// than the raw transition table restarting an agent mid-shutdown.
+	noteAgentUnhealthy := func() {
+		if wd.State() == watchdog.StateStandby {
+			applyStandby()
+			return
+		}
+		wd.HandleEvent(watchdog.EventAgentUnhealthy)
+	}
+
 	for {
 		select {
 		case <-runCtx.Done():
@@ -524,7 +603,7 @@ func runWatchdog(stopCh <-chan struct{}) {
 				result := healthChecker.CheckProcess(pid)
 				if result == watchdog.CheckProcessGone {
 					journal.Log(watchdog.LevelWarn, "check.process_gone", map[string]any{"pid": pid})
-					wd.HandleEvent(watchdog.EventAgentUnhealthy)
+					noteAgentUnhealthy()
 				}
 			}
 
@@ -536,7 +615,7 @@ func runWatchdog(stopCh <-chan struct{}) {
 					journal.Log(watchdog.LevelError, "check.ipc_failed", map[string]any{
 						"consecutive_failures": healthChecker.IPCFailCount(),
 					})
-					wd.HandleEvent(watchdog.EventAgentUnhealthy)
+					noteAgentUnhealthy()
 				case watchdog.CheckIPCDegraded:
 					journal.Log(watchdog.LevelWarn, "check.ipc_degraded", map[string]any{
 						"consecutive_failures": healthChecker.IPCFailCount(),
@@ -581,7 +660,7 @@ func runWatchdog(stopCh <-chan struct{}) {
 					"ipc_connected": ipcUp,
 					"vetoes_before": vetoes,
 				})
-				wd.HandleEvent(watchdog.EventAgentUnhealthy)
+				noteAgentUnhealthy()
 			case watchdog.StaleVetoed:
 				journal.Log(watchdog.LevelWarn, "check.heartbeat_stale_ipc_alive", map[string]any{
 					"consecutive_vetoes": vetoes,
@@ -589,7 +668,17 @@ func runWatchdog(stopCh <-chan struct{}) {
 			}
 
 		case env := <-ipcMessages:
-			handleIPCMessage(env, wd, journal, cfg, tokenStore, healthChecker)
+			if intent := handleIPCMessage(env, wd, journal, cfg, tokenStore, healthChecker); intent != nil {
+				standbyReason = intent.Reason
+				standbyRecognized = watchdog.RecognizedShutdownReason(intent.Reason)
+				standbyWindow = watchdog.StandbyWindow(
+					intent.Reason, intent.ExpectedDuration, wdCfg.StandbyGrace, wdCfg.StandbyTimeout)
+				journal.Log(watchdog.LevelInfo, "standby.window", map[string]any{
+					"reason":         standbyReason,
+					"recognized":     standbyRecognized,
+					"window_seconds": int(standbyWindow.Seconds()),
+				})
+			}
 
 		case <-failoverTicker.C:
 			// Only poll in FAILOVER state.
@@ -756,11 +845,7 @@ func runWatchdog(stopCh <-chan struct{}) {
 			}
 
 		case watchdog.StateStandby:
-			// Check standby timeout.
-			if time.Since(wd.LastTransitionTime()) > wdCfg.StandbyTimeout {
-				journal.Log(watchdog.LevelWarn, "standby.timeout", nil)
-				wd.HandleEvent(watchdog.EventStandbyTimeout)
-			}
+			applyStandby()
 
 		case watchdog.StateMonitoring:
 			// Reset per-window recovery counter when healthy. Note: restart history
@@ -777,8 +862,11 @@ func runWatchdog(stopCh <-chan struct{}) {
 	}
 }
 
-// handleIPCMessage dispatches IPC envelope messages from the agent.
-func handleIPCMessage(env *ipc.Envelope, wd *watchdog.Watchdog, journal *watchdog.Journal, cfg *config.Config, tokens *tokenHolder, health *watchdog.HealthChecker) {
+// handleIPCMessage dispatches IPC envelope messages from the agent. It returns
+// the shutdown intent it handled, if any, so the caller can size the standby
+// window from the reason and declared duration the agent sent (#5252); nil for
+// every other message type and for an intent that failed to parse.
+func handleIPCMessage(env *ipc.Envelope, wd *watchdog.Watchdog, journal *watchdog.Journal, cfg *config.Config, tokens *tokenHolder, health *watchdog.HealthChecker) *ipc.ShutdownIntent {
 	switch env.Type {
 	case ipc.TypeShutdownIntent:
 		var intent ipc.ShutdownIntent
@@ -786,13 +874,14 @@ func handleIPCMessage(env *ipc.Envelope, wd *watchdog.Watchdog, journal *watchdo
 			journal.Log(watchdog.LevelError, "ipc.bad_shutdown_intent", map[string]any{
 				"error": err.Error(),
 			})
-			return
+			return nil
 		}
 		journal.Log(watchdog.LevelInfo, "agent.shutdown_intent", map[string]any{
 			"reason":   intent.Reason,
 			"duration": intent.ExpectedDuration,
 		})
 		wd.HandleEvent(watchdog.EventShutdownIntent)
+		return &intent
 
 	case ipc.TypeTokenUpdate:
 		var update ipc.TokenUpdate
@@ -800,7 +889,7 @@ func handleIPCMessage(env *ipc.Envelope, wd *watchdog.Watchdog, journal *watchdo
 			journal.Log(watchdog.LevelError, "ipc.bad_token_update", map[string]any{
 				"error": err.Error(),
 			})
-			return
+			return nil
 		}
 		journal.Log(watchdog.LevelInfo, "token.updated", nil)
 		tokens.Replace(update.Token)
@@ -818,7 +907,7 @@ func handleIPCMessage(env *ipc.Envelope, wd *watchdog.Watchdog, journal *watchdo
 			journal.Log(watchdog.LevelError, "ipc.bad_state_sync", map[string]any{
 				"error": err.Error(),
 			})
-			return
+			return nil
 		}
 		journal.Log(watchdog.LevelInfo, "agent.state_sync", map[string]any{
 			"agentVersion":  sync.AgentVersion,
@@ -849,6 +938,7 @@ func handleIPCMessage(env *ipc.Envelope, wd *watchdog.Watchdog, journal *watchdo
 			"type": env.Type,
 		})
 	}
+	return nil
 }
 
 // ensureAgentStartedBeforeFailover issues a budget-free, best-effort

--- a/agent/cmd/breeze-watchdog/main.go
+++ b/agent/cmd/breeze-watchdog/main.go
@@ -503,6 +503,9 @@ func runWatchdog(stopCh <-chan struct{}) {
 	standbyWindow := watchdog.StandbyWindow("", 0, wdCfg.StandbyGrace, wdCfg.StandbyTimeout)
 	standbyReason := ""
 	standbyRecognized := true
+	// standbyHoldLogInterval bounds how often a still-holding STANDBY writes a
+	// heartbeat to the health journal.
+	const standbyHoldLogInterval = 5 * time.Minute
 	// A hold is deliberately not journaled per tick (the process ticker runs
 	// every few seconds), but a long hold must not look like a dead watchdog
 	// in the diagnostics bundle: an unrecognized reason can legitimately hold

--- a/agent/cmd/breeze-watchdog/service_cmd_linux.go
+++ b/agent/cmd/breeze-watchdog/service_cmd_linux.go
@@ -130,18 +130,22 @@ func serviceInstallCmd() *cobra.Command {
 			}
 			fmt.Printf("Systemd unit installed to %s\n", watchdogUnitDst)
 
-			// Reload systemd.
-			if out, err := exec.Command("systemctl", "daemon-reload").CombinedOutput(); err != nil {
-				return fmt.Errorf("failed to reload systemd: %s", strings.TrimSpace(string(out)))
+			// Reload, enable, and RESTART — the install stopped the unit above
+			// and the new binary is only live once the process is replaced
+			// (#5252). The darwin install has always bootstrapped here; linux
+			// merely printed "Start with: ..." and left the old process (or
+			// nothing) running.
+			if err := installWatchdogUnit(execCommandRunner, watchdogServiceName); err != nil {
+				fmt.Fprintf(os.Stderr,
+					"ERROR: the Breeze Watchdog was stopped for this install and could NOT be started again: %v\n"+
+						"       This host has no agent supervisor until it starts. Recover with:\n"+
+						"         sudo systemctl start breeze-watchdog\n"+
+						"         sudo journalctl -u breeze-watchdog -n 100 --no-pager\n", err)
+				return err
 			}
 
-			// Enable the service.
-			if out, err := exec.Command("systemctl", "enable", watchdogServiceName).CombinedOutput(); err != nil {
-				fmt.Fprintf(os.Stderr, "Warning: failed to enable service: %s\n", strings.TrimSpace(string(out)))
-			}
-
-			fmt.Println("Breeze Watchdog service installed and enabled.")
-			fmt.Println("Start with: sudo breeze-watchdog service start")
+			fmt.Println("Breeze Watchdog service installed, enabled and started.")
+			fmt.Println("Logs: journalctl -u breeze-watchdog -f")
 			return nil
 		},
 	}

--- a/agent/cmd/breeze-watchdog/service_install.go
+++ b/agent/cmd/breeze-watchdog/service_install.go
@@ -5,7 +5,14 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 )
+
+// standbyHoldLogInterval bounds how often a still-holding STANDBY writes a
+// heartbeat to the health journal. Long enough not to flood a journal written
+// on a multi-second tick, short enough that a 30-minute hold is visibly alive
+// in the diagnostics bundle rather than looking like a dead watchdog.
+const standbyHoldLogInterval = 5 * time.Minute
 
 // commandRunner runs an external command and returns its combined output.
 // Production code uses execCommandRunner; tests substitute a recorder so the

--- a/agent/cmd/breeze-watchdog/service_install.go
+++ b/agent/cmd/breeze-watchdog/service_install.go
@@ -5,14 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-	"time"
 )
-
-// standbyHoldLogInterval bounds how often a still-holding STANDBY writes a
-// heartbeat to the health journal. Long enough not to flood a journal written
-// on a multi-second tick, short enough that a 30-minute hold is visibly alive
-// in the diagnostics bundle rather than looking like a dead watchdog.
-const standbyHoldLogInterval = 5 * time.Minute
 
 // commandRunner runs an external command and returns its combined output.
 // Production code uses execCommandRunner; tests substitute a recorder so the

--- a/agent/cmd/breeze-watchdog/service_install.go
+++ b/agent/cmd/breeze-watchdog/service_install.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// commandRunner runs an external command and returns its combined output.
+// Production code uses execCommandRunner; tests substitute a recorder so the
+// exact argv sequence an install issues can be asserted (#5252).
+type commandRunner func(name string, args ...string) ([]byte, error)
+
+// execCommandRunner is the production commandRunner.
+func execCommandRunner(name string, args ...string) ([]byte, error) {
+	return exec.Command(name, args...).CombinedOutput()
+}
+
+// installWatchdogUnit runs the systemd tail of `breeze-watchdog service
+// install`: daemon-reload, enable, and — always — restart.
+//
+// Always, with no enrollment-style condition, because there is nothing for a
+// watchdog to wait for: it holds no credentials of its own, and an
+// installed-but-not-started watchdog is precisely the #5252 condition. On the
+// reporting host the new watchdog binary sat on disk at v0.110.0 while the
+// v0.104.0 PROCESS kept running, so none of the fixes in the new binary were
+// live and nothing recovered the stopped agent. `restart` covers both the
+// already-running case (adopt the new binary) and the stopped case.
+func installWatchdogUnit(run commandRunner, serviceName string) error {
+	if out, err := run("systemctl", "daemon-reload"); err != nil {
+		return fmt.Errorf("failed to reload systemd: %s", strings.TrimSpace(string(out)))
+	}
+
+	// An un-enabled watchdog still runs until the next reboot, which beats
+	// aborting the install half-done.
+	if out, err := run("systemctl", "enable", serviceName); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to enable service: %s\n", strings.TrimSpace(string(out)))
+	}
+
+	if out, err := run("systemctl", "restart", serviceName); err != nil {
+		return fmt.Errorf("failed to start %s after install: %s",
+			serviceName, strings.TrimSpace(string(out)))
+	}
+	return nil
+}

--- a/agent/cmd/breeze-watchdog/service_install_test.go
+++ b/agent/cmd/breeze-watchdog/service_install_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+type recordingRunner struct {
+	calls  []string
+	failOn map[string]string
+}
+
+func newRecordingRunner() *recordingRunner {
+	return &recordingRunner{failOn: map[string]string{}}
+}
+
+func (r *recordingRunner) run(name string, args ...string) ([]byte, error) {
+	argv := strings.TrimSpace(name + " " + strings.Join(args, " "))
+	r.calls = append(r.calls, argv)
+	if msg, bad := r.failOn[argv]; bad {
+		return []byte(msg), fmt.Errorf("exit status 1")
+	}
+	return nil, nil
+}
+
+func (r *recordingRunner) sequence() string { return strings.Join(r.calls, " | ") }
+
+// TestInstallWatchdogUnitAlwaysRestarts is the regression guard for the
+// watchdog half of #5252. `breeze-watchdog service install` stopped the unit,
+// rewrote it, enabled it — and returned. On the reporting host that left the
+// NEW watchdog binary on disk while the OLD v0.104.0 process kept running, so
+// none of the recovery behaviour in the new binary was live.
+func TestInstallWatchdogUnitAlwaysRestarts(t *testing.T) {
+	r := newRecordingRunner()
+	if err := installWatchdogUnit(r.run, "breeze-watchdog"); err != nil {
+		t.Fatalf("installWatchdogUnit returned error: %v", err)
+	}
+	want := "systemctl daemon-reload | systemctl enable breeze-watchdog | systemctl restart breeze-watchdog"
+	if r.sequence() != want {
+		t.Errorf("argv sequence = %q, want %q", r.sequence(), want)
+	}
+}
+
+// TestInstallWatchdogUnitSurfacesRestartFailure — the install stopped the
+// watchdog; failing to start it again leaves the host with no supervisor at
+// all, so it must not exit 0.
+func TestInstallWatchdogUnitSurfacesRestartFailure(t *testing.T) {
+	r := newRecordingRunner()
+	r.failOn["systemctl restart breeze-watchdog"] = "Job for breeze-watchdog.service failed"
+	err := installWatchdogUnit(r.run, "breeze-watchdog")
+	if err == nil {
+		t.Fatal("a watchdog that could not be restarted after install must be reported as an error")
+	}
+	if !strings.Contains(err.Error(), "Job for breeze-watchdog.service failed") {
+		t.Errorf("error must carry systemctl's own message, got: %v", err)
+	}
+}
+
+// TestInstallWatchdogUnitEnableFailureDoesNotBlockRestart — an un-enabled
+// watchdog still supervises until reboot; refusing to start it would leave
+// the host unsupervised now.
+func TestInstallWatchdogUnitEnableFailureDoesNotBlockRestart(t *testing.T) {
+	r := newRecordingRunner()
+	r.failOn["systemctl enable breeze-watchdog"] = "Failed to enable unit"
+	if err := installWatchdogUnit(r.run, "breeze-watchdog"); err != nil {
+		t.Fatalf("enable failure must not abort the install: %v", err)
+	}
+	if !strings.Contains(r.sequence(), "systemctl restart breeze-watchdog") {
+		t.Errorf("the watchdog must still be restarted, got %q", r.sequence())
+	}
+}
+
+// TestInstallWatchdogUnitDaemonReloadFailureIsFatal — starting after a failed
+// reload would run the OLD unit definition.
+func TestInstallWatchdogUnitDaemonReloadFailureIsFatal(t *testing.T) {
+	r := newRecordingRunner()
+	r.failOn["systemctl daemon-reload"] = "Failed to reload daemon"
+	if err := installWatchdogUnit(r.run, "breeze-watchdog"); err == nil {
+		t.Fatal("daemon-reload failure must abort the install")
+	}
+	if len(r.calls) != 1 {
+		t.Errorf("nothing must run after a failed daemon-reload, got %q", r.sequence())
+	}
+}

--- a/agent/internal/agentapp/install_script_test.go
+++ b/agent/internal/agentapp/install_script_test.go
@@ -1,0 +1,87 @@
+package agentapp
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// installLinuxScript is the shell installer that ships in the Linux tarball.
+// It is the third copy of the "stop, rewrite, enable" sequence that #5252 was
+// about (the other two are the agent and watchdog `service install` commands),
+// and the only one with no compiler or type checker watching it — so it gets a
+// guard here, in the job that already runs on every agent change.
+const installLinuxScript = "../../scripts/install/install-linux.sh"
+
+func readInstallScript(t *testing.T) string {
+	t.Helper()
+	data, err := os.ReadFile(installLinuxScript)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", installLinuxScript, err)
+	}
+	return string(data)
+}
+
+// TestInstallScriptStartsTheAgentItStopped is the regression guard for the
+// shell half of #5252: the script stopped breeze-agent to replace the binary,
+// enabled the unit, printed "Next steps: 1. Start" — and exited, leaving a
+// remote host offline.
+func TestInstallScriptStartsTheAgentItStopped(t *testing.T) {
+	script := readInstallScript(t)
+
+	if !strings.Contains(script, "systemctl stop breeze-agent") {
+		t.Skip("script no longer stops the agent; the start requirement below no longer applies")
+	}
+	if !strings.Contains(script, "systemctl restart breeze-agent") {
+		t.Error("install-linux.sh stops breeze-agent but never starts it again — " +
+			"an already-enrolled remote host is left offline with no management path (#5252)")
+	}
+}
+
+// TestInstallScriptSamplesRunningStateBeforeStopping — the decision to start
+// again must be based on the state BEFORE the script's own stop. Sampling
+// afterwards always reports "not running", which is exactly the inverted check
+// that shipped in the Go command.
+func TestInstallScriptSamplesRunningStateBeforeStopping(t *testing.T) {
+	script := readInstallScript(t)
+
+	sample := strings.Index(script, "systemctl is-active --quiet breeze-agent")
+	stop := strings.Index(script, "systemctl stop breeze-agent")
+	if sample < 0 {
+		t.Fatal("install-linux.sh must record whether breeze-agent was active before it stops it (#5252)")
+	}
+	if stop >= 0 && sample > stop {
+		t.Error("install-linux.sh samples breeze-agent's active state AFTER its own stop — " +
+			"that check can only ever report 'not running' (#5252)")
+	}
+}
+
+// TestInstallScriptStartsTheAgentAfterIPCPrereqs — the agent inherits its
+// group list and opens its IPC socket in /var/run/breeze at startup, so a
+// start issued before the breeze group and that directory exist comes up
+// without a usable socket.
+func TestInstallScriptStartsTheAgentAfterIPCPrereqs(t *testing.T) {
+	script := readInstallScript(t)
+
+	start := strings.Index(script, "systemctl restart breeze-agent")
+	group := strings.Index(script, "groupadd --system breeze")
+	ipcDir := strings.Index(script, `mkdir -p "$IPC_DIR"`)
+	if start < 0 || group < 0 || ipcDir < 0 {
+		t.Fatalf("install script shape changed (start=%d group=%d ipcDir=%d) — re-check the ordering guard",
+			start, group, ipcDir)
+	}
+	if start < group || start < ipcDir {
+		t.Error("install-linux.sh starts breeze-agent before creating the breeze group / IPC directory; " +
+			"the agent would come up without a usable IPC socket")
+	}
+}
+
+// TestInstallScriptStillRestartsTheWatchdog — the host in #5252 kept running a
+// v0.104.0 watchdog process while the v0.110.0 binary sat on disk, so none of
+// the watchdog's recovery behaviour was live.
+func TestInstallScriptStillRestartsTheWatchdog(t *testing.T) {
+	script := readInstallScript(t)
+	if !strings.Contains(script, "systemctl restart breeze-watchdog") {
+		t.Error("install-linux.sh must restart breeze-watchdog so a staged new binary actually takes over (#5252)")
+	}
+}

--- a/agent/internal/agentapp/install_script_test.go
+++ b/agent/internal/agentapp/install_script_test.go
@@ -85,3 +85,40 @@ func TestInstallScriptStillRestartsTheWatchdog(t *testing.T) {
 		t.Error("install-linux.sh must restart breeze-watchdog so a staged new binary actually takes over (#5252)")
 	}
 }
+
+// TestInstallScriptDoesNotLetTheWatchdogAbortTheAgentInstall guards a
+// regression introduced while fixing #5252.
+//
+// `breeze-watchdog service install` now exits non-zero when it cannot restart
+// the watchdog. install-linux.sh runs under `set -e` and invokes it roughly
+// halfway through — BEFORE the breeze-agent restart at the bottom. Left
+// unguarded, a transient watchdog restart failure aborts the installer right
+// there, the agent (already stopped near the top of the script) is never
+// started, and the only error printed talks about the watchdog. That is the
+// exact stranding this fix exists to prevent, reached through the watchdog leg.
+func TestInstallScriptDoesNotLetTheWatchdogAbortTheAgentInstall(t *testing.T) {
+	script := readInstallScript(t)
+
+	const invocation = "/usr/local/bin/breeze-watchdog service install"
+	var found bool
+	for _, line := range strings.Split(script, "\n") {
+		trimmed := strings.TrimSpace(line)
+		// Only lines that RUN the installer count. Comments and the recovery
+		// hint printed on failure mention the same command text.
+		if !strings.Contains(trimmed, invocation) ||
+			strings.HasPrefix(trimmed, "#") ||
+			strings.HasPrefix(trimmed, "echo ") {
+			continue
+		}
+		found = true
+		guarded := strings.HasPrefix(trimmed, "if ") || strings.Contains(trimmed, "||")
+		if !guarded {
+			t.Errorf("install-linux.sh calls %q unguarded under `set -e` (line: %q). "+
+				"A watchdog failure would abort the installer before breeze-agent is "+
+				"started, leaving the host offline (#5252).", invocation, trimmed)
+		}
+	}
+	if !found {
+		t.Skip("install-linux.sh no longer invokes the watchdog installer; guard not applicable")
+	}
+}

--- a/agent/internal/agentapp/service_cmd_darwin.go
+++ b/agent/internal/agentapp/service_cmd_darwin.go
@@ -97,6 +97,8 @@ func init() {
 	serviceCmd.AddCommand(serviceStatusCmd)
 	serviceInstallCmd.Flags().BoolVar(&withUserHelper, "with-user-helper", false, "Also install the per-user desktop helper LaunchAgent")
 	serviceInstallCmd.Flags().BoolVar(&noWatchdog, "no-watchdog", false, "Skip automatic watchdog installation")
+	// A failed start returns an error from RunE; usage text would bury it.
+	serviceInstallCmd.SilenceUsage = true
 }
 
 var serviceInstallCmd = &cobra.Command{
@@ -120,7 +122,15 @@ var serviceInstallCmd = &cobra.Command{
 		}
 
 		// Stop existing service before replacing binary (safe for upgrades).
+		//
+		// Whether it was RUNNING is sampled BEFORE the unload, because this
+		// command then decides whether to bootstrap it again — asking
+		// afterwards only reports the state this unload produced. That
+		// inversion is what stranded Linux hosts in #5252; macOS had the same
+		// shape (unload, never bootstrap).
+		wasRunning := false
 		if _, err := os.Stat(darwinPlistDst); err == nil {
+			wasRunning = isSystemServiceRunning()
 			if stopErr := exec.Command("launchctl", "unload", darwinPlistDst).Run(); stopErr != nil {
 				fmt.Fprintf(os.Stderr, "Warning: failed to stop existing service: %v\n", stopErr)
 			} else {
@@ -216,17 +226,32 @@ var serviceInstallCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Println()
-		fmt.Println("Breeze Agent service installed.")
-
-		// Show contextual next steps based on enrollment and service state.
+		// Start the daemon back up, so `service install` really is the upgrade
+		// path the docs describe (#5252). Runs after the breeze group and the
+		// helper LaunchAgents above: the agent inherits its group list at
+		// startup and opens its IPC socket immediately.
 		existingCfg, _ := config.Load(cfgFile)
 		enrolled := existingCfg != nil && existingCfg.AgentID != ""
-		running := isSystemServiceRunning()
+		plan := planServiceStart(wasRunning, enrolled)
+		started, startErr := applyLaunchdJob(
+			execCommandRunner, darwinLabel, darwinPlistDst, isLaunchdLoaded(darwinLabel), plan)
 
-		if enrolled && running {
-			// Already enrolled and running — nothing more to do.
-			fmt.Printf("\nAgent is enrolled and the service is running.\n")
+		fmt.Println()
+		switch {
+		case started:
+			fmt.Printf("Breeze Agent service installed and started (%s).\n", plan.Reason)
+		case startErr != nil:
+			fmt.Fprintf(os.Stderr,
+				"ERROR: the Breeze Agent daemon was stopped for this install and could NOT be started again: %v\n"+
+					"       This host is not being managed until it starts. Recover with:\n"+
+					"         sudo launchctl bootstrap system %s\n"+
+					"         tail -n 100 %s/agent.err\n",
+				startErr, darwinPlistDst, darwinLogDir)
+		default:
+			fmt.Println("Breeze Agent service installed (not started: " + plan.Reason + ").")
+		}
+
+		if started {
 			fmt.Printf("  Logs:    tail -f %s/agent.log\n", darwinLogDir)
 		} else if enrolled {
 			fmt.Println()
@@ -262,7 +287,10 @@ var serviceInstallCmd = &cobra.Command{
 			}
 		}
 
-		return nil
+		// Reported last so the watchdog still gets bootstrapped, but reported:
+		// a silent exit 0 on a host whose agent is down is exactly how #5252
+		// went unnoticed until the device showed Offline.
+		return startErr
 	},
 }
 

--- a/agent/internal/agentapp/service_cmd_darwin.go
+++ b/agent/internal/agentapp/service_cmd_darwin.go
@@ -268,6 +268,14 @@ var serviceInstallCmd = &cobra.Command{
 			fmt.Printf("  4. Logs:    tail -f %s/agent.log\n", darwinLogDir)
 		}
 		if !noWatchdog {
+			// Describe the service state we actually left behind. This line
+			// used to assert "installed and running" unconditionally, which
+			// before #5252 was never true on this platform and is still not
+			// true for a fresh un-enrolled host or a failed start.
+			agentStateLine := "The agent service is installed but is NOT running."
+			if started {
+				agentStateLine = "The agent service is installed and running."
+			}
 			err := bootstrapWatchdog(bootstrapOptions{
 				agentPath: exePath,
 				version:   version,
@@ -277,13 +285,13 @@ var serviceInstallCmd = &cobra.Command{
 			if err != nil {
 				fmt.Fprintf(os.Stderr,
 					"Warning: watchdog bootstrap failed: %v\n"+
-						"The agent service is installed and running. The watchdog is NOT installed.\n"+
+						"%s The watchdog is NOT installed.\n"+
 						"To retry, choose one of:\n"+
 						"  1. Re-run `sudo breeze-agent service install` (will retry the download).\n"+
 						"  2. Download %s manually, place it next to breeze-agent,\n"+
 						"     then run `sudo breeze-watchdog service install`.\n"+
 						"  3. To skip the watchdog entirely, use `--no-watchdog`.\n",
-					err, watchdogDownloadURL(version, runtime.GOOS, runtime.GOARCH))
+					err, agentStateLine, watchdogDownloadURL(version, runtime.GOOS, runtime.GOARCH))
 			}
 		}
 

--- a/agent/internal/agentapp/service_cmd_linux.go
+++ b/agent/internal/agentapp/service_cmd_linux.go
@@ -277,6 +277,14 @@ var serviceInstallCmd = &cobra.Command{
 		}
 
 		if !noWatchdog {
+			// Describe the service state we actually left behind. This line
+			// used to assert "installed and running" unconditionally, which
+			// before #5252 was never true on this platform and is still not
+			// true for a fresh un-enrolled host or a failed start.
+			agentStateLine := "The agent service is installed but is NOT running."
+			if started {
+				agentStateLine = "The agent service is installed and running."
+			}
 			err := bootstrapWatchdog(bootstrapOptions{
 				agentPath: exePath,
 				version:   version,
@@ -286,13 +294,13 @@ var serviceInstallCmd = &cobra.Command{
 			if err != nil {
 				fmt.Fprintf(os.Stderr,
 					"Warning: watchdog bootstrap failed: %v\n"+
-						"The agent service is installed and running. The watchdog is NOT installed.\n"+
+						"%s The watchdog is NOT installed.\n"+
 						"To retry, choose one of:\n"+
 						"  1. Re-run `sudo breeze-agent service install` (will retry the download).\n"+
 						"  2. Download %s manually, place it next to breeze-agent,\n"+
 						"     then run `sudo breeze-watchdog service install`.\n"+
 						"  3. To skip the watchdog entirely, use `--no-watchdog`.\n",
-					err, watchdogDownloadURL(version, runtime.GOOS, runtime.GOARCH))
+					err, agentStateLine, watchdogDownloadURL(version, runtime.GOOS, runtime.GOARCH))
 			}
 		}
 

--- a/agent/internal/agentapp/service_cmd_linux.go
+++ b/agent/internal/agentapp/service_cmd_linux.go
@@ -122,6 +122,8 @@ func init() {
 	serviceCmd.AddCommand(serviceReconcileUnitCmd)
 	serviceInstallCmd.Flags().BoolVar(&withUserHelper, "with-user-helper", false, "Also install the per-user desktop helper systemd unit")
 	serviceInstallCmd.Flags().BoolVar(&noWatchdog, "no-watchdog", false, "Skip automatic watchdog installation")
+	// A failed start returns an error from RunE; usage text would bury it.
+	serviceInstallCmd.SilenceUsage = true
 }
 
 var serviceInstallCmd = &cobra.Command{
@@ -145,7 +147,16 @@ var serviceInstallCmd = &cobra.Command{
 		}
 
 		// Stop existing service before replacing binary (safe for upgrades).
+		//
+		// Whether it was RUNNING must be sampled BEFORE the stop: this command
+		// then goes on to decide whether to start it again, and asking
+		// afterwards only ever reports the state this very stop produced. That
+		// inversion is what shipped #5252 — the post-install check read
+		// "not running", printed "Next steps: 1. Start", and left a remote
+		// enrolled host offline with no way back in.
+		wasRunning := false
 		if _, err := os.Stat(linuxUnitDst); err == nil {
+			wasRunning = isSystemServiceRunning()
 			if stopErr := exec.Command("systemctl", "stop", linuxServiceName).Run(); stopErr != nil {
 				fmt.Fprintf(os.Stderr, "Warning: failed to stop existing service: %v\n", stopErr)
 			} else {
@@ -191,17 +202,10 @@ var serviceInstallCmd = &cobra.Command{
 			}
 		}
 
-		// Reload systemd
-		if out, err := exec.Command("systemctl", "daemon-reload").CombinedOutput(); err != nil {
-			return fmt.Errorf("failed to reload systemd: %s", strings.TrimSpace(string(out)))
-		}
-
-		// Enable the service
-		if out, err := exec.Command("systemctl", "enable", linuxServiceName).CombinedOutput(); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to enable service: %s\n", strings.TrimSpace(string(out)))
-		}
-
-		// Create breeze group for IPC socket access (best-effort, idempotent)
+		// IPC prerequisites are created BEFORE the service is started: the
+		// agent opens its IPC socket in /var/run/breeze owned by the breeze
+		// group at startup, so an agent started ahead of them comes up
+		// without a usable socket. Best-effort and idempotent.
 		if err := exec.Command("getent", "group", "breeze").Run(); err != nil {
 			// Group doesn't exist — create it
 			if createErr := exec.Command("groupadd", "--system", "breeze").Run(); createErr != nil {
@@ -220,16 +224,33 @@ var serviceInstallCmd = &cobra.Command{
 			fmt.Fprintf(os.Stderr, "Warning: failed to set IPC directory ownership: %v\n", err)
 		}
 
-		fmt.Println()
-		fmt.Println("Breeze Agent service installed and enabled.")
-
-		// Show contextual next steps based on enrollment and service state.
 		existingCfg, _ := config.Load(cfgFile)
 		enrolled := existingCfg != nil && existingCfg.AgentID != ""
-		running := isSystemServiceRunning()
 
-		if enrolled && running {
-			// Already enrolled and running — show current status automatically.
+		// Reload systemd, enable, and — unless this is a fresh un-enrolled
+		// host — start the service, so `service install` really is the
+		// upgrade path the docs describe (#5252).
+		plan := planServiceStart(wasRunning, enrolled)
+		started, startErr := applySystemdUnit(execCommandRunner, linuxServiceName, plan)
+		fmt.Printf("Systemd unit reloaded and enabled (%s).\n", linuxUnitDst)
+
+		fmt.Println()
+		switch {
+		case started:
+			fmt.Printf("Breeze Agent service installed, enabled and started (%s).\n", plan.Reason)
+		case startErr != nil:
+			fmt.Fprintf(os.Stderr,
+				"ERROR: the Breeze Agent service was stopped for this install and could NOT be started again: %v\n"+
+					"       This host is not being managed until it starts. Recover with:\n"+
+					"         sudo systemctl start breeze-agent\n"+
+					"         sudo journalctl -u breeze-agent -n 100 --no-pager\n",
+				startErr)
+		default:
+			fmt.Println("Breeze Agent service installed and enabled (not started: " + plan.Reason + ").")
+		}
+
+		if started {
+			// Show current status automatically.
 			fmt.Println()
 			statusCmd := exec.Command(linuxBinaryPath, "status")
 			statusCmd.Stdout = os.Stdout
@@ -239,7 +260,7 @@ var serviceInstallCmd = &cobra.Command{
 			fmt.Println("\nHelpful Commands:")
 			fmt.Println("  Logs:    journalctl -u breeze-agent -f")
 			fmt.Println("  Status:  sudo breeze-agent service status")
-			fmt.Println("  Restart: sudo breeze-agent service start")
+			fmt.Println("  Restart: sudo systemctl restart breeze-agent")
 		} else if enrolled {
 			fmt.Println()
 			fmt.Println("Next steps:")
@@ -275,7 +296,10 @@ var serviceInstallCmd = &cobra.Command{
 			}
 		}
 
-		return nil
+		// Reported last so the watchdog still gets bootstrapped, but reported:
+		// a silent exit 0 on a host whose agent is down is exactly how #5252
+		// went unnoticed until the device showed Offline.
+		return startErr
 	},
 }
 

--- a/agent/internal/agentapp/service_install.go
+++ b/agent/internal/agentapp/service_install.go
@@ -1,0 +1,114 @@
+package agentapp
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// serviceStartPlan records whether `service install` must leave the service
+// RUNNING when it returns, and the reason to print.
+//
+// Before #5252 the install command stopped the unit ("safe for upgrades"),
+// rewrote it, enabled it — and then returned without ever starting it. On a
+// remote, already-enrolled host whose only management path is the agent
+// itself, that stranded the box: the device went Offline and stayed Offline
+// until somebody reached it over SSH or a console. The watchdog did not save
+// it either (see EvaluateStandby).
+type serviceStartPlan struct {
+	// Start is true when install must (re)start the service before returning.
+	Start bool
+	// Reason is a short human-readable justification, printed by the caller.
+	Reason string
+}
+
+// planServiceStart decides whether `service install` starts the service.
+//
+// Two independent triggers, either of which is sufficient:
+//
+//   - wasRunning: the unit was active before install stopped it. Install is
+//     documented as an upgrade path, and an upgrade must not change whether
+//     the service is running.
+//   - enrolled: the host already has an agent ID, so the service is meant to
+//     be running even if it happened to be down at install time (a crashed or
+//     manually-stopped agent being upgraded still wants to come back).
+//
+// A host that is neither running nor enrolled is a fresh install: there is
+// nothing to talk to a server about yet, so the operator enrolls first.
+func planServiceStart(wasRunning, enrolled bool) serviceStartPlan {
+	switch {
+	case wasRunning:
+		return serviceStartPlan{Start: true, Reason: "it was running before this install"}
+	case enrolled:
+		return serviceStartPlan{Start: true, Reason: "this host is already enrolled"}
+	default:
+		return serviceStartPlan{Start: false, Reason: "this host is not enrolled yet"}
+	}
+}
+
+// applySystemdUnit runs the systemd tail of `service install`: daemon-reload,
+// enable, and — when the plan says so — restart.
+//
+// `restart` rather than `start` deliberately: it is correct whether or not the
+// unit is currently active, so it also covers the case where something else
+// (a sibling installer, the watchdog) started the unit between our stop and
+// this call, and it guarantees the freshly copied binary is the one running.
+//
+// Split out of the cobra RunE bodies purely so the argv sequence is assertable
+// without root or a live init system — the regression guard for #5252 is
+// "a restart is issued at all", which is exactly the kind of omission a
+// hand-read of the command misses.
+func applySystemdUnit(run commandRunner, serviceName string, plan serviceStartPlan) (started bool, err error) {
+	if out, err := run("systemctl", "daemon-reload"); err != nil {
+		return false, fmt.Errorf("failed to reload systemd: %s", strings.TrimSpace(string(out)))
+	}
+
+	// Enable failures stay warnings: a unit that is installed but not enabled
+	// still runs until the next reboot, which is strictly better than aborting
+	// the install half-done.
+	if out, err := run("systemctl", "enable", serviceName); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to enable service: %s\n", strings.TrimSpace(string(out)))
+	}
+
+	if !plan.Start {
+		return false, nil
+	}
+
+	if out, err := run("systemctl", "restart", serviceName); err != nil {
+		return false, fmt.Errorf("failed to start %s after install: %s",
+			serviceName, strings.TrimSpace(string(out)))
+	}
+	return true, nil
+}
+
+// applyLaunchdJob is the launchd counterpart of applySystemdUnit: it leaves the
+// job RUNNING when the plan says so.
+//
+// A job that is already loaded is kickstarted with -k, which kills the running
+// instance and starts a fresh one — the launchd equivalent of `systemctl
+// restart`, and the only way the binary we just copied over the old one
+// actually takes over. A job that is not loaded is bootstrapped, falling back
+// to the legacy `load` on older macOS.
+func applyLaunchdJob(run commandRunner, label, plistPath string, loaded bool, plan serviceStartPlan) (started bool, err error) {
+	if !plan.Start {
+		return false, nil
+	}
+	if loaded {
+		if out, kickErr := run("launchctl", "kickstart", "-k", "system/"+label); kickErr != nil {
+			return false, fmt.Errorf("failed to restart %s after install: %s",
+				label, strings.TrimSpace(string(out)))
+		}
+		return true, nil
+	}
+	out, bootErr := run("launchctl", "bootstrap", "system", plistPath)
+	if bootErr == nil {
+		return true, nil
+	}
+	// Fallback to the legacy loader before giving up.
+	out2, loadErr := run("launchctl", "load", plistPath)
+	if loadErr != nil {
+		return false, fmt.Errorf("failed to start %s after install: %s / %s",
+			label, strings.TrimSpace(string(out)), strings.TrimSpace(string(out2)))
+	}
+	return true, nil
+}

--- a/agent/internal/agentapp/service_install_exit_test.go
+++ b/agent/internal/agentapp/service_install_exit_test.go
@@ -1,0 +1,98 @@
+package agentapp
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+// The two platform install commands are build-tagged, so on any given host
+// `go test` compiles only one of them and neither is reachable from a test at
+// all (the RunE body needs root, /etc, and a live init system). They are
+// parsed as SOURCE here instead, which works on every platform and covers both
+// files from a single untagged test.
+var installCommandSources = map[string]string{
+	"linux":  "service_cmd_linux.go",
+	"darwin": "service_cmd_darwin.go",
+}
+
+// TestServiceInstallReturnsTheStartError is the guard for the fail-closed half
+// of #5252.
+//
+// The original command stopped the agent service, failed to leave anything
+// running, and STILL exited 0 — so a provisioning script, a golden-image
+// build, or an operator watching the shell all saw success while the host went
+// offline. The fix is one line: the install RunE ends in `return startErr`
+// rather than `return nil`. Nothing else in the suite can catch a refactor
+// that reverts it, because nothing calls RunE.
+func TestServiceInstallReturnsTheStartError(t *testing.T) {
+	for platform, file := range installCommandSources {
+		t.Run(platform, func(t *testing.T) {
+			body := installRunEBody(t, file)
+			if len(body.List) == 0 {
+				t.Fatalf("%s: serviceInstallCmd RunE body is empty", file)
+			}
+			last, ok := body.List[len(body.List)-1].(*ast.ReturnStmt)
+			if !ok {
+				t.Fatalf("%s: serviceInstallCmd RunE does not end in a return statement", file)
+			}
+			if len(last.Results) != 1 {
+				t.Fatalf("%s: serviceInstallCmd RunE returns %d values, want 1", file, len(last.Results))
+			}
+			ident, ok := last.Results[0].(*ast.Ident)
+			if !ok || ident.Name != "startErr" {
+				t.Errorf("%s: serviceInstallCmd RunE ends in `return %s`, want `return startErr`. "+
+					"Returning nil makes an install that stopped the service and could not start it "+
+					"again exit 0 — the silent success that stranded a remote host in #5252.",
+					file, exprText(last.Results[0]))
+			}
+		})
+	}
+}
+
+// installRunEBody parses file and returns the body of the RunE function
+// literal on the serviceInstallCmd command value.
+func installRunEBody(t *testing.T, file string) *ast.BlockStmt {
+	t.Helper()
+	fset := token.NewFileSet()
+	parsed, err := parser.ParseFile(fset, file, nil, 0)
+	if err != nil {
+		t.Fatalf("failed to parse %s: %v", file, err)
+	}
+
+	var body *ast.BlockStmt
+	ast.Inspect(parsed, func(n ast.Node) bool {
+		vs, ok := n.(*ast.ValueSpec)
+		if !ok || len(vs.Names) == 0 || vs.Names[0].Name != "serviceInstallCmd" {
+			return true
+		}
+		ast.Inspect(vs, func(inner ast.Node) bool {
+			kv, ok := inner.(*ast.KeyValueExpr)
+			if !ok {
+				return true
+			}
+			if key, ok := kv.Key.(*ast.Ident); !ok || key.Name != "RunE" {
+				return true
+			}
+			if fn, ok := kv.Value.(*ast.FuncLit); ok {
+				body = fn.Body
+			}
+			return false
+		})
+		return false
+	})
+
+	if body == nil {
+		t.Fatalf("%s: could not find the RunE function literal on serviceInstallCmd — "+
+			"the command's shape changed, re-check this guard", file)
+	}
+	return body
+}
+
+func exprText(e ast.Expr) string {
+	if ident, ok := e.(*ast.Ident); ok {
+		return ident.Name
+	}
+	return "<non-identifier>"
+}

--- a/agent/internal/agentapp/service_install_runner.go
+++ b/agent/internal/agentapp/service_install_runner.go
@@ -1,0 +1,13 @@
+package agentapp
+
+import "os/exec"
+
+// commandRunner runs an external command and returns its combined output.
+// Production code uses execCommandRunner; tests substitute a recorder so the
+// exact argv sequence an install issues can be asserted (#5252).
+type commandRunner func(name string, args ...string) ([]byte, error)
+
+// execCommandRunner is the production commandRunner.
+func execCommandRunner(name string, args ...string) ([]byte, error) {
+	return exec.Command(name, args...).CombinedOutput()
+}

--- a/agent/internal/agentapp/service_install_test.go
+++ b/agent/internal/agentapp/service_install_test.go
@@ -1,0 +1,218 @@
+package agentapp
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// recordingRunner captures every argv a caller issues and can be told to fail
+// a specific command.
+type recordingRunner struct {
+	calls  []string
+	failOn map[string]string // joined argv -> stderr text
+}
+
+func newRecordingRunner() *recordingRunner {
+	return &recordingRunner{failOn: map[string]string{}}
+}
+
+func (r *recordingRunner) run(name string, args ...string) ([]byte, error) {
+	argv := strings.TrimSpace(name + " " + strings.Join(args, " "))
+	r.calls = append(r.calls, argv)
+	if msg, bad := r.failOn[argv]; bad {
+		return []byte(msg), fmt.Errorf("exit status 1")
+	}
+	return nil, nil
+}
+
+func (r *recordingRunner) sequence() string { return strings.Join(r.calls, " | ") }
+
+// TestPlanServiceStartCoversEveryHostShape pins the decision table behind
+// #5252: an install that stopped a running (or enrolled) agent must start it
+// again, and a fresh un-enrolled host must not be started into a pointless
+// crash-loop before it has credentials.
+func TestPlanServiceStartCoversEveryHostShape(t *testing.T) {
+	tests := []struct {
+		name       string
+		wasRunning bool
+		enrolled   bool
+		wantStart  bool
+	}{
+		{"running and enrolled (the #5252 upgrade case)", true, true, true},
+		{"enrolled but stopped — upgrade of a down agent still comes back", false, true, true},
+		{"running but not enrolled — never regress a running service", true, false, true},
+		{"fresh host, neither running nor enrolled — enroll first", false, false, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := planServiceStart(tc.wasRunning, tc.enrolled)
+			if got.Start != tc.wantStart {
+				t.Errorf("planServiceStart(wasRunning=%v, enrolled=%v).Start = %v, want %v",
+					tc.wasRunning, tc.enrolled, got.Start, tc.wantStart)
+			}
+			if got.Reason == "" {
+				t.Error("plan must carry a printable reason so the operator can see what install decided")
+			}
+		})
+	}
+}
+
+// TestApplySystemdUnitRestartsWhenPlanSaysStart is the direct regression guard
+// for #5252: `service install` stopped breeze-agent, rewrote and enabled the
+// unit, and returned WITHOUT any systemctl start — stranding a remote host
+// offline. The argv sequence must now end in a restart.
+func TestApplySystemdUnitRestartsWhenPlanSaysStart(t *testing.T) {
+	r := newRecordingRunner()
+	started, err := applySystemdUnit(r.run, "breeze-agent", serviceStartPlan{Start: true, Reason: "test"})
+	if err != nil {
+		t.Fatalf("applySystemdUnit returned error: %v", err)
+	}
+	if !started {
+		t.Error("applySystemdUnit must report started=true when the plan says start")
+	}
+	want := "systemctl daemon-reload | systemctl enable breeze-agent | systemctl restart breeze-agent"
+	if r.sequence() != want {
+		t.Errorf("argv sequence = %q, want %q", r.sequence(), want)
+	}
+}
+
+// TestApplySystemdUnitDoesNotStartWhenPlanSaysNo keeps the fresh-install path
+// unchanged: an un-enrolled host is installed and enabled but not started.
+func TestApplySystemdUnitDoesNotStartWhenPlanSaysNo(t *testing.T) {
+	r := newRecordingRunner()
+	started, err := applySystemdUnit(r.run, "breeze-agent", serviceStartPlan{Start: false, Reason: "test"})
+	if err != nil {
+		t.Fatalf("applySystemdUnit returned error: %v", err)
+	}
+	if started {
+		t.Error("started must be false when the plan says not to start")
+	}
+	for _, call := range r.calls {
+		if strings.Contains(call, "restart") || strings.Contains(call, "systemctl start") {
+			t.Errorf("unexpected start/restart on a fresh un-enrolled host: %q", r.sequence())
+		}
+	}
+}
+
+// TestApplySystemdUnitSurfacesRestartFailure — a restart that fails after we
+// already stopped the agent is precisely the stranded-host condition. It must
+// be a hard error, never a swallowed warning.
+func TestApplySystemdUnitSurfacesRestartFailure(t *testing.T) {
+	r := newRecordingRunner()
+	r.failOn["systemctl restart breeze-agent"] = "Job for breeze-agent.service failed"
+	started, err := applySystemdUnit(r.run, "breeze-agent", serviceStartPlan{Start: true, Reason: "test"})
+	if err == nil {
+		t.Fatal("a failed restart after install stopped the service must be reported as an error")
+	}
+	if started {
+		t.Error("started must be false when the restart failed")
+	}
+	if !strings.Contains(err.Error(), "Job for breeze-agent.service failed") {
+		t.Errorf("error must carry systemctl's own message, got: %v", err)
+	}
+}
+
+// TestApplySystemdUnitEnableFailureDoesNotBlockStart — an un-enabled unit
+// still runs until the next reboot; refusing to start it would turn a
+// cosmetic failure into an offline host.
+func TestApplySystemdUnitEnableFailureDoesNotBlockStart(t *testing.T) {
+	r := newRecordingRunner()
+	r.failOn["systemctl enable breeze-agent"] = "Failed to enable unit"
+	started, err := applySystemdUnit(r.run, "breeze-agent", serviceStartPlan{Start: true, Reason: "test"})
+	if err != nil {
+		t.Fatalf("enable failure must not abort the install: %v", err)
+	}
+	if !started {
+		t.Error("the service must still be started when only enable failed")
+	}
+}
+
+// TestApplySystemdUnitDaemonReloadFailureIsFatal keeps the pre-existing
+// contract: systemd cannot pick up the rewritten unit, so starting it would
+// run the OLD unit definition.
+func TestApplySystemdUnitDaemonReloadFailureIsFatal(t *testing.T) {
+	r := newRecordingRunner()
+	r.failOn["systemctl daemon-reload"] = "Failed to reload daemon"
+	if _, err := applySystemdUnit(r.run, "breeze-agent", serviceStartPlan{Start: true, Reason: "test"}); err == nil {
+		t.Fatal("daemon-reload failure must abort before the unit is enabled or started")
+	}
+	if len(r.calls) != 1 {
+		t.Errorf("nothing must run after a failed daemon-reload, got: %q", r.sequence())
+	}
+}
+
+// TestApplyLaunchdJobRestartsALoadedJob — macOS had the same #5252 shape:
+// install `launchctl unload`ed the daemon and never bootstrapped it back.
+// A job that is still loaded must be kickstarted with -k, because a plain
+// kickstart would leave the OLD process (and therefore the old binary) running.
+func TestApplyLaunchdJobRestartsALoadedJob(t *testing.T) {
+	r := newRecordingRunner()
+	started, err := applyLaunchdJob(r.run, "com.breeze.agent", "/Library/LaunchDaemons/com.breeze.agent.plist",
+		true, serviceStartPlan{Start: true, Reason: "test"})
+	if err != nil {
+		t.Fatalf("applyLaunchdJob returned error: %v", err)
+	}
+	if !started {
+		t.Error("started must be true")
+	}
+	want := "launchctl kickstart -k system/com.breeze.agent"
+	if r.sequence() != want {
+		t.Errorf("argv = %q, want %q", r.sequence(), want)
+	}
+}
+
+func TestApplyLaunchdJobBootstrapsAnUnloadedJob(t *testing.T) {
+	r := newRecordingRunner()
+	started, err := applyLaunchdJob(r.run, "com.breeze.agent", "/Library/LaunchDaemons/com.breeze.agent.plist",
+		false, serviceStartPlan{Start: true, Reason: "test"})
+	if err != nil || !started {
+		t.Fatalf("applyLaunchdJob = (%v, %v), want (true, nil)", started, err)
+	}
+	want := "launchctl bootstrap system /Library/LaunchDaemons/com.breeze.agent.plist"
+	if r.sequence() != want {
+		t.Errorf("argv = %q, want %q", r.sequence(), want)
+	}
+}
+
+// TestApplyLaunchdJobFallsBackToLegacyLoad keeps older macOS working.
+func TestApplyLaunchdJobFallsBackToLegacyLoad(t *testing.T) {
+	r := newRecordingRunner()
+	r.failOn["launchctl bootstrap system /p.plist"] = "Bootstrap failed: 5: Input/output error"
+	started, err := applyLaunchdJob(r.run, "com.breeze.agent", "/p.plist", false,
+		serviceStartPlan{Start: true, Reason: "test"})
+	if err != nil || !started {
+		t.Fatalf("applyLaunchdJob = (%v, %v), want (true, nil) via the legacy load fallback", started, err)
+	}
+	if !strings.Contains(r.sequence(), "launchctl load /p.plist") {
+		t.Errorf("expected a legacy load fallback, got %q", r.sequence())
+	}
+}
+
+// TestApplyLaunchdJobSurfacesTotalFailure — both loaders failing after install
+// already unloaded the daemon is the stranded-host condition on macOS.
+func TestApplyLaunchdJobSurfacesTotalFailure(t *testing.T) {
+	r := newRecordingRunner()
+	r.failOn["launchctl bootstrap system /p.plist"] = "boom"
+	r.failOn["launchctl load /p.plist"] = "also boom"
+	started, err := applyLaunchdJob(r.run, "com.breeze.agent", "/p.plist", false,
+		serviceStartPlan{Start: true, Reason: "test"})
+	if err == nil {
+		t.Fatal("a daemon that could not be started after install must be an error")
+	}
+	if started {
+		t.Error("started must be false")
+	}
+}
+
+func TestApplyLaunchdJobDoesNothingWhenPlanSaysNo(t *testing.T) {
+	r := newRecordingRunner()
+	started, err := applyLaunchdJob(r.run, "com.breeze.agent", "/p.plist", false,
+		serviceStartPlan{Start: false, Reason: "test"})
+	if err != nil || started {
+		t.Fatalf("applyLaunchdJob = (%v, %v), want (false, nil)", started, err)
+	}
+	if len(r.calls) != 0 {
+		t.Errorf("nothing must run on a fresh un-enrolled host, got %q", r.sequence())
+	}
+}

--- a/agent/internal/config/config.go
+++ b/agent/internal/config/config.go
@@ -363,7 +363,9 @@ func Default() *Config {
 			RecoveryCooldown:        10 * time.Minute,
 			StandbyTimeout:          30 * time.Minute,
 			// Kept in lockstep with watchdog.DefaultStandbyGrace by
-			// TestStandbyGraceDefaultMatchesWatchdogPackage. Not imported:
+			// TestStandbyGraceDefaultMatchesConfigDefault (it lives in the
+			// watchdog package, which may import config; not the reverse —
+			// watchdog/netcache.go already imports config). Not imported:
 			// config is the more fundamental package and must not grow a
 			// dependency on the watchdog for one constant.
 			StandbyGrace:               2 * time.Minute,

--- a/agent/internal/config/config.go
+++ b/agent/internal/config/config.go
@@ -23,10 +23,19 @@ type WatchdogConfig struct {
 	HeartbeatStaleThreshold time.Duration `mapstructure:"heartbeat_stale_threshold" yaml:"heartbeat_stale_threshold"`
 	MaxRecoveryAttempts     int           `mapstructure:"max_recovery_attempts" yaml:"max_recovery_attempts"`
 	RecoveryCooldown        time.Duration `mapstructure:"recovery_cooldown" yaml:"recovery_cooldown"`
-	StandbyTimeout          time.Duration `mapstructure:"standby_timeout" yaml:"standby_timeout"`
-	FailoverPollInterval    time.Duration `mapstructure:"failover_poll_interval" yaml:"failover_poll_interval"`
-	HealthJournalMaxSizeMB  int           `mapstructure:"health_journal_max_size_mb" yaml:"health_journal_max_size_mb"`
-	HealthJournalMaxFiles   int           `mapstructure:"health_journal_max_files" yaml:"health_journal_max_files"`
+	// StandbyTimeout is the ABSOLUTE cap on a standby. Since #5252 it is the
+	// ceiling only: a shutdown reason the agent itself sends is bounded by the
+	// much shorter StandbyGrace instead, so an ordinary stop no longer leaves
+	// a host unmanaged for half an hour.
+	StandbyTimeout time.Duration `mapstructure:"standby_timeout" yaml:"standby_timeout"`
+	// StandbyGrace is how long a recognized graceful shutdown (user_stop,
+	// update, config_reload) is tolerated before the watchdog treats the agent
+	// as stranded and restarts it. An agent-declared ExpectedDuration can
+	// raise it; StandbyTimeout caps it.
+	StandbyGrace           time.Duration `mapstructure:"standby_grace" yaml:"standby_grace"`
+	FailoverPollInterval   time.Duration `mapstructure:"failover_poll_interval" yaml:"failover_poll_interval"`
+	HealthJournalMaxSizeMB int           `mapstructure:"health_journal_max_size_mb" yaml:"health_journal_max_size_mb"`
+	HealthJournalMaxFiles  int           `mapstructure:"health_journal_max_files" yaml:"health_journal_max_files"`
 	// Auto-restart verification gate — set after Task 5 wires them.
 	RestartVerificationGrace   time.Duration `mapstructure:"restart_verification_grace" yaml:"restart_verification_grace"`
 	RestartVerificationTimeout time.Duration `mapstructure:"restart_verification_timeout" yaml:"restart_verification_timeout"`
@@ -346,13 +355,18 @@ func Default() *Config {
 		PolicyConfigStateProbes:    []PolicyConfigStateProbe{},
 
 		Watchdog: WatchdogConfig{
-			Enabled:                    true,
-			ProcessCheckInterval:       5 * time.Second,
-			IPCProbeInterval:           30 * time.Second,
-			HeartbeatStaleThreshold:    3 * time.Minute,
-			MaxRecoveryAttempts:        3,
-			RecoveryCooldown:           10 * time.Minute,
-			StandbyTimeout:             30 * time.Minute,
+			Enabled:                 true,
+			ProcessCheckInterval:    5 * time.Second,
+			IPCProbeInterval:        30 * time.Second,
+			HeartbeatStaleThreshold: 3 * time.Minute,
+			MaxRecoveryAttempts:     3,
+			RecoveryCooldown:        10 * time.Minute,
+			StandbyTimeout:          30 * time.Minute,
+			// Kept in lockstep with watchdog.DefaultStandbyGrace by
+			// TestStandbyGraceDefaultMatchesWatchdogPackage. Not imported:
+			// config is the more fundamental package and must not grow a
+			// dependency on the watchdog for one constant.
+			StandbyGrace:               2 * time.Minute,
 			FailoverPollInterval:       30 * time.Second,
 			HealthJournalMaxSizeMB:     10,
 			HealthJournalMaxFiles:      3,

--- a/agent/internal/watchdog/standby.go
+++ b/agent/internal/watchdog/standby.go
@@ -1,0 +1,154 @@
+package watchdog
+
+import (
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/state"
+)
+
+// DefaultStandbyGrace is how long the watchdog tolerates an announced,
+// recognized agent shutdown before it treats the agent as stranded and starts
+// it again.
+//
+// Two minutes is chosen to sit comfortably above a systemd stop+start of the
+// agent (seconds) and above an in-band binary swap, while being short enough
+// that a remote host whose agent was stopped and never restarted — the #5252
+// failure — is back before anyone notices. The previous behaviour was to wait
+// out StandbyTimeout (30 minutes) and then park in FAILOVER *without* starting
+// the agent, i.e. the host stayed offline indefinitely.
+const DefaultStandbyGrace = 2 * time.Minute
+
+// StandbyDecision is the action the watchdog should take for the current
+// STANDBY tick.
+type StandbyDecision int
+
+const (
+	// StandbyHold keeps the watchdog in STANDBY and means every "the agent
+	// looks dead" signal must be DROPPED: the agent is intentionally down and
+	// restarting it now would fight the very operation it announced (an admin
+	// `service stop`, an installer's stop-rewrite-start, the in-band updater).
+	StandbyHold StandbyDecision = iota
+	// StandbyResume means the agent turned out to be alive and healthy after
+	// all (the announced shutdown never completed) — return to MONITORING
+	// rather than restarting a working agent.
+	StandbyResume
+	// StandbyRecover means the announced window closed with the agent still
+	// gone. Hand off to the normal RECOVERING ladder, which carries the
+	// restart budget, flap detection and its own ensure-start-before-FAILOVER.
+	StandbyRecover
+	// StandbyFailover means we held an UNRECOGNIZED shutdown reason all the
+	// way to the ceiling. We deliberately do not run the restart ladder for a
+	// reason we do not understand, but we must not leave the host dead either:
+	// the caller issues one budget-free ensure-start and parks in FAILOVER so
+	// the server learns the host needs attention.
+	StandbyFailover
+)
+
+func (d StandbyDecision) String() string {
+	switch d {
+	case StandbyHold:
+		return "hold"
+	case StandbyResume:
+		return "resume"
+	case StandbyRecover:
+		return "recover"
+	case StandbyFailover:
+		return "failover"
+	default:
+		return "unknown"
+	}
+}
+
+// StandbyInput is the evidence EvaluateStandby judges.
+type StandbyInput struct {
+	// Elapsed is how long the watchdog has been in STANDBY.
+	Elapsed time.Duration
+	// Window is the tolerated shutdown window for a recognized reason
+	// (see StandbyWindow).
+	Window time.Duration
+	// Ceiling is the absolute cap on any standby (config StandbyTimeout).
+	Ceiling time.Duration
+	// Recognized reports whether the shutdown reason is one this agent sends.
+	Recognized bool
+	// AgentHealthy reports live IPC *and* a fresh heartbeat. It is only
+	// consulted once the window has closed — during the window the agent's
+	// heartbeat is still fresh purely because it was alive moments ago, and
+	// treating that as "healthy" would cancel the standby it just announced.
+	AgentHealthy bool
+}
+
+// EvaluateStandby is the single source of truth for what STANDBY does.
+//
+// It is consulted from two places in the watchdog run loop — the per-tick
+// STANDBY block and the funnel that every agent_unhealthy signal passes
+// through — precisely so those two cannot drift apart. Keeping it pure keeps
+// the transition table static and makes the policy table-testable without a
+// live agent, an init system, or a clock.
+func EvaluateStandby(in StandbyInput) StandbyDecision {
+	if !in.Recognized {
+		// An unfamiliar reason may describe genuinely long maintenance, so we
+		// wait out the full ceiling rather than guessing a short window.
+		if in.Elapsed < in.Ceiling {
+			return StandbyHold
+		}
+		if in.AgentHealthy {
+			return StandbyResume
+		}
+		return StandbyFailover
+	}
+	if in.Elapsed < in.Window {
+		return StandbyHold
+	}
+	if in.AgentHealthy {
+		return StandbyResume
+	}
+	return StandbyRecover
+}
+
+// RecognizedShutdownReason reports whether reason is one the Breeze agent
+// itself sends on a graceful shutdown. An empty reason counts as recognized:
+// older agents send the intent without one, and they are still our agents.
+func RecognizedShutdownReason(reason string) bool {
+	switch reason {
+	case "", state.ReasonUserStop, state.ReasonUpdate, state.ReasonConfigReload:
+		return true
+	default:
+		return false
+	}
+}
+
+// StandbyWindow returns how long an announced shutdown with this reason is
+// tolerated before the watchdog acts.
+//
+// grace is the floor, an agent-declared ExpectedDuration can raise it, and
+// ceiling caps it. The declared duration is clamped in SECONDS before it is
+// multiplied into a time.Duration: a hostile or corrupt value would otherwise
+// overflow int64 nanoseconds and wrap to a negative window, which reads as
+// "already expired" and would restart the agent immediately.
+func StandbyWindow(reason string, expectedDurationSeconds int, grace, ceiling time.Duration) time.Duration {
+	if grace <= 0 {
+		grace = DefaultStandbyGrace
+	}
+	if ceiling <= 0 || ceiling < grace {
+		// A misconfigured ceiling must never shrink the window below the
+		// grace period; that would make every graceful stop a restart race.
+		ceiling = grace
+	}
+	if !RecognizedShutdownReason(reason) {
+		return ceiling
+	}
+	window := grace
+	if expectedDurationSeconds > 0 {
+		maxSeconds := int(ceiling / time.Second)
+		if expectedDurationSeconds > maxSeconds {
+			expectedDurationSeconds = maxSeconds
+		}
+		if declared := time.Duration(expectedDurationSeconds) * time.Second; declared > window {
+			window = declared
+		}
+	}
+	if window > ceiling {
+		window = ceiling
+	}
+	return window
+}

--- a/agent/internal/watchdog/standby.go
+++ b/agent/internal/watchdog/standby.go
@@ -85,6 +85,13 @@ type StandbyInput struct {
 // the transition table static and makes the policy table-testable without a
 // live agent, an init system, or a clock.
 func EvaluateStandby(in StandbyInput) StandbyDecision {
+	// Defence in depth. The only production caller already clamps via
+	// StandbyWindow, but a future caller passing an unclamped window would
+	// reintroduce the indefinite standby this function exists to prevent —
+	// and it would do so silently, with every test still green.
+	if in.Ceiling > 0 && in.Window > in.Ceiling {
+		in.Window = in.Ceiling
+	}
 	if !in.Recognized {
 		// An unfamiliar reason may describe genuinely long maintenance, so we
 		// wait out the full ceiling rather than guessing a short window.

--- a/agent/internal/watchdog/standby_config_parity_test.go
+++ b/agent/internal/watchdog/standby_config_parity_test.go
@@ -1,0 +1,36 @@
+package watchdog
+
+import (
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/config"
+)
+
+// TestStandbyGraceDefaultMatchesConfigDefault pins the duplicated default.
+//
+// internal/config cannot import this package (watchdog already imports config
+// for the net cache — that would be an import cycle), so DefaultStandbyGrace
+// is spelled out again in config.Default(). This test is what keeps the
+// two in step. A drift is not cosmetic: the watchdog would tolerate a stopped
+// agent for a different length of time than the shipped config documents,
+// which is the class of gap #5252 was.
+func TestStandbyGraceDefaultMatchesConfigDefault(t *testing.T) {
+	if got := config.Default().Watchdog.StandbyGrace; got != DefaultStandbyGrace {
+		t.Errorf("config.Default().Watchdog.StandbyGrace = %s, want DefaultStandbyGrace (%s)",
+			got, DefaultStandbyGrace)
+	}
+}
+
+// TestStandbyGraceIsWellBelowStandbyTimeout — the point of #5252 is that an
+// ordinary graceful stop no longer waits out the 30-minute ceiling. If the
+// grace period ever grew to meet the ceiling the stranding window would be
+// back, with nothing else failing.
+func TestStandbyGraceIsWellBelowStandbyTimeout(t *testing.T) {
+	wd := config.Default().Watchdog
+	if wd.StandbyGrace <= 0 {
+		t.Fatalf("StandbyGrace must be positive, got %s", wd.StandbyGrace)
+	}
+	if wd.StandbyGrace >= wd.StandbyTimeout {
+		t.Errorf("StandbyGrace (%s) must be shorter than StandbyTimeout (%s)", wd.StandbyGrace, wd.StandbyTimeout)
+	}
+}

--- a/agent/internal/watchdog/standby_test.go
+++ b/agent/internal/watchdog/standby_test.go
@@ -175,3 +175,21 @@ func TestStandbyWindowSurvivesMisconfiguration(t *testing.T) {
 		})
 	}
 }
+
+// TestEvaluateStandbyClampsAWindowPastTheCeiling — the production caller
+// clamps via StandbyWindow, but EvaluateStandby must not depend on that. An
+// unclamped window from a future caller would silently reintroduce the
+// indefinite standby of #5252 with every other test still green.
+func TestEvaluateStandbyClampsAWindowPastTheCeiling(t *testing.T) {
+	const ceiling = 30 * time.Minute
+	in := StandbyInput{
+		Elapsed:    ceiling + time.Minute,
+		Window:     10 * time.Hour, // absurd, unclamped
+		Ceiling:    ceiling,
+		Recognized: true,
+	}
+	if got := EvaluateStandby(in); got != StandbyRecover {
+		t.Errorf("EvaluateStandby(%+v) = %s, want %s — an over-long window must be clamped to the ceiling",
+			in, got, StandbyRecover)
+	}
+}

--- a/agent/internal/watchdog/standby_test.go
+++ b/agent/internal/watchdog/standby_test.go
@@ -1,0 +1,177 @@
+package watchdog
+
+import (
+	"testing"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/state"
+)
+
+// TestEvaluateStandby is the decision table behind #5252.
+//
+// The stranding failure was: agent announces a graceful stop, the installer
+// never starts it again, and the watchdog waits out a 30-minute standby and
+// then parks in FAILOVER — leaving a remote host offline with no management
+// path. The policy now has to distinguish four situations, and getting any of
+// them wrong is a production incident in one direction or the other:
+// restarting an agent that is mid-shutdown, or leaving a dead one dead.
+func TestEvaluateStandby(t *testing.T) {
+	const (
+		grace   = 2 * time.Minute
+		ceiling = 30 * time.Minute
+	)
+	tests := []struct {
+		name string
+		in   StandbyInput
+		want StandbyDecision
+	}{
+		{
+			name: "inside the window: the announced stop is still in progress",
+			in:   StandbyInput{Elapsed: 10 * time.Second, Window: grace, Ceiling: ceiling, Recognized: true},
+			want: StandbyHold,
+		},
+		{
+			name: "inside the window and the agent still looks alive: still hold",
+			// Health is deliberately NOT consulted before the window closes:
+			// an agent that announced a stop 10s ago still has a fresh
+			// heartbeat, and resuming on that would cancel every standby.
+			in:   StandbyInput{Elapsed: 10 * time.Second, Window: grace, Ceiling: ceiling, Recognized: true, AgentHealthy: true},
+			want: StandbyHold,
+		},
+		{
+			name: "window closed with the agent gone: escalate to the recovery ladder",
+			in:   StandbyInput{Elapsed: grace, Window: grace, Ceiling: ceiling, Recognized: true},
+			want: StandbyRecover,
+		},
+		{
+			name: "window closed but the shutdown never happened: resume monitoring",
+			in:   StandbyInput{Elapsed: grace + time.Second, Window: grace, Ceiling: ceiling, Recognized: true, AgentHealthy: true},
+			want: StandbyResume,
+		},
+		{
+			name: "unrecognized reason inside the ceiling: hold, do not guess a short window",
+			in:   StandbyInput{Elapsed: 5 * time.Minute, Window: grace, Ceiling: ceiling},
+			want: StandbyHold,
+		},
+		{
+			name: "unrecognized reason at the ceiling with the agent gone: ensure-start then failover",
+			in:   StandbyInput{Elapsed: ceiling, Window: grace, Ceiling: ceiling},
+			want: StandbyFailover,
+		},
+		{
+			name: "unrecognized reason at the ceiling but healthy: resume monitoring",
+			in:   StandbyInput{Elapsed: ceiling, Window: grace, Ceiling: ceiling, AgentHealthy: true},
+			want: StandbyResume,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := EvaluateStandby(tc.in); got != tc.want {
+				t.Errorf("EvaluateStandby(%+v) = %s, want %s", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestEvaluateStandbyNeverHoldsForeverOnAGoneAgent is the property that #5252
+// is really about: whatever the reason and whatever the config, a standby that
+// has outlived its ceiling with a dead agent must produce an action, never
+// another hold. A hold here is an offline host.
+func TestEvaluateStandbyNeverHoldsForeverOnAGoneAgent(t *testing.T) {
+	const ceiling = 30 * time.Minute
+	for _, recognized := range []bool{true, false} {
+		for _, window := range []time.Duration{0, time.Minute, ceiling} {
+			in := StandbyInput{
+				Elapsed:    ceiling + time.Second,
+				Window:     window,
+				Ceiling:    ceiling,
+				Recognized: recognized,
+			}
+			if got := EvaluateStandby(in); got == StandbyHold {
+				t.Errorf("EvaluateStandby(%+v) = hold — a stranded host would stay offline", in)
+			}
+		}
+	}
+}
+
+func TestRecognizedShutdownReason(t *testing.T) {
+	tests := []struct {
+		reason string
+		want   bool
+	}{
+		{state.ReasonUserStop, true},
+		{state.ReasonUpdate, true},
+		{state.ReasonConfigReload, true},
+		{"", true}, // older agents send no reason; still our agent
+		{"scheduled_maintenance", false},
+		{"something_a_future_version_invents", false},
+	}
+	for _, tc := range tests {
+		if got := RecognizedShutdownReason(tc.reason); got != tc.want {
+			t.Errorf("RecognizedShutdownReason(%q) = %v, want %v", tc.reason, got, tc.want)
+		}
+	}
+}
+
+// TestStandbyWindow pins the window arithmetic, including the overflow clamp:
+// ExpectedDuration arrives over IPC as an int of seconds, and multiplying a
+// large one into time.Duration wraps int64 nanoseconds NEGATIVE — which reads
+// as "already expired" and would restart the agent instantly, the exact
+// opposite of what a long declared maintenance asked for.
+func TestStandbyWindow(t *testing.T) {
+	const (
+		grace   = 2 * time.Minute
+		ceiling = 30 * time.Minute
+	)
+	tests := []struct {
+		name     string
+		reason   string
+		expected int
+		want     time.Duration
+	}{
+		{"recognized reason with no declared duration uses the grace period", state.ReasonUserStop, 0, grace},
+		{"a short declared duration cannot shrink the grace period", state.ReasonUpdate, 5, grace},
+		{"a longer declared duration is honoured", state.ReasonUpdate, 600, 10 * time.Minute},
+		{"a declared duration past the ceiling is capped", state.ReasonUpdate, 3600, ceiling},
+		{"an unrecognized reason waits out the ceiling", "scheduled_maintenance", 0, ceiling},
+		{"an int64-overflowing declared duration is clamped, not wrapped", state.ReasonUpdate, 1 << 40, ceiling},
+		{"a negative declared duration is ignored", state.ReasonUpdate, -1, grace},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := StandbyWindow(tc.reason, tc.expected, grace, ceiling)
+			if got != tc.want {
+				t.Errorf("StandbyWindow(%q, %d, %s, %s) = %s, want %s",
+					tc.reason, tc.expected, grace, ceiling, got, tc.want)
+			}
+			if got <= 0 {
+				t.Errorf("window must always be positive, got %s", got)
+			}
+		})
+	}
+}
+
+// TestStandbyWindowSurvivesMisconfiguration — a zero or nonsensical config
+// must never produce a window that has already expired, because that turns
+// every graceful stop into an immediate restart race.
+func TestStandbyWindowSurvivesMisconfiguration(t *testing.T) {
+	tests := []struct {
+		name    string
+		grace   time.Duration
+		ceiling time.Duration
+	}{
+		{"both unset", 0, 0},
+		{"grace unset", 0, 30 * time.Minute},
+		{"ceiling unset", 2 * time.Minute, 0},
+		{"ceiling below grace", 2 * time.Minute, time.Second},
+		{"negative values", -time.Minute, -time.Hour},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := StandbyWindow(state.ReasonUserStop, 0, tc.grace, tc.ceiling); got <= 0 {
+				t.Errorf("StandbyWindow with grace=%s ceiling=%s = %s; must be positive",
+					tc.grace, tc.ceiling, got)
+			}
+		})
+	}
+}

--- a/agent/internal/watchdog/watchdog.go
+++ b/agent/internal/watchdog/watchdog.go
@@ -42,8 +42,19 @@ var transitions = map[string]map[string]string{
 		EventIPCConnected:      StateMonitoring,
 		EventRecoveryExhausted: StateFailover,
 	},
+	// STANDBY is entered when the agent announces a graceful shutdown. It is
+	// deliberately deaf to health signals for the duration of the announced
+	// window (see EvaluateStandby) — the agent is SUPPOSED to be gone — but it
+	// must still be able to leave once that window closes. Before #5252 it
+	// could not: agent_unhealthy and ipc_connected had no edge here, so the
+	// process-gone tick that follows every graceful stop, and the reconnect
+	// that follows every successful upgrade, were both silently dropped. A
+	// host stopped by `service install` sat unmanaged for the whole 30-minute
+	// standby timeout and then parked in FAILOVER, still stopped.
 	StateStandby: {
 		EventAgentRecovered: StateMonitoring,
+		EventIPCConnected:   StateMonitoring,
+		EventAgentUnhealthy: StateRecovering,
 		EventStandbyTimeout: StateFailover,
 		EventStartAgent:     StateRecovering,
 	},
@@ -61,6 +72,7 @@ type Config struct {
 	MaxRecoveryAttempts     int
 	RecoveryCooldown        time.Duration
 	StandbyTimeout          time.Duration
+	StandbyGrace            time.Duration
 	FailoverPollInterval    time.Duration
 }
 

--- a/agent/internal/watchdog/watchdog_test.go
+++ b/agent/internal/watchdog/watchdog_test.go
@@ -215,3 +215,46 @@ func TestStateHistory(t *testing.T) {
 		}
 	}
 }
+
+// TestStandbyTransitions is the table-driven guard for #5252.
+//
+// A graceful agent stop moves the watchdog MONITORING → STANDBY. Before this
+// fix STANDBY accepted only agent_recovered / standby_timeout / start_agent,
+// so the process-gone signal that arrives moments later (the agent really did
+// exit) was SILENTLY DROPPED, and so was the ipc_connected edge that fires
+// when the agent comes back after an upgrade. A host whose agent was stopped
+// by `service install` therefore sat unmanaged for the full 30-minute standby
+// timeout and then parked in FAILOVER — still stopped.
+//
+// STANDBY must now be able to reach both RECOVERING (the agent is gone and is
+// not coming back on its own) and MONITORING (the agent came back).
+func TestStandbyTransitions(t *testing.T) {
+	tests := []struct {
+		name  string
+		event string
+		want  string
+	}{
+		{"agent process gone during standby escalates to recovery", EventAgentUnhealthy, StateRecovering},
+		{"agent reconnected over IPC returns to monitoring", EventIPCConnected, StateMonitoring},
+		{"verified-healthy agent returns to monitoring", EventAgentRecovered, StateMonitoring},
+		{"standby window exhausted parks in failover", EventStandbyTimeout, StateFailover},
+		{"server-delivered start command drives recovery", EventStartAgent, StateRecovering},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := NewWatchdog(DefaultTestConfig())
+			w.HandleEvent(EventIPCConnected)   // CONNECTING → MONITORING
+			w.HandleEvent(EventShutdownIntent) // MONITORING → STANDBY
+			if w.State() != StateStandby {
+				t.Fatalf("setup failed: state = %s, want %s", w.State(), StateStandby)
+			}
+			next, ok := w.HandleEvent(tc.event)
+			if !ok {
+				t.Fatalf("STANDBY dropped event %q — the watchdog cannot react to it at all", tc.event)
+			}
+			if next != tc.want {
+				t.Fatalf("STANDBY + %q = %s, want %s", tc.event, next, tc.want)
+			}
+		})
+	}
+}

--- a/agent/scripts/install/install-linux.sh
+++ b/agent/scripts/install/install-linux.sh
@@ -94,9 +94,19 @@ fi
 # also runs against hosts where no NEW watchdog binary was staged above — in
 # which case the OLD binary's install still only enables — so the explicit
 # restart stays as the belt-and-braces path.
+#
+# The call is GUARDED. Since #5252 `breeze-watchdog service install` exits
+# non-zero when it cannot restart the watchdog, and this script runs under
+# `set -e` — so a bare call would abort the installer here, long before the
+# breeze-agent restart at the bottom, and leave the agent stopped. That is the
+# very stranding this script is being changed to prevent, just reached through
+# the watchdog leg. A watchdog problem must never block the agent.
 if [ -f "/usr/local/bin/breeze-watchdog" ]; then
     echo "Registering watchdog service..."
-    /usr/local/bin/breeze-watchdog service install
+    if ! /usr/local/bin/breeze-watchdog service install; then
+        echo "Warning: watchdog service install failed — continuing so the agent is still installed and started." >&2
+        echo "         Recover the watchdog with: sudo /usr/local/bin/breeze-watchdog service install" >&2
+    fi
     echo "Starting watchdog service..."
     systemctl restart breeze-watchdog || true
 fi

--- a/agent/scripts/install/install-linux.sh
+++ b/agent/scripts/install/install-linux.sh
@@ -17,7 +17,17 @@ fi
 echo "Installing Breeze Agent..."
 
 # Stop existing service before replacing binary (safe for upgrades).
+#
+# Whether it was RUNNING is sampled BEFORE the stop: this script decides at the
+# end whether to start it again, and asking afterwards only ever reports the
+# state this stop produced. That inversion stranded a remote host in #5252 —
+# the installer stopped the agent, printed "Next steps: 1. Start", and left the
+# box offline with no management path back in.
+AGENT_WAS_RUNNING=0
 if [ -f "$SERVICE_DST" ]; then
+    if systemctl is-active --quiet breeze-agent; then
+        AGENT_WAS_RUNNING=1
+    fi
     if systemctl stop breeze-agent 2>&1; then
         echo "Stopped existing Breeze Agent service."
     else
@@ -80,8 +90,10 @@ fi
 # absent, else just restart" path silently skipped those edits, so an upgraded
 # host kept its stale watchdog unit and stayed one reboot away from a
 # 226/NAMESPACE wedge. `service install` is idempotent, so always calling it is
-# safe. It stops the service while writing the unit but does not start it, so we
-# (re)start explicitly afterward.
+# safe. Since #5252 `service install` restarts the unit itself, but this script
+# also runs against hosts where no NEW watchdog binary was staged above — in
+# which case the OLD binary's install still only enables — so the explicit
+# restart stays as the belt-and-braces path.
 if [ -f "/usr/local/bin/breeze-watchdog" ]; then
     echo "Registering watchdog service..."
     /usr/local/bin/breeze-watchdog service install
@@ -175,17 +187,37 @@ echo "Breeze Agent installed."
 echo ""
 
 # If the agent is already enrolled, skip the enrollment step in Next Steps.
+AGENT_ENROLLED=0
 if [ -f "$CONFIG_DIR/agent.yaml" ] && grep -q 'agent_id:' "$CONFIG_DIR/agent.yaml" 2>/dev/null; then
-    echo "Next steps:"
-    echo "  1. Start:   sudo systemctl start breeze-agent"
-    echo "  2. Status:  sudo systemctl status breeze-agent"
-    echo "  3. Logs:    journalctl -u breeze-agent -f"
-    echo "  4. User helper: systemctl --user enable breeze-agent-user (per-user)"
-else
-    echo "Next steps:"
-    echo "  1. Enroll:  sudo breeze-agent enroll <enrollment-key> --server https://your-server [--enrollment-secret <secret>]"
-    echo "  2. Start:   sudo systemctl start breeze-agent"
-    echo "  3. Status:  sudo systemctl status breeze-agent"
-    echo "  4. Logs:    journalctl -u breeze-agent -f"
-    echo "  5. User helper: systemctl --user enable breeze-agent-user (per-user)"
+    AGENT_ENROLLED=1
 fi
+
+# Start the agent when it was running before this install, or when the host is
+# already enrolled. Deliberately AFTER the breeze group, /run/breeze and the
+# tmpfiles snippet above: the agent inherits its group list and opens its IPC
+# socket at startup. A fresh un-enrolled host is left stopped — there is
+# nothing for it to talk to yet.
+if [ "$AGENT_WAS_RUNNING" -eq 1 ] || [ "$AGENT_ENROLLED" -eq 1 ]; then
+    echo "Starting Breeze Agent service..."
+    if systemctl restart breeze-agent; then
+        echo "Breeze Agent service started."
+        echo ""
+        echo "Helpful commands:"
+        echo "  Status:  sudo systemctl status breeze-agent"
+        echo "  Logs:    journalctl -u breeze-agent -f"
+        echo "  User helper: systemctl --user enable breeze-agent-user (per-user)"
+        exit 0
+    fi
+    echo "ERROR: the Breeze Agent service was stopped for this install and could NOT be started again." >&2
+    echo "       This host is not being managed until it starts. Recover with:" >&2
+    echo "         sudo systemctl start breeze-agent" >&2
+    echo "         sudo journalctl -u breeze-agent -n 100 --no-pager" >&2
+    exit 1
+fi
+
+echo "Next steps:"
+echo "  1. Enroll:  sudo breeze-agent enroll <enrollment-key> --server https://your-server [--enrollment-secret <secret>]"
+echo "  2. Start:   sudo systemctl start breeze-agent"
+echo "  3. Status:  sudo systemctl status breeze-agent"
+echo "  4. Logs:    journalctl -u breeze-agent -f"
+echo "  5. User helper: systemctl --user enable breeze-agent-user (per-user)"

--- a/apps/docs/src/content/docs/agents/advanced-install.mdx
+++ b/apps/docs/src/content/docs/agents/advanced-install.mdx
@@ -213,7 +213,11 @@ The agent refuses to enroll with an empty hostname — if your provisioning pipe
 | `--no-watchdog` | all | Skip auto-fetching and registering the watchdog. Use for air-gapped hosts where the agent cannot reach GitHub releases. |
 | `--with-user-helper` | Linux, macOS | Also install the per-user desktop helper unit (systemd user unit / LaunchAgent). Not needed on Windows — the helper is spawned per-session by the service. |
 
-`service install` is safe to re-run — it overwrites the binary at the install path, restarts the agent service, and registers any missing watchdog. Use this to add the watchdog to a previously agent-only install. To install only the watchdog without touching the agent, run `breeze-watchdog service install` directly.
+`service install` is safe to re-run — it overwrites the binary at the install path, records whether the agent service was running beforehand, and rewrites and re-enables the unit. It starts the service again if it was running before the install or the host is already enrolled; a fresh, unenrolled host is left stopped until you enroll it. If the service was stopped for the install and can't be started again, the command now fails with recovery instructions rather than exiting successfully. It also registers any missing watchdog, which is always restarted so a newly staged binary takes over. Use this to add the watchdog to a previously agent-only install. To install only the watchdog without touching the agent, run `breeze-watchdog service install` directly.
+
+<Aside type="note">
+On agent v0.110.0 and earlier, `service install` stopped the service and did not start it again. On those versions, follow it with `sudo systemctl restart breeze-agent breeze-watchdog` (Linux), or prefer the in-band auto-update instead.
+</Aside>
 
 `service uninstall` stops and removes both the agent and the watchdog services, but does **not** remove `agent.yaml` or `secrets.yaml` — wipe `/etc/breeze`, `/Library/Application Support/Breeze`, or `C:\ProgramData\Breeze` manually if you want a clean uninstall.
 

--- a/apps/docs/src/content/docs/agents/installation.mdx
+++ b/apps/docs/src/content/docs/agents/installation.mdx
@@ -209,7 +209,11 @@ When running `breeze-agent service install` manually, the agent fetches the matc
 
 On macOS the desktop helper is resolved the same way: `breeze-agent service install` uses a `breeze-desktop-helper` binary staged next to the agent if there is one, and otherwise downloads the matching-version signed binary from GitHub releases. If neither is available (for example on an air-gapped host), the install prints a warning and continues -- the agent service is still installed and running, and only the helper's features are unavailable until you place the binary next to `breeze-agent` and re-run `service install`. The agent binary is never installed under the helper's name: doing so would give the helper the agent's code-signing identity, and macOS would drop the Screen Recording and Accessibility grants once a real helper replaced it. The macOS `.pkg` always ships the signed helper, so this only affects raw-binary installs.
 
-If a previously agent-only install needs the watchdog added, re-run `breeze-agent service install`. This reinstalls the agent binary and restarts the agent service (safe for upgrades) and registers the missing watchdog. To add *only* the watchdog without touching the agent service, run `breeze-watchdog service install` directly.
+If a previously agent-only install needs the watchdog added, re-run `breeze-agent service install`. It records whether the agent service was running before the install, rewrites and re-enables the unit, and starts the service again if it was running before or the host is already enrolled -- a fresh, unenrolled host is left stopped until you enroll it. If the service was stopped for the install and can't be started again, the command now fails with recovery instructions instead of exiting successfully. It also registers the missing watchdog, which is always restarted so a newly staged binary takes over. To add *only* the watchdog without touching the agent service, run `breeze-watchdog service install` directly.
+
+<Aside type="note">
+On agent v0.110.0 and earlier, `service install` stopped the service and did not start it again. On those versions, follow it with `sudo systemctl restart breeze-agent breeze-watchdog` (Linux), or prefer the in-band auto-update instead.
+</Aside>
 
 ---
 

--- a/apps/docs/src/content/docs/agents/self-host-migration.mdx
+++ b/apps/docs/src/content/docs/agents/self-host-migration.mdx
@@ -65,8 +65,12 @@ agent's configuration to keep the device's identity — see step 2).
      the agent re-enrolls as a new device record instead.
    - **macOS / Linux** — run the install script over the existing
      installation, or replace the binary and run
-     `breeze-agent service install`, which reinstalls the binary and restarts
-     the service without re-enrolling. See
+     `breeze-agent service install`, which reinstalls the binary and, because
+     the device is already enrolled, starts the service again automatically
+     without re-enrolling. (On agent v0.110.0 and earlier, `service install`
+     stopped the service without restarting it — on those versions, follow it
+     with `sudo systemctl restart breeze-agent breeze-watchdog`, or prefer the
+     in-band auto-update instead.) See
      [Agent Installation](/agents/installation/) for the full commands.
 
 3. Let the device check in. The agent reports its edition on every check-in,

--- a/apps/docs/src/content/docs/features/watchdog.mdx
+++ b/apps/docs/src/content/docs/features/watchdog.mdx
@@ -46,7 +46,7 @@ The watchdog operates as a state machine with five states:
 | **Connecting** | Starting up, attempting to establish IPC connection to the agent |
 | **Monitoring** | Agent is healthy; running periodic health checks |
 | **Recovering** | Agent is unhealthy; performing escalating restart attempts |
-| **Standby** | Agent signaled a graceful shutdown (e.g., for an update); waiting for it to come back |
+| **Standby** | Agent signaled a graceful shutdown (e.g., for an update); waiting a bounded window for it to come back |
 | **Failover** | Recovery attempts exhausted; watchdog is communicating directly with the Breeze server on behalf of the device |
 
 ### State transitions
@@ -54,22 +54,33 @@ The watchdog operates as a state machine with five states:
 ```
 CONNECTING ──ipc connected──→ MONITORING
 CONNECTING ──agent not found─→ RECOVERING
+CONNECTING ──agent unhealthy─→ RECOVERING
 
 MONITORING ──agent unhealthy─→ RECOVERING
 MONITORING ──shutdown intent─→ STANDBY
 
 RECOVERING ──agent recovered─→ MONITORING
+RECOVERING ──ipc connected───→ MONITORING
 RECOVERING ──recovery exhausted──→ FAILOVER
 
 STANDBY ────agent recovered──→ MONITORING
+STANDBY ────ipc connected────→ MONITORING
+STANDBY ────agent unhealthy──→ RECOVERING
 STANDBY ────standby timeout──→ FAILOVER
 STANDBY ────start agent──────→ RECOVERING
 
 FAILOVER ───agent recovered──→ MONITORING
+FAILOVER ───ipc connected────→ MONITORING
 ```
 
 <Aside>
-  The **Standby** state handles planned agent downtime — for example, when the agent shuts itself down to apply a self-update. The watchdog waits for the configured standby timeout before escalating to failover, giving the update time to complete.
+  The **Standby** state handles planned agent downtime — for example, when the agent shuts itself down to apply a self-update. Health signals are ignored for the duration of the announced window, so the watchdog does not fight the very restart the agent asked for.
+
+  That window is bounded. Once it closes, the watchdog acts: if the agent is back and healthy it returns to **Monitoring**, and if the agent is still gone it escalates to **Recovering** and starts it. A shutdown reason the agent itself sends (a user stop, a self-update, a config reload) uses the short **standby grace** window; an unrecognised reason is held to the longer **standby timeout** ceiling and then parks in **Failover** — but only after a best-effort start, so a host is never left stopped indefinitely.
+</Aside>
+
+<Aside type="caution">
+  Because the watchdog restarts an agent that stays down past its standby window, `breeze-agent service stop` is **temporary** while the watchdog is installed — the agent comes back after the standby grace period. To stop the agent durably, stop or uninstall the watchdog as well.
 </Aside>
 
 ---
@@ -141,12 +152,13 @@ The watchdog reads its configuration from the same config directory as the agent
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| Process check interval | 10 s | How often to check if the agent process is alive |
-| IPC probe interval | 15 s | How often to ping the agent over IPC |
-| Heartbeat stale threshold | 5 min | How long since the last heartbeat before the agent is considered stale |
+| Process check interval | 5 s | How often to check if the agent process is alive |
+| IPC probe interval | 30 s | How often to ping the agent over IPC |
+| Heartbeat stale threshold | 3 min | How long since the last heartbeat before the agent is considered stale |
 | Max recovery attempts | 3 | Number of escalating recovery tries before entering failover |
 | Recovery cooldown | 10 min | Window in which recovery attempts are counted; resets after expiry |
-| Standby timeout | 5 min | How long to wait in standby before escalating to failover |
+| Standby grace | 2 min | How long an announced shutdown the agent itself signalled is tolerated before the watchdog starts the agent again |
+| Standby timeout | 30 min | Ceiling on any standby. Applies in full only to an unrecognised shutdown reason; the agent's own reasons use the standby grace above |
 | Failover poll interval | 30 s | How often to poll the server for commands during failover |
 
 ---


### PR DESCRIPTION
Closes #5252

## The bug

`breeze-agent service install` ran `systemctl stop breeze-agent`, rewrote and enabled the unit, and **never started it**. On an already-enrolled remote Linux host whose only management path is the agent itself, that stranded the box — the device went Offline and stayed Offline until someone reached it over SSH or a console. The watchdog did not recover it either.

Reported by SemoTech on a self-hosted v0.110.0 stack, Ubuntu 24.04 host previously enrolled on 0.104.0.

**Verified** (read directly from the code at the reported version):
- `service install` had no `systemctl start` anywhere. Its post-install "is it running?" check ran *after* its own stop, so it could only ever read "not running", and it printed `Next steps: 1. Start` and exited 0.
- macOS had the same shape: `launchctl unload`, never bootstrapped back.
- `scripts/install/install-linux.sh` had the same hole for the agent (it already restarted the watchdog).
- `breeze-watchdog service install` on Linux also stopped and only enabled — which is why the reporting host kept running a **v0.104.0 watchdog process** while the v0.110.0 binary sat on disk.
- On the watchdog side, the graceful stop's shutdown intent moved MONITORING → STANDBY, and STANDBY's transition table accepted neither `agent_unhealthy` nor `ipc_connected`, so the process-gone tick was silently dropped. STANDBY timed out after 30 minutes into FAILOVER, and that was the one FAILOVER edge that did **not** call `ensureAgentStartedBeforeFailover`. `ExpectedDuration` on the intent was read by nothing.
- Windows unaffected on both halves.

## The fix

### Install side — Linux, macOS, `install-linux.sh`, watchdog

- Sample whether the unit was **ACTIVE before the stop**, and use that to decide. Asking afterwards is the inverted check that shipped the bug.
- After reload + enable, **restart** the service when it was running before **OR** the host is already enrolled. `restart` rather than `start` so it is correct whether or not something else started the unit in between, and so the freshly copied binary is definitely the one running. A fresh un-enrolled host is still deliberately left stopped.
- A start that fails *after* the install stopped the service is now a **non-zero exit** with recovery instructions, not a silent exit 0 — that silence is how this went unnoticed until the device showed Offline. It is reported after the watchdog bootstrap so the watchdog still gets installed.
- IPC prerequisites (the `breeze` group and `/var/run/breeze`) are created **before** the start: the agent inherits its group list and opens its IPC socket at startup, so a start ahead of them comes up without a usable socket. Guarded by an ordering test.
- `breeze-watchdog service install` on Linux now always ends in a restart. Unconditional, because a watchdog has no credentials to wait for and an installed-but-not-started watchdog is exactly the failure here. macOS already bootstrapped; only Linux was missing it. This also fixes `bootstrapWatchdog`, which shells out to that same command.
- `install-linux.sh` keeps its explicit `systemctl restart breeze-watchdog`: the script can run on a host where no *new* watchdog binary was staged, in which case the old binary's `service install` still only enables.

### Watchdog side

- STANDBY gains `agent_unhealthy → RECOVERING` and `ipc_connected → MONITORING`.
- A **recognized** shutdown reason (`user_stop` / `update` / `config_reload` / empty) is now bounded by a new `standby_grace` (default **2 minutes**, configurable) instead of the 30-minute `standby_timeout`, which becomes the ceiling. An agent-declared `ExpectedDuration` — previously dead code — can raise the window, clamped **in seconds before conversion** so a hostile or corrupt value cannot overflow int64 nanoseconds into a negative (already-expired) window.
- The STANDBY → FAILOVER edge now issues `ensureAgentStartedBeforeFailover` like every other FAILOVER edge, and only on an *accepted* transition, so the budget-free start cannot repeat on every tick.
- All standby policy lives in one pure `EvaluateStandby`, consulted both by the per-tick STANDBY block **and** by the funnel every "the agent looks dead" signal now passes through — so a tick cannot bypass the policy the expiry check applies.
- Health is deliberately **not** consulted before the window closes: an agent that announced a stop seconds ago still has a fresh heartbeat, and resuming on that would cancel every standby it just asked for. After the window, live IPC **plus** a fresh heartbeat (the same evidence FAILOVER self-recovery uses) means the shutdown never actually happened → back to MONITORING instead of a pointless restart.
- Expiry hands off to the normal RECOVERING ladder rather than duplicating the restart budget, so flap detection and the existing ensure-start-before-FAILOVER keep owning that decision.

### Docs

- The three pages claiming `service install` "restarts the agent service (safe for upgrades)" now describe what it actually does, with interim guidance for v0.110.0 and earlier.
- `features/watchdog.mdx` documented the old STANDBY behaviour. Its state diagram now matches the transition table (including edges it was already missing for CONNECTING/RECOVERING/FAILOVER), the standby section describes the bounded window and the escalation, and the config table gains `standby_grace`. **Four of its seven listed defaults did not match `config.Default()`** (process check 10s→5s, IPC probe 15s→30s, heartbeat stale 5m→3m, standby timeout 5m→30m) and are corrected in passing.

### Behaviour change worth knowing

**`breeze-agent service stop` is now temporary while the watchdog is installed** — the agent comes back after ~2 minutes. Previously it was permanent, which *is* the stranding bug. For a durable stop, stop or uninstall the watchdog too. Deliberately **not** gated on "is the systemd unit enabled": unit enablement describes boot activation, not whether watchdog recovery is wanted. A persistent watchdog pause/maintenance flag is the right long-term mechanism and is **not** in this PR.

**Inferred, not verified:** the reporter's watchdog surviving on the old process was most likely an earlier failed watchdog bootstrap; the watchdog-install fix here covers the path regardless.

**Adjacent issue observed, deliberately not fixed here:** `service_cmd_windows.go` prints the same "The agent service is installed and running" line after a watchdog-bootstrap failure, and Windows `service install` does not start the service either (it creates it `StartAutomatic`, which starts at *boot*). The issue scopes Windows out and the MSI is the supported Windows install path, so changing Windows install behaviour is left alone rather than expanded into. Flagging it rather than leaving it silent.

**Known limitation, pre-existing and unchanged:** a process-gone tick can in principle beat a queued shutdown intent into the select loop, landing in RECOVERING where the intent has no edge. Closing that needs an acknowledged-intent protocol; out of scope here.

## Design review

Consequential (agent-shipped, hard to reverse), so it went through the advisor quorum. Codex `gpt-6-astra` at high effort reviewed the design independently and materially changed it: health evidence must be stronger than `IsConnected()` (a socket flag can still describe an agent on its way out); the policy must be one function consulted by both call paths rather than two consistent-by-hope checks; the `ExpectedDuration` seconds clamp must precede the `time.Duration` conversion; and expiry must not re-derive the recovery budget, because `recovery.Reset()` only runs in MONITORING and a standby entered right after a verified recovery could carry stale attempts. All four are in the code above.

## Verification

- **Red-first, and each guard mutation-tested** — the install argv test fails with exactly `argv sequence = "systemctl daemon-reload | systemctl enable breeze-agent"` when the restart is removed; `EvaluateStandby` forced to always-hold reds 14 assertions; removing the seconds clamp reds only the overflow case; removing the agent start from `install-linux.sh` reds the script guards. The two new STANDBY edges were written as failing transition tests against the old table first.
- `go test -race ./internal/agentapp/... ./internal/watchdog/... ./cmd/breeze-watchdog/... ./internal/config/...` — green (darwin).
- Full `go test ./...` — 74 packages green (darwin).
- Full `go test ./...` under **GOOS=linux in a golang:1.27 container** — green except two container artifacts in packages this branch does not touch (`systemstate` needs real `/proc/cpuinfo` + systemd; `TestConfigureRunAsElevatedWhenNotRoot` cannot hold when docker runs as root). Both pass on ubuntu-latest.
- `go vet ./...` clean on darwin **and** `GOOS=linux` (which type-checks the linux-only `_test.go` files that darwin never compiles).
- `golangci-lint v2.12.2` — **0 issues in any file this branch touches**.
- `bash -n scripts/install/install-linux.sh` clean; `npx astro check` on the docs — 0 errors, 0 warnings.

Not verified: no real Linux/macOS host was upgraded end to end. The systemd/launchd argv sequences are asserted through an injected runner, not executed against a live init system. A Linux canary retest is the reporter's stated gate.

## Release note for self-hosters

> **Linux/macOS agent upgrade behaviour changed.** `breeze-agent service install` (and `install-linux.sh`) now **start** the agent service after installing it when the host is already enrolled or the service was running beforehand — previously they stopped it and left it stopped, which could take a remote host offline. `breeze-watchdog service install` now restarts the watchdog so a newly staged binary actually takes over. A start that fails now exits non-zero instead of silently succeeding. Consequently, `breeze-agent service stop` is temporary while the watchdog is installed: the watchdog restarts a stopped agent after ~2 minutes (new `watchdog.standby_grace`, default `2m`; the existing `watchdog.standby_timeout` is now the ceiling). To stop the agent durably, stop or uninstall the watchdog as well. Windows is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGT9BJVfpG3nyM6c9koAN8
