### PR TITLE
fix(api): enforce site-scoped operator controls

### DIFF
--- a/apps/api/src/__tests__/integration/alertAuthenticatedSite.integration.test.ts
+++ b/apps/api/src/__tests__/integration/alertAuthenticatedSite.integration.test.ts
@@ -1,0 +1,110 @@
+import './setup';
+import { Hono } from 'hono';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { db } from '../../db';
+import { alertRules, alertTemplates } from '../../db/schema';
+import { getTestDb } from './setup';
+import { siteFixture, request } from './siteHttpFixtures';
+const effects = vi.hoisted(() => ({ audit: vi.fn((_context: unknown, _event: unknown) => { }) }));
+// Audit calls are captured synchronously; audit durability is outside this fixture.
+vi.mock('../../services/auditEvents', async (original) => ({ ...await original<typeof import('../../services/auditEvents')>(), writeRouteAudit: effects.audit }));
+import { alertTemplateRoutes } from '../../routes/alertTemplates';
+const grants = [{ resource: 'alerts', action: 'read' }, { resource: 'alerts', action: 'write' }];
+beforeEach(() => vi.clearAllMocks());
+describe('legacy alert HTTP with real MFA, site permissions and PostgreSQL', () => {
+    it('keeps denied mutations inert and admits visible rule/template controls', async () => {
+        const f = await siteFixture();
+        const app = new Hono().route('/api/v1/alert-templates', alertTemplateRoutes);
+        const seed = getTestDb();
+        const selected = await f.actor([f.allowedSite.id], grants);
+        const empty = await f.actor([], grants);
+        const noMfa = await f.actor([f.allowedSite.id], grants, false);
+        const denied = await f.actor([f.allowedSite.id], []);
+        const template = async (orgId: string, name: string) => { const [x] = await seed.insert(alertTemplates).values({ orgId, name, conditions: { type: 'metric', threshold: 90 }, severity: 'high', titleTemplate: 'Synthetic title', messageTemplate: 'Synthetic message' }).returning(); if (!x)
+            throw new Error('Missing template'); return x; };
+        const visibleTemplate = await template(f.org.id, 'visible-template');
+        const sharedTemplate = await template(f.org.id, 'mixed-dependent-template');
+        const foreignTemplate = await template(f.foreignOrg.id, 'foreign-template');
+        const rule = async (orgId: string, templateId: string, targetId: string, name: string) => { const [x] = await seed.insert(alertRules).values({ orgId, templateId, targetType: 'device', targetId, name }).returning(); if (!x)
+            throw new Error('Missing rule'); return x; };
+        const visibleRule = await rule(f.org.id, visibleTemplate.id, f.allowed.id, 'visible-rule');
+        const hiddenRule = await rule(f.org.id, sharedTemplate.id, f.hidden.id, 'hidden-rule');
+        await rule(f.org.id, sharedTemplate.id, f.allowed.id, 'mixed-visible-rule');
+        const foreignRule = await rule(f.foreignOrg.id, foreignTemplate.id, f.foreign.id, 'foreign-rule');
+        const snapshot = () => Promise.all([false, true].map(other => f.scoped(async () => ({ rules: await db.select().from(alertRules).orderBy(alertRules.id), templates: await db.select().from(alertTemplates).orderBy(alertTemplates.id) }), other)));
+        const before = await snapshot();
+        const reject = async (token: string, method: string, path: string, body: unknown, status: number) => { const r = await request(app, token, method, '/api/v1/alert-templates' + path, body); expect(r.status).toBe(status); expect(await snapshot()).toEqual(before); expect(effects.audit).not.toHaveBeenCalled(); return r; };
+        for (const targets of [undefined, { deviceIds: [f.hidden.id] }, { deviceIds: [f.foreign.id] }])
+            await reject(selected.token, 'POST', '/rules', { name: 'denied-create', templateId: visibleTemplate.id, ...(targets ? { targets } : {}) }, 403);
+        await reject(empty.token, 'POST', '/rules', { name: 'empty-create', templateId: visibleTemplate.id, targets: { deviceIds: [f.allowed.id] } }, 403);
+        const noMfaResponse = await reject(noMfa.token, 'PATCH', `/rules/${visibleRule.id}`, { name: 'denied' }, 403);
+        expect(await noMfaResponse.json()).toMatchObject({ code: 'MFA_REQUIRED' });
+        await reject(denied.token, 'PATCH', `/rules/${visibleRule.id}`, { name: 'no-permission' }, 403);
+        await reject(empty.token, 'PATCH', `/rules/${visibleRule.id}`, { name: 'empty-sites' }, 403);
+        for (const [id, status] of [[hiddenRule.id, 403], [foreignRule.id, 404]] as const) {
+            await reject(selected.token, 'PATCH', `/rules/${id}`, { name: 'denied' }, status);
+            await reject(selected.token, 'POST', `/rules/${id}/toggle`, { enabled: false }, status);
+            await reject(selected.token, 'DELETE', `/rules/${id}`, undefined, status);
+        }
+        for (const [id, status] of [[sharedTemplate.id, 403], [foreignTemplate.id, 404]] as const) {
+            await reject(selected.token, 'PATCH', `/templates/${id}`, { name: 'denied' }, status);
+            await reject(selected.token, 'DELETE', `/templates/${id}`, undefined, status);
+        }
+        for (const path of ['/templates', '/templates/built-in', `/templates/${visibleTemplate.id}`, '/rules', `/rules/${visibleRule.id}`])
+            await reject(denied.token, 'GET', path, undefined, 403);
+        expect((await request(app, undefined, 'GET', '/api/v1/alert-templates/rules')).status).toBe(401);
+        for (const [path, ownId, foreignId] of [['/templates', visibleTemplate.id, foreignTemplate.id], ['/rules', visibleRule.id, foreignRule.id]]) {
+            const r = await request(app, selected.token, 'GET', '/api/v1/alert-templates' + path);
+            expect(r.status).toBe(200);
+            const ids = (await r.json()).data.map((x: {
+                id: string;
+            }) => x.id);
+            expect(ids).toContain(ownId);
+            expect(ids).not.toContain(foreignId);
+        }
+        const created = await request(app, selected.token, 'POST', '/api/v1/alert-templates/rules', { name: 'allowed-created', templateId: visibleTemplate.id, targets: { deviceIds: [f.allowed.id] } });
+        expect(created.status).toBe(201);
+        const createdRule = (await created.json()).data;
+        expect(createdRule.targetId).toBe(f.allowed.id);
+        expect((await request(app, selected.token, 'PATCH', `/api/v1/alert-templates/rules/${createdRule.id}`, { name: 'allowed-updated' })).status).toBe(200);
+        expect((await request(app, selected.token, 'POST', `/api/v1/alert-templates/rules/${createdRule.id}/toggle`, { enabled: false })).status).toBe(200);
+        expect((await request(app, selected.token, 'DELETE', `/api/v1/alert-templates/rules/${createdRule.id}`)).status).toBe(200);
+        expect((await request(app, selected.token, 'PATCH', `/api/v1/alert-templates/templates/${visibleTemplate.id}`, { name: 'allowed-template-updated' })).status).toBe(200);
+        const spare = await template(f.org.id, 'deletable-template');
+        expect((await request(app, selected.token, 'DELETE', `/api/v1/alert-templates/templates/${spare.id}`)).status).toBe(200);
+        expect(effects.audit.mock.calls.map(x => (x[1] as {
+            action: string;
+        }).action)).toEqual(['alert_rule.create', 'alert_rule.update', 'alert_rule.toggle', 'alert_rule.delete', 'alert_template.update', 'alert_template.delete']);
+    });
+    it('preserves built-in and exact owning-partner catalog visibility through authenticated reads', async () => {
+        const f = await siteFixture();
+        const app = new Hono().route('/api/v1/alert-templates', alertTemplateRoutes);
+        const reader = await f.actor([f.allowedSite.id], grants);
+        const seed = getTestDb();
+        const values = { conditions: { type: 'metric', threshold: 90 }, severity: 'high' as const, titleTemplate: 'Synthetic title', messageTemplate: 'Synthetic message' };
+        const rows = await seed.insert(alertTemplates).values([
+            { ...values, name: 'shared-own-partner', orgId: null, partnerId: f.partner.id },
+            { ...values, name: 'shared-foreign-partner', orgId: null, partnerId: f.foreignPartner.id },
+            { ...values, name: 'global-catalog', orgId: null, partnerId: null, isBuiltIn: true },
+            { ...values, name: 'foreign-owned-built-in', orgId: f.foreignOrg.id, partnerId: null, isBuiltIn: true },
+        ]).returning();
+        const [own, foreign, global, foreignBuiltIn] = rows;
+        if (!own || !foreign || !global || !foreignBuiltIn)
+            throw new Error('Missing catalog fixture');
+        for (const path of ['/templates', '/templates/built-in']) {
+            const response = await request(app, reader.token, 'GET', '/api/v1/alert-templates' + path);
+            expect(response.status).toBe(200);
+            const ids = (await response.json()).data.map((x: {
+                id: string;
+            }) => x.id);
+            expect(ids).toContain(global.id);
+            expect(ids).not.toContain(foreign.id);
+            expect(ids).not.toContain(foreignBuiltIn.id);
+            if (path === '/templates')
+                expect(ids).toContain(own.id);
+        }
+        for (const [id, status] of [[own.id, 200], [foreign.id, 404], [foreignBuiltIn.id, 404]] as const)
+            expect((await request(app, reader.token, 'GET', `/api/v1/alert-templates/templates/${id}`)).status).toBe(status);
+        expect(effects.audit).not.toHaveBeenCalled();
+    });
+});

--- a/apps/api/src/__tests__/integration/alertTemplateReadPermission.integration.test.ts
+++ b/apps/api/src/__tests__/integration/alertTemplateReadPermission.integration.test.ts
@@ -1,0 +1,90 @@
+/** Real-PostgreSQL route proof for legacy alert template/rule read RBAC. */
+import './setup';
+
+import { describe, expect, it } from 'vitest';
+import { Hono } from 'hono';
+import { alertRules, alertTemplates } from '../../db/schema';
+import { alertTemplateRoutes } from '../../routes/alertTemplates';
+import { createIntegrationTestClient } from './db-utils';
+import { getTestDb } from './setup';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+function makeApp() {
+  const app = new Hono();
+  app.route('/alert-templates', alertTemplateRoutes);
+  return app;
+}
+
+async function seedTemplateAndRule(orgId: string, label: string) {
+  const [template] = await getTestDb().insert(alertTemplates).values({
+    orgId,
+    partnerId: null,
+    name: `${label} private template`,
+    conditions: { type: 'metric', threshold: 90 },
+    severity: 'high',
+    titleTemplate: `${label} title {{hostname}}`,
+    messageTemplate: `${label} private response instructions`,
+  }).returning();
+  if (!template) throw new Error('template fixture insert failed');
+
+  const [rule] = await getTestDb().insert(alertRules).values({
+    orgId,
+    partnerId: null,
+    templateId: template.id,
+    name: `${label} private rule`,
+    targetType: 'all',
+    targetId: orgId,
+    overrideSettings: { cooldownMinutes: 11 },
+  }).returning();
+  if (!rule) throw new Error('rule fixture insert failed');
+  return { template, rule };
+}
+
+describe('legacy alert template/rule read permission (real PostgreSQL)', () => {
+  runDb('denies permissionless members and returns only the authorized tenant rows', async () => {
+    const app = makeApp();
+    const denied = await createIntegrationTestClient(app, {
+      scope: 'organization',
+      rolePermissions: [],
+    });
+    const reader = await createIntegrationTestClient(app, {
+      scope: 'organization',
+      rolePermissions: [{ resource: 'alerts', action: 'read' }],
+    });
+    const foreign = await createIntegrationTestClient(app, {
+      scope: 'organization',
+      rolePermissions: [{ resource: 'alerts', action: 'read' }],
+    });
+    const deniedRows = await seedTemplateAndRule(denied.env.organization.id, 'denied-own');
+    const ownRows = await seedTemplateAndRule(reader.env.organization.id, 'own');
+    const foreignRows = await seedTemplateAndRule(foreign.env.organization.id, 'foreign');
+
+    for (const path of [
+      '/alert-templates/templates',
+      '/alert-templates/templates/built-in',
+      `/alert-templates/templates/${deniedRows.template.id}`,
+      '/alert-templates/rules',
+      `/alert-templates/rules/${deniedRows.rule.id}`,
+    ]) {
+      expect((await denied.get(path)).status, path).toBe(403);
+    }
+
+    const templateResponse = await reader.get('/alert-templates/templates');
+    expect(templateResponse.status).toBe(200);
+    const templateBody = await templateResponse.json() as { data: Array<{ id: string }> };
+    expect(templateBody.data.map((row) => row.id)).toContain(ownRows.template.id);
+    expect(templateBody.data.map((row) => row.id)).not.toContain(foreignRows.template.id);
+    expect((await reader.get('/alert-templates/templates/built-in')).status).toBe(200);
+    expect((await reader.get(`/alert-templates/templates/${ownRows.template.id}`)).status).toBe(200);
+    expect((await reader.get(`/alert-templates/templates/${foreignRows.template.id}`)).status).toBe(404);
+
+    const ruleResponse = await reader.get('/alert-templates/rules');
+    expect(ruleResponse.status).toBe(200);
+    const ruleBody = await ruleResponse.json() as { data: Array<{ id: string }> };
+    expect(ruleBody.data.map((row) => row.id)).toContain(ownRows.rule.id);
+    expect(ruleBody.data.map((row) => row.id)).not.toContain(foreignRows.rule.id);
+    expect((await reader.get(`/alert-templates/rules/${ownRows.rule.id}`)).status).toBe(200);
+    expect((await reader.get(`/alert-templates/rules/${foreignRows.rule.id}`)).status).toBe(404);
+  });
+});

--- a/apps/api/src/__tests__/integration/alertTemplateSiteScope.integration.test.ts
+++ b/apps/api/src/__tests__/integration/alertTemplateSiteScope.integration.test.ts
@@ -1,0 +1,64 @@
+/** Real-PostgreSQL proof for legacy alert rule/template site authorization. */
+import './setup';
+import { randomUUID } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { withDbAccessContext } from '../../db';
+import { alertRules, alertTemplates, devices } from '../../db/schema';
+import {
+  canAccessAlertRuleTargets,
+  canAccessTemplateDependents,
+} from '../../routes/alertTemplates/siteScope';
+import { createOrganization, createPartner, createSite } from './db-utils';
+import { getTestDb } from './setup';
+
+describe('legacy alert rule/template site authorization as breeze_app', () => {
+  it('allows visible targets and denies hidden targets and shared templates with hidden dependents', async () => {
+    const testDb = getTestDb();
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const foreignOrg = await createOrganization({ partnerId: partner.id });
+    const allowedSite = await createSite({ orgId: org.id });
+    const hiddenSite = await createSite({ orgId: org.id });
+    const foreignSite = await createSite({ orgId: foreignOrg.id });
+    const [allowedDevice, hiddenDevice, foreignDevice] = await testDb.insert(devices).values([
+      {
+        orgId: org.id, siteId: allowedSite.id, agentId: `agent-${randomUUID()}`,
+        hostname: 'allowed-alert-host', osType: 'linux', osVersion: '1', architecture: 'amd64', agentVersion: '1', status: 'online',
+      },
+      {
+        orgId: org.id, siteId: hiddenSite.id, agentId: `agent-${randomUUID()}`,
+        hostname: 'hidden-alert-host', osType: 'linux', osVersion: '1', architecture: 'amd64', agentVersion: '1', status: 'online',
+      },
+      {
+        orgId: foreignOrg.id, siteId: foreignSite.id, agentId: `agent-${randomUUID()}`,
+        hostname: 'foreign-alert-host', osType: 'linux', osVersion: '1', architecture: 'amd64', agentVersion: '1', status: 'online',
+      },
+    ]).returning();
+    const [template] = await testDb.insert(alertTemplates).values({
+      orgId: org.id, name: 'Shared site fixture', conditions: {}, severity: 'high',
+      titleTemplate: 'Fixture', messageTemplate: 'Fixture', isBuiltIn: false,
+    }).returning();
+    await testDb.insert(alertRules).values([
+      {
+        orgId: org.id, templateId: template!.id, name: 'Visible rule',
+        targetType: 'device', targetId: allowedDevice!.id,
+      },
+      {
+        orgId: org.id, templateId: template!.id, name: 'Hidden rule',
+        targetType: 'device', targetId: hiddenDevice!.id,
+      },
+    ]);
+
+    const auth = { allowedSiteIds: [allowedSite.id] } as any;
+    await withDbAccessContext({ scope: 'organization', orgId: org.id, accessibleOrgIds: [org.id] }, async () => {
+      await expect(canAccessAlertRuleTargets(auth, org.id, 'device', [allowedDevice!.id], true)).resolves.toBe(true);
+      await expect(canAccessAlertRuleTargets(auth, org.id, 'device', [hiddenDevice!.id], true)).resolves.toBe(false);
+      await expect(canAccessAlertRuleTargets(auth, org.id, 'device', [foreignDevice!.id], true)).resolves.toBe(false);
+      await expect(canAccessAlertRuleTargets(
+        { allowedSiteIds: [foreignSite.id] }, org.id, 'site', [foreignSite.id], true,
+      )).resolves.toBe(false);
+      await expect(canAccessAlertRuleTargets(auth, org.id, 'org', [], true)).resolves.toBe(false);
+      await expect(canAccessTemplateDependents(auth, template!.id, org.id)).resolves.toBe(false);
+    });
+  });
+});

--- a/apps/api/src/__tests__/integration/automationAuthenticatedSite.integration.test.ts
+++ b/apps/api/src/__tests__/integration/automationAuthenticatedSite.integration.test.ts
@@ -1,0 +1,97 @@
+import './setup';
+import { Hono } from 'hono';
+import { describe, expect, it } from 'vitest';
+import { automations, automationRuns, automationRunDeviceResults, scripts, scriptExecutions } from '../../db/schema';
+import { automationRoutes } from '../../routes/automations';
+import { getTestDb } from './setup';
+import { siteFixture, request } from './siteHttpFixtures';
+const grants = [{ resource: 'automations', action: 'read' }];
+describe('automation history HTTP with real bearer permissions and PostgreSQL', () => {
+    it('projects mixed history, hides foreign/hidden-only rows and keeps small ordered pages correct', async () => {
+        const f = await siteFixture();
+        const seed = getTestDb();
+        const app = new Hono().route('/api/v1/automations', automationRoutes);
+        const selected = await f.actor([f.allowedSite.id], grants);
+        const empty = await f.actor([], grants);
+        const unrestricted = await f.actor(null, grants);
+        const denied = await f.actor([f.allowedSite.id], []);
+        const makeAutomation = async (orgId: string, deviceId: string, name: string, updatedAt: Date) => {
+            const [row] = await seed.insert(automations).values({ orgId, name, trigger: { type: 'manual' }, conditions: { type: 'devices', deviceIds: [deviceId] }, actions: [], runCount: 99, lastRunAt: new Date(), updatedAt }).returning();
+            if (!row)
+                throw new Error('Missing automation');
+            return row;
+        };
+        const visible = await makeAutomation(f.org.id, f.allowed.id, 'visible-definition', new Date('2026-01-02'));
+        const hidden = await makeAutomation(f.org.id, f.hidden.id, 'hidden-definition', new Date('2026-01-03'));
+        const other = await makeAutomation(f.org.id, f.allowed.id, 'other-visible-definition', new Date('2026-01-01'));
+        const foreign = await makeAutomation(f.foreignOrg.id, f.foreign.id, 'foreign-definition', new Date('2026-01-04'));
+        const makeRun = async (automationId: string, deviceRows: Array<{
+            deviceId: string;
+            orgId: string;
+            visible: boolean;
+        }>, start: string) => {
+            const [run] = await seed.insert(automationRuns).values({ automationId, triggeredBy: 'synthetic', status: 'failed', devicesTargeted: 88, devicesSucceeded: 0, devicesFailed: 88, startedAt: new Date(start), logs: deviceRows.map(x => ({ level: x.visible ? 'info' : 'error', message: x.visible ? 'visible-log' : 'hidden-log', deviceId: x.deviceId })) }).returning();
+            if (!run)
+                throw new Error('Missing run');
+            for (const x of deviceRows)
+                await seed.insert(automationRunDeviceResults).values({ runId: run.id, deviceId: x.deviceId, orgId: x.orgId, status: x.visible ? 'success' : 'failed', output: x.visible ? 'visible-output' : 'hidden-output', startedAt: new Date('2026-01-01T00:00:10Z'), completedAt: new Date(x.visible ? '2026-01-01T00:00:20Z' : '2026-01-01T00:05:00Z') });
+            return run;
+        };
+        const mixed = await makeRun(visible.id, [{ deviceId: f.allowed.id, orgId: f.org.id, visible: true }, { deviceId: f.hidden.id, orgId: f.org.id, visible: false }], '2026-01-02T00:00:00Z');
+        const hiddenOnly = await makeRun(visible.id, [{ deviceId: f.hidden.id, orgId: f.org.id, visible: false }], '2026-01-03T00:00:00Z');
+        const foreignRun = await makeRun(foreign.id, [{ deviceId: f.foreign.id, orgId: f.foreignOrg.id, visible: false }], '2026-01-04T00:00:00Z');
+        const [script] = await seed.insert(scripts).values({ orgId: f.org.id, name: 'passive-history', osTypes: ['linux'], language: 'bash', content: '# inert fixture; never executed' }).returning();
+        if (!script)
+            throw new Error('Missing script');
+        for (const [deviceId, stdout] of [[f.allowed.id, 'visible-script-output'], [f.hidden.id, 'hidden-script-output']] as const)
+            await seed.insert(scriptExecutions).values({ orgId: f.org.id, scriptId: script.id, deviceId, automationRunId: mixed.id, status: 'completed', stdout });
+        expect((await request(app, undefined, 'GET', '/api/v1/automations')).status).toBe(401);
+        expect((await request(app, denied.token, 'GET', '/api/v1/automations')).status).toBe(403);
+        const page = async (token: string, page: number) => { const r = await request(app, token, 'GET', `/api/v1/automations?page=${page}&limit=1`); expect(r.status).toBe(200); return r.json(); };
+        const first = await page(selected.token, 1);
+        const second = await page(selected.token, 2);
+        expect(first.pagination.total).toBe(2);
+        expect(first.data.map((x: {
+            id: string;
+        }) => x.id)).toEqual([visible.id]);
+        expect(second.data.map((x: {
+            id: string;
+        }) => x.id)).toEqual([other.id]);
+        expect(first.data[0]).not.toHaveProperty('runCount');
+        expect(first.data[0]).not.toHaveProperty('lastRunAt');
+        expect((await page(empty.token, 1)).pagination.total).toBe(0);
+        expect((await page(unrestricted.token, 1)).pagination.total).toBe(3);
+        for (const id of [hidden.id, foreign.id])
+            expect((await request(app, selected.token, 'GET', `/api/v1/automations/${id}`)).status).toBe(404);
+        const detail = await request(app, selected.token, 'GET', `/api/v1/automations/${visible.id}`);
+        expect(detail.status).toBe(200);
+        const detailBody = await detail.json();
+        expect(detailBody.statistics).toMatchObject({ totalRuns: 1, completedRuns: 1, failedRuns: 0 });
+        expect(detailBody.runCount).toBe(1);
+        const history = await request(app, selected.token, 'GET', `/api/v1/automations/${visible.id}/runs?limit=1`);
+        expect(history.status).toBe(200);
+        const historyBody = await history.json();
+        expect(historyBody.pagination.total).toBe(1);
+        expect(historyBody.data.map((x: {
+            id: string;
+        }) => x.id)).toEqual([mixed.id]);
+        const response = await request(app, selected.token, 'GET', `/api/v1/automations/runs/${mixed.id}`);
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body).toMatchObject({ devicesTargeted: 1, devicesSucceeded: 1, devicesFailed: 0, status: 'success', startedAt: '2026-01-01T00:00:10.000Z', completedAt: '2026-01-01T00:00:20.000Z' });
+        expect(body.deviceResults.map((x: {
+            deviceId: string;
+        }) => x.deviceId)).toEqual([f.allowed.id]);
+        const serialized = JSON.stringify([detailBody, historyBody, body]);
+        expect(serialized).toContain('visible-log');
+        expect(serialized).toContain('visible-script-output');
+        for (const marker of ['hidden-log', 'hidden-output', 'hidden-script-output', f.hidden.id, f.foreign.id])
+            expect(serialized).not.toContain(marker);
+        for (const id of [hiddenOnly.id, foreignRun.id])
+            expect((await request(app, selected.token, 'GET', `/api/v1/automations/runs/${id}`)).status).toBe(404);
+        expect((await request(app, empty.token, 'GET', `/api/v1/automations/runs/${mixed.id}`)).status).toBe(404);
+        const full = await request(app, unrestricted.token, 'GET', `/api/v1/automations/runs/${mixed.id}`);
+        expect(full.status).toBe(200);
+        expect((await full.json()).deviceResults).toHaveLength(2);
+    });
+});

--- a/apps/api/src/__tests__/integration/automationReadSiteScope.integration.test.ts
+++ b/apps/api/src/__tests__/integration/automationReadSiteScope.integration.test.ts
@@ -1,0 +1,121 @@
+/** Real-PostgreSQL proof for the automation/script history site boundary. */
+import './setup';
+import { randomUUID } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { db, withDbAccessContext } from '../../db';
+import {
+  automationRunDeviceResults,
+  automationRuns,
+  automations,
+  devices,
+  scriptExecutions,
+  scripts,
+} from '../../db/schema';
+import type { AuthContext } from '../../middleware/auth';
+import type { AiTool } from '../../services/aiTools';
+import { registerScriptTools } from '../../services/aiToolsScripts';
+import { projectAutomationRunsToSites } from '../../services/automationReadProjection';
+import { createOrganization, createPartner, createSite } from './db-utils';
+import { getTestDb } from './setup';
+
+function scriptHistory(): AiTool['handler'] {
+  const tools = new Map<string, AiTool>();
+  registerScriptTools(tools);
+  return tools.get('get_script_execution_history')!.handler;
+}
+
+describe('automation history site projection as breeze_app', () => {
+  it('keeps allowed output and removes sibling-site output, counts, and logs', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const foreignOrg = await createOrganization({ partnerId: partner.id });
+    const allowedSite = await createSite({ orgId: org.id });
+    const hiddenSite = await createSite({ orgId: org.id });
+    const foreignSite = await createSite({ orgId: foreignOrg.id });
+    const testDb = getTestDb();
+    const [allowedDevice, hiddenDevice, foreignDevice] = await testDb.insert(devices).values([
+      {
+        orgId: org.id, siteId: allowedSite.id, agentId: `agent-${randomUUID()}`,
+        hostname: 'allowed-host', osType: 'linux', osVersion: '1', architecture: 'amd64', agentVersion: '1', status: 'online',
+      },
+      {
+        orgId: org.id, siteId: hiddenSite.id, agentId: `agent-${randomUUID()}`,
+        hostname: 'hidden-host', osType: 'linux', osVersion: '1', architecture: 'amd64', agentVersion: '1', status: 'online',
+      },
+      {
+        orgId: foreignOrg.id, siteId: foreignSite.id, agentId: `agent-${randomUUID()}`,
+        hostname: 'foreign-host', osType: 'linux', osVersion: '1', architecture: 'amd64', agentVersion: '1', status: 'online',
+      },
+    ]).returning();
+    const [automation] = await testDb.insert(automations).values({
+      orgId: org.id,
+      name: 'Site projection fixture',
+      trigger: { type: 'manual' },
+      conditions: { type: 'devices', deviceIds: [allowedDevice!.id, hiddenDevice!.id] },
+      actions: [],
+    }).returning();
+    const [run] = await testDb.insert(automationRuns).values({
+      automationId: automation!.id,
+      triggeredBy: 'integration',
+      status: 'failed',
+      devicesTargeted: 2,
+      devicesSucceeded: 1,
+      devicesFailed: 1,
+      logs: [
+        { level: 'info', message: 'allowed-log', deviceId: allowedDevice!.id },
+        { level: 'error', message: 'hidden-log', deviceId: hiddenDevice!.id },
+      ],
+    }).returning();
+    await testDb.insert(automationRunDeviceResults).values([
+      {
+        runId: run!.id, deviceId: allowedDevice!.id, orgId: org.id, status: 'success', output: 'allowed-output',
+        startedAt: new Date('2026-09-05T00:00:10Z'), completedAt: new Date('2026-09-05T00:00:20Z'),
+      },
+      {
+        runId: run!.id, deviceId: hiddenDevice!.id, orgId: org.id, status: 'failed', output: 'hidden-output',
+        startedAt: new Date('2026-09-05T00:00:11Z'), completedAt: new Date('2026-09-05T00:05:00Z'),
+      },
+    ]);
+    const [script] = await testDb.insert(scripts).values({
+      orgId: org.id, name: 'History fixture', osTypes: ['linux'], language: 'bash', content: 'exit 0',
+    }).returning();
+    const [foreignScript] = await testDb.insert(scripts).values({
+      orgId: foreignOrg.id, name: 'Foreign history fixture', osTypes: ['linux'], language: 'bash', content: 'exit 0',
+    }).returning();
+    await testDb.insert(scriptExecutions).values([
+      { scriptId: script!.id, deviceId: allowedDevice!.id, orgId: org.id, status: 'completed', stdout: 'allowed-stdout' },
+      { scriptId: script!.id, deviceId: hiddenDevice!.id, orgId: org.id, status: 'completed', stdout: 'hidden-stdout' },
+      { scriptId: foreignScript!.id, deviceId: foreignDevice!.id, orgId: foreignOrg.id, status: 'completed', stdout: 'foreign-stdout' },
+    ]);
+
+    const context = { scope: 'organization' as const, orgId: org.id, accessibleOrgIds: [org.id] };
+    await withDbAccessContext(context, async () => {
+      const projected = await projectAutomationRunsToSites([run!], [allowedSite.id]);
+      expect(projected).toHaveLength(1);
+      expect(projected[0]).toMatchObject({
+        devicesTargeted: 1, devicesSucceeded: 1, devicesFailed: 0, status: 'completed',
+        startedAt: new Date('2026-09-05T00:00:10Z'),
+        completedAt: new Date('2026-09-05T00:00:20Z'),
+      });
+      expect(JSON.stringify(projected)).toContain('allowed-log');
+      expect(JSON.stringify(projected)).not.toContain('hidden-log');
+
+      const auth = {
+        user: { id: randomUUID(), email: 'op@example.test', name: 'Op', isPlatformAdmin: false },
+        token: {}, partnerId: null, orgId: org.id, scope: 'organization', accessibleOrgIds: [org.id],
+        allowedSiteIds: [allowedSite.id],
+        orgCondition: () => undefined,
+        canAccessOrg: (id: string) => id === org.id,
+        canAccessSite: (id: string | null | undefined) => id === allowedSite.id,
+      } as unknown as AuthContext;
+      const history = JSON.parse(await scriptHistory()({ scriptId: script!.id, limit: 10 }, auth));
+      expect(history.count).toBe(1);
+      expect(JSON.stringify(history)).toContain('allowed-stdout');
+      expect(JSON.stringify(history)).not.toContain('hidden-stdout');
+      expect(JSON.stringify(history)).not.toContain(hiddenDevice!.id);
+      const foreignHistory = JSON.parse(await scriptHistory()({ scriptId: foreignScript!.id, limit: 10 }, auth));
+      expect(foreignHistory).toEqual({ error: 'Script not found' });
+      expect(JSON.stringify(foreignHistory)).not.toContain('foreign-stdout');
+    });
+  });
+});

--- a/apps/api/src/__tests__/integration/mtlsQuarantineSiteScope.integration.test.ts
+++ b/apps/api/src/__tests__/integration/mtlsQuarantineSiteScope.integration.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Quarantine administration boundary against real PostgreSQL as breeze_app.
+ *
+ * The unit suite pins handler ordering and generated predicates. This suite
+ * proves that forced RLS, site filtering, and the exact preflight-site CAS
+ * compose correctly against actual rows and a real concurrent site move.
+ */
+import './setup';
+import { describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import { and, eq, sql } from 'drizzle-orm';
+import { withDbAccessContext, type DbAccessContext } from '../../db';
+import { devices } from '../../db/schema';
+import { getTestDb } from './setup';
+import { createOrganization, createPartner, createSite } from './db-utils';
+
+const {
+  authState,
+  issueMtlsCertForDeviceMock,
+  terminateDeviceRemoteSessionsMock,
+  writeAuditEventMock,
+} = vi.hoisted(() => ({
+  authState: {
+    orgId: '',
+    allowedSiteIds: undefined as string[] | undefined,
+  },
+  issueMtlsCertForDeviceMock: vi.fn(async () => null),
+  terminateDeviceRemoteSessionsMock: vi.fn(async () => 0),
+  writeAuditEventMock: vi.fn(),
+}));
+
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: async (c: any, next: any) => {
+    c.set('auth', {
+      user: { id: '11111111-1111-4111-8111-111111111111' },
+      canAccessOrg: (orgId: string) => orgId === authState.orgId,
+    });
+    return next();
+  },
+  requirePermission: () => async (c: any, next: any) => {
+    c.set('permissions', {
+      permissions: [{ resource: 'devices', action: 'write' }],
+      allowedSiteIds: authState.allowedSiteIds,
+    });
+    return next();
+  },
+  requireMfa: () => async (_c: any, next: any) => next(),
+}));
+
+vi.mock('../../routes/agents/helpers', () => ({
+  getOrgHelperSettings: vi.fn(async () => ({ enabled: true })),
+  issueMtlsCertForDevice: issueMtlsCertForDeviceMock,
+  isObject: (value: unknown) => typeof value === 'object' && value !== null && !Array.isArray(value),
+}));
+
+vi.mock('../../services/auditEvents', () => ({ writeAuditEvent: writeAuditEventMock }));
+vi.mock('../../services/remoteSessionTeardown', () => ({
+  terminateDeviceRemoteSessions: terminateDeviceRemoteSessionsMock,
+  TEARDOWN_FAILED: -1,
+}));
+vi.mock('../../routes/agentWs', () => ({ disconnectAgent: vi.fn() }));
+
+import { mtlsRoutes } from '../../routes/agents/mtls';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+function orgContext(orgId: string, partnerId: string): DbAccessContext {
+  return {
+    scope: 'organization',
+    orgId,
+    accessibleOrgIds: [orgId],
+    accessiblePartnerIds: [partnerId],
+    currentPartnerId: partnerId,
+  };
+}
+
+function app(): Hono {
+  const instance = new Hono();
+  instance.route('/agents', mtlsRoutes);
+  return instance;
+}
+
+async function requestForOrg(
+  partnerId: string,
+  orgId: string,
+  path: string,
+  init?: RequestInit,
+): Promise<Response> {
+  authState.orgId = orgId;
+  return withDbAccessContext(orgContext(orgId, partnerId), async () => app().request(path, init));
+}
+
+async function seedDevice(orgId: string, siteId: string, suffix: string) {
+  const [device] = await getTestDb()
+    .insert(devices)
+    .values({
+      orgId,
+      siteId,
+      agentId: `quarantine-it-${suffix}`,
+      hostname: `quarantine-${suffix}`,
+      osType: 'linux',
+      osVersion: 'test',
+      architecture: 'x86_64',
+      agentVersion: 'test',
+      status: 'quarantined',
+      quarantinedAt: new Date(),
+      quarantinedReason: 'synthetic integration fixture',
+    })
+    .returning();
+  if (!device) throw new Error('failed to seed device');
+  return device;
+}
+
+async function fixture() {
+  const partner = await createPartner();
+  const org = await createOrganization({ partnerId: partner.id });
+  const foreignOrg = await createOrganization({ partnerId: partner.id });
+  const allowedSite = await createSite({ orgId: org.id, name: 'Allowed' });
+  const secondAllowedSite = await createSite({ orgId: org.id, name: 'Second allowed' });
+  const hiddenSite = await createSite({ orgId: org.id, name: 'Hidden' });
+  const foreignSite = await createSite({ orgId: foreignOrg.id, name: 'Foreign' });
+  const allowed = await seedDevice(org.id, allowedSite.id, 'allowed');
+  const hidden = await seedDevice(org.id, hiddenSite.id, 'hidden');
+  const foreign = await seedDevice(foreignOrg.id, foreignSite.id, 'foreign');
+  return { partner, org, allowedSite, secondAllowedSite, hiddenSite, allowed, hidden, foreign };
+}
+
+// Attach rejection handlers as operations start and settle them after releasing
+// the barrier. Cleanup must retain the original assertion or operation error.
+function startedOperations() {
+  const pending: Promise<PromiseSettledResult<unknown>[]>[] = [];
+  return {
+    track<T>(operation: Promise<T>): Promise<T> {
+      pending.push(Promise.allSettled([operation]));
+      return operation;
+    },
+    async drain(primaryFailed: boolean) {
+      const results = (await Promise.all(pending)).flat();
+      const rejected = results.find((result) => result.status === 'rejected');
+      if (!primaryFailed && rejected?.status === 'rejected') throw rejected.reason;
+    },
+  };
+}
+
+describe('quarantine administration site scope (real PostgreSQL, breeze_app)', () => {
+  runDb('filters list and enforces allowed, hidden, cross-org, and null controls', async () => {
+    const fx = await fixture();
+    authState.allowedSiteIds = [fx.allowedSite.id];
+    issueMtlsCertForDeviceMock.mockClear();
+    terminateDeviceRemoteSessionsMock.mockClear();
+    writeAuditEventMock.mockClear();
+
+    const list = await requestForOrg(fx.partner.id, fx.org.id, '/agents/quarantined');
+    expect(list.status).toBe(200);
+    expect((await list.json()).devices.map((row: { id: string }) => row.id)).toEqual([fx.allowed.id]);
+
+    const hidden = await requestForOrg(fx.partner.id, fx.org.id, `/agents/${fx.hidden.id}/approve`, { method: 'POST' });
+    expect(hidden.status).toBe(403);
+    expect(issueMtlsCertForDeviceMock).not.toHaveBeenCalled();
+    expect(terminateDeviceRemoteSessionsMock).not.toHaveBeenCalled();
+    expect(writeAuditEventMock).not.toHaveBeenCalled();
+
+    const foreign = await requestForOrg(fx.partner.id, fx.org.id, `/agents/${fx.foreign.id}/deny`, { method: 'POST' });
+    expect(foreign.status).toBe(404);
+    expect(issueMtlsCertForDeviceMock).not.toHaveBeenCalled();
+    expect(terminateDeviceRemoteSessionsMock).not.toHaveBeenCalled();
+    expect(writeAuditEventMock).not.toHaveBeenCalled();
+
+    const approved = await requestForOrg(fx.partner.id, fx.org.id, `/agents/${fx.allowed.id}/approve`, { method: 'POST' });
+    expect(approved.status).toBe(200);
+    expect(issueMtlsCertForDeviceMock).toHaveBeenCalledWith(fx.allowed.id, fx.org.id);
+    expect(writeAuditEventMock).toHaveBeenCalledOnce();
+
+    // Current schema makes site_id NOT NULL. Pin that DB control rather than
+    // fabricating an impossible route row; the unit suite covers the route's
+    // defensive null fail-closed branches for legacy/drifted data.
+    await expect(
+      getTestDb().insert(devices).values({
+        orgId: fx.org.id,
+        siteId: null as never,
+        agentId: 'quarantine-it-null',
+        hostname: 'quarantine-null',
+        osType: 'linux',
+        osVersion: 'test',
+        architecture: 'x86_64',
+        agentVersion: 'test',
+        status: 'quarantined',
+      }),
+    ).rejects.toMatchObject({ cause: { code: '23502' } });
+  });
+
+  runDb.each(['approve', 'deny'] as const)(
+    'loses the %s CAS when the device moves A -> B inside the same allowlist',
+    async (action) => {
+      const fx = await fixture();
+      authState.allowedSiteIds = [fx.allowedSite.id, fx.secondAllowedSite.id];
+      issueMtlsCertForDeviceMock.mockClear();
+      terminateDeviceRemoteSessionsMock.mockClear();
+      writeAuditEventMock.mockClear();
+
+      let releaseLock!: () => void;
+      let locked!: () => void;
+      const lockReady = new Promise<void>((resolve) => { locked = resolve; });
+      const release = new Promise<void>((resolve) => { releaseLock = resolve; });
+      const started = startedOperations();
+      let primaryFailed = false;
+      try {
+        const mover = started.track(getTestDb().transaction(async (tx) => {
+          await tx.select({ id: devices.id }).from(devices).where(eq(devices.id, fx.allowed.id)).for('update');
+          locked();
+          await release;
+          await tx.update(devices).set({ siteId: fx.secondAllowedSite.id }).where(eq(devices.id, fx.allowed.id));
+        }));
+        await Promise.race([lockReady, mover.then(() => {
+          throw new Error('site mover ended before acquiring its barrier');
+        })]);
+
+        const responsePromise = started.track(requestForOrg(
+          fx.partner.id,
+          fx.org.id,
+          `/agents/${fx.allowed.id}/${action}`,
+          { method: 'POST' },
+        ));
+
+        // Wait until the real breeze_app UPDATE is blocked behind the mover's
+        // row lock. At that point preflight definitely observed site A.
+        let updateBlocked = false;
+        for (let attempt = 0; attempt < 100; attempt += 1) {
+          const result = await getTestDb().execute(sql<{ blocked: boolean }>`
+            SELECT EXISTS (
+              SELECT 1 FROM pg_stat_activity
+              WHERE usename = 'breeze_app'
+                AND wait_event_type = 'Lock'
+                AND lower(query) LIKE 'update %devices%'
+            ) AS blocked
+          `);
+          updateBlocked = result[0]?.blocked === true;
+          if (updateBlocked) break;
+          await new Promise((resolve) => setTimeout(resolve, 10));
+        }
+        expect(updateBlocked).toBe(true);
+        releaseLock();
+        await mover;
+
+        const response = await responsePromise;
+        expect(response.status).toBe(409);
+        const [after] = await getTestDb()
+          .select({ siteId: devices.siteId, status: devices.status })
+          .from(devices)
+          .where(and(eq(devices.id, fx.allowed.id), eq(devices.orgId, fx.org.id)));
+        expect(after).toMatchObject({ siteId: fx.secondAllowedSite.id, status: 'quarantined' });
+        expect(issueMtlsCertForDeviceMock).not.toHaveBeenCalled();
+        expect(terminateDeviceRemoteSessionsMock).not.toHaveBeenCalled();
+        expect(writeAuditEventMock).not.toHaveBeenCalled();
+      } catch (error) {
+        primaryFailed = true;
+        throw error;
+      } finally {
+        releaseLock();
+        await started.drain(primaryFailed);
+      }
+    },
+  );
+});

--- a/apps/api/src/__tests__/integration/quarantineAuthenticatedSite.integration.test.ts
+++ b/apps/api/src/__tests__/integration/quarantineAuthenticatedSite.integration.test.ts
@@ -1,0 +1,68 @@
+import './setup';
+import { Hono } from 'hono';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db } from '../../db';
+import { devices } from '../../db/schema';
+import { siteFixture, request } from './siteHttpFixtures';
+const effects = vi.hoisted(() => ({ issue: vi.fn(async (_deviceId: string, _orgId: string) => null), teardown: vi.fn(async (_deviceId: string) => 0), audit: vi.fn((_context: unknown, _event: unknown) => { }) }));
+// Only external certificate/session effects and the asynchronous audit adapter are inert.
+vi.mock('../../routes/agents/helpers', async (original) => ({ ...await original<typeof import('../../routes/agents/helpers')>(), issueMtlsCertForDevice: effects.issue }));
+vi.mock('../../services/remoteSessionTeardown', async (original) => ({ ...await original<typeof import('../../services/remoteSessionTeardown')>(), terminateDeviceRemoteSessions: effects.teardown }));
+vi.mock('../../services/auditEvents', async (original) => ({ ...await original<typeof import('../../services/auditEvents')>(), writeAuditEvent: effects.audit }));
+import { mtlsRoutes } from '../../routes/agents/mtls';
+const grants = [{ resource: 'devices', action: 'read' }, { resource: 'devices', action: 'write' }];
+beforeEach(() => vi.clearAllMocks());
+describe('quarantine HTTP through real bearer, site, MFA and request PostgreSQL middleware', () => {
+    it('lists the selected ceiling and denies hidden, foreign, empty and non-MFA decisions without effects', async () => {
+        const f = await siteFixture();
+        const app = new Hono().route('/api/v1/agents', mtlsRoutes);
+        const selected = await f.actor([f.allowedSite.id], grants);
+        const empty = await f.actor([], grants);
+        const unrestricted = await f.actor(null, grants);
+        const noMfa = await f.actor([f.allowedSite.id], grants, false);
+        expect((await request(app, undefined, 'GET', '/api/v1/agents/quarantined')).status).toBe(401);
+        const visible = await request(app, selected.token, 'GET', '/api/v1/agents/quarantined');
+        expect(visible.status).toBe(200);
+        expect((await visible.json()).devices.map((x: {
+            id: string;
+        }) => x.id)).toEqual([f.allowed.id]);
+        expect((await (await request(app, empty.token, 'GET', '/api/v1/agents/quarantined')).json()).devices).toEqual([]);
+        expect((await (await request(app, unrestricted.token, 'GET', '/api/v1/agents/quarantined')).json()).devices.map((x: {
+            id: string;
+        }) => x.id).sort()).toEqual([f.allowed.id, f.hidden.id].sort());
+        const before = await f.deviceSnapshot();
+        for (const action of ['approve', 'deny']) {
+            for (const [token, id, status] of [[selected.token, f.hidden.id, 403], [selected.token, f.foreign.id, 404], [empty.token, f.allowed.id, 403], [noMfa.token, f.allowed.id, 403]] as const) {
+                const response = await request(app, token, 'POST', `/api/v1/agents/${id}/${action}`);
+                expect(response.status).toBe(status);
+                if (token === noMfa.token)
+                    expect(await response.json()).toMatchObject({ code: 'MFA_REQUIRED' });
+                expect(await f.deviceSnapshot()).toEqual(before);
+                expect(effects.issue).not.toHaveBeenCalled();
+                expect(effects.teardown).not.toHaveBeenCalled();
+                expect(effects.audit).not.toHaveBeenCalled();
+            }
+        }
+    });
+    it('admits visible MFA decisions and observes only the corresponding inert effect and audit', async () => {
+        const f = await siteFixture();
+        const app = new Hono().route('/api/v1/agents', mtlsRoutes);
+        const selected = await f.actor([f.allowedSite.id], grants);
+        const unrestricted = await f.actor(null, grants);
+        expect((await request(app, selected.token, 'POST', `/api/v1/agents/${f.allowed.id}/approve`)).status).toBe(200);
+        expect(effects.issue).toHaveBeenCalledExactlyOnceWith(f.allowed.id, f.org.id);
+        expect(effects.teardown).not.toHaveBeenCalled();
+        expect(effects.audit.mock.calls[0]?.[1]).toMatchObject({ action: 'admin.device.approve', resourceId: f.allowed.id, actorId: selected.user.id });
+        const rows = await f.scoped(() => db.select().from(devices).where(eq(devices.id, f.allowed.id)));
+        expect(rows[0]?.status).toBe('online');
+        expect((await request(app, unrestricted.token, 'POST', `/api/v1/agents/${f.hidden.id}/deny`)).status).toBe(200);
+        expect(effects.teardown).toHaveBeenCalledExactlyOnceWith(f.hidden.id);
+        expect(effects.issue).toHaveBeenCalledTimes(1);
+        expect(effects.audit.mock.calls[1]?.[1]).toMatchObject({ action: 'admin.device.deny', resourceId: f.hidden.id });
+        const denied = await f.scoped(() => db.select().from(devices).where(eq(devices.id, f.hidden.id)));
+        expect(denied[0]?.status).toBe('decommissioned');
+        expect(denied[0]?.decommissionedAt).not.toBeNull();
+        expect(effects.audit).toHaveBeenCalledTimes(2);
+    });
+});

--- a/apps/api/src/__tests__/integration/siteHttpFixtures.ts
+++ b/apps/api/src/__tests__/integration/siteHttpFixtures.ts
@@ -1,0 +1,59 @@
+/** Fixed-state HTTP fixtures. No authentication, permission or database mocks. */
+import { randomUUID } from 'node:crypto';
+import { Hono } from 'hono';
+import { and, eq, sql } from 'drizzle-orm';
+import { expect } from 'vitest';
+import { db, withDbAccessContext } from '../../db';
+import { devices, organizationUsers } from '../../db/schema';
+import { createAccessToken } from '../../services/jwt';
+import { createOrganization, createPartner, createRole, createSite, createUser, grantRolePermissions, assignUserToOrganization } from './db-utils';
+import { getTestDb, getAppDb } from './setup';
+export async function siteFixture() {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const foreignPartner = await createPartner();
+    const foreignOrg = await createOrganization({ partnerId: foreignPartner.id });
+    const allowedSite = await createSite({ orgId: org.id });
+    const hiddenSite = await createSite({ orgId: org.id });
+    const foreignSite = await createSite({ orgId: foreignOrg.id });
+    const makeDevice = async (orgId: string, siteId: string, hostname: string) => {
+        const [row] = await getTestDb().insert(devices).values({
+            orgId, siteId, agentId: randomUUID(), hostname, osType: 'linux', osVersion: 'synthetic',
+            architecture: 'amd64', agentVersion: 'synthetic', status: 'quarantined',
+            quarantinedAt: new Date(), quarantinedReason: 'synthetic fixture',
+        }).returning();
+        if (!row)
+            throw new Error('Missing device fixture');
+        return row;
+    };
+    const allowed = await makeDevice(org.id, allowedSite.id, 'visible-fixture');
+    const hidden = await makeDevice(org.id, hiddenSite.id, 'hidden-fixture');
+    const foreign = await makeDevice(foreignOrg.id, foreignSite.id, 'foreign-fixture');
+    const actor = async (siteIds: string[] | null, grants: Array<{
+        resource: string;
+        action: string;
+    }>, mfa = true) => {
+        const user = await createUser({ partnerId: partner.id, orgId: org.id, email: `${randomUUID()}@example.test`, mfaEnabled: true });
+        const role = await createRole({ scope: 'organization', orgId: org.id, name: randomUUID() });
+        await grantRolePermissions(role.id, grants);
+        await assignUserToOrganization(user.id, org.id, role.id);
+        await getTestDb().update(organizationUsers).set({ siteIds }).where(and(eq(organizationUsers.userId, user.id), eq(organizationUsers.orgId, org.id)));
+        const token = await createAccessToken({ sub: user.id, email: user.email, roleId: role.id,
+            orgId: org.id, partnerId: partner.id, scope: 'organization', mfa, aep: user.authEpoch,
+            mep: user.mfaEpoch, sid: randomUUID() });
+        return { user, token };
+    };
+    const appRole = await getAppDb().execute(sql `select current_user, rolsuper, rolbypassrls from pg_roles where rolname=current_user`);
+    expect(appRole[0]).toMatchObject({ current_user: 'breeze_app', rolsuper: false, rolbypassrls: false });
+    const scoped = <T>(fn: () => Promise<T>, foreign = false) => withDbAccessContext({
+        scope: 'organization', orgId: foreign ? foreignOrg.id : org.id,
+        accessibleOrgIds: [foreign ? foreignOrg.id : org.id], accessiblePartnerIds: [],
+        currentPartnerId: foreign ? foreignPartner.id : partner.id,
+    }, fn);
+    const deviceSnapshot = () => Promise.all([false, true].map(other => scoped(() => db.select().from(devices).orderBy(devices.id), other)));
+    return { partner, org, foreignPartner, foreignOrg, allowedSite, hiddenSite, foreignSite, allowed, hidden, foreign, actor, scoped, deviceSnapshot };
+}
+export function request(app: Hono, token: string | undefined, method: string, path: string, body?: unknown) {
+    return app.request(path, { method, headers: { ...(token ? { Authorization: `Bearer ${token}` } : {}), 'Content-Type': 'application/json' },
+        ...(body === undefined ? {} : { body: JSON.stringify(body) }) });
+}

--- a/apps/api/src/routes/agents/mtls.test.ts
+++ b/apps/api/src/routes/agents/mtls.test.ts
@@ -57,6 +57,8 @@ const {
   txUpdateMock,
   txInsertMock,
   mfaGate,
+  permissionSiteScope,
+  issueMtlsCertForDeviceMock,
 } = vi.hoisted(() => {
   const txSelect = vi.fn();
   const txUpdate = vi.fn();
@@ -72,6 +74,13 @@ const {
       fn({ select: txSelect, update: txUpdate, insert: txInsert }),
     ),
     mfaGate: { deny: false },
+    permissionSiteScope: { allowedSiteIds: undefined as string[] | undefined },
+    issueMtlsCertForDeviceMock: vi.fn(async (): Promise<{
+      certificate: string;
+      privateKey: string;
+      expiresAt: string;
+      serialNumber: string;
+    } | null> => null),
   };
 });
 
@@ -91,7 +100,10 @@ vi.mock('../../db/schema', () => ({
   devices: {
     id: 'devices.id',
     orgId: 'devices.orgId',
+    siteId: 'devices.siteId',
     agentId: 'devices.agentId',
+    status: 'devices.status',
+    quarantinedAt: 'devices.quarantinedAt',
     agentTokenHash: 'devices.agentTokenHash',
     previousTokenHash: 'devices.previousTokenHash',
   },
@@ -123,7 +135,13 @@ vi.mock('../../middleware/auth', () => ({
     });
     return next();
   }),
-  requirePermission: vi.fn(() => async (_c: any, next: any) => next()),
+  requirePermission: vi.fn(() => async (c: any, next: any) => {
+    c.set('permissions', {
+      permissions: [{ resource: 'devices', action: 'write' }],
+      allowedSiteIds: permissionSiteScope.allowedSiteIds,
+    });
+    return next();
+  }),
   requireMfa: vi.fn(() => async (c: any, next: any) => {
     if (mfaGate.deny) return c.json({ error: 'MFA required' }, 403);
     return next();
@@ -195,7 +213,7 @@ vi.mock('@breeze/shared', () => ({
 vi.mock('./helpers', () => ({
   getOrgMtlsSettings: vi.fn(async () => ({ certLifetimeDays: 30, expiredCertPolicy: 'quarantine' })),
   getOrgHelperSettings: vi.fn(async () => ({ enabled: true })),
-  issueMtlsCertForDevice: vi.fn(async () => null),
+  issueMtlsCertForDevice: issueMtlsCertForDeviceMock,
   isObject: (v: unknown) => typeof v === 'object' && v !== null && !Array.isArray(v),
 }));
 
@@ -522,6 +540,9 @@ function baseActiveDeviceRow(overrides: Record<string, unknown> = {}) {
 
 function resetAllMocksForTest() {
   vi.clearAllMocks();
+  mfaGate.deny = false;
+  permissionSiteScope.allowedSiteIds = undefined;
+  issueMtlsCertForDeviceMock.mockReset().mockResolvedValue(null);
   redisState.clear();
   redisStringState.clear();
   issueCertMock.mockReset();
@@ -703,6 +724,241 @@ describe('remote-session teardown wiring on quarantine / deny', () => {
     expect(setArg.status).toBe('decommissioned');
     expect(setArg.decommissionedAt).toBeInstanceOf(Date);
   });
+});
+
+describe('quarantine administration site boundary', () => {
+  const ALLOWED_SITE_ID = '66666666-6666-4666-8666-666666666666';
+  const HIDDEN_SITE_ID = '77777777-7777-4777-8777-777777777777';
+
+  beforeEach(() => {
+    resetAllMocksForTest();
+    permissionSiteScope.allowedSiteIds = [ALLOWED_SITE_ID];
+  });
+
+  it('narrows the quarantined-device list to the caller site allowlist', async () => {
+    const where = vi.fn().mockReturnValue({
+      orderBy: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
+    });
+    dbSelectMock.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({ where }),
+    } as any);
+
+    const res = await buildApp().request('/agents/quarantined', {
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(JSON.stringify(where.mock.calls[0]![0])).toContain(ALLOWED_SITE_ID);
+  });
+
+  it('makes an empty site allowlist an empty quarantined-device result', async () => {
+    permissionSiteScope.allowedSiteIds = [];
+    const where = vi.fn().mockReturnValue({
+      orderBy: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
+    });
+    dbSelectMock.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({ where }),
+    } as any);
+
+    const res = await buildApp().request('/agents/quarantined', {
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(JSON.stringify(where.mock.calls[0]![0])).toContain('false');
+  });
+
+  it.each(['approve', 'deny'] as const)(
+    'rejects %s for a quarantined device outside the caller site allowlist before side effects',
+    async (action) => {
+      mockDeviceLookup({
+        id: DEVICE_ID,
+        orgId: ORG_ID,
+        siteId: HIDDEN_SITE_ID,
+        agentId: AGENT_ID,
+        hostname: 'hidden-host',
+        status: 'quarantined',
+      });
+      const res = await buildApp().request(`/agents/${DEVICE_ID}/${action}`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(403);
+      expect(dbUpdateMock).not.toHaveBeenCalled();
+      expect(issueMtlsCertForDeviceMock).not.toHaveBeenCalled();
+      expect(terminateDeviceRemoteSessions).not.toHaveBeenCalled();
+      expect(writeAuditEventMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(['approve', 'deny'] as const)(
+    'allows %s for a quarantined device inside the caller site allowlist',
+    async (action) => {
+      mockDeviceLookup({
+        id: DEVICE_ID,
+        orgId: ORG_ID,
+        siteId: ALLOWED_SITE_ID,
+        agentId: AGENT_ID,
+        hostname: 'allowed-host',
+        status: 'quarantined',
+      });
+      if (action === 'approve') {
+        issueMtlsCertForDeviceMock.mockResolvedValueOnce({
+          certificate: 'synthetic-certificate',
+          privateKey: 'synthetic-private-key',
+          expiresAt: '2030-01-01T00:00:00.000Z',
+          serialNumber: 'synthetic-serial',
+        });
+      }
+
+      const res = await buildApp().request(`/agents/${DEVICE_ID}/${action}`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(dbUpdateMock).toHaveBeenCalled();
+      if (action === 'approve') {
+        expect(issueMtlsCertForDeviceMock).toHaveBeenCalledWith(DEVICE_ID, ORG_ID);
+        expect(await res.json()).toMatchObject({
+          success: true,
+          mtls: { certificate: 'synthetic-certificate', serialNumber: 'synthetic-serial' },
+        });
+      } else {
+        expect(issueMtlsCertForDeviceMock).not.toHaveBeenCalled();
+      }
+    },
+  );
+
+  it('keeps a foreign-organization device opaque before mutation', async () => {
+    mockDeviceLookup({
+      id: DEVICE_ID,
+      orgId: '88888888-8888-4888-8888-888888888888',
+      siteId: ALLOWED_SITE_ID,
+      agentId: AGENT_ID,
+      hostname: 'foreign-host',
+      status: 'quarantined',
+    });
+
+    const res = await buildApp().request(`/agents/${DEVICE_ID}/deny`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(404);
+    expect(dbUpdateMock).not.toHaveBeenCalled();
+    expect(terminateDeviceRemoteSessions).not.toHaveBeenCalled();
+  });
+
+  it.each(['approve', 'deny'] as const)(
+    'fails %s closed when a concurrent state or site change wins the conditional update',
+    async (action) => {
+      mockDeviceLookup({
+        id: DEVICE_ID,
+        orgId: ORG_ID,
+        siteId: ALLOWED_SITE_ID,
+        agentId: AGENT_ID,
+        hostname: 'racing-host',
+        status: 'quarantined',
+      });
+      mockDbUpdateOk(0);
+
+      const res = await buildApp().request(`/agents/${DEVICE_ID}/${action}`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(409);
+      expect(issueMtlsCertForDeviceMock).not.toHaveBeenCalled();
+      expect(terminateDeviceRemoteSessions).not.toHaveBeenCalled();
+      expect(writeAuditEventMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(['approve', 'deny'] as const)(
+    'fails %s closed when the device moves between two sites in the same allowlist',
+    async (action) => {
+      const SECOND_ALLOWED_SITE_ID = '99999999-9999-4999-8999-999999999999';
+      permissionSiteScope.allowedSiteIds = [ALLOWED_SITE_ID, SECOND_ALLOWED_SITE_ID];
+      mockDeviceLookup({
+        id: DEVICE_ID,
+        orgId: ORG_ID,
+        siteId: ALLOWED_SITE_ID,
+        agentId: AGENT_ID,
+        hostname: 'moving-host',
+        status: 'quarantined',
+      });
+      // The mocked zero-row CAS represents site A -> site B after preflight.
+      mockDbUpdateOk(0);
+
+      const res = await buildApp().request(`/agents/${DEVICE_ID}/${action}`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(409);
+      const whereArg = (dbUpdateMock.mock.results[0]!.value as {
+        set: ReturnType<typeof vi.fn>;
+      }).set.mock.results[0]!.value.where.mock.calls[0]![0];
+      const serializedWhere = JSON.stringify(whereArg);
+      // Site A appears once in the exact preflight-state comparison and once
+      // in the authorization allowlist. Merely retaining IN (A, B) would only
+      // produce one occurrence and would not stop the same-allowlist move.
+      expect(serializedWhere.split(ALLOWED_SITE_ID)).toHaveLength(3);
+      expect(serializedWhere).toContain(SECOND_ALLOWED_SITE_ID);
+      expect(issueMtlsCertForDeviceMock).not.toHaveBeenCalled();
+      expect(terminateDeviceRemoteSessions).not.toHaveBeenCalled();
+      expect(writeAuditEventMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(['approve', 'deny'] as const)(
+    'fails %s closed when an unrestricted caller races a null-site assignment',
+    async (action) => {
+      permissionSiteScope.allowedSiteIds = undefined;
+      mockDeviceLookup({
+        id: DEVICE_ID,
+        orgId: ORG_ID,
+        siteId: null,
+        agentId: AGENT_ID,
+        hostname: 'unassigned-host',
+        status: 'quarantined',
+      });
+      // The mocked zero-row CAS represents null -> a concrete site after preflight.
+      mockDbUpdateOk(0);
+
+      const res = await buildApp().request(`/agents/${DEVICE_ID}/${action}`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(409);
+      const whereArg = (dbUpdateMock.mock.results[0]!.value as {
+        set: ReturnType<typeof vi.fn>;
+      }).set.mock.results[0]!.value.where.mock.calls[0]![0];
+      expect(JSON.stringify(whereArg)).toContain(' is null');
+      expect(issueMtlsCertForDeviceMock).not.toHaveBeenCalled();
+      expect(terminateDeviceRemoteSessions).not.toHaveBeenCalled();
+      expect(writeAuditEventMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(['approve', 'deny'] as const)(
+    'requires MFA before %s reads or mutates a quarantined device',
+    async (action) => {
+      mfaGate.deny = true;
+
+      const res = await buildApp().request(`/agents/${DEVICE_ID}/${action}`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(403);
+      expect(dbSelectMock).not.toHaveBeenCalled();
+      expect(dbUpdateMock).not.toHaveBeenCalled();
+    },
+  );
 });
 
 describe('POST /renew-cert — cert-issuing fail-closed guards', () => {

--- a/apps/api/src/routes/agents/mtls.ts
+++ b/apps/api/src/routes/agents/mtls.ts
@@ -3,14 +3,14 @@ import { Hono } from 'hono';
 import type { Context } from 'hono';
 import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
-import { and, desc, eq, or } from 'drizzle-orm';
+import { and, desc, eq, inArray, isNull, or, sql } from 'drizzle-orm';
 import { createHash } from 'crypto';
 import { lookup as dnsLookup } from 'dns/promises';
 import { isIP } from 'net';
 import { db, withSystemDbAccessContext } from '../../db';
 import { isAgentTenantActive } from '../../services/tenantStatus';
 import { devices, organizations, deviceMtlsCertificates } from '../../db/schema';
-import { authMiddleware, requireMfa, requirePermission } from '../../middleware/auth';
+import { authMiddleware, requireMfa, requirePermission, type AuthContext } from '../../middleware/auth';
 import { matchAgentTokenHash } from '../../middleware/agentAuth';
 import { writeAuditEvent } from '../../services/auditEvents';
 import {
@@ -1500,6 +1500,12 @@ mtlsRoutes.post(
 
 mtlsRoutes.get('/quarantined', authMiddleware, requirePermission('devices', 'read'), async (c) => {
   const auth = c.get('auth') as { orgId?: string; orgCondition?: (col: any) => any };
+  const permissions = c.get('permissions') as { allowedSiteIds?: string[] };
+  const siteCondition = permissions.allowedSiteIds === undefined
+    ? undefined
+    : permissions.allowedSiteIds.length === 0
+      ? sql`false`
+      : inArray(devices.siteId, permissions.allowedSiteIds);
 
   const rows = await db
     .select({
@@ -1514,7 +1520,8 @@ mtlsRoutes.get('/quarantined', authMiddleware, requirePermission('devices', 'rea
     .where(
       and(
         eq(devices.status, 'quarantined'),
-        auth.orgCondition ? auth.orgCondition(devices.orgId) : undefined
+        auth.orgCondition ? auth.orgCondition(devices.orgId) : undefined,
+        siteCondition,
       )
     )
     .orderBy(desc(devices.quarantinedAt))
@@ -1523,14 +1530,15 @@ mtlsRoutes.get('/quarantined', authMiddleware, requirePermission('devices', 'rea
   return c.json({ devices: rows });
 });
 
-mtlsRoutes.post('/:id/approve', authMiddleware, requirePermission('devices', 'write'), zValidator('param', deviceIdParamSchema), async (c) => {
+mtlsRoutes.post('/:id/approve', authMiddleware, requirePermission('devices', 'write'), requireMfa(), zValidator('param', deviceIdParamSchema), async (c) => {
   const { id: deviceId } = c.req.valid('param');
-  const auth = c.get('auth') as { orgId?: string; user?: { id: string }; canAccessOrg?: (id: string) => boolean };
+  const auth = c.get('auth') as AuthContext;
 
   const [device] = await db
     .select({
       id: devices.id,
       orgId: devices.orgId,
+      siteId: devices.siteId,
       agentId: devices.agentId,
       hostname: devices.hostname,
       status: devices.status,
@@ -1543,17 +1551,22 @@ mtlsRoutes.post('/:id/approve', authMiddleware, requirePermission('devices', 'wr
     return c.json({ error: 'Device not found' }, 404);
   }
 
-  if (auth.canAccessOrg && !auth.canAccessOrg(device.orgId)) {
-    return c.json({ error: 'Not authorized' }, 403);
+  if (!auth.canAccessOrg(device.orgId)) {
+    return c.json({ error: 'Device not found' }, 404);
+  }
+
+  const permissions = c.get('permissions') as { allowedSiteIds?: string[] } | undefined;
+  if (!permissions || (permissions.allowedSiteIds !== undefined && (
+    typeof device.siteId !== 'string' || !permissions.allowedSiteIds.includes(device.siteId)
+  ))) {
+    return c.json({ error: 'Access to this site denied' }, 403);
   }
 
   if (device.status !== 'quarantined') {
     return c.json({ error: 'Device is not quarantined' }, 400);
   }
 
-  const mtlsCert = await issueMtlsCertForDevice(device.id, device.orgId);
-
-  await db
+  const approved = await db
     .update(devices)
     .set({
       status: 'online',
@@ -1561,7 +1574,24 @@ mtlsRoutes.post('/:id/approve', authMiddleware, requirePermission('devices', 'wr
       quarantinedReason: null,
       updatedAt: new Date(),
     })
-    .where(eq(devices.id, device.id));
+    .where(and(
+      eq(devices.id, device.id),
+      eq(devices.orgId, device.orgId),
+      eq(devices.status, 'quarantined'),
+      device.siteId === null
+        ? isNull(devices.siteId)
+        : eq(devices.siteId, device.siteId),
+      permissions.allowedSiteIds === undefined
+        ? undefined
+        : inArray(devices.siteId, permissions.allowedSiteIds),
+    ))
+    .returning({ id: devices.id });
+
+  if (approved.length !== 1) {
+    return c.json({ error: 'Device quarantine state changed' }, 409);
+  }
+
+  const mtlsCert = await issueMtlsCertForDevice(device.id, device.orgId);
 
   writeAuditEvent(c, {
     orgId: device.orgId,
@@ -1580,14 +1610,15 @@ mtlsRoutes.post('/:id/approve', authMiddleware, requirePermission('devices', 'wr
   });
 });
 
-mtlsRoutes.post('/:id/deny', authMiddleware, requirePermission('devices', 'write'), zValidator('param', deviceIdParamSchema), async (c) => {
+mtlsRoutes.post('/:id/deny', authMiddleware, requirePermission('devices', 'write'), requireMfa(), zValidator('param', deviceIdParamSchema), async (c) => {
   const { id: deviceId } = c.req.valid('param');
-  const auth = c.get('auth') as { orgId?: string; user?: { id: string }; canAccessOrg?: (id: string) => boolean };
+  const auth = c.get('auth') as AuthContext;
 
   const [device] = await db
     .select({
       id: devices.id,
       orgId: devices.orgId,
+      siteId: devices.siteId,
       agentId: devices.agentId,
       hostname: devices.hostname,
       status: devices.status,
@@ -1600,15 +1631,22 @@ mtlsRoutes.post('/:id/deny', authMiddleware, requirePermission('devices', 'write
     return c.json({ error: 'Device not found' }, 404);
   }
 
-  if (auth.canAccessOrg && !auth.canAccessOrg(device.orgId)) {
-    return c.json({ error: 'Not authorized' }, 403);
+  if (!auth.canAccessOrg(device.orgId)) {
+    return c.json({ error: 'Device not found' }, 404);
+  }
+
+  const permissions = c.get('permissions') as { allowedSiteIds?: string[] } | undefined;
+  if (!permissions || (permissions.allowedSiteIds !== undefined && (
+    typeof device.siteId !== 'string' || !permissions.allowedSiteIds.includes(device.siteId)
+  ))) {
+    return c.json({ error: 'Access to this site denied' }, 403);
   }
 
   if (device.status !== 'quarantined') {
     return c.json({ error: 'Device is not quarantined' }, 400);
   }
 
-  await db
+  const denied = await db
     .update(devices)
     .set({
       status: 'decommissioned',
@@ -1616,7 +1654,22 @@ mtlsRoutes.post('/:id/deny', authMiddleware, requirePermission('devices', 'write
       decommissionedAt: new Date(),
       updatedAt: new Date(),
     })
-    .where(eq(devices.id, device.id));
+    .where(and(
+      eq(devices.id, device.id),
+      eq(devices.orgId, device.orgId),
+      eq(devices.status, 'quarantined'),
+      device.siteId === null
+        ? isNull(devices.siteId)
+        : eq(devices.siteId, device.siteId),
+      permissions.allowedSiteIds === undefined
+        ? undefined
+        : inArray(devices.siteId, permissions.allowedSiteIds),
+    ))
+    .returning({ id: devices.id });
+
+  if (denied.length !== 1) {
+    return c.json({ error: 'Device quarantine state changed' }, 409);
+  }
 
   // Tear down any live remote-control session to a device we're decommissioning.
   // Never throws; a TEARDOWN_FAILED is recorded in the audit trail below.

--- a/apps/api/src/routes/alertTemplates.partnerWide.test.ts
+++ b/apps/api/src/routes/alertTemplates.partnerWide.test.ts
@@ -54,7 +54,10 @@ vi.mock('../db/schema', () => ({
 vi.mock('../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
 vi.mock('../services/alertConditions', () => ({ retiredConditionTypeError: vi.fn(() => null) }));
 vi.mock('../services/permissions', () => ({
-  PERMISSIONS: { ALERTS_WRITE: { resource: 'alerts', action: 'write' } },
+  PERMISSIONS: {
+    ALERTS_READ: { resource: 'alerts', action: 'read' },
+    ALERTS_WRITE: { resource: 'alerts', action: 'write' },
+  },
 }));
 vi.mock('../utils/pagination', () => ({
   getPagination: vi.fn(() => ({ page: 1, limit: 50, offset: 0 })),

--- a/apps/api/src/routes/alertTemplates/conditionTypes.test.ts
+++ b/apps/api/src/routes/alertTemplates/conditionTypes.test.ts
@@ -163,7 +163,7 @@ describe('alert-template condition types (#2948)', () => {
       [{ partnerId: null }],
       // then the rule lookup — inactive, with all-custom override conditions
       [{
-        id: RULE_ID, orgId: 'org-1', isActive: false, templateId: TEMPLATE_ID,
+        id: RULE_ID, orgId: 'org-1', isActive: false, templateId: TEMPLATE_ID, targetType: 'org', targetId: 'org-1',
         overrideSettings: { conditions: [{ type: 'custom' }] },
       }],
     ];
@@ -179,7 +179,7 @@ describe('alert-template condition types (#2948)', () => {
   it('falls back to the template conditions when the rule carries no override', async () => {
     dbRef.current = [
       [{ partnerId: null }],
-      [{ id: RULE_ID, orgId: 'org-1', isActive: false, templateId: TEMPLATE_ID, overrideSettings: {} }],
+      [{ id: RULE_ID, orgId: 'org-1', isActive: false, templateId: TEMPLATE_ID, targetType: 'org', targetId: 'org-1', overrideSettings: {} }],
       [{ conditions: [{ type: 'custom' }] }],
     ];
 
@@ -192,7 +192,7 @@ describe('alert-template condition types (#2948)', () => {
     dbRef.current = [
       [{ partnerId: null }],
       [{
-        id: RULE_ID, orgId: 'org-1', isActive: false, templateId: TEMPLATE_ID,
+        id: RULE_ID, orgId: 'org-1', isActive: false, templateId: TEMPLATE_ID, targetType: 'org', targetId: 'org-1',
         overrideSettings: { conditions: [{ type: 'metric', metric: 'cpu', operator: 'gt', value: 85 }] },
       }],
       [{ id: RULE_ID, isActive: true }],
@@ -210,7 +210,7 @@ describe('alert-template condition types (#2948)', () => {
     // retired", or the gate waves through the rule it exists to stop.
     dbRef.current = [
       [{ partnerId: null }],
-      [{ id: RULE_ID, orgId: 'org-1', isActive: false, templateId: TEMPLATE_ID, overrideSettings: {} }],
+      [{ id: RULE_ID, orgId: 'org-1', isActive: false, templateId: TEMPLATE_ID, targetType: 'org', targetId: 'org-1', overrideSettings: {} }],
       [], // template invisible
     ];
 
@@ -226,7 +226,7 @@ describe('alert-template condition types (#2948)', () => {
     dbRef.current = [
       [{ partnerId: null }],
       [{
-        id: RULE_ID, orgId: 'org-1', isActive: false, templateId: TEMPLATE_ID,
+        id: RULE_ID, orgId: 'org-1', isActive: false, templateId: TEMPLATE_ID, targetType: 'org', targetId: 'org-1',
         overrideSettings: { conditions: [{ type: 'custom' }] },
       }],
     ];
@@ -241,7 +241,7 @@ describe('alert-template condition types (#2948)', () => {
     dbRef.current = [
       [{ partnerId: null }],
       [{
-        id: RULE_ID, orgId: 'org-1', isActive: true, templateId: TEMPLATE_ID,
+        id: RULE_ID, orgId: 'org-1', isActive: true, templateId: TEMPLATE_ID, targetType: 'org', targetId: 'org-1',
         overrideSettings: { conditions: [{ type: 'custom' }] },
       }],
       [{ id: RULE_ID, isActive: false }],

--- a/apps/api/src/routes/alertTemplates/rules.authz.test.ts
+++ b/apps/api/src/routes/alertTemplates/rules.authz.test.ts
@@ -54,6 +54,7 @@ function makeApp() {
 }
 
 const RULE_ID = '5d4c3b2a-1111-4222-8333-444455556666';
+const ALERTS_READ = 'alerts:read';
 const ALERTS_WRITE = 'alerts:write';
 
 describe('alert-template rules authz (Finding #6)', () => {
@@ -65,6 +66,20 @@ describe('alert-template rules authz (Finding #6)', () => {
       user: { id: 'u-1', name: 'Reed Only', email: 'reed@org.example' },
       partnerId: null, orgId: 'org-1', accessibleOrgIds: null, canAccessOrg: () => true,
     } as typeof authRef.current;
+  });
+
+  it.each([
+    '/alert-templates/rules',
+    `/alert-templates/rules/${RULE_ID}`,
+  ])('403 on GET %s without ALERTS_READ', async (path) => {
+    const res = await makeApp().request(path);
+    expect(res.status).toBe(403);
+  });
+
+  it('passes the rule list read gate when ALERTS_READ is granted', async () => {
+    grantedRef.current.add(ALERTS_READ);
+    const res = await makeApp().request('/alert-templates/rules');
+    expect(res.status).not.toBe(403);
   });
 
   it('403 on POST /alert-templates/rules without ALERTS_WRITE', async () => {

--- a/apps/api/src/routes/alertTemplates/rules.siteScope.test.ts
+++ b/apps/api/src/routes/alertTemplates/rules.siteScope.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+const { authRef, selectQueue, insertMock, updateMock, deleteMock, accessMock } = vi.hoisted(() => ({
+  authRef: { current: {} as any },
+  selectQueue: [] as unknown[][],
+  insertMock: vi.fn(),
+  updateMock: vi.fn(),
+  deleteMock: vi.fn(),
+  accessMock: vi.fn(),
+}));
+
+vi.mock('../../middleware/auth', () => ({
+  requireScope: () => async (c: any, next: any) => { c.set('auth', authRef.current); await next(); },
+  requirePermission: () => async (_c: any, next: any) => next(),
+  requireMfa: () => async (_c: any, next: any) => next(),
+}));
+vi.mock('../../db/schema', () => ({
+  organizations: { id: 'org.id', partnerId: 'org.partnerId' },
+  alertTemplates: { id: 'template.id', orgId: 'template.orgId', isBuiltIn: 'template.isBuiltIn' },
+  alertRules: {
+    id: 'rule.id', orgId: 'rule.orgId', partnerId: 'rule.partnerId', templateId: 'rule.templateId',
+    targetType: 'rule.targetType', targetId: 'rule.targetId', overrideSettings: 'rule.overrideSettings',
+    isActive: 'rule.isActive', name: 'rule.name', createdAt: 'rule.createdAt',
+  },
+}));
+vi.mock('../../db', () => {
+  const select = () => {
+    const chain: any = {
+      from: () => chain, leftJoin: () => chain, where: () => chain, orderBy: () => chain,
+      limit: () => chain,
+      then: (resolve: (value: unknown) => unknown) => Promise.resolve(selectQueue.shift() ?? []).then(resolve),
+    };
+    return chain;
+  };
+  const mutation = (spy: ReturnType<typeof vi.fn>, result: unknown[]) => {
+    const chain: any = {
+      values: (value: unknown) => { (spy as any)(value); return chain; },
+      set: (value: unknown) => { (spy as any)(value); return chain; },
+      where: () => chain,
+      returning: () => Promise.resolve(result),
+      then: (resolve: (value: unknown) => unknown) => Promise.resolve(undefined).then(resolve),
+    };
+    return chain;
+  };
+  return { db: {
+    select: vi.fn(select),
+    insert: vi.fn(() => mutation(insertMock, [{ id: 'rule-new', name: 'Rule', isActive: true }])),
+    update: vi.fn(() => mutation(updateMock, [{ id: 'rule-1', name: 'Rule', isActive: true }])),
+    delete: vi.fn(() => mutation(deleteMock, [])),
+  } };
+});
+vi.mock('./siteScope', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./siteScope')>();
+  return { ...actual, canAccessAlertRuleTargets: (...args: unknown[]) => accessMock(...args) };
+});
+vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
+vi.mock('../alerts/helpers', () => ({ retiredConditionReactivationError: vi.fn(async () => null) }));
+
+import { ruleRoutes } from './rules';
+
+const ORG_ID = '11111111-1111-4111-8111-111111111111';
+const TEMPLATE_ID = '22222222-2222-4222-8222-222222222222';
+const RULE_ID = '33333333-3333-4333-8333-333333333333';
+const DEVICE_ID = '44444444-4444-4444-8444-444444444444';
+
+function app() {
+  const instance = new Hono();
+  instance.route('/alert-templates', ruleRoutes);
+  return instance;
+}
+
+describe('legacy alert rule site boundary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    selectQueue.length = 0;
+    accessMock.mockResolvedValue(false);
+    authRef.current = {
+      scope: 'organization', orgId: ORG_ID, partnerId: null, allowedSiteIds: ['site-allowed'],
+      canAccessOrg: () => true, user: { id: 'user-1' },
+    };
+  });
+
+  it('rejects default all-org creation before template lookup or insertion', async () => {
+    const res = await app().request('/alert-templates/rules', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ templateId: TEMPLATE_ID, name: 'Rule' }),
+    });
+    expect(res.status).toBe(403);
+    expect(selectQueue).toHaveLength(0);
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  it('allows a validated device target and persists only that target', async () => {
+    accessMock.mockResolvedValue(true);
+    selectQueue.push([{ id: TEMPLATE_ID, name: 'Template' }]);
+    const res = await app().request('/alert-templates/rules', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ templateId: TEMPLATE_ID, name: 'Rule', targets: { deviceIds: [DEVICE_ID] } }),
+    });
+    expect(res.status).toBe(201);
+    expect(insertMock).toHaveBeenCalledWith(expect.objectContaining({ targetType: 'device', targetId: DEVICE_ID }));
+  });
+
+  it.each([
+    ['PATCH', `/alert-templates/rules/${RULE_ID}`, { name: 'Changed' }],
+    ['DELETE', `/alert-templates/rules/${RULE_ID}`, undefined],
+    ['POST', `/alert-templates/rules/${RULE_ID}/toggle`, { enabled: false }],
+  ] as const)('denies %s of a hidden persisted target before mutation', async (method, path, body) => {
+    selectQueue.push(
+      [{ partnerId: null }],
+      [{ id: RULE_ID, orgId: ORG_ID, name: 'Hidden', targetType: 'device', targetId: DEVICE_ID, isActive: true }],
+    );
+    const res = await app().request(path, {
+      method,
+      headers: body ? { 'Content-Type': 'application/json' } : undefined,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    expect(res.status).toBe(403);
+    expect(updateMock).not.toHaveBeenCalled();
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/routes/alertTemplates/rules.ts
+++ b/apps/api/src/routes/alertTemplates/rules.ts
@@ -11,9 +11,15 @@ import { getPagination } from '../../utils/pagination';
 import { PERMISSIONS } from '../../services/permissions';
 import { retiredConditionTypeError } from '../../services/alertConditions';
 import { retiredConditionReactivationError } from '../alerts/helpers';
+import {
+  canAccessAlertRuleTargets,
+  legacyRuleTarget,
+  persistedRuleTargets,
+} from './siteScope';
 
 export const ruleRoutes = new Hono();
 
+const requireAlertRead = requirePermission(PERMISSIONS.ALERTS_READ.resource, PERMISSIONS.ALERTS_READ.action);
 const requireAlertWrite = requirePermission(PERMISSIONS.ALERTS_WRITE.resource, PERMISSIONS.ALERTS_WRITE.action);
 
 // Dual-axis rule condition for this legacy org-pinned route (#2128): the org's
@@ -41,6 +47,7 @@ const PARTNER_WIDE_RULE_READONLY_HERE =
 ruleRoutes.get(
   '/rules',
   requireScope('organization', 'partner', 'system'),
+  requireAlertRead,
   zValidator('query', listRulesSchema),
   async (c) => {
     try {
@@ -143,6 +150,19 @@ ruleRoutes.post(
         return c.json({ error: createConditionTypeError }, 400);
       }
 
+      const requestedTarget = legacyRuleTarget(data.targets, orgId);
+      if (!await canAccessAlertRuleTargets(
+        auth,
+        orgId,
+        requestedTarget.targetType,
+        requestedTarget.targetType === 'all' || requestedTarget.targetType === 'org'
+          ? []
+          : [requestedTarget.targetId],
+        true,
+      )) {
+        return c.json({ error: 'Access to alert rule target denied' }, 403);
+      }
+
       // Verify template exists and is accessible
       const [template] = await db
         .select()
@@ -169,32 +189,14 @@ ruleRoutes.post(
       if (data.conditions) overrideSettings.conditions = data.conditions;
       if (data.cooldownMinutes !== undefined) overrideSettings.cooldownMinutes = data.cooldownMinutes;
 
-      // Determine target type and ID from targets object
-      const targets = data.targets as Record<string, unknown> | undefined;
-      let targetType = 'all';
-      let targetId = orgId; // default to org
-
-      if (targets) {
-        if (targets.deviceIds && Array.isArray(targets.deviceIds) && targets.deviceIds.length > 0) {
-          targetType = 'device';
-          targetId = targets.deviceIds[0];
-        } else if (targets.siteIds && Array.isArray(targets.siteIds) && targets.siteIds.length > 0) {
-          targetType = 'site';
-          targetId = targets.siteIds[0];
-        } else if (targets.scope === 'organization') {
-          targetType = 'org';
-          targetId = orgId;
-        }
-      }
-
       const [rule] = await db
         .insert(alertRules)
         .values({
           orgId,
           templateId: template.id,
           name: data.name.trim(),
-          targetType,
-          targetId,
+          targetType: requestedTarget.targetType,
+          targetId: requestedTarget.targetId,
           overrideSettings: Object.keys(overrideSettings).length > 0 ? overrideSettings : null,
           isActive: data.enabled ?? true,
         })
@@ -226,6 +228,7 @@ ruleRoutes.post(
 ruleRoutes.get(
   '/rules/:id',
   requireScope('organization', 'partner', 'system'),
+  requireAlertRead,
   async (c) => {
     try {
       const auth = c.get('auth');
@@ -283,6 +286,13 @@ ruleRoutes.patch(
 
       if (existing.orgId === null) {
         return c.json({ error: PARTNER_WIDE_RULE_READONLY_HERE }, 403);
+      }
+
+      const existingTarget = persistedRuleTargets(existing);
+      if (!await canAccessAlertRuleTargets(
+        auth, orgId, existingTarget.targetType, existingTarget.targetIds, true,
+      )) {
+        return c.json({ error: 'Access to alert rule target denied' }, 403);
       }
 
       if (Object.keys(updates).length === 0) {
@@ -369,6 +379,13 @@ ruleRoutes.delete(
         return c.json({ error: PARTNER_WIDE_RULE_READONLY_HERE }, 403);
       }
 
+      const existingTarget = persistedRuleTargets(existing);
+      if (!await canAccessAlertRuleTargets(
+        auth, orgId, existingTarget.targetType, existingTarget.targetIds, true,
+      )) {
+        return c.json({ error: 'Access to alert rule target denied' }, 403);
+      }
+
       await db.delete(alertRules).where(eq(alertRules.id, ruleId));
 
       writeRouteAudit(c, {
@@ -415,6 +432,13 @@ ruleRoutes.post(
 
       if (existing.orgId === null) {
         return c.json({ error: PARTNER_WIDE_RULE_READONLY_HERE }, 403);
+      }
+
+      const existingTarget = persistedRuleTargets(existing);
+      if (!await canAccessAlertRuleTargets(
+        auth, orgId, existingTarget.targetType, existingTarget.targetIds, true,
+      )) {
+        return c.json({ error: 'Access to alert rule target denied' }, 403);
       }
 
       // #2948 — same gate as PUT /alerts/rules. Without it this is the one-click

--- a/apps/api/src/routes/alertTemplates/siteScope.test.ts
+++ b/apps/api/src/routes/alertTemplates/siteScope.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { selectQueue } = vi.hoisted(() => ({ selectQueue: [] as unknown[][] }));
+vi.mock('../../middleware/auth', () => ({
+  siteAccessCheck: (allowed?: string[]) => (siteId?: string | null) =>
+    allowed === undefined || (!!siteId && allowed.includes(siteId)),
+}));
+vi.mock('../../db/schema', () => ({
+  alertRules: { templateId: 'rule.templateId', orgId: 'rule.orgId', targetType: 'rule.targetType', targetId: 'rule.targetId', overrideSettings: 'rule.overrideSettings' },
+  sites: { id: 'site.id', orgId: 'site.orgId' },
+  devices: { id: 'device.id', orgId: 'device.orgId', siteId: 'device.siteId' },
+  deviceGroups: { id: 'group.id', orgId: 'group.orgId', siteId: 'group.siteId' },
+}));
+vi.mock('../../db', () => {
+  const chain: any = {};
+  chain.from = () => chain;
+  chain.where = () => Promise.resolve(selectQueue.shift() ?? []);
+  return { db: { select: vi.fn(() => chain) } };
+});
+
+import {
+  canAccessAlertRuleTargets,
+  canAccessTemplateDependents,
+  legacyRuleTarget,
+} from './siteScope';
+
+const ORG_ID = '11111111-1111-4111-8111-111111111111';
+const ALLOWED_SITE = '22222222-2222-4222-8222-222222222222';
+const HIDDEN_SITE = '33333333-3333-4333-8333-333333333333';
+
+describe('alert-template site-scope helpers', () => {
+  beforeEach(() => { vi.clearAllMocks(); selectQueue.length = 0; });
+
+  it('normalizes legacy defaults and first concrete target deterministically', () => {
+    expect(legacyRuleTarget(undefined, ORG_ID)).toEqual({ targetType: 'all', targetId: ORG_ID });
+    expect(legacyRuleTarget({ scope: 'organization' }, ORG_ID)).toEqual({ targetType: 'org', targetId: ORG_ID });
+    expect(legacyRuleTarget({ deviceIds: ['device-a', 'device-b'], siteIds: ['site-a'] }, ORG_ID))
+      .toEqual({ targetType: 'device', targetId: 'device-a' });
+  });
+
+  it('denies org-wide, hidden, missing, and foreign targets while allowing an owned visible target', async () => {
+    const restricted = { allowedSiteIds: [ALLOWED_SITE] };
+    await expect(canAccessAlertRuleTargets(restricted as any, ORG_ID, 'org', [], true)).resolves.toBe(false);
+    selectQueue.push([{ id: 'device-a', orgId: ORG_ID, siteId: HIDDEN_SITE }]);
+    await expect(canAccessAlertRuleTargets(restricted as any, ORG_ID, 'device', ['device-a'], true)).resolves.toBe(false);
+    selectQueue.push([]);
+    await expect(canAccessAlertRuleTargets(restricted as any, ORG_ID, 'device', ['missing'], true)).resolves.toBe(false);
+    selectQueue.push([{ id: 'foreign', orgId: 'another-org', siteId: ALLOWED_SITE }]);
+    await expect(canAccessAlertRuleTargets(restricted as any, ORG_ID, 'device', ['foreign'], true)).resolves.toBe(false);
+    selectQueue.push([{ id: 'device-a', orgId: ORG_ID, siteId: ALLOWED_SITE }]);
+    await expect(canAccessAlertRuleTargets(restricted as any, ORG_ID, 'device', ['device-a'], true)).resolves.toBe(true);
+    await expect(canAccessAlertRuleTargets({ allowedSiteIds: undefined } as any, ORG_ID, 'org', [], true)).resolves.toBe(true);
+  });
+
+  it('rejects a shared template when any dependent rule resolves outside the grant', async () => {
+    selectQueue.push([
+      { targetType: 'device', targetId: 'visible-device', overrideSettings: null },
+      { targetType: 'device', targetId: 'hidden-device', overrideSettings: null },
+    ]);
+    selectQueue.push([{ id: 'visible-device', orgId: ORG_ID, siteId: ALLOWED_SITE }]);
+    selectQueue.push([{ id: 'hidden-device', orgId: ORG_ID, siteId: HIDDEN_SITE }]);
+    await expect(canAccessTemplateDependents(
+      { allowedSiteIds: [ALLOWED_SITE] } as any, 'template-a', ORG_ID,
+    )).resolves.toBe(false);
+  });
+});

--- a/apps/api/src/routes/alertTemplates/siteScope.ts
+++ b/apps/api/src/routes/alertTemplates/siteScope.ts
@@ -1,0 +1,99 @@
+import { and, eq, inArray } from 'drizzle-orm';
+import { db } from '../../db';
+import { alertRules, deviceGroups, devices, sites } from '../../db/schema';
+import { siteAccessCheck, type AuthContext } from '../../middleware/auth';
+
+type TargetType = 'all' | 'org' | 'site' | 'device' | 'group';
+
+function record(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+export function legacyRuleTarget(targets: unknown, orgId: string): {
+  targetType: TargetType;
+  targetId: string;
+} {
+  const value = record(targets);
+  const deviceIds = Array.isArray(value.deviceIds) ? value.deviceIds : [];
+  const siteIds = Array.isArray(value.siteIds) ? value.siteIds : [];
+  if (typeof deviceIds[0] === 'string' && deviceIds[0]) {
+    return { targetType: 'device', targetId: deviceIds[0] };
+  }
+  if (typeof siteIds[0] === 'string' && siteIds[0]) {
+    return { targetType: 'site', targetId: siteIds[0] };
+  }
+  if (value.scope === 'organization') return { targetType: 'org', targetId: orgId };
+  return { targetType: 'all', targetId: orgId };
+}
+
+export function persistedRuleTargets(rule: {
+  targetType: string;
+  targetId: string;
+  overrideSettings?: unknown;
+}): { targetType: string; targetIds: string[] } {
+  const overrides = record(rule.overrideSettings);
+  const storedTargets = record(overrides.targets);
+  const targetType = typeof storedTargets.type === 'string' ? storedTargets.type : rule.targetType;
+  const ids = new Set<string>();
+  if (targetType !== 'all' && targetType !== 'org' && rule.targetId) ids.add(rule.targetId);
+  if (Array.isArray(storedTargets.ids)) {
+    for (const id of storedTargets.ids) if (typeof id === 'string' && id) ids.add(id);
+  }
+  if (Array.isArray(overrides.targetIds)) {
+    for (const id of overrides.targetIds) if (typeof id === 'string' && id) ids.add(id);
+  }
+  return { targetType, targetIds: [...ids] };
+}
+
+export async function canAccessAlertRuleTargets(
+  auth: Pick<AuthContext, 'allowedSiteIds'>,
+  orgId: string,
+  targetType: string,
+  targetIds: string[],
+  validateOwnership = true,
+): Promise<boolean> {
+  const restricted = auth.allowedSiteIds !== undefined;
+  if (!restricted && !validateOwnership) return true;
+  if (targetType === 'all' || targetType === 'org') return !restricted;
+
+  const ids = [...new Set(targetIds.filter(Boolean))];
+  if (ids.length === 0) return false;
+  let rows: Array<{ id: string; orgId: string; siteId?: string | null }>;
+  if (targetType === 'site') {
+    rows = await db.select({ id: sites.id, orgId: sites.orgId })
+      .from(sites).where(and(inArray(sites.id, ids), eq(sites.orgId, orgId)));
+  } else if (targetType === 'device') {
+    rows = await db.select({ id: devices.id, orgId: devices.orgId, siteId: devices.siteId })
+      .from(devices).where(and(inArray(devices.id, ids), eq(devices.orgId, orgId)));
+  } else if (targetType === 'group') {
+    rows = await db.select({ id: deviceGroups.id, orgId: deviceGroups.orgId, siteId: deviceGroups.siteId })
+      .from(deviceGroups).where(and(inArray(deviceGroups.id, ids), eq(deviceGroups.orgId, orgId)));
+  } else {
+    return false;
+  }
+  if (rows.length !== ids.length || rows.some((row) => row.orgId !== orgId)) return false;
+  if (!restricted) return true;
+  const canAccessSite = siteAccessCheck(auth.allowedSiteIds);
+  return rows.every((row) => canAccessSite(targetType === 'site' ? row.id : row.siteId));
+}
+
+/** Every rule consuming a mutable template must remain inside the editor's grant. */
+export async function canAccessTemplateDependents(
+  auth: Pick<AuthContext, 'allowedSiteIds'>,
+  templateId: string,
+  orgId: string,
+): Promise<boolean> {
+  if (auth.allowedSiteIds === undefined) return true;
+  const rules = await db.select({
+    targetType: alertRules.targetType,
+    targetId: alertRules.targetId,
+    overrideSettings: alertRules.overrideSettings,
+  }).from(alertRules).where(and(eq(alertRules.templateId, templateId), eq(alertRules.orgId, orgId)));
+  for (const rule of rules) {
+    const target = persistedRuleTargets(rule);
+    if (!await canAccessAlertRuleTargets(auth, orgId, target.targetType, target.targetIds, true)) return false;
+  }
+  return true;
+}

--- a/apps/api/src/routes/alertTemplates/templates.authz.test.ts
+++ b/apps/api/src/routes/alertTemplates/templates.authz.test.ts
@@ -54,6 +54,7 @@ function makeApp() {
 }
 
 const TEMPLATE_ID = '5d4c3b2a-1111-4222-8333-444455556666';
+const ALERTS_READ = 'alerts:read';
 const ALERTS_WRITE = 'alerts:write';
 
 describe('alert templates authz (Finding #6)', () => {
@@ -65,6 +66,21 @@ describe('alert templates authz (Finding #6)', () => {
       user: { id: 'u-1', name: 'Reed Only', email: 'reed@org.example' },
       partnerId: null, orgId: 'org-1', accessibleOrgIds: null, canAccessOrg: () => true,
     } as typeof authRef.current;
+  });
+
+  it.each([
+    '/alert-templates/templates',
+    '/alert-templates/templates/built-in',
+    `/alert-templates/templates/${TEMPLATE_ID}`,
+  ])('403 on GET %s without ALERTS_READ', async (path) => {
+    const res = await makeApp().request(path);
+    expect(res.status).toBe(403);
+  });
+
+  it('passes the template list read gate when ALERTS_READ is granted', async () => {
+    grantedRef.current.add(ALERTS_READ);
+    const res = await makeApp().request('/alert-templates/templates');
+    expect(res.status).not.toBe(403);
   });
 
   it('403 on POST /alert-templates/templates without ALERTS_WRITE', async () => {

--- a/apps/api/src/routes/alertTemplates/templates.siteScope.test.ts
+++ b/apps/api/src/routes/alertTemplates/templates.siteScope.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+const { authRef, updateMock, deleteMock, dependentAccessMock } = vi.hoisted(() => ({
+  authRef: { current: {} as any },
+  updateMock: vi.fn(),
+  deleteMock: vi.fn(),
+  dependentAccessMock: vi.fn(),
+}));
+
+vi.mock('../../middleware/auth', () => ({
+  requireScope: () => async (c: any, next: any) => { c.set('auth', authRef.current); await next(); },
+  requirePermission: () => async (_c: any, next: any) => next(),
+  requireMfa: () => async (_c: any, next: any) => next(),
+}));
+vi.mock('../../db/schema', () => ({ alertTemplates: {
+  id: 'template.id', orgId: 'template.orgId', partnerId: 'template.partnerId', isBuiltIn: 'template.isBuiltIn',
+} }));
+vi.mock('../../db', () => {
+  const existing = {
+    id: '22222222-2222-4222-8222-222222222222',
+    orgId: '11111111-1111-4111-8111-111111111111', partnerId: null, isBuiltIn: false, name: 'Shared',
+  };
+  const selectChain: any = {};
+  selectChain.from = () => selectChain;
+  selectChain.where = () => selectChain;
+  selectChain.limit = () => Promise.resolve([existing]);
+  const mutation = (spy: ReturnType<typeof vi.fn>) => {
+    const chain: any = {
+      set: (value: unknown) => { (spy as any)(value); return chain; },
+      where: () => chain,
+      returning: () => Promise.resolve([existing]),
+      then: (resolve: (value: unknown) => unknown) => Promise.resolve(undefined).then(resolve),
+    };
+    return chain;
+  };
+  return { db: {
+    select: vi.fn(() => selectChain),
+    update: vi.fn(() => mutation(updateMock)),
+    delete: vi.fn(() => mutation(deleteMock)),
+  } };
+});
+vi.mock('./siteScope', () => ({
+  canAccessTemplateDependents: (...args: unknown[]) => dependentAccessMock(...args),
+}));
+vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
+
+import { templateRoutes } from './templates';
+
+const ORG_ID = '11111111-1111-4111-8111-111111111111';
+const TEMPLATE_ID = '22222222-2222-4222-8222-222222222222';
+
+function app() {
+  const instance = new Hono();
+  instance.route('/alert-templates', templateRoutes);
+  return instance;
+}
+
+describe('alert template dependent-rule site boundary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dependentAccessMock.mockResolvedValue(false);
+    authRef.current = {
+      scope: 'organization', orgId: ORG_ID, partnerId: null, allowedSiteIds: ['site-allowed'],
+      canAccessOrg: (id: string) => id === ORG_ID, user: { id: 'user-1' },
+    };
+  });
+
+  it('rejects editing a template consumed by a hidden rule before update', async () => {
+    const res = await app().request(`/alert-templates/templates/${TEMPLATE_ID}`, {
+      method: 'PATCH', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ conditions: { threshold: 99 } }),
+    });
+    expect(res.status).toBe(403);
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects deleting a template consumed by a hidden rule before delete', async () => {
+    const res = await app().request(`/alert-templates/templates/${TEMPLATE_ID}`, { method: 'DELETE' });
+    expect(res.status).toBe(403);
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  it('allows an update when every dependent rule remains visible', async () => {
+    dependentAccessMock.mockResolvedValue(true);
+    const res = await app().request(`/alert-templates/templates/${TEMPLATE_ID}`, {
+      method: 'PATCH', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ severity: 'high' }),
+    });
+    expect(res.status).toBe(200);
+    expect(updateMock).toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/routes/alertTemplates/templates.ts
+++ b/apps/api/src/routes/alertTemplates/templates.ts
@@ -14,9 +14,11 @@ import {
   PARTNER_WIDE_WRITE_DENIED_MESSAGE,
   canManagePartnerWidePolicies,
 } from '../../services/partnerWideAccess';
+import { canAccessTemplateDependents } from './siteScope';
 
 export const templateRoutes = new Hono();
 
+const requireAlertRead = requirePermission(PERMISSIONS.ALERTS_READ.resource, PERMISSIONS.ALERTS_READ.action);
 const requireAlertWrite = requirePermission(PERMISSIONS.ALERTS_WRITE.resource, PERMISSIONS.ALERTS_WRITE.action);
 
 // Partner-wide means `partner_id = X AND org_id IS NULL` — NEVER a bare
@@ -106,6 +108,7 @@ export function canWriteTemplate(
 templateRoutes.get(
   '/templates',
   requireScope('organization', 'partner', 'system'),
+  requireAlertRead,
   zValidator('query', listTemplatesSchema),
   async (c) => {
     try {
@@ -164,6 +167,7 @@ templateRoutes.get(
 templateRoutes.get(
   '/templates/built-in',
   requireScope('organization', 'partner', 'system'),
+  requireAlertRead,
   zValidator('query', listTemplatesSchema),
   async (c) => {
     try {
@@ -317,6 +321,7 @@ templateRoutes.post(
 templateRoutes.get(
   '/templates/:id',
   requireScope('organization', 'partner', 'system'),
+  requireAlertRead,
   async (c) => {
     try {
       const auth = c.get('auth');
@@ -369,6 +374,13 @@ templateRoutes.patch(
       const writable = canWriteTemplate(auth, existing);
       if (!writable.ok) {
         return c.json({ error: writable.error }, writable.status);
+      }
+
+      if (auth.allowedSiteIds !== undefined && (
+        existing.orgId === null
+        || !await canAccessTemplateDependents(auth, existing.id, existing.orgId)
+      )) {
+        return c.json({ error: 'Access to one or more dependent alert rule targets denied' }, 403);
       }
 
       const updateConditionTypeError = retiredConditionTypeError(updates.conditions);
@@ -433,6 +445,13 @@ templateRoutes.delete(
       const writable = canWriteTemplate(auth, existing);
       if (!writable.ok) {
         return c.json({ error: writable.error }, writable.status);
+      }
+
+      if (auth.allowedSiteIds !== undefined && (
+        existing.orgId === null
+        || !await canAccessTemplateDependents(auth, existing.id, existing.orgId)
+      )) {
+        return c.json({ error: 'Access to one or more dependent alert rule targets denied' }, 403);
       }
 
       await db

--- a/apps/api/src/routes/automations.test.ts
+++ b/apps/api/src/routes/automations.test.ts
@@ -6,9 +6,18 @@ import { automationRoutes, automationWebhookRoutes } from './automations';
 const {
   resolveAutomationReferencesForOwnerMock,
   replaceAutomationResourceBindingsMock,
+  projectAutomationRunsToSitesMock,
+  scanProjectedAutomationRunsMock,
 } = vi.hoisted(() => ({
   resolveAutomationReferencesForOwnerMock: vi.fn(),
   replaceAutomationResourceBindingsMock: vi.fn(),
+  projectAutomationRunsToSitesMock: vi.fn(),
+  scanProjectedAutomationRunsMock: vi.fn(),
+}));
+
+vi.mock('../services/automationReadProjection', () => ({
+  projectAutomationRunsToSites: projectAutomationRunsToSitesMock,
+  scanProjectedAutomationRuns: scanProjectedAutomationRunsMock,
 }));
 
 vi.mock('../jobs/automationWorker', () => ({
@@ -115,7 +124,7 @@ vi.mock('../db/schema', () => ({
 function deviceResultsSelectMock(rows: any[]) {
   return {
     from: vi.fn().mockReturnValue({
-      leftJoin: vi.fn().mockReturnValue({
+      innerJoin: vi.fn().mockReturnValue({
         where: vi.fn().mockReturnValue({
           orderBy: vi.fn().mockResolvedValue(rows),
         }),
@@ -135,10 +144,12 @@ const capturedScriptExecWhere: unknown[] = [];
 function scriptExecutionsSelectMock(rows: any[]) {
   return {
     from: vi.fn().mockReturnValue({
-      leftJoin: vi.fn().mockReturnValue({
-        where: vi.fn((condition: unknown) => {
-          capturedScriptExecWhere.push(condition);
-          return { orderBy: vi.fn().mockResolvedValue(rows) };
+      innerJoin: vi.fn().mockReturnValue({
+        leftJoin: vi.fn().mockReturnValue({
+          where: vi.fn((condition: unknown) => {
+            capturedScriptExecWhere.push(condition);
+            return { orderBy: vi.fn().mockResolvedValue(rows) };
+          }),
         }),
       }),
     }),
@@ -201,6 +212,10 @@ describe('automations routes', () => {
 	      outOfScopeDeviceIds: [],
 	      unbounded: false,
 	    } as any);
+	    projectAutomationRunsToSitesMock.mockImplementation(async (runs: unknown[]) => runs);
+	    scanProjectedAutomationRunsMock.mockResolvedValue({
+	      rows: [], total: 0, statusCounts: { completed: 0, failed: 0, partial: 0 },
+	    });
 	    delete process.env.AUTOMATION_WEBHOOK_ALLOW_LEGACY_SECRET;
 	    delete process.env.AUTOMATION_WEBHOOK_ALLOW_LOCAL_REPLAY_FALLBACK;
 	    vi.mocked(getRedis).mockReturnValue(null);
@@ -254,6 +269,71 @@ describe('automations routes', () => {
     const body = await res.json();
     expect(body.data).toHaveLength(2);
     expect(body.pagination.total).toBe(2);
+  });
+
+  it('omits out-of-scope automation definitions and computes pagination from visible rows', async () => {
+    mockState.permissions = { allowedSiteIds: ['site-allowed'] };
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          orderBy: vi.fn().mockReturnValue({
+            limit: vi.fn().mockReturnValue({
+              offset: vi.fn().mockResolvedValue([
+                { id: '11111111-1111-4111-8111-111111111111', name: 'Visible', orgId: 'org-123' },
+                { id: '22222222-2222-4222-8222-222222222222', name: 'Hidden', orgId: 'org-123' },
+              ]),
+            }),
+          }),
+        }),
+      }),
+    } as any);
+    vi.mocked(checkAutomationTargetsWithinSiteScope)
+      .mockResolvedValueOnce({ ok: true, outOfScopeDeviceIds: [], unbounded: false } as any)
+      .mockResolvedValueOnce({ ok: false, outOfScopeDeviceIds: ['hidden'], unbounded: false } as any);
+
+    const res = await app.request('/automations?limit=10&page=1', {
+      headers: { Authorization: 'Bearer valid-token' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      data: [{ id: '11111111-1111-4111-8111-111111111111', name: 'Visible' }],
+      pagination: { total: 1 },
+    });
+  });
+
+  it('scans beyond a full hidden definition page to preserve visible pagination', async () => {
+    mockState.permissions = { allowedSiteIds: ['site-allowed'] };
+    const queryPage = (rows: unknown[]) => ({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          orderBy: vi.fn().mockReturnValue({
+            limit: vi.fn().mockReturnValue({ offset: vi.fn().mockResolvedValue(rows) }),
+          }),
+        }),
+      }),
+    });
+    const hidden = Array.from({ length: 100 }, (_, index) => ({
+      id: `hidden-${index}`, name: 'Hidden', orgId: 'org-123',
+    }));
+    vi.mocked(db.select)
+      .mockReturnValueOnce(queryPage(hidden) as any)
+      .mockReturnValueOnce(queryPage([{
+        id: '11111111-1111-4111-8111-111111111111', name: 'Visible', orgId: 'org-123',
+      }]) as any);
+    vi.mocked(checkAutomationTargetsWithinSiteScope).mockImplementation(async (automation: any) => ({
+      ok: automation.name === 'Visible', outOfScopeDeviceIds: [], unbounded: false,
+    } as any));
+
+    const res = await app.request('/automations?limit=10&page=1', {
+      headers: { Authorization: 'Bearer valid-token' },
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      data: [{ id: '11111111-1111-4111-8111-111111111111' }],
+      pagination: { total: 1 },
+    });
+    expect(db.select).toHaveBeenCalledTimes(2);
   });
 
   // The web list renders the "Managed by AI agent" badge and its edit lock off
@@ -345,6 +425,130 @@ describe('automations routes', () => {
     expect(body.id).toBe('11111111-1111-4111-8111-111111111111');
     expect(body.recentRuns).toHaveLength(1);
     expect(body.statistics.totalRuns).toBe(3);
+  });
+
+  it('returns opaque not-found for an automation definition whose targets escape site scope', async () => {
+    mockState.permissions = { allowedSiteIds: ['site-allowed'] };
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([{
+            id: '11111111-1111-4111-8111-111111111111',
+            name: 'Hidden-target automation',
+            orgId: 'org-123',
+          }]),
+        }),
+      }),
+    } as any);
+    vi.mocked(checkAutomationTargetsWithinSiteScope).mockResolvedValueOnce({
+      ok: false,
+      outOfScopeDeviceIds: ['device-hidden'],
+      unbounded: false,
+    } as any);
+
+    const res = await app.request('/automations/11111111-1111-4111-8111-111111111111', {
+      headers: { Authorization: 'Bearer valid-token' },
+    });
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'Automation not found' });
+    expect(db.select).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns only the restricted run projection and its visible device output', async () => {
+    mockState.permissions = { allowedSiteIds: ['site-allowed'] };
+    const runId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+    const safeRun = {
+      id: runId,
+      automationId: '11111111-1111-4111-8111-111111111111',
+      status: 'completed',
+      devicesTargeted: 1,
+      devicesSucceeded: 1,
+      devicesFailed: 0,
+      devicesCancelled: 0,
+      startedAt: new Date('2026-09-05T00:00:10Z'),
+      completedAt: new Date('2026-09-05T00:00:20Z'),
+      logs: [{ level: 'info', message: 'visible-log', deviceId: 'device-visible' }],
+    };
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([{ ...safeRun, devicesTargeted: 2 }]) }) }),
+      } as any)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([{
+          id: safeRun.automationId, name: 'Visible automation', orgId: 'org-123',
+        }]) }) }),
+      } as any)
+      .mockReturnValueOnce(deviceResultsSelectMock([{
+        deviceId: 'device-visible', status: 'success', output: 'visible-output',
+        hostname: 'visible-host', displayName: null, startedAt: safeRun.startedAt, completedAt: safeRun.completedAt,
+      }]))
+      .mockReturnValueOnce(scriptExecutionsSelectMock([]));
+    projectAutomationRunsToSitesMock.mockResolvedValueOnce([safeRun]);
+
+    const res = await app.request(`/automations/runs/${runId}`, {
+      headers: { Authorization: 'Bearer valid-token' },
+    });
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body).toMatchObject({
+      status: 'success', devicesTargeted: 1, devicesSucceeded: 1, devicesFailed: 0,
+      startedAt: '2026-09-05T00:00:10.000Z', completedAt: '2026-09-05T00:00:20.000Z',
+      logs: ['[info] visible-log'],
+      deviceResults: [{ deviceId: 'device-visible', output: 'visible-output' }],
+    });
+    expect(JSON.stringify(body)).not.toContain('hidden');
+  });
+
+  it('returns opaque not-found for a run with no visible child', async () => {
+    mockState.permissions = { allowedSiteIds: ['site-allowed'] };
+    const runId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([{
+          id: runId, automationId: '11111111-1111-4111-8111-111111111111', status: 'failed', logs: [],
+        }]) }) }),
+      } as any)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([{
+          id: '11111111-1111-4111-8111-111111111111', name: 'Automation', orgId: 'org-123',
+        }]) }) }),
+      } as any);
+    projectAutomationRunsToSitesMock.mockResolvedValueOnce([]);
+
+    const res = await app.request(`/automations/runs/${runId}`, {
+      headers: { Authorization: 'Bearer valid-token' },
+    });
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'Automation run not found' });
+    expect(db.select).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses the exact visible scan for restricted history pagination and status', async () => {
+    mockState.permissions = { allowedSiteIds: ['site-allowed'] };
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([{
+        id: '11111111-1111-4111-8111-111111111111', name: 'Automation', orgId: 'org-123',
+      }]) }) }),
+    } as any);
+    scanProjectedAutomationRunsMock.mockResolvedValueOnce({
+      rows: [{ id: 'visible-after-hidden-page', status: 'failed', logs: [] }],
+      total: 101,
+      statusCounts: { completed: 0, failed: 101, partial: 0 },
+    });
+
+    const res = await app.request('/automations/11111111-1111-4111-8111-111111111111/runs?page=2&limit=100&status=failed', {
+      headers: { Authorization: 'Bearer valid-token' },
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      data: [{ id: 'visible-after-hidden-page', status: 'failed' }],
+      pagination: { page: 2, limit: 100, total: 101 },
+    });
+    expect(scanProjectedAutomationRunsMock).toHaveBeenCalledWith({
+      automationId: '11111111-1111-4111-8111-111111111111',
+      allowedSiteIds: ['site-allowed'], offset: 100, limit: 100, status: 'failed',
+    });
   });
 
   it('returns 404 without querying the database for a malformed automation id', async () => {

--- a/apps/api/src/routes/automations.ts
+++ b/apps/api/src/routes/automations.ts
@@ -46,6 +46,7 @@ import {
   managedAutomationOwnerIsLive,
 } from '../services/aiAgents/managedAutomation';
 import { UUID_REGEX } from '../utils/uuid';
+import { projectAutomationRunsToSites, scanProjectedAutomationRuns } from '../services/automationReadProjection';
 
 export const automationRoutes = new Hono();
 export const automationWebhookRoutes = new Hono();
@@ -399,6 +400,11 @@ function shapeAutomationForResponse(automation: typeof automations.$inferSelect)
   };
 }
 
+function shapeRestrictedAutomationForResponse(automation: typeof automations.$inferSelect) {
+  const { runCount: _runCount, lastRunAt: _lastRunAt, ...safe } = shapeAutomationForResponse(automation);
+  return safe;
+}
+
 function toRunStatus(status: (typeof automationRuns.$inferSelect)['status']) {
   if (status === 'completed') return 'success';
   return status;
@@ -460,7 +466,12 @@ function takePreview(
  * context cannot see a partner-wide script (`scripts.org_id IS NULL`), so the
  * UI falls back to a generic label rather than dropping the output row.
  */
-async function fetchRunScriptExecutions(runId: string) {
+async function fetchRunScriptExecutions(runId: string, auth: AuthContext, allowedSiteIds?: string[]) {
+  const conditions: SQL[] = [eq(scriptExecutions.automationRunId, runId)];
+  const orgCondition = auth.orgCondition?.(scriptExecutions.orgId);
+  if (orgCondition) conditions.push(orgCondition);
+  if (allowedSiteIds !== undefined) conditions.push(inArray(devices.siteId, allowedSiteIds));
+
   const rows = await db
     .select({
       executionId: scriptExecutions.id,
@@ -476,8 +487,9 @@ async function fetchRunScriptExecutions(runId: string) {
       createdAt: scriptExecutions.createdAt,
     })
     .from(scriptExecutions)
+    .innerJoin(devices, eq(devices.id, scriptExecutions.deviceId))
     .leftJoin(scripts, eq(scripts.id, scriptExecutions.scriptId))
-    .where(eq(scriptExecutions.automationRunId, runId))
+    .where(and(...conditions))
     .orderBy(scriptExecutions.createdAt);
 
   const byDevice = new Map<string, RunScriptResult[]>();
@@ -512,7 +524,9 @@ async function fetchRunScriptExecutions(runId: string) {
  * automation_run_device_results (org_id = device's org) already scopes rows to
  * the caller's tenancy, so no extra org filter is needed here.
  */
-async function fetchRunDeviceResults(runId: string) {
+async function fetchRunDeviceResults(runId: string, auth: AuthContext, allowedSiteIds?: string[]) {
+  const conditions: SQL[] = [eq(automationRunDeviceResults.runId, runId)];
+  if (allowedSiteIds !== undefined) conditions.push(inArray(devices.siteId, allowedSiteIds));
   const [rows, scriptExecutionsByDevice] = await Promise.all([
     db
       .select({
@@ -526,10 +540,10 @@ async function fetchRunDeviceResults(runId: string) {
         displayName: devices.displayName,
       })
       .from(automationRunDeviceResults)
-      .leftJoin(devices, eq(devices.id, automationRunDeviceResults.deviceId))
-      .where(eq(automationRunDeviceResults.runId, runId))
+      .innerJoin(devices, eq(devices.id, automationRunDeviceResults.deviceId))
+      .where(and(...conditions))
       .orderBy(desc(automationRunDeviceResults.startedAt)),
-    fetchRunScriptExecutions(runId),
+    fetchRunScriptExecutions(runId, auth, allowedSiteIds),
   ]);
 
   return rows.map((row) => {
@@ -612,6 +626,7 @@ automationRoutes.get(
   zValidator('query', listAutomationsSchema),
   async (c) => {
     const auth = c.get('auth');
+    const permissions = c.get('permissions') as UserPermissions | undefined;
     const query = c.req.valid('query');
     const { page, limit, offset } = getPagination(query);
 
@@ -663,22 +678,54 @@ automationRoutes.get(
 
     const whereCondition = conditions.length > 0 ? and(...conditions) : undefined;
 
-    const countResult = await db
-      .select({ count: sql<number>`count(*)` })
-      .from(automations)
-      .where(whereCondition);
-    const total = Number(countResult[0]?.count ?? 0);
+    let rows: Array<typeof automations.$inferSelect>;
+    let total: number;
+    if (permissions?.allowedSiteIds !== undefined) {
+      const scanSize = 100;
+      let databaseOffset = 0;
+      total = 0;
+      rows = [];
+      while (true) {
+        const candidates = await db
+          .select()
+          .from(automations)
+          .where(whereCondition)
+          .orderBy(desc(automations.updatedAt), desc(automations.id))
+          .limit(scanSize)
+          .offset(databaseOffset);
+        if (candidates.length === 0) break;
+        // Dynamic/JSON targets require the canonical resolver. Keep resolution
+        // sequential and batch-bounded so a large definition catalog cannot
+        // fan out an unbounded Promise.all against PostgreSQL.
+        for (const automation of candidates) {
+          const check = await checkAutomationTargetsWithinSiteScope(automation, permissions);
+          if (!check.ok) continue;
+          if (total >= offset && rows.length < limit) rows.push(automation);
+          total += 1;
+        }
+        databaseOffset += candidates.length;
+        if (candidates.length < scanSize) break;
+      }
+    } else {
+      const countResult = await db
+        .select({ count: sql<number>`count(*)` })
+        .from(automations)
+        .where(whereCondition);
+      total = Number(countResult[0]?.count ?? 0);
 
-    const rows = await db
-      .select()
-      .from(automations)
-      .where(whereCondition)
-      .orderBy(desc(automations.updatedAt), desc(automations.id))
-      .limit(limit)
-      .offset(offset);
+      rows = await db
+        .select()
+        .from(automations)
+        .where(whereCondition)
+        .orderBy(desc(automations.updatedAt), desc(automations.id))
+        .limit(limit)
+        .offset(offset);
+    }
 
     return c.json({
-      data: rows.map(shapeAutomationForResponse),
+      data: rows.map((automation) => permissions?.allowedSiteIds === undefined
+        ? shapeAutomationForResponse(automation)
+        : shapeRestrictedAutomationForResponse(automation)),
       pagination: { page, limit, total },
     });
   },
@@ -691,6 +738,7 @@ automationRoutes.get(
   requireValidRunId,
   async (c) => {
     const auth = c.get('auth');
+    const permissions = c.get('permissions') as UserPermissions | undefined;
     const runId = c.req.param('runId')!;
 
     const [run] = await db
@@ -723,11 +771,14 @@ automationRoutes.get(
         return c.json({ error: 'Automation run not found' }, 404);
       }
 
+      const [visibleRun] = await projectAutomationRunsToSites([run], permissions?.allowedSiteIds);
+      if (!visibleRun) return c.json({ error: 'Automation run not found' }, 404);
+
       return c.json({
-        ...run,
-        status: toRunStatus(run.status),
-        logs: serializeRunLogs(run.logs),
-        deviceResults: await fetchRunDeviceResults(run.id),
+        ...visibleRun,
+        status: toRunStatus(visibleRun.status),
+        logs: serializeRunLogs(visibleRun.logs),
+        deviceResults: await fetchRunDeviceResults(run.id, auth, permissions?.allowedSiteIds),
         automation: null,
         configPolicyId: run.configPolicyId,
         configItemName: run.configItemName,
@@ -739,11 +790,14 @@ automationRoutes.get(
       return c.json({ error: 'Automation run not found' }, 404);
     }
 
+    const [visibleRun] = await projectAutomationRunsToSites([run], permissions?.allowedSiteIds);
+    if (!visibleRun) return c.json({ error: 'Automation run not found' }, 404);
+
     return c.json({
-      ...run,
-      status: toRunStatus(run.status),
-      logs: serializeRunLogs(run.logs),
-      deviceResults: await fetchRunDeviceResults(run.id),
+      ...visibleRun,
+      status: toRunStatus(visibleRun.status),
+      logs: serializeRunLogs(visibleRun.logs),
+      deviceResults: await fetchRunDeviceResults(run.id, auth, permissions?.allowedSiteIds),
       automation: {
         id: automation.id,
         name: automation.name,
@@ -891,6 +945,7 @@ automationRoutes.get(
   requireValidAutomationId,
   async (c) => {
     const auth = c.get('auth');
+    const permissions = c.get('permissions') as UserPermissions | undefined;
     const automationId = c.req.param('id')!;
 
     if (automationId === 'runs') {
@@ -900,6 +955,36 @@ automationRoutes.get(
     const automation = await getAutomationWithOrgCheck(automationId, auth);
     if (!automation) {
       return c.json({ error: 'Automation not found' }, 404);
+    }
+
+    if (permissions?.allowedSiteIds !== undefined) {
+      const siteCheck = await checkAutomationTargetsWithinSiteScope(automation, permissions);
+      if (!siteCheck.ok) return c.json({ error: 'Automation not found' }, 404);
+    }
+
+    if (permissions?.allowedSiteIds !== undefined) {
+      const scan = await scanProjectedAutomationRuns({
+        automationId,
+        allowedSiteIds: permissions.allowedSiteIds,
+        limit: 10,
+      });
+      const stats = {
+        totalRuns: scan.total,
+        completedRuns: scan.statusCounts.completed,
+        failedRuns: scan.statusCounts.failed,
+        partialRuns: scan.statusCounts.partial,
+      };
+      return c.json({
+        ...shapeAutomationForResponse(automation),
+        runCount: scan.total,
+        lastRunAt: scan.rows[0]?.startedAt ?? null,
+        recentRuns: scan.rows.map((run) => ({
+          ...run,
+          status: toRunStatus(run.status),
+          logs: serializeRunLogs(run.logs),
+        })),
+        statistics: stats,
+      });
     }
 
     const recentRuns = await db
@@ -944,6 +1029,7 @@ automationRoutes.get(
   zValidator('query', listRunsSchema),
   async (c) => {
     const auth = c.get('auth');
+    const permissions = c.get('permissions') as UserPermissions | undefined;
     const automationId = c.req.param('id')!;
     const query = c.req.valid('query');
     const { page, limit, offset } = getPagination(query);
@@ -953,27 +1039,49 @@ automationRoutes.get(
       return c.json({ error: 'Automation not found' }, 404);
     }
 
+    if (permissions?.allowedSiteIds !== undefined) {
+      const siteCheck = await checkAutomationTargetsWithinSiteScope(automation, permissions);
+      if (!siteCheck.ok) return c.json({ error: 'Automation not found' }, 404);
+    }
+
     const conditions: SQL<unknown>[] = [eq(automationRuns.automationId, automationId)];
 
-    if (query.status) {
+    // Restricted callers' status is recomputed from visible child rows below;
+    // filtering on the stored org-wide status would both leak a hidden-device
+    // outcome and return rows under a contradictory status filter.
+    if (query.status && permissions?.allowedSiteIds === undefined) {
       conditions.push(eq(automationRuns.status, query.status));
     }
 
     const whereCondition = and(...conditions);
 
-    const countResult = await db
-      .select({ count: sql<number>`count(*)` })
-      .from(automationRuns)
-      .where(whereCondition);
-    const total = Number(countResult[0]?.count ?? 0);
+    let rows: Array<typeof automationRuns.$inferSelect>;
+    let total: number;
+    if (permissions?.allowedSiteIds !== undefined) {
+      const scan = await scanProjectedAutomationRuns({
+        automationId,
+        allowedSiteIds: permissions.allowedSiteIds,
+        offset,
+        limit,
+        status: query.status,
+      });
+      total = scan.total;
+      rows = scan.rows;
+    } else {
+      const countResult = await db
+        .select({ count: sql<number>`count(*)` })
+        .from(automationRuns)
+        .where(whereCondition);
+      total = Number(countResult[0]?.count ?? 0);
 
-    const rows = await db
-      .select()
-      .from(automationRuns)
-      .where(whereCondition)
-      .orderBy(desc(automationRuns.startedAt), desc(automationRuns.id))
-      .limit(limit)
-      .offset(offset);
+      rows = await db
+        .select()
+        .from(automationRuns)
+        .where(whereCondition)
+        .orderBy(desc(automationRuns.startedAt), desc(automationRuns.id))
+        .limit(limit)
+        .offset(offset);
+    }
 
     return c.json({
       data: rows.map((run) => ({

--- a/apps/api/src/services/aiToolsFleet.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsFleet.siteScope.test.ts
@@ -350,16 +350,30 @@ describe('SR5-05 manage_automations — target site scoping', () => {
     expect(JSON.parse(r).automation.id).toBe('a1');
   });
 
+  it('get omits org-wide run metadata for a restricted caller', async () => {
+    mockCheck.mockResolvedValue({ ok: true, unbounded: false, outOfScopeDeviceIds: [] });
+    mockDb.select.mockReturnValue({
+      from: () => ({ where: () => ({ limit: () => Promise.resolve([{
+        ...autoRow, runCount: 99, lastRunAt: new Date('2026-09-05T00:00:00Z'),
+      }]) }) }),
+    });
+    const r = await handlerFor('manage_automations')({ action: 'get', automationId: 'a1' }, makeAuth(['site-A']));
+    expect(JSON.parse(r).automation).not.toHaveProperty('runCount');
+    expect(JSON.parse(r).automation).not.toHaveProperty('lastRunAt');
+  });
+
   it('list omits automations that fail the site-scope check', async () => {
     mockCheck.mockImplementation(async (a: any) => ({ ok: a.id === 'keep', unbounded: false, outOfScopeDeviceIds: [] }));
-    mockDb.select.mockReturnValue({ from: () => ({ where: () => ({ orderBy: () => ({ limit: () => Promise.resolve([
-      { id: 'keep', name: 'K', trigger: {}, orgId: 'org-1', partnerId: null, conditions: {} },
-      { id: 'drop', name: 'D', trigger: {}, orgId: 'org-1', partnerId: null, conditions: {} },
-    ]) }) }) }) });
+    mockDb.select.mockReturnValue({ from: () => ({ where: () => ({ orderBy: () => ({ limit: () => ({ offset: () => Promise.resolve([
+      { id: 'keep', name: 'K', trigger: {}, orgId: 'org-1', partnerId: null, conditions: {}, runCount: 7, lastRunAt: new Date() },
+      { id: 'drop', name: 'D', trigger: {}, orgId: 'org-1', partnerId: null, conditions: {}, runCount: 9, lastRunAt: new Date() },
+    ]) }) }) }) }) });
     const r = await handlerFor('manage_automations')({ action: 'list' }, makeAuth(['site-A']));
     const parsed = JSON.parse(r);
     expect(parsed.showing).toBe(1);
     expect(parsed.automations[0].id).toBe('keep');
+    expect(parsed.automations[0]).not.toHaveProperty('runCount');
+    expect(parsed.automations[0]).not.toHaveProperty('lastRunAt');
   });
 });
 

--- a/apps/api/src/services/aiToolsFleet.ts
+++ b/apps/api/src/services/aiToolsFleet.ts
@@ -75,6 +75,7 @@ import { canManagePartnerWidePolicies, PARTNER_WIDE_WRITE_DENIED_MESSAGE } from 
 import { filterWindowsToSiteScope, scopeWindowForRead } from './maintenanceSiteScope';
 import { deviceSiteDenied, deviceIdSiteDenied, resolveSiteAllowedDeviceIds } from './aiToolsSiteScope';
 import { checkAutomationTargetsWithinSiteScope } from './automationRuntime';
+import { scanProjectedAutomationRuns } from './automationReadProjection';
 import { assertReportExecutionPreflight } from './reportGenerationService';
 import { deleteDeviceGroup, DeviceGroupDeleteError } from './deviceGroupDelete';
 import {
@@ -1670,7 +1671,7 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
         }
 
         const limit = Math.min(Math.max(1, Number(input.limit) || 25), 100);
-        const rows = await db.select({
+        const selectRows = () => db.select({
           id: automations.id,
           name: automations.name,
           description: automations.description,
@@ -1685,18 +1686,37 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
           partnerId: automations.partnerId,
           conditions: automations.conditions,
         }).from(automations)
-          .where(conditions.length > 0 ? and(...conditions) : undefined)
-          .orderBy(desc(automations.createdAt))
-          .limit(limit);
+          .where(conditions.length > 0 ? and(...conditions) : undefined);
 
         // Site axis: omit automations whose resolvable target set escapes the
         // caller's site allowlist (only queries the DB for restricted callers).
-        let visible = rows;
-        if (auth.allowedSiteIds) {
-          const checks = await Promise.all(
-            rows.map((r) => checkAutomationTargetsWithinSiteScope(r as any, siteScopePerms(auth))),
-          );
-          visible = rows.filter((_, i) => checks[i]!.ok);
+        let visible: any[];
+        if (auth.allowedSiteIds !== undefined) {
+          visible = [];
+          const scanSize = 100;
+          let databaseOffset = 0;
+          while (visible.length < limit) {
+            const batch = await selectRows()
+              .orderBy(desc(automations.createdAt), desc(automations.id))
+              .limit(scanSize).offset(databaseOffset);
+            if (batch.length === 0) break;
+            for (const row of batch) {
+              if ((await checkAutomationTargetsWithinSiteScope(row as any, siteScopePerms(auth))).ok) {
+                visible.push(row);
+                if (visible.length === limit) break;
+              }
+            }
+            databaseOffset += batch.length;
+            if (batch.length < scanSize) break;
+          }
+          visible = visible.map((automation: any) => {
+            const { lastRunAt: _lastRunAt, runCount: _runCount, ...row } = automation;
+            return row;
+          });
+        } else {
+          visible = await selectRows()
+            .orderBy(desc(automations.createdAt), desc(automations.id))
+            .limit(limit);
         }
 
         return JSON.stringify({ automations: visible, showing: visible.length });
@@ -1714,6 +1734,10 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
         const getDenied = await automationSiteDenied(auto);
         if (getDenied) return JSON.stringify({ error: getDenied });
 
+        if (auth.allowedSiteIds !== undefined) {
+          const { lastRunAt: _lastRunAt, runCount: _runCount, ...restricted } = auto;
+          return JSON.stringify({ automation: restricted });
+        }
         return JSON.stringify({ automation: auto });
       }
 
@@ -1730,13 +1754,19 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
         if (historyDenied) return JSON.stringify({ error: historyDenied });
 
         const limit = Math.min(Math.max(1, Number(input.limit) || 25), 100);
-        const runs = await db.select()
-          .from(automationRuns)
-          .where(eq(automationRuns.automationId, auto.id))
-          .orderBy(desc(automationRuns.startedAt))
-          .limit(limit);
+        const page = auth.allowedSiteIds === undefined
+          ? await db.select()
+            .from(automationRuns)
+            .where(eq(automationRuns.automationId, auto.id))
+            .orderBy(desc(automationRuns.startedAt))
+            .limit(limit)
+          : (await scanProjectedAutomationRuns({
+            automationId: auto.id,
+            allowedSiteIds: auth.allowedSiteIds,
+            limit,
+          })).rows;
 
-        return JSON.stringify({ automationId: auto.id, runs, showing: runs.length });
+        return JSON.stringify({ automationId: auto.id, runs: page, showing: page.length });
       }
 
       if (action === 'create') {

--- a/apps/api/src/services/aiToolsScripts.historySiteScope.test.ts
+++ b/apps/api/src/services/aiToolsScripts.historySiteScope.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: any) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: { select: vi.fn() },
+}));
+
+import { db } from '../db';
+import { scriptExecutions } from '../db/schema';
+import type { AuthContext } from '../middleware/auth';
+import type { AiTool } from './aiTools';
+import { registerScriptTools } from './aiToolsScripts';
+
+const SCRIPT_ID = '11111111-1111-4111-8111-111111111111';
+const ORG_ID = '22222222-2222-4222-8222-222222222222';
+const SITE_ID = '33333333-3333-4333-8333-333333333333';
+
+function tool(): AiTool {
+  const tools = new Map<string, AiTool>();
+  registerScriptTools(tools);
+  return tools.get('get_script_execution_history')!;
+}
+
+function auth(allowedSiteIds: string[] | undefined): AuthContext {
+  return {
+    user: { id: 'u1', email: 'private@example.test', name: 'Private', isPlatformAdmin: false },
+    token: {} as any,
+    partnerId: null,
+    orgId: ORG_ID,
+    scope: 'organization',
+    accessibleOrgIds: [ORG_ID],
+    allowedSiteIds,
+    orgCondition: (column: any) => eq(column, ORG_ID),
+    canAccessOrg: (id: string) => id === ORG_ID,
+    canAccessSite: (id: string | null | undefined) =>
+      allowedSiteIds === undefined || (!!id && allowedSiteIds.includes(id)),
+  } as unknown as AuthContext;
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('get_script_execution_history site projection', () => {
+  it('binds execution org and current device site, returning only bounded previews', async () => {
+    let executionWhere: unknown;
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([{ id: SCRIPT_ID }]) }),
+        }),
+      } as any)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          innerJoin: vi.fn().mockReturnValue({
+            where: vi.fn((condition) => {
+              executionWhere = condition;
+              return {
+                orderBy: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockResolvedValue([{
+                    id: 'execution-a',
+                    status: 'completed',
+                    exitCode: 0,
+                    stdout: 'x'.repeat(16_385),
+                    stderr: 'y'.repeat(8_193),
+                  }]),
+                }),
+              };
+            }),
+          }),
+        }),
+      } as any);
+
+    const result = JSON.parse(await tool().handler({ scriptId: SCRIPT_ID }, auth([SITE_ID])));
+    const query = new PgDialect().sqlToQuery(executionWhere as any);
+
+    expect(query.params).toEqual(expect.arrayContaining([SCRIPT_ID, ORG_ID, SITE_ID]));
+    expect(query.sql).toContain('script_executions');
+    expect(query.sql).toContain('site_id');
+    expect(result.executions[0].stdout).toHaveLength(16_384);
+    expect(result.executions[0].stderr).toHaveLength(8_192);
+    expect(result.executions[0].stdoutTruncated).toBe(true);
+    expect(result.executions[0].stderrTruncated).toBe(true);
+  });
+
+  it('does not add a site predicate for an unrestricted caller', async () => {
+    let executionWhere: unknown;
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([{ id: SCRIPT_ID }]) }),
+        }),
+      } as any)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          innerJoin: vi.fn().mockReturnValue({
+            where: vi.fn((condition) => {
+              executionWhere = condition;
+              return { orderBy: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }) };
+            }),
+          }),
+        }),
+      } as any);
+
+    await tool().handler({ scriptId: SCRIPT_ID }, auth(undefined));
+    const query = new PgDialect().sqlToQuery(executionWhere as any);
+    expect(query.params).toEqual(expect.arrayContaining([SCRIPT_ID, ORG_ID]));
+    expect(query.params).not.toContain(SITE_ID);
+  });
+});

--- a/apps/api/src/services/aiToolsScripts.ts
+++ b/apps/api/src/services/aiToolsScripts.ts
@@ -27,7 +27,7 @@ import {
   scriptTemplates,
   scriptExecutions,
 } from '../db/schema';
-import { eq, and, desc, sql, ilike, isNull, or, SQL } from 'drizzle-orm';
+import { eq, and, desc, sql, ilike, inArray, isNull, or, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import { escapeLike } from '../utils/sql';
 import type { AiTool } from './aiTools';
@@ -1020,22 +1020,39 @@ export function registerScriptTools(aiTools: Map<string, AiTool>): void {
 
       const limit = Math.min(Math.max(1, Number(input.limit) || 10), 50);
 
+      const executionConditions: SQL[] = [eq(scriptExecutions.scriptId, input.scriptId as string)];
+      const executionOrgCondition = auth.orgCondition(scriptExecutions.orgId);
+      if (executionOrgCondition) executionConditions.push(executionOrgCondition);
+      if (auth.allowedSiteIds !== undefined) {
+        executionConditions.push(inArray(devices.siteId, auth.allowedSiteIds));
+      }
+
       const results = await db
         .select({
           id: scriptExecutions.id,
           status: scriptExecutions.status,
           exitCode: scriptExecutions.exitCode,
-          stdout: scriptExecutions.stdout,
-          stderr: scriptExecutions.stderr,
+          stdout: sql<string | null>`left(${scriptExecutions.stdout}, 16385)`,
+          stderr: sql<string | null>`left(${scriptExecutions.stderr}, 8193)`,
           createdAt: scriptExecutions.createdAt,
           completedAt: scriptExecutions.completedAt,
         })
         .from(scriptExecutions)
-        .where(eq(scriptExecutions.scriptId, input.scriptId as string))
+        .innerJoin(devices, eq(devices.id, scriptExecutions.deviceId))
+        .where(and(...executionConditions))
         .orderBy(desc(scriptExecutions.createdAt))
         .limit(limit);
 
-      return JSON.stringify({ executions: results, count: results.length });
+      const executions = results.map((execution) => ({
+        ...execution,
+        ...(execution.stdout && execution.stdout.length > 16_384
+          ? { stdout: execution.stdout.slice(0, 16_384), stdoutTruncated: true }
+          : {}),
+        ...(execution.stderr && execution.stderr.length > 8_192
+          ? { stderr: execution.stderr.slice(0, 8_192), stderrTruncated: true }
+          : {}),
+      }));
+      return JSON.stringify({ executions, count: executions.length });
     },
   });
 

--- a/apps/api/src/services/automationReadProjection.test.ts
+++ b/apps/api/src/services/automationReadProjection.test.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PgDialect } from 'drizzle-orm/pg-core';
+
+vi.mock('../db', () => ({ db: { select: vi.fn() } }));
+
+import { db } from '../db';
+import { projectAutomationRunsToSites, scanProjectedAutomationRuns } from './automationReadProjection';
+
+const RUN_A = '11111111-1111-4111-8111-111111111111';
+const RUN_B = '22222222-2222-4222-8222-222222222222';
+const SITE_A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+function run(id: string) {
+  return {
+    id,
+    automationId: '33333333-3333-4333-8333-333333333333',
+    configPolicyId: null,
+    configItemName: null,
+    triggeredBy: 'manual:user',
+    status: 'failed' as const,
+    devicesTargeted: 99,
+    devicesSucceeded: 0,
+    devicesFailed: 99,
+    devicesCancelled: 0,
+    startedAt: new Date('2026-09-05T00:00:00Z'),
+    completedAt: new Date('2026-09-05T00:01:00Z'),
+    logs: [
+      { level: 'error', message: 'allowed output', deviceId: 'device-a' },
+      { level: 'error', message: 'hidden output', deviceId: 'device-b' },
+      { level: 'warning', message: 'org-wide aggregate without a device' },
+    ],
+    createdAt: new Date('2026-09-05T00:00:00Z'),
+  };
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('projectAutomationRunsToSites', () => {
+  it('keeps the legacy projection and avoids a device query for unrestricted readers', async () => {
+    const original = run(RUN_A);
+    await expect(projectAutomationRunsToSites([original], undefined)).resolves.toEqual([original]);
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it('binds run and site ids, omits hidden-only runs, and recomputes every aggregate', async () => {
+    let whereClause: unknown;
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        innerJoin: vi.fn().mockReturnValue({
+          where: vi.fn((condition) => {
+            whereClause = condition;
+            return Promise.resolve([
+              {
+                runId: RUN_A, deviceId: 'device-a', status: 'success',
+                startedAt: new Date('2026-09-05T00:00:10Z'),
+                completedAt: new Date('2026-09-05T00:00:20Z'),
+              },
+            ]);
+          }),
+        }),
+      }),
+    } as any);
+
+    const projected = await projectAutomationRunsToSites([run(RUN_A), run(RUN_B)], [SITE_A]);
+    const query = new PgDialect().sqlToQuery(whereClause as any);
+
+    expect(query.params).toEqual(expect.arrayContaining([RUN_A, RUN_B, SITE_A]));
+    expect(query.sql).toContain('automation_run_device_results');
+    expect(query.sql).toContain('site_id');
+    expect(projected).toHaveLength(1);
+    expect(projected[0]).toMatchObject({
+      id: RUN_A,
+      status: 'completed',
+      devicesTargeted: 1,
+      devicesSucceeded: 1,
+      devicesFailed: 0,
+      devicesCancelled: 0,
+      startedAt: new Date('2026-09-05T00:00:10Z'),
+      completedAt: new Date('2026-09-05T00:00:20Z'),
+      logs: [{ level: 'error', message: 'allowed output', deviceId: 'device-a' }],
+    });
+    expect(JSON.stringify(projected)).not.toContain('hidden output');
+    expect(JSON.stringify(projected)).not.toContain('org-wide aggregate');
+  });
+
+  it('fails closed for an empty site grant', async () => {
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        innerJoin: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue([]) }),
+      }),
+    } as any);
+    await expect(projectAutomationRunsToSites([run(RUN_A)], [])).resolves.toEqual([]);
+  });
+
+  it('keeps live projected completion null and never borrows hidden timing', async () => {
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        innerJoin: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{
+            runId: RUN_A, deviceId: 'device-a', status: 'running',
+            startedAt: new Date('2026-09-05T00:00:30Z'), completedAt: null,
+          }]),
+        }),
+      }),
+    } as any);
+    const [projected] = await projectAutomationRunsToSites([run(RUN_A)], [SITE_A]);
+    expect(projected).toMatchObject({
+      status: 'running', startedAt: new Date('2026-09-05T00:00:30Z'), completedAt: null,
+    });
+  });
+
+  it('scans beyond a hidden first batch without retaining or binding an unbounded history', async () => {
+    const hidden = Array.from({ length: 250 }, (_, index) => run(`${index}`.padStart(8, '0') + '-0000-4000-8000-000000000000'));
+    const visible = run(RUN_A);
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockReturnValue({
+              limit: vi.fn().mockReturnValue({ offset: vi.fn().mockResolvedValue(hidden) }),
+            }),
+          }),
+        }),
+      } as any)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({ innerJoin: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue([]) }) }),
+      } as any)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockReturnValue({
+              limit: vi.fn().mockReturnValue({ offset: vi.fn().mockResolvedValue([visible]) }),
+            }),
+          }),
+        }),
+      } as any)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          innerJoin: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue([{
+            runId: RUN_A, deviceId: 'device-a', status: 'success',
+            startedAt: new Date('2026-09-05T00:00:10Z'), completedAt: new Date('2026-09-05T00:00:20Z'),
+          }]) }),
+        }),
+      } as any);
+
+    const result = await scanProjectedAutomationRuns({
+      automationId: '33333333-3333-4333-8333-333333333333',
+      allowedSiteIds: [SITE_A],
+      limit: 10,
+    });
+    expect(result.total).toBe(1);
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0]?.id).toBe(RUN_A);
+  });
+});

--- a/apps/api/src/services/automationReadProjection.ts
+++ b/apps/api/src/services/automationReadProjection.ts
@@ -1,0 +1,152 @@
+import { and, desc, eq, inArray } from 'drizzle-orm';
+import { db } from '../db';
+import { automationRunDeviceResults, automationRuns, devices } from '../db/schema';
+
+type AutomationRun = typeof automationRuns.$inferSelect;
+type DeviceResultStatus = typeof automationRunDeviceResults.$inferSelect.status;
+
+type VisibleRunDevice = {
+  runId: string;
+  deviceId: string;
+  status: DeviceResultStatus;
+  startedAt: Date | null;
+  completedAt: Date | null;
+};
+
+const RUN_PROJECTION_BATCH_SIZE = 250;
+
+function restrictedRunStatus(rows: readonly VisibleRunDevice[]): AutomationRun['status'] {
+  if (rows.some((row) => row.status === 'pending' || row.status === 'running')) return 'running';
+  const failed = rows.filter((row) => row.status === 'failed').length;
+  const succeeded = rows.filter((row) => row.status === 'success').length;
+  const cancelled = rows.filter((row) => row.status === 'cancelled').length;
+  if (failed > 0 && succeeded > 0) return 'partial';
+  if (failed > 0) return 'failed';
+  if (cancelled > 0) return 'cancelled';
+  return 'completed';
+}
+
+function visibleLogs(logs: unknown, visibleDeviceIds: ReadonlySet<string>): unknown[] {
+  if (!Array.isArray(logs)) return [];
+  return logs.filter((entry) => {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return false;
+    const deviceId = (entry as Record<string, unknown>).deviceId;
+    return typeof deviceId === 'string' && visibleDeviceIds.has(deviceId);
+  });
+}
+
+/**
+ * Project run history onto the caller's current site grant. Run counters and
+ * JSON logs are org-wide snapshots, so restricted readers may only receive
+ * values recomputed from currently visible per-device rows. A run with no
+ * visible child is omitted rather than becoming an existence oracle.
+ */
+export async function projectAutomationRunsToSites<T extends AutomationRun>(
+  runs: readonly T[],
+  allowedSiteIds: readonly string[] | undefined,
+): Promise<T[]> {
+  if (allowedSiteIds === undefined || runs.length === 0) return [...runs];
+
+  const rows: VisibleRunDevice[] = [];
+  for (let start = 0; start < runs.length; start += RUN_PROJECTION_BATCH_SIZE) {
+    const runIds = runs.slice(start, start + RUN_PROJECTION_BATCH_SIZE).map((run) => run.id);
+    rows.push(...await db
+      .select({
+        runId: automationRunDeviceResults.runId,
+        deviceId: automationRunDeviceResults.deviceId,
+        status: automationRunDeviceResults.status,
+        startedAt: automationRunDeviceResults.startedAt,
+        completedAt: automationRunDeviceResults.completedAt,
+      })
+      .from(automationRunDeviceResults)
+      .innerJoin(devices, eq(devices.id, automationRunDeviceResults.deviceId))
+      .where(and(
+        inArray(automationRunDeviceResults.runId, runIds),
+        inArray(devices.siteId, [...allowedSiteIds]),
+      )));
+  }
+
+  const byRun = new Map<string, VisibleRunDevice[]>();
+  for (const row of rows) {
+    const list = byRun.get(row.runId) ?? [];
+    list.push(row);
+    byRun.set(row.runId, list);
+  }
+
+  return runs.flatMap((run) => {
+    const visible = byRun.get(run.id);
+    if (!visible?.length) return [];
+    const deviceIds = new Set(visible.map((row) => row.deviceId));
+    const status = restrictedRunStatus(visible);
+    const started = visible.flatMap((row) => row.startedAt ? [row.startedAt.getTime()] : []);
+    const completed = visible.flatMap((row) => row.completedAt ? [row.completedAt.getTime()] : []);
+    return [{
+      ...run,
+      status,
+      devicesTargeted: visible.length,
+      devicesSucceeded: visible.filter((row) => row.status === 'success').length,
+      devicesFailed: visible.filter((row) => row.status === 'failed').length,
+      devicesCancelled: visible.filter((row) => row.status === 'cancelled').length,
+      // Run-level timing is an org-wide aggregate. A restricted projection starts
+      // at its first visible child and completes at its last visible child. Missing
+      // terminal timestamps (or any live child) remain null rather than borrowing
+      // timing from a hidden sibling.
+      startedAt: started.length > 0 ? new Date(Math.min(...started)) : null,
+      completedAt: status === 'running' || completed.length !== visible.length
+        ? null
+        : new Date(Math.max(...completed)),
+      logs: visibleLogs(run.logs, deviceIds),
+    }];
+  });
+}
+
+export type ProjectedRunScan = {
+  rows: AutomationRun[];
+  total: number;
+  statusCounts: Record<'completed' | 'failed' | 'partial', number>;
+};
+
+/**
+ * Scan one automation's runs in fixed-size pages and retain only the requested
+ * visible page. This preserves exact restricted totals without materializing an
+ * unbounded run history or constructing an unbounded SQL `IN` predicate.
+ */
+export async function scanProjectedAutomationRuns(input: {
+  automationId: string;
+  allowedSiteIds: readonly string[];
+  offset?: number;
+  limit: number;
+  status?: AutomationRun['status'];
+}): Promise<ProjectedRunScan> {
+  const wantedOffset = input.offset ?? 0;
+  const rows: AutomationRun[] = [];
+  const statusCounts = { completed: 0, failed: 0, partial: 0 };
+  let total = 0;
+  let databaseOffset = 0;
+
+  while (true) {
+    const batch = await db
+      .select()
+      .from(automationRuns)
+      .where(eq(automationRuns.automationId, input.automationId))
+      .orderBy(desc(automationRuns.startedAt), desc(automationRuns.id))
+      .limit(RUN_PROJECTION_BATCH_SIZE)
+      .offset(databaseOffset);
+    if (batch.length === 0) break;
+
+    const projected = await projectAutomationRunsToSites(batch, input.allowedSiteIds);
+    for (const run of projected) {
+      if (run.status === 'completed' || run.status === 'failed' || run.status === 'partial') {
+        statusCounts[run.status] += 1;
+      }
+      if (input.status && run.status !== input.status) continue;
+      if (total >= wantedOffset && rows.length < input.limit) rows.push(run);
+      total += 1;
+    }
+
+    databaseOffset += batch.length;
+    if (batch.length < RUN_PROJECTION_BATCH_SIZE) break;
+  }
+
+  return { rows, total, statusCounts };
+}


### PR DESCRIPTION
Constrain quarantine decisions, automation history and legacy alert definitions to the operator's organization and current site permissions. Require MFA for quarantine decisions and alert-read permission for legacy definition reads. Add authenticated HTTP and PostgreSQL coverage, with unconditional cleanup of concurrent tests.

Validation on the preceding code-identical candidate: 11 site controls, 14 scan-authority controls, 102 RLS checks, 103 migration checks, 89 scan unit tests, typecheck, lint and build passed. Independent site and scan controls also passed; the scan suite retained a post-success Vite shutdown warning, with an unchanged database catalog and no remaining client sessions afterward. The final rebase preserves all tested source and runtime inputs across a two-file documentation change. Earlier focused and full-suite results remain dated. This patch adds no migration or agent update.

Rollout must preserve compatible role grants and service versions, including alerts:read access. Prefer a corrected roll-forward; a downgrade removes these boundaries and needs containment of affected operations. Browser, provider, native endpoint and multi-replica validation remain separate rollout requirements.
