### PR TITLE
feat(backup): publish system-state under its own snapshot prefix + GC awareness (D15 W01)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1754,7 +1754,7 @@ jobs:
           $out | ForEach-Object { Write-Host $_ }
           if ($exit -ne 0) { throw "go test failed (exit $exit)" }
           $passes = @($out | Select-String -Pattern '^--- PASS: Test').Count
-          if ($passes -ne 14) { throw "expected exactly 14 top-level PASS lines, got $passes - a test in the -run filter was renamed, removed, or added without updating this count" }
+          if ($passes -ne 13) { throw "expected exactly 13 top-level PASS lines, got $passes - a test in the -run filter was renamed, removed, or added without updating this count" }
 
       # -race requires cgo, which remote/desktop cannot satisfy on Windows, so
       # this covers only packages that do not import it (heartbeat, agentapp and

--- a/agent/cmd/breeze-backup/exec_backup.go
+++ b/agent/cmd/breeze-backup/exec_backup.go
@@ -156,6 +156,7 @@ func managerFromBackupRunPayload(payload json.RawMessage) (*backup.BackupManager
 			SystemStateEnabled: true,
 			VSSEnabled:         vssEnabled,
 			AgentID:            helperAgentID,
+			AgentVersion:       version,
 		}), nil
 	}
 	if len(p.Paths) == 0 {
@@ -169,11 +170,12 @@ func managerFromBackupRunPayload(payload json.RawMessage) (*backup.BackupManager
 	// Retention: 0 makes DeleteSnapshotContext a no-op (it returns early on
 	// retention <= 0), leaving the server as the sole retention authority.
 	return backup.NewBackupManager(backup.BackupConfig{
-		Provider:   provider,
-		Paths:      p.Paths,
-		Retention:  0,
-		VSSEnabled: vssEnabled,
-		AgentID:    helperAgentID,
+		Provider:     provider,
+		Paths:        p.Paths,
+		Retention:    0,
+		VSSEnabled:   vssEnabled,
+		AgentID:      helperAgentID,
+		AgentVersion: version,
 	}), nil
 }
 

--- a/agent/cmd/breeze-backup/main.go
+++ b/agent/cmd/breeze-backup/main.go
@@ -420,6 +420,7 @@ func initBackupManager(cfg *config.Config) *backup.BackupManager {
 		SystemStateEnabled: cfg.BackupSystemStateEnabled,
 		StagingDir:         stagingDir,
 		AgentID:            cfg.AgentID,
+		AgentVersion:       version,
 	})
 
 	return mgr

--- a/agent/internal/backup/backup.go
+++ b/agent/internal/backup/backup.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -88,6 +88,17 @@ type BackupConfig struct {
 	// snapshot it is either way. Fail-open to a full backup, the same safe
 	// default as every other dedupe failure mode in this package.
 	AgentID string
+
+	// AgentVersion is stamped onto a collected system state manifest's
+	// CollectorVersion field (see systemstate.SystemStateManifest) so a
+	// restore can tell which agent/helper build produced it. The systemstate
+	// package itself has no notion of "the agent version" — it collects OS
+	// state, not agent identity — so this is wired through BackupConfig the
+	// same way AgentID is (see that field's doc comment): the caller
+	// populates it from the running binary's version string (e.g. breeze-
+	// backup's `version` build var). Empty means the manifest carries no
+	// CollectorVersion, e.g. an older caller that hasn't wired this through.
+	AgentVersion string
 
 	// VSSProvider overrides where a VSS-enabled run gets its provider from.
 	// Nil — the production case, and what every real caller sets — means
@@ -458,19 +469,13 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 
 	// System state collection: gather OS config, hardware profile, etc.
 	var systemStateErr error
-	// systemStateStagingIdx marks the staging dir's slot in backupPaths so the
-	// VSS rewrite below can leave it alone — it is created after the snapshot
-	// and therefore only exists on the live volume (#3026). Because it is never
-	// rewritten, systemStateStagingDir is simply the path collectSystemState
-	// returned, and it is the same prefix collectBackupFilesFromPaths produces
-	// for markSystemStateFiles to match on.
-	//
-	// The index is POSITIONAL and captured immediately before the append below.
-	// Nothing may insert into, reorder, filter or dedupe backupPaths between
-	// that append and rewritePathsForVSS, or the exclusion lands on a real user
-	// path — which would then read live with its warning suppressed, i.e. the
-	// #2999 class this file works to keep visible. If backupPaths ever needs
-	// post-processing, append the staging dir after it instead of moving this.
+	// systemStateStagingIdx is always noStagingIdx now: the staging dir is
+	// published separately (see publishSystemState) rather than appended to
+	// backupPaths, so there is never an entry in backupPaths for the VSS
+	// rewrite below to protect. Kept as a named constant purely so
+	// rewritePathsForVSS/reportableLiveReads (D8/D12's VSS machinery, out of
+	// scope for this change) keep their existing "no staging dir" signature
+	// unchanged.
 	var systemStateStagingDir string
 	systemStateStagingIdx := noStagingIdx
 	if m.config.SystemStateEnabled {
@@ -490,6 +495,7 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 			// failed, i.e. the capture would not boot at restore time.
 			appendWarning(job, "system state was not collected: "+ssErr.Error())
 		} else {
+			manifest.CollectorVersion = m.config.AgentVersion
 			job.SystemStateManifest = manifest
 			// Collection succeeded on all *required* artifacts (missing a
 			// required class returns an error above and fails the run). Any
@@ -515,12 +521,14 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 				appendWarning(job, incomplete)
 				log.Warn("system state collection incomplete", "warning", incomplete)
 			}
-			// Append the staging dir to the walked paths so its artifacts land
-			// in the backup manifest. NOT in the VSS shadow copy — the rewrite
-			// below deliberately skips this entry (see rewritePathsForVSS).
-			systemStateStagingIdx = len(backupPaths)
+			// The staging dir is published to snapshots/<id>/system-state/ as
+			// its own step (see publishSystemState in snapshot.go), never
+			// appended to backupPaths — Option A of the D15 bare-metal-recovery
+			// contract (see docs/superpowers/plans/backup/
+			// 2026-09-09-bmr-system-state-contract.md). Record it so the
+			// publish step(s) below can find it, and clean it up once this run
+			// is done with it either way.
 			systemStateStagingDir = stagingDir
-			backupPaths = append(backupPaths, stagingDir)
 			defer func() {
 				if removeErr := os.RemoveAll(stagingDir); removeErr != nil {
 					log.Warn("failed to clean up system state staging dir", "dir", stagingDir, "error", removeErr.Error())
@@ -611,50 +619,73 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 		// backupFile.originalPath doc comment.
 		originalPathsForVSS(files, vssSession.ShadowPaths)
 	}
-	if systemStateArtifactsMissing(job.SystemStateManifest, markSystemStateFiles(files, systemStateStagingDir)) {
-		// Reached only when the manifest and the collected files disagree, so
-		// it cannot fire on a healthy run.
-		//
-		// Warning rather than failure for the JOB: the file-path portion is
-		// still valid and restorable, so failing would throw away good data.
-		// But a warning alone is not enough, because unlike job.VSSMetadata the
-		// manifest DOES survive the trip — it is persisted to
-		// backup_snapshots.system_state_manifest and handed to the bare-metal
-		// recovery paths. Left intact it would advertise a complete system
-		// state on a restore point that holds none of it, which is the #3026
-		// symptom rather than a report of it. So drop the artifact list it can
-		// no longer vouch for, and keep the rest of the manifest (platform, OS
-		// version, hardware profile) — that is inline collector output, still
-		// accurate, and the hardware profile is persisted from here for
-		// recovery planning.
-		artifactCount := len(job.SystemStateManifest.Artifacts)
-		log.Warn("system state manifest was recorded but none of its artifacts were captured; "+
-			"the restore point does not contain the system state it describes",
-			"jobId", job.ID,
-			"artifacts", artifactCount,
-			"stagingDir", systemStateStagingDir,
-		)
-		job.SystemStateManifest.Artifacts = nil
-		appendWarning(job, "system state artifacts were not captured: the manifest described "+
-			strconv.Itoa(artifactCount)+" artifacts but none reached the snapshot")
-	}
+	// NOTE: system-state artifacts are no longer part of `files` at all (see
+	// the SystemStateEnabled block above) — they are uploaded by
+	// publishSystemState from job.SystemStateManifest/systemStateStagingDir
+	// directly, below and after createSnapshotWithProgress. That function
+	// reads each artifact straight from disk and fails loudly if one is
+	// missing or unreadable, which is a strictly stronger guarantee than the
+	// old "did the file walk happen to see it" proxy check this replaced —
+	// see the plan doc's Wave 1 section for why the old check (markSystem-
+	// StateFiles/systemStateArtifactsMissing) is now dead code and was
+	// removed rather than left inert.
 	if len(files) == 0 {
 		if err := runCtx.Err(); err != nil {
 			return stopBackupRun()
 		}
-		// A system-state-only run (no configured file paths) that produced
-		// nothing is a hard failure, not a no-op skip: there are no files to
-		// fall back on, so a green empty snapshot would silently protect
-		// nothing. Surface the collection error (or a synthetic one).
 		if m.config.SystemStateEnabled && len(m.config.Paths) == 0 {
-			runErr := systemStateErr
-			if runErr == nil {
-				runErr = errors.New("system state collection produced no artifacts")
+			// A system-state-only run (no configured file paths): success
+			// depends entirely on what was collected above, since there is no
+			// ordinary-files fallback. Nothing to publish (collection failed,
+			// or produced a manifest with zero artifacts) is a hard failure —
+			// a green empty snapshot would silently protect nothing.
+			if systemStateStagingDir == "" || job.SystemStateManifest == nil || len(job.SystemStateManifest.Artifacts) == 0 {
+				runErr := systemStateErr
+				if runErr == nil {
+					runErr = errors.New("system state collection produced no artifacts")
+				}
+				job.Status = jobStatusFailed
+				job.CompletedAt = time.Now().UTC()
+				job.Error = errors.Join(scanErr, runErr)
+				return job, job.Error
 			}
-			job.Status = jobStatusFailed
+			// Collection succeeded and has something to publish. Publish it as
+			// its own snapshot: system-state/ artifacts + manifest, plus the
+			// ordinary (empty-files) manifest.json so the snapshot-id group
+			// stays "manifest-bearing" for GC (see markLiveBackupObjects in
+			// apps/api/src/jobs/backupRetention.ts). A publish failure here is
+			// a hard job failure, not `completed` — there is no fallback for a
+			// state-only run.
+			snapshot := &Snapshot{
+				ID:             newSnapshotID(),
+				Timestamp:      time.Now().UTC(),
+				BackupIdentity: m.runBackupIdentity(),
+			}
+			prefix := path.Join(snapshotRootDir, snapshot.ID)
+			if pubErr := publishSystemState(runCtx, m.config.Provider, snapshot.ID, systemStateStagingDir, job.SystemStateManifest); pubErr != nil {
+				job.Status = jobStatusFailed
+				job.CompletedAt = time.Now().UTC()
+				job.Error = fmt.Errorf("system state publish failed: %w", pubErr)
+				return job, job.Error
+			}
+			if pubErr := publishSnapshotManifest(runCtx, m.config.Provider, snapshot, prefix); pubErr != nil {
+				job.Status = jobStatusFailed
+				job.CompletedAt = time.Now().UTC()
+				job.Error = fmt.Errorf("system state publish failed: %w", pubErr)
+				return job, job.Error
+			}
+			job.Snapshot = snapshot
+			job.BytesBackedUp = 0
 			job.CompletedAt = time.Now().UTC()
-			job.Error = errors.Join(scanErr, runErr)
-			return job, job.Error
+			job.Status = jobStatusCompleted
+			log.Info("system-state-only backup run finished",
+				"status", job.Status,
+				"jobId", job.ID,
+				"snapshotId", snapshot.ID,
+				"artifacts", len(job.SystemStateManifest.Artifacts),
+				"elapsedMs", time.Since(job.StartedAt).Milliseconds(),
+			)
+			return job, nil
 		}
 		job.Status = jobStatusSkipped
 		job.CompletedAt = time.Now().UTC()
@@ -674,11 +705,15 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 	// and a full run — dedupe is strictly an optimization and must never
 	// fail or block a backup (see previousManifest's doc comment).
 	//
-	// Skipped entirely for a system-state-only run (no configured file
-	// paths): every one of its files is staging-dir and therefore already
-	// excluded from reference decisions by markSystemStateFiles above, so
-	// there is nothing eligible to dedupe against — the extra remote
-	// list+manifest-download would be pure waste.
+	// A system-state-only run (SystemStateEnabled with no configured file
+	// paths) never reaches this line at all — see the len(files)==0 branch
+	// above, which returns before this point since system-state artifacts
+	// are no longer part of `files` (they are published separately by
+	// publishSystemState). So len(m.config.Paths) > 0 always holds by the
+	// time we get here; this expression is kept as an explicit guard rather
+	// than assumed, so a future change to the branches above fails safe
+	// (skips dedupe) instead of silently building a reference index off an
+	// unintended run shape.
 	var prevSnapshot *Snapshot
 	incrementalDedupeActive := !m.config.SystemStateEnabled || len(m.config.Paths) > 0
 	if incrementalDedupeActive {
@@ -813,6 +848,29 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 		job.Status = jobStatusFailed
 		job.Error = combinedErr
 		return job, combinedErr
+	}
+
+	// A run with BOTH configured file paths and system state (SystemStateEnabled
+	// with len(m.config.Paths) > 0 — the state-only case above already handled
+	// SystemStateEnabled with no configured paths): the ordinary snapshot above
+	// already has its real ID and published manifest, so publish the collected
+	// system state under that SAME snapshot ID now. A publish failure here is a
+	// hard job failure — per the D15 contract, a system_image-shaped run that
+	// reports `completed` while its state silently never reached the snapshot
+	// is exactly the bug this fixes, so a partial success (files ok, state
+	// missing) must not read as `completed`.
+	if m.config.SystemStateEnabled && systemStateStagingDir != "" && job.SystemStateManifest != nil && len(job.SystemStateManifest.Artifacts) > 0 {
+		if pubErr := publishSystemState(runCtx, m.config.Provider, snapshot.ID, systemStateStagingDir, job.SystemStateManifest); pubErr != nil {
+			log.Error("system state publish failed; the snapshot's ordinary files were still stored, "+
+				"but the restore point is missing bare-metal recovery state",
+				"jobId", job.ID,
+				"snapshotId", snapshot.ID,
+				"error", pubErr.Error(),
+			)
+			job.Status = jobStatusFailed
+			job.Error = fmt.Errorf("system state publish failed: %w", pubErr)
+			return job, job.Error
+		}
 	}
 
 	// Per-file upload failures on a PARTIAL success (some files uploaded,
@@ -1091,12 +1149,6 @@ type backupFile struct {
 	// copy device path every run), so keying the journal on it would make
 	// resume silently never match on Windows-with-VSS.
 	originalPath string
-	// systemState marks a file collected from the run's system-state
-	// staging directory (see markSystemStateFiles / collectSystemState's
-	// call site in RunBackupContext). decideFile always uploads these —
-	// they are never reference candidates, see markSystemStateFiles's doc
-	// comment for why this is explicit rather than incidental.
-	systemState bool
 }
 
 func (m *BackupManager) collectBackupFiles() ([]backupFile, error) {
@@ -1299,6 +1351,15 @@ func summarizeLiveReads(paths []string) string {
 
 // rewritePathsForVSS rewrites source paths to use VSS shadow copy device paths.
 // e.g., "C:\\Users\\data" with shadow "C:" -> "\\\\?\\GLOBALROOT\\...\\Users\\data"
+//
+// NOTE: as of Wave 1 of the D15 bare-metal-recovery contract, the caller
+// (RunBackupContext) never appends the system-state staging dir into
+// backupPaths anymore — it is published separately (see
+// snapshot.go's publishSystemState) — so stagingIdx is always noStagingIdx in
+// production today. The parameter and the exclusion logic below are kept
+// (rather than removed) because this function's own tests exercise it
+// directly, and because a future caller that DOES need to walk a directory
+// alongside VSS-rewritten paths can still opt in without re-deriving this.
 //
 // stagingIdx (noStagingIdx when the run has none) is the index of the
 // system-state staging directory, which is excluded from the rewrite. It is

--- a/agent/internal/backup/backup.go
+++ b/agent/internal/backup/backup.go
@@ -633,32 +633,49 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 		if err := runCtx.Err(); err != nil {
 			return stopBackupRun()
 		}
-		if m.config.SystemStateEnabled && len(m.config.Paths) == 0 {
-			// A system-state-only run (no configured file paths): success
-			// depends entirely on what was collected above, since there is no
-			// ordinary-files fallback. Nothing to publish (collection failed,
-			// or produced a manifest with zero artifacts) is a hard failure —
-			// a green empty snapshot would silently protect nothing.
-			if systemStateStagingDir == "" || job.SystemStateManifest == nil || len(job.SystemStateManifest.Artifacts) == 0 {
-				runErr := systemStateErr
-				if runErr == nil {
-					runErr = errors.New("system state collection produced no artifacts")
-				}
-				job.Status = jobStatusFailed
-				job.CompletedAt = time.Now().UTC()
-				job.Error = errors.Join(scanErr, runErr)
-				return job, job.Error
+		stateHasArtifacts := systemStateStagingDir != "" && job.SystemStateManifest != nil && len(job.SystemStateManifest.Artifacts) > 0
+		if !stateHasArtifacts && m.config.SystemStateEnabled && len(m.config.Paths) == 0 {
+			// A system-state-only run (no configured file paths) that
+			// collected nothing: success depends entirely on what was
+			// collected above, since there is no ordinary-files fallback.
+			// Nothing to publish (collection failed, or produced a manifest
+			// with zero artifacts) is a hard failure — a green empty
+			// snapshot would silently protect nothing.
+			runErr := systemStateErr
+			if runErr == nil {
+				runErr = errors.New("system state collection produced no artifacts")
 			}
-			// Collection succeeded and has something to publish. Publish it as
-			// its own snapshot: system-state/ artifacts + manifest, plus the
-			// ordinary (empty-files) manifest.json so the snapshot-id group
-			// stays "manifest-bearing" for GC (see markLiveBackupObjects in
-			// apps/api/src/jobs/backupRetention.ts). A publish failure here is
-			// a hard job failure, not `completed` — there is no fallback for a
-			// state-only run.
+			job.Status = jobStatusFailed
+			job.CompletedAt = time.Now().UTC()
+			job.Error = errors.Join(scanErr, runErr)
+			return job, job.Error
+		}
+		if stateHasArtifacts {
+			// State was collected with at least one artifact — publish it
+			// even though the ordinary file walk yielded nothing.
+			// Deliberately NOT gated on len(m.config.Paths)==0: a MIXED run
+			// (SystemStateEnabled with configured file paths too) can walk
+			// zero files just as easily — an empty directory, everything
+			// excluded, or a stale configured path — and losing the
+			// already-collected state in that case is exactly as silent a
+			// failure as the pure state-only case this branch was written
+			// for. Publish it as its own snapshot: system-state/ artifacts +
+			// manifest, plus the ordinary (empty-files) manifest.json so the
+			// snapshot-id group stays "manifest-bearing" for GC (see
+			// markLiveBackupObjects in apps/api/src/jobs/backupRetention.ts).
+			// A publish failure here is a hard job failure, not `completed`
+			// — there is no ordinary-files fallback for this snapshot.
 			snapshot := &Snapshot{
-				ID:             newSnapshotID(),
-				Timestamp:      time.Now().UTC(),
+				ID:        newSnapshotID(),
+				Timestamp: time.Now().UTC(),
+				// Files must be a non-nil empty slice, not the zero value: the
+				// field has no `omitempty` (a genuine empty-files manifest
+				// must still round-trip as "files":[]), and a nil slice
+				// encodes as `"files":null`, which the API's resultSchemas/
+				// queueSchemas reject (z.array(...).optional() accepts a
+				// missing key or [] but not null) — that silently drops the
+				// whole job result server-side.
+				Files:          []SnapshotFile{},
 				BackupIdentity: m.runBackupIdentity(),
 			}
 			prefix := path.Join(snapshotRootDir, snapshot.ID)
@@ -678,11 +695,12 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 			job.BytesBackedUp = 0
 			job.CompletedAt = time.Now().UTC()
 			job.Status = jobStatusCompleted
-			log.Info("system-state-only backup run finished",
+			log.Info("backup run finished with state artifacts but zero walked files",
 				"status", job.Status,
 				"jobId", job.ID,
 				"snapshotId", snapshot.ID,
 				"artifacts", len(job.SystemStateManifest.Artifacts),
+				"configuredPaths", len(m.config.Paths),
 				"elapsedMs", time.Since(job.StartedAt).Milliseconds(),
 			)
 			return job, nil
@@ -790,7 +808,16 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 		}
 	}
 
-	snapshot, snapErr := createSnapshotWithProgress(runCtx, m.config.Provider, files, progressFn, journal, prevSnapshot, sourceLiveness, runIdentity)
+	snapshotOpts := []createSnapshotOption{withRunIdentity(runIdentity)}
+	if m.config.SystemStateEnabled && systemStateStagingDir != "" && job.SystemStateManifest != nil && len(job.SystemStateManifest.Artifacts) > 0 {
+		// Publish system state under this call's own snapshot ID, BEFORE its
+		// ordinary manifest.json — see withSystemState's doc comment. This
+		// replaces a separate publishSystemState call this function used to
+		// make AFTER createSnapshotWithProgress returned, which published the
+		// ordinary manifest first (wrong order — D15 Wave 1 finding #4).
+		snapshotOpts = append(snapshotOpts, withSystemState(systemStateStagingDir, job.SystemStateManifest))
+	}
+	snapshot, snapErr := createSnapshotWithProgress(runCtx, m.config.Provider, files, progressFn, journal, prevSnapshot, sourceLiveness, snapshotOpts...)
 	if errors.Is(snapErr, errBackupStopped) {
 		return stopBackupRun()
 	}
@@ -852,26 +879,14 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 
 	// A run with BOTH configured file paths and system state (SystemStateEnabled
 	// with len(m.config.Paths) > 0 — the state-only case above already handled
-	// SystemStateEnabled with no configured paths): the ordinary snapshot above
-	// already has its real ID and published manifest, so publish the collected
-	// system state under that SAME snapshot ID now. A publish failure here is a
-	// hard job failure — per the D15 contract, a system_image-shaped run that
-	// reports `completed` while its state silently never reached the snapshot
-	// is exactly the bug this fixes, so a partial success (files ok, state
-	// missing) must not read as `completed`.
-	if m.config.SystemStateEnabled && systemStateStagingDir != "" && job.SystemStateManifest != nil && len(job.SystemStateManifest.Artifacts) > 0 {
-		if pubErr := publishSystemState(runCtx, m.config.Provider, snapshot.ID, systemStateStagingDir, job.SystemStateManifest); pubErr != nil {
-			log.Error("system state publish failed; the snapshot's ordinary files were still stored, "+
-				"but the restore point is missing bare-metal recovery state",
-				"jobId", job.ID,
-				"snapshotId", snapshot.ID,
-				"error", pubErr.Error(),
-			)
-			job.Status = jobStatusFailed
-			job.Error = fmt.Errorf("system state publish failed: %w", pubErr)
-			return job, job.Error
-		}
-	}
+	// SystemStateEnabled with no configured paths) already published its
+	// collected system state INSIDE createSnapshotWithProgress above, via the
+	// withSystemState option — before its ordinary manifest, per D15 Wave 1
+	// finding #4. A publish failure there surfaces as snapErr (checked
+	// above), which fails the job loudly: a system_image-shaped run that
+	// reports `completed` while its state silently never reached the
+	// snapshot is exactly the bug this fixes, so a partial success (files
+	// ok, state missing) must not read as `completed`.
 
 	// Per-file upload failures on a PARTIAL success (some files uploaded,
 	// some skipped/stalled/retry-exhausted): the job still completes — the

--- a/agent/internal/backup/backup_test.go
+++ b/agent/internal/backup/backup_test.go
@@ -538,6 +538,18 @@ func TestRunBackup_SystemImage_NoPathsAllowed(t *testing.T) {
 	if len(ordinaryManifest.Files) != 0 {
 		t.Errorf("ordinary manifest.files = %d, want 0 (state-only run)", len(ordinaryManifest.Files))
 	}
+	// len()==0 can't distinguish a nil slice ("files":null) from an empty one
+	// ("files":[]) — the API's resultSchemas/queueSchemas reject null (they're
+	// z.array(...).optional(), which accepts a missing key or [] but not
+	// null) and silently drop the whole job result. Assert the raw wire shape,
+	// not just the decoded length.
+	var rawOrdinaryManifest map[string]json.RawMessage
+	if err := json.Unmarshal(provider.files[wantOrdinaryManifestKey], &rawOrdinaryManifest); err != nil {
+		t.Fatalf("decode ordinary manifest as raw JSON: %v", err)
+	}
+	if rawFiles := string(rawOrdinaryManifest["files"]); rawFiles != "[]" {
+		t.Errorf(`ordinary manifest raw "files" = %s, want "[]" (not null) — API schemas reject null`, rawFiles)
+	}
 	if ordinaryManifest.ID != job.Snapshot.ID {
 		t.Errorf("ordinary manifest ID = %q, want %q (must share the state prefix's snapshot ID)", ordinaryManifest.ID, job.Snapshot.ID)
 	}
@@ -551,6 +563,130 @@ func TestRunBackup_SystemImage_NoPathsAllowed(t *testing.T) {
 	}
 	if len(stateManifest.Artifacts) != 1 || stateManifest.Artifacts[0].Checksum == "" {
 		t.Errorf("published system state manifest should carry the artifact's checksum, got %+v", stateManifest.Artifacts)
+	}
+}
+
+func TestRunBackup_SystemState_MixedRunZeroWalkedFilesStillPublishesState(t *testing.T) {
+	// A MIXED run (SystemStateEnabled AND configured file paths) whose walk
+	// yields zero files — an empty directory, everything excluded, or a stale
+	// configured path — must not lose already-collected system state. The
+	// state-only special case used to be gated on len(m.config.Paths)==0, so
+	// this exact shape (Paths configured, walk empty, state collected) fell
+	// through to jobStatusSkipped, which removes the staging dir and
+	// discards the state silently.
+	emptyDir := t.TempDir()
+
+	stagingDir := t.TempDir()
+	content := []byte("svc")
+	if err := os.WriteFile(pathpkg.Join(stagingDir, "services.txt"), content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	stubCollectSystemState(t, func() (*systemstate.SystemStateManifest, string, error) {
+		return &systemstate.SystemStateManifest{
+			Platform: "test",
+			Artifacts: []systemstate.Artifact{{
+				Name: "services", Category: "services", Path: "services.txt",
+				SizeBytes: int64(len(content)),
+				Checksum:  "348c658682ae8701d3e9d21f191872491cf15e6acbb1681770b1cb787c1cf7ff",
+			}},
+		}, stagingDir, nil
+	})
+
+	provider := newMockProvider()
+	mgr := NewBackupManager(BackupConfig{
+		Provider:           provider,
+		Paths:              []string{emptyDir},
+		SystemStateEnabled: true,
+	})
+	job, err := mgr.RunBackup()
+	if err != nil {
+		t.Fatalf("mixed run with collected state should succeed despite an empty walk: %v", err)
+	}
+	if job.Status != jobStatusCompleted {
+		t.Fatalf("status = %q, want %q", job.Status, jobStatusCompleted)
+	}
+	if job.Snapshot == nil {
+		t.Fatal("collected state must still produce a snapshot even though the walk found nothing")
+	}
+
+	wantArtifactKey := path.Join("snapshots", job.Snapshot.ID, "system-state", "services.txt")
+	wantManifestKey := path.Join("snapshots", job.Snapshot.ID, "system-state", "manifest.json")
+	wantOrdinaryManifestKey := path.Join("snapshots", job.Snapshot.ID, "manifest.json")
+	if _, ok := provider.files[wantArtifactKey]; !ok {
+		t.Errorf("expected artifact uploaded to %q, got keys %v", wantArtifactKey, providerKeys(provider))
+	}
+	if _, ok := provider.files[wantManifestKey]; !ok {
+		t.Errorf("expected system-state manifest uploaded to %q, got keys %v", wantManifestKey, providerKeys(provider))
+	}
+	if _, ok := provider.files[wantOrdinaryManifestKey]; !ok {
+		t.Errorf("expected ordinary (empty-files) manifest uploaded to %q, got keys %v", wantOrdinaryManifestKey, providerKeys(provider))
+	}
+}
+
+func TestRunBackup_SystemState_PublishOrderStateBeforeOrdinaryManifest(t *testing.T) {
+	// A mixed run (ordinary files + system state) must publish the
+	// system-state artifact(s), then the system-state manifest, and ONLY
+	// THEN the ordinary manifest.json — the ordinary manifest is the "commit
+	// point" a concurrent GC sweep uses to decide a snapshot-id group is
+	// "manifest-bearing" (markLiveBackupObjects, backupRetention.ts). If the
+	// ordinary manifest lands first, a GC sweep racing in between sees a
+	// manifest-bearing group whose system-state/* objects aren't marked live
+	// yet and can reap them under the per-object grace rule.
+	tmpDir := t.TempDir()
+	file1 := createTempFile(t, tmpDir, "single.txt", "single file backup")
+
+	stagingDir := t.TempDir()
+	content := []byte("svc")
+	if err := os.WriteFile(pathpkg.Join(stagingDir, "services.txt"), content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	stubCollectSystemState(t, func() (*systemstate.SystemStateManifest, string, error) {
+		return &systemstate.SystemStateManifest{
+			Platform: "test",
+			Artifacts: []systemstate.Artifact{{
+				Name: "services", Category: "services", Path: "services.txt",
+				SizeBytes: int64(len(content)),
+				Checksum:  "348c658682ae8701d3e9d21f191872491cf15e6acbb1681770b1cb787c1cf7ff",
+			}},
+		}, stagingDir, nil
+	})
+
+	provider := newMockProvider()
+	mgr := NewBackupManager(BackupConfig{
+		Provider:           provider,
+		Paths:              []string{file1},
+		SystemStateEnabled: true,
+	})
+	job, err := mgr.RunBackup()
+	if err != nil {
+		t.Fatalf("RunBackup failed: %v", err)
+	}
+	if job.Status != jobStatusCompleted {
+		t.Fatalf("status = %q, want %q", job.Status, jobStatusCompleted)
+	}
+
+	wantArtifactKey := path.Join("snapshots", job.Snapshot.ID, "system-state", "services.txt")
+	wantStateManifestKey := path.Join("snapshots", job.Snapshot.ID, "system-state", "manifest.json")
+	wantOrdinaryManifestKey := path.Join("snapshots", job.Snapshot.ID, "manifest.json")
+
+	indexOf := func(remotePath string) int {
+		for i, c := range provider.uploadCalls {
+			if c.remotePath == remotePath {
+				return i
+			}
+		}
+		return -1
+	}
+	artifactIdx := indexOf(wantArtifactKey)
+	stateManifestIdx := indexOf(wantStateManifestKey)
+	ordinaryManifestIdx := indexOf(wantOrdinaryManifestKey)
+	if artifactIdx == -1 || stateManifestIdx == -1 || ordinaryManifestIdx == -1 {
+		t.Fatalf("missing expected upload(s): artifact=%d stateManifest=%d ordinaryManifest=%d, calls=%+v",
+			artifactIdx, stateManifestIdx, ordinaryManifestIdx, provider.uploadCalls)
+	}
+	if artifactIdx >= stateManifestIdx || stateManifestIdx >= ordinaryManifestIdx {
+		t.Errorf("wrong publish order: artifact=%d, stateManifest=%d, ordinaryManifest=%d (want artifact < stateManifest < ordinaryManifest)",
+			artifactIdx, stateManifestIdx, ordinaryManifestIdx)
 	}
 }
 

--- a/agent/internal/backup/backup_test.go
+++ b/agent/internal/backup/backup_test.go
@@ -488,14 +488,26 @@ func TestRunBackup_SystemImage_NoPathsAllowed(t *testing.T) {
 	// system-state staging dir is the whole snapshot, so the "backup paths are
 	// required" guard must NOT fire.
 	stagingDir := t.TempDir()
-	if err := os.WriteFile(pathpkg.Join(stagingDir, "services.txt"), []byte("svc"), 0o600); err != nil {
+	content := []byte("svc")
+	if err := os.WriteFile(pathpkg.Join(stagingDir, "services.txt"), content, 0o600); err != nil {
 		t.Fatal(err)
 	}
 	stubCollectSystemState(t, func() (*systemstate.SystemStateManifest, string, error) {
-		return &systemstate.SystemStateManifest{Platform: "test"}, stagingDir, nil
+		return &systemstate.SystemStateManifest{
+			Platform: "test",
+			Artifacts: []systemstate.Artifact{{
+				Name: "services", Category: "services", Path: "services.txt",
+				SizeBytes: int64(len(content)),
+				// sha256("svc") — a real collector fills this in at collection
+				// time (systemstate.artifactFromFile); this fixture stands in
+				// for that.
+				Checksum: "348c658682ae8701d3e9d21f191872491cf15e6acbb1681770b1cb787c1cf7ff",
+			}},
+		}, stagingDir, nil
 	})
 
-	mgr := NewBackupManager(BackupConfig{Provider: newMockProvider(), SystemStateEnabled: true})
+	provider := newMockProvider()
+	mgr := NewBackupManager(BackupConfig{Provider: provider, SystemStateEnabled: true})
 	job, err := mgr.RunBackup()
 	if err != nil {
 		t.Fatalf("system-state-only run should succeed with collected artifacts: %v", err)
@@ -503,6 +515,53 @@ func TestRunBackup_SystemImage_NoPathsAllowed(t *testing.T) {
 	if job.Status != jobStatusCompleted {
 		t.Fatalf("status = %q, want completed", job.Status)
 	}
+	if job.Snapshot == nil {
+		t.Fatal("a state-only success must still produce a snapshot")
+	}
+	wantArtifactKey := path.Join("snapshots", job.Snapshot.ID, "system-state", "services.txt")
+	wantManifestKey := path.Join("snapshots", job.Snapshot.ID, "system-state", "manifest.json")
+	wantOrdinaryManifestKey := path.Join("snapshots", job.Snapshot.ID, "manifest.json")
+	if _, ok := provider.files[wantArtifactKey]; !ok {
+		t.Errorf("expected artifact uploaded to %q, got keys %v", wantArtifactKey, providerKeys(provider))
+	}
+	if _, ok := provider.files[wantManifestKey]; !ok {
+		t.Errorf("expected system-state manifest uploaded to %q, got keys %v", wantManifestKey, providerKeys(provider))
+	}
+	if _, ok := provider.files[wantOrdinaryManifestKey]; !ok {
+		t.Errorf("expected ordinary (empty-files) manifest uploaded to %q, got keys %v", wantOrdinaryManifestKey, providerKeys(provider))
+	}
+
+	var ordinaryManifest Snapshot
+	if err := json.Unmarshal(provider.files[wantOrdinaryManifestKey], &ordinaryManifest); err != nil {
+		t.Fatalf("decode ordinary manifest: %v", err)
+	}
+	if len(ordinaryManifest.Files) != 0 {
+		t.Errorf("ordinary manifest.files = %d, want 0 (state-only run)", len(ordinaryManifest.Files))
+	}
+	if ordinaryManifest.ID != job.Snapshot.ID {
+		t.Errorf("ordinary manifest ID = %q, want %q (must share the state prefix's snapshot ID)", ordinaryManifest.ID, job.Snapshot.ID)
+	}
+
+	var stateManifest systemstate.SystemStateManifest
+	if err := json.Unmarshal(provider.files[wantManifestKey], &stateManifest); err != nil {
+		t.Fatalf("decode system state manifest: %v", err)
+	}
+	if stateManifest.SchemaVersion != 1 {
+		t.Errorf("system state manifest schemaVersion = %d, want 1", stateManifest.SchemaVersion)
+	}
+	if len(stateManifest.Artifacts) != 1 || stateManifest.Artifacts[0].Checksum == "" {
+		t.Errorf("published system state manifest should carry the artifact's checksum, got %+v", stateManifest.Artifacts)
+	}
+}
+
+// providerKeys returns the sorted list of remote keys the mock provider has
+// stored, for readable test failure messages.
+func providerKeys(p *mockProvider) []string {
+	keys := make([]string, 0, len(p.files))
+	for k := range p.files {
+		keys = append(keys, k)
+	}
+	return keys
 }
 
 func TestRunBackup_SystemImage_CollectionFailureFailsLoud(t *testing.T) {
@@ -598,13 +657,14 @@ func TestRunBackup_SystemImage_PartialCollectionWarns(t *testing.T) {
 	// missing *required* class returns an error from the collector and fails the
 	// run instead — see TestRunBackup_SystemImage_CollectionFailureFailsLoud.)
 	stagingDir := t.TempDir()
-	if err := os.WriteFile(pathpkg.Join(stagingDir, "services.txt"), []byte("svc"), 0o600); err != nil {
+	content := []byte("svc")
+	if err := os.WriteFile(pathpkg.Join(stagingDir, "services.txt"), content, 0o600); err != nil {
 		t.Fatal(err)
 	}
 	stubCollectSystemState(t, func() (*systemstate.SystemStateManifest, string, error) {
 		return &systemstate.SystemStateManifest{
 			Platform:        "test",
-			Artifacts:       []systemstate.Artifact{{Name: "services", Category: "services"}},
+			Artifacts:       []systemstate.Artifact{{Name: "services", Category: "services", Path: "services.txt", SizeBytes: int64(len(content))}},
 			IncompleteSteps: []string{"certs", "iis"},
 		}, stagingDir, nil
 	})
@@ -622,26 +682,33 @@ func TestRunBackup_SystemImage_PartialCollectionWarns(t *testing.T) {
 	}
 }
 
-// TestRunBackup_SystemStateManifestWithoutArtifactsWarnsAndDropsArtifacts is
-// the end-to-end guard for #3026's symptom, at the level the bug actually
-// presented: a run that ALSO has configured file paths, so the len(files)==0
-// hard-failure guard never fires and the job completes green.
+// TestRunBackup_MixedRun_SystemStatePublishFailureFailsLoud is the end-to-end
+// guard for #3026/D15's symptom, at the level the bug actually presented: a
+// run that ALSO has configured file paths, so the len(files)==0 hard-failure
+// guard never fires on its own.
 //
-// The staging dir is empty here, which is what the walk saw when VSS had
-// rewritten the staging path onto a shadow-device path that predated the
-// snapshot. The manifest still claims two artifacts. That combination must not
-// produce an unqualified success: the operator has to be told, and the manifest
-// must stop advertising artifacts the restore point does not contain — it is
-// persisted server-side and drives the bare-metal recovery paths.
-func TestRunBackup_SystemStateManifestWithoutArtifactsWarnsAndDropsArtifacts(t *testing.T) {
+// The manifest claims two artifacts, but neither exists in the staging dir
+// handed to publishSystemState (a stand-in for #3026's actual cause — a
+// staging dir rewritten onto a shadow-device path that predated the
+// snapshot — and any other way the collected bytes fail to reach the
+// snapshot). That combination must NOT produce an unqualified `completed`:
+// per the D15 contract, a job whose system state silently never reached the
+// snapshot must fail loud, even though the ordinary file-path portion
+// succeeded — this is the exact bug the old "warn and drop the artifact
+// list" behavior papered over.
+func TestRunBackup_MixedRun_SystemStatePublishFailureFailsLoud(t *testing.T) {
 	tmpDir := t.TempDir()
 	file1 := createTempFile(t, tmpDir, "doc.txt", "user data that backed up fine")
 
-	// Collection reports artifacts, but nothing of theirs is on disk to walk.
+	// Collection reports artifacts, but nothing of theirs is on disk in the
+	// staging dir handed back (a different, empty temp dir).
 	stubCollectSystemState(t, func() (*systemstate.SystemStateManifest, string, error) {
 		return &systemstate.SystemStateManifest{
-			Platform:  "test",
-			Artifacts: []systemstate.Artifact{{Name: "registry"}, {Name: "boot"}},
+			Platform: "test",
+			Artifacts: []systemstate.Artifact{
+				{Name: "registry", Path: "registry.dat", SizeBytes: 4},
+				{Name: "boot", Path: "boot.cfg", SizeBytes: 4},
+			},
 		}, t.TempDir(), nil
 	})
 
@@ -651,24 +718,14 @@ func TestRunBackup_SystemStateManifestWithoutArtifactsWarnsAndDropsArtifacts(t *
 		SystemStateEnabled: true,
 	})
 	job, err := mgr.RunBackup()
-	if err != nil {
-		t.Fatalf("the file-path portion is still valid, so the run should complete: %v", err)
+	if err == nil {
+		t.Fatal("a system state publish failure must fail the job, not complete green")
 	}
-	if job.Status != jobStatusCompleted {
-		t.Fatalf("status = %q, want completed", job.Status)
+	if job == nil || job.Status != jobStatusFailed {
+		t.Fatalf("status = %v, want %q", job, jobStatusFailed)
 	}
-	if !strings.Contains(job.Warning, "system state artifacts were not captured") {
-		t.Errorf("job completed with no warning about the missing system state; warning = %q", job.Warning)
-	}
-	if job.SystemStateManifest == nil {
-		t.Fatal("the manifest should be retained (platform/hardware profile are still accurate), not dropped wholesale")
-	}
-	if len(job.SystemStateManifest.Artifacts) != 0 {
-		t.Errorf("manifest still advertises %d artifacts that never reached the snapshot",
-			len(job.SystemStateManifest.Artifacts))
-	}
-	if job.SystemStateManifest.Platform != "test" {
-		t.Errorf("platform = %q, want the collector's value retained", job.SystemStateManifest.Platform)
+	if !strings.Contains(err.Error(), "system state publish failed") {
+		t.Errorf("expected a clear 'system state publish failed' reason, got: %v", err)
 	}
 }
 
@@ -679,18 +736,20 @@ func TestRunBackup_SystemStateCapturedProducesNoWarning(t *testing.T) {
 	file1 := createTempFile(t, tmpDir, "doc.txt", "user data")
 
 	stagingDir := t.TempDir()
-	if err := os.WriteFile(pathpkg.Join(stagingDir, "registry.dat"), []byte("hive"), 0o600); err != nil {
+	content := []byte("hive")
+	if err := os.WriteFile(pathpkg.Join(stagingDir, "registry.dat"), content, 0o600); err != nil {
 		t.Fatal(err)
 	}
 	stubCollectSystemState(t, func() (*systemstate.SystemStateManifest, string, error) {
 		return &systemstate.SystemStateManifest{
 			Platform:  "test",
-			Artifacts: []systemstate.Artifact{{Name: "registry"}},
+			Artifacts: []systemstate.Artifact{{Name: "registry", Path: "registry.dat", SizeBytes: int64(len(content))}},
 		}, stagingDir, nil
 	})
 
+	provider := newMockProvider()
 	mgr := NewBackupManager(BackupConfig{
-		Provider:           newMockProvider(),
+		Provider:           provider,
 		Paths:              []string{file1},
 		SystemStateEnabled: true,
 	})
@@ -698,11 +757,18 @@ func TestRunBackup_SystemStateCapturedProducesNoWarning(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RunBackup failed: %v", err)
 	}
+	if job.Status != jobStatusCompleted {
+		t.Fatalf("status = %q, want completed", job.Status)
+	}
 	if job.Warning != "" {
 		t.Errorf("healthy system-state run produced warning %q, want none", job.Warning)
 	}
 	if len(job.SystemStateManifest.Artifacts) != 1 {
 		t.Errorf("a captured artifact list must be left intact, got %d", len(job.SystemStateManifest.Artifacts))
+	}
+	wantArtifactKey := path.Join("snapshots", job.Snapshot.ID, "system-state", "registry.dat")
+	if _, ok := provider.files[wantArtifactKey]; !ok {
+		t.Errorf("expected artifact uploaded to %q, got keys %v", wantArtifactKey, providerKeys(provider))
 	}
 }
 

--- a/agent/internal/backup/incremental.go
+++ b/agent/internal/backup/incremental.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"fmt"
 	"path"
-	"path/filepath"
 	"strings"
 
 	"github.com/breeze-rmm/agent/internal/backup/providers"
-	"github.com/breeze-rmm/agent/internal/backup/systemstate"
 )
 
 // referenceDecision classifies one walked file against the previous
@@ -120,12 +118,6 @@ func buildPreviousIndex(prev *Snapshot) map[string]SnapshotFile {
 // index prev (nil = no usable previous manifest → always decideUpload),
 // implementing the design's decision table:
 //
-//   - f is a system-state staging artifact (f.systemState) → always
-//     decideUpload, never even looked up. CollectSystemState stages into a
-//     fresh os.MkdirTemp root every run, so these paths are inherently
-//     ephemeral and referencing them would be meaningless — see
-//     markSystemStateFiles for the explicit, defensive exclusion (rather
-//     than relying on the temp-dir path simply never colliding).
 //   - no entry for f's key → decideUpload (new file).
 //   - entry found but Size differs → decideUpload ("anything else" in the
 //     design table — a size change is never a reference even if some other
@@ -147,9 +139,6 @@ func buildPreviousIndex(prev *Snapshot) map[string]SnapshotFile {
 // entry itself after the upload actually completes, exactly as before
 // incremental backups existed.
 func decideFile(f backupFile, prev map[string]SnapshotFile) (referenceDecision, SnapshotFile) {
-	if f.systemState {
-		return decideUpload, SnapshotFile{}
-	}
 	entry, ok := prev[journalLookupKey(f)]
 	if !ok || entry.Size != f.size {
 		return decideUpload, SnapshotFile{}
@@ -193,74 +182,19 @@ func isReferenceEntry(entry SnapshotFile, snapshotID string) bool {
 	return !strings.HasPrefix(entry.BackupPath, ownPrefix)
 }
 
-// isUnderDir reports whether p is dir itself or a descendant of it. Used by
-// markSystemStateFiles; dir == "" always reports false (no staging dir to
-// exclude, e.g. a non-system-state run).
-func isUnderDir(p, dir string) bool {
-	if dir == "" {
-		return false
-	}
-	rel, err := filepath.Rel(dir, p)
-	if err != nil {
-		return false
-	}
-	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
-}
-
-// markSystemStateFiles flags every file in files whose sourcePath falls
-// under stagingDir (the run's system-state staging root — see
-// collectSystemState's call site in RunBackupContext) as
-// backupFile.systemState = true, so decideFile always uploads them.
-//
-// stagingDir is always the live path collectSystemState returned, never a VSS
-// shadow-device path: rewritePathsForVSS deliberately skips the staging index
-// because the dir is created after the snapshot is taken (#3026). That is what
-// keeps this prefix comparable to the sourcePaths collectBackupFilesFromPaths
-// actually produced.
-//
-// This exclusion is defense-in-depth, not strictly load-bearing for
-// correctness in production: CollectSystemState creates a fresh
-// os.MkdirTemp root every run, so a staging file's sourcePath is already
-// guaranteed never to appear as a key in a PREVIOUS manifest's index
-// (buildPreviousIndex) — the natural "new file" miss in decideFile would
-// reach the same decideUpload outcome on its own. Making it explicit here
-// keeps the exclusion correct independent of that randomness assumption
-// (e.g. a test double that reuses a fixed staging path across simulated
-// runs) and gives readers/reviewers a single obvious place the "never
-// referenced" rule lives, matching the design doc's explicit callout.
-//
-// Returns the number of files marked, so the caller can detect a manifest that
-// describes artifacts no collected file was matched to — see
-// systemStateArtifactsMissing.
-func markSystemStateFiles(files []backupFile, stagingDir string) int {
-	if stagingDir == "" {
-		return 0
-	}
-	marked := 0
-	for i := range files {
-		if isUnderDir(files[i].sourcePath, stagingDir) {
-			files[i].systemState = true
-			marked++
-		}
-	}
-	return marked
-}
-
-// systemStateArtifactsMissing reports the #3026 failure signature: the run
-// recorded a manifest describing system-state artifacts, but not one collected
-// file was matched to the staging directory those artifacts were written to.
-//
-// The manifest is written from the collector's own return value, so it says
-// nothing about whether the artifacts reached the snapshot. #3026 was one route
-// to that divergence (the staging dir rewritten onto a VSS shadow path that
-// predates it); the walk failing on the staging root, or a user exclude pattern
-// matching artifact names, are others. On a run that also has configured file
-// paths each one produces a green job whose restore point is missing the system
-// state it claims. Rather than guard only the route that was fixed, make the
-// outcome itself loud.
-//
-// A manifest with no artifacts is not a divergence — there is nothing to match
-// — so it is excluded rather than reported on every such run.
-func systemStateArtifactsMissing(manifest *systemstate.SystemStateManifest, markedFiles int) bool {
-	return manifest != nil && len(manifest.Artifacts) > 0 && markedFiles == 0
-}
+// NOTE: this package used to also carry isUnderDir/markSystemStateFiles/
+// systemStateArtifactsMissing, a detector for the #3026 failure signature (a
+// manifest recording system-state artifacts that the file walk never actually
+// saw). That whole mechanism assumed system-state artifacts were walked as
+// ordinary files (appended into backupPaths) alongside everything else.
+// Wave 1 of the D15 bare-metal-recovery contract (see
+// docs/superpowers/plans/backup/2026-09-09-bmr-system-state-contract.md)
+// moved system-state artifacts to their own remote prefix, published
+// directly from the manifest by publishSystemState (snapshot.go) rather than
+// discovered via the file walk — so a walked `files` slice never contains
+// staging-dir entries at all anymore, and the old detector would misfire on
+// EVERY run that collects any system state (markedFiles would always be 0).
+// publishSystemState's own per-artifact stat/upload is a strictly stronger
+// replacement: it fails loudly if an artifact the manifest describes isn't
+// actually on disk, rather than inferring the mismatch indirectly from the
+// file walk. Removed rather than left inert.

--- a/agent/internal/backup/incremental_test.go
+++ b/agent/internal/backup/incremental_test.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/breeze-rmm/agent/internal/backup/systemstate"
 )
 
 // TestDecideFile is the decision-table unit test: table-driven coverage of
@@ -93,14 +91,6 @@ func TestDecideFile(t *testing.T) {
 			file: backupFile{sourcePath: missingPath, size: 5, modTime: laterTime},
 			prev: map[string]SnapshotFile{
 				missingPath: {SourcePath: missingPath, BackupPath: "snapshots/old/files/missing.gz", Size: 5, ModTime: baseTime, Checksum: "whatever"},
-			},
-			wantResult: decideUpload,
-		},
-		{
-			name: "system-state staging file never referenced, even with a matching entry",
-			file: backupFile{sourcePath: unchangedPath, size: int64(len("same content")), modTime: baseTime, systemState: true},
-			prev: map[string]SnapshotFile{
-				unchangedPath: {SourcePath: unchangedPath, BackupPath: "snapshots/old/files/unchanged.txt.gz", Size: int64(len("same content")), ModTime: baseTime, Checksum: unchangedSum},
 			},
 			wantResult: decideUpload,
 		},
@@ -430,109 +420,9 @@ func TestIsReferenceEntry(t *testing.T) {
 	}
 }
 
-// TestMarkSystemStateFiles proves the staging-dir exclusion flags exactly
-// the files under stagingDir, leaving everything else untouched.
-func TestMarkSystemStateFiles(t *testing.T) {
-	tmpDir := t.TempDir()
-	stagingDir := pathpkg.Join(tmpDir, "staging")
-	files := []backupFile{
-		{sourcePath: pathpkg.Join(stagingDir, "registry.dat")},
-		{sourcePath: pathpkg.Join(stagingDir, "sub", "boot.cfg")},
-		{sourcePath: pathpkg.Join(tmpDir, "unrelated", "doc.txt")},
-		// A sibling directory that merely shares stagingDir as a string
-		// prefix must NOT match (path-boundary correctness).
-		{sourcePath: stagingDir + "-not-actually-inside" + string(pathpkg.Separator) + "f.txt"},
-	}
-
-	if marked := markSystemStateFiles(files, stagingDir); marked != 2 {
-		t.Errorf("markSystemStateFiles marked %d files, want 2 — the count is what "+
-			"systemStateArtifactsMissing uses to detect an uncaptured manifest", marked)
-	}
-
-	if !files[0].systemState {
-		t.Error("file directly under stagingDir should be marked systemState")
-	}
-	if !files[1].systemState {
-		t.Error("file nested under stagingDir should be marked systemState")
-	}
-	if files[2].systemState {
-		t.Error("file outside stagingDir must not be marked systemState")
-	}
-	if files[3].systemState {
-		t.Error("a path that merely shares stagingDir as a string prefix must not be marked systemState")
-	}
-}
-
-// TestMarkSystemStateFiles_EmptyStagingDirNoOp proves the common case (no
-// system-state collection this run) leaves every file untouched.
-func TestMarkSystemStateFiles_EmptyStagingDirNoOp(t *testing.T) {
-	files := []backupFile{{sourcePath: "/data/a.txt"}}
-	if marked := markSystemStateFiles(files, ""); marked != 0 {
-		t.Errorf("markSystemStateFiles with an empty stagingDir marked %d files, want 0", marked)
-	}
-	if files[0].systemState {
-		t.Error("markSystemStateFiles with an empty stagingDir must not mark anything")
-	}
-}
-
-// TestSystemStateArtifactsMissing is the backstop for #3026's SYMPTOM rather
-// than its cause: a job that reports success while the restore point is missing
-// the system state its manifest advertises. #3026 was one route there; the
-// detector has to fire for any of them, and stay silent otherwise.
-func TestSystemStateArtifactsMissing(t *testing.T) {
-	withArtifacts := &systemstate.SystemStateManifest{
-		Artifacts: []systemstate.Artifact{{Name: "registry"}, {Name: "boot"}},
-	}
-
-	tests := []struct {
-		name        string
-		manifest    *systemstate.SystemStateManifest
-		markedFiles int
-		want        bool
-	}{
-		{
-			// The #3026 signature: manifest recorded, staging walk produced
-			// nothing that matched it.
-			name:        "manifest with artifacts but nothing captured is reported",
-			manifest:    withArtifacts,
-			markedFiles: 0,
-			want:        true,
-		},
-		{
-			name:        "manifest with artifacts and files captured is healthy",
-			manifest:    withArtifacts,
-			markedFiles: 2,
-			want:        false,
-		},
-		{
-			// Partial capture is a different problem and deliberately out of
-			// scope here — this detector only claims "none at all".
-			name:        "a single captured file is enough to clear the check",
-			manifest:    withArtifacts,
-			markedFiles: 1,
-			want:        false,
-		},
-		{
-			name:        "no system state collected this run is not a divergence",
-			manifest:    nil,
-			markedFiles: 0,
-			want:        false,
-		},
-		{
-			// Nothing to match, so reporting would fire on every such run and
-			// train operators to ignore the warning.
-			name:        "a manifest describing no artifacts is not a divergence",
-			manifest:    &systemstate.SystemStateManifest{},
-			markedFiles: 0,
-			want:        false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := systemStateArtifactsMissing(tt.manifest, tt.markedFiles); got != tt.want {
-				t.Errorf("systemStateArtifactsMissing = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
+// NOTE: TestMarkSystemStateFiles/TestMarkSystemStateFiles_EmptyStagingDirNoOp/
+// TestSystemStateArtifactsMissing used to live here, covering
+// markSystemStateFiles/isUnderDir/systemStateArtifactsMissing — all removed
+// in incremental.go (see the NOTE there) now that system-state artifacts are
+// published directly from the manifest (snapshot.go's publishSystemState)
+// rather than discovered via the ordinary file walk.

--- a/agent/internal/backup/incremental_test.go
+++ b/agent/internal/backup/incremental_test.go
@@ -351,7 +351,7 @@ func TestIncrementalDedupeBase_ScopedToBackupIdentity(t *testing.T) {
 	}
 	run1Files := []backupFile{{sourcePath: f1, snapshotPath: "path_0/f1.txt", size: 3, modTime: modTime}}
 
-	snapshot1, err := createSnapshotWithProgress(context.Background(), provider, run1Files, nil, nil, nil, nil, identityA)
+	snapshot1, err := createSnapshotWithProgress(context.Background(), provider, run1Files, nil, nil, nil, nil, withRunIdentity(identityA))
 	if err != nil {
 		t.Fatalf("run 1 (identity A) failed: %v", err)
 	}
@@ -363,7 +363,7 @@ func TestIncrementalDedupeBase_ScopedToBackupIdentity(t *testing.T) {
 	// reports it as the newest snapshot in the whole bucket.
 	fB := createTempFile(t, tmpDir, "fb.txt", "foreign-device-file")
 	runBFiles := []backupFile{{sourcePath: fB, snapshotPath: "path_0/fb.txt", size: int64(len("foreign-device-file")), modTime: modTime}}
-	snapshotB, err := createSnapshotWithProgress(context.Background(), provider, runBFiles, nil, nil, nil, nil, identityB)
+	snapshotB, err := createSnapshotWithProgress(context.Background(), provider, runBFiles, nil, nil, nil, nil, withRunIdentity(identityB))
 	if err != nil {
 		t.Fatalf("foreign run (identity B) failed: %v", err)
 	}
@@ -377,7 +377,7 @@ func TestIncrementalDedupeBase_ScopedToBackupIdentity(t *testing.T) {
 	}
 
 	run2Files := []backupFile{{sourcePath: f1, snapshotPath: "path_0/f1.txt", size: 3, modTime: modTime}} // unchanged
-	snapshot2, err := createSnapshotWithProgress(context.Background(), provider, run2Files, nil, nil, prev, nil, identityA)
+	snapshot2, err := createSnapshotWithProgress(context.Background(), provider, run2Files, nil, nil, prev, nil, withRunIdentity(identityA))
 	if err != nil {
 		t.Fatalf("run 2 (identity A) failed: %v", err)
 	}

--- a/agent/internal/backup/snapshot.go
+++ b/agent/internal/backup/snapshot.go
@@ -11,12 +11,14 @@ import (
 	"io"
 	"os"
 	"path"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/breeze-rmm/agent/internal/backup/providers"
+	"github.com/breeze-rmm/agent/internal/backup/systemstate"
 )
 
 // sha256File streams a file through SHA-256 and returns the lowercase-hex
@@ -46,6 +48,21 @@ const (
 	snapshotRootDir     = "snapshots"
 	snapshotFilesDir    = "files"
 	snapshotManifestKey = "manifest.json"
+	// systemStateDir is the remote sub-prefix, under a snapshot, where system
+	// state artifacts and their own manifest live — a dedicated tree, never
+	// the ordinary files/ tree. This is Option A of the D15 bare-metal-
+	// recovery contract (docs/superpowers/plans/backup/
+	// 2026-09-09-bmr-system-state-contract.md): the consumer (agent/internal/
+	// backup/bmr/bmr.go's systemStatePath) already expects exactly this
+	// layout, so the value here MUST match that constant.
+	systemStateDir = "system-state"
+	// systemStateManifestKey mirrors snapshotManifestKey, scoped to
+	// systemStateDir.
+	systemStateManifestKey = "manifest.json"
+	// systemStateManifestSchemaVersion mirrors systemstate.manifestSchemaVersion
+	// (that package's own unexported constant) — see publishSystemState's
+	// doc comment for why the backup package also stamps it.
+	systemStateManifestSchemaVersion = 1
 )
 
 // Snapshot represents a point-in-time backup.
@@ -832,6 +849,111 @@ func publishSnapshotManifest(ctx context.Context, provider providers.BackupProvi
 		return fmt.Errorf("failed to upload snapshot manifest: %w", manifestUploadErr)
 	}
 	return nil
+}
+
+// publishSystemState uploads every artifact manifest describes (read from
+// stagingDir, where systemstate.CollectSystemState wrote them) to
+// snapshots/<snapshotID>/system-state/<artifact.Path>, then uploads manifest
+// itself to snapshots/<snapshotID>/system-state/manifest.json.
+//
+// Deliberately a SEPARATE remote prefix and a separate publish step from the
+// ordinary files/ tree and publishSnapshotManifest: mixing the two write
+// paths (appending the staging dir into the ordinary file walk) is exactly
+// the D15/O10 bug this function exists to fix — see the plan doc referenced
+// on systemStateDir. A caller invokes this using the SAME snapshot ID as the
+// rest of that run's snapshot (its own, for a state-only run; or the one
+// createSnapshotWithProgress already minted, for a run that also has
+// configured file paths), so bmr.go's bootstrap-driven lookup by snapshot ID
+// finds both trees under one prefix.
+//
+// Every artifact must exist in stagingDir at exactly the size the collector
+// recorded (SizeBytes) — a mismatch means the staging file was mutated or
+// truncated after collection, which is treated as a hard failure rather than
+// silently uploading corrupt/incomplete bytes. Checksums are computed by the
+// collector at collection time (systemstate.artifactFromFile /
+// collectArtifactsInDir) and carried through unchanged here; a downloading
+// consumer verifies against them.
+//
+// Returns nil for a nil manifest (nothing to publish) — callers gate this
+// off Artifacts being non-empty before calling, but staying a safe no-op
+// keeps this function usable standalone too.
+func publishSystemState(ctx context.Context, provider providers.BackupProvider, snapshotID, stagingDir string, manifest *systemstate.SystemStateManifest) error {
+	if manifest == nil {
+		return nil
+	}
+	// Belt-and-suspenders alongside systemstate.CollectSystemState (which
+	// already sets this on the real collection path): guarantees every
+	// manifest this function ever publishes carries a schema version, even
+	// one built by a test double or future caller that bypasses
+	// CollectSystemState.
+	manifest.SchemaVersion = systemStateManifestSchemaVersion
+	prefix := path.Join(snapshotRootDir, snapshotID, systemStateDir)
+
+	for i := range manifest.Artifacts {
+		art := &manifest.Artifacts[i]
+		localPath := filepath.Join(stagingDir, filepath.FromSlash(art.Path))
+
+		info, statErr := os.Stat(localPath)
+		if statErr != nil {
+			return fmt.Errorf("stat system state artifact %s: %w", art.Path, statErr)
+		}
+		if info.Size() != art.SizeBytes {
+			return fmt.Errorf("system state artifact %s changed size since collection (expected %d bytes, found %d)",
+				art.Path, art.SizeBytes, info.Size())
+		}
+
+		remoteKey := path.Join(prefix, art.Path)
+		attemptCtx, cancelAttempt := context.WithTimeout(ctx, uploadDeadline(info.Size()))
+		uploadErr := uploadSnapshotFile(attemptCtx, provider, localPath, remoteKey)
+		cancelAttempt()
+		if uploadErr != nil {
+			if errors.Is(uploadErr, errBackupStopped) {
+				return uploadErr
+			}
+			return fmt.Errorf("upload system state artifact %s: %w", art.Path, uploadErr)
+		}
+	}
+
+	manifestPath, manifestErr := writeSystemStateManifest(manifest)
+	if manifestErr != nil {
+		return manifestErr
+	}
+	defer os.Remove(manifestPath)
+
+	manifestKey := path.Join(prefix, systemStateManifestKey)
+	manifestInfo, statErr := os.Stat(manifestPath)
+	var manifestSize int64
+	if statErr == nil {
+		manifestSize = manifestInfo.Size()
+	}
+	attemptCtx, cancelAttempt := context.WithTimeout(ctx, uploadDeadline(manifestSize))
+	manifestUploadErr := uploadSnapshotFile(attemptCtx, provider, manifestPath, manifestKey)
+	cancelAttempt()
+	if manifestUploadErr != nil {
+		if errors.Is(manifestUploadErr, errBackupStopped) {
+			return manifestUploadErr
+		}
+		return fmt.Errorf("failed to upload system state manifest: %w", manifestUploadErr)
+	}
+	return nil
+}
+
+// writeSystemStateManifest serializes manifest to a temp file for upload,
+// mirroring writeSnapshotManifest.
+func writeSystemStateManifest(manifest *systemstate.SystemStateManifest) (string, error) {
+	tempFile, err := os.CreateTemp("", "system-state-manifest-*.json")
+	if err != nil {
+		return "", fmt.Errorf("failed to create system state manifest: %w", err)
+	}
+	encoder := json.NewEncoder(tempFile)
+	if err := encoder.Encode(manifest); err != nil {
+		_ = tempFile.Close()
+		return "", fmt.Errorf("failed to encode system state manifest: %w", err)
+	}
+	if err := tempFile.Close(); err != nil {
+		return "", fmt.Errorf("failed to close system state manifest: %w", err)
+	}
+	return tempFile.Name(), nil
 }
 
 // attemptFileUpload runs a single upload attempt for file against a fresh

--- a/agent/internal/backup/snapshot.go
+++ b/agent/internal/backup/snapshot.go
@@ -303,6 +303,49 @@ func CreateSnapshotContext(ctx context.Context, provider providers.BackupProvide
 	return createSnapshotWithProgress(ctx, provider, files, nil, nil, nil, nil)
 }
 
+// createSnapshotOption customizes a single createSnapshotWithProgress call.
+// Functional options rather than more positional parameters: each option is
+// needed by only a handful of call sites, out of dozens across this
+// package's tests, and a positional parameter would force every other call
+// site to pass an explicit zero value.
+type createSnapshotOption func(*createSnapshotOptions)
+
+type createSnapshotOptions struct {
+	runIdentity           string
+	systemStateStagingDir string
+	systemStateManifest   *systemstate.SystemStateManifest
+}
+
+// withRunIdentity stamps identity onto the new snapshot's BackupIdentity —
+// see createSnapshotWithProgress's doc comment.
+func withRunIdentity(identity string) createSnapshotOption {
+	return func(o *createSnapshotOptions) { o.runIdentity = identity }
+}
+
+// withSystemState arranges for the system state already collected into
+// stagingDir (described by manifest) to be published under the SAME
+// snapshot ID as the ordinary files this createSnapshotWithProgress call is
+// snapshotting — and published BEFORE that call's own ordinary
+// manifest.json. Ordering matters: the ordinary manifest.json is the
+// "commit point" a concurrent GC sweep uses to decide a snapshot-id group is
+// "manifest-bearing" (markLiveBackupObjects, apps/api/src/jobs/
+// backupRetention.ts) and therefore eligible for the per-object grace period
+// rather than the manifestless-prefix rule. Publishing it FIRST — the
+// previous behavior, when backup.go called publishSystemState only after
+// createSnapshotWithProgress had already returned (and therefore already
+// published the ordinary manifest internally) — leaves a window where a GC
+// sweep sees a manifest-bearing group whose system-state/* objects are not
+// marked live yet, and can reap them.
+//
+// A no-op when manifest is nil or carries zero artifacts (nothing to
+// publish), matching the existing gate used elsewhere in this package.
+func withSystemState(stagingDir string, manifest *systemstate.SystemStateManifest) createSnapshotOption {
+	return func(o *createSnapshotOptions) {
+		o.systemStateStagingDir = stagingDir
+		o.systemStateManifest = manifest
+	}
+}
+
 // createSnapshotWithProgress creates a new snapshot using the provided
 // context, invoking onProgress (if non-nil) as files upload. Calls are
 // throttled to at most once per progressThrottle interval, except for a
@@ -349,25 +392,27 @@ func CreateSnapshotContext(ctx context.Context, provider providers.BackupProvide
 // letting every remaining file be recorded as individually bad (#3260). nil
 // means the run reads the live filesystem and has nothing to defend.
 //
-// runIdentity, if provided (variadic so the ~25 existing call sites that
-// don't care about it need no change — same pattern as main.go's
-// `tickets ...*backupExecutionTicket`), is stamped onto the new snapshot's
-// BackupIdentity (see that field's doc comment and runBackupIdentity) so a
-// LATER run can find this one via previousManifest without picking up
-// another device's or run-kind's snapshot instead (D6). At most the first
-// element is used; passing more than one is a caller bug and only the first
-// is honored.
-func createSnapshotWithProgress(ctx context.Context, provider providers.BackupProvider, files []backupFile, onProgress ProgressFn, journal *snapshotJournal, prevSnapshot *Snapshot, sourceLiveness sourceLivenessFn, runIdentity ...string) (*Snapshot, error) {
+// opts, if provided (variadic functional options so the ~25 existing call
+// sites that don't care about either option need no change — same pattern
+// as main.go's `tickets ...*backupExecutionTicket`), customize the call:
+// withRunIdentity stamps the new snapshot's BackupIdentity (see that field's
+// doc comment and runBackupIdentity) so a LATER run can find this one via
+// previousManifest without picking up another device's or run-kind's
+// snapshot instead (D6); withSystemState publishes already-collected system
+// state under this call's snapshot ID BEFORE the ordinary manifest.json (see
+// withSystemState's doc comment for why the order matters).
+func createSnapshotWithProgress(ctx context.Context, provider providers.BackupProvider, files []backupFile, onProgress ProgressFn, journal *snapshotJournal, prevSnapshot *Snapshot, sourceLiveness sourceLivenessFn, opts ...createSnapshotOption) (*Snapshot, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	if sourceLiveness == nil {
 		sourceLiveness = func(string) error { return nil }
 	}
-	identity := ""
-	if len(runIdentity) > 0 {
-		identity = runIdentity[0]
+	var options createSnapshotOptions
+	for _, opt := range opts {
+		opt(&options)
 	}
+	identity := options.runIdentity
 
 	// Register the journal's fd cleanup before any other return path so
 	// every exit — including the validation errors just below — closes it.
@@ -798,6 +843,23 @@ func createSnapshotWithProgress(ctx context.Context, provider providers.BackupPr
 		return abortStopped()
 	}
 
+	// System state (if any was collected for this run — see withSystemState)
+	// publishes BEFORE the ordinary manifest below: see withSystemState's doc
+	// comment for why the order matters to a concurrent GC sweep.
+	if options.systemStateManifest != nil && len(options.systemStateManifest.Artifacts) > 0 {
+		if err := publishSystemState(ctx, provider, snapshot.ID, options.systemStateStagingDir, options.systemStateManifest); err != nil {
+			log.Error("system state publish failed; the snapshot's ordinary files were still stored, "+
+				"but the restore point is missing bare-metal recovery state",
+				"snapshotId", snapshot.ID,
+				"error", err.Error(),
+			)
+			if errors.Is(err, errBackupStopped) {
+				return abortStopped()
+			}
+			return snapshot, fmt.Errorf("system state publish failed: %w", err)
+		}
+	}
+
 	if err := publishSnapshotManifest(ctx, provider, snapshot, prefix); err != nil {
 		if errors.Is(err, errBackupStopped) {
 			// A manifest-upload deadline expiry is fatal for the snapshot too
@@ -891,6 +953,12 @@ func publishSystemState(ctx context.Context, provider providers.BackupProvider, 
 
 	for i := range manifest.Artifacts {
 		art := &manifest.Artifacts[i]
+		if art.LinkTarget != "" {
+			// Symlink artifact: no independent file content to upload (see
+			// Artifact.LinkTarget's doc comment) — the manifest entry alone,
+			// written below, is enough for a consumer to recreate the link.
+			continue
+		}
 		localPath := filepath.Join(stagingDir, filepath.FromSlash(art.Path))
 
 		info, statErr := os.Stat(localPath)
@@ -918,7 +986,11 @@ func publishSystemState(ctx context.Context, provider providers.BackupProvider, 
 	if manifestErr != nil {
 		return manifestErr
 	}
-	defer os.Remove(manifestPath)
+	// Best-effort: manifestPath is a local OS temp file, already uploaded (or
+	// about to fail trying) — a leftover on Remove failure is harmless OS
+	// temp-dir clutter, not a correctness issue worth failing the publish
+	// over. Matches the sibling cleanup in publishSnapshotManifest above.
+	defer func() { _ = os.Remove(manifestPath) }()
 
 	manifestKey := path.Join(prefix, systemStateManifestKey)
 	manifestInfo, statErr := os.Stat(manifestPath)

--- a/agent/internal/backup/snapshot_test.go
+++ b/agent/internal/backup/snapshot_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/breeze-rmm/agent/internal/backup/providers"
+	"github.com/breeze-rmm/agent/internal/backup/systemstate"
 )
 
 // mockProvider implements providers.BackupProvider for testing.
@@ -1633,7 +1634,7 @@ func TestCreateSnapshotWithProgress_IncrementalTwoRun_ReferencesUnchangedFiles(t
 		{sourcePath: f2, snapshotPath: "path_0/f2.txt", size: 3, modTime: modTime},
 		{sourcePath: f3, snapshotPath: "path_0/f3.txt", size: 5, modTime: modTime},
 	}
-	snapshot1, err := createSnapshotWithProgress(context.Background(), provider, run1Files, nil, nil, nil, nil, "test-device")
+	snapshot1, err := createSnapshotWithProgress(context.Background(), provider, run1Files, nil, nil, nil, nil, withRunIdentity("test-device"))
 	if err != nil {
 		t.Fatalf("run 1 failed: %v", err)
 	}
@@ -1673,7 +1674,7 @@ func TestCreateSnapshotWithProgress_IncrementalTwoRun_ReferencesUnchangedFiles(t
 		{sourcePath: f2, snapshotPath: "path_0/f2.txt", size: int64(len("TWO-CHANGED")), modTime: newModTime}, // changed
 		// f3 deliberately absent — deleted from disk before this run's walk.
 	}
-	snapshot2, err := createSnapshotWithProgress(context.Background(), provider, run2Files, nil, nil, prev, nil, "test-device")
+	snapshot2, err := createSnapshotWithProgress(context.Background(), provider, run2Files, nil, nil, prev, nil, withRunIdentity("test-device"))
 	if err != nil {
 		t.Fatalf("run 2 failed: %v", err)
 	}
@@ -1834,5 +1835,74 @@ func TestCreateSnapshotWithProgress_JournalResumeWinsOverReference(t *testing.T)
 	}
 	if len(provider.uploadCalls) != 1 { // only the manifest uploads
 		t.Fatalf("expected only the manifest to upload (file resumed via journal), got %d upload calls: %v", len(provider.uploadCalls), provider.uploadCalls)
+	}
+}
+
+// TestPublishSystemState_SkipsUploadingSymlinkArtifacts pins the D15 Wave 1
+// fix (finding #5): a symlink artifact (LinkTarget set) has no independent
+// file content — publishSystemState must record it in the manifest but NOT
+// try to upload anything for its key, unlike an ordinary artifact.
+func TestPublishSystemState_SkipsUploadingSymlinkArtifacts(t *testing.T) {
+	stagingDir := t.TempDir()
+	regularContent := []byte("hello")
+	if err := os.WriteFile(pathpkg.Join(stagingDir, "real.txt"), regularContent, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// The symlink artifact's Path need not exist as a real file in staging
+	// for this to matter — publishSystemState must not even stat/open it as
+	// a regular file — but stage the actual link too, matching what
+	// collectArtifactsInDir would have produced from a real copyTree run.
+	if err := os.Symlink("real.txt", pathpkg.Join(stagingDir, "link.txt")); err != nil {
+		t.Fatal(err)
+	}
+
+	manifest := &systemstate.SystemStateManifest{
+		Platform: "test",
+		Artifacts: []systemstate.Artifact{
+			{Name: "real.txt", Category: "config", Path: "real.txt", SizeBytes: int64(len(regularContent))},
+			{Name: "link.txt", Category: "config", Path: "link.txt", LinkTarget: "real.txt"},
+		},
+	}
+
+	provider := newMockProvider()
+	snapshotID := "snap-1"
+	if err := publishSystemState(context.Background(), provider, snapshotID, stagingDir, manifest); err != nil {
+		t.Fatalf("publishSystemState: %v", err)
+	}
+
+	wantRegularKey := path.Join("snapshots", snapshotID, "system-state", "real.txt")
+	wantSymlinkKey := path.Join("snapshots", snapshotID, "system-state", "link.txt")
+	wantManifestKey := path.Join("snapshots", snapshotID, "system-state", "manifest.json")
+
+	if _, ok := provider.files[wantRegularKey]; !ok {
+		t.Errorf("expected the regular artifact to upload to %q, got keys %v", wantRegularKey, providerKeys(provider))
+	}
+	if _, ok := provider.files[wantSymlinkKey]; ok {
+		t.Errorf("symlink artifact must NOT be uploaded as its own object (manifest-only), but found %q", wantSymlinkKey)
+	}
+	for _, c := range provider.uploadCalls {
+		if c.remotePath == wantSymlinkKey {
+			t.Errorf("publishSystemState issued an upload call for the symlink artifact %q, want none", wantSymlinkKey)
+		}
+	}
+	if _, ok := provider.files[wantManifestKey]; !ok {
+		t.Errorf("expected system-state manifest uploaded to %q, got keys %v", wantManifestKey, providerKeys(provider))
+	}
+
+	var gotManifest systemstate.SystemStateManifest
+	if err := json.Unmarshal(provider.files[wantManifestKey], &gotManifest); err != nil {
+		t.Fatalf("decode published manifest: %v", err)
+	}
+	var gotLink *systemstate.Artifact
+	for i := range gotManifest.Artifacts {
+		if gotManifest.Artifacts[i].Name == "link.txt" {
+			gotLink = &gotManifest.Artifacts[i]
+		}
+	}
+	if gotLink == nil {
+		t.Fatal("published manifest is missing the symlink artifact entry")
+	}
+	if gotLink.LinkTarget != "real.txt" {
+		t.Errorf("published symlink artifact LinkTarget = %q, want %q", gotLink.LinkTarget, "real.txt")
 	}
 }

--- a/agent/internal/backup/systemstate/helpers.go
+++ b/agent/internal/backup/systemstate/helpers.go
@@ -1,6 +1,8 @@
 package systemstate
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"io/fs"
@@ -10,22 +12,60 @@ import (
 	"path/filepath"
 )
 
-// artifactFromFile creates an Artifact for a single collected file.
+// sha256File streams a file through SHA-256 and returns the lowercase-hex
+// digest, mirroring backup.sha256File — this package sits below the backup
+// package in the dependency graph (backup imports systemstate) so it cannot
+// reuse that one directly.
+func sha256File(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// artifactFromFile creates an Artifact for a single collected file, including
+// its SHA-256 checksum (computed here, at collection time, while the file is
+// known-good — a BMR consumer verifies downloaded bytes against this before
+// applying them).
 func artifactFromFile(name, category, absPath, stagingDir string) Artifact {
 	relPath, _ := filepath.Rel(stagingDir, absPath)
 	var size int64
 	if info, err := os.Stat(absPath); err == nil {
 		size = info.Size()
 	}
+	checksum, err := sha256File(absPath)
+	if err != nil {
+		slog.Warn("systemstate: checksum failed, artifact recorded without one",
+			"path", absPath, "error", err.Error())
+	}
 	return Artifact{
 		Name:      name,
 		Category:  category,
 		Path:      filepath.ToSlash(relPath),
 		SizeBytes: size,
+		Checksum:  checksum,
 	}
 }
 
-// collectArtifactsInDir walks a directory and returns an Artifact for each file.
+// collectArtifactsInDir walks a directory and returns an Artifact (with
+// checksum — see artifactFromFile's doc comment) for each REGULAR file.
+//
+// Symlinks are deliberately excluded from the artifact list (not just
+// skipped from checksumming): copyTree/copyFile stage a symlink as a real
+// symlink (see copySymlink), so it has no independent file content of its
+// own to checksum — sha256File would either silently follow the link and
+// checksum whatever it currently points at (not what this "artifact" is) or
+// fail outright on a dangling link. The link itself is still staged and
+// still gets restored; it is just not tracked or integrity-checked as its
+// own Artifact entry. This is the documented, simpler-than-the-alternative
+// choice over recording a symlink artifact with its target path — see the
+// D15 plan's Wave 1 addendum.
 func collectArtifactsInDir(category, dir, stagingDir string) ([]Artifact, error) {
 	var artifacts []Artifact
 	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, walkErr error) error {
@@ -35,24 +75,58 @@ func collectArtifactsInDir(category, dir, stagingDir string) ([]Artifact, error)
 		if d.IsDir() {
 			return nil
 		}
+		if !d.Type().IsRegular() {
+			return nil // symlinks and any other non-regular entry — see doc comment above
+		}
 		info, err := d.Info()
 		if err != nil {
 			return nil
 		}
 		relPath, _ := filepath.Rel(stagingDir, path)
+		checksum, sumErr := sha256File(path)
+		if sumErr != nil {
+			slog.Warn("systemstate: checksum failed, artifact recorded without one",
+				"path", path, "error", sumErr.Error())
+		}
 		artifacts = append(artifacts, Artifact{
 			Name:      filepath.Base(path),
 			Category:  category,
 			Path:      filepath.ToSlash(relPath),
 			SizeBytes: info.Size(),
+			Checksum:  checksum,
 		})
 		return nil
 	})
 	return artifacts, err
 }
 
-// copyFile copies a single file from src to dst.
+// copyFile copies a single filesystem entry from src to dst, preserving its
+// permission bits, modification time, and (best-effort, Unix only — see
+// lchownBestEffort) owning uid/gid.
+//
+// src is statted here via os.Lstat (never follows symlinks), so:
+//   - a symlink is recreated as a symlink at dst (see copySymlink) rather
+//     than silently dereferenced into a copy of its target's content — the
+//     bug that would otherwise turn e.g. /etc/localtime (commonly a symlink
+//     into /usr/share/zoneinfo) into a plain-file copy that restore can never
+//     tell apart from the original;
+//   - anything that isn't a regular file or a symlink (socket, FIFO, device)
+//     is rejected — callers that walk a tree (copyTree) are expected to
+//     filter those out themselves with an info-level log, since "not a
+//     regular file" from here reads like a plain error otherwise.
 func copyFile(src, dst string) error {
+	info, err := os.Lstat(src)
+	if err != nil {
+		return fmt.Errorf("lstat %s: %w", src, err)
+	}
+
+	if info.Mode()&os.ModeSymlink != 0 {
+		return copySymlink(src, dst, info)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("copyFile: %s is not a regular file or symlink (mode %s)", src, info.Mode())
+	}
+
 	in, err := os.Open(src)
 	if err != nil {
 		return fmt.Errorf("open %s: %w", src, err)
@@ -67,18 +141,91 @@ func copyFile(src, dst string) error {
 	if err != nil {
 		return fmt.Errorf("create %s: %w", dst, err)
 	}
-	defer out.Close()
 
 	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
 		return fmt.Errorf("copy %s → %s: %w", src, dst, err)
 	}
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("close %s: %w", dst, err)
+	}
+
+	applyFileMetadata(dst, info)
 	return nil
 }
 
-// copyTree recursively copies a directory tree. Symlinks are skipped.
-// Permission errors on individual files are logged and skipped, not fatal.
+// copySymlink recreates src — a symlink, per copyFile's os.Lstat check — at
+// dst pointing at the same target. A dangling target is fine: os.Symlink
+// does not validate it, matching how the live source symlink may already be
+// dangling (e.g. a stale /etc entry). Mode and mtime are not meaningfully
+// settable on a symlink on the platforms this agent targets and are skipped;
+// ownership is applied via os.Lchown (see lchownBestEffort) so it lands on
+// the LINK itself, never on whatever it points at.
+func copySymlink(src, dst string, info os.FileInfo) error {
+	target, err := os.Readlink(src)
+	if err != nil {
+		return fmt.Errorf("readlink %s: %w", src, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o700); err != nil {
+		return err
+	}
+	// Best-effort: a stale entry from an earlier, interrupted run must not
+	// block os.Symlink with EEXIST. The staging dir is normally fresh
+	// (os.MkdirTemp per run), so this is defense-in-depth, not the common
+	// case.
+	_ = os.Remove(dst)
+	if err := os.Symlink(target, dst); err != nil {
+		return fmt.Errorf("symlink %s -> %s: %w", dst, target, err)
+	}
+	lchownBestEffort(dst, info)
+	return nil
+}
+
+// applyFileMetadata chmods/chtimes dst to match info (a REGULAR file's
+// os.Lstat result), then best-effort chowns it (see lchownBestEffort). Each
+// step is independently best-effort/warn-only: a staged copy that is missing
+// exact metadata is still far more useful for restore than none at all, so
+// nothing here fails the collection.
+func applyFileMetadata(dst string, info os.FileInfo) {
+	if err := os.Chmod(dst, info.Mode().Perm()); err != nil {
+		slog.Warn("systemstate: chmod failed on staged copy", "path", dst, "error", err.Error())
+	}
+	if err := os.Chtimes(dst, info.ModTime(), info.ModTime()); err != nil {
+		slog.Warn("systemstate: chtimes failed on staged copy", "path", dst, "error", err.Error())
+	}
+	lchownBestEffort(dst, info)
+}
+
+// dirFixup defers a staged directory's final permissions/mtime/ownership
+// until every entry underneath it has been written — see copyTree's doc
+// comment for why this can't happen inline during the walk.
+type dirFixup struct {
+	path string
+	info os.FileInfo
+}
+
+// copyTree recursively copies a directory tree, preserving each entry's
+// permission bits, modification time, and (best-effort) owning uid/gid —
+// see copyFile/copySymlink/applyFileMetadata. Permission errors on
+// individual files are logged and skipped, not fatal; sockets, FIFOs, and
+// device files are skipped with an info log (not staged at all — copying
+// their "content" as a plain file is meaningless and os.Open on some of
+// these can block).
+//
+// Directories are created at a permissive 0o700 DURING the walk (so writing
+// their own children never fails even when the SOURCE directory is more
+// restrictive, e.g. mode 0500) and only chmod/chtimes/chown'd to match the
+// source in a second pass after the whole walk completes — fixing them up
+// inline, in the same pre-order pass WalkDir uses, would risk locking a
+// directory down before its own children are written. The staging ROOT
+// (stagingDir itself, created by CollectSystemState via os.MkdirTemp) is
+// NOT touched by this function and keeps its own 0700 regardless — it holds
+// secret material (registry hives, /etc/shadow-adjacent copies, etc.)
+// unrelated to whatever mode any individual copied source directory had.
 func copyTree(srcRoot, dstRoot string) error {
-	return filepath.WalkDir(srcRoot, func(path string, d fs.DirEntry, walkErr error) error {
+	var dirFixups []dirFixup
+
+	walkErr := filepath.WalkDir(srcRoot, func(path string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return nil // skip inaccessible entries
 		}
@@ -89,21 +236,54 @@ func copyTree(srcRoot, dstRoot string) error {
 		}
 		dstPath := filepath.Join(dstRoot, relPath)
 
+		info, err := d.Info() // Lstat-based: does not follow symlinks
+		if err != nil {
+			return nil // vanished between walk and stat; skip
+		}
+
 		if d.IsDir() {
-			return os.MkdirAll(dstPath, 0o700)
-		}
-
-		// Skip symlinks and non-regular files.
-		if !d.Type().IsRegular() {
+			if err := os.MkdirAll(dstPath, 0o700); err != nil {
+				return nil
+			}
+			if relPath != "." {
+				dirFixups = append(dirFixups, dirFixup{path: dstPath, info: info})
+			}
 			return nil
 		}
 
-		if err := copyFile(path, dstPath); err != nil {
-			// Non-fatal: skip files we can't read (e.g. /etc/shadow).
+		if d.Type()&os.ModeSymlink != 0 || d.Type().IsRegular() {
+			if err := copyFile(path, dstPath); err != nil {
+				// Non-fatal: skip files we can't read (e.g. /etc/shadow).
+				slog.Warn("systemstate: skipping unreadable file during tree copy",
+					"path", path, "error", err.Error())
+			}
 			return nil
 		}
+
+		// Sockets, FIFOs, character/block devices: not meaningful to stage
+		// as a file, and opening some of these can block indefinitely.
+		// Routine on a live /etc tree — e.g. some distros place sockets
+		// under /etc/... — so this is an info log, not a warning.
+		slog.Info("systemstate: skipping non-regular, non-symlink entry",
+			"path", path, "mode", d.Type().String())
 		return nil
 	})
+
+	// Fix up every staged directory's real permissions/mtime/ownership now
+	// that everything underneath has been written. Order among fixups
+	// doesn't matter: this phase only narrows/adjusts metadata and never
+	// needs to write anything further inside any of them afterward.
+	for _, fx := range dirFixups {
+		if err := os.Chmod(fx.path, fx.info.Mode().Perm()); err != nil {
+			slog.Warn("systemstate: chmod failed on staged directory", "path", fx.path, "error", err.Error())
+		}
+		if err := os.Chtimes(fx.path, fx.info.ModTime(), fx.info.ModTime()); err != nil {
+			slog.Warn("systemstate: chtimes failed on staged directory", "path", fx.path, "error", err.Error())
+		}
+		lchownBestEffort(fx.path, fx.info)
+	}
+
+	return walkErr
 }
 
 // ---------------------------------------------------------------------------

--- a/agent/internal/backup/systemstate/helpers.go
+++ b/agent/internal/backup/systemstate/helpers.go
@@ -12,6 +12,29 @@ import (
 	"path/filepath"
 )
 
+// modeFromInfo converts info's os.FileMode into the traditional POSIX
+// st_mode & 07777 encoding: the low 9 bits (permission bits, i.e.
+// info.Mode().Perm()) OR'd with the setuid/setgid/sticky bits translated
+// from Go's os.ModeSetuid/os.ModeSetgid/os.ModeSticky (which use different
+// bit positions than the traditional octal 04000/02000/01000) into those
+// traditional positions. Platform-independent: os.ModeSetuid/Setgid/Sticky
+// are always false on Windows, so this degrades to just the permission bits
+// there, matching Artifact.Mode's doc comment.
+func modeFromInfo(info os.FileInfo) uint32 {
+	fm := info.Mode()
+	mode := uint32(fm.Perm())
+	if fm&os.ModeSetuid != 0 {
+		mode |= 0o4000
+	}
+	if fm&os.ModeSetgid != 0 {
+		mode |= 0o2000
+	}
+	if fm&os.ModeSticky != 0 {
+		mode |= 0o1000
+	}
+	return mode
+}
+
 // sha256File streams a file through SHA-256 and returns the lowercase-hex
 // digest, mirroring backup.sha256File — this package sits below the backup
 // package in the dependency graph (backup imports systemstate) so it cannot
@@ -21,7 +44,10 @@ func sha256File(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer f.Close()
+	// Read-only handle: nothing buffered to lose, so a Close failure here
+	// (already-closed fd, or a similarly benign race) is not worth
+	// propagating — discard explicitly rather than leaving it unchecked.
+	defer func() { _ = f.Close() }()
 	h := sha256.New()
 	if _, err := io.Copy(h, f); err != nil {
 		return "", err
@@ -32,40 +58,43 @@ func sha256File(path string) (string, error) {
 // artifactFromFile creates an Artifact for a single collected file, including
 // its SHA-256 checksum (computed here, at collection time, while the file is
 // known-good — a BMR consumer verifies downloaded bytes against this before
-// applying them).
+// applying them) and its mode/uid/gid/modTime (from os.Lstat, never
+// following a symlink — see Artifact.Mode/UID/GID/ModTime's doc comments),
+// so a BMR restore (Wave 3) can put the restored file back exactly as it was
+// collected.
 func artifactFromFile(name, category, absPath, stagingDir string) Artifact {
 	relPath, _ := filepath.Rel(stagingDir, absPath)
-	var size int64
-	if info, err := os.Stat(absPath); err == nil {
-		size = info.Size()
+	art := Artifact{
+		Name:     name,
+		Category: category,
+		Path:     filepath.ToSlash(relPath),
+	}
+	if info, err := os.Lstat(absPath); err == nil {
+		art.SizeBytes = info.Size()
+		art.Mode = modeFromInfo(info)
+		art.ModTime = info.ModTime()
+		if uid, gid := uidGidFromInfo(info); uid >= 0 {
+			art.UID, art.GID = uid, gid
+		}
 	}
 	checksum, err := sha256File(absPath)
 	if err != nil {
 		slog.Warn("systemstate: checksum failed, artifact recorded without one",
 			"path", absPath, "error", err.Error())
 	}
-	return Artifact{
-		Name:      name,
-		Category:  category,
-		Path:      filepath.ToSlash(relPath),
-		SizeBytes: size,
-		Checksum:  checksum,
-	}
+	art.Checksum = checksum
+	return art
 }
 
-// collectArtifactsInDir walks a directory and returns an Artifact (with
-// checksum — see artifactFromFile's doc comment) for each REGULAR file.
-//
-// Symlinks are deliberately excluded from the artifact list (not just
-// skipped from checksumming): copyTree/copyFile stage a symlink as a real
-// symlink (see copySymlink), so it has no independent file content of its
-// own to checksum — sha256File would either silently follow the link and
-// checksum whatever it currently points at (not what this "artifact" is) or
-// fail outright on a dangling link. The link itself is still staged and
-// still gets restored; it is just not tracked or integrity-checked as its
-// own Artifact entry. This is the documented, simpler-than-the-alternative
-// choice over recording a symlink artifact with its target path — see the
-// D15 plan's Wave 1 addendum.
+// collectArtifactsInDir walks a directory and returns an Artifact for each
+// REGULAR file (with checksum + metadata — see artifactFromFile's doc
+// comment) and each SYMLINK (LinkTarget set instead — see Artifact.
+// LinkTarget's doc comment; no checksum or metadata, since a symlink has no
+// independent file content of its own to hash and copyTree/copyFile don't
+// preserve mode/ownership on the link itself in a way worth restoring
+// separately from recreating the link). Any other non-regular, non-symlink
+// entry (socket, FIFO, device) is skipped entirely, matching copyTree's own
+// choice not to stage them.
 func collectArtifactsInDir(category, dir, stagingDir string) ([]Artifact, error) {
 	var artifacts []Artifact
 	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, walkErr error) error {
@@ -75,26 +104,50 @@ func collectArtifactsInDir(category, dir, stagingDir string) ([]Artifact, error)
 		if d.IsDir() {
 			return nil
 		}
+		relPath, relErr := filepath.Rel(stagingDir, path)
+		if relErr != nil {
+			return nil
+		}
+		if d.Type()&os.ModeSymlink != 0 {
+			target, readErr := os.Readlink(path)
+			if readErr != nil {
+				slog.Warn("systemstate: readlink failed, symlink artifact skipped",
+					"path", path, "error", readErr.Error())
+				return nil
+			}
+			artifacts = append(artifacts, Artifact{
+				Name:       filepath.Base(path),
+				Category:   category,
+				Path:       filepath.ToSlash(relPath),
+				LinkTarget: target,
+			})
+			return nil
+		}
 		if !d.Type().IsRegular() {
-			return nil // symlinks and any other non-regular entry — see doc comment above
+			return nil // socket, FIFO, device — see doc comment above
 		}
 		info, err := d.Info()
 		if err != nil {
 			return nil
 		}
-		relPath, _ := filepath.Rel(stagingDir, path)
 		checksum, sumErr := sha256File(path)
 		if sumErr != nil {
 			slog.Warn("systemstate: checksum failed, artifact recorded without one",
 				"path", path, "error", sumErr.Error())
 		}
-		artifacts = append(artifacts, Artifact{
+		art := Artifact{
 			Name:      filepath.Base(path),
 			Category:  category,
 			Path:      filepath.ToSlash(relPath),
 			SizeBytes: info.Size(),
 			Checksum:  checksum,
-		})
+			Mode:      modeFromInfo(info),
+			ModTime:   info.ModTime(),
+		}
+		if uid, gid := uidGidFromInfo(info); uid >= 0 {
+			art.UID, art.GID = uid, gid
+		}
+		artifacts = append(artifacts, art)
 		return nil
 	})
 	return artifacts, err
@@ -143,7 +196,10 @@ func copyFile(src, dst string) error {
 	}
 
 	if _, err := io.Copy(out, in); err != nil {
-		out.Close()
+		// Best-effort cleanup on the failure path: the io.Copy error below is
+		// already the meaningful one to return, and a Close failure here
+		// would just be noise on top of it — discard explicitly.
+		_ = out.Close()
 		return fmt.Errorf("copy %s → %s: %w", src, dst, err)
 	}
 	if err := out.Close(); err != nil {

--- a/agent/internal/backup/systemstate/helpers_unix.go
+++ b/agent/internal/backup/systemstate/helpers_unix.go
@@ -1,0 +1,26 @@
+//go:build !windows
+
+package systemstate
+
+import (
+	"log/slog"
+	"os"
+	"syscall"
+)
+
+// lchownBestEffort applies info's owning uid/gid (as captured by os.Lstat,
+// which does NOT follow symlinks) to path via os.Lchown — Lchown rather than
+// Chown so a copied symlink's own ownership is set, never the ownership of
+// whatever it points at. Best-effort: running unprivileged (no CAP_CHOWN) is
+// a routine, expected way for this to fail — warn and move on rather than
+// failing the whole collection over one file's ownership.
+func lchownBestEffort(path string, info os.FileInfo) {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return
+	}
+	if err := os.Lchown(path, int(stat.Uid), int(stat.Gid)); err != nil {
+		slog.Warn("systemstate: chown failed on staged copy, keeping the collecting process's owner",
+			"path", path, "error", err.Error())
+	}
+}

--- a/agent/internal/backup/systemstate/helpers_unix.go
+++ b/agent/internal/backup/systemstate/helpers_unix.go
@@ -24,3 +24,17 @@ func lchownBestEffort(path string, info os.FileInfo) {
 			"path", path, "error", err.Error())
 	}
 }
+
+// uidGidFromInfo extracts the owning uid/gid from info (as captured by
+// os.Lstat, which does NOT follow symlinks — same source as
+// lchownBestEffort) for Artifact.UID/GID. Returns (-1, -1) if info carries
+// no *syscall.Stat_t (shouldn't happen on a real unix Lstat result, but this
+// mirrors lchownBestEffort's own defensive type assertion); callers treat a
+// negative return as "leave Artifact.UID/GID unset".
+func uidGidFromInfo(info os.FileInfo) (uid, gid int) {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return -1, -1
+	}
+	return int(stat.Uid), int(stat.Gid)
+}

--- a/agent/internal/backup/systemstate/helpers_windows.go
+++ b/agent/internal/backup/systemstate/helpers_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package systemstate
+
+import "os"
+
+// lchownBestEffort is a no-op on Windows: POSIX uid/gid ownership has no
+// direct equivalent there (ACLs are a different model entirely, and out of
+// scope for this best-effort staging copy — Windows system state is
+// collected via reg.exe/other tools that don't go through copyFile/copyTree
+// for anything ownership-sensitive).
+func lchownBestEffort(_ string, _ os.FileInfo) {}

--- a/agent/internal/backup/systemstate/helpers_windows.go
+++ b/agent/internal/backup/systemstate/helpers_windows.go
@@ -10,3 +10,11 @@ import "os"
 // collected via reg.exe/other tools that don't go through copyFile/copyTree
 // for anything ownership-sensitive).
 func lchownBestEffort(_ string, _ os.FileInfo) {}
+
+// uidGidFromInfo always reports "not applicable" on Windows — no POSIX
+// uid/gid concept (see lchownBestEffort's doc comment above). Callers treat
+// a negative return as "leave Artifact.UID/GID unset", which then omits
+// from the manifest JSON.
+func uidGidFromInfo(_ os.FileInfo) (uid, gid int) {
+	return -1, -1
+}

--- a/agent/internal/backup/systemstate/state_windows.go
+++ b/agent/internal/backup/systemstate/state_windows.go
@@ -32,17 +32,28 @@ func NewCollector() Collector {
 	return &WindowsCollector{}
 }
 
-// CollectState gathers all Windows system state artifacts into stagingDir.
-// Individual collection steps log errors but do not abort the entire run.
-func (c *WindowsCollector) CollectState(stagingDir string) (*SystemStateManifest, error) {
-	hostname, _ := os.Hostname()
-	manifest := &SystemStateManifest{
+// newWindowsManifestSkeleton builds the initial SystemStateManifest before
+// any collection step runs. Factored out of CollectState (rather than an
+// inline struct literal there) so a unit test can construct a manifest via
+// this EXACT function — the same one production uses — marshal it, and
+// assert on the serialized shape: if a future edit ever drops the
+// RequiredSteps assignment here, that test fails immediately instead of only
+// a duplicated/inlined assertion elsewhere silently going stale.
+func newWindowsManifestSkeleton(hostname string) *SystemStateManifest {
+	return &SystemStateManifest{
 		Platform:      runtime.GOOS,
 		OSVersion:     windowsVersion(),
 		Hostname:      hostname,
 		CollectedAt:   time.Now().UTC(),
 		RequiredSteps: sortedRequiredSteps(windowsRequiredSteps),
 	}
+}
+
+// CollectState gathers all Windows system state artifacts into stagingDir.
+// Individual collection steps log errors but do not abort the entire run.
+func (c *WindowsCollector) CollectState(stagingDir string) (*SystemStateManifest, error) {
+	hostname, _ := os.Hostname()
+	manifest := newWindowsManifestSkeleton(hostname)
 
 	type step struct {
 		name string

--- a/agent/internal/backup/systemstate/state_windows.go
+++ b/agent/internal/backup/systemstate/state_windows.go
@@ -37,10 +37,11 @@ func NewCollector() Collector {
 func (c *WindowsCollector) CollectState(stagingDir string) (*SystemStateManifest, error) {
 	hostname, _ := os.Hostname()
 	manifest := &SystemStateManifest{
-		Platform:    runtime.GOOS,
-		OSVersion:   windowsVersion(),
-		Hostname:    hostname,
-		CollectedAt: time.Now().UTC(),
+		Platform:      runtime.GOOS,
+		OSVersion:     windowsVersion(),
+		Hostname:      hostname,
+		CollectedAt:   time.Now().UTC(),
+		RequiredSteps: sortedRequiredSteps(windowsRequiredSteps),
 	}
 
 	type step struct {

--- a/agent/internal/backup/systemstate/state_windows_test.go
+++ b/agent/internal/backup/systemstate/state_windows_test.go
@@ -108,6 +108,24 @@ func TestWindowsCollectCertificatesSkipsWhenCertSvcAbsent(t *testing.T) {
 	}
 }
 
+// TestWindowsRequiredStepsSerialized pins that windowsRequiredSteps'
+// membership (registry, boot) is exactly what CollectState serializes onto
+// SystemStateManifest.RequiredSteps — the field a bare-metal-recovery
+// consumer uses to independently enforce the same required-step policy the
+// collector itself enforces via missingRequired.
+func TestWindowsRequiredStepsSerialized(t *testing.T) {
+	got := sortedRequiredSteps(windowsRequiredSteps)
+	want := []string{"boot", "registry"}
+	if len(got) != len(want) {
+		t.Fatalf("sortedRequiredSteps(windowsRequiredSteps) = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("sortedRequiredSteps(windowsRequiredSteps)[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
 func TestWindowsCollectCertificatesFailsWhenCertSvcPresentButCertutilFails(t *testing.T) {
 	origInstalled := certSvcInstalled
 	defer func() { certSvcInstalled = origInstalled }()

--- a/agent/internal/backup/systemstate/state_windows_test.go
+++ b/agent/internal/backup/systemstate/state_windows_test.go
@@ -3,6 +3,7 @@
 package systemstate
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"testing"
@@ -113,15 +114,36 @@ func TestWindowsCollectCertificatesSkipsWhenCertSvcAbsent(t *testing.T) {
 // SystemStateManifest.RequiredSteps — the field a bare-metal-recovery
 // consumer uses to independently enforce the same required-step policy the
 // collector itself enforces via missingRequired.
+//
+// Deliberately does NOT call sortedRequiredSteps directly and check its
+// return value in isolation (the previous, vacuous version of this test) —
+// that only proves sortedRequiredSteps itself works, not that CollectState
+// actually wires the result onto the manifest it serializes. Instead this
+// builds a manifest via newWindowsManifestSkeleton — the EXACT function
+// CollectState calls — and marshals it to JSON, so dropping the
+// RequiredSteps assignment from that function (or a bad json tag on the
+// field) fails this test.
 func TestWindowsRequiredStepsSerialized(t *testing.T) {
-	got := sortedRequiredSteps(windowsRequiredSteps)
+	manifest := newWindowsManifestSkeleton("test-host")
+
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	var decoded struct {
+		RequiredSteps []string `json:"requiredSteps"`
+	}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal serialized manifest: %v", err)
+	}
+
 	want := []string{"boot", "registry"}
-	if len(got) != len(want) {
-		t.Fatalf("sortedRequiredSteps(windowsRequiredSteps) = %v, want %v", got, want)
+	if len(decoded.RequiredSteps) != len(want) {
+		t.Fatalf("serialized requiredSteps = %v, want %v", decoded.RequiredSteps, want)
 	}
 	for i := range want {
-		if got[i] != want[i] {
-			t.Errorf("sortedRequiredSteps(windowsRequiredSteps)[%d] = %q, want %q", i, got[i], want[i])
+		if decoded.RequiredSteps[i] != want[i] {
+			t.Errorf("serialized requiredSteps[%d] = %q, want %q", i, decoded.RequiredSteps[i], want[i])
 		}
 	}
 }

--- a/agent/internal/backup/systemstate/systemstate.go
+++ b/agent/internal/backup/systemstate/systemstate.go
@@ -4,7 +4,12 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"sort"
 )
+
+// manifestSchemaVersion is the current SystemStateManifest shape version —
+// see SystemStateManifest.SchemaVersion's doc comment.
+const manifestSchemaVersion = 1
 
 // CollectSystemState gathers all platform-specific system state artifacts
 // into a temporary staging directory. The caller is responsible for adding
@@ -18,6 +23,9 @@ func CollectSystemState() (manifest *SystemStateManifest, stagingDir string, err
 
 	collector := NewCollector()
 	manifest, err = collector.CollectState(stagingDir)
+	if manifest != nil {
+		manifest.SchemaVersion = manifestSchemaVersion
+	}
 	if err != nil {
 		// Clean up staging dir on failure.
 		if removeErr := os.RemoveAll(stagingDir); removeErr != nil {
@@ -49,6 +57,25 @@ func missingRequired(incomplete []string, required map[string]bool) []string {
 		}
 	}
 	return missing
+}
+
+// sortedRequiredSteps returns the sorted step names required is required==true
+// for, so SystemStateManifest.RequiredSteps has a stable, deterministic order
+// independent of Go's map iteration — callers set manifest.RequiredSteps to
+// this so a consumer (bare-metal recovery) can independently enforce the same
+// required-step policy the collector itself enforces via missingRequired.
+func sortedRequiredSteps(required map[string]bool) []string {
+	if len(required) == 0 {
+		return nil
+	}
+	steps := make([]string, 0, len(required))
+	for name, isRequired := range required {
+		if isRequired {
+			steps = append(steps, name)
+		}
+	}
+	sort.Strings(steps)
+	return steps
 }
 
 // CollectHardwareOnly captures hardware information without performing

--- a/agent/internal/backup/systemstate/systemstate_test.go
+++ b/agent/internal/backup/systemstate/systemstate_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -236,6 +237,100 @@ func TestHelperArtifactFromFile(t *testing.T) {
 	if a.Path != "test.txt" {
 		t.Errorf("path: got %q, want %q", a.Path, "test.txt")
 	}
+	// sha256("hello")
+	wantChecksum := "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+	if a.Checksum != wantChecksum {
+		t.Errorf("checksum: got %q, want %q", a.Checksum, wantChecksum)
+	}
+}
+
+// TestHelperArtifactFromFile_MissingFileOmitsChecksum proves a hashing
+// failure (e.g. the file vanished between stat and hash) degrades to an
+// artifact without a checksum rather than panicking or erroring — matching
+// the "size 0 / best-effort" tolerance the rest of this helper already has.
+func TestHelperArtifactFromFile_MissingFileOmitsChecksum(t *testing.T) {
+	tmpDir := t.TempDir()
+	missing := filepath.Join(tmpDir, "does-not-exist.txt")
+
+	a := artifactFromFile("missing", "test", missing, tmpDir)
+	if a.Checksum != "" {
+		t.Errorf("checksum for an unreadable file should be empty, got %q", a.Checksum)
+	}
+	if a.SizeBytes != 0 {
+		t.Errorf("sizeBytes for an unreadable file should be 0, got %d", a.SizeBytes)
+	}
+}
+
+// TestHelperCollectArtifactsInDir_Checksums proves every artifact walked out
+// of a directory carries a checksum too (not just the single-file helper),
+// so a BMR consumer can verify EVERY artifact, not a subset.
+func TestHelperCollectArtifactsInDir_Checksums(t *testing.T) {
+	tmpDir := t.TempDir()
+	dir := filepath.Join(tmpDir, "dir")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("hello"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	artifacts, err := collectArtifactsInDir("test", dir, tmpDir)
+	if err != nil {
+		t.Fatalf("collectArtifactsInDir: %v", err)
+	}
+	if len(artifacts) != 1 {
+		t.Fatalf("artifacts: got %d, want 1", len(artifacts))
+	}
+	wantChecksum := "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+	if artifacts[0].Checksum != wantChecksum {
+		t.Errorf("checksum: got %q, want %q", artifacts[0].Checksum, wantChecksum)
+	}
+}
+
+func TestCollectSystemState_SchemaVersionSet(t *testing.T) {
+	manifest, stagingDir, err := CollectSystemState()
+	if err != nil {
+		t.Fatalf("CollectSystemState: %v", err)
+	}
+	defer os.RemoveAll(stagingDir)
+
+	if manifest.SchemaVersion != manifestSchemaVersion {
+		t.Errorf("SchemaVersion = %d, want %d", manifest.SchemaVersion, manifestSchemaVersion)
+	}
+}
+
+func TestSortedRequiredSteps(t *testing.T) {
+	tests := []struct {
+		name     string
+		required map[string]bool
+		want     []string
+	}{
+		{"nil map", nil, nil},
+		{"empty map", map[string]bool{}, nil},
+		{
+			"mixed required/not-required, sorted output",
+			map[string]bool{"boot": true, "registry": true, "certs": false},
+			[]string{"boot", "registry"},
+		},
+		{
+			"none required",
+			map[string]bool{"certs": false, "iis": false},
+			nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sortedRequiredSteps(tt.required)
+			if len(got) != len(tt.want) {
+				t.Fatalf("sortedRequiredSteps(%v) = %v, want %v", tt.required, got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Errorf("sortedRequiredSteps(%v)[%d] = %q, want %q", tt.required, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
 }
 
 func TestHelperCopyFile(t *testing.T) {
@@ -280,6 +375,202 @@ func TestHelperCopyTree(t *testing.T) {
 		if _, err := os.Stat(path); err != nil {
 			t.Errorf("missing file: %s", rel)
 		}
+	}
+}
+
+// TestHelperCopyFile_PreservesModeAndMtime pins the W03-review fix: a staged
+// file must keep the SOURCE's permission bits and modification time, not a
+// hardcoded 0600/now(). Without this, restoring staged /etc entries back onto
+// a live system (the Linux restorer's job) would land every file as
+// root:root 0600 regardless of what it was — e.g. /etc/passwd (normally
+// 0644) turning unreadable to non-root processes.
+func TestHelperCopyFile_PreservesModeAndMtime(t *testing.T) {
+	tmpDir := t.TempDir()
+	src := filepath.Join(tmpDir, "src.txt")
+	dst := filepath.Join(tmpDir, "dst.txt")
+
+	if err := os.WriteFile(src, []byte("mode test"), 0o644); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	wantMtime := time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC)
+	if err := os.Chtimes(src, wantMtime, wantMtime); err != nil {
+		t.Fatalf("chtimes src: %v", err)
+	}
+
+	if err := copyFile(src, dst); err != nil {
+		t.Fatalf("copyFile: %v", err)
+	}
+
+	info, err := os.Stat(dst)
+	if err != nil {
+		t.Fatalf("stat dst: %v", err)
+	}
+	if info.Mode().Perm() != 0o644 {
+		t.Errorf("dst mode = %v, want 0644 (source's mode)", info.Mode().Perm())
+	}
+	if !info.ModTime().Equal(wantMtime) {
+		t.Errorf("dst mtime = %v, want %v (source's mtime)", info.ModTime(), wantMtime)
+	}
+}
+
+// TestHelperCopyTree_PreservesDirModeAndMtime is TestHelperCopyFile_
+// PreservesModeAndMtime's directory counterpart: a staged directory must
+// keep the source directory's mode (e.g. 0750), not a hardcoded 0700.
+func TestHelperCopyTree_PreservesDirModeAndMtime(t *testing.T) {
+	srcDir := t.TempDir()
+	dstDir := filepath.Join(t.TempDir(), "copy")
+
+	subDir := filepath.Join(srcDir, "a")
+	if err := os.MkdirAll(subDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subDir, "file1.txt"), []byte("one"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	wantMtime := time.Date(2020, 6, 1, 0, 0, 0, 0, time.UTC)
+	if err := os.Chtimes(subDir, wantMtime, wantMtime); err != nil {
+		t.Fatalf("chtimes subDir: %v", err)
+	}
+
+	if err := copyTree(srcDir, dstDir); err != nil {
+		t.Fatalf("copyTree: %v", err)
+	}
+
+	info, err := os.Stat(filepath.Join(dstDir, "a"))
+	if err != nil {
+		t.Fatalf("stat staged dir: %v", err)
+	}
+	if info.Mode().Perm() != 0o750 {
+		t.Errorf("staged dir mode = %v, want 0750 (source's mode)", info.Mode().Perm())
+	}
+	if !info.ModTime().Equal(wantMtime) {
+		t.Errorf("staged dir mtime = %v, want %v (source's mtime)", info.ModTime(), wantMtime)
+	}
+}
+
+// TestHelperCopyFile_RecreatesSymlink proves a symlink is staged as a real
+// symlink (Lstat + Readlink + Symlink), not dereferenced into a plain-file
+// copy of whatever it currently points at — including a DANGLING link, which
+// must stage successfully rather than erroring.
+func TestHelperCopyFile_RecreatesSymlink(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	target := filepath.Join(tmpDir, "target.txt")
+	if err := os.WriteFile(target, []byte("target contents"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(tmpDir, "link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	dangling := filepath.Join(tmpDir, "dangling")
+	if err := os.Symlink(filepath.Join(tmpDir, "does-not-exist"), dangling); err != nil {
+		t.Fatal(err)
+	}
+
+	dstLink := filepath.Join(tmpDir, "staged", "link")
+	if err := copyFile(link, dstLink); err != nil {
+		t.Fatalf("copyFile(symlink): %v", err)
+	}
+	gotTarget, err := os.Readlink(dstLink)
+	if err != nil {
+		t.Fatalf("staged entry is not a symlink: %v", err)
+	}
+	if gotTarget != target {
+		t.Errorf("staged symlink target = %q, want %q", gotTarget, target)
+	}
+
+	dstDangling := filepath.Join(tmpDir, "staged", "dangling")
+	if err := copyFile(dangling, dstDangling); err != nil {
+		t.Fatalf("copyFile(dangling symlink) should succeed, got: %v", err)
+	}
+	gotDanglingTarget, err := os.Readlink(dstDangling)
+	if err != nil {
+		t.Fatalf("staged dangling entry is not a symlink: %v", err)
+	}
+	if gotDanglingTarget != filepath.Join(tmpDir, "does-not-exist") {
+		t.Errorf("staged dangling symlink target = %q, want %q", gotDanglingTarget, filepath.Join(tmpDir, "does-not-exist"))
+	}
+}
+
+// TestHelperCopyTree_RecreatesSymlinksAndSkipsSpecialFiles exercises the
+// whole-tree walk: a symlink inside the tree is staged as a symlink, and a
+// Unix socket (a stand-in for any of socket/FIFO/device) is skipped rather
+// than staged or erroring the whole walk.
+func TestHelperCopyTree_RecreatesSymlinksAndSkipsSpecialFiles(t *testing.T) {
+	srcDir := t.TempDir()
+	dstDir := filepath.Join(t.TempDir(), "copy")
+
+	if err := os.WriteFile(filepath.Join(srcDir, "real.txt"), []byte("real"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("real.txt", filepath.Join(srcDir, "link.txt")); err != nil {
+		t.Fatal(err)
+	}
+
+	// AF_UNIX socket paths are capped at ~104-108 bytes on macOS/BSD — well
+	// under what t.TempDir()'s nesting can produce — so this uses its own
+	// short-named temp dir rather than srcDir/t.TempDir() directly.
+	sockDir, sockDirErr := os.MkdirTemp("", "bzss")
+	if sockDirErr != nil {
+		t.Fatalf("create short-path temp dir for socket: %v", sockDirErr)
+	}
+	defer os.RemoveAll(sockDir)
+	sockPath := filepath.Join(sockDir, "s")
+	ln, sockErr := net.Listen("unix", sockPath)
+	if sockErr != nil {
+		t.Skipf("cannot create a unix socket in this sandbox, skipping: %v", sockErr)
+	}
+	defer ln.Close()
+	if err := os.Rename(sockPath, filepath.Join(srcDir, "test.sock")); err != nil {
+		t.Fatalf("move socket into srcDir: %v", err)
+	}
+
+	if err := copyTree(srcDir, dstDir); err != nil {
+		t.Fatalf("copyTree: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dstDir, "real.txt")); err != nil {
+		t.Errorf("regular file was not staged: %v", err)
+	}
+	linkTarget, err := os.Readlink(filepath.Join(dstDir, "link.txt"))
+	if err != nil {
+		t.Fatalf("symlink was not staged as a symlink: %v", err)
+	}
+	if linkTarget != "real.txt" {
+		t.Errorf("staged symlink target = %q, want %q", linkTarget, "real.txt")
+	}
+	if _, err := os.Lstat(filepath.Join(dstDir, "test.sock")); err == nil {
+		t.Error("unix socket should have been skipped, not staged")
+	}
+}
+
+// TestHelperCollectArtifactsInDir_SkipsSymlinks pins the documented choice
+// (see collectArtifactsInDir's doc comment): a staged symlink is excluded
+// from the artifact list entirely, rather than checksummed (which would mean
+// silently following it) or recorded with no checksum.
+func TestHelperCollectArtifactsInDir_SkipsSymlinks(t *testing.T) {
+	tmpDir := t.TempDir()
+	dir := filepath.Join(tmpDir, "dir")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "real.txt"), []byte("hello"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("real.txt", filepath.Join(dir, "link.txt")); err != nil {
+		t.Fatal(err)
+	}
+
+	artifacts, err := collectArtifactsInDir("test", dir, tmpDir)
+	if err != nil {
+		t.Fatalf("collectArtifactsInDir: %v", err)
+	}
+	if len(artifacts) != 1 {
+		t.Fatalf("artifacts = %d, want 1 (symlink excluded)", len(artifacts))
+	}
+	if artifacts[0].Name != "real.txt" {
+		t.Errorf("artifact name = %q, want %q", artifacts[0].Name, "real.txt")
 	}
 }
 

--- a/agent/internal/backup/systemstate/systemstate_test.go
+++ b/agent/internal/backup/systemstate/systemstate_test.go
@@ -244,6 +244,87 @@ func TestHelperArtifactFromFile(t *testing.T) {
 	}
 }
 
+// TestHelperArtifactFromFile_PopulatesMetadata pins the D15 Wave 1 fix
+// (finding #6): artifactFromFile must carry mode/uid/gid/modTime, not just
+// name/size/checksum — a BMR restore (Wave 3) needs these to put the
+// restored file back with its original permissions/ownership/mtime, and the
+// only place that metadata is ever recorded is here, at collection time,
+// while the source is known-good.
+func TestHelperArtifactFromFile_PopulatesMetadata(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.txt")
+	if err := os.WriteFile(testFile, []byte("hello"), 0o640); err != nil {
+		t.Fatalf("write test file: %v", err)
+	}
+	wantModTime := time.Date(2020, 3, 4, 5, 6, 7, 0, time.UTC)
+	if err := os.Chtimes(testFile, wantModTime, wantModTime); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	a := artifactFromFile("test_file", "test", testFile, tmpDir)
+
+	if a.Mode&0o777 != 0o640 {
+		t.Errorf("Mode = %#o, want low 9 bits 0640", a.Mode)
+	}
+	if !a.ModTime.Equal(wantModTime) {
+		t.Errorf("ModTime = %v, want %v", a.ModTime, wantModTime)
+	}
+	wantUID, wantGID := currentUIDGID(t)
+	if wantUID >= 0 && a.UID != wantUID {
+		t.Errorf("UID = %d, want %d (current process owner)", a.UID, wantUID)
+	}
+	if wantGID >= 0 && a.GID != wantGID {
+		t.Errorf("GID = %d, want %d (current process group)", a.GID, wantGID)
+	}
+}
+
+// TestArtifact_JSONRoundTrip proves the new metadata fields (LinkTarget,
+// Mode, UID, GID, ModTime) survive a JSON encode/decode cycle unchanged —
+// this is the wire format Wave 2's restorer will consume verbatim.
+func TestArtifact_JSONRoundTrip(t *testing.T) {
+	want := Artifact{
+		Name:      "etc_hostname",
+		Category:  "config",
+		Path:      "etc/hostname",
+		SizeBytes: 12,
+		Checksum:  "abc123",
+		Mode:      0o644,
+		UID:       501,
+		GID:       20,
+		ModTime:   time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC),
+	}
+	data, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got Artifact
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(want, got) {
+		t.Errorf("round-trip mismatch:\n got  %+v\n want %+v", got, want)
+	}
+
+	// A symlink artifact (LinkTarget set, no size/checksum) round-trips too.
+	link := Artifact{
+		Name:       "link_service",
+		Category:   "services",
+		Path:       "services/wants/x.service",
+		LinkTarget: "../x.service",
+	}
+	linkData, err := json.Marshal(link)
+	if err != nil {
+		t.Fatalf("marshal link: %v", err)
+	}
+	var gotLink Artifact
+	if err := json.Unmarshal(linkData, &gotLink); err != nil {
+		t.Fatalf("unmarshal link: %v", err)
+	}
+	if !reflect.DeepEqual(link, gotLink) {
+		t.Errorf("symlink round-trip mismatch:\n got  %+v\n want %+v", gotLink, link)
+	}
+}
+
 // TestHelperArtifactFromFile_MissingFileOmitsChecksum proves a hashing
 // failure (e.g. the file vanished between stat and hash) degrades to an
 // artifact without a checksum rather than panicking or erroring — matching
@@ -292,7 +373,7 @@ func TestCollectSystemState_SchemaVersionSet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CollectSystemState: %v", err)
 	}
-	defer os.RemoveAll(stagingDir)
+	defer func() { _ = os.RemoveAll(stagingDir) }()
 
 	if manifest.SchemaVersion != manifestSchemaVersion {
 		t.Errorf("SchemaVersion = %d, want %d", manifest.SchemaVersion, manifestSchemaVersion)
@@ -448,6 +529,70 @@ func TestHelperCopyTree_PreservesDirModeAndMtime(t *testing.T) {
 	}
 }
 
+// TestHelperCopyTree_NestedRestrictiveDirFixupOrder proves a 0500 (r-x,
+// write-denied but still traversable) parent directory's fixup never blocks
+// a deeper child's own chmod/lchown fixup — i.e. dir fixups are applied in
+// an order that lets every descendant still be reached and fixed up, however
+// restrictive an ancestor's SOURCE mode is. copyTree stages directories at a
+// permissive 0700 DURING the walk specifically so writing children never
+// fails; this test is the other half — the fixup PASS afterward must not
+// re-lock a parent down before its child's own fixup has run.
+func TestHelperCopyTree_NestedRestrictiveDirFixupOrder(t *testing.T) {
+	srcDir := t.TempDir()
+	parent := filepath.Join(srcDir, "parent")
+	child := filepath.Join(parent, "child")
+	if err := os.MkdirAll(child, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(child, "file.txt"), []byte("nested"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Set restrictive/looser modes AFTER writing content, since MkdirAll with
+	// 0o500 partway through would block creating file.txt itself.
+	if err := os.Chmod(child, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(parent, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	// Restore write permission before t.TempDir()'s own cleanup tries to
+	// RemoveAll srcDir — otherwise deleting "child" out of a 0500 "parent"
+	// fails. Registered after the chmod above so it runs first (LIFO).
+	t.Cleanup(func() { _ = os.Chmod(parent, 0o700) })
+
+	dstDir := filepath.Join(t.TempDir(), "copy")
+	stagedParent := filepath.Join(dstDir, "parent")
+	// Same reasoning as srcDir's cleanup above: copyTree replicates the
+	// restrictive mode onto the STAGED parent too, which would otherwise
+	// block this test's own dstDir tempdir cleanup.
+	t.Cleanup(func() { _ = os.Chmod(stagedParent, 0o700) })
+
+	if err := copyTree(srcDir, dstDir); err != nil {
+		t.Fatalf("copyTree: %v", err)
+	}
+
+	stagedChild := filepath.Join(stagedParent, "child")
+	stagedFile := filepath.Join(stagedChild, "file.txt")
+
+	if _, err := os.Stat(stagedFile); err != nil {
+		t.Fatalf("nested file under a restrictive parent was not staged: %v", err)
+	}
+	parentInfo, err := os.Stat(stagedParent)
+	if err != nil {
+		t.Fatalf("stat staged parent: %v", err)
+	}
+	if parentInfo.Mode().Perm() != 0o500 {
+		t.Errorf("staged parent mode = %v, want 0500 (source's mode)", parentInfo.Mode().Perm())
+	}
+	childInfo, err := os.Stat(stagedChild)
+	if err != nil {
+		t.Fatalf("stat staged child: %v", err)
+	}
+	if childInfo.Mode().Perm() != 0o700 {
+		t.Errorf("staged child mode = %v, want 0700 (source's mode) — restrictive parent fixup must not have blocked this", childInfo.Mode().Perm())
+	}
+}
+
 // TestHelperCopyFile_RecreatesSymlink proves a symlink is staged as a real
 // symlink (Lstat + Readlink + Symlink), not dereferenced into a plain-file
 // copy of whatever it currently points at — including a DANGLING link, which
@@ -515,13 +660,13 @@ func TestHelperCopyTree_RecreatesSymlinksAndSkipsSpecialFiles(t *testing.T) {
 	if sockDirErr != nil {
 		t.Fatalf("create short-path temp dir for socket: %v", sockDirErr)
 	}
-	defer os.RemoveAll(sockDir)
+	defer func() { _ = os.RemoveAll(sockDir) }()
 	sockPath := filepath.Join(sockDir, "s")
 	ln, sockErr := net.Listen("unix", sockPath)
 	if sockErr != nil {
 		t.Skipf("cannot create a unix socket in this sandbox, skipping: %v", sockErr)
 	}
-	defer ln.Close()
+	defer func() { _ = ln.Close() }()
 	if err := os.Rename(sockPath, filepath.Join(srcDir, "test.sock")); err != nil {
 		t.Fatalf("move socket into srcDir: %v", err)
 	}
@@ -545,11 +690,13 @@ func TestHelperCopyTree_RecreatesSymlinksAndSkipsSpecialFiles(t *testing.T) {
 	}
 }
 
-// TestHelperCollectArtifactsInDir_SkipsSymlinks pins the documented choice
-// (see collectArtifactsInDir's doc comment): a staged symlink is excluded
-// from the artifact list entirely, rather than checksummed (which would mean
-// silently following it) or recorded with no checksum.
-func TestHelperCollectArtifactsInDir_SkipsSymlinks(t *testing.T) {
+// TestHelperCollectArtifactsInDir_SymlinksEnumeratedWithLinkTarget pins the
+// D15 Wave 1 fix (finding #5): a staged symlink is now enumerated as its own
+// Artifact — LinkTarget set to the link's target, SizeBytes 0, no checksum —
+// rather than excluded outright. Only enumerated artifacts get published
+// (see publishSystemState), so excluding symlinks silently lost every one of
+// them (e.g. /etc/systemd/system/*.wants/*.service).
+func TestHelperCollectArtifactsInDir_SymlinksEnumeratedWithLinkTarget(t *testing.T) {
 	tmpDir := t.TempDir()
 	dir := filepath.Join(tmpDir, "dir")
 	if err := os.MkdirAll(dir, 0o700); err != nil {
@@ -566,11 +713,35 @@ func TestHelperCollectArtifactsInDir_SkipsSymlinks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("collectArtifactsInDir: %v", err)
 	}
-	if len(artifacts) != 1 {
-		t.Fatalf("artifacts = %d, want 1 (symlink excluded)", len(artifacts))
+	if len(artifacts) != 2 {
+		t.Fatalf("artifacts = %d, want 2 (real file + symlink), got %+v", len(artifacts), artifacts)
 	}
-	if artifacts[0].Name != "real.txt" {
-		t.Errorf("artifact name = %q, want %q", artifacts[0].Name, "real.txt")
+	var symlinkArtifact, regularArtifact *Artifact
+	for i := range artifacts {
+		switch artifacts[i].Name {
+		case "link.txt":
+			symlinkArtifact = &artifacts[i]
+		case "real.txt":
+			regularArtifact = &artifacts[i]
+		}
+	}
+	if regularArtifact == nil {
+		t.Fatal("real.txt artifact missing")
+	}
+	if regularArtifact.Checksum == "" {
+		t.Error("regular file artifact should still carry a checksum")
+	}
+	if symlinkArtifact == nil {
+		t.Fatal("link.txt symlink artifact missing")
+	}
+	if symlinkArtifact.LinkTarget != "real.txt" {
+		t.Errorf("symlink LinkTarget = %q, want %q", symlinkArtifact.LinkTarget, "real.txt")
+	}
+	if symlinkArtifact.SizeBytes != 0 {
+		t.Errorf("symlink SizeBytes = %d, want 0", symlinkArtifact.SizeBytes)
+	}
+	if symlinkArtifact.Checksum != "" {
+		t.Errorf("symlink Checksum = %q, want empty (no independent file content)", symlinkArtifact.Checksum)
 	}
 }
 

--- a/agent/internal/backup/systemstate/testutil_unix_test.go
+++ b/agent/internal/backup/systemstate/testutil_unix_test.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package systemstate
+
+import (
+	"os"
+	"testing"
+)
+
+// currentUIDGID returns the current process's uid/gid for test assertions
+// against Artifact.UID/GID — mirrors what uidGidFromInfo extracts from a
+// freshly-written file's os.Lstat result (the file is owned by this process).
+func currentUIDGID(t *testing.T) (uid, gid int) {
+	t.Helper()
+	return os.Getuid(), os.Getgid()
+}

--- a/agent/internal/backup/systemstate/testutil_windows_test.go
+++ b/agent/internal/backup/systemstate/testutil_windows_test.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package systemstate
+
+import "testing"
+
+// currentUIDGID has no meaning on Windows (no POSIX uid/gid) — see
+// uidGidFromInfo's Windows doc comment. -1 tells the caller "don't assert".
+func currentUIDGID(t *testing.T) (uid, gid int) {
+	t.Helper()
+	return -1, -1
+}

--- a/agent/internal/backup/systemstate/types.go
+++ b/agent/internal/backup/systemstate/types.go
@@ -20,6 +20,29 @@ type SystemStateManifest struct {
 	// Empty/omitted means every step succeeded.
 	IncompleteSteps []string         `json:"incompleteSteps,omitempty"`
 	HardwareProfile *HardwareProfile `json:"hardwareProfile,omitempty"`
+
+	// SchemaVersion identifies the shape of this manifest, so a future
+	// consumer-side change can detect and branch on an older manifest
+	// explicitly instead of guessing from field presence. Set to 1 by
+	// CollectSystemState; every manifest this package produces carries it.
+	SchemaVersion int `json:"schemaVersion"`
+
+	// CollectorVersion is the agent/helper version string that produced this
+	// manifest. The systemstate package has no notion of "the agent version"
+	// itself (it collects OS state, not agent identity), so this is left for
+	// the caller to fill in — see backup.BackupConfig.AgentVersion, wired the
+	// same way as BackupConfig.AgentID — before the manifest is persisted or
+	// published. Empty when the caller didn't set one (e.g. an older backup
+	// package build, or a test double).
+	CollectorVersion string `json:"collectorVersion,omitempty"`
+
+	// RequiredSteps names the collection steps this platform's collector
+	// treats as required for a restorable image (see missingRequired) — e.g.
+	// registry and boot on Windows. Serialized so a CONSUMER (bare-metal
+	// recovery) can independently enforce the same policy rather than
+	// trusting only the producer's own collection-time gate. Empty/omitted
+	// when the collecting platform defines no required steps.
+	RequiredSteps []string `json:"requiredSteps,omitempty"`
 }
 
 // Artifact is a single collected system state item.
@@ -28,6 +51,13 @@ type Artifact struct {
 	Category  string `json:"category"` // registry, boot, drivers, certs, services, packages, config
 	Path      string `json:"path"`     // path within staging dir
 	SizeBytes int64  `json:"sizeBytes"`
+	// Checksum is the lowercase-hex SHA-256 of the artifact file, computed at
+	// collection time (see artifactFromFile / collectArtifactsInDir). A
+	// consumer downloading this artifact from remote storage verifies its
+	// bytes against this value before applying it — the same integrity
+	// contract backup.SnapshotFile.Checksum gives ordinary backed-up files.
+	// Empty/omitted only if hashing failed at collection time.
+	Checksum string `json:"checksum,omitempty"`
 }
 
 // HardwareProfile captures machine hardware for recovery planning.

--- a/agent/internal/backup/systemstate/types.go
+++ b/agent/internal/backup/systemstate/types.go
@@ -56,8 +56,47 @@ type Artifact struct {
 	// consumer downloading this artifact from remote storage verifies its
 	// bytes against this value before applying it — the same integrity
 	// contract backup.SnapshotFile.Checksum gives ordinary backed-up files.
-	// Empty/omitted only if hashing failed at collection time.
+	// Empty/omitted only if hashing failed at collection time, or if this
+	// artifact is a symlink (see LinkTarget) — a symlink has no independent
+	// file content to hash.
 	Checksum string `json:"checksum,omitempty"`
+
+	// LinkTarget is set when this artifact is a symlink rather than a
+	// regular file — the readlink(2) target, recorded exactly as staged
+	// (absolute or relative, whichever the source symlink used; never
+	// resolved). When set, SizeBytes is 0 and Checksum is empty, and the
+	// publisher does NOT upload any bytes for this artifact (see
+	// publishSystemState) — the manifest entry alone is enough for a
+	// consumer to recreate the link. Symlinks used to be excluded from the
+	// artifact list entirely (see collectArtifactsInDir), which silently
+	// lost every one collected (e.g. /etc/systemd/system/*.wants/*.service).
+	LinkTarget string `json:"linkTarget,omitempty"`
+
+	// Mode carries the artifact's permission bits at collection time: the
+	// low 9 bits (rwxrwxrwx, i.e. os.FileMode.Perm()) OR'd with the
+	// setuid/setgid/sticky bits translated into their traditional octal
+	// positions (04000/02000/01000 respectively) — i.e. equivalent to a
+	// POSIX stat's st_mode & 07777. A BMR restore (Wave 3) chmods the
+	// restored file to this value. Zero/omitted on Windows (no POSIX
+	// permission bits — Windows collection sets Mode via the same helper,
+	// which just yields the low bits Go's os.FileMode reports there) or on
+	// an artifact that predates this field.
+	Mode uint32 `json:"mode,omitempty"`
+	// UID is the artifact's owning user id at collection time, from
+	// os.Lstat (never resolved from a symlink's target — see
+	// uidGidFromInfo). Omitted (left at the zero value) on Windows, which
+	// has no POSIX uid, or if the artifact predates this field. NOTE:
+	// omitempty means a genuine uid 0 (root-owned file) also omits — the
+	// same accepted tradeoff SnapshotFile.Mode's sibling fields make
+	// elsewhere in this codebase; a consumer restoring uid unconditionally
+	// (e.g. always chown, defaulting to 0) is unaffected either way.
+	UID int `json:"uid,omitempty"`
+	// GID is the artifact's owning group id at collection time — see UID.
+	GID int `json:"gid,omitempty"`
+	// ModTime is the artifact's modification time at collection time, so a
+	// BMR restore can set it back on the restored file. Zero/omitted if
+	// unavailable or the artifact predates this field.
+	ModTime time.Time `json:"modTime,omitempty"`
 }
 
 // HardwareProfile captures machine hardware for recovery planning.

--- a/agent/internal/backup/vss_shadow_path_windows_test.go
+++ b/agent/internal/backup/vss_shadow_path_windows_test.go
@@ -317,34 +317,15 @@ func TestRewritePathsForVSS_LeavesSystemStateStagingDirUnrewritten(t *testing.T)
 	}
 }
 
-// TestRewritePathsForVSS_StagingDirStaysMatchableByMarkSystemStateFiles encodes
-// the downstream symptom of #3026 rather than only the rewrite itself.
-//
-// RunBackupContext passes the walked staging root to markSystemStateFiles,
-// which prefix-matches it against each collected file's sourcePath. Files under
-// the staging dir only ever exist on the live volume, so a shadow-rewritten
-// root matched zero of them — SystemStateManifest was set on a snapshot that
-// carried none of the artifacts it described. Leaving the index unrewritten is
-// what keeps the two ends of that comparison on the same volume.
-func TestRewritePathsForVSS_StagingDirStaysMatchableByMarkSystemStateFiles(t *testing.T) {
-	const shadowRoot = `\\?\GLOBALROOT\Device\HarddiskVolumeShadowCopy1`
-	const staging = `C:\Windows\Temp\breeze-systemstate-1234`
-	shadowPaths := map[string]string{"C:": shadowRoot}
-
-	rewritten, _ := rewritePathsForVSS([]string{`C:\Users\data`, staging}, shadowPaths, 1)
-	walkedStagingRoot := rewritten[1]
-
-	// The artifact as it exists on disk — collectSystemState wrote it to the
-	// live volume moments ago, after the snapshot was already taken.
-	files := []backupFile{{sourcePath: filepath.Join(staging, "registry", "SOFTWARE.hiv")}}
-	markSystemStateFiles(files, walkedStagingRoot)
-
-	if !files[0].systemState {
-		t.Fatalf("system-state artifact %q was not matched against walked staging root %q — "+
-			"the manifest would be recorded with the artifacts missing (#3026)",
-			files[0].sourcePath, walkedStagingRoot)
-	}
-}
+// NOTE: TestRewritePathsForVSS_StagingDirStaysMatchableByMarkSystemStateFiles
+// used to live here, pinning that a shadow-rewritten staging root still
+// prefix-matched markSystemStateFiles. Both markSystemStateFiles and the
+// backupPaths-append it depended on were removed in Wave 1 of the D15
+// bare-metal-recovery contract (see incremental.go's NOTE) — system-state
+// artifacts are no longer part of the ordinary file walk at all, so there is
+// nothing for this rewrite to protect on their behalf anymore. rewritePathsForVSS
+// itself is untouched (see the tests above and below, which still exercise it
+// directly for ordinary VSS-rewritten paths).
 
 // The exclusion must not trade silent data loss for a warning that fires on
 // every system_image backup. The staging dir is genuinely a live read, so

--- a/apps/api/src/jobs/backupRetention.test.ts
+++ b/apps/api/src/jobs/backupRetention.test.ts
@@ -82,6 +82,7 @@ const {
   normalizeStorageIdentity,
   BACKUP_GC_GRACE_MS,
   BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS,
+  isRetainableBackupTypeForGc,
 } = await import('./backupRetention');
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -790,20 +791,41 @@ describe('sweepUnreferencedBackupObjects', () => {
     });
   });
 
+  // D15 Wave 1 finding #3: retainedSnapshotIds' backupType allowlist must
+  // include system_image (it now shares the ordinary snapshots/<id>/
+  // manifest.json layout, per backup.go's Option A publish paths) while
+  // still excluding backupTypes that write their manifest elsewhere
+  // (hyperv's 'application', mssql's 'database') — including one of THOSE
+  // would 404 markLiveBackupObjects's unconditional ordinary-manifest fetch
+  // and fail-close the whole identity, exactly the FIX 6 regression below.
+  describe('isRetainableBackupTypeForGc', () => {
+    it.each([
+      ['file', true],
+      ['system_image', true],
+      [null, true], // legacy rows predating the backupType column
+      ['application', false], // hyperv — different manifest namespace
+      ['database', false], // mssql — different manifest namespace
+    ] as const)('backupType %s → %s', (backupType, want) => {
+      expect(isRetainableBackupTypeForGc(backupType)).toBe(want);
+    });
+  });
+
   // FIX 6 — the mark phase only fetches snapshots/<id>/manifest.json for
-  // FILE-type snapshots. A non-file snapshot (system_image / hyperv / mssql)
+  // backupTypes in BACKUP_GC_RETAINED_MANIFEST_BACKUP_TYPES (plus NULL). A
+  // snapshot of some OTHER type (hyperv's 'application' / mssql's 'database')
   // sharing a storage identity writes its manifest to a DIFFERENT key and
   // never appears under snapshots/<id>/manifest.json, so including it in the
   // retained set used to 404 the fetch and fail-close the WHOLE identity
-  // forever. The retained-rows query now filters to backupType file / NULL.
+  // forever. The retained-rows query filters to that allowlist (plus NULL).
   describe('non-file snapshots no longer wedge the file-backup sweep (FIX 6)', () => {
-    it('does not fail-close the identity when a non-file snapshot shares the bucket', async () => {
-      // The retained-rows query (filtered to file-type in SQL) returns only the
-      // FILE snapshot; the system_image snapshot's row is excluded and so its
-      // non-existent snapshots/IMG1/manifest.json is never fetched. (The SQL
-      // WHERE clause itself is exercised by the integration suite — the mocked
-      // query builder here can't filter, so we assert the downstream behavior
-      // the filter produces: only the file manifest is fetched, no fail-close.)
+    it('does not fail-close the identity when a non-file, non-system_image snapshot shares the bucket', async () => {
+      // The retained-rows query (filtered in SQL) returns only the
+      // FILE snapshot; a hyperv (backupType 'application') snapshot's row is
+      // excluded and so its non-existent snapshots/HYPERV1/manifest.json is
+      // never fetched. (The SQL WHERE clause itself is exercised by the
+      // integration suite — the mocked query builder here can't filter, so
+      // we assert the downstream behavior the filter produces: only the file
+      // manifest is fetched, no fail-close.)
       selectQueue.push([]); // unattributedRows
       selectQueue.push([destination]); // destinations
       selectQueue.push([{ snapshotId: 'FILE1' }]); // retained FILE-type snapshots ONLY (non-file filtered out)
@@ -819,8 +841,8 @@ describe('sweepUnreferencedBackupObjects', () => {
 
       // Only FILE1's manifests are fetched (ordinary + D15's system-state
       // probe, which falls through to "not found" since this fixture has
-      // none); the system_image snapshot's keys are never touched at all, so
-      // the identity is NOT blocked.
+      // none); the hyperv snapshot's keys are never touched at all, so the
+      // identity is NOT blocked.
       expect(fetchBackupObjectTextMock).toHaveBeenCalledTimes(2);
       expect(fetchBackupObjectTextMock).toHaveBeenCalledWith(
         expect.objectContaining({ key: 'snapshots/FILE1/manifest.json' }),
@@ -829,10 +851,10 @@ describe('sweepUnreferencedBackupObjects', () => {
         expect.objectContaining({ key: 'snapshots/FILE1/system-state/manifest.json' }),
       );
       expect(fetchBackupObjectTextMock).not.toHaveBeenCalledWith(
-        expect.objectContaining({ key: 'snapshots/IMG1/manifest.json' }),
+        expect.objectContaining({ key: 'snapshots/HYPERV1/manifest.json' }),
       );
       expect(fetchBackupObjectTextMock).not.toHaveBeenCalledWith(
-        expect.objectContaining({ key: 'snapshots/IMG1/system-state/manifest.json' }),
+        expect.objectContaining({ key: 'snapshots/HYPERV1/system-state/manifest.json' }),
       );
       expect(result).toEqual({ deleted: 0, skippedIdentities: 0, blockedIdentities: 0 });
       expect(captureExceptionMock).not.toHaveBeenCalled();
@@ -1071,6 +1093,54 @@ describe('sweepUnreferencedBackupObjects', () => {
       // A non-"not found" fetch failure cannot prove liveness one way or the
       // other, so the WHOLE identity is fail-closed — same contract as an
       // unfetchable ordinary manifest.
+      expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled();
+      expect(result).toEqual({ deleted: 0, skippedIdentities: 1, blockedIdentities: 1 });
+      expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+    });
+
+    // D15 Wave 1 finding #3: a retained system_image row used to be excluded
+    // from retainedSnapshotIds outright (see the FIX 6 describe block above,
+    // now updated to use an 'application'/'database' example instead), so its
+    // system-state/* objects had NO db-side protection at all — only the
+    // listing's own manifest.json presence decided their fate. Now that
+    // system_image rows are included, this proves a retained system_image
+    // snapshot's system-state prefix is NOT deleted even in the (defensive,
+    // not routine — see the publish-ordering fix in backup.go) case where the
+    // ordinary snapshots/<id>/manifest.json object itself is missing from the
+    // bucket, with its system-state objects older than the manifest-less
+    // prefix's max-age window (which would otherwise sweep them at PREFIX
+    // granularity on age alone).
+    it('protects a retained system_image snapshot whose ordinary manifest object is absent from the bucket', async () => {
+      selectQueue.push([]); // unattributedRows
+      selectQueue.push([destination]); // destinations
+      // Post-fix: the retained-rows query includes system_image (not just
+      // file/null) — IMG1 here stands in for that DB row.
+      selectQueue.push([{ snapshotId: 'IMG1' }]);
+
+      // IMG1's ordinary manifest is genuinely absent from the bucket — the
+      // mock's base implementation (module-level default) already rejects
+      // any unconfigured key as "not found", so no explicit queuing is
+      // needed here to model that; this test asserts the CONSEQUENCE.
+
+      const old = EVEN_FURTHER_PAST_MANIFESTLESS_THRESHOLD();
+      listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
+        // No snapshots/IMG1/manifest.json entry at all — group.manifestItem
+        // is null, so this group is classified manifest-less (protected at
+        // PREFIX granularity by age alone) UNLESS the retained-row lookup
+        // changes the outcome.
+        { key: 'snapshots/IMG1/system-state/manifest.json', lastModified: old },
+        { key: 'snapshots/IMG1/system-state/registry/SYSTEM', lastModified: old },
+      ]);
+
+      const result = await sweepUnreferencedBackupObjects();
+
+      // markLiveBackupObjects has no not-found tolerance on the ORDINARY
+      // manifest fetch (only the system-state fetch does) — a retained
+      // snapshot whose ordinary manifest can't be fetched fails the WHOLE
+      // identity closed, exactly like the pre-existing "still fail-closes...
+      // when a genuine FILE manifest is unfetchable" contract above. That is
+      // a STRONGER guarantee than per-group protection: nothing in the
+      // identity deletes this run, so IMG1's system-state objects survive.
       expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled();
       expect(result).toEqual({ deleted: 0, skippedIdentities: 1, blockedIdentities: 1 });
       expect(captureExceptionMock).toHaveBeenCalledTimes(1);

--- a/apps/api/src/jobs/backupRetention.test.ts
+++ b/apps/api/src/jobs/backupRetention.test.ts
@@ -33,7 +33,29 @@ const mockDb = {
 
 vi.mock('../db', () => ({ db: mockDb }));
 
-const fetchBackupObjectTextMock = vi.fn();
+// notFoundError mirrors what isBackupObjectNotFound (backupSnapshotStorage.ts)
+// recognizes as "object absent" (S3's NoSuchKey / local's ENOENT) — used
+// below as fetchBackupObjectTextMock's DEFAULT (base) implementation.
+function notFoundError(): Error {
+  return Object.assign(new Error('not found'), { name: 'NoSuchKey' });
+}
+
+// fetchBackupObjectTextMock's base implementation always rejects "not found".
+// markLiveBackupObjects now fetches TWO keys per snapshot — the ordinary
+// manifest, then (D15) the system-state manifest — and the vast majority of
+// tests in this file only care about the ordinary one. vi.fn()'s queued
+// `.mockResolvedValueOnce`/`.mockRejectedValueOnce` calls are consumed
+// strictly in CALL order regardless of the key argument, so as long as each
+// test queues exactly one entry per snapshot's ORDINARY manifest fetch (the
+// existing, unchanged convention), the interleaved system-state fetch calls
+// fall through to this base implementation and resolve as "no system state
+// for this snapshot" — the routine, expected case for a file-mode snapshot —
+// without every pre-existing test needing to queue a second entry. Tests that
+// DO care about system-state behavior override this per-call via
+// `mockImplementation`/explicit `.Once` queuing, same as any other vi.fn().
+const fetchBackupObjectTextMock = vi.fn(async () => {
+  throw notFoundError();
+});
 const listBackupObjectsUnderPrefixMock = vi.fn();
 const deleteBackupObjectKeysMock = vi.fn();
 
@@ -594,9 +616,20 @@ describe('sweepUnreferencedBackupObjects', () => {
       // different config's snapshot, same bucket) references an object that
       // physically lives under A's prefix — the cross-config reference the
       // identity-scoped mark protects.
-      fetchBackupObjectTextMock
-        .mockResolvedValueOnce(manifestJson([])) // manifest for A
-        .mockResolvedValueOnce(manifestJson([{ backupPath: 'snapshots/A/files/shared.dat' }])); // manifest for B
+      //
+      // Dispatched by key (not a positional .mockResolvedValueOnce chain):
+      // markLiveBackupObjects now fetches TWO keys per snapshot (ordinary +
+      // D15's system-state probe), which would otherwise misalign a
+      // positional queue across multiple snapshots — see the failure this
+      // fixture originally hit before switching to key dispatch.
+      fetchBackupObjectTextMock.mockImplementation(async (input: { key: string }) => {
+        if (input.key === 'snapshots/A/manifest.json') return manifestJson([]);
+        if (input.key === 'snapshots/B/manifest.json') {
+          return manifestJson([{ backupPath: 'snapshots/A/files/shared.dat' }]);
+        }
+        if (input.key.endsWith('/system-state/manifest.json')) throw notFoundError();
+        throw new Error(`unexpected manifest fetch: ${input.key}`);
+      });
 
       const old = new Date(Date.now() - 10 * DAY_MS);
       listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
@@ -667,9 +700,12 @@ describe('sweepUnreferencedBackupObjects', () => {
     selectQueue.push([destination]); // destinations
     selectQueue.push([]); // retained snapshots for the identity — NONE (row never persisted)
 
-    // Only ONE manifest fetch expected: snapshot NEW is picked up purely from
-    // the listing (not from a retained row), and NEW is the only snapshot in
-    // this bucket at all.
+    // ONE ordinary-manifest fetch expected: snapshot NEW is picked up purely
+    // from the listing (not from a retained row), and NEW is the only
+    // snapshot in this bucket at all. markLiveBackupObjects also probes for a
+    // system-state manifest per snapshot (D15) — that second call falls
+    // through to fetchBackupObjectTextMock's default "not found" (this
+    // snapshot has none), so it isn't queued here.
     fetchBackupObjectTextMock.mockResolvedValueOnce(
       manifestJson([{ backupPath: 'snapshots/OLD/files/base.dat' }]),
     );
@@ -683,9 +719,12 @@ describe('sweepUnreferencedBackupObjects', () => {
 
     const result = await sweepUnreferencedBackupObjects();
 
-    expect(fetchBackupObjectTextMock).toHaveBeenCalledTimes(1);
+    expect(fetchBackupObjectTextMock).toHaveBeenCalledTimes(2);
     expect(fetchBackupObjectTextMock).toHaveBeenCalledWith(
       expect.objectContaining({ key: 'snapshots/NEW/manifest.json' }),
+    );
+    expect(fetchBackupObjectTextMock).toHaveBeenCalledWith(
+      expect.objectContaining({ key: 'snapshots/NEW/system-state/manifest.json' }),
     );
     expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled();
     expect(result).toEqual({ deleted: 0, skippedIdentities: 0, blockedIdentities: 0 });
@@ -720,6 +759,11 @@ describe('sweepUnreferencedBackupObjects', () => {
         if (input.key === 'snapshots/OLDER/manifest.json') {
           return manifestJson([{ backupPath: 'snapshots/BASE/files/base.dat' }]);
         }
+        // Neither snapshot has system state — this test predates D15 and
+        // isn't about it. markLiveBackupObjects probes for it unconditionally
+        // per snapshot, so it must resolve as "absent" (routine case), not an
+        // unexpected-key failure.
+        if (input.key.endsWith('/system-state/manifest.json')) throw notFoundError();
         throw new Error(`unexpected manifest fetch: ${input.key}`);
       });
 
@@ -771,14 +815,22 @@ describe('sweepUnreferencedBackupObjects', () => {
 
       const result = await sweepUnreferencedBackupObjects();
 
-      // Only the file manifest is fetched; the system_image manifest key is
-      // never touched, so the identity is NOT blocked.
-      expect(fetchBackupObjectTextMock).toHaveBeenCalledTimes(1);
+      // Only FILE1's manifests are fetched (ordinary + D15's system-state
+      // probe, which falls through to "not found" since this fixture has
+      // none); the system_image snapshot's keys are never touched at all, so
+      // the identity is NOT blocked.
+      expect(fetchBackupObjectTextMock).toHaveBeenCalledTimes(2);
       expect(fetchBackupObjectTextMock).toHaveBeenCalledWith(
         expect.objectContaining({ key: 'snapshots/FILE1/manifest.json' }),
       );
+      expect(fetchBackupObjectTextMock).toHaveBeenCalledWith(
+        expect.objectContaining({ key: 'snapshots/FILE1/system-state/manifest.json' }),
+      );
       expect(fetchBackupObjectTextMock).not.toHaveBeenCalledWith(
         expect.objectContaining({ key: 'snapshots/IMG1/manifest.json' }),
+      );
+      expect(fetchBackupObjectTextMock).not.toHaveBeenCalledWith(
+        expect.objectContaining({ key: 'snapshots/IMG1/system-state/manifest.json' }),
       );
       expect(result).toEqual({ deleted: 0, skippedIdentities: 0, blockedIdentities: 0 });
       expect(captureExceptionMock).not.toHaveBeenCalled();
@@ -924,6 +976,102 @@ describe('sweepUnreferencedBackupObjects', () => {
     it('sweeps a manifest-less prefix whose newest object is 1ms past the 9-day threshold', async () => {
       const result = await sweepManifestlessPrefixAtNewestAge(BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS + 1);
       expect(result.deleted).toBe(1);
+    });
+  });
+
+  // D15 bare-metal-recovery contract (Option A): a system_image snapshot
+  // publishes system-state/manifest.json + system-state/<artifact.path>
+  // alongside (or instead of) the ordinary manifest.files[] — see
+  // docs/superpowers/plans/backup/2026-09-09-bmr-system-state-contract.md.
+  // markLiveBackupObjects must mark those objects live too, or GC deletes
+  // every system_image snapshot's bare-metal-recovery state 48h after upload.
+  describe('D15 system-state GC (Option A)', () => {
+    it('keeps system-state objects live when referenced by system-state/manifest.json', async () => {
+      selectQueue.push([]); // unattributedRows
+      selectQueue.push([destination]); // destinations
+      selectQueue.push([{ snapshotId: 'B' }]); // retained
+
+      fetchBackupObjectTextMock.mockImplementation(async (input: { key: string }) => {
+        if (input.key === 'snapshots/B/manifest.json') return manifestJson([]);
+        if (input.key === 'snapshots/B/system-state/manifest.json') {
+          return JSON.stringify({ artifacts: [{ path: 'registry/SYSTEM' }, { path: 'boot/grub.cfg' }] });
+        }
+        throw new Error(`unexpected manifest fetch: ${input.key}`);
+      });
+
+      const old = JUST_PAST_MANIFESTLESS_THRESHOLD();
+      listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
+        { key: 'snapshots/B/manifest.json', lastModified: old },
+        { key: 'snapshots/B/system-state/manifest.json', lastModified: old },
+        // Both old enough to sweep on age alone if NOT marked live by the
+        // system-state manifest's artifacts[] — the thing under test.
+        { key: 'snapshots/B/system-state/registry/SYSTEM', lastModified: old },
+        { key: 'snapshots/B/system-state/boot/grub.cfg', lastModified: old },
+      ]);
+
+      const result = await sweepUnreferencedBackupObjects();
+
+      expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled();
+      expect(result).toEqual({ deleted: 0, skippedIdentities: 0, blockedIdentities: 0 });
+    });
+
+    it('deletes system-state objects under an expired/unretained snapshot the same way ordinary file objects are', async () => {
+      // Snapshot B is retained and references nothing; snapshot EXPIRED is
+      // NOT retained and not in the listing's manifest set either (it has
+      // aged out / its row is gone) — both its ordinary-shaped loose object
+      // and its system-state artifact are old, unreferenced, manifest-less,
+      // and past the 9-day manifest-less-prefix window, so BOTH must sweep.
+      selectQueue.push([]); // unattributedRows
+      selectQueue.push([destination]); // destinations
+      selectQueue.push([{ snapshotId: 'B' }]); // retained
+
+      fetchBackupObjectTextMock.mockResolvedValueOnce(manifestJson([])); // B's ordinary manifest; B has no system-state manifest (falls through to "not found")
+
+      const old = JUST_PAST_MANIFESTLESS_THRESHOLD();
+      listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
+        { key: 'snapshots/B/manifest.json', lastModified: old },
+        { key: 'snapshots/EXPIRED/system-state/registry/SYSTEM', lastModified: old },
+      ]);
+
+      deleteBackupObjectKeysMock.mockResolvedValueOnce({
+        deletedKeys: ['snapshots/EXPIRED/system-state/registry/SYSTEM'],
+        failedKeys: [],
+      });
+
+      const result = await sweepUnreferencedBackupObjects();
+
+      const deletedArg = deleteBackupObjectKeysMock.mock.calls[0]![0] as { keys: string[] };
+      expect(deletedArg.keys).toEqual(['snapshots/EXPIRED/system-state/registry/SYSTEM']);
+      expect(result.deleted).toBe(1);
+    });
+
+    it('does NOT sweep the group when the system-state manifest fetch fails with a non-404 error (fail-closed)', async () => {
+      selectQueue.push([]); // unattributedRows
+      selectQueue.push([destination]); // destinations
+      selectQueue.push([{ snapshotId: 'B' }]); // retained
+
+      fetchBackupObjectTextMock.mockImplementation(async (input: { key: string }) => {
+        if (input.key === 'snapshots/B/manifest.json') return manifestJson([]);
+        if (input.key === 'snapshots/B/system-state/manifest.json') {
+          throw new Error('S3 500 fetching system state manifest');
+        }
+        throw new Error(`unexpected manifest fetch: ${input.key}`);
+      });
+
+      const old = JUST_PAST_MANIFESTLESS_THRESHOLD();
+      listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
+        { key: 'snapshots/B/manifest.json', lastModified: old },
+        { key: 'snapshots/B/system-state/registry/SYSTEM', lastModified: old }, // would be deletable if the abort didn't protect it
+      ]);
+
+      const result = await sweepUnreferencedBackupObjects();
+
+      // A non-"not found" fetch failure cannot prove liveness one way or the
+      // other, so the WHOLE identity is fail-closed — same contract as an
+      // unfetchable ordinary manifest.
+      expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled();
+      expect(result).toEqual({ deleted: 0, skippedIdentities: 1, blockedIdentities: 1 });
+      expect(captureExceptionMock).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/apps/api/src/jobs/backupRetention.test.ts
+++ b/apps/api/src/jobs/backupRetention.test.ts
@@ -53,7 +53,9 @@ function notFoundError(): Error {
 // without every pre-existing test needing to queue a second entry. Tests that
 // DO care about system-state behavior override this per-call via
 // `mockImplementation`/explicit `.Once` queuing, same as any other vi.fn().
-const fetchBackupObjectTextMock = vi.fn(async () => {
+const fetchBackupObjectTextMock = vi.fn<
+  (input: { provider: string | null | undefined; providerConfig: unknown; key: string }) => Promise<string>
+>(async () => {
   throw notFoundError();
 });
 const listBackupObjectsUnderPrefixMock = vi.fn();

--- a/apps/api/src/jobs/backupRetention.ts
+++ b/apps/api/src/jobs/backupRetention.ts
@@ -21,8 +21,11 @@ import {
   BACKUP_SNAPSHOT_MANIFEST_KEY,
   backupSnapshotManifestKey,
   backupSnapshotRootPrefix,
+  backupSystemStateArtifactKey,
+  backupSystemStateManifestKey,
   deleteBackupObjectKeys,
   fetchBackupObjectText,
+  isBackupObjectNotFound,
   listBackupObjectsUnderPrefix,
   type BackupObjectListing,
 } from '../services/backupSnapshotStorage';
@@ -559,6 +562,25 @@ export type BackupGcResult = { deleted: number; skippedIdentities: number; block
 
 type BackupGcManifest = { files?: Array<{ backupPath?: unknown }> };
 
+// D15 bare-metal-recovery contract (Option A): a system_image snapshot
+// publishes a SEPARATE manifest under system-state/manifest.json, describing
+// artifacts under system-state/<artifact.path> — never inside the ordinary
+// manifest's `files[]`. Mirrors agent/internal/backup/systemstate/types.go's
+// SystemStateManifest/Artifact shape (only the field GC needs: path).
+type BackupGcSystemStateManifest = { artifacts?: Array<{ path?: unknown }> };
+
+function parseBackupGcSystemStateManifest(raw: string): BackupGcSystemStateManifest {
+  const parsed: unknown = JSON.parse(raw);
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('system state manifest is not a JSON object');
+  }
+  const artifacts = (parsed as { artifacts?: unknown }).artifacts;
+  if (artifacts !== undefined && !Array.isArray(artifacts)) {
+    throw new Error('system state manifest.artifacts is not an array');
+  }
+  return parsed as BackupGcSystemStateManifest;
+}
+
 /**
  * Resolves the per-run deletion cap from env on every call (not once at
  * module load) so it stays test-overridable without module-reset gymnastics.
@@ -853,6 +875,55 @@ async function markLiveBackupObjects(
     for (const file of manifest.files ?? []) {
       if (typeof file.backupPath === 'string' && file.backupPath.length > 0) {
         live.add(file.backupPath);
+      }
+    }
+
+    // D15 bare-metal-recovery contract (Option A): system-state artifacts
+    // live under their own manifest/prefix, never inside manifest.files[]
+    // above — so without this, GC would sweep them 48h after ANY
+    // system_image snapshot, live regression, not hypothetical (see the plan
+    // doc referenced on backupSystemStateManifestKey). Absence is the
+    // ROUTINE case for a file-mode snapshot (no system state ever
+    // collected) — isBackupObjectNotFound distinguishes that from "the fetch
+    // failed for some other reason", which must still fail-closed (abort
+    // this identity's whole sweep) the same as an ordinary-manifest fetch
+    // failure: an unproven system-state manifest must never be inferred as
+    // "doesn't exist" — that would open the door to sweeping objects a
+    // transient error only made unreachable, not orphaned.
+    const stateManifestKey = backupSystemStateManifestKey(snapshotId);
+    let stateRaw: string;
+    try {
+      stateRaw = await fetchBackupObjectText({
+        provider: identity.provider,
+        providerConfig: identity.providerConfig,
+        key: stateManifestKey,
+      });
+    } catch (error) {
+      if (isBackupObjectNotFound(error)) continue;
+      console.error(
+        `[BackupGC] System state manifest fetch failed for snapshot ${snapshotId} (key ${stateManifestKey}) — ` +
+        `aborting sweep for this identity:`,
+        error,
+      );
+      return null;
+    }
+
+    let stateManifest: BackupGcSystemStateManifest;
+    try {
+      stateManifest = parseBackupGcSystemStateManifest(stateRaw);
+    } catch (error) {
+      console.error(
+        `[BackupGC] System state manifest parse failed for snapshot ${snapshotId} (key ${stateManifestKey}) — ` +
+        `aborting sweep for this identity:`,
+        error,
+      );
+      return null;
+    }
+
+    live.add(stateManifestKey);
+    for (const artifact of stateManifest.artifacts ?? []) {
+      if (typeof artifact.path === 'string' && artifact.path.length > 0) {
+        live.add(backupSystemStateArtifactKey(snapshotId, artifact.path));
       }
     }
   }

--- a/apps/api/src/jobs/backupRetention.ts
+++ b/apps/api/src/jobs/backupRetention.ts
@@ -560,6 +560,54 @@ const BACKUP_GC_SUPPORTED_PROVIDERS = new Set(['s3', 'local']);
 //     distinctly rather than letting it hide inside skippedIdentities.
 export type BackupGcResult = { deleted: number; skippedIdentities: number; blockedIdentities: number };
 
+/**
+ * backupType values whose manifest lives under the shared
+ * snapshots/<id>/manifest.json namespace the mark phase (markLiveBackupObjects)
+ * understands. Only these — plus a NULL backupType (legacy rows predating the
+ * column's 'file' default) — may safely appear in retainedSnapshotIds:
+ * markLiveBackupObjects's ordinary-manifest fetch is UNCONDITIONAL and has no
+ * not-found tolerance, so a retained row whose type writes its manifest
+ * elsewhere would 404 and fail-close the WHOLE identity (see FIX 6 below).
+ *
+ * 'system_image' was excluded here too until D15 Wave 1 gave it the SAME
+ * snapshots/<id>/manifest.json + system-state/ layout (Option A — see
+ * docs/superpowers/plans/backup/2026-09-09-bmr-system-state-contract.md):
+ * backup.go's state-only AND mixed-run publish paths now both publish a
+ * (possibly empty-files) ordinary manifest.json for EVERY system_image run,
+ * specifically so the snapshot-id group stays "manifest-bearing" for GC.
+ * Excluding system_image rows from this set left every retained
+ * system_image snapshot's bare-metal-recovery state with no DB-side
+ * protection at all — surviving only by luck, if its manifest.json also
+ * happened to still be present in the bucket LISTING (see
+ * listedManifestSnapshotIds).
+ *
+ * 'application' (hyperv) and 'database' (mssql) still write their manifests
+ * to a different key/namespace entirely and must stay excluded.
+ *
+ * `as const` (rather than `readonly string[]` directly) so the literal tuple
+ * type-checks against backupSnapshots.backupType's pgEnum column in the
+ * `inArray(...)` call below — Drizzle's enum column typing rejects a bare
+ * `string[]`. BACKUP_GC_RETAINED_MANIFEST_BACKUP_TYPES itself is exported as
+ * the widened `readonly string[]` (below) since callers like
+ * isRetainableBackupTypeForGc only need plain string membership.
+ */
+const RETAINABLE_BACKUP_TYPES_FOR_GC = ['file', 'system_image'] as const;
+export const BACKUP_GC_RETAINED_MANIFEST_BACKUP_TYPES: readonly string[] = RETAINABLE_BACKUP_TYPES_FOR_GC;
+
+/**
+ * Whether a backupSnapshots row of this backupType may safely be included in
+ * retainedSnapshotIds — see BACKUP_GC_RETAINED_MANIFEST_BACKUP_TYPES' doc
+ * comment. NULL (legacy rows predating the backupType column) is always
+ * retainable. Factored out as its own predicate (rather than inlined into
+ * the query's `or(...)` below) purely so it has an isolated unit test
+ * independent of the mocked Drizzle query builder, which cannot exercise a
+ * real `.where()` filter — see backupRetention.test.ts's own comment on that
+ * limitation.
+ */
+export function isRetainableBackupTypeForGc(backupType: string | null): boolean {
+  return backupType === null || BACKUP_GC_RETAINED_MANIFEST_BACKUP_TYPES.includes(backupType);
+}
+
 type BackupGcManifest = { files?: Array<{ backupPath?: unknown }> };
 
 // D15 bare-metal-recovery contract (Option A): a system_image snapshot
@@ -1125,22 +1173,27 @@ export async function sweepUnreferencedBackupObjects(): Promise<BackupGcResult> 
     }
 
     try {
-      // Only FILE-type snapshots use the snapshots/<id>/manifest.json layout
-      // the mark phase fetches. system_image / hyperv (backupType 'application')
-      // / mssql (backupType 'database') snapshots write their manifests to
-      // DIFFERENT keys and never share the snapshots/ namespace, so fetching
-      // snapshots/<id>/manifest.json for them 404s and fail-closes the WHOLE
-      // identity forever (a single such row sharing a bucket with file backups
-      // would silently wedge GC). Excluding them here confines GC to the layout
-      // it actually understands. Legacy rows with NULL backupType predate the
-      // column's 'file' default and are file backups, so include them too.
+      // Only backupTypes in BACKUP_GC_RETAINED_MANIFEST_BACKUP_TYPES (file,
+      // system_image — plus NULL, legacy rows predating the column) use the
+      // snapshots/<id>/manifest.json layout the mark phase fetches. hyperv
+      // (backupType 'application') / mssql (backupType 'database') snapshots
+      // write their manifests to DIFFERENT keys and never share the
+      // snapshots/ namespace, so fetching snapshots/<id>/manifest.json for
+      // them 404s and fail-closes the WHOLE identity forever (a single such
+      // row sharing a bucket with file backups would silently wedge GC).
+      // Excluding THOSE here confines GC to the layout it actually
+      // understands — see BACKUP_GC_RETAINED_MANIFEST_BACKUP_TYPES' doc
+      // comment for why system_image is no longer in that excluded set.
       const retainedRows = await db
         .select({ snapshotId: backupSnapshots.snapshotId })
         .from(backupSnapshots)
         .where(
           and(
             inArray(backupSnapshots.configId, identity.configIds),
-            or(eq(backupSnapshots.backupType, 'file'), isNull(backupSnapshots.backupType)),
+            or(
+              inArray(backupSnapshots.backupType, RETAINABLE_BACKUP_TYPES_FOR_GC),
+              isNull(backupSnapshots.backupType),
+            ),
           ),
         );
       const retainedSnapshotIds = retainedRows.map((row) => row.snapshotId);

--- a/apps/api/src/routes/backup/resultSchemas.test.ts
+++ b/apps/api/src/routes/backup/resultSchemas.test.ts
@@ -50,6 +50,45 @@ describe('backupCommandResultSchema — system_image manifest', () => {
   });
 });
 
+// D15 Wave 1 finding #1: a state-only system_image run's ordinary manifest
+// must publish `"files":[]`, never `"files":null` — the agent-side fix is at
+// backup.go's state-only Snapshot literal. This documents the API-side half
+// of that contract: `snapshot.files` is `z.array(...).optional()`, which
+// accepts a MISSING key or an empty array, but Zod's `.optional()` rejects an
+// explicit `null` — so a result that regressed back to emitting `null` would
+// 400 and silently drop the whole job result (snapshot id, size, everything).
+describe('backupCommandResultSchema — snapshot.files null-vs-empty contract (D15)', () => {
+  it('parses a system_image result whose snapshot.files is an empty array', () => {
+    const parsed = backupCommandResultSchema.parse({
+      snapshotId: 'snap-1',
+      backupType: 'system_image',
+      systemStateManifest: {
+        platform: 'linux',
+        artifacts: [{ name: 'services_systemd', category: 'services' }],
+      },
+      snapshot: {
+        id: 'snap-1',
+        files: [],
+      },
+    });
+    expect(parsed.snapshot?.files).toEqual([]);
+    expect(parsed.systemStateManifest?.platform).toBe('linux');
+  });
+
+  it('rejects a result whose snapshot.files is null', () => {
+    expect(() =>
+      backupCommandResultSchema.parse({
+        snapshotId: 'snap-1',
+        backupType: 'system_image',
+        snapshot: {
+          id: 'snap-1',
+          files: null,
+        },
+      }),
+    ).toThrow();
+  });
+});
+
 describe('backupCommandResultSchema — incremental-backup referenced stats', () => {
   it('accepts referencedBytes + referencedFiles from an agent that deduped files', () => {
     const parsed = backupCommandResultSchema.parse({

--- a/apps/api/src/services/backupSnapshotStorage.ts
+++ b/apps/api/src/services/backupSnapshotStorage.ts
@@ -162,6 +162,22 @@ export function backupSnapshotManifestKey(snapshotId: string): string {
   return `${BACKUP_SNAPSHOT_ROOT_DIR}/${snapshotId}/${BACKUP_SNAPSHOT_MANIFEST_KEY}`;
 }
 
+// Mirrors agent/internal/backup/snapshot.go's systemStateDir/
+// systemStateManifestKey constants exactly (D15 bare-metal-recovery
+// contract, Option A — see docs/superpowers/plans/backup/
+// 2026-09-09-bmr-system-state-contract.md): system-state artifacts live
+// under their own sub-prefix, never inside manifest.files[].
+export const BACKUP_SYSTEM_STATE_DIR = 'system-state';
+export const BACKUP_SYSTEM_STATE_MANIFEST_KEY = 'manifest.json';
+
+export function backupSystemStateManifestKey(snapshotId: string): string {
+  return `${BACKUP_SNAPSHOT_ROOT_DIR}/${snapshotId}/${BACKUP_SYSTEM_STATE_DIR}/${BACKUP_SYSTEM_STATE_MANIFEST_KEY}`;
+}
+
+export function backupSystemStateArtifactKey(snapshotId: string, artifactPath: string): string {
+  return `${BACKUP_SNAPSHOT_ROOT_DIR}/${snapshotId}/${BACKUP_SYSTEM_STATE_DIR}/${artifactPath}`;
+}
+
 // ── GC support: list objects with last-modified ──────────────────────────────
 
 async function listS3ObjectsWithLastModified(
@@ -302,6 +318,24 @@ export async function fetchBackupObjectText(input: {
   if (provider === 's3') return fetchS3ObjectText(providerConfig, input.key);
   if (provider === 'local') return fetchLocalObjectText(providerConfig, input.key);
   throw new Error(`Provider ${provider ?? 'unknown'} does not support object fetch for GC`);
+}
+
+/**
+ * Distinguishes a genuine "object not present" from any other fetch failure,
+ * across both providers fetchBackupObjectText supports — mirrors
+ * isS3NotFound (s3Storage.ts) for S3 (NotFound/NoSuchKey) and adds the local
+ * provider's ENOENT. Used by GC's system-state-manifest probe
+ * (backupRetention.ts's markLiveBackupObjects): "not found" is the expected,
+ * routine case for a file-mode snapshot with no system-state manifest, so it
+ * must NOT abort the sweep the way every other fetch failure does — but
+ * anything else (permission fault, transport error, corrupt local FS) means
+ * liveness cannot be proven and the fail-closed contract still applies.
+ */
+export function isBackupObjectNotFound(err: unknown): boolean {
+  const name = (err as { name?: string } | undefined)?.name;
+  if (name === 'NotFound' || name === 'NoSuchKey') return true;
+  const code = (err as NodeJS.ErrnoException | undefined)?.code;
+  return code === 'ENOENT';
 }
 
 // ── GC support: delete specific object keys ───────────────────────────────────


### PR DESCRIPTION
Wave 1 of #5439 (bare-metal recovery system-state contract, campaign defect D15 / O10).

Closes #5440

## Problem
`system_image` backups appended the system-state staging dir to the ordinary file walk, so artifacts landed under `snapshots/<id>/files/path_N/…`, while the BMR consumer (`bmr.go`) has always read `snapshots/<id>/system-state/manifest.json` + `system-state/<artifact.path>`. Bare-metal recovery of a system_image snapshot therefore downloaded artifacts into a temp dir and applied nothing while reporting `completed`.

## What (Option A from the plan)
- **Producer** (`backup.go`, `snapshot.go`): dedicated `publishSystemState` step writes every artifact raw to `snapshots/<id>/system-state/<artifact.path>` and then `system-state/manifest.json`. `snapshots/<id>/manifest.json` is still published for every system_image run (empty `files[]` is fine) so GC sees a manifest-bearing group. The `len(files)==0` hard-fail now distinguishes "state published, no ordinary files" (success) from "state publish failed" (loud failure). The old `markSystemStateFiles` detector, whose premise Option A invalidates, is removed.
- **Manifest schema** (`systemstate/types.go`): `schemaVersion` (1), `collectorVersion` (agent version, wired via `BackupConfig.AgentVersion`), `requiredSteps` (so the consumer can enforce independently of the producer), `artifacts[].checksum` (sha256). Pure JSON growth — no migration; the strict queue/result schemas accept it.
- **Collector metadata** (`systemstate/helpers.go`): staged copies now preserve mode/mtime/uid-gid and recreate symlinks (previously everything staged as 0600/0700 root, which the W03 restorer would have propagated onto `/etc`). Symlinks are excluded from the artifact list.
- **GC** (`backupRetention.ts` `markLiveBackupObjects`): fetches `system-state/manifest.json` when present and marks it plus every artifact live. Any non-404 fetch error is fail-closed (the group is not swept). Without this, the new layout would have been deleted after the 48 h per-object grace.

## Tests
- Go: fake collector + capturing provider assert the exact remote layout; state-only success; state-publish failure fails loudly; helpers metadata/symlink tests. `go test -race ./internal/backup/...`, build/vet on darwin/linux/windows.
- API: `backupRetention.test.ts` (+3: referenced state objects survive, unreferenced are deleted, non-404 blocks deletion), `backupResultPersistence.test.ts`, tsc clean.

W02 (consumer enforcement) and W04 (integration cell) follow; W03 (#5444) is independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sufm7gYXhWknkCbT9Fz9Nu