### PR TITLE
fix(e2e): pin the forced-MFA relief valve off for wt-stack and diagnose login failures (#5266)

### DIFF
--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -143,21 +143,36 @@ Set in the parent `.env` file. Playwright reads via `process.env`:
 | `E2E_LINUX_DEVICE_ID` | Enrolled Linux device UUID |
 | `REDIS_PASSWORD` | Used by globalSetup to clear login rate-limit |
 
-### Seeded admin and forced MFA (RMM-QA-164)
+### Seeded admin and forced MFA (RMM-QA-164 / #5266)
 
-A fresh stack seeds the system Partner Admin role with `force_mfa = true`, but
-enforcement of that flag is gated by `MFA_FORCE_FOR_PARTNER_ADMIN`, which
-**defaults to `false`** (#4491) — so a fresh stack's `.env` (matching
-`.env.example`) does NOT hit the 428 wall below unless you've explicitly set
-that var to `true`. If you have set it to `true`, the seeded
-`admin@breeze.local` (or your `BREEZE_BOOTSTRAP_ADMIN_EMAIL`) is minted
-`mfa: false` and receives `428 mfa_enrollment_required` on the first protected
-request — `globalSetup`'s login lands on `/auth/mfa/setup?forced=1` instead of
-the dashboard. Pick one before running the suite:
+A fresh stack seeds the system Partner Admin role with `force_mfa = true`
+(#4491), and the seeded `admin@breeze.local` (or your
+`BREEZE_BOOTSTRAP_ADMIN_EMAIL`) holds that role. When enforcement is on, that
+admin is minted `mfa: false` and receives `428 mfa_enrollment_required` on the
+first protected request — `globalSetup`'s login lands on
+`/auth/mfa/setup?forced=1` instead of the dashboard, the shared storage state is
+never written, and every spec fails before it starts.
 
-- enrol TOTP for that admin once (Settings → Security → Two-factor), or
-- unset (or set back to `false`) `MFA_FORCE_FOR_PARTNER_ADMIN` in the stack's
-  `.env` (it suppresses only the role-force component) and restart `api`.
+Enforcement is gated by the API's `MFA_FORCE_FOR_PARTNER_ADMIN` flag. **Do not
+rely on its shipping default**: it was `true` until #5307, is `false` for this
+release only, and returns to `true` once #5306 (the grace-window feature) lands.
+The stack must pin it explicitly.
+
+- **`pnpm wt-stack up` pins it for you.** `scripts/dev/wt-stack/env.ts` writes
+  `MFA_FORCE_FOR_PARTNER_ADMIN=false` into the generated `.env.stack`, which
+  compose loads *after* your root `.env`, so it wins even if your `.env` sets the
+  var. Nothing to do. (The `portal-dev-e2e` CI job writes the same value into its
+  own `.env`.)
+- **Any other stack** (a hand-rolled `docker compose -f docker-compose.yml -f
+  docker-compose.override.yml.dev up`) is governed by your root `.env` and the
+  shipping default. Set `MFA_FORCE_FOR_PARTNER_ADMIN=false` there and restart
+  `api`, or enrol TOTP for that admin once (Settings → Security → Two-factor).
+
+The flag suppresses **only** the role-force component; an org's or partner's
+`security.requireMfa` setting is still enforced, so MFA-policy specs keep
+working. Nothing here changes the stored `force_mfa` flag — the Partner Admin
+posture is intact, and `globalSetup` fails fast with the remedy above rather
+than timing out if it ever lands on `/auth/mfa/setup`.
 
 ### WebAuthn specs need `PUBLIC_APP_URL` to match the browser origin
 
@@ -188,7 +203,16 @@ docker compose -f docker-compose.yml -f docker-compose.override.yml.dev up --bui
 
 ### Login 429 (rate limited)
 
-`globalSetup` already clears the rate-limit for `admin@breeze.local` on each run. If it fires anyway, your stack's redis isn't reachable from the host — confirm `breeze-redis` container is running.
+`globalSetup` clears the per-email rate-limit window before it logs in, and now
+reports a 429 as a 429 instead of letting it look like a login hang.
+
+That clear talks to redis as `redis-cli -a $REDIS_PASSWORD`, so it **silently
+no-ops when `REDIS_PASSWORD` is absent from the environment** and a stack whose
+redis requires auth rejects the `DEL` (#5266). `pnpm wt-stack test` now passes
+the value through from the stack's own env files; if you invoke `playwright
+test` directly, export `REDIS_PASSWORD` yourself. If it still fires, your
+stack's redis isn't reachable from the host — confirm the redis container is
+running.
 
 ### Selector not found
 

--- a/e2e-tests/global-setup.ts
+++ b/e2e-tests/global-setup.ts
@@ -73,6 +73,48 @@ export default async function globalSetup(config: FullConfig) {
     await page.locator('[data-testid="login-email-input"]').fill(email);
     await page.locator('[data-testid="login-password-input"]').fill(password);
     await page.locator('[data-testid="login-submit"]').click();
+
+    // #5266 — read the login response itself rather than inferring from the URL.
+    // Two stack-level conditions leave this login unusable, and neither is
+    // visible in `waitForURL('/')`, which just burns its 30s timeout (or worse,
+    // matches `/` a moment before the app bounces to the enrolment wall) and
+    // reports "Timeout 30000ms exceeded" — two fixer sessions lost a stack to
+    // exactly that. The response says which one it is, immediately.
+    let mfaEnrollmentRequired = false;
+    for (let attempt = 0; attempt < 5; attempt++) {
+      const res = await page.waitForResponse(
+        (r) => r.request().method() === 'POST' && new URL(r.url()).pathname.endsWith('/auth/login'),
+        { timeout: 30_000 }
+      );
+      if (res.status() === 429) {
+        throw new Error(
+          `[globalSetup] login as ${email} was rate limited (429). A stale per-email window ` +
+            'survived; the limiter clear above needs REDIS_PASSWORD to reach an authenticated ' +
+            'redis (`pnpm wt-stack test` passes it for you). Wait for the window to expire or ' +
+            'clear `login:*` in redis by hand, then re-run.'
+        );
+      }
+      // 428 auth_binding_rotation_required: the app rotates and re-POSTs.
+      if (res.status() === 428) continue;
+      const body = (await res.json().catch(() => null)) as { mfaEnrollmentRequired?: boolean } | null;
+      mfaEnrollmentRequired = body?.mfaEnrollmentRequired === true;
+      break;
+    }
+    if (mfaEnrollmentRequired) {
+      // The seeded admin holds the system Partner Admin role, which stores
+      // `force_mfa = true` (#4491). With enforcement on, it is minted
+      // `mfa: false`, every protected request answers 428
+      // `mfa_enrollment_required`, and the app parks on /auth/mfa/setup.
+      throw new Error(
+        `[globalSetup] login as ${email} came back \`mfaEnrollmentRequired: true\`: this stack ` +
+          'enforces the Partner Admin force_mfa flag, so no spec can run. Set ' +
+          'MFA_FORCE_FOR_PARTNER_ADMIN=false in the stack env and restart the api container ' +
+          '(`pnpm wt-stack up` pins this for you — a stack brought up any other way does not), ' +
+          'or enrol TOTP for that account once. ' +
+          'See e2e-tests/README.md ("Seeded admin and forced MFA").'
+      );
+    }
+
     await page.waitForURL('/', { timeout: 30_000 });
     await ctx.storageState({ path: STORAGE_STATE });
   } finally {

--- a/e2e-tests/global-setup.ts
+++ b/e2e-tests/global-setup.ts
@@ -69,49 +69,99 @@ export default async function globalSetup(config: FullConfig) {
   const ctx = await browser.newContext({ baseURL });
   const page = await ctx.newPage();
   try {
+    // #5266 — read the login RESPONSE rather than inferring from the URL.
+    // Several stack-level conditions leave this login unusable, and every one of
+    // them previously surfaced only as `Timeout 30000ms exceeded` from
+    // `waitForURL('/')` — two fixer sessions lost a stack to exactly that. The
+    // URL is also racy: the app can touch `/` a moment before it bounces to
+    // /auth/mfa/setup, so a URL check can capture a storage state that then 428s
+    // inside every spec.
+    //
+    // The collector is attached BEFORE the click (and before the goto): an
+    // `await page.waitForResponse(...)` registered afterwards cannot see a
+    // response that already arrived — on loopback that race is real — and the
+    // app's own 428 re-POST would be just as easy to miss between iterations.
+    type LoginResponse = { status: number; text: string };
+    const loginResponses: Promise<LoginResponse>[] = [];
+    page.on('response', (res) => {
+      if (res.request().method() !== 'POST') return;
+      if (!new URL(res.url()).pathname.endsWith('/auth/login')) return;
+      loginResponses.push(
+        res.text().then(
+          (text) => ({ status: res.status(), text }),
+          () => ({ status: res.status(), text: '' })
+        )
+      );
+    });
+
     await page.goto('/login');
     await page.locator('[data-testid="login-email-input"]').fill(email);
     await page.locator('[data-testid="login-password-input"]').fill(password);
     await page.locator('[data-testid="login-submit"]').click();
 
-    // #5266 — read the login response itself rather than inferring from the URL.
-    // Two stack-level conditions leave this login unusable, and neither is
-    // visible in `waitForURL('/')`, which just burns its 30s timeout (or worse,
-    // matches `/` a moment before the app bounces to the enrolment wall) and
-    // reports "Timeout 30000ms exceeded" — two fixer sessions lost a stack to
-    // exactly that. The response says which one it is, immediately.
-    let mfaEnrollmentRequired = false;
-    for (let attempt = 0; attempt < 5; attempt++) {
-      const res = await page.waitForResponse(
-        (r) => r.request().method() === 'POST' && new URL(r.url()).pathname.endsWith('/auth/login'),
-        { timeout: 30_000 }
-      );
-      if (res.status() === 429) {
-        throw new Error(
-          `[globalSetup] login as ${email} was rate limited (429). A stale per-email window ` +
-            'survived; the limiter clear above needs REDIS_PASSWORD to reach an authenticated ' +
-            'redis (`pnpm wt-stack test` passes it for you). Wait for the window to expire or ' +
-            'clear `login:*` in redis by hand, then re-run.'
-        );
+    // 428 auth_binding_rotation_required is not terminal: the app rotates its
+    // binding and re-POSTs. Anything else is the answer we act on.
+    const deadline = Date.now() + 30_000;
+    let consumed = 0;
+    let settled: LoginResponse | undefined;
+    while (!settled && Date.now() < deadline) {
+      while (consumed < loginResponses.length) {
+        const res = await loginResponses[consumed++];
+        if (res.status !== 428) {
+          settled = res;
+          break;
+        }
       }
-      // 428 auth_binding_rotation_required: the app rotates and re-POSTs.
-      if (res.status() === 428) continue;
-      const body = (await res.json().catch(() => null)) as { mfaEnrollmentRequired?: boolean } | null;
-      mfaEnrollmentRequired = body?.mfaEnrollmentRequired === true;
-      break;
+      if (!settled) await page.waitForTimeout(200);
     }
-    if (mfaEnrollmentRequired) {
+
+    const remedy =
+      'Set MFA_FORCE_FOR_PARTNER_ADMIN=false in the stack env and restart the api container ' +
+      '(`pnpm wt-stack up` pins this for you — a stack brought up any other way does not), ' +
+      'or enrol TOTP for that account once. ' +
+      'See e2e-tests/README.md ("Seeded admin and forced MFA").';
+
+    if (!settled) {
+      throw new Error(
+        `[globalSetup] no usable POST /auth/login response for ${email} within 30s ` +
+          `(${loginResponses.length} seen; any that arrived were 428 auth_binding_rotation_required, ` +
+          'i.e. the client and server auth epochs never converged). The login never completed, so ' +
+          'no storage state can be written.'
+      );
+    }
+    if (settled.status === 429) {
+      throw new Error(
+        `[globalSetup] login as ${email} was rate limited (429). A stale per-email window ` +
+          'survived: the limiter clear above needs REDIS_PASSWORD to reach an authenticated redis ' +
+          '(`pnpm wt-stack test` passes it for you). Wait for the window to expire or clear ' +
+          '`login:*` in redis by hand, then re-run.'
+      );
+    }
+    if (settled.status >= 400) {
+      throw new Error(
+        `[globalSetup] login as ${email} failed with HTTP ${settled.status}: ` +
+          `${settled.text.slice(0, 300) || '<empty body>'}`
+      );
+    }
+    let body: { mfaEnrollmentRequired?: boolean };
+    try {
+      body = JSON.parse(settled.text) as { mfaEnrollmentRequired?: boolean };
+    } catch {
+      // Never silently treat an unreadable body as "no MFA required" — that
+      // lands back on the generic navigation timeout this block replaces.
+      throw new Error(
+        `[globalSetup] login as ${email} returned an unparseable body (HTTP ${settled.status}): ` +
+          `${settled.text.slice(0, 300) || '<empty body>'}`
+      );
+    }
+    if (body.mfaEnrollmentRequired === true) {
       // The seeded admin holds the system Partner Admin role, which stores
-      // `force_mfa = true` (#4491). With enforcement on, it is minted
+      // `force_mfa = true` (#4491). With enforcement on it is minted
       // `mfa: false`, every protected request answers 428
       // `mfa_enrollment_required`, and the app parks on /auth/mfa/setup.
       throw new Error(
         `[globalSetup] login as ${email} came back \`mfaEnrollmentRequired: true\`: this stack ` +
-          'enforces the Partner Admin force_mfa flag, so no spec can run. Set ' +
-          'MFA_FORCE_FOR_PARTNER_ADMIN=false in the stack env and restart the api container ' +
-          '(`pnpm wt-stack up` pins this for you — a stack brought up any other way does not), ' +
-          'or enrol TOTP for that account once. ' +
-          'See e2e-tests/README.md ("Seeded admin and forced MFA").'
+          `enforces the Partner Admin force_mfa flag, so no spec can run. ${remedy}`
       );
     }
 

--- a/scripts/dev/wt-stack/cli.ts
+++ b/scripts/dev/wt-stack/cli.ts
@@ -2,7 +2,7 @@
 import { execFileSync } from 'node:child_process';
 import { deriveProjectName, descriptorPath } from './project';
 import { writeDescriptor, readDescriptor, type StackDescriptor } from './descriptor';
-import { writeEnvStack } from './env';
+import { writeEnvStack, readStackEnvValue } from './env';
 import { composeUp, waitHealthy, publishedPort, containerName, seedDatabase, composeDown } from './compose';
 
 const ADMIN = { email: 'admin@breeze.local', password: 'BreezeAdmin123!' };
@@ -65,6 +65,11 @@ function test(passthrough: string[]): void {
       E2E_BASE_URL: d.baseUrl,
       E2E_ADMIN_EMAIL: d.admin.email,
       E2E_ADMIN_PASSWORD: d.admin.password,
+      // #5266 — globalSetup clears the login rate limiter with
+      // `redis-cli -a $REDIS_PASSWORD`; this stack's redis requires auth, so
+      // without this the clear silently no-ops and a stale window 429s the one
+      // login the whole suite depends on.
+      REDIS_PASSWORD: process.env.REDIS_PASSWORD ?? readStackEnvValue(worktreePath, 'REDIS_PASSWORD') ?? '',
     },
   });
 }

--- a/scripts/dev/wt-stack/cli.ts
+++ b/scripts/dev/wt-stack/cli.ts
@@ -56,6 +56,22 @@ function down(keepVolumes: boolean): void {
 function test(passthrough: string[]): void {
   const worktreePath = process.cwd();
   const d = readDescriptor(worktreePath); // throws clear error if not up
+  // #5266 — globalSetup clears the login rate limiter with
+  // `redis-cli -a $REDIS_PASSWORD`; this stack's redis requires auth, so an
+  // absent value makes that clear silently no-op and 429s the one login the
+  // whole suite depends on. The stack is already up here, and compose refuses
+  // to boot redis without a password, so a miss means a lookup bug — say so
+  // rather than passing '' and reproducing the defect one layer down.
+  const redisPassword =
+    process.env.REDIS_PASSWORD ?? readStackEnvValue(worktreePath, 'REDIS_PASSWORD');
+  if (!redisPassword) {
+    throw new Error(
+      '[wt-stack test] REDIS_PASSWORD is not in the environment, .env or .env.stack, yet the ' +
+        "stack is up — so it can't legitimately be missing. globalSetup's login rate-limit " +
+        'clear would silently no-op and 429 the suite. Restore the value (or re-run ' +
+        '`wt-stack up`) before testing.'
+    );
+  }
   execFileSync('npx', ['playwright', 'test', ...passthrough], {
     cwd: `${worktreePath}/e2e-tests`,
     stdio: 'inherit',
@@ -65,11 +81,7 @@ function test(passthrough: string[]): void {
       E2E_BASE_URL: d.baseUrl,
       E2E_ADMIN_EMAIL: d.admin.email,
       E2E_ADMIN_PASSWORD: d.admin.password,
-      // #5266 — globalSetup clears the login rate limiter with
-      // `redis-cli -a $REDIS_PASSWORD`; this stack's redis requires auth, so
-      // without this the clear silently no-ops and a stale window 429s the one
-      // login the whole suite depends on.
-      REDIS_PASSWORD: process.env.REDIS_PASSWORD ?? readStackEnvValue(worktreePath, 'REDIS_PASSWORD') ?? '',
+      REDIS_PASSWORD: redisPassword,
     },
   });
 }

--- a/scripts/dev/wt-stack/env.test.ts
+++ b/scripts/dev/wt-stack/env.test.ts
@@ -49,6 +49,17 @@ describe('readStackEnvValue', () => {
     expect(readStackEnvValue(dir, 'REDIS_PASSWORD')).toBe('quoted pw');
   });
 
+  it('strips a trailing inline comment from an unquoted value but not from a quoted one', () => {
+    writeFileSync(
+      path.join(dir, '.env'),
+      'REDIS_PASSWORD=plain-pw   # the redis password\nHASHY="pw # not a comment"\nNOSPACE=a#b\n'
+    );
+    expect(readStackEnvValue(dir, 'REDIS_PASSWORD')).toBe('plain-pw');
+    expect(readStackEnvValue(dir, 'HASHY')).toBe('pw # not a comment');
+    // No preceding whitespace — compose treats this as part of the value.
+    expect(readStackEnvValue(dir, 'NOSPACE')).toBe('a#b');
+  });
+
   it('returns undefined for a missing key, a commented-out key, and a missing file', () => {
     writeFileSync(path.join(dir, '.env'), '# REDIS_PASSWORD=commented\n');
     expect(readStackEnvValue(dir, 'REDIS_PASSWORD')).toBeUndefined();

--- a/scripts/dev/wt-stack/env.test.ts
+++ b/scripts/dev/wt-stack/env.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, readFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { writeEnvStack } from './env';
+import { writeEnvStack, readStackEnvValue } from './env';
 
 let dir: string;
 beforeEach(() => { dir = mkdtempSync(path.join(tmpdir(), 'wt-')); });
@@ -20,5 +20,38 @@ describe('writeEnvStack', () => {
     }
     expect(env).toContain('CADDY_SITE_ADDRESS=:80');
     expect(env).toContain('IS_HOSTED=false');
+  });
+
+  // #5266 — the seeded system Partner Admin role stores force_mfa=true, so a
+  // stack that lets the API's own default decide bounces the seeded
+  // admin@breeze.local login to /auth/mfa/setup and every Playwright spec dies
+  // in globalSetup. The stack pins the relief valve OFF so the dev stack does
+  // not follow the shipping default (which flips back ON once #5306 lands).
+  it('pins the partner-admin forced-MFA relief valve off for the dev stack', () => {
+    const env = readFileSync(writeEnvStack(dir), 'utf8');
+    expect(env).toContain('MFA_FORCE_FOR_PARTNER_ADMIN=false');
+  });
+});
+
+// #5266 — `wt-stack test` reads REDIS_PASSWORD this way to hand it to
+// Playwright's globalSetup, which needs it to clear the login rate limiter.
+describe('readStackEnvValue', () => {
+  it('resolves the way compose does: .env.stack overrides .env', () => {
+    writeFileSync(path.join(dir, '.env'), 'REDIS_PASSWORD=from-root\nOTHER=x\n');
+    writeFileSync(path.join(dir, '.env.stack'), 'REDIS_PASSWORD=from-stack\n');
+    expect(readStackEnvValue(dir, 'REDIS_PASSWORD')).toBe('from-stack');
+    expect(readStackEnvValue(dir, 'OTHER')).toBe('x');
+  });
+
+  it('falls back to .env when the key is only there, and strips quotes', () => {
+    writeFileSync(path.join(dir, '.env'), 'REDIS_PASSWORD="quoted pw"\n');
+    writeFileSync(path.join(dir, '.env.stack'), 'UNRELATED=1\n');
+    expect(readStackEnvValue(dir, 'REDIS_PASSWORD')).toBe('quoted pw');
+  });
+
+  it('returns undefined for a missing key, a commented-out key, and a missing file', () => {
+    writeFileSync(path.join(dir, '.env'), '# REDIS_PASSWORD=commented\n');
+    expect(readStackEnvValue(dir, 'REDIS_PASSWORD')).toBeUndefined();
+    expect(readStackEnvValue(dir, 'NOPE')).toBeUndefined();
   });
 });

--- a/scripts/dev/wt-stack/env.ts
+++ b/scripts/dev/wt-stack/env.ts
@@ -1,4 +1,5 @@
-import { writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
 import { envStackPath } from './project';
 
 /** Deterministic dev defaults — NOT secrets, local-only. Keeps a fresh worktree
@@ -23,6 +24,20 @@ const DEV_ENV: Record<string, string> = {
   EVENT_PERMISSION_EPOCH_MODE: 'compat',
   REMOTE_WS_AUTH_MODE: 'post_upgrade',
   REMOTE_WS_REDIS_TOPOLOGY: 'standalone-single-primary',
+  // #5266 — the seeded system Partner Admin role stores `force_mfa = true`
+  // (#4491), and this stack's only login is the bootstrap `admin@breeze.local`,
+  // which holds that role. If enforcement is left to the API's shipping default
+  // that admin is minted `mfa: false`, gets `428 mfa_enrollment_required` on its
+  // first protected request, and Playwright's globalSetup lands on
+  // /auth/mfa/setup instead of the dashboard — every spec then dies before it
+  // runs. Pin the relief valve OFF here so the dev stack is deterministic
+  // regardless of the shipping default (off this release, back ON once #5306's
+  // grace-window feature lands) and regardless of what the developer's root
+  // .env says — .env.stack is passed LAST, so it wins. This mirrors what the
+  // portal-dev-e2e CI job already writes into its own .env. It suppresses only
+  // the role-force component; settings-driven `security.requireMfa` still
+  // applies, so MFA-policy specs are unaffected.
+  MFA_FORCE_FOR_PARTNER_ADMIN: 'false',
   // Caddy/postgres/redis images are digest-pinned in base compose; reuse the
   // values already present in the developer's root .env via compose interpolation.
 };
@@ -32,4 +47,28 @@ export function writeEnvStack(worktreePath: string): string {
   const body = Object.entries(DEV_ENV).map(([k, v]) => `${k}=${v}`).join('\n') + '\n';
   writeFileSync(p, body, 'utf8');
   return p;
+}
+
+/**
+ * #5266 — read a value the way compose resolves it for this stack:
+ * `--env-file .env --env-file .env.stack`, later file wins.
+ *
+ * Host-side tooling needs a few of these. `wt-stack test` has to hand
+ * `REDIS_PASSWORD` to Playwright, because `e2e-tests/global-setup.ts` clears the
+ * per-email login rate limiter with `redis-cli -a $REDIS_PASSWORD` and this
+ * stack's redis requires auth — without it the DEL is rejected, a stale window
+ * survives, and the one login globalSetup gets is answered `429 Too many login
+ * attempts`, killing every spec exactly as the forced-MFA wall does.
+ */
+export function readStackEnvValue(worktreePath: string, key: string): string | undefined {
+  let found: string | undefined;
+  for (const file of ['.env', '.env.stack']) {
+    const p = path.join(worktreePath, file);
+    if (!existsSync(p)) continue;
+    for (const line of readFileSync(p, 'utf8').split('\n')) {
+      const m = /^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*?)\s*$/.exec(line);
+      if (m?.[1] === key) found = m[2].replace(/^(["'])(.*)\1$/, '$2');
+    }
+  }
+  return found;
 }

--- a/scripts/dev/wt-stack/env.ts
+++ b/scripts/dev/wt-stack/env.ts
@@ -67,7 +67,14 @@ export function readStackEnvValue(worktreePath: string, key: string): string | u
     if (!existsSync(p)) continue;
     for (const line of readFileSync(p, 'utf8').split('\n')) {
       const m = /^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*?)\s*$/.exec(line);
-      if (m?.[1] === key) found = m[2].replace(/^(["'])(.*)\1$/, '$2');
+      if (m?.[1] !== key) continue;
+      const raw = m[2];
+      const quoted = /^(["'])(.*)\1$/.exec(raw);
+      // A quoted value keeps everything inside the quotes; an unquoted one ends
+      // at a whitespace-preceded `#`, the way compose's dotenv parser reads it.
+      // `.env.example` puts trailing comments on values all over the place, so
+      // not stripping them here would hand back e.g. `pw   # the redis password`.
+      found = quoted ? quoted[2] : raw.replace(/\s+#.*$/, '').trimEnd();
     }
   }
   return found;


### PR DESCRIPTION
Closes #5266

## Premise check first: the README was wrong, not the stack

The issue and `e2e-tests/README.md` both said enforcement of the seeded Partner
Admin's `force_mfa` flag is gated by `MFA_FORCE_FOR_PARTNER_ADMIN`, which
"**defaults to `false`** (#4491)". It did not. `mfaForcePartnerAdmin()`
(`apps/api/src/config/env.ts`) was `envFlag('MFA_FORCE_FOR_PARTNER_ADMIN', true)`
until **#5307 flipped it to `false` on 2026-09-09 00:38Z** — the day *after* the
two fixer sessions were bounced. The README documented #4491's intent, not the
shipped code.

**Root cause of the bounce, then:** the wt-stack left enforcement to the API's
shipping default, and that default was ON. Nothing leaked in from a copied
prod-shaped `.env` — `scripts/dev/wt-stack/env.ts` never wrote the var at all,
and the operator's root `.env` does not set it. The `portal-dev-e2e` CI job has
always written `MFA_FORCE_FOR_PARTNER_ADMIN=false` into its own `.env`
(`ci.yml`), which is exactly why CI never hit this and local stacks did.

That also means "it works today" is not a fix: #5307's `false` is explicitly for
this release only, and the default returns to ON once #5306 (the grace-window
feature) ships. The stack has to pin it.

## What changed

**1. `scripts/dev/wt-stack/env.ts` — pin the valve off in the generated `.env.stack`.**
Compose is invoked `--env-file .env --env-file .env.stack`, later file wins, so
this beats both the API default and anything the developer's root `.env` says.
Chosen over the issue's "seed a dedicated e2e login user": the cause is the env
default, not the seeded user's role, and a second always-present privileged
account (with a password hash baked into `seed-fixtures.sql`) would be new
surface for no gain. **The stored `force_mfa = true` is untouched — the Partner
Admin posture is intact**, and the valve suppresses only the role-force
component, so settings-driven `security.requireMfa` still applies.

**2. `e2e-tests/global-setup.ts` — read the login RESPONSE, not the URL.**
Two stack-level conditions leave this login unusable, and both previously
surfaced only as `Timeout 30000ms exceeded` from `waitForURL('/')`:
`mfaEnrollmentRequired: true`, and a `429`. The URL is also *racy* — the app can
touch `/` a moment before bouncing to `/auth/mfa/setup`, so a URL-based check
silently captured a storage state that then 428s inside the specs (observed
live). Each condition now throws in about a second with the remedy. The loop
tolerates the app's `428 auth_binding_rotation_required` re-POST.

**3. `scripts/dev/wt-stack/{cli,env}.ts` — pass `REDIS_PASSWORD` to Playwright.**
Found while verifying: globalSetup clears the per-email rate limiter with
`redis-cli -a $REDIS_PASSWORD`, but `wt-stack test` never put that value in the
child env and the stack's redis requires auth — so the `DEL` was **silently
rejected**, a stale window survived, and the single login the whole suite depends
on came back `429`. Just as fatal as the MFA wall, and it masked my first repro.
`readStackEnvValue()` resolves it with compose's own precedence.

**4. `e2e-tests/README.md`** — correct the "defaults to false" claim, state which
stacks pin the valve and which do not, and document the 429/`REDIS_PASSWORD` trap.

## Verification — what actually ran

Live, on a real `pnpm wt-stack up` stack (project
`breeze-wt-fix-5266-e2e-mfa-login`), with the root `.env` deliberately carrying
`MFA_FORCE_FOR_PARTNER_ADMIN=true` to prove precedence:

| Check | Result |
|---|---|
| `docker compose config` resolved api env | `MFA_FORCE_FOR_PARTNER_ADMIN: "false"` — `.env.stack` beats root `.env` |
| stored role flag | `Partner Admin \| partner \| t` — posture intact |
| `POST /api/v1/auth/login` | `mfaEnrollmentRequired: false` |
| `wt-stack test -- tests/dashboard.spec.ts` | **3 passed** (globalSetup wrote storage state) |
| valve forced back ON, api restarted | login → `mfaEnrollmentRequired: true`; browser parks on `/auth/mfa/setup?forced=1` |
| same run, with the fix | globalSetup fails in ~1s with the new actionable error, not a 30s timeout |
| valve restored to `false` | **3 passed** again |
| rate-limit clear, before fix | verified silently no-op → `429 Too many login attempts` on the browser login |

Stack torn down afterwards (`docker compose ls -a` confirms it is gone).

Red-first: the new `env.test.ts` assertion failed on unfixed code
(`expect(env).toContain('MFA_FORCE_FOR_PARTNER_ADMIN=false')`) before the
one-line addition to `DEV_ENV`.

- `pnpm test:dev-scripts` — **27 passed / 6 files** (was 24; +1 valve assertion, +3 `readStackEnvValue`).
- `npx tsc --noEmit -p e2e-tests/tsconfig.json` — 0 errors in `global-setup.ts`. One pre-existing, unrelated error remains in `tests/ai-agents.spec.ts:70` (`message: () => string` where `string` is expected); untouched here.

## Not fixed / follow-ups

- The `portal-dev-e2e` CI job's own `MFA_FORCE_FOR_PARTNER_ADMIN=false` line is
  now redundant (`.env.stack` wins regardless). Left in place — harmless, and it
  documents the job's intent.
- `tests/ai-agents.spec.ts:70` typecheck error is pre-existing and out of scope.
- When #5306 lands and the API default returns to ON, nothing here needs to
  change — but any stack brought up *without* `wt-stack` will need
  `MFA_FORCE_FOR_PARTNER_ADMIN=false` in its `.env`, which the README now says.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEX58GdCWkLHA9M8nfataF
