### PR TITLE
fix(web): script editor custom-field help shows the stdout marker, not PATCH-via-API-key (#5233)

### DIFF
--- a/apps/docs/src/content/docs/features/custom-fields.mdx
+++ b/apps/docs/src/content/docs/features/custom-fields.mdx
@@ -220,6 +220,8 @@ Script write-back is opt-in per field definition, and off by default. Turn on **
 
 ### The marker
 
+The script editor has a **Reading and writing custom fields** panel under the code area with the same read and write summary, an example for the editor's current language, and an **Insert example** button that drops it at the cursor.
+
 Print a line to stdout in this exact form:
 
 ```

--- a/apps/web/src/components/scripts/CustomFieldHelp.test.tsx
+++ b/apps/web/src/components/scripts/CustomFieldHelp.test.tsx
@@ -42,7 +42,8 @@ describe('CustomFieldHelp (#5233)', () => {
       const snippet = customFieldExampleSnippet(lang);
       expect(snippet, lang).toContain(CUSTOM_FIELD_MARKER);
     }
-    // The bash/cmd/python forms print a literal JSON object — parse it.
+    // bash and cmd print a literal JSON object — parse it (python builds its
+    // object with json.dumps, so it is valid by construction).
     for (const lang of ['bash', 'cmd']) {
       const line = customFieldExampleSnippet(lang).split('\n').find(l => l.includes(CUSTOM_FIELD_MARKER))!;
       const json = line.slice(line.indexOf(CUSTOM_FIELD_MARKER) + CUSTOM_FIELD_MARKER.length).replace(/["']\s*$/, '').replace(/\\"/g, '"').trim();
@@ -76,6 +77,7 @@ describe('CustomFieldHelp (#5233)', () => {
     expect(editor.executeEdits).toHaveBeenCalledTimes(1);
     expect(editor.executeEdits.mock.calls[0][1][0].text).toContain(CUSTOM_FIELD_MARKER);
     expect(editor.pushUndoStop).toHaveBeenCalledTimes(2);
+    expect(editor.executeEdits.mock.calls[0][1][0].range).toEqual({ startLineNumber: 2, startColumn: 1, endLineNumber: 2, endColumn: 1 });
     expect(onInsert).toHaveBeenCalledWith('MODEL');
     expect(editor.focus).toHaveBeenCalled();
   });

--- a/apps/web/src/components/scripts/CustomFieldHelp.test.tsx
+++ b/apps/web/src/components/scripts/CustomFieldHelp.test.tsx
@@ -1,0 +1,82 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import '@/lib/i18n';
+import CustomFieldHelp, { customFieldExampleSnippet, CUSTOM_FIELD_MARKER } from './CustomFieldHelp';
+import en from '@/locales/en/scripts.json';
+
+// #5233: the script editor's only custom-field help told users to PATCH the
+// API with an API key. The supported path is the stdout marker.
+describe('CustomFieldHelp (#5233)', () => {
+  it('drops the stale PATCH-plus-API-key advice from the binding tooltip and names the env var', () => {
+    const help = en.scriptForm.parameterBinding.fieldHelp;
+    expect(help).not.toMatch(/PATCH/i);
+    expect(help).not.toMatch(/API key/i);
+    expect(help).toContain('BREEZE_PARAM_');
+    expect(help).toContain(CUSTOM_FIELD_MARKER);
+  });
+
+  it('renders the read syntax, the write marker, the secret caveat, and a docs link', () => {
+    render(<CustomFieldHelp language="powershell" editorRef={{ current: null }} content="" onInsert={vi.fn()} />);
+    fireEvent.click(screen.getByTestId('custom-field-help-toggle'));
+    const body = screen.getByTestId('custom-field-help-body');
+    expect(body.textContent).toContain('BREEZE_PARAM_');
+    expect(body.textContent).toContain(CUSTOM_FIELD_MARKER);
+    expect(body.textContent).toMatch(/never write a secret/i);
+    const link = screen.getByTestId('custom-field-help-docs') as HTMLAnchorElement;
+    expect(link.href).toContain('docs.breezermm.com/features/custom-fields/');
+  });
+
+  it('shows a snippet for the editor language and swaps it when the language changes', () => {
+    const { rerender } = render(<CustomFieldHelp language="powershell" editorRef={{ current: null }} content="" onInsert={vi.fn()} />);
+    fireEvent.click(screen.getByTestId('custom-field-help-toggle'));
+    expect(screen.getByTestId('custom-field-help-snippet').textContent).toContain('$env:BREEZE_PARAM_');
+    rerender(<CustomFieldHelp language="bash" editorRef={{ current: null }} content="" onInsert={vi.fn()} />);
+    expect(screen.getByTestId('custom-field-help-snippet').textContent).toContain('$BREEZE_PARAM_');
+    expect(screen.getByTestId('custom-field-help-snippet').textContent).not.toContain('$env:');
+    rerender(<CustomFieldHelp language="python" editorRef={{ current: null }} content="" onInsert={vi.fn()} />);
+    expect(screen.getByTestId('custom-field-help-snippet').textContent).toContain('os.environ');
+  });
+
+  it('every language snippet emits the marker with a valid JSON object', () => {
+    for (const lang of ['powershell', 'bash', 'python', 'cmd']) {
+      const snippet = customFieldExampleSnippet(lang);
+      expect(snippet, lang).toContain(CUSTOM_FIELD_MARKER);
+    }
+    // The bash/cmd/python forms print a literal JSON object — parse it.
+    for (const lang of ['bash', 'cmd']) {
+      const line = customFieldExampleSnippet(lang).split('\n').find(l => l.includes(CUSTOM_FIELD_MARKER))!;
+      const json = line.slice(line.indexOf(CUSTOM_FIELD_MARKER) + CUSTOM_FIELD_MARKER.length).replace(/["']\s*$/, '').replace(/\\"/g, '"').trim();
+      expect(() => JSON.parse(json), `${lang}: ${json}`).not.toThrow();
+    }
+  });
+
+  it('appends the example when Monaco is not mounted', () => {
+    const onInsert = vi.fn();
+    render(<CustomFieldHelp language="bash" editorRef={{ current: null }} content={'echo hi\n'} onInsert={onInsert} />);
+    fireEvent.click(screen.getByTestId('custom-field-help-toggle'));
+    fireEvent.click(screen.getByTestId('custom-field-help-insert'));
+    expect(onInsert).toHaveBeenCalledTimes(1);
+    const next = onInsert.mock.calls[0][0] as string;
+    expect(next.startsWith('echo hi\n')).toBe(true);
+    expect(next).toContain(CUSTOM_FIELD_MARKER);
+  });
+
+  it('inserts at the live selection through executeEdits when Monaco is mounted', () => {
+    const onInsert = vi.fn();
+    const editor = {
+      getSelection: vi.fn(() => ({ startLineNumber: 2, startColumn: 1, endLineNumber: 2, endColumn: 1 })),
+      pushUndoStop: vi.fn(),
+      executeEdits: vi.fn(),
+      getModel: vi.fn(() => ({ getValue: () => 'MODEL' })),
+      focus: vi.fn()
+    };
+    render(<CustomFieldHelp language="python" editorRef={{ current: editor as never }} content="" onInsert={onInsert} />);
+    fireEvent.click(screen.getByTestId('custom-field-help-toggle'));
+    fireEvent.click(screen.getByTestId('custom-field-help-insert'));
+    expect(editor.executeEdits).toHaveBeenCalledTimes(1);
+    expect(editor.executeEdits.mock.calls[0][1][0].text).toContain(CUSTOM_FIELD_MARKER);
+    expect(editor.pushUndoStop).toHaveBeenCalledTimes(2);
+    expect(onInsert).toHaveBeenCalledWith('MODEL');
+    expect(editor.focus).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/scripts/CustomFieldHelp.tsx
+++ b/apps/web/src/components/scripts/CustomFieldHelp.tsx
@@ -1,0 +1,149 @@
+import { useState } from 'react';
+import { ChevronRight, ExternalLink } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import type { EditorProps } from '@monaco-editor/react';
+import { cn } from '@/lib/utils';
+
+type EditorInstance = Parameters<NonNullable<EditorProps['onMount']>>[0];
+
+/** The stdout marker the agent extracts and the API ingests (#4678). */
+export const CUSTOM_FIELD_MARKER = '::breeze:custom-fields::';
+
+export const CUSTOM_FIELD_DOCS_URL =
+  'https://docs.breezermm.com/features/custom-fields/#writing-custom-fields-from-a-script';
+
+/**
+ * A read-then-write example for the editor's current language. Code, not
+ * copy, so it is deliberately not translated. Mirrors the three snippets in
+ * `apps/docs/.../custom-fields.mdx` and adds CMD.
+ */
+export function customFieldExampleSnippet(language: string): string {
+  switch (language) {
+    case 'powershell':
+      return [
+        '# Read: a parameter bound to custom field "asset_tag" arrives as an env var',
+        '$assetTag = $env:BREEZE_PARAM_ASSET_TAG',
+        '# Write: print the marker; the field needs "Allow scripts to write this field"',
+        "$fields = @{ ram_slot_type = 'DDR5-5600'; free_dimm_slots = 2 }",
+        `Write-Output "${CUSTOM_FIELD_MARKER} $($fields | ConvertTo-Json -Compress)"`,
+      ].join('\n');
+    case 'python':
+      return [
+        'import json, os',
+        '# Read: a parameter bound to custom field "asset_tag" arrives as an env var',
+        'asset_tag = os.environ.get("BREEZE_PARAM_ASSET_TAG")',
+        '# Write: print the marker; the field needs "Allow scripts to write this field"',
+        `print("${CUSTOM_FIELD_MARKER} " + json.dumps({"ram_slot_type": "DDR5-5600", "free_dimm_slots": 2}))`,
+      ].join('\n');
+    case 'cmd':
+      return [
+        'REM Read: a parameter bound to custom field "asset_tag" arrives as an env var',
+        'set ASSET_TAG=%BREEZE_PARAM_ASSET_TAG%',
+        'REM Write: print the marker; the field needs "Allow scripts to write this field"',
+        `echo ${CUSTOM_FIELD_MARKER} {"ram_slot_type":"DDR5-5600","free_dimm_slots":2}`,
+      ].join('\n');
+    case 'bash':
+    default:
+      return [
+        '# Read: a parameter bound to custom field "asset_tag" arrives as an env var',
+        'asset_tag="$BREEZE_PARAM_ASSET_TAG"',
+        '# Write: print the marker; the field needs "Allow scripts to write this field"',
+        `echo '${CUSTOM_FIELD_MARKER} {"ram_slot_type":"DDR5-5600","free_dimm_slots":2}'`,
+      ].join('\n');
+  }
+}
+
+interface CustomFieldHelpProps {
+  language: string;
+  editorRef: { current: EditorInstance | null };
+  content: string;
+  onInsert: (next: string) => void;
+}
+
+/**
+ * Collapsible "Reading and writing custom fields" aside under the script
+ * editor (#5233). The binding tooltip on a parameter row is the only other
+ * in-context help, and it cannot hold a snippet. Insertion goes through
+ * `executeEdits` at the live selection, the same way `ScriptVariablePicker`
+ * does, so it lands at the caret inside Monaco and is a single undo stop.
+ */
+export default function CustomFieldHelp({ language, editorRef, content, onInsert }: CustomFieldHelpProps) {
+  const { t } = useTranslation('scripts');
+  const [open, setOpen] = useState(false);
+  const snippet = customFieldExampleSnippet(language);
+
+  const insert = () => {
+    const text = `\n${snippet}\n`;
+    const editor = editorRef.current;
+    if (!editor) {
+      onInsert(content + text);
+      return;
+    }
+    const range = editor.getSelection() ?? { startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 1 };
+    editor.pushUndoStop();
+    editor.executeEdits('breeze-custom-field-help', [{ range, text, forceMoveMarkers: true }]);
+    editor.pushUndoStop();
+    const next = editor.getModel()?.getValue();
+    if (next !== undefined) onInsert(next);
+    editor.focus();
+  };
+
+  return (
+    <div className="rounded-md border text-sm" data-testid="custom-field-help">
+      <button
+        type="button"
+        data-testid="custom-field-help-toggle"
+        aria-expanded={open}
+        onClick={() => setOpen(o => !o)}
+        className="flex w-full items-center gap-1.5 px-3 py-2 text-left text-xs font-medium text-muted-foreground hover:bg-muted"
+      >
+        <ChevronRight className={cn('h-3.5 w-3.5 transition-transform', open && 'rotate-90')} />
+        {t('scriptForm.customFieldHelp.title')}
+      </button>
+      {open && (
+        <div className="space-y-2 border-t px-3 py-3" data-testid="custom-field-help-body">
+          <p>
+            <span className="font-medium">{t('scriptForm.customFieldHelp.readLabel')}</span>{' '}
+            {t('scriptForm.customFieldHelp.read')}{' '}
+            <code className="rounded bg-muted px-1">BREEZE_PARAM_&lt;KEY&gt;</code>{' '}
+            {t('scriptForm.customFieldHelp.readPlaceholders')}{' '}
+            <code className="rounded bg-muted px-1">{'{{paramName}}'}</code>.
+          </p>
+          <p>
+            <span className="font-medium">{t('scriptForm.customFieldHelp.writeLabel')}</span>{' '}
+            {t('scriptForm.customFieldHelp.write')}{' '}
+            <code className="rounded bg-muted px-1">{CUSTOM_FIELD_MARKER} {'{"key": "value"}'}</code>.{' '}
+            {t('scriptForm.customFieldHelp.writeGate')}
+          </p>
+          <p className="text-amber-700 dark:text-amber-500">{t('scriptForm.customFieldHelp.secretCaveat')}</p>
+          <pre
+            data-testid="custom-field-help-snippet"
+            className="overflow-x-auto rounded bg-muted p-2 font-mono text-xs"
+          >
+            {snippet}
+          </pre>
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              data-testid="custom-field-help-insert"
+              onClick={insert}
+              className="rounded-md border px-2.5 py-1 text-xs font-medium hover:bg-muted"
+            >
+              {t('scriptForm.customFieldHelp.insertExample')}
+            </button>
+            <a
+              href={CUSTOM_FIELD_DOCS_URL}
+              target="_blank"
+              rel="noopener"
+              data-testid="custom-field-help-docs"
+              className="inline-flex items-center gap-1 text-xs text-primary hover:underline"
+            >
+              {t('scriptForm.customFieldHelp.docsLink')}
+              <ExternalLink className="h-3 w-3" />
+            </a>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/scripts/CustomFieldHelp.tsx
+++ b/apps/web/src/components/scripts/CustomFieldHelp.tsx
@@ -21,7 +21,7 @@ export function customFieldExampleSnippet(language: string): string {
   switch (language) {
     case 'powershell':
       return [
-        '# Read: a parameter bound to custom field "asset_tag" arrives as an env var',
+        '# Read: a parameter named asset_tag (bound to a custom field) arrives as BREEZE_PARAM_<NAME>',
         '$assetTag = $env:BREEZE_PARAM_ASSET_TAG',
         '# Write: print the marker; the field needs "Allow scripts to write this field"',
         "$fields = @{ ram_slot_type = 'DDR5-5600'; free_dimm_slots = 2 }",
@@ -30,14 +30,14 @@ export function customFieldExampleSnippet(language: string): string {
     case 'python':
       return [
         'import json, os',
-        '# Read: a parameter bound to custom field "asset_tag" arrives as an env var',
+        '# Read: a parameter named asset_tag (bound to a custom field) arrives as BREEZE_PARAM_<NAME>',
         'asset_tag = os.environ.get("BREEZE_PARAM_ASSET_TAG")',
         '# Write: print the marker; the field needs "Allow scripts to write this field"',
         `print("${CUSTOM_FIELD_MARKER} " + json.dumps({"ram_slot_type": "DDR5-5600", "free_dimm_slots": 2}))`,
       ].join('\n');
     case 'cmd':
       return [
-        'REM Read: a parameter bound to custom field "asset_tag" arrives as an env var',
+        'REM Read: a parameter named asset_tag (bound to a custom field) arrives as BREEZE_PARAM_<NAME>',
         'set ASSET_TAG=%BREEZE_PARAM_ASSET_TAG%',
         'REM Write: print the marker; the field needs "Allow scripts to write this field"',
         `echo ${CUSTOM_FIELD_MARKER} {"ram_slot_type":"DDR5-5600","free_dimm_slots":2}`,
@@ -45,7 +45,7 @@ export function customFieldExampleSnippet(language: string): string {
     case 'bash':
     default:
       return [
-        '# Read: a parameter bound to custom field "asset_tag" arrives as an env var',
+        '# Read: a parameter named asset_tag (bound to a custom field) arrives as BREEZE_PARAM_<NAME>',
         'asset_tag="$BREEZE_PARAM_ASSET_TAG"',
         '# Write: print the marker; the field needs "Allow scripts to write this field"',
         `echo '${CUSTOM_FIELD_MARKER} {"ram_slot_type":"DDR5-5600","free_dimm_slots":2}'`,

--- a/apps/web/src/components/scripts/ScriptForm.test.tsx
+++ b/apps/web/src/components/scripts/ScriptForm.test.tsx
@@ -722,7 +722,13 @@ describe('ScriptForm sourced parameters', () => {
 
     const trigger = await screen.findByRole('button', { name: 'About the device custom field binding' });
     fireEvent.click(trigger);
-    expect(await screen.findByRole('tooltip')).toHaveTextContent(/PATCH request/i);
+    const tip = await screen.findByRole('tooltip');
+    // #5233: the marker replaces the stale PATCH-plus-API-key advice, the env
+    // var is named, and the literal {{paramName}} survives i18next interpolation.
+    expect(tip).toHaveTextContent('::breeze:custom-fields::');
+    expect(tip).toHaveTextContent('BREEZE_PARAM_<KEY>');
+    expect(tip).toHaveTextContent('{{paramName}}');
+    expect(tip).not.toHaveTextContent(/PATCH/i);
   });
 
   it('clears the previous arm\'s binding key when the source changes', async () => {
@@ -824,5 +830,20 @@ describe('ScriptForm security acknowledgement wiring', () => {
     await waitFor(() => expect(onSubmit).toHaveBeenCalled());
     // Verbatim: the agent compares against its own description string.
     expect(onSubmit.mock.calls[0]![0].acknowledgedSecurityPatterns).toEqual([HKLM]);
+  });
+});
+
+describe('ScriptForm custom-field help (#5233)', () => {
+  beforeEach(() => {
+    editorInstances.length = 0;
+    getJwtClaimsMock.mockReturnValue({ scope: 'organization', partnerId: null, orgId: 'o-1' });
+    orgStoreMock.mockReturnValue({ organizations: [{ id: 'o-1', name: 'Org One' }], partners: [], sites: [] });
+  });
+  afterEach(() => { vi.clearAllMocks(); });
+
+  it('renders the "Reading and writing custom fields" aside under the editor', async () => {
+    render(<ScriptForm isNew />);
+    await waitFor(() => expect(editorInstances.length).toBeGreaterThan(0));
+    expect(screen.getByTestId('custom-field-help-toggle').textContent).toContain('Reading and writing custom fields');
   });
 });

--- a/apps/web/src/components/scripts/ScriptForm.test.tsx
+++ b/apps/web/src/components/scripts/ScriptForm.test.tsx
@@ -14,9 +14,21 @@ const { editorInstances } = vi.hoisted(() => ({
 vi.mock('@monaco-editor/react', async () => {
   const React = (await vi.importActual<typeof import('react')>('react'));
   const loader = { config: vi.fn() };
-  function MockEditor({ onMount, value }: { onMount?: (e: unknown) => void; value?: string }) {
+  function MockEditor({ onMount, value, onChange }: { onMount?: (e: unknown) => void; value?: string; onChange?: (v: string) => void }) {
+    const valueRef = React.useRef(value ?? '');
+    valueRef.current = value ?? '';
     React.useEffect(() => {
-      const instance = { layout: vi.fn(), dispose: vi.fn() };
+      // Enough of the Monaco surface for CustomFieldHelp's insert path (#5233):
+      // executeEdits appends to the current value and getModel reads it back.
+      const instance = {
+        layout: vi.fn(),
+        dispose: vi.fn(),
+        getSelection: () => null,
+        pushUndoStop: vi.fn(),
+        executeEdits: (_src: string, edits: Array<{ text: string }>) => { valueRef.current += edits.map(e => e.text).join(''); onChange?.(valueRef.current); },
+        getModel: () => ({ getValue: () => valueRef.current }),
+        focus: vi.fn()
+      };
       editorInstances.push(instance);
       onMount?.(instance);
       // The real wrapper disposes on its own unmount; the mock deliberately does
@@ -845,5 +857,13 @@ describe('ScriptForm custom-field help (#5233)', () => {
     render(<ScriptForm isNew />);
     await waitFor(() => expect(editorInstances.length).toBeGreaterThan(0));
     expect(screen.getByTestId('custom-field-help-toggle').textContent).toContain('Reading and writing custom fields');
+  });
+
+  it('Insert example writes the snippet into the form content the editor renders', async () => {
+    render(<ScriptForm isNew />);
+    await waitFor(() => expect(editorInstances.length).toBeGreaterThan(0));
+    fireEvent.click(screen.getByTestId('custom-field-help-toggle'));
+    fireEvent.click(screen.getByTestId('custom-field-help-insert'));
+    await waitFor(() => expect(screen.getByTestId('mock-monaco').textContent).toContain('::breeze:custom-fields::'));
   });
 });

--- a/apps/web/src/components/scripts/ScriptForm.tsx
+++ b/apps/web/src/components/scripts/ScriptForm.tsx
@@ -27,6 +27,7 @@ import ScriptVariablePicker from './ScriptVariablePicker';
 import TenantVariableMenu from './TenantVariableMenu';
 import { findUnknownVariableKeys, useTenantVariables, type TenantVariableEntry } from '@/lib/tenantVariableTokens';
 import HelpTooltip from '../shared/HelpTooltip';
+import CustomFieldHelp from './CustomFieldHelp';
 import { cn } from '@/lib/utils';
 import { configureMonacoLoader } from '@/lib/monacoLoader';
 import { useScriptAiStore } from '@/stores/scriptAiStore';
@@ -827,6 +828,12 @@ export default function ScriptForm({
           {panelOpen && <ScriptAiPanel bridge={bridge} />}
         </div>
         {errors.content && <p className="text-sm text-destructive">{errors.content.message}</p>}
+        <CustomFieldHelp
+          language={watchLanguage}
+          editorRef={editorInstanceRef}
+          content={watchContent ?? ''}
+          onInsert={next => setValue('content', next, { shouldDirty: true })}
+        />
         {unknownVariableKeys.length > 0 && (
           <p
             data-testid="script-variable-warning"
@@ -937,7 +944,9 @@ export default function ScriptForm({
                       <label className="flex items-center gap-1 text-xs font-medium text-muted-foreground">
                         {t('scriptForm.parameterBinding.fieldLabel')}
                         <HelpTooltip
-                          text={t('scriptForm.parameterBinding.fieldHelp')}
+                          // Literal `{{paramName}}` in the copy; passed as a value so i18next
+                          // does not treat it as an interpolation slot.
+                          text={t('scriptForm.parameterBinding.fieldHelp', { paramName: '{{paramName}}' })}
                           ariaLabel={t('scriptForm.parameterBinding.fieldHelpAriaLabel')}
                         />
                       </label>

--- a/apps/web/src/locales/de-DE/scripts.json
+++ b/apps/web/src/locales/de-DE/scripts.json
@@ -1117,7 +1117,7 @@
       "variablePlaceholder": "z.B. vendor_token",
       "fieldLabel": "Schlüssel des benutzerdefinierten Felds",
       "fieldPlaceholder": "z.B. asset_tag",
-      "fieldHelp": "Geben Sie den Feldschlüssel ein, der unter Einstellungen → Benutzerdefinierte Felder angezeigt wird (Groß-/Kleinschreibung beachten). Lesen: Sobald die Bindung besteht, wird der aufgelöste Wert wie ein normaler Parameter an das Skript übergeben — es erscheint keine Eingabeaufforderung. Schreiben: Um einen neuen Wert zurückzuschreiben, lassen Sie das Skript die Custom-Fields-API des Geräts mit einer PATCH-Anfrage und einem API-Schlüssel aufrufen.",
+      "fieldHelp": "Geben Sie den Feldschlüssel ein, der unter Einstellungen → Benutzerdefinierte Felder angezeigt wird (Groß-/Kleinschreibung beachten). Lesen: Der aufgelöste Wert wird dem Skript als Umgebungsvariable BREEZE_PARAM_<KEY> (Parametername in Großbuchstaben mit Unterstrichen) und als Platzhalter {{paramName}} übergeben — es erscheint keine Eingabeaufforderung. Schreiben: Geben Sie ::breeze:custom-fields:: {\"key\": \"value\"} auf stdout aus, für ein Feld mit aktivierter Option „Skripte dürfen dieses Feld schreiben“. Ein Beispiel finden Sie unter „Benutzerdefinierte Felder lesen und schreiben“ unterhalb des Editors.",
       "fieldHelpAriaLabel": "Über die Bindung des benutzerdefinierten Gerätefelds",
       "builtinLabel": "Eigenschaft",
       "chooseTitle": "Variable auswählen",
@@ -1134,6 +1134,18 @@
       "clearedHint": "Alle erkannten Muster wurden bestätigt.",
       "willBlock": "Nicht bestätigt — der Agent wird die Ausführung dieses Skripts verweigern.",
       "footnote": "Eine Bestätigung gilt nur für dieses Skript und deckt nur die hier aufgeführten Muster ab. Wenn Sie später einen anderen riskanten Vorgang hinzufügen, wird dieser blockiert, bis Sie auch ihn bestätigen."
+    },
+    "customFieldHelp": {
+      "title": "Benutzerdefinierte Felder lesen und schreiben",
+      "readLabel": "Lesen:",
+      "read": "Binden Sie einen Parameter an ein benutzerdefiniertes Feld (Quelle „Aus einem Gerätefeld“). Der Wert kommt als Umgebungsvariable an",
+      "readPlaceholders": "und als Platzhalter",
+      "writeLabel": "Schreiben:",
+      "write": "Geben Sie eine Zeile auf stdout in der Form aus",
+      "writeGate": "Für das Feld muss unter Einstellungen → Benutzerdefinierte Felder „Skripte dürfen dieses Feld schreiben“ aktiviert sein. Werte werden gegen den Feldtyp geprüft; abgelehnte Schlüssel erscheinen in den Ausführungsdetails.",
+      "secretCaveat": "Der geschriebene Wert erscheint auch in der gespeicherten Skriptausgabe — schreiben Sie so niemals ein Geheimnis. Verwenden Sie stattdessen eine geheime Variable.",
+      "insertExample": "Beispiel einfügen",
+      "docsLink": "Dokumentation zu benutzerdefinierten Feldern"
     }
   },
   "scriptList": {

--- a/apps/web/src/locales/en/scripts.json
+++ b/apps/web/src/locales/en/scripts.json
@@ -1117,7 +1117,7 @@
       "variablePlaceholder": "e.g. vendor_token",
       "fieldLabel": "Custom field key",
       "fieldPlaceholder": "e.g. asset_tag",
-      "fieldHelp": "Enter the Field Key shown in Settings → Custom Fields (case-sensitive). Read: once bound, the resolved value is delivered to the script just like a normal parameter — no prompt is shown. Write: to save a new value back, have the script call the device's custom-fields API with a PATCH request and an API key.",
+      "fieldHelp": "Enter the Field Key shown in Settings → Custom Fields (case-sensitive). Read: the resolved value is delivered to the script as the environment variable BREEZE_PARAM_<KEY> (the parameter name in upper snake case) and as the {{paramName}} placeholder — no prompt is shown. Write: print ::breeze:custom-fields:: {\"key\": \"value\"} to stdout for a field that has \"Allow scripts to write this field\" enabled. See \"Reading and writing custom fields\" under the editor for an example.",
       "fieldHelpAriaLabel": "About the device custom field binding",
       "builtinLabel": "Property",
       "chooseTitle": "Choose a variable",
@@ -1134,6 +1134,18 @@
       "clearedHint": "Every matched pattern has been acknowledged.",
       "willBlock": "Not acknowledged — the agent will refuse to run this script.",
       "footnote": "An acknowledgement applies to this script only, and covers just the patterns listed here. If you later add a different risky operation, it will be blocked until you acknowledge that one too."
+    },
+    "customFieldHelp": {
+      "title": "Reading and writing custom fields",
+      "readLabel": "Read:",
+      "read": "bind a parameter to a custom field (source \"From a device custom field\"). The value arrives as the environment variable",
+      "readPlaceholders": "and as the placeholder",
+      "writeLabel": "Write:",
+      "write": "print a line to stdout in the form",
+      "writeGate": "The field must have \"Allow scripts to write this field\" enabled in Settings → Custom Fields. Values are validated against the field type; rejected keys are listed in the run details.",
+      "secretCaveat": "The written value also appears in the script's saved output — never write a secret this way. Use a secret variable instead.",
+      "insertExample": "Insert example",
+      "docsLink": "Custom fields docs"
     }
   },
   "scriptList": {

--- a/apps/web/src/locales/es-419/scripts.json
+++ b/apps/web/src/locales/es-419/scripts.json
@@ -1117,7 +1117,7 @@
       "variablePlaceholder": "p.ej. vendor_token",
       "fieldLabel": "Clave del campo personalizado",
       "fieldPlaceholder": "p.ej. asset_tag",
-      "fieldHelp": "Ingresa la Clave de Campo que se muestra en Configuración → Campos Personalizados (distingue mayúsculas de minúsculas). Lectura: una vez vinculado, el valor resuelto se entrega al script como cualquier parámetro normal, sin mostrar ninguna solicitud. Escritura: para guardar un nuevo valor, haz que el script llame a la API de campos personalizados del dispositivo con una solicitud PATCH y una clave de API.",
+      "fieldHelp": "Ingresa la Clave del campo que se muestra en Configuración → Campos personalizados (distingue mayúsculas y minúsculas). Lectura: el valor resuelto se entrega al script como la variable de entorno BREEZE_PARAM_<KEY> (el nombre del parámetro en mayúsculas con guiones bajos) y como el marcador {{paramName}} — no se muestra ningún aviso. Escritura: imprime ::breeze:custom-fields:: {\"key\": \"value\"} en stdout para un campo con «Permitir que los scripts escriban este campo» habilitado. Consulta «Leer y escribir campos personalizados» debajo del editor para ver un ejemplo.",
       "fieldHelpAriaLabel": "Acerca de la vinculación de campo personalizado del dispositivo",
       "builtinLabel": "Propiedad",
       "chooseTitle": "Elegir una variable",
@@ -1134,6 +1134,18 @@
       "clearedHint": "Todos los patrones detectados han sido reconocidos.",
       "willBlock": "No reconocido: el agente se negará a ejecutar este script.",
       "footnote": "Un reconocimiento se aplica solo a este script y cubre únicamente los patrones indicados aquí. Si más adelante agregas una operación riesgosa distinta, se bloqueará hasta que también la reconozcas."
+    },
+    "customFieldHelp": {
+      "title": "Leer y escribir campos personalizados",
+      "readLabel": "Lectura:",
+      "read": "vincula un parámetro a un campo personalizado (origen «Desde un campo personalizado del dispositivo»). El valor llega como la variable de entorno",
+      "readPlaceholders": "y como el marcador",
+      "writeLabel": "Escritura:",
+      "write": "imprime una línea en stdout con la forma",
+      "writeGate": "El campo debe tener «Permitir que los scripts escriban este campo» habilitado en Configuración → Campos personalizados. Los valores se validan contra el tipo del campo; las claves rechazadas se listan en los detalles de la ejecución.",
+      "secretCaveat": "El valor escrito también aparece en la salida guardada del script — nunca escribas un secreto de esta forma. Usa una variable secreta en su lugar.",
+      "insertExample": "Insertar ejemplo",
+      "docsLink": "Documentación de campos personalizados"
     }
   },
   "scriptList": {

--- a/apps/web/src/locales/fr-CA/scripts.json
+++ b/apps/web/src/locales/fr-CA/scripts.json
@@ -1117,7 +1117,7 @@
       "variablePlaceholder": "p. ex. vendor_token",
       "fieldLabel": "Clé du champ personnalisé",
       "fieldPlaceholder": "p. ex. asset_tag",
-      "fieldHelp": "Saisissez la Clé du champ affichée dans Paramètres → Champs personnalisés (sensible à la casse). Lecture : une fois liée, la valeur résolue est transmise au script comme un paramètre normal — aucune invite n’est affichée. Écriture : pour enregistrer une nouvelle valeur, faites appeler par le script l’API des champs personnalisés de l’appareil avec une requête PATCH et une clé API.",
+      "fieldHelp": "Saisissez la Clé du champ affichée dans Paramètres → Champs personnalisés (sensible à la casse). Lecture : la valeur résolue est transmise au script sous forme de variable d’environnement BREEZE_PARAM_<KEY> (nom du paramètre en majuscules avec des tirets bas) et de l’espace réservé {{paramName}} — aucune invite n’est affichée. Écriture : affichez ::breeze:custom-fields:: {\"key\": \"value\"} sur stdout pour un champ dont l’option « Autoriser les scripts à écrire ce champ » est activée. Voir « Lire et écrire les champs personnalisés » sous l’éditeur pour un exemple.",
       "fieldHelpAriaLabel": "À propos de la liaison du champ personnalisé de l’appareil",
       "builtinLabel": "Propriété",
       "chooseTitle": "Choisir une variable",
@@ -1134,6 +1134,18 @@
       "clearedHint": "Tous les motifs détectés ont été confirmés.",
       "willBlock": "Non confirmé — l'agent refusera d'exécuter ce script.",
       "footnote": "Une confirmation s'applique uniquement à ce script et ne couvre que les motifs listés ici. Si vous ajoutez plus tard une autre opération à risque, elle sera bloquée jusqu'à ce que vous la confirmiez aussi."
+    },
+    "customFieldHelp": {
+      "title": "Lire et écrire les champs personnalisés",
+      "readLabel": "Lecture :",
+      "read": "liez un paramètre à un champ personnalisé (source « Depuis un champ personnalisé de l’appareil »). La valeur arrive sous forme de variable d’environnement",
+      "readPlaceholders": "et d’espace réservé",
+      "writeLabel": "Écriture :",
+      "write": "affichez une ligne sur stdout sous la forme",
+      "writeGate": "Le champ doit avoir l’option « Autoriser les scripts à écrire ce champ » activée dans Paramètres → Champs personnalisés. Les valeurs sont validées selon le type du champ ; les clés rejetées sont listées dans les détails de l’exécution.",
+      "secretCaveat": "La valeur écrite apparaît aussi dans la sortie enregistrée du script — n’écrivez jamais un secret de cette façon. Utilisez plutôt une variable secrète.",
+      "insertExample": "Insérer un exemple",
+      "docsLink": "Documentation des champs personnalisés"
     }
   },
   "scriptList": {

--- a/apps/web/src/locales/fr-FR/scripts.json
+++ b/apps/web/src/locales/fr-FR/scripts.json
@@ -1117,7 +1117,7 @@
       "variablePlaceholder": "p. ex. vendor_token",
       "fieldLabel": "Clé du champ personnalisé",
       "fieldPlaceholder": "p. ex. asset_tag",
-      "fieldHelp": "Saisissez la Clé du champ affichée dans Paramètres → Champs personnalisés (sensible à la casse). Lecture : une fois liée, la valeur résolue est transmise au script comme un paramètre normal — aucune invite n’est affichée. Écriture : pour enregistrer une nouvelle valeur, faites appeler par le script l’API des champs personnalisés de l’appareil avec une requête PATCH et une clé API.",
+      "fieldHelp": "Saisissez la Clé du champ affichée dans Paramètres → Champs personnalisés (sensible à la casse). Lecture : la valeur résolue est transmise au script sous forme de variable d’environnement BREEZE_PARAM_<KEY> (nom du paramètre en majuscules avec des tirets bas) et de l’espace réservé {{paramName}} — aucune invite n’est affichée. Écriture : affichez ::breeze:custom-fields:: {\"key\": \"value\"} sur stdout pour un champ dont l’option « Autoriser les scripts à écrire ce champ » est activée. Voir « Lire et écrire les champs personnalisés » sous l’éditeur pour un exemple.",
       "fieldHelpAriaLabel": "À propos de la liaison du champ personnalisé de l’appareil",
       "builtinLabel": "Propriété",
       "chooseTitle": "Choisir une variable",
@@ -1134,6 +1134,18 @@
       "clearedHint": "Tous les motifs détectés ont été confirmés.",
       "willBlock": "Non confirmé — l'agent refusera d'exécuter ce script.",
       "footnote": "Une confirmation s'applique uniquement à ce script et ne couvre que les motifs listés ici. Si vous ajoutez plus tard une autre opération à risque, elle sera bloquée jusqu'à ce que vous la confirmiez aussi."
+    },
+    "customFieldHelp": {
+      "title": "Lire et écrire les champs personnalisés",
+      "readLabel": "Lecture :",
+      "read": "liez un paramètre à un champ personnalisé (source « Depuis un champ personnalisé de l’appareil »). La valeur arrive sous forme de variable d’environnement",
+      "readPlaceholders": "et d’espace réservé",
+      "writeLabel": "Écriture :",
+      "write": "affichez une ligne sur stdout sous la forme",
+      "writeGate": "Le champ doit avoir l’option « Autoriser les scripts à écrire ce champ » activée dans Paramètres → Champs personnalisés. Les valeurs sont validées selon le type du champ ; les clés rejetées sont listées dans les détails de l’exécution.",
+      "secretCaveat": "La valeur écrite apparaît aussi dans la sortie enregistrée du script — n’écrivez jamais un secret de cette façon. Utilisez plutôt une variable secrète.",
+      "insertExample": "Insérer un exemple",
+      "docsLink": "Documentation des champs personnalisés"
     }
   },
   "scriptList": {

--- a/apps/web/src/locales/it-IT/scripts.json
+++ b/apps/web/src/locales/it-IT/scripts.json
@@ -1117,7 +1117,7 @@
       "variablePlaceholder": "es. vendor_token",
       "fieldLabel": "Chiave del campo personalizzato",
       "fieldPlaceholder": "es. asset_tag",
-      "fieldHelp": "Inserisci la Chiave del campo mostrata in Impostazioni → Campi personalizzati (sensibile a maiuscole/minuscole). Lettura: una volta associato, il valore risolto viene consegnato allo script come un parametro normale: non viene mostrata alcuna richiesta. Scrittura: per salvare un nuovo valore, fai in modo che lo script chiami l'API dei campi personalizzati del dispositivo con una richiesta PATCH e una chiave API.",
+      "fieldHelp": "Inserisci la Chiave del campo mostrata in Impostazioni → Campi personalizzati (distingue maiuscole e minuscole). Lettura: il valore risolto viene consegnato allo script come variabile d’ambiente BREEZE_PARAM_<KEY> (nome del parametro in maiuscolo con trattini bassi) e come segnaposto {{paramName}} — non viene mostrato alcun prompt. Scrittura: stampa ::breeze:custom-fields:: {\"key\": \"value\"} su stdout per un campo con «Consenti agli script di scrivere questo campo» abilitato. Vedi «Leggere e scrivere i campi personalizzati» sotto l’editor per un esempio.",
       "fieldHelpAriaLabel": "Informazioni sull'associazione del campo personalizzato del dispositivo",
       "builtinLabel": "Proprietà",
       "chooseTitle": "Scegli una variabile",
@@ -1134,6 +1134,18 @@
       "clearedHint": "Tutti i pattern rilevati sono stati confermati.",
       "willBlock": "Non confermato — l'agente rifiuterà di eseguire questo script.",
       "footnote": "Una conferma si applica solo a questo script e copre solo i pattern elencati qui. Se in seguito aggiungi un'altra operazione rischiosa, verrà bloccata finché non confermi anche quella."
+    },
+    "customFieldHelp": {
+      "title": "Leggere e scrivere i campi personalizzati",
+      "readLabel": "Lettura:",
+      "read": "associa un parametro a un campo personalizzato (origine «Da un campo personalizzato del dispositivo»). Il valore arriva come variabile d’ambiente",
+      "readPlaceholders": "e come segnaposto",
+      "writeLabel": "Scrittura:",
+      "write": "stampa una riga su stdout nella forma",
+      "writeGate": "Il campo deve avere «Consenti agli script di scrivere questo campo» abilitato in Impostazioni → Campi personalizzati. I valori sono convalidati rispetto al tipo del campo; le chiavi rifiutate sono elencate nei dettagli dell’esecuzione.",
+      "secretCaveat": "Il valore scritto compare anche nell’output salvato dello script — non scrivere mai un segreto in questo modo. Usa invece una variabile segreta.",
+      "insertExample": "Inserisci esempio",
+      "docsLink": "Documentazione dei campi personalizzati"
     }
   },
   "scriptList": {

--- a/apps/web/src/locales/pt-BR/scripts.json
+++ b/apps/web/src/locales/pt-BR/scripts.json
@@ -1117,7 +1117,7 @@
       "variablePlaceholder": "ex.: vendor_token",
       "fieldLabel": "Chave do campo personalizado",
       "fieldPlaceholder": "ex.: asset_tag",
-      "fieldHelp": "Digite a Chave do Campo exibida em Configurações → Campos Personalizados (diferencia maiúsculas de minúsculas). Leitura: uma vez vinculado, o valor resolvido é entregue ao script como qualquer parâmetro normal — nenhum prompt é exibido. Gravação: para salvar um novo valor, faça o script chamar a API de campos personalizados do dispositivo com uma requisição PATCH e uma chave de API.",
+      "fieldHelp": "Digite a Chave do Campo exibida em Configurações → Campos Personalizados (diferencia maiúsculas de minúsculas). Leitura: o valor resolvido é entregue ao script como a variável de ambiente BREEZE_PARAM_<KEY> (nome do parâmetro em maiúsculas com sublinhados) e como o marcador {{paramName}} — nenhum prompt é exibido. Gravação: imprima ::breeze:custom-fields:: {\"key\": \"value\"} no stdout para um campo com \"Permitir que scripts gravem este campo\" habilitado. Veja \"Ler e gravar campos personalizados\" abaixo do editor para um exemplo.",
       "fieldHelpAriaLabel": "Sobre a vinculação de campo personalizado do dispositivo",
       "builtinLabel": "Propriedade",
       "chooseTitle": "Escolher uma variável",
@@ -1134,6 +1134,18 @@
       "clearedHint": "Todos os padrões detectados foram reconhecidos.",
       "willBlock": "Não reconhecido — o agente se recusará a executar este script.",
       "footnote": "Um reconhecimento se aplica somente a este script e cobre apenas os padrões listados aqui. Se você adicionar depois uma operação arriscada diferente, ela será bloqueada até que você também a reconheça."
+    },
+    "customFieldHelp": {
+      "title": "Ler e gravar campos personalizados",
+      "readLabel": "Leitura:",
+      "read": "vincule um parâmetro a um campo personalizado (origem \"De um campo personalizado do dispositivo\"). O valor chega como a variável de ambiente",
+      "readPlaceholders": "e como o marcador",
+      "writeLabel": "Gravação:",
+      "write": "imprima uma linha no stdout no formato",
+      "writeGate": "O campo precisa ter \"Permitir que scripts gravem este campo\" habilitado em Configurações → Campos Personalizados. Os valores são validados contra o tipo do campo; chaves rejeitadas são listadas nos detalhes da execução.",
+      "secretCaveat": "O valor gravado também aparece na saída salva do script — nunca grave um segredo dessa forma. Use uma variável secreta.",
+      "insertExample": "Inserir exemplo",
+      "docsLink": "Documentação de campos personalizados"
     }
   },
   "scriptList": {

--- a/apps/web/src/locales/tr-TR/scripts.json
+++ b/apps/web/src/locales/tr-TR/scripts.json
@@ -1053,7 +1053,7 @@
       "variablePlaceholder": "ör. vendor_token",
       "fieldLabel": "Özel alan anahtarı",
       "fieldPlaceholder": "ör. asset_tag",
-      "fieldHelp": "Ayarlar → Özel Alanlar bölümünde gösterilen Alan Anahtarını girin (büyük/küçük harfe duyarlıdır). Okuma: bağlandıktan sonra, çözümlenen değer normal bir parametre gibi betiğe iletilir — herhangi bir istem gösterilmez. Yazma: yeni bir değeri geri kaydetmek için betiğin, bir API anahtarıyla birlikte PATCH isteği kullanarak cihazın özel alan API'sini çağırmasını sağlayın.",
+      "fieldHelp": "Ayarlar → Özel Alanlar bölümünde gösterilen Alan Anahtarını girin (büyük/küçük harfe duyarlıdır). Okuma: çözümlenen değer betiğe BREEZE_PARAM_<KEY> ortam değişkeni (parametre adı büyük harf ve alt çizgiyle) ve {{paramName}} yer tutucusu olarak iletilir — herhangi bir istem gösterilmez. Yazma: \"Betiklerin bu alanı yazmasına izin ver\" etkin olan bir alan için stdout’a ::breeze:custom-fields:: {\"key\": \"value\"} yazdırın. Örnek için düzenleyicinin altındaki \"Özel alanları okuma ve yazma\" bölümüne bakın.",
       "fieldHelpAriaLabel": "Cihaz özel alan bağlaması hakkında",
       "builtinLabel": "Özellik",
       "chooseTitle": "Bir değişken seçin",
@@ -1134,6 +1134,18 @@
       "empty": "Henüz değişken yok.",
       "secretUnavailable": "Gizli — kaynağı \"Gizli bir değişkenden\" olan bir parametre üzerinden bağlayın.",
       "unknown": "{{keys}} için değişken yok — hedeflenen cihazlar siz onu oluşturana kadar başarısız olacaktır."
+    },
+    "customFieldHelp": {
+      "title": "Özel alanları okuma ve yazma",
+      "readLabel": "Okuma:",
+      "read": "bir parametreyi özel bir alana bağlayın (kaynak \"Cihaz özel alanından\"). Değer şu ortam değişkeni olarak gelir:",
+      "readPlaceholders": "ve şu yer tutucu olarak:",
+      "writeLabel": "Yazma:",
+      "write": "stdout’a şu biçimde bir satır yazdırın:",
+      "writeGate": "Alanın Ayarlar → Özel Alanlar bölümünde \"Betiklerin bu alanı yazmasına izin ver\" seçeneği etkin olmalıdır. Değerler alan türüne göre doğrulanır; reddedilen anahtarlar çalıştırma ayrıntılarında listelenir.",
+      "secretCaveat": "Yazılan değer betiğin kaydedilen çıktısında da görünür — bu yolla asla bir gizli değer yazmayın. Bunun yerine gizli bir değişken kullanın.",
+      "insertExample": "Örnek ekle",
+      "docsLink": "Özel alanlar belgeleri"
     }
   },
   "scriptList": {


### PR DESCRIPTION
## Summary
- The **Custom field key** tooltip in the script editor told users to write a field by calling the device custom-fields API with a PATCH and an API key. Since #4678 the supported path is the stdout marker `::breeze:custom-fields:: {"key":"value"}` on a field with **Allow scripts to write this field** enabled. The read side also never named the env var.
- Rewrote `scriptForm.parameterBinding.fieldHelp` in all 8 locales: read = `BREEZE_PARAM_<KEY>` env var + `{{paramName}}` placeholder; write = the marker + the per-field gate. The literal `{{paramName}}` is passed as an interpolation value so i18next leaves it intact.
- New collapsible **Reading and writing custom fields** aside under the editor (`CustomFieldHelp.tsx`): read/write summary, the secret caveat already used in Settings, a per-language example (PowerShell / Bash / Python / CMD) that follows the editor language, an **Insert example** button (Monaco `executeEdits` at the caret with a single undo stop, append fallback when the editor isn't mounted), and a link to the docs page.

## Tests
- `CustomFieldHelp.test.tsx`: stale-text guard on the en tooltip, body content + docs link, snippet follows language, every snippet's marker JSON parses, insert with and without Monaco.
- `ScriptForm.test.tsx`: aside renders; the existing tooltip test now asserts the marker, env var, and intact `{{paramName}}` instead of `PATCH request`.
- `localeParity` + `translationCoverage` green.

es-419, fr-FR, fr-CA, de-DE, and it-IT strings are machine-drafted pending native review
pt-BR strings are machine-drafted pending native review

Closes #5233

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UuLQAed76V8bJSphzaWDxW