### PR TITLE
fix(web): cancel ScriptExecutionModal's auto-close timer on unmount (#5270)

### DIFF
--- a/apps/web/src/components/scripts/ScriptExecutionModal.test.tsx
+++ b/apps/web/src/components/scripts/ScriptExecutionModal.test.tsx
@@ -51,7 +51,7 @@ function renderModal(
   onClose = vi.fn(),
   availableDevices = devices,
 ) {
-  render(
+  const view = render(
     <ScriptExecutionModal
       script={{ ...baseScript, parameters }}
       devices={availableDevices}
@@ -60,7 +60,7 @@ function renderModal(
       onExecute={onExecute}
     />
   );
-  return { onExecute, onClose };
+  return { onExecute, onClose, unmount: view.unmount };
 }
 
 /** Select the one online device and drive the two-step execute button. */
@@ -250,6 +250,44 @@ describe('ScriptExecutionModal admission truth', () => {
     expect(onClose).not.toHaveBeenCalled();
     expect(vi.getTimerCount()).toBeGreaterThan(0);
     await act(async () => { await vi.runOnlyPendingTimersAsync(); });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  // #5270 — the 1.5s auto-close timer used to outlive the component. A test
+  // that unmounted before it fired left it pending, and when it eventually ran
+  // (after that file's jsdom was torn down) it threw
+  // `ReferenceError: window is not defined` as an unhandled error, failing
+  // Test Web with every file passing.
+  it('cancels the pending auto-close timer on unmount and never calls onClose afterwards', async () => {
+    const onClose = vi.fn();
+    const { unmount } = renderModal([], vi.fn().mockResolvedValue(admittedResult), onClose);
+
+    await execute();
+    await act(async () => { await Promise.resolve(); });
+    expect(vi.getTimerCount()).toBeGreaterThan(0);
+
+    unmount();
+    expect(vi.getTimerCount()).toBe(0);
+
+    await act(async () => { await vi.runAllTimersAsync(); });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  // #5270 — the modal's own close path must cancel it too, so a re-open can't
+  // be slammed shut by a timer scheduled before the operator closed it.
+  it('cancels the pending auto-close timer when the operator closes the modal first', async () => {
+    const onClose = vi.fn();
+    renderModal([], vi.fn().mockResolvedValue(admittedResult), onClose);
+
+    await execute();
+    await act(async () => { await Promise.resolve(); });
+    expect(vi.getTimerCount()).toBeGreaterThan(0);
+
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+
+    await act(async () => { await vi.runAllTimersAsync(); });
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/web/src/components/scripts/ScriptExecutionModal.tsx
+++ b/apps/web/src/components/scripts/ScriptExecutionModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from 'react';
+import { useState, useMemo, useEffect, useRef, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { X, Play, Loader2, Clock, AlertCircle, Filter } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -248,6 +248,23 @@ export default function ScriptExecutionModal({
     setRunAs(script.runAs === 'user' ? 'user' : 'system');
   }, [script.id, script.runAs, isOpen]);
 
+  // #5270 — the success path schedules a 1.5s auto-close. Left untracked it
+  // outlived the component: in Test Web it fired after that file's jsdom had
+  // been torn down and threw `ReferenceError: window is not defined` as an
+  // unhandled error, failing the job with every test passing. In the app it
+  // would call `onClose` on a modal the operator had already closed and
+  // re-opened. Track it and cancel it on unmount and on every close.
+  const autoCloseTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const cancelAutoClose = useCallback(() => {
+    if (autoCloseTimer.current !== null) {
+      clearTimeout(autoCloseTimer.current);
+      autoCloseTimer.current = null;
+    }
+  }, []);
+
+  useEffect(() => cancelAutoClose, [cancelAutoClose]);
+
   const handleClearSelection = () => {
     setSelectedDeviceIds(new Set());
   };
@@ -301,7 +318,9 @@ export default function ScriptExecutionModal({
         showToast({ type: 'success', message: t('scriptExecutionModal.toasts.runsWhenOnline') });
       }
       if (presentationState === 'admitted') {
-        setTimeout(() => {
+        cancelAutoClose();
+        autoCloseTimer.current = setTimeout(() => {
+          autoCloseTimer.current = null;
           onClose();
           setExecutionState('idle');
           setAdmissionResult(null);
@@ -317,6 +336,7 @@ export default function ScriptExecutionModal({
 
   const handleClose = () => {
     if (executionState === 'submitting') return;
+    cancelAutoClose();
     onClose();
     setExecutionState('idle');
     setShowConfirm(false);


### PR DESCRIPTION
## Problem

`ScriptExecutionModal` scheduled a bare 1.5s `setTimeout` on the admitted-execution path to auto-close itself. Nothing tracked or cancelled it, so the timer outlived the component.

**In CI:** a test that finished before the timer fired left it pending; when it eventually ran — after that file's jsdom had been torn down — it threw `ReferenceError: window is not defined` as an unhandled error. Test Web then exited 1 with **825/825 files passing** (run 34194497917 on #5260). Load-dependent, so it read as a flake.

**In the app:** the same orphaned timer could call `onClose` on a modal the operator had already closed and re-opened, slamming it shut.

## Fix

- Track the handle in an `autoCloseTimer` ref; null it out when the callback fires.
- `cancelAutoClose()` cleared from a `useEffect` cleanup (unmount) and from `handleClose` (operator-close path), and before scheduling a new one.

## Tests

Two regression tests in `ScriptExecutionModal.test.tsx` (`admission truth` describe, which already runs fake timers):

- unmount after an admitted execution → `vi.getTimerCount()` is 0 and `onClose` is never called by `runAllTimersAsync`;
- operator clicks Cancel after an admitted execution → timer cancelled, `onClose` stays at exactly one call.

Both written red-first and confirmed failing against the unfixed component (`expected 1 to be +0` on the timer count).

## Verification

- `npx vitest run src/components/scripts/ScriptExecutionModal.test.tsx` — 30 passed (was 28 passed / 2 failed pre-fix).
- `npx tsc --noEmit` in `apps/web` — clean.
- `pnpm --filter @breeze/web lint` — clean.

Closes #5270

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEX58GdCWkLHA9M8nfataF