### PR TITLE
fix(auth): default MFA_FORCE_FOR_PARTNER_ADMIN to off for this release

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -852,13 +852,17 @@ ENABLE_REGISTRATION=false               # gates both the API endpoints and the "
 # PENDING_ACCOUNT_MEETING_URL=https://your-scheduler.example.com/intro-call
 # PENDING_ACCOUNT_MEETING_LABEL=
 ENABLE_2FA=true
-# Kill-switch for the role-level MFA gate. Defaults ON: members of a
-# force_mfa role — the system Partner Admin role on every install since
-# RMM-QA-164 — are minted mfa=false and receive 428 mfa_enrollment_required
-# until they enrol at /auth/mfa/setup. Flip to false ONLY to relieve an
-# enrollment outage that locks operators out; it suppresses the role-force
-# component alone (settings-driven requireMfa stays enforced) and is read
-# at call time, so no code deploy is needed. Mirrors deploy/.env.example.
+# Kill-switch for the role-level MFA gate. Defaults OFF for this release
+# (#4491): the reconcile migration flips force_mfa on every EXISTING
+# Partner Admin role, so enforcing on upgrade with no warning would lock
+# those admins into enrolment unexpectedly. Set to true to opt in now and
+# enforce immediately — members of a force_mfa role (the system Partner
+# Admin role on every install since RMM-QA-164) are then minted mfa=false
+# and receive 428 mfa_enrollment_required until they enrol at
+# /auth/mfa/setup (settings-driven requireMfa is unaffected either way —
+# it stays enforced). Read at call time, so no code deploy is needed to
+# flip it. Enforcement returns to default ON once the notification-period
+# feature (#5306) ships. Mirrors deploy/.env.example.
 # MFA_FORCE_FOR_PARTNER_ADMIN=true
 # Per-refresh-token-family budget for POST /auth/refresh (#3696). The web app is
 # an Astro MPA, so one full-page navigation spends exactly one refresh; the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2580,9 +2580,23 @@ jobs:
           fi
           echo "::add-mask::${TOKEN}"
           echo "token=${TOKEN}" >> "$GITHUB_OUTPUT"
-          # RMM-QA-164: with MFA_FORCE_FOR_PARTNER_ADMIN=false in this stack's
-          # .env the role-force component must be suppressed end to end
-          # (proves the root compose actually threads the valve, D6).
+          # RMM-QA-164 (D6): the behavioural mfaEnrollmentRequired assertion
+          # below only discriminates a compose-wiring regression when the
+          # container's resolved value actually differs from the code
+          # default. mfaForcePartnerAdmin() now defaults to false (#4491),
+          # matching this stack's .env, so an UNMAPPED variable would produce
+          # the identical container-resolved value and this assertion would
+          # pass on a broken mapping too. Read the container's own env
+          # directly first so a dropped mapping is still caught regardless of
+          # which way the code default points.
+          RESOLVED=$(docker compose -f docker-compose.yml -f docker-compose.override.yml.ci \
+            exec -T api printenv MFA_FORCE_FOR_PARTNER_ADMIN || true)
+          echo "api container MFA_FORCE_FOR_PARTNER_ADMIN='${RESOLVED}' (expected 'false': set in .env)"
+          if [ "${RESOLVED}" != "false" ]; then
+            echo "ERROR: docker-compose.yml did not thread MFA_FORCE_FOR_PARTNER_ADMIN from .env into the api container"
+            exit 1
+          fi
+          # ...and then confirm it's actually honoured end to end.
           ENROLL=$(echo "${RESPONSE}" | jq -r '.mfaEnrollmentRequired')
           echo "mfaEnrollmentRequired=${ENROLL} (expected false: relief valve set in .env)"
           if [ "${ENROLL}" != "false" ]; then

--- a/apps/api/src/config/env.test.ts
+++ b/apps/api/src/config/env.test.ts
@@ -145,12 +145,16 @@ describe('config env', () => {
   });
 
   // mfaForcePartnerAdmin is the kill-switch for the role-level MFA gate
-  // introduced in Task 8 of the launch-readiness sprint. Defaults ON so
-  // the secure-by-default posture holds, but ops can flip it OFF without
-  // a code change when an enrollment outage locks legitimate users out.
-  it('defaults mfaForcePartnerAdmin to true when unset', async () => {
+  // introduced in Task 8 of the launch-readiness sprint. Defaults OFF for
+  // this release (#4491): the reconcile migration
+  // (2026-10-11-170000-partner-admin-force-mfa-reconcile.sql) flips
+  // force_mfa on every EXISTING Partner Admin role, so enforcing on
+  // upgrade with no warning would lock admins into enrolment with zero
+  // notice. Enforcement returns to default ON once the notification-period
+  // feature (#5306) ships; MFA_FORCE_FOR_PARTNER_ADMIN=true opts in now.
+  it('defaults mfaForcePartnerAdmin to false when unset', async () => {
     const mod = await loadEnv();
-    expect(mod.mfaForcePartnerAdmin()).toBe(true);
+    expect(mod.mfaForcePartnerAdmin()).toBe(false);
   });
 
   it('returns false when MFA_FORCE_FOR_PARTNER_ADMIN is explicitly disabled', async () => {

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -496,12 +496,17 @@ export const OAUTH_JWKS_PUBLIC_JWK = process.env.OAUTH_JWKS_PUBLIC_JWK ?? '';
 export const OAUTH_COOKIE_SECRET = process.env.OAUTH_COOKIE_SECRET ?? '';
 
 // Kill-switch for the role-level MFA gate (Task 8 of the launch-readiness
-// sprint). Defaults ON so the secure-by-default posture holds; ops can
-// flip it OFF without a code change to relieve an enrollment outage that
-// locks legitimate partner-admins out. Read at call time so tests and
-// runtime overrides don't need module re-evaluation.
+// sprint). Defaults OFF for this release (#4491): the reconcile migration
+// (2026-10-11-170000-partner-admin-force-mfa-reconcile.sql) flips
+// force_mfa on every EXISTING Partner Admin role, and enforcing on upgrade
+// with no warning would lock those admins into enrolment unexpectedly.
+// Enforcement returns to default ON once the notification-period feature
+// (#5306 — grace window, banner, deadline before force_mfa takes effect)
+// ships. Set MFA_FORCE_FOR_PARTNER_ADMIN=true to opt in and enforce now.
+// Read at call time so tests and runtime overrides don't need module
+// re-evaluation.
 export function mfaForcePartnerAdmin(): boolean {
-  return envFlag('MFA_FORCE_FOR_PARTNER_ADMIN', true);
+  return envFlag('MFA_FORCE_FOR_PARTNER_ADMIN', false);
 }
 
 /**

--- a/apps/docs/src/content/docs/reference/users-and-roles.mdx
+++ b/apps/docs/src/content/docs/reference/users-and-roles.mdx
@@ -335,6 +335,8 @@ Roles can be **system** (built-in, immutable) or **custom** (created by administ
 
 Roles also carry a **Force MFA** flag. When the flag is on, any user assigned to that role gets a `428 Precondition Required` response on protected endpoints until they enrol an MFA method. The enrolment screen offers whichever methods the organisation allows -- an authenticator app, SMS, or a passkey. The dashboard intercepts the 428 and walks the user through a forced enrollment screen before letting them reach any other workflow. Partner Admin is seeded with Force MFA on. Switch it on for any role whose privilege level warrants mandatory MFA — admin-equivalent roles, billing operators, and similar.
 
+Enforcement of the Force MFA flag is itself gated by the `MFA_FORCE_FOR_PARTNER_ADMIN` environment variable, which **defaults to `false`** for this release: the Partner Admin role is seeded/reconciled with Force MFA on regardless, but the 428 wall above only fires once an operator sets `MFA_FORCE_FOR_PARTNER_ADMIN=true`. See `.env.example` for details. This default returns to `true` once a notification-period rollout ships.
+
 ### Permission Model
 
 Permissions are stored as `resource:action` pairs in the `permissions` table. Roles are linked to permissions through the `role_permissions` join table.

--- a/apps/docs/src/content/docs/security/hardening.mdx
+++ b/apps/docs/src/content/docs/security/hardening.mdx
@@ -48,7 +48,7 @@ Before going live, verify every item:
 ### Authentication
 
 - [ ] MFA enabled for all admin accounts (authenticator app, SMS, or a passkey)
-- [ ] Roles that should require MFA have **Force MFA** turned on. Users in a force-MFA role get a `428 Precondition Required` response until they enrol an allowed MFA method; the dashboard then redirects them through a forced-enrollment page before any other workflow becomes available.
+- [ ] Roles that should require MFA have **Force MFA** turned on. Users in a force-MFA role get a `428 Precondition Required` response until they enrol an allowed MFA method; the dashboard then redirects them through a forced-enrollment page before any other workflow becomes available. **This enforcement defaults OFF** (`MFA_FORCE_FOR_PARTNER_ADMIN=false`) as of this release — set it to `true` to actually enforce Force MFA roles; see `.env.example`.
 - [ ] Registration disabled in production (`ENABLE_REGISTRATION=false`) after initial setup
 - [ ] Rate limiting active on login endpoints
 - [ ] Session timeout configured (`SESSION_MAX_AGE`)

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -178,9 +178,14 @@ AGENT_REQUIRE_MANIFEST_SIGNING_KEY_ID=false
 MANAGED_SOFTWARE_POLICY_MODE=compat
 
 # Kill-switches for the launch-readiness MFA and lockout features.
-# Defaults are secure (gate ON, lockout 5-in-15min). Operators can flip
-# either off without a code deploy if an enrollment outage or stuck-out
-# lockout needs immediate relief.
+# MFA_FORCE_FOR_PARTNER_ADMIN defaults OFF for this release (#4491): the
+# reconcile migration flips force_mfa on every EXISTING Partner Admin
+# role, so enforcing on upgrade with no warning would lock those admins
+# into enrolment unexpectedly. Set to true to opt in and enforce now;
+# enforcement returns to default ON once the notification-period feature
+# (#5306) ships. Lockout still defaults secure (5-in-15min); operators can
+# flip either off without a code deploy if an enrollment outage or
+# stuck-out lockout needs immediate relief.
 # MFA_FORCE_FOR_PARTNER_ADMIN=true
 # LOGIN_ACCOUNT_LOCKOUT_MAX=5        # 0 disables per-account lockout entirely
 # LOGIN_ACCOUNT_LOCKOUT_WINDOW_SECONDS=900

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -288,7 +288,8 @@ x-api-env: &api-env
   # Auth / security / session
   ENABLE_2FA: ${ENABLE_2FA:-}
   # RMM-QA-164 relief valve (see .env.example). Empty when unset → envFlag
-  # default true; mapped so a locked-out self-hoster can actually flip it.
+  # default false this release (#4491, opt in with true); mapped so a
+  # self-hoster can actually flip it either way.
   MFA_FORCE_FOR_PARTNER_ADMIN: ${MFA_FORCE_FOR_PARTNER_ADMIN:-}
   # Optional per-refresh-token-family budget for POST /auth/refresh (#3696).
   # Mapped so the knob is actually reachable inside the container — a value

--- a/docs/release-notes/next-release-draft.md
+++ b/docs/release-notes/next-release-draft.md
@@ -216,3 +216,17 @@ No env vars, no migrations.
 - Behaviour change (API), no migration and no new env vars: confirming a phone number that REPLACES the one behind an already-active SMS factor still advances `mfa_epoch` and revokes every refresh family — every OTHER session is signed out — but the calling session is now REPLACED in the same response instead of evicted (it previously bounced the user to `/login?reason=session-expired` by their own action). `POST /auth/phone/confirm` now returns `sessionReplaced: true` plus `tokens.accessToken` on that branch, alongside rotated refresh/CSRF cookies the client must adopt, and can now answer **409** (another authentication issuance is in flight, or the factor set changed concurrently — nothing was written) and **428** (the client auth binding must be rotated first) from the shared auth-issuance admission path. `tokens` is withheld on the rare post-commit install failure, in which case the client must re-authenticate. Initial phone verification (no active SMS factor yet) is unchanged and returns neither field.
 
 ---
+
+## Partner Admin forced MFA: reconciled but not enforced by default yet (#4491)
+
+**Self-Hosting / Upgrade Notes.**
+- The `2026-10-11-170000-partner-admin-force-mfa-reconcile.sql` migration marks
+  every EXISTING system Partner Admin role as MFA-required (`force_mfa = true`)
+  on every install, reconciling installs that predate RMM-QA-164.
+- Enforcement of that flag is **OFF by default this release**
+  (`MFA_FORCE_FOR_PARTNER_ADMIN` now defaults to `false`) — the migration alone
+  would otherwise lock existing Partner Admins into enrolment at upgrade time
+  with no warning. Set `MFA_FORCE_FOR_PARTNER_ADMIN=true` to enforce now.
+- Enforcement returns to default ON once the notification-period rollout
+  (grace window, banner, deadline before `force_mfa` takes effect — #5306)
+  ships next release.

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -145,15 +145,19 @@ Set in the parent `.env` file. Playwright reads via `process.env`:
 
 ### Seeded admin and forced MFA (RMM-QA-164)
 
-A fresh stack seeds the system Partner Admin role with `force_mfa = true`, so the
-seeded `admin@breeze.local` (or your `BREEZE_BOOTSTRAP_ADMIN_EMAIL`) is minted
+A fresh stack seeds the system Partner Admin role with `force_mfa = true`, but
+enforcement of that flag is gated by `MFA_FORCE_FOR_PARTNER_ADMIN`, which
+**defaults to `false`** (#4491) — so a fresh stack's `.env` (matching
+`.env.example`) does NOT hit the 428 wall below unless you've explicitly set
+that var to `true`. If you have set it to `true`, the seeded
+`admin@breeze.local` (or your `BREEZE_BOOTSTRAP_ADMIN_EMAIL`) is minted
 `mfa: false` and receives `428 mfa_enrollment_required` on the first protected
-request — `globalSetup`'s login lands on `/auth/mfa/setup?forced=1` instead of the
-dashboard. Pick one before running the suite:
+request — `globalSetup`'s login lands on `/auth/mfa/setup?forced=1` instead of
+the dashboard. Pick one before running the suite:
 
 - enrol TOTP for that admin once (Settings → Security → Two-factor), or
-- set `MFA_FORCE_FOR_PARTNER_ADMIN=false` in the stack's `.env` (the documented
-  relief valve; it suppresses only the role-force component) and restart `api`.
+- unset (or set back to `false`) `MFA_FORCE_FOR_PARTNER_ADMIN` in the stack's
+  `.env` (it suppresses only the role-force component) and restart `api`.
 
 ### WebAuthn specs need `PUBLIC_APP_URL` to match the browser origin
 


### PR DESCRIPTION
## What

Flips `mfaForcePartnerAdmin()` (`apps/api/src/config/env.ts`) from
`envFlag('MFA_FORCE_FOR_PARTNER_ADMIN', true)` to default `false`, and
updates the comment above it plus `.env.example`, `deploy/.env.example`,
and the `docker-compose.yml` mapping comment (values/mappings themselves
unchanged) to match.

## Why

The #4491 reconcile migration
(`apps/api/migrations/2026-10-11-170000-partner-admin-force-mfa-reconcile.sql`)
flips `force_mfa` on every EXISTING Partner Admin role at upgrade time.
With the kill-switch still defaulting ON, that migration plus the
default would enforce MFA on every self-hosted Partner Admin the moment
they upgrade, with no warning — locking them into enrolment
unexpectedly. Defaulting the enforcement flag OFF this release
decouples "reconcile the data" from "start enforcing it".

`MFA_FORCE_FOR_PARTNER_ADMIN=true` opts in to enforce now.
Enforcement returns to default ON once the notification-period
feature (#5306 — grace window, banner, deadline before `force_mfa`
takes effect) ships next release.

## Verified / inferred

- **Verified**: `apps/api/src/config/env.test.ts` — updated the
  "defaults to true" test to a red assertion first
  (`expect(...).toBe(false)` against the unchanged code, confirmed
  failing), then flipped the implementation and confirmed green.
  `mfaPolicy.test.ts`, `cfAccessLogin.test.ts`,
  `cfAccessRedirectLogin.test.ts` already mock `mfaForcePartnerAdmin`
  directly (not the env default) — ran green, unaffected.
  `registerPartnerMfaPolicy.integration.test.ts` already sets
  `MFA_FORCE_FOR_PARTNER_ADMIN='true'` explicitly in `beforeAll` — not
  run here (needs a live DB / Integration Tests shard) but unaffected
  by inspection since it never relies on the implicit default.
  `envComposeParity.test.ts` and `composeBindMounts.test.ts` (which
  gate the `.env.example`/compose edits) ran green — they check
  variable presence, not comment prose.
  `npx tsc --noEmit` clean in `apps/api`.
- **Inferred**: no other call site reads `MFA_FORCE_FOR_PARTNER_ADMIN`
  or relies on the implicit true default (grepped
  `apps/api/src` and `apps/docs/src`; nothing else found).

## Release note

Added to `docs/release-notes/next-release-draft.md` under "Partner
Admin forced MFA: reconciled but not enforced by default yet (#4491)":
the migration marks every existing Partner Admin role MFA-required;
enforcement is OFF by default this release; set
`MFA_FORCE_FOR_PARTNER_ADMIN=true` to enforce now; a notification-period
rollout (#5306) comes next release.

Refs #4491
Refs #5306

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGT9BJVfpG3nyM6c9koAN8