### PR TITLE
feat(tickets,mobile): set a requester contact on new tickets; accept requesterContactId on the staff ticket API (#5367)

### DIFF
--- a/apps/api/src/routes/tickets/tickets.test.ts
+++ b/apps/api/src/routes/tickets/tickets.test.ts
@@ -210,6 +210,7 @@ import { emitTicketTriageFeedback } from '../../services/mlFeedbackEmitters';
 
 const TICKET_ID = '3f2f1d8e-1111-4222-8333-444455556666';
 const ORG_ID    = '3f2f1d8e-1111-4222-8333-444455556666';
+const CONTACT_ID = '9c8d7e6f-2222-4333-8444-555566667777';
 const STUB_TICKET = { id: TICKET_ID, orgId: 'org-1', partnerId: 'p-1', subject: 'Printer' };
 
 const DEFAULT_AUTH = {
@@ -470,6 +471,50 @@ describe('POST /tickets', () => {
       body: JSON.stringify({ orgId: ORG_ID })
     });
     expect(res.status).toBe(400);
+  });
+
+  // #5367: the mobile New-ticket form names the requester CONTACT. The route
+  // spreads the parsed body, so this asserts the SCHEMA carries the field —
+  // an omitted key is stripped silently and the ticket lands with no requester.
+  it('passes requesterContactId through to createTicket', async () => {
+    serviceMocks.createTicket.mockResolvedValue({ id: 't-5', internalNumber: 'T-2026-0005' });
+    const res = await makeApp().request('/tickets', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ orgId: ORG_ID, subject: 'Printer offline', requesterContactId: CONTACT_ID })
+    });
+    expect(res.status).toBe(201);
+    expect(serviceMocks.createTicket).toHaveBeenCalledWith(
+      expect.objectContaining({ requesterContactId: CONTACT_ID, source: 'manual' }),
+      expect.anything()
+    );
+  });
+
+  it('400s on a non-uuid requesterContactId before reaching the service', async () => {
+    const res = await makeApp().request('/tickets', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ orgId: ORG_ID, subject: 'x', requesterContactId: 'not-a-uuid' })
+    });
+    expect(res.status).toBe(400);
+    expect(serviceMocks.createTicket).not.toHaveBeenCalled();
+  });
+
+  // The same-org rule stays where it already is — `assertRequesterContactInOrg`
+  // in the service, which runs before the ticket number is allocated. The route
+  // only has to surface it; this pins the status/code the client sees.
+  it('surfaces the service cross-org contact rejection as 400 with its code', async () => {
+    const { TicketServiceError } = await vi.importActual<typeof import('../../services/ticketService')>('../../services/ticketService');
+    serviceMocks.createTicket.mockRejectedValue(
+      new TicketServiceError('Requester contact must belong to the ticket organization', 400, 'REQUESTER_CONTACT_WRONG_ORG')
+    );
+    const res = await makeApp().request('/tickets', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ orgId: ORG_ID, subject: 'x', requesterContactId: CONTACT_ID })
+    });
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ code: 'REQUESTER_CONTACT_WRONG_ORG' });
   });
 
   it('maps TicketServiceError status through (404 org)', async () => {

--- a/apps/api/src/services/ticketService.test.ts
+++ b/apps/api/src/services/ticketService.test.ts
@@ -2130,6 +2130,77 @@ describe('updateTicketFields', () => {
   //   submitterEmail changed, no login -> re-resolve by (org, lower(email))
   //   submitterName only   -> neither id is touched
 
+  // #5367: naming the CONTACT directly. The three rules above derive the link
+  // from a login or an address; an explicit `requesterContactId` states it, and
+  // wins — the same precedence createTicket gives a named contact.
+  it('sets the requester contact named explicitly and backfills the name/email snapshot', async () => {
+    // selects in order: ticket, contact
+    dbMocks.selectResult
+      .mockResolvedValueOnce([{ ...BASE_TICKET, submittedBy: null, submitterName: 'Tess Tech', submitterEmail: null, requesterContactId: null }])
+      .mockResolvedValueOnce([{ id: 'ct-1', orgId: 'o-1', name: 'Jane Doe', email: 'jane@acme.test' }]);
+    dbMocks.updateReturning.mockResolvedValue([{ ...BASE_TICKET, requesterContactId: 'ct-1' }]);
+    dbMocks.insertReturning.mockResolvedValue([{ id: 'c-1' }]);
+
+    await updateTicketFields('t-1', { requesterContactId: 'ct-1' }, actor);
+
+    expect(setMock.mock.calls[0]![0]).toMatchObject({
+      requesterContactId: 'ct-1',
+      submitterName: 'Jane Doe',
+      submitterEmail: 'jane@acme.test',
+    });
+    expect(valuesMock).toHaveBeenCalledWith(expect.objectContaining({ content: 'Updated requester' }));
+  });
+
+  it('rejects a requesterContactId from another org and writes nothing', async () => {
+    dbMocks.selectResult
+      .mockResolvedValueOnce([{ ...BASE_TICKET, requesterContactId: null }])
+      .mockResolvedValueOnce([{ id: 'ct-x', orgId: 'o-OTHER', name: 'Intruder', email: 'x@evil.test' }]);
+
+    const err = await updateTicketFields('t-1', { requesterContactId: 'ct-x' }, actor).catch((e) => e);
+
+    expect(err).toBeInstanceOf(TicketServiceError);
+    expect(err.status).toBe(400);
+    expect(err.code).toBe('REQUESTER_CONTACT_WRONG_ORG');
+    expect(setMock).not.toHaveBeenCalled();
+    expect(valuesMock).not.toHaveBeenCalled();
+  });
+
+  it('clears the contact link on requesterContactId: null without touching the snapshot', async () => {
+    dbMocks.selectResult.mockResolvedValue([
+      { ...BASE_TICKET, submittedBy: null, submitterName: 'Jane Doe', submitterEmail: 'jane@acme.test', requesterContactId: 'ct-1' },
+    ]);
+    dbMocks.updateReturning.mockResolvedValue([{ ...BASE_TICKET, requesterContactId: null }]);
+    dbMocks.insertReturning.mockResolvedValue([{ id: 'c-1' }]);
+
+    await updateTicketFields('t-1', { requesterContactId: null }, actor);
+
+    const payload = setMock.mock.calls[0]![0];
+    expect(payload).toMatchObject({ requesterContactId: null });
+    expect(payload).not.toHaveProperty('submitterName');
+    expect(payload).not.toHaveProperty('submitterEmail');
+  });
+
+  it('keeps the login-derived name/email when a contact is named alongside a portal user', async () => {
+    // selects in order: ticket, portal user, contact
+    dbMocks.selectResult
+      .mockResolvedValueOnce([{ ...BASE_TICKET, submittedBy: null, submitterName: null, submitterEmail: null, requesterContactId: null }])
+      .mockResolvedValueOnce([{ id: 'pu-1', orgId: 'o-1', name: 'Login Name', email: 'login@acme.test', contactId: 'ct-login' }])
+      .mockResolvedValueOnce([{ id: 'ct-1', orgId: 'o-1', name: 'Jane Doe', email: 'jane@acme.test' }]);
+    dbMocks.updateReturning.mockResolvedValue([{ ...BASE_TICKET, requesterContactId: 'ct-1' }]);
+    dbMocks.insertReturning.mockResolvedValue([{ id: 'c-1' }]);
+
+    await updateTicketFields('t-1', { submittedBy: 'pu-1', requesterContactId: 'ct-1' }, actor);
+
+    expect(setMock.mock.calls[0]![0]).toMatchObject({
+      submittedBy: 'pu-1',
+      // The explicit contact wins the LINK...
+      requesterContactId: 'ct-1',
+      // ...but the login still owns the snapshot, exactly as on create.
+      submitterName: 'Login Name',
+      submitterEmail: 'login@acme.test',
+    });
+  });
+
   it('leaves requesterContactId ALONE when only submitterName changes', async () => {
     dbMocks.selectResult.mockResolvedValue([
       { ...BASE_TICKET, submittedBy: null, submitterName: 'Jane', submitterEmail: 'jane@acme.test', requesterContactId: 'ct-1' },

--- a/apps/api/src/services/ticketService.ts
+++ b/apps/api/src/services/ticketService.ts
@@ -1064,11 +1064,20 @@ export interface UpdateTicketFieldsInput {
   submittedBy?: string | null;
   submitterName?: string | null;
   submitterEmail?: string | null;
+  /**
+   * #5367: name the requester CONTACT explicitly, instead of letting the link
+   * be derived from the login/address rules below. Tenant-validated against
+   * the ticket's org before any write; `null` clears the link.
+   */
+  requesterContactId?: string | null;
 }
 
-// Fields handled by the generic diff loop. The requester triple is excluded —
-// it's resolved/diffed separately (portal-user backfill, single "requester" label).
-type DiffFieldKey = Exclude<keyof UpdateTicketFieldsInput, 'submittedBy' | 'submitterName' | 'submitterEmail'>;
+// Fields handled by the generic diff loop. The requester fields are excluded —
+// they're resolved/diffed separately (portal-user backfill, single "requester" label).
+type DiffFieldKey = Exclude<
+  keyof UpdateTicketFieldsInput,
+  'submittedBy' | 'submitterName' | 'submitterEmail' | 'requesterContactId'
+>;
 
 /** Humanized labels for the system feed entry, in canonical field order. */
 const UPDATE_FIELD_LABELS: Record<DiffFieldKey, string> = {
@@ -1144,7 +1153,8 @@ export async function updateTicketFields(
   const requesterEdit =
     fields.submittedBy !== undefined ||
     fields.submitterName !== undefined ||
-    fields.submitterEmail !== undefined;
+    fields.submitterEmail !== undefined ||
+    fields.requesterContactId !== undefined;
   //
   // #3258 W03: `requester_contact_id` is kept COHERENT with that triple rather
   // than editable on its own — a requester edit either names a portal login
@@ -1203,6 +1213,34 @@ export async function updateTicketFields(
       }
       // A ticket that KEEPS its portal login keeps the link derived from it;
       // an address correction does not re-attribute a login-backed ticket.
+    }
+
+    // #5367: an explicitly named CONTACT overrides whatever the login/address
+    // rules above derived — the caller is stating who the requester IS, which
+    // is strictly more information than either derivation. Same precedence
+    // createTicket gives `namedContact`, and tenant-validated the same way
+    // (before any write, so a cross-org link never reaches the update).
+    if (fields.requesterContactId !== undefined) {
+      if (fields.requesterContactId === null) {
+        // Only the link is dropped. The name/email snapshot is what the notify
+        // worker mails and what threadMatcher binds on, so unlinking a person
+        // must not silently strip the ticket's reply-to identity as well.
+        requesterPatch.requesterContactId = null;
+      } else {
+        const contact = await assertRequesterContactInOrg(fields.requesterContactId, ticket.orgId);
+        requesterPatch.requesterContactId = contact.id;
+        // Backfill mirrors createTicket exactly: the snapshot comes from the
+        // contact only when no portal login owns it, and never over free text
+        // the caller supplied in the same patch.
+        const keepsLogin =
+          'submittedBy' in requesterPatch
+            ? requesterPatch.submittedBy !== null
+            : (tRow.submittedBy ?? null) !== null;
+        if (!keepsLogin) {
+          if (fields.submitterName === undefined) requesterPatch.submitterName = contact.name ?? null;
+          if (fields.submitterEmail === undefined) requesterPatch.submitterEmail = contact.email ?? null;
+        }
+      }
     }
   }
   const requesterChanged =

--- a/apps/mobile/src/screens/tickets/CreateTicketScreen.tsx
+++ b/apps/mobile/src/screens/tickets/CreateTicketScreen.tsx
@@ -367,7 +367,11 @@ export function CreateTicketScreen() {
           // does not silently drop a deliberate choice.
           setContactId((current) => contactSelectionForOrg({ orgId, contactId: current }, id));
           setContactSearch('');
-          setContactsForbidden(false);
+          // Only a REAL org change re-opens the question of whether contacts
+          // are readable. Reselecting the same org changes no state the effect
+          // below keys on, so clearing the flag unconditionally would unhide
+          // the row without ever refetching it.
+          if (id !== orgId) setContactsForbidden(false);
           setOrgId(id);
           setOrgSheetVisible(false);
         }}

--- a/apps/mobile/src/screens/tickets/CreateTicketScreen.tsx
+++ b/apps/mobile/src/screens/tickets/CreateTicketScreen.tsx
@@ -18,6 +18,7 @@ import { palette, radii, spacing, type } from '../../theme';
 import { useAppSelector } from '../../store';
 import { createTicket, type TicketPriority } from '../../services/tickets';
 import { listOrganizations } from '../../services/organizations';
+import { listOrgContacts } from '../../services/orgContacts';
 import { listAssignableUsers } from '../../services/users';
 import type { TicketsStackParamList } from '../../navigation/MainNavigator';
 import { Toast } from '../../components/Toast';
@@ -28,17 +29,23 @@ import {
   assigneeOptions,
   buildCreateTicketBody,
   canSubmitTicket,
+  contactOptions,
+  contactSelectionForOrg,
   defaultAssigneeId,
   DEFAULT_TICKET_PRIORITY,
   isExpectedAssigneeLoadFailure,
+  isExpectedContactLoadFailure,
+  NO_CONTACT_LABEL,
   preselectOrg,
   SUBJECT_MAX_LENGTH,
   TICKET_PRIORITY_OPTIONS,
   type AssigneeUser,
+  type OrgContactOption,
   type OrgOption,
 } from './createTicketForm';
 import { OrgPickerSheet } from './components/OrgPickerSheet';
 import { AssigneePickerSheet } from './components/AssigneePickerSheet';
+import { ContactPickerSheet } from './components/ContactPickerSheet';
 
 type Nav = NativeStackNavigationProp<TicketsStackParamList, 'CreateTicket'>;
 
@@ -56,6 +63,15 @@ export function CreateTicketScreen() {
   const [staff, setStaff] = useState<AssigneeUser[]>([]);
   const [assigneeId, setAssigneeId] = useState<string | null>(() => defaultAssigneeId(user));
   const [assigneeSheetVisible, setAssigneeSheetVisible] = useState(false);
+
+  // #5367: the requester contact. `null` contacts = still loading for the
+  // current org; `contactsForbidden` hides the row outright for a technician
+  // without `organizations:read` (see isExpectedContactLoadFailure).
+  const [contacts, setContacts] = useState<OrgContactOption[] | null>(null);
+  const [contactsForbidden, setContactsForbidden] = useState(false);
+  const [contactId, setContactId] = useState<string | null>(null);
+  const [contactSearch, setContactSearch] = useState('');
+  const [contactSheetVisible, setContactSheetVisible] = useState(false);
 
   const [subject, setSubject] = useState('');
   const [description, setDescription] = useState('');
@@ -106,12 +122,56 @@ export function CreateTicketScreen() {
     };
   }, []);
 
+  // #5367: contacts are ORG-SCOPED, so this refetches on every org change and
+  // the in-flight result of the previous org is discarded rather than shown
+  // against the new one. A failure leaves the row visible but empty ("No
+  // contact" only) — the field is optional, so it must never block the form.
+  useEffect(() => {
+    if (!orgId) {
+      setContacts(null);
+      return;
+    }
+    let cancelled = false;
+    setContacts(null);
+    listOrgContacts(orgId)
+      .then((rows) => {
+        if (!cancelled) setContacts(rows);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setContacts([]);
+        if (isExpectedContactLoadFailure(err)) {
+          setContactsForbidden(true);
+          return;
+        }
+        reportInternalError(err, 'CreateTicketScreen.loadOrgContacts');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [orgId]);
+
+  const contactChoices = useMemo(
+    () => (contacts === null ? null : contactOptions(contacts, contactSearch)),
+    [contacts, contactSearch]
+  );
+  const contactLabel =
+    (contacts === null ? null : contactOptions(contacts).find((o) => o.id === contactId)?.label) ??
+    NO_CONTACT_LABEL;
+
   const me: AssigneeUser | null = user ? { id: user.id, name: user.name, email: user.email } : null;
   const assigneeChoices = useMemo(() => assigneeOptions(staff, me), [staff, me]);
   const assigneeLabel = assigneeChoices.find((o) => o.id === assigneeId)?.label ?? 'Unassigned';
 
   const submit = async () => {
-    const built = buildCreateTicketBody({ orgId, subject, description, priority, assigneeId });
+    const built = buildCreateTicketBody({
+      orgId,
+      subject,
+      description,
+      priority,
+      assigneeId,
+      requesterContactId: contactId,
+    });
     if (!built.ok) return;
     // #5171: without this, the spinner ran with the keyboard still up, and
     // `navigation.replace('TicketDetail', …)` below swapped in the next
@@ -191,6 +251,27 @@ export function CreateTicketScreen() {
                 <Text style={styles.error}>{orgError}</Text>
               </Pressable>
             ) : null}
+          </>
+        )}
+
+        {contactsForbidden ? null : (
+          <>
+            <Text style={styles.label}>CONTACT</Text>
+            <Pressable
+              onPress={() => setContactSheetVisible(true)}
+              accessibilityRole="button"
+              accessibilityState={{ disabled: !orgId }}
+              disabled={!orgId}
+              style={[styles.selectorRow, !orgId && styles.selectorDisabled]}
+            >
+              <Text
+                style={[styles.selectorText, contactId === null && styles.selectorPlaceholder]}
+                numberOfLines={1}
+              >
+                {contactLabel}
+              </Text>
+              <Text style={styles.chevron}>{'\u203a'}</Text>
+            </Pressable>
           </>
         )}
 
@@ -281,10 +362,30 @@ export function CreateTicketScreen() {
         }}
         onRetry={() => void loadOrgs(orgSearch)}
         onSelect={(id) => {
+          // #5367: contacts belong to the org, so a different org invalidates
+          // the pick. Guarded by the pure helper so "reselected the same org"
+          // does not silently drop a deliberate choice.
+          setContactId((current) => contactSelectionForOrg({ orgId, contactId: current }, id));
+          setContactSearch('');
+          setContactsForbidden(false);
           setOrgId(id);
           setOrgSheetVisible(false);
         }}
         onCancel={() => setOrgSheetVisible(false)}
+      />
+      <ContactPickerSheet
+        visible={contactSheetVisible}
+        options={contactChoices}
+        totalOptions={contacts?.length ?? 0}
+        search={contactSearch}
+        selectedId={contactId}
+        onSearchChange={setContactSearch}
+        onSelect={(id) => {
+          setContactId(id);
+          setContactSearch('');
+          setContactSheetVisible(false);
+        }}
+        onCancel={() => setContactSheetVisible(false)}
       />
       <AssigneePickerSheet
         visible={assigneeSheetVisible}
@@ -335,6 +436,7 @@ const styles = StyleSheet.create({
   },
   selectorText: { ...type.body, color: palette.dark.textHi, flex: 1, marginRight: spacing['2'] },
   selectorPlaceholder: { color: palette.dark.textLo },
+  selectorDisabled: { opacity: 0.5 },
   chevron: { ...type.body, color: palette.dark.textLo },
   error: { ...type.meta, color: palette.deny.base, marginTop: spacing['2'] },
   priorityRow: { flexDirection: 'row', flexWrap: 'wrap', gap: spacing['2'], marginTop: spacing['2'] },

--- a/apps/mobile/src/screens/tickets/TicketDetailScreen.tsx
+++ b/apps/mobile/src/screens/tickets/TicketDetailScreen.tsx
@@ -73,6 +73,7 @@ import {
   priorityColor,
   priorityLabel,
   statusLabel,
+  requesterLabel,
   ticketRef,
   visibleActivityCount,
 } from './ticketCopy';
@@ -667,6 +668,14 @@ export function TicketDetailScreen() {
         ) : (
           <Text style={styles.metaDim}>Unassigned</Text>
         )}
+        {/*
+          #5367: who the ticket is FOR. Hidden rather than shown empty when the
+          ticket names nobody — most agent/alert-raised tickets have no
+          requester at all, and a bare "Requester:" reads as a load failure.
+        */}
+        {requesterLabel(ticket) ? (
+          <Text style={styles.metaDim}>Requester {requesterLabel(ticket)}</Text>
+        ) : null}
 
         {ticket.description ? (
           <View style={styles.card}>

--- a/apps/mobile/src/screens/tickets/components/ContactPickerSheet.tsx
+++ b/apps/mobile/src/screens/tickets/components/ContactPickerSheet.tsx
@@ -1,0 +1,151 @@
+import { ActivityIndicator, FlatList, Modal, Pressable, Text, TextInput, View } from 'react-native';
+
+import { useApprovalTheme, radii, spacing, type } from '../../../theme';
+import type { ContactOption } from '../createTicketForm';
+
+/** Above this many rows the picker gets a search box (client-side filter). */
+const SEARCH_THRESHOLD = 8;
+
+interface Props {
+  visible: boolean;
+  /** `null` while the org's contacts are still loading. */
+  options: ContactOption[] | null;
+  /** Rows before the search filter — decides whether the search box is worth showing. */
+  totalOptions: number;
+  search: string;
+  selectedId: string | null;
+  onSearchChange: (text: string) => void;
+  onSelect: (contactId: string | null) => void;
+  onCancel: () => void;
+}
+
+/**
+ * #5367: pick who a new ticket is FOR. Same `Modal` shape as `OrgPickerSheet`
+ * (and deliberately not `AssigneePickerSheet`, which has no search) because a
+ * customer org routinely has more contacts than a partner has staff.
+ *
+ * The search filter is client-side over the single page `listOrgContacts`
+ * fetched — see `contactOptions`. "No contact" is always the first row and is
+ * never filtered out, so clearing a pick stays reachable mid-search.
+ */
+export function ContactPickerSheet({
+  visible,
+  options,
+  totalOptions,
+  search,
+  selectedId,
+  onSearchChange,
+  onSelect,
+  onCancel,
+}: Props) {
+  const theme = useApprovalTheme('dark');
+  const showSearch = totalOptions > SEARCH_THRESHOLD || search.length > 0;
+
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onCancel}>
+      <Pressable
+        style={{ flex: 1, backgroundColor: 'rgba(0,0,0,0.55)', justifyContent: 'flex-end' }}
+        onPress={onCancel}
+      >
+        <Pressable
+          onPress={(e) => e.stopPropagation()}
+          style={{
+            backgroundColor: theme.bg1,
+            borderTopLeftRadius: radii.xl,
+            borderTopRightRadius: radii.xl,
+            paddingTop: spacing[5],
+            paddingBottom: spacing[10],
+            maxHeight: '80%',
+          }}
+        >
+          <View
+            style={{
+              alignSelf: 'center',
+              width: 36,
+              height: 4,
+              borderRadius: 2,
+              backgroundColor: theme.bg3,
+              marginBottom: spacing[4],
+            }}
+          />
+          <Text style={[type.title, { color: theme.textHi, paddingHorizontal: spacing[6] }]}>
+            Contact
+          </Text>
+
+          {showSearch ? (
+            <View style={{ paddingHorizontal: spacing[6], marginTop: spacing[4] }}>
+              <TextInput
+                style={[
+                  type.body,
+                  {
+                    color: theme.textHi,
+                    backgroundColor: theme.bg2,
+                    borderRadius: radii.md,
+                    paddingHorizontal: spacing[3],
+                    paddingVertical: spacing[3],
+                  },
+                ]}
+                placeholder="Search contacts"
+                placeholderTextColor={theme.textLo}
+                value={search}
+                onChangeText={onSearchChange}
+                autoCorrect={false}
+                autoCapitalize="none"
+                accessibilityLabel="Search contacts"
+              />
+            </View>
+          ) : null}
+
+          {options === null ? (
+            <View style={{ paddingVertical: spacing[8], alignItems: 'center' }}>
+              <ActivityIndicator color={theme.brand} />
+            </View>
+          ) : (
+            <FlatList
+              data={options}
+              keyExtractor={(o) => o.id ?? 'none'}
+              keyboardShouldPersistTaps="handled"
+              style={{ marginTop: spacing[3] }}
+              // Only the pinned "No contact" row survives a search that matches
+              // nobody, and a lone row reads as "that IS the result" — say so.
+              ListFooterComponent={
+                options.length <= 1 && search.trim().length > 0 ? (
+                  <Text
+                    style={[
+                      type.meta,
+                      { color: theme.textLo, paddingHorizontal: spacing[6], paddingTop: spacing[3] },
+                    ]}
+                  >
+                    No contacts match.
+                  </Text>
+                ) : null
+              }
+              renderItem={({ item }) => {
+                const active = item.id === selectedId;
+                return (
+                  <Pressable
+                    onPress={() => onSelect(item.id)}
+                    accessibilityRole="button"
+                    accessibilityState={{ selected: active }}
+                    style={({ pressed }) => ({
+                      paddingHorizontal: spacing[6],
+                      paddingVertical: spacing[3],
+                      backgroundColor: pressed || active ? theme.bg2 : 'transparent',
+                    })}
+                  >
+                    <Text
+                      style={[type.bodyMd, { color: active ? theme.textHi : theme.textMd }]}
+                      numberOfLines={1}
+                    >
+                      {item.label}
+                    </Text>
+                  </Pressable>
+                );
+              }}
+            />
+          )}
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}

--- a/apps/mobile/src/screens/tickets/createTicketForm.test.ts
+++ b/apps/mobile/src/screens/tickets/createTicketForm.test.ts
@@ -4,9 +4,13 @@ import {
   assigneeOptions,
   buildCreateTicketBody,
   canSubmitTicket,
+  contactDisplayLabel,
+  contactOptions,
+  contactSelectionForOrg,
   defaultAssigneeId,
   DEFAULT_TICKET_PRIORITY,
   isExpectedAssigneeLoadFailure,
+  isExpectedContactLoadFailure,
   preselectOrg,
   TICKET_PRIORITY_OPTIONS,
 } from './createTicketForm';
@@ -196,5 +200,84 @@ describe('assigneeOptions', () => {
       { id: 'u3', label: 'alex@example.com' },
       { id: 'u2', label: 'Bailey Ops' },
     ]);
+  });
+});
+
+// #5367: the requester CONTACT on a new ticket.
+describe('contact selection', () => {
+  const contacts = [
+    { id: 'c2', name: 'Bailey Buyer', email: 'bailey@acme.test', isPrimary: false },
+    { id: 'c1', name: 'Alex Admin', email: 'alex@acme.test', isPrimary: true },
+    { id: 'c3', name: 'Casey Clerk', email: 'casey@acme.test', isPrimary: false },
+  ];
+
+  it('labels a contact as "name · email", falling back to whichever it has', () => {
+    expect(contactDisplayLabel({ name: 'Alex Admin', email: 'alex@acme.test' })).toBe(
+      'Alex Admin · alex@acme.test'
+    );
+    expect(contactDisplayLabel({ name: 'Alex Admin', email: null })).toBe('Alex Admin');
+    expect(contactDisplayLabel({ name: '  ', email: 'alex@acme.test' })).toBe('alex@acme.test');
+    expect(contactDisplayLabel({ name: null, email: null })).toBe('Unnamed contact');
+  });
+
+  it('puts "No contact" first, then the primary contact, then the rest by label', () => {
+    expect(contactOptions(contacts)).toEqual([
+      { id: null, label: 'No contact' },
+      { id: 'c1', label: 'Alex Admin · alex@acme.test' },
+      { id: 'c2', label: 'Bailey Buyer · bailey@acme.test' },
+      { id: 'c3', label: 'Casey Clerk · casey@acme.test' },
+    ]);
+  });
+
+  it('keeps a primary contact ahead of an alphabetically earlier non-primary', () => {
+    const primaryLast = [
+      { id: 'c2', name: 'Aaron Early', email: 'aaron@acme.test', isPrimary: false },
+      { id: 'c1', name: 'Zoe Primary', email: 'zoe@acme.test', isPrimary: true },
+    ];
+    expect(contactOptions(primaryLast).map((o) => o.id)).toEqual([null, 'c1', 'c2']);
+  });
+
+  it('filters by name or email, case-insensitively, and always keeps the "No contact" row', () => {
+    expect(contactOptions(contacts, 'BAIL').map((o) => o.id)).toEqual([null, 'c2']);
+    expect(contactOptions(contacts, 'casey@acme').map((o) => o.id)).toEqual([null, 'c3']);
+    expect(contactOptions(contacts, 'nobody').map((o) => o.id)).toEqual([null]);
+    // A blank search is not a filter.
+    expect(contactOptions(contacts, '   ').map((o) => o.id)).toEqual([null, 'c1', 'c2', 'c3']);
+  });
+
+  it('drops the contact selection when the organization changes, keeps it when it does not', () => {
+    expect(contactSelectionForOrg({ orgId: 'o1', contactId: 'c1' }, 'o2')).toBeNull();
+    expect(contactSelectionForOrg({ orgId: 'o1', contactId: 'c1' }, null)).toBeNull();
+    expect(contactSelectionForOrg({ orgId: 'o1', contactId: 'c1' }, 'o1')).toBe('c1');
+    expect(contactSelectionForOrg({ orgId: null, contactId: null }, 'o1')).toBeNull();
+  });
+
+  it('treats a 403 contacts fetch as expected (hide the row) and anything else as reportable', () => {
+    expect(isExpectedContactLoadFailure({ statusCode: 403 })).toBe(true);
+    expect(isExpectedContactLoadFailure({ statusCode: 500 })).toBe(false);
+    expect(isExpectedContactLoadFailure(new Error('offline'))).toBe(false);
+    expect(isExpectedContactLoadFailure(null)).toBe(false);
+  });
+
+  it('sends requesterContactId when a contact is picked, and omits it for "No contact"', () => {
+    expect(
+      buildCreateTicketBody({
+        orgId: 'o1',
+        subject: 'x',
+        description: '',
+        priority: 'normal',
+        requesterContactId: 'c1',
+      })
+    ).toEqual({ ok: true, body: { orgId: 'o1', subject: 'x', priority: 'normal', requesterContactId: 'c1' } });
+
+    expect(
+      buildCreateTicketBody({
+        orgId: 'o1',
+        subject: 'x',
+        description: '',
+        priority: 'normal',
+        requesterContactId: null,
+      })
+    ).toEqual({ ok: true, body: { orgId: 'o1', subject: 'x', priority: 'normal' } });
   });
 });

--- a/apps/mobile/src/screens/tickets/createTicketForm.ts
+++ b/apps/mobile/src/screens/tickets/createTicketForm.ts
@@ -25,6 +25,12 @@ export interface CreateTicketBody {
   description?: string;
   priority: TicketPriority;
   assigneeId?: string;
+  /**
+   * #5367: the requester CONTACT (`tickets.requester_contact_id`). Omitted —
+   * never sent as null — for "No contact", matching how `assigneeId` handles
+   * "Unassigned": the server only ever sees the field when a real id was picked.
+   */
+  requesterContactId?: string;
 }
 
 export type BuildResult =
@@ -44,6 +50,7 @@ export function buildCreateTicketBody(input: {
   description: string;
   priority: TicketPriority;
   assigneeId?: string | null;
+  requesterContactId?: string | null;
 }): BuildResult {
   if (!input.orgId) return { ok: false, reason: 'org' };
   const subject = input.subject.trim();
@@ -52,6 +59,7 @@ export function buildCreateTicketBody(input: {
   const body: CreateTicketBody = { orgId: input.orgId, subject, priority: input.priority };
   if (description) body.description = description;
   if (input.assigneeId) body.assigneeId = input.assigneeId;
+  if (input.requesterContactId) body.requesterContactId = input.requesterContactId;
   return { ok: true, body };
 }
 
@@ -106,8 +114,23 @@ export function defaultAssigneeId(me: { id: string } | null | undefined): string
  * network failure, a non-ApiError throw — is still worth reporting.
  */
 export function isExpectedAssigneeLoadFailure(err: unknown): boolean {
+  return isForbidden(err);
+}
+
+/** A refusal by the permission model, as opposed to a failure worth reporting. */
+function isForbidden(err: unknown): boolean {
   if (!err || typeof err !== 'object') return false;
   return (err as { statusCode?: unknown }).statusCode === 403;
+}
+
+/**
+ * #5367: same rule for the contacts fetch. `GET /orgs/organizations/:id/contacts`
+ * is gated on `organizations:read`, which plenty of technician roles do not
+ * carry — for them the CONTACT row is simply not offered, which is the
+ * permission model working, not a defect to report.
+ */
+export function isExpectedContactLoadFailure(err: unknown): boolean {
+  return isForbidden(err);
 }
 
 /**
@@ -134,4 +157,81 @@ export function assigneeOptions(
   rest.sort((a, b) => a.label.localeCompare(b.label));
 
   return [...options, ...rest];
+}
+
+// ── Requester contact (#5367) ────────────────────────────────────────────────
+
+/** A row from `GET /orgs/organizations/:id/contacts`, trimmed to what the picker needs. */
+export interface OrgContactOption {
+  id: string;
+  name: string | null;
+  email: string | null;
+  isPrimary?: boolean;
+}
+
+export interface ContactOption {
+  /** `null` is the "No contact" row — sent as an omitted field, not literal null. */
+  id: string | null;
+  label: string;
+}
+
+/** The default, and the way back to it once a contact has been picked. */
+export const NO_CONTACT_LABEL = 'No contact';
+
+/**
+ * How a contact reads in the picker: `name · email`, or whichever one it has.
+ * A contact row is only required to carry ONE identifier (the API's
+ * `no-identifier` rule), so both halves are individually optional.
+ */
+export function contactDisplayLabel(contact: Pick<OrgContactOption, 'name' | 'email'>): string {
+  const name = contact.name?.trim();
+  const email = contact.email?.trim();
+  if (name && email) return `${name} · ${email}`;
+  return name || email || 'Unnamed contact';
+}
+
+/**
+ * Picker contents: "No contact" first (it is both the default and the only way
+ * to clear a pick, so it survives every search), then the org's primary contact
+ * ahead of everyone else — on most customer sites that is the person a ticket
+ * is for — then the rest by display label.
+ *
+ * `search` filters client-side over name AND email. The list is one page of at
+ * most 100 contacts, so this is a filter over what was fetched, not a query:
+ * an org with more contacts than that needs server-side search (follow-up).
+ */
+export function contactOptions(
+  contacts: readonly OrgContactOption[],
+  search?: string
+): ContactOption[] {
+  const needle = search?.trim().toLowerCase() ?? '';
+  const matching = needle
+    ? contacts.filter(
+        (c) =>
+          (c.name ?? '').toLowerCase().includes(needle) || (c.email ?? '').toLowerCase().includes(needle)
+      )
+    : [...contacts];
+
+  const ranked = matching
+    .map((c) => ({ id: c.id, label: contactDisplayLabel(c), primary: c.isPrimary === true }))
+    .sort((a, b) => (a.primary === b.primary ? a.label.localeCompare(b.label) : a.primary ? -1 : 1));
+
+  return [
+    { id: null, label: NO_CONTACT_LABEL },
+    ...ranked.map(({ id, label }) => ({ id, label })),
+  ];
+}
+
+/**
+ * The contact selection that survives an organization change: none, unless the
+ * organization did not actually change. Contacts are org-scoped, so carrying a
+ * pick across would POST a `requesterContactId` from the previous customer —
+ * which the API rejects (400 `REQUESTER_CONTACT_WRONG_ORG`), and which would
+ * name the wrong customer's person if it ever did not.
+ */
+export function contactSelectionForOrg(
+  current: { orgId: string | null; contactId: string | null },
+  nextOrgId: string | null
+): string | null {
+  return current.orgId === nextOrgId ? current.contactId : null;
 }

--- a/apps/mobile/src/screens/tickets/ticketCopy.test.ts
+++ b/apps/mobile/src/screens/tickets/ticketCopy.test.ts
@@ -6,6 +6,7 @@ import {
   isBreached,
   isVisibleActivityEntry,
   priorityLabel,
+  requesterLabel,
   statusLabel,
   ticketRef,
   visibleActivityCount,
@@ -142,5 +143,20 @@ describe('visibleActivityCount', () => {
       { commentType: 'comment' as const, content: 'Looking into it' },
     ];
     expect(visibleActivityCount(comments)).toBe(2);
+  });
+});
+
+// #5367: who the ticket is FOR, on the detail header.
+describe('requesterLabel', () => {
+  it('prefers the requester name, falls back to the address', () => {
+    expect(requesterLabel({ submitterName: 'Jane Doe', submitterEmail: 'jane@acme.test' })).toBe('Jane Doe');
+    expect(requesterLabel({ submitterName: null, submitterEmail: 'jane@acme.test' })).toBe('jane@acme.test');
+    expect(requesterLabel({ submitterName: '   ', submitterEmail: 'jane@acme.test' })).toBe('jane@acme.test');
+  });
+
+  it('is null when the ticket names nobody, so the row is hidden rather than blank', () => {
+    expect(requesterLabel({ submitterName: null, submitterEmail: null })).toBeNull();
+    expect(requesterLabel({})).toBeNull();
+    expect(requesterLabel({ submitterName: '  ', submitterEmail: '  ' })).toBeNull();
   });
 });

--- a/apps/mobile/src/screens/tickets/ticketCopy.ts
+++ b/apps/mobile/src/screens/tickets/ticketCopy.ts
@@ -76,6 +76,25 @@ export function isBreached(ticket: Pick<TicketSummary, 'slaBreachedAt'>): boolea
 }
 
 /**
+ * #5367: who the ticket is FOR, for the detail header.
+ *
+ * Reads the requester SNAPSHOT (`submitter_name` / `submitter_email`) rather
+ * than resolving `requester_contact_id`, because the snapshot is what the API
+ * already returns on the ticket read and what the notify worker actually mails
+ * — so the header names the person who will receive the public replies. Null
+ * when the ticket names nobody, so the caller hides the row instead of
+ * rendering "Requester:" with nothing after it.
+ */
+export function requesterLabel(
+  ticket: { submitterName?: string | null; submitterEmail?: string | null }
+): string | null {
+  const name = ticket.submitterName?.trim();
+  if (name) return name;
+  const email = ticket.submitterEmail?.trim();
+  return email || null;
+}
+
+/**
  * Empty-state copy depends on both filters — "no tickets at all" and "none
  * assigned to you" are different situations and a single string reads as a bug
  * when the tech knows the queue is not empty.

--- a/apps/mobile/src/services/orgContacts.test.ts
+++ b/apps/mobile/src/services/orgContacts.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const coreRequest = vi.fn();
+vi.mock('./api', () => ({ coreRequest: (...args: unknown[]) => coreRequest(...args) }));
+
+import { listOrgContacts } from './orgContacts';
+
+beforeEach(() => { coreRequest.mockReset(); });
+
+describe('listOrgContacts', () => {
+  it('asks the org-scoped contacts endpoint for the server maximum page and narrows the row', async () => {
+    coreRequest.mockResolvedValue({
+      data: [
+        { id: 'c1', orgId: 'o1', name: 'Alex Admin', email: 'alex@acme.test', isPrimary: true, phone: '555', notes: 'x' },
+        { id: 'c2', orgId: 'o1', name: null, email: 'bailey@acme.test', isPrimary: false },
+      ],
+      pagination: { page: 1, limit: 100, total: 2 },
+    });
+
+    const contacts = await listOrgContacts('o1');
+
+    expect(coreRequest).toHaveBeenCalledWith('/orgs/organizations/o1/contacts?limit=100');
+    expect(contacts).toEqual([
+      { id: 'c1', name: 'Alex Admin', email: 'alex@acme.test', isPrimary: true },
+      { id: 'c2', name: null, email: 'bailey@acme.test', isPrimary: false },
+    ]);
+  });
+
+  it('encodes the org id into the path rather than interpolating it raw', async () => {
+    coreRequest.mockResolvedValue({ data: [] });
+    await listOrgContacts('o 1/../x');
+    expect(coreRequest).toHaveBeenCalledWith('/orgs/organizations/o%201%2F..%2Fx/contacts?limit=100');
+  });
+
+  it('defaults a missing name/email/isPrimary rather than passing undefined to the picker', async () => {
+    coreRequest.mockResolvedValue({ data: [{ id: 'c3' }] });
+    expect(await listOrgContacts('o1')).toEqual([{ id: 'c3', name: null, email: null, isPrimary: false }]);
+  });
+
+  it('tolerates an empty body', async () => {
+    coreRequest.mockResolvedValue({});
+    expect(await listOrgContacts('o1')).toEqual([]);
+  });
+});

--- a/apps/mobile/src/services/orgContacts.ts
+++ b/apps/mobile/src/services/orgContacts.ts
@@ -1,0 +1,35 @@
+import { coreRequest } from './api';
+
+import type { OrgContactOption } from '../screens/tickets/createTicketForm';
+
+/** The server clamps `limit` to 100 (see `getPagination`); ask for that. */
+const PAGE_LIMIT = 100;
+
+/**
+ * #5367: one page of an organization's contacts, for the New ticket requester
+ * picker.
+ *
+ * Mirrors `listOrganizations` in shape, with two differences that matter:
+ * the endpoint (`GET /orgs/organizations/:id/contacts`) is org-SCOPED, so the
+ * id goes in the path and must be encoded; and it has no server-side search,
+ * so this returns the page and the picker filters it client-side. An org with
+ * more than 100 contacts therefore shows only the first page — acceptable for
+ * v1, and the reason `contactOptions` documents server-side search as the
+ * follow-up.
+ *
+ * The row is narrowed to what the picker needs rather than passed through:
+ * `ContactRecord` carries phone/notes/roles that no caller here reads, and a
+ * missing field becomes an explicit null so the picker never has to
+ * distinguish "absent" from "empty".
+ */
+export async function listOrgContacts(orgId: string): Promise<OrgContactOption[]> {
+  const response = await coreRequest<{
+    data?: Array<{ id: string; name?: string | null; email?: string | null; isPrimary?: boolean }>;
+  }>(`/orgs/organizations/${encodeURIComponent(orgId)}/contacts?limit=${PAGE_LIMIT}`);
+  return (response.data ?? []).map((c) => ({
+    id: c.id,
+    name: c.name ?? null,
+    email: c.email ?? null,
+    isPrimary: c.isPrimary === true,
+  }));
+}

--- a/apps/mobile/src/services/tickets.ts
+++ b/apps/mobile/src/services/tickets.ts
@@ -86,6 +86,16 @@ export interface TicketComment {
 export interface TicketDetail extends TicketSummary {
   description: string | null;
   comments: TicketComment[];
+  /**
+   * #5367: the requester SNAPSHOT the detail route already returns (it selects
+   * the whole `tickets` row). Optional here because a server predating the
+   * field — or a cached payload — simply has no requester to show; the detail
+   * header hides the row rather than rendering an empty one.
+   */
+  submitterName?: string | null;
+  submitterEmail?: string | null;
+  /** The canonical requester CONTACT link behind that snapshot (#3258 W03). */
+  requesterContactId?: string | null;
 }
 
 export interface TicketPage {

--- a/packages/shared/src/validators/tickets.test.ts
+++ b/packages/shared/src/validators/tickets.test.ts
@@ -145,6 +145,7 @@ describe('ticket validators', () => {
   describe('requester fields', () => {
     const ORG = '3f2f1d8e-1111-4222-8333-444455556666';
     const PORTAL_USER = '5a6b7c8d-1234-4321-abcd-000011112222';
+    const CONTACT = '9c8d7e6f-2222-4333-8444-555566667777';
 
     it('createTicketSchema accepts a portal-user requester (submittedBy)', () => {
       const r = createTicketSchema.safeParse({ orgId: ORG, subject: 'x', submittedBy: PORTAL_USER });
@@ -175,6 +176,35 @@ describe('ticket validators', () => {
     it('updateTicketSchema rejects an empty submitterName (clear via null, not "")', () => {
       expect(updateTicketSchema.safeParse({ submitterName: '' }).success).toBe(false);
       expect(updateTicketSchema.safeParse({ submitterName: null }).success).toBe(true);
+    });
+
+    // #5367: the staff create/update surface can now name the canonical
+    // requester PERSON directly (`tickets.requester_contact_id`), not just a
+    // portal login. A missing field here is not a validation error — it is a
+    // SILENT DROP, because the schema strips unknown keys before the route
+    // spreads the body into `createTicket`.
+    it('createTicketSchema accepts and preserves requesterContactId', () => {
+      const r = createTicketSchema.safeParse({ orgId: ORG, subject: 'x', requesterContactId: CONTACT });
+      expect(r.success).toBe(true);
+      if (r.success) expect(r.data.requesterContactId).toBe(CONTACT);
+    });
+
+    it('createTicketSchema rejects a non-uuid requesterContactId', () => {
+      expect(createTicketSchema.safeParse({ orgId: ORG, subject: 'x', requesterContactId: 'nope' }).success).toBe(false);
+    });
+
+    it('updateTicketSchema accepts requesterContactId, incl null to clear the contact link', () => {
+      const set = updateTicketSchema.safeParse({ requesterContactId: CONTACT });
+      expect(set.success).toBe(true);
+      if (set.success) expect(set.data.requesterContactId).toBe(CONTACT);
+
+      const cleared = updateTicketSchema.safeParse({ requesterContactId: null });
+      expect(cleared.success).toBe(true);
+      if (cleared.success) expect(cleared.data.requesterContactId).toBeNull();
+    });
+
+    it('updateTicketSchema rejects a non-uuid requesterContactId', () => {
+      expect(updateTicketSchema.safeParse({ requesterContactId: 'nope' }).success).toBe(false);
     });
   });
 

--- a/packages/shared/src/validators/tickets.ts
+++ b/packages/shared/src/validators/tickets.ts
@@ -31,7 +31,15 @@ export const createTicketSchema = z
     // backfills name/email from that row when they aren't supplied here.
     submittedBy: z.string().guid().optional(),
     submitterName: z.string().min(1).max(255).optional(),
-    submitterEmail: z.string().email().max(255).optional()
+    submitterEmail: z.string().email().max(255).optional(),
+    // #5367: the canonical requester PERSON (`tickets.requester_contact_id`,
+    // #3258 W03). Independent of `submittedBy`, which names the optional portal
+    // LOGIN — a contact may have no login at all. The service tenant-validates
+    // it against the ticket's org before any write and backfills the
+    // name/email snapshot from the contact when neither is supplied here.
+    // Declared on the schema because a zod object STRIPS unknown keys: without
+    // this line the route silently drops the field on its way to createTicket.
+    requesterContactId: z.string().guid().optional()
   })
   .superRefine((v, ctx) => {
     if (!v.formId && (!v.subject || v.subject.trim().length === 0)) {
@@ -76,7 +84,11 @@ export const updateTicketSchema = z.object({
   // submitterName mirrors create's min(1) (use null to clear, not an empty string).
   submittedBy: z.string().guid().nullable().optional(),
   submitterName: z.string().min(1).max(255).nullable().optional(),
-  submitterEmail: z.string().email().max(255).nullable().optional()
+  submitterEmail: z.string().email().max(255).nullable().optional(),
+  // #5367: re-point the requester CONTACT explicitly. An explicit value wins
+  // over the link the service otherwise derives from the login/address (the
+  // same precedence createTicket gives a named contact); null clears it.
+  requesterContactId: z.string().guid().nullable().optional()
 });
 
 export const changeTicketStatusSchema = z.object({


### PR DESCRIPTION
## What

Phone-created tickets landed with an empty requester, so the customer never got the public-reply emails.

The canonical requester person (`tickets.requester_contact_id`, #3258 W03) was already accepted, same-org validated and written by `createTicket()` (`ticketService.ts:465-471, 565-567, 673`). The gap was one level up: `createTicketSchema` never declared `requesterContactId`, and a zod object **strips unknown keys**, so `POST /api/v1/tickets` — which spreads the parsed body straight into `createTicket` — silently dropped it. Only the Outlook add-in and inbound email could set a requester contact.

## API

- `requesterContactId` added to `createTicketSchema` (optional uuid) and `updateTicketSchema` (nullable, so a requester can be unlinked).
- `updateTicketFields` now honours an explicitly named contact, overriding the link the login/address rules otherwise derive — the same precedence `createTicket` gives `namedContact`. It is tenant-validated through the existing `assertRequesterContactInOrg` **before any write**, so a cross-org id never reaches the update. `null` drops only the link: the `submitter_name`/`submitter_email` snapshot is what the notify worker mails and what threadMatcher binds on, so unlinking must not strip the ticket's reply-to identity.
- When a contact is named and neither name nor email was supplied (and no portal login owns the ticket), both are backfilled from the contact row, so the existing email/reply worker keeps working.

**Enforcement point is unchanged** — the same-org rule stays in the service. The route only surfaces it (`400 REQUESTER_CONTACT_WRONG_ORG`).

## Mobile

- New `services/orgContacts.ts` against `GET /api/v1/orgs/organizations/:id/contacts?limit=100`, mirroring `services/organizations.ts` and narrowing `ContactRecord` to what the picker needs.
- New `ContactPickerSheet` in the `OrgPickerSheet` shape — searchable, because a customer org routinely has more contacts than a partner has staff. Search is a client-side filter over the single fetched page; an org with >100 contacts needs server-side search (follow-up).
- CONTACT selector under Organization on `CreateTicketScreen`: optional, "No contact" default, primary contact first, `name · email` labels. It clears when the organization changes (contacts are org-scoped, so carrying a pick across would POST another customer's person), and the row is hidden entirely on a 403 — the same rule `isExpectedAssigneeLoadFailure` already applies for a tech without `users:read`. `buildCreateTicketBody` omits the field rather than sending `null`.
- Ticket detail shows `Requester <name>` off the `submitterName`/`submitterEmail` snapshot. **No new API display fields were needed**: `GET /tickets/:id` returns the whole `tickets` row via `getScopedTicketOr404`, so the snapshot (and `requesterContactId`) already ship. The row is hidden when the ticket names nobody rather than rendered empty.

## Tests (written red-first, control verified)

Removing the two schema lines makes the route suite fail 2 (`201` instead of `400`; pass-through assertion) and the shared validator suite fail 4 — confirmed by mutating the source and re-running, not assumed.

- `apps/api/src/routes/tickets/tickets.test.ts` — pass-through to `createTicket`, `400` on a non-uuid before the service is reached, and the cross-org rejection surfaced as `400 REQUESTER_CONTACT_WRONG_ORG`.
- `apps/api/src/services/ticketService.test.ts` — same-org write, cross-org rejection, snapshot backfill, and the update path's explicit-contact precedence / clear semantics.
- `packages/shared/src/validators/tickets.test.ts` — both schemas.
- `apps/mobile/src/screens/tickets/createTicketForm.test.ts`, `ticketCopy.test.ts`, `services/orgContacts.test.ts` — body building, org-change clearing, ordering/labels, 403 classification, request path encoding.

### Verification

| check | result |
|---|---|
| `npx vitest run src/routes/tickets src/services/ticketService.test.ts` (apps/api) | 12 files, 575 passed |
| `npx vitest run src/validators/tickets.test.ts` (packages/shared) | 53 passed |
| `pnpm --filter breeze-mobile test` (full suite) | 116 files, 1510 passed / 3 skipped |
| `pnpm --filter breeze-mobile typecheck` | clean |
| `npx tsc --noEmit -p .` (apps/api) | clean (needed `--max-old-space-size=8192`) |

`packages/shared` `tsc --noEmit` reports 3 pre-existing errors in `src/validators/quotes.test.ts`, untouched by this PR.

No migration, no schema change, no new table — `requester_contact_id` and its composite FK already exist, so no cascade/export-policy registration applies.

## Follow-up (not this PR)

The web `CreateTicketPage` still offers **portal users** only (`GET /tickets/requesters`) and has no contact picker. Giving it the same selector is a separate issue, as the issue notes.

Closes #5367

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01141Ns599G1Dp4MqYcmp7Qn