### PR TITLE
fix(api): resolve device hostname for approval headlines on every intent path (#5363)

### DIFF
--- a/apps/api/src/services/actionIntents/actionLabel.ts
+++ b/apps/api/src/services/actionIntents/actionLabel.ts
@@ -61,3 +61,19 @@ export function buildActionLabel(args: ActionLabelInput): string {
   label = label.replace(/\s+/g, ' ').trim();
   return label.length > MAX_LABEL_LENGTH ? `${label.slice(0, MAX_LABEL_LENGTH - 1)}…` : label;
 }
+
+/**
+ * #5363 — does `text` carry the id stub for THIS call's device?
+ *
+ * `buildActionLabel` above rewrites any `on device <8 hex>...` it finds, so a
+ * caller must only hand it a `deviceHostname` once it knows the stub actually
+ * names the device that hostname belongs to. Matched on the call's own id
+ * prefix, literally (the rule the chat bridge in aiAgentSdk.ts applied before
+ * #5363 moved this into the intent service), so a caller-supplied label that
+ * happens to mention some OTHER device's id is never relabelled — and so the
+ * resolving read below it is skipped entirely for the many tools whose
+ * description has no device stub at all.
+ */
+export function hasDeviceIdStub(text: string, deviceId: string): boolean {
+  return text.toLowerCase().includes(`on device ${deviceId.slice(0, 8).toLowerCase()}...`);
+}

--- a/apps/api/src/services/actionIntents/approvalDeviceName.test.ts
+++ b/apps/api/src/services/actionIntents/approvalDeviceName.test.ts
@@ -1,0 +1,179 @@
+/**
+ * #5363 — the org pin on the approval-headline device read.
+ *
+ * `resolveApprovalDeviceName` deliberately runs under
+ * `withSystemDbAccessContext`, i.e. with RLS bypassed, because
+ * `createActionIntent` is called from a contextless stack. The ONLY thing
+ * standing between that and a cross-tenant hostname oracle is the
+ * `eq(devices.orgId, orgId)` term in its WHERE clause — the device id it
+ * resolves comes from attacker-supplied tool ARGUMENTS.
+ *
+ * The `intentService.test.ts` harness cannot protect that term: its Drizzle
+ * mock keys canned rows off the TABLE and discards the `where(...)` argument
+ * entirely, so the behavioural tests over there would stay green if the org
+ * pin were deleted. This suite therefore asserts on the BOUND PARAMETERS of
+ * the condition actually handed to `where()`, built by the real `drizzle-orm`
+ * `and`/`eq` — the repo's standing rule for guarding a query's shape (see
+ * memory `drizzle_condition_deep_search_matches_enum_values_vacuous.md`).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const dbState = {
+  /** Every condition object handed to `.where()`, in call order. */
+  whereArgs: [] as unknown[],
+  /** Rows the next `.limit()` resolves to. */
+  rows: [] as Array<{ hostname: string; displayName: string | null }>,
+  /** When set, `.limit()` rejects with this — the "never fatal" path. */
+  failWith: null as Error | null,
+  systemContextLabels: [] as Array<string | undefined>,
+  outsideContextCalls: 0,
+};
+
+vi.mock('../../db', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: (condition: unknown) => {
+          dbState.whereArgs.push(condition);
+          return {
+            limit: async () => {
+              if (dbState.failWith) throw dbState.failWith;
+              return dbState.rows;
+            },
+          };
+        },
+      }),
+    }),
+  },
+  runOutsideDbContext: <T,>(fn: () => Promise<T>) => {
+    dbState.outsideContextCalls += 1;
+    return fn();
+  },
+  withSystemDbAccessContext: <T,>(fn: () => Promise<T>, label?: string) => {
+    dbState.systemContextLabels.push(label);
+    return fn();
+  },
+}));
+
+const captureException = vi.fn();
+vi.mock('../sentry', () => ({ captureException: (e: unknown) => captureException(e) }));
+
+import { and, eq } from 'drizzle-orm';
+import { argumentDeviceId, resolveApprovalDeviceName } from './approvalDeviceName';
+import { devices } from '../../db/schema/devices';
+
+const DEVICE_ID = '6eae0f70-1111-4222-8333-444455556666';
+const ORG_ID = '11111111-2222-4333-8444-555566667777';
+const OTHER_ORG_ID = '99999999-2222-4333-8444-555566667777';
+
+/**
+ * Every value bound as a parameter anywhere inside a drizzle SQL condition.
+ * Walks `queryChunks` recursively so a nested `and(eq(...), eq(...))` is
+ * flattened — asserting on this is what makes a dropped `eq()` term fail,
+ * where asserting on the returned ROWS would not.
+ */
+function boundParams(node: unknown): unknown[] {
+  if (node === null || typeof node !== 'object') return [];
+  const obj = node as Record<string, unknown>;
+  // A drizzle Param carries its bound value on `.value`.
+  if ('value' in obj && 'encoder' in obj) return [obj.value];
+  const chunks = obj.queryChunks;
+  if (Array.isArray(chunks)) return chunks.flatMap(boundParams);
+  return [];
+}
+
+beforeEach(() => {
+  dbState.whereArgs = [];
+  dbState.rows = [];
+  dbState.failWith = null;
+  dbState.systemContextLabels = [];
+  dbState.outsideContextCalls = 0;
+  captureException.mockClear();
+});
+
+describe('boundParams (control for the assertions below)', () => {
+  it('sees both terms of an and(eq, eq) and loses one when a term is dropped', () => {
+    // Proves the helper discriminates: if it returned [] for everything, every
+    // org-pin assertion in this file would be vacuously satisfiable.
+    expect(boundParams(and(eq(devices.id, DEVICE_ID), eq(devices.orgId, ORG_ID))))
+      .toEqual(expect.arrayContaining([DEVICE_ID, ORG_ID]));
+    expect(boundParams(eq(devices.id, DEVICE_ID))).not.toContain(ORG_ID);
+  });
+});
+
+describe('resolveApprovalDeviceName — the org pin', () => {
+  it('pins the read to BOTH the device id and the intent org', async () => {
+    dbState.rows = [{ hostname: 'kit', displayName: 'KIT' }];
+
+    await resolveApprovalDeviceName(DEVICE_ID, ORG_ID);
+
+    expect(dbState.whereArgs).toHaveLength(1);
+    const params = boundParams(dbState.whereArgs[0]);
+    // The device id alone is NOT sufficient: without the org term this read
+    // would resolve any tenant's device into an approval headline.
+    expect(params).toContain(DEVICE_ID);
+    expect(params).toContain(ORG_ID);
+    expect(params).not.toContain(OTHER_ORG_ID);
+  });
+
+  it('reads under a system context opened outside any ambient one', async () => {
+    // A bare system wrapper inside an ambient request context is a
+    // passthrough, so dropping runOutsideDbContext would silently read under
+    // whatever context the caller happened to hold — or none, returning zero
+    // rows and quietly leaving the id stub in the headline.
+    dbState.rows = [{ hostname: 'kit', displayName: 'KIT' }];
+
+    await resolveApprovalDeviceName(DEVICE_ID, ORG_ID);
+
+    expect(dbState.outsideContextCalls).toBe(1);
+    expect(dbState.systemContextLabels).toEqual(['actionIntents.approvalDeviceName']);
+  });
+
+  it('prefers the display name over the hostname', async () => {
+    dbState.rows = [{ hostname: 'kit', displayName: 'KIT' }];
+    await expect(resolveApprovalDeviceName(DEVICE_ID, ORG_ID)).resolves.toBe('KIT');
+  });
+
+  it('falls back to the hostname when there is no display name', async () => {
+    dbState.rows = [{ hostname: 'kit-01', displayName: null }];
+    await expect(resolveApprovalDeviceName(DEVICE_ID, ORG_ID)).resolves.toBe('kit-01');
+  });
+
+  it('resolves to nothing when the org pin matches no row', async () => {
+    // What a foreign or deleted device id looks like from here: the caller
+    // leaves the id stub in place rather than leaking another tenant's name.
+    dbState.rows = [];
+    await expect(resolveApprovalDeviceName(DEVICE_ID, ORG_ID)).resolves.toBeNull();
+  });
+
+  it('reports a failed read to Sentry and degrades to null instead of throwing', async () => {
+    // A headline is presentation — an approval that would otherwise be
+    // created must not fail because a display-name lookup blipped.
+    dbState.failWith = new Error('connection terminated');
+
+    await expect(resolveApprovalDeviceName(DEVICE_ID, ORG_ID)).resolves.toBeNull();
+    expect(captureException).toHaveBeenCalledTimes(1);
+    expect(captureException.mock.calls[0]?.[0]).toBeInstanceOf(Error);
+  });
+});
+
+describe('argumentDeviceId', () => {
+  it('accepts a canonical uuid argument', () => {
+    expect(argumentDeviceId({ deviceId: DEVICE_ID })).toBe(DEVICE_ID);
+  });
+
+  it('rejects a non-uuid so a malformed argument can never raise 22P02', () => {
+    // devices.id is a Postgres uuid: passing junk would abort the statement
+    // and turn a cosmetic lookup into a failed approval.
+    for (const bad of ['not-a-uuid', '', '6eae0f70', `${DEVICE_ID} OR 1=1`]) {
+      expect(argumentDeviceId({ deviceId: bad })).toBeNull();
+    }
+    expect(argumentDeviceId({ deviceId: 42 })).toBeNull();
+    expect(argumentDeviceId({})).toBeNull();
+  });
+
+  it('ignores multi-device arguments, which have no single name to substitute', () => {
+    expect(argumentDeviceId({ deviceIds: [DEVICE_ID] })).toBeNull();
+  });
+});

--- a/apps/api/src/services/actionIntents/approvalDeviceName.ts
+++ b/apps/api/src/services/actionIntents/approvalDeviceName.ts
@@ -1,0 +1,91 @@
+/**
+ * #5363 — the target device's HUMAN name for an approval headline.
+ *
+ * The guardrail description an approval carries names its device by an id
+ * stub (`on device 6eae0f70...` — `buildApprovalDescription` in
+ * aiGuardrails.ts). #5106 taught `buildActionLabel` to rewrite that stub into
+ * `on <name>`, but only ever fed it a name inside `createActionIntent`'s
+ * `ai_agent` branch, where a SCOPED sweep device is already loaded for free.
+ * Every human-originated intent (chat, `mcp_api`) — and any agent intent
+ * without an explicit scope — reached the approver with the raw stub, which
+ * is what the mobile takeover renders as its 28pt headline.
+ *
+ * This module is the one place that turns "the device id these arguments
+ * name" into "the device name an approver recognises", so the chat bridge,
+ * the intent service, and anything else that renders an approval headline
+ * cannot drift on what that means.
+ *
+ * Two properties are load-bearing:
+ *
+ *  - **Org-pinned.** The id comes from tool ARGUMENTS, which for a human
+ *    principal are not otherwise verified against the intent's org at
+ *    creation time. Pinning the read to `orgId` means a foreign (or
+ *    nonexistent) id resolves to nothing and the stub simply survives — the
+ *    headline can never become a cross-tenant hostname oracle.
+ *  - **Never fatal.** A headline is presentation. An approval that would
+ *    otherwise be created must not fail because a display-name lookup blipped,
+ *    so a failure degrades to the stub — reported to Sentry, never swallowed.
+ */
+
+import { and, eq } from 'drizzle-orm';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../../db';
+import { devices } from '../../db/schema/devices';
+import { captureException } from '../sentry';
+
+/**
+ * Shape-only UUID guard. `devices.id` is a Postgres `uuid`, so a malformed
+ * argument would raise 22P02 and abort the statement — turning a cosmetic
+ * lookup into a failed approval. Version/variant are deliberately NOT
+ * constrained (unlike `CANONICAL_UUID_LOWER` in intentService, which gates
+ * what gets WRITTEN): this only decides whether an id is safe to compare.
+ */
+const UUID_SHAPE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * The device id THIS call's arguments name, when they name one at all.
+ *
+ * Deliberately only `deviceId` (singular): that is the argument every
+ * `on device <id>...` stub in `buildApprovalDescription` is built from.
+ * Multi-device tools (`run_script`'s `deviceIds`, `manage_patches`) render
+ * `on N device(s)` and have no single name to substitute.
+ */
+export function argumentDeviceId(input: Record<string, unknown>): string | null {
+  const raw = input.deviceId;
+  return typeof raw === 'string' && UUID_SHAPE.test(raw) ? raw : null;
+}
+
+/**
+ * Resolve `deviceId` to the name an approver recognises — display name first,
+ * hostname second, matching the projection #5106 added for scoped agent
+ * intents — or `null` when it cannot be resolved.
+ *
+ * Opens its OWN system-scoped context: `createActionIntent`'s callers reach it
+ * from a contextless stack (the one route with a request context wraps the
+ * call in `runOutsideDbContext` for exactly this reason — see
+ * routes/aiAgents.ts's supervised-key promotion), so an ambient-context read
+ * would silently return zero rows under `breeze.scope = 'none'` and quietly
+ * leave the stub in place. `runOutsideDbContext` keeps that true for a caller
+ * that DOES hold one, where a bare system wrapper is a no-op passthrough.
+ * System scope is safe here only because of the `orgId` pin below.
+ */
+export async function resolveApprovalDeviceName(deviceId: string, orgId: string): Promise<string | null> {
+  try {
+    return await runOutsideDbContext(() =>
+      withSystemDbAccessContext(async () => {
+        const [device] = await db
+          .select({ hostname: devices.hostname, displayName: devices.displayName })
+          .from(devices)
+          .where(and(eq(devices.id, deviceId), eq(devices.orgId, orgId)))
+          .limit(1);
+        return device ? (device.displayName ?? device.hostname) : null;
+      }, 'actionIntents.approvalDeviceName'),
+    );
+  } catch (err) {
+    // Reported, not swallowed: the only symptom of this failing is an
+    // approval headline that quietly goes back to naming a truncated UUID,
+    // which is invisible to everything except the approver holding the phone.
+    captureException(err instanceof Error ? err : new Error(String(err)));
+    console.error(`[actionIntents] Failed to resolve the approval device name for ${deviceId}:`, err);
+    return null;
+  }
+}

--- a/apps/api/src/services/actionIntents/intentService.test.ts
+++ b/apps/api/src/services/actionIntents/intentService.test.ts
@@ -281,7 +281,10 @@ vi.mock('./policyDecide', () => ({
 // logic (already covered by actionLabel.test.ts).
 vi.mock('./actionLabel', async (importOriginal) => {
   const actual = await importOriginal<typeof import('./actionLabel')>();
-  return { buildActionLabel: vi.fn(actual.buildActionLabel) };
+  // Spread the real module: intentService also imports `hasDeviceIdStub`
+  // (#5363), and a mock that returns only `buildActionLabel` would hand it
+  // `undefined` at call time.
+  return { ...actual, buildActionLabel: vi.fn(actual.buildActionLabel) };
 });
 
 vi.mock('drizzle-orm', () => ({
@@ -1587,6 +1590,102 @@ describe('runDeferredHumanFanout', () => {
     for (const [args] of calls) {
       expect(args.deviceHostname).toBeNull();
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #5363 — the approval HEADLINE names the device, on every intent path
+//
+// #5106 only populated `deviceHostname` inside the ai_agent branch's scoped
+// device read, so every human-originated intent (chat, mcp_api) — and an
+// agent intent with no explicit scope — persisted the raw
+// "on device 6eae0f70..." stub that buildApprovalDescription emits. These
+// tests assert the value the MOBILE takeover actually renders: the
+// `action_label` column of the fanned-out approval_requests rows.
+// ---------------------------------------------------------------------------
+
+describe('createActionIntent — approval headline device name (#5363)', () => {
+  /** Exactly what aiGuardrails.buildApprovalDescription emits for this call. */
+  const RESTART_DESCRIPTION = `RESTART service "Spooler" on device ${DEVICE_ID.slice(0, 8)}...`;
+
+  function restartInput(overrides?: Partial<CreateActionIntentInput>): CreateActionIntentInput {
+    return baseInput({
+      toolName: 'manage_services',
+      input: { deviceId: DEVICE_ID, action: 'restart', serviceName: 'Spooler' },
+      ...overrides,
+    });
+  }
+
+  /** One eligible approver + the insert results a successful fan-out needs. */
+  function queueFanout(id: string) {
+    intentApproversState.resolveIntentApprovers.mockResolvedValueOnce([APPROVER_1]);
+    dbState.insertActionIntentsResults.push(echoInsertedIntent({ id }));
+    dbState.insertApprovalRequestsResults.push([{ id: `approval-${id}` }]);
+  }
+
+  function persistedApprovalLabels(): string[] {
+    const rows = dbState.insertedApprovalRequestsValues[0] as Array<{ actionLabel: string }> | undefined;
+    return (rows ?? []).map((r) => r.actionLabel);
+  }
+
+  beforeEach(() => {
+    guardrailMock.checkGuardrails.mockReturnValue({
+      tier: 3,
+      allowed: true,
+      requiresApproval: true,
+      description: RESTART_DESCRIPTION,
+    });
+  });
+
+  it('resolves the argument device name into the headline of a user-principal intent', async () => {
+    // displayName wins over hostname, matching the scoped-agent read #5106 added.
+    dbState.selectDevicesResults.push([{ hostname: 'kit', displayName: 'KIT' }]);
+    queueFanout('intent-5363-named');
+
+    await createActionIntent(makeAuth(), restartInput());
+
+    const labels = persistedApprovalLabels();
+    expect(labels).toHaveLength(1);
+    expect(labels[0]).toContain('on KIT');
+    expect(labels[0]).not.toContain('on device');
+  });
+
+  it('falls back to the hostname when the device has no display name', async () => {
+    dbState.selectDevicesResults.push([{ hostname: 'kit-01', displayName: null }]);
+    queueFanout('intent-5363-hostname');
+
+    await createActionIntent(makeAuth(), restartInput());
+
+    expect(persistedApprovalLabels()[0]).toContain('on kit-01');
+  });
+
+  it('leaves the stub intact (and does not throw) when the device cannot be resolved', async () => {
+    // Deleted, or an id from another tenant — the org-pinned read returns
+    // nothing and the headline degrades to exactly what it says today.
+    dbState.selectDevicesResults.push([]);
+    queueFanout('intent-5363-missing');
+
+    await createActionIntent(makeAuth(), restartInput());
+
+    expect(persistedApprovalLabels()[0]).toBe(
+      `Restart service "Spooler" on device ${DEVICE_ID.slice(0, 8)}...`,
+    );
+  });
+
+  it('never rewrites a stub that names a DIFFERENT device than this call', async () => {
+    // A caller-supplied label mentioning some other device's id prefix must
+    // not be relabelled with THIS call's device name.
+    dbState.selectDevicesResults.push([{ hostname: 'kit', displayName: 'KIT' }]);
+    queueFanout('intent-5363-other');
+
+    await createActionIntent(
+      makeAuth(),
+      restartInput({ actionLabel: `Restart service "Spooler" on device ${OTHER_ORG_ID.slice(0, 8)}...` }),
+    );
+
+    const label = persistedApprovalLabels()[0];
+    expect(label).toContain(`on device ${OTHER_ORG_ID.slice(0, 8)}...`);
+    expect(label).not.toContain('KIT');
   });
 });
 

--- a/apps/api/src/services/actionIntents/intentService.ts
+++ b/apps/api/src/services/actionIntents/intentService.ts
@@ -1,4 +1,5 @@
-import { buildActionLabel } from './actionLabel';
+import { buildActionLabel, hasDeviceIdStub } from './actionLabel';
+import { argumentDeviceId, resolveApprovalDeviceName } from './approvalDeviceName';
 import { randomUUID, createHash } from 'crypto';
 import { and, eq, inArray, sql } from 'drizzle-orm';
 import { actionIntentTaskContextSchema, type ActionIntentTaskContext, type AssuranceLevel } from '@breeze/shared';
@@ -1373,14 +1374,26 @@ export async function createActionIntent(
   const targetSummary = buildTargetSummary(input.toolName, input.input);
   const impactSummary = buildImpactSummary(input.toolName, input.input, guardrail);
   // What the approver READS. `targetSummary` stays the audit signature.
+  const labelReason = input.actionLabel ?? guardrail.description ?? null;
+  // #5106 turned "on device 6eae0f70..." into "on <name>" using the SCOPED
+  // agent device — the one device row this function already loads. #5363:
+  // every other path (chat, mcp_api, an agent intent with no explicit scope)
+  // left the raw stub as the mobile takeover's headline, so resolve the
+  // device THESE arguments name. One indexed, org-pinned read, and only when
+  // the label really carries this call's stub — no read at all for the many
+  // tools whose description never mentions a device.
+  let labelDeviceName = scopedDeviceHostname;
+  if (!labelDeviceName && labelReason) {
+    const argDeviceId = argumentDeviceId(input.input);
+    if (argDeviceId && hasDeviceIdStub(labelReason, argDeviceId)) {
+      labelDeviceName = await resolveApprovalDeviceName(argDeviceId, orgId);
+    }
+  }
   const actionLabel = buildActionLabel({
     toolName: input.toolName,
     input: input.input,
-    reason: input.actionLabel ?? guardrail.description ?? null,
-    // #5106: turns "on device 6eae0f70..." into "on <hostname>" for the
-    // approval headline. Only populated for a scoped (sweep) agent intent —
-    // the one place this function loads a device row before this call.
-    deviceHostname: scopedDeviceHostname,
+    reason: labelReason,
+    deviceHostname: labelDeviceName,
   });
   const expiresAt = computeExpiresAt(input.source, approvalScope);
   const requestingClientLabel = input.requestingClientLabel

--- a/apps/api/src/services/aiAgentSdk.ts
+++ b/apps/api/src/services/aiAgentSdk.ts
@@ -39,6 +39,7 @@ import {
   transitionIntent,
   type ActionIntentTransitionPatch,
 } from './actionIntents/intentService';
+import { buildActionLabel } from './actionIntents/actionLabel';
 import { publishIntentTerminalOutbox } from './aiOperator/taskOutbox';
 import { revalidateApprovedIntentForRelease } from './actionIntents/revalidateRelease';
 import { requiresDurableRelease } from './actionIntents/durableRelease';
@@ -1180,15 +1181,13 @@ export function createSessionPreToolUse(session: ActiveSession): PreToolUseCallb
             }
           } catch { /* non-fatal: fall back to default description */ }
           const riskSummary = m365Summary ?? (description.length > 500 ? `${description.slice(0, 497)}...` : description);
-          // The guardrail description names the device by an id stub
-          // ("on device 6eae0f70..." — buildApprovalDescription in
-          // aiGuardrails.ts); the approver reads the hostname. Matched on
-          // THIS call's id prefix, literally, so nothing user-supplied that
-          // happens to look like a stub gets rewritten.
-          const deviceStub = deviceId ? `on device ${deviceId.slice(0, 8)}...` : null;
-          const approvalLabel = deviceStub && deviceContext?.hostname
-            ? riskSummary.split(deviceStub).join(`on ${deviceContext.hostname}`)
-            : riskSummary;
+          // #5363: the "on device 6eae0f70..." → "on KIT" substitution that
+          // used to live here is now `createActionIntent`'s, for every intent
+          // path rather than only a chat with a resolvable deviceContext (see
+          // actionIntents/approvalDeviceName.ts). `riskSummary` is passed as
+          // the label unchanged so an M365 risk summary still wins over the
+          // guardrail description — the intent service rewrites the stub
+          // inside whichever string it receives.
 
           // Create the durable intent. This fans out to eligible org approvers
           // (or the sole-operator self-approval row), dispatches mobile push, and
@@ -1203,7 +1202,7 @@ export function createSessionPreToolUse(session: ActiveSession): PreToolUseCallb
               input: input as Record<string, unknown>,
               source: 'chat',
               reason: riskSummary,
-              actionLabel: approvalLabel,
+              actionLabel: riskSummary,
               orgId: session.orgId,
             });
           } catch (err) {
@@ -1654,7 +1653,20 @@ export function createSessionPreToolUse(session: ActiveSession): PreToolUseCallb
         // Tier → riskTier mapping (documented in the spec): Tier 2 → 'medium'.
         const riskTier: 'medium' | 'high' | 'critical' =
           guardrailCheck.tier >= 4 ? 'critical' : guardrailCheck.tier >= 3 ? 'high' : 'medium';
-        const actionLabel = description;
+        // #5363: this row is rendered by the SAME mobile takeover headline as
+        // a tier-3 intent's, so it gets the same builder — the id stub
+        // ("on device 6eae0f70...") becomes the device's name and a shouted
+        // verb is softened. No extra read: `deviceContext` was already
+        // resolved above from this call's own `deviceId` argument. This path
+        // inserts its approval_requests row directly (it must NOT call
+        // createActionIntent — see the comment block above), so the intent
+        // service's own resolution never reaches it.
+        const actionLabel = buildActionLabel({
+          toolName,
+          input: input as Record<string, unknown>,
+          reason: description,
+          deviceHostname: deviceContext?.displayName ?? deviceContext?.hostname ?? null,
+        });
         // For M365 mutation tools, enrich the approval card with the customer
         // tenant + target user + reason. Non-fatal: any DB hiccup falls back to
         // the default description rather than throwing into the approval path.


### PR DESCRIPTION
## Problem

The mobile approval takeover renders `approval_requests.action_label` as its 28pt headline. On API 0.111.1 a phone-initiated chat ("reboot print service on Kit") produced:

> Restart service "Spooler" on device 6eae0f70…

**#5106 only covered scoped agent intents.** It threaded a `deviceHostname` into `buildActionLabel`, but `createActionIntent` only ever populated that variable inside the `auth.principal.kind === 'ai_agent'` branch, where a scoped sweep device row is already loaded. Every other intent left it `null` and the raw id stub survived into the headline.

The chat bridge in `aiAgentSdk.ts` did its own substitution, but only when `deviceContext?.hostname` was set — i.e. only when the chat was opened *from a device page*. A general chat that resolves the device mid-conversation had no `deviceContext`. The tier-2 per-step bridge (`const actionLabel = description`) never substituted at all.

## Fix

Resolve the device the tool **arguments** name, once, in `createActionIntent` — one org-pinned, indexed read, gated on the label actually carrying *this call's* id stub, so tools whose description never mentions a device do no extra read.

- **`actionIntents/approvalDeviceName.ts`** (new) — the single place that turns "the device id these arguments name" into "the name an approver recognises". Display name first, hostname second (matching #5106's projection). Two load-bearing properties:
  - *Org-pinned.* The id comes from tool arguments, which for a human principal are not otherwise verified against the intent's org at creation time. Pinning the read to `orgId` means a foreign or nonexistent id resolves to nothing and the stub simply survives — the headline can never become a cross-tenant hostname oracle.
  - *Never fatal.* A headline is presentation; a blipped lookup must not fail an approval. Failures go to Sentry and degrade to the stub, never swallowed silently.
  - Uses `runOutsideDbContext(() => withSystemDbAccessContext(...))`, the same shape as the sibling scoped-device read at `intentService.ts:1136` (a bare system wrapper inside an ambient request context is a passthrough, so the read would otherwise run under whatever org context the caller happens to hold — or none).
- **`actionLabel.hasDeviceIdStub`** (new) — gates both the rewrite and the read on this call's own 8-hex prefix, so a caller-supplied label that happens to mention some *other* device's id is never relabelled.
- **`aiAgentSdk.ts`** — the ad-hoc tier-3 chat substitution (1183-1190) is deleted, now redundant. `riskSummary` is passed through as the label unchanged, so an M365 risk summary still wins over the guardrail description and the intent service rewrites the stub inside whichever string it receives.
- **`aiAgentSdk.ts:1657`** (tier-2 per-step bridge) — done, and cheap. This path inserts its `approval_requests` row directly and must *not* call `createActionIntent` (it throws `tool_not_tier3` below tier 3), so the intent service's resolution never reaches it. It now builds its label with the same `buildActionLabel`, feeding it the `deviceContext` it had **already** loaded from this call's `deviceId` — no extra read, and it picks up shout-softening (`RESTART` → `Restart`) as a bonus.

### Paths now covered

| Path | Before | After |
|---|---|---|
| Chat tier 3, opened from a device page | hostname (ad-hoc substitution) | display name / hostname |
| Chat tier 3, general chat (the reported bug) | **`on device 6eae0f70…`** | display name / hostname |
| Chat tier 2, per-step bridge | **`on device 6eae0f70…`** | display name / hostname |
| `mcp_api` | **`on device 6eae0f70…`** | display name / hostname |
| Agent intent, no explicit scope | **`on device 6eae0f70…`** | display name / hostname |
| Agent intent, scoped (#5106) | hostname | unchanged |

## Test evidence

4 new cases in `intentService.test.ts` asserting the value the mobile takeover actually renders — the `actionLabel` of the persisted `approval_requests` rows, from a **`user`** principal:

- `{ displayName: 'KIT', hostname: 'kit' }` → label contains `on KIT`, not `on device`
- `{ displayName: null, hostname: 'kit-01' }` → `on kit-01` (hostname fallback)
- lookup returns nothing → stub survives verbatim, no throw
- label naming a *different* device's id prefix → not rewritten, `KIT` never appears

**Red-first verified by mutation control:** reverting `intentService.ts` to `origin/main` and re-running the `#5363` cases fails 2 of 4 with `expected 'Restart service "Spooler" on device 99999999...' to contain 'on kit-01'`. (The two negative cases pass either way by design.)

```
npx vitest run src/services/actionIntents/{actionLabel,intentService,intentService.scope,intentService.ticketAutonomy,intentService.tier2Agent}.test.ts
  → 5 files, 163 tests passed

npx vitest run src/services/aiAgentSdk
  → 14 files, 261 tests passed

NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit -p apps/api
  → clean (needed the larger heap; the default 4GB OOMs on this package)
```

## Not done

The optional mobile hardening from the issue (declaring `targetDevice` on `ApprovalRequest` in `apps/mobile/src/services/approvals.ts` and preferring it in `approvalCopy.ts`) is **not** included — the API now emits a correct headline, so it would be belt-and-braces for old rows only, and it ships on a separate App Store cadence. Say the word and I'll open a follow-up.

Existing `approval_requests` rows created before this change keep their stored stub; only new approvals are affected.

Closes #5363

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01141Ns599G1Dp4MqYcmp7Qn