### PR TITLE
fix(agent): start the Windows service `service install` leaves stopped (#5299)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1627,11 +1627,25 @@ jobs:
       # privilege -> remote/tools — which is harmless here (CGO_ENABLED=0 is
       # exactly the configuration remote/desktop's !cgo files are written for)
       # but is why it must stay out of the race step below.
+      # ./internal/winsvcinstall is the SCM half of `service install` for both the
+      # agent and the watchdog, extracted in #5299. Its package IS listed here
+      # rather than relying on internal/agentapp, which is NOT on this list (its
+      # inherited Windows reds are tracked in #2523) — a //go:build windows test
+      # left next to the installer would therefore have run on no job at all,
+      # which is the exact vacuous-gate failure the steps below guard against.
+      # Most of the package is deliberately untagged so the install sequence
+      # (sample before stop, stop before staging the binary, confirm RUNNING
+      # before claiming it) also executes in the Linux `test-agent` job; the
+      # windows-tagged half is the mgr adapter plus its command-line quoting and
+      # SCM-state mapping tests, which can only run here. Verified like logging
+      # and ipc: with GOOS=windows GOARCH=amd64 CGO_ENABLED=0 the package vets,
+      # its test binary compiles, and its Windows dependency graph contains no
+      # remote/desktop, no cgo, and no other first-party package.
       - name: Run Windows Go tests
         working-directory: agent
         env:
           CGO_ENABLED: "0"
-        run: go test ./internal/sessionbroker ./internal/eventlog ./internal/elevaccount ./internal/ipc ./internal/logging ./internal/state ./internal/watchdog ./internal/backup/vss ./internal/executor ./cmd/breeze-watchdog
+        run: go test ./internal/sessionbroker ./internal/eventlog ./internal/elevaccount ./internal/ipc ./internal/logging ./internal/state ./internal/watchdog ./internal/backup/vss ./internal/executor ./internal/winsvcinstall ./cmd/breeze-watchdog
 
       # The step above runs without -v, so a t.Skip is indistinguishable from a
       # pass in its output. That matters here more than usual: elevaccount's two

--- a/agent/cmd/breeze-watchdog/service_cmd_windows.go
+++ b/agent/cmd/breeze-watchdog/service_cmd_windows.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/breeze-rmm/agent/internal/serviceinstall"
+	"github.com/breeze-rmm/agent/internal/winsvcinstall"
 	"github.com/spf13/cobra"
 	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/mgr"
@@ -34,43 +35,45 @@ func serviceInstallCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed to determine executable path: %w", err)
 			}
-			serviceExePath, copied, err := serviceinstall.InstallProtectedBinary(exePath, "breeze-watchdog.exe")
-			if err != nil {
-				return fmt.Errorf("failed to install service binary in protected Program Files location: %w", err)
-			}
-			if copied {
-				fmt.Printf("Copied service binary to protected location: %s\n", serviceExePath)
-			}
 
-			m, err := mgr.Connect()
+			m, err := winsvcinstall.Connect()
 			if err != nil {
-				return fmt.Errorf("failed to connect to SCM (run as Administrator): %w", err)
+				return err
 			}
-			defer m.Disconnect()
+			defer m.Close()
 
-			s, err := m.CreateService(windowsWatchdogServiceName, serviceExePath, mgr.Config{
-				DisplayName:  "Breeze RMM Watchdog",
-				Description:  "Breeze Agent Watchdog - monitors and recovers the agent process",
-				StartType:    mgr.StartAutomatic,
-				ErrorControl: mgr.ErrorNormal,
-			}, "run")
-			if err != nil {
-				return fmt.Errorf("failed to create service: %w", err)
+			// AlwaysStart, unconditionally: unlike the agent the watchdog has no
+			// enrollment to wait for, and an installed-but-not-started watchdog
+			// is exactly the failure it exists to prevent. Before #5299 this
+			// command created the service StartAutomatic and returned — so a
+			// freshly bootstrapped watchdog did not actually supervise anything
+			// until the host next rebooted, and re-running it on a host that
+			// already had the service failed outright on CreateService.
+			outcome, installErr := winsvcinstall.Install(m, winsvcinstall.Request{
+				Spec: winsvcinstall.Spec{
+					Name:        windowsWatchdogServiceName,
+					DisplayName: "Breeze RMM Watchdog",
+					Description: "Breeze Agent Watchdog - monitors and recovers the agent process",
+					Args:        []string{"run"},
+				},
+				Stage: func() (string, error) {
+					path, copied, err := serviceinstall.InstallProtectedBinary(exePath, "breeze-watchdog.exe")
+					if err != nil {
+						return "", fmt.Errorf(
+							"failed to install service binary in protected Program Files location: %w", err)
+					}
+					if copied {
+						fmt.Printf("Copied service binary to protected location: %s\n", path)
+					}
+					return path, nil
+				},
+				Decide: winsvcinstall.AlwaysStart(),
+				Warn:   os.Stderr,
+			})
+			if outcome.Installed {
+				fmt.Println(outcome.Summary(windowsWatchdogServiceName))
 			}
-			defer s.Close()
-
-			// Set recovery actions: restart on first three failures.
-			err = s.SetRecoveryActions([]mgr.RecoveryAction{
-				{Type: mgr.ServiceRestart, Delay: 5 * time.Second},
-				{Type: mgr.ServiceRestart, Delay: 10 * time.Second},
-				{Type: mgr.ServiceRestart, Delay: 30 * time.Second},
-			}, 86400) // reset failure count after 24 h
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Warning: failed to set recovery actions: %v\n", err)
-			}
-
-			fmt.Printf("Service %q installed successfully.\n", windowsWatchdogServiceName)
-			return nil
+			return installErr
 		},
 	}
 }

--- a/agent/installer/breeze.wxs
+++ b/agent/installer/breeze.wxs
@@ -348,9 +348,11 @@
       Return="ignore" />
 
     <!-- Set SCM failure-action recovery on both services after they're
-         installed. Mirrors agent/cmd/breeze-agent/service_cmd_windows.go:72-79
-         and agent/cmd/breeze-watchdog/service_cmd_windows.go:63-67 (5s/10s/30s
-         restart escalation with 24-hour counter reset).
+         installed. Mirrors scmService.SetRecoveryActions in
+         agent/internal/winsvcinstall/scm_windows.go, which is what both
+         `breeze-agent.exe service install` and `breeze-watchdog.exe service
+         install` now apply (5s/10s/30s restart escalation with 24-hour counter
+         reset).
 
          Without this, MSI-installed services have no SCM-driven auto-restart;
          only `breeze-agent.exe service install` (the manual subcommand)

--- a/agent/internal/agentapp/service_cmd_windows.go
+++ b/agent/internal/agentapp/service_cmd_windows.go
@@ -8,7 +8,9 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/breeze-rmm/agent/internal/config"
 	"github.com/breeze-rmm/agent/internal/serviceinstall"
+	"github.com/breeze-rmm/agent/internal/winsvcinstall"
 	"github.com/spf13/cobra"
 	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/mgr"
@@ -43,42 +45,59 @@ var serviceInstallCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("failed to determine executable path: %w", err)
 		}
-		serviceExePath, copied, err := serviceinstall.InstallProtectedBinary(exePath, "breeze-agent.exe")
+
+		m, err := winsvcinstall.Connect()
 		if err != nil {
-			return fmt.Errorf("failed to install service binary in protected Program Files location: %w", err)
+			return err
 		}
-		if copied {
-			fmt.Printf("Copied service binary to protected location: %s\n", serviceExePath)
+		defer m.Close()
+
+		// An enrolled host is one whose only management path IS the agent, so
+		// leaving it stopped after an upgrade strands the box (#5252/#5299).
+		existingCfg, _ := config.Load(cfgFile)
+		enrolled := existingCfg != nil && existingCfg.AgentID != ""
+
+		var serviceExePath string
+		outcome, installErr := winsvcinstall.Install(m, winsvcinstall.Request{
+			Spec: winsvcinstall.Spec{
+				Name:        windowsServiceName,
+				DisplayName: "Breeze RMM Agent",
+				Description: "Breeze Remote Monitoring and Management Agent",
+				Args:        []string{"run"},
+			},
+			Stage: func() (string, error) {
+				path, copied, err := serviceinstall.InstallProtectedBinary(exePath, "breeze-agent.exe")
+				if err != nil {
+					return "", fmt.Errorf(
+						"failed to install service binary in protected Program Files location: %w", err)
+				}
+				if copied {
+					fmt.Printf("Copied service binary to protected location: %s\n", path)
+				}
+				serviceExePath = path
+				return path, nil
+			},
+			Decide: winsvcinstall.StartWhenRunningOrEnrolled(enrolled),
+			Warn:   os.Stderr,
+		})
+		if installErr != nil && !outcome.Installed {
+			// Nothing is registered — there is no point bootstrapping a watchdog
+			// for a service that does not exist.
+			return installErr
 		}
 
-		m, err := mgr.Connect()
-		if err != nil {
-			return fmt.Errorf("failed to connect to SCM (run as Administrator): %w", err)
-		}
-		defer m.Disconnect()
+		fmt.Println(outcome.Summary(windowsServiceName))
 
-		s, err := m.CreateService(windowsServiceName, serviceExePath, mgr.Config{
-			DisplayName:  "Breeze RMM Agent",
-			Description:  "Breeze Remote Monitoring and Management Agent",
-			StartType:    mgr.StartAutomatic,
-			ErrorControl: mgr.ErrorNormal,
-		}, "run")
-		if err != nil {
-			return fmt.Errorf("failed to create service: %w", err)
+		if !outcome.Started && installErr == nil {
+			fmt.Println()
+			fmt.Println("Next steps:")
+			if !enrolled {
+				fmt.Println("  1. Enroll: breeze-agent.exe enroll <key> --server https://your-server")
+				fmt.Println("  2. Start:  breeze-agent.exe service start")
+			} else {
+				fmt.Println("  1. Start:  breeze-agent.exe service start")
+			}
 		}
-		defer s.Close()
-
-		// Set recovery actions: restart on first three failures.
-		err = s.SetRecoveryActions([]mgr.RecoveryAction{
-			{Type: mgr.ServiceRestart, Delay: 5 * time.Second},
-			{Type: mgr.ServiceRestart, Delay: 10 * time.Second},
-			{Type: mgr.ServiceRestart, Delay: 30 * time.Second},
-		}, 86400) // reset failure count after 24 h
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to set recovery actions: %v\n", err)
-		}
-
-		fmt.Printf("Service %q installed successfully.\n", windowsServiceName)
 
 		if !noWatchdog {
 			err := bootstrapWatchdog(bootstrapOptions{
@@ -90,16 +109,27 @@ var serviceInstallCmd = &cobra.Command{
 			if err != nil {
 				fmt.Fprintf(os.Stderr,
 					"Warning: watchdog bootstrap failed: %v\n"+
-						"The agent service is installed and running. The watchdog is NOT installed.\n"+
+						"%s The watchdog is NOT installed.\n"+
 						"To retry, choose one of:\n"+
 						"  1. Re-run `breeze-agent.exe service install` (will retry the download).\n"+
 						"  2. Download %s manually, place it next to breeze-agent.exe,\n"+
 						"     then run `breeze-watchdog.exe service install`.\n"+
 						"  3. To skip the watchdog entirely, use `--no-watchdog`.\n",
-					err, watchdogDownloadURL(version, runtime.GOOS, runtime.GOARCH))
+					err, outcome.Summary(windowsServiceName),
+					watchdogDownloadURL(version, runtime.GOOS, runtime.GOARCH))
 			}
 		}
 
+		// Reported last, and as a non-zero exit: the service is registered but
+		// not running, and the watchdog still needed installing first so it can
+		// recover the host. Exiting 0 here is what let the Linux half of this
+		// bug go unnoticed until devices showed Offline.
+		if installErr != nil {
+			fmt.Fprintf(os.Stderr,
+				"\nRecover with: breeze-agent.exe service start\n"+
+					"and check the Windows event log for the service start failure.\n")
+			return installErr
+		}
 		return nil
 	},
 }
@@ -148,20 +178,17 @@ var serviceStartCmd = &cobra.Command{
 	Use:   "start",
 	Short: "Start the agent Windows service",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		m, err := mgr.Connect()
+		m, err := winsvcinstall.Connect()
 		if err != nil {
-			return fmt.Errorf("failed to connect to SCM: %w", err)
+			return err
 		}
-		defer m.Disconnect()
+		defer m.Close()
 
-		s, err := m.OpenService(windowsServiceName)
-		if err != nil {
-			return fmt.Errorf("failed to open service: %w", err)
-		}
-		defer s.Close()
-
-		if err := s.Start(); err != nil {
-			return fmt.Errorf("failed to start service: %w", err)
+		// StartAndWait, not a bare Start: the SCM accepts a start request
+		// asynchronously, so returning straight after it would print "started"
+		// for a service that came up and died.
+		if err := winsvcinstall.StartAndWait(m, windowsServiceName, winsvcinstall.DefaultTimeouts()); err != nil {
+			return err
 		}
 
 		fmt.Printf("Service %q started.\n", windowsServiceName)

--- a/agent/internal/agentapp/service_cmd_windows.go
+++ b/agent/internal/agentapp/service_cmd_windows.go
@@ -54,8 +54,27 @@ var serviceInstallCmd = &cobra.Command{
 
 		// An enrolled host is one whose only management path IS the agent, so
 		// leaving it stopped after an upgrade strands the box (#5252/#5299).
-		existingCfg, _ := config.Load(cfgFile)
-		enrolled := existingCfg != nil && existingCfg.AgentID != ""
+		//
+		// config.Load returns (cfg, nil) when the file simply does not exist —
+		// a genuinely fresh host — and (nil, err) only when a config that IS
+		// there cannot be parsed. That second case is treated as ENROLLED: the
+		// file exists because something installed before, and silently
+		// downgrading an unreadable config to "fresh host" would leave stopped
+		// exactly the box we cannot diagnose, which is the failure this issue
+		// is about. The cost of guessing wrong is an un-enrolled agent sitting
+		// in waitForEnrollment, which is what the MSI does anyway.
+		existingCfg, cfgErr := config.Load(cfgFile)
+		agentID := ""
+		if existingCfg != nil {
+			agentID = existingCfg.AgentID
+		}
+		enrolled := hostLooksEnrolled(agentID, cfgErr)
+		if cfgErr != nil {
+			fmt.Fprintf(os.Stderr,
+				"Warning: could not read the agent config (%v).\n"+
+					"Assuming this host is enrolled and starting the service. "+
+					"Fix the config and re-run if that is wrong.\n", cfgErr)
+		}
 
 		var serviceExePath string
 		outcome, installErr := winsvcinstall.Install(m, winsvcinstall.Request{

--- a/agent/internal/agentapp/windows_install_enrollment.go
+++ b/agent/internal/agentapp/windows_install_enrollment.go
@@ -1,0 +1,21 @@
+package agentapp
+
+// hostLooksEnrolled decides whether `service install` should treat this host as
+// already enrolled — which, on Windows, decides whether the install starts the
+// service it just registered (#5299).
+//
+// The interesting case is loadErr. config.Load reports no error when the config
+// file is simply absent (a genuinely fresh host, agentID ""); it errors only
+// when a config that IS present cannot be read or parsed. Treating that as "not
+// enrolled" would leave the service stopped on exactly the host nobody can
+// diagnose remotely, which is the stranding failure this fix exists to prevent
+// — so an unreadable config counts as enrolled and the caller says so out loud.
+// Guessing wrong the other way costs an un-enrolled agent sitting in
+// waitForEnrollment, which is what the MSI install produces anyway.
+//
+// Lives in an untagged file so this decision is covered by the Linux
+// `test-agent` job: internal/agentapp is not in the Test Agent (Windows)
+// package list, so a windows-tagged test of it would run nowhere.
+func hostLooksEnrolled(agentID string, loadErr error) bool {
+	return loadErr != nil || agentID != ""
+}

--- a/agent/internal/agentapp/windows_install_enrollment_test.go
+++ b/agent/internal/agentapp/windows_install_enrollment_test.go
@@ -1,0 +1,37 @@
+package agentapp
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestHostLooksEnrolled(t *testing.T) {
+	cases := []struct {
+		name    string
+		agentID string
+		loadErr error
+		want    bool
+	}{
+		{name: "enrolled host", agentID: "agent-123", want: true},
+		{name: "fresh host, no config file", agentID: "", want: false},
+		{
+			name:    "config present but unreadable is assumed enrolled",
+			agentID: "",
+			loadErr: errors.New("yaml: line 3: mapping values are not allowed"),
+			want:    true,
+		},
+		{
+			name:    "unreadable config wins even with an empty agent id",
+			agentID: "",
+			loadErr: errors.New("reading secrets file: permission denied"),
+			want:    true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := hostLooksEnrolled(c.agentID, c.loadErr); got != c.want {
+				t.Errorf("hostLooksEnrolled(%q, %v) = %v, want %v", c.agentID, c.loadErr, got, c.want)
+			}
+		})
+	}
+}

--- a/agent/internal/winsvcinstall/install.go
+++ b/agent/internal/winsvcinstall/install.go
@@ -1,0 +1,406 @@
+// Package winsvcinstall owns the Service Control Manager half of
+// `service install` for the Windows agent and the Windows watchdog.
+//
+// It exists because of #5299. Both installers used to call CreateService
+// unconditionally, which fails outright on a host where the service already
+// exists, and neither ever issued a start: the service was created
+// StartAutomatic, which starts it at the next BOOT, and the command then
+// printed a message claiming the agent was "installed and running". On an
+// already-enrolled remote host that is the same stranding bug #5252 fixed for
+// Linux and macOS — the device goes Offline and stays Offline until somebody
+// reaches the box out of band.
+//
+// The interfaces below are deliberately expressed in neutral terms with no
+// golang.org/x/sys/windows types, so the whole decision sequence — sample
+// before stopping, stop before staging the binary, create-or-reconfigure,
+// start, confirm RUNNING — compiles and its tests execute on every platform.
+// That matters concretely: `internal/agentapp` is NOT in the Test Agent
+// (Windows) package list (its inherited Windows reds are tracked in #2523), so
+// a //go:build windows test placed next to the installer would have run on no
+// CI job at all. Only the thin *_windows.go adapter in this package is
+// platform-bound, and `build-agent (windows/amd64)` compiles it.
+package winsvcinstall
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"time"
+)
+
+// ErrNotInstalled is what Manager.Open reports when the named service does not
+// exist yet. It is the signal to create rather than reconfigure, so it must be
+// distinguishable from "the SCM refused to tell us".
+var ErrNotInstalled = errors.New("service is not installed")
+
+// ErrNotRunning is what Service.RequestStop reports when the service turned out
+// to be stopped already. Racing our own state sample is not a failure.
+var ErrNotRunning = errors.New("service is not running")
+
+// State is the neutral spelling of a Windows service state.
+type State int
+
+// Service states. Only the three the install sequence actually branches on are
+// named; everything else collapses into StateOther, which is treated as "busy,
+// keep polling".
+const (
+	StateOther State = iota
+	StateStopped
+	StateStartPending
+	StateRunning
+)
+
+func (s State) String() string {
+	switch s {
+	case StateStopped:
+		return "STOPPED"
+	case StateStartPending:
+		return "START_PENDING"
+	case StateRunning:
+		return "RUNNING"
+	default:
+		return "PENDING"
+	}
+}
+
+// Status is the neutral subset of svc.Status the install sequence reads.
+type Status struct {
+	State State
+	// Win32ExitCode and ServiceExitCode are only meaningful on a STOPPED
+	// reading; they are what turns "it isn't running" into a diagnosable
+	// message.
+	Win32ExitCode   uint32
+	ServiceExitCode uint32
+}
+
+// Spec is the service identity an install asserts. It is applied on create AND
+// on reconfigure, so an upgrade heals a drifted registration (a service left
+// Disabled by a previous troubleshooting session, say) instead of silently
+// installing a binary that will never run.
+type Spec struct {
+	Name        string
+	DisplayName string
+	Description string
+	// Args are appended to the service command line after the executable path.
+	Args []string
+}
+
+// Service is the minimal control surface the install sequence needs over one
+// Windows service.
+type Service interface {
+	// Status reports the current state.
+	Status() (Status, error)
+	// RequestStop asks the SCM to stop the service. It returns as soon as the
+	// request is accepted; STOPPED is confirmed by polling Status.
+	// ErrNotRunning means it was already stopped.
+	RequestStop() error
+	// Reconfigure repoints an existing service at exePath and re-asserts spec.
+	Reconfigure(spec Spec, exePath string) error
+	// SetRecoveryActions installs the restart-on-failure ladder.
+	SetRecoveryActions() error
+	// RequestStart asks the SCM to start the service. It returns as soon as the
+	// request is accepted; RUNNING is confirmed by polling Status.
+	RequestStart() error
+	// Close releases the handle.
+	Close() error
+}
+
+// Manager is the minimal surface over an open SCM connection.
+type Manager interface {
+	// Open returns a handle to an existing service, or ErrNotInstalled.
+	Open(name string) (Service, error)
+	// Create registers a new service pointing at exePath.
+	Create(spec Spec, exePath string) (Service, error)
+	// Close disconnects from the SCM.
+	Close() error
+}
+
+// StartDecision records whether install must leave the service RUNNING when it
+// returns, and the reason — which the caller prints, so an install that
+// deliberately leaves the service stopped says why.
+type StartDecision struct {
+	Start  bool
+	Reason string
+}
+
+// StartWhenRunningOrEnrolled is the agent's rule, mirroring the Linux/macOS
+// behaviour settled in #5252/#5296.
+//
+// Two independent triggers, either sufficient:
+//
+//   - wasRunning: the service was up before this install stopped it. Install is
+//     the documented upgrade path, and an upgrade must not change whether the
+//     service is running.
+//   - enrolled: the host already has an agent ID, so the service is meant to be
+//     running even if it happened to be down at install time.
+//
+// Neither means a fresh, un-enrolled host: nothing to talk to a server about
+// yet, so the operator enrolls first and starts it deliberately.
+func StartWhenRunningOrEnrolled(enrolled bool) func(wasRunning bool) StartDecision {
+	return func(wasRunning bool) StartDecision {
+		switch {
+		case wasRunning:
+			return StartDecision{Start: true, Reason: "it was running before this install"}
+		case enrolled:
+			return StartDecision{Start: true, Reason: "this host is already enrolled"}
+		default:
+			return StartDecision{Start: false, Reason: "this host is not enrolled yet"}
+		}
+	}
+}
+
+// AlwaysStart is the watchdog's rule. Unconditional, because a watchdog has no
+// credentials to wait for and an installed-but-not-started watchdog is exactly
+// the failure it exists to prevent.
+func AlwaysStart() func(wasRunning bool) StartDecision {
+	return func(bool) StartDecision {
+		return StartDecision{Start: true, Reason: "a watchdog is useless unless it is running"}
+	}
+}
+
+// Timeouts bounds the two waits the install sequence performs.
+type Timeouts struct {
+	// Stop bounds the wait for STOPPED after a stop request.
+	Stop time.Duration
+	// Start bounds the wait for RUNNING after a start request.
+	Start time.Duration
+	// Poll is the interval between Status reads.
+	Poll time.Duration
+	// Settle is how long a STOPPED reading after a start request is treated as
+	// "the SCM has not moved it yet" rather than "it started and died".
+	// StartService is asynchronous, so without this the very first read after a
+	// successful start request would be misread as an immediate crash.
+	Settle time.Duration
+}
+
+// DefaultTimeouts are the production values.
+func DefaultTimeouts() Timeouts {
+	return Timeouts{
+		Stop:   30 * time.Second,
+		Start:  60 * time.Second,
+		Poll:   500 * time.Millisecond,
+		Settle: 3 * time.Second,
+	}
+}
+
+// Request is one `service install` invocation.
+type Request struct {
+	Spec Spec
+	// Stage copies the binary into its protected location and returns the path
+	// the service must point at. It is a callback rather than a path because it
+	// MUST run after the stop: Windows holds an exclusive lock on the image of
+	// a running service, so staging over it while the service runs fails.
+	Stage func() (string, error)
+	// Decide chooses whether to start, given whether the service was running
+	// before this install stopped it.
+	Decide func(wasRunning bool) StartDecision
+	// Timeouts is DefaultTimeouts() when zero.
+	Timeouts Timeouts
+	// Warn receives non-fatal diagnostics. nil discards them.
+	Warn io.Writer
+}
+
+// Outcome is what actually happened, so the caller can print the truth rather
+// than a hardcoded "installed and running".
+type Outcome struct {
+	// Existed is true when the service was already registered before this run.
+	Existed bool
+	// WasRunning is the state sampled BEFORE this install stopped anything.
+	WasRunning bool
+	// Installed is true once the service is registered and pointing at the new
+	// binary — i.e. a later error is a start failure, not an install failure.
+	Installed bool
+	// StartAttempted is true when the policy asked for a start, whether or not
+	// it succeeded.
+	StartAttempted bool
+	// Started is true only when the service was confirmed RUNNING.
+	Started bool
+	// StartReason is the Decide reason, printed either way.
+	StartReason string
+}
+
+// Summary is the one-line truth about what an install did — the replacement for
+// the hardcoded "The agent service is installed and running" that #5299 is
+// named after. It says "is running" only when the service was observed RUNNING.
+func (o Outcome) Summary(name string) string {
+	verb := "installed"
+	if o.Existed {
+		verb = "upgraded"
+	}
+	switch {
+	case o.Started:
+		return fmt.Sprintf("Service %q %s and is running.", name, verb)
+	case o.StartAttempted:
+		return fmt.Sprintf("Service %q %s but FAILED TO START.", name, verb)
+	default:
+		return fmt.Sprintf("Service %q %s and is NOT running (%s).", name, verb, o.StartReason)
+	}
+}
+
+// Install runs the SCM half of `service install`.
+//
+// The order is the whole bug:
+//
+//  1. open the existing service, if any;
+//  2. sample whether it is running — BEFORE our own stop. Asking afterwards is
+//     the inverted check that shipped #5252;
+//  3. stop it, and wait for STOPPED, so the staged binary can replace a locked
+//     image;
+//  4. stage the binary;
+//  5. reconfigure the existing registration, or create a new one;
+//  6. set recovery actions;
+//  7. start it when the policy says so, and confirm RUNNING before claiming it.
+func Install(m Manager, req Request) (Outcome, error) {
+	var out Outcome
+	warn := req.Warn
+	if warn == nil {
+		warn = io.Discard
+	}
+	t := req.Timeouts
+	if t == (Timeouts{}) {
+		t = DefaultTimeouts()
+	}
+
+	svcHandle, err := m.Open(req.Spec.Name)
+	switch {
+	case err == nil:
+		out.Existed = true
+		defer func() { _ = svcHandle.Close() }()
+	case errors.Is(err, ErrNotInstalled):
+	default:
+		return out, fmt.Errorf("failed to open the existing %q service: %w", req.Spec.Name, err)
+	}
+
+	if out.Existed {
+		// Sample BEFORE our own stop. Sampling afterwards can only ever answer
+		// "not running", which is the inverted check that shipped #5252.
+		status, err := svcHandle.Status()
+		if err != nil {
+			return out, fmt.Errorf("failed to read the state of the existing %q service: %w", req.Spec.Name, err)
+		}
+		out.WasRunning = status.State != StateStopped
+
+		if out.WasRunning {
+			if err := stopAndWait(svcHandle, t); err != nil {
+				return out, fmt.Errorf("failed to stop the running %q service before upgrading it: %w",
+					req.Spec.Name, err)
+			}
+		}
+	}
+
+	// Only now: Windows holds an exclusive lock on the image of a running
+	// service, so staging over it before the stop fails with a file-in-use
+	// error that says nothing about the real problem.
+	exePath, err := req.Stage()
+	if err != nil {
+		return out, err
+	}
+
+	if out.Existed {
+		if err := svcHandle.Reconfigure(req.Spec, exePath); err != nil {
+			return out, fmt.Errorf("failed to reconfigure the existing %q service: %w", req.Spec.Name, err)
+		}
+	} else {
+		svcHandle, err = m.Create(req.Spec, exePath)
+		if err != nil {
+			return out, fmt.Errorf("failed to create the %q service: %w", req.Spec.Name, err)
+		}
+		defer func() { _ = svcHandle.Close() }()
+	}
+	out.Installed = true
+
+	// Best-effort: a service that runs without a restart ladder is strictly
+	// better than an install aborted half-done.
+	if err := svcHandle.SetRecoveryActions(); err != nil {
+		_, _ = fmt.Fprintf(warn, "Warning: failed to set recovery actions: %v\n", err)
+	}
+
+	decision := req.Decide(out.WasRunning)
+	out.StartReason = decision.Reason
+	if !decision.Start {
+		return out, nil
+	}
+	out.StartAttempted = true
+
+	if err := startAndWait(svcHandle, t); err != nil {
+		// Installed stays true: the registration and the new binary are in
+		// place, so the caller can finish the rest of the install (the watchdog
+		// bootstrap) before surfacing this as a non-zero exit.
+		return out, fmt.Errorf("the %q service was installed but did not start: %w", req.Spec.Name, err)
+	}
+	out.Started = true
+	return out, nil
+}
+
+// StartAndWait starts an already-installed service and blocks until the SCM
+// reports it RUNNING. Exported so `service start` reports the same truth the
+// installer does — "the request was accepted" is not "it is running".
+func StartAndWait(m Manager, name string, t Timeouts) error {
+	if t == (Timeouts{}) {
+		t = DefaultTimeouts()
+	}
+	s, err := m.Open(name)
+	if err != nil {
+		return fmt.Errorf("failed to open the %q service: %w", name, err)
+	}
+	defer func() { _ = s.Close() }()
+	return startAndWait(s, t)
+}
+
+// stopAndWait requests a stop and blocks until the service reports STOPPED.
+func stopAndWait(s Service, t Timeouts) error {
+	if err := s.RequestStop(); err != nil && !errors.Is(err, ErrNotRunning) {
+		return err
+	}
+	deadline := time.Now().Add(t.Stop)
+	for {
+		status, err := s.Status()
+		if err != nil {
+			return fmt.Errorf("failed to read the service state while waiting for it to stop: %w", err)
+		}
+		if status.State == StateStopped {
+			return nil
+		}
+		if !time.Now().Before(deadline) {
+			return fmt.Errorf("it was still %s after %s", status.State, t.Stop)
+		}
+		time.Sleep(t.Poll)
+	}
+}
+
+// startAndWait requests a start and blocks until the service reports RUNNING.
+//
+// Waiting matters twice over: it is what makes an "installed and running"
+// message true, and it is the only way a service that starts and immediately
+// dies becomes a non-zero exit instead of a silent success.
+func startAndWait(s Service, t Timeouts) error {
+	if err := s.RequestStart(); err != nil {
+		return err
+	}
+	start := time.Now()
+	deadline := start.Add(t.Start)
+	settled := start.Add(t.Settle)
+	for {
+		status, err := s.Status()
+		if err != nil {
+			return fmt.Errorf("failed to read the service state after requesting a start: %w", err)
+		}
+		switch status.State {
+		case StateRunning:
+			return nil
+		case StateStopped:
+			// StartService is asynchronous, so an immediate STOPPED reading
+			// usually means "the SCM has not moved it yet", not "it died".
+			// Past the settle window it does mean it died.
+			if !time.Now().Before(settled) {
+				return fmt.Errorf(
+					"it stopped again immediately (Win32 exit code %d, service exit code %d)",
+					status.Win32ExitCode, status.ServiceExitCode)
+			}
+		}
+		if !time.Now().Before(deadline) {
+			return fmt.Errorf("it was still %s after %s", status.State, t.Start)
+		}
+		time.Sleep(t.Poll)
+	}
+}

--- a/agent/internal/winsvcinstall/install.go
+++ b/agent/internal/winsvcinstall/install.go
@@ -293,12 +293,14 @@ func Install(m Manager, req Request) (Outcome, error) {
 	// error that says nothing about the real problem.
 	exePath, err := req.Stage()
 	if err != nil {
-		return out, err
+		return out, afterStopNote(err, out.WasRunning, req.Spec.Name)
 	}
 
 	if out.Existed {
 		if err := svcHandle.Reconfigure(req.Spec, exePath); err != nil {
-			return out, fmt.Errorf("failed to reconfigure the existing %q service: %w", req.Spec.Name, err)
+			return out, afterStopNote(
+				fmt.Errorf("failed to reconfigure the existing %q service: %w", req.Spec.Name, err),
+				out.WasRunning, req.Spec.Name)
 		}
 	} else {
 		svcHandle, err = m.Create(req.Spec, exePath)
@@ -345,6 +347,22 @@ func StartAndWait(m Manager, name string, t Timeouts) error {
 	}
 	defer func() { _ = s.Close() }()
 	return startAndWait(s, t)
+}
+
+// afterStopNote records that this attempt took a healthy service down.
+//
+// Everything between the stop and the start runs on a service this command
+// stopped itself, so a failure there is not "nothing changed" — it is a
+// previously-running agent left stopped. The bare staging or reconfigure error
+// reads as harmless, which is precisely how a stranded host goes unnoticed.
+func afterStopNote(err error, wasRunning bool, name string) error {
+	if !wasRunning {
+		return err
+	}
+	return fmt.Errorf(
+		"%w; the %q service was RUNNING and this attempt stopped it to replace the binary, "+
+			"so it is STILL STOPPED — recover with `sc start %s` once the cause above is fixed",
+		err, name, name)
 }
 
 // stopAndWait requests a stop and blocks until the service reports STOPPED.

--- a/agent/internal/winsvcinstall/install_test.go
+++ b/agent/internal/winsvcinstall/install_test.go
@@ -1,0 +1,509 @@
+package winsvcinstall
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fastTimeouts opts out of DefaultTimeouts without being the zero struct.
+// Poll 0 keeps the waits from sleeping; Settle 0 makes a STOPPED reading after
+// a start request immediately conclusive.
+func fastTimeouts() Timeouts {
+	return Timeouts{Stop: time.Second, Start: time.Second, Poll: 0, Settle: 0}
+}
+
+type fakeService struct {
+	rec *[]string
+
+	// beforeStart is consumed one entry per Status() call until RequestStart is
+	// accepted; the last entry repeats. afterStart takes over from then on.
+	beforeStart []Status
+	afterStart  []Status
+	started     bool
+	idx         int
+
+	statusErr error
+	stopErr   error
+	reconfErr error
+	recovErr  error
+	startErr  error
+
+	gotSpec    Spec
+	gotExePath string
+	closed     bool
+}
+
+func (f *fakeService) log(op string) { *f.rec = append(*f.rec, op) }
+
+func (f *fakeService) Status() (Status, error) {
+	f.log("status")
+	if f.statusErr != nil {
+		return Status{}, f.statusErr
+	}
+	queue := f.beforeStart
+	if f.started {
+		queue = f.afterStart
+	}
+	if len(queue) == 0 {
+		return Status{State: StateStopped}, nil
+	}
+	i := f.idx
+	if i >= len(queue) {
+		i = len(queue) - 1
+	}
+	f.idx++
+	return queue[i], nil
+}
+
+func (f *fakeService) RequestStop() error {
+	f.log("stop")
+	return f.stopErr
+}
+
+func (f *fakeService) Reconfigure(spec Spec, exePath string) error {
+	f.log("reconfigure")
+	f.gotSpec, f.gotExePath = spec, exePath
+	return f.reconfErr
+}
+
+func (f *fakeService) SetRecoveryActions() error {
+	f.log("recovery")
+	return f.recovErr
+}
+
+func (f *fakeService) RequestStart() error {
+	f.log("start")
+	if f.startErr != nil {
+		return f.startErr
+	}
+	f.started, f.idx = true, 0
+	return nil
+}
+
+func (f *fakeService) Close() error {
+	f.closed = true
+	return nil
+}
+
+type fakeManager struct {
+	rec []string
+	// existing is the service Open returns; nil means ErrNotInstalled.
+	existing  *fakeService
+	created   *fakeService
+	openErr   error
+	createErr error
+}
+
+func (m *fakeManager) Open(name string) (Service, error) {
+	m.rec = append(m.rec, "open")
+	if m.openErr != nil {
+		return nil, m.openErr
+	}
+	if m.existing == nil {
+		return nil, ErrNotInstalled
+	}
+	m.existing.rec = &m.rec
+	return m.existing, nil
+}
+
+func (m *fakeManager) Create(spec Spec, exePath string) (Service, error) {
+	m.rec = append(m.rec, "create")
+	if m.createErr != nil {
+		return nil, m.createErr
+	}
+	if m.created == nil {
+		m.created = &fakeService{}
+	}
+	m.created.rec = &m.rec
+	m.created.gotSpec, m.created.gotExePath = spec, exePath
+	return m.created, nil
+}
+
+func (m *fakeManager) Close() error { return nil }
+
+const testExePath = `C:\Program Files\Breeze\breeze-agent.exe`
+
+func testSpec() Spec {
+	return Spec{
+		Name:        "BreezeAgent",
+		DisplayName: "Breeze RMM Agent",
+		Description: "Breeze Remote Monitoring and Management Agent",
+		Args:        []string{"run"},
+	}
+}
+
+func newRequest(m *fakeManager, decide func(bool) StartDecision) Request {
+	return Request{
+		Spec: testSpec(),
+		Stage: func() (string, error) {
+			m.rec = append(m.rec, "stage")
+			return testExePath, nil
+		},
+		Decide:   decide,
+		Timeouts: fastTimeouts(),
+	}
+}
+
+func seq(rec []string) string { return strings.Join(rec, " | ") }
+
+// The headline regression for #5299: an existing, RUNNING service is sampled
+// before it is stopped, the binary is staged only after the stop, and the
+// service is started again at the end.
+func TestInstallExistingRunningServiceSamplesStopsRestagesAndStarts(t *testing.T) {
+	m := &fakeManager{existing: &fakeService{
+		beforeStart: []Status{{State: StateRunning}, {State: StateStopped}},
+		afterStart:  []Status{{State: StateRunning}},
+	}}
+
+	out, err := Install(m, newRequest(m, StartWhenRunningOrEnrolled(false)))
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	want := "open | status | stop | status | stage | reconfigure | recovery | start | status"
+	if got := seq(m.rec); got != want {
+		t.Fatalf("call sequence =\n  %q\nwant\n  %q", got, want)
+	}
+	if !out.Existed || !out.WasRunning || !out.Installed || !out.Started {
+		t.Fatalf("outcome = %+v, want Existed/WasRunning/Installed/Started all true", out)
+	}
+	if out.StartReason != "it was running before this install" {
+		t.Errorf("StartReason = %q", out.StartReason)
+	}
+	if m.existing.gotExePath != testExePath {
+		t.Errorf("reconfigured to %q, want %q", m.existing.gotExePath, testExePath)
+	}
+	if m.existing.gotSpec.Name != "BreezeAgent" {
+		t.Errorf("reconfigured spec = %+v", m.existing.gotSpec)
+	}
+}
+
+// The state sample must precede our own stop. Reading it afterwards can only
+// ever answer "not running", which is the inverted check that shipped #5252.
+func TestInstallSamplesStateBeforeItsOwnStop(t *testing.T) {
+	m := &fakeManager{existing: &fakeService{
+		beforeStart: []Status{{State: StateRunning}, {State: StateStopped}},
+		afterStart:  []Status{{State: StateRunning}},
+	}}
+	if _, err := Install(m, newRequest(m, StartWhenRunningOrEnrolled(false))); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	firstStatus, firstStop := indexOf(m.rec, "status"), indexOf(m.rec, "stop")
+	if firstStatus < 0 || firstStop < 0 || firstStatus > firstStop {
+		t.Fatalf("state was not sampled before the stop: %s", seq(m.rec))
+	}
+}
+
+// Windows holds an exclusive lock on the image of a running service, so the
+// binary can only be staged once the service is confirmed STOPPED.
+func TestInstallStagesBinaryOnlyAfterTheServiceStopped(t *testing.T) {
+	m := &fakeManager{existing: &fakeService{
+		beforeStart: []Status{{State: StateRunning}, {State: StateStopped}},
+		afterStart:  []Status{{State: StateRunning}},
+	}}
+	if _, err := Install(m, newRequest(m, StartWhenRunningOrEnrolled(false))); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	stop, stage := indexOf(m.rec, "stop"), indexOf(m.rec, "stage")
+	if stop < 0 || stage < 0 {
+		t.Fatalf("expected both a stop and a stage in the sequence, got: %s", seq(m.rec))
+	}
+	if stop > stage {
+		t.Fatalf("binary staged before the stop: %s", seq(m.rec))
+	}
+}
+
+// A stop that never completes must abort the install loudly rather than fall
+// through to a binary copy that would fail with an unrelated file-lock error.
+func TestInstallFailsWhenTheServiceNeverStops(t *testing.T) {
+	m := &fakeManager{existing: &fakeService{
+		beforeStart: []Status{{State: StateRunning}},
+	}}
+	req := newRequest(m, StartWhenRunningOrEnrolled(true))
+	req.Timeouts = Timeouts{Stop: 0, Start: time.Second, Poll: 0, Settle: 0}
+
+	out, err := Install(m, req)
+	if err == nil {
+		t.Fatal("Install returned nil error after the stop timed out")
+	}
+	if out.Installed {
+		t.Errorf("outcome claims Installed after a failed stop: %+v", out)
+	}
+	if strings.Contains(seq(m.rec), "stage") {
+		t.Errorf("staged the binary despite the stop failing: %s", seq(m.rec))
+	}
+}
+
+// An enrolled host whose service happened to be down still wants it back: the
+// agent is that host's only management path.
+func TestInstallExistingStoppedServiceStartsWhenEnrolled(t *testing.T) {
+	m := &fakeManager{existing: &fakeService{
+		beforeStart: []Status{{State: StateStopped}},
+		afterStart:  []Status{{State: StateRunning}},
+	}}
+	out, err := Install(m, newRequest(m, StartWhenRunningOrEnrolled(true)))
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if strings.Contains(seq(m.rec), "stop") {
+		t.Errorf("stopped an already-stopped service: %s", seq(m.rec))
+	}
+	if !out.Started {
+		t.Fatalf("outcome = %+v, want Started", out)
+	}
+	if out.StartReason != "this host is already enrolled" {
+		t.Errorf("StartReason = %q", out.StartReason)
+	}
+}
+
+// A fresh, un-enrolled host is deliberately left stopped — there is nothing for
+// the agent to talk to a server about yet.
+func TestInstallFreshUnenrolledHostIsLeftStopped(t *testing.T) {
+	m := &fakeManager{}
+	out, err := Install(m, newRequest(m, StartWhenRunningOrEnrolled(false)))
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	want := "open | stage | create | recovery"
+	if got := seq(m.rec); got != want {
+		t.Fatalf("call sequence =\n  %q\nwant\n  %q", got, want)
+	}
+	if out.Existed || out.Started {
+		t.Fatalf("outcome = %+v, want a fresh install left stopped", out)
+	}
+	if !out.Installed {
+		t.Errorf("outcome = %+v, want Installed", out)
+	}
+	if out.StartReason != "this host is not enrolled yet" {
+		t.Errorf("StartReason = %q", out.StartReason)
+	}
+}
+
+func TestInstallFreshEnrolledHostStarts(t *testing.T) {
+	m := &fakeManager{created: &fakeService{afterStart: []Status{{State: StateRunning}}}}
+	out, err := Install(m, newRequest(m, StartWhenRunningOrEnrolled(true)))
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if !out.Started {
+		t.Fatalf("outcome = %+v, want Started", out)
+	}
+	if m.created.gotExePath != testExePath {
+		t.Errorf("created against %q, want %q", m.created.gotExePath, testExePath)
+	}
+}
+
+// The watchdog rule: always end running, even on a fresh un-enrolled host.
+func TestAlwaysStartStartsAFreshUnenrolledInstall(t *testing.T) {
+	m := &fakeManager{created: &fakeService{afterStart: []Status{{State: StateRunning}}}}
+	out, err := Install(m, newRequest(m, AlwaysStart()))
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if !out.Started {
+		t.Fatalf("outcome = %+v, want Started", out)
+	}
+}
+
+// A start that the SCM refuses is a non-zero exit, not a silent success — that
+// silence is how the Linux half of this bug went unnoticed until devices showed
+// Offline. Installed stays true so the caller can still bootstrap the watchdog
+// before surfacing the failure.
+func TestInstallFailsWhenTheStartRequestIsRefused(t *testing.T) {
+	m := &fakeManager{created: &fakeService{startErr: errors.New("access is denied")}}
+	out, err := Install(m, newRequest(m, StartWhenRunningOrEnrolled(true)))
+	if err == nil {
+		t.Fatal("Install returned nil error after the start was refused")
+	}
+	if !strings.Contains(err.Error(), "access is denied") {
+		t.Errorf("error does not carry the cause: %v", err)
+	}
+	if out.Started {
+		t.Errorf("outcome claims Started: %+v", out)
+	}
+	if !out.Installed {
+		t.Errorf("outcome = %+v, want Installed true so the caller can still install the watchdog", out)
+	}
+}
+
+// StartService is asynchronous: "accepted" is not "running". A service that
+// starts and dies must not be reported as installed and running.
+func TestInstallFailsWhenTheServiceDiesImmediatelyAfterStarting(t *testing.T) {
+	m := &fakeManager{created: &fakeService{
+		afterStart: []Status{{State: StateStopped, Win32ExitCode: 1067}},
+	}}
+	_, err := Install(m, newRequest(m, StartWhenRunningOrEnrolled(true)))
+	if err == nil {
+		t.Fatal("Install returned nil error for a service that stopped right after starting")
+	}
+	if !strings.Contains(err.Error(), "1067") {
+		t.Errorf("error does not report the exit code: %v", err)
+	}
+}
+
+// A START_PENDING reading is not yet a success; Started must only be reported
+// once the service is confirmed RUNNING.
+func TestInstallWaitsThroughStartPendingBeforeReportingStarted(t *testing.T) {
+	m := &fakeManager{created: &fakeService{
+		afterStart: []Status{{State: StateStartPending}, {State: StateStartPending}, {State: StateRunning}},
+	}}
+	out, err := Install(m, newRequest(m, StartWhenRunningOrEnrolled(true)))
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if !out.Started {
+		t.Fatalf("outcome = %+v, want Started", out)
+	}
+	if n := countOf(m.rec, "status"); n != 3 {
+		t.Errorf("polled Status %d times, want 3 (two START_PENDING then RUNNING)", n)
+	}
+}
+
+// A service that never leaves START_PENDING must time out rather than hang or
+// be reported as running.
+func TestInstallTimesOutWaitingForRunning(t *testing.T) {
+	m := &fakeManager{created: &fakeService{
+		afterStart: []Status{{State: StateStartPending}},
+	}}
+	req := newRequest(m, StartWhenRunningOrEnrolled(true))
+	req.Timeouts = Timeouts{Stop: time.Second, Start: 0, Poll: 0, Settle: time.Minute}
+
+	out, err := Install(m, req)
+	if err == nil {
+		t.Fatal("Install returned nil error for a service stuck in START_PENDING")
+	}
+	if !strings.Contains(err.Error(), "START_PENDING") {
+		t.Errorf("error does not report the last state: %v", err)
+	}
+	if out.Started {
+		t.Errorf("outcome claims Started: %+v", out)
+	}
+}
+
+// An Open failure that is not "not installed" must not be silently treated as a
+// fresh install — that would create a second registration or mask an SCM
+// permission problem.
+func TestInstallPropagatesUnexpectedOpenErrors(t *testing.T) {
+	m := &fakeManager{openErr: errors.New("access is denied")}
+	if _, err := Install(m, newRequest(m, StartWhenRunningOrEnrolled(true))); err == nil {
+		t.Fatal("Install swallowed an unexpected Open error")
+	}
+	if strings.Contains(seq(m.rec), "create") {
+		t.Errorf("created a service after an unexpected Open error: %s", seq(m.rec))
+	}
+}
+
+// Recovery actions are best-effort: a service that runs without a restart
+// ladder is strictly better than an aborted install.
+func TestInstallTreatsRecoveryActionFailureAsAWarning(t *testing.T) {
+	m := &fakeManager{created: &fakeService{
+		recovErr:   errors.New("no permission"),
+		afterStart: []Status{{State: StateRunning}},
+	}}
+	warn := &strings.Builder{}
+	req := newRequest(m, StartWhenRunningOrEnrolled(true))
+	req.Warn = warn
+
+	out, err := Install(m, req)
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if !out.Started {
+		t.Fatalf("outcome = %+v, want Started", out)
+	}
+	if !strings.Contains(warn.String(), "recovery actions") {
+		t.Errorf("recovery failure was not warned about: %q", warn.String())
+	}
+}
+
+func TestStartWhenRunningOrEnrolled(t *testing.T) {
+	cases := []struct {
+		wasRunning, enrolled, wantStart bool
+	}{
+		{wasRunning: true, enrolled: true, wantStart: true},
+		{wasRunning: true, enrolled: false, wantStart: true},
+		{wasRunning: false, enrolled: true, wantStart: true},
+		{wasRunning: false, enrolled: false, wantStart: false},
+	}
+	for _, c := range cases {
+		got := StartWhenRunningOrEnrolled(c.enrolled)(c.wasRunning)
+		if got.Start != c.wantStart {
+			t.Errorf("wasRunning=%v enrolled=%v: Start=%v want %v", c.wasRunning, c.enrolled, got.Start, c.wantStart)
+		}
+		if got.Reason == "" {
+			t.Errorf("wasRunning=%v enrolled=%v: empty reason", c.wasRunning, c.enrolled)
+		}
+	}
+}
+
+func TestAlwaysStartIsUnconditional(t *testing.T) {
+	for _, wasRunning := range []bool{true, false} {
+		if d := AlwaysStart()(wasRunning); !d.Start || d.Reason == "" {
+			t.Errorf("AlwaysStart()(%v) = %+v", wasRunning, d)
+		}
+	}
+}
+
+func indexOf(rec []string, op string) int {
+	for i, v := range rec {
+		if v == op {
+			return i
+		}
+	}
+	return -1
+}
+
+func countOf(rec []string, op string) int {
+	n := 0
+	for _, v := range rec {
+		if v == op {
+			n++
+		}
+	}
+	return n
+}
+
+// The message this whole issue is named after: "installed and running" was
+// printed unconditionally. Summary must claim "is running" only when the
+// service was actually observed RUNNING.
+func TestSummaryClaimsRunningOnlyWhenStarted(t *testing.T) {
+	cases := []Outcome{
+		{Installed: true},
+		{Installed: true, Existed: true},
+		{Installed: true, StartReason: "this host is not enrolled yet"},
+		{Installed: true, Existed: true, WasRunning: true, StartAttempted: true},
+		{Installed: true, StartAttempted: true, Started: true},
+		{Installed: true, Existed: true, StartAttempted: true, Started: true},
+	}
+	for _, o := range cases {
+		got := o.Summary("BreezeAgent")
+		if strings.Contains(got, "is running") != o.Started {
+			t.Errorf("Summary(%+v) = %q; claims running=%v want %v",
+				o, got, strings.Contains(got, "is running"), o.Started)
+		}
+		if !strings.Contains(got, "BreezeAgent") {
+			t.Errorf("Summary(%+v) = %q, does not name the service", o, got)
+		}
+		if o.Existed && !strings.Contains(got, "upgraded") {
+			t.Errorf("Summary(%+v) = %q, does not say upgraded", o, got)
+		}
+	}
+}
+
+// A start that was attempted and failed must not be reported with the
+// "we deliberately left it stopped" wording.
+func TestSummaryDistinguishesAFailedStartFromADeliberateOne(t *testing.T) {
+	failed := Outcome{Installed: true, Existed: true, WasRunning: true, StartAttempted: true}.Summary("BreezeAgent")
+	if !strings.Contains(failed, "FAILED TO START") {
+		t.Errorf("failed-start summary = %q", failed)
+	}
+	deliberate := Outcome{Installed: true, StartReason: "this host is not enrolled yet"}.Summary("BreezeAgent")
+	if !strings.Contains(deliberate, "not enrolled yet") {
+		t.Errorf("deliberate-stop summary = %q", deliberate)
+	}
+	if strings.Contains(deliberate, "FAILED") {
+		t.Errorf("deliberate-stop summary alarms the operator: %q", deliberate)
+	}
+}

--- a/agent/internal/winsvcinstall/install_test.go
+++ b/agent/internal/winsvcinstall/install_test.go
@@ -507,3 +507,66 @@ func TestSummaryDistinguishesAFailedStartFromADeliberateOne(t *testing.T) {
 		t.Errorf("deliberate-stop summary alarms the operator: %q", deliberate)
 	}
 }
+
+// Everything between the stop and the start runs on a service this command
+// took down itself. A bare "failed to copy the binary" reads as though nothing
+// changed, which is how a stranded host goes unnoticed — the error must say the
+// service is still stopped, and how to bring it back.
+func TestInstallSaysTheServiceIsStillStoppedWhenStagingFailsAfterAStop(t *testing.T) {
+	m := &fakeManager{existing: &fakeService{
+		beforeStart: []Status{{State: StateRunning}, {State: StateStopped}},
+	}}
+	req := newRequest(m, StartWhenRunningOrEnrolled(true))
+	req.Stage = func() (string, error) {
+		m.rec = append(m.rec, "stage")
+		return "", errors.New("failed to install service binary in protected Program Files location")
+	}
+
+	out, err := Install(m, req)
+	if err == nil {
+		t.Fatal("Install returned nil error after staging failed")
+	}
+	if !strings.Contains(err.Error(), "STILL STOPPED") {
+		t.Errorf("error does not warn that the service is still stopped: %v", err)
+	}
+	if !strings.Contains(err.Error(), "sc start BreezeAgent") {
+		t.Errorf("error does not say how to recover: %v", err)
+	}
+	if !strings.Contains(err.Error(), "protected Program Files location") {
+		t.Errorf("error lost the underlying cause: %v", err)
+	}
+	if !out.WasRunning || out.Installed {
+		t.Errorf("outcome = %+v, want WasRunning true and Installed false", out)
+	}
+}
+
+// The same failure on a service that was already stopped must NOT claim this
+// command took anything down.
+func TestInstallDoesNotClaimItStoppedAnAlreadyStoppedService(t *testing.T) {
+	m := &fakeManager{existing: &fakeService{beforeStart: []Status{{State: StateStopped}}}}
+	req := newRequest(m, StartWhenRunningOrEnrolled(true))
+	req.Stage = func() (string, error) { return "", errors.New("disk full") }
+
+	_, err := Install(m, req)
+	if err == nil {
+		t.Fatal("Install returned nil error after staging failed")
+	}
+	if strings.Contains(err.Error(), "STILL STOPPED") {
+		t.Errorf("error blames this install for a service it never stopped: %v", err)
+	}
+}
+
+// A reconfigure failure is the same class: it happens after the stop.
+func TestInstallSaysTheServiceIsStillStoppedWhenReconfigureFailsAfterAStop(t *testing.T) {
+	m := &fakeManager{existing: &fakeService{
+		beforeStart: []Status{{State: StateRunning}, {State: StateStopped}},
+		reconfErr:   errors.New("access is denied"),
+	}}
+	_, err := Install(m, newRequest(m, StartWhenRunningOrEnrolled(true)))
+	if err == nil {
+		t.Fatal("Install returned nil error after reconfigure failed")
+	}
+	if !strings.Contains(err.Error(), "STILL STOPPED") {
+		t.Errorf("error does not warn that the service is still stopped: %v", err)
+	}
+}

--- a/agent/internal/winsvcinstall/scm_windows.go
+++ b/agent/internal/winsvcinstall/scm_windows.go
@@ -1,0 +1,157 @@
+//go:build windows
+
+package winsvcinstall
+
+import (
+	"errors"
+	"fmt"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/svc"
+	"golang.org/x/sys/windows/svc/mgr"
+)
+
+// recoveryResetPeriodSeconds is how long Windows waits before forgetting a
+// service's failure count (24 h).
+const recoveryResetPeriodSeconds = 86400
+
+// Connect opens the Service Control Manager. The caller must Close the Manager.
+func Connect() (Manager, error) {
+	m, err := mgr.Connect()
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to the Service Control Manager (run as Administrator): %w", err)
+	}
+	return &scmManager{m: m}, nil
+}
+
+type scmManager struct{ m *mgr.Mgr }
+
+func (s *scmManager) Open(name string) (Service, error) {
+	handle, err := s.m.OpenService(name)
+	if err != nil {
+		// "does not exist" is the create signal and must stay distinguishable
+		// from an SCM that simply refused to answer.
+		if errors.Is(err, windows.ERROR_SERVICE_DOES_NOT_EXIST) {
+			return nil, ErrNotInstalled
+		}
+		return nil, err
+	}
+	return &scmService{s: handle}, nil
+}
+
+func (s *scmManager) Create(spec Spec, exePath string) (Service, error) {
+	handle, err := s.m.CreateService(spec.Name, exePath, mgr.Config{
+		DisplayName:  spec.DisplayName,
+		Description:  spec.Description,
+		StartType:    mgr.StartAutomatic,
+		ErrorControl: mgr.ErrorNormal,
+	}, spec.Args...)
+	if err != nil {
+		return nil, err
+	}
+	return &scmService{s: handle}, nil
+}
+
+func (s *scmManager) Close() error { return s.m.Disconnect() }
+
+type scmService struct{ s *mgr.Service }
+
+func (x *scmService) Status() (Status, error) {
+	st, err := x.s.Query()
+	if err != nil {
+		return Status{}, err
+	}
+	return Status{
+		State:           neutralState(st.State),
+		Win32ExitCode:   st.Win32ExitCode,
+		ServiceExitCode: st.ServiceSpecificExitCode,
+	}, nil
+}
+
+// neutralState maps the SCM's state to the three states the install sequence
+// branches on. Everything else (STOP_PENDING, PAUSED, …) is "busy, keep
+// polling" — deliberately not STOPPED, so a service on its way down is never
+// mistaken for one that is already down.
+func neutralState(s svc.State) State {
+	switch s {
+	case svc.Stopped:
+		return StateStopped
+	case svc.StartPending:
+		return StateStartPending
+	case svc.Running:
+		return StateRunning
+	default:
+		return StateOther
+	}
+}
+
+func (x *scmService) RequestStop() error {
+	if _, err := x.s.Control(svc.Stop); err != nil {
+		// The service stopped between our sample and this call. Not a failure.
+		if errors.Is(err, windows.ERROR_SERVICE_NOT_ACTIVE) {
+			return ErrNotRunning
+		}
+		return err
+	}
+	return nil
+}
+
+// Reconfigure repoints an existing registration at exePath.
+//
+// Only the three fields the install functionally depends on are re-asserted:
+// the command line, so the service runs the binary we just staged; StartType,
+// so an upgrade heals a service left Disabled by earlier troubleshooting
+// (otherwise the install would succeed and the Start that follows would fail
+// with ERROR_SERVICE_DISABLED); and ErrorControl. This mirrors the unconditional
+// `systemctl enable` the Linux install does.
+//
+// Spec.DisplayName and Spec.Description are deliberately NOT applied here, only
+// on Create. The MSI registers BreezeAgent with its own display name, and the
+// MSI is the supported Windows install path — re-running `service install` on
+// such a host should fix what is broken, not silently rename the service in
+// services.msc. Everything else (account, dependencies, SID type, delayed
+// start) is read back and preserved for the same reason.
+func (x *scmService) Reconfigure(spec Spec, exePath string) error {
+	cfg, err := x.s.Config()
+	if err != nil {
+		return fmt.Errorf("read the current service configuration: %w", err)
+	}
+	cfg.BinaryPathName = binaryPathName(exePath, spec.Args...)
+	cfg.StartType = mgr.StartAutomatic
+	cfg.ErrorControl = mgr.ErrorNormal
+	return x.s.UpdateConfig(cfg)
+}
+
+// binaryPathName builds the service command line exactly the way
+// mgr.CreateService does internally, so a reconfigured service and a freshly
+// created one end up registered identically — including the quoting that keeps
+// `C:\Program Files\…` from being read as two arguments.
+func binaryPathName(exePath string, args ...string) string {
+	line := syscall.EscapeArg(exePath)
+	for _, a := range args {
+		line += " " + syscall.EscapeArg(a)
+	}
+	return line
+}
+
+func (x *scmService) SetRecoveryActions() error {
+	return x.s.SetRecoveryActions([]mgr.RecoveryAction{
+		{Type: mgr.ServiceRestart, Delay: 5 * time.Second},
+		{Type: mgr.ServiceRestart, Delay: 10 * time.Second},
+		{Type: mgr.ServiceRestart, Delay: 30 * time.Second},
+	}, recoveryResetPeriodSeconds)
+}
+
+// RequestStart passes no arguments: the command line, including "run", lives in
+// the registration itself, and start-time arguments would not survive an SCM
+// restart of the service.
+func (x *scmService) RequestStart() error { return x.s.Start() }
+
+func (x *scmService) Close() error { return x.s.Close() }
+
+var (
+	_ Manager = (*scmManager)(nil)
+	_ Service = (*scmService)(nil)
+)

--- a/agent/internal/winsvcinstall/scm_windows_test.go
+++ b/agent/internal/winsvcinstall/scm_windows_test.go
@@ -1,0 +1,50 @@
+//go:build windows
+
+package winsvcinstall
+
+import (
+	"testing"
+
+	"golang.org/x/sys/windows/svc"
+)
+
+// A reconfigured service must get the same command line CreateService would
+// have produced. Program Files contains a space, so unquoted the SCM would read
+// the path as an executable plus a stray "Files\breeze-agent.exe" argument.
+func TestBinaryPathNameQuotesPathsWithSpaces(t *testing.T) {
+	got := binaryPathName(`C:\Program Files\Breeze\breeze-agent.exe`, "run")
+	want := `"C:\Program Files\Breeze\breeze-agent.exe" run`
+	if got != want {
+		t.Fatalf("binaryPathName = %s, want %s", got, want)
+	}
+}
+
+func TestBinaryPathNameWithoutArgs(t *testing.T) {
+	got := binaryPathName(`C:\Breeze\breeze-watchdog.exe`)
+	if got != `C:\Breeze\breeze-watchdog.exe` {
+		t.Fatalf("binaryPathName = %s", got)
+	}
+}
+
+// STOP_PENDING must NOT map to STOPPED: a service on its way down is still
+// holding its image open, so treating it as stopped would let the installer
+// stage a binary over a locked file.
+func TestNeutralStateMapping(t *testing.T) {
+	cases := []struct {
+		in   svc.State
+		want State
+	}{
+		{svc.Stopped, StateStopped},
+		{svc.StartPending, StateStartPending},
+		{svc.Running, StateRunning},
+		{svc.StopPending, StateOther},
+		{svc.Paused, StateOther},
+		{svc.PausePending, StateOther},
+		{svc.ContinuePending, StateOther},
+	}
+	for _, c := range cases {
+		if got := neutralState(c.in); got != c.want {
+			t.Errorf("neutralState(%d) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}

--- a/apps/docs/src/content/docs/features/agent-diagnostics.mdx
+++ b/apps/docs/src/content/docs/features/agent-diagnostics.mdx
@@ -166,6 +166,12 @@ All `service` commands require the terminal to be running as **Administrator** b
     - Start automatically when Windows boots
     - Restart automatically on failure (after 5 s on the first failure, 10 s on the second, 30 s on the third)
     - Reset the failure count after 24 hours of stable operation
+
+    Safe to re-run on a host where the service already exists: it stops the running service, replaces the binary, repoints the registration at it, and then **starts the service again** if it was running beforehand or the host is already enrolled. A fresh, un-enrolled host is left stopped deliberately — enroll first, then start. If the service is meant to come back and fails to start, the command exits non-zero and says so rather than reporting success.
+
+    <Aside type="caution">
+      **v0.110.0 and earlier:** `service install` did **not** start the service, and re-running it on a host that already had the service failed with "service already exists". After installing or upgrading on those versions, run `breeze-agent.exe service start` yourself.
+    </Aside>
   </TabItem>
   <TabItem label="Uninstall">
     ```cmd
@@ -200,6 +206,8 @@ breeze-agent.exe service install
 breeze-agent.exe service start
 ```
 
+`service install` already starts the service on an enrolled host, so the explicit `service start` is only needed on a fresh host that has not enrolled yet (and on agents at v0.110.0 or earlier, where install never started anything).
+
 **Stop and uninstall:**
 
 ```cmd
@@ -230,8 +238,8 @@ The command must be run from an **Administrator** command prompt or PowerShell s
 
 **`service install` fails with "service already exists"**
 
-The `BreezeAgent` service is already registered. Run `breeze-agent.exe service uninstall` first if you need to re-install, or use `breeze-agent.exe service start` if the service is simply stopped.
+Only on **v0.110.0 and earlier**, where `service install` could not upgrade an existing registration. Run `breeze-agent.exe service uninstall` first if you need to re-install, or `breeze-agent.exe service start` if the service is simply stopped. Newer agents upgrade the existing service in place instead of failing.
 
 **`service start` fails after install**
 
-Ensure the agent binary path has not moved since installation. The SCM stores the absolute path at install time. If the binary was relocated, uninstall and reinstall the service.
+The SCM stores the absolute path to the binary. On current agents, re-running `breeze-agent.exe service install` repoints the registration at the binary's real location; on **v0.110.0 and earlier** you have to uninstall and reinstall the service instead. If the start still fails, check **Event Viewer → Windows Logs → Application** for the service's own start error.


### PR DESCRIPTION
Closes #5299

## The bug

**Verified** (read directly from `main` at d8a06fb015; **not reproduced on a Windows host** — no Windows box was available, so every runtime claim below is inferred from the code and the SCM contract):

- `agent/internal/agentapp/service_cmd_windows.go` `service install` called `mgr.CreateService(..., StartAutomatic, ...)` and returned. **`StartAutomatic` starts the service at the next BOOT, not now** — nothing in the command ever issued a start. A manual or scripted install left the agent registered and stopped.
- On a host where `BreezeAgent` already exists, `CreateService` fails with `ERROR_SERVICE_EXISTS`, so the command aborted with `failed to create service: ...`. There was **no in-place upgrade path on Windows at all**. (The issue body describes the Windows branch as stopping and reconfiguring — it did neither; that detail was inferred by the #5252 fixer from the Linux shape.)
- The watchdog-bootstrap failure warning printed `The agent service is installed and running.` unconditionally — untrue on every fresh install, and untrue after a failed start.
- `agent/cmd/breeze-watchdog/service_cmd_windows.go` had both holes too: `CreateService`-only (fails on an existing install) and never started. Since `bootstrapWatchdog` shells out to exactly that command, a watchdog bootstrapped by the agent installer **did not supervise anything until the host rebooted**.
- Ordering hazard the fix has to respect: `serviceinstall.InstallProtectedBinary` ran *before* the SCM work. Windows holds an exclusive lock on the image of a running service, so on an in-place upgrade the copy would fail with a file-in-use error long before anything reached the SCM.

The MSI is **not** affected: `agent/installer/breeze.wxs` uses `<ServiceControl Start="install" Wait="yes">`, which does start the service. This is a CLI-`service install` bug, which is the path the docs recommend for manual/scripted installs and the path `bootstrapWatchdog` uses.

## The fix

New package `agent/internal/winsvcinstall` owns the SCM half of `service install` for both binaries:

1. **Open the existing service**, distinguishing `ERROR_SERVICE_DOES_NOT_EXIST` (create) from any other SCM error (fail loudly rather than silently registering a second service).
2. **Sample whether it is running BEFORE our own stop.** Sampling afterwards can only ever answer "not running" — the inverted check that shipped #5252.
3. **Stop and wait for STOPPED**, then stage the binary. A stop that never completes aborts with a message about the stop, instead of falling through to a file-in-use copy error. `STOP_PENDING` deliberately does **not** map to stopped: a service on its way down still holds its image open.
4. **Reconfigure** the existing registration instead of failing. Only the three fields the install functionally needs are re-asserted — command line, `StartAutomatic` (so an upgrade heals a service left `Disabled`, which would otherwise make the following start fail with `ERROR_SERVICE_DISABLED`), and `ErrorControl`. This mirrors the unconditional `systemctl enable` on Linux. `DisplayName`/`Description` are applied on **create only**: the MSI registers `BreezeAgent` under its own display name, and re-running `service install` on an MSI host should fix what is broken, not silently rename the service in `services.msc`.
5. **Start when the service was running beforehand OR the host is enrolled** (`config.Load(cfgFile).AgentID != ""`, the same predicate the Linux install uses). A fresh un-enrolled host is still left stopped deliberately. The watchdog uses `AlwaysStart()` — it has no enrollment to wait for, and an installed-but-not-started watchdog is exactly the failure it exists to prevent.
6. **Confirm RUNNING.** `StartService` is asynchronous, so "the request was accepted" is not "it is running". The wait polls until RUNNING, reports a service that stopped again with its Win32/service exit codes, and times out with the last observed state. A `STOPPED` reading inside a short settle window is treated as "the SCM has not moved it yet", not as a crash.
7. **Exit non-zero on a start failure** — reported *after* the watchdog bootstrap, so a stranded host still gets the watchdog that can recover it, with `Recover with: breeze-agent.exe service start` on stderr. Exiting 0 is what let the Linux half of this go unnoticed until devices showed Offline.
8. **`Outcome.Summary`** replaces the hardcoded string. It says `is running` only when the service was observed RUNNING, distinguishes `FAILED TO START` from a deliberate `is NOT running (this host is not enrolled yet)`, and is what the watchdog-bootstrap warning now interpolates.

`service start` was changed to use the same confirmed start, so it can no longer print `started` for a service that came up and died — it is the command the install output tells the operator to run.

## Where the tests actually run

**The issue's premise that `internal/agentapp` is in the Test Agent (Windows) job is wrong.** That job runs an explicit package list, and `internal/agentapp` is *not* on it — its inherited Windows reds are tracked in #2523 and the workflow comment names `TestStaticUnitMatchesEmbedded` specifically. A `//go:build windows` test placed next to the installer would have executed **on no CI job at all**, which is the exact vacuous-gate failure that workflow's comments already guard against.

So the sequence lives in **untagged** files:

- `install.go` / `install_test.go` are platform-neutral (no `golang.org/x/sys` types anywhere) → they run in **Test Agent** (`go test ./...`, ubuntu, required) and **Test Agent Race** (macOS).
- `internal/winsvcinstall` is **added to the Test Agent (Windows) package list**, so the same sequence tests also execute on the target OS, alongside the windows-tagged adapter's own tests (`binaryPathName` quoting, `svc.State` mapping). Verified the way `logging`/`ipc`/`elevaccount` were: with `GOOS=windows GOARCH=amd64 CGO_ENABLED=0` the package vets, its test binary compiles, and its Windows dependency graph contains no `remote/desktop`, no cgo, and no other first-party package.
- Only the thin `scm_windows.go` adapter is platform-bound, and `build-agent (windows/amd64)` compiles it.

## Verification

**Verified:**

- **Red-first:** the tests were written against the pre-fix sequence and failed 13/17 before the fix.
- **Each guard mutation-tested** (mutation → tests that red):
  - remove the start entirely (the exact pre-fix behaviour) → 9 tests red
  - sample the state *after* the stop → 3 red, incl. `TestInstallSamplesStateBeforeItsOwnStop`
  - return immediately after `RequestStart` without confirming RUNNING → 4 red
  - stage the binary before the stop → 3 red, incl. `TestInstallStagesBinaryOnlyAfterTheServiceStopped`
  - `Summary` always claims "is running" → both summary tests red
  - The one test that passed vacuously in the first red run (`indexOf` returning `-1` for an absent op) was tightened to require both ops present before comparing order.
- `go test ./...` in `agent/` — **76 packages ok, 0 FAIL** (darwin, CGO off).
- `go test -race ./internal/winsvcinstall/... ./internal/agentapp/... ./cmd/breeze-watchdog/...` — green.
- `GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build ./...` — clean; `go test -c` cross-compiles the Windows test binaries for `internal/winsvcinstall`, `internal/agentapp` and `cmd/breeze-watchdog`.
- `GOOS=linux` vet + test-binary compile — clean.
- `go vet ./...` on linux/darwin — clean. `GOOS=windows go vet ./internal/agentapp/...` reports one finding, `service_windows.go:263 possible misuse of unsafe.Pointer`, which is **pre-existing** (that file is untouched by this branch) and invisible to `lint-agent`, which vets on ubuntu.
- `golangci-lint v2.12.2 --new-from-rev=origin/main` on all three packages — **0 issues** (four errcheck findings were introduced and fixed before commit).
- `npx astro check` on the docs — 0 errors, 0 warnings.
- `ci.yml` parses and the Windows step's package list contains `./internal/winsvcinstall`.

**Not verified / inferred:**

- **No Windows host was available**, so nothing here was executed against a real SCM. Every runtime claim — that `CreateService` fails on an existing service, that `StartAutomatic` does not start now, that a running service's image is locked against replacement, that `ChangeServiceConfig` accepts the readback config — is inferred from the Win32 contract and from reading `golang.org/x/sys/windows/svc/mgr@v0.48.0`. A Windows canary upgrade is the real gate.
- The `Settle` window (3 s) for distinguishing "not started yet" from "started and died" is a judgement call, not a measured value.

## Relationship to #5296

#5296 (Linux/macOS/`install-linux.sh`, still open at the time of writing) is **not** depended on: no file it touches is touched here, and none of its symbols are used. `StartWhenRunningOrEnrolled` deliberately restates its `planServiceStart` rule rather than importing it, so the two can land in either order. **Follow-up worth doing once both are merged:** collapse the duplicated start policy into one helper.

## Behaviour changes worth knowing

- `breeze-agent.exe service install` on an already-installed Windows host now **succeeds and upgrades in place** where it used to fail with "service already exists", and **starts the agent** when it was running or the host is enrolled.
- `breeze-watchdog.exe service install` now **always ends with the watchdog running**, on a fresh install too. Consequence: on a fresh *un-enrolled* host the agent install leaves the agent stopped, but the watchdog it bootstraps will start the agent, which then sits in `waitForEnrollment`. That matches both the Linux behaviour after #5296 and what the MSI already does.
- A `service install` that was supposed to start the service and could not now **exits non-zero**. Scripts that ignored the exit code will keep working; scripts that check it will now see the failure they should always have seen.
- Re-running `service install` on an MSI-installed host repoints the registration at the same path the MSI uses, and does not rename the service.

## Release note

> **Windows agent install now starts the service.** `breeze-agent.exe service install` used to register the service and return without starting it (`StartAutomatic` only takes effect at the next reboot), while printing "installed and running" — so a manual or scripted install, or an upgrade of an already-enrolled host, could leave the device Offline. Re-running it on a host that already had the service failed with "service already exists". It now upgrades an existing service in place, and starts it when it was running beforehand or the host is already enrolled, failing with a non-zero exit if the start does not succeed. `breeze-watchdog.exe service install` now always ends with the watchdog running, so a watchdog bootstrapped by the agent installer supervises the agent immediately instead of at the next reboot. A fresh, un-enrolled host is still left stopped on purpose — enroll, then `breeze-agent.exe service start`. MSI installs were never affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGT9BJVfpG3nyM6c9koAN8
