### PR TITLE
feat(mobile): findings list + detail with acknowledge/dismiss/reopen from the Systems tab (#5365)

### DIFF
--- a/apps/mobile/src/lib/errorReporting.test.ts
+++ b/apps/mobile/src/lib/errorReporting.test.ts
@@ -11,7 +11,7 @@ vi.mock('@sentry/react-native', () => ({
   captureException: (...a: unknown[]) => sentry.captureException(...a),
 }));
 
-import { reportInternalError } from './errorReporting';
+import { reportInternalError, safeReportInternalError } from './errorReporting';
 
 beforeEach(() => {
   sentry.captureException.mockReset();
@@ -87,5 +87,19 @@ describe('reportInternalError', () => {
     );
 
     expect(sentry.captureException).not.toHaveBeenCalled();
+  });
+});
+
+describe('safeReportInternalError', () => {
+  it('swallows a throwing reporter so the caller can never be stranded', () => {
+    sentry.captureException.mockImplementationOnce(() => {
+      throw new Error('Sentry transport is down');
+    });
+    expect(() => safeReportInternalError(new Error('boom'), 'findings')).not.toThrow();
+  });
+
+  it('still reports normally when nothing throws', () => {
+    safeReportInternalError(new Error('boom'), 'findings');
+    expect(sentry.captureException).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/mobile/src/lib/errorReporting.ts
+++ b/apps/mobile/src/lib/errorReporting.ts
@@ -50,3 +50,26 @@ export function reportInternalError(err: unknown, area: string): void {
       : { extra: { apiError: err } }),
   });
 }
+
+/**
+ * `reportInternalError` for a catch block that still has state to resolve.
+ *
+ * `Sentry.captureException` has no no-throw guard of its own, so reporting
+ * from a catch block BEFORE the state update that clears a spinner or
+ * re-enables a button lets a throwing reporter skip that update entirely —
+ * turning a handled failure into a permanently stuck screen, since callers
+ * discard the promise. `useSystemsData` learned this the hard way and guards
+ * its own reporting call; this is that guard, named, so a call site does not
+ * have to re-derive it.
+ *
+ * Resolve state first and call this, or call this and resolve state after —
+ * either order is safe with this wrapper. There is nothing left to report to
+ * if the reporter itself is what failed.
+ */
+export function safeReportInternalError(err: unknown, area: string): void {
+  try {
+    reportInternalError(err, area);
+  } catch {
+    // nothing left to report to
+  }
+}

--- a/apps/mobile/src/navigation/MainNavigator.tsx
+++ b/apps/mobile/src/navigation/MainNavigator.tsx
@@ -13,6 +13,8 @@ import { DeviceDetailScreen } from '../screens/devices/DeviceDetailScreen';
 import { DevicesListScreen } from '../screens/devices/DevicesListScreen';
 import { HomeScreen } from '../screens/chat/HomeScreen';
 import { SystemsScreen } from '../screens/systems/SystemsScreen';
+import { FindingsListScreen } from '../screens/systems/FindingsListScreen';
+import { FindingDetailScreen } from '../screens/systems/FindingDetailScreen';
 import { TicketsScreen } from '../screens/tickets/TicketsScreen';
 import { TicketDetailScreen } from '../screens/tickets/TicketDetailScreen';
 import { CreateTicketScreen } from '../screens/tickets/CreateTicketScreen';
@@ -30,6 +32,16 @@ export type SystemsStackParamList = {
   SystemsDevices: { orgId?: string | null; orgName?: string | null } | undefined;
   SystemsAlertDetail: { alert: Alert };
   SystemsDeviceDetail: { device: Device };
+  /**
+   * #5365. `SystemsFindings` carries `orgName` alongside `orgId` because the
+   * ACTIVE ISSUES row the tap comes from already resolved the name — refetching
+   * the org list just to title the screen would leave the header blank on the
+   * way in. The detail screen carries only the id: everything else it needs
+   * comes from `GET /fleet/findings/:id`, and a stale copied-down title is
+   * exactly what a lifecycle action would invalidate.
+   */
+  SystemsFindings: { orgId: string; orgName: string };
+  SystemsFindingDetail: { findingId: string };
 };
 
 export type TicketsStackParamList = {
@@ -178,6 +190,18 @@ function SystemsStackNavigator() {
         name="SystemsDeviceDetail"
         component={DeviceDetailScreen}
         options={{ title: 'Device Details' }}
+      />
+      <SystemsStack.Screen
+        name="SystemsFindings"
+        component={FindingsListScreen}
+        // The org name replaces this at mount (`navigation.setOptions`); the
+        // static value is what shows during the push transition.
+        options={{ title: 'Findings' }}
+      />
+      <SystemsStack.Screen
+        name="SystemsFindingDetail"
+        component={FindingDetailScreen}
+        options={{ title: 'Finding' }}
       />
     </SystemsStack.Navigator>
   );

--- a/apps/mobile/src/screens/systems/FindingDetailScreen.tsx
+++ b/apps/mobile/src/screens/systems/FindingDetailScreen.tsx
@@ -4,7 +4,7 @@ import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
 import { Toast } from '../../components/Toast';
-import { reportInternalError } from '../../lib/errorReporting';
+import { safeReportInternalError as safeReport } from '../../lib/errorReporting';
 import type { SystemsStackParamList } from '../../navigation/MainNavigator';
 import { getDevice } from '../../services/api';
 import { getFinding, isFindingNotFound, patchFinding } from '../../services/findings';
@@ -62,11 +62,16 @@ export function FindingDetailScreen({ route }: Props): React.JSX.Element {
         dispatch({ type: 'notFound' });
         return;
       }
-      reportInternalError(err, 'finding-detail');
+      // Resolve the spinner FIRST. `reportInternalError` calls straight into
+      // Sentry with no no-throw guard of its own, so reporting before this
+      // would let a throwing reporter skip the state update and strand the
+      // screen on `loading` forever — the same trap `useSystemsData` documents
+      // in its own catch.
       dispatch({
         type: 'failed',
         message: err instanceof Error ? err.message : 'Could not load this finding',
       });
+      safeReport(err, 'finding-detail');
     }
   }, [findingId]);
 
@@ -77,34 +82,55 @@ export function FindingDetailScreen({ route }: Props): React.JSX.Element {
   const runAction = useCallback(
     async (action: FleetFindingAction, notes?: string) => {
       dispatch({ type: 'actionStarted', action });
+      let updated;
       try {
-        await patchFinding(findingId, action, notes);
-        // PATCH answers with the finding row only — no members — so re-read
-        // the detail rather than rendering a device list of zero.
-        dispatch({ type: 'actionSucceeded', finding: await getFinding(findingId) });
+        updated = await patchFinding(findingId, action, notes);
       } catch (err) {
-        // A 404 from either the PATCH or the re-read means the finding is no
-        // longer there — most often the reconciler resolved it mid-action.
-        // The counts are stale either way, and the honest answer is the empty
-        // state, not a red "could not acknowledge".
+        // A 404 on the PATCH means the finding is no longer there — most often
+        // the reconciler resolved it. The honest answer is the empty state,
+        // not a red "could not acknowledge".
         if (isFindingNotFound(err)) {
           dispatch({ type: 'notFound' });
           markFindingsChanged();
+          safeReport(err, 'finding-action');
           return;
         }
-        reportInternalError(err, 'finding-action');
         dispatch({
           type: 'actionFailed',
           message: err instanceof Error ? err.message : `Could not ${action} this finding`,
         });
         setToast({ text: `Could not ${action} this finding`, kind: 'error' });
+        safeReport(err, 'finding-action');
         return;
       }
+
+      // Past this line the mutation HAS landed. Everything below is refresh,
+      // and a failure in it must never be reported as the action failing: the
+      // tech would retry, and the server's state machine would answer
+      // "Cannot acknowledge a finding with status 'acknowledged'" — a
+      // confusing 400 for something they were told did not happen.
+      //
       // The Systems hero and Home strip both read the counts endpoint, whose
-      // focus refresh is debounced to 60s — without this the tab would keep
+      // focus refresh is debounced to 60s; without this the tab would keep
       // claiming "1 open finding" for up to a minute after it was cleared.
       markFindingsChanged();
       setToast({ text: findingActionSuccessMessage(action), kind: 'success' });
+
+      try {
+        // PATCH answers with the finding row only — no members — so prefer a
+        // re-read.
+        dispatch({ type: 'actionSucceeded', finding: await getFinding(findingId) });
+      } catch (err) {
+        if (isFindingNotFound(err)) {
+          dispatch({ type: 'notFound' });
+          return;
+        }
+        // Fall back to the row the PATCH itself returned. It carries the new
+        // status, and a lifecycle action does not change membership, so the
+        // members already on screen remain correct.
+        dispatch({ type: 'actionSettled', row: updated });
+        safeReport(err, 'finding-action-refresh');
+      }
     },
     [findingId],
   );
@@ -130,8 +156,8 @@ export function FindingDetailScreen({ route }: Props): React.JSX.Element {
         const device = await getDevice(member.deviceId);
         navigation.navigate('SystemsDeviceDetail', { device });
       } catch (err) {
-        reportInternalError(err, 'finding-member-open');
         setToast({ text: 'That device is no longer available', kind: 'error' });
+        safeReport(err, 'finding-member-open');
       } finally {
         setOpeningDeviceId(null);
       }
@@ -220,6 +246,17 @@ export function FindingDetailScreen({ route }: Props): React.JSX.Element {
             </View>
           ))}
         </View>
+
+        {/* A refresh that failed with the finding already on screen is a
+            banner, not a wipe — the reducer keeps the finding deliberately, so
+            without this the RefreshControl would just stop spinning and the
+            tech would never learn the reload failed. Same rule as the list
+            screen. */}
+        {state.phase === 'error' && state.errorMessage ? (
+          <Text style={[type.meta, { color: theme.deny, marginTop: spacing[4] }]}>
+            {state.errorMessage}
+          </Text>
+        ) : null}
 
         {state.actionErrorMessage ? (
           <Text style={[type.meta, { color: theme.deny, marginTop: spacing[4] }]}>

--- a/apps/mobile/src/screens/systems/FindingDetailScreen.tsx
+++ b/apps/mobile/src/screens/systems/FindingDetailScreen.tsx
@@ -3,7 +3,7 @@ import { ActivityIndicator, Pressable, RefreshControl, ScrollView, Text, View } 
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
-import { Toast } from '../../components/Toast';
+import { useToast } from '../../components/toast/ToastHost';
 import { safeReportInternalError as safeReport } from '../../lib/errorReporting';
 import type { SystemsStackParamList } from '../../navigation/MainNavigator';
 import { getDevice } from '../../services/api';
@@ -50,7 +50,7 @@ export function FindingDetailScreen({ route }: Props): React.JSX.Element {
   const navigation = useNavigation<Nav>();
   const [state, dispatch] = useReducer(findingDetailReducer, initialFindingDetailState);
   const [dismissing, setDismissing] = useState(false);
-  const [toast, setToast] = useState<{ text: string; kind: 'success' | 'error' } | null>(null);
+  const { show: showToast } = useToast();
   const [openingDeviceId, setOpeningDeviceId] = useState<string | null>(null);
 
   const load = useCallback(async () => {
@@ -99,7 +99,7 @@ export function FindingDetailScreen({ route }: Props): React.JSX.Element {
           type: 'actionFailed',
           message: err instanceof Error ? err.message : `Could not ${action} this finding`,
         });
-        setToast({ text: `Could not ${action} this finding`, kind: 'error' });
+        showToast({ kind: 'error', text: `Could not ${action} this finding` });
         safeReport(err, 'finding-action');
         return;
       }
@@ -114,7 +114,7 @@ export function FindingDetailScreen({ route }: Props): React.JSX.Element {
       // focus refresh is debounced to 60s; without this the tab would keep
       // claiming "1 open finding" for up to a minute after it was cleared.
       markFindingsChanged();
-      setToast({ text: findingActionSuccessMessage(action), kind: 'success' });
+      showToast({ kind: 'success', text: findingActionSuccessMessage(action) });
 
       try {
         // PATCH answers with the finding row only — no members — so prefer a
@@ -156,7 +156,7 @@ export function FindingDetailScreen({ route }: Props): React.JSX.Element {
         const device = await getDevice(member.deviceId);
         navigation.navigate('SystemsDeviceDetail', { device });
       } catch (err) {
-        setToast({ text: 'That device is no longer available', kind: 'error' });
+        showToast({ kind: 'error', text: 'That device is no longer available' });
         safeReport(err, 'finding-member-open');
       } finally {
         setOpeningDeviceId(null);
@@ -332,13 +332,6 @@ export function FindingDetailScreen({ route }: Props): React.JSX.Element {
           setDismissing(false);
           void runAction('dismiss', notes);
         }}
-      />
-
-      <Toast
-        visible={toast !== null}
-        text={toast?.text ?? ''}
-        kind={toast?.kind ?? 'success'}
-        onHidden={() => setToast(null)}
       />
     </View>
   );

--- a/apps/mobile/src/screens/systems/FindingDetailScreen.tsx
+++ b/apps/mobile/src/screens/systems/FindingDetailScreen.tsx
@@ -1,0 +1,308 @@
+import { useCallback, useEffect, useReducer, useState } from 'react';
+import { ActivityIndicator, Pressable, RefreshControl, ScrollView, Text, View } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+
+import { Toast } from '../../components/Toast';
+import { reportInternalError } from '../../lib/errorReporting';
+import type { SystemsStackParamList } from '../../navigation/MainNavigator';
+import { getDevice } from '../../services/api';
+import { getFinding, isFindingNotFound, patchFinding } from '../../services/findings';
+import { radii, spacing, type, useApprovalTheme } from '../../theme';
+import { FindingDismissSheet } from './components/FindingDismissSheet';
+import { SeverityPill } from './components/SeverityPill';
+import { findingActionLabel, type FleetFindingAction } from './findingActions';
+import {
+  detailActions,
+  findingActionSuccessMessage,
+  findingDetailMeta,
+  findingDetailNotFoundCopy,
+  findingDetailReducer,
+  initialFindingDetailState,
+  isActionBusy,
+  memberPrimaryLabel,
+  memberSecondaryLabel,
+  type FindingMember,
+} from './findingDetail';
+import { markFindingsChanged } from './findingsRefreshSignal';
+
+type Nav = NativeStackNavigationProp<SystemsStackParamList, 'SystemsFindingDetail'>;
+
+interface Props {
+  route: { params: { findingId: string } };
+}
+
+/**
+ * One fleet-hygiene finding with its member devices and the acknowledge /
+ * dismiss / reopen actions (#5365), gated exactly as the web drawer
+ * (`apps/web/src/components/fleet/FindingDrawer.tsx`). Remediation is
+ * deliberately out of scope here — it needs an MFA'd session and a script
+ * picker.
+ *
+ * The state machine lives in `findingDetail.ts` (node-tested); this file maps
+ * it to JSX and owns the two side effects that cannot: fetching a member
+ * device before pushing the existing device detail screen, and telling the
+ * Systems tab its counts went stale.
+ */
+export function FindingDetailScreen({ route }: Props): React.JSX.Element {
+  const { findingId } = route.params;
+  const theme = useApprovalTheme('dark');
+  const navigation = useNavigation<Nav>();
+  const [state, dispatch] = useReducer(findingDetailReducer, initialFindingDetailState);
+  const [dismissing, setDismissing] = useState(false);
+  const [toast, setToast] = useState<{ text: string; kind: 'success' | 'error' } | null>(null);
+  const [openingDeviceId, setOpeningDeviceId] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    dispatch({ type: 'load' });
+    try {
+      dispatch({ type: 'loaded', finding: await getFinding(findingId) });
+    } catch (err) {
+      if (isFindingNotFound(err)) {
+        dispatch({ type: 'notFound' });
+        return;
+      }
+      reportInternalError(err, 'finding-detail');
+      dispatch({
+        type: 'failed',
+        message: err instanceof Error ? err.message : 'Could not load this finding',
+      });
+    }
+  }, [findingId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const runAction = useCallback(
+    async (action: FleetFindingAction, notes?: string) => {
+      dispatch({ type: 'actionStarted', action });
+      try {
+        await patchFinding(findingId, action, notes);
+        // PATCH answers with the finding row only — no members — so re-read
+        // the detail rather than rendering a device list of zero.
+        dispatch({ type: 'actionSucceeded', finding: await getFinding(findingId) });
+      } catch (err) {
+        // A 404 from either the PATCH or the re-read means the finding is no
+        // longer there — most often the reconciler resolved it mid-action.
+        // The counts are stale either way, and the honest answer is the empty
+        // state, not a red "could not acknowledge".
+        if (isFindingNotFound(err)) {
+          dispatch({ type: 'notFound' });
+          markFindingsChanged();
+          return;
+        }
+        reportInternalError(err, 'finding-action');
+        dispatch({
+          type: 'actionFailed',
+          message: err instanceof Error ? err.message : `Could not ${action} this finding`,
+        });
+        setToast({ text: `Could not ${action} this finding`, kind: 'error' });
+        return;
+      }
+      // The Systems hero and Home strip both read the counts endpoint, whose
+      // focus refresh is debounced to 60s — without this the tab would keep
+      // claiming "1 open finding" for up to a minute after it was cleared.
+      markFindingsChanged();
+      setToast({ text: findingActionSuccessMessage(action), kind: 'success' });
+    },
+    [findingId],
+  );
+
+  const onPressAction = useCallback(
+    (action: FleetFindingAction) => {
+      if (action === 'dismiss') {
+        setDismissing(true);
+        return;
+      }
+      void runAction(action);
+    },
+    [runAction],
+  );
+
+  const onOpenDevice = useCallback(
+    async (member: FindingMember) => {
+      // `SystemsDeviceDetail` takes a whole Device, not an id, so the row has
+      // to resolve one first. A device that is gone (or invisible to this
+      // account) surfaces as a toast rather than a dead tap.
+      setOpeningDeviceId(member.deviceId);
+      try {
+        const device = await getDevice(member.deviceId);
+        navigation.navigate('SystemsDeviceDetail', { device });
+      } catch (err) {
+        reportInternalError(err, 'finding-member-open');
+        setToast({ text: 'That device is no longer available', kind: 'error' });
+      } finally {
+        setOpeningDeviceId(null);
+      }
+    },
+    [navigation],
+  );
+
+  if (state.phase === 'loading') {
+    return (
+      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+        <ActivityIndicator color={theme.textMd} />
+      </View>
+    );
+  }
+
+  if (state.phase === 'notFound') {
+    const copy = findingDetailNotFoundCopy();
+    return (
+      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: spacing[6] }}>
+        <Text style={[type.bodyMd, { color: theme.textHi }]}>{copy.title}</Text>
+        <Text
+          style={[type.meta, { color: theme.textMd, marginTop: spacing[2], textAlign: 'center' }]}
+        >
+          {copy.body}
+        </Text>
+      </View>
+    );
+  }
+
+  if (state.phase === 'error' && !state.finding) {
+    return (
+      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: spacing[6] }}>
+        <Text style={[type.bodyMd, { color: theme.textHi }]}>Could not load this finding</Text>
+        <Text
+          style={[type.meta, { color: theme.textMd, marginTop: spacing[2], textAlign: 'center' }]}
+        >
+          {state.errorMessage}
+        </Text>
+        <Pressable onPress={() => void load()} style={{ marginTop: spacing[5] }}>
+          <Text style={[type.bodyMd, { color: theme.brand }]}>Try again</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  const finding = state.finding;
+  if (!finding) {
+    return <View style={{ flex: 1 }} />;
+  }
+
+  const actions = detailActions(state);
+  const busy = isActionBusy(state);
+
+  return (
+    <View style={{ flex: 1 }}>
+      <ScrollView
+        contentContainerStyle={{ padding: spacing[6], paddingBottom: spacing[10] }}
+        refreshControl={
+          <RefreshControl
+            refreshing={state.refreshing}
+            onRefresh={() => void load()}
+            tintColor={theme.textMd}
+          />
+        }
+      >
+        <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+          <SeverityPill severity={finding.severity} />
+        </View>
+        <Text style={[type.title, { color: theme.textHi, marginTop: spacing[3] }]}>
+          {finding.title}
+        </Text>
+        {finding.summary ? (
+          <Text style={[type.body, { color: theme.textMd, marginTop: spacing[3] }]}>
+            {finding.summary}
+          </Text>
+        ) : null}
+
+        <View style={{ marginTop: spacing[6] }}>
+          {findingDetailMeta(finding).map((row) => (
+            <View
+              key={row.label}
+              style={{ flexDirection: 'row', paddingVertical: spacing[2], alignItems: 'flex-start' }}
+            >
+              <Text style={[type.meta, { color: theme.textLo, width: 110 }]}>{row.label}</Text>
+              <Text style={[type.meta, { color: theme.textHi, flex: 1 }]}>{row.value}</Text>
+            </View>
+          ))}
+        </View>
+
+        {state.actionErrorMessage ? (
+          <Text style={[type.meta, { color: theme.deny, marginTop: spacing[4] }]}>
+            {state.actionErrorMessage}
+          </Text>
+        ) : null}
+
+        {actions.length > 0 ? (
+          <View style={{ flexDirection: 'row', gap: spacing[3], marginTop: spacing[5] }}>
+            {actions.map((action) => (
+              <Pressable
+                key={action}
+                testID={`finding-action-${action}`}
+                accessibilityRole="button"
+                onPress={() => onPressAction(action)}
+                disabled={busy}
+                style={{
+                  flex: 1,
+                  paddingVertical: spacing[4],
+                  alignItems: 'center',
+                  borderRadius: radii.md,
+                  backgroundColor: action === 'dismiss' ? theme.bg2 : theme.brand,
+                  opacity: busy ? 0.5 : 1,
+                }}
+              >
+                <Text style={[type.bodyMd, { color: theme.textHi }]}>
+                  {state.pendingAction === action ? '…' : findingActionLabel(action)}
+                </Text>
+              </Pressable>
+            ))}
+          </View>
+        ) : null}
+
+        <Text style={[type.metaCaps, { color: theme.textLo, marginTop: spacing[8] }]}>
+          AFFECTED DEVICES
+        </Text>
+        {finding.members.length === 0 ? (
+          <Text style={[type.meta, { color: theme.textMd, marginTop: spacing[3] }]}>
+            No devices are currently attached to this finding.
+          </Text>
+        ) : (
+          finding.members.map((member) => (
+            <Pressable
+              key={member.deviceId}
+              testID={`finding-member-${member.deviceId}`}
+              accessibilityRole="button"
+              onPress={() => void onOpenDevice(member)}
+              disabled={openingDeviceId !== null}
+              style={({ pressed }) => ({
+                paddingVertical: spacing[3],
+                opacity: pressed || openingDeviceId === member.deviceId ? 0.6 : 1,
+              })}
+            >
+              <Text style={[type.bodyMd, { color: theme.textHi }]} numberOfLines={1}>
+                {memberPrimaryLabel(member)}
+              </Text>
+              <Text
+                style={[type.meta, { color: theme.textMd, marginTop: spacing[1] }]}
+                numberOfLines={1}
+              >
+                {memberSecondaryLabel(member)}
+              </Text>
+            </Pressable>
+          ))
+        )}
+      </ScrollView>
+
+      <FindingDismissSheet
+        visible={dismissing}
+        busy={state.pendingAction === 'dismiss'}
+        onCancel={() => setDismissing(false)}
+        onSubmit={(notes) => {
+          setDismissing(false);
+          void runAction('dismiss', notes);
+        }}
+      />
+
+      <Toast
+        visible={toast !== null}
+        text={toast?.text ?? ''}
+        kind={toast?.kind ?? 'success'}
+        onHidden={() => setToast(null)}
+      />
+    </View>
+  );
+}

--- a/apps/mobile/src/screens/systems/FindingsListScreen.tsx
+++ b/apps/mobile/src/screens/systems/FindingsListScreen.tsx
@@ -3,7 +3,7 @@ import { ActivityIndicator, Pressable, RefreshControl, ScrollView, Text, View } 
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
-import { reportInternalError } from '../../lib/errorReporting';
+import { safeReportInternalError as safeReport } from '../../lib/errorReporting';
 import type { SystemsStackParamList } from '../../navigation/MainNavigator';
 import { isFindingNotFound, listFindings } from '../../services/findings';
 import { spacing, type, useApprovalTheme } from '../../theme';
@@ -50,11 +50,13 @@ export function FindingsListScreen({ route }: Props): React.JSX.Element {
         dispatch({ type: 'empty' });
         return;
       }
-      reportInternalError(err, 'findings-list');
+      // Resolve the spinner FIRST: a throwing reporter must not be able to skip
+      // this update and strand the screen on `loading` (see `safeReport`).
       dispatch({
         type: 'failed',
         message: err instanceof Error ? err.message : 'Could not load findings',
       });
+      safeReport(err, 'findings-list');
     }
   }, [orgId]);
 

--- a/apps/mobile/src/screens/systems/FindingsListScreen.tsx
+++ b/apps/mobile/src/screens/systems/FindingsListScreen.tsx
@@ -1,0 +1,205 @@
+import { useCallback, useEffect, useReducer } from 'react';
+import { ActivityIndicator, Pressable, RefreshControl, ScrollView, Text, View } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+
+import { reportInternalError } from '../../lib/errorReporting';
+import type { SystemsStackParamList } from '../../navigation/MainNavigator';
+import { isFindingNotFound, listFindings } from '../../services/findings';
+import { spacing, type, useApprovalTheme } from '../../theme';
+import { SeverityPill } from './components/SeverityPill';
+import {
+  findingRowSubtitle,
+  findingsListEmptyCopy,
+  findingsListReducer,
+  initialFindingsListState,
+  toFindingListItem,
+  type FindingListItem,
+} from './findingsList';
+
+type Nav = NativeStackNavigationProp<SystemsStackParamList, 'SystemsFindings'>;
+
+interface Props {
+  route: { params: { orgId: string; orgName: string } };
+}
+
+/**
+ * The open + acknowledged fleet-hygiene findings for one org (#5365) — the
+ * screen behind an ACTIVE ISSUES "N open findings" row, which until now was
+ * display-only.
+ *
+ * All state lives in `findingsList.ts` so the sorting, the
+ * keep-rows-on-a-failed-refresh rule and the copy are unit-tested in node;
+ * this file is the state-to-JSX mapping.
+ */
+export function FindingsListScreen({ route }: Props): React.JSX.Element {
+  const { orgId, orgName } = route.params;
+  const theme = useApprovalTheme('dark');
+  const navigation = useNavigation<Nav>();
+  const [state, dispatch] = useReducer(findingsListReducer, initialFindingsListState);
+
+  const load = useCallback(async () => {
+    dispatch({ type: 'load' });
+    try {
+      const { findings, total } = await listFindings({ orgId });
+      dispatch({ type: 'loaded', findings: findings.map(toFindingListItem), total });
+    } catch (err) {
+      // A 404 here is "nothing to show for this org", not a fault — the same
+      // rule the detail screen applies.
+      if (isFindingNotFound(err)) {
+        dispatch({ type: 'empty' });
+        return;
+      }
+      reportInternalError(err, 'findings-list');
+      dispatch({
+        type: 'failed',
+        message: err instanceof Error ? err.message : 'Could not load findings',
+      });
+    }
+  }, [orgId]);
+
+  useEffect(() => {
+    navigation.setOptions({ title: orgName || 'Findings' });
+  }, [navigation, orgName]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const onPressFinding = useCallback(
+    (item: FindingListItem) => {
+      navigation.navigate('SystemsFindingDetail', { findingId: item.id });
+    },
+    [navigation],
+  );
+
+  if (state.phase === 'loading') {
+    return (
+      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+        <ActivityIndicator color={theme.textMd} />
+      </View>
+    );
+  }
+
+  const empty = findingsListEmptyCopy(orgName);
+
+  return (
+    <ScrollView
+      style={{ flex: 1 }}
+      contentContainerStyle={{ paddingVertical: spacing[4], flexGrow: 1 }}
+      refreshControl={
+        <RefreshControl
+          refreshing={state.refreshing}
+          onRefresh={() => void load()}
+          tintColor={theme.textMd}
+        />
+      }
+    >
+      {/* A refresh that failed while rows are still on screen is a banner, not
+          a wipe — the reducer keeps the stale rows deliberately. */}
+      {state.errorMessage && state.findings.length > 0 ? (
+        <Text
+          style={[
+            type.meta,
+            { color: theme.deny, paddingHorizontal: spacing[6], paddingBottom: spacing[3] },
+          ]}
+        >
+          {state.errorMessage}
+        </Text>
+      ) : null}
+
+      {state.phase === 'error' ? (
+        <View style={{ padding: spacing[6], alignItems: 'center' }}>
+          <Text style={[type.bodyMd, { color: theme.textHi, textAlign: 'center' }]}>
+            Could not load findings
+          </Text>
+          <Text
+            style={[
+              type.meta,
+              { color: theme.textMd, marginTop: spacing[2], textAlign: 'center' },
+            ]}
+          >
+            {state.errorMessage}
+          </Text>
+          <Pressable
+            onPress={() => void load()}
+            style={{ marginTop: spacing[5], paddingVertical: spacing[3] }}
+          >
+            <Text style={[type.bodyMd, { color: theme.brand }]}>Try again</Text>
+          </Pressable>
+        </View>
+      ) : null}
+
+      {state.phase === 'ready' && state.findings.length === 0 ? (
+        <View style={{ padding: spacing[6], alignItems: 'center' }}>
+          <Text style={[type.bodyMd, { color: theme.textHi }]}>{empty.title}</Text>
+          <Text
+            style={[
+              type.meta,
+              { color: theme.textMd, marginTop: spacing[2], textAlign: 'center' },
+            ]}
+          >
+            {empty.body}
+          </Text>
+        </View>
+      ) : null}
+
+      {state.findings.map((item, idx) => (
+        <Pressable
+          key={item.id}
+          testID={`finding-row-${item.id}`}
+          accessibilityRole="button"
+          accessibilityLabel={`${item.title}. ${findingRowSubtitle(item)}`}
+          onPress={() => onPressFinding(item)}
+          style={({ pressed }) => ({
+            paddingHorizontal: spacing[6],
+            paddingVertical: spacing[4],
+            backgroundColor: pressed ? theme.bg1 : 'transparent',
+          })}
+        >
+          <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+            <SeverityPill severity={item.severity} />
+            <View style={{ flex: 1, marginLeft: spacing[3] }}>
+              <Text style={[type.bodyMd, { color: theme.textHi }]} numberOfLines={2}>
+                {item.title}
+              </Text>
+              <Text
+                style={[type.meta, { color: theme.textMd, marginTop: spacing[1] }]}
+                numberOfLines={1}
+              >
+                {findingRowSubtitle(item)}
+              </Text>
+            </View>
+          </View>
+          {idx < state.findings.length - 1 ? (
+            <View
+              style={{
+                height: 1,
+                backgroundColor: theme.border,
+                marginTop: spacing[4],
+                marginBottom: -spacing[4],
+              }}
+            />
+          ) : null}
+        </Pressable>
+      ))}
+
+      {/* The list is capped at one page; say so rather than implying the org
+          has only what fits on screen. */}
+      {state.total > state.findings.length ? (
+        <Text
+          style={[
+            type.meta,
+            {
+              color: theme.textLo,
+              paddingHorizontal: spacing[6],
+              paddingTop: spacing[5],
+            },
+          ]}
+        >
+          Showing {state.findings.length} of {state.total}. Open the web console for the rest.
+        </Text>
+      ) : null}
+    </ScrollView>
+  );
+}

--- a/apps/mobile/src/screens/systems/SystemsScreen.tsx
+++ b/apps/mobile/src/screens/systems/SystemsScreen.tsx
@@ -766,6 +766,12 @@ export function SystemsScreen() {
                 key={finding.orgId}
                 orgName={finding.orgName}
                 count={finding.count}
+                onPress={() =>
+                  navigation.navigate('SystemsFindings', {
+                    orgId: finding.orgId,
+                    orgName: finding.orgName,
+                  })
+                }
                 showDivider={idx < activeFindingsSummary.length - 1}
                 dividerColor={theme.border}
               />

--- a/apps/mobile/src/screens/systems/components/FindingDismissSheet.tsx
+++ b/apps/mobile/src/screens/systems/components/FindingDismissSheet.tsx
@@ -1,0 +1,154 @@
+import { useEffect, useState } from 'react';
+import {
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  Pressable,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+
+import { useApprovalTheme, type, spacing, radii, palette } from '../../../theme';
+import { DISMISS_NOTES_MAX_LENGTH, validateDismissNote } from '../findingActions';
+
+interface Props {
+  visible: boolean;
+  busy?: boolean;
+  onCancel: () => void;
+  onSubmit: (notes: string) => void;
+}
+
+const ERROR_COPY: Record<'required' | 'too_long', string> = {
+  required: 'A note is required to dismiss a finding.',
+  too_long: `Keep the note under ${DISMISS_NOTES_MAX_LENGTH} characters.`,
+};
+
+/**
+ * The dismiss sheet for a fleet finding (#5365). Follows the approval-mode
+ * `DenyReasonSheet` pattern, with one deliberate difference: the note is
+ * REQUIRED, not optional. `PATCH /fleet/findings/:id` rejects a dismiss with
+ * no notes, so the submit button validates locally rather than letting the
+ * tech watch a round-trip end in a 400.
+ */
+export function FindingDismissSheet({ visible, busy, onCancel, onSubmit }: Props) {
+  const theme = useApprovalTheme('dark');
+  const [notes, setNotes] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  // Reopening the sheet after a cancel must not resurrect the previous draft
+  // or a stale validation message.
+  useEffect(() => {
+    if (!visible) {
+      setNotes('');
+      setError(null);
+    }
+  }, [visible]);
+
+  function handleCancel() {
+    if (busy) return;
+    onCancel();
+  }
+
+  function handleSubmit() {
+    if (busy) return;
+    const result = validateDismissNote(notes);
+    if (!result.ok) {
+      setError(ERROR_COPY[result.reason]);
+      return;
+    }
+    setError(null);
+    onSubmit(result.notes);
+  }
+
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={handleCancel}>
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        style={{ flex: 1 }}
+      >
+        <Pressable
+          style={{ flex: 1, backgroundColor: 'rgba(0,0,0,0.55)', justifyContent: 'flex-end' }}
+          onPress={handleCancel}
+        >
+          <Pressable
+            onPress={(e) => e.stopPropagation()}
+            style={{
+              backgroundColor: theme.bg1,
+              borderTopLeftRadius: radii.xl,
+              borderTopRightRadius: radii.xl,
+              padding: spacing[6],
+              paddingBottom: spacing[10],
+            }}
+          >
+            <Text style={[type.title, { color: theme.textHi }]}>Why dismiss?</Text>
+            <Text style={[type.meta, { color: theme.textMd, marginTop: spacing[1] }]}>
+              Required. Recorded on the finding so the rest of the team can see why.
+            </Text>
+            <TextInput
+              testID="finding-dismiss-notes"
+              value={notes}
+              onChangeText={(next) => {
+                setNotes(next);
+                if (error) setError(null);
+              }}
+              placeholder="Reason"
+              placeholderTextColor={theme.textLo}
+              editable={!busy}
+              multiline
+              maxLength={DISMISS_NOTES_MAX_LENGTH}
+              style={[
+                type.body,
+                {
+                  color: theme.textHi,
+                  backgroundColor: theme.bg2,
+                  borderRadius: radii.md,
+                  padding: spacing[4],
+                  marginTop: spacing[4],
+                  minHeight: 88,
+                  textAlignVertical: 'top',
+                },
+              ]}
+            />
+            {error ? (
+              <Text style={[type.meta, { color: theme.deny, marginTop: spacing[2] }]}>{error}</Text>
+            ) : null}
+            <View style={{ flexDirection: 'row', marginTop: spacing[5], gap: spacing[3] }}>
+              <Pressable
+                onPress={handleCancel}
+                disabled={busy}
+                style={{
+                  flex: 1,
+                  paddingVertical: spacing[4],
+                  alignItems: 'center',
+                  borderRadius: radii.md,
+                  backgroundColor: theme.bg2,
+                  opacity: busy ? 0.5 : 1,
+                }}
+              >
+                <Text style={[type.bodyMd, { color: theme.textHi }]}>Cancel</Text>
+              </Pressable>
+              <Pressable
+                testID="finding-dismiss-submit"
+                onPress={handleSubmit}
+                disabled={busy}
+                style={{
+                  flex: 1,
+                  paddingVertical: spacing[4],
+                  alignItems: 'center',
+                  borderRadius: radii.md,
+                  backgroundColor: theme.deny,
+                  opacity: busy ? 0.5 : 1,
+                }}
+              >
+                <Text style={[type.bodyMd, { color: palette.deny.onBase }]}>
+                  {busy ? 'Dismissing…' : 'Dismiss'}
+                </Text>
+              </Pressable>
+            </View>
+          </Pressable>
+        </Pressable>
+      </KeyboardAvoidingView>
+    </Modal>
+  );
+}

--- a/apps/mobile/src/screens/systems/components/FindingsRow.tsx
+++ b/apps/mobile/src/screens/systems/components/FindingsRow.tsx
@@ -1,4 +1,4 @@
-import { Text, View } from 'react-native';
+import { Pressable, Text, View } from 'react-native';
 import Animated, { FadeIn, FadeOut, LinearTransition } from 'react-native-reanimated';
 
 import { useApprovalTheme, spacing, type } from '../../../theme';
@@ -6,6 +6,7 @@ import { useApprovalTheme, spacing, type } from '../../../theme';
 interface Props {
   orgName: string;
   count: number;
+  onPress: () => void;
   showDivider?: boolean;
   dividerColor?: string;
 }
@@ -15,11 +16,15 @@ interface Props {
  * (#5139 / #5117 decision 1) — VSS/Universal Print/Intel ME/SCEP failures,
  * the same findings `get_fleet_findings` reports to the AI. Visually
  * distinct from `IssueRow` (alerts): a "Finding" label instead of a severity
- * dot, and no swipe-to-acknowledge or selection — findings are acted on from
- * the AI/web flow today. Display-only; tap-through to a findings detail
- * screen is a later item (#5117).
+ * dot, and no swipe-to-acknowledge or selection — a finding is acted on one at
+ * a time on its own detail screen, not in bulk from this list.
+ *
+ * #5365 made the row tappable: it opens the org's findings list, and from
+ * there a finding's detail with acknowledge / dismiss / reopen. Before that it
+ * was display-only and a tech could see something was wrong without being able
+ * to find out what.
  */
-export function FindingsRow({ orgName, count, showDivider, dividerColor }: Props) {
+export function FindingsRow({ orgName, count, onPress, showDivider, dividerColor }: Props) {
   const theme = useApprovalTheme('dark');
 
   return (
@@ -28,13 +33,18 @@ export function FindingsRow({ orgName, count, showDivider, dividerColor }: Props
       exiting={FadeOut.duration(180)}
       layout={LinearTransition.duration(220)}
     >
-      <View
-        style={{
+      <Pressable
+        testID={`findings-row-${orgName}`}
+        accessibilityRole="button"
+        accessibilityLabel={`${count} open ${count === 1 ? 'finding' : 'findings'} for ${orgName}`}
+        onPress={onPress}
+        style={({ pressed }) => ({
           paddingHorizontal: spacing[6],
           paddingVertical: spacing[3],
           flexDirection: 'row',
           alignItems: 'center',
-        }}
+          backgroundColor: pressed ? theme.bg1 : 'transparent',
+        })}
       >
         <View
           accessibilityRole="text"
@@ -59,7 +69,7 @@ export function FindingsRow({ orgName, count, showDivider, dividerColor }: Props
             {orgName}
           </Text>
         </View>
-      </View>
+      </Pressable>
       {showDivider ? (
         <View
           style={{

--- a/apps/mobile/src/screens/systems/components/SeverityPill.tsx
+++ b/apps/mobile/src/screens/systems/components/SeverityPill.tsx
@@ -1,0 +1,34 @@
+import { Text, View } from 'react-native';
+
+import { riskTier, spacing, type, radii } from '../../../theme';
+import { findingSeverityTier, severityLabel, type FleetFindingSeverity } from '../findingActions';
+
+interface Props {
+  severity: FleetFindingSeverity;
+}
+
+/**
+ * The severity chip on findings rows and the finding detail header (#5365).
+ * Reuses the shared `riskTier` bands so a "Critical" finding reads the same
+ * colour as a critical alert — a second colour scale for the same word would
+ * be actively misleading on a triage screen.
+ */
+export function SeverityPill({ severity }: Props) {
+  const tier = riskTier[findingSeverityTier(severity)];
+
+  return (
+    <View
+      accessibilityRole="text"
+      style={{
+        paddingHorizontal: spacing[2],
+        paddingVertical: 2,
+        borderRadius: radii.sm,
+        backgroundColor: tier.band,
+      }}
+    >
+      <Text style={[type.meta, { color: tier.text, fontSize: 10 }]}>
+        {severityLabel(severity).toUpperCase()}
+      </Text>
+    </View>
+  );
+}

--- a/apps/mobile/src/screens/systems/findingActions.test.ts
+++ b/apps/mobile/src/screens/systems/findingActions.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DISMISS_NOTES_MAX_LENGTH,
+  availableFindingActions,
+  canAcknowledge,
+  canDismiss,
+  canReopen,
+  findingActionLabel,
+  findingSeverityRank,
+  findingSeverityTier,
+  findingStatusLabel,
+  severityLabel,
+  validateDismissNote,
+  type FleetFindingSeverity,
+  type FleetFindingStatus,
+} from './findingActions';
+
+const ALL_STATUSES: FleetFindingStatus[] = ['open', 'acknowledged', 'dismissed', 'resolved'];
+
+describe('finding action gating', () => {
+  // The table is the contract: it must match
+  // apps/web/src/components/fleet/FindingDrawer.tsx so a tech sees the same
+  // affordances on the phone as in the browser. `resolved` is terminal — the
+  // reconciler owns it and no human action applies.
+  const expected: Record<FleetFindingStatus, { ack: boolean; dismiss: boolean; reopen: boolean }> =
+    {
+      open: { ack: true, dismiss: true, reopen: false },
+      acknowledged: { ack: false, dismiss: true, reopen: true },
+      dismissed: { ack: false, dismiss: false, reopen: true },
+      resolved: { ack: false, dismiss: false, reopen: false },
+    };
+
+  it.each(ALL_STATUSES)('gates every action for status %s exactly as the web drawer', (status) => {
+    expect(canAcknowledge(status)).toBe(expected[status].ack);
+    expect(canDismiss(status)).toBe(expected[status].dismiss);
+    expect(canReopen(status)).toBe(expected[status].reopen);
+  });
+
+  it('lists the available actions in the order they are rendered', () => {
+    expect(availableFindingActions('open')).toEqual(['acknowledge', 'dismiss']);
+    expect(availableFindingActions('acknowledged')).toEqual(['dismiss', 'reopen']);
+    expect(availableFindingActions('dismissed')).toEqual(['reopen']);
+    expect(availableFindingActions('resolved')).toEqual([]);
+  });
+
+  it('offers nothing for a status the server may add later', () => {
+    const future = 'snoozed' as FleetFindingStatus;
+    expect(canAcknowledge(future)).toBe(false);
+    expect(canDismiss(future)).toBe(false);
+    expect(canReopen(future)).toBe(false);
+    expect(availableFindingActions(future)).toEqual([]);
+  });
+});
+
+describe('validateDismissNote', () => {
+  it('requires a note — the API rejects a dismiss without one', () => {
+    expect(validateDismissNote('')).toEqual({ ok: false, reason: 'required' });
+    expect(validateDismissNote('   \n  ')).toEqual({ ok: false, reason: 'required' });
+  });
+
+  it('trims an accepted note', () => {
+    expect(validateDismissNote('  known false positive  ')).toEqual({
+      ok: true,
+      notes: 'known false positive',
+    });
+  });
+
+  it('accepts exactly the maximum length and rejects one over', () => {
+    const atMax = 'x'.repeat(DISMISS_NOTES_MAX_LENGTH);
+    expect(validateDismissNote(atMax)).toEqual({ ok: true, notes: atMax });
+    expect(validateDismissNote(`${atMax}x`)).toEqual({ ok: false, reason: 'too_long' });
+  });
+
+  it('measures the trimmed note, not the raw input', () => {
+    const atMax = 'x'.repeat(DISMISS_NOTES_MAX_LENGTH);
+    expect(validateDismissNote(`  ${atMax}  `)).toEqual({ ok: true, notes: atMax });
+  });
+
+  it('pins the maximum to the server schema', () => {
+    expect(DISMISS_NOTES_MAX_LENGTH).toBe(2000);
+  });
+});
+
+describe('labels', () => {
+  it('names each action the way the button reads', () => {
+    expect(findingActionLabel('acknowledge')).toBe('Acknowledge');
+    expect(findingActionLabel('dismiss')).toBe('Dismiss');
+    expect(findingActionLabel('reopen')).toBe('Reopen');
+  });
+
+  it('names each status', () => {
+    expect(findingStatusLabel('open')).toBe('Open');
+    expect(findingStatusLabel('acknowledged')).toBe('Acknowledged');
+    expect(findingStatusLabel('dismissed')).toBe('Dismissed');
+    expect(findingStatusLabel('resolved')).toBe('Resolved');
+  });
+
+  it('falls back to the raw value for an unknown status rather than rendering nothing', () => {
+    expect(findingStatusLabel('snoozed' as FleetFindingStatus)).toBe('snoozed');
+  });
+
+  it('names each severity', () => {
+    expect(severityLabel('critical')).toBe('Critical');
+    expect(severityLabel('error')).toBe('Error');
+    expect(severityLabel('warning')).toBe('Warning');
+    expect(severityLabel('info')).toBe('Info');
+  });
+});
+
+describe('findingSeverityRank', () => {
+  it('ranks critical above error above warning above info', () => {
+    expect(findingSeverityRank('critical')).toBeGreaterThan(findingSeverityRank('error'));
+    expect(findingSeverityRank('error')).toBeGreaterThan(findingSeverityRank('warning'));
+    expect(findingSeverityRank('warning')).toBeGreaterThan(findingSeverityRank('info'));
+  });
+
+  it('sorts an unknown severity last', () => {
+    expect(findingSeverityRank('nonsense' as 'info')).toBe(0);
+    expect(findingSeverityRank('info')).toBeGreaterThan(0);
+  });
+});
+
+describe('findingSeverityTier', () => {
+  it('maps each severity onto the shared riskTier band the alert rows use', () => {
+    expect(findingSeverityTier('critical')).toBe('critical');
+    expect(findingSeverityTier('error')).toBe('high');
+    expect(findingSeverityTier('warning')).toBe('medium');
+    expect(findingSeverityTier('info')).toBe('low');
+  });
+
+  it('falls back to the lowest band for a severity this build does not know', () => {
+    expect(findingSeverityTier('nonsense' as FleetFindingSeverity)).toBe('low');
+  });
+});

--- a/apps/mobile/src/screens/systems/findingActions.ts
+++ b/apps/mobile/src/screens/systems/findingActions.ts
@@ -16,7 +16,7 @@ export type FleetFindingStatus = 'open' | 'acknowledged' | 'dismissed' | 'resolv
 export type FleetFindingSeverity = 'info' | 'warning' | 'error' | 'critical';
 export type FleetFindingAction = 'acknowledge' | 'dismiss' | 'reopen';
 
-/** Matches the server's `notes` max on `PATCH /fleet/findings/:id`. */
+/** Matches the server's `z.string().max(2000)` on `PATCH /fleet/findings/:id`. */
 export const DISMISS_NOTES_MAX_LENGTH = 2000;
 
 export function canAcknowledge(status: FleetFindingStatus): boolean {
@@ -48,9 +48,15 @@ export type DismissNoteResult =
   | { ok: false; reason: 'required' | 'too_long' };
 
 /**
- * A dismiss without a note is a 400 from the API, so the sheet blocks it
- * locally rather than round-tripping. The length is measured on the trimmed
- * value because that is what gets sent.
+ * The API takes `notes` as optional on every action
+ * (`apps/api/src/routes/fleetFindings.ts:79`) — requiring one on dismiss is a
+ * PRODUCT rule, enforced client-side, and the web drawer enforces exactly the
+ * same one. A dismissal with no recorded reason is indistinguishable from a
+ * mis-tap to whoever reads the finding next, which is the whole reason the
+ * field exists.
+ *
+ * The length is measured on the trimmed value because that is what gets sent,
+ * and the cap matches the server's `z.string().max(2000)`.
  */
 export function validateDismissNote(raw: string): DismissNoteResult {
   const notes = raw.trim();

--- a/apps/mobile/src/screens/systems/findingActions.ts
+++ b/apps/mobile/src/screens/systems/findingActions.ts
@@ -1,0 +1,129 @@
+/**
+ * Fleet-finding lifecycle gating and copy (#5365).
+ *
+ * Kept as a pure leaf module — no React Native imports — so the gating table
+ * is unit-tested in Vitest's node environment. The mobile app has no RN test
+ * runtime (see `apps/mobile/vitest.config.ts`), so anything worth asserting
+ * has to live outside a `.tsx`.
+ *
+ * The table below mirrors `apps/web/src/components/fleet/FindingDrawer.tsx`
+ * exactly: a tech must not be offered an action on the phone that the web
+ * refuses (or vice versa), because both hit the same
+ * `PATCH /fleet/findings/:id` and the server is the real arbiter.
+ */
+
+export type FleetFindingStatus = 'open' | 'acknowledged' | 'dismissed' | 'resolved';
+export type FleetFindingSeverity = 'info' | 'warning' | 'error' | 'critical';
+export type FleetFindingAction = 'acknowledge' | 'dismiss' | 'reopen';
+
+/** Matches the server's `notes` max on `PATCH /fleet/findings/:id`. */
+export const DISMISS_NOTES_MAX_LENGTH = 2000;
+
+export function canAcknowledge(status: FleetFindingStatus): boolean {
+  return status === 'open';
+}
+
+export function canDismiss(status: FleetFindingStatus): boolean {
+  return status === 'open' || status === 'acknowledged';
+}
+
+export function canReopen(status: FleetFindingStatus): boolean {
+  return status === 'acknowledged' || status === 'dismissed';
+}
+
+/**
+ * The actions to render, in render order. `resolved` is terminal: the
+ * reconciler owns resolution and there is deliberately no resolve action.
+ */
+export function availableFindingActions(status: FleetFindingStatus): FleetFindingAction[] {
+  const actions: FleetFindingAction[] = [];
+  if (canAcknowledge(status)) actions.push('acknowledge');
+  if (canDismiss(status)) actions.push('dismiss');
+  if (canReopen(status)) actions.push('reopen');
+  return actions;
+}
+
+export type DismissNoteResult =
+  | { ok: true; notes: string }
+  | { ok: false; reason: 'required' | 'too_long' };
+
+/**
+ * A dismiss without a note is a 400 from the API, so the sheet blocks it
+ * locally rather than round-tripping. The length is measured on the trimmed
+ * value because that is what gets sent.
+ */
+export function validateDismissNote(raw: string): DismissNoteResult {
+  const notes = raw.trim();
+  if (notes.length === 0) return { ok: false, reason: 'required' };
+  if (notes.length > DISMISS_NOTES_MAX_LENGTH) return { ok: false, reason: 'too_long' };
+  return { ok: true, notes };
+}
+
+const ACTION_LABELS: Record<FleetFindingAction, string> = {
+  acknowledge: 'Acknowledge',
+  dismiss: 'Dismiss',
+  reopen: 'Reopen',
+};
+
+export function findingActionLabel(action: FleetFindingAction): string {
+  return ACTION_LABELS[action];
+}
+
+const STATUS_LABELS: Record<FleetFindingStatus, string> = {
+  open: 'Open',
+  acknowledged: 'Acknowledged',
+  dismissed: 'Dismissed',
+  resolved: 'Resolved',
+};
+
+/**
+ * Falls back to the raw server value for a status this build does not know
+ * about — a blank chip would read as "no status" and hide the truth.
+ */
+export function findingStatusLabel(status: FleetFindingStatus): string {
+  return STATUS_LABELS[status] ?? String(status);
+}
+
+const SEVERITY_LABELS: Record<FleetFindingSeverity, string> = {
+  info: 'Info',
+  warning: 'Warning',
+  error: 'Error',
+  critical: 'Critical',
+};
+
+export function severityLabel(severity: FleetFindingSeverity): string {
+  return SEVERITY_LABELS[severity] ?? String(severity);
+}
+
+const SEVERITY_RANK: Record<FleetFindingSeverity, number> = {
+  critical: 4,
+  error: 3,
+  warning: 2,
+  info: 1,
+};
+
+/** Higher sorts first. An unrecognised severity ranks 0, i.e. last. */
+export function findingSeverityRank(severity: FleetFindingSeverity): number {
+  return SEVERITY_RANK[severity] ?? 0;
+}
+
+/**
+ * The `riskTier` band a severity pill should wear. Findings carry the API's
+ * four-value severity scale while the mobile theme exposes the alert
+ * `riskTier` bands, so the two have to be mapped somewhere — here, as a pure
+ * function, rather than inline in the screen where it would be untestable.
+ * `error` maps to `high` and `warning` to `medium`, matching how the web
+ * findings table colours the same values.
+ */
+export type FindingSeverityTier = 'low' | 'medium' | 'high' | 'critical';
+
+const SEVERITY_TIERS: Record<FleetFindingSeverity, FindingSeverityTier> = {
+  info: 'low',
+  warning: 'medium',
+  error: 'high',
+  critical: 'critical',
+};
+
+export function findingSeverityTier(severity: FleetFindingSeverity): FindingSeverityTier {
+  return SEVERITY_TIERS[severity] ?? 'low';
+}

--- a/apps/mobile/src/screens/systems/findingDetail.test.ts
+++ b/apps/mobile/src/screens/systems/findingDetail.test.ts
@@ -272,3 +272,54 @@ describe('outcome copy', () => {
     });
   });
 });
+
+describe('actionSettled — the action landed but the re-read did not', () => {
+  const loaded: FindingDetailState = {
+    ...initialFindingDetailState,
+    phase: 'ready',
+    finding: finding({ status: 'open', members: [member()] }),
+    pendingAction: 'acknowledge',
+  };
+
+  it('folds the PATCH row in and keeps the members already on screen', () => {
+    const next = findingDetailReducer(loaded, {
+      type: 'actionSettled',
+      row: {
+        ...finding(),
+        status: 'acknowledged',
+      },
+    });
+    expect(next.phase).toBe('ready');
+    expect(next.finding?.status).toBe('acknowledged');
+    // A lifecycle action does not change membership, so the list we already
+    // hold is still the truth — dropping it would blank the device list on a
+    // refresh blip.
+    expect(next.finding?.members).toEqual([member()]);
+  });
+
+  it('clears the pending action so the buttons come back enabled', () => {
+    const next = findingDetailReducer(loaded, {
+      type: 'actionSettled',
+      row: { ...finding(), status: 'acknowledged' },
+    });
+    expect(next.pendingAction).toBeNull();
+    expect(isActionBusy(next)).toBe(false);
+  });
+
+  it('does not report the action as failed', () => {
+    const next = findingDetailReducer(loaded, {
+      type: 'actionSettled',
+      row: { ...finding(), status: 'acknowledged' },
+    });
+    expect(next.actionErrorMessage).toBeNull();
+  });
+
+  it('is a no-op on pendingAction alone when nothing is on screen to merge into', () => {
+    const next = findingDetailReducer(
+      { ...initialFindingDetailState, pendingAction: 'acknowledge' },
+      { type: 'actionSettled', row: { ...finding(), status: 'acknowledged' } },
+    );
+    expect(next.finding).toBeNull();
+    expect(next.pendingAction).toBeNull();
+  });
+});

--- a/apps/mobile/src/screens/systems/findingDetail.test.ts
+++ b/apps/mobile/src/screens/systems/findingDetail.test.ts
@@ -1,0 +1,274 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  detailActions,
+  findingActionSuccessMessage,
+  findingDetailMeta,
+  findingDetailNotFoundCopy,
+  findingDetailReducer,
+  initialFindingDetailState,
+  isActionBusy,
+  memberPrimaryLabel,
+  memberSecondaryLabel,
+  type FindingDetailData,
+  type FindingDetailState,
+  type FindingMember,
+} from './findingDetail';
+
+function member(overrides: Partial<FindingMember> = {}): FindingMember {
+  return {
+    deviceId: 'd-1',
+    hostname: 'WIN-ACCT-01',
+    displayName: 'Reception PC',
+    osType: 'windows',
+    lastSeenAt: '2026-09-09T12:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function finding(overrides: Partial<FindingDetailData> = {}): FindingDetailData {
+  return {
+    id: 'f-1',
+    orgId: 'o-1',
+    orgName: 'Berthoud Vet Care',
+    title: 'VSS writers failing',
+    summary: 'Shadow copy creation failed on 3 devices.',
+    status: 'open',
+    severity: 'error',
+    deviceCount: 3,
+    firstSeenAt: '2026-09-01T12:00:00.000Z',
+    lastSeenAt: '2026-09-09T12:00:00.000Z',
+    dismissNotes: null,
+    members: [member()],
+    ...overrides,
+  };
+}
+
+describe('findingDetailReducer', () => {
+  it('starts loading with nothing loaded', () => {
+    expect(initialFindingDetailState).toEqual({
+      phase: 'loading',
+      finding: null,
+      refreshing: false,
+      pendingAction: null,
+      errorMessage: null,
+      actionErrorMessage: null,
+    });
+  });
+
+  it('loads a finding', () => {
+    const state = findingDetailReducer(initialFindingDetailState, {
+      type: 'loaded',
+      finding: finding(),
+    });
+    expect(state.phase).toBe('ready');
+    expect(state.finding?.id).toBe('f-1');
+    expect(state.errorMessage).toBeNull();
+  });
+
+  it('treats a 404 as its own state so the screen shows an empty state, not a crash', () => {
+    const state = findingDetailReducer(initialFindingDetailState, { type: 'notFound' });
+    expect(state.phase).toBe('notFound');
+    expect(state.finding).toBeNull();
+    expect(state.errorMessage).toBeNull();
+  });
+
+  it('errors when the fetch fails for any other reason', () => {
+    const state = findingDetailReducer(initialFindingDetailState, {
+      type: 'failed',
+      message: 'Network request failed',
+    });
+    expect(state.phase).toBe('error');
+    expect(state.errorMessage).toBe('Network request failed');
+  });
+
+  it('keeps the loaded finding on screen while a reload runs', () => {
+    const ready = findingDetailReducer(initialFindingDetailState, {
+      type: 'loaded',
+      finding: finding(),
+    });
+    const reloading = findingDetailReducer(ready, { type: 'load' });
+    expect(reloading.phase).toBe('ready');
+    expect(reloading.refreshing).toBe(true);
+    expect(reloading.finding?.id).toBe('f-1');
+  });
+
+  it('shows the skeleton on a first load', () => {
+    const state = findingDetailReducer(initialFindingDetailState, { type: 'load' });
+    expect(state.phase).toBe('loading');
+    expect(state.refreshing).toBe(false);
+  });
+
+  it('marks the action pending and clears a prior action error', () => {
+    const ready: FindingDetailState = {
+      ...initialFindingDetailState,
+      phase: 'ready',
+      finding: finding(),
+      actionErrorMessage: 'Previously failed',
+    };
+    const pending = findingDetailReducer(ready, { type: 'actionStarted', action: 'acknowledge' });
+    expect(pending.pendingAction).toBe('acknowledge');
+    expect(pending.actionErrorMessage).toBeNull();
+    expect(isActionBusy(pending)).toBe(true);
+  });
+
+  it('swaps in the server copy of the finding when an action succeeds', () => {
+    const pending = findingDetailReducer(
+      { ...initialFindingDetailState, phase: 'ready', finding: finding() },
+      { type: 'actionStarted', action: 'acknowledge' },
+    );
+    const done = findingDetailReducer(pending, {
+      type: 'actionSucceeded',
+      finding: finding({ status: 'acknowledged' }),
+    });
+    expect(done.finding?.status).toBe('acknowledged');
+    expect(done.pendingAction).toBeNull();
+    expect(done.actionErrorMessage).toBeNull();
+    expect(isActionBusy(done)).toBe(false);
+  });
+
+  it('keeps the old finding and reports the failure when an action fails', () => {
+    const pending = findingDetailReducer(
+      { ...initialFindingDetailState, phase: 'ready', finding: finding() },
+      { type: 'actionStarted', action: 'dismiss' },
+    );
+    const failed = findingDetailReducer(pending, {
+      type: 'actionFailed',
+      message: 'Notes are required',
+    });
+    expect(failed.finding?.status).toBe('open');
+    expect(failed.pendingAction).toBeNull();
+    expect(failed.actionErrorMessage).toBe('Notes are required');
+    expect(failed.phase).toBe('ready');
+  });
+
+  it('does not turn an action failure into a whole-screen error', () => {
+    const pending = findingDetailReducer(
+      { ...initialFindingDetailState, phase: 'ready', finding: finding() },
+      { type: 'actionStarted', action: 'reopen' },
+    );
+    const failed = findingDetailReducer(pending, { type: 'actionFailed', message: 'Offline' });
+    expect(failed.errorMessage).toBeNull();
+  });
+
+  it('recovers to ready after a failed first load succeeds on retry', () => {
+    const errored = findingDetailReducer(initialFindingDetailState, {
+      type: 'failed',
+      message: 'Offline',
+    });
+    const recovered = findingDetailReducer(errored, { type: 'loaded', finding: finding() });
+    expect(recovered.phase).toBe('ready');
+    expect(recovered.errorMessage).toBeNull();
+  });
+});
+
+describe('detailActions', () => {
+  it('offers nothing while the finding is still loading', () => {
+    expect(detailActions(initialFindingDetailState)).toEqual([]);
+  });
+
+  it('derives the buttons from the loaded status', () => {
+    const open = { ...initialFindingDetailState, phase: 'ready' as const, finding: finding() };
+    expect(detailActions(open)).toEqual(['acknowledge', 'dismiss']);
+
+    const acked = {
+      ...open,
+      finding: finding({ status: 'acknowledged' }),
+    };
+    expect(detailActions(acked)).toEqual(['dismiss', 'reopen']);
+
+    const resolved = { ...open, finding: finding({ status: 'resolved' }) };
+    expect(detailActions(resolved)).toEqual([]);
+  });
+
+  it('keeps offering the buttons while one is running so they can render disabled', () => {
+    const pending = findingDetailReducer(
+      { ...initialFindingDetailState, phase: 'ready', finding: finding() },
+      { type: 'actionStarted', action: 'acknowledge' },
+    );
+    expect(detailActions(pending)).toEqual(['acknowledge', 'dismiss']);
+    expect(isActionBusy(pending)).toBe(true);
+  });
+});
+
+describe('member copy', () => {
+  it('prefers the display name and falls back to the hostname', () => {
+    expect(memberPrimaryLabel(member())).toBe('Reception PC');
+    expect(memberPrimaryLabel(member({ displayName: null }))).toBe('WIN-ACCT-01');
+    expect(memberPrimaryLabel(member({ displayName: '   ' }))).toBe('WIN-ACCT-01');
+  });
+
+  it('falls back to the device id when a device has neither name', () => {
+    expect(memberPrimaryLabel(member({ displayName: null, hostname: '' }))).toBe('d-1');
+  });
+
+  describe('secondary line', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-09-09T14:00:00.000Z'));
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('shows the hostname alongside the OS when the display name differs', () => {
+      expect(memberSecondaryLabel(member())).toBe('WIN-ACCT-01 · Windows · 2h ago');
+    });
+
+    it('does not repeat the hostname when it is already the primary label', () => {
+      expect(memberSecondaryLabel(member({ displayName: null }))).toBe('Windows · 2h ago');
+    });
+
+    it('drops an unusable last-seen', () => {
+      expect(memberSecondaryLabel(member({ displayName: null, lastSeenAt: '' }))).toBe('Windows');
+    });
+  });
+});
+
+describe('findingDetailMeta', () => {
+  it('renders an em dash rather than a blank for a missing value', () => {
+    const rows = findingDetailMeta(finding({ orgName: null, summary: null }));
+    const byLabel = Object.fromEntries(rows.map((r) => [r.label, r.value]));
+    expect(byLabel.Organization).toBe('—');
+  });
+
+  it('reports status, severity, org, device count and both timestamps', () => {
+    const rows = findingDetailMeta(finding());
+    expect(rows.map((r) => r.label)).toEqual([
+      'Status',
+      'Severity',
+      'Organization',
+      'Devices',
+      'First seen',
+      'Last seen',
+    ]);
+    const byLabel = Object.fromEntries(rows.map((r) => [r.label, r.value]));
+    expect(byLabel.Status).toBe('Open');
+    expect(byLabel.Severity).toBe('Error');
+    expect(byLabel.Organization).toBe('Berthoud Vet Care');
+    expect(byLabel.Devices).toBe('3');
+  });
+
+  it('adds the dismiss note only when the finding carries one', () => {
+    expect(findingDetailMeta(finding()).some((r) => r.label === 'Dismiss note')).toBe(false);
+    const dismissed = findingDetailMeta(
+      finding({ status: 'dismissed', dismissNotes: 'Known and accepted' }),
+    );
+    expect(dismissed.at(-1)).toEqual({ label: 'Dismiss note', value: 'Known and accepted' });
+  });
+});
+
+describe('outcome copy', () => {
+  it('confirms each action in plain words', () => {
+    expect(findingActionSuccessMessage('acknowledge')).toBe('Finding acknowledged.');
+    expect(findingActionSuccessMessage('dismiss')).toBe('Finding dismissed.');
+    expect(findingActionSuccessMessage('reopen')).toBe('Finding reopened.');
+  });
+
+  it('explains a missing finding instead of showing a blank screen', () => {
+    expect(findingDetailNotFoundCopy()).toEqual({
+      title: 'Finding not available',
+      body: 'This finding was resolved or is no longer visible to your account.',
+    });
+  });
+});

--- a/apps/mobile/src/screens/systems/findingDetail.ts
+++ b/apps/mobile/src/screens/systems/findingDetail.ts
@@ -34,6 +34,14 @@ export interface FindingMember {
   lastSeenAt: string;
 }
 
+/**
+ * A finding WITHOUT its member devices — the shape `PATCH /fleet/findings/:id`
+ * answers with. The lifecycle actions never change membership, so a row of
+ * this shape can be folded into what is already on screen without losing the
+ * device list.
+ */
+export type FindingDetailRow = Omit<FindingDetailData, 'members'>;
+
 export interface FindingDetailData {
   id: string;
   orgId: string;
@@ -77,6 +85,12 @@ export type FindingDetailEvent =
   | { type: 'failed'; message: string }
   | { type: 'actionStarted'; action: FleetFindingAction }
   | { type: 'actionSucceeded'; finding: FindingDetailData }
+  /**
+   * The PATCH landed but the follow-up read did not. The mutation is real, so
+   * this is NOT a failure: fold the row the PATCH itself returned into what is
+   * on screen and keep the members already held.
+   */
+  | { type: 'actionSettled'; row: FindingDetailRow }
   | { type: 'actionFailed'; message: string };
 
 export function findingDetailReducer(
@@ -115,6 +129,17 @@ export function findingDetailReducer(
         ...state,
         phase: 'ready',
         finding: event.finding,
+        pendingAction: null,
+        actionErrorMessage: null,
+      };
+    case 'actionSettled':
+      // Without a finding on screen there is nothing to merge into — the only
+      // thing left to do is release the buttons.
+      if (!state.finding) return { ...state, pendingAction: null };
+      return {
+        ...state,
+        phase: 'ready',
+        finding: { ...state.finding, ...event.row },
         pendingAction: null,
         actionErrorMessage: null,
       };

--- a/apps/mobile/src/screens/systems/findingDetail.ts
+++ b/apps/mobile/src/screens/systems/findingDetail.ts
@@ -1,0 +1,203 @@
+import { osLabel } from '../../lib/osLabel';
+import { relativeTime } from '../../lib/relativeTime';
+import {
+  availableFindingActions,
+  findingStatusLabel,
+  severityLabel,
+  type FleetFindingAction,
+  type FleetFindingSeverity,
+  type FleetFindingStatus,
+} from './findingActions';
+
+/**
+ * State and copy for the finding detail screen (#5365).
+ *
+ * Pure leaf module (no React Native imports) so the lifecycle state machine is
+ * unit-tested in Vitest's node environment — `FindingDetailScreen.tsx` is a
+ * state-to-JSX mapping over it.
+ *
+ * The two states worth calling out:
+ *  - `notFound` is its own phase, not an error. `GET /fleet/findings/:id`
+ *    answers 404 for a finding that was resolved, deleted, or belongs to an
+ *    org/site the caller cannot see (the API deliberately does not distinguish
+ *    those). A tech tapping a stale row must get an explanation, not a crash
+ *    or a red "something went wrong".
+ *  - an action failure never clears the finding. Losing the screen because a
+ *    dismiss was rejected would be worse than the rejection.
+ */
+
+export interface FindingMember {
+  deviceId: string;
+  hostname: string;
+  displayName: string | null;
+  osType: string;
+  lastSeenAt: string;
+}
+
+export interface FindingDetailData {
+  id: string;
+  orgId: string;
+  orgName: string | null;
+  title: string;
+  summary: string | null;
+  status: FleetFindingStatus;
+  severity: FleetFindingSeverity;
+  deviceCount: number;
+  firstSeenAt: string;
+  lastSeenAt: string;
+  dismissNotes: string | null;
+  members: FindingMember[];
+}
+
+export interface FindingDetailState {
+  phase: 'loading' | 'ready' | 'notFound' | 'error';
+  finding: FindingDetailData | null;
+  refreshing: boolean;
+  /** The lifecycle action currently in flight, if any. */
+  pendingAction: FleetFindingAction | null;
+  /** A load failure — owns the whole screen. */
+  errorMessage: string | null;
+  /** An action failure — shown inline, the finding stays on screen. */
+  actionErrorMessage: string | null;
+}
+
+export const initialFindingDetailState: FindingDetailState = {
+  phase: 'loading',
+  finding: null,
+  refreshing: false,
+  pendingAction: null,
+  errorMessage: null,
+  actionErrorMessage: null,
+};
+
+export type FindingDetailEvent =
+  | { type: 'load' }
+  | { type: 'loaded'; finding: FindingDetailData }
+  | { type: 'notFound' }
+  | { type: 'failed'; message: string }
+  | { type: 'actionStarted'; action: FleetFindingAction }
+  | { type: 'actionSucceeded'; finding: FindingDetailData }
+  | { type: 'actionFailed'; message: string };
+
+export function findingDetailReducer(
+  state: FindingDetailState,
+  event: FindingDetailEvent,
+): FindingDetailState {
+  switch (event.type) {
+    case 'load':
+      return state.finding
+        ? { ...state, refreshing: true, errorMessage: null }
+        : { ...state, phase: 'loading', refreshing: false, errorMessage: null };
+    case 'loaded':
+      return {
+        ...state,
+        phase: 'ready',
+        finding: event.finding,
+        refreshing: false,
+        errorMessage: null,
+      };
+    case 'notFound':
+      return {
+        ...initialFindingDetailState,
+        phase: 'notFound',
+      };
+    case 'failed':
+      return {
+        ...state,
+        phase: 'error',
+        refreshing: false,
+        errorMessage: event.message,
+      };
+    case 'actionStarted':
+      return { ...state, pendingAction: event.action, actionErrorMessage: null };
+    case 'actionSucceeded':
+      return {
+        ...state,
+        phase: 'ready',
+        finding: event.finding,
+        pendingAction: null,
+        actionErrorMessage: null,
+      };
+    case 'actionFailed':
+      return { ...state, pendingAction: null, actionErrorMessage: event.message };
+    default:
+      return state;
+  }
+}
+
+/**
+ * The lifecycle buttons to render. Still returned while an action is in
+ * flight so the screen can render them disabled rather than have them vanish
+ * mid-tap — use `isActionBusy` for the disabled state.
+ */
+export function detailActions(state: FindingDetailState): FleetFindingAction[] {
+  if (!state.finding) return [];
+  return availableFindingActions(state.finding.status);
+}
+
+export function isActionBusy(state: FindingDetailState): boolean {
+  return state.pendingAction !== null;
+}
+
+export function memberPrimaryLabel(member: FindingMember): string {
+  return member.displayName?.trim() || member.hostname.trim() || member.deviceId;
+}
+
+/** e.g. "WIN-ACCT-01 · Windows · 2h ago" — the hostname only when it adds something. */
+export function memberSecondaryLabel(member: FindingMember): string {
+  const segments: string[] = [];
+  const hostname = member.hostname.trim();
+  if (hostname && hostname !== memberPrimaryLabel(member)) segments.push(hostname);
+  if (member.osType.trim()) segments.push(osLabel(member.osType));
+  const seen = relativeTime(member.lastSeenAt);
+  if (seen) segments.push(seen);
+  return segments.join(' · ');
+}
+
+export interface FindingDetailMetaRow {
+  label: string;
+  value: string;
+}
+
+const EM_DASH = '—';
+
+function formatTimestamp(iso: string): string {
+  const t = new Date(iso).getTime();
+  if (Number.isNaN(t)) return EM_DASH;
+  return new Date(t).toLocaleString();
+}
+
+/**
+ * The label/value rows under the title. Mirrors `deviceDetailFields.ts`'s
+ * rule: an empty value renders an em dash, never a blank.
+ */
+export function findingDetailMeta(finding: FindingDetailData): FindingDetailMetaRow[] {
+  const rows: FindingDetailMetaRow[] = [
+    { label: 'Status', value: findingStatusLabel(finding.status) },
+    { label: 'Severity', value: severityLabel(finding.severity) },
+    { label: 'Organization', value: finding.orgName?.trim() || EM_DASH },
+    { label: 'Devices', value: String(finding.deviceCount) },
+    { label: 'First seen', value: formatTimestamp(finding.firstSeenAt) },
+    { label: 'Last seen', value: formatTimestamp(finding.lastSeenAt) },
+  ];
+  const note = finding.dismissNotes?.trim();
+  if (note) rows.push({ label: 'Dismiss note', value: note });
+  return rows;
+}
+
+const ACTION_SUCCESS: Record<FleetFindingAction, string> = {
+  acknowledge: 'Finding acknowledged.',
+  dismiss: 'Finding dismissed.',
+  reopen: 'Finding reopened.',
+};
+
+export function findingActionSuccessMessage(action: FleetFindingAction): string {
+  return ACTION_SUCCESS[action];
+}
+
+export function findingDetailNotFoundCopy(): { title: string; body: string } {
+  return {
+    title: 'Finding not available',
+    body: 'This finding was resolved or is no longer visible to your account.',
+  };
+}

--- a/apps/mobile/src/screens/systems/findingsList.test.ts
+++ b/apps/mobile/src/screens/systems/findingsList.test.ts
@@ -1,0 +1,235 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  findingRowSubtitle,
+  findingsListEmptyCopy,
+  findingsListReducer,
+  initialFindingsListState,
+  sortFindings,
+  toFindingListItem,
+  type FindingListItem,
+  type FindingsListState,
+} from './findingsList';
+import type { FleetFinding } from '../../services/findings';
+
+function item(overrides: Partial<FindingListItem> = {}): FindingListItem {
+  return {
+    id: 'f-1',
+    title: 'VSS writers failing',
+    status: 'open',
+    severity: 'warning',
+    deviceCount: 3,
+    lastSeenAt: '2026-09-09T12:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('sortFindings', () => {
+  it('puts the worst severity first', () => {
+    const sorted = sortFindings([
+      item({ id: 'info', severity: 'info' }),
+      item({ id: 'critical', severity: 'critical' }),
+      item({ id: 'warning', severity: 'warning' }),
+      item({ id: 'error', severity: 'error' }),
+    ]);
+    expect(sorted.map((f) => f.id)).toEqual(['critical', 'error', 'warning', 'info']);
+  });
+
+  it('breaks a severity tie with the most recently seen', () => {
+    const sorted = sortFindings([
+      item({ id: 'older', lastSeenAt: '2026-09-01T00:00:00.000Z' }),
+      item({ id: 'newer', lastSeenAt: '2026-09-08T00:00:00.000Z' }),
+    ]);
+    expect(sorted.map((f) => f.id)).toEqual(['newer', 'older']);
+  });
+
+  it('breaks a full tie on title so the order does not flicker between refreshes', () => {
+    const sorted = sortFindings([
+      item({ id: 'b', title: 'Zeta' }),
+      item({ id: 'a', title: 'Alpha' }),
+    ]);
+    expect(sorted.map((f) => f.id)).toEqual(['a', 'b']);
+  });
+
+  it('does not mutate the input', () => {
+    const input = [item({ id: 'info', severity: 'info' }), item({ id: 'crit', severity: 'critical' })];
+    sortFindings(input);
+    expect(input.map((f) => f.id)).toEqual(['info', 'crit']);
+  });
+
+  it('sorts a finding with an unparseable lastSeenAt last within its severity', () => {
+    const sorted = sortFindings([
+      item({ id: 'bad', lastSeenAt: 'not-a-date' }),
+      item({ id: 'good', lastSeenAt: '2026-01-01T00:00:00.000Z' }),
+    ]);
+    expect(sorted.map((f) => f.id)).toEqual(['good', 'bad']);
+  });
+});
+
+describe('findingsListReducer', () => {
+  it('starts loading with nothing to show', () => {
+    expect(initialFindingsListState).toEqual({
+      phase: 'loading',
+      findings: [],
+      total: 0,
+      refreshing: false,
+      errorMessage: null,
+    });
+  });
+
+  it('shows the skeleton on the first load and the refresh control on later ones', () => {
+    const first = findingsListReducer(initialFindingsListState, { type: 'load' });
+    expect(first.phase).toBe('loading');
+    expect(first.refreshing).toBe(false);
+
+    const ready = findingsListReducer(first, { type: 'loaded', findings: [item()], total: 1 });
+    const second = findingsListReducer(ready, { type: 'load' });
+    expect(second.phase).toBe('ready');
+    expect(second.refreshing).toBe(true);
+    expect(second.findings).toHaveLength(1);
+  });
+
+  it('sorts on load so the screen never has to', () => {
+    const state = findingsListReducer(initialFindingsListState, {
+      type: 'loaded',
+      findings: [item({ id: 'low', severity: 'info' }), item({ id: 'high', severity: 'critical' })],
+      total: 2,
+    });
+    expect(state.phase).toBe('ready');
+    expect(state.findings.map((f) => f.id)).toEqual(['high', 'low']);
+    expect(state.total).toBe(2);
+    expect(state.refreshing).toBe(false);
+    expect(state.errorMessage).toBeNull();
+  });
+
+  it('treats a 404 as an empty list, not an error', () => {
+    const state = findingsListReducer(initialFindingsListState, { type: 'empty' });
+    expect(state).toEqual({
+      phase: 'ready',
+      findings: [],
+      total: 0,
+      refreshing: false,
+      errorMessage: null,
+    });
+  });
+
+  it('errors only when there is nothing already on screen', () => {
+    const state = findingsListReducer(initialFindingsListState, {
+      type: 'failed',
+      message: 'Network request failed',
+    });
+    expect(state.phase).toBe('error');
+    expect(state.errorMessage).toBe('Network request failed');
+    expect(state.refreshing).toBe(false);
+  });
+
+  it('keeps the rows and surfaces a banner when a refresh fails', () => {
+    const ready = findingsListReducer(initialFindingsListState, {
+      type: 'loaded',
+      findings: [item()],
+      total: 1,
+    });
+    const refreshing = findingsListReducer(ready, { type: 'load' });
+    const failed = findingsListReducer(refreshing, { type: 'failed', message: 'Offline' });
+    expect(failed.phase).toBe('ready');
+    expect(failed.findings).toHaveLength(1);
+    expect(failed.refreshing).toBe(false);
+    expect(failed.errorMessage).toBe('Offline');
+  });
+
+  it('clears a previous error when a load starts', () => {
+    const errored: FindingsListState = {
+      phase: 'error',
+      findings: [],
+      total: 0,
+      refreshing: false,
+      errorMessage: 'Offline',
+    };
+    expect(findingsListReducer(errored, { type: 'load' }).errorMessage).toBeNull();
+  });
+
+  it('recovers from an error state on a successful reload', () => {
+    const errored = findingsListReducer(initialFindingsListState, {
+      type: 'failed',
+      message: 'Offline',
+    });
+    const recovered = findingsListReducer(errored, {
+      type: 'loaded',
+      findings: [item()],
+      total: 1,
+    });
+    expect(recovered.phase).toBe('ready');
+    expect(recovered.errorMessage).toBeNull();
+  });
+});
+
+describe('copy', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-09-09T14:00:00.000Z'));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('reads status, device count and recency', () => {
+    expect(findingRowSubtitle(item({ status: 'open', deviceCount: 3 }))).toBe(
+      'Open · 3 devices · 2h ago',
+    );
+  });
+
+  it('singularises one device', () => {
+    expect(findingRowSubtitle(item({ deviceCount: 1 }))).toBe('Open · 1 device · 2h ago');
+  });
+
+  it('omits the device segment when the finding has no members', () => {
+    expect(findingRowSubtitle(item({ deviceCount: 0 }))).toBe('Open · 2h ago');
+  });
+
+  it('omits the time segment when lastSeenAt is unusable', () => {
+    expect(findingRowSubtitle(item({ lastSeenAt: 'not-a-date' }))).toBe('Open · 3 devices');
+  });
+
+  it('names the org in the empty state so the tech knows what was checked', () => {
+    expect(findingsListEmptyCopy('Berthoud Vet Care')).toEqual({
+      title: 'No open findings',
+      body: 'Berthoud Vet Care has no open or acknowledged findings right now.',
+    });
+  });
+
+  it('falls back to a generic empty state when the org name is unknown', () => {
+    expect(findingsListEmptyCopy('').body).toBe(
+      'This organization has no open or acknowledged findings right now.',
+    );
+  });
+});
+
+describe('toFindingListItem', () => {
+  it('narrows an API finding row to only the fields the list renders', () => {
+    const row: FleetFinding = {
+      id: 'f-9',
+      orgId: 'org-1',
+      orgName: 'Berthoud Vet Care',
+      kind: 'reliability_offenders',
+      status: 'acknowledged',
+      severity: 'error',
+      title: 'Repeated unexpected reboots',
+      summary: 'Three devices rebooted unexpectedly',
+      deviceCount: 3,
+      firstSeenAt: '2026-09-01T00:00:00.000Z',
+      lastSeenAt: '2026-09-09T12:00:00.000Z',
+      acknowledgedAt: '2026-09-09T13:00:00.000Z',
+      dismissedAt: null,
+      dismissNotes: null,
+      resolvedAt: null,
+    };
+    expect(toFindingListItem(row)).toEqual({
+      id: 'f-9',
+      title: 'Repeated unexpected reboots',
+      status: 'acknowledged',
+      severity: 'error',
+      deviceCount: 3,
+      lastSeenAt: '2026-09-09T12:00:00.000Z',
+    });
+  });
+});

--- a/apps/mobile/src/screens/systems/findingsList.ts
+++ b/apps/mobile/src/screens/systems/findingsList.ts
@@ -1,0 +1,154 @@
+import { relativeTime } from '../../lib/relativeTime';
+import {
+  findingSeverityRank,
+  findingStatusLabel,
+  type FleetFindingSeverity,
+  type FleetFindingStatus,
+} from './findingActions';
+
+/**
+ * State and copy for the findings list screen (#5365) — the screen behind an
+ * ACTIVE ISSUES "N open findings" row on Systems.
+ *
+ * Pure leaf module (no React Native imports) so the reducer is unit-tested in
+ * Vitest's node environment; `FindingsListScreen.tsx` is a straight
+ * state-to-JSX mapping over it. See `apps/mobile/vitest.config.ts` for why
+ * anything worth asserting has to live outside a `.tsx`.
+ */
+
+/** The subset of `FleetFindingRow` the list renders. */
+export interface FindingListItem {
+  id: string;
+  title: string;
+  status: FleetFindingStatus;
+  severity: FleetFindingSeverity;
+  deviceCount: number;
+  lastSeenAt: string;
+}
+
+export interface FindingsListState {
+  phase: 'loading' | 'ready' | 'error';
+  findings: FindingListItem[];
+  /** Server-side total for the filter, which may exceed `findings.length`. */
+  total: number;
+  refreshing: boolean;
+  errorMessage: string | null;
+}
+
+export const initialFindingsListState: FindingsListState = {
+  phase: 'loading',
+  findings: [],
+  total: 0,
+  refreshing: false,
+  errorMessage: null,
+};
+
+export type FindingsListEvent =
+  | { type: 'load' }
+  | { type: 'loaded'; findings: FindingListItem[]; total: number }
+  /** A 404 from the findings endpoint — an org with nothing to show, not a fault. */
+  | { type: 'empty' }
+  | { type: 'failed'; message: string };
+
+function lastSeenMillis(item: FindingListItem): number {
+  const t = new Date(item.lastSeenAt).getTime();
+  // An unparseable timestamp sorts last within its severity rather than
+  // poisoning the comparator with NaN (every comparison against NaN is false,
+  // which makes the sort order implementation-defined).
+  return Number.isNaN(t) ? Number.NEGATIVE_INFINITY : t;
+}
+
+/**
+ * Worst severity first, then most recently seen, then title. The final tie
+ * break is what stops rows swapping places between refreshes.
+ */
+export function sortFindings(findings: readonly FindingListItem[]): FindingListItem[] {
+  return [...findings].sort((a, b) => {
+    const bySeverity = findingSeverityRank(b.severity) - findingSeverityRank(a.severity);
+    if (bySeverity !== 0) return bySeverity;
+    const byRecency = lastSeenMillis(b) - lastSeenMillis(a);
+    if (byRecency !== 0) return byRecency;
+    return a.title.localeCompare(b.title);
+  });
+}
+
+export function findingsListReducer(
+  state: FindingsListState,
+  event: FindingsListEvent,
+): FindingsListState {
+  switch (event.type) {
+    case 'load':
+      // First load shows the skeleton; a reload with rows already on screen
+      // keeps them and spins the pull-to-refresh control instead of blanking.
+      return state.findings.length > 0
+        ? { ...state, refreshing: true, errorMessage: null }
+        : { ...state, phase: 'loading', refreshing: false, errorMessage: null };
+    case 'loaded':
+      return {
+        phase: 'ready',
+        findings: sortFindings(event.findings),
+        total: event.total,
+        refreshing: false,
+        errorMessage: null,
+      };
+    case 'empty':
+      return { ...initialFindingsListState, phase: 'ready' };
+    case 'failed':
+      // With rows already on screen a failed refresh is a banner, not a wipe:
+      // stale findings beat an empty screen when a tech is mid-triage.
+      return state.findings.length > 0
+        ? { ...state, refreshing: false, errorMessage: event.message }
+        : {
+            phase: 'error',
+            findings: [],
+            total: 0,
+            refreshing: false,
+            errorMessage: event.message,
+          };
+    default:
+      return state;
+  }
+}
+
+/** e.g. "Open · 3 devices · 2h ago". Segments with nothing to say are dropped. */
+export function findingRowSubtitle(item: FindingListItem): string {
+  const segments: string[] = [findingStatusLabel(item.status)];
+  if (item.deviceCount > 0) {
+    segments.push(`${item.deviceCount} ${item.deviceCount === 1 ? 'device' : 'devices'}`);
+  }
+  const seen = relativeTime(item.lastSeenAt);
+  if (seen) segments.push(seen);
+  return segments.join(' · ');
+}
+
+export function findingsListEmptyCopy(orgName: string): { title: string; body: string } {
+  const who = orgName.trim() || 'This organization';
+  return {
+    title: 'No open findings',
+    body: `${who} has no open or acknowledged findings right now.`,
+  };
+}
+
+/**
+ * Narrows an API finding row to what the list renders. The API row carries a
+ * dozen fields this screen never shows (evidence timestamps, dismiss notes,
+ * kind); keeping them out of reducer state means a change to the API shape
+ * cannot silently change what the list is asserted to hold.
+ */
+export function toFindingListItem(row: {
+  id: string;
+  title: string;
+  status: FleetFindingStatus;
+  severity: FleetFindingSeverity;
+  deviceCount: number;
+  lastSeenAt: string;
+}): FindingListItem {
+  return {
+    id: row.id,
+    title: row.title,
+    status: row.status,
+    severity: row.severity,
+    deviceCount: row.deviceCount,
+    lastSeenAt: row.lastSeenAt,
+  };
+}

--- a/apps/mobile/src/screens/systems/findingsRefreshSignal.test.ts
+++ b/apps/mobile/src/screens/systems/findingsRefreshSignal.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  findingsChangedRevision,
+  markFindingsChanged,
+  shouldRefreshOnFocus,
+} from './findingsRefreshSignal';
+
+describe('findings change signal', () => {
+  it('advances the revision on every change so a consumer can spot one it has not seen', () => {
+    const before = findingsChangedRevision();
+    markFindingsChanged();
+    const after = findingsChangedRevision();
+    expect(after).toBeGreaterThan(before);
+
+    markFindingsChanged();
+    expect(findingsChangedRevision()).toBeGreaterThan(after);
+  });
+
+  it('does not move on its own', () => {
+    const first = findingsChangedRevision();
+    expect(findingsChangedRevision()).toBe(first);
+  });
+});
+
+describe('shouldRefreshOnFocus', () => {
+  const base = { now: 1_000_000, lastFetchAt: 1_000_000, debounceMs: 60_000 };
+
+  it('holds off when the data is fresh and nothing changed', () => {
+    expect(shouldRefreshOnFocus({ ...base, signalRevision: 3, seenRevision: 3 })).toBe(false);
+  });
+
+  it('refreshes once the debounce window has passed', () => {
+    expect(
+      shouldRefreshOnFocus({
+        ...base,
+        now: base.lastFetchAt + 60_000,
+        signalRevision: 3,
+        seenRevision: 3,
+      }),
+    ).toBe(true);
+  });
+
+  it('refreshes immediately after a finding was acted on, debounce or not', () => {
+    // This is the whole point of the signal: acknowledging a finding must
+    // update the Systems hero the moment the tech navigates back, not up to
+    // a minute later.
+    expect(shouldRefreshOnFocus({ ...base, signalRevision: 4, seenRevision: 3 })).toBe(true);
+  });
+
+  it('refreshes when the clock jumps backwards rather than stalling forever', () => {
+    expect(
+      shouldRefreshOnFocus({
+        ...base,
+        now: base.lastFetchAt - 5_000,
+        signalRevision: 3,
+        seenRevision: 3,
+      }),
+    ).toBe(true);
+  });
+
+  it('always refreshes before the first fetch has landed', () => {
+    expect(
+      shouldRefreshOnFocus({ now: 1_000, lastFetchAt: 0, debounceMs: 60_000, signalRevision: 0, seenRevision: 0 }),
+    ).toBe(true);
+  });
+});

--- a/apps/mobile/src/screens/systems/findingsRefreshSignal.ts
+++ b/apps/mobile/src/screens/systems/findingsRefreshSignal.ts
@@ -1,0 +1,56 @@
+/**
+ * A one-way "a finding changed" signal (#5365).
+ *
+ * `useSystemsData` is a bespoke per-mount hook — there is no react-query
+ * cache, no store, and no cross-screen invalidation channel in this app. So
+ * after the finding detail screen acknowledges/dismisses/reopens something,
+ * nothing tells the Systems tab that its open-findings counts are stale, and
+ * its focus refresh is debounced to 60s: the hero would keep claiming
+ * "1 open finding" for up to a minute after the tech cleared it.
+ *
+ * Rather than introduce a store for one number, the mutation bumps a
+ * module-level revision and the Systems screen compares it against the one it
+ * last fetched with. A monotonic counter (not a boolean flag) means several
+ * screens can consume it independently without racing to clear it.
+ *
+ * Pure module — no React Native imports — so the staleness rule is testable.
+ */
+
+let revision = 0;
+
+/** Call after a finding lifecycle action succeeds. */
+export function markFindingsChanged(): void {
+  revision += 1;
+}
+
+export function findingsChangedRevision(): number {
+  return revision;
+}
+
+export interface FocusRefreshInput {
+  now: number;
+  /** Epoch ms of the last successful fetch; 0 when none has landed. */
+  lastFetchAt: number;
+  debounceMs: number;
+  signalRevision: number;
+  /** The revision in effect when this consumer last fetched. */
+  seenRevision: number;
+}
+
+export function shouldRefreshOnFocus({
+  now,
+  lastFetchAt,
+  debounceMs,
+  signalRevision,
+  seenRevision,
+}: FocusRefreshInput): boolean {
+  // A finding was acted on since this consumer last fetched — the counts are
+  // known-stale, so the debounce does not apply.
+  if (signalRevision !== seenRevision) return true;
+  if (lastFetchAt === 0) return true;
+  const elapsed = now - lastFetchAt;
+  // A backwards clock (NTP correction, manual change) would otherwise wedge
+  // the debounce until real time caught back up.
+  if (elapsed < 0) return true;
+  return elapsed >= debounceMs;
+}

--- a/apps/mobile/src/screens/systems/useSystemsData.ts
+++ b/apps/mobile/src/screens/systems/useSystemsData.ts
@@ -143,6 +143,14 @@ export function useSystemsData() {
   // acknowledge is confirmed, which can be 13-15s after the callback was
   // created) instead of a value captured in a stale closure.
   const activeAlertsGenerationRef = useRef<number>(0);
+  // The same primitive for the FINDINGS slice (#5365). `fetchAll`'s boolean
+  // return is an aggregate — "at least one of six slices landed" — and its own
+  // doc comment warns it is not a freshness signal for any single slice. The
+  // findings-changed bypass below must be consumed only when the counts call
+  // itself resolved, or a transient failure on that one call while the other
+  // five succeed would mark the bypass as spent and leave the hero showing a
+  // count the tech already cleared for another full minute.
+  const findingsGenerationRef = useRef<number>(0);
   const [activeAlertsGeneration, setActiveAlertsGeneration] = useState<number>(0);
   const getActiveAlertsGeneration = useCallback(() => activeAlertsGenerationRef.current, []);
 
@@ -204,6 +212,8 @@ export function useSystemsData() {
         activeAlertsGenerationRef.current += 1;
         setActiveAlertsGeneration(activeAlertsGenerationRef.current);
       }
+      // Same reasoning, for the slice the findings-changed bypass cares about.
+      if (findings.status === 'fulfilled') findingsGenerationRef.current += 1;
       // The raw messages are internal (function name + HTTP status) — report
       // them to Sentry and keep only a static string in UI state (issue #3141).
       for (const reason of rejectionReasons(results)) {
@@ -341,8 +351,9 @@ export function useSystemsData() {
   // finding detail screen leaves the hero and the ACTIVE ISSUES findings rows
   // claiming a count the tech just cleared, for up to a minute — the counts
   // endpoint is the only source for those numbers and nothing else invalidates
-  // it. The revision is only marked as seen once a fetch actually landed, so a
-  // call that coalesced into an in-flight request does not consume the signal.
+  // it. The revision is only marked as seen once the findings counts themselves
+  // came back, so neither a coalesced call nor a round where only the other
+  // slices landed consumes the signal.
   const FOCUS_DEBOUNCE_MS = 60_000;
   const seenFindingsRevision = useRef<number>(findingsChangedRevision());
   const refreshIfStale = useCallback(() => {
@@ -358,8 +369,13 @@ export function useSystemsData() {
     ) {
       return;
     }
-    void fetchAll('refresh').then((arrived) => {
-      if (arrived) seenFindingsRevision.current = signalRevision;
+    const generationBefore = findingsGenerationRef.current;
+    void fetchAll('refresh').then(() => {
+      // Consume the bypass only if the COUNTS call actually resolved this
+      // round — not merely because some other slice did.
+      if (findingsGenerationRef.current !== generationBefore) {
+        seenFindingsRevision.current = signalRevision;
+      }
     });
   }, [fetchAll]);
 

--- a/apps/mobile/src/screens/systems/useSystemsData.ts
+++ b/apps/mobile/src/screens/systems/useSystemsData.ts
@@ -23,6 +23,7 @@ import {
   resolveOrgName,
   type SystemsSlices,
 } from './mergeSystemsResults';
+import { findingsChangedRevision, shouldRefreshOnFocus } from './findingsRefreshSignal';
 import {
   buildFindingsSummary,
   foldFindingsIntoOrgRollups,
@@ -334,10 +335,32 @@ export function useSystemsData() {
 
   // Soft refresh on tab focus, debounced so a rapid Home → Systems →
   // Home → Systems doesn't fire four requests. Manual pull always wins.
+  //
+  // The debounce is bypassed when a finding was acknowledged/dismissed/reopened
+  // since this hook last fetched (#5365). Without that, coming back from the
+  // finding detail screen leaves the hero and the ACTIVE ISSUES findings rows
+  // claiming a count the tech just cleared, for up to a minute — the counts
+  // endpoint is the only source for those numbers and nothing else invalidates
+  // it. The revision is only marked as seen once a fetch actually landed, so a
+  // call that coalesced into an in-flight request does not consume the signal.
   const FOCUS_DEBOUNCE_MS = 60_000;
+  const seenFindingsRevision = useRef<number>(findingsChangedRevision());
   const refreshIfStale = useCallback(() => {
-    if (Date.now() - lastFetchAt.current < FOCUS_DEBOUNCE_MS) return;
-    fetchAll('refresh');
+    const signalRevision = findingsChangedRevision();
+    if (
+      !shouldRefreshOnFocus({
+        now: Date.now(),
+        lastFetchAt: lastFetchAt.current,
+        debounceMs: FOCUS_DEBOUNCE_MS,
+        signalRevision,
+        seenRevision: seenFindingsRevision.current,
+      })
+    ) {
+      return;
+    }
+    void fetchAll('refresh').then((arrived) => {
+      if (arrived) seenFindingsRevision.current = signalRevision;
+    });
   }, [fetchAll]);
 
   // Apply the local org filter if one is active.

--- a/apps/mobile/src/services/findings.test.ts
+++ b/apps/mobile/src/services/findings.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// `vi.mock` is hoisted above every other statement, so both the spy and the
+// stand-in error class have to be created inside `vi.hoisted` — a plain
+// top-level `const`/`class` is still in its temporal dead zone when the
+// factory runs.
+const { coreRequest, FakeApiError } = vi.hoisted(() => {
+  class HoistedApiError extends Error {
+    code?: string;
+    statusCode?: number;
+    constructor(params: { message: string; code?: string; statusCode?: number }) {
+      super(params.message);
+      this.name = 'ApiError';
+      this.code = params.code;
+      this.statusCode = params.statusCode;
+    }
+  }
+  return { coreRequest: vi.fn(), FakeApiError: HoistedApiError };
+});
+
+vi.mock('./api', () => ({ coreRequest, ApiError: FakeApiError }));
+
+import { getFinding, isFindingNotFound, listFindings, patchFinding } from './findings';
+
+beforeEach(() => {
+  coreRequest.mockReset();
+});
+
+describe('listFindings', () => {
+  it('defaults to the findings a tech can still act on', async () => {
+    coreRequest.mockResolvedValue({ findings: [], total: 0 });
+    await listFindings({ orgId: 'org-1' });
+    expect(coreRequest).toHaveBeenCalledWith(
+      '/fleet/findings?orgId=org-1&status=open%2Cacknowledged&limit=50',
+    );
+  });
+
+  it('passes an explicit status set, severity, kind and paging through', async () => {
+    coreRequest.mockResolvedValue({ findings: [], total: 0 });
+    await listFindings({
+      orgId: 'org-1',
+      statuses: ['dismissed'],
+      severity: 'critical',
+      kind: 'log_correlation',
+      limit: 10,
+      offset: 20,
+    });
+    const url = coreRequest.mock.calls[0][0] as string;
+    const query = new URLSearchParams(url.split('?')[1]);
+    expect(query.get('orgId')).toBe('org-1');
+    expect(query.get('status')).toBe('dismissed');
+    expect(query.get('severity')).toBe('critical');
+    expect(query.get('kind')).toBe('log_correlation');
+    expect(query.get('limit')).toBe('10');
+    expect(query.get('offset')).toBe('20');
+  });
+
+  it('joins several statuses into the CSV the API parses', async () => {
+    coreRequest.mockResolvedValue({ findings: [], total: 0 });
+    await listFindings({ orgId: 'org-1', statuses: ['open', 'dismissed'] });
+    const query = new URLSearchParams((coreRequest.mock.calls[0][0] as string).split('?')[1]);
+    expect(query.get('status')).toBe('open,dismissed');
+  });
+
+  it('omits an empty status list rather than sending status= and getting a 400', async () => {
+    coreRequest.mockResolvedValue({ findings: [], total: 0 });
+    await listFindings({ orgId: 'org-1', statuses: [] });
+    const url = coreRequest.mock.calls[0][0] as string;
+    expect(url).not.toContain('status=');
+  });
+
+  it('tolerates a body with no findings array', async () => {
+    coreRequest.mockResolvedValue({});
+    expect(await listFindings({ orgId: 'org-1' })).toEqual({ findings: [], total: 0 });
+  });
+
+  it('falls back to the row count when the server omits total', async () => {
+    coreRequest.mockResolvedValue({ findings: [{ id: 'f-1' }] });
+    const result = await listFindings({ orgId: 'org-1' });
+    expect(result.total).toBe(1);
+  });
+});
+
+describe('getFinding', () => {
+  it('fetches one finding by id and url-encodes it', async () => {
+    coreRequest.mockResolvedValue({ id: 'f-1', members: [], runs: [] });
+    await getFinding('f/1');
+    expect(coreRequest).toHaveBeenCalledWith('/fleet/findings/f%2F1');
+  });
+
+  it('defaults members to an empty array when the server omits them', async () => {
+    coreRequest.mockResolvedValue({ id: 'f-1', title: 'x' });
+    const finding = await getFinding('f-1');
+    expect(finding.members).toEqual([]);
+  });
+});
+
+describe('patchFinding', () => {
+  it('sends the action alone when there are no notes', async () => {
+    coreRequest.mockResolvedValue({ id: 'f-1', status: 'acknowledged' });
+    await patchFinding('f-1', 'acknowledge');
+    expect(coreRequest).toHaveBeenCalledWith('/fleet/findings/f-1', {
+      method: 'PATCH',
+      body: JSON.stringify({ action: 'acknowledge' }),
+    });
+  });
+
+  it('sends notes with a dismiss', async () => {
+    coreRequest.mockResolvedValue({ id: 'f-1', status: 'dismissed' });
+    await patchFinding('f-1', 'dismiss', 'known false positive');
+    expect(coreRequest).toHaveBeenCalledWith('/fleet/findings/f-1', {
+      method: 'PATCH',
+      body: JSON.stringify({ action: 'dismiss', notes: 'known false positive' }),
+    });
+  });
+
+  it('drops a blank note rather than sending an empty string', async () => {
+    coreRequest.mockResolvedValue({ id: 'f-1' });
+    await patchFinding('f-1', 'reopen', '   ');
+    expect(coreRequest).toHaveBeenCalledWith('/fleet/findings/f-1', {
+      method: 'PATCH',
+      body: JSON.stringify({ action: 'reopen' }),
+    });
+  });
+});
+
+describe('isFindingNotFound', () => {
+  it('recognises the API 404 the screens turn into an empty state', () => {
+    expect(isFindingNotFound(new FakeApiError({ message: 'Finding not found', statusCode: 404 }))).toBe(
+      true,
+    );
+  });
+
+  it('does not swallow other API failures', () => {
+    expect(isFindingNotFound(new FakeApiError({ message: 'Permission denied', statusCode: 403 }))).toBe(
+      false,
+    );
+    expect(isFindingNotFound(new FakeApiError({ message: 'Boom', statusCode: 500 }))).toBe(false);
+  });
+
+  it('does not treat a network failure as an empty result', () => {
+    expect(isFindingNotFound(new TypeError('Network request failed'))).toBe(false);
+    expect(isFindingNotFound(undefined)).toBe(false);
+  });
+});

--- a/apps/mobile/src/services/findings.ts
+++ b/apps/mobile/src/services/findings.ts
@@ -1,0 +1,133 @@
+import { ApiError, coreRequest } from './api';
+
+/**
+ * Mobile client for the fleet-findings surface (#5365), mirroring
+ * `apps/web/src/services/fleetFindings.ts` so both clients speak the same
+ * contract. These routes live outside the `/mobile` surface, so they go
+ * through the core `/api/v1` prefix via `coreRequest` — the same reason
+ * `getFleetFindingCounts` in `api.ts` uses `requestWithPrefix` rather than the
+ * `/mobile`-prefixed helper.
+ *
+ * Remediation (`POST /fleet/findings/:id/remediate`) is deliberately not
+ * wired here: it needs an MFA'd session and a script picker, which is its own
+ * piece of work.
+ */
+
+export type FleetFindingKind =
+  | 'metric_anomaly_pattern'
+  | 'log_correlation'
+  | 'reliability_offenders';
+export type FleetFindingSeverity = 'info' | 'warning' | 'error' | 'critical';
+export type FleetFindingStatus = 'open' | 'acknowledged' | 'dismissed' | 'resolved';
+export type FleetFindingLifecycleAction = 'acknowledge' | 'dismiss' | 'reopen';
+
+export interface FleetFinding {
+  id: string;
+  orgId: string;
+  orgName: string | null;
+  kind: FleetFindingKind;
+  status: FleetFindingStatus;
+  severity: FleetFindingSeverity;
+  title: string;
+  summary: string | null;
+  deviceCount: number;
+  firstSeenAt: string;
+  lastSeenAt: string;
+  acknowledgedAt: string | null;
+  dismissedAt: string | null;
+  dismissNotes: string | null;
+  resolvedAt: string | null;
+}
+
+export interface FleetFindingMember {
+  deviceId: string;
+  hostname: string;
+  displayName: string | null;
+  siteId: string;
+  osType: string;
+  firstSeenAt: string;
+  lastSeenAt: string;
+}
+
+export interface FleetFindingDetail extends FleetFinding {
+  members: FleetFindingMember[];
+}
+
+export interface FleetFindingListResult {
+  findings: FleetFinding[];
+  total: number;
+}
+
+export interface FleetFindingFilters {
+  orgId?: string;
+  kind?: FleetFindingKind;
+  severity?: FleetFindingSeverity;
+  /**
+   * Omit to use the mobile default (`open,acknowledged`). Pass an empty array
+   * to send no `status` at all and take the server's own default.
+   */
+  statuses?: FleetFindingStatus[];
+  limit?: number;
+  offset?: number;
+}
+
+/** What a tech can still act on — the same pair the API defaults to. */
+const DEFAULT_STATUSES: FleetFindingStatus[] = ['open', 'acknowledged'];
+
+/** The server caps `limit` at 100; one screenful of findings is plenty. */
+const DEFAULT_LIMIT = 50;
+
+function buildQuery(filters: FleetFindingFilters): string {
+  const params = new URLSearchParams();
+  if (filters.orgId) params.set('orgId', filters.orgId);
+  if (filters.kind) params.set('kind', filters.kind);
+  if (filters.severity) params.set('severity', filters.severity);
+  const statuses = filters.statuses ?? DEFAULT_STATUSES;
+  // An empty CSV would be a 400 ("Invalid status filter"), so send nothing
+  // and let the server apply its own default instead.
+  if (statuses.length > 0) params.set('status', statuses.join(','));
+  params.set('limit', String(filters.limit ?? DEFAULT_LIMIT));
+  if (filters.offset !== undefined) params.set('offset', String(filters.offset));
+  const query = params.toString();
+  return query ? `?${query}` : '';
+}
+
+export async function listFindings(
+  filters: FleetFindingFilters = {},
+): Promise<FleetFindingListResult> {
+  const response = await coreRequest<Partial<FleetFindingListResult>>(
+    `/fleet/findings${buildQuery(filters)}`,
+  );
+  const findings = response.findings ?? [];
+  return { findings, total: response.total ?? findings.length };
+}
+
+export async function getFinding(id: string): Promise<FleetFindingDetail> {
+  const response = await coreRequest<FleetFindingDetail>(
+    `/fleet/findings/${encodeURIComponent(id)}`,
+  );
+  // `members` drives the device list; a missing array would crash the screen
+  // on `.map`, so normalise it here rather than at every read site.
+  return { ...response, members: response.members ?? [] };
+}
+
+export async function patchFinding(
+  id: string,
+  action: FleetFindingLifecycleAction,
+  notes?: string,
+): Promise<FleetFinding> {
+  const trimmed = notes?.trim();
+  return coreRequest<FleetFinding>(`/fleet/findings/${encodeURIComponent(id)}`, {
+    method: 'PATCH',
+    body: JSON.stringify(trimmed ? { action, notes: trimmed } : { action }),
+  });
+}
+
+/**
+ * The API answers 404 for a finding that was resolved, deleted, or belongs to
+ * an org/site the caller cannot see — it deliberately does not distinguish
+ * those. Screens turn this into an empty state, not an error.
+ */
+export function isFindingNotFound(err: unknown): boolean {
+  return err instanceof ApiError && err.statusCode === 404;
+}


### PR DESCRIPTION
Closes #5365

The Systems tab listed **1 open finding · Berthoud Vet Care** rows under ACTIVE ISSUES, but tapping did nothing. A tech on the phone could see something was wrong and had no way to find out what, which devices, or act on it. `FindingsRow` was a plain `View` and mobile only ever called `GET /fleet/findings/counts`.

**No API change** — everything here runs against the routes `apps/api/src/routes/fleetFindings.ts` already ships.

## Screens

**`SystemsFindings` ({ orgId, orgName })** — the org's open + acknowledged findings. Severity pill (reusing the shared `riskTier` bands so a critical finding reads the same colour as a critical alert), title, and a `Open · 3 devices · 2h ago` subtitle. Sorted worst severity first, then most recently seen, then title — the last tie-break is what stops rows swapping places between refreshes. Pull-to-refresh; a failed refresh with rows on screen is a banner, not a wipe. Says "Showing N of M" when the page is capped rather than implying the org has only what fits.

**`SystemsFindingDetail` ({ findingId })** — status / severity / organization / devices / first seen / last seen, summary, dismiss note when there is one, and the member devices. Each member row resolves the device via `getDevice` and pushes the existing `SystemsDeviceDetail` (that route takes a whole `Device`, not an id); a device that has since gone surfaces as a toast rather than a dead tap.

**Actions** are gated exactly as the web drawer (`apps/web/src/components/fleet/FindingDrawer.tsx:130-137`):

| status | offered |
|---|---|
| `open` | Acknowledge, Dismiss |
| `acknowledged` | Dismiss, Reopen |
| `dismissed` | Reopen |
| `resolved` | — (terminal; the reconciler owns resolution) |

Dismiss opens a sheet following the approval-mode `DenyReasonSheet` pattern, with one deliberate difference: the note is **required**, validated locally so the tech does not watch a round-trip end in a 400.

After an action the detail re-reads the finding (PATCH answers with the row only, no members) and bumps a module-level revision that lets the Systems tab bypass its 60s focus debounce — otherwise the hero and the ACTIVE ISSUES row would keep claiming a count the tech just cleared, for up to a minute. The counts endpoint is the only source for those numbers and nothing else invalidates it.

**404 is an empty state, not an error**, on both screens: the API answers 404 for a finding that was resolved, deleted, or belongs to an org/site the caller cannot see, and deliberately does not distinguish those.

## Structure

The app has no React Native test runtime (`vitest.config.ts` deliberately includes `.ts`, not `.tsx`), so everything worth asserting lives in node-testable leaf modules and the `.tsx` files are state-to-JSX mappings:

- `services/findings.ts` — mirrors `apps/web/src/services/fleetFindings.ts`; `coreRequest` because these routes live outside the `/mobile` surface, same reason `getFleetFindingCounts` uses the core prefix.
- `screens/systems/findingActions.ts` — the gating table, dismiss-note validation, labels, severity rank and tier.
- `screens/systems/findingsList.ts` / `findingDetail.ts` — reducers, sorting, copy.
- `screens/systems/findingsRefreshSignal.ts` — the staleness rule.

## Test evidence

- `pnpm --filter breeze-mobile typecheck` — clean.
- Touched suites: `npx vitest run src/services/findings.test.ts src/screens/systems/findingActions.test.ts src/screens/systems/findingDetail.test.ts src/screens/systems/findingsList.test.ts src/screens/systems/findingsRefreshSignal.test.ts` — **6 files, 95 tests passed** (includes `src/lib/errorReporting.test.ts`, touched by the review round).
- Whole mobile suite, `npx vitest run --pool=threads --maxWorkers=2` — **120 files, 1587 passed / 3 skipped**.

Both new pure functions added on top of the leaf modules (`findingSeverityTier`, `toFindingListItem`, `actionSettled`, `safeReportInternalError`) were written red first and confirmed failing before implementation.

## Not verified

Not run on a device or simulator — there is no RN component-test runtime in this app, so the rendering, the navigation pushes and the dismiss sheet's keyboard behaviour are unexercised by CI and want a pass on the next TestFlight build.

## Follow-ups

- **Remediation** is deliberately out of scope: `POST /fleet/findings/:id/remediate` needs an MFA'd session and a script picker, which is its own piece of work.
- Evidence JSON (the web drawer shows it capped at 4000 chars) is not rendered on mobile.
- The list is a single page (limit 50) with no infinite scroll; the "Showing N of M" line points at the web console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01141Ns599G1Dp4MqYcmp7Qn
