### PR TITLE
feat(web): device-group name picker in the filter chip bar + View devices link from Groups page

### DIFF
--- a/apps/web/src/components/devices/DeviceFilterToolbar.test.tsx
+++ b/apps/web/src/components/devices/DeviceFilterToolbar.test.tsx
@@ -75,4 +75,22 @@ describe('DeviceFilterToolbar — device search', () => {
 
     await applyLocale('en');
   });
+
+  // The `groups` prop was accepted and discarded (`groups: _groups`) after the
+  // chip-bar rewrite; this pins the toolbar → Chip → summarizeCondition path.
+  it('resolves a groupId chip to the group name through the toolbar', () => {
+    const groups = [{ id: '33333333-3333-3333-3333-333333333333', name: 'Domain Controllers', type: 'static' as const, deviceCount: 3 }];
+    render(
+      <DeviceFilterToolbar
+        value={{ operator: 'AND', conditions: [{ field: 'groupId', operator: 'in', value: [groups[0].id] }] }}
+        onChange={vi.fn()}
+        listFilters={{ search: '' }}
+        onListFiltersChange={vi.fn()}
+        groups={groups}
+      />
+    );
+    const chip = screen.getByTestId('filter-chip-groupId');
+    expect(chip.textContent).toContain('Domain Controllers');
+    expect(chip.textContent).not.toContain('33333333');
+  });
 });

--- a/apps/web/src/components/devices/DeviceFilterToolbar.tsx
+++ b/apps/web/src/components/devices/DeviceFilterToolbar.tsx
@@ -202,7 +202,7 @@ export function DeviceFilterToolbar({
   onListFiltersChange,
   orgs = [],
   sites = [],
-  groups: _groups = [],
+  groups = [],
   softwareOptions,
   onSoftwareSearch,
   onCreateGroup,
@@ -460,6 +460,7 @@ export function DeviceFilterToolbar({
               onRemove={() => removeConditionAt(index)}
               orgs={orgs as NamedRef[]}
               sites={sites as NamedRef[]}
+              groups={groups as NamedRef[]}
               softwareOptions={softwareOptions}
               onSoftwareSearch={onSoftwareSearch}
             />
@@ -499,6 +500,7 @@ export function DeviceFilterToolbar({
             onChange={(g) => onChange(g.conditions.length === 0 ? null : g)}
             orgs={orgs as NamedRef[]}
             sites={sites as NamedRef[]}
+            groups={groups as NamedRef[]}
             softwareOptions={softwareOptions}
             onSoftwareSearch={onSoftwareSearch}
           />

--- a/apps/web/src/components/devices/DeviceGroupsPage.tsx
+++ b/apps/web/src/components/devices/DeviceGroupsPage.tsx
@@ -7,11 +7,12 @@ import {
   type DragEvent,
   type FormEvent,
 } from "react";
-import { Plus, Pencil, Trash2, Shield, Play, X } from "lucide-react";
+import { Plus, Pencil, Trash2, Shield, Play, X, ListFilter } from "lucide-react";
 import { fetchWithAuth } from "@/stores/auth";
 import { useFleetOrgOwner } from "@/hooks/useFleetOrgOwner";
 import { asList } from "@/lib/asList";
 import type { FilterConditionGroup } from "@breeze/shared";
+import { encodeFilterToHash } from "./filterUrl";
 import { FilterBuilder, DEFAULT_FILTER_FIELDS } from "../filters/FilterBuilder";
 import { FilterPreview } from "../filters/FilterPreview";
 import { useFilterPreview } from "../../hooks/useFilterPreview";
@@ -1097,6 +1098,19 @@ export default function DeviceGroupsPage() {
                       </div>
                     </div>
                     <div className="flex items-center gap-2">
+                      {/* One-click jump into the device list with this group
+                          applied as a chip (the list resolves the id server-side). */}
+                      <a
+                        href={`/devices#${encodeFilterToHash({
+                          operator: "AND",
+                          conditions: [{ field: "groupId", operator: "in", value: [group.id] }],
+                        })}`}
+                        data-testid={`group-view-devices-${group.id}`}
+                        className="inline-flex h-9 items-center gap-2 rounded-md border px-3 text-sm font-medium transition hover:bg-muted"
+                      >
+                        <ListFilter className="h-4 w-4" />
+                        {t("deviceGroupsPage.viewDevices")}
+                      </a>
                       <button
                         type="button"
                         onClick={() => handleOpenEdit(group)}

--- a/apps/web/src/components/devices/DeviceGroupsPage.viewDevices.test.tsx
+++ b/apps/web/src/components/devices/DeviceGroupsPage.viewDevices.test.tsx
@@ -1,0 +1,58 @@
+import { i18n } from '@/lib/i18n';
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import DeviceGroupsPage from './DeviceGroupsPage';
+import { fetchWithAuth } from '../../stores/auth';
+import { useOrgStore } from '../../stores/orgStore';
+import { decodeFilterFromHash } from './filterUrl';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  registerOrgIdProvider: vi.fn(),
+}));
+
+vi.mock('../../hooks/useFilterPreview', () => ({
+  useFilterPreview: () => ({ preview: null, loading: false, error: undefined, refresh: vi.fn() }),
+}));
+
+const mockFetch = vi.mocked(fetchWithAuth);
+const jsonResponse = (body: unknown) =>
+  ({ ok: true, status: 200, json: async () => body }) as unknown as Response;
+
+const GROUP = { id: 'group-1', name: 'Domain Controllers', type: 'static', deviceIds: [], deviceCount: 0 };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useOrgStore.setState({
+    currentOrgId: 'org-focused',
+    allOrgs: false,
+    organizations: [{ id: 'org-focused', partnerId: 'p-1', name: 'Focused Org', status: 'active', createdAt: '2026-01-01T00:00:00Z' }],
+    organizationsLoaded: true,
+    error: null,
+  });
+  mockFetch.mockImplementation(async (url: string) => {
+    const path = String(url).split('?')[0];
+    if (path === '/device-groups') return jsonResponse({ data: [GROUP], total: 1 });
+    if (/^\/device-groups\/[^/]+\/devices$/.test(path)) return jsonResponse({ data: [], total: 0 });
+    return jsonResponse({ data: [], pagination: { page: 1, limit: 50, total: 0 } });
+  });
+});
+
+// Groups were only usable as a device-list filter by hand-pasting a UUID. Each
+// group card now deep-links into /devices with the group pre-applied as a chip.
+describe('DeviceGroupsPage — view devices link', () => {
+  it('links each group card to the device list with a groupId filter in the hash', async () => {
+    await i18n.changeLanguage('en');
+    render(<DeviceGroupsPage />);
+    const link = await waitFor(() => screen.getByTestId('group-view-devices-group-1'));
+    expect(link.tagName).toBe('A');
+    const href = link.getAttribute('href') ?? '';
+    expect(href.startsWith('/devices#filtersV2=')).toBe(true);
+    const group = decodeFilterFromHash(href.slice('/devices#'.length));
+    expect(group).toEqual({
+      operator: 'AND',
+      conditions: [{ field: 'groupId', operator: 'in', value: ['group-1'] }],
+    });
+  });
+});

--- a/apps/web/src/components/devices/FilterChipBar.test.tsx
+++ b/apps/web/src/components/devices/FilterChipBar.test.tsx
@@ -254,6 +254,13 @@ describe('FilterChipBar', () => {
     expect(next.conditions).toHaveLength(1);
   });
 
+  it('sentence builder renders the group picker for a groupId row', () => {
+    const groups = [{ id: '33333333-3333-3333-3333-333333333333', name: 'Domain Controllers' }];
+    const value: FilterConditionGroup = { operator: 'AND', conditions: [{ field: 'groupId', operator: 'in', value: [] }] };
+    render(<FilterSentenceBuilder value={value} onChange={vi.fn()} groups={groups} />);
+    expect(screen.getByTestId('filter-group-picker')).toBeDefined();
+  });
+
   // ---- Spec 4.12 — keyboard ----
   it("'/' focuses the chip bar add button", () => {
     render(<FilterChipBar value={null} onChange={() => {}} />);

--- a/apps/web/src/components/devices/FilterChipBar.tsx
+++ b/apps/web/src/components/devices/FilterChipBar.tsx
@@ -30,6 +30,7 @@ export interface FilterChipBarProps {
   // Spec 4.1 — passed through to FilterValueEditor for name lookups.
   orgs?: NamedRef[];
   sites?: NamedRef[];
+  groups?: NamedRef[];
   // Spec 4.2 — passed through for software multi-select. Optional; if
   // undefined the editor falls back to comma-separated text input.
   softwareOptions?: string[];
@@ -55,7 +56,7 @@ export function defaultConditionForField(field: FilterFieldDefinition): FilterCo
 }
 
 export function FilterChipBar({
-  value, onChange, orgs, sites, softwareOptions, softwareOptionCounts, onSoftwareSearch, onSaveRequested
+  value, onChange, orgs, sites, groups, softwareOptions, softwareOptionCounts, onSoftwareSearch, onSaveRequested
 }: FilterChipBarProps) {
   const { t } = useTranslation('devices');
   const group = value ?? EMPTY_GROUP;
@@ -216,6 +217,7 @@ export function FilterChipBar({
               onRemove={() => handleRemove(i)}
               orgs={orgs}
               sites={sites}
+              groups={groups}
               softwareOptions={softwareOptions}
               softwareOptionCounts={softwareOptionCounts}
               onSoftwareSearch={onSoftwareSearch}
@@ -242,6 +244,7 @@ export function FilterChipBar({
           onChange={(g) => onChange(g.conditions.length === 0 ? null : g)}
           orgs={orgs}
           sites={sites}
+          groups={groups}
           softwareOptions={softwareOptions}
           softwareOptionCounts={softwareOptionCounts}
           onSoftwareSearch={onSoftwareSearch}
@@ -260,6 +263,7 @@ interface ChipProps {
   onRemove: () => void;
   orgs?: NamedRef[];
   sites?: NamedRef[];
+  groups?: NamedRef[];
   softwareOptions?: string[];
   softwareOptionCounts?: Record<string, number>;
   onSoftwareSearch?: (q: string) => void;
@@ -268,7 +272,7 @@ interface ChipProps {
   focused?: boolean;
 }
 
-export function Chip({ condition, onChange, onRemove, orgs, sites, softwareOptions, softwareOptionCounts, onSoftwareSearch, btnRef, onKeyDown, focused }: ChipProps) {
+export function Chip({ condition, onChange, onRemove, orgs, sites, groups, softwareOptions, softwareOptionCounts, onSoftwareSearch, btnRef, onKeyDown, focused }: ChipProps) {
   const { t } = useTranslation('devices');
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
@@ -304,7 +308,7 @@ export function Chip({ condition, onChange, onRemove, orgs, sites, softwareOptio
           onClick={() => setOpen(o => !o)}
           className="hover:underline"
         >
-          {summarizeCondition(field, condition, { orgs, sites })}
+          {summarizeCondition(field, condition, { orgs, sites, groups })}
         </button>
         <button
           type="button"
@@ -326,6 +330,7 @@ export function Chip({ condition, onChange, onRemove, orgs, sites, softwareOptio
             onChange={onChange}
             orgs={orgs}
             sites={sites}
+            groups={groups}
             softwareOptions={softwareOptions}
             softwareOptionCounts={softwareOptionCounts}
             onSoftwareSearch={onSoftwareSearch}

--- a/apps/web/src/components/devices/FilterSentenceBuilder.tsx
+++ b/apps/web/src/components/devices/FilterSentenceBuilder.tsx
@@ -28,6 +28,7 @@ export interface FilterSentenceBuilderProps {
   onChange: (next: FilterConditionGroup) => void;
   orgs?: NamedRef[];
   sites?: NamedRef[];
+  groups?: NamedRef[];
   softwareOptions?: string[];
   softwareOptionCounts?: Record<string, number>;
   // #1459 — debounced server-side software-name search, threaded to the picker.
@@ -61,7 +62,7 @@ export function isChipRenderable(group: FilterConditionGroup | null): boolean {
 const EMPTY_GROUP: FilterConditionGroup = { operator: 'AND', conditions: [] };
 
 export function FilterSentenceBuilder({
-  value, onChange, orgs, sites, softwareOptions, softwareOptionCounts, onSoftwareSearch, onSaveRequested
+  value, onChange, orgs, sites, groups, softwareOptions, softwareOptionCounts, onSoftwareSearch, onSaveRequested
 }: FilterSentenceBuilderProps) {
   const { t } = useTranslation('devices');
   const hasConditions = value.conditions.length > 0;
@@ -75,6 +76,7 @@ export function FilterSentenceBuilder({
         onChange={onChange}
         orgs={orgs}
         sites={sites}
+        groups={groups}
         softwareOptions={softwareOptions}
         softwareOptionCounts={softwareOptionCounts}
         onSoftwareSearch={onSoftwareSearch}
@@ -122,12 +124,13 @@ interface GroupEditorProps {
   onChange: (next: FilterConditionGroup) => void;
   orgs?: NamedRef[];
   sites?: NamedRef[];
+  groups?: NamedRef[];
   softwareOptions?: string[];
   softwareOptionCounts?: Record<string, number>;
   onSoftwareSearch?: (q: string) => void;
   depth: number;
 }
-function GroupEditor({ group, onChange, orgs, sites, softwareOptions, softwareOptionCounts, onSoftwareSearch, depth }: GroupEditorProps) {
+function GroupEditor({ group, onChange, orgs, sites, groups, softwareOptions, softwareOptionCounts, onSoftwareSearch, depth }: GroupEditorProps) {
   const { t } = useTranslation('devices');
   const toggleOp = () => onChange({ ...group, operator: group.operator === 'AND' ? 'OR' : 'AND' });
   const addCondition = () => {
@@ -183,6 +186,7 @@ function GroupEditor({ group, onChange, orgs, sites, softwareOptions, softwareOp
                   onChange={(g) => updateAt(i, g)}
                   orgs={orgs}
                   sites={sites}
+                  groups={groups}
                   softwareOptions={softwareOptions}
                   softwareOptionCounts={softwareOptionCounts}
                   onSoftwareSearch={onSoftwareSearch}
@@ -208,6 +212,7 @@ function GroupEditor({ group, onChange, orgs, sites, softwareOptions, softwareOp
               onRemove={() => removeAt(i)}
               orgs={orgs}
               sites={sites}
+              groups={groups}
               softwareOptions={softwareOptions}
               softwareOptionCounts={softwareOptionCounts}
               onSoftwareSearch={onSoftwareSearch}
@@ -244,12 +249,13 @@ interface ConditionRowProps {
   onRemove: () => void;
   orgs?: NamedRef[];
   sites?: NamedRef[];
+  groups?: NamedRef[];
   softwareOptions?: string[];
   softwareOptionCounts?: Record<string, number>;
   onSoftwareSearch?: (q: string) => void;
   rowId: string;
 }
-function ConditionRow({ condition, onChange, onRemove, orgs, sites, softwareOptions, softwareOptionCounts, onSoftwareSearch, rowId }: ConditionRowProps) {
+function ConditionRow({ condition, onChange, onRemove, orgs, sites, groups, softwareOptions, softwareOptionCounts, onSoftwareSearch, rowId }: ConditionRowProps) {
   const { t } = useTranslation('devices');
   const field = getFieldDef(condition.field) ?? V2_FILTER_FIELDS[0];
   const setField = (key: string) => {
@@ -281,6 +287,7 @@ function ConditionRow({ condition, onChange, onRemove, orgs, sites, softwareOpti
           onChange={onChange}
           orgs={orgs}
           sites={sites}
+          groups={groups}
           softwareOptions={softwareOptions}
           softwareOptionCounts={softwareOptionCounts}
           onSoftwareSearch={onSoftwareSearch}

--- a/apps/web/src/components/devices/FilterValueEditor.groupPicker.test.tsx
+++ b/apps/web/src/components/devices/FilterValueEditor.groupPicker.test.tsx
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { FilterValueEditor } from './FilterValueEditor';
+import { getFieldDef } from './filterFields';
+
+describe('FilterValueEditor — device group picker', () => {
+  it('renders a searchable group name picker (not a raw UUID input) and stores ids', () => {
+    const groups = [
+      { id: '33333333-3333-3333-3333-333333333333', name: 'Domain Controllers' },
+      { id: '44444444-4444-4444-4444-444444444444', name: 'Kiosks' }
+    ];
+    const onChange = vi.fn();
+    render(
+      <FilterValueEditor
+        field={getFieldDef('groupId')!}
+        condition={{ field: 'groupId', operator: 'in', value: [] }}
+        onChange={onChange}
+        groups={groups}
+      />
+    );
+    expect(screen.getByTestId('filter-group-picker')).toBeDefined();
+    expect(screen.getByTestId(`filter-group-picker-option-${groups[0].id}`).textContent).toContain('Domain Controllers');
+    expect(screen.getByTestId(`filter-group-picker-option-${groups[1].id}`).textContent).toContain('Kiosks');
+
+    fireEvent.click(screen.getByTestId(`filter-group-picker-option-${groups[1].id}`));
+    const next = onChange.mock.calls[0][0];
+    expect(next.operator).toBe('in');
+    expect(next.value).toEqual([groups[1].id]);
+  });
+});

--- a/apps/web/src/components/devices/FilterValueEditor.test.tsx
+++ b/apps/web/src/components/devices/FilterValueEditor.test.tsx
@@ -34,3 +34,26 @@ describe('summarizeCondition', () => {
     expect(summary).not.toContain('decommissioned');
   });
 });
+
+// Device-group filter: the chip-bar rewrite dropped the old group multi-select
+// and left `groupId` as a raw-UUID text input. Groups now get the same named
+// picker + chip-name resolution as orgs/sites.
+const groupField: FilterFieldDefinition = {
+  key: 'groupId',
+  label: 'Device Group',
+  category: 'hierarchy',
+  type: 'string',
+  operators: ['equals', 'in']
+};
+
+describe('summarizeCondition — device groups', () => {
+  it('resolves group UUIDs to names when a groups lookup is provided', () => {
+    const groups = [{ id: '33333333-3333-3333-3333-333333333333', name: 'Domain Controllers' }];
+    const condition: FilterCondition = { field: 'groupId', operator: 'in', value: [groups[0].id] };
+
+    const summary = summarizeCondition(groupField, condition, { groups });
+
+    expect(summary).toBe('Device Group is any of Domain Controllers');
+    expect(summary).not.toContain('33333333');
+  });
+});

--- a/apps/web/src/components/devices/FilterValueEditor.tsx
+++ b/apps/web/src/components/devices/FilterValueEditor.tsx
@@ -36,6 +36,8 @@ export interface FilterValueEditorProps {
   // Spec 4.1 — name lookups for hierarchy fields.
   orgs?: NamedRef[];
   sites?: NamedRef[];
+  // Device groups (static + dynamic) — same named picker as org/site.
+  groups?: NamedRef[];
   // Optional filter to limit shown sites to those under the orgIds the user
   // has already selected (parent provides this filtered list).
   // Spec 4.2 — distinct software-name list pulled from API.
@@ -63,9 +65,10 @@ function isSoftwareField(key: string): boolean {
 
 function isOrgField(key: string): boolean { return key === 'orgId'; }
 function isSiteField(key: string): boolean { return key === 'siteId'; }
+function isGroupField(key: string): boolean { return key === 'groupId'; }
 
 export function FilterValueEditor({
-  field, condition, onChange, orgs, sites, softwareOptions, softwareOptionCounts, onSoftwareSearch
+  field, condition, onChange, orgs, sites, groups, softwareOptions, softwareOptionCounts, onSoftwareSearch
 }: FilterValueEditorProps) {
   const { t } = useTranslation('devices');
   const op = condition.operator;
@@ -109,6 +112,17 @@ export function FilterValueEditor({
         condition={condition}
         onChange={onChange}
         testId="filter-site-picker"
+      />
+    );
+  }
+  if (isGroupField(field.key) && groups) {
+    return (
+      <NamedMultiSelect
+        label={t('filterValueEditor.deviceGroups')}
+        options={groups}
+        condition={condition}
+        onChange={onChange}
+        testId="filter-group-picker"
       />
     );
   }
@@ -371,17 +385,18 @@ const CHIP_VALUE_DISPLAY_OVERRIDES: Record<string, string> = {
 };
 
 export function summarizeCondition(field: FilterFieldDefinition, c: FilterCondition, lookups?: {
-  orgs?: NamedRef[]; sites?: NamedRef[];
+  orgs?: NamedRef[]; sites?: NamedRef[]; groups?: NamedRef[];
 }): string {
   const op = operatorLabel(c.operator);
   if (NO_VALUE_OPERATORS.includes(c.operator)) return `${field.label} ${op}`;
   let v: string;
   if (Array.isArray(c.value)) {
-    // Resolve names for org/site chips.
+    // Resolve names for org/site/group chips.
     let display = c.value as string[];
     if (lookups) {
       const table = field.key === 'orgId' ? lookups.orgs
-        : field.key === 'siteId' ? lookups.sites : undefined;
+        : field.key === 'siteId' ? lookups.sites
+        : field.key === 'groupId' ? lookups.groups : undefined;
       if (table) {
         const byId = new Map(table.map(o => [o.id, o.name]));
         display = display.map(id => byId.get(id) ?? id.slice(0, 8));

--- a/apps/web/src/components/devices/FilterValueEditor.tsx
+++ b/apps/web/src/components/devices/FilterValueEditor.tsx
@@ -7,9 +7,10 @@
 //   - array + hasAny/hasAll: comma-separated text → string[]
 //   - any + isNull/isNotNull/isEmpty/isNotEmpty: no value input
 //
-// Spec section 4.1 — when the field is `orgId` / `siteId` and the parent
-// provides orgs/sites name lookups, render a searchable multi-select of
-// names instead of raw UUIDs.
+// Spec section 4.1 — when the field is `orgId` / `siteId` / `groupId` and the
+// parent provides the matching orgs/sites/groups name lookup, render a
+// searchable multi-select of names instead of raw UUIDs. (Groups extend the
+// spec text — #5342.)
 // Spec section 4.2 — when the field is `software.installed` /
 // `software.notInstalled` and softwareOptions are provided, render a
 // multi-select chip list with All/Any combinator.
@@ -38,8 +39,6 @@ export interface FilterValueEditorProps {
   sites?: NamedRef[];
   // Device groups (static + dynamic) — same named picker as org/site.
   groups?: NamedRef[];
-  // Optional filter to limit shown sites to those under the orgIds the user
-  // has already selected (parent provides this filtered list).
   // Spec 4.2 — distinct software-name list pulled from API.
   softwareOptions?: string[];
   // Optional per-name device counts to surface in the picker list.

--- a/apps/web/src/locales/de-DE/devices.json
+++ b/apps/web/src/locales/de-DE/devices.json
@@ -800,6 +800,7 @@
     "activeFilters": "Aktive Filter:"
   },
   "deviceGroupsPage": {
+    "viewDevices": "Geräte anzeigen",
     "failedToFetchDeviceGroups": "Gerätegruppen konnten nicht abgerufen werden",
     "windows": "Fenster",
     "put": "PUT",
@@ -2210,6 +2211,7 @@
     }
   },
   "filterValueEditor": {
+    "deviceGroups": "Gerätegruppen",
     "any": "Irgendein",
     "csvPlaceholder": "Durch Kommas getrennte App-Namen",
     "noMatches": "Keine Übereinstimmungen",

--- a/apps/web/src/locales/en/devices.json
+++ b/apps/web/src/locales/en/devices.json
@@ -800,6 +800,7 @@
     "activeFilters": "Active filters:"
   },
   "deviceGroupsPage": {
+    "viewDevices": "View devices",
     "failedToFetchDeviceGroups": "Failed to fetch device groups",
     "windows": "windows",
     "put": "PUT",
@@ -2210,6 +2211,7 @@
     }
   },
   "filterValueEditor": {
+    "deviceGroups": "Device groups",
     "any": "Any",
     "csvPlaceholder": "comma-separated app names",
     "noMatches": "No matches",

--- a/apps/web/src/locales/es-419/devices.json
+++ b/apps/web/src/locales/es-419/devices.json
@@ -800,6 +800,7 @@
     "activeFilters": "Filtros activos:"
   },
   "deviceGroupsPage": {
+    "viewDevices": "Ver dispositivos",
     "failedToFetchDeviceGroups": "No se pudieron recuperar los grupos de dispositivos",
     "windows": "Windows",
     "put": "PUT",
@@ -2210,6 +2211,7 @@
     }
   },
   "filterValueEditor": {
+    "deviceGroups": "Grupos de dispositivos",
     "any": "Cualquier",
     "csvPlaceholder": "nombres de aplicaciones separados por comas",
     "noMatches": "No hay coincidencias",

--- a/apps/web/src/locales/fr-CA/devices.json
+++ b/apps/web/src/locales/fr-CA/devices.json
@@ -800,6 +800,7 @@
     "activeFilters": "Filtres actifs :"
   },
   "deviceGroupsPage": {
+    "viewDevices": "Voir les appareils",
     "failedToFetchDeviceGroups": "Impossible de récupérer les groupes d’appareils",
     "windows": "Fenêtres",
     "put": "PUT",
@@ -2210,6 +2211,7 @@
     }
   },
   "filterValueEditor": {
+    "deviceGroups": "Groupes d’appareils",
     "any": "N’importe lequel",
     "csvPlaceholder": "Noms d’applications séparés par virgules",
     "noMatches": "Pas de matchs",

--- a/apps/web/src/locales/fr-FR/devices.json
+++ b/apps/web/src/locales/fr-FR/devices.json
@@ -800,6 +800,7 @@
     "activeFilters": "Filtres actifs :"
   },
   "deviceGroupsPage": {
+    "viewDevices": "Voir les appareils",
     "failedToFetchDeviceGroups": "Impossible de récupérer les groupes d’appareils",
     "windows": "Fenêtres",
     "put": "PUT",
@@ -2210,6 +2211,7 @@
     }
   },
   "filterValueEditor": {
+    "deviceGroups": "Groupes d’appareils",
     "any": "N’importe lequel",
     "csvPlaceholder": "Noms d’applications séparés par virgules",
     "noMatches": "Pas de matchs",

--- a/apps/web/src/locales/it-IT/devices.json
+++ b/apps/web/src/locales/it-IT/devices.json
@@ -800,6 +800,7 @@
     "activeFilters": "Filtri attivi:"
   },
   "deviceGroupsPage": {
+    "viewDevices": "Visualizza dispositivi",
     "failedToFetchDeviceGroups": "Impossibile recuperare i gruppi di dispositivi",
     "windows": "windows",
     "put": "PUT",
@@ -2210,6 +2211,7 @@
     }
   },
   "filterValueEditor": {
+    "deviceGroups": "Gruppi di dispositivi",
     "any": "Qualsiasi",
     "csvPlaceholder": "nomi delle app separati da virgole",
     "noMatches": "Nessuna corrispondenza",

--- a/apps/web/src/locales/pt-BR/devices.json
+++ b/apps/web/src/locales/pt-BR/devices.json
@@ -800,6 +800,7 @@
     "activeFilters": "Filtros ativos:"
   },
   "deviceGroupsPage": {
+    "viewDevices": "Ver dispositivos",
     "failedToFetchDeviceGroups": "Falha ao buscar grupos de dispositivos",
     "windows": "windows",
     "put": "PUT",
@@ -2210,6 +2211,7 @@
     }
   },
   "filterValueEditor": {
+    "deviceGroups": "Grupos de dispositivos",
     "any": "Qualquer",
     "csvPlaceholder": "nomes de aplicativos separados por vírgulas",
     "noMatches": "Nenhuma correspondência",

--- a/apps/web/src/locales/tr-TR/devices.json
+++ b/apps/web/src/locales/tr-TR/devices.json
@@ -800,6 +800,7 @@
     "activeFilters": "Aktif filtreler:"
   },
   "deviceGroupsPage": {
+    "viewDevices": "Cihazları görüntüle",
     "failedToFetchDeviceGroups": "Cihaz grupları getirilemedi",
     "windows": "pencereler",
     "put": "PUT",
@@ -2210,6 +2211,7 @@
     }
   },
   "filterValueEditor": {
+    "deviceGroups": "Cihaz grupları",
     "any": "Herhangi biri",
     "csvPlaceholder": "virgülle ayrılmış uygulama adları",
     "noMatches": "Eşleşme yok",


### PR DESCRIPTION
## Problem
Custom device groups were well supported as targets (alerts, automations, deployments, policies…) but nearly unusable as a **device-list filter**: the chip-bar rewrite deleted the group multi-select, leaving the *Device Group* filter as a free-text UUID input whose chip rendered a truncated UUID. `DevicesPage` already fetched groups and passed them to `DeviceFilterToolbar`, which discarded them (`groups: _groups`). There was also no way to get from the Groups page to the filtered device list.

## Change
- `FilterValueEditor`: `groupId` renders the same searchable name picker as org/site (`filter-group-picker`), storing ids with operator `in`.
- `summarizeCondition` resolves group ids → names on the chip.
- `groups` threaded through `DeviceFilterToolbar` → `Chip` / `FilterSentenceBuilder` (the dead prop is now live).
- `DeviceGroupsPage`: each group card gets a **View devices** link to `/devices#filtersV2=…` with the group pre-applied, so Groups → filtered list is one click. Saved views persist it like any other chip.
- i18n keys `filterValueEditor.deviceGroups` and `deviceGroupsPage.viewDevices` in all 8 locales. pt-BR strings are machine-drafted pending native review.

## Tests
Red-first: `FilterValueEditor.groupPicker.test.tsx`, `DeviceGroupsPage.viewDevices.test.tsx`, and a `summarizeCondition` group case — all failed before the change, pass after. Ran the devices filter suites + i18n parity/coverage (15 files, 191 tests), `tsc --noEmit`, eslint on touched files: clean.

## Not in scope (follow-ups worth filing)
Script execution modal cannot target a group; reports can group-by but not scope-to a group; partner API has no `groupId` filter; portal/mobile have no group concept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Du64qwqJjTsGGyf69qePG9