### PR TITLE
fix(portal): separate password and Entra identity paths; epoch-check invitations and live sessions

### DIFF
--- a/apps/api/migrations/2026-10-15-150010-portal-user-auth-epoch.sql
+++ b/apps/api/migrations/2026-10-15-150010-portal-user-auth-epoch.sql
@@ -1,0 +1,29 @@
+ALTER TABLE portal_users
+  ADD COLUMN IF NOT EXISTS auth_epoch integer;
+
+SELECT set_config('breeze.scope', 'system', true);
+
+DO $$
+DECLARE
+  affected_rows bigint;
+BEGIN
+  UPDATE portal_users SET auth_epoch = 1 WHERE auth_epoch IS NULL;
+  GET DIAGNOSTICS affected_rows = ROW_COUNT;
+  RAISE WARNING 'initialized auth_epoch for % portal_users rows', affected_rows;
+END $$;
+
+ALTER TABLE portal_users
+  ALTER COLUMN auth_epoch SET DEFAULT 1,
+  ALTER COLUMN auth_epoch SET NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'portal_users'::regclass
+      AND conname = 'portal_users_auth_epoch_positive_chk'
+  ) THEN
+    ALTER TABLE portal_users
+      ADD CONSTRAINT portal_users_auth_epoch_positive_chk CHECK (auth_epoch > 0);
+  END IF;
+END $$;

--- a/apps/api/src/__tests__/integration/orgMergeCustomExecutors.integration.test.ts
+++ b/apps/api/src/__tests__/integration/orgMergeCustomExecutors.integration.test.ts
@@ -199,13 +199,14 @@ describe('org merge engine SQL against real Postgres', () => {
         token: portalToken,
         portalUserId,
         orgId: L,
+        authEpoch: 1,
         createdAt: new Date(),
         expiresAt: new Date(Date.now() + 3600_000),
       });
 
       const redis = getRedis();
       expect(redis, 'this test requires the test Redis to be reachable').not.toBeNull();
-      await redis!.setex(`clientai:session:${clientAiToken}`, 3600, JSON.stringify({ portalUserId, orgId: L }));
+      await redis!.setex(`clientai:session:${clientAiToken}`, 3600, JSON.stringify({ portalUserId, orgId: L, authEpoch: 1 }));
       await redis!.sadd(`clientai:user-sessions:${portalUserId}`, clientAiToken);
 
       await fenceLoser(candidate);

--- a/apps/api/src/__tests__/integration/portal-routes-rls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/portal-routes-rls.integration.test.ts
@@ -20,11 +20,12 @@ import { createHash } from 'crypto';
 import { Hono } from 'hono';
 import { describe, expect, it } from 'vitest';
 import { portalRoutes } from '../../routes/portal';
-import { portalResetTokens } from '../../routes/portal/helpers';
+import { portalResetTokens, portalSessions } from '../../routes/portal/helpers';
 import { portalUsers, devices, portalBranding } from '../../db/schema';
 import { hashPassword } from '../../services/password';
 import { createPartner, createOrganization, createSite } from './db-utils';
 import { getTestDb } from './setup';
+import { eq } from 'drizzle-orm';
 
 const PORTAL_PASSWORD = 'PortalPass123!';
 
@@ -275,6 +276,63 @@ describe('portal routes — scoped DB access context (breeze_app pool)', () => {
       body: JSON.stringify({ email: portalUser.email, password: PORTAL_PASSWORD, orgId }),
     });
     expect(loginOld.status).toBe(401);
+  });
+
+  it('keeps an Entra identity out of local login, reset, and existing portal sessions', async () => {
+    const { orgId } = await seedOrgWithDevice('portal-entra-method-host');
+    const admin = getTestDb() as any;
+    const contaminatedHash = await hashPassword(PORTAL_PASSWORD);
+    const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const [entraUser] = await admin.insert(portalUsers).values({
+      orgId,
+      email: `portal-entra-${unique}@example.test`,
+      name: 'Entra Customer',
+      passwordHash: contaminatedHash,
+      authMethod: 'entra',
+      entraOid: `oid-${unique}`,
+      entraTenantId: `tenant-${unique}`,
+      status: 'active',
+    }).returning();
+    const app = buildPortalApp();
+
+    const loginRes = await app.request('/portal/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: entraUser.email, password: PORTAL_PASSWORD, orgId }),
+    });
+    expect(loginRes.status).toBe(401);
+
+    const resetToken = `entra-reset-${unique}`;
+    const tokenHash = createHash('sha256').update(resetToken).digest('hex');
+    portalResetTokens.set(tokenHash, {
+      userId: entraUser.id,
+      expiresAt: new Date(Date.now() + 60_000),
+      createdAt: new Date(),
+    });
+    const resetRes = await app.request('/portal/auth/reset-password', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token: resetToken, password: 'DifferentPortalPass456!' }),
+    });
+    expect(resetRes.status).toBe(400);
+    const [afterReset] = await admin.select({ passwordHash: portalUsers.passwordHash })
+      .from(portalUsers).where(eq(portalUsers.id, entraUser.id)).limit(1);
+    expect(afterReset.passwordHash).toBe(contaminatedHash);
+
+    const sessionToken = `legacy-entra-session-${unique}`;
+    portalSessions.set(sessionToken, {
+      token: sessionToken,
+      portalUserId: entraUser.id,
+      orgId,
+      authEpoch: entraUser.authEpoch,
+      createdAt: new Date(),
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    const profileRes = await app.request('/portal/profile', {
+      headers: { Authorization: `Bearer ${sessionToken}` },
+    });
+    expect(profileRes.status).toBe(401);
+    expect(portalSessions.has(sessionToken)).toBe(false);
   });
 
   it('profile read + update works under org scope', async () => {

--- a/apps/api/src/__tests__/integration/portalAuthAudit.integration.test.ts
+++ b/apps/api/src/__tests__/integration/portalAuthAudit.integration.test.ts
@@ -1,0 +1,51 @@
+import './setup';
+import { Hono } from 'hono';
+import { eq } from 'drizzle-orm';
+import { describe, expect, it } from 'vitest';
+import { auditLogs, portalUsers } from '../../db/schema';
+import { hashPassword } from '../../services/password';
+import { authRoutes } from '../../routes/portal/auth';
+import { createOrganization, createPartner } from './db-utils';
+import { getTestDb } from './setup';
+
+describe.runIf(!!process.env.DATABASE_URL_APP)('portal authentication audit persistence', () => {
+  it('persists attributable success and denial without credential material', async () => {
+    const db = getTestDb();
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const password = 'Synthetic-Portal-Pass-156!';
+    const [user] = await db.insert(portalUsers).values({
+      orgId: org.id,
+      email: `portal-audit-${Date.now()}@example.test`,
+      name: 'Portal Audit Fixture',
+      passwordHash: await hashPassword(password),
+      status: 'active',
+    }).returning();
+    if (!user) throw new Error('failed to seed portal user');
+    const app = new Hono().route('/', authRoutes);
+
+    const denied = await app.request('/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'User-Agent': 'synthetic-audit-test' },
+      body: JSON.stringify({ email: user.email, password: `${password}-wrong`, orgId: org.id }),
+    });
+    expect(denied.status).toBe(401);
+
+    const allowed = await app.request('/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'User-Agent': 'synthetic-audit-test' },
+      body: JSON.stringify({ email: user.email, password, orgId: org.id }),
+    });
+    expect(allowed.status).toBe(200);
+
+    const rows = await db.select().from(auditLogs).where(eq(auditLogs.action, 'portal.auth.login'));
+    expect(rows.map((row) => row.result).sort()).toEqual(['denied', 'success']);
+    for (const row of rows) {
+      expect(row.orgId).toBe(org.id);
+      expect(row.actorId).toBe(user.id);
+      expect(row.actorEmail).toBe(user.email);
+      expect(row.details).toEqual({ httpStatus: row.result === 'success' ? 200 : 401 });
+      expect(JSON.stringify(row)).not.toContain(password);
+    }
+  });
+});

--- a/apps/api/src/__tests__/integration/portalAuthEpoch.integration.test.ts
+++ b/apps/api/src/__tests__/integration/portalAuthEpoch.integration.test.ts
@@ -1,0 +1,97 @@
+import './setup';
+import { randomUUID } from 'crypto';
+import { Hono } from 'hono';
+import { describe, expect, it } from 'vitest';
+import { eq, sql } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../../db';
+import { portalUsers } from '../../db/schema';
+import { clientAiAuthMiddleware } from '../../middleware/clientAiAuth';
+import { portalAuthMiddleware } from '../../routes/portal/auth';
+import { portalSessions } from '../../routes/portal/helpers';
+import { CLIENT_AI_REDIS_KEYS } from '../../routes/clientAi/schemas';
+import { createOrganization, createPartner } from './db-utils';
+import { getTestDb, getTestRedis } from './setup';
+
+async function seedPortalUser() {
+  const partner = await createPartner();
+  const org = await createOrganization({ partnerId: partner.id });
+  const [user] = await getTestDb()
+    .insert(portalUsers)
+    .values({ orgId: org.id, email: `${randomUUID()}@epoch.test`, status: 'active' })
+    .returning({ id: portalUsers.id, orgId: portalUsers.orgId, authEpoch: portalUsers.authEpoch });
+  return user!;
+}
+
+async function advanceEpoch(userId: string) {
+  const [row] = await withSystemDbAccessContext(() =>
+    db
+      .update(portalUsers)
+      .set({ authEpoch: sql`${portalUsers.authEpoch} + 1` })
+      .where(eq(portalUsers.id, userId))
+      .returning({ authEpoch: portalUsers.authEpoch })
+  );
+  return row!.authEpoch;
+}
+
+describe('portal auth epoch — real PostgreSQL as breeze_app', () => {
+  it('admits the current generation and rejects the same portal token after an epoch advance', async () => {
+    const user = await seedPortalUser();
+    const token = `portal-${randomUUID()}`;
+    portalSessions.set(token, {
+      token,
+      portalUserId: user.id,
+      orgId: user.orgId,
+      authEpoch: user.authEpoch,
+      createdAt: new Date(),
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    const app = new Hono();
+    app.use('*', portalAuthMiddleware);
+    app.get('/protected', (c) => c.json({ id: c.get('portalAuth').user.id }));
+
+    expect((await app.request('/protected', { headers: { Authorization: `Bearer ${token}` } })).status).toBe(200);
+    await advanceEpoch(user.id);
+    expect((await app.request('/protected', { headers: { Authorization: `Bearer ${token}` } })).status).toBe(401);
+    expect(portalSessions.has(token)).toBe(false);
+  });
+
+  it('rejects and removes a stale client-AI Redis session before opening its org context', async () => {
+    const user = await seedPortalUser();
+    const token = `client-ai-${randomUUID()}`;
+    const redis = getTestRedis();
+    await redis.set(
+      CLIENT_AI_REDIS_KEYS.session(token),
+      JSON.stringify({ portalUserId: user.id, orgId: user.orgId, authEpoch: user.authEpoch, createdAt: new Date().toISOString() })
+    );
+    await redis.sadd(CLIENT_AI_REDIS_KEYS.userSessions(user.id), token);
+    await advanceEpoch(user.id);
+    const app = new Hono();
+    app.use('*', clientAiAuthMiddleware);
+    app.get('/protected', () => new Response('downstream'));
+
+    const res = await app.request('/protected', { headers: { Authorization: `Bearer ${token}` } });
+
+    expect(res.status).toBe(401);
+    expect(await redis.get(CLIENT_AI_REDIS_KEYS.session(token))).toBeNull();
+    expect(await redis.sismember(CLIENT_AI_REDIS_KEYS.userSessions(user.id), token)).toBe(0);
+  });
+
+  it('fails closed when a session claims the wrong organization', async () => {
+    const user = await seedPortalUser();
+    const other = await createOrganization({ partnerId: (await createPartner()).id });
+    const token = `portal-cross-org-${randomUUID()}`;
+    portalSessions.set(token, {
+      token,
+      portalUserId: user.id,
+      orgId: other.id,
+      authEpoch: user.authEpoch,
+      createdAt: new Date(),
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    const app = new Hono();
+    app.use('*', portalAuthMiddleware);
+    app.get('/protected', () => new Response('downstream'));
+
+    expect((await app.request('/protected', { headers: { Authorization: `Bearer ${token}` } })).status).toBe(401);
+  });
+});

--- a/apps/api/src/__tests__/integration/portalUserInvite.integration.test.ts
+++ b/apps/api/src/__tests__/integration/portalUserInvite.integration.test.ts
@@ -33,7 +33,7 @@
  *   4. bulk-invite must not re-invite a `status='disabled'` row (closes a
  *      gap not covered by the mocked unit test — `bulkWhere` excludes
  *      `disabled` rows at the SQL predicate level, which a mocked
- *      `db.select` can't exercise).
+ *      `db.select` can't exercise), nor an Entra JIT identity.
  */
 import './setup';
 import { Hono } from 'hono';
@@ -94,6 +94,7 @@ async function fetchPortalUser(userId: string) {
         email: portalUsers.email,
         status: portalUsers.status,
         passwordHash: portalUsers.passwordHash,
+        authMethod: portalUsers.authMethod,
         invitedBy: portalUsers.invitedBy,
         invitedAt: portalUsers.invitedAt,
       })
@@ -210,6 +211,41 @@ describe('portal user invite→accept — end-to-end + tenant isolation', () => 
     expect(loginBody.accessToken).toBeTruthy();
   });
 
+  it('never converts an Entra identity through single-invite or invite acceptance', async () => {
+    const envA = await setupTestEnvironment({ scope: 'partner' });
+    const mfaToken = await mfaTokenFor(envA);
+    const admin = getTestDb();
+    const [entraUser] = await admin.insert(portalUsers).values({
+      orgId: envA.organization.id,
+      email: 'entra-invite@acme.example',
+      passwordHash: null,
+      authMethod: 'entra',
+      entraOid: `oid-${Date.now()}`,
+      entraTenantId: `tenant-${Date.now()}`,
+      status: 'active',
+    }).returning();
+
+    const mspApp = buildMspApp();
+    const inviteRes = await mspApp.request(`/organizations/${envA.organization.id}/portal-users/invite`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${mfaToken}`, ...JSON_HEADERS },
+      body: JSON.stringify({ email: entraUser!.email }),
+    });
+    expect(inviteRes.status).toBe(409);
+
+    const rawToken = await storePortalInviteToken(entraUser!.id);
+    const acceptRes = await buildPortalApp().request('/portal/auth/accept-invite', {
+      method: 'POST',
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ token: rawToken, password: NEW_PORTAL_PASSWORD }),
+    });
+    expect(acceptRes.status).toBe(400);
+    const after = await fetchPortalUser(entraUser!.id);
+    expect(after!.authMethod).toBe('entra');
+    expect(after!.passwordHash).toBeNull();
+    expect(after!.status).toBe('active');
+  });
+
   it('bulk-invite skips a disabled portal_users row but re-invites a pending one', async () => {
     const envA = await setupTestEnvironment({ scope: 'partner' });
     const mfaToken = await mfaTokenFor(envA);
@@ -238,6 +274,19 @@ describe('portal user invite→accept — end-to-end + tenant isolation', () => 
       })
       .returning();
 
+    const [entraUser] = await admin
+      .insert(portalUsers)
+      .values({
+        orgId: envA.organization.id,
+        email: 'entra-bulk@acme.example',
+        passwordHash: null,
+        authMethod: 'entra',
+        entraOid: `bulk-oid-${Date.now()}`,
+        entraTenantId: `bulk-tenant-${Date.now()}`,
+        status: 'active',
+      })
+      .returning();
+
     const app = buildMspApp();
     const res = await app.request(`/organizations/${envA.organization.id}/portal-users/bulk-invite`, {
       method: 'POST',
@@ -249,6 +298,7 @@ describe('portal user invite→accept — end-to-end + tenant isolation', () => 
     const invitedIds = body.data.map((r: { id: string }) => r.id);
     expect(invitedIds).toContain(pendingUser!.id);
     expect(invitedIds).not.toContain(disabledUser!.id);
+    expect(invitedIds).not.toContain(entraUser!.id);
 
     const disabledRow = await fetchPortalUser(disabledUser!.id);
     expect(disabledRow!.status).toBe('disabled');
@@ -258,5 +308,10 @@ describe('portal user invite→accept — end-to-end + tenant isolation', () => 
     expect(pendingRow!.status).toBe('invited');
     expect(pendingRow!.invitedBy).toBe(envA.user.id);
     expect(pendingRow!.invitedAt).not.toBeNull();
+
+    const entraRow = await fetchPortalUser(entraUser!.id);
+    expect(entraRow!.authMethod).toBe('entra');
+    expect(entraRow!.status).toBe('active');
+    expect(entraRow!.invitedBy).toBeNull();
   });
 });

--- a/apps/api/src/db/schema/portal.ts
+++ b/apps/api/src/db/schema/portal.ts
@@ -56,6 +56,9 @@ export const portalUsers = pgTable('portal_users', {
   entraOid: text('entra_oid'),
   entraTenantId: text('entra_tenant_id'),
   authMethod: text('auth_method').notNull().default('password'), // 'password' | 'entra' (SQL CHECK)
+  // Durable generation snapshotted by portal and client-AI sessions. Redis
+  // deletion is cleanup; live authorization compares this column instead.
+  authEpoch: integer('auth_epoch').notNull().default(1),
   linkedUserId: uuid('linked_user_id').references(() => users.id),
   // A portal user is a LOGIN attached to a contact, not a second kind of
   // person (#3258). Nullable because the link is established after the fact by

--- a/apps/api/src/middleware/clientAiAuth.queryToken.test.ts
+++ b/apps/api/src/middleware/clientAiAuth.queryToken.test.ts
@@ -36,7 +36,7 @@ const TOKEN = 'tok_abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJK';
 
 const USER_ROW = {
   id: PORTAL_USER_ID, orgId: ORG_ID, email: 'finance.user@contoso.com',
-  name: 'Finance User', status: 'active', partnerAiForOfficeEnabled: true,
+  name: 'Finance User', status: 'active', authEpoch: 1, partnerAiForOfficeEnabled: true,
 };
 
 function buildApp() {
@@ -51,7 +51,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   getRedisMock.mockReturnValue(redisMock);
   redisMock.get.mockResolvedValue(
-    JSON.stringify({ portalUserId: PORTAL_USER_ID, orgId: ORG_ID, createdAt: new Date().toISOString() }),
+    JSON.stringify({ portalUserId: PORTAL_USER_ID, orgId: ORG_ID, authEpoch: 1, createdAt: new Date().toISOString() }),
   );
   dbSelectMock.mockImplementation(() => ({
     from: vi.fn(() => ({

--- a/apps/api/src/middleware/clientAiAuth.test.ts
+++ b/apps/api/src/middleware/clientAiAuth.test.ts
@@ -64,6 +64,7 @@ const USER_ROW = {
   email: 'finance.user@contoso.com',
   name: 'Finance User',
   status: 'active',
+  authEpoch: 1,
   partnerAiForOfficeEnabled: true,
 };
 
@@ -96,7 +97,7 @@ beforeEach(() => {
   capturedDbContexts.length = 0;
   getRedisMock.mockReturnValue(redisMock);
   redisMock.get.mockResolvedValue(
-    JSON.stringify({ portalUserId: PORTAL_USER_ID, orgId: ORG_ID, createdAt: new Date().toISOString() })
+    JSON.stringify({ portalUserId: PORTAL_USER_ID, orgId: ORG_ID, authEpoch: 1, createdAt: new Date().toISOString() })
   );
   setupUserSelect(USER_ROW);
 });

--- a/apps/api/src/middleware/clientAiAuth.ts
+++ b/apps/api/src/middleware/clientAiAuth.ts
@@ -67,6 +67,7 @@ export async function clientAiAuthMiddleware(c: Context, next: Next) {
         email: portalUsers.email,
         name: portalUsers.name,
         status: portalUsers.status,
+        authEpoch: portalUsers.authEpoch,
         partnerAiForOfficeEnabled: partners.aiForOfficeEnabled,
       })
       .from(portalUsers)
@@ -78,6 +79,16 @@ export async function clientAiAuthMiddleware(c: Context, next: Next) {
 
   if (!user) {
     await redis.del(CLIENT_AI_REDIS_KEYS.session(token));
+    return c.json({ error: 'Invalid or expired session' }, 401);
+  }
+
+  if (
+    !Number.isSafeInteger(session.authEpoch)
+    || session.authEpoch <= 0
+    || user.authEpoch !== session.authEpoch
+  ) {
+    await redis.del(CLIENT_AI_REDIS_KEYS.session(token));
+    await redis.srem(CLIENT_AI_REDIS_KEYS.userSessions(user.id), token);
     return c.json({ error: 'Invalid or expired session' }, 401);
   }
 

--- a/apps/api/src/middleware/clientAiAuthOrgStatusGate.test.ts
+++ b/apps/api/src/middleware/clientAiAuthOrgStatusGate.test.ts
@@ -91,15 +91,68 @@ beforeEach(() => {
     email: 'finance.user@contoso.com',
     name: 'Finance User',
     status: 'active',
+    authEpoch: 1,
     partnerAiForOfficeEnabled: true,
   };
   setupUserSelect(userRow.current);
   redisMock.get.mockResolvedValue(
-    JSON.stringify({ portalUserId: PORTAL_USER_ID, orgId: ORG_ID, createdAt: new Date().toISOString() }),
+    JSON.stringify({ portalUserId: PORTAL_USER_ID, orgId: ORG_ID, authEpoch: 1, createdAt: new Date().toISOString() }),
   );
 });
 
 describe('clientAiAuthMiddleware org-status gate', () => {
+  it('fails closed without opening org context when the durable epoch lookup is uncertain', async () => {
+    dbSelectMock.mockImplementation(() => ({
+      from: () => ({
+        innerJoin: () => ({
+          innerJoin: () => ({
+            where: () => ({ limit: () => Promise.reject(new Error('synthetic database uncertainty')) }),
+          }),
+        }),
+      }),
+    }));
+
+    const res = await call();
+
+    expect(res.status).toBe(500);
+    expect(capturedDbContexts).toHaveLength(0);
+    expect(getActiveOrgTenant).not.toHaveBeenCalled();
+  });
+
+  it('fails closed for a legacy session that has no durable epoch snapshot', async () => {
+    redisMock.get.mockResolvedValue(JSON.stringify({ portalUserId: PORTAL_USER_ID, orgId: ORG_ID }));
+
+    const res = await call();
+
+    expect(res.status).toBe(401);
+    expect(redisMock.del).toHaveBeenCalledWith(`clientai:session:${TOKEN}`);
+    expect(getActiveOrgTenant).not.toHaveBeenCalled();
+  });
+
+  it('rejects a session minted before the durable portal auth epoch advanced', async () => {
+    userRow.current = { ...userRow.current, authEpoch: 2 };
+    setupUserSelect(userRow.current);
+
+    const res = await call();
+
+    expect(res.status).toBe(401);
+    expect(redisMock.del).toHaveBeenCalledWith(`clientai:session:${TOKEN}`);
+    expect(getActiveOrgTenant).not.toHaveBeenCalled();
+    expect(capturedDbContexts).toHaveLength(0);
+  });
+
+  it('still fails closed when stale-session Redis cleanup fails', async () => {
+    userRow.current = { ...userRow.current, authEpoch: 2 };
+    setupUserSelect(userRow.current);
+    redisMock.del.mockRejectedValueOnce(new Error('synthetic Redis fault'));
+
+    const res = await call();
+
+    expect(res.status).toBe(500);
+    expect(getActiveOrgTenant).not.toHaveBeenCalled();
+    expect(capturedDbContexts).toHaveLength(0);
+  });
+
   it('admits an add-in session whose org is usable', async () => {
     const res = await call();
     expect(res.status).toBe(200);

--- a/apps/api/src/routes/clientAi/auth.test.ts
+++ b/apps/api/src/routes/clientAi/auth.test.ts
@@ -125,6 +125,7 @@ const USER_ROW = {
   email: 'finance.user@contoso.com',
   name: 'Finance User',
   status: 'active',
+  authMethod: 'entra',
   // Already linked (#3258), so an ordinary repeat login re-derives nothing.
   contactId: 'c0c0c0c0-1111-4222-8333-444455556666',
 };

--- a/apps/api/src/routes/clientAi/schemas.ts
+++ b/apps/api/src/routes/clientAi/schemas.ts
@@ -200,6 +200,7 @@ export const clientToolResultSchema = z.object({
 export type ClientAiSessionPayload = {
   portalUserId: string;
   orgId: string;
+  authEpoch: number;
   createdAt: string;
 };
 

--- a/apps/api/src/routes/orgPortalUsers.test.ts
+++ b/apps/api/src/routes/orgPortalUsers.test.ts
@@ -59,7 +59,7 @@ vi.mock('../db', () => ({
   }
 }));
 vi.mock('../db/schema', () => ({
-  portalUsers: { id: 'id', orgId: 'orgId', email: 'email', name: 'name', passwordHash: 'passwordHash', receiveNotifications: 'receiveNotifications', status: 'status', invitedBy: 'invitedBy', invitedAt: 'invitedAt', lastLoginAt: 'lastLoginAt', createdAt: 'createdAt', contactId: 'contactId' },
+  portalUsers: { id: 'id', orgId: 'orgId', email: 'email', name: 'name', passwordHash: 'passwordHash', authMethod: 'authMethod', receiveNotifications: 'receiveNotifications', status: 'status', invitedBy: 'invitedBy', invitedAt: 'invitedAt', lastLoginAt: 'lastLoginAt', createdAt: 'createdAt', contactId: 'contactId' },
   contacts: { id: 'id', orgId: 'orgId', email: 'email', roles: 'roles' },
   organizations: { id: 'id', name: 'name', deletedAt: 'deletedAt' },
   tickets: { id: 'id', submittedBy: 'submittedBy' },
@@ -71,11 +71,16 @@ vi.mock('../services/contacts/crud', async () => {
   const actual = await vi.importActual<typeof import('../services/contacts/crud')>('../services/contacts/crud');
   return { ...actual, createContact: createContactMock, updateContact: updateContactMock };
 });
-vi.mock('../routes/portal/helpers', () => ({ storePortalInviteToken: vi.fn(async () => 'raw-token'), buildPortalUrl: (p: string) => `https://x/portal${p}` }));
+vi.mock('../routes/portal/helpers', () => ({
+  storePortalInviteToken: vi.fn(async () => 'raw-token'),
+  buildPortalUrl: (p: string) => `https://x/portal${p}`,
+  purgePortalSessionsForUsers: vi.fn(async () => 0),
+}));
 vi.mock('../services/email', () => ({ getEmailService: () => ({ sendPortalInvite: sendInvite }) }));
 
 import { authMiddleware } from '../middleware/auth';
 import { registerOrgPortalUsersRoutes } from './orgPortalUsers';
+import { purgePortalSessionsForUsers } from './portal/helpers';
 
 const ORG_ID = '7c0a1f7e-1111-4222-8333-444455556666';
 const makeApp = () => { const app = new Hono(); app.use('*', authMiddleware as any); registerOrgPortalUsersRoutes(app); return app; };
@@ -236,7 +241,7 @@ describe('POST /organizations/:id/portal-users/invite', () => {
   it('re-inviting an existing login NEVER overwrites a contact link it already has', async () => {
     selectResult
       .mockResolvedValueOnce([{ id: ORG_ID }])
-      .mockResolvedValueOnce([{ id: 'pu-1', email: 'again@acme.example', passwordHash: null, status: 'invited', contactId: 'ct-existing' }])
+      .mockResolvedValueOnce([{ id: 'pu-1', email: 'again@acme.example', passwordHash: null, authMethod: 'password', status: 'invited', contactId: 'ct-existing' }])
       .mockResolvedValueOnce([{ name: 'Acme Co' }]);
     insertReturning.mockResolvedValueOnce([{ id: 'pu-1' }]);
 
@@ -259,7 +264,7 @@ describe('POST /organizations/:id/portal-users/invite', () => {
   it('re-inviting a login with NO contact link backfills one', async () => {
     selectResult
       .mockResolvedValueOnce([{ id: ORG_ID }])
-      .mockResolvedValueOnce([{ id: 'pu-1', email: 'again@acme.example', passwordHash: null, status: 'invited', contactId: null }])
+      .mockResolvedValueOnce([{ id: 'pu-1', email: 'again@acme.example', passwordHash: null, authMethod: 'password', status: 'invited', contactId: null }])
       .mockResolvedValueOnce([{ id: 'ct-1' }])
       .mockResolvedValueOnce([{ name: 'Acme Co' }]);
     insertReturning.mockResolvedValueOnce([{ id: 'pu-1' }]);
@@ -273,16 +278,26 @@ describe('POST /organizations/:id/portal-users/invite', () => {
   it('409s when the email is already an active account with a password', async () => {
     selectResult
       .mockResolvedValueOnce([{ id: ORG_ID }])
-      .mockResolvedValueOnce([{ id: 'pu-1', email: 'live@acme.example', passwordHash: 'h', status: 'active' }]);
+      .mockResolvedValueOnce([{ id: 'pu-1', email: 'live@acme.example', passwordHash: 'h', authMethod: 'password', status: 'active' }]);
     const res = await invite({ email: 'live@acme.example' });
     expect(res.status).toBe(409);
+    expect(sendInvite).not.toHaveBeenCalled();
+  });
+
+  it('409s without mutation or email when the address belongs to an Entra identity', async () => {
+    selectResult
+      .mockResolvedValueOnce([{ id: ORG_ID }])
+      .mockResolvedValueOnce([{ id: 'pu-entra', email: 'entra@acme.example', passwordHash: null, authMethod: 'entra', status: 'active', contactId: null }]);
+    const res = await invite({ email: 'entra@acme.example' });
+    expect(res.status).toBe(409);
+    expect(setSpy).not.toHaveBeenCalled();
     expect(sendInvite).not.toHaveBeenCalled();
   });
 
   it('409s when the existing row is disabled — disable is terminal, must not resurrect via invite', async () => {
     selectResult
       .mockResolvedValueOnce([{ id: ORG_ID }])
-      .mockResolvedValueOnce([{ id: 'pu-1', email: 'disabled@acme.example', passwordHash: 'h', status: 'disabled' }]);
+      .mockResolvedValueOnce([{ id: 'pu-1', email: 'disabled@acme.example', passwordHash: 'h', authMethod: 'password', status: 'disabled' }]);
     const res = await invite({ email: 'disabled@acme.example' });
     expect(res.status).toBe(409);
     expect(sendInvite).not.toHaveBeenCalled();
@@ -298,6 +313,20 @@ describe('PATCH /organizations/:id/portal-users/:userId', () => {
     insertReturning.mockResolvedValueOnce([{ id: 'pu-1', status: 'disabled' }]); // update .returning
     const res = await patch('pu-1', { status: 'disabled' });
     expect(res.status).toBe(200);
+    expect(setSpy).toHaveBeenCalledWith(expect.objectContaining({ authEpoch: expect.anything() }));
+    expect(purgePortalSessionsForUsers).toHaveBeenCalledWith(['pu-1']);
+  });
+
+  it('rotates the durable session epoch when a user is reactivated', async () => {
+    selectResult
+      .mockResolvedValueOnce([{ id: ORG_ID }])
+      .mockResolvedValueOnce([{ id: 'pu-1', orgId: ORG_ID, status: 'disabled' }]);
+    insertReturning.mockResolvedValueOnce([{ id: 'pu-1', status: 'active' }]);
+
+    const res = await patch('pu-1', { status: 'active' });
+
+    expect(res.status).toBe(200);
+    expect(setSpy).toHaveBeenCalledWith(expect.objectContaining({ authEpoch: expect.anything() }));
   });
 });
 
@@ -307,7 +336,7 @@ describe('POST /organizations/:id/portal-users/:userId/resend-invite', () => {
   it('resends the invite to a pending (no-password) user', async () => {
     selectResult
       .mockResolvedValueOnce([{ id: ORG_ID }]) // org
-      .mockResolvedValueOnce([{ id: 'pu-1', orgId: ORG_ID, email: 'pending@acme.example', name: null, passwordHash: null, status: 'invited' }]) // target
+      .mockResolvedValueOnce([{ id: 'pu-1', orgId: ORG_ID, email: 'pending@acme.example', name: null, passwordHash: null, authMethod: 'password', status: 'invited' }]) // target
       .mockResolvedValueOnce([{ name: 'Acme Co' }]); // org name
     const res = await resend('pu-1');
     expect(res.status).toBe(200);
@@ -318,8 +347,17 @@ describe('POST /organizations/:id/portal-users/:userId/resend-invite', () => {
   it('409s when the target already has an active password-set account', async () => {
     selectResult
       .mockResolvedValueOnce([{ id: ORG_ID }]) // org
-      .mockResolvedValueOnce([{ id: 'pu-1', orgId: ORG_ID, email: 'live@acme.example', name: null, passwordHash: 'h', status: 'active' }]); // target
+      .mockResolvedValueOnce([{ id: 'pu-1', orgId: ORG_ID, email: 'live@acme.example', name: null, passwordHash: 'h', authMethod: 'password', status: 'active' }]); // target
     const res = await resend('pu-1');
+    expect(res.status).toBe(409);
+    expect(sendInvite).not.toHaveBeenCalled();
+  });
+
+  it('409s without email when the target is an Entra identity', async () => {
+    selectResult
+      .mockResolvedValueOnce([{ id: ORG_ID }])
+      .mockResolvedValueOnce([{ id: 'pu-entra', orgId: ORG_ID, email: 'entra@acme.example', name: null, passwordHash: null, authMethod: 'entra', status: 'active' }]);
+    const res = await resend('pu-entra');
     expect(res.status).toBe(409);
     expect(sendInvite).not.toHaveBeenCalled();
   });
@@ -327,7 +365,7 @@ describe('POST /organizations/:id/portal-users/:userId/resend-invite', () => {
   it('409s when the target is disabled — disable is terminal, must not resurrect via resend', async () => {
     selectResult
       .mockResolvedValueOnce([{ id: ORG_ID }]) // org
-      .mockResolvedValueOnce([{ id: 'pu-1', orgId: ORG_ID, email: 'disabled@acme.example', name: null, passwordHash: 'h', status: 'disabled' }]); // target
+      .mockResolvedValueOnce([{ id: 'pu-1', orgId: ORG_ID, email: 'disabled@acme.example', name: null, passwordHash: 'h', authMethod: 'password', status: 'disabled' }]); // target
     const res = await resend('pu-1');
     expect(res.status).toBe(409);
     expect(sendInvite).not.toHaveBeenCalled();

--- a/apps/api/src/routes/orgPortalUsers.ts
+++ b/apps/api/src/routes/orgPortalUsers.ts
@@ -1,6 +1,6 @@
 import type { Hono } from 'hono';
 import { zValidator } from '../lib/validation';
-import { and, eq, isNull, desc, ne } from 'drizzle-orm';
+import { and, eq, isNull, desc, ne, sql } from 'drizzle-orm';
 import { db } from '../db';
 import { organizations, portalUsers, tickets, ticketComments, assetCheckouts } from '../db/schema';
 import { linkLoginToContact, type LoginContactOutcome } from '../services/contacts/loginLink';
@@ -8,7 +8,9 @@ import { requireMfa, requirePermission, requireScope, type AuthContext } from '.
 import { PERMISSIONS } from '../services/permissions';
 import { writeRouteAudit } from '../services/auditEvents';
 import { getEmailService } from '../services/email';
-import { storePortalInviteToken, buildPortalUrl } from './portal/helpers';
+import { getRedis } from '../services/redis';
+import { purgeClientAiSessionsForUsers } from '../services/clientAiSessionStore';
+import { storePortalInviteToken, buildPortalUrl, purgePortalSessionsForUsers } from './portal/helpers';
 import { invitePortalUserSchema, bulkInvitePortalUsersSchema, updatePortalUserSchema } from '@breeze/shared';
 
 // MSP-facing customer-portal user management (portal_users): list, invite,
@@ -65,7 +67,7 @@ async function resolveAccessibleOrg(c: any): Promise<{ id: string } | Response> 
 }
 
 async function getOrgScopedPortalUser(orgId: string, userId: string) {
-  const [row] = await db.select({ id: portalUsers.id, orgId: portalUsers.orgId, email: portalUsers.email, name: portalUsers.name, passwordHash: portalUsers.passwordHash, status: portalUsers.status })
+  const [row] = await db.select({ id: portalUsers.id, orgId: portalUsers.orgId, email: portalUsers.email, name: portalUsers.name, passwordHash: portalUsers.passwordHash, authMethod: portalUsers.authMethod, status: portalUsers.status })
     .from(portalUsers).where(and(eq(portalUsers.id, userId), eq(portalUsers.orgId, orgId))).limit(1);
   return row ?? null;
 }
@@ -168,8 +170,12 @@ export function registerOrgPortalUsersRoutes(orgRoutes: Hono) {
     const { email, name, message } = c.req.valid('json');
     const normalizedEmail = email.trim().toLowerCase();
 
-    const [existing] = await db.select({ id: portalUsers.id, email: portalUsers.email, passwordHash: portalUsers.passwordHash, status: portalUsers.status, contactId: portalUsers.contactId })
+    const [existing] = await db.select({ id: portalUsers.id, email: portalUsers.email, passwordHash: portalUsers.passwordHash, authMethod: portalUsers.authMethod, status: portalUsers.status, contactId: portalUsers.contactId })
       .from(portalUsers).where(and(eq(portalUsers.orgId, org.id), eq(portalUsers.email, normalizedEmail))).limit(1);
+
+    if (existing && existing.authMethod !== 'password') {
+      return c.json({ error: 'This identity is managed by an external sign-in provider.' }, 409);
+    }
 
     if (existing && existing.status === 'disabled') {
       return c.json({ error: 'This user is disabled. Reactivate them before inviting.' }, 409);
@@ -202,7 +208,10 @@ export function registerOrgPortalUsersRoutes(orgRoutes: Hono) {
         contactLink = resolved.link;
         if (resolved.contactId) contactPatch.contactId = resolved.contactId;
       }
-      await db.update(portalUsers).set({ name: name ?? undefined, status: 'invited', invitedBy: auth.user.id, invitedAt: now, updatedAt: now, ...contactPatch }).where(eq(portalUsers.id, existing.id)).returning({ id: portalUsers.id });
+      await db.update(portalUsers).set({ name: name ?? undefined, status: 'invited', authEpoch: sql`${portalUsers.authEpoch} + 1`, invitedBy: auth.user.id, invitedAt: now, updatedAt: now, ...contactPatch }).where(eq(portalUsers.id, existing.id)).returning({ id: portalUsers.id });
+      await purgePortalSessionsForUsers([existing.id]);
+      const redis = getRedis();
+      if (redis) await purgeClientAiSessionsForUsers(redis, [existing.id]);
       userId = existing.id;
     } else {
       const resolved = await resolveInviteContact(org.id, normalizedEmail, name ?? null, auth.user.id);
@@ -230,7 +239,16 @@ export function registerOrgPortalUsersRoutes(orgRoutes: Hono) {
     if (Object.keys(body).length === 0) return c.json({ error: 'No updates provided' }, 400);
     const target = await getOrgScopedPortalUser(org.id, c.req.param('userId')!);
     if (!target) return c.json({ error: 'Portal user not found' }, 404);
-    const [updated] = await db.update(portalUsers).set({ ...body, updatedAt: new Date() }).where(eq(portalUsers.id, target.id)).returning({ id: portalUsers.id, status: portalUsers.status });
+    const [updated] = await db.update(portalUsers).set({
+      ...body,
+      ...(body.status !== undefined ? { authEpoch: sql`${portalUsers.authEpoch} + 1` } : {}),
+      updatedAt: new Date(),
+    }).where(eq(portalUsers.id, target.id)).returning({ id: portalUsers.id, status: portalUsers.status });
+    if (body.status !== undefined) {
+      await purgePortalSessionsForUsers([target.id]);
+      const redis = getRedis();
+      if (redis) await purgeClientAiSessionsForUsers(redis, [target.id]);
+    }
     writeRouteAudit(c, { orgId: org.id, action: 'organization.portal_user.update', resourceType: 'portal_user', resourceId: target.id, details: { changedFields: Object.keys(body) } });
     return c.json({ data: { id: updated!.id, status: updated!.status } });
   });
@@ -241,6 +259,7 @@ export function registerOrgPortalUsersRoutes(orgRoutes: Hono) {
     const auth = c.get('auth') as AuthContext;
     const target = await getOrgScopedPortalUser(org.id, c.req.param('userId')!);
     if (!target) return c.json({ error: 'Portal user not found' }, 404);
+    if (target.authMethod !== 'password') return c.json({ error: 'This identity is managed by an external sign-in provider.' }, 409);
     if (target.status === 'disabled') return c.json({ error: 'This user is disabled. Reactivate them first.' }, 409);
     if (target.passwordHash && target.status === 'active') return c.json({ error: 'This account is already set up.' }, 409);
     const [orgRow] = await db.select({ name: organizations.name }).from(organizations).where(eq(organizations.id, org.id)).limit(1);
@@ -255,14 +274,17 @@ export function registerOrgPortalUsersRoutes(orgRoutes: Hono) {
     const auth = c.get('auth') as AuthContext;
     const { userIds } = c.req.valid('json');
     // "Pending setup" = no password. Invite selected, or all pending in the org.
-    const baseWhere = and(eq(portalUsers.orgId, org.id), isNull(portalUsers.passwordHash), ne(portalUsers.status, 'disabled'));
+    const baseWhere = and(eq(portalUsers.orgId, org.id), eq(portalUsers.authMethod, 'password'), isNull(portalUsers.passwordHash), ne(portalUsers.status, 'disabled'));
     const candidates = await db.select({ id: portalUsers.id, email: portalUsers.email }).from(portalUsers).where(baseWhere);
     const targets = userIds && userIds.length > 0 ? candidates.filter((u) => userIds.includes(u.id)) : candidates;
     const [orgRow] = await db.select({ name: organizations.name }).from(organizations).where(eq(organizations.id, org.id)).limit(1);
     const now = new Date();
     const results: Array<{ id: string; emailSent: boolean }> = [];
     for (const t of targets) {
-      await db.update(portalUsers).set({ status: 'invited', invitedBy: auth.user.id, invitedAt: now, updatedAt: now }).where(eq(portalUsers.id, t.id));
+      await db.update(portalUsers).set({ status: 'invited', authEpoch: sql`${portalUsers.authEpoch} + 1`, invitedBy: auth.user.id, invitedAt: now, updatedAt: now }).where(eq(portalUsers.id, t.id));
+      await purgePortalSessionsForUsers([t.id]);
+      const redis = getRedis();
+      if (redis) await purgeClientAiSessionsForUsers(redis, [t.id]);
       const emailSent = await issueAndSendInvite(c, org.id, t, orgRow?.name ?? null, auth.user.name);
       results.push({ id: t.id, emailSent });
     }

--- a/apps/api/src/routes/portal.compat.test.ts
+++ b/apps/api/src/routes/portal.compat.test.ts
@@ -80,6 +80,7 @@ vi.mock('../db/schema', () => ({
     email: 'portalUsers.email',
     name: 'portalUsers.name',
     passwordHash: 'portalUsers.passwordHash',
+    authMethod: 'portalUsers.authMethod',
     receiveNotifications: 'portalUsers.receiveNotifications',
     status: 'portalUsers.status',
     lastLoginAt: 'portalUsers.lastLoginAt',
@@ -100,6 +101,7 @@ const portalUser = {
   email: 'portal@example.com',
   name: 'Portal User',
   passwordHash: 'hash',
+  authMethod: 'password',
   receiveNotifications: true,
   status: 'active'
 };

--- a/apps/api/src/routes/portal.test.ts
+++ b/apps/api/src/routes/portal.test.ts
@@ -179,8 +179,10 @@ const portalUser = {
   email: 'portal@example.com',
   name: 'Portal User',
   passwordHash: 'hash',
+  authMethod: 'password',
   receiveNotifications: true,
-  status: 'active'
+  status: 'active',
+  authEpoch: 1,
 };
 
 describe('portal routes', () => {
@@ -336,7 +338,8 @@ describe('portal routes', () => {
           {
             id: 'portal-user-1',
             email: 'portal@example.com',
-            orgId: 'f1b0c8a6-45d1-4f84-8b8b-0ad0ce620001'
+            orgId: 'f1b0c8a6-45d1-4f84-8b8b-0ad0ce620001',
+            authMethod: 'password'
           }
         ]) as any)
         .mockReturnValueOnce(mockSelectLimit([]) as any); // password reset defaults enabled
@@ -364,6 +367,7 @@ describe('portal routes', () => {
           id: 'portal-user-1',
           email: 'portal@example.com',
           orgId: 'f1b0c8a6-45d1-4f84-8b8b-0ad0ce620001',
+          authMethod: 'password',
         }]) as any)
         .mockReturnValueOnce(mockSelectLimit([{ enablePasswordReset: false }]) as any);
 
@@ -390,7 +394,8 @@ describe('portal routes', () => {
           {
             id: 'portal-user-1',
             email: 'portal@example.com',
-            orgId: 'org-123'
+            orgId: 'org-123',
+            authMethod: 'password'
           }
         ]) as any)
         .mockReturnValueOnce(mockSelectLimit([]) as any); // issuance feature flag
@@ -404,14 +409,20 @@ describe('portal routes', () => {
         })
       });
 
+      const resetUpdate = vi.fn();
       vi.mocked(db.update).mockReturnValueOnce({
-        set: vi.fn().mockReturnValue({
-          where: vi.fn().mockResolvedValue(undefined)
+        set: vi.fn((value) => {
+          resetUpdate(value);
+          return {
+            where: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([{ id: 'portal-user-1' }])
+            })
+          };
         })
       } as any);
 
       vi.mocked(db.select)
-        .mockReturnValueOnce(mockSelectLimit([{ orgId: 'org-123' }]) as any)
+        .mockReturnValueOnce(mockSelectLimit([{ orgId: 'org-123', authMethod: 'password' }]) as any)
         .mockReturnValueOnce(mockSelectLimit([]) as any); // consumption feature flag
 
       const res = await app.request('/portal/auth/reset-password', {
@@ -426,6 +437,7 @@ describe('portal routes', () => {
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body.success).toBe(true);
+      expect(resetUpdate).toHaveBeenCalledWith(expect.objectContaining({ authEpoch: expect.anything() }));
     });
 
     it('should reject invalid token', async () => {
@@ -450,6 +462,7 @@ describe('portal routes', () => {
           id: 'portal-user-reset-disabled',
           email: 'reset-disabled@example.com',
           orgId: 'org-reset-disabled',
+          authMethod: 'password',
         }]) as any)
         .mockReturnValueOnce(mockSelectLimit([{ enablePasswordReset: true }]) as any);
 
@@ -460,7 +473,7 @@ describe('portal routes', () => {
       });
 
       vi.mocked(db.select)
-        .mockReturnValueOnce(mockSelectLimit([{ orgId: 'org-reset-disabled' }]) as any)
+        .mockReturnValueOnce(mockSelectLimit([{ orgId: 'org-reset-disabled', authMethod: 'password' }]) as any)
         .mockReturnValueOnce(mockSelectLimit([{ enablePasswordReset: false }]) as any);
 
       const res = await app.request('/portal/auth/reset-password', {
@@ -1233,8 +1246,7 @@ describe('portal routes', () => {
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
         body: JSON.stringify({
           name: 'Updated User',
-          receiveNotifications: false,
-          password: 'NewStrongPass123'
+          receiveNotifications: false
         })
       });
 

--- a/apps/api/src/routes/portal/acceptInvite.test.ts
+++ b/apps/api/src/routes/portal/acceptInvite.test.ts
@@ -1,15 +1,25 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Hono } from 'hono';
 
-const { userRow, updateSpy } = vi.hoisted(() => ({
+const { userRow, updateSpy, sendPasswordResetSpy, updateRows } = vi.hoisted(() => ({
   userRow: { current: null as any },
-  updateSpy: vi.fn()
+  updateSpy: vi.fn(),
+  sendPasswordResetSpy: vi.fn(),
+  updateRows: { current: null as Array<{ authEpoch: number; id?: string }> | null },
+}));
+const { auditSpy } = vi.hoisted(() => ({ auditSpy: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('../../services/auditEvents', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../services/auditEvents')>()),
+  writeAuditEventAsync: auditSpy,
 }));
 
 vi.mock('../../db', () => ({
   db: {
     select: () => ({ from: () => ({ where: () => ({ limit: () => Promise.resolve(userRow.current ? [userRow.current] : []) }) }) }),
-    update: () => ({ set: (v: any) => ({ where: () => { updateSpy(v); return Promise.resolve(); } }) })
+    update: () => ({ set: (v: any) => ({ where: () => {
+      updateSpy(v);
+      return { returning: () => Promise.resolve(updateRows.current ?? [{ id: '11111111-2222-4333-8444-555566667777', authEpoch: (userRow.current?.authEpoch ?? 1) + 1 }]) };
+    } }) })
   },
   withDbAccessContext: (_ctx: any, fn: any) => fn(),
   withSystemDbAccessContext: (fn: any) => fn(),
@@ -22,8 +32,8 @@ vi.mock('../../db', () => ({
 // discoveredAssetTypeEnum: networkBaseline.ts (transitive import of the portal
 // route graph) reads its .enumValues at module load, so the full-module mock
 // must provide it or the suite fails to load.
-vi.mock('../../db/schema', () => ({ discoveredAssetTypeEnum: { enumValues: [] }, portalUsers: { id: 'id', orgId: 'orgId', email: 'email', name: 'name', passwordHash: 'passwordHash', receiveNotifications: 'receiveNotifications', status: 'status' } }));
-vi.mock('../../services/email', () => ({ getEmailService: () => null }));
+vi.mock('../../db/schema', () => ({ discoveredAssetTypeEnum: { enumValues: [] }, portalUsers: { id: 'id', orgId: 'orgId', email: 'email', name: 'name', passwordHash: 'passwordHash', authMethod: 'authMethod', authEpoch: 'authEpoch', receiveNotifications: 'receiveNotifications', status: 'status' }, portalBranding: { orgId: 'orgId', enablePasswordReset: 'enablePasswordReset' } }));
+vi.mock('../../services/email', () => ({ getEmailService: () => ({ sendPasswordReset: sendPasswordResetSpy }) }));
 
 import { authRoutes } from './auth';
 import { storePortalInviteToken } from './helpers';
@@ -32,12 +42,65 @@ const ORG_ID = '7c0a1f7e-1111-4222-8333-444455556666';
 const USER_ID = '11111111-2222-4333-8444-555566667777';
 const makeApp = () => { const app = new Hono(); app.route('/', authRoutes); return app; };
 const post = (body: unknown) => makeApp().request('/auth/accept-invite', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+const forgot = (body: unknown) => makeApp().request('/auth/forgot-password', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
 
-beforeEach(() => { vi.clearAllMocks(); userRow.current = null; });
+beforeEach(() => { vi.clearAllMocks(); auditSpy.mockResolvedValue(undefined); updateRows.current = null; userRow.current = null; });
+
+describe('portal authentication lifecycle audit', () => {
+  it.each([
+    ['/auth/login', 'portal.auth.login'],
+    ['/auth/forgot-password', 'portal.auth.password_reset.request'],
+    ['/auth/reset-password', 'portal.auth.password_reset.complete'],
+    ['/auth/accept-invite', 'portal.auth.invite.accept'],
+    ['/auth/logout', 'portal.auth.logout'],
+  ])('audits denied POST %s without copying credential input', async (path, action) => {
+    const secret = `must-not-persist-${path}`;
+    const res = await makeApp().request(path, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ password: secret, token: secret }),
+    });
+    expect(res.status).toBeGreaterThanOrEqual(400);
+    expect(auditSpy).toHaveBeenCalledTimes(1);
+    const event = auditSpy.mock.calls[0]![1];
+    expect(event).toMatchObject({ action, resourceType: 'portal_auth', result: 'denied' });
+    expect(JSON.stringify(event)).not.toContain(secret);
+  });
+
+  it('attributes a recovery request only after a current portal user resolves', async () => {
+    userRow.current = { id: USER_ID, orgId: ORG_ID, email: 'cust@acme.example', authMethod: 'password', authEpoch: 1 };
+    const res = await makeApp().request('/auth/forgot-password', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'cust@acme.example', orgId: ORG_ID }),
+    });
+    expect(res.status).toBe(200);
+    expect(auditSpy).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      orgId: ORG_ID,
+      actorId: USER_ID,
+      action: 'portal.auth.password_reset.request',
+      result: 'success',
+    }));
+  });
+
+  it('records an attributable handler exception as failure and rethrows it', async () => {
+    userRow.current = { id: USER_ID, orgId: ORG_ID, email: 'cust@acme.example', name: null, passwordHash: null, authMethod: 'password', authEpoch: 1, receiveNotifications: true, status: 'invited' };
+    const token = await storePortalInviteToken(USER_ID);
+    updateSpy.mockImplementationOnce(() => { throw new Error('synthetic update failure'); });
+    expect((await post({ token, password: 'Str0ngPass!' })).status).toBe(500);
+    expect(auditSpy).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      orgId: ORG_ID,
+      actorId: USER_ID,
+      action: 'portal.auth.invite.accept',
+      result: 'failure',
+      details: { httpStatus: 500 },
+    }));
+  });
+});
 
 describe('POST /auth/accept-invite', () => {
   it('activates an invited user and issues a session', async () => {
-    userRow.current = { id: USER_ID, orgId: ORG_ID, email: 'cust@acme.example', name: null, passwordHash: null, receiveNotifications: true, status: 'invited' };
+    userRow.current = { id: USER_ID, orgId: ORG_ID, email: 'cust@acme.example', name: null, passwordHash: null, authMethod: 'password', receiveNotifications: true, status: 'invited', authEpoch: 4 };
     const token = await storePortalInviteToken(USER_ID);
     const res = await post({ token, password: 'Str0ngPass!', name: 'Cust Omer' });
     expect(res.status).toBe(200);
@@ -45,6 +108,14 @@ describe('POST /auth/accept-invite', () => {
     expect(body.user.id).toBe(USER_ID);
     expect(body.accessToken).toBeTruthy();
     expect(updateSpy).toHaveBeenCalledWith(expect.objectContaining({ status: 'active', name: 'Cust Omer' }));
+    expect(updateSpy).toHaveBeenCalledWith(expect.objectContaining({ authEpoch: expect.anything() }));
+    expect(auditSpy).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      orgId: ORG_ID,
+      actorId: USER_ID,
+      actorEmail: 'cust@acme.example',
+      action: 'portal.auth.invite.accept',
+      result: 'success',
+    }));
   });
 
   it('rejects an invalid/expired token', async () => {
@@ -52,16 +123,36 @@ describe('POST /auth/accept-invite', () => {
     expect(res.status).toBe(400);
   });
 
+  it('fails closed when a concurrent status transition advances the checked generation', async () => {
+    userRow.current = { id: USER_ID, orgId: ORG_ID, email: 'cust@acme.example', name: null, passwordHash: null, authMethod: 'password', receiveNotifications: true, status: 'invited', authEpoch: 4 };
+    updateRows.current = [];
+    const token = await storePortalInviteToken(USER_ID);
+
+    const res = await post({ token, password: 'Str0ngPass!', name: 'Cust Omer' });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'Invalid or expired invite' });
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+  });
+
   it('rejects a disabled account, even with a valid consumed invite token', async () => {
-    userRow.current = { id: USER_ID, orgId: ORG_ID, email: 'cust@acme.example', name: null, passwordHash: null, receiveNotifications: true, status: 'disabled' };
+    userRow.current = { id: USER_ID, orgId: ORG_ID, email: 'cust@acme.example', name: null, passwordHash: null, authMethod: 'password', receiveNotifications: true, status: 'disabled' };
     const token = await storePortalInviteToken(USER_ID);
     const res = await post({ token, password: 'Str0ngPass!' });
     expect(res.status).toBe(403);
     expect(updateSpy).not.toHaveBeenCalled();
   });
 
+  it('rejects an Entra identity even when staff minted it an invite token', async () => {
+    userRow.current = { id: USER_ID, orgId: ORG_ID, email: 'entra@acme.example', name: null, passwordHash: null, authMethod: 'entra', receiveNotifications: true, status: 'active' };
+    const token = await storePortalInviteToken(USER_ID);
+    const res = await post({ token, password: 'Str0ngPass!' });
+    expect(res.status).toBe(400);
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
   it('rejects when the account is already active with a password', async () => {
-    userRow.current = { id: USER_ID, orgId: ORG_ID, email: 'cust@acme.example', name: 'X', passwordHash: 'existing-hash', receiveNotifications: true, status: 'active' };
+    userRow.current = { id: USER_ID, orgId: ORG_ID, email: 'cust@acme.example', name: 'X', passwordHash: 'existing-hash', authMethod: 'password', receiveNotifications: true, status: 'active' };
     const token = await storePortalInviteToken(USER_ID);
     const res = await post({ token, password: 'Str0ngPass!' });
     expect(res.status).toBe(400);
@@ -69,9 +160,18 @@ describe('POST /auth/accept-invite', () => {
   });
 
   it('rejects a weak password', async () => {
-    userRow.current = { id: USER_ID, orgId: ORG_ID, email: 'c@a.example', name: null, passwordHash: null, receiveNotifications: true, status: 'invited' };
+    userRow.current = { id: USER_ID, orgId: ORG_ID, email: 'c@a.example', name: null, passwordHash: null, authMethod: 'password', receiveNotifications: true, status: 'invited' };
     const token = await storePortalInviteToken(USER_ID);
     const res = await post({ token, password: 'short' });
     expect(res.status).toBe(400);
+  });
+});
+
+describe('POST /auth/forgot-password', () => {
+  it('does not mint or email a reset for an Entra identity', async () => {
+    userRow.current = { id: USER_ID, orgId: ORG_ID, email: 'entra@acme.example', authMethod: 'entra' };
+    const res = await forgot({ email: 'entra@acme.example', orgId: ORG_ID });
+    expect(res.status).toBe(200);
+    expect(sendPasswordResetSpy).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/routes/portal/auth.test.ts
+++ b/apps/api/src/routes/portal/auth.test.ts
@@ -85,6 +85,7 @@ function seedSession() {
     token: TOKEN,
     portalUserId: USER_ID,
     orgId: ORG_ID,
+    authEpoch: 1,
     createdAt: new Date(),
     expiresAt: new Date(Date.now() + 60 * 60 * 1000),
   });
@@ -101,6 +102,8 @@ beforeEach(() => {
     contactId: null,
     receiveNotifications: true,
     status: 'active',
+    authMethod: 'password',
+    authEpoch: 1,
   };
   activeOrgResult.current = { orgId: ORG_ID, partnerId: 'partner-1' };
 });

--- a/apps/api/src/routes/portal/auth.ts
+++ b/apps/api/src/routes/portal/auth.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import type { Context, Next } from 'hono';
 import { zValidator } from '../../lib/validation';
-import { and, eq } from 'drizzle-orm';
+import { and, eq, sql } from 'drizzle-orm';
 import { nanoid } from 'nanoid';
 import { createHash } from 'crypto';
 import { db, withDbAccessContext, withSystemDbAccessContext } from '../../db';
@@ -46,8 +46,11 @@ import {
   validatePortalCookieCsrfRequest,
   consumePortalInviteToken,
   buildPortalUrl,
+  purgePortalSessionsForUsers,
 } from './helpers';
 import { isSelfManagedDbContextRoute } from '../../middleware/selfManagedDbContextRoutes';
+import { purgeClientAiSessionsForUsers } from '../../services/clientAiSessionStore';
+import { ANONYMOUS_ACTOR_ID, writeAuditEventAsync } from '../../services/auditEvents';
 
 export const authRoutes = new Hono();
 const ALLOW_IN_MEMORY_PORTAL_STATE = !PORTAL_USE_REDIS;
@@ -65,6 +68,57 @@ export const PORTAL_ACCOUNT_INACTIVE_CODE = 'PORTAL_ACCOUNT_INACTIVE';
 function isPortalAuthGateExemptPath(path: string): boolean {
   return path.endsWith('/auth/logout');
 }
+
+const PORTAL_AUTH_AUDIT_ACTIONS = new Map<string, string>([
+  ['/auth/login', 'portal.auth.login'],
+  ['/auth/forgot-password', 'portal.auth.password_reset.request'],
+  ['/auth/reset-password', 'portal.auth.password_reset.complete'],
+  ['/auth/accept-invite', 'portal.auth.invite.accept'],
+  ['/auth/logout', 'portal.auth.logout'],
+]);
+
+function setPortalAuthAuditIdentity(
+  c: Context,
+  user: { id: string; orgId: string; email: string },
+): void {
+  c.set('portalAuthAuditIdentity', { userId: user.id, orgId: user.orgId, email: user.email });
+}
+
+// These public/session-auth endpoints sit outside the staff mutation fallback.
+// Wrap validation and the handler so every terminal response (including a
+// validator rejection or thrown failure) receives one secret-safe event.
+authRoutes.use('/auth/*', async (c, next) => {
+  const action = PORTAL_AUTH_AUDIT_ACTIONS.get(c.req.path.replace(/^\/api\/v1\/portal/, ''));
+  if (!action || c.req.method !== 'POST') return next();
+
+  let threw = false;
+  try {
+    await next();
+  } catch (error) {
+    threw = true;
+    throw error;
+  } finally {
+    const portalAuth = c.get('portalAuth');
+    const identity = c.get('portalAuthAuditIdentity') ?? (portalAuth ? {
+      userId: portalAuth.user.id,
+      orgId: portalAuth.user.orgId,
+      email: portalAuth.user.email,
+    } : undefined);
+    const status = threw ? 500 : c.res.status;
+    await writeAuditEventAsync(c, {
+      orgId: identity?.orgId,
+      actorType: identity ? 'user' : 'system',
+      actorId: identity?.userId ?? ANONYMOUS_ACTOR_ID,
+      actorEmail: identity?.email,
+      initiatedBy: 'manual',
+      action,
+      resourceType: 'portal_auth',
+      resourceId: identity?.userId,
+      result: threw || status >= 500 ? 'failure' : status >= 400 ? 'denied' : 'success',
+      details: { httpStatus: status },
+    });
+  }
+});
 
 async function isPortalPasswordResetEnabled(orgId: string): Promise<boolean> {
   const [row] = await withSystemDbAccessContext(() =>
@@ -94,7 +148,7 @@ export async function portalAuthMiddleware(c: Context, next: Next) {
     return c.json({ error: 'Missing or invalid authorization header' }, 401);
   }
 
-  let sessionData: { portalUserId: string; orgId: string } | null = null;
+  let sessionData: { portalUserId: string; orgId: string; authEpoch: number } | null = null;
 
   if (PORTAL_USE_REDIS) {
     const redis = getRedis();
@@ -107,7 +161,18 @@ export async function portalAuthMiddleware(c: Context, next: Next) {
       if (raw) {
         try {
           const parsed = JSON.parse(raw);
-          sessionData = { portalUserId: parsed.portalUserId, orgId: parsed.orgId };
+          if (
+            typeof parsed.portalUserId === 'string'
+            && typeof parsed.orgId === 'string'
+            && Number.isSafeInteger(parsed.authEpoch)
+            && parsed.authEpoch > 0
+          ) {
+            sessionData = {
+              portalUserId: parsed.portalUserId,
+              orgId: parsed.orgId,
+              authEpoch: parsed.authEpoch,
+            };
+          }
         } catch (err) {
           console.error('[portal] Failed to parse Redis session data:', (err as Error).message);
         }
@@ -118,7 +183,11 @@ export async function portalAuthMiddleware(c: Context, next: Next) {
   if (!sessionData && ALLOW_IN_MEMORY_PORTAL_STATE) {
     const session = portalSessions.get(token);
     if (session && session.expiresAt.getTime() > Date.now()) {
-      sessionData = { portalUserId: session.portalUserId, orgId: session.orgId };
+      sessionData = {
+        portalUserId: session.portalUserId,
+        orgId: session.orgId,
+        authEpoch: session.authEpoch,
+      };
     } else if (session) {
       portalSessions.delete(token);
     }
@@ -135,7 +204,7 @@ export async function portalAuthMiddleware(c: Context, next: Next) {
   // but the portal_users row lives behind org-forced RLS. Run this lookup
   // under system scope so it resolves under the unprivileged breeze_app pool —
   // the same pattern authMiddleware uses for its pre-auth users lookup.
-  const { user, timezone } = await withSystemDbAccessContext(async () => {
+  const user = await withSystemDbAccessContext(async () => {
     const [user] = await db
       .select({
         id: portalUsers.id,
@@ -148,28 +217,34 @@ export async function portalAuthMiddleware(c: Context, next: Next) {
         // and then logged in would see none of their own tickets, because an
         // emailed ticket has no `submitted_by` at all.
         contactId: portalUsers.contactId,
+        authMethod: portalUsers.authMethod,
         receiveNotifications: portalUsers.receiveNotifications,
-        status: portalUsers.status
+        status: portalUsers.status,
+        authEpoch: portalUsers.authEpoch,
       })
       .from(portalUsers)
       .where(and(eq(portalUsers.id, sessionData.portalUserId), eq(portalUsers.orgId, sessionData.orgId)))
       .limit(1);
-
-    return {
-      user,
-      // Resolved here (not per-route/per-read-model) so every portal read
-      // model can consume `auth.timezone` without its own DB round trip —
-      // see services/portal/timezone.ts.
-      timezone: user
-        ? await resolveOrgTimezone(sessionData.orgId)
-        : null,
-    };
+    return user;
   });
 
-  if (!user) {
+  // Browser portal sessions are password-ceremony sessions. Entra JIT uses a
+  // separate Client-AI session and must never inherit browser access merely
+  // because a historical recovery/invite path populated password_hash.
+  if (!user || user.authMethod !== 'password') {
     if (PORTAL_USE_REDIS) {
       const redis = getRedis();
-      if (redis) await redis.del(PORTAL_REDIS_KEYS.session(token));
+      if (redis) {
+        if (user) {
+          await redis
+            .multi()
+            .del(PORTAL_REDIS_KEYS.session(token))
+            .srem(PORTAL_REDIS_KEYS.userSessions(user.id), token)
+            .exec();
+        } else {
+          await redis.del(PORTAL_REDIS_KEYS.session(token));
+        }
+      }
     }
     if (ALLOW_IN_MEMORY_PORTAL_STATE) {
       portalSessions.delete(token);
@@ -178,6 +253,19 @@ export async function portalAuthMiddleware(c: Context, next: Next) {
       clearPortalSessionCookies(c);
     }
     return c.json({ error: 'Portal user not found' }, 401);
+  }
+
+  if (user.authEpoch !== sessionData.authEpoch) {
+    if (PORTAL_USE_REDIS) {
+      const redis = getRedis();
+      if (redis) {
+        await redis.del(PORTAL_REDIS_KEYS.session(token));
+        await redis.srem(PORTAL_REDIS_KEYS.userSessions(user.id), token);
+      }
+    }
+    if (ALLOW_IN_MEMORY_PORTAL_STATE) portalSessions.delete(token);
+    if (cookieToken) clearPortalSessionCookies(c);
+    return c.json({ error: 'Invalid or expired session' }, 401);
   }
 
   if (user.status !== 'active') {
@@ -195,7 +283,11 @@ export async function portalAuthMiddleware(c: Context, next: Next) {
       // "access disabled" page instead of rendering the outage copy.
       return c.json({ error: 'Account is not active', code: PORTAL_ACCOUNT_INACTIVE_CODE }, 403);
     }
-    c.set('portalAuth', { user, token, authMethod, timezone: timezone ?? 'UTC' });
+    // Timezone is resolved further down, only after the durable session/org
+    // checks pass (see the comment there) — this exempt path returns before
+    // that point by design (pure teardown, no DB reads), and logout is the
+    // only handler reachable here, which never consumes `auth.timezone`.
+    c.set('portalAuth', { user, token, authMethod, timezone: 'UTC' });
     if (authMethod === 'cookie') {
       setPortalSessionCookies(c, token);
     }
@@ -228,6 +320,10 @@ export async function portalAuthMiddleware(c: Context, next: Next) {
     }
     return c.json({ error: 'Organization is not available' }, 403);
   }
+
+  // Resolve only after the durable session checks. A stale/legacy generation
+  // must not trigger even a secondary tenant read, much less route work.
+  const timezone = await withSystemDbAccessContext(() => resolveOrgTimezone(sessionData.orgId));
 
   // Sliding session timeout: any authenticated activity pushes expiry forward.
   if (PORTAL_USE_REDIS) {
@@ -329,14 +425,16 @@ authRoutes.post('/auth/login', zValidator('json', loginSchema), async (c) => {
         email: portalUsers.email,
         name: portalUsers.name,
         passwordHash: portalUsers.passwordHash,
+        authMethod: portalUsers.authMethod,
         receiveNotifications: portalUsers.receiveNotifications,
-        status: portalUsers.status
+        status: portalUsers.status,
+        authEpoch: portalUsers.authEpoch,
       })
       .from(portalUsers)
       .where(
         orgId
-          ? and(eq(portalUsers.orgId, orgId), eq(portalUsers.email, normalizedEmail))
-          : eq(portalUsers.email, normalizedEmail)
+          ? and(eq(portalUsers.orgId, orgId), eq(portalUsers.email, normalizedEmail), eq(portalUsers.authMethod, 'password'))
+          : and(eq(portalUsers.email, normalizedEmail), eq(portalUsers.authMethod, 'password'))
       )
       .limit(orgId ? 1 : 2)
   );
@@ -346,6 +444,8 @@ authRoutes.post('/auth/login', zValidator('json', loginSchema), async (c) => {
   }
 
   const user = userRows[0];
+
+  if (user) setPortalAuthAuditIdentity(c, user);
 
   if (!user || !user.passwordHash) {
     return c.json({ error: 'Invalid email or password' }, 401);
@@ -374,6 +474,7 @@ authRoutes.post('/auth/login', zValidator('json', loginSchema), async (c) => {
       const sessionPayload = JSON.stringify({
         portalUserId: user.id,
         orgId: user.orgId,
+        authEpoch: user.authEpoch,
         createdAt: now.toISOString(),
       });
       const results = await redis
@@ -401,6 +502,7 @@ authRoutes.post('/auth/login', zValidator('json', loginSchema), async (c) => {
       token,
       portalUserId: user.id,
       orgId: user.orgId,
+      authEpoch: user.authEpoch,
       createdAt: now,
       expiresAt
     });
@@ -454,17 +556,19 @@ authRoutes.post('/auth/forgot-password', zValidator('json', forgotPasswordSchema
 
   const [user] = await withSystemDbAccessContext(() =>
     db
-      .select({ id: portalUsers.id, email: portalUsers.email, orgId: portalUsers.orgId })
+      .select({ id: portalUsers.id, email: portalUsers.email, orgId: portalUsers.orgId, authMethod: portalUsers.authMethod })
       .from(portalUsers)
       .where(
         orgId
-          ? and(eq(portalUsers.orgId, orgId), eq(portalUsers.email, normalizedEmail))
-          : eq(portalUsers.email, normalizedEmail)
+          ? and(eq(portalUsers.orgId, orgId), eq(portalUsers.email, normalizedEmail), eq(portalUsers.authMethod, 'password'))
+          : and(eq(portalUsers.email, normalizedEmail), eq(portalUsers.authMethod, 'password'))
       )
       .limit(1)
   );
 
-  if (user && await isPortalPasswordResetEnabled(user.orgId)) {
+  if (user) setPortalAuthAuditIdentity(c, user);
+
+  if (user?.authMethod === 'password' && await isPortalPasswordResetEnabled(user.orgId)) {
     const resetToken = nanoid(48);
     const tokenHash = createHash('sha256').update(resetToken).digest('hex');
     const expiresAt = new Date(Date.now() + RESET_TTL_MS);
@@ -560,12 +664,16 @@ authRoutes.post('/auth/reset-password', zValidator('json', resetPasswordSchema),
 
   const [resetUser] = await withSystemDbAccessContext(() =>
     db
-      .select({ orgId: portalUsers.orgId })
+      .select({ id: portalUsers.id, orgId: portalUsers.orgId, email: portalUsers.email, authMethod: portalUsers.authMethod })
       .from(portalUsers)
       .where(eq(portalUsers.id, storedUserId))
       .limit(1)
   );
   if (!resetUser) {
+    return c.json({ error: 'Invalid or expired reset token' }, 400);
+  }
+  setPortalAuthAuditIdentity(c, resetUser);
+  if (resetUser.authMethod !== 'password') {
     return c.json({ error: 'Invalid or expired reset token' }, 400);
   }
   if (!await isPortalPasswordResetEnabled(resetUser.orgId)) {
@@ -575,12 +683,16 @@ authRoutes.post('/auth/reset-password', zValidator('json', resetPasswordSchema),
   const passwordHash = await hashPassword(password);
   const now = new Date();
 
-  await withSystemDbAccessContext(() =>
+  const updated = await withSystemDbAccessContext(() =>
     db
       .update(portalUsers)
-      .set({ passwordHash, updatedAt: now })
-      .where(eq(portalUsers.id, storedUserId))
+      .set({ passwordHash, authEpoch: sql`${portalUsers.authEpoch} + 1`, updatedAt: now })
+      .where(and(eq(portalUsers.id, storedUserId), eq(portalUsers.authMethod, 'password')))
+      .returning({ id: portalUsers.id })
   );
+  if (updated.length !== 1) {
+    return c.json({ error: 'Invalid or expired reset token' }, 400);
+  }
 
   await clearRateLimitKeys([ipRateKey, tokenRateKey]);
 
@@ -603,6 +715,9 @@ authRoutes.post('/auth/reset-password', zValidator('json', resetPasswordSchema),
       }
     }
   }
+
+  const resetRedis = getRedis();
+  if (resetRedis) await purgeClientAiSessionsForUsers(resetRedis, [storedUserId]);
 
   return c.json({ success: true, message: 'Password reset successfully' });
 });
@@ -644,8 +759,10 @@ authRoutes.post('/auth/accept-invite', zValidator('json', acceptInviteSchema), a
         email: portalUsers.email,
         name: portalUsers.name,
         passwordHash: portalUsers.passwordHash,
+        authMethod: portalUsers.authMethod,
         receiveNotifications: portalUsers.receiveNotifications,
-        status: portalUsers.status
+        status: portalUsers.status,
+        authEpoch: portalUsers.authEpoch,
       })
       .from(portalUsers)
       .where(eq(portalUsers.id, portalUserId))
@@ -653,6 +770,10 @@ authRoutes.post('/auth/accept-invite', zValidator('json', acceptInviteSchema), a
   );
 
   if (!user) {
+    return c.json({ error: 'Invalid or expired invite' }, 400);
+  }
+  setPortalAuthAuditIdentity(c, user);
+  if (user.authMethod !== 'password') {
     return c.json({ error: 'Invalid or expired invite' }, 400);
   }
   // Disable is terminal — a disabled account may not be resurrected via an
@@ -670,12 +791,21 @@ authRoutes.post('/auth/accept-invite', zValidator('json', acceptInviteSchema), a
   const passwordHash = await hashPassword(password);
   const resolvedName = user.name ?? (name ?? null);
 
-  await withSystemDbAccessContext(() =>
+  const [activated] = await withSystemDbAccessContext(() =>
     db
       .update(portalUsers)
-      .set({ passwordHash, name: resolvedName, status: 'active', lastLoginAt: now, updatedAt: now })
-      .where(eq(portalUsers.id, user.id))
+      .set({ passwordHash, name: resolvedName, status: 'active', authEpoch: sql`${portalUsers.authEpoch} + 1`, lastLoginAt: now, updatedAt: now })
+      // The invite was checked against this exact durable generation. A
+      // concurrent disable/status or credential transition advances it, so
+      // this activation must lose instead of resurrecting the account.
+      .where(and(eq(portalUsers.id, user.id), eq(portalUsers.authEpoch, user.authEpoch), eq(portalUsers.authMethod, 'password')))
+      .returning({ authEpoch: portalUsers.authEpoch })
   );
+  if (!activated) return c.json({ error: 'Invalid or expired invite' }, 400);
+
+  await purgePortalSessionsForUsers([user.id]);
+  const inviteRedis = getRedis();
+  if (inviteRedis) await purgeClientAiSessionsForUsers(inviteRedis, [user.id]);
 
   const sessionToken = nanoid(48);
   const expiresAt = new Date(now.getTime() + SESSION_TTL_MS);
@@ -685,13 +815,13 @@ authRoutes.post('/auth/accept-invite', zValidator('json', acceptInviteSchema), a
     if (redis) {
       await redis
         .multi()
-        .setex(PORTAL_REDIS_KEYS.session(sessionToken), SESSION_TTL_SECONDS, JSON.stringify({ portalUserId: user.id, orgId: user.orgId, createdAt: now.toISOString() }))
+        .setex(PORTAL_REDIS_KEYS.session(sessionToken), SESSION_TTL_SECONDS, JSON.stringify({ portalUserId: user.id, orgId: user.orgId, authEpoch: activated.authEpoch, createdAt: now.toISOString() }))
         .sadd(PORTAL_REDIS_KEYS.userSessions(user.id), sessionToken)
         .expire(PORTAL_REDIS_KEYS.userSessions(user.id), SESSION_TTL_SECONDS * 2)
         .exec();
     }
   } else {
-    portalSessions.set(sessionToken, { token: sessionToken, portalUserId: user.id, orgId: user.orgId, createdAt: now, expiresAt });
+    portalSessions.set(sessionToken, { token: sessionToken, portalUserId: user.id, orgId: user.orgId, authEpoch: activated.authEpoch, createdAt: now, expiresAt });
     capMapByOldest(portalSessions, PORTAL_SESSION_CAP, (s) => s.createdAt.getTime());
   }
 

--- a/apps/api/src/routes/portal/authOrgStatusGate.test.ts
+++ b/apps/api/src/routes/portal/authOrgStatusGate.test.ts
@@ -16,9 +16,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Hono } from 'hono';
 
-const { portalUserRow, activeOrgResult } = vi.hoisted(() => ({
+const { portalUserRow, activeOrgResult, portalUserLookupError } = vi.hoisted(() => ({
   portalUserRow: { current: null as Record<string, unknown> | null },
   activeOrgResult: { current: null as { orgId: string; partnerId: string } | null },
+  portalUserLookupError: { current: null as Error | null },
 }));
 
 const resolveOrgTimezone = vi.hoisted(() =>
@@ -36,6 +37,7 @@ vi.mock('../../services/portal/timezone', () => ({
 // (verified: the naive echo mock kept these tests green through exactly that
 // mutation).
 function project(columns: Record<string, unknown>): Array<Record<string, unknown>> {
+  if (portalUserLookupError.current) throw portalUserLookupError.current;
   const row = portalUserRow.current;
   if (!row) return [];
   const out: Record<string, unknown> = {};
@@ -64,7 +66,9 @@ vi.mock('../../db/schema', () => ({
     name: 'name',
     contactId: 'contactId',
     receiveNotifications: 'receiveNotifications',
+    authMethod: 'authMethod',
     status: 'status',
+    authEpoch: 'authEpoch',
   },
   portalBranding: { orgId: 'orgId', enablePasswordReset: 'enablePasswordReset' },
 }));
@@ -79,7 +83,7 @@ vi.mock('../../services/tenantStatus', () => ({
   invalidateAgentTenantCache: vi.fn(async () => undefined),
 }));
 
-import { portalAuthMiddleware } from './auth';
+import { authRoutes, portalAuthMiddleware } from './auth';
 import { portalSessions } from './helpers';
 import { getActiveOrgTenant } from '../../services/tenantStatus';
 
@@ -114,7 +118,8 @@ function seedSession() {
     orgId: ORG_ID,
     createdAt: new Date(),
     expiresAt: new Date(Date.now() + 60 * 60 * 1000),
-  });
+    authEpoch: 1,
+  } as any);
 }
 
 beforeEach(() => {
@@ -127,12 +132,49 @@ beforeEach(() => {
     name: 'Cust',
     contactId: CONTACT_ID,
     receiveNotifications: true,
+    authMethod: 'password',
     status: 'active',
+    authEpoch: 1,
   };
   activeOrgResult.current = { orgId: ORG_ID, partnerId: 'partner-1' };
+  portalUserLookupError.current = null;
 });
 
 describe('portalAuthMiddleware org-status gate', () => {
+  it('fails closed without running downstream when the durable epoch lookup is uncertain', async () => {
+    seedSession();
+    portalUserLookupError.current = new Error('synthetic database uncertainty');
+
+    const res = await call();
+
+    expect(res.status).toBe(500);
+    expect(getActiveOrgTenant).not.toHaveBeenCalled();
+  });
+
+  it('fails closed for a legacy session that has no durable epoch snapshot', async () => {
+    seedSession();
+    const legacy = portalSessions.get(TOKEN)!;
+    delete (legacy as Partial<typeof legacy>).authEpoch;
+
+    const res = await call();
+
+    expect(res.status).toBe(401);
+    expect(portalSessions.has(TOKEN)).toBe(false);
+    expect(getActiveOrgTenant).not.toHaveBeenCalled();
+    expect(resolveOrgTimezone).not.toHaveBeenCalled();
+  });
+
+  it('rejects a session minted before the durable portal auth epoch advanced', async () => {
+    seedSession();
+    portalUserRow.current = { ...portalUserRow.current, authEpoch: 2 };
+
+    const res = await call();
+
+    expect(res.status).toBe(401);
+    expect(portalSessions.has(TOKEN)).toBe(false);
+    expect(getActiveOrgTenant).not.toHaveBeenCalled();
+  });
+
   it('admits an active portal user whose org is usable', async () => {
     seedSession();
     const res = await call();
@@ -216,5 +258,31 @@ describe('portalAuthMiddleware org-status gate', () => {
     // sneaks past a required field.
     expect(Object.prototype.hasOwnProperty.call(body.user, 'contactId')).toBe(true);
     expect(body.user.contactId).toBeNull();
+  });
+});
+
+describe('portal logout session scope', () => {
+  it('continues to revoke only the presented session, not every session for the user', async () => {
+    seedSession();
+    portalSessions.set('other-current-session', {
+      token: 'other-current-session',
+      portalUserId: USER_ID,
+      orgId: ORG_ID,
+      authEpoch: 1,
+      createdAt: new Date(),
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    });
+    const app = new Hono();
+    app.route('/', authRoutes);
+
+    const res = await app.request('/auth/logout', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    });
+
+    expect(res.status).toBe(200);
+    expect(portalSessions.has(TOKEN)).toBe(false);
+    expect(portalSessions.has('other-current-session')).toBe(true);
+    expect(portalUserRow.current?.authEpoch).toBe(1);
   });
 });

--- a/apps/api/src/routes/portal/profile.compatPassword.test.ts
+++ b/apps/api/src/routes/portal/profile.compatPassword.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+const mocks = vi.hoisted(() => ({
+  hashPassword: vi.fn(async () => 'replacement-hash'),
+  update: vi.fn(),
+  set: vi.fn(),
+  where: vi.fn(),
+  returning: vi.fn(),
+  audit: vi.fn(),
+}));
+
+vi.mock('../../db', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../db')>();
+  return { ...actual, db: { update: mocks.update, select: vi.fn() } };
+});
+
+vi.mock('../../services/password', () => ({
+  hashPassword: mocks.hashPassword,
+  verifyPassword: vi.fn(),
+  isPasswordStrong: vi.fn(() => ({ valid: true, errors: [] })),
+}));
+
+vi.mock('../../services/redis', () => ({ getRedis: vi.fn(() => null) }));
+
+vi.mock('./helpers', async () => {
+  const actual = await vi.importActual<typeof import('./helpers')>('./helpers');
+  return {
+    ...actual,
+    validatePortalCookieCsrfRequest: vi.fn(() => null),
+    writePortalAudit: mocks.audit,
+  };
+});
+
+import { profileRoutes } from './profile';
+import { portalSessions } from './helpers';
+
+const AUTH_USER = {
+  id: '11111111-1111-4111-8111-111111111111',
+  orgId: '22222222-2222-4222-8222-222222222222',
+  email: 'customer@example.test',
+  name: 'Customer',
+  contactId: null,
+  receiveNotifications: true,
+  status: 'active',
+};
+
+function app() {
+  const hono = new Hono();
+  hono.use('*', async (c, next) => {
+    c.set('portalAuth', {
+      user: AUTH_USER,
+      token: 'synthetic-session',
+      authMethod: 'bearer',
+      timezone: 'UTC',
+    });
+    await next();
+  });
+  hono.route('/', profileRoutes);
+  return hono;
+}
+
+async function patchProfile(body: unknown) {
+  return app().request('/profile', {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('PATCH /profile compatibility boundary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    portalSessions.clear();
+    mocks.update.mockReturnValue({ set: mocks.set });
+    mocks.set.mockReturnValue({ where: mocks.where });
+    mocks.where.mockReturnValue({ returning: mocks.returning });
+    mocks.returning.mockResolvedValue([{
+      id: AUTH_USER.id,
+      orgId: AUTH_USER.orgId,
+      email: AUTH_USER.email,
+      name: 'Updated Customer',
+      receiveNotifications: false,
+      status: 'active',
+    }]);
+  });
+
+  it('rejects a legacy password-shaped request before password, database, or audit effects', async () => {
+    portalSessions.set('other-session', {
+      token: 'other-session',
+      portalUserId: AUTH_USER.id,
+      orgId: AUTH_USER.orgId,
+      authEpoch: 1,
+      createdAt: new Date(0),
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+
+    const response = await patchProfile({
+      name: 'Updated Customer',
+      password: 'LegacyCompatibilityPassword123!',
+    });
+
+    expect(response.status).toBe(400);
+    expect(mocks.hashPassword).not.toHaveBeenCalled();
+    expect(mocks.update).not.toHaveBeenCalled();
+    expect(mocks.audit).not.toHaveBeenCalled();
+    expect(portalSessions.has('other-session')).toBe(true);
+  });
+
+  it('preserves ordinary profile name and notification updates', async () => {
+    const response = await patchProfile({
+      name: 'Updated Customer',
+      receiveNotifications: false,
+    });
+
+    expect(response.status).toBe(200);
+    expect(mocks.set).toHaveBeenCalledWith(expect.objectContaining({
+      name: 'Updated Customer',
+      receiveNotifications: false,
+    }));
+    expect(mocks.hashPassword).not.toHaveBeenCalled();
+    expect(mocks.audit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/routes/portal/profile.password.redisFault.test.ts
+++ b/apps/api/src/routes/portal/profile.password.redisFault.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+vi.hoisted(() => {
+  process.env.PORTAL_STATE_BACKEND = 'redis';
+});
+
+const { updateSet, redis } = vi.hoisted(() => ({
+  updateSet: vi.fn(),
+  redis: {
+    smembers: vi.fn(() => Promise.reject(new Error('synthetic Redis read fault'))),
+    del: vi.fn(),
+  },
+}));
+
+vi.mock('../../db', () => ({
+  runOutsideDbContext: <T,>(fn: () => T) => fn(),
+  withDbAccessContext: (_context: unknown, fn: () => unknown) => fn(),
+  withSystemDbAccessContext: (fn: () => unknown) => fn(),
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: () => Promise.resolve([{
+            id: 'portal-user-1',
+            passwordHash: 'old-hash',
+            email: 'customer@example.test',
+            orgId: 'org-1',
+            name: 'Customer',
+          }]),
+        }),
+      }),
+    }),
+    update: () => ({
+      set: (value: unknown) => {
+        updateSet(value);
+        return { where: () => Promise.resolve() };
+      },
+    }),
+  },
+}));
+
+vi.mock('../../db/schema', () => ({
+  discoveredAssetTypeEnum: { enumValues: [] },
+  portalUsers: {
+    id: 'id',
+    passwordHash: 'passwordHash',
+    email: 'email',
+    orgId: 'orgId',
+    name: 'name',
+    authEpoch: 'authEpoch',
+  },
+}));
+
+vi.mock('../../services/password', () => ({
+  verifyPassword: vi.fn(() => Promise.resolve(true)),
+  hashPassword: vi.fn(() => Promise.resolve('new-hash')),
+  isPasswordStrong: vi.fn(() => ({ valid: true, errors: [] })),
+}));
+
+vi.mock('../../services/redis', () => ({ getRedis: () => redis }));
+
+vi.mock('./helpers', () => ({
+  applyPortalCacheHeaders: vi.fn(),
+  buildWeakEtag: vi.fn(() => 'etag'),
+  buildPortalUserPayload: vi.fn((user) => user),
+  checkRateLimit: vi.fn(() => Promise.resolve({ allowed: true })),
+  isEtagFresh: vi.fn(() => false),
+  portalSessions: new Map(),
+  validatePortalCookieCsrfRequest: vi.fn(() => null),
+  writePortalAudit: vi.fn(),
+}));
+
+import { profileRoutes } from './profile';
+
+describe('portal password epoch under Redis cleanup faults', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('commits the durable epoch advance before a Redis fault and never reports success', async () => {
+    const app = new Hono();
+    app.use('*', async (c, next) => {
+      c.set('portalAuth', {
+        user: {
+          id: 'portal-user-1', orgId: 'org-1', email: 'customer@example.test',
+          name: 'Customer', contactId: null, receiveNotifications: true, status: 'active',
+        },
+        token: 'current-token', authMethod: 'bearer', timezone: 'UTC',
+      });
+      await next();
+    });
+    app.route('/', profileRoutes);
+
+    const res = await app.request('/profile/password', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ currentPassword: 'Old-password-1!', newPassword: 'New-password-2!' }),
+    });
+
+    expect(res.status).toBe(500);
+    expect(updateSet).toHaveBeenCalledWith(expect.objectContaining({
+      passwordHash: 'new-hash',
+      authEpoch: expect.anything(),
+    }));
+    expect(redis.smembers).toHaveBeenCalledWith('portal:user-sessions:portal-user-1');
+    expect(redis.del).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/routes/portal/profile.password.test.ts
+++ b/apps/api/src/routes/portal/profile.password.test.ts
@@ -10,6 +10,7 @@ import { Hono } from 'hono';
 
 const verifyPasswordMock = vi.fn(async (_hash: string, _plaintext: string) => true);
 const hashPasswordMock = vi.fn(async (_plaintext: string) => 'new-hash');
+const updateSetSpy = vi.fn();
 
 const dbState: { userRow: unknown } = {
   userRow: {
@@ -107,8 +108,12 @@ function buildSelectChain() {
 
 function buildUpdateChain() {
   vi.mocked(db.update as any).mockReturnValue({
-    set: vi.fn().mockReturnValue({
-      where: vi.fn().mockResolvedValue(undefined),
+    set: vi.fn((value) => {
+      updateSetSpy(value);
+      return { where: vi.fn(() => ({
+        returning: vi.fn(() => updateReturningMock()),
+        then: (resolve: (value: undefined) => unknown) => Promise.resolve(undefined).then(resolve),
+      })) };
     }),
   });
 }
@@ -136,6 +141,7 @@ describe('POST /profile/password', () => {
     buildSelectChain();
     buildUpdateChain();
     updateReturningMock.mockClear();
+    updateSetSpy.mockClear();
   });
 
   it('happy path: a correct current password still succeeds', async () => {
@@ -151,6 +157,7 @@ describe('POST /profile/password', () => {
       expect.anything(),
       expect.objectContaining({ action: 'portal.profile.password.change' })
     );
+    expect(updateSetSpy).toHaveBeenCalledWith(expect.objectContaining({ authEpoch: expect.anything() }));
   });
 
   // The core #4797 fix: a wrong guess must never collide with the session
@@ -247,5 +254,23 @@ describe('POST /profile/password', () => {
       body: JSON.stringify({ currentPassword: 'wrong', newPassword: 'battery-staple-9' }),
     });
     expect(otherUserRes.status).toBe(400); // rejected on password, not throttled
+  });
+});
+
+describe('PATCH /profile compatibility writer', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('rejects the removed legacy password field without a credential or epoch write', async () => {
+    const res = await app().request('/profile', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ password: 'battery-staple-9' }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(hashPasswordMock).not.toHaveBeenCalled();
+    expect(verifyPasswordMock).not.toHaveBeenCalled();
+    expect(updateSetSpy).not.toHaveBeenCalled();
+    expect(writePortalAudit).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/routes/portal/profile.ts
+++ b/apps/api/src/routes/portal/profile.ts
@@ -1,11 +1,12 @@
 import { Hono } from 'hono';
 import { zValidator } from '../../lib/validation';
-import { eq } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm';
 import { db } from '../../db';
 import { portalUsers } from '../../db/schema';
 import { hashPassword, isPasswordStrong, verifyPassword } from '../../services/password';
 import { getRedis } from '../../services/redis';
 import { rejectProof, INVALID_CREDENTIALS_CODE } from '../auth/helpers';
+import { purgeClientAiSessionsForUsers } from '../../services/clientAiSessionStore';
 import {
   updateProfileSchema,
   changePasswordSchema,
@@ -57,7 +58,6 @@ profileRoutes.patch('/profile', zValidator('json', updateProfileSchema), async (
   const updates: {
     name?: string;
     receiveNotifications?: boolean;
-    passwordHash?: string;
     updatedAt: Date;
   } = { updatedAt: new Date() };
 
@@ -67,14 +67,6 @@ profileRoutes.patch('/profile', zValidator('json', updateProfileSchema), async (
 
   if (payload.receiveNotifications !== undefined) {
     updates.receiveNotifications = payload.receiveNotifications;
-  }
-
-  if (payload.password) {
-    const passwordCheck = isPasswordStrong(payload.password);
-    if (!passwordCheck.valid) {
-      return c.json({ error: passwordCheck.errors[0] }, 400);
-    }
-    updates.passwordHash = await hashPassword(payload.password);
   }
 
   const userResult = await db
@@ -106,7 +98,6 @@ profileRoutes.patch('/profile', zValidator('json', updateProfileSchema), async (
     resourceName: user.name ?? user.email,
     details: {
       updatedFields: Object.keys(payload),
-      passwordUpdated: Boolean(payload.password),
     },
   });
 
@@ -176,6 +167,7 @@ profileRoutes.post('/profile/password', zValidator('json', changePasswordSchema)
     .update(portalUsers)
     .set({
       passwordHash: await hashPassword(newPassword),
+      authEpoch: sql`${portalUsers.authEpoch} + 1`,
       updatedAt: new Date()
     })
     .where(eq(portalUsers.id, auth.user.id));
@@ -197,6 +189,9 @@ profileRoutes.post('/profile/password', zValidator('json', changePasswordSchema)
       portalSessions.delete(sessionToken);
     }
   }
+
+  const passwordRedis = getRedis();
+  if (passwordRedis) await purgeClientAiSessionsForUsers(passwordRedis, [auth.user.id]);
 
   writePortalAudit(c, {
     orgId: auth.user.orgId,

--- a/apps/api/src/routes/portal/schemas.ts
+++ b/apps/api/src/routes/portal/schemas.ts
@@ -11,6 +11,7 @@ export type PortalSession = {
   token: string;
   portalUserId: string;
   orgId: string;
+  authEpoch: number;
   createdAt: Date;
   expiresAt: Date;
 };
@@ -52,6 +53,11 @@ export type PortalAuthContext = {
 declare module 'hono' {
   interface ContextVariableMap {
     portalAuth: PortalAuthContext;
+    portalAuthAuditIdentity?: {
+      userId: string;
+      orgId: string;
+      email: string;
+    };
   }
 }
 
@@ -249,7 +255,10 @@ export const checkinSchema = z.object({
 export const updateProfileSchema = z.object({
   name: z.string().min(1).max(255).optional(),
   receiveNotifications: z.boolean().optional(),
-  password: z.string().min(8).optional()
+  // Password changes require current-password proof and session revocation on
+  // POST /profile/password. Keep the legacy field explicit so it is rejected
+  // rather than silently stripped as an unknown compatibility property.
+  password: z.never().optional()
 });
 
 export const changePasswordSchema = z.object({

--- a/apps/api/src/routes/portal/security.test.ts
+++ b/apps/api/src/routes/portal/security.test.ts
@@ -39,8 +39,10 @@ vi.mock('../../db', () => ({
                   email: 'customer@example.com',
                   name: 'Customer',
                   contactId: null,
+                  authMethod: 'password',
                   receiveNotifications: true,
                   status: 'active',
+                  authEpoch: 1,
                 }],
           ),
         }),
@@ -93,6 +95,7 @@ function seedSession() {
     token: TOKEN,
     portalUserId: 'pu-1',
     orgId: ORG_ID,
+    authEpoch: 1,
     createdAt: new Date(),
     expiresAt: new Date(Date.now() + 60_000),
   });

--- a/apps/api/src/services/clientAiExchange.test.ts
+++ b/apps/api/src/services/clientAiExchange.test.ts
@@ -108,7 +108,8 @@ const claims = (over: Partial<ClientAiEntraClaims> = {}): ClientAiEntraClaims =>
     ...over,
   }) as ClientAiEntraClaims;
 
-const redis = { setex: vi.fn(), sadd: vi.fn(), expire: vi.fn() } as never;
+const redisMock = { setex: vi.fn(), sadd: vi.fn(), expire: vi.fn() };
+const redis = redisMock as never;
 
 /** mapping row, then the portal-user lookup row(s). */
 const seedSelects = (user: Array<Record<string, unknown>>) => {
@@ -123,6 +124,8 @@ const activeUser = (over: Record<string, unknown> = {}) => ({
   email: EMAIL,
   name: 'Jane',
   status: 'active',
+  authMethod: 'entra',
+  authEpoch: 1,
   contactId: null,
   ...over,
 });
@@ -144,6 +147,15 @@ beforeEach(() => {
 });
 
 describe('resolveAndMintClientSession — contact linkage (#3258)', () => {
+  it('binds the minted Redis session to the live portal auth epoch', async () => {
+    seedSelects([activeUser({ authEpoch: 7, contactId: 'ct-existing' })]);
+
+    await resolveAndMintClientSession(claims(), redis);
+
+    const payload = JSON.parse(redisMock.setex.mock.calls[0]![2] as string);
+    expect(payload).toMatchObject({ portalUserId: 'pu-1', orgId: ORG_ID, authEpoch: 7 });
+  });
+
   it('links a contact on the FIRST exchange and writes it onto the new login', async () => {
     seedSelects([]);
     insertReturning.mockResolvedValueOnce([activeUser()]);
@@ -206,6 +218,17 @@ describe('resolveAndMintClientSession — contact linkage (#3258)', () => {
     // No `contactId` in the .set() either — the pre-gate write is lastLoginAt only.
     expect(setSpy.mock.calls.every((c) => !('contactId' in (c[0] as object)))).toBe(true);
     expect(outcome.audit.details).toMatchObject({ reason: 'account_inactive', contactLink: 'not-attempted' });
+  });
+
+  it('fails closed when an Entra identity was reclassified as a password login', async () => {
+    seedSelects([activeUser({ authMethod: 'password' })]);
+
+    const outcome = await resolveAndMintClientSession(claims(), redis);
+
+    expect(outcome.kind).toBe('denied');
+    expect(linkLoginToContactMock).not.toHaveBeenCalled();
+    expect(resolveAddressMock).not.toHaveBeenCalled();
+    expect(outcome.audit.details).toMatchObject({ reason: 'identity_method_mismatch' });
   });
 
   // ---- S1: only an address the customer demonstrably owns may link ----
@@ -383,6 +406,20 @@ describe('resolveAndMintClientSession — contact linkage (#3258)', () => {
     expect(outcome.kind).toBe('resolved');
     // The winner already linked it, so the loser keeps that link untouched.
     expect(outcome.audit.details).toMatchObject({ contactLink: 'kept', contactId: 'ct-1' });
+  });
+
+  it('rejects a concurrent provisioning winner with the wrong identity method', async () => {
+    selectResult
+      .mockResolvedValueOnce([{ orgId: ORG_ID, partnerId: PARTNER_ID, partnerEnabled: true }])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([activeUser({ id: 'pu-winner', authMethod: 'password' })]);
+    insertReturning.mockRejectedValueOnce(Object.assign(new Error('dup'), { cause: { code: '23505' } }));
+
+    const outcome = await resolveAndMintClientSession(claims(), redis);
+
+    expect(outcome.kind).toBe('denied');
+    expect(outcome.audit.details).toMatchObject({ reason: 'identity_method_mismatch' });
+    expect(linkLoginToContactMock).not.toHaveBeenCalled();
   });
 
   it('records not-attempted on the partner-entitlement denial', async () => {

--- a/apps/api/src/services/clientAiExchange.ts
+++ b/apps/api/src/services/clientAiExchange.ts
@@ -15,6 +15,8 @@ import {
   CLIENT_AI_SESSION_TTL_SECONDS,
 } from '../routes/clientAi/schemas';
 
+export { purgeClientAiSessionsForUsers } from './clientAiSessionStore';
+
 /**
  * Resolves a verified Entra ID token's claims to a Breeze client-AI session
  * (tenant mapping → partner entitlement → org policy → portal-user JIT →
@@ -33,6 +35,7 @@ export type ExchangeUser = {
   email: string;
   name: string | null;
   status: string;
+  authEpoch: number;
   /** The `contacts` row this login belongs to (#3258); null until resolved. */
   contactId: string | null;
 };
@@ -140,6 +143,8 @@ const USER_COLUMNS = {
   email: portalUsers.email,
   name: portalUsers.name,
   status: portalUsers.status,
+  authMethod: portalUsers.authMethod,
+  authEpoch: portalUsers.authEpoch,
   contactId: portalUsers.contactId,
 };
 
@@ -375,11 +380,6 @@ export async function resolveAndMintClientSession(
         const stale = orgMismatchDenial(user, mapping.orgId, claims);
         if (stale) return stale;
       }
-    } else {
-      await db
-        .update(portalUsers)
-        .set({ lastLoginAt: now, updatedAt: now, ...(claims.name ? { name: claims.name } : {}) })
-        .where(eq(portalUsers.id, user.id));
     }
 
     if (!user) {
@@ -391,6 +391,26 @@ export async function resolveAndMintClientSession(
           details: { reason: 'provisioning_failed', tid: claims.tid, oid: claims.oid, ...NOT_ATTEMPTED },
         },
       };
+    }
+
+    // The Entra identity tuple must never resolve to a password login. This
+    // also covers the concurrent-insert winner selected in the 23505 branch.
+    if (user.authMethod !== 'entra') {
+      return {
+        denied: {
+          status: 403,
+          error: 'identity_method_mismatch',
+          orgId: mapping.orgId,
+          details: { reason: 'identity_method_mismatch', portalUserId: user.id, ...NOT_ATTEMPTED },
+        },
+      };
+    }
+
+    if (!provisioned) {
+      await db
+        .update(portalUsers)
+        .set({ lastLoginAt: now, updatedAt: now, ...(claims.name ? { name: claims.name } : {}) })
+        .where(eq(portalUsers.id, user.id));
     }
 
     if (user.status !== 'active') {
@@ -460,7 +480,7 @@ export async function resolveAndMintClientSession(
   await redis.setex(
     CLIENT_AI_REDIS_KEYS.session(token),
     CLIENT_AI_SESSION_TTL_SECONDS,
-    JSON.stringify({ portalUserId: user.id, orgId: user.orgId, createdAt: new Date().toISOString() })
+    JSON.stringify({ portalUserId: user.id, orgId: user.orgId, authEpoch: user.authEpoch, createdAt: new Date().toISOString() })
   );
   await redis.sadd(CLIENT_AI_REDIS_KEYS.userSessions(user.id), token);
   await redis.expire(CLIENT_AI_REDIS_KEYS.userSessions(user.id), CLIENT_AI_SESSION_TTL_SECONDS * 2);
@@ -482,47 +502,4 @@ export async function resolveAndMintClientSession(
       details: { tid: claims.tid, oid: claims.oid, provisioned, ...link },
     },
   };
-}
-
-/**
- * Drop every live client-AI (Excel/Word/Outlook add-in) session belonging to a
- * set of portal users. Used by the org-merge fence (`services/orgMerge.ts`) so
- * add-in principals stop writing under an org the moment it is fenced.
- *
- * `/client-ai` is a SECOND portal_users ingress with its own Redis namespace,
- * so the portal purge does not reach it: an add-in user would keep inserting
- * `ai_messages` and updating `ai_sessions` under the loser org through the
- * drain and into Phase B, where those rows are stranded by the re-tenant and
- * then destroyed by the erasure that follows.
- *
- * Lives here, next to `resolveAndMintClientSession` (which is what `sadd`s each
- * token into the `userSessions` index above), so the purge and the mint can
- * never disagree about the key layout.
- *
- * Best-effort by design — the durable control is the org-status gate in
- * `clientAiAuthMiddleware`, which rejects any session surviving this purge on
- * its very next request.
- */
-export async function purgeClientAiSessionsForUsers(
-  redis: Redis,
-  portalUserIds: string[]
-): Promise<number> {
-  let purged = 0;
-  for (const portalUserId of new Set(portalUserIds)) {
-    try {
-      const indexKey = CLIENT_AI_REDIS_KEYS.userSessions(portalUserId);
-      const tokens = await redis.smembers(indexKey);
-      if (tokens.length > 0) {
-        await redis.del(...tokens.map((t) => CLIENT_AI_REDIS_KEYS.session(t)));
-        purged += tokens.length;
-      }
-      await redis.del(indexKey);
-    } catch (err) {
-      console.error('[client-ai] Failed to purge sessions for portal user:', {
-        portalUserId,
-        error: err instanceof Error ? err.message : String(err),
-      });
-    }
-  }
-  return purged;
 }

--- a/apps/api/src/services/clientAiSessionStore.ts
+++ b/apps/api/src/services/clientAiSessionStore.ts
@@ -1,0 +1,34 @@
+import type Redis from 'ioredis';
+import { CLIENT_AI_REDIS_KEYS } from '../routes/clientAi/schemas';
+
+/**
+ * Best-effort cleanup for client-AI sessions owned by portal users.
+ *
+ * Durable authorization is enforced by the portal-user auth epoch on every
+ * request. This cleanup only shortens revocation latency and deliberately
+ * stays independent of the exchange/DB module so credential and status
+ * writers do not initialize exchange-time schema dependencies.
+ */
+export async function purgeClientAiSessionsForUsers(
+  redis: Redis,
+  portalUserIds: string[]
+): Promise<number> {
+  let purged = 0;
+  for (const portalUserId of new Set(portalUserIds)) {
+    try {
+      const indexKey = CLIENT_AI_REDIS_KEYS.userSessions(portalUserId);
+      const tokens = await redis.smembers(indexKey);
+      if (tokens.length > 0) {
+        await redis.del(...tokens.map((token) => CLIENT_AI_REDIS_KEYS.session(token)));
+        purged += tokens.length;
+      }
+      await redis.del(indexKey);
+    } catch (err) {
+      console.error('[client-ai] Failed to purge sessions for portal user:', {
+        portalUserId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+  return purged;
+}

--- a/apps/api/src/services/tenantExportPolicy.test.ts
+++ b/apps/api/src/services/tenantExportPolicy.test.ts
@@ -269,6 +269,25 @@ describe('buildTenantExportPlan', () => {
 });
 
 describe('CORE_TENANT_EXPORT_POLICY migration-era columns', () => {
+  it('classifies the portal auth epoch but omits it from the export plan', async () => {
+    const portalPolicy = CORE_TENANT_EXPORT_POLICY.portal_users!;
+    mockState.columns = Object.keys(portalPolicy.columns).map((columnName, index) =>
+      column('portal_users', columnName, 'text', index + 1),
+    );
+
+    const [plan] = await buildTenantExportPlan(
+      ['portal_users'],
+      CORE_TENANT_EXPORT_POLICY,
+    );
+
+    expect(portalPolicy.columns.auth_epoch).toMatchObject({
+      decision: 'exclude',
+      reviewedSensitiveName: true,
+    });
+    expect(plan?.includedColumns).not.toContain('auth_epoch');
+    expect(plan?.includedColumns).toContain('status');
+  });
+
   it('exports portal report definitions and contact-bound recipients', () => {
     expect(
       CORE_TENANT_EXPORT_POLICY.reports!.columns.portal_self_service!.decision,

--- a/apps/api/src/services/tenantExportPolicyRegistry.ts
+++ b/apps/api/src/services/tenantExportPolicyRegistry.ts
@@ -350,7 +350,11 @@ export const CORE_TENANT_EXPORT_POLICY: TenantExportPolicyRegistry = {
   "plugin_instances": tablePolicy("org_id", {"included":["id","plugin_id","org_id","enabled","created_at","updated_at"],"reviewedIncluded":[],"excludedSensitive":[],"excludedOpen":["config"]}),
   "plugins": tablePolicy("org_id", {"included":["id","org_id","name","slug","version","description","author","homepage","manifest_url","entry_point","status","is_system","installed_at","updated_at","error_message","last_active_at"],"reviewedIncluded":[],"excludedSensitive":[],"excludedOpen":["permissions","hooks","settings"]}),
   "portal_branding": tablePolicy("org_id", {"included":["id","org_id","logo_url","favicon_url","primary_color","secondary_color","accent_color","custom_domain","domain_verified","welcome_message","support_email","support_phone","footer_text","custom_css","enable_tickets","enable_asset_checkout","enable_self_service","created_at","updated_at","enable_dashboard","enable_security","enable_backups","enable_reports","enable_support_usage"],"reviewedIncluded":["enable_password_reset"],"excludedSensitive":[],"excludedOpen":[]}),
-  "portal_users": tablePolicy("org_id", {"included":["id","org_id","email","name","entra_oid","entra_tenant_id","auth_method","linked_user_id","contact_id","receive_notifications","last_login_at","status","created_at","updated_at"],"reviewedIncluded":["invited_by","invited_at"],"excludedSensitive":["password_hash"],"excludedOpen":[]}),
+  // auth_epoch is server-side bearer-session revocation state, not portable
+  // customer content. Exporting it would disclose credential/status transition
+  // history and invite consumers to treat an internal generation as restorable
+  // identity state. Keep it with the password verifier outside tenant exports.
+  "portal_users": tablePolicy("org_id", {"included":["id","org_id","email","name","entra_oid","entra_tenant_id","auth_method","linked_user_id","contact_id","receive_notifications","last_login_at","status","created_at","updated_at"],"reviewedIncluded":["invited_by","invited_at"],"excludedSensitive":["password_hash","auth_epoch"],"excludedOpen":[]}),
   "provision_credential_handles": tablePolicy("org_id", {"included":["id","org_id","device_id","created_by","created_at","expires_at","consumed_at","consumed_from_ip"],"reviewedIncluded":[],"excludedSensitive":["token"],"excludedOpen":["credentials"]}),
   // partner_id (epic #2135, 2026-08-17): dual ownership — org_id XOR partner_id.
   // A tenant identifier like org_id, so `included`. Note the org export only

--- a/apps/portal/src/lib/api.ts
+++ b/apps/portal/src/lib/api.ts
@@ -937,7 +937,7 @@ export const portalApi = {
   },
 
   updateProfile: async (
-    data: { name?: string; receiveNotifications?: boolean; password?: string; email?: string },
+    data: { name?: string; receiveNotifications?: boolean },
     config: ApiRequestConfig = {}
   ): Promise<ApiResponse<Profile>> => {
     const response = await apiPatch<{ user: Profile }>('/portal/profile', data, config);


### PR DESCRIPTION
## Summary

Hardens portal identity and session handling in three ways:

- **Password vs. Entra identity separation**: portal login, forgot-password, and
  reset-password now all require `portal_users.auth_method === 'password'`
  before touching `password_hash`. An Entra-provisioned (or Entra-migrated)
  portal user can no longer authenticate against a stale local password hash
  or be driven through the local password-reset flow.
- **Session/token epoch checking**: sessions now carry a durable per-user
  `auth_epoch`. `portalAuthMiddleware` and the Client-AI session store both
  reject a token whose epoch no longer matches the user's current epoch, so
  any writer that bumps the epoch (e.g. a password change, an admin action)
  invalidates every outstanding session/token immediately rather than leaving
  them live until natural expiry. Invitation acceptance is epoch-checked too,
  so a stale invite link can't silently re-attach to a since-rotated identity.
- **Removes the generic password writer**: the general-purpose profile `PATCH`
  handler can no longer set `passwordHash`. The dedicated password-change
  route — which requires current-password proof and bumps the epoch — is now
  the only path that can write it.

Also adds secret-safe audit events for portal auth endpoints (login, password
reset request/complete, invite accept, logout), covering both success and
denied/failed terminal states with authoritative actor identity.

## Migration

`apps/api/migrations/2026-10-15-150010-portal-user-auth-epoch.sql` adds
`portal_users.auth_epoch`, backfilled to `1` for existing rows. Idempotent,
sorts after the newest migration on `main`.

## Test plan

- [x] `apps/api` `tsc --noEmit` — clean
- [x] `apps/portal` `tsc --noEmit` — clean
- [x] `apps/api` lint (`eslint src`) — clean
- [x] `apps/portal` lint — clean (one pre-existing, unrelated
      `react-hooks/exhaustive-deps` rule-not-found finding in a file this PR
      does not touch)
- [x] Unit tests: 17 files / 219 tests green (`apps/api`), plus
      `apps/portal/src/lib/api.test.ts` (22 tests) green
- [x] Integration tests against a live Postgres + Redis stack: 5 files / 27
      tests green, including a clean apply of the new migration
      (`portalAuthAudit`, `portalAuthEpoch`, `portalUserInvite`,
      `portal-routes-rls`, `orgMergeCustomExecutors`)
- [x] RLS contract suite: 2 files / 31 tests green
- [x] Tenancy registration-list contract suites (rls-coverage,
      tenantCascade, tenant-export-policy, tenantExportErasureRoundtrip):
      4 files / 116 tests green
- [x] `scripts/check-migration-naming.sh` — OK
- [x] `db/autoMigrate.test.ts` — 78 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CY81usuo74quP5Ci39Eqhh
