### PR TITLE
fix(api): count pre-execution action-intent CAS losses as cas_lost (#5326)

### DIFF
--- a/apps/api/src/services/actionIntents/metrics.ts
+++ b/apps/api/src/services/actionIntents/metrics.ts
@@ -59,7 +59,24 @@ export type ActionIntentOutcome =
   | 'self_approved_sole_operator'
   | 'digest_mismatch'
   | 'approver_unauthorized'
-  | 'effect_digest_unpinned';
+  | 'effect_digest_unpinned'
+  /**
+   * #5326: a compare-and-swap into a terminal state (`executing -> completed`
+   * / `executing -> failed`) was LOST — another writer (a reaper, the durable
+   * release worker, a duplicate delivery) had already terminalized the intent.
+   * Emitted by the PRE-execution loss sites in services/aiAgentSdk.ts, where
+   * the tool never ran: nothing is wrong with the intent, so it is neither a
+   * failure of the action nor Sentry-worthy (contention here is expected),
+   * but it was previously a bare `console.warn` and therefore uncountable.
+   * A POST-execution loss is materially different — the side effect already
+   * happened — and stays on `executed` plus its own Sentry event and audit
+   * marker; do not merge the two.
+   *
+   * Metric-only by design: this outcome never flows through
+   * `recordActionIntentEvent`, so it deliberately has no
+   * `action_intent.cas_lost` audit action and no `FAILURE_OUTCOMES` entry.
+   */
+  | 'cas_lost';
 
 interface ActionIntentMetricsRecorder {
   onEvent: (source: ActionIntentSource, action: string, outcome: ActionIntentOutcome) => void;

--- a/apps/api/src/services/aiAgentSdk.test.ts
+++ b/apps/api/src/services/aiAgentSdk.test.ts
@@ -3192,6 +3192,49 @@ describe('Task 2: plan index advances only once the step is authorized', () => {
     }
   });
 
+  // Guard for the metric call itself: a throw out of the metrics layer must
+  // not unwind into the caller's outer catch and replace the specific
+  // revalidation diagnosis with a generic execution_error.
+  it('keeps the specific revalidation error when the cas_lost metric recorder throws (#5326)', async () => {
+    setActionIntentMetricsRecorder({
+      onEvent: () => {
+        throw new Error('prom registry exploded');
+      },
+    });
+    try {
+      vi.mocked(checkGuardrails).mockReturnValue({
+        allowed: true,
+        tier: 3,
+        requiresApproval: true,
+        description: 'Execute command',
+      } as any);
+      mockInsertReturning({ id: 'exec-plan-metric-throws' });
+      mockCreateActionIntent.mockResolvedValue(
+        makeIntentSnapshot({
+          id: 'intent-plan-metric-throws',
+          approvalRequestIds: ['appr-plan-metric-throws'],
+        }),
+      );
+      mockWaitForIntentDecision.mockResolvedValue('approved');
+      mockTransitionIntent.mockResolvedValueOnce(true).mockResolvedValue(false);
+      mockRevalidateApprovedIntentForRelease.mockResolvedValue({ ok: false, errorCode: 'actor_invalid' });
+      const session = makeActiveSession({
+        approvalMode: 'action_plan',
+        activePlanId: 'plan-1',
+        approvedPlanSteps: new Map([[0, { toolName: 'execute_command', input: { command: 'whoami' } }]]),
+      });
+
+      const result = await createSessionPreToolUse(session)('execute_command', { command: 'whoami' });
+
+      expect(result).toEqual({
+        allowed: false,
+        error: 'Authorization for this action could no longer be verified; it was not executed.',
+      });
+    } finally {
+      setActionIntentMetricsRecorder(null);
+    }
+  });
+
   // Control for the test above: when the terminal CAS WINS there is no
   // contention to report, so nothing may be counted as cas_lost.
   it('does NOT bump cas_lost when the pre-execution terminal CAS wins (#5326)', async () => {

--- a/apps/api/src/services/aiAgentSdk.test.ts
+++ b/apps/api/src/services/aiAgentSdk.test.ts
@@ -6,6 +6,7 @@ import { waitForApproval } from './aiAgent';
 import type { ActionIntentSnapshot } from './actionIntents/intentService';
 import type { IntentReleaseRevalidation } from './actionIntents/revalidateRelease';
 import { APPROVED_EXECUTING_MESSAGE, APPROVED_EXECUTING_STATUS } from './aiToolHandoff';
+import { setActionIntentMetricsRecorder } from './actionIntents/metrics';
 
 // ============================================
 // Mocks
@@ -3142,6 +3143,89 @@ describe('Task 2: plan index advances only once the step is authorized', () => {
       { id: 'intent-plan-revalidate-fail', orgId: 'org-1', taskId: null },
       'intent_failed',
     );
+  });
+
+  // #5326: a pre-execution terminal-CAS loss (this one on the revalidation
+  // -failure path) used to be a bare console.warn — invisible to Prometheus.
+  // It now bumps breeze_action_intents_total{outcome="cas_lost"} so contention
+  // on the pre-execution terminalization paths is countable and alertable.
+  it('bumps the cas_lost action-intent metric when a PRE-EXECUTION terminal CAS loses (#5326)', async () => {
+    const onEvent = vi.fn();
+    setActionIntentMetricsRecorder({ onEvent });
+    try {
+      vi.mocked(checkGuardrails).mockReturnValue({
+        allowed: true,
+        tier: 3,
+        requiresApproval: true,
+        description: 'Execute command',
+      } as any);
+      mockInsertReturning({ id: 'exec-plan-revalidate-cas-lost' });
+      mockCreateActionIntent.mockResolvedValue(
+        makeIntentSnapshot({
+          id: 'intent-plan-revalidate-cas-lost',
+          approvalRequestIds: ['appr-plan-revalidate-cas-lost'],
+        }),
+      );
+      mockWaitForIntentDecision.mockResolvedValue('approved');
+      // Wins the approved -> executing release CAS; LOSES the terminal
+      // executing -> failed CAS that the revalidation failure drives.
+      mockTransitionIntent.mockResolvedValueOnce(true).mockResolvedValue(false);
+      mockRevalidateApprovedIntentForRelease.mockResolvedValue({ ok: false, errorCode: 'actor_invalid' });
+      const session = makeActiveSession({
+        approvalMode: 'action_plan',
+        activePlanId: 'plan-1',
+        approvedPlanSteps: new Map([[0, { toolName: 'execute_command', input: { command: 'whoami' } }]]),
+      });
+
+      const result = await createSessionPreToolUse(session)('execute_command', { command: 'whoami' });
+
+      expect(result).toEqual({
+        allowed: false,
+        error: 'Authorization for this action could no longer be verified; it was not executed.',
+      });
+      expect(onEvent).toHaveBeenCalledWith('chat', 'execute_command', 'cas_lost');
+      // Discriminating control: the tool never ran, so this must NOT be
+      // counted as an execution.
+      expect(onEvent).not.toHaveBeenCalledWith('chat', 'execute_command', 'executed');
+    } finally {
+      setActionIntentMetricsRecorder(null);
+    }
+  });
+
+  // Control for the test above: when the terminal CAS WINS there is no
+  // contention to report, so nothing may be counted as cas_lost.
+  it('does NOT bump cas_lost when the pre-execution terminal CAS wins (#5326)', async () => {
+    const onEvent = vi.fn();
+    setActionIntentMetricsRecorder({ onEvent });
+    try {
+      vi.mocked(checkGuardrails).mockReturnValue({
+        allowed: true,
+        tier: 3,
+        requiresApproval: true,
+        description: 'Execute command',
+      } as any);
+      mockInsertReturning({ id: 'exec-plan-revalidate-cas-won' });
+      mockCreateActionIntent.mockResolvedValue(
+        makeIntentSnapshot({
+          id: 'intent-plan-revalidate-cas-won',
+          approvalRequestIds: ['appr-plan-revalidate-cas-won'],
+        }),
+      );
+      mockWaitForIntentDecision.mockResolvedValue('approved');
+      mockTransitionIntent.mockResolvedValue(true);
+      mockRevalidateApprovedIntentForRelease.mockResolvedValue({ ok: false, errorCode: 'actor_invalid' });
+      const session = makeActiveSession({
+        approvalMode: 'action_plan',
+        activePlanId: 'plan-1',
+        approvedPlanSteps: new Map([[0, { toolName: 'execute_command', input: { command: 'whoami' } }]]),
+      });
+
+      await createSessionPreToolUse(session)('execute_command', { command: 'whoami' });
+
+      expect(onEvent).not.toHaveBeenCalledWith('chat', 'execute_command', 'cas_lost');
+    } finally {
+      setActionIntentMetricsRecorder(null);
+    }
   });
 
   // Effect-digest revalidation (tier3-supervised-four-eyes design §4.1): the

--- a/apps/api/src/services/aiAgentSdk.ts
+++ b/apps/api/src/services/aiAgentSdk.ts
@@ -537,8 +537,12 @@ async function transitionIntentAndPublish(
  *   this intent. There is no side effect to reconcile and no result to lose —
  *   the intent is terminal either way. Mirrors `intentReleaseWorker.ts`'s
  *   `failIntent`, which returns quietly on the same race rather than writing
- *   a duplicate audit row for an event that already happened once. A single
- *   warn line, because "which writer won" is still worth being able to grep.
+ *   a duplicate audit row for an event that already happened once. A warn
+ *   line, because "which writer won" is still worth being able to grep, plus
+ *   (#5326) a `breeze_action_intents_total{outcome="cas_lost"}` bump so the
+ *   contention rate is countable — the warn alone left this path invisible to
+ *   Prometheus. Still no Sentry event and no audit row: expected contention
+ *   with no side effect to reconcile is not an error.
  *
  * - `executed: true` — the CAS is attempted AFTER the tool had its real-world
  *   side effect. The effect happened and cannot be undone, but the intent now
@@ -594,6 +598,12 @@ function reportLostTerminalCas(opts: {
       `[AI-SDK] Lost the executing->${intendedStatus} CAS for intent ${intentId} (${casLabel}) — `
       + 'another writer already terminalized it; the tool never ran',
     );
+    // #5326: metric only — no Sentry, no audit marker. The tool never ran, so
+    // nothing was lost but the transition itself, and losing it to a reaper or
+    // the durable worker is expected under contention. It still has to be
+    // COUNTABLE: a rising cas_lost rate means the pre-execution paths are
+    // racing something, and a console.warn cannot carry that signal.
+    recordActionIntentMetric('chat', toolName, 'cas_lost');
     return;
   }
 

--- a/apps/api/src/services/aiAgentSdk.ts
+++ b/apps/api/src/services/aiAgentSdk.ts
@@ -603,7 +603,18 @@ function reportLostTerminalCas(opts: {
     // the durable worker is expected under contention. It still has to be
     // COUNTABLE: a rising cas_lost rate means the pre-execution paths are
     // racing something, and a console.warn cannot carry that signal.
-    recordActionIntentMetric('chat', toolName, 'cas_lost');
+    try {
+      recordActionIntentMetric('chat', toolName, 'cas_lost');
+    } catch (err) {
+      // Mirrors the `executed: true` branch's guard below, for the same
+      // reason: every caller of this helper is reporting SOME other failure
+      // (a revalidation stop, a digest mismatch, the tier-3 catch), and a
+      // throw out of the metrics layer here would unwind into that caller's
+      // outer catch — replacing the specific reason it had already computed
+      // with a generic `execution_error`. Observability must never be able
+      // to overwrite the diagnosis it exists to support.
+      console.error(`[AI-SDK] Failed to record the cas_lost metric for intent ${intentId}:`, err);
+    }
     return;
   }
 


### PR DESCRIPTION
Closes #5326

## Problem

`reportLostTerminalCas` (`apps/api/src/services/aiAgentSdk.ts`) recorded a Prometheus metric only on its `executed: true` branch. The three **pre-execution** call sites — the revalidation stop, the effect-digest mismatch, and the tier-3 catch's self-heal — pass `executed: false` and hit an early return that was a bare `console.warn`. A terminal CAS lost *before* the tool ran was therefore invisible to Prometheus: nothing could count or alert on contention there.

## Fix

- New `cas_lost` member on `ActionIntentOutcome` (`services/actionIntents/metrics.ts`).
- The `executed: false` branch now bumps `breeze_action_intents_total{source,action,outcome="cas_lost"}`, keeping the existing warn line.

**Metric-only by design** — no Sentry event, no audit row. The tool never ran, so there is no side effect to reconcile, and losing the transition to a reaper / the durable release worker / a duplicate delivery is expected under contention. The post-execution case is materially different (the effect already happened) and is untouched: it keeps its `executed` metric, its `captureException`, and its `execution_cas_lost` audit marker.

`cas_lost` never flows through `recordActionIntentEvent`, so it deliberately has **no** `action_intent.cas_lost` audit action and **no** `FAILURE_OUTCOMES` entry; both are documented at the enum member.

## Tests

Red-first. Two tests in `aiAgentSdk.test.ts` drive the real pre-execution path (revalidation failure with the terminal CAS losing) rather than calling the helper directly:

- lost CAS → `onEvent('chat', 'execute_command', 'cas_lost')` fires, and `'executed'` does **not**;
- CAS wins → `cas_lost` is not bumped (discriminating control).

Verified red before the fix (assertion failed with 0 calls while the warn line confirmed the branch was reached), green after.

**Status:** `vitest run src/services/actionIntents src/services/aiAgentSdk src/routes/actionIntents.test.ts src/jobs/intentExpiryReaper.test.ts` → 43 files / 876 tests passed. `tsc --noEmit` clean. No schema, migration, or tenancy surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEX58GdCWkLHA9M8nfataF