### PR TITLE
fix(api): publish alert.triggered for network-monitor alerts (#5241)

### DIFF
--- a/apps/api/src/jobs/monitorWorker.test.ts
+++ b/apps/api/src/jobs/monitorWorker.test.ts
@@ -109,12 +109,13 @@ vi.mock('../services/alertCooldown', () => ({
 }));
 
 vi.mock('../services/alertService', () => ({
-  resolveAlert: vi.fn(async () => undefined)
+  resolveAlert: vi.fn(async () => undefined),
+  createSourcedAlert: vi.fn(async () => 'alert-1')
 }));
 
 import { db } from '../db';
 import { isCooldownActive, setCooldown } from '../services/alertCooldown';
-import { resolveAlert } from '../services/alertService';
+import { resolveAlert, createSourcedAlert } from '../services/alertService';
 import { dispatchCommandToAgent, isAgentConnectedAnywhere } from '../services/agentCommandRelay';
 import { buildMonitorCommand } from '../routes/monitors';
 
@@ -310,10 +311,64 @@ describe('recordMonitorCheckResult', () => {
       error: 'timeout'
     });
 
-    expect(vi.mocked(db.insert)).toHaveBeenCalledWith(expect.anything());
+    // #5241: the alert must go through the shared create+publish path so
+    // `alert.triggered` actually fires — never a raw insert into `alerts`.
+    expect(vi.mocked(db.insert)).not.toHaveBeenCalled();
+    expect(vi.mocked(createSourcedAlert)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(createSourcedAlert)).toHaveBeenCalledWith(expect.objectContaining({
+      deviceId: 'device-1',
+      orgId: 'org-1',
+      severity: 'high',
+      publisher: 'monitor-worker',
+      context: expect.objectContaining({
+        source: 'network_monitor',
+        monitorId: 'monitor-1',
+        alertRuleId: 'rule-1',
+      }),
+      eventPayload: expect.objectContaining({
+        source: 'network_monitor',
+        monitorId: 'monitor-1',
+        alertRuleId: 'rule-1',
+      }),
+    }));
     expect(vi.mocked(isCooldownActive)).toHaveBeenCalledWith('rule-1', 'device-1');
     expect(vi.mocked(setCooldown)).toHaveBeenCalledWith('rule-1', 'device-1', 5);
     expect(vi.mocked(resolveAlert)).not.toHaveBeenCalled();
+  });
+
+  it('does not burn the cooldown when alert creation fails (#5241)', async () => {
+    vi.mocked(createSourcedAlert).mockResolvedValueOnce(null);
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectLimitResolved([{
+        id: 'monitor-1',
+        orgId: 'org-1',
+        assetId: null,
+        name: 'Edge Ping',
+        target: '8.8.8.8',
+        monitorType: 'icmp_ping',
+        consecutiveFailures: 3
+      }]) as any)
+      .mockReturnValueOnce(selectWhereResolved([{
+        id: 'rule-1',
+        monitorId: 'monitor-1',
+        condition: 'offline',
+        threshold: null,
+        severity: 'high',
+        message: null,
+        isActive: true
+      }]) as any)
+      .mockReturnValueOnce(selectWhereOrderLimitResolved([{ id: 'device-1' }]) as any)
+      .mockReturnValueOnce(selectWhereResolved([]) as any);
+
+    await recordMonitorCheckResult('monitor-1', {
+      monitorId: 'monitor-1',
+      status: 'offline',
+      responseMs: 250,
+      error: 'timeout'
+    });
+
+    expect(vi.mocked(createSourcedAlert)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(setCooldown)).not.toHaveBeenCalled();
   });
 
   it('auto-resolves matching alerts when the monitor recovers', async () => {
@@ -350,6 +405,7 @@ describe('recordMonitorCheckResult', () => {
       expect.stringContaining('recovered from offline')
     );
     expect(vi.mocked(db.insert)).not.toHaveBeenCalled();
+    expect(vi.mocked(createSourcedAlert)).not.toHaveBeenCalled();
     expect(vi.mocked(setCooldown)).not.toHaveBeenCalled();
   });
 

--- a/apps/api/src/jobs/monitorWorker.test.ts
+++ b/apps/api/src/jobs/monitorWorker.test.ts
@@ -325,10 +325,13 @@ describe('recordMonitorCheckResult', () => {
         monitorId: 'monitor-1',
         alertRuleId: 'rule-1',
       }),
+      title: expect.stringContaining('Edge Ping'),
+      message: expect.stringContaining('Edge Ping'),
       eventPayload: expect.objectContaining({
-        source: 'network_monitor',
         monitorId: 'monitor-1',
         alertRuleId: 'rule-1',
+        monitorType: 'icmp_ping',
+        target: '8.8.8.8',
       }),
     }));
     expect(vi.mocked(isCooldownActive)).toHaveBeenCalledWith('rule-1', 'device-1');
@@ -369,6 +372,58 @@ describe('recordMonitorCheckResult', () => {
 
     expect(vi.mocked(createSourcedAlert)).toHaveBeenCalledTimes(1);
     expect(vi.mocked(setCooldown)).not.toHaveBeenCalled();
+  });
+
+  it('keeps evaluating later rules after one rule fails to create its alert (#5241)', async () => {
+    // rule-1's create fails, rule-2's succeeds: the `continue` must skip only
+    // rule-1's cooldown, not abort the rest of the monitor's rule set.
+    vi.mocked(createSourcedAlert)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce('alert-2');
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectLimitResolved([{
+        id: 'monitor-1',
+        orgId: 'org-1',
+        assetId: null,
+        name: 'Edge Ping',
+        target: '8.8.8.8',
+        monitorType: 'icmp_ping',
+        consecutiveFailures: 3
+      }]) as any)
+      .mockReturnValueOnce(selectWhereResolved([
+        {
+          id: 'rule-1',
+          monitorId: 'monitor-1',
+          condition: 'offline',
+          threshold: null,
+          severity: 'high',
+          message: null,
+          isActive: true
+        },
+        {
+          id: 'rule-2',
+          monitorId: 'monitor-1',
+          condition: 'consecutive_failures_gt',
+          threshold: '2',
+          severity: 'critical',
+          message: null,
+          isActive: true
+        }
+      ]) as any)
+      .mockReturnValueOnce(selectWhereOrderLimitResolved([{ id: 'device-1' }]) as any)
+      .mockReturnValueOnce(selectWhereResolved([]) as any)
+      .mockReturnValueOnce(selectWhereResolved([]) as any);
+
+    await recordMonitorCheckResult('monitor-1', {
+      monitorId: 'monitor-1',
+      status: 'offline',
+      responseMs: 250,
+      error: 'timeout'
+    });
+
+    expect(vi.mocked(createSourcedAlert)).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(setCooldown)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(setCooldown)).toHaveBeenCalledWith('rule-2', 'device-1', 5);
   });
 
   it('auto-resolves matching alerts when the monitor recovers', async () => {

--- a/apps/api/src/jobs/monitorWorker.ts
+++ b/apps/api/src/jobs/monitorWorker.ts
@@ -15,7 +15,7 @@ import { isReusableState } from '../services/bullmqUtils';
 import { dispatchCommandToAgent, isAgentConnectedAnywhere } from '../services/agentCommandRelay';
 import { buildMonitorCommand } from '../services/monitorCommands';
 import { isCooldownActive, setCooldown } from '../services/alertCooldown';
-import { resolveAlert } from '../services/alertService';
+import { resolveAlert, createSourcedAlert } from '../services/alertService';
 import { assertQueueJobName, parseQueueJobData } from '../services/bullmqValidation';
 import {
   monitorQueueJobDataSchema,
@@ -426,11 +426,16 @@ async function evaluateMonitorAlertRules(
     const message = rule.message
       ?? `${condition.detail}. Target: ${monitor.target}. Status: ${result.status}.`;
 
-    await db.insert(alerts).values({
-      ruleId: null,
+    // #5241: route through the shared create+publish path. A raw
+    // `db.insert(alerts)` here left the alert visible only in the inbox —
+    // notifications, escalation, automations and AI verdicts all hang off the
+    // `alert.triggered` event this publishes. Dedupe/cooldown stay above,
+    // keyed on the monitor alert rule rather than an `alertRules` row.
+    const alertId = await createSourcedAlert({
       deviceId: alertDeviceId,
+      // Alert rows always take the DEVICE's org; monitors are org-scoped and
+      // resolveMonitorAlertDevice only returns devices in monitor.orgId.
       orgId: monitor.orgId,
-      status: 'active',
       severity: rule.severity,
       title,
       message,
@@ -446,8 +451,25 @@ async function evaluateMonitorAlertRules(
         error: result.error ?? null,
         threshold: rule.threshold ?? null
       },
-      triggeredAt: new Date()
+      publisher: 'monitor-worker',
+      eventPayload: {
+        source: 'network_monitor',
+        monitorId: monitor.id,
+        alertRuleId: rule.id,
+        monitorType: monitor.monitorType,
+        target: monitor.target
+      }
     });
+
+    if (!alertId) {
+      // Insert produced no row, so nothing was published. Leave the cooldown
+      // unset so the next check retries instead of silently swallowing the
+      // breach for the whole cooldown window.
+      console.error(
+        `[MonitorWorker] Failed to create alert for monitor ${monitor.id} rule ${rule.id}; will retry on next check`
+      );
+      continue;
+    }
 
     await setCooldown(rule.id, alertDeviceId, MONITOR_ALERT_COOLDOWN_MINUTES);
   }

--- a/apps/api/src/jobs/monitorWorker.ts
+++ b/apps/api/src/jobs/monitorWorker.ts
@@ -452,8 +452,8 @@ async function evaluateMonitorAlertRules(
         threshold: rule.threshold ?? null
       },
       publisher: 'monitor-worker',
+      // `source` is supplied by createSourcedAlert from `context.source`.
       eventPayload: {
-        source: 'network_monitor',
         monitorId: monitor.id,
         alertRuleId: rule.id,
         monitorType: monitor.monitorType,

--- a/apps/api/src/services/alertService.test.ts
+++ b/apps/api/src/services/alertService.test.ts
@@ -79,7 +79,8 @@ vi.mock('./eventBus', () => ({ publishEvent: vi.fn(() => Promise.resolve()) }));
 vi.mock('./deviceSiteResolver', () => ({ resolveDeviceSiteId: vi.fn(() => Promise.resolve('site-1')) }));
 vi.mock('../jobs/alertCorrelation', () => ({ enqueueAlertCorrelation: enqueueAlertCorrelationMock }));
 
-import { createAlert } from './alertService';
+import { publishEvent } from './eventBus';
+import { createAlert, createSourcedAlert } from './alertService';
 
 describe('createAlert correlation enqueue boundary', () => {
   beforeEach(() => {
@@ -108,5 +109,72 @@ describe('createAlert correlation enqueue boundary', () => {
     expect(enqueueAlertCorrelationMock).toHaveBeenCalledWith({ orgId: 'org-1', deviceId: 'device-1' });
     expect(insertCalls).toHaveBeenCalledTimes(1);
     expect(insertCalls).not.toHaveBeenCalledWith(alertCorrelationsTable);
+  });
+});
+
+describe('createSourcedAlert (#5241 — rule-less alert sources publish alert.triggered)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbMock._selectResults.length = 0;
+    dbMock._insertReturnResults.length = 0;
+    dbMock._insertReturnResults.push([{ id: 'alert-9' }]);
+  });
+
+  it('inserts a rule-less alert and publishes exactly one alert.triggered carrying the source', async () => {
+    const triggeredAt = new Date('2026-01-02T03:04:05.000Z');
+
+    const alertId = await createSourcedAlert({
+      deviceId: 'device-1',
+      orgId: 'org-1',
+      severity: 'high',
+      title: 'Edge Ping offline',
+      message: 'Monitor Edge Ping is offline',
+      context: { source: 'network_monitor', monitorId: 'monitor-1' },
+      publisher: 'monitor-worker',
+      eventPayload: { source: 'network_monitor', monitorId: 'monitor-1' },
+      triggeredAt,
+    });
+
+    expect(alertId).toBe('alert-9');
+    expect(insertCalls).toHaveBeenCalledTimes(1);
+    expect(insertCalls).toHaveBeenCalledWith(alertsTable);
+
+    expect(vi.mocked(publishEvent)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(publishEvent)).toHaveBeenCalledWith(
+      'alert.triggered',
+      'org-1',
+      expect.objectContaining({
+        alertId: 'alert-9',
+        ruleId: null,
+        deviceId: 'device-1',
+        severity: 'high',
+        title: 'Edge Ping offline',
+        message: 'Monitor Edge Ping is offline',
+        source: 'network_monitor',
+        monitorId: 'monitor-1',
+      }),
+      'monitor-worker',
+      { siteId: 'site-1' },
+    );
+
+    expect(enqueueAlertCorrelationMock).toHaveBeenCalledWith({ orgId: 'org-1', deviceId: 'device-1' });
+  });
+
+  it('returns null and publishes nothing when the insert yields no row', async () => {
+    dbMock._insertReturnResults.length = 0;
+    dbMock._insertReturnResults.push([]);
+
+    const alertId = await createSourcedAlert({
+      deviceId: 'device-1',
+      orgId: 'org-1',
+      severity: 'low',
+      title: 't',
+      message: 'm',
+      context: { source: 'network_monitor' },
+      publisher: 'monitor-worker',
+    });
+
+    expect(alertId).toBeNull();
+    expect(vi.mocked(publishEvent)).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/services/alertService.test.ts
+++ b/apps/api/src/services/alertService.test.ts
@@ -1,6 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { dbMock, insertCalls, enqueueAlertCorrelationMock, alertsTable, alertCorrelationsTable } = vi.hoisted(() => {
+const {
+  dbMock,
+  insertCalls,
+  deleteCalls,
+  captureExceptionMock,
+  enqueueAlertCorrelationMock,
+  alertsTable,
+  alertCorrelationsTable,
+} = vi.hoisted(() => {
   const alertsTable = { id: 'alerts.id', ruleId: 'alerts.ruleId', deviceId: 'alerts.deviceId', status: 'alerts.status' };
   const alertCorrelationsTable = { id: 'alert_correlations.id' };
   const selectResults: unknown[][] = [];
@@ -21,12 +29,17 @@ const { dbMock, insertCalls, enqueueAlertCorrelationMock, alertsTable, alertCorr
       })),
       _table: table,
     })),
+    delete: vi.fn(() => ({
+      where: vi.fn(() => Promise.resolve(undefined)),
+    })),
   };
   return {
     dbMock,
     alertsTable,
     alertCorrelationsTable,
     insertCalls: dbMock.insert,
+    deleteCalls: dbMock.delete,
+    captureExceptionMock: vi.fn(),
     enqueueAlertCorrelationMock: vi.fn(() => Promise.resolve('correlation-job-1')),
   };
 });
@@ -76,6 +89,7 @@ vi.mock('./featureConfigResolver', () => ({
 }));
 
 vi.mock('./eventBus', () => ({ publishEvent: vi.fn(() => Promise.resolve()) }));
+vi.mock('./sentry', () => ({ captureException: captureExceptionMock }));
 vi.mock('./deviceSiteResolver', () => ({ resolveDeviceSiteId: vi.fn(() => Promise.resolve('site-1')) }));
 vi.mock('../jobs/alertCorrelation', () => ({ enqueueAlertCorrelation: enqueueAlertCorrelationMock }));
 
@@ -176,5 +190,32 @@ describe('createSourcedAlert (#5241 — rule-less alert sources publish alert.tr
 
     expect(alertId).toBeNull();
     expect(vi.mocked(publishEvent)).not.toHaveBeenCalled();
+    // The null-check must short-circuit BEFORE the correlation enqueue too —
+    // there is no alert to correlate.
+    expect(enqueueAlertCorrelationMock).not.toHaveBeenCalled();
+  });
+
+  it('rolls back the alert row and reports when publishing alert.triggered throws', async () => {
+    dbMock._insertReturnResults.length = 0;
+    dbMock._insertReturnResults.push([{ id: 'alert-9' }]);
+    vi.mocked(publishEvent).mockRejectedValueOnce(new Error('redis down'));
+
+    const alertId = await createSourcedAlert({
+      deviceId: 'device-1',
+      orgId: 'org-1',
+      severity: 'high',
+      title: 't',
+      message: 'm',
+      context: { source: 'network_monitor', monitorId: 'monitor-1' },
+      publisher: 'monitor-worker',
+    });
+
+    // An `active` row nobody was ever notified about is exactly the silent
+    // inbox-only alert #5241 exists to remove: it must not survive, or the
+    // caller's dedupe would skip re-creating it forever.
+    expect(alertId).toBeNull();
+    expect(deleteCalls).toHaveBeenCalledWith(alertsTable);
+    expect(captureExceptionMock).toHaveBeenCalled();
+    expect(enqueueAlertCorrelationMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/services/alertService.ts
+++ b/apps/api/src/services/alertService.ts
@@ -173,6 +173,96 @@ export async function createAlert(params: CreateAlertParams): Promise<string | n
 }
 
 /**
+ * Parameters for {@link createSourcedAlert}.
+ */
+export interface CreateSourcedAlertParams {
+  deviceId: string;
+  orgId: string;
+  severity: 'critical' | 'high' | 'medium' | 'low' | 'info';
+  title: string;
+  message: string;
+  /**
+   * Persisted to `alerts.context`. `source` names the producing subsystem and
+   * is also what the caller's own dedupe query keys on.
+   */
+  context: Record<string, unknown> & { source: string };
+  /** Event-bus publisher label, e.g. `'monitor-worker'`. */
+  publisher: string;
+  /** Extra fields merged into the `alert.triggered` payload. */
+  eventPayload?: Record<string, unknown>;
+  triggeredAt?: Date;
+}
+
+/**
+ * Create an alert that has no `alert_rules` row behind it and publish
+ * `alert.triggered` for it.
+ *
+ * Rule-less producers (network monitors, warranty, network baseline, …) cannot
+ * use {@link createAlert}: that path looks up `alertRules`/`alertTemplates` by
+ * `ruleId` for its cooldown + dedupe settings and bails when the rule does not
+ * exist. Inserting into `alerts` directly instead — which is what
+ * `monitorWorker` did before #5241 — makes the alert visible in the inbox but
+ * invisible to every `alert.triggered` consumer: no notifications, no
+ * escalation, no automations, no AI verdict.
+ *
+ * This helper is the shared insert + publish tail. Cooldown, dedupe and
+ * flap-suppression stay with the caller, whose keys are source-specific
+ * (a monitor rule id, a warranty end date, …) rather than an `alertRules` id.
+ *
+ * @returns the new alert id, or null if the insert produced no row (in which
+ *          case nothing is published — the caller should not burn its cooldown).
+ */
+export async function createSourcedAlert(params: CreateSourcedAlertParams): Promise<string | null> {
+  const { deviceId, orgId, severity, title, message, context, publisher, eventPayload, triggeredAt } = params;
+
+  const [newAlert] = await db
+    .insert(alerts)
+    .values({
+      ruleId: null,
+      deviceId,
+      orgId,
+      severity,
+      title,
+      message,
+      context,
+      status: 'active',
+      triggeredAt: triggeredAt ?? new Date()
+    })
+    .returning({ id: alerts.id });
+
+  const alertId = newAlert?.id;
+  if (!alertId) {
+    console.error(
+      `[AlertService] Insert returned no row for ${context.source} alert (org=${orgId} device=${deviceId}); nothing published`
+    );
+    return null;
+  }
+
+  enqueueAlertCorrelationForDevice(orgId, deviceId);
+
+  // Attach the device's site so site-restricted users see it, same as createAlert.
+  const siteId = await resolveDeviceSiteId(deviceId);
+  await publishEvent(
+    'alert.triggered',
+    orgId,
+    {
+      alertId,
+      ruleId: null,
+      deviceId,
+      severity,
+      title,
+      message,
+      source: context.source,
+      ...eventPayload
+    },
+    publisher,
+    { siteId }
+  );
+
+  return alertId;
+}
+
+/**
  * Check if an alert should be auto-resolved
  * Evaluates auto-resolve conditions and resolves if met
  *

--- a/apps/api/src/services/alertService.ts
+++ b/apps/api/src/services/alertService.ts
@@ -27,6 +27,7 @@ import { resolveAlertRulesForDevice, resolveMaintenanceConfigForDevice, isInMain
 import { publishEvent } from './eventBus';
 import { resolveDeviceSiteId } from './deviceSiteResolver';
 import { enqueueAlertCorrelation } from '../jobs/alertCorrelation';
+import { captureException } from './sentry';
 
 // Types for alert creation
 export interface CreateAlertParams {
@@ -232,32 +233,75 @@ export async function createSourcedAlert(params: CreateSourcedAlertParams): Prom
 
   const alertId = newAlert?.id;
   if (!alertId) {
-    console.error(
+    const err = new Error(
       `[AlertService] Insert returned no row for ${context.source} alert (org=${orgId} device=${deviceId}); nothing published`
     );
+    console.error(err.message);
+    captureException(err, undefined, { alertSource: context.source, orgId, deviceId });
     return null;
   }
 
-  enqueueAlertCorrelationForDevice(orgId, deviceId);
-
-  // Attach the device's site so site-restricted users see it, same as createAlert.
-  const siteId = await resolveDeviceSiteId(deviceId);
-  await publishEvent(
-    'alert.triggered',
-    orgId,
-    {
+  try {
+    // Attach the device's site so site-restricted users see it, same as createAlert.
+    const siteId = await resolveDeviceSiteId(deviceId);
+    await publishEvent(
+      'alert.triggered',
+      orgId,
+      {
+        alertId,
+        ruleId: null,
+        deviceId,
+        severity,
+        title,
+        message,
+        // `source` last so it is always the one persisted in context — a caller
+        // cannot accidentally publish a source that disagrees with the row.
+        ...eventPayload,
+        source: context.source
+      },
+      publisher,
+      { siteId }
+    );
+  } catch (error) {
+    // The row is already committed but nothing was notified. Leaving it is
+    // WORSE than never creating it: callers dedupe on the open alert, so they
+    // would find an `active` row and skip re-creating it forever — precisely
+    // the silent, inbox-only alert #5241 exists to eliminate. Roll it back so
+    // the next evaluation retries the whole create+publish.
+    captureException(error, undefined, {
+      errorId: 'alert-triggered-publish-failed',
       alertId,
-      ruleId: null,
-      deviceId,
-      severity,
-      title,
-      message,
-      source: context.source,
-      ...eventPayload
-    },
-    publisher,
-    { siteId }
-  );
+      alertSource: context.source,
+      orgId,
+      deviceId
+    });
+    console.error(
+      `[AlertService] Failed to publish alert.triggered for ${context.source} alert ${alertId}; rolling the alert row back:`,
+      error
+    );
+    try {
+      await db.delete(alerts).where(eq(alerts.id, alertId));
+    } catch (deleteError) {
+      // Now the row IS stranded — unpublished and undeletable. Nothing else
+      // will notice it, so this needs to page rather than only log.
+      captureException(deleteError, undefined, {
+        errorId: 'alert-triggered-orphan-rollback-failed',
+        alertId,
+        alertSource: context.source,
+        orgId,
+        deviceId
+      });
+      console.error(
+        `[AlertService] Could not roll back unpublished alert ${alertId}; it is stranded active with no notification:`,
+        deleteError
+      );
+    }
+    return null;
+  }
+
+  // Only correlate an alert that actually published — a rolled-back row must
+  // not leave a correlation job pointing at a deleted alert.
+  enqueueAlertCorrelationForDevice(orgId, deviceId);
 
   return alertId;
 }

--- a/docs/release-notes/next-release-draft.md
+++ b/docs/release-notes/next-release-draft.md
@@ -230,3 +230,29 @@ No env vars, no migrations.
 - Enforcement returns to default ON once the notification-period rollout
   (grace window, banner, deadline before `force_mfa` takes effect — #5306)
   ships next release.
+
+---
+
+## Network-monitor alerts now notify, escalate and automate (#5241)
+
+**Self-Hosting / Upgrade Notes.**
+- Behaviour change (API), no migration and no new env vars: alerts raised by
+  **Network Monitors** (ICMP / TCP / HTTP / DNS checks) were previously written
+  straight into the `alerts` table without publishing `alert.triggered`, so they
+  appeared only in the Alerts inbox. They now go through the shared alert
+  create+publish path and therefore start **sending notifications** (email,
+  Teams, Slack, webhook, PagerDuty, SMS, Pushover), **starting escalation
+  policies**, **firing automations** with an `alert.triggered` trigger, and
+  **receiving AI alert verdicts** — exactly like every other alert source.
+- **Expect a step change in notification and automation volume on upgrade** if
+  you have network monitors configured with alert rules: monitors that were
+  silently raising inbox-only alerts will start paging on-call. Review your
+  monitor alert rules, notification channels and escalation policies before
+  deploying. The existing 5-minute per-rule cooldown and the
+  `source = network_monitor` dedupe still apply, and recovery still auto-resolves
+  as before.
+- The published event carries `source: 'network_monitor'`, `monitorId`,
+  `alertRuleId`, `monitorType` and `target` alongside the standard
+  `alertId`/`deviceId`/`severity` fields, so an automation event filter can be
+  narrowed to network monitors (`source` = `network_monitor`) or to one monitor.
+  `ruleId` is `null` for these alerts — they have no `alert_rules` row.


### PR DESCRIPTION
## Problem

Alerts raised by **Network Monitors** (ICMP / TCP / HTTP / DNS checks) were inserted straight into the `alerts` table by `monitorWorker.evaluateMonitorAlertRules` and never published `alert.triggered`. They appeared in the Alerts inbox and nowhere else:

- no notifications (email / Teams / Slack / webhook / PagerDuty / SMS / Pushover — `notification-dispatcher` only reacts to `alert.triggered`),
- no escalation policy,
- no automations with an `alert.triggered` trigger,
- no AI alert verdict (`ai-agent-alert-verdict`),
- no alert-correlation enqueue.

Recovery already went through `resolveAlert`, so `alert.resolved` fired while `alert.triggered` never did — a tech with a ping monitor on a router and a Teams channel got nothing when it went down.

## Fix

`createAlert` cannot serve rule-less producers: it looks up `alertRules`/`alertTemplates` by `ruleId` for its cooldown and dedupe settings and returns `null` when the rule does not exist. Network monitor rules live in `networkMonitorAlertRules` and the alert row carries `ruleId: null`.

So this adds **`createSourcedAlert`** to `alertService` — the shared *insert + publish* tail for producers with no `alert_rules` row behind them. It inserts the alert, enqueues device correlation, resolves the device's `siteId` and publishes exactly one `alert.triggered`. Cooldown, dedupe and flap suppression deliberately stay with the caller, whose keys are source-specific (a monitor alert-rule id, a warranty end date, …) rather than an `alertRules` id.

`monitorWorker` now calls it. The published payload is:

```
{ alertId, ruleId: null, deviceId, severity, title, message,
  source: 'network_monitor', monitorId, alertRuleId, monitorType, target }
```

`source` lets an automation event filter be narrowed to network monitors or to one monitor. Payload contract checked against both consumers: `notification-dispatcher` (`handleAlertLifecycleEvent`) and `ai-agent-alert-verdict` (`handleAlertTriggeredEvent`) require only `alertId` (+ the event's `orgId`); `ruleId` is optional and already `null` for the `network-baseline` and `warranty-alert-evaluator` publishers, so nothing breaks.

Also fixed on the way: a failed insert no longer burns the per-rule cooldown, so the next check retries instead of silently swallowing the breach for the whole window.

**Not changed:** the existing `context.source = 'network_monitor'` dedupe key, the 5-minute per-rule cooldown, the auto-resolve path, and tenancy — alert rows keep taking the DEVICE's org and `networkMonitors` / `networkMonitorAlertRules` stay org-only. The #4984/#5287 unified-monitor redesign is deliberately out of scope; this is the standalone bug.

## Tests (red first)

- `alertService.test.ts` — `createSourcedAlert` inserts one rule-less alert and publishes **exactly one** `alert.triggered` carrying `source`/`monitorId` and the resolved `siteId`; returns `null` and publishes nothing when the insert yields no row. Both failed with `createSourcedAlert is not a function` before the implementation.
- `monitorWorker.test.ts` — a matching monitor rule now routes through `createSourcedAlert` with `source: 'network_monitor'` + `monitorId`/`alertRuleId` and does **not** raw-insert into `alerts` (the assertion that failed on unfixed code); recovery still calls neither; a null return does not set the cooldown.

`vitest run src/jobs/monitorWorker src/services/alertService src/services/eventSubscribers` → 9 files / 69 tests passed. `tsc --noEmit` clean.

## Release notes

Added a `docs/release-notes/next-release-draft.md` entry — this is a user-visible behaviour change and operators should expect a step change in notification/automation volume on upgrade if they have monitor alert rules configured.

## Follow-ups (not in this PR)

- `warrantyAlertEvaluator` and `networkBaseline` still hand-roll the same insert + publish and could adopt `createSourcedAlert`; neither is broken, so converting them is a separate cleanup.
- An integration test proving an `alertNotifications` row lands for a configured channel would be the end-to-end proof; the existing subscriber harness would need a live-DB monitor fixture, which is larger than this fix.

Closes #5241

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEX58GdCWkLHA9M8nfataF