### PR TITLE
fix(ci): signing jobs depend on release lineage validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -544,7 +544,10 @@ jobs:
       github.ref_type == 'tag'
       && startsWith(github.ref, 'refs/tags/v')
     runs-on: macos-latest
-    needs: [build-agent]
+    # validate-release-lineage: this job codesigns/notarizes with the Apple
+    # secrets — it must not run against a tag whose lineage hasn't been
+    # validated yet.
+    needs: [build-agent, validate-release-lineage]
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -994,6 +997,12 @@ jobs:
     if: >-
       github.ref_type == 'tag'
       && startsWith(github.ref, 'refs/tags/v')
+    # validate-release-lineage: this job signs the Tauri updater bundle with
+    # TAURI_SIGNING_PRIVATE_KEY — it must not run against a tag whose
+    # lineage hasn't been validated yet. sign-windows-tauri-{azure,sslcom}
+    # (which Authenticode-sign the MSI this job produces) already depend on
+    # build-viewer, so they inherit this transitively.
+    needs: [validate-release-lineage]
     strategy:
       fail-fast: false
       matrix:
@@ -1276,6 +1285,10 @@ jobs:
       github.ref_type == 'tag'
       && startsWith(github.ref, 'refs/tags/v')
     runs-on: macos-latest
+    # validate-release-lineage: this job codesigns (TAURI_SIGNING_PRIVATE_KEY
+    # + Apple signing identity) and notarizes the DMG — it must not run
+    # against a tag whose lineage hasn't been validated yet.
+    needs: [validate-release-lineage]
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -1413,6 +1426,10 @@ jobs:
       github.ref_type == 'tag'
       && startsWith(github.ref, 'refs/tags/v')
     runs-on: macos-latest
+    # validate-release-lineage: this job codesigns (Apple signing identity)
+    # and notarizes the DMG — it must not run against a tag whose lineage
+    # hasn't been validated yet.
+    needs: [validate-release-lineage]
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7


### PR DESCRIPTION
## Summary

`.github/workflows/release.yml` has a `validate-release-lineage` job that confirms a release tag corresponds to a real, authorized commit on `main` before the release proceeds. However, several of the jobs that actually codesign, notarize, or Authenticode-sign release artifacts had no `needs:` dependency on it, so they could start (and consume signing secrets/certificates) before lineage had been validated. Only the final `create-release` job was gated on lineage — the signing work upstream of it was not.

This PR adds `validate-release-lineage` to the `needs:` of the four signing jobs that had no path to it, so every signing/notarizing job in the workflow now depends on lineage validation, directly or transitively. No other workflow structure changes.

## Signing jobs updated

| Job | What it signs | `needs:` before | `needs:` after |
|---|---|---|---|
| `build-macos-agent` | codesigns + notarizes the agent/backup/watchdog/desktop-helper Mach-O binaries and `.pkg` installers (Apple secrets) | `[build-agent]` | `[build-agent, validate-release-lineage]` (direct) |
| `build-viewer` | Tauri build signs the updater bundle with `TAURI_SIGNING_PRIVATE_KEY` | *(none)* | `[validate-release-lineage]` (direct) |
| `build-viewer-macos` | Tauri build signs with `TAURI_SIGNING_PRIVATE_KEY` + Apple signing identity, then notarizes/staples the DMG | *(none)* | `[validate-release-lineage]` (direct) |
| `build-helper-macos` | Apple signing identity in the Tauri build, then notarizes/staples the DMG | *(none)* | `[validate-release-lineage]` (direct) |

The following signing jobs already had a `needs:` edge into one of the four jobs above, so they now reach `validate-release-lineage` **transitively** and needed no direct edit:

| Job | Reaches lineage via |
|---|---|
| `build-macos-installer-app` | `build-macos-agent` |
| `sign-windows-tauri-azure` | `build-viewer` |
| `sign-windows-tauri-sslcom` | `build-viewer` |
| `package-windows-updater` | `sign-windows-tauri` → `sign-windows-tauri-azure` |

Jobs that matched the `sign|notar|APPLE_|WINDOWS_CERT|TAURI_SIGNING` grep but were **not** treated as signing jobs, with the reason: `build-agent` and `build-windows-unsigned` only run a malware threat-*signature* scanner (`check-agent-binary-signatures.sh`, unrelated to code signing) and `build-windows-unsigned` explicitly ships unsigned binaries; `build-helper` (the Windows/Linux leg) sets `TAURI_SIGNING_PRIVATE_KEY: ''` so Tauri signing is deliberately disabled there (its MSI is signed later by `sign-windows-tauri-{azure,sslcom}`); `resolve-windows-signing-provider` only resolves a provider name; `sign-windows-tauri` is a convergence gate that asserts on results without signing anything itself; `release-integrity-gate` and `create-release` only check job results / assemble already-signed artifacts.

## Verification

A small script computes each job's transitive `needs:` closure from the workflow YAML and asserts every signing job's closure contains `validate-release-lineage`.

**Before (on the unmodified file):**
```
Checking 8 signing jobs for a needs-closure path to 'validate-release-lineage' in .github/workflows/release.yml

  FAIL  build-macos-agent            does NOT reach validate-release-lineage — needs=['build-agent'], closure=['build-agent']
  FAIL  build-macos-installer-app    does NOT reach validate-release-lineage — needs=['build-macos-agent'], closure=['build-agent', 'build-macos-agent']
  FAIL  build-viewer                 does NOT reach validate-release-lineage — needs=[], closure=[]
  FAIL  build-viewer-macos           does NOT reach validate-release-lineage — needs=[], closure=[]
  FAIL  build-helper-macos           does NOT reach validate-release-lineage — needs=[], closure=[]
  FAIL  sign-windows-tauri-azure     does NOT reach validate-release-lineage — needs=['build-viewer', 'build-helper', 'resolve-windows-signing-provider'], closure=['build-helper', 'build-viewer', 'resolve-windows-signing-provider']
  FAIL  sign-windows-tauri-sslcom    does NOT reach validate-release-lineage — needs=['build-viewer', 'build-helper', 'resolve-windows-signing-provider'], closure=['build-helper', 'build-viewer', 'resolve-windows-signing-provider']
  FAIL  package-windows-updater      does NOT reach validate-release-lineage — needs=['sign-windows-tauri'], closure=['build-helper', 'build-viewer', 'resolve-windows-signing-provider', 'sign-windows-tauri', 'sign-windows-tauri-azure', 'sign-windows-tauri-sslcom']

RESULT: at least one signing job can run without validate-release-lineage having succeeded first.
```

**After (this PR's file):**
```
Checking 8 signing jobs for a needs-closure path to 'validate-release-lineage' in .github/workflows/release.yml

  PASS  build-macos-agent            reaches validate-release-lineage (direct) via needs=['build-agent', 'validate-release-lineage']
  PASS  build-macos-installer-app    reaches validate-release-lineage (transitive) via needs=['build-macos-agent']
  PASS  build-viewer                 reaches validate-release-lineage (direct) via needs=['validate-release-lineage']
  PASS  build-viewer-macos           reaches validate-release-lineage (direct) via needs=['validate-release-lineage']
  PASS  build-helper-macos           reaches validate-release-lineage (direct) via needs=['validate-release-lineage']
  PASS  sign-windows-tauri-azure     reaches validate-release-lineage (transitive) via needs=['build-viewer', 'build-helper', 'resolve-windows-signing-provider']
  PASS  sign-windows-tauri-sslcom    reaches validate-release-lineage (transitive) via needs=['build-viewer', 'build-helper', 'resolve-windows-signing-provider']
  PASS  package-windows-updater      reaches validate-release-lineage (transitive) via needs=['sign-windows-tauri']

RESULT: all signing jobs reach validate-release-lineage. OK.
```

Also ran `actionlint` against both the original and modified file: the same 11 pre-existing shellcheck warnings appear in both (only their line numbers shift, from the added `needs:`/comment lines) — no new findings, and no job-graph errors. `python3 -c "import yaml; yaml.safe_load(...)"` also parses the modified file cleanly.

## Test plan

- [x] Transitive-closure script run against the unmodified file — confirms the gaps this PR fixes
- [x] Transitive-closure script run against the modified file — confirms every signing job now reaches `validate-release-lineage`
- [x] `actionlint .github/workflows/release.yml` — no new findings vs. `origin/main`
- [x] `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/release.yml'))"` — parses cleanly
- [ ] This is a `needs:`-only change to a tag-triggered release workflow, so it cannot be exercised by a normal PR run; the next real tag push is the first live exercise of the new dependency edges

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CY81usuo74quP5Ci39Eqhh
