### PR TITLE
fix(api): stop metric-anomaly runs piling up on metric_rollups (#5283)

### DIFF
--- a/apps/api/scripts/metric-anomaly-backfill.ts
+++ b/apps/api/scripts/metric-anomaly-backfill.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env tsx
-import { closeDb, withSystemDbAccessContext } from '../src/db';
+import { closeDb } from '../src/db';
 import { detectMetricAnomaliesRange } from '../src/services/metricAnomalies';
 import { parseMetricAnomalyBackfillArgs } from './metric-anomaly-backfill.lib';
 
@@ -17,18 +17,36 @@ async function main(): Promise<void> {
     return;
   }
 
-  const result = await withSystemDbAccessContext(() =>
-    detectMetricAnomaliesRange({
-      orgId: options.orgId,
-      from: options.from,
-      to: options.to,
-    })
-  );
+  // No outer `withSystemDbAccessContext` (#5283): `detectMetricAnomaliesRange`
+  // opens a fresh system-scoped transaction per detection stage. Wrapping it
+  // here would have every stage early-return into this one ambient transaction
+  // and silently rebuild the single long-lived transaction the split exists to
+  // eliminate.
+  const result = await detectMetricAnomaliesRange({
+    orgId: options.orgId,
+    from: options.from,
+    to: options.to,
+  });
 
+  // A skip is no longer synonymous with "flag off" (#5283) — it also covers a
+  // run that lost the org advisory lock or exceeded its wait bounds. Naming the
+  // reason matters here: "disabled" tells an operator to change a setting,
+  // while "locked" tells them to re-run, and the old message asserted the first
+  // for both.
+  const incomplete = result.stages.filter((stage) => stage.outcome !== 'completed');
   if (result.skipped) {
-    // Feature flag off for this org — no anomalies were written. Warn loudly on stderr
-    // so an operator does not mistake a no-op for a completed backfill.
-    console.warn('[metric-anomaly-backfill] SKIPPED: metric anomaly detection is disabled for this org; nothing written.');
+    const reason = result.skippedReason ?? 'unknown';
+    const explanation = reason === 'ml-disabled'
+      ? 'metric anomaly detection is disabled for this org'
+      : reason === 'locked'
+        ? 'another detection run holds this org\'s advisory lock — re-run once it finishes'
+        : 'every detection stage exceeded its wait bound — re-run, and check for lock contention on metric_rollups';
+    console.warn(`[metric-anomaly-backfill] SKIPPED (${reason}): ${explanation}; nothing written.`);
+  } else if (incomplete.length > 0) {
+    console.warn(
+      `[metric-anomaly-backfill] PARTIAL: ${result.statements} stage(s) committed, `
+        + `${incomplete.map((stage) => `${stage.stage}=${stage.outcome}`).join(', ')}. Re-run to cover the rest.`,
+    );
   } else {
     console.log('[metric-anomaly-backfill] Completed.');
   }

--- a/apps/api/src/__tests__/integration/metricAnomalies.integration.test.ts
+++ b/apps/api/src/__tests__/integration/metricAnomalies.integration.test.ts
@@ -1,11 +1,14 @@
 import './setup';
 
 import { beforeEach, describe, expect, it } from 'vitest';
-import { and, eq } from 'drizzle-orm';
+import { and, eq, sql } from 'drizzle-orm';
 
 import { withSystemDbAccessContext } from '../../db';
 import { alerts, devices, metricAnomalies, metricRollups, organizations } from '../../db/schema';
-import { detectMetricAnomaliesRange } from '../../services/metricAnomalies';
+import {
+  METRIC_ANOMALY_LOCK_NAMESPACE,
+  detectMetricAnomaliesRange,
+} from '../../services/metricAnomalies';
 import { promoteMetricAnomalyToAlert } from '../../services/metricAnomalyPromotion';
 import { createOrganization, createPartner, createSite } from './db-utils';
 import { getTestDb } from './setup';
@@ -88,8 +91,12 @@ function bucketAt(base: Date, offsetBuckets: number): Date {
   return new Date(base.getTime() + offsetBuckets * RAW_BUCKET_SECONDS * 1000);
 }
 
+// No outer context (#5283): detectMetricAnomaliesRange opens its own
+// system-scoped transaction per stage. Wrapping it here would collapse them
+// back into one ambient transaction and stop this suite exercising the shape
+// that actually ships.
 async function runDetection(orgId: string, from: Date, to: Date): Promise<void> {
-  await withSystemDbAccessContext(() => detectMetricAnomaliesRange({ orgId, from, to }));
+  await detectMetricAnomaliesRange({ orgId, from, to });
 }
 
 async function selectAnomalies(orgId: string, deviceId: string) {
@@ -397,5 +404,155 @@ describe('metric anomalies integration', () => {
     expect(all).toHaveLength(2);
     expect(all.every((a) => a.linkedAlertId === first.alertId)).toBe(true);
     expect(all.every((a) => a.status === 'promoted')).toBe(true);
+  });
+});
+
+// #5283: the production incident was overlapping runs of the same
+// metric_rollups baseline query, one parked in a `Lock` wait for 29+ minutes
+// while another executed. Advisory-lock behaviour cannot be proven with a
+// mocked db — whether a second run BLOCKS or returns is decided by Postgres —
+// so the guard gets a real-database proof here.
+describe('metric anomaly overlap guard (#5283)', () => {
+  let orgA: string;
+  let orgB: string;
+
+  beforeEach(async () => {
+    const partner = await createPartner();
+    orgA = (await createOrganization({ partnerId: partner.id, name: 'Lock Guard Org A' })).id;
+    orgB = (await createOrganization({ partnerId: partner.id, name: 'Lock Guard Org B' })).id;
+    await enableAnomalies(orgA);
+    await enableAnomalies(orgB);
+  });
+
+  const from = new Date('2026-06-18T18:00:00.000Z');
+  const to = new Date('2026-06-18T18:15:00.000Z');
+
+  /**
+   * Hold the org's detection lock on a SEPARATE connection for the duration of
+   * `body`, exactly as an in-flight run would. Advisory locks are scoped to a
+   * session/transaction, not to a role, so this genuinely contends with the
+   * app-pool connection the detector runs on.
+   */
+  async function whileOrgLockHeld<T>(orgId: string, body: () => Promise<T>): Promise<T> {
+    let captured: T;
+    await getTestDb().transaction(async (tx) => {
+      await tx.execute(
+        sql`SELECT pg_advisory_xact_lock(${METRIC_ANOMALY_LOCK_NAMESPACE}, hashtext(${orgId}))`,
+      );
+      captured = await body();
+    });
+    return captured!;
+  }
+
+  it('skips the run instead of queueing behind an in-flight run for the same org', async () => {
+    const startedAt = Date.now();
+    const result = await whileOrgLockHeld(orgA, () => detectMetricAnomaliesRange({ orgId: orgA, from, to }));
+    const elapsedMs = Date.now() - startedAt;
+
+    expect(result).toMatchObject({ skipped: true, skippedReason: 'locked', statements: 0 });
+    // Stops at the first stage: every later stage takes the same org key.
+    expect(result.stages.map((stage) => `${stage.stage}:${stage.outcome}`)).toEqual(['baseline:locked']);
+    // The load-bearing assertion. `pg_try_advisory_xact_lock` returns rather
+    // than waiting, so the contended run gives its pooled connection straight
+    // back. A blocking acquisition would sit here until the holder commits —
+    // which is precisely the 29-minute hold from the incident.
+    expect(elapsedMs).toBeLessThan(5_000);
+  });
+
+  it('positive control: an unrelated org is not serialised by another org\'s lock', async () => {
+    // Proves the previous test's skip is caused by the ORG key and not by some
+    // blanket refusal — without this, a detector that always reported `locked`
+    // would pass the test above.
+    const result = await whileOrgLockHeld(orgA, () => detectMetricAnomaliesRange({ orgId: orgB, from, to }));
+
+    expect(result.skipped).toBe(false);
+    expect(result.stages.map((stage) => stage.outcome)).toEqual([
+      'completed',
+      'completed',
+      'completed',
+      'completed',
+    ]);
+  });
+
+  it('releases the lock at the end of every stage, so the next run is unblocked', async () => {
+    // Each stage commits its own transaction (#5283), so nothing is still held
+    // when the run returns. A session-level lock, or one stage leaking its
+    // transaction, would make this second run report `locked`.
+    const first = await detectMetricAnomaliesRange({ orgId: orgA, from, to });
+    const second = await detectMetricAnomaliesRange({ orgId: orgA, from, to });
+
+    expect(first.skipped).toBe(false);
+    expect(second.skipped).toBe(false);
+    expect(second.stages.map((stage) => stage.outcome)).toEqual([
+      'completed',
+      'completed',
+      'completed',
+      'completed',
+    ]);
+
+    // And no advisory lock survives the run on the app pool.
+    const held = await getTestDb().execute(sql`
+      SELECT count(*)::int AS n FROM pg_locks
+      WHERE locktype = 'advisory' AND classid = ${METRIC_ANOMALY_LOCK_NAMESPACE}
+    `);
+    expect((held as unknown as Array<{ n: number }>)[0]?.n).toBe(0);
+  });
+
+  it('commits each detection stage separately rather than in one long-lived transaction', async () => {
+    // The compounding in the incident came from all four statements sharing one
+    // transaction: run N+1 waited on run N's *transactionid* for the whole run,
+    // not for the single statement it actually conflicted with.
+    //
+    // Postgres only assigns a transaction id to a transaction that WRITES, so
+    // this counts xids consumed across a run seeded to write in two different
+    // stages (baseline, then the incident collapse). Separate transactions
+    // consume one xid each; a single shared transaction would consume one for
+    // both. `txid_current()` also assigns one per probe, so:
+    //   separate stages -> >= 2 writes + 1 probe = 3
+    //   one shared      ->    1 write  + 1 probe = 2
+    const site = (await createSite({ orgId: orgA, name: 'Txn Split Site' })).id;
+    const device = await insertDevice({ orgId: orgA, siteId: site, hostname: 'txn-split-device' });
+    const anchor = new Date('2026-06-18T18:00:00.000Z');
+    for (let i = 0; i < MIN_BASELINE_BUCKETS + 2; i++) {
+      await insertRollup({
+        orgId: orgA,
+        deviceId: device,
+        sourceTable: 'device_metrics',
+        metricType: 'cpu',
+        metricName: 'cpu_percent',
+        bucketStart: bucketAt(anchor, -(6 + i)),
+        avgValue: 10,
+      });
+    }
+    await insertRollup({
+      orgId: orgA,
+      deviceId: device,
+      sourceTable: 'device_metrics',
+      metricType: 'cpu',
+      metricName: 'cpu_percent',
+      bucketStart: anchor,
+      avgValue: 99,
+    });
+
+    const readTxid = async (): Promise<number> => {
+      const rows = await getTestDb().execute(sql`SELECT txid_current()::text AS "txid"`);
+      return Number((rows as unknown as Array<{ txid: string }>)[0]!.txid);
+    };
+
+    const before = await readTxid();
+    const result = await detectMetricAnomaliesRange({ orgId: orgA, from: anchor, to: bucketAt(anchor, 1) });
+    const after = await readTxid();
+
+    // Guard against a vacuous pass: if the seed stopped producing writes the
+    // xid delta would collapse for the RIGHT reason and hide a real regression.
+    expect(result.stages.map((stage) => stage.outcome)).toEqual([
+      'completed',
+      'completed',
+      'completed',
+      'completed',
+    ]);
+    expect(await selectAnomaliesByType(orgA, device, 'spike')).toHaveLength(1);
+
+    expect(after - before).toBeGreaterThanOrEqual(3);
   });
 });

--- a/apps/api/src/jobs/metricAnomalies.test.ts
+++ b/apps/api/src/jobs/metricAnomalies.test.ts
@@ -335,4 +335,50 @@ describe('metric anomalies queue helpers', () => {
       expect(new Date(second.from).getTime()).toBeLessThan(new Date(first.to).getTime());
     });
   });
+
+  // Review follow-ups on #5283.
+  describe('scan fan-out accounting (#5283 review)', () => {
+    it('does not enqueue — and does not report a fresh queue — when a spent record cannot be removed', async () => {
+      await initializeMetricAnomaliesWorker();
+      addMock.mockClear();
+      const removeMock = vi.fn().mockRejectedValue(new Error('redis unavailable'));
+      getJobMock.mockResolvedValue({
+        id: 'metric-anomalies-scheduled-org-1',
+        getState: vi.fn().mockResolvedValue('completed'),
+        remove: removeMock,
+      });
+
+      const result = await workerProcessorMock({ data: { type: 'scan-orgs' } });
+
+      // BullMQ's addStandardJob checks `EXISTS jobIdKey` FIRST and takes the
+      // duplicate path when the record is still there: it returns the id
+      // without storing the payload or pushing onto the wait list. Calling
+      // `add` anyway would be a total no-op reported as a successful enqueue,
+      // so the org's window would silently go uncovered — the exact class of
+      // invisible drop this PR exists to remove.
+      expect(detectAddCalls()).toHaveLength(0);
+      expect(result).toMatchObject({ queued: 0, reused: 0, staleRemoveFailed: 1 });
+    });
+
+    it('accounts each org separately across a multi-org fan-out', async () => {
+      groupByMock.mockResolvedValue([{ orgId: 'org-1' }, { orgId: 'org-2' }]);
+      await initializeMetricAnomaliesWorker();
+      addMock.mockClear();
+      // org-1 has a run in flight; org-2 is free.
+      getJobMock.mockImplementation(async (jobId: string) =>
+        jobId === 'metric-anomalies-scheduled-org-1'
+          ? { id: jobId, getState: vi.fn().mockResolvedValue('active') }
+          : null,
+      );
+
+      const result = await workerProcessorMock({ data: { type: 'scan-orgs' } });
+
+      // One org's reuse must not be counted against the other's enqueue.
+      expect(result).toMatchObject({ queued: 1, reused: 1, staleRemoveFailed: 0 });
+      const enqueued = detectAddCalls();
+      expect(enqueued).toHaveLength(1);
+      expect(enqueued[0]![1]).toMatchObject({ orgId: 'org-2' });
+      expect(enqueued[0]![2]).toMatchObject({ jobId: 'metric-anomalies-scheduled-org-2' });
+    });
+  });
 });

--- a/apps/api/src/jobs/metricAnomalies.test.ts
+++ b/apps/api/src/jobs/metricAnomalies.test.ts
@@ -80,10 +80,18 @@ vi.mock('./workerObservability', () => ({
 
 import {
   buildMetricAnomalyJobId,
+  buildScheduledMetricAnomalyJobId,
   enqueueMetricAnomalyBackfill,
   initializeMetricAnomaliesWorker,
   shutdownMetricAnomaliesWorker,
 } from './metricAnomalies';
+
+/** The `detect-org-range` enqueues, excluding the `scan-orgs` repeatable. */
+function detectAddCalls(): Array<[string, Record<string, unknown>, Record<string, unknown>]> {
+  return addMock.mock.calls.filter(([name]) => name === 'detect-org-range') as Array<
+    [string, Record<string, unknown>, Record<string, unknown>]
+  >;
+}
 
 describe('metric anomalies queue helpers', () => {
   beforeEach(async () => {
@@ -172,7 +180,7 @@ describe('metric anomalies queue helpers', () => {
   it('uses the worker execution time when fan-out repeat scans create anomaly ranges', async () => {
     vi.setSystemTime(new Date('2026-06-18T12:01:00.000Z'));
     await initializeMetricAnomaliesWorker();
-    addBulkMock.mockClear();
+    addMock.mockClear();
 
     vi.setSystemTime(new Date('2026-06-18T12:26:10.000Z'));
     await workerProcessorMock({
@@ -183,20 +191,16 @@ describe('metric anomalies queue helpers', () => {
       },
     });
 
-    expect(addBulkMock).toHaveBeenCalledWith([
-      expect.objectContaining({
-        name: 'detect-org-range',
-        data: expect.objectContaining({
-          orgId: 'org-1',
-          from: '2026-06-18T11:55:00.000Z',
-          to: '2026-06-18T12:25:00.000Z',
-          queuedAt: '2026-06-18T12:26:10.000Z',
-        }),
-        opts: expect.objectContaining({
-          jobId: 'metric-anomalies-org-1-20260618T115500000Z-20260618T122500000Z',
-        }),
-      }),
-    ]);
+    expect(detectAddCalls()).toHaveLength(1);
+    const [, data, opts] = detectAddCalls()[0]!;
+    expect(data).toMatchObject({
+      orgId: 'org-1',
+      from: '2026-06-18T11:55:00.000Z',
+      to: '2026-06-18T12:25:00.000Z',
+    });
+    // The scheduled id carries NO window (#5283) — that is what lets BullMQ's
+    // jobId dedup collapse a tick whose predecessor is still running.
+    expect(opts).toMatchObject({ jobId: 'metric-anomalies-scheduled-org-1' });
   });
 
   it('does not hold system DB context while scan fan-out enqueues BullMQ jobs', async () => {
@@ -211,17 +215,19 @@ describe('metric anomalies queue helpers', () => {
       callOrder.push('withSystemDbAccessContext:end');
       return result;
     });
-    addBulkMock.mockImplementation(async () => {
-      callOrder.push('addBulk');
-      return [];
+    await initializeMetricAnomaliesWorker();
+    // The repeatable `scan-orgs` add happens during init; only track the
+    // per-org fan-out enqueues that follow.
+    callOrder.length = 0;
+    addMock.mockImplementation(async () => {
+      callOrder.push('add');
+      return { id: 'queued-anomaly-job' };
     });
 
-    await initializeMetricAnomaliesWorker();
-    addBulkMock.mockClear();
     await workerProcessorMock({
       data: {
         type: 'scan-orgs',
-        lookbackMinutes: 30,
+        lookbackMinutes: 15,
       },
     });
 
@@ -229,7 +235,104 @@ describe('metric anomalies queue helpers', () => {
       'runOutsideDbContext',
       'withSystemDbAccessContext:start',
       'withSystemDbAccessContext:end',
-      'addBulk',
+      'add',
     ]);
+  });
+
+  // #5283: the scheduled fan-out kept the detection WINDOW in its job id, so
+  // BullMQ's dedup never matched and every 10-minute tick stacked a fresh job
+  // for an org whose previous run was still holding a transaction open.
+  describe('scheduled overlap guard (#5283)', () => {
+    it('uses a window-free per-org job id so consecutive ticks collapse instead of stacking', async () => {
+      await initializeMetricAnomaliesWorker();
+
+      addMock.mockClear();
+      vi.setSystemTime(new Date('2026-06-18T12:00:30.000Z'));
+      await workerProcessorMock({ data: { type: 'scan-orgs' } });
+      const firstTick = detectAddCalls();
+
+      addMock.mockClear();
+      vi.setSystemTime(new Date('2026-06-18T12:10:30.000Z'));
+      await workerProcessorMock({ data: { type: 'scan-orgs' } });
+      const secondTick = detectAddCalls();
+
+      // Same id across ticks — the property the old window-scoped id lacked.
+      expect(firstTick[0]![2]).toMatchObject({ jobId: 'metric-anomalies-scheduled-org-1' });
+      expect(secondTick[0]![2]).toMatchObject({ jobId: 'metric-anomalies-scheduled-org-1' });
+      expect(buildScheduledMetricAnomalyJobId('org-1')).toBe('metric-anomalies-scheduled-org-1');
+      // ...while the payload window still advances, so a job that DOES run
+      // covers the current range rather than a frozen one.
+      expect(firstTick[0]![1]).toMatchObject({ to: '2026-06-18T12:00:00.000Z' });
+      expect(secondTick[0]![1]).toMatchObject({ to: '2026-06-18T12:10:00.000Z' });
+    });
+
+    it('reuses an in-flight scheduled job instead of enqueueing a second run for the same org', async () => {
+      await initializeMetricAnomaliesWorker();
+      addMock.mockClear();
+      getJobMock.mockResolvedValue({
+        id: 'metric-anomalies-scheduled-org-1',
+        getState: vi.fn().mockResolvedValue('active'),
+      });
+
+      const result = await workerProcessorMock({ data: { type: 'scan-orgs' } });
+
+      // The whole point: while the previous run is still executing, the tick
+      // adds nothing. Before #5283 this enqueued a second job whose upsert then
+      // waited on the first run's transactionid.
+      expect(detectAddCalls()).toHaveLength(0);
+      expect(result).toMatchObject({ queued: 0, reused: 1 });
+    });
+
+    it('replaces a spent scheduled record so a completed or failed run cannot wedge the org forever', async () => {
+      await initializeMetricAnomaliesWorker();
+      addMock.mockClear();
+      const removeMock = vi.fn().mockResolvedValue(undefined);
+      getJobMock.mockResolvedValue({
+        id: 'metric-anomalies-scheduled-org-1',
+        getState: vi.fn().mockResolvedValue('completed'),
+        remove: removeMock,
+      });
+
+      const result = await workerProcessorMock({ data: { type: 'scan-orgs' } });
+
+      // BullMQ's jobId dedup keys on "a record exists", not "a job is pending",
+      // and removeOnComplete/removeOnFail RETAIN records — so a stable id
+      // without this replacement would silently discard every tick after the
+      // org's first run.
+      expect(removeMock).toHaveBeenCalled();
+      expect(detectAddCalls()).toHaveLength(1);
+      expect(result).toMatchObject({ queued: 1, reused: 0 });
+    });
+
+    it('schedules a 15-minute lookback: one cron interval plus one bucket, so ticks overlap by exactly one bucket', async () => {
+      await initializeMetricAnomaliesWorker();
+
+      const scanData = addMock.mock.calls.find(([name]) => name === 'scan-orgs')?.[1] as
+        | { lookbackMinutes?: number }
+        | undefined;
+      // 30 minutes on a 10-minute cron meant FOUR buckets of overlap, i.e. four
+      // buckets' worth of identical ON CONFLICT keys contending every tick.
+      expect(scanData?.lookbackMinutes).toBe(15);
+
+      addMock.mockClear();
+      vi.setSystemTime(new Date('2026-06-18T12:00:30.000Z'));
+      await workerProcessorMock({ data: { type: 'scan-orgs', lookbackMinutes: scanData?.lookbackMinutes } });
+      const first = detectAddCalls()[0]![1] as { from: string; to: string };
+
+      addMock.mockClear();
+      vi.setSystemTime(new Date('2026-06-18T12:10:30.000Z'));
+      await workerProcessorMock({ data: { type: 'scan-orgs', lookbackMinutes: scanData?.lookbackMinutes } });
+      const second = detectAddCalls()[0]![1] as { from: string; to: string };
+
+      expect(first).toMatchObject({ from: '2026-06-18T11:45:00.000Z', to: '2026-06-18T12:00:00.000Z' });
+      expect(second).toMatchObject({ from: '2026-06-18T11:55:00.000Z', to: '2026-06-18T12:10:00.000Z' });
+
+      // Exactly one 5-minute bucket of overlap...
+      const overlapMs = new Date(first.to).getTime() - new Date(second.from).getTime();
+      expect(overlapMs).toBe(5 * 60 * 1000);
+      // ...and no gap: the second window starts before the first one ends, so
+      // no bucket falls between consecutive ticks.
+      expect(new Date(second.from).getTime()).toBeLessThan(new Date(first.to).getTime());
+    });
   });
 });

--- a/apps/api/src/jobs/metricAnomalies.ts
+++ b/apps/api/src/jobs/metricAnomalies.ts
@@ -9,7 +9,32 @@ import { getBullMQConnection } from '../services/redis';
 import { attachWorkerObservability } from './workerObservability';
 
 const METRIC_ANOMALIES_QUEUE = 'metric-anomalies';
-const DEFAULT_LOOKBACK_MINUTES = 30;
+const SCAN_CRON_PATTERN = '*/10 * * * *';
+const SCAN_INTERVAL_MINUTES = 10;
+const RAW_BUCKET_MINUTES = 5;
+
+/**
+ * Scheduled lookback = one cron interval + one raw bucket (#5283).
+ *
+ * It was 30 minutes on a 10-minute cron, so consecutive windows overlapped by
+ * FOUR buckets and every tick re-upserted the same `metric_anomalies` conflict
+ * keys the previous tick was still holding — that overlap is what the waiting
+ * PID in the incident was blocked on.
+ *
+ * 15 minutes is the smallest value that still cannot drop a bucket: `to` is
+ * floored to a 5-minute boundary and advances 10 minutes per tick, so
+ * `[11:45,12:00)` is followed by `[11:55,12:10)` — full coverage with exactly
+ * one bucket of overlap. That one bucket is deliberate, not slack: it is the
+ * grace period for rollups that land after the tick that would otherwise have
+ * been their only chance.
+ *
+ * Trade-off, stated plainly: the old 30-minute window self-healed a missed tick
+ * for 20 minutes. This one does not — a tick that is skipped, coalesced, or
+ * lock-contended leaves buckets uncovered, and the recovery path is an explicit
+ * `enqueueMetricAnomalyBackfill` over the missed range rather than "the next
+ * tick will pick it up".
+ */
+const DEFAULT_LOOKBACK_MINUTES = SCAN_INTERVAL_MINUTES + RAW_BUCKET_MINUTES;
 const JOB_REUSE_STATES = new Set(['waiting', 'delayed', 'active']);
 
 type ScanOrgsJobData = {
@@ -44,8 +69,33 @@ function compactIso(value: Date | string): string {
   return new Date(value).toISOString().replace(/[^0-9A-Za-z]/g, '');
 }
 
+/**
+ * Job id for an EXPLICIT-window run (the backfill path).
+ *
+ * The window is part of the id here on purpose: two backfills over different
+ * ranges are different work and must both run.
+ */
 export function buildMetricAnomalyJobId(orgId: string, from: Date | string, to: Date | string): string {
   return ['metric-anomalies', orgId, compactIso(from), compactIso(to)].join('-');
+}
+
+/**
+ * Job id for the SCHEDULED run — stable per org, with no window in it (#5283).
+ *
+ * The scheduled path used `buildMetricAnomalyJobId`, whose window advances
+ * every cycle, so BullMQ's jobId dedup never matched and each 10-minute tick
+ * enqueued a brand-new job for an org whose previous job was still running.
+ * A window-free id makes the dedup do its job: while a run for this org is
+ * waiting/delayed/active, the next tick reuses it instead of stacking a second.
+ *
+ * The cost is that a discarded tick's window is simply not covered — reusing an
+ * active job does NOT extend its range. That is the intended trade (an
+ * uncovered window beats an unbounded pile-up), and it is bounded by the
+ * per-detector `statement_timeout` the service now sets, which stops a stuck
+ * run from wedging this id indefinitely.
+ */
+export function buildScheduledMetricAnomalyJobId(orgId: string): string {
+  return ['metric-anomalies', 'scheduled', orgId].join('-');
 }
 
 function recentWindow(now = new Date(), lookbackMinutes = DEFAULT_LOOKBACK_MINUTES): { from: Date; to: Date } {
@@ -69,38 +119,53 @@ async function findAnomalyOrgRows(): Promise<Array<{ orgId: string }>> {
     .groupBy(devices.orgId);
 }
 
-async function processScanOrgs(data: ScanOrgsJobData): Promise<{ queued: number }> {
+async function processScanOrgs(data: ScanOrgsJobData): Promise<{ queued: number; reused: number }> {
   const orgRows = await runOutsideDbContext(() =>
     withSystemDbAccessContext(() => findAnomalyOrgRows())
   );
 
   if (orgRows.length === 0) {
-    return { queued: 0 };
+    return { queued: 0, reused: 0 };
   }
 
   const scannedAt = new Date();
-  const queuedAt = scannedAt.toISOString();
   const { from, to } = recentWindow(scannedAt, data.lookbackMinutes);
-  const queue = getMetricAnomaliesQueue();
-  await queue.addBulk(
-    orgRows.map((row) => ({
-      name: 'detect-org-range',
-      data: {
-        type: 'detect-org-range' as const,
-        orgId: row.orgId,
-        from: from.toISOString(),
-        to: to.toISOString(),
-        queuedAt,
-      },
-      opts: {
-        jobId: buildMetricAnomalyJobId(row.orgId, from, to),
-        removeOnComplete: { count: 100 },
-        removeOnFail: { count: 200 },
-      },
-    }))
-  );
 
-  return { queued: orgRows.length };
+  // One `enqueueDetectOrgRange` per org rather than a single `addBulk` (#5283).
+  // `addBulk` cannot express reuse-if-active: under a stable per-org job id it
+  // would silently discard the add whenever ANY record survives under that id —
+  // including a COMPLETED or FAILED one that `removeOnComplete`/`removeOnFail`
+  // retained — which would wedge that org's detection permanently after its
+  // first run. The per-org path reuses a genuinely in-flight job and replaces a
+  // spent record. The extra Redis round trips are irrelevant at a 10-minute
+  // cadence.
+  let queued = 0;
+  let reused = 0;
+  for (const row of orgRows) {
+    const result = await enqueueDetectOrgRange({
+      jobId: buildScheduledMetricAnomalyJobId(row.orgId),
+      orgId: row.orgId,
+      from,
+      to,
+    });
+    if (result.reused) {
+      reused += 1;
+    } else {
+      queued += 1;
+    }
+  }
+
+  if (reused > 0) {
+    // The signal that detection is not keeping up with its own cadence. Silent
+    // reuse is exactly how the original pile-up stayed invisible until Postgres
+    // showed it.
+    console.warn(
+      `[MetricAnomaliesWorker] scan-orgs reused ${reused} in-flight detection job(s) `
+        + `(${queued} newly queued) — those orgs' windows are not covered by this tick`,
+    );
+  }
+
+  return { queued, reused };
 }
 
 async function processDetectOrgRange(data: DetectOrgRangeJobData): Promise<MetricAnomalyResult> {
@@ -118,10 +183,13 @@ export function createMetricAnomaliesWorker(): Worker<MetricAnomalyJobData> {
       if (job.data.type === 'scan-orgs') {
         return processScanOrgs(job.data);
       }
-      const data = job.data;
-      return runOutsideDbContext(() =>
-        withSystemDbAccessContext(() => processDetectOrgRange(data))
-      );
+      // No outer DB context here on purpose (#5283). This used to wrap the
+      // whole per-org run, which made all four detector statements share ONE
+      // transaction on ONE pooled connection — so a second run waited on the
+      // first run's entire transactionid, not on the one statement it actually
+      // conflicted with. `detectMetricAnomaliesRange` now opens a fresh
+      // system-scoped transaction per stage.
+      return processDetectOrgRange(job.data);
     },
     {
       connection: getBullMQConnection(),
@@ -150,7 +218,7 @@ async function scheduleMetricAnomaliesScan(): Promise<void> {
     },
     {
       jobId: 'metric-anomalies-scan-orgs',
-      repeat: { pattern: '*/10 * * * *' },
+      repeat: { pattern: SCAN_CRON_PATTERN },
       removeOnComplete: { count: 20 },
       removeOnFail: { count: 100 },
     }
@@ -181,21 +249,32 @@ export async function shutdownMetricAnomaliesWorker(): Promise<void> {
   }
 }
 
-export async function enqueueMetricAnomalyBackfill(options: {
+/**
+ * Enqueue a `detect-org-range` job under `jobId`, reusing a genuinely in-flight
+ * job and replacing a spent record.
+ *
+ * Shared by the scheduled fan-out and the backfill entry point so the
+ * reuse-vs-replace rule has one home — the two differ only in how the id is
+ * built (stable per org vs. window-scoped). BullMQ's own jobId dedup keys on
+ * "a record exists", not "a job is pending", so a retained completed/failed
+ * record would otherwise swallow every later add under the same id.
+ */
+async function enqueueDetectOrgRange(options: {
+  jobId: string;
   orgId: string;
   from: Date;
   to: Date;
-}): Promise<string> {
+}): Promise<{ id: string; reused: boolean }> {
   const queue = getMetricAnomaliesQueue();
-  const jobId = buildMetricAnomalyJobId(options.orgId, options.from, options.to);
+  const { jobId } = options;
   const existing = await queue.getJob(jobId);
   if (existing) {
     const state = await existing.getState();
     if (JOB_REUSE_STATES.has(state) || isReusableState(state)) {
-      return String(existing.id);
+      return { id: String(existing.id ?? jobId), reused: true };
     }
     await existing.remove().catch((error) => {
-      console.error(`[MetricAnomaliesWorker] Failed to remove stale job ${jobId}:`, error);
+      console.error(`[MetricAnomaliesWorker] Failed to remove stale job ${jobId} (state '${state}'):`, error);
     });
   }
 
@@ -215,5 +294,19 @@ export async function enqueueMetricAnomalyBackfill(options: {
     }
   );
 
-  return String(job.id);
+  return { id: String(job.id ?? jobId), reused: false };
+}
+
+export async function enqueueMetricAnomalyBackfill(options: {
+  orgId: string;
+  from: Date;
+  to: Date;
+}): Promise<string> {
+  const { id } = await enqueueDetectOrgRange({
+    jobId: buildMetricAnomalyJobId(options.orgId, options.from, options.to),
+    orgId: options.orgId,
+    from: options.from,
+    to: options.to,
+  });
+  return id;
 }

--- a/apps/api/src/jobs/metricAnomalies.ts
+++ b/apps/api/src/jobs/metricAnomalies.ts
@@ -35,7 +35,15 @@ const RAW_BUCKET_MINUTES = 5;
  * tick will pick it up".
  */
 const DEFAULT_LOOKBACK_MINUTES = SCAN_INTERVAL_MINUTES + RAW_BUCKET_MINUTES;
-const JOB_REUSE_STATES = new Set(['waiting', 'delayed', 'active']);
+/**
+ * - `queued`             — a new job was actually persisted.
+ * - `reused`             — a genuinely in-flight job already covers this org;
+ *                          this tick's window is NOT covered.
+ * - `stale-remove-failed`— a spent record could not be removed, so BullMQ would
+ *                          silently discard the add. Also uncovered, and a
+ *                          fault rather than an expected outcome.
+ */
+type EnqueueOutcome = 'queued' | 'reused' | 'stale-remove-failed';
 
 type ScanOrgsJobData = {
   type: 'scan-orgs';
@@ -119,13 +127,15 @@ async function findAnomalyOrgRows(): Promise<Array<{ orgId: string }>> {
     .groupBy(devices.orgId);
 }
 
-async function processScanOrgs(data: ScanOrgsJobData): Promise<{ queued: number; reused: number }> {
+async function processScanOrgs(
+  data: ScanOrgsJobData,
+): Promise<{ queued: number; reused: number; staleRemoveFailed: number }> {
   const orgRows = await runOutsideDbContext(() =>
     withSystemDbAccessContext(() => findAnomalyOrgRows())
   );
 
   if (orgRows.length === 0) {
-    return { queued: 0, reused: 0 };
+    return { queued: 0, reused: 0, staleRemoveFailed: 0 };
   }
 
   const scannedAt = new Date();
@@ -141,18 +151,17 @@ async function processScanOrgs(data: ScanOrgsJobData): Promise<{ queued: number;
   // cadence.
   let queued = 0;
   let reused = 0;
+  let staleRemoveFailed = 0;
   for (const row of orgRows) {
-    const result = await enqueueDetectOrgRange({
+    const { outcome } = await enqueueDetectOrgRange({
       jobId: buildScheduledMetricAnomalyJobId(row.orgId),
       orgId: row.orgId,
       from,
       to,
     });
-    if (result.reused) {
-      reused += 1;
-    } else {
-      queued += 1;
-    }
+    if (outcome === 'reused') reused += 1;
+    else if (outcome === 'stale-remove-failed') staleRemoveFailed += 1;
+    else queued += 1;
   }
 
   if (reused > 0) {
@@ -164,8 +173,17 @@ async function processScanOrgs(data: ScanOrgsJobData): Promise<{ queued: number;
         + `(${queued} newly queued) — those orgs' windows are not covered by this tick`,
     );
   }
+  if (staleRemoveFailed > 0) {
+    // Distinct from `reused`: nothing is running for these orgs AND nothing was
+    // scheduled. Counted and reported separately so it can never be read as the
+    // benign "a run is already in flight" case.
+    console.error(
+      `[MetricAnomaliesWorker] scan-orgs could not replace ${staleRemoveFailed} spent job record(s) — `
+        + 'those orgs were NOT scheduled this tick and will retry next tick',
+    );
+  }
 
-  return { queued, reused };
+  return { queued, reused, staleRemoveFailed };
 }
 
 async function processDetectOrgRange(data: DetectOrgRangeJobData): Promise<MetricAnomalyResult> {
@@ -264,18 +282,41 @@ async function enqueueDetectOrgRange(options: {
   orgId: string;
   from: Date;
   to: Date;
-}): Promise<{ id: string; reused: boolean }> {
+}): Promise<{ id: string; outcome: EnqueueOutcome }> {
   const queue = getMetricAnomaliesQueue();
   const { jobId } = options;
   const existing = await queue.getJob(jobId);
   if (existing) {
     const state = await existing.getState();
-    if (JOB_REUSE_STATES.has(state) || isReusableState(state)) {
-      return { id: String(existing.id ?? jobId), reused: true };
+    // `isReusableState` already covers active/waiting/delayed/waiting-children/
+    // prioritized — a strict superset of the local JOB_REUSE_STATES this used to
+    // OR against, so the extra check was redundant.
+    if (isReusableState(state)) {
+      return { id: String(existing.id ?? jobId), outcome: 'reused' };
     }
-    await existing.remove().catch((error) => {
-      console.error(`[MetricAnomaliesWorker] Failed to remove stale job ${jobId} (state '${state}'):`, error);
-    });
+
+    // A failed remove must NOT fall through to `add`. BullMQ's addStandardJob
+    // Lua script checks `EXISTS jobIdKey` FIRST and, when the key is still
+    // there, takes the duplicate path: it emits a `duplicated` event and
+    // returns the id without storing the new payload or pushing onto the wait
+    // list. So the `add` below would be a total no-op while still handing back
+    // a plausible-looking Job whose fields echo the options we passed — the
+    // caller would count a fresh enqueue, the org's window would silently go
+    // uncovered, and the `reused` warning that exists to surface exactly that
+    // undercoverage would never fire.
+    const removed = await existing.remove().then(
+      () => true,
+      (error: unknown) => {
+        console.error(
+          `[MetricAnomaliesWorker] Failed to remove stale job ${jobId} (state '${state}'):`,
+          error,
+        );
+        return false;
+      },
+    );
+    if (!removed) {
+      return { id: jobId, outcome: 'stale-remove-failed' };
+    }
   }
 
   const job = await queue.add(
@@ -294,7 +335,7 @@ async function enqueueDetectOrgRange(options: {
     }
   );
 
-  return { id: String(job.id ?? jobId), reused: false };
+  return { id: String(job.id ?? jobId), outcome: 'queued' };
 }
 
 export async function enqueueMetricAnomalyBackfill(options: {

--- a/apps/api/src/services/metricAnomalies.test.ts
+++ b/apps/api/src/services/metricAnomalies.test.ts
@@ -1,26 +1,73 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { executeMock, shouldProduceMlOutputMock } = vi.hoisted(() => ({
+const {
+  executeMock,
+  shouldProduceMlOutputMock,
+  runOutsideDbContextMock,
+  withSystemDbAccessContextMock,
+} = vi.hoisted(() => ({
   executeMock: vi.fn(),
   shouldProduceMlOutputMock: vi.fn(),
+  runOutsideDbContextMock: vi.fn(),
+  withSystemDbAccessContextMock: vi.fn(),
 }));
 
 vi.mock('../db', () => ({
   db: {
     execute: executeMock,
   },
+  runOutsideDbContext: runOutsideDbContextMock,
+  withSystemDbAccessContext: withSystemDbAccessContextMock,
 }));
 
 vi.mock('./mlFeatureFlags', () => ({
   shouldProduceMlOutput: shouldProduceMlOutputMock,
 }));
 
-import { METRIC_ANOMALY_V1_SHADOW_VERSION, detectMetricAnomaliesRange } from './metricAnomalies';
+import {
+  METRIC_ANOMALY_LOCK_NAMESPACE,
+  METRIC_ANOMALY_LOCK_TIMEOUT_MS,
+  METRIC_ANOMALY_STATEMENT_TIMEOUT_MS,
+  METRIC_ANOMALY_V1_SHADOW_VERSION,
+  detectMetricAnomaliesRange,
+} from './metricAnomalies';
+
+/**
+ * A Postgres driver error carries SQLSTATE on `.code`; `pgErrorCode` unwraps
+ * that shape (directly or via `.cause`).
+ */
+function pgError(code: string): Error {
+  return Object.assign(new Error(`simulated SQLSTATE ${code}`), { code });
+}
+
+/**
+ * The detector statements, in execution order, with the per-stage preamble
+ * (advisory-lock probe + the two `set_config` timeout statements) filtered out.
+ *
+ * Indexing `executeMock.mock.calls` directly stopped working in #5283: every
+ * stage now issues three bookkeeping statements before its own, so a bare
+ * `calls[3]` silently points at a `set_config` instead of the incident upsert
+ * and every assertion against it passes vacuously.
+ */
+function detectorStatements(): string[] {
+  return executeMock.mock.calls
+    .map((call) => JSON.stringify(call))
+    .filter((text) => text.includes('INSERT INTO'));
+}
+
+/** Reset the db mock to "lock acquired, no prior timeout to report". */
+function resetDbMocks(): void {
+  executeMock.mockReset();
+  executeMock.mockResolvedValue([{ acquired: true }]);
+  runOutsideDbContextMock.mockReset();
+  runOutsideDbContextMock.mockImplementation((fn: () => unknown) => fn());
+  withSystemDbAccessContextMock.mockReset();
+  withSystemDbAccessContextMock.mockImplementation((fn: () => unknown) => fn());
+}
 
 describe('metric anomalies service', () => {
   beforeEach(() => {
-    executeMock.mockReset();
-    executeMock.mockResolvedValue([]);
+    resetDbMocks();
     shouldProduceMlOutputMock.mockReset();
     shouldProduceMlOutputMock.mockImplementation(async (_orgId: string, flag: string) => flag === 'ml.anomalies.enabled');
   });
@@ -40,6 +87,8 @@ describe('metric anomalies service', () => {
       to: '2026-06-18T12:30:00.000Z',
       statements: 0,
       skipped: true,
+      skippedReason: 'ml-disabled',
+      stages: [],
     });
     expect(shouldProduceMlOutputMock).toHaveBeenCalledWith(
       '11111111-1111-1111-1111-111111111111',
@@ -57,7 +106,13 @@ describe('metric anomalies service', () => {
 
     expect(result).toMatchObject({ statements: 4, skipped: false });
     expect(result).toMatchObject({ v1ShadowStatements: 0, v1ShadowSkipped: true });
-    expect(executeMock).toHaveBeenCalledTimes(4);
+    expect(result.stages.map((stage) => `${stage.stage}:${stage.outcome}`)).toEqual([
+      'baseline:completed',
+      'growth-trend:completed',
+      'process-runaway:completed',
+      'incidents:completed',
+    ]);
+    expect(detectorStatements()).toHaveLength(4);
     const executedSql = JSON.stringify(executeMock.mock.calls);
     expect(executedSql).toContain('INSERT INTO metric_anomalies');
     expect(executedSql).toContain('ON CONFLICT');
@@ -65,7 +120,7 @@ describe('metric anomalies service', () => {
     expect(executedSql).toContain('network_egress');
     expect(executedSql).toContain('memory_growth');
 
-    const processStatementSql = JSON.stringify(executeMock.mock.calls[2]);
+    const processStatementSql = detectorStatements()[2] ?? '';
     expect(processStatementSql).toContain("mr.source_table = 'device_process_samples'");
     expect(processStatementSql).toContain('top_process_cpu_percent_sum');
     expect(processStatementSql).toContain('top_process_cpu_percent_max');
@@ -96,9 +151,9 @@ describe('metric anomalies service', () => {
       skipped: false,
     });
     // 3 detectors + the incident upsert (always) + the v1 shadow statement.
-    expect(executeMock).toHaveBeenCalledTimes(5);
+    expect(detectorStatements()).toHaveLength(5);
 
-    const v1StatementSql = JSON.stringify(executeMock.mock.calls[4]);
+    const v1StatementSql = detectorStatements()[4] ?? '';
     expect(v1StatementSql).toContain('INSERT INTO metric_anomaly_candidates');
     expect(v1StatementSql).toContain(METRIC_ANOMALY_V1_SHADOW_VERSION);
     expect(v1StatementSql).toContain('percentile_cont');
@@ -129,13 +184,12 @@ describe('metric anomalies service', () => {
 // assertion here is the load-bearing re-publish guard the plan calls for —
 // dispatched_at/dispatch_attempts/agent_run_id are the transactional dispatch
 // marker (metricAnomalyIncidents.ts), and this statement must NEVER assign
-// any of them, or a bulk detector re-upsert (the 10-min/30-min-lookback
-// schedule revisits every row ~3x) would silently re-publish an
+// any of them, or a bulk detector re-upsert (the 10-min cron with a
+// 15-min lookback revisits the trailing bucket twice) would silently re-publish an
 // already-dispatched incident.
 describe('metric anomaly incidents upsert (#3828 wave-6-4 task 2)', () => {
   beforeEach(() => {
-    executeMock.mockReset();
-    executeMock.mockResolvedValue([]);
+    resetDbMocks();
     shouldProduceMlOutputMock.mockReset();
     shouldProduceMlOutputMock.mockImplementation(async (_orgId: string, flag: string) => flag === 'ml.anomalies.enabled');
   });
@@ -147,8 +201,8 @@ describe('metric anomaly incidents upsert (#3828 wave-6-4 task 2)', () => {
       to: new Date('2026-06-18T12:30:00.000Z'),
     });
 
-    expect(executeMock).toHaveBeenCalledTimes(4);
-    const incidentSql = JSON.stringify(executeMock.mock.calls[3]);
+    expect(detectorStatements()).toHaveLength(4);
+    const incidentSql = detectorStatements()[3] ?? '';
 
     expect(incidentSql).toContain('INSERT INTO metric_anomaly_incidents');
     expect(incidentSql).toContain('FROM metric_anomalies');
@@ -175,7 +229,7 @@ describe('metric anomaly incidents upsert (#3828 wave-6-4 task 2)', () => {
       to: new Date('2026-06-18T12:30:00.000Z'),
     });
 
-    const incidentSql = JSON.stringify(executeMock.mock.calls[3]);
+    const incidentSql = detectorStatements()[3] ?? '';
     // The statement never references these columns at all (not in the
     // INSERT column list, not in SELECT, not in SET) — so a future edit that
     // starts refreshing the dispatch marker on every re-detect (the exact
@@ -200,8 +254,7 @@ describe('metric anomaly incidents upsert (#3828 wave-6-4 task 2)', () => {
       to: new Date('2026-06-18T12:30:00.000Z'),
     });
 
-    const incidentCall = executeMock.mock.calls[3];
-    const incidentSql = JSON.stringify(incidentCall);
+    const incidentSql = detectorStatements()[3] ?? '';
     // window_end, not window_start: a growth-trend row's window_start is the
     // START of its multi-bucket trend window and can predate `from`, but
     // every detector writes window_end >= its own bucket_start >= `from`, so
@@ -225,8 +278,7 @@ describe('metric anomaly incidents upsert (#3828 wave-6-4 task 2)', () => {
       to: new Date('2026-06-18T12:30:00.000Z'),
     });
 
-    const incidentCall = executeMock.mock.calls[3];
-    const incidentSql = JSON.stringify(incidentCall);
+    const incidentSql = detectorStatements()[3] ?? '';
     // `ma.window_start` legitimately appears in SELECT and GROUP BY (it's
     // the collapsing key), so assert on the WHERE-clause predicate shape
     // specifically: no comparison operator is ever applied to
@@ -250,5 +302,193 @@ describe('metric anomaly incidents upsert (#3828 wave-6-4 task 2)', () => {
 
     expect(result).toMatchObject({ statements: 0, skipped: true });
     expect(executeMock).not.toHaveBeenCalled();
+  });
+});
+
+// #5283: enabling ml.anomalies.enabled put overlapping runs of the same
+// baseline query against metric_rollups in a `Lock` wait for 29+ minutes,
+// compounding until the feature had to be disabled. The guard has three parts,
+// all asserted here: a per-org advisory lock so a second run SKIPS instead of
+// queueing behind the first, one transaction per stage so a waiter can never be
+// blocked by more than the single statement it conflicts with, and bounded lock
+// /statement waits so a blocked stage gives the connection back.
+describe('metric anomaly overlap guard (#5283)', () => {
+  beforeEach(() => {
+    resetDbMocks();
+    shouldProduceMlOutputMock.mockReset();
+    shouldProduceMlOutputMock.mockImplementation(async (_orgId: string, flag: string) => flag === 'ml.anomalies.enabled');
+  });
+
+  it('probes the per-org advisory lock before any detector statement, in every stage', async () => {
+    await detectMetricAnomaliesRange({
+      orgId: '11111111-1111-1111-1111-111111111111',
+      from: new Date('2026-06-18T12:00:00.000Z'),
+      to: new Date('2026-06-18T12:15:00.000Z'),
+    });
+
+    const texts = executeMock.mock.calls.map((call) => JSON.stringify(call));
+    const lockProbes = texts.filter((text) => text.includes('pg_try_advisory_xact_lock'));
+    // One per stage — the lock is transaction-scoped, so a single probe at the
+    // top of the run would protect only the first stage's transaction.
+    expect(lockProbes).toHaveLength(4);
+
+    // `pg_try_advisory_*` never waits, so a contended run returns immediately
+    // instead of joining the queue. A blocking `pg_advisory_xact_lock` here
+    // would rebuild the pile-up with a different lock type.
+    expect(texts.join('')).not.toContain('pg_advisory_xact_lock(');
+
+    // Namespaced two-int form keyed on the org, so this can neither collide
+    // with metricRollupMaintenance's single-int lock nor serialise unrelated orgs.
+    expect(lockProbes[0]).toContain(String(METRIC_ANOMALY_LOCK_NAMESPACE));
+    expect(lockProbes[0]).toContain('hashtext');
+    expect(lockProbes[0]).toContain('11111111-1111-1111-1111-111111111111');
+
+    // Ordering: the probe precedes the first detector statement.
+    expect(texts.findIndex((text) => text.includes('pg_try_advisory_xact_lock')))
+      .toBeLessThan(texts.findIndex((text) => text.includes('INSERT INTO')));
+  });
+
+  it('skips the run without throwing when another run holds the org lock', async () => {
+    executeMock.mockResolvedValue([{ acquired: false }]);
+
+    const result = await detectMetricAnomaliesRange({
+      orgId: '11111111-1111-1111-1111-111111111111',
+      from: new Date('2026-06-18T12:00:00.000Z'),
+      to: new Date('2026-06-18T12:15:00.000Z'),
+    });
+
+    expect(result).toMatchObject({ skipped: true, skippedReason: 'locked', statements: 0 });
+    // Stops at the first refusal: every later stage takes the SAME org key, so
+    // probing them all would be four wasted round trips.
+    expect(result.stages).toEqual([
+      { stage: 'baseline', outcome: 'locked', durationMs: expect.any(Number) },
+    ]);
+    // The point of the whole change: a contended run issues NO upsert, so it
+    // cannot land behind the winner's transactionid.
+    expect(detectorStatements()).toHaveLength(0);
+  });
+
+  it('bounds lock and statement waits inside each stage, before the detector statement', async () => {
+    await detectMetricAnomaliesRange({
+      orgId: '11111111-1111-1111-1111-111111111111',
+      from: new Date('2026-06-18T12:00:00.000Z'),
+      to: new Date('2026-06-18T12:15:00.000Z'),
+    });
+
+    const texts = executeMock.mock.calls.map((call) => JSON.stringify(call));
+    const lockTimeouts = texts.filter((text) => text.includes("'lock_timeout'"));
+    const statementTimeouts = texts.filter((text) => text.includes("'statement_timeout'"));
+    expect(lockTimeouts).toHaveLength(4);
+    expect(statementTimeouts).toHaveLength(4);
+    expect(lockTimeouts[0]).toContain(String(METRIC_ANOMALY_LOCK_TIMEOUT_MS));
+    expect(statementTimeouts[0]).toContain(String(METRIC_ANOMALY_STATEMENT_TIMEOUT_MS));
+    // `SET LOCAL` semantics (set_config's third arg), so the bound dies with
+    // the stage's transaction and never leaks onto a pooled connection.
+    expect(lockTimeouts[0]).toContain('set_config');
+    expect(texts.findIndex((text) => text.includes("'statement_timeout'")))
+      .toBeLessThan(texts.findIndex((text) => text.includes('INSERT INTO')));
+  });
+
+  it.each([
+    ['55P03', 'lock_timeout'],
+    ['57014', 'statement_timeout'],
+  ])('skips only the stage that trips %s (%s) and keeps the run going', async (code) => {
+    // Fail the FIRST detector statement; the advisory-lock probe and the two
+    // set_config statements still succeed.
+    let detectorCalls = 0;
+    executeMock.mockImplementation(async (query: unknown) => {
+      if (JSON.stringify(query).includes('INSERT INTO')) {
+        detectorCalls += 1;
+        if (detectorCalls === 1) throw pgError(code);
+      }
+      return [{ acquired: true }];
+    });
+
+    const result = await detectMetricAnomaliesRange({
+      orgId: '11111111-1111-1111-1111-111111111111',
+      from: new Date('2026-06-18T12:00:00.000Z'),
+      to: new Date('2026-06-18T12:15:00.000Z'),
+    });
+
+    expect(result.stages[0]).toMatchObject({ stage: 'baseline', outcome: 'timeout', sqlState: code });
+    // A timeout is per-statement, so the remaining stages still get their turn
+    // — unlike `locked`, which stops the run.
+    expect(result.stages.map((stage) => stage.outcome)).toEqual([
+      'timeout',
+      'completed',
+      'completed',
+      'completed',
+    ]);
+    expect(result).toMatchObject({ statements: 3, skipped: false });
+  });
+
+  it('reports skippedReason "timeout" when every stage trips its wait bound', async () => {
+    executeMock.mockImplementation(async (query: unknown) => {
+      if (JSON.stringify(query).includes('INSERT INTO')) throw pgError('57014');
+      return [{ acquired: true }];
+    });
+
+    const result = await detectMetricAnomaliesRange({
+      orgId: '11111111-1111-1111-1111-111111111111',
+      from: new Date('2026-06-18T12:00:00.000Z'),
+      to: new Date('2026-06-18T12:15:00.000Z'),
+    });
+
+    expect(result).toMatchObject({ skipped: true, skippedReason: 'timeout', statements: 0 });
+  });
+
+  it('propagates a non-timeout database error instead of silently skipping the stage', async () => {
+    executeMock.mockImplementation(async (query: unknown) => {
+      if (JSON.stringify(query).includes('INSERT INTO')) throw pgError('23505');
+      return [{ acquired: true }];
+    });
+
+    await expect(
+      detectMetricAnomaliesRange({
+        orgId: '11111111-1111-1111-1111-111111111111',
+        from: new Date('2026-06-18T12:00:00.000Z'),
+        to: new Date('2026-06-18T12:15:00.000Z'),
+      }),
+    ).rejects.toThrow('23505');
+  });
+
+  it('opens a fresh system context per stage rather than one for the whole run', async () => {
+    await detectMetricAnomaliesRange({
+      orgId: '11111111-1111-1111-1111-111111111111',
+      from: new Date('2026-06-18T12:00:00.000Z'),
+      to: new Date('2026-06-18T12:15:00.000Z'),
+    });
+
+    const labels = withSystemDbAccessContextMock.mock.calls.map((call) => call[1]);
+    // One transaction per detection stage. Before #5283 all four statements
+    // shared ONE, so a waiting run blocked on the whole run's transactionid.
+    expect(labels).toContain('metricAnomalies.baseline');
+    expect(labels).toContain('metricAnomalies.growth-trend');
+    expect(labels).toContain('metricAnomalies.process-runaway');
+    expect(labels).toContain('metricAnomalies.incidents');
+
+    // Every context is opened via runOutsideDbContext: withDbAccessContext
+    // early-returns into an ambient context, so a caller that still wrapped the
+    // whole run would otherwise collapse all four stages back into one
+    // transaction with no error anywhere.
+    expect(runOutsideDbContextMock).toHaveBeenCalledTimes(
+      withSystemDbAccessContextMock.mock.calls.length,
+    );
+  });
+
+  it('reads ml flags in their own system context, so the RLS-scoped org read still resolves', async () => {
+    await detectMetricAnomaliesRange({
+      orgId: '11111111-1111-1111-1111-111111111111',
+      from: new Date('2026-06-18T12:00:00.000Z'),
+      to: new Date('2026-06-18T12:15:00.000Z'),
+    });
+
+    // loadMlFlagInputs reads `organizations` in the CALLER'S RLS context by
+    // design (#2822). Splitting the per-stage transactions out of the old
+    // single outer system context would otherwise leave this read contextless,
+    // resolving every flag to org_not_found -> disabled and silently stopping
+    // detection fleet-wide.
+    expect(withSystemDbAccessContextMock.mock.calls.map((call) => call[1]))
+      .toContain('metricAnomalies.flags');
   });
 });

--- a/apps/api/src/services/metricAnomalies.test.ts
+++ b/apps/api/src/services/metricAnomalies.test.ts
@@ -5,11 +5,17 @@ const {
   shouldProduceMlOutputMock,
   runOutsideDbContextMock,
   withSystemDbAccessContextMock,
+  captureMessageMock,
 } = vi.hoisted(() => ({
   executeMock: vi.fn(),
   shouldProduceMlOutputMock: vi.fn(),
   runOutsideDbContextMock: vi.fn(),
   withSystemDbAccessContextMock: vi.fn(),
+  captureMessageMock: vi.fn(),
+}));
+
+vi.mock('./sentry', () => ({
+  captureMessage: captureMessageMock,
 }));
 
 vi.mock('../db', () => ({
@@ -25,6 +31,7 @@ vi.mock('./mlFeatureFlags', () => ({
 }));
 
 import {
+  __resetMetricAnomalyStallTracking,
   METRIC_ANOMALY_LOCK_NAMESPACE,
   METRIC_ANOMALY_LOCK_TIMEOUT_MS,
   METRIC_ANOMALY_STATEMENT_TIMEOUT_MS,
@@ -57,6 +64,8 @@ function detectorStatements(): string[] {
 
 /** Reset the db mock to "lock acquired, no prior timeout to report". */
 function resetDbMocks(): void {
+  __resetMetricAnomalyStallTracking();
+  captureMessageMock.mockReset();
   executeMock.mockReset();
   executeMock.mockResolvedValue([{ acquired: true }]);
   runOutsideDbContextMock.mockReset();
@@ -490,5 +499,145 @@ describe('metric anomaly overlap guard (#5283)', () => {
     // detection fleet-wide.
     expect(withSystemDbAccessContextMock.mock.calls.map((call) => call[1]))
       .toContain('metricAnomalies.flags');
+  });
+});
+
+// Review follow-ups on #5283: the outcomes that only arise when stages
+// INTERACT — a timeout followed by lock contention, and the shadow stage
+// losing the lock while the main stages succeeded — plus the escalation that
+// stops a permanently-skipping stage from being an invisible outage.
+describe('metric anomaly skip reporting and stall escalation (#5283 review)', () => {
+  const orgId = '11111111-1111-1111-1111-111111111111';
+  const range = { from: new Date('2026-06-18T12:00:00.000Z'), to: new Date('2026-06-18T12:15:00.000Z') };
+
+  beforeEach(() => {
+    resetDbMocks();
+    shouldProduceMlOutputMock.mockReset();
+    shouldProduceMlOutputMock.mockImplementation(async (_orgId: string, flag: string) => flag === 'ml.anomalies.enabled');
+  });
+
+  /**
+   * Drive per-stage outcomes by call order, cycling so the SAME programme
+   * repeats for each successive `detectMetricAnomaliesRange` call — which is
+   * what the consecutive-skip tests need. (A non-cycling counter runs off the
+   * end of the array on run 2 and every stage silently succeeds, which is a
+   * vacuous green.)
+   */
+  function programDetectors(outcomes: Array<'ok' | string>): void {
+    let n = 0;
+    executeMock.mockImplementation(async (query: unknown) => {
+      const text = JSON.stringify(query);
+      if (text.includes('pg_try_advisory_xact_lock')) {
+        return [{ acquired: outcomes[n % outcomes.length] !== 'locked' }];
+      }
+      if (text.includes('INSERT INTO')) {
+        const outcome = outcomes[n % outcomes.length];
+        n += 1;
+        if (outcome && outcome !== 'ok') throw pgError(outcome);
+        return [];
+      }
+      return [{ acquired: true }];
+    });
+  }
+
+  it('reports a timeout ahead of later lock contention, so the actionable failure is not masked', async () => {
+    // baseline times out; growth-trend then loses the org lock to a racing
+    // backfill. Reporting this as a benign `locked` would hide the timeout —
+    // the one an operator actually has to act on.
+    let detectorIndex = 0;
+    executeMock.mockImplementation(async (query: unknown) => {
+      const text = JSON.stringify(query);
+      if (text.includes('pg_try_advisory_xact_lock')) {
+        return [{ acquired: detectorIndex < 1 }];
+      }
+      if (text.includes('INSERT INTO')) {
+        detectorIndex += 1;
+        throw pgError('57014');
+      }
+      return [{ acquired: true }];
+    });
+
+    const result = await detectMetricAnomaliesRange({ orgId, ...range });
+
+    expect(result.stages.map((stage) => `${stage.stage}:${stage.outcome}`)).toEqual([
+      'baseline:timeout',
+      'growth-trend:locked',
+    ]);
+    expect(result).toMatchObject({ skipped: true, skippedReason: 'timeout', statements: 0 });
+  });
+
+  it('does not mark the whole run skipped when only the v1 shadow stage loses the lock', async () => {
+    shouldProduceMlOutputMock.mockResolvedValue(true);
+    let detectorIndex = 0;
+    executeMock.mockImplementation(async (query: unknown) => {
+      const text = JSON.stringify(query);
+      // Refuse the lock only for the 5th stage (v1-shadow).
+      if (text.includes('pg_try_advisory_xact_lock')) return [{ acquired: detectorIndex < 4 }];
+      if (text.includes('INSERT INTO')) {
+        detectorIndex += 1;
+        return [];
+      }
+      return [{ acquired: true }];
+    });
+
+    const result = await detectMetricAnomaliesRange({ orgId, ...range });
+
+    expect(result).toMatchObject({
+      statements: 4,
+      v1ShadowStatements: 0,
+      v1ShadowSkipped: true,
+      skipped: false,
+    });
+    // The four main stages committed, so no skip reason may leak through.
+    expect(result.skippedReason).toBeUndefined();
+    expect(result.stages.map((stage) => stage.outcome)).toEqual([
+      'completed',
+      'completed',
+      'completed',
+      'completed',
+      'locked',
+    ]);
+  });
+
+  it('escalates to Sentry once a stage has skipped three consecutive runs, tagged with org, stage and SQLSTATE', async () => {
+    programDetectors(['57014', 'ok', 'ok', 'ok']);
+
+    await detectMetricAnomaliesRange({ orgId, ...range });
+    await detectMetricAnomaliesRange({ orgId, ...range });
+    // One skip is expected and self-healing — it must NOT page anyone.
+    expect(captureMessageMock).not.toHaveBeenCalled();
+
+    await detectMetricAnomaliesRange({ orgId, ...range });
+
+    expect(captureMessageMock).toHaveBeenCalledTimes(1);
+    expect(captureMessageMock).toHaveBeenCalledWith(
+      expect.stringContaining('3 consecutive'),
+      expect.objectContaining({
+        eventCode: 'metric_anomaly_stage_stalled',
+        tags: expect.objectContaining({
+          org_id: orgId,
+          metric_anomaly_stage: 'baseline',
+          // Separates an administrative pg_cancel_backend from a real bound trip.
+          pg_code: '57014',
+        }),
+      }),
+    );
+  });
+
+  it('clears the stall counter when a stage recovers, so old skips cannot accumulate into a false alert', async () => {
+    programDetectors(['57014', 'ok', 'ok', 'ok']);
+    await detectMetricAnomaliesRange({ orgId, ...range });
+    await detectMetricAnomaliesRange({ orgId, ...range });
+
+    // A healthy run in between resets the streak...
+    programDetectors(['ok', 'ok', 'ok', 'ok']);
+    await detectMetricAnomaliesRange({ orgId, ...range });
+
+    // ...so two further skips are still below the threshold.
+    programDetectors(['57014', 'ok', 'ok', 'ok']);
+    await detectMetricAnomaliesRange({ orgId, ...range });
+    await detectMetricAnomaliesRange({ orgId, ...range });
+
+    expect(captureMessageMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/services/metricAnomalies.ts
+++ b/apps/api/src/services/metricAnomalies.ts
@@ -1,10 +1,72 @@
 import { sql, type SQL } from 'drizzle-orm';
 
-import { db } from '../db';
-import { shouldProduceMlOutput } from './mlFeatureFlags';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
+import { tightenLockTimeout, tightenStatementTimeout } from '../db/lockTimeout';
+import { pgErrorCode } from '../utils/pgErrors';
+import { shouldProduceMlOutput, type MlFeatureFlagName } from './mlFeatureFlags';
 
 export const METRIC_ANOMALY_VERSION = 'metric-anomalies-v1';
 export const METRIC_ANOMALY_V1_SHADOW_VERSION = 'metric-anomaly-v1-seasonal-robust';
+
+/**
+ * Advisory-lock namespace for per-org anomaly detection (#5283).
+ *
+ * The two-int form of `pg_try_advisory_xact_lock` is deliberate: the sibling
+ * worker on the same table (`metricRollupMaintenance.tryAcquireMaintenanceLock`)
+ * takes the SINGLE-int `pg_try_advisory_lock(hashtext(...))`, and single-int and
+ * two-int advisory locks live in the same 64-bit key space — a one-arg
+ * `hashtext()` that happened to equal our packed pair would collide across two
+ * unrelated subsystems. Namespacing the org hash keeps the two disjoint.
+ */
+export const METRIC_ANOMALY_LOCK_NAMESPACE = 5283;
+
+/**
+ * Per-detector wait bounds (#5283).
+ *
+ * `lock_timeout` bounds each individual lock ACQUISITION, `statement_timeout`
+ * bounds the whole statement — both are needed, because a detector's upsert
+ * touches many rows and a run of staggered blockers would otherwise buy a fresh
+ * `lock_timeout` interval per row (see `db/lockTimeout`). Without these, the
+ * production incident held one pooled connection in a `Lock` wait for 29+
+ * minutes. A detector that trips either bound is skipped for this tick rather
+ * than crashing the worker; the next tick re-covers the window.
+ */
+export const METRIC_ANOMALY_LOCK_TIMEOUT_MS = 30_000;
+export const METRIC_ANOMALY_STATEMENT_TIMEOUT_MS = 90_000;
+
+/**
+ * The ordered detection stages. Each runs in its OWN transaction (#5283): the
+ * whole run used to share one, so a second run's `ON CONFLICT` upsert waited on
+ * the first run's *transactionid* for the duration of all four statements
+ * instead of just the one it actually conflicted with.
+ */
+export const METRIC_ANOMALY_STAGES = [
+  'baseline',
+  'growth-trend',
+  'process-runaway',
+  'incidents',
+  'v1-shadow',
+] as const;
+export type MetricAnomalyStage = (typeof METRIC_ANOMALY_STAGES)[number];
+
+/**
+ * - `completed` — the stage's statement committed.
+ * - `locked`    — another run for this org held the advisory lock. Not an
+ *                 error: the concurrent run is covering an overlapping window.
+ * - `timeout`   — the stage hit `lock_timeout` (55P03) or `statement_timeout`
+ *                 (57014) and was rolled back. Nothing was written.
+ */
+export type MetricAnomalyStageOutcome = 'completed' | 'locked' | 'timeout';
+
+export interface MetricAnomalyStageResult {
+  stage: MetricAnomalyStage;
+  outcome: MetricAnomalyStageOutcome;
+  durationMs: number;
+  /** Postgres SQLSTATE for a `timeout` outcome; absent otherwise. */
+  sqlState?: string;
+}
+
+export type MetricAnomalySkipReason = 'ml-disabled' | 'locked' | 'timeout';
 
 const RAW_BUCKET_SECONDS = 300;
 const BASELINE_LOOKBACK_HOURS = 24;
@@ -28,10 +90,118 @@ export interface MetricAnomalyResult {
   orgId: string;
   from: string;
   to: string;
+  /** Non-shadow stages that actually committed (was a hardcoded 4 before #5283). */
   statements: number;
   v1ShadowStatements?: number;
   v1ShadowSkipped?: boolean;
+  /**
+   * True when the run wrote NOTHING. Before #5283 that could only mean
+   * "ml.anomalies.enabled is off"; it now also covers a lock-contended or
+   * timed-out run, so read `skippedReason` rather than assuming the flag.
+   */
   skipped: boolean;
+  skippedReason?: MetricAnomalySkipReason;
+  /**
+   * Per-stage outcomes, in execution order. A run where some stages committed
+   * and others were `locked`/`timeout` reports `skipped: false` with a short
+   * `stages` array — that partial coverage is only legible here.
+   */
+  stages: MetricAnomalyStageResult[];
+}
+
+/**
+ * Try to claim this org's detection slot for the CURRENT transaction.
+ *
+ * `pg_try_advisory_xact_lock` never waits, so a second run returns false
+ * immediately instead of joining the queue behind the first — which is the
+ * whole point: the incident in #5283 was runs piling up in a `Lock` wait, not
+ * runs being slow. The lock releases at commit/rollback, so it scopes to
+ * exactly one stage.
+ */
+async function tryAcquireOrgDetectionLock(orgId: string): Promise<boolean> {
+  const result = await db.execute(sql`
+    SELECT pg_try_advisory_xact_lock(${METRIC_ANOMALY_LOCK_NAMESPACE}, hashtext(${orgId})) AS "acquired"
+  `);
+  const row = Array.isArray(result) ? (result[0] as { acquired?: unknown } | undefined) : undefined;
+  return row?.acquired === true;
+}
+
+/**
+ * Run one detection stage in its own system-scoped transaction, under the
+ * per-org advisory lock and bounded wait timeouts.
+ *
+ * `runOutsideDbContext` is load-bearing, not defensive: `withDbAccessContext`
+ * early-returns into an ambient context, so a caller that still wrapped the
+ * whole run (the CLI backfill did) would silently collapse all five stages back
+ * into ONE transaction — reintroducing the exact bug. Exiting the ambient store
+ * first guarantees a genuinely fresh transaction per stage regardless of caller.
+ *
+ * The timeout catch sits OUTSIDE the transaction callback on purpose: a 55P03 /
+ * 57014 aborts the transaction, so any statement issued after it inside the
+ * callback would fail 25P02 and mask the real cause. By the time we catch here,
+ * drizzle has rolled back and the connection is clean for the next stage.
+ */
+async function runDetectionStage(
+  stage: MetricAnomalyStage,
+  orgId: string,
+  run: () => Promise<void>,
+): Promise<MetricAnomalyStageResult> {
+  const startedAt = Date.now();
+  try {
+    const outcome = await runOutsideDbContext(() =>
+      withSystemDbAccessContext(async (): Promise<MetricAnomalyStageOutcome> => {
+        if (!(await tryAcquireOrgDetectionLock(orgId))) return 'locked';
+        // Never restored: this transaction ends with the stage, so `SET LOCAL`
+        // dies with it. Both helpers only ever tighten, so a caller that
+        // already set something stricter keeps its own bound.
+        await tightenLockTimeout(db, METRIC_ANOMALY_LOCK_TIMEOUT_MS);
+        await tightenStatementTimeout(db, METRIC_ANOMALY_STATEMENT_TIMEOUT_MS);
+        await run();
+        return 'completed';
+      }, `metricAnomalies.${stage}`),
+    );
+
+    if (outcome === 'locked') {
+      // Info, not warn: with a stable per-org scheduled job id this only
+      // happens when a manual backfill races the cron, and the winner is
+      // covering an overlapping window. Skipping is the designed behaviour.
+      console.info(
+        `[MetricAnomalies] org=${orgId} stage=${stage} skipped — another detection run holds the org advisory lock`,
+      );
+    }
+    return { stage, outcome, durationMs: Date.now() - startedAt };
+  } catch (error) {
+    const sqlState = pgErrorCode(error);
+    // 55P03 = lock_not_available (our `lock_timeout`), 57014 = query_canceled
+    // (our `statement_timeout`, or an administrative cancel — the code does not
+    // distinguish, and the response is the same either way). Both mean this
+    // stage wrote nothing and rolled back cleanly, so the run continues.
+    // Anything else is a real fault and must fail the job.
+    if (sqlState === '55P03' || sqlState === '57014') {
+      console.warn(
+        `[MetricAnomalies] org=${orgId} stage=${stage} exceeded its wait bound `
+          + `(SQLSTATE ${sqlState}) after ${Date.now() - startedAt}ms — skipped for this tick`,
+      );
+      return { stage, outcome: 'timeout', sqlState, durationMs: Date.now() - startedAt };
+    }
+    throw error;
+  }
+}
+
+/**
+ * Read one ML flag in its own short system context.
+ *
+ * `loadMlFlagInputs` reads `organizations` in the CALLER'S RLS context by
+ * design (#2822), so a contextless read matches zero rows and resolves the flag
+ * to `org_not_found` → disabled. Splitting the per-stage transactions out of the
+ * old single outer `withSystemDbAccessContext` therefore has to keep an explicit
+ * system context here, or anomaly detection would silently stop for every org
+ * with no error anywhere.
+ */
+async function readMlFlag(orgId: string, flag: MlFeatureFlagName): Promise<boolean> {
+  return runOutsideDbContext(() =>
+    withSystemDbAccessContext(() => shouldProduceMlOutput(orgId, flag), 'metricAnomalies.flags'),
+  );
 }
 
 function normalizeRange(from: Date, to: Date): { from: Date; to: Date } {
@@ -943,38 +1113,70 @@ async function detectSeasonalRobustCandidates(options: MetricAnomalyRange): Prom
 
 export async function detectMetricAnomaliesRange(options: MetricAnomalyRange): Promise<MetricAnomalyResult> {
   const { from, to } = normalizeRange(options.from, options.to);
-  if (!(await shouldProduceMlOutput(options.orgId, 'ml.anomalies.enabled'))) {
-    return {
-      orgId: options.orgId,
-      from: from.toISOString(),
-      to: to.toISOString(),
-      statements: 0,
-      skipped: true,
-    };
+  const range: MetricAnomalyRange = { orgId: options.orgId, from, to };
+  const base = { orgId: options.orgId, from: from.toISOString(), to: to.toISOString() };
+
+  if (!(await readMlFlag(options.orgId, 'ml.anomalies.enabled'))) {
+    return { ...base, statements: 0, skipped: true, skippedReason: 'ml-disabled', stages: [] };
   }
 
-  await detectBaselineDeviations(options);
-  await detectGrowthTrends(options);
-  await detectProcessSampleRunaways(options);
-  // Task 2 (#3828): collapse the rows the three detectors above just
-  // touched into their canonical incident row. Always runs (gated only by
-  // the same ml.anomalies.enabled flag as the rest of this function, via the
-  // early return above) — independent of the v1 shadow flag below, since it
-  // reads from metric_anomalies, never metric_anomaly_candidates.
-  await upsertMetricAnomalyIncidents(options);
+  // Task 2 (#3828): `incidents` collapses the rows the three detectors above it
+  // just touched into their canonical incident row. It is listed LAST and runs
+  // even when an earlier stage was skipped — it reads `metric_anomalies`, so it
+  // still has this tick's committed rows plus anything a previous tick left
+  // unmaterialised, and skipping it would strand those anomalies with no
+  // incident to dispatch.
+  const orderedStages: ReadonlyArray<readonly [MetricAnomalyStage, () => Promise<void>]> = [
+    ['baseline', () => detectBaselineDeviations(range)],
+    ['growth-trend', () => detectGrowthTrends(range)],
+    ['process-runaway', () => detectProcessSampleRunaways(range)],
+    ['incidents', () => upsertMetricAnomalyIncidents(range)],
+  ];
 
-  const runV1Shadow = await shouldProduceMlOutput(options.orgId, 'ml.anomalies.v1_shadow.enabled');
-  if (runV1Shadow) {
-    await detectSeasonalRobustCandidates(options);
+  const stages: MetricAnomalyStageResult[] = [];
+  let lockContended = false;
+
+  for (const [stage, run] of orderedStages) {
+    const result = await runDetectionStage(stage, options.orgId, run);
+    stages.push(result);
+    // Stop on `locked` — every later stage takes the SAME org key, so they
+    // would all fail to acquire too and the round trips would be pure waste.
+    // A `timeout` is per-statement, so the remaining stages still get a turn.
+    if (result.outcome === 'locked') {
+      lockContended = true;
+      break;
+    }
   }
+
+  let v1ShadowStatements = 0;
+  let v1ShadowSkipped = true;
+  if (!lockContended && (await readMlFlag(options.orgId, 'ml.anomalies.v1_shadow.enabled'))) {
+    const shadow = await runDetectionStage('v1-shadow', options.orgId, () =>
+      detectSeasonalRobustCandidates(range),
+    );
+    stages.push(shadow);
+    v1ShadowSkipped = shadow.outcome !== 'completed';
+    v1ShadowStatements = shadow.outcome === 'completed' ? 1 : 0;
+    if (shadow.outcome === 'locked') lockContended = true;
+  }
+
+  const statements = stages.filter(
+    (stage) => stage.stage !== 'v1-shadow' && stage.outcome === 'completed',
+  ).length;
+  const skipped = statements === 0 && v1ShadowStatements === 0;
 
   return {
-    orgId: options.orgId,
-    from: from.toISOString(),
-    to: to.toISOString(),
-    statements: 4,
-    v1ShadowStatements: runV1Shadow ? 1 : 0,
-    v1ShadowSkipped: !runV1Shadow,
-    skipped: false,
+    ...base,
+    statements,
+    v1ShadowStatements,
+    v1ShadowSkipped,
+    skipped,
+    // Only meaningful when nothing landed at all. `locked` wins over `timeout`
+    // because a contended run is expected and self-healing, while a timeout is
+    // the one an operator needs to look at.
+    ...(skipped
+      ? { skippedReason: (lockContended ? 'locked' : 'timeout') as MetricAnomalySkipReason }
+      : {}),
+    stages,
   };
 }

--- a/apps/api/src/services/metricAnomalies.ts
+++ b/apps/api/src/services/metricAnomalies.ts
@@ -3,6 +3,7 @@ import { sql, type SQL } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { tightenLockTimeout, tightenStatementTimeout } from '../db/lockTimeout';
 import { pgErrorCode } from '../utils/pgErrors';
+import { captureMessage } from './sentry';
 import { shouldProduceMlOutput, type MlFeatureFlagName } from './mlFeatureFlags';
 
 export const METRIC_ANOMALY_VERSION = 'metric-anomalies-v1';
@@ -127,6 +128,57 @@ async function tryAcquireOrgDetectionLock(orgId: string): Promise<boolean> {
 }
 
 /**
+ * Consecutive non-`completed` outcomes per (org, stage).
+ *
+ * One skip is expected and self-healing — a backfill raced the cron, or a
+ * detector lost a lock race. A RUN of them is not: a detector that is
+ * permanently too slow for its `statement_timeout`, or an org whose lock is
+ * held by something stuck, would otherwise skip on every tick forever behind
+ * nothing but a `console.warn`. That is the same invisible-degradation shape as
+ * the incident this fixes, so it escalates to Sentry.
+ *
+ * Entries are deleted on success, so the map is bounded by the set of
+ * CURRENTLY failing (org, stage) pairs rather than by fleet size.
+ */
+const consecutiveSkipsByOrgStage = new Map<string, number>();
+const METRIC_ANOMALY_STALL_ALERT_AFTER = 3;
+
+/** TEST ONLY — clears the consecutive-skip counters between cases. */
+export function __resetMetricAnomalyStallTracking(): void {
+  consecutiveSkipsByOrgStage.clear();
+}
+
+function recordStageOutcome(result: MetricAnomalyStageResult, orgId: string): void {
+  const key = `${orgId}:${result.stage}`;
+  if (result.outcome === 'completed') {
+    consecutiveSkipsByOrgStage.delete(key);
+    return;
+  }
+
+  const consecutive = (consecutiveSkipsByOrgStage.get(key) ?? 0) + 1;
+  consecutiveSkipsByOrgStage.set(key, consecutive);
+
+  // Fire on the threshold and then once per further N, so a permanently stuck
+  // stage reports roughly every 30 minutes at the 10-minute cron rather than on
+  // every tick. `scrubEvent` strips the message, so the tags carry the payload —
+  // `pg_code` is what separates an administrative `pg_cancel_backend` (57014,
+  // arriving once) from a genuine statement_timeout or lock_timeout regression.
+  if (consecutive % METRIC_ANOMALY_STALL_ALERT_AFTER !== 0) return;
+  captureMessage(
+    `Metric anomaly stage skipped ${consecutive} consecutive runs`,
+    {
+      eventCode: 'metric_anomaly_stage_stalled',
+      level: 'warning',
+      tags: {
+        org_id: orgId,
+        metric_anomaly_stage: result.stage,
+        ...(result.sqlState ? { pg_code: result.sqlState } : {}),
+      },
+    },
+  );
+}
+
+/**
  * Run one detection stage in its own system-scoped transaction, under the
  * per-org advisory lock and bounded wait timeouts.
  *
@@ -169,7 +221,9 @@ async function runDetectionStage(
         `[MetricAnomalies] org=${orgId} stage=${stage} skipped — another detection run holds the org advisory lock`,
       );
     }
-    return { stage, outcome, durationMs: Date.now() - startedAt };
+    const result: MetricAnomalyStageResult = { stage, outcome, durationMs: Date.now() - startedAt };
+    recordStageOutcome(result, orgId);
+    return result;
   } catch (error) {
     const sqlState = pgErrorCode(error);
     // 55P03 = lock_not_available (our `lock_timeout`), 57014 = query_canceled
@@ -182,7 +236,14 @@ async function runDetectionStage(
         `[MetricAnomalies] org=${orgId} stage=${stage} exceeded its wait bound `
           + `(SQLSTATE ${sqlState}) after ${Date.now() - startedAt}ms — skipped for this tick`,
       );
-      return { stage, outcome: 'timeout', sqlState, durationMs: Date.now() - startedAt };
+      const result: MetricAnomalyStageResult = {
+        stage,
+        outcome: 'timeout',
+        sqlState,
+        durationMs: Date.now() - startedAt,
+      };
+      recordStageOutcome(result, orgId);
+      return result;
     }
     throw error;
   }
@@ -1111,6 +1172,21 @@ async function detectSeasonalRobustCandidates(options: MetricAnomalyRange): Prom
   `);
 }
 
+/**
+ * Why a run that wrote nothing wrote nothing.
+ *
+ * `timeout` wins over `locked`, deliberately. A lock skip is the DESIGNED
+ * outcome — a concurrent run is covering an overlapping window and this one
+ * correctly stood down — whereas a timeout means a detector could not finish
+ * inside its wait bound, which is the outcome an operator has to act on. A run
+ * can end up with both (a stage times out, then a backfill takes the org lock
+ * before the next stage starts), and reporting that as a benign `locked` would
+ * hide the very signal the bounds exist to raise.
+ */
+function deriveSkipReason(stages: MetricAnomalyStageResult[]): MetricAnomalySkipReason {
+  return stages.some((stage) => stage.outcome === 'timeout') ? 'timeout' : 'locked';
+}
+
 export async function detectMetricAnomaliesRange(options: MetricAnomalyRange): Promise<MetricAnomalyResult> {
   const { from, to } = normalizeRange(options.from, options.to);
   const range: MetricAnomalyRange = { orgId: options.orgId, from, to };
@@ -1171,12 +1247,7 @@ export async function detectMetricAnomaliesRange(options: MetricAnomalyRange): P
     v1ShadowStatements,
     v1ShadowSkipped,
     skipped,
-    // Only meaningful when nothing landed at all. `locked` wins over `timeout`
-    // because a contended run is expected and self-healing, while a timeout is
-    // the one an operator needs to look at.
-    ...(skipped
-      ? { skippedReason: (lockContended ? 'locked' : 'timeout') as MetricAnomalySkipReason }
-      : {}),
+    ...(skipped ? { skippedReason: deriveSkipReason(stages) } : {}),
     stages,
   };
 }

--- a/apps/api/src/services/sentry.ts
+++ b/apps/api/src/services/sentry.ts
@@ -69,6 +69,14 @@ const ALLOWED_TAG_NAMES = new Set([
   // tenant, device, or command identifier.
   'prior_status',
   'cas_label',
+  // #5283: `metric_anomaly_stage_stalled` is only actionable if the operator
+  // can see WHICH detection stage is stuck — a stalled `baseline` (the heavy
+  // metric_rollups scan) and a stalled `incidents` (a small collapse over
+  // metric_anomalies) have completely different causes and fixes. Closed
+  // 5-value set (METRIC_ANOMALY_STAGES), written as string literals; carries no
+  // tenant, device, or host identifier. `org_id` is separately allowlisted
+  // above and is what scopes the alert to a tenant.
+  'metric_anomaly_stage',
   // #3022: a Postgres CONNECT_TIMEOUT is already tagged `pg_code:CONNECT_TIMEOUT`,
   // but that alone says nothing about WHY — the driver reports the identical
   // error whether the handshake failed or this process was simply never

--- a/apps/api/src/services/sentryEventCodes.ts
+++ b/apps/api/src/services/sentryEventCodes.ts
@@ -35,6 +35,16 @@ export const SENTRY_EVENT_CODES = [
   /** A mobile caller's device id resolved to no `mobile_devices` row. */
   'mobile_device_unresolved',
 
+  // --- background workers -----------------------------------------------
+  /**
+   * A metric-anomaly detection stage has been skipped (advisory-lock contention
+   * or a `lock_timeout`/`statement_timeout` trip) on N consecutive ticks for the
+   * same org. One skip is expected and self-healing; a run of them is a silent,
+   * indefinite detection outage for that org, which is exactly the shape of the
+   * incident #5283 fixed — invisible until Postgres was inspected by hand.
+   */
+  'metric_anomaly_stage_stalled',
+
   // --- database / pool --------------------------------------------------
   /** Pool-health watchdog published a non-healthy verdict. */
   'db_pool_health_degraded',


### PR DESCRIPTION
## Problem

Enabling `ml.anomalies.enabled` caused a real production incident (#5283): the same anomaly-baseline query against `metric_rollups` ran in overlapping instances, one held in a `Lock` wait for 29+ minutes while another executed, with the held-connection duration compounding across consecutive runs (~57s → 3min → 4min) until the only available mitigation was disabling the feature org-wide.

**Root cause — verified in source** (four defects that combine):

| # | Defect | Where |
|---|---|---|
| 1 | Scheduled job id included the detection window, which advances every cycle, so BullMQ's dedup never matched and every 10-min tick enqueued a **new** job for an org whose previous run was still open | `jobs/metricAnomalies.ts` `buildMetricAnomalyJobId` / `recentWindow` |
| 2 | **No overlap guard at all** — no advisory lock, no in-flight flag, no rate limiter. The sibling worker on the same table (`metricRollupMaintenance`) already takes `pg_try_advisory_lock`; this path never got it | `services/metricAnomalies.ts` |
| 3 | The whole per-org run was wrapped in **one** `withSystemDbAccessContext` = one transaction on one pooled connection for all four detectors, so run N+1 waited on run N's entire *transactionid* rather than the single statement it conflicted with | `jobs/metricAnomalies.ts` worker handler |
| 4 | No `lock_timeout` / `statement_timeout` anywhere on the path, so a blocked upsert pinned its connection indefinitely | `services/metricAnomalies.ts` |

The 30-minute lookback on a 10-minute cron meant consecutive windows overlapped by **four** buckets and hit identical `metric_anomalies` conflict keys every tick — that overlap is what the waiting PID was blocked on.

## Fix

1. **Stable scheduled job id.** `buildScheduledMetricAnomalyJobId(orgId)` carries no window, so an in-flight run collapses the next tick instead of stacking. The backfill path keeps its window-scoped id (two backfills over different ranges are genuinely different work). The fan-out enqueues per org rather than via `addBulk` — `addBulk` cannot express reuse-vs-replace, and BullMQ's dedup keys on *"a record exists"*, not *"a job is pending"*, so a retained completed/failed record under a stable id would have **wedged that org's detection permanently**. Both paths now share one `enqueueDetectOrgRange` helper.
2. **Per-org advisory lock.** Each stage takes `pg_try_advisory_xact_lock(5283, hashtext(org_id))` as its first statement and returns `skipped: 'locked'` (logged at info, never thrown) when it cannot acquire. `try` is the point: a contended run returns its pooled connection immediately instead of joining the queue behind the holder. Two-int form so it cannot collide with `metricRollupMaintenance`'s single-int lock.
3. **One transaction per stage.** Each of the five stages opens its own system-scoped transaction. `runOutsideDbContext` is load-bearing rather than defensive here — `withDbAccessContext` early-returns into an ambient context, so any caller still wrapping the run (the CLI backfill did) would have silently rebuilt the single long transaction with no error anywhere.
4. **Bounded waits.** `SET LOCAL lock_timeout = 30s` + `statement_timeout = 90s` per stage via the existing never-widening `db/lockTimeout` helpers. A stage that trips either (55P03 / 57014) is rolled back and skipped for the tick with a warning naming the SQLSTATE; the run continues. Any other SQLSTATE still fails the job.

### Lookback: 30 → 15 minutes (the choice this PR makes)

**Chosen: cron interval + one bucket = 15 minutes**, rather than documenting why overlap is required.

15 min is the smallest value that cannot drop a bucket: `to` is floored to a 5-minute boundary and advances 10 minutes per tick, so `[11:45,12:00)` is followed by `[11:55,12:10)` — full coverage with exactly **one** bucket of overlap instead of four. That one bucket is deliberate, not slack: it is the grace period for rollups that land after the tick that would otherwise be their only chance.

**Trade-off, stated plainly:** the old 30-minute window self-healed a missed tick for 20 minutes; this one does not. A tick that is skipped, coalesced, or lock-contended leaves buckets uncovered, and recovery is an explicit `enqueueMetricAnomalyBackfill` over the missed range rather than "the next tick picks it up". That is the intended exchange — an uncovered window beats an unbounded pile-up — and the new `reused`/skip logging makes it visible when it happens.

## API change

`MetricAnomalyResult` gains `stages[]` (per-stage outcome, duration, SQLSTATE) and `skippedReason` (`ml-disabled` | `locked` | `timeout`), and `statements` now counts stages that actually committed instead of being hardcoded to `4`. `skipped` is no longer synonymous with "flag off", so the CLI backfill was updated — it previously reported every skip as "detection is disabled for this org", which would have told an operator to change a setting when the correct action was to re-run.

## Verification

**Verified (ran locally):**
- `apps/api` unit suites, single-fork: **104 passed / 8 files** (`jobs/metricAnomalies`, `services/metricAnomalies`, plus the anomaly publisher/retention/promotion, workerRegistry, analytics, and backfill-lib suites).
- **Integration, against real Postgres** (private worktree stack): `metricAnomalies.integration.test.ts` **10 passed**, including four new proofs — a contended run returns in <5s with `skipped: 'locked'` instead of blocking; a **positive control** that an unrelated org is *not* serialised by another org's lock; no advisory lock survives a run; and an xid-count proof that the stages commit separately (write-backed, with a guard assertion so it cannot pass vacuously if the seed stops producing writes).
- `npx tsc --noEmit` on `apps/api`: clean. `eslint` on all changed files: clean.
- **Mutation-checked, not just green.** Every new assertion was confirmed to go **red** against a reverted fix: lock guard removed → skip test fails; per-stage contexts collapsed to one label → per-stage test fails; `statement_timeout` dropped → bounds test fails; timeout catch widened to all errors → error-propagation test fails; window-scoped scheduled id restored → 2 job tests fail; lookback reverted to 30 → window test fails; spent-record replacement removed → wedge test fails; advisory lock removed → the real-Postgres skip test fails.

**Inferred (not reproduced):** that these four defects produced the reporter's specific 29-minute hold. The mechanism and the missing guard are verified in source and the code would produce exactly that shape, but I did not reproduce the incident itself.

**Not checked:** whether 90s is the right `statement_timeout` for the largest production orgs. It is comfortably above a healthy run on a 15-minute window with the `device_process_samples (org_id, timestamp)` index from #5009, but if a big org's baseline query legitimately exceeds it, that stage would skip every tick — visible as a repeating `exceeded its wait bound` warning naming the SQLSTATE. **This is the one thing worth watching after deploy;** the bound is an exported constant, so raising it is a one-line change.

No schema change, no migration, no new table or column — so no RLS/cascade/export-policy registration applies.

## Release note

Fixed anomaly detection (`ml.anomalies.enabled`) piling up overlapping runs against `metric_rollups`, which could hold database connections in lock waits for tens of minutes and required disabling the feature. Detection now skips a run when one is already in flight for the same organization, runs each detector in its own transaction, and bounds how long any detector will wait.

Closes #5283

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGT9BJVfpG3nyM6c9koAN8
