### PR TITLE
fix(api): exclude removed devices from organization device counts (#5315)

### DIFF
--- a/apps/api/src/routes/orgSummary.test.ts
+++ b/apps/api/src/routes/orgSummary.test.ts
@@ -8,6 +8,8 @@ import { orgSummaryRoutes } from './orgSummary';
 // checks (a typo'd literal in the route would fail these tests instead of
 // silently never matching).
 import { PERMISSIONS } from '../services/permissions';
+import type { SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
 
 vi.mock('../middleware/auth', () => ({
   authMiddleware: vi.fn((_c: any, next: any) => next()),
@@ -78,7 +80,8 @@ function setupDb(rowsByTable: Map<unknown, RowsSpec<unknown>>) {
     () =>
       ({
         from: (table: unknown) => ({
-          where: () => {
+          where: (condition: unknown) => {
+            whereByTable.set(table, condition);
             const spec = rowsByTable.get(table);
             if (spec && !Array.isArray(spec)) {
               return queryResult(spec.base, spec.limited);
@@ -88,6 +91,25 @@ function setupDb(rowsByTable: Map<unknown, RowsSpec<unknown>>) {
         }),
       }) as any,
   );
+}
+
+/** WHERE condition captured per table by `setupDb`, so a test can assert on the
+ * predicate the route actually built and not just the rows the mock returned. */
+const whereByTable = new Map<unknown, unknown>();
+
+/** Compile a captured WHERE into its REAL SQL text.
+ *
+ * `JSON.stringify` on a Drizzle condition is NOT a usable substitute: the tree
+ * embeds the `devices.status` column object, whose `enumValues` array literally
+ * contains the string `'decommissioned'` — so a substring assertion on the dump
+ * passes against unfixed code (a vacuous red). Compiling through the real
+ * dialect renders only the statement the database would receive.
+ */
+function compiledWhere(table: unknown): { sql: string; params: unknown[] } {
+  const condition = whereByTable.get(table);
+  if (!condition) throw new Error('no WHERE captured for that table');
+  const query = new PgDialect().sqlToQuery(condition as SQL);
+  return { sql: query.sql, params: query.params as unknown[] };
 }
 
 function buildApp(opts: {
@@ -122,6 +144,7 @@ const WILDCARD_GRANTS = [{ resource: '*', action: '*' }];
 describe('GET /orgs/organizations/:id/summary', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    whereByTable.clear();
   });
 
   it('404s when :id is not UUID-shaped', async () => {
@@ -146,6 +169,25 @@ describe('GET /orgs/organizations/:id/summary', () => {
     const res = await app.request(`/orgs/organizations/${ORG_ID}/summary`);
     expect(res.status).toBe(404);
     expect(await res.json()).toEqual({ error: 'Organization not found' });
+  });
+
+  // #5315 — the Overview "Devices" tile read `count(*)` with no status filter
+  // while the record's Devices tab (GET /devices) excludes decommissioned rows
+  // by default, so a removed device made the tile disagree with its own tab.
+  it('excludes decommissioned devices from the device counts', async () => {
+    setupDb(
+      new Map<unknown, unknown[]>([
+        [organizations, [{ id: ORG_ID, currencyCode: 'USD' }]],
+        [devices, [{ total: '5', online: '3', offline: '2' }]],
+      ]),
+    );
+    const app = buildApp({ grants: WILDCARD_GRANTS });
+    const res = await app.request(`/orgs/organizations/${ORG_ID}/summary`);
+
+    expect(res.status).toBe(200);
+    const where = compiledWhere(devices);
+    expect(where.sql).toContain('"devices"."status" <>');
+    expect(where.params).toContain('decommissioned');
   });
 
   it('returns every section for a wildcard-permission partner', async () => {

--- a/apps/api/src/routes/orgSummary.ts
+++ b/apps/api/src/routes/orgSummary.ts
@@ -20,7 +20,7 @@
  * so it carries the same visibility requirement as the audit trail itself.
  */
 import { Hono } from 'hono';
-import { and, eq, isNull, sql } from 'drizzle-orm';
+import { and, eq, isNull, ne, sql } from 'drizzle-orm';
 import { INVOICE_STATUSES } from '@breeze/shared';
 import { db } from '../db';
 import {
@@ -157,10 +157,17 @@ orgSummaryRoutes.get(
         .select({
           total: sql<string>`count(*)`,
           online: sql<string>`count(*) FILTER (WHERE ${devices.status} = 'online')`,
-          offline: sql<string>`count(*) FILTER (WHERE ${devices.status} <> 'online' AND ${devices.status} <> 'decommissioned')`,
+          offline: sql<string>`count(*) FILTER (WHERE ${devices.status} <> 'online')`,
         })
         .from(devices)
-        .where(eq(devices.orgId, id));
+        // Removed (decommissioned) devices are excluded from EVERY count here,
+        // not just `offline` (#5315). The record page's own Devices tab lists
+        // `GET /devices`, which drops decommissioned rows by default — with the
+        // exclusion applied only to `offline`, the Overview tile reported a
+        // higher total than the tab it sits next to ("Devices 6" vs 5 rows).
+        // Filtering in the WHERE keeps `total`, `online` and `offline` on one
+        // population, so the tile's "N of M online" sub-label stays coherent.
+        .where(and(eq(devices.orgId, id), ne(devices.status, 'decommissioned')));
       summary.devices = {
         total: toCount(row?.total),
         online: toCount(row?.online),

--- a/apps/api/src/routes/orgs.test.ts
+++ b/apps/api/src/routes/orgs.test.ts
@@ -2000,6 +2000,52 @@ describe('org routes', () => {
       expect(body.data.find((o: { id: string }) => o.id === 'org-2').deviceCount).toBe(0);
     });
 
+    // #5315 — the org card counted decommissioned devices while every other
+    // device surface (fleet list, org record Overview tile and Devices tab)
+    // hides them, so a removed device made this card read one higher than the
+    // record it links to. Assert on the bound parameter: this suite mocks the
+    // schema module, so column names render blank in the compiled statement,
+    // and a JSON dump of the condition would match `devices.status`'s own
+    // `enumValues` and pass against unfixed code.
+    it('excludes decommissioned devices from the per-organization device count', async () => {
+      setAuthContext({ scope: 'partner', partnerId: 'partner-123', accessibleOrgIds: ['org-1'] });
+      let countWhere: SQL | undefined;
+      vi.mocked(db.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ count: 1 }])
+          })
+        } as any)
+        .mockReturnValueOnce(mockPartnerOrderSettings())
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockReturnValue({
+                offset: vi.fn().mockReturnValue({
+                  orderBy: vi.fn().mockResolvedValue([{ id: 'org-1' }])
+                })
+              })
+            })
+          })
+        } as any)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockImplementation((condition: SQL) => {
+              countWhere = condition;
+              return { groupBy: vi.fn().mockResolvedValue([{ orgId: 'org-1', count: 12 }]) };
+            })
+          })
+        } as any);
+
+      const res = await app.request('/orgs/organizations?page=1&limit=10');
+
+      expect(res.status).toBe(200);
+      expect(countWhere).toBeDefined();
+      const compiled = new PgDialect().sqlToQuery(countWhere as SQL);
+      expect(compiled.sql).toContain('<>');
+      expect(compiled.params).toContain('decommissioned');
+    });
+
     // ── includeArchived (Wave 4 Task 3) ────────────────────────────────────
     // Archived orgs are NOT in accessibleOrgIds (computeAccessibleOrgIds
     // allowlists active|trial), so they can never come out of the paginated
@@ -4405,6 +4451,52 @@ describe('org routes', () => {
   };
 
   describe('GET /orgs/sites', () => {
+    // #5315 — the per-site deviceCount filtered only `isEphemeral`, so a
+    // decommissioned device still inflated the Sites table while the record's
+    // Devices tab (GET /devices) excluded it. Assert on the COMPILED predicate:
+    // a JSON dump of the Drizzle condition embeds `devices.status`'s
+    // `enumValues`, which contains the literal 'decommissioned' and would make
+    // this pass against unfixed code.
+    it('excludes decommissioned devices from the per-site device count', async () => {
+      setAuthContext({ scope: 'organization', orgId: '11111111-1111-1111-1111-111111111111' });
+      let countWhere: SQL | undefined;
+      vi.mocked(db.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ count: 1 }])
+          })
+        } as any)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockReturnValue({
+                offset: vi.fn().mockReturnValue({
+                  orderBy: vi.fn().mockResolvedValue([{ id: 'site-1' }])
+                })
+              })
+            })
+          })
+        } as any)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockImplementation((condition: SQL) => {
+              countWhere = condition;
+              return { groupBy: vi.fn().mockResolvedValue([{ siteId: 'site-1', count: 4 }]) };
+            })
+          })
+        } as any);
+
+      const res = await app.request('/orgs/sites?orgId=11111111-1111-1111-1111-111111111111');
+
+      expect(res.status).toBe(200);
+      expect(countWhere).toBeDefined();
+      // This suite mocks the schema module, so column names render blank —
+      // assert on the bound parameter, which carries the real value either way.
+      const compiled = new PgDialect().sqlToQuery(countWhere as SQL);
+      expect(compiled.sql).toContain('<>');
+      expect(compiled.params).toContain('decommissioned');
+    });
+
     it('should return sites with pagination', async () => {
       setAuthContext({ scope: 'organization', orgId: '11111111-1111-1111-1111-111111111111' });
       vi.mocked(db.select)

--- a/apps/api/src/routes/orgs.test.ts
+++ b/apps/api/src/routes/orgs.test.ts
@@ -229,7 +229,17 @@ vi.mock('../db/schema', () => ({
   // inArray was called against the sites.id column specifically.
   sites: { id: { __column: 'sites.id' }, orgId: { __column: 'sites.orgId' } },
   // GET /orgs/sites enriches each site with a grouped device count (#1790).
-  devices: { siteId: { __column: 'devices.siteId' } },
+  // #5315 — `status` and `orgId` are sentinels (same pattern as sites.id /
+  // organizations.status) so the device-count tests can prove the
+  // decommissioned filter is applied to devices.status and not to some other
+  // column: an unrecognized chunk compiles to an opaque bound parameter, so
+  // the sentinel OBJECT itself shows up in `params` and identifies the column.
+  devices: {
+    siteId: { __column: 'devices.siteId' },
+    orgId: { __column: 'devices.orgId' },
+    status: { __column: 'devices.status' },
+    isEphemeral: { __column: 'devices.isEphemeral' },
+  },
   // Agent version pins (issue #2124) validate against this table at save time.
   agentVersions: { id: {}, component: {}, version: {} }
 }));
@@ -2041,9 +2051,14 @@ describe('org routes', () => {
 
       expect(res.status).toBe(200);
       expect(countWhere).toBeDefined();
+      // This suite mocks the schema module, so column names render blank in the
+      // compiled statement — assert on the bound parameters instead, which
+      // carry BOTH the sentinel identifying the column and the excluded value.
+      // Pairing them is what rules out the filter landing on the wrong column.
       const compiled = new PgDialect().sqlToQuery(countWhere as SQL);
       expect(compiled.sql).toContain('<>');
       expect(compiled.params).toContain('decommissioned');
+      expect(compiled.params).toContainEqual({ __column: 'devices.status' });
     });
 
     // ── includeArchived (Wave 4 Task 3) ────────────────────────────────────
@@ -4490,11 +4505,14 @@ describe('org routes', () => {
 
       expect(res.status).toBe(200);
       expect(countWhere).toBeDefined();
-      // This suite mocks the schema module, so column names render blank —
-      // assert on the bound parameter, which carries the real value either way.
+      // This suite mocks the schema module, so column names render blank in the
+      // compiled statement — assert on the bound parameters instead, which
+      // carry BOTH the sentinel identifying the column and the excluded value.
+      // Pairing them is what rules out the filter landing on the wrong column.
       const compiled = new PgDialect().sqlToQuery(countWhere as SQL);
       expect(compiled.sql).toContain('<>');
       expect(compiled.params).toContain('decommissioned');
+      expect(compiled.params).toContainEqual({ __column: 'devices.status' });
     });
 
     it('should return sites with pagination', async () => {

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -1578,17 +1578,23 @@ orgRoutes.get('/organizations', requireScope('organization', 'partner', 'system'
   // `devices_org_id_last_seen_at_idx`, and EXPLAIN on a populated deployment
   // takes the index, not a seq scan.
   //
-  // `devices` has no soft-delete or archive column, so every row is a live
-  // device and a plain count is the whole story. An org with no devices is
-  // absent from the grouped result, hence the `?? 0` rather than leaving it
-  // undefined — "0 devices" is the truth for a new tenant, and undefined is
-  // what produced the blank label in the first place.
+  // Removed devices are excluded (#5315). `devices` has no soft-delete column,
+  // but `status = 'decommissioned'` is the removal marker, and every device
+  // surface a tech reads — the fleet list, the org record's Devices tab, its
+  // Overview tile — hides those rows, so counting them here made this card the
+  // odd one out. An org with no (live) devices is absent from the grouped
+  // result, hence the `?? 0` rather than leaving it undefined — "0 devices" is
+  // the truth for a new tenant, and undefined is what produced the blank label
+  // in the first place.
   const pageOrgIds = ordered.map((org) => org.id);
   const deviceCounts = pageOrgIds.length
     ? await db
         .select({ orgId: devices.orgId, count: sql<number>`count(*)` })
         .from(devices)
-        .where(inArray(devices.orgId, pageOrgIds))
+        .where(and(
+          inArray(devices.orgId, pageOrgIds),
+          ne(devices.status, 'decommissioned'),
+        ))
         .groupBy(devices.orgId)
     : [];
   const deviceCountByOrgId = new Map(
@@ -2556,7 +2562,15 @@ orgRoutes.get('/sites', requireScope('organization', 'partner', 'system'), requi
     const counts = await db
       .select({ siteId: devices.siteId, count: sql<number>`count(*)` })
       .from(devices)
-      .where(and(inArray(devices.siteId, siteIds), eq(devices.isEphemeral, false)))
+      // Removed (decommissioned) devices are excluded alongside the ephemeral
+      // Quick Support ones (#5315): the org record's Devices tab lists
+      // `GET /devices`, which drops decommissioned rows by default, so counting
+      // them here made the Sites table disagree with the tab beside it.
+      .where(and(
+        inArray(devices.siteId, siteIds),
+        eq(devices.isEphemeral, false),
+        ne(devices.status, 'decommissioned'),
+      ))
       .groupBy(devices.siteId);
     for (const row of counts) {
       deviceCountBySite.set(row.siteId, Number(row.count));

--- a/apps/api/src/routes/partner.ts
+++ b/apps/api/src/routes/partner.ts
@@ -146,7 +146,16 @@ partnerRoutes.get(
       lastSeenAt: devices.lastSeenAt
     })
     .from(devices)
-    .where(and(inArray(devices.orgId, orgIdList), eq(devices.isEphemeral, false)));
+    // Removed devices are dropped alongside the ephemeral Quick Support ones
+    // (#5315). This feeds BOTH `deviceCount` and the per-org `devices` rollup
+    // on each dashboard card, and `GET /devices` — every other list a tech
+    // reads — already hides decommissioned rows by default, so leaving them in
+    // made this card disagree with the org record it links to.
+    .where(and(
+      inArray(devices.orgId, orgIdList),
+      eq(devices.isEphemeral, false),
+      ne(devices.status, 'decommissioned'),
+    ));
 
   const devicesByOrg = new Map<string, Array<{
     id: string;

--- a/apps/api/src/services/aiAgents/narrativeContext.ts
+++ b/apps/api/src/services/aiAgents/narrativeContext.ts
@@ -685,7 +685,8 @@ async function loadHeader(orgId: string): Promise<RawOrgHeader & { partnerId: st
            o.partner_id AS partner_id,
            p.name AS partner_name,
            p.timezone AS timezone,
-           (SELECT COUNT(*) FROM devices d WHERE d.org_id = ${orgId} AND d.is_ephemeral = false)::int AS device_count,
+           (SELECT COUNT(*) FROM devices d WHERE d.org_id = ${orgId} AND d.is_ephemeral = false
+             AND d.status <> 'decommissioned')::int AS device_count,
            (SELECT COUNT(*) FROM sites s WHERE s.org_id = ${orgId})::int AS site_count
     FROM organizations o
     JOIN partners p ON p.id = o.partner_id

--- a/apps/api/src/services/archivedOrgReads.ts
+++ b/apps/api/src/services/archivedOrgReads.ts
@@ -270,7 +270,11 @@ export async function listArchivedOrgs(input: {
       const counts = await db
         .select({ orgId: devices.orgId, count: sql<number>`count(*)` })
         .from(devices)
-        .where(inArray(devices.orgId, ids))
+        // Removed devices are excluded here for the same reason as the live
+        // org rows in `GET /orgs/organizations` (#5315) — archived orgs ride
+        // along in THAT response, so a different rule here would make one
+        // payload count two ways.
+        .where(and(inArray(devices.orgId, ids), ne(devices.status, 'decommissioned')))
         .groupBy(devices.orgId);
       return { rows: orgRows, deviceCounts: counts };
     }),


### PR DESCRIPTION
Closes #5315

## Problem

On `/organizations/[id]`, the Overview **Devices** tile and the Sites table device counts included decommissioned devices, while the record's own **Devices** tab excluded them — the sweep saw "Devices 6" over a tab listing 5 rows.

## Root cause

The Devices tab renders `GET /devices`, which drops `status = 'decommissioned'` by default (`routes/devices/core.ts:863`). Three count queries never applied the same predicate:

| Surface | Query | Before |
|---|---|---|
| Overview tile | `orgSummary.ts` | `count(*)` with no status filter — only the `offline` FILTER excluded decommissioned |
| Sites table | `orgs.ts` `GET /orgs/sites` | filtered `isEphemeral` only |
| Org list card | `orgs.ts` `GET /orgs/organizations` | no status filter |

## Fix

`ne(devices.status, 'decommissioned')` on all three. In `orgSummary.ts` the exclusion moved into the WHERE rather than being repeated per FILTER, so `total`, `online` and `offline` describe one population and the tile's "N of M online" sub-label stays coherent.

**Beyond the issue's literal scope:** the issue named the two record-page surfaces; I also fixed the org **list card** count. It disagreed with the record page it links to in exactly the same way, and its comment asserted "`devices` has no soft-delete or archive column, so every row is a live device" — which `decommissioned_at` has since made untrue. Say the word if you'd rather the list card keep counting removed inventory and I'll drop that hunk.

No "removed" label was added — the issue offered that as an alternative and counting only live devices is the smaller, more consistent answer.

## Tests

Three new tests, one per query. Each asserts on the **bound parameter of the compiled statement** (`PgDialect().sqlToQuery(...)`), not a JSON dump of the Drizzle condition — that dump embeds `devices.status`'s `enumValues`, which literally contains `'decommissioned'`, so a substring assertion on it passes against unfixed code. All three were run red against the unfixed queries before the fix landed.

- `apps/api/src/routes/orgSummary.test.ts` — 11 passed
- `apps/api/src/routes/orgs.test.ts` — 301 passed
- `npx tsc --noEmit` (apps/api) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEX58GdCWkLHA9M8nfataF