### PR TITLE
test(api): de-flake SR2-22 forgot-password duration ratio (warm-up + interleave)

### DIFF
--- a/apps/api/src/routes/auth/password.test.ts
+++ b/apps/api/src/routes/auth/password.test.ts
@@ -259,16 +259,31 @@ describe('password reset eligibility (#719)', () => {
 
     it('enqueues for a known and an unknown address indistinguishably (structural + duration)', async () => {
       const ITER = 40;
-      const timeMany = async (email: string): Promise<number> => {
-        const start = performance.now();
-        for (let i = 0; i < ITER; i++) {
-          // eslint-disable-next-line no-await-in-loop
-          await postForgot({ email });
-        }
-        return performance.now() - start;
-      };
-      const knownMs = await timeMany('admin@msp.com');
-      const unknownMs = await timeMany('nobody@nowhere.test');
+      const KNOWN = 'admin@msp.com';
+      const UNKNOWN = 'nobody@nowhere.test';
+
+      // Untimed warm-up so neither timed batch pays JIT/module/mock start-up.
+      // Without it the FIRST batch ran ~6x slower than the second on a loaded
+      // CI runner and tripped the ratio bound below (merge-group run for
+      // #5302), which is an oracle for warm-up, not for address existence.
+      await postForgot({ email: KNOWN });
+      await postForgot({ email: UNKNOWN });
+      vi.mocked(enqueuePasswordResetRequest).mockClear();
+
+      // Interleave the two addresses so any drift during the run (GC, runner
+      // load) lands on both equally instead of on whichever batch went first.
+      let knownMs = 0;
+      let unknownMs = 0;
+      for (let i = 0; i < ITER; i++) {
+        let start = performance.now();
+        // eslint-disable-next-line no-await-in-loop
+        await postForgot({ email: KNOWN });
+        knownMs += performance.now() - start;
+        start = performance.now();
+        // eslint-disable-next-line no-await-in-loop
+        await postForgot({ email: UNKNOWN });
+        unknownMs += performance.now() - start;
+      }
 
       // Structural indistinguishability: identical enqueue count, and NONE of
       // the existence-dependent calls fired for either address.


### PR DESCRIPTION
**Flake:** `password.test.ts:286` asserts the known/unknown forgot-password batches stay within a 5x ratio. The first batch pays JIT/module/mock warm-up, so under runner load it ran ~6x slower and failed the merge-group run for #5302 (a Go-only diff), dequeuing it.

**Fix:** one untimed warm-up request per address, then interleave the two addresses in a single loop so GC/runner drift lands on both equally. Ratio bound kept as a loose sanity check; the structural assertions (identical enqueue count, no existence-dependent calls) remain the real guard.

**Verified:** file passes 3 consecutive local runs. Test-only diff.

Closes #5304

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGT9BJVfpG3nyM6c9koAN8