### PR TITLE
fix(api): gate precheckCommandExecution on the deciding org (#5264)

### DIFF
--- a/apps/api/src/__tests__/integration/commandDispatchOrgMove.integration.test.ts
+++ b/apps/api/src/__tests__/integration/commandDispatchOrgMove.integration.test.ts
@@ -1,0 +1,146 @@
+/**
+ * #5264 — live-Postgres proof that a device which changes organization
+ * between a background caller's DECISION and its DISPATCH cannot receive the
+ * command.
+ *
+ * Why this needs a real database, and why the mocked unit cases in
+ * `services/commandQueue.dbcontext.test.ts` are not enough:
+ *
+ *  - The unit suite hands `precheckCommandExecution` whatever device row its
+ *    `db` double is told to return, so it can only prove the comparison
+ *    fires. It cannot prove the premise the comparison exists FOR — that
+ *    under `withSystemDbAccessContext` the `devices` SELECT genuinely returns
+ *    the moved row, i.e. that RLS is NOT quietly filtering it and the guard
+ *    is therefore load-bearing rather than belt-and-braces.
+ *  - The first case below asserts exactly that premise against real RLS,
+ *    with a real cross-org UPDATE in between. If a future migration ever made
+ *    the system scope org-filtered, this case would go green for the wrong
+ *    reason — so it asserts the visibility DIRECTLY rather than inferring it
+ *    from the refusal.
+ *
+ * Placement: `src/__tests__/integration/**` is the shared glob in
+ * `vitest.integration.config.ts`, so this file runs in the blocking
+ * `integration-test` job with no extra registration and no `runIf` gate.
+ */
+import './setup';
+import { getTestDb } from './setup';
+
+import { randomUUID } from 'node:crypto';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../../db';
+import { deviceCommands, devices } from '../../db/schema';
+import { createOrganization, createPartner, createSite } from './db-utils';
+
+// The WS layer is the only thing between the precheck and a real socket send.
+// Stubbing it lets a PASSING dispatch be observed (the positive control) without
+// an agent — and makes "was anything sent?" a direct assertion rather than an
+// inference from the returned status.
+const wsMocks = vi.hoisted(() => ({
+  sendCommandToAgent: vi.fn(() => true),
+  isAgentConnected: vi.fn(() => true),
+}));
+vi.mock('../../routes/agentWs', () => ({
+  sendCommandToAgent: wsMocks.sendCommandToAgent,
+  isAgentConnected: wsMocks.isAgentConnected,
+}));
+
+async function seedOnlineDevice() {
+  const adminDb = getTestDb() as never as typeof db;
+  const partner = await createPartner({});
+  const sourceOrg = await createOrganization({ partnerId: partner.id });
+  const targetOrg = await createOrganization({ partnerId: partner.id });
+  const site = await createSite({ orgId: sourceOrg.id });
+  const unique = randomUUID().slice(0, 8);
+  const [device] = await adminDb
+    .insert(devices)
+    .values({
+      orgId: sourceOrg.id,
+      siteId: site.id,
+      agentId: `dispatch-move-agent-${unique}`,
+      hostname: `dispatch-move-host-${unique}`,
+      osType: 'linux',
+      osVersion: '22.04',
+      architecture: 'x86_64',
+      agentVersion: '0.0.0-test',
+      status: 'online',
+    })
+    .returning();
+  return { partner, sourceOrg, targetOrg, device: device! };
+}
+
+/** The org move a real `POST /devices/:id/move-org` performs, reduced to the
+ *  one column this guard reads. */
+async function moveDeviceToOrg(deviceId: string, orgId: string, siteId: string) {
+  const adminDb = getTestDb() as never as typeof db;
+  await adminDb.update(devices).set({ orgId, siteId }).where(eq(devices.id, deviceId));
+}
+
+describe('command dispatch after a device org move (#5264)', () => {
+  beforeEach(() => {
+    wsMocks.sendCommandToAgent.mockClear();
+    wsMocks.isAgentConnected.mockClear();
+  });
+
+  it('refuses the dispatch, and the system-scope read really can still see the moved device', async () => {
+    const { sourceOrg, targetOrg, device } = await seedOnlineDevice();
+    const decidedUnderOrgId = sourceOrg.id;
+
+    // ---- the move, between decision and dispatch ----
+    const targetSite = await createSite({ orgId: targetOrg.id });
+    await moveDeviceToOrg(device.id, targetOrg.id, targetSite.id);
+
+    // PREMISE (not the conclusion): under the same system scope the precheck
+    // uses, the id-only SELECT still resolves the row — now owned by the
+    // OTHER org. This is what makes the guard load-bearing.
+    const seenUnderSystemScope = await withSystemDbAccessContext(() =>
+      db.select({ orgId: devices.orgId }).from(devices).where(eq(devices.id, device.id)).limit(1),
+    );
+    expect(seenUnderSystemScope).toHaveLength(1);
+    expect(seenUnderSystemScope[0]!.orgId).toBe(targetOrg.id);
+    expect(seenUnderSystemScope[0]!.orgId).not.toBe(decidedUnderOrgId);
+
+    // ---- the dispatch ----
+    const { executeCommandWithSystemPrecheck } = await import('../../services/commandQueue');
+    const result = await executeCommandWithSystemPrecheck(
+      device.id,
+      'list_services',
+      {},
+      { timeoutMs: 2_000, expectedOrgId: decidedUnderOrgId },
+    );
+
+    expect(result.status).toBe('failed');
+    expect(result.error).toBe('Device not found');
+    // Refused BEFORE the row existed: no commandId, and nothing in the table.
+    expect(result.commandId).toBeUndefined();
+    const rows = await withSystemDbAccessContext(() =>
+      db.select({ id: deviceCommands.id }).from(deviceCommands).where(eq(deviceCommands.deviceId, device.id)),
+    );
+    expect(rows).toHaveLength(0);
+    expect(wsMocks.sendCommandToAgent).not.toHaveBeenCalled();
+  });
+
+  it('positive control: the same dispatch is admitted while the device has NOT moved', async () => {
+    // Without this, the case above would pass equally against a precheck that
+    // refused unconditionally — which would break every background dispatch
+    // in the product while looking like a security win.
+    const { sourceOrg, device } = await seedOnlineDevice();
+
+    const { executeCommandWithSystemPrecheck } = await import('../../services/commandQueue');
+    const result = await executeCommandWithSystemPrecheck(
+      device.id,
+      'list_services',
+      {},
+      { timeoutMs: 1_000, expectedOrgId: sourceOrg.id },
+    );
+
+    // No agent answers, so it times out — the point is that it got PAST the
+    // precheck and a real command row was written and sent.
+    expect(result.error).not.toBe('Device not found');
+    const rows = await withSystemDbAccessContext(() =>
+      db.select({ id: deviceCommands.id }).from(deviceCommands).where(eq(deviceCommands.deviceId, device.id)),
+    );
+    expect(rows).toHaveLength(1);
+    expect(wsMocks.sendCommandToAgent).toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/aiAgents/actVerify.test.ts
+++ b/apps/api/src/services/aiAgents/actVerify.test.ts
@@ -93,7 +93,9 @@ describe('verifyActExecution — manage_services.restart (service_running)', () 
     });
     expect(result).toEqual({ execution: 'succeeded', verification: 'passed' });
     expect(executeCommandWithSystemPrecheck).toHaveBeenCalledWith('device-1', 'list_services', { search: 'Spooler' }, {
-      userId: AGENT_USER_ID, timeoutMs: 8_000,
+      // #5264: the run's org travels with the dispatch so a device that has
+      // moved tenants since the run started is refused by the precheck.
+      userId: AGENT_USER_ID, timeoutMs: 8_000, expectedOrgId: RUN.orgId,
     });
   });
 
@@ -173,7 +175,9 @@ describe('verifyActExecution — process_absent (manage_processes.kill is deferr
     });
     expect(result).toEqual({ execution: 'succeeded', verification: 'failed', verifyDetail: 'process with the pinned pid is still present' });
     expect(executeCommandWithSystemPrecheck).toHaveBeenCalledWith('device-1', 'list_processes', { search: 'notepad.exe', limit: 200 }, {
-      userId: AGENT_USER_ID, timeoutMs: 8_000,
+      // #5264: the run's org travels with the dispatch so a device that has
+      // moved tenants since the run started is refused by the precheck.
+      userId: AGENT_USER_ID, timeoutMs: 8_000, expectedOrgId: RUN.orgId,
     });
   });
 

--- a/apps/api/src/services/aiAgents/actVerify.ts
+++ b/apps/api/src/services/aiAgents/actVerify.ts
@@ -131,15 +131,16 @@ function commandExecutionVerdict(output: string, isError: boolean): ActExecution
  */
 export async function verifyServiceRunningForTask(
   target: { serviceName: string },
-  device: { deviceId: string },
+  device: { deviceId: string; orgId: string },
   agentUserId: string,
 ): Promise<{ verification: ActVerificationVerdict; detail?: string }> {
   return verifyServiceRunning(
     { kind: 'service', serviceName: target.serviceName } as Extract<ActTarget, { kind: 'service' }>,
-    // Only `deviceId` is read by `verifyServiceRunning`; the other three
-    // fields exist to satisfy the act-lane shape. Empty strings would be a
-    // lie if anything read them, so this cast documents that nothing does.
-    { id: '', orgId: '', agentId: '', deviceId: device.deviceId },
+    // `deviceId` and `orgId` are both REAL and both read: the org is the
+    // tenant the task was decided under and now gates the dispatch itself
+    // (#5264 — it used to be `''`, i.e. unread filler). `id`/`agentId` exist
+    // only to satisfy the act-lane shape and are still read by nothing.
+    { id: '', orgId: device.orgId, agentId: '', deviceId: device.deviceId },
     agentUserId,
   );
 }
@@ -158,6 +159,9 @@ async function verifyServiceRunning(
   const result = await executeCommandWithSystemPrecheck(
     run.deviceId, 'list_services', { search: target.serviceName }, {
       userId: agentUserId, timeoutMs: VERIFY_READ_TIMEOUT_MS,
+      // #5264: the run's org is the tenant this verification was authorized
+      // under. A device that has since moved must not be read from here.
+      expectedOrgId: run.orgId,
     });
 
   if (result.status !== 'completed') {
@@ -200,6 +204,8 @@ async function verifyProcessAbsent(
   const result = await executeCommandWithSystemPrecheck(
     run.deviceId, 'list_processes', { search: target.processName, limit: 200 }, {
       userId: agentUserId, timeoutMs: VERIFY_READ_TIMEOUT_MS,
+      // #5264 — see `verifyServiceRunning`.
+      expectedOrgId: run.orgId,
     });
 
   if (result.status !== 'completed') {

--- a/apps/api/src/services/aiAgents/playbookActExecutor.test.ts
+++ b/apps/api/src/services/aiAgents/playbookActExecutor.test.ts
@@ -408,8 +408,13 @@ describe('runPlaybookSteps — verify (service_status)', () => {
     // `name`, which the agent's ListServices command ignores — the read-back
     // must go through `search` directly, or it silently returns page 1 of an
     // unfiltered list on a real device.
+    // #5264: the org must be the RUN's, not the device's current org — the
+    // whole point is that they can differ once a device has been moved. An
+    // `objectContaining` that omits this key would pass against either, so
+    // the value is asserted explicitly.
     expect(executeCommandFn).toHaveBeenCalledWith(
-      'device-1', 'list_services', { search: 'Spooler' }, expect.objectContaining({ userId: 'agent-1' }),
+      'device-1', 'list_services', { search: 'Spooler' },
+      expect.objectContaining({ userId: 'agent-1', expectedOrgId: RUN.orgId }),
     );
     expect(deps.executeToolFn).not.toHaveBeenCalled();
   });

--- a/apps/api/src/services/aiAgents/playbookActExecutor.ts
+++ b/apps/api/src/services/aiAgents/playbookActExecutor.ts
@@ -454,6 +454,10 @@ async function readServiceStatus(
   const result = await deps.executeCommandFn(
     run.deviceId, 'list_services', { search: serviceName }, {
       userId: agentAuth.user.id, timeoutMs: SERVICE_STATUS_READ_TIMEOUT_MS,
+      // #5264: the precheck below this runs under a system scope with RLS
+      // off, so the run's own org is what keeps the read inside this tenant
+      // if the device has been moved since the run started.
+      expectedOrgId: run.orgId,
     });
   if (result.status !== 'completed') {
     return { ok: false, detail: `service status read did not complete (${result.status})` };

--- a/apps/api/src/services/aiOperator/verification.test.ts
+++ b/apps/api/src/services/aiOperator/verification.test.ts
@@ -28,6 +28,10 @@ vi.mock('../aiAgents/actVerify', () => ({
   verifyServiceRunningForTask: vi.fn(() => Promise.resolve(mockState.serviceVerdict)),
 }));
 
+// Imported so the #5264 case below can assert on the ARGUMENTS the mock was
+// called with, not merely on the verdict it returned.
+import { verifyServiceRunningForTask } from '../aiAgents/actVerify';
+
 // `verification.ts` makes exactly TWO reads, and this stub keeps them apart by
 // the TABLE passed to `.from(...)` rather than by call order:
 //
@@ -128,6 +132,23 @@ describe('evaluateCriterion — the device must still be in the task org', () =>
     expect(result.result).toBe('inconclusive');
     expect(result.outcome).toBeNull();
     expect(result.detail).toMatch(/no longer in this organization/i);
+  });
+
+  it('hands the TASK org down to the dispatch, not just to the pre-flight probe (#5264)', async () => {
+    // The pre-flight probe above is not the only guard any more: the org now
+    // travels into `precheckCommandExecution` as the mandatory
+    // `expectedOrgId`, which is what actually refuses a device that moved
+    // between the probe and the dispatch. `tsc` enforces that the key is
+    // PRESENT; only this asserts it carries the right VALUE — passing the
+    // device's current org instead of the task's would compile, would make
+    // the two trivially match, and would silently defeat the whole gate.
+    await evaluate({ serviceVerdict: { verification: 'passed' }, deviceInOrg: true, alertId: null });
+
+    expect(verifyServiceRunningForTask).toHaveBeenCalledWith(
+      expect.objectContaining({ serviceName: expect.any(String) }),
+      expect.objectContaining({ orgId: ORG_ID }),
+      AGENT_USER_ID,
+    );
   });
 });
 

--- a/apps/api/src/services/aiOperator/verification.ts
+++ b/apps/api/src/services/aiOperator/verification.ts
@@ -74,9 +74,15 @@ export interface CriterionEvaluation {
  * THE ORG CHECK IS NOT DECORATION. `verifyServiceRunningForTask` ends up in
  * `executeCommandWithSystemPrecheck`, whose `precheckCommandExecution`
  * (`commandQueue.ts`) resolves the device with `WHERE devices.id = $1` and NO
- * org predicate, under a SYSTEM scope that bypasses RLS. Its comment calls
- * that read "RLS-protected", which is true of the request paths it was
- * written for and false of the system path.
+ * org predicate, under a SYSTEM scope that bypasses RLS.
+ *
+ * Since #5264 that precheck ALSO enforces the org itself — `args.orgId` now
+ * travels all the way down as the mandatory `expectedOrgId` — so this is no
+ * longer the only thing standing between a moved device and a cross-tenant
+ * dispatch. It is kept because it is the only place that can answer
+ * "inconclusive" with a caller-meaningful reason instead of a generic
+ * dispatch failure, and because a pre-flight refusal never reaches the
+ * device_commands path at all.
  *
  * For a short-lived act-mode run that is academic — the device id came from
  * the run's own org moments earlier. For a DURABLE TASK it is not: a task can
@@ -122,7 +128,7 @@ export async function readServiceRunning(args: {
 
   const outcome = await verifyServiceRunningForTask(
     { serviceName: args.serviceName },
-    { deviceId: args.deviceId },
+    { deviceId: args.deviceId, orgId: args.orgId },
     args.agentUserId,
   );
   return {

--- a/apps/api/src/services/commandQueue.dbcontext.test.ts
+++ b/apps/api/src/services/commandQueue.dbcontext.test.ts
@@ -170,6 +170,7 @@ describe('executeCommandWithSystemPrecheck (#4150/#1105)', () => {
   it('closes the precheck context BEFORE dispatching and waiting', async () => {
     const result = await executeCommandWithSystemPrecheck('device-1', 'list_services', { search: 'Spooler' }, {
       timeoutMs: 5_000,
+      expectedOrgId: 'org-1',
     });
 
     expect(result.status).toBe('completed');
@@ -198,7 +199,7 @@ describe('executeCommandWithSystemPrecheck (#4150/#1105)', () => {
   it('opens no context at all past the precheck when the device is missing', async () => {
     dbState.deviceRows = [];
 
-    const result = await executeCommandWithSystemPrecheck('device-1', 'list_services', {}, { timeoutMs: 5_000 });
+    const result = await executeCommandWithSystemPrecheck('device-1', 'list_services', {}, { timeoutMs: 5_000, expectedOrgId: 'org-1' });
 
     expect(result).toEqual({ status: 'failed', error: 'Device not found' });
     expect(ctxState.events).toEqual(['ctx:enter', 'select:devices@depth1', 'ctx:exit']);
@@ -215,7 +216,7 @@ describe('executeCommandWithSystemPrecheck (#4150/#1105)', () => {
       ctxState.ambient = { scope };
       ctxState.depth = 1;
 
-      const result = await executeCommandWithSystemPrecheck('device-1', 'list_services', {}, { timeoutMs: 5_000 });
+      const result = await executeCommandWithSystemPrecheck('device-1', 'list_services', {}, { timeoutMs: 5_000, expectedOrgId: 'org-1' });
 
       expect(result.status).toBe('completed');
       // No leading ctx:enter — the precheck read is the very first event, so it
@@ -254,9 +255,9 @@ describe('executeCommandWithSystemPrecheck (#4150/#1105)', () => {
       ctxState.ambient = { scope: 'organization' };
       ctxState.depth = 1;
 
-      await executeCommandWithSystemPrecheck('device-1', 'list_services', {}, { timeoutMs: 5_000 });
-      await executeCommandWithSystemPrecheck('device-1', 'list_services', {}, { timeoutMs: 5_000 });
-      await executeCommandWithSystemPrecheck('device-1', 'list_services', {}, { timeoutMs: 5_000 });
+      await executeCommandWithSystemPrecheck('device-1', 'list_services', {}, { timeoutMs: 5_000, expectedOrgId: 'org-1' });
+      await executeCommandWithSystemPrecheck('device-1', 'list_services', {}, { timeoutMs: 5_000, expectedOrgId: 'org-1' });
+      await executeCommandWithSystemPrecheck('device-1', 'list_services', {}, { timeoutMs: 5_000, expectedOrgId: 'org-1' });
 
       // The same eventCode has burned thousands of events/day off the org
       // quota when emitted per call — see the throttle's comment.
@@ -276,7 +277,7 @@ describe('executeCommandWithSystemPrecheck (#4150/#1105)', () => {
       new TrustDeniedError('TRUST_PROBATION', 'probation_default_deny', 'device-1', 'list_services'),
     );
 
-    const result = await executeCommandWithSystemPrecheck('device-1', 'list_services', {}, { timeoutMs: 5_000 });
+    const result = await executeCommandWithSystemPrecheck('device-1', 'list_services', {}, { timeoutMs: 5_000, expectedOrgId: 'org-1' });
 
     expect(result).toEqual({
       status: 'failed',
@@ -296,7 +297,7 @@ describe('executeCommandWithSystemPrecheck (#4150/#1105)', () => {
     partnerTrustMocks.assertDeviceExecuteAllowed.mockRejectedValueOnce(new Error('trust store unreachable'));
 
     await expect(
-      executeCommandWithSystemPrecheck('device-1', 'list_services', {}, { timeoutMs: 5_000 }),
+      executeCommandWithSystemPrecheck('device-1', 'list_services', {}, { timeoutMs: 5_000, expectedOrgId: 'org-1' }),
     ).rejects.toThrow('trust store unreachable');
     // The context must still have closed on the throw path.
     expect(ctxState.depth).toBe(0);
@@ -306,7 +307,7 @@ describe('executeCommandWithSystemPrecheck (#4150/#1105)', () => {
   it('opens no context past the precheck when the device is offline', async () => {
     dbState.deviceRows = [{ ...ONLINE_DEVICE, status: 'offline' }];
 
-    const result = await executeCommandWithSystemPrecheck('device-1', 'list_services', {}, { timeoutMs: 5_000 });
+    const result = await executeCommandWithSystemPrecheck('device-1', 'list_services', {}, { timeoutMs: 5_000, expectedOrgId: 'org-1' });
 
     expect(result).toEqual({ status: 'failed', error: 'Device is offline, cannot execute command' });
     expect(ctxState.events).toEqual([
@@ -336,5 +337,104 @@ describe('executeCommand (unchanged by #4150)', () => {
       'wsSend@depth0',
       'select:device_commands@depth0',
     ]);
+  });
+});
+
+/**
+ * #5264 — the tenancy gate on the precheck's device lookup.
+ *
+ * `precheckCommandExecution` resolves the device with `WHERE devices.id = $1`
+ * and no org predicate. Under `executeCommandWithSystemPrecheck` that read
+ * runs in a SYSTEM scope where RLS filters nothing, so a background caller
+ * holding a device id from an earlier decision (an approved intent, a queued
+ * act step, a durable Operator task) could dispatch a live command into
+ * whatever tenant the device now belongs to.
+ *
+ * These cases live in this file rather than a new one because the harness
+ * above is the only mock of the precheck's `devices` SELECT that lets the row
+ * disagree with the caller's org — which is the entire scenario.
+ *
+ * MUTATION-VERIFIED: deleting the `expectedOrgId` comparison in
+ * `precheckCommandExecution` turns the first two cases red (status
+ * 'completed', a device_commands row inserted) rather than leaving them
+ * vacuously green.
+ */
+describe('precheckCommandExecution org gate (#5264)', () => {
+  it('refuses the dispatch when the device has moved to another org', async () => {
+    dbState.deviceRows = [{ ...ONLINE_DEVICE, orgId: 'org-2' }];
+
+    const result = await executeCommandWithSystemPrecheck('device-1', 'list_services', {}, {
+      timeoutMs: 5_000,
+      expectedOrgId: 'org-1',
+    });
+
+    expect(result.status).toBe('failed');
+    // Indistinguishable from a genuine miss on purpose: a caller with no
+    // claim on the device must not learn from the error that it still exists.
+    expect(result.error).toBe('Device not found');
+    // Refused BEFORE the row exists — no commandId, nothing inserted, nothing
+    // sent. This is the assertion that actually proves "fail closed".
+    expect(result.commandId).toBeUndefined();
+    expect(dbState.insertedCommand).toBeNull();
+    expect(agentWsMocks.sendCommandToAgent).not.toHaveBeenCalled();
+    expect(ctxState.events).not.toContain('insert:device_commands@depth1');
+  });
+
+  it('refuses before the trust, edition and liveness gates run', async () => {
+    // An OFFLINE device in another org: if the org gate ran after the
+    // liveness gate, the caller would get "Device is offline" — which both
+    // leaks that the id resolves and invites a retry when it comes back.
+    dbState.deviceRows = [{ ...ONLINE_DEVICE, orgId: 'org-2', status: 'offline' }];
+
+    const result = await executeCommandWithSystemPrecheck('device-1', 'list_services', {}, {
+      timeoutMs: 5_000,
+      expectedOrgId: 'org-1',
+    });
+
+    expect(result.error).toBe('Device not found');
+    expect(partnerTrustMocks.assertDeviceExecuteAllowed).not.toHaveBeenCalled();
+  });
+
+  it('reports the refusal to Sentry under a registered event code with no device id in the tags', async () => {
+    dbState.deviceRows = [{ ...ONLINE_DEVICE, orgId: 'org-2' }];
+
+    await executeCommandWithSystemPrecheck('device-1', 'list_services', {}, {
+      timeoutMs: 5_000,
+      expectedOrgId: 'org-1',
+    });
+
+    expect(sentryMocks.captureMessage).toHaveBeenCalledTimes(1);
+    const [, options] = sentryMocks.captureMessage.mock.calls[0] as [string, {
+      eventCode: string; tags: Record<string, string>;
+    }];
+    expect(options.eventCode).toBe('command_dispatch_cross_tenant_refused');
+    // Only allowlisted, non-identifying keys survive sentry.ts's scrubber;
+    // a device id must never ride a tag at all.
+    expect(Object.keys(options.tags)).toEqual(['org_id']);
+    expect(options.tags.org_id).toBe('org-1');
+  });
+
+  it('dispatches normally when the device is still in the expected org', async () => {
+    // Positive control: without this the three refusals above would also pass
+    // against a precheck that refuses everything.
+    const result = await executeCommandWithSystemPrecheck('device-1', 'list_services', {}, {
+      timeoutMs: 5_000,
+      expectedOrgId: 'org-1',
+    });
+
+    expect(result.status).toBe('completed');
+    expect(dbState.insertedCommand).not.toBeNull();
+    expect(sentryMocks.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('leaves the request path alone when no expectedOrgId is supplied', async () => {
+    // `executeCommand` from a route runs inside the caller's org-scoped RLS
+    // transaction, where the SELECT cannot return another tenant's row in the
+    // first place. The gate must not start refusing those.
+    dbState.deviceRows = [{ ...ONLINE_DEVICE, orgId: 'org-2' }];
+
+    const result = await executeCommand('device-1', 'list_services', {}, { timeoutMs: 5_000 });
+
+    expect(result.status).toBe('completed');
   });
 });

--- a/apps/api/src/services/commandQueue.dbcontext.test.ts
+++ b/apps/api/src/services/commandQueue.dbcontext.test.ts
@@ -365,7 +365,10 @@ describe('precheckCommandExecution org gate (#5264)', () => {
 
     const result = await executeCommandWithSystemPrecheck('device-1', 'list_services', {}, {
       timeoutMs: 5_000,
-      expectedOrgId: 'org-1',
+      // Each refusal case below uses a DISTINCT deciding org: the Sentry
+      // throttle is keyed on it and its map is module-level, so sharing one
+      // org would make whichever case ran second silently miss its capture.
+      expectedOrgId: 'org-decider-a',
     });
 
     expect(result.status).toBe('failed');
@@ -388,7 +391,7 @@ describe('precheckCommandExecution org gate (#5264)', () => {
 
     const result = await executeCommandWithSystemPrecheck('device-1', 'list_services', {}, {
       timeoutMs: 5_000,
-      expectedOrgId: 'org-1',
+      expectedOrgId: 'org-decider-b',
     });
 
     expect(result.error).toBe('Device not found');
@@ -400,7 +403,7 @@ describe('precheckCommandExecution org gate (#5264)', () => {
 
     await executeCommandWithSystemPrecheck('device-1', 'list_services', {}, {
       timeoutMs: 5_000,
-      expectedOrgId: 'org-1',
+      expectedOrgId: 'org-decider-c',
     });
 
     expect(sentryMocks.captureMessage).toHaveBeenCalledTimes(1);
@@ -411,7 +414,27 @@ describe('precheckCommandExecution org gate (#5264)', () => {
     // Only allowlisted, non-identifying keys survive sentry.ts's scrubber;
     // a device id must never ride a tag at all.
     expect(Object.keys(options.tags)).toEqual(['org_id']);
-    expect(options.tags.org_id).toBe('org-1');
+    expect(options.tags.org_id).toBe('org-decider-c');
+  });
+
+  it('throttles the Sentry event per deciding org while still refusing every dispatch', async () => {
+    // A durable Operator task re-reads on a schedule and a bulk org move can
+    // strand many device ids at once, so the refusal is rare by design but not
+    // by construction. The REFUSAL must never be throttled — only the alert.
+    dbState.deviceRows = [{ ...ONLINE_DEVICE, orgId: 'org-2' }];
+    const options = { timeoutMs: 5_000, expectedOrgId: 'org-decider-d' } as const;
+
+    const first = await executeCommandWithSystemPrecheck('device-1', 'list_services', {}, options);
+    const second = await executeCommandWithSystemPrecheck('device-1', 'list_services', {}, options);
+    const third = await executeCommandWithSystemPrecheck('device-9', 'list_services', {}, options);
+
+    for (const result of [first, second, third]) {
+      expect(result.error).toBe('Device not found');
+    }
+    expect(dbState.insertedCommand).toBeNull();
+    // One event for the window — the 2nd and 3rd tell an operator nothing the
+    // 1st did not, and a retry loop would otherwise burn the org's quota.
+    expect(sentryMocks.captureMessage).toHaveBeenCalledTimes(1);
   });
 
   it('dispatches normally when the device is still in the expected org', async () => {

--- a/apps/api/src/services/commandQueue.ts
+++ b/apps/api/src/services/commandQueue.ts
@@ -869,6 +869,51 @@ type CommandPrecheckOutcome =
   | { ok: false; result: CommandResult };
 
 /**
+ * At most one Sentry event per deciding org per window for the #5264
+ * cross-tenant refusal below.
+ *
+ * Same reasoning as `reportHeldContextDispatch` further down this file, which
+ * exists because a hot path emitting one event per call has previously burned
+ * thousands of events/day off the org quota. The refusal is rare by design,
+ * but it is NOT rare by construction: a durable AI Operator task re-runs its
+ * verification read on a schedule for as long as it stays `waiting`, and a
+ * bulk org move can strand many device ids at once — either one would fire an
+ * event per attempt, and the Nth is worth nothing the first was not.
+ *
+ * A SEPARATE map from `heldContextDispatchLastCapture` on purpose: sharing one
+ * would let a burst of either signal silently suppress the other for a whole
+ * window, and "a dispatch was refused across tenants" and "a dispatch was made
+ * from inside a held context" are problems an operator needs to see
+ * independently.
+ *
+ * Keyed by the DECIDING org rather than the device, so one misbehaving caller
+ * cannot evict everyone else's window by cycling device ids — and capped,
+ * because unlike the three-valued `scope` key the sibling uses, the org space
+ * is unbounded. Blowing past the cap inside one window IS the storm this
+ * throttle exists for, so dropping the whole map (rather than growing it) is
+ * the right failure mode: the next refusal per org re-alerts and the map
+ * restarts small.
+ *
+ * The console line stays unthrottled: it carries the deviceId, the command
+ * type and the ACTUAL org, none of which may ride a Sentry tag. Logs have no
+ * quota, so the event is the alert and the log line is the attribution.
+ */
+const CROSS_TENANT_REFUSAL_CAPTURE_THROTTLE_MS = 15 * 60 * 1000;
+const CROSS_TENANT_REFUSAL_MAX_TRACKED_ORGS = 200;
+const crossTenantRefusalLastCapture = new Map<string, number>();
+
+function shouldCaptureCrossTenantRefusal(expectedOrgId: string): boolean {
+  const now = Date.now();
+  const last = crossTenantRefusalLastCapture.get(expectedOrgId);
+  if (last !== undefined && now - last < CROSS_TENANT_REFUSAL_CAPTURE_THROTTLE_MS) return false;
+  if (crossTenantRefusalLastCapture.size >= CROSS_TENANT_REFUSAL_MAX_TRACKED_ORGS) {
+    crossTenantRefusalLastCapture.clear();
+  }
+  crossTenantRefusalLastCapture.set(expectedOrgId, now);
+  return true;
+}
+
+/**
  * Phase 1 of `executeCommand` — every gate that must clear BEFORE a
  * `device_commands` row exists: the device lookup, the partner-trust
  * capability check, the artifact-edition gate, the liveness gates and the
@@ -944,11 +989,15 @@ async function precheckCommandExecution(
       '[commandQueue] refusing dispatch: device is no longer in the deciding organization (#5264)',
       { deviceId, type, expectedOrgId: options.expectedOrgId, actualOrgId: device.orgId },
     );
-    captureMessage(
-      '[commandQueue] command dispatch refused: device left the deciding organization between '
-        + 'decision and dispatch (#5264)',
-      { eventCode: 'command_dispatch_cross_tenant_refused', tags: { org_id: options.expectedOrgId } },
-    );
+    if (shouldCaptureCrossTenantRefusal(options.expectedOrgId)) {
+      // Invariant text: it is the Sentry grouping key, so the varying part
+      // rides the allowlisted `org_id` tag rather than the message.
+      captureMessage(
+        '[commandQueue] command dispatch refused: device left the deciding organization between '
+          + 'decision and dispatch (#5264)',
+        { eventCode: 'command_dispatch_cross_tenant_refused', tags: { org_id: options.expectedOrgId } },
+      );
+    }
     // Deliberately indistinguishable from a genuine miss — byte-identical to
     // the sibling gate on the QUEUE lane (`dispatchDeviceCommand.ts`, which
     // has carried this same `expectedOrgId` contract for the

--- a/apps/api/src/services/commandQueue.ts
+++ b/apps/api/src/services/commandQueue.ts
@@ -784,6 +784,29 @@ export interface ExecuteCommandOptions {
   timeoutMs?: number;
   preferHeartbeat?: boolean;
   /**
+   * The organization the caller made its dispatch decision under. When set,
+   * the precheck refuses the dispatch unless the device is STILL in that org
+   * (#5264).
+   *
+   * Why this is a parameter and not just RLS: `precheckCommandExecution`
+   * resolves the device by id alone, and `executeCommandWithSystemPrecheck`
+   * runs that read under a SYSTEM scope that bypasses RLS entirely. Any
+   * background caller holding a device id from an earlier decision — an
+   * approved intent, a queued act step, a durable Operator task — can
+   * therefore dispatch a live command to a device that has since been moved
+   * to another organization, attributed to the ORIGINAL org's agent
+   * principal. That is an active cross-tenant command dispatch, not a stale
+   * read.
+   *
+   * REQUIRED (not optional) on `executeCommandWithSystemPrecheck` — see
+   * `SystemPrecheckCommandOptions`. Optional here because `executeCommand`
+   * runs the precheck inside the caller's OWN org-scoped RLS transaction,
+   * where the `devices` SELECT already cannot see another tenant's row; the
+   * request routes get their guarantee from RLS and pass nothing. Passing it
+   * there anyway is harmless defence in depth.
+   */
+  expectedOrgId?: string;
+  /**
    * Which polling consumer on the device picks up this command.
    * - 'agent' (default): the long-lived Go agent. Has a WS connection, so
    *   executeCommand dispatches over WS for low latency.
@@ -801,6 +824,20 @@ export interface ExecuteCommandOptions {
    */
   targetRole?: 'agent' | 'watchdog';
 }
+
+/**
+ * `ExecuteCommandOptions` for the SYSTEM entry point, where `expectedOrgId` is
+ * mandatory rather than optional (#5264).
+ *
+ * `executeCommandWithSystemPrecheck` runs its device lookup under a scope that
+ * bypasses RLS, so nothing else in the stack can tell the caller's tenant from
+ * anyone else's. Requiring the field at the type level makes the omission a
+ * compile error at the call site rather than a silent cross-tenant dispatch in
+ * production — the same reason the RLS contract tests exist rather than a
+ * review checklist.
+ */
+export type SystemPrecheckCommandOptions =
+  Omit<ExecuteCommandOptions, 'expectedOrgId'> & { expectedOrgId: string };
 
 /**
  * Watchdog-targeted commands have no WS consumer; the WS pre-check and the
@@ -845,6 +882,14 @@ type CommandPrecheckOutcome =
  * `executeCommandWithSystemPrecheck` to get a short system context that closes
  * before anything waits on the device.
  *
+ * THE DEVICE LOOKUP IS NOT SELF-TENANTING (#5264). It is
+ * `WHERE devices.id = $1` with no org predicate, so its isolation comes
+ * ENTIRELY from the ambient RLS context — which is exactly what the system
+ * path does not have. `options.expectedOrgId` closes that: when the caller
+ * says which org it decided under, a device that has since moved refuses the
+ * dispatch here, before any `device_commands` row exists. The system entry
+ * point makes it mandatory; see `SystemPrecheckCommandOptions`.
+ *
  * Every terminal `CommandResult` returned here predates the row, so none of
  * them carries a `commandId` — that preserves the "commandId present ⇔ row
  * exists" contract the dispatch phase relies on.
@@ -858,7 +903,9 @@ async function precheckCommandExecution(
   const targetRole = options.targetRole ?? 'agent';
   const dispatchViaWs = dispatchesViaWs(options);
 
-  // 1. Verify device inside the caller's transaction (RLS-protected).
+  // 1. Verify device inside the caller's transaction (RLS-protected ONLY when
+  // the caller holds a tenant-scoped context — see the header note on #5264
+  // and the explicit `expectedOrgId` gate immediately after this SELECT).
   // agentEdition/agentVersion/watchdogVersion feed the artifact-edition gate
   // below (#4093) — cheap here because this SELECT already runs.
   const [device] = await db
@@ -878,6 +925,36 @@ async function precheckCommandExecution(
     .limit(1);
 
   if (!device) {
+    return { ok: false, result: { status: 'failed', error: 'Device not found' } };
+  }
+
+  // #5264 — fail-closed tenancy gate. The SELECT above has no org predicate,
+  // and under the system scope RLS is not filtering it either, so this is the
+  // ONLY thing standing between a device that moved organizations and a live
+  // command dispatched into its new tenant under the old tenant's principal.
+  // It runs FIRST — before trust, edition and liveness — because none of those
+  // gates mean anything once the device is known to be the wrong tenant's, and
+  // because their refusal strings would otherwise leak that a device with this
+  // id exists and what state it is in.
+  if (options.expectedOrgId !== undefined && device.orgId !== options.expectedOrgId) {
+    // The deviceId and the two org ids are attribution, so they ride the log
+    // line, not the Sentry event: a device id never belongs in a tag, and the
+    // event's job is only to alert that the class occurred at all.
+    console.error(
+      '[commandQueue] refusing dispatch: device is no longer in the deciding organization (#5264)',
+      { deviceId, type, expectedOrgId: options.expectedOrgId, actualOrgId: device.orgId },
+    );
+    captureMessage(
+      '[commandQueue] command dispatch refused: device left the deciding organization between '
+        + 'decision and dispatch (#5264)',
+      { eventCode: 'command_dispatch_cross_tenant_refused', tags: { org_id: options.expectedOrgId } },
+    );
+    // Deliberately indistinguishable from a genuine miss — byte-identical to
+    // the sibling gate on the QUEUE lane (`dispatchDeviceCommand.ts`, which
+    // has carried this same `expectedOrgId` contract for the
+    // `queueCommandForExecution` callers). The two are one contract: a caller
+    // holding a device id it no longer has any claim to must not learn from
+    // the error string that the device still exists somewhere.
     return { ok: false, result: { status: 'failed', error: 'Device not found' } };
   }
 
@@ -1271,6 +1348,13 @@ function reportHeldContextDispatch(
  * that context itself and call `executeCommand` — but see the note there
  * about how long it will then hold a connection.
  *
+ * BECAUSE the scope is system, the precheck's `devices` read is not filtered
+ * by RLS at all, so `options.expectedOrgId` is MANDATORY here (#5264): every
+ * caller must name the organization it made the dispatch decision under, and
+ * a device that has moved since then is refused. It is a required parameter
+ * rather than a lint rule so that adding a new background dispatch site
+ * cannot compile without answering the question.
+ *
  * PRECONDITION: no ambient DB access context. It is reported (not thrown) when
  * broken, because from inside someone else's transaction the no-held-context
  * promise is unrecoverable — see the guard below.
@@ -1279,7 +1363,7 @@ export async function executeCommandWithSystemPrecheck(
   deviceId: string,
   type: CommandType | string,
   payload: CommandPayload = {},
-  options: ExecuteCommandOptions = {}
+  options: SystemPrecheckCommandOptions,
 ): Promise<CommandResult> {
   const ambient = getCurrentDbAccessContext();
   if (ambient) {

--- a/apps/api/src/services/sentryEventCodes.ts
+++ b/apps/api/src/services/sentryEventCodes.ts
@@ -217,6 +217,15 @@ export const SENTRY_EVENT_CODES = [
    *  partner row was readable — the recipient got English. A steady stream
    *  for one partner means misconfiguration or an RLS-invisible row. */
   'recipient_locale_unresolved',
+
+  // --- command dispatch tenancy (#5264) ---------------------------------
+  /** A background caller asked to dispatch a device command under an org the
+   *  device is no longer in — the device moved tenants between the decision
+   *  and the dispatch. The command was REFUSED before any `device_commands`
+   *  row existed, so this is a blocked attempt, not a leak. Any occurrence
+   *  is worth a look: either a real org move raced a queued act/task (benign
+   *  but should be rare), or a caller is threading the wrong org. */
+  'command_dispatch_cross_tenant_refused',
 ] as const;
 
 /**


### PR DESCRIPTION
Closes #5264

## The bug

`precheckCommandExecution` (`apps/api/src/services/commandQueue.ts`) resolved the device with `WHERE devices.id = $1` and **no org predicate**. Its isolation came entirely from the ambient RLS context — and `executeCommandWithSystemPrecheck` runs that read under a **system scope where RLS filters nothing**. A background caller holding a device id from an earlier decision could therefore dispatch a live command to a device that had since moved to another organization, under the original org's agent principal. The header comment called the read "RLS-protected", which was true only of the request paths it was written for.

## The fix

`ExecuteCommandOptions.expectedOrgId` — the org the caller made its dispatch decision under. When set, the precheck refuses unless the device is still in that org:

- **Fails closed, and first.** The gate runs before the trust, artifact-edition and liveness gates: none of those mean anything once the device is known to be the wrong tenant's, and their refusal strings would otherwise leak that the id resolves and what state the device is in.
- **Refused before the row exists.** No `device_commands` insert, no `commandId`, no WS send.
- **Never leaks existence.** Reported as `Device not found` — byte-identical to the sibling `expectedOrgId` gate that already guards the *queue* lane in `services/dispatchDeviceCommand.ts`. The two are now visibly one contract.
- **Mandatory on the system entry point.** `executeCommandWithSystemPrecheck` takes a new `SystemPrecheckCommandOptions` (`expectedOrgId: string`, required). A new background dispatch site cannot compile without answering the question — `tsc`, not review, is what enforces it. It stays optional on `executeCommand`, which runs its precheck inside the caller's own org-scoped RLS transaction where the SELECT already cannot see another tenant's row.
- Header comment corrected. New registered Sentry event code `command_dispatch_cross_tenant_refused`; the only tag is the allowlisted snake_case `org_id`. The device id and the actual org ride the `console.error` line, never a tag.

## Caller sweep

`git grep -n precheckCommandExecution apps/api/src` reaches it via exactly two entry points. Every call site, and what it now passes:

| Entry point | Call site | Scope at the device read | `expectedOrgId` now passed |
|---|---|---|---|
| `executeCommandWithSystemPrecheck` | `services/aiAgents/actVerify.ts` — `verifyServiceRunning` | **system (RLS off)** | `run.orgId` |
| `executeCommandWithSystemPrecheck` | `services/aiAgents/actVerify.ts` — `verifyProcessAbsent` | **system (RLS off)** | `run.orgId` |
| `executeCommandWithSystemPrecheck` | `services/aiAgents/playbookActExecutor.ts` — `readServiceStatus` (via the injected `deps.executeCommandFn`) | **system (RLS off)** | `run.orgId` |
| `executeCommandWithSystemPrecheck` | `services/aiAgents/actVerify.ts` — `verifyServiceRunningForTask`, the AI Operator task adapter | **system (RLS off)** | the task's real org, threaded from `aiOperator/verification.ts` (`args.orgId`) |
| `executeCommand` | ~70 request-route and AI-tool sites (`routes/systemTools/*`, `routes/backup/*`, `routes/devices/*`, `services/aiTools*`) | caller's **organization**-scoped auth transaction | nothing — RLS already filters the row; unchanged |

`playbookActExecutor.ts`'s `REAL_DEPS.executeCommandFn` is module-scope indirection with no org in scope; the only invocation of it is `readServiceStatus`, covered above. **No caller was left without an org**, so there is no "genuinely system, no org" exemption to justify.

### `verifyServiceRunningForTask` fabricated an org

Its `run` argument was `{ id: '', orgId: '', agentId: '', deviceId }`, with a comment stating the fields other than `deviceId` were read by nothing. That became false the moment the org gated the dispatch, so the adapter now takes a real `orgId` and `aiOperator/verification.ts` supplies the task's own. That file's pre-flight ownership re-check (added in #5263) is kept — it is the only place that can answer `inconclusive` with a caller-meaningful reason instead of a generic dispatch failure — but its comment no longer claims to be the only thing standing between a moved device and a cross-tenant dispatch.

### Two paths the issue named that turned out to be already covered

Traced with file:line evidence, and reported here rather than silently: **direct act execution** (`manage_services` / `manage_processes` / `kill_process` from the run loop) and **intent release** (`jobs/intentReleaseWorker.ts`) both reach `executeCommand`, not the system entry point, and both hold an **organization**-scoped context at the device read — `dbAccessContextFromAuth(buildAgentAuthContext(...))` with `orgId: run.orgId` (`services/aiAgentSdkTools.ts`), and `withAuthDbAccessContext(buildAuthContextForIntent(intent))` with `orgId: intent.orgId` (`jobs/intentReleaseWorker.ts`) respectively. RLS filters those reads today, so this PR does not change them. The act-lane exposure was real but sat in the **verify** half (the three system-precheck sites above), not the execute half. **No tenancy was widened anywhere.**

## Tests

Both layers are **mutation-verified** — removing the `expectedOrgId` comparison from `precheckCommandExecution` turns them red, so neither is vacuous.

**Unit** — `services/commandQueue.dbcontext.test.ts` (existing harness; it is the only mock of the precheck's `devices` SELECT that lets the row disagree with the caller's org). Five new cases: refusal with no row/no send, refusal *before* the trust gate (an offline foreign device must not answer "Device is offline"), the Sentry event code + tag shape, a positive control that a matching org still dispatches, and a control that the request path with no `expectedOrgId` is unaffected. **15 passed**; with the guard stubbed out, **3 failed**.

**Integration** — new `src/__tests__/integration/commandDispatchOrgMove.integration.test.ts`, run against **real Postgres** (worktree-private `pnpm test-stack`, real migrations + RLS): seeds an online device, moves it to another org between decision and dispatch, and asserts the dispatch is refused with no `device_commands` row and no WS send. It also asserts the **premise** directly — that under the same system scope the id-only SELECT still returns the moved row — so the case cannot pass for the wrong reason if a future migration ever made the system scope org-filtered. Plus a positive control that an unmoved device is still admitted. **2 passed**; with the guard stubbed out, **1 failed**.

Placement verified: `src/__tests__/integration/**` is the shared glob in `vitest.integration.config.ts` (no `runIf` gate, no extra registration), so it runs in the blocking `integration-test` job.

Also green: `commandQueue.test.ts`, `aiAgents/actVerify.test.ts`, `aiAgents/playbookActExecutor*`, `aiOperator/verification.test.ts`, `sentry.test.ts`, `sentryEventCodes.test.ts` (146+ tests), and the two AI-Operator integration suites (`aiOperatorServiceRecoveryE2E`, `aiOperatorCoordinator`, 24 tests) against the live DB. `tsc --noEmit` clean on `apps/api`.

No schema change, no migration, no new table — nothing for the RLS-coverage, cascade or export-policy registries.

## Follow-up not done here

`dispatchDeviceCommand.ts`'s equivalent refusal is silent — no Sentry event. Adding the same `command_dispatch_cross_tenant_refused` capture there would make both lanes observable under one code; left out to keep this PR to the reported path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEX58GdCWkLHA9M8nfataF