### PR TITLE
fix(api): roll back the alert row when alert.triggered fails to publish (#5325)

### DIFF
--- a/apps/api/src/services/alertService.test.ts
+++ b/apps/api/src/services/alertService.test.ts
@@ -94,7 +94,10 @@ vi.mock('./deviceSiteResolver', () => ({ resolveDeviceSiteId: vi.fn(() => Promis
 vi.mock('../jobs/alertCorrelation', () => ({ enqueueAlertCorrelation: enqueueAlertCorrelationMock }));
 
 import { publishEvent } from './eventBus';
-import { createAlert, createSourcedAlert } from './alertService';
+import { setCooldown, isConfigPolicyRuleCooling, markConfigPolicyRuleCooldown, isFlapping } from './alertCooldown';
+import { evaluateConditions } from './alertConditions';
+import { resolveAlertRulesForDevice, resolveMaintenanceConfigForDevice } from './featureConfigResolver';
+import { createAlert, createSourcedAlert, evaluateDeviceAlertsFromPolicy } from './alertService';
 
 describe('createAlert correlation enqueue boundary', () => {
   beforeEach(() => {
@@ -216,6 +219,124 @@ describe('createSourcedAlert (#5241 — rule-less alert sources publish alert.tr
     expect(alertId).toBeNull();
     expect(deleteCalls).toHaveBeenCalledWith(alertsTable);
     expect(captureExceptionMock).toHaveBeenCalled();
+    expect(enqueueAlertCorrelationMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('createAlert publish rollback (#5325)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbMock._selectResults.length = 0;
+    dbMock._insertReturnResults.length = 0;
+    dbMock._selectResults.push(
+      [{ id: 'rule-1', templateId: 'template-1', overrideSettings: null }],
+      [{ id: 'template-1', cooldownMinutes: 5 }],
+      [],
+    );
+    dbMock._insertReturnResults.push([{ id: 'alert-1' }]);
+  });
+
+  it('rolls the alert row back, skips the cooldown and reports when publishing throws', async () => {
+    vi.mocked(publishEvent).mockRejectedValueOnce(new Error('redis down'));
+
+    const alertId = await createAlert({
+      ruleId: 'rule-1',
+      deviceId: 'device-1',
+      orgId: 'org-1',
+      severity: 'critical',
+      title: 'CPU high',
+      message: 'CPU high on device',
+    });
+
+    // An `active` row nobody was notified about would be found by this path's
+    // own dedupe query forever, so it must not survive the failed publish.
+    expect(alertId).toBeNull();
+    expect(deleteCalls).toHaveBeenCalledWith(alertsTable);
+    expect(captureExceptionMock).toHaveBeenCalled();
+    // Burning the cooldown would stop the next evaluation from retrying the
+    // whole create+publish.
+    expect(vi.mocked(setCooldown)).not.toHaveBeenCalled();
+    expect(enqueueAlertCorrelationMock).not.toHaveBeenCalled();
+  });
+
+  it('sets the cooldown and enqueues correlation once the publish succeeds', async () => {
+    const alertId = await createAlert({
+      ruleId: 'rule-1',
+      deviceId: 'device-1',
+      orgId: 'org-1',
+      severity: 'critical',
+      title: 'CPU high',
+      message: 'CPU high on device',
+    });
+
+    expect(alertId).toBe('alert-1');
+    expect(deleteCalls).not.toHaveBeenCalled();
+    expect(vi.mocked(setCooldown)).toHaveBeenCalledWith('rule-1', 'device-1', 5);
+    expect(enqueueAlertCorrelationMock).toHaveBeenCalledWith({ orgId: 'org-1', deviceId: 'device-1' });
+  });
+});
+
+describe('evaluateDeviceAlertsFromPolicy publish rollback (#5325)', () => {
+  const rule = {
+    id: 'cpar-1',
+    name: 'Disk almost full',
+    severity: 'high' as const,
+    conditions: {},
+    cooldownMinutes: 15,
+    autoResolve: false,
+    autoResolveConditions: null,
+    titleTemplate: 'Disk almost full',
+    messageTemplate: 'Disk almost full on device',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbMock._selectResults.length = 0;
+    dbMock._insertReturnResults.length = 0;
+    // device row, then the open-alert dedupe query
+    dbMock._selectResults.push([{ id: 'device-1', orgId: 'org-1', siteId: 'site-7', hostname: 'host' }], []);
+    dbMock._insertReturnResults.push([{ id: 'alert-5' }]);
+    vi.mocked(resolveMaintenanceConfigForDevice).mockResolvedValue(null);
+    vi.mocked(resolveAlertRulesForDevice).mockResolvedValue([rule] as never);
+    vi.mocked(isConfigPolicyRuleCooling).mockResolvedValue(false as never);
+    vi.mocked(isFlapping).mockResolvedValue(false);
+    vi.mocked(evaluateConditions).mockResolvedValue({
+      triggered: true,
+      context: {},
+      conditionsMet: [],
+      conditionsNotMet: [],
+    } as never);
+  });
+
+  it('publishes with the device site and marks the cooldown on success', async () => {
+    const created = await evaluateDeviceAlertsFromPolicy('device-1');
+
+    expect(created).toEqual(['alert-5']);
+    expect(vi.mocked(publishEvent)).toHaveBeenCalledWith(
+      'alert.triggered',
+      'org-1',
+      expect.objectContaining({
+        alertId: 'alert-5',
+        configPolicyAlertRuleId: 'cpar-1',
+        configItemName: 'Disk almost full',
+        source: 'config_policy',
+      }),
+      'alert-service',
+      { siteId: 'site-7' },
+    );
+    expect(vi.mocked(markConfigPolicyRuleCooldown)).toHaveBeenCalledWith('cpar-1', 'device-1', 15);
+  });
+
+  it('rolls the row back and leaves the cooldown unset when publishing throws', async () => {
+    vi.mocked(publishEvent).mockRejectedValueOnce(new Error('redis down'));
+
+    const created = await evaluateDeviceAlertsFromPolicy('device-1');
+
+    expect(created).toEqual([]);
+    expect(deleteCalls).toHaveBeenCalledWith(alertsTable);
+    expect(captureExceptionMock).toHaveBeenCalled();
+    // Marking the cooldown would suppress the retry for cooldownMinutes.
+    expect(vi.mocked(markConfigPolicyRuleCooldown)).not.toHaveBeenCalled();
     expect(enqueueAlertCorrelationMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/services/alertService.ts
+++ b/apps/api/src/services/alertService.ts
@@ -95,7 +95,11 @@ async function publishAlertTriggeredOrRollback(opts: {
       await db.delete(alerts).where(eq(alerts.id, alertId));
     } catch (deleteError) {
       // Now the row IS stranded — unpublished and undeletable. Nothing else
-      // will notice it, so this needs to page rather than only log.
+      // will notice it, so report it under its own errorId. Note that
+      // `captureException` is a no-op when Sentry is not initialised (the
+      // common self-hosted shape), so on those deployments the console.error
+      // below is the only durable trace — operators who want to be paged on
+      // this need a log-based alert on it.
       captureException(deleteError, undefined, {
         errorId: 'alert-triggered-orphan-rollback-failed',
         alertId,

--- a/apps/api/src/services/alertService.ts
+++ b/apps/api/src/services/alertService.ts
@@ -52,6 +52,67 @@ export interface RuleWithTemplate {
 }
 
 /**
+ * Publish `alert.triggered` for an already-inserted alert row, rolling the row
+ * back if the publish fails.
+ *
+ * A committed `active` alert that was never published is worse than no alert at
+ * all: every creator dedupes on open alerts, so the unpublished row makes them
+ * skip re-creating it forever — the silent, inbox-only alert #5241 exists to
+ * eliminate. Deleting it lets the next evaluation retry the whole
+ * create + publish.
+ *
+ * @returns true when the event was published; false when the row was rolled
+ *          back (the caller must not burn a cooldown or enqueue follow-up work).
+ */
+async function publishAlertTriggeredOrRollback(opts: {
+  alertId: string;
+  orgId: string;
+  deviceId: string;
+  /** Producing subsystem, used for the Sentry tag and log lines. */
+  source: string;
+  payload: Record<string, unknown>;
+  publisher: string;
+  siteId: string | null | undefined;
+}): Promise<boolean> {
+  const { alertId, orgId, deviceId, source, payload, publisher, siteId } = opts;
+
+  try {
+    await publishEvent('alert.triggered', orgId, payload, publisher, { siteId });
+    return true;
+  } catch (error) {
+    captureException(error, undefined, {
+      errorId: 'alert-triggered-publish-failed',
+      alertId,
+      alertSource: source,
+      orgId,
+      deviceId
+    });
+    console.error(
+      `[AlertService] Failed to publish alert.triggered for ${source} alert ${alertId}; rolling the alert row back:`,
+      error
+    );
+    try {
+      await db.delete(alerts).where(eq(alerts.id, alertId));
+    } catch (deleteError) {
+      // Now the row IS stranded — unpublished and undeletable. Nothing else
+      // will notice it, so this needs to page rather than only log.
+      captureException(deleteError, undefined, {
+        errorId: 'alert-triggered-orphan-rollback-failed',
+        alertId,
+        alertSource: source,
+        orgId,
+        deviceId
+      });
+      console.error(
+        `[AlertService] Could not roll back unpublished alert ${alertId}; it is stranded active with no notification:`,
+        deleteError
+      );
+    }
+    return false;
+  }
+}
+
+/**
  * Create a new alert
  * - Checks cooldown to prevent duplicates
  * - Deduplicates against existing active alerts
@@ -146,17 +207,17 @@ export async function createAlert(params: CreateAlertParams): Promise<string | n
     return null;
   }
 
-  // Set cooldown
-  await setCooldown(ruleId, deviceId, cooldownMinutes);
-
-  enqueueAlertCorrelationForDevice(orgId, deviceId);
-
-  // Publish event — attach the device's site so site-restricted users see it
+  // Publish event — attach the device's site so site-restricted users see it.
+  // The cooldown and the correlation job are deliberately set only AFTER a
+  // successful publish: on a rollback the next evaluation must be free to retry
+  // the whole create + publish, and nothing may point at the deleted row.
   const siteId = await resolveDeviceSiteId(deviceId);
-  await publishEvent(
-    'alert.triggered',
+  const published = await publishAlertTriggeredOrRollback({
+    alertId: newAlert.id,
     orgId,
-    {
+    deviceId,
+    source: 'alert_rule',
+    payload: {
       alertId: newAlert.id,
       ruleId,
       deviceId,
@@ -164,9 +225,18 @@ export async function createAlert(params: CreateAlertParams): Promise<string | n
       title,
       message
     },
-    'alert-service',
-    { siteId }
-  );
+    publisher: 'alert-service',
+    siteId
+  });
+
+  if (!published) {
+    return null;
+  }
+
+  // Set cooldown
+  await setCooldown(ruleId, deviceId, cooldownMinutes);
+
+  enqueueAlertCorrelationForDevice(orgId, deviceId);
 
   console.log(`[AlertService] Created alert ${newAlert.id} for rule=${ruleId} device=${deviceId}`);
 
@@ -192,6 +262,15 @@ export interface CreateSourcedAlertParams {
   /** Extra fields merged into the `alert.triggered` payload. */
   eventPayload?: Record<string, unknown>;
   triggeredAt?: Date;
+  /** Config-policy alert rule behind this alert, when there is one. */
+  configPolicyId?: string | null;
+  /** Human label for the producing config item, e.g. `'warranty_expiry'`. */
+  configItemName?: string | null;
+  /**
+   * Site to scope the published event to. Omit to resolve it from the device;
+   * pass it explicitly (including `null`) when the caller already knows it.
+   */
+  siteId?: string | null;
 }
 
 /**
@@ -210,8 +289,9 @@ export interface CreateSourcedAlertParams {
  * flap-suppression stay with the caller, whose keys are source-specific
  * (a monitor rule id, a warranty end date, …) rather than an `alertRules` id.
  *
- * @returns the new alert id, or null if the insert produced no row (in which
- *          case nothing is published — the caller should not burn its cooldown).
+ * @returns the new alert id, or null if the insert produced no row or the
+ *          publish failed and the row was rolled back — in either case nothing
+ *          was published and the caller should not burn its cooldown.
  */
 export async function createSourcedAlert(params: CreateSourcedAlertParams): Promise<string | null> {
   const { deviceId, orgId, severity, title, message, context, publisher, eventPayload, triggeredAt } = params;
@@ -222,6 +302,8 @@ export async function createSourcedAlert(params: CreateSourcedAlertParams): Prom
       ruleId: null,
       deviceId,
       orgId,
+      configPolicyId: params.configPolicyId ?? null,
+      configItemName: params.configItemName ?? null,
       severity,
       title,
       message,
@@ -241,61 +323,30 @@ export async function createSourcedAlert(params: CreateSourcedAlertParams): Prom
     return null;
   }
 
-  try {
-    // Attach the device's site so site-restricted users see it, same as createAlert.
-    const siteId = await resolveDeviceSiteId(deviceId);
-    await publishEvent(
-      'alert.triggered',
-      orgId,
-      {
-        alertId,
-        ruleId: null,
-        deviceId,
-        severity,
-        title,
-        message,
-        // `source` last so it is always the one persisted in context — a caller
-        // cannot accidentally publish a source that disagrees with the row.
-        ...eventPayload,
-        source: context.source
-      },
-      publisher,
-      { siteId }
-    );
-  } catch (error) {
-    // The row is already committed but nothing was notified. Leaving it is
-    // WORSE than never creating it: callers dedupe on the open alert, so they
-    // would find an `active` row and skip re-creating it forever — precisely
-    // the silent, inbox-only alert #5241 exists to eliminate. Roll it back so
-    // the next evaluation retries the whole create+publish.
-    captureException(error, undefined, {
-      errorId: 'alert-triggered-publish-failed',
+  // Attach the device's site so site-restricted users see it, same as createAlert.
+  const siteId = params.siteId !== undefined ? params.siteId : await resolveDeviceSiteId(deviceId);
+  const published = await publishAlertTriggeredOrRollback({
+    alertId,
+    orgId,
+    deviceId,
+    source: context.source,
+    payload: {
       alertId,
-      alertSource: context.source,
-      orgId,
-      deviceId
-    });
-    console.error(
-      `[AlertService] Failed to publish alert.triggered for ${context.source} alert ${alertId}; rolling the alert row back:`,
-      error
-    );
-    try {
-      await db.delete(alerts).where(eq(alerts.id, alertId));
-    } catch (deleteError) {
-      // Now the row IS stranded — unpublished and undeletable. Nothing else
-      // will notice it, so this needs to page rather than only log.
-      captureException(deleteError, undefined, {
-        errorId: 'alert-triggered-orphan-rollback-failed',
-        alertId,
-        alertSource: context.source,
-        orgId,
-        deviceId
-      });
-      console.error(
-        `[AlertService] Could not roll back unpublished alert ${alertId}; it is stranded active with no notification:`,
-        deleteError
-      );
-    }
+      ruleId: null,
+      deviceId,
+      severity,
+      title,
+      message,
+      // `source` last so it is always the one persisted in context — a caller
+      // cannot accidentally publish a source that disagrees with the row.
+      ...eventPayload,
+      source: context.source
+    },
+    publisher,
+    siteId
+  });
+
+  if (!published) {
     return null;
   }
 
@@ -1024,56 +1075,40 @@ export async function evaluateDeviceAlertsFromPolicy(deviceId: string): Promise<
         const title = interpolateTemplate(rule.titleTemplate, templateContext);
         const message = interpolateTemplate(rule.messageTemplate, templateContext);
 
-        // 9. Create alert with config policy references (ruleId left null)
-        const [newAlert] = await db
-          .insert(alerts)
-          .values({
-            ruleId: null,
-            deviceId,
-            orgId: device.orgId,
-            configPolicyId: rule.id,
+        // 9. Create alert with config policy references (ruleId left null).
+        // Routed through createSourcedAlert so a failed publish rolls the row
+        // back instead of leaving a silent, dedupe-blocking alert (#5325).
+        const newAlertId = await createSourcedAlert({
+          deviceId,
+          orgId: device.orgId,
+          severity: rule.severity,
+          title,
+          message,
+          context: {
+            ...result.context,
+            conditionsMet: result.conditionsMet,
+            conditionsNotMet: result.conditionsNotMet,
+            cooldownMinutes: rule.cooldownMinutes,
+            source: 'config_policy',
+          },
+          configPolicyId: rule.id,
+          configItemName: rule.name,
+          publisher: 'alert-service',
+          eventPayload: {
+            configPolicyAlertRuleId: rule.id,
             configItemName: rule.name,
-            severity: rule.severity,
-            title,
-            message,
-            context: {
-              ...result.context,
-              conditionsMet: result.conditionsMet,
-              conditionsNotMet: result.conditionsNotMet,
-              cooldownMinutes: rule.cooldownMinutes,
-              source: 'config_policy',
-            },
-            status: 'active',
-            triggeredAt: new Date(),
-          })
-          .returning();
+          },
+          // The device row already carries its site — no need to re-resolve it.
+          siteId: device.siteId,
+        });
 
-        if (newAlert) {
-          // 10. Set cooldown
+        if (newAlertId) {
+          // 10. Set cooldown — only once the alert actually published, so a
+          // rolled-back create is retried on the next evaluation.
           await markConfigPolicyRuleCooldown(rule.id, deviceId, rule.cooldownMinutes);
 
-          enqueueAlertCorrelationForDevice(device.orgId, deviceId);
-
-          // 11. Publish event — carry siteId so site-restricted users get it
-          await publishEvent(
-            'alert.triggered',
-            device.orgId,
-            {
-              alertId: newAlert.id,
-              configPolicyAlertRuleId: rule.id,
-              configItemName: rule.name,
-              deviceId,
-              severity: rule.severity,
-              title,
-              message,
-              source: 'config_policy',
-            },
-            'alert-service',
-            { siteId: device.siteId }
-          );
-
-          console.log(`[AlertService] Created config policy alert ${newAlert.id} for cpar=${rule.id} device=${deviceId}`);
-          createdAlerts.push(newAlert.id);
+          console.log(`[AlertService] Created config policy alert ${newAlertId} for cpar=${rule.id} device=${deviceId}`);
+          createdAlerts.push(newAlertId);
         }
       }
     } catch (error) {

--- a/apps/api/src/services/networkBaseline.alertRollback.test.ts
+++ b/apps/api/src/services/networkBaseline.alertRollback.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// createNetworkChangeAlert used to insert the alert row, link the change event
+// to it, and only then publish — so a failed publish left a change event
+// pointing at an alert nobody was ever notified about (#5325). It now delegates
+// the insert+publish to the guarded createSourcedAlert and only records the link
+// once that returns an id.
+const { dbMock, createSourcedAlertMock, updateSet } = vi.hoisted(() => {
+  const updateSet = vi.fn(() => ({ where: vi.fn(() => Promise.resolve(undefined)) }));
+  return {
+    updateSet,
+    createSourcedAlertMock: vi.fn(),
+    dbMock: {
+      select: vi.fn(() => ({
+        from: () => ({ where: () => ({ limit: () => Promise.resolve([]) }) }),
+      })),
+      update: vi.fn(() => ({ set: updateSet })),
+    },
+  };
+});
+
+vi.mock('../db', () => ({ db: dbMock }));
+vi.mock('./alertService', () => ({ createSourcedAlert: createSourcedAlertMock }));
+
+import { createNetworkChangeAlert } from './networkBaseline';
+
+const DETECTED_AT = new Date('2026-03-04T05:06:07.000Z');
+
+const CHANGE_EVENT = {
+  id: 'change-1',
+  orgId: 'org-1',
+  baselineId: 'baseline-1',
+  linkedDeviceId: 'device-1',
+  ipAddress: '192.168.1.50',
+  macAddress: 'aa:bb:cc:dd:ee:ff',
+  hostname: 'printer-1',
+  assetType: 'printer',
+  eventType: 'new_device',
+  currentState: {},
+  previousState: {},
+  detectedAt: DETECTED_AT,
+} as never;
+
+const SETTINGS = { alertSettings: { newDevice: true } };
+
+describe('createNetworkChangeAlert alert rollback (#5325)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('routes the alert through createSourcedAlert and links the change event on success', async () => {
+    createSourcedAlertMock.mockResolvedValue('alert-3');
+
+    await createNetworkChangeAlert('new_device', CHANGE_EVENT, SETTINGS);
+
+    expect(createSourcedAlertMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        deviceId: 'device-1',
+        orgId: 'org-1',
+        publisher: 'network-baseline',
+        context: expect.objectContaining({ source: 'network_baseline', networkChangeEventId: 'change-1' }),
+        triggeredAt: DETECTED_AT,
+      }),
+    );
+    expect(updateSet).toHaveBeenCalledWith({ alertId: 'alert-3', linkedDeviceId: 'device-1' });
+  });
+
+  it('leaves the change event unlinked when the alert was rolled back', async () => {
+    createSourcedAlertMock.mockResolvedValue(null);
+
+    await createNetworkChangeAlert('new_device', CHANGE_EVENT, SETTINGS);
+
+    // Linking to a deleted alert id would strand the change event pointing at
+    // nothing; leaving it unlinked lets a later run retry.
+    expect(dbMock.update).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/networkBaseline.ts
+++ b/apps/api/src/services/networkBaseline.ts
@@ -16,7 +16,7 @@ import {
   type NetworkBaselineScanSchedule
 } from '../db/schema';
 import type { DiscoveredHostResult } from '../jobs/discoveryWorker';
-import { publishEvent } from './eventBus';
+import { createSourcedAlert } from './alertService';
 
 type NetworkEventType = typeof networkEventTypeEnum.enumValues[number];
 
@@ -637,30 +637,29 @@ export async function createNetworkChangeAlert(
     : eventMessageFallback(normalizedEventType, context);
   const severity = template?.severity ?? EVENT_SEVERITY_FALLBACK[normalizedEventType];
 
-  const [alert] = await db
-    .insert(alerts)
-    .values({
-      ruleId: null,
-      deviceId: alertDeviceId,
-      orgId: changeEvent.orgId,
-      severity,
-      title,
-      message,
-      context: {
-        source: 'network_baseline',
-        networkChangeEventId: changeEvent.id,
-        baselineId: changeEvent.baselineId,
-        ...context
-      },
-      status: 'active',
-      triggeredAt: changeEvent.detectedAt
-    })
-    .returning({ id: alerts.id });
+  // Routed through createSourcedAlert so the row is rolled back if the
+  // alert.triggered publish fails — a committed-but-unpublished alert would be
+  // linked to the change event yet never notify anyone (#5325).
+  const alertId = await createSourcedAlert({
+    deviceId: alertDeviceId,
+    orgId: changeEvent.orgId,
+    severity,
+    title,
+    message,
+    context: {
+      source: 'network_baseline',
+      networkChangeEventId: changeEvent.id,
+      baselineId: changeEvent.baselineId,
+      ...context
+    },
+    publisher: 'network-baseline',
+    eventPayload: { networkChangeEventId: changeEvent.id },
+    triggeredAt: changeEvent.detectedAt
+  });
 
-  const alertId = alert?.id;
   if (!alertId) {
     console.error(
-      `[NetworkBaseline] Alert insert returned no ID for change event ${changeEvent.id} (${normalizedEventType}, device=${alertDeviceId}). Alert may not have been persisted.`
+      `[NetworkBaseline] No alert persisted for change event ${changeEvent.id} (${normalizedEventType}, device=${alertDeviceId}); the change event is left unlinked so a later run can retry.`
     );
     return;
   }
@@ -675,26 +674,6 @@ export async function createNetworkChangeAlert(
       .update(networkChangeEvents)
       .set({ alertId })
       .where(eq(networkChangeEvents.id, changeEvent.id));
-  }
-
-  try {
-    await publishEvent(
-      'alert.triggered',
-      changeEvent.orgId,
-      {
-        alertId,
-        ruleId: null,
-        deviceId: alertDeviceId,
-        severity,
-        title,
-        message,
-        source: 'network-baseline',
-        networkChangeEventId: changeEvent.id
-      },
-      'network-baseline'
-    );
-  } catch (error) {
-    console.error('[NetworkBaseline] Failed to publish alert.triggered event:', error);
   }
 }
 

--- a/apps/api/src/services/warrantyAlertEvaluator.test.ts
+++ b/apps/api/src/services/warrantyAlertEvaluator.test.ts
@@ -5,12 +5,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const selectMock = vi.fn();
 const insertMock = vi.fn();
 const updateMock = vi.fn();
+const deleteMock = vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) }));
 
 vi.mock('../db', () => ({
   db: {
     select: (...args: unknown[]) => selectMock(...args),
     insert: (...args: unknown[]) => insertMock(...args),
     update: (...args: unknown[]) => updateMock(...args),
+    delete: (...args: unknown[]) => deleteMock(...(args as [])),
   },
 }));
 
@@ -23,6 +25,12 @@ vi.mock('../db/schema', () => ({
   configPolicyAssignments: { configPolicyId: 'configPolicyAssignments.configPolicyId', targetId: 'configPolicyAssignments.targetId', level: 'configPolicyAssignments.level', priority: 'configPolicyAssignments.priority' },
   configurationPolicies: { id: 'configurationPolicies.id', status: 'configurationPolicies.status', orgId: 'configurationPolicies.orgId', partnerId: 'configurationPolicies.partnerId' },
   deviceGroupMemberships: { deviceId: 'deviceGroupMemberships.deviceId', groupId: 'deviceGroupMemberships.groupId' },
+}));
+
+const captureExceptionMock = vi.fn();
+vi.mock('./sentry', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  captureException: (...args: unknown[]) => captureExceptionMock(...args),
 }));
 
 const publishEventMock = vi.fn().mockResolvedValue(undefined);
@@ -207,8 +215,41 @@ describe('evaluateWarrantyAlerts gating', () => {
       'alert.triggered',
       ORG_ID,
       expect.objectContaining({ source: 'warranty_evaluator' }),
-      expect.any(String)
+      'warranty-alert-evaluator',
+      expect.objectContaining({}),
     );
+  });
+
+  it('rolls the warranty alert row back when publishing alert.triggered throws (#5325)', async () => {
+    stubAutoResolve();
+    captureInsert();
+    publishEventMock.mockRejectedValueOnce(new Error('redis down'));
+    // 1: warranty row (expiring, fixed-term)
+    selectMock.mockReturnValueOnce(queueSelect([baseWarranty]));
+    // 2: device row (evaluate)
+    selectMock.mockReturnValueOnce(queueSelect([baseDevice]));
+    // 3: device row (resolveWarrantySettings)
+    selectMock.mockReturnValueOnce(queueSelect([baseDevice]));
+    // 4: org row
+    selectMock.mockReturnValueOnce(queueSelect([{ id: ORG_ID, partnerId: null }]));
+    // 5: device group memberships
+    selectMock.mockReturnValueOnce(queueSelect([]));
+    // 6: warranty feature link, enabled at org level
+    selectMock.mockReturnValueOnce(
+      queueSelect([{ inlineSettings: { enabled: true, warnDays: 90, criticalDays: 30 }, level: 'organization', priority: 0 }])
+    );
+    // 7: existing open warranty alert check → none
+    selectMock.mockReturnValueOnce(queueSelect([]));
+    // 8: dismissed warranty alert check → none
+    selectMock.mockReturnValueOnce(queueSelect([]));
+
+    const result = await evaluateWarrantyAlerts(DEVICE_ID);
+
+    // An unpublished `active` row would satisfy check 7 forever, so the device
+    // would never alert on this warranty again.
+    expect(result).toBeNull();
+    expect(deleteMock).toHaveBeenCalled();
+    expect(captureExceptionMock).toHaveBeenCalled();
   });
 
   it('does NOT fire for fixed-term coverage when the assigned policy disables warranty alerts', async () => {

--- a/apps/api/src/services/warrantyAlertEvaluator.ts
+++ b/apps/api/src/services/warrantyAlertEvaluator.ts
@@ -17,7 +17,7 @@ import {
   organizations,
 } from '../db/schema';
 import { eq, and, inArray, isNotNull, or, sql, type SQL } from 'drizzle-orm';
-import { buildResolveAlertCas } from './alertService';
+import { buildResolveAlertCas, createSourcedAlert } from './alertService';
 import { policyOwnershipCondition } from './configPolicyOwnership';
 import { publishEvent } from './eventBus';
 import { captureException } from './sentry';
@@ -310,47 +310,29 @@ export async function evaluateWarrantyAlerts(deviceId: string): Promise<string |
     return null;
   }
 
-  // Create alert
-  const [newAlert] = await db
-    .insert(alerts)
-    .values({
-      ruleId: null,
-      deviceId,
-      orgId: device.orgId,
-      configPolicyId: null,
-      configItemName: 'warranty_expiry',
-      severity,
-      title,
-      message,
-      context: {
-        warrantyEndDate: warranty.warrantyEndDate,
-        daysRemaining,
-        manufacturer: warranty.manufacturer,
-        serialNumber: warranty.serialNumber,
-        source: 'warranty_evaluator',
-      },
-      status: 'active',
-      triggeredAt: new Date(),
-    })
-    .returning();
+  // Create alert. Routed through createSourcedAlert so a failed publish rolls
+  // the row back instead of leaving a silent alert the dedupe above would then
+  // treat as "already open" forever (#5325).
+  const alertId = await createSourcedAlert({
+    deviceId,
+    orgId: device.orgId,
+    severity,
+    title,
+    message,
+    context: {
+      warrantyEndDate: warranty.warrantyEndDate,
+      daysRemaining,
+      manufacturer: warranty.manufacturer,
+      serialNumber: warranty.serialNumber,
+      source: 'warranty_evaluator',
+    },
+    configItemName: 'warranty_expiry',
+    publisher: 'warranty-alert-evaluator',
+  });
 
-  if (newAlert) {
-    await publishEvent(
-      'alert.triggered',
-      device.orgId,
-      {
-        alertId: newAlert.id,
-        deviceId,
-        severity,
-        title,
-        message,
-        source: 'warranty_evaluator',
-      },
-      'warranty-alert-evaluator'
-    );
-
-    console.log(`[WarrantyAlertEvaluator] Created warranty alert ${newAlert.id} for device ${deviceId}`);
-    return newAlert.id;
+  if (alertId) {
+    console.log(`[WarrantyAlertEvaluator] Created warranty alert ${alertId} for device ${deviceId}`);
+    return alertId;
   }
 
   return null;


### PR DESCRIPTION
Closes #5325

## Problem

PR #5309 gave `createSourcedAlert` an insert → publish → compensating-delete guard. Four sibling paths kept the pre-#5309 shape — the alert row is committed and the event published with no guard, so a failed publish leaves an `active` alert nobody was ever notified about. Every one of these paths dedupes on open alerts, so that row then blocks re-creation **forever**: precisely the silent, inbox-only alert #5241 exists to eliminate.

Sites fixed:

| Path | Was |
|---|---|
| `alertService.createAlert` | unguarded publish; cooldown burnt before it |
| `alertService.evaluateDeviceAlertsFromPolicy` | raw insert + unguarded publish |
| `warrantyAlertEvaluator` | raw insert, self-published |
| `networkBaseline.createNetworkChangeAlert` | raw insert, publish logged-and-swallowed, change event already linked |

## Change

- Extracted **`publishAlertTriggeredOrRollback`** as the single guard: publish; on failure delete the row + Sentry `alert-triggered-publish-failed`, and escalate with `alert-triggered-orphan-rollback-failed` when the delete itself fails. `createSourcedAlert` now uses it instead of its own inline copy (behaviour unchanged).
- **`createAlert`** gets the same guard. Its `setCooldown` and correlation enqueue move to *after* a successful publish — burning the cooldown on a rolled-back create would suppress the very retry the rollback exists to enable, and a correlation job must not point at a deleted alert.
- The three raw inserts route through **`createSourcedAlert`**. `CreateSourcedAlertParams` gains `configPolicyId`, `configItemName` and an optional `siteId` so those callers keep their existing columns and event payloads. The config-policy path passes `device.siteId` instead of re-resolving it, and marks its cooldown only once the publish succeeds. `networkBaseline` now sets `network_change_events.alert_id` **after** the alert publishes, so a rolled-back alert can no longer strand a change event linked to a deleted row.

### Intentional behaviour changes from the consolidation

- Warranty and network-baseline alerts now carry the device's `siteId` on the published event (site-restricted users see them, matching every other path) and enqueue device alert correlation.
- The network-baseline event's `source` is now `network_baseline`, matching the value persisted in `alerts.context`. Grepped: no consumer keyed on the old hyphenated `network-baseline` spelling.

## Tests

Red-first per site, mirroring the pattern #5309 added:

- `createAlert` — publish throws → row deleted, `captureException` called, **cooldown not burnt**, no correlation; plus the success control asserting cooldown + correlation do fire.
- `evaluateDeviceAlertsFromPolicy` — publish throws → row deleted, `markConfigPolicyRuleCooldown` not called, returns `[]`; plus a success control asserting the `device.siteId` publish and the cooldown.
- `warrantyAlertEvaluator` — publish throws → row deleted, returns `null`.
- `networkBaseline` (new `networkBaseline.alertRollback.test.ts`) — the change event is linked on success and left **unlinked** when the alert was rolled back.

Verification: 34 files / 361 tests green across `services/alertService*`, `services/networkBaseline*`, `services/warrantyAlertEvaluator*`, `services/policyAlertBridge`, `services/deviceIdentityCollisionAlert`, `jobs/monitorWorker`, `jobs/alertWorker`, `jobs/networkBaselineWorker`, `jobs/offlineDetector*`, `jobs/discoveryWorker`, `routes/networkBaselines*`, `routes/networkChanges*`, `services/warrantySync*`, `services/aiToolsNetwork`, `services/workerRegistry`. `tsc --noEmit` clean; eslint clean on the touched files. No schema or migration changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEX58GdCWkLHA9M8nfataF