### PR TITLE
docs(mobile): App Store listing copy for the shipped 1.0 feature set; iPhone-only + tab-name fixes

### DIFF
--- a/apps/mobile/APP_REVIEW_NOTES.md
+++ b/apps/mobile/APP_REVIEW_NOTES.md
@@ -56,7 +56,7 @@ There is no self-service sign-up. Accounts are created by the customer organisat
 GETTING IN
 1. On first launch, choose "United States" on the server screen. Selecting it fills in the server address; nothing needs to be typed.
 2. Sign in with the review credentials above. MFA is disabled on this account.
-3. The bottom tabs reach Devices, Tickets, Alerts and Time. The review tenant is seeded with devices, tickets, alerts, time entries and approvals.
+3. The bottom tabs are Home (the AI assistant), Systems (organizations, devices and alerts), Tickets and Time. The review tenant is seeded with devices, tickets, alerts, time entries and approvals.
 
 Account deletion: Settings (gear icon) -> Delete Account, which opens a secure web page to submit the request.
 
@@ -126,14 +126,13 @@ covered in items 3 and 5.
 ## 2. Devices and operating systems tested
 
 > **Needs your input — I have no record of what you tested on.** This is also the item that invites
-> a bugs-and-crashes follow-up if it looks thin. Test at least one iPhone *and* one iPad before
-> replying, since the app declares `supportsTablet: true`.
+> a bugs-and-crashes follow-up if it looks thin. The app is iPhone-only (`supportsTablet` is
+> `false` in `app.json`), so list iPhones only; do not list an iPad.
 
 ```
 The app was tested on the following physical devices prior to submission:
 
 - iPhone 16 Pro, iOS 26.x
-- iPad (10th generation), iPadOS 26.x
 
 Builds were distributed to testers through TestFlight and exercised against a live tenant.
 ```
@@ -199,8 +198,8 @@ The account is a technician in a demonstration organisation pre-populated with m
 open tickets and recent alerts, so every feature has real data behind it.
 
 Reaching the main features:
-- Alerts: "Alerts" tab. Tap any alert to see detail and the device it came from.
-- Devices: "Devices" tab. Tap a device for health, installed software and status.
+- AI assistant: "Home" tab. Type or dictate a question about the fleet; suggested prompts are shown on an empty chat.
+- Alerts and devices: "Systems" tab. Active issues are listed at the top; tap an alert for detail and Acknowledge. Tap an organization, then a device, for health, IPs, logged-in user and the Reboot / Shutdown / Wake actions.
 - Tickets: "Tickets" tab. Open any ticket to comment, change status, or attach a photo.
 - Time tracking: open a ticket and use the timer, or the "Time" tab for the timesheet.
 - Approvals: shown in-app when an automation requests a privileged action.

--- a/apps/mobile/STORE_SUBMISSION.md
+++ b/apps/mobile/STORE_SUBMISSION.md
@@ -67,11 +67,14 @@ Create an iOS app record with:
 - SKU: `breeze-rmm-ios`
 - User access: Full Access
 
-The app supports iPhone and iPad. Capture screenshots for every required iPhone and iPad display-size family after the first release candidate is installed.
+The app is **iPhone-only** (`supportsTablet` is `false` in `app.json`). Do not tick iPad in the App Store Connect availability, and do not upload iPad screenshots. Capture iPhone screenshots for every required display-size family after the first release candidate is installed.
 
 ## Metadata ready to enter
 
-- Subtitle: `Manage and secure your IT fleet`
+Field limits are App Store Connect's (subtitle 30, promotional text 170, description 4000, keywords 100). Copy verified against the shipped feature set on 2026-09-09; every capability named below exists in `apps/mobile/src` at that date. Do not add a feature here without a matching screen.
+
+- Name: `Breeze RMM`
+- Subtitle (23/30): `Your fleet, in one chat` (alternate, 29/30: `Manage your IT fleet anywhere`)
 - Primary category: Business
 - Secondary category: Productivity
 - Support URL: `https://breezermm.com/`
@@ -84,11 +87,47 @@ The app supports iPhone and iPad. Capture screenshots for every required iPhone 
     API, and in-app the URL is built from the user's selected server via
     `serverConfig.buildAccountDeletionUrl`.
 
-Suggested description:
+Promotional text (169/170; editable without a new build):
 
-> Breeze RMM gives IT teams and managed service providers a secure mobile command center for their fleet. Review alerts, investigate managed systems, approve sensitive actions with biometric protection, and stay informed with push notifications. Sign in with your Breeze organization account to manage the systems you are authorized to access.
+> Ask Breeze about your fleet, approve privileged actions with Face ID, work tickets with photos, and log time in the field. Sign in with your Breeze organization account.
 
-Suggested keywords: `IT management, RMM, remote monitoring, MSP, device management, IT operations, alerts`
+Description (2472/4000):
+
+> Breeze RMM puts your fleet in your pocket. It's the mobile console for Breeze, the remote monitoring and management platform for MSPs and internal IT teams. Sign in with your Breeze organization account and work the same devices, alerts, tickets and time you manage on the web.
+>
+> ASK BREEZE
+> You land in a chat, not a dashboard. Ask what broke last night, which devices are offline, or whether a service is running, and get answers built from your live fleet data. Ask Breeze to restart a service or run a script and it prepares the action for your approval. Type it or say it.
+>
+> APPROVE SAFELY
+> When automation or the assistant needs to do something privileged, Breeze takes over the screen with an approval card: what the action is, which device it touches, how much impact it carries, and the exact tool arguments. Approve with Face ID or Touch ID, deny with a reason, or report it as suspicious. AI prepares. A person decides anything that can't be undone.
+>
+> SYSTEMS
+> See online, offline and issue counts for every organization at a glance. Drill into a customer, filter devices by status, and open a device for CPU, memory, disk, IP addresses, the logged-in user, last seen, and open alerts and tickets. Reboot, shut down, or wake a machine from wherever you are. Acknowledge alerts with a swipe.
+>
+> TICKETS
+> Work your queue from the field. Filter by open or closed, mine or all. Create a ticket with organization, priority and assignee. Reply to the requester or add an internal note. Internal is the default, so a mis-tap never emails a customer. Attach photos of hardware, screens and cabling straight from the camera, your library, or a file.
+>
+> TIME
+> Start a timer on any ticket and it follows you across the app. Stop it and the entry lands on your weekly timesheet, marked billable or not. Time entries save offline and sync when you're back on a network, so a basement job still gets billed.
+>
+> BUILT FOR THE JOB
+> • Push notifications for approvals, tickets assigned to you, and SLA breaches
+> • Face ID or Touch ID lock, with fleet data hidden from the app switcher
+> • Two-factor sign-in, a list of your signed-in phones, and one-tap revoke
+> • Works with Breeze Cloud in the United States or Europe, or your own Breeze server
+> • The assistant runs through your Breeze server. No model credentials live on the phone.
+>
+> Breeze RMM is for existing Breeze customers. Accounts are created by your organization admin, and there's nothing to buy in the app. Learn more at breezermm.com.
+
+Keywords (98/100, comma-separated, no spaces after commas):
+
+> rmm,msp,it management,remote monitoring,help desk,ticketing,psa,time tracking,it support,alerts,ai
+
+What's New (first release; App Store Connect requires the field on updates only):
+
+> First release. Chat with your fleet, approve privileged actions with Face ID, work tickets with photo attachments, and log time with a timer that follows you across the app.
+
+Things the listing must NOT claim (verified absent on 2026-09-09): iPad support, location-aware time suggestions, resolving or muting alerts from the phone (acknowledge only), acting on findings from the phone (display-only until #5365), any purchase or sign-up flow.
 
 ## Privacy declaration
 
@@ -297,7 +336,7 @@ Four constraints worth recording:
 2. Put `EXPO_PUBLIC_SENTRY_DSN`, `EXPO_PUBLIC_API_URL`, and (when approved) `EXPO_PUBLIC_POSTHOG_KEY` / `EXPO_PUBLIC_POSTHOG_HOST` in **`apps/mobile/.env`** — the file, not your shell, because Xcode build phases do not inherit it. See `.env.example` for what each one does when left unset. Neither `EXPO_PUBLIC_SENTRY_DSN` nor `EXPO_PUBLIC_API_URL` is optional for a release build: the Archive fails without either (see "Sentry — telemetry" above and `src/config/apiUrl.js`). The API URL check also rejects `localhost`, a private-network address, and plaintext `http` to a public host. A genuinely LAN-hosted self-hosted build sets `BREEZE_MOBILE_ALLOW_PRIVATE_API_URL=1`, which accepts a private host (plaintext included) and warns on every build that it did; loopback, placeholders, and plaintext to a *public* host still fail.
 3. Run `npx pnpm@10.33.4 --filter=breeze-mobile preflight`. **This is an optional convenience, not a gate** — nothing in the repo invokes it, and Xcode will never run it for you. It is worth running anyway for the one thing it still catches that the build-time guards do not: a missing `SENTRY_AUTH_TOKEN` (not silent, but it fails ten minutes into an archive instead of instantly here). Its DSN and API-URL checks are now echoes of the `app.config.js` guards, which cannot be skipped — the API-URL one literally calls the same rule function, so the two can never disagree.
 4. Run `npx pnpm@10.33.4 --filter=breeze-mobile typecheck` and `npx pnpm@10.33.4 --filter=breeze-mobile test`.
-5. In Xcode, run the `BreezeRMM` scheme on a current iPhone and iPad simulator. Capture the reviewed production UI in the simulator, not the development error or debug overlay.
-6. Save iPhone screenshots at the App Store Connect-required 6.5-inch size (1242 × 2688 or 1284 × 2778) and the iPad screenshots for the supported iPad display-size family. In Simulator, use **File → Save Screen** for each approved screen.
+5. In Xcode, run the `BreezeRMM` scheme on a current iPhone simulator. Capture the reviewed production UI in the simulator, not the development error or debug overlay.
+6. Save iPhone screenshots at the App Store Connect-required 6.5-inch size (1242 × 2688 or 1284 × 2778); no iPad screenshots (iPhone-only). In Simulator, use **File → Save Screen** for each approved screen.
 7. In Xcode, select a physical device or **Any iOS Device**, use **Product → Archive**, then upload the archive to App Store Connect. Attach the processed build to version 1.0.
 8. Enter review notes and working reviewer credentials or an approved demo path, then submit the version to Apple for review.


### PR DESCRIPTION
## Summary
- Replaces the pre-tickets/pre-AI "suggested description" in `apps/mobile/STORE_SUBMISSION.md` with a full listing: subtitle (23/30), promotional text (169/170), description (2472/4000), keywords (98/100), What's New. Every capability named was checked against `apps/mobile/src` on 2026-09-09; a "must not claim" list records what was verified absent (iPad, location-aware time suggestions, alert resolve/mute, findings actions, purchases).
- Fixes the iPad claim: `app.json` has `supportsTablet: false`, so the checklist, screenshot steps and review notes now say iPhone-only.
- Fixes `APP_REVIEW_NOTES.md`, which told reviewers to look for "Devices" and "Alerts" tabs that do not exist and listed an iPad as a test device. Tabs are Home / Systems / Tickets / Time.

Docs only; no code. Companion to the iOS submission review issues #5362–#5368.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019psQNbt2rBxLL5Jo6iY65z