### PR TITLE
fix(ai): serviceName selector only falls back on an explicit undefined name

### DIFF
--- a/apps/api/src/services/actionIntents/actionLabel.test.ts
+++ b/apps/api/src/services/actionIntents/actionLabel.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { canonicalizeArguments, computeArgumentDigest } from './canonicalize';
 import { buildActionLabel } from './actionLabel';
 import { checkGuardrails } from '../aiGuardrails';
 
@@ -90,4 +91,35 @@ describe('buildActionLabel', () => {
     expect(label.length).toBeLessThanOrEqual(140);
     expect(label.endsWith('…')).toBe(true);
   });
+
+  it.each([
+    [{ name: 'Chosen', serviceName: 'Alternate' }, 'Restart service "Chosen" on KIT'],
+    [{ name: '', serviceName: 'Alternate' }, 'Execute "restart_service" command on KIT'],
+    [{ name: null, serviceName: 'Alternate' }, 'Execute "restart_service" command on KIT'],
+    [{ name: false, serviceName: 'Alternate' }, 'Execute "restart_service" command on KIT'],
+    [{ serviceName: 'Alternate' }, 'Restart service "Alternate" on KIT'],
+    [{ name: 0, serviceName: 'Alternate' }, 'Restart service "0" on KIT'],
+  ] as const)('keeps the dispatch-selected headline through hostname substitution for %j', (payload, expected) => {
+    const input = Object.freeze({ deviceId: '6eae0f70-8da9-49ff-9e18-c241698975f3', commandType: 'restart_service', payload: Object.freeze(payload) });
+    const canonical = canonicalizeArguments(input);
+    const digest = computeArgumentDigest(canonical);
+    const guardrail = checkGuardrails('execute_command', input);
+    expect(buildActionLabel({ toolName: 'execute_command', input, reason: guardrail.description, deviceHostname: 'KIT' })).toBe(expected);
+    expect(canonicalizeArguments(input)).toBe(canonical);
+    expect(computeArgumentDigest(canonicalizeArguments(input))).toBe(digest);
+    expect(JSON.parse(canonical).payload).toEqual(payload);
+  });
+
+  it('keeps both raw aliases digest-bound despite displaying only the selected name', () => {
+    const input = { commandType: 'restart_service', payload: { name: 'Chosen', serviceName: 'Alternate' } };
+    const before = canonicalizeArguments(input);
+    checkGuardrails('execute_command', input);
+    expect(canonicalizeArguments(input)).toBe(before);
+    const digest = computeArgumentDigest(before);
+    expect(digest).not.toBe(computeArgumentDigest(canonicalizeArguments({ ...input, payload: { name: 'Chosen' } })));
+    expect(digest).not.toBe(computeArgumentDigest(canonicalizeArguments({ ...input, payload: { ...input.payload, serviceName: 'Changed' } })));
+    expect(buildActionLabel({ toolName: 'execute_command', input })).toBe('Execute command: restart_service');
+    expect(buildActionLabel({ toolName: 'execute_command', input, reason: 'Explicit caller label' })).toBe('Explicit caller label');
+  });
+
 });

--- a/apps/api/src/services/aiGuardrails.test.ts
+++ b/apps/api/src/services/aiGuardrails.test.ts
@@ -63,6 +63,7 @@ vi.mock('./redis', () => ({
 
 import {
   checkGuardrails,
+  checkAgentGuardrails,
   checkToolPermission,
   checkPermissionRequirement,
   checkPermissionRequirements,
@@ -377,14 +378,74 @@ describe('checkGuardrails — fleet tool tier escalation', () => {
       expect(result.description).toBe(expected);
     });
 
-    it('prefers payload.serviceName over payload.name when both are present', () => {
+    it('prefers the dispatch-selected payload.name when both names are present', () => {
       const result = checkGuardrails('execute_command', {
         deviceId: DEVICE_ID,
         commandType: 'restart_service',
-        payload: { serviceName: 'Spooler', name: 'ignored' },
+        payload: { serviceName: 'Spooler', name: 'selected-service' },
       });
-      expect(result.description).toBe('Restart service "Spooler" on device 74e15ef8...');
+      expect(result.description).toBe('Restart service "selected-service" on device 74e15ef8...');
     });
+
+    it('keeps every raw service alias subject to protected-resource denial', () => {
+      vi.stubEnv('BREEZE_AI_AGENTS_ENABLED', 'true');
+      try {
+        const policy = {
+          enabled: true, mode: 'act' as const, toolAllowlist: ['execute_command'],
+          protectedResources: { services: ['Protected'], paths: [], registryKeys: [], deviceTags: [] },
+          deviceSiteId: 'site-a', deviceId: DEVICE_ID,
+        };
+        for (const payload of [
+          { name: 'Chosen', serviceName: 'Protected' },
+          { name: 'Protected', serviceName: 'Alternate' },
+          { name: 'Chosen', service: 'Protected' },
+        ]) {
+          const result = checkAgentGuardrails('execute_command', { deviceId: DEVICE_ID, commandType: 'restart_service', payload }, policy);
+          expect(result.allowed).toBe(false);
+          expect(result.reason).toContain('service "Protected" is protected');
+        }
+        const positive = checkAgentGuardrails('execute_command', {
+          deviceId: DEVICE_ID, commandType: 'restart_service', payload: { name: 'Chosen', serviceName: 'Alternate' },
+        }, policy);
+        expect(positive.disposition).toBe('propose');
+        expect(positive.allowed).toBe(false);
+        expect(positive.requiresApproval).toBe(false);
+        expect(positive.reason).toBe('Tool "execute_command" is not act-eligible; recorded as a proposal');
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    });
+
+    const serviceSelectionCases: Array<{ label: string; payload: Record<string, unknown>; display: string | null }> = [
+      { label: 'both strings', payload: { name: 'Chosen', serviceName: 'Alternate' }, display: 'Chosen' },
+      { label: 'name only', payload: { name: 'Chosen' }, display: 'Chosen' },
+      { label: 'alias only', payload: { serviceName: 'Alternate' }, display: 'Alternate' },
+      { label: 'undefined name', payload: { name: undefined, serviceName: 'Alternate' }, display: 'Alternate' },
+      { label: 'empty name', payload: { name: '', serviceName: 'Alternate' }, display: null },
+      { label: 'blank name', payload: { name: '   ', serviceName: 'Alternate' }, display: null },
+      { label: 'null name', payload: { name: null, serviceName: 'Alternate' }, display: null },
+      { label: 'false name', payload: { name: false, serviceName: 'Alternate' }, display: null },
+      { label: 'object name', payload: { name: { nested: 'Chosen' }, serviceName: 'Alternate' }, display: null },
+      { label: 'array name', payload: { name: ['Chosen'], serviceName: 'Alternate' }, display: null },
+      { label: 'zero name is display only', payload: { name: 0, serviceName: 'Alternate' }, display: '0' },
+      { label: 'finite name is display only', payload: { name: 42, serviceName: 'Alternate' }, display: '42' },
+      { label: 'padded display', payload: { name: ' Chosen ', serviceName: 'Alternate' }, display: 'Chosen' },
+      { label: 'nonfinite inert helper value', payload: { name: Infinity, serviceName: 'Alternate' }, display: null },
+      { label: 'NaN inert helper value', payload: { name: NaN, serviceName: 'Alternate' }, display: null },
+      { label: 'absent names', payload: {}, display: null },
+      { label: 'unsupported fallback', payload: { serviceName: false }, display: null },
+    ];
+    for (const [commandType, verb] of [['start_service', 'Start'], ['stop_service', 'Stop'], ['restart_service', 'Restart']]) {
+      it.each(serviceSelectionCases)(`${commandType}: $label preserves selected-value display and input`, ({ payload, display }) => {
+        const original = structuredClone(payload);
+        const input = Object.freeze({ deviceId: DEVICE_ID, commandType, payload: Object.freeze(payload) });
+        const result = checkGuardrails('execute_command', input);
+        expect(result.description).toBe(display === null
+          ? `Execute "${commandType}" command on device 74e15ef8...`
+          : `${verb} service "${display}" on device 74e15ef8...`);
+        expect(input.payload).toEqual(original);
+      });
+    }
 
     it('file_read names the target path', () => {
       const result = checkGuardrails('execute_command', {

--- a/apps/api/src/services/aiGuardrails.ts
+++ b/apps/api/src/services/aiGuardrails.ts
@@ -2070,20 +2070,12 @@ function nonEmptyText(value: unknown): string | null {
 }
 
 /**
- * sweep 2026-09-08 row 19: `manage_services` exposes `serviceName` on ITS OWN
- * input schema and normalizes it to `payload.name` before calling into
- * commandQueue — but `execute_command`'s schema never documented a payload
- * key for service commands, so a model calling it directly has been observed
- * reusing the more visible `serviceName` name instead. A persisted approval's
- * `action_arguments` looked like
- * `{ commandType: 'restart_service', payload: { serviceName: 'Spooler' } }`,
- * which the old `payload.name`-only read missed, falling back to the generic
- * "Execute \"restart_service\" command" wording. Try `serviceName` first
- * (the more likely source for a direct execute_command call) then `name`
- * (manage_services' normalized shape) so either caller gets a named headline.
+ * Match execute_command's service payload selection before display formatting.
+ * A defined name wins even when it cannot produce a named headline; only an
+ * undefined name falls back to serviceName. Formatting is not agent validation.
  */
 function serviceNameFromPayload(payload: Record<string, unknown>): string | null {
-  return nonEmptyText(payload.serviceName) ?? nonEmptyText(payload.name);
+  return nonEmptyText(payload.name !== undefined ? payload.name : payload.serviceName);
 }
 
 /**

--- a/apps/api/src/services/aiToolsScripts.executeCommandServicePayload.test.ts
+++ b/apps/api/src/services/aiToolsScripts.executeCommandServicePayload.test.ts
@@ -129,4 +129,55 @@ describe('execute_command — service payload normalization', () => {
     const [, , payload] = executeCommand.mock.calls[0]!;
     expect(payload).toEqual({ processName: 'foo.exe', pid: '123' });
   });
+
+  const selectedValues: Array<{ label: string; value: unknown }> = [
+    { label: 'empty', value: '' }, { label: 'blank', value: ' ' },
+    { label: 'null', value: null }, { label: 'false', value: false },
+    { label: 'object', value: { nested: 'Chosen' } }, { label: 'array', value: ['Chosen'] },
+    { label: 'zero display-only', value: 0 }, { label: 'finite display-only', value: 42 },
+    { label: 'padded', value: ' Chosen ' }, { label: 'undefined fallback', value: undefined },
+  ];
+  for (const commandType of serviceCommandTypes) {
+    it.each(selectedValues)(`${commandType}: $label preserves defined-name precedence without mutating input`, async ({ value }) => {
+      const payload = Object.freeze({ name: value, serviceName: 'Alternate', extra: 'kept' });
+      const original = structuredClone(payload);
+      const input = Object.freeze({ deviceId: DEVICE_ID, commandType, payload });
+      await toolMap().get('execute_command')!.handler(input, makeAuth());
+      expect(executeCommand).toHaveBeenCalledTimes(1);
+      expect(executeCommand.mock.calls[0]?.[2]).toEqual({ name: value === undefined ? 'Alternate' : value, extra: 'kept' });
+      expect(input.payload).toEqual(original);
+    });
+  }
+
+  it('retains undefined alias keys under the existing no-normalization branch', async () => {
+    const payload = Object.freeze({ name: 'Chosen', serviceName: undefined });
+    await toolMap().get('execute_command')!.handler({ deviceId: DEVICE_ID, commandType: 'restart_service', payload }, makeAuth());
+    expect(executeCommand.mock.calls[0]?.[2]).toEqual(payload);
+    expect(Object.hasOwn(executeCommand.mock.calls[0]?.[2] as object, 'serviceName')).toBe(true);
+  });
+
+  it('does not normalize service-shaped payloads on other command types', async () => {
+    const payload = Object.freeze({ name: 'Chosen', serviceName: 'Alternate', pid: '123' });
+    await toolMap().get('execute_command')!.handler({ deviceId: DEVICE_ID, commandType: 'kill_process', payload }, makeAuth());
+    expect(executeCommand.mock.calls[0]?.[2]).toEqual(payload);
+  });
+
+  it('does not dispatch when device access is denied', async () => {
+    const auth = makeAuth(); auth.canAccessSite = () => false;
+    const input = Object.freeze({ deviceId: DEVICE_ID, commandType: 'restart_service', payload: Object.freeze({ name: 'Chosen', serviceName: 'Alternate' }) });
+    const result = JSON.parse(await toolMap().get('execute_command')!.handler(input, auth));
+    expect(result).toHaveProperty('error');
+    expect(executeCommand).not.toHaveBeenCalled();
+    expect(input.payload).toEqual({ name: 'Chosen', serviceName: 'Alternate' });
+  });
+
+  it('propagates the inert dispatcher failure without mutating approved input', async () => {
+    const failure = new Error('synthetic dispatcher failure');
+    executeCommand.mockRejectedValueOnce(failure);
+    const input = Object.freeze({ deviceId: DEVICE_ID, commandType: 'restart_service', payload: Object.freeze({ name: 'Chosen', serviceName: 'Alternate' }) });
+    await expect(toolMap().get('execute_command')!.handler(input, makeAuth())).rejects.toBe(failure);
+    expect(executeCommand).toHaveBeenCalledTimes(1);
+    expect(input.payload).toEqual({ name: 'Chosen', serviceName: 'Alternate' });
+  });
+
 });


### PR DESCRIPTION
## Summary
- The AI approval-label formatter (`serviceNameFromPayload` in `aiGuardrails.ts`) and the `execute_command` dispatcher were reading a service-command payload's name in opposite priority order: the formatter preferred `payload.serviceName` over `payload.name`, while the dispatcher (and `manage_services`, which normalizes to `payload.name`) prefers `payload.name` and only falls back to `payload.serviceName` when `name` is strictly `undefined`.
- That mismatch could produce a generic "Execute `<commandType>` command" approval headline instead of naming the actual service, even though the dispatcher itself was correctly identifying and acting on the target service.
- Fix: `serviceNameFromPayload` now matches the dispatcher's own selection — it reads `payload.name` unless that field is explicitly `undefined`, in which case it falls back to `payload.serviceName`. This is a display/labeling fix only; it does not change what command actually executes.

## Test plan
- [x] `cd apps/api && npx tsc --noEmit` — clean
- [x] `pnpm --filter @breeze/api lint` — clean
- [x] `cd apps/api && npx vitest run --pool=threads --maxWorkers=2 src/services/actionIntents/actionLabel.test.ts src/services/aiGuardrails.test.ts src/services/aiToolsScripts.executeCommandServicePayload.test.ts` — 3 files / 277 tests passed
- [x] `apps/api/scripts/check-migration-naming.sh` equivalent pre-commit hook passed (no migrations in this change)
- No schema/migration/RLS changes — integration and RLS suites not applicable to this diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CY81usuo74quP5Ci39Eqhh
