### PR TITLE
feat(backup): BMR consumer verifies system-state checksums, enforces required steps, fixes status derivation (D15 W02)

### DIFF
--- a/agent/internal/backup/bmr/bmr.go
+++ b/agent/internal/backup/bmr/bmr.go
@@ -162,7 +162,7 @@ func RunRecoveryContext(ctx context.Context, cfg RecoveryConfig, provider provid
 	if checkCancelled() {
 		return result, ctx.Err()
 	}
-	validation, valErr := Validate(stateResult.serviceUnits)
+	validation, valErr := Validate(stateResult.serviceUnits, stateResult.serviceUnitsErr)
 	if valErr != nil {
 		result.Warnings = append(result.Warnings, fmt.Sprintf("validation error: %s", valErr.Error()))
 	} else {
@@ -324,6 +324,115 @@ type systemStateResult struct {
 	// staging dir is removed so validate.go's post-restore service probe
 	// can check them. See enabledSystemdUnitsFromStaging (validate.go).
 	serviceUnits []string
+	// serviceUnitsErr is set when reading services/systemd.txt from
+	// staging failed for a reason OTHER than the artifact simply not being
+	// there (enabledSystemdUnitsFromStaging maps a not-exist error to
+	// (nil, nil) — that's the ordinary "no services artifact" case, not a
+	// failure). A non-nil value here must fail post-restore validation
+	// outright (Validate, validate.go) rather than silently treating an
+	// unreadable list the same as an empty one.
+	serviceUnitsErr error
+}
+
+// resolveStagingArtifactPath validates artifact.Path — an untrusted,
+// server-supplied manifest field, exactly like every other value in a
+// downloaded manifest — and resolves it to a location strictly inside
+// stagingDir, or returns an error naming why it was rejected. Called for
+// EVERY artifact (symlink or regular) before any filesystem call
+// (MkdirAll/Download/Symlink) ever touches the computed path. Three checks:
+//
+//  1. Reject an absolute path or one containing a ".." segment, BEFORE any
+//     filesystem access. path.Clean alone is not a defense on its own — it
+//     silently collapses "a/../../etc/passwd" rather than rejecting it — so
+//     the escape must be detected explicitly on the cleaned result, never
+//     "fixed" by re-rooting the string (which would hide the attack, not
+//     reject it).
+//  2. Reject if any ALREADY-STAGED ancestor directory component is itself a
+//     symlink (ensureNoStagedSymlinkAncestor, via os.Lstat — never os.Stat,
+//     which follows the very thing being checked for and would hide it). A
+//     manifest can legitimately stage a symlink artifact (Path "etc/link",
+//     LinkTarget "/some/real/path" — see systemstate.Artifact.LinkTarget's
+//     doc comment) and then include a LATER artifact with Path
+//     "etc/link/passwd": naively joining and MkdirAll/Download-ing through
+//     "etc/link" would follow the symlink via ordinary Stat-following
+//     filesystem calls and write that later artifact's content onto the
+//     REAL filesystem location the symlink points at — entirely outside
+//     stagingDir.
+//  3. As defense in depth beyond this artifact loop's own symlinks, resolve
+//     the deepest already-existing ancestor via filepath.EvalSymlinks and
+//     confirm it's still inside stagingDir's own resolved form.
+func resolveStagingArtifactPath(stagingDir, artifactPath string) (string, error) {
+	cleaned := path.Clean(artifactPath)
+	if path.IsAbs(cleaned) || cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return "", fmt.Errorf("path %q is absolute or escapes the staging directory", artifactPath)
+	}
+
+	localPath := filepath.Join(stagingDir, filepath.FromSlash(cleaned))
+
+	if err := ensureNoStagedSymlinkAncestor(stagingDir, localPath); err != nil {
+		return "", err
+	}
+
+	resolvedStagingDir, err := filepath.EvalSymlinks(stagingDir)
+	if err != nil {
+		return "", fmt.Errorf("resolve staging directory: %w", err)
+	}
+	resolvedAncestor, err := filepath.EvalSymlinks(deepestExistingAncestor(localPath))
+	if err != nil {
+		return "", fmt.Errorf("resolve staging path: %w", err)
+	}
+	if resolvedAncestor != resolvedStagingDir && !strings.HasPrefix(resolvedAncestor, resolvedStagingDir+string(filepath.Separator)) {
+		return "", fmt.Errorf("resolved path %q escapes the staging directory", artifactPath)
+	}
+
+	return localPath, nil
+}
+
+// ensureNoStagedSymlinkAncestor walks every already-existing ancestor
+// directory between stagingDir and target — EXCLUSIVE of target's own final
+// path segment, which legitimately may not exist yet (this artifact hasn't
+// been written) — and rejects the path if any of them was staged as a
+// symlink rather than a real directory. Stops (returns nil) at the first
+// ancestor segment that doesn't exist yet: nothing has been staged that
+// deep, so there is nothing further to walk through.
+func ensureNoStagedSymlinkAncestor(stagingDir, target string) error {
+	rel, err := filepath.Rel(stagingDir, target)
+	if err != nil {
+		return fmt.Errorf("resolve relative staging path: %w", err)
+	}
+	segments := strings.Split(filepath.ToSlash(rel), "/")
+	current := stagingDir
+	for _, seg := range segments[:len(segments)-1] {
+		current = filepath.Join(current, seg)
+		info, lstatErr := os.Lstat(current)
+		if lstatErr != nil {
+			if os.IsNotExist(lstatErr) {
+				return nil
+			}
+			return fmt.Errorf("stat staged path %q: %w", current, lstatErr)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("path component %q was staged as a symlink by an earlier artifact — refusing to write beneath it", current)
+		}
+	}
+	return nil
+}
+
+// deepestExistingAncestor walks up from p until it finds a path segment
+// that actually exists on disk (stagingDir itself always does, so this
+// always terminates), for filepath.EvalSymlinks — which errors on a path
+// that doesn't exist yet.
+func deepestExistingAncestor(p string) string {
+	for {
+		if _, err := os.Lstat(p); err == nil {
+			return p
+		}
+		parent := filepath.Dir(p)
+		if parent == p {
+			return p
+		}
+		p = parent
+	}
 }
 
 func applySystemState(ctx context.Context, cfg RecoveryConfig, provider providers.BackupProvider) systemStateResult {
@@ -379,6 +488,20 @@ func applySystemState(ctx context.Context, cfg RecoveryConfig, provider provider
 		warnings = append(warnings, fmt.Sprintf("system state capture incomplete for non-required steps: %s", strings.Join(nonRequired, ", ")))
 	}
 
+	// A snapshot whose bootstrap advertised system state (ExpectSystemState)
+	// but whose manifest decodes to zero artifacts is a contradiction, not a
+	// legitimate empty capture — fail loud rather than silently reporting
+	// StateApplied=true with nothing actually restored. When
+	// ExpectSystemState is false (or unset), the vacuous-truth soft path
+	// below is preserved: a manifest can legitimately have zero artifacts
+	// (e.g. a capture that only recorded HardwareProfile).
+	if cfg.ExpectSystemState && len(stateManifest.Artifacts) == 0 {
+		return systemStateResult{
+			manifestFound: true,
+			err:           fmt.Errorf("bmr: system-state manifest has no artifacts"),
+		}
+	}
+
 	// Download artifacts to staging directory.
 	stagingDir, stagingErr := os.MkdirTemp("", "bmr-state-staging-*")
 	if stagingErr != nil {
@@ -389,9 +512,22 @@ func applySystemState(ctx context.Context, cfg RecoveryConfig, provider provider
 	verificationFailed := false
 	for _, artifact := range stateManifest.Artifacts {
 		if ctx != nil && ctx.Err() != nil {
-			return systemStateResult{manifestFound: true, warnings: warnings, serviceUnits: enabledSystemdUnitsFromStaging(stagingDir)}
+			units, unitsErr := enabledSystemdUnitsFromStaging(stagingDir)
+			return systemStateResult{manifestFound: true, warnings: warnings, serviceUnits: units, serviceUnitsErr: unitsErr}
 		}
-		localPath := filepath.Join(stagingDir, artifact.Path)
+
+		// artifact.Path (and, for a symlink artifact, LinkTarget) is
+		// server-supplied manifest data — untrusted. resolveStagingArtifactPath
+		// rejects path traversal / absolute paths and any path that would
+		// resolve underneath a symlink an earlier artifact in this same
+		// manifest staged, BEFORE any MkdirAll/Download/Symlink call ever
+		// touches the filesystem with it.
+		localPath, pathErr := resolveStagingArtifactPath(stagingDir, artifact.Path)
+		if pathErr != nil {
+			warnings = append(warnings, fmt.Sprintf("artifact %s rejected: %s", artifact.Name, pathErr.Error()))
+			verificationFailed = true
+			continue
+		}
 		if mkErr := os.MkdirAll(filepath.Dir(localPath), 0o750); mkErr != nil {
 			warnings = append(warnings, fmt.Sprintf("failed to create dir for %s: %s", artifact.Name, mkErr.Error()))
 			verificationFailed = true
@@ -406,7 +542,15 @@ func applySystemState(ctx context.Context, cfg RecoveryConfig, provider provider
 			// construction), and no metadata (Mode/UID/GID/ModTime) to
 			// reapply — a symlink has no independent content or POSIX
 			// metadata of its own worth restoring separately from the link
-			// itself.
+			// itself. LinkTarget's own value is NOT path-validated the way
+			// artifact.Path is: it is legitimately an absolute path to a
+			// real filesystem location outside staging (e.g.
+			// /run/systemd/resolve/stub-resolv.conf) — that's the whole
+			// point of restoring it as a symlink later. The danger this
+			// function guards against is a LATER artifact resolving
+			// underneath THIS symlink once staged (see
+			// resolveStagingArtifactPath's doc comment), not this target
+			// value itself.
 			if rmErr := os.Remove(localPath); rmErr != nil && !os.IsNotExist(rmErr) {
 				warnings = append(warnings, fmt.Sprintf("failed to clear existing path before creating symlink %s: %s", artifact.Name, rmErr.Error()))
 				verificationFailed = true
@@ -423,6 +567,10 @@ func applySystemState(ctx context.Context, cfg RecoveryConfig, provider provider
 		remoteKey := path.Join(snapshotRootDir, cfg.SnapshotID, systemStatePath, artifact.Path)
 		if dlErr := provider.Download(remoteKey, localPath); dlErr != nil {
 			warnings = append(warnings, fmt.Sprintf("failed to download %s: %s", artifact.Name, dlErr.Error()))
+			// The provider may have written partial content before
+			// failing — never let that reach the restorer as if it were a
+			// complete, verified file.
+			_ = os.Remove(localPath)
 			verificationFailed = true
 			continue
 		}
@@ -444,16 +592,17 @@ func applySystemState(ctx context.Context, cfg RecoveryConfig, provider provider
 	// removed (the defer above fires when this function returns) — Validate
 	// runs later, in RunRecoveryContext step 4, well after this staging dir
 	// is gone.
-	serviceUnits := enabledSystemdUnitsFromStaging(stagingDir)
+	serviceUnits, serviceUnitsErr := enabledSystemdUnitsFromStaging(stagingDir)
 
 	// Apply system state via platform-specific restorer.
 	restorer := newRestorerFunc()
 	if restoreErr := restorer.RestoreSystemState(stagingDir); restoreErr != nil {
 		return systemStateResult{
-			manifestFound: true,
-			warnings:      warnings,
-			err:           fmt.Errorf("bmr: restore system state: %w", restoreErr),
-			serviceUnits:  serviceUnits,
+			manifestFound:   true,
+			warnings:        warnings,
+			err:             fmt.Errorf("bmr: restore system state: %w", restoreErr),
+			serviceUnits:    serviceUnits,
+			serviceUnitsErr: serviceUnitsErr,
 		}
 	}
 
@@ -468,25 +617,31 @@ func applySystemState(ctx context.Context, cfg RecoveryConfig, provider provider
 	}
 
 	return systemStateResult{
-		applied:       !verificationFailed,
-		drivers:       drivers,
-		warnings:      warnings,
-		manifestFound: true,
-		serviceUnits:  serviceUnits,
+		applied:         !verificationFailed,
+		drivers:         drivers,
+		warnings:        warnings,
+		manifestFound:   true,
+		serviceUnits:    serviceUnits,
+		serviceUnitsErr: serviceUnitsErr,
 	}
 }
 
 // verifyArtifactIntegrity checks a downloaded system-state artifact against
-// the manifest's recorded size and (when present) sha256 checksum. A
-// missing Checksum (older manifest schema, or a collection-time hashing
-// failure) is NOT an error here — the caller logs an "unverified" warning
-// for that case instead; only an actual mismatch fails the artifact.
+// the manifest's recorded size and (when present) sha256 checksum. Size is
+// always compared, INCLUDING when SizeBytes==0 (a manifest asserting the
+// artifact is empty) — an unconditional `> 0` guard here would let a
+// corrupted/truncated-the-other-way download of a nominally-empty artifact
+// through unverified, since an empty artifact by definition also has no
+// Checksum to catch it via the sha256 comparison below. A missing Checksum
+// (older manifest schema, or a collection-time hashing failure) is NOT an
+// error here — the caller logs an "unverified" warning for that case
+// instead; only an actual size or checksum mismatch fails the artifact.
 func verifyArtifactIntegrity(localPath string, artifact systemstate.Artifact) error {
 	info, statErr := os.Stat(localPath)
 	if statErr != nil {
 		return fmt.Errorf("stat downloaded artifact: %w", statErr)
 	}
-	if artifact.SizeBytes > 0 && info.Size() != artifact.SizeBytes {
+	if info.Size() != artifact.SizeBytes {
 		return fmt.Errorf("size mismatch: downloaded %d bytes, manifest says %d", info.Size(), artifact.SizeBytes)
 	}
 	if artifact.Checksum == "" {
@@ -517,14 +672,19 @@ func verifyArtifactIntegrity(localPath string, artifact systemstate.Artifact) er
 // reaches this function.
 func applyArtifactMetadata(localPath string, artifact systemstate.Artifact) []string {
 	var warnings []string
-	if artifact.Mode != 0 {
-		if err := chmodFile(localPath, fileModeFromArtifactMode(artifact.Mode)); err != nil {
-			warnings = append(warnings, fmt.Sprintf("could not reapply mode %04o to %s: %s", artifact.Mode, artifact.Name, err.Error()))
-		}
-	}
+	// Ownership MUST be reapplied BEFORE mode: on Linux, chown(2)/lchown(2)
+	// clears a file's setuid/setgid bits as a kernel-enforced anti-privilege-
+	// escalation measure whenever the owner or group actually changes.
+	// Reversing this order would silently drop a setuid/setgid bit this
+	// same call just (re)applied via chmod moments earlier.
 	if artifact.UID != 0 || artifact.GID != 0 {
 		if err := lchownFile(localPath, artifact.UID, artifact.GID); err != nil {
 			warnings = append(warnings, fmt.Sprintf("could not reapply ownership %d:%d to %s: %s", artifact.UID, artifact.GID, artifact.Name, err.Error()))
+		}
+	}
+	if artifact.Mode != 0 {
+		if err := chmodFile(localPath, fileModeFromArtifactMode(artifact.Mode)); err != nil {
+			warnings = append(warnings, fmt.Sprintf("could not reapply mode %04o to %s: %s", artifact.Mode, artifact.Name, err.Error()))
 		}
 	}
 	if !artifact.ModTime.IsZero() {

--- a/agent/internal/backup/bmr/bmr.go
+++ b/agent/internal/backup/bmr/bmr.go
@@ -2,12 +2,16 @@ package bmr
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/breeze-rmm/agent/internal/backup/providers"
@@ -48,6 +52,15 @@ var (
 // already restored fine. It is a package-level var (not const) so tests
 // can shrink it to keep fixtures small.
 var maxConsecutiveDownloadFailures = 25
+
+// newRestorerFunc is a package-level indirection over the platform-specific
+// newRestorer() (restore_linux.go / restore_windows.go / restore_darwin.go,
+// each behind its own //go:build tag) purely so tests can inject a fake
+// Restorer without needing to run on that real OS or shell out to
+// systemctl/reg/launchctl. It is a var initialized from the build-tagged
+// func, not a redefinition of it — restore_linux.go is owned by a sibling
+// wave and is not touched here.
+var newRestorerFunc = newRestorer
 
 // RunRecovery orchestrates a full bare metal recovery.
 //
@@ -107,10 +120,11 @@ func RunRecoveryContext(ctx context.Context, cfg RecoveryConfig, provider provid
 	if checkCancelled() {
 		return result, ctx.Err()
 	}
-	stateApplied, driversInjected, stateWarnings, stateErr := applySystemState(ctx, cfg, provider)
-	result.StateApplied = stateApplied
-	result.DriversInjected = driversInjected
-	result.Warnings = append(result.Warnings, stateWarnings...)
+	stateResult := applySystemState(ctx, cfg, provider)
+	result.StateApplied = stateResult.applied
+	result.DriversInjected = stateResult.drivers
+	result.Warnings = append(result.Warnings, stateResult.warnings...)
+	stateErr := stateResult.err
 	if stateErr != nil {
 		slog.Warn("bmr: system state restore had errors", "error", stateErr.Error())
 	}
@@ -138,7 +152,7 @@ func RunRecoveryContext(ctx context.Context, cfg RecoveryConfig, provider provid
 	if checkCancelled() {
 		return result, ctx.Err()
 	}
-	validation, valErr := Validate()
+	validation, valErr := Validate(stateResult.serviceUnits)
 	if valErr != nil {
 		result.Warnings = append(result.Warnings, fmt.Sprintf("validation error: %s", valErr.Error()))
 	} else {
@@ -149,10 +163,21 @@ func RunRecoveryContext(ctx context.Context, cfg RecoveryConfig, provider provid
 	}
 
 	// 5. Determine final status.
+	//
+	// stateBlocksCompletion is true whenever a system-state manifest was
+	// actually found (stateResult.manifestFound) but the state was not
+	// fully/successfully applied (stateResult.applied is false) — covering
+	// both a required-step violation / download failure (stateErr != nil,
+	// already excluded from "completed" by the first switch case below) and
+	// the checksum/size verification failures folded into `applied` itself.
+	// Before this fix, applySystemState could skip/fail state application
+	// silently (err == nil, applied == false) and still let status land on
+	// "completed" (D15/O10) purely because filesErr/stateErr were both nil.
+	stateBlocksCompletion := stateResult.manifestFound && !stateResult.applied
 	switch {
-	case filesErr == nil && stateErr == nil:
+	case filesErr == nil && stateErr == nil && !stateBlocksCompletion:
 		result.Status = "completed"
-	case filesRestored > 0 || stateApplied:
+	case result.FilesRestored > 0 || result.StateApplied:
 		result.Status = "partial"
 	default:
 		result.Status = "failed"
@@ -245,65 +270,160 @@ func downloadManifest(snapshotID string, provider providers.BackupProvider) (*sn
 	return &manifest, nil
 }
 
-func applySystemState(ctx context.Context, cfg RecoveryConfig, provider providers.BackupProvider) (applied bool, drivers int, warnings []string, err error) {
+// systemStateResult carries applySystemState's outcome. It replaced a
+// 4-value naked return (applied bool, drivers int, warnings []string, err
+// error) once tracking "was a manifest actually found" became necessary for
+// the status-derivation fix (RunRecoveryContext step 5) — a plain bool
+// return couldn't distinguish "no state existed" from "state existed but
+// failed to verify/apply" without an extra parameter creeping into every
+// call site.
+type systemStateResult struct {
+	// applied is true only when: the state manifest was downloaded, every
+	// required-step gate passed, every artifact download+verification
+	// succeeded (see verifyArtifactIntegrity), and the platform Restorer
+	// returned nil. Before this fix, applied (then a naked `applied` return)
+	// was set unconditionally to true right after a successful
+	// RestoreSystemState call, with no regard for whether any artifacts
+	// actually verified — including the degenerate case where every
+	// artifact failed to download and RestoreSystemState ran against an
+	// empty staging dir (D15/O10's "completed, stateApplied: false" was the
+	// closest observed symptom of the sibling status bug this also feeds).
+	applied bool
+	drivers int
+	// warnings accumulates non-fatal issues: unverified (checksum-less)
+	// artifacts, non-required incomplete capture steps, driver injection
+	// errors, and per-artifact download/verification failures.
+	warnings []string
+	// err is set only for FATAL conditions: a required capture step never
+	// completed (manifest.RequiredSteps ∩ manifest.IncompleteSteps), the
+	// bootstrap advertised system state that could not be found
+	// (cfg.ExpectSystemState with a 404 on the manifest itself), or the
+	// platform Restorer itself returned an error.
+	err error
+	// manifestFound is true once system-state/manifest.json was
+	// successfully downloaded and decoded — independent of `applied` — so
+	// RunRecoveryContext's status derivation can tell "state was never
+	// captured for this snapshot" (fine, status unaffected) apart from
+	// "state was captured but this run did not fully apply it" (must not
+	// report status "completed"), regardless of whether ExpectSystemState
+	// happened to be set.
+	manifestFound bool
+	// serviceUnits is the list of systemd unit names read from the staged
+	// services/systemd.txt artifact (Linux only; nil on every other
+	// platform or when that artifact wasn't staged), captured before the
+	// staging dir is removed so validate.go's post-restore service probe
+	// can check them. See enabledSystemdUnitsFromStaging (validate.go).
+	serviceUnits []string
+}
+
+func applySystemState(ctx context.Context, cfg RecoveryConfig, provider providers.BackupProvider) systemStateResult {
 	// Download system state manifest from the snapshot.
 	stateManifestKey := path.Join(snapshotRootDir, cfg.SnapshotID, systemStatePath, "manifest.json")
 
 	tmpFile, tmpErr := os.CreateTemp("", "bmr-state-manifest-*.json")
 	if tmpErr != nil {
-		return false, 0, nil, fmt.Errorf("bmr: create temp: %w", tmpErr)
+		return systemStateResult{err: fmt.Errorf("bmr: create temp: %w", tmpErr)}
 	}
 	tmpPath := tmpFile.Name()
 	_ = tmpFile.Close()
 	defer os.Remove(tmpPath)
 
 	if dlErr := provider.Download(stateManifestKey, tmpPath); dlErr != nil {
-		warnings = append(warnings, "no system state found in snapshot, skipping state restore")
+		if cfg.ExpectSystemState {
+			// The bootstrap said this snapshot has system state (see
+			// hasSystemStateManifest, session.go) — a missing manifest here
+			// is not "no state to restore", it's a broken/incomplete
+			// snapshot. Fatal, not the soft warning below.
+			return systemStateResult{
+				err: fmt.Errorf("bmr: snapshot advertises system state but system-state/manifest.json is missing: %w", dlErr),
+			}
+		}
 		slog.Info("bmr: no system state manifest found, skipping", "error", dlErr.Error())
-		return false, 0, warnings, nil
+		return systemStateResult{warnings: []string{"no system state found in snapshot, skipping state restore"}}
 	}
 
 	data, readErr := os.ReadFile(tmpPath)
 	if readErr != nil {
-		return false, 0, nil, fmt.Errorf("bmr: read state manifest: %w", readErr)
+		return systemStateResult{err: fmt.Errorf("bmr: read state manifest: %w", readErr)}
 	}
 
 	var stateManifest systemstate.SystemStateManifest
 	if err := json.Unmarshal(data, &stateManifest); err != nil {
-		return false, 0, nil, fmt.Errorf("bmr: decode state manifest: %w", err)
+		return systemStateResult{err: fmt.Errorf("bmr: decode state manifest: %w", err)}
+	}
+
+	var warnings []string
+
+	// Required-step enforcement: independently re-derive the producer's own
+	// gate (systemstate.missingRequired) instead of trusting that the
+	// producer never published a manifest with a required-and-incomplete
+	// step — a corrupted upload, a partial retry, or a future producer bug
+	// should not silently pass here just because SOME manifest exists.
+	if blocking := intersectStrings(stateManifest.RequiredSteps, stateManifest.IncompleteSteps); len(blocking) > 0 {
+		return systemStateResult{
+			manifestFound: true,
+			err:           fmt.Errorf("bmr: required system-state steps incomplete: %s", strings.Join(blocking, ", ")),
+		}
+	}
+	if nonRequired := subtractStrings(stateManifest.IncompleteSteps, stateManifest.RequiredSteps); len(nonRequired) > 0 {
+		warnings = append(warnings, fmt.Sprintf("system state capture incomplete for non-required steps: %s", strings.Join(nonRequired, ", ")))
 	}
 
 	// Download artifacts to staging directory.
 	stagingDir, stagingErr := os.MkdirTemp("", "bmr-state-staging-*")
 	if stagingErr != nil {
-		return false, 0, nil, fmt.Errorf("bmr: create staging dir: %w", stagingErr)
+		return systemStateResult{manifestFound: true, warnings: warnings, err: fmt.Errorf("bmr: create staging dir: %w", stagingErr)}
 	}
 	defer os.RemoveAll(stagingDir)
 
+	verificationFailed := false
 	for _, artifact := range stateManifest.Artifacts {
 		if ctx != nil && ctx.Err() != nil {
-			return applied, drivers, warnings, nil
+			return systemStateResult{manifestFound: true, warnings: warnings, serviceUnits: enabledSystemdUnitsFromStaging(stagingDir)}
 		}
 		remoteKey := path.Join(snapshotRootDir, cfg.SnapshotID, systemStatePath, artifact.Path)
 		localPath := filepath.Join(stagingDir, artifact.Path)
 		if mkErr := os.MkdirAll(filepath.Dir(localPath), 0o750); mkErr != nil {
 			warnings = append(warnings, fmt.Sprintf("failed to create dir for %s: %s", artifact.Name, mkErr.Error()))
+			verificationFailed = true
 			continue
 		}
 		if dlErr := provider.Download(remoteKey, localPath); dlErr != nil {
 			warnings = append(warnings, fmt.Sprintf("failed to download %s: %s", artifact.Name, dlErr.Error()))
+			verificationFailed = true
 			continue
+		}
+		if verifyErr := verifyArtifactIntegrity(localPath, artifact); verifyErr != nil {
+			warnings = append(warnings, fmt.Sprintf("artifact %s failed verification, discarding: %s", artifact.Name, verifyErr.Error()))
+			_ = os.Remove(localPath)
+			verificationFailed = true
+			continue
+		}
+		if artifact.Checksum == "" {
+			// Older manifest (schemaVersion 0) or a collection-time hashing
+			// failure — accept it best-effort but flag it, per plan §2/B1c.
+			warnings = append(warnings, fmt.Sprintf("artifact %s has no checksum (older manifest schema), unverified", artifact.Name))
 		}
 	}
 
-	// Apply system state via platform-specific restorer.
-	restorer := newRestorer()
-	if restoreErr := restorer.RestoreSystemState(stagingDir); restoreErr != nil {
-		return false, 0, warnings, fmt.Errorf("bmr: restore system state: %w", restoreErr)
-	}
-	applied = true
+	// Capture the Linux enabled-services list from staging BEFORE it's
+	// removed (the defer above fires when this function returns) — Validate
+	// runs later, in RunRecoveryContext step 4, well after this staging dir
+	// is gone.
+	serviceUnits := enabledSystemdUnitsFromStaging(stagingDir)
 
-	// Inject drivers if present.
+	// Apply system state via platform-specific restorer.
+	restorer := newRestorerFunc()
+	if restoreErr := restorer.RestoreSystemState(stagingDir); restoreErr != nil {
+		return systemStateResult{
+			manifestFound: true,
+			warnings:      warnings,
+			err:           fmt.Errorf("bmr: restore system state: %w", restoreErr),
+			serviceUnits:  serviceUnits,
+		}
+	}
+
+	drivers := 0
 	driverDir := filepath.Join(stagingDir, "drivers")
 	if info, statErr := os.Stat(driverDir); statErr == nil && info.IsDir() {
 		count, dErr := restorer.InjectDrivers(driverDir)
@@ -313,7 +433,85 @@ func applySystemState(ctx context.Context, cfg RecoveryConfig, provider provider
 		drivers = count
 	}
 
-	return applied, drivers, warnings, nil
+	return systemStateResult{
+		applied:       !verificationFailed,
+		drivers:       drivers,
+		warnings:      warnings,
+		manifestFound: true,
+		serviceUnits:  serviceUnits,
+	}
+}
+
+// verifyArtifactIntegrity checks a downloaded system-state artifact against
+// the manifest's recorded size and (when present) sha256 checksum. A
+// missing Checksum (older manifest schema, or a collection-time hashing
+// failure) is NOT an error here — the caller logs an "unverified" warning
+// for that case instead; only an actual mismatch fails the artifact.
+func verifyArtifactIntegrity(localPath string, artifact systemstate.Artifact) error {
+	info, statErr := os.Stat(localPath)
+	if statErr != nil {
+		return fmt.Errorf("stat downloaded artifact: %w", statErr)
+	}
+	if artifact.SizeBytes > 0 && info.Size() != artifact.SizeBytes {
+		return fmt.Errorf("size mismatch: downloaded %d bytes, manifest says %d", info.Size(), artifact.SizeBytes)
+	}
+	if artifact.Checksum == "" {
+		return nil
+	}
+	sum, err := sha256HexFile(localPath)
+	if err != nil {
+		return fmt.Errorf("compute checksum: %w", err)
+	}
+	if !strings.EqualFold(sum, artifact.Checksum) {
+		return fmt.Errorf("checksum mismatch: downloaded %s, manifest says %s", sum, artifact.Checksum)
+	}
+	return nil
+}
+
+func sha256HexFile(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// intersectStrings returns the elements common to both a and b (order
+// follows a), used by the required-step gate above.
+func intersectStrings(a, b []string) []string {
+	set := make(map[string]bool, len(b))
+	for _, s := range b {
+		set[s] = true
+	}
+	var out []string
+	for _, s := range a {
+		if set[s] {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// subtractStrings returns the elements of a not present in b (order follows
+// a), used to separate "incomplete but not required" steps from the
+// required-step gate above.
+func subtractStrings(a, b []string) []string {
+	set := make(map[string]bool, len(b))
+	for _, s := range b {
+		set[s] = true
+	}
+	var out []string
+	for _, s := range a {
+		if !set[s] {
+			out = append(out, s)
+		}
+	}
+	return out
 }
 
 func restoreFiles(

--- a/agent/internal/backup/bmr/bmr.go
+++ b/agent/internal/backup/bmr/bmr.go
@@ -31,12 +31,22 @@ const (
 	maxRecoveryWarnings = 50
 )
 
-// chmodFile and chtimesFile are seams over os.Chmod/os.Chtimes so tests can
-// force deterministic post-restore fidelity failures without depending on
-// filesystem-specific chmod/chtimes error behavior.
+// chmodFile, chtimesFile, and lchownFile are seams over
+// os.Chmod/os.Chtimes/os.Lchown so tests can force deterministic
+// post-restore fidelity failures without depending on filesystem-specific
+// chmod/chtimes/chown error behavior. lchownFile is also used by
+// applyArtifactMetadata (system-state artifacts) — see its doc comment for
+// why ownership is best-effort (EPERM is common when not running as root).
 var (
 	chmodFile   = os.Chmod
 	chtimesFile = os.Chtimes
+	lchownFile  = os.Lchown
+	// symlinkFile is a seam over os.Symlink (used by applySystemState's
+	// symlink-artifact branch) so tests can force a deterministic
+	// symlink-creation failure without depending on filesystem permission
+	// quirks — e.g. a test running as root bypasses the directory-write
+	// check that would otherwise produce the failure.
+	symlinkFile = os.Symlink
 )
 
 // maxConsecutiveDownloadFailures bounds how many per-file restore failures
@@ -381,13 +391,36 @@ func applySystemState(ctx context.Context, cfg RecoveryConfig, provider provider
 		if ctx != nil && ctx.Err() != nil {
 			return systemStateResult{manifestFound: true, warnings: warnings, serviceUnits: enabledSystemdUnitsFromStaging(stagingDir)}
 		}
-		remoteKey := path.Join(snapshotRootDir, cfg.SnapshotID, systemStatePath, artifact.Path)
 		localPath := filepath.Join(stagingDir, artifact.Path)
 		if mkErr := os.MkdirAll(filepath.Dir(localPath), 0o750); mkErr != nil {
 			warnings = append(warnings, fmt.Sprintf("failed to create dir for %s: %s", artifact.Name, mkErr.Error()))
 			verificationFailed = true
 			continue
 		}
+
+		if artifact.LinkTarget != "" {
+			// Symlink artifact (systemstate.Artifact.LinkTarget's doc
+			// comment): no bytes were uploaded for this one — the manifest
+			// entry alone is enough to recreate the link. Never downloaded,
+			// never checksum/size-verified (SizeBytes==0, Checksum=="" by
+			// construction), and no metadata (Mode/UID/GID/ModTime) to
+			// reapply — a symlink has no independent content or POSIX
+			// metadata of its own worth restoring separately from the link
+			// itself.
+			if rmErr := os.Remove(localPath); rmErr != nil && !os.IsNotExist(rmErr) {
+				warnings = append(warnings, fmt.Sprintf("failed to clear existing path before creating symlink %s: %s", artifact.Name, rmErr.Error()))
+				verificationFailed = true
+				continue
+			}
+			if symErr := symlinkFile(artifact.LinkTarget, localPath); symErr != nil {
+				warnings = append(warnings, fmt.Sprintf("failed to create symlink %s -> %s: %s", artifact.Name, artifact.LinkTarget, symErr.Error()))
+				verificationFailed = true
+				continue
+			}
+			continue
+		}
+
+		remoteKey := path.Join(snapshotRootDir, cfg.SnapshotID, systemStatePath, artifact.Path)
 		if dlErr := provider.Download(remoteKey, localPath); dlErr != nil {
 			warnings = append(warnings, fmt.Sprintf("failed to download %s: %s", artifact.Name, dlErr.Error()))
 			verificationFailed = true
@@ -404,6 +437,7 @@ func applySystemState(ctx context.Context, cfg RecoveryConfig, provider provider
 			// failure — accept it best-effort but flag it, per plan §2/B1c.
 			warnings = append(warnings, fmt.Sprintf("artifact %s has no checksum (older manifest schema), unverified", artifact.Name))
 		}
+		warnings = append(warnings, applyArtifactMetadata(localPath, artifact)...)
 	}
 
 	// Capture the Linux enabled-services list from staging BEFORE it's
@@ -468,12 +502,73 @@ func verifyArtifactIntegrity(localPath string, artifact systemstate.Artifact) er
 	return nil
 }
 
+// applyArtifactMetadata reapplies a downloaded regular artifact's staged
+// mode, ownership, and modification time to localPath — best effort,
+// mirroring restoreFiles' post-download fidelity step (chmodFile/
+// chtimesFile) for ordinary backed-up files: a failure here (most commonly
+// EPERM chowning to a uid/gid this process doesn't have privilege for) is
+// recorded as a warning, never folded into verificationFailed, since the
+// artifact's BYTES already downloaded and verified fine — only the
+// metadata reapply failed. Each field is applied only when non-zero (see
+// systemstate.Artifact's Mode/UID/GID/ModTime doc comments: zero means
+// "unavailable at collection time or artifact predates this field", not
+// "explicitly zero"). Never called for a symlink artifact — see the
+// LinkTarget branch in applySystemState's artifact loop, which never
+// reaches this function.
+func applyArtifactMetadata(localPath string, artifact systemstate.Artifact) []string {
+	var warnings []string
+	if artifact.Mode != 0 {
+		if err := chmodFile(localPath, fileModeFromArtifactMode(artifact.Mode)); err != nil {
+			warnings = append(warnings, fmt.Sprintf("could not reapply mode %04o to %s: %s", artifact.Mode, artifact.Name, err.Error()))
+		}
+	}
+	if artifact.UID != 0 || artifact.GID != 0 {
+		if err := lchownFile(localPath, artifact.UID, artifact.GID); err != nil {
+			warnings = append(warnings, fmt.Sprintf("could not reapply ownership %d:%d to %s: %s", artifact.UID, artifact.GID, artifact.Name, err.Error()))
+		}
+	}
+	if !artifact.ModTime.IsZero() {
+		if err := chtimesFile(localPath, artifact.ModTime, artifact.ModTime); err != nil {
+			warnings = append(warnings, fmt.Sprintf("could not reapply mtime to %s: %s", artifact.Name, err.Error()))
+		}
+	}
+	return warnings
+}
+
+// fileModeFromArtifactMode inverts systemstate.modeFromInfo: it converts
+// Artifact.Mode's traditional POSIX st_mode & 07777 encoding (permission
+// bits OR'd with setuid/setgid/sticky at their traditional octal positions
+// 04000/02000/01000) back into a Go os.FileMode with the corresponding
+// os.ModeSetuid/os.ModeSetgid/os.ModeSticky bits set — those live at
+// entirely different bit positions in Go's FileMode than in the raw octal
+// encoding, so a bare cast would silently drop them. Only os.Chmod (via
+// chmodFile) needs this; a raw permission-only cast would restore the file
+// world-writable-safe but silently lose a legitimately staged setuid/setgid
+// bit (e.g. /usr/bin/sudo, ping) on every BMR restore.
+func fileModeFromArtifactMode(raw uint32) os.FileMode {
+	fm := os.FileMode(raw & 0o777)
+	if raw&0o4000 != 0 {
+		fm |= os.ModeSetuid
+	}
+	if raw&0o2000 != 0 {
+		fm |= os.ModeSetgid
+	}
+	if raw&0o1000 != 0 {
+		fm |= os.ModeSticky
+	}
+	return fm
+}
+
 func sha256HexFile(path string) (string, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return "", err
 	}
-	defer f.Close()
+	// Read-only handle: nothing buffered to lose, so a Close failure here
+	// (already-closed fd, or a similarly benign race) is not worth
+	// propagating — discard explicitly rather than leaving it unchecked
+	// (mirrors systemstate.sha256File's identical seam).
+	defer func() { _ = f.Close() }()
 	h := sha256.New()
 	if _, err := io.Copy(h, f); err != nil {
 		return "", err

--- a/agent/internal/backup/bmr/bmr_system_state_test.go
+++ b/agent/internal/backup/bmr/bmr_system_state_test.go
@@ -8,13 +8,30 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/breeze-rmm/agent/internal/backup"
 	"github.com/breeze-rmm/agent/internal/backup/providers"
 	"github.com/breeze-rmm/agent/internal/backup/systemstate"
 )
+
+// countingDownloadProvider wraps a *providers.LocalProvider and counts
+// Download calls, so a test can assert a symlink artifact triggers ZERO
+// downloads (see systemstate.Artifact.LinkTarget's doc comment: the
+// publisher never uploads bytes for a symlink artifact, so a consumer that
+// tried to download one would always fail against real storage).
+type countingDownloadProvider struct {
+	*providers.LocalProvider
+	downloadCalls int
+}
+
+func (p *countingDownloadProvider) Download(remotePath, localPath string) error {
+	p.downloadCalls++
+	return p.LocalProvider.Download(remotePath, localPath)
+}
 
 // fakeStateRestorer is a Restorer double for exercising applySystemState /
 // RunRecoveryContext without shelling out to reg/systemctl/cp on a real OS.
@@ -530,5 +547,265 @@ func TestRunRecoveryContext_ExpectSystemStateTrue_NotApplied_NeverCompleted(t *t
 	// bmrCompleteSchema accepts (completed/failed/partial).
 	if result.Status != "partial" {
 		t.Fatalf("status = %q, want partial (files restored fine, only state failed)", result.Status)
+	}
+}
+
+// --- Symlink artifacts and staged-metadata reapply (W01's LinkTarget/Mode/UID/GID/ModTime) ---
+
+// TestApplySystemState_SymlinkArtifact_NoDownloadCreatesSymlink proves (a)
+// from the symlink-artifact contract: an artifact with LinkTarget set must
+// never be downloaded (the publisher uploads no bytes for it — see
+// systemstate.Artifact.LinkTarget's doc comment) and must be recreated as a
+// real symlink in staging, pointing at the recorded target exactly.
+func TestApplySystemState_SymlinkArtifact_NoDownloadCreatesSymlink(t *testing.T) {
+	baseDir := t.TempDir()
+	base := providers.NewLocalProvider(baseDir)
+	snapshotID := "snap-symlink"
+
+	uploadSystemStateManifest(t, base, snapshotID, systemstate.SystemStateManifest{
+		SchemaVersion: 1,
+		Artifacts: []systemstate.Artifact{
+			{Name: "resolv-conf-link", Category: "config", Path: "etc/resolv.conf", LinkTarget: "/run/systemd/resolve/stub-resolv.conf"},
+		},
+	})
+	provider := &countingDownloadProvider{LocalProvider: base}
+
+	var gotIsSymlink bool
+	var gotTarget string
+	var readlinkErr error
+	restorer := useFakeRestorer(t, &fakeStateRestorer{
+		onRestore: func(stagingDir string) {
+			linkPath := filepath.Join(stagingDir, "etc", "resolv.conf")
+			info, statErr := os.Lstat(linkPath)
+			if statErr != nil {
+				t.Fatalf("lstat staged symlink: %v", statErr)
+			}
+			gotIsSymlink = info.Mode()&os.ModeSymlink != 0
+			gotTarget, readlinkErr = os.Readlink(linkPath)
+		},
+	})
+
+	result := applySystemState(context.Background(), RecoveryConfig{SnapshotID: snapshotID}, provider)
+
+	if result.err != nil {
+		t.Fatalf("unexpected fatal error: %v", result.err)
+	}
+	if !result.applied {
+		t.Fatalf("expected applied=true, warnings: %v", result.warnings)
+	}
+	// Exactly one Download call total: the state manifest.json itself.
+	// Zero of those are for the symlink artifact — the publisher never
+	// uploads bytes for one (see systemstate.Artifact.LinkTarget's doc
+	// comment), so a consumer that tried would always fail against real
+	// storage.
+	if provider.downloadCalls != 1 {
+		t.Fatalf("expected exactly 1 Download call (the manifest only, none for the symlink artifact), got %d", provider.downloadCalls)
+	}
+	if restorer.restoreCalls != 1 {
+		t.Fatalf("expected the restorer to run once, got %d", restorer.restoreCalls)
+	}
+	if !gotIsSymlink {
+		t.Fatal("expected a real symlink to be created in staging, not a regular file")
+	}
+	if readlinkErr != nil {
+		t.Fatalf("readlink staged symlink: %v", readlinkErr)
+	}
+	if gotTarget != "/run/systemd/resolve/stub-resolv.conf" {
+		t.Fatalf("symlink target = %q, want %q", gotTarget, "/run/systemd/resolve/stub-resolv.conf")
+	}
+}
+
+// TestApplySystemState_SymlinkArtifact_CreationFailureCountsAsVerificationFailure
+// proves a symlink that fails to create (e.g. os.Symlink error) blocks
+// `applied` exactly like any other per-artifact failure, rather than being
+// silently ignored.
+func TestApplySystemState_SymlinkArtifact_CreationFailureCountsAsVerificationFailure(t *testing.T) {
+	baseDir := t.TempDir()
+	base := providers.NewLocalProvider(baseDir)
+	snapshotID := "snap-symlink-failure"
+
+	uploadSystemStateManifest(t, base, snapshotID, systemstate.SystemStateManifest{
+		Artifacts: []systemstate.Artifact{
+			{Name: "broken-link", Category: "config", Path: "etc/broken-link", LinkTarget: "/somewhere"},
+		},
+	})
+	provider := &countingDownloadProvider{LocalProvider: base}
+
+	// Force a deterministic symlink-creation failure via the injectable
+	// seam, rather than relying on a filesystem permission quirk that a
+	// root-running test process would bypass.
+	origSymlink := symlinkFile
+	t.Cleanup(func() { symlinkFile = origSymlink })
+	symlinkFile = func(string, string) error { return os.ErrPermission }
+
+	useFakeRestorer(t, &fakeStateRestorer{})
+	result := applySystemState(context.Background(), RecoveryConfig{SnapshotID: snapshotID}, provider)
+
+	if result.applied {
+		t.Fatal("expected applied=false when a symlink artifact fails to create")
+	}
+	found := false
+	for _, w := range result.warnings {
+		if strings.Contains(w, "symlink") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a warning about the failed symlink, got: %v", result.warnings)
+	}
+}
+
+// TestApplySystemState_RegularArtifact_MetadataReapplied proves (b) from
+// the staged-metadata contract: after a regular artifact downloads and
+// verifies successfully, its staged Mode/UID/GID/ModTime must be reapplied
+// to the staging copy (which the Linux restorer then propagates onto
+// /etc — W03).
+func TestApplySystemState_RegularArtifact_MetadataReapplied(t *testing.T) {
+	baseDir := t.TempDir()
+	provider := providers.NewLocalProvider(baseDir)
+	snapshotID := "snap-metadata"
+
+	content := []byte("metadata artifact content")
+	uploadSystemStateArtifact(t, provider, snapshotID, "config/meta.txt", content)
+
+	wantMTime := time.Date(2024, 3, 1, 8, 0, 0, 0, time.UTC)
+	uploadSystemStateManifest(t, provider, snapshotID, systemstate.SystemStateManifest{
+		SchemaVersion: 1,
+		Artifacts: []systemstate.Artifact{
+			{
+				Name: "meta", Category: "config", Path: "config/meta.txt",
+				SizeBytes: int64(len(content)), Checksum: sha256Hex(t, content),
+				Mode: 0o640, UID: 1000, GID: 1000, ModTime: wantMTime,
+			},
+		},
+	})
+
+	type chownCall struct {
+		path     string
+		uid, gid int
+	}
+	var gotChown chownCall
+	origLchown := lchownFile
+	t.Cleanup(func() { lchownFile = origLchown })
+	lchownFile = func(name string, uid, gid int) error {
+		gotChown = chownCall{path: name, uid: uid, gid: gid}
+		return nil
+	}
+
+	var gotMode os.FileMode
+	var gotModTime time.Time
+	useFakeRestorer(t, &fakeStateRestorer{
+		onRestore: func(stagingDir string) {
+			info, statErr := os.Stat(filepath.Join(stagingDir, "config", "meta.txt"))
+			if statErr != nil {
+				t.Fatalf("stat staged artifact: %v", statErr)
+			}
+			gotMode = info.Mode()
+			gotModTime = info.ModTime()
+		},
+	})
+
+	result := applySystemState(context.Background(), RecoveryConfig{SnapshotID: snapshotID}, provider)
+	if result.err != nil {
+		t.Fatalf("unexpected fatal error: %v", result.err)
+	}
+	if !result.applied {
+		t.Fatalf("expected applied=true, warnings: %v", result.warnings)
+	}
+
+	if runtime.GOOS != "windows" {
+		if gotMode.Perm() != 0o640 {
+			t.Errorf("mode = %o, want 0640", gotMode.Perm())
+		}
+	}
+	if !gotModTime.Truncate(time.Second).Equal(wantMTime) {
+		t.Errorf("modTime = %v, want %v", gotModTime, wantMTime)
+	}
+	if !strings.HasSuffix(gotChown.path, filepath.Join("config", "meta.txt")) {
+		t.Errorf("lchown called with path %q, want it to target the staged meta.txt", gotChown.path)
+	}
+	if gotChown.uid != 1000 || gotChown.gid != 1000 {
+		t.Errorf("lchown called with uid=%d gid=%d, want 1000/1000", gotChown.uid, gotChown.gid)
+	}
+}
+
+// TestApplySystemState_ZeroMetadataFields_NotReapplied proves the
+// "only when non-zero" gate: an artifact with no Mode/UID/GID/ModTime (an
+// older pre-metadata capture, or collection-time stat failure) must not
+// invoke chmod/chown/chtimes at all.
+func TestApplySystemState_ZeroMetadataFields_NotReapplied(t *testing.T) {
+	baseDir := t.TempDir()
+	provider := providers.NewLocalProvider(baseDir)
+	snapshotID := "snap-zero-metadata"
+
+	content := []byte("no metadata recorded")
+	uploadSystemStateArtifact(t, provider, snapshotID, "legacy.txt", content)
+	uploadSystemStateManifest(t, provider, snapshotID, systemstate.SystemStateManifest{
+		Artifacts: []systemstate.Artifact{
+			{Name: "legacy", Category: "config", Path: "legacy.txt", SizeBytes: int64(len(content)), Checksum: sha256Hex(t, content)},
+		},
+	})
+
+	chmodCalled, chownCalled, chtimesCalled := false, false, false
+	origChmod, origChtimes, origLchown := chmodFile, chtimesFile, lchownFile
+	t.Cleanup(func() {
+		chmodFile, chtimesFile, lchownFile = origChmod, origChtimes, origLchown
+	})
+	chmodFile = func(string, os.FileMode) error { chmodCalled = true; return nil }
+	chtimesFile = func(string, time.Time, time.Time) error { chtimesCalled = true; return nil }
+	lchownFile = func(string, int, int) error { chownCalled = true; return nil }
+
+	useFakeRestorer(t, &fakeStateRestorer{})
+	result := applySystemState(context.Background(), RecoveryConfig{SnapshotID: snapshotID}, provider)
+
+	if result.err != nil {
+		t.Fatalf("unexpected fatal error: %v", result.err)
+	}
+	if !result.applied {
+		t.Fatalf("expected applied=true, warnings: %v", result.warnings)
+	}
+	if chmodCalled || chownCalled || chtimesCalled {
+		t.Fatalf("expected no metadata reapply calls for zero-value fields: chmod=%v chown=%v chtimes=%v", chmodCalled, chownCalled, chtimesCalled)
+	}
+}
+
+// TestApplySystemState_LchownFailure_WarnsButStillApplied proves ownership
+// reapply is best-effort: an Lchown failure (commonly EPERM when not
+// running as root) must produce a warning but must NOT block `applied` —
+// the artifact's bytes already downloaded and verified fine.
+func TestApplySystemState_LchownFailure_WarnsButStillApplied(t *testing.T) {
+	baseDir := t.TempDir()
+	provider := providers.NewLocalProvider(baseDir)
+	snapshotID := "snap-lchown-eperm"
+
+	content := []byte("owned by someone else")
+	uploadSystemStateArtifact(t, provider, snapshotID, "owned.txt", content)
+	uploadSystemStateManifest(t, provider, snapshotID, systemstate.SystemStateManifest{
+		Artifacts: []systemstate.Artifact{
+			{Name: "owned", Category: "config", Path: "owned.txt", SizeBytes: int64(len(content)), Checksum: sha256Hex(t, content), UID: 1000, GID: 1000},
+		},
+	})
+
+	origLchown := lchownFile
+	t.Cleanup(func() { lchownFile = origLchown })
+	lchownFile = func(string, int, int) error { return os.ErrPermission }
+
+	useFakeRestorer(t, &fakeStateRestorer{})
+	result := applySystemState(context.Background(), RecoveryConfig{SnapshotID: snapshotID}, provider)
+
+	if result.err != nil {
+		t.Fatalf("unexpected fatal error: %v", result.err)
+	}
+	if !result.applied {
+		t.Fatalf("expected applied=true despite the chown failure (best-effort), warnings: %v", result.warnings)
+	}
+	found := false
+	for _, w := range result.warnings {
+		if strings.Contains(w, "ownership") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a warning about the failed ownership reapply, got: %v", result.warnings)
 	}
 }

--- a/agent/internal/backup/bmr/bmr_system_state_test.go
+++ b/agent/internal/backup/bmr/bmr_system_state_test.go
@@ -1,0 +1,534 @@
+package bmr
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/backup"
+	"github.com/breeze-rmm/agent/internal/backup/providers"
+	"github.com/breeze-rmm/agent/internal/backup/systemstate"
+)
+
+// fakeStateRestorer is a Restorer double for exercising applySystemState /
+// RunRecoveryContext without shelling out to reg/systemctl/cp on a real OS.
+// It records the stagingDir it was called with (a live, not-yet-removed
+// directory — RestoreSystemState runs before applySystemState's staging-dir
+// defer fires) so tests can assert on which artifacts actually landed there.
+type fakeStateRestorer struct {
+	restoreErr       error
+	restoreStagingAt string
+	restoreCalls     int
+	injectCount      int
+	injectErr        error
+	// onRestore, if set, runs synchronously inside RestoreSystemState —
+	// i.e. BEFORE applySystemState's `defer os.RemoveAll(stagingDir)`
+	// fires — so tests can inspect which artifacts actually landed in
+	// staging. Checking stagingDir after applySystemState returns is too
+	// late: the directory is already gone by then.
+	onRestore func(stagingDir string)
+}
+
+func (f *fakeStateRestorer) RestoreSystemState(stagingDir string) error {
+	f.restoreCalls++
+	f.restoreStagingAt = stagingDir
+	if f.onRestore != nil {
+		f.onRestore(stagingDir)
+	}
+	return f.restoreErr
+}
+
+func (f *fakeStateRestorer) InjectDrivers(_ string) (int, error) {
+	return f.injectCount, f.injectErr
+}
+
+// useFakeRestorer swaps newRestorerFunc for the duration of the test.
+func useFakeRestorer(t *testing.T, r Restorer) *fakeStateRestorer {
+	t.Helper()
+	orig := newRestorerFunc
+	t.Cleanup(func() { newRestorerFunc = orig })
+	newRestorerFunc = func() Restorer { return r }
+	fr, _ := r.(*fakeStateRestorer)
+	return fr
+}
+
+func sha256Hex(t *testing.T, data []byte) string {
+	t.Helper()
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+// uploadSystemStateManifest uploads a system-state manifest.json for
+// snapshotID to provider (rooted at a LocalProvider), matching the
+// snapshots/<id>/system-state/manifest.json layout applySystemState expects.
+func uploadSystemStateManifest(t *testing.T, provider *providers.LocalProvider, snapshotID string, manifest systemstate.SystemStateManifest) {
+	t.Helper()
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("marshal state manifest: %v", err)
+	}
+	tmp := filepath.Join(t.TempDir(), "manifest.json")
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		t.Fatalf("write state manifest fixture: %v", err)
+	}
+	key := filepath.ToSlash(path.Join("snapshots", snapshotID, "system-state", "manifest.json"))
+	if err := provider.Upload(tmp, key); err != nil {
+		t.Fatalf("upload state manifest: %v", err)
+	}
+}
+
+// uploadSystemStateArtifact uploads artifact content under
+// snapshots/<id>/system-state/<artifact.Path>, matching applySystemState's
+// remote key construction.
+func uploadSystemStateArtifact(t *testing.T, provider *providers.LocalProvider, snapshotID string, artifactPath string, content []byte) {
+	t.Helper()
+	tmp := filepath.Join(t.TempDir(), filepath.Base(artifactPath))
+	if err := os.WriteFile(tmp, content, 0o644); err != nil {
+		t.Fatalf("write artifact fixture: %v", err)
+	}
+	key := filepath.ToSlash(path.Join("snapshots", snapshotID, "system-state", artifactPath))
+	if err := provider.Upload(tmp, key); err != nil {
+		t.Fatalf("upload artifact: %v", err)
+	}
+}
+
+// TestApplySystemState_WrongChecksum_NotAppliedAndArtifactDiscarded proves
+// the checksum-verification fix (plan §2 / campaign finding B1c): an
+// artifact whose downloaded bytes don't match manifest.Artifacts[].Checksum
+// must not be applied — it's discarded from staging before the restorer
+// runs, and the run must not be reported as StateApplied.
+func TestApplySystemState_WrongChecksum_NotAppliedAndArtifactDiscarded(t *testing.T) {
+	baseDir := t.TempDir()
+	provider := providers.NewLocalProvider(baseDir)
+	snapshotID := "snap-checksum-mismatch"
+
+	goodContent := []byte("good artifact bytes")
+	badContent := []byte("bad artifact bytes")
+	uploadSystemStateArtifact(t, provider, snapshotID, "config/good.txt", goodContent)
+	uploadSystemStateArtifact(t, provider, snapshotID, "config/bad.txt", badContent)
+
+	uploadSystemStateManifest(t, provider, snapshotID, systemstate.SystemStateManifest{
+		SchemaVersion: 1,
+		Artifacts: []systemstate.Artifact{
+			{Name: "good", Category: "config", Path: "config/good.txt", SizeBytes: int64(len(goodContent)), Checksum: sha256Hex(t, goodContent)},
+			{Name: "bad", Category: "config", Path: "config/bad.txt", SizeBytes: int64(len(badContent)), Checksum: sha256Hex(t, []byte("not the real content"))},
+		},
+	})
+
+	var goodExisted, badExisted bool
+	restorer := useFakeRestorer(t, &fakeStateRestorer{
+		onRestore: func(stagingDir string) {
+			_, goodErr := os.Stat(filepath.Join(stagingDir, "config", "good.txt"))
+			goodExisted = goodErr == nil
+			_, badErr := os.Stat(filepath.Join(stagingDir, "config", "bad.txt"))
+			badExisted = badErr == nil
+		},
+	})
+
+	result := applySystemState(context.Background(), RecoveryConfig{SnapshotID: snapshotID}, provider)
+
+	if result.err != nil {
+		t.Fatalf("expected no fatal error (best-effort restore), got: %v", result.err)
+	}
+	if result.applied {
+		t.Fatal("expected StateApplied-equivalent (applied) to be false when an artifact fails checksum verification")
+	}
+	if !result.manifestFound {
+		t.Fatal("expected manifestFound to be true")
+	}
+	if restorer.restoreCalls != 1 {
+		t.Fatalf("expected the restorer to still run once (best-effort), got %d calls", restorer.restoreCalls)
+	}
+
+	if !goodExisted {
+		t.Fatal("expected the good artifact to remain staged")
+	}
+	if badExisted {
+		t.Fatal("expected the bad-checksum artifact to be REMOVED from staging before the restorer ran")
+	}
+
+	foundWarning := false
+	for _, w := range result.warnings {
+		if strings.Contains(w, "bad") && strings.Contains(w, "verification") {
+			foundWarning = true
+		}
+	}
+	if !foundWarning {
+		t.Fatalf("expected a warning naming the failed artifact, got: %v", result.warnings)
+	}
+}
+
+// TestApplySystemState_EmptyChecksum_UnverifiedWarningButApplied proves the
+// older-manifest (schemaVersion 0) compatibility path: an artifact with no
+// Checksum must not be treated as a failure — just flagged "unverified" —
+// so pre-D15 manifests still apply.
+func TestApplySystemState_EmptyChecksum_UnverifiedWarningButApplied(t *testing.T) {
+	baseDir := t.TempDir()
+	provider := providers.NewLocalProvider(baseDir)
+	snapshotID := "snap-no-checksum"
+
+	content := []byte("legacy artifact, no checksum recorded")
+	uploadSystemStateArtifact(t, provider, snapshotID, "legacy.txt", content)
+	uploadSystemStateManifest(t, provider, snapshotID, systemstate.SystemStateManifest{
+		SchemaVersion: 0,
+		Artifacts: []systemstate.Artifact{
+			{Name: "legacy", Category: "config", Path: "legacy.txt", SizeBytes: int64(len(content))},
+		},
+	})
+
+	useFakeRestorer(t, &fakeStateRestorer{})
+	result := applySystemState(context.Background(), RecoveryConfig{SnapshotID: snapshotID}, provider)
+
+	if result.err != nil {
+		t.Fatalf("unexpected fatal error: %v", result.err)
+	}
+	if !result.applied {
+		t.Fatalf("expected applied=true (an unverified but present artifact is not a failure), warnings: %v", result.warnings)
+	}
+	found := false
+	for _, w := range result.warnings {
+		if strings.Contains(w, "unverified") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected an 'unverified' warning for the checksum-less artifact, got: %v", result.warnings)
+	}
+}
+
+// TestApplySystemState_SizeMismatch_FailsEvenWithoutChecksum proves
+// SizeBytes is checked independently of Checksum's presence — a truncated
+// or corrupted download must fail verification even against an older
+// manifest that never recorded a checksum.
+func TestApplySystemState_SizeMismatch_FailsEvenWithoutChecksum(t *testing.T) {
+	baseDir := t.TempDir()
+	provider := providers.NewLocalProvider(baseDir)
+	snapshotID := "snap-size-mismatch"
+
+	content := []byte("short")
+	uploadSystemStateArtifact(t, provider, snapshotID, "truncated.txt", content)
+	uploadSystemStateManifest(t, provider, snapshotID, systemstate.SystemStateManifest{
+		Artifacts: []systemstate.Artifact{
+			{Name: "truncated", Category: "config", Path: "truncated.txt", SizeBytes: int64(len(content)) + 100},
+		},
+	})
+
+	useFakeRestorer(t, &fakeStateRestorer{})
+	result := applySystemState(context.Background(), RecoveryConfig{SnapshotID: snapshotID}, provider)
+
+	if result.applied {
+		t.Fatal("expected applied=false on a size mismatch")
+	}
+	found := false
+	for _, w := range result.warnings {
+		if strings.Contains(w, "truncated") && strings.Contains(w, "verification") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a verification-failure warning naming the artifact, got: %v", result.warnings)
+	}
+}
+
+// TestApplySystemState_ManifestWithZeroArtifacts_Applies proves the
+// vacuous-truth case: a manifest with no artifacts at all (nothing to
+// verify) still counts as applied once the restorer succeeds against an
+// empty staging dir.
+func TestApplySystemState_ManifestWithZeroArtifacts_Applies(t *testing.T) {
+	baseDir := t.TempDir()
+	provider := providers.NewLocalProvider(baseDir)
+	snapshotID := "snap-zero-artifacts"
+
+	uploadSystemStateManifest(t, provider, snapshotID, systemstate.SystemStateManifest{
+		SchemaVersion: 1,
+	})
+
+	restorer := useFakeRestorer(t, &fakeStateRestorer{})
+	result := applySystemState(context.Background(), RecoveryConfig{SnapshotID: snapshotID}, provider)
+
+	if result.err != nil {
+		t.Fatalf("unexpected fatal error: %v", result.err)
+	}
+	if !result.applied {
+		t.Fatalf("expected applied=true with zero artifacts and a successful restorer, warnings: %v", result.warnings)
+	}
+	if restorer.restoreCalls != 1 {
+		t.Fatalf("expected the restorer to run once, got %d", restorer.restoreCalls)
+	}
+}
+
+// TestApplySystemState_RequiredStepIncomplete_Fatal proves the
+// required-step gate (plan §2 step 4.2): a required step that never
+// completed must be a fatal error naming it, and must short-circuit BEFORE
+// any artifact is downloaded or the restorer is invoked — an incomplete
+// required capture cannot be partially applied.
+func TestApplySystemState_RequiredStepIncomplete_Fatal(t *testing.T) {
+	baseDir := t.TempDir()
+	provider := providers.NewLocalProvider(baseDir)
+	snapshotID := "snap-required-incomplete"
+
+	uploadSystemStateArtifact(t, provider, snapshotID, "registry_SYSTEM", []byte("hive bytes"))
+	uploadSystemStateManifest(t, provider, snapshotID, systemstate.SystemStateManifest{
+		RequiredSteps:   []string{"registry", "boot"},
+		IncompleteSteps: []string{"registry"},
+		Artifacts: []systemstate.Artifact{
+			{Name: "registry_SYSTEM", Category: "registry", Path: "registry_SYSTEM", SizeBytes: 10, Checksum: sha256Hex(t, []byte("hive bytes"))},
+		},
+	})
+
+	restorer := useFakeRestorer(t, &fakeStateRestorer{})
+	result := applySystemState(context.Background(), RecoveryConfig{SnapshotID: snapshotID}, provider)
+
+	if result.err == nil {
+		t.Fatal("expected a fatal error when a required step is incomplete")
+	}
+	if !strings.Contains(result.err.Error(), "registry") {
+		t.Fatalf("expected the error to name the incomplete required step, got: %v", result.err)
+	}
+	if result.applied {
+		t.Fatal("expected applied=false")
+	}
+	if !result.manifestFound {
+		t.Fatal("expected manifestFound=true (the manifest itself was found and decoded)")
+	}
+	if restorer.restoreCalls != 0 {
+		t.Fatalf("expected the restorer to NEVER run when a required step is incomplete, got %d calls", restorer.restoreCalls)
+	}
+}
+
+// TestApplySystemState_NonRequiredIncomplete_WarnsOnly proves incomplete
+// steps that are NOT in RequiredSteps degrade to a warning, not a fatal
+// error — only the required∩incomplete intersection blocks the run.
+func TestApplySystemState_NonRequiredIncomplete_WarnsOnly(t *testing.T) {
+	baseDir := t.TempDir()
+	provider := providers.NewLocalProvider(baseDir)
+	snapshotID := "snap-nonrequired-incomplete"
+
+	uploadSystemStateManifest(t, provider, snapshotID, systemstate.SystemStateManifest{
+		RequiredSteps:   []string{"registry"},
+		IncompleteSteps: []string{"firewall"},
+	})
+
+	useFakeRestorer(t, &fakeStateRestorer{})
+	result := applySystemState(context.Background(), RecoveryConfig{SnapshotID: snapshotID}, provider)
+
+	if result.err != nil {
+		t.Fatalf("unexpected fatal error for a non-required incomplete step: %v", result.err)
+	}
+	if !result.applied {
+		t.Fatalf("expected applied=true, warnings: %v", result.warnings)
+	}
+	found := false
+	for _, w := range result.warnings {
+		if strings.Contains(w, "firewall") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a warning naming the non-required incomplete step, got: %v", result.warnings)
+	}
+}
+
+// TestApplySystemState_ExpectSystemStateTrue_ManifestMissing_Fatal proves
+// the ExpectSystemState fatal path: when the bootstrap advertised system
+// state for this snapshot but the manifest object itself can't be found,
+// that must be treated as a broken snapshot, not "no state to restore".
+func TestApplySystemState_ExpectSystemStateTrue_ManifestMissing_Fatal(t *testing.T) {
+	baseDir := t.TempDir()
+	provider := providers.NewLocalProvider(baseDir)
+	snapshotID := "snap-missing-manifest"
+	// Deliberately do not upload any system-state/manifest.json.
+
+	useFakeRestorer(t, &fakeStateRestorer{})
+	result := applySystemState(context.Background(), RecoveryConfig{SnapshotID: snapshotID, ExpectSystemState: true}, provider)
+
+	if result.err == nil {
+		t.Fatal("expected a fatal error when ExpectSystemState is true and the manifest is missing")
+	}
+	if !strings.Contains(result.err.Error(), "missing") {
+		t.Fatalf("expected the error to describe the missing manifest, got: %v", result.err)
+	}
+	if result.manifestFound {
+		t.Fatal("expected manifestFound=false (the manifest download itself failed)")
+	}
+	if result.applied {
+		t.Fatal("expected applied=false")
+	}
+}
+
+// TestApplySystemState_ExpectSystemStateFalse_ManifestMissing_Soft proves
+// the existing soft-skip path is preserved when the bootstrap never
+// advertised system state in the first place (an ordinary, non-system-image
+// snapshot) — this must remain a warning, not an error.
+func TestApplySystemState_ExpectSystemStateFalse_ManifestMissing_Soft(t *testing.T) {
+	baseDir := t.TempDir()
+	provider := providers.NewLocalProvider(baseDir)
+	snapshotID := "snap-no-state-expected"
+
+	useFakeRestorer(t, &fakeStateRestorer{})
+	result := applySystemState(context.Background(), RecoveryConfig{SnapshotID: snapshotID, ExpectSystemState: false}, provider)
+
+	if result.err != nil {
+		t.Fatalf("expected no error, got: %v", result.err)
+	}
+	if result.applied {
+		t.Fatal("expected applied=false (nothing to apply)")
+	}
+	if result.manifestFound {
+		t.Fatal("expected manifestFound=false")
+	}
+	found := false
+	for _, w := range result.warnings {
+		if strings.Contains(w, "no system state found") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected the soft-skip warning, got: %v", result.warnings)
+	}
+}
+
+// --- Full-pipeline (RunRecoveryContext) status-derivation tests ---
+
+// buildOrdinaryManifestFixture uploads a minimal one-file ordinary snapshot
+// (manifest.json + its single file object) so RunRecoveryContext's file
+// restore step (independent of system state) always succeeds, isolating
+// these tests to the state-related status derivation.
+func buildOrdinaryManifestFixture(t *testing.T, provider *providers.LocalProvider, snapshotID string) {
+	t.Helper()
+	srcDir := t.TempDir()
+	srcPath := filepath.Join(srcDir, "data.txt")
+	content := []byte("ordinary file content")
+	if err := os.WriteFile(srcPath, content, 0o644); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+	backupPath := filepath.ToSlash(path.Join("snapshots", snapshotID, "files", "data.txt.gz"))
+	if err := provider.Upload(srcPath, backupPath); err != nil {
+		t.Fatalf("upload snapshot file: %v", err)
+	}
+
+	manifest := backup.Snapshot{
+		ID: snapshotID,
+		Files: []backup.SnapshotFile{
+			{SourcePath: filepath.Join(t.TempDir(), "data.txt"), BackupPath: backupPath, Size: int64(len(content))},
+		},
+		Size: int64(len(content)),
+	}
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	manifestFile := filepath.Join(t.TempDir(), "manifest.json")
+	if err := os.WriteFile(manifestFile, data, 0o644); err != nil {
+		t.Fatalf("write manifest fixture: %v", err)
+	}
+	if err := provider.Upload(manifestFile, filepath.ToSlash(path.Join("snapshots", snapshotID, "manifest.json"))); err != nil {
+		t.Fatalf("upload manifest: %v", err)
+	}
+}
+
+// TestRunRecoveryContext_ExpectSystemStateFalse_SoftSkip_StatusUnchanged
+// proves point 3/4 together end to end: when the bootstrap never advertised
+// system state, a missing system-state manifest must not affect the
+// overall status at all — it stays exactly what a files-only recovery would
+// have produced ("completed").
+func TestRunRecoveryContext_ExpectSystemStateFalse_SoftSkip_StatusUnchanged(t *testing.T) {
+	baseDir := t.TempDir()
+	provider := providers.NewLocalProvider(baseDir)
+	snapshotID := "snap-pipeline-no-state"
+	buildOrdinaryManifestFixture(t, provider, snapshotID)
+
+	useFakeRestorer(t, &fakeStateRestorer{})
+
+	result, err := RunRecoveryContext(context.Background(), RecoveryConfig{SnapshotID: snapshotID, ExpectSystemState: false}, provider)
+	if err != nil {
+		t.Fatalf("RunRecoveryContext failed: %v", err)
+	}
+	if result.Status != "completed" {
+		t.Fatalf("status = %q, want completed (soft-skip must not affect status)", result.Status)
+	}
+	if result.StateApplied {
+		t.Fatal("expected StateApplied=false")
+	}
+}
+
+// TestRunRecoveryContext_HappyPath_StateAppliedAndCompleted proves the
+// positive case end to end: a valid system-state manifest with a verified
+// artifact and a successful restorer must produce StateApplied=true and
+// overall status "completed".
+func TestRunRecoveryContext_HappyPath_StateAppliedAndCompleted(t *testing.T) {
+	baseDir := t.TempDir()
+	provider := providers.NewLocalProvider(baseDir)
+	snapshotID := "snap-pipeline-happy"
+	buildOrdinaryManifestFixture(t, provider, snapshotID)
+
+	content := []byte("state artifact bytes")
+	uploadSystemStateArtifact(t, provider, snapshotID, "config/etc.txt", content)
+	uploadSystemStateManifest(t, provider, snapshotID, systemstate.SystemStateManifest{
+		SchemaVersion: 1,
+		Artifacts: []systemstate.Artifact{
+			{Name: "etc", Category: "config", Path: "config/etc.txt", SizeBytes: int64(len(content)), Checksum: sha256Hex(t, content)},
+		},
+	})
+
+	useFakeRestorer(t, &fakeStateRestorer{})
+
+	result, err := RunRecoveryContext(context.Background(), RecoveryConfig{SnapshotID: snapshotID, ExpectSystemState: true}, provider)
+	if err != nil {
+		t.Fatalf("RunRecoveryContext failed: %v", err)
+	}
+	if !result.StateApplied {
+		t.Fatalf("expected StateApplied=true, warnings: %v", result.Warnings)
+	}
+	if result.Status != "completed" {
+		t.Fatalf("status = %q, want completed, warnings: %v", result.Status, result.Warnings)
+	}
+}
+
+// TestRunRecoveryContext_ExpectSystemStateTrue_NotApplied_NeverCompleted
+// proves the status-derivation fix at the pipeline level: whenever the
+// bootstrap expected system state and it was not (fully) applied, the
+// overall status must never be reported as "completed" even though the
+// ordinary file restore succeeded — the API only accepts
+// completed/failed/partial (bmrCompleteSchema,
+// apps/api/src/routes/backup/schemas.ts), so "partial" is the value used
+// here.
+func TestRunRecoveryContext_ExpectSystemStateTrue_NotApplied_NeverCompleted(t *testing.T) {
+	baseDir := t.TempDir()
+	provider := providers.NewLocalProvider(baseDir)
+	snapshotID := "snap-pipeline-expected-but-missing"
+	buildOrdinaryManifestFixture(t, provider, snapshotID)
+	// Deliberately no system-state manifest uploaded, but ExpectSystemState
+	// is true (as if the bootstrap advertised state for this snapshot).
+
+	useFakeRestorer(t, &fakeStateRestorer{})
+
+	// RunRecoveryContext's second (error) return value only ever carries
+	// context-cancellation or the ordinary-manifest download error (see its
+	// step 1) — a system-state failure is surfaced through
+	// RecoveryResult.Status/Warnings instead (mirrors how filesErr is
+	// folded into result.Error rather than returned), so this test asserts
+	// on the result, not on err.
+	result, err := RunRecoveryContext(context.Background(), RecoveryConfig{SnapshotID: snapshotID, ExpectSystemState: true}, provider)
+	if err != nil {
+		t.Fatalf("RunRecoveryContext returned an unexpected top-level error: %v", err)
+	}
+	if result.Status == "completed" {
+		t.Fatalf("status must never be completed when ExpectSystemState was true and state was not applied; got %q", result.Status)
+	}
+	if result.StateApplied {
+		t.Fatal("expected StateApplied=false")
+	}
+	// Files still restored fine, so this should land on "partial", not "failed" —
+	// and "partial" is one of the only three status values the API's
+	// bmrCompleteSchema accepts (completed/failed/partial).
+	if result.Status != "partial" {
+		t.Fatalf("status = %q, want partial (files restored fine, only state failed)", result.Status)
+	}
+}

--- a/agent/internal/backup/bmr/bmr_system_state_test.go
+++ b/agent/internal/backup/bmr/bmr_system_state_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"os"
 	"path"
 	"path/filepath"
@@ -253,11 +254,18 @@ func TestApplySystemState_SizeMismatch_FailsEvenWithoutChecksum(t *testing.T) {
 	}
 }
 
-// TestApplySystemState_ManifestWithZeroArtifacts_Applies proves the
-// vacuous-truth case: a manifest with no artifacts at all (nothing to
-// verify) still counts as applied once the restorer succeeds against an
-// empty staging dir.
-func TestApplySystemState_ManifestWithZeroArtifacts_Applies(t *testing.T) {
+// TestApplySystemState_ManifestWithZeroArtifacts_ExpectSystemStateFalse_SoftPath
+// proves the vacuous-truth case is preserved when the bootstrap never
+// advertised system state for this snapshot: a manifest with no artifacts
+// at all (e.g. one that only recorded a HardwareProfile) still counts as
+// applied once the restorer succeeds against an empty staging dir.
+//
+// This used to be named …_Applies with no ExpectSystemState set at all,
+// which review flagged as asserting the wrong thing once the fatal
+// zero-artifacts gate below was added — that gate only fires when
+// ExpectSystemState is true, and this test's scenario needed to say so
+// explicitly rather than merely default to it.
+func TestApplySystemState_ManifestWithZeroArtifacts_ExpectSystemStateFalse_SoftPath(t *testing.T) {
 	baseDir := t.TempDir()
 	provider := providers.NewLocalProvider(baseDir)
 	snapshotID := "snap-zero-artifacts"
@@ -267,7 +275,7 @@ func TestApplySystemState_ManifestWithZeroArtifacts_Applies(t *testing.T) {
 	})
 
 	restorer := useFakeRestorer(t, &fakeStateRestorer{})
-	result := applySystemState(context.Background(), RecoveryConfig{SnapshotID: snapshotID}, provider)
+	result := applySystemState(context.Background(), RecoveryConfig{SnapshotID: snapshotID, ExpectSystemState: false}, provider)
 
 	if result.err != nil {
 		t.Fatalf("unexpected fatal error: %v", result.err)
@@ -277,6 +285,42 @@ func TestApplySystemState_ManifestWithZeroArtifacts_Applies(t *testing.T) {
 	}
 	if restorer.restoreCalls != 1 {
 		t.Fatalf("expected the restorer to run once, got %d", restorer.restoreCalls)
+	}
+}
+
+// TestApplySystemState_ManifestWithZeroArtifacts_ExpectSystemStateTrue_Fatal
+// proves the flip side (review P1): when the bootstrap DID advertise system
+// state for this snapshot, a manifest that decodes to zero artifacts is a
+// contradiction, not a legitimate empty capture — it must be a fatal error
+// naming the problem, never StateApplied=true, and the restorer must never
+// even run (nothing to apply, and the gate fires before staging is
+// created).
+func TestApplySystemState_ManifestWithZeroArtifacts_ExpectSystemStateTrue_Fatal(t *testing.T) {
+	baseDir := t.TempDir()
+	provider := providers.NewLocalProvider(baseDir)
+	snapshotID := "snap-zero-artifacts-expected"
+
+	uploadSystemStateManifest(t, provider, snapshotID, systemstate.SystemStateManifest{
+		SchemaVersion: 1,
+	})
+
+	restorer := useFakeRestorer(t, &fakeStateRestorer{})
+	result := applySystemState(context.Background(), RecoveryConfig{SnapshotID: snapshotID, ExpectSystemState: true}, provider)
+
+	if result.err == nil {
+		t.Fatal("expected a fatal error when ExpectSystemState=true and the manifest has zero artifacts")
+	}
+	if !strings.Contains(result.err.Error(), "no artifacts") {
+		t.Fatalf("expected the error to mention 'no artifacts', got: %v", result.err)
+	}
+	if result.applied {
+		t.Fatal("expected applied=false")
+	}
+	if !result.manifestFound {
+		t.Fatal("expected manifestFound=true (the manifest itself was found and decoded)")
+	}
+	if restorer.restoreCalls != 0 {
+		t.Fatalf("expected the restorer to NEVER run when the manifest has zero artifacts and state was expected, got %d calls", restorer.restoreCalls)
 	}
 }
 
@@ -807,5 +851,255 @@ func TestApplySystemState_LchownFailure_WarnsButStillApplied(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("expected a warning about the failed ownership reapply, got: %v", result.warnings)
+	}
+}
+
+// --- Review round findings: staging path confinement, partial-download cleanup, size==0, chown/chmod order ---
+
+// partialWriteThenErrorProvider simulates a download that writes some bytes
+// to the destination before the underlying transfer fails (e.g. a
+// connection drop mid-stream) — a realistic shape a naive
+// io.Copy-then-check-err provider implementation can produce.
+type partialWriteThenErrorProvider struct {
+	*providers.LocalProvider
+	failSubstring string
+}
+
+func (p *partialWriteThenErrorProvider) Download(remotePath, localPath string) error {
+	if strings.Contains(remotePath, p.failSubstring) {
+		if err := os.WriteFile(localPath, []byte("PARTIAL-CONTENT-ONLY"), 0o644); err != nil {
+			return err
+		}
+		return errors.New("simulated network failure mid-download")
+	}
+	return p.LocalProvider.Download(remotePath, localPath)
+}
+
+// TestApplySystemState_PathTraversal_RelativeParentEscape_Rejected proves
+// the P1 staging-confinement fix: an artifact Path containing a ".."
+// segment must be rejected before any filesystem write is attempted for
+// it, and must never write a file outside the staging directory.
+func TestApplySystemState_PathTraversal_RelativeParentEscape_Rejected(t *testing.T) {
+	baseDir := t.TempDir()
+	base := providers.NewLocalProvider(baseDir)
+	snapshotID := "snap-traversal-parent"
+
+	content := []byte("malicious content")
+	uploadSystemStateManifest(t, base, snapshotID, systemstate.SystemStateManifest{
+		Artifacts: []systemstate.Artifact{
+			{Name: "escape", Category: "config", Path: "../escape.txt", SizeBytes: int64(len(content)), Checksum: sha256Hex(t, content)},
+		},
+	})
+	provider := &countingDownloadProvider{LocalProvider: base}
+
+	var stagingParent string
+	useFakeRestorer(t, &fakeStateRestorer{
+		onRestore: func(stagingDir string) { stagingParent = filepath.Dir(stagingDir) },
+	})
+
+	result := applySystemState(context.Background(), RecoveryConfig{SnapshotID: snapshotID}, provider)
+
+	if result.applied {
+		t.Fatal("expected applied=false for a path-traversal artifact")
+	}
+	found := false
+	for _, w := range result.warnings {
+		if strings.Contains(w, "escape") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a warning naming the rejected artifact, got: %v", result.warnings)
+	}
+	// Exactly one Download call total: the manifest. Zero attempted for the
+	// rejected artifact.
+	if provider.downloadCalls != 1 {
+		t.Fatalf("expected no download attempt for the rejected artifact, got %d download calls", provider.downloadCalls)
+	}
+	if stagingParent == "" {
+		t.Fatal("onRestore never fired — test fixture broken")
+	}
+	if _, statErr := os.Stat(filepath.Join(stagingParent, "escape.txt")); !os.IsNotExist(statErr) {
+		t.Fatalf("expected no file written outside the staging directory, stat err = %v", statErr)
+	}
+}
+
+// TestApplySystemState_PathTraversal_AbsolutePath_Rejected is the absolute-
+// path half of the same P1 fix.
+func TestApplySystemState_PathTraversal_AbsolutePath_Rejected(t *testing.T) {
+	baseDir := t.TempDir()
+	base := providers.NewLocalProvider(baseDir)
+	snapshotID := "snap-traversal-absolute"
+
+	outsideTarget := filepath.Join(t.TempDir(), "absolute-escape.txt")
+	content := []byte("malicious content")
+	uploadSystemStateManifest(t, base, snapshotID, systemstate.SystemStateManifest{
+		Artifacts: []systemstate.Artifact{
+			{Name: "escape-abs", Category: "config", Path: filepath.ToSlash(outsideTarget), SizeBytes: int64(len(content)), Checksum: sha256Hex(t, content)},
+		},
+	})
+	provider := &countingDownloadProvider{LocalProvider: base}
+
+	useFakeRestorer(t, &fakeStateRestorer{})
+	result := applySystemState(context.Background(), RecoveryConfig{SnapshotID: snapshotID}, provider)
+
+	if result.applied {
+		t.Fatal("expected applied=false for an absolute-path artifact")
+	}
+	found := false
+	for _, w := range result.warnings {
+		if strings.Contains(w, "escape-abs") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a warning naming the rejected artifact, got: %v", result.warnings)
+	}
+	if provider.downloadCalls != 1 {
+		t.Fatalf("expected no download attempt for the rejected artifact, got %d download calls", provider.downloadCalls)
+	}
+	if _, statErr := os.Stat(outsideTarget); !os.IsNotExist(statErr) {
+		t.Fatalf("expected no file written at the absolute target path, stat err = %v", statErr)
+	}
+}
+
+// TestApplySystemState_ArtifactUnderStagedSymlink_Rejected proves the P1
+// symlink-ancestor fix: an artifact staged as a symlink pointing outside
+// the staging directory, followed by a LATER artifact whose Path resolves
+// underneath that symlink, must NOT let the later artifact's content land
+// at the symlink's real target — it must be rejected outright.
+func TestApplySystemState_ArtifactUnderStagedSymlink_Rejected(t *testing.T) {
+	baseDir := t.TempDir()
+	base := providers.NewLocalProvider(baseDir)
+	snapshotID := "snap-symlink-escape"
+	outsideDir := t.TempDir() // sibling temp dir, NOT nested in staging
+
+	content := []byte("should never land outside staging")
+	uploadSystemStateManifest(t, base, snapshotID, systemstate.SystemStateManifest{
+		Artifacts: []systemstate.Artifact{
+			{Name: "linkdir", Category: "config", Path: "linkdir", LinkTarget: outsideDir},
+			{Name: "evil", Category: "config", Path: "linkdir/evil.txt", SizeBytes: int64(len(content)), Checksum: sha256Hex(t, content)},
+		},
+	})
+	provider := &countingDownloadProvider{LocalProvider: base}
+
+	useFakeRestorer(t, &fakeStateRestorer{})
+	result := applySystemState(context.Background(), RecoveryConfig{SnapshotID: snapshotID}, provider)
+
+	if result.applied {
+		t.Fatal("expected applied=false: the second artifact resolves beneath a staged symlink")
+	}
+	found := false
+	for _, w := range result.warnings {
+		if strings.Contains(w, "evil") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a warning naming the rejected artifact, got: %v", result.warnings)
+	}
+	entries, err := os.ReadDir(outsideDir)
+	if err != nil {
+		t.Fatalf("read outside dir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected nothing written outside staging via the symlink, found: %v", entries)
+	}
+	// One download for the manifest; the symlink artifact never downloads
+	// (see the earlier symlink test), and "evil" must be rejected before
+	// any download is attempted for it either.
+	if provider.downloadCalls != 1 {
+		t.Fatalf("expected exactly 1 download call (the manifest only), got %d", provider.downloadCalls)
+	}
+}
+
+// TestApplySystemState_DownloadError_RemovesPartialFile proves the P1 fix:
+// a download that fails after writing partial content must never leave
+// that partial file behind for the restorer to pick up as if it were
+// complete.
+func TestApplySystemState_DownloadError_RemovesPartialFile(t *testing.T) {
+	baseDir := t.TempDir()
+	base := providers.NewLocalProvider(baseDir)
+	snapshotID := "snap-partial-download"
+
+	uploadSystemStateManifest(t, base, snapshotID, systemstate.SystemStateManifest{
+		Artifacts: []systemstate.Artifact{
+			{Name: "flaky", Category: "config", Path: "flaky.txt", SizeBytes: 100, Checksum: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"},
+		},
+	})
+	provider := &partialWriteThenErrorProvider{LocalProvider: base, failSubstring: "flaky.txt"}
+
+	var existedAfterDownload bool
+	useFakeRestorer(t, &fakeStateRestorer{
+		onRestore: func(stagingDir string) {
+			_, statErr := os.Stat(filepath.Join(stagingDir, "flaky.txt"))
+			existedAfterDownload = statErr == nil
+		},
+	})
+
+	result := applySystemState(context.Background(), RecoveryConfig{SnapshotID: snapshotID}, provider)
+
+	if result.applied {
+		t.Fatal("expected applied=false")
+	}
+	if existedAfterDownload {
+		t.Fatal("expected the partially-downloaded file to be removed after a download error, before the restorer runs")
+	}
+}
+
+// TestApplySystemState_ZeroSizeBytes_NonEmptyContent_Fails proves the P2
+// fix: SizeBytes must be compared unconditionally, INCLUDING when it's 0
+// (an artifact asserted to be empty) — previously the `> 0` guard let a
+// corrupted download of a nominally-empty, checksum-less artifact through
+// unverified.
+func TestApplySystemState_ZeroSizeBytes_NonEmptyContent_Fails(t *testing.T) {
+	baseDir := t.TempDir()
+	provider := providers.NewLocalProvider(baseDir)
+	snapshotID := "snap-zero-size-mismatch"
+
+	content := []byte("x")
+	uploadSystemStateArtifact(t, provider, snapshotID, "empty.txt", content)
+	uploadSystemStateManifest(t, provider, snapshotID, systemstate.SystemStateManifest{
+		Artifacts: []systemstate.Artifact{
+			{Name: "empty", Category: "config", Path: "empty.txt", SizeBytes: 0},
+		},
+	})
+
+	useFakeRestorer(t, &fakeStateRestorer{})
+	result := applySystemState(context.Background(), RecoveryConfig{SnapshotID: snapshotID}, provider)
+
+	if result.applied {
+		t.Fatal("expected applied=false when SizeBytes=0 but the downloaded content is non-empty")
+	}
+	found := false
+	for _, w := range result.warnings {
+		if strings.Contains(w, "empty") && strings.Contains(w, "verification") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a verification-failure warning, got: %v", result.warnings)
+	}
+}
+
+// TestApplyArtifactMetadata_LchownRunsBeforeChmod proves the P2 fix:
+// ownership must be reapplied BEFORE mode, because chown(2)/lchown(2)
+// clears setuid/setgid bits on Linux — doing this in the opposite order
+// would silently drop a setuid/setgid bit chmod just applied.
+func TestApplyArtifactMetadata_LchownRunsBeforeChmod(t *testing.T) {
+	var order []string
+	origChmod, origLchown := chmodFile, lchownFile
+	t.Cleanup(func() { chmodFile, lchownFile = origChmod, origLchown })
+	chmodFile = func(string, os.FileMode) error { order = append(order, "chmod"); return nil }
+	lchownFile = func(string, int, int) error { order = append(order, "lchown"); return nil }
+
+	warnings := applyArtifactMetadata("/tmp/does-not-need-to-exist-for-this-unit-test", systemstate.Artifact{
+		Name: "x", Mode: 0o640, UID: 1000, GID: 1000,
+	})
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings: %v", warnings)
+	}
+	if len(order) != 2 || order[0] != "lchown" || order[1] != "chmod" {
+		t.Fatalf("call order = %v, want [lchown chmod] (chown must run before chmod: chown clears setuid/setgid on Linux)", order)
 	}
 }

--- a/agent/internal/backup/bmr/session.go
+++ b/agent/internal/backup/bmr/session.go
@@ -85,12 +85,31 @@ func RunRecoveryWithTokenContext(ctx context.Context, cfg RecoveryConfig) (*Reco
 	if len(effectiveCfg.TargetPaths) == 0 {
 		effectiveCfg.TargetPaths = targetPathsFromConfig(bootstrap.TargetConfig)
 	}
+	if bootstrap.Snapshot != nil {
+		effectiveCfg.ExpectSystemState = hasSystemStateManifest(bootstrap.Snapshot.SystemStateManifest)
+	}
 
 	runResult, runErr := runRecovery(ctx, effectiveCfg, provider)
 	if runResult != nil {
 		result = runResult
 	}
 	return completeAndReturn(runErr)
+}
+
+// hasSystemStateManifest reports whether raw (bootstrap.Snapshot's
+// SystemStateManifest field) represents an actual manifest rather than an
+// absent/null value. json.RawMessage is nil (len 0) when the server omits
+// the field entirely, and literal "null" when the server sends the field
+// with a SQL NULL jsonb column (see recoveryBootstrap.ts /
+// routes/backup/bmr.ts, which both populate this from
+// backup_snapshots.system_state_manifest) — both mean "no system state was
+// captured for this snapshot", not "system state exists".
+func hasSystemStateManifest(raw json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return false
+	}
+	return !bytes.Equal(trimmed, []byte("null"))
 }
 
 func authenticateRecoverySession(serverURL, token string) (*BootstrapResponse, error) {

--- a/agent/internal/backup/bmr/session_test.go
+++ b/agent/internal/backup/bmr/session_test.go
@@ -344,3 +344,131 @@ func TestRunRecoveryWithToken_RewritesUnreachableDescriptorOrigin(t *testing.T) 
 		t.Fatalf("result status = %q, want completed", result.Status)
 	}
 }
+
+// TestHasSystemStateManifest proves the three raw-JSON shapes
+// bootstrap.Snapshot.SystemStateManifest (json.RawMessage) can actually take
+// coming off the wire: absent entirely (nil/empty), an explicit JSON null
+// (a SQL NULL jsonb column decoded by encoding/json), and a real object —
+// only the last one means "this snapshot has system state".
+func TestHasSystemStateManifest(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  json.RawMessage
+		want bool
+	}{
+		{name: "nil", raw: nil, want: false},
+		{name: "empty", raw: json.RawMessage(``), want: false},
+		{name: "whitespace_only", raw: json.RawMessage("   "), want: false},
+		{name: "json_null", raw: json.RawMessage(`null`), want: false},
+		{name: "real_manifest", raw: json.RawMessage(`{"platform":"linux","schemaVersion":1}`), want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasSystemStateManifest(tt.raw); got != tt.want {
+				t.Errorf("hasSystemStateManifest(%q) = %v, want %v", string(tt.raw), got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRunRecoveryWithToken_SetsExpectSystemStateFromBootstrap proves
+// session.go's wiring (RunRecoveryWithTokenContext): the effective
+// RecoveryConfig handed to runRecovery must carry ExpectSystemState=true
+// when the bootstrap's Snapshot.SystemStateManifest is a real (non-null)
+// manifest, so applySystemState (bmr.go) can tell "state was captured for
+// this snapshot" apart from "no state was ever captured" (see
+// RecoveryConfig.ExpectSystemState's doc comment).
+func TestRunRecoveryWithToken_SetsExpectSystemStateFromBootstrap(t *testing.T) {
+	origRunRecovery := runRecovery
+	defer func() { runRecovery = origRunRecovery }()
+
+	var gotExpectSystemState bool
+	runRecovery = func(ctx context.Context, cfg RecoveryConfig, provider providers.BackupProvider) (*RecoveryResult, error) {
+		gotExpectSystemState = cfg.ExpectSystemState
+		return &RecoveryResult{Status: "completed"}, nil
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/backup/bmr/recover/authenticate":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"bootstrap": BootstrapResponse{
+					Version:    BootstrapResponseVersion,
+					TokenID:    "token-1",
+					DeviceID:   "device-1",
+					SnapshotID: "db-snapshot-1",
+					Snapshot: &AuthenticatedSnapshot{
+						ID:                  "snapshot-db-id",
+						SnapshotID:          "provider-snapshot-1",
+						SystemStateManifest: json.RawMessage(`{"platform":"linux","schemaVersion":1}`),
+					},
+					BackupConfig: &AuthenticatedProviderConfig{
+						Provider:       "local",
+						ProviderConfig: map[string]any{"path": t.TempDir()},
+					},
+				},
+			})
+		case "/api/v1/backup/bmr/recover/complete":
+			_ = json.NewEncoder(w).Encode(map[string]any{"restoreJobId": "job-1", "status": "completed"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	if _, err := RunRecoveryWithToken(RecoveryConfig{RecoveryToken: "brz_rec_test", ServerURL: server.URL}); err != nil {
+		t.Fatalf("RunRecoveryWithToken: %v", err)
+	}
+	if !gotExpectSystemState {
+		t.Fatal("expected ExpectSystemState=true when the bootstrap's snapshot carries a real SystemStateManifest")
+	}
+}
+
+// TestRunRecoveryWithToken_ExpectSystemStateFalseWithoutManifest is the
+// negative half of the above: a bootstrap snapshot with no
+// SystemStateManifest at all (an ordinary, non-system-image snapshot) must
+// leave ExpectSystemState false.
+func TestRunRecoveryWithToken_ExpectSystemStateFalseWithoutManifest(t *testing.T) {
+	origRunRecovery := runRecovery
+	defer func() { runRecovery = origRunRecovery }()
+
+	gotExpectSystemState := true // start true so a no-op wiring bug would be caught
+	runRecovery = func(ctx context.Context, cfg RecoveryConfig, provider providers.BackupProvider) (*RecoveryResult, error) {
+		gotExpectSystemState = cfg.ExpectSystemState
+		return &RecoveryResult{Status: "completed"}, nil
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/backup/bmr/recover/authenticate":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"bootstrap": BootstrapResponse{
+					Version:    BootstrapResponseVersion,
+					TokenID:    "token-1",
+					DeviceID:   "device-1",
+					SnapshotID: "db-snapshot-1",
+					Snapshot: &AuthenticatedSnapshot{
+						ID:         "snapshot-db-id",
+						SnapshotID: "provider-snapshot-1",
+					},
+					BackupConfig: &AuthenticatedProviderConfig{
+						Provider:       "local",
+						ProviderConfig: map[string]any{"path": t.TempDir()},
+					},
+				},
+			})
+		case "/api/v1/backup/bmr/recover/complete":
+			_ = json.NewEncoder(w).Encode(map[string]any{"restoreJobId": "job-1", "status": "completed"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	if _, err := RunRecoveryWithToken(RecoveryConfig{RecoveryToken: "brz_rec_test", ServerURL: server.URL}); err != nil {
+		t.Fatalf("RunRecoveryWithToken: %v", err)
+	}
+	if gotExpectSystemState {
+		t.Fatal("expected ExpectSystemState=false when the bootstrap's snapshot has no SystemStateManifest")
+	}
+}

--- a/agent/internal/backup/bmr/types.go
+++ b/agent/internal/backup/bmr/types.go
@@ -12,6 +12,18 @@ type RecoveryConfig struct {
 	SnapshotID    string            `json:"snapshotId"`
 	DeviceID      string            `json:"deviceId"`
 	TargetPaths   map[string]string `json:"targetPaths,omitempty"` // original -> target path overrides
+
+	// ExpectSystemState is derived from the recovery bootstrap payload (see
+	// session.go, RunRecoveryWithTokenContext) rather than set by a caller:
+	// it is true when bootstrap.Snapshot.SystemStateManifest is present and
+	// non-null, i.e. the snapshot's producer captured system state for this
+	// run. applySystemState (bmr.go) uses it to distinguish "this snapshot
+	// never had system state" (fine — the existing soft-skip path) from
+	// "state was advertised but couldn't be downloaded/applied" (fatal).
+	// Before this field existed, both cases looked identical to bmr.go, so a
+	// snapshot advertising system state that failed to download it still
+	// reported StateApplied=false with status "completed" (D15/O10).
+	ExpectSystemState bool `json:"expectSystemState,omitempty"`
 }
 
 type AuthenticatedProviderConfig struct {

--- a/agent/internal/backup/bmr/validate.go
+++ b/agent/internal/backup/bmr/validate.go
@@ -47,8 +47,11 @@ var windowsCriticalServices = []string{
 // serviceUnits is the list of systemd unit names the Linux restorer staged
 // for this run (see applySystemState's enabledSystemdUnitsFromStaging,
 // bmr.go) — ignored on Windows (a fixed critical set is checked instead)
-// and on macOS (no-op probe, see checkServices' default case).
-func Validate(serviceUnits []string) (*ValidationResult, error) {
+// and on macOS (no-op probe, see checkServices' default case). serviceUnitsErr
+// is applySystemState's error (if any) from reading that staged list — see
+// applyServiceValidation's doc comment for why this must fail validation
+// outright rather than being treated the same as "no services staged".
+func Validate(serviceUnits []string, serviceUnitsErr error) (*ValidationResult, error) {
 	result := &ValidationResult{Passed: true}
 
 	// Check network connectivity.
@@ -66,16 +69,7 @@ func Validate(serviceUnits []string) (*ValidationResult, error) {
 	}
 
 	// Check key services.
-	servicesRunning, inactive := checkServices(serviceUnits)
-	result.ServicesRunning = servicesRunning
-	if !servicesRunning {
-		result.Passed = false
-		if len(inactive) > 0 {
-			result.Failures = append(result.Failures, fmt.Sprintf("services not running: %s", strings.Join(inactive, ", ")))
-		} else {
-			result.Failures = append(result.Failures, "one or more critical services are not running")
-		}
-	}
+	applyServiceValidation(result, serviceUnits, serviceUnitsErr)
 
 	slog.Info("bmr: validation complete",
 		"passed", result.Passed,
@@ -165,6 +159,40 @@ func checkServices(serviceUnits []string) (bool, []string) {
 	}
 }
 
+// applyServiceValidation runs the service-health portion of Validate and
+// records the outcome into result. Split out from Validate itself so it can
+// be unit-tested directly, without also exercising Validate's real network
+// dial (checkNetwork) and OS file checks (checkCriticalFiles).
+//
+// serviceUnitsErr, if non-nil, means applySystemState (bmr.go) could not
+// even determine which services this run was supposed to restore — e.g. a
+// permission error reading the staged services/systemd.txt artifact, as
+// opposed to that artifact simply not existing (enabledSystemdUnitsFromStaging
+// maps a not-exist error to (nil, nil), the ordinary "nothing staged"
+// case). That is NOT the same as "no services to check" and must not
+// silently pass validation the way an empty serviceUnits list does —
+// otherwise a corrupted/unreadable service list would validate as if
+// nothing needed restoring at all.
+func applyServiceValidation(result *ValidationResult, serviceUnits []string, serviceUnitsErr error) {
+	if serviceUnitsErr != nil {
+		result.ServicesRunning = false
+		result.Passed = false
+		result.Failures = append(result.Failures, fmt.Sprintf("could not determine restored services: %s", serviceUnitsErr.Error()))
+		return
+	}
+
+	servicesRunning, inactive := checkServices(serviceUnits)
+	result.ServicesRunning = servicesRunning
+	if !servicesRunning {
+		result.Passed = false
+		if len(inactive) > 0 {
+			result.Failures = append(result.Failures, fmt.Sprintf("services not running: %s", strings.Join(inactive, ", ")))
+		} else {
+			result.Failures = append(result.Failures, "one or more critical services are not running")
+		}
+	}
+}
+
 func checkServicesLinux(units []string) (bool, []string) {
 	var inactive []string
 	for _, unit := range units {
@@ -190,20 +218,37 @@ func checkServicesWindows() (bool, []string) {
 	return len(inactive) == 0, inactive
 }
 
+// readServicesArtifact is a seam over os.ReadFile so tests can inject a
+// deterministic non-not-exist read failure (e.g. simulating EACCES)
+// without depending on filesystem permission behavior that a root-running
+// test process would bypass.
+var readServicesArtifact = os.ReadFile
+
 // enabledSystemdUnitsFromStaging reads the staged services/systemd.txt
 // artifact (written by systemstate.LinuxCollector.collectServices as the
 // raw output of `systemctl list-unit-files --type=service`,
 // agent/internal/backup/systemstate/state_linux.go) and returns the unit
 // names whose STATE column reads "enabled" — the same units restore_linux.go
 // (a sibling wave's file, not touched here) enables during
-// RestoreSystemState. Returns nil if the artifact wasn't staged (non-Linux
-// platform, or a capture that skipped the services step).
-func enabledSystemdUnitsFromStaging(stagingDir string) []string {
-	data, err := os.ReadFile(filepath.Join(stagingDir, "services", "systemd.txt"))
+// RestoreSystemState.
+//
+// Returns (nil, nil) if the artifact simply wasn't staged (os.IsNotExist —
+// non-Linux platform, or a capture that skipped the services step): that is
+// the ordinary "nothing to check" case. Any OTHER read error (permission
+// denied, I/O error, ...) is returned as-is rather than being swallowed the
+// same way — the caller (applySystemState, bmr.go) threads it through to
+// Validate's applyServiceValidation, which must fail validation outright
+// rather than silently treating "couldn't tell what to check" the same as
+// "nothing needs checking".
+func enabledSystemdUnitsFromStaging(stagingDir string) ([]string, error) {
+	data, err := readServicesArtifact(filepath.Join(stagingDir, "services", "systemd.txt"))
 	if err != nil {
-		return nil
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read staged services list: %w", err)
 	}
-	return parseSystemdEnabledUnits(data)
+	return parseSystemdEnabledUnits(data), nil
 }
 
 // parseSystemdEnabledUnits extracts unit names from the output of

--- a/agent/internal/backup/bmr/validate.go
+++ b/agent/internal/backup/bmr/validate.go
@@ -1,17 +1,54 @@
 package bmr
 
 import (
+	"fmt"
 	"log/slog"
 	"net"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"runtime"
+	"strings"
 	"time"
 )
 
+// goos defaults to runtime.GOOS; tests override it to exercise a specific
+// platform's checkServices branch without needing to run on that real OS.
+var goos = runtime.GOOS
+
+// runServiceProbeCommand executes an external service-status command
+// (systemctl on Linux, sc on Windows) and returns its combined output. A
+// package-level var — like chmodFile/chtimesFile (bmr.go) and runCommand in
+// sibling wave's restore_linux.go — so tests can substitute a fake instead
+// of shelling out to a real systemctl/sc binary that may not exist (or may
+// behave unpredictably) on the test host.
+var runServiceProbeCommand = func(name string, args ...string) ([]byte, error) {
+	return exec.Command(name, args...).CombinedOutput()
+}
+
+// windowsCriticalServices is the fixed set of Windows service names a BMR
+// validation checks are running. Windows BMR does not (yet) stage a
+// services artifact the way Linux's systemd unit list does (see the plan
+// doc, §3/§5 Wave 3-4), so there is no per-run "units this restore enabled"
+// list to check against — a fixed, always-critical set stands in instead.
+var windowsCriticalServices = []string{
+	"EventLog",
+	"Winmgmt",
+	"LanmanServer",
+	"Dhcp",
+	"Dnscache",
+	"MpsSvc",
+}
+
 // Validate performs post-restore checks to verify the system is in a
-// working state after BMR. It checks network connectivity, critical
-// file existence, and key services.
-func Validate() (*ValidationResult, error) {
+// working state after BMR. It checks network connectivity, critical file
+// existence, and key services.
+//
+// serviceUnits is the list of systemd unit names the Linux restorer staged
+// for this run (see applySystemState's enabledSystemdUnitsFromStaging,
+// bmr.go) — ignored on Windows (a fixed critical set is checked instead)
+// and on macOS (no-op probe, see checkServices' default case).
+func Validate(serviceUnits []string) (*ValidationResult, error) {
 	result := &ValidationResult{Passed: true}
 
 	// Check network connectivity.
@@ -29,10 +66,15 @@ func Validate() (*ValidationResult, error) {
 	}
 
 	// Check key services.
-	result.ServicesRunning = checkServices()
-	if !result.ServicesRunning {
+	servicesRunning, inactive := checkServices(serviceUnits)
+	result.ServicesRunning = servicesRunning
+	if !servicesRunning {
 		result.Passed = false
-		result.Failures = append(result.Failures, "one or more critical services are not running")
+		if len(inactive) > 0 {
+			result.Failures = append(result.Failures, fmt.Sprintf("services not running: %s", strings.Join(inactive, ", ")))
+		} else {
+			result.Failures = append(result.Failures, "one or more critical services are not running")
+		}
 	}
 
 	slog.Info("bmr: validation complete",
@@ -93,10 +135,99 @@ func checkCriticalFiles() bool {
 	return allPresent
 }
 
-// checkServices is a stub that returns true. Platform-specific service
-// checks (e.g., sc query on Windows, launchctl on macOS, systemctl on
-// Linux) can be added in the future.
-func checkServices() bool {
-	// TODO: implement platform-specific service health checks
-	return true
+// checkServices probes whether critical services are active, dispatched by
+// platform (via the overridable `goos` var, not runtime.GOOS directly, so
+// tests can exercise every branch from one dev machine):
+//
+//   - linux: `systemctl is-active <unit>` for each of serviceUnits — the
+//     units this run's Linux restorer staged (see Validate's doc comment).
+//     No known units (serviceUnits empty — e.g. no services/systemd.txt was
+//     staged, an older/partial capture) trivially passes: this run never
+//     claimed to restore any services, so there is nothing to fail on.
+//   - windows: `sc query <name>` over windowsCriticalServices, regardless
+//     of serviceUnits (Windows BMR has no per-run service list yet).
+//   - darwin (and anything else): no-op, always passes — matches
+//     restore_darwin.go, which has no service-restore step to validate.
+//
+// Returns (allRunning, namesThatFailed) so Validate can name the specific
+// services in ValidationResult.Failures instead of the old always-true stub's
+// unconditional pass (validate.go's checkServices could never drag
+// ValidationResult.Passed down — a stopped service after BMR was invisible
+// to validation, campaign finding B1b).
+func checkServices(serviceUnits []string) (bool, []string) {
+	switch goos {
+	case "linux":
+		return checkServicesLinux(serviceUnits)
+	case "windows":
+		return checkServicesWindows()
+	default:
+		return true, nil
+	}
+}
+
+func checkServicesLinux(units []string) (bool, []string) {
+	var inactive []string
+	for _, unit := range units {
+		out, err := runServiceProbeCommand("systemctl", "is-active", unit)
+		state := strings.TrimSpace(string(out))
+		if err != nil || state != "active" {
+			inactive = append(inactive, unit)
+			slog.Warn("bmr: service not active", "unit", unit, "state", state)
+		}
+	}
+	return len(inactive) == 0, inactive
+}
+
+func checkServicesWindows() (bool, []string) {
+	var inactive []string
+	for _, svc := range windowsCriticalServices {
+		out, err := runServiceProbeCommand("sc", "query", svc)
+		if err != nil || !strings.Contains(strings.ToUpper(string(out)), "RUNNING") {
+			inactive = append(inactive, svc)
+			slog.Warn("bmr: service not running", "service", svc)
+		}
+	}
+	return len(inactive) == 0, inactive
+}
+
+// enabledSystemdUnitsFromStaging reads the staged services/systemd.txt
+// artifact (written by systemstate.LinuxCollector.collectServices as the
+// raw output of `systemctl list-unit-files --type=service`,
+// agent/internal/backup/systemstate/state_linux.go) and returns the unit
+// names whose STATE column reads "enabled" — the same units restore_linux.go
+// (a sibling wave's file, not touched here) enables during
+// RestoreSystemState. Returns nil if the artifact wasn't staged (non-Linux
+// platform, or a capture that skipped the services step).
+func enabledSystemdUnitsFromStaging(stagingDir string) []string {
+	data, err := os.ReadFile(filepath.Join(stagingDir, "services", "systemd.txt"))
+	if err != nil {
+		return nil
+	}
+	return parseSystemdEnabledUnits(data)
+}
+
+// parseSystemdEnabledUnits extracts unit names from the output of
+// `systemctl list-unit-files --type=service`, keeping only units whose
+// STATE column reads exactly "enabled".
+//
+// KNOWN DUPLICATION (intentional, see the plan doc's Wave 2 file list and
+// Wave 5's reconciliation note): a sibling wave's restore_linux_logic.go
+// independently adds a same-purpose `parseEnabledServices` helper to drive
+// the actual service-restore step. This package cannot import or reuse that
+// helper here without editing restore_linux.go, which is out of scope for
+// this change (owned by that wave). The two parsers must be kept in sync on
+// the parsing rule (STATE column == "enabled") until a follow-up
+// consolidates them into one shared helper.
+func parseSystemdEnabledUnits(data []byte) []string {
+	var units []string
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		if fields[1] == "enabled" {
+			units = append(units, fields[0])
+		}
+	}
+	return units
 }

--- a/agent/internal/backup/bmr/validate_test.go
+++ b/agent/internal/backup/bmr/validate_test.go
@@ -167,10 +167,14 @@ func TestParseSystemdEnabledUnits(t *testing.T) {
 
 // TestEnabledSystemdUnitsFromStaging_MissingArtifactReturnsNil proves the
 // non-Linux / older-capture case: no services/systemd.txt in staging simply
-// yields nil, not an error.
+// yields (nil, nil), not an error.
 func TestEnabledSystemdUnitsFromStaging_MissingArtifactReturnsNil(t *testing.T) {
 	stagingDir := t.TempDir()
-	if got := enabledSystemdUnitsFromStaging(stagingDir); got != nil {
+	got, err := enabledSystemdUnitsFromStaging(stagingDir)
+	if err != nil {
+		t.Fatalf("expected no error for a missing (not-exist) artifact, got: %v", err)
+	}
+	if got != nil {
 		t.Fatalf("expected nil for a staging dir with no services artifact, got %v", got)
 	}
 }
@@ -188,8 +192,76 @@ func TestEnabledSystemdUnitsFromStaging_ReadsStagedArtifact(t *testing.T) {
 		t.Fatalf("write fixture: %v", err)
 	}
 
-	got := enabledSystemdUnitsFromStaging(stagingDir)
+	got, err := enabledSystemdUnitsFromStaging(stagingDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if len(got) != 1 || got[0] != "cron.service" {
 		t.Fatalf("got %v, want [cron.service]", got)
+	}
+}
+
+// TestEnabledSystemdUnitsFromStaging_OtherReadError_Propagates proves the
+// P2 fix: a non-not-exist read failure (e.g. permission denied) must
+// propagate as an error, not be silently treated the same as "no services
+// artifact staged" — see enabledSystemdUnitsFromStaging's doc comment.
+func TestEnabledSystemdUnitsFromStaging_OtherReadError_Propagates(t *testing.T) {
+	orig := readServicesArtifact
+	t.Cleanup(func() { readServicesArtifact = orig })
+	injected := errors.New("simulated permission denied")
+	readServicesArtifact = func(string) ([]byte, error) { return nil, injected }
+
+	units, err := enabledSystemdUnitsFromStaging(t.TempDir())
+	if err == nil {
+		t.Fatal("expected a non-nil error for a non-not-exist read failure")
+	}
+	if !errors.Is(err, injected) {
+		t.Fatalf("expected the injected error to be wrapped/propagated, got: %v", err)
+	}
+	if units != nil {
+		t.Fatalf("expected nil units on error, got %v", units)
+	}
+}
+
+// TestApplyServiceValidation_EnumerationError_FailsValidation proves the
+// other half of the P2 fix: applyServiceValidation (the piece of Validate
+// that checks services) must turn a non-nil serviceUnitsErr into a failed,
+// not-passed result — never silently checking zero services and passing,
+// which is what would happen if the error were dropped upstream.
+func TestApplyServiceValidation_EnumerationError_FailsValidation(t *testing.T) {
+	result := &ValidationResult{Passed: true}
+	applyServiceValidation(result, nil, errors.New("permission denied reading services/systemd.txt"))
+
+	if result.Passed {
+		t.Fatal("expected Passed=false when service enumeration failed")
+	}
+	if result.ServicesRunning {
+		t.Fatal("expected ServicesRunning=false when service enumeration failed")
+	}
+	found := false
+	for _, f := range result.Failures {
+		if strings.Contains(f, "permission denied") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a failure message recording the enumeration error, got: %v", result.Failures)
+	}
+}
+
+// TestApplyServiceValidation_NoErrorFallsThroughToCheckServices proves
+// applyServiceValidation's normal (nil-error) path is unaffected: it still
+// dispatches to checkServices exactly as before.
+func TestApplyServiceValidation_NoErrorFallsThroughToCheckServices(t *testing.T) {
+	withGOOS(t, "linux")
+	withServiceProbeCommand(t, func(name string, args ...string) ([]byte, error) {
+		return []byte("active\n"), nil
+	})
+
+	result := &ValidationResult{Passed: true}
+	applyServiceValidation(result, []string{"cron"}, nil)
+
+	if !result.Passed || !result.ServicesRunning {
+		t.Fatalf("expected Passed=true, ServicesRunning=true, got Passed=%v ServicesRunning=%v Failures=%v", result.Passed, result.ServicesRunning, result.Failures)
 	}
 }

--- a/agent/internal/backup/bmr/validate_test.go
+++ b/agent/internal/backup/bmr/validate_test.go
@@ -1,0 +1,195 @@
+package bmr
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// withGOOS overrides the package-level goos var (validate.go) for the
+// duration of the test, so checkServices' platform dispatch can be
+// exercised deterministically regardless of the actual test host OS.
+func withGOOS(t *testing.T, value string) {
+	t.Helper()
+	orig := goos
+	t.Cleanup(func() { goos = orig })
+	goos = value
+}
+
+// withServiceProbeCommand overrides runServiceProbeCommand for the
+// duration of the test so checkServicesLinux/checkServicesWindows never
+// shell out to a real systemctl/sc binary.
+func withServiceProbeCommand(t *testing.T, fn func(name string, args ...string) ([]byte, error)) {
+	t.Helper()
+	orig := runServiceProbeCommand
+	t.Cleanup(func() { runServiceProbeCommand = orig })
+	runServiceProbeCommand = fn
+}
+
+// TestCheckServicesLinux_InactiveUnitFailsAndIsNamed proves the Linux
+// service probe (validate.go checkServicesLinux, replacing the old
+// unconditional-true stub, campaign finding B1b): a unit the probe finds
+// NOT active must fail validation and be named in the result.
+func TestCheckServicesLinux_InactiveUnitFailsAndIsNamed(t *testing.T) {
+	withGOOS(t, "linux")
+	withServiceProbeCommand(t, func(name string, args ...string) ([]byte, error) {
+		if name != "systemctl" || len(args) != 2 || args[0] != "is-active" {
+			t.Fatalf("unexpected command: %s %v", name, args)
+		}
+		unit := args[1]
+		if unit == "sshd" {
+			return []byte("inactive\n"), errors.New("exit status 3")
+		}
+		return []byte("active\n"), nil
+	})
+
+	ok, inactive := checkServices([]string{"cron", "sshd", "networking"})
+	if ok {
+		t.Fatal("expected checkServices to report failure when one unit is inactive")
+	}
+	if len(inactive) != 1 || inactive[0] != "sshd" {
+		t.Fatalf("inactive = %v, want exactly [sshd]", inactive)
+	}
+}
+
+// TestCheckServicesLinux_AllActivePasses is the positive counterpart: every
+// unit reporting active must pass with no names returned.
+func TestCheckServicesLinux_AllActivePasses(t *testing.T) {
+	withGOOS(t, "linux")
+	withServiceProbeCommand(t, func(name string, args ...string) ([]byte, error) {
+		return []byte("active\n"), nil
+	})
+
+	ok, inactive := checkServices([]string{"cron", "sshd"})
+	if !ok {
+		t.Fatalf("expected checkServices to pass, inactive = %v", inactive)
+	}
+	if len(inactive) != 0 {
+		t.Fatalf("expected no inactive services, got %v", inactive)
+	}
+}
+
+// TestCheckServicesLinux_NoKnownUnitsTriviallyPasses proves that an empty
+// serviceUnits list (no services/systemd.txt was staged — e.g. an
+// older/partial capture) does not fail validation: this run never claimed
+// to restore any services, so there is nothing to check.
+func TestCheckServicesLinux_NoKnownUnitsTriviallyPasses(t *testing.T) {
+	withGOOS(t, "linux")
+	called := false
+	withServiceProbeCommand(t, func(name string, args ...string) ([]byte, error) {
+		called = true
+		return nil, nil
+	})
+
+	ok, inactive := checkServices(nil)
+	if !ok || len(inactive) != 0 {
+		t.Fatalf("expected trivial pass for no known units, got ok=%v inactive=%v", ok, inactive)
+	}
+	if called {
+		t.Fatal("expected no probe command to run with zero known units")
+	}
+}
+
+// TestCheckServicesWindows_InactiveServiceFailsAndIsNamed proves the
+// Windows probe checks a fixed critical set via `sc query`, independent of
+// serviceUnits.
+func TestCheckServicesWindows_InactiveServiceFailsAndIsNamed(t *testing.T) {
+	withGOOS(t, "windows")
+	withServiceProbeCommand(t, func(name string, args ...string) ([]byte, error) {
+		if name != "sc" || len(args) != 2 || args[0] != "query" {
+			t.Fatalf("unexpected command: %s %v", name, args)
+		}
+		svc := args[1]
+		if svc == "Dnscache" {
+			return []byte("STATE: 1 STOPPED"), nil
+		}
+		return []byte("STATE: 4 RUNNING"), nil
+	})
+
+	ok, inactive := checkServices(nil) // serviceUnits ignored on Windows
+	if ok {
+		t.Fatal("expected checkServices to fail when a critical Windows service is stopped")
+	}
+	if len(inactive) != 1 || inactive[0] != "Dnscache" {
+		t.Fatalf("inactive = %v, want exactly [Dnscache]", inactive)
+	}
+}
+
+// TestCheckServicesDarwin_AlwaysPasses proves the macOS branch is a no-op —
+// there is no per-run service-restore step to validate on darwin (see
+// restore_darwin.go).
+func TestCheckServicesDarwin_AlwaysPasses(t *testing.T) {
+	withGOOS(t, "darwin")
+	called := false
+	withServiceProbeCommand(t, func(name string, args ...string) ([]byte, error) {
+		called = true
+		return nil, nil
+	})
+
+	ok, inactive := checkServices([]string{"anything"})
+	if !ok || len(inactive) != 0 {
+		t.Fatalf("expected darwin to always pass, got ok=%v inactive=%v", ok, inactive)
+	}
+	if called {
+		t.Fatal("expected no probe command to run on darwin")
+	}
+}
+
+// TestParseSystemdEnabledUnits proves the parser matches the real
+// `systemctl list-unit-files --type=service` output shape the producer
+// writes to services/systemd.txt (systemstate/state_linux.go
+// collectServices) — keeping only units whose STATE column is exactly
+// "enabled", skipping the header and footer lines.
+func TestParseSystemdEnabledUnits(t *testing.T) {
+	data := []byte(strings.Join([]string{
+		"UNIT FILE                              STATE",
+		"cron.service                           enabled",
+		"sshd.service                           enabled",
+		"bluetooth.service                      disabled",
+		"getty@.service                         static",
+		"",
+		"4 unit files listed.",
+	}, "\n"))
+
+	got := parseSystemdEnabledUnits(data)
+	want := []string{"cron.service", "sshd.service"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	}
+}
+
+// TestEnabledSystemdUnitsFromStaging_MissingArtifactReturnsNil proves the
+// non-Linux / older-capture case: no services/systemd.txt in staging simply
+// yields nil, not an error.
+func TestEnabledSystemdUnitsFromStaging_MissingArtifactReturnsNil(t *testing.T) {
+	stagingDir := t.TempDir()
+	if got := enabledSystemdUnitsFromStaging(stagingDir); got != nil {
+		t.Fatalf("expected nil for a staging dir with no services artifact, got %v", got)
+	}
+}
+
+// TestEnabledSystemdUnitsFromStaging_ReadsStagedArtifact proves the
+// staging-dir lookup path end to end.
+func TestEnabledSystemdUnitsFromStaging_ReadsStagedArtifact(t *testing.T) {
+	stagingDir := t.TempDir()
+	servicesDir := filepath.Join(stagingDir, "services")
+	if err := os.MkdirAll(servicesDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	content := "UNIT FILE          STATE\ncron.service       enabled\nbluetooth.service  disabled\n"
+	if err := os.WriteFile(filepath.Join(servicesDir, "systemd.txt"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	got := enabledSystemdUnitsFromStaging(stagingDir)
+	if len(got) != 1 || got[0] != "cron.service" {
+		t.Fatalf("got %v, want [cron.service]", got)
+	}
+}


### PR DESCRIPTION
Wave 2 of #5439 (bare-metal recovery system-state contract, campaign defect D15). Consumer side of the contract W01 (#5445) produces.

Closes #5441

## What (`agent/internal/backup/bmr/`)
- **Checksum + size verification** of every downloaded system-state artifact against the manifest (`checksum` sha256, `sizeBytes`, size enforced even when 0). Mismatch or a failed download removes the local file and fails verification. Manifests without checksums (schemaVersion 0) log an "unverified" warning.
- **Required steps**: `requiredSteps ∩ incompleteSteps` non-empty is fatal; other incomplete steps become warnings.
- **`RecoveryConfig.ExpectSystemState`**, set from the bootstrap payload's `systemStateManifest`. A snapshot that advertises state but has no `system-state/manifest.json`, or a manifest with zero artifacts, now fails instead of reporting `completed`. Without the advertisement the soft path is unchanged.
- **Status derivation**: `stateApplied` is true only when the manifest was fetched, every artifact verified, and the restorer returned nil. Expected-but-unapplied state yields `partial`/`failed` (existing `bmrCompleteSchema` vocabulary), never `completed`.
- **Staging materialisation**: symlink artifacts (`linkTarget`) are recreated without download; regular artifacts get uid/gid (best-effort, before chmod so setuid/setgid survive), mode, and mtime reapplied. Artifact paths are treated as untrusted: absolute, `..`, and paths under an earlier staged symlink are rejected; a resolved-ancestor check backs the lexical one.
- **Service probe** (`validate.go`): `systemctl is-active` over the enabled units the collector recorded (Linux), `sc query` over a fixed critical set (Windows), no-op on macOS. Unreadable service lists propagate as validation failures instead of an empty pass.

## Tests
75 tests in the package (was ~30): fake provider + per-OS restorer fakes cover wrong checksum, partial download, zero artifacts with/without expectation, required-step gate, path escapes, symlink/metadata reapply order, service probe parsing and read errors. gofmt/vet/build clean on darwin, linux, windows; golangci-lint new-issues 0.

Reviewed: Codex medium round (6 findings, all fixed with red-first tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sufm7gYXhWknkCbT9Fz9Nu