### PR TITLE
docs(agent): state actual Linux support — X11-only capture, apt/dnf patching, dpkg/rpm inventory

### DIFF
--- a/apps/docs/src/content/docs/agents/helper.mdx
+++ b/apps/docs/src/content/docs/agents/helper.mdx
@@ -213,7 +213,7 @@ The Helper can capture the user's screen and send it to the AI for analysis. Thi
 
 1. The AI invokes the `take_screenshot` tool during a chat conversation.
 
-2. The Helper captures the screen using platform-native APIs (DXGI on Windows, Core Graphics on macOS, X11/Wayland on Linux). These APIs are only available in the user session, not in Session 0 -- this is why the Helper exists.
+2. The Helper captures the screen using platform-native APIs (DXGI on Windows, Core Graphics on macOS, X11 on Linux -- Wayland-only sessions are not supported yet). These APIs are only available in the user session, not in Session 0 -- this is why the Helper exists.
 
 3. The screenshot is uploaded to the API via `POST /helper/screenshots` as a base64-encoded image.
 
@@ -519,7 +519,7 @@ The Helper enforces a rate limit of 30 messages per 60 seconds per device. Wait 
 The organization's AI budget may be exhausted or the budget service is temporarily unavailable. Contact your IT administrator to check the org AI budget in **Settings > AI Configuration**.
 
 **Screenshot capture fails.**
-Screen capture requires display access. On Windows, DXGI requires the Helper to be running in the user's desktop session (not Session 0). On Linux, the Helper needs access to the X11 or Wayland display. Check that `CanCapture` is `true` in the capabilities message logged at startup.
+Screen capture requires display access. On Windows, DXGI requires the Helper to be running in the user's desktop session (not Session 0). On Linux, the Helper needs access to an X11 display; Wayland-only sessions cannot be captured yet -- the device page shows **Wayland Unsupported**, or, where XWayland is running, capture attaches to it and shows only X11 application windows (see [Supported Linux Distributions](/agents/installation/#supported-linux-distributions)). Check that `CanCapture` is `true` in the capabilities message logged at startup.
 
 **Computer control actions have no effect.**
 Input injection requires the Helper to have appropriate permissions. On Windows, the Helper runs with a SYSTEM token that can `OpenInputDesktop(GENERIC_ALL)` for UAC and lock screen access. On Linux, `XTest` extension must be available. On macOS, the Helper needs Accessibility permissions in System Preferences > Privacy & Security > Accessibility.

--- a/apps/docs/src/content/docs/agents/installation.mdx
+++ b/apps/docs/src/content/docs/agents/installation.mdx
@@ -47,6 +47,37 @@ clear message instead of installing a binary that can't run.
   shipped features -- reach out if this is blocking you.
 </Aside>
 
+### Supported Linux Distributions
+
+The Linux agent is a statically linked binary, so it runs on any amd64 or
+arm64 distribution, and it is installed as a **systemd** service. What works
+beyond that depends on the distribution's package manager and display server:
+
+| Capability | Debian, Ubuntu | RHEL, Fedora, Rocky, AlmaLinux | openSUSE | Arch, other systemd distributions |
+|---|---|---|---|---|
+| Install, enrollment, heartbeat, monitoring, alerts | Yes | Yes | Yes | Yes |
+| Remote terminal, scripts, automations | Yes | Yes | Yes | Yes |
+| Software inventory | Yes (dpkg) | Yes (rpm) | Yes (rpm) | No (pacman not collected) |
+| OS patch management | Yes (apt) | Yes (dnf/yum) | No (zypper) | No (pacman) |
+| Disk encryption (LUKS) and firewall (ufw, firewalld) status | Yes | Yes | Yes | Yes |
+| Remote desktop and screenshots | X11 sessions only | X11 sessions only | X11 sessions only | X11 sessions only |
+
+<Aside type="caution" title="Wayland sessions">
+  Remote desktop and screenshots require an X11 session. Wayland-only
+  sessions -- the default GNOME and KDE sessions on current Ubuntu and Fedora
+  releases, and compositors such as Hyprland and Sway -- are not supported
+  yet. When no X11 display exists the device page reports **Wayland
+  Unsupported** and **Connect Desktop** is disabled; on compositors that run
+  XWayland the agent may attach to that display instead and show only X11
+  application windows. Everything else works normally. Where the login
+  screen offers an X11 session, selecting it restores remote desktop.
+</Aside>
+
+Distributions without systemd (for example Alpine with OpenRC) can run the
+binary but are not supported by the service installer. There is no `.deb`,
+`.rpm`, or Arch package -- see [Mass Deployment](/migration/mass-deployment/)
+for the script-based fleet install.
+
 ## Quick Install
 
 <Tabs>

--- a/apps/docs/src/content/docs/features/patch-management.mdx
+++ b/apps/docs/src/content/docs/features/patch-management.mdx
@@ -25,7 +25,7 @@ Compliance reports give you a point-in-time snapshot of your fleet's patch statu
 |--------|-------------|
 | **`microsoft`** | Windows Update patches sourced from Microsoft, including cumulative updates, security fixes, and optional feature updates |
 | **`apple`** | macOS and iOS system updates distributed through Apple Software Update |
-| **`linux`** | Distribution packages managed via the native package manager (apt, yum, dnf, zypper, etc.) |
+| **`linux`** | Distribution packages managed via apt (Debian, Ubuntu) or dnf/yum (RHEL, Fedora, Rocky, AlmaLinux). Distributions that use another package manager (pacman, zypper, apk) are inventoried where possible but not patched yet -- see [Supported Linux Distributions](/agents/installation/#supported-linux-distributions) |
 | **`third_party`** | Updates for non-OS applications (browsers, runtimes, productivity tools) detected via winget and Chocolatey on Windows devices, and Homebrew on macOS devices. Enriched with vendor metadata and CVE data through the [Third-Party Package Catalog](#third-party-application-patching) |
 | **`custom`** | Internally published updates distributed through Breeze's custom patch channel |
 

--- a/apps/docs/src/content/docs/features/remote-access.mdx
+++ b/apps/docs/src/content/docs/features/remote-access.mdx
@@ -86,7 +86,11 @@ The `list_sessions` command returns available user sessions by merging the WTS s
 
 The same session broker architecture extends to macOS and Linux. When the agent runs as a LaunchDaemon (macOS) or systemd service (Linux), it has no display access. The agent detects this via the `IsHeadless` flag (checked by `hasConsole()` on Unix).
 
-In headless mode, all desktop and screenshot commands are routed through IPC to the Breeze Helper process running in the user's desktop session, rather than attempting direct screen capture which would silently fail. The Helper handles screen capture using platform-native APIs (Core Graphics on macOS, X11/Wayland on Linux).
+In headless mode, all desktop and screenshot commands are routed through IPC to the Breeze Helper process running in the user's desktop session, rather than attempting direct screen capture which would silently fail. The Helper handles screen capture using platform-native APIs (Core Graphics on macOS, X11 on Linux).
+
+<Aside type="caution" title="Wayland sessions are not supported yet">
+  Remote desktop and screenshots on Linux require an X11 session. Wayland-only sessions -- the default GNOME and KDE sessions on current Ubuntu and Fedora releases, and wlroots compositors such as Hyprland and Sway -- cannot be captured. When the device has no X11 display at all, the device page reports **Wayland Unsupported** and the **Connect Desktop** button is disabled. On compositors that run XWayland for legacy apps, the agent may attach to that XWayland display instead, so a session can connect but shows only X11 application windows rather than the desktop. Terminal, scripts, and monitoring are unaffected either way. Where the login screen offers an X11 session, selecting it restores remote desktop. See [Supported Linux Distributions](/agents/installation/#supported-linux-distributions).
+</Aside>
 
 <Aside>
   If no Helper process is connected when a remote desktop session is requested in headless mode, the agent returns an error immediately rather than streaming zero frames.

--- a/scripts/docs-review/mapping.json
+++ b/scripts/docs-review/mapping.json
@@ -3858,6 +3858,34 @@
         "migration/overview.mdx",
         "migration/syncro.mdx"
       ]
+    },
+    {
+      "pattern": "agent/internal/collectors/software_linux.go",
+      "docs": [
+        "agents/installation.mdx"
+      ]
+    },
+    {
+      "pattern": "agent/internal/patching/defaults_linux.go",
+      "docs": [
+        "agents/installation.mdx",
+        "features/patch-management.mdx"
+      ]
+    },
+    {
+      "pattern": "agent/internal/remote/desktop/x11/**",
+      "docs": [
+        "agents/installation.mdx",
+        "features/remote-access.mdx",
+        "agents/helper.mdx"
+      ]
+    },
+    {
+      "pattern": "agent/internal/heartbeat/desktop_access_linux.go",
+      "docs": [
+        "agents/installation.mdx",
+        "features/remote-access.mdx"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Why

While scoping Arch/Omarchy support, an audit of the Go agent against the docs found three overclaims:

| Doc said | Code does (main @ 3f086236cc) |
|---|---|
| Linux capture uses "X11/Wayland" (`remote-access.mdx`, `helper.mdx` ×2) | Pure-Go X11 client only; Wayland-only sessions return `ErrWaylandUnsupported` (`agent/internal/remote/desktop/x11/resolve_linux.go:106`), surfaced in the UI as **Wayland Unsupported**. Where XWayland is running the resolver attaches to it instead. |
| Linux patching covers "apt, yum, dnf, zypper, etc." (`patch-management.mdx`) | Providers registered: apt, dnf/yum only (`agent/internal/patching/defaults_linux.go`) |
| (nothing on distro support) | Software inventory reads dpkg and rpm only (`agent/internal/collectors/software_linux.go`); no `.deb`/`.rpm`/Arch package |

## What changed

- **`agents/installation.mdx`** — new *Supported Linux Distributions* section: capability × distro-family matrix, a Wayland caution that describes the actual UI behaviour, and the systemd / no-native-package note.
- **`features/patch-management.mdx`** — `linux` source row now names apt and dnf/yum and states pacman/zypper/apk are not patched yet, linking to the matrix.
- **`features/remote-access.mdx`**, **`agents/helper.mdx`** — "X11/Wayland" → X11, plus the Wayland caution.
- **`scripts/docs-review/mapping.json`** — maps the four source files that define this matrix to these pages so the next docs sweep re-checks it.

Docs only, no code. `cd apps/docs && npx astro build` passes (170 pages); the `#supported-linux-distributions` anchor resolves in `dist/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SKrAnEU3jQQeC9oNMQ6FnJ
