### PR TITLE
fix(mobile): count findings in the Home fleet strip and share the bar severity mapping (#5364)

### DIFF
--- a/apps/mobile/src/components/fleetBarSegments.test.ts
+++ b/apps/mobile/src/components/fleetBarSegments.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+
+import { deriveFleetBarSegments } from './fleetBarSegments';
+import { deriveHeroState } from '../screens/systems/heroCopy';
+import { deriveStripFleetSegments } from '../screens/chat/components/homeFleetStripCopy';
+import type { Alert } from '../services/api';
+import type { MobileSummary } from '../services/systems';
+
+function alert(overrides: Partial<Alert> = {}): Alert {
+  return {
+    id: 'a-1',
+    title: 'something',
+    message: 'something happened',
+    severity: 'medium',
+    type: 'system',
+    acknowledged: false,
+    createdAt: '2026-09-09T00:00:00Z',
+    updatedAt: '2026-09-09T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function summary(
+  devices: Partial<MobileSummary['devices']> = {},
+  alerts: Partial<MobileSummary['alerts']> = {},
+): MobileSummary {
+  return {
+    devices: { total: 0, online: 0, offline: 0, maintenance: 0, ...devices },
+    alerts: { total: 0, active: 0, acknowledged: 0, resolved: 0, critical: 0, ...alerts },
+  };
+}
+
+describe('deriveFleetBarSegments', () => {
+  it('paints offline and maintenance devices as warning, never critical', () => {
+    expect(
+      deriveFleetBarSegments({
+        total: 50,
+        offline: 15,
+        maintenance: 1,
+        criticalAlerts: 0,
+        warningAlerts: 0,
+      }),
+    ).toEqual({ healthy: 34, warning: 16, critical: 0 });
+  });
+
+  it('reserves the critical slice for critical/high alerts', () => {
+    expect(
+      deriveFleetBarSegments({
+        total: 10,
+        offline: 2,
+        maintenance: 0,
+        criticalAlerts: 3,
+        warningAlerts: 1,
+      }),
+    ).toEqual({ healthy: 4, warning: 3, critical: 3 });
+  });
+
+  it('clamps a critical count larger than the fleet to the whole bar', () => {
+    expect(
+      deriveFleetBarSegments({
+        total: 4,
+        offline: 0,
+        maintenance: 0,
+        criticalAlerts: 9,
+        warningAlerts: 2,
+      }),
+    ).toEqual({ healthy: 0, warning: 0, critical: 4 });
+  });
+
+  it('clamps the warning slice to what the critical slice left over', () => {
+    expect(
+      deriveFleetBarSegments({
+        total: 6,
+        offline: 5,
+        maintenance: 4,
+        criticalAlerts: 2,
+        warningAlerts: 0,
+      }),
+    ).toEqual({ healthy: 0, warning: 4, critical: 2 });
+  });
+
+  it('returns an all-zero bar for an empty fleet', () => {
+    expect(
+      deriveFleetBarSegments({
+        total: 0,
+        offline: 0,
+        maintenance: 0,
+        criticalAlerts: 0,
+        warningAlerts: 0,
+      }),
+    ).toEqual({ healthy: 0, warning: 0, critical: 0 });
+  });
+});
+
+// The regression this file exists for (#5364): Home painted offline devices
+// red while Systems painted the same devices amber. Both surfaces now feed the
+// one mapping above, so the same fleet must produce the same bar on both.
+describe('hero and Home strip agree on the same fleet', () => {
+  const devices = { total: 50, online: 34, offline: 15, maintenance: 1 };
+
+  it('produces identical segments for the same fleet state', () => {
+    const activeIssues = [
+      alert({ id: 'a-1', severity: 'medium' }),
+      alert({ id: 'a-2', severity: 'low' }),
+    ];
+    const hero = deriveHeroState(
+      summary(devices, { active: activeIssues.length }),
+      activeIssues,
+      null,
+      3,
+      [],
+    );
+    const strip = deriveStripFleetSegments(summary(devices, { active: activeIssues.length }));
+
+    expect(strip).toEqual(hero.segments);
+    // Offline devices are amber on BOTH surfaces, not red on one of them.
+    expect(strip).toEqual({ healthy: 32, warning: 18, critical: 0 });
+  });
+
+  it('agrees on an all-healthy fleet', () => {
+    const healthy = { total: 12, online: 12, offline: 0, maintenance: 0 };
+    const hero = deriveHeroState(summary(healthy), [], null, 0, []);
+    const strip = deriveStripFleetSegments(summary(healthy));
+
+    expect(strip).toEqual(hero.segments);
+    expect(strip).toEqual({ healthy: 12, warning: 0, critical: 0 });
+  });
+});

--- a/apps/mobile/src/components/fleetBarSegments.ts
+++ b/apps/mobile/src/components/fleetBarSegments.ts
@@ -1,0 +1,50 @@
+import type { FleetSegments } from './FleetBar';
+
+/**
+ * Neutral, already-aggregated input to the bar mapping. Deliberately plain
+ * numbers rather than `Alert[]` / `MobileSummary`: the two call sites reach
+ * the same fleet state through different endpoints (the Systems hero has the
+ * unacked alert rows, the Home strip only has `/mobile/summary` aggregates),
+ * and the mapping must not care which.
+ */
+export interface FleetSegmentInput {
+  /** Non-decommissioned device total the bar is proportioned against. */
+  total: number;
+  offline: number;
+  maintenance: number;
+  /** Unacknowledged alerts at critical/high severity — the red slice. */
+  criticalAlerts: number;
+  /** Unacknowledged alerts at medium/low severity — folded into amber. */
+  warningAlerts: number;
+}
+
+/**
+ * The single fleet-bar severity mapping (#5364). Home and Systems used to
+ * carry their own copies and disagreed on what a device being offline means:
+ * the Home strip painted offline devices red (`critical`) while the Systems
+ * hero painted the very same devices amber (`warning`). Offline is degraded
+ * fleet state, not an emergency, so amber is the answer both surfaces now
+ * give — and they give it by calling this function rather than by two
+ * expressions that happen to agree today.
+ *
+ * Red is reserved for critical/high *alerts*. Slices are clamped so they can
+ * never sum past `total` (a fleet can easily carry more alerts than devices),
+ * with critical taking precedence over warning for the space available.
+ */
+export function deriveFleetBarSegments({
+  total,
+  offline,
+  maintenance,
+  criticalAlerts,
+  warningAlerts,
+}: FleetSegmentInput): FleetSegments {
+  // Offline + maintenance devices contribute to warning even without alerts,
+  // since they're degraded fleet state.
+  const degradedDevices = Math.max(0, offline + maintenance);
+
+  const criticalSlice = Math.min(criticalAlerts, total);
+  const warningSlice = Math.min(warningAlerts + degradedDevices, total - criticalSlice);
+  const healthySlice = Math.max(0, total - criticalSlice - warningSlice);
+
+  return { healthy: healthySlice, warning: warningSlice, critical: criticalSlice };
+}

--- a/apps/mobile/src/screens/chat/components/HomeFleetStrip.tsx
+++ b/apps/mobile/src/screens/chat/components/HomeFleetStrip.tsx
@@ -25,7 +25,9 @@ import { deriveStripFleetSegments, formatFleetStripCopy } from './homeFleetStrip
  * strip entirely rather than showing a red banner above the composer — Home
  * is not the place to surface a Systems-tab data error. A findings rejection
  * does NOT hide it: findings are additive, so the strip degrades to the
- * alerts-only count it showed before #5364 rather than vanishing.
+ * alerts-only count it showed before #5364 rather than vanishing. Silent to
+ * the user is not silent to us: either rejection is reported to Sentry even
+ * when the strip has already unmounted.
  */
 export function HomeFleetStrip() {
   const theme = useApprovalTheme('dark');
@@ -42,19 +44,24 @@ export function HomeFleetStrip() {
     // sums the same two terms for the Systems hero (#5364).
     Promise.allSettled([getMobileSummary(), getFleetFindingCounts()]).then(
       ([summaryResult, findingsResult]) => {
-        if (cancelled) return;
-
-        if (findingsResult.status === 'fulfilled') {
-          setFindingsCount(findingsResult.value.total);
+        // Only the state writes are gated on `cancelled` — the reporting
+        // below is not. The strip unmounts the instant the first message
+        // lands, which is an ordinary and fast user action, so gating Sentry
+        // on it would mean a real outage on either endpoint produces zero
+        // signal for every user who types before the fetches settle.
+        if (!cancelled) {
+          if (findingsResult.status === 'fulfilled') {
+            setFindingsCount(findingsResult.value.total);
+          }
+          if (summaryResult.status === 'fulfilled') {
+            setSummary(summaryResult.value);
+          } else {
+            setFailed(true);
+          }
+          // Settled before any reporting below, which can itself throw: a
+          // Sentry hiccup must not strand the strip on its skeleton forever.
+          setLoading(false);
         }
-        if (summaryResult.status === 'fulfilled') {
-          setSummary(summaryResult.value);
-        } else {
-          setFailed(true);
-        }
-        // Settled before any reporting below, which can itself throw: a
-        // Sentry hiccup must not strand the strip on its skeleton forever.
-        setLoading(false);
 
         if (findingsResult.status === 'rejected') {
           // Findings are additive, so losing them costs accuracy, not the
@@ -62,7 +69,15 @@ export function HomeFleetStrip() {
           // `/fleet/findings/counts` 404s against an older API, which must
           // stay a silent degrade (#5177) — the breadcrumb is for us, not
           // for the user.
-          reportInternalError(findingsResult.reason, 'home-fleet-strip-findings');
+          try {
+            reportInternalError(findingsResult.reason, 'home-fleet-strip-findings');
+          } catch {
+            // Best-effort telemetry for the non-fatal path. Swallowed so it
+            // cannot cancel the summary report below, which is the more
+            // important of the two when both endpoints fail together — that
+            // one explains why the strip vanished. Same reason
+            // useSystemsData.ts guards its reporting loop.
+          }
         }
         if (summaryResult.status === 'rejected') {
           // Hidden from the user by design (never a red banner on Home), but

--- a/apps/mobile/src/screens/chat/components/HomeFleetStrip.tsx
+++ b/apps/mobile/src/screens/chat/components/HomeFleetStrip.tsx
@@ -8,48 +8,72 @@ import { haptic } from '../../../lib/motion';
 import { reportInternalError } from '../../../lib/errorReporting';
 import { FleetBar } from '../../../components/FleetBar';
 import { getMobileSummary, type MobileSummary } from '../../../services/systems';
+import { getFleetFindingCounts } from '../../../services/api';
 import type { MainTabParamList } from '../../../navigation/MainNavigator';
-import { formatFleetStripCopy } from './homeFleetStripCopy';
+import { deriveStripFleetSegments, formatFleetStripCopy } from './homeFleetStripCopy';
 
 /**
  * Compact online/offline/issues strip shown above the cold-open chips on a
- * new conversation (#5141, decision 3 of #5117). Reuses the same
- * `/mobile/summary` fetch the Systems tab hero is built from (via
- * `getMobileSummary`, `services/systems.ts`) — no new endpoint. The parent
- * (HomeScreen) only mounts this while the conversation is empty, so it
- * disappears the instant the first message lands; no visibility prop needed
- * here.
+ * new conversation (#5141, decision 3 of #5117). Reuses the same two fetches
+ * the Systems tab hero is built from — `/mobile/summary` and
+ * `/fleet/findings/counts` — so both surfaces count issues the same way
+ * (#5364); no new endpoint. The parent (HomeScreen) only mounts this while
+ * the conversation is empty, so it disappears the instant the first message
+ * lands; no visibility prop needed here.
  *
- * Fails soft: a skeleton covers the fetch, and any rejection hides the strip
- * entirely rather than showing a red banner above the composer — Home is not
- * the place to surface a Systems-tab data error.
+ * Fails soft: a skeleton covers the fetch, and a summary rejection hides the
+ * strip entirely rather than showing a red banner above the composer — Home
+ * is not the place to surface a Systems-tab data error. A findings rejection
+ * does NOT hide it: findings are additive, so the strip degrades to the
+ * alerts-only count it showed before #5364 rather than vanishing.
  */
 export function HomeFleetStrip() {
   const theme = useApprovalTheme('dark');
   const navigation = useNavigation<BottomTabNavigationProp<MainTabParamList>>();
   const [summary, setSummary] = useState<MobileSummary | null>(null);
+  const [findingsCount, setFindingsCount] = useState(0);
   const [loading, setLoading] = useState(true);
   const [failed, setFailed] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
-    getMobileSummary()
-      .then((s) => {
+    // allSettled, not Promise.all: the two fetches fail independently and
+    // only the summary is load-bearing. Mirrors useSystemsData.ts, which
+    // sums the same two terms for the Systems hero (#5364).
+    Promise.allSettled([getMobileSummary(), getFleetFindingCounts()]).then(
+      ([summaryResult, findingsResult]) => {
         if (cancelled) return;
-        setSummary(s);
+
+        if (findingsResult.status === 'fulfilled') {
+          setFindingsCount(findingsResult.value.total);
+        }
+        if (summaryResult.status === 'fulfilled') {
+          setSummary(summaryResult.value);
+        } else {
+          setFailed(true);
+        }
+        // Settled before any reporting below, which can itself throw: a
+        // Sentry hiccup must not strand the strip on its skeleton forever.
         setLoading(false);
-      })
-      .catch((err) => {
-        if (cancelled) return;
-        // Hidden from the user by design (never a red banner on Home), but
-        // still worth a Sentry breadcrumb — otherwise the strip going quiet
-        // for every user (expired token, endpoint regression) has zero
-        // signal anywhere. Mirrors useSystemsData.ts's handling of the same
-        // getMobileSummary() call.
-        reportInternalError(err, 'home-fleet-strip');
-        setFailed(true);
-        setLoading(false);
-      });
+
+        if (findingsResult.status === 'rejected') {
+          // Findings are additive, so losing them costs accuracy, not the
+          // strip: it falls back to alerts-only and keeps rendering.
+          // `/fleet/findings/counts` 404s against an older API, which must
+          // stay a silent degrade (#5177) — the breadcrumb is for us, not
+          // for the user.
+          reportInternalError(findingsResult.reason, 'home-fleet-strip-findings');
+        }
+        if (summaryResult.status === 'rejected') {
+          // Hidden from the user by design (never a red banner on Home), but
+          // still worth a Sentry breadcrumb — otherwise the strip going quiet
+          // for every user (expired token, endpoint regression) has zero
+          // signal anywhere. Mirrors useSystemsData.ts's handling of the same
+          // getMobileSummary() call.
+          reportInternalError(summaryResult.reason, 'home-fleet-strip');
+        }
+      },
+    );
     return () => {
       cancelled = true;
     };
@@ -71,9 +95,6 @@ export function HomeFleetStrip() {
     );
   }
 
-  const { online, offline } = summary.devices;
-  const issues = summary.alerts.active;
-
   return (
     <View style={{ paddingHorizontal: spacing[6], marginBottom: spacing[4] }}>
       <Pressable
@@ -89,9 +110,9 @@ export function HomeFleetStrip() {
           borderColor: pressed ? theme.brand : 'transparent',
         })}
       >
-        <FleetBar segments={{ healthy: online, warning: issues, critical: offline }} />
+        <FleetBar segments={deriveStripFleetSegments(summary)} />
         <Text style={[type.bodyMd, { color: theme.textHi, marginTop: spacing[3] }]}>
-          {formatFleetStripCopy(summary)}
+          {formatFleetStripCopy(summary, findingsCount)}
         </Text>
       </Pressable>
     </View>

--- a/apps/mobile/src/screens/chat/components/homeFleetStripCopy.test.ts
+++ b/apps/mobile/src/screens/chat/components/homeFleetStripCopy.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { MobileSummary } from '../../../services/systems';
-import { formatFleetStripCopy } from './homeFleetStripCopy';
+import { deriveStripFleetSegments, formatFleetStripCopy } from './homeFleetStripCopy';
 
 function summary(
   devices: Partial<MobileSummary['devices']> = {},
@@ -42,5 +42,58 @@ describe('formatFleetStripCopy', () => {
     expect(formatFleetStripCopy(summary({ online: 0, offline: 5 }, { active: 0 }))).toBe(
       '0 online · 5 offline · no issues',
     );
+  });
+
+  // #5364: the strip counted alerts only while the Systems hero counted
+  // alerts + open fleet findings, so the same fleet read "no issues" on Home
+  // and "3 issues across 3 organizations" one tab over.
+  it('counts open fleet findings even when no alerts are active', () => {
+    expect(formatFleetStripCopy(summary({ online: 36, offline: 15 }, { active: 0 }), 3)).toBe(
+      '36 online · 15 offline · 3 issues',
+    );
+  });
+
+  it('adds findings to active alerts rather than replacing them', () => {
+    expect(formatFleetStripCopy(summary({ online: 36, offline: 15 }, { active: 2 }), 3)).toBe(
+      '36 online · 15 offline · 5 issues',
+    );
+  });
+
+  it('singularizes a lone finding', () => {
+    expect(formatFleetStripCopy(summary({ online: 4, offline: 0 }, { active: 0 }), 1)).toBe(
+      '4 online · 0 offline · 1 issue',
+    );
+  });
+
+  it('still says "no issues" with zero alerts and zero findings', () => {
+    expect(formatFleetStripCopy(summary({ online: 36, offline: 15 }, { active: 0 }), 0)).toBe(
+      '36 online · 15 offline · no issues',
+    );
+  });
+
+  // A failed findings fetch degrades to 0 rather than hiding the strip
+  // (#5177), which is the same thing as omitting the argument entirely.
+  it('treats an omitted findings count as zero', () => {
+    expect(formatFleetStripCopy(summary({ online: 36, offline: 15 }, { active: 2 }))).toBe(
+      '36 online · 15 offline · 2 issues',
+    );
+  });
+});
+
+describe('deriveStripFleetSegments', () => {
+  it('paints offline devices amber, matching the Systems hero (#5364)', () => {
+    expect(
+      deriveStripFleetSegments(
+        summary({ total: 51, online: 36, offline: 15 }, { active: 0 }),
+      ),
+    ).toEqual({ healthy: 36, warning: 15, critical: 0 });
+  });
+
+  it('folds active alerts into the warning slice', () => {
+    expect(
+      deriveStripFleetSegments(
+        summary({ total: 10, online: 10, offline: 0, maintenance: 0 }, { active: 2 }),
+      ),
+    ).toEqual({ healthy: 8, warning: 2, critical: 0 });
   });
 });

--- a/apps/mobile/src/screens/chat/components/homeFleetStripCopy.ts
+++ b/apps/mobile/src/screens/chat/components/homeFleetStripCopy.ts
@@ -1,14 +1,50 @@
 import type { MobileSummary } from '../../../services/systems';
+import type { FleetSegments } from '../../../components/FleetBar';
+import { deriveFleetBarSegments } from '../../../components/fleetBarSegments';
 
 // Pure copy for the Home empty-state fleet strip (#5141, decision 3 of
 // #5117): "{online} online · {offline} offline · {issues}", where the issues
-// clause pluralizes and collapses to "no issues" at zero. `issues` is
-// `alerts.active` (unacknowledged active alerts) — the same field the
-// Systems hero's breakdown is built from, so the count on Home never reads
-// higher than what tapping through actually shows.
-export function formatFleetStripCopy(summary: MobileSummary): string {
+// clause pluralizes and collapses to "no issues" at zero.
+//
+// `issues` is active alerts PLUS open fleet-hygiene findings — the same two
+// terms the Systems hero sums (`heroCopy.ts`, `activeIssues.length +
+// findingsCount`). Alerts alone is what this used to count, which made Home
+// read "36 online · 15 offline · no issues" while Systems read "3 issues
+// across 3 organizations" for the same fleet at the same moment (#5364).
+// `findingsCount` defaults to 0 so a failed `/fleet/findings/counts` fetch
+// degrades to the old alerts-only number instead of hiding the strip (#5177).
+export function formatFleetStripCopy(summary: MobileSummary, findingsCount = 0): string {
   const { online, offline } = summary.devices;
-  const issues = summary.alerts.active;
+  const issues = summary.alerts.active + findingsCount;
   const issuesPart = issues === 0 ? 'no issues' : `${issues} ${issues === 1 ? 'issue' : 'issues'}`;
   return `${online} online · ${offline} offline · ${issuesPart}`;
+}
+
+/**
+ * The strip's bar segments, through the same mapping the Systems hero uses
+ * (#5364) — offline devices are amber on both surfaces now, where the strip
+ * previously painted them red.
+ *
+ * `/mobile/summary` carries no severity split of the *unacknowledged* alerts:
+ * `alerts.critical` counts active AND acknowledged criticals (see the
+ * `/summary` handler in `apps/api/src/routes/mobile.ts`), which is exactly
+ * the source the hero refuses because it paints red under an "all healthy"
+ * headline. So every active alert enters as warning-tier here. That can
+ * under-state severity on a 6px bar whose only job is to be tapped through to
+ * Systems, which shows the real breakdown — the honest error direction, and
+ * strictly better than the previous mapping, which called every offline
+ * device critical.
+ *
+ * Findings are deliberately absent: like the hero, they carry no severity
+ * here (only a count), so they move the issue *copy* but not the bar.
+ */
+export function deriveStripFleetSegments(summary: MobileSummary): FleetSegments {
+  const { total, offline, maintenance } = summary.devices;
+  return deriveFleetBarSegments({
+    total,
+    offline,
+    maintenance,
+    criticalAlerts: 0,
+    warningAlerts: summary.alerts.active,
+  });
 }

--- a/apps/mobile/src/screens/systems/heroCopy.ts
+++ b/apps/mobile/src/screens/systems/heroCopy.ts
@@ -1,6 +1,7 @@
 import type { Alert } from '../../services/api';
 import type { MobileSummary } from '../../services/systems';
 import type { FleetSegments } from '../../components/FleetBar';
+import { deriveFleetBarSegments } from '../../components/fleetBarSegments';
 
 export interface HeroState {
   copy: string;
@@ -77,8 +78,6 @@ export function deriveHeroState(
   // from the *unacked* activeIssues (same source the headline counts), not
   // from summary.alerts.critical (which includes acknowledged criticals
   // and would paint a red slice while the headline says "all healthy").
-  // Offline + maintenance devices also contribute to warning even without
-  // alerts, since they're degraded fleet state.
   const criticalAlerts = activeIssues.filter(
     (a) => a.severity === 'critical' || a.severity === 'high',
   ).length;
@@ -87,14 +86,15 @@ export function deriveHeroState(
   ).length;
   const degradedDevices = Math.max(0, offline + maintenance);
 
-  const criticalSlice = Math.min(criticalAlerts, total);
-  const warningSlice = Math.min(warningAlerts + degradedDevices, total - criticalSlice);
-  const healthySlice = Math.max(0, total - criticalSlice - warningSlice);
-  const segments: FleetSegments = {
-    healthy: healthySlice,
-    warning: warningSlice,
-    critical: criticalSlice,
-  };
+  // Shared with the Home fleet strip (#5364) so offline devices can't be
+  // amber here and red there — see components/fleetBarSegments.ts.
+  const segments: FleetSegments = deriveFleetBarSegments({
+    total,
+    offline,
+    maintenance,
+    criticalAlerts,
+    warningAlerts,
+  });
 
   if (issueCount === 0 && degradedDevices === 0) {
     const legendParts: string[] = [];


### PR DESCRIPTION
## Problem

On the same fleet at the same moment (OliveTech, 2026-09-09 submission recording), the Home tab strip read **36 online · 15 offline · no issues** while the Systems hero read **3 issues across 3 organizations.** The three were open fleet findings.

Two independent defects, both from Home and Systems computing the same thing twice:

1. **Issue count.** `homeFleetStripCopy.ts` counted `summary.alerts.active`; `heroCopy.ts` counts `activeIssues.length + findingsCount`. Findings were never fetched on Home. The strip's own comment promised the count "never reads higher than what tapping through shows" — since the findings fold-in it read *lower*, so that comment was stale and is gone.
2. **Bar severity.** `HomeFleetStrip.tsx` painted offline devices `critical` (red); `heroCopy.ts` painted the same devices `warning` (amber). Same data, opposite colour.

## Fix

**Count.** The strip now fetches `getFleetFindingCounts()` alongside `getMobileSummary()` through `Promise.allSettled` and adds `findings.total` to its issue count — the same two terms the hero sums. Only the summary is load-bearing:

- **findings rejected** → count degrades to alerts-only, strip **stays rendered**. `/fleet/findings/counts` 404s against an older API and that must remain a silent degrade (#5177).
- **summary rejected** → strip hides, as before (never a red banner above the composer).
- Both keep their Sentry breadcrumb, now emitted *after* `setLoading(false)` so a throw inside the reporter can't strand the strip on its skeleton.

**Severity.** New `apps/mobile/src/components/fleetBarSegments.ts` holds the one mapping (`deriveFleetBarSegments`), called by both `heroCopy.ts` and the strip's `deriveStripFleetSegments`. Offline + maintenance are degraded fleet state, so they land in `warning` on both surfaces; red stays reserved for critical/high alerts. The hero's slice arithmetic moved verbatim — its existing tests are unchanged and green.

One asymmetry worth naming: `/mobile/summary` carries no severity split of the *unacknowledged* alerts. `alerts.critical` counts active **and** acknowledged criticals (see the `/summary` handler in `apps/api/src/routes/mobile.ts`), which is precisely the source `heroCopy.ts` refuses because it paints red under an "all healthy" headline. So the strip enters every active alert as warning-tier. That can under-state severity on a 6px bar whose only job is to be tapped through to Systems — the honest error direction, and strictly better than calling every offline device critical.

## Tests (red first)

Both new assertions were watched failing against unfixed code — 5 failed / 7 passed, plus `fleetBarSegments.test.ts` failing to resolve the not-yet-written module.

- `apps/mobile/src/screens/chat/components/homeFleetStripCopy.test.ts` — 0 alerts + 3 findings → `"3 issues"`; 0 + 0 → `"no issues"`; findings added to rather than replacing alerts; a lone finding singularizes; an omitted count behaves as 0 (the failed-fetch path); plus the strip's segments.
- `apps/mobile/src/components/fleetBarSegments.test.ts` — the mapping's clamping and its offline→amber rule, and **the cross-caller test the issue asked for**: one fleet state fed to `deriveHeroState` and `deriveStripFleetSegments` must produce deep-equal segments (`{healthy: 32, warning: 18, critical: 0}` — offline amber on both, where the old strip gave `{healthy: 34, warning: 2, critical: 15}`).

**Evidence**

- `vitest run` on the three touched files: **3 files, 46 tests passed**.
- Full mobile suite: **116 files, 1511 passed, 3 skipped**.
- `pnpm --filter breeze-mobile typecheck` (`tsc --noEmit`): **clean**.

## Not in scope — flagged for follow-up

`screens/chat/blocks/FleetStatusRow.tsx:62` is a **third** copy of the mapping with the same disagreement (`critical: agg.offline`), so an AI-rendered fleet block on Home still paints offline red. It was left alone deliberately: its aggregate comes from a device *slice* that can be smaller than the reported total, so routing it through the shared helper changes the bar's proportions — a behaviour change beyond this issue, which is about the strip vs. the hero. `AlertSummaryRow.tsx` also calls `FleetBar` but buckets alert *severities*, a different domain that legitimately keeps its own mapping.

Closes #5364

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019psQNbt2rBxLL5Jo6iY65z
