### PR TITLE
fix(workspace): require explicit permissions for workspace and connected-app actions

### DIFF
--- a/apps/api/migrations/2026-10-15-150030-workspace-permissions.sql
+++ b/apps/api/migrations/2026-10-15-150030-workspace-permissions.sql
@@ -1,0 +1,40 @@
+-- Register explicit authorization boundaries for the built-in Workspace
+-- extension. Tenant reachability alone never grants any of these operations.
+--
+-- Existing wildcard administrators retain access through *:*; all other roles
+-- must receive an intentional assignment. This fail-closed rollout avoids
+-- silently preserving the pre-migration behavior for read-only partner roles.
+--
+-- `permissions` has no unique(resource, action) constraint, so ON CONFLICT is
+-- not an idempotency mechanism here. Resolve each row with an existence check.
+
+DO $$
+DECLARE
+  n integer := 0;
+  total integer := 0;
+  v_action text;
+  v_description text;
+BEGIN
+  PERFORM set_config('breeze.scope', 'system', true);
+
+  FOR v_action, v_description IN VALUES
+    ('read', 'View Workspace sources and processing status'),
+    ('write', 'Configure Workspace sources and settings'),
+    ('credentials', 'Manage Workspace source credentials'),
+    ('execute', 'Run Workspace crawling and content processing')
+  LOOP
+    IF NOT EXISTS (
+      SELECT 1 FROM permissions
+      WHERE resource = 'workspace' AND action = v_action
+    ) THEN
+      INSERT INTO permissions (resource, action, description)
+      VALUES ('workspace', v_action, v_description);
+      GET DIAGNOSTICS n = ROW_COUNT;
+      total := total + n;
+    END IF;
+  END LOOP;
+
+  IF total > 0 THEN
+    RAISE WARNING 'workspace-permissions: inserted % permission row(s)', total;
+  END IF;
+END $$;

--- a/apps/api/migrations/2026-10-15-150031-connected-app-permissions.sql
+++ b/apps/api/migrations/2026-10-15-150031-connected-app-permissions.sql
@@ -1,0 +1,23 @@
+-- Partner-global OAuth/MCP connected applications need capabilities distinct
+-- from generic organization or device administration. Partner Admin
+-- roles already satisfy these through *:*; custom roles receive no implicit
+-- escalation and must be granted the new capabilities deliberately.
+--
+-- The permissions table has no unique(resource, action), so each catalog row
+-- is guarded explicitly. This migration changes no tenant data.
+
+SELECT set_config('breeze.scope', 'system', true);
+
+INSERT INTO permissions (resource, action, description)
+SELECT 'connected_apps', 'read', 'View partner connected OAuth applications'
+WHERE NOT EXISTS (
+  SELECT 1 FROM permissions
+  WHERE resource = 'connected_apps' AND action = 'read'
+);
+
+INSERT INTO permissions (resource, action, description)
+SELECT 'connected_apps', 'manage', 'Disconnect partner connected OAuth applications'
+WHERE NOT EXISTS (
+  SELECT 1 FROM permissions
+  WHERE resource = 'connected_apps' AND action = 'manage'
+);

--- a/apps/api/migrations/2026-10-15-150032-workspace-permissions-org-admin.sql
+++ b/apps/api/migrations/2026-10-15-150032-workspace-permissions-org-admin.sql
@@ -1,0 +1,47 @@
+-- Fail-closed follow-up to 2026-10-15-150030/150031: those migrations added
+-- workspace:* and connected_apps:* permission rows but granted them to no
+-- built-in role except Partner Admin (via its *:* wildcard). Every existing
+-- Org Admin — full access within its organization — therefore lost Workspace
+-- and partner connected-app access on upgrade the moment those permissions
+-- started being enforced. Org Admin gets every new key by default; Org
+-- Technician, viewers, and custom roles are deliberately left ungranted.
+--
+-- New installs get this from db/seed.ts SYSTEM_ROLES, but seed() only runs
+-- when the users table is empty (apps/api/src/db/autoMigrate.ts) — an
+-- existing install never re-seeds, so this migration is what carries the
+-- grant to it.
+--
+-- Org Admin is a per-partner is_system role (one row per partner), so this
+-- must sweep ALL of them. Matched on name + scope + is_system = TRUE only —
+-- deliberately NO `partner_id IS NULL` clause, matching
+-- 2026-10-08-100600-audit-retention-manage-permission.sql: is_system = TRUE
+-- is what excludes attacker/operator-created custom roles named 'Org Admin'
+-- (routes/roles.ts POST creates those with is_system = false); partner_id
+-- plays no role in that boundary and every per-partner clone must be swept.
+--
+-- role_permissions has a composite PRIMARY KEY on (role_id, permission_id)
+-- (apps/api/src/db/schema/users.ts), so ON CONFLICT DO NOTHING is a real
+-- idempotency mechanism here — unlike `permissions`, which carries no
+-- unique(resource, action) constraint.
+
+DO $$
+DECLARE
+  n integer;
+BEGIN
+  PERFORM set_config('breeze.scope', 'system', true);
+
+  INSERT INTO role_permissions (role_id, permission_id)
+  SELECT r.id, p.id
+  FROM roles r
+  CROSS JOIN permissions p
+  WHERE r.name = 'Org Admin'
+    AND r.scope = 'organization'
+    AND r.is_system = TRUE
+    AND p.resource IN ('workspace', 'connected_apps')
+  ON CONFLICT DO NOTHING;
+
+  GET DIAGNOSTICS n = ROW_COUNT;
+  IF n > 0 THEN
+    RAISE WARNING 'granted % workspace/connected_apps permission row(s) to existing Org Admin role(s)', n;
+  END IF;
+END $$;

--- a/apps/api/src/__tests__/integration/workspaceAuthorization.integration.test.ts
+++ b/apps/api/src/__tests__/integration/workspaceAuthorization.integration.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Real-DB regression coverage for the host-owned Workspace authorization
+ * decisions used by the built-in Workspace extension. The extension gateway
+ * obtains these grants through getUserPermissions; mocked route tests pin
+ * every Workspace method/path decision and the MFA requirement.
+ */
+import './setup';
+
+import { randomUUID } from 'crypto';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { runOutsideDbContext } from '../../db';
+import {
+  clearPermissionCache,
+  getUserPermissions,
+  hasPermission,
+} from '../../services/permissions';
+import {
+  assignUserToPartner,
+  createPartner,
+  createRole,
+  createUser,
+  grantRolePermissions,
+} from './db-utils';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+const WORKSPACE_GRANTS = [
+  { resource: 'workspace', action: 'read' },
+  { resource: 'workspace', action: 'write' },
+  { resource: 'workspace', action: 'credentials' },
+  { resource: 'workspace', action: 'execute' },
+  { resource: 'devices', action: 'read' },
+  { resource: 'devices', action: 'execute' },
+] as const;
+
+async function createPartnerPrincipal(
+  grants: ReadonlyArray<{ resource: string; action: string }>,
+) {
+  const suffix = randomUUID();
+  const partner = await createPartner({
+    name: `Workspace authorization ${suffix}`,
+    slug: `workspace-authorization-${suffix}`,
+  });
+  const user = await createUser({
+    partnerId: partner.id,
+    email: `workspace-authorization-${suffix}@example.test`,
+  });
+  const role = await createRole({
+    name: `Workspace role ${suffix}`,
+    scope: 'partner',
+    partnerId: partner.id,
+  });
+  await grantRolePermissions(role.id, [...grants]);
+  await assignUserToPartner(user.id, partner.id, role.id, 'all');
+  return { partnerId: partner.id, userId: user.id };
+}
+
+async function resolve(fixture: { partnerId: string; userId: string }) {
+  return runOutsideDbContext(() =>
+    getUserPermissions(fixture.userId, { partnerId: fixture.partnerId }),
+  );
+}
+
+describe('Workspace authorization grants (breeze_app, real DB)', () => {
+  beforeEach(async () => {
+    await clearPermissionCache();
+  });
+
+  runDb('a read-only partner role receives no implicit Workspace capability', async () => {
+    const fixture = await createPartnerPrincipal([
+      { resource: 'organizations', action: 'read' },
+    ]);
+
+    const permissions = await resolve(fixture);
+
+    expect(permissions).not.toBeNull();
+    for (const grant of WORKSPACE_GRANTS) {
+      expect(hasPermission(permissions!, grant.resource, grant.action)).toBe(false);
+    }
+  });
+
+  runDb('an explicitly granted role resolves only its assigned Workspace capabilities', async () => {
+    const assigned = [
+      { resource: 'workspace', action: 'read' },
+      { resource: 'workspace', action: 'write' },
+      { resource: 'devices', action: 'read' },
+    ] as const;
+    const fixture = await createPartnerPrincipal(assigned);
+
+    const permissions = await resolve(fixture);
+
+    expect(permissions).not.toBeNull();
+    for (const grant of assigned) {
+      expect(hasPermission(permissions!, grant.resource, grant.action)).toBe(true);
+    }
+    expect(hasPermission(permissions!, 'workspace', 'credentials')).toBe(false);
+    expect(hasPermission(permissions!, 'workspace', 'execute')).toBe(false);
+    expect(hasPermission(permissions!, 'devices', 'execute')).toBe(false);
+  });
+
+  runDb('the existing wildcard administrator grant remains compatible', async () => {
+    const fixture = await createPartnerPrincipal([{ resource: '*', action: '*' }]);
+
+    const permissions = await resolve(fixture);
+
+    expect(permissions).not.toBeNull();
+    for (const grant of WORKSPACE_GRANTS) {
+      expect(hasPermission(permissions!, grant.resource, grant.action)).toBe(true);
+    }
+  });
+});

--- a/apps/api/src/db/seed.test.ts
+++ b/apps/api/src/db/seed.test.ts
@@ -134,6 +134,15 @@ describe('agent rollback RBAC', () => {
   });
 });
 
+describe('billing-role device isolation', () => {
+  it.each(['Partner Billing', 'Partner Billing Viewer'])('%s does not grant devices:read', (roleName) => {
+    const role = SYSTEM_ROLES.find((candidate) => candidate.name === roleName);
+
+    expect(role).toBeDefined();
+    expect(role?.permissions).not.toContain('devices:read');
+  });
+});
+
 describe('ticket mailbox permissions', () => {
   it('registers and seeds the ticket mailbox permissions', () => {
     expect(PERMISSION_GRANTS.TICKET_MAILBOX_READ).toEqual({ resource: 'ticket_mailbox', action: 'read' });
@@ -381,5 +390,26 @@ describe('system role MFA posture (RMM-QA-164)', () => {
 
   it('forces MFA for Partner Admin and for no other system role (D9: Org Admin stays MSP opt-in)', () => {
     expect(SYSTEM_ROLES.filter((role) => role.forceMfa).map((role) => role.name)).toEqual(['Partner Admin']);
+  });
+});
+
+describe('Workspace extension permissions', () => {
+  const workspaceKeys = ['workspace:read', 'workspace:write', 'workspace:credentials', 'workspace:execute'];
+
+  it('seeds every closed Workspace capability so custom roles can receive it', () => {
+    const seeded = new Set(DEFAULT_PERMISSIONS.map((permission) =>
+      `${permission.resource}:${permission.action}`));
+    for (const permission of workspaceKeys) expect(seeded.has(permission)).toBe(true);
+  });
+
+  it('does not grandfather accidental Workspace authority to non-admin roles', () => {
+    for (const role of SYSTEM_ROLES) {
+      if (role.name === 'Partner Admin') continue;
+      for (const permission of workspaceKeys) {
+        expect(role.permissions, `${role.name} received ${permission}`).not.toContain(permission);
+      }
+    }
+    expect(SYSTEM_ROLES.find((role) => role.name === 'Partner Admin')?.permissions)
+      .toContain('*:*');
   });
 });

--- a/apps/api/src/db/seed.test.ts
+++ b/apps/api/src/db/seed.test.ts
@@ -404,12 +404,49 @@ describe('Workspace extension permissions', () => {
 
   it('does not grandfather accidental Workspace authority to non-admin roles', () => {
     for (const role of SYSTEM_ROLES) {
-      if (role.name === 'Partner Admin') continue;
+      if (role.name === 'Partner Admin' || role.name === 'Org Admin') continue;
       for (const permission of workspaceKeys) {
         expect(role.permissions, `${role.name} received ${permission}`).not.toContain(permission);
       }
     }
     expect(SYSTEM_ROLES.find((role) => role.name === 'Partner Admin')?.permissions)
       .toContain('*:*');
+  });
+});
+
+describe('Workspace and connected-app permission defaults on upgrade (fail-closed except Org Admin)', () => {
+  // Org Admin is the existing full-access-within-organization role. When the
+  // workspace:* and connected_apps:* permissions were introduced, they were
+  // granted to no built-in role except Partner Admin (via *:*) — silently
+  // dropping Workspace and connected-app access for every pre-existing Org
+  // Admin on upgrade. Org Admin must carry every new key explicitly; every
+  // other non-wildcard role stays fail-closed.
+  const newKeys = [
+    'workspace:read', 'workspace:write', 'workspace:credentials', 'workspace:execute',
+    'connected_apps:read', 'connected_apps:manage',
+  ];
+  const byName = (name: string) => SYSTEM_ROLES.find((role) => role.name === name);
+
+  it('every new key is seeded in DEFAULT_PERMISSIONS', () => {
+    const seeded = new Set(DEFAULT_PERMISSIONS.map((permission) =>
+      `${permission.resource}:${permission.action}`));
+    for (const key of newKeys) expect(seeded.has(key)).toBe(true);
+  });
+
+  it('grants Org Admin every new workspace:* and connected_apps:* permission', () => {
+    const orgAdminPermissions = byName('Org Admin')?.permissions ?? [];
+    for (const key of newKeys) {
+      expect(orgAdminPermissions, `Org Admin missing ${key}`).toContain(key);
+    }
+  });
+
+  it('does not grant the new permissions to Org Technician, Org Viewer, or partner non-admin roles', () => {
+    const roleNames = ['Org Technician', 'Org Viewer', 'Partner Technician', 'Partner Viewer', 'Partner Billing', 'Partner Billing Viewer'];
+    for (const roleName of roleNames) {
+      const permissions = byName(roleName)?.permissions ?? [];
+      for (const key of newKeys) {
+        expect(permissions, `${roleName} unexpectedly received ${key}`).not.toContain(key);
+      }
+    }
   });
 });

--- a/apps/api/src/db/seed.ts
+++ b/apps/api/src/db/seed.ts
@@ -361,7 +361,16 @@ export const SYSTEM_ROLES: readonly SystemRoleDefinition[] = [
       'agent_rollback:create',
       // Tenant variables (#3409): managing the definitions is an admin task;
       // running a script that USES one only needs scripts:execute.
-      'variables:read', 'variables:manage'
+      'variables:read', 'variables:manage',
+      // Workspace and partner connected-app permissions were introduced with
+      // no built-in role grant except Partner Admin's wildcard, which would
+      // have silently dropped this access for every existing Org Admin on
+      // upgrade. Org Admin gets every new key by default; the routes for
+      // connected_apps additionally require partner scope, so this literal
+      // grant is inert for an org-scoped token until that boundary is
+      // crossed deliberately.
+      'workspace:read', 'workspace:write', 'workspace:credentials', 'workspace:execute',
+      'connected_apps:read', 'connected_apps:manage'
     ]
   },
   {

--- a/apps/api/src/db/seed.ts
+++ b/apps/api/src/db/seed.ts
@@ -120,6 +120,14 @@ export const DEFAULT_PERMISSIONS = [
 
   { resource: 'agent_rollback', action: 'create', description: 'Authorize a signed agent rollback' },
 
+  // Built-in Workspace extension. No non-wildcard system role receives these
+  // implicitly: operators must deliberately assign the least privilege a role
+  // needs; Partner Admin retains access through its existing *:* grant.
+  { resource: 'workspace', action: 'read', description: 'View Workspace sources and processing status' },
+  { resource: 'workspace', action: 'write', description: 'Configure Workspace sources and settings' },
+  { resource: 'workspace', action: 'credentials', description: 'Manage Workspace source credentials' },
+  { resource: 'workspace', action: 'execute', description: 'Run Workspace crawling and content processing' },
+
   // Network topology (discovery topology view + saved layout)
   { resource: 'topology', action: 'read', description: 'View network topology and saved layout' },
   { resource: 'topology', action: 'write', description: 'Persist topology node layout (drag-to-save)' },
@@ -185,6 +193,11 @@ export const DEFAULT_PERMISSIONS = [
   { resource: 'organizations', action: 'read', description: 'View organizations' },
   { resource: 'organizations', action: 'write', description: 'Create and edit organizations' },
   { resource: 'organizations', action: 'delete', description: 'Delete organizations' },
+
+  // Partner-wide OAuth/MCP connected applications. Partner Admin satisfies
+  // these through its wildcard; custom roles must be granted them explicitly.
+  { resource: 'connected_apps', action: 'read', description: 'View partner connected OAuth applications' },
+  { resource: 'connected_apps', action: 'manage', description: 'Disconnect partner connected OAuth applications' },
 
   // Sites
   { resource: 'sites', action: 'read', description: 'View sites' },

--- a/apps/api/src/extensions/enabledGate.test.ts
+++ b/apps/api/src/extensions/enabledGate.test.ts
@@ -10,9 +10,27 @@ vi.mock('../middleware/auth', () => ({
     c: { set(key: string, value: unknown): void },
     next: () => Promise<void>,
   ) => {
-    c.set('auth', { user: { id: 'user-1' } });
+    c.set('auth', {
+      user: { id: 'user-1', isPlatformAdmin: false },
+      token: { mfa: true },
+      partnerId: 'partner-1',
+      orgId: 'org-1',
+      scope: 'organization',
+    });
     await next();
   }),
+  hasSatisfiedMfa: vi.fn(() => true),
+}));
+
+vi.mock('../services/permissions', () => ({
+  getUserPermissions: vi.fn(async () => ({
+    permissions: [{ resource: '*', action: '*' }],
+    roleId: 'role-1',
+    scope: 'organization',
+    partnerId: 'partner-1',
+    orgId: 'org-1',
+  })),
+  hasPermission: vi.fn(() => true),
 }));
 
 vi.mock('../middleware/agentAuth', () => ({

--- a/apps/api/src/extensions/gateway.test.ts
+++ b/apps/api/src/extensions/gateway.test.ts
@@ -1,20 +1,48 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { Hono } from 'hono';
+import { Hono, type Context } from 'hono';
 import type { ExtensionManifestV1 } from '@breeze/extension-sdk';
 
 import { ExtensionContributionRegistry } from './contributionRegistry';
 
 const authLifetime = new AsyncLocalStorage<'user' | 'agent' | 'helper'>();
+const permissionState = vi.hoisted(() => ({ missing: false, error: false }));
+const authState = vi.hoisted(() => ({
+  value: {
+    user: { id: 'user-1', isPlatformAdmin: false },
+    token: { mfa: true },
+    partnerId: 'partner-1' as string | null,
+    orgId: 'org-1' as string | null,
+    scope: 'organization' as 'organization' | 'partner' | 'system',
+  },
+}));
 
 vi.mock('../middleware/auth', () => ({
   authMiddleware: vi.fn(async (
     c: { set(key: string, value: unknown): void },
     next: () => Promise<void>,
   ) => {
-    c.set('auth', { user: { id: 'user-1' }, orgId: 'org-1', scope: 'organization' });
-    await authLifetime.run('user', next);
+    c.set('auth', authState.value);
+    return authLifetime.run('user', next);
   }),
+  hasSatisfiedMfa: vi.fn((auth: { token?: { mfa?: boolean } }) => auth.token?.mfa === true),
+}));
+
+vi.mock('../services/permissions', () => ({
+  getUserPermissions: vi.fn(async () => {
+    if (permissionState.error) throw new Error('synthetic permission lookup failure');
+    return permissionState.missing ? null : ({
+      permissions: [{ resource: '*', action: '*' }],
+      roleId: 'role-1',
+      scope: 'organization',
+      partnerId: 'partner-1',
+      orgId: 'org-1',
+    });
+  }),
+  hasPermission: vi.fn((userPermissions: { permissions: Array<{ resource: string; action: string }> }, resource: string, action: string) =>
+    userPermissions.permissions.some((permission) =>
+      (permission.resource === '*' || permission.resource === resource)
+      && (permission.action === '*' || permission.action === action))),
 }));
 
 vi.mock('../middleware/agentAuth', () => ({
@@ -122,6 +150,16 @@ function makeGatewayFixture(options: {
     userId: (c.get('auth') as { user: { id: string } }).user.id,
     authLifetime: authLifetime.getStore(),
   }));
+  routeApp.get('/authorization', (c) => {
+    const authorization = c.get('extensionAuthorization') as {
+      hasPermission(resource: string, action: string): boolean;
+      mfaSatisfied: boolean;
+    };
+    return c.json({
+      workspaceRead: authorization.hasPermission('workspace', 'read'),
+      mfaSatisfied: authorization.mfaSatisfied,
+    });
+  });
   routeApp.get('/agent/:id/config', (c) => c.json({
     deviceId: (c.get('agent') as { deviceId: string }).deviceId,
     authLifetime: authLifetime.getStore(),
@@ -136,6 +174,59 @@ function makeGatewayFixture(options: {
 describe('mountExtensionGateway', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    permissionState.missing = false;
+    permissionState.error = false;
+    authState.value = {
+      user: { id: 'user-1', isPlatformAdmin: false },
+      token: { mfa: true },
+      partnerId: 'partner-1',
+      orgId: 'org-1',
+      scope: 'organization',
+    };
+  });
+
+  it('exposes host-resolved wildcard permission and MFA decisions to user routes', async () => {
+    const { app } = makeGatewayFixture();
+    const response = await app.request('/api/v1/ext/demo/authorization');
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ workspaceRead: true, mfaSatisfied: true });
+  });
+
+  it('fails closed before extension dispatch when the live role has no permissions', async () => {
+    permissionState.missing = true;
+    const { app } = makeGatewayFixture();
+    const response = await app.request('/api/v1/ext/demo/items/item-42');
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ error: 'Permission denied' });
+  });
+
+  it('fails closed when live permission resolution errors', async () => {
+    permissionState.error = true;
+    const routeApp = new Hono();
+    const handler = vi.fn((c: Context) => c.json({ ok: true }));
+    routeApp.get('/protected', handler);
+    const { app } = makeGatewayFixture({ routeApp });
+    const response = await app.request('/api/v1/ext/demo/protected');
+    expect(response.status).toBe(500);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('authorizes only a verified platform admin for system-scope extension requests', async () => {
+    authState.value = {
+      user: { id: 'platform-1', isPlatformAdmin: true },
+      token: { mfa: false },
+      partnerId: null,
+      orgId: null,
+      scope: 'system',
+    };
+    const { app } = makeGatewayFixture();
+    const allowed = await app.request('/api/v1/ext/demo/authorization');
+    expect(allowed.status).toBe(200);
+    expect(await allowed.json()).toEqual({ workspaceRead: true, mfaSatisfied: false });
+
+    authState.value.user.isPlatformAdmin = false;
+    const denied = await app.request('/api/v1/ext/demo/authorization');
+    expect(denied.status).toBe(403);
   });
 
   it('runs user auth and the matched handler in the same context and auth lifetime', async () => {

--- a/apps/api/src/extensions/gateway.ts
+++ b/apps/api/src/extensions/gateway.ts
@@ -3,8 +3,10 @@ import type { Context, MiddlewareHandler } from 'hono';
 import type { ExtensionManifestV1 } from '@breeze/extension-sdk';
 
 import { agentAuthMiddleware } from '../middleware/agentAuth';
-import { authMiddleware } from '../middleware/auth';
+import { authMiddleware, hasSatisfiedMfa } from '../middleware/auth';
 import { helperAuth } from '../middleware/helperAuth';
+import { getUserPermissions, hasPermission } from '../services/permissions';
+import type { ExtensionRequestAuthorization } from '@breeze/extension-sdk';
 import { recordExtensionRequest } from './metrics';
 import type {
   ExtensionContributionRegistry,
@@ -13,6 +15,58 @@ import type {
 
 type LoaderAuthKind = 'user' | 'agent' | 'helper';
 const LOADER_AUTH_KIND = 'extensionLoaderAuthKind';
+
+declare module 'hono' {
+  interface ContextVariableMap {
+    extensionAuthorization: ExtensionRequestAuthorization;
+  }
+}
+
+/**
+ * Resolve product RBAC once at the host boundary and expose only decisions to
+ * the extension. Tenant reachability remains a separate, outer ceiling.
+ */
+async function loadExtensionAuthorization(
+  c: Context,
+  next: () => Promise<void>,
+): Promise<void> {
+  const auth = c.get('auth');
+  if (!auth) {
+    c.res = c.json({ error: 'Not authenticated' }, 401);
+    return;
+  }
+
+  if (auth.scope === 'system') {
+    if (!auth.user.isPlatformAdmin) {
+      c.res = c.json({ error: 'Permission denied' }, 403);
+      return;
+    }
+    c.set('extensionAuthorization', {
+      hasPermission: () => true,
+      mfaSatisfied: hasSatisfiedMfa(auth),
+    });
+    return next();
+  }
+
+  const userPermissions = await getUserPermissions(auth.user.id, {
+    partnerId: auth.partnerId ?? undefined,
+    orgId: auth.orgId ?? undefined,
+  });
+  if (!userPermissions) {
+    c.res = c.json({ error: 'Permission denied' }, 403);
+    return;
+  }
+
+  c.set('extensionAuthorization', {
+    hasPermission: (resource, action) =>
+      hasPermission(userPermissions, resource, action),
+    mfaSatisfied: hasSatisfiedMfa(auth),
+    ...(userPermissions.allowedSiteIds === undefined
+      ? {}
+      : { allowedSiteIds: userPermissions.allowedSiteIds }),
+  });
+  return next();
+}
 
 function skipIfLoaderAuthed(
   inner: MiddlewareHandler,
@@ -79,7 +133,7 @@ export function buildExtensionAuthGuard(
       return next();
     }
     c.set(LOADER_AUTH_KIND, 'user');
-    return authMiddleware(c, next);
+    return authMiddleware(c, () => loadExtensionAuthorization(c, next));
   };
 }
 

--- a/apps/api/src/routes/connectedApps.authorityBoundary.test.ts
+++ b/apps/api/src/routes/connectedApps.authorityBoundary.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const routeSource = readFileSync(new URL('./connectedApps.ts', import.meta.url), 'utf8');
+const permissionSource = readFileSync(
+  new URL('../../../../packages/shared/src/constants/permissions.ts', import.meta.url),
+  'utf8',
+);
+
+describe('partner connected-app authority boundary', () => {
+  it('defines separate read and manage capabilities', () => {
+    expect(permissionSource).toContain(
+      "CONNECTED_APPS_READ: { resource: 'connected_apps', action: 'read' }",
+    );
+    expect(permissionSource).toContain(
+      "CONNECTED_APPS_MANAGE: { resource: 'connected_apps', action: 'manage' }",
+    );
+  });
+
+  it('requires partner scope and full-partner authority for the whole router', () => {
+    expect(routeSource).toContain("connectedAppsRoutes.use('*', requireScope('partner'))");
+    expect(routeSource).toContain(
+      "connectedAppsRoutes.use('*', requireFullPartnerConnectedAppAuthority)",
+    );
+  });
+
+  it('requires connected-app read authority before listing rows', () => {
+    expect(routeSource).toMatch(
+      /connectedAppsRoutes\.get\(\s*'\/'\s*,\s*requireConnectedAppsRead\s*,/,
+    );
+  });
+
+  it('requires connected-app management authority and MFA before disconnect effects', () => {
+    expect(routeSource).toMatch(
+      /connectedAppsRoutes\.delete\(\s*'\/:clientId'\s*,\s*requireConnectedAppsManage\s*,\s*requireMfa\(\)\s*,/,
+    );
+    const deleteAt = routeSource.indexOf("connectedAppsRoutes.delete(");
+    const revokeAt = routeSource.indexOf('revokeClientFamilies(', deleteAt);
+    expect(revokeAt).toBeGreaterThan(deleteAt);
+  });
+
+  it('retains feature gating and partner-scoped revocation', () => {
+    expect(routeSource).toContain('if (MCP_OAUTH_ENABLED)');
+    expect(routeSource).toContain(
+      "revokeClientFamilies(clientId, { kind: 'partner', partnerId }",
+    );
+  });
+});

--- a/apps/api/src/routes/connectedApps.disabled.test.ts
+++ b/apps/api/src/routes/connectedApps.disabled.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it, vi } from 'vitest';
 import { Hono } from 'hono';
 
 vi.mock('../config/env', () => ({ MCP_OAUTH_ENABLED: false }));
-vi.mock('../middleware/auth', () => ({ authMiddleware: vi.fn() }));
+vi.mock('../middleware/auth', () => ({
+  authMiddleware: vi.fn(),
+  requireScope: vi.fn(() => vi.fn()),
+  requirePermission: vi.fn(() => vi.fn()),
+  requireMfa: vi.fn(() => vi.fn()),
+}));
 vi.mock('../db', () => ({ db: {} }));
 vi.mock('../db/schema', () => ({
   oauthClients: {},

--- a/apps/api/src/routes/connectedApps.test.ts
+++ b/apps/api/src/routes/connectedApps.test.ts
@@ -17,6 +17,8 @@ const mocks = vi.hoisted(() => ({
   // marker-write failure. The service's own behavior is covered in
   // oauth/revocationService.test.ts + the integration suite.
   revokeClientFamilies: vi.fn(async () => ({ grants: 0, refreshTokens: 0 })),
+  permissionDenied: false,
+  mfaDenied: false,
   eq: vi.fn((left: unknown, right: unknown) => ({ op: 'eq', left, right })),
   and: vi.fn((...conditions: unknown[]) => ({ op: 'and', conditions })),
 }));
@@ -30,6 +32,18 @@ vi.mock('../middleware/auth', () => ({
   authMiddleware: vi.fn(async (c: any, next: any) => {
     c.set('auth', mocks.auth);
     await next();
+  }),
+  requireScope: vi.fn((...scopes: string[]) => async (c: any, next: any) => {
+    if (!scopes.includes(mocks.auth.scope)) return c.json({ error: 'Insufficient scope' }, 403);
+    return next();
+  }),
+  requirePermission: vi.fn(() => async (c: any, next: any) => {
+    if (mocks.permissionDenied) return c.json({ error: 'Permission denied' }, 403);
+    return next();
+  }),
+  requireMfa: vi.fn(() => async (c: any, next: any) => {
+    if (mocks.mfaDenied) return c.json({ error: 'MFA required', code: 'MFA_REQUIRED' }, 403);
+    return next();
   }),
 }));
 
@@ -68,11 +82,13 @@ import { connectedAppsRoutes } from './connectedApps';
 
 function resetAuth(partnerId: string | null = 'current-partner') {
   mocks.auth = {
+    principal: { kind: 'user_session' },
     user: { id: 'u1', email: 'user@example.com', name: 'User One' },
     token: {},
     partnerId,
     orgId: 'current-org',
     scope: partnerId ? 'partner' : 'system',
+    partnerOrgAccess: partnerId ? 'all' : undefined,
     accessibleOrgIds: null,
     orgCondition: vi.fn(),
     canAccessOrg: vi.fn(),
@@ -124,14 +140,40 @@ describe('connectedAppsRoutes', () => {
     mocks.delete.mockReset();
     mocks.revokeClientFamilies.mockReset();
     mocks.revokeClientFamilies.mockResolvedValue({ grants: 0, refreshTokens: 0 });
+    mocks.permissionDenied = false;
+    mocks.mfaDenied = false;
     resetAuth();
+  });
+
+  it.each(['selected', 'none'] as const)(
+    'denies a partner member with orgAccess=%s before listing connected apps',
+    async (partnerOrgAccess) => {
+      mocks.auth.partnerOrgAccess = partnerOrgAccess;
+      const res = await loadApp().request('/api/v1/settings/connected-apps');
+      expect(res.status).toBe(403);
+      expect(mocks.select).not.toHaveBeenCalled();
+    },
+  );
+
+  it('denies system scope because this partner-pinned route has no target partner parameter', async () => {
+    resetAuth(null);
+    const res = await loadApp().request('/api/v1/settings/connected-apps');
+    expect(res.status).toBe(403);
+    expect(mocks.select).not.toHaveBeenCalled();
+  });
+
+  it('requires connected-app read permission before listing', async () => {
+    mocks.permissionDenied = true;
+    const res = await loadApp().request('/api/v1/settings/connected-apps');
+    expect(res.status).toBe(403);
+    expect(mocks.select).not.toHaveBeenCalled();
   });
 
   it('returns 403 when auth has no partner scope', async () => {
     resetAuth(null);
     const res = await loadApp().request('/api/v1/settings/connected-apps');
     expect(res.status).toBe(403);
-    expect(await res.json()).toEqual({ message: 'partner scope required' });
+    expect(await res.json()).toEqual({ error: 'Insufficient scope' });
     expect(mocks.select).not.toHaveBeenCalled();
   });
 
@@ -226,10 +268,44 @@ describe('connectedAppsRoutes', () => {
       method: 'DELETE',
     });
     expect(res.status).toBe(403);
-    expect(await res.json()).toEqual({ message: 'partner scope required' });
+    expect(await res.json()).toEqual({ error: 'Insufficient scope' });
     expect(mocks.select).not.toHaveBeenCalled();
     expect(mocks.update).not.toHaveBeenCalled();
     expect(mocks.delete).not.toHaveBeenCalled();
+  });
+
+  it.each(['selected', 'none'] as const)(
+    'DELETE denies a partner member with orgAccess=%s before lookup or revocation',
+    async (partnerOrgAccess) => {
+      mocks.auth.partnerOrgAccess = partnerOrgAccess;
+      const res = await loadApp().request('/api/v1/settings/connected-apps/client-1', {
+        method: 'DELETE',
+      });
+      expect(res.status).toBe(403);
+      expect(mocks.select).not.toHaveBeenCalled();
+      expect(mocks.revokeClientFamilies).not.toHaveBeenCalled();
+    },
+  );
+
+  it('DELETE requires connected-app management permission before lookup or revocation', async () => {
+    mocks.permissionDenied = true;
+    const res = await loadApp().request('/api/v1/settings/connected-apps/client-1', {
+      method: 'DELETE',
+    });
+    expect(res.status).toBe(403);
+    expect(mocks.select).not.toHaveBeenCalled();
+    expect(mocks.revokeClientFamilies).not.toHaveBeenCalled();
+  });
+
+  it('DELETE requires MFA before lookup or revocation', async () => {
+    mocks.mfaDenied = true;
+    const res = await loadApp().request('/api/v1/settings/connected-apps/client-1', {
+      method: 'DELETE',
+    });
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'MFA required', code: 'MFA_REQUIRED' });
+    expect(mocks.select).not.toHaveBeenCalled();
+    expect(mocks.revokeClientFamilies).not.toHaveBeenCalled();
   });
 
   it('returns 404 when this partner has no join row for the client', async () => {

--- a/apps/api/src/routes/connectedApps.ts
+++ b/apps/api/src/routes/connectedApps.ts
@@ -1,19 +1,43 @@
 import { Hono } from 'hono';
+import type { Context, Next } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 import { and, eq } from 'drizzle-orm';
-import { authMiddleware } from '../middleware/auth';
+import { authMiddleware, requireMfa, requirePermission, requireScope } from '../middleware/auth';
 import { db } from '../db';
 import { oauthClients, oauthClientPartnerGrants } from '../db/schema';
 import { revokeClientFamilies } from '../oauth/revocationService';
 import { ERROR_IDS, logOauthError } from '../oauth/log';
 import { MCP_OAUTH_ENABLED } from '../config/env';
+import { PERMISSIONS } from '../services/permissions';
+import { canManagePartnerWidePolicies } from '../services/partnerWideAccess';
 
 export const connectedAppsRoutes = new Hono();
 
+const requireConnectedAppsRead = requirePermission(
+  PERMISSIONS.CONNECTED_APPS_READ.resource,
+  PERMISSIONS.CONNECTED_APPS_READ.action,
+);
+const requireConnectedAppsManage = requirePermission(
+  PERMISSIONS.CONNECTED_APPS_MANAGE.resource,
+  PERMISSIONS.CONNECTED_APPS_MANAGE.action,
+);
+
+async function requireFullPartnerConnectedAppAuthority(c: Context, next: Next) {
+  const auth = c.get('auth');
+  if (!auth.partnerId || !canManagePartnerWidePolicies(auth)) {
+    throw new HTTPException(403, {
+      message: 'Connected-app administration requires full partner organization access',
+    });
+  }
+  await next();
+}
+
 if (MCP_OAUTH_ENABLED) {
   connectedAppsRoutes.use('*', authMiddleware);
+  connectedAppsRoutes.use('*', requireScope('partner'));
+  connectedAppsRoutes.use('*', requireFullPartnerConnectedAppAuthority);
 
-  connectedAppsRoutes.get('/', async (c) => {
+  connectedAppsRoutes.get('/', requireConnectedAppsRead, async (c) => {
     const partnerId = c.get('auth').partnerId;
     if (!partnerId) throw new HTTPException(403, { message: 'partner scope required' });
 
@@ -47,10 +71,11 @@ if (MCP_OAUTH_ENABLED) {
     });
   });
 
-  connectedAppsRoutes.delete('/:clientId', async (c) => {
+  connectedAppsRoutes.delete('/:clientId', requireConnectedAppsManage, requireMfa(), async (c) => {
     const partnerId = c.get('auth').partnerId;
     if (!partnerId) throw new HTTPException(403, { message: 'partner scope required' });
     const clientId = c.req.param('clientId');
+    if (!clientId) throw new HTTPException(400, { message: 'client id required' });
 
     // Look up the join row, not the client row. A DCR client is shared
     // across partners; "is this app connected for me?" is answered by the

--- a/apps/api/src/routes/permissionsCatalog.test.ts
+++ b/apps/api/src/routes/permissionsCatalog.test.ts
@@ -60,6 +60,7 @@ describe('permissions catalog routes', () => {
       expect(keys).toContain('audit:read');
       expect(keys).toContain('alerts:acknowledge');
       expect(keys).toContain('backup:cross_site_restore');
+      expect(keys).toContain('workspace:credentials');
 
       // Labels are present and cover every resource/action used.
       expect(typeof body.resourceLabels).toBe('object');
@@ -69,6 +70,8 @@ describe('permissions catalog routes', () => {
         expect(body.actionLabels[p.action]).toBeTruthy();
       }
       expect(body.actionLabels.cross_site_restore).toBe('Cross-Site Restore');
+      expect(body.resourceLabels.workspace).toBe('Workspace');
+      expect(body.actionLabels.credentials).toBe('Manage Credentials');
     });
 
     it('rejects unauthenticated requests', async () => {

--- a/apps/api/src/routes/permissionsCatalog.ts
+++ b/apps/api/src/routes/permissionsCatalog.ts
@@ -20,6 +20,7 @@ const RESOURCE_LABELS: Record<string, string> = {
   time_entries: 'Time Entries',
   users: 'Users',
   organizations: 'Organizations',
+  connected_apps: 'Connected Applications',
   sites: 'Sites',
   automations: 'Automations',
   remote: 'Remote Access',
@@ -36,7 +37,8 @@ const RESOURCE_LABELS: Record<string, string> = {
   ai_sessions: 'AI Sessions',
   ai_agents: 'AI Agents',
   approvals: 'Approvals',
-  variables: 'Variables'
+  variables: 'Variables',
+  workspace: 'Workspace'
 };
 
 const ACTION_LABELS: Record<string, string> = {
@@ -56,7 +58,8 @@ const ACTION_LABELS: Record<string, string> = {
   accept_risk: 'Accept Risk',
   read_all: 'Read All',
   decide: 'Decide',
-  create: 'Create'
+  create: 'Create',
+  credentials: 'Manage Credentials'
 };
 
 // GET /permissions/catalog - Returns the authoritative list of assignable

--- a/apps/api/src/routes/security/compliance.test.ts
+++ b/apps/api/src/routes/security/compliance.test.ts
@@ -23,7 +23,15 @@ vi.mock('../../middleware/auth', async () => {
   return { ...actual, requireScope: vi.fn(() => async (_c: any, next: any) => next()) };
 });
 
-const { listStatusRowsMock } = vi.hoisted(() => ({ listStatusRowsMock: vi.fn() }));
+const { listStatusRowsMock, getUserPermissionsMock } = vi.hoisted(() => ({
+  listStatusRowsMock: vi.fn(),
+  getUserPermissionsMock: vi.fn(),
+}));
+
+vi.mock('../../services/permissions', async () => {
+  const actual = await vi.importActual<any>('../../services/permissions');
+  return { ...actual, getUserPermissions: getUserPermissionsMock };
+});
 
 vi.mock('./helpers', async () => {
   const actual = await vi.importActual<any>('./helpers');
@@ -74,7 +82,13 @@ function mockEscrowRows(deviceIds: string[]) {
 }
 
 describe('GET /encryption', () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getUserPermissionsMock.mockResolvedValue({
+      permissions: [{ resource: 'devices', action: 'read' }],
+      allowedSiteIds: undefined,
+    });
+  });
 
   it('reports real escrow status, not the old heuristic', async () => {
     listStatusRowsMock.mockResolvedValue([

--- a/apps/api/src/routes/security/compliance.ts
+++ b/apps/api/src/routes/security/compliance.ts
@@ -23,12 +23,14 @@ import {
   parseLocalAdminSummary,
   parseEncryptionVolumes
 } from './helpers';
+import { requireSecurityReadAccess } from './readAuthorization';
 
 export const complianceRoutes = new Hono();
 
 complianceRoutes.get(
   '/trends',
   requireScope('organization', 'partner', 'system'),
+  requireSecurityReadAccess,
   zValidator('query', trendsQuerySchema),
   async (c) => {
     const auth = c.get('auth');
@@ -67,6 +69,7 @@ complianceRoutes.get(
 complianceRoutes.get(
   '/firewall',
   requireScope('organization', 'partner', 'system'),
+  requireSecurityReadAccess,
   zValidator('query', firewallQuerySchema),
   async (c) => {
     const auth = c.get('auth');
@@ -122,6 +125,7 @@ complianceRoutes.get(
 complianceRoutes.get(
   '/encryption',
   requireScope('organization', 'partner', 'system'),
+  requireSecurityReadAccess,
   zValidator('query', encryptionQuerySchema),
   async (c) => {
     const auth = c.get('auth');
@@ -223,6 +227,7 @@ complianceRoutes.get(
 complianceRoutes.get(
   '/password-policy',
   requireScope('organization', 'partner', 'system'),
+  requireSecurityReadAccess,
   zValidator('query', passwordPolicyQuerySchema),
   async (c) => {
     const auth = c.get('auth');
@@ -291,6 +296,7 @@ complianceRoutes.get(
 complianceRoutes.get(
   '/admin-audit',
   requireScope('organization', 'partner', 'system'),
+  requireSecurityReadAccess,
   zValidator('query', adminAuditQuerySchema),
   async (c) => {
     const auth = c.get('auth');

--- a/apps/api/src/routes/security/policies.ts
+++ b/apps/api/src/routes/security/policies.ts
@@ -6,6 +6,7 @@ import { db } from '../../db';
 import { securityPolicies } from '../../db/schema';
 import { requirePermission, requireScope, type AuthContext } from '../../middleware/auth';
 import { canManagePartnerWidePolicies, PARTNER_WIDE_WRITE_DENIED_MESSAGE } from '../../services/partnerWideAccess';
+import { requireSecurityReadAccess } from './readAuthorization';
 import {
   listPoliciesQuerySchema,
   createPolicySchema,
@@ -36,6 +37,7 @@ function securityPolicyAccessCondition(auth: AuthContext): SQL | undefined {
 policiesRoutes.get(
   '/policies',
   requireScope('organization', 'partner', 'system'),
+  requireSecurityReadAccess,
   zValidator('query', listPoliciesQuerySchema),
   async (c) => {
     const auth = c.get('auth');

--- a/apps/api/src/routes/security/readAuthorization.ts
+++ b/apps/api/src/routes/security/readAuthorization.ts
@@ -1,0 +1,25 @@
+import type { MiddlewareHandler } from 'hono';
+import { HTTPException } from 'hono/http-exception';
+
+import { requirePermission } from '../../middleware/auth';
+
+const requireDeviceRead = requirePermission('devices', 'read');
+
+/**
+ * Security fleet reads are available to live platform administrators in system
+ * scope without a tenant membership. Tenant-scoped callers must instead prove
+ * the ordinary devices:read grant from their current org/partner membership.
+ *
+ * authMiddleware revalidates that a system token still belongs to a platform
+ * admin. Keep the identity check here too: it makes this boundary fail closed
+ * when mounted in isolation and prevents a forged system-shaped context from
+ * bypassing the membership-backed permission path.
+ */
+export const requireSecurityReadAccess: MiddlewareHandler = async (c, next) => {
+  const auth = c.get('auth');
+  if (auth?.scope === 'system') {
+    if (auth.user?.isPlatformAdmin === true) return next();
+    throw new HTTPException(403, { message: 'platform admin access required' });
+  }
+  return requireDeviceRead(c, next);
+};

--- a/apps/api/src/routes/security/readAuthz.test.ts
+++ b/apps/api/src/routes/security/readAuthz.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+const {
+  getUserPermissionsMock,
+  getSecurityPostureTrendMock,
+  listStatusRowsMock,
+  buildBe9RecommendationsMock,
+  getRecommendationStatusMapMock,
+} = vi.hoisted(() => ({
+  getUserPermissionsMock: vi.fn(),
+  getSecurityPostureTrendMock: vi.fn(),
+  listStatusRowsMock: vi.fn(),
+  buildBe9RecommendationsMock: vi.fn(),
+  getRecommendationStatusMapMock: vi.fn(),
+}));
+
+vi.mock('../../db', async () => {
+  const actual = await vi.importActual<typeof import('../../db')>('../../db');
+  return {
+    ...actual,
+    db: {
+      select: vi.fn(),
+      selectDistinct: vi.fn(),
+    },
+  };
+});
+
+vi.mock('../../services/permissions', async () => {
+  const actual = await vi.importActual<typeof import('../../services/permissions')>('../../services/permissions');
+  return { ...actual, getUserPermissions: getUserPermissionsMock };
+});
+
+vi.mock('../../middleware/auth', async () => {
+  const actual = await vi.importActual<typeof import('../../middleware/auth')>('../../middleware/auth');
+  return {
+    ...actual,
+    requireScope: vi.fn(() => async (_c: unknown, next: () => Promise<void>) => next()),
+  };
+});
+
+vi.mock('../../services/securityPosture', async () => {
+  const actual = await vi.importActual<typeof import('../../services/securityPosture')>('../../services/securityPosture');
+  return { ...actual, getSecurityPostureTrend: getSecurityPostureTrendMock };
+});
+
+vi.mock('./helpers', async () => {
+  const actual = await vi.importActual<typeof import('./helpers')>('./helpers');
+  return {
+    ...actual,
+    listStatusRows: listStatusRowsMock,
+    buildBe9Recommendations: buildBe9RecommendationsMock,
+    getRecommendationStatusMap: getRecommendationStatusMapMock,
+  };
+});
+
+import { db } from '../../db';
+import { complianceRoutes } from './compliance';
+import { policiesRoutes } from './policies';
+import { recommendationsRoutes } from './recommendations';
+
+const ORG_ID = '11111111-1111-4111-8111-111111111111';
+
+const readRoutes = [
+  { label: 'compliance trends', path: '/security/trends', invalidPath: '/security/trends?period=invalid' },
+  { label: 'firewall compliance', path: '/security/firewall', invalidPath: '/security/firewall?orgId=invalid' },
+  { label: 'encryption compliance', path: '/security/encryption', invalidPath: '/security/encryption?orgId=invalid' },
+  { label: 'password-policy compliance', path: '/security/password-policy', invalidPath: '/security/password-policy?orgId=invalid' },
+  { label: 'admin audit', path: '/security/admin-audit', invalidPath: '/security/admin-audit?orgId=invalid' },
+  { label: 'security policies', path: '/security/policies', invalidPath: '/security/policies?scanSchedule=invalid' },
+  { label: 'security recommendations', path: '/security/recommendations', invalidPath: '/security/recommendations?priority=invalid' },
+] as const;
+
+function mockPolicyRead(): void {
+  vi.mocked(db.select).mockReturnValue({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        orderBy: vi.fn().mockResolvedValue([]),
+      }),
+    }),
+  } as never);
+}
+
+function buildApp(scope: 'organization' | 'partner' | 'system' = 'organization', isPlatformAdmin = false): Hono {
+  const app = new Hono();
+  app.use('*', async (c, next) => {
+    c.set('auth', {
+      scope,
+      orgId: scope === 'organization' ? ORG_ID : null,
+      partnerId: scope === 'partner' ? '22222222-2222-4222-8222-222222222222' : null,
+      accessibleOrgIds: scope === 'system' ? null : [ORG_ID],
+      user: { id: 'user-1', email: 'billing@example.com', name: 'Billing User', isPlatformAdmin },
+      canAccessOrg: (orgId: string) => orgId === ORG_ID,
+      orgCondition: () => undefined,
+    } as never);
+    await next();
+  });
+  app.route('/security', complianceRoutes);
+  app.route('/security', policiesRoutes);
+  app.route('/security', recommendationsRoutes);
+  return app;
+}
+
+function expectNoReadSideEffects(): void {
+  expect(db.select).not.toHaveBeenCalled();
+  expect(db.selectDistinct).not.toHaveBeenCalled();
+  expect(getSecurityPostureTrendMock).not.toHaveBeenCalled();
+  expect(listStatusRowsMock).not.toHaveBeenCalled();
+  expect(buildBe9RecommendationsMock).not.toHaveBeenCalled();
+  expect(getRecommendationStatusMapMock).not.toHaveBeenCalled();
+}
+
+describe.each(readRoutes)('$label requires devices:read', ({ path, invalidPath }) => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getSecurityPostureTrendMock.mockResolvedValue([]);
+    listStatusRowsMock.mockResolvedValue([]);
+    buildBe9RecommendationsMock.mockResolvedValue({ recommendations: [] });
+    getRecommendationStatusMapMock.mockResolvedValue(new Map());
+    mockPolicyRead();
+  });
+
+  it.each([
+    ['no permissions row', null],
+    ['billing-shaped permissions', { permissions: [{ resource: 'catalog', action: 'read' }], allowedSiteIds: undefined }],
+    ['unrelated grant', { permissions: [{ resource: 'scripts', action: 'read' }], allowedSiteIds: undefined }],
+  ])('denies %s before validation or read effects for org and partner scope', async (_label, permissions) => {
+    getUserPermissionsMock.mockResolvedValue(permissions);
+
+    for (const scope of ['organization', 'partner'] as const) {
+      const response = await buildApp(scope).request(invalidPath);
+      expect(response.status).toBe(403);
+      expectNoReadSideEffects();
+    }
+  });
+
+  it.each([
+    ['the exact grant', { permissions: [{ resource: 'devices', action: 'read' }], allowedSiteIds: undefined }],
+    ['a wildcard grant', { permissions: [{ resource: '*', action: '*' }], allowedSiteIds: undefined }],
+  ])('allows %s to reach the handler for org and partner scope', async (_label, permissions) => {
+    getUserPermissionsMock.mockResolvedValue(permissions);
+
+    for (const scope of ['organization', 'partner'] as const) {
+      const response = await buildApp(scope).request(path);
+      expect(response.status).toBe(200);
+    }
+  });
+
+  it('allows a live platform administrator in system scope without a membership lookup', async () => {
+    const response = await buildApp('system', true).request(path);
+
+    expect(response.status).toBe(200);
+    expect(getUserPermissionsMock).not.toHaveBeenCalled();
+  });
+
+  it('does not allow a non-admin system-shaped context to bypass the gate', async () => {
+    const response = await buildApp('system', false).request(invalidPath);
+
+    expect(response.status).toBe(403);
+    expect(getUserPermissionsMock).not.toHaveBeenCalled();
+    expectNoReadSideEffects();
+  });
+});

--- a/apps/api/src/routes/security/recommendations.ts
+++ b/apps/api/src/routes/security/recommendations.ts
@@ -12,12 +12,14 @@ import {
   getRecommendationStatusMap,
   buildBe9Recommendations
 } from './helpers';
+import { requireSecurityReadAccess } from './readAuthorization';
 
 export const recommendationsRoutes = new Hono();
 
 recommendationsRoutes.get(
   '/recommendations',
   requireScope('organization', 'partner', 'system'),
+  requireSecurityReadAccess,
   zValidator('query', recommendationsQuerySchema),
   async (c) => {
     const auth = c.get('auth');

--- a/ee/workspace/src/index.test.ts
+++ b/ee/workspace/src/index.test.ts
@@ -100,6 +100,12 @@ async function stagedApp(options: {
       ? { user: { id: USER_ID }, scope: 'system', accessibleOrgIds: null }
       : options.auth;
     if (auth) c.set('auth' as never, auth as never);
+    if (auth) {
+      c.set('extensionAuthorization' as never, {
+        hasPermission: () => true,
+        mfaSatisfied: true,
+      } as never);
+    }
     const agent = options.agent === undefined
       ? { deviceId: DEVICE_ID, agentId: 'agent-1', orgId: ORG_ID, siteId: null, role: 'agent' }
       : options.agent;

--- a/ee/workspace/src/routes/adminGate.test.ts
+++ b/ee/workspace/src/routes/adminGate.test.ts
@@ -1,0 +1,93 @@
+import { Hono } from 'hono';
+import { describe, expect, it } from 'vitest';
+import { adminGate, type WorkspaceRouteEnv } from './adminGate';
+
+const ORG_ID = '11111111-1111-4111-8111-111111111111';
+
+const ROUTES: Array<{
+  method: string;
+  path: string;
+  grants: string[];
+  mutation?: boolean;
+}> = [
+  { method: 'GET', path: '/sources', grants: ['workspace:read'] },
+  { method: 'GET', path: '/sources/source-1', grants: ['workspace:read'] },
+  { method: 'GET', path: '/sources/source-1/runs', grants: ['workspace:read'] },
+  { method: 'POST', path: '/sources', grants: ['workspace:write', 'workspace:execute', 'devices:execute'], mutation: true },
+  { method: 'PATCH', path: '/sources/source-1', grants: ['workspace:write', 'workspace:execute', 'devices:execute'], mutation: true },
+  { method: 'DELETE', path: '/sources/source-1', grants: ['workspace:write', 'workspace:execute', 'devices:execute'], mutation: true },
+  { method: 'PUT', path: '/sources/source-1/credential', grants: ['workspace:credentials', 'workspace:write', 'workspace:execute', 'devices:execute'], mutation: true },
+  { method: 'DELETE', path: '/sources/source-1/credential', grants: ['workspace:credentials', 'workspace:write', 'workspace:execute', 'devices:execute'], mutation: true },
+  { method: 'GET', path: '/content/status', grants: ['workspace:read'] },
+  { method: 'GET', path: '/content/settings', grants: ['workspace:read'] },
+  { method: 'GET', path: '/content/jobs', grants: ['workspace:read'] },
+  { method: 'PUT', path: '/content/settings', grants: ['workspace:write'], mutation: true },
+  { method: 'POST', path: '/content/ingest-run', grants: ['workspace:execute', 'devices:execute'], mutation: true },
+  { method: 'POST', path: '/content/enrich-run', grants: ['workspace:execute', 'devices:execute'], mutation: true },
+  { method: 'POST', path: '/content/crosswalk-run', grants: ['workspace:execute', 'devices:execute'], mutation: true },
+  { method: 'POST', path: '/content/jobs', grants: ['workspace:execute', 'devices:execute'], mutation: true },
+  { method: 'POST', path: '/content/jobs/advance', grants: ['workspace:execute', 'devices:execute'], mutation: true },
+  { method: 'GET', path: '/dashboard/summary', grants: ['workspace:read'] },
+  { method: 'GET', path: '/dashboard/jobs', grants: ['workspace:read'] },
+  { method: 'GET', path: '/devices/device-1/summary', grants: ['workspace:read', 'devices:read'] },
+];
+
+function appFor(grants: string[], mfaSatisfied = true, allowedSiteIds?: string[]) {
+  const app = new Hono<WorkspaceRouteEnv>();
+  app.use('*', async (c, next) => {
+    c.set('auth', {
+      user: { id: 'user-1', isPlatformAdmin: false },
+      scope: 'partner',
+      partnerId: 'partner-1',
+      accessibleOrgIds: [ORG_ID],
+    });
+    c.set('extensionAuthorization', {
+      hasPermission: (resource, action) => grants.includes(`${resource}:${action}`),
+      mfaSatisfied,
+      ...(allowedSiteIds === undefined ? {} : { allowedSiteIds }),
+    });
+    await next();
+  });
+  app.use('*', adminGate);
+  app.all('*', (c) => c.body(null, 204));
+  return app;
+}
+
+function request(app: Hono<WorkspaceRouteEnv>, method: string, path: string) {
+  return app.request(`${path}?orgId=${ORG_ID}`, { method });
+}
+
+describe('Workspace admin authorization matrix', () => {
+  for (const route of ROUTES) {
+    it(`${route.method} ${route.path} requires every declared grant`, async () => {
+      expect((await request(appFor(route.grants), route.method, route.path)).status).toBe(204);
+      for (const omitted of route.grants) {
+        const remaining = route.grants.filter((grant) => grant !== omitted);
+        expect(
+          (await request(appFor(remaining), route.method, route.path)).status,
+          `omitting ${omitted}`,
+        ).toBe(403);
+      }
+    });
+
+    if (route.mutation) {
+      it(`${route.method} ${route.path} requires host-resolved MFA`, async () => {
+        const response = await request(appFor(route.grants, false), route.method, route.path);
+        expect(response.status).toBe(403);
+        expect(await response.json()).toEqual({ error: 'MFA required', code: 'MFA_REQUIRED' });
+      });
+    }
+
+    it(`${route.method} ${route.path} fails closed for a site-restricted principal`, async () => {
+      const response = await request(
+        appFor(route.grants, true, ['site-1']),
+        route.method,
+        route.path,
+      );
+      expect(response.status).toBe(403);
+      expect(await response.json()).toEqual({
+        error: 'Site-restricted Workspace access is not supported',
+      });
+    });
+  }
+});

--- a/ee/workspace/src/routes/adminGate.ts
+++ b/ee/workspace/src/routes/adminGate.ts
@@ -1,4 +1,5 @@
 import type { MiddlewareHandler } from 'hono';
+import type { ExtensionRequestAuthorization } from '@breeze/extension-sdk';
 
 export interface WorkspaceAuthContext {
   user: {
@@ -16,9 +17,42 @@ export interface WorkspaceAuthContext {
 export type WorkspaceRouteEnv = {
   Variables: {
     auth: WorkspaceAuthContext;
+    extensionAuthorization: ExtensionRequestAuthorization;
     workspaceOrgId: string;
   };
 };
+
+const WORKSPACE_RESOURCE = 'workspace';
+
+function requiredPermissions(method: string, path: string): Array<[string, string]> {
+  if (method === 'GET' || method === 'HEAD') {
+    return path.includes('/devices/')
+      ? [[WORKSPACE_RESOURCE, 'read'], ['devices', 'read']]
+      : [[WORKSPACE_RESOURCE, 'read']];
+  }
+  if (path.endsWith('/credential')) {
+    return [
+      [WORKSPACE_RESOURCE, 'credentials'],
+      [WORKSPACE_RESOURCE, 'write'],
+      [WORKSPACE_RESOURCE, 'execute'],
+      ['devices', 'execute'],
+    ];
+  }
+  if (path.includes('/content/') && !path.endsWith('/content/settings')) {
+    return [[WORKSPACE_RESOURCE, 'execute'], ['devices', 'execute']];
+  }
+  // Creating or changing an active source changes what endpoint agents crawl,
+  // so configuration authority alone is insufficient: it also requires the
+  // explicit Workspace and core device-execution grants.
+  if (path.includes('/sources')) {
+    return [
+      [WORKSPACE_RESOURCE, 'write'],
+      [WORKSPACE_RESOURCE, 'execute'],
+      ['devices', 'execute'],
+    ];
+  }
+  return [[WORKSPACE_RESOURCE, 'write']];
+}
 
 export const adminGate: MiddlewareHandler<WorkspaceRouteEnv> = async (c, next) => {
   const auth = c.get('auth');
@@ -42,7 +76,27 @@ export const adminGate: MiddlewareHandler<WorkspaceRouteEnv> = async (c, next) =
     return c.json({ error: 'Organization access denied' }, 403);
   }
 
+  const authorization = c.get('extensionAuthorization');
+  if (!authorization) {
+    return c.json({ error: 'Permission denied' }, 403);
+  }
+  if (
+    requiredPermissions(c.req.method, c.req.path)
+      .some(([resource, action]) => !authorization.hasPermission(resource, action))
+  ) {
+    return c.json({ error: 'Permission denied' }, 403);
+  }
+  if (!['GET', 'HEAD'].includes(c.req.method) && !authorization.mfaSatisfied) {
+    return c.json({ error: 'MFA required', code: 'MFA_REQUIRED' }, 403);
+  }
+  // Current interactive partner/system sessions have no site restriction.
+  // Workspace's present schema and services cannot express a durable site
+  // ceiling for sources, processing, dashboards, or device summaries, so a
+  // future restricted principal must fail closed across this entire gate.
+  if (authorization.allowedSiteIds !== undefined) {
+    return c.json({ error: 'Site-restricted Workspace access is not supported' }, 403);
+  }
+
   c.set('workspaceOrgId', orgId);
   await next();
 };
-

--- a/ee/workspace/src/routes/content.test.ts
+++ b/ee/workspace/src/routes/content.test.ts
@@ -83,6 +83,10 @@ function makeApp(overrides: Partial<ContentRouteDeps> = {}, auth?: object | null
       c.set('auth', (auth ?? {
         user: { id: 'admin-1' }, scope: 'partner', accessibleOrgIds: [ORG_ID],
       }) as WorkspaceRouteEnv['Variables']['auth']);
+      c.set('extensionAuthorization', {
+        hasPermission: () => true,
+        mfaSatisfied: true,
+      });
     }
     await next();
   });

--- a/ee/workspace/src/routes/deviceSummary.test.ts
+++ b/ee/workspace/src/routes/deviceSummary.test.ts
@@ -35,6 +35,10 @@ function harness(authContext: WorkspaceAuthContext = auth()) {
   const app = new Hono<WorkspaceRouteEnv>();
   app.use('*', async (c, next) => {
     c.set('auth', authContext);
+    c.set('extensionAuthorization', {
+      hasPermission: () => true,
+      mfaSatisfied: true,
+    });
     await next();
   });
   app.route('/', createDeviceSummaryRoutes({ deviceSummaryService }));

--- a/ee/workspace/src/routes/sources.test.ts
+++ b/ee/workspace/src/routes/sources.test.ts
@@ -57,7 +57,26 @@ function auth(overrides: Partial<WorkspaceAuthContext> = {}): WorkspaceAuthConte
   };
 }
 
-function makeHarness(authValue = auth()) {
+type ExtensionAuthorizationFixture = {
+  hasPermission: (resource: string, action: string) => boolean;
+  mfaSatisfied: boolean;
+};
+
+function authorization(
+  grants: string[] = ['*:*'],
+  mfaSatisfied = true,
+): ExtensionAuthorizationFixture {
+  return {
+    hasPermission: (resource, action) =>
+      grants.includes('*:*') || grants.includes(`${resource}:${action}`),
+    mfaSatisfied,
+  };
+}
+
+function makeHarness(
+  authValue = auth(),
+  authorizationValue: ExtensionAuthorizationFixture = authorization(),
+) {
   const sourcesService = {
     list: vi.fn(async () => [source()]),
     get: vi.fn(async () => source()),
@@ -88,6 +107,11 @@ function makeHarness(authValue = auth()) {
   const app = new Hono<WorkspaceRouteEnv>();
   app.use('*', async (c, next) => {
     c.set('auth', authValue);
+    // The host gateway owns permission resolution. Keep this fixture explicit
+    // so route tests exercise the extension's authorization boundary rather
+    // than treating partner scope as a privilege signal.
+    (c as unknown as { set(key: string, value: unknown): void })
+      .set('extensionAuthorization', authorizationValue);
     await next();
   });
   app.route('/', createSourcesRoutes({ sourcesService, credentialService, audit, log }));
@@ -107,6 +131,49 @@ beforeEach(() => {
 });
 
 describe('sources admin routes', () => {
+  it('does not treat read-only partner organization reach as source administration', async () => {
+    const h = makeHarness(auth(), authorization(['workspace:read']));
+
+    const read = await h.app.request(`/sources?orgId=${ORG_ID}`);
+    expect(read.status).toBe(200);
+
+    const create = await h.app.request(
+      `/sources?orgId=${ORG_ID}`,
+      jsonRequest('POST', sourceInput),
+    );
+    expect(create.status).toBe(403);
+    expect(h.sourcesService.create).not.toHaveBeenCalled();
+  });
+
+  it('requires the credential grant before touching stored source credentials', async () => {
+    const h = makeHarness(
+      auth(),
+      authorization(['workspace:read', 'workspace:write', 'workspace:execute', 'devices:execute']),
+    );
+    const res = await h.app.request(
+      `/sources/${SOURCE_ID}/credential?orgId=${ORG_ID}`,
+      jsonRequest('PUT', { username: 'synthetic-user', password: 'synthetic-password' }),
+    );
+    expect(res.status).toBe(403);
+    expect(h.credentialService.set).not.toHaveBeenCalled();
+  });
+
+  it('requires MFA before a permitted source mutation', async () => {
+    const h = makeHarness(
+      auth(),
+      authorization(
+        ['workspace:read', 'workspace:write', 'workspace:execute', 'devices:execute'],
+        false,
+      ),
+    );
+    const res = await h.app.request(
+      `/sources?orgId=${ORG_ID}`,
+      jsonRequest('POST', sourceInput),
+    );
+    expect(res.status).toBe(403);
+    expect(h.sourcesService.create).not.toHaveBeenCalled();
+  });
+
   it('rejects organization-scoped callers', async () => {
     const h = makeHarness(auth({ scope: 'organization', orgId: ORG_ID }));
     const res = await h.app.request(`/sources?orgId=${ORG_ID}`);

--- a/packages/extension-sdk/src/server.ts
+++ b/packages/extension-sdk/src/server.ts
@@ -108,6 +108,22 @@ export interface ExtensionAiContext {
   invoke(input: ExtensionAiInvokeInput): Promise<ExtensionAiInvokeResult>;
 }
 
+/**
+ * Host-resolved authorization attached to each authenticated extension request.
+ *
+ * Extensions must use this capability instead of treating tenant reachability
+ * (`scope`, `orgId`, or an organization allowlist) as product authority. The
+ * host owns wildcard matching, live role resolution, MFA feature semantics and
+ * permission-cache invalidation; extensions receive only the decisions needed
+ * at their route boundary.
+ */
+export interface ExtensionRequestAuthorization {
+  hasPermission(resource: string, action: string): boolean;
+  mfaSatisfied: boolean;
+  /** Undefined means the resolved role has no site restriction. */
+  allowedSiteIds?: readonly string[];
+}
+
 export interface ExtensionRuntimeContext {
   db: Record<string, unknown> & { execute(query: unknown): Promise<unknown> };
   secrets: {

--- a/packages/shared/src/constants/permissions.test.ts
+++ b/packages/shared/src/constants/permissions.test.ts
@@ -13,3 +13,12 @@ describe('agent rollback grant', () => {
     expect(PERMISSION_GRANTS.AGENT_ROLLBACK_CREATE).toEqual({ resource: 'agent_rollback', action: 'create' });
   });
 });
+
+describe('Workspace extension grants', () => {
+  it('keeps read, configuration, credentials, and execution as distinct capabilities', () => {
+    expect(PERMISSION_GRANTS.WORKSPACE_READ).toEqual({ resource: 'workspace', action: 'read' });
+    expect(PERMISSION_GRANTS.WORKSPACE_WRITE).toEqual({ resource: 'workspace', action: 'write' });
+    expect(PERMISSION_GRANTS.WORKSPACE_CREDENTIALS).toEqual({ resource: 'workspace', action: 'credentials' });
+    expect(PERMISSION_GRANTS.WORKSPACE_EXECUTE).toEqual({ resource: 'workspace', action: 'execute' });
+  });
+});

--- a/packages/shared/src/constants/permissions.ts
+++ b/packages/shared/src/constants/permissions.ts
@@ -26,6 +26,13 @@ export const PERMISSION_GRANTS = {
   // Signed, resource-bound rollback of customer-machine agent components.
   AGENT_ROLLBACK_CREATE: { resource: 'agent_rollback', action: 'create' },
 
+  // Built-in Workspace extension. Keep content/source administration and
+  // credential use distinct from read-only visibility and crawl execution.
+  WORKSPACE_READ: { resource: 'workspace', action: 'read' },
+  WORKSPACE_WRITE: { resource: 'workspace', action: 'write' },
+  WORKSPACE_CREDENTIALS: { resource: 'workspace', action: 'credentials' },
+  WORKSPACE_EXECUTE: { resource: 'workspace', action: 'execute' },
+
   // Network topology (discovery topology view + saved layout — #1728)
   TOPOLOGY_READ: { resource: 'topology', action: 'read' },
   TOPOLOGY_WRITE: { resource: 'topology', action: 'write' },
@@ -94,6 +101,12 @@ export const PERMISSION_GRANTS = {
   ORGS_READ: { resource: 'organizations', action: 'read' },
   ORGS_WRITE: { resource: 'organizations', action: 'write' },
   ORGS_DELETE: { resource: 'organizations', action: 'delete' },
+
+  // Partner-wide OAuth/MCP connected applications. These are deliberately
+  // separate from organization administration: one disconnect revokes every
+  // grant for the shared client under the partner.
+  CONNECTED_APPS_READ: { resource: 'connected_apps', action: 'read' },
+  CONNECTED_APPS_MANAGE: { resource: 'connected_apps', action: 'manage' },
 
   // SSO administration: configure providers + manage verified domains. A
   // higher-trust capability than organizations:write (security review #2 H-2).


### PR DESCRIPTION
## Summary

- Workspace source management (read/write/credentials/execute) and partner connected-app (OAuth/MCP) actions previously relied on tenant reachability alone — any authenticated caller who could reach an org or partner could act on Workspace sources and connected apps without holding an explicit permission for it.
- Adds dedicated `workspace:*` and `connected_apps:*` permissions, enforces them in the extension gateway / Workspace admin gate / connected-apps routes, and seeds the new permission rows via idempotent migrations. Existing wildcard (`*:*`) roles keep working unchanged; narrower custom roles now need the capability granted deliberately (fail-closed rollout).
- Preserves connected-app authority for callers who also hold Workspace-scoped grants, so the new Workspace gating can't be used to narrow an existing connected-app permission.
- Requires device-read authorization on the security posture/compliance read views, since those surface device-level findings.
- **Follow-up fix**: the new permissions were originally granted to no built-in role except Partner Admin (via `*:*`), which would have silently dropped Workspace and connected-app access for every existing **Org Admin** on upgrade. Org Admin now receives every new `workspace:*` and `connected_apps:*` key by default (`SYSTEM_ROLES` in `db/seed.ts` + a new idempotent migration, `2026-10-15-150032-workspace-permissions-org-admin.sql`, that grants existing per-partner Org Admin role clones).

## Upgrade notes

- **Org Admins keep their access automatically.** The follow-up migration grants every new `workspace:*` and `connected_apps:*` permission to the built-in Org Admin role on every partner, so no MSP admin action is required — Workspace and connected-app functionality your Org Admins could reach before this PR remains reachable after upgrading.
- **Custom roles need explicit grants.** Any custom role (including one named "Org Admin" that isn't the built-in system role) does not receive these permissions automatically and must be granted `workspace:read` / `workspace:write` / `workspace:credentials` / `workspace:execute` and/or `connected_apps:read` / `connected_apps:manage` explicitly via Role management, consistent with this PR's fail-closed design. Org Technician, Org Viewer, and all Partner non-admin roles are deliberately left ungranted.

## Test plan

- [x] `apps/api`: `tsc --noEmit` clean, `eslint` clean
- [x] `ee/workspace`, `packages/shared`, `packages/extension-sdk`: `tsc --noEmit` clean (pre-existing, unrelated tsc errors remain in `packages/shared/src/validators/quotes.test.ts`, a file not touched by this change)
- [x] Unit tests: 9 `apps/api` test files (273 tests), 5 `ee/workspace` test files (151 tests), `packages/shared` `permissions.test.ts` (3 tests), `packages/extension-sdk` `server.test.ts` (3 tests) — all passing
- [x] `src/db/autoMigrate.test.ts`: 78/78 passing (migration ordering)
- [x] Live-DB integration: `workspaceAuthorization.integration.test.ts` (3/3), `tenantCascade` / `tenant-export-policy` / `tenantExportErasureRoundtrip` integration suites (14/14 combined)
- [x] RLS/contract suites: `vitest.config.rls.ts` (31/31), `vitest.config.rls-coverage.ts` (102/102)
- [x] `scripts/check-migration-naming.sh` passes; new migrations placed after the newest shipped migration on main
- [x] **Org Admin default-grant follow-up**: red-first assertion added to `seed.test.ts` (failed before the `SYSTEM_ROLES` change, confirmed green after); `tsc --noEmit` clean; targeted suites green — `seed.test.ts` (169/169), `autoMigrate.test.ts`, `migrationRlsScope.test.ts`, `permissionsCatalog.test.ts` (274 tests combined); live Postgres test-stack: `workspaceAuthorization.integration.test.ts` (3/3) with the new migration applied; manually deleted the 6 Org Admin `workspace:*`/`connected_apps:*` `role_permissions` rows to simulate a pre-upgrade existing install, re-ran the migration SQL directly and confirmed it restores all 6 grants, re-ran a second time and confirmed idempotency (0 new rows, no error); confirmed no other role (Org Technician, Org Viewer, Partner Technician/Viewer/Billing/Billing Viewer) received the grant; test-stack torn down and confirmed removed from `docker compose ls -a`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013auR2S4tHMtuKXj1bXD9aD
