### PR TITLE
fix(db): preserve tenant context across assignment deletes and device moves

### DIFF
--- a/apps/api/migrations/2026-10-15-120001-restore-assignment-delete-context.sql
+++ b/apps/api/migrations/2026-10-15-120001-restore-assignment-delete-context.sql
@@ -1,0 +1,79 @@
+-- The assignment-owner DELETE statement trigger enters system scope for
+-- integrity checks. Restore the exact request context before returning so
+-- later statements in the same transaction remain tenant-scoped.
+-- CREATE OR REPLACE preserves the existing function owner and ACL.
+CREATE OR REPLACE FUNCTION public.breeze_serialize_config_policy_assignment_owner_deletes()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  _prev_scope text := current_setting('breeze.scope', true);
+  _prev_org_ids text := current_setting('breeze.accessible_org_ids', true);
+  _prev_partner_ids text := current_setting('breeze.accessible_partner_ids', true);
+  identities text[] := ARRAY[]::text[];
+  values jsonb[] := ARRAY[]::jsonb[];
+  lock_key integer;
+BEGIN
+  PERFORM set_config('breeze.scope', 'system', true);
+  PERFORM set_config('breeze.accessible_org_ids', '', true);
+  PERFORM set_config('breeze.accessible_partner_ids', '', true);
+  IF TG_TABLE_NAME = 'configuration_policies' THEN
+    SELECT COALESCE(array_agg(identity), ARRAY[]::text[]) INTO identities FROM (
+      SELECT 'policy:' || id::text AS identity FROM old_rows
+      UNION SELECT 'org:' || org_id::text FROM old_rows WHERE org_id IS NOT NULL
+      UNION SELECT 'partner:' || partner_id::text FROM old_rows WHERE partner_id IS NOT NULL
+    ) keys;
+  ELSIF TG_TABLE_NAME = 'organizations' THEN
+    SELECT COALESCE(array_agg(identity), ARRAY[]::text[]) INTO identities FROM (
+      SELECT 'target:organization:' || id::text AS identity FROM old_rows
+      UNION SELECT 'org:' || id::text FROM old_rows
+      UNION SELECT 'partner:' || partner_id::text FROM old_rows
+    ) keys;
+  ELSE
+    SELECT COALESCE(array_agg(identity), ARRAY[]::text[]) INTO identities FROM (
+      SELECT 'target:' || CASE TG_TABLE_NAME
+        WHEN 'sites' THEN 'site'
+        WHEN 'device_groups' THEN 'device_group'
+        WHEN 'devices' THEN 'device'
+      END || ':' || id::text AS identity FROM old_rows
+      UNION SELECT 'org:' || org_id::text FROM old_rows
+      UNION SELECT 'partner:' || organization.partner_id::text
+        FROM public.organizations organization
+        WHERE organization.id IN (SELECT org_id FROM old_rows)
+    ) keys;
+  END IF;
+
+  FOR lock_key IN
+    SELECT DISTINCT hashtext(identity) FROM unnest(identities) identity
+    ORDER BY hashtext(identity)
+  LOOP
+    PERFORM pg_advisory_xact_lock(1000301, lock_key);
+  END LOOP;
+
+  IF TG_TABLE_NAME = 'configuration_policies' THEN
+    -- The FK cascade has already removed these assignments.
+    values := ARRAY[]::jsonb[];
+  ELSIF TG_TABLE_NAME = 'organizations' THEN
+    SELECT COALESCE(array_agg(to_jsonb(assignment)), ARRAY[]::jsonb[]) INTO values
+    FROM public.config_policy_assignments assignment
+    WHERE assignment.level = 'organization'
+      AND assignment.target_id IN (SELECT id FROM old_rows);
+  ELSE
+    SELECT COALESCE(array_agg(to_jsonb(assignment)), ARRAY[]::jsonb[]) INTO values
+    FROM public.config_policy_assignments assignment
+    WHERE assignment.target_id IN (SELECT id FROM old_rows)
+      AND assignment.level::text = CASE TG_TABLE_NAME
+        WHEN 'sites' THEN 'site'
+        WHEN 'device_groups' THEN 'device_group'
+        WHEN 'devices' THEN 'device'
+      END;
+  END IF;
+  PERFORM public.breeze_validate_config_policy_assignment_new_rows(values);
+  PERFORM set_config('breeze.scope', COALESCE(_prev_scope, ''), true);
+  PERFORM set_config('breeze.accessible_org_ids', COALESCE(_prev_org_ids, ''), true);
+  PERFORM set_config('breeze.accessible_partner_ids', COALESCE(_prev_partner_ids, ''), true);
+  RETURN NULL;
+END;
+$$;

--- a/apps/api/migrations/2026-10-15-120002-authorize-custom-field-value-rehome.sql
+++ b/apps/api/migrations/2026-10-15-120002-authorize-custom-field-value-rehome.sql
@@ -1,0 +1,144 @@
+-- Harden the callable SECURITY DEFINER re-home helper: authorize both move
+-- endpoints under the original request context before its cross-axis work
+-- enters system scope. Remove PostgreSQL's default PUBLIC execute privilege;
+-- CREATE OR REPLACE preserves the established owner.
+CREATE OR REPLACE FUNCTION public.breeze_rehome_device_custom_field_values(
+  p_device_id uuid,
+  p_target_org_id uuid
+)
+RETURNS TABLE (rehomed int, dropped int)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  _prev_scope text := NULLIF(current_setting('breeze.scope', true), '');
+  source_org_id uuid;
+  source_partner_id uuid;
+  target_partner_id uuid;
+  n_rehomed int := 0;
+  n_dropped int := 0;
+BEGIN
+  -- The definer may own/bypass RLS, so row visibility here is data resolution,
+  -- never authorization. The breeze_has_org_access checks below consume the
+  -- unchanged caller GUCs and make the authorization decision before elevation.
+  SELECT d.org_id, o.partner_id
+    INTO source_org_id, source_partner_id
+    FROM public.devices d
+    JOIN public.organizations o ON o.id = d.org_id
+   WHERE d.id = p_device_id;
+  SELECT o.partner_id INTO target_partner_id
+    FROM public.organizations o WHERE o.id = p_target_org_id;
+
+  IF _prev_scope IS NULL
+     OR _prev_scope NOT IN ('system', 'partner', 'organization')
+     OR (
+       _prev_scope <> 'system'
+       AND (
+         source_org_id IS NULL
+         OR target_partner_id IS NULL
+         OR NOT public.breeze_has_org_access(source_org_id)
+         OR NOT public.breeze_has_org_access(p_target_org_id)
+         OR source_partner_id IS DISTINCT FROM target_partner_id
+       )
+     ) THEN
+    RAISE EXCEPTION 'custom-field value re-home access denied'
+      USING ERRCODE = '42501';
+  END IF;
+
+  -- Preserve the established system-only no-op contract for missing/same-org
+  -- inputs. Normal request callers were rejected above if either object was
+  -- missing, avoiding a foreign-object existence oracle.
+  IF source_org_id IS NULL OR target_partner_id IS NULL OR source_org_id = p_target_org_id THEN
+    rehomed := 0;
+    dropped := 0;
+    RETURN NEXT;
+    RETURN;
+  END IF;
+
+  -- Acquire the move's established export locks under caller scope, then
+  -- re-resolve every authorization fact. The advisory lock can block; facts
+  -- read before it are not safe to use after it returns.
+  PERFORM public.breeze_partner_export_lock_orgs_exclusive(
+    ARRAY[source_org_id, p_target_org_id]
+  );
+
+  source_org_id := NULL;
+  source_partner_id := NULL;
+  target_partner_id := NULL;
+  SELECT d.org_id, o.partner_id
+    INTO source_org_id, source_partner_id
+    FROM public.devices d
+    JOIN public.organizations o ON o.id = d.org_id
+   WHERE d.id = p_device_id;
+  SELECT o.partner_id INTO target_partner_id
+    FROM public.organizations o WHERE o.id = p_target_org_id;
+
+  IF source_org_id IS NULL
+     OR target_partner_id IS NULL
+     OR (
+       _prev_scope <> 'system'
+       AND (
+         NOT public.breeze_has_org_access(source_org_id)
+         OR NOT public.breeze_has_org_access(p_target_org_id)
+         OR source_partner_id IS DISTINCT FROM target_partner_id
+       )
+     ) THEN
+    RAISE EXCEPTION 'custom-field value re-home access denied'
+      USING ERRCODE = '42501';
+  END IF;
+
+  PERFORM set_config('breeze.scope', 'system', true);
+
+  WITH candidate AS (
+    SELECT v.id AS value_id, tgt.id AS target_definition_id
+      FROM public.device_custom_field_values v
+      CROSS JOIN LATERAL (
+        SELECT f.id
+          FROM public.custom_field_definitions f
+         WHERE f.field_key = v.field_key
+           AND (f.org_id = p_target_org_id
+                OR (f.org_id IS NULL AND f.partner_id = target_partner_id))
+         LIMIT 1
+      ) tgt
+     WHERE v.device_id = p_device_id
+       AND v.org_id = source_org_id
+       AND tgt.id <> v.definition_id
+       AND NOT EXISTS (
+         SELECT 1 FROM public.device_custom_field_values occupied
+          WHERE occupied.device_id = p_device_id
+            AND occupied.definition_id = tgt.id)
+  ), moved AS (
+    UPDATE public.device_custom_field_values v
+       SET definition_id = candidate.target_definition_id,
+           org_id = p_target_org_id,
+           updated_at = now()
+      FROM candidate
+     WHERE v.id = candidate.value_id
+       AND v.org_id = source_org_id
+    RETURNING 1
+  )
+  SELECT count(*)::int INTO n_rehomed FROM moved;
+
+  WITH gone AS (
+    DELETE FROM public.device_custom_field_values v
+     WHERE v.device_id = p_device_id
+       AND v.org_id = source_org_id
+       AND NOT EXISTS (
+         SELECT 1 FROM public.custom_field_definitions f
+          WHERE f.id = v.definition_id
+            AND (f.org_id = p_target_org_id
+                 OR (f.org_id IS NULL AND f.partner_id = target_partner_id)))
+    RETURNING 1
+  )
+  SELECT count(*)::int INTO n_dropped FROM gone;
+
+  PERFORM set_config('breeze.scope', _prev_scope, true);
+  rehomed := n_rehomed;
+  dropped := n_dropped;
+  RETURN NEXT;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.breeze_rehome_device_custom_field_values(uuid, uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.breeze_rehome_device_custom_field_values(uuid, uuid) TO breeze_app;

--- a/apps/api/src/__tests__/integration/configPolicyAssignmentDeleteContext.integration.test.ts
+++ b/apps/api/src/__tests__/integration/configPolicyAssignmentDeleteContext.integration.test.ts
@@ -1,0 +1,186 @@
+/**
+ * The five assignment-owner DELETE triggers temporarily enter system scope.
+ * A zero-row DELETE must restore the exact request context before the next
+ * statement in the same transaction.
+ */
+import './setup';
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { sql } from 'drizzle-orm';
+import { db, withDbAccessContext, type DbAccessContext } from '../../db';
+import { createOrganization, createPartner, createSite } from './db-utils';
+import { getTestDb } from './setup';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+const MIGRATION_FILE = join(
+  __dirname,
+  '../../../migrations/2026-10-15-120001-restore-assignment-delete-context.sql',
+);
+const DELETE_TRIGGER_TABLES = [
+  'configuration_policies',
+  'organizations',
+  'sites',
+  'device_groups',
+  'devices',
+] as const;
+const createdPartnerIds: string[] = [];
+
+function orgContext(orgId: string, partnerId: string): DbAccessContext {
+  return {
+    scope: 'organization',
+    orgId,
+    accessibleOrgIds: [orgId],
+    accessiblePartnerIds: [partnerId],
+    userId: null,
+    currentPartnerId: null,
+  };
+}
+
+async function seedTenant() {
+  const partner = await createPartner();
+  const org = await createOrganization({ partnerId: partner.id });
+  const site = await createSite({ orgId: org.id });
+  createdPartnerIds.push(partner.id);
+  return { partner, org, site };
+}
+
+afterEach(async () => {
+  const testDb = getTestDb();
+  for (const partnerId of createdPartnerIds.splice(0)) {
+    await testDb.execute(sql`
+      DELETE FROM config_policy_assignments
+      WHERE config_policy_id IN (
+        SELECT policy.id FROM configuration_policies policy
+        JOIN organizations organization ON organization.id = policy.org_id
+        WHERE organization.partner_id = ${partnerId}::uuid
+      )`);
+    await testDb.execute(sql`
+      DELETE FROM configuration_policies
+      WHERE org_id IN (SELECT id FROM organizations WHERE partner_id = ${partnerId}::uuid)`);
+    await testDb.execute(sql`
+      DELETE FROM sites
+      WHERE org_id IN (SELECT id FROM organizations WHERE partner_id = ${partnerId}::uuid)`);
+    await testDb.execute(sql`DELETE FROM organizations WHERE partner_id = ${partnerId}::uuid`);
+    await testDb.execute(sql`DELETE FROM partners WHERE id = ${partnerId}::uuid`);
+  }
+});
+
+describe('configuration-policy assignment owner DELETE context', () => {
+  runDb('forward migration is repeatable and preserves function security attributes', async () => {
+    const testDb = getTestDb();
+    const before = await testDb.execute(sql`
+      SELECT owner.rolname AS owner,
+             function.prosecdef AS security_definer,
+             function.proconfig AS config,
+             function.proacl AS acl
+      FROM pg_proc function
+      JOIN pg_roles owner ON owner.oid = function.proowner
+      WHERE function.oid =
+        'public.breeze_serialize_config_policy_assignment_owner_deletes()'::regprocedure`);
+    const migration = readFileSync(MIGRATION_FILE, 'utf8');
+    await testDb.execute(sql.raw(migration));
+    await testDb.execute(sql.raw(migration));
+    const after = await testDb.execute(sql`
+      SELECT owner.rolname AS owner,
+             function.prosecdef AS security_definer,
+             function.proconfig AS config,
+             function.proacl AS acl,
+             pg_get_functiondef(function.oid) AS definition
+      FROM pg_proc function
+      JOIN pg_roles owner ON owner.oid = function.proowner
+      WHERE function.oid =
+        'public.breeze_serialize_config_policy_assignment_owner_deletes()'::regprocedure`);
+
+    expect(after[0]).toMatchObject(before[0]!);
+    expect(after[0]).toMatchObject({
+      security_definer: true,
+      config: ['search_path=pg_catalog, public'],
+      definition: expect.stringContaining(
+        "set_config('breeze.accessible_partner_ids', COALESCE(_prev_partner_ids, ''), true)",
+      ),
+    });
+  });
+
+  runDb('is bound to exactly the five intended statement-level DELETE triggers', async () => {
+    const rows = await getTestDb().execute(sql`
+      SELECT trigger.tgname AS trigger_name,
+             relation.relname AS table_name,
+             trigger.tgenabled AS enabled,
+             trigger.tgoldtable AS old_table
+      FROM pg_trigger trigger
+      JOIN pg_class relation ON relation.oid = trigger.tgrelid
+      WHERE NOT trigger.tgisinternal
+        AND trigger.tgfoid =
+          'public.breeze_serialize_config_policy_assignment_owner_deletes()'::regprocedure
+        AND (trigger.tgtype & 8) = 8
+        AND (trigger.tgtype & 1) = 0
+        AND (trigger.tgtype & 2) = 0
+        AND (trigger.tgtype & 64) = 0
+      ORDER BY relation.relname`);
+
+    expect(rows).toEqual([
+      { trigger_name: 'ab_config_policy_assignment_policy_owner_delete', table_name: 'configuration_policies', enabled: 'O', old_table: 'old_rows' },
+      { trigger_name: 'ab_config_policy_assignment_group_owner_delete', table_name: 'device_groups', enabled: 'O', old_table: 'old_rows' },
+      { trigger_name: 'ab_config_policy_assignment_device_owner_delete', table_name: 'devices', enabled: 'O', old_table: 'old_rows' },
+      { trigger_name: 'ab_config_policy_assignment_org_owner_delete', table_name: 'organizations', enabled: 'O', old_table: 'old_rows' },
+      { trigger_name: 'ab_config_policy_assignment_site_owner_delete', table_name: 'sites', enabled: 'O', old_table: 'old_rows' },
+    ]);
+  });
+
+  runDb.each(DELETE_TRIGGER_TABLES)(
+    '%s zero-row DELETE restores all changed GUCs and keeps foreign rows hidden',
+    async (table) => {
+      const own = await seedTenant();
+      const foreign = await seedTenant();
+      const missingId = randomUUID();
+
+      const observed = await withDbAccessContext(orgContext(own.org.id, own.partner.id), async () => {
+        const roleRows = await db.execute(sql`
+          SELECT current_user AS role_name, role.rolsuper, role.rolbypassrls
+          FROM pg_roles role WHERE role.rolname = current_user`);
+        expect((roleRows as unknown as Array<{
+          role_name: string;
+          rolsuper: boolean;
+          rolbypassrls: boolean;
+        }>)[0]).toEqual({ role_name: 'breeze_app', rolsuper: false, rolbypassrls: false });
+
+        await db.execute(sql.raw(`DELETE FROM public.${table} WHERE id = '${missingId}'::uuid`));
+        const rows = await db.execute(sql`
+          SELECT public.breeze_current_scope() AS scope,
+                 current_setting('breeze.accessible_org_ids', true) AS org_ids,
+                 current_setting('breeze.accessible_partner_ids', true) AS partner_ids,
+                 (SELECT count(*)::integer FROM organizations WHERE id = ${own.org.id}::uuid) AS own_visible,
+                 (SELECT count(*)::integer FROM organizations WHERE id = ${foreign.org.id}::uuid) AS foreign_visible`);
+        const context = (rows as unknown as Array<{
+          scope: string;
+          org_ids: string;
+          partner_ids: string;
+          own_visible: number;
+          foreign_visible: number;
+        }>)[0]!;
+        const changed = await db.execute(sql`
+          WITH updated AS (
+            UPDATE organizations SET name = name WHERE id = ${foreign.org.id}::uuid
+            RETURNING id
+          )
+          SELECT count(*)::integer AS count FROM updated`);
+        return {
+          ...context,
+          foreign_updated: (changed as unknown as Array<{ count: number }>)[0]!.count,
+        };
+      });
+
+      expect(observed).toEqual({
+        scope: 'organization',
+        org_ids: own.org.id,
+        partner_ids: own.partner.id,
+        own_visible: 1,
+        foreign_visible: 0,
+        foreign_updated: 0,
+      });
+    },
+  );
+});

--- a/apps/api/src/__tests__/integration/deviceCustomFieldRehomeAuthorization.integration.test.ts
+++ b/apps/api/src/__tests__/integration/deviceCustomFieldRehomeAuthorization.integration.test.ts
@@ -1,0 +1,326 @@
+/**
+ * The custom-field re-home helper is SECURITY DEFINER and accepts source and
+ * target UUIDs. Its privilege boundary must reject either a foreign source
+ * device or a foreign target organization before entering system scope, while
+ * preserving the authorized move path.
+ */
+import './setup';
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { sql } from 'drizzle-orm';
+import postgres from 'postgres';
+import { db, withDbAccessContext, type DbAccessContext } from '../../db';
+import { customFieldDefinitions, devices } from '../../db/schema';
+import { createOrganization, createPartner, createSite } from './db-utils';
+import { getTestDb } from './setup';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+const MIGRATION_FILE = join(
+  __dirname,
+  '../../../migrations/2026-10-15-120002-authorize-custom-field-value-rehome.sql',
+);
+
+function context(partnerId: string, orgIds: string[]): DbAccessContext {
+  return {
+    scope: 'partner',
+    orgId: null,
+    accessibleOrgIds: orgIds,
+    accessiblePartnerIds: [partnerId],
+    userId: null,
+    currentPartnerId: partnerId,
+  };
+}
+
+async function seedOrg(partnerId?: string) {
+  const partner = partnerId ? { id: partnerId } : await createPartner();
+  const org = await createOrganization({ partnerId: partner.id });
+  const site = await createSite({ orgId: org.id });
+  return { partner, org, site };
+}
+
+let deviceSequence = 0;
+
+async function seedDeviceValue(
+  orgId: string,
+  siteId: string,
+  fieldKey: string,
+  value: string,
+) {
+  deviceSequence += 1;
+  const [device] = await getTestDb().insert(devices).values({
+    orgId,
+    siteId,
+    agentId: `custom-field-rehome-${Date.now()}-${deviceSequence}`,
+    hostname: `custom-field-rehome-${deviceSequence}`,
+    osType: 'linux',
+    osVersion: '1',
+    architecture: 'amd64',
+    agentVersion: '1',
+  }).returning({ id: devices.id });
+  const [definition] = await getTestDb().insert(customFieldDefinitions).values({
+    orgId,
+    partnerId: null,
+    name: fieldKey,
+    fieldKey,
+    type: 'text',
+  }).returning({ id: customFieldDefinitions.id });
+  const [row] = await getTestDb().execute<{ id: string }>(sql`
+    INSERT INTO public.device_custom_field_values
+      (device_id, org_id, definition_id, field_key, value_text)
+    VALUES (${device!.id}::uuid, ${orgId}::uuid, ${definition!.id}::uuid, ${fieldKey}, ${value})
+    RETURNING id`);
+  return { deviceId: device!.id, definitionId: definition!.id, valueId: row!.id };
+}
+
+async function callRehome(deviceId: string, targetOrgId: string) {
+  return db.execute<{ rehomed: number; dropped: number }>(sql`
+    SELECT rehomed, dropped
+      FROM public.breeze_rehome_device_custom_field_values(
+        ${deviceId}::uuid, ${targetOrgId}::uuid)`);
+}
+
+async function readValue(valueId: string) {
+  const [row] = await getTestDb().execute<{
+    id: string;
+    deviceId: string;
+    orgId: string;
+    definitionId: string;
+    fieldKey: string;
+    valueText: string | null;
+    valueNumber: number | null;
+    valueBool: boolean | null;
+    valueDate: string | null;
+  }>(sql`
+    SELECT id, device_id AS "deviceId", org_id AS "orgId",
+           definition_id AS "definitionId", field_key AS "fieldKey",
+           value_text AS "valueText", value_number AS "valueNumber",
+           value_bool AS "valueBool", value_date::text AS "valueDate"
+      FROM public.device_custom_field_values
+     WHERE id = ${valueId}::uuid`);
+  return row;
+}
+
+async function waitForAdvisoryLockWait(pid: number): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const [activity] = await getTestDb().execute<{ waitEvent: string | null }>(sql`
+      SELECT wait_event AS "waitEvent" FROM pg_stat_activity WHERE pid = ${pid}`);
+    if (activity?.waitEvent === 'advisory') return;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`backend ${pid} did not reach the expected advisory-lock wait`);
+}
+
+describe('breeze_rehome_device_custom_field_values authorization', () => {
+  runDb('forward migration is repeatable and stores the authorization before elevation', async () => {
+    const migration = readFileSync(MIGRATION_FILE, 'utf8');
+    await getTestDb().execute(sql.raw(migration));
+    await getTestDb().execute(sql.raw(migration));
+
+    const [stored] = await getTestDb().execute<{
+      securityDefiner: boolean;
+      configuration: string[];
+      definition: string;
+    }>(sql`
+      SELECT p.prosecdef AS "securityDefiner",
+             p.proconfig AS configuration,
+             pg_get_functiondef(p.oid) AS definition
+        FROM pg_proc p
+       WHERE p.oid =
+         'public.breeze_rehome_device_custom_field_values(uuid,uuid)'::regprocedure`);
+    expect(stored?.securityDefiner).toBe(true);
+    expect(stored?.configuration).toEqual(['search_path=pg_catalog, public']);
+    expect(stored?.definition).toContain('breeze_has_org_access(source_org_id)');
+    expect(stored?.definition).toContain('breeze_has_org_access(p_target_org_id)');
+    const definition = stored!.definition;
+    expect(definition.indexOf('breeze_has_org_access(source_org_id)'))
+      .toBeLessThan(definition.indexOf("set_config('breeze.scope', 'system', true)"));
+  });
+
+  runDb('is executable by breeze_app but not PUBLIC', async () => {
+    const [acl] = await getTestDb().execute<{
+      appExecute: boolean;
+      publicExecute: boolean;
+    }>(sql`
+      SELECT has_function_privilege(
+               'breeze_app',
+               'public.breeze_rehome_device_custom_field_values(uuid,uuid)',
+               'EXECUTE') AS "appExecute",
+             has_function_privilege(
+               'public',
+               'public.breeze_rehome_device_custom_field_values(uuid,uuid)',
+               'EXECUTE') AS "publicExecute"`);
+    expect(acl).toEqual({ appExecute: true, publicExecute: false });
+  });
+
+  runDb('rejects a foreign source device and leaves its hidden value intact', async () => {
+    const caller = await seedOrg();
+    const foreign = await seedOrg(caller.partner.id);
+    const value = await seedDeviceValue(
+      foreign.org.id,
+      foreign.site.id,
+      'foreign_source',
+      'must-survive',
+    );
+    const before = await readValue(value.valueId);
+
+    await expect(withDbAccessContext(
+      context(caller.partner.id, [caller.org.id]),
+      () => callRehome(value.deviceId, caller.org.id),
+    )).rejects.toMatchObject({ cause: { code: '42501' } });
+
+    expect(await readValue(value.valueId)).toEqual(before);
+  });
+
+  runDb('rejects a foreign target organization and leaves the source value intact', async () => {
+    const caller = await seedOrg();
+    const foreign = await seedOrg(caller.partner.id);
+    const value = await seedDeviceValue(
+      caller.org.id,
+      caller.site.id,
+      'foreign_target',
+      'must-survive',
+    );
+    const before = await readValue(value.valueId);
+
+    await expect(withDbAccessContext(
+      context(caller.partner.id, [caller.org.id]),
+      () => callRehome(value.deviceId, foreign.org.id),
+    )).rejects.toMatchObject({ cause: { code: '42501' } });
+
+    expect(await readValue(value.valueId)).toEqual(before);
+  });
+
+  runDb('rejects a non-system cross-partner move even if both org UUIDs are allowlisted', async () => {
+    const source = await seedOrg();
+    const foreign = await seedOrg();
+    const value = await seedDeviceValue(
+      source.org.id,
+      source.site.id,
+      'cross_partner',
+      'must-survive',
+    );
+    const before = await readValue(value.valueId);
+
+    await expect(withDbAccessContext(
+      context(source.partner.id, [source.org.id, foreign.org.id]),
+      () => callRehome(value.deviceId, foreign.org.id),
+    )).rejects.toMatchObject({ cause: { code: '42501' } });
+
+    expect(await readValue(value.valueId)).toEqual(before);
+  });
+
+  runDb('re-authorizes after a blocking export lock before entering system scope', async () => {
+    const source = await seedOrg();
+    const target = await seedOrg(source.partner.id);
+    const newTargetPartner = await createPartner();
+    const value = await seedDeviceValue(
+      source.org.id,
+      source.site.id,
+      'lock_race',
+      'must-survive',
+    );
+    const before = await readValue(value.valueId);
+
+    const admin = postgres(process.env.DATABASE_URL!, { max: 1 });
+    const app = postgres(process.env.DATABASE_URL_APP!, { max: 1 });
+    let mover: Promise<unknown> | undefined;
+    try {
+      // The organization update trigger takes exclusive partner/export locks
+      // and retains them to commit. Its uncommitted row version remains hidden
+      // while the app-side helper authorizes against the old ownership facts.
+      await admin`BEGIN`;
+      await admin`
+        UPDATE public.organizations
+           SET partner_id = ${newTargetPartner.id}::uuid
+         WHERE id = ${target.org.id}::uuid`;
+
+      await app`BEGIN`;
+      await app`SELECT set_config('breeze.scope', 'partner', true)`;
+      await app`SELECT set_config(
+        'breeze.accessible_org_ids', ${`${source.org.id},${target.org.id}`}, true)`;
+      await app`SELECT set_config(
+        'breeze.accessible_partner_ids', ${source.partner.id}, true)`;
+      const [backend] = await app<{ pid: number }[]>`SELECT pg_backend_pid() AS pid`;
+
+      // Force execution immediately. It passes the pre-lock check against the
+      // old committed row and then waits behind the updater's advisory lock.
+      mover = Promise.resolve(app`
+        SELECT rehomed, dropped
+          FROM public.breeze_rehome_device_custom_field_values(
+            ${value.deviceId}::uuid, ${target.org.id}::uuid)`);
+      await waitForAdvisoryLockWait(backend!.pid);
+
+      await admin`COMMIT`;
+      await expect(mover).rejects.toMatchObject({ code: '42501' });
+      await app`ROLLBACK`;
+    } finally {
+      await admin`ROLLBACK`.catch(() => undefined);
+      if (mover) await mover.catch(() => undefined);
+      await app`ROLLBACK`.catch(() => undefined);
+      await Promise.all([admin.end(), app.end()]);
+    }
+
+    expect(await readValue(value.valueId)).toEqual(before);
+  });
+
+  runDb('allows a same-partner caller with access to both move endpoints', async () => {
+    const source = await seedOrg();
+    const target = await seedOrg(source.partner.id);
+    const value = await seedDeviceValue(
+      source.org.id,
+      source.site.id,
+      'asset_tag',
+      'AB-168',
+    );
+    const [targetDefinition] = await getTestDb().insert(customFieldDefinitions).values({
+      orgId: target.org.id,
+      partnerId: null,
+      name: 'asset_tag',
+      fieldKey: 'asset_tag',
+      type: 'text',
+    }).returning({ id: customFieldDefinitions.id });
+
+    const counts = await withDbAccessContext(
+      context(source.partner.id, [source.org.id, target.org.id]),
+      async () => {
+        const [role] = await db.execute<{
+          roleName: string;
+          rolsuper: boolean;
+          rolbypassrls: boolean;
+        }>(sql`
+          SELECT current_user AS "roleName", r.rolsuper, r.rolbypassrls
+            FROM pg_roles r WHERE r.rolname = current_user`);
+        expect(role).toEqual({ roleName: 'breeze_app', rolsuper: false, rolbypassrls: false });
+
+        const [result] = await callRehome(value.deviceId, target.org.id);
+        const [restored] = await db.execute<{ scope: string }>(sql`
+          SELECT current_setting('breeze.scope', true) AS scope`);
+        expect(restored?.scope).toBe('partner');
+        await db.execute(sql`
+          UPDATE public.devices
+             SET org_id = ${target.org.id}::uuid, site_id = ${target.site.id}::uuid
+           WHERE id = ${value.deviceId}::uuid`);
+        return result;
+      },
+    );
+    expect({ rehomed: Number(counts?.rehomed), dropped: Number(counts?.dropped) })
+      .toEqual({ rehomed: 1, dropped: 0 });
+
+    const [moved] = await getTestDb().execute<{
+      orgId: string;
+      definitionId: string;
+      valueText: string;
+    }>(sql`
+      SELECT org_id AS "orgId", definition_id AS "definitionId", value_text AS "valueText"
+        FROM public.device_custom_field_values
+       WHERE id = ${value.valueId}::uuid`);
+    expect(moved).toEqual({
+      orgId: target.org.id,
+      definitionId: targetDefinition!.id,
+      valueText: 'AB-168',
+    });
+  });
+});

--- a/apps/api/src/__tests__/integration/partnerApiConfigurationWatermark.integration.test.ts
+++ b/apps/api/src/__tests__/integration/partnerApiConfigurationWatermark.integration.test.ts
@@ -798,6 +798,10 @@ describe('partner desired-configuration material watermarks', () => {
     // the value pointing at the target org before the device does while the two
     // statements share a transaction.
     await expect(db.transaction(async (tx) => {
+      // This fixture uses the admin test client rather than the request app
+      // pool. Declare the system authority it is intentionally simulating;
+      // the re-home SECURITY DEFINER helper rejects missing/ambiguous context.
+      await tx.execute(sql`SELECT set_config('breeze.scope', 'system', true)`);
       await tx.execute(sql`
         SELECT public.breeze_rehome_device_custom_field_values(
           ${device.id}::uuid, ${targetOrgId}::uuid)`);


### PR DESCRIPTION
Restore the caller's transaction-local database context after assignment-deletion trigger work. Require access to both organizations before rehoming device custom-field values, and recheck authorization after serialization locks. Two idempotent forward migrations preserve authorized moves and function security attributes.

Validation: 17 final PostgreSQL boundary regressions; 4 selected configuration-watermark controls; 102 RLS, 78 migration and 7 site-scope checks; affected documentation consumers; API type, selected-file lint and build. The selected watermark run passed with a process-close warning. A separate shared-package type check has a previously reproduced failure in unchanged quote tests.

Rollout requires both database migrations and verification across API instances. Preserve the corrected database definitions and migration history during an application rollback. Browser end-to-end, load/failover and deployed-environment verification remain outstanding.
