### PR TITLE
fix(webhooks): bound automatic delivery retries per queued cycle

### DIFF
--- a/apps/api/migrations/2026-10-15-150001-bound-webhook-retries.sql
+++ b/apps/api/migrations/2026-10-15-150001-bound-webhook-retries.sql
@@ -1,0 +1,41 @@
+-- Bound legacy alert-webhook retryCount values. Runtime delivery clamps these
+-- values independently; this cleanup makes subsequent edits pass validation
+-- and preserves the configured intent as closely as the new ceiling allows.
+-- Non-numeric legacy values become the safe default of two retries.
+DO $$
+DECLARE
+  cleaned_rows bigint;
+BEGIN
+  PERFORM set_config('breeze.scope', 'system', true);
+
+  UPDATE public.notification_channels
+  SET config = jsonb_set(
+    config,
+    '{retryCount}',
+    to_jsonb(
+      CASE
+        WHEN jsonb_typeof(config -> 'retryCount') = 'number' THEN
+          LEAST(
+            2::numeric,
+            GREATEST(0::numeric, FLOOR((config ->> 'retryCount')::numeric))
+          )::integer
+        ELSE 2
+      END
+    ),
+    true
+  )
+  WHERE type = 'webhook'
+    AND config ? 'retryCount'
+    AND CASE
+      WHEN jsonb_typeof(config -> 'retryCount') = 'number' THEN
+        (config ->> 'retryCount')::numeric < 0
+        OR (config ->> 'retryCount')::numeric > 2
+        OR (config ->> 'retryCount')::numeric <> FLOOR((config ->> 'retryCount')::numeric)
+      ELSE true
+    END;
+
+  GET DIAGNOSTICS cleaned_rows = ROW_COUNT;
+  IF cleaned_rows > 0 THEN
+    RAISE WARNING 'normalized % notification channel webhook retryCount value(s) to the supported 0..2 range', cleaned_rows;
+  END IF;
+END $$;

--- a/apps/api/src/__tests__/integration/webhookRetryBudget.integration.test.ts
+++ b/apps/api/src/__tests__/integration/webhookRetryBudget.integration.test.ts
@@ -1,0 +1,74 @@
+import './setup';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { afterAll, describe, expect, it } from 'vitest';
+import { asc, eq } from 'drizzle-orm';
+import postgres from 'postgres';
+import { db, withDbAccessContext, withSystemDbAccessContext, type DbAccessContext } from '../../db';
+import { notificationChannels } from '../../db/schema';
+import { createOrganization, createPartner } from './db-utils';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+const migrationSql = readFileSync(join(
+  __dirname,
+  '../../../migrations/2026-10-15-150001-bound-webhook-retries.sql',
+), 'utf8');
+const notices: string[] = [];
+const adminSql = postgres(process.env.DATABASE_URL ?? '', {
+  max: 1,
+  onnotice: (notice) => notices.push(String(notice.message)),
+});
+afterAll(async () => adminSql.end({ timeout: 5 }));
+
+function orgContext(orgId: string): DbAccessContext {
+  return {
+    scope: 'organization', orgId, accessibleOrgIds: [orgId],
+    accessiblePartnerIds: [], userId: null,
+  };
+}
+
+describe('webhook retry migration and tenant boundary', () => {
+  runDb('normalizes legacy outliers idempotently and preserves breeze_app isolation', async () => {
+    const fixture = await withSystemDbAccessContext(async () => {
+      const partner = await createPartner();
+      const ownOrg = await createOrganization({ partnerId: partner.id });
+      const foreignOrg = await createOrganization({ partnerId: partner.id });
+      await db.insert(notificationChannels).values([
+        { orgId: ownOrg.id, name: 'negative', type: 'webhook', config: { url: 'https://example.com/a', retryCount: -5 } },
+        { orgId: ownOrg.id, name: 'fractional', type: 'webhook', config: { url: 'https://example.com/b', retryCount: 1.8 } },
+        { orgId: ownOrg.id, name: 'huge', type: 'webhook', config: { url: 'https://example.com/c', retryCount: 1_000_000 } },
+        { orgId: ownOrg.id, name: 'string', type: 'webhook', config: { url: 'https://example.com/d', retryCount: '1000' } },
+        { orgId: foreignOrg.id, name: 'foreign', type: 'webhook', config: { url: 'https://example.com/e', retryCount: 1_000_000 } },
+      ]);
+      return { ownOrg, foreignOrg };
+    });
+
+    notices.length = 0;
+    await adminSql.unsafe(migrationSql);
+    expect(notices).toContain('normalized 5 notification channel webhook retryCount value(s) to the supported 0..2 range');
+    const first = await withDbAccessContext(orgContext(fixture.ownOrg.id), () => db
+      .select({ name: notificationChannels.name, config: notificationChannels.config })
+      .from(notificationChannels)
+      .orderBy(asc(notificationChannels.name)));
+    expect(first.map((row) => [row.name, (row.config as Record<string, unknown>).retryCount])).toEqual([
+      ['fractional', 1], ['huge', 2], ['negative', 0], ['string', 2],
+    ]);
+
+    const hidden = await withDbAccessContext(orgContext(fixture.ownOrg.id), () => db
+      .select({ id: notificationChannels.id })
+      .from(notificationChannels)
+      .where(eq(notificationChannels.orgId, fixture.foreignOrg.id)));
+    expect(hidden).toEqual([]);
+
+    notices.length = 0;
+    await adminSql.unsafe(migrationSql);
+    expect(notices).not.toEqual(expect.arrayContaining([
+      expect.stringContaining('notification channel webhook retryCount'),
+    ]));
+    const second = await withDbAccessContext(orgContext(fixture.ownOrg.id), () => db
+      .select({ name: notificationChannels.name, config: notificationChannels.config })
+      .from(notificationChannels)
+      .orderBy(asc(notificationChannels.name)));
+    expect(second).toEqual(first);
+  });
+});

--- a/apps/api/src/__tests__/integration/webhookRetryQueue.integration.test.ts
+++ b/apps/api/src/__tests__/integration/webhookRetryQueue.integration.test.ts
@@ -1,0 +1,107 @@
+import './setup';
+import { randomUUID } from 'node:crypto';
+import { afterAll, describe, expect, it, vi } from 'vitest';
+import type { Worker } from 'bullmq';
+import { eq } from 'drizzle-orm';
+import { withSystemDbAccessContext } from '../../db';
+import { alerts, alertNotifications, devices, notificationChannels } from '../../db/schema';
+import { createOrganization, createPartner, createSite } from './db-utils';
+import { getTestDb } from './setup';
+
+const { calls } = vi.hoisted(() => ({ calls: [] as { path: string; time: number }[] }));
+// Only provider I/O and unrelated in-app fan-out are synthetic. Sender,
+// dispatcher, SQL state transitions, production enqueue options and BullMQ
+// delayed/failed states all execute unchanged against the owned local lab.
+vi.mock('../../services/urlSafety', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../services/urlSafety')>();
+  return { ...actual, safeFetch: vi.fn(async (url: string) => {
+    const parsed = new URL(url);
+    if (parsed.hostname !== 'example.com') throw new Error('Unexpected synthetic destination');
+    calls.push({ path: parsed.pathname, time: Date.now() });
+    const status = parsed.pathname === '/retry' ? 503 : parsed.pathname === '/terminal' ? 400 : 200;
+    return new Response('synthetic response', { status });
+  }) };
+});
+vi.mock('../../services/notificationSenders/inAppSender', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../services/notificationSenders/inAppSender')>();
+  return { ...actual, sendInAppNotification: vi.fn(async () => ({ success: true, notificationCount: 0 })) };
+});
+
+import {
+  createNotificationWorker, getNotificationQueue, processAlertNotifications,
+  shutdownNotificationDispatcher,
+} from '../../services/notificationDispatcher';
+import { closeRedis } from '../../services/redis';
+
+let worker: Worker | undefined;
+afterAll(async () => {
+  await worker?.close();
+  await shutdownNotificationDispatcher();
+  await closeRedis();
+});
+
+async function until(check: () => Promise<boolean>, timeout = 10_000) {
+  const deadline = Date.now() + timeout;
+  while (!(await check())) {
+    if (Date.now() >= deadline) throw new Error('Synthetic queue state did not reach its bounded deadline');
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+}
+
+describe('webhook durable retry scheduling', () => {
+  it('releases the worker during real backoff, bounds retryable sends and terminates ordinary 4xx', async () => {
+    const db = getTestDb();
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const site = await createSite({ orgId: org.id });
+    const [device] = await db.insert(devices).values({
+      orgId: org.id, siteId: site.id, agentId: randomUUID(), hostname: 'synthetic-retry-host',
+      osType: 'linux', osVersion: 'synthetic', architecture: 'x64', agentVersion: '1.0.0',
+    }).returning();
+    const [alert] = await db.insert(alerts).values({
+      orgId: org.id, deviceId: device!.id, severity: 'high', title: 'Synthetic queue check',
+    }).returning();
+    const channels = await db.insert(notificationChannels).values(
+      ['retry', 'terminal', 'healthy'].map((name) => ({
+        orgId: org.id, name, type: 'webhook' as const,
+        config: { url: `https://example.com/${name}`, retryCount: 2 },
+      })),
+    ).returning();
+    const queue = getNotificationQueue();
+    const result = await withSystemDbAccessContext(() => processAlertNotifications({ type: 'process-alert', alertId: alert!.id }));
+    expect(result.queued).toBe(3);
+    const jobFor = async (name: string) => queue.getJob(`alert-send-${alert!.id}-${channels.find((c) => c.name === name)!.id}-0`);
+    const retry = (await jobFor('retry'))!;
+    const terminal = (await jobFor('terminal'))!;
+    expect(retry.opts.attempts).toBe(3);
+    expect(retry.opts.backoff).toEqual({ type: 'exponential', delay: 30_000 });
+    expect(terminal.opts.attempts).toBe(3);
+    worker = createNotificationWorker();
+    // Tighten only the harness worker capacity: one healthy job must progress
+    // while the retry job waits. Production's actual backoff stays 30s/60s.
+    worker.concurrency = 1;
+    await until(async () => await retry.getState() === 'delayed' && await terminal.getState() === 'failed'
+      && calls.some((call) => call.path === '/healthy'));
+    expect(calls.filter((call) => call.path === '/retry')).toHaveLength(1);
+    expect(calls.filter((call) => call.path === '/terminal')).toHaveLength(1);
+    await until(async () => await retry.getState() === 'failed', 110_000);
+    await worker.close();
+    worker = undefined;
+    const finalRetry = (await jobFor('retry'))!;
+    const finalTerminal = (await jobFor('terminal'))!;
+    expect(finalRetry.attemptsMade).toBe(3);
+    expect(finalTerminal.attemptsMade).toBe(1);
+    const retryCalls = calls.filter((call) => call.path === '/retry');
+    expect(retryCalls).toHaveLength(3);
+    expect(calls.filter((call) => call.path === '/terminal')).toHaveLength(1);
+    expect(calls.filter((call) => call.path === '/healthy')).toHaveLength(1);
+    expect(retryCalls[1]!.time - retryCalls[0]!.time).toBeGreaterThanOrEqual(29_000);
+    expect(retryCalls[2]!.time - retryCalls[1]!.time).toBeGreaterThanOrEqual(59_000);
+    expect(calls.find((call) => call.path === '/healthy')!.time).toBeLessThan(retryCalls[1]!.time);
+    const rows = await db.select().from(alertNotifications).where(eq(alertNotifications.alertId, alert!.id));
+    expect(rows).toHaveLength(3);
+    for (const channel of channels) {
+      expect(rows.find((row) => row.channelId === channel.id)?.status).toBe(channel.name === 'healthy' ? 'sent' : 'failed');
+    }
+  }, 125_000);
+});

--- a/apps/api/src/services/notificationDispatcher.orderingGuards.test.ts
+++ b/apps/api/src/services/notificationDispatcher.orderingGuards.test.ts
@@ -75,11 +75,13 @@ vi.mock('./notificationChannelSecrets', () => ({
 }));
 
 const sendInAppNotificationMock = vi.hoisted(() => vi.fn());
+const webhookTotalAttemptsMock = vi.hoisted(() => vi.fn(() => 3));
 
 vi.mock('./notificationSenders', () => ({
   sendEmailNotification: vi.fn(),
   getEmailRecipients: vi.fn(),
   sendWebhookNotification: vi.fn(),
+  webhookTotalAttempts: webhookTotalAttemptsMock,
   sendInAppNotification: sendInAppNotificationMock,
   sendPagerDutyNotification: vi.fn(),
   sendPushoverNotification: vi.fn()
@@ -135,6 +137,7 @@ beforeEach(() => {
   );
   queueAddMock.mockReset().mockImplementation(async () => makeJobStub('job-1'));
   sendInAppNotificationMock.mockReset().mockResolvedValue({ success: true, notificationCount: 1 });
+  webhookTotalAttemptsMock.mockReset().mockReturnValue(3);
 });
 
 describe('processAlertNotifications status guard (a)', () => {
@@ -219,23 +222,46 @@ describe('processAlertNotifications baseline send jobId (c)', () => {
     expect(jobs).toHaveLength(1);
     expect(jobs[0]!.opts?.jobId).toBe('alert-send-alert-1-channel-1-0');
   });
+
+  it('uses configured retries to set durable total attempts on the send job', async () => {
+    webhookTotalAttemptsMock.mockReturnValueOnce(1);
+    const config = { url: 'https://example.com/hook', retryCount: 0 };
+    selectQueue.push(
+      [makeAlert({ status: 'active' })],
+      [{ id: 'device-1', displayName: 'Server-1' }],
+      [{ partnerId: null }],
+      [],
+      [{ id: 'channel-1' }],
+      [{ id: 'channel-1', type: 'webhook', config }]
+    );
+
+    await processAlertNotifications({ type: 'process-alert', alertId: 'alert-1' });
+
+    expect(webhookTotalAttemptsMock).toHaveBeenCalledWith(config);
+    const jobs = queueAddBulkMock.mock.calls[0]![0] as Array<{ opts: { attempts: number } }>;
+    expect(jobs[0]!.opts.attempts).toBe(1);
+  });
 });
 
 describe('scheduleEscalation job options (carried Task 8 review handoff)', () => {
   it('gives escalation send jobs attempts/backoff/removal options so a transport failure gets retried instead of permanently occupying the jobId', async () => {
+    const webhookConfig = { url: 'https://example.com/hook', retryCount: 2 };
     selectQueue.push(
       [makeAlert({ status: 'active', ruleId: 'rule-1' })], // alert
       [{ id: 'device-1', displayName: 'Server-1' }], // device
       [{ overrideSettings: { notificationChannelIds: ['channel-1'], escalationPolicyId: 'policy-1' } }], // rule
       [{ partnerId: null }], // org (partnerIdForOrg)
-      [{ id: 'channel-1' }], // validChannels (baseline)
+      [{ id: 'channel-1', type: 'webhook', config: webhookConfig }], // validChannels (baseline)
       [{ id: 'policy-1', orgId: 'org-1', partnerId: null, steps: [{ delayMinutes: 5, channelIds: ['channel-1'] }] }], // escalation policy
-      [{ id: 'channel-1' }] // validChannels (escalation)
+      [{ id: 'channel-1', type: 'webhook', config: webhookConfig }] // validChannels (escalation)
     );
 
     await processAlertNotifications({ type: 'process-alert', alertId: 'alert-1' });
 
     expect(queueAddMock).toHaveBeenCalledTimes(1);
+    expect(webhookTotalAttemptsMock).toHaveBeenCalledTimes(2);
+    expect(webhookTotalAttemptsMock).toHaveBeenNthCalledWith(1, webhookConfig);
+    expect(webhookTotalAttemptsMock).toHaveBeenNthCalledWith(2, webhookConfig);
     const [name, data, opts] = queueAddMock.mock.calls[0]!;
     expect(name).toBe('send');
     expect(data).toEqual({ type: 'send', alertId: 'alert-1', channelId: 'channel-1', escalationStep: 1 });

--- a/apps/api/src/services/notificationDispatcher.test.ts
+++ b/apps/api/src/services/notificationDispatcher.test.ts
@@ -115,6 +115,7 @@ vi.mock('./notificationSenders', () => ({
   sendEmailNotification: vi.fn(),
   getEmailRecipients: vi.fn(),
   sendWebhookNotification: sendWebhookNotificationMock,
+  webhookTotalAttempts: vi.fn(() => 3),
   sendInAppNotification: vi.fn(),
   sendPagerDutyNotification: vi.fn(),
   sendPushoverNotification: vi.fn()
@@ -375,11 +376,14 @@ describe('processSendNotification send-identity state machine', () => {
     const record = makeNotificationRow();
     insertReturningMock.mockResolvedValueOnce([record]);
     queueDeviceOrgSelects();
-    sendWebhookNotificationMock.mockResolvedValue({ success: false, error: 'endpoint unreachable' });
+    sendWebhookNotificationMock.mockResolvedValue({ success: false, error: 'endpoint unreachable', retryable: true });
     // The CAS matches (this attempt still holds the claim) — one row written.
     updateReturningMock.mockResolvedValueOnce([{ ...record, status: 'failed' }]);
 
-    await expect(processSendNotification(baseData)).rejects.toThrow('endpoint unreachable');
+    await expect(processSendNotification(baseData)).rejects.toMatchObject({
+      name: 'Error',
+      message: 'endpoint unreachable',
+    });
 
     // sentAt: null guards against a failed row reading as failed-with-sentAt
     // (only relevant if it was ever set, but keeps the row's shape honest).
@@ -419,6 +423,29 @@ describe('processSendNotification send-identity state machine', () => {
       channelType: 'webhook',
       error: undefined,
       durationMs: expect.any(Number)
+    });
+  });
+
+  it('(d3) marks a non-retryable webhook response unrecoverable after persisting failure', async () => {
+    queuePrepareSelects();
+    const record = makeNotificationRow();
+    insertReturningMock.mockResolvedValueOnce([record]);
+    queueDeviceOrgSelects();
+    sendWebhookNotificationMock.mockResolvedValue({
+      success: false,
+      error: 'HTTP 404: not found',
+      retryable: false,
+    });
+    updateReturningMock.mockResolvedValueOnce([{ ...record, status: 'failed' }]);
+
+    await expect(processSendNotification(baseData)).rejects.toMatchObject({
+      name: 'UnrecoverableError',
+      message: 'HTTP 404: not found',
+    });
+    expect(updateSetMock).toHaveBeenCalledWith({
+      status: 'failed',
+      sentAt: null,
+      errorMessage: 'HTTP 404: not found',
     });
   });
 

--- a/apps/api/src/services/notificationDispatcher.ts
+++ b/apps/api/src/services/notificationDispatcher.ts
@@ -5,7 +5,7 @@
  * Handles channel routing, escalation policies, and delivery tracking.
  */
 
-import { Queue, Worker, Job } from 'bullmq';
+import { Queue, Worker, Job, UnrecoverableError } from 'bullmq';
 import * as dbModule from '../db';
 import {
   alerts,
@@ -31,6 +31,7 @@ import {
   sendInAppNotification,
   sendPagerDutyNotification,
   sendPushoverNotification,
+  webhookTotalAttempts,
   type WebhookConfig,
   type PagerDutyConfig,
   type PushoverConfig,
@@ -43,6 +44,14 @@ import { decryptNotificationChannelConfig } from './notificationChannelSecrets';
 import { attachWorkerObservability } from '../jobs/workerObservability';
 
 const { db } = dbModule;
+
+const DEFAULT_NOTIFICATION_RETRIES = 2;
+
+/** Configured retry count excludes the initial attempt; BullMQ uses totals. */
+export function notificationJobAttempts(type: string, config: unknown): number {
+  if (type !== 'webhook') return DEFAULT_NOTIFICATION_RETRIES + 1;
+  return webhookTotalAttempts(config);
+}
 const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
   const withSystem = dbModule.withSystemDbAccessContext;
   return typeof withSystem === 'function' ? withSystem(fn) : fn();
@@ -314,7 +323,7 @@ export async function processAlertNotifications(data: ProcessAlertJobData): Prom
   }
 
   const validChannels = await db
-    .select({ id: notificationChannels.id })
+    .select({ id: notificationChannels.id, type: notificationChannels.type, config: notificationChannels.config })
     .from(notificationChannels)
     .where(
       and(
@@ -332,15 +341,15 @@ export async function processAlertNotifications(data: ProcessAlertJobData): Prom
 
   // Queue notification jobs for each channel with retry + exponential backoff (Phase 4a)
   const queue = getNotificationQueue();
-  const jobs = channelIds.map(channelId => ({
+  const jobs = validChannels.map(channel => ({
     name: 'send',
     data: {
       type: 'send' as const,
       alertId: data.alertId,
-      channelId
+      channelId: channel.id
     },
     opts: {
-      attempts: 3,
+      attempts: notificationJobAttempts(channel.type, channel.config),
       backoff: { type: 'exponential' as const, delay: 30_000 }, // 30s, 60s (2 retries)
       removeOnComplete: true,
       removeOnFail: { count: 100 },
@@ -359,7 +368,7 @@ export async function processAlertNotifications(data: ProcessAlertJobData): Prom
       // reaches 'failed'. Task 8's durable (alertId, channelId, escalationStep)
       // row identity in `alert_notifications` (unique index; see
       // `buildAlertNotificationClaimCas`) is the actual double-send backstop.
-      jobId: `alert-send-${data.alertId}-${channelId}-0`
+      jobId: `alert-send-${data.alertId}-${channel.id}-0`
     }
   }));
 
@@ -754,6 +763,7 @@ export async function processSendNotification(data: SendNotificationJobData): Pr
   // Send notification based on channel type — OUTSIDE any DB context (#1105).
   let success = false;
   let error: string | undefined;
+  let retryable: boolean | undefined;
 
   try {
     const channelConfig = decryptNotificationChannelConfig(channel.type, channel.config);
@@ -778,6 +788,7 @@ export async function processSendNotification(data: SendNotificationJobData): Pr
         );
         success = webhookResult.success;
         error = webhookResult.error;
+        retryable = webhookResult.retryable;
         break;
 
       case 'sms':
@@ -801,6 +812,7 @@ export async function processSendNotification(data: SendNotificationJobData): Pr
         );
         success = slackResult.success;
         error = slackResult.error;
+        retryable = slackResult.retryable;
         break;
 
       case 'teams':
@@ -813,6 +825,7 @@ export async function processSendNotification(data: SendNotificationJobData): Pr
         );
         success = teamsResult.success;
         error = teamsResult.error;
+        retryable = teamsResult.retryable;
         break;
 
       case 'pagerduty':
@@ -908,7 +921,9 @@ export async function processSendNotification(data: SendNotificationJobData): Pr
   // as a completed job and never retries (#4085 — codex-flagged defect: with
   // attempts:3, transport failures were never actually retried). The row is
   // reclaimed on the next attempt via the send-identity claim path above.
-  throw new Error(error || `Unknown error sending ${channel.type} notification`);
+  const failureMessage = error || `Unknown error sending ${channel.type} notification`;
+  if (retryable === false) throw new UnrecoverableError(failureMessage);
+  throw new Error(failureMessage);
 }
 
 /**
@@ -950,7 +965,7 @@ async function sendWebhookChannelNotification(
   alert: typeof alerts.$inferSelect,
   device: typeof devices.$inferSelect | undefined,
   org: typeof organizations.$inferSelect | undefined
-): Promise<{ success: boolean; error?: string }> {
+): Promise<{ success: boolean; error?: string; retryable?: boolean }> {
   // Get rule for additional context (ruleId may be null for config policy alerts).
   // This now runs during the outbound-send phase (#1105), with no ambient DB
   // context, so it must open its own short one rather than assume `db` is
@@ -991,10 +1006,10 @@ async function sendChatWebhookChannelNotification(
   alert: typeof alerts.$inferSelect,
   device: typeof devices.$inferSelect | undefined,
   org: typeof organizations.$inferSelect | undefined
-): Promise<{ success: boolean; error?: string }> {
+): Promise<{ success: boolean; error?: string; retryable?: boolean }> {
   const webhookUrl = typeof config.webhookUrl === 'string' ? config.webhookUrl.trim() : '';
   if (!webhookUrl) {
-    return { success: false, error: `${channelType} channel missing webhookUrl` };
+    return { success: false, error: `${channelType} channel missing webhookUrl`, retryable: false };
   }
 
   const dashboardUrl = process.env.DASHBOARD_URL
@@ -1267,7 +1282,7 @@ async function scheduleEscalation(alertId: string, policyId: string, orgId: stri
   )];
   const validChannels = requestedChannelIds.length > 0
     ? await db
-      .select({ id: notificationChannels.id })
+      .select({ id: notificationChannels.id, type: notificationChannels.type, config: notificationChannels.config })
       .from(notificationChannels)
       .where(
         and(
@@ -1278,6 +1293,7 @@ async function scheduleEscalation(alertId: string, policyId: string, orgId: stri
       )
     : [];
   const validChannelIdSet = new Set(validChannels.map((channel) => channel.id));
+  const validChannelById = new Map(validChannels.map((channel) => [channel.id, channel]));
 
   for (let i = 0; i < steps.length; i++) {
     const step = steps[i];
@@ -1288,6 +1304,7 @@ async function scheduleEscalation(alertId: string, policyId: string, orgId: stri
     const stepChannelIds = (step.channelIds || []).filter((channelId) => validChannelIdSet.has(channelId));
 
     for (const channelId of stepChannelIds) {
+      const channel = validChannelById.get(channelId)!;
       const job = await queue.add(
         'send',
         {
@@ -1306,7 +1323,7 @@ async function scheduleEscalation(alertId: string, policyId: string, orgId: stri
           // permanently-retained failed job hash with ZERO retries — the
           // stable jobId then stays occupied forever and nothing ever
           // re-fires that escalation step.
-          attempts: 3,
+          attempts: notificationJobAttempts(channel.type, channel.config),
           backoff: { type: 'exponential', delay: 30_000 },
           removeOnComplete: true,
           removeOnFail: { age: 3600 }

--- a/apps/api/src/services/notificationSenders/index.ts
+++ b/apps/api/src/services/notificationSenders/index.ts
@@ -16,6 +16,8 @@ export {
   sendWebhookNotification,
   validateWebhookConfig,
   testWebhook,
+  MAX_WEBHOOK_RETRIES,
+  webhookTotalAttempts,
   type WebhookNotificationPayload,
   type WebhookConfig,
   type SendResult as WebhookSendResult

--- a/apps/api/src/services/notificationSenders/webhookSender.retryBudget.test.ts
+++ b/apps/api/src/services/notificationSenders/webhookSender.retryBudget.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { safeFetchMock } = vi.hoisted(() => ({ safeFetchMock: vi.fn() }));
+vi.mock('../urlSafety', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../urlSafety')>();
+  return { ...actual, safeFetch: safeFetchMock };
+});
+
+import { sendWebhookNotification, validateWebhookConfig, webhookTotalAttempts } from './webhookSender';
+
+const payload = {
+  alertId: 'alert-1',
+  alertName: 'Synthetic alert',
+  severity: 'high',
+  summary: 'bounded retry test',
+  orgId: 'org-1',
+  triggeredAt: '2026-09-07T00:00:00.000Z',
+};
+
+describe('webhook sender retry budget', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    safeFetchMock.mockReset();
+  });
+
+  it('performs one bounded network attempt and never sleeps in a worker slot', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    safeFetchMock.mockResolvedValue({
+      ok: false,
+      status: 503,
+      text: async () => 'synthetic retryable failure',
+    } as Response);
+
+    const pending = sendWebhookNotification(
+      { url: 'https://example.com/hook', retryCount: 1, timeout: 1_000 },
+      payload,
+    );
+    await vi.runAllTimersAsync();
+    const result = await pending;
+
+    expect(result.success).toBe(false);
+    expect(result.retryable).toBe(true);
+    expect(safeFetchMock).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it.each([
+    [0, 1],
+    [1, 2],
+    [2, 3],
+    [99, 3],
+    [-4, 1],
+    [1.9, 2],
+    ['99', 3],
+    [undefined, 3],
+  ])('converts configured retries %j to %d bounded total attempts', (retryCount, attempts) => {
+    expect(webhookTotalAttempts({ retryCount })).toBe(attempts);
+  });
+
+  it('marks 4xx configuration failures non-retryable', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    safeFetchMock.mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: async () => 'not found',
+    } as Response);
+
+    await expect(sendWebhookNotification(
+      { url: 'https://example.com/hook' }, payload,
+    )).resolves.toMatchObject({ success: false, retryable: false });
+    expect(safeFetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([408, 425, 429, 503])('marks transient HTTP %d failures retryable', async (status) => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    safeFetchMock.mockResolvedValue({
+      ok: false,
+      status,
+      text: async () => 'synthetic transient failure',
+    } as Response);
+
+    await expect(sendWebhookNotification(
+      { url: 'https://example.com/hook' }, payload,
+    )).resolves.toMatchObject({ success: false, retryable: true });
+    expect(safeFetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('clamps a legacy oversized timeout, aborts once, and never adds a backoff sleep', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    safeFetchMock.mockImplementation((_url: string, options?: RequestInit) => new Promise((_resolve, reject) => {
+      options?.signal?.addEventListener('abort', () => {
+        const error = new Error('aborted');
+        error.name = 'AbortError';
+        reject(error);
+      }, { once: true });
+    }));
+
+    const pending = sendWebhookNotification(
+      { url: 'https://example.com/hook', retryCount: 2, timeout: Number.MAX_SAFE_INTEGER }, payload,
+    );
+    await vi.advanceTimersByTimeAsync(59_999);
+    expect(vi.getTimerCount()).toBe(1);
+    await vi.advanceTimersByTimeAsync(1);
+
+    await expect(pending).resolves.toMatchObject({
+      success: false,
+      error: 'Request timed out',
+      retryable: true,
+    });
+    expect(safeFetchMock).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it.each([-1, 1.5, 3, Number.MAX_SAFE_INTEGER, '1000'])('rejects an unsafe retryCount %j', (retryCount) => {
+    const result = validateWebhookConfig({
+      url: 'https://example.com/hook',
+      retryCount,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.join(' ')).toContain('retryCount');
+  });
+
+  it.each([0, 1, 2])('accepts bounded integer retryCount %d for durable queue scheduling', (retryCount) => {
+    expect(validateWebhookConfig({ url: 'https://example.com/hook', retryCount })).toEqual({
+      valid: true,
+      errors: [],
+    });
+  });
+});

--- a/apps/api/src/services/notificationSenders/webhookSender.ts
+++ b/apps/api/src/services/notificationSenders/webhookSender.ts
@@ -66,6 +66,23 @@ export interface SendResult {
   statusCode?: number;
   error?: string;
   responseBody?: string;
+  /** Whether a durable queue may safely retry this transport result. */
+  retryable?: boolean;
+}
+
+/** Configured retries exclude the initial attempt. The queue stores total attempts. */
+export const MAX_WEBHOOK_RETRIES = 2;
+
+/** Clamp legacy JSON and convert configured retries to BullMQ total attempts. */
+export function webhookTotalAttempts(config: unknown): number {
+  if (!config || typeof config !== 'object' || Array.isArray(config)) {
+    return MAX_WEBHOOK_RETRIES + 1;
+  }
+  const value = (config as Record<string, unknown>).retryCount;
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return MAX_WEBHOOK_RETRIES + 1;
+  }
+  return Math.min(MAX_WEBHOOK_RETRIES, Math.max(0, Math.floor(value))) + 1;
 }
 
 export function validateWebhookUrlSafety(rawUrl: string): string[] {
@@ -199,13 +216,17 @@ export async function sendWebhookNotification(
   if (staticErrors.length > 0) {
     return {
       success: false,
-      error: `Unsafe webhook URL: ${staticErrors.join('; ')}`
+      error: `Unsafe webhook URL: ${staticErrors.join('; ')}`,
+      retryable: false,
     };
   }
 
   const method = config.method || 'POST';
-  const timeout = config.timeout || 30000; // 30 second default
-  const maxRetries = config.retryCount || 0;
+  // Runtime clamp protects pre-validation legacy JSON as well as new writes.
+  const requestedTimeout = typeof config.timeout === 'number' && Number.isFinite(config.timeout)
+    ? config.timeout
+    : 30_000;
+  const timeout = Math.min(60_000, Math.max(1_000, requestedTimeout));
 
   // Build headers
   const headers: Record<string, string> = {
@@ -224,7 +245,8 @@ export async function sendWebhookNotification(
     if (validateOutboundHeader(config.apiKeyHeader, config.apiKeyValue)) {
       return {
         success: false,
-        error: 'Invalid API key header'
+        error: 'Invalid API key header',
+        retryable: false,
       };
     }
     headers[config.apiKeyHeader.trim()] = config.apiKeyValue;
@@ -261,91 +283,88 @@ export async function sendWebhookNotification(
     });
   }
 
-  // Send request with retries
+  // Perform exactly one request. Alert delivery retries are scheduled by
+  // BullMQ, outside this scarce worker slot; direct test/automation calls are
+  // deliberately one-shot. Never reintroduce an in-process sleep loop here.
   let lastError: string | undefined;
   // The operator-facing `lastError` is deliberately short and markup-free
   // (#3992); the unshortened form is kept for the log line below so debugging
   // a strange destination loses nothing.
   let lastErrorDetail: string | undefined;
-  for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    try {
-      const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), timeout);
+  let retryable = true;
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeout);
+  try {
+    const response = await safeFetch(config.url, {
+      method,
+      headers,
+      body,
+      signal: controller.signal,
+      redirect: 'error',
+      // Must mirror the save-time decision, or a URL we accepted would be
+      // refused at delivery — the TOCTOU re-check is meant to catch DNS
+      // rebinding, not to second-guess the deployment's own policy.
+      allowPrivateNetwork: selfHostAllowsPrivateNetwork(),
+      // The cleartext allowance is for the operator's own LAN hop; safeFetch
+      // enforces it against the record it pins, so this cannot drift from the
+      // address actually dialed.
+      requirePrivateForCleartext: true
+    });
 
-      const response = await safeFetch(config.url, {
-        method,
-        headers,
-        body,
-        signal: controller.signal,
-        redirect: 'error',
-        // Must mirror the save-time decision, or a URL we accepted would be
-        // refused at delivery — the TOCTOU re-check is meant to catch DNS
-        // rebinding, not to second-guess the deployment's own policy.
-        allowPrivateNetwork: selfHostAllowsPrivateNetwork(),
-        // The cleartext allowance is for the operator's own LAN hop; safeFetch
-        // enforces it against the record it pins, so this cannot drift from the
-        // address actually dialed.
-        requirePrivateForCleartext: true
-      });
+    const responseBody = await response.text();
 
-      clearTimeout(timeoutId);
+    if (response.ok) {
+      return {
+        success: true,
+        statusCode: response.status,
+        responseBody
+      };
+    }
 
-      const responseBody = await response.text();
+    // Non-2xx response. Redact the channel's own credentials from the RAW
+    // body first: the route's scrub runs on the already-transformed string.
+    const secrets = collectChannelSecretStrings('webhook', config);
+    lastError = formatHttpFailure(response.status, responseBody, { secrets });
+    lastErrorDetail = formatHttpFailureDetail(response.status, responseBody, secrets);
 
-      if (response.ok) {
-        return {
-          success: true,
-          statusCode: response.status,
-          responseBody
-        };
-      }
-
-      // Non-2xx response
-      // Redact the channel's own credentials from the RAW body first: the
-      // route's scrub runs on the already-transformed string and matches by
-      // literal substring, so it cannot catch what normalisation rewrote (#3992).
-      const secrets = collectChannelSecretStrings('webhook', config);
-      lastError = formatHttpFailure(response.status, responseBody, { secrets });
-      lastErrorDetail = formatHttpFailureDetail(response.status, responseBody, secrets);
-
-      // Don't retry on 4xx errors (client errors)
-      if (response.status >= 400 && response.status < 500) {
-        break;
-      }
-    } catch (error) {
-      if (error instanceof SsrfBlockedError) {
-        // DNS resolved to a private IP — do not retry, the answer won't change
-        // on this timescale and we don't want to spam DNS either.
-        return {
-          success: false,
-          error: `Unsafe webhook URL: ${error.message}`
-        };
-      }
-      if (error instanceof Error) {
-        if (error.name === 'AbortError') {
-          lastError = 'Request timed out';
-          lastErrorDetail = lastError;
-        } else {
-          lastError = error.message;
-          lastErrorDetail = lastError;
-        }
+    // Retry only statuses that can reasonably be transient. In particular,
+    // rate limiting is not a durable configuration failure, while ordinary
+    // 4xx responses should dead-letter instead of consuming the queue budget.
+    retryable = response.status === 408
+      || response.status === 425
+      || response.status === 429
+      || response.status >= 500;
+  } catch (error) {
+    if (error instanceof SsrfBlockedError) {
+      // DNS policy failures are durable configuration errors.
+      return {
+        success: false,
+        error: `Unsafe webhook URL: ${error.message}`,
+        retryable: false,
+      };
+    }
+    if (error instanceof Error) {
+      if (error.name === 'AbortError') {
+        lastError = 'Request timed out';
+        lastErrorDetail = lastError;
       } else {
-        lastError = 'Unknown error';
+        lastError = error.message;
         lastErrorDetail = lastError;
       }
+    } else {
+      lastError = 'Unknown error';
+      lastErrorDetail = lastError;
     }
-
-    // Wait before retry (exponential backoff)
-    if (attempt < maxRetries) {
-      await new Promise(resolve => setTimeout(resolve, Math.pow(2, attempt) * 1000));
-    }
+  } finally {
+    clearTimeout(timeoutId);
   }
 
   console.error(`[WebhookSender] Failed to send to ${redactUrlForLogs(config.url)}: ${lastErrorDetail ?? lastError}`);
 
   return {
     success: false,
-    error: lastError
+    error: lastError,
+    retryable,
   };
 }
 
@@ -462,6 +481,18 @@ export function validateWebhookConfig(config: unknown): { valid: boolean; errors
     if (typeof c.timeout !== 'number' || c.timeout < 1000 || c.timeout > 60000) {
       errors.push('Timeout must be between 1000 and 60000 milliseconds');
     }
+  }
+
+  // Retries are durable queue jobs, not sleeps inside a five-slot worker.
+  // retryCount means retries AFTER the initial request, hence max 2 -> 3
+  // total attempts. Runtime scheduling also clamps legacy stored values.
+  if (c.retryCount !== undefined && (
+    typeof c.retryCount !== 'number'
+    || !Number.isInteger(c.retryCount)
+    || c.retryCount < 0
+    || c.retryCount > MAX_WEBHOOK_RETRIES
+  )) {
+    errors.push(`retryCount must be an integer between 0 and ${MAX_WEBHOOK_RETRIES}`);
   }
 
   // Validate payload template if provided


### PR DESCRIPTION
## Summary

Alert webhook and notification delivery could retry an unbounded/uncapped
number of times per queued job, and the per-attempt webhook sender ran its
own internal retry loop on top of BullMQ's queue-level retries, so a slow or
misbehaving destination could consume worker time far beyond the intended
retry budget. This hardens delivery to a bounded, predictable retry policy:

- Alert notification jobs (webhook and other channel types) are now queued
  with an explicit, capped `attempts` count derived from the channel's own
  configuration, rather than always assuming a flat retry count.
- The webhook sender performs exactly one HTTP attempt per invocation; retry
  scheduling is left entirely to BullMQ's queue-level backoff, removing the
  in-process retry loop that previously ran inside a single worker slot.
- Transport failures are classified as retryable or not: permanent failures
  (invalid webhook configuration, SSRF-blocked URLs, ordinary 4xx client
  errors) are surfaced via BullMQ's `UnrecoverableError` so they dead-letter
  immediately instead of consuming the bounded retry budget, while transient
  failures (timeouts, 408/425/429, 5xx) remain retryable up to the cap.
- A companion migration normalizes any legacy `notification_channels` webhook
  `retryCount` values into the newly supported 0..2 range, with the cleanup
  count logged via `RAISE WARNING` for the operational record.

## Test plan

- [x] `npx tsc --noEmit` (apps/api) — clean
- [x] `pnpm --filter @breeze/api lint` — clean
- [x] Unit tests: `notificationDispatcher.orderingGuards.test.ts`,
      `notificationDispatcher.test.ts`, `webhookSender.retryBudget.test.ts`,
      `webhookSender.test.ts` — 4 files / 93 tests passed
- [x] Integration tests (live Postgres+Redis):
      `webhookRetryBudget.integration.test.ts`,
      `webhookRetryQueue.integration.test.ts` — 2 files / 2 tests passed
- [x] `scripts/check-migration-naming.sh` and `src/db/autoMigrate.test.ts` — passed
- [x] RLS contract suite (`vitest.config.rls.ts`) — 2 files / 31 tests passed
- [x] Tenant cascade / export-policy contract suites
      (`tenantCascade.integration.test.ts`,
      `tenant-export-policy.integration.test.ts`,
      `tenantExportErasureRoundtrip.integration.test.ts`,
      `rls-coverage` via its dedicated `vitest.config.rls-coverage.ts` runner)
      — all passed (14 + 102 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CY81usuo74quP5Ci39Eqhh
