### PR TITLE
fix(ai): handle the lost transitionIntent CAS at every aiAgentSdk call site (#5232)

### DIFF
--- a/apps/api/src/services/aiAgentSdk.test.ts
+++ b/apps/api/src/services/aiAgentSdk.test.ts
@@ -1374,12 +1374,21 @@ describe('createSessionPreToolUse', () => {
         result: 'failure',
         details: expect.objectContaining({
           actionName: 'execute_command',
+          source: 'chat',
           errorCode: 'execution_cas_lost',
           intendedStatus: 'completed',
+          // Pins WHICH of the five call sites lost — a copy-pasted label
+          // would make the marker untriageable.
+          casLabel: 'ai_sdk_inline_completion',
           executed: true,
         }),
       });
       expect(mockCaptureException).toHaveBeenCalled();
+      // The Sentry tag must be the snake_case `cas_label` (allowlisted in
+      // services/sentry.ts); a camelCase key is voided by the scrubber.
+      expect(mockCaptureException.mock.calls[0]?.[2]).toEqual({
+        cas_label: 'ai_sdk_inline_completion',
+      });
     });
 
     it('writes NO CAS-lost marker when the terminal CAS wins (#5232)', async () => {
@@ -2614,6 +2623,49 @@ describe('inline secret-bearing completion (Task 6)', () => {
     );
   });
 
+  // #5232: the worst of the five call sites. The reset ALREADY happened, the
+  // credential it produced is being refused persistence, and now the intent
+  // records neither — it carries the winner's terminal state instead. Shares
+  // the `executed: true` branch with the completion site but is a distinct
+  // call with its own casLabel/intendedStatus, so a copy-paste slip here
+  // would not show up in the completion test.
+  it('records a CAS-lost marker for the plaintext-guard site when its CAS loses after the tool ran (#5232)', async () => {
+    mockTransitionIntent.mockResolvedValue(false);
+    const session = makeActiveSession({ auditSnapshot: { requestId: 'req-1' } as any });
+
+    await createSessionPostToolUse(session)(
+      'm365_reset_password',
+      { userIdentifier: 'a@b.com' },
+      'Reset done.',
+      false,
+      12,
+      { intentId: 'intent-leak-cas-lost', sealedResult: { temporaryPassword: 'hunter2-plaintext' } },
+    );
+
+    const marker = mockWriteAuditEvent.mock.calls.find(
+      (c) => (c[1] as any)?.action === 'action_intent.executed',
+    );
+    expect(marker).toBeDefined();
+    expect(marker![1]).toMatchObject({
+      resourceId: 'intent-leak-cas-lost',
+      result: 'failure',
+      details: expect.objectContaining({
+        actionName: 'm365_reset_password',
+        errorCode: 'execution_cas_lost',
+        intendedStatus: 'failed',
+        casLabel: 'ai_sdk_inline_plaintext_guard',
+        executed: true,
+      }),
+    });
+    // Two captures: the guard trip itself, and the lost CAS on top of it.
+    // Neither may swallow the other.
+    expect(
+      mockCaptureException.mock.calls.some((c) => (c[2] as any)?.cas_label === 'ai_sdk_inline_plaintext_guard'),
+    ).toBe(true);
+    // The guarded plaintext must never ride along into the marker.
+    expect(JSON.stringify(marker![1])).not.toContain('hunter2-plaintext');
+  });
+
   describe('Important 4: PAM-helper tier-3-but-intentless path pins intentId===undefined (deliberately out of scope for the plan-step fix below — PAM/helper sessions use their own elevation governance, not durable action-intents; see design doc docs/superpowers/specs/ai-mcp/2026-07-27-tier3-plan-mode-approval-parity-design.md §1.5)', () => {
     it('PAM-helper session: intentId is undefined for a secret-bearing tool auto-approved by organization policy', async () => {
       vi.mocked(checkGuardrails).mockReturnValue({
@@ -3159,6 +3211,68 @@ describe('Task 2: plan index advances only once the step is authorized', () => {
       { id: 'intent-plan-digest-mismatch', orgId: 'org-1', taskId: null },
       'intent_failed',
     );
+  });
+
+  // #5232, `executed: false` branch. The other half of `reportLostTerminalCas`:
+  // a CAS lost BEFORE the tool ran is the mutual exclusion working, not a lost
+  // outcome — nothing executed, so there is no result to strand and no reason
+  // to duplicate an audit row the winner already wrote. Without this test the
+  // "quiet on the pre-execution path" decision (which mirrors
+  // intentReleaseWorker.ts's failIntent) is unproven, and a regression that
+  // started marking these would look identical to the real thing.
+  it('does NOT write a CAS-lost marker or capture when the digest-mismatch CAS loses BEFORE the tool ran (#5232)', async () => {
+    vi.mocked(checkGuardrails).mockReturnValue({
+      allowed: true,
+      tier: 3,
+      requiresApproval: true,
+      description: 'Execute command',
+    } as any);
+    mockInsertReturning({ id: 'exec-digest-cas-lost' });
+    mockCreateActionIntent.mockResolvedValue(
+      makeIntentSnapshot({ id: 'intent-digest-cas-lost', approvalRequestIds: ['appr-digest-cas-lost'] }),
+    );
+    mockWaitForIntentDecision.mockResolvedValue('approved');
+    // The approved -> executing release CAS WINS; only the terminal
+    // executing -> failed:content_changed CAS loses.
+    mockTransitionIntent.mockResolvedValueOnce(true).mockResolvedValue(false);
+    const selectChain: Record<string, unknown> = {
+      from: vi.fn(() => selectChain),
+      where: vi.fn(() => selectChain),
+      limit: vi.fn(async () => [
+        {
+          id: 'intent-digest-cas-lost',
+          boundArgumentDigest: 'digest',
+          actionName: 'execute_command',
+          arguments: { command: 'whoami' },
+          effectDigest: 'stored-digest-abc',
+        },
+      ]),
+    };
+    vi.mocked(db.select).mockReturnValue(selectChain as any);
+    mockComputeEffectDigest.mockResolvedValueOnce({ digest: 'recomputed-digest-xyz' });
+    const session = makeActiveSession({ approvalMode: 'per_step' });
+
+    const result = await createSessionPreToolUse(session)('execute_command', { command: 'whoami' });
+
+    // Still refuses to execute — losing the terminal CAS must not turn a
+    // content_changed stop into an allowed run.
+    expect(result).toEqual({
+      allowed: false,
+      error: 'The referenced content changed after approval; it was not executed.',
+    });
+    expect(mockTransitionIntent).toHaveBeenCalledWith(
+      'intent-digest-cas-lost',
+      'executing',
+      'failed',
+      { errorCode: 'content_changed' },
+    );
+    // No side effect happened, so no marker and no Sentry event.
+    expect(
+      mockWriteAuditEvent.mock.calls.find((c) => (c[1] as any)?.action === 'action_intent.executed'),
+    ).toBeUndefined();
+    expect(mockCaptureException).not.toHaveBeenCalled();
+    // A lost CAS means the winner owns the outbox row too.
+    expect(mockPublishIntentTerminalOutbox).not.toHaveBeenCalled();
   });
 
   // The mirror image: a stored NULL effect digest (supervised intents never

--- a/apps/api/src/services/aiAgentSdk.test.ts
+++ b/apps/api/src/services/aiAgentSdk.test.ts
@@ -1298,6 +1298,104 @@ describe('createSessionPreToolUse', () => {
     });
 
     // ---------------------------------------------------------------------
+    // #5232: a LOST executing -> terminal CAS after the tool already ran.
+    // `transitionIntent` returns false and never throws, so before this the
+    // inline path executed a real side effect and then discarded its result
+    // with no log line, no Sentry event and no audit row — strictly more
+    // silent than jobs/intentReleaseWorker.ts, which handles the same race.
+    // ---------------------------------------------------------------------
+    async function runInlineTier3WithCasOutcome(opts: {
+      intentId: string;
+      execId: string;
+      casWon: boolean;
+    }) {
+      vi.mocked(checkGuardrails).mockReturnValue({
+        allowed: true,
+        tier: 3,
+        requiresApproval: true,
+        description: 'Execute command',
+      } as any);
+      mockInsertReturning({ id: opts.execId });
+      mockCreateActionIntent.mockResolvedValue(
+        makeIntentSnapshot({ id: opts.intentId, approvalRequestIds: ['appr-cas'] }),
+      );
+      mockWaitForIntentDecision.mockResolvedValue('approved');
+      // The approved -> executing release CAS must WIN, otherwise the session
+      // never runs the tool and there is no post-execution race to test.
+      mockTransitionIntent.mockResolvedValue(true);
+      vi.mocked(db.update).mockReturnValue({
+        set: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+      } as any);
+      const session = makeActiveSession({ approvalMode: 'per_step' });
+
+      const pre = await createSessionPreToolUse(session)('execute_command', {});
+      expect(pre).toEqual({ allowed: true, intentId: opts.intentId });
+
+      // Only the TERMINAL CAS loses.
+      mockTransitionIntent.mockClear();
+      mockWriteAuditEvent.mockClear();
+      mockCaptureException.mockClear();
+      mockTransitionIntent.mockResolvedValue(opts.casWon);
+
+      await createSessionPostToolUse(session)(
+        'execute_command',
+        {},
+        JSON.stringify({ status: 'completed' }),
+        false,
+        10,
+      );
+
+      expect(mockTransitionIntent).toHaveBeenCalledWith(
+        opts.intentId,
+        'executing',
+        'completed',
+        expect.anything(),
+      );
+      return mockWriteAuditEvent.mock.calls.find(
+        (c) => (c[1] as any)?.action === 'action_intent.executed',
+      );
+    }
+
+    it('records a CAS-lost marker + Sentry event when the terminal CAS loses after the tool ran (#5232)', async () => {
+      const marker = await runInlineTier3WithCasOutcome({
+        intentId: 'intent-cas-lost',
+        execId: 'exec-cas-lost',
+        casWon: false,
+      });
+
+      // The side effect already happened and cannot be undone — but the
+      // intent now carries someone else's terminal state, so the result this
+      // execution produced is recorded nowhere. That must be loud.
+      expect(marker).toBeDefined();
+      expect(marker![1]).toMatchObject({
+        orgId: 'org-1',
+        resourceType: 'action_intent',
+        resourceId: 'intent-cas-lost',
+        result: 'failure',
+        details: expect.objectContaining({
+          actionName: 'execute_command',
+          errorCode: 'execution_cas_lost',
+          intendedStatus: 'completed',
+          executed: true,
+        }),
+      });
+      expect(mockCaptureException).toHaveBeenCalled();
+    });
+
+    it('writes NO CAS-lost marker when the terminal CAS wins (#5232)', async () => {
+      // Discriminating control: without it, a helper that unconditionally
+      // wrote the marker would satisfy the test above.
+      const marker = await runInlineTier3WithCasOutcome({
+        intentId: 'intent-cas-won',
+        execId: 'exec-cas-won',
+        casWon: true,
+      });
+
+      expect(marker).toBeUndefined();
+      expect(mockCaptureException).not.toHaveBeenCalled();
+    });
+
+    // ---------------------------------------------------------------------
     // approvalMethod audit fidelity for the tier-3 scope split
     // (tier3-supervised-four-eyes design §4.2). `supervised_self` had NO test
     // anywhere: grepping for it in the suite hit only the route-side audit

--- a/apps/api/src/services/aiAgentSdk.ts
+++ b/apps/api/src/services/aiAgentSdk.ts
@@ -53,6 +53,7 @@ import {
 } from './actionIntents/secretBearingTools';
 import { TEMP_PASSWORD_ENC_KEY } from './actionIntents/resultSecrets';
 import { captureException } from './sentry';
+import { recordActionIntentMetric } from './actionIntents/metrics';
 import { resolveLlmConfigForOrg, type UsableLlmConfig } from './llm/llmConfigResolver';
 
 const SESSION_MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours
@@ -521,6 +522,106 @@ async function transitionIntentAndPublish(
     }
     return won;
   });
+}
+
+/**
+ * #5232: `transitionIntent` returns `false` on a lost compare-and-swap and
+ * never throws, so every `transitionIntentAndPublish` call site has to decide
+ * what a LOST race means for it. Two cases, and the difference is whether the
+ * tool already ran:
+ *
+ * - `executed: false` — the CAS is attempted BEFORE the tool runs (a
+ *   revalidation stop, an effect-digest mismatch, or the tier-3 catch's
+ *   self-heal). Losing means some other writer (the stale-executing reaper,
+ *   the durable release worker, or a duplicate delivery) already terminalized
+ *   this intent. There is no side effect to reconcile and no result to lose —
+ *   the intent is terminal either way. Mirrors `intentReleaseWorker.ts`'s
+ *   `failIntent`, which returns quietly on the same race rather than writing
+ *   a duplicate audit row for an event that already happened once. A single
+ *   warn line, because "which writer won" is still worth being able to grep.
+ *
+ * - `executed: true` — the CAS is attempted AFTER the tool had its real-world
+ *   side effect. The effect happened and cannot be undone, but the intent now
+ *   carries the winner's terminal state, so the result THIS execution produced
+ *   is recorded nowhere. That is the hole this helper exists to close, and it
+ *   is the exact posture `intentReleaseWorker.ts` already takes on its own
+ *   `executing -> completed` loss: log, `captureException`, and write an
+ *   `action_intent.executed` / `result: 'failure'` audit row carrying an
+ *   explicit `execution_cas_lost` marker.
+ *
+ * Never retries the tool: a lost CAS means another writer owns the intent, and
+ * re-running would double-execute a real side effect — the precise thing the
+ * `approved -> executing` CAS exists to prevent.
+ *
+ * Written as a direct `writeAuditEvent` rather than `recordActionIntentEvent`
+ * for the same reason `intentReleaseWorker.ts`'s `auditReleaseFailure` is:
+ * `ActionIntentOutcome` has no "outcome executed, but it failed" member, so
+ * routing through that helper would file this as `result: 'success'`. The
+ * Prometheus counter is bumped separately so `executed` totals still include
+ * this path.
+ *
+ * `actionName`/`source` are supplied by the caller rather than re-read from the
+ * intent row: every intent this file transitions was created by its own
+ * `createActionIntent(session.auth, { toolName, source: 'chat', ... })` call
+ * above, so both are known by construction and a DB read on an error path
+ * would only add a second way to fail.
+ */
+const INLINE_CAS_LOST_ERROR_CODE = 'execution_cas_lost';
+
+function reportLostTerminalCas(opts: {
+  intentId: string;
+  orgId: string;
+  toolName: string;
+  intendedStatus: 'completed' | 'failed';
+  /** Hardcoded string literal per call site; allowlisted Sentry tag. */
+  casLabel: string;
+  executed: boolean;
+}): void {
+  const { intentId, orgId, toolName, intendedStatus, casLabel, executed } = opts;
+
+  if (!executed) {
+    console.warn(
+      `[AI-SDK] Lost the executing->${intendedStatus} CAS for intent ${intentId} (${casLabel}) — `
+      + 'another writer already terminalized it; the tool never ran',
+    );
+    return;
+  }
+
+  console.error(
+    `[AI-SDK] Lost the executing->${intendedStatus} CAS for intent ${intentId} (${casLabel}) — `
+    + 'a reaper or duplicate delivery likely already terminalized it; the tool DID execute',
+  );
+  captureException(
+    new Error(`intent ${intentId} executed but lost the executing->${intendedStatus} CAS`),
+    undefined,
+    { cas_label: casLabel },
+  );
+
+  try {
+    writeAuditEvent(requestLikeFromSnapshot({}), {
+      orgId,
+      action: 'action_intent.executed',
+      resourceType: 'action_intent',
+      resourceId: intentId,
+      actorType: 'system',
+      actorId: null,
+      result: 'failure',
+      details: {
+        actionName: toolName,
+        source: 'chat',
+        errorCode: INLINE_CAS_LOST_ERROR_CODE,
+        intendedStatus,
+        casLabel,
+        executed: true,
+      },
+    });
+    recordActionIntentMetric('chat', toolName, 'executed');
+  } catch (err) {
+    // The marker is the ONLY record that this execution's outcome exists at
+    // all, so losing it must not itself be silent.
+    console.error(`[AI-SDK] Failed to write the CAS-lost audit marker for intent ${intentId}:`, err);
+    captureException(err instanceof Error ? err : new Error(String(err)));
+  }
 }
 
 // ============================================
@@ -1318,13 +1419,23 @@ export function createSessionPreToolUse(session: ActiveSession): PreToolUseCallb
 
           const revalidation = await revalidateApprovedIntentForRelease(intentRow, winningApproval);
           if (!revalidation.ok) {
-            await transitionIntentAndPublish(
+            const revalidationCasWon = await transitionIntentAndPublish(
               intent.id,
               'failed',
               { errorCode: revalidation.errorCode },
               session.orgId,
               'intent_failed',
             );
+            if (!revalidationCasWon) {
+              reportLostTerminalCas({
+                intentId: intent.id,
+                orgId: session.orgId,
+                toolName,
+                intendedStatus: 'failed',
+                casLabel: 'ai_sdk_inline_revalidation_failed',
+                executed: false,
+              });
+            }
             console.error(
               `[AI-SDK] inline release revalidation failed for intent ${intent.id}: ${revalidation.errorCode}`,
             );
@@ -1369,13 +1480,23 @@ export function createSessionPreToolUse(session: ActiveSession): PreToolUseCallb
               ),
             );
             if (recomputed.digest !== intentRow.effectDigest) {
-              await transitionIntentAndPublish(
+              const digestCasWon = await transitionIntentAndPublish(
                 intent.id,
                 'failed',
                 { errorCode: 'content_changed' },
                 session.orgId,
                 'intent_failed',
               );
+              if (!digestCasWon) {
+                reportLostTerminalCas({
+                  intentId: intent.id,
+                  orgId: session.orgId,
+                  toolName,
+                  intendedStatus: 'failed',
+                  casLabel: 'ai_sdk_inline_content_changed',
+                  executed: false,
+                });
+              }
               console.error(
                 `[AI-SDK] inline release effect-digest mismatch for intent ${intent.id}: content_changed`,
               );
@@ -1436,13 +1557,27 @@ export function createSessionPreToolUse(session: ActiveSession): PreToolUseCallb
           // original error being handled.
           if (wonIntentId) {
             try {
-              await transitionIntentAndPublish(
+              const selfHealCasWon = await transitionIntentAndPublish(
                 wonIntentId,
                 'failed',
                 { errorCode: 'execution_error' },
                 session.orgId,
                 'intent_failed',
               );
+              if (!selfHealCasWon) {
+                reportLostTerminalCas({
+                  intentId: wonIntentId,
+                  orgId: session.orgId,
+                  toolName,
+                  intendedStatus: 'failed',
+                  casLabel: 'ai_sdk_inline_self_heal',
+                  // This catch wraps the tier-3 admission flow inside
+                  // preToolUse — it can only be reached BEFORE the handler
+                  // runs the tool, which is exactly why the self-heal is safe
+                  // to attempt at all.
+                  executed: false,
+                });
+              }
             } catch (transitionErr) {
               // #5205 W05 (#5210): transitionIntentAndPublish now couples the
               // CAS to a constraint-guarded intentOutbox insert in the SAME
@@ -1965,13 +2100,27 @@ export function createSessionPostToolUse(session: ActiveSession): PostToolUseCal
           captureException(err instanceof Error ? err : new Error(String(err)));
           plaintextGuardTripped = true;
           try {
-            await transitionIntentAndPublish(
+            const guardCasWon = await transitionIntentAndPublish(
               pendingIntentId,
               'failed',
               { executedAt: new Date(), errorCode: SECRET_SEAL_INVARIANT_VIOLATED_ERROR_CODE },
               session.orgId,
               'intent_failed',
             );
+            if (!guardCasWon) {
+              // The tool ALREADY ran (this is postToolUse) and the credential
+              // it produced is being refused persistence — losing the CAS on
+              // top of that means the intent records neither the execution nor
+              // the guard trip. Loudest possible case for the marker.
+              reportLostTerminalCas({
+                intentId: pendingIntentId,
+                orgId: session.orgId,
+                toolName,
+                intendedStatus: 'failed',
+                casLabel: 'ai_sdk_inline_plaintext_guard',
+                executed: true,
+              });
+            }
           } catch (transitionErr) {
             // #5205 W05 (#5210): the CAS is now coupled to a constraint-
             // guarded intentOutbox insert in the SAME transaction — a
@@ -1988,7 +2137,7 @@ export function createSessionPostToolUse(session: ActiveSession): PostToolUseCal
 
         if (!plaintextGuardTripped) {
           try {
-            await transitionIntentAndPublish(
+            const completionCasWon = await transitionIntentAndPublish(
               pendingIntentId,
               isError ? 'failed' : 'completed',
               {
@@ -2003,6 +2152,21 @@ export function createSessionPostToolUse(session: ActiveSession): PostToolUseCal
               session.orgId,
               isError ? 'intent_failed' : 'intent_completed',
             );
+            if (!completionCasWon) {
+              // #5232: the primary inline-execution completion write. The tool
+              // ran and had its real-world side effect; losing this CAS means
+              // the result it produced is recorded nowhere on the intent.
+              // Never retried — the winner owns the intent, and re-running
+              // would double-execute the side effect.
+              reportLostTerminalCas({
+                intentId: pendingIntentId,
+                orgId: session.orgId,
+                toolName,
+                intendedStatus: isError ? 'failed' : 'completed',
+                casLabel: 'ai_sdk_inline_completion',
+                executed: true,
+              });
+            }
           } catch (err) {
             // #5205 W05 (#5210): this is the primary inline-execution
             // completion write — every non-durable-release tier-3 tool call

--- a/apps/api/src/services/aiAgentSdk.ts
+++ b/apps/api/src/services/aiAgentSdk.ts
@@ -543,11 +543,21 @@ async function transitionIntentAndPublish(
  * - `executed: true` — the CAS is attempted AFTER the tool had its real-world
  *   side effect. The effect happened and cannot be undone, but the intent now
  *   carries the winner's terminal state, so the result THIS execution produced
- *   is recorded nowhere. That is the hole this helper exists to close, and it
- *   is the exact posture `intentReleaseWorker.ts` already takes on its own
- *   `executing -> completed` loss: log, `captureException`, and write an
- *   `action_intent.executed` / `result: 'failure'` audit row carrying an
- *   explicit `execution_cas_lost` marker.
+ *   is recorded nowhere. That is the hole this helper exists to close: log,
+ *   `captureException`, and write an `action_intent.executed` /
+ *   `result: 'failure'` audit row carrying an explicit `execution_cas_lost`
+ *   marker.
+ *
+ *   The log + `captureException` half is taken straight from
+ *   `intentReleaseWorker.ts`'s own `executing -> completed` loss. The durable
+ *   record is NOT: the worker re-persists the outcome on the intent's TASK
+ *   OPERATION row (`persistTaskOperationOutcome`, #5209), which is a channel
+ *   this file does not have — every intent it transitions is created without a
+ *   task context, so `taskId` is null by construction (see
+ *   `transitionIntentAndPublish` above). The audit row is this path's
+ *   equivalent durable record, not a claim of parity. The worker's own three
+ *   lost-CAS branches still write no audit row of their own; backporting one
+ *   is a separate change, deliberately not made here.
  *
  * Never retries the tool: a lost CAS means another writer owns the intent, and
  * re-running would double-execute a real side effect — the precise thing the
@@ -617,8 +627,13 @@ function reportLostTerminalCas(opts: {
     });
     recordActionIntentMetric('chat', toolName, 'executed');
   } catch (err) {
-    // The marker is the ONLY record that this execution's outcome exists at
-    // all, so losing it must not itself be silent.
+    // Only a SYNCHRONOUS throw reaches here (a bug in the payload sanitiser,
+    // say): `writeAuditEvent` is a fire-and-forget `void writeAuditEventAsync`
+    // (auditEvents.ts) and the underlying `createAuditLogAsync` never rejects —
+    // it catches internally and routes a real DB-write failure to its own retry
+    // queue plus `captureException`. So this catch is not what makes a failed
+    // marker write observable; it exists so that the one failure mode the audit
+    // layer canNOT absorb doesn't take the rest of postToolUse down with it.
     console.error(`[AI-SDK] Failed to write the CAS-lost audit marker for intent ${intentId}:`, err);
     captureException(err instanceof Error ? err : new Error(String(err)));
   }


### PR DESCRIPTION
Closes #5232

## Problem

`transitionIntent` returns `false` on a lost compare-and-swap and never throws. All five `transitionIntentAndPublish(...)` call sites in `apps/api/src/services/aiAgentSdk.ts` dropped that boolean, so the inline chat execution path could run a real tool, lose the `executing -> completed` race (to the stale-executing reaper's `failed:execution_lost`, or to a duplicate delivery), and discard the result with **no log line, no Sentry event and no audit row**. `jobs/intentReleaseWorker.ts` handles the same race explicitly; the SDK path was strictly more silent.

## Fix

New `reportLostTerminalCas` helper, called at all five sites. It splits the two cases by whether the tool had already run:

| Call site | Executed? | Behavior on a lost CAS |
|---|---|---|
| revalidation stop | no | warn + return |
| effect-digest `content_changed` | no | warn + return |
| tier-3 catch self-heal | no | warn + return |
| plaintext-secret guard (postToolUse) | **yes** | log + `captureException` + audit marker |
| primary completion (postToolUse) | **yes** | log + `captureException` + audit marker |

The pre-execution sites are quiet by design: nothing executed, the intent is terminal either way, and `intentReleaseWorker.ts`'s `failIntent` takes the same posture rather than writing a duplicate audit row for an event that already happened once.

The post-execution sites write an `action_intent.executed` / `result: 'failure'` audit row with an explicit `errorCode: 'execution_cas_lost'` marker plus `intendedStatus`, `casLabel` and `executed: true`, and bump the Prometheus `executed` counter. Like `auditReleaseFailure`, it writes the audit row directly rather than through `recordActionIntentEvent` — `ActionIntentOutcome` has no "outcome executed, but it failed" member, so that helper would mis-file this as `result: 'success'`.

The Sentry tag is `cas_label` (already in `ALLOWED_TAG_NAMES`, hardcoded string literal per call site, snake_case), so it survives the scrubber.

**The tool is never retried.** A lost CAS means another writer owns the intent; re-running would double-execute the real side effect the `approved -> executing` CAS exists to prevent.

## Tests

Two tests in `services/aiAgentSdk.test.ts` drive a real inline tier-3 admission (release CAS wins, tool runs), then stub the *terminal* CAS to lose:

- lost CAS → the `execution_cas_lost` marker is written and `captureException` fires. **Verified red before the fix** (`expected undefined to be defined`).
- won CAS → **no** marker, no capture. Discriminating control: an unconditional marker would fail this one.

## Verification

- `npx vitest run src/services/aiAgentSdk.test.ts` — 129 passed.
- `aiAgentSdk.approvalWait` / `.enforcementArmingGate` / `.m365risk` / `.planMatch`, `actionIntents/metrics`, `sentry` — 91 passed.
- `npx tsc --noEmit` (apps/api) — clean.

No schema, migration, or tenancy change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEX58GdCWkLHA9M8nfataF