### PR TITLE
feat(devices): colour the Agent Version column by relation to the effective pin (#5285)

### DIFF
--- a/apps/api/src/routes/agentVersions.effective.test.ts
+++ b/apps/api/src/routes/agentVersions.effective.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Tests for GET /agent-versions/effective — issue #5285: the Devices list
+ * "Agent Version" column needs each visible org's EFFECTIVE agent-version
+ * target (its agentVersionPins.agent pin, or the globally promoted version
+ * when unpinned) to colour-code rows, resolved ONCE per page load across
+ * every visible org rather than once per device row.
+ *
+ * This route is a thin composition of two already-tested resolvers
+ * (getOrgAgentVersionPinsBatch in agents/helpers.ts,
+ * getPromotedAgentVersionForDisplay in services/promotedAgentVersion.ts), so
+ * both are mocked here — this file pins the route's OWN contract: query
+ * parsing, auth scoping (an orgId outside the caller's access is silently
+ * dropped, never a 403 leak), and the pin-vs-promoted merge.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+vi.mock('../middleware/auth', () => ({
+  authMiddleware: vi.fn((c: any, next: any) => next()),
+  requireScope: vi.fn((..._scopes: string[]) => (_c: any, next: any) => next()),
+  requirePermission: vi.fn(() => async (_c: any, next: any) => next()),
+  requireMfa: vi.fn(() => async (_c: any, next: any) => next()),
+}));
+
+vi.mock('../middleware/platformAdmin', () => ({
+  platformAdminMiddleware: vi.fn(async (_c: any, next: any) => next()),
+}));
+
+const pinsMock = vi.hoisted(() => ({ fn: vi.fn() }));
+vi.mock('../services/orgAgentVersionPins', () => ({
+  getOrgAgentVersionPinsBatch: pinsMock.fn,
+}));
+
+const promotedMock = vi.hoisted(() => ({ fn: vi.fn() }));
+vi.mock('../services/promotedAgentVersion', () => ({
+  getPromotedAgentVersionForDisplay: promotedMock.fn,
+  // Referenced elsewhere in agentVersions.ts (download route) — stub so the
+  // module still loads.
+  getPromotedComponentVersion: vi.fn(async () => null),
+  getRegisteredComponentVersion: vi.fn(async () => null),
+  PromotedVersionUnavailableError: class extends Error {},
+}));
+
+vi.mock('../services/binarySync', () => ({ syncFromGitHub: vi.fn() }));
+vi.mock('../services/sentry', () => ({ captureException: vi.fn(), captureMessage: vi.fn() }));
+vi.mock('../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
+vi.mock('../services/manifestSigning', () => ({
+  getActivePublicKeys: vi.fn().mockResolvedValue([]),
+  getActiveTrustKeyset: vi.fn().mockResolvedValue([]),
+  ensureActiveSigningKey: vi.fn().mockResolvedValue({ keyId: 'test-key', publicKeyB64: '' }),
+  signManifest: vi.fn().mockResolvedValue('test-signature'),
+}));
+
+vi.mock('../db', () => ({
+  db: { select: vi.fn(), insert: vi.fn(), update: vi.fn(), transaction: vi.fn() },
+}));
+
+import { agentVersionRoutes } from './agentVersions';
+import { authMiddleware } from '../middleware/auth';
+
+function buildAuth(overrides: Partial<{
+  scope: 'system' | 'partner' | 'organization';
+  orgId: string | null;
+  accessibleOrgIds: string[] | null;
+}> = {}) {
+  const scope = overrides.scope ?? 'partner';
+  const accessibleOrgIds: string[] | null =
+    'accessibleOrgIds' in overrides ? (overrides.accessibleOrgIds ?? null) : ['org-a', 'org-b'];
+  return {
+    user: { id: 'user-1', email: 't@example.com', name: 'Test', isPlatformAdmin: false },
+    token: {},
+    partnerId: 'partner-1',
+    orgId: overrides.orgId ?? null,
+    scope,
+    accessibleOrgIds,
+    canAccessOrg: (id: string) =>
+      accessibleOrgIds === null ? true : accessibleOrgIds.includes(id),
+  };
+}
+
+describe('GET /agent-versions/effective', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = new Hono();
+    app.route('/agent-versions', agentVersionRoutes);
+  });
+
+  function setAuth(auth: ReturnType<typeof buildAuth>) {
+    vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+      c.set('auth', auth);
+      return next();
+    });
+  }
+
+  it('uses the org pin when one is set', async () => {
+    setAuth(buildAuth());
+    pinsMock.fn.mockResolvedValue({ 'org-a': { agent: '0.88.0', watchdog: null } });
+    promotedMock.fn.mockResolvedValue('0.110.0');
+
+    const res = await app.request('/agent-versions/effective?orgIds=org-a');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toEqual({ 'org-a': '0.88.0' });
+  });
+
+  it('falls back to the globally promoted version when the org has no pin', async () => {
+    setAuth(buildAuth());
+    pinsMock.fn.mockResolvedValue({ 'org-a': { agent: null, watchdog: null } });
+    promotedMock.fn.mockResolvedValue('0.110.0');
+
+    const res = await app.request('/agent-versions/effective?orgIds=org-a');
+    const body = await res.json();
+    expect(body.data).toEqual({ 'org-a': '0.110.0' });
+  });
+
+  it('resolves the promoted fallback ONCE regardless of how many orgs are requested', async () => {
+    setAuth(buildAuth({ accessibleOrgIds: ['org-a', 'org-b', 'org-c'] }));
+    pinsMock.fn.mockResolvedValue({
+      'org-a': { agent: null, watchdog: null },
+      'org-b': { agent: '0.90.0', watchdog: null },
+      'org-c': { agent: null, watchdog: null },
+    });
+    promotedMock.fn.mockResolvedValue('0.110.0');
+
+    const res = await app.request('/agent-versions/effective?orgIds=org-a,org-b,org-c');
+    const body = await res.json();
+    expect(body.data).toEqual({
+      'org-a': '0.110.0',
+      'org-b': '0.90.0',
+      'org-c': '0.110.0',
+    });
+    expect(promotedMock.fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null for an org when neither a pin nor a promoted version exists (never synced)', async () => {
+    setAuth(buildAuth());
+    pinsMock.fn.mockResolvedValue({ 'org-a': { agent: null, watchdog: null } });
+    promotedMock.fn.mockResolvedValue(null);
+
+    const res = await app.request('/agent-versions/effective?orgIds=org-a');
+    const body = await res.json();
+    expect(body.data).toEqual({ 'org-a': null });
+  });
+
+  it('silently drops an orgId the caller cannot access, rather than erroring', async () => {
+    setAuth(buildAuth({ accessibleOrgIds: ['org-a'] }));
+    pinsMock.fn.mockResolvedValue({ 'org-a': { agent: '0.88.0', watchdog: null } });
+    promotedMock.fn.mockResolvedValue('0.110.0');
+
+    const res = await app.request('/agent-versions/effective?orgIds=org-a,org-forbidden');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toEqual({ 'org-a': '0.88.0' });
+    // The batch resolver is only ever asked about orgs the caller can access.
+    expect(pinsMock.fn).toHaveBeenCalledWith(['org-a']);
+  });
+
+  it('returns an empty map without calling either resolver when no requested org is accessible', async () => {
+    setAuth(buildAuth({ accessibleOrgIds: [] }));
+
+    const res = await app.request('/agent-versions/effective?orgIds=org-a,org-b');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toEqual({});
+    expect(pinsMock.fn).not.toHaveBeenCalled();
+    expect(promotedMock.fn).not.toHaveBeenCalled();
+  });
+
+  it('system scope can access any requested org', async () => {
+    setAuth(buildAuth({ scope: 'system', accessibleOrgIds: null }));
+    pinsMock.fn.mockResolvedValue({ 'org-anything': { agent: '0.99.0', watchdog: null } });
+    promotedMock.fn.mockResolvedValue(null);
+
+    const res = await app.request('/agent-versions/effective?orgIds=org-anything');
+    const body = await res.json();
+    expect(body.data).toEqual({ 'org-anything': '0.99.0' });
+  });
+
+  it('rejects a request with no orgIds query param', async () => {
+    setAuth(buildAuth());
+    const res = await app.request('/agent-versions/effective');
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/api/src/routes/agentVersions.effective.test.ts
+++ b/apps/api/src/routes/agentVersions.effective.test.ts
@@ -6,7 +6,7 @@
  * every visible org rather than once per device row.
  *
  * This route is a thin composition of two already-tested resolvers
- * (getOrgAgentVersionPinsBatch in agents/helpers.ts,
+ * (getOrgAgentVersionPinsBatch in services/orgAgentVersionPins.ts,
  * getPromotedAgentVersionForDisplay in services/promotedAgentVersion.ts), so
  * both are mocked here — this file pins the route's OWN contract: query
  * parsing, auth scoping (an orgId outside the caller's access is silently

--- a/apps/api/src/routes/agentVersions.ts
+++ b/apps/api/src/routes/agentVersions.ts
@@ -10,6 +10,7 @@ import {
   requireMfa,
   requirePermission,
   requireScope,
+  type AuthContext,
 } from "../middleware/auth";
 import { platformAdminMiddleware } from "../middleware/platformAdmin";
 import { writeRouteAudit } from "../services/auditEvents";
@@ -18,7 +19,11 @@ import { captureException } from "../services/sentry";
 import { ResponseTooLargeError, SsrfBlockedError } from "../services/urlSafety";
 import { getBinaryEdition } from "../services/binaryEdition";
 import { getBinarySource, getGithubReleaseVersion } from "../services/binarySource";
-import { getPromotedComponentVersion } from "../services/promotedAgentVersion";
+import {
+  getPromotedComponentVersion,
+  getPromotedAgentVersionForDisplay,
+} from "../services/promotedAgentVersion";
+import { getOrgAgentVersionPinsBatch } from "../services/orgAgentVersionPins";
 import { PERMISSIONS } from "../services/permissions";
 import {
   verifyReleaseArtifactManifestAsset,
@@ -80,6 +85,13 @@ const latestQuerySchema = z.object({
   platform: platformEnum,
   arch: architectureEnum,
   component: componentEnum.optional().default("agent"),
+});
+
+// Issue #5285: comma-separated orgIds for GET /agent-versions/effective. A
+// generous but bounded cap (below) keeps one caller from turning this into an
+// unbounded fan-out; the query itself is otherwise as cheap as GET /orgs.
+const effectiveVersionsQuerySchema = z.object({
+  orgIds: z.string().min(1),
 });
 
 const downloadParamsSchema = z.object({
@@ -675,6 +687,62 @@ export async function validateReleaseManifest(args: {
 
   return { ok: true };
 }
+
+// GET /agent-versions/effective?orgIds=a,b,c — issue #5285. The Devices list
+// "Agent Version" column needs each visible org's EFFECTIVE agent-version
+// target (its agentVersionPins.agent pin, or the globally promoted version
+// when unpinned) to colour-code device rows by relation to it. Resolved ONCE
+// per page load across every visible org (this one request), never per row —
+// the caller (DevicesPage) calls this after loading /orgs, not per device.
+//
+// Mounted BEFORE the "/:version/download" family below (this file has no
+// "/:orgId"-shaped route to collide with, but keeping static paths ahead of
+// param routes is the house style in this file).
+agentVersionRoutes.get(
+  "/effective",
+  authMiddleware,
+  requireScope("organization", "partner", "system"),
+  zValidator("query", effectiveVersionsQuerySchema),
+  async (c) => {
+    const auth = c.get("auth") as AuthContext;
+    const { orgIds: orgIdsParam } = c.req.valid("query");
+
+    // Silently drop an orgId the caller cannot access rather than 403ing the
+    // whole request — a stale/foreign id on the query string (e.g. a device
+    // row from an org the caller lost access to mid-session) should not sink
+    // every other org's badge, and dropping it never confirms or denies that
+    // the id exists (same posture as GET /orgs' accessible-scope filter).
+    // Capped well above any real page's distinct-org count so one caller
+    // can't turn this into an unbounded fan-out.
+    const requested = [
+      ...new Set(
+        orgIdsParam
+          .split(",")
+          .map((id) => id.trim())
+          .filter(Boolean),
+      ),
+    ].slice(0, 200);
+    const allowed = requested.filter((id) => auth.canAccessOrg(id));
+
+    if (allowed.length === 0) {
+      return c.json({ data: {} });
+    }
+
+    // The pin batch is per-org; the promoted fallback is edition-wide, so it
+    // is resolved ONCE for the whole request regardless of org count.
+    const [pinsByOrg, promoted] = await Promise.all([
+      getOrgAgentVersionPinsBatch(allowed),
+      getPromotedAgentVersionForDisplay(),
+    ]);
+
+    const data: Record<string, string | null> = {};
+    for (const orgId of allowed) {
+      data[orgId] = pinsByOrg[orgId]?.agent ?? promoted;
+    }
+
+    return c.json({ data });
+  },
+);
 
 // GET /agent-versions/latest - Get latest version info for platform/arch
 // This endpoint is public (no auth) so agents can check for updates

--- a/apps/api/src/routes/agents/helpers.agentUpdatePolicy.test.ts
+++ b/apps/api/src/routes/agents/helpers.agentUpdatePolicy.test.ts
@@ -424,6 +424,11 @@ describe('getOrgAgentUpdateConfig — version pins', () => {
   });
 });
 
+// getOrgAgentVersionPinsBatch (issue #5285) lives in its own service module
+// (services/orgAgentVersionPins.ts) with its own minimal test file — it does
+// not import helpers.ts, so its tests don't belong in this file's heavy
+// mock harness. See orgAgentVersionPins.test.ts.
+
 // ---------------------------------------------------------------------------
 // resolvePinnedUpgradeTarget — turns a pin (or its absence) into a concrete
 // target version, fail-closed when a pinned build is missing for the device's

--- a/apps/api/src/routes/agents/helpers.ts
+++ b/apps/api/src/routes/agents/helpers.ts
@@ -68,7 +68,11 @@ import {
   normalizeAgentUpdatePolicy,
   type AgentUpdateSettings,
 } from './agentUpdatePolicy';
-import { isAlwaysMaintenanceWindow, parseMaintenanceWindow, normalizeVersionPin } from '@breeze/shared';
+import {
+  isAlwaysMaintenanceWindow,
+  parseMaintenanceWindow,
+  resolveInheritedAgentVersionPins,
+} from '@breeze/shared';
 import {
   type SecurityProviderValue,
   type SecurityStatusPayload,
@@ -2300,20 +2304,13 @@ export async function getOrgAgentUpdateConfig(orgId: string): Promise<AgentUpdat
     'maintenanceWindow' in partnerDefaults
       ? partnerDefaults.maintenanceWindow
       : orgDefaults.maintenanceWindow;
-  // Version pins: inherit-with-override, per component (issue #2124). An org-set
-  // component wins for that org; where the org has NOT set a component the partner
-  // default is inherited; unset at both levels → global promoted latest. Keyed by
-  // PRESENCE ('agent' in orgPins), NOT truthiness, so an org can store 'latest' to
-  // deliberately override a partner pin back to the global latest. Agent and
-  // watchdog are independent.
-  const orgPins = isObject(orgDefaults.agentVersionPins) ? orgDefaults.agentVersionPins : {};
-  const partnerPins = isObject(partnerDefaults.agentVersionPins)
-    ? partnerDefaults.agentVersionPins
-    : {};
-  const pins: AgentVersionPins = {
-    agent: normalizeVersionPin('agent' in orgPins ? orgPins.agent : partnerPins.agent),
-    watchdog: normalizeVersionPin('watchdog' in orgPins ? orgPins.watchdog : partnerPins.watchdog),
-  };
+  // Version pins: inherit-with-override, per component (issue #2124). Resolved
+  // via the shared `resolveInheritedAgentVersionPins` (packages/shared) — the
+  // SAME function `getOrgAgentVersionPinsBatch`
+  // (services/orgAgentVersionPins.ts, issue #5285) calls, so the two resolvers
+  // can never silently drift apart. See that function's docstring for the
+  // full precedence contract.
+  const pins: AgentVersionPins = resolveInheritedAgentVersionPins(orgDefaults, partnerDefaults);
 
   const policy = normalizeAgentUpdatePolicy(effectivePolicy);
   const rawWindow = typeof effectiveWindow === 'string' ? effectiveWindow.trim() : '';

--- a/apps/api/src/services/orgAgentVersionPins.test.ts
+++ b/apps/api/src/services/orgAgentVersionPins.test.ts
@@ -9,10 +9,31 @@
  * imports only db/schema + @breeze/shared, NOT routes/agents/helpers.ts
  * (whose import graph is far larger and broke unrelated route tests when
  * this function briefly lived there — see the comment in the source file).
+ *
+ * IMPORTANT LIMITATION (mirrors enrollmentDefaults.test.ts, issue #2776's
+ * pattern): a mocked-DB unit test CANNOT prove that an org-scoped caller
+ * actually sees the partner's pin — that requires real Postgres RLS to
+ * deny/allow the `partners` row, which no mock can emulate. These tests only
+ * prove the WIRING: that the join runs via
+ * runOutsideDbContext(withSystemDbAccessContext(...)) whenever the ambient
+ * context is not already system-scoped, exactly as `getEnrollmentDefaultsForOrg`
+ * (services/enrollmentDefaults.ts) does for the identical org⋈partner RLS
+ * shape. Without this escalation, `computeAccessiblePartnerIds` returns `[]`
+ * for an organization-scoped caller (middleware/auth.ts), the `partners` FOR
+ * SELECT policy `breeze_has_partner_access(id)` denies the row, and the
+ * LEFT JOIN silently returns `partnerSettings: null` — a partner-inherited
+ * pin would vanish with no error for exactly the population (org-scoped
+ * tokens hitting GET /agent-versions/effective) this resolver exists to
+ * serve.
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { dbMock } = vi.hoisted(() => {
+const {
+  dbMock,
+  runOutsideDbContextMock,
+  withSystemDbAccessContextMock,
+  getCurrentDbAccessContextMock,
+} = vi.hoisted(() => {
   let nextResult: unknown[] = [];
   const chains: any[] = [];
 
@@ -34,10 +55,30 @@ const { dbMock } = vi.hoisted(() => {
     },
   };
 
-  return { dbMock };
+  // Pass-through mocks that still let assertions verify they were invoked —
+  // real behavior (exiting the ALS context, setting RLS GUCs) can't be
+  // exercised without a real DB; the underlying escape mechanism is already
+  // proven against Postgres by enrollmentDefaultsPartnerCap.integration.test.ts.
+  const runOutsideDbContextMock = vi.fn((fn: () => unknown) => fn());
+  const withSystemDbAccessContextMock = vi.fn((fn: () => unknown) => fn());
+  // Ambient DbAccessContext metadata. Default: no context at all (background /
+  // contextless caller), which must take the escape just like an org-scoped one.
+  const getCurrentDbAccessContextMock = vi.fn((): unknown => undefined);
+
+  return {
+    dbMock,
+    runOutsideDbContextMock,
+    withSystemDbAccessContextMock,
+    getCurrentDbAccessContextMock,
+  };
 });
 
-vi.mock('../db', () => ({ db: dbMock }));
+vi.mock('../db', () => ({
+  db: dbMock,
+  runOutsideDbContext: runOutsideDbContextMock,
+  withSystemDbAccessContext: withSystemDbAccessContextMock,
+  getCurrentDbAccessContext: getCurrentDbAccessContextMock,
+}));
 vi.mock('../db/schema', () => ({
   organizations: { id: 'orgs.id', settings: 'orgs.settings', partnerId: 'orgs.partner_id' },
   partners: { id: 'partners.id', settings: 'partners.settings' },
@@ -45,9 +86,87 @@ vi.mock('../db/schema', () => ({
 
 import { getOrgAgentVersionPinsBatch } from './orgAgentVersionPins';
 
+/** Stand-in for the metadata AsyncLocalStorage store of an active context. */
+function ambientContext(scope: 'system' | 'partner' | 'organization'): unknown {
+  return {
+    scope,
+    orgId: scope === 'organization' ? 'org-a' : null,
+    accessibleOrgIds: scope === 'organization' ? ['org-a'] : null,
+    accessiblePartnerIds: scope === 'system' ? null : [],
+    userId: null,
+  };
+}
+
 describe('getOrgAgentVersionPinsBatch', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    runOutsideDbContextMock.mockImplementation((fn: () => unknown) => fn());
+    withSystemDbAccessContextMock.mockImplementation((fn: () => unknown) => fn());
+    getCurrentDbAccessContextMock.mockImplementation(() => undefined);
+  });
+
+  // The RLS-escalation wiring (partner rows are invisible to an org-scoped
+  // request otherwise — see the file header). Mirrors
+  // enrollmentDefaults.test.ts's "ambient-context branch" exactly, since this
+  // resolver is the same org⋈partner-join-under-RLS shape.
+  describe('ambient-context branch', () => {
+    it('reads in the AMBIENT context — opening no second context — when the caller is already system-scoped', async () => {
+      getCurrentDbAccessContextMock.mockImplementation(() => ambientContext('system'));
+      dbMock._setResult([
+        { id: 'org-a', orgSettings: { defaults: {} }, partnerSettings: { defaults: { agentVersionPins: { agent: '0.88.0' } } } },
+      ]);
+
+      const result = await getOrgAgentVersionPinsBatch(['org-a']);
+
+      expect(result).toEqual({ 'org-a': { agent: '0.88.0', watchdog: null } });
+      expect(dbMock.select).toHaveBeenCalledTimes(1);
+      expect(runOutsideDbContextMock).not.toHaveBeenCalled();
+      expect(withSystemDbAccessContextMock).not.toHaveBeenCalled();
+    });
+
+    it('escapes to a fresh system context for an ORG-scoped caller, so the partner-inherited pin is not silently lost', async () => {
+      getCurrentDbAccessContextMock.mockImplementation(() => ambientContext('organization'));
+      dbMock._setResult([
+        { id: 'org-a', orgSettings: { defaults: {} }, partnerSettings: { defaults: { agentVersionPins: { agent: '0.88.0' } } } },
+      ]);
+
+      const result = await getOrgAgentVersionPinsBatch(['org-a']);
+
+      expect(result).toEqual({ 'org-a': { agent: '0.88.0', watchdog: null } });
+      expect(runOutsideDbContextMock).toHaveBeenCalledTimes(1);
+      expect(withSystemDbAccessContextMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('escapes for a PARTNER-scoped caller too (partner scope sees only its OWN partner row otherwise)', async () => {
+      getCurrentDbAccessContextMock.mockImplementation(() => ambientContext('partner'));
+      dbMock._setResult([{ id: 'org-a', orgSettings: { defaults: {} }, partnerSettings: null }]);
+
+      await getOrgAgentVersionPinsBatch(['org-a']);
+
+      expect(runOutsideDbContextMock).toHaveBeenCalledTimes(1);
+      expect(withSystemDbAccessContextMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('escapes when there is no ambient context at all (background/worker caller)', async () => {
+      getCurrentDbAccessContextMock.mockImplementation(() => undefined);
+      dbMock._setResult([{ id: 'org-a', orgSettings: { defaults: {} }, partnerSettings: null }]);
+
+      await getOrgAgentVersionPinsBatch(['org-a']);
+
+      expect(runOutsideDbContextMock).toHaveBeenCalledTimes(1);
+      expect(withSystemDbAccessContextMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not escalate for an empty orgIds input (no query is issued at all)', async () => {
+      getCurrentDbAccessContextMock.mockImplementation(() => ambientContext('organization'));
+
+      const result = await getOrgAgentVersionPinsBatch([]);
+
+      expect(result).toEqual({});
+      expect(dbMock.select).not.toHaveBeenCalled();
+      expect(runOutsideDbContextMock).not.toHaveBeenCalled();
+      expect(withSystemDbAccessContextMock).not.toHaveBeenCalled();
+    });
   });
 
   it('returns an empty map without querying for an empty input', async () => {

--- a/apps/api/src/services/orgAgentVersionPins.test.ts
+++ b/apps/api/src/services/orgAgentVersionPins.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for getOrgAgentVersionPinsBatch — the batch variant of
+ * getOrgAgentUpdateConfig's pin resolution (routes/agents/helpers.ts), for
+ * read paths that need MANY orgs' effective agent-version pins in one round
+ * trip (issue #5285: the Devices list "Agent Version" badge, resolved once
+ * per page load across every visible org).
+ *
+ * Deliberately its own file with its own minimal mock harness: this module
+ * imports only db/schema + @breeze/shared, NOT routes/agents/helpers.ts
+ * (whose import graph is far larger and broke unrelated route tests when
+ * this function briefly lived there — see the comment in the source file).
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { dbMock } = vi.hoisted(() => {
+  let nextResult: unknown[] = [];
+  const chains: any[] = [];
+
+  const makeSelectChain = () => {
+    const chain: any = {
+      from: vi.fn(() => chain),
+      leftJoin: vi.fn(() => chain),
+      where: vi.fn(() => chain),
+    };
+    chain.then = (resolve: any, reject: any) => Promise.resolve(nextResult).then(resolve, reject);
+    chains.push(chain);
+    return chain;
+  };
+
+  const dbMock = {
+    select: vi.fn(() => makeSelectChain()),
+    _setResult(rows: unknown[]) {
+      nextResult = rows;
+    },
+  };
+
+  return { dbMock };
+});
+
+vi.mock('../db', () => ({ db: dbMock }));
+vi.mock('../db/schema', () => ({
+  organizations: { id: 'orgs.id', settings: 'orgs.settings', partnerId: 'orgs.partner_id' },
+  partners: { id: 'partners.id', settings: 'partners.settings' },
+}));
+
+import { getOrgAgentVersionPinsBatch } from './orgAgentVersionPins';
+
+describe('getOrgAgentVersionPinsBatch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns an empty map without querying for an empty input', async () => {
+    const result = await getOrgAgentVersionPinsBatch([]);
+    expect(result).toEqual({});
+    expect(dbMock.select).not.toHaveBeenCalled();
+  });
+
+  it('resolves pins for multiple orgs from ONE joined query', async () => {
+    dbMock._setResult([
+      { id: 'org-a', orgSettings: { defaults: { agentVersionPins: { agent: '0.88.0' } } }, partnerSettings: null },
+      { id: 'org-b', orgSettings: { defaults: {} }, partnerSettings: { defaults: { agentVersionPins: { agent: '0.90.0' } } } },
+      { id: 'org-c', orgSettings: { defaults: {} }, partnerSettings: null },
+    ]);
+    const result = await getOrgAgentVersionPinsBatch(['org-a', 'org-b', 'org-c']);
+    expect(dbMock.select).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      'org-a': { agent: '0.88.0', watchdog: null },
+      'org-b': { agent: '0.90.0', watchdog: null },
+      'org-c': { agent: null, watchdog: null },
+    });
+  });
+
+  it('org pin overrides an inherited partner pin, same precedence as the single-org resolver', async () => {
+    dbMock._setResult([
+      {
+        id: 'org-a',
+        orgSettings: { defaults: { agentVersionPins: { agent: '0.80.0' } } },
+        partnerSettings: { defaults: { agentVersionPins: { agent: '0.88.0' } } },
+      },
+    ]);
+    const result = await getOrgAgentVersionPinsBatch(['org-a']);
+    expect(result).toEqual({ 'org-a': { agent: '0.80.0', watchdog: null } });
+  });
+
+  it('org inherits the partner pin per component where the org has not set it', async () => {
+    dbMock._setResult([
+      {
+        id: 'org-a',
+        orgSettings: { defaults: { agentVersionPins: { watchdog: '0.70.0' } } },
+        partnerSettings: { defaults: { agentVersionPins: { agent: '0.88.0' } } },
+      },
+    ]);
+    const result = await getOrgAgentVersionPinsBatch(['org-a']);
+    expect(result).toEqual({ 'org-a': { agent: '0.88.0', watchdog: '0.70.0' } });
+  });
+
+  it("normalizes the 'latest' sentinel to null (no pin), same as the single-org resolver", async () => {
+    dbMock._setResult([
+      { id: 'org-a', orgSettings: { defaults: { agentVersionPins: { agent: 'latest' } } }, partnerSettings: null },
+    ]);
+    const result = await getOrgAgentVersionPinsBatch(['org-a']);
+    expect(result).toEqual({ 'org-a': { agent: null, watchdog: null } });
+  });
+
+  it('an org missing from the result rows (e.g. deleted mid-request) is simply absent, not a crash', async () => {
+    dbMock._setResult([
+      { id: 'org-a', orgSettings: { defaults: {} }, partnerSettings: null },
+    ]);
+    const result = await getOrgAgentVersionPinsBatch(['org-a', 'org-missing']);
+    expect(result).toEqual({ 'org-a': { agent: null, watchdog: null } });
+  });
+});

--- a/apps/api/src/services/orgAgentVersionPins.ts
+++ b/apps/api/src/services/orgAgentVersionPins.ts
@@ -1,6 +1,11 @@
 import { eq, inArray } from 'drizzle-orm';
-import { normalizeVersionPin } from '@breeze/shared';
-import { db } from '../db';
+import { resolveInheritedAgentVersionPins } from '@breeze/shared';
+import {
+  db,
+  getCurrentDbAccessContext,
+  runOutsideDbContext,
+  withSystemDbAccessContext,
+} from '../db';
 import { organizations, partners } from '../db/schema';
 
 /**
@@ -12,6 +17,10 @@ import { organizations, partners } from '../db/schema';
  * (routes/agents/helpers.ts pulls in most of the agent-route service layer;
  * importing ANY export from it into a route file drags all of that into the
  * importer's module graph, which broke unrelated route tests when tried).
+ * The actual PRECEDENCE logic, however, is NOT duplicated — both this file
+ * and helpers.ts call the shared `resolveInheritedAgentVersionPins`
+ * (packages/shared/src/validators/agentVersionPins.ts) so the two can never
+ * silently drift apart.
  */
 export interface AgentVersionPins {
   agent: string | null;
@@ -46,34 +55,65 @@ function extractSettingsDefaults(settings: unknown): Record<string, unknown> {
  * id) is simply absent from the result rather than erroring — the caller
  * treats a missing entry the same as "no pin anywhere" (falls back to global
  * latest for display purposes).
+ *
+ * RLS: read in a SYSTEM context, exited from any ambient request context
+ * first — same pattern, and the same underlying bug class, as
+ * `getEnrollmentDefaultsForOrg` (services/enrollmentDefaults.ts, issue
+ * #2776). `partners`' SELECT policy is `breeze_has_partner_access(id)`, and
+ * `computeAccessiblePartnerIds` returns `[]` for an organization-scoped
+ * caller (middleware/auth.ts) — exactly the scope `GET
+ * /agent-versions/effective` runs under for an org token. Under that
+ * request's own RLS context the `partners` leftJoin would silently return
+ * `partnerSettings: null`, and any partner-inherited pin would evaporate
+ * with no error — the opposite of "no pin" is what should render, but a
+ * wrongly-empty partner default (never set at all) looks identical from
+ * inside this function, so the caller could never tell the two apart.
+ * `withSystemDbAccessContext` alone is not enough inside an active request
+ * context (it is a no-op that inherits the caller's scope) —
+ * `runOutsideDbContext` must exit that context first. The lookup stays keyed
+ * on the caller-supplied `orgIds` alone (already auth-filtered by the route
+ * before this call) — escaping RLS here widens visibility of settings
+ * columns for those specific orgs, not which orgs can be queried.
+ *
+ * AVAILABILITY: only escalate when actually needed. `withDbAccessContext`
+ * pins one pooled connection for its whole callback, and
+ * `runOutsideDbContext` exits the AsyncLocalStorage store, so a nested
+ * `withSystemDbAccessContext` does NOT nest — it opens a SECOND transaction
+ * on a SECOND connection while the first is still held. A caller already
+ * inside a system context pays that for no benefit (`partners` is already
+ * fully visible), so the ambient scope is checked first and the escape is
+ * skipped when it is already `'system'`.
  */
 export async function getOrgAgentVersionPinsBatch(
   orgIds: string[],
 ): Promise<Record<string, AgentVersionPins>> {
   if (orgIds.length === 0) return {};
 
-  const rows = await db
-    .select({
-      id: organizations.id,
-      orgSettings: organizations.settings,
-      partnerSettings: partners.settings,
-    })
-    .from(organizations)
-    .leftJoin(partners, eq(partners.id, organizations.partnerId))
-    .where(inArray(organizations.id, orgIds));
+  const readJoin = () =>
+    db
+      .select({
+        id: organizations.id,
+        orgSettings: organizations.settings,
+        partnerSettings: partners.settings,
+      })
+      .from(organizations)
+      .leftJoin(partners, eq(partners.id, organizations.partnerId))
+      .where(inArray(organizations.id, orgIds));
+
+  const ambientScope = getCurrentDbAccessContext()?.scope;
+  const rows =
+    ambientScope === 'system'
+      ? await readJoin()
+      : await runOutsideDbContext(() => withSystemDbAccessContext(readJoin));
 
   const result: Record<string, AgentVersionPins> = {};
   for (const row of rows) {
     const orgDefaults = extractSettingsDefaults(row.orgSettings);
     const partnerDefaults = extractSettingsDefaults(row.partnerSettings);
-    const orgPins = isObject(orgDefaults.agentVersionPins) ? orgDefaults.agentVersionPins : {};
-    const partnerPins = isObject(partnerDefaults.agentVersionPins)
-      ? partnerDefaults.agentVersionPins
-      : {};
-    result[row.id as string] = {
-      agent: normalizeVersionPin('agent' in orgPins ? orgPins.agent : partnerPins.agent),
-      watchdog: normalizeVersionPin('watchdog' in orgPins ? orgPins.watchdog : partnerPins.watchdog),
-    };
+    // The SAME shared resolver `getOrgAgentUpdateConfig`
+    // (routes/agents/helpers.ts) calls — see this file's docstring above for
+    // why the precedence lives there, not duplicated here.
+    result[row.id as string] = resolveInheritedAgentVersionPins(orgDefaults, partnerDefaults);
   }
   return result;
 }

--- a/apps/api/src/services/orgAgentVersionPins.ts
+++ b/apps/api/src/services/orgAgentVersionPins.ts
@@ -1,0 +1,79 @@
+import { eq, inArray } from 'drizzle-orm';
+import { normalizeVersionPin } from '@breeze/shared';
+import { db } from '../db';
+import { organizations, partners } from '../db/schema';
+
+/**
+ * Effective per-component update version pins (issue #2124). `null` means "no
+ * pin" → track the globally promoted latest version. Same shape as the
+ * `AgentVersionPins` interface in routes/agents/helpers.ts (the heartbeat's
+ * per-org resolver) — deliberately a separate type rather than a shared
+ * import so this file stays free of that file's much larger import graph
+ * (routes/agents/helpers.ts pulls in most of the agent-route service layer;
+ * importing ANY export from it into a route file drags all of that into the
+ * importer's module graph, which broke unrelated route tests when tried).
+ */
+export interface AgentVersionPins {
+  agent: string | null;
+  watchdog: string | null;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Pull the `defaults` sub-object out of a settings JSONB blob (safe for null). */
+function extractSettingsDefaults(settings: unknown): Record<string, unknown> {
+  const root = isObject(settings) ? settings : {};
+  return isObject(root.defaults) ? root.defaults : {};
+}
+
+/**
+ * Batch resolver for the SAME inherit-with-override pin precedence as
+ * `getOrgAgentUpdateConfig` in routes/agents/helpers.ts (issue #2124): an
+ * org-set component wins for that org; where the org has NOT set a
+ * component, the partner default is inherited; unset at both levels resolves
+ * to `null` (track global latest).
+ *
+ * Built for read paths that need MANY orgs' effective pins at once — the
+ * Devices list "Agent Version" badge (issue #5285), which resolves once per
+ * page load across every visible org rather than once per device row. ONE
+ * joined query for all requested orgs, instead of N calls to the per-org
+ * heartbeat resolver (which stays as-is: it already fetches settings +
+ * update-policy together for the ONE org a heartbeat request concerns).
+ *
+ * An orgId with no matching row (already deleted, or the caller passed a bad
+ * id) is simply absent from the result rather than erroring — the caller
+ * treats a missing entry the same as "no pin anywhere" (falls back to global
+ * latest for display purposes).
+ */
+export async function getOrgAgentVersionPinsBatch(
+  orgIds: string[],
+): Promise<Record<string, AgentVersionPins>> {
+  if (orgIds.length === 0) return {};
+
+  const rows = await db
+    .select({
+      id: organizations.id,
+      orgSettings: organizations.settings,
+      partnerSettings: partners.settings,
+    })
+    .from(organizations)
+    .leftJoin(partners, eq(partners.id, organizations.partnerId))
+    .where(inArray(organizations.id, orgIds));
+
+  const result: Record<string, AgentVersionPins> = {};
+  for (const row of rows) {
+    const orgDefaults = extractSettingsDefaults(row.orgSettings);
+    const partnerDefaults = extractSettingsDefaults(row.partnerSettings);
+    const orgPins = isObject(orgDefaults.agentVersionPins) ? orgDefaults.agentVersionPins : {};
+    const partnerPins = isObject(partnerDefaults.agentVersionPins)
+      ? partnerDefaults.agentVersionPins
+      : {};
+    result[row.id as string] = {
+      agent: normalizeVersionPin('agent' in orgPins ? orgPins.agent : partnerPins.agent),
+      watchdog: normalizeVersionPin('watchdog' in orgPins ? orgPins.watchdog : partnerPins.watchdog),
+    };
+  }
+  return result;
+}

--- a/apps/api/src/services/promotedAgentVersion.test.ts
+++ b/apps/api/src/services/promotedAgentVersion.test.ts
@@ -81,6 +81,7 @@ vi.mock('../db/schema', () => ({
 import {
   getPromotedComponentVersion,
   getRegisteredComponentVersion,
+  getPromotedAgentVersionForDisplay,
   PromotedVersionUnavailableError,
   __resetPromotedVersionCaptureCacheForTests,
 } from './promotedAgentVersion';
@@ -339,5 +340,56 @@ describe('getRegisteredComponentVersion (issue #5159)', () => {
     await expect(
       getRegisteredComponentVersion('agent', 'solaris', 'amd64', '0.110.0'),
     ).rejects.toBeInstanceOf(PromotedVersionUnavailableError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getPromotedAgentVersionForDisplay — a deliberately platform/arch-UNSCOPED
+// lookup of the promoted "agent" version, used only to feed the Devices list
+// colour badge (issue #5285). NOT part of the #3499 lockstep above: this is a
+// display hint, not a byte-serving decision, so it fails soft (null) rather
+// than throwing.
+// ---------------------------------------------------------------------------
+describe('getPromotedAgentVersionForDisplay', () => {
+  const OLD_EDITION = process.env.BINARY_EDITION;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbMock._reset();
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    if (OLD_EDITION === undefined) delete process.env.BINARY_EDITION;
+    else process.env.BINARY_EDITION = OLD_EDITION;
+  });
+
+  it('returns the promoted agent version for this edition', async () => {
+    dbMock._setResult([{ version: '0.110.0' }]);
+    await expect(getPromotedAgentVersionForDisplay()).resolves.toBe('0.110.0');
+    expect(boundValueFor('av.component')).toBe('agent');
+    expect(boundValueFor('av.is_latest')).toBe(true);
+  });
+
+  it('scopes to this server\'s own build edition', async () => {
+    process.env.BINARY_EDITION = 'hosted';
+    dbMock._setResult([{ version: '0.110.0' }]);
+    await getPromotedAgentVersionForDisplay();
+    expect(boundValueFor('av.edition')).toBe('hosted');
+  });
+
+  it('returns null when no promoted row exists yet (never synced)', async () => {
+    dbMock._setResult([]);
+    await expect(getPromotedAgentVersionForDisplay()).resolves.toBeNull();
+  });
+
+  it('treats the "unknown" sentinel as unresolvable, same as the other resolvers', async () => {
+    dbMock._setResult([{ version: 'unknown' }]);
+    await expect(getPromotedAgentVersionForDisplay()).resolves.toBeNull();
+  });
+
+  it('fails soft (null) rather than throwing on a lookup fault — this only feeds a display badge', async () => {
+    dbMock._setError(new Error('connection terminated'));
+    await expect(getPromotedAgentVersionForDisplay()).resolves.toBeNull();
   });
 });

--- a/apps/api/src/services/promotedAgentVersion.ts
+++ b/apps/api/src/services/promotedAgentVersion.ts
@@ -300,3 +300,54 @@ export async function getRegisteredComponentVersion(
 
   return row.version;
 }
+
+/**
+ * The promoted "agent" component version, deliberately WITHOUT platform/arch
+ * scoping — used only to feed the Devices list "Agent Version" colour badge
+ * (issue #5285: a device with no org-level pin is compared against this as
+ * its effective target). NOT part of the #3499 lockstep the two resolvers
+ * above maintain: this is a display hint the user can visually skim, not a
+ * byte-serving decision, so a lookup fault fails SOFT (null, badge falls back
+ * to the plain dash) rather than throwing/503ing a page render.
+ *
+ * In practice every platform/arch slot for a component is promoted together —
+ * `POST /agent-versions/promote` operates on every registered tuple of a
+ * version at once — so any single isLatest row for `agent` in this server's
+ * edition is representative of the whole fleet's target. If a rollout is ever
+ * left split mid-promotion across slots, this takes the most-recently-
+ * promoted row (same `created_at DESC` tiebreak the lockstep resolvers use) —
+ * a deliberately loose choice since the caller only renders a colour hint
+ * from it, never a checksum or download decision.
+ */
+export async function getPromotedAgentVersionForDisplay(): Promise<string | null> {
+  const edition = getBinaryEdition();
+
+  let row: { version: string } | undefined;
+  try {
+    [row] = await db
+      .select({ version: agentVersions.version })
+      .from(agentVersions)
+      .where(
+        and(
+          eq(agentVersions.component, 'agent'),
+          eq(agentVersions.isLatest, true),
+          eq(agentVersions.edition, edition),
+        ),
+      )
+      .orderBy(desc(agentVersions.createdAt))
+      .limit(1);
+  } catch (err) {
+    console.error(
+      '[promotedAgentVersion] display-only promoted-version lookup failed; ' +
+        'the Devices list badge falls back to the plain dash for this render',
+      err,
+    );
+    return null;
+  }
+
+  // Same "unknown" sentinel handling as the other resolvers (binarySync's
+  // local-registration path for a deployment with no BINARY_VERSION_FILE).
+  if (!row || row.version === 'unknown') return null;
+
+  return row.version;
+}

--- a/apps/web/src/components/devices/DeviceList.agentVersionRelation.test.tsx
+++ b/apps/web/src/components/devices/DeviceList.agentVersionRelation.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+
+import DeviceList, { type Device } from './DeviceList';
+import { DEFAULT_VISIBLE_COLUMNS, writeColumnVisibility } from './columnVisibility';
+
+// Issue #5285: colour the Devices "Agent Version" column by relation to the
+// org's effective agent-version pin/promoted version, resolved once per org
+// (the `effectiveAgentVersionByOrgId` map) rather than per row.
+
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn(), registerOrgIdProvider: vi.fn() }));
+vi.mock('@/stores/orgStore', () => ({
+  useOrgStore: (selector: (s: { currentOrgId: string | null; allOrgs: boolean }) => unknown) =>
+    selector({ currentOrgId: null, allOrgs: true }),
+}));
+vi.mock('../remote/ConnectDesktopButton', () => ({ default: () => null }));
+vi.mock('@/lib/formatTime', () => ({ formatLastSeen: () => 'just now' }));
+
+function device(id: string, hostname: string, overrides: Partial<Device> = {}): Device {
+  return {
+    id,
+    deviceClass: 'agent',
+    hostname,
+    os: 'linux',
+    osVersion: '22.04',
+    status: 'online',
+    cpuPercent: 1,
+    ramPercent: 1,
+    lastSeen: new Date().toISOString(),
+    orgId: 'org-1',
+    orgName: 'Acme',
+    siteId: 'site-1',
+    siteName: 'HQ',
+    agentVersion: '0.110.0',
+    tags: [],
+    ...overrides,
+  };
+}
+
+// The Agent Version column is opt-in (columnVisibility.ts), same as WAN/LAN
+// IP — seed it visible before each render.
+beforeEach(() => writeColumnVisibility([...DEFAULT_VISIBLE_COLUMNS, 'agentVersion']));
+afterEach(() => window.localStorage.clear());
+
+describe('DeviceList — Agent Version column colour coding (#5285)', () => {
+  it('tints the version neutral/green when it matches the effective version', () => {
+    const dev = device('11111111-1111-1111-1111-111111111111', 'on-pin', { agentVersion: '0.110.0' });
+    render(
+      <DeviceList
+        devices={[dev]}
+        pageSize={50}
+        effectiveAgentVersionByOrgId={{ 'org-1': '0.110.0' }}
+      />,
+    );
+    const cell = screen.getByTestId(`device-${dev.id}-agent-version`);
+    expect(cell.textContent).toContain('0.110.0');
+    expect(cell.querySelector('[data-agent-version-relation="equal"]')).not.toBeNull();
+  });
+
+  it('tints the version as ahead/canary when newer than the effective version, with a tooltip', () => {
+    const dev = device('22222222-2222-2222-2222-222222222222', 'canary', { agentVersion: '0.111.0' });
+    render(
+      <DeviceList
+        devices={[dev]}
+        pageSize={50}
+        effectiveAgentVersionByOrgId={{ 'org-1': '0.110.0' }}
+      />,
+    );
+    const cell = screen.getByTestId(`device-${dev.id}-agent-version`);
+    const badge = cell.querySelector('[data-agent-version-relation="ahead"]');
+    expect(badge).not.toBeNull();
+    expect(badge?.getAttribute('title')).toContain('0.110.0');
+  });
+
+  it('tints the version as behind/amber when older than the effective version, with a tooltip', () => {
+    const dev = device('33333333-3333-3333-3333-333333333333', 'stale', { agentVersion: '0.108.0' });
+    render(
+      <DeviceList
+        devices={[dev]}
+        pageSize={50}
+        effectiveAgentVersionByOrgId={{ 'org-1': '0.110.0' }}
+      />,
+    );
+    const cell = screen.getByTestId(`device-${dev.id}-agent-version`);
+    const badge = cell.querySelector('[data-agent-version-relation="behind"]');
+    expect(badge).not.toBeNull();
+    expect(badge?.getAttribute('title')).toContain('0.110.0');
+  });
+
+  it('renders an unchanged plain dash, with no colour, when the org has no effective version yet', () => {
+    const dev = device('44444444-4444-4444-4444-444444444444', 'unsynced', { agentVersion: '0.110.0' });
+    render(<DeviceList devices={[dev]} pageSize={50} effectiveAgentVersionByOrgId={{}} />);
+    const cell = screen.getByTestId(`device-${dev.id}-agent-version`);
+    expect(cell.textContent).toContain('0.110.0');
+    expect(cell.querySelector('[data-agent-version-relation]')).toBeNull();
+  });
+
+  it('renders the plain dash for a network row with no agent version at all', () => {
+    const dev = device('55555555-5555-5555-5555-555555555555', 'printer', {
+      deviceClass: 'network',
+      agentVersion: '' as unknown as string,
+    });
+    render(
+      <DeviceList
+        devices={[dev]}
+        pageSize={50}
+        effectiveAgentVersionByOrgId={{ 'org-1': '0.110.0' }}
+      />,
+    );
+    const cell = screen.getByTestId(`device-${dev.id}-agent-version`);
+    expect(cell.textContent).toContain('—');
+    expect(cell.querySelector('[data-agent-version-relation]')).toBeNull();
+  });
+});

--- a/apps/web/src/components/devices/DeviceList.tsx
+++ b/apps/web/src/components/devices/DeviceList.tsx
@@ -104,6 +104,7 @@ const COMPARE_MAX_DEVICES = 4;
 import { OSIcon } from "./osIcons";
 import { formatDeviceOsVersion } from "./osDisplay";
 import { type ListFilters, DEFAULT_LIST_FILTERS } from "./deviceListFilters";
+import { getAgentVersionRelation } from "./agentVersionRelation";
 import { useTranslation } from "react-i18next";
 import "../../lib/i18n";
 
@@ -497,6 +498,22 @@ type DeviceListProps = {
   // could be viewing this org's record while the switcher points at "All
   // organizations" or a different org entirely.
   forceSingleOrg?: boolean;
+  // Issue #5285: each visible org's effective agent-version target (its
+  // agentVersionPins.agent pin, or the globally promoted version when
+  // unpinned), resolved ONCE per page load by the caller (DevicesPage) — not
+  // per row, since the list is hot. Keyed by orgId; a missing/null entry
+  // means "not resolved yet" and the column renders unchanged (plain dash
+  // stays plain, no tint).
+  effectiveAgentVersionByOrgId?: Record<string, string | null | undefined>;
+};
+
+// Agent Version column tint (#5285). No new colours: reuses the same
+// success/info/warning tokens statusColors already draws on, just without the
+// border (this is a text pill inside a plain cell, not a status chip).
+const agentVersionRelationColors: Record<"equal" | "ahead" | "behind", string> = {
+  equal: "bg-success/15 text-success",
+  ahead: "bg-info/15 text-info",
+  behind: "bg-warning/15 text-warning",
 };
 
 const statusColors: Record<DeviceStatus, string> = {
@@ -765,6 +782,7 @@ export default function DeviceList({
   listFilters,
   onListFiltersChange,
   forceSingleOrg = false,
+  effectiveAgentVersionByOrgId,
 }: DeviceListProps) {
   const { t } = useTranslation("devices");
   // Use provided timezone or browser default
@@ -1925,14 +1943,51 @@ export default function DeviceList({
     agentVersion: {
       header: () =>
         sortHeader("agentVersion", "Agent Version", "Sort by agent version"),
-      cell: (device) => (
-        <td
-          key="agentVersion"
-          className="px-3 py-3 text-sm text-muted-foreground whitespace-nowrap"
-        >
-          {device.agentVersion || dash}
-        </td>
-      ),
+      cell: (device) => {
+        // Issue #5285: colour by relation to the org's effective agent-
+        // version pin/promoted version. Unresolved effective version (org not
+        // in the map yet), a missing device version (network/manual rows,
+        // never heartbeat'd), or an unparseable string on either side all
+        // classify as "unknown" — render the plain dash exactly as before.
+        const effectiveVersion =
+          effectiveAgentVersionByOrgId?.[device.orgId] ?? null;
+        const relation = getAgentVersionRelation(
+          device.agentVersion,
+          effectiveVersion,
+        );
+        if (relation === "unknown") {
+          return (
+            <td
+              key="agentVersion"
+              data-testid={`device-${device.id}-agent-version`}
+              className="px-3 py-3 text-sm text-muted-foreground whitespace-nowrap"
+            >
+              {device.agentVersion || dash}
+            </td>
+          );
+        }
+        const tooltipKey =
+          relation === "equal"
+            ? "deviceList.agentVersionRelation.equalTooltip"
+            : relation === "ahead"
+              ? "deviceList.agentVersionRelation.aheadTooltip"
+              : "deviceList.agentVersionRelation.behindTooltip";
+        return (
+          <td
+            key="agentVersion"
+            data-testid={`device-${device.id}-agent-version`}
+            className="px-3 py-3 text-sm whitespace-nowrap"
+          >
+            <span
+              data-agent-version-relation={relation}
+              title={t(/* i18n-dynamic */ tooltipKey, { version: effectiveVersion })}
+              className={`rounded px-1.5 py-0.5 text-xs font-medium ${agentVersionRelationColors[relation]}`}
+            >
+              {device.agentVersion}
+            </span>
+          </td>
+        );
+      },
     },
     watchdogVersion: {
       header: () =>

--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -302,6 +302,12 @@ export default function DevicesPage() {
   const [devices, setDevices] = useState<Device[]>([]);
   const [orgs, setOrgs] = useState<Org[]>([]);
   const [sites, setSites] = useState<Site[]>([]);
+  // Issue #5285: each visible org's effective agent-version target (pin or
+  // promoted fallback), resolved once per page load — see the fetch below.
+  // Absent until it resolves; DeviceList treats a missing entry as "not
+  // resolved yet" and renders the column unchanged (no tint).
+  const [effectiveAgentVersionByOrgId, setEffectiveAgentVersionByOrgId] =
+    useState<Record<string, string | null>>({});
   const [deviceGroups, setDeviceGroups] = useState<DeviceGroup[]>([]);
   const [groupMembershipMap, setGroupMembershipMap] = useState<Map<string, Set<string>>>(new Map());
   const [loading, setLoading] = useState(true);
@@ -894,6 +900,32 @@ export default function DevicesPage() {
       setDevices(devicesWithNames);
       setOrgs(orgsList);
       setSites(sitesList);
+
+      // Issue #5285: resolve each visible org's effective agent-version
+      // target ONCE per page load (not per device row) so the Agent Version
+      // column can colour-code by relation to it. Fired after orgsList is
+      // known, in parallel with rendering — best-effort: a failure here only
+      // means the column stays uncoloured (plain dash), never blocks the
+      // device list itself from rendering.
+      const orgIdsForVersions = [...new Set(orgsList.map((o) => o.id))];
+      if (orgIdsForVersions.length > 0) {
+        fetchWithAuth(`/agent-versions/effective?orgIds=${orgIdsForVersions.join(',')}`, { signal })
+          .then(async (res) => {
+            if (!res.ok) {
+              console.warn('Failed to fetch effective agent versions:', res.status);
+              return;
+            }
+            const body = await res.json();
+            const data = body?.data;
+            if (data && typeof data === 'object' && !Array.isArray(data)) {
+              setEffectiveAgentVersionByOrgId(data);
+            }
+          })
+          .catch((err) => {
+            if (err instanceof Error && err.name === 'AbortError') return;
+            console.warn('Failed to fetch effective agent versions:', err);
+          });
+      }
     } catch (err) {
       // Aborts are expected when the component unmounts mid-walk — drop
       // them silently rather than rendering a misleading error banner.
@@ -2275,6 +2307,7 @@ export default function DevicesPage() {
           autoSelectGroupId={autoSelectGroupId}
           onAutoSelectConsumed={handleAutoSelectConsumed}
           networkDevicesEnabled={ENABLE_NETWORK_DEVICES_IN_LIST}
+          effectiveAgentVersionByOrgId={effectiveAgentVersionByOrgId}
         />
       ) : (
         <div className="space-y-3">

--- a/apps/web/src/components/devices/agentVersionRelation.test.ts
+++ b/apps/web/src/components/devices/agentVersionRelation.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { getAgentVersionRelation } from './agentVersionRelation';
+
+// Issue #5285: colour the Devices "Agent Version" column by relation to the
+// org's effective pin/promoted version. This is the pure classification the
+// render layer keys its tint/tooltip off of.
+describe('getAgentVersionRelation', () => {
+  it('returns "equal" when the device matches the effective version exactly', () => {
+    expect(getAgentVersionRelation('0.110.0', '0.110.0')).toBe('equal');
+  });
+
+  it('returns "equal" ignoring a prerelease suffix (semver-aware, not string equality)', () => {
+    expect(getAgentVersionRelation('0.110.0-dev', '0.110.0')).toBe('equal');
+  });
+
+  it('returns "ahead" when the device is newer than the effective version', () => {
+    expect(getAgentVersionRelation('0.111.0', '0.110.0')).toBe('ahead');
+  });
+
+  it('returns "behind" when the device is older than the effective version', () => {
+    expect(getAgentVersionRelation('0.108.0', '0.110.0')).toBe('behind');
+  });
+
+  it('returns "unknown" when the device version is missing', () => {
+    expect(getAgentVersionRelation(null, '0.110.0')).toBe('unknown');
+    expect(getAgentVersionRelation(undefined, '0.110.0')).toBe('unknown');
+    expect(getAgentVersionRelation('', '0.110.0')).toBe('unknown');
+  });
+
+  it('returns "unknown" when the effective version is missing (no pin, never synced)', () => {
+    expect(getAgentVersionRelation('0.110.0', null)).toBe('unknown');
+    expect(getAgentVersionRelation('0.110.0', undefined)).toBe('unknown');
+  });
+
+  it('returns "unknown" when either side is not a valid semver string', () => {
+    expect(getAgentVersionRelation('not-a-version', '0.110.0')).toBe('unknown');
+    expect(getAgentVersionRelation('0.110.0', 'not-a-version')).toBe('unknown');
+  });
+});

--- a/apps/web/src/components/devices/agentVersionRelation.ts
+++ b/apps/web/src/components/devices/agentVersionRelation.ts
@@ -1,0 +1,29 @@
+import { semverCompare } from '@breeze/shared';
+
+/**
+ * How a device's reported agent version relates to the org's effective
+ * agent-version pin (or, when unpinned, the globally promoted version).
+ * 'unknown' covers every case where the comparison can't be made in good
+ * faith — missing device version (network/manual rows, never heartbeat'd),
+ * missing effective version (never synced), or an unparseable string on
+ * either side — and the caller renders the plain dash for it, same as today
+ * (issue #5285).
+ */
+export type AgentVersionRelation = 'equal' | 'ahead' | 'behind' | 'unknown';
+
+/**
+ * Classify `deviceVersion` against `effectiveVersion` using semver
+ * comparison (never plain string equality — a device on "0.110.0" and a pin
+ * of "0.110.0-dev" are the same release). Reuses the same `semverCompare`
+ * the Sidebar "what's new" banner already keys its version check off of.
+ */
+export function getAgentVersionRelation(
+  deviceVersion: string | null | undefined,
+  effectiveVersion: string | null | undefined,
+): AgentVersionRelation {
+  if (!deviceVersion || !effectiveVersion) return 'unknown';
+  const cmp = semverCompare(deviceVersion, effectiveVersion);
+  if (cmp === null) return 'unknown';
+  if (cmp === 0) return 'equal';
+  return cmp > 0 ? 'ahead' : 'behind';
+}

--- a/apps/web/src/locales/de-DE/devices.json
+++ b/apps/web/src/locales/de-DE/devices.json
@@ -1225,6 +1225,11 @@
       "scan": "Scan",
       "unifi": "UniFi",
       "manual": "Manuell"
+    },
+    "agentVersionRelation": {
+      "equalTooltip": "Entspricht der effektiven Version {{version}}",
+      "aheadTooltip": "Vor dem Pin {{version}}",
+      "behindTooltip": "Hinter dem Pin {{version}}"
     }
   },
   "deviceLogsTab": {

--- a/apps/web/src/locales/en/devices.json
+++ b/apps/web/src/locales/en/devices.json
@@ -1225,6 +1225,11 @@
       "scan": "Scan",
       "unifi": "UniFi",
       "manual": "Manual"
+    },
+    "agentVersionRelation": {
+      "equalTooltip": "Matches the effective version {{version}}",
+      "aheadTooltip": "Ahead of pin {{version}}",
+      "behindTooltip": "Behind pin {{version}}"
     }
   },
   "deviceLogsTab": {

--- a/apps/web/src/locales/es-419/devices.json
+++ b/apps/web/src/locales/es-419/devices.json
@@ -1225,6 +1225,11 @@
       "scan": "Escaneo",
       "unifi": "UniFi",
       "manual": "Manual"
+    },
+    "agentVersionRelation": {
+      "equalTooltip": "Coincide con la versión efectiva {{version}}",
+      "aheadTooltip": "Por delante del pin {{version}}",
+      "behindTooltip": "Por detrás del pin {{version}}"
     }
   },
   "deviceLogsTab": {

--- a/apps/web/src/locales/fr-CA/devices.json
+++ b/apps/web/src/locales/fr-CA/devices.json
@@ -1225,6 +1225,11 @@
       "scan": "Analyse",
       "unifi": "UniFi",
       "manual": "Manuel"
+    },
+    "agentVersionRelation": {
+      "equalTooltip": "Correspond à la version effective {{version}}",
+      "aheadTooltip": "En avance sur l'épinglage {{version}}",
+      "behindTooltip": "En retard sur l'épinglage {{version}}"
     }
   },
   "deviceLogsTab": {

--- a/apps/web/src/locales/fr-FR/devices.json
+++ b/apps/web/src/locales/fr-FR/devices.json
@@ -1225,6 +1225,11 @@
       "scan": "Analyse",
       "unifi": "UniFi",
       "manual": "Manuel"
+    },
+    "agentVersionRelation": {
+      "equalTooltip": "Correspond à la version effective {{version}}",
+      "aheadTooltip": "En avance sur l'épinglage {{version}}",
+      "behindTooltip": "En retard sur l'épinglage {{version}}"
     }
   },
   "deviceLogsTab": {

--- a/apps/web/src/locales/it-IT/devices.json
+++ b/apps/web/src/locales/it-IT/devices.json
@@ -1225,6 +1225,11 @@
       "scan": "Scansione",
       "unifi": "UniFi",
       "manual": "Manuale"
+    },
+    "agentVersionRelation": {
+      "equalTooltip": "Corrisponde alla versione effettiva {{version}}",
+      "aheadTooltip": "In anticipo rispetto al pin {{version}}",
+      "behindTooltip": "In ritardo rispetto al pin {{version}}"
     }
   },
   "deviceLogsTab": {

--- a/apps/web/src/locales/pt-BR/devices.json
+++ b/apps/web/src/locales/pt-BR/devices.json
@@ -1225,6 +1225,11 @@
       "scan": "Varredura",
       "unifi": "UniFi",
       "manual": "Manual"
+    },
+    "agentVersionRelation": {
+      "equalTooltip": "Corresponde à versão efetiva {{version}}",
+      "aheadTooltip": "À frente do pin {{version}}",
+      "behindTooltip": "Atrás do pin {{version}}"
     }
   },
   "deviceLogsTab": {

--- a/apps/web/src/locales/tr-TR/devices.json
+++ b/apps/web/src/locales/tr-TR/devices.json
@@ -1225,6 +1225,11 @@
       "scan": "Tarama",
       "unifi": "UniFi",
       "manual": "Manuel"
+    },
+    "agentVersionRelation": {
+      "equalTooltip": "Etkin sürümle eşleşiyor: {{version}}",
+      "aheadTooltip": "{{version}} sabitlemesinin ilerisinde",
+      "behindTooltip": "{{version}} sabitlemesinin gerisinde"
     }
   },
   "deviceLogsTab": {

--- a/packages/shared/src/validators/agentVersionPins.test.ts
+++ b/packages/shared/src/validators/agentVersionPins.test.ts
@@ -3,6 +3,7 @@ import {
   agentVersionPinsSchema,
   normalizeVersionPin,
   extractAgentVersionPins,
+  resolveInheritedAgentVersionPins,
   PINNABLE_COMPONENTS,
 } from './agentVersionPins';
 
@@ -60,5 +61,63 @@ describe('extractAgentVersionPins', () => {
       agent: null,
       watchdog: null,
     });
+  });
+});
+
+// The SINGLE SOURCE for the org/partner inherit-with-override precedence
+// (issue #2124) — both getOrgAgentUpdateConfig (routes/agents/helpers.ts) and
+// getOrgAgentVersionPinsBatch (services/orgAgentVersionPins.ts, issue #5285)
+// call this instead of re-deriving it, so the two callers can never drift.
+describe('resolveInheritedAgentVersionPins', () => {
+  it('no pin anywhere -> both components track global latest (null)', () => {
+    expect(resolveInheritedAgentVersionPins({}, {})).toEqual({ agent: null, watchdog: null });
+    expect(resolveInheritedAgentVersionPins(undefined, undefined)).toEqual({
+      agent: null,
+      watchdog: null,
+    });
+  });
+
+  it('org pin only -> uses the org pin (no partner pin to inherit)', () => {
+    expect(
+      resolveInheritedAgentVersionPins({ agentVersionPins: { agent: '0.88.0' } }, {}),
+    ).toEqual({ agent: '0.88.0', watchdog: null });
+  });
+
+  it('partner pin only -> org inherits the partner pin', () => {
+    expect(
+      resolveInheritedAgentVersionPins({}, { agentVersionPins: { watchdog: '0.87.0' } }),
+    ).toEqual({ agent: null, watchdog: '0.87.0' });
+  });
+
+  it('org pin OVERRIDES the partner pin (inherit-with-override, not a lock)', () => {
+    expect(
+      resolveInheritedAgentVersionPins(
+        { agentVersionPins: { agent: '0.80.0', watchdog: '0.80.0' } },
+        { agentVersionPins: { agent: '0.88.0' } },
+      ),
+    ).toEqual({ agent: '0.80.0', watchdog: '0.80.0' });
+  });
+
+  it('org inherits the partner pin per component where the org has not set it', () => {
+    expect(
+      resolveInheritedAgentVersionPins(
+        { agentVersionPins: { watchdog: '0.70.0' } },
+        { agentVersionPins: { agent: '0.88.0' } },
+      ),
+    ).toEqual({ agent: '0.88.0', watchdog: '0.70.0' });
+  });
+
+  it("an org 'latest' deliberately overrides a partner pin back to global latest (presence-keyed, not truthiness)", () => {
+    expect(
+      resolveInheritedAgentVersionPins(
+        { agentVersionPins: { agent: 'latest' } },
+        { agentVersionPins: { agent: '0.88.0' } },
+      ),
+    ).toEqual({ agent: null, watchdog: null });
+  });
+
+  it('is null-safe for missing / malformed input on either side', () => {
+    expect(resolveInheritedAgentVersionPins(null, null)).toEqual({ agent: null, watchdog: null });
+    expect(resolveInheritedAgentVersionPins('nope', 42)).toEqual({ agent: null, watchdog: null });
   });
 });

--- a/packages/shared/src/validators/agentVersionPins.ts
+++ b/packages/shared/src/validators/agentVersionPins.ts
@@ -93,3 +93,50 @@ export function extractAgentVersionPins(defaults: unknown): {
     watchdog: normalizeVersionPin(pins.watchdog),
   };
 }
+
+/** The raw (un-normalized) `agentVersionPins` sub-object of a `settings.defaults` blob. */
+function extractRawAgentVersionPins(defaults: unknown): Record<string, unknown> {
+  const root =
+    defaults && typeof defaults === 'object' && !Array.isArray(defaults)
+      ? (defaults as Record<string, unknown>)
+      : {};
+  return root.agentVersionPins &&
+    typeof root.agentVersionPins === 'object' &&
+    !Array.isArray(root.agentVersionPins)
+    ? (root.agentVersionPins as Record<string, unknown>)
+    : {};
+}
+
+/**
+ * Resolve BOTH components' EFFECTIVE pins for an org from its own
+ * `settings.defaults` and its partner's, using INHERIT-WITH-OVERRIDE
+ * precedence (issue #2124, per maintainer): an org-set component wins for
+ * that org; where the org has NOT set a component, the partner default is
+ * inherited; unset at both levels resolves to `null` (track global latest).
+ * Presence-keyed (`component in orgPins`), NOT truthiness, so an org may
+ * explicitly store `'latest'` to override a partner pin back to global
+ * latest. `orgDefaults`/`partnerDefaults` are `settings.defaults` objects (or
+ * anything shaped like one) — safe for any input, never throws.
+ *
+ * THE SINGLE SOURCE for this precedence. Two callers in the API resolve it
+ * against the SAME org⋈partner shape for different read patterns —
+ * `getOrgAgentUpdateConfig` (apps/api/src/routes/agents/helpers.ts, the
+ * heartbeat's per-org resolver) and `getOrgAgentVersionPinsBatch`
+ * (apps/api/src/services/orgAgentVersionPins.ts, the Devices list's
+ * many-orgs-at-once resolver, issue #5285) — and BOTH call this function
+ * rather than re-deriving the ternary, so the two can never silently drift.
+ * This codebase has repeatedly shipped exactly that failure shape elsewhere
+ * (duplicated cascade/allowlist logic drifting apart, caught only by
+ * dedicated contract tests — see CLAUDE.md's tenancy-cascade history).
+ */
+export function resolveInheritedAgentVersionPins(
+  orgDefaults: unknown,
+  partnerDefaults: unknown,
+): { agent: string | null; watchdog: string | null } {
+  const orgPins = extractRawAgentVersionPins(orgDefaults);
+  const partnerPins = extractRawAgentVersionPins(partnerDefaults);
+  return {
+    agent: normalizeVersionPin('agent' in orgPins ? orgPins.agent : partnerPins.agent),
+    watchdog: normalizeVersionPin('watchdog' in orgPins ? orgPins.watchdog : partnerPins.watchdog),
+  };
+}


### PR DESCRIPTION
## Summary

Colour-codes the Devices list **Agent Version** column
(`apps/web/src/components/devices/DeviceList.tsx`) by relation to the
device's effective agent-version target, so an operator can see at a
glance which devices are on the pin, ahead of it (canary), or behind it
(needs attention).

- **equal** → neutral/green tint
- **ahead** → blue "canary" tint, tooltip "ahead of pin X"
- **behind** → amber tint, tooltip "behind pin X"
- **unknown/blank** (network rows, no heartbeat, effective version not
  yet resolved) → unchanged plain dash

Comparison is semver-aware (reuses the existing `semverCompare` helper
from `packages/shared`, the same one the Sidebar "what's new" banner
already uses) — never plain string equality.

## Design choices

- **Effective version resolution**: new `GET
  /agent-versions/effective?orgIds=a,b,c`, called once per Devices page
  load (after `/orgs` resolves the visible org set), not per row. For
  each org it returns the org's `agentVersionPins.agent` pin
  (inherit-with-override across partner/org, issue #2124 — same
  precedence as the heartbeat's `getOrgAgentUpdateConfig`) or, when
  unpinned, the globally promoted `agent` version.
- The pin batch resolver (`getOrgAgentVersionPinsBatch`) lives in a new,
  deliberately small `apps/api/src/services/orgAgentVersionPins.ts`
  rather than `routes/agents/helpers.ts` — importing anything from that
  file drags its much larger import graph into the importer's module
  graph, which broke unrelated `agentVersions.test.ts` route tests when
  I tried it there first. The new file only imports db/schema +
  `@breeze/shared`.
- The promoted-version fallback
  (`getPromotedAgentVersionForDisplay`) is deliberately **NOT**
  platform/arch-scoped like the three existing promoted-version
  resolvers (`getPromotedComponentVersion`,
  `getRegisteredComponentVersion`, `resolvePinnedUpgradeTarget`) — those
  exist for byte-serving/checksum correctness (#3499) and require an
  exact platform/arch/edition match. This one only feeds a colour hint,
  so it takes any single `isLatest` row for `agent` in this server's
  edition (in practice every platform/arch slot promotes together) and
  fails **soft** (`null`, badge shows the plain dash) rather than
  throwing on a DB fault.
- No new colours: reuses the existing `success`/`info`/`warning` design
  tokens `DeviceList`'s status badges already draw from.
- **Skipped**: the optional "behind pin" filter facet in
  `mergedListFilter.ts` — kept the diff contained per the issue's own
  scope note ("skip if it grows the diff a lot"). Can be a fast
  follow-up if wanted.

## Tests

- `apps/web/src/components/devices/agentVersionRelation.test.ts` — unit
  tests for the pure semver-relation classifier (equal/ahead/behind/unknown).
- `apps/web/src/components/devices/DeviceList.agentVersionRelation.test.tsx`
  — render test for all four states (three tints + unchanged dash).
- `apps/api/src/services/orgAgentVersionPins.test.ts` — batch pin
  resolver (inherit-with-override precedence, `latest` sentinel,
  missing-org handling).
- `apps/api/src/services/promotedAgentVersion.test.ts` — new
  `getPromotedAgentVersionForDisplay` cases (edition scoping, `unknown`
  sentinel, fail-soft on DB fault).
- `apps/api/src/routes/agentVersions.effective.test.ts` — the new
  route's own contract (auth scoping drops inaccessible orgIds
  silently, pin-vs-promoted merge, promoted fallback resolved once per
  request).
- i18n: added `deviceList.agentVersionRelation.{equal,ahead,behind}Tooltip`
  to all 8 locales; `es-419, fr-FR, fr-CA, de-DE, and it-IT strings are
  machine-drafted pending native review` (pt-BR and tr-TR too, per the
  repo's existing disclaimer convention for these three tooltip strings).

Verification: web (`vitest run src/components/devices/DeviceList`,
`src/lib/i18n`) and API (`vitest run` on all touched/new files) affected
suites green; `tsc --noEmit` clean on both `apps/web` and `apps/api`.

Release note: Devices list now colour-codes the Agent Version column by
relation to each org's effective agent-version pin/promoted version.

Closes #5285

Requested by SemoTech on #3876.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGT9BJVfpG3nyM6c9koAN8