### PR TITLE
chore(ci): reuse application builds across tests and releases

### DIFF
--- a/.github/actions/load-smoke-images/action.yml
+++ b/.github/actions/load-smoke-images/action.yml
@@ -1,0 +1,38 @@
+name: Load smoke images
+description: Load this workflow run's API, web, and portal images for both smoke suites.
+runs:
+  using: composite
+  steps:
+    - name: Download smoke images from this run
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      with:
+        pattern: ci-smoke-image-*
+        merge-multiple: true
+        path: ${{ runner.temp }}/smoke-images
+
+    - name: Load and verify smoke images
+      shell: bash
+      env:
+        IMAGE_ARCHIVE_DIR: ${{ runner.temp }}/smoke-images
+        CI_IMAGE_VERSION: ci-smoke-${{ github.run_id }}
+        CI_IMAGE_REVISION: ${{ github.sha }}
+      run: |
+        set -euo pipefail
+        for app in api web portal; do
+          docker load --input "${IMAGE_ARCHIVE_DIR}/${app}.tar"
+          ref="ghcr.io/lanternops/breeze/${app}:${CI_IMAGE_VERSION}"
+          revision="$(docker image inspect --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' "${ref}")"
+          if [[ "${revision}" != "${CI_IMAGE_REVISION}" ]]; then
+            echo "::error::${app} image does not match this checkout"
+            exit 1
+          fi
+        done
+        # Export only after all three images are loaded and verified. Shell
+        # environment takes precedence over .env during Compose interpolation.
+        {
+          echo "BREEZE_VERSION=${CI_IMAGE_VERSION}"
+          echo "GUIDED_SMOKE_VERSION=${CI_IMAGE_VERSION}"
+          echo "BREEZE_API_IMAGE_REF=ghcr.io/lanternops/breeze/api:${CI_IMAGE_VERSION}"
+          echo "BREEZE_WEB_IMAGE_REF=ghcr.io/lanternops/breeze/web:${CI_IMAGE_VERSION}"
+          echo "BREEZE_PORTAL_IMAGE_REF=ghcr.io/lanternops/breeze/portal:${CI_IMAGE_VERSION}"
+        } >> "${GITHUB_ENV}"

--- a/.github/scripts/ci-build-reuse.test.mjs
+++ b/.github/scripts/ci-build-reuse.test.mjs
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { test } from 'node:test';
+
+const workflow = readFileSync(new URL('../workflows/ci.yml', import.meta.url), 'utf8');
+const loader = readFileSync(new URL('../actions/load-smoke-images/action.yml', import.meta.url), 'utf8');
+const job = (name) => {
+  const body = workflow.match(new RegExp(`^  ${name}:\\n([\\s\\S]*?)(?=^  [a-z][\\w-]*:|$(?![\\s\\S]))`, 'm'))?.[1];
+  assert.ok(body, `Missing job ${name}`);
+  return body;
+};
+const shellBlock = (text, indentation) => {
+  const lines = text.split('run: |\n')[1]?.split('\n');
+  assert.ok(lines, 'Missing run script');
+  return lines.filter((line) => line.startsWith(' '.repeat(indentation)))
+    .map((line) => line.slice(indentation)).join('\n');
+};
+
+test('unit tests avoid app compilation while dedicated builds remain required', () => {
+  for (const [app, command] of [
+    ['api', 'pnpm --filter=@breeze/api test:run'],
+    ['web', 'pnpm --filter=@breeze/web test --run'],
+    ['portal', 'pnpm --filter=@breeze/portal test'],
+  ]) {
+    assert.ok(job(`test-${app}`).includes(`run: ${command}`));
+    assert.doesNotMatch(job(`test-${app}`), /run: pnpm test --filter=/u);
+    assert.ok(job(`build-${app}`).includes(`pnpm build --filter=@breeze/${app}`));
+    assert.ok(job('ci-success').includes(`[[ "\${BUILD_${app.toUpperCase()}_RESULT}" != "success" ]]`));
+  }
+});
+
+test('each smoke image is built once, with matching build args and its own cache', () => {
+  const producer = job('build-smoke-images');
+  const compose = readFileSync(new URL('../../docker-compose.override.yml.ci', import.meta.url), 'utf8');
+  for (const app of ['api', 'web', 'portal']) assert.ok(producer.includes(`- image: ${app}`));
+  for (const file of ['docker/Dockerfile.api', 'docker/Dockerfile.web', 'apps/portal/Dockerfile']) {
+    assert.ok(producer.includes(`dockerfile: ${file}`));
+    assert.ok(compose.includes(`dockerfile: ${file}`));
+  }
+  assert.match(producer, /build-args: PUBLIC_API_URL=/u);
+  assert.match(producer, /PORTAL_BASE_PATH=\/portal\n\s+PUBLIC_API_URL=/u);
+  assert.match(producer, /platforms: linux\/amd64/u);
+  assert.match(producer, /push: false/u);
+  assert.doesNotMatch(producer, /packages: write|secrets\.|login-action/u);
+  assert.match(producer, /cache-from: type=gha,scope=ci-smoke-\$\{\{ matrix.image \}\}/u);
+  assert.match(producer, /cache-to: type=gha,mode=max,scope=ci-smoke-\$\{\{ matrix.image \}\}/u);
+  assert.match(producer, /outputs: type=docker,dest=\$\{\{ runner.temp \}\}\/\$\{\{ matrix.image \}\}.tar/u);
+  assert.match(producer, /name: ci-smoke-image-\$\{\{ matrix.image \}\}/u);
+  assert.match(producer, /if-no-files-found: error/u);
+  assert.match(loader, /pattern: ci-smoke-image-\*/u);
+  assert.doesNotMatch(loader, /github-token:|run-id:|repository:/u, 'download only this run, including fork PRs');
+});
+
+test('both suites depend on and load shared images instead of rebuilding', () => {
+  for (const name of ['smoke-test', 'guided-setup-smoke']) {
+    const body = job(name);
+    assert.match(body, /needs: \[[^\]]*build-smoke-images[^\]]*\]/u);
+    assert.match(body, /uses: \.\/\.github\/actions\/load-smoke-images/u);
+    assert.doesNotMatch(body, /docker build|up --build/u);
+  }
+  assert.match(job('smoke-test'), /up --no-build -d/u);
+  assert.doesNotMatch(job('smoke-test'), /BREEZE_(API|WEB|PORTAL)_IMAGE_REF=.*:latest/u);
+  assert.match(job('lint'), /node --test \.github\/scripts\/ci-build-reuse.test.mjs/u);
+});
+
+// Exercise the actual loader shell without building or loading local images.
+// A missing artifact, failed docker load, or wrong checkout must stop both
+// consumers before their application references are exported to later steps.
+for (const [label, missing, loadFailure, revision, expectedStatus] of [
+  ['all images match', '', '', 'current-sha', 0],
+  ['missing portal archive', 'portal', '', 'current-sha', 1],
+  ['docker load fails', '', 'web', 'current-sha', 1],
+  ['stale image revision', '', '', 'previous-sha', 1],
+]) {
+  test(`loader: ${label}`, () => {
+    const dir = mkdtempSync(join(tmpdir(), 'breeze-image-loader-'));
+    try {
+      for (const app of ['api', 'web', 'portal']) {
+        if (app !== missing) writeFileSync(join(dir, `${app}.tar`), 'fixture');
+      }
+      writeFileSync(join(dir, 'docker'), `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "load" ]]; then
+  [[ "$2" == "--input" && -f "$3" ]] || exit 1
+  [[ -z "$LOAD_FAILURE" || "$3" != */"$LOAD_FAILURE".tar ]] || exit 1
+elif [[ "$1 $2" == "image inspect" ]]; then
+  [[ "\${@: -1}" == ghcr.io/lanternops/breeze/*:ci-smoke-123 ]] || exit 1
+  echo "$TEST_REVISION"
+else
+  exit 1
+fi
+`, { mode: 0o755 });
+      const envFile = join(dir, 'github-env');
+      writeFileSync(envFile, '');
+      const execution = spawnSync('bash', ['-e', '-c', shellBlock(loader, 8)], {
+        encoding: 'utf8',
+        env: {
+          ...process.env, PATH: `${dir}:${process.env.PATH}`, IMAGE_ARCHIVE_DIR: dir,
+          CI_IMAGE_VERSION: 'ci-smoke-123', CI_IMAGE_REVISION: 'current-sha',
+          TEST_REVISION: revision, LOAD_FAILURE: loadFailure, GITHUB_ENV: envFile,
+        },
+      });
+      assert.equal(execution.status, expectedStatus, execution.stdout + execution.stderr);
+      const output = readFileSync(envFile, 'utf8');
+      if (expectedStatus !== 0) assert.equal(output, '');
+      else {
+        assert.ok(output.includes('GUIDED_SMOKE_VERSION=ci-smoke-123\n'));
+        for (const app of ['api', 'web', 'portal']) {
+          assert.ok(output.includes(`BREEZE_${app.toUpperCase()}_IMAGE_REF=ghcr.io/lanternops/breeze/${app}:ci-smoke-123\n`));
+        }
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+}
+
+const summary = job('ci-success');
+const passing = Object.fromEntries(
+  [...summary.matchAll(/^          (\w+_RESULT):/gmu)].map((match) => [match[1], 'success']),
+);
+for (const result of ['failure', 'cancelled', 'skipped', '']) {
+  for (const isPr of ['true', 'false']) {
+    test(`summary: image producer ${result || 'missing'}, PR=${isPr}`, () => {
+      const execution = spawnSync('bash', ['-e', '-c', shellBlock(summary, 10)], {
+        encoding: 'utf8',
+        env: {
+          ...process.env, ...passing, IS_PR: isPr, CODE_CHANGED: 'true', DOCS_CHANGED: 'false',
+          MOBILE_NATIVE_REQUIRED: 'true', BUILD_SMOKE_IMAGES_RESULT: result,
+          SMOKE_TEST_RESULT: 'skipped', GUIDED_SETUP_SMOKE_RESULT: 'skipped',
+        },
+      });
+      assert.equal(execution.status, isPr === 'true' ? 0 : 1, execution.stdout + execution.stderr);
+    });
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,9 @@ jobs:
       - name: Test docs-only CI contract
         run: node --test .github/scripts/classify-pr-paths.test.mjs
 
+      - name: Test CI build reuse contract
+        run: node --test .github/scripts/ci-build-reuse.test.mjs
+
       - name: Guard retired AI documentation automation
         run: pnpm test:docs-automation
 
@@ -291,7 +294,9 @@ jobs:
         run: pnpm --filter @breeze/ext-workspace typecheck
 
       - name: Run API tests
-        run: pnpm test --filter=@breeze/api
+        # Vitest resolves workspace packages from source; build-api owns the
+        # production bundle check. Root `pnpm test` would also invoke that build.
+        run: pnpm --filter=@breeze/api test:run
 
       # Timezone-correctness regression gate (#4046): GitHub-hosted runners
       # default to UTC, and nothing else in this job or in vitest.config.ts
@@ -632,7 +637,9 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run Web tests
-        run: pnpm test --filter=@breeze/web
+        # Source aliases in vitest.config.ts avoid a production Astro build.
+        # build-web still runs prebuild (checksums/Monaco assets) and Astro.
+        run: pnpm --filter=@breeze/web test --run
 
   # REQUIRED check: asserted in ci-success (see #3941, and #3139 for the
   # original gap).
@@ -803,7 +810,8 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run Portal tests
-        run: pnpm test --filter=@breeze/portal
+        # Keep production compilation in build-portal; Vitest tests source.
+        run: pnpm --filter=@breeze/portal test
 
   # The Viewer's TypeScript tests (transports, keymap, protocol, paste, …) ran
   # in no CI job at all until issue #3410 added a regression test here and found
@@ -2437,19 +2445,78 @@ jobs:
         run: docker compose -f docker-compose.test.yml down -v || true
 
   # ─── Smoke Test ───────────────────────────────────────────────────────
-  # Builds Docker images, starts the full stack, and verifies:
+  # Both smoke suites consume these exact images from this workflow run. Keep
+  # image artifacts separate from the cache: a cache miss must never require a
+  # consumer to rebuild, and fork PRs must not need registry write credentials.
+  build-smoke-images:
+    name: Build Smoke Image (${{ matrix.image }})
+    runs-on: ubuntu-latest
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
+    continue-on-error: ${{ github.event_name == 'pull_request' }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: api
+            dockerfile: docker/Dockerfile.api
+            build-args: ''
+          - image: web
+            dockerfile: docker/Dockerfile.web
+            build-args: PUBLIC_API_URL=
+          - image: portal
+            dockerfile: apps/portal/Dockerfile
+            build-args: |
+              PORTAL_BASE_PATH=/portal
+              PUBLIC_API_URL=
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
+
+      - name: Build and export smoke image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64
+          push: false
+          tags: ghcr.io/lanternops/breeze/${{ matrix.image }}:ci-smoke-${{ github.run_id }}
+          labels: org.opencontainers.image.revision=${{ github.sha }}
+          build-args: ${{ matrix.build-args }}
+          outputs: type=docker,dest=${{ runner.temp }}/${{ matrix.image }}.tar
+          cache-from: type=gha,scope=ci-smoke-${{ matrix.image }}
+          cache-to: type=gha,mode=max,scope=ci-smoke-${{ matrix.image }}
+
+      - name: Upload smoke image
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ci-smoke-image-${{ matrix.image }}
+          path: ${{ runner.temp }}/${{ matrix.image }}.tar
+          if-no-files-found: error
+          compression-level: 1
+          retention-days: 3
+          overwrite: true
+
+  # Loads the shared images, starts the full stack, and verifies:
   #   1. DB + Redis connectivity (health/ready)
   #   2. Login + JWT issuance
   #   3. Authenticated API endpoints (exercises core DB tables)
   #   4. Web page loads (SSR rendering works)
-  # Non-blocking on PRs (continue-on-error), required on main pushes.
+  # Non-blocking on PRs (continue-on-error), required in the merge queue and
+  # manual main validation.
   # The API integration suite used to run here too — it now has its own
   # BLOCKING integration-test job above; this job is purely the Docker
   # image build + stack boot + endpoint smoke.
   smoke-test:
     name: Smoke Test
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, changes]
+    needs: [lint, typecheck, changes, build-smoke-images]
     if: needs.changes.outputs.code == 'true'
     continue-on-error: ${{ github.event_name == 'pull_request' }}
     timeout-minutes: 15
@@ -2459,6 +2526,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+
+      - name: Load shared smoke images
+        uses: ./.github/actions/load-smoke-images
 
       - name: Create .env
         run: |
@@ -2483,13 +2553,11 @@ jobs:
           TURN_HOST=127.0.0.1
           TRUST_PROXY_HEADERS=false
           # Image refs — base docker-compose.yml requires these via ${VAR:?...}.
-          # The CI override builds api/web from source and disables caddy/coturn,
+          # The CI override defines app builds and disables caddy/coturn,
           # but Compose still parses interpolation in the base file before
           # profile filtering, so all refs must resolve. Mutable tags are fine
           # here since this stack is ephemeral (torn down in Teardown step).
-          BREEZE_API_IMAGE_REF=ghcr.io/lanternops/breeze/api:latest
-          BREEZE_WEB_IMAGE_REF=ghcr.io/lanternops/breeze/web:latest
-          BREEZE_PORTAL_IMAGE_REF=ghcr.io/lanternops/breeze/portal:latest
+          # App refs are supplied by the shared-image loader via GITHUB_ENV.
           BREEZE_BINARIES_IMAGE_REF=ghcr.io/lanternops/breeze/binaries:latest
           CADDY_IMAGE_REF=caddy:2-alpine
           # Mirrors .env.example's default. This stack deliberately leaves
@@ -2538,8 +2606,8 @@ jobs:
           FORCE_HTTPS=false
           EOF
 
-      - name: Build and start containers
-        run: docker compose -f docker-compose.yml -f docker-compose.override.yml.ci up --build -d
+      - name: Start containers from shared images
+        run: docker compose -f docker-compose.yml -f docker-compose.override.yml.ci up --no-build -d
 
       - name: Wait for API ready (DB + Redis)
         run: |
@@ -2756,11 +2824,11 @@ jobs:
   # reboot-startup systemd unit really enables/starts/stops/starts the stack.
   # Both #4201 defects and the tunnel login loop only ever surfaced on
   # customers' hosts because nothing executed the installer before release.
-  # Same policy as smoke-test: non-blocking on PRs, required on main.
+  # Same policy as smoke-test: non-blocking on PRs, required in the merge queue.
   guided-setup-smoke:
     name: Guided Setup Smoke (self-host installer)
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, changes]
+    needs: [lint, typecheck, changes, build-smoke-images]
     if: needs.changes.outputs.code == 'true'
     continue-on-error: ${{ github.event_name == 'pull_request' }}
     timeout-minutes: 30
@@ -2776,33 +2844,10 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y -qq socat
 
-      # The installer pins images by BREEZE_VERSION; build this checkout's
-      # api/web/portal under that tag so `docker compose up` uses them
-      # (the pull for these local-only tags fails, which the installer treats
-      # as non-fatal — the documented bring-your-own-images path). The agent
-      # binaries image is pulled from GHCR like the Smoke Test job does.
-      - name: Build api/web/portal images under the ci-smoke tag
-        run: |
-          set -euo pipefail
-          mkdir -p /tmp/guided-smoke-build
-          docker build -f docker/Dockerfile.api -t ghcr.io/lanternops/breeze/api:ci-smoke .             > /tmp/guided-smoke-build/api.log 2>&1 &
-          API_PID=$!
-          docker build -f docker/Dockerfile.web --build-arg PUBLIC_API_URL=             -t ghcr.io/lanternops/breeze/web:ci-smoke .             > /tmp/guided-smoke-build/web.log 2>&1 &
-          WEB_PID=$!
-          docker build -f apps/portal/Dockerfile --build-arg PORTAL_BASE_PATH=/portal --build-arg PUBLIC_API_URL=             -t ghcr.io/lanternops/breeze/portal:ci-smoke .             > /tmp/guided-smoke-build/portal.log 2>&1 &
-          PORTAL_PID=$!
-          FAIL=0
-          for pair in "api:${API_PID}" "web:${WEB_PID}" "portal:${PORTAL_PID}"; do
-            name="${pair%%:*}"; pid="${pair##*:}"
-            if wait "${pid}"; then
-              echo "built ghcr.io/lanternops/breeze/${name}:ci-smoke"
-            else
-              echo "::error::docker build failed for ${name}"
-              tail -60 "/tmp/guided-smoke-build/${name}.log"
-              FAIL=1
-            fi
-          done
-          [ "${FAIL}" -eq 0 ]
+      # The installer uses the same run-specific local tags as Smoke Test.
+      # Registry pulls cannot substitute a published release for this checkout.
+      - name: Load shared smoke images
+        uses: ./.github/actions/load-smoke-images
 
       - name: Mask the fixed bootstrap credential before the installer prints it
         run: echo "::add-mask::ci-smoke-bootstrap-credential-32-chars"
@@ -3176,7 +3221,7 @@ jobs:
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [changes, docs-check, lint, typecheck, test-api, test-m365-graph-read-executor, test-m365-graph-actions-executor, test-m365-communications-executor, test-web, test-mobile, mobile-native-changes, build-mobile-ios, test-portal, test-viewer, test-office-addin-core, test-excel-addin, test-word-addin, test-powerpoint-addin, test-outlook-addin, security-audit, build-api, build-m365-graph-read-executor, build-m365-graph-actions-executor, build-m365-communications-executor, build-web, build-portal, build-agent, test-agent, test-agent-windows, windows-runtime-smoke, integration-test, check-migrations-nonsuperuser, rust-check, smoke-test, guided-setup-smoke, auth-browser-transition-browser-contract]
+    needs: [changes, docs-check, lint, typecheck, test-api, test-m365-graph-read-executor, test-m365-graph-actions-executor, test-m365-communications-executor, test-web, test-mobile, mobile-native-changes, build-mobile-ios, test-portal, test-viewer, test-office-addin-core, test-excel-addin, test-word-addin, test-powerpoint-addin, test-outlook-addin, security-audit, build-api, build-m365-graph-read-executor, build-m365-graph-actions-executor, build-m365-communications-executor, build-web, build-portal, build-agent, test-agent, test-agent-windows, windows-runtime-smoke, integration-test, check-migrations-nonsuperuser, rust-check, build-smoke-images, smoke-test, guided-setup-smoke, auth-browser-transition-browser-contract]
     if: ${{ !cancelled() }}
     steps:
       - name: Check all jobs passed
@@ -3217,6 +3262,7 @@ jobs:
           INTEGRATION_TEST_RESULT: ${{ needs.integration-test.result }}
           CHECK_MIGRATIONS_NONSUPERUSER_RESULT: ${{ needs.check-migrations-nonsuperuser.result }}
           RUST_CHECK_RESULT: ${{ needs.rust-check.result }}
+          BUILD_SMOKE_IMAGES_RESULT: ${{ needs.build-smoke-images.result }}
           SMOKE_TEST_RESULT: ${{ needs.smoke-test.result }}
           GUIDED_SETUP_SMOKE_RESULT: ${{ needs.guided-setup-smoke.result }}
           AUTH_BROWSER_TRANSITION_BROWSER_CONTRACT_RESULT: ${{ needs.auth-browser-transition-browser-contract.result }}
@@ -3277,7 +3323,12 @@ jobs:
             echo "Docs-only PR: code jobs skipped, docs-check passed; the merge queue runs the full suite before merge."
             exit 0
           fi
-          # Smoke test: non-blocking on PRs, required on main
+          # The shared producer has the same policy as its smoke consumers.
+          if [[ "${IS_PR}" != "true" ]] && [[ "${BUILD_SMOKE_IMAGES_RESULT}" != "success" ]]; then
+            echo "Smoke image build failed during merge-queue or manual validation"
+            exit 1
+          fi
+          # Smoke test: non-blocking on PRs, required in the merge queue and manual validation
           if [[ "${IS_PR}" != "true" ]] && [[ "${SMOKE_TEST_RESULT}" != "success" ]]; then
             echo "Smoke test failed on main branch push"
             exit 1

--- a/.github/workflows/hosted-images.yml
+++ b/.github/workflows/hosted-images.yml
@@ -167,8 +167,8 @@ jobs:
             org.opencontainers.image.revision=${{ needs.validate.outputs.sha }}
             org.opencontainers.image.version=${{ needs.validate.outputs.version }}
           build-args: ${{ env.BUILD_ARGS }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=server-${{ matrix.image }}
+          cache-to: type=gha,mode=max,scope=server-${{ matrix.image }}
 
   build-m365-executor-image:
     name: Build & Push ${{ matrix.image }} (${{ inputs.tag }})
@@ -234,8 +234,8 @@ jobs:
           context: .
           file: apps/${{ matrix.image }}/Dockerfile
           outputs: type=image,name=${{ env.IMAGE_BASE }}/${{ matrix.image }},push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=server-${{ matrix.image }}
+          cache-to: type=gha,mode=max,scope=server-${{ matrix.image }}
 
       - name: Scan exact executor digest
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0

--- a/.github/workflows/release-build-check.yml
+++ b/.github/workflows/release-build-check.yml
@@ -1,0 +1,85 @@
+name: Release Build Check
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/api/Dockerfile'
+      - 'apps/web/Dockerfile'
+      - '.github/workflows/release.yml'
+      - '.github/workflows/release-build-check.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-build-check-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify-release-packaging:
+    name: Verify ${{ matrix.app }} release packaging
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        app: [api, web]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
+
+      - name: Build and export release distribution
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: .
+          file: apps/${{ matrix.app }}/Dockerfile
+          target: release-dist
+          push: false
+          outputs: type=local,dest=${{ runner.temp }}/release-dist
+          build-args: |
+            APP_VERSION=release-build-check
+            PUBLIC_APP_VERSION=release-build-check
+          cache-from: type=gha,scope=release-build-check-${{ matrix.app }}
+          cache-to: type=gha,mode=max,scope=release-build-check-${{ matrix.app }}
+
+      # Exercise the same context override as release.yml before a tag publishes
+      # an image. No registry credentials or application startup are necessary.
+      # Reuse this job's builder locally; do not overwrite its compilation cache
+      # with the smaller named-context runtime graph.
+      - name: Package runtime from exported distribution
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: .
+          file: apps/${{ matrix.app }}/Dockerfile
+          build-contexts: |
+            release-dist=${{ runner.temp }}/release-dist
+          push: false
+          load: true
+          tags: breeze-release-build-check:${{ matrix.app }}
+          build-args: |
+            APP_VERSION=release-build-check
+            PUBLIC_APP_VERSION=release-build-check
+
+      - name: Verify runtime contains the exact exported files
+        env:
+          APP: ${{ matrix.app }}
+          EXPORT_DIR: ${{ runner.temp }}/release-dist
+          VERIFY_DIR: ${{ runner.temp }}/verify-release-dist
+        run: |
+          set -euo pipefail
+          mkdir -p "$VERIFY_DIR"
+          container_id=$(docker create "breeze-release-build-check:$APP")
+          trap 'docker rm "$container_id" >/dev/null' EXIT
+          docker cp "$container_id:/app/apps/$APP/dist" "$VERIFY_DIR/app-dist"
+          diff --recursive --no-dereference "$EXPORT_DIR/apps/$APP/dist" "$VERIFY_DIR/app-dist"
+          if [ "$APP" = api ]; then
+            docker cp "$container_id:/app/apps/api/ee/workspace/dist" "$VERIFY_DIR/workspace-dist"
+            diff --recursive --no-dereference "$EXPORT_DIR/ee/workspace/dist" "$VERIFY_DIR/workspace-dist"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,28 +39,43 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
+
+      - name: Get version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      # Export the runtime Dockerfile's compiled files. The publisher consumes
+      # these exact artifacts through a named context after create-release.
+      - name: Build and export API distribution
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
-          version: ${{ env.PNPM_VERSION }}
-
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        with:
-          node-version-file: .node-version
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build API
-        run: pnpm build --filter=@breeze/api
+          context: .
+          file: apps/api/Dockerfile
+          target: release-dist
+          outputs: type=local,dest=${{ runner.temp }}/api-release
+          build-args: |
+            APP_VERSION=${{ steps.version.outputs.version }}
+          cache-from: |
+            type=gha,scope=server-api-build
+            type=gha,scope=server-api
+          cache-to: type=gha,mode=max,scope=server-api-build
 
       - name: Upload API artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: api-dist
-          path: apps/api/dist
+          path: ${{ runner.temp }}/api-release/apps/api/dist
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Upload built-in workspace web bundle
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: api-workspace-dist
+          path: ${{ runner.temp }}/api-release/ee/workspace/dist
+          if-no-files-found: error
           retention-days: 30
 
   build-web:
@@ -72,34 +87,35 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        with:
-          version: ${{ env.PNPM_VERSION }}
-
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        with:
-          node-version-file: .node-version
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
 
       - name: Get version from tag
-        id: web-version
+        id: version
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
-      - name: Build Web
-        env:
-          PUBLIC_APP_VERSION: ${{ steps.web-version.outputs.version }}
-        run: pnpm build --filter=@breeze/web
+      # Export the runtime Dockerfile's compiled files. The publisher consumes
+      # these exact artifacts through a named context after create-release.
+      - name: Build and export Web distribution
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: .
+          file: apps/web/Dockerfile
+          target: release-dist
+          outputs: type=local,dest=${{ runner.temp }}/web-release
+          build-args: |
+            PUBLIC_APP_VERSION=${{ steps.version.outputs.version }}
+          cache-from: |
+            type=gha,scope=server-web-build
+            type=gha,scope=server-web
+          cache-to: type=gha,mode=max,scope=server-web-build
 
       - name: Upload Web artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: web-dist
-          path: apps/web/dist
+          path: ${{ runner.temp }}/web-release/apps/web/dist
+          if-no-files-found: error
           retention-days: 30
 
   build-agent:
@@ -2758,8 +2774,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=server-binaries
+          cache-to: type=gha,mode=max,scope=server-binaries
 
   build-docker-api:
     name: Build & Push API Docker Image
@@ -2784,7 +2800,13 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: api-dist
-          path: apps/api/dist
+          path: ${{ runner.temp }}/release-dist/apps/api/dist
+
+      - name: Download built-in workspace web bundle
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: api-workspace-dist
+          path: ${{ runner.temp }}/release-dist/ee/workspace/dist
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
@@ -2817,13 +2839,17 @@ jobs:
         with:
           context: .
           file: apps/api/Dockerfile
+          build-contexts: |
+            release-dist=${{ runner.temp }}/release-dist
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             APP_VERSION=${{ steps.version.outputs.version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: |
+            type=gha,scope=server-api-build
+            type=gha,scope=server-api
+          cache-to: type=gha,mode=max,scope=server-api
 
   build-docker-m365-graph-read-executor:
     name: Build & Push M365 Graph Read Executor Image
@@ -2876,8 +2902,8 @@ jobs:
           context: .
           file: apps/m365-graph-read-executor/Dockerfile
           outputs: type=image,name=${{ env.IMAGE_BASE }}/m365-graph-read-executor,push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=server-m365-graph-read-executor
+          cache-to: type=gha,mode=max,scope=server-m365-graph-read-executor
 
       - name: Scan exact executor digest
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
@@ -2972,8 +2998,8 @@ jobs:
           context: .
           file: apps/m365-graph-actions-executor/Dockerfile
           outputs: type=image,name=${{ env.IMAGE_BASE }}/m365-graph-actions-executor,push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=server-m365-graph-actions-executor
+          cache-to: type=gha,mode=max,scope=server-m365-graph-actions-executor
 
       - name: Scan exact executor digest
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
@@ -3068,8 +3094,8 @@ jobs:
           context: .
           file: apps/m365-communications-executor/Dockerfile
           outputs: type=image,name=${{ env.IMAGE_BASE }}/m365-communications-executor,push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=server-m365-communications-executor
+          cache-to: type=gha,mode=max,scope=server-m365-communications-executor
 
       - name: Scan exact executor digest
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
@@ -3136,7 +3162,7 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: web-dist
-          path: apps/web/dist
+          path: ${{ runner.temp }}/release-dist/apps/web/dist
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
@@ -3169,13 +3195,17 @@ jobs:
         with:
           context: .
           file: apps/web/Dockerfile
+          build-contexts: |
+            release-dist=${{ runner.temp }}/release-dist
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             PUBLIC_APP_VERSION=${{ steps.version.outputs.version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: |
+            type=gha,scope=server-web-build
+            type=gha,scope=server-web
+          cache-to: type=gha,mode=max,scope=server-web
 
   build-docker-portal:
     name: Build & Push Portal Docker Image
@@ -3228,5 +3258,5 @@ jobs:
           build-args: |
             PORTAL_BASE_PATH=/portal
             PUBLIC_API_URL=
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=server-portal
+          cache-to: type=gha,mode=max,scope=server-portal

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -56,6 +56,21 @@ RUN pnpm --filter @breeze/ext-workspace build:web
 WORKDIR /app/apps/api
 RUN pnpm build
 
+# Export only compiled files. Release jobs replace this stage with a named
+# context containing these same-run artifacts; ordinary builds use builder.
+FROM scratch AS release-dist
+COPY --from=builder /app/apps/api/dist /apps/api/dist
+COPY --from=builder /app/ee/workspace/dist /ee/workspace/dist
+
+# Runtime source and workspace dependencies do not require compilation. Keeping
+# them separate lets release packaging skip builder when release-dist is supplied.
+FROM deps AS runtime-source
+COPY packages ./packages
+COPY ee ./ee
+COPY apps/api/package.json ./apps/api/package.json
+COPY apps/api/migrations ./apps/api/migrations
+COPY apps/api/assets ./apps/api/assets
+
 # Stage 4: Production runner
 FROM node:24-alpine@sha256:e67514e5d0f6c46656005e1b693b2ec9d52e80b641307de684d4a015ba7a4eaf AS runner
 WORKDIR /app
@@ -79,24 +94,25 @@ RUN addgroup --system --gid 1001 nodejs && \
 
 # Copy API build output and dependencies while preserving pnpm workspace symlink layout.
 # /app/apps/api/node_modules links into /app/node_modules/.pnpm.
-COPY --from=builder --chown=hono:nodejs /app/apps/api/dist ./apps/api/dist
-COPY --from=builder --chown=hono:nodejs /app/apps/api/package.json ./apps/api/package.json
+COPY --from=release-dist --chown=hono:nodejs /apps/api/dist ./apps/api/dist
+COPY --from=runtime-source --chown=hono:nodejs /app/apps/api/package.json ./apps/api/package.json
 COPY --from=deps --chown=hono:nodejs /app/apps/api/node_modules ./apps/api/node_modules
 COPY --from=deps --chown=hono:nodejs /app/node_modules ./node_modules
-COPY --from=builder --chown=hono:nodejs /app/packages ./packages
+COPY --from=runtime-source --chown=hono:nodejs /app/packages ./packages
 
 # Built-in extensions: this runner's WORKDIR ends at /app/apps/api (see below),
 # and builtinRegistry.ts's CJS-bundle fallback resolves packageDir relative to
 # process.cwd() -- so the copy destination must be apps/api/ee, not /app/ee.
-COPY --from=builder --chown=hono:nodejs /app/ee ./apps/api/ee
+COPY --from=runtime-source --chown=hono:nodejs /app/ee ./apps/api/ee
+COPY --from=release-dist --chown=hono:nodejs /ee/workspace/dist ./apps/api/ee/workspace/dist
 
 # Copy migration files for auto-migrate on startup
-COPY --from=builder --chown=hono:nodejs /app/apps/api/migrations ./apps/api/migrations
+COPY --from=runtime-source --chown=hono:nodejs /app/apps/api/migrations ./apps/api/migrations
 # Document theme assets (vendored OFL font files for proposal/quote PDF
 # rendering — see apps/api/src/services/documentThemes.ts). FONT_DIR resolves
 # from process.cwd(), and this runner's cwd ends at /app/apps/api (WORKDIR
 # below), so the destination mirrors the migrations copy above.
-COPY --from=builder --chown=hono:nodejs /app/apps/api/assets ./apps/api/assets
+COPY --from=runtime-source --chown=hono:nodejs /app/apps/api/assets ./apps/api/assets
 # Run the API from its workspace path so module resolution uses apps/api/node_modules first.
 WORKDIR /app/apps/api
 

--- a/apps/api/src/config/ciSuccessGatingContract.test.ts
+++ b/apps/api/src/config/ciSuccessGatingContract.test.ts
@@ -40,10 +40,10 @@ const blockingEnd = ciSuccess.indexOf('; then', blockingStart) + '; then'.length
 const blockingCondition = ciSuccess.slice(blockingStart, blockingEnd);
 const conditionalChecks = ciSuccess.slice(blockingEnd);
 
-// smoke-test and guided-setup-smoke are deliberately non-blocking on PRs and required on main
-// pushes via the IS_PR guard (both boot a full stack; guided-setup-smoke also runs the real
+// The smoke suites and their shared image producer are non-blocking on PRs and required
+// in merge groups/manual validation via IS_PR (both boot a full stack; guided setup runs the real
 // self-host installer + systemd unit on the runner).
-const PR_EXEMPT_JOBS = new Set(['smoke-test', 'guided-setup-smoke']);
+const PR_EXEMPT_JOBS = new Set(['build-smoke-images', 'smoke-test', 'guided-setup-smoke']);
 
 const UNGATED_JOBS = new Set([
   'ci-success', // the aggregate itself

--- a/apps/api/src/config/releaseBuildReuse.test.ts
+++ b/apps/api/src/config/releaseBuildReuse.test.ts
@@ -11,6 +11,11 @@ type Job = { needs?: string[]; if?: string; steps: Step[]; permissions?: Record<
 const workflow = load(read('.github/workflows/release.yml')) as { jobs: Record<string, Job> };
 const stepsUsing = (job: Job, action: string) => job.steps.filter((step) => step.uses?.startsWith(`${action}@`));
 
+function required<T>(value: T | null | undefined, label: string): T {
+  if (value === null || value === undefined) throw new Error(`Missing ${label}`);
+  return value;
+}
+
 // Model FROM/COPY dependencies, so a future runner COPY from builder cannot
 // silently restore compilation in the release packaging path.
 function stages(source: string) {
@@ -19,13 +24,13 @@ function stages(source: string) {
   for (const line of source.split('\n')) {
     const from = line.match(/^FROM\s+(\S+)\s+AS\s+(\S+)$/i);
     if (from) {
-      current = from[2];
-      result.set(current, { body: '', dependencies: [from[1]] });
+      current = required(from[2], 'FROM stage alias');
+      result.set(current, { body: '', dependencies: [required(from[1], 'FROM source')] });
     } else if (current) {
-      const stage = result.get(current)!;
+      const stage = required(result.get(current), `stage ${current}`);
       stage.body += `${line}\n`;
       const copy = line.match(/^COPY\s+--from=(\S+)/i);
-      if (copy) stage.dependencies.push(copy[1]);
+      if (copy) stage.dependencies.push(required(copy[1], 'COPY source stage'));
     }
   }
   return result;
@@ -37,16 +42,16 @@ function ancestors(source: string, overrides: Set<string>) {
   function visit(name: string) {
     if (seen.has(name) || !graph.has(name)) return;
     seen.add(name);
-    if (!overrides.has(name)) graph.get(name)!.dependencies.forEach(visit);
+    if (!overrides.has(name)) required(graph.get(name), `stage ${name}`).dependencies.forEach(visit);
   }
-  visit([...graph.keys()].at(-1)!);
+  visit(required([...graph.keys()].at(-1), 'final Dockerfile stage'));
   return seen;
 }
 
 describe.each(['api', 'web'])('release %s compilation reuse', (app) => {
   const dockerfile = read(`apps/${app}/Dockerfile`);
-  const build = workflow.jobs[`build-${app}`];
-  const publish = workflow.jobs[`build-docker-${app}`];
+  const build = required(workflow.jobs[`build-${app}`], `build-${app} job`);
+  const publish = required(workflow.jobs[`build-docker-${app}`], `build-docker-${app} job`);
 
   it('uses the compiler for ordinary builds and bypasses it for supplied distributions', () => {
     expect([...stages(dockerfile).keys()].at(-1)).toBe('runner');
@@ -55,33 +60,35 @@ describe.each(['api', 'web'])('release %s compilation reuse', (app) => {
     expect(packaging).toContain('release-dist');
     expect(packaging).toContain('deps');
     expect(packaging).not.toContain('builder');
-    expect(stages(dockerfile).get('runner')!.body).toContain(` /apps/${app}/dist ./apps/${app}/dist`);
+    expect(required(stages(dockerfile).get('runner'), 'runner stage').body).toContain(` /apps/${app}/dist ./apps/${app}/dist`);
   });
 
   it('maps every exported compiled directory through same-run artifacts into the named context', () => {
     const buildStep = stepsUsing(build, 'docker/build-push-action');
     expect(buildStep).toHaveLength(1);
-    expect(buildStep[0].with?.target).toBe('release-dist');
-    expect(buildStep[0].with?.push).not.toBe(true);
-    expect(buildStep[0].with?.outputs).toBe(`type=local,dest=\${{ runner.temp }}/${app}-release`);
+    const compileStep = required(buildStep[0], 'release compilation step');
+    expect(compileStep.with?.target).toBe('release-dist');
+    expect(compileStep.with?.push).not.toBe(true);
+    expect(compileStep.with?.outputs).toBe(`type=local,dest=\${{ runner.temp }}/${app}-release`);
     const push = stepsUsing(publish, 'docker/build-push-action');
     expect(push).toHaveLength(1);
-    expect(String(push[0].with?.['build-contexts']).trim()).toBe('release-dist=${{ runner.temp }}/release-dist');
+    const publishStep = required(push[0], 'release publishing step');
+    expect(String(publishStep.with?.['build-contexts']).trim()).toBe('release-dist=${{ runner.temp }}/release-dist');
 
-    const exported = [...stages(dockerfile).get('release-dist')!.body.matchAll(/^COPY --from=builder (\S+) (\S+)$/gm)];
+    const exported = [...required(stages(dockerfile).get('release-dist'), 'release-dist stage').body.matchAll(/^COPY --from=builder (\S+) (\S+)$/gm)];
     expect(exported).toHaveLength(app === 'api' ? 2 : 1);
-    for (const [, source, destination] of exported) {
+    for (const match of exported) {
+      const source = required(match[1], 'exported source path');
+      const destination = required(match[2], 'exported destination path');
       expect(source).toBe(`/app${destination}`);
-      const upload = stepsUsing(build, 'actions/upload-artifact').find((step) =>
-        step.with?.path === `\${{ runner.temp }}/${app}-release${destination}`);
-      expect(upload, `missing upload for ${destination}`).toBeDefined();
-      expect(upload!.with?.['if-no-files-found']).toBe('error');
-      const download = stepsUsing(publish, 'actions/download-artifact').find((step) =>
-        step.with?.name === upload!.with?.name);
-      expect(download, `missing download for ${destination}`).toBeDefined();
-      expect(download!.with?.path).toBe(`\${{ runner.temp }}/release-dist${destination}`);
-      expect(download!.with?.['run-id']).toBeUndefined();
-      expect(download!.with?.repository).toBeUndefined();
+      const upload = required(stepsUsing(build, 'actions/upload-artifact').find((step) =>
+        step.with?.path === `\${{ runner.temp }}/${app}-release${destination}`), `upload for ${destination}`);
+      expect(upload.with?.['if-no-files-found']).toBe('error');
+      const download = required(stepsUsing(publish, 'actions/download-artifact').find((step) =>
+        step.with?.name === upload.with?.name), `download for ${destination}`);
+      expect(download.with?.path).toBe(`\${{ runner.temp }}/release-dist${destination}`);
+      expect(download.with?.['run-id']).toBeUndefined();
+      expect(download.with?.repository).toBeUndefined();
     }
     // Preserve the public tarball's layout: its artifact contains dist contents,
     // while API's additional built-in web bundle remains a separate artifact.
@@ -92,7 +99,7 @@ describe.each(['api', 'web'])('release %s compilation reuse', (app) => {
   it('keeps publishing behind release integrity and lineage validation', () => {
     expect(publish.needs).toEqual(expect.arrayContaining([`build-${app}`, 'create-release']));
     expect(publish.if).toContain("needs.create-release.result == 'success'");
-    expect(workflow.jobs['create-release'].needs).toEqual(expect.arrayContaining(['release-integrity-gate', 'validate-release-lineage']));
+    expect(required(workflow.jobs['create-release'], 'create-release job').needs).toEqual(expect.arrayContaining(['release-integrity-gate', 'validate-release-lineage']));
     expect(build.permissions?.packages).not.toBe('write');
     expect(stepsUsing(build, 'docker/login-action')).toHaveLength(0);
     expect(build.steps.some((step) => step.run?.includes('pnpm build'))).toBe(false);
@@ -106,7 +113,7 @@ describe('release packaging validation in GitHub Actions', () => {
     permissions: Record<string, string>;
     jobs: Record<string, Job & { strategy: { matrix: { app: string[] } } }>;
   };
-  const job = check.jobs['verify-release-packaging'];
+  const job = required(check.jobs['verify-release-packaging'], 'verify-release-packaging job');
 
   it('checks both runtime images when their release build definitions change', () => {
     expect(job.strategy.matrix.app).toEqual(['api', 'web']);
@@ -119,10 +126,12 @@ describe('release packaging validation in GitHub Actions', () => {
     ]);
     const builds = stepsUsing(job, 'docker/build-push-action');
     expect(builds).toHaveLength(2);
-    expect(builds[0].with?.target).toBe('release-dist');
-    expect(builds[0].with?.outputs).toBe('type=local,dest=${{ runner.temp }}/release-dist');
-    expect(String(builds[1].with?.['build-contexts']).trim()).toBe('release-dist=${{ runner.temp }}/release-dist');
-    expect(builds[1].with?.load).toBe(true);
+    const compileStep = required(builds[0], 'validation compilation step');
+    const packageStep = required(builds[1], 'validation packaging step');
+    expect(compileStep.with?.target).toBe('release-dist');
+    expect(compileStep.with?.outputs).toBe('type=local,dest=${{ runner.temp }}/release-dist');
+    expect(String(packageStep.with?.['build-contexts']).trim()).toBe('release-dist=${{ runner.temp }}/release-dist');
+    expect(packageStep.with?.load).toBe(true);
     for (const build of builds) expect(build.with?.push).toBe(false);
     expect(check.permissions).toEqual({ contents: 'read' });
     expect(stepsUsing(job, 'docker/login-action')).toHaveLength(0);

--- a/apps/api/src/config/releaseBuildReuse.test.ts
+++ b/apps/api/src/config/releaseBuildReuse.test.ts
@@ -1,0 +1,140 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { load } from 'js-yaml';
+import { describe, expect, it } from 'vitest';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..');
+const read = (file: string) => readFileSync(path.join(root, file), 'utf8');
+type Step = { uses?: string; with?: Record<string, unknown>; run?: string };
+type Job = { needs?: string[]; if?: string; steps: Step[]; permissions?: Record<string, string> };
+const workflow = load(read('.github/workflows/release.yml')) as { jobs: Record<string, Job> };
+const stepsUsing = (job: Job, action: string) => job.steps.filter((step) => step.uses?.startsWith(`${action}@`));
+
+// Model FROM/COPY dependencies, so a future runner COPY from builder cannot
+// silently restore compilation in the release packaging path.
+function stages(source: string) {
+  const result = new Map<string, { body: string; dependencies: string[] }>();
+  let current: string | undefined;
+  for (const line of source.split('\n')) {
+    const from = line.match(/^FROM\s+(\S+)\s+AS\s+(\S+)$/i);
+    if (from) {
+      current = from[2];
+      result.set(current, { body: '', dependencies: [from[1]] });
+    } else if (current) {
+      const stage = result.get(current)!;
+      stage.body += `${line}\n`;
+      const copy = line.match(/^COPY\s+--from=(\S+)/i);
+      if (copy) stage.dependencies.push(copy[1]);
+    }
+  }
+  return result;
+}
+
+function ancestors(source: string, overrides: Set<string>) {
+  const graph = stages(source);
+  const seen = new Set<string>();
+  function visit(name: string) {
+    if (seen.has(name) || !graph.has(name)) return;
+    seen.add(name);
+    if (!overrides.has(name)) graph.get(name)!.dependencies.forEach(visit);
+  }
+  visit([...graph.keys()].at(-1)!);
+  return seen;
+}
+
+describe.each(['api', 'web'])('release %s compilation reuse', (app) => {
+  const dockerfile = read(`apps/${app}/Dockerfile`);
+  const build = workflow.jobs[`build-${app}`];
+  const publish = workflow.jobs[`build-docker-${app}`];
+
+  it('uses the compiler for ordinary builds and bypasses it for supplied distributions', () => {
+    expect([...stages(dockerfile).keys()].at(-1)).toBe('runner');
+    expect(ancestors(dockerfile, new Set())).toContain('builder');
+    const packaging = ancestors(dockerfile, new Set(['release-dist']));
+    expect(packaging).toContain('release-dist');
+    expect(packaging).toContain('deps');
+    expect(packaging).not.toContain('builder');
+    expect(stages(dockerfile).get('runner')!.body).toContain(` /apps/${app}/dist ./apps/${app}/dist`);
+  });
+
+  it('maps every exported compiled directory through same-run artifacts into the named context', () => {
+    const buildStep = stepsUsing(build, 'docker/build-push-action');
+    expect(buildStep).toHaveLength(1);
+    expect(buildStep[0].with?.target).toBe('release-dist');
+    expect(buildStep[0].with?.push).not.toBe(true);
+    expect(buildStep[0].with?.outputs).toBe(`type=local,dest=\${{ runner.temp }}/${app}-release`);
+    const push = stepsUsing(publish, 'docker/build-push-action');
+    expect(push).toHaveLength(1);
+    expect(String(push[0].with?.['build-contexts']).trim()).toBe('release-dist=${{ runner.temp }}/release-dist');
+
+    const exported = [...stages(dockerfile).get('release-dist')!.body.matchAll(/^COPY --from=builder (\S+) (\S+)$/gm)];
+    expect(exported).toHaveLength(app === 'api' ? 2 : 1);
+    for (const [, source, destination] of exported) {
+      expect(source).toBe(`/app${destination}`);
+      const upload = stepsUsing(build, 'actions/upload-artifact').find((step) =>
+        step.with?.path === `\${{ runner.temp }}/${app}-release${destination}`);
+      expect(upload, `missing upload for ${destination}`).toBeDefined();
+      expect(upload!.with?.['if-no-files-found']).toBe('error');
+      const download = stepsUsing(publish, 'actions/download-artifact').find((step) =>
+        step.with?.name === upload!.with?.name);
+      expect(download, `missing download for ${destination}`).toBeDefined();
+      expect(download!.with?.path).toBe(`\${{ runner.temp }}/release-dist${destination}`);
+      expect(download!.with?.['run-id']).toBeUndefined();
+      expect(download!.with?.repository).toBeUndefined();
+    }
+    // Preserve the public tarball's layout: its artifact contains dist contents,
+    // while API's additional built-in web bundle remains a separate artifact.
+    expect(stepsUsing(build, 'actions/upload-artifact').find((step) => step.with?.name === `${app}-dist`)?.with?.path)
+      .toBe(`\${{ runner.temp }}/${app}-release/apps/${app}/dist`);
+  });
+
+  it('keeps publishing behind release integrity and lineage validation', () => {
+    expect(publish.needs).toEqual(expect.arrayContaining([`build-${app}`, 'create-release']));
+    expect(publish.if).toContain("needs.create-release.result == 'success'");
+    expect(workflow.jobs['create-release'].needs).toEqual(expect.arrayContaining(['release-integrity-gate', 'validate-release-lineage']));
+    expect(build.permissions?.packages).not.toBe('write');
+    expect(stepsUsing(build, 'docker/login-action')).toHaveLength(0);
+    expect(build.steps.some((step) => step.run?.includes('pnpm build'))).toBe(false);
+  });
+});
+
+
+describe('release packaging validation in GitHub Actions', () => {
+  const check = load(read('.github/workflows/release-build-check.yml')) as {
+    on: { pull_request: { branches: string[]; paths: string[] } };
+    permissions: Record<string, string>;
+    jobs: Record<string, Job & { strategy: { matrix: { app: string[] } } }>;
+  };
+  const job = check.jobs['verify-release-packaging'];
+
+  it('checks both runtime images when their release build definitions change', () => {
+    expect(job.strategy.matrix.app).toEqual(['api', 'web']);
+    expect(check.on.pull_request.branches).toEqual(['main']);
+    expect(check.on.pull_request.paths).toEqual([
+      'apps/api/Dockerfile',
+      'apps/web/Dockerfile',
+      '.github/workflows/release.yml',
+      '.github/workflows/release-build-check.yml',
+    ]);
+    const builds = stepsUsing(job, 'docker/build-push-action');
+    expect(builds).toHaveLength(2);
+    expect(builds[0].with?.target).toBe('release-dist');
+    expect(builds[0].with?.outputs).toBe('type=local,dest=${{ runner.temp }}/release-dist');
+    expect(String(builds[1].with?.['build-contexts']).trim()).toBe('release-dist=${{ runner.temp }}/release-dist');
+    expect(builds[1].with?.load).toBe(true);
+    for (const build of builds) expect(build.with?.push).toBe(false);
+    expect(check.permissions).toEqual({ contents: 'read' });
+    expect(stepsUsing(job, 'docker/login-action')).toHaveLength(0);
+  });
+
+  it('compares application and built-in workspace bytes without starting services', () => {
+    const commands = job.steps.map((step) => step.run ?? '').join('\n');
+    expect(commands).toContain('docker create');
+    expect(commands).not.toMatch(/docker (?:run|start)\b/);
+    expect(commands).toContain('docker cp "$container_id:/app/apps/$APP/dist"');
+    expect(commands).toContain('diff --recursive --no-dereference "$EXPORT_DIR/apps/$APP/dist"');
+    expect(commands).toContain('docker cp "$container_id:/app/apps/api/ee/workspace/dist"');
+    expect(commands).toContain('diff --recursive --no-dereference "$EXPORT_DIR/ee/workspace/dist"');
+  });
+});

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -59,6 +59,11 @@ COPY tsconfig.json ./
 WORKDIR /app/apps/web
 RUN pnpm build
 
+# Export only compiled files. Release jobs replace this stage with a named
+# context containing these same-run artifacts; ordinary builds use builder.
+FROM scratch AS release-dist
+COPY --from=builder /app/apps/web/dist /apps/web/dist
+
 # Stage 4: Production runner
 FROM node:24-alpine@sha256:e67514e5d0f6c46656005e1b693b2ec9d52e80b641307de684d4a015ba7a4eaf AS runner
 WORKDIR /app
@@ -81,8 +86,8 @@ RUN addgroup --system --gid 1001 nodejs && \
 
 # Copy built application and dependencies while preserving pnpm workspace symlink layout.
 # /app/apps/web/node_modules links into /app/node_modules/.pnpm.
-COPY --from=builder --chown=astro:nodejs /app/apps/web/dist ./apps/web/dist
-COPY --from=builder --chown=astro:nodejs /app/apps/web/package.json ./apps/web/package.json
+COPY --from=release-dist --chown=astro:nodejs /apps/web/dist ./apps/web/dist
+COPY --from=deps --chown=astro:nodejs /app/apps/web/package.json ./apps/web/package.json
 COPY --from=deps --chown=astro:nodejs /app/apps/web/node_modules ./apps/web/node_modules
 COPY --from=deps --chown=astro:nodejs /app/node_modules ./node_modules
 


### PR DESCRIPTION
## Summary

Full CI compiles API, web, and portal in their unit-test jobs, dedicated build jobs, and both smoke suites. Run those unit tests directly and build each smoke image once, then pass the exact run-specific images to both suites. The dedicated application builds and existing PR/merge-queue gate policies stay intact.

Release API/web bundles now come from the Docker compilation. Image packaging consumes those exact same-run artifacts through a named build context, including the API workspace bundle, without recompiling. Public tarball layouts and release integrity/publication gates remain intact. Separate per-image compilation/runtime cache scopes prevent cache overwrites and allow hosted builds to warm release caches.

A narrowly triggered Release Build Check workflow constructs API/web images without publishing and compares their compiled files byte-for-byte with the exported distributions.

## Type of Change

- [x] CI / build / tooling

## Testing

- [x] 593 application tests passed without application dist outputs: full Portal suite (508), targeted Web tests (51), targeted API tests (34).
- [x] Workflow/loader failure-path tests, existing docs/native gating contracts, and workflow security tests passed (145 Node tests).
- [x] API workflow gating and release artifact contracts passed (19 targeted tests); release-lineage and Docker contracts also passed.
- [x] Actionlint workflow validation, supply-chain hardening, and whitespace checks passed. Full actionlint reports pre-existing ShellCheck warnings in unchanged scripts; the new release workflow passes with ShellCheck enabled.
- [x] GitHub Actions on final commit: lint/typecheck, all three shared image builds, both smoke suites, and both release packaging byte-comparison checks passed. [CI run](https://github.com/LanternOps/breeze/actions/runs/34406739482), [release packaging run](https://github.com/LanternOps/breeze/actions/runs/34406739496).
- [x] Full API/Web/Portal test jobs passed on the initial implementation commit; the follow-up fixes only strict TypeScript indexing in the new workflow test helper.
- [ ] Remaining full CI jobs on the final commit are still running.

Security Scanning has failures in the same five Trivy jobs that failed on main before this PR. No dependency or scan-policy changes are included.

No local application or Docker builds were run. Measured smoke image uploads took 6–8 seconds each. The regular smoke job completed in 2m02s, including 65 seconds for downloading/loading shared images, versus 3m09s in the earlier sampled PR run. These are job-level observations, not a claimed end-to-end CI speedup; runner waits and native builds still affect the overall duration. This draft is not queued for merge.
