### PR TITLE
fix(agent): give session teardown a reason so mid-session capture failures surface (#5300)

### DIFF
--- a/agent/internal/agentapp/support.go
+++ b/agent/internal/agentapp/support.go
@@ -455,7 +455,7 @@ func runSupportSession() {
 	// peer-disconnect notification.
 	comps.hb.SetSupportSessionNotifier(
 		func(string) { fmt.Println("Technician connected.") },
-		func(string) { fmt.Println("Technician disconnected.") },
+		func(string, string) { fmt.Println("Technician disconnected.") },
 	)
 
 	fmt.Print(supportBanner)

--- a/agent/internal/heartbeat/desktop_disconnect_reason_test.go
+++ b/agent/internal/heartbeat/desktop_disconnect_reason_test.go
@@ -1,0 +1,52 @@
+package heartbeat
+
+import (
+	"strings"
+	"testing"
+)
+
+// These tests cover the #5300 wiring: a mid-session capture failure recorded
+// via Session.StopWithReason/LastStopReason must reach the API in the same
+// desk-disconnect command_result the agent already sends on every WebRTC
+// peer disconnect, so remote_sessions.errorMessage gets populated the same
+// way the startup probe path already does (#5284/#5295).
+
+func TestDesktopDisconnectResultPayload_CarriesReason(t *testing.T) {
+	payload := desktopDisconnectResultPayload("sess-1", "GetDIBits failed: Win32 error 87 (0x57)")
+
+	if payload["sessionId"] != "sess-1" {
+		t.Errorf("sessionId = %v, want sess-1", payload["sessionId"])
+	}
+	if payload["event"] != "peer_disconnected" {
+		t.Errorf("event = %v, want peer_disconnected", payload["event"])
+	}
+	got, ok := payload["stopReason"].(string)
+	if !ok || got != "GetDIBits failed: Win32 error 87 (0x57)" {
+		t.Errorf("stopReason = %v, want the recorded reason", payload["stopReason"])
+	}
+}
+
+func TestDesktopDisconnectResultPayload_OmitsStopReasonWhenEmpty(t *testing.T) {
+	// Every non-#5300 disconnect path (peer-connection grace timeout, lifetime
+	// policy, operator stop, darwin handoff) passes "" — the key must be
+	// absent entirely, not present-and-empty, so the API's "only fill
+	// errorMessage when currently empty" check has a clean signal.
+	payload := desktopDisconnectResultPayload("sess-1", "")
+
+	if _, present := payload["stopReason"]; present {
+		t.Errorf("stopReason present with value %v, want the key absent for an empty reason", payload["stopReason"])
+	}
+}
+
+func TestDesktopDisconnectResultPayload_TruncatesOverlongReason(t *testing.T) {
+	huge := strings.Repeat("x", desktopStopReasonMaxBytes*3)
+	payload := desktopDisconnectResultPayload("sess-1", huge)
+
+	got, ok := payload["stopReason"].(string)
+	if !ok {
+		t.Fatalf("stopReason missing or not a string: %v", payload["stopReason"])
+	}
+	if len(got) > desktopStopReasonMaxBytes {
+		t.Errorf("stopReason length = %d, want <= %d", len(got), desktopStopReasonMaxBytes)
+	}
+}

--- a/agent/internal/heartbeat/desktop_handoff_darwin.go
+++ b/agent/internal/heartbeat/desktop_handoff_darwin.go
@@ -122,7 +122,8 @@ func (h *Heartbeat) reconcileDarwinDesktopOwners(reason string) {
 		switch {
 		case owner == nil:
 			h.forgetDesktopOwner(desktopSessionID)
-			go h.sendDesktopDisconnectNotification(desktopSessionID)
+			// Handoff disconnect, not a capture failure — no #5300 reason.
+			go h.sendDesktopDisconnectNotification(desktopSessionID, "")
 		case preferred == nil:
 			h.disconnectDarwinDesktopOwner(desktopSessionID, owner, reason)
 		case preferred.SessionID != owner.SessionID:
@@ -165,5 +166,6 @@ func (h *Heartbeat) disconnectDarwinDesktopOwner(desktopSessionID string, owner 
 	}
 
 	h.forgetDesktopOwner(desktopSessionID)
-	go h.sendDesktopDisconnectNotification(desktopSessionID)
+	// Handoff disconnect, not a capture failure — no #5300 reason.
+	go h.sendDesktopDisconnectNotification(desktopSessionID, "")
 }

--- a/agent/internal/heartbeat/handlers_desktop_lease_test.go
+++ b/agent/internal/heartbeat/handlers_desktop_lease_test.go
@@ -470,7 +470,7 @@ func TestDesktopDisconnectNotificationReleasesLeases(t *testing.T) {
 	if res := h.acquireDesktopLeases("sess-drop", 3, true); res != nil {
 		t.Fatalf("acquire failed: %+v", res)
 	}
-	h.sendDesktopDisconnectNotification("sess-drop")
+	h.sendDesktopDisconnectNotification("sess-drop", "")
 	_, released, _, _ := f.snapshot()
 	if len(released) != 2 {
 		t.Fatalf("peer disconnect must release every held role, got %+v", released)

--- a/agent/internal/heartbeat/handlers_support.go
+++ b/agent/internal/heartbeat/handlers_support.go
@@ -135,18 +135,21 @@ func (h *Heartbeat) RunSupportCleanup() {
 //
 // Must be called right after startAgent returns and before any session can
 // start; the desktop manager's hooks are plain fields set at construction.
-func (h *Heartbeat) SetSupportSessionNotifier(onStart, onStop func(sessionID string)) {
+//
+// onStop takes (sessionID, reason string) — reason mirrors Session's
+// LastStopReason() (#5300) and is "" for a routine disconnect.
+func (h *Heartbeat) SetSupportSessionNotifier(onStart func(sessionID string), onStop func(sessionID, reason string)) {
 	if h == nil || h.desktopMgr == nil {
 		return
 	}
 	previousStop := h.desktopMgr.OnSessionStopped
 	h.desktopMgr.OnSessionStarted = onStart
-	h.desktopMgr.OnSessionStopped = func(sessionID string) {
+	h.desktopMgr.OnSessionStopped = func(sessionID, reason string) {
 		if previousStop != nil {
-			previousStop(sessionID)
+			previousStop(sessionID, reason)
 		}
 		if onStop != nil {
-			onStop(sessionID)
+			onStop(sessionID, reason)
 		}
 	}
 }

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -1067,8 +1067,8 @@ func NewWithVersion(cfg *config.Config, version string, token *secmem.SecureStri
 	// here. The callback is nil-checked at every fire site and inert in helper
 	// mode, so registering it unconditionally on Linux is safe.
 	if (!cfg.IsService && !cfg.IsHeadless) || runtime.GOOS == "linux" {
-		h.desktopMgr.OnSessionStopped = func(sessionID string) {
-			h.sendDesktopDisconnectNotification(sessionID)
+		h.desktopMgr.OnSessionStopped = func(sessionID, reason string) {
+			h.sendDesktopDisconnectNotification(sessionID, reason)
 		}
 	}
 
@@ -1246,7 +1246,7 @@ func (h *Heartbeat) handleUserHelperMessage(session *sessionbroker.Session, env 
 			return
 		}
 		h.forgetDesktopOwner(notice.SessionID)
-		go h.sendDesktopDisconnectNotification(notice.SessionID)
+		go h.sendDesktopDisconnectNotification(notice.SessionID, notice.Reason)
 	case backupipc.TypeBackupResult:
 		// NOTE: do NOT early-return when wsClient is nil. The outbox needs no
 		// live WS client, and a terminal backup result that arrives during
@@ -1375,10 +1375,45 @@ func (h *Heartbeat) takeDesktopTarget(sessionID string) string {
 	return t
 }
 
+// desktopStopReasonMaxBytes bounds the reason text sent to the API in the
+// disconnect notification (#5300). Session.StopWithReason already caps at
+// this same size, but the value crosses a process boundary here (helper ->
+// service -> API over IPC/WS) — including a future notice.Reason from an
+// older or third-party helper build — so it's capped again defensively
+// rather than trusting the sender.
+const desktopStopReasonMaxBytes = 300
+
+// desktopDisconnectResultPayload builds the `result` object of the
+// desk-disconnect command_result sent to the API. Split out from
+// sendDesktopDisconnectNotification (which requires a live *websocket.Client)
+// so the shape of the outbound message — in particular, that a non-empty
+// reason lands in `stopReason` and is bounded — is unit-testable on its own.
+func desktopDisconnectResultPayload(sessionID, reason string) map[string]any {
+	if len(reason) > desktopStopReasonMaxBytes {
+		reason = reason[:desktopStopReasonMaxBytes]
+	}
+	payload := map[string]any{
+		"sessionId": sessionID,
+		"event":     "peer_disconnected",
+	}
+	if reason != "" {
+		payload["stopReason"] = reason
+	}
+	return payload
+}
+
 // sendDesktopDisconnectNotification tells the API that a WebRTC peer
 // connection dropped so it can mark the session as disconnected and allow
 // the viewer to reconnect.
-func (h *Heartbeat) sendDesktopDisconnectNotification(sessionID string) {
+//
+// reason (#5300) is the session's LastStopReason() — e.g. the Win32 error
+// the no-video watchdog's capturer swallowed — or "" for every other
+// disconnect path (peer-connection grace timeout, lifetime policy, operator
+// stop, darwin handoff). The API stores a non-empty reason in
+// remote_sessions.errorMessage only when that column is still empty, so it
+// never overwrites a startup-probe failure text (#5284/#5295) that got there
+// first.
+func (h *Heartbeat) sendDesktopDisconnectNotification(sessionID, reason string) {
 	// Fire the end-of-session UX (banner hide + ended notice) for any session
 	// that carried a consent/notify prompt. Runs on every disconnect path
 	// (direct OnSessionStopped, IPC peer-disconnect, darwin handoff) and is a
@@ -1406,10 +1441,7 @@ func (h *Heartbeat) sendDesktopDisconnectNotification(sessionID string) {
 		Type:      "command_result",
 		CommandID: "desk-disconnect-" + sessionID,
 		Status:    "completed",
-		Result: map[string]any{
-			"sessionId": sessionID,
-			"event":     "peer_disconnected",
-		},
+		Result:    desktopDisconnectResultPayload(sessionID, reason),
 	}
 	if err := h.wsClient.SendResult(result); err != nil {
 		log.Warn("failed to send desktop disconnect notification", "session", sessionID, "error", err.Error())

--- a/agent/internal/ipc/message.go
+++ b/agent/internal/ipc/message.go
@@ -362,8 +362,17 @@ type SASResponse struct {
 // DesktopPeerDisconnectedNotice is sent by the user helper to the service
 // when a WebRTC peer connection drops (Failed or Closed). The service relays
 // this to the API so it can mark the session as disconnected.
+//
+// Reason (#5300) is the session's LastStopReason() at the time it stopped —
+// e.g. the Win32 error the no-video watchdog's capturer swallowed — so a
+// mid-session capture failure reaches the technician the same way the
+// startup probe path already does. Empty for every other stop path (peer
+// disconnect grace timeout, lifetime policy, operator stop). Older helpers
+// omit this field entirely; the service treats a missing Reason the same as
+// an empty one.
 type DesktopPeerDisconnectedNotice struct {
 	SessionID string `json:"sessionId"`
+	Reason    string `json:"reason,omitempty"`
 }
 
 // LaunchProcessRequest asks the user-role helper to launch a binary.

--- a/agent/internal/remote/desktop/capture.go
+++ b/agent/internal/remote/desktop/capture.go
@@ -194,3 +194,27 @@ func describeCaptureFailure(capturer ScreenCapturer, probeErr error) error {
 	}
 	return fmt.Errorf("%w (last capture error: %w)", probeErr, last)
 }
+
+// swallowedCaptureError returns the text of the most recent error capturer
+// reported as a nil frame (see lastCaptureErrorReporter), or "" when the
+// capturer kept none, or does not implement the optional interface at all
+// (e.g. DXGI, which returns real errors instead of swallowing them), or is
+// nil.
+//
+// This is the mid-session counterpart to describeCaptureFailure: the no-video
+// watchdog (session_capture.go, #5300) uses it to give Session.StopWithReason
+// the same swallowed Win32 detail the startup probe attaches on the way in.
+func swallowedCaptureError(capturer ScreenCapturer) string {
+	if capturer == nil {
+		return ""
+	}
+	reporter, ok := capturer.(lastCaptureErrorReporter)
+	if !ok {
+		return ""
+	}
+	last := reporter.LastCaptureError()
+	if last == nil {
+		return ""
+	}
+	return last.Error()
+}

--- a/agent/internal/remote/desktop/session.go
+++ b/agent/internal/remote/desktop/session.go
@@ -54,10 +54,16 @@ type Session struct {
 	mu              sync.RWMutex
 	isActive        bool
 	fps             int
-	cleanupOnce     sync.Once
-	stopOnce        sync.Once
-	startOnce       sync.Once
-	wg              sync.WaitGroup
+	// stopReason is the short, technician-facing text describing why teardown
+	// happened, set by StopWithReason (#5300). Empty for a plain Stop() call
+	// (operator-initiated stop, lifetime policy, peer disconnect) — callers
+	// fall back to the generic ended-session text in that case, same as the
+	// startup probe path does when describeCaptureFailure has nothing to add.
+	stopReason  string
+	cleanupOnce sync.Once
+	stopOnce    sync.Once
+	startOnce   sync.Once
+	wg          sync.WaitGroup
 
 	// Optimized pipeline components (shared with WS path)
 	differ   *frameDiffer
@@ -406,7 +412,36 @@ func (m *SessionManager) StopAllSessions() {
 	}
 }
 
+// maxStopReasonBytes bounds the text StopWithReason records. Every source we
+// feed it (gdiCallError's Win32 text, describeCaptureFailure's wrapping) is
+// already short by construction, but the bound is enforced here — not left to
+// callers — so a future caller cannot regress it. Mirrors the ~400-byte bar
+// describeCaptureFailure is held to on the startup path (#5284/#5295).
+const maxStopReasonBytes = 300
+
+// Stop tears down the session with no specific reason recorded. Existing
+// call sites (operator-initiated stop, lifetime-policy expiry, peer
+// disconnect) are unaffected — LastStopReason() reads back empty, and callers
+// fall back to the generic ended-session text.
 func (s *Session) Stop() {
+	s.StopWithReason("")
+}
+
+// StopWithReason tears down the session, recording reason as the short,
+// technician-facing explanation for why it ended.
+//
+// This exists for #5300: the no-video watchdog (session_capture.go) used to
+// call Stop() with nothing, so a mid-session capture failure left the viewer
+// with the same generic "This remote session has ended" text regardless of
+// cause — while the startup probe path (#5284/#5295) already attaches the
+// real Win32 error via describeCaptureFailure. StopWithReason gives teardown
+// the same channel: pass the swallowed capture error (see noVideoStopReason)
+// when one is known, or "" to fall back to the generic text, same as the
+// probe path does when describeCaptureFailure has nothing to add.
+//
+// reason should already be short and free of OS handle values — the same bar
+// gdiCallError's text is held to — but it is truncated defensively regardless.
+func (s *Session) StopWithReason(reason string) {
 	s.stopOnce.Do(func() {
 		s.mu.Lock()
 		if !s.isActive {
@@ -414,6 +449,10 @@ func (s *Session) Stop() {
 			return
 		}
 		s.isActive = false
+		if len(reason) > maxStopReasonBytes {
+			reason = reason[:maxStopReasonBytes]
+		}
+		s.stopReason = reason
 		s.mu.Unlock()
 
 		close(s.done)
@@ -435,6 +474,7 @@ func (s *Session) Stop() {
 			"totalSent", snap.FramesSent,
 			"totalSkipped", snap.FramesSkipped,
 			"uptime", snap.Uptime.Round(time.Second),
+			"reason", reason,
 		)
 
 		// Desktop sessions allocate large buffers (DXGI textures, NV12
@@ -442,6 +482,15 @@ func (s *Session) Stop() {
 		// than waiting for the next GC cycle.
 		debug.FreeOSMemory()
 	})
+}
+
+// LastStopReason returns the reason the most recent StopWithReason call
+// recorded, or "" when the session hasn't stopped yet or was stopped via the
+// plain zero-arg Stop(). Safe to call before, during, or after teardown.
+func (s *Session) LastStopReason() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.stopReason
 }
 
 func (s *Session) doCleanup() {

--- a/agent/internal/remote/desktop/session.go
+++ b/agent/internal/remote/desktop/session.go
@@ -187,7 +187,14 @@ type SessionManager struct {
 	// OnSessionStopped is called when a WebRTC peer connection transitions to
 	// Failed or Closed. Used to notify the API so it can mark the session as
 	// disconnected and allow reconnection.
-	OnSessionStopped func(sessionID string)
+	//
+	// reason is the session's LastStopReason() at the time this fires (#5300)
+	// — "" for every stop path except the no-video watchdog, which records the
+	// swallowed capture error via StopWithReason. Safe to read here: by the
+	// time a call site below invokes this, Session.Stop/StopWithReason has
+	// already returned (called synchronously, earlier in the same call chain),
+	// so the reason is fully committed under s.mu before this ever reads it.
+	OnSessionStopped func(sessionID, reason string)
 
 	// OnSessionStarted is the symmetric hook: called when a WebRTC peer
 	// connection reaches Connected, i.e. the viewer is actually watching.

--- a/agent/internal/remote/desktop/session.go
+++ b/agent/internal/remote/desktop/session.go
@@ -441,17 +441,26 @@ func (s *Session) Stop() {
 //
 // reason should already be short and free of OS handle values — the same bar
 // gdiCallError's text is held to — but it is truncated defensively regardless.
+//
+// stopOnce means only the first caller's reason is ever recorded — a second,
+// concurrent StopWithReason (e.g. an operator-initiated Stop() racing the
+// no-video watchdog) never runs this body at all. That second reason is not
+// silently dropped: it's logged at Debug below so a real failure reason lost
+// to that race is still visible to anyone reading agent logs, even though it
+// never reaches LastStopReason().
 func (s *Session) StopWithReason(reason string) {
+	if len(reason) > maxStopReasonBytes {
+		reason = reason[:maxStopReasonBytes]
+	}
+	ran := false
 	s.stopOnce.Do(func() {
+		ran = true
 		s.mu.Lock()
 		if !s.isActive {
 			s.mu.Unlock()
 			return
 		}
 		s.isActive = false
-		if len(reason) > maxStopReasonBytes {
-			reason = reason[:maxStopReasonBytes]
-		}
 		s.stopReason = reason
 		s.mu.Unlock()
 
@@ -468,20 +477,35 @@ func (s *Session) StopWithReason(reason string) {
 		s.doCleanup()
 
 		snap := s.metrics.Snapshot()
-		slog.Info("Desktop WebRTC session stopped",
+		logArgs := []any{
 			"session", s.id,
 			"totalCaptured", snap.FramesCaptured,
 			"totalSent", snap.FramesSent,
 			"totalSkipped", snap.FramesSkipped,
 			"uptime", snap.Uptime.Round(time.Second),
 			"reason", reason,
-		)
+		}
+		if reason != "" {
+			// A recorded reason means teardown was triggered by a real
+			// failure (currently: the no-video watchdog), not a routine
+			// stop — log it at a level that stands out from normal teardown.
+			slog.Warn("Desktop WebRTC session stopped", logArgs...)
+		} else {
+			slog.Info("Desktop WebRTC session stopped", logArgs...)
+		}
 
 		// Desktop sessions allocate large buffers (DXGI textures, NV12
 		// staging, RGBA frames). Return memory to the OS promptly rather
 		// than waiting for the next GC cycle.
 		debug.FreeOSMemory()
 	})
+	if !ran && reason != "" {
+		slog.Debug("Desktop session already stopping; discarding late stop reason",
+			"session", s.id,
+			"discardedReason", reason,
+			"recordedReason", s.LastStopReason(),
+		)
+	}
 }
 
 // LastStopReason returns the reason the most recent StopWithReason call

--- a/agent/internal/remote/desktop/session_capture.go
+++ b/agent/internal/remote/desktop/session_capture.go
@@ -35,6 +35,12 @@ const (
 	// (2560x1440 IDRs are typically 60-150KB). Dropping keyframes causes decoder
 	// corruption — garbled blocks and color artifacts until the next IDR arrives.
 	maxFrameSizeBytes = 512_000 // 512KB — safe for 1440p IDR keyframes
+
+	// noVideoStopReasonFallback is recorded when the no-video watchdog gives
+	// up and exhausts its reattach budget, but the capturer swallowed no
+	// specific Win32 failure to explain why (e.g. DXGI, which returns real
+	// errors instead of swallowing them as a nil frame). See noVideoStopReason.
+	noVideoStopReasonFallback = "screen capture stopped producing frames and did not recover"
 )
 
 var encodedFramePool = sync.Pool{
@@ -252,6 +258,18 @@ func (s *Session) captureLoop() {
 	}
 }
 
+// noVideoStopReason builds the reason passed to Session.StopWithReason when
+// the no-video watchdog exhausts its reattach budget (#5300). It prefers the
+// last Win32 error the capturer swallowed as a nil frame — the same detail
+// describeCaptureFailure attaches on the startup probe path — and falls back
+// to a generic description when the capturer recorded none (e.g. DXGI).
+func noVideoStopReason(capturer ScreenCapturer) string {
+	if reason := swallowedCaptureError(capturer); reason != "" {
+		return reason
+	}
+	return noVideoStopReasonFallback
+}
+
 // captureLoopDXGI runs a tight loop driven by DXGI's AcquireNextFrame blocking.
 // No ticker — capture calls block until a new frame is available or timeout.
 // Returns the next captureMode when a mode switch is needed.
@@ -331,8 +349,14 @@ func (s *Session) captureLoopDXGI() captureMode {
 			if time.Since(lastWrite) > noVideoReattachTimeout &&
 				time.Since(wd.lastAttempt) > reattachCooldown {
 				if wd.evaluate(s.id, lastWriteNanos) {
-					// Spawn Stop() in a goroutine because Stop() waits on the capture goroutine via s.wg — calling inline would deadlock.
-					go s.Stop()
+					// Spawn StopWithReason() in a goroutine because it waits on the capture goroutine via s.wg — calling inline would deadlock.
+					// #5300: pass the last swallowed capture error (if any) so the
+					// ended-session text names the real failure instead of the
+					// generic text, matching what the startup probe path already does.
+					s.mu.RLock()
+					capturer := s.capturer
+					s.mu.RUnlock()
+					go s.StopWithReason(noVideoStopReason(capturer))
 					return captureModeStopped
 				}
 				wd.recordAttempt(lastWriteNanos)
@@ -640,8 +664,12 @@ func (s *Session) captureLoopTicker() captureMode {
 				if time.Since(lastWrite) > noVideoReattachTimeout &&
 					time.Since(wd.lastAttempt) > reattachCooldown {
 					if wd.evaluate(s.id, lastWriteNanos) {
-						// Spawn Stop() in a goroutine because Stop() waits on the capture goroutine via s.wg — calling inline would deadlock.
-						go s.Stop()
+						// Spawn StopWithReason() in a goroutine because it waits on the capture goroutine via s.wg — calling inline would deadlock.
+						// #5300: same rationale as captureLoopDXGI above.
+						s.mu.RLock()
+						capturer := s.capturer
+						s.mu.RUnlock()
+						go s.StopWithReason(noVideoStopReason(capturer))
 						return captureModeStopped
 					}
 					wd.recordAttempt(lastWriteNanos)

--- a/agent/internal/remote/desktop/session_stop_reason_test.go
+++ b/agent/internal/remote/desktop/session_stop_reason_test.go
@@ -1,0 +1,146 @@
+package desktop
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// These tests cover #5300: the no-video watchdog used to call Session.Stop()
+// with no reason and never read LastCaptureError(), so a mid-session capture
+// failure reached the viewer as the generic "This remote session has ended"
+// text while the startup probe path (#5284/#5295) showed the real Win32
+// error. StopWithReason gives teardown the same diagnostic channel the probe
+// path already has, reusing the lastCaptureErrorReporter shim #5295
+// introduced (reportingCapturer, stubCapturer, gdiCallError, errnoForTest —
+// all defined in capture_failure_detail_test.go, same package).
+
+func newTestSession(id string) *Session {
+	return &Session{
+		id:       id,
+		done:     make(chan struct{}),
+		isActive: true,
+		metrics:  newStreamMetrics(),
+	}
+}
+
+func TestStopWithReason_RecordsReason(t *testing.T) {
+	s := newTestSession("session-1")
+	s.StopWithReason("GetDIBits failed: Win32 error 87 (0x57)")
+
+	if got := s.LastStopReason(); got != "GetDIBits failed: Win32 error 87 (0x57)" {
+		t.Errorf("LastStopReason() = %q, want the recorded reason", got)
+	}
+}
+
+func TestStop_LeavesReasonEmpty(t *testing.T) {
+	// Existing zero-arg call sites (operator-initiated stop, lifetime policy,
+	// etc.) must keep compiling and keep falling back to the generic
+	// ended-session text — i.e. Stop() must record no reason at all.
+	s := newTestSession("session-1")
+	s.Stop()
+
+	if got := s.LastStopReason(); got != "" {
+		t.Errorf("LastStopReason() after plain Stop() = %q, want empty", got)
+	}
+}
+
+func TestStopWithReason_IdempotentWithStopOnce(t *testing.T) {
+	// stopOnce guards teardown; a reason passed to a StopWithReason call that
+	// loses the race with a concurrent Stop() must not panic or deadlock, and
+	// the recorded reason is whichever call actually ran the teardown body.
+	s := newTestSession("session-1")
+	s.StopWithReason("first")
+	s.StopWithReason("second")
+
+	if got := s.LastStopReason(); got != "first" {
+		t.Errorf("LastStopReason() = %q, want %q (first Stop wins via stopOnce)", got, "first")
+	}
+}
+
+func TestStopWithReason_TruncatesOverlongReason(t *testing.T) {
+	s := newTestSession("session-1")
+	huge := strings.Repeat("x", maxStopReasonBytes*3)
+	s.StopWithReason(huge)
+
+	got := s.LastStopReason()
+	if len(got) > maxStopReasonBytes {
+		t.Errorf("LastStopReason() length = %d, want <= %d (bounded, no handles)", len(got), maxStopReasonBytes)
+	}
+}
+
+func TestNoVideoStopReason_UsesSwallowedCaptureError(t *testing.T) {
+	capturer := &reportingCapturer{lastErr: gdiCallError("GetDIBits", errnoForTest(87))}
+
+	got := noVideoStopReason(capturer)
+
+	if !strings.Contains(got, "GetDIBits failed") {
+		t.Errorf("noVideoStopReason() = %q, want it to contain the swallowed GDI error", got)
+	}
+	if !strings.Contains(got, "87") {
+		t.Errorf("noVideoStopReason() = %q, want the Win32 error code", got)
+	}
+}
+
+func TestNoVideoStopReason_FallsBackWhenNothingSwallowed(t *testing.T) {
+	cases := []struct {
+		name     string
+		capturer ScreenCapturer
+	}{
+		{"reporter with nil last error", &reportingCapturer{lastErr: nil}},
+		{"capturer without the optional interface", &stubCapturer{}},
+		{"nil capturer", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := noVideoStopReason(tc.capturer)
+			if got != noVideoStopReasonFallback {
+				t.Errorf("noVideoStopReason() = %q, want fallback %q", got, noVideoStopReasonFallback)
+			}
+		})
+	}
+}
+
+// The technician-facing reason must stay readable — no OS handle values, the
+// same bar describeCaptureFailure holds the startup path to (#5284).
+func TestNoVideoStopReason_StaysHandleFree(t *testing.T) {
+	got := noVideoStopReason(&reportingCapturer{lastErr: gdiCallError("GetDIBits", errnoForTest(5))})
+	for _, banned := range []string{"0x0000", "hdc", "HDC", "hBitmap", "memDC"} {
+		if strings.Contains(got, banned) {
+			t.Errorf("noVideoStopReason() leaks handle detail %q: %q", banned, got)
+		}
+	}
+	if n := len(got); n > 400 {
+		t.Errorf("noVideoStopReason() is %d bytes, too long to read: %q", n, got)
+	}
+}
+
+func TestNoVideoStopReason_WiredThroughToSession(t *testing.T) {
+	// End-to-end within the package: what the watchdog would actually record
+	// on the session it stops.
+	s := newTestSession("session-1")
+	capturer := &reportingCapturer{lastErr: gdiCallError("GetDIBits", errnoForTest(87))}
+
+	s.StopWithReason(noVideoStopReason(capturer))
+
+	got := s.LastStopReason()
+	if !strings.Contains(got, "GetDIBits failed") {
+		t.Errorf("session recorded reason %q, want it to contain the swallowed GDI error", got)
+	}
+}
+
+func TestSwallowedCaptureError_PassThroughCases(t *testing.T) {
+	if got := swallowedCaptureError(nil); got != "" {
+		t.Errorf("swallowedCaptureError(nil) = %q, want empty", got)
+	}
+	if got := swallowedCaptureError(&stubCapturer{}); got != "" {
+		t.Errorf("swallowedCaptureError(non-reporting capturer) = %q, want empty", got)
+	}
+	if got := swallowedCaptureError(&reportingCapturer{lastErr: nil}); got != "" {
+		t.Errorf("swallowedCaptureError(reporter with nil last error) = %q, want empty", got)
+	}
+	err := fmt.Errorf("boom")
+	if got := swallowedCaptureError(&reportingCapturer{lastErr: err}); got != err.Error() {
+		t.Errorf("swallowedCaptureError() = %q, want %q", got, err.Error())
+	}
+}

--- a/agent/internal/remote/desktop/session_stop_reason_test.go
+++ b/agent/internal/remote/desktop/session_stop_reason_test.go
@@ -3,6 +3,7 @@ package desktop
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -126,6 +127,35 @@ func TestNoVideoStopReason_WiredThroughToSession(t *testing.T) {
 	got := s.LastStopReason()
 	if !strings.Contains(got, "GetDIBits failed") {
 		t.Errorf("session recorded reason %q, want it to contain the swallowed GDI error", got)
+	}
+}
+
+// A genuinely concurrent race (not just sequential calls) between two
+// StopWithReason callers — e.g. an operator-initiated Stop() racing the
+// no-video watchdog — must not panic or deadlock, and exactly one reason
+// wins. Run with -race: this is the scenario the silent-failure review
+// flagged (a losing StopWithReason call's reason used to vanish with no
+// trace at all; it's now logged at Debug — see StopWithReason's doc comment
+// — but this test only asserts the non-negotiable part: no data race, no
+// panic, and the winner is one of the two reasons offered, never a mix).
+func TestStopWithReason_ConcurrentCallsPickOneWinnerSafely(t *testing.T) {
+	s := newTestSession("session-1")
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		s.StopWithReason("watchdog: capture failed")
+	}()
+	go func() {
+		defer wg.Done()
+		s.StopWithReason("")
+	}()
+	wg.Wait()
+
+	got := s.LastStopReason()
+	if got != "watchdog: capture failed" && got != "" {
+		t.Fatalf("LastStopReason() = %q, want one of the two offered reasons", got)
 	}
 }
 

--- a/agent/internal/remote/desktop/session_webrtc.go
+++ b/agent/internal/remote/desktop/session_webrtc.go
@@ -162,7 +162,11 @@ func (m *SessionManager) StartSession(sessionID string, offer string, iceServers
 					}
 					m.StopSession(sessionID)
 					if m.OnSessionStopped != nil {
-						go m.OnSessionStopped(sessionID)
+						// session.LastStopReason() is "" here — a lifetime-policy
+						// stop goes through the plain Stop() path, not
+						// StopWithReason (#5300 is specifically about capture
+						// failures, not policy-driven expiry).
+						go m.OnSessionStopped(sessionID, session.LastStopReason())
 					}
 					return
 				}
@@ -618,7 +622,10 @@ func (m *SessionManager) StartSession(sessionID string, offer string, iceServers
 					logSelectedPair("disconnect-timeout")
 					m.StopSession(sessionID)
 					if m.OnSessionStopped != nil {
-						go m.OnSessionStopped(sessionID)
+						// #5300: carries the no-video watchdog's swallowed
+						// capture error through, when StopWithReason already
+						// closed peerConn and landed the session here.
+						go m.OnSessionStopped(sessionID, session.LastStopReason())
 					}
 				}
 			})
@@ -627,7 +634,8 @@ func (m *SessionManager) StartSession(sessionID string, offer string, iceServers
 			logSelectedPair("failed-or-closed")
 			m.StopSession(sessionID)
 			if m.OnSessionStopped != nil {
-				go m.OnSessionStopped(sessionID)
+				// #5300: same rationale as the disconnect-timeout branch above.
+				go m.OnSessionStopped(sessionID, session.LastStopReason())
 			}
 		}
 	})

--- a/agent/internal/userhelper/client.go
+++ b/agent/internal/userhelper/client.go
@@ -150,9 +150,11 @@ func (c *Client) Run() error {
 	}
 
 	// Notify the service when a WebRTC peer connection drops so it can relay
-	// the disconnect to the API and allow the viewer to reconnect.
-	c.desktopMgr.mgr.OnSessionStopped = func(sessionID string) {
-		notice := ipc.DesktopPeerDisconnectedNotice{SessionID: sessionID}
+	// the disconnect to the API and allow the viewer to reconnect. reason
+	// (#5300) carries the no-video watchdog's swallowed capture error, when
+	// one was recorded, across the helper->service IPC boundary.
+	c.desktopMgr.mgr.OnSessionStopped = func(sessionID, reason string) {
+		notice := ipc.DesktopPeerDisconnectedNotice{SessionID: sessionID, Reason: reason}
 		if err := c.conn.SendTyped("desk-disc-"+sessionID, ipc.TypeDesktopPeerDisconnected, notice); err != nil {
 			log.Warn("failed to send desktop peer disconnect via IPC", "session", sessionID, "error", err)
 		}

--- a/apps/api/src/routes/agentWs.test.ts
+++ b/apps/api/src/routes/agentWs.test.ts
@@ -78,6 +78,9 @@ vi.mock('../db/schema', () => ({
     id: 'remoteSessions.id',
     deviceId: 'remoteSessions.deviceId',
     status: 'remoteSessions.status',
+    // #5300: the peer-disconnect handler references this inside a
+    // sql`COALESCE(...)` fragment to only fill errorMessage when empty.
+    errorMessage: 'remoteSessions.errorMessage',
   },
   // The delivery-epoch suites drive the REAL terminalWs (see the './terminalWs'
   // mock below), which reaches for these alongside remoteSessions/devices.
@@ -856,6 +859,42 @@ function selectWithInnerJoin(rows: unknown[]) {
   };
 }
 
+// Recursively collects string leaves out of a Drizzle `sql`/`and`/`eq` query
+// tree (mirrors the identical helper in installer.test.ts / discovery.test.ts).
+// Used to assert the shape of a sql`COALESCE(...)` fragment passed to a
+// mocked `.set()` without depending on Drizzle's internal node classes.
+function collectSqlLeafStrings(node: unknown, seen = new Set<unknown>(), acc: string[] = []): string[] {
+  if (typeof node === 'string') {
+    acc.push(node);
+    return acc;
+  }
+  if (typeof node === 'number' || typeof node === 'boolean') {
+    acc.push(String(node));
+    return acc;
+  }
+  if (node === null || typeof node !== 'object' || seen.has(node)) return acc;
+  seen.add(node);
+  if (Array.isArray(node)) {
+    for (const item of node) collectSqlLeafStrings(item, seen, acc);
+    return acc;
+  }
+  const queryChunks = (node as { queryChunks?: unknown[] }).queryChunks;
+  if (Array.isArray(queryChunks)) {
+    for (const item of queryChunks) collectSqlLeafStrings(item, seen, acc);
+    return acc;
+  }
+  const value = (node as { value?: unknown }).value;
+  if (Array.isArray(value)) {
+    for (const item of value) collectSqlLeafStrings(item, seen, acc);
+    return acc;
+  }
+  if (typeof value === 'string' || typeof value === 'number') {
+    acc.push(String(value));
+    return acc;
+  }
+  return acc;
+}
+
 function updateResult(rows: unknown[] = []) {
   const returning = vi.fn().mockResolvedValue(rows);
   return {
@@ -1604,6 +1643,82 @@ describe('agent websocket command results', () => {
 
     expect(db.update).not.toHaveBeenCalled();
     expect(ws.send).toHaveBeenCalledWith(expect.stringContaining('"ack"'));
+  });
+
+  // #5300: the no-video watchdog records the swallowed capture error via
+  // Session.StopWithReason/LastStopReason and the agent rides it as
+  // `stopReason` in the desk-disconnect result (heartbeat.
+  // sendDesktopDisconnectNotification / desktopDisconnectResultPayload).
+  // remote_sessions.errorMessage should pick it up, the same channel the
+  // startup-probe path (#5284/#5295) already fills on a desk-start failure.
+  it('persists the agent stopReason into remote_sessions.errorMessage on peer disconnect (#5300)', async () => {
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123', partnerId: 'partner-123' };
+
+    const handlers = createAgentWsHandlers('agent-123', preValidatedAgent);
+    const ws = wsMock();
+    await connectAgentSocket(handlers, ws);
+
+    const sessionSetSpy = vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{ id: 'session-123' }]),
+      }),
+    });
+    vi.mocked(db.update).mockReturnValue({ set: sessionSetSpy } as any);
+
+    await handlers.onMessage({
+      data: JSON.stringify({
+        type: 'command_result',
+        commandId: 'desk-disconnect-session-123',
+        status: 'completed',
+        result: {
+          sessionId: 'session-123',
+          event: 'peer_disconnected',
+          stopReason: 'GetDIBits failed: Win32 error 87 (0x57)',
+        },
+      }),
+    } as any, ws as any);
+
+    expect(sessionSetSpy).toHaveBeenCalledTimes(1);
+    const setArg = sessionSetSpy.mock.calls[0]![0] as Record<string, unknown>;
+    expect(setArg.status).toBe('disconnected');
+    expect(setArg.endedAt).toBeInstanceOf(Date);
+    // errorMessage is a sql`COALESCE(...)` fragment, not a plain string —
+    // walk its leaves for the reason text and the column it guards on.
+    const leaves = collectSqlLeafStrings(setArg.errorMessage);
+    expect(leaves).toContain('GetDIBits failed: Win32 error 87 (0x57)');
+    expect(leaves).toContain('remoteSessions.errorMessage');
+  });
+
+  it('leaves errorMessage untouched on a peer disconnect with no stopReason', async () => {
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123', partnerId: 'partner-123' };
+
+    const handlers = createAgentWsHandlers('agent-123', preValidatedAgent);
+    const ws = wsMock();
+    await connectAgentSocket(handlers, ws);
+
+    const sessionSetSpy = vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{ id: 'session-123' }]),
+      }),
+    });
+    vi.mocked(db.update).mockReturnValue({ set: sessionSetSpy } as any);
+
+    // Every non-#5300 disconnect (grace timeout, lifetime policy, operator
+    // stop, darwin handoff, or simply an agent build predating this field)
+    // omits stopReason entirely — behavior must be identical to before #5300.
+    await handlers.onMessage({
+      data: JSON.stringify({
+        type: 'command_result',
+        commandId: 'desk-disconnect-session-123',
+        status: 'completed',
+        result: { sessionId: 'session-123', event: 'peer_disconnected' },
+      }),
+    } as any, ws as any);
+
+    expect(sessionSetSpy).toHaveBeenCalledTimes(1);
+    const setArg = sessionSetSpy.mock.calls[0]![0] as Record<string, unknown>;
+    expect(setArg.status).toBe('disconnected');
+    expect('errorMessage' in setArg).toBe(false);
   });
 
   it('rejects desktop start failures with mismatched session IDs', async () => {

--- a/apps/api/src/routes/agentWs.ts
+++ b/apps/api/src/routes/agentWs.ts
@@ -2408,11 +2408,30 @@ export function createAgentWsHandlers(agentId: string, preValidatedAgent: AgentD
                 ? expectedSessionId
                 : null;
             if (sessionId && fastResult.event === 'peer_disconnected') {
+              // #5300: the no-video watchdog records the swallowed capture
+              // error via Session.StopWithReason/LastStopReason and the agent
+              // rides it here as `stopReason` (agentWs.desktop.peerDisconnected
+              // path — heartbeat.sendDesktopDisconnectNotification). Every
+              // other disconnect (peer-connection grace timeout, lifetime
+              // policy, operator stop, darwin handoff) omits the field, so
+              // this stays null for them, same as before this change.
+              const stopReason = redactSecretsFromOutput(
+                typeof fastResult.stopReason === 'string' ? fastResult.stopReason.slice(0, 1024) : ''
+              ) || null;
               try {
                 await runWithAgentDbAccess('agentWs.desktop.peerDisconnected', async () => {
                   const result = await db
                     .update(remoteSessions)
-                    .set({ status: 'disconnected', endedAt: new Date() })
+                    .set({
+                      status: 'disconnected',
+                      endedAt: new Date(),
+                      // Only fills errorMessage when it's still empty — never
+                      // overwrites a startup-probe failure text (#5284/#5295)
+                      // that a `desk-start` failure already stored there.
+                      ...(stopReason
+                        ? { errorMessage: sql`COALESCE(${remoteSessions.errorMessage}, ${stopReason})` }
+                        : {}),
+                    })
                     .where(
                       and(
                         eq(remoteSessions.id, sessionId),
@@ -3070,6 +3089,12 @@ const desktopCommandResultSchema = z.object({
     // server-side, but must be accepted so the result isn't dropped as
     // malformed (#2307).
     stopped: z.boolean().optional(),
+    // #5300: rides alongside a `peer_disconnected` event when the session's
+    // Session.LastStopReason() was non-empty — currently only the no-video
+    // watchdog's swallowed capture error. Bounded to match the agent's own
+    // cap (Session.StopWithReason / desktopStopReasonMaxBytes). Absent on
+    // every routine disconnect and from any agent build predating this field.
+    stopReason: z.string().max(300).optional(),
   }).strict().optional(),
 }).passthrough();
 

--- a/apps/api/src/routes/desktopWs.test.ts
+++ b/apps/api/src/routes/desktopWs.test.ts
@@ -411,8 +411,38 @@ describe('GET /:id/viewer/session failure diagnostics', () => {
     expect(sendCommandToAgent).not.toHaveBeenCalled();
   });
 
-  it.each(['pending', 'connecting', 'active', 'disconnected', 'denied'])('still rejects a revoked %s session', async (status) => {
+  // 'disconnected' is deliberately excluded here (see the two #5300 tests
+  // below): a 'disconnected' session WITH a recorded errorMessage is now the
+  // mid-session counterpart to 'failed' and must return the diagnosis too —
+  // only a 'disconnected' session with NO recorded reason still rejects.
+  it.each(['pending', 'connecting', 'active', 'denied'])('still rejects a revoked %s session', async (status) => {
     mockViewerSelect({ session: { ...failedSession, status }, device: DEVICE, user: USER });
+    const res = await request();
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: 'Session closed' });
+  });
+
+  // #5300: the no-video watchdog's swallowed capture error reaches
+  // remote_sessions.errorMessage via the peer-disconnect command_result
+  // (agentWs.desktop.peerDisconnected), landing the session in 'disconnected'
+  // — not 'failed'. Extends the same failure-diagnostics exception above so a
+  // mid-session capture failure is shown the same way a failed start already
+  // is (#5284/#5295).
+  it('returns the capture diagnosis for a disconnected session carrying a #5300 stop reason', async () => {
+    mockViewerSelect({ session: { ...failedSession, status: 'disconnected' }, device: DEVICE, user: USER });
+    const res = await request();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ id: SESSION_ID, status: 'disconnected', errorMessage });
+    expect(db.update).not.toHaveBeenCalled();
+    expect(sendCommandToAgent).not.toHaveBeenCalled();
+  });
+
+  it('still rejects a revoked disconnected session with no recorded reason', async () => {
+    mockViewerSelect({
+      session: { ...failedSession, status: 'disconnected', errorMessage: null },
+      device: DEVICE,
+      user: USER,
+    });
     const res = await request();
     expect(res.status).toBe(401);
     expect(await res.json()).toEqual({ error: 'Session closed' });

--- a/apps/api/src/routes/desktopWs.test.ts
+++ b/apps/api/src/routes/desktopWs.test.ts
@@ -448,6 +448,31 @@ describe('GET /:id/viewer/session failure diagnostics', () => {
     expect(await res.json()).toEqual({ error: 'Session closed' });
   });
 
+  // The gate is "any recorded errorMessage on a disconnected row", not
+  // "a #5300 reason specifically" (see the comment above readingFailure) —
+  // staleCommandReaper.ts's reapStaleRemoteSessions also writes errorMessage
+  // on a 'disconnected' transition for its own routine timeouts. Documented
+  // here as accepted, not a regression: the reaper's text is benign/user-safe
+  // and this still never grants live access.
+  it('also returns a reaper-written timeout reason on a disconnected session', async () => {
+    mockViewerSelect({
+      session: {
+        ...failedSession,
+        status: 'disconnected',
+        errorMessage: 'Session timed out: exceeded maximum session duration',
+      },
+      device: DEVICE,
+      user: USER,
+    });
+    const res = await request();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      id: SESSION_ID,
+      status: 'disconnected',
+      errorMessage: 'Session timed out: exceeded maximum session duration',
+    });
+  });
+
   it.each([
     ['offer', 'POST'], ['ws-ticket', 'POST'], ['ice-servers', 'GET'],
   ])('does not grant live access to %s', async (route, method) => {

--- a/apps/api/src/routes/desktopWs.ts
+++ b/apps/api/src/routes/desktopWs.ts
@@ -286,9 +286,18 @@ async function validateViewerSessionAccess(
     // peer-disconnect command_result as `stopReason` and written to
     // errorMessage (agentWs.ts, agentWs.desktop.peerDisconnected). Extend the
     // same diagnostics-only exception #5295 introduced for 'failed' so the
-    // viewer can read that reason back too — but only when one was actually
-    // recorded; a routine disconnect (no errorMessage) still 401s exactly as
-    // before, so this never widens access beyond what #5295 already allowed.
+    // viewer can read that reason back too.
+    //
+    // The gate is "any recorded errorMessage on a disconnected row", not
+    // "a #5300 reason specifically" — staleCommandReaper.ts's
+    // reapStaleRemoteSessions also writes errorMessage on a 'disconnected'
+    // transition for its own routine timeouts ("connection was never
+    // established", "exceeded maximum session duration"), and those become
+    // readable here too. That's accepted as a side effect: the reaper's text
+    // is benign/user-safe and arguably useful to show instead of the bare
+    // generic message, and this still never grants live access — a routine
+    // disconnect with NO errorMessage at all still 401s exactly as before,
+    // so this never widens access beyond a read-only diagnostic string.
     const readingFailure = accessMode === 'failure-diagnostics' &&
       (session.status === 'failed' || (session.status === 'disconnected' && !!session.errorMessage));
     if (sessionRevoked && !readingFailure) {

--- a/apps/api/src/routes/desktopWs.ts
+++ b/apps/api/src/routes/desktopWs.ts
@@ -280,11 +280,21 @@ async function validateViewerSessionAccess(
     // The status poll may read a terminal failure after agentWs revokes the
     // session so the viewer can explain why capture failed. This exception
     // never grants live access, and individual token revocation still wins.
-    const readingFailure = accessMode === 'failure-diagnostics' && session.status === 'failed';
+    //
+    // #5300: a 'disconnected' session can also carry a real reason now — the
+    // no-video watchdog's swallowed capture error, relayed through the
+    // peer-disconnect command_result as `stopReason` and written to
+    // errorMessage (agentWs.ts, agentWs.desktop.peerDisconnected). Extend the
+    // same diagnostics-only exception #5295 introduced for 'failed' so the
+    // viewer can read that reason back too — but only when one was actually
+    // recorded; a routine disconnect (no errorMessage) still 401s exactly as
+    // before, so this never widens access beyond what #5295 already allowed.
+    const readingFailure = accessMode === 'failure-diagnostics' &&
+      (session.status === 'failed' || (session.status === 'disconnected' && !!session.errorMessage));
     if (sessionRevoked && !readingFailure) {
       return { valid: false as const, status: 401 as const, error: 'Session closed' };
     }
-    if (session.status === 'disconnected' || (session.status === 'failed' && !readingFailure)) {
+    if ((session.status === 'disconnected' || session.status === 'failed') && !readingFailure) {
       return { valid: false as const, status: 401 as const, error: 'Session ended' };
     }
 

--- a/apps/viewer/src/components/DesktopViewer.tsx
+++ b/apps/viewer/src/components/DesktopViewer.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useCallback, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { type ConnectionParams } from '../lib/protocol';
 import { exchangeDesktopConnectCode, exchangeVncConnectCode } from '../lib/api';
-import { scaleVideoCoords, isWebRTCSupported, AgentSessionError, SessionEndedError, type AuthenticatedConnectionParams } from '../lib/webrtc';
+import { scaleVideoCoords, isWebRTCSupported, AgentSessionError, SessionEndedError, SESSION_ENDED_DEFAULT_MESSAGE, type AuthenticatedConnectionParams } from '../lib/webrtc';
 import { connectWebRTC as connectWebRTCTransport, type WebRTCSessionWrapper } from '../lib/transports/webrtc';
 import { connectWebSocket as connectWebSocketTransport, type WebSocketSessionWrapper } from '../lib/transports/websocket';
 import { capabilitiesFor, type TransportCapabilities } from '../lib/transports/types';
@@ -50,6 +50,18 @@ const PASTE_NOTICE_TTL_MS = 8_000;
 // operator must relaunch from the dashboard.
 const SESSION_ENDED_MESSAGE =
   'This remote session has ended. Relaunch it from the Breeze dashboard.';
+
+// #5300: a SessionEndedError carries a real server-provided reason (e.g. the
+// no-video watchdog's swallowed capture error) exactly when the caller found
+// one via fetchSessionEndedReason — SessionEndedError otherwise defaults to
+// SESSION_ENDED_DEFAULT_MESSAGE. Keep the relaunch call-to-action either way;
+// only the diagnostic clause changes.
+function sessionEndedDisplayMessage(err: SessionEndedError): string {
+  if (err.message && err.message !== SESSION_ENDED_DEFAULT_MESSAGE) {
+    return `${err.message} Relaunch it from the Breeze dashboard.`;
+  }
+  return SESSION_ENDED_MESSAGE;
+}
 
 // Shown when the WebSocket upgrade was refused before it completed. The
 // browser never exposes the HTTP status behind a failed handshake, so this
@@ -836,8 +848,9 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
         stopReconnect();
         setStatus('error');
         setConnectedAt(null);
-        setErrorMessage(SESSION_ENDED_MESSAGE);
-        onError(SESSION_ENDED_MESSAGE);
+        const msg = sessionEndedDisplayMessage(err);
+        setErrorMessage(msg);
+        onError(msg);
         reconnectInFlightRef.current = false;
         return;
       }
@@ -1020,9 +1033,10 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
           userDisconnectRef.current = true;
           stopReconnect();
           setStatus('error');
-          setErrorMessage(SESSION_ENDED_MESSAGE);
+          const msg = sessionEndedDisplayMessage(err);
+          setErrorMessage(msg);
           setConnectedAt(null);
-          onError(SESSION_ENDED_MESSAGE);
+          onError(msg);
           return;
         }
         const msg = err instanceof Error ? err.message : 'Connection failed';

--- a/apps/viewer/src/lib/sessionEnded.test.ts
+++ b/apps/viewer/src/lib/sessionEnded.test.ts
@@ -8,6 +8,7 @@ import {
   nextAnswerPollInterval,
   parseRetryAfterMs,
   SessionEndedError,
+  SESSION_ENDED_DEFAULT_MESSAGE,
   AgentSessionError,
   type AuthenticatedConnectionParams,
 } from './webrtc';
@@ -199,6 +200,46 @@ describe('createWebRTCSession — session-ended (401) handling', () => {
     await expect(createWebRTCSession(baseParams, videoEl)).rejects.toBeInstanceOf(
       SessionEndedError,
     );
+  });
+
+  // #5300: the no-video watchdog's swallowed capture error reaches
+  // remote_sessions.errorMessage on a 'disconnected' session (agentWs.ts,
+  // agentWs.desktop.peerDisconnected). When a reconnect's offer POST 401s
+  // because that session was already revoked, one diagnostic read of
+  // /viewer/session (the same failure-diagnostics exception #5295 uses for a
+  // failed start, extended to 'disconnected' in desktopWs.ts) should surface
+  // that reason on the thrown SessionEndedError instead of the generic text.
+  it('carries the recorded stop reason on SessionEndedError when the offer POST 401s (#5300)', async () => {
+    const reason = 'GetDIBits failed: Win32 error 87 (0x57)';
+    stubFetch((url) => {
+      if (url.includes('/ice-servers')) return jsonResponse({ iceServers: [] });
+      if (url.includes('/viewer/offer')) return jsonResponse('Session ended', 401);
+      if (url.includes('/viewer/session')) {
+        return jsonResponse({ status: 'disconnected', errorMessage: reason });
+      }
+      return jsonResponse({}, 404);
+    });
+
+    const error = await createWebRTCSession(baseParams, videoEl).catch((err) => err);
+    expect(error).toBeInstanceOf(SessionEndedError);
+    expect(error.message).toBe(reason);
+  });
+
+  // Every routine disconnect (grace timeout, lifetime policy, operator stop,
+  // or simply a session diagnostics can't read back — e.g. still revoked with
+  // no recorded reason) must fall back to the generic text exactly as before
+  // #5300, not surface something derived from a 401/404 diagnostic response.
+  it('falls back to the generic message when the diagnostic read finds no reason', async () => {
+    stubFetch((url) => {
+      if (url.includes('/ice-servers')) return jsonResponse({ iceServers: [] });
+      if (url.includes('/viewer/offer')) return jsonResponse('Session ended', 401);
+      if (url.includes('/viewer/session')) return jsonResponse('Session closed', 401);
+      return jsonResponse({}, 404);
+    });
+
+    const error = await createWebRTCSession(baseParams, videoEl).catch((err) => err);
+    expect(error).toBeInstanceOf(SessionEndedError);
+    expect(error.message).toBe(SESSION_ENDED_DEFAULT_MESSAGE);
   });
 
   it('throws SessionEndedError when the answer poll returns 401', async () => {

--- a/apps/viewer/src/lib/webrtc.ts
+++ b/apps/viewer/src/lib/webrtc.ts
@@ -19,14 +19,28 @@ export class AgentSessionError extends Error {
 }
 
 /**
+ * The bare fallback text SessionEndedError carries when no server-provided
+ * reason is available. Exported so a caller (DesktopViewer) can tell a real
+ * #5300 reason apart from "nothing was recorded" without string-matching on
+ * a duplicated literal.
+ */
+export const SESSION_ENDED_DEFAULT_MESSAGE = 'This remote session has ended.';
+
+/**
  * Error thrown when the server rejects access to the session because it has
  * already ended (HTTP 401 'Session ended' from the mid-session revocation
  * guard — see Finding #5). The single-session viewer token can never connect
  * to this session again, so callers MUST stop retrying the same sessionId and
  * surface a terminal "session ended" state rather than hammering the endpoint.
+ *
+ * message (#5300) carries the session's remote_sessions.errorMessage when the
+ * caller looked one up (fetchSessionEndedReason) and the API had one to give
+ * — e.g. the no-video watchdog's swallowed capture error — so a mid-session
+ * failure can be shown the same way a failed start already is (#5284/#5295).
+ * Defaults to the generic text when no such reason exists.
  */
 export class SessionEndedError extends Error {
-  constructor(message = 'This remote session has ended.') {
+  constructor(message = SESSION_ENDED_DEFAULT_MESSAGE) {
     super(message);
     this.name = 'SessionEndedError';
   }
@@ -330,7 +344,14 @@ export async function createWebRTCSession(
       // A 401 here means the session was ended/revoked server-side — retrying
       // the same sessionId is futile (Finding #5). Surface a terminal error.
       if (isSessionEndedResponse(offerResp.status)) {
-        throw new SessionEndedError();
+        // #5300: this is exactly the case a mid-session capture failure hits
+        // — the no-video watchdog already revoked the session before this
+        // reconnect attempt's offer POST landed. One diagnostic read (same
+        // failure-diagnostics exception #5295 uses for a failed start) picks
+        // up the real reason when the API recorded one; every routine
+        // disconnect still falls back to the generic message unchanged.
+        const reason = await fetchSessionEndedReason(params);
+        throw new SessionEndedError(reason ?? undefined);
       }
       const msg = await offerResp.text().catch(() => 'unknown error');
       throw new Error(`Failed to submit WebRTC offer: ${msg}`);
@@ -377,6 +398,34 @@ function waitForIceGathering(pc: RTCPeerConnection, timeoutMs: number): Promise<
       }
     };
   });
+}
+
+/**
+ * Fetches the short, technician-facing reason a session ended, when the API
+ * has one. #5300: a mid-session capture failure (the no-video watchdog)
+ * leaves remote_sessions.errorMessage populated on a 'disconnected' session,
+ * the same way a failed start already does (#5284/#5295) — but only a
+ * request under desktopWs's `failure-diagnostics` exception can read it back
+ * after the viewer token/session was revoked. That exception is deliberately
+ * narrow (see validateViewerSessionAccess): it returns nothing for a routine
+ * disconnect with no recorded reason, so a null return here is the normal,
+ * silent case, not an error condition worth logging.
+ */
+async function fetchSessionEndedReason(params: AuthenticatedConnectionParams): Promise<string | null> {
+  try {
+    const resp = await apiFetch(
+      params.apiUrl,
+      `/api/v1/desktop-ws/${params.sessionId}/viewer/session`,
+      params.accessToken,
+    );
+    if (!resp.ok) return null;
+    const data = await resp.json();
+    return typeof data.errorMessage === 'string' && data.errorMessage.length > 0
+      ? data.errorMessage
+      : null;
+  } catch {
+    return null;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #5300

The no-video watchdog in `agent/internal/remote/desktop/session_capture.go` called `Session.Stop()` with no reason and never read `LastCaptureError()`. So a capture failure that begins **mid-session** (the same class of Winlogon `GetDIBits` failure fixed at startup by #5284/#5295) reached the viewer as the generic "This remote session has ended" text, even though the startup probe path already attaches the real Win32 error via `describeCaptureFailure`.

This PR wires the reason **all the way through to the viewer** — agent capture → agent teardown → helper→service IPC → API → `remote_sessions.errorMessage` → viewer — the same path a failed start already uses (#5284/#5295).

## Changes

### Agent — `agent/internal/remote/desktop/`
- `Session.StopWithReason(reason string)` — new teardown entry point that records a short, technician-facing reason before tearing down. `Session.Stop()` now delegates to it with `""`, so every existing zero-arg call site keeps compiling and keeps the generic fallback.
- `Session.LastStopReason()` — read-back accessor.
- `swallowedCaptureError(capturer)` (`capture.go`) and `noVideoStopReason(capturer)` (`session_capture.go`) — prefer the capturer's last swallowed Win32 error (the `lastCaptureErrorReporter` shim #5295 introduced), falling back to a generic description when none was recorded (e.g. DXGI).
- Both no-video-watchdog call sites (`captureLoopDXGI`, `captureLoopTicker`) call `s.StopWithReason(noVideoStopReason(capturer))` instead of the bare `s.Stop()`.
- Reason is bounded to 300 bytes inside `StopWithReason`, logged at `Warn` when non-empty (vs `Info` for a routine stop), and a reason that loses the `stopOnce` race is logged at `Debug` rather than silently dropped.

### Agent — wiring out to the API (`agent/internal/heartbeat/`, `agent/internal/userhelper/`, `agent/internal/ipc/`)
- `Session.OnSessionStopped` now carries `(sessionID, reason string)` — `reason` is `session.LastStopReason()` at each of the three fire sites in `session_webrtc.go`, `""` for every stop path except the no-video watchdog.
- `ipc.DesktopPeerDisconnectedNotice` gains an optional `Reason` field so the Windows user-helper process (where desktop capture actually runs) can carry the reason across the helper→service IPC boundary. Older helpers simply omit it.
- `heartbeat.sendDesktopDisconnectNotification` takes a reason and rides it as `stopReason` in the desk-disconnect `command_result` sent to the API (bounded to 300 bytes again, defensively, at this boundary). Payload construction is split into the pure, unit-tested `desktopDisconnectResultPayload`.
- All non-#5300 disconnect call sites (lifetime policy, darwin handoff, the support-mode notifier chain) pass/forward `""` and are otherwise unaffected.

### API — `apps/api/src/routes/`
- `desktopCommandResultSchema`'s `result` object gains `stopReason` (bounded, optional) so the fast-path parse doesn't drop the message.
- The `peer_disconnected` handler in `agentWs.ts` now fills `remote_sessions.errorMessage` from `stopReason` via `COALESCE(errorMessage, stopReason)` — never overwriting a startup-probe failure text that's already there.
- `desktopWs.ts`'s `validateViewerSessionAccess` extends the failure-diagnostics exception #5295 introduced for a `'failed'` session to also cover a `'disconnected'` session that has a recorded `errorMessage`, so the viewer can read it back after the session was revoked. A routine disconnect (no `errorMessage`) still 401s exactly as before.

### Viewer — `apps/viewer/src/`
- `webrtc.ts`: when a reconnect's offer POST 401s (the session was already revoked), one diagnostic read of `/viewer/session` picks up `errorMessage` before throwing `SessionEndedError`, carrying it as the error's `message`. Every other case (no reason recorded) still gets the default message.
- `DesktopViewer.tsx` shows that message (with the existing "Relaunch it from the Breeze dashboard" call-to-action appended) instead of always rendering the hardcoded generic banner text, at both `SessionEndedError` catch sites.

## Test plan

- [x] Wrote failing tests first for the core `Session` logic (`session_stop_reason_test.go`), confirmed they failed to compile against pre-fix code.
- [x] `cd agent && go test -race ./internal/remote/desktop/... ./internal/heartbeat/... ./internal/userhelper/... ./internal/agentapp/... ./internal/ipc/...` — all green, including new tests (reason recording, `Stop()` empty-fallback, `stopOnce` idempotency + a genuinely concurrent `-race` variant, 300-byte truncation, swallowed-error extraction, handle-free/short-text guard, disconnect-payload shape).
- [x] `GOOS=windows GOARCH=amd64 go build ./...` — cross-compiles clean.
- [x] `go vet ./...` — clean. `gofmt` clean.
- [x] `cd apps/api && npx tsc --noEmit` — clean. `pnpm --filter @breeze/api lint` — clean.
- [x] `cd apps/api && npx vitest run src/routes/agentWs.test.ts src/routes/desktopWs*.test.ts` — 244 tests pass, including new coverage for `stopReason` persistence and the extended failure-diagnostics exception.
- [x] `cd apps/viewer && npx tsc --noEmit` — clean.
- [x] `cd apps/viewer && npx vitest run src/lib/sessionEnded.test.ts src/lib/webrtc.test.ts src/lib/transports/webrtc.test.ts src/components/DesktopViewer.capsLock.test.ts` — 46 tests pass, including new coverage for `SessionEndedError` carrying the recorded reason (and falling back when none is found).

## Release note

Remote desktop: a mid-session screen-capture failure (e.g. a Winlogon capture error) now shows the real cause to the technician in the viewer, the same way a failed session start already does, instead of the generic "This remote session has ended" text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
