### PR TITLE
docs(backup): D18 storage-reclamation design spec + W01–W04 plans (#5429, feature #5449)

### DIFF
--- a/docs/superpowers/plans/backup/2026-09-09-backup-gc-reclamation-w01-api-pins-and-retirements.md
+++ b/docs/superpowers/plans/backup/2026-09-09-backup-gc-reclamation-w01-api-pins-and-retirements.md
@@ -1,3 +1,7 @@
+---
+tracking_issue: LanternOps/breeze#5449
+---
+
 # Wave 01 — API: server-chosen base, pins, leases, retirements, storage identity, lineage — Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
@@ -23,7 +27,7 @@
   - `BACKUP_BASE_LEASE_MS` — default 7 d (`604_800_000`), production floor 1 h.
   - `BACKUP_RESTORE_PIN_LINGER_MS` — default 7 d, production floor 1 h.
   - `BACKUP_PUBLISH_MARGIN_MS` — default 1 h (`3_600_000`), production floor 5 min.
-- `normalizeStorageIdentity(provider, providerConfig)` (exported, `apps/api/src/jobs/backupRetention.ts:661`) is the ONE identity function for live TypeScript code paths. The migration's backfill replicates its logic in PL/pgSQL for a **guarded** subset of rows only (spec §3.6) — see Task 1's open question on fidelity.
+- `normalizeStorageIdentity(provider, providerConfig)` (exported, `apps/api/src/jobs/backupRetention.ts:661`) is the ONE identity function for live TypeScript code paths. Migration `140005` does NOT replicate it in SQL and does not backfill `backup_snapshots.storage_identity` at all (coordinator decision, spec §3.6/§4 amended) — every row starts NULL and is self-healed later by the W02 GC sweep from a live bucket listing.
 - Registries to touch: `apps/api/src/services/tenantCascade.ts` (`CORE_ORG_CASCADE_DELETE_ORDER`), `apps/api/src/routes/devices/core.ts` (`CORE_DEVICE_CASCADE_DELETE_TABLES`, `CORE_DEVICE_ORG_DENORMALIZED_TABLES`), `apps/api/src/services/tenantExportPolicyRegistry.ts` (`CORE_TENANT_EXPORT_POLICY`). `rls-coverage.integration.test.ts` needs NO new allowlist entry (shape 1 = plain `org_id` column = auto-discovered).
 - Lock order for the base pin is **job, then snapshot** (mirrors `routes/devices/moveOrg.ts:248-253`'s "lock parents in a fixed order as the transaction's first statements" pattern).
 
@@ -33,6 +37,7 @@ All of the below was verified directly against the worktree at `/Users/toddhebeb
 
 - `apps/api/src/db/schema/backup.ts:207-278` (`backupJobs`) — no `baseSnapshotId`/`publishLeaseExpiresAt`/`storageIdentity` columns exist yet. `:247` `snapshotId varchar(BACKUP_SNAPSHOT_ID_MAX_LENGTH)`.
 - `apps/api/src/db/schema/backup.ts:280-337` (`backupSnapshots`) — `:300` `isIncremental boolean default(false)` and `:305-308` `parentSnapshotId` self-FK `ON DELETE SET NULL` already exist (D17, migration `2026-10-15-140004`) and are never written by the live write path. No `storageIdentity` column yet.
+- `apps/api/src/db/schema/backup.ts:330-332` — `snapshotIdIdx: index('backup_snapshots_snapshot_id_idx').on(table.snapshotId)` is a PLAIN, NON-UNIQUE index — `backup_snapshots.snapshot_id` (the agent-supplied string) carries no uniqueness constraint of any kind at the DB level. Review fix implication: every lookup in this plan that matches a row by a bare `snapshotId` string (dispatch's base-candidate re-check, retention's backup-pin check, the late-result fence's base lookup, reconcile's base-existence check) must ALSO be scoped by `storageIdentity`, or it is not guaranteed to identify one specific row.
 - `apps/api/src/db/schema/backup.ts:62` — `IN_FLIGHT_BACKUP_JOB_STATUSES = ['pending', 'running'] as const`, exported from this module.
 - `apps/api/migrations/2026-10-15-140004-backup-snapshot-lineage-fk-set-null.sql` (full file read) — the newest shipped migration; confirmed via `ls apps/api/migrations/*.sql | sort | tail -1` that no later-sorting file exists, so `140005`/`140006` are free, correctly-ordered slots.
 - `apps/api/src/jobs/backupRetention.ts:661-672` — `normalizeStorageIdentity` verbatim:
@@ -54,7 +59,7 @@ All of the below was verified directly against the worktree at `/Users/toddhebeb
 - `apps/api/src/jobs/backupWorker.ts:60-64` — `const { db } = dbModule;` and `runWithSystemDbAccess = (fn) => typeof dbModule.withSystemDbAccessContext === 'function' ? dbModule.withSystemDbAccessContext(fn) : fn()`.
 - `apps/api/src/jobs/backupWorker.ts:77-130` (`createBackupWorker`, full read) — the BullMQ processor. `dispatch-backup` is special-cased **outside** the blanket wrap at `:89-99` (comment `:82-88` explains why: Redis/WS I/O via `agentCommandRelay` must not pin a pooled connection idle-in-transaction). Every other job type — including `cleanup-expired-snapshots` at `:109-111` — runs inside `return runWithSystemDbAccess(async () => { switch (data.type) { ... } })` at `:101`. `withDbAccessContext`/`withSystemDbAccessContext` (`apps/api/src/db/index.ts:525-554,610`) open exactly one real Postgres transaction (`baseDb.transaction(...)`) when no ambient context is already active, and are a no-op passthrough when nested inside one that already is. **This is the bug §3.7 fixes**: today, every retirement insert + row delete `cleanupExpiredSnapshots` performs, across every org and every candidate row, plus the entire GC sweep that follows it, all share the ONE transaction opened at `:101` — a later `failed > 0` throw or any savepoint rollback undoes retirements that already "committed" from the caller's point of view.
 - `apps/api/src/jobs/backupWorker.ts:325-395` — `processCleanupExpiredSnapshots` verbatim: loops `db.selectDistinct({ orgId }).from(backupSnapshots)`, calls `cleanupExpiredSnapshots(orgId)` per org, then `sweepUnreferencedBackupObjects()` once (try/catch, GC failure never fails the job), then the deliberate D17 `if (failed > 0) throw ...` **last**, after the sweep has already run.
-- `apps/api/src/jobs/backupRetention.ts:982` — `sweepUnreferencedBackupObjects` has **no internal `withSystemDbAccessContext`/`withDbAccessContext` call of its own** — it relies entirely on the ambient context the caller already opened. Pulling `cleanup-expired-snapshots` out of the blanket wrap (as this wave must) would leave it running with NO context at all unless its call site is separately wrapped — Task 8 wraps the call site (not its internals; internal per-identity context splitting is W02's §3.4/§3.7-item-2 job).
+- `apps/api/src/jobs/backupRetention.ts:982` — `sweepUnreferencedBackupObjects` has **no internal `withSystemDbAccessContext`/`withDbAccessContext` call of its own** — it relies entirely on the ambient context the caller already opened. Pulling `cleanup-expired-snapshots` out of the blanket wrap (as this wave must) would leave this function's DB reads running with NO context at all unless Task 8's call site compensates. Per the coordinator's authoritative call-shape contract, Task 8 wraps the sweep call in exactly ONE `runWithSystemDbAccess`/`withSystemDbAccessContext` call (matching today's shape, so the function's existing GUC-dependent reads keep working) — internal per-identity context splitting is left entirely to W02 (§3.4/§3.7 item 2).
 - `apps/api/src/jobs/backupWorker.ts:609-778` (`prepareBackupDispatchTargets`, full read) — builds `targets` (`:652`), loops `for (let i = 0; i < targets.length; i++)` (`:703`), creates a child `backup_jobs` row via `.insert(backupJobs)...returning()` for `i > 0` (`:713-733`, reusing `data.jobId` for `i === 0`), then builds `command.payload` at `:742-762`: `{ jobId, configId, provider, providerConfig: commandProviderConfig, storageEncryption, ...target.payload }` — no base/lease/identity fields today. This is the exact insertion point.
 - `apps/api/src/jobs/backupWorker.ts:399-431` — `resolveBackupTargets`: `case 'file'` and `case 'system_image'` both return `commandType: 'backup_run'`; hyperv/mssql return `hyperv_backup`/`mssql_backup` — never base-pinned. `system_image` payload is `{ systemImage: true }`; `file` payload is `{ paths, excludes? }`.
 - `apps/api/src/jobs/backupWorker.ts:26` — drizzle-orm import is `eq, ne, and, sql, isNull, lt, inArray` — `desc`, `or`, `gt` are NOT yet imported and must be added.
@@ -76,10 +81,17 @@ All of the below was verified directly against the worktree at `/Users/toddhebeb
 - `apps/api/src/jobs/backupRetention.test.ts:1-75` (full read) — the `chainable(rows)` mock helper (`from/where/leftJoin/innerJoin/orderBy/limit` all return `obj`, `.then()` resolves `rows`), a FIFO `selectQueue` consumed by `mockDb.select`, `vi.mock('../db', () => ({ db: mockDb }))`. **No `.for()` method on `chainable`, no `insert`, no `withSystemDbAccessContext` export from the mock today** — Task 9's test setup must add all three.
 - `apps/api/src/jobs/backupWorker.test.ts:1-59` (full read) — `mockDb` with `select/from/where/limit` chainable via `mockReturnThis()`, `vi.mock('../db', () => ({ db: mockDb, withSystemDbAccessContext: undefined, runOutsideDbContext: (fn) => fn(), SYSTEM_DB_ACCESS_CONTEXT: {...} }))`, `cleanupExpiredSnapshots`/`sweepUnreferencedBackupObjects` mocked wholesale from `./backupRetention`, `__testOnly` exported from `backupWorker.ts` for driving `processDispatchBackup` directly. No `mockDb.transaction` today — Task 6's test adds one.
 - `apps/api/src/__tests__/integration/staleBackupReaper.integration.test.ts` (full read) — the real-DB integration-test convention this wave's new suites mirror: `import './setup'`, `it.runIf(!!process.env.DATABASE_URL)`, seed via `withSystemDbAccessContext(async () => { ... insert partner/org/site/device/config/job ... })`, exercise the real function, assert via a second `withSystemDbAccessContext` read.
+- **Round-2 review findings, independently re-verified:**
+  - `apps/api/src/db/index.ts:124-129` — the REAL `DbAccessContext` interface: `{ scope: DbAccessScope; orgId: string | null; accessibleOrgIds: string[] | null; accessiblePartnerIds?: string[] | null; userId?: string | null; currentPartnerId?: string | null; ... }`. There is NO `partnerId` field — an earlier draft's `{ scope, orgId, partnerId: null }` in the RLS forge test was simply a no-op extra property, not a real context value.
+  - `apps/api/src/__tests__/integration/agentRollbackRls.integration.test.ts:12-13` — the established `orgContext(orgId)` helper convention: `{ scope: 'organization', orgId, accessibleOrgIds: [orgId], accessiblePartnerIds: [], userId: null }`. `:105` confirms a Drizzle `.insert(...)` rejection wraps the real Postgres error under `.cause` (`rejects.toMatchObject({ cause: { code: '23505' } })`), while `:128`'s raw `db.execute(sql\`...\`)` rejection carries `.code` at the top level instead — the two are NOT interchangeable.
+  - `apps/api/src/__tests__/integration/db-utils.ts:59,106,146` — `createUser`/`createPartner`/`createOrganization` are the established seed helpers this suite's integration tests use in preference to hand-rolled inserts; no `createDevice` helper exists there (device rows are inserted directly, as `staleBackupReaper.integration.test.ts` and this plan's own tests already do).
+  - `apps/api/scripts/check-drift.ts:1-31` (header) — `db:check-drift` verifies ONLY that the hand-written migration set applies cleanly and that `breeze_migrations` has one row per file; its own comment block is explicit that "Schema-vs-live-DB structural drift" is deliberately NOT checked here (drizzle-kit's introspect/generate round-trip produces too many false positives in this repo) — that is covered instead by the real-DB integration tests and PR review. It CANNOT fail or pass based on a Drizzle schema TypeScript change alone.
+  - `apps/api/src/testUtils/integrationDatabaseSafety.ts` — `assertTestDatabaseUrlSafe` REFUSES any connection whose database name doesn't match `/^breeze_test(_[a-z0-9]+)?$/`, whose host isn't in a local allowlist, or whose port is `5432` (the dev/prod default) — the dev-DB URL used elsewhere in this repo's docs (`postgresql://breeze:breeze@localhost:5432/breeze`) is exactly the shape this rejects. `apps/api/src/__tests__/integration/setup.ts:32-33` defaults `DATABASE_URL`/`DATABASE_URL_APP` to `postgresql://breeze_test:breeze_test@localhost:5433/breeze_test` when unset, and `docker-compose.test.yml:27-33` provisions exactly that database on port 5433 — the integration runner needs NO `DATABASE_URL` override at all locally as long as that compose service is up.
+  - `apps/api/src/jobs/queueSchemas.ts` — `backupSnapshotSummarySchema` (the block starting `const backupSnapshotSummarySchema = z.object({`) is `.strict()` and today declares only `id`/`timestamp`/`size`/`files` — none of this wave's `baseSnapshotId`/`formatVersion`/`backupIdentity` fields. `apps/api/src/jobs/backupEnqueue.ts:79-117` — `ProcessResultsResult` is a plain (non-Zod) TS interface with the same gap at its `snapshot?: {...}` sub-type (`:105-115`). `enqueueBackupResults` (`:161-187`) parses its `result` argument through `backupQueueJobDataSchema.parse(...)` — the same schema `backupWorker.ts`'s `parseQueueJobData` uses at `:81` — so a `.strict()` mismatch either throws at enqueue time or silently strips the fields, and either way the lineage data added in `resultSchemas.ts` (the WS-ingress schema) never reaches `backupResultPersistence.ts`.
 
 ## File structure
 
-- **Create** `apps/api/migrations/2026-10-15-140005-backup-jobs-base-pin-and-storage-identity.sql` — new `backup_jobs` columns + partial index; nullable `backup_snapshots.storage_identity` + guarded SQL backfill.
+- **Create** `apps/api/migrations/2026-10-15-140005-backup-jobs-base-pin-and-storage-identity.sql` — new `backup_jobs` columns + partial index; nullable `backup_snapshots.storage_identity` column, DDL only, no backfill.
 - **Create** `apps/api/migrations/2026-10-15-140006-backup-snapshot-retirements.sql` — new table + shape-1 RLS.
 - **Create** `apps/api/src/services/backupGcKnobs.ts` + `apps/api/src/services/backupGcKnobs.test.ts` — shared per-run env-knob resolver.
 - **Modify** `apps/api/src/db/schema/backup.ts` — add columns to `backupJobs`/`backupSnapshots`, new `backupSnapshotRetirements` table.
@@ -88,19 +100,20 @@ All of the below was verified directly against the worktree at `/Users/toddhebeb
 - **Modify** `apps/api/src/jobs/staleCommandReaper.ts` — new `reapCommandlessPendingRestores` domain.
 - **Modify** `apps/api/src/jobs/backupRetention.ts` — per-row system-context retention with pin checks + retirement insert.
 - **Modify** `apps/api/src/routes/backup/resultSchemas.ts` — lineage fields on `backupSnapshotResultSchema`.
-- **Modify** `apps/api/src/services/backupResultPersistence.ts` — lineage on write + late-result fence.
-- **Modify** `apps/api/src/services/backupSnapshotReconcile.ts` — forward lineage, refuse retired/too-old/base-missing adoption.
-- **Modify** `apps/api/src/routes/backup/configs.ts` — `warnings: ['storage_identity_changed']` on PATCH.
-- **Test (modify)** `apps/api/src/jobs/backupWorker.test.ts`, `apps/api/src/jobs/backupRetention.test.ts`, `apps/api/src/jobs/staleCommandReaper.test.ts`, `apps/api/src/services/backupResultPersistence.test.ts`, `apps/api/src/services/backupSnapshotReconcile.test.ts`, `apps/api/src/routes/backup/configs.test.ts`.
+- **Modify** `apps/api/src/services/backupResultPersistence.ts` — lineage on write + late-result fence (device-scoped, `FOR UPDATE`-atomic, identity-scoped).
+- **Modify** `apps/api/src/jobs/queueSchemas.ts`, `apps/api/src/jobs/backupEnqueue.ts` — propagate the new lineage fields through the BullMQ queue schema and `ProcessResultsResult` interface (review fix — otherwise stripped/rejected before persistence ever sees them).
+- **Modify** `apps/api/src/services/backupSnapshotReconcile.ts` — forward lineage, refuse retired/too-old/base-missing/late-result-fenced adoption; scope the base-existence lookup by `storageIdentity`.
+- **Modify** `apps/api/src/routes/backup/configs.ts` — `warnings: string[]` (always present) on PATCH.
+- **Test (modify)** `apps/api/src/jobs/backupWorker.test.ts`, `apps/api/src/jobs/backupRetention.test.ts`, `apps/api/src/jobs/staleCommandReaper.test.ts`, `apps/api/src/services/backupResultPersistence.test.ts`, `apps/api/src/services/backupSnapshotReconcile.test.ts`, `apps/api/src/routes/backup/configs.test.ts`, `apps/api/src/jobs/backupEnqueue.test.ts` (new queue round-trip case).
 - **Test (new)** `apps/api/src/__tests__/integration/backupRetentionPins.integration.test.ts`, `apps/api/src/__tests__/integration/backupSnapshotRetirementsRls.integration.test.ts`.
 
 ---
 
-### Task 1: Migration 140005 — `backup_jobs` pin/identity columns + guarded SQL backfill for `backup_snapshots.storage_identity`
+### Task 1: Migration 140005 — `backup_jobs` pin/identity columns + nullable `backup_snapshots.storage_identity` (DDL only)
 
 **Files:** Create `apps/api/migrations/2026-10-15-140005-backup-jobs-base-pin-and-storage-identity.sql`.
 
-**Decision (backfill mechanism):** the spec (§3.6/§4) is explicit that this must be a SQL backfill inside the migration, guarded to only touch rows whose config was **not** edited after the snapshot (`backup_configs.updated_at <= backup_snapshots.timestamp`) — everything else, including every NULL-`config_id` row, stays NULL and is self-healed later by the GC sweep (W02) from the storage listing. This supersedes a TS-script approach an earlier draft of this plan used; the guard exists precisely so the fidelity gap between `normalizeStorageIdentity`'s `path.resolve()`/`new URL()` semantics and a hand-written SQL equivalent only matters for the *unguarded* (self-healing) rows, not the ones this migration commits. See the open question below for what's still imperfect even inside the guard.
+**Decision (no backfill — coordinator directive, spec §3.6/§4 amended):** this migration is DDL only. `backup_snapshots.storage_identity` is added nullable with **no UPDATE and no `breeze.scope` elevation** — every existing row is simply left NULL. W02's sweep self-heals each NULL row by matching it against a live bucket listing (per row id), so no SQL or TS backfill of any kind is needed here. This replaces an earlier draft of this task that ported `normalizeStorageIdentity` into PL/pgSQL for a guarded subset of rows — dropped entirely, not merely deferred.
 
 - [ ] Step 1: Write the failing test — this migration has no unit-testable TS surface; the "red" step is observing the column/table absence against a real DB.
   Command: `docker exec -it breeze-postgres psql -U breeze_app -d breeze -c "\d backup_jobs"` → confirm `base_snapshot_id`/`publish_lease_expires_at`/`storage_identity` are absent.
@@ -119,14 +132,13 @@ All of the below was verified directly against the worktree at `/Users/toddhebeb
 -- (base or not) at DISPATCH time only — it is never renewed (no delivery
 -- channel exists to renew it; see backupWorker.ts's stampDispatchPinAndIdentity
 -- docstring). storage_identity on backup_snapshots is nullable FOREVER: no
--- follow-up NOT NULL migration exists for it. Rows this migration cannot
--- confidently attribute (config edited after the snapshot, or no config_id at
--- all) are left NULL and self-healed later by the GC sweep (W02) from the live
--- storage listing.
+-- follow-up NOT NULL migration exists for it, and this migration does NOT
+-- backfill it — every existing row is left NULL. The W02 GC sweep self-heals
+-- each NULL row by matching it (by row id) against a live bucket listing; no
+-- SQL or TS backfill of any kind is required or attempted here.
 --
--- Idempotent: IF NOT EXISTS on every column/index; the backfill only touches
--- rows where storage_identity IS NULL, so re-running is a no-op once the
--- eligible set has already been filled.
+-- DDL only — no UPDATE, no breeze.scope elevation needed. Idempotent:
+-- IF NOT EXISTS on every column/index.
 
 DO $$
 BEGIN
@@ -143,66 +155,7 @@ CREATE INDEX IF NOT EXISTS backup_jobs_base_snapshot_id_idx
 DO $$
 BEGIN
   ALTER TABLE backup_snapshots ADD COLUMN IF NOT EXISTS storage_identity text;
-  RAISE NOTICE 'backup_snapshots: storage_identity ensured (nullable, no NOT NULL — self-healed by the W02 GC sweep)';
-END $$;
-
--- Guarded backfill (§3.6): only for rows whose config was NOT edited after the
--- snapshot was taken, so the config's CURRENT provider/provider_config is
--- known to be the same one the snapshot was actually written under. This is a
--- best-effort PL/pgSQL port of normalizeStorageIdentity
--- (apps/api/src/jobs/backupRetention.ts:661-672) — see the open question below
--- for where it can diverge from the TS function.
-DO $$
-DECLARE
-  backfilled_count integer := 0;
-  left_null_count integer := 0;
-BEGIN
-  WITH candidates AS (
-    SELECT s.id,
-           c.provider,
-           c.provider_config
-    FROM backup_snapshots s
-    JOIN backup_configs c ON c.id = s.config_id
-    WHERE s.storage_identity IS NULL
-      AND c.updated_at <= s."timestamp"
-  ),
-  computed AS (
-    SELECT
-      id,
-      CASE
-        WHEN provider = 'local' THEN
-          'local::' || regexp_replace(
-            COALESCE(provider_config->>'path', provider_config->>'basePath', ''),
-            '/+$', ''
-          )
-        ELSE
-          provider || '::' ||
-          CASE
-            WHEN provider_config->>'endpoint' IS NULL OR btrim(provider_config->>'endpoint') = '' THEN ''
-            WHEN lower(regexp_replace(regexp_replace(provider_config->>'endpoint', '^[a-zA-Z]+://', ''), '/.*$', ''))
-                 ~ '^s3(\.dualstack)?([.-][a-z0-9-]+)?\.amazonaws\.com(:[0-9]+)?$'
-              THEN ''
-            ELSE lower(regexp_replace(regexp_replace(provider_config->>'endpoint', '^[a-zA-Z]+://', ''), '/.*$', ''))
-          END
-          || '::' ||
-          btrim(COALESCE(provider_config->>'bucket', provider_config->>'bucketName', ''))
-      END AS identity
-    FROM candidates
-  )
-  UPDATE backup_snapshots s
-  SET storage_identity = computed.identity
-  FROM computed
-  WHERE s.id = computed.id;
-
-  GET DIAGNOSTICS backfilled_count = ROW_COUNT;
-  IF backfilled_count > 0 THEN
-    RAISE WARNING 'backup_snapshots storage_identity backfill: % row(s) backfilled from an unedited-since-snapshot config', backfilled_count;
-  END IF;
-
-  SELECT count(*) INTO left_null_count FROM backup_snapshots WHERE storage_identity IS NULL;
-  IF left_null_count > 0 THEN
-    RAISE WARNING 'backup_snapshots storage_identity backfill: % row(s) left NULL (config edited after the snapshot, or config_id NULL) — the W02 GC sweep self-heals these from the storage listing per spec §3.6', left_null_count;
-  END IF;
+  RAISE NOTICE 'backup_snapshots: storage_identity ensured (nullable, no NOT NULL, no backfill — every row starts NULL and is self-healed by the W02 GC sweep from a live bucket listing)';
 END $$;
 ```
 
@@ -210,10 +163,10 @@ END $$;
   Commands:
   - `pnpm db:migrate`
   - `docker exec -it breeze-postgres psql -U breeze_app -d breeze -c "\d backup_jobs"` — confirm all three columns present.
-  - `docker exec -it breeze-postgres psql -U breeze_app -d breeze -c "SELECT count(*) FROM backup_snapshots WHERE storage_identity IS NOT NULL;"` — non-zero if any pre-existing rows had an unedited config.
+  - `docker exec -it breeze-postgres psql -U breeze_app -d breeze -c "SELECT count(*) FROM backup_snapshots WHERE storage_identity IS NOT NULL;"` — expect `0` (no backfill).
 
 - [ ] Step 5: Commit
-  `git add apps/api/migrations/2026-10-15-140005-backup-jobs-base-pin-and-storage-identity.sql && git commit -m "feat(backup): base-pin/storage-identity columns + guarded backfill (D18 W01)"`
+  `git add apps/api/migrations/2026-10-15-140005-backup-jobs-base-pin-and-storage-identity.sql && git commit -m "feat(backup): base-pin/storage-identity columns, DDL only, no backfill (D18 W01)"`
 
 ---
 
@@ -221,12 +174,12 @@ END $$;
 
 **Files:** Modify `apps/api/src/db/schema/backup.ts` (add to `backupJobs` after `snapshotId` ~:247, `backupSnapshots` after `backupType` ~:322, new table after `backupSnapshotFiles` ~:356).
 
-**Interfaces:** Produces `backupSnapshotRetirements` Drizzle table export, `backupJobs.baseSnapshotId`/`.publishLeaseExpiresAt`/`.storageIdentity`, `backupSnapshots.storageIdentity`.
+**Interfaces:** Produces `backupSnapshotRetirements` Drizzle table export, `backupJobs.baseSnapshotId`/`.publishLeaseExpiresAt`/`.storageIdentity` (+ a matching partial index), `backupSnapshots.storageIdentity`.
 
-- [ ] Step 1: Write the failing test (schema drift is the mechanical gate here — no unit framework exercises schema files directly per repo convention)
-  Command: `pnpm db:check-drift` — expect FAIL once Task 1's migration is applied but the schema hasn't caught up (or vice versa if this task lands first).
+- [ ] Step 1: There is no automated red/green test for this task. **Correction (review fix):** `pnpm db:check-drift` does NOT compare the Drizzle schema against a live database at all — it verifies migration-ledger parity (every file in `apps/api/migrations/` has exactly one `breeze_migrations` row after a fresh apply; see `scripts/check-drift.ts:17-24`'s own header comment: "What is intentionally NOT checked here. Schema-vs-live-DB drift..."). It cannot fail or pass based on anything in this task. The actual verification for a Drizzle schema change is: (a) `pnpm db:migrate` applies cleanly against a fresh DB, (b) running it a SECOND time is a true no-op (idempotency), and (c) the integration tests written in Task 13 actually insert/query through these Drizzle table objects against real Postgres — that is what proves the TypeScript column definitions match the real column types/names.
+  Command (idempotency check, run against a disposable local DB): `pnpm db:migrate && pnpm db:migrate` — second run must report zero newly-applied migrations.
 
-- [ ] Step 2: Confirm the FAIL is the expected drift (missing columns/table), not a pre-existing unrelated one.
+- [ ] Step 2: (No FAIL step — see Step 1's correction. Proceed directly to Step 3.)
 
 - [ ] Step 3: Implement
 
@@ -303,10 +256,21 @@ export const backupSnapshotRetirements = pgTable(
 );
 ```
 
-  (`text` and `pgEnum` are already imported at the top of `backup.ts` — confirmed at lines 1-15.)
+```ts
+// apps/api/src/db/schema/backup.ts — inside backupJobs' (table) => ({...}) index block
+// (alongside the existing snapshotIdIdx/statusIdx/etc.): a Drizzle-side partial
+// index matching the migration's backup_jobs_base_snapshot_id_idx (Task 1).
+    baseSnapshotIdIdx: index('backup_jobs_base_snapshot_id_idx')
+      .on(table.baseSnapshotId)
+      .where(sql`base_snapshot_id IS NOT NULL`),
+```
+
+  (`text` and `pgEnum` are already imported at the top of `backup.ts` — confirmed at lines 1-15. `sql` from `drizzle-orm` is already imported in this file, used by the existing `orgDefaultUq`/`snapshotIdIdx` partial-index definitions.)
 
 - [ ] Step 4: Run, expect PASS
-  Command: `pnpm db:check-drift`
+  Commands:
+  - `pnpm db:migrate && pnpm db:migrate` (idempotency — second run is a no-op)
+  - `docker exec -it breeze-postgres psql -U breeze_app -d breeze -c "\d backup_jobs"` — confirm `backup_jobs_base_snapshot_id_idx` exists.
 
 - [ ] Step 5: Commit
   `git add apps/api/src/db/schema/backup.ts && git commit -m "feat(backup): add base-pin/storage-identity columns and backupSnapshotRetirements schema (D18 W01)"`
@@ -349,7 +313,7 @@ CREATE TABLE IF NOT EXISTS backup_snapshot_retirements (
   org_id uuid NOT NULL REFERENCES organizations(id),
   config_id uuid REFERENCES backup_configs(id) ON DELETE CASCADE,
   device_id uuid REFERENCES devices(id) ON DELETE SET NULL,
-  snapshot_id varchar(255) NOT NULL,
+  snapshot_id varchar(200) NOT NULL,
   storage_identity text NOT NULL,
   backup_type backup_type,
   reason backup_snapshot_retirement_reason NOT NULL,
@@ -385,7 +349,7 @@ CREATE POLICY breeze_org_isolation_delete ON backup_snapshot_retirements
   FOR DELETE USING (public.breeze_has_org_access(org_id));
 ```
 
-  Note: `varchar(255)` here (not `BACKUP_SNAPSHOT_ID_MAX_LENGTH`'s literal value) matches the width already used for `backup_jobs.base_snapshot_id` in Task 1 — confirm both stay in sync with the constant if it ever changes.
+  Note: `varchar(200)` matches `BACKUP_SNAPSHOT_ID_MAX_LENGTH` (`apps/api/src/db/schema/backupConstants.ts`, confirmed value `200`) and `backup_jobs.snapshot_id`'s existing width (`apps/api/src/db/schema/backup.ts:247`) — this is deliberately narrower than `backup_jobs.base_snapshot_id`'s `varchar(255)` (Task 1, an explicit spec choice for that column); the two widths are independent and this one is pinned to the constant, not to the other.
 
 - [ ] Step 4: Run, expect PASS
   Commands:
@@ -626,7 +590,7 @@ export function resolveBackupPublishMarginMs(): number {
 
 **Interfaces:**
 - Consumes: `resolveBackupBaseLeaseMs()` from `./services/backupGcKnobs`; `normalizeStorageIdentity` from `./backupRetention`; `backupSnapshotRetirements` schema; `desc`/`or`/`gt` added to the `drizzle-orm` import.
-- Produces: new function `stampDispatchPinAndIdentity(params): Promise<{ baseSnapshotId: string; publishLeaseExpiresAt: Date }>`; payload fields `baseSnapshotId: string` (`""` = full run) and `publishLeaseExpiresAt: string` (RFC3339) added to every `backup_run` command's payload.
+- Produces: new function `stampDispatchPinAndIdentity(params): Promise<{ baseSnapshotId: string; publishLeaseExpiresAt: Date | null }>`, called for **every** dispatched target regardless of `commandType`. `storage_identity` is stamped on `backup_jobs` for every target, including `hyperv_backup`/`mssql_backup` (review fix — GC must be able to group those rows by identity too), but `publish_lease_expires_at` and `base_snapshot_id` are set/attempted only when `mode` is `'file'`/`'system_image'` (`mode: null` for hyperv/mssql skips the pin/lease logic entirely). Payload fields `baseSnapshotId: string` (`""` = full run) and `publishLeaseExpiresAt: string` (RFC3339) are added only to `backup_run` commands' payloads (unchanged — pins/leases stay file/system_image-only at the wire-protocol level per spec).
 
 - [ ] Step 1: Write the failing test
 
@@ -649,20 +613,22 @@ describe('prepareBackupDispatchTargets — base pin + storage identity (D18 W01)
       capturedCommand = command;
       return { status: 'sent', via: 'local' };
     });
-    // First select in the transaction is the base-candidate lookup; second
-    // (inside the `.for('share')` chain) is the re-check lock. Both return a
-    // matching row so the base is pinned.
+    // Three selects in the transaction, in order: (1) the base-candidate
+    // lookup (.limit(1)), (2) the FOR SHARE lock on backup_snapshots ALONE
+    // (.for('share') — no leftJoin, per the Postgres outer-join fix), and
+    // (3) the plain, unlocked retirement-existence check (.limit(1),
+    // returns [] = "not retired"). All three must resolve for the base to
+    // be pinned.
     let selectCall = 0;
     mockDb.select.mockImplementation(() => {
       selectCall += 1;
       return {
         from: vi.fn().mockReturnThis(),
         innerJoin: vi.fn().mockReturnThis(),
-        leftJoin: vi.fn().mockReturnThis(),
         where: vi.fn().mockReturnThis(),
         orderBy: vi.fn().mockReturnThis(),
         limit: vi.fn().mockResolvedValue(
-          selectCall === 1 ? [{ id: 'base-row-id', snapshotId: 'base-snap-1' }] : [{ id: 'base-row-id' }],
+          selectCall === 1 ? [{ id: 'base-row-id', snapshotId: 'base-snap-1' }] : [],
         ),
         for: vi.fn().mockResolvedValue([{ id: 'base-row-id' }]),
       };
@@ -695,6 +661,25 @@ describe('prepareBackupDispatchTargets — base pin + storage identity (D18 W01)
     expect(capturedCommand?.payload?.baseSnapshotId).toBe('');
     expect(typeof capturedCommand?.payload?.publishLeaseExpiresAt).toBe('string');
   });
+
+  it('stamps storage_identity (but no lease/pin) on a hyperv_backup target', async () => {
+    // Arrange DATA/resolveBackupTargets so this fan-out includes a hyperv
+    // target (commandType: 'hyperv_backup'). Capture the backupJobs UPDATE
+    // call for that target's job row.
+    let capturedUpdateSet: Record<string, unknown> | undefined;
+    mockDb.update.mockImplementation(() => ({
+      set: (values: Record<string, unknown>) => {
+        capturedUpdateSet = values;
+        return { where: vi.fn().mockResolvedValue(undefined) };
+      },
+    }));
+
+    await __testOnly.processDispatchBackup(DATA_WITH_HYPERV_TARGET as any);
+
+    expect(capturedUpdateSet?.storageIdentity).toBeDefined();
+    expect(capturedUpdateSet?.publishLeaseExpiresAt).toBeUndefined();
+    expect(capturedUpdateSet?.baseSnapshotId).toBeUndefined();
+  });
 });
 ```
 
@@ -711,10 +696,31 @@ import { eq, ne, and, or, desc, gt, sql, isNull, lt, inArray } from 'drizzle-orm
 ```
 
 ```ts
-// apps/api/src/jobs/backupWorker.ts — new imports
+// apps/api/src/jobs/backupWorker.ts — new imports. backupSnapshotRetirements
+// is added to the EXISTING barrel import (`import { backupJobs,
+// backupSnapshotFiles, backupSnapshots, backupConfigs, ... } from
+// '../db/schema';`, confirmed at :11-23) rather than a separate line — this
+// file already imports backupJobs/backupSnapshots from that same barrel.
 import { resolveBackupBaseLeaseMs } from '../services/backupGcKnobs';
 import { normalizeStorageIdentity } from './backupRetention';
-import { backupSnapshotRetirements } from '../db/schema/backup';
+```
+
+```ts
+// apps/api/src/jobs/backupWorker.ts:11-23 — add backupSnapshotRetirements to the existing barrel import
+import {
+  backupJobs,
+  backupSnapshotFiles,
+  backupSnapshots,
+  backupSnapshotRetirements,
+  backupConfigs,
+  devices,
+  configurationPolicies,
+  organizations,
+  configPolicyEffectiveFeatureLinks,
+  configPolicyBackupSettings,
+  hypervVms,
+  sqlInstances,
+} from '../db/schema';
 ```
 
 ```ts
@@ -722,31 +728,53 @@ import { backupSnapshotRetirements } from '../db/schema/backup';
 
 /**
  * D18 §3.1/§3.6: stamps this job's storage_identity (from the providerConfig
- * actually placed in the dispatch payload) and a FIXED publish-lease deadline
- * — for EVERY dispatched file/system_image target, base found or not — and,
- * when an eligible incremental-dedupe base exists, pins it.
+ * actually placed in the dispatch payload) on EVERY dispatched target —
+ * including `hyperv_backup`/`mssql_backup` (review fix: GC must be able to
+ * group those rows by identity too, even though they never carry a base pin)
+ * — and, only when `mode` is `'file'`/`'system_image'`, a FIXED publish-lease
+ * deadline plus, when an eligible incremental-dedupe base exists, a pin on it.
+ * `mode: null` (hyperv/mssql) stamps identity only and returns immediately.
  *
  * Lock order is JOB then SNAPSHOT (mirrors the parent-rows-first pattern at
  * routes/devices/moveOrg.ts:248-253): the UPDATE on backup_jobs below takes
- * the job row's lock first; the FOR SHARE re-check on backup_snapshots takes
- * the candidate's lock second. Retention's per-row delete (backupRetention.ts)
- * takes FOR UPDATE on the snapshot row — whichever side gets there first wins:
- * the other either sees the live pin (and skips) or finds the row already
- * gone (and this function falls back to a full run). No FK-column write
- * happens while a lock from the other table is held (cf. #3911's key-share
- * deadlock).
+ * the job row's lock first. The snapshot-row re-check is then done as TWO
+ * separate statements, not one outer-joined `FOR SHARE` — Postgres rejects
+ * `FOR UPDATE`/`FOR SHARE` on the nullable side of an outer join (review
+ * fix: the original draft's `leftJoin(backupSnapshotRetirements, ...)` inside
+ * a `.for('share')` chain is exactly that and would raise `0A000` at
+ * runtime). First, `FOR SHARE` locks `backup_snapshots` ALONE; only once that
+ * lock is held is `backup_snapshot_retirements` checked with a second, plain
+ * (unlocked) SELECT — safe because by the time the FOR SHARE lock is granted,
+ * any concurrent retention transaction that already inserted a retirement row
+ * for this snapshot has either fully committed (so its retirement row is
+ * visible here) or is blocked behind this same lock (so no retirement can
+ * appear between the two selects). Retention's per-row delete
+ * (backupRetention.ts) takes `FOR UPDATE` on the same snapshot row —
+ * whichever side gets there first wins: the other either sees the live pin
+ * (and skips) or finds the row already gone (and this function falls back to
+ * a full run). No FK-column write happens while a lock from the other table
+ * is held (cf. #3911's key-share deadlock).
  */
 async function stampDispatchPinAndIdentity(params: {
   deviceId: string;
   configId: string;
   jobId: string;
-  mode: 'file' | 'system_image';
+  mode: 'file' | 'system_image' | null;
   provider: string;
   providerConfig: Record<string, unknown>;
-}): Promise<{ baseSnapshotId: string; publishLeaseExpiresAt: Date }> {
+}): Promise<{ baseSnapshotId: string; publishLeaseExpiresAt: Date | null }> {
+  const storageIdentity = normalizeStorageIdentity(params.provider, params.providerConfig);
+
+  if (params.mode === null) {
+    // hyperv/mssql: identity only — no lease, no pin (spec: pins/leases are
+    // file/system_image only; storage_identity stamping is not).
+    await db.update(backupJobs).set({ storageIdentity }).where(eq(backupJobs.id, params.jobId));
+    return { baseSnapshotId: '', publishLeaseExpiresAt: null };
+  }
+  const mode = params.mode;
+
   const leaseMs = resolveBackupBaseLeaseMs();
   const publishLeaseExpiresAt = new Date(Date.now() + leaseMs);
-  const storageIdentity = normalizeStorageIdentity(params.provider, params.providerConfig);
 
   return db.transaction(async (tx) => {
     const [candidate] = await tx
@@ -757,7 +785,7 @@ async function stampDispatchPinAndIdentity(params: {
         and(
           eq(backupSnapshots.deviceId, params.deviceId),
           eq(backupSnapshots.configId, params.configId),
-          params.mode === 'system_image'
+          mode === 'system_image'
             ? eq(backupSnapshots.backupType, 'system_image')
             : or(eq(backupSnapshots.backupType, 'file'), isNull(backupSnapshots.backupType)),
           or(isNull(backupSnapshots.expiresAt), gt(backupSnapshots.expiresAt, publishLeaseExpiresAt)),
@@ -782,24 +810,32 @@ async function stampDispatchPinAndIdentity(params: {
       return { baseSnapshotId: '', publishLeaseExpiresAt };
     }
 
-    // SNAPSHOT row second: FOR SHARE re-check that the candidate is still
-    // present and unretired. A concurrent retention delete either already
-    // removed the row (this SELECT returns nothing) or is blocked behind
-    // this lock until commit (its own FOR UPDATE on the same row).
+    // SNAPSHOT row second, locked ALONE (see docstring for why the retirement
+    // check cannot share this statement).
     const [locked] = await tx
       .select({ id: backupSnapshots.id })
       .from(backupSnapshots)
-      .leftJoin(
-        backupSnapshotRetirements,
+      .where(eq(backupSnapshots.id, candidate.id))
+      .for('share');
+
+    if (!locked) {
+      // Row already gone — a concurrent retention delete won the race.
+      await tx.update(backupJobs).set({ baseSnapshotId: null }).where(eq(backupJobs.id, params.jobId));
+      return { baseSnapshotId: '', publishLeaseExpiresAt };
+    }
+
+    const [retirement] = await tx
+      .select({ id: backupSnapshotRetirements.id })
+      .from(backupSnapshotRetirements)
+      .where(
         and(
           eq(backupSnapshotRetirements.storageIdentity, storageIdentity),
           eq(backupSnapshotRetirements.snapshotId, candidate.snapshotId),
         ),
       )
-      .where(and(eq(backupSnapshots.id, candidate.id), isNull(backupSnapshotRetirements.id)))
-      .for('share');
+      .limit(1);
 
-    if (!locked) {
+    if (retirement) {
       await tx.update(backupJobs).set({ baseSnapshotId: null }).where(eq(backupJobs.id, params.jobId));
       return { baseSnapshotId: '', publishLeaseExpiresAt };
     }
@@ -811,19 +847,20 @@ async function stampDispatchPinAndIdentity(params: {
 
 ```ts
 // apps/api/src/jobs/backupWorker.ts — inside prepareBackupDispatchTargets's per-target loop,
-// right before `const command: AgentCommand = {` (~:742):
+// right before `const command: AgentCommand = {` (~:742). Called for EVERY
+// target (review fix — identity stamping must cover hyperv/mssql too):
 
-    let dispatchPin: { baseSnapshotId: string; publishLeaseExpiresAt: Date } | null = null;
-    if (target.commandType === 'backup_run') {
-      dispatchPin = await stampDispatchPinAndIdentity({
-        deviceId: data.deviceId,
-        configId: data.configId,
-        jobId: commandJobId,
-        mode: (target.payload as Record<string, unknown>).systemImage === true ? 'system_image' : 'file',
-        provider: config.provider,
-        providerConfig: commandProviderConfig,
-      });
-    }
+    const dispatchPin = await stampDispatchPinAndIdentity({
+      deviceId: data.deviceId,
+      configId: data.configId,
+      jobId: commandJobId,
+      mode:
+        target.commandType === 'backup_run'
+          ? ((target.payload as Record<string, unknown>).systemImage === true ? 'system_image' : 'file')
+          : null,
+      provider: config.provider,
+      providerConfig: commandProviderConfig,
+    });
 
     const command: AgentCommand = {
       id: commandJobId,
@@ -843,10 +880,12 @@ async function stampDispatchPinAndIdentity(params: {
               required: false,
               mode: 'disabled',
             },
-        ...(dispatchPin
+        // Payload fields stay file/system_image-only (spec §3.1) even though
+        // storage_identity is now stamped for every target above.
+        ...(target.commandType === 'backup_run'
           ? {
               baseSnapshotId: dispatchPin.baseSnapshotId,
-              publishLeaseExpiresAt: dispatchPin.publishLeaseExpiresAt.toISOString(),
+              publishLeaseExpiresAt: dispatchPin.publishLeaseExpiresAt!.toISOString(),
             }
           : {}),
         ...target.payload,
@@ -972,7 +1011,9 @@ export const REAPER_DOMAINS = [
 
 **Files:** Modify `apps/api/src/jobs/backupWorker.ts:77-130` (`createBackupWorker`), `:325-395` (`processCleanupExpiredSnapshots`). Test: `apps/api/src/jobs/backupWorker.test.ts`.
 
-**Why this task must land before Task 9:** Task 9 restructures `cleanupExpiredSnapshots` (in `backupRetention.ts`) to open its own real per-row transaction via `withSystemDbAccessContext`. That only works if the call arrives with NO ambient context already open — today it's nested inside the blanket `runWithSystemDbAccess(async () => { switch(...) {...} })` at `backupWorker.ts:101`, where a nested `withSystemDbAccessContext` call is a no-op passthrough (same outer transaction, no new commit boundary). This task removes that ambient wrap for `cleanup-expired-snapshots` the same way `dispatch-backup` is already excluded from it (`:89-99`), and gives the GC sweep call its own separate context so a sweep failure can never roll back a retirement Task 9 already committed.
+**Interfaces — authoritative call shape for W02 (corrected per coordinator's second review pass):** this task's restructure of `processCleanupExpiredSnapshots` is the contract W02 builds on. After row-level retention has committed per row (Task 9), the handler wraps the sweep in exactly **ONE** shared context — `await runWithSystemDbAccess(() => sweepUnreferencedBackupObjects())` — matching today's read shape so `sweepUnreferencedBackupObjects`'s existing internal `db.select(...)` calls keep the working GUCs they rely on today (they have no context management of their own — Ground Truth, `backupRetention.ts:982`). This is deliberately ONE context for the whole sweep, not per-identity — W02 is expected to replace this single wrap with genuinely separate per-identity contexts internally (spec §3.7 item 2: "a separate system context per identity for the DB reads, with every storage call at depth 0"), at which point this call site's wrap is removed and the per-identity splitting moves inside `sweepUnreferencedBackupObjects` itself. This task adds no new fields to `processCleanupExpiredSnapshots`'s returned/logged result shape (`gcDeleted`/`gcSkippedIdentities`/`gcBlockedIdentities` only) — W02 is the one expected to add fields there as its own internal restructuring surfaces more detail.
+
+**Why this task must land before Task 9:** Task 9 restructures `cleanupExpiredSnapshots` (in `backupRetention.ts`) to open its own real per-row transaction via `withSystemDbAccessContext`. That only works if the call arrives with NO ambient context already open — today it's nested inside the blanket `runWithSystemDbAccess(async () => { switch(...) {...} })` at `backupWorker.ts:101`, where a nested `withSystemDbAccessContext` call is a no-op passthrough (same outer transaction, no new commit boundary). This task removes that ambient wrap for `cleanup-expired-snapshots` the same way `dispatch-backup` is already excluded from it (`:89-99`), while the sweep call — which runs strictly AFTER every row's retention has already committed independently — gets its own single, separate context (see Interfaces above), so a sweep failure can never roll back a retirement that already committed.
 
 - [ ] Step 1: Write the failing test — a source-text contract test, mirroring the style of `backupAgentContract.test.ts`'s cross-file literal checks, since this is a structural wiring invariant rather than a behavior a mock can observe.
 
@@ -1098,8 +1139,16 @@ export async function processCleanupExpiredSnapshots(): Promise<{
   let gcSkippedIdentities = 0;
   let gcBlockedIdentities = 0;
   try {
-    // Its own context, separate from every retention row's — a GC failure
-    // must never roll back a retirement that has already committed.
+    // D18 §3.7 (authoritative shape for W02, corrected): ONE shared context
+    // for the whole sweep — matches today's read shape, so
+    // sweepUnreferencedBackupObjects's existing internal db.select(...) calls
+    // keep the working GUCs they rely on (it has no context management of
+    // its own). This runs strictly AFTER every row's retention has already
+    // committed independently (Task 9), so a GC failure here can never roll
+    // back a retirement that already committed, and a GC failure never fails
+    // this job. W02 replaces this single wrap with genuinely separate
+    // per-identity contexts managed inside sweepUnreferencedBackupObjects
+    // itself.
     const gcResult = await runWithSystemDbAccess(() => sweepUnreferencedBackupObjects());
     gcDeleted = gcResult.deleted;
     gcSkippedIdentities = gcResult.skippedIdentities;
@@ -1133,8 +1182,8 @@ export async function processCleanupExpiredSnapshots(): Promise<{
 **Files:** Modify `apps/api/src/jobs/backupRetention.ts:9-31` (imports), `:159-171` (`RetentionCleanupResult`), `:189-221` (`deleteSnapshotRow`/`tryDeleteSnapshotRow`, rewritten), `:231-387` (`cleanupExpiredSnapshots`, read/pin/delete phases re-wrapped). Test: `apps/api/src/jobs/backupRetention.test.ts`.
 
 **Interfaces:**
-- Consumes: `withSystemDbAccessContext` from `../db`; `resolveBackupRestorePinLingerMs`/`resolveBackupPublishMarginMs` from `../services/backupGcKnobs`; `restoreJobs`, `backupSnapshotRetirements`, `IN_FLIGHT_BACKUP_JOB_STATUSES` from `../db/schema/backup`; `recoveryTokens` from `../db/schema/recoveryTokens`; `gt` added to the `drizzle-orm` import.
-- Produces: `RetentionCleanupResult` gains `skippedPinned: number`. `tryDeleteSnapshotRow` now returns `'deleted' | 'pinned' | 'failed'` (was `boolean`) and opens its own `withSystemDbAccessContext` per call — one real top-level transaction per candidate row, per §3.7.
+- Consumes: `withSystemDbAccessContext` from `../db`; `resolveBackupRestorePinLingerMs`/`resolveBackupPublishMarginMs` from `../services/backupGcKnobs`; `restoreJobs`, `backupSnapshotRetirements`, `IN_FLIGHT_BACKUP_JOB_STATUSES` from `../db/schema` (the barrel — resolved open question 3: `backupRetention.test.ts:34` mocks `'../db'` only, not `'../db/schema'`, and this file's existing imports already pull `backupSnapshots`/`backupPolicies`/`backupJobs`/`configPolicyBackupSettings`/`backupConfigs` from that same barrel, so the new symbols join that one import statement rather than a separate `'../db/schema/backup'` line); `recoveryTokens` from `../db/schema/recoveryTokens` (a direct, non-barrel import — the same convention `backupWorker.ts:24` already uses for this specific table); `gt` and `sql` added to the `drizzle-orm` import.
+- Produces: `RetentionCleanupResult` gains `skippedPinned: number` AND `skippedUnresolved: number` (review fix). `tryDeleteSnapshotRow` now returns `'deleted' | 'pinned' | 'legalHold' | 'immutable' | 'unresolved' | 'failed'` (was `boolean`) and opens its own `withSystemDbAccessContext` per call — one real top-level transaction per candidate row, per §3.7. Legal-hold and immutability are now decided ONLY inside `deleteSnapshotRow`, re-read under the `FOR UPDATE` lock — the caller's enumeration-pass copy of those columns is no longer trusted (review fix). A row whose `storageIdentity` is `NULL` is skipped (not retired with an invented identity — the `unknown::<uuid>` fallback is removed entirely) and counted as `skippedUnresolved`; it is retried on a later run once identity resolves. Every lookup that matches a snapshot by its bare (agent-supplied) `snapshotId` string is scoped by `storageIdentity` too, since `backup_snapshots.snapshot_id` carries no uniqueness constraint (`schema/backup.ts:330`, `snapshotIdIdx` is a plain, non-unique index) — a bare `snapshotId` match alone is not guaranteed to identify one row.
 
 - [ ] Step 1: Write the failing test — update the shared `chainable`/`mockDb` fixture first (it currently has no `.for()`, no `insert`, and the `'../db'` mock exports only `db`):
 
@@ -1189,8 +1238,8 @@ describe('cleanupExpiredSnapshots — pins + retirement (D18 W01 §3.2/§3.3/§3
       id: 'snap-1', snapshotId: 'snap-1-provider', metadata: null, legalHold: false,
       isImmutable: false, immutableUntil: null, provider: 's3', providerConfig: {},
       orgId: 'org-1', configId: 'config-1', deviceId: 'device-1', storageIdentity: 's3::e::b', backupType: 'file',
-    }]); // candidate select
-    selectQueue.push([{ id: 'snap-1' }]); // FOR UPDATE lock
+    }]); // candidate select (enumeration pass)
+    selectQueue.push([{ id: 'snap-1', legalHold: false, isImmutable: false, immutableUntil: null }]); // FOR UPDATE lock, re-reads legal hold/immutability
     selectQueue.push([{ id: 'job-1' }]); // backup pin — found, short-circuits
     selectQueue.push([]); // versionBoundSnapshots pass (empty)
 
@@ -1206,8 +1255,8 @@ describe('cleanupExpiredSnapshots — pins + retirement (D18 W01 §3.2/§3.3/§3
       id: 'snap-2', snapshotId: 'snap-2-provider', metadata: null, legalHold: false,
       isImmutable: false, immutableUntil: null, provider: 's3', providerConfig: { bucket: 'b', endpoint: 'e' },
       orgId: 'org-1', configId: 'config-1', deviceId: 'device-1', storageIdentity: 's3::e::b', backupType: 'file',
-    }]); // candidate select
-    selectQueue.push([{ id: 'snap-2' }]); // FOR UPDATE lock
+    }]); // candidate select (enumeration pass)
+    selectQueue.push([{ id: 'snap-2', legalHold: false, isImmutable: false, immutableUntil: null }]); // FOR UPDATE lock
     selectQueue.push([]); // backup pin — none
     selectQueue.push([]); // restore pin — none
     selectQueue.push([]); // recovery pin — none
@@ -1221,10 +1270,44 @@ describe('cleanupExpiredSnapshots — pins + retirement (D18 W01 §3.2/§3.3/§3
       expect.objectContaining({ snapshotId: 'snap-2-provider', storageIdentity: 's3::e::b', reason: 'expired' }),
     ]);
   });
+
+  it('re-reads legal hold under the FOR UPDATE lock, ignoring the (stale) enumeration-pass value', async () => {
+    // Enumeration pass saw legalHold: false — the row was placed under hold
+    // AFTER enumeration but BEFORE this row's turn. The lock re-read must win.
+    selectQueue.push([{
+      id: 'snap-3', snapshotId: 'snap-3-provider', metadata: null, legalHold: false,
+      isImmutable: false, immutableUntil: null, provider: 's3', providerConfig: {},
+      orgId: 'org-1', configId: 'config-1', deviceId: 'device-1', storageIdentity: 's3::e::b', backupType: 'file',
+    }]);
+    selectQueue.push([{ id: 'snap-3', legalHold: true, isImmutable: false, immutableUntil: null }]); // FOR UPDATE lock — now held
+    selectQueue.push([]); // versionBoundSnapshots pass (empty)
+
+    const result = await cleanupExpiredSnapshots('org-1');
+
+    expect(result.skippedLegalHold).toBe(1);
+    expect(result.deleted).toBe(0);
+    expect(insertedRows.length).toBe(0);
+  });
+
+  it('skips (does not retire) a row with an unresolved storage_identity and counts it as skippedUnresolved', async () => {
+    selectQueue.push([{
+      id: 'snap-4', snapshotId: 'snap-4-provider', metadata: null, legalHold: false,
+      isImmutable: false, immutableUntil: null, provider: 's3', providerConfig: {},
+      orgId: 'org-1', configId: null, deviceId: 'device-1', storageIdentity: null, backupType: 'file',
+    }]);
+    selectQueue.push([{ id: 'snap-4', legalHold: false, isImmutable: false, immutableUntil: null }]); // FOR UPDATE lock
+    selectQueue.push([]); // versionBoundSnapshots pass (empty)
+
+    const result = await cleanupExpiredSnapshots('org-1');
+
+    expect(result.skippedUnresolved).toBe(1);
+    expect(result.deleted).toBe(0);
+    expect(insertedRows.length).toBe(0); // no invented 'unknown::<uuid>' retirement is ever written
+  });
 });
 ```
 
-- [ ] Step 2: Run it, expect FAIL — `result.skippedPinned` is `undefined` (field doesn't exist yet); `insertedRows` stays empty in the second case (no retirement is written today).
+- [ ] Step 2: Run it, expect FAIL — `result.skippedPinned`/`result.skippedUnresolved` are `undefined` (fields don't exist yet); `insertedRows` stays empty in the second case (no retirement is written today); the legal-hold re-read case fails because today's code decides legal hold from the enumeration pass, before the FOR UPDATE lock select is even issued.
   Command: `cd apps/api && npx vitest run src/jobs/backupRetention.test.ts`
 
 - [ ] Step 3: Implement
@@ -1242,21 +1325,27 @@ import {
   restoreJobs,
   backupSnapshotRetirements,
   IN_FLIGHT_BACKUP_JOB_STATUSES,
-} from '../db/schema/backup';
+} from '../db/schema';
 import { recoveryTokens } from '../db/schema/recoveryTokens';
-import { eq, and, or, lt, gt, desc, inArray, isNull } from 'drizzle-orm';
+import { eq, and, or, lt, gt, desc, inArray, isNull, sql } from 'drizzle-orm';
 import { resolveBackupRestorePinLingerMs, resolveBackupPublishMarginMs } from '../services/backupGcKnobs';
 ```
 
-  (`configPolicyBackupSettings`/`backupConfigs`/`backupPolicies`/`backupSnapshots`/`backupJobs` were previously imported from `'../db/schema'` (the barrel) — switching `restoreJobs`/`backupSnapshotRetirements`/`IN_FLIGHT_BACKUP_JOB_STATUSES` to the concrete `'../db/schema/backup'` module avoids a barrel/mock mismatch in `backupRetention.test.ts`'s `vi.mock('../db/schema', ...)` if one exists — confirm during implementation whether the file's existing imports already come from `'../db/schema'` or `'../db/schema/backup'` and match that convention exactly rather than mixing styles.)
+  (Resolved: `backupRetention.test.ts:34` only mocks `vi.mock('../db', () => ({ db: mockDb }))` — there is no `vi.mock('../db/schema', ...)` in this file at all, so real schema symbols always flow through regardless of which schema path they're imported from. The existing imports (`backupSnapshots`/`backupPolicies`/`backupJobs`/`configPolicyBackupSettings`/`backupConfigs`) already come from the barrel `'../db/schema'`, so `restoreJobs`/`backupSnapshotRetirements`/`IN_FLIGHT_BACKUP_JOB_STATUSES` join that same statement rather than introducing a second, `'../db/schema/backup'`-rooted import for the same underlying module.)
 
 ```ts
-// apps/api/src/jobs/backupRetention.ts:159-171 — RetentionCleanupResult gains a field
+// apps/api/src/jobs/backupRetention.ts:159-171 — RetentionCleanupResult gains fields
 export type RetentionCleanupResult = {
   deleted: number;
   skippedLegalHold: number;
   skippedImmutable: number;
   skippedPinned: number;
+  // D18 review fix: a row whose storage_identity is unresolved (NULL) is
+  // never retired with an invented identity — it is retried on a later run
+  // once identity resolves (a live write stamping it, or W02's sweep
+  // self-heal). Counted separately from skippedPinned so operators can see
+  // "how many rows are stuck on identity resolution" distinctly.
+  skippedUnresolved: number;
   prunedByMaxVersions: number;
   failed: number;
 };
@@ -1264,18 +1353,38 @@ export type RetentionCleanupResult = {
 
 ```ts
 // apps/api/src/jobs/backupRetention.ts:189-221 — replace deleteSnapshotRow + tryDeleteSnapshotRow
+type DeleteSnapshotOutcome = 'deleted' | 'pinned' | 'legalHold' | 'immutable' | 'unresolved';
+
 /**
- * Deletes a `backup_snapshots` ROW ONLY, after checking every pin type (D18
- * §3.2: backup-job base pin via publish_lease_expires_at + margin, restore-job
- * pin, recovery-token pin — legal hold/immutability are checked by the caller
- * before this is ever invoked) and writing a durable retirement tombstone
- * (backup_snapshot_retirements) in the SAME per-row system context as the
- * delete. The caller (`tryDeleteSnapshotRow`) wraps this whole function in its
- * own `withSystemDbAccessContext` call — since `cleanupExpiredSnapshots` is no
+ * Deletes a `backup_snapshots` ROW ONLY, after RE-READING legal hold /
+ * immutability under the row's own `FOR UPDATE` lock (review fix — the
+ * caller's enumeration-pass copy of those columns can be stale by the time
+ * this row's turn comes up: a hold set or cleared in between must be honored
+ * NOW, not then), checking every pin type (D18 §3.2: backup-job base pin via
+ * publish_lease_expires_at + margin, restore-job pin, recovery-token pin),
+ * and writing a durable retirement tombstone (backup_snapshot_retirements) in
+ * the SAME per-row system context as the delete. The caller
+ * (`tryDeleteSnapshotRow`) wraps this whole function in its own
+ * `withSystemDbAccessContext` call — since `cleanupExpiredSnapshots` is no
  * longer invoked from inside any ambient transaction (D18 §3.7,
  * jobs/backupWorker.ts), that call opens a REAL top-level Postgres
  * transaction distinct from every other row's, so a retirement written here
  * commits durably before the next candidate row is even considered.
+ *
+ * A row whose `storage_identity` is NULL is never retired with an invented
+ * identity (review fix — the earlier `unknown::<uuid>` fallback is removed
+ * entirely): a retirement's uniqueness and every lookup against it is keyed
+ * on `(storage_identity, snapshot_id)`, and a fabricated identity would let
+ * two genuinely different unresolved rows collide, or hand GC an identity it
+ * can never match against a real bucket listing. Such a row is left alone
+ * (`'unresolved'`) and retried on a later run once identity resolves.
+ *
+ * Every lookup that matches a row by the bare (agent-supplied) `snapshotId`
+ * string is additionally scoped by `storageIdentity`, since
+ * `backup_snapshots.snapshot_id` carries no uniqueness constraint
+ * (`schema/backup.ts:330` — `snapshotIdIdx` is a plain, non-unique index): a
+ * bare string match alone is not guaranteed to identify the row this
+ * function is actually retiring.
  *
  * Deliberately does NOT touch object storage — under the incremental/
  * synthetic-full manifest model, an incremental snapshot's unchanged files
@@ -1287,10 +1396,6 @@ export type RetentionCleanupResult = {
  * writes is what lets that sweep treat this snapshot's exclusive objects as
  * garbage immediately, with no age-based ambiguity between "expired" and
  * merely "orphaned".
- *
- * Returns 'pinned' (left alone, a pin is still live) or 'deleted' (row
- * removed and retirement written, or the row was already gone — a no-op
- * treated as success).
  */
 async function deleteSnapshotRow(params: {
   id: string;
@@ -1301,14 +1406,20 @@ async function deleteSnapshotRow(params: {
   storageIdentity: string | null;
   backupType: (typeof backupSnapshots.$inferSelect)['backupType'];
   reason: 'expired' | 'max_versions';
-}): Promise<'pinned' | 'deleted'> {
+}): Promise<DeleteSnapshotOutcome> {
+  const now = new Date();
   const restoreLingerMs = resolveBackupRestorePinLingerMs();
   const restoreLingerCutoff = new Date(Date.now() - restoreLingerMs);
   const publishMarginMs = resolveBackupPublishMarginMs();
   const publishMarginCutoff = new Date(Date.now() - publishMarginMs);
 
   const [locked] = await db
-    .select({ id: backupSnapshots.id })
+    .select({
+      id: backupSnapshots.id,
+      legalHold: backupSnapshots.legalHold,
+      isImmutable: backupSnapshots.isImmutable,
+      immutableUntil: backupSnapshots.immutableUntil,
+    })
     .from(backupSnapshots)
     .where(eq(backupSnapshots.id, params.id))
     .for('update');
@@ -1318,17 +1429,26 @@ async function deleteSnapshotRow(params: {
     return 'deleted';
   }
 
+  // Re-read under the lock — authoritative, not the enumeration pass's copy.
+  if (locked.legalHold) return 'legalHold';
+  if (locked.isImmutable && locked.immutableUntil && locked.immutableUntil > now) return 'immutable';
+
+  if (!params.storageIdentity) return 'unresolved';
+  const storageIdentity = params.storageIdentity;
+
   // Backup pin (§3.1/§3.2): a backup_jobs row still building on this snapshot
-  // as its base. status IN (pending, running) covers an in-flight run;
-  // publish_lease_expires_at > now() - margin covers a reaped-but-still-
-  // uploading helper (the same lease+margin the helper itself enforces
-  // before publishing — see spec §3.1's "publish margin").
+  // as its base, SCOPED BY storageIdentity (a bare snapshotId match is not
+  // enough — see docstring). status IN (pending, running) covers an
+  // in-flight run; publish_lease_expires_at > now() - margin covers a
+  // reaped-but-still-uploading helper (the same lease+margin the helper
+  // itself enforces before publishing — see spec §3.1's "publish margin").
   const [backupPin] = await db
     .select({ id: backupJobs.id })
     .from(backupJobs)
     .where(
       and(
         eq(backupJobs.baseSnapshotId, params.snapshotId),
+        eq(backupJobs.storageIdentity, storageIdentity),
         or(
           inArray(backupJobs.status, IN_FLIGHT_BACKUP_JOB_STATUSES),
           gt(backupJobs.publishLeaseExpiresAt, publishMarginCutoff),
@@ -1338,11 +1458,12 @@ async function deleteSnapshotRow(params: {
     .limit(1);
   if (backupPin) return 'pinned';
 
-  // Restore pin (§3.2, F8): the in-flight status check only counts once a
-  // command exists (a commandless pending row is reaped by
-  // staleCommandReaper's own 1h rule, Task 7, instead of pinning forever);
-  // the linger separately covers both that crash window and a helper reading
-  // past the server's restore timeout.
+  // Restore pin (§3.2, F8): scoped by the row's own uuid (backupSnapshots.id)
+  // — unambiguous already, no storageIdentity scoping needed here. The
+  // in-flight status check only counts once a command exists (a commandless
+  // pending row is reaped by staleCommandReaper's own 1h rule, Task 7,
+  // instead of pinning forever); the linger separately covers both that
+  // crash window and a helper reading past the server's restore timeout.
   const [restorePin] = await db
     .select({ id: restoreJobs.id })
     .from(restoreJobs)
@@ -1358,9 +1479,9 @@ async function deleteSnapshotRow(params: {
     .limit(1);
   if (restorePin) return 'pinned';
 
-  // Recovery pin (§3.2): active/authenticated token, or one not yet
-  // completed and still within its expiry + the same linger (covers a BMR
-  // session mid-download).
+  // Recovery pin (§3.2): also scoped by the row's own uuid — unambiguous.
+  // Active/authenticated token, or one not yet completed and still within
+  // its expiry + the same linger (covers a BMR session mid-download).
   const [recoveryPin] = await db
     .select({ id: recoveryTokens.id })
     .from(recoveryTokens)
@@ -1381,7 +1502,7 @@ async function deleteSnapshotRow(params: {
     configId: params.configId,
     deviceId: params.deviceId,
     snapshotId: params.snapshotId,
-    storageIdentity: params.storageIdentity ?? `unknown::${params.id}`,
+    storageIdentity,
     backupType: params.backupType,
     reason: params.reason,
   });
@@ -1410,7 +1531,7 @@ async function tryDeleteSnapshotRow(snap: {
   storageIdentity: string | null;
   backupType: (typeof backupSnapshots.$inferSelect)['backupType'];
   reason: 'expired' | 'max_versions';
-}): Promise<'deleted' | 'pinned' | 'failed'> {
+}): Promise<DeleteSnapshotOutcome | 'failed'> {
   try {
     return await withSystemDbAccessContext(() => deleteSnapshotRow(snap));
   } catch (error) {
@@ -1430,7 +1551,22 @@ async function tryDeleteSnapshotRow(snap: {
 
 ```ts
 // apps/api/src/jobs/backupRetention.ts:231-387 — cleanupExpiredSnapshots, both read phases
-// wrapped in their own context, both delete loops updated to the new outcome type
+// wrapped in their own context, both delete loops route through the same
+// outcome-to-counter mapping. Legal hold / immutability are NO LONGER decided
+// here (review fix) — the enumeration selects below still fetch those columns
+// only because groupRows/versionBoundSnapshots still needs other row fields;
+// the authoritative decision is made inside deleteSnapshotRow, under the lock.
+function applyDeleteOutcome(result: RetentionCleanupResult, outcome: DeleteSnapshotOutcome | 'failed'): void {
+  switch (outcome) {
+    case 'deleted': result.deleted++; break;
+    case 'pinned': result.skippedPinned++; break;
+    case 'legalHold': result.skippedLegalHold++; break;
+    case 'immutable': result.skippedImmutable++; break;
+    case 'unresolved': result.skippedUnresolved++; break;
+    case 'failed': result.failed++; break;
+  }
+}
+
 export async function cleanupExpiredSnapshots(
   orgId: string
 ): Promise<RetentionCleanupResult> {
@@ -1440,32 +1576,27 @@ export async function cleanupExpiredSnapshots(
     skippedLegalHold: 0,
     skippedImmutable: 0,
     skippedPinned: 0,
+    skippedUnresolved: 0,
     prunedByMaxVersions: 0,
     failed: 0,
   };
 
   // D18 §3.7: this read runs with no ambient context (cleanupExpiredSnapshots
   // is no longer called from inside one) — a snapshot-in-time read is fine
-  // here since every candidate is independently re-verified with FOR UPDATE
-  // inside its own per-row commit below.
+  // here since every candidate is independently re-verified (legal hold,
+  // immutability, storage identity, every pin) with FOR UPDATE inside its own
+  // per-row commit below.
   const expired = await withSystemDbAccessContext(() =>
     db
       .select({
         id: backupSnapshots.id,
         snapshotId: backupSnapshots.snapshotId,
-        metadata: backupSnapshots.metadata,
-        legalHold: backupSnapshots.legalHold,
-        isImmutable: backupSnapshots.isImmutable,
-        immutableUntil: backupSnapshots.immutableUntil,
-        provider: backupConfigs.provider,
-        providerConfig: backupConfigs.providerConfig,
         deviceId: backupSnapshots.deviceId,
         configId: backupSnapshots.configId,
         storageIdentity: backupSnapshots.storageIdentity,
         backupType: backupSnapshots.backupType,
       })
       .from(backupSnapshots)
-      .leftJoin(backupConfigs, eq(backupSnapshots.configId, backupConfigs.id))
       .where(
         and(
           eq(backupSnapshots.orgId, orgId),
@@ -1475,17 +1606,6 @@ export async function cleanupExpiredSnapshots(
   );
 
   for (const snap of expired) {
-    if (snap.legalHold) {
-      result.skippedLegalHold++;
-      console.warn(`[BackupRetention] Snapshot ${snap.snapshotId} held by legal hold — skipping deletion`);
-      continue;
-    }
-    if (snap.isImmutable && snap.immutableUntil && snap.immutableUntil > now) {
-      result.skippedImmutable++;
-      console.warn(`[BackupRetention] Snapshot ${snap.snapshotId} immutable until ${snap.immutableUntil.toISOString()} — skipping deletion`);
-      continue;
-    }
-
     const outcome = await tryDeleteSnapshotRow({
       id: snap.id,
       snapshotId: snap.snapshotId,
@@ -1496,9 +1616,7 @@ export async function cleanupExpiredSnapshots(
       backupType: snap.backupType,
       reason: 'expired',
     });
-    if (outcome === 'deleted') result.deleted++;
-    else if (outcome === 'pinned') result.skippedPinned++;
-    else result.failed++;
+    applyDeleteOutcome(result, outcome);
   }
 
   const versionBoundSnapshots = await withSystemDbAccessContext(() =>
@@ -1509,19 +1627,12 @@ export async function cleanupExpiredSnapshots(
         timestamp: backupSnapshots.timestamp,
         deviceId: backupSnapshots.deviceId,
         configId: backupSnapshots.configId,
-        metadata: backupSnapshots.metadata,
-        legalHold: backupSnapshots.legalHold,
-        isImmutable: backupSnapshots.isImmutable,
-        immutableUntil: backupSnapshots.immutableUntil,
-        provider: backupConfigs.provider,
-        providerConfig: backupConfigs.providerConfig,
         storageIdentity: backupSnapshots.storageIdentity,
         backupType: backupSnapshots.backupType,
         retention: configPolicyBackupSettings.retention,
       })
       .from(backupSnapshots)
       .innerJoin(backupJobs, eq(backupSnapshots.jobId, backupJobs.id))
-      .leftJoin(backupConfigs, eq(backupSnapshots.configId, backupConfigs.id))
       .leftJoin(
         configPolicyBackupSettings,
         eq(backupJobs.featureLinkId, configPolicyBackupSettings.featureLinkId),
@@ -1548,15 +1659,6 @@ export async function cleanupExpiredSnapshots(
     if (!maxVersions || maxVersions < 1 || groupRows.length <= maxVersions) continue;
 
     for (const snap of groupRows.slice(maxVersions)) {
-      if (snap.legalHold) {
-        result.skippedLegalHold++;
-        continue;
-      }
-      if (snap.isImmutable && snap.immutableUntil && snap.immutableUntil > now) {
-        result.skippedImmutable++;
-        continue;
-      }
-
       const outcome = await tryDeleteSnapshotRow({
         id: snap.id,
         snapshotId: snap.snapshotId,
@@ -1567,25 +1669,20 @@ export async function cleanupExpiredSnapshots(
         backupType: snap.backupType,
         reason: 'max_versions',
       });
-      if (outcome === 'deleted') {
-        result.deleted++;
-        result.prunedByMaxVersions++;
-      } else if (outcome === 'pinned') {
-        result.skippedPinned++;
-      } else {
-        result.failed++;
-      }
+      if (outcome === 'deleted') result.prunedByMaxVersions++;
+      applyDeleteOutcome(result, outcome);
     }
   }
 
   if (
     result.deleted > 0 || result.skippedLegalHold > 0 || result.skippedImmutable > 0 ||
-    result.skippedPinned > 0 || result.prunedByMaxVersions > 0 || result.failed > 0
+    result.skippedPinned > 0 || result.skippedUnresolved > 0 || result.prunedByMaxVersions > 0 || result.failed > 0
   ) {
     console.log(
       `[BackupRetention] Org ${orgId}: deleted ${result.deleted}, ` +
       `skipped ${result.skippedLegalHold} (legal hold), ${result.skippedImmutable} (immutable), ` +
-      `${result.skippedPinned} (pinned), pruned ${result.prunedByMaxVersions} by maxVersions` +
+      `${result.skippedPinned} (pinned), ${result.skippedUnresolved} (unresolved identity), ` +
+      `pruned ${result.prunedByMaxVersions} by maxVersions` +
       (result.failed > 0 ? `, FAILED ${result.failed} delete(s) (see prior per-row errors — will retry next run)` : '')
     );
   }
@@ -1602,6 +1699,8 @@ export async function cleanupExpiredSnapshots(
 }
 ```
 
+  Note: `applyDeleteOutcome` double-counts `'deleted'` into `prunedByMaxVersions` deliberately in the max-versions loop (increment `prunedByMaxVersions` first, then call the shared helper which ALSO increments `deleted`) — this mirrors the pre-existing behavior where a max-versions prune counts as both a deletion and a prune, unchanged from before this task.
+
 - [ ] Step 4: Run, expect PASS
   Command: `cd apps/api && npx vitest run src/jobs/backupRetention.test.ts`
 
@@ -1612,22 +1711,32 @@ export async function cleanupExpiredSnapshots(
 
 ### Task 10: Lineage on write — `resultSchemas.ts` + `backupResultPersistence.ts` + late-result fence
 
-**Files:** Modify `apps/api/src/routes/backup/resultSchemas.ts:27-32`, `apps/api/src/services/backupResultPersistence.ts:1041-1051` (widen `updatedJob` select), `:972-981` area (new pre-check before the main UPDATE), `:1143-1162` (`snapshotValues`). Test: `apps/api/src/services/backupResultPersistence.test.ts`.
+**Files:** Modify `apps/api/src/routes/backup/resultSchemas.ts:27-32`, `apps/api/src/services/backupResultPersistence.ts:1041-1051` (widen `updatedJob` select), `:972-981` area (new pre-check before the main UPDATE), `:1143-1162` (`snapshotValues`); `apps/api/src/jobs/queueSchemas.ts` (`backupSnapshotSummarySchema`, `.strict()`); `apps/api/src/jobs/backupEnqueue.ts` (`ProcessResultsResult.snapshot` interface). Test: `apps/api/src/services/backupResultPersistence.test.ts`, plus a new queue-round-trip regression test.
 
 **Interfaces:**
 - Produces: `backupSnapshotResultSchema` gains `baseSnapshotId?: string`, `formatVersion?: number`, `backupIdentity?: string`.
-- Produces: `backupSnapshots.parentSnapshotId`/`.isIncremental`/`.storageIdentity` are now set on every successful write; `storageIdentity` is **copied from the job's own stamped `storageIdentity`** (Task 6), never recomputed from the config.
-- Produces: a late result for a reaped-terminal job is rejected with `errorLog` containing `publish_lease_expired` or `base_retired` when the fence fails.
+- Produces: `backupSnapshots.parentSnapshotId`/`.isIncremental`/`.storageIdentity` are now set on every successful write; `storageIdentity` is **copied from the job's own stamped `storageIdentity`** (Task 6), never recomputed from the config; the base-row lookup for `parentSnapshotId` is scoped by `(storageIdentity, snapshotId)`, not `(configId, snapshotId)` — `snapshot_id` carries no uniqueness constraint (review fix, `schema/backup.ts:330`).
+- Produces: a late result for a reaped-terminal job is rejected with `errorLog` containing `publish_lease_expired` (also fires when the lease is NULL — review fix, no implicit pass) or `base_retired` when the fence fails. The whole check-and-write happens inside one `db.transaction` with `FOR UPDATE` on the job row, scoped by `(id, deviceId)` matching the file's own #3036 tenant-scoping convention (review fix — atomic against a concurrently running `staleCommandReaper` pass, and never keyed on job id alone).
+- **P1 queue-schema propagation (review finding):** `apps/api/src/jobs/queueSchemas.ts`'s `backupSnapshotSummarySchema` is `.strict()` and does not yet declare `baseSnapshotId`/`formatVersion`/`backupIdentity` — every one of this task's new fields is silently stripped (or the whole `.strict()` parse throws) before `backupWorker.ts`'s `process-results` handler (`parseQueueJobData` at `:81`) or the earlier `enqueueBackupResults` call in `backupEnqueue.ts` ever sees them, making the lineage fields dead on arrival end to end. This task widens `backupSnapshotSummarySchema` (queue ingress/egress validation) AND the plain TS interface `ProcessResultsResult.snapshot` (`backupEnqueue.ts:105-115`, which has no `baseSnapshotId`/`formatVersion` fields today either) to match `resultSchemas.ts`'s `backupSnapshotResultSchema` shape, and adds a regression test proving a result carrying these fields survives an `enqueueBackupResults` → `parseQueueJobData` round trip.
 
 - [ ] Step 1: Write the failing test
 
 ```ts
-// apps/api/src/services/backupResultPersistence.test.ts — new cases (mirror this file's existing mocking style)
+// apps/api/src/services/backupResultPersistence.test.ts — new cases (mirror this file's existing mocking style;
+// capture the object passed to db.insert(backupSnapshots).values(...) / db.update(backupSnapshots).set(...) via
+// this file's existing insert/update capture mechanism — read the file's current tests for the exact spy shape
+// before writing, since it wasn't fully quoted in Ground Truth)
   it('sets parentSnapshotId/isIncremental/storageIdentity from the job and result (D18 W01)', async () => {
     // Arrange: updatedJob's widened .returning() resolves { id, orgId, configId,
     // backupType, backupMode, baseSnapshotId: 'snap-1', publishLeaseExpiresAt: <future>,
     // storageIdentity: 's3::e::b' }; a lookup for the base row by
-    // (configId, snapshotId='snap-1') returns { id: 'base-db-id' }.
+    // (storageIdentity='s3::e::b', snapshotId='snap-1') returns { id: 'base-db-id' }.
+    let capturedSnapshotValues: Record<string, unknown> | undefined;
+    // Wire this file's backupSnapshots insert/update mock to capture its argument:
+    //   mockDb.insert.mockImplementation((table) => table === backupSnapshots
+    //     ? { values: (v: Record<string, unknown>) => { capturedSnapshotValues = v; return chainable([{ id: 'new-snap-db-id' }]); } }
+    //     : defaultInsertChain(table));
+
     const result = await applyBackupCommandResultToJob({
       jobId: 'job-1', orgId: 'org-1', deviceId: 'device-1', resultStatus: 'completed',
       result: {
@@ -1638,15 +1747,19 @@ export async function cleanupExpiredSnapshots(
     });
 
     expect(result.applied).toBe(true);
-    // Assert the values passed to the backup_snapshots insert/update carried
-    // parentSnapshotId = 'base-db-id', isIncremental = true, and
-    // storageIdentity = 's3::e::b' (copied straight from the job row, no
-    // config re-lookup) — via this file's existing capture mechanism.
+    // Discriminating assertions (review fix — applied===true alone proves
+    // nothing about lineage correctness):
+    expect(capturedSnapshotValues?.parentSnapshotId).toBe('base-db-id');
+    expect(capturedSnapshotValues?.isIncremental).toBe(true);
+    expect(capturedSnapshotValues?.storageIdentity).toBe('s3::e::b');
   });
 
   it('fails a late result with publish_lease_expired when the job is reaped-terminal and its lease has passed', async () => {
-    // Arrange: job row is 'failed' with STALE_BACKUP_REAP_MARKER,
-    // publishLeaseExpiresAt in the past.
+    // Arrange: job row (returned by the FOR UPDATE select mock) is 'failed'
+    // with STALE_BACKUP_REAP_MARKER, publishLeaseExpiresAt in the past.
+    let capturedUpdateSet: Record<string, unknown> | undefined;
+    // Wire mockDb.update(backupJobs).set(...) to capture its argument.
+
     const result = await applyBackupCommandResultToJob({
       jobId: 'job-2', orgId: 'org-1', deviceId: 'device-1', resultStatus: 'completed',
       result: { snapshotId: 'snap-3', snapshot: { id: 'snap-3' }, filesBackedUp: 1, bytesBackedUp: 1 } as any,
@@ -1654,15 +1767,34 @@ export async function cleanupExpiredSnapshots(
     });
 
     expect(result.applied).toBe(true);
-    // The job's own row should have been updated to status 'failed' with
-    // errorLog containing 'publish_lease_expired', NOT flipped to completed.
+    expect(result.snapshotDbId).toBeNull();
+    expect(capturedUpdateSet?.status).toBe('failed');
+    expect(capturedUpdateSet?.errorLog).toContain('publish_lease_expired');
+  });
+
+  it('fails a late result with publish_lease_expired when the lease is NULL (review fix: no implicit pass)', async () => {
+    // Arrange: job row is 'failed' with STALE_BACKUP_REAP_MARKER,
+    // publishLeaseExpiresAt: null (anomalous/legacy — must fail closed, not
+    // be treated as "no fence applies").
+    let capturedUpdateSet: Record<string, unknown> | undefined;
+
+    const result = await applyBackupCommandResultToJob({
+      jobId: 'job-2b', orgId: 'org-1', deviceId: 'device-1', resultStatus: 'completed',
+      result: { snapshotId: 'snap-3b', snapshot: { id: 'snap-3b' }, filesBackedUp: 1, bytesBackedUp: 1 } as any,
+      source: 'agent',
+    });
+
+    expect(result.applied).toBe(true);
+    expect(capturedUpdateSet?.errorLog).toContain('publish_lease_expired');
   });
 
   it('fails a late result with base_retired when the lease is live but the base row is gone', async () => {
     // Arrange: job row is 'failed' with STALE_BACKUP_REAP_MARKER,
-    // publishLeaseExpiresAt in the future, baseSnapshotId set, and the
-    // lookup for that snapshotId finds NO row (retired + swept, or never
-    // existed).
+    // publishLeaseExpiresAt in the future, baseSnapshotId set, storageIdentity
+    // set, and the (storageIdentity, snapshotId)-scoped lookup finds NO row
+    // (retired + swept, or never existed).
+    let capturedUpdateSet: Record<string, unknown> | undefined;
+
     const result = await applyBackupCommandResultToJob({
       jobId: 'job-3', orgId: 'org-1', deviceId: 'device-1', resultStatus: 'completed',
       result: { snapshotId: 'snap-4', snapshot: { id: 'snap-4' }, filesBackedUp: 1, bytesBackedUp: 1 } as any,
@@ -1670,7 +1802,24 @@ export async function cleanupExpiredSnapshots(
     });
 
     expect(result.applied).toBe(true);
-    // errorLog should contain 'base_retired'.
+    expect(capturedUpdateSet?.errorLog).toContain('base_retired');
+  });
+
+  it('does not fence a late result for a DIFFERENT device carrying the same job id (device predicate, review fix)', async () => {
+    // Arrange: no row matches (id=jobId AND deviceId='device-1') because the
+    // real job row belongs to a different device — the FOR UPDATE select
+    // returns undefined, so the fence must not fire at all (falls through
+    // to the pre-existing terminalJobGuard/statusGuard behavior on the main
+    // UPDATE, unrelated to this fence).
+    const result = await applyBackupCommandResultToJob({
+      jobId: 'job-4', orgId: 'org-1', deviceId: 'device-1', resultStatus: 'completed',
+      result: { snapshotId: 'snap-5', snapshot: { id: 'snap-5' }, filesBackedUp: 1, bytesBackedUp: 1 } as any,
+      source: 'agent',
+    });
+    // No fence-triggered update should have happened; whatever `result`
+    // ultimately is depends on the main UPDATE's own device-scoped guard,
+    // not on this fence firing.
+    expect(result.applied).toBe(false);
   });
 ```
 
@@ -1714,26 +1863,36 @@ export const backupSnapshotResultSchema = z.object({
 // apps/api/src/services/backupResultPersistence.ts — new helper, placed above applyBackupCommandResultToJob
 /**
  * D18 §3.1 late-result fence: a result for a job already in the reaped
- * 'failed' terminal status (STALE_BACKUP_REAP_MARKER) is accepted only if
- * its publish_lease_expires_at has not yet passed AND (it has no base pin,
- * or its base row still exists and is not retired). Otherwise the caller
- * must record the result as failed with a distinguishing reason instead of
- * flipping the job to completed — the manifest the agent uploaded may
- * reference storage GC has already started reclaiming.
+ * 'failed' terminal status (STALE_BACKUP_REAP_MARKER) is accepted only if its
+ * publish_lease_expires_at is STRICTLY IN THE FUTURE (review fix: a NULL
+ * lease is now a REJECT, not an implicit pass — every job this wave dispatches
+ * always carries one, so NULL on a reaped-terminal job is anomalous/legacy
+ * and must fail closed) AND (it has no base pin, or its base row still
+ * exists — scoped by the JOB's own storage_identity, since
+ * backup_snapshots.snapshot_id carries no uniqueness constraint,
+ * schema/backup.ts:330 — and is not retired). Otherwise the caller must
+ * record the result as failed with a distinguishing reason instead of
+ * flipping the job to completed.
  */
 async function checkLateResultBaseFence(job: {
   baseSnapshotId: string | null;
   publishLeaseExpiresAt: Date | null;
+  storageIdentity: string | null;
 }): Promise<{ ok: true } | { ok: false; reason: 'publish_lease_expired' | 'base_retired' }> {
-  if (job.publishLeaseExpiresAt && job.publishLeaseExpiresAt.getTime() < Date.now()) {
+  if (!job.publishLeaseExpiresAt || job.publishLeaseExpiresAt.getTime() <= Date.now()) {
     return { ok: false, reason: 'publish_lease_expired' };
   }
   if (!job.baseSnapshotId) return { ok: true };
 
   const [baseRow] = await db
-    .select({ id: backupSnapshots.id, storageIdentity: backupSnapshots.storageIdentity })
+    .select({ id: backupSnapshots.id })
     .from(backupSnapshots)
-    .where(eq(backupSnapshots.snapshotId, job.baseSnapshotId))
+    .where(
+      and(
+        eq(backupSnapshots.snapshotId, job.baseSnapshotId),
+        eq(backupSnapshots.storageIdentity, job.storageIdentity ?? ''),
+      ),
+    )
     .limit(1);
   if (!baseRow) return { ok: false, reason: 'base_retired' };
 
@@ -1742,7 +1901,7 @@ async function checkLateResultBaseFence(job: {
     .from(backupSnapshotRetirements)
     .where(
       and(
-        eq(backupSnapshotRetirements.storageIdentity, baseRow.storageIdentity ?? ''),
+        eq(backupSnapshotRetirements.storageIdentity, job.storageIdentity ?? ''),
         eq(backupSnapshotRetirements.snapshotId, job.baseSnapshotId),
       ),
     )
@@ -1756,40 +1915,56 @@ async function checkLateResultBaseFence(job: {
 // BEFORE the main `db.update(backupJobs)...` (before :1041), when source === 'agent' and isSuccessResult:
 
   if (source === 'agent' && isSuccessResult) {
-    const [currentJob] = await db
-      .select({
-        status: backupJobs.status,
-        errorLog: backupJobs.errorLog,
-        baseSnapshotId: backupJobs.baseSnapshotId,
-        publishLeaseExpiresAt: backupJobs.publishLeaseExpiresAt,
-      })
-      .from(backupJobs)
-      .where(eq(backupJobs.id, jobId))
-      .limit(1);
+    // Review fix: the whole read-decide-write sequence runs inside ONE
+    // transaction with a FOR UPDATE lock on the job row, so the status check,
+    // fence evaluation, and (on failure) the write are atomic against a
+    // concurrently running staleCommandReaper pass — without the lock, the
+    // reaper could re-decide the job's terminal state between this read and
+    // this write. The predicate mirrors the file's own #3036 tenant-scoping
+    // convention (eq(id) AND eq(deviceId) — see the main UPDATE at :1044):
+    // job id alone is not trusted as a sufficient key anywhere else in this
+    // file, and this new code must not be the one exception.
+    const fenceOutcome = await db.transaction(async (tx) => {
+      const [currentJob] = await tx
+        .select({
+          status: backupJobs.status,
+          errorLog: backupJobs.errorLog,
+          baseSnapshotId: backupJobs.baseSnapshotId,
+          publishLeaseExpiresAt: backupJobs.publishLeaseExpiresAt,
+          storageIdentity: backupJobs.storageIdentity,
+        })
+        .from(backupJobs)
+        .where(and(eq(backupJobs.id, jobId), eq(backupJobs.deviceId, deviceId)))
+        .for('update');
 
-    const isReapedTerminal =
-      currentJob?.status === 'failed' &&
-      typeof currentJob.errorLog === 'string' &&
-      currentJob.errorLog.includes(STALE_BACKUP_REAP_MARKER);
+      const isReapedTerminal =
+        currentJob?.status === 'failed' &&
+        typeof currentJob.errorLog === 'string' &&
+        currentJob.errorLog.includes(STALE_BACKUP_REAP_MARKER);
 
-    if (isReapedTerminal) {
+      if (!isReapedTerminal) return null;
+
       const fence = await checkLateResultBaseFence(currentJob);
-      if (!fence.ok) {
-        const detail =
-          fence.reason === 'publish_lease_expired'
-            ? 'its publish lease had already expired'
-            : 'its dedupe base was reclaimed';
-        await db
-          .update(backupJobs)
-          .set({
-            status: 'failed',
-            completedAt: new Date(),
-            updatedAt: new Date(),
-            errorLog: `${fence.reason}: late result rejected — ${detail} before this result arrived`,
-          })
-          .where(eq(backupJobs.id, jobId));
-        return { applied: true, snapshotDbId: null, providerSnapshotId };
-      }
+      if (fence.ok) return null;
+
+      const detail =
+        fence.reason === 'publish_lease_expired'
+          ? 'its publish lease had already expired'
+          : 'its dedupe base was reclaimed';
+      await tx
+        .update(backupJobs)
+        .set({
+          status: 'failed',
+          completedAt: new Date(),
+          updatedAt: new Date(),
+          errorLog: `${fence.reason}: late result rejected — ${detail} before this result arrived`,
+        })
+        .where(and(eq(backupJobs.id, jobId), eq(backupJobs.deviceId, deviceId)));
+      return fence.reason;
+    });
+
+    if (fenceOutcome) {
+      return { applied: true, snapshotDbId: null, providerSnapshotId };
     }
   }
 ```
@@ -1798,11 +1973,21 @@ async function checkLateResultBaseFence(job: {
 // apps/api/src/services/backupResultPersistence.ts:1143-1162 — snapshotValues gains lineage fields
   let parentSnapshotId: string | null = null;
   const baseSnapshotId = result.snapshot?.baseSnapshotId;
-  if (updatedJob.configId && baseSnapshotId) {
+  if (updatedJob.storageIdentity && baseSnapshotId) {
+    // Scoped by storageIdentity, not configId (review fix): snapshot_id
+    // carries no uniqueness constraint (schema/backup.ts:330), and identity
+    // — not configId — is the authoritative scope GC and every other lookup
+    // in this wave use. A config's identity can also drift after the base
+    // was written (§3.6), so configId is not even a reliable proxy here.
     const [baseRow] = await db
       .select({ id: backupSnapshots.id })
       .from(backupSnapshots)
-      .where(and(eq(backupSnapshots.configId, updatedJob.configId), eq(backupSnapshots.snapshotId, baseSnapshotId)))
+      .where(
+        and(
+          eq(backupSnapshots.storageIdentity, updatedJob.storageIdentity),
+          eq(backupSnapshots.snapshotId, baseSnapshotId),
+        ),
+      )
       .limit(1);
     parentSnapshotId = baseRow?.id ?? null;
   }
@@ -1838,21 +2023,96 @@ async function checkLateResultBaseFence(job: {
   } as const;
 ```
 
-  Add `backupSnapshotRetirements` to this file's imports (`import { backupSnapshotRetirements } from '../db/schema/backup';`); `STALE_BACKUP_REAP_MARKER` is already imported (`:11`).
+  Add `backupSnapshotRetirements` to this file's EXISTING barrel import (`apps/api/src/services/backupResultPersistence.ts:3-12`, which already pulls `backupJobs`/`backupSnapshotFiles`/`backupSnapshots`/`backupPolicies`/`configPolicyBackupSettings`/`backupConfigs`/`IN_FLIGHT_BACKUP_JOB_STATUSES`/`STALE_BACKUP_REAP_MARKER` from `'../db/schema'`) — do not add a second, separate `'../db/schema/backup'` import line for the same table.
+
+**P1 review finding — queue schema propagation.** Everything above is dead on arrival without this: `apps/api/src/jobs/queueSchemas.ts`'s `backupSnapshotSummarySchema` is `.strict()` and `apps/api/src/jobs/backupEnqueue.ts`'s `ProcessResultsResult.snapshot` is a plain TS interface — NEITHER declares `baseSnapshotId`/`formatVersion`/`backupIdentity` today, so the fields this task adds to `resultSchemas.ts`'s WS-ingress schema are stripped (or the whole `.strict()` parse throws) before `backupWorker.ts`'s `process-results` handler ever sees them.
+
+```ts
+// apps/api/src/jobs/queueSchemas.ts — widen backupSnapshotSummarySchema (the block starting
+// "const backupSnapshotSummarySchema = z.object({")
+const backupSnapshotSummarySchema = z.object({
+  id: z.string().min(1),
+  timestamp: z.string().min(1).optional(),
+  size: z.number().nonnegative().optional(),
+  files: z.array(backupSnapshotFileSchema).optional(),
+  // D18 (#5429/§3.1): mirrors resultSchemas.ts's backupSnapshotResultSchema —
+  // must be added here too or `.strict()` drops/rejects these before
+  // backupWorker.ts's process-results handler ever sees them.
+  baseSnapshotId: z.string().optional(),
+  formatVersion: z.number().optional(),
+  backupIdentity: z.string().optional(),
+}).strict();
+```
+
+```ts
+// apps/api/src/jobs/backupEnqueue.ts:105-115 — widen the ProcessResultsResult.snapshot interface
+  snapshot?: {
+    id: string;
+    timestamp?: string;
+    size?: number;
+    files?: Array<{
+      sourcePath: string;
+      backupPath: string;
+      size?: number;
+      modTime?: string;
+    }>;
+    // D18 (#5429/§3.1): must mirror backupSnapshotSummarySchema above, or
+    // agentWs.ts's caller can construct a ProcessResultsResult carrying these
+    // fields (from the parsed WS ingress payload) that TypeScript happily
+    // accepts here, then loses at the very next hop when
+    // backupQueueJobDataSchema.parse(...) strict-validates it.
+    baseSnapshotId?: string;
+    formatVersion?: number;
+    backupIdentity?: string;
+  };
+```
+
+- [ ] Queue-propagation regression test:
+
+```ts
+// apps/api/src/jobs/backupEnqueue.test.ts (or co-located queueSchemas.test.ts — confirm which
+// file already covers backupQueueJobDataSchema round-trips and add there)
+  it('round-trips baseSnapshotId/formatVersion/backupIdentity through enqueueBackupResults (D18 W01)', async () => {
+    // Uses backupQueueJobDataSchema.parse directly (the same schema both
+    // enqueueBackupResults and backupWorker.ts's parseQueueJobData use) so
+    // this test exercises the actual contract without needing a running
+    // BullMQ queue.
+    const payload = backupQueueJobDataSchema.parse({
+      type: 'process-results',
+      jobId: 'job-1',
+      orgId: 'org-1',
+      deviceId: 'device-1',
+      result: {
+        status: 'completed',
+        snapshotId: 'snap-1',
+        snapshot: { id: 'snap-1', baseSnapshotId: 'snap-0', formatVersion: 2, backupIdentity: 's3::e::b' },
+      },
+      actorType: 'agent',
+      actorId: null,
+      source: 'route:agentWs:backup-result',
+    });
+
+    expect(payload.result.snapshot?.baseSnapshotId).toBe('snap-0');
+    expect(payload.result.snapshot?.formatVersion).toBe(2);
+    expect(payload.result.snapshot?.backupIdentity).toBe('s3::e::b');
+  });
+```
+
+  Run it BEFORE the widening above to confirm it fails with a Zod `.strict()` "unrecognized key(s)" error, then after to confirm PASS: `cd apps/api && npx vitest run src/jobs/backupEnqueue.test.ts` (adjust path once the exact existing test file covering `backupQueueJobDataSchema` is confirmed).
 
 - [ ] Step 4: Run, expect PASS
-  Command: `cd apps/api && npx vitest run src/services/backupResultPersistence.test.ts`
+  Command: `cd apps/api && npx vitest run src/services/backupResultPersistence.test.ts src/jobs/backupEnqueue.test.ts`
 
 - [ ] Step 5: Commit
-  `git add apps/api/src/routes/backup/resultSchemas.ts apps/api/src/services/backupResultPersistence.ts apps/api/src/services/backupResultPersistence.test.ts && git commit -m "feat(backup): lineage fields on write + publish-lease/base-retirement late-result fence (D18 W01 §3.1)"`
+  `git add apps/api/src/routes/backup/resultSchemas.ts apps/api/src/services/backupResultPersistence.ts apps/api/src/services/backupResultPersistence.test.ts apps/api/src/jobs/queueSchemas.ts apps/api/src/jobs/backupEnqueue.ts && git commit -m "feat(backup): lineage fields on write + late-result fence + queue-schema propagation (D18 W01 §3.1)"`
 
 ---
 
 ### Task 11: Reconcile — forward lineage, refuse retired/too-old/base-missing adoption
 
-**Files:** Modify `apps/api/src/services/backupSnapshotReconcile.ts:135-155` (`ReconcileSkipReason`), `:538-585` (`manifestToCommandResult`), `:669-720` (new pre-loop retired-id lookup + in-loop checks), `:864-882` (new base-existence check after the manifest parses). Test: `apps/api/src/services/backupSnapshotReconcile.test.ts`.
+**Files:** Modify `apps/api/src/services/backupSnapshotReconcile.ts:135-155` (`ReconcileSkipReason`), `:538-585` (`manifestToCommandResult`), `:669-720` (new pre-loop retired-id lookup + in-loop checks), the `ClaimingJob` type + `loadClaimsAndSharing` query + the `claimingJob` branch of the per-candidate loop (new "late-result-fenced" check — locate by searching `ADOPTABLE_JOB_STATUSES.includes` in this file), `:864-882` (new base-existence check after the manifest parses). Test: `apps/api/src/services/backupSnapshotReconcile.test.ts`.
 
-**Interfaces:** Consumes `backupSnapshotRetirements` schema. `RECONCILE_ORPHAN_HALF_WINDOW_MS` is a local literal (half of the 9-day default `BACKUP_GC_ORPHAN_MANIFEST_MAX_AGE_MS`, which doesn't exist as a named knob until W02) with a `TODO(W02)` to replace it once `backupGcKnobs.ts` grows that export.
+**Interfaces:** Consumes `backupSnapshotRetirements` schema. `RECONCILE_ORPHAN_HALF_WINDOW_MS` is a local literal (half of the 9-day default `BACKUP_GC_ORPHAN_MANIFEST_MAX_AGE_MS`, which doesn't exist as a named knob until W02) with a `TODO(W02)` to replace it once `backupGcKnobs.ts` grows that export. **Review fix:** reconcile must also refuse to adopt a job whose late result was already fenced off by Task 10's late-result fence — such a job is `status: 'failed'` with `errorLog` containing `publish_lease_expired` or `base_retired`; re-adopting it via the write-time-window path would resurrect exactly the state the fence exists to prevent. New skip reason `'late-result-fenced'`.
 
 - [ ] Step 1: Write the failing test
 
@@ -1894,6 +2154,16 @@ async function checkLateResultBaseFence(job: {
     expect(candidate?.skipReason).toBe('base-missing');
     expect(candidate?.adopted).toBe(false);
   });
+
+  it('refuses to adopt a job whose late result was already fenced (publish_lease_expired/base_retired)', async () => {
+    // Arrange claims.jobs to include a job-snapshot-id match whose status is
+    // 'failed' and errorLog contains 'base_retired' (Task 10's late-result
+    // fence already fired for this exact job/snapshot pair).
+    const result = await reconcileOrphanedBackupSnapshots({ orgId: 'org-1', configId: 'config-1' });
+    const candidate = result.candidates.find((c) => c.snapshotId === 'FENCED-JOB-SNAP');
+    expect(candidate?.skipReason).toBe('late-result-fenced');
+    expect(candidate?.adopted).toBe(false);
+  });
 ```
 
 - [ ] Step 2: Run it, expect FAIL — `manifestToCommandResult`'s result has no `baseSnapshotId` field, and all three refusal cases adopt instead of skipping.
@@ -1921,7 +2191,12 @@ export type ReconcileSkipReason =
   | 'orphan-too-old-for-adoption'
   /** D18 §3.1/§3.4: the manifest declares a baseSnapshotId with no live,
    *  unretired backup_snapshots row — its references may already dangle. */
-  | 'base-missing';
+  | 'base-missing'
+  /** D18 §3.1 review fix: the claiming job's own late result was already
+   *  rejected by backupResultPersistence.ts's late-result fence
+   *  (errorLog contains publish_lease_expired or base_retired) — re-adopting
+   *  it here would resurrect exactly what that fence exists to prevent. */
+  | 'late-result-fenced';
 ```
 
 ```ts
@@ -1948,8 +2223,9 @@ export type ReconcileSkipReason =
 ```
 
 ```ts
-// apps/api/src/services/backupSnapshotReconcile.ts — new import + constant near the top of the file
-import { backupSnapshotRetirements } from '../db/schema/backup';
+// apps/api/src/services/backupSnapshotReconcile.ts — add backupSnapshotRetirements
+// to the EXISTING barrel import (this file already pulls backupConfigs/
+// backupJobs/backupSnapshots from '../db/schema') rather than a separate line.
 
 // Half of BACKUP_GC_ORPHAN_MANIFEST_MAX_AGE_MS's 9-day default (spec §3.4:
 // "reconcile adopts an orphan only while its manifest is younger than half
@@ -1998,6 +2274,11 @@ const RECONCILE_ORPHAN_HALF_WINDOW_MS = (9 * 24 * 60 * 60 * 1000) / 2;
 
     if (result.snapshot?.baseSnapshotId) {
       const declaredBase = result.snapshot.baseSnapshotId;
+      // WHERE is scoped by storageIdentity too (review fix), not just the
+      // leftJoin condition — backup_snapshots.snapshot_id carries no
+      // uniqueness constraint (schema/backup.ts:330), so without this the
+      // base row lookup itself (not just the retirement check) could match
+      // a same-string snapshot_id belonging to a different identity.
       const [liveBase] = await runInDbContext(() =>
         db
           .select({ id: backupSnapshots.id })
@@ -2009,7 +2290,13 @@ const RECONCILE_ORPHAN_HALF_WINDOW_MS = (9 * 24 * 60 * 60 * 1000) / 2;
               eq(backupSnapshotRetirements.snapshotId, declaredBase),
             ),
           )
-          .where(and(eq(backupSnapshots.snapshotId, declaredBase), isNull(backupSnapshotRetirements.id)))
+          .where(
+            and(
+              eq(backupSnapshots.snapshotId, declaredBase),
+              eq(backupSnapshots.storageIdentity, storageIdentity),
+              isNull(backupSnapshotRetirements.id),
+            ),
+          )
           .limit(1)
       );
       if (!liveBase) {
@@ -2021,7 +2308,27 @@ const RECONCILE_ORPHAN_HALF_WINDOW_MS = (9 * 24 * 60 * 60 * 1000) / 2;
     }
 ```
 
-  Add `inArray`/`isNull` to this file's `drizzle-orm` import if not already present (confirm during implementation — several are already used elsewhere in the file for the claims lookups).
+```ts
+// apps/api/src/services/backupSnapshotReconcile.ts — review fix: refuse a job whose
+// late result was already fenced. Add `errorLog: backupJobs.errorLog` to whatever
+// column-selector `loadClaimsAndSharing` (or its equivalent claims-building query)
+// uses to populate `claims.jobs`'s ClaimingJob values, and widen the ClaimingJob
+// type with `errorLog: string | null`. Then, inside the per-snapshotId loop's
+// `claimingJob` branch — right after the existing
+// `if (!ADOPTABLE_JOB_STATUSES.includes(claimingJob.status as ...))` check and
+// before `adoptable.push(...)` — add:
+
+      if (
+        claimingJob.status === 'failed' &&
+        typeof claimingJob.errorLog === 'string' &&
+        /publish_lease_expired|base_retired/.test(claimingJob.errorLog)
+      ) {
+        skip('late-result-fenced');
+        continue;
+      }
+```
+
+  Add `inArray`/`isNull` to this file's `drizzle-orm` import if not already present (confirm during implementation — several are already used elsewhere in the file for the claims lookups). Verify the exact `ClaimingJob` type definition and `loadClaimsAndSharing`'s query column list against the real file before implementing this block — its precise shape was not fully re-quoted here.
 
 - [ ] Step 4: Run, expect PASS
   Command: `cd apps/api && npx vitest run src/services/backupSnapshotReconcile.test.ts`
@@ -2035,7 +2342,7 @@ const RECONCILE_ORPHAN_HALF_WINDOW_MS = (9 * 24 * 60 * 60 * 1000) / 2;
 
 **Files:** Modify `apps/api/src/routes/backup/configs.ts:440-467`. Test: `apps/api/src/routes/backup/configs.test.ts`.
 
-**Interfaces:** Response from `PATCH /backup/configs/:id` gains an optional `warnings: string[]` field, populated with `'storage_identity_changed'` when the edit changes `normalizeStorageIdentity(provider, providerConfig)` for a config that has at least one `backup_snapshots` row. Never blocks the write.
+**Interfaces:** Response from `PATCH /backup/configs/:id` gains a `warnings: string[]` field, **always present** (possibly empty — a stable contract for the frontend, per coordinator decision), populated with `'storage_identity_changed'` when the edit changes `normalizeStorageIdentity(provider, providerConfig)` for a config that has at least one `backup_snapshots` row. Never blocks the write.
 
 - [ ] Step 1: Write the failing test
 
@@ -2055,7 +2362,7 @@ const RECONCILE_ORPHAN_HALF_WINDOW_MS = (9 * 24 * 60 * 60 * 1000) / 2;
     expect(body.warnings).toEqual(['storage_identity_changed']);
   });
 
-  it('does not warn when the edit does not change storage identity', async () => {
+  it('always includes warnings (empty) when the edit does not change storage identity', async () => {
     // Same config, PATCH body only changes `name`.
     const res = await app.request('/backup/configs/config-1?orgId=org-1', {
       method: 'PATCH',
@@ -2063,7 +2370,7 @@ const RECONCILE_ORPHAN_HALF_WINDOW_MS = (9 * 24 * 60 * 60 * 1000) / 2;
       body: JSON.stringify({ name: 'Renamed' }),
     });
     const body = await res.json();
-    expect(body.warnings ?? []).toEqual([]);
+    expect(body.warnings).toEqual([]);
   });
 ```
 
@@ -2071,6 +2378,13 @@ const RECONCILE_ORPHAN_HALF_WINDOW_MS = (9 * 24 * 60 * 60 * 1000) / 2;
   Command: `cd apps/api && npx vitest run src/routes/backup/configs.test.ts`
 
 - [ ] Step 3: Implement
+
+```ts
+// apps/api/src/routes/backup/configs.ts:13 — widen the existing import (confirmed
+// today: `import { backupConfigs } from '../../db/schema';` — backupSnapshots is
+// NOT currently imported in this file; `eq`/`and` are already imported at :4)
+import { backupConfigs, backupSnapshots } from '../../db/schema';
+```
 
 ```ts
 // apps/api/src/routes/backup/configs.ts — new import
@@ -2104,10 +2418,12 @@ import { normalizeStorageIdentity } from '../../jobs/backupRetention';
       details: { changedFields: Object.keys(payload) },
     });
 
-    return c.json(warnings.length > 0 ? { ...toConfigResponse(row), warnings } : toConfigResponse(row));
+    // Always present (possibly empty) — a stable response shape, per
+    // coordinator decision, rather than an optional field callers must guard.
+    return c.json({ ...toConfigResponse(row), warnings });
 ```
 
-  `backupSnapshots` must already be imported in this route file (it is used elsewhere for other backup routes in this module tree — confirm and add if missing).
+  (Resolved: `backupSnapshots` was NOT already imported in `configs.ts` — confirmed by reading the file's import block; the widened import above adds it.)
 
 - [ ] Step 4: Run, expect PASS
   Command: `cd apps/api && npx vitest run src/routes/backup/configs.test.ts`
@@ -2135,14 +2451,25 @@ import {
   backupJobs,
   backupSnapshots,
   backupSnapshotRetirements,
+  deviceCommands,
   devices,
   organizations,
   partners,
+  recoveryTokens,
+  restoreJobs,
   sites,
 } from '../../db/schema';
 import { cleanupExpiredSnapshots } from '../../jobs/backupRetention';
+import { processCleanupExpiredSnapshots, __testOnly } from '../../jobs/backupWorker';
+import { applyBackupCommandResultToJob } from '../../services/backupResultPersistence';
 
 const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+// Confirm during implementation whether stampDispatchPinAndIdentity (Task 6)
+// needs to be added to backupWorker.ts's existing `__testOnly` export bag —
+// it is a private `async function` today, not exported, and this suite's
+// concurrent-dispatch-vs-retention test needs to call the REAL function
+// (not a hand-rolled copy of its SQL) from outside the module.
 
 async function seedOrgDeviceConfig(unique: string) {
   const [partner] = await db.insert(partners).values({ name: `RP ${unique}`, slug: `rp-${unique}`, type: 'msp', plan: 'pro', status: 'active' }).returning({ id: partners.id });
@@ -2241,6 +2568,203 @@ runDb("one row failing on a unique-constraint collision does not undo an earlier
     expect(collideRows.length).toBe(1); // the colliding row's delete never happened — retried next run
   });
 });
+
+// D18 §3.2 restore pin: WITH a command_id, the in-flight status check pins;
+// WITHOUT one, only the linger pins (a commandless pending row is instead
+// reaped by Task 7's staleCommandReaper rule, not by this pin lasting forever).
+runDb('restore pin holds a snapshot with an in-flight, commanded restore', async () => {
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const ctx = await withSystemDbAccessContext(async () => {
+    const { orgId, deviceId, configId } = await seedOrgDeviceConfig(unique);
+    const [job] = await db.insert(backupJobs).values({ orgId, configId, deviceId, status: 'completed', startedAt: new Date(), completedAt: new Date() }).returning({ id: backupJobs.id });
+    const [snap] = await db.insert(backupSnapshots).values({ orgId, jobId: job!.id, deviceId, configId, snapshotId: `restore-pin-${unique}`, backupType: 'file', storageIdentity: `local::/tmp/gc-test-${unique}`, expiresAt: new Date(Date.now() - 60 * 60 * 1000) }).returning({ id: backupSnapshots.id });
+    const [command] = await db.insert(deviceCommands).values({ deviceId, type: 'backup_restore', payload: {}, status: 'sent' }).returning({ id: deviceCommands.id });
+    await db.insert(restoreJobs).values({ orgId, deviceId, snapshotId: snap!.id, restoreType: 'full', status: 'running', commandId: command!.id });
+    return { orgId, snapId: snap!.id };
+  });
+
+  const result = await cleanupExpiredSnapshots(ctx.orgId);
+  expect(result.skippedPinned).toBeGreaterThanOrEqual(1);
+
+  await withSystemDbAccessContext(async () => {
+    const rows = await db.select().from(backupSnapshots).where(eq(backupSnapshots.id, ctx.snapId));
+    expect(rows.length).toBe(1);
+  });
+});
+
+runDb('a COMMANDLESS pending restore pins only for the linger, not indefinitely', async () => {
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const ctx = await withSystemDbAccessContext(async () => {
+    const { orgId, deviceId, configId } = await seedOrgDeviceConfig(unique);
+    const [job] = await db.insert(backupJobs).values({ orgId, configId, deviceId, status: 'completed', startedAt: new Date(), completedAt: new Date() }).returning({ id: backupJobs.id });
+    const [snap] = await db.insert(backupSnapshots).values({ orgId, jobId: job!.id, deviceId, configId, snapshotId: `commandless-restore-${unique}`, backupType: 'file', storageIdentity: `local::/tmp/gc-test-${unique}`, expiresAt: new Date(Date.now() - 60 * 60 * 1000) }).returning({ id: backupSnapshots.id });
+    // commandId NULL, status pending, created recently — still within the
+    // 7-day-default linger, so the row IS pinned (linger, not status).
+    await db.insert(restoreJobs).values({ orgId, deviceId, snapshotId: snap!.id, restoreType: 'full', status: 'pending', commandId: null, createdAt: new Date() });
+    return { orgId, snapId: snap!.id };
+  });
+
+  const result = await cleanupExpiredSnapshots(ctx.orgId);
+  expect(result.skippedPinned).toBeGreaterThanOrEqual(1);
+});
+
+// D18 §3.2 recovery-token pin: an active/authenticated token, or one not yet
+// completed and still within its expiry + linger, pins the snapshot.
+runDb('recovery-token pin holds a snapshot with an active BMR token', async () => {
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const ctx = await withSystemDbAccessContext(async () => {
+    const { orgId, deviceId, configId } = await seedOrgDeviceConfig(unique);
+    const [job] = await db.insert(backupJobs).values({ orgId, configId, deviceId, status: 'completed', startedAt: new Date(), completedAt: new Date() }).returning({ id: backupJobs.id });
+    const [snap] = await db.insert(backupSnapshots).values({ orgId, jobId: job!.id, deviceId, configId, snapshotId: `recovery-pin-${unique}`, backupType: 'system_image', storageIdentity: `local::/tmp/gc-test-${unique}`, expiresAt: new Date(Date.now() - 60 * 60 * 1000) }).returning({ id: backupSnapshots.id });
+    await db.insert(recoveryTokens).values({
+      orgId, deviceId, snapshotId: snap!.id, tokenHash: `hash-${unique}`, restoreType: 'bare_metal',
+      status: 'active', expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    });
+    return { orgId, snapId: snap!.id };
+  });
+
+  const result = await cleanupExpiredSnapshots(ctx.orgId);
+  expect(result.skippedPinned).toBeGreaterThanOrEqual(1);
+});
+
+// D18 §3.2/§4: the maxVersions prune pass must respect the SAME pins as the
+// expiry pass — a pinned row over the version cap is skipped, not pruned.
+runDb('the max-versions prune pass respects an active base pin', async () => {
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const ctx = await withSystemDbAccessContext(async () => {
+    const { orgId, deviceId, configId } = await seedOrgDeviceConfig(unique);
+    // A configPolicyBackupSettings row with retention.maxVersions=1, linked
+    // via a job's featureLinkId, is required for the maxVersions branch to
+    // fire — construct the minimal chain this test needs; consult
+    // resolveGfsConfigForJob / the maxVersions query in backupRetention.ts
+    // for the exact featureLinkId wiring before finalizing this fixture.
+    const [oldJob] = await db.insert(backupJobs).values({ orgId, configId, deviceId, status: 'completed', startedAt: new Date(Date.now() - 2 * 60 * 60 * 1000), completedAt: new Date(Date.now() - 2 * 60 * 60 * 1000) }).returning({ id: backupJobs.id });
+    const [oldSnap] = await db.insert(backupSnapshots).values({ orgId, jobId: oldJob!.id, deviceId, configId, snapshotId: `mv-old-${unique}`, backupType: 'file', storageIdentity: `local::/tmp/gc-test-${unique}`, timestamp: new Date(Date.now() - 2 * 60 * 60 * 1000) }).returning({ id: backupSnapshots.id });
+    // Pin the OLDER (over-cap) snapshot as an in-flight job's base.
+    await db.insert(backupJobs).values({ orgId, configId, deviceId, status: 'running', baseSnapshotId: `mv-old-${unique}`, publishLeaseExpiresAt: new Date(Date.now() + 60 * 60 * 1000) });
+    return { orgId, oldSnapId: oldSnap!.id };
+  });
+
+  await cleanupExpiredSnapshots(ctx.orgId);
+
+  await withSystemDbAccessContext(async () => {
+    const rows = await db.select().from(backupSnapshots).where(eq(backupSnapshots.id, ctx.oldSnapId));
+    expect(rows.length).toBe(1); // pinned — NOT pruned by maxVersions despite being over cap
+  });
+});
+
+// D18 §3.1 late-result fence, through the real applyBackupCommandResultToJob
+// path (not the mocked unit test) — proves the whole chain end to end: a
+// result arriving after the job's publish lease has expired is rejected.
+runDb('a late result is rejected once its publish lease has expired (real DB)', async () => {
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const ctx = await withSystemDbAccessContext(async () => {
+    const { orgId, deviceId, configId } = await seedOrgDeviceConfig(unique);
+    const [job] = await db.insert(backupJobs).values({
+      orgId, configId, deviceId, status: 'failed',
+      errorLog: '[stale-backup-reaper] reaped: no progress',
+      publishLeaseExpiresAt: new Date(Date.now() - 60 * 1000), // already expired
+      storageIdentity: `local::/tmp/gc-test-${unique}`,
+    }).returning({ id: backupJobs.id });
+    return { orgId, deviceId, jobId: job!.id };
+  });
+
+  const result = await applyBackupCommandResultToJob({
+    jobId: ctx.jobId, orgId: ctx.orgId, deviceId: ctx.deviceId, resultStatus: 'completed',
+    result: { snapshotId: `late-${unique}`, snapshot: { id: `late-${unique}` }, filesBackedUp: 1, bytesBackedUp: 1 } as any,
+    source: 'agent',
+  });
+
+  expect(result.applied).toBe(true);
+  await withSystemDbAccessContext(async () => {
+    const [row] = await db.select().from(backupJobs).where(eq(backupJobs.id, ctx.jobId));
+    expect(row!.status).toBe('failed');
+    expect(row!.errorLog ?? '').toContain('publish_lease_expired');
+    // No backup_snapshots row must have been created for the late result.
+    const snaps = await db.select().from(backupSnapshots).where(eq(backupSnapshots.snapshotId, `late-${unique}`));
+    expect(snaps.length).toBe(0);
+  });
+});
+
+// D18 §3.1 concurrent dispatch vs retention, on TWO SEPARATE connections/
+// transactions racing the SAME snapshot row — proves the lock order (job then
+// snapshot, dispatch side; FOR UPDATE, retention side) leaves no dangling
+// pin: either dispatch sees the pin survive (retention skipped it) or
+// retention wins and dispatch falls back to a full run, never both "dispatch
+// pinned a row retention also deleted."
+runDb('concurrent dispatch-vs-retention on the same row never leaves a dangling pin', async () => {
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const ctx = await withSystemDbAccessContext(async () => {
+    const { orgId, deviceId, configId } = await seedOrgDeviceConfig(unique);
+    const [job] = await db.insert(backupJobs).values({ orgId, configId, deviceId, status: 'completed', startedAt: new Date(), completedAt: new Date() }).returning({ id: backupJobs.id });
+    const [snap] = await db.insert(backupSnapshots).values({ orgId, jobId: job!.id, deviceId, configId, snapshotId: `race-${unique}`, backupType: 'file', storageIdentity: `local::/tmp/gc-test-${unique}`, expiresAt: new Date(Date.now() - 60 * 60 * 1000) }).returning({ id: backupSnapshots.id });
+    const [dispatchJob] = await db.insert(backupJobs).values({ orgId, configId, deviceId, status: 'pending' }).returning({ id: backupJobs.id });
+    return { orgId, deviceId, configId, snapId: snap!.id, dispatchJobId: dispatchJob!.id };
+  });
+
+  // Race the two real code paths concurrently — NOT two manually-opened raw
+  // connections, since the point is to prove the actual functions
+  // (stampDispatchPinAndIdentity via a minimal harness, and
+  // cleanupExpiredSnapshots) interleave safely under Postgres's real lock
+  // semantics, not to hand-roll the SQL twice. Import
+  // `stampDispatchPinAndIdentity` — confirm during implementation whether it
+  // needs exporting from backupWorker.ts (it is `async function`, not
+  // exported today) via `__testOnly`, mirroring the existing
+  // `__testOnly.processDispatchBackup` pattern.
+  const [dispatchOutcome] = await Promise.all([
+    withSystemDbAccessContext(() => __testOnly.stampDispatchPinAndIdentity({
+      deviceId: ctx.deviceId, configId: ctx.configId, jobId: ctx.dispatchJobId,
+      mode: 'file', provider: 'local', providerConfig: { path: `/tmp/gc-test-${unique}` },
+    })),
+    cleanupExpiredSnapshots(ctx.orgId),
+  ]);
+
+  await withSystemDbAccessContext(async () => {
+    if (dispatchOutcome.baseSnapshotId === `race-${unique}`) {
+      // Dispatch won: the snapshot row must still exist (retention saw the pin).
+      const rows = await db.select().from(backupSnapshots).where(eq(backupSnapshots.id, ctx.snapId));
+      expect(rows.length).toBe(1);
+    } else {
+      // Retention won: dispatch must have fallen back to a full run, and the
+      // dispatch job's own base_snapshot_id must be NULL, not dangling.
+      expect(dispatchOutcome.baseSnapshotId).toBe('');
+      const [dispatchJobRow] = await db.select().from(backupJobs).where(eq(backupJobs.id, ctx.dispatchJobId));
+      expect(dispatchJobRow!.baseSnapshotId).toBeNull();
+    }
+  });
+});
+
+// D18 §6(6b) / §3.7 — run through the actual WORKER HANDLER
+// (processCleanupExpiredSnapshots: per-org retention loop → sweep → the D17
+// final throw), not just cleanupExpiredSnapshots directly, proving the
+// worker-level restructuring (Task 8) really does leave earlier retirements
+// committed even when the run as a whole ends in the D17 throw.
+runDb('processCleanupExpiredSnapshots: an org with a failing row still commits every other retirement, then throws', async () => {
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const ctx = await withSystemDbAccessContext(async () => {
+    const { orgId, deviceId, configId } = await seedOrgDeviceConfig(unique);
+    const identity = `local::/tmp/gc-test-${unique}`;
+    const [job1] = await db.insert(backupJobs).values({ orgId, configId, deviceId, status: 'completed', startedAt: new Date(), completedAt: new Date() }).returning({ id: backupJobs.id });
+    const [okSnap] = await db.insert(backupSnapshots).values({ orgId, jobId: job1!.id, deviceId, configId, snapshotId: `worker-ok-${unique}`, backupType: 'file', storageIdentity: identity, expiresAt: new Date(Date.now() - 60 * 60 * 1000) }).returning({ id: backupSnapshots.id });
+    const [job2] = await db.insert(backupJobs).values({ orgId, configId, deviceId, status: 'completed', startedAt: new Date(), completedAt: new Date() }).returning({ id: backupJobs.id });
+    const [failSnap] = await db.insert(backupSnapshots).values({ orgId, jobId: job2!.id, deviceId, configId, snapshotId: `worker-fail-${unique}`, backupType: 'file', storageIdentity: identity, expiresAt: new Date(Date.now() - 60 * 60 * 1000) }).returning({ id: backupSnapshots.id });
+    // Pre-seed the retirement row the second row's own insert will collide on.
+    await db.insert(backupSnapshotRetirements).values({ orgId, configId, deviceId, snapshotId: `worker-fail-${unique}`, storageIdentity: identity, backupType: 'file', reason: 'manual' });
+    return { orgId, okSnapId: okSnap!.id, failSnapId: failSnap!.id };
+  });
+
+  // processCleanupExpiredSnapshots iterates ALL orgs with expired snapshots
+  // (module-level, not scoped to ctx.orgId) — the D17 throw at the end is
+  // expected given the seeded collision.
+  await expect(processCleanupExpiredSnapshots()).rejects.toThrow(/snapshot row delete\(s\) failed/);
+
+  await withSystemDbAccessContext(async () => {
+    const okRows = await db.select().from(backupSnapshots).where(eq(backupSnapshots.id, ctx.okSnapId));
+    expect(okRows.length).toBe(0); // committed despite the throw happening after it
+    const failRows = await db.select().from(backupSnapshots).where(eq(backupSnapshots.id, ctx.failSnapId));
+    expect(failRows.length).toBe(1); // this one legitimately failed and is retried next run
+  });
+});
 ```
 
 ```ts
@@ -2248,27 +2772,39 @@ runDb("one row failing on a unique-constraint collision does not undo an earlier
 import './setup';
 
 import { expect, it } from 'vitest';
-import { db, withDbAccessContext, withSystemDbAccessContext } from '../../db';
-import { backupConfigs, backupSnapshotRetirements, devices, organizations, partners, sites } from '../../db/schema';
+import { db, withDbAccessContext, withSystemDbAccessContext, type DbAccessContext } from '../../db';
+import { backupConfigs, backupSnapshotRetirements, devices, sites } from '../../db/schema';
+import { createOrganization, createPartner } from './db-utils';
 
 const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+// Real DbAccessContext shape (apps/api/src/db/index.ts:124-129) has NO
+// `partnerId` field — an earlier draft of this test used
+// `{ scope, orgId, partnerId: null }`, which is not a real field on the type
+// at all (it would simply be ignored, silently defeating the forge's intent
+// to prove RLS, not "TypeScript accepted an object literal"). Mirrors the
+// established `orgContext` helper convention used elsewhere in this suite
+// (e.g. agentRollbackRls.integration.test.ts:12).
+function orgContext(orgId: string): DbAccessContext {
+  return { scope: 'organization', orgId, accessibleOrgIds: [orgId], accessiblePartnerIds: [], userId: null };
+}
 
 // D18 §3.3: shape-1 RLS forge — an org-scoped context for org B must not be
 // able to insert (or read) a retirement row stamped with org A's id.
 runDb('forges a cross-tenant insert on backup_snapshot_retirements and gets 42501', async () => {
   const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   const { orgAId, orgBId, configId, deviceId } = await withSystemDbAccessContext(async () => {
-    const [partner] = await db.insert(partners).values({ name: `RLSP ${unique}`, slug: `rlsp-${unique}`, type: 'msp', plan: 'pro', status: 'active' }).returning({ id: partners.id });
-    const [orgA] = await db.insert(organizations).values({ currencyCode: 'USD', partnerId: partner!.id, name: `RLSA ${unique}`, slug: `rlsa-${unique}`, type: 'customer', status: 'active' }).returning({ id: organizations.id });
-    const [orgB] = await db.insert(organizations).values({ currencyCode: 'USD', partnerId: partner!.id, name: `RLSB ${unique}`, slug: `rlsb-${unique}`, type: 'customer', status: 'active' }).returning({ id: organizations.id });
-    const [site] = await db.insert(sites).values({ orgId: orgA!.id, name: `RLSS ${unique}` }).returning({ id: sites.id });
-    const [device] = await db.insert(devices).values({ orgId: orgA!.id, siteId: site!.id, agentId: `rlsa-agent-${unique}`, hostname: `rlsa-host-${unique}`, osType: 'windows', osVersion: '11', architecture: 'x86_64', agentVersion: '0.0.0-test', status: 'online' }).returning({ id: devices.id });
-    const [config] = await db.insert(backupConfigs).values({ orgId: orgA!.id, name: `RLSC ${unique}`, type: 'file', provider: 'local', providerConfig: {} }).returning({ id: backupConfigs.id });
-    return { orgAId: orgA!.id, orgBId: orgB!.id, configId: config!.id, deviceId: device!.id };
+    const partner = await createPartner();
+    const orgA = await createOrganization({ partnerId: partner.id });
+    const orgB = await createOrganization({ partnerId: partner.id });
+    const [site] = await db.insert(sites).values({ orgId: orgA.id, name: `RLSS ${unique}` }).returning({ id: sites.id });
+    const [device] = await db.insert(devices).values({ orgId: orgA.id, siteId: site!.id, agentId: `rlsa-agent-${unique}`, hostname: `rlsa-host-${unique}`, osType: 'windows', osVersion: '11', architecture: 'x86_64', agentVersion: '0.0.0-test', status: 'online' }).returning({ id: devices.id });
+    const [config] = await db.insert(backupConfigs).values({ orgId: orgA.id, name: `RLSC ${unique}`, type: 'file', provider: 'local', providerConfig: {} }).returning({ id: backupConfigs.id });
+    return { orgAId: orgA.id, orgBId: orgB.id, configId: config!.id, deviceId: device!.id };
   });
 
   await expect(
-    withDbAccessContext({ scope: 'organization', orgId: orgBId, partnerId: null }, () =>
+    withDbAccessContext(orgContext(orgBId), () =>
       db.insert(backupSnapshotRetirements).values({
         orgId: orgAId, // forged: org B's context, org A's row
         configId,
@@ -2279,14 +2815,21 @@ runDb('forges a cross-tenant insert on backup_snapshot_retirements and gets 4250
         reason: 'manual',
       })
     )
-  ).rejects.toMatchObject({ code: '42501' });
+    // Review fix (SQLSTATE assertion must read the wrapped cause): a Drizzle
+    // `.insert(...)` call's rejection wraps the real Postgres error under
+    // `.cause`, NOT a top-level `.code` — confirmed against
+    // agentRollbackRls.integration.test.ts:105 (`{ cause: { code: '23505' } }`).
+    // A raw `db.execute(sql\`...\`)` call gets `.code` directly instead
+    // (same file, :128) — this test uses the Drizzle insert form, so it must
+    // use the wrapped form.
+  ).rejects.toMatchObject({ cause: { code: '42501' } });
 });
 ```
 
-  Confirm `withDbAccessContext`'s exact parameter shape (`{ scope, orgId, partnerId }` or similar) against `apps/api/src/db/index.ts:525-554` before finalizing — mirror whatever an existing RLS-forge integration test in this repo already uses (e.g. search `rejects.toMatchObject({ code: '42501' })` across `__tests__/integration/`) rather than guessing the context-object shape from scratch.
+  Confirm `createOrganization`/`createPartner`'s exact option shape against `apps/api/src/__tests__/integration/db-utils.ts:106,146` before finalizing (both already used by numerous other suites in this directory).
 
 - [ ] Step 2: Run it, expect FAIL against the current code (before Tasks 1-9 land) or PASS trivially once run after — this task is naturally the LAST implementation task, so by the time it's written Tasks 1-11 should already be in place; if any of these tests fail unexpectedly at this point, that's a real defect in an earlier task, not a sequencing artifact.
-  Command: `cd apps/api && DATABASE_URL=postgresql://breeze:breeze@localhost:5432/breeze npx vitest run --config vitest.integration.config.ts src/__tests__/integration/backupRetentionPins.integration.test.ts src/__tests__/integration/backupSnapshotRetirementsRls.integration.test.ts`
+  Command (NO `DATABASE_URL` override — see Task 14's correction on why the dev DB URL must never be passed to the integration runner): `cd apps/api && npx vitest run --config vitest.integration.config.ts src/__tests__/integration/backupRetentionPins.integration.test.ts src/__tests__/integration/backupSnapshotRetirementsRls.integration.test.ts`
 
 - [ ] Step 3: (No separate implement step — these tests exercise Tasks 1-11's already-implemented code.)
 
@@ -2301,29 +2844,57 @@ runDb('forges a cross-tenant insert on backup_snapshot_retirements and gets 4250
 ### Task 14: Wave verification
 
 - [ ] `cd apps/api && npx tsc --noEmit` (or `pnpm --filter @breeze/api exec tsc --noEmit` — no dedicated `typecheck` script exists in `apps/api/package.json`, confirmed).
-- [ ] `cd apps/api && npx vitest run src/services/backupGcKnobs.test.ts src/jobs/backupWorker.test.ts src/jobs/staleCommandReaper.test.ts src/jobs/backupRetention.test.ts src/services/backupResultPersistence.test.ts src/services/backupSnapshotReconcile.test.ts src/routes/backup/configs.test.ts`.
-- [ ] `pnpm db:check-drift`
-- [ ] `cd apps/api && DATABASE_URL=postgresql://breeze:breeze@localhost:5432/breeze npx vitest run --config vitest.integration.config.ts src/__tests__/integration/backupRetentionPins.integration.test.ts src/__tests__/integration/backupSnapshotRetirementsRls.integration.test.ts`
+- [ ] `cd apps/api && npx vitest run src/services/backupGcKnobs.test.ts src/jobs/backupWorker.test.ts src/jobs/staleCommandReaper.test.ts src/jobs/backupRetention.test.ts src/services/backupResultPersistence.test.ts src/services/backupSnapshotReconcile.test.ts src/routes/backup/configs.test.ts src/jobs/backupEnqueue.test.ts`.
+- [ ] `pnpm db:migrate && pnpm db:migrate` against a disposable local DB — second run applies zero migrations (idempotency; NOT what `db:check-drift` checks — see Task 2's Step 1 correction).
+- [ ] `pnpm db:check-drift` — verifies migration-ledger parity only (every file in `apps/api/migrations/` has one `breeze_migrations` row); run it because it's the standing gate for any new migration file, not because it proves schema correctness.
+- [ ] Integration tests — run with NO `DATABASE_URL` override (the safe default in `apps/api/src/__tests__/integration/setup.ts` already points at the dedicated test database, `postgresql://breeze_test:breeze_test@localhost:5433/breeze_test`; `apps/api/src/testUtils/integrationDatabaseSafety.ts` actively REFUSES a connection string on port 5432 or with a database name other than `breeze_test(_*)`, so the dev DB URL used elsewhere in this repo's docs must never be passed here):
+  `cd apps/api && npx vitest run --config vitest.integration.config.ts src/__tests__/integration/backupRetentionPins.integration.test.ts src/__tests__/integration/backupSnapshotRetirementsRls.integration.test.ts`
 - [ ] Contract suites this wave's registry edits are graded against (tenancy/cascade code was touched — run these before PR per CLAUDE.md):
-  - `find apps/api/src -iname "tenantCascade*integration*"` then `npx vitest run <path>` against a real DB.
+  - `find apps/api/src -iname "tenantCascade*integration*"` then `npx vitest run <path>` against the same test DB (no `DATABASE_URL` override needed).
   - `apps/api/src/routes/devices/*.test.ts` matching `cascade`/`moveOrg` (both device-side lists fail in the unit job since they read the Drizzle schema statically — no live DB required).
-  - `apps/api/src/services/tenantExportPolicyRegistry`'s check script/integration test (`grep -n check-tenant-export-policy apps/api/package.json` for the exact invocation) and `tenant-export-policy.integration.test.ts` + `tenantExportErasureRoundtrip.integration.test.ts` (only fail under Integration Tests — run against a real DB before PR).
+  - `apps/api/src/services/tenantExportPolicyRegistry`'s check script/integration test (`grep -n check-tenant-export-policy apps/api/package.json` for the exact invocation) and `tenant-export-policy.integration.test.ts` + `tenantExportErasureRoundtrip.integration.test.ts` (only fail under Integration Tests — run against the test DB before PR).
   - `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts` — confirm it still passes with no new allowlist entry needed for shape-1 auto-discovery.
 - [ ] `pnpm lint`
+- [ ] **Explicitly out of scope, handed to W02:** pruning `backup_snapshot_retirements` rows 30 days after `swept_at` is set (spec §3.3: "Rows are pruned 30 d after `swept_at`"). This wave never sets `swept_at` at all (that's the GC sweep's job, §3.4/W02) and adds no pruning job — a pruning task only makes sense once W02's sweep is setting `swept_at` in the first place. W02's plan should include a `swept_at IS NOT NULL AND swept_at < now() - 30d` cleanup pass (a new scheduled job, or folded into the existing GC cadence) as one of its own tasks; it is NOT silently dropped here — call it out in that plan's own Consumes/Produces the same way this note does.
 - [ ] PR body checklist:
   - [ ] Migrations `140005`/`140006` applied and idempotent-verified (`pnpm db:migrate` run twice locally, second run a no-op).
-  - [ ] `pnpm db:check-drift` clean.
-  - [ ] Tenancy contract suites (cascade order, device cascade/denormalized lists, export-policy, rls-coverage) all green against a real DB, not just the unit job.
+  - [ ] `pnpm db:check-drift` clean (ledger parity only — not a schema-correctness proof; see above).
+  - [ ] Tenancy contract suites (cascade order, device cascade/denormalized lists, export-policy, rls-coverage) all green against the real test DB, not just the unit job.
   - [ ] `Closes #<W01 sub-issue>` once this feature is registered via `feature-lifecycle` (per CLAUDE.md's Feature Lifecycle Tracking section, if this plan is executed as a tracked wave).
-  - [ ] Note for W02/W03 reviewers: `backupGcKnobs.ts` currently exports `BACKUP_BASE_LEASE_MS`, `BACKUP_RESTORE_PIN_LINGER_MS`, `BACKUP_PUBLISH_MARGIN_MS` — W02 is expected to migrate `BACKUP_GC_GRACE_MS`/`BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS`/a real `BACKUP_GC_ORPHAN_MANIFEST_MAX_AGE_MS` into this same module and delete the `RECONCILE_ORPHAN_HALF_WINDOW_MS` local literal in `backupSnapshotReconcile.ts` (Task 11).
+  - [ ] Note for W02/W03 reviewers: `backupGcKnobs.ts` currently exports `BACKUP_BASE_LEASE_MS`, `BACKUP_RESTORE_PIN_LINGER_MS`, `BACKUP_PUBLISH_MARGIN_MS` — W02 is expected to migrate `BACKUP_GC_GRACE_MS`/`BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS`/a real `BACKUP_GC_ORPHAN_MANIFEST_MAX_AGE_MS` into this same module, delete the `RECONCILE_ORPHAN_HALF_WINDOW_MS` local literal in `backupSnapshotReconcile.ts` (Task 11), replace Task 8's single shared `runWithSystemDbAccess` wrap around `sweepUnreferencedBackupObjects()` with genuinely separate per-identity contexts managed inside that function, and add the 30-day `backup_snapshot_retirements` pruning pass noted above.
 
-## Open questions / contradictions
+## Open questions / contradictions — resolved by coordinator 2026-09-09
 
-1. **SQL backfill fidelity vs. `normalizeStorageIdentity` (Task 1).** The PL/pgSQL replica in the migration is a best-effort port, not a proven-identical one: (a) the `local` branch strips only a trailing slash, it does not replicate `path.resolve()`'s handling of `.`/`..` segments or resolving a genuinely relative path against a cwd (impossible to replicate in SQL at all — flagged in the migration's own comment); (b) the S3 branch's endpoint canonicalization strips a leading scheme and anything from the first `/` onward, but does not replicate the TS function's `new URL(...)` parsing exactly for atypical inputs (e.g. userinfo in the URL, IPv6 hosts). Both divergences are bounded to the *guarded* backfill set (config unedited since the snapshot) — a mismatch here means a row is left with a technically-wrong-but-internally-consistent identity, never crossed with a different bucket's rows, and W02's sweep only ever compares against the *live* `normalizeStorageIdentity` output for a listing, so a divergent backfilled identity would show as an "unreachable identity" leak (logged, not silently merged) rather than a cross-tenant/cross-bucket deletion. Still, this was not proven byte-for-byte against real data before landing — recommend a one-off comparison script (SQL backfill's computed identities vs. `normalizeStorageIdentity(row)` in TS) run against a copy of production data before the migration ships, similar in spirit to the Go↔TS contract-test pattern this repo already uses elsewhere (`backupAgentContract.test.ts`), even though no such automated cross-check exists here.
-2. **`RESTORE_COMMANDLESS_PENDING_TIMEOUT_MS` (Task 7) vs. `BACKUP_RESTORE_PIN_LINGER_MS` (Task 9/backupGcKnobs.ts).** The spec's reaper rule is a fixed 1 hour, independent of the (env-tunable) 7-day-default linger retention's own pin check uses. This is intentional per the spec's plain reading (§3.2: "a new reaper rule in staleCommandReaper.ts: commandless pending restore_jobs older than 1h → failed"), but it does mean an operator who raises `BACKUP_RESTORE_PIN_LINGER_MS` well above 1h still gets commandless rows reaped at the fixed 1h mark while status-based pins linger far longer — not a bug, but worth confirming this asymmetry is the intended operator-facing behavior rather than an oversight in the spec itself.
-3. **Task 9's import path for `restoreJobs`/`backupSnapshotRetirements`/`IN_FLIGHT_BACKUP_JOB_STATUSES`.** The plan imports these from the concrete `'../db/schema/backup'` module rather than the `'../db/schema'` barrel that `backupRetention.ts`'s other imports currently use. This needs to be reconciled against whatever `backupRetention.test.ts`'s `vi.mock(...)` setup actually targets (the barrel or the concrete module) during implementation — mixing the two in one file's imports is a code-smell the implementing agent should resolve one way or the other, not leave split.
-4. **Task 11's base-existence check re-queries the DB per adopted candidate inside a loop already doing per-candidate manifest fetches.** This mirrors the existing per-candidate DB-read pattern in `reconcileOrphanedBackupSnapshots` (which already does one write per adopted candidate), so it is consistent with the file's existing performance envelope, but it is an N+1-shaped query pattern that could matter if reconcile is ever run over a very large orphan backlog. Not fixed here — flagged for W02/a future pass if reconcile's throughput becomes a real bottleneck.
-5. **`backup_snapshot_retirements.snapshot_id` width is `varchar(255)`** (Task 3's migration) while `BACKUP_SNAPSHOT_ID_MAX_LENGTH`'s actual numeric value was not independently re-verified in this pass — only that the constant exists and is imported elsewhere. Confirm `BACKUP_SNAPSHOT_ID_MAX_LENGTH`'s actual value during implementation and either use the constant directly in both the migration's hand-written SQL and the Drizzle schema, or confirm `255` matches it, so the two never silently drift.
-6. **Task 6's multi-target dispatch and sequential base selection.** When a profile fans out to multiple targets in one dispatch call (`prepareBackupDispatchTargets`'s per-target loop), each `backup_run` target calls `stampDispatchPinAndIdentity` independently, in its own transaction. Two sibling targets for the SAME `(deviceId, configId, mode)` pair (not a scenario the current profile model appears to produce, since distinct targets carry distinct modes/paths, but not verified as structurally impossible) could theoretically select the same base snapshot and both pin it — harmless (both dispatch fine, retention just sees two pins on the same snapshot instead of one) but not something this plan explicitly proves against. Not treated as a defect; flagged as unverified.
-7. **Task 12's `backupSnapshots` import in `configs.ts`.** The plan assumes `backupSnapshots` needs adding to this route file's imports; whether it's already imported (for an unrelated existing route in the same file) was not independently confirmed — a two-second `grep` during implementation resolves this, called out so it isn't silently skipped.
-8. **PATCH `/backup/configs/:id`'s response-shape change.** Returning `{ ...toConfigResponse(row), warnings }` only when `warnings.length > 0` (rather than always including an empty `warnings: []`) avoids widening every existing PATCH response body, but means callers must treat `warnings` as always-optional. If the web UI consuming this endpoint expects a stable shape, this may need `warnings: []` unconditionally instead — a product/UI-contract decision this plan defers to whoever wires up the frontend warning banner (out of scope for W01, which is API-only).
+All eight items below were raised during drafting and have since been resolved by explicit coordinator decision; the plan text above already reflects each resolution. Kept here as a decision log, not as open items.
+
+1. **RESOLVED — no backfill.** Migration `140005` is DDL only (Task 1): no PL/pgSQL port of `normalizeStorageIdentity`, no UPDATE, no `breeze.scope` elevation. Every `backup_snapshots.storage_identity` starts NULL; W02's sweep self-heals each row from a live bucket listing, matched by row id. The SQL-fidelity concerns that motivated the original open question (path/URL parsing divergence) no longer apply, since no SQL normalization is attempted here at all.
+2. **CONFIRMED — asymmetry intentional.** `staleCommandReaper.ts`'s `RESTORE_COMMANDLESS_PENDING_TIMEOUT_MS` (Task 7) is a fixed 1 hour, independent of the env-tunable, 7-day-default `BACKUP_RESTORE_PIN_LINGER_MS` (Task 9) retention's own pin check uses. Coordinator confirms this is the intended operator-facing behavior, not an oversight.
+3. **RESOLVED — import path.** `backupRetention.test.ts:34` mocks only `vi.mock('../db', () => ({ db: mockDb }))` — there is no mock on `'../db/schema'` in that file. Task 9 now imports `restoreJobs`/`backupSnapshotRetirements`/`IN_FLIGHT_BACKUP_JOB_STATUSES` from the barrel `'../db/schema'` (joining the file's existing barrel import), and `recoveryTokens` from the concrete `'../db/schema/recoveryTokens'` module (matching `backupWorker.ts`'s existing convention for that specific table). Tasks 6/10/11 were also normalized to add `backupSnapshotRetirements` to each file's existing barrel import rather than a separate `'../db/schema/backup'` line.
+4. **ACCEPTED — N+1 query shape.** Task 11's base-existence check re-queries the DB per adopted candidate; accepted as consistent with `reconcileOrphanedBackupSnapshots`'s existing per-candidate DB-read pattern. Flagged for a future pass only if reconcile's throughput over a large orphan backlog becomes a real bottleneck — not addressed in this wave.
+5. **RESOLVED — width.** `BACKUP_SNAPSHOT_ID_MAX_LENGTH = 200` (confirmed, `apps/api/src/db/schema/backupConstants.ts`), matching `backup_jobs.snapshot_id`'s existing `varchar(200)` (`apps/api/src/db/schema/backup.ts:247`). Task 3's migration now uses `varchar(200)` for `backup_snapshot_retirements.snapshot_id` (was `varchar(255)`); Task 2's Drizzle schema already used the `BACKUP_SNAPSHOT_ID_MAX_LENGTH` constant directly and needed no change. `backup_jobs.base_snapshot_id` (Task 1) deliberately stays `varchar(255)` per the spec's own explicit choice for that column — the two widths are independent.
+6. **ACCEPTED — noted, not fixed.** Task 6's sequential per-target base selection in a multi-target dispatch could theoretically let two sibling targets pin the same base snapshot. Coordinator confirms this is fine as-is (harmless: both dispatch normally, retention just sees two pins instead of one) — left as a noted, unverified-as-impossible edge case, not a defect requiring a fix.
+7. **RESOLVED — import.** Confirmed by reading `apps/api/src/routes/backup/configs.ts`'s import block directly: `backupSnapshots` was NOT already imported (only `backupConfigs`, from `'../db/schema'` at line 13). Task 12 now widens that same import line.
+8. **RESOLVED — always include `warnings`.** Per coordinator decision, `PATCH /backup/configs/:id`'s response always includes `warnings: string[]` (empty array when there's nothing to warn about), not an optional field. Task 12's implementation and tests were updated accordingly.
+
+## Round-2 review findings — all fixed in the plan text above
+
+An independent review pass found the following defects; each is fixed in place (not merely noted) in the tasks above.
+
+9. **FIXED — retention never invents an identity.** `unknown::<uuid>` is removed entirely (Task 9); a row with `storageIdentity IS NULL` is skipped and counted as a new `skippedUnresolved` counter, retried on a later run.
+10. **FIXED — legal hold/immutability re-read under the lock.** Moved from the enumeration pass into `deleteSnapshotRow` itself, decided from the `FOR UPDATE`-locked row (Task 9); the enumeration selects no longer fetch or branch on those columns at all.
+11. **FIXED — identity-scoped snapshot_id lookups.** `backup_snapshots.snapshot_id` has no uniqueness constraint (`schema/backup.ts:330`). Every lookup that matches a row by that bare string is now also scoped by `storageIdentity`: retention's backup-pin check (Task 9), the late-result fence's base lookup (Task 10), the `parentSnapshotId` lookup (Task 10, also switched from `configId` to `storageIdentity` scoping), and reconcile's base-existence check (Task 11).
+12. **FIXED — §3.7 sweep call shape corrected.** Task 8 wraps `sweepUnreferencedBackupObjects()` in exactly ONE `runWithSystemDbAccess` call (not bare/depth-0, superseding an earlier, since-corrected instruction) so its existing GUC-dependent reads keep working; W02 replaces the single wrap with genuine per-identity contexts.
+13. **FIXED — queue schema propagation (P1).** `queueSchemas.ts`'s `.strict()` `backupSnapshotSummarySchema` and `backupEnqueue.ts`'s `ProcessResultsResult.snapshot` interface both widened to carry `baseSnapshotId`/`formatVersion`/`backupIdentity`, with a round-trip regression test (Task 10).
+14. **FIXED — dispatch lock query (P1).** The outer-joined `FOR SHARE` (rejected by Postgres — `FOR UPDATE`/`FOR SHARE` cannot apply to the nullable side of an outer join) is split into two statements: `FOR SHARE` on `backup_snapshots` alone, then a plain (unlocked) SELECT against `backup_snapshot_retirements` (Task 6).
+15. **FIXED — rejection branch device predicate (P1).** The late-result fence's SELECT and UPDATE are both scoped by `(id, deviceId)`, matching the file's own #3036 convention at the main UPDATE (Task 10) — never by job id alone.
+16. **FIXED — late-result fence atomicity + NULL lease (P1).** The whole check-and-write sequence runs inside one `db.transaction` with `FOR UPDATE` on the job row (atomic against the reaper); a NULL `publishLeaseExpiresAt` is now a REJECT (`publish_lease_expired`), not an implicit pass (Task 10). Reconcile additionally refuses to adopt a job whose late result was already fenced (new `'late-result-fenced'` skip reason, Task 11).
+17. **FIXED — hyperv/mssql identity stamping (P2).** `stampDispatchPinAndIdentity` is now called for every dispatched target; `storage_identity` is stamped unconditionally, while `publish_lease_expires_at`/`base_snapshot_id` remain file/system_image-only (Task 6).
+18. **FIXED — discriminating test assertions (P2).** Task 10's tests now assert the actual captured `parentSnapshotId`/`isIncremental`/`storageIdentity`/`errorLog` values, not `applied === true` alone. Task 13 gained: restore pin with/without `command_id`, recovery-token pin, max-versions-respects-pins, a real-DB late-result-lease-expired case, a two-path concurrent dispatch-vs-retention race, and a `processCleanupExpiredSnapshots` (worker-handler-level) proof of §6(6b).
+19. **FIXED — compile/setup issues (P2).** `sql` added to `backupRetention.ts`'s widened `drizzle-orm` import (Task 9); the RLS forge test's `DbAccessContext` shape corrected to the real interface (no `partnerId` field) using the established `orgContext` helper convention, with the SQLSTATE assertion corrected to read `.cause.code` for a Drizzle insert (Task 13); all integration-test run commands now use the safe default test DB instead of the dev DB URl, which `testUtils/integrationDatabaseSafety.ts` actively refuses (Tasks 13-14).
+20. **FIXED — migration verification claims (P2).** A Drizzle partial index matching migration `140005`'s `backup_jobs_base_snapshot_id_idx` was added to Task 2's schema edit (previously missing). The plan no longer claims `pnpm db:check-drift` compares the Drizzle schema to a live database — `scripts/check-drift.ts` verifies migration-ledger parity only; a `pnpm db:migrate` run-twice idempotency check was added instead (Tasks 2, 14). The 30-day `backup_snapshot_retirements` pruning pass (spec §3.3) is explicitly handed to W02 (Task 14's Produces/handoff note), since this wave never sets `swept_at` in the first place.
+
+## W02 handoff note (§3.7 call-shape contract — corrected by coordinator's second review pass)
+
+Task 8 makes `processCleanupExpiredSnapshots` call `await runWithSystemDbAccess(() => sweepUnreferencedBackupObjects())` — **ONE shared context for the whole sweep**, opened strictly AFTER every row's retention has already committed independently (Task 9). This matches today's read shape exactly, so `sweepUnreferencedBackupObjects`'s existing internal `db.select(...)` calls keep the working GUCs they rely on (it has no context management of its own — Ground Truth, `backupRetention.ts:982`) — no interim regression is introduced. W02 is expected to replace this single shared wrap with genuinely separate per-identity contexts managed INSIDE `sweepUnreferencedBackupObjects` itself (spec §3.7 item 2: "a separate system context per identity for the DB reads, with every storage call at depth 0"), at which point this call site's wrap is removed entirely and W02 should not need to touch `backupWorker.ts` again beyond that one deletion.
+
+An earlier draft of this plan had this call site bare (no context at all) per an initial, since-superseded coordinator instruction; that was corrected back to the single-wrap shape described above after independent review flagged it would leave the sweep's reads genuinely broken (not merely under-optimized) until W02 landed. The single-wrap shape is the final, authoritative one.

--- a/docs/superpowers/plans/backup/2026-09-09-backup-gc-reclamation-w01-api-pins-and-retirements.md
+++ b/docs/superpowers/plans/backup/2026-09-09-backup-gc-reclamation-w01-api-pins-and-retirements.md
@@ -1,0 +1,2329 @@
+# Wave 01 — API: server-chosen base, pins, leases, retirements, storage identity, lineage — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the server a durable, lease-fenced pin on the incremental-dedupe base it hands the agent, a durable retirement tombstone for every row retention deletes, a per-job/per-snapshot storage identity stamped at dispatch, full lineage (parent/incremental/late-result) plumbing, and a transaction-boundary fix so retention's retirements commit per row instead of inside one giant ambient transaction — the data-model half of D18. The GC sweep rewrite (§3.4) and the agent (§3.5) are W02/W03.
+
+**Architecture:** `backup_jobs` gains `base_snapshot_id`, `publish_lease_expires_at` (set for every dispatched file/system_image job, fixed at dispatch, never renewed), and `storage_identity` (stamped at dispatch from the payload's `providerConfig`). `backup_snapshots` gains a nullable `storage_identity`, copied from the job at publication. A new `backup_snapshot_retirements` table is the durable tombstone retention writes instead of a bare delete. Dispatch acquires the base pin in a job→snapshot lock-ordered transaction; retention is restructured so each candidate row commits in its own system-DB context instead of sharing the worker's blanket transaction (§3.7); a new reaper rule fails commandless pending restores after 1h; lineage fields are threaded through both live results and reconcile-adopted manifests, gated by a late-result fence.
+
+**Tech Stack:** Hono + Drizzle ORM + PostgreSQL (RLS), Vitest (unit + `vitest.integration.config.ts`), zod.
+
+**Spec:** `docs/superpowers/specs/backup/2026-09-09-backup-gc-reclamation-design.md` v3 (§3.1 base pin/lease, §3.2 retention pin checks, §3.3 retirements table, §3.6 storage identity, §3.7 transaction boundaries, §4 migrations/registries — NOT §3.4 sweep rules or §3.5 agent-side, which are W02/W03).
+
+**Depends on:** none (first wave). W02 (GC sweep rewrite) and W03 (agent) depend on this wave's schema + `backupGcKnobs.ts`.
+
+## Global Constraints
+
+- Migration files (next free slot after shipped `2026-10-15-140004`, confirmed via `ls apps/api/migrations/*.sql | sort | tail -1`):
+  - `apps/api/migrations/2026-10-15-140005-backup-jobs-base-pin-and-storage-identity.sql`
+  - `apps/api/migrations/2026-10-15-140006-backup-snapshot-retirements.sql`
+- New columns: `backup_jobs.base_snapshot_id varchar(255)` NULL, `backup_jobs.publish_lease_expires_at timestamptz` NULL (set for **every** dispatched file/system_image job, base or not; fixed at dispatch — never renewed on progress), `backup_jobs.storage_identity text` NULL (stamped at dispatch), `backup_snapshots.storage_identity text` NULL (**forever** nullable — no follow-up `SET NOT NULL` migration; self-healing is W02's sweep job).
+- New table: `backup_snapshot_retirements` (columns per spec §3.3, shape-1 RLS, unique `(storage_identity, snapshot_id)`).
+- New env knobs, all resolved **per call** (never module-load-cached) via one shared `resolveMsKnob` helper in new file `apps/api/src/services/backupGcKnobs.ts`:
+  - `BACKUP_BASE_LEASE_MS` — default 7 d (`604_800_000`), production floor 1 h.
+  - `BACKUP_RESTORE_PIN_LINGER_MS` — default 7 d, production floor 1 h.
+  - `BACKUP_PUBLISH_MARGIN_MS` — default 1 h (`3_600_000`), production floor 5 min.
+- `normalizeStorageIdentity(provider, providerConfig)` (exported, `apps/api/src/jobs/backupRetention.ts:661`) is the ONE identity function for live TypeScript code paths. The migration's backfill replicates its logic in PL/pgSQL for a **guarded** subset of rows only (spec §3.6) — see Task 1's open question on fidelity.
+- Registries to touch: `apps/api/src/services/tenantCascade.ts` (`CORE_ORG_CASCADE_DELETE_ORDER`), `apps/api/src/routes/devices/core.ts` (`CORE_DEVICE_CASCADE_DELETE_TABLES`, `CORE_DEVICE_ORG_DENORMALIZED_TABLES`), `apps/api/src/services/tenantExportPolicyRegistry.ts` (`CORE_TENANT_EXPORT_POLICY`). `rls-coverage.integration.test.ts` needs NO new allowlist entry (shape 1 = plain `org_id` column = auto-discovered).
+- Lock order for the base pin is **job, then snapshot** (mirrors `routes/devices/moveOrg.ts:248-253`'s "lock parents in a fixed order as the transaction's first statements" pattern).
+
+## 0. Ground truth
+
+All of the below was verified directly against the worktree at `/Users/toddhebebrand/.herdr/worktrees/breeze/backup-gc-5429` on 2026-09-09; every citation was re-opened, not copied from the spec.
+
+- `apps/api/src/db/schema/backup.ts:207-278` (`backupJobs`) — no `baseSnapshotId`/`publishLeaseExpiresAt`/`storageIdentity` columns exist yet. `:247` `snapshotId varchar(BACKUP_SNAPSHOT_ID_MAX_LENGTH)`.
+- `apps/api/src/db/schema/backup.ts:280-337` (`backupSnapshots`) — `:300` `isIncremental boolean default(false)` and `:305-308` `parentSnapshotId` self-FK `ON DELETE SET NULL` already exist (D17, migration `2026-10-15-140004`) and are never written by the live write path. No `storageIdentity` column yet.
+- `apps/api/src/db/schema/backup.ts:62` — `IN_FLIGHT_BACKUP_JOB_STATUSES = ['pending', 'running'] as const`, exported from this module.
+- `apps/api/migrations/2026-10-15-140004-backup-snapshot-lineage-fk-set-null.sql` (full file read) — the newest shipped migration; confirmed via `ls apps/api/migrations/*.sql | sort | tail -1` that no later-sorting file exists, so `140005`/`140006` are free, correctly-ordered slots.
+- `apps/api/src/jobs/backupRetention.ts:661-672` — `normalizeStorageIdentity` verbatim:
+  ```ts
+  export function normalizeStorageIdentity(provider: string, providerConfig: Record<string, unknown>): string {
+    if (provider === 'local') {
+      const rawPath = getStringValue(providerConfig, 'path') || getStringValue(providerConfig, 'basePath') || '';
+      const normalizedPath = rawPath ? resolveLocalPath(rawPath) : '';
+      return `local::${normalizedPath}`;
+    }
+    const endpoint = normalizeS3Endpoint(getStringValue(providerConfig, 'endpoint'));
+    const bucket = (getStringValue(providerConfig, 'bucket') || getStringValue(providerConfig, 'bucketName') || '').trim();
+    return `${provider}::${endpoint}::${bucket}`;
+  }
+  ```
+  `resolveLocalPath = require('node:path').resolve` (import at `:9`) — resolves relative to the **calling process's cwd**. `normalizeS3Endpoint` (`:631-642`) strips scheme, lowercases the host, canonicalizes a blank endpoint and AWS's own default endpoints (`DEFAULT_AWS_S3_ENDPOINT_PATTERN`, `:617`, `/^s3(\.dualstack)?([.-][a-z0-9-]+)?\.amazonaws\.com$/`) to `''`, and keeps `host:port` when a port is present. Bucket names are trimmed but never lowercased (case-sensitive per S3 spec).
+- `apps/api/src/jobs/backupRetention.ts:494-539` — `BACKUP_GC_GRACE_MS` is resolved via `resolveBackupGcGraceMs()` but frozen at module load (`export const BACKUP_GC_GRACE_MS = resolveBackupGcGraceMs();`) — the defect this wave's `resolveMsKnob` must not repeat (never captured into a module-level `const`; call it fresh at each use site).
+- `apps/api/src/jobs/backupRetention.ts:159-387` (full read) — current `RetentionCleanupResult`, `deleteSnapshotRow` (`:189-193`, today a bare `db.delete(...)`, no lock, no pin check), `tryDeleteSnapshotRow` (`:205-221`, try/catch around the delete, returns boolean), and `cleanupExpiredSnapshots` (`:231-387`, two passes: `expired` — a single bulk SELECT then a JS loop calling `tryDeleteSnapshotRow` per row — and `versionBoundSnapshots`, grouped by `(deviceId, configId)` for the `maxVersions` prune). **No transaction of any kind exists today** — both passes run under whatever ambient context the caller already opened.
+- `apps/api/src/jobs/backupWorker.ts:60-64` — `const { db } = dbModule;` and `runWithSystemDbAccess = (fn) => typeof dbModule.withSystemDbAccessContext === 'function' ? dbModule.withSystemDbAccessContext(fn) : fn()`.
+- `apps/api/src/jobs/backupWorker.ts:77-130` (`createBackupWorker`, full read) — the BullMQ processor. `dispatch-backup` is special-cased **outside** the blanket wrap at `:89-99` (comment `:82-88` explains why: Redis/WS I/O via `agentCommandRelay` must not pin a pooled connection idle-in-transaction). Every other job type — including `cleanup-expired-snapshots` at `:109-111` — runs inside `return runWithSystemDbAccess(async () => { switch (data.type) { ... } })` at `:101`. `withDbAccessContext`/`withSystemDbAccessContext` (`apps/api/src/db/index.ts:525-554,610`) open exactly one real Postgres transaction (`baseDb.transaction(...)`) when no ambient context is already active, and are a no-op passthrough when nested inside one that already is. **This is the bug §3.7 fixes**: today, every retirement insert + row delete `cleanupExpiredSnapshots` performs, across every org and every candidate row, plus the entire GC sweep that follows it, all share the ONE transaction opened at `:101` — a later `failed > 0` throw or any savepoint rollback undoes retirements that already "committed" from the caller's point of view.
+- `apps/api/src/jobs/backupWorker.ts:325-395` — `processCleanupExpiredSnapshots` verbatim: loops `db.selectDistinct({ orgId }).from(backupSnapshots)`, calls `cleanupExpiredSnapshots(orgId)` per org, then `sweepUnreferencedBackupObjects()` once (try/catch, GC failure never fails the job), then the deliberate D17 `if (failed > 0) throw ...` **last**, after the sweep has already run.
+- `apps/api/src/jobs/backupRetention.ts:982` — `sweepUnreferencedBackupObjects` has **no internal `withSystemDbAccessContext`/`withDbAccessContext` call of its own** — it relies entirely on the ambient context the caller already opened. Pulling `cleanup-expired-snapshots` out of the blanket wrap (as this wave must) would leave it running with NO context at all unless its call site is separately wrapped — Task 8 wraps the call site (not its internals; internal per-identity context splitting is W02's §3.4/§3.7-item-2 job).
+- `apps/api/src/jobs/backupWorker.ts:609-778` (`prepareBackupDispatchTargets`, full read) — builds `targets` (`:652`), loops `for (let i = 0; i < targets.length; i++)` (`:703`), creates a child `backup_jobs` row via `.insert(backupJobs)...returning()` for `i > 0` (`:713-733`, reusing `data.jobId` for `i === 0`), then builds `command.payload` at `:742-762`: `{ jobId, configId, provider, providerConfig: commandProviderConfig, storageEncryption, ...target.payload }` — no base/lease/identity fields today. This is the exact insertion point.
+- `apps/api/src/jobs/backupWorker.ts:399-431` — `resolveBackupTargets`: `case 'file'` and `case 'system_image'` both return `commandType: 'backup_run'`; hyperv/mssql return `hyperv_backup`/`mssql_backup` — never base-pinned. `system_image` payload is `{ systemImage: true }`; `file` payload is `{ paths, excludes? }`.
+- `apps/api/src/jobs/backupWorker.ts:26` — drizzle-orm import is `eq, ne, and, sql, isNull, lt, inArray` — `desc`, `or`, `gt` are NOT yet imported and must be added.
+- `apps/api/src/services/orgCurrencyCore.ts:68,102`, `apps/api/src/jobs/softwareRemediationWorker.ts:248`, `apps/api/src/jobs/sensitiveDataJobs.ts:301,330,340` — confirmed directly: `.for('share')` and `.for('update')` (optionally `.for('update', { of: table })`) are established Drizzle patterns already in production code in this repo.
+- `apps/api/src/routes/devices/moveOrg.ts:248-253` — the actual lock-order precedent (the spec's `:656` citation was stale): both parent org rows are locked `FOR SHARE`, in a fixed (ascending id) order, as the **first** statements of the transaction, before any dependent row is touched. Mirrored here as job-row-then-snapshot-row.
+- `apps/api/src/jobs/staleCommandReaper.ts:97-100` — `BACKUP_STALL_TIMEOUT_MS = 15*60*1000`, `BACKUP_OFFLINE_GRACE_MS = 10*60*1000`, `BACKUP_ABSOLUTE_TIMEOUT_MS = 24*60*60*1000`, `BACKUP_PENDING_TIMEOUT_MS = 60*60*1000`. `:150-240` (`propagateTimedOutDeviceCommand`) matches `restoreJobs` **only by `commandId`** (`:220-240`, `WHERE command_id = $1 AND status IN ('pending','running')`) — a restore row created before its command row exists (`routes/backup/restore.ts:281,361`) is never reached by this function. `:1343-1482` (`reapStaleBackupJobs`) and `:1291` (`reapBackupJobRow`) are the exact per-domain reap pattern to mirror. `:1496-1505` `REAPER_DOMAINS` is the exported, module-scope array of `[name, fn]` pairs the BullMQ worker iterates, each wrapped individually in `runWithSystemDbAccess` (`:1517-1524`) — the new domain is added here.
+- `apps/api/src/routes/backup/resultSchemas.ts:27-32` — `backupSnapshotResultSchema` today: `{ id, timestamp?, size?, files? }` only. No `baseSnapshotId`/`formatVersion`/`backupIdentity`.
+- `apps/api/src/services/backupResultPersistence.ts:972-981` — the terminal-job guard: `terminalJobGuard` (source `'agent'` branch) = `status='failed' AND errorLog LIKE '%[stale-backup-reaper]%'` (`STALE_BACKUP_REAP_MARKER`, imported from `../db/schema/backup` at `:11`). `:1041-1051` — `updatedJob` is `.returning({ id, orgId, configId, backupType, backupMode })` from the job UPDATE — must widen to also return `baseSnapshotId`, `publishLeaseExpiresAt`, `storageIdentity`. `:1143-1162` — `snapshotValues` object is where `parentSnapshotId`/`isIncremental`/`storageIdentity` must be added.
+- `apps/api/src/services/backupSnapshotReconcile.ts:135-155` — `ReconcileSkipReason` union (must widen with `'retired' | 'orphan-too-old-for-adoption' | 'base-missing'`). `:234-240` — `reconcileManifestSchema` (zod `.passthrough()`) already parses `formatVersion`/`baseSnapshotId` off the manifest. `:538-585` (`manifestToCommandResult`) builds its returned `snapshot: {...}` **without** forwarding either field — the exact gap Task 11 closes. `:592-973` (`reconcileOrphanedBackupSnapshots`, full read) — `writtenAt` is computed per candidate at `:705`, immediately followed by a `skip(reason)` closure (`:706-719`) and the `restorableOwner`/`foreignClaimed`/`claimingJob` checks (`:721-774`) — this is where the retired/orphan-age refusals are inserted. The manifest is only fetched and parsed later, in the adoption loop, at `:864-874` (`manifestToCommandResult` call) — the base-existence refusal belongs right after that, before `:882`.
+- `apps/api/src/routes/backup/configs.ts:354-469` (PATCH handler, full read) — `current` read at `:376-380`; `nextProviderConfig` computed at `:393-395`; the write transaction at `:440-452`; response built via `toConfigResponse(row)` at `:467`.
+- `apps/api/src/db/schema/recoveryTokens.ts:20-57` (full file read) — `recoveryTokens.snapshotId` is a `uuid` FK to `backupSnapshots.id` (`ON DELETE SET NULL`), `status varchar(20) default('active')`, `completedAt timestamp` nullable, `expiresAt timestamp` NOT NULL. No `session_status` column.
+- `apps/api/migrations/2026-04-11-bucket-a-rls-policies.sql:12-32` — exact shape-1 RLS pattern (four `DROP POLICY IF EXISTS`, `ENABLE`+`FORCE ROW LEVEL SECURITY`, four `CREATE POLICY breeze_org_isolation_{select,insert,update,delete}` using `public.breeze_has_org_access(org_id)`), copied verbatim in Task 3's migration.
+- `apps/api/src/services/tenantCascade.ts:169-179` — `CORE_ORG_CASCADE_DELETE_ORDER` reads `..., 'backup_chains', 'backup_configs', 'backup_jobs', 'backup_policies', 'backup_profiles', 'backup_sla_configs', 'backup_sla_events', 'backup_snapshots', 'backup_verifications', ...` at exactly those lines. `'backup_snapshot_retirements'.localeCompare('backup_snapshots')` is negative (`'_r' < '_s'` after the shared `backup_snapshot` prefix), so the new entry sorts between `'backup_sla_events'` and `'backup_snapshots'`.
+- `apps/api/src/routes/devices/core.ts:257-270` — `CORE_DEVICE_ORG_DENORMALIZED_TABLES` reads `'backup_chains', 'backup_jobs', 'backup_sla_events', 'backup_snapshots', 'backup_verifications', ...` — same insertion point.
+- `apps/api/src/routes/devices/core.ts:463-478` — `CORE_DEVICE_CASCADE_DELETE_TABLES` is explicitly children-before-parents ORDERED (comment `:475-478`): `'recovery_tokens', 'backup_chains', 'restore_jobs', 'backup_verifications', 'backup_snapshots', 'backup_jobs', ...`. `backup_snapshot_retirements.device_id` is nullable `ON DELETE SET NULL` — SET NULL never raises an FK violation regardless of position, so it can be added anywhere; placed right after `'backup_jobs'` for readability.
+- `apps/api/src/services/tenantExportPolicyRegistry.ts:118-125` — exact `tablePolicy("org_id", {...})` shape; `backup_jobs`'s current `included` list and `backup_snapshots`'s current `included` list quoted verbatim in Task 4.
+- `apps/api/vitest.integration.config.ts` (full read) — `include` contains `'src/__tests__/integration/**/*.test.ts'` as a standing glob entry — new files under that directory need **no config edit**.
+- `apps/api/package.json:26` — `"test": "vitest"` (bare, watch-mode by default — the `--` trap applies). No `typecheck` script exists; use `pnpm --filter @breeze/api exec tsc --noEmit` per CLAUDE.md.
+- `apps/api/src/jobs/backupRetention.test.ts:1-75` (full read) — the `chainable(rows)` mock helper (`from/where/leftJoin/innerJoin/orderBy/limit` all return `obj`, `.then()` resolves `rows`), a FIFO `selectQueue` consumed by `mockDb.select`, `vi.mock('../db', () => ({ db: mockDb }))`. **No `.for()` method on `chainable`, no `insert`, no `withSystemDbAccessContext` export from the mock today** — Task 9's test setup must add all three.
+- `apps/api/src/jobs/backupWorker.test.ts:1-59` (full read) — `mockDb` with `select/from/where/limit` chainable via `mockReturnThis()`, `vi.mock('../db', () => ({ db: mockDb, withSystemDbAccessContext: undefined, runOutsideDbContext: (fn) => fn(), SYSTEM_DB_ACCESS_CONTEXT: {...} }))`, `cleanupExpiredSnapshots`/`sweepUnreferencedBackupObjects` mocked wholesale from `./backupRetention`, `__testOnly` exported from `backupWorker.ts` for driving `processDispatchBackup` directly. No `mockDb.transaction` today — Task 6's test adds one.
+- `apps/api/src/__tests__/integration/staleBackupReaper.integration.test.ts` (full read) — the real-DB integration-test convention this wave's new suites mirror: `import './setup'`, `it.runIf(!!process.env.DATABASE_URL)`, seed via `withSystemDbAccessContext(async () => { ... insert partner/org/site/device/config/job ... })`, exercise the real function, assert via a second `withSystemDbAccessContext` read.
+
+## File structure
+
+- **Create** `apps/api/migrations/2026-10-15-140005-backup-jobs-base-pin-and-storage-identity.sql` — new `backup_jobs` columns + partial index; nullable `backup_snapshots.storage_identity` + guarded SQL backfill.
+- **Create** `apps/api/migrations/2026-10-15-140006-backup-snapshot-retirements.sql` — new table + shape-1 RLS.
+- **Create** `apps/api/src/services/backupGcKnobs.ts` + `apps/api/src/services/backupGcKnobs.test.ts` — shared per-run env-knob resolver.
+- **Modify** `apps/api/src/db/schema/backup.ts` — add columns to `backupJobs`/`backupSnapshots`, new `backupSnapshotRetirements` table.
+- **Modify** `apps/api/src/services/tenantCascade.ts`, `apps/api/src/routes/devices/core.ts`, `apps/api/src/services/tenantExportPolicyRegistry.ts` — registries.
+- **Modify** `apps/api/src/jobs/backupWorker.ts` — carve `cleanup-expired-snapshots` out of the blanket wrap; base selection + pin acquisition + storage-identity stamping in `prepareBackupDispatchTargets`.
+- **Modify** `apps/api/src/jobs/staleCommandReaper.ts` — new `reapCommandlessPendingRestores` domain.
+- **Modify** `apps/api/src/jobs/backupRetention.ts` — per-row system-context retention with pin checks + retirement insert.
+- **Modify** `apps/api/src/routes/backup/resultSchemas.ts` — lineage fields on `backupSnapshotResultSchema`.
+- **Modify** `apps/api/src/services/backupResultPersistence.ts` — lineage on write + late-result fence.
+- **Modify** `apps/api/src/services/backupSnapshotReconcile.ts` — forward lineage, refuse retired/too-old/base-missing adoption.
+- **Modify** `apps/api/src/routes/backup/configs.ts` — `warnings: ['storage_identity_changed']` on PATCH.
+- **Test (modify)** `apps/api/src/jobs/backupWorker.test.ts`, `apps/api/src/jobs/backupRetention.test.ts`, `apps/api/src/jobs/staleCommandReaper.test.ts`, `apps/api/src/services/backupResultPersistence.test.ts`, `apps/api/src/services/backupSnapshotReconcile.test.ts`, `apps/api/src/routes/backup/configs.test.ts`.
+- **Test (new)** `apps/api/src/__tests__/integration/backupRetentionPins.integration.test.ts`, `apps/api/src/__tests__/integration/backupSnapshotRetirementsRls.integration.test.ts`.
+
+---
+
+### Task 1: Migration 140005 — `backup_jobs` pin/identity columns + guarded SQL backfill for `backup_snapshots.storage_identity`
+
+**Files:** Create `apps/api/migrations/2026-10-15-140005-backup-jobs-base-pin-and-storage-identity.sql`.
+
+**Decision (backfill mechanism):** the spec (§3.6/§4) is explicit that this must be a SQL backfill inside the migration, guarded to only touch rows whose config was **not** edited after the snapshot (`backup_configs.updated_at <= backup_snapshots.timestamp`) — everything else, including every NULL-`config_id` row, stays NULL and is self-healed later by the GC sweep (W02) from the storage listing. This supersedes a TS-script approach an earlier draft of this plan used; the guard exists precisely so the fidelity gap between `normalizeStorageIdentity`'s `path.resolve()`/`new URL()` semantics and a hand-written SQL equivalent only matters for the *unguarded* (self-healing) rows, not the ones this migration commits. See the open question below for what's still imperfect even inside the guard.
+
+- [ ] Step 1: Write the failing test — this migration has no unit-testable TS surface; the "red" step is observing the column/table absence against a real DB.
+  Command: `docker exec -it breeze-postgres psql -U breeze_app -d breeze -c "\d backup_jobs"` → confirm `base_snapshot_id`/`publish_lease_expires_at`/`storage_identity` are absent.
+
+- [ ] Step 2: Run it, expect FAIL (columns absent) — already true, this is the baseline.
+
+- [ ] Step 3: Implement
+
+```sql
+-- apps/api/migrations/2026-10-15-140005-backup-jobs-base-pin-and-storage-identity.sql
+-- D18 W01 (#5429 family, spec v3 §3.1/§3.6): server-chosen incremental-dedupe
+-- base pin with a fixed publish-lease deadline, plus a per-job/per-snapshot
+-- storage identity that survives a backup_configs destination edit.
+--
+-- publish_lease_expires_at is set for EVERY dispatched file/system_image job
+-- (base or not) at DISPATCH time only — it is never renewed (no delivery
+-- channel exists to renew it; see backupWorker.ts's stampDispatchPinAndIdentity
+-- docstring). storage_identity on backup_snapshots is nullable FOREVER: no
+-- follow-up NOT NULL migration exists for it. Rows this migration cannot
+-- confidently attribute (config edited after the snapshot, or no config_id at
+-- all) are left NULL and self-healed later by the GC sweep (W02) from the live
+-- storage listing.
+--
+-- Idempotent: IF NOT EXISTS on every column/index; the backfill only touches
+-- rows where storage_identity IS NULL, so re-running is a no-op once the
+-- eligible set has already been filled.
+
+DO $$
+BEGIN
+  ALTER TABLE backup_jobs ADD COLUMN IF NOT EXISTS base_snapshot_id varchar(255);
+  ALTER TABLE backup_jobs ADD COLUMN IF NOT EXISTS publish_lease_expires_at timestamptz;
+  ALTER TABLE backup_jobs ADD COLUMN IF NOT EXISTS storage_identity text;
+  RAISE NOTICE 'backup_jobs: base_snapshot_id / publish_lease_expires_at / storage_identity ensured';
+END $$;
+
+CREATE INDEX IF NOT EXISTS backup_jobs_base_snapshot_id_idx
+  ON backup_jobs (base_snapshot_id)
+  WHERE base_snapshot_id IS NOT NULL;
+
+DO $$
+BEGIN
+  ALTER TABLE backup_snapshots ADD COLUMN IF NOT EXISTS storage_identity text;
+  RAISE NOTICE 'backup_snapshots: storage_identity ensured (nullable, no NOT NULL — self-healed by the W02 GC sweep)';
+END $$;
+
+-- Guarded backfill (§3.6): only for rows whose config was NOT edited after the
+-- snapshot was taken, so the config's CURRENT provider/provider_config is
+-- known to be the same one the snapshot was actually written under. This is a
+-- best-effort PL/pgSQL port of normalizeStorageIdentity
+-- (apps/api/src/jobs/backupRetention.ts:661-672) — see the open question below
+-- for where it can diverge from the TS function.
+DO $$
+DECLARE
+  backfilled_count integer := 0;
+  left_null_count integer := 0;
+BEGIN
+  WITH candidates AS (
+    SELECT s.id,
+           c.provider,
+           c.provider_config
+    FROM backup_snapshots s
+    JOIN backup_configs c ON c.id = s.config_id
+    WHERE s.storage_identity IS NULL
+      AND c.updated_at <= s."timestamp"
+  ),
+  computed AS (
+    SELECT
+      id,
+      CASE
+        WHEN provider = 'local' THEN
+          'local::' || regexp_replace(
+            COALESCE(provider_config->>'path', provider_config->>'basePath', ''),
+            '/+$', ''
+          )
+        ELSE
+          provider || '::' ||
+          CASE
+            WHEN provider_config->>'endpoint' IS NULL OR btrim(provider_config->>'endpoint') = '' THEN ''
+            WHEN lower(regexp_replace(regexp_replace(provider_config->>'endpoint', '^[a-zA-Z]+://', ''), '/.*$', ''))
+                 ~ '^s3(\.dualstack)?([.-][a-z0-9-]+)?\.amazonaws\.com(:[0-9]+)?$'
+              THEN ''
+            ELSE lower(regexp_replace(regexp_replace(provider_config->>'endpoint', '^[a-zA-Z]+://', ''), '/.*$', ''))
+          END
+          || '::' ||
+          btrim(COALESCE(provider_config->>'bucket', provider_config->>'bucketName', ''))
+      END AS identity
+    FROM candidates
+  )
+  UPDATE backup_snapshots s
+  SET storage_identity = computed.identity
+  FROM computed
+  WHERE s.id = computed.id;
+
+  GET DIAGNOSTICS backfilled_count = ROW_COUNT;
+  IF backfilled_count > 0 THEN
+    RAISE WARNING 'backup_snapshots storage_identity backfill: % row(s) backfilled from an unedited-since-snapshot config', backfilled_count;
+  END IF;
+
+  SELECT count(*) INTO left_null_count FROM backup_snapshots WHERE storage_identity IS NULL;
+  IF left_null_count > 0 THEN
+    RAISE WARNING 'backup_snapshots storage_identity backfill: % row(s) left NULL (config edited after the snapshot, or config_id NULL) — the W02 GC sweep self-heals these from the storage listing per spec §3.6', left_null_count;
+  END IF;
+END $$;
+```
+
+- [ ] Step 4: Run, expect PASS
+  Commands:
+  - `pnpm db:migrate`
+  - `docker exec -it breeze-postgres psql -U breeze_app -d breeze -c "\d backup_jobs"` — confirm all three columns present.
+  - `docker exec -it breeze-postgres psql -U breeze_app -d breeze -c "SELECT count(*) FROM backup_snapshots WHERE storage_identity IS NOT NULL;"` — non-zero if any pre-existing rows had an unedited config.
+
+- [ ] Step 5: Commit
+  `git add apps/api/migrations/2026-10-15-140005-backup-jobs-base-pin-and-storage-identity.sql && git commit -m "feat(backup): base-pin/storage-identity columns + guarded backfill (D18 W01)"`
+
+---
+
+### Task 2: Drizzle schema edits — `backup.ts` new columns + `backupSnapshotRetirements` table
+
+**Files:** Modify `apps/api/src/db/schema/backup.ts` (add to `backupJobs` after `snapshotId` ~:247, `backupSnapshots` after `backupType` ~:322, new table after `backupSnapshotFiles` ~:356).
+
+**Interfaces:** Produces `backupSnapshotRetirements` Drizzle table export, `backupJobs.baseSnapshotId`/`.publishLeaseExpiresAt`/`.storageIdentity`, `backupSnapshots.storageIdentity`.
+
+- [ ] Step 1: Write the failing test (schema drift is the mechanical gate here — no unit framework exercises schema files directly per repo convention)
+  Command: `pnpm db:check-drift` — expect FAIL once Task 1's migration is applied but the schema hasn't caught up (or vice versa if this task lands first).
+
+- [ ] Step 2: Confirm the FAIL is the expected drift (missing columns/table), not a pre-existing unrelated one.
+
+- [ ] Step 3: Implement
+
+```ts
+// apps/api/src/db/schema/backup.ts — inside backupJobs' column object, after `snapshotId` (~:247)
+    // D18 W01 (#5429/§3.1): server-chosen incremental-dedupe base for this
+    // run. Deliberately NOT a FK — a pin must survive independent of the base
+    // row's own lifecycle; retention checks this column directly.
+    baseSnapshotId: varchar('base_snapshot_id', { length: 255 }),
+    // Fixed publish deadline, set once at dispatch for EVERY dispatched
+    // file/system_image job (base or not) — never renewed (no delivery
+    // channel exists to renew it on progress). A pin is live while
+    // status IN ('pending','running') OR
+    // publish_lease_expires_at + BACKUP_PUBLISH_MARGIN_MS > now().
+    publishLeaseExpiresAt: timestamp('publish_lease_expires_at', { withTimezone: true }),
+    // D18 W01 (#5429/§3.6): the identity of the providerConfig actually
+    // placed in the DISPATCH payload — stamped once, at dispatch, regardless
+    // of whether a base was found. Copied onto backup_snapshots.storageIdentity
+    // at publication so GC groups by write-time identity, not the config's
+    // possibly-since-edited current one.
+    storageIdentity: text('storage_identity'),
+```
+
+```ts
+// apps/api/src/db/schema/backup.ts — inside backupSnapshots' column object, after `backupType` (~:322)
+    // D18 W01 (#5429/§3.6): copied from the owning job's storageIdentity at
+    // publication (or by reconcile from the adoptable job). Nullable FOREVER
+    // — the W02 sweep self-heals a NULL row from the storage listing; there
+    // is no follow-up NOT NULL migration.
+    storageIdentity: text('storage_identity'),
+```
+
+```ts
+// apps/api/src/db/schema/backup.ts — new table, placed after backupSnapshotFiles (~:356)
+export const backupSnapshotRetirementReasonEnum = pgEnum('backup_snapshot_retirement_reason', [
+  'expired',
+  'max_versions',
+  'manual',
+]);
+
+// D18 W01 (#5429/§3.3): a durable tombstone written the instant retention
+// deletes a backup_snapshots row. Age alone cannot distinguish "expired" from
+// "orphan" and cannot stop reconcile re-adopting an expired prefix mid-sweep
+// — see the design doc's "why" note. Shape 1 (plain org_id) tenancy.
+export const backupSnapshotRetirements = pgTable(
+  'backup_snapshot_retirements',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    orgId: uuid('org_id')
+      .notNull()
+      .references(() => organizations.id),
+    configId: uuid('config_id').references(() => backupConfigs.id, { onDelete: 'cascade' }),
+    deviceId: uuid('device_id').references(() => devices.id, { onDelete: 'set null' }),
+    snapshotId: varchar('snapshot_id', { length: BACKUP_SNAPSHOT_ID_MAX_LENGTH }).notNull(),
+    storageIdentity: text('storage_identity').notNull(),
+    backupType: backupTypeEnum('backup_type'),
+    reason: backupSnapshotRetirementReasonEnum('reason').notNull(),
+    retiredAt: timestamp('retired_at', { withTimezone: true }).defaultNow().notNull(),
+    // Set by the GC sweep (W02) once the prefix is confirmed empty. NULL =
+    // not yet swept. Rows are pruned 30d after this is set.
+    sweptAt: timestamp('swept_at', { withTimezone: true }),
+  },
+  (table) => ({
+    orgIdIdx: index('backup_snapshot_retirements_org_id_idx').on(table.orgId),
+    storageIdentitySnapshotUq: uniqueIndex('backup_snapshot_retirements_identity_snapshot_uq').on(
+      table.storageIdentity,
+      table.snapshotId
+    ),
+    identitySweptIdx: index('backup_snapshot_retirements_identity_swept_idx').on(
+      table.storageIdentity,
+      table.sweptAt
+    ),
+  })
+);
+```
+
+  (`text` and `pgEnum` are already imported at the top of `backup.ts` — confirmed at lines 1-15.)
+
+- [ ] Step 4: Run, expect PASS
+  Command: `pnpm db:check-drift`
+
+- [ ] Step 5: Commit
+  `git add apps/api/src/db/schema/backup.ts && git commit -m "feat(backup): add base-pin/storage-identity columns and backupSnapshotRetirements schema (D18 W01)"`
+
+---
+
+### Task 3: `backup_snapshot_retirements` table + RLS migration
+
+**Files:** Create `apps/api/migrations/2026-10-15-140006-backup-snapshot-retirements.sql`.
+
+- [ ] Step 1: Write the failing test
+  Command: `docker exec -it breeze-postgres psql -U breeze_app -d breeze -c "SELECT * FROM backup_snapshot_retirements LIMIT 1;"` → expect `ERROR: relation "backup_snapshot_retirements" does not exist`.
+
+- [ ] Step 2: Run it, expect FAIL (as above).
+
+- [ ] Step 3: Implement
+
+```sql
+-- apps/api/migrations/2026-10-15-140006-backup-snapshot-retirements.sql
+-- D18 W01 (#5429/§3.3): backup_snapshot_retirements — durable tombstone
+-- written by retention the instant it deletes an expired/pruned
+-- backup_snapshots row (see backupRetention.ts's cleanupExpiredSnapshots).
+--
+-- Shape 1 tenancy (plain org_id column), same RLS pattern as
+-- 2026-04-11-bucket-a-rls-policies.sql:12-32. config_id cascades (a config's
+-- deletion should not orphan its retirement ledger); device_id is SET NULL
+-- (retirement history must survive the device being deleted).
+--
+-- Idempotent: IF NOT EXISTS throughout; DROP POLICY IF EXISTS before create.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'backup_snapshot_retirement_reason') THEN
+    CREATE TYPE backup_snapshot_retirement_reason AS ENUM ('expired', 'max_versions', 'manual');
+  END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS backup_snapshot_retirements (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id uuid NOT NULL REFERENCES organizations(id),
+  config_id uuid REFERENCES backup_configs(id) ON DELETE CASCADE,
+  device_id uuid REFERENCES devices(id) ON DELETE SET NULL,
+  snapshot_id varchar(255) NOT NULL,
+  storage_identity text NOT NULL,
+  backup_type backup_type,
+  reason backup_snapshot_retirement_reason NOT NULL,
+  retired_at timestamptz NOT NULL DEFAULT now(),
+  swept_at timestamptz
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS backup_snapshot_retirements_identity_snapshot_uq
+  ON backup_snapshot_retirements (storage_identity, snapshot_id);
+
+CREATE INDEX IF NOT EXISTS backup_snapshot_retirements_identity_swept_idx
+  ON backup_snapshot_retirements (storage_identity, swept_at);
+
+CREATE INDEX IF NOT EXISTS backup_snapshot_retirements_org_id_idx
+  ON backup_snapshot_retirements (org_id);
+
+DROP POLICY IF EXISTS breeze_org_isolation_select ON backup_snapshot_retirements;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON backup_snapshot_retirements;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON backup_snapshot_retirements;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON backup_snapshot_retirements;
+
+ALTER TABLE backup_snapshot_retirements ENABLE ROW LEVEL SECURITY;
+ALTER TABLE backup_snapshot_retirements FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY breeze_org_isolation_select ON backup_snapshot_retirements
+  FOR SELECT USING (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_insert ON backup_snapshot_retirements
+  FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_update ON backup_snapshot_retirements
+  FOR UPDATE USING (public.breeze_has_org_access(org_id))
+  WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_delete ON backup_snapshot_retirements
+  FOR DELETE USING (public.breeze_has_org_access(org_id));
+```
+
+  Note: `varchar(255)` here (not `BACKUP_SNAPSHOT_ID_MAX_LENGTH`'s literal value) matches the width already used for `backup_jobs.base_snapshot_id` in Task 1 — confirm both stay in sync with the constant if it ever changes.
+
+- [ ] Step 4: Run, expect PASS
+  Commands:
+  - `pnpm db:migrate`
+  - `docker exec -it breeze-postgres psql -U breeze_app -d breeze -c "SELECT * FROM backup_snapshot_retirements LIMIT 1;"` → `0 rows`, no error.
+  - `pnpm db:check-drift`
+
+- [ ] Step 5: Commit
+  `git add apps/api/migrations/2026-10-15-140006-backup-snapshot-retirements.sql && git commit -m "feat(backup): backup_snapshot_retirements table + RLS (D18 W01)"`
+
+---
+
+### Task 4: Registries — `tenantCascade.ts`, `devices/core.ts`, `tenantExportPolicyRegistry.ts`
+
+**Files:** Modify `apps/api/src/services/tenantCascade.ts` (insert between the verified `'backup_sla_events'`/`'backup_snapshots'` lines), `apps/api/src/routes/devices/core.ts` (both lists), `apps/api/src/services/tenantExportPolicyRegistry.ts` (widen two entries + one new entry).
+
+- [ ] Step 1: Write the failing test (these are existing contract tests — run them first to establish red/green)
+  Commands:
+  - `find apps/api/src -iname "tenantCascade*integration*"` to confirm the exact path, then `cd apps/api && npx vitest run <that path>`
+  - `ls apps/api/src/routes/devices/*.test.ts | grep -iE "cascade|moveorg"` to confirm exact filenames, then run both
+  - `grep -n check-tenant-export-policy apps/api/package.json` to confirm the invocation, then run it
+
+- [ ] Step 2: Run against Task 2/3's new schema with NO registry edits yet, expect FAIL:
+  - cascade test: `backup_snapshot_retirements has an org_id column but is missing from CORE_ORG_CASCADE_DELETE_ORDER`
+  - device cascade tests: `backup_snapshot_retirements has a device_id column but is missing from CORE_DEVICE_CASCADE_DELETE_TABLES` / `...CORE_DEVICE_ORG_DENORMALIZED_TABLES`
+  - export-policy check: `backup_jobs.base_snapshot_id`/`.publish_lease_expires_at`/`.storage_identity: unclassified`, `backup_snapshots.storage_identity: unclassified`, every `backup_snapshot_retirements.*` column unclassified.
+
+- [ ] Step 3: Implement
+
+```ts
+// apps/api/src/services/tenantCascade.ts — insert between the verified 'backup_sla_events' and 'backup_snapshots' lines
+  'backup_sla_configs',
+  'backup_sla_events',
+  'backup_snapshot_retirements',
+  'backup_snapshots',
+```
+
+```ts
+// apps/api/src/routes/devices/core.ts — CORE_DEVICE_ORG_DENORMALIZED_TABLES, same insertion point
+  'backup_chains', 'backup_jobs', 'backup_sla_events', 'backup_snapshot_retirements',
+  'backup_snapshots', 'backup_verifications',
+```
+
+```ts
+// apps/api/src/routes/devices/core.ts — CORE_DEVICE_CASCADE_DELETE_TABLES
+// (device_id is nullable ON DELETE SET NULL — no FK-direction ordering
+// constraint against backup_snapshots/backup_jobs; added alongside them)
+  'recovery_tokens', 'backup_chains',
+  'restore_jobs', 'backup_verifications', 'backup_snapshots', 'backup_jobs', 'backup_snapshot_retirements',
+```
+
+```ts
+// apps/api/src/services/tenantExportPolicyRegistry.ts — widen backup_jobs (verified current line)
+  "backup_jobs": tablePolicy("org_id", {"included":["id","org_id","config_id","policy_id","feature_link_id","device_id","status","type","backup_mode","started_at","completed_at","total_size","transferred_size","file_count","error_count","error_log","snapshot_id","backup_type","last_progress_at","total_files","referenced_size","referenced_files","base_snapshot_id","publish_lease_expires_at","storage_identity","created_at","updated_at"],"reviewedIncluded":[],"excludedSensitive":[],"excludedOpen":["mode_targets","vss_metadata"]}),
+```
+
+```ts
+// apps/api/src/services/tenantExportPolicyRegistry.ts — widen backup_snapshots (verified current line)
+  "backup_snapshots": tablePolicy("org_id", {"included":["id","org_id","job_id","device_id","config_id","snapshot_id","label","location","timestamp","size","file_count","is_incremental","parent_snapshot_id","expires_at","storage_tier","is_immutable","immutable_until","legal_hold","legal_hold_reason","immutability_enforcement","requested_immutability_enforcement","immutability_fallback_reason","checksum_sha256","backup_type","storage_identity"],"reviewedIncluded":["encryption_key_id"],"excludedSensitive":[],"excludedOpen":["metadata","gfs_tags","hardware_profile","system_state_manifest"]}),
+```
+
+```ts
+// apps/api/src/services/tenantExportPolicyRegistry.ts — new entry, alphabetically between backup_sla_events and backup_snapshots
+  "backup_snapshot_retirements": tablePolicy("org_id", {"included":["id","org_id","config_id","device_id","snapshot_id","storage_identity","backup_type","reason","retired_at","swept_at"],"reviewedIncluded":[],"excludedSensitive":[],"excludedOpen":[]}),
+```
+
+- [ ] Step 4: Run, expect PASS (same commands as Step 1)
+
+- [ ] Step 5: Commit
+  `git add apps/api/src/services/tenantCascade.ts apps/api/src/routes/devices/core.ts apps/api/src/services/tenantExportPolicyRegistry.ts && git commit -m "chore(backup): register backup_snapshot_retirements + new columns in cascade/export-policy registries (D18 W01)"`
+
+---
+
+### Task 5: `backupGcKnobs.ts` — shared per-run env-knob resolver
+
+**Files:** Create `apps/api/src/services/backupGcKnobs.ts`, `apps/api/src/services/backupGcKnobs.test.ts`.
+
+**Interfaces:** Produces `resolveMsKnob(envVarName: string, defaultMs: number, floorMs: number): number`, `resolveBackupBaseLeaseMs(): number`, `resolveBackupRestorePinLingerMs(): number`, `resolveBackupPublishMarginMs(): number`.
+
+- [ ] Step 1: Write the failing test
+
+```ts
+// apps/api/src/services/backupGcKnobs.test.ts
+import { describe, expect, it, afterEach } from 'vitest';
+import {
+  resolveMsKnob,
+  resolveBackupBaseLeaseMs,
+  resolveBackupRestorePinLingerMs,
+  resolveBackupPublishMarginMs,
+  BACKUP_BASE_LEASE_MS_DEFAULT,
+  BACKUP_RESTORE_PIN_LINGER_MS_DEFAULT,
+  BACKUP_PUBLISH_MARGIN_MS_DEFAULT,
+} from './backupGcKnobs';
+
+const ENV_VAR = 'BACKUP_TEST_KNOB_MS';
+
+afterEach(() => {
+  delete process.env[ENV_VAR];
+  delete process.env.NODE_ENV;
+});
+
+describe('resolveMsKnob', () => {
+  it('returns the default when unset', () => {
+    expect(resolveMsKnob(ENV_VAR, 1000, 100)).toBe(1000);
+  });
+
+  it('returns the override when set to a valid positive number above the floor', () => {
+    process.env[ENV_VAR] = '5000';
+    expect(resolveMsKnob(ENV_VAR, 1000, 100)).toBe(5000);
+  });
+
+  it('ignores a non-numeric override and falls back to default', () => {
+    process.env[ENV_VAR] = 'not-a-number';
+    expect(resolveMsKnob(ENV_VAR, 1000, 100)).toBe(1000);
+  });
+
+  it('enforces the production floor', () => {
+    process.env.NODE_ENV = 'production';
+    process.env[ENV_VAR] = '10';
+    expect(resolveMsKnob(ENV_VAR, 1000, 100)).toBe(100);
+  });
+
+  it('is resolved fresh on every call — not cached at module load', () => {
+    expect(resolveMsKnob(ENV_VAR, 1000, 100)).toBe(1000);
+    process.env[ENV_VAR] = '2000';
+    expect(resolveMsKnob(ENV_VAR, 1000, 100)).toBe(2000);
+  });
+});
+
+describe('per-knob defaults', () => {
+  it('BACKUP_BASE_LEASE_MS / BACKUP_RESTORE_PIN_LINGER_MS default to 7 days, BACKUP_PUBLISH_MARGIN_MS to 1 hour', () => {
+    expect(resolveBackupBaseLeaseMs()).toBe(BACKUP_BASE_LEASE_MS_DEFAULT);
+    expect(resolveBackupRestorePinLingerMs()).toBe(BACKUP_RESTORE_PIN_LINGER_MS_DEFAULT);
+    expect(resolveBackupPublishMarginMs()).toBe(BACKUP_PUBLISH_MARGIN_MS_DEFAULT);
+    expect(BACKUP_BASE_LEASE_MS_DEFAULT).toBe(7 * 24 * 60 * 60 * 1000);
+    expect(BACKUP_PUBLISH_MARGIN_MS_DEFAULT).toBe(60 * 60 * 1000);
+  });
+});
+```
+
+- [ ] Step 2: Run it, expect FAIL with `Cannot find module './backupGcKnobs'`
+  Command: `cd apps/api && npx vitest run src/services/backupGcKnobs.test.ts`
+
+- [ ] Step 3: Implement
+
+```ts
+// apps/api/src/services/backupGcKnobs.ts
+/**
+ * Shared per-run env-knob resolver for backup GC/retention timing constants.
+ *
+ * D18 (#5429): backupRetention.ts's existing BACKUP_GC_GRACE_MS is resolved
+ * once at module load (`export const BACKUP_GC_GRACE_MS = resolve...()`),
+ * so an env var change requires a process restart to take effect — a defect
+ * called out in the design doc's ground truth. Every knob added here (and
+ * every existing one W02 migrates here) is resolved FRESH on each call —
+ * never captured into a module-level `const`.
+ */
+function resolveMsKnob(envVarName: string, defaultMs: number, floorMs: number): number {
+  const raw = process.env[envVarName];
+  if (raw === undefined || raw.trim() === '') return defaultMs;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) {
+    console.warn(
+      `[BackupGcKnobs] Ignoring ${envVarName}=${JSON.stringify(raw)} (not a positive number); using default ${defaultMs} ms`,
+    );
+    return defaultMs;
+  }
+  if (process.env.NODE_ENV === 'production' && n < floorMs) {
+    console.warn(
+      `[BackupGcKnobs] ${envVarName}=${n} is below the production floor; using ${floorMs} ms instead`,
+    );
+    return floorMs;
+  }
+  if (n !== defaultMs) {
+    console.warn(`[BackupGcKnobs] ${envVarName} override active: ${n} ms (default ${defaultMs} ms)`);
+  }
+  return n;
+}
+
+export { resolveMsKnob };
+
+/**
+ * How long a base-snapshot pin (backup_jobs.base_snapshot_id) stays valid
+ * after dispatch. Matches the agent's journal max-age (7 days) — a run
+ * longer than this cannot resume anyway, so "must publish within the lease"
+ * is the existing envelope made explicit (spec §3.1, §8 decision 2).
+ */
+export const BACKUP_BASE_LEASE_MS_DEFAULT = 7 * 24 * 60 * 60 * 1000;
+const BACKUP_BASE_LEASE_MS_PRODUCTION_FLOOR = 60 * 60 * 1000;
+export function resolveBackupBaseLeaseMs(): number {
+  return resolveMsKnob('BACKUP_BASE_LEASE_MS', BACKUP_BASE_LEASE_MS_DEFAULT, BACKUP_BASE_LEASE_MS_PRODUCTION_FLOOR);
+}
+
+/**
+ * How long a restore_jobs row keeps pinning its snapshot AFTER creation,
+ * covering commandless/crashed restores (never reach a terminal status until
+ * staleCommandReaper's own 1h rule fires) and helpers that keep reading past
+ * the server's restore timeout.
+ */
+export const BACKUP_RESTORE_PIN_LINGER_MS_DEFAULT = 7 * 24 * 60 * 60 * 1000;
+const BACKUP_RESTORE_PIN_LINGER_MS_PRODUCTION_FLOOR = 60 * 60 * 1000;
+export function resolveBackupRestorePinLingerMs(): number {
+  return resolveMsKnob(
+    'BACKUP_RESTORE_PIN_LINGER_MS',
+    BACKUP_RESTORE_PIN_LINGER_MS_DEFAULT,
+    BACKUP_RESTORE_PIN_LINGER_MS_PRODUCTION_FLOOR,
+  );
+}
+
+/**
+ * Grace window added on top of publish_lease_expires_at before retention
+ * treats a base pin as released (spec §3.1: "the margin is what turns the
+ * pre-PUT check into a fence — the server keeps the pin for lease + margin,
+ * so a PUT that starts inside the margin completes before the pin lapses").
+ */
+export const BACKUP_PUBLISH_MARGIN_MS_DEFAULT = 60 * 60 * 1000;
+const BACKUP_PUBLISH_MARGIN_MS_PRODUCTION_FLOOR = 5 * 60 * 1000;
+export function resolveBackupPublishMarginMs(): number {
+  return resolveMsKnob(
+    'BACKUP_PUBLISH_MARGIN_MS',
+    BACKUP_PUBLISH_MARGIN_MS_DEFAULT,
+    BACKUP_PUBLISH_MARGIN_MS_PRODUCTION_FLOOR,
+  );
+}
+```
+
+- [ ] Step 4: Run, expect PASS
+  Command: `cd apps/api && npx vitest run src/services/backupGcKnobs.test.ts`
+
+- [ ] Step 5: Commit
+  `git add apps/api/src/services/backupGcKnobs.ts apps/api/src/services/backupGcKnobs.test.ts && git commit -m "feat(backup): add per-run env-knob resolver for GC/retention timing (D18 W01)"`
+
+---
+
+### Task 6: Dispatch — base selection, lease + storage-identity stamping, lock order job→snapshot
+
+**Files:** Modify `apps/api/src/jobs/backupWorker.ts:26` (imports), new function placed just above `prepareBackupDispatchTargets` (before line 609), and the per-target loop body (`:742` insertion point). Test: `apps/api/src/jobs/backupWorker.test.ts`.
+
+**Interfaces:**
+- Consumes: `resolveBackupBaseLeaseMs()` from `./services/backupGcKnobs`; `normalizeStorageIdentity` from `./backupRetention`; `backupSnapshotRetirements` schema; `desc`/`or`/`gt` added to the `drizzle-orm` import.
+- Produces: new function `stampDispatchPinAndIdentity(params): Promise<{ baseSnapshotId: string; publishLeaseExpiresAt: Date }>`; payload fields `baseSnapshotId: string` (`""` = full run) and `publishLeaseExpiresAt: string` (RFC3339) added to every `backup_run` command's payload.
+
+- [ ] Step 1: Write the failing test
+
+```ts
+// apps/api/src/jobs/backupWorker.test.ts — new describe block; add `transaction` to mockDb first:
+//   const mockDb = { ..., transaction: vi.fn((cb: (tx: unknown) => unknown) => cb(mockDb)) };
+describe('prepareBackupDispatchTargets — base pin + storage identity (D18 W01)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDb.select.mockReturnThis();
+    mockDb.from.mockReturnThis();
+    mockDb.where.mockReturnThis();
+    mockDb.limit.mockResolvedValue([]);
+    mockDb.transaction.mockImplementation((cb: (tx: unknown) => unknown) => cb(mockDb));
+  });
+
+  it('pins a base snapshot and includes baseSnapshotId/publishLeaseExpiresAt in the backup_run payload', async () => {
+    let capturedCommand: { payload?: Record<string, unknown> } | undefined;
+    agentRelayMock.dispatchCommandToAgent.mockImplementation(async (_agentId: string, command: any) => {
+      capturedCommand = command;
+      return { status: 'sent', via: 'local' };
+    });
+    // First select in the transaction is the base-candidate lookup; second
+    // (inside the `.for('share')` chain) is the re-check lock. Both return a
+    // matching row so the base is pinned.
+    let selectCall = 0;
+    mockDb.select.mockImplementation(() => {
+      selectCall += 1;
+      return {
+        from: vi.fn().mockReturnThis(),
+        innerJoin: vi.fn().mockReturnThis(),
+        leftJoin: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        orderBy: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockResolvedValue(
+          selectCall === 1 ? [{ id: 'base-row-id', snapshotId: 'base-snap-1' }] : [{ id: 'base-row-id' }],
+        ),
+        for: vi.fn().mockResolvedValue([{ id: 'base-row-id' }]),
+      };
+    });
+
+    await __testOnly.processDispatchBackup(DATA as any);
+
+    expect(capturedCommand?.payload?.baseSnapshotId).toBe('base-snap-1');
+    expect(typeof capturedCommand?.payload?.publishLeaseExpiresAt).toBe('string');
+  });
+
+  it('sends baseSnapshotId "" and still sets publishLeaseExpiresAt when no eligible base exists', async () => {
+    let capturedCommand: { payload?: Record<string, unknown> } | undefined;
+    agentRelayMock.dispatchCommandToAgent.mockImplementation(async (_agentId: string, command: any) => {
+      capturedCommand = command;
+      return { status: 'sent', via: 'local' };
+    });
+    mockDb.select.mockImplementation(() => ({
+      from: vi.fn().mockReturnThis(),
+      innerJoin: vi.fn().mockReturnThis(),
+      leftJoin: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      orderBy: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue([]),
+      for: vi.fn().mockResolvedValue([]),
+    }));
+
+    await __testOnly.processDispatchBackup(DATA as any);
+
+    expect(capturedCommand?.payload?.baseSnapshotId).toBe('');
+    expect(typeof capturedCommand?.payload?.publishLeaseExpiresAt).toBe('string');
+  });
+});
+```
+
+  (Adapt the exact chain shape to whatever `wireSelects()`-style helper this file already uses elsewhere in its suite — read the surrounding `describe('processDispatchBackup ...')` block before writing, and mirror its existing convention for routing `db.select({...})` calls by column-selector shape; the assertions above are the exact contract regardless of mock plumbing.)
+
+- [ ] Step 2: Run it, expect FAIL with `capturedCommand?.payload?.baseSnapshotId` being `undefined`
+  Command: `cd apps/api && npx vitest run src/jobs/backupWorker.test.ts`
+
+- [ ] Step 3: Implement
+
+```ts
+// apps/api/src/jobs/backupWorker.ts:26 — widen the drizzle-orm import
+import { eq, ne, and, or, desc, gt, sql, isNull, lt, inArray } from 'drizzle-orm';
+```
+
+```ts
+// apps/api/src/jobs/backupWorker.ts — new imports
+import { resolveBackupBaseLeaseMs } from '../services/backupGcKnobs';
+import { normalizeStorageIdentity } from './backupRetention';
+import { backupSnapshotRetirements } from '../db/schema/backup';
+```
+
+```ts
+// apps/api/src/jobs/backupWorker.ts — new function, placed just above prepareBackupDispatchTargets (before line 609)
+
+/**
+ * D18 §3.1/§3.6: stamps this job's storage_identity (from the providerConfig
+ * actually placed in the dispatch payload) and a FIXED publish-lease deadline
+ * — for EVERY dispatched file/system_image target, base found or not — and,
+ * when an eligible incremental-dedupe base exists, pins it.
+ *
+ * Lock order is JOB then SNAPSHOT (mirrors the parent-rows-first pattern at
+ * routes/devices/moveOrg.ts:248-253): the UPDATE on backup_jobs below takes
+ * the job row's lock first; the FOR SHARE re-check on backup_snapshots takes
+ * the candidate's lock second. Retention's per-row delete (backupRetention.ts)
+ * takes FOR UPDATE on the snapshot row — whichever side gets there first wins:
+ * the other either sees the live pin (and skips) or finds the row already
+ * gone (and this function falls back to a full run). No FK-column write
+ * happens while a lock from the other table is held (cf. #3911's key-share
+ * deadlock).
+ */
+async function stampDispatchPinAndIdentity(params: {
+  deviceId: string;
+  configId: string;
+  jobId: string;
+  mode: 'file' | 'system_image';
+  provider: string;
+  providerConfig: Record<string, unknown>;
+}): Promise<{ baseSnapshotId: string; publishLeaseExpiresAt: Date }> {
+  const leaseMs = resolveBackupBaseLeaseMs();
+  const publishLeaseExpiresAt = new Date(Date.now() + leaseMs);
+  const storageIdentity = normalizeStorageIdentity(params.provider, params.providerConfig);
+
+  return db.transaction(async (tx) => {
+    const [candidate] = await tx
+      .select({ id: backupSnapshots.id, snapshotId: backupSnapshots.snapshotId })
+      .from(backupSnapshots)
+      .innerJoin(backupJobs, eq(backupSnapshots.jobId, backupJobs.id))
+      .where(
+        and(
+          eq(backupSnapshots.deviceId, params.deviceId),
+          eq(backupSnapshots.configId, params.configId),
+          params.mode === 'system_image'
+            ? eq(backupSnapshots.backupType, 'system_image')
+            : or(eq(backupSnapshots.backupType, 'file'), isNull(backupSnapshots.backupType)),
+          or(isNull(backupSnapshots.expiresAt), gt(backupSnapshots.expiresAt, publishLeaseExpiresAt)),
+          eq(backupJobs.status, 'completed'),
+        ),
+      )
+      .orderBy(desc(backupSnapshots.timestamp))
+      .limit(1);
+
+    // Lock order: JOB row first (this UPDATE stamps identity/lease/tentative
+    // pin unconditionally — every dispatched backup_run job gets these).
+    await tx
+      .update(backupJobs)
+      .set({
+        storageIdentity,
+        publishLeaseExpiresAt,
+        baseSnapshotId: candidate?.snapshotId ?? null,
+      })
+      .where(eq(backupJobs.id, params.jobId));
+
+    if (!candidate) {
+      return { baseSnapshotId: '', publishLeaseExpiresAt };
+    }
+
+    // SNAPSHOT row second: FOR SHARE re-check that the candidate is still
+    // present and unretired. A concurrent retention delete either already
+    // removed the row (this SELECT returns nothing) or is blocked behind
+    // this lock until commit (its own FOR UPDATE on the same row).
+    const [locked] = await tx
+      .select({ id: backupSnapshots.id })
+      .from(backupSnapshots)
+      .leftJoin(
+        backupSnapshotRetirements,
+        and(
+          eq(backupSnapshotRetirements.storageIdentity, storageIdentity),
+          eq(backupSnapshotRetirements.snapshotId, candidate.snapshotId),
+        ),
+      )
+      .where(and(eq(backupSnapshots.id, candidate.id), isNull(backupSnapshotRetirements.id)))
+      .for('share');
+
+    if (!locked) {
+      await tx.update(backupJobs).set({ baseSnapshotId: null }).where(eq(backupJobs.id, params.jobId));
+      return { baseSnapshotId: '', publishLeaseExpiresAt };
+    }
+
+    return { baseSnapshotId: candidate.snapshotId, publishLeaseExpiresAt };
+  });
+}
+```
+
+```ts
+// apps/api/src/jobs/backupWorker.ts — inside prepareBackupDispatchTargets's per-target loop,
+// right before `const command: AgentCommand = {` (~:742):
+
+    let dispatchPin: { baseSnapshotId: string; publishLeaseExpiresAt: Date } | null = null;
+    if (target.commandType === 'backup_run') {
+      dispatchPin = await stampDispatchPinAndIdentity({
+        deviceId: data.deviceId,
+        configId: data.configId,
+        jobId: commandJobId,
+        mode: (target.payload as Record<string, unknown>).systemImage === true ? 'system_image' : 'file',
+        provider: config.provider,
+        providerConfig: commandProviderConfig,
+      });
+    }
+
+    const command: AgentCommand = {
+      id: commandJobId,
+      type: target.commandType,
+      payload: {
+        jobId: commandJobId,
+        configId: data.configId,
+        provider: config.provider,
+        providerConfig: commandProviderConfig,
+        storageEncryption: encryptionPlan.required
+          ? {
+              required: true,
+              mode: encryptionPlan.mode,
+              keyReference: encryptionPlan.keyReference,
+            }
+          : {
+              required: false,
+              mode: 'disabled',
+            },
+        ...(dispatchPin
+          ? {
+              baseSnapshotId: dispatchPin.baseSnapshotId,
+              publishLeaseExpiresAt: dispatchPin.publishLeaseExpiresAt.toISOString(),
+            }
+          : {}),
+        ...target.payload,
+      },
+    };
+```
+
+- [ ] Step 4: Run, expect PASS
+  Command: `cd apps/api && npx vitest run src/jobs/backupWorker.test.ts`
+
+- [ ] Step 5: Commit
+  `git add apps/api/src/jobs/backupWorker.ts apps/api/src/jobs/backupWorker.test.ts && git commit -m "feat(backup): stamp storage identity + publish lease and pin the dedupe base at dispatch (D18 W01 §3.1/§3.6)"`
+
+---
+
+### Task 7: `staleCommandReaper.ts` — reap commandless pending restores after 1h
+
+**Files:** Modify `apps/api/src/jobs/staleCommandReaper.ts` (new function + `REAPER_DOMAINS` entry, near `reapStaleBackupJobs` ~:1343-1482 and `:1496-1505`). Test: `apps/api/src/jobs/staleCommandReaper.test.ts`.
+
+**Interfaces:** Produces `reapCommandlessPendingRestores(): Promise<number>`, registered as `['commandlessRestores', reapCommandlessPendingRestores]` in `REAPER_DOMAINS`.
+
+- [ ] Step 1: Write the failing test
+
+```ts
+// apps/api/src/jobs/staleCommandReaper.test.ts — new case (mirror this file's existing db-mocking style for reapStaleBackupJobs)
+  it('fails a commandless pending restore_jobs row older than 1h (D18 W01 §3.2 F8)', async () => {
+    // Arrange: mockDb.update chain returns one row from .returning() for a
+    // restore_jobs row with command_id NULL, status 'pending', created_at
+    // 2h ago; a second row created 10 minutes ago must NOT match.
+    const reaped = await reapCommandlessPendingRestores();
+    expect(reaped).toBe(1);
+    // Assert the update's `.set()` argument had status: 'failed'.
+  });
+
+  it('does not touch a restore that already has a command_id', async () => {
+    // Arrange the same mocked update chain to return 0 rows when the WHERE
+    // includes `command_id IS NULL` and the seeded row has a commandId set.
+    const reaped = await reapCommandlessPendingRestores();
+    expect(reaped).toBe(0);
+  });
+```
+
+- [ ] Step 2: Run it, expect FAIL with `Cannot find name 'reapCommandlessPendingRestores'` (not exported yet)
+  Command: `cd apps/api && npx vitest run src/jobs/staleCommandReaper.test.ts`
+
+- [ ] Step 3: Implement
+
+```ts
+// apps/api/src/jobs/staleCommandReaper.ts — new constant, placed alongside the other Backup thresholds (~:97-100)
+const RESTORE_COMMANDLESS_PENDING_TIMEOUT_MS = 60 * 60 * 1000; // 1 hour
+```
+
+```ts
+// apps/api/src/jobs/staleCommandReaper.ts — new function, placed near reapStaleBackupJobs (~after :1482)
+
+/**
+ * D18 §3.2 (Codex F8): a restore_jobs row is created `pending` BEFORE its
+ * command_id exists (routes/backup/restore.ts:281,361) — a crash between
+ * those two statements leaves a row propagateTimedOutDeviceCommand can never
+ * reach, because that path matches restores ONLY by command_id
+ * (:220-240, `WHERE command_id = $1`). Without this reaper, such a row keeps
+ * retention's restore pin alive past its linger only by luck of the linger
+ * window, then pins forever with no path to a terminal status. This rule is
+ * independent of that linger: any commandless pending row older than one
+ * hour is failed outright, regardless of the (separately configurable)
+ * BACKUP_RESTORE_PIN_LINGER_MS retention uses for its own pin check.
+ */
+export async function reapCommandlessPendingRestores(): Promise<number> {
+  const cutoff = new Date(Date.now() - RESTORE_COMMANDLESS_PENDING_TIMEOUT_MS);
+  const completedAt = new Date();
+  const reapedRows = await db
+    .update(restoreJobs)
+    .set({
+      status: 'failed',
+      completedAt,
+      updatedAt: completedAt,
+      targetConfig: sql`coalesce(${restoreJobs.targetConfig}, '{}'::jsonb) || jsonb_build_object(
+        'error', 'Restore never received a command (crashed before dispatch)'
+      )`,
+    })
+    .where(
+      and(
+        isNull(restoreJobs.commandId),
+        eq(restoreJobs.status, 'pending'),
+        lt(restoreJobs.createdAt, cutoff),
+      ),
+    )
+    .returning({ id: restoreJobs.id });
+
+  if (reapedRows.length > 0) {
+    console.log(`[StaleCommandReaper] Reaped ${reapedRows.length} commandless pending restore(s)`);
+  }
+  return reapedRows.length;
+}
+```
+
+```ts
+// apps/api/src/jobs/staleCommandReaper.ts — REAPER_DOMAINS (~:1496-1505), new entry
+export const REAPER_DOMAINS = [
+  ['deviceCommands', reapStaleDeviceCommands],
+  ['scriptExecutions', reapStaleScriptExecutions],
+  ['scriptCancellations', reapStaleCancellations],
+  ['patchJobResults', reapStalePatchJobResults],
+  ['deploymentDevices', reapStaleDeploymentDevices],
+  ['softwareDeploymentResults', reapStaleSoftwareDeploymentResults],
+  ['remoteSessions', reapStaleRemoteSessions],
+  ['backupJobs', reapStaleBackupJobs],
+  ['commandlessRestores', reapCommandlessPendingRestores],
+] as const;
+```
+
+  `restoreJobs`, `sql`, `and`, `eq`, `lt`, `isNull` are already imported in this file (confirmed at the top-of-file `drizzle-orm` import and the existing `restoreJobs` usage in `propagateTimedOutDeviceCommand`).
+
+- [ ] Step 4: Run, expect PASS
+  Command: `cd apps/api && npx vitest run src/jobs/staleCommandReaper.test.ts`
+
+- [ ] Step 5: Commit
+  `git add apps/api/src/jobs/staleCommandReaper.ts apps/api/src/jobs/staleCommandReaper.test.ts && git commit -m "feat(backup): reap commandless pending restores after 1h (D18 W01 §3.2 F8)"`
+
+---
+
+### Task 8: Transaction boundaries (§3.7) — carve `cleanup-expired-snapshots` out of the worker's blanket wrap
+
+**Files:** Modify `apps/api/src/jobs/backupWorker.ts:77-130` (`createBackupWorker`), `:325-395` (`processCleanupExpiredSnapshots`). Test: `apps/api/src/jobs/backupWorker.test.ts`.
+
+**Why this task must land before Task 9:** Task 9 restructures `cleanupExpiredSnapshots` (in `backupRetention.ts`) to open its own real per-row transaction via `withSystemDbAccessContext`. That only works if the call arrives with NO ambient context already open — today it's nested inside the blanket `runWithSystemDbAccess(async () => { switch(...) {...} })` at `backupWorker.ts:101`, where a nested `withSystemDbAccessContext` call is a no-op passthrough (same outer transaction, no new commit boundary). This task removes that ambient wrap for `cleanup-expired-snapshots` the same way `dispatch-backup` is already excluded from it (`:89-99`), and gives the GC sweep call its own separate context so a sweep failure can never roll back a retirement Task 9 already committed.
+
+- [ ] Step 1: Write the failing test — a source-text contract test, mirroring the style of `backupAgentContract.test.ts`'s cross-file literal checks, since this is a structural wiring invariant rather than a behavior a mock can observe.
+
+```ts
+// apps/api/src/jobs/backupWorker.test.ts — new case
+  it('handles cleanup-expired-snapshots OUTSIDE the blanket runWithSystemDbAccess wrap (D18 W01 §3.7)', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const source = fs.readFileSync(path.resolve(__dirname, './backupWorker.ts'), 'utf-8');
+
+    const cleanupBranchIndex = source.indexOf("data.type === 'cleanup-expired-snapshots'");
+    const blanketWrapIndex = source.indexOf('return runWithSystemDbAccess(async () => {');
+    const switchCleanupCaseIndex = source.indexOf("case 'cleanup-expired-snapshots':");
+
+    expect(cleanupBranchIndex).toBeGreaterThan(-1);
+    expect(blanketWrapIndex).toBeGreaterThan(-1);
+    // The special-cased branch must appear BEFORE the blanket wrap.
+    expect(cleanupBranchIndex).toBeLessThan(blanketWrapIndex);
+    // The switch inside the blanket wrap must no longer have its own
+    // 'cleanup-expired-snapshots' case.
+    expect(switchCleanupCaseIndex).toBe(-1);
+  });
+```
+
+- [ ] Step 2: Run it, expect FAIL — `cleanupBranchIndex` is `-1` and `switchCleanupCaseIndex` is still found inside the switch.
+  Command: `cd apps/api && npx vitest run src/jobs/backupWorker.test.ts`
+
+- [ ] Step 3: Implement
+
+```ts
+// apps/api/src/jobs/backupWorker.ts:77-130 — createBackupWorker, restructured
+function createBackupWorker(): Worker<BackupQueueJobData> {
+  return new Worker<BackupQueueJobData>(
+    BACKUP_QUEUE,
+    async (job: Job<BackupQueueJobData>) => {
+      const data = parseQueueJobData(BACKUP_QUEUE, job, backupQueueJobDataSchema);
+      // dispatch-backup is handled OUTSIDE the blanket context below (#1105):
+      // it does Redis/WS I/O via the agentCommandRelay facade ...
+      if (data.type === 'dispatch-backup') {
+        assertQueueJobName(BACKUP_QUEUE, job, 'dispatch-backup');
+        return await processDispatchBackup(data, { redelivered: job.attemptsStarted > 1 });
+      }
+      // cleanup-expired-snapshots is ALSO handled outside the blanket
+      // context (D18 §3.7): its own retention pass must open one real
+      // system-DB transaction PER CANDIDATE ROW so a retirement commits
+      // durably before the next row is even considered, and the GC sweep
+      // that follows must run in its own separate context so a sweep
+      // failure can never roll back a retirement already committed.
+      // processCleanupExpiredSnapshots (below) manages both of those
+      // contexts itself — nesting it inside runWithSystemDbAccess here would
+      // silently collapse every one of those into the single ambient
+      // transaction this task exists to eliminate.
+      if (data.type === 'cleanup-expired-snapshots') {
+        assertQueueJobName(BACKUP_QUEUE, job, 'cleanup-expired-snapshots');
+        return await processCleanupExpiredSnapshots();
+      }
+      return runWithSystemDbAccess(async () => {
+        switch (data.type) {
+          case 'check-schedules':
+            assertQueueJobName(BACKUP_QUEUE, job, 'check-schedules');
+            return await processCheckSchedules();
+          case 'expire-recovery-tokens':
+            assertQueueJobName(BACKUP_QUEUE, job, 'expire-recovery-tokens');
+            return await processExpireRecoveryTokens();
+          case 'process-results':
+            assertQueueJobName(BACKUP_QUEUE, job, 'process-results');
+            return await processResults(data);
+          default:
+            throw new Error(
+              `Unknown job type: ${(data as { type: string }).type}`
+            );
+        }
+      });
+    },
+    {
+      connection: getBullMQConnection(),
+      concurrency: 5,
+      lockDuration: 300_000,
+      stalledInterval: 60_000,
+      maxStalledCount: 2,
+    }
+  );
+}
+```
+
+```ts
+// apps/api/src/jobs/backupWorker.ts:325-395 — processCleanupExpiredSnapshots, only the wrapping changes
+export async function processCleanupExpiredSnapshots(): Promise<{
+  deleted: number;
+  skipped: number;
+  prunedByMaxVersions: number;
+  failed: number;
+  gcDeleted: number;
+  gcSkippedIdentities: number;
+  gcBlockedIdentities: number;
+}> {
+  // D18 §3.7: this whole function now runs with NO ambient DB context (it is
+  // called directly from the worker, no longer inside the blanket wrap) — the
+  // read below and cleanupExpiredSnapshots's own per-row work each open their
+  // OWN context explicitly.
+  const orgRows = await runWithSystemDbAccess(() =>
+    db.selectDistinct({ orgId: backupSnapshots.orgId }).from(backupSnapshots)
+  );
+
+  let deleted = 0;
+  let skipped = 0;
+  let prunedByMaxVersions = 0;
+  let failed = 0;
+
+  for (const { orgId } of orgRows) {
+    // cleanupExpiredSnapshots (backupRetention.ts) opens its OWN per-
+    // candidate-row system context internally — deliberately NOT wrapped
+    // here, so each row's retirement-insert + delete commits independently
+    // of every other row and of the sweep below.
+    const result = await cleanupExpiredSnapshots(orgId);
+    deleted += result.deleted;
+    skipped += result.skippedLegalHold + result.skippedImmutable;
+    prunedByMaxVersions += result.prunedByMaxVersions;
+    failed += result.failed;
+  }
+
+  let gcDeleted = 0;
+  let gcSkippedIdentities = 0;
+  let gcBlockedIdentities = 0;
+  try {
+    // Its own context, separate from every retention row's — a GC failure
+    // must never roll back a retirement that has already committed.
+    const gcResult = await runWithSystemDbAccess(() => sweepUnreferencedBackupObjects());
+    gcDeleted = gcResult.deleted;
+    gcSkippedIdentities = gcResult.skippedIdentities;
+    gcBlockedIdentities = gcResult.blockedIdentities;
+  } catch (err) {
+    console.error('[BackupWorker] Backup object GC sweep failed — retention run still succeeded:', err);
+    captureException(err instanceof Error ? err : new Error(String(err)));
+  }
+
+  if (failed > 0) {
+    throw new Error(
+      `[BackupWorker] cleanup-expired-snapshots: ${failed} snapshot row delete(s) failed this run — ` +
+      'see prior [BackupRetention] per-row error logs for detail; rows will be retried next run.'
+    );
+  }
+
+  return { deleted, skipped, prunedByMaxVersions, failed, gcDeleted, gcSkippedIdentities, gcBlockedIdentities };
+}
+```
+
+- [ ] Step 4: Run, expect PASS
+  Command: `cd apps/api && npx vitest run src/jobs/backupWorker.test.ts`
+
+- [ ] Step 5: Commit
+  `git add apps/api/src/jobs/backupWorker.ts apps/api/src/jobs/backupWorker.test.ts && git commit -m "fix(backup): carve cleanup-expired-snapshots out of the blanket transaction wrap (D18 W01 §3.7)"`
+
+---
+
+### Task 9: Retention — per-row commits, pin checks (backup/restore/recovery), retirement insert
+
+**Files:** Modify `apps/api/src/jobs/backupRetention.ts:9-31` (imports), `:159-171` (`RetentionCleanupResult`), `:189-221` (`deleteSnapshotRow`/`tryDeleteSnapshotRow`, rewritten), `:231-387` (`cleanupExpiredSnapshots`, read/pin/delete phases re-wrapped). Test: `apps/api/src/jobs/backupRetention.test.ts`.
+
+**Interfaces:**
+- Consumes: `withSystemDbAccessContext` from `../db`; `resolveBackupRestorePinLingerMs`/`resolveBackupPublishMarginMs` from `../services/backupGcKnobs`; `restoreJobs`, `backupSnapshotRetirements`, `IN_FLIGHT_BACKUP_JOB_STATUSES` from `../db/schema/backup`; `recoveryTokens` from `../db/schema/recoveryTokens`; `gt` added to the `drizzle-orm` import.
+- Produces: `RetentionCleanupResult` gains `skippedPinned: number`. `tryDeleteSnapshotRow` now returns `'deleted' | 'pinned' | 'failed'` (was `boolean`) and opens its own `withSystemDbAccessContext` per call — one real top-level transaction per candidate row, per §3.7.
+
+- [ ] Step 1: Write the failing test — update the shared `chainable`/`mockDb` fixture first (it currently has no `.for()`, no `insert`, and the `'../db'` mock exports only `db`):
+
+```ts
+// apps/api/src/jobs/backupRetention.test.ts — fixture changes near the top of the file
+function chainable(rows: unknown[]) {
+  const obj: Record<string, unknown> = {
+    from: () => obj,
+    where: () => obj,
+    leftJoin: () => obj,
+    innerJoin: () => obj,
+    orderBy: () => obj,
+    limit: () => obj,
+    for: () => obj,
+    then: (resolve: (v: unknown[]) => unknown, reject?: (e: unknown) => unknown) =>
+      Promise.resolve(rows).then(resolve, reject),
+  };
+  return obj;
+}
+
+const selectQueue: unknown[][] = [];
+const insertedRows: unknown[] = [];
+
+const mockDb = {
+  select: vi.fn(() => chainable(selectQueue.shift() ?? [])),
+  delete: vi.fn(() => chainable([])),
+  update: vi.fn(() => chainable([])),
+  insert: vi.fn((table: unknown) => ({
+    values: (v: unknown) => {
+      insertedRows.push(v);
+      return chainable([]);
+    },
+  })),
+};
+
+vi.mock('../db', () => ({
+  db: mockDb,
+  withSystemDbAccessContext: (fn: () => unknown) => fn(),
+}));
+```
+
+```ts
+// apps/api/src/jobs/backupRetention.test.ts — new describe block
+describe('cleanupExpiredSnapshots — pins + retirement (D18 W01 §3.2/§3.3/§3.7)', () => {
+  beforeEach(() => {
+    selectQueue.length = 0;
+    insertedRows.length = 0;
+  });
+
+  it('skips a row pinned by an in-flight backup_jobs base pin and counts it as skippedPinned', async () => {
+    selectQueue.push([{
+      id: 'snap-1', snapshotId: 'snap-1-provider', metadata: null, legalHold: false,
+      isImmutable: false, immutableUntil: null, provider: 's3', providerConfig: {},
+      orgId: 'org-1', configId: 'config-1', deviceId: 'device-1', storageIdentity: 's3::e::b', backupType: 'file',
+    }]); // candidate select
+    selectQueue.push([{ id: 'snap-1' }]); // FOR UPDATE lock
+    selectQueue.push([{ id: 'job-1' }]); // backup pin — found, short-circuits
+    selectQueue.push([]); // versionBoundSnapshots pass (empty)
+
+    const result = await cleanupExpiredSnapshots('org-1');
+
+    expect(result.skippedPinned).toBe(1);
+    expect(result.deleted).toBe(0);
+    expect(insertedRows.length).toBe(0);
+  });
+
+  it('writes a retirement row and deletes the snapshot row when unpinned', async () => {
+    selectQueue.push([{
+      id: 'snap-2', snapshotId: 'snap-2-provider', metadata: null, legalHold: false,
+      isImmutable: false, immutableUntil: null, provider: 's3', providerConfig: { bucket: 'b', endpoint: 'e' },
+      orgId: 'org-1', configId: 'config-1', deviceId: 'device-1', storageIdentity: 's3::e::b', backupType: 'file',
+    }]); // candidate select
+    selectQueue.push([{ id: 'snap-2' }]); // FOR UPDATE lock
+    selectQueue.push([]); // backup pin — none
+    selectQueue.push([]); // restore pin — none
+    selectQueue.push([]); // recovery pin — none
+    selectQueue.push([]); // versionBoundSnapshots pass (empty)
+
+    const result = await cleanupExpiredSnapshots('org-1');
+
+    expect(result.deleted).toBe(1);
+    expect(result.skippedPinned).toBe(0);
+    expect(insertedRows).toEqual([
+      expect.objectContaining({ snapshotId: 'snap-2-provider', storageIdentity: 's3::e::b', reason: 'expired' }),
+    ]);
+  });
+});
+```
+
+- [ ] Step 2: Run it, expect FAIL — `result.skippedPinned` is `undefined` (field doesn't exist yet); `insertedRows` stays empty in the second case (no retirement is written today).
+  Command: `cd apps/api && npx vitest run src/jobs/backupRetention.test.ts`
+
+- [ ] Step 3: Implement
+
+```ts
+// apps/api/src/jobs/backupRetention.ts:9-18 — widen imports
+import { resolve as resolveLocalPath } from 'node:path';
+import { db, withSystemDbAccessContext } from '../db';
+import {
+  backupSnapshots,
+  backupPolicies,
+  backupJobs,
+  configPolicyBackupSettings,
+  backupConfigs,
+  restoreJobs,
+  backupSnapshotRetirements,
+  IN_FLIGHT_BACKUP_JOB_STATUSES,
+} from '../db/schema/backup';
+import { recoveryTokens } from '../db/schema/recoveryTokens';
+import { eq, and, or, lt, gt, desc, inArray, isNull } from 'drizzle-orm';
+import { resolveBackupRestorePinLingerMs, resolveBackupPublishMarginMs } from '../services/backupGcKnobs';
+```
+
+  (`configPolicyBackupSettings`/`backupConfigs`/`backupPolicies`/`backupSnapshots`/`backupJobs` were previously imported from `'../db/schema'` (the barrel) — switching `restoreJobs`/`backupSnapshotRetirements`/`IN_FLIGHT_BACKUP_JOB_STATUSES` to the concrete `'../db/schema/backup'` module avoids a barrel/mock mismatch in `backupRetention.test.ts`'s `vi.mock('../db/schema', ...)` if one exists — confirm during implementation whether the file's existing imports already come from `'../db/schema'` or `'../db/schema/backup'` and match that convention exactly rather than mixing styles.)
+
+```ts
+// apps/api/src/jobs/backupRetention.ts:159-171 — RetentionCleanupResult gains a field
+export type RetentionCleanupResult = {
+  deleted: number;
+  skippedLegalHold: number;
+  skippedImmutable: number;
+  skippedPinned: number;
+  prunedByMaxVersions: number;
+  failed: number;
+};
+```
+
+```ts
+// apps/api/src/jobs/backupRetention.ts:189-221 — replace deleteSnapshotRow + tryDeleteSnapshotRow
+/**
+ * Deletes a `backup_snapshots` ROW ONLY, after checking every pin type (D18
+ * §3.2: backup-job base pin via publish_lease_expires_at + margin, restore-job
+ * pin, recovery-token pin — legal hold/immutability are checked by the caller
+ * before this is ever invoked) and writing a durable retirement tombstone
+ * (backup_snapshot_retirements) in the SAME per-row system context as the
+ * delete. The caller (`tryDeleteSnapshotRow`) wraps this whole function in its
+ * own `withSystemDbAccessContext` call — since `cleanupExpiredSnapshots` is no
+ * longer invoked from inside any ambient transaction (D18 §3.7,
+ * jobs/backupWorker.ts), that call opens a REAL top-level Postgres
+ * transaction distinct from every other row's, so a retirement written here
+ * commits durably before the next candidate row is even considered.
+ *
+ * Deliberately does NOT touch object storage — under the incremental/
+ * synthetic-full manifest model, an incremental snapshot's unchanged files
+ * are references whose backupPath points into an OLDER snapshot's prefix, so
+ * eagerly nuking this snapshot's whole storage prefix the instant its row
+ * expires would delete objects a still-retained sibling snapshot's manifest
+ * still points at. Object deletion is the mark-and-sweep GC's exclusive job
+ * (sweepUnreferencedBackupObjects, W02): the retirement row this function
+ * writes is what lets that sweep treat this snapshot's exclusive objects as
+ * garbage immediately, with no age-based ambiguity between "expired" and
+ * merely "orphaned".
+ *
+ * Returns 'pinned' (left alone, a pin is still live) or 'deleted' (row
+ * removed and retirement written, or the row was already gone — a no-op
+ * treated as success).
+ */
+async function deleteSnapshotRow(params: {
+  id: string;
+  snapshotId: string;
+  orgId: string;
+  configId: string | null;
+  deviceId: string | null;
+  storageIdentity: string | null;
+  backupType: (typeof backupSnapshots.$inferSelect)['backupType'];
+  reason: 'expired' | 'max_versions';
+}): Promise<'pinned' | 'deleted'> {
+  const restoreLingerMs = resolveBackupRestorePinLingerMs();
+  const restoreLingerCutoff = new Date(Date.now() - restoreLingerMs);
+  const publishMarginMs = resolveBackupPublishMarginMs();
+  const publishMarginCutoff = new Date(Date.now() - publishMarginMs);
+
+  const [locked] = await db
+    .select({ id: backupSnapshots.id })
+    .from(backupSnapshots)
+    .where(eq(backupSnapshots.id, params.id))
+    .for('update');
+
+  if (!locked) {
+    // Already gone (concurrent delete/adoption) — nothing to do.
+    return 'deleted';
+  }
+
+  // Backup pin (§3.1/§3.2): a backup_jobs row still building on this snapshot
+  // as its base. status IN (pending, running) covers an in-flight run;
+  // publish_lease_expires_at > now() - margin covers a reaped-but-still-
+  // uploading helper (the same lease+margin the helper itself enforces
+  // before publishing — see spec §3.1's "publish margin").
+  const [backupPin] = await db
+    .select({ id: backupJobs.id })
+    .from(backupJobs)
+    .where(
+      and(
+        eq(backupJobs.baseSnapshotId, params.snapshotId),
+        or(
+          inArray(backupJobs.status, IN_FLIGHT_BACKUP_JOB_STATUSES),
+          gt(backupJobs.publishLeaseExpiresAt, publishMarginCutoff),
+        ),
+      ),
+    )
+    .limit(1);
+  if (backupPin) return 'pinned';
+
+  // Restore pin (§3.2, F8): the in-flight status check only counts once a
+  // command exists (a commandless pending row is reaped by
+  // staleCommandReaper's own 1h rule, Task 7, instead of pinning forever);
+  // the linger separately covers both that crash window and a helper reading
+  // past the server's restore timeout.
+  const [restorePin] = await db
+    .select({ id: restoreJobs.id })
+    .from(restoreJobs)
+    .where(
+      and(
+        eq(restoreJobs.snapshotId, params.id),
+        or(
+          and(inArray(restoreJobs.status, ['pending', 'running']), sql`${restoreJobs.commandId} IS NOT NULL`),
+          gt(restoreJobs.createdAt, restoreLingerCutoff),
+        ),
+      ),
+    )
+    .limit(1);
+  if (restorePin) return 'pinned';
+
+  // Recovery pin (§3.2): active/authenticated token, or one not yet
+  // completed and still within its expiry + the same linger (covers a BMR
+  // session mid-download).
+  const [recoveryPin] = await db
+    .select({ id: recoveryTokens.id })
+    .from(recoveryTokens)
+    .where(
+      and(
+        eq(recoveryTokens.snapshotId, params.id),
+        or(
+          inArray(recoveryTokens.status, ['active', 'authenticated']),
+          and(isNull(recoveryTokens.completedAt), gt(recoveryTokens.expiresAt, restoreLingerCutoff)),
+        ),
+      ),
+    )
+    .limit(1);
+  if (recoveryPin) return 'pinned';
+
+  await db.insert(backupSnapshotRetirements).values({
+    orgId: params.orgId,
+    configId: params.configId,
+    deviceId: params.deviceId,
+    snapshotId: params.snapshotId,
+    storageIdentity: params.storageIdentity ?? `unknown::${params.id}`,
+    backupType: params.backupType,
+    reason: params.reason,
+  });
+
+  await db.delete(backupSnapshots).where(eq(backupSnapshots.id, params.id));
+  return 'deleted';
+}
+
+/**
+ * D18 §3.7: opens ONE real top-level Postgres transaction per candidate row
+ * (`withSystemDbAccessContext`, called with no ambient context already open
+ * — see Task 8) so a `deleteSnapshotRow` outcome (retirement insert + row
+ * delete) for THIS row commits independently of every other row's outcome
+ * and of the D17 `failed > 0` throw at the end of `cleanupExpiredSnapshots`.
+ * An unexpected DB error (lock timeout, connection blip, an
+ * as-yet-unregistered referencing table) is caught here rather than aborting
+ * the whole cleanup pass — logged with the PG SQLSTATE/constraint when the
+ * driver surfaces one, and the row is simply retried on the next run.
+ */
+async function tryDeleteSnapshotRow(snap: {
+  id: string;
+  snapshotId: string;
+  orgId: string;
+  configId: string | null;
+  deviceId: string | null;
+  storageIdentity: string | null;
+  backupType: (typeof backupSnapshots.$inferSelect)['backupType'];
+  reason: 'expired' | 'max_versions';
+}): Promise<'deleted' | 'pinned' | 'failed'> {
+  try {
+    return await withSystemDbAccessContext(() => deleteSnapshotRow(snap));
+  } catch (error) {
+    const code = pgErrorCode(error);
+    const constraint = pgErrorConstraint(error);
+    console.error(
+      `[BackupRetention] Failed to delete snapshot ${snap.snapshotId} (id ${snap.id})` +
+      (code ? ` — PG ${code}` : ' — no PG SQLSTATE on the error') +
+      (constraint ? ` (constraint ${constraint})` : '') +
+      ' — skipping this row; will retry next run:',
+      error,
+    );
+    return 'failed';
+  }
+}
+```
+
+```ts
+// apps/api/src/jobs/backupRetention.ts:231-387 — cleanupExpiredSnapshots, both read phases
+// wrapped in their own context, both delete loops updated to the new outcome type
+export async function cleanupExpiredSnapshots(
+  orgId: string
+): Promise<RetentionCleanupResult> {
+  const now = new Date();
+  const result: RetentionCleanupResult = {
+    deleted: 0,
+    skippedLegalHold: 0,
+    skippedImmutable: 0,
+    skippedPinned: 0,
+    prunedByMaxVersions: 0,
+    failed: 0,
+  };
+
+  // D18 §3.7: this read runs with no ambient context (cleanupExpiredSnapshots
+  // is no longer called from inside one) — a snapshot-in-time read is fine
+  // here since every candidate is independently re-verified with FOR UPDATE
+  // inside its own per-row commit below.
+  const expired = await withSystemDbAccessContext(() =>
+    db
+      .select({
+        id: backupSnapshots.id,
+        snapshotId: backupSnapshots.snapshotId,
+        metadata: backupSnapshots.metadata,
+        legalHold: backupSnapshots.legalHold,
+        isImmutable: backupSnapshots.isImmutable,
+        immutableUntil: backupSnapshots.immutableUntil,
+        provider: backupConfigs.provider,
+        providerConfig: backupConfigs.providerConfig,
+        deviceId: backupSnapshots.deviceId,
+        configId: backupSnapshots.configId,
+        storageIdentity: backupSnapshots.storageIdentity,
+        backupType: backupSnapshots.backupType,
+      })
+      .from(backupSnapshots)
+      .leftJoin(backupConfigs, eq(backupSnapshots.configId, backupConfigs.id))
+      .where(
+        and(
+          eq(backupSnapshots.orgId, orgId),
+          lt(backupSnapshots.expiresAt, now)
+        )
+      )
+  );
+
+  for (const snap of expired) {
+    if (snap.legalHold) {
+      result.skippedLegalHold++;
+      console.warn(`[BackupRetention] Snapshot ${snap.snapshotId} held by legal hold — skipping deletion`);
+      continue;
+    }
+    if (snap.isImmutable && snap.immutableUntil && snap.immutableUntil > now) {
+      result.skippedImmutable++;
+      console.warn(`[BackupRetention] Snapshot ${snap.snapshotId} immutable until ${snap.immutableUntil.toISOString()} — skipping deletion`);
+      continue;
+    }
+
+    const outcome = await tryDeleteSnapshotRow({
+      id: snap.id,
+      snapshotId: snap.snapshotId,
+      orgId,
+      configId: snap.configId,
+      deviceId: snap.deviceId,
+      storageIdentity: snap.storageIdentity,
+      backupType: snap.backupType,
+      reason: 'expired',
+    });
+    if (outcome === 'deleted') result.deleted++;
+    else if (outcome === 'pinned') result.skippedPinned++;
+    else result.failed++;
+  }
+
+  const versionBoundSnapshots = await withSystemDbAccessContext(() =>
+    db
+      .select({
+        id: backupSnapshots.id,
+        snapshotId: backupSnapshots.snapshotId,
+        timestamp: backupSnapshots.timestamp,
+        deviceId: backupSnapshots.deviceId,
+        configId: backupSnapshots.configId,
+        metadata: backupSnapshots.metadata,
+        legalHold: backupSnapshots.legalHold,
+        isImmutable: backupSnapshots.isImmutable,
+        immutableUntil: backupSnapshots.immutableUntil,
+        provider: backupConfigs.provider,
+        providerConfig: backupConfigs.providerConfig,
+        storageIdentity: backupSnapshots.storageIdentity,
+        backupType: backupSnapshots.backupType,
+        retention: configPolicyBackupSettings.retention,
+      })
+      .from(backupSnapshots)
+      .innerJoin(backupJobs, eq(backupSnapshots.jobId, backupJobs.id))
+      .leftJoin(backupConfigs, eq(backupSnapshots.configId, backupConfigs.id))
+      .leftJoin(
+        configPolicyBackupSettings,
+        eq(backupJobs.featureLinkId, configPolicyBackupSettings.featureLinkId),
+      )
+      .where(eq(backupSnapshots.orgId, orgId))
+      .orderBy(
+        backupSnapshots.deviceId,
+        backupSnapshots.configId,
+        desc(backupSnapshots.timestamp),
+      )
+  );
+
+  const snapshotsByGroup = new Map<string, typeof versionBoundSnapshots>();
+  for (const row of versionBoundSnapshots) {
+    const groupKey = `${row.deviceId}:${row.configId ?? 'none'}`;
+    const existing = snapshotsByGroup.get(groupKey);
+    if (existing) existing.push(row);
+    else snapshotsByGroup.set(groupKey, [row]);
+  }
+
+  for (const groupRows of snapshotsByGroup.values()) {
+    const retention = groupRows[0]?.retention as Record<string, unknown> | null | undefined;
+    const maxVersions = typeof retention?.maxVersions === 'number' ? retention.maxVersions : null;
+    if (!maxVersions || maxVersions < 1 || groupRows.length <= maxVersions) continue;
+
+    for (const snap of groupRows.slice(maxVersions)) {
+      if (snap.legalHold) {
+        result.skippedLegalHold++;
+        continue;
+      }
+      if (snap.isImmutable && snap.immutableUntil && snap.immutableUntil > now) {
+        result.skippedImmutable++;
+        continue;
+      }
+
+      const outcome = await tryDeleteSnapshotRow({
+        id: snap.id,
+        snapshotId: snap.snapshotId,
+        orgId,
+        configId: snap.configId,
+        deviceId: snap.deviceId,
+        storageIdentity: snap.storageIdentity,
+        backupType: snap.backupType,
+        reason: 'max_versions',
+      });
+      if (outcome === 'deleted') {
+        result.deleted++;
+        result.prunedByMaxVersions++;
+      } else if (outcome === 'pinned') {
+        result.skippedPinned++;
+      } else {
+        result.failed++;
+      }
+    }
+  }
+
+  if (
+    result.deleted > 0 || result.skippedLegalHold > 0 || result.skippedImmutable > 0 ||
+    result.skippedPinned > 0 || result.prunedByMaxVersions > 0 || result.failed > 0
+  ) {
+    console.log(
+      `[BackupRetention] Org ${orgId}: deleted ${result.deleted}, ` +
+      `skipped ${result.skippedLegalHold} (legal hold), ${result.skippedImmutable} (immutable), ` +
+      `${result.skippedPinned} (pinned), pruned ${result.prunedByMaxVersions} by maxVersions` +
+      (result.failed > 0 ? `, FAILED ${result.failed} delete(s) (see prior per-row errors — will retry next run)` : '')
+    );
+  }
+
+  if (result.failed > 0) {
+    const summary =
+      `[BackupRetention] Org ${orgId}: ${result.failed} snapshot row delete(s) failed this run — ` +
+      'see prior per-row error logs for the specific snapshot id(s) and PG error; will retry next run.';
+    console.error(summary);
+    captureException(new Error(summary));
+  }
+
+  return result;
+}
+```
+
+- [ ] Step 4: Run, expect PASS
+  Command: `cd apps/api && npx vitest run src/jobs/backupRetention.test.ts`
+
+- [ ] Step 5: Commit
+  `git add apps/api/src/jobs/backupRetention.ts apps/api/src/jobs/backupRetention.test.ts && git commit -m "feat(backup): retention checks base/restore/recovery pins and writes a retirement row per committed row (D18 W01 §3.2/§3.3/§3.7)"`
+
+---
+
+### Task 10: Lineage on write — `resultSchemas.ts` + `backupResultPersistence.ts` + late-result fence
+
+**Files:** Modify `apps/api/src/routes/backup/resultSchemas.ts:27-32`, `apps/api/src/services/backupResultPersistence.ts:1041-1051` (widen `updatedJob` select), `:972-981` area (new pre-check before the main UPDATE), `:1143-1162` (`snapshotValues`). Test: `apps/api/src/services/backupResultPersistence.test.ts`.
+
+**Interfaces:**
+- Produces: `backupSnapshotResultSchema` gains `baseSnapshotId?: string`, `formatVersion?: number`, `backupIdentity?: string`.
+- Produces: `backupSnapshots.parentSnapshotId`/`.isIncremental`/`.storageIdentity` are now set on every successful write; `storageIdentity` is **copied from the job's own stamped `storageIdentity`** (Task 6), never recomputed from the config.
+- Produces: a late result for a reaped-terminal job is rejected with `errorLog` containing `publish_lease_expired` or `base_retired` when the fence fails.
+
+- [ ] Step 1: Write the failing test
+
+```ts
+// apps/api/src/services/backupResultPersistence.test.ts — new cases (mirror this file's existing mocking style)
+  it('sets parentSnapshotId/isIncremental/storageIdentity from the job and result (D18 W01)', async () => {
+    // Arrange: updatedJob's widened .returning() resolves { id, orgId, configId,
+    // backupType, backupMode, baseSnapshotId: 'snap-1', publishLeaseExpiresAt: <future>,
+    // storageIdentity: 's3::e::b' }; a lookup for the base row by
+    // (configId, snapshotId='snap-1') returns { id: 'base-db-id' }.
+    const result = await applyBackupCommandResultToJob({
+      jobId: 'job-1', orgId: 'org-1', deviceId: 'device-1', resultStatus: 'completed',
+      result: {
+        snapshotId: 'snap-2', snapshot: { id: 'snap-2', baseSnapshotId: 'snap-1', formatVersion: 2, files: [] },
+        filesBackedUp: 0, bytesBackedUp: 0, referencedFiles: 5,
+      } as any,
+      source: 'agent',
+    });
+
+    expect(result.applied).toBe(true);
+    // Assert the values passed to the backup_snapshots insert/update carried
+    // parentSnapshotId = 'base-db-id', isIncremental = true, and
+    // storageIdentity = 's3::e::b' (copied straight from the job row, no
+    // config re-lookup) — via this file's existing capture mechanism.
+  });
+
+  it('fails a late result with publish_lease_expired when the job is reaped-terminal and its lease has passed', async () => {
+    // Arrange: job row is 'failed' with STALE_BACKUP_REAP_MARKER,
+    // publishLeaseExpiresAt in the past.
+    const result = await applyBackupCommandResultToJob({
+      jobId: 'job-2', orgId: 'org-1', deviceId: 'device-1', resultStatus: 'completed',
+      result: { snapshotId: 'snap-3', snapshot: { id: 'snap-3' }, filesBackedUp: 1, bytesBackedUp: 1 } as any,
+      source: 'agent',
+    });
+
+    expect(result.applied).toBe(true);
+    // The job's own row should have been updated to status 'failed' with
+    // errorLog containing 'publish_lease_expired', NOT flipped to completed.
+  });
+
+  it('fails a late result with base_retired when the lease is live but the base row is gone', async () => {
+    // Arrange: job row is 'failed' with STALE_BACKUP_REAP_MARKER,
+    // publishLeaseExpiresAt in the future, baseSnapshotId set, and the
+    // lookup for that snapshotId finds NO row (retired + swept, or never
+    // existed).
+    const result = await applyBackupCommandResultToJob({
+      jobId: 'job-3', orgId: 'org-1', deviceId: 'device-1', resultStatus: 'completed',
+      result: { snapshotId: 'snap-4', snapshot: { id: 'snap-4' }, filesBackedUp: 1, bytesBackedUp: 1 } as any,
+      source: 'agent',
+    });
+
+    expect(result.applied).toBe(true);
+    // errorLog should contain 'base_retired'.
+  });
+```
+
+  (Read this file's existing mock plumbing before writing — it wasn't fully quoted in Ground Truth — and mirror its exact `mockDb`/`vi.mock('../db', ...)` shape.)
+
+- [ ] Step 2: Run it, expect FAIL — `storageIdentity`/`parentSnapshotId` absent from the write; both late-result cases flip to `completed` instead of `failed`.
+  Command: `cd apps/api && npx vitest run src/services/backupResultPersistence.test.ts`
+
+- [ ] Step 3: Implement
+
+```ts
+// apps/api/src/routes/backup/resultSchemas.ts:27-32
+export const backupSnapshotResultSchema = z.object({
+  id: z.string().min(1),
+  timestamp: z.string().datetime({ offset: true }).optional(),
+  size: z.number().int().nonnegative().optional(),
+  files: z.array(backupSnapshotFileResultSchema).optional(),
+  // D18 (#5429/§3.1): server-chosen dedupe base, echoed back by the agent so
+  // lineage can be recorded. Absent = full run or a legacy agent.
+  baseSnapshotId: z.string().optional(),
+  formatVersion: z.number().int().nonnegative().optional(),
+  backupIdentity: z.string().optional(),
+});
+```
+
+```ts
+// apps/api/src/services/backupResultPersistence.ts:1041-1051 — widen updatedJob's returning()
+    .returning({
+      id: backupJobs.id,
+      orgId: backupJobs.orgId,
+      configId: backupJobs.configId,
+      backupType: backupJobs.backupType,
+      backupMode: backupJobs.backupMode,
+      baseSnapshotId: backupJobs.baseSnapshotId,
+      publishLeaseExpiresAt: backupJobs.publishLeaseExpiresAt,
+      storageIdentity: backupJobs.storageIdentity,
+    });
+```
+
+```ts
+// apps/api/src/services/backupResultPersistence.ts — new helper, placed above applyBackupCommandResultToJob
+/**
+ * D18 §3.1 late-result fence: a result for a job already in the reaped
+ * 'failed' terminal status (STALE_BACKUP_REAP_MARKER) is accepted only if
+ * its publish_lease_expires_at has not yet passed AND (it has no base pin,
+ * or its base row still exists and is not retired). Otherwise the caller
+ * must record the result as failed with a distinguishing reason instead of
+ * flipping the job to completed — the manifest the agent uploaded may
+ * reference storage GC has already started reclaiming.
+ */
+async function checkLateResultBaseFence(job: {
+  baseSnapshotId: string | null;
+  publishLeaseExpiresAt: Date | null;
+}): Promise<{ ok: true } | { ok: false; reason: 'publish_lease_expired' | 'base_retired' }> {
+  if (job.publishLeaseExpiresAt && job.publishLeaseExpiresAt.getTime() < Date.now()) {
+    return { ok: false, reason: 'publish_lease_expired' };
+  }
+  if (!job.baseSnapshotId) return { ok: true };
+
+  const [baseRow] = await db
+    .select({ id: backupSnapshots.id, storageIdentity: backupSnapshots.storageIdentity })
+    .from(backupSnapshots)
+    .where(eq(backupSnapshots.snapshotId, job.baseSnapshotId))
+    .limit(1);
+  if (!baseRow) return { ok: false, reason: 'base_retired' };
+
+  const [retirement] = await db
+    .select({ id: backupSnapshotRetirements.id })
+    .from(backupSnapshotRetirements)
+    .where(
+      and(
+        eq(backupSnapshotRetirements.storageIdentity, baseRow.storageIdentity ?? ''),
+        eq(backupSnapshotRetirements.snapshotId, job.baseSnapshotId),
+      ),
+    )
+    .limit(1);
+  return retirement ? { ok: false, reason: 'base_retired' } : { ok: true };
+}
+```
+
+```ts
+// apps/api/src/services/backupResultPersistence.ts — inside applyBackupCommandResultToJob,
+// BEFORE the main `db.update(backupJobs)...` (before :1041), when source === 'agent' and isSuccessResult:
+
+  if (source === 'agent' && isSuccessResult) {
+    const [currentJob] = await db
+      .select({
+        status: backupJobs.status,
+        errorLog: backupJobs.errorLog,
+        baseSnapshotId: backupJobs.baseSnapshotId,
+        publishLeaseExpiresAt: backupJobs.publishLeaseExpiresAt,
+      })
+      .from(backupJobs)
+      .where(eq(backupJobs.id, jobId))
+      .limit(1);
+
+    const isReapedTerminal =
+      currentJob?.status === 'failed' &&
+      typeof currentJob.errorLog === 'string' &&
+      currentJob.errorLog.includes(STALE_BACKUP_REAP_MARKER);
+
+    if (isReapedTerminal) {
+      const fence = await checkLateResultBaseFence(currentJob);
+      if (!fence.ok) {
+        const detail =
+          fence.reason === 'publish_lease_expired'
+            ? 'its publish lease had already expired'
+            : 'its dedupe base was reclaimed';
+        await db
+          .update(backupJobs)
+          .set({
+            status: 'failed',
+            completedAt: new Date(),
+            updatedAt: new Date(),
+            errorLog: `${fence.reason}: late result rejected — ${detail} before this result arrived`,
+          })
+          .where(eq(backupJobs.id, jobId));
+        return { applied: true, snapshotDbId: null, providerSnapshotId };
+      }
+    }
+  }
+```
+
+```ts
+// apps/api/src/services/backupResultPersistence.ts:1143-1162 — snapshotValues gains lineage fields
+  let parentSnapshotId: string | null = null;
+  const baseSnapshotId = result.snapshot?.baseSnapshotId;
+  if (updatedJob.configId && baseSnapshotId) {
+    const [baseRow] = await db
+      .select({ id: backupSnapshots.id })
+      .from(backupSnapshots)
+      .where(and(eq(backupSnapshots.configId, updatedJob.configId), eq(backupSnapshots.snapshotId, baseSnapshotId)))
+      .limit(1);
+    parentSnapshotId = baseRow?.id ?? null;
+  }
+  const isIncremental =
+    (result.referencedFiles !== undefined && result.referencedFiles > 0) ||
+    (result.snapshot?.formatVersion !== undefined && result.snapshot.formatVersion >= 2);
+
+  const snapshotValues = {
+    orgId: effectiveOrgId,
+    jobId,
+    deviceId,
+    configId: updatedJob.configId ?? null,
+    snapshotId: providerSnapshotId,
+    label: snapshotLabel,
+    location:
+      typeof snapshotMetadata.storagePrefix === 'string'
+        ? snapshotMetadata.storagePrefix
+        : null,
+    size: result.snapshot?.size ?? result.bytesBackedUp ?? null,
+    fileCount: result.filesBackedUp ?? result.snapshot?.files?.length ?? null,
+    timestamp,
+    metadata: snapshotMetadata,
+    encryptionKeyId: resolveSnapshotEncryptionKeyId(snapshotMetadata),
+    backupType: snapshotBackupType,
+    systemStateManifest,
+    hardwareProfile,
+    parentSnapshotId,
+    isIncremental,
+    // D18 §3.6: copied straight from the job's own stamped storageIdentity —
+    // NOT recomputed from the config — so GC groups by the identity the run
+    // actually wrote to, even if the config's destination has since changed.
+    storageIdentity: updatedJob.storageIdentity ?? null,
+  } as const;
+```
+
+  Add `backupSnapshotRetirements` to this file's imports (`import { backupSnapshotRetirements } from '../db/schema/backup';`); `STALE_BACKUP_REAP_MARKER` is already imported (`:11`).
+
+- [ ] Step 4: Run, expect PASS
+  Command: `cd apps/api && npx vitest run src/services/backupResultPersistence.test.ts`
+
+- [ ] Step 5: Commit
+  `git add apps/api/src/routes/backup/resultSchemas.ts apps/api/src/services/backupResultPersistence.ts apps/api/src/services/backupResultPersistence.test.ts && git commit -m "feat(backup): lineage fields on write + publish-lease/base-retirement late-result fence (D18 W01 §3.1)"`
+
+---
+
+### Task 11: Reconcile — forward lineage, refuse retired/too-old/base-missing adoption
+
+**Files:** Modify `apps/api/src/services/backupSnapshotReconcile.ts:135-155` (`ReconcileSkipReason`), `:538-585` (`manifestToCommandResult`), `:669-720` (new pre-loop retired-id lookup + in-loop checks), `:864-882` (new base-existence check after the manifest parses). Test: `apps/api/src/services/backupSnapshotReconcile.test.ts`.
+
+**Interfaces:** Consumes `backupSnapshotRetirements` schema. `RECONCILE_ORPHAN_HALF_WINDOW_MS` is a local literal (half of the 9-day default `BACKUP_GC_ORPHAN_MANIFEST_MAX_AGE_MS`, which doesn't exist as a named knob until W02) with a `TODO(W02)` to replace it once `backupGcKnobs.ts` grows that export.
+
+- [ ] Step 1: Write the failing test
+
+```ts
+// apps/api/src/services/backupSnapshotReconcile.test.ts — new cases
+  it('manifestToCommandResult forwards baseSnapshotId and formatVersion', () => {
+    const result = manifestToCommandResult({
+      snapshotId: 'snap-1',
+      manifestText: JSON.stringify({ id: 'snap-1', baseSnapshotId: 'snap-0', formatVersion: 2, files: [] }),
+      matchedBy: 'job-snapshot-id',
+    });
+    expect(result.snapshot?.baseSnapshotId).toBe('snap-0');
+    expect(result.snapshot?.formatVersion).toBe(2);
+  });
+
+  it('refuses to adopt a retired snapshot id', async () => {
+    // Arrange listing to include snapshot RETIRED-1; the retirement lookup
+    // (mocked select) returns a matching row for (storageIdentity, RETIRED-1).
+    const result = await reconcileOrphanedBackupSnapshots({ orgId: 'org-1', configId: 'config-1' });
+    const candidate = result.candidates.find((c) => c.snapshotId === 'RETIRED-1');
+    expect(candidate?.skipReason).toBe('retired');
+    expect(candidate?.adopted).toBe(false);
+  });
+
+  it('refuses to adopt a manifest older than half the orphan window', async () => {
+    // Arrange listing with a manifest lastModified older than 4.5 days (half
+    // the 9-day default) with no retirement row.
+    const result = await reconcileOrphanedBackupSnapshots({ orgId: 'org-1', configId: 'config-1' });
+    const candidate = result.candidates.find((c) => c.snapshotId === 'OLD-ORPHAN');
+    expect(candidate?.skipReason).toBe('orphan-too-old-for-adoption');
+  });
+
+  it('refuses to adopt a manifest whose declared base has no live, unretired row', async () => {
+    // Arrange a fresh (well within the window), job-snapshot-id-matched
+    // manifest declaring baseSnapshotId 'gone-base'; the base-existence
+    // lookup (mocked select) returns no row.
+    const result = await reconcileOrphanedBackupSnapshots({ orgId: 'org-1', configId: 'config-1' });
+    const candidate = result.candidates.find((c) => c.snapshotId === 'HAS-MISSING-BASE');
+    expect(candidate?.skipReason).toBe('base-missing');
+    expect(candidate?.adopted).toBe(false);
+  });
+```
+
+- [ ] Step 2: Run it, expect FAIL — `manifestToCommandResult`'s result has no `baseSnapshotId` field, and all three refusal cases adopt instead of skipping.
+  Command: `cd apps/api && npx vitest run src/services/backupSnapshotReconcile.test.ts`
+
+- [ ] Step 3: Implement
+
+```ts
+// apps/api/src/services/backupSnapshotReconcile.ts:135-155 — widen ReconcileSkipReason
+export type ReconcileSkipReason =
+  | 'already-restorable'
+  | 'claimed-by-another-organization'
+  | 'shared-destination-ambiguous'
+  | 'no-matching-job'
+  | 'ambiguous-job-match'
+  | 'job-not-adoptable'
+  | 'job-on-another-config'
+  | 'manifest-unreadable'
+  | 'adoption-failed'
+  | 'limit-reached'
+  /** D18 §3.3/§3.4: the storage identity has a retirement row for this id. */
+  | 'retired'
+  /** D18 §3.4: the manifest is older than half the orphan window — leave it
+   *  for the sweep instead of racing it. */
+  | 'orphan-too-old-for-adoption'
+  /** D18 §3.1/§3.4: the manifest declares a baseSnapshotId with no live,
+   *  unretired backup_snapshots row — its references may already dangle. */
+  | 'base-missing';
+```
+
+```ts
+// apps/api/src/services/backupSnapshotReconcile.ts:538-585 — manifestToCommandResult forwards lineage
+  return {
+    snapshotId: params.snapshotId,
+    filesBackedUp: files.length,
+    bytesBackedUp: size,
+    snapshot: {
+      id: params.snapshotId,
+      timestamp,
+      size,
+      files,
+      baseSnapshotId: parsed.baseSnapshotId,
+      formatVersion: parsed.formatVersion,
+    },
+    metadata: {
+      storagePrefix: `${BACKUP_SNAPSHOT_ROOT_DIR}/${params.snapshotId}`,
+      reconciledFromStorage: true,
+      reconciledAt: new Date().toISOString(),
+      reconcileMatchedBy: params.matchedBy,
+    },
+  };
+```
+
+```ts
+// apps/api/src/services/backupSnapshotReconcile.ts — new import + constant near the top of the file
+import { backupSnapshotRetirements } from '../db/schema/backup';
+
+// Half of BACKUP_GC_ORPHAN_MANIFEST_MAX_AGE_MS's 9-day default (spec §3.4:
+// "reconcile adopts an orphan only while its manifest is younger than half
+// the window, so adoption and sweeping are disjoint by age").
+// TODO(W02): replace with backupGcKnobs.ts's real orphan-window export once
+// that module grows it — kept as a local literal here so this wave does not
+// reach into a not-yet-defined W02 constant.
+const RECONCILE_ORPHAN_HALF_WINDOW_MS = (9 * 24 * 60 * 60 * 1000) / 2;
+```
+
+```ts
+// apps/api/src/services/backupSnapshotReconcile.ts — inside reconcileOrphanedBackupSnapshots,
+// right after storageIdentity/coarseIdentity are computed (~:673-674), before loadClaimsAndSharing:
+
+  const retiredRows = await runInDbContext(() =>
+    db
+      .select({ snapshotId: backupSnapshotRetirements.snapshotId })
+      .from(backupSnapshotRetirements)
+      .where(
+        and(
+          eq(backupSnapshotRetirements.storageIdentity, storageIdentity),
+          inArray(backupSnapshotRetirements.snapshotId, snapshotIds),
+        ),
+      )
+  );
+  const retiredSnapshotIds = new Set(retiredRows.map((r) => r.snapshotId));
+```
+
+```ts
+// apps/api/src/services/backupSnapshotReconcile.ts — inside the per-snapshotId loop, right
+// after the `skip` closure is defined (~:719), before the restorableOwner check (~:721):
+
+    if (retiredSnapshotIds.has(snapshotId)) {
+      skip('retired');
+      continue;
+    }
+    if (writtenAt && now.getTime() - writtenAt.getTime() > RECONCILE_ORPHAN_HALF_WINDOW_MS) {
+      skip('orphan-too-old-for-adoption');
+      continue;
+    }
+```
+
+```ts
+// apps/api/src/services/backupSnapshotReconcile.ts — inside the adoption loop, right after
+// `result = manifestToCommandResult({...})` succeeds (~:874), before `candidate.fileCount = ...` (~:882):
+
+    if (result.snapshot?.baseSnapshotId) {
+      const declaredBase = result.snapshot.baseSnapshotId;
+      const [liveBase] = await runInDbContext(() =>
+        db
+          .select({ id: backupSnapshots.id })
+          .from(backupSnapshots)
+          .leftJoin(
+            backupSnapshotRetirements,
+            and(
+              eq(backupSnapshotRetirements.storageIdentity, storageIdentity),
+              eq(backupSnapshotRetirements.snapshotId, declaredBase),
+            ),
+          )
+          .where(and(eq(backupSnapshots.snapshotId, declaredBase), isNull(backupSnapshotRetirements.id)))
+          .limit(1)
+      );
+      if (!liveBase) {
+        candidate.skipReason = 'base-missing';
+        candidate.error = `manifest declares base ${declaredBase}, which has no live, unretired row`;
+        candidates.push(candidate);
+        continue;
+      }
+    }
+```
+
+  Add `inArray`/`isNull` to this file's `drizzle-orm` import if not already present (confirm during implementation — several are already used elsewhere in the file for the claims lookups).
+
+- [ ] Step 4: Run, expect PASS
+  Command: `cd apps/api && npx vitest run src/services/backupSnapshotReconcile.test.ts`
+
+- [ ] Step 5: Commit
+  `git add apps/api/src/services/backupSnapshotReconcile.ts apps/api/src/services/backupSnapshotReconcile.test.ts && git commit -m "feat(backup): reconcile forwards lineage and refuses retired/stale/base-missing adoption (D18 W01 §3.4)"`
+
+---
+
+### Task 12: `PATCH /backup/configs/:id` — warn when the edit changes storage identity
+
+**Files:** Modify `apps/api/src/routes/backup/configs.ts:440-467`. Test: `apps/api/src/routes/backup/configs.test.ts`.
+
+**Interfaces:** Response from `PATCH /backup/configs/:id` gains an optional `warnings: string[]` field, populated with `'storage_identity_changed'` when the edit changes `normalizeStorageIdentity(provider, providerConfig)` for a config that has at least one `backup_snapshots` row. Never blocks the write.
+
+- [ ] Step 1: Write the failing test
+
+```ts
+// apps/api/src/routes/backup/configs.test.ts — new case (mirror this file's existing PATCH test setup)
+  it('warns (does not block) when an s3 endpoint edit changes storage identity for a config with snapshots', async () => {
+    // Arrange: `current` row is s3 with endpoint 'old.example.com', bucket 'b';
+    // a snapshot-exists check for this configId returns a row; PATCH body
+    // changes details.endpoint to 'new.example.com'.
+    const res = await app.request('/backup/configs/config-1?orgId=org-1', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json', authorization: 'Bearer test' },
+      body: JSON.stringify({ details: { endpoint: 'new.example.com', bucket: 'b' } }),
+    });
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.warnings).toEqual(['storage_identity_changed']);
+  });
+
+  it('does not warn when the edit does not change storage identity', async () => {
+    // Same config, PATCH body only changes `name`.
+    const res = await app.request('/backup/configs/config-1?orgId=org-1', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json', authorization: 'Bearer test' },
+      body: JSON.stringify({ name: 'Renamed' }),
+    });
+    const body = await res.json();
+    expect(body.warnings ?? []).toEqual([]);
+  });
+```
+
+- [ ] Step 2: Run it, expect FAIL — `body.warnings` is `undefined`.
+  Command: `cd apps/api && npx vitest run src/routes/backup/configs.test.ts`
+
+- [ ] Step 3: Implement
+
+```ts
+// apps/api/src/routes/backup/configs.ts — new import
+import { normalizeStorageIdentity } from '../../jobs/backupRetention';
+```
+
+```ts
+// apps/api/src/routes/backup/configs.ts — inside the PATCH handler, after the write
+// transaction resolves `row` (~:452) and before the response (~:467):
+
+    const warnings: string[] = [];
+    const priorIdentity = normalizeStorageIdentity(current.provider, (current.providerConfig ?? {}) as Record<string, unknown>);
+    const nextIdentity = normalizeStorageIdentity(row.provider, (row.providerConfig ?? {}) as Record<string, unknown>);
+    if (priorIdentity !== nextIdentity) {
+      const [existingSnapshot] = await db
+        .select({ id: backupSnapshots.id })
+        .from(backupSnapshots)
+        .where(eq(backupSnapshots.configId, configId))
+        .limit(1);
+      if (existingSnapshot) {
+        warnings.push('storage_identity_changed');
+      }
+    }
+
+    writeRouteAudit(c, {
+      orgId,
+      action: 'backup.config.update',
+      resourceType: 'backup_config',
+      resourceId: row.id,
+      resourceName: row.name,
+      details: { changedFields: Object.keys(payload) },
+    });
+
+    return c.json(warnings.length > 0 ? { ...toConfigResponse(row), warnings } : toConfigResponse(row));
+```
+
+  `backupSnapshots` must already be imported in this route file (it is used elsewhere for other backup routes in this module tree — confirm and add if missing).
+
+- [ ] Step 4: Run, expect PASS
+  Command: `cd apps/api && npx vitest run src/routes/backup/configs.test.ts`
+
+- [ ] Step 5: Commit
+  `git add apps/api/src/routes/backup/configs.ts apps/api/src/routes/backup/configs.test.ts && git commit -m "feat(backup): warn on PATCH /backup/configs/:id when the edit changes storage identity (D18 W01 §3.6)"`
+
+---
+
+### Task 13: Integration tests — pins/retirement/race + RLS forge
+
+**Files:** Create `apps/api/src/__tests__/integration/backupRetentionPins.integration.test.ts`, `apps/api/src/__tests__/integration/backupSnapshotRetirementsRls.integration.test.ts`. Both are already covered by `vitest.integration.config.ts`'s standing `'src/__tests__/integration/**/*.test.ts'` glob — no config edit needed.
+
+- [ ] Step 1: Write the failing tests
+
+```ts
+// apps/api/src/__tests__/integration/backupRetentionPins.integration.test.ts
+import './setup';
+
+import { expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../../db';
+import {
+  backupConfigs,
+  backupJobs,
+  backupSnapshots,
+  backupSnapshotRetirements,
+  devices,
+  organizations,
+  partners,
+  sites,
+} from '../../db/schema';
+import { cleanupExpiredSnapshots } from '../../jobs/backupRetention';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+async function seedOrgDeviceConfig(unique: string) {
+  const [partner] = await db.insert(partners).values({ name: `RP ${unique}`, slug: `rp-${unique}`, type: 'msp', plan: 'pro', status: 'active' }).returning({ id: partners.id });
+  const [org] = await db.insert(organizations).values({ currencyCode: 'USD', partnerId: partner!.id, name: `RO ${unique}`, slug: `ro-${unique}`, type: 'customer', status: 'active' }).returning({ id: organizations.id });
+  const [site] = await db.insert(sites).values({ orgId: org!.id, name: `RS ${unique}` }).returning({ id: sites.id });
+  const [device] = await db.insert(devices).values({ orgId: org!.id, siteId: site!.id, agentId: `ra-${unique}`, hostname: `rh-${unique}`, osType: 'windows', osVersion: '11', architecture: 'x86_64', agentVersion: '0.0.0-test', status: 'online' }).returning({ id: devices.id });
+  const [config] = await db.insert(backupConfigs).values({ orgId: org!.id, name: `RC ${unique}`, type: 'file', provider: 'local', providerConfig: { path: `/tmp/gc-test-${unique}` } }).returning({ id: backupConfigs.id });
+  return { orgId: org!.id, deviceId: device!.id, configId: config!.id };
+}
+
+// D18 §3.2: a base-pinned snapshot must survive retention even though its
+// expires_at is in the past — the pin, not the expiry, decides.
+runDb("skips an expired snapshot pinned as a running job's base and writes no retirement", async () => {
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const ctx = await withSystemDbAccessContext(async () => {
+    const { orgId, deviceId, configId } = await seedOrgDeviceConfig(unique);
+    const [baseJob] = await db.insert(backupJobs).values({ orgId, configId, deviceId, status: 'completed', startedAt: new Date(), completedAt: new Date() }).returning({ id: backupJobs.id });
+    const [baseSnap] = await db.insert(backupSnapshots).values({
+      orgId, jobId: baseJob!.id, deviceId, configId,
+      snapshotId: `base-snap-${unique}`, backupType: 'file', storageIdentity: `local::/tmp/gc-test-${unique}`,
+      expiresAt: new Date(Date.now() - 60 * 60 * 1000),
+    }).returning({ id: backupSnapshots.id });
+    await db.insert(backupJobs).values({
+      orgId, configId, deviceId, status: 'running', baseSnapshotId: `base-snap-${unique}`,
+      publishLeaseExpiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    }).returning({ id: backupJobs.id });
+    return { orgId, baseSnapId: baseSnap!.id };
+  });
+
+  const result = await cleanupExpiredSnapshots(ctx.orgId);
+  expect(result.skippedPinned).toBeGreaterThanOrEqual(1);
+
+  await withSystemDbAccessContext(async () => {
+    const [row] = await db.select().from(backupSnapshots).where(eq(backupSnapshots.id, ctx.baseSnapId));
+    expect(row).toBeDefined();
+    const retirements = await db.select().from(backupSnapshotRetirements).where(eq(backupSnapshotRetirements.snapshotId, `base-snap-${unique}`));
+    expect(retirements.length).toBe(0);
+  });
+});
+
+// D18 §3.3: an expired, unpinned snapshot is deleted AND its retirement row
+// is written in the same commit.
+runDb('deletes an unpinned expired snapshot and writes its retirement row', async () => {
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const ctx = await withSystemDbAccessContext(async () => {
+    const { orgId, deviceId, configId } = await seedOrgDeviceConfig(unique);
+    const [job] = await db.insert(backupJobs).values({ orgId, configId, deviceId, status: 'completed', startedAt: new Date(), completedAt: new Date() }).returning({ id: backupJobs.id });
+    const [snap] = await db.insert(backupSnapshots).values({
+      orgId, jobId: job!.id, deviceId, configId,
+      snapshotId: `expired-snap-${unique}`, backupType: 'file', storageIdentity: `local::/tmp/gc-test-${unique}`,
+      expiresAt: new Date(Date.now() - 60 * 60 * 1000),
+    }).returning({ id: backupSnapshots.id });
+    return { orgId, snapId: snap!.id };
+  });
+
+  const result = await cleanupExpiredSnapshots(ctx.orgId);
+  expect(result.deleted).toBeGreaterThanOrEqual(1);
+
+  await withSystemDbAccessContext(async () => {
+    const rows = await db.select().from(backupSnapshots).where(eq(backupSnapshots.id, ctx.snapId));
+    expect(rows.length).toBe(0);
+    const retirements = await db.select().from(backupSnapshotRetirements).where(eq(backupSnapshotRetirements.snapshotId, `expired-snap-${unique}`));
+    expect(retirements.length).toBe(1);
+    expect(retirements[0]!.reason).toBe('expired');
+  });
+});
+
+// D18 §3.7: proves the per-row-commit restructuring — a later row's failure
+// must not undo an earlier row's already-committed retirement. Forced here
+// via a duplicate (storage_identity, snapshot_id) unique-constraint
+// violation on the SECOND row's retirement insert (a manufactured collision
+// against a pre-seeded retirement row) — the first (non-colliding) row's
+// delete+retirement must remain committed regardless of the second's failure.
+runDb("one row failing on a unique-constraint collision does not undo an earlier row's committed retirement", async () => {
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const ctx = await withSystemDbAccessContext(async () => {
+    const { orgId, deviceId, configId } = await seedOrgDeviceConfig(unique);
+    const identity = `local::/tmp/gc-test-${unique}`;
+    const [job1] = await db.insert(backupJobs).values({ orgId, configId, deviceId, status: 'completed', startedAt: new Date(), completedAt: new Date() }).returning({ id: backupJobs.id });
+    const [collideSnap] = await db.insert(backupSnapshots).values({ orgId, jobId: job1!.id, deviceId, configId, snapshotId: `collide-${unique}`, backupType: 'file', storageIdentity: identity, expiresAt: new Date(Date.now() - 60 * 60 * 1000) }).returning({ id: backupSnapshots.id });
+    const [job2] = await db.insert(backupJobs).values({ orgId, configId, deviceId, status: 'completed', startedAt: new Date(), completedAt: new Date() }).returning({ id: backupJobs.id });
+    const [uniqueSnap] = await db.insert(backupSnapshots).values({ orgId, jobId: job2!.id, deviceId, configId, snapshotId: `unique-${unique}`, backupType: 'file', storageIdentity: identity, expiresAt: new Date(Date.now() - 60 * 60 * 1000) }).returning({ id: backupSnapshots.id });
+    // Pre-seed the retirement row the colliding row's own insert will violate.
+    await db.insert(backupSnapshotRetirements).values({ orgId, configId, deviceId, snapshotId: `collide-${unique}`, storageIdentity: identity, backupType: 'file', reason: 'manual' });
+    return { orgId, collideSnapId: collideSnap!.id, uniqueSnapId: uniqueSnap!.id };
+  });
+
+  const result = await cleanupExpiredSnapshots(ctx.orgId);
+  expect(result.failed).toBeGreaterThanOrEqual(1);
+  expect(result.deleted).toBeGreaterThanOrEqual(1);
+
+  await withSystemDbAccessContext(async () => {
+    const uniqueRows = await db.select().from(backupSnapshots).where(eq(backupSnapshots.id, ctx.uniqueSnapId));
+    expect(uniqueRows.length).toBe(0); // the non-colliding row committed its delete
+    const collideRows = await db.select().from(backupSnapshots).where(eq(backupSnapshots.id, ctx.collideSnapId));
+    expect(collideRows.length).toBe(1); // the colliding row's delete never happened — retried next run
+  });
+});
+```
+
+```ts
+// apps/api/src/__tests__/integration/backupSnapshotRetirementsRls.integration.test.ts
+import './setup';
+
+import { expect, it } from 'vitest';
+import { db, withDbAccessContext, withSystemDbAccessContext } from '../../db';
+import { backupConfigs, backupSnapshotRetirements, devices, organizations, partners, sites } from '../../db/schema';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+// D18 §3.3: shape-1 RLS forge — an org-scoped context for org B must not be
+// able to insert (or read) a retirement row stamped with org A's id.
+runDb('forges a cross-tenant insert on backup_snapshot_retirements and gets 42501', async () => {
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const { orgAId, orgBId, configId, deviceId } = await withSystemDbAccessContext(async () => {
+    const [partner] = await db.insert(partners).values({ name: `RLSP ${unique}`, slug: `rlsp-${unique}`, type: 'msp', plan: 'pro', status: 'active' }).returning({ id: partners.id });
+    const [orgA] = await db.insert(organizations).values({ currencyCode: 'USD', partnerId: partner!.id, name: `RLSA ${unique}`, slug: `rlsa-${unique}`, type: 'customer', status: 'active' }).returning({ id: organizations.id });
+    const [orgB] = await db.insert(organizations).values({ currencyCode: 'USD', partnerId: partner!.id, name: `RLSB ${unique}`, slug: `rlsb-${unique}`, type: 'customer', status: 'active' }).returning({ id: organizations.id });
+    const [site] = await db.insert(sites).values({ orgId: orgA!.id, name: `RLSS ${unique}` }).returning({ id: sites.id });
+    const [device] = await db.insert(devices).values({ orgId: orgA!.id, siteId: site!.id, agentId: `rlsa-agent-${unique}`, hostname: `rlsa-host-${unique}`, osType: 'windows', osVersion: '11', architecture: 'x86_64', agentVersion: '0.0.0-test', status: 'online' }).returning({ id: devices.id });
+    const [config] = await db.insert(backupConfigs).values({ orgId: orgA!.id, name: `RLSC ${unique}`, type: 'file', provider: 'local', providerConfig: {} }).returning({ id: backupConfigs.id });
+    return { orgAId: orgA!.id, orgBId: orgB!.id, configId: config!.id, deviceId: device!.id };
+  });
+
+  await expect(
+    withDbAccessContext({ scope: 'organization', orgId: orgBId, partnerId: null }, () =>
+      db.insert(backupSnapshotRetirements).values({
+        orgId: orgAId, // forged: org B's context, org A's row
+        configId,
+        deviceId,
+        snapshotId: `forge-${unique}`,
+        storageIdentity: `local::/tmp/forge-${unique}`,
+        backupType: 'file',
+        reason: 'manual',
+      })
+    )
+  ).rejects.toMatchObject({ code: '42501' });
+});
+```
+
+  Confirm `withDbAccessContext`'s exact parameter shape (`{ scope, orgId, partnerId }` or similar) against `apps/api/src/db/index.ts:525-554` before finalizing — mirror whatever an existing RLS-forge integration test in this repo already uses (e.g. search `rejects.toMatchObject({ code: '42501' })` across `__tests__/integration/`) rather than guessing the context-object shape from scratch.
+
+- [ ] Step 2: Run it, expect FAIL against the current code (before Tasks 1-9 land) or PASS trivially once run after — this task is naturally the LAST implementation task, so by the time it's written Tasks 1-11 should already be in place; if any of these tests fail unexpectedly at this point, that's a real defect in an earlier task, not a sequencing artifact.
+  Command: `cd apps/api && DATABASE_URL=postgresql://breeze:breeze@localhost:5432/breeze npx vitest run --config vitest.integration.config.ts src/__tests__/integration/backupRetentionPins.integration.test.ts src/__tests__/integration/backupSnapshotRetirementsRls.integration.test.ts`
+
+- [ ] Step 3: (No separate implement step — these tests exercise Tasks 1-11's already-implemented code.)
+
+- [ ] Step 4: Run, expect PASS
+  Command: same as Step 2.
+
+- [ ] Step 5: Commit
+  `git add apps/api/src/__tests__/integration/backupRetentionPins.integration.test.ts apps/api/src/__tests__/integration/backupSnapshotRetirementsRls.integration.test.ts && git commit -m "test(backup): integration coverage for base pins, retirements, per-row commit, and RLS forge (D18 W01)"`
+
+---
+
+### Task 14: Wave verification
+
+- [ ] `cd apps/api && npx tsc --noEmit` (or `pnpm --filter @breeze/api exec tsc --noEmit` — no dedicated `typecheck` script exists in `apps/api/package.json`, confirmed).
+- [ ] `cd apps/api && npx vitest run src/services/backupGcKnobs.test.ts src/jobs/backupWorker.test.ts src/jobs/staleCommandReaper.test.ts src/jobs/backupRetention.test.ts src/services/backupResultPersistence.test.ts src/services/backupSnapshotReconcile.test.ts src/routes/backup/configs.test.ts`.
+- [ ] `pnpm db:check-drift`
+- [ ] `cd apps/api && DATABASE_URL=postgresql://breeze:breeze@localhost:5432/breeze npx vitest run --config vitest.integration.config.ts src/__tests__/integration/backupRetentionPins.integration.test.ts src/__tests__/integration/backupSnapshotRetirementsRls.integration.test.ts`
+- [ ] Contract suites this wave's registry edits are graded against (tenancy/cascade code was touched — run these before PR per CLAUDE.md):
+  - `find apps/api/src -iname "tenantCascade*integration*"` then `npx vitest run <path>` against a real DB.
+  - `apps/api/src/routes/devices/*.test.ts` matching `cascade`/`moveOrg` (both device-side lists fail in the unit job since they read the Drizzle schema statically — no live DB required).
+  - `apps/api/src/services/tenantExportPolicyRegistry`'s check script/integration test (`grep -n check-tenant-export-policy apps/api/package.json` for the exact invocation) and `tenant-export-policy.integration.test.ts` + `tenantExportErasureRoundtrip.integration.test.ts` (only fail under Integration Tests — run against a real DB before PR).
+  - `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts` — confirm it still passes with no new allowlist entry needed for shape-1 auto-discovery.
+- [ ] `pnpm lint`
+- [ ] PR body checklist:
+  - [ ] Migrations `140005`/`140006` applied and idempotent-verified (`pnpm db:migrate` run twice locally, second run a no-op).
+  - [ ] `pnpm db:check-drift` clean.
+  - [ ] Tenancy contract suites (cascade order, device cascade/denormalized lists, export-policy, rls-coverage) all green against a real DB, not just the unit job.
+  - [ ] `Closes #<W01 sub-issue>` once this feature is registered via `feature-lifecycle` (per CLAUDE.md's Feature Lifecycle Tracking section, if this plan is executed as a tracked wave).
+  - [ ] Note for W02/W03 reviewers: `backupGcKnobs.ts` currently exports `BACKUP_BASE_LEASE_MS`, `BACKUP_RESTORE_PIN_LINGER_MS`, `BACKUP_PUBLISH_MARGIN_MS` — W02 is expected to migrate `BACKUP_GC_GRACE_MS`/`BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS`/a real `BACKUP_GC_ORPHAN_MANIFEST_MAX_AGE_MS` into this same module and delete the `RECONCILE_ORPHAN_HALF_WINDOW_MS` local literal in `backupSnapshotReconcile.ts` (Task 11).
+
+## Open questions / contradictions
+
+1. **SQL backfill fidelity vs. `normalizeStorageIdentity` (Task 1).** The PL/pgSQL replica in the migration is a best-effort port, not a proven-identical one: (a) the `local` branch strips only a trailing slash, it does not replicate `path.resolve()`'s handling of `.`/`..` segments or resolving a genuinely relative path against a cwd (impossible to replicate in SQL at all — flagged in the migration's own comment); (b) the S3 branch's endpoint canonicalization strips a leading scheme and anything from the first `/` onward, but does not replicate the TS function's `new URL(...)` parsing exactly for atypical inputs (e.g. userinfo in the URL, IPv6 hosts). Both divergences are bounded to the *guarded* backfill set (config unedited since the snapshot) — a mismatch here means a row is left with a technically-wrong-but-internally-consistent identity, never crossed with a different bucket's rows, and W02's sweep only ever compares against the *live* `normalizeStorageIdentity` output for a listing, so a divergent backfilled identity would show as an "unreachable identity" leak (logged, not silently merged) rather than a cross-tenant/cross-bucket deletion. Still, this was not proven byte-for-byte against real data before landing — recommend a one-off comparison script (SQL backfill's computed identities vs. `normalizeStorageIdentity(row)` in TS) run against a copy of production data before the migration ships, similar in spirit to the Go↔TS contract-test pattern this repo already uses elsewhere (`backupAgentContract.test.ts`), even though no such automated cross-check exists here.
+2. **`RESTORE_COMMANDLESS_PENDING_TIMEOUT_MS` (Task 7) vs. `BACKUP_RESTORE_PIN_LINGER_MS` (Task 9/backupGcKnobs.ts).** The spec's reaper rule is a fixed 1 hour, independent of the (env-tunable) 7-day-default linger retention's own pin check uses. This is intentional per the spec's plain reading (§3.2: "a new reaper rule in staleCommandReaper.ts: commandless pending restore_jobs older than 1h → failed"), but it does mean an operator who raises `BACKUP_RESTORE_PIN_LINGER_MS` well above 1h still gets commandless rows reaped at the fixed 1h mark while status-based pins linger far longer — not a bug, but worth confirming this asymmetry is the intended operator-facing behavior rather than an oversight in the spec itself.
+3. **Task 9's import path for `restoreJobs`/`backupSnapshotRetirements`/`IN_FLIGHT_BACKUP_JOB_STATUSES`.** The plan imports these from the concrete `'../db/schema/backup'` module rather than the `'../db/schema'` barrel that `backupRetention.ts`'s other imports currently use. This needs to be reconciled against whatever `backupRetention.test.ts`'s `vi.mock(...)` setup actually targets (the barrel or the concrete module) during implementation — mixing the two in one file's imports is a code-smell the implementing agent should resolve one way or the other, not leave split.
+4. **Task 11's base-existence check re-queries the DB per adopted candidate inside a loop already doing per-candidate manifest fetches.** This mirrors the existing per-candidate DB-read pattern in `reconcileOrphanedBackupSnapshots` (which already does one write per adopted candidate), so it is consistent with the file's existing performance envelope, but it is an N+1-shaped query pattern that could matter if reconcile is ever run over a very large orphan backlog. Not fixed here — flagged for W02/a future pass if reconcile's throughput becomes a real bottleneck.
+5. **`backup_snapshot_retirements.snapshot_id` width is `varchar(255)`** (Task 3's migration) while `BACKUP_SNAPSHOT_ID_MAX_LENGTH`'s actual numeric value was not independently re-verified in this pass — only that the constant exists and is imported elsewhere. Confirm `BACKUP_SNAPSHOT_ID_MAX_LENGTH`'s actual value during implementation and either use the constant directly in both the migration's hand-written SQL and the Drizzle schema, or confirm `255` matches it, so the two never silently drift.
+6. **Task 6's multi-target dispatch and sequential base selection.** When a profile fans out to multiple targets in one dispatch call (`prepareBackupDispatchTargets`'s per-target loop), each `backup_run` target calls `stampDispatchPinAndIdentity` independently, in its own transaction. Two sibling targets for the SAME `(deviceId, configId, mode)` pair (not a scenario the current profile model appears to produce, since distinct targets carry distinct modes/paths, but not verified as structurally impossible) could theoretically select the same base snapshot and both pin it — harmless (both dispatch fine, retention just sees two pins on the same snapshot instead of one) but not something this plan explicitly proves against. Not treated as a defect; flagged as unverified.
+7. **Task 12's `backupSnapshots` import in `configs.ts`.** The plan assumes `backupSnapshots` needs adding to this route file's imports; whether it's already imported (for an unrelated existing route in the same file) was not independently confirmed — a two-second `grep` during implementation resolves this, called out so it isn't silently skipped.
+8. **PATCH `/backup/configs/:id`'s response-shape change.** Returning `{ ...toConfigResponse(row), warnings }` only when `warnings.length > 0` (rather than always including an empty `warnings: []`) avoids widening every existing PATCH response body, but means callers must treat `warnings` as always-optional. If the web UI consuming this endpoint expects a stable shape, this may need `warnings: []` unconditionally instead — a product/UI-contract decision this plan defers to whoever wires up the frontend warning banner (out of scope for W01, which is API-only).

--- a/docs/superpowers/plans/backup/2026-09-09-backup-gc-reclamation-w02-gc-sweep.md
+++ b/docs/superpowers/plans/backup/2026-09-09-backup-gc-reclamation-w02-gc-sweep.md
@@ -91,6 +91,70 @@ Verified against `backup-gc-5429` worktree, current `main`-based state (i.e. **b
 - Consumes: `resolveMsKnob(name: string, defaultMs: number, productionFloorMs?: number): number` from `../services/backupGcKnobs` (W01).
 - Produces: `resolveBackupGcGraceMs(): number` (kept, now a thin wrapper), removes the module-load `export const BACKUP_GC_GRACE_MS` and `export const BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS`; adds `resolveBackupManifestlessPrefixMaxAgeMs(): number` (exported, per-run).
 
+- [ ] Step 0: Extend the test mock harness up front — every later task (through Task 7) needs DB primitives the current `chainable`/`mockDb` (`backupRetention.test.ts:1-34`) doesn't provide (`selectDistinct`, `.groupBy()`, `.set()`, `.returning()`) and two new `../db` exports (`withSystemDbAccessContext`, `assertOutsideHeldDbContext`) the current `vi.mock('../db', () => ({ db: mockDb }))` doesn't stub. Doing this once, now, avoids re-touching the mock setup piecemeal in Tasks 4/7. Replace the top-of-file mock block:
+
+```typescript
+function chainable(rows: unknown[]) {
+  const obj: Record<string, unknown> = {
+    from: () => obj,
+    where: () => obj,
+    leftJoin: () => obj,
+    innerJoin: () => obj,
+    orderBy: () => obj,
+    groupBy: () => obj,
+    limit: () => obj,
+    set: () => obj, // db.update(...).set({...}) — returns itself so .where()/.returning() still chain
+    returning: () => obj, // db.delete(...).returning() / db.update(...).returning()
+    then: (resolve: (v: unknown[]) => unknown, reject?: (e: unknown) => unknown) =>
+      Promise.resolve(rows).then(resolve, reject),
+  };
+  return obj;
+}
+
+const selectQueue: unknown[][] = [];
+
+const mockDb = {
+  select: vi.fn(() => chainable(selectQueue.shift() ?? [])),
+  // selectDistinct shares the SAME selectQueue as select — from the test's
+  // perspective they're both just "the next db read in source order"; Task 7's
+  // capability-gate query is the only selectDistinct call site.
+  selectDistinct: vi.fn(() => chainable(selectQueue.shift() ?? [])),
+  delete: vi.fn(() => chainable([])),
+  update: vi.fn(() => chainable([])),
+};
+
+vi.mock('../db', () => ({ db: mockDb }));
+```
+
+  Note this REPLACES the plain `db: mockDb` mock with the same shape (no `withSystemDbAccessContext`/`assertOutsideHeldDbContext` yet — those are added in the SAME `vi.mock('../db', ...)` call, but wait until Task 7 needs them; add both exports here anyway so this task's edit is the only place the mock's shape changes):
+
+```typescript
+const assertOutsideHeldDbContextMock = vi.fn();
+vi.mock('../db', () => ({
+  db: mockDb,
+  withSystemDbAccessContext: (fn: () => unknown) => fn(), // pass-through under the mock — no real context to open
+  assertOutsideHeldDbContext: assertOutsideHeldDbContextMock,
+}));
+```
+
+  Also fix the age-fixture helpers at `:67-70` (`JUST_PAST_MANIFESTLESS_THRESHOLD`/`EVEN_FURTHER_PAST_MANIFESTLESS_THRESHOLD`), which currently read the module-load `BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS` export this task removes:
+
+```typescript
+// BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS is no longer a module-load export
+// (Task 1) — its default (9 days) is a fixture constant here, independent of
+// the real per-run resolver under test. The frozen-time boundary tests later
+// in this file exercise the resolver's actual output directly; these two
+// helpers only need "comfortably past the default" for tests that don't care
+// about the exact boundary.
+const MANIFESTLESS_WINDOW_MS_DEFAULT = 9 * DAY_MS;
+const JUST_PAST_MANIFESTLESS_THRESHOLD = () =>
+  new Date(Date.now() - MANIFESTLESS_WINDOW_MS_DEFAULT - DAY_MS);
+const EVEN_FURTHER_PAST_MANIFESTLESS_THRESHOLD = () =>
+  new Date(Date.now() - MANIFESTLESS_WINDOW_MS_DEFAULT - 2 * DAY_MS);
+```
+
+  Run `cd apps/api && npx vitest run src/jobs/backupRetention.test.ts` after this step alone to confirm the existing (unmodified) tests still pass against the extended mock before continuing to Step 1 — this step is pure test-infra, no source change yet.
+
 - [ ] Step 1: Write the failing test — replace the module-reset tests at `backupRetention.test.ts:497-540` (they `await import('./backupRetention')` with mutated `process.env` to catch a module-load constant; that pattern breaks once resolution moves off module load):
 
 ```typescript
@@ -423,6 +487,11 @@ async function logUnreachableStorageIdentities(
 
   let unreachable = 0;
   for (const row of usage) {
+    // A NULL storage_identity is not "unreachable" — it's an unresolved row
+    // the self-heal path (Task 7) owns, and `row.storageIdentity` is
+    // `string | null` here, so a naive `identities.has(null)` would be a type
+    // error and — if coerced — could misreport "unreachable identity null".
+    if (row.storageIdentity === null) continue;
     if (identities.has(row.storageIdentity)) continue;
     unreachable++;
     console.warn(`[BackupGC] unreachable identity ${row.storageIdentity}: ${row.count} rows`);
@@ -715,7 +784,23 @@ async function loadGcFailedKeySkipSet(identityKey: string): Promise<Set<string>>
   }
 }
 
-/** Best-effort; a Redis failure here must never fail the sweep that already ran. */
+/**
+ * Best-effort; a Redis failure here must never fail the sweep that already
+ * ran. Called from EVERY delete branch (rooted, manifest-less, retired/orphan
+ * non-manifest phase, retired/orphan manifest phase) — see Task 7 — not just
+ * the retired/orphan path, so a persistently-locked object anywhere stops
+ * burning cap budget on repeat attempts every run.
+ *
+ * ACCEPTED APPROXIMATION (documented, not fixed): `EXPIRE` sets a TTL on the
+ * whole per-identity SET, refreshed to a full 7 days on every call that adds
+ * a new key — Redis SETs have no native per-member TTL. On a busy identity
+ * that keeps failing DIFFERENT keys, an older failed key can therefore stay
+ * excluded from the cap for longer than 7 days. This is accepted because it
+ * only ever makes the sweep MORE conservative (skips more, never deletes
+ * something it shouldn't); a precise per-member TTL would need a Redis hash
+ * of `key -> expiresAt` plus a separate pruning pass, which is unwarranted
+ * complexity for a purely advisory cap-fairness mechanism.
+ */
 async function recordGcFailedKeys(
   identityKey: string,
   failedKeys: { key: string; error: string }[],
@@ -739,33 +824,31 @@ async function recordGcFailedKeys(
 
 - [ ] Step 5: Commit: `git add apps/api/src/jobs/backupRetention.ts apps/api/src/jobs/backupRetention.test.ts && git commit -m "feat(backup-gc): add Redis-backed failed-key skip set for delete-cap fairness"`
 
-### Task 7: Rewrite `sweepStorageIdentity` + `sweepUnreferencedBackupObjects` — NULL-identity self-heal, ORPHAN_WINDOW, stronger manifest-last rule, capability gate, and §3.7 transaction-boundary split
+### Task 7: Rewrite `sweepStorageIdentity` + `sweepUnreferencedBackupObjects` — NULL rows always roots, deferral runs today's algorithm, cap/skip-set correctness, §3.7 transaction-boundary split
 
-**IMPORTANT — supersedes earlier tasks' test scaffolding.** Tasks 3-6 added tests against an interim shape of `sweepUnreferencedBackupObjects` that queried the DB with a fixed, flat sequence of `db.select(...)` calls (matched 1:1 by `selectQueue.push(...)` in test order). This task changes that sequence for real (see the finalized per-identity query order below) **and** splits every DB access into its own short `withSystemDbAccessContext` call per §3.7, which the hand-rolled `chainable`/`selectQueue` mock does not distinguish from an un-wrapped call (the mock replaces `db` itself, not the context wrapper, so `withSystemDbAccessContext(fn)` calling straight through to `fn()` under the mock is transparent — no mock changes needed for the context wrapping itself). This step's implementation, once done, requires going back through every `selectQueue.push(...)` sequence added in Tasks 3-6 and updating it to match the **finalized per-identity read order**:
+**Spec amendment applied (re-read spec §3.4 "Capability gate" / "Unknown-identity rows" before implementing):** deferral (legacy helper OR any unresolved NULL-identity row) does **not** mean "rooted rule only" — it means run **exactly today's (pre-D18) algorithm**: every listed manifest (rooted or not, retired or not) is marked live via the pre-existing mark path, so only loose objects under a manifest-bearing prefix (48h grace) and manifest-less prefixes (9-day rule) are ever touched. No retired/orphan reclamation runs at all while deferred. Separately, **every** `backup_snapshots` row with `storage_identity IS NULL` mapped to identity `I` (via `configId`) is a root of `I` unconditionally (its manifest is fetched by the mark phase; a fetch failure aborts `I` fail-closed like any other root) — "resolved" (self-healed) is a narrower, independent signal (its manifest was found in *this run's listing*) that only gates (a) whether `storage_identity` gets backfilled and (b) whether that row counts toward the identity being deferred.
+
+**IMPORTANT — supersedes earlier tasks' test scaffolding.** Tasks 3-6 added tests against an interim shape of `sweepUnreferencedBackupObjects` that queried the DB with a fixed, flat sequence of `db.select(...)` calls (matched 1:1 by `selectQueue.push(...)` in test order). This task changes that sequence for real (see the finalized per-identity query order below) **and** splits every DB access into its own short `withSystemDbAccessContext` call per §3.7 (mocked as a transparent pass-through since Task 1, Step 0). This step's implementation, once done, requires going back through every `selectQueue.push(...)` sequence added in Tasks 3-6 and updating it to match the **finalized per-identity read order**:
 1. `unattributedRows` (run-level, once).
 2. `destinations` (run-level, once).
 3. `identityUsage` — the `GROUP BY storageIdentity` query for `logUnreachableStorageIdentities` (run-level, once).
-4. Per identity, in this order: (a) `retainedRows` (`storageIdentity = I`), (b) `nullIdentityRows` (`storageIdentity IS NULL AND configId IN I.configIds`), (c) `retirementRows` (`storageIdentity = I AND sweptAt IS NULL`), (d) `capabilityRows` (the legacy-helper job/device join).
-Do this fix-up as part of this task's Step 1 (the new tests below already use the finalized order; go back and add the missing `selectQueue.push([])` calls for the NULL-identity-rows query — step (b) above — to every test from Tasks 3, 5, and 6 that currently pushes only 4 per-identity-adjacent items instead of 5, or re-run the full suite after Step 3's implementation and fix whatever the mismatch count reveals).
+4. Per identity, in this order: (a) `retainedRows` (`storageIdentity = I`), (b) `nullIdentityRows` — `{id, snapshotId}` pairs, `storageIdentity IS NULL AND configId IN I.configIds` (note: **two columns**, not just `snapshotId` — the self-heal write-back needs the primary key, see the P1 fix below), (c) `retirementRows` (`storageIdentity = I AND sweptAt IS NULL`), (d) `capabilityRows` (the legacy-helper job/device join).
+
+Do this fix-up as part of this task's Step 1: go back and add the missing `selectQueue.push([])` calls for the NULL-identity-rows query (step 4b above) to every test from Tasks 3, 5, and 6 that currently pushes only 4 per-identity-adjacent items instead of 5, then re-run the full suite (`cd apps/api && npx vitest run src/jobs/backupRetention.test.ts`) and fix whatever mismatch the run reveals — given how many tasks compound this ordering, treat "run and fix" as mandatory, not optional, before moving to Step 2 below.
 
 **Files:** Modify `apps/api/src/jobs/backupRetention.ts:873-1110` (full rewrite of both functions plus the `BackupGcResult` type at `~550`).
 
 **Interfaces:**
-- Consumes: `backupSnapshotRetirements` from `../db/schema` (W01), `devices` from `../db/schema`, `backupHelperSupportsServerBase` from `../services/backupHelperCapabilities`, `withSystemDbAccessContext` from `../db`, `resolveBackupBaseLeaseMs` from `../services/backupGcKnobs`, everything from Tasks 1-6.
+- Consumes: `backupSnapshotRetirements` from `../db/schema` (W01), `devices` from `../db/schema`, `backupHelperSupportsServerBase` from `../services/backupHelperCapabilities`, `withSystemDbAccessContext`, `assertOutsideHeldDbContext` from `../db`, `resolveBackupBaseLeaseMs` from `../services/backupGcKnobs`, everything from Tasks 1-6.
 - Produces: `export type BackupGcResult = { deleted: number; skippedIdentities: number; blockedIdentities: number; retiredSwept: number; orphansSwept: number; deferredIdentities: number; unreachableIdentities: number };`, a `sweepStorageIdentity` that is now a **pure storage-and-compute function with zero DB calls** (all DB reads/writes happen in its caller, split into short contexts), and the same `export async function sweepUnreferencedBackupObjects(): Promise<BackupGcResult>` — internally phase-split per §3.7, but its name and signature are unchanged so W01's `backupWorker.ts` call site (`const gcResult = await sweepUnreferencedBackupObjects();`) needs no edit.
 
-- [ ] Step 1: Write the failing test — first extend the file's existing `vi.mock('../db', () => ({ db: mockDb }));` (top of `backupRetention.test.ts`) to also provide the two new `../db` imports this task adds, so the mock doesn't throw `withSystemDbAccessContext is not a function`:
+**Two accepted-and-stated approximations (per review — pick, don't leave ambiguous):**
+1. **Redis skip-set TTL is per-identity-SET, not per-member.** `EXPIRE` on `backup-gc:failed:<hash>` is refreshed to a full 7 days every time ANY new key is added to that set (Redis `SET`s have no native per-member TTL). A busy identity accumulating new failures can therefore keep an OLDER failed key excluded from the cap for longer than 7 days. Accepted: this only ever makes the sweep MORE conservative (skips more, never deletes something it shouldn't) — a per-member-TTL design (a Redis hash of `key -> expiresAt` plus a separate pruning pass) would be more precise but adds real complexity for a purely advisory cap-fairness mechanism. Not implemented; documented in code.
+2. **`orphansSwept` is a best-effort per-run metric, not a durable "confirmed swept" count** (unlike `retiredSwept`, which is durable via `swept_at` and therefore held to the stricter "confirmed absent from a fresh listing" bar below). An orphan has no DB row to mark, so there is nothing to protect against double-counting or a stale confirmation — it is purely observability. Counted here when at least one object was actually deleted for that old-orphan prefix this run.
 
-```typescript
-const assertOutsideHeldDbContextMock = vi.fn();
-vi.mock('../db', () => ({
-  db: mockDb,
-  withSystemDbAccessContext: (fn: () => unknown) => fn(), // pass-through under the mock — no real context to open
-  assertOutsideHeldDbContext: assertOutsideHeldDbContextMock,
-}));
-```
+**P1 fix — `swept_at` is never inferred from this run's own delete bookkeeping.** The previous draft of this task computed "prefix empty" from `this run's items minus this run's deletedKeys` and set `swept_at` in the SAME pass as the deletes. That's fragile (a delete provider that lies, a concurrent write, a missed edge) and conflates two different questions. Corrected rule: a retirement's `swept_at` is set **only when this run's fresh `listBackupObjectsUnderPrefix` listing has NO group at all for that `snapshotId`** — i.e., the prefix is confirmed **already** gone (covers a retirement whose objects were already fully removed by an earlier run, or that were never fully written) or, on a **later** run, confirmed gone **after** an earlier run's real deletes landed. This decouples "did I just delete some stuff" from "is the prefix actually empty" — the latter always comes from an independent, fresh listing.
 
-  Then add a small tripwire test proving the guard is wired (mirrors `apps/api/src/services/urlSafety.tripwire.test.ts`'s pattern — spy on the guard, assert it fires before the storage call):
+- [ ] Step 1: Write the failing test — the `../db` mock (`withSystemDbAccessContext`, `assertOutsideHeldDbContext`, `selectDistinct`, `.groupBy()`/`.set()`/`.returning()` on `chainable`) was already extended in Task 1, Step 0; nothing further to add to the mock here. First add a small tripwire test proving the guard is wired (mirrors `apps/api/src/services/urlSafety.tripwire.test.ts`'s pattern — spy on the guard, assert it fires before the storage call):
 
 ```typescript
 describe('§3.7 held-context tripwire', () => {
@@ -784,123 +867,95 @@ describe('§3.7 held-context tripwire', () => {
     await sweepUnreferencedBackupObjects();
 
     expect(assertOutsideHeldDbContextMock).toHaveBeenCalledWith('backupGC.sweepStorageIdentity');
-    // The guard is a no-op under the mock (it doesn't throw), so the sweep still
-    // completes — this test only proves the call site exists, not the guard's
-    // real held-context detection (that's exercised by db/index.ts's own suite).
   });
 });
 ```
 
-  Now add these scenarios to `backupRetention.test.ts` (the earlier tasks' tests already exercise pieces of this; these close the remaining gaps: retirement-immediate deletion, the stronger manifest-last rule, the capability gate, the NULL-identity self-heal, and the unresolved-rows gate). Every test below pushes 5 per-identity queries in the finalized order: retained rows, NULL-identity rows, retirements, capability rows — see this task's header note:
+  Now add the scenarios below (the earlier tasks' tests already exercise the pieces unaffected by this task's changes — orphan-window boundaries, Redis skip-set exclusion itself, etc.). These close the P1/P2 gaps: NULL rows are ALWAYS roots (not just resolved ones), deferral runs today's full algorithm (not "rooted only"), self-heal by row `id`, cap accounting charges failed attempts, skip-set is fed from every branch, and `swept_at` is a two-pass, listing-confirmed fact:
 
 ```typescript
-describe('retirement-aware sweep (§3.4 v3)', () => {
-  it('reclaims a retired prefix immediately regardless of age, and marks the retirement swept once empty', async () => {
+describe('NULL-identity rows are ALWAYS roots of I, resolved or not (§3.6 v3 P1)', () => {
+  it('fetches (and requires) the manifest of an UNRESOLVED NULL row too, and defers the whole identity if it is not found in the listing', async () => {
     selectQueue.push([]); // unattributedRows
     selectQueue.push([destination]); // destinations
     selectQueue.push([{ storageIdentity: normalizeStorageIdentity(destination.provider, destination.providerConfig), count: 1 }]); // identityUsage
-    selectQueue.push([]); // retained snapshots — the row was already deleted by retention
-    selectQueue.push([]); // NULL-identity rows for this identity — none
-    selectQueue.push([{ id: 'retirement-1', snapshotId: 'RETIRED1' }]); // retirements for this identity, sweptAt IS NULL
-    selectQueue.push([]); // legacy-helper capability check — no jobs on this identity -> not deferred
+    selectQueue.push([]); // retained — none
+    selectQueue.push([{ id: 'row-neverwritten', snapshotId: 'NEVERWRITTEN' }]); // NULL-identity row mapped here
+    selectQueue.push([{ id: 'retirement-5', snapshotId: 'RETIRED5' }]); // a genuine retirement, different snapshot
+    selectQueue.push([]); // capability check
 
-    const veryRecent = new Date(Date.now() - 1000); // 1 second old — would be protected under every OTHER rule
+    // NEVERWRITTEN never appears in the listing at all — its manifest fetch is
+    // therefore never attempted (markLiveBackupObjects only fetches ids it's
+    // given; a NULL-identity root whose object plainly isn't in this bucket
+    // would 404 if fetched, but here it simply never shows up — the "not
+    // found in the listing" signal, not a fetch failure).
+    const t = new Date(Date.now() - 1000);
     listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
-      { key: 'snapshots/RETIRED1/manifest.json', lastModified: veryRecent },
-      { key: 'snapshots/RETIRED1/files/x.dat', lastModified: veryRecent },
+      { key: 'snapshots/RETIRED5/manifest.json', lastModified: t },
+      { key: 'snapshots/RETIRED5/files/x.dat', lastModified: t },
     ]);
-    deleteBackupObjectKeysMock.mockResolvedValueOnce({ deletedKeys: ['snapshots/RETIRED1/files/x.dat'], failedKeys: [] });
-    deleteBackupObjectKeysMock.mockResolvedValueOnce({ deletedKeys: ['snapshots/RETIRED1/manifest.json'], failedKeys: [] });
+    // Deferred (today's algorithm): RETIRED5's manifest IS listed, so it's
+    // marked live via the "every listed manifest" path, and fetched.
+    fetchBackupObjectTextMock.mockResolvedValueOnce(manifestJson([]));
 
-    const result = await sweepUnreferencedBackupObjects();
-
-    expect(result.deleted).toBe(2);
-    expect(result.retiredSwept).toBe(1);
-    // Non-manifest phase first, manifest phase second.
-    expect(deleteBackupObjectKeysMock.mock.calls[0][0].keys).toEqual(['snapshots/RETIRED1/files/x.dat']);
-    expect(deleteBackupObjectKeysMock.mock.calls[1][0].keys).toEqual(['snapshots/RETIRED1/manifest.json']);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const result = await sweepUnreferencedBackupObjects();
+      expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled(); // today's algorithm: nothing unrooted is touched
+      expect(result.retiredSwept).toBe(0); // never confirmed gone — it's still fully listed
+      expect(warn.mock.calls.some(([msg]) => String(msg).includes('identity deferred: 1 unresolved rows'))).toBe(true);
+    } finally {
+      warn.mockRestore();
+    }
   });
 
-  it('does NOT delete the manifest when a non-manifest key is skip-set-excluded, even though none FAILED this run (stronger v3 rule)', async () => {
+  it('fetch failure for an UNRESOLVED NULL row still aborts the identity fail-closed (it is a root regardless of resolution)', async () => {
     selectQueue.push([]);
     selectQueue.push([destination]);
     selectQueue.push([{ storageIdentity: normalizeStorageIdentity(destination.provider, destination.providerConfig), count: 1 }]);
     selectQueue.push([]); // retained
-    selectQueue.push([]); // NULL-identity rows
-    selectQueue.push([{ id: 'retirement-2', snapshotId: 'RETIRED2' }]);
+    selectQueue.push([{ id: 'row-badfetch', snapshotId: 'BADFETCH' }]); // NULL row, and its manifest IS listed
+    selectQueue.push([]); // retirements
     selectQueue.push([]); // capability check
-
-    redisSmembersMock.mockResolvedValueOnce(['snapshots/RETIRED2/files/skipme.dat']); // already in the failed-key skip set
 
     const t = new Date(Date.now() - 1000);
     listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
-      { key: 'snapshots/RETIRED2/manifest.json', lastModified: t },
-      { key: 'snapshots/RETIRED2/files/skipme.dat', lastModified: t },
+      { key: 'snapshots/BADFETCH/manifest.json', lastModified: t },
     ]);
-    // The skip-set-excluded key is never even attempted, so deleteBackupObjectKeys
-    // is called zero times for the non-manifest phase — nothing to delete once
-    // the sole candidate is filtered out — and the manifest phase never runs
-    // because a deletable-but-skipped key still "remains" in the prefix.
-    deleteBackupObjectKeysMock.mockResolvedValueOnce({ deletedKeys: [], failedKeys: [] });
+    // BADFETCH resolves (found in listing) but its manifest fetch fails —
+    // markLiveBackupObjects fetches every rooted id regardless of resolution.
+    fetchBackupObjectTextMock.mockRejectedValueOnce(new Error('S3 500'));
 
     const result = await sweepUnreferencedBackupObjects();
-
-    expect(deleteBackupObjectKeysMock).not.toHaveBeenCalledWith(
-      expect.objectContaining({ keys: expect.arrayContaining(['snapshots/RETIRED2/manifest.json']) }),
-    );
-    expect(result.retiredSwept).toBe(0);
+    expect(result.blockedIdentities).toBe(1);
+    expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled();
   });
+});
 
-  it('does NOT delete the manifest when the delete cap truncates the non-manifest phase (stronger v3 rule: capped, not just failed)', async () => {
-    selectQueue.push([]);
-    selectQueue.push([destination]);
-    selectQueue.push([{ storageIdentity: normalizeStorageIdentity(destination.provider, destination.providerConfig), count: 1 }]);
-    selectQueue.push([]);
-    selectQueue.push([]);
-    selectQueue.push([{ id: 'retirement-4', snapshotId: 'RETIRED4' }]);
-    selectQueue.push([]);
-
-    const prevCap = process.env.BACKUP_GC_MAX_DELETES_PER_RUN;
-    process.env.BACKUP_GC_MAX_DELETES_PER_RUN = '1'; // only 1 delete allowed this whole run
-    try {
-      const t = new Date(Date.now() - 1000);
-      listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
-        { key: 'snapshots/RETIRED4/manifest.json', lastModified: t },
-        { key: 'snapshots/RETIRED4/files/a.dat', lastModified: t },
-        { key: 'snapshots/RETIRED4/files/b.dat', lastModified: t }, // capped out — never attempted this run
-      ]);
-      deleteBackupObjectKeysMock.mockResolvedValueOnce({ deletedKeys: ['snapshots/RETIRED4/files/a.dat'], failedKeys: [] });
-
-      const result = await sweepUnreferencedBackupObjects();
-
-      expect(deleteBackupObjectKeysMock).toHaveBeenCalledTimes(1); // manifest phase never runs — cap exhausted, b.dat still present
-      expect(result.retiredSwept).toBe(0);
-    } finally {
-      if (prevCap === undefined) delete process.env.BACKUP_GC_MAX_DELETES_PER_RUN; else process.env.BACKUP_GC_MAX_DELETES_PER_RUN = prevCap;
-    }
-  });
-
-  it('defers reclamation on an identity with a legacy (pre-server-base) helper on a PENDING job of any age, running only the rooted rule', async () => {
+describe('deferral runs EXACTLY today\'s algorithm, not "rooted only" (§3.4 v3 P1)', () => {
+  it('legacy-helper deferral marks EVERY listed manifest live (including a retired one) and only reclaims loose/manifest-less objects', async () => {
     selectQueue.push([]); // unattributedRows
     selectQueue.push([destination]);
     selectQueue.push([{ storageIdentity: normalizeStorageIdentity(destination.provider, destination.providerConfig), count: 1 }]);
     selectQueue.push([]); // retained
     selectQueue.push([]); // NULL-identity rows
     selectQueue.push([{ id: 'retirement-3', snapshotId: 'RETIRED3' }]); // a retirement exists...
-    // ...but a PENDING job (any age, per v3's widened criteria) on this
-    // identity is still served by a pre-0.112.0 helper.
-    selectQueue.push([{ deviceId: 'device-legacy', backupVersion: '0.109.0' }]);
+    selectQueue.push([{ deviceId: 'device-legacy', backupVersion: '0.109.0' }]); // ...but a legacy helper defers the identity
 
     const t = new Date(Date.now() - 1000);
     listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
       { key: 'snapshots/RETIRED3/manifest.json', lastModified: t },
       { key: 'snapshots/RETIRED3/files/x.dat', lastModified: t },
     ]);
+    // Deferred path fetches EVERY listed manifest, including RETIRED3's —
+    // without this mock, the mark phase 404s and fail-closes the identity.
+    fetchBackupObjectTextMock.mockResolvedValueOnce(manifestJson([]));
 
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     try {
       const result = await sweepUnreferencedBackupObjects();
-      expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled();
+      expect(fetchBackupObjectTextMock).toHaveBeenCalledWith(expect.objectContaining({ key: 'snapshots/RETIRED3/manifest.json' }));
+      expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled(); // both objects are 1s old — inside the 48h rooted grace
       expect(result.deferredIdentities).toBe(1);
       expect(result.retiredSwept).toBe(0);
       expect(warn.mock.calls.some(([msg]) => String(msg).includes('reclamation deferred: legacy helper device-legacy 0.109.0'))).toBe(true);
@@ -908,65 +963,186 @@ describe('retirement-aware sweep (§3.4 v3)', () => {
       warn.mockRestore();
     }
   });
-});
 
-describe('NULL storage_identity self-heal and unresolved-rows gate (§3.6/§3.4 v3)', () => {
-  it('self-heals a NULL-identity row once its manifest is found in the listing, and treats it as rooted this run', async () => {
-    selectQueue.push([]); // unattributedRows
-    selectQueue.push([destination]); // destinations
-    selectQueue.push([{ storageIdentity: normalizeStorageIdentity(destination.provider, destination.providerConfig), count: 1 }]); // identityUsage
-    selectQueue.push([]); // retained (storageIdentity = I) — none yet, this row is still NULL
-    selectQueue.push([{ snapshotId: 'HEALME' }]); // NULL-identity rows mapped to this identity's configIds
-    selectQueue.push([]); // retirements — none
-    selectQueue.push([]); // capability check — no legacy helper
+  it('a deferred identity STILL reclaims a manifest-less prefix older than 9 days (that rule is unconditional)', async () => {
+    selectQueue.push([]);
+    selectQueue.push([destination]);
+    selectQueue.push([{ storageIdentity: normalizeStorageIdentity(destination.provider, destination.providerConfig), count: 1 }]);
+    selectQueue.push([]); // retained
+    selectQueue.push([]); // NULL-identity rows
+    selectQueue.push([]); // retirements
+    selectQueue.push([{ deviceId: 'device-legacy', backupVersion: '0.109.0' }]); // legacy helper -> deferred
 
-    fetchBackupObjectTextMock.mockResolvedValueOnce(manifestJson([]));
-    const t = new Date(Date.now() - DAY_MS);
+    const old = JUST_PAST_MANIFESTLESS_THRESHOLD();
     listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
-      { key: 'snapshots/HEALME/manifest.json', lastModified: t }, // found — resolvable
+      { key: 'snapshots/ORPHANPARTIAL/files/partial.dat', lastModified: old }, // no manifest.json at all
     ]);
+    deleteBackupObjectKeysMock.mockResolvedValueOnce({ deletedKeys: ['snapshots/ORPHANPARTIAL/files/partial.dat'], failedKeys: [] });
 
     const result = await sweepUnreferencedBackupObjects();
-
-    expect(fetchBackupObjectTextMock).toHaveBeenCalledWith(expect.objectContaining({ key: 'snapshots/HEALME/manifest.json' }));
-    expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled(); // rooted -> protected, not swept
+    expect(result.deleted).toBe(1);
+    expect(result.deferredIdentities).toBe(1);
   });
+});
 
-  it('defers ALL retired/orphan reclamation on an identity with an unresolved NULL-identity row, even though a retirement exists', async () => {
+describe('self-heal writes by row id, guarded by storage_identity IS NULL (§3.6 v3 P1)', () => {
+  it('resolves a NULL row (found in listing) and reclaims a co-located retirement in the SAME run once nothing is unresolved', async () => {
     selectQueue.push([]); // unattributedRows
     selectQueue.push([destination]);
     selectQueue.push([{ storageIdentity: normalizeStorageIdentity(destination.provider, destination.providerConfig), count: 1 }]);
-    selectQueue.push([]); // retained — none
-    selectQueue.push([{ snapshotId: 'NEVERWRITTEN' }]); // a NULL row mapped here, but its manifest never shows up in the listing
-    selectQueue.push([{ id: 'retirement-5', snapshotId: 'RETIRED5' }]); // a genuine retirement, on a DIFFERENT snapshot
-    selectQueue.push([]); // capability check — no legacy helper
+    selectQueue.push([]); // retained
+    selectQueue.push([{ id: 'row-healme', snapshotId: 'HEALME' }]); // resolves this run
+    selectQueue.push([{ id: 'retirement-6', snapshotId: 'RETIRED6' }]); // retired, same identity
+    selectQueue.push([]); // capability check
+
+    fetchBackupObjectTextMock.mockResolvedValueOnce(manifestJson([])); // HEALME's manifest, fetched as a root
+    const t = new Date(Date.now() - 1000);
+    listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
+      { key: 'snapshots/HEALME/manifest.json', lastModified: t }, // found -> resolves
+      { key: 'snapshots/RETIRED6/manifest.json', lastModified: t },
+      { key: 'snapshots/RETIRED6/files/r.dat', lastModified: t },
+    ]);
+    deleteBackupObjectKeysMock.mockResolvedValueOnce({ deletedKeys: ['snapshots/RETIRED6/files/r.dat'], failedKeys: [] });
+    deleteBackupObjectKeysMock.mockResolvedValueOnce({ deletedKeys: ['snapshots/RETIRED6/manifest.json'], failedKeys: [] });
+
+    const result = await sweepUnreferencedBackupObjects();
+
+    // Not deferred (HEALME resolved, no unresolved rows left) -> normal
+    // retired reclaim runs against RETIRED6.
+    expect(result.deleted).toBe(2);
+    expect(mockDb.update).toHaveBeenCalledWith(backupSnapshots);
+    // Self-heal write targets the ROW ID, not the snapshot id.
+    // (Assert via the update/.set/.where mock call chain if the chainable mock
+    // records call args — otherwise assert indirectly via a second run's
+    // retainedRows push showing HEALME now returns from the storageIdentity=I
+    // query; either is acceptable, pick one and document which.)
+    expect(result.retiredSwept).toBe(0); // NOT yet confirmed by a fresh listing — see the two-pass test below
+  });
+});
+
+describe('swept_at is set only once a FRESH listing confirms the prefix is gone (two-pass, §3.4 v3 P2)', () => {
+  it('does not set swept_at in the same pass as the deletes, but does on a later run once the listing shows it gone', async () => {
+    // Pass 1: RETIRED1 is fully listed; both its objects get deleted.
+    selectQueue.push([]); selectQueue.push([destination]);
+    selectQueue.push([{ storageIdentity: normalizeStorageIdentity(destination.provider, destination.providerConfig), count: 1 }]);
+    selectQueue.push([]); selectQueue.push([]); // retained, NULL rows
+    selectQueue.push([{ id: 'retirement-1', snapshotId: 'RETIRED1' }]);
+    selectQueue.push([]); // capability
 
     const t = new Date(Date.now() - 1000);
     listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
-      { key: 'snapshots/RETIRED5/manifest.json', lastModified: t },
-      { key: 'snapshots/RETIRED5/files/x.dat', lastModified: t },
-      // Note: 'snapshots/NEVERWRITTEN/...' never appears — its NULL row stays unresolved.
+      { key: 'snapshots/RETIRED1/manifest.json', lastModified: t },
+      { key: 'snapshots/RETIRED1/files/x.dat', lastModified: t },
     ]);
+    deleteBackupObjectKeysMock.mockResolvedValueOnce({ deletedKeys: ['snapshots/RETIRED1/files/x.dat'], failedKeys: [] });
+    deleteBackupObjectKeysMock.mockResolvedValueOnce({ deletedKeys: ['snapshots/RETIRED1/manifest.json'], failedKeys: [] });
 
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const firstRun = await sweepUnreferencedBackupObjects();
+    expect(firstRun.deleted).toBe(2);
+    expect(firstRun.retiredSwept).toBe(0); // NOT confirmed this pass, even though everything was just deleted
+
+    // Pass 2: a fresh listing (real deletes from pass 1 already landed) shows
+    // NOTHING at all for RETIRED1's prefix — confirmed gone.
+    selectQueue.push([]); selectQueue.push([destination]);
+    selectQueue.push([{ storageIdentity: normalizeStorageIdentity(destination.provider, destination.providerConfig), count: 1 }]);
+    selectQueue.push([]); selectQueue.push([]);
+    selectQueue.push([{ id: 'retirement-1', snapshotId: 'RETIRED1' }]); // still unswept in the DB
+    selectQueue.push([]);
+    listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([]); // RETIRED1 not present at all
+
+    const secondRun = await sweepUnreferencedBackupObjects();
+    expect(secondRun.deleted).toBe(0);
+    expect(secondRun.retiredSwept).toBe(1);
+  });
+
+  it('confirms swept_at IMMEDIATELY (first time it is ever swept) when a retirement is already fully absent from the listing', async () => {
+    selectQueue.push([]); selectQueue.push([destination]);
+    selectQueue.push([{ storageIdentity: normalizeStorageIdentity(destination.provider, destination.providerConfig), count: 1 }]);
+    selectQueue.push([]); selectQueue.push([]);
+    selectQueue.push([{ id: 'retirement-7', snapshotId: 'RETIRED7' }]);
+    selectQueue.push([]);
+    listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([]); // never had objects, or a manual cleanup already removed them
+
+    const result = await sweepUnreferencedBackupObjects();
+    expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled();
+    expect(result.retiredSwept).toBe(1);
+  });
+
+  it('a manifest-less "retired remnant" (manifest already gone from a prior run) is reclaimed immediately, with no 9-day wait', async () => {
+    selectQueue.push([]); selectQueue.push([destination]);
+    selectQueue.push([{ storageIdentity: normalizeStorageIdentity(destination.provider, destination.providerConfig), count: 1 }]);
+    selectQueue.push([]); selectQueue.push([]);
+    selectQueue.push([{ id: 'retirement-8', snapshotId: 'RETIRED8' }]);
+    selectQueue.push([]);
+
+    const veryRecent = new Date(Date.now() - 1000); // would be fully protected under the ordinary 9-day manifest-less rule
+    listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
+      { key: 'snapshots/RETIRED8/files/remnant.dat', lastModified: veryRecent }, // no manifest.json — already deleted
+    ]);
+    deleteBackupObjectKeysMock.mockResolvedValueOnce({ deletedKeys: ['snapshots/RETIRED8/files/remnant.dat'], failedKeys: [] });
+
+    const result = await sweepUnreferencedBackupObjects();
+    expect(result.deleted).toBe(1); // reclaimed despite being 1 second old — retired status has no age gate
+  });
+});
+
+describe('delete-cap accounting and skip-set feeding (§3.4 v3 P2)', () => {
+  it('a FAILED delete attempt consumes the per-run cap, not just successful deletes', async () => {
+    selectQueue.push([]); selectQueue.push([destination]);
+    selectQueue.push([{ storageIdentity: normalizeStorageIdentity(destination.provider, destination.providerConfig), count: 1 }]);
+    selectQueue.push([{ snapshotId: 'B' }]); // retained (rooted)
+    selectQueue.push([]); selectQueue.push([]); selectQueue.push([]);
+
+    fetchBackupObjectTextMock.mockResolvedValueOnce(manifestJson([]));
+    const prevCap = process.env.BACKUP_GC_MAX_DELETES_PER_RUN;
+    process.env.BACKUP_GC_MAX_DELETES_PER_RUN = '1';
     try {
-      const result = await sweepUnreferencedBackupObjects();
-      // Even though RETIRED5's retirement is real and its prefix is listed,
-      // the WHOLE identity is deferred to rooted-only this run because of the
-      // unresolved NULL row — RETIRED5 is untouched.
-      expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled();
-      expect(result.retiredSwept).toBe(0);
-      expect(warn.mock.calls.some(([msg]) => String(msg).includes('identity deferred: 1 unresolved rows'))).toBe(true);
+      const old = JUST_PAST_MANIFESTLESS_THRESHOLD();
+      listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
+        { key: 'snapshots/B/manifest.json', lastModified: old },
+        { key: 'snapshots/B/files/a.dat', lastModified: old }, // this one "fails" to delete
+        { key: 'snapshots/B/files/b.dat', lastModified: old }, // never attempted — cap already spent on a.dat's ATTEMPT
+      ]);
+      deleteBackupObjectKeysMock.mockResolvedValueOnce({
+        deletedKeys: [],
+        failedKeys: [{ key: 'snapshots/B/files/a.dat', error: 'object-lock' }],
+      });
+
+      await sweepUnreferencedBackupObjects();
+      // Only ONE deleteBackupObjectKeys call happened at all — the cap was
+      // exhausted by the FAILED attempt, so b.dat was never even tried.
+      expect(deleteBackupObjectKeysMock).toHaveBeenCalledTimes(1);
     } finally {
-      warn.mockRestore();
+      if (prevCap === undefined) delete process.env.BACKUP_GC_MAX_DELETES_PER_RUN; else process.env.BACKUP_GC_MAX_DELETES_PER_RUN = prevCap;
     }
+  });
+
+  it('a rooted-branch delete failure is recorded into the Redis skip set too (not just the retired/orphan branch)', async () => {
+    selectQueue.push([]); selectQueue.push([destination]);
+    selectQueue.push([{ storageIdentity: normalizeStorageIdentity(destination.provider, destination.providerConfig), count: 1 }]);
+    selectQueue.push([{ snapshotId: 'B' }]);
+    selectQueue.push([]); selectQueue.push([]); selectQueue.push([]);
+
+    fetchBackupObjectTextMock.mockResolvedValueOnce(manifestJson([]));
+    const old = JUST_PAST_MANIFESTLESS_THRESHOLD();
+    listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
+      { key: 'snapshots/B/manifest.json', lastModified: old },
+      { key: 'snapshots/B/files/locked.dat', lastModified: old },
+    ]);
+    deleteBackupObjectKeysMock.mockResolvedValueOnce({
+      deletedKeys: [],
+      failedKeys: [{ key: 'snapshots/B/files/locked.dat', error: 'object-lock' }],
+    });
+
+    await sweepUnreferencedBackupObjects();
+    expect(redisSaddMock).toHaveBeenCalledWith(expect.stringMatching(/^backup-gc:failed:/), 'snapshots/B/files/locked.dat');
   });
 });
 ```
 
-- [ ] Step 2: Run it, expect FAIL: `cd apps/api && npx vitest run src/jobs/backupRetention.test.ts` — `result.retiredSwept`/`deferredIdentities` undefined, retirement/capability/NULL-identity queries never issued.
+- [ ] Step 2: Run it, expect FAIL: `cd apps/api && npx vitest run src/jobs/backupRetention.test.ts` — every new assertion above fails against the pre-Task-7 implementation (wrong deferral semantics, `retiredSwept` computed same-pass, cap counting successes only, skip-set fed from one branch).
 
-- [ ] Step 3: Implement — full replacement of `backupRetention.ts:550` (type) and `:873-1110` (both functions), split per §3.7 into short contexts for DB work and depth-0 storage calls:
+- [ ] Step 3: Implement — full replacement of `backupRetention.ts:550` (type) and `:873-1110` (both functions):
 
 ```typescript
 export type BackupGcResult = {
@@ -986,56 +1162,48 @@ async function deleteCandidatesWithCap(
   candidates: BackupObjectListing[],
   cap: number,
   skipSet: Set<string>,
-): Promise<{ deletedKeys: string[]; failedKeys: { key: string; error: string }[] }> {
+): Promise<{ deletedKeys: string[]; failedKeys: { key: string; error: string }[]; attempted: number }> {
   const eligible = candidates.filter((c) => !skipSet.has(c.key));
-  if (eligible.length === 0 || cap <= 0) return { deletedKeys: [], failedKeys: [] };
+  if (eligible.length === 0 || cap <= 0) return { deletedKeys: [], failedKeys: [], attempted: 0 };
   eligible.sort((a, b) => (a.lastModified?.getTime() ?? 0) - (b.lastModified?.getTime() ?? 0));
   const toDelete = eligible.slice(0, cap).map((c) => c.key);
-  return deleteBackupObjectKeys({ provider: identity.provider, providerConfig: identity.providerConfig, keys: toDelete });
+  const result = await deleteBackupObjectKeys({ provider: identity.provider, providerConfig: identity.providerConfig, keys: toDelete });
+  // `attempted` (not `deletedKeys.length`) is what the caller charges against
+  // the per-run cap — a failed attempt still cost a real provider call this
+  // run and must not be retried unboundedly within the same run (review item).
+  return { ...result, attempted: toDelete.length };
 }
 
 function manifestOlderThanWindow(item: BackupObjectListing, nowMs: number, windowMs: number): boolean {
-  if (!item.lastModified) return false; // unknown age -> not provably old; orphanManifestSnapshotIds already protects it
+  if (!item.lastModified) return false;
   return item.lastModified.getTime() <= nowMs - windowMs;
 }
 
 /**
- * §3.7: pure storage-and-compute — every DB read this needs (retained ids,
- * NULL-identity ids, retirement map, the legacy-helper verdict) is gathered
- * by the caller in a short DB context BEFORE this runs; every DB write this
- * produces (self-heal, retirement-swept) is applied by the caller in a
- * short DB context AFTER this returns. This function itself never touches
- * `db` — only `listBackupObjectsUnderPrefix` / `fetchBackupObjectText` /
- * `deleteBackupObjectKeys` (storage calls) and Redis (skip-set), so nothing
- * here can hold a Postgres transaction open across a slow S3 call.
+ * §3.7: pure storage-and-compute — every DB read this needs is gathered by
+ * the caller in a short DB context BEFORE this runs; every DB write this
+ * produces (self-heal, retirement-swept) is applied by the caller in a short
+ * DB context AFTER this returns. Never touches `db` itself.
  */
 async function sweepStorageIdentity(
   identity: { key: string; provider: string; providerConfig: unknown },
   retainedSnapshotIds: string[],
-  nullIdentitySnapshotIds: string[], // storage_identity IS NULL rows whose configId maps to this identity
+  nullIdentityRows: { id: string; snapshotId: string }[], // storage_identity IS NULL, configId maps to this identity
   retiredSnapshotIds: Map<string, string>, // snapshotId -> retirement row id, sweptAt IS NULL only
   nowMs: number,
   deletesRemaining: number,
   graceMs: number,
   orphanWindowMs: number,
   manifestlessWindowMs: number,
-  restrictToRootedOnly: boolean, // true if EITHER the capability gate OR the unresolved-NULL-rows gate applies
+  legacyHelperDeferred: boolean,
 ): Promise<{
   deleted: number;
-  retiredSwept: string[]; // retirement row ids to mark swept (caller writes these)
-  orphansSwept: number;
-  selfHealSnapshotIds: string[]; // NULL-identity snapshot ids whose manifest was found (caller writes storage_identity)
-  unresolvedNullIdentityCount: number; // NULL-identity rows that did NOT resolve this run
+  retiredSweptIds: string[]; // retirement row ids CONFIRMED fully gone from THIS run's fresh listing
+  orphansSwept: number; // best-effort metric — see the accepted-approximation note above
+  selfHealRowIds: string[]; // backup_snapshots.id values to self-heal
+  unresolvedNullIdentityCount: number;
   deletesUsed: number;
 }> {
-  // §3.7 guard: reuse the existing #1105 tripwire (apps/api/src/db/index.ts) —
-  // the same mechanism urlSafety.ts/bullmqQueue.ts already use before a slow
-  // network primitive — to catch (warn in prod, throw under
-  // DB_CONTEXT_TRIPWIRE_STRICT) a caller that invokes this function from
-  // inside an open withDbAccessContext/withSystemDbAccessContext. This is a
-  // defense-in-depth check on the consumed W01 interface (the worker calls
-  // sweepUnreferencedBackupObjects at depth 0), not a replacement for it —
-  // see "Depends on".
   assertOutsideHeldDbContext('backupGC.sweepStorageIdentity');
 
   const listing = await listBackupObjectsUnderPrefix({
@@ -1045,133 +1213,121 @@ async function sweepStorageIdentity(
   });
   const groups = groupListingBySnapshotId(listing);
 
-  // Self-heal resolution: a NULL-identity row is resolvable this run iff its
-  // manifest is present in the listing (proves it belongs to THIS identity).
-  // "Unresolved" can only be known AFTER the listing (not before), which is
-  // why the unresolved-rows gate below is computed HERE, not by the caller.
-  const selfHealSnapshotIds = nullIdentitySnapshotIds.filter((id) => groups.get(id)?.manifestItem);
-  const unresolvedNullIdentityCount = nullIdentitySnapshotIds.length - selfHealSnapshotIds.length;
-  // §3.6: while ANY NULL-identity row mapped to this identity is unresolved,
-  // the WHOLE identity runs rooted-only this run — combined with the
-  // capability gate via OR (either reason alone is sufficient to defer).
-  const runRootedOnly = restrictToRootedOnly || unresolvedNullIdentityCount > 0;
+  // §3.4/§3.6 P1: every NULL-identity row mapped to this identity is a root,
+  // unconditionally. "Resolved" is the narrower, independent question of
+  // whether THIS run's listing actually shows its manifest — that only
+  // decides self-heal eligibility and the deferral gate below, never whether
+  // the row counts as a root for the mark phase.
+  const nullIdentitySnapshotIds = nullIdentityRows.map((r) => r.snapshotId);
+  const alwaysRootedIds = new Set([...retainedSnapshotIds, ...nullIdentitySnapshotIds]);
+  const selfHealRowIds = nullIdentityRows.filter((r) => groups.get(r.snapshotId)?.manifestItem).map((r) => r.id);
+  const unresolvedNullIdentityCount = nullIdentityRows.length - selfHealRowIds.length;
 
-  const rootedIds = new Set([...retainedSnapshotIds, ...selfHealSnapshotIds]);
-  for (const id of orphanManifestSnapshotIds(groups, rootedIds, retiredSnapshotIds, nowMs, orphanWindowMs)) {
-    rootedIds.add(id);
-  }
+  // §3.4: EITHER condition defers the WHOLE identity to exactly today's
+  // (pre-D18) algorithm — no retired/orphan reclamation at all this run.
+  const deferred = legacyHelperDeferred || unresolvedNullIdentityCount > 0;
 
-  const liveSet = await markLiveBackupObjects(identity, rootedIds);
-  if (liveSet === null) {
-    throw new Error('mark phase failed — see prior log line for the specific snapshot/manifest');
-  }
-
-  const skipSet = await loadGcFailedKeySkipSet(identity.key);
   const graceThreshold = nowMs - graceMs;
   const manifestlessThreshold = nowMs - manifestlessWindowMs;
-
+  const skipSet = await loadGcFailedKeySkipSet(identity.key);
   let deleted = 0;
-  const retiredSwept: string[] = [];
   let orphansSwept = 0;
   let remaining = deletesRemaining;
 
-  for (const [snapshotId, group] of groups) {
-    if (remaining <= 0) break;
+  async function sweepRootedLoose(group: BackupGcSnapshotGroup, liveSet: Set<string>): Promise<void> {
+    const candidates = group.items.filter(
+      (item) => !liveSet.has(item.key) && item.lastModified && item.lastModified.getTime() <= graceThreshold,
+    );
+    const result = await deleteCandidatesWithCap(identity, candidates, remaining, skipSet);
+    deleted += result.deletedKeys.length;
+    remaining -= result.attempted;
+    if (result.failedKeys.length > 0) await recordGcFailedKeys(identity.key, result.failedKeys); // review: fed from EVERY branch now
+  }
 
-    if (rootedIds.has(snapshotId)) {
-      // Rooted prefix: unchanged per-object 48h grace rule.
-      const candidates = group.items.filter(
-        (item) => !liveSet.has(item.key) && item.lastModified && item.lastModified.getTime() <= graceThreshold,
-      );
-      const { deletedKeys } = await deleteCandidatesWithCap(identity, candidates, remaining, skipSet);
-      deleted += deletedKeys.length;
-      remaining -= deletedKeys.length;
-      continue;
+  async function sweepManifestless(group: BackupGcSnapshotGroup, liveSet: Set<string>): Promise<void> {
+    let newestMs: number | null = null;
+    let hasUnknownAge = false;
+    for (const item of group.items) {
+      if (!item.lastModified) { hasUnknownAge = true; break; }
+      const ms = item.lastModified.getTime();
+      if (newestMs === null || ms > newestMs) newestMs = ms;
     }
+    if (hasUnknownAge || newestMs === null || newestMs > manifestlessThreshold) return;
+    const candidates = group.items.filter((item) => !liveSet.has(item.key));
+    const result = await deleteCandidatesWithCap(identity, candidates, remaining, skipSet);
+    deleted += result.deletedKeys.length;
+    remaining -= result.attempted;
+    if (result.failedKeys.length > 0) await recordGcFailedKeys(identity.key, result.failedKeys);
+  }
 
-    if (!group.manifestItem) {
-      // Manifest-less (partial/resumable) prefix — unchanged prefix-granularity
-      // protection for the agent's journal lifetime, regardless of either gate
-      // (this rule predates and is independent of §3.4's new unrooted-prefix
-      // reclamation).
-      let newestMs: number | null = null;
-      let hasUnknownAge = false;
-      for (const item of group.items) {
-        if (!item.lastModified) { hasUnknownAge = true; break; }
-        const ms = item.lastModified.getTime();
-        if (newestMs === null || ms > newestMs) newestMs = ms;
-      }
-      if (hasUnknownAge || newestMs === null || newestMs > manifestlessThreshold) continue;
-      const candidates = group.items.filter((item) => !liveSet.has(item.key));
-      const { deletedKeys } = await deleteCandidatesWithCap(identity, candidates, remaining, skipSet);
-      deleted += deletedKeys.length;
-      remaining -= deletedKeys.length;
-      continue;
-    }
-
-    // Manifest-bearing, not rooted -> must be retired or an old orphan (an
-    // orphan younger than the window, or a resolved self-heal id, would
-    // already be in rootedIds above).
-    if (runRootedOnly) continue; // capability gate OR unresolved-rows gate: leave unrooted prefixes alone this run
-
-    const isRetired = retiredSnapshotIds.has(snapshotId);
-    const isOldOrphan = !isRetired && manifestOlderThanWindow(group.manifestItem, nowMs, orphanWindowMs);
-    if (!isRetired && !isOldOrphan) continue; // defensive; should be unreachable given rootedIds above
-
-    const manifestKey = group.manifestItem.key;
-    const nonLiveItems = group.items.filter((item) => !liveSet.has(item.key));
-    const nonManifestNonLive = nonLiveItems.filter((item) => item.key !== manifestKey);
-
+  // Retired (any age) OR old-orphan two-phase reclaim. Handles a
+  // "manifest-less retired remnant" too (manifest already gone from a prior
+  // run) — in that case there is no manifest-gating to do, just delete
+  // everything non-live in one phase. Never sets swept_at itself.
+  async function reclaimUnrooted(group: BackupGcSnapshotGroup, liveSet: Set<string>): Promise<void> {
+    const manifestKey = group.manifestItem?.key;
+    const nonManifestNonLive = group.items.filter((item) => !liveSet.has(item.key) && item.key !== manifestKey);
     const nonManifestResult = await deleteCandidatesWithCap(identity, nonManifestNonLive, remaining, skipSet);
     deleted += nonManifestResult.deletedKeys.length;
-    remaining -= nonManifestResult.deletedKeys.length;
-    if (nonManifestResult.failedKeys.length > 0) {
-      await recordGcFailedKeys(identity.key, nonManifestResult.failedKeys);
-    }
+    remaining -= nonManifestResult.attempted;
+    if (nonManifestResult.failedKeys.length > 0) await recordGcFailedKeys(identity.key, nonManifestResult.failedKeys);
 
-    // v3 manifest-last rule: NOT "zero failedKeys" — the manifest is a
-    // candidate only when NO deletable non-manifest key remains at all,
-    // whatever the reason (failed, cap-truncated, or skip-set-excluded).
-    const remainingNonManifest = nonManifestNonLive.filter(
-      (item) => !nonManifestResult.deletedKeys.includes(item.key),
-    );
+    if (!group.manifestItem) return; // manifest-less remnant — nothing further to gate
 
-    let manifestDeletedThisRun = false;
-    const manifestIsCandidate = remainingNonManifest.length === 0 && !liveSet.has(manifestKey) && remaining > 0;
-    if (manifestIsCandidate) {
+    // v3 manifest-last rule: candidate only when NO deletable non-manifest
+    // key remains — none failed, none capped, none skip-set-excluded.
+    const remainingNonManifest = nonManifestNonLive.filter((item) => !nonManifestResult.deletedKeys.includes(item.key));
+    if (remainingNonManifest.length === 0 && !liveSet.has(manifestKey!) && remaining > 0) {
       const manifestResult = await deleteCandidatesWithCap(identity, [group.manifestItem], remaining, skipSet);
       deleted += manifestResult.deletedKeys.length;
-      remaining -= manifestResult.deletedKeys.length;
-      manifestDeletedThisRun = manifestResult.deletedKeys.length > 0;
-      if (manifestResult.failedKeys.length > 0) {
-        await recordGcFailedKeys(identity.key, manifestResult.failedKeys);
-      }
-    }
-
-    const deletedThisPass = new Set([...nonManifestResult.deletedKeys, ...(manifestDeletedThisRun ? [manifestKey] : [])]);
-    const stillPresent = nonLiveItems.filter((item) => !deletedThisPass.has(item.key));
-    const prefixEmpty = stillPresent.length === 0;
-
-    if (isRetired && prefixEmpty) {
-      retiredSwept.push(retiredSnapshotIds.get(snapshotId)!);
-    } else if (!isRetired && isOldOrphan && prefixEmpty) {
-      orphansSwept++;
+      remaining -= manifestResult.attempted;
+      if (manifestResult.failedKeys.length > 0) await recordGcFailedKeys(identity.key, manifestResult.failedKeys);
     }
   }
 
-  return { deleted, retiredSwept, orphansSwept, selfHealSnapshotIds, unresolvedNullIdentityCount, deletesUsed: deletesRemaining - remaining };
+  if (deferred) {
+    // §3.4 amendment: exactly today's algorithm. EVERY listed manifest is a
+    // root, not just DB-rooted ids.
+    const everyListedManifestIds: string[] = [];
+    for (const [snapshotId, group] of groups) if (group.manifestItem) everyListedManifestIds.push(snapshotId);
+    const rootsForMark = new Set([...alwaysRootedIds, ...everyListedManifestIds]);
+    const liveSet = await markLiveBackupObjects(identity, rootsForMark);
+    if (liveSet === null) throw new Error('mark phase failed — see prior log line for the specific snapshot/manifest');
+
+    for (const [, group] of groups) {
+      if (remaining <= 0) break;
+      if (group.manifestItem) await sweepRootedLoose(group, liveSet);
+      else await sweepManifestless(group, liveSet);
+    }
+  } else {
+    const orphanIds = orphanManifestSnapshotIds(groups, alwaysRootedIds, retiredSnapshotIds, nowMs, orphanWindowMs);
+    const rootsForMark = new Set([...alwaysRootedIds, ...orphanIds]);
+    const liveSet = await markLiveBackupObjects(identity, rootsForMark);
+    if (liveSet === null) throw new Error('mark phase failed — see prior log line for the specific snapshot/manifest');
+
+    for (const [snapshotId, group] of groups) {
+      if (remaining <= 0) break;
+      if (rootsForMark.has(snapshotId)) { await sweepRootedLoose(group, liveSet); continue; }
+      if (retiredSnapshotIds.has(snapshotId)) { await reclaimUnrooted(group, liveSet); continue; }
+      if (!group.manifestItem) { await sweepManifestless(group, liveSet); continue; }
+      if (!manifestOlderThanWindow(group.manifestItem, nowMs, orphanWindowMs)) continue; // defensive; unreachable given rootsForMark
+      const before = deleted;
+      await reclaimUnrooted(group, liveSet);
+      if (deleted > before) orphansSwept++; // best-effort metric — see accepted approximation
+    }
+  }
+
+  // swept_at confirmation — independent of `deferred`, and independent of
+  // whatever this run deleted: a retirement is confirmed gone ONLY when
+  // THIS run's fresh listing has NO group at all for its snapshotId.
+  const retiredSweptIds: string[] = [];
+  for (const [snapshotId, retirementId] of retiredSnapshotIds) {
+    if (!groups.has(snapshotId)) retiredSweptIds.push(retirementId);
+  }
+
+  return { deleted, retiredSweptIds, orphansSwept, selfHealRowIds, unresolvedNullIdentityCount, deletesUsed: deletesRemaining - remaining };
 }
 
-/**
- * §3.4 capability gate: unrooted-prefix reclamation (retired + old-orphan
- * deletion) on an identity is enabled only when every device with a
- * `backup_jobs` row on this identity that is `pending`/`running` (ANY age —
- * a helper upgrade kills any run in progress, so the CURRENT version attests
- * the running helper) OR created in the last 30 days reports a helper >=
- * BACKUP_SERVER_BASE_MIN_HELPER_VERSION. A job is "on this identity" via its
- * own `storageIdentity` column (stamped at dispatch) when present, or by
- * `configId` membership for legacy jobs that predate that column.
- */
 async function identityHasLegacyHelper(
   identity: { key: string; configIds: string[] },
   nowMs: number,
@@ -1203,7 +1359,7 @@ async function loadIdentityGcState(
   nowMs: number,
 ): Promise<{
   retainedSnapshotIds: string[];
-  nullIdentitySnapshotIds: string[];
+  nullIdentityRows: { id: string; snapshotId: string }[];
   retiredSnapshotIds: Map<string, string>;
   legacyHelper: { deferred: boolean; deviceId?: string; version?: string | null };
 }> {
@@ -1213,8 +1369,12 @@ async function loadIdentityGcState(
       .from(backupSnapshots)
       .where(eq(backupSnapshots.storageIdentity, identity.key));
 
+    // P1 fix: fetch the primary key `id`, not just `snapshotId` — snapshot_id
+    // is NOT unique across identities (schema/backup.ts:330's index is a
+    // plain, non-unique index), so the self-heal write-back below must never
+    // match on snapshot_id alone.
     const nullIdentityRows = await db
-      .select({ snapshotId: backupSnapshots.snapshotId })
+      .select({ id: backupSnapshots.id, snapshotId: backupSnapshots.snapshotId })
       .from(backupSnapshots)
       .where(and(isNull(backupSnapshots.storageIdentity), inArray(backupSnapshots.configId, identity.configIds)));
 
@@ -1227,7 +1387,7 @@ async function loadIdentityGcState(
 
     return {
       retainedSnapshotIds: retainedRows.map((r) => r.snapshotId),
-      nullIdentitySnapshotIds: nullIdentityRows.map((r) => r.snapshotId),
+      nullIdentityRows,
       retiredSnapshotIds: new Map(retirementRows.map((r) => [r.snapshotId, r.id])),
       legacyHelper,
     };
@@ -1237,18 +1397,22 @@ async function loadIdentityGcState(
 /** Per-identity DB writes applied in ONE short system context, per §3.7 — always AFTER every storage call for this identity has already returned. */
 async function applyIdentityGcWriteBacks(
   identity: { key: string },
-  writeBacks: { retiredSwept: string[]; selfHealSnapshotIds: string[] },
+  writeBacks: { retiredSweptIds: string[]; selfHealRowIds: string[] },
 ): Promise<void> {
-  if (writeBacks.retiredSwept.length === 0 && writeBacks.selfHealSnapshotIds.length === 0) return;
+  if (writeBacks.retiredSweptIds.length === 0 && writeBacks.selfHealRowIds.length === 0) return;
   await withSystemDbAccessContext(async () => {
-    for (const retirementId of writeBacks.retiredSwept) {
+    for (const retirementId of writeBacks.retiredSweptIds) {
       await db.update(backupSnapshotRetirements).set({ sweptAt: new Date() }).where(eq(backupSnapshotRetirements.id, retirementId));
     }
-    if (writeBacks.selfHealSnapshotIds.length > 0) {
+    if (writeBacks.selfHealRowIds.length > 0) {
+      // P1 fix: heal by PRIMARY ROW ID, guarded by storage_identity IS NULL —
+      // matching on snapshot_id alone could re-stamp a DIFFERENT identity's
+      // row sharing the same agent-generated snapshot id; the IS NULL guard
+      // also protects against re-stamping a row a concurrent run just healed.
       await db
         .update(backupSnapshots)
         .set({ storageIdentity: identity.key })
-        .where(inArray(backupSnapshots.snapshotId, writeBacks.selfHealSnapshotIds));
+        .where(and(inArray(backupSnapshots.id, writeBacks.selfHealRowIds), isNull(backupSnapshots.storageIdentity)));
     }
   });
 }
@@ -1260,23 +1424,10 @@ async function pruneSweptRetirements(nowMs: number): Promise<void> {
       .delete(backupSnapshotRetirements)
       .where(and(isNotNull(backupSnapshotRetirements.sweptAt), lt(backupSnapshotRetirements.sweptAt, cutoff)))
       .returning({ id: backupSnapshotRetirements.id });
-    if (deleted.length > 0) {
-      console.log(`[BackupGC] Pruned ${deleted.length} swept retirement row(s) older than 30 days`);
-    }
+    if (deleted.length > 0) console.log(`[BackupGC] Pruned ${deleted.length} swept retirement row(s) older than 30 days`);
   });
 }
 
-/**
- * §3.7: this is the top-level entry the worker calls, and it must NEVER be
- * invoked from inside another DB transaction. W01 owns keeping the
- * `cleanup-expired-snapshots` case out of the worker's blanket
- * `runWithSystemDbAccess` wrap (consumed interface — see "Depends on"); this
- * function's job is only to honor that assumption internally: every DB
- * read/write happens in its own short `withSystemDbAccessContext` call, and
- * every storage call (inside `sweepStorageIdentity`, which asserts
- * `assertOutsideHeldDbContext` at its own top as a tripwire) runs at depth 0,
- * between those contexts, never nested inside one.
- */
 export async function sweepUnreferencedBackupObjects(): Promise<BackupGcResult> {
   const nowMs = Date.now();
   const graceMs = resolveBackupGcGraceMs();
@@ -1304,7 +1455,6 @@ export async function sweepUnreferencedBackupObjects(): Promise<BackupGcResult> 
       `resume on its next run.`;
     console.error(wedgeMessage);
     captureException(new Error(wedgeMessage));
-    console.log(`[BackupGC] Run complete: deleted 0 object(s), ${identities.size} identity/identities skipped`);
     return {
       deleted: 0, skippedIdentities: identities.size, blockedIdentities: 0,
       retiredSwept: 0, orphansSwept: 0, deferredIdentities: 0, unreachableIdentities,
@@ -1319,93 +1469,71 @@ export async function sweepUnreferencedBackupObjects(): Promise<BackupGcResult> 
     ));
   }
 
-  let deleted = 0;
-  let skippedIdentities = 0;
-  let blockedIdentities = 0;
-  let retiredSwept = 0;
-  let orphansSwept = 0;
-  let deferredIdentities = 0;
+  let deleted = 0, skippedIdentities = 0, blockedIdentities = 0, retiredSwept = 0, orphansSwept = 0, deferredIdentities = 0;
   let deletesRemaining = resolveBackupGcMaxDeletesPerRun();
 
   for (const identity of identities.values()) {
-    if (deletesRemaining <= 0) {
-      console.log('[BackupGC] Deletion cap reached for this run — stopping cleanly; remaining identities resume next run');
-      break;
-    }
+    if (deletesRemaining <= 0) { console.log('[BackupGC] Deletion cap reached — stopping cleanly'); break; }
     if (suspiciousIdentityKeys.has(identity.key)) { skippedIdentities++; continue; }
     if (!BACKUP_GC_SUPPORTED_PROVIDERS.has(identity.provider)) {
       skippedIdentities++;
-      console.warn(`[BackupGC] Identity ${identity.key}: provider '${identity.provider}' has no GC listing support — skipping (fail-closed)`);
+      console.warn(`[BackupGC] Identity ${identity.key}: provider '${identity.provider}' has no GC listing support — skipping`);
       continue;
     }
 
     try {
-      // Phase: short DB context, reads only.
       const state = await loadIdentityGcState(identity, nowMs);
       if (state.legacyHelper.deferred) {
         deferredIdentities++;
         console.warn(`[BackupGC] reclamation deferred: legacy helper ${state.legacyHelper.deviceId} ${state.legacyHelper.version}`);
       }
 
-      // Phase: no DB context, storage calls only (depth 0). The
-      // unresolved-NULL-rows gate is computed INSIDE sweepStorageIdentity
-      // (it needs the listing to know which NULL rows resolve — see that
-      // function's comment), combined there with the capability gate via OR;
-      // `restrictToRootedOnly` here carries only the capability-gate half.
       const identityResult = await sweepStorageIdentity(
-        identity, state.retainedSnapshotIds, state.nullIdentitySnapshotIds, state.retiredSnapshotIds,
+        identity, state.retainedSnapshotIds, state.nullIdentityRows, state.retiredSnapshotIds,
         nowMs, deletesRemaining, graceMs, orphanWindowMs, manifestlessWindowMs,
         state.legacyHelper.deferred,
       );
 
       if (identityResult.unresolvedNullIdentityCount > 0) {
         console.warn(`[BackupGC] identity deferred: ${identityResult.unresolvedNullIdentityCount} unresolved rows`);
-        if (!state.legacyHelper.deferred) deferredIdentities++; // avoid double-counting if both gates fired
+        if (!state.legacyHelper.deferred) deferredIdentities++; // avoid double-counting one identity for both reasons
       }
 
       deleted += identityResult.deleted;
-      retiredSwept += identityResult.retiredSwept.length;
+      retiredSwept += identityResult.retiredSweptIds.length;
       orphansSwept += identityResult.orphansSwept;
       deletesRemaining -= identityResult.deletesUsed;
 
-      // Phase: short DB context, writes only — always after every storage
-      // call for this identity above has already completed.
       await applyIdentityGcWriteBacks(identity, {
-        retiredSwept: identityResult.retiredSwept,
-        selfHealSnapshotIds: identityResult.selfHealSnapshotIds,
+        retiredSweptIds: identityResult.retiredSweptIds,
+        selfHealRowIds: identityResult.selfHealRowIds,
       });
 
-      if (identityResult.deleted > 0) {
-        console.log(`[BackupGC] Identity ${identity.key}: deleted ${identityResult.deleted} unreferenced object(s)`);
-      } else {
-        console.debug(`[BackupGC] Identity ${identity.key}: 0 objects deleted`);
-      }
+      if (identityResult.deleted > 0) console.log(`[BackupGC] Identity ${identity.key}: deleted ${identityResult.deleted} object(s)`);
     } catch (error) {
-      skippedIdentities++;
-      blockedIdentities++;
+      skippedIdentities++; blockedIdentities++;
       console.error(`[BackupGC] Identity ${identity.key}: sweep failed — isolated, other identities proceed:`, error);
       captureException(error instanceof Error ? error : new Error(String(error)));
     }
   }
 
   console.log(
-    `[BackupGC] Run complete: deleted ${deleted} object(s), ${retiredSwept} retirement(s) fully swept, ` +
-    `${orphansSwept} orphan(s) swept, ${identities.size - skippedIdentities} identity/identities processed, ` +
-    `${skippedIdentities} skipped, ${deferredIdentities} deferred (legacy helper), ${unreachableIdentities} unreachable` +
-    (blockedIdentities > 0 ? ` (${blockedIdentities} blocked by unfetchable manifest — fail-closed)` : ''),
+    `[BackupGC] Run complete: deleted ${deleted} object(s), ${retiredSwept} retirement(s) confirmed swept, ` +
+    `${orphansSwept} orphan(s) swept, ${skippedIdentities} identity/identities skipped, ${deferredIdentities} deferred, ` +
+    `${unreachableIdentities} unreachable` + (blockedIdentities > 0 ? ` (${blockedIdentities} blocked)` : ''),
   );
 
   return { deleted, skippedIdentities, blockedIdentities, retiredSwept, orphansSwept, deferredIdentities, unreachableIdentities };
 }
 ```
 
-  Note the ordering that makes this correct: `unresolvedNullIdentityCount` is computed and applied **inside** `sweepStorageIdentity` itself (combined with the capability gate via OR, right after the self-heal filter and before the main per-group loop — see that function above), not by the caller after the fact. Computing it in the caller instead would be a chicken-and-egg bug: "unresolved" can only be known once the listing exists, but by the time the caller sees the result the sweep would already have run — so `sweepUnreferencedBackupObjects` above only *reads* `identityResult.unresolvedNullIdentityCount` to log and count `deferredIdentities`, it never uses it to decide whether to sweep.
+  Add to the top imports: `backupSnapshotRetirements`, `devices` to the `../db/schema` import list; `gte`, `isNotNull` to the `drizzle-orm` import list; `withSystemDbAccessContext`, `assertOutsideHeldDbContext` from `../db`; `resolveBackupOrphanManifestMaxAgeMs`, `resolveBackupBaseLeaseMs` from `../services/backupGcKnobs`; `backupHelperSupportsServerBase` from `../services/backupHelperCapabilities`.
 
-  Add to the top imports: `backupSnapshotRetirements`, `devices` to the `../db/schema` import list; `gte`, `isNotNull` to the `drizzle-orm` import list; `withSystemDbAccessContext`, `assertOutsideHeldDbContext` from `../db` (verify both export names against `apps/api/src/db/index.ts` — confirmed present as `export async function withSystemDbAccessContext` at `:610` and `export function assertOutsideHeldDbContext` at `:989` in the pre-W01 file; re-check after W01 lands in case it moves either); `resolveBackupOrphanManifestMaxAgeMs`, `resolveBackupBaseLeaseMs` from `../services/backupGcKnobs`; `backupHelperSupportsServerBase` from `../services/backupHelperCapabilities`.
+  **Honesty note for the implementer:** the exact `selectQueue` push sequence in every test above was hand-derived against the finalized query order, not verified by actually running vitest — given how many tasks compound this file's mock ordering, treat a mismatch as expected friction, not a sign the design is wrong. Run the suite, read the first failure's actual vs. expected call, and fix the test's push order (never the source) unless the source itself is what's wrong per this task's stated algorithm.
 
-- [ ] Step 4: Run, expect PASS (this is the point every test from Tasks 3, 5, 6 and this task's own tests should all go green together — fix up the `selectQueue` push counts in Tasks 3/5/6's tests per this task's header note first if they fail on an unexpected-shape mismatch): `cd apps/api && npx vitest run src/jobs/backupRetention.test.ts`
+- [ ] Step 4: Run, expect PASS (fix up `selectQueue` push counts per the note above as needed): `cd apps/api && npx vitest run src/jobs/backupRetention.test.ts`
 
-- [ ] Step 5: Commit: `git add apps/api/src/jobs/backupRetention.ts apps/api/src/jobs/backupRetention.test.ts && git commit -m "feat(backup-gc): retirement-aware two-phase sweep, NULL-identity self-heal, capability gate (D18 §3.4/§3.6)"`
+- [ ] Step 5: Commit: `git add apps/api/src/jobs/backupRetention.ts apps/api/src/jobs/backupRetention.test.ts && git commit -m "feat(backup-gc): NULL rows always roots, deferral runs today's algorithm, cap/skip-set/swept_at correctness (D18 §3.4/§3.6 v3)"`
 
 ### Task 8: `backupWorker.ts` — log the four new result fields (no worker restructuring — W01 owns that)
 
@@ -1492,9 +1620,57 @@ export async function processCleanupExpiredSnapshots(): Promise<{
 
 - [ ] Step 4: Run, expect PASS: `cd apps/api && npx vitest run src/jobs/backupWorker.test.ts`
 
-- [ ] Step 5: Commit: `git add apps/api/src/jobs/backupWorker.ts apps/api/src/jobs/backupWorker.test.ts && git commit -m "feat(backup-gc): surface retirement/orphan/deferred/unreachable counts from the worker"`
+- [ ] Step 4b: Add the depth-0 regression to the existing real-depth harness — `apps/api/src/jobs/backupWorker.dbcontext.test.ts` (review item: "the depth harness is `backupWorker.dbcontext.test.ts`"). This file already mocks `../db`'s `withSystemDbAccessContext` with REAL enter/exit depth tracking (`ctxState`, see its header comment) and already stubs `./backupRetention`'s `cleanupExpiredSnapshots`/`sweepUnreferencedBackupObjects` as plain `vi.fn()`s — replace those two stubs with implementations that record `ctxState.depth` when called, and add a describe block exercising `processCleanupExpiredSnapshots` (already exported, unchanged by this task's Step 3 beyond its return shape) directly:
 
-### Task 9: Integration test — real DB + real local filesystem, spec §6 scenarios (1)-(5) + self-heal scenario (6)
+```typescript
+// Replace the existing blanket stub:
+//   vi.mock('./backupRetention', () => ({
+//     cleanupExpiredSnapshots: vi.fn(),
+//     sweepUnreferencedBackupObjects: vi.fn(),
+//   }));
+// with recording versions so this file's real ctxState can prove WHERE each
+// call happens, mirroring how it already does this for dispatchCommandToAgent.
+const cleanupExpiredSnapshotsMock = vi.fn(async () => {
+  ctxState.events.push(`cleanupExpiredSnapshots@depth${ctxState.depth}`);
+  return { deleted: 0, skippedLegalHold: 0, skippedImmutable: 0, prunedByMaxVersions: 0, failed: 0 };
+});
+const sweepUnreferencedBackupObjectsMock = vi.fn(async () => {
+  ctxState.events.push(`sweepUnreferencedBackupObjects@depth${ctxState.depth}`);
+  return {
+    deleted: 0, skippedIdentities: 0, blockedIdentities: 0,
+    retiredSwept: 0, orphansSwept: 0, deferredIdentities: 0, unreachableIdentities: 0,
+  };
+});
+vi.mock('./backupRetention', () => ({
+  cleanupExpiredSnapshots: cleanupExpiredSnapshotsMock,
+  sweepUnreferencedBackupObjects: sweepUnreferencedBackupObjectsMock,
+}));
+
+describe('processCleanupExpiredSnapshots DB-context scoping (D18 §3.7)', () => {
+  beforeEach(() => {
+    ctxState.depth = 0;
+    ctxState.events = [];
+    mockDb.select.mockReturnValue({
+      from: () => ({ then: (resolve: (v: unknown[]) => unknown) => Promise.resolve([]).then(resolve) }),
+    });
+  });
+
+  it('calls sweepUnreferencedBackupObjects at depth 0 — never nested inside a held DB context', async () => {
+    const { processCleanupExpiredSnapshots } = await import('./backupWorker');
+    await processCleanupExpiredSnapshots();
+
+    expect(sweepUnreferencedBackupObjectsMock).toHaveBeenCalledTimes(1);
+    const sweepEvent = ctxState.events.find((e) => e.startsWith('sweepUnreferencedBackupObjects@'));
+    expect(sweepEvent).toBe('sweepUnreferencedBackupObjects@depth0');
+  });
+});
+```
+
+  Note this test exercises `processCleanupExpiredSnapshots` directly — it does NOT invoke it through `createBackupWorker`'s job-dispatch switch (that carve-out is W01's to author and test; this file's existing `mockDb.select.mockReturnValue(...)` for the org-loop query may need adjusting to match whatever shape W01's actual per-org retention loop takes — treat the exact mock as illustrative and adapt to W01's real `processCleanupExpiredSnapshots` internals once merged, the way this task's Step 1/3 already do for the same reason).
+
+- [ ] Step 5: Commit: `git add apps/api/src/jobs/backupWorker.ts apps/api/src/jobs/backupWorker.test.ts apps/api/src/jobs/backupWorker.dbcontext.test.ts && git commit -m "feat(backup-gc): surface retirement/orphan/deferred/unreachable counts from the worker; assert depth-0 invocation"`
+
+### Task 9: Integration test — real DB + real local filesystem, spec §6 scenarios (1)-(5) + self-heal scenarios (6a/6b)
 
 **Files:** Create `apps/api/src/__tests__/integration/backupGcReclamation.integration.test.ts`.
 
@@ -1502,15 +1678,19 @@ export async function processCleanupExpiredSnapshots(): Promise<{
 - Consumes: `withSystemDbAccessContext`, `db` from `../../db`; `partners, organizations, sites, devices, backupConfigs, backupJobs, backupSnapshots, backupSnapshotRetirements` from `../../db/schema`; `sweepUnreferencedBackupObjects` from `../../jobs/backupRetention`.
 - Runs against: `providerConfig.path` pointing at `fs.mkdtempSync` temp dirs (provider `'local'`), real files written and aged via `fs.promises.utimes`.
 
+**Test database (P2 review — do not point this at the dev DB).** This suite runs against the **dedicated integration test database**, never `postgresql://breeze:breeze@localhost:5432/breeze` (that's the dev/wt-stack DB). `apps/api/src/__tests__/integration/setup.ts` (imported via `import './setup'`, same as `staleBackupReaper.integration.test.ts`) already resolves `DATABASE_URL`/`DATABASE_URL_APP` from `.env.test` (defaults: `postgresql://breeze_test:breeze_test@localhost:5433/breeze_test` — port **5433**, not 5432 — and the `breeze_app`-equivalent role) and calls `assertTestDatabaseUrlSafe` (`apps/api/src/testUtils/integrationDatabaseSafety.ts`) before opening any pool, which hard-refuses a non-`breeze_test(_*)`-named database, a non-allowlisted host, or the default port 5432. **Never pass an explicit `DATABASE_URL=...` override on the command line for this suite** — let `setup.ts` resolve it from `.env.test`, and stand up the test containers first with `pnpm test-stack up` (repo root) if they aren't already running, matching `setup.ts`'s own docstring.
+
+**Out of scope for this file (say so explicitly, per review) — these are W01's suite, not this wave's:** lease expiry / renewal (`base_lease_expires_at`/`publish_lease_expires_at`), the restore-pin linger window, and the concurrent-dispatch-vs-retention row-lock race. This wave's "pinned" scenario below only proves that a still-RETAINED row (one retention hasn't deleted — because W01's pin check blocked it, which is W01's own concern) is protected by the sweep like any other rooted row; it does not exercise or assert anything about how or when a row becomes pinned.
+
 - [ ] Step 1: Write the failing test (this whole file is new — "failing" means it doesn't exist / fails to compile until Task 7 is fully landed):
 
 ```typescript
 import './setup';
 
-import { mkdtemp, mkdir, writeFile, utimes, readdir } from 'node:fs/promises';
+import { mkdtemp, mkdir, writeFile, utimes, readdir, chmod } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { expect, it } from 'vitest';
+import { afterEach, expect, it } from 'vitest';
 import { eq } from 'drizzle-orm';
 import { db, withSystemDbAccessContext } from '../../db';
 import {
@@ -1551,7 +1731,7 @@ async function listAll(root: string, prefix = ''): Promise<string[]> {
   return out;
 }
 
-async function seedOrgDeviceConfig(unique: string, rootPath: string) {
+async function seedOrgDeviceConfig(unique: string, rootPath: string, backupVersion = '0.112.0') {
   const [partner] = await db.insert(partners).values({
     name: `GC Partner ${unique}`, slug: `gc-partner-${unique}`, type: 'msp', plan: 'pro', status: 'active',
   }).returning({ id: partners.id });
@@ -1562,7 +1742,7 @@ async function seedOrgDeviceConfig(unique: string, rootPath: string) {
   const [device] = await db.insert(devices).values({
     orgId: org!.id, siteId: site!.id, agentId: `gc-agent-${unique}`, hostname: `gc-host-${unique}`,
     osType: 'linux', osVersion: '1', architecture: 'x86_64', agentVersion: '0.0.0-test',
-    backupVersion: '0.112.0', status: 'online',
+    backupVersion, status: 'online',
   }).returning({ id: devices.id });
   const [config] = await db.insert(backupConfigs).values({
     orgId: org!.id, name: `GC Config ${unique}`, type: 'file', provider: 'local', providerConfig: { path: rootPath },
@@ -1572,7 +1752,8 @@ async function seedOrgDeviceConfig(unique: string, rootPath: string) {
 }
 
 async function insertSnapshotRow(params: {
-  orgId: string; deviceId: string; configId: string; snapshotId: string; identity: string; expiresAt?: Date | null;
+  orgId: string; deviceId: string; configId: string; snapshotId: string; identity: string;
+  expiresAt?: Date | null; backupType?: 'file' | 'system_image' | 'hyperv' | 'mssql';
 }) {
   const [job] = await db.insert(backupJobs).values({
     orgId: params.orgId, configId: params.configId, deviceId: params.deviceId, status: 'completed', snapshotId: params.snapshotId,
@@ -1580,26 +1761,32 @@ async function insertSnapshotRow(params: {
   await db.insert(backupSnapshots).values({
     orgId: params.orgId, jobId: job!.id, deviceId: params.deviceId, configId: params.configId,
     snapshotId: params.snapshotId, storageIdentity: params.identity, expiresAt: params.expiresAt ?? null,
+    backupType: params.backupType ?? 'file',
   });
 }
 
-runDb('scenario 1: expiring a base with an incremental child reclaims the base-exclusive object but keeps every backupPath the incremental references', async () => {
+runDb('scenario 1: expiring a base with an incremental child reclaims ONLY the base-exclusive object, keeping every shared backupPath the incremental references', async () => {
   const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   const root = await mkdtemp(join(tmpdir(), 'breeze-gc-'));
 
-  const ctx = await withSystemDbAccessContext(async () => {
+  const seed = await withSystemDbAccessContext(async () => {
     const seed = await seedOrgDeviceConfig(unique, root);
 
-    // Base B: exclusive object X, still has a live row (not yet expired) so its
-    // own manifest survives; the row is deleted directly here to simulate
-    // retention already having run and written the retirement (W01's job —
-    // this test inserts the retirement row directly rather than re-driving
-    // cleanupExpiredSnapshots, which is out of this wave's scope).
-    await writeAged(root, 'snapshots/B/manifest.json', 1000, JSON.stringify({ files: [{ backupPath: 'snapshots/B/files/x.dat' }] }));
-    await writeAged(root, 'snapshots/B/files/x.dat', 1000); // B-exclusive
-    // Incremental C references B's object X plus its own file.
+    // Base B has an object exclusively its own (only-in-b.dat) AND a
+    // separately-tracked shared object (shared.dat) that C's manifest ALSO
+    // references. Retiring B must reclaim only-in-b.dat and B's manifest,
+    // never shared.dat — the previous draft of this scenario wrongly listed
+    // shared.dat as B's own exclusive object while ALSO having C reference
+    // it, then asserted it gone (a real data-loss bug in the TEST, not the
+    // implementation — fixed here per review).
+    await writeAged(root, 'snapshots/B/manifest.json', 1000, JSON.stringify({ files: [
+      { backupPath: 'snapshots/B/files/only-in-b.dat' },
+      { backupPath: 'snapshots/B/files/shared.dat' },
+    ] }));
+    await writeAged(root, 'snapshots/B/files/only-in-b.dat', 1000); // B-exclusive — must be deleted
+    await writeAged(root, 'snapshots/B/files/shared.dat', 1000); // referenced by C too — must survive
     await writeAged(root, 'snapshots/C/manifest.json', 1000, JSON.stringify({ files: [
-      { backupPath: 'snapshots/B/files/x.dat' },
+      { backupPath: 'snapshots/B/files/shared.dat' },
       { backupPath: 'snapshots/C/files/c.dat' },
     ] }));
     await writeAged(root, 'snapshots/C/files/c.dat', 1000);
@@ -1609,47 +1796,62 @@ runDb('scenario 1: expiring a base with an incremental child reclaims the base-e
       orgId: seed.orgId, configId: seed.configId, deviceId: seed.deviceId,
       snapshotId: 'B', storageIdentity: seed.identity, backupType: 'file', reason: 'expired', retiredAt: new Date(),
     });
-
     return seed;
   });
 
-  await sweepUnreferencedBackupObjects(); // manages its own short per-identity DB contexts internally (§3.7) — no outer wrap needed
+  await sweepUnreferencedBackupObjects();
 
-  const remaining = await listAll(root);
-  // B's manifest and exclusive object are gone; C's manifest, C's own file, and
-  // the SHARED object (still referenced by C's manifest) all survive.
-  expect(remaining.sort()).toEqual(['snapshots/C/files/c.dat', 'snapshots/C/manifest.json'].sort());
+  const afterFirstRun = await listAll(root);
+  expect(afterFirstRun).not.toContain('snapshots/B/files/only-in-b.dat');
+  expect(afterFirstRun).toContain('snapshots/B/files/shared.dat'); // still shared with C — must survive
+  expect(afterFirstRun).toContain('snapshots/C/manifest.json');
+  expect(afterFirstRun).toContain('snapshots/C/files/c.dat');
+  // B's manifest is only removable once nothing non-manifest remains under
+  // B's prefix; shared.dat is LIVE (referenced by C), so it is never a
+  // candidate — B's prefix therefore never reaches "everything non-manifest
+  // gone", and per the v3 manifest-last rule B's manifest is retained too.
+  // (This is intentional and matches spec §5's dedup-sharing row: a bucket
+  // holding a still-referenced object is not incorrectly reclaimed.)
+  expect(afterFirstRun).toContain('snapshots/B/manifest.json');
 
+  // swept_at is NEVER set in the same pass as the deletes (P2 review) — and
+  // in this case it will never be set at all while shared.dat stays live.
   const [retirementRow] = await withSystemDbAccessContext(() =>
-    db.select().from(backupSnapshotRetirements).where(eq(backupSnapshotRetirements.storageIdentity, ctx.identity)),
+    db.select().from(backupSnapshotRetirements).where(eq(backupSnapshotRetirements.storageIdentity, seed.identity)),
   );
-  expect(retirementRow!.sweptAt).not.toBeNull();
+  expect(retirementRow!.sweptAt).toBeNull();
 });
 
-runDb('scenario 2: a pinned (in-progress) prefix is never reclaimed even if retired', async () => {
+runDb('scenario 2: a still-retained (non-expired) row is protected regardless of age — including one referenced by an in-progress base pin', async () => {
   const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   const root = await mkdtemp(join(tmpdir(), 'breeze-gc-'));
 
   await withSystemDbAccessContext(async () => {
     const seed = await seedOrgDeviceConfig(unique, root);
-    await writeAged(root, 'snapshots/PINNED/manifest.json', 1000, JSON.stringify({ files: [] }));
-    await writeAged(root, 'snapshots/PINNED/files/p.dat', 1000);
-    // No backup_snapshots row (row already deleted), but a running job still
-    // has base_snapshot_id = 'PINNED' with a live lease — simulated here by
-    // simply NOT writing a retirement row and keeping the manifest young
-    // enough to fall inside the default orphan-protection window, which is
-    // this wave's actual mechanism for "don't delete something that might
-    // still be needed" (the lease/pin itself is W01's mechanism and is
-    // exercised in W01's own suite, not here).
+    await writeAged(root, 'snapshots/PINNED/manifest.json', 30 * 24 * 60 * 60 * 1000, JSON.stringify({ files: [] })); // 30 days old
+    await writeAged(root, 'snapshots/PINNED/files/p.dat', 30 * 24 * 60 * 60 * 1000);
+    await insertSnapshotRow({ ...seed, snapshotId: 'PINNED' }); // retention has NOT deleted this row
+
+    // Realistic fixture for what W01's pin looks like on disk — an in-progress
+    // dispatch that picked PINNED as its dedupe base. Requires W01's
+    // `backup_jobs.base_snapshot_id`/`publish_lease_expires_at` columns; this
+    // integration suite is authored to run AFTER W01 merges, so they exist.
+    // This test does not exercise the LEASE mechanism itself (expiry,
+    // renewal) — that is W01's own suite; it only proves the sweep leaves a
+    // still-retained row alone regardless of how old its objects are.
+    await db.insert(backupJobs).values({
+      orgId: seed.orgId, configId: seed.configId, deviceId: seed.deviceId, status: 'running',
+      baseSnapshotId: 'PINNED', publishLeaseExpiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    });
   });
 
-  await sweepUnreferencedBackupObjects(); // manages its own short per-identity DB contexts internally (§3.7) — no outer wrap needed
+  await sweepUnreferencedBackupObjects();
 
   const remaining = await listAll(root);
   expect(remaining.sort()).toEqual(['snapshots/PINNED/files/p.dat', 'snapshots/PINNED/manifest.json'].sort());
 });
 
-runDb('scenario 3: an orphan manifest past the window with no row and no retirement is reclaimed', async () => {
+runDb('scenario 3: an orphan manifest past ORPHAN_WINDOW with no row and no retirement is reclaimed; younger than the window it is a root', async () => {
   const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   const root = await mkdtemp(join(tmpdir(), 'breeze-gc-'));
   const TEN_DAYS_MS = 10 * 24 * 60 * 60 * 1000;
@@ -1660,75 +1862,95 @@ runDb('scenario 3: an orphan manifest past the window with no row and no retirem
     await writeAged(root, 'snapshots/ABANDONED/files/a.dat', TEN_DAYS_MS);
   });
 
-  await sweepUnreferencedBackupObjects(); // manages its own short per-identity DB contexts internally (§3.7) — no outer wrap needed
-
+  await sweepUnreferencedBackupObjects();
   expect(await listAll(root)).toEqual([]);
 });
 
-runDb('scenario 4: legacy helper on the identity defers reclamation of a retired prefix', async () => {
+runDb('scenario 3b: ORPHAN_WINDOW\'s lease-derived arm (BACKUP_BASE_LEASE_MS + BACKUP_GC_GRACE_MS) protects an orphan the 9-day default alone would already have swept', async () => {
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const root = await mkdtemp(join(tmpdir(), 'breeze-gc-'));
+  const NINE_DAYS_PLUS_MS = 9 * 24 * 60 * 60 * 1000 + 60 * 60 * 1000; // just past the 9-day default arm...
+
+  await withSystemDbAccessContext(async () => {
+    await seedOrgDeviceConfig(unique, root);
+    await writeAged(root, 'snapshots/LEASEWINDOW/manifest.json', NINE_DAYS_PLUS_MS, JSON.stringify({ files: [] }));
+  });
+
+  const prevLease = process.env.BACKUP_BASE_LEASE_MS;
+  process.env.BACKUP_BASE_LEASE_MS = String(9 * 24 * 60 * 60 * 1000); // ...but a widened lease makes the OTHER arm bigger
+  try {
+    await sweepUnreferencedBackupObjects();
+    // Still protected: max(9d default, 9d lease + 48h grace) > this object's age.
+    expect(await listAll(root)).toContain('snapshots/LEASEWINDOW/manifest.json');
+  } finally {
+    if (prevLease === undefined) delete process.env.BACKUP_BASE_LEASE_MS; else process.env.BACKUP_BASE_LEASE_MS = prevLease;
+  }
+});
+
+runDb('scenario 4: a legacy helper on the identity defers to EXACTLY today\'s algorithm — the retired prefix is fully protected, not just its manifest', async () => {
   const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   const root = await mkdtemp(join(tmpdir(), 'breeze-gc-'));
 
   await withSystemDbAccessContext(async () => {
-    const seed = await seedOrgDeviceConfig(unique, root);
-    await db.update(devices).set({ backupVersion: '0.109.0' }).where(eq(devices.id, seed.deviceId));
+    const seed = await seedOrgDeviceConfig(unique, root, '0.109.0'); // pre-server-base helper
     await writeAged(root, 'snapshots/RETIREDLEGACY/manifest.json', 1000, JSON.stringify({ files: [] }));
     await writeAged(root, 'snapshots/RETIREDLEGACY/files/r.dat', 1000);
     await db.insert(backupSnapshotRetirements).values({
       orgId: seed.orgId, configId: seed.configId, deviceId: seed.deviceId,
       snapshotId: 'RETIREDLEGACY', storageIdentity: seed.identity, backupType: 'file', reason: 'expired', retiredAt: new Date(),
     });
-    // A backup_jobs row within the last 30 days on this config pins the
-    // identity's capability check to the legacy device version.
-    await db.insert(backupJobs).values({
-      orgId: seed.orgId, configId: seed.configId, deviceId: seed.deviceId, status: 'completed',
-    });
+    await db.insert(backupJobs).values({ orgId: seed.orgId, configId: seed.configId, deviceId: seed.deviceId, status: 'completed' });
   });
 
-  await sweepUnreferencedBackupObjects(); // manages its own short per-identity DB contexts internally (§3.7) — no outer wrap needed
+  await sweepUnreferencedBackupObjects();
 
   const remaining = await listAll(root);
   expect(remaining.sort()).toEqual(['snapshots/RETIREDLEGACY/files/r.dat', 'snapshots/RETIREDLEGACY/manifest.json'].sort());
 });
 
-runDb('scenario 5: an object still failing to delete blocks only the manifest for that prefix, not other prefixes', async () => {
-  // A local-provider ENOENT-on-delete is treated as success (rm force:true),
-  // so this scenario proves the two-phase gate using a genuinely undeletable
-  // path instead: a directory placed where a file key is expected causes
-  // deleteLocalObjectKeys' rm() to throw (EISDIR is NOT swallowed by force),
-  // landing in failedKeys.
+runDb('scenario 5: an undeletable object blocks only that prefix\'s manifest, not other prefixes', async () => {
+  // Local-provider delete is `rm(path, { force: true })`, which swallows
+  // ENOENT — an empty/missing FILE never fails. A DIRECTORY placed where a
+  // file key is expected also does NOT reach deletion: listLocalObjectsWithLastModified
+  // (backupSnapshotStorage.ts:213-256) RECURSES into directories, so an empty
+  // `blocked.dat/` dir simply contributes zero listed files — it's invisible
+  // to the sweep entirely, never a delete candidate (this was a fixture bug
+  // in the previous draft, per review). Induce a REAL, permanent delete
+  // failure instead: chmod the parent directory read+execute-only (0500)
+  // during the delete phase, so `unlink` inside it gets EACCES; restore
+  // permissions in `afterEach` so the temp dir can still be cleaned up.
   const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   const root = await mkdtemp(join(tmpdir(), 'breeze-gc-'));
+  const blockedDir = join(root, 'snapshots/RETIREDBLOCKED/files');
 
   await withSystemDbAccessContext(async () => {
     const seed = await seedOrgDeviceConfig(unique, root);
     await writeAged(root, 'snapshots/RETIREDBLOCKED/manifest.json', 1000, JSON.stringify({ files: [] }));
-    // Make the "file" a directory instead, so rm({force:true}) without
-    // recursive:true throws EISDIR — deleteLocalObjectKeys catches it into
-    // failedKeys rather than deleting it.
-    await mkdir(join(root, 'snapshots/RETIREDBLOCKED/files/blocked.dat'), { recursive: true });
+    await writeAged(root, 'snapshots/RETIREDBLOCKED/files/locked.dat', 1000);
     await db.insert(backupSnapshotRetirements).values({
       orgId: seed.orgId, configId: seed.configId, deviceId: seed.deviceId,
       snapshotId: 'RETIREDBLOCKED', storageIdentity: seed.identity, backupType: 'file', reason: 'expired', retiredAt: new Date(),
     });
   });
 
-  await sweepUnreferencedBackupObjects(); // manages its own short per-identity DB contexts internally (§3.7) — no outer wrap needed
+  await chmod(blockedDir, 0o500); // read+execute only — unlink() inside it fails EACCES
+  try {
+    await sweepUnreferencedBackupObjects();
+  } finally {
+    await chmod(blockedDir, 0o700); // restore before the temp-dir cleanup / next test
+  }
 
   // Manifest survives because the non-manifest phase had a failure.
   expect(await listAll(root)).toContain('snapshots/RETIREDBLOCKED/manifest.json');
 });
 
-runDb('scenario 6: a NULL storage_identity row self-heals when found, and blocks unrooted reclamation on the identity until every NULL row resolves', async () => {
+runDb('scenario 6a: a NULL-identity row whose manifest IS found resolves in this run and its identity reclaims normally (no longer deferred)', async () => {
   const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   const root = await mkdtemp(join(tmpdir(), 'breeze-gc-'));
 
-  const ctx = await withSystemDbAccessContext(async () => {
+  const seed = await withSystemDbAccessContext(async () => {
     const seed = await seedOrgDeviceConfig(unique, root);
 
-    // HEALME: a real, still-published snapshot whose storage_identity was
-    // never backfilled (simulates a row written before W01's backfill ran,
-    // or one whose config was edited after publication per §3.6).
     await writeAged(root, 'snapshots/HEALME/manifest.json', 1000, JSON.stringify({ files: [] }));
     const [job] = await db.insert(backupJobs).values({
       orgId: seed.orgId, configId: seed.configId, deviceId: seed.deviceId, status: 'completed', snapshotId: 'HEALME',
@@ -1738,50 +1960,102 @@ runDb('scenario 6: a NULL storage_identity row self-heals when found, and blocks
       snapshotId: 'HEALME', storageIdentity: null, // deliberately unresolved
     });
 
-    // RETIRED6: a genuinely retired prefix on the SAME identity, which must
-    // stay untouched this run because HEALME hasn't resolved yet.
-    await writeAged(root, 'snapshots/RETIRED6/manifest.json', 1000, JSON.stringify({ files: [] }));
-    await writeAged(root, 'snapshots/RETIRED6/files/r.dat', 1000);
+    await writeAged(root, 'snapshots/RETIRED6A/manifest.json', 1000, JSON.stringify({ files: [] }));
+    await writeAged(root, 'snapshots/RETIRED6A/files/r.dat', 1000);
     await db.insert(backupSnapshotRetirements).values({
       orgId: seed.orgId, configId: seed.configId, deviceId: seed.deviceId,
-      snapshotId: 'RETIRED6', storageIdentity: seed.identity, backupType: 'file', reason: 'expired', retiredAt: new Date(),
+      snapshotId: 'RETIRED6A', storageIdentity: seed.identity, backupType: 'file', reason: 'expired', retiredAt: new Date(),
+    });
+    return seed;
+  });
+
+  // HEALME's manifest IS present in this run's listing -> resolves; with no
+  // unresolved rows left and no legacy helper, this identity is NOT deferred,
+  // so RETIRED6A reclaims its non-manifest objects in the SAME run (its
+  // swept_at confirmation still waits for the NEXT run's fresh listing, per
+  // the two-pass rule — asserted separately in the unit suite, Task 7).
+  await sweepUnreferencedBackupObjects();
+
+  const remaining = await listAll(root);
+  expect(remaining).not.toContain('snapshots/RETIRED6A/files/r.dat');
+  expect(remaining).toContain('snapshots/HEALME/manifest.json');
+
+  const [healedRow] = await withSystemDbAccessContext(() =>
+    db.select().from(backupSnapshots).where(eq(backupSnapshots.snapshotId, 'HEALME')),
+  );
+  expect(healedRow!.storageIdentity).toBe(seed.identity);
+});
+
+runDb('scenario 6b: a NULL-identity row whose manifest is NOT found defers the WHOLE identity to today\'s algorithm — nothing unrooted is deleted', async () => {
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const root = await mkdtemp(join(tmpdir(), 'breeze-gc-'));
+
+  await withSystemDbAccessContext(async () => {
+    const seed = await seedOrgDeviceConfig(unique, root);
+
+    // NEVERWRITTEN's row exists (mapped to this identity's config) but its
+    // object was never actually written to THIS bucket — never appears in
+    // the listing, so it can never resolve.
+    const [job] = await db.insert(backupJobs).values({
+      orgId: seed.orgId, configId: seed.configId, deviceId: seed.deviceId, status: 'completed', snapshotId: 'NEVERWRITTEN',
+    }).returning({ id: backupJobs.id });
+    await db.insert(backupSnapshots).values({
+      orgId: seed.orgId, jobId: job!.id, deviceId: seed.deviceId, configId: seed.configId,
+      snapshotId: 'NEVERWRITTEN', storageIdentity: null,
     });
 
+    await writeAged(root, 'snapshots/RETIRED6B/manifest.json', 1000, JSON.stringify({ files: [] }));
+    await writeAged(root, 'snapshots/RETIRED6B/files/r.dat', 1000);
+    await db.insert(backupSnapshotRetirements).values({
+      orgId: seed.orgId, configId: seed.configId, deviceId: seed.deviceId,
+      snapshotId: 'RETIRED6B', storageIdentity: seed.identity, backupType: 'file', reason: 'expired', retiredAt: new Date(),
+    });
+  });
+
+  await sweepUnreferencedBackupObjects();
+
+  // Deferred (unresolved NULL row) -> today's algorithm -> RETIRED6B's
+  // manifest is marked live (it's listed) and its loose object is only 1s
+  // old, well inside the 48h grace -> nothing deleted at all.
+  const remaining = await listAll(root);
+  expect(remaining.sort()).toEqual(['snapshots/RETIRED6B/files/r.dat', 'snapshots/RETIRED6B/manifest.json'].sort());
+});
+
+runDb('scenario 7: system_image, hyperv, and mssql rows are roots exactly like file rows (no backupType filter)', async () => {
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const root = await mkdtemp(join(tmpdir(), 'breeze-gc-'));
+
+  const seed = await withSystemDbAccessContext(async () => {
+    const seed = await seedOrgDeviceConfig(unique, root);
+    for (const [snapshotId, backupType] of [
+      ['IMG1', 'system_image'], ['HV1', 'hyperv'], ['SQL1', 'mssql'],
+    ] as const) {
+      await writeAged(root, `snapshots/${snapshotId}/manifest.json`, 20 * 24 * 60 * 60 * 1000, JSON.stringify({ files: [] }));
+      await insertSnapshotRow({ ...seed, snapshotId, backupType });
+    }
     return seed;
   });
 
   await sweepUnreferencedBackupObjects();
 
-  // Nothing was deleted: RETIRED6 is deferred because HEALME (mapped to the
-  // same identity via configId) was still unresolved when this run started.
-  const afterFirstRun = await listAll(root);
-  expect(afterFirstRun.sort()).toEqual([
-    'snapshots/HEALME/manifest.json',
-    'snapshots/RETIRED6/files/r.dat',
-    'snapshots/RETIRED6/manifest.json',
+  // All three survive despite being 20 days old — they're rooted DB rows,
+  // never filtered out by backupType (Task 3's fix), and their manifest
+  // fetch must succeed (proving the mark phase doesn't 404 on a non-file
+  // manifest key, since every mode publishes the same snapshots/<id>/manifest.json).
+  const remaining = await listAll(root);
+  expect(remaining.sort()).toEqual([
+    'snapshots/IMG1/manifest.json', 'snapshots/HV1/manifest.json', 'snapshots/SQL1/manifest.json',
   ].sort());
-
-  // But HEALME's row is now healed (its manifest WAS found in this run's
-  // listing), so a SECOND run has no unresolved rows left and reclaims
-  // RETIRED6 normally.
-  const [healedRow] = await withSystemDbAccessContext(() =>
-    db.select().from(backupSnapshots).where(eq(backupSnapshots.snapshotId, 'HEALME')),
-  );
-  expect(healedRow!.storageIdentity).toBe(ctx.identity);
-
-  await sweepUnreferencedBackupObjects();
-  const afterSecondRun = await listAll(root);
-  expect(afterSecondRun).toEqual(['snapshots/HEALME/manifest.json']);
 });
 ```
 
-- [ ] Step 2: Run it, expect FAIL until Task 7 lands: `DATABASE_URL=postgresql://breeze:breeze@localhost:5432/breeze cd apps/api && npx vitest run src/__tests__/integration/backupGcReclamation.integration.test.ts --config vitest.integration.config.ts`
+- [ ] Step 2: Run it, expect FAIL until Task 7 lands: `cd apps/api && npx vitest run --config vitest.integration.config.ts src/__tests__/integration/backupGcReclamation.integration.test.ts` (ensure the dedicated test stack is up first — `pnpm test-stack up` at the repo root, or `docker compose -f docker-compose.test.yml up -d` per `setup.ts`'s docstring; do **not** set `DATABASE_URL` on the command line — `setup.ts` resolves it from `.env.test`).
 
 - [ ] Step 3: Implement — no production code changes in this step; this task exists to prove Task 7's implementation against a real database and real filesystem. If any scenario fails, fix `backupRetention.ts` (not the test) unless the test itself has a bug — re-derive from spec §6 rather than loosening an assertion.
 
-- [ ] Step 4: Run, expect PASS: `DATABASE_URL=postgresql://breeze:breeze@localhost:5432/breeze pnpm --filter @breeze/api run test:integration --run src/__tests__/integration/backupGcReclamation.integration.test.ts` (verify the exact script name in `apps/api/package.json` first — grep `"test:integration"`; if absent, run `cd apps/api && npx vitest run --config vitest.integration.config.ts src/__tests__/integration/backupGcReclamation.integration.test.ts` directly, which sidesteps any pnpm passthrough).
+- [ ] Step 4: Run, expect PASS: `cd apps/api && npx vitest run --config vitest.integration.config.ts src/__tests__/integration/backupGcReclamation.integration.test.ts` (the `pnpm --filter @breeze/api run test:integration -- <path>` form is the CLAUDE.md `--` trap — it runs the WHOLE integration suite, not this one file; the direct `npx vitest run --config ...` form above sidesteps it entirely).
 
-- [ ] Step 5: Commit: `git add apps/api/src/__tests__/integration/backupGcReclamation.integration.test.ts && git commit -m "test(backup-gc): integration coverage for retirement/orphan/pin/legacy-helper/self-heal sweep rules"`
+- [ ] Step 5: Commit: `git add apps/api/src/__tests__/integration/backupGcReclamation.integration.test.ts && git commit -m "test(backup-gc): integration coverage for retirement/orphan/pin/legacy-helper/self-heal/cross-type sweep rules"`
 
 ### Task 10: Docs — storage.mdx and monitoring.mdx no longer say "not reclaimed"
 
@@ -1824,9 +2098,9 @@ If storage is growing faster than expected, check whether large datasets were re
 
 ### Task 11: Wave verification
 
-- [ ] Full targeted unit run: `cd apps/api && npx vitest run src/jobs/backupRetention.test.ts src/jobs/backupWorker.test.ts src/services/backupHelperCapabilities.test.ts src/services/backupAgentContract.test.ts`
+- [ ] Full targeted unit run: `cd apps/api && npx vitest run src/jobs/backupRetention.test.ts src/jobs/backupWorker.test.ts src/jobs/backupWorker.dbcontext.test.ts src/services/backupHelperCapabilities.test.ts src/services/backupAgentContract.test.ts`
 - [ ] Typecheck: `pnpm --filter @breeze/api exec tsc --noEmit` (no dedicated typecheck script in `apps/api/package.json` — confirmed via `grep -n '"test"\|"typecheck"\|"build"' apps/api/package.json`, which shows only `"build": "tsup"` and `"test": "vitest"`).
-- [ ] Integration suite (needs `DATABASE_URL=postgresql://breeze:breeze@localhost:5432/breeze` and a running dev DB): `cd apps/api && npx vitest run --config vitest.integration.config.ts src/__tests__/integration/backupGcReclamation.integration.test.ts src/__tests__/integration/staleBackupReaper.integration.test.ts`
+- [ ] Integration suite (needs the dedicated test stack up — `pnpm test-stack up` at the repo root — and resolves `DATABASE_URL`/`DATABASE_URL_APP` from `.env.test` automatically via `setup.ts`; **do not** pass an explicit `DATABASE_URL=...` override, and never point this at port 5432): `cd apps/api && npx vitest run --config vitest.integration.config.ts src/__tests__/integration/backupGcReclamation.integration.test.ts src/__tests__/integration/staleBackupReaper.integration.test.ts`
 - [ ] No schema changes in this wave, so `pnpm db:check-drift` is not expected to show new drift — run it anyway as a sanity check since W01 may have just landed: `pnpm db:check-drift`
 - [ ] Full API unit suite once the above are green: `pnpm --filter @breeze/api test --run` (NOT `-- --run`, see the CLAUDE.md `--` trap)
 - [ ] `pnpm lint`
@@ -1836,17 +2110,17 @@ If storage is growing faster than expected, check whether large datasets were re
   - [ ] Confirms `backupAgentContract.test.ts` is green (the 7-day journal literal contract).
   - [ ] Confirms the Redis skip-set uses the shared non-blocking client (`getRedis()`), never a blocking command on it.
   - [ ] Confirms the capability gate and the unresolved-NULL-rows gate each independently suppress ONLY the retired/orphan reclamation, never the pre-existing rooted-grace or manifest-less-prefix rules.
-  - [ ] Confirms no code path calls `sweepUnreferencedBackupObjects()` (or anything it calls) from inside another open `withSystemDbAccessContext`/`withDbAccessContext` — specifically that `backupWorker.ts`'s `cleanup-expired-snapshots` case runs OUTSIDE the blanket `runWithSystemDbAccess` wrap (§3.7).
-  - [ ] Confirms with whoever landed W01 that `processCleanupExpiredSnapshots`'s body and the `backupWorker.ts` switch-statement carve-out (both touched by this plan's Task 8) merged cleanly against W01's own retention-side short-context restructure — see the Open Questions entry on this.
+  - [ ] Confirms no code path calls `sweepUnreferencedBackupObjects()` (or anything it calls) from inside another open `withSystemDbAccessContext`/`withDbAccessContext` — verified two ways: `backupWorker.dbcontext.test.ts`'s new depth assertion (Task 8) proving THIS wave's `processCleanupExpiredSnapshots` edit calls it at depth 0, and confirming W01 actually landed the `cleanup-expired-snapshots` carve-out out of the blanket `runWithSystemDbAccess` wrap (consumed interface, not re-verified by this wave's own tests beyond the depth-0 assertion above).
   - [ ] No production migration in this PR (W01 owns migrations); `db:check-drift` clean.
   - [ ] Docs PR note: storage.mdx/monitoring.mdx no longer claim reclamation is unimplemented.
 
 ## Open questions / contradictions
 
-- **Cross-wave collision on `backupWorker.ts`'s `cleanup-expired-snapshots` handling.** Spec §3.7 assigns W01 the retention-side restructure (short context per candidate row inside `processCleanupExpiredSnapshots`) and this plan (Task 8) the worker-dispatch-side restructure (carving the whole case out of the blanket `runWithSystemDbAccess` wrap in `createBackupWorker`, `~99-118`). Both waves therefore touch `backupWorker.ts` — W01 inside the function body, W02 at its call site — which is likely fine (different regions of the same file) but should be confirmed rather than assumed; whichever branch merges second must rebase onto the other's changes to this file, not silently overwrite them. Flagged in the PR checklist above.
-- **"Prefix found empty" definition when a shared live object remains.** Spec §3.4 says "when the listing later shows the prefix empty, set `swept_at`" but doesn't define emptiness in the presence of a still-live shared object (e.g. a retired snapshot's manifest referenced no exclusive files, but one of its listed objects is still `liveSet`-protected because another rooted snapshot's manifest also references it). This plan's Task 7 implementation treats the prefix as "empty" once every **non-live** object it contained has been deleted (a permanently shared object never counts against emptiness). This is a reasonable reading but not explicitly stated in the spec — flag for confirmation; if wrong, the write-back call site needs the stricter "truly zero objects remain, live or not" definition instead (which would mean a retirement can never be swept while any dedup sharing continues, likely the wrong behavior — but worth an explicit sign-off).
-- **`orphansSwept` counting granularity.** The spec's `BackupGcResult` field list (§3.4/§6) doesn't define whether `orphansSwept` counts prefixes-fully-cleared (this plan's choice, mirroring `retiredSwept`) or every individual old-orphan prefix touched regardless of whether it fully cleared this run. Chose "fully cleared" for symmetry with `retiredSwept`; flag for confirmation.
-- **Two-phase manifest-delete cap interaction.** The v3 manifest-last rule ("no deletable non-manifest key remains — none failed, none capped, none skip-set-excluded") is more conservative than v2's "zero failedKeys": a single capped-out or skip-set-excluded non-manifest key now blocks the manifest for the WHOLE run, even if every other object in the prefix was cleanly deleted. This plan implements that literally (`remainingNonManifest.length === 0` gates the manifest phase). The spec doesn't explicitly discuss whether a capped-out key should behave differently from a skip-set-excluded one for this purpose (e.g. "cap will clear next run regardless" vs. "skip-set exclusion could persist for the full 7-day TTL") — this plan treats them identically per the literal spec wording; flag for confirmation if a different treatment was intended.
+- **`backupWorker.ts` ownership is now cleanly split (resolved).** Per coordinator decision, W01 owns the ENTIRE `cleanup-expired-snapshots` dispatch-switch carve-out; this wave's Task 8 only edits `processCleanupExpiredSnapshots`'s return type/logging, a small hunk inside a function W01 also touches. A rebase may still be needed if both waves land near-simultaneously, but the overlap is now small and well-scoped rather than a full dispatch-switch collision — no longer flagging this as unresolved, just noting the small-overlap merge risk in the PR checklist.
+- **"Prefix found empty"/`swept_at` timing (resolved by review, restated for traceability).** The corrected design (Task 7) never infers `swept_at` from the same run's own delete bookkeeping — it is set only when a FRESH listing shows no group at all for that `snapshotId`, which naturally handles both "already gone" (same run, zero storage calls needed) and "gone after this run's real deletes" (confirmed on the NEXT run). A snapshot still holding a live, shared object simply never reaches this state, indefinitely — which is correct, not a bug: the object is legitimately still needed elsewhere.
+- **`orphansSwept` is an explicitly accepted best-effort approximation (resolved by review — documented, not fixed).** See the "Two accepted-and-stated approximations" callout at the top of Task 7. Unlike `retiredSwept` (durable, DB-tracked, listing-confirmed), an orphan has no row to protect from double-counting, so this counter is observability-only.
+- **Redis skip-set TTL is a per-identity-SET approximation, not per-member (resolved by review — documented, not fixed).** See the same callout and the updated `recordGcFailedKeys` doc comment in Task 6/7. Accepted because it only ever makes the sweep MORE conservative.
+- **Deferred-identity double-counting in `deferredIdentities`.** When BOTH the legacy-helper gate and the unresolved-NULL-rows gate fire for the same identity in the same run, Task 7's caller increments `deferredIdentities` only once (`if (!state.legacyHelper.deferred) deferredIdentities++` guards the second increment) — but it still logs BOTH `reclamation deferred: legacy helper ...` and `identity deferred: N unresolved rows` as separate lines. This is a deliberate choice (both facts are independently true and operationally useful to know) but means the deferred-identity COUNT and the deferred-identity LOG LINE COUNT can differ for a doubly-deferred identity — flag for confirmation if a stricter 1:1 correspondence between the metric and the logs was expected.
 - **W01 interface drift risk.** This plan was written against the *assumed* W01 v3 deliverables listed under "Depends on" above, since W01 has not landed in this worktree at plan-authoring time. Every exact name (`resolveMsKnob`, `resolveBackupBaseLeaseMs`, `resolveBackupOrphanManifestMaxAgeMs`, `resolveBackupPublishMarginMs`, `backupSnapshotRetirements` column names, `backup_jobs.storage_identity`/`backup_snapshots.storage_identity` nullability and exact naming) **must be re-verified against W01's actual merged code before Task 1 starts** — if any signature differs, this plan's Task 1/6/7/9 code blocks need matching edits before they'll compile.
-- **Migration backfill predicate is untested by this wave.** Spec §3.6 says the migration backfills `backup_snapshots.storage_identity` "only when `backup_configs.updated_at <= backup_snapshots.timestamp`" — that's W01's migration, not this wave's code, but this wave's self-heal logic (Task 7) is the safety net for every row the backfill predicate deliberately leaves NULL. This plan's integration scenario 6 proves the self-heal mechanism works in isolation (a NULL row inserted directly) but does NOT exercise the actual migration/backfill predicate end-to-end — that boundary is W01's to test, flagged here only so it isn't assumed covered by this wave's suite.
+- **Migration backfill predicate is untested by this wave.** Spec §3.6 says the migration backfills `backup_snapshots.storage_identity` "only when `backup_configs.updated_at <= backup_snapshots.timestamp`" — that's W01's migration, not this wave's code, but this wave's self-heal logic (Task 7) is the safety net for every row the backfill predicate deliberately leaves NULL. This plan's integration scenarios 6a/6b prove the self-heal mechanism works in isolation (a NULL row inserted directly) but do NOT exercise the actual migration/backfill predicate end-to-end — that boundary is W01's to test, flagged here only so it isn't assumed covered by this wave's suite.
 - **`backupRetention.test.ts` exact line numbers and `selectQueue` push counts will drift as Tasks 1-7 compound.** The Ground Truth section's line numbers were re-verified against the current (pre-Task-1) file; each subsequent task's edits shift later line numbers, and Task 7 changes the per-identity query count/order from what Tasks 3/5/6 assumed (see Task 7's header note). Re-grep before each task and re-run the full suite after Task 7 to catch any stale `selectQueue` sequence, rather than trusting a fixed count once Tasks 1-7 start compounding edits within one PR branch.

--- a/docs/superpowers/plans/backup/2026-09-09-backup-gc-reclamation-w02-gc-sweep.md
+++ b/docs/superpowers/plans/backup/2026-09-09-backup-gc-reclamation-w02-gc-sweep.md
@@ -1,0 +1,1852 @@
+# Wave 02 — API: GC Sweep Reclaims Retired and Orphaned Prefixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `sweepUnreferencedBackupObjects` (name unchanged — W01 owns the worker call site and expects this exact export) actually reclaim the objects of retired/expired snapshots and abandoned orphan uploads — today it only ever protects, never deletes anything beyond the pre-existing 48h loose-object grace and 9-day manifest-less-prefix rule.
+
+**Architecture:** `backupRetention.ts`'s mark-and-sweep GC gains three new root-set inputs — `backup_snapshots.storage_identity` (nullable, denormalized identity stamped at dispatch/publication, all backup types, not just `file`, self-healed by the sweep when NULL), `backup_snapshot_retirements` (a durable tombstone written whenever retention deletes a row), and a widened `ORPHAN_WINDOW = max(9d default, base lease + grace)` — plus a new per-prefix classification (rooted / retired-or-old-orphan / manifest-less) that deletes retired/orphaned prefixes in two phases (non-manifest objects, then the manifest only when **no deletable non-manifest key remains** — none failed, none capped, none skip-set-excluded), a Redis-backed skip-set for cap fairness, a helper-version capability gate, and an unresolved-NULL-identity gate, both of which defer the new deletion behavior on an identity to "rooted-prefix rule only" until satisfied. Per Codex v2 P1 (§3.7), the whole sweep is restructured to run its DB reads/writes in short per-identity system contexts with every storage call at depth 0 — never inside the worker's blanket per-job transaction.
+
+**Tech Stack:** TypeScript, Drizzle ORM, Vitest (unit + `vitest.integration.config.ts` real-DB), ioredis (shared client via `services/redis.ts`), local-filesystem backup provider for the integration test.
+
+**Spec:** `docs/superpowers/specs/backup/2026-09-09-backup-gc-reclamation-design.md` (v3) (§3.4 sweep rules, §3.6 storage identity, §3.7 transaction boundaries, §6 verification)
+
+**Depends on:** Wave 01 (server-owned dedupe base + retirements table). This plan assumes W01 has already shipped and merged the following, and treats them as read-only consumed interfaces — **do not re-implement them here**:
+- `backup_jobs.base_snapshot_id varchar(255) NULL`, `backup_jobs.publish_lease_expires_at timestamptz NULL` (renamed from `base_lease_expires_at`) (+ partial index).
+- `backup_jobs.storage_identity text NULL` — stamped **at dispatch** from the `providerConfig` placed in the payload (the bucket the helper will actually write to, regardless of later config edits).
+- `backup_snapshots.storage_identity text NULL` — **nullable** (not `NOT NULL`): copied from the job at publication (reconcile copies it from the adoptable job too). The migration backfills it from the current config only when `backup_configs.updated_at <= backup_snapshots.timestamp`; everything else stays `NULL` and is self-healed by this wave's sweep (§3.6).
+- Table `backup_snapshot_retirements` (migration `2026-10-15-140006-backup-snapshot-retirements.sql`), Drizzle export `backupSnapshotRetirements` from `apps/api/src/db/schema/backup.ts`, columns `id uuid pk`, `orgId uuid not null`, `configId uuid` (FK `backup_configs` ON DELETE CASCADE), `deviceId uuid` (nullable, FK SET NULL), `snapshotId varchar(255)`, `storageIdentity text`, `backupType`, `reason` (`expired`|`max_versions`|`manual`), `retiredAt timestamptz`, `sweptAt timestamptz` (nullable), unique `(storageIdentity, snapshotId)`. RLS shape 1, already registered in every cascade/export registry by W01.
+- Module `apps/api/src/services/backupGcKnobs.ts` exporting `resolveMsKnob(name: string, defaultMs: number, productionFloorMs?: number): number` (same env-override / production-floor / warn-log convention as today's `resolveBackupGcGraceMs`), `resolveBackupBaseLeaseMs()` (default 7d), `resolveBackupOrphanManifestMaxAgeMs()` (default 9d = `9 * 24 * 60 * 60 * 1000`), and `resolveBackupPublishMarginMs()` (default 1h) — the last is consumed by W01's agent-publish lease check, not directly by this wave's sweep, but is part of the same module surface; note it exists so an import-list diff doesn't surprise anyone.
+- `cleanupExpiredSnapshots`/`tryDeleteSnapshotRow` (`apps/api/src/jobs/backupRetention.ts:189-231`) already insert a `backup_snapshot_retirements` row (reason `expired`/`max_versions`) durably — per §3.7, W01 restructures this into **one short system context per candidate row** (`SELECT FOR UPDATE` → pin checks → insert retirement → delete row → commit) so each retirement commits before GC could ever act on it. This wave only **reads** `backup_snapshot_retirements`, never writes a retirement row itself, and never writes `backup_jobs`/`backup_snapshots`' pin/lease columns — it only ever writes `backup_snapshot_retirements.swept_at` and `backup_snapshots.storage_identity` (self-heal).
+- Reconcile (`services/backupSnapshotReconcile.ts`, W01-owned) refuses to adopt a retired `snapshotId` and only adopts an orphan younger than half of `ORPHAN_WINDOW` — nothing to implement here, but this wave's orphan-window tests must independently prove "younger than window = root, older = swept" since reconcile's own half-window boundary is out of scope.
+- **`backupWorker.ts`'s `cleanup-expired-snapshots` handler runs OUTSIDE the blanket `runWithSystemDbAccess` transaction — W01 owns this, not W02.** Concretely: W01 restructures `processCleanupExpiredSnapshots` and the `createBackupWorker` job-dispatch switch (spec §3.7) so the `cleanup-expired-snapshots` case is carved out of the blanket wrap the same way `dispatch-backup` already is (mirroring the `#1105` fix), runs retention's per-row short contexts, and then calls `await sweepUnreferencedBackupObjects()` at depth 0 (no active DB context). This wave does **not** touch `backupWorker.ts`'s dispatch switch (Task 8 is scoped to `processCleanupExpiredSnapshots`'s logging only) and does **not** rename `sweepUnreferencedBackupObjects` — W01's call site depends on that exact export name and signature. This wave's own defense against a violation of this assumption is a runtime guard (`assertOutsideHeldDbContext`, Task 7), not a restructure.
+
+If any of these interfaces differ from what W01 actually shipped, treat that as a blocking discrepancy — re-verify against the real file before starting Task 1.
+
+## Global Constraints
+
+**Standing rule — `selectQueue` push order compounds across tasks.** `backupRetention.test.ts`'s mock (`chainable`/`selectQueue`, see Ground Truth) requires one `selectQueue.push([...])` per `db.select(...)` call **in the exact order the source code issues them**. Because `sweepUnreferencedBackupObjects` gains new run-level and per-identity queries incrementally across Tasks 3-7 (Task 4 adds a run-level `identityUsage` query, Task 5's per-identity retained-rows query is unaffected, Task 7 adds per-identity NULL-identity-rows and capability-gate queries), **a task that inserts a new query earlier in the call sequence invalidates every already-written test after it in the file**, not just its own new tests. Concretely: Task 4's `identityUsage` push lands as the 3rd run-level push (after `unattributedRows`, `destinations`) — go back and insert a matching `selectQueue.push([...])` at that position in every per-identity test Task 3 already wrote, immediately after landing Task 4, and re-run the full file (not just the new `describe` block) before moving on. Do this same check after every task from here through Task 7: run `cd apps/api && npx vitest run src/jobs/backupRetention.test.ts` at the end of **every** task's Step 4, not just the newest test's `-t` filter, and fix any prior test whose mock queue is now off by one. Task 7's own header note calls this out again for its specific (larger) reordering, but the rule applies starting at Task 4.
+
+- Knobs (all resolved **per run**, not at module load): `BACKUP_GC_GRACE_MS` (default 48h = `172800000`, production floor 1h = `3600000`); `BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS` (default 9d = `BACKUP_GC_AGENT_JOURNAL_MAX_AGE_MS + BACKUP_GC_GRACE_MS_DEFAULT`, production floor = `BACKUP_GC_AGENT_JOURNAL_MAX_AGE_MS + 1`ms — must stay strictly larger than the agent's 7-day `journalMaxAge`); `BACKUP_GC_ORPHAN_MANIFEST_MAX_AGE_MS` (W01's `resolveBackupOrphanManifestMaxAgeMs()`, default 9d); `BACKUP_BASE_LEASE_MS` (W01's `resolveBackupBaseLeaseMs()`, default 7d) — consumed here only to compute `ORPHAN_WINDOW`, never written.
+- `ORPHAN_WINDOW = Math.max(resolveBackupOrphanManifestMaxAgeMs(), resolveBackupBaseLeaseMs() + resolveBackupGcGraceMs())`, computed once per run (spec §3.4) — with today's defaults (9d vs 7d+48h=9d) the two arms are numerically equal, but an operator override of either knob can make either arm the binding one, so the `max()` must be computed from the resolved values every run, never hardcoded to "9 days".
+- `BACKUP_GC_AGENT_JOURNAL_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000` **must remain a literal in `apps/api/src/jobs/backupRetention.ts`** — `apps/api/src/services/backupAgentContract.test.ts:29-40` greps this file's source text for that exact expression and must keep passing unmodified.
+- New constant `BACKUP_SERVER_BASE_MIN_HELPER_VERSION = '0.112.0'` in `apps/api/src/services/backupHelperCapabilities.ts`.
+- New function `backupHelperSupportsServerBase(version: string | null | undefined): boolean` in the same file, mirroring `backupHelperSupportsQueue`.
+- Redis skip-set key: `backup-gc:failed:<sha1(identity.key)>` (a Redis SET of object keys), TTL 7 days (`604800` seconds).
+- `BackupGcResult` gains `retiredSwept: number`, `orphansSwept: number`, `deferredIdentities: number`, `unreachableIdentities: number` alongside the existing `deleted`, `skippedIdentities`, `blockedIdentities`.
+- Retirement pruning window: 30 days after `sweptAt`.
+- Manifest-last rule (spec v3, stronger than "zero failedKeys"): `manifest.json` is deleted only when **no deletable non-manifest key remains** in the prefix — none failed, none excluded by the per-run delete cap, none in the Redis skip set. A capped-out or skip-set-excluded (not just a failed) non-manifest key must also block the manifest this run.
+- Capability-gate device criteria (spec v3): devices considered for an identity = those with a `backup_jobs` row on that identity (via `backupJobs.storageIdentity = identity.key`, OR `backupJobs.storageIdentity IS NULL AND backupJobs.configId IN identity.configIds` for legacy jobs predating the column) whose status is `pending`/`running` (**any age**) **or** whose `createdAt` is within the last 30 days.
+- Unresolved-NULL-identity gate (spec §3.4/§3.6, new): while any `backup_snapshots` row with `storageIdentity IS NULL` maps to identity `I` (via `configId IN I.configIds`) and its `snapshots/<id>/manifest.json` is **not found** in `I`'s current listing, `I` runs the rooted-prefix rule only this run, logging `identity deferred: <n> unresolved rows`. A NULL row whose manifest **is** found in the listing is self-healed (`UPDATE backup_snapshots SET storage_identity = I`) and treated as rooted, independent of whether other NULL rows on the same identity remain unresolved.
+- No migrations in this wave — W01 owns all schema/registry changes. This wave's only writes are `UPDATE backup_snapshots SET storage_identity = ...` (self-heal) and `UPDATE backup_snapshot_retirements SET swept_at = ...` / the 30-day prune `DELETE`.
+- Transaction boundaries (spec §3.7): every DB read/write this wave performs runs inside its own **short** `withSystemDbAccessContext` call; every storage call (list/fetch/delete against S3 or local) runs at depth 0, never nested inside a DB context. **W01 owns moving the `cleanup-expired-snapshots` worker call site out of the blanket `runWithSystemDbAccess` wrap** (consumed interface — see "Depends on"); this wave's `sweepUnreferencedBackupObjects` only defends that assumption with a runtime guard (`assertOutsideHeldDbContext`, Task 7) rather than restructuring the worker itself (Task 8 no longer touches `backupWorker.ts`'s dispatch switch).
+
+## 0. Ground truth
+
+Verified against `backup-gc-5429` worktree, current `main`-based state (i.e. **before** W01 lands — line numbers below are pre-W01 and will shift slightly once W01's columns/imports land; re-check before editing):
+
+- `apps/api/src/jobs/backupRetention.ts` is 1110 lines. Key line numbers (`grep -n "^function \|^export function\|^async function\|^export async function\|^const BACKUP_GC\|^export const BACKUP_GC"`):
+  - `189` `deleteSnapshotRow`, `205` `tryDeleteSnapshotRow`, `231` `cleanupExpiredSnapshots` (W01's territory — do not touch).
+  - `494` `BACKUP_GC_GRACE_MS_DEFAULT`, `501` `BACKUP_GC_GRACE_MS_PRODUCTION_FLOOR`, `503` `resolveBackupGcGraceMs()`, `524` `export const BACKUP_GC_GRACE_MS = resolveBackupGcGraceMs();` (module-load — this is what Task 1 removes).
+  - `537` `BACKUP_GC_AGENT_JOURNAL_MAX_AGE_MS` (**keep this line's literal exactly**, see Global Constraints), `538-539` `export const BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS = ...` (module-load — Task 1 removes the `export const`, keeps the journal-age literal above it).
+  - `546` `BACKUP_GC_SUPPORTED_PROVIDERS`.
+  - `572` `resolveBackupGcMaxDeletesPerRun()` — already per-run-resolved; **pattern to copy** for the new knobs' call sites.
+  - `582` `parseBackupGcManifest`, `631` `normalizeS3Endpoint`, `661` `normalizeStorageIdentity` (exported, pure function — reused verbatim, not modified), `674` `groupBackupConfigsByStorageIdentity`, `709` `detectSuspiciousStorageIdentityCollisions`, `761` `groupListingBySnapshotId` (returns `Map<string, BackupGcSnapshotGroup>`, `BackupGcSnapshotGroup = { items: BackupObjectListing[]; manifestItem: BackupObjectListing | null }`, both defined `730-763`).
+  - `805` `listedManifestSnapshotIds` (17 lines, `805-816`) — **replaced** by `orphanManifestSnapshotIds` (Task 3).
+  - `817` `markLiveBackupObjects` (`817-871`) — unchanged signature, only its caller changes which ids it's given.
+  - `873` `sweepStorageIdentity` (`873-981`) — rewritten by Task 7 into a pure storage/compute function (no DB calls) per §3.7.
+  - `982` `sweepUnreferencedBackupObjects` (`982-1110`, exported) — **name kept exactly as-is** (W01's `backupWorker.ts` call site depends on this export name) but restructured internally into phased short DB contexts by Task 7.
+  - `export type BackupGcResult = { deleted: number; skippedIdentities: number; blockedIdentities: number };` at line 550.
+  - Imports at top (`9-30`): `db`, `{ backupSnapshots, backupPolicies, backupJobs, configPolicyBackupSettings, backupConfigs }` from `../db/schema`, `{ eq, and, or, lt, desc, inArray, isNull }` from `drizzle-orm`, storage helpers from `../services/backupSnapshotStorage`, `{ asRecord, getStringValue }` from `../services/recoveryBootstrap`, `{ captureException }` from `../services/sentry`, `{ pgErrorCode, pgErrorConstraint }` from `../utils/pgErrors`. Task 7 additionally imports `withSystemDbAccessContext` from `../db` (grep confirms `db/index.ts` exports it — same import already used by `staleBackupReaper.integration.test.ts`).
+  - The retained-rows query inside the current `sweepUnreferencedBackupObjects` (`~1017-1027`) filters `or(eq(backupSnapshots.backupType, 'file'), isNull(backupSnapshots.backupType))` against `inArray(backupSnapshots.configId, identity.configIds)` — the comment directly above it (`~1005-1016`) is the one the spec calls out as factually wrong (claims non-file types use a different manifest layout; ground truth in the spec confirms every mode writes `snapshots/<id>/manifest.json`). Task 3 deletes this filter and rewrites the comment; Task 7 further replaces the `configId IN (...)` scoping with `storageIdentity = I` (all rows) `∪` a separate NULL-identity self-heal query.
+- `apps/api/src/jobs/backupWorker.ts`: `processCleanupExpiredSnapshots` is `324-390` (`export async function processCleanupExpiredSnapshots(): Promise<{...}>`); it calls `sweepUnreferencedBackupObjects()` at `~366` inside a try/catch and destructures `gcResult.deleted/skippedIdentities/blockedIdentities` at `~367-369`; the returned object shape is built at the final `return` (`~390`). Today the `cleanup-expired-snapshots` job-type case (`~109-111`) is dispatched from **inside** the worker's blanket `runWithSystemDbAccess(async () => { switch (...) { ... } })` wrap (`101-118`) — this is exactly the Codex v2 P1 hazard (spec §3.7): that wrap is one Postgres transaction, confirmed a single-transaction context by the `#1105` comment already present at `~505-520` describing the identical hazard for `dispatch-backup`, which was fixed by carving that case out to run **before** the blanket wrap (`~99-100,104`). **W01 owns carving `cleanup-expired-snapshots` out the same way and calling `sweepUnreferencedBackupObjects()` at depth 0** (consumed interface, see "Depends on") — this plan's Task 8 does not touch the dispatch switch, only the logging inside `processCleanupExpiredSnapshots` itself.
+- `apps/api/src/services/backupHelperCapabilities.ts` (23 lines) — existing pattern to mirror exactly: `BACKUP_QUEUE_MIN_HELPER_VERSION = '0.110.0'`, `backupHelperSupportsQueue(version)` uses `parseComparableVersion`/`compareAgentVersions` from `./agentEditionCompat`, returns `false` for null/unparseable, `compareAgentVersions(version, MIN) >= 0`. Its test `backupHelperCapabilities.test.ts` (18 lines) is the pattern for the new test — confirms `'0.110.0-rc.1'` (prerelease of the introducing version) is correctly rejected by the existing `compareAgentVersions` prerelease-ordering rule (`agentEditionCompat.ts:62-65`: a prerelease always compares less than the same-or-higher non-prerelease core), so no extra prerelease-handling logic is needed in `backupHelperSupportsServerBase` — it's a pure mirror.
+- `apps/api/src/db/schema/backup.ts`: `backupJobs` (`207-278`, has `configId`, `deviceId`, `createdAt`, no `storageIdentity`), `backupSnapshots` (`280-...`, has `orgId`, `jobId`, `deviceId`, `configId`, `snapshotId`, `backupType`, `expiresAt`, etc. — W01 adds `storageIdentity`). `apps/api/src/db/schema/devices.ts:175` `backupVersion: varchar('backup_version', { length: 50 })`.
+- `apps/api/src/services/redis.ts`: `getRedis(): Redis | null` (`110-152`, shared non-blocking lazy client, auto-reconnect) and `isRedisAvailable(): boolean` (`153-155`) are the pair to use — **not** `getBullMQConnection`/`createBlockingRedisConnection`, which are for BullMQ and blocking commands respectively (a blocking command on the shared connection stalls unrelated enqueues elsewhere in the app). Usage pattern mirrored from `apps/api/src/services/alertCooldown.ts:61-72`: check `isRedisAvailable()`, get the client, null-check it, fail closed/degrade on either failure — never throw.
+- `apps/api/src/services/backupSnapshotStorage.ts`: local-provider layout confirmed — `listLocalObjectsWithLastModified` (`213-256`) walks `providerConfig.path`/`providerConfig.basePath` recursively, using each file's `stat().mtime` as `lastModified`, keyed by the relative path (e.g. `snapshots/<id>/manifest.json`, `snapshots/<id>/files/<name>`). `deleteLocalObjectKeys` (`365-388`) does `rm(targetPath, { force: true })` per key inside `deleteBackupObjectKeys` (`398-407`), never a prefix-wide delete. `backupSnapshotRootPrefix()` returns `'snapshots'`, `backupSnapshotManifestKey(id)` returns `` `snapshots/${id}/manifest.json` ``. For the integration test: write real files under a temp dir, then use `fs.promises.utimes(path, mtime, mtime)` to age them, since `lastModified` is derived from `stat().mtime`, not from any DB column.
+- `apps/api/src/__tests__/integration/staleBackupReaper.integration.test.ts` (86 lines) is the pattern for the new integration test: `import './setup'`, `const runDb = it.runIf(!!process.env.DATABASE_URL)`, `withSystemDbAccessContext` wraps both the fixture inserts and the assertions, fixtures inserted in order `partners → organizations → sites → devices → backupConfigs → backupJobs` (then this wave adds `→ backupSnapshots → backupSnapshotRetirements`), unique suffix `` `${Date.now()}-${Math.random().toString(36).slice(2, 8)}` `` on every named/slugged value to avoid cross-run collisions on the shared dev DB.
+- `apps/api/vitest.integration.config.ts` `include` already contains `'src/__tests__/integration/**/*.test.ts'` — a new file at `apps/api/src/__tests__/integration/backupGcReclamation.integration.test.ts` is picked up with no config change.
+- `apps/api/src/jobs/backupRetention.test.ts` (1041 lines) mocking style: a hand-rolled chainable Drizzle mock (`chainable(rows)`, `1-22`) fed by a shared `selectQueue: unknown[][]` array that `mockDb.select` shifts from FIFO (`24-30`) — every `db.select(...)` call in source order must have a matching `selectQueue.push([...])` in the test. `vi.mock('../services/backupSnapshotStorage', ...)` (`36-45`) replaces `fetchBackupObjectText`/`listBackupObjectsUnderPrefix`/`deleteBackupObjectKeys` with mocks while keeping the real (pure) exports like `normalizeStorageIdentity`. `vi.mock('../services/sentry', ...)` (`48-49`) captures `captureException` calls. Exact line numbers of the two blocks this wave must remove/rewrite (re-verified, NOT the spec's `~665`/`~699-752` — actual):
+  - `665-698`: `it('keeps a listed manifest\'s exclusive objects live even though no backup_snapshots row retains it', ...)` — rewritten into an "orphan younger than the window is a root" case.
+  - `699-752`: `describe('marks every listed manifest, not just the newest (FIX 5)', ...)` (one `it` inside) — this behavior (every listed manifest is live forever) is **removed** under the new design; the underlying dedup-source race it protected against is now closed by W01's base pin/lease, not by an unbounded listing heuristic. Replaced with orphan-window boundary tests (young orphan protected, old orphan swept).
+  - `753-813`: `describe('non-file snapshots no longer wedge the file-backup sweep (FIX 6)', ...)` (two `it`s) — this entire block tests the `backupType='file'` filter Task 2 deletes; rewritten to prove ALL backup types are now included in the retained set via `storage_identity`, and that a genuinely unfetchable manifest (any type) still fail-closes the identity.
+  - `497-540`: the `BACKUP_GC_GRACE_MS` module-load re-import tests (`await import('./backupRetention')` with fresh env — module-reset gymnastics) — these must be rewritten to call the per-run resolver directly instead, since the constant is no longer resolved at module load.
+- `apps/docs/src/content/docs/backup/storage.mdx:53-61` — the `<Aside type="note" title="What retention removes today">` block (9 lines) explicitly states objects are *not yet* reclaimed and links issue #5429. `apps/docs/src/content/docs/backup/monitoring.mdx:119` — one sentence repeating the same "not yet reclaimed" claim, linking back to the storage page.
+
+## File structure
+
+- Modify `apps/api/src/jobs/backupRetention.ts` — per-run knob resolution, all-type root set via `storage_identity`, orphan-window root function, retirement-aware two-phase sweep, Redis skip-set, capability gate, unreachable-identity logging, extended `BackupGcResult`.
+- Modify `apps/api/src/services/backupHelperCapabilities.ts` — add `BACKUP_SERVER_BASE_MIN_HELPER_VERSION` + `backupHelperSupportsServerBase`.
+- Modify `apps/api/src/services/backupHelperCapabilities.test.ts` — add a `describe('backupHelperSupportsServerBase', ...)` block mirroring the existing one.
+- Modify `apps/api/src/jobs/backupWorker.ts` — extend `processCleanupExpiredSnapshots`'s return shape and log line with the four new `BackupGcResult` fields.
+- Modify `apps/api/src/jobs/backupRetention.test.ts` — remove/rewrite the three blocks in Ground Truth, add new unit coverage for every new rule.
+- Create `apps/api/src/__tests__/integration/backupGcReclamation.integration.test.ts` — real-DB + real-local-filesystem proof of spec §6 scenarios (1)-(5) plus this wave's own NULL-identity self-heal/unresolved-gate scenario (6).
+- Modify `apps/docs/src/content/docs/backup/storage.mdx` — rewrite the "What retention removes today" aside.
+- Modify `apps/docs/src/content/docs/backup/monitoring.mdx` — rewrite the storage-growth sentence.
+
+### Task 1: Per-run knob resolution via `backupGcKnobs`
+
+**Files:** Modify `apps/api/src/jobs/backupRetention.ts:494-541` (the `BACKUP_GC_GRACE_MS_DEFAULT`/`_PRODUCTION_FLOOR`/`resolveBackupGcGraceMs`/`export const BACKUP_GC_GRACE_MS` block and the `BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS` block). Test: `apps/api/src/jobs/backupRetention.test.ts:497-540`.
+
+**Interfaces:**
+- Consumes: `resolveMsKnob(name: string, defaultMs: number, productionFloorMs?: number): number` from `../services/backupGcKnobs` (W01).
+- Produces: `resolveBackupGcGraceMs(): number` (kept, now a thin wrapper), removes the module-load `export const BACKUP_GC_GRACE_MS` and `export const BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS`; adds `resolveBackupManifestlessPrefixMaxAgeMs(): number` (exported, per-run).
+
+- [ ] Step 1: Write the failing test — replace the module-reset tests at `backupRetention.test.ts:497-540` (they `await import('./backupRetention')` with mutated `process.env` to catch a module-load constant; that pattern breaks once resolution moves off module load):
+
+```typescript
+// Replaces the BACKUP_GC_GRACE_MS module-reset describe block (was 497-540).
+import { resolveBackupGcGraceMs, resolveBackupManifestlessPrefixMaxAgeMs } from './backupRetention';
+
+describe('resolveBackupGcGraceMs (per-run)', () => {
+  const prev = process.env.BACKUP_GC_GRACE_MS;
+  const prevEnv = process.env.NODE_ENV;
+  afterEach(() => {
+    if (prev === undefined) delete process.env.BACKUP_GC_GRACE_MS; else process.env.BACKUP_GC_GRACE_MS = prev;
+    process.env.NODE_ENV = prevEnv;
+  });
+
+  it('defaults to 48h when unset', () => {
+    delete process.env.BACKUP_GC_GRACE_MS;
+    expect(resolveBackupGcGraceMs()).toBe(48 * 60 * 60 * 1000);
+  });
+
+  it('honors a positive override outside production', () => {
+    process.env.NODE_ENV = 'test';
+    process.env.BACKUP_GC_GRACE_MS = '1000';
+    expect(resolveBackupGcGraceMs()).toBe(1000);
+  });
+
+  it('floors an override below 1h in production', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.BACKUP_GC_GRACE_MS = '1000';
+    expect(resolveBackupGcGraceMs()).toBe(60 * 60 * 1000);
+  });
+
+  it('re-resolves on every call (no module-load caching)', () => {
+    process.env.NODE_ENV = 'test';
+    process.env.BACKUP_GC_GRACE_MS = '5000';
+    expect(resolveBackupGcGraceMs()).toBe(5000);
+    process.env.BACKUP_GC_GRACE_MS = '9000';
+    expect(resolveBackupGcGraceMs()).toBe(9000);
+  });
+});
+
+describe('resolveBackupManifestlessPrefixMaxAgeMs (per-run)', () => {
+  const AGENT_JOURNAL_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+  const prev = process.env.BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS;
+  afterEach(() => {
+    if (prev === undefined) delete process.env.BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS;
+    else process.env.BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS = prev;
+  });
+
+  it('defaults to 9 days (journalMaxAge + 48h), strictly greater than journalMaxAge', () => {
+    delete process.env.BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS;
+    const resolved = resolveBackupManifestlessPrefixMaxAgeMs();
+    expect(resolved).toBe(9 * 24 * 60 * 60 * 1000);
+    expect(resolved).toBeGreaterThan(AGENT_JOURNAL_MAX_AGE_MS);
+  });
+
+  it('never allows an override at or below journalMaxAge (production floor holds even outside prod - see step 3)', () => {
+    process.env.BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS = String(AGENT_JOURNAL_MAX_AGE_MS);
+    expect(resolveBackupManifestlessPrefixMaxAgeMs()).toBeGreaterThan(AGENT_JOURNAL_MAX_AGE_MS);
+  });
+});
+```
+
+- [ ] Step 2: Run it, expect FAIL (both new functions don't exist / old exports removed): `cd apps/api && npx vitest run src/jobs/backupRetention.test.ts` — TypeError `resolveBackupManifestlessPrefixMaxAgeMs is not a function` (or a compile error if run through `tsc`).
+
+- [ ] Step 3: Implement — replace `backupRetention.ts:494-541`:
+
+```typescript
+import { resolveMsKnob } from '../services/backupGcKnobs';
+
+const BACKUP_GC_GRACE_MS_DEFAULT = 48 * 60 * 60 * 1000;
+// Test/lab knob only (2026-09-09 assurance campaign, cell R1/R4): the grace is a
+// production safety margin and must never be lowered on a real deployment.
+const BACKUP_GC_GRACE_MS_PRODUCTION_FLOOR = 60 * 60 * 1000;
+
+/** Resolved fresh on every GC run — see resolveMsKnob for the override/floor/warn contract. */
+export function resolveBackupGcGraceMs(): number {
+  return resolveMsKnob('BACKUP_GC_GRACE_MS', BACKUP_GC_GRACE_MS_DEFAULT, BACKUP_GC_GRACE_MS_PRODUCTION_FLOOR);
+}
+
+// Must stay STRICTLY LARGER than agent/internal/backup/journal.go's
+// journalMaxAge (7 days) — see apps/api/src/services/backupAgentContract.test.ts,
+// which greps THIS FILE's source text for this exact literal. Do not move it,
+// rename it, or change its RHS expression without updating that contract test.
+const BACKUP_GC_AGENT_JOURNAL_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000; // must equal the agent's journalMaxAge
+const BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS_DEFAULT =
+  BACKUP_GC_AGENT_JOURNAL_MAX_AGE_MS + BACKUP_GC_GRACE_MS_DEFAULT; // 9 days
+// Floor is journalMaxAge + 1ms (not a round number): the invariant is STRICT
+// inequality against journalMaxAge, not "at least 7 days" — an override of
+// exactly 7 days would race a resume opened just inside day 7 (see the
+// resume-headroom comment this constant used to carry).
+const BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS_PRODUCTION_FLOOR = BACKUP_GC_AGENT_JOURNAL_MAX_AGE_MS + 1;
+
+/** Resolved fresh on every GC run. Replaces the old module-load export. */
+export function resolveBackupManifestlessPrefixMaxAgeMs(): number {
+  return resolveMsKnob(
+    'BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS',
+    BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS_DEFAULT,
+    BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS_PRODUCTION_FLOOR,
+  );
+}
+```
+
+  Every other reference to `BACKUP_GC_GRACE_MS`/`BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS` inside `backupRetention.ts` (only inside `sweepStorageIdentity`, rewritten in Task 6) switches to calling `resolveBackupGcGraceMs()`/`resolveBackupManifestlessPrefixMaxAgeMs()` once per `sweepUnreferencedBackupObjects()` run and threading the resulting numbers down as parameters (not re-resolving per identity — keeps one run internally consistent even if env changes mid-run).
+
+- [ ] Step 4: Run, expect PASS: `cd apps/api && npx vitest run src/jobs/backupRetention.test.ts src/services/backupAgentContract.test.ts`
+
+- [ ] Step 5: Commit: `git add apps/api/src/jobs/backupRetention.ts apps/api/src/jobs/backupRetention.test.ts && git commit -m "refactor(backup-gc): resolve GC grace/manifestless-window knobs per run"`
+
+### Task 2: Capability constant + `backupHelperSupportsServerBase`
+
+**Files:** Modify `apps/api/src/services/backupHelperCapabilities.ts` (append). Modify `apps/api/src/services/backupHelperCapabilities.test.ts` (append a describe block).
+
+**Interfaces:**
+- Produces: `export const BACKUP_SERVER_BASE_MIN_HELPER_VERSION = '0.112.0';`, `export function backupHelperSupportsServerBase(version: string | null | undefined): boolean`.
+
+- [ ] Step 1: Write the failing test — append to `backupHelperCapabilities.test.ts`:
+
+```typescript
+import {
+  BACKUP_SERVER_BASE_MIN_HELPER_VERSION,
+  backupHelperSupportsQueue,
+  backupHelperSupportsServerBase,
+} from './backupHelperCapabilities';
+
+describe('backupHelperSupportsServerBase', () => {
+  it('accepts the introducing release and anything newer', () => {
+    expect(backupHelperSupportsServerBase(BACKUP_SERVER_BASE_MIN_HELPER_VERSION)).toBe(true);
+    expect(backupHelperSupportsServerBase('v0.112.0')).toBe(true);
+    expect(backupHelperSupportsServerBase('0.112.1')).toBe(true);
+    expect(backupHelperSupportsServerBase('0.113.0')).toBe(true);
+    expect(backupHelperSupportsServerBase('1.0.0')).toBe(true);
+  });
+
+  it('rejects older helpers, pre-releases of the introducing version, dev builds, and unknowns', () => {
+    expect(backupHelperSupportsServerBase('0.111.0')).toBe(false);
+    expect(backupHelperSupportsServerBase('0.111.99')).toBe(false);
+    expect(backupHelperSupportsServerBase('0.112.0-rc.1')).toBe(false);
+    expect(backupHelperSupportsServerBase(null)).toBe(false);
+    expect(backupHelperSupportsServerBase(undefined)).toBe(false);
+    expect(backupHelperSupportsServerBase('')).toBe(false);
+    expect(backupHelperSupportsServerBase('dev')).toBe(false);
+    expect(backupHelperSupportsServerBase('unknown')).toBe(false);
+  });
+});
+```
+
+- [ ] Step 2: Run it, expect FAIL: `cd apps/api && npx vitest run src/services/backupHelperCapabilities.test.ts` — `backupHelperSupportsServerBase is not exported`.
+
+- [ ] Step 3: Implement — append to `backupHelperCapabilities.ts`:
+
+```typescript
+/**
+ * First breeze-backup helper release that supports server-owned dedupe base
+ * selection (D18 W01/W02): the server picks and leases the incremental base,
+ * the agent downloads it by id, and the agent itself never deletes remote
+ * objects. Older helpers still list the bucket to choose a base and still
+ * prune remotely on retention, so GC's new unrooted-prefix reclamation
+ * (retired + orphan-past-window deletion) must stay disabled on any identity
+ * still serving a helper below this version — see
+ * apps/api/src/jobs/backupRetention.ts's capability gate.
+ */
+export const BACKUP_SERVER_BASE_MIN_HELPER_VERSION = '0.112.0';
+
+/**
+ * True when `devices.backup_version` reports a helper new enough to trust
+ * with unrooted-prefix GC reclamation. Unknown, unparseable, or missing
+ * versions are treated as NOT capable (conservative: legacy behavior).
+ */
+export function backupHelperSupportsServerBase(version: string | null | undefined): boolean {
+  if (!version) return false;
+  if (!parseComparableVersion(version)) return false;
+  return compareAgentVersions(version, BACKUP_SERVER_BASE_MIN_HELPER_VERSION) >= 0;
+}
+```
+
+- [ ] Step 4: Run, expect PASS: `cd apps/api && npx vitest run src/services/backupHelperCapabilities.test.ts`
+
+- [ ] Step 5: Commit: `git add apps/api/src/services/backupHelperCapabilities.ts apps/api/src/services/backupHelperCapabilities.test.ts && git commit -m "feat(backup-gc): add backupHelperSupportsServerBase capability gate"`
+
+### Task 3: All-type root set via `storage_identity` (drop the `backupType='file'` filter)
+
+**Files:** Modify `apps/api/src/jobs/backupRetention.ts` (the retained-rows query, currently inside `sweepUnreferencedBackupObjects`'s per-identity loop, `~1005-1027`, plus its wrong comment at `~1057-1065`/`~1066-1074` per the spec — re-verify exact lines against Task 1's edited file before touching). Test: `apps/api/src/jobs/backupRetention.test.ts:753-813` (the FIX 6 block).
+
+**Interfaces:**
+- Produces: a helper `async function retainedSnapshotIdsForIdentity(identityKey: string): Promise<string[]>` querying `backupSnapshots.snapshotId` `WHERE storageIdentity = identityKey` (no `backupType` filter, no `configId` filter — `storage_identity` already scopes it precisely, including across a config whose `providerConfig` was edited after some rows were written).
+
+- [ ] Step 1: Write the failing test — replace `backupRetention.test.ts:753-813` (the `describe('non-file snapshots no longer wedge the file-backup sweep (FIX 6)', ...)` block, which tested the now-deleted filter) with:
+
+```typescript
+describe('all backup types share one retained set via storage_identity (no more backupType filter)', () => {
+  it('includes a system_image row in the retained set alongside a file row on the same identity', async () => {
+    selectQueue.push([]); // unattributedRows
+    selectQueue.push([destination]); // destinations
+    // Retained-rows query is no longer filtered by backupType — both rows come back.
+    selectQueue.push([{ snapshotId: 'FILE1' }, { snapshotId: 'IMG1' }]);
+
+    fetchBackupObjectTextMock.mockImplementation(async (input: { key: string }) => {
+      if (input.key === 'snapshots/FILE1/manifest.json') return manifestJson([]);
+      if (input.key === 'snapshots/IMG1/manifest.json') return manifestJson([]);
+      throw new Error(`unexpected manifest fetch: ${input.key}`);
+    });
+
+    const old = JUST_PAST_MANIFESTLESS_THRESHOLD();
+    listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
+      { key: 'snapshots/FILE1/manifest.json', lastModified: old },
+      { key: 'snapshots/IMG1/manifest.json', lastModified: old },
+    ]);
+
+    const result = await sweepUnreferencedBackupObjects();
+
+    expect(fetchBackupObjectTextMock).toHaveBeenCalledWith(expect.objectContaining({ key: 'snapshots/FILE1/manifest.json' }));
+    expect(fetchBackupObjectTextMock).toHaveBeenCalledWith(expect.objectContaining({ key: 'snapshots/IMG1/manifest.json' }));
+    expect(result.blockedIdentities).toBe(0);
+    expect(result.skippedIdentities).toBe(0);
+  });
+
+  it('still fail-closes AND increments blockedIdentities when ANY retained type\'s manifest is unfetchable', async () => {
+    selectQueue.push([]); // unattributedRows
+    selectQueue.push([destination]); // destinations
+    selectQueue.push([{ snapshotId: 'IMG1' }]); // a system_image row, now equally retained
+
+    fetchBackupObjectTextMock.mockRejectedValueOnce(new Error('S3 500 fetching manifest'));
+
+    const old = JUST_PAST_MANIFESTLESS_THRESHOLD();
+    listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
+      { key: 'snapshots/IMG1/manifest.json', lastModified: old },
+      { key: 'snapshots/ORPHAN/files/x.dat', lastModified: old },
+    ]);
+
+    const result = await sweepUnreferencedBackupObjects();
+
+    expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled();
+    expect(result.skippedIdentities).toBe(1);
+    expect(result.blockedIdentities).toBe(1);
+  });
+});
+```
+
+- [ ] Step 2: Run it, expect FAIL: `cd apps/api && npx vitest run src/jobs/backupRetention.test.ts` — the current query still filters `backupType`, so with the mocked chainable `.where()` being a no-op this particular mock-level test may actually pass spuriously today (the mock can't enforce the real SQL filter); the REAL assertion of the filter removal is in the integration test (Task 9). This unit test instead pins the *behavioral contract* (all types flow into the same retained/fetched set) so it fails once Task 9's integration proof is added and would fail if the filter were mistakenly reintroduced. Run and confirm current code still passes this one (expected — proceed to Step 3 to also remove the SQL-level filter for real, then re-verify with the integration test in Task 9).
+
+- [ ] Step 3: Implement — in `sweepUnreferencedBackupObjects`, replace the per-identity retained-rows query:
+
+```typescript
+// Storage-identity-scoped retained set — deliberately NOT filtered by
+// backupType (every mode publishes snapshots/<id>/manifest.json, see
+// docs/superpowers/specs/backup/2026-09-09-backup-gc-reclamation-design.md
+// §1 ground truth) and NOT filtered by configId (storage_identity is
+// denormalized onto the row at publish time, so it survives a later
+// providerConfig edit that would otherwise misattribute historical rows —
+// see normalizeStorageIdentity / §3.6).
+const retainedRows = await db
+  .select({ snapshotId: backupSnapshots.snapshotId })
+  .from(backupSnapshots)
+  .where(eq(backupSnapshots.storageIdentity, identity.key));
+const retainedSnapshotIds = retainedRows.map((row) => row.snapshotId);
+```
+
+  `storage_identity` is **nullable** (W01 v3 — corrected from an earlier NOT NULL assumption), so `eq(backupSnapshots.storageIdentity, identity.key)` correctly excludes NULL rows via ordinary SQL three-valued-logic (`NULL = 'x'` is unknown, never true) — this query only ever returns rows that already carry the identity string. Rows still `storage_identity IS NULL` (never dispatched with the column, or backfill skipped them because their config was edited after publication) are a **separate** root-set input handled entirely in Task 7's `identityHasUnresolvedNullRows`/self-heal logic — do not fold NULL-row handling into this query.
+
+  Remove the now-unused `or(eq(backupSnapshots.backupType, 'file'), isNull(backupSnapshots.backupType))` clause and its preceding comment block entirely (the comment claimed different backup types use a different manifest layout — confirmed factually wrong per the spec's ground truth). Remove the `BACKUP_GC_SUPPORTED_PROVIDERS`-adjacent `or`/`isNull` imports if now unused elsewhere in the file (re-check — `isNull` is still used by the `unattributedRows` query at the top of `sweepUnreferencedBackupObjects`, so keep it; drop `or` only if nothing else in the file uses it — grep first).
+
+- [ ] Step 4: Run, expect PASS: `cd apps/api && npx vitest run src/jobs/backupRetention.test.ts`
+
+- [ ] Step 5: Commit: `git add apps/api/src/jobs/backupRetention.ts apps/api/src/jobs/backupRetention.test.ts && git commit -m "fix(backup-gc): root ALL backup types via storage_identity, not just file"`
+
+### Task 4: Unreachable-identity detection and logging
+
+**Files:** Modify `apps/api/src/jobs/backupRetention.ts` (add a helper + call site inside `sweepUnreferencedBackupObjects`, after the `identities` map is built and before the per-identity loop).
+
+**Interfaces:**
+- Produces: `async function logUnreachableStorageIdentities(identities: Map<string, BackupGcStorageIdentity>): Promise<number>` — returns the count of *identities* (not rows) with no matching current config.
+
+**This task inserts a new run-level query (`identityUsage`, the 3rd `db.select(...)` overall, right after `unattributedRows` and `destinations`) that every earlier test in the file assumed didn't exist.** Per the standing rule in Global Constraints: after Step 3 below, go back to every test Task 3 added (`describe('all backup types share one retained set via storage_identity ...')`) and insert `selectQueue.push([{ storageIdentity: normalizeStorageIdentity(destination.provider, destination.providerConfig), count: 1 }]);` as the 3rd push (between `destinations` and the per-identity `retained` push) in each of its two `it`s, then re-run the whole file.
+
+- [ ] Step 1: Write the failing test — add to `backupRetention.test.ts` (new `describe`):
+
+```typescript
+describe('unreachable storage identities (no config points at them any more)', () => {
+  it('logs and counts a storage_identity with rows but no matching current config, without touching it', async () => {
+    selectQueue.push([]); // unattributedRows
+    selectQueue.push([destination]); // destinations — only ONE identity is listable
+    // groupBy query: identity usage across ALL backup_snapshots rows, including
+    // one identity no config currently produces.
+    selectQueue.push([
+      { storageIdentity: normalizeStorageIdentity(destination.provider, destination.providerConfig), count: 2 },
+      { storageIdentity: 'local::/var/orphaned-bucket-nobody-points-at', count: 5 },
+    ]);
+    selectQueue.push([]); // retained rows for the one real identity
+
+    listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([]);
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const result = await sweepUnreferencedBackupObjects();
+      expect(result.unreachableIdentities).toBe(1);
+      expect(warn.mock.calls.some(([msg]) => String(msg).includes('unreachable identity local::/var/orphaned-bucket-nobody-points-at: 5 rows'))).toBe(true);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});
+```
+
+- [ ] Step 2: Run it, expect FAIL: `cd apps/api && npx vitest run src/jobs/backupRetention.test.ts` — `result.unreachableIdentities` is `undefined`.
+
+- [ ] Step 3: Implement — add near the top of `sweepUnreferencedBackupObjects`, right after `const identities = groupBackupConfigsByStorageIdentity(destinations);`:
+
+```typescript
+import { sql } from 'drizzle-orm';
+// ... (add to the existing drizzle-orm import line)
+
+/**
+ * §3.6: rows carry the identity string they were PUBLISHED under, which
+ * survives a later providerConfig edit. An identity with rows but no current
+ * config producing that exact key is unreachable — it is never listed (no
+ * config = no provider/providerConfig to list with), so it leaks silently
+ * unless logged here. This is visibility only; reclaiming an unreachable
+ * identity needs manual tooling (spec §7, deferred).
+ */
+async function logUnreachableStorageIdentities(
+  identities: Map<string, BackupGcStorageIdentity>,
+): Promise<number> {
+  const usage = await db
+    .select({
+      storageIdentity: backupSnapshots.storageIdentity,
+      count: sql<number>`count(*)`,
+    })
+    .from(backupSnapshots)
+    .groupBy(backupSnapshots.storageIdentity);
+
+  let unreachable = 0;
+  for (const row of usage) {
+    if (identities.has(row.storageIdentity)) continue;
+    unreachable++;
+    console.warn(`[BackupGC] unreachable identity ${row.storageIdentity}: ${row.count} rows`);
+  }
+  return unreachable;
+}
+```
+
+  Call it once per run: `const unreachableIdentities = await logUnreachableStorageIdentities(identities);` placed after `identities` is built and before the unattributed-rows early-return (so it still logs even on a fully-blocked run — visibility should not depend on whether the run could otherwise proceed). Thread `unreachableIdentities` into every `return` statement of `sweepUnreferencedBackupObjects` (Task 6 finalizes the full result shape).
+
+- [ ] Step 4: Run, expect PASS: `cd apps/api && npx vitest run src/jobs/backupRetention.test.ts`
+
+- [ ] Step 5: Commit: `git add apps/api/src/jobs/backupRetention.ts apps/api/src/jobs/backupRetention.test.ts && git commit -m "feat(backup-gc): log unreachable storage identities (rows with no matching config)"`
+
+### Task 5: `orphanManifestSnapshotIds` replaces `listedManifestSnapshotIds`
+
+**Files:** Modify `apps/api/src/jobs/backupRetention.ts:805-816` (delete `listedManifestSnapshotIds`, add `orphanManifestSnapshotIds`). Test: `apps/api/src/jobs/backupRetention.test.ts:665-698` and `:699-752`.
+
+**Interfaces:**
+- Produces: `function orphanManifestSnapshotIds(groups: Map<string, BackupGcSnapshotGroup>, retainedSnapshotIds: Set<string>, retiredSnapshotIds: Map<string, string>, nowMs: number, windowMs: number): string[]`.
+
+**Per the standing rule in Global Constraints, this task's full-run tests below already include the `identityUsage` push (3rd position, right after `destinations`) that Task 4 introduced** — write them exactly as shown.
+
+- [ ] Step 1: Write the failing test — replace `backupRetention.test.ts:665-752` (both the standalone `it` and the FIX 5 `describe`) with:
+
+```typescript
+describe('orphan manifest root set (replaces the old "mark every listed manifest forever" rule)', () => {
+  it('protects a young orphan manifest (no row, no retirement) as a root', async () => {
+    selectQueue.push([]); // unattributedRows
+    selectQueue.push([destination]); // destinations
+    selectQueue.push([{ storageIdentity: normalizeStorageIdentity(destination.provider, destination.providerConfig), count: 1 }]); // identityUsage
+    selectQueue.push([]); // retained snapshots — none (row never persisted yet)
+    selectQueue.push([]); // retirements for this identity — none
+
+    fetchBackupObjectTextMock.mockResolvedValueOnce(
+      manifestJson([{ backupPath: 'snapshots/OLD/files/base.dat' }]),
+    );
+
+    const recent = new Date(Date.now() - 1 * DAY_MS); // well within the 9-day default orphan window
+    const old = JUST_PAST_MANIFESTLESS_THRESHOLD();
+    listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
+      { key: 'snapshots/NEW/manifest.json', lastModified: recent },
+      { key: 'snapshots/OLD/files/base.dat', lastModified: old }, // referenced by NEW — must survive
+    ]);
+
+    const result = await sweepUnreferencedBackupObjects();
+
+    expect(fetchBackupObjectTextMock).toHaveBeenCalledWith(expect.objectContaining({ key: 'snapshots/NEW/manifest.json' }));
+    expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled();
+    expect(result.deleted).toBe(0);
+  });
+
+  it('reclaims an orphan manifest once its manifest object clears the orphan window (default 9 days), with no retirement row', async () => {
+    selectQueue.push([]); // unattributedRows
+    selectQueue.push([destination]); // destinations
+    selectQueue.push([{ storageIdentity: normalizeStorageIdentity(destination.provider, destination.providerConfig), count: 1 }]); // identityUsage
+    selectQueue.push([]); // retained snapshots — none
+    selectQueue.push([]); // retirements — none
+
+    const pastWindow = new Date(Date.now() - 10 * DAY_MS); // past the 9-day default
+    listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
+      { key: 'snapshots/ABANDONED/manifest.json', lastModified: pastWindow },
+      { key: 'snapshots/ABANDONED/files/x.dat', lastModified: pastWindow },
+    ]);
+    deleteBackupObjectKeysMock.mockResolvedValueOnce({ deletedKeys: ['snapshots/ABANDONED/files/x.dat'], failedKeys: [] });
+    deleteBackupObjectKeysMock.mockResolvedValueOnce({ deletedKeys: ['snapshots/ABANDONED/manifest.json'], failedKeys: [] });
+
+    const result = await sweepUnreferencedBackupObjects();
+
+    // Old orphan is never fetched for its manifest content (it's garbage, not a root).
+    expect(fetchBackupObjectTextMock).not.toHaveBeenCalled();
+    expect(result.deleted).toBe(2);
+    expect(result.orphansSwept).toBe(1);
+  });
+
+  it('a manifest object with unknown last-modified is treated as young (fail-closed protect)', async () => {
+    selectQueue.push([]); // unattributedRows
+    selectQueue.push([destination]); // destinations
+    selectQueue.push([{ storageIdentity: normalizeStorageIdentity(destination.provider, destination.providerConfig), count: 1 }]); // identityUsage
+    selectQueue.push([]); // retained
+    selectQueue.push([]); // retirements
+
+    fetchBackupObjectTextMock.mockResolvedValueOnce(manifestJson([]));
+    listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
+      { key: 'snapshots/UNKNOWNAGE/manifest.json', lastModified: null },
+    ]);
+
+    const result = await sweepUnreferencedBackupObjects();
+
+    expect(fetchBackupObjectTextMock).toHaveBeenCalledWith(expect.objectContaining({ key: 'snapshots/UNKNOWNAGE/manifest.json' }));
+    expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled();
+    expect(result.deleted).toBe(0);
+  });
+});
+```
+
+  (This test drives Task 6's `sweepStorageIdentity` rewrite too — `orphanManifestSnapshotIds` alone is a pure function; write a narrower direct unit test for it as well since it's exported for testability:)
+
+```typescript
+import { orphanManifestSnapshotIds } from './backupRetention'; // add to the existing import list
+
+describe('orphanManifestSnapshotIds (pure)', () => {
+  const groups = new Map([
+    ['young', { items: [], manifestItem: { key: 'snapshots/young/manifest.json', lastModified: new Date(Date.now() - DAY_MS) } }],
+    ['old', { items: [], manifestItem: { key: 'snapshots/old/manifest.json', lastModified: new Date(Date.now() - 20 * DAY_MS) } }],
+    ['retained', { items: [], manifestItem: { key: 'snapshots/retained/manifest.json', lastModified: new Date(Date.now() - 20 * DAY_MS) } }],
+    ['retired', { items: [], manifestItem: { key: 'snapshots/retired/manifest.json', lastModified: new Date(Date.now() - DAY_MS) } }],
+    ['nomanifest', { items: [{ key: 'snapshots/nomanifest/files/a', lastModified: new Date() }], manifestItem: null }],
+  ]);
+
+  it('returns only young, unretained, unretired manifest-bearing ids', () => {
+    const ids = orphanManifestSnapshotIds(
+      groups as any,
+      new Set(['retained']),
+      new Map([['retired', 'retirement-row-id']]),
+      Date.now(),
+      9 * DAY_MS,
+    );
+    expect(ids.sort()).toEqual(['young']);
+  });
+});
+```
+
+- [ ] Step 2: Run it, expect FAIL: `cd apps/api && npx vitest run src/jobs/backupRetention.test.ts` — `orphanManifestSnapshotIds is not exported`, `result.orphansSwept` undefined.
+
+- [ ] Step 3: Implement — replace `backupRetention.ts:805-816`:
+
+```typescript
+/**
+ * §3.4 orphan root set: a listed manifest-bearing prefix with no
+ * backup_snapshots row and no retirement row is a root ONLY while its
+ * manifest object is younger than the orphan window — giving reconcile
+ * (backupSnapshotReconcile.ts) time to adopt a completed-but-unpersisted
+ * snapshot into a real row before GC would otherwise reclaim it. A manifest
+ * object with no last-modified data cannot have its age disproven, so it is
+ * fail-closed treated as YOUNG (protected), never as old.
+ *
+ * Replaces the old listedManifestSnapshotIds, which marked EVERY listed
+ * manifest live FOREVER to guard the agent's listing-based dedup-base
+ * selection race. That race no longer exists: the server now picks and
+ * LEASES the incremental base itself (base_snapshot_id / publish_lease_expires_at,
+ * W01) — an in-flight backup's base is protected by its own retained DB row
+ * and lease, not by an unbounded listing heuristic, so an orphan manifest
+ * past the window really is garbage (or a retirement will already exist).
+ */
+function orphanManifestSnapshotIds(
+  groups: Map<string, BackupGcSnapshotGroup>,
+  retainedSnapshotIds: Set<string>,
+  retiredSnapshotIds: Map<string, string>,
+  nowMs: number,
+  windowMs: number,
+): string[] {
+  const ids: string[] = [];
+  const threshold = nowMs - windowMs;
+  for (const [snapshotId, group] of groups) {
+    if (!group.manifestItem) continue;
+    if (retainedSnapshotIds.has(snapshotId)) continue; // already a root via its DB row
+    if (retiredSnapshotIds.has(snapshotId)) continue; // retired -> never a root, regardless of age
+    const lm = group.manifestItem.lastModified;
+    if (!lm || lm.getTime() > threshold) ids.push(snapshotId);
+  }
+  return ids;
+}
+```
+
+  Export it (`export function orphanManifestSnapshotIds`) for the direct unit test. Wiring into `sweepStorageIdentity`/`sweepUnreferencedBackupObjects` (including `orphansSwept` accounting and the retired-set plumbing) happens in Task 6 — this task only needs the pure function to exist and be independently correct; the full-run tests above will stay red until Task 6 lands. Note that in-file ordering matters: keep this function right where `listedManifestSnapshotIds` was (between `groupListingBySnapshotId` and `markLiveBackupObjects`), since `sweepStorageIdentity` right below it is what calls it next.
+
+- [ ] Step 4: Run, expect the pure-function test to PASS and the full-run tests to remain red (expected until Task 6): `cd apps/api && npx vitest run src/jobs/backupRetention.test.ts -t "orphanManifestSnapshotIds (pure)"`
+
+- [ ] Step 5: Commit: `git add apps/api/src/jobs/backupRetention.ts apps/api/src/jobs/backupRetention.test.ts && git commit -m "feat(backup-gc): add orphanManifestSnapshotIds (age-windowed), remove unbounded listedManifestSnapshotIds"`
+
+### Task 6: Redis skip-set for delete-cap fairness
+
+**Files:** Modify `apps/api/src/jobs/backupRetention.ts` (add helpers near the top, after imports).
+
+**Per the standing rule in Global Constraints, this task's tests below already include the `identityUsage` push (3rd position) that Task 4 introduced** — write them exactly as shown.
+
+**Interfaces:**
+- Consumes: `getRedis(): Redis | null`, `isRedisAvailable(): boolean` from `../services/redis`.
+- Produces: `async function loadGcFailedKeySkipSet(identityKey: string): Promise<Set<string>>`, `async function recordGcFailedKeys(identityKey: string, failedKeys: { key: string; error: string }[]): Promise<void>`.
+
+- [ ] Step 1: Write the failing test — add to `backupRetention.test.ts` a new mock + describe block. First add the Redis mock alongside the existing `vi.mock` calls near the top of the file:
+
+```typescript
+const redisSaddMock = vi.fn();
+const redisExpireMock = vi.fn();
+const redisSmembersMock = vi.fn();
+let redisAvailableForTest = true;
+vi.mock('../services/redis', () => ({
+  isRedisAvailable: () => redisAvailableForTest,
+  getRedis: () => (redisAvailableForTest ? { sadd: redisSaddMock, expire: redisExpireMock, smembers: redisSmembersMock } : null),
+}));
+```
+
+  Then:
+
+```typescript
+describe('GC failed-key skip set (cap fairness)', () => {
+  beforeEach(() => {
+    redisAvailableForTest = true;
+    redisSmembersMock.mockResolvedValue([]);
+  });
+
+  it('excludes a previously-failed key from candidates on a later run without re-attempting it', async () => {
+    redisSmembersMock.mockResolvedValueOnce(['snapshots/ABANDONED/files/locked.dat']);
+
+    selectQueue.push([]); // unattributedRows
+    selectQueue.push([destination]); // destinations
+    selectQueue.push([{ storageIdentity: normalizeStorageIdentity(destination.provider, destination.providerConfig), count: 1 }]); // identityUsage
+    selectQueue.push([]); // retained
+    selectQueue.push([]); // retirements
+
+    const pastWindow = new Date(Date.now() - 10 * DAY_MS);
+    listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
+      { key: 'snapshots/ABANDONED/manifest.json', lastModified: pastWindow },
+      { key: 'snapshots/ABANDONED/files/locked.dat', lastModified: pastWindow }, // in the skip set — never attempted
+      { key: 'snapshots/ABANDONED/files/free.dat', lastModified: pastWindow },
+    ]);
+    deleteBackupObjectKeysMock.mockResolvedValueOnce({ deletedKeys: ['snapshots/ABANDONED/files/free.dat'], failedKeys: [] });
+
+    await sweepUnreferencedBackupObjects();
+
+    expect(deleteBackupObjectKeysMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ keys: expect.arrayContaining(['snapshots/ABANDONED/files/locked.dat']) }),
+    );
+  });
+
+  it('records a failed key with a 7-day TTL after deleteBackupObjectKeys reports it', async () => {
+    selectQueue.push([]);
+    selectQueue.push([destination]);
+    selectQueue.push([{ storageIdentity: normalizeStorageIdentity(destination.provider, destination.providerConfig), count: 1 }]); // identityUsage
+    selectQueue.push([]);
+    selectQueue.push([]);
+
+    const pastWindow = new Date(Date.now() - 10 * DAY_MS);
+    listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
+      { key: 'snapshots/ABANDONED/manifest.json', lastModified: pastWindow },
+      { key: 'snapshots/ABANDONED/files/locked.dat', lastModified: pastWindow },
+    ]);
+    deleteBackupObjectKeysMock.mockResolvedValueOnce({
+      deletedKeys: [],
+      failedKeys: [{ key: 'snapshots/ABANDONED/files/locked.dat', error: 'object-lock' }],
+    });
+
+    await sweepUnreferencedBackupObjects();
+
+    expect(redisSaddMock).toHaveBeenCalledWith(expect.stringMatching(/^backup-gc:failed:/), 'snapshots/ABANDONED/files/locked.dat');
+    expect(redisExpireMock).toHaveBeenCalledWith(expect.stringMatching(/^backup-gc:failed:/), 7 * 24 * 60 * 60);
+  });
+
+  it('degrades to no skip set (proceeds normally) when Redis is unavailable', async () => {
+    redisAvailableForTest = false;
+    selectQueue.push([]);
+    selectQueue.push([destination]);
+    selectQueue.push([{ storageIdentity: normalizeStorageIdentity(destination.provider, destination.providerConfig), count: 1 }]); // identityUsage
+    selectQueue.push([]);
+    selectQueue.push([]);
+    listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([]);
+    const result = await sweepUnreferencedBackupObjects();
+    expect(result.deleted).toBe(0);
+  });
+});
+```
+
+- [ ] Step 2: Run it, expect FAIL: `cd apps/api && npx vitest run src/jobs/backupRetention.test.ts` — no skip-set behavior exists yet, `redisSaddMock` never called.
+
+- [ ] Step 3: Implement — add near the top of `backupRetention.ts`, after the existing imports:
+
+```typescript
+import { createHash } from 'node:crypto';
+import { getRedis, isRedisAvailable } from '../services/redis';
+
+const BACKUP_GC_FAILED_KEY_TTL_SECONDS = 7 * 24 * 60 * 60;
+
+function backupGcFailedKeySetName(identityKey: string): string {
+  return `backup-gc:failed:${createHash('sha1').update(identityKey).digest('hex')}`;
+}
+
+/** Fails open to an empty set (never blocks the sweep) if Redis is unavailable or errors. */
+async function loadGcFailedKeySkipSet(identityKey: string): Promise<Set<string>> {
+  if (!isRedisAvailable()) return new Set();
+  const redis = getRedis();
+  if (!redis) return new Set();
+  try {
+    const members = await redis.smembers(backupGcFailedKeySetName(identityKey));
+    return new Set(members);
+  } catch (error) {
+    console.warn(`[BackupGC] Failed to load skip-set for identity ${identityKey} — proceeding without it:`, error);
+    return new Set();
+  }
+}
+
+/** Best-effort; a Redis failure here must never fail the sweep that already ran. */
+async function recordGcFailedKeys(
+  identityKey: string,
+  failedKeys: { key: string; error: string }[],
+): Promise<void> {
+  if (failedKeys.length === 0 || !isRedisAvailable()) return;
+  const redis = getRedis();
+  if (!redis) return;
+  const setKey = backupGcFailedKeySetName(identityKey);
+  try {
+    await redis.sadd(setKey, ...failedKeys.map((f) => f.key));
+    await redis.expire(setKey, BACKUP_GC_FAILED_KEY_TTL_SECONDS);
+  } catch (error) {
+    console.warn(`[BackupGC] Failed to record skip-set entries for identity ${identityKey}:`, error);
+  }
+}
+```
+
+  Wiring `loadGcFailedKeySkipSet`/`recordGcFailedKeys` into `sweepStorageIdentity`'s candidate filtering and post-delete bookkeeping happens in Task 7 (the full rewrite) — this task only needs the two functions to exist and behave correctly in isolation; use `vi.mock` at the file level as shown so Task 6's own tests exercise them end-to-end once Task 7 wires them in. If these tests are still red after this step alone (expected, since nothing calls them yet), that's fine — proceed to Task 7 before re-running.
+
+- [ ] Step 4: Run, expect PASS (after Task 7 wires the call sites — mark this step's real verification as deferred to Task 7's Step 4, but confirm no syntax/type errors now): `cd apps/api && npx tsc --noEmit -p apps/api/tsconfig.json` (or the project's equivalent noEmit check) to confirm the new helpers compile cleanly before Task 7 wires them in.
+
+- [ ] Step 5: Commit: `git add apps/api/src/jobs/backupRetention.ts apps/api/src/jobs/backupRetention.test.ts && git commit -m "feat(backup-gc): add Redis-backed failed-key skip set for delete-cap fairness"`
+
+### Task 7: Rewrite `sweepStorageIdentity` + `sweepUnreferencedBackupObjects` — NULL-identity self-heal, ORPHAN_WINDOW, stronger manifest-last rule, capability gate, and §3.7 transaction-boundary split
+
+**IMPORTANT — supersedes earlier tasks' test scaffolding.** Tasks 3-6 added tests against an interim shape of `sweepUnreferencedBackupObjects` that queried the DB with a fixed, flat sequence of `db.select(...)` calls (matched 1:1 by `selectQueue.push(...)` in test order). This task changes that sequence for real (see the finalized per-identity query order below) **and** splits every DB access into its own short `withSystemDbAccessContext` call per §3.7, which the hand-rolled `chainable`/`selectQueue` mock does not distinguish from an un-wrapped call (the mock replaces `db` itself, not the context wrapper, so `withSystemDbAccessContext(fn)` calling straight through to `fn()` under the mock is transparent — no mock changes needed for the context wrapping itself). This step's implementation, once done, requires going back through every `selectQueue.push(...)` sequence added in Tasks 3-6 and updating it to match the **finalized per-identity read order**:
+1. `unattributedRows` (run-level, once).
+2. `destinations` (run-level, once).
+3. `identityUsage` — the `GROUP BY storageIdentity` query for `logUnreachableStorageIdentities` (run-level, once).
+4. Per identity, in this order: (a) `retainedRows` (`storageIdentity = I`), (b) `nullIdentityRows` (`storageIdentity IS NULL AND configId IN I.configIds`), (c) `retirementRows` (`storageIdentity = I AND sweptAt IS NULL`), (d) `capabilityRows` (the legacy-helper job/device join).
+Do this fix-up as part of this task's Step 1 (the new tests below already use the finalized order; go back and add the missing `selectQueue.push([])` calls for the NULL-identity-rows query — step (b) above — to every test from Tasks 3, 5, and 6 that currently pushes only 4 per-identity-adjacent items instead of 5, or re-run the full suite after Step 3's implementation and fix whatever the mismatch count reveals).
+
+**Files:** Modify `apps/api/src/jobs/backupRetention.ts:873-1110` (full rewrite of both functions plus the `BackupGcResult` type at `~550`).
+
+**Interfaces:**
+- Consumes: `backupSnapshotRetirements` from `../db/schema` (W01), `devices` from `../db/schema`, `backupHelperSupportsServerBase` from `../services/backupHelperCapabilities`, `withSystemDbAccessContext` from `../db`, `resolveBackupBaseLeaseMs` from `../services/backupGcKnobs`, everything from Tasks 1-6.
+- Produces: `export type BackupGcResult = { deleted: number; skippedIdentities: number; blockedIdentities: number; retiredSwept: number; orphansSwept: number; deferredIdentities: number; unreachableIdentities: number };`, a `sweepStorageIdentity` that is now a **pure storage-and-compute function with zero DB calls** (all DB reads/writes happen in its caller, split into short contexts), and the same `export async function sweepUnreferencedBackupObjects(): Promise<BackupGcResult>` — internally phase-split per §3.7, but its name and signature are unchanged so W01's `backupWorker.ts` call site (`const gcResult = await sweepUnreferencedBackupObjects();`) needs no edit.
+
+- [ ] Step 1: Write the failing test — first extend the file's existing `vi.mock('../db', () => ({ db: mockDb }));` (top of `backupRetention.test.ts`) to also provide the two new `../db` imports this task adds, so the mock doesn't throw `withSystemDbAccessContext is not a function`:
+
+```typescript
+const assertOutsideHeldDbContextMock = vi.fn();
+vi.mock('../db', () => ({
+  db: mockDb,
+  withSystemDbAccessContext: (fn: () => unknown) => fn(), // pass-through under the mock — no real context to open
+  assertOutsideHeldDbContext: assertOutsideHeldDbContextMock,
+}));
+```
+
+  Then add a small tripwire test proving the guard is wired (mirrors `apps/api/src/services/urlSafety.tripwire.test.ts`'s pattern — spy on the guard, assert it fires before the storage call):
+
+```typescript
+describe('§3.7 held-context tripwire', () => {
+  beforeEach(() => assertOutsideHeldDbContextMock.mockClear());
+
+  it('calls assertOutsideHeldDbContext before any storage call in sweepStorageIdentity', async () => {
+    selectQueue.push([]); // unattributedRows
+    selectQueue.push([destination]); // destinations
+    selectQueue.push([{ storageIdentity: normalizeStorageIdentity(destination.provider, destination.providerConfig), count: 1 }]); // identityUsage
+    selectQueue.push([]); // retained
+    selectQueue.push([]); // NULL-identity rows
+    selectQueue.push([]); // retirements
+    selectQueue.push([]); // capability check
+    listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([]);
+
+    await sweepUnreferencedBackupObjects();
+
+    expect(assertOutsideHeldDbContextMock).toHaveBeenCalledWith('backupGC.sweepStorageIdentity');
+    // The guard is a no-op under the mock (it doesn't throw), so the sweep still
+    // completes — this test only proves the call site exists, not the guard's
+    // real held-context detection (that's exercised by db/index.ts's own suite).
+  });
+});
+```
+
+  Now add these scenarios to `backupRetention.test.ts` (the earlier tasks' tests already exercise pieces of this; these close the remaining gaps: retirement-immediate deletion, the stronger manifest-last rule, the capability gate, the NULL-identity self-heal, and the unresolved-rows gate). Every test below pushes 5 per-identity queries in the finalized order: retained rows, NULL-identity rows, retirements, capability rows — see this task's header note:
+
+```typescript
+describe('retirement-aware sweep (§3.4 v3)', () => {
+  it('reclaims a retired prefix immediately regardless of age, and marks the retirement swept once empty', async () => {
+    selectQueue.push([]); // unattributedRows
+    selectQueue.push([destination]); // destinations
+    selectQueue.push([{ storageIdentity: normalizeStorageIdentity(destination.provider, destination.providerConfig), count: 1 }]); // identityUsage
+    selectQueue.push([]); // retained snapshots — the row was already deleted by retention
+    selectQueue.push([]); // NULL-identity rows for this identity — none
+    selectQueue.push([{ id: 'retirement-1', snapshotId: 'RETIRED1' }]); // retirements for this identity, sweptAt IS NULL
+    selectQueue.push([]); // legacy-helper capability check — no jobs on this identity -> not deferred
+
+    const veryRecent = new Date(Date.now() - 1000); // 1 second old — would be protected under every OTHER rule
+    listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
+      { key: 'snapshots/RETIRED1/manifest.json', lastModified: veryRecent },
+      { key: 'snapshots/RETIRED1/files/x.dat', lastModified: veryRecent },
+    ]);
+    deleteBackupObjectKeysMock.mockResolvedValueOnce({ deletedKeys: ['snapshots/RETIRED1/files/x.dat'], failedKeys: [] });
+    deleteBackupObjectKeysMock.mockResolvedValueOnce({ deletedKeys: ['snapshots/RETIRED1/manifest.json'], failedKeys: [] });
+
+    const result = await sweepUnreferencedBackupObjects();
+
+    expect(result.deleted).toBe(2);
+    expect(result.retiredSwept).toBe(1);
+    // Non-manifest phase first, manifest phase second.
+    expect(deleteBackupObjectKeysMock.mock.calls[0][0].keys).toEqual(['snapshots/RETIRED1/files/x.dat']);
+    expect(deleteBackupObjectKeysMock.mock.calls[1][0].keys).toEqual(['snapshots/RETIRED1/manifest.json']);
+  });
+
+  it('does NOT delete the manifest when a non-manifest key is skip-set-excluded, even though none FAILED this run (stronger v3 rule)', async () => {
+    selectQueue.push([]);
+    selectQueue.push([destination]);
+    selectQueue.push([{ storageIdentity: normalizeStorageIdentity(destination.provider, destination.providerConfig), count: 1 }]);
+    selectQueue.push([]); // retained
+    selectQueue.push([]); // NULL-identity rows
+    selectQueue.push([{ id: 'retirement-2', snapshotId: 'RETIRED2' }]);
+    selectQueue.push([]); // capability check
+
+    redisSmembersMock.mockResolvedValueOnce(['snapshots/RETIRED2/files/skipme.dat']); // already in the failed-key skip set
+
+    const t = new Date(Date.now() - 1000);
+    listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
+      { key: 'snapshots/RETIRED2/manifest.json', lastModified: t },
+      { key: 'snapshots/RETIRED2/files/skipme.dat', lastModified: t },
+    ]);
+    // The skip-set-excluded key is never even attempted, so deleteBackupObjectKeys
+    // is called zero times for the non-manifest phase — nothing to delete once
+    // the sole candidate is filtered out — and the manifest phase never runs
+    // because a deletable-but-skipped key still "remains" in the prefix.
+    deleteBackupObjectKeysMock.mockResolvedValueOnce({ deletedKeys: [], failedKeys: [] });
+
+    const result = await sweepUnreferencedBackupObjects();
+
+    expect(deleteBackupObjectKeysMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ keys: expect.arrayContaining(['snapshots/RETIRED2/manifest.json']) }),
+    );
+    expect(result.retiredSwept).toBe(0);
+  });
+
+  it('does NOT delete the manifest when the delete cap truncates the non-manifest phase (stronger v3 rule: capped, not just failed)', async () => {
+    selectQueue.push([]);
+    selectQueue.push([destination]);
+    selectQueue.push([{ storageIdentity: normalizeStorageIdentity(destination.provider, destination.providerConfig), count: 1 }]);
+    selectQueue.push([]);
+    selectQueue.push([]);
+    selectQueue.push([{ id: 'retirement-4', snapshotId: 'RETIRED4' }]);
+    selectQueue.push([]);
+
+    const prevCap = process.env.BACKUP_GC_MAX_DELETES_PER_RUN;
+    process.env.BACKUP_GC_MAX_DELETES_PER_RUN = '1'; // only 1 delete allowed this whole run
+    try {
+      const t = new Date(Date.now() - 1000);
+      listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
+        { key: 'snapshots/RETIRED4/manifest.json', lastModified: t },
+        { key: 'snapshots/RETIRED4/files/a.dat', lastModified: t },
+        { key: 'snapshots/RETIRED4/files/b.dat', lastModified: t }, // capped out — never attempted this run
+      ]);
+      deleteBackupObjectKeysMock.mockResolvedValueOnce({ deletedKeys: ['snapshots/RETIRED4/files/a.dat'], failedKeys: [] });
+
+      const result = await sweepUnreferencedBackupObjects();
+
+      expect(deleteBackupObjectKeysMock).toHaveBeenCalledTimes(1); // manifest phase never runs — cap exhausted, b.dat still present
+      expect(result.retiredSwept).toBe(0);
+    } finally {
+      if (prevCap === undefined) delete process.env.BACKUP_GC_MAX_DELETES_PER_RUN; else process.env.BACKUP_GC_MAX_DELETES_PER_RUN = prevCap;
+    }
+  });
+
+  it('defers reclamation on an identity with a legacy (pre-server-base) helper on a PENDING job of any age, running only the rooted rule', async () => {
+    selectQueue.push([]); // unattributedRows
+    selectQueue.push([destination]);
+    selectQueue.push([{ storageIdentity: normalizeStorageIdentity(destination.provider, destination.providerConfig), count: 1 }]);
+    selectQueue.push([]); // retained
+    selectQueue.push([]); // NULL-identity rows
+    selectQueue.push([{ id: 'retirement-3', snapshotId: 'RETIRED3' }]); // a retirement exists...
+    // ...but a PENDING job (any age, per v3's widened criteria) on this
+    // identity is still served by a pre-0.112.0 helper.
+    selectQueue.push([{ deviceId: 'device-legacy', backupVersion: '0.109.0' }]);
+
+    const t = new Date(Date.now() - 1000);
+    listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
+      { key: 'snapshots/RETIRED3/manifest.json', lastModified: t },
+      { key: 'snapshots/RETIRED3/files/x.dat', lastModified: t },
+    ]);
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const result = await sweepUnreferencedBackupObjects();
+      expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled();
+      expect(result.deferredIdentities).toBe(1);
+      expect(result.retiredSwept).toBe(0);
+      expect(warn.mock.calls.some(([msg]) => String(msg).includes('reclamation deferred: legacy helper device-legacy 0.109.0'))).toBe(true);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});
+
+describe('NULL storage_identity self-heal and unresolved-rows gate (§3.6/§3.4 v3)', () => {
+  it('self-heals a NULL-identity row once its manifest is found in the listing, and treats it as rooted this run', async () => {
+    selectQueue.push([]); // unattributedRows
+    selectQueue.push([destination]); // destinations
+    selectQueue.push([{ storageIdentity: normalizeStorageIdentity(destination.provider, destination.providerConfig), count: 1 }]); // identityUsage
+    selectQueue.push([]); // retained (storageIdentity = I) — none yet, this row is still NULL
+    selectQueue.push([{ snapshotId: 'HEALME' }]); // NULL-identity rows mapped to this identity's configIds
+    selectQueue.push([]); // retirements — none
+    selectQueue.push([]); // capability check — no legacy helper
+
+    fetchBackupObjectTextMock.mockResolvedValueOnce(manifestJson([]));
+    const t = new Date(Date.now() - DAY_MS);
+    listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
+      { key: 'snapshots/HEALME/manifest.json', lastModified: t }, // found — resolvable
+    ]);
+
+    const result = await sweepUnreferencedBackupObjects();
+
+    expect(fetchBackupObjectTextMock).toHaveBeenCalledWith(expect.objectContaining({ key: 'snapshots/HEALME/manifest.json' }));
+    expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled(); // rooted -> protected, not swept
+  });
+
+  it('defers ALL retired/orphan reclamation on an identity with an unresolved NULL-identity row, even though a retirement exists', async () => {
+    selectQueue.push([]); // unattributedRows
+    selectQueue.push([destination]);
+    selectQueue.push([{ storageIdentity: normalizeStorageIdentity(destination.provider, destination.providerConfig), count: 1 }]);
+    selectQueue.push([]); // retained — none
+    selectQueue.push([{ snapshotId: 'NEVERWRITTEN' }]); // a NULL row mapped here, but its manifest never shows up in the listing
+    selectQueue.push([{ id: 'retirement-5', snapshotId: 'RETIRED5' }]); // a genuine retirement, on a DIFFERENT snapshot
+    selectQueue.push([]); // capability check — no legacy helper
+
+    const t = new Date(Date.now() - 1000);
+    listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
+      { key: 'snapshots/RETIRED5/manifest.json', lastModified: t },
+      { key: 'snapshots/RETIRED5/files/x.dat', lastModified: t },
+      // Note: 'snapshots/NEVERWRITTEN/...' never appears — its NULL row stays unresolved.
+    ]);
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const result = await sweepUnreferencedBackupObjects();
+      // Even though RETIRED5's retirement is real and its prefix is listed,
+      // the WHOLE identity is deferred to rooted-only this run because of the
+      // unresolved NULL row — RETIRED5 is untouched.
+      expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled();
+      expect(result.retiredSwept).toBe(0);
+      expect(warn.mock.calls.some(([msg]) => String(msg).includes('identity deferred: 1 unresolved rows'))).toBe(true);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});
+```
+
+- [ ] Step 2: Run it, expect FAIL: `cd apps/api && npx vitest run src/jobs/backupRetention.test.ts` — `result.retiredSwept`/`deferredIdentities` undefined, retirement/capability/NULL-identity queries never issued.
+
+- [ ] Step 3: Implement — full replacement of `backupRetention.ts:550` (type) and `:873-1110` (both functions), split per §3.7 into short contexts for DB work and depth-0 storage calls:
+
+```typescript
+export type BackupGcResult = {
+  deleted: number;
+  skippedIdentities: number;
+  blockedIdentities: number;
+  retiredSwept: number;
+  orphansSwept: number;
+  deferredIdentities: number;
+  unreachableIdentities: number;
+};
+```
+
+```typescript
+async function deleteCandidatesWithCap(
+  identity: { provider: string; providerConfig: unknown },
+  candidates: BackupObjectListing[],
+  cap: number,
+  skipSet: Set<string>,
+): Promise<{ deletedKeys: string[]; failedKeys: { key: string; error: string }[] }> {
+  const eligible = candidates.filter((c) => !skipSet.has(c.key));
+  if (eligible.length === 0 || cap <= 0) return { deletedKeys: [], failedKeys: [] };
+  eligible.sort((a, b) => (a.lastModified?.getTime() ?? 0) - (b.lastModified?.getTime() ?? 0));
+  const toDelete = eligible.slice(0, cap).map((c) => c.key);
+  return deleteBackupObjectKeys({ provider: identity.provider, providerConfig: identity.providerConfig, keys: toDelete });
+}
+
+function manifestOlderThanWindow(item: BackupObjectListing, nowMs: number, windowMs: number): boolean {
+  if (!item.lastModified) return false; // unknown age -> not provably old; orphanManifestSnapshotIds already protects it
+  return item.lastModified.getTime() <= nowMs - windowMs;
+}
+
+/**
+ * §3.7: pure storage-and-compute — every DB read this needs (retained ids,
+ * NULL-identity ids, retirement map, the legacy-helper verdict) is gathered
+ * by the caller in a short DB context BEFORE this runs; every DB write this
+ * produces (self-heal, retirement-swept) is applied by the caller in a
+ * short DB context AFTER this returns. This function itself never touches
+ * `db` — only `listBackupObjectsUnderPrefix` / `fetchBackupObjectText` /
+ * `deleteBackupObjectKeys` (storage calls) and Redis (skip-set), so nothing
+ * here can hold a Postgres transaction open across a slow S3 call.
+ */
+async function sweepStorageIdentity(
+  identity: { key: string; provider: string; providerConfig: unknown },
+  retainedSnapshotIds: string[],
+  nullIdentitySnapshotIds: string[], // storage_identity IS NULL rows whose configId maps to this identity
+  retiredSnapshotIds: Map<string, string>, // snapshotId -> retirement row id, sweptAt IS NULL only
+  nowMs: number,
+  deletesRemaining: number,
+  graceMs: number,
+  orphanWindowMs: number,
+  manifestlessWindowMs: number,
+  restrictToRootedOnly: boolean, // true if EITHER the capability gate OR the unresolved-NULL-rows gate applies
+): Promise<{
+  deleted: number;
+  retiredSwept: string[]; // retirement row ids to mark swept (caller writes these)
+  orphansSwept: number;
+  selfHealSnapshotIds: string[]; // NULL-identity snapshot ids whose manifest was found (caller writes storage_identity)
+  unresolvedNullIdentityCount: number; // NULL-identity rows that did NOT resolve this run
+  deletesUsed: number;
+}> {
+  // §3.7 guard: reuse the existing #1105 tripwire (apps/api/src/db/index.ts) —
+  // the same mechanism urlSafety.ts/bullmqQueue.ts already use before a slow
+  // network primitive — to catch (warn in prod, throw under
+  // DB_CONTEXT_TRIPWIRE_STRICT) a caller that invokes this function from
+  // inside an open withDbAccessContext/withSystemDbAccessContext. This is a
+  // defense-in-depth check on the consumed W01 interface (the worker calls
+  // sweepUnreferencedBackupObjects at depth 0), not a replacement for it —
+  // see "Depends on".
+  assertOutsideHeldDbContext('backupGC.sweepStorageIdentity');
+
+  const listing = await listBackupObjectsUnderPrefix({
+    provider: identity.provider,
+    providerConfig: identity.providerConfig,
+    prefix: backupSnapshotRootPrefix(),
+  });
+  const groups = groupListingBySnapshotId(listing);
+
+  // Self-heal resolution: a NULL-identity row is resolvable this run iff its
+  // manifest is present in the listing (proves it belongs to THIS identity).
+  // "Unresolved" can only be known AFTER the listing (not before), which is
+  // why the unresolved-rows gate below is computed HERE, not by the caller.
+  const selfHealSnapshotIds = nullIdentitySnapshotIds.filter((id) => groups.get(id)?.manifestItem);
+  const unresolvedNullIdentityCount = nullIdentitySnapshotIds.length - selfHealSnapshotIds.length;
+  // §3.6: while ANY NULL-identity row mapped to this identity is unresolved,
+  // the WHOLE identity runs rooted-only this run — combined with the
+  // capability gate via OR (either reason alone is sufficient to defer).
+  const runRootedOnly = restrictToRootedOnly || unresolvedNullIdentityCount > 0;
+
+  const rootedIds = new Set([...retainedSnapshotIds, ...selfHealSnapshotIds]);
+  for (const id of orphanManifestSnapshotIds(groups, rootedIds, retiredSnapshotIds, nowMs, orphanWindowMs)) {
+    rootedIds.add(id);
+  }
+
+  const liveSet = await markLiveBackupObjects(identity, rootedIds);
+  if (liveSet === null) {
+    throw new Error('mark phase failed — see prior log line for the specific snapshot/manifest');
+  }
+
+  const skipSet = await loadGcFailedKeySkipSet(identity.key);
+  const graceThreshold = nowMs - graceMs;
+  const manifestlessThreshold = nowMs - manifestlessWindowMs;
+
+  let deleted = 0;
+  const retiredSwept: string[] = [];
+  let orphansSwept = 0;
+  let remaining = deletesRemaining;
+
+  for (const [snapshotId, group] of groups) {
+    if (remaining <= 0) break;
+
+    if (rootedIds.has(snapshotId)) {
+      // Rooted prefix: unchanged per-object 48h grace rule.
+      const candidates = group.items.filter(
+        (item) => !liveSet.has(item.key) && item.lastModified && item.lastModified.getTime() <= graceThreshold,
+      );
+      const { deletedKeys } = await deleteCandidatesWithCap(identity, candidates, remaining, skipSet);
+      deleted += deletedKeys.length;
+      remaining -= deletedKeys.length;
+      continue;
+    }
+
+    if (!group.manifestItem) {
+      // Manifest-less (partial/resumable) prefix — unchanged prefix-granularity
+      // protection for the agent's journal lifetime, regardless of either gate
+      // (this rule predates and is independent of §3.4's new unrooted-prefix
+      // reclamation).
+      let newestMs: number | null = null;
+      let hasUnknownAge = false;
+      for (const item of group.items) {
+        if (!item.lastModified) { hasUnknownAge = true; break; }
+        const ms = item.lastModified.getTime();
+        if (newestMs === null || ms > newestMs) newestMs = ms;
+      }
+      if (hasUnknownAge || newestMs === null || newestMs > manifestlessThreshold) continue;
+      const candidates = group.items.filter((item) => !liveSet.has(item.key));
+      const { deletedKeys } = await deleteCandidatesWithCap(identity, candidates, remaining, skipSet);
+      deleted += deletedKeys.length;
+      remaining -= deletedKeys.length;
+      continue;
+    }
+
+    // Manifest-bearing, not rooted -> must be retired or an old orphan (an
+    // orphan younger than the window, or a resolved self-heal id, would
+    // already be in rootedIds above).
+    if (runRootedOnly) continue; // capability gate OR unresolved-rows gate: leave unrooted prefixes alone this run
+
+    const isRetired = retiredSnapshotIds.has(snapshotId);
+    const isOldOrphan = !isRetired && manifestOlderThanWindow(group.manifestItem, nowMs, orphanWindowMs);
+    if (!isRetired && !isOldOrphan) continue; // defensive; should be unreachable given rootedIds above
+
+    const manifestKey = group.manifestItem.key;
+    const nonLiveItems = group.items.filter((item) => !liveSet.has(item.key));
+    const nonManifestNonLive = nonLiveItems.filter((item) => item.key !== manifestKey);
+
+    const nonManifestResult = await deleteCandidatesWithCap(identity, nonManifestNonLive, remaining, skipSet);
+    deleted += nonManifestResult.deletedKeys.length;
+    remaining -= nonManifestResult.deletedKeys.length;
+    if (nonManifestResult.failedKeys.length > 0) {
+      await recordGcFailedKeys(identity.key, nonManifestResult.failedKeys);
+    }
+
+    // v3 manifest-last rule: NOT "zero failedKeys" — the manifest is a
+    // candidate only when NO deletable non-manifest key remains at all,
+    // whatever the reason (failed, cap-truncated, or skip-set-excluded).
+    const remainingNonManifest = nonManifestNonLive.filter(
+      (item) => !nonManifestResult.deletedKeys.includes(item.key),
+    );
+
+    let manifestDeletedThisRun = false;
+    const manifestIsCandidate = remainingNonManifest.length === 0 && !liveSet.has(manifestKey) && remaining > 0;
+    if (manifestIsCandidate) {
+      const manifestResult = await deleteCandidatesWithCap(identity, [group.manifestItem], remaining, skipSet);
+      deleted += manifestResult.deletedKeys.length;
+      remaining -= manifestResult.deletedKeys.length;
+      manifestDeletedThisRun = manifestResult.deletedKeys.length > 0;
+      if (manifestResult.failedKeys.length > 0) {
+        await recordGcFailedKeys(identity.key, manifestResult.failedKeys);
+      }
+    }
+
+    const deletedThisPass = new Set([...nonManifestResult.deletedKeys, ...(manifestDeletedThisRun ? [manifestKey] : [])]);
+    const stillPresent = nonLiveItems.filter((item) => !deletedThisPass.has(item.key));
+    const prefixEmpty = stillPresent.length === 0;
+
+    if (isRetired && prefixEmpty) {
+      retiredSwept.push(retiredSnapshotIds.get(snapshotId)!);
+    } else if (!isRetired && isOldOrphan && prefixEmpty) {
+      orphansSwept++;
+    }
+  }
+
+  return { deleted, retiredSwept, orphansSwept, selfHealSnapshotIds, unresolvedNullIdentityCount, deletesUsed: deletesRemaining - remaining };
+}
+
+/**
+ * §3.4 capability gate: unrooted-prefix reclamation (retired + old-orphan
+ * deletion) on an identity is enabled only when every device with a
+ * `backup_jobs` row on this identity that is `pending`/`running` (ANY age —
+ * a helper upgrade kills any run in progress, so the CURRENT version attests
+ * the running helper) OR created in the last 30 days reports a helper >=
+ * BACKUP_SERVER_BASE_MIN_HELPER_VERSION. A job is "on this identity" via its
+ * own `storageIdentity` column (stamped at dispatch) when present, or by
+ * `configId` membership for legacy jobs that predate that column.
+ */
+async function identityHasLegacyHelper(
+  identity: { key: string; configIds: string[] },
+  nowMs: number,
+): Promise<{ deferred: boolean; deviceId?: string; version?: string | null }> {
+  const cutoff = new Date(nowMs - 30 * 24 * 60 * 60 * 1000);
+  const rows = await db
+    .selectDistinct({ deviceId: backupJobs.deviceId, backupVersion: devices.backupVersion })
+    .from(backupJobs)
+    .innerJoin(devices, eq(backupJobs.deviceId, devices.id))
+    .where(and(
+      or(
+        eq(backupJobs.storageIdentity, identity.key),
+        and(isNull(backupJobs.storageIdentity), inArray(backupJobs.configId, identity.configIds)),
+      ),
+      or(inArray(backupJobs.status, ['pending', 'running']), gte(backupJobs.createdAt, cutoff)),
+    ));
+
+  for (const row of rows) {
+    if (!backupHelperSupportsServerBase(row.backupVersion)) {
+      return { deferred: true, deviceId: row.deviceId, version: row.backupVersion };
+    }
+  }
+  return { deferred: false };
+}
+
+/** Per-identity DB reads gathered in ONE short system context, per §3.7. */
+async function loadIdentityGcState(
+  identity: BackupGcStorageIdentity,
+  nowMs: number,
+): Promise<{
+  retainedSnapshotIds: string[];
+  nullIdentitySnapshotIds: string[];
+  retiredSnapshotIds: Map<string, string>;
+  legacyHelper: { deferred: boolean; deviceId?: string; version?: string | null };
+}> {
+  return withSystemDbAccessContext(async () => {
+    const retainedRows = await db
+      .select({ snapshotId: backupSnapshots.snapshotId })
+      .from(backupSnapshots)
+      .where(eq(backupSnapshots.storageIdentity, identity.key));
+
+    const nullIdentityRows = await db
+      .select({ snapshotId: backupSnapshots.snapshotId })
+      .from(backupSnapshots)
+      .where(and(isNull(backupSnapshots.storageIdentity), inArray(backupSnapshots.configId, identity.configIds)));
+
+    const retirementRows = await db
+      .select({ id: backupSnapshotRetirements.id, snapshotId: backupSnapshotRetirements.snapshotId })
+      .from(backupSnapshotRetirements)
+      .where(and(eq(backupSnapshotRetirements.storageIdentity, identity.key), isNull(backupSnapshotRetirements.sweptAt)));
+
+    const legacyHelper = await identityHasLegacyHelper(identity, nowMs);
+
+    return {
+      retainedSnapshotIds: retainedRows.map((r) => r.snapshotId),
+      nullIdentitySnapshotIds: nullIdentityRows.map((r) => r.snapshotId),
+      retiredSnapshotIds: new Map(retirementRows.map((r) => [r.snapshotId, r.id])),
+      legacyHelper,
+    };
+  });
+}
+
+/** Per-identity DB writes applied in ONE short system context, per §3.7 — always AFTER every storage call for this identity has already returned. */
+async function applyIdentityGcWriteBacks(
+  identity: { key: string },
+  writeBacks: { retiredSwept: string[]; selfHealSnapshotIds: string[] },
+): Promise<void> {
+  if (writeBacks.retiredSwept.length === 0 && writeBacks.selfHealSnapshotIds.length === 0) return;
+  await withSystemDbAccessContext(async () => {
+    for (const retirementId of writeBacks.retiredSwept) {
+      await db.update(backupSnapshotRetirements).set({ sweptAt: new Date() }).where(eq(backupSnapshotRetirements.id, retirementId));
+    }
+    if (writeBacks.selfHealSnapshotIds.length > 0) {
+      await db
+        .update(backupSnapshots)
+        .set({ storageIdentity: identity.key })
+        .where(inArray(backupSnapshots.snapshotId, writeBacks.selfHealSnapshotIds));
+    }
+  });
+}
+
+async function pruneSweptRetirements(nowMs: number): Promise<void> {
+  await withSystemDbAccessContext(async () => {
+    const cutoff = new Date(nowMs - 30 * 24 * 60 * 60 * 1000);
+    const deleted = await db
+      .delete(backupSnapshotRetirements)
+      .where(and(isNotNull(backupSnapshotRetirements.sweptAt), lt(backupSnapshotRetirements.sweptAt, cutoff)))
+      .returning({ id: backupSnapshotRetirements.id });
+    if (deleted.length > 0) {
+      console.log(`[BackupGC] Pruned ${deleted.length} swept retirement row(s) older than 30 days`);
+    }
+  });
+}
+
+/**
+ * §3.7: this is the top-level entry the worker calls, and it must NEVER be
+ * invoked from inside another DB transaction. W01 owns keeping the
+ * `cleanup-expired-snapshots` case out of the worker's blanket
+ * `runWithSystemDbAccess` wrap (consumed interface — see "Depends on"); this
+ * function's job is only to honor that assumption internally: every DB
+ * read/write happens in its own short `withSystemDbAccessContext` call, and
+ * every storage call (inside `sweepStorageIdentity`, which asserts
+ * `assertOutsideHeldDbContext` at its own top as a tripwire) runs at depth 0,
+ * between those contexts, never nested inside one.
+ */
+export async function sweepUnreferencedBackupObjects(): Promise<BackupGcResult> {
+  const nowMs = Date.now();
+  const graceMs = resolveBackupGcGraceMs();
+  const orphanWindowMs = Math.max(resolveBackupOrphanManifestMaxAgeMs(), resolveBackupBaseLeaseMs() + graceMs);
+  const manifestlessWindowMs = resolveBackupManifestlessPrefixMaxAgeMs();
+
+  const { unattributedCount, identities, unreachableIdentities } = await withSystemDbAccessContext(async () => {
+    const unattributedRows = await db.select({ id: backupSnapshots.id }).from(backupSnapshots).where(isNull(backupSnapshots.configId));
+    const destinations = await db
+      .select({ id: backupConfigs.id, provider: backupConfigs.provider, providerConfig: backupConfigs.providerConfig })
+      .from(backupConfigs);
+    const identitiesInner = groupBackupConfigsByStorageIdentity(destinations);
+    const unreachable = await logUnreachableStorageIdentities(identitiesInner);
+    return { unattributedCount: unattributedRows.length, identities: identitiesInner, unreachableIdentities: unreachable };
+  });
+
+  await pruneSweptRetirements(nowMs);
+
+  if (unattributedCount > 0) {
+    const wedgeMessage =
+      `[BackupGC] ${unattributedCount} backup_snapshots row(s) have no config_id — cannot attribute to a ` +
+      `storage identity, so their objects could live in ANY bucket. Blocking ALL ${identities.size} identity ` +
+      `sweep(s) this run (fail-closed). REMEDIATION REQUIRED: this does not self-heal — attribute the affected ` +
+      `row(s) to the correct backup_configs.id, or confirm they're orphaned and delete the row(s), then GC will ` +
+      `resume on its next run.`;
+    console.error(wedgeMessage);
+    captureException(new Error(wedgeMessage));
+    console.log(`[BackupGC] Run complete: deleted 0 object(s), ${identities.size} identity/identities skipped`);
+    return {
+      deleted: 0, skippedIdentities: identities.size, blockedIdentities: 0,
+      retiredSwept: 0, orphansSwept: 0, deferredIdentities: 0, unreachableIdentities,
+    };
+  }
+
+  const suspiciousIdentityKeys = detectSuspiciousStorageIdentityCollisions(identities);
+  if (suspiciousIdentityKeys.size > 0) {
+    captureException(new Error(
+      `[BackupGC] ${suspiciousIdentityKeys.size} storage identity/identities excluded this run: a cruder ` +
+      `bucket+host comparison collapses identities normalizeStorageIdentity kept apart.`,
+    ));
+  }
+
+  let deleted = 0;
+  let skippedIdentities = 0;
+  let blockedIdentities = 0;
+  let retiredSwept = 0;
+  let orphansSwept = 0;
+  let deferredIdentities = 0;
+  let deletesRemaining = resolveBackupGcMaxDeletesPerRun();
+
+  for (const identity of identities.values()) {
+    if (deletesRemaining <= 0) {
+      console.log('[BackupGC] Deletion cap reached for this run — stopping cleanly; remaining identities resume next run');
+      break;
+    }
+    if (suspiciousIdentityKeys.has(identity.key)) { skippedIdentities++; continue; }
+    if (!BACKUP_GC_SUPPORTED_PROVIDERS.has(identity.provider)) {
+      skippedIdentities++;
+      console.warn(`[BackupGC] Identity ${identity.key}: provider '${identity.provider}' has no GC listing support — skipping (fail-closed)`);
+      continue;
+    }
+
+    try {
+      // Phase: short DB context, reads only.
+      const state = await loadIdentityGcState(identity, nowMs);
+      if (state.legacyHelper.deferred) {
+        deferredIdentities++;
+        console.warn(`[BackupGC] reclamation deferred: legacy helper ${state.legacyHelper.deviceId} ${state.legacyHelper.version}`);
+      }
+
+      // Phase: no DB context, storage calls only (depth 0). The
+      // unresolved-NULL-rows gate is computed INSIDE sweepStorageIdentity
+      // (it needs the listing to know which NULL rows resolve — see that
+      // function's comment), combined there with the capability gate via OR;
+      // `restrictToRootedOnly` here carries only the capability-gate half.
+      const identityResult = await sweepStorageIdentity(
+        identity, state.retainedSnapshotIds, state.nullIdentitySnapshotIds, state.retiredSnapshotIds,
+        nowMs, deletesRemaining, graceMs, orphanWindowMs, manifestlessWindowMs,
+        state.legacyHelper.deferred,
+      );
+
+      if (identityResult.unresolvedNullIdentityCount > 0) {
+        console.warn(`[BackupGC] identity deferred: ${identityResult.unresolvedNullIdentityCount} unresolved rows`);
+        if (!state.legacyHelper.deferred) deferredIdentities++; // avoid double-counting if both gates fired
+      }
+
+      deleted += identityResult.deleted;
+      retiredSwept += identityResult.retiredSwept.length;
+      orphansSwept += identityResult.orphansSwept;
+      deletesRemaining -= identityResult.deletesUsed;
+
+      // Phase: short DB context, writes only — always after every storage
+      // call for this identity above has already completed.
+      await applyIdentityGcWriteBacks(identity, {
+        retiredSwept: identityResult.retiredSwept,
+        selfHealSnapshotIds: identityResult.selfHealSnapshotIds,
+      });
+
+      if (identityResult.deleted > 0) {
+        console.log(`[BackupGC] Identity ${identity.key}: deleted ${identityResult.deleted} unreferenced object(s)`);
+      } else {
+        console.debug(`[BackupGC] Identity ${identity.key}: 0 objects deleted`);
+      }
+    } catch (error) {
+      skippedIdentities++;
+      blockedIdentities++;
+      console.error(`[BackupGC] Identity ${identity.key}: sweep failed — isolated, other identities proceed:`, error);
+      captureException(error instanceof Error ? error : new Error(String(error)));
+    }
+  }
+
+  console.log(
+    `[BackupGC] Run complete: deleted ${deleted} object(s), ${retiredSwept} retirement(s) fully swept, ` +
+    `${orphansSwept} orphan(s) swept, ${identities.size - skippedIdentities} identity/identities processed, ` +
+    `${skippedIdentities} skipped, ${deferredIdentities} deferred (legacy helper), ${unreachableIdentities} unreachable` +
+    (blockedIdentities > 0 ? ` (${blockedIdentities} blocked by unfetchable manifest — fail-closed)` : ''),
+  );
+
+  return { deleted, skippedIdentities, blockedIdentities, retiredSwept, orphansSwept, deferredIdentities, unreachableIdentities };
+}
+```
+
+  Note the ordering that makes this correct: `unresolvedNullIdentityCount` is computed and applied **inside** `sweepStorageIdentity` itself (combined with the capability gate via OR, right after the self-heal filter and before the main per-group loop — see that function above), not by the caller after the fact. Computing it in the caller instead would be a chicken-and-egg bug: "unresolved" can only be known once the listing exists, but by the time the caller sees the result the sweep would already have run — so `sweepUnreferencedBackupObjects` above only *reads* `identityResult.unresolvedNullIdentityCount` to log and count `deferredIdentities`, it never uses it to decide whether to sweep.
+
+  Add to the top imports: `backupSnapshotRetirements`, `devices` to the `../db/schema` import list; `gte`, `isNotNull` to the `drizzle-orm` import list; `withSystemDbAccessContext`, `assertOutsideHeldDbContext` from `../db` (verify both export names against `apps/api/src/db/index.ts` — confirmed present as `export async function withSystemDbAccessContext` at `:610` and `export function assertOutsideHeldDbContext` at `:989` in the pre-W01 file; re-check after W01 lands in case it moves either); `resolveBackupOrphanManifestMaxAgeMs`, `resolveBackupBaseLeaseMs` from `../services/backupGcKnobs`; `backupHelperSupportsServerBase` from `../services/backupHelperCapabilities`.
+
+- [ ] Step 4: Run, expect PASS (this is the point every test from Tasks 3, 5, 6 and this task's own tests should all go green together — fix up the `selectQueue` push counts in Tasks 3/5/6's tests per this task's header note first if they fail on an unexpected-shape mismatch): `cd apps/api && npx vitest run src/jobs/backupRetention.test.ts`
+
+- [ ] Step 5: Commit: `git add apps/api/src/jobs/backupRetention.ts apps/api/src/jobs/backupRetention.test.ts && git commit -m "feat(backup-gc): retirement-aware two-phase sweep, NULL-identity self-heal, capability gate (D18 §3.4/§3.6)"`
+
+### Task 8: `backupWorker.ts` — log the four new result fields (no worker restructuring — W01 owns that)
+
+**Scope correction (read before starting):** W01, not this wave, owns moving `cleanup-expired-snapshots` out of `createBackupWorker`'s blanket `runWithSystemDbAccess` wrap (spec §3.7 point 2 — the job-dispatch-side half of the transaction-boundary fix). This wave's **consumed interface** from W01 is: *"the `cleanup-expired-snapshots` job handler runs retention, then calls `await sweepUnreferencedBackupObjects()`, both outside the blanket per-job DB context — i.e. `sweepUnreferencedBackupObjects` is always invoked at depth 0."* This task does **not** touch `createBackupWorker`'s job-dispatch switch (`~99-118`) at all. It also does **not** rename `sweepUnreferencedBackupObjects` — W01's call site (`processCleanupExpiredSnapshots`, `~366`) depends on that exact export name and signature being unchanged, which is why Task 7 keeps the name as-is throughout. This wave's own defense of the depth-0 assumption is the `assertOutsideHeldDbContext` tripwire added inside `sweepStorageIdentity` in Task 7 — not a restructure here.
+
+**Files:** Modify `apps/api/src/jobs/backupWorker.ts:324-390` (`processCleanupExpiredSnapshots` only — its return type, its `try` block around the `sweepUnreferencedBackupObjects()` call, and its `return`). No other part of `backupWorker.ts` is touched by this task.
+
+**Interfaces:**
+- Consumes: the extended `BackupGcResult` from Task 7 (`sweepUnreferencedBackupObjects(): Promise<BackupGcResult>`, name and call depth unchanged — W01's consumed-interface guarantee above).
+- Produces: extended return type `{ deleted, skipped, prunedByMaxVersions, failed, gcDeleted, gcSkippedIdentities, gcBlockedIdentities, gcRetiredSwept, gcOrphansSwept, gcDeferredIdentities, gcUnreachableIdentities }`.
+
+**Cross-wave coordination note:** W01 restructures `processCleanupExpiredSnapshots`'s retention half (per-row short contexts) and moves its own call site out of the blanket wrap. This task's diff is scoped to the `try`/`return` around the `sweepUnreferencedBackupObjects()` call inside that same function — a small, easily-mergeable hunk, but still touching a function W01 is also editing. Whichever branch merges second should rebase onto the other's version of `processCleanupExpiredSnapshots` rather than blindly overwriting it (flagged in the PR checklist below), though the surface area of overlap is now much smaller than a full dispatch-switch restructure.
+
+- [ ] Step 1: Write the failing test — find or add `apps/api/src/jobs/backupWorker.test.ts`'s test for `processCleanupExpiredSnapshots` (grep first: `grep -n "processCleanupExpiredSnapshots" apps/api/src/jobs/backupWorker.test.ts`) and extend its mock return value + assertion:
+
+```typescript
+// Extend the existing sweepUnreferencedBackupObjects mock in whatever
+// describe block already covers processCleanupExpiredSnapshots:
+sweepUnreferencedBackupObjectsMock.mockResolvedValueOnce({
+  deleted: 3, skippedIdentities: 0, blockedIdentities: 0,
+  retiredSwept: 1, orphansSwept: 2, deferredIdentities: 0, unreachableIdentities: 0,
+});
+
+const result = await processCleanupExpiredSnapshots();
+expect(result.gcRetiredSwept).toBe(1);
+expect(result.gcOrphansSwept).toBe(2);
+expect(result.gcDeferredIdentities).toBe(0);
+expect(result.gcUnreachableIdentities).toBe(0);
+```
+
+  (If no existing test file/mock covers this function, write the full test scaffold mirroring the mocking style already used elsewhere in `backupWorker.test.ts` for `db`/`sweepUnreferencedBackupObjects` — grep the file first for the established pattern before adding a new one. Do NOT add a test asserting anything about `runWithSystemDbAccess`/the job-dispatch switch — that boundary is W01's to prove.)
+
+- [ ] Step 2: Run it, expect FAIL: `cd apps/api && npx vitest run src/jobs/backupWorker.test.ts` — `result.gcRetiredSwept` is undefined.
+
+- [ ] Step 3: Implement — in `processCleanupExpiredSnapshots`, extend the return type annotation and the try block (this is the ONLY code change in this task):
+
+```typescript
+export async function processCleanupExpiredSnapshots(): Promise<{
+  deleted: number;
+  skipped: number;
+  prunedByMaxVersions: number;
+  failed: number;
+  gcDeleted: number;
+  gcSkippedIdentities: number;
+  gcBlockedIdentities: number;
+  gcRetiredSwept: number;
+  gcOrphansSwept: number;
+  gcDeferredIdentities: number;
+  gcUnreachableIdentities: number;
+}> {
+  // ... unchanged org loop (and unchanged short-context restructuring, whatever
+  // shape W01 lands it in) ...
+
+  let gcDeleted = 0;
+  let gcSkippedIdentities = 0;
+  let gcBlockedIdentities = 0;
+  let gcRetiredSwept = 0;
+  let gcOrphansSwept = 0;
+  let gcDeferredIdentities = 0;
+  let gcUnreachableIdentities = 0;
+  try {
+    const gcResult = await sweepUnreferencedBackupObjects();
+    gcDeleted = gcResult.deleted;
+    gcSkippedIdentities = gcResult.skippedIdentities;
+    gcBlockedIdentities = gcResult.blockedIdentities;
+    gcRetiredSwept = gcResult.retiredSwept;
+    gcOrphansSwept = gcResult.orphansSwept;
+    gcDeferredIdentities = gcResult.deferredIdentities;
+    gcUnreachableIdentities = gcResult.unreachableIdentities;
+  } catch (err) {
+    console.error('[BackupWorker] Backup object GC sweep failed — retention run still succeeded:', err);
+    captureException(err instanceof Error ? err : new Error(String(err)));
+  }
+
+  // ... unchanged failed>0 throw ...
+
+  return {
+    deleted, skipped, prunedByMaxVersions, failed,
+    gcDeleted, gcSkippedIdentities, gcBlockedIdentities,
+    gcRetiredSwept, gcOrphansSwept, gcDeferredIdentities, gcUnreachableIdentities,
+  };
+}
+```
+
+- [ ] Step 4: Run, expect PASS: `cd apps/api && npx vitest run src/jobs/backupWorker.test.ts`
+
+- [ ] Step 5: Commit: `git add apps/api/src/jobs/backupWorker.ts apps/api/src/jobs/backupWorker.test.ts && git commit -m "feat(backup-gc): surface retirement/orphan/deferred/unreachable counts from the worker"`
+
+### Task 9: Integration test — real DB + real local filesystem, spec §6 scenarios (1)-(5) + self-heal scenario (6)
+
+**Files:** Create `apps/api/src/__tests__/integration/backupGcReclamation.integration.test.ts`.
+
+**Interfaces:**
+- Consumes: `withSystemDbAccessContext`, `db` from `../../db`; `partners, organizations, sites, devices, backupConfigs, backupJobs, backupSnapshots, backupSnapshotRetirements` from `../../db/schema`; `sweepUnreferencedBackupObjects` from `../../jobs/backupRetention`.
+- Runs against: `providerConfig.path` pointing at `fs.mkdtempSync` temp dirs (provider `'local'`), real files written and aged via `fs.promises.utimes`.
+
+- [ ] Step 1: Write the failing test (this whole file is new — "failing" means it doesn't exist / fails to compile until Task 7 is fully landed):
+
+```typescript
+import './setup';
+
+import { mkdtemp, mkdir, writeFile, utimes, readdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../../db';
+import {
+  backupConfigs,
+  backupJobs,
+  backupSnapshots,
+  backupSnapshotRetirements,
+  devices,
+  organizations,
+  partners,
+  sites,
+} from '../../db/schema';
+import { sweepUnreferencedBackupObjects } from '../../jobs/backupRetention';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+async function writeAged(root: string, relPath: string, ageMs: number, contents = 'x'): Promise<void> {
+  const full = join(root, relPath);
+  await mkdir(join(full, '..'), { recursive: true });
+  await writeFile(full, contents);
+  const t = new Date(Date.now() - ageMs);
+  await utimes(full, t, t);
+}
+
+async function listAll(root: string, prefix = ''): Promise<string[]> {
+  let entries;
+  try {
+    entries = await readdir(join(root, prefix), { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const out: string[] = [];
+  for (const e of entries) {
+    const rel = prefix ? `${prefix}/${e.name}` : e.name;
+    if (e.isDirectory()) out.push(...(await listAll(root, rel)));
+    else out.push(rel);
+  }
+  return out;
+}
+
+async function seedOrgDeviceConfig(unique: string, rootPath: string) {
+  const [partner] = await db.insert(partners).values({
+    name: `GC Partner ${unique}`, slug: `gc-partner-${unique}`, type: 'msp', plan: 'pro', status: 'active',
+  }).returning({ id: partners.id });
+  const [org] = await db.insert(organizations).values({
+    currencyCode: 'USD', partnerId: partner!.id, name: `GC Org ${unique}`, slug: `gc-org-${unique}`, type: 'customer', status: 'active',
+  }).returning({ id: organizations.id });
+  const [site] = await db.insert(sites).values({ orgId: org!.id, name: `GC Site ${unique}` }).returning({ id: sites.id });
+  const [device] = await db.insert(devices).values({
+    orgId: org!.id, siteId: site!.id, agentId: `gc-agent-${unique}`, hostname: `gc-host-${unique}`,
+    osType: 'linux', osVersion: '1', architecture: 'x86_64', agentVersion: '0.0.0-test',
+    backupVersion: '0.112.0', status: 'online',
+  }).returning({ id: devices.id });
+  const [config] = await db.insert(backupConfigs).values({
+    orgId: org!.id, name: `GC Config ${unique}`, type: 'file', provider: 'local', providerConfig: { path: rootPath },
+  }).returning({ id: backupConfigs.id });
+  const identity = `local::${rootPath}`;
+  return { orgId: org!.id, deviceId: device!.id, configId: config!.id, identity };
+}
+
+async function insertSnapshotRow(params: {
+  orgId: string; deviceId: string; configId: string; snapshotId: string; identity: string; expiresAt?: Date | null;
+}) {
+  const [job] = await db.insert(backupJobs).values({
+    orgId: params.orgId, configId: params.configId, deviceId: params.deviceId, status: 'completed', snapshotId: params.snapshotId,
+  }).returning({ id: backupJobs.id });
+  await db.insert(backupSnapshots).values({
+    orgId: params.orgId, jobId: job!.id, deviceId: params.deviceId, configId: params.configId,
+    snapshotId: params.snapshotId, storageIdentity: params.identity, expiresAt: params.expiresAt ?? null,
+  });
+}
+
+runDb('scenario 1: expiring a base with an incremental child reclaims the base-exclusive object but keeps every backupPath the incremental references', async () => {
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const root = await mkdtemp(join(tmpdir(), 'breeze-gc-'));
+
+  const ctx = await withSystemDbAccessContext(async () => {
+    const seed = await seedOrgDeviceConfig(unique, root);
+
+    // Base B: exclusive object X, still has a live row (not yet expired) so its
+    // own manifest survives; the row is deleted directly here to simulate
+    // retention already having run and written the retirement (W01's job —
+    // this test inserts the retirement row directly rather than re-driving
+    // cleanupExpiredSnapshots, which is out of this wave's scope).
+    await writeAged(root, 'snapshots/B/manifest.json', 1000, JSON.stringify({ files: [{ backupPath: 'snapshots/B/files/x.dat' }] }));
+    await writeAged(root, 'snapshots/B/files/x.dat', 1000); // B-exclusive
+    // Incremental C references B's object X plus its own file.
+    await writeAged(root, 'snapshots/C/manifest.json', 1000, JSON.stringify({ files: [
+      { backupPath: 'snapshots/B/files/x.dat' },
+      { backupPath: 'snapshots/C/files/c.dat' },
+    ] }));
+    await writeAged(root, 'snapshots/C/files/c.dat', 1000);
+
+    await insertSnapshotRow({ ...seed, snapshotId: 'C' }); // C stays retained
+    await db.insert(backupSnapshotRetirements).values({
+      orgId: seed.orgId, configId: seed.configId, deviceId: seed.deviceId,
+      snapshotId: 'B', storageIdentity: seed.identity, backupType: 'file', reason: 'expired', retiredAt: new Date(),
+    });
+
+    return seed;
+  });
+
+  await sweepUnreferencedBackupObjects(); // manages its own short per-identity DB contexts internally (§3.7) — no outer wrap needed
+
+  const remaining = await listAll(root);
+  // B's manifest and exclusive object are gone; C's manifest, C's own file, and
+  // the SHARED object (still referenced by C's manifest) all survive.
+  expect(remaining.sort()).toEqual(['snapshots/C/files/c.dat', 'snapshots/C/manifest.json'].sort());
+
+  const [retirementRow] = await withSystemDbAccessContext(() =>
+    db.select().from(backupSnapshotRetirements).where(eq(backupSnapshotRetirements.storageIdentity, ctx.identity)),
+  );
+  expect(retirementRow!.sweptAt).not.toBeNull();
+});
+
+runDb('scenario 2: a pinned (in-progress) prefix is never reclaimed even if retired', async () => {
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const root = await mkdtemp(join(tmpdir(), 'breeze-gc-'));
+
+  await withSystemDbAccessContext(async () => {
+    const seed = await seedOrgDeviceConfig(unique, root);
+    await writeAged(root, 'snapshots/PINNED/manifest.json', 1000, JSON.stringify({ files: [] }));
+    await writeAged(root, 'snapshots/PINNED/files/p.dat', 1000);
+    // No backup_snapshots row (row already deleted), but a running job still
+    // has base_snapshot_id = 'PINNED' with a live lease — simulated here by
+    // simply NOT writing a retirement row and keeping the manifest young
+    // enough to fall inside the default orphan-protection window, which is
+    // this wave's actual mechanism for "don't delete something that might
+    // still be needed" (the lease/pin itself is W01's mechanism and is
+    // exercised in W01's own suite, not here).
+  });
+
+  await sweepUnreferencedBackupObjects(); // manages its own short per-identity DB contexts internally (§3.7) — no outer wrap needed
+
+  const remaining = await listAll(root);
+  expect(remaining.sort()).toEqual(['snapshots/PINNED/files/p.dat', 'snapshots/PINNED/manifest.json'].sort());
+});
+
+runDb('scenario 3: an orphan manifest past the window with no row and no retirement is reclaimed', async () => {
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const root = await mkdtemp(join(tmpdir(), 'breeze-gc-'));
+  const TEN_DAYS_MS = 10 * 24 * 60 * 60 * 1000;
+
+  await withSystemDbAccessContext(async () => {
+    await seedOrgDeviceConfig(unique, root);
+    await writeAged(root, 'snapshots/ABANDONED/manifest.json', TEN_DAYS_MS, JSON.stringify({ files: [] }));
+    await writeAged(root, 'snapshots/ABANDONED/files/a.dat', TEN_DAYS_MS);
+  });
+
+  await sweepUnreferencedBackupObjects(); // manages its own short per-identity DB contexts internally (§3.7) — no outer wrap needed
+
+  expect(await listAll(root)).toEqual([]);
+});
+
+runDb('scenario 4: legacy helper on the identity defers reclamation of a retired prefix', async () => {
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const root = await mkdtemp(join(tmpdir(), 'breeze-gc-'));
+
+  await withSystemDbAccessContext(async () => {
+    const seed = await seedOrgDeviceConfig(unique, root);
+    await db.update(devices).set({ backupVersion: '0.109.0' }).where(eq(devices.id, seed.deviceId));
+    await writeAged(root, 'snapshots/RETIREDLEGACY/manifest.json', 1000, JSON.stringify({ files: [] }));
+    await writeAged(root, 'snapshots/RETIREDLEGACY/files/r.dat', 1000);
+    await db.insert(backupSnapshotRetirements).values({
+      orgId: seed.orgId, configId: seed.configId, deviceId: seed.deviceId,
+      snapshotId: 'RETIREDLEGACY', storageIdentity: seed.identity, backupType: 'file', reason: 'expired', retiredAt: new Date(),
+    });
+    // A backup_jobs row within the last 30 days on this config pins the
+    // identity's capability check to the legacy device version.
+    await db.insert(backupJobs).values({
+      orgId: seed.orgId, configId: seed.configId, deviceId: seed.deviceId, status: 'completed',
+    });
+  });
+
+  await sweepUnreferencedBackupObjects(); // manages its own short per-identity DB contexts internally (§3.7) — no outer wrap needed
+
+  const remaining = await listAll(root);
+  expect(remaining.sort()).toEqual(['snapshots/RETIREDLEGACY/files/r.dat', 'snapshots/RETIREDLEGACY/manifest.json'].sort());
+});
+
+runDb('scenario 5: an object still failing to delete blocks only the manifest for that prefix, not other prefixes', async () => {
+  // A local-provider ENOENT-on-delete is treated as success (rm force:true),
+  // so this scenario proves the two-phase gate using a genuinely undeletable
+  // path instead: a directory placed where a file key is expected causes
+  // deleteLocalObjectKeys' rm() to throw (EISDIR is NOT swallowed by force),
+  // landing in failedKeys.
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const root = await mkdtemp(join(tmpdir(), 'breeze-gc-'));
+
+  await withSystemDbAccessContext(async () => {
+    const seed = await seedOrgDeviceConfig(unique, root);
+    await writeAged(root, 'snapshots/RETIREDBLOCKED/manifest.json', 1000, JSON.stringify({ files: [] }));
+    // Make the "file" a directory instead, so rm({force:true}) without
+    // recursive:true throws EISDIR — deleteLocalObjectKeys catches it into
+    // failedKeys rather than deleting it.
+    await mkdir(join(root, 'snapshots/RETIREDBLOCKED/files/blocked.dat'), { recursive: true });
+    await db.insert(backupSnapshotRetirements).values({
+      orgId: seed.orgId, configId: seed.configId, deviceId: seed.deviceId,
+      snapshotId: 'RETIREDBLOCKED', storageIdentity: seed.identity, backupType: 'file', reason: 'expired', retiredAt: new Date(),
+    });
+  });
+
+  await sweepUnreferencedBackupObjects(); // manages its own short per-identity DB contexts internally (§3.7) — no outer wrap needed
+
+  // Manifest survives because the non-manifest phase had a failure.
+  expect(await listAll(root)).toContain('snapshots/RETIREDBLOCKED/manifest.json');
+});
+
+runDb('scenario 6: a NULL storage_identity row self-heals when found, and blocks unrooted reclamation on the identity until every NULL row resolves', async () => {
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const root = await mkdtemp(join(tmpdir(), 'breeze-gc-'));
+
+  const ctx = await withSystemDbAccessContext(async () => {
+    const seed = await seedOrgDeviceConfig(unique, root);
+
+    // HEALME: a real, still-published snapshot whose storage_identity was
+    // never backfilled (simulates a row written before W01's backfill ran,
+    // or one whose config was edited after publication per §3.6).
+    await writeAged(root, 'snapshots/HEALME/manifest.json', 1000, JSON.stringify({ files: [] }));
+    const [job] = await db.insert(backupJobs).values({
+      orgId: seed.orgId, configId: seed.configId, deviceId: seed.deviceId, status: 'completed', snapshotId: 'HEALME',
+    }).returning({ id: backupJobs.id });
+    await db.insert(backupSnapshots).values({
+      orgId: seed.orgId, jobId: job!.id, deviceId: seed.deviceId, configId: seed.configId,
+      snapshotId: 'HEALME', storageIdentity: null, // deliberately unresolved
+    });
+
+    // RETIRED6: a genuinely retired prefix on the SAME identity, which must
+    // stay untouched this run because HEALME hasn't resolved yet.
+    await writeAged(root, 'snapshots/RETIRED6/manifest.json', 1000, JSON.stringify({ files: [] }));
+    await writeAged(root, 'snapshots/RETIRED6/files/r.dat', 1000);
+    await db.insert(backupSnapshotRetirements).values({
+      orgId: seed.orgId, configId: seed.configId, deviceId: seed.deviceId,
+      snapshotId: 'RETIRED6', storageIdentity: seed.identity, backupType: 'file', reason: 'expired', retiredAt: new Date(),
+    });
+
+    return seed;
+  });
+
+  await sweepUnreferencedBackupObjects();
+
+  // Nothing was deleted: RETIRED6 is deferred because HEALME (mapped to the
+  // same identity via configId) was still unresolved when this run started.
+  const afterFirstRun = await listAll(root);
+  expect(afterFirstRun.sort()).toEqual([
+    'snapshots/HEALME/manifest.json',
+    'snapshots/RETIRED6/files/r.dat',
+    'snapshots/RETIRED6/manifest.json',
+  ].sort());
+
+  // But HEALME's row is now healed (its manifest WAS found in this run's
+  // listing), so a SECOND run has no unresolved rows left and reclaims
+  // RETIRED6 normally.
+  const [healedRow] = await withSystemDbAccessContext(() =>
+    db.select().from(backupSnapshots).where(eq(backupSnapshots.snapshotId, 'HEALME')),
+  );
+  expect(healedRow!.storageIdentity).toBe(ctx.identity);
+
+  await sweepUnreferencedBackupObjects();
+  const afterSecondRun = await listAll(root);
+  expect(afterSecondRun).toEqual(['snapshots/HEALME/manifest.json']);
+});
+```
+
+- [ ] Step 2: Run it, expect FAIL until Task 7 lands: `DATABASE_URL=postgresql://breeze:breeze@localhost:5432/breeze cd apps/api && npx vitest run src/__tests__/integration/backupGcReclamation.integration.test.ts --config vitest.integration.config.ts`
+
+- [ ] Step 3: Implement — no production code changes in this step; this task exists to prove Task 7's implementation against a real database and real filesystem. If any scenario fails, fix `backupRetention.ts` (not the test) unless the test itself has a bug — re-derive from spec §6 rather than loosening an assertion.
+
+- [ ] Step 4: Run, expect PASS: `DATABASE_URL=postgresql://breeze:breeze@localhost:5432/breeze pnpm --filter @breeze/api run test:integration --run src/__tests__/integration/backupGcReclamation.integration.test.ts` (verify the exact script name in `apps/api/package.json` first — grep `"test:integration"`; if absent, run `cd apps/api && npx vitest run --config vitest.integration.config.ts src/__tests__/integration/backupGcReclamation.integration.test.ts` directly, which sidesteps any pnpm passthrough).
+
+- [ ] Step 5: Commit: `git add apps/api/src/__tests__/integration/backupGcReclamation.integration.test.ts && git commit -m "test(backup-gc): integration coverage for retirement/orphan/pin/legacy-helper/self-heal sweep rules"`
+
+### Task 10: Docs — storage.mdx and monitoring.mdx no longer say "not reclaimed"
+
+**Files:** Modify `apps/docs/src/content/docs/backup/storage.mdx:53-61`. Modify `apps/docs/src/content/docs/backup/monitoring.mdx:119`.
+
+**Interfaces:** None (prose only).
+
+- [ ] Step 1: Write the failing test — this is a docs-only change; there is no automated assertion, so the "test" is a manual content diff review. Skip the red/green cycle per the repo's low-blast-radius carve-out (CLAUDE.md: "CRUD, copy, renames, docs, config" proceed directly). Confirm the exact old text first: `grep -n "not yet reclaim\|not yet reclaimed" apps/docs/src/content/docs/backup/*.mdx`.
+
+- [ ] Step 2: N/A (docs).
+
+- [ ] Step 3: Implement — replace `storage.mdx`'s aside (lines `53-61`):
+
+```mdx
+  <Aside type="note" title="What retention removes today">
+    When a restore point passes its retention window, Breeze removes it from the snapshot list — it can no
+    longer be restored or verified — and marks its data for reclamation. A background storage sweep then
+    deletes the restore point's exclusive data from the storage target on its next scheduled run, after a
+    short safety grace period (48 hours by default) that protects any object still mid-upload. Data another
+    surviving restore point still depends on (for example, a file shared with an incremental backup) is never
+    deleted, no matter how old it is. An upload that never finished, or whose record could not be reconciled,
+    is reclaimed once it has sat idle for about 9 days — giving Breeze time to recognize and finish adopting
+    it first.
+
+    If a device's Breeze backup helper predates version 0.112.0, storage reclamation beyond an expired
+    snapshot's own row stays deferred on that device's destination until every device sharing it has
+    upgraded — update the agent to enable full reclamation.
+  </Aside>
+```
+
+  Replace `monitoring.mdx:119`:
+
+```mdx
+If storage is growing faster than expected, check whether large datasets were recently added to backup scope. Expired restore points are removed from Breeze immediately and their storage is reclaimed by the periodic reclamation sweep (see the [storage page](/backup/storage/) for timing and safety windows) — allow for the grace period and the next scheduled sweep before usage reflects the drop.
+```
+
+- [ ] Step 4: N/A (docs) — sanity-check the build: `pnpm --filter @breeze/docs build` if time allows, otherwise a visual proofread of the rendered MDX is sufficient for a prose-only change.
+
+- [ ] Step 5: Commit: `git add apps/docs/src/content/docs/backup/storage.mdx apps/docs/src/content/docs/backup/monitoring.mdx && git commit -m "docs(backup): storage reclamation is now implemented (closes the #5429 caveat)"`
+
+### Task 11: Wave verification
+
+- [ ] Full targeted unit run: `cd apps/api && npx vitest run src/jobs/backupRetention.test.ts src/jobs/backupWorker.test.ts src/services/backupHelperCapabilities.test.ts src/services/backupAgentContract.test.ts`
+- [ ] Typecheck: `pnpm --filter @breeze/api exec tsc --noEmit` (no dedicated typecheck script in `apps/api/package.json` — confirmed via `grep -n '"test"\|"typecheck"\|"build"' apps/api/package.json`, which shows only `"build": "tsup"` and `"test": "vitest"`).
+- [ ] Integration suite (needs `DATABASE_URL=postgresql://breeze:breeze@localhost:5432/breeze` and a running dev DB): `cd apps/api && npx vitest run --config vitest.integration.config.ts src/__tests__/integration/backupGcReclamation.integration.test.ts src/__tests__/integration/staleBackupReaper.integration.test.ts`
+- [ ] No schema changes in this wave, so `pnpm db:check-drift` is not expected to show new drift — run it anyway as a sanity check since W01 may have just landed: `pnpm db:check-drift`
+- [ ] Full API unit suite once the above are green: `pnpm --filter @breeze/api test --run` (NOT `-- --run`, see the CLAUDE.md `--` trap)
+- [ ] `pnpm lint`
+- [ ] PR body checklist:
+  - [ ] Links the spec (`docs/superpowers/specs/backup/2026-09-09-backup-gc-reclamation-design.md`, v3) and this plan.
+  - [ ] States the dependency on W01 explicitly and confirms W01's actual shipped shape (table/column names — especially `publish_lease_expires_at` vs the earlier `base_lease_expires_at`, `backup_jobs.storage_identity`, `backup_snapshots.storage_identity` nullability, `backupGcKnobs.ts` signatures) matched what this plan assumed — flag any drift found during implementation.
+  - [ ] Confirms `backupAgentContract.test.ts` is green (the 7-day journal literal contract).
+  - [ ] Confirms the Redis skip-set uses the shared non-blocking client (`getRedis()`), never a blocking command on it.
+  - [ ] Confirms the capability gate and the unresolved-NULL-rows gate each independently suppress ONLY the retired/orphan reclamation, never the pre-existing rooted-grace or manifest-less-prefix rules.
+  - [ ] Confirms no code path calls `sweepUnreferencedBackupObjects()` (or anything it calls) from inside another open `withSystemDbAccessContext`/`withDbAccessContext` — specifically that `backupWorker.ts`'s `cleanup-expired-snapshots` case runs OUTSIDE the blanket `runWithSystemDbAccess` wrap (§3.7).
+  - [ ] Confirms with whoever landed W01 that `processCleanupExpiredSnapshots`'s body and the `backupWorker.ts` switch-statement carve-out (both touched by this plan's Task 8) merged cleanly against W01's own retention-side short-context restructure — see the Open Questions entry on this.
+  - [ ] No production migration in this PR (W01 owns migrations); `db:check-drift` clean.
+  - [ ] Docs PR note: storage.mdx/monitoring.mdx no longer claim reclamation is unimplemented.
+
+## Open questions / contradictions
+
+- **Cross-wave collision on `backupWorker.ts`'s `cleanup-expired-snapshots` handling.** Spec §3.7 assigns W01 the retention-side restructure (short context per candidate row inside `processCleanupExpiredSnapshots`) and this plan (Task 8) the worker-dispatch-side restructure (carving the whole case out of the blanket `runWithSystemDbAccess` wrap in `createBackupWorker`, `~99-118`). Both waves therefore touch `backupWorker.ts` — W01 inside the function body, W02 at its call site — which is likely fine (different regions of the same file) but should be confirmed rather than assumed; whichever branch merges second must rebase onto the other's changes to this file, not silently overwrite them. Flagged in the PR checklist above.
+- **"Prefix found empty" definition when a shared live object remains.** Spec §3.4 says "when the listing later shows the prefix empty, set `swept_at`" but doesn't define emptiness in the presence of a still-live shared object (e.g. a retired snapshot's manifest referenced no exclusive files, but one of its listed objects is still `liveSet`-protected because another rooted snapshot's manifest also references it). This plan's Task 7 implementation treats the prefix as "empty" once every **non-live** object it contained has been deleted (a permanently shared object never counts against emptiness). This is a reasonable reading but not explicitly stated in the spec — flag for confirmation; if wrong, the write-back call site needs the stricter "truly zero objects remain, live or not" definition instead (which would mean a retirement can never be swept while any dedup sharing continues, likely the wrong behavior — but worth an explicit sign-off).
+- **`orphansSwept` counting granularity.** The spec's `BackupGcResult` field list (§3.4/§6) doesn't define whether `orphansSwept` counts prefixes-fully-cleared (this plan's choice, mirroring `retiredSwept`) or every individual old-orphan prefix touched regardless of whether it fully cleared this run. Chose "fully cleared" for symmetry with `retiredSwept`; flag for confirmation.
+- **Two-phase manifest-delete cap interaction.** The v3 manifest-last rule ("no deletable non-manifest key remains — none failed, none capped, none skip-set-excluded") is more conservative than v2's "zero failedKeys": a single capped-out or skip-set-excluded non-manifest key now blocks the manifest for the WHOLE run, even if every other object in the prefix was cleanly deleted. This plan implements that literally (`remainingNonManifest.length === 0` gates the manifest phase). The spec doesn't explicitly discuss whether a capped-out key should behave differently from a skip-set-excluded one for this purpose (e.g. "cap will clear next run regardless" vs. "skip-set exclusion could persist for the full 7-day TTL") — this plan treats them identically per the literal spec wording; flag for confirmation if a different treatment was intended.
+- **W01 interface drift risk.** This plan was written against the *assumed* W01 v3 deliverables listed under "Depends on" above, since W01 has not landed in this worktree at plan-authoring time. Every exact name (`resolveMsKnob`, `resolveBackupBaseLeaseMs`, `resolveBackupOrphanManifestMaxAgeMs`, `resolveBackupPublishMarginMs`, `backupSnapshotRetirements` column names, `backup_jobs.storage_identity`/`backup_snapshots.storage_identity` nullability and exact naming) **must be re-verified against W01's actual merged code before Task 1 starts** — if any signature differs, this plan's Task 1/6/7/9 code blocks need matching edits before they'll compile.
+- **Migration backfill predicate is untested by this wave.** Spec §3.6 says the migration backfills `backup_snapshots.storage_identity` "only when `backup_configs.updated_at <= backup_snapshots.timestamp`" — that's W01's migration, not this wave's code, but this wave's self-heal logic (Task 7) is the safety net for every row the backfill predicate deliberately leaves NULL. This plan's integration scenario 6 proves the self-heal mechanism works in isolation (a NULL row inserted directly) but does NOT exercise the actual migration/backfill predicate end-to-end — that boundary is W01's to test, flagged here only so it isn't assumed covered by this wave's suite.
+- **`backupRetention.test.ts` exact line numbers and `selectQueue` push counts will drift as Tasks 1-7 compound.** The Ground Truth section's line numbers were re-verified against the current (pre-Task-1) file; each subsequent task's edits shift later line numbers, and Task 7 changes the per-identity query count/order from what Tasks 3/5/6 assumed (see Task 7's header note). Re-grep before each task and re-run the full suite after Task 7 to catch any stale `selectQueue` sequence, rather than trusting a fixed count once Tasks 1-7 start compounding edits within one PR branch.

--- a/docs/superpowers/plans/backup/2026-09-09-backup-gc-reclamation-w02-gc-sweep.md
+++ b/docs/superpowers/plans/backup/2026-09-09-backup-gc-reclamation-w02-gc-sweep.md
@@ -1,3 +1,7 @@
+---
+tracking_issue: LanternOps/breeze#5449
+---
+
 # Wave 02 — API: GC Sweep Reclaims Retired and Orphaned Prefixes Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
@@ -1535,15 +1539,15 @@ export async function sweepUnreferencedBackupObjects(): Promise<BackupGcResult> 
 
 - [ ] Step 5: Commit: `git add apps/api/src/jobs/backupRetention.ts apps/api/src/jobs/backupRetention.test.ts && git commit -m "feat(backup-gc): NULL rows always roots, deferral runs today's algorithm, cap/skip-set/swept_at correctness (D18 §3.4/§3.6 v3)"`
 
-### Task 8: `backupWorker.ts` — log the four new result fields (no worker restructuring — W01 owns that)
+### Task 8: `backupWorker.ts` — remove the sweep's wrapping DB context and log the four new result fields
 
-**Scope correction (read before starting):** W01, not this wave, owns moving `cleanup-expired-snapshots` out of `createBackupWorker`'s blanket `runWithSystemDbAccess` wrap (spec §3.7 point 2 — the job-dispatch-side half of the transaction-boundary fix). This wave's **consumed interface** from W01 is: *"the `cleanup-expired-snapshots` job handler runs retention, then calls `await sweepUnreferencedBackupObjects()`, both outside the blanket per-job DB context — i.e. `sweepUnreferencedBackupObjects` is always invoked at depth 0."* This task does **not** touch `createBackupWorker`'s job-dispatch switch (`~99-118`) at all. It also does **not** rename `sweepUnreferencedBackupObjects` — W01's call site (`processCleanupExpiredSnapshots`, `~366`) depends on that exact export name and signature being unchanged, which is why Task 7 keeps the name as-is throughout. This wave's own defense of the depth-0 assumption is the `assertOutsideHeldDbContext` tripwire added inside `sweepStorageIdentity` in Task 7 — not a restructure here.
+**Scope correction (read before starting):** W01, not this wave, owns moving `cleanup-expired-snapshots` out of `createBackupWorker`'s blanket `runWithSystemDbAccess` wrap (spec §3.7 point 2 — the job-dispatch-side half of the transaction-boundary fix), and this task does **not** touch `createBackupWorker`'s job-dispatch switch (`~99-118`) at all. But per spec §3.7's last paragraph, W01's `processCleanupExpiredSnapshots` calls the sweep as `await withSystemDbAccessContext(() => sweepUnreferencedBackupObjects())` — ONE system context wrapping the ENTIRE sweep call, opened after retention has committed per row (today's read shape, kept so the sweep's reads still had working GUCs at the point W01 hands off). This task's actual code change is to **remove that wrapper** so the call becomes bare (`await sweepUnreferencedBackupObjects();`) at depth 0 — Task 7's sweep now opens its own short per-identity contexts internally and does every storage call outside them, so a context still wrapping the whole call would defeat that split. This task also does **not** rename `sweepUnreferencedBackupObjects` — its exact export name and signature stay unchanged, which is why Task 7 keeps the name as-is throughout. This wave's own defense of the depth-0 assumption is both this wrapper removal AND the `assertOutsideHeldDbContext` tripwire added inside `sweepStorageIdentity` in Task 7.
 
 **Files:** Modify `apps/api/src/jobs/backupWorker.ts:324-390` (`processCleanupExpiredSnapshots` only — its return type, its `try` block around the `sweepUnreferencedBackupObjects()` call, and its `return`). No other part of `backupWorker.ts` is touched by this task.
 
 **Interfaces:**
-- Consumes: the extended `BackupGcResult` from Task 7 (`sweepUnreferencedBackupObjects(): Promise<BackupGcResult>`, name and call depth unchanged — W01's consumed-interface guarantee above).
-- Produces: extended return type `{ deleted, skipped, prunedByMaxVersions, failed, gcDeleted, gcSkippedIdentities, gcBlockedIdentities, gcRetiredSwept, gcOrphansSwept, gcDeferredIdentities, gcUnreachableIdentities }`.
+- Consumes: the extended `BackupGcResult` from Task 7, and W01's `processCleanupExpiredSnapshots` shape — per spec §3.7's last paragraph, W01 calls the sweep as `await withSystemDbAccessContext(() => sweepUnreferencedBackupObjects())` (ONE system context wrapping the whole sweep call, opened after retention has committed per row — today's read shape, kept so the sweep's DB reads still have working GUCs at the call site W01 hands off from).
+- Produces: that same call site with the `withSystemDbAccessContext(...)` wrapper REMOVED — `await sweepUnreferencedBackupObjects();` bare, at depth 0 — since Task 7's `sweepUnreferencedBackupObjects` now opens its own short per-identity contexts internally and does every storage call outside them; plus the extended return type `{ deleted, skipped, prunedByMaxVersions, failed, gcDeleted, gcSkippedIdentities, gcBlockedIdentities, gcRetiredSwept, gcOrphansSwept, gcDeferredIdentities, gcUnreachableIdentities }`.
 
 **Cross-wave coordination note:** W01 restructures `processCleanupExpiredSnapshots`'s retention half (per-row short contexts) and moves its own call site out of the blanket wrap. This task's diff is scoped to the `try`/`return` around the `sweepUnreferencedBackupObjects()` call inside that same function — a small, easily-mergeable hunk, but still touching a function W01 is also editing. Whichever branch merges second should rebase onto the other's version of `processCleanupExpiredSnapshots` rather than blindly overwriting it (flagged in the PR checklist below), though the surface area of overlap is now much smaller than a full dispatch-switch restructure.
 
@@ -1595,6 +1599,11 @@ export async function processCleanupExpiredSnapshots(): Promise<{
   let gcDeferredIdentities = 0;
   let gcUnreachableIdentities = 0;
   try {
+    // W01 hands this off as `await withSystemDbAccessContext(() =>
+    // sweepUnreferencedBackupObjects())` — remove that wrapper here. The
+    // sweep (Task 7) now opens its own short per-identity contexts and does
+    // every storage call outside them, so wrapping the whole call in one
+    // context would defeat that split (§3.7) — the call must be bare, depth 0.
     const gcResult = await sweepUnreferencedBackupObjects();
     gcDeleted = gcResult.deleted;
     gcSkippedIdentities = gcResult.skippedIdentities;

--- a/docs/superpowers/plans/backup/2026-09-09-backup-gc-reclamation-w03-agent.md
+++ b/docs/superpowers/plans/backup/2026-09-09-backup-gc-reclamation-w03-agent.md
@@ -20,6 +20,7 @@
 - `journalMaxAge = 7 * 24 * time.Hour` (`agent/internal/backup/journal.go:34`) — unchanged, reused as the resumed-journal-age fence.
 - `uploadLeaseInterval = 15 * time.Minute`, constant in `agent/internal/backup/snapshot.go`, comment must state it stays well under the API's 9-day (`journalMaxAge` + 48h grace) manifest-less window.
 - No lease renewal exists anywhere in this wave: the helper enforces exactly the payload's `publishLeaseExpiresAt` value with no extension. A run that legitimately takes longer than the lease fails to publish by design — this mirrors the existing `journalMaxAge` non-resumable-after-7-days envelope, not a new limitation class.
+- **Gate-installation rule (P1 fix):** a present `baseSnapshotId` field (server-owned mode is ON — including an explicit full run, `baseSnapshotId: ""`) REQUIRES a non-zero `publishLeaseExpiresAt`; a payload violating this is rejected outright by `managerFromBackupRunPayload` (Task 1) before any manager is built. The `leaseGate` (Task 4) installs whenever `BackupConfig.BaseSnapshotID != nil` — never keyed off the lease value alone — so a legacy server (nil `BaseSnapshotID`) skips the gate entirely, and a server-owned-mode run always gets it. Inside the gate, a zero lease is treated as a fail-CLOSED bug condition (refuse to publish), never as "no lease configured, go ahead."
 - `DeleteSnapshot`, `DeleteSnapshotContext` are removed from `agent/internal/backup/snapshot.go` (ground truth below confirms no other caller exists). `cleanupSnapshotPrefix`/`listSnapshotPrefixItems` are KEPT — spec §3.5 names the own-run-prefix abort cleanups (`snapshot.go:499`, `:544`) as explicit exceptions.
 
 ## 0. Ground truth (re-verified 2026-09-09 against this worktree)
@@ -39,7 +40,7 @@
 - `agent/internal/backup/incremental.go:54-92` `previousManifest` (spec says `:53-100`, off by one; logic identical) — scans `ListSnapshots` results newest-first for `candidate.BackupIdentity == identity`; empty `identity` short-circuits to full-run.
 - `agent/internal/backup/snapshot.go:52-91` `Snapshot` struct (`ID`, `Timestamp`, `Files`, `Size`, `FormatVersion`, `BaseSnapshotID`, `BackupIdentity`, `UploadFailures`). `:898-956` `ListSnapshots` downloads and decodes every `snapshots/*/manifest.json`. `:1099-1126` `backupIdentity`/`runBackupIdentity`.
 - `agent/internal/backup/snapshot.go:343` `createSnapshotWithProgress(ctx, provider, files, onProgress, journal, prevSnapshot, sourceLiveness, runIdentity ...string) (*Snapshot, error)` — called from ~30 sites across `backup.go` and 5 test files with a bare `providers.BackupProvider`. Deliberately left with this exact signature (no new parameter) — see Task 4's design note.
-- `agent/internal/backup/snapshot.go:812-834` `publishSnapshotManifest` — writes the manifest to a temp file, then `uploadSnapshotFile(attemptCtx, provider, manifestPath, manifestKey)`. Both the normal-completion call (`:782`) and the `abortSourceGone` partial-manifest call (`:544-561`, specifically the `publishSnapshotManifest` at `:547`) go through this same function, so gating at the `provider.Upload`/`UploadContext` boundary via `isManifestPath` covers both without duplicating the check.
+- `agent/internal/backup/snapshot.go:812-834` `publishSnapshotManifest` — writes the manifest to a temp file, then `uploadSnapshotFile(attemptCtx, provider, manifestPath, manifestKey)`. Both the normal-completion call (`:784`) and the `abortSourceGone` partial-manifest call (`:544-561`, specifically the `publishSnapshotManifest` at `:548`) go through this same function, so gating at the `provider.Upload`/`UploadContext` boundary via `isManifestPath` covers both without duplicating the check.
 - `agent/internal/backup/snapshot.go:151` `contextUploader` interface (`UploadContext(ctx, localPath, remotePath) error`), checked via type assertion in `uploadSnapshotFile` (`:869`).
 - `agent/internal/backup/snapshot.go:1054-1057` `isManifestPath(item string) bool` — already matches `.../manifest.json` or a bare `manifest.json` basename; reused as-is by the new lease gate, no change needed.
 - `agent/internal/backup/journal.go:34` `journalMaxAge`. `:60-68` `snapshotJournal` struct has no `createdAt` field today — `header.CreatedAt` is read at `:155` inside `openSnapshotJournal` but never stored on the struct, so nothing today can ask "how old is my journal" after open. `:268-292` `createFreshJournal` builds `header.CreatedAt = time.Now().UTC()` but likewise drops it. `:88` `resumed bool` field already exists and is exactly the flag Task 4 needs ("if the run was resumed from a journal").
@@ -49,22 +50,25 @@
 - `apps/api/src/services/backupAgentContract.test.ts` (243 lines) — existing source-text-grep contract suite (e.g. `:31-48` pins `journalMaxAge` parity). Picked up by the ordinary unit config: confirmed `apps/api/vitest.config.ts` has no `exclude` for `services/*.test.ts`, so this file runs in `pnpm --filter @breeze/api test`, not the integration config.
 - `apps/api/src/jobs/backupWorker.ts:411-490,640-760` `resolveBackupTargets`/dispatch payload construction — confirmed **no** `baseSnapshotId`/`publishLeaseExpiresAt` field exists yet (W01's job). Task 8's contract test must not hard-fail before W01 lands.
 - `apps/api/src/services/backupHelperCapabilities.ts:1-20` — existing min-helper-version gate pattern (`BACKUP_QUEUE_MIN_HELPER_VERSION`, `backupHelperSupportsQueue`) that W02 will mirror for the GC capability gate; W03 does not add a TS constant, it only needs to confirm the *mechanism* by which a shipped agent's version becomes visible server-side (Task 9 below, doc-only).
-- `agent/internal/heartbeat/backup_version.go:13-120` — the helper reports its version by shelling out to `breeze-backup --version`, which prints `Breeze Backup Version: <version>` (`agent/cmd/breeze-backup/main.go:36 var version = "dev"`, overridden via `-ldflags "-X main.version=$VERSION"` in `agent/Makefile:2-8` and the release build script). This is a **build-time value supplied by the release pipeline**, not something this wave's code sets — see Open Questions.
+- `agent/internal/heartbeat/backup_version.go:13-120` (exec at `:160`) — the helper reports its version by shelling out to `breeze-backup --version`, which prints `Breeze Backup Version: <version>` (`agent/cmd/breeze-backup/main.go:36 var version = "dev"`, overridden via `-ldflags "-X main.version=$VERSION"` in `agent/Makefile:2-8` and the release build script). This is a **build-time value supplied by the release pipeline**, not something this wave's code sets — see Open Questions.
 
 ## File structure
 
 - Modify `agent/cmd/breeze-backup/exec_backup.go` — decode `baseSnapshotId`/`publishLeaseExpiresAt`, thread into both `BackupConfig` literals.
-- Modify `agent/internal/backup/backup.go` — `BackupConfig` new fields + doc comments, run-path mode switch, lease-gated provider substitution at the `createSnapshotWithProgress` call site, remove the retention-prune branch, remove ONLY the stale-journal `cleanupSnapshotPrefix` call (the two own-run-prefix `cleanupSnapshotPrefix` calls in `snapshot.go` are kept, see Task 5), add `ErrPublishLeaseExpired`/`ErrJournalExpiredAtPublish`, add `GetBaseSnapshotID`/`GetPublishLeaseExpiresAt` getters.
+- Modify `agent/internal/backup/backup.go` — `BackupConfig` new fields + doc comments, HOISTED journal-open block (moved before VSS/scan) + early resume-shortcut check, gate-install call site keyed on `BaseSnapshotID != nil`, remove the retention-prune branch (preserving the `runCtx.Err()` guard that was inside it), remove ONLY the stale-journal `cleanupSnapshotPrefix` call (the two own-run-prefix `cleanupSnapshotPrefix` calls in `snapshot.go` are kept, see Task 5), fix `job.Error = errors.Join(scanErr, retentionErr)` → `job.Error = scanErr`, add `ErrPublishLeaseExpired`/`ErrJournalExpiredAtPublish`, add `GetBaseSnapshotID`/`GetPublishLeaseExpiresAt` getters, add a plain `"path"` import.
 - Modify `agent/internal/backup/incremental.go` — new `fetchServerOwnedBase` function (imports gain `encoding/json`, `os`).
 - Modify `agent/internal/backup/journal.go` — add `createdAt time.Time` field + `Age() time.Duration` method.
-- Modify `agent/internal/backup/snapshot.go` — new `leaseGate` provider wrapper + `publishMargin`/`uploadLeaseInterval` constants; remove `DeleteSnapshot`/`DeleteSnapshotContext` only (`cleanupSnapshotPrefix`/`listSnapshotPrefixItems` and their two call sites in `abortStopped`/`abortSourceGone` are KEPT — spec §3.5 exception); add the resume-with-published-manifest shortcut and the `upload.lease` refresh goroutine + post-publish delete inside `createSnapshotWithProgress`.
-- Modify (delete tests) `agent/internal/backup/snapshot_lifecycle_test.go` — remove the six `TestDeleteSnapshot_*` tests (they target the removed `DeleteSnapshot`/`DeleteSnapshotContext`), replace with `TestBackupNeverDeletesRemoteObjects_RetentionConfigured`.
-- Modify `agent/internal/backup/snapshot_test.go` — remove `TestDeleteSnapshot_DoesNotDeleteAdjacentPrefix`; add `TestAbortCleanup_OnlyDeletesOwnUnpublishedPrefix_NeverAPublishedManifestPrefix` plus lease-gate / resume-shortcut / upload-lease tests.
-- Modify `agent/internal/backup/incremental_test.go` — add `TestFetchServerOwnedBase_*` table.
-- Modify `agent/internal/backup/journal_test.go` — add `TestSnapshotJournal_Age`.
-- Modify `agent/internal/backup/backup_test.go` — add server-owned-mode `RunBackupContext` integration-style tests; update the stale comment on `TestRunBackup_IncrementalRetentionDoesNotStrandReferencedObjects`.
-- Modify `agent/cmd/breeze-backup/exec_backup_test.go` — extend `TestManagerFromBackupRunPayload` table with the two new fields.
-- Modify `apps/api/src/services/backupAgentContract.test.ts` — add the Go/TS payload-field-name parity test + the `uploadLeaseInterval` vs. manifest-less-window assertion.
+- Modify `agent/internal/backup/providers/interface.go` — new `ErrObjectNotFound` sentinel.
+- Modify `agent/internal/backup/providers/local.go` and `agent/internal/backup/providers/s3.go` — wrap confirmed-not-found `Download` errors with `ErrObjectNotFound`.
+- Modify `agent/internal/backup/snapshot.go` — new `leaseGate` provider wrapper (fail-closed on a zero lease) + `publishMargin` const + `uploadLeaseInterval` var; remove `DeleteSnapshot`/`DeleteSnapshotContext` only (`cleanupSnapshotPrefix`/`listSnapshotPrefixItems` and their two call sites in `abortStopped`/`abortSourceGone` are KEPT — spec §3.5 exception); add the three-state `fetchPublishedManifest` + its defensive in-function resume-shortcut check; add the `upload.lease` refresh goroutine (bounded per-refresh context, `leaseCtx`-based cancellation) + post-publish delete inside `createSnapshotWithProgress`.
+- Modify (delete tests) `agent/internal/backup/snapshot_lifecycle_test.go` — remove the six `TestDeleteSnapshot_*` tests (they target the removed `DeleteSnapshot`/`DeleteSnapshotContext`) and the now-unused `"fmt"`/`"strings"` imports; no replacement test added here (moved to `backup_test.go`).
+- Modify `agent/internal/backup/snapshot_test.go` — remove `TestDeleteSnapshot_DoesNotDeleteAdjacentPrefix`; add `TestAbortCleanup_OnlyDeletesOwnUnpublishedPrefix_NeverAForeignPublishedPrefix` plus lease-gate / resume-shortcut / upload-lease / `fetchPublishedManifest` tests.
+- Modify `agent/internal/backup/incremental_test.go` — add `TestFetchServerOwnedBase` table.
+- Modify `agent/internal/backup/journal_test.go` — add `TestSnapshotJournal_Age` (with the real-gap fix), `TestSnapshotJournal_Age_SurvivesResume`.
+- Modify `agent/internal/backup/backup_test.go` — add `TestBackupNeverDeletesRemoteObjects_RetentionConfigured` (system-state-only config, see Task 5), rewrite `TestRunBackupContext_StaleJournalCleansUpRemotePrefixAndRunsFresh` → `TestRunBackupContext_StaleJournalDiscardedWithoutRemoteCleanup`, add `TestRunBackupContext_ServerOwnedMode_NeverListsTheBucket`, `TestRunBackupContext_ExpiredLease_RefusesToPublishManifest` (Task 4b), `TestRunBackupContext_ResumeWithPublishedManifest_SucceedsEvenIfSourceGone` (Task 6), update the stale comment on `TestRunBackup_IncrementalRetentionDoesNotStrandReferencedObjects`.
+- Modify (new tests) `agent/internal/backup/providers/local_test.go`, `agent/internal/backup/providers/s3_test.go` — `ErrObjectNotFound` wrapping proof.
+- Modify `agent/cmd/breeze-backup/exec_backup_test.go` — extend `TestManagerFromBackupRunPayload` table with the two new fields; add `TestManagerFromBackupRunPayload_RejectsServerOwnedModeWithoutLease`.
+- Modify `apps/api/src/services/backupAgentContract.test.ts` — add the Go/TS payload-field-name parity test, the real `BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS` import + comparison, and the gated `BACKUP_PUBLISH_MARGIN_MS` regex check.
 
 ### Task 1: Thread `baseSnapshotId`/`publishLeaseExpiresAt` from payload into `BackupConfig`
 
@@ -117,6 +121,40 @@ wantPublishLeaseExpiresAt time.Time
 },
 ```
 
+Also add a dedicated rejection test (P1 fix — a present `baseSnapshotId` with a missing/zero lease must be a hard payload error, not a silently-ungated run):
+```go
+func TestManagerFromBackupRunPayload_RejectsServerOwnedModeWithoutLease(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload string
+	}{
+		{
+			name:    "baseSnapshotId present, publishLeaseExpiresAt entirely absent",
+			payload: `{"provider":"local","providerConfig":{"path":"/var/backups"},"paths":["/data"],"baseSnapshotId":"snap-1"}`,
+		},
+		{
+			name:    "baseSnapshotId present, publishLeaseExpiresAt empty string",
+			payload: `{"provider":"local","providerConfig":{"path":"/var/backups"},"paths":["/data"],"baseSnapshotId":"snap-1","publishLeaseExpiresAt":""}`,
+		},
+		{
+			name:    "baseSnapshotId is an explicit full-run empty string, lease still required",
+			payload: `{"provider":"local","providerConfig":{"path":"/var/backups"},"paths":["/data"],"baseSnapshotId":""}`,
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			mgr, err := managerFromBackupRunPayload(json.RawMessage(tt.payload))
+			if err == nil {
+				t.Fatal("expected an error rejecting a server-owned-mode payload with no publish lease")
+			}
+			if mgr != nil {
+				t.Fatal("expected a nil manager on rejection")
+			}
+		})
+	}
+}
+```
+
 Add near the top of the test file (or reuse if a similar helper already exists — grep first):
 ```go
 func strPtr(s string) *string { return &s }
@@ -136,9 +174,9 @@ if !mgr.GetPublishLeaseExpiresAt().Equal(tt.wantPublishLeaseExpiresAt) {
 }
 ```
 
-- [ ] Step 2: Run it, expect FAIL with `mgr.GetBaseSnapshotID undefined (type *backup.BackupManager has no field or method GetBaseSnapshotID)`:
+- [ ] Step 2: Run it, expect FAIL with `mgr.GetBaseSnapshotID undefined (type *backup.BackupManager has no field or method GetBaseSnapshotID)`; the new rejection test currently FAILS the other way (expects an error, gets none, since no validation exists yet):
 ```
-cd agent && go test ./cmd/breeze-backup/ -run TestManagerFromBackupRunPayload
+cd agent && go test ./cmd/breeze-backup/ -run 'TestManagerFromBackupRunPayload|TestManagerFromBackupRunPayload_RejectsServerOwnedModeWithoutLease'
 ```
 
 - [ ] Step 3: Implement.
@@ -227,6 +265,18 @@ In `agent/cmd/breeze-backup/exec_backup.go`, extend the payload struct inside `m
 			return nil, fmt.Errorf("invalid backup_run payload: publishLeaseExpiresAt %q: %w", p.PublishLeaseExpiresAt, parseErr)
 		}
 		publishLeaseExpiresAt = parsed
+	}
+	// D18 §3.1 (P1 fix): publishLeaseExpiresAt is sent for EVERY
+	// server-owned-mode run — base or an explicit full run — never only
+	// when a base was actually chosen. A present baseSnapshotId (server-
+	// owned mode is ON, even if it points at "") with a missing, empty, or
+	// unparseable-to-zero lease means the dispatching server is violating
+	// its own protocol. Reject the WHOLE payload here rather than silently
+	// running server-owned mode ungated: main.go's caller turns this error
+	// into `fail(err.Error())`, so the backup_run command fails outright
+	// and uploads nothing.
+	if p.BaseSnapshotID != nil && publishLeaseExpiresAt.IsZero() {
+		return nil, fmt.Errorf("invalid backup_run payload: baseSnapshotId is present (server-owned mode) but publishLeaseExpiresAt is missing, empty, or zero")
 	}
 ```
 
@@ -515,6 +565,13 @@ func TestSnapshotJournal_Age_SurvivesResume(t *testing.T) {
 	}
 	j1.Abandon()
 
+	// A real gap between creation and resume (P3 fix): back-to-back opens
+	// with no sleep can't distinguish "createdAt correctly preserved from
+	// the original header" from "createdAt buggily reset to time.Now() on
+	// resume" — both would read back as ~0 either way. The sleep makes the
+	// two hypotheses diverge: preserved reads back ~50ms, reset reads ~0.
+	time.Sleep(50 * time.Millisecond)
+
 	j2, resumed, err := openSnapshotJournal(dir, "resume-age-identity", journalMaxAge)
 	if err != nil {
 		t.Fatalf("openSnapshotJournal (2nd) failed: %v", err)
@@ -523,8 +580,8 @@ func TestSnapshotJournal_Age_SurvivesResume(t *testing.T) {
 	if !resumed {
 		t.Fatal("expected the second open to resume the first journal")
 	}
-	if age := j2.Age(); age < 0 || age > time.Second {
-		t.Fatalf("resumed journal Age() = %v, want ~0 (same createdAt as the original)", age)
+	if age := j2.Age(); age < 40*time.Millisecond || age > 2*time.Second {
+		t.Fatalf("resumed journal Age() = %v, want ~50ms (original createdAt preserved across resume, not reset to time.Now())", age)
 	}
 }
 ```
@@ -606,6 +663,7 @@ git commit -m "feat(agent/backup): track checkpoint journal creation age"
 **Interfaces:**
 - Produces: `ErrPublishLeaseExpired`, `ErrJournalExpiredAtPublish` (both `error`, `backup.go`); `leaseGate` (unexported, `snapshot.go`); `publishMargin`, `uploadLeaseInterval` constants (`snapshot.go`).
 - Design note: `createSnapshotWithProgress`'s signature (`snapshot.go:343`) is deliberately left unchanged — it has ~30 call sites across 5 test files. The lease/journal-age check is enforced by wrapping the `providers.BackupProvider` passed in, at the ONE real call site (`backup.go:758`), so existing tests need no changes for this task.
+- **Gate-installation rule (P1 fix, see Global Constraints):** the gate installs whenever `m.config.BaseSnapshotID != nil` (server-owned mode ON), NOT whenever the lease happens to be non-zero. Inside `checkPublish`, a zero `publishLeaseExpiresAt` is a FAIL-CLOSED condition (`ErrPublishLeaseExpired`), never treated as "no lease, allow" — Task 1's payload validation is what's supposed to prevent this combination from ever occurring, so this is defense in depth, not the primary enforcement point.
 
 - [ ] Step 1: Write the failing test in `snapshot_test.go`:
 ```go
@@ -623,10 +681,31 @@ func TestLeaseGate_RefusesManifestPastLeaseMargin(t *testing.T) {
 	if !errors.Is(err, ErrPublishLeaseExpired) {
 		t.Fatalf("err = %v, want ErrPublishLeaseExpired", err)
 	}
-	for _, key := range provider.uploads {
+	// provider.uploads is map[remotePath]localPath — range over the KEYS
+	// (remote paths), never the values (which are local temp filenames and
+	// would make isManifestPath check the wrong string entirely).
+	for key := range provider.uploads {
 		if isManifestPath(key) {
 			t.Fatalf("manifest was uploaded despite an expired lease: %s", key)
 		}
+	}
+}
+
+func TestLeaseGate_ZeroLeaseFailsClosed(t *testing.T) {
+	// Defense in depth for the P1 fix: Task 1's payload validation is
+	// SUPPOSED to make a zero lease alongside server-owned mode
+	// unreachable, but the gate itself must never fail open if that
+	// invariant is ever violated upstream — a missing lease must refuse to
+	// publish, not silently behave as "no lease configured".
+	tmpDir := t.TempDir()
+	file1 := createTempFile(t, tmpDir, "file1.txt", "content")
+	provider := newMockProvider()
+	gated := &leaseGate{BackupProvider: provider} // publishLeaseExpiresAt left zero
+
+	files := []backupFile{{sourcePath: file1, snapshotPath: "path_0/file1.txt", size: 7, modTime: time.Now()}}
+	_, err := createSnapshotWithProgress(context.Background(), gated, files, nil, nil, nil, nil)
+	if !errors.Is(err, ErrPublishLeaseExpired) {
+		t.Fatalf("err = %v, want ErrPublishLeaseExpired (zero lease must fail closed)", err)
 	}
 }
 
@@ -756,7 +835,18 @@ func (g *leaseGate) checkPublish(remotePath string) error {
 	if !isManifestPath(remotePath) {
 		return nil
 	}
-	if !g.publishLeaseExpiresAt.IsZero() && time.Now().Add(publishMargin).After(g.publishLeaseExpiresAt) {
+	if g.publishLeaseExpiresAt.IsZero() {
+		// P1 fix: a zero lease reaching here means the "server-owned mode
+		// implies a non-zero lease" invariant (enforced at payload
+		// validation, exec_backup.go) was violated somewhere upstream.
+		// Fail CLOSED — refusing to publish is always safe; treating an
+		// absent lease as "no lease configured, proceed" is exactly the
+		// fail-open bug this gate exists to prevent, and this gate is only
+		// ever installed when server-owned mode is on (see backup.go's
+		// call site), so there is no legitimate zero-lease case here.
+		return ErrPublishLeaseExpired
+	}
+	if time.Now().Add(publishMargin).After(g.publishLeaseExpiresAt) {
 		return ErrPublishLeaseExpired
 	}
 	if g.journal != nil && g.journal.resumed && g.journal.Age() >= journalMaxAge {
@@ -791,13 +881,19 @@ func (g *leaseGate) UploadContext(ctx context.Context, localPath, remotePath str
 
 In `agent/internal/backup/backup.go`, change the call site at `:758` (immediately before it, after the journal block ends at `:756`):
 ```go
-	// Gate manifest publication on the server's lease (D18 §3.1) whenever
-	// one was sent — legacy servers (zero PublishLeaseExpiresAt) get the
-	// unwrapped provider and unchanged behavior. Applies to full runs too,
-	// not just incremental ones: the server fences every dispatched run's
+	// Gate manifest publication whenever server-owned mode is on (D18
+	// §3.1) — keyed on BaseSnapshotID being present, NOT on the lease
+	// being non-zero (P1 fix): Task 1's payload validation guarantees a
+	// non-zero lease whenever BaseSnapshotID is set, but the gate's
+	// INSTALLATION must not itself depend on that value, or a payload that
+	// somehow slipped validation with a zero lease would run completely
+	// ungated instead of hitting checkPublish's fail-closed zero-lease
+	// branch. Legacy servers (nil BaseSnapshotID) get the unwrapped
+	// provider and fully unchanged behavior. Applies to full runs too, not
+	// just incremental ones — the server fences every dispatched run's
 	// late-result window this way.
 	uploadProvider := m.config.Provider
-	if !m.config.PublishLeaseExpiresAt.IsZero() {
+	if m.config.BaseSnapshotID != nil {
 		uploadProvider = &leaseGate{
 			BackupProvider:        m.config.Provider,
 			publishLeaseExpiresAt: m.config.PublishLeaseExpiresAt,
@@ -818,6 +914,117 @@ git add agent/internal/backup/backup.go agent/internal/backup/snapshot.go agent/
 git commit -m "feat(agent/backup): refuse to publish a manifest past its lease or journal age"
 ```
 
+### Task 4b: Manager-level proof — server-owned mode never lists, expired lease blocks publish end-to-end
+
+Task 4's tests exercise `leaseGate`/`createSnapshotWithProgress` directly; this task proves the SAME properties hold through the full `RunBackupContext` wiring (goal 4's "never lists the bucket" and the gate's actual installation), which nothing else in this plan otherwise checks end-to-end.
+
+**Files:**
+- Test: `agent/internal/backup/backup_test.go` (new tests)
+
+**Interfaces:** none new — exercises `BackupManager.RunBackupContext` only.
+
+- [ ] Step 1: Write the failing tests:
+```go
+// listRecordingProvider wraps mockProvider and counts List calls, proving
+// goal 4 ("the agent never lists the bucket to choose a base") at the
+// RunBackupContext level — fetchServerOwnedBase's own unit tests (Task 2)
+// only prove it in isolation.
+type listRecordingProvider struct {
+	*mockProvider
+	listCalls int
+}
+
+func (p *listRecordingProvider) List(prefix string) ([]string, error) {
+	p.listCalls++
+	return p.mockProvider.List(prefix)
+}
+
+func TestRunBackupContext_ServerOwnedMode_NeverListsTheBucket(t *testing.T) {
+	tmpDir := t.TempDir()
+	file1 := createTempFile(t, tmpDir, "file1.txt", "content")
+	backing := newMockProvider()
+	provider := &listRecordingProvider{mockProvider: backing}
+
+	baseID := "snap-base"
+	mgr := NewBackupManager(BackupConfig{
+		Provider:              provider,
+		Paths:                 []string{tmpDir},
+		StagingDir:            t.TempDir(),
+		AgentID:               "test-device",
+		BaseSnapshotID:        &baseID,
+		PublishLeaseExpiresAt: time.Now().Add(1 * time.Hour),
+	})
+
+	// Seed the server-selected base AFTER constructing mgr, using its own
+	// runBackupIdentity() so the identity guard (D6) matches exactly what
+	// this run will compute — see incremental.go's fetchServerOwnedBase.
+	base := &Snapshot{
+		ID:             baseID,
+		BackupIdentity: mgr.runBackupIdentity(),
+		Files:          []SnapshotFile{{SourcePath: "/prior.txt", BackupPath: "snapshots/snap-base/files/prior.txt.gz", Size: 3}},
+	}
+	storeManifest(t, backing, base)
+
+	job, err := mgr.RunBackupContext(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("RunBackupContext failed: %v", err)
+	}
+	if job.Status != jobStatusCompleted {
+		t.Fatalf("job.Status = %q, want %q", job.Status, jobStatusCompleted)
+	}
+	if provider.listCalls != 0 {
+		t.Fatalf("expected zero List calls in server-owned mode, got %d", provider.listCalls)
+	}
+}
+
+func TestRunBackupContext_ExpiredLease_RefusesToPublishManifest(t *testing.T) {
+	tmpDir := t.TempDir()
+	createTempFile(t, tmpDir, "file1.txt", "content")
+	provider := newMockProvider()
+
+	baseID := "" // full run — the lease is enforced for full runs too, not just incremental ones
+	mgr := NewBackupManager(BackupConfig{
+		Provider:              provider,
+		Paths:                 []string{tmpDir},
+		StagingDir:            t.TempDir(),
+		AgentID:               "test-device",
+		BaseSnapshotID:        &baseID,
+		PublishLeaseExpiresAt: time.Now().Add(-1 * time.Hour), // already expired
+	})
+
+	job, err := mgr.RunBackupContext(context.Background(), nil)
+	if !errors.Is(err, ErrPublishLeaseExpired) {
+		t.Fatalf("err = %v, want ErrPublishLeaseExpired", err)
+	}
+	if job.Status != jobStatusFailed {
+		t.Fatalf("job.Status = %q, want %q", job.Status, jobStatusFailed)
+	}
+	for key := range provider.files {
+		if isManifestPath(key) {
+			t.Fatalf("manifest was published despite an expired lease: %s", key)
+		}
+	}
+}
+```
+
+- [ ] Step 2: Run it, expect FAIL (both: `TestRunBackupContext_ServerOwnedMode_NeverListsTheBucket` fails to compile / behaves like legacy mode since Tasks 1/2/4's production code doesn't exist on its own branch point yet if run standalone; run AFTER Tasks 1, 2, and 4 land, at which point this is a regression-proof addition — if implementing strictly in order, this task's tests should already be GREEN, so treat any failure here as a signal that Tasks 1/2/4 have a wiring gap, not as this task's own red-first step):
+```
+cd agent && go test ./internal/backup/ -run 'TestRunBackupContext_ServerOwnedMode_NeverListsTheBucket|TestRunBackupContext_ExpiredLease_RefusesToPublishManifest' -v
+```
+
+- [ ] Step 3: No new production code — this task is verification-only, confirming Tasks 1/2/4's wiring holds end-to-end.
+
+- [ ] Step 4: Run, expect PASS:
+```
+cd agent && go test ./internal/backup/ -run 'TestRunBackupContext_ServerOwnedMode_NeverListsTheBucket|TestRunBackupContext_ExpiredLease_RefusesToPublishManifest' -v
+```
+
+- [ ] Step 5: Commit:
+```
+git add agent/internal/backup/backup_test.go
+git commit -m "test(agent/backup): prove server-owned mode never lists the bucket and an expired lease blocks publish end-to-end"
+```
+
 ### Task 5: Remove agent-side retention pruning and stale-journal cleanup; keep the own-run-prefix abort cleanups
 
 Spec §3.5 (re-read after coordinator review) states the deletion removal has two **explicit
@@ -834,36 +1041,44 @@ snapshots' entire prefixes — the actually dangerous case). `cleanupSnapshotPre
 **Files:**
 - Modify `agent/internal/backup/backup.go` (retention branch `:780-806`, stale-journal cleanup call `:748`)
 - Modify `agent/internal/backup/snapshot.go` (remove only `DeleteSnapshot`/`DeleteSnapshotContext`; `abortStopped` `:496-500` and `abortSourceGone`'s zero-files branch `:541-546` are UNCHANGED — their `cleanupSnapshotPrefix` calls stay)
-- Modify `agent/internal/backup/snapshot_lifecycle_test.go` (remove the `DeleteSnapshot`/`DeleteSnapshotContext` tests only; `cleanupSnapshotPrefix`'s own behavior needs no new coverage here since Task 6 already proves it's never reached for a published manifest)
-- Modify `agent/internal/backup/snapshot_test.go` (add a new scoping test; `TestDeleteSnapshot_DoesNotDeleteAdjacentPrefix` is removed since it targets the removed `DeleteSnapshot`)
-- Modify `agent/internal/backup/backup_test.go:924-985` (comment update only)
+- Modify `agent/internal/backup/snapshot_lifecycle_test.go` (remove ONLY the six `DeleteSnapshot`/`DeleteSnapshotContext` tests; also drop the now-unused `"fmt"` and `"strings"` imports — see P2 compile-facts note below)
+- Modify `agent/internal/backup/snapshot_test.go` (`TestDeleteSnapshot_DoesNotDeleteAdjacentPrefix` is removed since it targets the removed `DeleteSnapshot`; add the own-prefix-vs-foreign-prefix scoping test)
+- Modify `agent/internal/backup/backup_test.go` (add the retention regression test HERE, not in `snapshot_lifecycle_test.go` — see below; also rewrite `TestRunBackupContext_StaleJournalCleansUpRemotePrefixAndRunsFresh` at `:245-300` to assert NO deletion)
 
 **Interfaces:**
 - Removes: `DeleteSnapshot`, `DeleteSnapshotContext` only (confirmed zero external callers in Ground Truth §0; `backup.go:799` was `DeleteSnapshotContext`'s only caller).
 - Keeps unchanged: `cleanupSnapshotPrefix`, `listSnapshotPrefixItems` (still called from `snapshot.go:499`/`:544`).
-- Produces (test-only): `TestBackupNeverDeletesRemoteObjects_RetentionConfigured`, `TestAbortCleanup_OnlyDeletesOwnUnpublishedPrefix_NeverAPublishedManifestPrefix`.
-- **Ordering guarantee this task relies on**: Task 6's resume-with-already-published-manifest shortcut is inserted immediately after `prefix := path.Join(snapshotRootDir, snapshot.ID)` and returns before the upload loop — and therefore before either `abortStopped` or `abortSourceGone` can be reached — whenever `journal != nil && journal.resumed` and that journal's manifest already exists. So a journal-resumed run whose manifest is already published can never reach a `cleanupSnapshotPrefix` call: it returns via Task 6's early path first. This is a structural property of the current control flow (Task 6's insertion point strictly precedes both abort closures' only call sites), not something Task 5 needs to add logic for — but the new test below pins it as a regression guard in case a future refactor reorders them.
+- Produces (test-only): `TestBackupNeverDeletesRemoteObjects_RetentionConfigured` (moved to `backup_test.go`), `TestAbortCleanup_OnlyDeletesOwnUnpublishedPrefix_NeverAForeignPublishedPrefix` (`snapshot_test.go`), a rewritten `TestRunBackupContext_StaleJournalCleansUpRemotePrefixAndRunsFresh` (`backup_test.go`).
+- **Ordering guarantee this task relies on**: Task 6 (revised after review) installs the resume-with-already-published-manifest shortcut in TWO places: primarily in `RunBackupContext` (`backup.go`), hoisted to run before VSS/scan/`createSnapshotWithProgress` are ever reached at all; and defensively inside `createSnapshotWithProgress` itself, immediately after `prefix := path.Join(...)`, before the upload loop — and therefore before either `abortStopped` or `abortSourceGone` can be reached — whenever `journal != nil && journal.resumed` and that journal's manifest is CONFIRMED already published. Either way, a journal-resumed run whose manifest is already published never reaches a `cleanupSnapshotPrefix` call: it returns via one of the two early paths first. This is a structural property of the control flow both checks establish; Task 6's own `TestCreateSnapshot_ResumeWithAlreadyPublishedManifest_SkipsUploadAndDelete` test already asserts zero deletes for this exact scenario, so this task does not duplicate it.
 
 - [ ] Step 1: Write the failing tests.
 
-Remove `TestDeleteSnapshot_NothingToDelete`, `_ZeroRetention`, `_NegativeRetention`, `_PrunesOldSnapshots`, `_RetentionExceedsCount`, `_DeleteError` from `snapshot_lifecycle_test.go` (`:108-208`) — they exercise a function that no longer exists — and add:
+Remove `TestDeleteSnapshot_NothingToDelete`, `_ZeroRetention`, `_NegativeRetention`, `_PrunesOldSnapshots`, `_RetentionExceedsCount`, `_DeleteError` from `snapshot_lifecycle_test.go` (`:108-208`) — they exercise a function that no longer exists. **P2 compile-facts fix**: after removing them, `"fmt"` and `"strings"` become unused imports in this file (both are used ONLY inside these six tests — verified by reading the whole file; `errors` and `path` remain used by `TestListSnapshots_ListError`/`TestListSnapshots_CorruptManifest` and stay). Remove `"fmt"` and `"strings"` from this file's import block entirely; do not add a replacement test to this file (the replacement test below goes in `backup_test.go` instead, which already imports everything it needs).
+
+**P2 fix — exercise the REAL retention-prune branch, not a vacuous config.** `incrementalDedupeActive := !m.config.SystemStateEnabled || len(m.config.Paths) > 0` (`backup.go:683`) is `true` for ANY file-mode config with `Paths` set, regardless of Retention — so a `Paths`-configured test can never reach the retention-prune branch (`backup.go:798`) even on UNFIXED code, making it pass vacuously both before and after this task's fix. The branch is reachable only for a system-state-ONLY run (`SystemStateEnabled: true`, `Paths` empty). Also, after Task 7 lands, EVERY successful run legitimately writes-then-deletes its own `upload.lease` — so asserting `len(deleteCalls) == 0` outright would break for an unrelated, correct reason. Add to `backup_test.go` (which already imports `systemstate` for `stubCollectSystemState`, defined at `:479-484`):
 ```go
-// D18 §3.5: agent-side retention pruning is removed entirely (unlike the
-// two explicit own-run-prefix exceptions kept in snapshot.go — see
-// TestAbortCleanup_OnlyDeletesOwnUnpublishedPrefix... below). This replaces
-// the removed DeleteSnapshot/DeleteSnapshotContext pruning tests: instead of
-// asserting pruning behavior, it asserts NO deletion happens across
-// multiple successful runs even with Retention configured.
+// D18 §3.5: agent-side retention pruning is removed entirely. A
+// system-state-only run is the ONLY config shape that reaches the (now
+// removed) retention-prune branch pre-fix — incrementalDedupeActive is
+// false exactly when SystemStateEnabled && len(Paths)==0 (backup.go:683) —
+// so this is the config that actually exercises the danger, unlike a
+// Paths-configured run which never reaches that branch either way.
 func TestBackupNeverDeletesRemoteObjects_RetentionConfigured(t *testing.T) {
-	tmpDir := t.TempDir()
-	createTempFile(t, tmpDir, "data.txt", "content")
+	systemStateDir := t.TempDir()
+	if err := os.WriteFile(pathpkg.Join(systemStateDir, "services.txt"), []byte("svc"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	stubCollectSystemState(t, func() (*systemstate.SystemStateManifest, string, error) {
+		return &systemstate.SystemStateManifest{Platform: "test"}, systemStateDir, nil
+	})
+
 	provider := newMockProvider()
 	mgr := NewBackupManager(BackupConfig{
-		Provider:   provider,
-		Paths:      []string{tmpDir},
-		Retention:  1, // ignored — see GetRetention's doc comment
-		StagingDir: t.TempDir(),
-		AgentID:    "test-device",
+		Provider:           provider,
+		SystemStateEnabled: true,
+		Retention:          1, // ignored — see GetRetention's doc comment
+		StagingDir:         t.TempDir(),
+		AgentID:            "test-device",
 	})
 
 	for i := 0; i < 3; i++ {
@@ -871,113 +1086,102 @@ func TestBackupNeverDeletesRemoteObjects_RetentionConfigured(t *testing.T) {
 			t.Fatalf("RunBackupContext #%d failed: %v", i+1, err)
 		}
 	}
-	if len(provider.deleteCalls) != 0 {
-		t.Fatalf("expected zero Delete calls across successful runs with Retention set, got %d: %v", len(provider.deleteCalls), provider.deleteCalls)
+	// After Task 7, each run's own upload.lease is written then deleted —
+	// the ONLY delete this test may legitimately see. Any delete for a
+	// DIFFERENT run's snapshot id (i.e. anything but that run's own
+	// upload.lease) is the retention-prune bug this test guards against.
+	for _, key := range provider.deleteCalls {
+		if !strings.HasSuffix(key, "/upload.lease") {
+			t.Fatalf("expected deletes to be limited to each run's own upload.lease, got: %s (all: %v)", key, provider.deleteCalls)
+		}
 	}
 }
 ```
 
 Remove `TestDeleteSnapshot_DoesNotDeleteAdjacentPrefix` in `snapshot_test.go` (`:198-230`) and add:
 ```go
-// TestAbortCleanup_OnlyDeletesOwnUnpublishedPrefix_NeverAPublishedManifestPrefix
-// pins the §3.5 exception's boundary from both directions: (1) a journal-less
-// stop DOES delete keys, but only under the aborted run's OWN snapshot id —
-// never a sibling prefix that already has a manifest.json (an existing,
-// referenceable snapshot); and (2) proves the ordering guarantee this task's
-// Interfaces section describes — a journal-RESUMED run whose manifest is
-// already published takes Task 6's early-return path and reaches
-// cleanupSnapshotPrefix zero times, never deleting the manifest it just
-// found.
-func TestAbortCleanup_OnlyDeletesOwnUnpublishedPrefix_NeverAPublishedManifestPrefix(t *testing.T) {
-	t.Run("journal-less stop deletes only its own snapshot id's keys", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		file1 := createTempFile(t, tmpDir, "file1.txt", "content")
-		provider := newMockProvider()
+// cancelAfterFirstUploadProvider wraps mockProvider and cancels the given
+// CancelFunc right after the FIRST real Upload lands, so an aborted run has
+// something concrete under ITS OWN prefix for the abort cleanup to act on
+// (P3 fix — the previous version of this test never uploaded anything
+// before cancelling, so it could only prove absence-of-harm on an empty
+// prefix, not that own-prefix cleanup actually deletes what it should).
+type cancelAfterFirstUploadProvider struct {
+	*mockProvider
+	cancel   context.CancelFunc
+	uploaded int
+	mu       sync.Mutex
+}
 
-		// Seed a sibling, already-published snapshot that must never be
-		// touched by the aborted run's cleanup.
-		sibling := &Snapshot{
-			ID:    "snapshot-sibling-published",
-			Files: []SnapshotFile{{SourcePath: "/data/other.txt", BackupPath: "snapshots/snapshot-sibling-published/files/other.txt.gz", Size: 1}},
-		}
-		storeManifest(t, provider, sibling)
+func (p *cancelAfterFirstUploadProvider) Upload(localPath, remotePath string) error {
+	err := p.mockProvider.Upload(localPath, remotePath)
+	p.mu.Lock()
+	p.uploaded++
+	first := p.uploaded == 1
+	p.mu.Unlock()
+	if first && p.cancel != nil {
+		p.cancel()
+	}
+	return err
+}
 
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel() // already stopped before the loop starts
-		files := []backupFile{{sourcePath: file1, snapshotPath: "path_0/file1.txt", size: 7, modTime: time.Now()}}
-		snap, err := createSnapshotWithProgress(ctx, provider, files, nil, nil, nil, nil)
-		if !errors.Is(err, errBackupStopped) {
-			t.Fatalf("err = %v, want errBackupStopped", err)
-		}
-		_ = snap // stopped runs return a nil snapshot; the aborted run's own id is read from deleteCalls below.
+// TestAbortCleanup_OnlyDeletesOwnUnpublishedPrefix_NeverAForeignPublishedPrefix
+// pins the §3.5 exception's boundary from both directions (P3 fix): objects
+// are seeded under BOTH the aborted run's own (to-be-cleaned) prefix and a
+// foreign, already-published sibling prefix, and only the former may be
+// deleted. The resume-skips-cleanup property is deliberately NOT duplicated
+// here — Task 6's TestCreateSnapshot_ResumeWithAlreadyPublishedManifest_
+// SkipsUploadAndDelete already asserts zero deletes for that exact scenario
+// with a valid (non-cancelled) context; an earlier draft of this test tried
+// to force that scenario via an already-cancelled context, which cannot
+// pass against this plan's fetchPublishedManifest (it checks ctx.Err()
+// first and fails closed) and was dropped as a P2 fix.
+func TestAbortCleanup_OnlyDeletesOwnUnpublishedPrefix_NeverAForeignPublishedPrefix(t *testing.T) {
+	tmpDir := t.TempDir()
+	file1 := createTempFile(t, tmpDir, "file1.txt", "content-one")
+	file2 := createTempFile(t, tmpDir, "file2.txt", "content-two")
+	backing := newMockProvider()
 
-		for _, key := range provider.deleteCalls {
-			if strings.HasPrefix(key, "snapshots/snapshot-sibling-published/") {
-				t.Fatalf("abort cleanup deleted a key under a PUBLISHED sibling prefix: %s", key)
-			}
-		}
-		if _, stillThere := provider.files["snapshots/snapshot-sibling-published/manifest.json"]; !stillThere {
-			t.Fatal("sibling published manifest must survive the aborted run's cleanup")
-		}
-	})
+	// Seed a sibling, already-published snapshot that must never be
+	// touched by the aborted run's cleanup.
+	sibling := &Snapshot{
+		ID:    "snapshot-sibling-published",
+		Files: []SnapshotFile{{SourcePath: "/data/other.txt", BackupPath: "snapshots/snapshot-sibling-published/files/other.txt.gz", Size: 1}},
+	}
+	storeManifest(t, backing, sibling)
 
-	t.Run("resumed run with an already-published manifest never reaches cleanupSnapshotPrefix", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		file1 := createTempFile(t, tmpDir, "file1.txt", "content")
-		provider := newMockProvider()
+	ctx, cancel := context.WithCancel(context.Background())
+	provider := &cancelAfterFirstUploadProvider{mockProvider: backing, cancel: cancel}
 
-		journalDir := t.TempDir()
-		journal, _, err := openSnapshotJournal(journalDir, "resume-cleanup-guard-identity", journalMaxAge)
-		if err != nil {
-			t.Fatalf("openSnapshotJournal failed: %v", err)
-		}
-		published := &Snapshot{
-			ID:    journal.snapshotID,
-			Files: []SnapshotFile{{SourcePath: file1, BackupPath: "snapshots/" + journal.snapshotID + "/files/file1.txt.gz", Size: 7}},
-		}
-		storeManifest(t, provider, published)
-		journal.Abandon()
+	files := []backupFile{
+		{sourcePath: file1, snapshotPath: "path_0/file1.txt", size: 11, modTime: time.Now()},
+		{sourcePath: file2, snapshotPath: "path_0/file2.txt", size: 11, modTime: time.Now()},
+	}
+	_, err := createSnapshotWithProgress(ctx, provider, files, nil, nil, nil, nil)
+	if !errors.Is(err, errBackupStopped) {
+		t.Fatalf("err = %v, want errBackupStopped", err)
+	}
 
-		journal2, resumed, err := openSnapshotJournal(journalDir, "resume-cleanup-guard-identity", journalMaxAge)
-		if err != nil {
-			t.Fatalf("openSnapshotJournal (resume) failed: %v", err)
+	sawOwnPrefixDelete := false
+	for _, key := range backing.deleteCalls {
+		if strings.HasPrefix(key, "snapshots/snapshot-sibling-published/") {
+			t.Fatalf("abort cleanup deleted a key under a PUBLISHED sibling prefix: %s", key)
 		}
-		if !resumed {
-			t.Fatal("expected the journal to resume")
-		}
-
-		// A cancelled context proves the resume shortcut wins the race
-		// against abortStopped: if cleanupSnapshotPrefix ran here instead,
-		// it would delete the manifest just seeded above.
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel()
-		files := []backupFile{{sourcePath: file1, snapshotPath: "path_0/file1.txt", size: 7, modTime: time.Now()}}
-		snap, err := createSnapshotWithProgress(ctx, provider, files, nil, journal2, nil, nil)
-		if err != nil {
-			t.Fatalf("expected the resume shortcut to succeed despite the cancelled context, got err: %v", err)
-		}
-		if snap == nil || snap.ID != journal.snapshotID {
-			t.Fatalf("expected the already-published snapshot back, got %+v", snap)
-		}
-		manifestKey := "snapshots/" + journal.snapshotID + "/manifest.json"
-		if _, stillThere := provider.files[manifestKey]; !stillThere {
-			t.Fatal("resumed run's own already-published manifest must survive — cleanupSnapshotPrefix must never have run")
-		}
-		for _, key := range provider.deleteCalls {
-			if strings.HasPrefix(key, "snapshots/"+journal.snapshotID+"/") {
-				t.Fatalf("cleanupSnapshotPrefix ran for a prefix with an already-published manifest: deleted %s", key)
-			}
-		}
-	})
+		sawOwnPrefixDelete = true
+	}
+	if !sawOwnPrefixDelete {
+		t.Fatal("expected the aborted run's own uploaded file to be cleaned up under its own prefix")
+	}
+	if _, stillThere := backing.files["snapshots/snapshot-sibling-published/manifest.json"]; !stillThere {
+		t.Fatal("sibling published manifest must survive the aborted run's cleanup")
+	}
 }
 ```
-(`strings` is already imported by `snapshot_test.go` — verify before adding if not.)
 
-- [ ] Step 2: Run it, expect FAIL — `TestBackupNeverDeletesRemoteObjects_RetentionConfigured` fails with non-zero delete calls (current retention-prune branch still fires for `Retention:1` since it's only gated on `!incrementalDedupeActive`, and this test uses `Paths` with no prior snapshot so `incrementalDedupeActive` is still true every run in this config... re-check: confirm which sub-case reproduces the CURRENT bug before relying on it — if `incrementalDedupeActive` is true throughout for this config the branch already doesn't fire, in which case this specific test is a regression guard rather than red-first. The second test, `TestAbortCleanup_OnlyDeletesOwnUnpublishedPrefix_NeverAPublishedManifestPrefix`'s second subtest, IS red-first against current code: Task 6 doesn't exist yet, so the resumed run calls `abortStopped()` → `cleanupSnapshotPrefix` → deletes the seeded manifest):
+- [ ] Step 2: Run it, expect FAIL — `TestBackupNeverDeletesRemoteObjects_RetentionConfigured` (in `backup_test.go`) fails with a non-`/upload.lease` delete call, since the system-state-only config now correctly reaches the retention-prune branch pre-fix (`backup.go:798`, `!incrementalDedupeActive` is true for this config shape). `TestAbortCleanup_OnlyDeletesOwnUnpublishedPrefix_NeverAForeignPublishedPrefix` should already PASS against current (pre-Task-5) code — it exercises `abortStopped`'s existing, UNCHANGED own-prefix cleanup, which this task does not remove; treat any failure here as a signal the test itself has a bug, not as this task's red-first step:
 ```
 cd agent && go test ./internal/backup/ -run 'TestBackupNeverDeletesRemoteObjects_RetentionConfigured|TestAbortCleanup_OnlyDeletesOwnUnpublishedPrefix' -v
 ```
-Confirm the resume subtest fails with the manifest missing (`stillThere` false) before implementing — that failure is this task's actual red signal; write Task 6 first if sequencing this task standalone (Tasks are listed in dependency order specifically so Task 6 lands before this test is expected green — if implementing out of order, note the dependency here).
 
 - [ ] Step 3: Implement.
 
@@ -1007,6 +1211,69 @@ Change the stale-journal branch (`:738-749`) — remove ONLY the `cleanupSnapsho
 
 Remove `DeleteSnapshot` (`:972-974`) and `DeleteSnapshotContext` (`:977-1023`) from `snapshot.go` entirely. Leave `cleanupSnapshotPrefix` (`:884-892`) and `listSnapshotPrefixItems` (`:1025-1032`) exactly as they are.
 
+**P2 fix — rewrite the stale-journal test to assert NO deletion.** `TestRunBackupContext_StaleJournalCleansUpRemotePrefixAndRunsFresh` (`backup_test.go:245-300`) currently seeds an orphan object under the stale snapshot's prefix and asserts it GETS deleted (`found` must be `true` at `:295-299`) — that assertion describes the exact behavior this task removes. Rename and rewrite it:
+```go
+// TestRunBackupContext_StaleJournalDiscardedWithoutRemoteCleanup proves the
+// D18 §3.5 fix directly: a journal older than journalMaxAge is discarded
+// and the run proceeds fresh with a brand new snapshot ID, but the STALE
+// journal's remote prefix is left untouched — no agent-side delete, ever,
+// for another run's (even an abandoned one's) prefix. GC's existing
+// manifest-less-prefix rule is the only thing that may eventually reclaim
+// it.
+func TestRunBackupContext_StaleJournalDiscardedWithoutRemoteCleanup(t *testing.T) {
+	restoreMaxAge := setJournalMaxAgeForTest(time.Millisecond)
+	defer restoreMaxAge()
+
+	provider := newMockProvider()
+	stagingDir := t.TempDir()
+	tmpDir := t.TempDir()
+	createTempFile(t, tmpDir, "data.txt", "hello")
+
+	mgr := NewBackupManager(BackupConfig{
+		Provider:   provider,
+		Paths:      []string{tmpDir},
+		StagingDir: stagingDir,
+	})
+
+	identity := backupIdentity(provider, []string{tmpDir})
+	staleJournal, _, err := openSnapshotJournal(stagingDir, identity, time.Hour)
+	if err != nil {
+		t.Fatalf("openSnapshotJournal failed: %v", err)
+	}
+	if err := staleJournal.Record(SnapshotFile{SourcePath: "/gone.txt", Size: 1, ModTime: time.Now()}); err != nil {
+		t.Fatalf("Record failed: %v", err)
+	}
+	staleSnapshotID := staleJournal.snapshotID
+	staleJournal.Abandon()
+
+	orphanKey := path.Join(snapshotRootDir, staleSnapshotID, snapshotFilesDir, "orphan.gz")
+	provider.files[orphanKey] = []byte("orphan")
+
+	time.Sleep(2 * time.Millisecond) // the journal is now older than the shrunk maxAge
+
+	job, err := mgr.RunBackup()
+	if err != nil {
+		t.Fatalf("RunBackup failed: %v", err)
+	}
+	if job.Status != jobStatusCompleted {
+		t.Fatalf("job.Status = %q, want %q", job.Status, jobStatusCompleted)
+	}
+	if job.Snapshot == nil {
+		t.Fatal("expected a completed snapshot")
+	}
+	if job.Snapshot.ID == staleSnapshotID {
+		t.Fatal("a stale journal must never resume the old snapshot ID")
+	}
+
+	if len(provider.deleteCalls) != 0 {
+		t.Fatalf("expected zero Delete calls for a discarded stale journal, got: %v", provider.deleteCalls)
+	}
+	if _, stillThere := provider.files[orphanKey]; !stillThere {
+		t.Fatal("the stale journal's orphan object must survive — the agent no longer cleans it up (GC's manifest-less rule is the backstop)")
+	}
+}
+```
+
 Update the comment on `TestRunBackup_IncrementalRetentionDoesNotStrandReferencedObjects` (`backup_test.go:924-933`) — the branch it warns about is now gone, not merely gated:
 ```go
 // Incremental dedupe (now unconditional) carries an unchanged file's bytes
@@ -1023,7 +1290,7 @@ Update the comment on `TestRunBackup_IncrementalRetentionDoesNotStrandReferenced
 
 - [ ] Step 4: Run, expect PASS (and confirm the two removed functions leave no dangling references while the two kept ones still compile and are still called):
 ```
-cd agent && go build ./... && go test ./internal/backup/... ./cmd/breeze-backup/... -run 'TestBackupNeverDeletesRemoteObjects|TestAbortCleanup_OnlyDeletesOwnUnpublishedPrefix|TestRunBackup_IncrementalRetentionDoesNotStrandReferencedObjects' -v
+cd agent && go build ./... && go test ./internal/backup/... ./cmd/breeze-backup/... -run 'TestBackupNeverDeletesRemoteObjects|TestAbortCleanup_OnlyDeletesOwnUnpublishedPrefix|TestRunBackup_IncrementalRetentionDoesNotStrandReferencedObjects|TestRunBackupContext_StaleJournalDiscardedWithoutRemoteCleanup' -v
 ```
 
 - [ ] Step 5: Commit:
@@ -1032,18 +1299,83 @@ git add agent/internal/backup/backup.go agent/internal/backup/snapshot.go agent/
 git commit -m "feat(agent/backup): remove agent-side retention pruning and stale-journal cleanup (D18 §3.5)"
 ```
 
-### Task 6: Resume with an already-published manifest — skip re-upload entirely
+### Task 6: Resume with an already-published manifest — skip re-upload entirely, fail CLOSED on ambiguous errors, run BEFORE source validation
+
+Two corrections from independent review folded in here:
+- **P1 (fail-open bug):** the original design treated ANY download failure — including a transient network error — as "manifest absent, safe to upload". That is wrong: a transient error must never be conflated with a confirmed-absent object, since guessing wrong risks silently overwriting/duplicating a manifest that genuinely exists. Only a POSITIVELY CONFIRMED not-found may proceed to upload; every other error must abort the run untouched. This requires a way to distinguish "confirmed absent" from "some other failure" across providers — added as part of this task (`providers.ErrObjectNotFound`).
+- **P2 (ordering bug):** the resume check must run BEFORE `RunBackupContext`'s source-scan short-circuits (`backup.go:641`'s `len(files) == 0` exit, reached before `createSnapshotWithProgress` is ever called) and before `createSnapshotWithProgress`'s own `len(files) == 0` reject (`snapshot.go:371`). Otherwise a resumed run whose source has since vanished (disk unplugged, volume gone) would report failure/skipped instead of the success it should report, since the manifest was already durably published. This means the journal-open block (currently `backup.go:713-756`) must be HOISTED to before VSS/scan, and the resume check performed there — not solely inside `createSnapshotWithProgress`, which by construction can't run early enough for this ordering to hold when reached only from `RunBackupContext`.
 
 **Files:**
-- Modify `agent/internal/backup/snapshot.go` (`createSnapshotWithProgress`, insert after the `prefix := path.Join(...)` line, currently `:388`)
-- Test: `agent/internal/backup/snapshot_test.go` (new tests)
+- Modify `agent/internal/backup/providers/interface.go` (new `ErrObjectNotFound` sentinel)
+- Modify `agent/internal/backup/providers/local.go` (`Download`, `:87-107`) and `agent/internal/backup/providers/s3.go` (`Download`, `:135-165`) — wrap confirmed-not-found errors
+- Modify `agent/internal/backup/backup.go` — hoist the journal-open block (`:713-756`) from after the scan to right after `defer stopRunKeepalive()` (`:408`), before the VSS block (`:410`); add the resume-shortcut check there
+- Modify `agent/internal/backup/snapshot.go` (`createSnapshotWithProgress`, insert after the `prefix := path.Join(...)` line, currently `:390`, as a SECOND, defensive check — see design note)
+- Test: `agent/internal/backup/snapshot_test.go`, `agent/internal/backup/backup_test.go` (new tests), `agent/internal/backup/providers/local_test.go`, `agent/internal/backup/providers/s3_test.go` (new tests for the sentinel wrapping)
 
 **Interfaces:**
-- Produces (unexported): `fetchPublishedManifest(ctx context.Context, provider providers.BackupProvider, prefix string) (*Snapshot, bool)`
+- Produces: `providers.ErrObjectNotFound` (sentinel `error`, `providers/interface.go`) — a provider's `Download` wraps it (`fmt.Errorf("%w: ...", providers.ErrObjectNotFound, ...)`) only when it can POSITIVELY confirm the object doesn't exist.
+- Produces (unexported): `fetchPublishedManifest(ctx context.Context, provider providers.BackupProvider, prefix string) (snapshot *Snapshot, err error)` — **three-state**, not two: `(snapshot, nil)` = confirmed present and decodable; `(nil, nil)` = confirmed absent (`errors.Is(downloadErr, providers.ErrObjectNotFound)`), safe to proceed with upload; `(nil, err)` = anything else (network failure, decode error, corrupt manifest) — caller MUST fail the run closed, uploading and deleting nothing.
+- Design note: the check now lives in TWO places by design, not one. `RunBackupContext` (`backup.go`) performs it early (before scan) as the PRIMARY enforcement point — this is what makes the "source gone" ordering correct. `createSnapshotWithProgress` keeps a second, identical check (as before) so its own direct unit tests (which call it without going through `RunBackupContext`) still exercise and prove the behavior in isolation. Both call the same `fetchPublishedManifest` helper, so there is one implementation, not two.
 
-- [ ] Step 1: Write the failing test:
+- [ ] Step 1: Write the failing tests.
+
+**Provider-level (new files or extend existing `_test.go` files) — proves the sentinel wrapping:**
 ```go
-func TestCreateSnapshot_ResumeWithAlreadyPublishedManifest_SkipsUpload(t *testing.T) {
+// In agent/internal/backup/providers/local_test.go
+func TestLocalProvider_Download_MissingFileWrapsErrObjectNotFound(t *testing.T) {
+	p := NewLocalProvider(t.TempDir())
+	err := p.Download("snapshots/does-not-exist/manifest.json", filepath.Join(t.TempDir(), "out.json"))
+	if err == nil {
+		t.Fatal("expected an error for a missing object")
+	}
+	if !errors.Is(err, ErrObjectNotFound) {
+		t.Fatalf("err = %v, want it to wrap ErrObjectNotFound", err)
+	}
+}
+
+// In agent/internal/backup/providers/s3_test.go — requires whatever fake S3
+// backend / httptest server this file's existing tests already use to
+// return a 404/NoSuchKey response; mirror that pattern (grep the file
+// first for its existing GetObject-mocking approach) rather than hitting
+// real S3. If no such fake exists for Download today, add the minimal one
+// needed to return a NoSuchKey-shaped error.
+func TestS3Provider_Download_NoSuchKeyWrapsErrObjectNotFound(t *testing.T) {
+	// (fill in using this file's existing S3 test-double pattern)
+}
+```
+
+**Resume/ordering (`snapshot_test.go`):**
+```go
+func TestFetchPublishedManifest_ConfirmedAbsent_ReturnsNilNil(t *testing.T) {
+	provider := newMockProvider() // never seeded with the manifest key
+	snap, err := fetchPublishedManifest(context.Background(), provider, "snapshots/never-published")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if snap != nil {
+		t.Fatalf("expected nil snapshot for a confirmed-absent manifest, got %+v", snap)
+	}
+}
+
+// mockProvider needs a way to simulate a TRANSIENT (non-not-found) download
+// failure, distinct from "key genuinely absent" — add a `downloadErr error`
+// override if the existing field always represents a generic failure (check
+// mockProvider.downloadErr's current semantics first; if it's already a
+// plain, non-ErrObjectNotFound error by default, it already models this
+// case correctly with no changes needed).
+func TestFetchPublishedManifest_TransientError_FailsClosed_NotTreatedAsAbsent(t *testing.T) {
+	provider := newMockProvider()
+	provider.downloadErr = errors.New("connection reset by peer") // NOT ErrObjectNotFound
+	snap, err := fetchPublishedManifest(context.Background(), provider, "snapshots/some-id")
+	if err == nil {
+		t.Fatal("expected a non-nil error for a transient failure — must NOT be treated as confirmed absence")
+	}
+	if snap != nil {
+		t.Fatalf("expected nil snapshot on error, got %+v", snap)
+	}
+}
+
+func TestCreateSnapshot_ResumeWithAlreadyPublishedManifest_SkipsUploadAndDelete(t *testing.T) {
 	tmpDir := t.TempDir()
 	file1 := createTempFile(t, tmpDir, "file1.txt", "content one")
 	provider := newMockProvider()
@@ -1065,9 +1397,6 @@ func TestCreateSnapshot_ResumeWithAlreadyPublishedManifest_SkipsUpload(t *testin
 	storeManifest(t, provider, published)
 	preUploadCount := len(provider.uploadCalls)
 
-	// Re-open as a resume (same identity, same dir): openSnapshotJournal
-	// would normally do this on a real second process start. Emulate it by
-	// re-opening — resumed should be true since createdAt is fresh.
 	journal.Abandon()
 	journal2, resumed, err := openSnapshotJournal(journalDir, "resume-published-identity", journalMaxAge)
 	if err != nil {
@@ -1088,66 +1417,209 @@ func TestCreateSnapshot_ResumeWithAlreadyPublishedManifest_SkipsUpload(t *testin
 	if len(provider.uploadCalls) != preUploadCount {
 		t.Fatalf("expected zero NEW uploads on an already-published resume, got %d new calls", len(provider.uploadCalls)-preUploadCount)
 	}
+	if len(provider.deleteCalls) != 0 {
+		t.Fatalf("expected zero deletes on an already-published resume, got %v", provider.deleteCalls)
+	}
 }
 ```
 
-- [ ] Step 2: Run it, expect FAIL (current code re-uploads `file1.txt` since it isn't in the journal's resumed entries):
+**Source-gone ordering, at the `RunBackupContext` level (`backup_test.go`) — this is the test that actually proves the P2 fix:**
+```go
+func TestRunBackupContext_ResumeWithPublishedManifest_SucceedsEvenIfSourceGone(t *testing.T) {
+	tmpDir := t.TempDir()
+	file1 := createTempFile(t, tmpDir, "file1.txt", "content")
+	provider := newMockProvider()
+	stagingDir := t.TempDir()
+
+	identity := backupIdentity(provider, []string{tmpDir})
+	journal, _, err := openSnapshotJournal(stagingDir, identity, journalMaxAge)
+	if err != nil {
+		t.Fatalf("openSnapshotJournal failed: %v", err)
+	}
+	published := &Snapshot{
+		ID:    journal.snapshotID,
+		Files: []SnapshotFile{{SourcePath: file1, BackupPath: "snapshots/" + journal.snapshotID + "/files/file1.txt.gz", Size: 7}},
+		Size:  7,
+	}
+	storeManifest(t, provider, published)
+	journal.Abandon()
+
+	// The source is now GONE — remove the file (and its directory) the
+	// configured path pointed at, so a fresh scan would find nothing and,
+	// pre-fix, hit backup.go:641's len(files)==0 early exit BEFORE the
+	// journal/resume check ever ran.
+	if err := os.RemoveAll(tmpDir); err != nil {
+		t.Fatalf("failed to remove source dir: %v", err)
+	}
+
+	mgr := NewBackupManager(BackupConfig{
+		Provider:   provider,
+		Paths:      []string{tmpDir},
+		StagingDir: stagingDir,
+	})
+
+	job, err := mgr.RunBackupContext(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("expected the resume shortcut to succeed despite the gone source, got err: %v", err)
+	}
+	if job.Status != jobStatusCompleted {
+		t.Fatalf("job.Status = %q, want %q (source-gone must not prevent reporting the already-published manifest)", job.Status, jobStatusCompleted)
+	}
+	if job.Snapshot == nil || job.Snapshot.ID != journal.snapshotID {
+		t.Fatalf("expected the already-published snapshot back, got %+v", job.Snapshot)
+	}
+}
 ```
-cd agent && go test ./internal/backup/ -run TestCreateSnapshot_ResumeWithAlreadyPublishedManifest_SkipsUpload -v
+
+- [ ] Step 2: Run it, expect FAIL — `TestLocalProvider_Download_MissingFileWrapsErrObjectNotFound` fails to compile (`undefined: ErrObjectNotFound`); `TestFetchPublishedManifest_TransientError_FailsClosed_NotTreatedAsAbsent` fails to compile (`undefined: fetchPublishedManifest`, or once Step 3 lands, fails because the old two-state version treats the transient error as absence); `TestRunBackupContext_ResumeWithPublishedManifest_SucceedsEvenIfSourceGone` fails against CURRENT/unhoisted code with `job.Status = "skipped"` (or `"failed"`), proving the ordering bug:
+```
+cd agent && go test ./internal/backup/... -run 'ErrObjectNotFound|FetchPublishedManifest|TestCreateSnapshot_ResumeWithAlreadyPublishedManifest|TestRunBackupContext_ResumeWithPublishedManifest' -v
 ```
 
 - [ ] Step 3: Implement.
 
-Add near `publishSnapshotManifest` in `snapshot.go`:
+In `agent/internal/backup/providers/interface.go`, add:
 ```go
-// fetchPublishedManifest downloads and decodes prefix's manifest.json if it
-// exists, returning (snapshot, true) on success. ANY failure — download
-// error (including a genuine "not found"), or decode error — returns
-// (nil, false): a resume whose manifest isn't there yet just proceeds to
-// upload normally, exactly like every other fail-open check in this
-// package.
-func fetchPublishedManifest(ctx context.Context, provider providers.BackupProvider, prefix string) (*Snapshot, bool) {
+// ErrObjectNotFound is a sentinel a BackupProvider's Download should wrap
+// (via fmt.Errorf("%w: ...", ErrObjectNotFound, ...)) ONLY when it can
+// POSITIVELY confirm the requested remote object does not exist — never for
+// any other failure (network, permission, decode, timeout). Callers use
+// errors.Is(err, ErrObjectNotFound) to distinguish "confirmed absent, safe
+// to proceed" from "unknown, must fail closed" — see backup.fetchPublished
+// Manifest, whose entire correctness depends on this distinction never
+// being blurred. LocalProvider and S3Provider (the two providers reachable
+// via the backup_run payload today, per exec_backup.go) implement this;
+// other providers are not wired to it yet and any caller depending on it
+// must treat their errors as "not confirmed absent" (the safe default).
+var ErrObjectNotFound = errors.New("backup provider: object not found")
+```
+(Add `"errors"` to that file's imports if not already present.)
+
+In `agent/internal/backup/providers/local.go`, change `Download` (`:87-107`) to check for a missing source file and wrap it:
+```go
+// Download retrieves a file from the local backup store.
+func (p *LocalProvider) Download(remotePath, localPath string) error {
+	if p.BasePath == "" {
+		return errors.New("local provider base path is required")
+	}
+	if remotePath == "" {
+		return errors.New("remote path is required")
+	}
+	if localPath == "" {
+		return errors.New("local destination path is required")
+	}
+
+	srcPath, err := containedPath(p.BasePath, remotePath)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(localPath), 0o755); err != nil {
+		return fmt.Errorf("failed to create destination directory: %w", err)
+	}
+
+	var downloadErr error
+	if strings.HasSuffix(remotePath, ".gz") {
+		downloadErr = decompressFile(srcPath, localPath)
+	} else {
+		downloadErr = copyFileContext(context.Background(), srcPath, localPath)
+	}
+	if downloadErr != nil && errors.Is(downloadErr, fs.ErrNotExist) {
+		// %w wrapping through decompressFile/copyFileContext's own
+		// fmt.Errorf calls preserves the underlying os.PathError, so
+		// errors.Is against fs.ErrNotExist still sees through the chain —
+		// this positively confirms the source object is absent, not merely
+		// that SOME step failed.
+		return fmt.Errorf("%w: %s", ErrObjectNotFound, downloadErr)
+	}
+	return downloadErr
+}
+```
+(Add `"io/fs"` to `local.go`'s imports.)
+
+In `agent/internal/backup/providers/s3.go`, change `Download` (`:135-165`) to check for `NoSuchKey`:
+```go
+	resp, err := client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(s.Bucket),
+		Key:    aws.String(remotePath),
+	})
+	if err != nil {
+		var noSuchKey *s3types.NoSuchKey
+		if errors.As(err, &noSuchKey) {
+			return fmt.Errorf("%w: %s", ErrObjectNotFound, err)
+		}
+		return fmt.Errorf("failed to get s3 object: %w", err)
+	}
+```
+(Note: some S3-compatible backends return a generic API error with `Code() == "NoSuchKey"` rather than the typed `s3types.NoSuchKey` struct — this typed check does not catch that case. Flagged in Open Questions; not fixed in this wave to avoid pulling `github.com/aws/smithy-go` from an indirect to a direct `go.mod` dependency for a single error-classification edge case.)
+
+In `agent/internal/backup/snapshot.go`, replace the earlier two-state `fetchPublishedManifest` design with the three-state contract:
+```go
+// fetchPublishedManifest checks whether prefix's manifest.json has already
+// been published, distinguishing three outcomes (P1 fix — a transient
+// error must NEVER be treated the same as confirmed absence):
+//   - (snapshot, nil): confirmed present and decodable — the caller's
+//     resume-shortcut must return this snapshot, uploading nothing.
+//   - (nil, nil): CONFIRMED absent (providers.ErrObjectNotFound) — safe to
+//     proceed with a normal upload.
+//   - (nil, err): anything else (network error, decode error, corrupt
+//     manifest, context already done) — the caller MUST fail the run
+//     closed: upload nothing, delete nothing, since we genuinely don't
+//     know whether a real manifest exists at this prefix.
+func fetchPublishedManifest(ctx context.Context, provider providers.BackupProvider, prefix string) (*Snapshot, error) {
 	if ctx != nil {
 		if err := ctx.Err(); err != nil {
-			return nil, false
+			return nil, err
 		}
 	}
 	manifestKey := path.Join(prefix, snapshotManifestKey)
 	tempFile, err := os.CreateTemp("", "resume-manifest-*.json")
 	if err != nil {
-		return nil, false
+		return nil, fmt.Errorf("failed to create temp file for resume manifest check: %w", err)
 	}
 	tempPath := tempFile.Name()
 	_ = tempFile.Close()
 	defer os.Remove(tempPath)
 
 	if err := provider.Download(manifestKey, tempPath); err != nil {
-		return nil, false
+		if errors.Is(err, providers.ErrObjectNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to check for an already-published manifest at %s: %w", manifestKey, err)
 	}
 	data, err := os.ReadFile(tempPath)
 	if err != nil {
-		return nil, false
+		return nil, fmt.Errorf("failed to read downloaded resume manifest: %w", err)
 	}
 	var snapshot Snapshot
 	if err := json.Unmarshal(data, &snapshot); err != nil {
-		return nil, false
+		return nil, fmt.Errorf("failed to decode resume manifest %s: %w", manifestKey, err)
 	}
-	return &snapshot, true
+	return &snapshot, nil
 }
 ```
 
-In `createSnapshotWithProgress`, immediately after `prefix := path.Join(snapshotRootDir, snapshot.ID)` (currently line 388, right before `var errs []error`):
+In `createSnapshotWithProgress`, immediately after `prefix := path.Join(snapshotRootDir, snapshot.ID)` (currently line 390, right before `var errs []error`), add the SECOND (defensive, unit-testable-in-isolation) check:
 ```go
 	prefix := path.Join(snapshotRootDir, snapshot.ID)
 
 	// Resume-with-already-published-manifest (D18 §3.5): a prior attempt
 	// may have published manifest.json and then crashed before
-	// journal.Complete() removed the journal (or before Abandon even ran).
-	// Re-uploading now would overwrite a COMPLETED, restorable manifest —
-	// treat its presence as the definitive "this run already finished"
-	// signal and return it as-is, uploading nothing.
+	// journal.Complete() removed the journal. Re-uploading now would
+	// overwrite a COMPLETED, restorable manifest — treat its confirmed
+	// presence as "this run already finished" and return it as-is,
+	// uploading nothing. This is a SECOND check: RunBackupContext
+	// (backup.go) performs the same one earlier, before source scanning,
+	// so a source-gone resumed run reports success instead of hitting the
+	// len(files)==0 reject below first — see this task's ordering note.
+	// Kept here too so direct callers of this function (this package's own
+	// unit tests) still exercise and prove the behavior without going
+	// through RunBackupContext.
 	if journal != nil && journal.resumed {
-		if existing, ok := fetchPublishedManifest(ctx, provider, prefix); ok {
+		existing, fetchErr := fetchPublishedManifest(ctx, provider, prefix)
+		if fetchErr != nil {
+			return nil, fmt.Errorf("resume check failed, refusing to guess whether %s was already published: %w", prefix, fetchErr)
+		}
+		if existing != nil {
 			log.Info("resume: manifest already published, skipping upload",
 				"snapshotId", existing.ID,
 				"files", len(existing.Files),
@@ -1158,30 +1630,86 @@ In `createSnapshotWithProgress`, immediately after `prefix := path.Join(snapshot
 			completed = true
 			return existing, nil
 		}
+		// existing == nil, fetchErr == nil: confirmed absent — fall through
+		// to a normal upload below.
 	}
 
 	var errs []error
 ```
 
+In `agent/internal/backup/backup.go`, HOIST the journal-open block. Move the existing block currently at `:713-756` (from the `// Checkpoint journal:` comment through the closing `}` of the `if journal != nil { ... }` logging block) to immediately after `defer stopRunKeepalive()` (`:408`), before the `// VSS:` comment (`:410`). Immediately after the moved block, insert the early resume-shortcut check:
+```go
+	// (moved block: journal open + stale-journal warn + resumed-journal log,
+	// unchanged content from the original :713-756, minus the
+	// cleanupSnapshotPrefix call already removed by Task 5)
+
+	// Resume-with-already-published-manifest, checked BEFORE any source
+	// scanning (P2 fix): a resumed run whose manifest is already published
+	// must report success even if the configured source has since vanished
+	// — the len(files)==0 exits later in this function (and in
+	// createSnapshotWithProgress) must never get a chance to fail this run
+	// first. See fetchPublishedManifest's three-state contract: only a
+	// CONFIRMED-absent result falls through to a normal run; any other
+	// error fails the job closed right here.
+	if journal != nil && resumedJournal {
+		prefix := path.Join(snapshotRootDir, journal.snapshotID)
+		existing, fetchErr := fetchPublishedManifest(runCtx, m.config.Provider, prefix)
+		if fetchErr != nil {
+			job.Status = jobStatusFailed
+			job.CompletedAt = time.Now().UTC()
+			job.Error = fmt.Errorf("resume check failed, refusing to guess whether %s was already published: %w", prefix, fetchErr)
+			return job, job.Error
+		}
+		if existing != nil {
+			log.Info("resume: manifest already published, skipping the entire run",
+				"snapshotId", existing.ID,
+				"files", len(existing.Files),
+			)
+			if err := journal.Complete(); err != nil {
+				log.Warn("failed to remove completed checkpoint journal", "error", err.Error())
+			}
+			job.Status = jobStatusCompleted
+			job.CompletedAt = time.Now().UTC()
+			job.Snapshot = existing
+			job.FilesBackedUp = len(existing.Files)
+			job.BytesBackedUp = existing.Size
+			for _, f := range existing.Files {
+				if isReferenceEntry(f, existing.ID) {
+					job.ReferencedFiles++
+					job.ReferencedBytes += f.Size
+				}
+			}
+			return job, nil
+		}
+		// existing == nil, fetchErr == nil: confirmed absent — proceed to
+		// VSS/scan/upload normally, reusing this SAME journal (no second
+		// open) all the way down to createSnapshotWithProgress's call site.
+	}
+```
+`path` is already imported by `backup.go` — verify (`grep -n '"path"' agent/internal/backup/backup.go`); if the file imports only `path/filepath` today, add a plain `"path"` import alongside it (`path.Join` and `path/filepath`'s `filepath.Join` are different packages — `snapshotRootDir`/prefix construction elsewhere in this package uses `path.Join`, e.g. `snapshot.go:390`, so match that convention here, not `filepath.Join`).
+
+Remove the now-redundant original journal-open block from its old location (the code has moved, not duplicated) — the `createSnapshotWithProgress` call site (originally `:758`) now simply reuses the `journal`/`resumedJournal` variables declared up top; no `openSnapshotJournal` call remains at the bottom of the function.
+
 - [ ] Step 4: Run, expect PASS:
 ```
-cd agent && go test ./internal/backup/ -run TestCreateSnapshot_ResumeWithAlreadyPublishedManifest_SkipsUpload -v
+cd agent && go build ./... && go test ./internal/backup/... -run 'ErrObjectNotFound|FetchPublishedManifest|TestCreateSnapshot_ResumeWithAlreadyPublishedManifest|TestRunBackupContext_ResumeWithPublishedManifest' -v
 ```
 
 - [ ] Step 5: Commit:
 ```
-git add agent/internal/backup/snapshot.go agent/internal/backup/snapshot_test.go
-git commit -m "feat(agent/backup): skip re-upload when resume finds an already-published manifest"
+git add agent/internal/backup/providers/interface.go agent/internal/backup/providers/local.go agent/internal/backup/providers/s3.go agent/internal/backup/backup.go agent/internal/backup/snapshot.go agent/internal/backup/snapshot_test.go agent/internal/backup/backup_test.go agent/internal/backup/providers/local_test.go agent/internal/backup/providers/s3_test.go
+git commit -m "feat(agent/backup): resume-with-published-manifest runs before source validation, fails closed on ambiguous errors"
 ```
 
 ### Task 7: `upload.lease` heartbeat — write during upload, delete after publish
 
 **Files:**
-- Modify `agent/internal/backup/snapshot.go` (`createSnapshotWithProgress`, alongside the existing progress-keepalive goroutine at `:433-452`, and at the two successful-publish points: normal completion `:782-796` and `abortSourceGone`'s partial-publish branch `:547-566`)
+- Modify `agent/internal/backup/snapshot.go` (`createSnapshotWithProgress`, alongside the existing progress-keepalive goroutine at `:433-452`, and at the two successful-publish points: normal completion `:784-796` and `abortSourceGone`'s partial-publish branch `:548-566` — re-verified line numbers)
 - Test: `agent/internal/backup/snapshot_test.go` (new tests)
 
 **Interfaces:**
 - Produces (unexported): `refreshUploadLease(ctx context.Context, provider providers.BackupProvider, leaseKey string)`
+- **P2 fix — bounded, cancellable refreshes:** each refresh call gets its OWN context, derived from a dedicated `leaseCtx` (not the run's raw `ctx`) with a 60s timeout, so a single stalled PUT can never block longer than 60s. `stopLeaseRefresh` cancels `leaseCtx` directly (not just a bare `close(leaseStop)` channel) so an in-flight refresh's context becomes `Done` immediately on stop, rather than `stopLeaseRefresh` waiting out whatever timeout happened to be in flight.
 
 - [ ] Step 1: Write the failing test (use a short interval via a test seam, and a small local fake that sleeps on the FIRST file upload so the lease ticker has time to fire — `blockAfterNProvider` (`snapshot_test.go:743-778`) blocks until `ctx.Done()` rather than for a fixed duration, so it doesn't fit this test; a purpose-built fake is simpler than adapting it):
 ```go
@@ -1297,22 +1825,24 @@ func refreshUploadLease(ctx context.Context, provider providers.BackupProvider, 
 }
 ```
 
-In `createSnapshotWithProgress`, right after the existing progress-keepalive goroutine block (`:433-452`, the `if onProgress != nil { ... }` block), add a second, unconditional (runs regardless of `onProgress`) goroutine:
+In `createSnapshotWithProgress`, right after the existing progress-keepalive goroutine block (`:433-452`, the `if onProgress != nil { ... }` block), add a second, unconditional (runs regardless of `onProgress`) goroutine. **P2 fix**: each refresh gets its own 60s-bounded context derived from a dedicated `leaseCtx`, and `stopLeaseRefresh` cancels `leaseCtx` (not merely a bare channel close) so a stalled in-flight PUT is interrupted immediately on stop rather than making the caller wait out the full 60s:
 ```go
 	// upload.lease heartbeat (D18 §3.4): refresh a tiny marker object every
 	// uploadLeaseInterval while uploading, so GC's manifest-less-prefix
 	// window keeps extending for a legitimately slow multi-day single-file
-	// upload. Stopped on completion (stopLeaseRefresh, called exactly once
-	// via leaseStopOnce) or ctx cancellation. Skipped entirely by the
+	// upload. leaseCtx (derived from ctx) is cancelled by stopLeaseRefresh —
+	// called exactly once via leaseStopOnce, on completion or ctx
+	// cancellation — which immediately interrupts any in-flight refresh
+	// rather than waiting out its 60s bound. Skipped entirely by the
 	// resume-already-published shortcut above, since that path returns
 	// before this point.
 	leaseKey := path.Join(prefix, "upload.lease")
-	leaseStop := make(chan struct{})
+	leaseCtx, leaseCancel := context.WithCancel(ctx)
 	leaseDone := make(chan struct{})
 	var leaseStopOnce sync.Once
 	stopLeaseRefresh := func() {
 		leaseStopOnce.Do(func() {
-			close(leaseStop)
+			leaseCancel()
 			<-leaseDone
 		})
 	}
@@ -1322,12 +1852,16 @@ In `createSnapshotWithProgress`, right after the existing progress-keepalive gor
 		defer ticker.Stop()
 		for {
 			select {
-			case <-leaseStop:
-				return
-			case <-ctx.Done():
+			case <-leaseCtx.Done():
 				return
 			case <-ticker.C:
-				refreshUploadLease(ctx, provider, leaseKey)
+				// Each refresh is bounded to 60s AND tied to leaseCtx, so
+				// stopLeaseRefresh's leaseCancel() unblocks it immediately
+				// instead of this goroutine sitting in a stalled PUT for up
+				// to 60s after the caller asked it to stop.
+				refreshCtx, cancel := context.WithTimeout(leaseCtx, 60*time.Second)
+				refreshUploadLease(refreshCtx, provider, leaseKey)
+				cancel()
 			}
 		}
 	}()
@@ -1371,15 +1905,20 @@ git commit -m "feat(agent/backup): refresh an upload.lease heartbeat during uplo
 - Modify `apps/api/src/services/backupAgentContract.test.ts`
 
 **Interfaces:**
-- Consumes (source-text grep only, no import): Go field tags `baseSnapshotId`/`publishLeaseExpiresAt` in `exec_backup.go`; Go `publishMargin`/`uploadLeaseInterval` in `snapshot.go`; whatever W01 names the equivalent TS constants (grepped, not imported, so this file compiles today even though those TS names don't exist yet).
+- Consumes: `BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS` — a REAL import from `apps/api/src/jobs/backupRetention.ts` (it already exists today, confirmed via `grep -n "export const BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS" apps/api/src/jobs/backupRetention.ts`), so the `uploadLeaseInterval` assertion is an ACTUAL comparison against the live constant, not two independently-hardcoded literals that merely happen to agree. `BACKUP_PUBLISH_MARGIN_MS` does NOT exist anywhere in `apps/api` yet (it's spec §3.4/W02's constant) — it CANNOT be imported (a missing named export fails TypeScript compilation immediately, unlike a runtime `skipIf`), so that comparison is gated by source-text regex the same way the file's existing `BACKUP_GC_AGENT_JOURNAL_MAX_AGE_MS` check is (`:33-42`), and will need a follow-up edit once W02 lands to switch to a real import (noted in Open Questions).
 
-- [ ] Step 1: Write the failing test — append to `backupAgentContract.test.ts`:
+- [ ] Step 1: Write the failing test — append to `backupAgentContract.test.ts`. Add the import alongside the file's existing imports at the top:
+```ts
+import { BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS } from '../jobs/backupRetention';
+```
+Then:
 ```ts
 describe('backup Go<->TS contract — D18 server-owned base payload fields', () => {
-  it('agent exec_backup.go still decodes baseSnapshotId and publishLeaseExpiresAt from the backup_run payload', () => {
+  it('agent exec_backup.go decodes baseSnapshotId/publishLeaseExpiresAt and rejects server-owned mode without a lease', () => {
     const src = readRepoFile('agent/cmd/breeze-backup/exec_backup.go');
     expect(src).toMatch(/BaseSnapshotID\s*\*string\s*`json:"baseSnapshotId"`/);
     expect(src).toMatch(/PublishLeaseExpiresAt\s*string\s*`json:"publishLeaseExpiresAt"`/);
+    expect(src).toMatch(/BaseSnapshotID != nil && publishLeaseExpiresAt\.IsZero\(\)/);
   });
 
   // Gated on W01 having landed: apps/api/src/jobs/backupWorker.ts does not
@@ -1398,20 +1937,36 @@ describe('backup Go<->TS contract — D18 server-owned base payload fields', () 
     },
   );
 
-  it('agent publishMargin is 1 hour and stays strictly under the manifest-less GC window', () => {
+  it('agent publishMargin is 1 hour', () => {
     const src = readRepoFile('agent/internal/backup/snapshot.go');
     expect(src).toMatch(/publishMargin\s*=\s*1\s*\*\s*time\.Hour/);
   });
 
-  it('agent uploadLeaseInterval (15 min) stays well under the 9-day manifest-less GC window', () => {
-    const src = readRepoFile('agent/internal/backup/snapshot.go');
-    expect(src).toMatch(/uploadLeaseInterval\s*=\s*15\s*\*\s*time\.Minute/);
-    // 15 minutes must be at least an order of magnitude under the 9-day
-    // window (journalMaxAge 7d + 48h grace) so a slow upload has many
-    // refresh opportunities before the prefix could be swept.
+  // BACKUP_PUBLISH_MARGIN_MS is W02's constant (spec §3.4) and does not
+  // exist in apps/api yet as of this wave (confirmed 2026-09-09) — it
+  // CANNOT be imported here (an import of a non-existent export fails
+  // TypeScript compilation outright, unlike a runtime skip), so this is
+  // gated by source-text regex, mirroring this file's existing
+  // BACKUP_GC_AGENT_JOURNAL_MAX_AGE_MS pattern (:33-42). When W02 adds the
+  // real export, switch this to a real import + direct equality check
+  // (see Open Questions) — until then this only proves the AGENT side.
+  const retentionSrc = readRepoFile('apps/api/src/jobs/backupRetention.ts');
+  const apiHasPublishMargin = /BACKUP_PUBLISH_MARGIN_MS/.test(retentionSrc);
+  it.skipIf(!apiHasPublishMargin)(
+    'API BACKUP_PUBLISH_MARGIN_MS equals 1 hour (3,600,000 ms), matching the agent publishMargin',
+    () => {
+      expect(retentionSrc).toMatch(/BACKUP_PUBLISH_MARGIN_MS\s*=\s*60\s*\*\s*60\s*\*\s*1000\b/);
+    },
+  );
+
+  it('agent uploadLeaseInterval (15 min) stays well under the ACTUAL API manifest-less GC window', () => {
+    const agentSrc = readRepoFile('agent/internal/backup/snapshot.go');
+    expect(agentSrc).toMatch(/uploadLeaseInterval\s*=\s*15\s*\*\s*time\.Minute/);
     const FIFTEEN_MIN_MS = 15 * 60 * 1000;
-    const NINE_DAYS_MS = 9 * 24 * 60 * 60 * 1000;
-    expect(FIFTEEN_MIN_MS).toBeLessThan(NINE_DAYS_MS / 100);
+    // Real comparison against the imported constant (currently 9 days:
+    // journalMaxAge 7d + BACKUP_GC_GRACE_MS 48h) — not two independent
+    // literals that happen to agree today.
+    expect(FIFTEEN_MIN_MS).toBeLessThan(BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS / 100);
   });
 });
 ```
@@ -1439,15 +1994,20 @@ git commit -m "test(api): pin the D18 server-owned-base payload field names and 
 
 Not a code task — recorded here because the plan brief requires verifying it, and the finding is doc-only (see Open Questions).
 
-`devices.backup_version` is populated from `breeze-backup --version`'s stdout (`agent/internal/heartbeat/backup_version.go:13-120`), which prints `main.version` (`agent/cmd/breeze-backup/main.go:36`), a build-time value injected via `-ldflags "-X main.version=$(VERSION)"` (`agent/Makefile:2-8`; release builds go through `agent/scripts/build-edition.sh` per the Makefile's own comment at `:4-6`). **No code in this wave sets or changes that value** — it is set by whatever release tag builds the binary that ships W03's changes. There is nothing to implement here; the release process must simply ensure the binary that carries this wave's changes is built with `VERSION` set to that release's number, so that W02's future capability gate (a `BACKUP_SERVER_BASE_MIN_HELPER_VERSION`-style constant, not yet added) can compare against it correctly. Flagged in Open Questions.
+`devices.backup_version` is populated from `breeze-backup --version`'s stdout (`agent/internal/heartbeat/backup_version.go:13-120`, the actual `exec.CommandContext(...).Output()` call at `:160`), which prints `main.version` (`agent/cmd/breeze-backup/main.go:36`), a build-time value injected via `-ldflags "-X main.version=$(VERSION)"` (`agent/Makefile:2-8`; release builds go through `agent/scripts/build-edition.sh` per the Makefile's own comment at `:4-6`). **No code in this wave sets or changes that value** — it is set by whatever release tag builds the binary that ships W03's changes. There is nothing to implement here; the release process must simply ensure the binary that carries this wave's changes is built with `VERSION` set to that release's number, so that W02's future capability gate (a `BACKUP_SERVER_BASE_MIN_HELPER_VERSION`-style constant, not yet added) can compare against it correctly. Flagged in Open Questions.
 
 ## Task 10: Wave verification
 
 **Files:** none (verification only)
 
-- [ ] Run the full agent backup package + breeze-backup command suite with race detection:
+- [ ] Run the full agent backup package + breeze-backup command suite (including the touched `providers` subpackage) with race detection:
 ```
-cd agent && go build ./... && go vet ./... && go test -race ./internal/backup/... ./cmd/breeze-backup/...
+cd agent && go build ./... && go vet ./... && go test -race ./internal/backup/... ./internal/backup/providers/... ./cmd/breeze-backup/...
+```
+- [ ] Run the specific tests this review round added or rewrote, to confirm each is actually green (not just "the package compiles"):
+```
+cd agent && go test -race ./internal/backup/... -run 'TestManagerFromBackupRunPayload|TestFetchServerOwnedBase|TestSnapshotJournal_Age|TestLeaseGate|TestRunBackupContext_ServerOwnedMode_NeverListsTheBucket|TestRunBackupContext_ExpiredLease_RefusesToPublishManifest|TestBackupNeverDeletesRemoteObjects|TestAbortCleanup_OnlyDeletesOwnUnpublishedPrefix|TestRunBackupContext_StaleJournalDiscardedWithoutRemoteCleanup|TestFetchPublishedManifest|TestCreateSnapshot_ResumeWithAlreadyPublishedManifest|TestRunBackupContext_ResumeWithPublishedManifest|TestCreateSnapshot_UploadLease' -v
+cd agent && go test -race ./internal/backup/providers/... -run 'ErrObjectNotFound' -v
 ```
 - [ ] Run the one API-side contract test file:
 ```
@@ -1472,6 +2032,7 @@ cd agent && go test -race ./...
   - [ ] States this wave is agent-shipped code (full review round per repo convention for agent/GC-adjacent changes) and names the one independent reviewer round performed.
   - [ ] Notes explicitly: no signature change to `createSnapshotWithProgress`; the lease/journal-age fence is enforced via the `leaseGate` provider wrapper instead, to avoid touching ~30 existing call sites.
   - [ ] Notes the two kept exceptions: `snapshot.go:499`/`:544` (`abortStopped`/`abortSourceGone`'s own-run-prefix `cleanupSnapshotPrefix` calls) are retained per spec §3.5 and are NOT part of this wave's "never deletes" removal — only `DeleteSnapshotContext`/`DeleteSnapshot` (deletion of OTHER, already-published snapshots) and the retention/stale-journal call sites were removed.
+  - [ ] Notes the independent-review fixes folded into this version: resume detection fails CLOSED on any ambiguous error via the new `providers.ErrObjectNotFound` sentinel (Task 6); the lease gate installs on `BaseSnapshotID != nil`, not on a non-zero lease, and fails closed on a zero lease (Task 4); the resume-with-published-manifest check runs in `RunBackupContext` BEFORE source scanning, not only inside `createSnapshotWithProgress` (Task 6); the `upload.lease` heartbeat uses a per-refresh bounded context so `stopLeaseRefresh` never blocks on a stalled PUT (Task 7).
   - [ ] Notes Task 9's finding as a follow-up for whoever cuts the release that ships this wave (confirm `VERSION` at build time is the release's own version, so `devices.backup_version` reports it correctly for W02's future capability gate).
 
 ## Open questions / contradictions
@@ -1480,3 +2041,5 @@ cd agent && go test -race ./...
 2. **`publishLeaseExpiresAt` applying to full runs too, with no renewal, means a slow full run can outlive its lease and simply fail to publish**, exactly like a run that outlives `journalMaxAge` already fails to resume. This is explicitly the spec's stated design ("a run longer than the lease already cannot resume... so 'a run must publish within 7d of dispatch' is the existing envelope made explicit" — spec line ~130-135), not an open question about correctness, but it IS a new user-visible failure mode for slow FULL (non-incremental) backups that didn't exist before this wave (previously a full run had no deadline at all beyond the per-file/whole-run reaper timeouts). Confirming this is accepted product behavior, not something W03 should soften, is worth an explicit sign-off since it wasn't true before D18.
 3. **Helper-version gating (spec §3.4's capability gate) is entirely W02's responsibility**, and its minimum-version constant does not exist yet in this worktree (confirmed via grep — only `BACKUP_QUEUE_MIN_HELPER_VERSION` exists today, for an unrelated feature). W03 has no code to write for it; Task 9 records that the mechanism it will eventually gate on (`devices.backup_version` sourced from `breeze-backup --version`, a build-time `-ldflags` value) is orthogonal to this wave's code and depends entirely on the release pipeline stamping the correct version — flagging so whoever cuts that release checks it, since there's no automated test that could catch a wrong `VERSION` at build time.
 4. **`leaseGate`'s `UploadContext` fallback-to-plain-`Upload` when the wrapped provider lacks context support** silently drops `ctx` cancellation for that one call, identical to `uploadSnapshotFile`'s own pre-existing fallback behavior (`snapshot.go:869-880`) — not a regression, just noting the design intentionally mirrors an existing accepted trade-off rather than introducing a new one.
+5. **S3 not-found detection (Task 6) only checks the typed `s3types.NoSuchKey`.** Some S3-compatible backends (older MinIO, certain on-prem gateways) return a generic API error with `Code() == "NoSuchKey"` rather than the SDK's typed struct — that shape is NOT caught by `errors.As(err, &noSuchKey)`, so on those backends a genuine 404 would be (safely, but sub-optimally) treated as "unknown error, fail closed" rather than "confirmed absent, proceed". This is the conservative failure direction (never silently overwrites/duplicates a real manifest) but does mean a resumed run against such a backend could spuriously fail its resume-check when it didn't need to. Not fixed in this wave because closing the gap requires promoting `github.com/aws/smithy-go` from an indirect to a direct `go.mod` dependency for one error-classification edge case — flagged for whoever owns provider compatibility to decide if it's worth doing.
+6. **`BACKUP_PUBLISH_MARGIN_MS` contract test (Task 8) is source-text-gated, not a real import**, because the constant doesn't exist in `apps/api` yet (it's W02's, per spec §3.4). When W02 adds it, `backupAgentContract.test.ts` should be updated to import it directly (mirroring how `BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS` is already imported after this wave) rather than leaving the regex-based check in place indefinitely — noted so it isn't forgotten once the real export exists.

--- a/docs/superpowers/plans/backup/2026-09-09-backup-gc-reclamation-w03-agent.md
+++ b/docs/superpowers/plans/backup/2026-09-09-backup-gc-reclamation-w03-agent.md
@@ -1,0 +1,1482 @@
+# Wave 03 — Agent/helper: server-owned dedupe base, leases, never delete — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the agent consume a server-selected incremental-dedupe base, refuse to publish a manifest past its lease/journal-age fence, and stop performing any remote deletion of its own.
+
+**Architecture:** `agent/cmd/breeze-backup/exec_backup.go` decodes two new `backup_run` payload fields (`baseSnapshotId`, `publishLeaseExpiresAt`) into `backup.BackupConfig`; `agent/internal/backup/backup.go`'s run path switches between the new server-owned base fetch (`fetchServerOwnedBase`, `incremental.go`) and the unchanged legacy `previousManifest` bucket-listing path purely on whether `BaseSnapshotID` is nil. A new `leaseGate` provider wrapper (`snapshot.go`) intercepts only `manifest.json` uploads and fails closed once the lease (plus a 1h margin) or, for a resumed run, the checkpoint journal's age has expired — no signature change to the widely-called `createSnapshotWithProgress` is needed. Agent-side deletion of OTHER, already-published snapshots is removed outright (the retention-prune branch, `DeleteSnapshot`/`DeleteSnapshotContext`, and the stale-journal remote cleanup call) — the two narrower own-run-prefix cleanups (`abortStopped`/`abortSourceGone` in `snapshot.go`, which can only ever delete the CURRENT, never-published run's own objects) are explicit, spec-confirmed exceptions and are kept as-is. `provider.Delete` is otherwise used only for the new `upload.lease` heartbeat object's post-publish removal.
+
+**Tech Stack:** Go 1.25 (agent), `go test -race`, TypeScript/Vitest for the one cross-boundary contract-test addition.
+
+**Spec:** `docs/superpowers/specs/backup/2026-09-09-backup-gc-reclamation-design.md` §3.1 (agent bullets), §3.4 (upload.lease), §3.5 (agent never deletes), §6 (Agent verification) — v3.
+
+**Depends on:** None at the code level. Protocol switch is presence of `baseSnapshotId` in the `backup_run` payload; an older/unmodified server (or W01 not yet merged) omits both new fields, and every payload-parsing change below defaults to nil/zero in that case, which routes to the unchanged legacy path. Task 8's contract test is written to stay green either way (see its `skipIf`).
+
+## Global Constraints
+
+- Payload fields (consumed, not produced by this wave): `payload.baseSnapshotId: string` (`""` = full run; absent = legacy mode) and `payload.publishLeaseExpiresAt: RFC3339 string` (set for **every** dispatched file/system_image run, base or not — spec §3.1).
+- Publish margin: `publishMargin = 1 * time.Hour`, declared as a constant in `agent/internal/backup/snapshot.go`. Fence condition: refuse to publish `manifest.json` when `time.Now().Add(publishMargin).After(publishLeaseExpiresAt)`.
+- New sentinel errors in `agent/internal/backup/backup.go`: `ErrPublishLeaseExpired`, `ErrJournalExpiredAtPublish`.
+- `journalMaxAge = 7 * 24 * time.Hour` (`agent/internal/backup/journal.go:34`) — unchanged, reused as the resumed-journal-age fence.
+- `uploadLeaseInterval = 15 * time.Minute`, constant in `agent/internal/backup/snapshot.go`, comment must state it stays well under the API's 9-day (`journalMaxAge` + 48h grace) manifest-less window.
+- No lease renewal exists anywhere in this wave: the helper enforces exactly the payload's `publishLeaseExpiresAt` value with no extension. A run that legitimately takes longer than the lease fails to publish by design — this mirrors the existing `journalMaxAge` non-resumable-after-7-days envelope, not a new limitation class.
+- `DeleteSnapshot`, `DeleteSnapshotContext` are removed from `agent/internal/backup/snapshot.go` (ground truth below confirms no other caller exists). `cleanupSnapshotPrefix`/`listSnapshotPrefixItems` are KEPT — spec §3.5 names the own-run-prefix abort cleanups (`snapshot.go:499`, `:544`) as explicit exceptions.
+
+## 0. Ground truth (re-verified 2026-09-09 against this worktree)
+
+- `agent/cmd/breeze-backup/exec_backup.go:101-178` `managerFromBackupRunPayload` — decodes `provider`/`providerConfig`/`paths`/`systemImage`/`vss` from the `backup_run` payload; builds `backup.BackupConfig` twice (system_image branch `:154-163`, file-mode branch `:171-177`). No `baseSnapshotId`/lease field exists yet.
+- `agent/internal/backup/backup.go:56-109` `BackupConfig` struct. `:220-224` `GetRetention` doc comment currently says "0 makes `DeleteSnapshotContext` a no-op" — stale after Task 5, needs rewording.
+- `agent/internal/backup/backup.go:665-691` — `runIdentity := m.runBackupIdentity()` then the `previousManifest` call gated by `incrementalDedupeActive`. This is the one and only mode-switch point for Task 2.
+- `agent/internal/backup/backup.go:717-756` — journal open (`:723-736`), `journal.StaleSnapshotID()` check that calls `cleanupSnapshotPrefix(m.config.Provider, staleID)` at `:748` (spec's "backup.go:738" is off by ~10 lines in this worktree; re-verified).
+- `agent/internal/backup/backup.go:758` — `createSnapshotWithProgress(runCtx, m.config.Provider, files, progressFn, journal, prevSnapshot, sourceLiveness, runIdentity)`. This is the one call site inside `RunBackupContext` where the lease-gated provider must be substituted.
+- `agent/internal/backup/backup.go:780-806` — the retention-prune branch (`if snapshot != nil && m.config.Retention > 0 && !incrementalDedupeActive { retentionErr = DeleteSnapshotContext(...) }`). Matches spec's `backup.go:780-806` exactly.
+- Two more agent-side remote-delete call sites exist beyond the retention branch and stale-journal cleanup — both are the spec's explicit exceptions (§3.5, re-read after coordinator review), NOT bugs to remove:
+  - `agent/internal/backup/snapshot.go:499` — `abortStopped()`'s `if journal == nil { cleanupSnapshotPrefix(provider, snapshot.ID) }` (fires when a job is stopped/cancelled mid-run with no checkpoint journal). Deletes only the current run's OWN, never-published prefix.
+  - `agent/internal/backup/snapshot.go:544` — `abortSourceGone()`'s `if len(snapshot.Files) == 0 { cleanupSnapshotPrefix(provider, snapshot.ID) }` (fires when the source volume disappears mid-run, no journal, and zero files landed). Same own-prefix-only property.
+  Both are safe by construction: until a manifest publishes an id, nothing else can reference it, so deleting it deletes nothing anyone else depends on. This is categorically different from the retention branch and `DeleteSnapshotContext`, which delete an OTHER, already-published (and possibly cross-referenced) snapshot's entire prefix — that is the actually dangerous case §3.5 removes. Task 5 keeps both call sites and the `cleanupSnapshotPrefix`/`listSnapshotPrefixItems` functions they use.
+- `agent/internal/backup/snapshot.go:884-892` `cleanupSnapshotPrefix` (KEPT), `:1025-1032` `listSnapshotPrefixItems` (KEPT), `:972-1023` `DeleteSnapshot`/`DeleteSnapshotContext` (REMOVED). Confirmed via `grep -rn "DeleteSnapshotContext(\|DeleteSnapshot(" agent/ apps/` that `backup.go:799` is the ONLY caller of `DeleteSnapshotContext`, and `DeleteSnapshot` (non-context) has ZERO callers outside its own file and tests — both remove cleanly with no orphaned caller elsewhere in `agent/` or `apps/helper/`. `listSnapshotPrefixItems` has a second caller (`cleanupSnapshotPrefix`, `:885`) beyond the removed `DeleteSnapshotContext` (`:1002`), so it stays.
+- `agent/cmd/breeze-backup/exec_backup.go:363-372` `execBackupCleanup` (the `backup_cleanup` command) calls `backup.CleanupRestoreDir`, a **local** staging-directory cleanup — it never calls `DeleteSnapshot`/`DeleteSnapshotContext`. Confirms spec §3.5's "removed (`backup_cleanup` is local-only)" clause: no command handler needs those two kept.
+- `agent/internal/backup/incremental.go:54-92` `previousManifest` (spec says `:53-100`, off by one; logic identical) — scans `ListSnapshots` results newest-first for `candidate.BackupIdentity == identity`; empty `identity` short-circuits to full-run.
+- `agent/internal/backup/snapshot.go:52-91` `Snapshot` struct (`ID`, `Timestamp`, `Files`, `Size`, `FormatVersion`, `BaseSnapshotID`, `BackupIdentity`, `UploadFailures`). `:898-956` `ListSnapshots` downloads and decodes every `snapshots/*/manifest.json`. `:1099-1126` `backupIdentity`/`runBackupIdentity`.
+- `agent/internal/backup/snapshot.go:343` `createSnapshotWithProgress(ctx, provider, files, onProgress, journal, prevSnapshot, sourceLiveness, runIdentity ...string) (*Snapshot, error)` — called from ~30 sites across `backup.go` and 5 test files with a bare `providers.BackupProvider`. Deliberately left with this exact signature (no new parameter) — see Task 4's design note.
+- `agent/internal/backup/snapshot.go:812-834` `publishSnapshotManifest` — writes the manifest to a temp file, then `uploadSnapshotFile(attemptCtx, provider, manifestPath, manifestKey)`. Both the normal-completion call (`:782`) and the `abortSourceGone` partial-manifest call (`:544-561`, specifically the `publishSnapshotManifest` at `:547`) go through this same function, so gating at the `provider.Upload`/`UploadContext` boundary via `isManifestPath` covers both without duplicating the check.
+- `agent/internal/backup/snapshot.go:151` `contextUploader` interface (`UploadContext(ctx, localPath, remotePath) error`), checked via type assertion in `uploadSnapshotFile` (`:869`).
+- `agent/internal/backup/snapshot.go:1054-1057` `isManifestPath(item string) bool` — already matches `.../manifest.json` or a bare `manifest.json` basename; reused as-is by the new lease gate, no change needed.
+- `agent/internal/backup/journal.go:34` `journalMaxAge`. `:60-68` `snapshotJournal` struct has no `createdAt` field today — `header.CreatedAt` is read at `:155` inside `openSnapshotJournal` but never stored on the struct, so nothing today can ask "how old is my journal" after open. `:268-292` `createFreshJournal` builds `header.CreatedAt = time.Now().UTC()` but likewise drops it. `:88` `resumed bool` field already exists and is exactly the flag Task 4 needs ("if the run was resumed from a journal").
+- `agent/internal/backup/snapshot_test.go:18-111` `mockProvider` — the fake `providers.BackupProvider` used across the package (`uploadCalls`/`deleteCalls`/`downloadCalls` tracking, `listResult` override, `uploadErr`/`downloadErr`/`listErr`/`deleteErr` injection). This is the fake every new test in this wave uses; no new fake needed.
+- `agent/internal/backup/snapshot_lifecycle_test.go:108-208` (`TestDeleteSnapshot_NothingToDelete`, `_ZeroRetention`, `_NegativeRetention`, `_PrunesOldSnapshots`, `_RetentionExceedsCount`, `_DeleteError`) and `agent/internal/backup/snapshot_test.go:198-230` (`TestDeleteSnapshot_DoesNotDeleteAdjacentPrefix`) are the seven tests directly exercising the functions Task 5 removes.
+- `agent/internal/backup/backup_test.go:924-985` `TestRunBackup_IncrementalRetentionDoesNotStrandReferencedObjects` already asserts the agent performs **no** pruning in the incremental path (its comment describes the bug this wave permanently forecloses) — it needs no behavior change, only a comment update (the branch it describes is now gone, not merely gated).
+- `apps/api/src/services/backupAgentContract.test.ts` (243 lines) — existing source-text-grep contract suite (e.g. `:31-48` pins `journalMaxAge` parity). Picked up by the ordinary unit config: confirmed `apps/api/vitest.config.ts` has no `exclude` for `services/*.test.ts`, so this file runs in `pnpm --filter @breeze/api test`, not the integration config.
+- `apps/api/src/jobs/backupWorker.ts:411-490,640-760` `resolveBackupTargets`/dispatch payload construction — confirmed **no** `baseSnapshotId`/`publishLeaseExpiresAt` field exists yet (W01's job). Task 8's contract test must not hard-fail before W01 lands.
+- `apps/api/src/services/backupHelperCapabilities.ts:1-20` — existing min-helper-version gate pattern (`BACKUP_QUEUE_MIN_HELPER_VERSION`, `backupHelperSupportsQueue`) that W02 will mirror for the GC capability gate; W03 does not add a TS constant, it only needs to confirm the *mechanism* by which a shipped agent's version becomes visible server-side (Task 9 below, doc-only).
+- `agent/internal/heartbeat/backup_version.go:13-120` — the helper reports its version by shelling out to `breeze-backup --version`, which prints `Breeze Backup Version: <version>` (`agent/cmd/breeze-backup/main.go:36 var version = "dev"`, overridden via `-ldflags "-X main.version=$VERSION"` in `agent/Makefile:2-8` and the release build script). This is a **build-time value supplied by the release pipeline**, not something this wave's code sets — see Open Questions.
+
+## File structure
+
+- Modify `agent/cmd/breeze-backup/exec_backup.go` — decode `baseSnapshotId`/`publishLeaseExpiresAt`, thread into both `BackupConfig` literals.
+- Modify `agent/internal/backup/backup.go` — `BackupConfig` new fields + doc comments, run-path mode switch, lease-gated provider substitution at the `createSnapshotWithProgress` call site, remove the retention-prune branch, remove ONLY the stale-journal `cleanupSnapshotPrefix` call (the two own-run-prefix `cleanupSnapshotPrefix` calls in `snapshot.go` are kept, see Task 5), add `ErrPublishLeaseExpired`/`ErrJournalExpiredAtPublish`, add `GetBaseSnapshotID`/`GetPublishLeaseExpiresAt` getters.
+- Modify `agent/internal/backup/incremental.go` — new `fetchServerOwnedBase` function (imports gain `encoding/json`, `os`).
+- Modify `agent/internal/backup/journal.go` — add `createdAt time.Time` field + `Age() time.Duration` method.
+- Modify `agent/internal/backup/snapshot.go` — new `leaseGate` provider wrapper + `publishMargin`/`uploadLeaseInterval` constants; remove `DeleteSnapshot`/`DeleteSnapshotContext` only (`cleanupSnapshotPrefix`/`listSnapshotPrefixItems` and their two call sites in `abortStopped`/`abortSourceGone` are KEPT — spec §3.5 exception); add the resume-with-published-manifest shortcut and the `upload.lease` refresh goroutine + post-publish delete inside `createSnapshotWithProgress`.
+- Modify (delete tests) `agent/internal/backup/snapshot_lifecycle_test.go` — remove the six `TestDeleteSnapshot_*` tests (they target the removed `DeleteSnapshot`/`DeleteSnapshotContext`), replace with `TestBackupNeverDeletesRemoteObjects_RetentionConfigured`.
+- Modify `agent/internal/backup/snapshot_test.go` — remove `TestDeleteSnapshot_DoesNotDeleteAdjacentPrefix`; add `TestAbortCleanup_OnlyDeletesOwnUnpublishedPrefix_NeverAPublishedManifestPrefix` plus lease-gate / resume-shortcut / upload-lease tests.
+- Modify `agent/internal/backup/incremental_test.go` — add `TestFetchServerOwnedBase_*` table.
+- Modify `agent/internal/backup/journal_test.go` — add `TestSnapshotJournal_Age`.
+- Modify `agent/internal/backup/backup_test.go` — add server-owned-mode `RunBackupContext` integration-style tests; update the stale comment on `TestRunBackup_IncrementalRetentionDoesNotStrandReferencedObjects`.
+- Modify `agent/cmd/breeze-backup/exec_backup_test.go` — extend `TestManagerFromBackupRunPayload` table with the two new fields.
+- Modify `apps/api/src/services/backupAgentContract.test.ts` — add the Go/TS payload-field-name parity test + the `uploadLeaseInterval` vs. manifest-less-window assertion.
+
+### Task 1: Thread `baseSnapshotId`/`publishLeaseExpiresAt` from payload into `BackupConfig`
+
+**Files:**
+- Modify `agent/internal/backup/backup.go:56-109` (`BackupConfig` struct), `:220-224` (`GetRetention` comment)
+- Modify `agent/cmd/breeze-backup/exec_backup.go:101-178` (`managerFromBackupRunPayload`)
+- Test: `agent/cmd/breeze-backup/exec_backup_test.go:283-360` (extend `TestManagerFromBackupRunPayload`)
+
+**Interfaces:**
+- Produces: `BackupConfig.BaseSnapshotID *string`, `BackupConfig.PublishLeaseExpiresAt time.Time`
+- Produces: `(*BackupManager) GetBaseSnapshotID() *string`, `(*BackupManager) GetPublishLeaseExpiresAt() time.Time`
+- Consumes: `backup_run` payload fields `baseSnapshotId` (JSON string, may be absent), `publishLeaseExpiresAt` (JSON RFC3339 string, may be absent)
+
+- [ ] Step 1: Write the failing test — extend the table in `TestManagerFromBackupRunPayload` (`exec_backup_test.go`), adding `wantBaseSnapshotID *string` and `wantPublishLeaseExpiresAt time.Time` fields to the test struct, two new cases, and assertions in the loop body:
+
+```go
+// Added fields on the existing test struct (exec_backup_test.go:283-296):
+wantBaseSnapshotID        *string
+wantPublishLeaseExpiresAt time.Time
+
+// New cases appended to the table:
+{
+    name:                      "server-owned mode: non-empty baseSnapshotId with a lease",
+    payload:                   `{"provider":"local","providerConfig":{"path":"/var/backups"},"paths":["/data"],"baseSnapshotId":"snap-123","publishLeaseExpiresAt":"2026-09-16T00:00:00Z"}`,
+    wantProvider:              "local",
+    wantBasePath:              filepath.Clean("/var/backups"),
+    wantPaths:                 []string{"/data"},
+    wantVSS:                   runtime.GOOS == "windows",
+    wantBaseSnapshotID:        strPtr("snap-123"),
+    wantPublishLeaseExpiresAt: time.Date(2026, 9, 16, 0, 0, 0, 0, time.UTC),
+},
+{
+    name:               "server-owned mode: empty baseSnapshotId means full run, lease still set",
+    payload:            `{"provider":"local","providerConfig":{"path":"/var/backups"},"paths":["/data"],"baseSnapshotId":"","publishLeaseExpiresAt":"2026-09-16T00:00:00Z"}`,
+    wantProvider:       "local",
+    wantBasePath:       filepath.Clean("/var/backups"),
+    wantPaths:          []string{"/data"},
+    wantVSS:            runtime.GOOS == "windows",
+    wantBaseSnapshotID: strPtr(""),
+    wantPublishLeaseExpiresAt: time.Date(2026, 9, 16, 0, 0, 0, 0, time.UTC),
+},
+{
+    name:         "legacy payload: no baseSnapshotId field at all",
+    payload:      `{"provider":"local","providerConfig":{"path":"/var/backups"},"paths":["/data"]}`,
+    wantProvider: "local",
+    wantBasePath: filepath.Clean("/var/backups"),
+    wantPaths:    []string{"/data"},
+    wantVSS:      runtime.GOOS == "windows",
+    // wantBaseSnapshotID left nil (legacy mode), wantPublishLeaseExpiresAt left zero.
+},
+```
+
+Add near the top of the test file (or reuse if a similar helper already exists — grep first):
+```go
+func strPtr(s string) *string { return &s }
+```
+
+In the loop body, after the existing `wantVSS` assertion, add:
+```go
+gotBase := mgr.GetBaseSnapshotID()
+if (gotBase == nil) != (tt.wantBaseSnapshotID == nil) {
+    t.Fatalf("GetBaseSnapshotID() = %v, want %v", gotBase, tt.wantBaseSnapshotID)
+}
+if gotBase != nil && tt.wantBaseSnapshotID != nil && *gotBase != *tt.wantBaseSnapshotID {
+    t.Fatalf("GetBaseSnapshotID() = %q, want %q", *gotBase, *tt.wantBaseSnapshotID)
+}
+if !mgr.GetPublishLeaseExpiresAt().Equal(tt.wantPublishLeaseExpiresAt) {
+    t.Fatalf("GetPublishLeaseExpiresAt() = %v, want %v", mgr.GetPublishLeaseExpiresAt(), tt.wantPublishLeaseExpiresAt)
+}
+```
+
+- [ ] Step 2: Run it, expect FAIL with `mgr.GetBaseSnapshotID undefined (type *backup.BackupManager has no field or method GetBaseSnapshotID)`:
+```
+cd agent && go test ./cmd/breeze-backup/ -run TestManagerFromBackupRunPayload
+```
+
+- [ ] Step 3: Implement.
+
+In `agent/internal/backup/backup.go`, add to the `BackupConfig` struct (after the `AgentID string` field, before `VSSProvider`, i.e. insert before line 109's closing brace):
+```go
+	// BaseSnapshotID switches this run between server-owned base selection
+	// (D18 §3.1) and the legacy bucket-listing previousManifest path. nil
+	// means the dispatching server predates the field (legacy mode,
+	// unchanged behavior — see exec_backup.go's payload decode). A non-nil
+	// pointer to "" means the server explicitly selected no base for this
+	// run (full run, no dedupe attempted). A non-nil pointer to a snapshot
+	// id means the server selected that snapshot as this run's dedupe base
+	// — fetchServerOwnedBase fetches and validates it (D6 identity guard)
+	// before use, failing open to a full run on any problem (download
+	// error, decode error, or identity mismatch).
+	BaseSnapshotID *string
+
+	// PublishLeaseExpiresAt is the deadline (verbatim from the backup_run
+	// payload's publishLeaseExpiresAt field) after which this run must not
+	// publish snapshots/<id>/manifest.json — see leaseGate. Set for every
+	// server-dispatched file/system_image run, base or not (it fences late
+	// results server-side too, D18 §3.1). Zero value means the dispatching
+	// server predates the field, disabling the check entirely (legacy
+	// behavior: publish whenever ready). There is no renewal — this is
+	// exactly what the server chose at dispatch time.
+	PublishLeaseExpiresAt time.Time
+```
+
+Add getters after `GetAgentID` (backup.go, near line 212):
+```go
+// GetBaseSnapshotID returns the server-selected incremental-dedupe base for
+// this run (D18 §3.1): nil in legacy mode, a pointer to "" for an
+// explicit full run, a pointer to a snapshot id otherwise.
+func (m *BackupManager) GetBaseSnapshotID() *string {
+	return m.config.BaseSnapshotID
+}
+
+// GetPublishLeaseExpiresAt returns the deadline this run must publish its
+// manifest by (zero value = no lease, legacy server).
+func (m *BackupManager) GetPublishLeaseExpiresAt() time.Time {
+	return m.config.PublishLeaseExpiresAt
+}
+```
+
+Update the now-stale `GetRetention` doc comment (backup.go:220-224):
+```go
+// GetRetention returns the configured retention count. It is retained for
+// config-shape compatibility only: agent-side retention pruning has been
+// removed entirely (D18 §3.5) — the server is the sole retention/GC
+// authority. This value drives no behavior anywhere in this package.
+func (m *BackupManager) GetRetention() int {
+	return m.config.Retention
+}
+```
+
+In `agent/cmd/breeze-backup/exec_backup.go`, extend the payload struct inside `managerFromBackupRunPayload` (`:105-114`):
+```go
+	var p struct {
+		Provider       string                   `json:"provider"`
+		ProviderConfig *backupRunProviderConfig `json:"providerConfig"`
+		Paths          []string                 `json:"paths"`
+		SystemImage    bool                     `json:"systemImage"`
+		// BaseSnapshotID/PublishLeaseExpiresAt implement the D18 §3.1
+		// server-owned-base protocol. BaseSnapshotID's presence in the JSON
+		// (vs. entirely absent) is the protocol switch: a *string stays nil
+		// when the field is omitted (older server, legacy bucket-listing
+		// mode) and becomes non-nil (possibly pointing at "") when present.
+		BaseSnapshotID        *string `json:"baseSnapshotId"`
+		PublishLeaseExpiresAt string  `json:"publishLeaseExpiresAt"`
+		// Vss lets the server force VSS on/off for this run. Not currently sent
+		// by apps/api/src/jobs/backupWorker.ts (a future policy toggle can); when
+		// absent the agent defaults it itself below.
+		Vss *bool `json:"vss,omitempty"`
+	}
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return nil, fmt.Errorf("invalid backup_run payload: %w", err)
+	}
+	if p.ProviderConfig == nil || p.Provider == "" {
+		return nil, nil
+	}
+	var publishLeaseExpiresAt time.Time
+	if p.PublishLeaseExpiresAt != "" {
+		parsed, parseErr := time.Parse(time.RFC3339, p.PublishLeaseExpiresAt)
+		if parseErr != nil {
+			return nil, fmt.Errorf("invalid backup_run payload: publishLeaseExpiresAt %q: %w", p.PublishLeaseExpiresAt, parseErr)
+		}
+		publishLeaseExpiresAt = parsed
+	}
+```
+
+Then add `BaseSnapshotID: p.BaseSnapshotID` and `PublishLeaseExpiresAt: publishLeaseExpiresAt` to BOTH `backup.NewBackupManager(backup.BackupConfig{...})` literals — the system_image branch (`:154-163`) and the file-mode branch (`:171-177`):
+```go
+		return backup.NewBackupManager(backup.BackupConfig{
+			Provider:              provider,
+			SystemStateEnabled:    true,
+			VSSEnabled:            vssEnabled,
+			AgentID:               helperAgentID,
+			BaseSnapshotID:        p.BaseSnapshotID,
+			PublishLeaseExpiresAt: publishLeaseExpiresAt,
+		}), nil
+	}
+	if len(p.Paths) == 0 {
+		return nil, fmt.Errorf("backup_run payload has no paths")
+	}
+	return backup.NewBackupManager(backup.BackupConfig{
+		Provider:              provider,
+		Paths:                 p.Paths,
+		Retention:             0,
+		VSSEnabled:            vssEnabled,
+		AgentID:               helperAgentID,
+		BaseSnapshotID:        p.BaseSnapshotID,
+		PublishLeaseExpiresAt: publishLeaseExpiresAt,
+	}), nil
+```
+
+- [ ] Step 4: Run, expect PASS:
+```
+cd agent && go test ./cmd/breeze-backup/ -run TestManagerFromBackupRunPayload -v
+```
+
+- [ ] Step 5: Commit:
+```
+git add agent/internal/backup/backup.go agent/cmd/breeze-backup/exec_backup.go agent/cmd/breeze-backup/exec_backup_test.go
+git commit -m "feat(agent/backup): decode server-owned base pin + publish lease from backup_run payload"
+```
+
+### Task 2: `fetchServerOwnedBase` + run-path mode switch
+
+**Files:**
+- Modify `agent/internal/backup/incremental.go` (new function; add `encoding/json`, `os` imports)
+- Modify `agent/internal/backup/backup.go:665-691`
+- Test: `agent/internal/backup/incremental_test.go` (new table), `agent/internal/backup/backup_test.go` (new `RunBackupContext` cases)
+
+**Interfaces:**
+- Produces: `fetchServerOwnedBase(ctx context.Context, provider providers.BackupProvider, baseSnapshotID, identity string) (*Snapshot, string)` — mirrors `previousManifest`'s `(*Snapshot, reason string)` fail-open contract.
+- Consumes: `Snapshot.BackupIdentity`, `snapshotRootDir`, `snapshotManifestKey` (all existing).
+
+- [ ] Step 1: Write the failing test in `incremental_test.go` (mirror `storeManifest`/`newMockProvider` helpers already used at the top of that file):
+
+```go
+func TestFetchServerOwnedBase(t *testing.T) {
+	const myIdentity = "s3|bucket-1|device-a|file"
+
+	t.Run("valid base with matching identity", func(t *testing.T) {
+		provider := newMockProvider()
+		base := &Snapshot{
+			ID:             "snap-base",
+			Timestamp:      time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+			BackupIdentity: myIdentity,
+			Files:          []SnapshotFile{{SourcePath: "/data/a.txt", BackupPath: "snapshots/snap-base/files/a.txt.gz", Size: 1}},
+		}
+		storeManifest(t, provider, base)
+
+		snap, reason := fetchServerOwnedBase(context.Background(), provider, "snap-base", myIdentity)
+		if snap == nil {
+			t.Fatalf("expected a matching snapshot, got nil (reason: %s)", reason)
+		}
+		if snap.ID != "snap-base" {
+			t.Fatalf("fetchServerOwnedBase picked %q, want %q", snap.ID, "snap-base")
+		}
+	})
+
+	t.Run("identity mismatch falls back to full run", func(t *testing.T) {
+		provider := newMockProvider()
+		base := &Snapshot{
+			ID:             "snap-base",
+			Timestamp:      time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+			BackupIdentity: "s3|bucket-1|device-b|file",
+			Files:          []SnapshotFile{{SourcePath: "/data/a.txt", BackupPath: "snapshots/snap-base/files/a.txt.gz", Size: 1}},
+		}
+		storeManifest(t, provider, base)
+
+		snap, reason := fetchServerOwnedBase(context.Background(), provider, "snap-base", myIdentity)
+		if snap != nil {
+			t.Fatalf("expected nil on identity mismatch, got %+v", snap)
+		}
+		if reason == "" {
+			t.Error("expected a non-empty reason")
+		}
+	})
+
+	t.Run("empty baseSnapshotId means full run", func(t *testing.T) {
+		provider := newMockProvider()
+		snap, reason := fetchServerOwnedBase(context.Background(), provider, "", myIdentity)
+		if snap != nil {
+			t.Fatalf("expected nil for empty baseSnapshotId, got %+v", snap)
+		}
+		if reason == "" {
+			t.Error("expected a non-empty reason")
+		}
+	})
+
+	t.Run("404 (manifest never uploaded) falls back to full run", func(t *testing.T) {
+		provider := newMockProvider()
+		snap, reason := fetchServerOwnedBase(context.Background(), provider, "snap-missing", myIdentity)
+		if snap != nil {
+			t.Fatalf("expected nil on download failure, got %+v", snap)
+		}
+		if reason == "" {
+			t.Error("expected a non-empty reason")
+		}
+	})
+}
+```
+
+- [ ] Step 2: Run it, expect FAIL with `undefined: fetchServerOwnedBase`:
+```
+cd agent && go test ./internal/backup/ -run TestFetchServerOwnedBase
+```
+
+- [ ] Step 3: Implement.
+
+Add to `agent/internal/backup/incremental.go` imports:
+```go
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/breeze-rmm/agent/internal/backup/providers"
+	"github.com/breeze-rmm/agent/internal/backup/systemstate"
+)
+```
+
+Append the new function:
+```go
+// fetchServerOwnedBase downloads and validates the manifest for
+// baseSnapshotID as this run's incremental-dedupe base, per the D18
+// server-owned-base protocol (§3.1). Unlike previousManifest (legacy
+// bucket-listing mode), the server has already chosen the base id — this
+// function only fetches and validates it belongs to this device/
+// destination/run-kind (the same D6 identity guard as previousManifest); it
+// never lists the bucket. Returns (nil, reason) on ANY failure — empty id,
+// download error, decode error, or identity mismatch — collapsing to a full
+// run, exactly like previousManifest's fail-open contract. reason is always
+// non-empty in that case so callers can log it directly.
+func fetchServerOwnedBase(ctx context.Context, provider providers.BackupProvider, baseSnapshotID, identity string) (*Snapshot, string) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if baseSnapshotID == "" {
+		return nil, "server selected no base for this run (full run)"
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Sprintf("context already done: %v", err)
+	}
+	if identity == "" {
+		return nil, "this run has no known backup identity, cannot safely validate the server-selected base"
+	}
+
+	manifestKey := path.Join(snapshotRootDir, baseSnapshotID, snapshotManifestKey)
+	tempFile, err := os.CreateTemp("", "base-manifest-*.json")
+	if err != nil {
+		return nil, fmt.Sprintf("failed to create temp file for base manifest: %v", err)
+	}
+	tempPath := tempFile.Name()
+	_ = tempFile.Close()
+	defer os.Remove(tempPath)
+
+	if err := provider.Download(manifestKey, tempPath); err != nil {
+		return nil, fmt.Sprintf("failed to download server-selected base manifest %s: %v", manifestKey, err)
+	}
+	data, err := os.ReadFile(tempPath)
+	if err != nil {
+		return nil, fmt.Sprintf("failed to read downloaded base manifest: %v", err)
+	}
+	var candidate Snapshot
+	if err := json.Unmarshal(data, &candidate); err != nil {
+		return nil, fmt.Sprintf("failed to decode base manifest %s: %v", manifestKey, err)
+	}
+	if candidate.BackupIdentity != identity {
+		return nil, fmt.Sprintf(
+			"server-selected base %s has BackupIdentity %q, this run's identity is %q — refusing to use a foreign snapshot as a dedupe base (D6)",
+			baseSnapshotID, candidate.BackupIdentity, identity)
+	}
+	return &candidate, ""
+}
+```
+
+In `agent/internal/backup/backup.go`, replace the block at `:682-691`:
+```go
+	var prevSnapshot *Snapshot
+	incrementalDedupeActive := !m.config.SystemStateEnabled || len(m.config.Paths) > 0
+	if incrementalDedupeActive {
+		if m.config.BaseSnapshotID != nil {
+			// Server-owned mode (D18 §3.1): the protocol switch is presence
+			// of baseSnapshotId in the backup_run payload (see
+			// exec_backup.go). The agent never lists the bucket to choose a
+			// base in this mode.
+			prev, reason := fetchServerOwnedBase(runCtx, m.config.Provider, *m.config.BaseSnapshotID, runIdentity)
+			if prev == nil {
+				log.Info("running full backup, no reference dedupe",
+					"mode", "server-owned",
+					"baseSnapshotId", *m.config.BaseSnapshotID,
+					"reason", reason,
+				)
+			} else {
+				prevSnapshot = prev
+				log.Info("using server-selected base for incremental reference dedupe",
+					"mode", "server-owned",
+					"baseSnapshotId", prev.ID,
+				)
+			}
+		} else {
+			// Legacy mode: server predates the field, fall back to the
+			// original bucket-listing lookup.
+			prev, reason := previousManifest(runCtx, m.config.Provider, runIdentity)
+			if prev == nil {
+				log.Info("running full backup, no reference dedupe", "mode", "legacy", "reason", reason)
+			} else {
+				prevSnapshot = prev
+			}
+		}
+	}
+```
+
+- [ ] Step 4: Run, expect PASS:
+```
+cd agent && go test ./internal/backup/ -run TestFetchServerOwnedBase -v
+```
+
+- [ ] Step 5: Commit:
+```
+git add agent/internal/backup/incremental.go agent/internal/backup/backup.go agent/internal/backup/incremental_test.go
+git commit -m "feat(agent/backup): fetch server-selected dedupe base, fall back to legacy listing"
+```
+
+### Task 3: Checkpoint-journal age tracking
+
+**Files:**
+- Modify `agent/internal/backup/journal.go` (struct field + method + both construction sites)
+- Test: `agent/internal/backup/journal_test.go` (new test)
+
+**Interfaces:**
+- Produces: `(*snapshotJournal) Age() time.Duration`
+
+- [ ] Step 1: Write the failing test in `journal_test.go`:
+```go
+func TestSnapshotJournal_Age(t *testing.T) {
+	dir := t.TempDir()
+	j, _, err := openSnapshotJournal(dir, "age-test-identity", journalMaxAge)
+	if err != nil {
+		t.Fatalf("openSnapshotJournal failed: %v", err)
+	}
+	defer j.Abandon()
+
+	if age := j.Age(); age < 0 || age > time.Second {
+		t.Fatalf("fresh journal Age() = %v, want ~0", age)
+	}
+
+	// A nil journal must not panic and reports zero age.
+	var nilJournal *snapshotJournal
+	if age := nilJournal.Age(); age != 0 {
+		t.Fatalf("nil journal Age() = %v, want 0", age)
+	}
+}
+
+func TestSnapshotJournal_Age_SurvivesResume(t *testing.T) {
+	dir := t.TempDir()
+	restore := setJournalMaxAgeForTest(24 * time.Hour)
+	defer restore()
+
+	j1, _, err := openSnapshotJournal(dir, "resume-age-identity", journalMaxAge)
+	if err != nil {
+		t.Fatalf("openSnapshotJournal (1st) failed: %v", err)
+	}
+	if err := j1.Record(SnapshotFile{SourcePath: "/a.txt", Size: 1}); err != nil {
+		t.Fatalf("Record failed: %v", err)
+	}
+	j1.Abandon()
+
+	j2, resumed, err := openSnapshotJournal(dir, "resume-age-identity", journalMaxAge)
+	if err != nil {
+		t.Fatalf("openSnapshotJournal (2nd) failed: %v", err)
+	}
+	defer j2.Abandon()
+	if !resumed {
+		t.Fatal("expected the second open to resume the first journal")
+	}
+	if age := j2.Age(); age < 0 || age > time.Second {
+		t.Fatalf("resumed journal Age() = %v, want ~0 (same createdAt as the original)", age)
+	}
+}
+```
+
+- [ ] Step 2: Run it, expect FAIL with `j.Age undefined (type *snapshotJournal has no field or method Age)`:
+```
+cd agent && go test ./internal/backup/ -run TestSnapshotJournal_Age
+```
+
+- [ ] Step 3: Implement.
+
+Add a field to the `snapshotJournal` struct (`journal.go`, after `identity string`):
+```go
+	// createdAt is the journal's original creation time (from its header,
+	// preserved verbatim across a resume — NOT reset on resume). Age()
+	// reports time.Since(createdAt), used at publish time to fence a
+	// resumed run against journalMaxAge (see leaseGate in snapshot.go).
+	createdAt time.Time
+```
+
+Set it in the resumed-open branch (`openSnapshotJournal`, inside the `identityMatches && time.Since(header.CreatedAt) <= maxAge` success path, where the `&snapshotJournal{...}` literal is built):
+```go
+				return &snapshotJournal{
+					file:              f,
+					writer:            bufio.NewWriter(f),
+					path:              path,
+					snapshotID:        header.SnapshotID,
+					identity:          identity,
+					entries:           entries,
+					resumedBytesTotal: resumedBytes,
+					resumed:           true,
+					createdAt:         header.CreatedAt,
+				}, true, nil
+```
+
+Set it in `createFreshJournal`'s return literal:
+```go
+	return &snapshotJournal{
+		file:       f,
+		writer:     bufio.NewWriter(f),
+		path:       path,
+		snapshotID: header.SnapshotID,
+		identity:   identity,
+		createdAt:  header.CreatedAt,
+	}, false, nil
+```
+
+Add the method after `ResumedBytes`:
+```go
+// Age reports how long ago this journal was originally created (the
+// header's CreatedAt, unaffected by resume — see the createdAt field doc).
+// A nil journal reports zero age.
+func (j *snapshotJournal) Age() time.Duration {
+	if j == nil || j.createdAt.IsZero() {
+		return 0
+	}
+	return time.Since(j.createdAt)
+}
+```
+
+- [ ] Step 4: Run, expect PASS:
+```
+cd agent && go test ./internal/backup/ -run TestSnapshotJournal_Age -v
+```
+
+- [ ] Step 5: Commit:
+```
+git add agent/internal/backup/journal.go agent/internal/backup/journal_test.go
+git commit -m "feat(agent/backup): track checkpoint journal creation age"
+```
+
+### Task 4: `leaseGate` — refuse to publish past the lease margin or journal age
+
+**Files:**
+- Modify `agent/internal/backup/backup.go` (sentinel errors, call-site substitution at `:758`)
+- Modify `agent/internal/backup/snapshot.go` (new `leaseGate` type + constants)
+- Test: `agent/internal/backup/snapshot_test.go` (new tests), `agent/internal/backup/backup_test.go` (new `RunBackupContext` case)
+
+**Interfaces:**
+- Produces: `ErrPublishLeaseExpired`, `ErrJournalExpiredAtPublish` (both `error`, `backup.go`); `leaseGate` (unexported, `snapshot.go`); `publishMargin`, `uploadLeaseInterval` constants (`snapshot.go`).
+- Design note: `createSnapshotWithProgress`'s signature (`snapshot.go:343`) is deliberately left unchanged — it has ~30 call sites across 5 test files. The lease/journal-age check is enforced by wrapping the `providers.BackupProvider` passed in, at the ONE real call site (`backup.go:758`), so existing tests need no changes for this task.
+
+- [ ] Step 1: Write the failing test in `snapshot_test.go`:
+```go
+func TestLeaseGate_RefusesManifestPastLeaseMargin(t *testing.T) {
+	tmpDir := t.TempDir()
+	file1 := createTempFile(t, tmpDir, "file1.txt", "content")
+	provider := newMockProvider()
+	gated := &leaseGate{
+		BackupProvider:        provider,
+		publishLeaseExpiresAt: time.Now().Add(30 * time.Minute), // inside the 1h margin
+	}
+
+	files := []backupFile{{sourcePath: file1, snapshotPath: "path_0/file1.txt", size: 7, modTime: time.Now()}}
+	_, err := createSnapshotWithProgress(context.Background(), gated, files, nil, nil, nil, nil)
+	if !errors.Is(err, ErrPublishLeaseExpired) {
+		t.Fatalf("err = %v, want ErrPublishLeaseExpired", err)
+	}
+	for _, key := range provider.uploads {
+		if isManifestPath(key) {
+			t.Fatalf("manifest was uploaded despite an expired lease: %s", key)
+		}
+	}
+}
+
+func TestLeaseGate_AllowsManifestWellInsideLease(t *testing.T) {
+	tmpDir := t.TempDir()
+	file1 := createTempFile(t, tmpDir, "file1.txt", "content")
+	provider := newMockProvider()
+	gated := &leaseGate{
+		BackupProvider:        provider,
+		publishLeaseExpiresAt: time.Now().Add(24 * time.Hour),
+	}
+
+	files := []backupFile{{sourcePath: file1, snapshotPath: "path_0/file1.txt", size: 7, modTime: time.Now()}}
+	snap, err := createSnapshotWithProgress(context.Background(), gated, files, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if snap == nil {
+		t.Fatal("expected a snapshot")
+	}
+}
+
+func TestLeaseGate_RefusesManifestWhenResumedJournalTooOld(t *testing.T) {
+	restore := setJournalMaxAgeForTest(1 * time.Millisecond)
+	defer restore()
+
+	dir := t.TempDir()
+	j1, _, err := openSnapshotJournal(dir, "lease-journal-identity", journalMaxAge)
+	if err != nil {
+		t.Fatalf("openSnapshotJournal (1st) failed: %v", err)
+	}
+	j1.Abandon()
+	time.Sleep(5 * time.Millisecond)
+
+	j2, resumed, err := openSnapshotJournal(dir, "lease-journal-identity", journalMaxAge)
+	if err != nil {
+		t.Fatalf("openSnapshotJournal (2nd) failed: %v", err)
+	}
+	if resumed {
+		t.Fatal("journal should be treated as stale (too old), not resumed")
+	}
+	// Force resumed+old state directly to exercise the gate deterministically
+	// (openSnapshotJournal already discarded the stale one above, matching
+	// production behavior — this constructs the boundary case directly).
+	j2.resumed = true
+	j2.createdAt = time.Now().Add(-2 * journalMaxAge)
+
+	tmpDir := t.TempDir()
+	file1 := createTempFile(t, tmpDir, "file1.txt", "content")
+	provider := newMockProvider()
+	gated := &leaseGate{BackupProvider: provider, journal: j2}
+
+	files := []backupFile{{sourcePath: file1, snapshotPath: "path_0/file1.txt", size: 7, modTime: time.Now()}}
+	_, err = createSnapshotWithProgress(context.Background(), gated, files, nil, j2, nil, nil)
+	if !errors.Is(err, ErrJournalExpiredAtPublish) {
+		t.Fatalf("err = %v, want ErrJournalExpiredAtPublish", err)
+	}
+}
+```
+
+- [ ] Step 2: Run it, expect FAIL with `undefined: leaseGate`:
+```
+cd agent && go test ./internal/backup/ -run TestLeaseGate
+```
+
+- [ ] Step 3: Implement.
+
+Add to `agent/internal/backup/backup.go` (near `errBackupStopped`, package-level `var` block):
+```go
+// ErrPublishLeaseExpired is returned when a server-dispatched run (D18
+// §3.1) cannot publish its manifest because the server's publish lease
+// (BackupConfig.PublishLeaseExpiresAt, minus the 1h publishMargin) expired
+// before upload finished. The server treats a late result past lease
+// expiry as failed — returning this distinct, unwrapped-comparable error
+// lets logs and tests tell it apart from an ordinary publish failure. No
+// manifest is uploaded and nothing is deleted: the partial, manifest-less
+// prefix is reclaimed by GC's existing manifest-less-prefix rule.
+var ErrPublishLeaseExpired = errors.New("backup publish lease expired before manifest could be published")
+
+// ErrJournalExpiredAtPublish is the same fail-closed rule as
+// ErrPublishLeaseExpired but keyed on the checkpoint journal's age for a
+// RESUMED run: if journalMaxAge has elapsed by the time upload finishes,
+// the server can no longer distinguish this manifest from an abandoned
+// resume attempt, so publishing is refused.
+var ErrJournalExpiredAtPublish = errors.New("checkpoint journal expired before manifest could be published")
+```
+
+Add to `agent/internal/backup/snapshot.go` (near the other package-level consts, e.g. next to `snapshotRootDir`):
+```go
+const (
+	// publishMargin is subtracted from the lease deadline at publish time
+	// (D18 §3.1): the server keeps a job's base pinned for
+	// lease+publishMargin precisely so a manifest PUT that STARTS inside
+	// the margin has room to finish before the server's pin lapses. Must
+	// match the API's BACKUP_PUBLISH_MARGIN_MS default —
+	// backupAgentContract.test.ts asserts the two stay equal.
+	publishMargin = 1 * time.Hour
+
+	// uploadLeaseInterval is how often createSnapshotWithProgress refreshes
+	// snapshots/<id>/upload.lease while uploading (D18 §3.4), so a
+	// long-running single-object upload keeps the prefix's newest object
+	// fresh. MUST stay well under the API's manifest-less-prefix GC window
+	// (journalMaxAge + 48h grace = 9 days) — backupAgentContract.test.ts
+	// asserts this.
+	uploadLeaseInterval = 15 * time.Minute
+)
+
+// leaseGate wraps a BackupProvider so publishing a snapshot manifest past
+// its server-granted publish lease (or, for a resumed run, past the
+// checkpoint journal's max age) fails closed instead of publishing a
+// manifest the server can no longer trust (D18 §3.1/§3.4). Only
+// isManifestPath uploads are gated — ordinary file uploads and the
+// upload.lease heartbeat object pass straight through to the wrapped
+// provider.
+type leaseGate struct {
+	providers.BackupProvider
+	// publishLeaseExpiresAt is BackupConfig.PublishLeaseExpiresAt verbatim.
+	// Zero value disables the lease check (legacy server, no field sent).
+	publishLeaseExpiresAt time.Time
+	// journal is this run's checkpoint journal, or nil. Only a RESUMED
+	// journal (journal.resumed) is checked against journalMaxAge — a fresh
+	// journal's age is irrelevant here.
+	journal *snapshotJournal
+}
+
+func (g *leaseGate) checkPublish(remotePath string) error {
+	if !isManifestPath(remotePath) {
+		return nil
+	}
+	if !g.publishLeaseExpiresAt.IsZero() && time.Now().Add(publishMargin).After(g.publishLeaseExpiresAt) {
+		return ErrPublishLeaseExpired
+	}
+	if g.journal != nil && g.journal.resumed && g.journal.Age() >= journalMaxAge {
+		return ErrJournalExpiredAtPublish
+	}
+	return nil
+}
+
+// Upload implements providers.BackupProvider.
+func (g *leaseGate) Upload(localPath, remotePath string) error {
+	if err := g.checkPublish(remotePath); err != nil {
+		return err
+	}
+	return g.BackupProvider.Upload(localPath, remotePath)
+}
+
+// UploadContext implements contextUploader. Declared unconditionally (even
+// when the wrapped provider doesn't support it) so uploadSnapshotFile's
+// type assertion on the WRAPPER always succeeds and the lease check always
+// runs; it falls back to a plain Upload when the wrapped provider lacks
+// context support, exactly like uploadSnapshotFile itself does.
+func (g *leaseGate) UploadContext(ctx context.Context, localPath, remotePath string) error {
+	if err := g.checkPublish(remotePath); err != nil {
+		return err
+	}
+	if u, ok := g.BackupProvider.(contextUploader); ok {
+		return u.UploadContext(ctx, localPath, remotePath)
+	}
+	return g.BackupProvider.Upload(localPath, remotePath)
+}
+```
+
+In `agent/internal/backup/backup.go`, change the call site at `:758` (immediately before it, after the journal block ends at `:756`):
+```go
+	// Gate manifest publication on the server's lease (D18 §3.1) whenever
+	// one was sent — legacy servers (zero PublishLeaseExpiresAt) get the
+	// unwrapped provider and unchanged behavior. Applies to full runs too,
+	// not just incremental ones: the server fences every dispatched run's
+	// late-result window this way.
+	uploadProvider := m.config.Provider
+	if !m.config.PublishLeaseExpiresAt.IsZero() {
+		uploadProvider = &leaseGate{
+			BackupProvider:        m.config.Provider,
+			publishLeaseExpiresAt: m.config.PublishLeaseExpiresAt,
+			journal:               journal,
+		}
+	}
+	snapshot, snapErr := createSnapshotWithProgress(runCtx, uploadProvider, files, progressFn, journal, prevSnapshot, sourceLiveness, runIdentity)
+```
+
+- [ ] Step 4: Run, expect PASS:
+```
+cd agent && go test ./internal/backup/ -run TestLeaseGate -v
+```
+
+- [ ] Step 5: Commit:
+```
+git add agent/internal/backup/backup.go agent/internal/backup/snapshot.go agent/internal/backup/snapshot_test.go
+git commit -m "feat(agent/backup): refuse to publish a manifest past its lease or journal age"
+```
+
+### Task 5: Remove agent-side retention pruning and stale-journal cleanup; keep the own-run-prefix abort cleanups
+
+Spec §3.5 (re-read after coordinator review) states the deletion removal has two **explicit
+exceptions**, not zero: the helper may still delete objects under **its own current run's
+prefix, before that run's manifest is published** (the journal-less abort paths at
+`snapshot.go:499` and `:544`) and its own `upload.lease` after publication (Task 7). Both
+exceptions are safe because neither prefix can ever be referenced by another manifest — nothing
+else knows the id exists until a manifest publishes it. What actually gets removed in this task
+is narrower than originally planned: the retention-prune branch, the stale-journal remote
+cleanup, and `DeleteSnapshot`/`DeleteSnapshotContext` (which pruned OTHER, already-published
+snapshots' entire prefixes — the actually dangerous case). `cleanupSnapshotPrefix` and
+`listSnapshotPrefixItems` are KEPT, since the two retained call sites still need them.
+
+**Files:**
+- Modify `agent/internal/backup/backup.go` (retention branch `:780-806`, stale-journal cleanup call `:748`)
+- Modify `agent/internal/backup/snapshot.go` (remove only `DeleteSnapshot`/`DeleteSnapshotContext`; `abortStopped` `:496-500` and `abortSourceGone`'s zero-files branch `:541-546` are UNCHANGED — their `cleanupSnapshotPrefix` calls stay)
+- Modify `agent/internal/backup/snapshot_lifecycle_test.go` (remove the `DeleteSnapshot`/`DeleteSnapshotContext` tests only; `cleanupSnapshotPrefix`'s own behavior needs no new coverage here since Task 6 already proves it's never reached for a published manifest)
+- Modify `agent/internal/backup/snapshot_test.go` (add a new scoping test; `TestDeleteSnapshot_DoesNotDeleteAdjacentPrefix` is removed since it targets the removed `DeleteSnapshot`)
+- Modify `agent/internal/backup/backup_test.go:924-985` (comment update only)
+
+**Interfaces:**
+- Removes: `DeleteSnapshot`, `DeleteSnapshotContext` only (confirmed zero external callers in Ground Truth §0; `backup.go:799` was `DeleteSnapshotContext`'s only caller).
+- Keeps unchanged: `cleanupSnapshotPrefix`, `listSnapshotPrefixItems` (still called from `snapshot.go:499`/`:544`).
+- Produces (test-only): `TestBackupNeverDeletesRemoteObjects_RetentionConfigured`, `TestAbortCleanup_OnlyDeletesOwnUnpublishedPrefix_NeverAPublishedManifestPrefix`.
+- **Ordering guarantee this task relies on**: Task 6's resume-with-already-published-manifest shortcut is inserted immediately after `prefix := path.Join(snapshotRootDir, snapshot.ID)` and returns before the upload loop — and therefore before either `abortStopped` or `abortSourceGone` can be reached — whenever `journal != nil && journal.resumed` and that journal's manifest already exists. So a journal-resumed run whose manifest is already published can never reach a `cleanupSnapshotPrefix` call: it returns via Task 6's early path first. This is a structural property of the current control flow (Task 6's insertion point strictly precedes both abort closures' only call sites), not something Task 5 needs to add logic for — but the new test below pins it as a regression guard in case a future refactor reorders them.
+
+- [ ] Step 1: Write the failing tests.
+
+Remove `TestDeleteSnapshot_NothingToDelete`, `_ZeroRetention`, `_NegativeRetention`, `_PrunesOldSnapshots`, `_RetentionExceedsCount`, `_DeleteError` from `snapshot_lifecycle_test.go` (`:108-208`) — they exercise a function that no longer exists — and add:
+```go
+// D18 §3.5: agent-side retention pruning is removed entirely (unlike the
+// two explicit own-run-prefix exceptions kept in snapshot.go — see
+// TestAbortCleanup_OnlyDeletesOwnUnpublishedPrefix... below). This replaces
+// the removed DeleteSnapshot/DeleteSnapshotContext pruning tests: instead of
+// asserting pruning behavior, it asserts NO deletion happens across
+// multiple successful runs even with Retention configured.
+func TestBackupNeverDeletesRemoteObjects_RetentionConfigured(t *testing.T) {
+	tmpDir := t.TempDir()
+	createTempFile(t, tmpDir, "data.txt", "content")
+	provider := newMockProvider()
+	mgr := NewBackupManager(BackupConfig{
+		Provider:   provider,
+		Paths:      []string{tmpDir},
+		Retention:  1, // ignored — see GetRetention's doc comment
+		StagingDir: t.TempDir(),
+		AgentID:    "test-device",
+	})
+
+	for i := 0; i < 3; i++ {
+		if _, err := mgr.RunBackupContext(context.Background(), nil); err != nil {
+			t.Fatalf("RunBackupContext #%d failed: %v", i+1, err)
+		}
+	}
+	if len(provider.deleteCalls) != 0 {
+		t.Fatalf("expected zero Delete calls across successful runs with Retention set, got %d: %v", len(provider.deleteCalls), provider.deleteCalls)
+	}
+}
+```
+
+Remove `TestDeleteSnapshot_DoesNotDeleteAdjacentPrefix` in `snapshot_test.go` (`:198-230`) and add:
+```go
+// TestAbortCleanup_OnlyDeletesOwnUnpublishedPrefix_NeverAPublishedManifestPrefix
+// pins the §3.5 exception's boundary from both directions: (1) a journal-less
+// stop DOES delete keys, but only under the aborted run's OWN snapshot id —
+// never a sibling prefix that already has a manifest.json (an existing,
+// referenceable snapshot); and (2) proves the ordering guarantee this task's
+// Interfaces section describes — a journal-RESUMED run whose manifest is
+// already published takes Task 6's early-return path and reaches
+// cleanupSnapshotPrefix zero times, never deleting the manifest it just
+// found.
+func TestAbortCleanup_OnlyDeletesOwnUnpublishedPrefix_NeverAPublishedManifestPrefix(t *testing.T) {
+	t.Run("journal-less stop deletes only its own snapshot id's keys", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		file1 := createTempFile(t, tmpDir, "file1.txt", "content")
+		provider := newMockProvider()
+
+		// Seed a sibling, already-published snapshot that must never be
+		// touched by the aborted run's cleanup.
+		sibling := &Snapshot{
+			ID:    "snapshot-sibling-published",
+			Files: []SnapshotFile{{SourcePath: "/data/other.txt", BackupPath: "snapshots/snapshot-sibling-published/files/other.txt.gz", Size: 1}},
+		}
+		storeManifest(t, provider, sibling)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // already stopped before the loop starts
+		files := []backupFile{{sourcePath: file1, snapshotPath: "path_0/file1.txt", size: 7, modTime: time.Now()}}
+		snap, err := createSnapshotWithProgress(ctx, provider, files, nil, nil, nil, nil)
+		if !errors.Is(err, errBackupStopped) {
+			t.Fatalf("err = %v, want errBackupStopped", err)
+		}
+		_ = snap // stopped runs return a nil snapshot; the aborted run's own id is read from deleteCalls below.
+
+		for _, key := range provider.deleteCalls {
+			if strings.HasPrefix(key, "snapshots/snapshot-sibling-published/") {
+				t.Fatalf("abort cleanup deleted a key under a PUBLISHED sibling prefix: %s", key)
+			}
+		}
+		if _, stillThere := provider.files["snapshots/snapshot-sibling-published/manifest.json"]; !stillThere {
+			t.Fatal("sibling published manifest must survive the aborted run's cleanup")
+		}
+	})
+
+	t.Run("resumed run with an already-published manifest never reaches cleanupSnapshotPrefix", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		file1 := createTempFile(t, tmpDir, "file1.txt", "content")
+		provider := newMockProvider()
+
+		journalDir := t.TempDir()
+		journal, _, err := openSnapshotJournal(journalDir, "resume-cleanup-guard-identity", journalMaxAge)
+		if err != nil {
+			t.Fatalf("openSnapshotJournal failed: %v", err)
+		}
+		published := &Snapshot{
+			ID:    journal.snapshotID,
+			Files: []SnapshotFile{{SourcePath: file1, BackupPath: "snapshots/" + journal.snapshotID + "/files/file1.txt.gz", Size: 7}},
+		}
+		storeManifest(t, provider, published)
+		journal.Abandon()
+
+		journal2, resumed, err := openSnapshotJournal(journalDir, "resume-cleanup-guard-identity", journalMaxAge)
+		if err != nil {
+			t.Fatalf("openSnapshotJournal (resume) failed: %v", err)
+		}
+		if !resumed {
+			t.Fatal("expected the journal to resume")
+		}
+
+		// A cancelled context proves the resume shortcut wins the race
+		// against abortStopped: if cleanupSnapshotPrefix ran here instead,
+		// it would delete the manifest just seeded above.
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		files := []backupFile{{sourcePath: file1, snapshotPath: "path_0/file1.txt", size: 7, modTime: time.Now()}}
+		snap, err := createSnapshotWithProgress(ctx, provider, files, nil, journal2, nil, nil)
+		if err != nil {
+			t.Fatalf("expected the resume shortcut to succeed despite the cancelled context, got err: %v", err)
+		}
+		if snap == nil || snap.ID != journal.snapshotID {
+			t.Fatalf("expected the already-published snapshot back, got %+v", snap)
+		}
+		manifestKey := "snapshots/" + journal.snapshotID + "/manifest.json"
+		if _, stillThere := provider.files[manifestKey]; !stillThere {
+			t.Fatal("resumed run's own already-published manifest must survive — cleanupSnapshotPrefix must never have run")
+		}
+		for _, key := range provider.deleteCalls {
+			if strings.HasPrefix(key, "snapshots/"+journal.snapshotID+"/") {
+				t.Fatalf("cleanupSnapshotPrefix ran for a prefix with an already-published manifest: deleted %s", key)
+			}
+		}
+	})
+}
+```
+(`strings` is already imported by `snapshot_test.go` — verify before adding if not.)
+
+- [ ] Step 2: Run it, expect FAIL — `TestBackupNeverDeletesRemoteObjects_RetentionConfigured` fails with non-zero delete calls (current retention-prune branch still fires for `Retention:1` since it's only gated on `!incrementalDedupeActive`, and this test uses `Paths` with no prior snapshot so `incrementalDedupeActive` is still true every run in this config... re-check: confirm which sub-case reproduces the CURRENT bug before relying on it — if `incrementalDedupeActive` is true throughout for this config the branch already doesn't fire, in which case this specific test is a regression guard rather than red-first. The second test, `TestAbortCleanup_OnlyDeletesOwnUnpublishedPrefix_NeverAPublishedManifestPrefix`'s second subtest, IS red-first against current code: Task 6 doesn't exist yet, so the resumed run calls `abortStopped()` → `cleanupSnapshotPrefix` → deletes the seeded manifest):
+```
+cd agent && go test ./internal/backup/ -run 'TestBackupNeverDeletesRemoteObjects_RetentionConfigured|TestAbortCleanup_OnlyDeletesOwnUnpublishedPrefix' -v
+```
+Confirm the resume subtest fails with the manifest missing (`stillThere` false) before implementing — that failure is this task's actual red signal; write Task 6 first if sequencing this task standalone (Tasks are listed in dependency order specifically so Task 6 lands before this test is expected green — if implementing out of order, note the dependency here).
+
+- [ ] Step 3: Implement.
+
+In `agent/internal/backup/backup.go`, delete the entire retention-prune block (`:780-806`, from `retentionErr := error(nil)` through its closing `}`) and the `retentionErr` variable's later use — grep `retentionErr` first to confirm every reference is inside this block before deleting (it is: the variable is declared, assigned, and read only within `:780-806` in this file). Replace the block with nothing (the `if err := runCtx.Err(); err != nil { return stopBackupRun() }` guard immediately before it stays, since a stop-check is still correct there).
+
+Change the stale-journal branch (`:738-749`) — remove ONLY the `cleanupSnapshotPrefix` call, keep the rest:
+```go
+	if journal != nil {
+		if staleID, ok := journal.StaleSnapshotID(); ok {
+			// StaleSnapshotID covers both an actually-stale (>journalMaxAge)
+			// journal and the (near-impossible) identity-mismatch case — see
+			// openSnapshotJournal — so the message below is deliberately
+			// generic rather than claiming a specific cause. The agent no
+			// longer cleans up the STALE JOURNAL'S remote prefix itself
+			// (D18 §3.5): that prefix belongs to a PRIOR, different run
+			// (not this run's own in-progress prefix, which is the only
+			// exception §3.5 keeps — see abortStopped/abortSourceGone in
+			// snapshot.go), so it is simply dropped and GC's existing
+			// manifest-less-prefix rule reclaims it.
+			log.Warn("discarding unusable checkpoint journal",
+				"snapshotId", staleID,
+				"maxAge", journalMaxAge.String(),
+			)
+		}
+```
+(Remove only the `cleanupSnapshotPrefix(m.config.Provider, staleID)` call. Do NOT touch `abortStopped`/`abortSourceGone` in `snapshot.go` — both keep their existing `cleanupSnapshotPrefix` calls unchanged, per the spec exception.)
+
+Remove `DeleteSnapshot` (`:972-974`) and `DeleteSnapshotContext` (`:977-1023`) from `snapshot.go` entirely. Leave `cleanupSnapshotPrefix` (`:884-892`) and `listSnapshotPrefixItems` (`:1025-1032`) exactly as they are.
+
+Update the comment on `TestRunBackup_IncrementalRetentionDoesNotStrandReferencedObjects` (`backup_test.go:924-933`) — the branch it warns about is now gone, not merely gated:
+```go
+// Incremental dedupe (now unconditional) carries an unchanged file's bytes
+// forward under the OLDEST snapshot's prefix, and every newer manifest
+// references back into it. Agent-side retention pruning of OTHER,
+// already-published snapshots has been removed entirely (D18 §3.5,
+// DeleteSnapshotContext deleted) — this test proves the server-only-
+// retention invariant holds end-to-end: with Retention:2 (now fully
+// ignored, see GetRetention's doc comment) and 3+ incremental runs over an
+// UNCHANGED source, the agent must NOT prune, and a verify/restore from the
+// NEWEST manifest must still succeed. (The narrower own-run-prefix cleanup
+// in abortStopped/abortSourceGone is unaffected and unrelated to this test.)
+```
+
+- [ ] Step 4: Run, expect PASS (and confirm the two removed functions leave no dangling references while the two kept ones still compile and are still called):
+```
+cd agent && go build ./... && go test ./internal/backup/... ./cmd/breeze-backup/... -run 'TestBackupNeverDeletesRemoteObjects|TestAbortCleanup_OnlyDeletesOwnUnpublishedPrefix|TestRunBackup_IncrementalRetentionDoesNotStrandReferencedObjects' -v
+```
+
+- [ ] Step 5: Commit:
+```
+git add agent/internal/backup/backup.go agent/internal/backup/snapshot.go agent/internal/backup/snapshot_lifecycle_test.go agent/internal/backup/snapshot_test.go agent/internal/backup/backup_test.go
+git commit -m "feat(agent/backup): remove agent-side retention pruning and stale-journal cleanup (D18 §3.5)"
+```
+
+### Task 6: Resume with an already-published manifest — skip re-upload entirely
+
+**Files:**
+- Modify `agent/internal/backup/snapshot.go` (`createSnapshotWithProgress`, insert after the `prefix := path.Join(...)` line, currently `:388`)
+- Test: `agent/internal/backup/snapshot_test.go` (new tests)
+
+**Interfaces:**
+- Produces (unexported): `fetchPublishedManifest(ctx context.Context, provider providers.BackupProvider, prefix string) (*Snapshot, bool)`
+
+- [ ] Step 1: Write the failing test:
+```go
+func TestCreateSnapshot_ResumeWithAlreadyPublishedManifest_SkipsUpload(t *testing.T) {
+	tmpDir := t.TempDir()
+	file1 := createTempFile(t, tmpDir, "file1.txt", "content one")
+	provider := newMockProvider()
+
+	journalDir := t.TempDir()
+	journal, _, err := openSnapshotJournal(journalDir, "resume-published-identity", journalMaxAge)
+	if err != nil {
+		t.Fatalf("openSnapshotJournal failed: %v", err)
+	}
+
+	// Simulate a crash AFTER manifest publish but BEFORE journal.Complete():
+	// the manifest already exists at this snapshot's prefix.
+	published := &Snapshot{
+		ID:        journal.snapshotID,
+		Timestamp: time.Now().UTC(),
+		Files:     []SnapshotFile{{SourcePath: file1, BackupPath: "snapshots/" + journal.snapshotID + "/files/file1.txt.gz", Size: 11}},
+		Size:      11,
+	}
+	storeManifest(t, provider, published)
+	preUploadCount := len(provider.uploadCalls)
+
+	// Re-open as a resume (same identity, same dir): openSnapshotJournal
+	// would normally do this on a real second process start. Emulate it by
+	// re-opening — resumed should be true since createdAt is fresh.
+	journal.Abandon()
+	journal2, resumed, err := openSnapshotJournal(journalDir, "resume-published-identity", journalMaxAge)
+	if err != nil {
+		t.Fatalf("openSnapshotJournal (resume) failed: %v", err)
+	}
+	if !resumed {
+		t.Fatal("expected the journal to resume")
+	}
+
+	files := []backupFile{{sourcePath: file1, snapshotPath: "path_0/file1.txt", size: 11, modTime: time.Now()}}
+	snap, err := createSnapshotWithProgress(context.Background(), provider, files, nil, journal2, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if snap == nil || snap.ID != journal.snapshotID {
+		t.Fatalf("expected the already-published snapshot to be returned, got %+v", snap)
+	}
+	if len(provider.uploadCalls) != preUploadCount {
+		t.Fatalf("expected zero NEW uploads on an already-published resume, got %d new calls", len(provider.uploadCalls)-preUploadCount)
+	}
+}
+```
+
+- [ ] Step 2: Run it, expect FAIL (current code re-uploads `file1.txt` since it isn't in the journal's resumed entries):
+```
+cd agent && go test ./internal/backup/ -run TestCreateSnapshot_ResumeWithAlreadyPublishedManifest_SkipsUpload -v
+```
+
+- [ ] Step 3: Implement.
+
+Add near `publishSnapshotManifest` in `snapshot.go`:
+```go
+// fetchPublishedManifest downloads and decodes prefix's manifest.json if it
+// exists, returning (snapshot, true) on success. ANY failure — download
+// error (including a genuine "not found"), or decode error — returns
+// (nil, false): a resume whose manifest isn't there yet just proceeds to
+// upload normally, exactly like every other fail-open check in this
+// package.
+func fetchPublishedManifest(ctx context.Context, provider providers.BackupProvider, prefix string) (*Snapshot, bool) {
+	if ctx != nil {
+		if err := ctx.Err(); err != nil {
+			return nil, false
+		}
+	}
+	manifestKey := path.Join(prefix, snapshotManifestKey)
+	tempFile, err := os.CreateTemp("", "resume-manifest-*.json")
+	if err != nil {
+		return nil, false
+	}
+	tempPath := tempFile.Name()
+	_ = tempFile.Close()
+	defer os.Remove(tempPath)
+
+	if err := provider.Download(manifestKey, tempPath); err != nil {
+		return nil, false
+	}
+	data, err := os.ReadFile(tempPath)
+	if err != nil {
+		return nil, false
+	}
+	var snapshot Snapshot
+	if err := json.Unmarshal(data, &snapshot); err != nil {
+		return nil, false
+	}
+	return &snapshot, true
+}
+```
+
+In `createSnapshotWithProgress`, immediately after `prefix := path.Join(snapshotRootDir, snapshot.ID)` (currently line 388, right before `var errs []error`):
+```go
+	prefix := path.Join(snapshotRootDir, snapshot.ID)
+
+	// Resume-with-already-published-manifest (D18 §3.5): a prior attempt
+	// may have published manifest.json and then crashed before
+	// journal.Complete() removed the journal (or before Abandon even ran).
+	// Re-uploading now would overwrite a COMPLETED, restorable manifest —
+	// treat its presence as the definitive "this run already finished"
+	// signal and return it as-is, uploading nothing.
+	if journal != nil && journal.resumed {
+		if existing, ok := fetchPublishedManifest(ctx, provider, prefix); ok {
+			log.Info("resume: manifest already published, skipping upload",
+				"snapshotId", existing.ID,
+				"files", len(existing.Files),
+			)
+			if err := journal.Complete(); err != nil {
+				log.Warn("failed to remove completed checkpoint journal", "error", err.Error())
+			}
+			completed = true
+			return existing, nil
+		}
+	}
+
+	var errs []error
+```
+
+- [ ] Step 4: Run, expect PASS:
+```
+cd agent && go test ./internal/backup/ -run TestCreateSnapshot_ResumeWithAlreadyPublishedManifest_SkipsUpload -v
+```
+
+- [ ] Step 5: Commit:
+```
+git add agent/internal/backup/snapshot.go agent/internal/backup/snapshot_test.go
+git commit -m "feat(agent/backup): skip re-upload when resume finds an already-published manifest"
+```
+
+### Task 7: `upload.lease` heartbeat — write during upload, delete after publish
+
+**Files:**
+- Modify `agent/internal/backup/snapshot.go` (`createSnapshotWithProgress`, alongside the existing progress-keepalive goroutine at `:433-452`, and at the two successful-publish points: normal completion `:782-796` and `abortSourceGone`'s partial-publish branch `:547-566`)
+- Test: `agent/internal/backup/snapshot_test.go` (new tests)
+
+**Interfaces:**
+- Produces (unexported): `refreshUploadLease(ctx context.Context, provider providers.BackupProvider, leaseKey string)`
+
+- [ ] Step 1: Write the failing test (use a short interval via a test seam, and a small local fake that sleeps on the FIRST file upload so the lease ticker has time to fire — `blockAfterNProvider` (`snapshot_test.go:743-778`) blocks until `ctx.Done()` rather than for a fixed duration, so it doesn't fit this test; a purpose-built fake is simpler than adapting it):
+```go
+// setUploadLeaseIntervalForTest overrides uploadLeaseInterval so tests don't
+// wait 15 real minutes. Mirrors setJournalMaxAgeForTest's pattern.
+// uploadLeaseInterval must be a `var` (Task 4/7 make it one, not `const`)
+// for this seam to compile.
+func setUploadLeaseIntervalForTest(d time.Duration) (restore func()) {
+	old := uploadLeaseInterval
+	uploadLeaseInterval = d
+	return func() { uploadLeaseInterval = old }
+}
+
+// slowFirstUploadProvider wraps mockProvider and sleeps for `delay` on the
+// FIRST call to Upload/UploadContext only (the real file, not the
+// upload.lease refreshes or the final manifest), so a test can force the
+// upload loop to sit still long enough for the lease-refresh ticker to fire
+// at least once without depending on real wall-clock file I/O.
+type slowFirstUploadProvider struct {
+	*mockProvider
+	delay    time.Duration
+	slowOnce sync.Once
+}
+
+func (p *slowFirstUploadProvider) Upload(localPath, remotePath string) error {
+	p.slowOnce.Do(func() { time.Sleep(p.delay) })
+	return p.mockProvider.Upload(localPath, remotePath)
+}
+
+func (p *slowFirstUploadProvider) UploadContext(ctx context.Context, localPath, remotePath string) error {
+	p.slowOnce.Do(func() { time.Sleep(p.delay) })
+	return p.mockProvider.Upload(localPath, remotePath)
+}
+
+func TestCreateSnapshot_UploadLease_RefreshedDuringUploadThenDeletedAfterPublish(t *testing.T) {
+	restore := setUploadLeaseIntervalForTest(10 * time.Millisecond)
+	defer restore()
+
+	tmpDir := t.TempDir()
+	file1 := createTempFile(t, tmpDir, "file1.txt", "content")
+	backing := newMockProvider()
+	provider := &slowFirstUploadProvider{mockProvider: backing, delay: 50 * time.Millisecond}
+
+	files := []backupFile{{sourcePath: file1, snapshotPath: "path_0/file1.txt", size: 7, modTime: time.Now()}}
+	snap, err := createSnapshotWithProgress(context.Background(), provider, files, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	leaseKey := "snapshots/" + snap.ID + "/upload.lease"
+	sawLeaseUpload := false
+	for _, call := range backing.uploadCalls {
+		if call.remotePath == leaseKey {
+			sawLeaseUpload = true
+		}
+	}
+	if !sawLeaseUpload {
+		t.Error("expected at least one upload.lease refresh during a slow upload")
+	}
+	if _, stillThere := backing.files[leaseKey]; stillThere {
+		t.Error("expected upload.lease to be deleted after a successful publish")
+	}
+	sawLeaseDelete := false
+	for _, key := range backing.deleteCalls {
+		if key == leaseKey {
+			sawLeaseDelete = true
+		}
+	}
+	if !sawLeaseDelete {
+		t.Error("expected exactly one Delete call for upload.lease after publish")
+	}
+}
+```
+
+- [ ] Step 2: Run it, expect FAIL (`sawLeaseUpload` false — no such object is ever written today):
+```
+cd agent && go test ./internal/backup/ -run TestCreateSnapshot_UploadLease -v
+```
+
+- [ ] Step 3: Implement.
+
+Change `uploadLeaseInterval` from `const` to a test-seamable `var` in `snapshot.go` (it must stay a variable, matching `journalMaxAge`'s pattern, so tests can shrink it):
+```go
+// uploadLeaseInterval is how often createSnapshotWithProgress refreshes
+// snapshots/<id>/upload.lease while uploading (D18 §3.4) ... [same doc as Task 4]
+var uploadLeaseInterval = 15 * time.Minute
+```
+(Move it out of the `const (...)` block introduced in Task 4 — `publishMargin` stays a `const`, `uploadLeaseInterval` becomes a package-level `var`.)
+
+Add the refresh helper near `publishSnapshotManifest`:
+```go
+// refreshUploadLease best-effort writes the current UTC time (RFC3339) to
+// leaseKey. Failure is logged, never fatal — see the upload.lease doc
+// comment in createSnapshotWithProgress.
+func refreshUploadLease(ctx context.Context, provider providers.BackupProvider, leaseKey string) {
+	tempFile, err := os.CreateTemp("", "upload-lease-*.txt")
+	if err != nil {
+		log.Warn("failed to create upload lease temp file", "error", err.Error())
+		return
+	}
+	tempPath := tempFile.Name()
+	if _, err := tempFile.WriteString(time.Now().UTC().Format(time.RFC3339)); err != nil {
+		_ = tempFile.Close()
+		os.Remove(tempPath)
+		log.Warn("failed to write upload lease content", "error", err.Error())
+		return
+	}
+	_ = tempFile.Close()
+	defer os.Remove(tempPath)
+	if err := uploadSnapshotFile(ctx, provider, tempPath, leaseKey); err != nil {
+		log.Warn("failed to refresh upload lease", "key", leaseKey, "error", err.Error())
+	}
+}
+```
+
+In `createSnapshotWithProgress`, right after the existing progress-keepalive goroutine block (`:433-452`, the `if onProgress != nil { ... }` block), add a second, unconditional (runs regardless of `onProgress`) goroutine:
+```go
+	// upload.lease heartbeat (D18 §3.4): refresh a tiny marker object every
+	// uploadLeaseInterval while uploading, so GC's manifest-less-prefix
+	// window keeps extending for a legitimately slow multi-day single-file
+	// upload. Stopped on completion (stopLeaseRefresh, called exactly once
+	// via leaseStopOnce) or ctx cancellation. Skipped entirely by the
+	// resume-already-published shortcut above, since that path returns
+	// before this point.
+	leaseKey := path.Join(prefix, "upload.lease")
+	leaseStop := make(chan struct{})
+	leaseDone := make(chan struct{})
+	var leaseStopOnce sync.Once
+	stopLeaseRefresh := func() {
+		leaseStopOnce.Do(func() {
+			close(leaseStop)
+			<-leaseDone
+		})
+	}
+	go func() {
+		defer close(leaseDone)
+		ticker := time.NewTicker(uploadLeaseInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-leaseStop:
+				return
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				refreshUploadLease(ctx, provider, leaseKey)
+			}
+		}
+	}()
+	defer stopLeaseRefresh()
+```
+
+At the normal-completion success path (immediately after the existing `if journal != nil { journal.Complete(); completed = true }` block, before `return snapshot, nil`):
+```go
+	stopLeaseRefresh()
+	if delErr := provider.Delete(leaseKey); delErr != nil {
+		log.Warn("failed to remove upload.lease after publish", "key", leaseKey, "error", delErr.Error())
+	}
+
+	return snapshot, nil
+```
+
+At `abortSourceGone`'s successful partial-publish path (after the `log.Warn("published a PARTIAL manifest...")` line, before `return snapshot, detail`):
+```go
+		stopLeaseRefresh()
+		if delErr := provider.Delete(leaseKey); delErr != nil {
+			log.Warn("failed to remove upload.lease after partial publish", "key", leaseKey, "error", delErr.Error())
+		}
+		return snapshot, detail
+```
+(`stopLeaseRefresh`/`leaseKey` are closures/locals of `createSnapshotWithProgress`, already in scope inside the `abortSourceGone` closure defined in the same function body.)
+
+- [ ] Step 4: Run, expect PASS:
+```
+cd agent && go test ./internal/backup/ -run TestCreateSnapshot_UploadLease -v -race
+```
+
+- [ ] Step 5: Commit:
+```
+git add agent/internal/backup/snapshot.go agent/internal/backup/snapshot_test.go
+git commit -m "feat(agent/backup): refresh an upload.lease heartbeat during upload, delete after publish"
+```
+
+### Task 8: API-side contract test for the new payload fields and constants
+
+**Files:**
+- Modify `apps/api/src/services/backupAgentContract.test.ts`
+
+**Interfaces:**
+- Consumes (source-text grep only, no import): Go field tags `baseSnapshotId`/`publishLeaseExpiresAt` in `exec_backup.go`; Go `publishMargin`/`uploadLeaseInterval` in `snapshot.go`; whatever W01 names the equivalent TS constants (grepped, not imported, so this file compiles today even though those TS names don't exist yet).
+
+- [ ] Step 1: Write the failing test — append to `backupAgentContract.test.ts`:
+```ts
+describe('backup Go<->TS contract — D18 server-owned base payload fields', () => {
+  it('agent exec_backup.go still decodes baseSnapshotId and publishLeaseExpiresAt from the backup_run payload', () => {
+    const src = readRepoFile('agent/cmd/breeze-backup/exec_backup.go');
+    expect(src).toMatch(/BaseSnapshotID\s*\*string\s*`json:"baseSnapshotId"`/);
+    expect(src).toMatch(/PublishLeaseExpiresAt\s*string\s*`json:"publishLeaseExpiresAt"`/);
+  });
+
+  // Gated on W01 having landed: apps/api/src/jobs/backupWorker.ts does not
+  // send these fields yet (confirmed 2026-09-09, no baseSnapshotId/
+  // publishLeaseExpiresAt in that file). Once W01 adds them, this
+  // assertion activates automatically — it is not skipped by name, it is
+  // skipped by content, so no follow-up edit is needed here when W01 lands.
+  const workerSrc = readRepoFile('apps/api/src/jobs/backupWorker.ts');
+  const workerHasBaseFields = /baseSnapshotId/.test(workerSrc);
+
+  it.skipIf(!workerHasBaseFields)(
+    'backupWorker.ts dispatch payload uses the exact field names baseSnapshotId/publishLeaseExpiresAt (matches the Go json tags)',
+    () => {
+      expect(workerSrc).toMatch(/baseSnapshotId/);
+      expect(workerSrc).toMatch(/publishLeaseExpiresAt/);
+    },
+  );
+
+  it('agent publishMargin is 1 hour and stays strictly under the manifest-less GC window', () => {
+    const src = readRepoFile('agent/internal/backup/snapshot.go');
+    expect(src).toMatch(/publishMargin\s*=\s*1\s*\*\s*time\.Hour/);
+  });
+
+  it('agent uploadLeaseInterval (15 min) stays well under the 9-day manifest-less GC window', () => {
+    const src = readRepoFile('agent/internal/backup/snapshot.go');
+    expect(src).toMatch(/uploadLeaseInterval\s*=\s*15\s*\*\s*time\.Minute/);
+    // 15 minutes must be at least an order of magnitude under the 9-day
+    // window (journalMaxAge 7d + 48h grace) so a slow upload has many
+    // refresh opportunities before the prefix could be swept.
+    const FIFTEEN_MIN_MS = 15 * 60 * 1000;
+    const NINE_DAYS_MS = 9 * 24 * 60 * 60 * 1000;
+    expect(FIFTEEN_MIN_MS).toBeLessThan(NINE_DAYS_MS / 100);
+  });
+});
+```
+
+- [ ] Step 2: Run it, expect FAIL with the `BaseSnapshotID`/`publishMargin`/`uploadLeaseInterval` regexes not matching (none exist until Tasks 1 and 4 land):
+```
+cd apps/api && npx vitest run src/services/backupAgentContract.test.ts
+```
+(Run this AFTER Tasks 1-7 are implemented, or expect it red until then — this task's steps assume it runs last in the sequence, per the Wave ordering below.)
+
+- [ ] Step 3: Implement — no production code change; this task IS the test (Step 1's content), confirmed to pass once Tasks 1-7 land.
+
+- [ ] Step 4: Run, expect PASS:
+```
+cd apps/api && npx vitest run src/services/backupAgentContract.test.ts
+```
+
+- [ ] Step 5: Commit:
+```
+git add apps/api/src/services/backupAgentContract.test.ts
+git commit -m "test(api): pin the D18 server-owned-base payload field names and lease/GC-window constants"
+```
+
+## Task 9 (doc-only, no code): Confirm the helper-version reporting path
+
+Not a code task — recorded here because the plan brief requires verifying it, and the finding is doc-only (see Open Questions).
+
+`devices.backup_version` is populated from `breeze-backup --version`'s stdout (`agent/internal/heartbeat/backup_version.go:13-120`), which prints `main.version` (`agent/cmd/breeze-backup/main.go:36`), a build-time value injected via `-ldflags "-X main.version=$(VERSION)"` (`agent/Makefile:2-8`; release builds go through `agent/scripts/build-edition.sh` per the Makefile's own comment at `:4-6`). **No code in this wave sets or changes that value** — it is set by whatever release tag builds the binary that ships W03's changes. There is nothing to implement here; the release process must simply ensure the binary that carries this wave's changes is built with `VERSION` set to that release's number, so that W02's future capability gate (a `BACKUP_SERVER_BASE_MIN_HELPER_VERSION`-style constant, not yet added) can compare against it correctly. Flagged in Open Questions.
+
+## Task 10: Wave verification
+
+**Files:** none (verification only)
+
+- [ ] Run the full agent backup package + breeze-backup command suite with race detection:
+```
+cd agent && go build ./... && go vet ./... && go test -race ./internal/backup/... ./cmd/breeze-backup/...
+```
+- [ ] Run the one API-side contract test file:
+```
+cd apps/api && npx vitest run src/services/backupAgentContract.test.ts
+```
+- [ ] Confirm no other agent package references the two REMOVED functions (`cleanupSnapshotPrefix`/`listSnapshotPrefixItems` are intentionally kept — spec §3.5 exception — so they must NOT appear in this grep's target list):
+```
+grep -rn "DeleteSnapshot(\|DeleteSnapshotContext(" agent/ apps/helper/
+```
+Expect zero results (aside from any remaining doc-comment prose, which should also have been updated by Task 5). Separately confirm the two kept call sites still exist exactly twice:
+```
+grep -rn "cleanupSnapshotPrefix(" agent/internal/backup/snapshot.go
+```
+Expect exactly the function definition plus its two call sites in `abortStopped`/`abortSourceGone` (three matches total).
+- [ ] Confirm the full agent test suite still passes (catches any of the ~30 unmodified `createSnapshotWithProgress` call sites breaking from an unrelated typo, though the signature itself is unchanged by design):
+```
+cd agent && go test -race ./...
+```
+- [ ] No DB migration, no Drizzle schema change, no cascade/export-registry change in this wave — `pnpm db:check-drift` is not applicable.
+- [ ] PR body checklist:
+  - [ ] Links the parent D18 tracking issue/feature (if `register_feature` was run for the whole D18 effort — check via `get_feature_status` before opening the PR).
+  - [ ] States this wave is agent-shipped code (full review round per repo convention for agent/GC-adjacent changes) and names the one independent reviewer round performed.
+  - [ ] Notes explicitly: no signature change to `createSnapshotWithProgress`; the lease/journal-age fence is enforced via the `leaseGate` provider wrapper instead, to avoid touching ~30 existing call sites.
+  - [ ] Notes the two kept exceptions: `snapshot.go:499`/`:544` (`abortStopped`/`abortSourceGone`'s own-run-prefix `cleanupSnapshotPrefix` calls) are retained per spec §3.5 and are NOT part of this wave's "never deletes" removal — only `DeleteSnapshotContext`/`DeleteSnapshot` (deletion of OTHER, already-published snapshots) and the retention/stale-journal call sites were removed.
+  - [ ] Notes Task 9's finding as a follow-up for whoever cuts the release that ships this wave (confirm `VERSION` at build time is the release's own version, so `devices.backup_version` reports it correctly for W02's future capability gate).
+
+## Open questions / contradictions
+
+1. **RESOLVED by coordinator decision (2026-09-09):** an earlier draft of this plan flagged `agent/internal/backup/snapshot.go:499`/`:544` (`abortStopped`/`abortSourceGone`'s own-run-prefix `cleanupSnapshotPrefix` calls) as candidates for removal, since the spec text available at the time named only two delete call sites. Spec §3.5 was subsequently updated to state these two are explicit, intentional exceptions ("the helper may delete objects under its own current run prefix before its manifest is published... kept as-is") — they delete only the CURRENT run's own never-yet-referenced prefix, never another snapshot's. Task 5 now keeps both call sites and the `cleanupSnapshotPrefix`/`listSnapshotPrefixItems` functions unchanged, removing only the retention-prune branch, the stale-journal cleanup call, and `DeleteSnapshot`/`DeleteSnapshotContext` (which deleted OTHER, already-published snapshots — the actually dangerous case). No further action needed.
+2. **`publishLeaseExpiresAt` applying to full runs too, with no renewal, means a slow full run can outlive its lease and simply fail to publish**, exactly like a run that outlives `journalMaxAge` already fails to resume. This is explicitly the spec's stated design ("a run longer than the lease already cannot resume... so 'a run must publish within 7d of dispatch' is the existing envelope made explicit" — spec line ~130-135), not an open question about correctness, but it IS a new user-visible failure mode for slow FULL (non-incremental) backups that didn't exist before this wave (previously a full run had no deadline at all beyond the per-file/whole-run reaper timeouts). Confirming this is accepted product behavior, not something W03 should soften, is worth an explicit sign-off since it wasn't true before D18.
+3. **Helper-version gating (spec §3.4's capability gate) is entirely W02's responsibility**, and its minimum-version constant does not exist yet in this worktree (confirmed via grep — only `BACKUP_QUEUE_MIN_HELPER_VERSION` exists today, for an unrelated feature). W03 has no code to write for it; Task 9 records that the mechanism it will eventually gate on (`devices.backup_version` sourced from `breeze-backup --version`, a build-time `-ldflags` value) is orthogonal to this wave's code and depends entirely on the release pipeline stamping the correct version — flagging so whoever cuts that release checks it, since there's no automated test that could catch a wrong `VERSION` at build time.
+4. **`leaseGate`'s `UploadContext` fallback-to-plain-`Upload` when the wrapped provider lacks context support** silently drops `ctx` cancellation for that one call, identical to `uploadSnapshotFile`'s own pre-existing fallback behavior (`snapshot.go:869-880`) — not a regression, just noting the design intentionally mirrors an existing accepted trade-off rather than introducing a new one.

--- a/docs/superpowers/plans/backup/2026-09-09-backup-gc-reclamation-w03-agent.md
+++ b/docs/superpowers/plans/backup/2026-09-09-backup-gc-reclamation-w03-agent.md
@@ -1,3 +1,7 @@
+---
+tracking_issue: LanternOps/breeze#5449
+---
+
 # Wave 03 — Agent/helper: server-owned dedupe base, leases, never delete — Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/plans/backup/2026-09-09-backup-gc-reclamation-w04-lab-verification-and-release.md
+++ b/docs/superpowers/plans/backup/2026-09-09-backup-gc-reclamation-w04-lab-verification-and-release.md
@@ -1,3 +1,7 @@
+---
+tracking_issue: LanternOps/breeze#5449
+---
+
 # D18 Wave 04 — Lab Verification on MinIO, Release Notes, Campaign Doc Close-out
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Tasks 1–3 need the lab (`~/breeze-assurance`, MinIO, the Linux rig) and run from the MAIN session (subagents cannot SSH the rigs).

--- a/docs/superpowers/plans/backup/2026-09-09-backup-gc-reclamation-w04-lab-verification-and-release.md
+++ b/docs/superpowers/plans/backup/2026-09-09-backup-gc-reclamation-w04-lab-verification-and-release.md
@@ -1,0 +1,192 @@
+# D18 Wave 04 — Lab Verification on MinIO, Release Notes, Campaign Doc Close-out
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Tasks 1–3 need the lab (`~/breeze-assurance`, MinIO, the Linux rig) and run from the MAIN session (subagents cannot SSH the rigs).
+
+**Goal:** Prove on real MinIO + a real Linux agent that an expired, unreferenced snapshot is reclaimed while a retained incremental still restores byte-identical, then ship the release-facing text.
+
+**Architecture:** Re-run campaign cells R1/R4 against a stack built from main after W01–W03 merged, with the lab knobs shortened; extend `scripts/backup-assurance/cells-gc.sh` to assert reclamation (object counts drop, retirement row `swept_at` set) and Hyper-V/MSSQL/system-image manifests untouched. Then release notes, docs, campaign ledger.
+
+**Tech Stack:** bash harness (`scripts/backup-assurance/*.sh`), `mc` (MinIO client), psql via the stack's postgres container, Playwright not needed.
+
+**Spec:** docs/superpowers/specs/backup/2026-09-09-backup-gc-reclamation-design.md (§6 "Lab", §8 decisions)
+
+**Depends on:** W01, W02, W03 merged to main; a helper build reporting `backup_version >= 0.112.0` (the W02 gate constant `BACKUP_SERVER_BASE_MIN_HELPER_VERSION`) installed on the Linux rig.
+
+## Global Constraints
+- Lab knobs on the API container: `BACKUP_GC_GRACE_MS=1000`, `BACKUP_GC_ORPHAN_MANIFEST_MAX_AGE_MS=1000`, `BACKUP_BASE_LEASE_MS=60000`, `BACKUP_PUBLISH_MARGIN_MS=1000`, `BACKUP_RESTORE_PIN_LINGER_MS=1000`. Production floors warn but do not apply outside `NODE_ENV=production` — check the stack is not built with production `NODE_ENV`.
+- Never run destructive restores on WIN-B (prod-enrolled); Linux rig only (campaign §9 decision 4).
+- Evidence lands under `~/breeze-assurance/runs/lnx/d18-*.txt` and is cited by filename in the campaign doc.
+
+## 0. Ground truth
+- `scripts/backup-assurance/cells-gc.sh` (94 lines at campaign close): expires rows by id in system scope, triggers `cleanup-expired-snapshots` via the lab Redis/BullMQ helper in `lab.sh`, counts objects per prefix with `mc ls -r lab/breeze-lab/snapshots/<label>/`, then restores the newest retained snapshot and compares hashes with `compare-hashes.sh`. It currently only asserts that referenced objects survive (R1); R4's reclamation assertion was recorded by hand in `runs/lnx/postfix-GC3.txt`.
+- The campaign doc `docs/testing/backup-assurance/2026-09-09-backup-assurance-campaign.md` has R4 = FAIL (D18) at line ~238, D18 OPEN at ~288, and decision 6 at §9.
+- Docs pages that state storage is not reclaimed: `apps/docs/src/content/docs/backup/storage.mdx`, `apps/docs/src/content/docs/backup/monitoring.mdx` (W02 rewrites the retention text; this wave re-reads them after merge and fixes anything W02 missed).
+
+## File structure
+- Modify: `scripts/backup-assurance/cells-gc.sh` — add R4 assertions (reclaimed prefix empty, retirement row swept, unrelated manifests intact).
+- Modify: `docs/testing/backup-assurance/2026-09-09-backup-assurance-campaign.md` — R4 → PASS, D18 → FIXED (PR numbers), §9 decision 6 → resolved.
+- Modify: `apps/docs/src/content/docs/backup/storage.mdx`, `monitoring.mdx` — final wording pass.
+- Modify: release notes source per `update-breeze-release-notes` skill (next version's entry).
+
+### Task 1: Extend `cells-gc.sh` with the reclamation assertions
+
+**Files:**
+- Modify: `scripts/backup-assurance/cells-gc.sh` (append after the existing restore/compare block)
+
+**Interfaces:**
+- Consumes: `lab.sh` helpers (`$L gc-run` or whatever the existing script calls to enqueue `cleanup-expired-snapshots` — read the file; the name is defined there), `$S/mc`, `psql()`.
+- Produces: exit code 0 only when every assertion passes; `runs/lnx/d18-gc.txt` transcript.
+
+- [ ] **Step 1: Write the assertion block (this is the "test")**
+
+```bash
+say "R4: reclaimed prefixes must be empty and retired"
+FAIL=0
+for lbl in $LABELS; do
+  n=$($S/mc ls -r lab/breeze-lab/snapshots/$lbl/ 2>/dev/null | wc -l | tr -d ' ')
+  swept=$(psql "select count(*) from backup_snapshot_retirements where snapshot_id='$lbl' and swept_at is not null")
+  echo "$lbl: $n objects remain, swept_at set: $swept"
+  # Objects a retained manifest still references legitimately survive; everything else must be gone.
+  refd=$(for m in $(psql "select snapshot_id from backup_snapshots where device_id='$DEV'"); do
+           $S/mc cat lab/breeze-lab/snapshots/$m/manifest.json 2>/dev/null | jq -r '.files[].backupPath' | grep "^snapshots/$lbl/" ; done | sort -u | wc -l | tr -d ' ')
+  echo "$lbl: $refd objects still referenced by retained manifests"
+  if [ "$n" -ne "$refd" ]; then echo "FAIL: $lbl has $n objects but only $refd are referenced"; FAIL=1; fi
+  if [ "$refd" -eq 0 ] && [ "$swept" -ne 1 ]; then echo "FAIL: $lbl fully reclaimed but retirement not marked swept"; FAIL=1; fi
+done
+
+say "R4b: unrelated manifests (other devices / modes) untouched"
+for m in $(psql "select snapshot_id from backup_snapshots where device_id<>'$DEV'"); do
+  $S/mc stat lab/breeze-lab/snapshots/$m/manifest.json >/dev/null 2>&1 || { echo "FAIL: retained manifest $m missing"; FAIL=1; }
+done
+
+say "R4c: bucket total dropped"
+TOTAL_AFTER=$($S/mc ls -r lab/breeze-lab/snapshots/ 2>/dev/null | wc -l | tr -d ' ')
+echo "objects in bucket: before=$TOTAL_BEFORE after=$TOTAL_AFTER"
+[ "$TOTAL_AFTER" -lt "$TOTAL_BEFORE" ] || { echo "FAIL: nothing reclaimed"; FAIL=1; }
+exit $FAIL
+```
+
+- [ ] **Step 2: Run against the pre-fix stack (control) — expect FAIL**
+
+Run (main session, lab up on a main build that predates W02):
+```bash
+LAB_SCRATCH=~/breeze-assurance/scratch scripts/backup-assurance/cells-gc.sh <expired-row-id> | tee ~/breeze-assurance/runs/lnx/d18-gc-control.txt
+```
+Expected: `FAIL: nothing reclaimed` (the control proves the assertion discriminates).
+
+- [ ] **Step 3: Rebuild the lab stack from main with W01–W03 merged, install the new helper on the Linux rig**
+
+```bash
+# from the worktree used for the lab (see docs/testing/backup-assurance/... §3 for the exact compose project)
+git fetch origin main && git checkout origin/main
+pnpm wt-stack up   # then set the Global Constraints env on the api service and restart it
+# Linux rig: control+rc install recipe in memory file lab_rigs_windows_ubuntu_ssh_2026_09.md
+```
+Verify: `psql "select backup_version from devices where id='$DEV'"` prints a version >= 0.112.0.
+
+- [ ] **Step 4: Produce the chain, expire the base, run the cell — expect PASS**
+
+```bash
+# run 1 (full), delete crlf.txt from the corpus, run 2 (incremental), run 3 (incremental) — cells-lnx-i2-c1.sh does this
+scripts/backup-assurance/cells-lnx-i2-c1.sh | tee ~/breeze-assurance/runs/lnx/d18-chain.txt
+BASE=$(psql "select id from backup_snapshots where device_id='$DEV' order by timestamp asc limit 1")
+LAB_SCRATCH=~/breeze-assurance/scratch scripts/backup-assurance/cells-gc.sh $BASE | tee ~/breeze-assurance/runs/lnx/d18-gc.txt
+```
+Expected: exit 0; the base prefix keeps exactly the objects run 2/3 reference and `crlf.txt.gz` is gone; the newest snapshot restores 10,04x/10,04x byte-identical (`compare-hashes.sh` output in the transcript).
+
+- [ ] **Step 5: Commit the harness change**
+
+```bash
+git add scripts/backup-assurance/cells-gc.sh
+git commit -m "test(backup-assurance): assert reclamation and retirement in cells-gc.sh (D18 R4)"
+```
+
+### Task 2: Pin and lease cells (in-flight base survives; expired lease refuses to publish)
+
+**Files:**
+- Create: `scripts/backup-assurance/cells-gc-pins.sh`
+
+- [ ] **Step 1: Write the cell**
+
+```bash
+#!/usr/bin/env bash
+# D18 pins: (a) a running job's base is not retired; (b) a job past its lease cannot publish.
+set -uo pipefail
+cd "$(dirname "$0")/../.."
+source scripts/backup-assurance/lab.sh   # psql(), say(), enqueue helpers
+DEV=$(jq -r .devLnx "$LAB_STATE")
+BASE=$(psql "select id from backup_snapshots where device_id='$DEV' order by timestamp desc limit 1")
+BASE_LBL=$(psql "select snapshot_id from backup_snapshots where id='$BASE'")
+
+say "(a) start a run, confirm the pin, expire the base, run retention: row must survive"
+JOB=$(curl -sf -X POST "$LAB_API/backup/jobs" -H "Authorization: Bearer $LAB_TOKEN" -H 'content-type: application/json' \
+      -d "{\"deviceId\":\"$DEV\",\"configId\":\"$(jq -r .configId "$LAB_STATE")\"}" | jq -r .id)
+sleep 5
+psql "select base_snapshot_id, publish_lease_expires_at from backup_jobs where id='$JOB'"
+psql "select set_config('breeze.scope','system',false); update backup_snapshots set expires_at = now() - interval '1 hour' where id='$BASE'"
+lab_run_retention   # helper from lab.sh that enqueues cleanup-expired-snapshots and waits
+psql "select count(*) from backup_snapshots where id='$BASE'"          # expect 1
+psql "select count(*) from backup_snapshot_retirements where snapshot_id='$BASE_LBL'"   # expect 0
+docker logs "$LAB_API_CONTAINER" 2>&1 | grep -c 'skippedPinned' 
+
+say "(b) lease expiry: dispatch with BACKUP_BASE_LEASE_MS=60000, stall the agent >60 s, resume: helper must refuse to publish"
+# stall by SIGSTOP-ing breeze-backup on the rig for 90 s (vmssh helper), then SIGCONT
+$LAB_SCRATCH/vmssh lnx 'sudo pkill -STOP breeze-backup; sleep 90; sudo pkill -CONT breeze-backup'
+sleep 30
+psql "select status, error_log from backup_jobs where id='$JOB'"     # expect failed / publish_lease_expired
+$LAB_SCRATCH/mc stat lab/breeze-lab/snapshots/$(psql "select snapshot_id from backup_jobs where id='$JOB'")/manifest.json && echo "FAIL: manifest published after lease" || echo "OK: no manifest"
+```
+
+- [ ] **Step 2: Run it, capture `runs/lnx/d18-pins.txt`; expected: (a) row survives with `skippedPinned 1`, (b) job `failed` with `publish_lease_expired`, no manifest.**
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/backup-assurance/cells-gc-pins.sh
+git commit -m "test(backup-assurance): D18 pin and lease cells"
+```
+
+### Task 3: Campaign doc close-out
+
+**Files:**
+- Modify: `docs/testing/backup-assurance/2026-09-09-backup-assurance-campaign.md` (R4 row ~:238, D18 row ~:288, §9 item 6, §10 issue table)
+
+- [ ] **Step 1: Edit R4 to PASS with evidence file names, D18 to FIXED with the W01–W03 PR numbers, §9.6 to "resolved: contract C (spec link), decisions §8 of the spec applied as defaults", and add rows for the two new cells (R5 pins, R6 lease).**
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/testing/backup-assurance/2026-09-09-backup-assurance-campaign.md
+git commit -m "docs(backup-assurance): close D18 — R4 PASS on MinIO, pin/lease cells added"
+```
+
+### Task 4: Release notes + docs wording pass
+
+**Files:**
+- Modify: release notes entry for the next version (follow the `update-breeze-release-notes` skill for file location and schema)
+- Modify: `apps/docs/src/content/docs/backup/storage.mdx`, `monitoring.mdx`
+
+- [ ] **Step 1: Release-note paragraph (self-hoster facing)**
+
+```md
+**Backup storage is now reclaimed.** Retention previously deleted only the database record of an expired snapshot; its objects stayed in the bucket forever. Expired snapshots' exclusive objects are now removed by the 6-hourly GC. Two things to know:
+- Reclamation on a destination only activates once every device backing up to it runs the backup helper from this release or newer (older helpers choose their own dedupe base and cannot be pinned). The API logs `reclamation deferred: legacy helper <device>` until then.
+- Deleting a device or organisation now also reclaims its backups after the orphan window (default 9 days). Previously those objects leaked.
+New env knobs (all optional): `BACKUP_BASE_LEASE_MS` (7 d), `BACKUP_PUBLISH_MARGIN_MS` (1 h), `BACKUP_RESTORE_PIN_LINGER_MS` (7 d), `BACKUP_GC_ORPHAN_MANIFEST_MAX_AGE_MS` (9 d). Migrations `2026-10-15-140005` and `-140006` add the pin columns and the `backup_snapshot_retirements` table; the backfill is batched and safe on large tables.
+```
+
+- [ ] **Step 2: Re-read both docs pages after W02 merged; remove any remaining "storage is not reclaimed" sentence; add the legacy-helper deferral and the device-deletion behaviour.**
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/docs/src/content/docs/backup/storage.mdx apps/docs/src/content/docs/backup/monitoring.mdx <release-notes-file>
+git commit -m "docs(backup): storage reclamation contract, knobs, legacy-helper deferral (D18)"
+```
+
+### Task 5: Wave verification
+- [ ] `~/breeze-assurance/runs/lnx/d18-gc-control.txt` shows FAIL; `d18-gc.txt` and `d18-pins.txt` show PASS.
+- [ ] `pnpm --filter @breeze/docs build` (docs site builds).
+- [ ] PR body: link the three evidence files, the spec, and `Closes #5429`; note the two §8 decisions as applied defaults.
+
+## Open questions / contradictions
+- `lab.sh` helper names for enqueueing retention (`lab_run_retention`) are assumed — read `lab.sh` and use the real name.
+- If the helper's `backup_version` on the rig comes from a dev build (`dev` counts as NOT capable per `backupHelperSupportsQueue`), the gate defers reclamation and Task 1 Step 4 cannot pass; build the helper with a real version tag (`0.112.0-lab`? prereleases also count as NOT capable — use `0.112.0`).

--- a/docs/superpowers/specs/backup/2026-09-09-backup-gc-reclamation-design.md
+++ b/docs/superpowers/specs/backup/2026-09-09-backup-gc-reclamation-design.md
@@ -276,13 +276,14 @@ copies it from the adoptable job too). GC groups rows by this column, not by the
 current `providerConfig`, so editing a destination cannot un-root snapshots already written to
 the old bucket.
 
-Historical rows: the migration backfills `storage_identity` from the current config **only
-when the config was not edited after the snapshot** (`backup_configs.updated_at <=
-backup_snapshots.timestamp`); everything else stays NULL. The sweep self-heals a NULL row when
-it finds `snapshots/<id>/manifest.json` in the listing of the config's current identity
-(`UPDATE … SET storage_identity = I`); until every NULL row mapped to an identity has been
-resolved, that identity runs the rooted-prefix rule only (§3.4). Rows with NULL `config_id`
-stay NULL and keep wedging the run as today. No `NOT NULL` constraint.
+Historical rows: **no SQL backfill** — replicating `normalizeStorageIdentity` in PL/pgSQL is
+a fidelity risk with no payoff. The sweep self-heals a NULL row when it finds
+`snapshots/<id>/manifest.json` in the listing of the config's current identity
+(`UPDATE … SET storage_identity = I WHERE id = row.id AND storage_identity IS NULL`), which
+resolves every resolvable row on the first GC run after deploy; until every NULL row mapped to
+an identity has been resolved, that identity runs today's algorithm (§3.4). A row still NULL
+after 30 d is logged (`unresolved storage identity <row>`) for operator attention. Rows with
+NULL `config_id` stay NULL and keep wedging the run as today. No `NOT NULL` constraint.
 
 An identity no config points at any more is never listed and therefore leaks; the sweep logs
 `unreachable identity <I>: <n> rows`. `PATCH /backup/configs/:id` warns (does not block) when
@@ -310,7 +311,7 @@ object is deleted only for a snapshot whose retirement is already durable.
 
 | Migration (slots after newest shipped `2026-10-15-140004`) | Content |
 |---|---|
-| `2026-10-15-140005-backup-jobs-base-pin-and-storage-identity.sql` | `backup_jobs.base_snapshot_id`, `publish_lease_expires_at`, `storage_identity`, partial index; `backup_snapshots.storage_identity` (nullable) + guarded backfill (§3.6, config not edited since snapshot) in SQL replicating `normalizeStorageIdentity`; `SELECT set_config('breeze.scope','system',true)` for the backfill; `GET DIAGNOSTICS` row counts, including how many rows were left NULL |
+| `2026-10-15-140005-backup-jobs-base-pin-and-storage-identity.sql` | `backup_jobs.base_snapshot_id`, `publish_lease_expires_at`, `storage_identity`, partial index; `backup_snapshots.storage_identity` (nullable, no backfill — §3.6 self-heal); DDL only, no `breeze.scope` needed |
 | `2026-10-15-140006-backup-snapshot-retirements.sql` | table + RLS (shape 1, enable+force, four policies) + indexes |
 
 Registries: `tenantExportPolicyRegistry.ts` (`backup_jobs` + 3 cols, `backup_snapshots` + 1

--- a/docs/superpowers/specs/backup/2026-09-09-backup-gc-reclamation-design.md
+++ b/docs/superpowers/specs/backup/2026-09-09-backup-gc-reclamation-design.md
@@ -255,9 +255,12 @@ All knobs are resolved **per run** with the existing production-floor/warn patte
   an unpublished prefix, and a published one is a root. (Codex F5.)
 - On resume, if `snapshots/<id>/manifest.json` already exists the run is treated as already
   published: no re-upload, no overwrite; report the existing manifest as the result.
-- `DeleteSnapshot`/`DeleteSnapshotContext` remain only for the explicit `backup_cleanup`
-  command path if one exists; otherwise removed. The helper's `providers.BackupProvider.Delete`
-  stays for `upload.lease` housekeeping only.
+- `DeleteSnapshot`/`DeleteSnapshotContext` are removed (`backup_cleanup` is local-only).
+  **Sole exceptions**, because they can never touch anything another manifest references: the
+  helper may delete objects under its **own current run prefix before its manifest is
+  published** (the journal-less abort paths at `snapshot.go:499` and `:544`, kept as-is) and
+  its own `upload.lease` after publication. Vault retention operates on the device-local vault
+  directory, not on a GC-managed identity, and is unchanged.
 
 ### 3.6 Snapshots carry their storage identity (Codex F7)
 

--- a/docs/superpowers/specs/backup/2026-09-09-backup-gc-reclamation-design.md
+++ b/docs/superpowers/specs/backup/2026-09-09-backup-gc-reclamation-design.md
@@ -1,0 +1,269 @@
+---
+title: Backup storage reclamation — server-owned dedupe base, pins, and a rows-only GC root set (D18)
+status: draft, pending advisor review
+date: 2026-09-09
+source: docs/testing/backup-assurance/2026-09-09-backup-assurance-campaign.md (D18, R1/R4, §9 decision 6); issue #5429
+author: Claude (Fable), code map by an Explore subagent
+---
+
+# Backup Storage Reclamation (D18) — Design
+
+## 0. Problem, in one paragraph
+
+Retention deletes `backup_snapshots` rows (D17, #5419) but the storage sweep in
+`apps/api/src/jobs/backupRetention.ts` marks **every prefix that still has a
+`manifest.json`** as a live root (`listedManifestSnapshotIds`, ~:805), and nothing ever
+deletes a manifest object. So once a snapshot is published, its manifest, every object it
+lists, and every object it references in older prefixes are immortal. Retention is purely
+logical; bucket usage only grows (campaign cell R4: three expired rows deleted, `0 objects
+deleted`, expired base still holds all 10,048 objects, six manifest-bearing prefixes with no
+row). The protection exists because the **agent** picks its incremental dedupe base by
+listing bucket manifests (`agent/internal/backup/incremental.go:53 previousManifest`), so
+the server cannot know which base an in-flight run depends on and must keep them all.
+
+## 1. Ground truth (verified on main `24c3e2ad81`, 2026-09-09)
+
+- **No pin of any kind exists.** `backup_jobs` has `snapshot_id` (the child) and no base
+  column (`apps/api/src/db/schema/backup.ts:207-278`). `restore_jobs.snapshot_id` is
+  `ON DELETE SET NULL` (`:363`), so retention can delete the row of a snapshot that is being
+  restored right now; the restore survives today only because every listed manifest is a
+  root. "Active restore pins" and "active upload prefixes" in the campaign quorum text do not
+  exist in code — the only in-flight protections are the 48 h object grace
+  (`BACKUP_GC_GRACE_MS`, `:494-524`, resolved once at module load) and the 9-day
+  manifest-less-prefix rule (`BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS` = agent journal
+  max age 7 d + grace, `:537-538`, source-text-contract-tested against the agent in
+  `services/backupAgentContract.test.ts:33,42`).
+- **The manifest already records the base** (`agent/internal/backup/snapshot.go:69
+  baseSnapshotId`, set at `:378-388`), the reconcile parser already models it
+  (`services/backupSnapshotReconcile.ts:240`), and `backup_snapshots.parent_snapshot_id`
+  (self-FK `ON DELETE SET NULL`, `:305`) and `is_incremental` (`:300`) exist — **none of
+  them is ever written**. Persistence is the missing piece, not information.
+- **The dispatch payload** (`jobs/backupWorker.ts:471-490`) is
+  `{jobId, configId, provider, providerConfig, storageEncryption, paths|systemImage|...}` —
+  no base field. Multi-target dispatch creates one `backup_jobs` row per extra target with no
+  parent linkage (`:713-739`).
+- **Two writers of snapshot rows:** `services/backupResultPersistence.ts:1144
+  applyBackupCommandResultToJob` (normal) and `services/backupSnapshotReconcile.ts:592
+  reconcileOrphanedBackupSnapshots` (adopts manifest-bearing prefixes with no row; on-demand
+  route, not scheduled).
+- **There is no agent-local scheduler** (`agent/internal/backup/backup.go:172-174`, #2452);
+  every run is a server `backup_run` command. But the helper falls back to an
+  **agent.yaml-built manager** when the payload lacks `provider`/`providerConfig`
+  (`agent/cmd/breeze-backup/main.go:729-737`, `exec_backup.go:117-119`); that manager carries
+  `Retention = cfg.BackupRetention || 7` and the agent's prefix-wide, reference-blind
+  `DeleteSnapshotContext` (`snapshot.go:977`) is suppressed **only** by
+  `incrementalDedupeActive` (`backup.go:780-806`). That is the real shape of the quorum's
+  "legacy writers" concern.
+- **Abandonment:** `jobs/staleCommandReaper.ts:1343 reapStaleBackupJobs` flips
+  `pending|running` rows after 15 min stall / 24 h absolute / 1 h pending, CAS on status.
+  GC runs 6-hourly (`scheduleRegistry.ts:151`, `27 2,8,14,20 * * *`).
+- **Root-set filter today** is `backupType = 'file' OR NULL` (`backupRetention.ts:1066-1074`)
+  on the claim that other modes never share `snapshots/`. That claim is **wrong for every
+  mode** — system_image, Hyper-V and MSSQL all publish `snapshots/<id>/manifest.json` (§3.4).
+- **A NULL `config_id` row wedges the whole GC run** (`:985-1017`); `backup_configs` is read
+  unfiltered (`:990-996`); `providerConfig.prefix` is ignored by both agent and API
+  (`backupSnapshotStorage.ts:136-161`) so keys are always `snapshots/<id>/...`.
+- **Tests that lock in the behaviour being removed:** `backupRetention.test.ts:665` ("keeps
+  a listed manifest's exclusive objects live even though no row retains it") and `:699-752`
+  ("marks every listed manifest, not just the newest (FIX 5)"). Both were data-loss review
+  fixes; §3 states what replaces their guarantee.
+- **No GC integration test exists**; MinIO is dev-compose only. The sweep already supports
+  the `local` provider, which is enough for a real-DB + real-filesystem proof in CI.
+
+## 2. Goals / non-goals
+
+**Goals**
+1. An expired snapshot's exclusive objects (and its manifest) are reclaimed, bounded in time.
+2. Every retained snapshot restores completely at all times: no object referenced by a
+   retained manifest is ever deleted, and no snapshot under active restore loses its row or
+   objects.
+3. An in-flight backup never ends up with dangling references, whatever base it used.
+4. The server, not the agent, decides the dedupe base; the agent never lists the bucket to
+   choose one and never deletes anything.
+5. Behaviour is provable against a real database and real object storage in CI.
+
+**Non-goals**
+- Prompt (sub-day) reclamation of *young* snapshots pruned by `maxVersions`. Bounded by the
+  unrooted-manifest window (§3.3). A tombstone object could shorten it; deferred (§7).
+- Changing the object key layout, `providerConfig.prefix` handling, or object-lock semantics.
+- MSSQL/Hyper-V chain retention semantics (#5421) beyond keeping their objects safe.
+
+## 3. Contract
+
+Roots and reachability are computed per storage identity, as today. Three changes.
+
+### 3.1 The server chooses the dedupe base and pins it
+
+- **New column** `backup_jobs.base_snapshot_id varchar(255) NULL` — the storage snapshot id
+  (same domain as `backup_jobs.snapshot_id` / `backup_snapshots.snapshot_id`), deliberately
+  **not** a FK: a pin must never be silently nulled by a cascade, and the reaper, not the DB,
+  releases it. Indexed partially `WHERE base_snapshot_id IS NOT NULL`.
+- **Selection** (in `prepareBackupDispatchTargets`, per dispatched file/system_image target,
+  including multi-target child rows): newest `backup_snapshots` row for
+  `(device_id, config_id)` with `backup_type IN ('file','system_image')` (or NULL) and the
+  same mode as the target, `expires_at IS NULL OR expires_at > now()`, whose owning job
+  `status = 'completed'`. Ties → newest `timestamp`. No candidate → no base (full run).
+- **Pin semantics:** a `backup_jobs` row with `status IN ('pending','running')` and a
+  non-null `base_snapshot_id` pins that snapshot. Retention (§3.2) refuses to delete a
+  pinned row. The pin is released by the job reaching any terminal status (result applied,
+  cancelled, or reaped by `reapStaleBackupJobs`). Worst-case hold by a dead job = 24 h
+  absolute timeout + reaper cadence; the column is never cleared, only made inert.
+- **Payload:** `backup_run` gains `baseSnapshotId: string` (empty string = "server chose no
+  base; run full"). Presence of the field, not its value, is the protocol switch.
+- **Agent** (`backup.go:683-691`): if the payload carries `baseSnapshotId`, the agent is in
+  *server-owned base* mode: non-empty → download `snapshots/<id>/manifest.json`, require
+  `backupIdentity == runBackupIdentity()` (same D6 guard as today; mismatch → log + full
+  run), use it as `prevSnapshot`; empty → full run. Payload without the field (older server)
+  → legacy `previousManifest` listing, unchanged. Log the decision in both modes.
+- **Agent never deletes:** remove the `Retention > 0 && !incrementalDedupeActive` prune
+  branch (`backup.go:780-806`) and stop honouring `BackupConfig.Retention` for deletion
+  anywhere in the run path. The agent.yaml manager fallback keeps working for uploads but can
+  no longer reclaim anything. Closes the "legacy writer" hole from the quorum.
+- **Publication:** `applyBackupCommandResultToJob` persists `parent_snapshot_id` (uuid of the
+  row whose `snapshot_id = result.snapshot.baseSnapshotId`, same config; NULL if absent) and
+  `is_incremental = referencedFiles > 0 || formatVersion >= 2`. Reconcile adoption does the
+  same from the manifest's `baseSnapshotId`. Informational only — reachability is by
+  `backupPath`, not by parent links — but it makes the chain visible and testable.
+
+### 3.2 Retention refuses to delete pinned rows
+
+`cleanupExpiredSnapshots` (both the `expiresAt` pass and the `maxVersions` pass) excludes a
+row when either holds:
+- `EXISTS backup_jobs WHERE base_snapshot_id = row.snapshot_id AND status IN
+  ('pending','running')` (backup pin), or
+- `EXISTS restore_jobs WHERE snapshot_id = row.id AND status IN ('pending','running')`
+  (restore pin), or
+- `EXISTS recovery_tokens WHERE snapshot_id = row.id AND expires_at > now() AND
+  session_status <> 'completed'` (bare-metal recovery pin — a BMR session downloads the
+  manifest and every object over minutes to hours; verify the exact status/expiry columns
+  in `schema` before implementing).
+
+Skipped rows are counted (`skippedPinned`) and retried next run. Because the row survives,
+its manifest and everything it references stay in the root set (§3.3) — the pin is enforced
+once, upstream, instead of being re-derived inside the sweep. The `deleteSnapshotRow`
+docstring is rewritten to state this contract.
+
+`restore_jobs` that never finish do not pin forever: `staleCommandReaper.ts:220-239` already
+flips `pending|running` restores to `failed` when their `device_commands` row is reaped.
+Recovery tokens are bounded by their own `expires_at`.
+
+### 3.3 GC roots = retained rows + young unrooted manifests; old unrooted prefixes are garbage
+
+`sweepStorageIdentity` mark set becomes:
+
+```
+roots = { snapshot_id of EVERY backup_snapshots row on this identity }        (all types, §3.4)
+      ∪ { listed manifest-bearing prefixes with no row whose manifest.json
+          lastModified is newer than BACKUP_GC_UNROOTED_MANIFEST_MAX_AGE_MS }
+live  = ⋃ over roots of { manifest key } ∪ { files[].backupPath }
+```
+
+Sweep rules per listed prefix group:
+- **Rooted prefix** (in `roots`): unchanged — delete only objects not in `live` and older
+  than `BACKUP_GC_GRACE_MS`.
+- **Unrooted, manifest-bearing, manifest older than the window:** delete every object in
+  the prefix that is not in `live` (objects a retained child still references stay), the
+  manifest **last** within the prefix so a cap-truncated sweep leaves a still-legible prefix.
+- **Manifest-less prefix:** unchanged 9-day rule (in-progress upload protection, coupled to
+  the agent journal age).
+
+`BACKUP_GC_UNROOTED_MANIFEST_MAX_AGE_MS` defaults to `BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS`
+(9 d), env-overridable with the same production floor/warn pattern as `BACKUP_GC_GRACE_MS`,
+and resolved **per run** (not at module load) so the lab and the integration test can set it.
+
+Why this replaces the FIX 5 guarantee without a tombstone:
+- A base chosen by the server is pinned → its row survives → it is a root. The "listed
+  manifest with no row" case that FIX 5 protected can now only be (i) an expired snapshot
+  (reclaim it — that is the point), (ii) a run that published but whose result the server
+  never applied (reaped; adoptable via reconcile for 9 days, then garbage), or (iii) a base
+  chosen by a **legacy helper** that still lists the bucket. For (iii) the newest
+  identity-matching manifest is, by construction of retention, the newest retained
+  snapshot except in degenerate configs (`maxVersions`=0-ish); residual risk accepted and
+  documented, removed when the legacy listing path is dropped one release later.
+- Reclamation lag for an expired snapshot is one GC cycle when it is older than the window
+  (the normal case — retention periods are days to years), and at most the window for a
+  young `maxVersions` prune.
+
+### 3.4 Every row is a root, whatever its `backup_type`
+
+Verified (subagent, file:line in §8): **all four modes write `snapshots/<id>/manifest.json`
+with a `files[].backupPath` manifest** the GC parser already accepts — file
+(`snapshot.go:390,819`), system_image (same manager; state artifacts additionally under
+`snapshots/<id>/system-state/`), hyperv (`agent/cmd/breeze-backup/exec_hyperv.go:240,421`),
+mssql (`exec_hyperv.go:78-81,532`, literally a `backup.Snapshot`). The retention comment at
+`backupRetention.ts:1057-1065` is wrong; those rows are protected today only by the
+every-listed-manifest rule that this design removes. Therefore:
+
+- `retainedSnapshotIds` = **every** `backup_snapshots` row whose `config_id` is on the
+  identity, no `backup_type` filter. Dropping the filter is a hard prerequisite of §3.3 —
+  with it, every Hyper-V/MSSQL/system-image snapshot older than the window would be swept.
+- Manifest fetch/parse failure for any root aborts the identity, uniformly (fail-closed, as
+  today). Hyper-V's manifest is a distinct Go type but structurally `files[].backupPath`.
+- Non-file modes never reference other prefixes (no dedupe), so their reachability is
+  self-contained; chains (`backup_chains`) are one pointer row per database, and each
+  differential/log run is its own `backup_snapshots` row, so chain members are roots by
+  the same rule. Chain-consistency of *retention* (expiring a full while its diffs live)
+  is #5421, not this spec.
+- Vault replication (`local_vaults`, agent `vault_path`) is a device-local directory, not a
+  `backup_configs` identity; GC never lists it. Unaffected.
+
+## 4. Data model & registries
+
+- Migration `apps/api/migrations/2026-10-15-140005-backup-jobs-base-snapshot-pin.sql`
+  (newest shipped is `2026-10-15-140004-…`; the date ceiling is ahead of real time, so a
+  today-dated file would replay first): `ALTER TABLE backup_jobs ADD COLUMN IF NOT EXISTS
+  base_snapshot_id varchar(255)`, partial index `WHERE base_snapshot_id IS NOT NULL`. DDL
+  only, no `breeze.scope` needed.
+- `services/tenantExportPolicyRegistry.ts:119` `backup_jobs` → add `base_snapshot_id` to
+  `included` (tenant identifier, not secret). No new table → no cascade-list change.
+- Drizzle schema + `pnpm db:check-drift`.
+
+## 5. Failure modes considered
+
+| Scenario | Outcome under this contract |
+|---|---|
+| Run in flight, base row expires | Row pinned → skipped by retention → still a root. |
+| Run reaped (stall/24 h) after publishing manifest, result lost | Pin released; child is an unrooted young manifest → root for 9 d (reconcile can adopt); after that its exclusive objects are garbage; objects a later retained child references stay live. |
+| Restore in flight, snapshot expires | Restore pin → row kept → root. |
+| Legacy helper lists bucket for base | Picks newest identity-matching manifest = newest retained row in practice; documented residual risk. |
+| Agent.yaml manager fallback | Uploads fine; can no longer delete (prune branch removed). |
+| Base manifest 404 at agent | Full run (logged). Server pin harmless. |
+| Object-lock refuses manifest delete | `failedKeys` logged as today; prefix retried each run. |
+| Cap hit mid-prefix | Manifest deleted last; partial prefix is either still manifest-bearing (retried) or manifest-less-old (retried). |
+| NULL `config_id` row | Still wedges the run (unchanged, fail-closed). |
+| Multi-target job | Each dispatched child row carries its own pin. |
+
+## 6. Verification
+
+- **Unit** (`backupRetention.test.ts`): replace `:665` and `:699-752` with (a) "unrooted
+  manifest older than window → prefix swept, manifest last, live-referenced objects kept",
+  (b) "unrooted manifest younger than window → root", (c) "pinned row skipped by both
+  retention passes", (d) "restore-pinned row skipped", (e) hyperv/mssql/system_image rows are roots and their
+  manifests parse, (f) window knob resolution per run. Worker/dispatch tests for base selection
+  and payload field; persistence tests for `parent_snapshot_id`/`is_incremental`; reaper test
+  that a reaped job releases the pin.
+- **Integration (real DB + `local` provider, CI shard):** seed identity with base B and
+  incremental child C referencing B's objects plus B-exclusive object X; expire B; run
+  retention + sweep with window=0 → X and B's manifest gone, C's manifest and every
+  `backupPath` it lists present, B's row gone, C's row intact. Second case: pin B via a
+  running job → nothing reclaimed. Third: restore pin.
+- **Agent** (`incremental_test.go`): server-owned mode with valid base, identity mismatch,
+  empty base, 404; legacy mode unchanged; prune branch gone (`snapshot_lifecycle_test.go`).
+  `backupAgentContract.test.ts` extended for the payload field name.
+- **Lab (manual, campaign harness, MinIO):** repeat cell R4 with
+  `BACKUP_GC_UNROOTED_MANIFEST_MAX_AGE_MS=1000` — expired base reclaimed, retained
+  incremental restores byte-identical (cell F2 hashes).
+
+## 7. Deferred / follow-ups
+
+- Tombstone object (`snapshots/<id>/expired.json`) for prompt reclamation of young prunes.
+- Drop the agent's legacy bucket-listing base path one release after this ships.
+- Helper capability gate (`backupHelperCapabilities.ts`) is **not** needed: unknown payload
+  fields are ignored by old helpers.
+- D15 (`system-state/` prefix) must extend `markLiveBackupObjects` — already in its plan.
+- Storage accounting UI ("reclaimed bytes") — out of scope.
+
+## 8. Verification log
+
+- [x] Hyper-V / MSSQL layout confirmed 2026-09-09 (Explore subagent): system_image `bmr.go:222`/`snapshot.go:819`; hyperv `exec_hyperv.go:240,421-422,437`; mssql `exec_hyperv.go:78-81,514,532-533`; `backupType` stamping `backupResultPersistence.ts:1127-1133`; vault `vault.go:77-78` + `routes/backup/vault.ts:92` (`local_vaults`).
+- [ ] Codex `xhigh` read-only review of this spec.

--- a/docs/superpowers/specs/backup/2026-09-09-backup-gc-reclamation-design.md
+++ b/docs/superpowers/specs/backup/2026-09-09-backup-gc-reclamation-design.md
@@ -1,269 +1,313 @@
 ---
-title: Backup storage reclamation — server-owned dedupe base, pins, and a rows-only GC root set (D18)
-status: draft, pending advisor review
+title: Backup storage reclamation — server-owned dedupe base, durable pins and retirements, rows-only GC roots (D18)
+status: v2 after Codex xhigh advisor review (9 findings folded in); ready for planning
 date: 2026-09-09
 source: docs/testing/backup-assurance/2026-09-09-backup-assurance-campaign.md (D18, R1/R4, §9 decision 6); issue #5429
-author: Claude (Fable), code map by an Explore subagent
+author: Claude (Fable); code map by Explore subagents; adversarial review by Codex gpt-6-astra xhigh (read-only)
 ---
 
-# Backup Storage Reclamation (D18) — Design
+# Backup Storage Reclamation (D18) — Design v2
 
 ## 0. Problem, in one paragraph
 
 Retention deletes `backup_snapshots` rows (D17, #5419) but the storage sweep in
 `apps/api/src/jobs/backupRetention.ts` marks **every prefix that still has a
 `manifest.json`** as a live root (`listedManifestSnapshotIds`, ~:805), and nothing ever
-deletes a manifest object. So once a snapshot is published, its manifest, every object it
-lists, and every object it references in older prefixes are immortal. Retention is purely
-logical; bucket usage only grows (campaign cell R4: three expired rows deleted, `0 objects
-deleted`, expired base still holds all 10,048 objects, six manifest-bearing prefixes with no
-row). The protection exists because the **agent** picks its incremental dedupe base by
-listing bucket manifests (`agent/internal/backup/incremental.go:53 previousManifest`), so
-the server cannot know which base an in-flight run depends on and must keep them all.
+deletes a manifest object. Once a snapshot is published, its manifest, every object it lists,
+and every object it references in older prefixes are immortal. Retention is purely logical;
+bucket usage only grows (campaign cell R4: three expired rows deleted, `0 objects deleted`,
+expired base still holds all 10,048 objects, six manifest-bearing prefixes with no row). The
+protection exists because the **agent** picks its incremental dedupe base by listing bucket
+manifests (`agent/internal/backup/incremental.go:53 previousManifest`), so the server cannot
+know which base an in-flight run depends on and must keep them all.
 
 ## 1. Ground truth (verified on main `24c3e2ad81`, 2026-09-09)
 
 - **No pin of any kind exists.** `backup_jobs` has `snapshot_id` (the child) and no base
   column (`apps/api/src/db/schema/backup.ts:207-278`). `restore_jobs.snapshot_id` is
-  `ON DELETE SET NULL` (`:363`), so retention can delete the row of a snapshot that is being
-  restored right now; the restore survives today only because every listed manifest is a
-  root. "Active restore pins" and "active upload prefixes" in the campaign quorum text do not
-  exist in code — the only in-flight protections are the 48 h object grace
-  (`BACKUP_GC_GRACE_MS`, `:494-524`, resolved once at module load) and the 9-day
-  manifest-less-prefix rule (`BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS` = agent journal
-  max age 7 d + grace, `:537-538`, source-text-contract-tested against the agent in
-  `services/backupAgentContract.test.ts:33,42`).
+  `ON DELETE SET NULL` (`:363`), so retention can delete the row of a snapshot being restored
+  right now; the restore survives today only because every listed manifest is a root. The only
+  in-flight protections are the 48 h object grace (`BACKUP_GC_GRACE_MS`, `:494-524`, resolved
+  once at module load) and the 9-day manifest-less-prefix rule
+  (`BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS` = agent journal max age 7 d + grace,
+  `:537-538`, source-text-contract-tested in `services/backupAgentContract.test.ts:33,42`).
 - **The manifest already records the base** (`agent/internal/backup/snapshot.go:69
-  baseSnapshotId`, set at `:378-388`), the reconcile parser already models it
-  (`services/backupSnapshotReconcile.ts:240`), and `backup_snapshots.parent_snapshot_id`
-  (self-FK `ON DELETE SET NULL`, `:305`) and `is_incremental` (`:300`) exist — **none of
-  them is ever written**. Persistence is the missing piece, not information.
-- **The dispatch payload** (`jobs/backupWorker.ts:471-490`) is
+  baseSnapshotId`, set `:378-388`) but the result parser strips it
+  (`routes/backup/resultSchemas.ts:27 backupSnapshotResultSchema` has no `baseSnapshotId` /
+  `formatVersion`) and reconcile discards it (`services/backupSnapshotReconcile.ts:576`).
+  `backup_snapshots.parent_snapshot_id` (self-FK `ON DELETE SET NULL`, `:305`) and
+  `is_incremental` (`:300`) exist and are never written.
+- **Dispatch payload** (`jobs/backupWorker.ts:471-490`):
   `{jobId, configId, provider, providerConfig, storageEncryption, paths|systemImage|...}` —
   no base field. Multi-target dispatch creates one `backup_jobs` row per extra target with no
   parent linkage (`:713-739`).
 - **Two writers of snapshot rows:** `services/backupResultPersistence.ts:1144
-  applyBackupCommandResultToJob` (normal) and `services/backupSnapshotReconcile.ts:592
-  reconcileOrphanedBackupSnapshots` (adopts manifest-bearing prefixes with no row; on-demand
-  route, not scheduled).
-- **There is no agent-local scheduler** (`agent/internal/backup/backup.go:172-174`, #2452);
-  every run is a server `backup_run` command. But the helper falls back to an
-  **agent.yaml-built manager** when the payload lacks `provider`/`providerConfig`
-  (`agent/cmd/breeze-backup/main.go:729-737`, `exec_backup.go:117-119`); that manager carries
-  `Retention = cfg.BackupRetention || 7` and the agent's prefix-wide, reference-blind
-  `DeleteSnapshotContext` (`snapshot.go:977`) is suppressed **only** by
-  `incrementalDedupeActive` (`backup.go:780-806`). That is the real shape of the quorum's
-  "legacy writers" concern.
-- **Abandonment:** `jobs/staleCommandReaper.ts:1343 reapStaleBackupJobs` flips
-  `pending|running` rows after 15 min stall / 24 h absolute / 1 h pending, CAS on status.
-  GC runs 6-hourly (`scheduleRegistry.ts:151`, `27 2,8,14,20 * * *`).
-- **Root-set filter today** is `backupType = 'file' OR NULL` (`backupRetention.ts:1066-1074`)
-  on the claim that other modes never share `snapshots/`. That claim is **wrong for every
-  mode** — system_image, Hyper-V and MSSQL all publish `snapshots/<id>/manifest.json` (§3.4).
-- **A NULL `config_id` row wedges the whole GC run** (`:985-1017`); `backup_configs` is read
-  unfiltered (`:990-996`); `providerConfig.prefix` is ignored by both agent and API
-  (`backupSnapshotStorage.ts:136-161`) so keys are always `snapshots/<id>/...`.
-- **Tests that lock in the behaviour being removed:** `backupRetention.test.ts:665` ("keeps
-  a listed manifest's exclusive objects live even though no row retains it") and `:699-752`
-  ("marks every listed manifest, not just the newest (FIX 5)"). Both were data-loss review
-  fixes; §3 states what replaces their guarantee.
-- **No GC integration test exists**; MinIO is dev-compose only. The sweep already supports
-  the `local` provider, which is enough for a real-DB + real-filesystem proof in CI.
+  applyBackupCommandResultToJob` (normal; also accepts a late result for an already-reaped job,
+  `:972`) and `services/backupSnapshotReconcile.ts:592 reconcileOrphanedBackupSnapshots`
+  (adopts any manifest-bearing prefix whose completed job lacks a snapshot row — including one
+  retention deliberately deleted, `:754`; never checks the objects exist, `:865`).
+- **Every mode writes `snapshots/<id>/manifest.json`** with a `files[].backupPath` manifest the
+  GC parser accepts: file (`snapshot.go:390,819`), system_image (same manager; today its
+  state artifacts go through the ordinary `files/` loop, `backup.go:518`, `snapshot.go:594`;
+  the `system-state/` sub-prefix is D15's *target*), hyperv
+  (`agent/cmd/breeze-backup/exec_hyperv.go:240,421-422`), mssql (`exec_hyperv.go:78-81,532`).
+  The retention comment at `backupRetention.ts:1057-1065` claiming otherwise is wrong; the
+  `backupType='file'` root filter (`:1066-1074`) means those rows are protected **only** by the
+  every-listed-manifest rule this design removes. Vault replication (`local_vaults`, agent
+  `vault_path`) is a device-local directory, not a `backup_configs` identity — never listed.
+- **Agent deletes remotely in two places**: the retention prune branch (`backup.go:780-806`,
+  suppressed only by `incrementalDedupeActive`) and **stale-journal cleanup**
+  (`backup.go:738` → `snapshot.go:884`), which deletes the journal's remote prefix even if that
+  prefix was already published (crash between manifest publish and journal completion). A
+  resumed journal also reuses the published snapshot id and re-uploads over it
+  (`snapshot.go:375,784`). Journal age is checked only at open (`journal.go:155`).
+- **No agent-local scheduler** (`backup.go:172-174`, #2452); every run is a server
+  `backup_run`. The helper falls back to an agent.yaml-built manager when the payload lacks
+  `provider`/`providerConfig` (`main.go:729-737`, `exec_backup.go:117-119`).
+- **Reaper** (`jobs/staleCommandReaper.ts:1343`): 15 min without progress, 1 h pending, and
+  24 h absolute **only when `lastProgressAt` is NULL** (`:1390`) — a progressing job runs
+  indefinitely. Reaping queues a best-effort `backup_stop` and skips it for offline devices
+  (`:1402`); a disconnected helper keeps uploading. Restore commands time out server-side after
+  30 min (`services/commandTimeouts.ts:89`) while the helper has no deadline (`main.go:80`).
+  Restores are created `pending` **before** their command row exists
+  (`routes/backup/restore.ts:281,361`); the reaper matches restores only by `commandId`
+  (`:237`), so a crash leaves a commandless `pending` restore forever.
+- **Destination identity is mutable**: `PATCH /backup/configs/:id` edits `providerConfig` in
+  place (`routes/backup/configs.ts:392`) and GC attributes rows to identities through the
+  config's *current* `providerConfig` (`backupRetention.ts:990`).
+- **GC cadence** 6-hourly (`scheduleRegistry.ts:151`); delete cap 2000/run oldest-first, failed
+  keys only logged (`:950-959`); `deleteBackupObjectKeys` batches and continues past failures
+  (`backupSnapshotStorage.ts:329`). A NULL `config_id` row wedges the whole run (`:985-1017`).
+- **`devices.backup_version`** (`schema/devices.ts:175`) carries the helper version;
+  `services/backupHelperCapabilities.ts` already gates a feature on it (#4925 pattern).
+- **Tests locking in removed behaviour:** `backupRetention.test.ts:665` and `:699-752` (FIX 5).
+- **No GC integration test**; MinIO is dev-compose only; the sweep supports the `local`
+  provider, enough for a real-DB + real-filesystem proof in CI.
 
 ## 2. Goals / non-goals
 
 **Goals**
-1. An expired snapshot's exclusive objects (and its manifest) are reclaimed, bounded in time.
-2. Every retained snapshot restores completely at all times: no object referenced by a
-   retained manifest is ever deleted, and no snapshot under active restore loses its row or
-   objects.
-3. An in-flight backup never ends up with dangling references, whatever base it used.
-4. The server, not the agent, decides the dedupe base; the agent never lists the bucket to
-   choose one and never deletes anything.
-5. Behaviour is provable against a real database and real object storage in CI.
+1. Expired snapshots' exclusive objects and manifests are reclaimed on the next GC cycle.
+2. No object referenced by a retained snapshot is ever deleted; no snapshot under restore,
+   bare-metal recovery, or in use as a dedupe base loses its row or objects.
+3. An in-flight or late-publishing backup never ends up with dangling references.
+4. The server chooses the dedupe base; the agent never lists the bucket to choose one and
+   **never deletes a remote object**.
+5. Every state transition GC depends on is durable in Postgres and provable against a real
+   database and real storage in CI.
 
 **Non-goals**
-- Prompt (sub-day) reclamation of *young* snapshots pruned by `maxVersions`. Bounded by the
-  unrooted-manifest window (§3.3). A tombstone object could shorten it; deferred (§7).
-- Changing the object key layout, `providerConfig.prefix` handling, or object-lock semantics.
-- MSSQL/Hyper-V chain retention semantics (#5421) beyond keeping their objects safe.
+- Changing key layout, `providerConfig.prefix` handling, or object-lock semantics.
+- MSSQL/Hyper-V chain-consistent retention (#5421) beyond keeping their objects safe.
+- Reclaiming identities no config points at any more (they leak, logged — see §3.6).
 
 ## 3. Contract
 
-Roots and reachability are computed per storage identity, as today. Three changes.
+### 3.1 Server-chosen base, pinned with a lease
 
-### 3.1 The server chooses the dedupe base and pins it
+- **Columns on `backup_jobs`:** `base_snapshot_id varchar(255) NULL` (storage snapshot id,
+  deliberately not a FK — a pin must never be nulled by a cascade) and
+  `base_lease_expires_at timestamptz NULL`. Partial index on `base_snapshot_id`.
+- **Selection** (`prepareBackupDispatchTargets`, per dispatched file/system_image target
+  including multi-target child rows): newest `backup_snapshots` row with the same
+  `(device_id, config_id)`, `backup_type IN ('file','system_image')` or NULL, same mode as the
+  target, `expires_at IS NULL OR expires_at > now() + lease`, owning job `completed`, and no
+  retirement row (§3.3). None → full run.
+- **Acquisition is serialised against retention** (Codex F1): in one transaction
+  `SELECT … FROM backup_snapshots WHERE id = $base FOR SHARE`, then `UPDATE backup_jobs SET
+  base_snapshot_id, base_lease_expires_at = now() + BACKUP_BASE_LEASE_MS`, commit. Retention's
+  per-row delete takes `FOR UPDATE` on the same row and re-checks pins in a fresh statement
+  (§3.2), so either the pin is visible to retention or the row is already gone and dispatch
+  falls back to a full run. No FK-column write occurs inside the locked section (no key-share
+  deadlock, cf. #3911).
+- **Pin definition:** a `backup_jobs` row pins `base_snapshot_id` while
+  `status IN ('pending','running') OR base_lease_expires_at > now()`. The lease (default
+  `BACKUP_BASE_LEASE_MS` = 7 d, matching the agent journal max age) is the answer to Codex F3:
+  a reaped job's helper may still be uploading, so terminal status alone never releases the
+  pin; the lease does. The helper enforces the same lease (below), so after expiry no manifest
+  referencing the base can be published. Lease is set at dispatch and **extended** by the
+  server on every progress report (`lastProgressAt` update) to `now() + lease`, so a legitimately
+  long, progressing run keeps its base.
+- **Payload:** `backup_run` gains `baseSnapshotId: string` ("" = full run) and
+  `baseLeaseExpiresAt: RFC3339`. Presence of `baseSnapshotId` is the protocol switch.
+- **Agent**: with the field present → server-owned mode: non-empty → download
+  `snapshots/<id>/manifest.json`, require `backupIdentity == runBackupIdentity()` (D6 guard),
+  use as `prevSnapshot`; "" or 404 or mismatch → full run, logged. Before **publishing** the
+  manifest the agent checks `now < baseLeaseExpiresAt` (and, for resumed runs, journal age <
+  `journalMaxAge` — Codex F6); if either fails it does not publish and fails the run with a
+  distinct error class. Without the field (older server) → legacy listing, unchanged.
+- **Publication / lineage:** `backupSnapshotResultSchema` gains `baseSnapshotId` and
+  `formatVersion`; `applyBackupCommandResultToJob` sets `parent_snapshot_id` (row uuid of the
+  base under the same config, NULL if absent) and `is_incremental = referencedFiles > 0 ||
+  formatVersion >= 2`. Reconcile adoption does the same from the manifest.
+- **Late results** (Codex F2b): a result for a job already in a terminal reaped status is
+  accepted only if the job's `base_snapshot_id` is NULL or its row still exists and is not
+  retired **and** the job's lease has not expired; otherwise the result is recorded as `failed`
+  (reason `base_retired`) and the manifest is left for GC as an orphan.
 
-- **New column** `backup_jobs.base_snapshot_id varchar(255) NULL` — the storage snapshot id
-  (same domain as `backup_jobs.snapshot_id` / `backup_snapshots.snapshot_id`), deliberately
-  **not** a FK: a pin must never be silently nulled by a cascade, and the reaper, not the DB,
-  releases it. Indexed partially `WHERE base_snapshot_id IS NOT NULL`.
-- **Selection** (in `prepareBackupDispatchTargets`, per dispatched file/system_image target,
-  including multi-target child rows): newest `backup_snapshots` row for
-  `(device_id, config_id)` with `backup_type IN ('file','system_image')` (or NULL) and the
-  same mode as the target, `expires_at IS NULL OR expires_at > now()`, whose owning job
-  `status = 'completed'`. Ties → newest `timestamp`. No candidate → no base (full run).
-- **Pin semantics:** a `backup_jobs` row with `status IN ('pending','running')` and a
-  non-null `base_snapshot_id` pins that snapshot. Retention (§3.2) refuses to delete a
-  pinned row. The pin is released by the job reaching any terminal status (result applied,
-  cancelled, or reaped by `reapStaleBackupJobs`). Worst-case hold by a dead job = 24 h
-  absolute timeout + reaper cadence; the column is never cleared, only made inert.
-- **Payload:** `backup_run` gains `baseSnapshotId: string` (empty string = "server chose no
-  base; run full"). Presence of the field, not its value, is the protocol switch.
-- **Agent** (`backup.go:683-691`): if the payload carries `baseSnapshotId`, the agent is in
-  *server-owned base* mode: non-empty → download `snapshots/<id>/manifest.json`, require
-  `backupIdentity == runBackupIdentity()` (same D6 guard as today; mismatch → log + full
-  run), use it as `prevSnapshot`; empty → full run. Payload without the field (older server)
-  → legacy `previousManifest` listing, unchanged. Log the decision in both modes.
-- **Agent never deletes:** remove the `Retention > 0 && !incrementalDedupeActive` prune
-  branch (`backup.go:780-806`) and stop honouring `BackupConfig.Retention` for deletion
-  anywhere in the run path. The agent.yaml manager fallback keeps working for uploads but can
-  no longer reclaim anything. Closes the "legacy writer" hole from the quorum.
-- **Publication:** `applyBackupCommandResultToJob` persists `parent_snapshot_id` (uuid of the
-  row whose `snapshot_id = result.snapshot.baseSnapshotId`, same config; NULL if absent) and
-  `is_incremental = referencedFiles > 0 || formatVersion >= 2`. Reconcile adoption does the
-  same from the manifest's `baseSnapshotId`. Informational only — reachability is by
-  `backupPath`, not by parent links — but it makes the chain visible and testable.
+### 3.2 Retention refuses pinned rows and writes a retirement
 
-### 3.2 Retention refuses to delete pinned rows
+`cleanupExpiredSnapshots` (both passes) processes each candidate in its own transaction:
+`SELECT … FOR UPDATE` on the row, then skip if any of:
+- backup pin (§3.1);
+- restore pin: `EXISTS restore_jobs WHERE snapshot_id = row.id AND (status IN
+  ('pending','running') OR created_at > now() - BACKUP_RESTORE_PIN_LINGER_MS)` — the linger
+  (default 7 d) covers commandless/crashed restores (Codex F8) and helpers that keep reading
+  after the 30-min server timeout (F3);
+- recovery pin: `EXISTS recovery_tokens WHERE snapshot_id = row.id AND (status IN
+  ('active','authenticated') OR completed_at IS NULL AND expires_at > now() - linger)`
+  (columns per `schema/recoveryTokens.ts:10-16`; no `session_status` column exists);
+- `legal_hold` / immutability, as today.
 
-`cleanupExpiredSnapshots` (both the `expiresAt` pass and the `maxVersions` pass) excludes a
-row when either holds:
-- `EXISTS backup_jobs WHERE base_snapshot_id = row.snapshot_id AND status IN
-  ('pending','running')` (backup pin), or
-- `EXISTS restore_jobs WHERE snapshot_id = row.id AND status IN ('pending','running')`
-  (restore pin), or
-- `EXISTS recovery_tokens WHERE snapshot_id = row.id AND expires_at > now() AND
-  session_status <> 'completed'` (bare-metal recovery pin — a BMR session downloads the
-  manifest and every object over minutes to hours; verify the exact status/expiry columns
-  in `schema` before implementing).
+Otherwise, in the same transaction: insert `backup_snapshot_retirements` (§3.3) and delete
+the row. Counts gain `skippedPinned`. `deleteSnapshotRow`'s docstring is rewritten to this.
 
-Skipped rows are counted (`skippedPinned`) and retried next run. Because the row survives,
-its manifest and everything it references stay in the root set (§3.3) — the pin is enforced
-once, upstream, instead of being re-derived inside the sweep. The `deleteSnapshotRow`
-docstring is rewritten to state this contract.
+### 3.3 Durable retirement (DB tombstone) — new table `backup_snapshot_retirements`
 
-`restore_jobs` that never finish do not pin forever: `staleCommandReaper.ts:220-239` already
-flips `pending|running` restores to `failed` when their `device_commands` row is reaped.
-Recovery tokens are bounded by their own `expires_at`.
+Columns: `id`, `org_id` (NOT NULL), `config_id` (FK `backup_configs` ON DELETE CASCADE),
+`device_id` (nullable, FK SET NULL), `snapshot_id varchar(255)`, `storage_identity text`
+(§3.6), `backup_type`, `reason` (`expired` | `max_versions` | `manual`), `retired_at`,
+`swept_at` (nullable; set when the sweep finds the prefix empty), unique
+`(storage_identity, snapshot_id)`. Tenancy shape 1 (`breeze_has_org_access(org_id)`), RLS in
+the creating migration, registered in `CORE_ORG_CASCADE_DELETE_ORDER`,
+`CORE_DEVICE_CASCADE_DELETE_TABLES`, `CORE_DEVICE_ORG_DENORMALIZED_TABLES`,
+`CORE_TENANT_EXPORT_POLICY` (all columns `included`). Rows are pruned 30 d after `swept_at`.
 
-### 3.3 GC roots = retained rows + young unrooted manifests; old unrooted prefixes are garbage
+Why (Codex choice 1): age alone cannot tell "expired" from "orphan", cannot stop reconcile from
+re-adopting an expired prefix mid-sweep, and delays reclamation of young `maxVersions` prunes
+by the orphan window. A retirement row is authoritative and visible to every writer:
+- reconcile refuses to adopt a retired `snapshot_id` (and prunes nothing itself);
+- dispatch never selects a retired base;
+- late results check it (§3.1);
+- the sweep treats a retired prefix as garbage immediately, no window.
 
-`sweepStorageIdentity` mark set becomes:
+### 3.4 GC roots and sweep rules
+
+Per storage identity (§3.6):
 
 ```
-roots = { snapshot_id of EVERY backup_snapshots row on this identity }        (all types, §3.4)
-      ∪ { listed manifest-bearing prefixes with no row whose manifest.json
-          lastModified is newer than BACKUP_GC_UNROOTED_MANIFEST_MAX_AGE_MS }
-live  = ⋃ over roots of { manifest key } ∪ { files[].backupPath }
+roots   = { snapshot_id of EVERY backup_snapshots row with storage_identity = I }   (all types)
+        ∪ { listed manifest-bearing prefixes with no row and no retirement whose
+            manifest.json lastModified is newer than BACKUP_GC_ORPHAN_MANIFEST_MAX_AGE_MS }
+live    = ⋃ roots { manifest key } ∪ { files[].backupPath }
+retired = { snapshot_id of backup_snapshot_retirements with storage_identity = I, swept_at IS NULL }
 ```
 
-Sweep rules per listed prefix group:
-- **Rooted prefix** (in `roots`): unchanged — delete only objects not in `live` and older
-  than `BACKUP_GC_GRACE_MS`.
-- **Unrooted, manifest-bearing, manifest older than the window:** delete every object in
-  the prefix that is not in `live` (objects a retained child still references stay), the
-  manifest **last** within the prefix so a cap-truncated sweep leaves a still-legible prefix.
-- **Manifest-less prefix:** unchanged 9-day rule (in-progress upload protection, coupled to
-  the agent journal age).
+Per listed prefix group:
+- **Rooted:** unchanged — delete objects not in `live` and older than `BACKUP_GC_GRACE_MS`.
+- **Retired, or orphan older than the window:** delete every object not in `live`. Two
+  phases per prefix (Codex F9b): all non-manifest keys first; only if that phase reports zero
+  `failedKeys` for the prefix is `manifest.json` deleted; when the listing later shows the
+  prefix empty, set `swept_at`.
+- **Manifest-less:** unchanged 9-day rule (in-progress upload protection). The agent
+  additionally refreshes `snapshots/<id>/upload.lease` (tiny object) every
+  `uploadLeaseInterval` (15 min) while uploading, so a multi-day single-object upload keeps the
+  prefix's newest object fresh (Codex F6).
+- **Reconcile boundary:** reconcile adopts an orphan only while its manifest is younger than
+  half the window, so adoption and sweeping are disjoint by age.
+- **Cap fairness (Codex F9a):** keys whose delete failed are remembered in Redis
+  (`backup-gc:failed:<identity-hash>`, TTL 7 d) and skipped from the cap for that period.
+- **Capability gate (Codex F4):** unrooted-prefix deletion (retired + orphan rules) on an
+  identity is enabled only when every device that has a `backup_jobs` row on that identity in
+  the last 30 d reports `devices.backup_version >= BACKUP_SERVER_BASE_MIN_HELPER_VERSION`
+  (`backupHelperCapabilities.ts`, the release carrying W03). Otherwise that identity logs
+  `reclamation deferred: legacy helper <device>` and only the rooted-prefix rule runs (today's
+  behaviour). The gate is removed one release after every supported helper carries W03.
 
-`BACKUP_GC_UNROOTED_MANIFEST_MAX_AGE_MS` defaults to `BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS`
-(9 d), env-overridable with the same production floor/warn pattern as `BACKUP_GC_GRACE_MS`,
-and resolved **per run** (not at module load) so the lab and the integration test can set it.
+All knobs are resolved **per run** with the existing production-floor/warn pattern:
+`BACKUP_GC_GRACE_MS`, `BACKUP_GC_ORPHAN_MANIFEST_MAX_AGE_MS` (default 9 d),
+`BACKUP_BASE_LEASE_MS` (7 d), `BACKUP_RESTORE_PIN_LINGER_MS` (7 d).
 
-Why this replaces the FIX 5 guarantee without a tombstone:
-- A base chosen by the server is pinned → its row survives → it is a root. The "listed
-  manifest with no row" case that FIX 5 protected can now only be (i) an expired snapshot
-  (reclaim it — that is the point), (ii) a run that published but whose result the server
-  never applied (reaped; adoptable via reconcile for 9 days, then garbage), or (iii) a base
-  chosen by a **legacy helper** that still lists the bucket. For (iii) the newest
-  identity-matching manifest is, by construction of retention, the newest retained
-  snapshot except in degenerate configs (`maxVersions`=0-ish); residual risk accepted and
-  documented, removed when the legacy listing path is dropped one release later.
-- Reclamation lag for an expired snapshot is one GC cycle when it is older than the window
-  (the normal case — retention periods are days to years), and at most the window for a
-  young `maxVersions` prune.
+### 3.5 The agent never deletes
 
-### 3.4 Every row is a root, whatever its `backup_type`
+- Remove the retention prune branch (`backup.go:780-806`); `BackupConfig.Retention` no longer
+  drives deletion anywhere (agent.yaml manager fallback keeps uploading, cannot reclaim).
+- Stale-journal cleanup no longer deletes the remote prefix (`backup.go:738`,
+  `snapshot.go:884`): a discarded journal is simply dropped; GC's manifest-less rule reclaims
+  an unpublished prefix, and a published one is a root. (Codex F5.)
+- On resume, if `snapshots/<id>/manifest.json` already exists the run is treated as already
+  published: no re-upload, no overwrite; report the existing manifest as the result.
+- `DeleteSnapshot`/`DeleteSnapshotContext` remain only for the explicit `backup_cleanup`
+  command path if one exists; otherwise removed. The helper's `providers.BackupProvider.Delete`
+  stays for `upload.lease` housekeeping only.
 
-Verified (subagent, file:line in §8): **all four modes write `snapshots/<id>/manifest.json`
-with a `files[].backupPath` manifest** the GC parser already accepts — file
-(`snapshot.go:390,819`), system_image (same manager; state artifacts additionally under
-`snapshots/<id>/system-state/`), hyperv (`agent/cmd/breeze-backup/exec_hyperv.go:240,421`),
-mssql (`exec_hyperv.go:78-81,532`, literally a `backup.Snapshot`). The retention comment at
-`backupRetention.ts:1057-1065` is wrong; those rows are protected today only by the
-every-listed-manifest rule that this design removes. Therefore:
+### 3.6 Snapshots carry their storage identity (Codex F7)
 
-- `retainedSnapshotIds` = **every** `backup_snapshots` row whose `config_id` is on the
-  identity, no `backup_type` filter. Dropping the filter is a hard prerequisite of §3.3 —
-  with it, every Hyper-V/MSSQL/system-image snapshot older than the window would be swept.
-- Manifest fetch/parse failure for any root aborts the identity, uniformly (fail-closed, as
-  today). Hyper-V's manifest is a distinct Go type but structurally `files[].backupPath`.
-- Non-file modes never reference other prefixes (no dedupe), so their reachability is
-  self-contained; chains (`backup_chains`) are one pointer row per database, and each
-  differential/log run is its own `backup_snapshots` row, so chain members are roots by
-  the same rule. Chain-consistency of *retention* (expiring a full while its diffs live)
-  is #5421, not this spec.
-- Vault replication (`local_vaults`, agent `vault_path`) is a device-local directory, not a
-  `backup_configs` identity; GC never lists it. Unaffected.
+New column `backup_snapshots.storage_identity text NOT NULL` = `normalizeStorageIdentity` of
+the config at publication time (backfilled from current configs in the migration, batched,
+`breeze.scope=system` via `set_config`). GC groups rows by this column, not by the config's
+current `providerConfig`, so editing a destination cannot un-root the snapshots already written
+to the old bucket. An identity no config points at any more is never listed and therefore
+leaks; the sweep logs `unreachable identity <I>: <n> rows` so it is visible. `PATCH
+/backup/configs/:id` warns (does not block) when the edit changes the identity of a config that
+has snapshot rows.
 
 ## 4. Data model & registries
 
-- Migration `apps/api/migrations/2026-10-15-140005-backup-jobs-base-snapshot-pin.sql`
-  (newest shipped is `2026-10-15-140004-…`; the date ceiling is ahead of real time, so a
-  today-dated file would replay first): `ALTER TABLE backup_jobs ADD COLUMN IF NOT EXISTS
-  base_snapshot_id varchar(255)`, partial index `WHERE base_snapshot_id IS NOT NULL`. DDL
-  only, no `breeze.scope` needed.
-- `services/tenantExportPolicyRegistry.ts:119` `backup_jobs` → add `base_snapshot_id` to
-  `included` (tenant identifier, not secret). No new table → no cascade-list change.
-- Drizzle schema + `pnpm db:check-drift`.
-
-## 5. Failure modes considered
-
-| Scenario | Outcome under this contract |
+| Migration (slots after newest shipped `2026-10-15-140004`) | Content |
 |---|---|
-| Run in flight, base row expires | Row pinned → skipped by retention → still a root. |
-| Run reaped (stall/24 h) after publishing manifest, result lost | Pin released; child is an unrooted young manifest → root for 9 d (reconcile can adopt); after that its exclusive objects are garbage; objects a later retained child references stay live. |
-| Restore in flight, snapshot expires | Restore pin → row kept → root. |
-| Legacy helper lists bucket for base | Picks newest identity-matching manifest = newest retained row in practice; documented residual risk. |
-| Agent.yaml manager fallback | Uploads fine; can no longer delete (prune branch removed). |
-| Base manifest 404 at agent | Full run (logged). Server pin harmless. |
-| Object-lock refuses manifest delete | `failedKeys` logged as today; prefix retried each run. |
-| Cap hit mid-prefix | Manifest deleted last; partial prefix is either still manifest-bearing (retried) or manifest-less-old (retried). |
-| NULL `config_id` row | Still wedges the run (unchanged, fail-closed). |
-| Multi-target job | Each dispatched child row carries its own pin. |
+| `2026-10-15-140005-backup-jobs-base-pin-and-storage-identity.sql` | `backup_jobs.base_snapshot_id`, `base_lease_expires_at`, partial index; `backup_snapshots.storage_identity` + batched backfill + `SET NOT NULL`; `set_config('breeze.scope','system',true)` for the backfill; `GET DIAGNOSTICS` row counts |
+| `2026-10-15-140006-backup-snapshot-retirements.sql` | table + RLS (shape 1, enable+force, four policies) + indexes |
+
+Registries: `tenantExportPolicyRegistry.ts` (`backup_jobs` + 2 cols, `backup_snapshots` + 1
+col, new table), `tenantCascade.ts` `CORE_ORG_CASCADE_DELETE_ORDER` (alphabetical: after
+`backup_snapshot_files`? — verify `localeCompare` order in the test), `routes/devices/core.ts`
+device lists, `orgMergeRegistry` if applicable. `pnpm db:check-drift`.
+
+## 5. Failure modes
+
+| Scenario | Outcome |
+|---|---|
+| Dispatch selects B while retention deletes B | Row lock: retention sees the pin and skips, or dispatch sees no row and runs full. |
+| Job reaped while helper offline, still uploading | Lease keeps B pinned 7 d; helper refuses to publish after lease; late result after lease → `failed(base_retired)`, manifest becomes orphan → swept after window. |
+| Crash after publish, before journal completion; stale journal later | Agent no longer deletes; prefix is rooted (if row) or orphan/adoptable. |
+| Resume reuses published id | Detected via existing manifest; no overwrite. |
+| Restore/BMR in flight, snapshot expires | Restore/recovery pin (status or linger). |
+| Legacy helper on identity | Identity's unrooted-prefix reclamation deferred; rooted-prefix rule only. |
+| Config bucket edited | Rows keep `storage_identity`; old bucket still swept iff some config lists it; else leak logged. |
+| Cap hit mid-prefix | Manifest deleted only after all other keys succeed; partial prefix retried next run. |
+| Object-lock refuses deletes | Failed keys skipped for 7 d; other garbage still progresses. |
+| Reconcile vs sweep | Retired ids refused; orphans adoptable only below half-window; sweep only above window. |
+| NULL `config_id` row | Still wedges the run (unchanged). |
+| Hyper-V/MSSQL/system_image rows | Roots like any other row; manifests parse. |
 
 ## 6. Verification
 
-- **Unit** (`backupRetention.test.ts`): replace `:665` and `:699-752` with (a) "unrooted
-  manifest older than window → prefix swept, manifest last, live-referenced objects kept",
-  (b) "unrooted manifest younger than window → root", (c) "pinned row skipped by both
-  retention passes", (d) "restore-pinned row skipped", (e) hyperv/mssql/system_image rows are roots and their
-  manifests parse, (f) window knob resolution per run. Worker/dispatch tests for base selection
-  and payload field; persistence tests for `parent_snapshot_id`/`is_incremental`; reaper test
-  that a reaped job releases the pin.
-- **Integration (real DB + `local` provider, CI shard):** seed identity with base B and
-  incremental child C referencing B's objects plus B-exclusive object X; expire B; run
-  retention + sweep with window=0 → X and B's manifest gone, C's manifest and every
-  `backupPath` it lists present, B's row gone, C's row intact. Second case: pin B via a
-  running job → nothing reclaimed. Third: restore pin.
-- **Agent** (`incremental_test.go`): server-owned mode with valid base, identity mismatch,
-  empty base, 404; legacy mode unchanged; prune branch gone (`snapshot_lifecycle_test.go`).
-  `backupAgentContract.test.ts` extended for the payload field name.
-- **Lab (manual, campaign harness, MinIO):** repeat cell R4 with
-  `BACKUP_GC_UNROOTED_MANIFEST_MAX_AGE_MS=1000` — expired base reclaimed, retained
-  incremental restores byte-identical (cell F2 hashes).
+- **Unit:** retention pin/retirement/skip counts; dispatch selection + lock protocol (mocked
+  chain) + payload fields; result-apply lineage + late-result fence; reconcile refusals; sweep
+  root set (all types), retired-immediate, orphan window, two-phase manifest delete, Redis skip
+  set, capability gate, per-run knobs. Replace `backupRetention.test.ts:665,699-752`.
+- **Integration (real DB, `local` provider, CI shard):** (1) base B + incremental C referencing
+  B + B-exclusive X; expire B → retirement row, X and B's manifest gone, C intact and every
+  `backupPath` present; (2) pinned B (running job) → nothing reclaimed; (3) lease expired,
+  job reaped → reclaimed; (4) restore pin; (5) legacy helper version on identity → deferred;
+  (6) concurrent dispatch/retention on the same row (two transactions) → no dangling pin;
+  (7) RLS forge on the retirements table (42501) + cascade/export contract suites.
+- **Agent (`go test -race`):** server-owned mode (valid / mismatch / "" / 404), lease refusal at
+  publish, resume-with-existing-manifest, no remote delete on stale journal, upload lease
+  refresh, legacy mode unchanged; `backupAgentContract.test.ts` for payload names and the
+  lease/journal constants.
+- **Lab (manual, campaign harness, MinIO):** cell R4 with `BACKUP_GC_ORPHAN_MANIFEST_MAX_AGE_MS`
+  and lease knobs shortened — expired base reclaimed; retained incremental restores
+  byte-identical (F2 hashes); Hyper-V/MSSQL manifests untouched.
 
-## 7. Deferred / follow-ups
+## 7. Deferred
 
-- Tombstone object (`snapshots/<id>/expired.json`) for prompt reclamation of young prunes.
-- Drop the agent's legacy bucket-listing base path one release after this ships.
-- Helper capability gate (`backupHelperCapabilities.ts`) is **not** needed: unknown payload
-  fields are ignored by old helpers.
-- D15 (`system-state/` prefix) must extend `markLiveBackupObjects` — already in its plan.
-- Storage accounting UI ("reclaimed bytes") — out of scope.
+- Drop the agent's legacy listing path and the capability gate one release after ship.
+- Agent-side restore deadline (helper has none today) — separate issue.
+- Reclaiming unreachable identities (no config) — manual tooling, separate issue.
+- D15 `system-state/` prefix must extend `markLiveBackupObjects` — already in its plan.
+- Storage accounting UI.
 
-## 8. Verification log
+## 8. Review log
 
-- [x] Hyper-V / MSSQL layout confirmed 2026-09-09 (Explore subagent): system_image `bmr.go:222`/`snapshot.go:819`; hyperv `exec_hyperv.go:240,421-422,437`; mssql `exec_hyperv.go:78-81,514,532-533`; `backupType` stamping `backupResultPersistence.ts:1127-1133`; vault `vault.go:77-78` + `routes/backup/vault.ts:92` (`local_vaults`).
-- [ ] Codex `xhigh` read-only review of this spec.
+- [x] Hyper-V / MSSQL layout confirmed 2026-09-09 (Explore subagent): system_image
+  `bmr.go:222`/`snapshot.go:819`; hyperv `exec_hyperv.go:240,421-422,437`; mssql
+  `exec_hyperv.go:78-81,514,532-533`; `backupType` stamping `backupResultPersistence.ts:1127-1133`;
+  vault `vault.go:77-78` + `routes/backup/vault.ts:92` (`local_vaults`).
+- [x] Codex gpt-6-astra xhigh read-only review 2026-09-09 of v1: 7×P1 + 2×P2 + 3 factual
+  corrections, all folded into v2 (F1 lock protocol §3.1; F2 retirement table §3.3 + late-result
+  fence; F3 leases §3.1/§3.2; F4 capability gate §3.4; F5 agent never deletes §3.5; F6 lease at
+  publish + upload lease object; F7 storage identity §3.6; F8 restore linger §3.2; F9 two-phase
+  manifest delete + Redis skip set §3.4). Codex agreed with retention-time pin enforcement given
+  atomic acquisition/retirement, and rejected age-only retirement — both adopted.

--- a/docs/superpowers/specs/backup/2026-09-09-backup-gc-reclamation-design.md
+++ b/docs/superpowers/specs/backup/2026-09-09-backup-gc-reclamation-design.md
@@ -174,10 +174,14 @@ know which base an in-flight run depends on and must keep them all.
 - recovery pin: `EXISTS recovery_tokens WHERE snapshot_id = row.id AND (status IN
   ('active','authenticated') OR completed_at IS NULL AND expires_at > now() - linger)`
   (columns per `schema/recoveryTokens.ts:10-16`; no `session_status` column exists);
-- `legal_hold` / immutability, as today.
+- `legal_hold` / immutability, **re-read under the row lock** (a hold set after candidate
+  enumeration must win);
+- `storage_identity IS NULL` (§3.6): the row cannot be tombstoned on an identity, so it is
+  skipped (`skippedUnresolved`) until the sweep self-heals it — never retired blind.
 
 Otherwise, in the same transaction: insert `backup_snapshot_retirements` (§3.3) and delete
-the row. Counts gain `skippedPinned`. `deleteSnapshotRow`'s docstring is rewritten to this.
+the row. Every lookup of a base or retired snapshot by storage `snapshot_id` is scoped by
+`storage_identity` (the id is not unique across identities, `schema/backup.ts:330`). Counts gain `skippedPinned`. `deleteSnapshotRow`'s docstring is rewritten to this.
 
 ### 3.3 Durable retirement (DB tombstone) — new table `backup_snapshot_retirements`
 
@@ -303,6 +307,9 @@ objects are gone. Required shape:
 2. Sweep: a separate system context per identity for the DB reads, with every storage call at
    depth 0 (outside any transaction), mirroring the dispatch phase split at `:508-528`.
 3. The D17 `failed > 0` throw stays last and can no longer undo anything.
+
+W01 delivers 1 and 3 and calls the sweep under one system context (today's shape, so
+`sweepUnreferencedBackupObjects` keeps working reads); W02 replaces that with 2.
 
 Retirement rows therefore commit strictly before any object they cover is deleted, and an
 object is deleted only for a snapshot whose retirement is already durable.

--- a/docs/superpowers/specs/backup/2026-09-09-backup-gc-reclamation-design.md
+++ b/docs/superpowers/specs/backup/2026-09-09-backup-gc-reclamation-design.md
@@ -236,11 +236,16 @@ Per listed prefix group:
   that is `pending`/`running` (any age) **or** was created in the last 30 d reports
   `devices.backup_version >= BACKUP_SERVER_BASE_MIN_HELPER_VERSION`
   (`backupHelperCapabilities.ts`, the release carrying W03). Otherwise that identity logs
-  `reclamation deferred: legacy helper <device>` and only the rooted-prefix rule runs (today's
-  behaviour). A helper upgrade kills any run in progress, so the current version attests the
+  `reclamation deferred: legacy helper <device>` and runs **exactly today's algorithm**: every
+  listed manifest (rooted or not, retired or not) is marked live, so a base a legacy helper
+  chose by listing keeps its cross-prefix references protected; only loose objects under a
+  manifest-bearing prefix and manifest-less prefixes older than 9 d are reclaimed. A helper upgrade kills any run in progress, so the current version attests the
   running helper. The gate is removed one release after every supported helper carries W03.
-- **Unknown-identity rows:** while any row mapped to I has `storage_identity IS NULL` and its
-  prefix is not found in I's listing, I runs the rooted-prefix rule only (§3.6).
+- **Unknown-identity rows:** every row mapped to I with `storage_identity IS NULL` is a root
+  of I (its manifest is fetched; a fetch failure aborts I fail-closed like any root). While any
+  such row's manifest is not found in I's listing, I runs today's algorithm as for a deferred
+  identity (§3.6). Self-heal updates by row **id** (`snapshot_id` is not unique across
+  identities, `schema/backup.ts:330`) and only where `storage_identity IS NULL`.
 
 All knobs are resolved **per run** with the existing production-floor/warn pattern:
 `BACKUP_GC_GRACE_MS`, `BACKUP_GC_ORPHAN_MANIFEST_MAX_AGE_MS` (default 9 d),

--- a/docs/superpowers/specs/backup/2026-09-09-backup-gc-reclamation-design.md
+++ b/docs/superpowers/specs/backup/2026-09-09-backup-gc-reclamation-design.md
@@ -1,12 +1,12 @@
 ---
 title: Backup storage reclamation — server-owned dedupe base, durable pins and retirements, rows-only GC roots (D18)
-status: v2 after Codex xhigh advisor review (9 findings folded in); ready for planning
+status: v3 after two Codex review rounds (xhigh + high confirmation); ready for planning
 date: 2026-09-09
 source: docs/testing/backup-assurance/2026-09-09-backup-assurance-campaign.md (D18, R1/R4, §9 decision 6); issue #5429
 author: Claude (Fable); code map by Explore subagents; adversarial review by Codex gpt-6-astra xhigh (read-only)
 ---
 
-# Backup Storage Reclamation (D18) — Design v2
+# Backup Storage Reclamation (D18) — Design v3
 
 ## 0. Problem, in one paragraph
 
@@ -106,54 +106,71 @@ know which base an in-flight run depends on and must keep them all.
 ### 3.1 Server-chosen base, pinned with a lease
 
 - **Columns on `backup_jobs`:** `base_snapshot_id varchar(255) NULL` (storage snapshot id,
-  deliberately not a FK — a pin must never be nulled by a cascade) and
-  `base_lease_expires_at timestamptz NULL`. Partial index on `base_snapshot_id`.
+  deliberately not a FK — a pin must never be nulled by a cascade),
+  `publish_lease_expires_at timestamptz NULL` (set for **every** dispatched file/system_image
+  job, base or not — it fences late results, §3.1 last bullet) and `storage_identity text NULL`
+  (the identity of the `providerConfig` actually placed in the payload, §3.6). Partial index on
+  `base_snapshot_id`.
 - **Selection** (`prepareBackupDispatchTargets`, per dispatched file/system_image target
   including multi-target child rows): newest `backup_snapshots` row with the same
   `(device_id, config_id)`, `backup_type IN ('file','system_image')` or NULL, same mode as the
   target, `expires_at IS NULL OR expires_at > now() + lease`, owning job `completed`, and no
   retirement row (§3.3). None → full run.
-- **Acquisition is serialised against retention** (Codex F1): in one transaction
-  `SELECT … FROM backup_snapshots WHERE id = $base FOR SHARE`, then `UPDATE backup_jobs SET
-  base_snapshot_id, base_lease_expires_at = now() + BACKUP_BASE_LEASE_MS`, commit. Retention's
-  per-row delete takes `FOR UPDATE` on the same row and re-checks pins in a fresh statement
-  (§3.2), so either the pin is visible to retention or the row is already gone and dispatch
-  falls back to a full run. No FK-column write occurs inside the locked section (no key-share
-  deadlock, cf. #3911).
+- **Acquisition is serialised against retention** (Codex F1) with lock order **job → snapshot**
+  (the same order `routes/devices/moveOrg.ts:656` uses, so no inversion): in one transaction
+  `UPDATE backup_jobs SET base_snapshot_id = $base, publish_lease_expires_at = now() + lease,
+  storage_identity = $identity WHERE id = $job` (locks J), then `SELECT id FROM
+  backup_snapshots WHERE id = $baseRow FOR SHARE` (locks B) and check no retirement row exists;
+  if the row is gone, `SET base_snapshot_id = NULL` in the same transaction and dispatch a full
+  run. Retention's per-row delete takes `FOR UPDATE` on B and re-checks pins in a fresh
+  statement (§3.2). Either the pin is visible to retention or the row is already gone and
+  dispatch falls back. No FK-column write inside the locked section (no key-share deadlock,
+  cf. #3911).
 - **Pin definition:** a `backup_jobs` row pins `base_snapshot_id` while
-  `status IN ('pending','running') OR base_lease_expires_at > now()`. The lease (default
-  `BACKUP_BASE_LEASE_MS` = 7 d, matching the agent journal max age) is the answer to Codex F3:
-  a reaped job's helper may still be uploading, so terminal status alone never releases the
-  pin; the lease does. The helper enforces the same lease (below), so after expiry no manifest
-  referencing the base can be published. Lease is set at dispatch and **extended** by the
-  server on every progress report (`lastProgressAt` update) to `now() + lease`, so a legitimately
-  long, progressing run keeps its base.
+  `status IN ('pending','running') OR publish_lease_expires_at + BACKUP_PUBLISH_MARGIN_MS >
+  now()`. The lease (default `BACKUP_BASE_LEASE_MS` = 7 d, matching the agent journal max age)
+  answers Codex F3: a reaped job's helper may still be uploading, so terminal status alone never
+  releases the pin; the lease does. The helper enforces the same lease at publish time with the
+  margin (below), so no manifest referencing the base can land after the server stops pinning
+  it. The lease is **fixed at dispatch — not renewed**: there is no progress-ack channel to
+  deliver a renewal to the helper (`routes/agentWs.ts:2723`), and a run longer than the lease
+  already cannot resume (journal max age 7 d), so "a run must publish within 7 d of dispatch" is
+  the existing envelope made explicit. Operators with slow initial seeds raise
+  `BACKUP_BASE_LEASE_MS`; the orphan window follows it (§3.4).
 - **Payload:** `backup_run` gains `baseSnapshotId: string` ("" = full run) and
-  `baseLeaseExpiresAt: RFC3339`. Presence of `baseSnapshotId` is the protocol switch.
+  `publishLeaseExpiresAt: RFC3339`. Presence of `baseSnapshotId` is the protocol switch.
 - **Agent**: with the field present → server-owned mode: non-empty → download
   `snapshots/<id>/manifest.json`, require `backupIdentity == runBackupIdentity()` (D6 guard),
   use as `prevSnapshot`; "" or 404 or mismatch → full run, logged. Before **publishing** the
-  manifest the agent checks `now < baseLeaseExpiresAt` (and, for resumed runs, journal age <
-  `journalMaxAge` — Codex F6); if either fails it does not publish and fails the run with a
-  distinct error class. Without the field (older server) → legacy listing, unchanged.
+  manifest the agent checks `now + publishMargin (1 h) < publishLeaseExpiresAt` (and, for
+  resumed runs, journal age < `journalMaxAge` — Codex F6); if either fails it does not publish
+  and fails the run with a distinct error class. The margin is what turns the pre-PUT check into
+  a fence: the server keeps the pin for lease + margin, so a PUT that starts inside the margin
+  completes before the pin lapses. Without the field (older server) → legacy listing, unchanged.
 - **Publication / lineage:** `backupSnapshotResultSchema` gains `baseSnapshotId` and
   `formatVersion`; `applyBackupCommandResultToJob` sets `parent_snapshot_id` (row uuid of the
   base under the same config, NULL if absent) and `is_incremental = referencedFiles > 0 ||
   formatVersion >= 2`. Reconcile adoption does the same from the manifest.
 - **Late results** (Codex F2b): a result for a job already in a terminal reaped status is
-  accepted only if the job's `base_snapshot_id` is NULL or its row still exists and is not
-  retired **and** the job's lease has not expired; otherwise the result is recorded as `failed`
-  (reason `base_retired`) and the manifest is left for GC as an orphan.
+  accepted only if `publish_lease_expires_at > now()` **and** (`base_snapshot_id IS NULL` or the
+  base row exists and is not retired); otherwise the result is recorded as `failed` (reason
+  `publish_lease_expired` / `base_retired`) and the manifest is left for GC as an orphan. The
+  lease fences full backups too: an orphan is never swept before its job's lease has expired
+  (window ≥ lease + grace, §3.4), so an accepted late result always refers to objects that
+  still exist.
 
 ### 3.2 Retention refuses pinned rows and writes a retirement
 
 `cleanupExpiredSnapshots` (both passes) processes each candidate in its own transaction:
 `SELECT … FOR UPDATE` on the row, then skip if any of:
 - backup pin (§3.1);
-- restore pin: `EXISTS restore_jobs WHERE snapshot_id = row.id AND (status IN
-  ('pending','running') OR created_at > now() - BACKUP_RESTORE_PIN_LINGER_MS)` — the linger
-  (default 7 d) covers commandless/crashed restores (Codex F8) and helpers that keep reading
-  after the 30-min server timeout (F3);
+- restore pin: `EXISTS restore_jobs WHERE snapshot_id = row.id AND ((status IN
+  ('pending','running') AND command_id IS NOT NULL) OR created_at > now() -
+  BACKUP_RESTORE_PIN_LINGER_MS)` — the linger (default 7 d) covers helpers that keep reading
+  after the 30-min server timeout (F3); a commandless `pending` restore (crash between
+  `restore.ts:281` and `:361`) pins only for the linger and is additionally failed by a new
+  reaper rule after 1 h (F8). A helper restore running longer than the linger is out of scope
+  (§7, agent restore deadline);
 - recovery pin: `EXISTS recovery_tokens WHERE snapshot_id = row.id AND (status IN
   ('active','authenticated') OR completed_at IS NULL AND expires_at > now() - linger)`
   (columns per `schema/recoveryTokens.ts:10-16`; no `session_status` column exists);
@@ -172,6 +189,9 @@ Columns: `id`, `org_id` (NOT NULL), `config_id` (FK `backup_configs` ON DELETE C
 the creating migration, registered in `CORE_ORG_CASCADE_DELETE_ORDER`,
 `CORE_DEVICE_CASCADE_DELETE_TABLES`, `CORE_DEVICE_ORG_DENORMALIZED_TABLES`,
 `CORE_TENANT_EXPORT_POLICY` (all columns `included`). Rows are pruned 30 d after `swept_at`.
+Deleting a device or org cascades its retirement rows *and* its snapshot rows; the prefixes
+then fall under the orphan rule and are reclaimed after the window — a deliberate behaviour
+change (today a deleted device's objects were immortal), called out in §9 for Todd.
 
 Why (Codex choice 1): age alone cannot tell "expired" from "orphan", cannot stop reconcile from
 re-adopting an expired prefix mid-sweep, and delays reclamation of young `maxVersions` prunes
@@ -187,8 +207,10 @@ Per storage identity (§3.6):
 
 ```
 roots   = { snapshot_id of EVERY backup_snapshots row with storage_identity = I }   (all types)
+        ∪ { snapshot_id of rows with storage_identity NULL whose config currently maps to I }
         ∪ { listed manifest-bearing prefixes with no row and no retirement whose
-            manifest.json lastModified is newer than BACKUP_GC_ORPHAN_MANIFEST_MAX_AGE_MS }
+            manifest.json lastModified is newer than ORPHAN_WINDOW }
+ORPHAN_WINDOW = max(BACKUP_GC_ORPHAN_MANIFEST_MAX_AGE_MS (9 d), BACKUP_BASE_LEASE_MS + BACKUP_GC_GRACE_MS)
 live    = ⋃ roots { manifest key } ∪ { files[].backupPath }
 retired = { snapshot_id of backup_snapshot_retirements with storage_identity = I, swept_at IS NULL }
 ```
@@ -196,27 +218,33 @@ retired = { snapshot_id of backup_snapshot_retirements with storage_identity = I
 Per listed prefix group:
 - **Rooted:** unchanged — delete objects not in `live` and older than `BACKUP_GC_GRACE_MS`.
 - **Retired, or orphan older than the window:** delete every object not in `live`. Two
-  phases per prefix (Codex F9b): all non-manifest keys first; only if that phase reports zero
-  `failedKeys` for the prefix is `manifest.json` deleted; when the listing later shows the
-  prefix empty, set `swept_at`.
+  phases per prefix (Codex F9b): all non-manifest keys first; `manifest.json` is deleted only
+  when **no deletable non-manifest key remains** in the prefix (none failed, none skipped by the
+  cap or the Redis skip set); when the listing later shows the prefix empty, set `swept_at`.
 - **Manifest-less:** unchanged 9-day rule (in-progress upload protection). The agent
   additionally refreshes `snapshots/<id>/upload.lease` (tiny object) every
   `uploadLeaseInterval` (15 min) while uploading, so a multi-day single-object upload keeps the
   prefix's newest object fresh (Codex F6).
 - **Reconcile boundary:** reconcile adopts an orphan only while its manifest is younger than
-  half the window, so adoption and sweeping are disjoint by age.
+  half the window, so adoption and sweeping are disjoint by age; and only if the manifest's
+  `baseSnapshotId` (when present) has a live, unretired row — a manifest whose base is gone is
+  refused (its references may already dangle).
 - **Cap fairness (Codex F9a):** keys whose delete failed are remembered in Redis
   (`backup-gc:failed:<identity-hash>`, TTL 7 d) and skipped from the cap for that period.
 - **Capability gate (Codex F4):** unrooted-prefix deletion (retired + orphan rules) on an
-  identity is enabled only when every device that has a `backup_jobs` row on that identity in
-  the last 30 d reports `devices.backup_version >= BACKUP_SERVER_BASE_MIN_HELPER_VERSION`
+  identity is enabled only when every device that has a `backup_jobs` row on that identity
+  that is `pending`/`running` (any age) **or** was created in the last 30 d reports
+  `devices.backup_version >= BACKUP_SERVER_BASE_MIN_HELPER_VERSION`
   (`backupHelperCapabilities.ts`, the release carrying W03). Otherwise that identity logs
   `reclamation deferred: legacy helper <device>` and only the rooted-prefix rule runs (today's
-  behaviour). The gate is removed one release after every supported helper carries W03.
+  behaviour). A helper upgrade kills any run in progress, so the current version attests the
+  running helper. The gate is removed one release after every supported helper carries W03.
+- **Unknown-identity rows:** while any row mapped to I has `storage_identity IS NULL` and its
+  prefix is not found in I's listing, I runs the rooted-prefix rule only (§3.6).
 
 All knobs are resolved **per run** with the existing production-floor/warn pattern:
 `BACKUP_GC_GRACE_MS`, `BACKUP_GC_ORPHAN_MANIFEST_MAX_AGE_MS` (default 9 d),
-`BACKUP_BASE_LEASE_MS` (7 d), `BACKUP_RESTORE_PIN_LINGER_MS` (7 d).
+`BACKUP_BASE_LEASE_MS` (7 d), `BACKUP_PUBLISH_MARGIN_MS` (1 h), `BACKUP_RESTORE_PIN_LINGER_MS` (7 d).
 
 ### 3.5 The agent never deletes
 
@@ -233,23 +261,51 @@ All knobs are resolved **per run** with the existing production-floor/warn patte
 
 ### 3.6 Snapshots carry their storage identity (Codex F7)
 
-New column `backup_snapshots.storage_identity text NOT NULL` = `normalizeStorageIdentity` of
-the config at publication time (backfilled from current configs in the migration, batched,
-`breeze.scope=system` via `set_config`). GC groups rows by this column, not by the config's
-current `providerConfig`, so editing a destination cannot un-root the snapshots already written
-to the old bucket. An identity no config points at any more is never listed and therefore
-leaks; the sweep logs `unreachable identity <I>: <n> rows` so it is visible. `PATCH
-/backup/configs/:id` warns (does not block) when the edit changes the identity of a config that
-has snapshot rows.
+`backup_jobs.storage_identity` is stamped **at dispatch** from the `providerConfig` placed in
+the payload (that is the bucket the helper will write to, whatever the config says later);
+`backup_snapshots.storage_identity text NULL` is copied from the job at publication (reconcile
+copies it from the adoptable job too). GC groups rows by this column, not by the config's
+current `providerConfig`, so editing a destination cannot un-root snapshots already written to
+the old bucket.
+
+Historical rows: the migration backfills `storage_identity` from the current config **only
+when the config was not edited after the snapshot** (`backup_configs.updated_at <=
+backup_snapshots.timestamp`); everything else stays NULL. The sweep self-heals a NULL row when
+it finds `snapshots/<id>/manifest.json` in the listing of the config's current identity
+(`UPDATE … SET storage_identity = I`); until every NULL row mapped to an identity has been
+resolved, that identity runs the rooted-prefix rule only (§3.4). Rows with NULL `config_id`
+stay NULL and keep wedging the run as today. No `NOT NULL` constraint.
+
+An identity no config points at any more is never listed and therefore leaks; the sweep logs
+`unreachable identity <I>: <n> rows`. `PATCH /backup/configs/:id` warns (does not block) when
+the edit changes the identity of a config that has snapshot rows.
+
+### 3.7 Transaction boundaries (Codex v2 P1)
+
+`processCleanupExpiredSnapshots` (`jobs/backupWorker.ts:325-390`) runs today inside the
+worker's blanket `runWithSystemDbAccess`, which is a **single transaction** (see the #1105
+comment at `:508-520`): every per-row retention "transaction" would be a savepoint, object
+deletes would happen before the row deletes commit, and the deliberate D17 throw at `:387`
+would roll all retirements back after the bucket was already swept — resurrecting rows whose
+objects are gone. Required shape:
+
+1. Retention: one short system context **per candidate row** (`SELECT FOR UPDATE` → pin checks
+   → insert retirement → delete row → commit), so each retirement is durable before the next.
+2. Sweep: a separate system context per identity for the DB reads, with every storage call at
+   depth 0 (outside any transaction), mirroring the dispatch phase split at `:508-528`.
+3. The D17 `failed > 0` throw stays last and can no longer undo anything.
+
+Retirement rows therefore commit strictly before any object they cover is deleted, and an
+object is deleted only for a snapshot whose retirement is already durable.
 
 ## 4. Data model & registries
 
 | Migration (slots after newest shipped `2026-10-15-140004`) | Content |
 |---|---|
-| `2026-10-15-140005-backup-jobs-base-pin-and-storage-identity.sql` | `backup_jobs.base_snapshot_id`, `base_lease_expires_at`, partial index; `backup_snapshots.storage_identity` + batched backfill + `SET NOT NULL`; `set_config('breeze.scope','system',true)` for the backfill; `GET DIAGNOSTICS` row counts |
+| `2026-10-15-140005-backup-jobs-base-pin-and-storage-identity.sql` | `backup_jobs.base_snapshot_id`, `publish_lease_expires_at`, `storage_identity`, partial index; `backup_snapshots.storage_identity` (nullable) + guarded backfill (§3.6, config not edited since snapshot) in SQL replicating `normalizeStorageIdentity`; `SELECT set_config('breeze.scope','system',true)` for the backfill; `GET DIAGNOSTICS` row counts, including how many rows were left NULL |
 | `2026-10-15-140006-backup-snapshot-retirements.sql` | table + RLS (shape 1, enable+force, four policies) + indexes |
 
-Registries: `tenantExportPolicyRegistry.ts` (`backup_jobs` + 2 cols, `backup_snapshots` + 1
+Registries: `tenantExportPolicyRegistry.ts` (`backup_jobs` + 3 cols, `backup_snapshots` + 1
 col, new table), `tenantCascade.ts` `CORE_ORG_CASCADE_DELETE_ORDER` (alphabetical: after
 `backup_snapshot_files`? — verify `localeCompare` order in the test), `routes/devices/core.ts`
 device lists, `orgMergeRegistry` if applicable. `pnpm db:check-drift`.
@@ -258,8 +314,14 @@ device lists, `orgMergeRegistry` if applicable. `pnpm db:check-drift`.
 
 | Scenario | Outcome |
 |---|---|
-| Dispatch selects B while retention deletes B | Row lock: retention sees the pin and skips, or dispatch sees no row and runs full. |
-| Job reaped while helper offline, still uploading | Lease keeps B pinned 7 d; helper refuses to publish after lease; late result after lease → `failed(base_retired)`, manifest becomes orphan → swept after window. |
+| Dispatch selects B while retention deletes B | Lock order job→snapshot; retention sees the pin and skips, or dispatch sees no row and runs full. |
+| Retention run throws after the sweep | Per-row commits (§3.7): nothing already swept can be rolled back. |
+| Config edited A→B while a run uploads to A | Job stamped A at dispatch; row inherits A; still rooted on A. |
+| Backfilled identity uncertain (config edited after snapshot) | Row stays NULL; identity runs rooted-only until self-healed from the listing. |
+| Late full-backup result after its orphan prefix was swept | Lease expired → `failed(publish_lease_expired)`; window ≥ lease + grace guarantees the converse. |
+| Manifest PUT straddles lease expiry | 1 h publish margin on both sides. |
+| Legacy helper with a >30-day running job | Gate includes active jobs of any age. |
+| Job reaped while helper offline, still uploading | Lease keeps B pinned 7 d + margin; helper refuses to publish inside the margin; late result after lease → `failed`, manifest becomes orphan → swept after window. |
 | Crash after publish, before journal completion; stale journal later | Agent no longer deletes; prefix is rooted (if row) or orphan/adoptable. |
 | Resume reuses published id | Detected via existing manifest; no overwrite. |
 | Restore/BMR in flight, snapshot expires | Restore/recovery pin (status or linger). |
@@ -282,6 +344,8 @@ device lists, `orgMergeRegistry` if applicable. `pnpm db:check-drift`.
   `backupPath` present; (2) pinned B (running job) → nothing reclaimed; (3) lease expired,
   job reaped → reclaimed; (4) restore pin; (5) legacy helper version on identity → deferred;
   (6) concurrent dispatch/retention on the same row (two transactions) → no dangling pin;
+  (6b) retention run with one failing row after a sweep → earlier retirements still committed;
+  (6c) NULL-identity row self-healed from listing, identity deferred until then;
   (7) RLS forge on the retirements table (42501) + cascade/export contract suites.
 - **Agent (`go test -race`):** server-owned mode (valid / mismatch / "" / 404), lease refusal at
   publish, resume-with-existing-manifest, no remote delete on stale journal, upload lease
@@ -299,12 +363,29 @@ device lists, `orgMergeRegistry` if applicable. `pnpm db:check-drift`.
 - D15 `system-state/` prefix must extend `markLiveBackupObjects` — already in its plan.
 - Storage accounting UI.
 
-## 8. Review log
+## 8. Decisions for Todd (defaults applied)
+
+1. **Deleted device/org → its backups are reclaimed after the orphan window** (§3.3). Default:
+   yes (matches "delete means delete"; today they leaked forever). Alternative: keep a
+   retirement-free hold for N days.
+2. **Runs longer than `BACKUP_BASE_LEASE_MS` (7 d) fail to publish** (§3.1). Default: yes —
+   journal resume already caps a run at 7 d; knob is env-tunable per deployment.
+
+## 9. Review log
 
 - [x] Hyper-V / MSSQL layout confirmed 2026-09-09 (Explore subagent): system_image
   `bmr.go:222`/`snapshot.go:819`; hyperv `exec_hyperv.go:240,421-422,437`; mssql
   `exec_hyperv.go:78-81,514,532-533`; `backupType` stamping `backupResultPersistence.ts:1127-1133`;
   vault `vault.go:77-78` + `routes/backup/vault.ts:92` (`local_vaults`).
+- [x] Codex gpt-6-astra **high** confirmation review of v2 (2026-09-09): 2 CLOSED / 6 PARTIAL /
+  1 OPEN + 5 P1 + 4 P2 new. Folded into v3: ambient-transaction rollback (§3.7, verified
+  `backupWorker.ts:61,101,508-520`); identity stamped at dispatch + guarded backfill +
+  self-heal + nullable (§3.6); gate includes active jobs of any age (§3.4); publish margin
+  (§3.1); lease fences full backups and orphan window ≥ lease + grace (§3.1/§3.4); lock order
+  job→snapshot (§3.1); reconcile refuses manifests whose base is gone (§3.4); manifest deleted
+  only when no deletable key remains (§3.4); commandless restores pin only for the linger and
+  are reaped (§3.2). Not adopted: server-side lease renewal (no delivery channel; fixed lease
+  instead, §3.1); helper restores longer than the linger (deferred, §7).
 - [x] Codex gpt-6-astra xhigh read-only review 2026-09-09 of v1: 7×P1 + 2×P2 + 3 factual
   corrections, all folded into v2 (F1 lock protocol §3.1; F2 retirement table §3.3 + late-result
   fence; F3 leases §3.1/§3.2; F4 capability gate §3.4; F5 agent never deletes §3.5; F6 lease at


### PR DESCRIPTION
Design and implementation plans for D18 (#5429): retention deletes rows but the object sweep treats every bucket manifest as a live root, so storage is never reclaimed.

**Spec** `docs/superpowers/specs/backup/2026-09-09-backup-gc-reclamation-design.md` (v3): server-chosen dedupe base pinned on `backup_jobs` with a fixed 7-day publish lease; retention runs per-row committed transactions and writes a durable `backup_snapshot_retirements` tombstone; GC roots = every snapshot row by storage identity (all backup types — Hyper-V/MSSQL/system-image also write `snapshots/<id>/manifest.json`) plus young orphans; retired/old-orphan prefixes are swept; per-identity helper-version gate; the agent never deletes remote objects. Two Codex xhigh/high review rounds folded in (§9 log). Decisions applied as defaults are in §8.

**Plans** (feature #5449): W01 API pins/retirements (#5450), W02 GC sweep (#5451), W03 agent (#5452), W04 lab MinIO verification + release notes (#5453). Each plan had an independent Codex read-only review against the code; findings folded in.

Docs only — no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YCS42Rm9Fdm17AQagpWb1G