### PR TITLE
D18 W02: GC sweep reclaims retired and orphaned backup prefixes

### DIFF
--- a/apps/api/src/__tests__/integration/backupGcReclamation.integration.test.ts
+++ b/apps/api/src/__tests__/integration/backupGcReclamation.integration.test.ts
@@ -367,3 +367,26 @@ runDb('scenario 8: a swept retirement row is pruned after 30 days past sweptAt',
   );
   expect(rows).toEqual([]);
 });
+
+runDb('scenario 8b: a retirement swept less than 30 days ago is NOT pruned', async () => {
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const root = await mkdtemp(join(tmpdir(), 'breeze-gc-'));
+
+  const retirementId = await withSystemDbAccessContext(async () => {
+    const seed = await seedOrgDeviceConfig(unique, root);
+    const [row] = await db.insert(backupSnapshotRetirements).values({
+      orgId: seed.orgId, configId: seed.configId, deviceId: seed.deviceId,
+      snapshotId: 'RECENTLYGONE', storageIdentity: seed.identity, backupType: 'file', reason: 'expired',
+      retiredAt: new Date(Date.now() - 15 * 24 * 60 * 60 * 1000),
+      sweptAt: new Date(Date.now() - 10 * 24 * 60 * 60 * 1000), // swept only 10 days ago
+    }).returning({ id: backupSnapshotRetirements.id });
+    return row!.id;
+  });
+
+  await sweepUnreferencedBackupObjects();
+
+  const rows = await withSystemDbAccessContext(() =>
+    db.select().from(backupSnapshotRetirements).where(eq(backupSnapshotRetirements.id, retirementId)),
+  );
+  expect(rows).toHaveLength(1);
+});

--- a/apps/api/src/__tests__/integration/backupGcReclamation.integration.test.ts
+++ b/apps/api/src/__tests__/integration/backupGcReclamation.integration.test.ts
@@ -1,0 +1,369 @@
+import './setup';
+
+import { mkdtemp, mkdir, writeFile, utimes, readdir, chmod } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../../db';
+import {
+  backupConfigs,
+  backupJobs,
+  backupSnapshots,
+  backupSnapshotRetirements,
+  devices,
+  organizations,
+  partners,
+  sites,
+} from '../../db/schema';
+import { sweepUnreferencedBackupObjects } from '../../jobs/backupRetention';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+async function writeAged(root: string, relPath: string, ageMs: number, contents = 'x'): Promise<void> {
+  const full = join(root, relPath);
+  await mkdir(join(full, '..'), { recursive: true });
+  await writeFile(full, contents);
+  const t = new Date(Date.now() - ageMs);
+  await utimes(full, t, t);
+}
+
+async function listAll(root: string, prefix = ''): Promise<string[]> {
+  let entries;
+  try {
+    entries = await readdir(join(root, prefix), { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const out: string[] = [];
+  for (const e of entries) {
+    const rel = prefix ? `${prefix}/${e.name}` : e.name;
+    if (e.isDirectory()) out.push(...(await listAll(root, rel)));
+    else out.push(rel);
+  }
+  return out;
+}
+
+async function seedOrgDeviceConfig(unique: string, rootPath: string, backupVersion = '0.112.0') {
+  const [partner] = await db.insert(partners).values({
+    name: `GC Partner ${unique}`, slug: `gc-partner-${unique}`, type: 'msp', plan: 'pro', status: 'active',
+  }).returning({ id: partners.id });
+  const [org] = await db.insert(organizations).values({
+    currencyCode: 'USD', partnerId: partner!.id, name: `GC Org ${unique}`, slug: `gc-org-${unique}`, type: 'customer', status: 'active',
+  }).returning({ id: organizations.id });
+  const [site] = await db.insert(sites).values({ orgId: org!.id, name: `GC Site ${unique}` }).returning({ id: sites.id });
+  const [device] = await db.insert(devices).values({
+    orgId: org!.id, siteId: site!.id, agentId: `gc-agent-${unique}`, hostname: `gc-host-${unique}`,
+    osType: 'linux', osVersion: '1', architecture: 'x86_64', agentVersion: '0.0.0-test',
+    backupVersion, status: 'online',
+  }).returning({ id: devices.id });
+  const [config] = await db.insert(backupConfigs).values({
+    orgId: org!.id, name: `GC Config ${unique}`, type: 'file', provider: 'local', providerConfig: { path: rootPath },
+  }).returning({ id: backupConfigs.id });
+  const identity = `local::${rootPath}`;
+  return { orgId: org!.id, deviceId: device!.id, configId: config!.id, identity };
+}
+
+async function insertSnapshotRow(params: {
+  orgId: string; deviceId: string; configId: string; snapshotId: string; identity: string;
+  expiresAt?: Date | null; backupType?: 'file' | 'system_image' | 'application' | 'database';
+}) {
+  const [job] = await db.insert(backupJobs).values({
+    orgId: params.orgId, configId: params.configId, deviceId: params.deviceId, status: 'completed', snapshotId: params.snapshotId,
+  }).returning({ id: backupJobs.id });
+  await db.insert(backupSnapshots).values({
+    orgId: params.orgId, jobId: job!.id, deviceId: params.deviceId, configId: params.configId,
+    snapshotId: params.snapshotId, storageIdentity: params.identity, expiresAt: params.expiresAt ?? null,
+    backupType: params.backupType ?? 'file',
+  });
+}
+
+runDb('scenario 1: retiring a base with an incremental child reclaims ONLY the base-exclusive object, keeping every shared backupPath the incremental references', async () => {
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const root = await mkdtemp(join(tmpdir(), 'breeze-gc-'));
+
+  const seed = await withSystemDbAccessContext(async () => {
+    const seed = await seedOrgDeviceConfig(unique, root);
+
+    // Base B has an object exclusively its own (only-in-b.dat) AND a
+    // separately-tracked shared object (shared.dat) that C's manifest ALSO
+    // references. Retiring B must reclaim only-in-b.dat, never shared.dat.
+    await writeAged(root, 'snapshots/B/manifest.json', 1000, JSON.stringify({ files: [
+      { backupPath: 'snapshots/B/files/only-in-b.dat' },
+      { backupPath: 'snapshots/B/files/shared.dat' },
+    ] }));
+    await writeAged(root, 'snapshots/B/files/only-in-b.dat', 1000);
+    await writeAged(root, 'snapshots/B/files/shared.dat', 1000);
+    await writeAged(root, 'snapshots/C/manifest.json', 1000, JSON.stringify({ files: [
+      { backupPath: 'snapshots/B/files/shared.dat' },
+      { backupPath: 'snapshots/C/files/c.dat' },
+    ] }));
+    await writeAged(root, 'snapshots/C/files/c.dat', 1000);
+
+    await insertSnapshotRow({ ...seed, snapshotId: 'C' });
+    await db.insert(backupSnapshotRetirements).values({
+      orgId: seed.orgId, configId: seed.configId, deviceId: seed.deviceId,
+      snapshotId: 'B', storageIdentity: seed.identity, backupType: 'file', reason: 'expired', retiredAt: new Date(),
+    });
+    return seed;
+  });
+
+  await sweepUnreferencedBackupObjects();
+
+  const afterFirstRun = await listAll(root);
+  expect(afterFirstRun).not.toContain('snapshots/B/files/only-in-b.dat');
+  expect(afterFirstRun).toContain('snapshots/B/files/shared.dat'); // still shared with C — must survive
+  expect(afterFirstRun).toContain('snapshots/C/manifest.json');
+  expect(afterFirstRun).toContain('snapshots/C/files/c.dat');
+  // B's manifest IS reclaimed once its only deletable non-manifest candidate
+  // (only-in-b.dat) is gone this run — shared.dat surviving (it's LIVE,
+  // referenced by C's manifest by exact backupPath) does not block manifest
+  // removal: nothing depends on B's own manifest.json to resolve that
+  // reference, so deleting B's now-orphaned restore metadata is safe (v3
+  // manifest-last rule: "no DELETABLE non-manifest key remains", not "no
+  // live object remains under this prefix").
+  expect(afterFirstRun).not.toContain('snapshots/B/manifest.json');
+
+  const [retirementRow] = await withSystemDbAccessContext(() =>
+    db.select().from(backupSnapshotRetirements).where(eq(backupSnapshotRetirements.storageIdentity, seed.identity)),
+  );
+  expect(retirementRow!.sweptAt).toBeNull();
+});
+
+runDb('scenario 2: a still-retained (non-expired) row is protected regardless of age — including one referenced by an in-progress base pin', async () => {
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const root = await mkdtemp(join(tmpdir(), 'breeze-gc-'));
+
+  await withSystemDbAccessContext(async () => {
+    const seed = await seedOrgDeviceConfig(unique, root);
+    // p.dat is a REFERENCED file in PINNED's own manifest (not a loose,
+    // unreferenced object) — this scenario proves a retained row's live
+    // content survives regardless of age, which is a different rule from the
+    // 48h loose-object grace (covered by the unit suite's own boundary
+    // tests). An unreferenced loose object under a retained prefix is
+    // legitimately subject to that separate 48h rule, pin or no pin.
+    await writeAged(
+      root,
+      'snapshots/PINNED/manifest.json',
+      30 * 24 * 60 * 60 * 1000,
+      JSON.stringify({ files: [{ backupPath: 'snapshots/PINNED/files/p.dat' }] }),
+    );
+    await writeAged(root, 'snapshots/PINNED/files/p.dat', 30 * 24 * 60 * 60 * 1000);
+    await insertSnapshotRow({ ...seed, snapshotId: 'PINNED' });
+
+    await db.insert(backupJobs).values({
+      orgId: seed.orgId, configId: seed.configId, deviceId: seed.deviceId, status: 'running',
+      baseSnapshotId: 'PINNED', publishLeaseExpiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    });
+  });
+
+  await sweepUnreferencedBackupObjects();
+
+  const remaining = await listAll(root);
+  expect(remaining.sort()).toEqual(['snapshots/PINNED/files/p.dat', 'snapshots/PINNED/manifest.json'].sort());
+});
+
+runDb('scenario 3: an orphan manifest past ORPHAN_WINDOW with no row and no retirement is reclaimed', async () => {
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const root = await mkdtemp(join(tmpdir(), 'breeze-gc-'));
+  const TEN_DAYS_MS = 10 * 24 * 60 * 60 * 1000;
+
+  await withSystemDbAccessContext(async () => {
+    await seedOrgDeviceConfig(unique, root);
+    await writeAged(root, 'snapshots/ABANDONED/manifest.json', TEN_DAYS_MS, JSON.stringify({ files: [] }));
+    await writeAged(root, 'snapshots/ABANDONED/files/a.dat', TEN_DAYS_MS);
+  });
+
+  await sweepUnreferencedBackupObjects();
+  expect(await listAll(root)).toEqual([]);
+});
+
+runDb('scenario 3b: ORPHAN_WINDOW\'s lease-derived arm protects an orphan the 9-day default alone would already have swept', async () => {
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const root = await mkdtemp(join(tmpdir(), 'breeze-gc-'));
+  const NINE_DAYS_PLUS_MS = 9 * 24 * 60 * 60 * 1000 + 60 * 60 * 1000;
+
+  await withSystemDbAccessContext(async () => {
+    await seedOrgDeviceConfig(unique, root);
+    await writeAged(root, 'snapshots/LEASEWINDOW/manifest.json', NINE_DAYS_PLUS_MS, JSON.stringify({ files: [] }));
+  });
+
+  const prevLease = process.env.BACKUP_BASE_LEASE_MS;
+  process.env.BACKUP_BASE_LEASE_MS = String(9 * 24 * 60 * 60 * 1000);
+  try {
+    await sweepUnreferencedBackupObjects();
+    expect(await listAll(root)).toContain('snapshots/LEASEWINDOW/manifest.json');
+  } finally {
+    if (prevLease === undefined) delete process.env.BACKUP_BASE_LEASE_MS; else process.env.BACKUP_BASE_LEASE_MS = prevLease;
+  }
+});
+
+runDb('scenario 4: a legacy helper on the identity defers to EXACTLY today\'s algorithm — the retired prefix is fully protected, not just its manifest', async () => {
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const root = await mkdtemp(join(tmpdir(), 'breeze-gc-'));
+
+  await withSystemDbAccessContext(async () => {
+    const seed = await seedOrgDeviceConfig(unique, root, '0.109.0'); // pre-server-base helper
+    await writeAged(root, 'snapshots/RETIREDLEGACY/manifest.json', 1000, JSON.stringify({ files: [] }));
+    await writeAged(root, 'snapshots/RETIREDLEGACY/files/r.dat', 1000);
+    await db.insert(backupSnapshotRetirements).values({
+      orgId: seed.orgId, configId: seed.configId, deviceId: seed.deviceId,
+      snapshotId: 'RETIREDLEGACY', storageIdentity: seed.identity, backupType: 'file', reason: 'expired', retiredAt: new Date(),
+    });
+    await db.insert(backupJobs).values({ orgId: seed.orgId, configId: seed.configId, deviceId: seed.deviceId, status: 'completed' });
+  });
+
+  await sweepUnreferencedBackupObjects();
+
+  const remaining = await listAll(root);
+  expect(remaining.sort()).toEqual(['snapshots/RETIREDLEGACY/files/r.dat', 'snapshots/RETIREDLEGACY/manifest.json'].sort());
+});
+
+runDb('scenario 5: an undeletable object blocks only that prefix\'s manifest, not other prefixes', async () => {
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const root = await mkdtemp(join(tmpdir(), 'breeze-gc-'));
+  const blockedDir = join(root, 'snapshots/RETIREDBLOCKED/files');
+
+  await withSystemDbAccessContext(async () => {
+    const seed = await seedOrgDeviceConfig(unique, root);
+    await writeAged(root, 'snapshots/RETIREDBLOCKED/manifest.json', 1000, JSON.stringify({ files: [] }));
+    await writeAged(root, 'snapshots/RETIREDBLOCKED/files/locked.dat', 1000);
+    await db.insert(backupSnapshotRetirements).values({
+      orgId: seed.orgId, configId: seed.configId, deviceId: seed.deviceId,
+      snapshotId: 'RETIREDBLOCKED', storageIdentity: seed.identity, backupType: 'file', reason: 'expired', retiredAt: new Date(),
+    });
+  });
+
+  // Local-provider delete is `rm(path, { force: true })`, which swallows
+  // ENOENT — induce a REAL, permanent delete failure via a read-only parent
+  // directory so unlink() inside it gets EACCES.
+  await chmod(blockedDir, 0o500);
+  try {
+    await sweepUnreferencedBackupObjects();
+  } finally {
+    await chmod(blockedDir, 0o700); // restore before temp-dir cleanup
+  }
+
+  expect(await listAll(root)).toContain('snapshots/RETIREDBLOCKED/manifest.json');
+});
+
+runDb('scenario 6a: a NULL-identity row whose manifest IS found resolves in this run and its identity reclaims normally (no longer deferred)', async () => {
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const root = await mkdtemp(join(tmpdir(), 'breeze-gc-'));
+
+  const seed = await withSystemDbAccessContext(async () => {
+    const seed = await seedOrgDeviceConfig(unique, root);
+
+    await writeAged(root, 'snapshots/HEALME/manifest.json', 1000, JSON.stringify({ files: [] }));
+    const [job] = await db.insert(backupJobs).values({
+      orgId: seed.orgId, configId: seed.configId, deviceId: seed.deviceId, status: 'completed', snapshotId: 'HEALME',
+    }).returning({ id: backupJobs.id });
+    await db.insert(backupSnapshots).values({
+      orgId: seed.orgId, jobId: job!.id, deviceId: seed.deviceId, configId: seed.configId,
+      snapshotId: 'HEALME', storageIdentity: null, // deliberately unresolved
+    });
+
+    await writeAged(root, 'snapshots/RETIRED6A/manifest.json', 1000, JSON.stringify({ files: [] }));
+    await writeAged(root, 'snapshots/RETIRED6A/files/r.dat', 1000);
+    await db.insert(backupSnapshotRetirements).values({
+      orgId: seed.orgId, configId: seed.configId, deviceId: seed.deviceId,
+      snapshotId: 'RETIRED6A', storageIdentity: seed.identity, backupType: 'file', reason: 'expired', retiredAt: new Date(),
+    });
+    return seed;
+  });
+
+  await sweepUnreferencedBackupObjects();
+
+  const remaining = await listAll(root);
+  expect(remaining).not.toContain('snapshots/RETIRED6A/files/r.dat');
+  expect(remaining).toContain('snapshots/HEALME/manifest.json');
+
+  const [healedRow] = await withSystemDbAccessContext(() =>
+    db.select().from(backupSnapshots).where(eq(backupSnapshots.snapshotId, 'HEALME')),
+  );
+  expect(healedRow!.storageIdentity).toBe(seed.identity);
+});
+
+runDb('scenario 6b: a NULL-identity row whose manifest is NOT found defers the WHOLE identity to today\'s algorithm — nothing unrooted is deleted', async () => {
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const root = await mkdtemp(join(tmpdir(), 'breeze-gc-'));
+
+  await withSystemDbAccessContext(async () => {
+    const seed = await seedOrgDeviceConfig(unique, root);
+
+    // NEVERWRITTEN's row exists (mapped to this identity's config) but its
+    // object was never actually written to THIS bucket — never appears in
+    // the listing, so it can never resolve.
+    const [job] = await db.insert(backupJobs).values({
+      orgId: seed.orgId, configId: seed.configId, deviceId: seed.deviceId, status: 'completed', snapshotId: 'NEVERWRITTEN',
+    }).returning({ id: backupJobs.id });
+    await db.insert(backupSnapshots).values({
+      orgId: seed.orgId, jobId: job!.id, deviceId: seed.deviceId, configId: seed.configId,
+      snapshotId: 'NEVERWRITTEN', storageIdentity: null,
+    });
+
+    await writeAged(root, 'snapshots/RETIRED6B/manifest.json', 1000, JSON.stringify({ files: [] }));
+    await writeAged(root, 'snapshots/RETIRED6B/files/r.dat', 1000);
+    await db.insert(backupSnapshotRetirements).values({
+      orgId: seed.orgId, configId: seed.configId, deviceId: seed.deviceId,
+      snapshotId: 'RETIRED6B', storageIdentity: seed.identity, backupType: 'file', reason: 'expired', retiredAt: new Date(),
+    });
+  });
+
+  await sweepUnreferencedBackupObjects();
+
+  // Deferred (unresolved NULL row) -> today's algorithm -> RETIRED6B's
+  // manifest is marked live (it's listed) and its loose object is only 1s
+  // old, well inside the 48h grace -> nothing deleted at all.
+  const remaining = await listAll(root);
+  expect(remaining.sort()).toEqual(['snapshots/RETIRED6B/files/r.dat', 'snapshots/RETIRED6B/manifest.json'].sort());
+});
+
+runDb('scenario 7: system_image, application (hyperv), and database (mssql) rows are roots exactly like file rows (no backupType filter)', async () => {
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const root = await mkdtemp(join(tmpdir(), 'breeze-gc-'));
+
+  await withSystemDbAccessContext(async () => {
+    const seed = await seedOrgDeviceConfig(unique, root);
+    for (const [snapshotId, backupType] of [
+      ['IMG1', 'system_image'], ['HV1', 'application'], ['SQL1', 'database'],
+    ] as const) {
+      await writeAged(root, `snapshots/${snapshotId}/manifest.json`, 20 * 24 * 60 * 60 * 1000, JSON.stringify({ files: [] }));
+      await insertSnapshotRow({ ...seed, snapshotId, backupType });
+    }
+  });
+
+  await sweepUnreferencedBackupObjects();
+
+  // All three survive despite being 20 days old — they're rooted DB rows via
+  // storage_identity (Task 3's fix), never filtered out by backupType, and
+  // their manifest fetch must succeed (every mode publishes the same
+  // snapshots/<id>/manifest.json layout).
+  const remaining = await listAll(root);
+  expect(remaining.sort()).toEqual([
+    'snapshots/IMG1/manifest.json', 'snapshots/HV1/manifest.json', 'snapshots/SQL1/manifest.json',
+  ].sort());
+});
+
+runDb('scenario 8: a swept retirement row is pruned after 30 days past sweptAt', async () => {
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const root = await mkdtemp(join(tmpdir(), 'breeze-gc-'));
+
+  const retirementId = await withSystemDbAccessContext(async () => {
+    const seed = await seedOrgDeviceConfig(unique, root);
+    const [row] = await db.insert(backupSnapshotRetirements).values({
+      orgId: seed.orgId, configId: seed.configId, deviceId: seed.deviceId,
+      snapshotId: 'LONGGONE', storageIdentity: seed.identity, backupType: 'file', reason: 'expired',
+      retiredAt: new Date(Date.now() - 40 * 24 * 60 * 60 * 1000),
+      sweptAt: new Date(Date.now() - 31 * 24 * 60 * 60 * 1000), // swept 31 days ago
+    }).returning({ id: backupSnapshotRetirements.id });
+    return row!.id;
+  });
+
+  await sweepUnreferencedBackupObjects();
+
+  const rows = await withSystemDbAccessContext(() =>
+    db.select().from(backupSnapshotRetirements).where(eq(backupSnapshotRetirements.id, retirementId)),
+  );
+  expect(rows).toEqual([]);
+});

--- a/apps/api/src/jobs/backupRetention.test.ts
+++ b/apps/api/src/jobs/backupRetention.test.ts
@@ -543,13 +543,17 @@ describe('sweepUnreferencedBackupObjects', () => {
   });
 
   it('marks snapshots/<id>/layout.json live without fetching it, so the sweep never deletes a retained layout manifest', async () => {
-    selectQueue.push([]); // unattributedRows
-    selectQueue.push([destination]); // destinations
-    selectQueue.push([{ snapshotId: 'A' }]); // retained
+    pushRunLevel([destination]);
+    pushIdentity({ retained: [{ snapshotId: 'A' }] });
 
     fetchBackupObjectTextMock.mockResolvedValueOnce(manifestJson([]));
 
-    const old = new Date(Date.now() - 10 * DAY_MS);
+    // ORPHAN here has NO manifest.json at all (only a layout.json) — a
+    // manifest-less prefix, past the (default 9-day) manifest-less-prefix
+    // window, so it is reclaimed via that pre-existing rule regardless of
+    // this wave's retired/orphan-window logic (which only applies to
+    // manifest-BEARING prefixes).
+    const old = JUST_PAST_MANIFESTLESS_THRESHOLD();
     listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
       { key: 'snapshots/A/manifest.json', lastModified: old },
       { key: 'snapshots/A/layout.json', lastModified: old },
@@ -573,7 +577,90 @@ describe('sweepUnreferencedBackupObjects', () => {
     const deletedArg = deleteBackupObjectKeysMock.mock.calls[0]![0] as { keys: string[] };
     expect(deletedArg.keys).toEqual(['snapshots/ORPHAN/layout.json']);
     expect(deletedArg.keys).not.toContain('snapshots/A/layout.json');
-    expect(result).toEqual({ deleted: 1, skippedIdentities: 0, blockedIdentities: 0 });
+    expect(result.deleted).toBe(1);
+    expect(result.skippedIdentities).toBe(0);
+    expect(result.blockedIdentities).toBe(0);
+  });
+
+  // D18 W02 addition (rooted-and-orphan protection, per #5523 follow-up):
+  // layout.json must get the SAME unconditional-live treatment as
+  // manifest.json in every root-set case this wave adds, not just the
+  // pre-existing "retained row" case above — a rooted NULL-identity
+  // self-heal root, a young (unaged) orphan manifest, and every listed
+  // manifest under the deferred-identity algorithm.
+  it('protects layout.json for a young orphan manifest (no row) and marks it live under the deferred (legacy-helper) algorithm too', async () => {
+    // Part 1: young orphan — no DB row, no retirement, well within the
+    // orphan window — its layout.json must survive alongside its manifest.
+    pushRunLevel([destination]);
+    pushIdentity();
+
+    fetchBackupObjectTextMock.mockResolvedValueOnce(manifestJson([]));
+    const recent = new Date(Date.now() - 1 * DAY_MS);
+    listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
+      { key: 'snapshots/YOUNGORPHAN/manifest.json', lastModified: recent },
+      { key: 'snapshots/YOUNGORPHAN/layout.json', lastModified: recent },
+    ]);
+
+    const result1 = await sweepUnreferencedBackupObjects();
+    expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled();
+    expect(result1.deleted).toBe(0);
+
+    // Part 2: deferred (legacy helper) — every listed manifest is a root
+    // under today's algorithm, and layout.json must stay protected there
+    // too, even though the snapshot is old enough it would otherwise be an
+    // orphan-window candidate.
+    pushRunLevel([destination]);
+    pushIdentity({ capability: [{ deviceId: 'device-legacy', backupVersion: '0.109.0' }] });
+
+    fetchBackupObjectTextMock.mockResolvedValueOnce(manifestJson([]));
+    const old = new Date(Date.now() - 30 * DAY_MS);
+    listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
+      { key: 'snapshots/DEFERREDOLD/manifest.json', lastModified: old },
+      { key: 'snapshots/DEFERREDOLD/layout.json', lastModified: old },
+    ]);
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const result2 = await sweepUnreferencedBackupObjects();
+      expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled();
+      expect(result2.deleted).toBe(0);
+      expect(result2.deferredIdentities).toBe(1);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  // A retired (or old-orphan) prefix's layout.json is NOT special-cased —
+  // it sweeps in the non-manifest phase exactly like any other non-manifest
+  // key, subject to the same cap/skip-set rules, with manifest.json only
+  // removed last/once nothing else remains.
+  it('sweeps layout.json for a RETIRED snapshot in the non-manifest phase, alongside its other objects', async () => {
+    pushRunLevel([destination]);
+    pushIdentity({ retirements: [{ id: 'retirement-layout', snapshotId: 'RETIREDLAYOUT' }] });
+
+    const t = new Date(Date.now() - 1000);
+    listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
+      { key: 'snapshots/RETIREDLAYOUT/manifest.json', lastModified: t },
+      { key: 'snapshots/RETIREDLAYOUT/layout.json', lastModified: t },
+      { key: 'snapshots/RETIREDLAYOUT/files/x.dat', lastModified: t },
+    ]);
+    deleteBackupObjectKeysMock.mockResolvedValueOnce({
+      deletedKeys: ['snapshots/RETIREDLAYOUT/layout.json', 'snapshots/RETIREDLAYOUT/files/x.dat'],
+      failedKeys: [],
+    });
+    deleteBackupObjectKeysMock.mockResolvedValueOnce({
+      deletedKeys: ['snapshots/RETIREDLAYOUT/manifest.json'],
+      failedKeys: [],
+    });
+
+    const result = await sweepUnreferencedBackupObjects();
+
+    expect(result.deleted).toBe(3);
+    const firstCallKeys = (deleteBackupObjectKeysMock.mock.calls[0]![0] as { keys: string[] }).keys;
+    expect(firstCallKeys).toEqual(expect.arrayContaining(['snapshots/RETIREDLAYOUT/layout.json', 'snapshots/RETIREDLAYOUT/files/x.dat']));
+    // Manifest deleted only in the SECOND (last) call, once nothing else remained.
+    const secondCallKeys = (deleteBackupObjectKeysMock.mock.calls[1]![0] as { keys: string[] }).keys;
+    expect(secondCallKeys).toEqual(['snapshots/RETIREDLAYOUT/manifest.json']);
   });
 
   it('keeps a loose unreferenced object under a manifest-bearing prefix that is still inside the 48h grace window', async () => {

--- a/apps/api/src/jobs/backupRetention.test.ts
+++ b/apps/api/src/jobs/backupRetention.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, symlink } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { backupSnapshots } from '../db/schema';
 
 // ── Chainable Drizzle mock ────────────────────────────────────────────────
@@ -30,6 +33,11 @@ function chainable(rows: unknown[]) {
 
 const selectQueue: unknown[][] = [];
 const insertedRows: unknown[] = [];
+// Captures every db.update(<table>).set(<payload>) call so a test can assert
+// WHICH row(s) a write targeted (review round 1, finding 5: proving the
+// cross-identity snapshotId self-heal collision guard needs to see the
+// actual .set() payload, which the generic `chainable` no-op can't record).
+const updateCalls: { table: unknown; payload: Record<string, unknown> }[] = [];
 
 const mockDb = {
   select: vi.fn(() => chainable(selectQueue.shift() ?? [])),
@@ -39,7 +47,12 @@ const mockDb = {
   // selectDistinct call site in backupRetention.ts.
   selectDistinct: vi.fn(() => chainable(selectQueue.shift() ?? [])),
   delete: vi.fn(() => chainable([])),
-  update: vi.fn(() => chainable([])),
+  update: vi.fn((table: unknown) => ({
+    set: (payload: Record<string, unknown>) => {
+      updateCalls.push({ table, payload });
+      return chainable([]);
+    },
+  })),
   insert: vi.fn((_table: unknown) => ({
     values: (v: unknown) => {
       insertedRows.push(v);
@@ -451,6 +464,7 @@ describe('sweepUnreferencedBackupObjects', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     selectQueue.length = 0;
+    updateCalls.length = 0;
     redisAvailableForTest = true;
     redisSmembersMock.mockResolvedValue([]);
     delete process.env.BACKUP_GC_MAX_DELETES_PER_RUN;
@@ -1186,7 +1200,7 @@ describe('sweepUnreferencedBackupObjects', () => {
         const result = await sweepUnreferencedBackupObjects();
         expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled();
         expect(result.retiredSwept).toBe(0);
-        expect(warn.mock.calls.some(([msg]) => String(msg).includes('identity deferred: 1 unresolved rows'))).toBe(true);
+        expect(warn.mock.calls.some(([msg]) => String(msg).includes('deferred') && String(msg).includes('1 unresolved') && String(msg).includes('NEVERWRITTEN'))).toBe(true);
       } finally {
         warn.mockRestore();
       }
@@ -1230,7 +1244,7 @@ describe('sweepUnreferencedBackupObjects', () => {
         expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled();
         expect(result.deferredIdentities).toBe(1);
         expect(result.retiredSwept).toBe(0);
-        expect(warn.mock.calls.some(([msg]) => String(msg).includes('reclamation deferred: legacy helper device-legacy 0.109.0'))).toBe(true);
+        expect(warn.mock.calls.some(([msg]) => String(msg).includes('reclamation deferred') && String(msg).includes('legacy helper device-legacy 0.109.0'))).toBe(true);
       } finally {
         warn.mockRestore();
       }
@@ -1424,6 +1438,100 @@ describe('sweepUnreferencedBackupObjects', () => {
     });
   });
 
+  // Review round 1, finding 4 (pr-test-analyzer): every existing test proving
+  // a retired group's manifest survives does so via a hard delete FAILURE.
+  // These prove the OTHER two ways a non-manifest key can remain
+  // undeletable this run — capped out, or skip-set-excluded — each of which
+  // must ALSO block the manifest (the v3 rule is "no DELETABLE non-manifest
+  // key remains", not "no FAILED non-manifest key remains").
+  describe('manifest-last rule also holds when a non-manifest key is capped or skip-set-excluded, not just failed (review round 1, finding 4)', () => {
+    it('does not delete the manifest when the per-run cap is exhausted before its non-manifest sibling is attempted', async () => {
+      pushRunLevel([destination]);
+      pushIdentity({ retirements: [{ id: 'retirement-cap', snapshotId: 'CAPPED' }] });
+
+      process.env.BACKUP_GC_MAX_DELETES_PER_RUN = '1';
+      try {
+        const t = new Date(Date.now() - 1000);
+        listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
+          { key: 'snapshots/CAPPED/manifest.json', lastModified: t },
+          { key: 'snapshots/CAPPED/files/a.dat', lastModified: t },
+          { key: 'snapshots/CAPPED/files/b.dat', lastModified: t },
+        ]);
+        // Cap is 1: only ONE non-manifest delete attempt happens this run —
+        // a.dat succeeds, b.dat is never even attempted (capped out).
+        deleteBackupObjectKeysMock.mockResolvedValueOnce({ deletedKeys: ['snapshots/CAPPED/files/a.dat'], failedKeys: [] });
+
+        await sweepUnreferencedBackupObjects();
+
+        // Only the one non-manifest delete call happened — the cap was
+        // exhausted, so the manifest was never even considered for deletion.
+        expect(deleteBackupObjectKeysMock).toHaveBeenCalledTimes(1);
+        expect(deleteBackupObjectKeysMock).not.toHaveBeenCalledWith(
+          expect.objectContaining({ keys: expect.arrayContaining(['snapshots/CAPPED/manifest.json']) }),
+        );
+      } finally {
+        delete process.env.BACKUP_GC_MAX_DELETES_PER_RUN;
+      }
+    });
+
+    it('does not delete the manifest when its only non-manifest sibling is skip-set-excluded, not failed', async () => {
+      redisSmembersMock.mockResolvedValueOnce(['snapshots/SKIPPED/files/locked-forever.dat']);
+      pushRunLevel([destination]);
+      pushIdentity({ retirements: [{ id: 'retirement-skip', snapshotId: 'SKIPPED' }] });
+
+      const t = new Date(Date.now() - 1000);
+      listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
+        { key: 'snapshots/SKIPPED/manifest.json', lastModified: t },
+        { key: 'snapshots/SKIPPED/files/locked-forever.dat', lastModified: t }, // in the skip set — never attempted, not "failed"
+      ]);
+
+      await sweepUnreferencedBackupObjects();
+
+      // No delete call at all: the only non-manifest candidate is skip-set
+      // excluded before any attempt, and that alone must still block the
+      // manifest.
+      expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled();
+    });
+  });
+
+  // Review round 1, finding 5 (silent-failure-hunter / pr-test-analyzer):
+  // backup_snapshots.snapshot_id has no uniqueness constraint, so two
+  // DIFFERENT identities can legitimately have a NULL-identity row sharing
+  // the exact same snapshotId string. The self-heal write-back is scoped by
+  // PRIMARY ROW ID (never snapshotId alone) specifically to prevent one
+  // identity's resolution from mis-healing a different identity's
+  // same-named, still-unresolved row.
+  describe('cross-identity snapshotId collision guard on self-heal (review round 1, finding 5)', () => {
+    it('heals only the identity whose OWN listing resolves the row, even though a different identity has an unresolved row with the identical snapshotId', async () => {
+      const destinationB = { id: 'cfg-b', provider: 's3', providerConfig: { bucket: 'other-bucket', region: 'us-east-1' } };
+
+      pushRunLevel([destination, destinationB]);
+      pushIdentity({ nullRows: [{ id: 'row-A', snapshotId: 'DUPLICATE' }] }); // identity A (destination)
+      pushIdentity({ nullRows: [{ id: 'row-B', snapshotId: 'DUPLICATE' }] }); // identity B (destinationB) — same snapshotId, different row
+
+      fetchBackupObjectTextMock.mockResolvedValueOnce(manifestJson([])); // A's DUPLICATE manifest fetch (it resolves)
+      const t = new Date(Date.now() - 1000);
+      listBackupObjectsUnderPrefixMock
+        .mockResolvedValueOnce([{ key: 'snapshots/DUPLICATE/manifest.json', lastModified: t }]) // identity A's listing — resolves
+        .mockResolvedValueOnce([]); // identity B's listing — DUPLICATE never appears here, stays unresolved
+
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        await sweepUnreferencedBackupObjects();
+      } finally {
+        warn.mockRestore();
+      }
+
+      // Exactly ONE self-heal write happened this run (identity A's), scoped
+      // to identity A's key — if the guard mismatched by bare snapshotId
+      // instead of row id, identity B's unresolved row could have been
+      // healed too (or healed with the wrong identity's key).
+      const selfHealCalls = updateCalls.filter((c) => 'storageIdentity' in c.payload);
+      expect(selfHealCalls).toHaveLength(1);
+      expect(selfHealCalls[0]!.payload.storageIdentity).toBe(identityKeyFor(destination));
+    });
+  });
+
   describe('unreachable storage identities (no config points at them any more)', () => {
     it('logs and counts a storage_identity with rows but no matching current config, without touching it', async () => {
       selectQueue.push([]); // unattributedRows
@@ -1444,6 +1552,149 @@ describe('sweepUnreferencedBackupObjects', () => {
       } finally {
         warn.mockRestore();
       }
+    });
+  });
+
+  // Review round 1 (CRITICAL): a config edit can change the NORMALIZED
+  // identity string while still pointing at the SAME physical bucket/
+  // directory. Rows recorded under the OLD string are unreachable (no
+  // current config produces that key) but their objects physically sit in
+  // the bucket the NEW identity is about to sweep — invisible to the NEW
+  // identity's root query, and (once old enough) indistinguishable from
+  // genuine orphan garbage. These prove the identity is deferred instead.
+  describe('review round 1: coarse alias detection defers a physical-location alias instead of reclaiming it', () => {
+    it('defers an S3 identity that coarsely aliases a stale/unreachable identity (a port-only difference normalizeStorageIdentity does not collapse)', async () => {
+      const aliasedDestination = {
+        id: 'cfg-alias',
+        provider: 's3',
+        providerConfig: { bucket: 'MyBucket', endpoint: 'nyc3.digitaloceanspaces.com' },
+      };
+      const newKey = normalizeStorageIdentity(aliasedDestination.provider, aliasedDestination.providerConfig);
+      // A stale identity string (no current config produces it) that differs
+      // from newKey only by an explicit port — same host+bucket physically.
+      const staleKey = 's3::nyc3.digitaloceanspaces.com:9000::MyBucket';
+
+      selectQueue.push([]); // unattributedRows
+      selectQueue.push([aliasedDestination]); // destinations
+      selectQueue.push([
+        { storageIdentity: staleKey, count: 3 },
+        { storageIdentity: newKey, count: 1 },
+      ]); // identityUsage
+      pushIdentity(); // retained/nullRows/retirements/capability all empty
+
+      // A lone, manifest-only "snapshot" well past ORPHAN_WINDOW — under the
+      // NORMAL (non-deferred) algorithm this would be reclaimed as abandoned
+      // orphan garbage (no row, no retirement, too old to be a young orphan).
+      fetchBackupObjectTextMock.mockResolvedValueOnce(manifestJson([]));
+      const old = new Date(Date.now() - 30 * DAY_MS);
+      listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
+        { key: 'snapshots/OLDORPHAN/manifest.json', lastModified: old },
+      ]);
+
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        const result = await sweepUnreferencedBackupObjects();
+        // Deferred -> today's algorithm marks EVERY listed manifest live ->
+        // the lone manifest object is in the live set -> nothing deleted,
+        // where the non-deferred algorithm would have reclaimed it.
+        expect(fetchBackupObjectTextMock).toHaveBeenCalledWith(expect.objectContaining({ key: 'snapshots/OLDORPHAN/manifest.json' }));
+        expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled();
+        expect(result.deferredIdentities).toBe(1);
+        expect(
+          warn.mock.calls.some(([msg]) =>
+            String(msg).includes(newKey) && String(msg).includes('aliases a stale/unreachable identity'),
+          ),
+        ).toBe(true);
+      } finally {
+        warn.mockRestore();
+      }
+    });
+
+    it('defers a local identity whose config path is a symlink alias of a stale/unreachable identity\'s real directory', async () => {
+      const realDir = await mkdtemp(join(tmpdir(), 'breeze-gc-real-'));
+      const linkPath = join(tmpdir(), `breeze-gc-link-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+      await symlink(realDir, linkPath, 'dir');
+
+      const destinationViaSymlink = { id: 'cfg-link', provider: 'local', providerConfig: { path: linkPath } };
+      const newKey = normalizeStorageIdentity('local', destinationViaSymlink.providerConfig); // local::<linkPath> — path.resolve is lexical, does NOT follow the symlink
+      const staleKey = `local::${realDir}`; // a stale identity recorded directly against the REAL directory
+
+      selectQueue.push([]); // unattributedRows
+      selectQueue.push([destinationViaSymlink]); // destinations
+      selectQueue.push([
+        { storageIdentity: staleKey, count: 2 },
+        { storageIdentity: newKey, count: 1 },
+      ]); // identityUsage
+      pushIdentity();
+
+      fetchBackupObjectTextMock.mockResolvedValueOnce(manifestJson([]));
+      const old = new Date(Date.now() - 30 * DAY_MS);
+      listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
+        { key: 'snapshots/OLDORPHAN/manifest.json', lastModified: old },
+      ]);
+
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        const result = await sweepUnreferencedBackupObjects();
+        expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled();
+        expect(result.deferredIdentities).toBe(1);
+        expect(
+          warn.mock.calls.some(([msg]) =>
+            String(msg).includes(newKey) && String(msg).includes('aliases a stale/unreachable identity'),
+          ),
+        ).toBe(true);
+      } finally {
+        warn.mockRestore();
+      }
+    });
+
+    it('does NOT defer an identity whose coarse signature does not match any unreachable identity', async () => {
+      // Sanity control: the previous two tests' mechanism must not defer
+      // EVERY identity — only ones that actually coarse-match something
+      // unreachable. destination/identityKeyFor here shares nothing with the
+      // 'local::/var/orphaned-bucket-nobody-points-at' unreachable key used
+      // elsewhere in this file.
+      selectQueue.push([]);
+      selectQueue.push([destination]);
+      selectQueue.push([
+        { storageIdentity: identityKeyFor(destination), count: 1 },
+        { storageIdentity: 'local::/var/totally-unrelated-stale-path', count: 4 },
+      ]);
+      pushIdentity();
+      listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([]);
+
+      const result = await sweepUnreferencedBackupObjects();
+      expect(result.deferredIdentities).toBe(0);
+      expect(result.unreachableIdentities).toBe(1);
+    });
+  });
+
+  // Review round 1: detectSuspiciousStorageIdentityCollisions previously
+  // exempted 'local' entirely from its coarse-collision check, so two
+  // CURRENT local configs whose paths are lexically different but resolve
+  // (via a symlink) to the SAME physical directory were never caught —
+  // each would see only its own retained snapshots and could delete the
+  // other's live objects.
+  describe('review round 1: local provider is now covered by the current-vs-current coarse collision check', () => {
+    it('fail-closed-skips two CURRENT local configs whose paths are a symlink alias of the same physical directory', async () => {
+      const realDir = await mkdtemp(join(tmpdir(), 'breeze-gc-real2-'));
+      const linkPath = join(tmpdir(), `breeze-gc-link2-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+      await symlink(realDir, linkPath, 'dir');
+
+      const configReal = { id: 'cfg-real', provider: 'local', providerConfig: { path: realDir } };
+      const configLink = { id: 'cfg-link', provider: 'local', providerConfig: { path: linkPath } };
+
+      expect(normalizeStorageIdentity('local', configReal.providerConfig))
+        .not.toBe(normalizeStorageIdentity('local', configLink.providerConfig));
+
+      pushRunLevel([configReal, configLink]); // 2 identities, symlink-aliased
+
+      const result = await sweepUnreferencedBackupObjects();
+
+      expect(fetchBackupObjectTextMock).not.toHaveBeenCalled();
+      expect(listBackupObjectsUnderPrefixMock).not.toHaveBeenCalled();
+      expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled();
+      expect(result.skippedIdentities).toBe(2);
     });
   });
 });

--- a/apps/api/src/jobs/backupRetention.test.ts
+++ b/apps/api/src/jobs/backupRetention.test.ts
@@ -1166,7 +1166,7 @@ describe('sweepUnreferencedBackupObjects', () => {
     });
   });
 
-  describe('NULL-identity rows are ALWAYS roots of I, resolved or not (§3.6 v3)', () => {
+  describe('a NULL-identity row becomes a root of I the moment it resolves; unresolved contributes only to deferral (§3.6 v3)', () => {
     it('fetches (and requires) the manifest of an UNRESOLVED NULL row too, and defers the whole identity if it is not found in the listing', async () => {
       pushRunLevel([destination]);
       pushIdentity({

--- a/apps/api/src/jobs/backupRetention.test.ts
+++ b/apps/api/src/jobs/backupRetention.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { backupSnapshots } from '../db/schema';
 
 // ── Chainable Drizzle mock ────────────────────────────────────────────────
 //
@@ -16,8 +17,11 @@ function chainable(rows: unknown[]) {
     leftJoin: () => obj,
     innerJoin: () => obj,
     orderBy: () => obj,
+    groupBy: () => obj,
     limit: () => obj,
     for: () => obj,
+    set: () => obj, // db.update(...).set({...}) — returns itself so .where()/.returning() still chain
+    returning: () => obj, // db.delete(...).returning() / db.update(...).returning()
     then: (resolve: (v: unknown[]) => unknown, reject?: (e: unknown) => unknown) =>
       Promise.resolve(rows).then(resolve, reject),
   };
@@ -29,6 +33,11 @@ const insertedRows: unknown[] = [];
 
 const mockDb = {
   select: vi.fn(() => chainable(selectQueue.shift() ?? [])),
+  // selectDistinct shares the SAME selectQueue as select — from the test's
+  // perspective they're both just "the next db read in source order".
+  // identityHasLegacyHelper (D18 W02 capability gate) is the only
+  // selectDistinct call site in backupRetention.ts.
+  selectDistinct: vi.fn(() => chainable(selectQueue.shift() ?? [])),
   delete: vi.fn(() => chainable([])),
   update: vi.fn(() => chainable([])),
   insert: vi.fn((_table: unknown) => ({
@@ -39,13 +48,26 @@ const mockDb = {
   })),
 };
 
+const assertOutsideHeldDbContextMock = vi.fn();
 vi.mock('../db', () => ({
   db: mockDb,
   withSystemDbAccessContext: (fn: () => unknown) => fn(),
-  // D18 §3.7 review fix: cleanupExpiredSnapshots asserts no ambient context
-  // is held on entry — a no-op here since this suite's mock has no context
-  // tracking (every call is "outside" by construction).
-  assertOutsideHeldDbContext: () => {},
+  // D18 §3.7 review fix: cleanupExpiredSnapshots/sweepStorageIdentity assert
+  // no ambient context is held on entry — a pass-through here (this suite's
+  // mock has no real context tracking), but still a vi.fn() so the §3.7
+  // tripwire test can assert it fires with the right operation label.
+  assertOutsideHeldDbContext: assertOutsideHeldDbContextMock,
+}));
+
+// Redis-backed failed-key skip set (D18 W02, Task 6) — shared non-blocking
+// client mock, mirroring alertCooldown.ts's isRedisAvailable()/getRedis() usage.
+const redisSaddMock = vi.fn();
+const redisExpireMock = vi.fn();
+const redisSmembersMock = vi.fn();
+let redisAvailableForTest = true;
+vi.mock('../services/redis', () => ({
+  isRedisAvailable: () => redisAvailableForTest,
+  getRedis: () => (redisAvailableForTest ? { sadd: redisSaddMock, expire: redisExpireMock, smembers: redisSmembersMock } : null),
 }));
 
 // notFoundError mirrors what isBackupObjectNotFound (backupSnapshotStorage.ts)
@@ -89,30 +111,35 @@ vi.mock('../services/backupSnapshotStorage', async (importOriginal) => {
 const captureExceptionMock = vi.fn();
 vi.mock('../services/sentry', () => ({ captureException: captureExceptionMock }));
 
+
 const {
   computeExpiresAt,
   cleanupExpiredSnapshots,
   sweepUnreferencedBackupObjects,
   resolveBackupGcMaxDeletesPerRun,
+  resolveBackupGcGraceMs,
+  resolveBackupManifestlessPrefixMaxAgeMs,
   normalizeStorageIdentity,
-  BACKUP_GC_GRACE_MS,
-  BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS,
-  isRetainableBackupTypeForGc,
+  orphanManifestSnapshotIds,
 } = await import('./backupRetention');
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const AGENT_JOURNAL_MAX_AGE_MS = 7 * DAY_MS;
-// Ages relative to the ACTUAL current threshold (not a hardcoded "7 days")
-// so these fixtures stay correct even if the headroom formula changes again.
+const MANIFESTLESS_WINDOW_MS_DEFAULT = 9 * DAY_MS;
+// BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS is no longer a module-load export
+// (D18 W02, Task 1) — its default (9 days) is a fixture constant here,
+// independent of the real per-run resolver under test. The frozen-time
+// boundary tests later in this file exercise the resolver's actual output
+// directly; these two helpers only need "comfortably past the default" for
+// tests that don't care about the exact boundary.
 const JUST_PAST_MANIFESTLESS_THRESHOLD = () =>
-  new Date(Date.now() - BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS - DAY_MS);
+  new Date(Date.now() - MANIFESTLESS_WINDOW_MS_DEFAULT - DAY_MS);
 const EVEN_FURTHER_PAST_MANIFESTLESS_THRESHOLD = () =>
-  new Date(Date.now() - BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS - 2 * DAY_MS);
+  new Date(Date.now() - MANIFESTLESS_WINDOW_MS_DEFAULT - 2 * DAY_MS);
 
 function manifestJson(files: { backupPath: string }[]): string {
   return JSON.stringify({ formatVersion: 2, files });
 }
-
 describe('backup retention', () => {
   it('uses retentionDays when no GFS tiers are configured', () => {
     const expiresAt = computeExpiresAt(
@@ -324,34 +351,154 @@ describe('cleanupExpiredSnapshots -- pins + retirement (D18 W01 section 3.2/3.3/
   });
 });
 
+describe('resolveBackupGcGraceMs (per-run)', () => {
+  const prev = process.env.BACKUP_GC_GRACE_MS;
+  const prevEnv = process.env.NODE_ENV;
+  afterEach(() => {
+    if (prev === undefined) delete process.env.BACKUP_GC_GRACE_MS; else process.env.BACKUP_GC_GRACE_MS = prev;
+    if (prevEnv === undefined) delete process.env.NODE_ENV; else process.env.NODE_ENV = prevEnv;
+  });
+
+  it('defaults to 48h when unset', () => {
+    delete process.env.BACKUP_GC_GRACE_MS;
+    expect(resolveBackupGcGraceMs()).toBe(48 * 60 * 60 * 1000);
+  });
+
+  it('honors a positive override outside production', () => {
+    process.env.NODE_ENV = 'test';
+    process.env.BACKUP_GC_GRACE_MS = '1000';
+    expect(resolveBackupGcGraceMs()).toBe(1000);
+  });
+
+  it('floors an override below 1h in production', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.BACKUP_GC_GRACE_MS = '1000';
+    expect(resolveBackupGcGraceMs()).toBe(60 * 60 * 1000);
+  });
+
+  it('re-resolves on every call (no module-load caching)', () => {
+    process.env.NODE_ENV = 'test';
+    process.env.BACKUP_GC_GRACE_MS = '5000';
+    expect(resolveBackupGcGraceMs()).toBe(5000);
+    process.env.BACKUP_GC_GRACE_MS = '9000';
+    expect(resolveBackupGcGraceMs()).toBe(9000);
+  });
+});
+
+describe('resolveBackupManifestlessPrefixMaxAgeMs (per-run)', () => {
+  const prev = process.env.BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS;
+  afterEach(() => {
+    if (prev === undefined) delete process.env.BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS;
+    else process.env.BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS = prev;
+  });
+
+  it('defaults to 9 days (journalMaxAge + 48h), strictly greater than journalMaxAge', () => {
+    delete process.env.BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS;
+    const resolved = resolveBackupManifestlessPrefixMaxAgeMs();
+    expect(resolved).toBe(9 * 24 * 60 * 60 * 1000);
+    expect(resolved).toBeGreaterThan(AGENT_JOURNAL_MAX_AGE_MS);
+  });
+
+  it('never allows an override at or below journalMaxAge in production (floor holds)', () => {
+    const prevEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    process.env.BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS = String(AGENT_JOURNAL_MAX_AGE_MS);
+    try {
+      expect(resolveBackupManifestlessPrefixMaxAgeMs()).toBeGreaterThan(AGENT_JOURNAL_MAX_AGE_MS);
+    } finally {
+      if (prevEnv === undefined) delete process.env.NODE_ENV; else process.env.NODE_ENV = prevEnv;
+    }
+  });
+});
+
+describe('orphanManifestSnapshotIds (pure)', () => {
+  it('returns only young, unretained, unretired manifest-bearing ids', () => {
+    const groups = new Map([
+      ['young', { items: [], manifestItem: { key: 'snapshots/young/manifest.json', lastModified: new Date(Date.now() - DAY_MS) } }],
+      ['old', { items: [], manifestItem: { key: 'snapshots/old/manifest.json', lastModified: new Date(Date.now() - 20 * DAY_MS) } }],
+      ['retained', { items: [], manifestItem: { key: 'snapshots/retained/manifest.json', lastModified: new Date(Date.now() - 20 * DAY_MS) } }],
+      ['retired', { items: [], manifestItem: { key: 'snapshots/retired/manifest.json', lastModified: new Date(Date.now() - DAY_MS) } }],
+      ['nomanifest', { items: [{ key: 'snapshots/nomanifest/files/a', lastModified: new Date() }], manifestItem: null }],
+    ]);
+
+    const ids = orphanManifestSnapshotIds(
+      groups as any,
+      new Set(['retained']),
+      new Map([['retired', 'retirement-row-id']]),
+      Date.now(),
+      9 * DAY_MS,
+    );
+    expect(ids.sort()).toEqual(['young']);
+  });
+
+  it('treats a manifest object with unknown last-modified as young (fail-closed protect)', () => {
+    const groups = new Map([
+      ['unknownage', { items: [], manifestItem: { key: 'snapshots/unknownage/manifest.json', lastModified: null } }],
+    ]);
+    const ids = orphanManifestSnapshotIds(groups as any, new Set(), new Map(), Date.now(), 9 * DAY_MS);
+    expect(ids).toEqual(['unknownage']);
+  });
+});
+
 describe('sweepUnreferencedBackupObjects', () => {
   const destination = {
     id: 'cfg-1',
     provider: 's3',
     providerConfig: { bucket: 'backups', region: 'us-east-1' },
   };
+  const identityKeyFor = (d: typeof destination) => normalizeStorageIdentity(d.provider, d.providerConfig);
 
   beforeEach(() => {
     vi.clearAllMocks();
     selectQueue.length = 0;
+    redisAvailableForTest = true;
+    redisSmembersMock.mockResolvedValue([]);
     delete process.env.BACKUP_GC_MAX_DELETES_PER_RUN;
+    // Belt-and-braces: vi.clearAllMocks() clears call history but NOT queued
+    // .mockResolvedValueOnce/.mockRejectedValueOnce implementations — a test
+    // that (by design, e.g. a fail-closed abort) consumes fewer/more storage
+    // calls than another test expects can otherwise leak a stale queued
+    // response into the NEXT test's calls. Full reset + restore the shared
+    // "not found" default for fetchBackupObjectTextMock guarantees every test
+    // in this block starts from a clean slate regardless of execution order.
+    fetchBackupObjectTextMock.mockReset();
+    fetchBackupObjectTextMock.mockImplementation(async () => {
+      throw notFoundError();
+    });
+    listBackupObjectsUnderPrefixMock.mockReset();
+    deleteBackupObjectKeysMock.mockReset();
   });
 
   afterEach(() => {
     delete process.env.BACKUP_GC_MAX_DELETES_PER_RUN;
   });
 
+  // Convenience: pushes the 3 run-level reads (unattributedRows, destinations,
+  // identityUsage) that precede every per-identity loop iteration.
+  function pushRunLevel(dests: unknown[], unattributed: unknown[] = []) {
+    selectQueue.push(unattributed);
+    selectQueue.push(dests);
+    const usage = dests.map((d: any) => ({ storageIdentity: identityKeyFor(d), count: 1 }));
+    selectQueue.push(usage);
+  }
+
+  // Convenience: pushes the 4 per-identity reads, in the finalized order
+  // (retainedRows, nullIdentityRows, retirementRows, capabilityRows).
+  function pushIdentity(opts: {
+    retained?: unknown[];
+    nullRows?: unknown[];
+    retirements?: unknown[];
+    capability?: unknown[];
+  } = {}) {
+    selectQueue.push(opts.retained ?? []);
+    selectQueue.push(opts.nullRows ?? []);
+    selectQueue.push(opts.retirements ?? []);
+    selectQueue.push(opts.capability ?? []);
+  }
+
   it('keeps an object referenced by a retained snapshot even though it lives under an older, deleted snapshot prefix', async () => {
-    // Snapshot A's row is already gone (row-level retention ran); snapshot B
-    // is still retained and its manifest references A's file via a
-    // cross-prefix backupPath — the incremental "reference" mechanism. A has
-    // no manifest.json in the listing (its own row/manifest are gone), so
-    // group A is evaluated under the manifest-less/prefix-granularity rule;
-    // both its objects are 10 days old (past the 7-day window), so orphan.dat
-    // is swept while foo.dat survives purely because it's in the live set.
-    selectQueue.push([]); // unattributedRows
-    selectQueue.push([destination]); // destinations
-    selectQueue.push([{ snapshotId: 'B' }]); // retained snapshots for the identity
+    pushRunLevel([destination]);
+    pushIdentity({ retained: [{ snapshotId: 'B' }] });
 
     fetchBackupObjectTextMock.mockResolvedValueOnce(
       manifestJson([{ backupPath: 'snapshots/A/files/foo.dat' }]),
@@ -376,7 +523,9 @@ describe('sweepUnreferencedBackupObjects', () => {
     expect(deletedArg.keys).toEqual(['snapshots/A/files/orphan.dat']);
     expect(deletedArg.keys).not.toContain('snapshots/A/files/foo.dat');
     expect(deletedArg.keys).not.toContain('snapshots/B/manifest.json');
-    expect(result).toEqual({ deleted: 1, skippedIdentities: 0, blockedIdentities: 0 });
+    expect(result.deleted).toBe(1);
+    expect(result.skippedIdentities).toBe(0);
+    expect(result.blockedIdentities).toBe(0);
   });
 
   it('marks snapshots/<id>/layout.json live without fetching it, so the sweep never deletes a retained layout manifest', async () => {
@@ -414,55 +563,49 @@ describe('sweepUnreferencedBackupObjects', () => {
   });
 
   it('keeps a loose unreferenced object under a manifest-bearing prefix that is still inside the 48h grace window', async () => {
-    selectQueue.push([]);
-    selectQueue.push([destination]);
-    selectQueue.push([{ snapshotId: 'B' }]);
+    pushRunLevel([destination]);
+    pushIdentity({ retained: [{ snapshotId: 'B' }] });
 
     fetchBackupObjectTextMock.mockResolvedValueOnce(manifestJson([]));
 
     const withinGrace = new Date(Date.now() - 1 * 60 * 60 * 1000); // 1h old, grace is 48h
     listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
       { key: 'snapshots/B/manifest.json', lastModified: withinGrace },
-      { key: 'snapshots/B/files/pending.dat', lastModified: withinGrace }, // loose object under B's manifest-bearing prefix
+      { key: 'snapshots/B/files/pending.dat', lastModified: withinGrace },
     ]);
 
     const result = await sweepUnreferencedBackupObjects();
 
     expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled();
-    expect(result).toEqual({ deleted: 0, skippedIdentities: 0, blockedIdentities: 0 });
+    expect(result.deleted).toBe(0);
   });
 
   it('never deletes an object with no last-modified data, even if otherwise unreferenced (fail-closed per-object)', async () => {
-    selectQueue.push([]);
-    selectQueue.push([destination]);
-    selectQueue.push([{ snapshotId: 'B' }]);
+    pushRunLevel([destination]);
+    pushIdentity({ retained: [{ snapshotId: 'B' }] });
 
     fetchBackupObjectTextMock.mockResolvedValueOnce(manifestJson([]));
 
     listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
       { key: 'snapshots/B/manifest.json', lastModified: new Date(Date.now() - 10 * DAY_MS) },
-      { key: 'snapshots/B/files/unknown-age.dat', lastModified: null }, // no age proof
+      { key: 'snapshots/B/files/unknown-age.dat', lastModified: null },
     ]);
 
     const result = await sweepUnreferencedBackupObjects();
 
     expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled();
-    expect(result).toEqual({ deleted: 0, skippedIdentities: 0, blockedIdentities: 0 });
+    expect(result.deleted).toBe(0);
   });
 
-  // Manifest-less prefixes are protected at PREFIX granularity for
-  // BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS (9 days = the agent's 7-day
-  // journalMaxAge + 48h resume headroom), not the 48h loose-object grace.
   describe('manifest-less prefix protection', () => {
     it('leaves a manifest-less prefix entirely untouched while ANY of its objects is fresh (mixed-age)', async () => {
-      selectQueue.push([]);
-      selectQueue.push([destination]);
-      selectQueue.push([{ snapshotId: 'B' }]);
+      pushRunLevel([destination]);
+      pushIdentity({ retained: [{ snapshotId: 'B' }] });
 
       fetchBackupObjectTextMock.mockResolvedValueOnce(manifestJson([]));
 
       const veryOld = new Date(Date.now() - 20 * DAY_MS);
-      const fresh = new Date(Date.now() - 1 * DAY_MS); // well past 48h grace but inside the 7-day journal window
+      const fresh = new Date(Date.now() - 1 * DAY_MS);
       listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
         { key: 'snapshots/B/manifest.json', lastModified: veryOld },
         { key: 'snapshots/C/files/partial-old.dat', lastModified: veryOld },
@@ -471,20 +614,17 @@ describe('sweepUnreferencedBackupObjects', () => {
 
       const result = await sweepUnreferencedBackupObjects();
 
-      // The single fresh object protects the WHOLE "C" prefix — including
-      // partial-old.dat, which on its own would look well past any grace.
       expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled();
-      expect(result).toEqual({ deleted: 0, skippedIdentities: 0, blockedIdentities: 0 });
+      expect(result.deleted).toBe(0);
     });
 
     it('sweeps a manifest-less prefix in full once its newest object clears the (9-day) window', async () => {
-      selectQueue.push([]);
-      selectQueue.push([destination]);
-      selectQueue.push([{ snapshotId: 'B' }]);
+      pushRunLevel([destination]);
+      pushIdentity({ retained: [{ snapshotId: 'B' }] });
 
       fetchBackupObjectTextMock.mockResolvedValueOnce(manifestJson([]));
 
-      const allOld = JUST_PAST_MANIFESTLESS_THRESHOLD(); // past the (headroom-inclusive) window
+      const allOld = JUST_PAST_MANIFESTLESS_THRESHOLD();
       listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
         { key: 'snapshots/B/manifest.json', lastModified: allOld },
         { key: 'snapshots/C/files/partial-1.dat', lastModified: allOld },
@@ -506,17 +646,12 @@ describe('sweepUnreferencedBackupObjects', () => {
     });
 
     it('boundary regression: protects a resume opened just inside the agent journal window (day ~6.9) that legitimately runs past day 7', async () => {
-      // The scenario the 48h headroom targets: using journalMaxAge (7 days)
-      // alone as the sweep threshold would have swept
-      // this prefix (its newest object is 7 days + a few hours old — past the
-      // OLD threshold). With the 48h headroom, it must stay protected.
-      selectQueue.push([]);
-      selectQueue.push([destination]);
-      selectQueue.push([{ snapshotId: 'B' }]);
+      pushRunLevel([destination]);
+      pushIdentity({ retained: [{ snapshotId: 'B' }] });
 
       fetchBackupObjectTextMock.mockResolvedValueOnce(manifestJson([]));
 
-      const justPastOldSevenDayThreshold = new Date(Date.now() - AGENT_JOURNAL_MAX_AGE_MS - 6 * 60 * 60 * 1000); // 7d + 6h
+      const justPastOldSevenDayThreshold = new Date(Date.now() - AGENT_JOURNAL_MAX_AGE_MS - 6 * 60 * 60 * 1000);
       listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
         { key: 'snapshots/B/manifest.json', lastModified: justPastOldSevenDayThreshold },
         { key: 'snapshots/D/files/resume-chunk.dat', lastModified: justPastOldSevenDayThreshold },
@@ -525,39 +660,28 @@ describe('sweepUnreferencedBackupObjects', () => {
       const result = await sweepUnreferencedBackupObjects();
 
       expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled();
-      expect(result).toEqual({ deleted: 0, skippedIdentities: 0, blockedIdentities: 0 });
-    });
-
-    it('BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS is strictly larger than the agent journalMaxAge (7 days), not merely equal', () => {
-      expect(BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS).toBeGreaterThan(AGENT_JOURNAL_MAX_AGE_MS);
-      // Exact value pinned for regression safety: 7 days + 48h headroom = 9 days.
-      expect(BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS).toBe(9 * DAY_MS);
+      expect(result.deleted).toBe(0);
     });
   });
 
   it('aborts the sweep for an identity whose manifest fetch fails, but still processes other identities', async () => {
-    // Listing now happens before marking for EVERY identity (the dedup-source
-    // race protection marks every listed manifest live), so both identities
-    // get listed — the broken one's mark phase then fails on the manifest
-    // fetch for its retained snapshot and aborts BEFORE any delete.
     const destinationBroken = { id: 'cfg-broken', provider: 's3', providerConfig: { bucket: 'b1', region: 'us-east-1' } };
     const destinationOk = { id: 'cfg-ok', provider: 's3', providerConfig: { bucket: 'b2', region: 'us-east-1' } };
 
-    selectQueue.push([]); // unattributedRows
-    selectQueue.push([destinationBroken, destinationOk]); // destinations
-    selectQueue.push([{ snapshotId: 'X' }]); // retained for destinationBroken's identity
-    selectQueue.push([{ snapshotId: 'Y' }]); // retained for destinationOk's identity
+    pushRunLevel([destinationBroken, destinationOk]);
+    pushIdentity({ retained: [{ snapshotId: 'X' }] }); // destinationBroken's identity
+    pushIdentity({ retained: [{ snapshotId: 'Y' }] }); // destinationOk's identity
 
     fetchBackupObjectTextMock
-      .mockRejectedValueOnce(new Error('network error fetching manifest')) // destinationBroken's snapshot X
-      .mockResolvedValueOnce(manifestJson([])); // destinationOk's snapshot Y
+      .mockRejectedValueOnce(new Error('network error fetching manifest'))
+      .mockResolvedValueOnce(manifestJson([]));
 
     const old = JUST_PAST_MANIFESTLESS_THRESHOLD();
     listBackupObjectsUnderPrefixMock
-      .mockResolvedValueOnce([]) // destinationBroken's identity — empty listing, mark still attempted+fails on X
+      .mockResolvedValueOnce([])
       .mockResolvedValueOnce([
         { key: 'snapshots/Y/manifest.json', lastModified: old },
-        { key: 'snapshots/Z/files/orphan.dat', lastModified: old }, // manifest-less, all-old — deletable
+        { key: 'snapshots/Z/files/orphan.dat', lastModified: old },
       ]);
 
     deleteBackupObjectKeysMock.mockResolvedValueOnce({
@@ -567,24 +691,22 @@ describe('sweepUnreferencedBackupObjects', () => {
 
     const result = await sweepUnreferencedBackupObjects();
 
-    // Both identities get listed; only the healthy one reaches delete.
     expect(listBackupObjectsUnderPrefixMock).toHaveBeenCalledTimes(2);
     expect(deleteBackupObjectKeysMock).toHaveBeenCalledTimes(1);
     expect(deleteBackupObjectKeysMock).toHaveBeenCalledWith(
       expect.objectContaining({ providerConfig: destinationOk.providerConfig }),
     );
-    // The fail-closed identity is both skipped and BLOCKED (distinct signal),
-    // and the failure is escalated to Sentry.
-    expect(result).toEqual({ deleted: 1, skippedIdentities: 1, blockedIdentities: 1 });
+    expect(result.deleted).toBe(1);
+    expect(result.skippedIdentities).toBe(1);
+    expect(result.blockedIdentities).toBe(1);
     expect(captureExceptionMock).toHaveBeenCalledTimes(1);
   });
 
   it('honors the per-run deletion cap, leaving the rest for a later run', async () => {
     process.env.BACKUP_GC_MAX_DELETES_PER_RUN = '1';
 
-    selectQueue.push([]);
-    selectQueue.push([destination]);
-    selectQueue.push([{ snapshotId: 'B' }]);
+    pushRunLevel([destination]);
+    pushIdentity({ retained: [{ snapshotId: 'B' }] });
 
     fetchBackupObjectTextMock.mockResolvedValueOnce(manifestJson([]));
 
@@ -605,76 +727,30 @@ describe('sweepUnreferencedBackupObjects', () => {
 
     expect(deleteBackupObjectKeysMock).toHaveBeenCalledTimes(1);
     const deletedArg = deleteBackupObjectKeysMock.mock.calls[0]![0] as { keys: string[] };
-    // Oldest-first: only 1 of the 2 deletable objects goes this run.
     expect(deletedArg.keys).toEqual(['snapshots/A/files/orphan-2.dat']);
     expect(result.deleted).toBe(1);
   });
 
-  it('grace window matches BACKUP_GC_GRACE_MS (48h)', () => {
-    expect(BACKUP_GC_GRACE_MS).toBe(48 * 60 * 60 * 1000);
-  });
-
-  it('BACKUP_GC_GRACE_MS env override is honoured only when a positive number (lab knob)', async () => {
-    const prev = process.env.BACKUP_GC_GRACE_MS;
-    try {
-      process.env.BACKUP_GC_GRACE_MS = '1000';
-      vi.resetModules();
-      const fresh = await import('./backupRetention');
-      expect(fresh.BACKUP_GC_GRACE_MS).toBe(1000);
-      process.env.BACKUP_GC_GRACE_MS = 'nope';
-      vi.resetModules();
-      const bad = await import('./backupRetention');
-      expect(bad.BACKUP_GC_GRACE_MS).toBe(48 * 60 * 60 * 1000);
-    } finally {
-      if (prev === undefined) delete process.env.BACKUP_GC_GRACE_MS; else process.env.BACKUP_GC_GRACE_MS = prev;
-      vi.resetModules();
-    }
-  });
-
-  it('BACKUP_GC_GRACE_MS override is floored to 1h in production and always logged (review item)', async () => {
-    const prevGrace = process.env.BACKUP_GC_GRACE_MS;
-    const prevEnv = process.env.NODE_ENV;
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    try {
-      process.env.BACKUP_GC_GRACE_MS = '1000';
-      process.env.NODE_ENV = 'production';
-      vi.resetModules();
-      const prod = await import('./backupRetention');
-      // A 1 s grace in production would sweep objects of any in-flight upload
-      // whose manifest is not published yet; the knob is a lab knob.
-      expect(prod.BACKUP_GC_GRACE_MS).toBe(60 * 60 * 1000);
-      expect(warn.mock.calls.some(([msg]) => String(msg).includes('BACKUP_GC_GRACE_MS'))).toBe(true);
-
-      warn.mockClear();
-      process.env.NODE_ENV = 'test';
-      vi.resetModules();
-      const lab = await import('./backupRetention');
-      expect(lab.BACKUP_GC_GRACE_MS).toBe(1000);
-      expect(warn.mock.calls.some(([msg]) => String(msg).includes('BACKUP_GC_GRACE_MS'))).toBe(true);
-    } finally {
-      warn.mockRestore();
-      if (prevGrace === undefined) delete process.env.BACKUP_GC_GRACE_MS; else process.env.BACKUP_GC_GRACE_MS = prevGrace;
-      if (prevEnv === undefined) delete process.env.NODE_ENV; else process.env.NODE_ENV = prevEnv;
-      vi.resetModules();
-    }
+  it('grace window matches the default 48h', () => {
+    expect(resolveBackupGcGraceMs()).toBe(48 * 60 * 60 * 1000);
   });
 
   it('skips an identity whose provider has no GC listing support, without touching storage', async () => {
     const unsupported = { id: 'cfg-azure', provider: 'azure_blob', providerConfig: {} };
-    selectQueue.push([]);
-    selectQueue.push([unsupported]);
+    pushRunLevel([unsupported]);
 
     const result = await sweepUnreferencedBackupObjects();
 
     expect(fetchBackupObjectTextMock).not.toHaveBeenCalled();
     expect(listBackupObjectsUnderPrefixMock).not.toHaveBeenCalled();
-    expect(result).toEqual({ deleted: 0, skippedIdentities: 1, blockedIdentities: 0 });
+    expect(result.deleted).toBe(0);
+    expect(result.skippedIdentities).toBe(1);
+    expect(result.blockedIdentities).toBe(0);
   });
 
   it('does not crash the sweep when a delete is rejected (e.g. object-lock) — counts it and moves on', async () => {
-    selectQueue.push([]);
-    selectQueue.push([destination]);
-    selectQueue.push([{ snapshotId: 'B' }]);
+    pushRunLevel([destination]);
+    pushIdentity({ retained: [{ snapshotId: 'B' }] });
 
     fetchBackupObjectTextMock.mockResolvedValueOnce(manifestJson([]));
 
@@ -691,31 +767,19 @@ describe('sweepUnreferencedBackupObjects', () => {
 
     const result = await sweepUnreferencedBackupObjects();
 
-    expect(result).toEqual({ deleted: 0, skippedIdentities: 0, blockedIdentities: 0 });
+    expect(result.deleted).toBe(0);
+    expect(result.skippedIdentities).toBe(0);
+    expect(result.blockedIdentities).toBe(0);
   });
 
-  // Sweep scope must be storage identity (provider + endpoint + bucket,
-  // excluding prefix), not backupConfigs row, or two configs on one bucket
-  // mass-delete each other's backups.
   describe('storage identity grouping', () => {
     it('unions retained snapshots across two configs sharing one physical bucket, so neither can delete the other\'s live objects', async () => {
       const configA = { id: 'cfg-a', provider: 's3', providerConfig: { bucket: 'shared-bucket', region: 'us-east-1' } };
       const configB = { id: 'cfg-b', provider: 's3', providerConfig: { bucket: 'shared-bucket', region: 'us-east-1' } };
 
-      selectQueue.push([]); // unattributedRows
-      selectQueue.push([configA, configB]); // destinations — same identity (same bucket)
-      selectQueue.push([{ snapshotId: 'A' }, { snapshotId: 'B' }]); // retained rows unioned across BOTH configs
+      pushRunLevel([configA, configB]);
+      pushIdentity({ retained: [{ snapshotId: 'A' }, { snapshotId: 'B' }] });
 
-      // A's manifest has no references of its own; B's manifest (a
-      // different config's snapshot, same bucket) references an object that
-      // physically lives under A's prefix — the cross-config reference the
-      // identity-scoped mark protects.
-      //
-      // Dispatched by key (not a positional .mockResolvedValueOnce chain):
-      // markLiveBackupObjects now fetches TWO keys per snapshot (ordinary +
-      // D15's system-state probe), which would otherwise misalign a
-      // positional queue across multiple snapshots — see the failure this
-      // fixture originally hit before switching to key dispatch.
       fetchBackupObjectTextMock.mockImplementation(async (input: { key: string }) => {
         if (input.key === 'snapshots/A/manifest.json') return manifestJson([]);
         if (input.key === 'snapshots/B/manifest.json') {
@@ -728,34 +792,30 @@ describe('sweepUnreferencedBackupObjects', () => {
       const old = new Date(Date.now() - 10 * DAY_MS);
       listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
         { key: 'snapshots/A/manifest.json', lastModified: old },
-        { key: 'snapshots/A/files/shared.dat', lastModified: old }, // sits under A, referenced by B — must survive
+        { key: 'snapshots/A/files/shared.dat', lastModified: old },
         { key: 'snapshots/B/manifest.json', lastModified: old },
       ]);
 
       const result = await sweepUnreferencedBackupObjects();
 
       expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled();
-      expect(result).toEqual({ deleted: 0, skippedIdentities: 0, blockedIdentities: 0 });
+      expect(result.deleted).toBe(0);
     });
 
     it('blocks the entire run when any backup_snapshots row has a null config_id (cannot be attributed to a bucket)', async () => {
-      selectQueue.push([{ id: 'orphan-snap-1' }]); // unattributedRows — one exists
-      selectQueue.push([destination]); // destinations — used only to size skippedIdentities
+      pushRunLevel([destination], [{ id: 'orphan-snap-1' }]);
 
       const result = await sweepUnreferencedBackupObjects();
 
       expect(fetchBackupObjectTextMock).not.toHaveBeenCalled();
       expect(listBackupObjectsUnderPrefixMock).not.toHaveBeenCalled();
       expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled();
-      expect(result).toEqual({ deleted: 0, skippedIdentities: 1, blockedIdentities: 0 });
+      expect(result.deleted).toBe(0);
+      expect(result.skippedIdentities).toBe(1);
+      expect(result.blockedIdentities).toBe(0);
     });
 
     it('belt-and-braces: fail-closed-skips every identity that coarsely collides on bucket+host despite normalizeStorageIdentity keeping them apart', async () => {
-      // Genuine variant normalizeStorageIdentity does NOT currently collapse:
-      // one config specifies the port explicitly, the other omits it. That's
-      // a real gap (an implicit default port could mean the same physical
-      // endpoint), so the two land in DIFFERENT identities by construction —
-      // exactly the "unanticipated variant" the coarse check exists to catch.
       const configWithPort = {
         id: 'cfg-port',
         provider: 's3',
@@ -767,227 +827,139 @@ describe('sweepUnreferencedBackupObjects', () => {
         providerConfig: { bucket: 'collide-bucket', endpoint: 'https://minio.local' },
       };
 
-      // Sanity check the premise: normalizeStorageIdentity really does treat
-      // these as different (otherwise this test would be proving nothing).
       expect(normalizeStorageIdentity('s3', configWithPort.providerConfig))
         .not.toBe(normalizeStorageIdentity('s3', configWithoutPort.providerConfig));
 
-      selectQueue.push([]); // unattributedRows
-      selectQueue.push([configWithPort, configWithoutPort]); // destinations — 2 identities, coarsely the same bucket+host
+      pushRunLevel([configWithPort, configWithoutPort]);
 
       const result = await sweepUnreferencedBackupObjects();
 
-      // Neither identity's retained-rows query, listing, mark, or delete
-      // ever runs — both are excluded before any provider call.
       expect(fetchBackupObjectTextMock).not.toHaveBeenCalled();
       expect(listBackupObjectsUnderPrefixMock).not.toHaveBeenCalled();
       expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled();
-      expect(result).toEqual({ deleted: 0, skippedIdentities: 2, blockedIdentities: 0 });
+      expect(result.deleted).toBe(0);
+      expect(result.skippedIdentities).toBe(2);
+      expect(result.blockedIdentities).toBe(0);
     });
   });
 
-  // Dedup-source race: agents pick their reference base from the bucket
-  // LISTING, not from DB rows, so a listed manifest must be treated as live
-  // even with no (or not-yet-persisted) backup_snapshots row.
-  it('keeps a listed manifest\'s exclusive objects live even though no backup_snapshots row retains it', async () => {
-    selectQueue.push([]); // unattributedRows
-    selectQueue.push([destination]); // destinations
-    selectQueue.push([]); // retained snapshots for the identity — NONE (row never persisted)
+  // D18 W02: replaces the old "every listed manifest is live forever" rule.
+  // An orphan manifest with no row and no retirement is a root only while
+  // younger than the orphan window (default 9 days).
+  describe('orphan manifest root set (age-windowed, no row required)', () => {
+    it('protects a young orphan manifest (no row, no retirement) as a root', async () => {
+      pushRunLevel([destination]);
+      pushIdentity(); // no retained rows, no NULL rows, no retirements, no legacy helper
 
-    // ONE ordinary-manifest fetch expected: snapshot NEW is picked up purely
-    // from the listing (not from a retained row), and NEW is the only
-    // snapshot in this bucket at all. markLiveBackupObjects also probes for a
-    // system-state manifest per snapshot (D15) — that second call falls
-    // through to fetchBackupObjectTextMock's default "not found" (this
-    // snapshot has none), so it isn't queued here.
-    fetchBackupObjectTextMock.mockResolvedValueOnce(
-      manifestJson([{ backupPath: 'snapshots/OLD/files/base.dat' }]),
-    );
+      fetchBackupObjectTextMock.mockResolvedValueOnce(
+        manifestJson([{ backupPath: 'snapshots/OLD/files/base.dat' }]),
+      );
 
-    const recent = new Date(Date.now() - 1 * DAY_MS);
-    const old = JUST_PAST_MANIFESTLESS_THRESHOLD();
-    listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
-      { key: 'snapshots/NEW/manifest.json', lastModified: recent }, // listed manifest — no DB row
-      { key: 'snapshots/OLD/files/base.dat', lastModified: old }, // referenced by NEW — must survive despite being old and manifest-less
-    ]);
+      const recent = new Date(Date.now() - 1 * DAY_MS);
+      const old = JUST_PAST_MANIFESTLESS_THRESHOLD();
+      listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
+        { key: 'snapshots/NEW/manifest.json', lastModified: recent },
+        { key: 'snapshots/OLD/files/base.dat', lastModified: old },
+      ]);
 
-    const result = await sweepUnreferencedBackupObjects();
+      const result = await sweepUnreferencedBackupObjects();
 
-    expect(fetchBackupObjectTextMock).toHaveBeenCalledTimes(2);
-    expect(fetchBackupObjectTextMock).toHaveBeenCalledWith(
-      expect.objectContaining({ key: 'snapshots/NEW/manifest.json' }),
-    );
-    expect(fetchBackupObjectTextMock).toHaveBeenCalledWith(
-      expect.objectContaining({ key: 'snapshots/NEW/system-state/manifest.json' }),
-    );
-    expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled();
-    expect(result).toEqual({ deleted: 0, skippedIdentities: 0, blockedIdentities: 0 });
+      expect(fetchBackupObjectTextMock).toHaveBeenCalledWith(expect.objectContaining({ key: 'snapshots/NEW/manifest.json' }));
+      expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled();
+      expect(result.deleted).toBe(0);
+    });
+
+    it('reclaims an orphan manifest once it clears the orphan window (default 9 days), with no retirement row', async () => {
+      pushRunLevel([destination]);
+      pushIdentity();
+
+      const pastWindow = new Date(Date.now() - 10 * DAY_MS);
+      listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
+        { key: 'snapshots/ABANDONED/manifest.json', lastModified: pastWindow },
+        { key: 'snapshots/ABANDONED/files/x.dat', lastModified: pastWindow },
+      ]);
+      deleteBackupObjectKeysMock.mockResolvedValueOnce({ deletedKeys: ['snapshots/ABANDONED/files/x.dat'], failedKeys: [] });
+      deleteBackupObjectKeysMock.mockResolvedValueOnce({ deletedKeys: ['snapshots/ABANDONED/manifest.json'], failedKeys: [] });
+
+      const result = await sweepUnreferencedBackupObjects();
+
+      expect(fetchBackupObjectTextMock).not.toHaveBeenCalled();
+      expect(result.deleted).toBe(2);
+      expect(result.orphansSwept).toBe(1);
+    });
+
+    it('a manifest object with unknown last-modified is treated as young (fail-closed protect)', async () => {
+      pushRunLevel([destination]);
+      pushIdentity();
+
+      fetchBackupObjectTextMock.mockResolvedValueOnce(manifestJson([]));
+      listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
+        { key: 'snapshots/UNKNOWNAGE/manifest.json', lastModified: null },
+      ]);
+
+      const result = await sweepUnreferencedBackupObjects();
+
+      expect(fetchBackupObjectTextMock).toHaveBeenCalledWith(expect.objectContaining({ key: 'snapshots/UNKNOWNAGE/manifest.json' }));
+      expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled();
+      expect(result.deleted).toBe(0);
+    });
   });
 
-  // FIX 5 — EVERY listed manifest is marked live, not just the newest by
-  // object last-modified. The agent picks its incremental dedup base by the
-  // manifest's INTERNAL timestamp (agent clock), which can diverge from the S3
-  // object's last-modified; so protecting only the newest-by-last-modified
-  // could sweep the in-flight backup's actual base out from under it.
-  describe('marks every listed manifest, not just the newest (FIX 5)', () => {
-    it('protects an OLDER listed manifest (the in-flight dedup base) whose object last-modified is older than a newer sibling', async () => {
-      selectQueue.push([]); // unattributedRows
-      selectQueue.push([destination]); // destinations
-      selectQueue.push([]); // retained snapshots — NONE persisted yet (both are listing-only)
+  describe('all backup types share one retained set via storage_identity (no more backupType filter)', () => {
+    it('includes a system_image row in the retained set alongside a file row on the same identity', async () => {
+      pushRunLevel([destination]);
+      pushIdentity({ retained: [{ snapshotId: 'FILE1' }, { snapshotId: 'IMG1' }] });
 
-      // Two manifest-bearing snapshots in the listing. NEWER's manifest object
-      // is more recently uploaded (server clock), but the in-flight backup is
-      // deduping against OLDER (chosen by OLDER's internal agent-clock
-      // timestamp), so OLDER references a base object that must survive. Under
-      // the old "newest listed manifest only" rule, OLDER would NOT be marked
-      // and its referenced base — being past the grace window and manifest-less
-      // at that prefix — would be swept, dangling the in-flight reference.
-      const newerUpload = new Date(Date.now() - 1 * DAY_MS);
-      const olderUpload = new Date(Date.now() - 3 * DAY_MS);
-      const baseObjOld = JUST_PAST_MANIFESTLESS_THRESHOLD();
-
-      // Marks are driven by which manifests exist in the listing; both are
-      // fetched. NEWER references nothing extra; OLDER references the base.
       fetchBackupObjectTextMock.mockImplementation(async (input: { key: string }) => {
-        if (input.key === 'snapshots/NEWER/manifest.json') return manifestJson([]);
-        if (input.key === 'snapshots/OLDER/manifest.json') {
-          return manifestJson([{ backupPath: 'snapshots/BASE/files/base.dat' }]);
-        }
-        // Neither snapshot has system state — this test predates D15 and
-        // isn't about it. markLiveBackupObjects probes for it unconditionally
-        // per snapshot, so it must resolve as "absent" (routine case), not an
-        // unexpected-key failure.
+        if (input.key === 'snapshots/FILE1/manifest.json') return manifestJson([]);
+        if (input.key === 'snapshots/IMG1/manifest.json') return manifestJson([]);
         if (input.key.endsWith('/system-state/manifest.json')) throw notFoundError();
         throw new Error(`unexpected manifest fetch: ${input.key}`);
       });
 
-      listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
-        { key: 'snapshots/NEWER/manifest.json', lastModified: newerUpload },
-        { key: 'snapshots/OLDER/manifest.json', lastModified: olderUpload },
-        { key: 'snapshots/BASE/files/base.dat', lastModified: baseObjOld }, // referenced by OLDER — must survive
-      ]);
-
-      const result = await sweepUnreferencedBackupObjects();
-
-      // BOTH manifests were fetched (every listed manifest is marked), and the
-      // OLDER manifest's referenced base was NOT deleted.
-      expect(fetchBackupObjectTextMock).toHaveBeenCalledWith(
-        expect.objectContaining({ key: 'snapshots/NEWER/manifest.json' }),
-      );
-      expect(fetchBackupObjectTextMock).toHaveBeenCalledWith(
-        expect.objectContaining({ key: 'snapshots/OLDER/manifest.json' }),
-      );
-      expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled();
-      expect(result).toEqual({ deleted: 0, skippedIdentities: 0, blockedIdentities: 0 });
-    });
-  });
-
-  // D15 Wave 1 finding #3: retainedSnapshotIds' backupType allowlist must
-  // include system_image (it now shares the ordinary snapshots/<id>/
-  // manifest.json layout, per backup.go's Option A publish paths) while
-  // still excluding backupTypes that write their manifest elsewhere
-  // (hyperv's 'application', mssql's 'database') — including one of THOSE
-  // would 404 markLiveBackupObjects's unconditional ordinary-manifest fetch
-  // and fail-close the whole identity, exactly the FIX 6 regression below.
-  describe('isRetainableBackupTypeForGc', () => {
-    it.each([
-      ['file', true],
-      ['system_image', true],
-      [null, true], // legacy rows predating the backupType column
-      ['application', false], // hyperv — different manifest namespace
-      ['database', false], // mssql — different manifest namespace
-    ] as const)('backupType %s → %s', (backupType, want) => {
-      expect(isRetainableBackupTypeForGc(backupType)).toBe(want);
-    });
-  });
-
-  // FIX 6 — the mark phase only fetches snapshots/<id>/manifest.json for
-  // backupTypes in BACKUP_GC_RETAINED_MANIFEST_BACKUP_TYPES (plus NULL). A
-  // snapshot of some OTHER type (hyperv's 'application' / mssql's 'database')
-  // sharing a storage identity writes its manifest to a DIFFERENT key and
-  // never appears under snapshots/<id>/manifest.json, so including it in the
-  // retained set used to 404 the fetch and fail-close the WHOLE identity
-  // forever. The retained-rows query filters to that allowlist (plus NULL).
-  describe('non-file snapshots no longer wedge the file-backup sweep (FIX 6)', () => {
-    it('does not fail-close the identity when a non-file, non-system_image snapshot shares the bucket', async () => {
-      // The retained-rows query (filtered in SQL) returns only the
-      // FILE snapshot; a hyperv (backupType 'application') snapshot's row is
-      // excluded and so its non-existent snapshots/HYPERV1/manifest.json is
-      // never fetched. (The SQL WHERE clause itself is exercised by the
-      // integration suite — the mocked query builder here can't filter, so
-      // we assert the downstream behavior the filter produces: only the file
-      // manifest is fetched, no fail-close.)
-      selectQueue.push([]); // unattributedRows
-      selectQueue.push([destination]); // destinations
-      selectQueue.push([{ snapshotId: 'FILE1' }]); // retained FILE-type snapshots ONLY (non-file filtered out)
-
-      fetchBackupObjectTextMock.mockResolvedValueOnce(manifestJson([]));
-
       const old = JUST_PAST_MANIFESTLESS_THRESHOLD();
       listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
         { key: 'snapshots/FILE1/manifest.json', lastModified: old },
+        { key: 'snapshots/IMG1/manifest.json', lastModified: old },
       ]);
 
       const result = await sweepUnreferencedBackupObjects();
 
-      // Only FILE1's manifests are fetched (ordinary + D15's system-state
-      // probe, which falls through to "not found" since this fixture has
-      // none); the hyperv snapshot's keys are never touched at all, so the
-      // identity is NOT blocked.
-      expect(fetchBackupObjectTextMock).toHaveBeenCalledTimes(2);
-      expect(fetchBackupObjectTextMock).toHaveBeenCalledWith(
-        expect.objectContaining({ key: 'snapshots/FILE1/manifest.json' }),
-      );
-      expect(fetchBackupObjectTextMock).toHaveBeenCalledWith(
-        expect.objectContaining({ key: 'snapshots/FILE1/system-state/manifest.json' }),
-      );
-      expect(fetchBackupObjectTextMock).not.toHaveBeenCalledWith(
-        expect.objectContaining({ key: 'snapshots/HYPERV1/manifest.json' }),
-      );
-      expect(fetchBackupObjectTextMock).not.toHaveBeenCalledWith(
-        expect.objectContaining({ key: 'snapshots/HYPERV1/system-state/manifest.json' }),
-      );
-      expect(result).toEqual({ deleted: 0, skippedIdentities: 0, blockedIdentities: 0 });
-      expect(captureExceptionMock).not.toHaveBeenCalled();
+      expect(fetchBackupObjectTextMock).toHaveBeenCalledWith(expect.objectContaining({ key: 'snapshots/FILE1/manifest.json' }));
+      expect(fetchBackupObjectTextMock).toHaveBeenCalledWith(expect.objectContaining({ key: 'snapshots/IMG1/manifest.json' }));
+      expect(result.blockedIdentities).toBe(0);
+      expect(result.skippedIdentities).toBe(0);
     });
 
-    it('still fail-closes AND increments blockedIdentities when a genuine FILE manifest is unfetchable', async () => {
-      selectQueue.push([]); // unattributedRows
-      selectQueue.push([destination]); // destinations
-      selectQueue.push([{ snapshotId: 'FILE1' }]); // retained FILE-type snapshot
+    it('still fail-closes AND increments blockedIdentities when ANY retained row\'s manifest is unfetchable', async () => {
+      pushRunLevel([destination]);
+      pushIdentity({ retained: [{ snapshotId: 'IMG1' }] });
 
-      // A genuine file manifest that fails to fetch (network/corruption) must
-      // still abort the sweep for this identity — the FILE-type filter narrows
-      // WHAT is fetched, it does NOT weaken the fail-closed guarantee.
       fetchBackupObjectTextMock.mockRejectedValueOnce(new Error('S3 500 fetching manifest'));
 
       const old = JUST_PAST_MANIFESTLESS_THRESHOLD();
       listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
-        { key: 'snapshots/FILE1/manifest.json', lastModified: old },
-        { key: 'snapshots/ORPHAN/files/x.dat', lastModified: old }, // would be deletable, but the abort protects it
+        { key: 'snapshots/IMG1/manifest.json', lastModified: old },
+        { key: 'snapshots/ORPHAN/files/x.dat', lastModified: old },
       ]);
 
       const result = await sweepUnreferencedBackupObjects();
 
       expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled();
-      expect(result).toEqual({ deleted: 0, skippedIdentities: 1, blockedIdentities: 1 });
-      expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+      expect(result.skippedIdentities).toBe(1);
+      expect(result.blockedIdentities).toBe(1);
     });
   });
 
-  // A corrupt/unparseable manifest must abort the identity fail-closed (a live
-  // set that silently dropped an unparseable manifest's references could
-  // justify deleting still-referenced objects).
   describe('corrupt manifest parse (fail-closed)', () => {
     async function runWithManifestBody(body: string) {
-      selectQueue.push([]); // unattributedRows
-      selectQueue.push([destination]); // destinations
-      selectQueue.push([{ snapshotId: 'B' }]); // retained
+      pushRunLevel([destination]);
+      pushIdentity({ retained: [{ snapshotId: 'B' }] });
       fetchBackupObjectTextMock.mockResolvedValueOnce(body);
       const old = JUST_PAST_MANIFESTLESS_THRESHOLD();
       listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
         { key: 'snapshots/B/manifest.json', lastModified: old },
-        { key: 'snapshots/A/files/orphan.dat', lastModified: old }, // would be deletable if the live set were trusted
+        { key: 'snapshots/A/files/orphan.dat', lastModified: old },
       ]);
       return sweepUnreferencedBackupObjects();
     }
@@ -995,22 +967,22 @@ describe('sweepUnreferencedBackupObjects', () => {
     it('aborts the identity when the manifest body is invalid JSON', async () => {
       const result = await runWithManifestBody('{ this is not json');
       expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled();
-      expect(result).toEqual({ deleted: 0, skippedIdentities: 1, blockedIdentities: 1 });
+      expect(result.deleted).toBe(0);
+      expect(result.skippedIdentities).toBe(1);
+      expect(result.blockedIdentities).toBe(1);
       expect(captureExceptionMock).toHaveBeenCalledTimes(1);
     });
 
     it('aborts the identity when manifest.files is not an array', async () => {
       const result = await runWithManifestBody(JSON.stringify({ files: 'not-an-array' }));
       expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled();
-      expect(result).toEqual({ deleted: 0, skippedIdentities: 1, blockedIdentities: 1 });
+      expect(result.deleted).toBe(0);
+      expect(result.skippedIdentities).toBe(1);
+      expect(result.blockedIdentities).toBe(1);
       expect(captureExceptionMock).toHaveBeenCalledTimes(1);
     });
   });
 
-  // Boundary tests for the strict-`>` timing operators. Time is frozen so
-  // Date.now() inside the sweep matches the fixture ages to the millisecond;
-  // otherwise the few-ms gap between constructing the fixture and the sweep
-  // reading the clock would make a ±1ms assertion flaky.
   describe('timing-operator boundaries (strict >)', () => {
     const FIXED_NOW = 1_700_000_000_000;
 
@@ -1022,16 +994,11 @@ describe('sweepUnreferencedBackupObjects', () => {
       vi.useRealTimers();
     });
 
-    // Manifest-bearing prefix, per-object 48h grace: an object is deletable
-    // when `lastModified > graceThreshold` is FALSE, i.e. at age EXACTLY 48h it
-    // is swept, and 1ms short of 48h it is kept.
     async function sweepLooseObjectAtAge(ageMs: number) {
-      selectQueue.push([]); // unattributedRows
-      selectQueue.push([destination]); // destinations
-      selectQueue.push([{ snapshotId: 'B' }]); // retained
-      fetchBackupObjectTextMock.mockResolvedValueOnce(manifestJson([])); // B references nothing
+      pushRunLevel([destination]);
+      pushIdentity({ retained: [{ snapshotId: 'B' }] });
+      fetchBackupObjectTextMock.mockResolvedValueOnce(manifestJson([]));
       listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
-        // manifest.json is in the live set (markLive adds it) — never a candidate
         { key: 'snapshots/B/manifest.json', lastModified: new Date(FIXED_NOW - 30 * DAY_MS) },
         { key: 'snapshots/B/files/obj.dat', lastModified: new Date(FIXED_NOW - ageMs) },
       ]);
@@ -1043,31 +1010,26 @@ describe('sweepUnreferencedBackupObjects', () => {
     }
 
     it('sweeps a loose object at EXACTLY 48h (not strictly inside the grace window)', async () => {
-      const result = await sweepLooseObjectAtAge(BACKUP_GC_GRACE_MS);
+      const result = await sweepLooseObjectAtAge(48 * 60 * 60 * 1000);
       expect(result.deleted).toBe(1);
     });
 
     it('keeps a loose object 1ms short of 48h (still strictly inside the grace window)', async () => {
-      const result = await sweepLooseObjectAtAge(BACKUP_GC_GRACE_MS - 1);
+      const result = await sweepLooseObjectAtAge(48 * 60 * 60 * 1000 - 1);
       expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled();
       expect(result.deleted).toBe(0);
     });
 
     it('sweeps a loose object 1ms past 48h', async () => {
-      const result = await sweepLooseObjectAtAge(BACKUP_GC_GRACE_MS + 1);
+      const result = await sweepLooseObjectAtAge(48 * 60 * 60 * 1000 + 1);
       expect(result.deleted).toBe(1);
     });
 
-    // Manifest-less prefix, 9-day prefix protection: the prefix is protected
-    // when its newest object age is `> manifestlessThreshold` (strictly inside
-    // the window). At age EXACTLY 9 days it is swept; 1ms short it is protected.
     async function sweepManifestlessPrefixAtNewestAge(ageMs: number) {
-      selectQueue.push([]); // unattributedRows
-      selectQueue.push([destination]); // destinations
-      selectQueue.push([{ snapshotId: 'B' }]); // retained (marked, not in listing)
+      pushRunLevel([destination]);
+      pushIdentity({ retained: [{ snapshotId: 'B' }] });
       fetchBackupObjectTextMock.mockResolvedValueOnce(manifestJson([]));
       listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
-        // No snapshots/C/manifest.json → C is a manifest-less prefix.
         { key: 'snapshots/C/files/partial.dat', lastModified: new Date(FIXED_NOW - ageMs) },
       ]);
       deleteBackupObjectKeysMock.mockResolvedValueOnce({
@@ -1078,33 +1040,26 @@ describe('sweepUnreferencedBackupObjects', () => {
     }
 
     it('sweeps a manifest-less prefix whose newest object is EXACTLY at the 9-day threshold', async () => {
-      const result = await sweepManifestlessPrefixAtNewestAge(BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS);
+      const result = await sweepManifestlessPrefixAtNewestAge(9 * DAY_MS);
       expect(result.deleted).toBe(1);
     });
 
     it('protects a manifest-less prefix whose newest object is 1ms short of the 9-day threshold', async () => {
-      const result = await sweepManifestlessPrefixAtNewestAge(BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS - 1);
+      const result = await sweepManifestlessPrefixAtNewestAge(9 * DAY_MS - 1);
       expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled();
       expect(result.deleted).toBe(0);
     });
 
     it('sweeps a manifest-less prefix whose newest object is 1ms past the 9-day threshold', async () => {
-      const result = await sweepManifestlessPrefixAtNewestAge(BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS + 1);
+      const result = await sweepManifestlessPrefixAtNewestAge(9 * DAY_MS + 1);
       expect(result.deleted).toBe(1);
     });
   });
 
-  // D15 bare-metal-recovery contract (Option A): a system_image snapshot
-  // publishes system-state/manifest.json + system-state/<artifact.path>
-  // alongside (or instead of) the ordinary manifest.files[] — see
-  // docs/superpowers/plans/backup/2026-09-09-bmr-system-state-contract.md.
-  // markLiveBackupObjects must mark those objects live too, or GC deletes
-  // every system_image snapshot's bare-metal-recovery state 48h after upload.
   describe('D15 system-state GC (Option A)', () => {
     it('keeps system-state objects live when referenced by system-state/manifest.json', async () => {
-      selectQueue.push([]); // unattributedRows
-      selectQueue.push([destination]); // destinations
-      selectQueue.push([{ snapshotId: 'B' }]); // retained
+      pushRunLevel([destination]);
+      pushIdentity({ retained: [{ snapshotId: 'B' }] });
 
       fetchBackupObjectTextMock.mockImplementation(async (input: { key: string }) => {
         if (input.key === 'snapshots/B/manifest.json') return manifestJson([]);
@@ -1118,8 +1073,6 @@ describe('sweepUnreferencedBackupObjects', () => {
       listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
         { key: 'snapshots/B/manifest.json', lastModified: old },
         { key: 'snapshots/B/system-state/manifest.json', lastModified: old },
-        // Both old enough to sweep on age alone if NOT marked live by the
-        // system-state manifest's artifacts[] — the thing under test.
         { key: 'snapshots/B/system-state/registry/SYSTEM', lastModified: old },
         { key: 'snapshots/B/system-state/boot/grub.cfg', lastModified: old },
       ]);
@@ -1127,20 +1080,14 @@ describe('sweepUnreferencedBackupObjects', () => {
       const result = await sweepUnreferencedBackupObjects();
 
       expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled();
-      expect(result).toEqual({ deleted: 0, skippedIdentities: 0, blockedIdentities: 0 });
+      expect(result.deleted).toBe(0);
     });
 
-    it('deletes system-state objects under an expired/unretained snapshot the same way ordinary file objects are', async () => {
-      // Snapshot B is retained and references nothing; snapshot EXPIRED is
-      // NOT retained and not in the listing's manifest set either (it has
-      // aged out / its row is gone) — both its ordinary-shaped loose object
-      // and its system-state artifact are old, unreferenced, manifest-less,
-      // and past the 9-day manifest-less-prefix window, so BOTH must sweep.
-      selectQueue.push([]); // unattributedRows
-      selectQueue.push([destination]); // destinations
-      selectQueue.push([{ snapshotId: 'B' }]); // retained
+    it('deletes system-state objects under an old orphan prefix the same way ordinary file objects are', async () => {
+      pushRunLevel([destination]);
+      pushIdentity({ retained: [{ snapshotId: 'B' }] });
 
-      fetchBackupObjectTextMock.mockResolvedValueOnce(manifestJson([])); // B's ordinary manifest; B has no system-state manifest (falls through to "not found")
+      fetchBackupObjectTextMock.mockResolvedValueOnce(manifestJson([]));
 
       const old = JUST_PAST_MANIFESTLESS_THRESHOLD();
       listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
@@ -1161,9 +1108,8 @@ describe('sweepUnreferencedBackupObjects', () => {
     });
 
     it('does NOT sweep the group when the system-state manifest fetch fails with a non-404 error (fail-closed)', async () => {
-      selectQueue.push([]); // unattributedRows
-      selectQueue.push([destination]); // destinations
-      selectQueue.push([{ snapshotId: 'B' }]); // retained
+      pushRunLevel([destination]);
+      pushIdentity({ retained: [{ snapshotId: 'B' }] });
 
       fetchBackupObjectTextMock.mockImplementation(async (input: { key: string }) => {
         if (input.key === 'snapshots/B/manifest.json') return manifestJson([]);
@@ -1176,65 +1122,328 @@ describe('sweepUnreferencedBackupObjects', () => {
       const old = JUST_PAST_MANIFESTLESS_THRESHOLD();
       listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
         { key: 'snapshots/B/manifest.json', lastModified: old },
-        { key: 'snapshots/B/system-state/registry/SYSTEM', lastModified: old }, // would be deletable if the abort didn't protect it
+        { key: 'snapshots/B/system-state/registry/SYSTEM', lastModified: old },
       ]);
 
       const result = await sweepUnreferencedBackupObjects();
 
-      // A non-"not found" fetch failure cannot prove liveness one way or the
-      // other, so the WHOLE identity is fail-closed — same contract as an
-      // unfetchable ordinary manifest.
       expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled();
-      expect(result).toEqual({ deleted: 0, skippedIdentities: 1, blockedIdentities: 1 });
+      expect(result.deleted).toBe(0);
+      expect(result.skippedIdentities).toBe(1);
+      expect(result.blockedIdentities).toBe(1);
       expect(captureExceptionMock).toHaveBeenCalledTimes(1);
     });
 
-    // D15 Wave 1 finding #3: a retained system_image row used to be excluded
-    // from retainedSnapshotIds outright (see the FIX 6 describe block above,
-    // now updated to use an 'application'/'database' example instead), so its
-    // system-state/* objects had NO db-side protection at all — only the
-    // listing's own manifest.json presence decided their fate. Now that
-    // system_image rows are included, this proves a retained system_image
-    // snapshot's system-state prefix is NOT deleted even in the (defensive,
-    // not routine — see the publish-ordering fix in backup.go) case where the
-    // ordinary snapshots/<id>/manifest.json object itself is missing from the
-    // bucket, with its system-state objects older than the manifest-less
-    // prefix's max-age window (which would otherwise sweep them at PREFIX
-    // granularity on age alone).
     it('protects a retained system_image snapshot whose ordinary manifest object is absent from the bucket', async () => {
-      selectQueue.push([]); // unattributedRows
-      selectQueue.push([destination]); // destinations
-      // Post-fix: the retained-rows query includes system_image (not just
-      // file/null) — IMG1 here stands in for that DB row.
-      selectQueue.push([{ snapshotId: 'IMG1' }]);
-
-      // IMG1's ordinary manifest is genuinely absent from the bucket — the
-      // mock's base implementation (module-level default) already rejects
-      // any unconfigured key as "not found", so no explicit queuing is
-      // needed here to model that; this test asserts the CONSEQUENCE.
+      pushRunLevel([destination]);
+      pushIdentity({ retained: [{ snapshotId: 'IMG1' }] });
 
       const old = EVEN_FURTHER_PAST_MANIFESTLESS_THRESHOLD();
       listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
-        // No snapshots/IMG1/manifest.json entry at all — group.manifestItem
-        // is null, so this group is classified manifest-less (protected at
-        // PREFIX granularity by age alone) UNLESS the retained-row lookup
-        // changes the outcome.
         { key: 'snapshots/IMG1/system-state/manifest.json', lastModified: old },
         { key: 'snapshots/IMG1/system-state/registry/SYSTEM', lastModified: old },
       ]);
 
       const result = await sweepUnreferencedBackupObjects();
 
-      // markLiveBackupObjects has no not-found tolerance on the ORDINARY
-      // manifest fetch (only the system-state fetch does) — a retained
-      // snapshot whose ordinary manifest can't be fetched fails the WHOLE
-      // identity closed, exactly like the pre-existing "still fail-closes...
-      // when a genuine FILE manifest is unfetchable" contract above. That is
-      // a STRONGER guarantee than per-group protection: nothing in the
-      // identity deletes this run, so IMG1's system-state objects survive.
       expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled();
-      expect(result).toEqual({ deleted: 0, skippedIdentities: 1, blockedIdentities: 1 });
+      expect(result.deleted).toBe(0);
+      expect(result.skippedIdentities).toBe(1);
+      expect(result.blockedIdentities).toBe(1);
       expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('§3.7 held-context tripwire', () => {
+    it('calls assertOutsideHeldDbContext with the sweepStorageIdentity operation label before any storage call', async () => {
+      pushRunLevel([destination]);
+      pushIdentity();
+      listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([]);
+
+      await sweepUnreferencedBackupObjects();
+
+      expect(assertOutsideHeldDbContextMock).toHaveBeenCalledWith('backupGC.sweepStorageIdentity');
+    });
+  });
+
+  describe('NULL-identity rows are ALWAYS roots of I, resolved or not (§3.6 v3)', () => {
+    it('fetches (and requires) the manifest of an UNRESOLVED NULL row too, and defers the whole identity if it is not found in the listing', async () => {
+      pushRunLevel([destination]);
+      pushIdentity({
+        nullRows: [{ id: 'row-neverwritten', snapshotId: 'NEVERWRITTEN' }],
+        retirements: [{ id: 'retirement-5', snapshotId: 'RETIRED5' }],
+      });
+
+      const t = new Date(Date.now() - 1000);
+      listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
+        { key: 'snapshots/RETIRED5/manifest.json', lastModified: t },
+        { key: 'snapshots/RETIRED5/files/x.dat', lastModified: t },
+      ]);
+      fetchBackupObjectTextMock.mockResolvedValueOnce(manifestJson([]));
+
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        const result = await sweepUnreferencedBackupObjects();
+        expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled();
+        expect(result.retiredSwept).toBe(0);
+        expect(warn.mock.calls.some(([msg]) => String(msg).includes('identity deferred: 1 unresolved rows'))).toBe(true);
+      } finally {
+        warn.mockRestore();
+      }
+    });
+
+    it('fetch failure for a RESOLVED NULL row (found in the listing) still aborts the identity fail-closed', async () => {
+      pushRunLevel([destination]);
+      pushIdentity({ nullRows: [{ id: 'row-badfetch', snapshotId: 'BADFETCH' }] });
+
+      const t = new Date(Date.now() - 1000);
+      listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
+        { key: 'snapshots/BADFETCH/manifest.json', lastModified: t },
+      ]);
+      fetchBackupObjectTextMock.mockRejectedValueOnce(new Error('S3 500'));
+
+      const result = await sweepUnreferencedBackupObjects();
+      expect(result.blockedIdentities).toBe(1);
+      expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deferral runs EXACTLY today\'s algorithm, not "rooted only" (§3.4 v3)', () => {
+    it('legacy-helper deferral marks EVERY listed manifest live (including a retired one) and only reclaims loose/manifest-less objects', async () => {
+      pushRunLevel([destination]);
+      pushIdentity({
+        retirements: [{ id: 'retirement-3', snapshotId: 'RETIRED3' }],
+        capability: [{ deviceId: 'device-legacy', backupVersion: '0.109.0' }],
+      });
+
+      const t = new Date(Date.now() - 1000);
+      listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
+        { key: 'snapshots/RETIRED3/manifest.json', lastModified: t },
+        { key: 'snapshots/RETIRED3/files/x.dat', lastModified: t },
+      ]);
+      fetchBackupObjectTextMock.mockResolvedValueOnce(manifestJson([]));
+
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        const result = await sweepUnreferencedBackupObjects();
+        expect(fetchBackupObjectTextMock).toHaveBeenCalledWith(expect.objectContaining({ key: 'snapshots/RETIRED3/manifest.json' }));
+        expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled();
+        expect(result.deferredIdentities).toBe(1);
+        expect(result.retiredSwept).toBe(0);
+        expect(warn.mock.calls.some(([msg]) => String(msg).includes('reclamation deferred: legacy helper device-legacy 0.109.0'))).toBe(true);
+      } finally {
+        warn.mockRestore();
+      }
+    });
+
+    it('a deferred identity STILL reclaims a manifest-less prefix older than 9 days (that rule is unconditional)', async () => {
+      pushRunLevel([destination]);
+      pushIdentity({ capability: [{ deviceId: 'device-legacy', backupVersion: '0.109.0' }] });
+
+      const old = JUST_PAST_MANIFESTLESS_THRESHOLD();
+      listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
+        { key: 'snapshots/ORPHANPARTIAL/files/partial.dat', lastModified: old },
+      ]);
+      deleteBackupObjectKeysMock.mockResolvedValueOnce({ deletedKeys: ['snapshots/ORPHANPARTIAL/files/partial.dat'], failedKeys: [] });
+
+      const result = await sweepUnreferencedBackupObjects();
+      expect(result.deleted).toBe(1);
+      expect(result.deferredIdentities).toBe(1);
+    });
+  });
+
+  describe('self-heal writes by row id, guarded by storage_identity IS NULL (§3.6 v3)', () => {
+    it('resolves a NULL row (found in listing) and reclaims a co-located retirement in the SAME run once nothing is unresolved', async () => {
+      pushRunLevel([destination]);
+      pushIdentity({
+        nullRows: [{ id: 'row-healme', snapshotId: 'HEALME' }],
+        retirements: [{ id: 'retirement-6', snapshotId: 'RETIRED6' }],
+      });
+
+      fetchBackupObjectTextMock.mockResolvedValueOnce(manifestJson([]));
+      const t = new Date(Date.now() - 1000);
+      listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
+        { key: 'snapshots/HEALME/manifest.json', lastModified: t },
+        { key: 'snapshots/RETIRED6/manifest.json', lastModified: t },
+        { key: 'snapshots/RETIRED6/files/r.dat', lastModified: t },
+      ]);
+      deleteBackupObjectKeysMock.mockResolvedValueOnce({ deletedKeys: ['snapshots/RETIRED6/files/r.dat'], failedKeys: [] });
+      deleteBackupObjectKeysMock.mockResolvedValueOnce({ deletedKeys: ['snapshots/RETIRED6/manifest.json'], failedKeys: [] });
+
+      const result = await sweepUnreferencedBackupObjects();
+
+      expect(result.deleted).toBe(2);
+      expect(mockDb.update).toHaveBeenCalledWith(backupSnapshots);
+      expect(result.retiredSwept).toBe(0); // not yet confirmed by a fresh listing
+    });
+  });
+
+  describe('swept_at is set only once a FRESH listing confirms the prefix is gone (two-pass, §3.4 v3)', () => {
+    it('does not set swept_at in the same pass as the deletes, but does on a later run once the listing shows it gone', async () => {
+      pushRunLevel([destination]);
+      pushIdentity({ retirements: [{ id: 'retirement-1', snapshotId: 'RETIRED1' }] });
+
+      const t = new Date(Date.now() - 1000);
+      listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
+        { key: 'snapshots/RETIRED1/manifest.json', lastModified: t },
+        { key: 'snapshots/RETIRED1/files/x.dat', lastModified: t },
+      ]);
+      deleteBackupObjectKeysMock.mockResolvedValueOnce({ deletedKeys: ['snapshots/RETIRED1/files/x.dat'], failedKeys: [] });
+      deleteBackupObjectKeysMock.mockResolvedValueOnce({ deletedKeys: ['snapshots/RETIRED1/manifest.json'], failedKeys: [] });
+
+      const firstRun = await sweepUnreferencedBackupObjects();
+      expect(firstRun.deleted).toBe(2);
+      expect(firstRun.retiredSwept).toBe(0);
+
+      pushRunLevel([destination]);
+      pushIdentity({ retirements: [{ id: 'retirement-1', snapshotId: 'RETIRED1' }] });
+      listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([]);
+
+      const secondRun = await sweepUnreferencedBackupObjects();
+      expect(secondRun.deleted).toBe(0);
+      expect(secondRun.retiredSwept).toBe(1);
+    });
+
+    it('confirms swept_at IMMEDIATELY (first time it is ever swept) when a retirement is already fully absent from the listing', async () => {
+      pushRunLevel([destination]);
+      pushIdentity({ retirements: [{ id: 'retirement-7', snapshotId: 'RETIRED7' }] });
+      listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([]);
+
+      const result = await sweepUnreferencedBackupObjects();
+      expect(deleteBackupObjectKeysMock).not.toHaveBeenCalled();
+      expect(result.retiredSwept).toBe(1);
+    });
+
+    it('a manifest-less "retired remnant" (manifest already gone from a prior run) is reclaimed immediately, with no 9-day wait', async () => {
+      pushRunLevel([destination]);
+      pushIdentity({ retirements: [{ id: 'retirement-8', snapshotId: 'RETIRED8' }] });
+
+      const veryRecent = new Date(Date.now() - 1000);
+      listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
+        { key: 'snapshots/RETIRED8/files/remnant.dat', lastModified: veryRecent },
+      ]);
+      deleteBackupObjectKeysMock.mockResolvedValueOnce({ deletedKeys: ['snapshots/RETIRED8/files/remnant.dat'], failedKeys: [] });
+
+      const result = await sweepUnreferencedBackupObjects();
+      expect(result.deleted).toBe(1);
+    });
+  });
+
+  describe('Redis-backed skip set (delete-cap fairness) and cap accounting', () => {
+    it('excludes a previously-failed key from candidates on a later run without re-attempting it', async () => {
+      redisSmembersMock.mockResolvedValueOnce(['snapshots/ABANDONED/files/locked.dat']);
+      pushRunLevel([destination]);
+      pushIdentity();
+
+      const pastWindow = new Date(Date.now() - 10 * DAY_MS);
+      listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
+        { key: 'snapshots/ABANDONED/manifest.json', lastModified: pastWindow },
+        { key: 'snapshots/ABANDONED/files/locked.dat', lastModified: pastWindow },
+        { key: 'snapshots/ABANDONED/files/free.dat', lastModified: pastWindow },
+      ]);
+      deleteBackupObjectKeysMock.mockResolvedValueOnce({ deletedKeys: ['snapshots/ABANDONED/files/free.dat'], failedKeys: [] });
+
+      await sweepUnreferencedBackupObjects();
+
+      expect(deleteBackupObjectKeysMock).not.toHaveBeenCalledWith(
+        expect.objectContaining({ keys: expect.arrayContaining(['snapshots/ABANDONED/files/locked.dat']) }),
+      );
+    });
+
+    it('records a failed key with a 7-day TTL after deleteBackupObjectKeys reports it', async () => {
+      pushRunLevel([destination]);
+      pushIdentity();
+
+      const pastWindow = new Date(Date.now() - 10 * DAY_MS);
+      listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
+        { key: 'snapshots/ABANDONED/manifest.json', lastModified: pastWindow },
+        { key: 'snapshots/ABANDONED/files/locked.dat', lastModified: pastWindow },
+      ]);
+      deleteBackupObjectKeysMock.mockResolvedValueOnce({
+        deletedKeys: [],
+        failedKeys: [{ key: 'snapshots/ABANDONED/files/locked.dat', error: 'object-lock' }],
+      });
+
+      await sweepUnreferencedBackupObjects();
+
+      expect(redisSaddMock).toHaveBeenCalledWith(expect.stringMatching(/^backup-gc:failed:/), 'snapshots/ABANDONED/files/locked.dat');
+      expect(redisExpireMock).toHaveBeenCalledWith(expect.stringMatching(/^backup-gc:failed:/), 7 * 24 * 60 * 60);
+    });
+
+    it('degrades to no skip set (proceeds normally) when Redis is unavailable', async () => {
+      redisAvailableForTest = false;
+      pushRunLevel([destination]);
+      pushIdentity();
+      listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([]);
+      const result = await sweepUnreferencedBackupObjects();
+      expect(result.deleted).toBe(0);
+    });
+
+    it('a FAILED delete attempt consumes the per-run cap, not just successful deletes', async () => {
+      pushRunLevel([destination]);
+      pushIdentity({ retained: [{ snapshotId: 'B' }] });
+
+      fetchBackupObjectTextMock.mockResolvedValueOnce(manifestJson([]));
+      process.env.BACKUP_GC_MAX_DELETES_PER_RUN = '1';
+      try {
+        const old = JUST_PAST_MANIFESTLESS_THRESHOLD();
+        listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
+          { key: 'snapshots/B/manifest.json', lastModified: old },
+          { key: 'snapshots/B/files/a.dat', lastModified: old },
+          { key: 'snapshots/B/files/b.dat', lastModified: old },
+        ]);
+        deleteBackupObjectKeysMock.mockResolvedValueOnce({
+          deletedKeys: [],
+          failedKeys: [{ key: 'snapshots/B/files/a.dat', error: 'object-lock' }],
+        });
+
+        await sweepUnreferencedBackupObjects();
+        expect(deleteBackupObjectKeysMock).toHaveBeenCalledTimes(1);
+      } finally {
+        delete process.env.BACKUP_GC_MAX_DELETES_PER_RUN;
+      }
+    });
+
+    it('a rooted-branch delete failure is recorded into the Redis skip set too (not just the retired/orphan branch)', async () => {
+      pushRunLevel([destination]);
+      pushIdentity({ retained: [{ snapshotId: 'B' }] });
+
+      fetchBackupObjectTextMock.mockResolvedValueOnce(manifestJson([]));
+      const old = JUST_PAST_MANIFESTLESS_THRESHOLD();
+      listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([
+        { key: 'snapshots/B/manifest.json', lastModified: old },
+        { key: 'snapshots/B/files/locked.dat', lastModified: old },
+      ]);
+      deleteBackupObjectKeysMock.mockResolvedValueOnce({
+        deletedKeys: [],
+        failedKeys: [{ key: 'snapshots/B/files/locked.dat', error: 'object-lock' }],
+      });
+
+      await sweepUnreferencedBackupObjects();
+      expect(redisSaddMock).toHaveBeenCalledWith(expect.stringMatching(/^backup-gc:failed:/), 'snapshots/B/files/locked.dat');
+    });
+  });
+
+  describe('unreachable storage identities (no config points at them any more)', () => {
+    it('logs and counts a storage_identity with rows but no matching current config, without touching it', async () => {
+      selectQueue.push([]); // unattributedRows
+      selectQueue.push([destination]); // destinations
+      selectQueue.push([
+        { storageIdentity: identityKeyFor(destination), count: 2 },
+        { storageIdentity: 'local::/var/orphaned-bucket-nobody-points-at', count: 5 },
+      ]); // identityUsage
+      pushIdentity();
+
+      listBackupObjectsUnderPrefixMock.mockResolvedValueOnce([]);
+
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        const result = await sweepUnreferencedBackupObjects();
+        expect(result.unreachableIdentities).toBe(1);
+        expect(warn.mock.calls.some(([msg]) => String(msg).includes('unreachable identity local::/var/orphaned-bucket-nobody-points-at: 5 rows'))).toBe(true);
+      } finally {
+        warn.mockRestore();
+      }
     });
   });
 });

--- a/apps/api/src/jobs/backupRetention.ts
+++ b/apps/api/src/jobs/backupRetention.ts
@@ -17,10 +17,18 @@ import {
   restoreJobs,
   backupSnapshotRetirements,
   IN_FLIGHT_BACKUP_JOB_STATUSES,
+  devices,
 } from '../db/schema';
 import { recoveryTokens } from '../db/schema/recoveryTokens';
-import { eq, and, or, lt, gt, desc, inArray, isNull, sql } from 'drizzle-orm';
-import { resolveBackupRestorePinLingerMs, resolveBackupPublishMarginMs } from '../services/backupGcKnobs';
+import { eq, and, or, lt, gt, gte, desc, inArray, isNull, isNotNull, sql } from 'drizzle-orm';
+import {
+  resolveMsKnob,
+  resolveBackupRestorePinLingerMs,
+  resolveBackupPublishMarginMs,
+  resolveBackupBaseLeaseMs,
+  resolveBackupOrphanManifestMaxAgeMs,
+} from '../services/backupGcKnobs';
+import { backupHelperSupportsServerBase } from '../services/backupHelperCapabilities';
 import {
   BACKUP_SNAPSHOT_ROOT_DIR,
   BACKUP_SNAPSHOT_MANIFEST_KEY,
@@ -38,6 +46,8 @@ import {
 import { asRecord, getStringValue } from '../services/recoveryBootstrap';
 import { captureException } from '../services/sentry';
 import { pgErrorCode, pgErrorConstraint } from '../utils/pgErrors';
+import { createHash } from 'node:crypto';
+import { getRedis, isRedisAvailable } from '../services/redis';
 
 // ── GFS tag types ────────────────────────────────────────────────────────────
 
@@ -601,176 +611,119 @@ export function computeExpiresAt(
 // snapshot's whole prefix when its row expires" — that would delete objects
 // a still-retained, newer sibling snapshot's manifest points at. This phase
 // runs AFTER row-level retention (cleanupExpiredSnapshots) has already
-// deleted expired backup_snapshots rows, and is the ONLY code path that
-// deletes backup objects.
+// deleted expired backup_snapshots rows (writing a durable
+// backup_snapshot_retirements tombstone as it goes), and is the ONLY code
+// path that deletes backup objects.
 //
-// Shape (see docs/superpowers/specs/backup/2026-07-16-incremental-backups-design.md,
-// "Amendments from GC review"):
+// D18 W02 (#5451, spec v3 docs/superpowers/specs/backup/2026-09-09-backup-gc-reclamation-design.md):
 //
 //   Identity: sweeps run per STORAGE IDENTITY (provider + endpoint + bucket),
-//             not per backupConfigs row. Two configs can point at the same
-//             physical bucket (e.g. shared credentials, migrated configs) —
-//             sweeping per-config would see only ITS OWN retained snapshots
-//             and delete objects a sibling config's retained snapshot still
-//             references. Identity deliberately EXCLUDES providerConfig.prefix
-//             (see backupSnapshotStorage.ts's prefix-exclusion comment: the
-//             agent ignores prefix when writing, so two configs differing only
-//             by prefix are the same physical namespace).
-//   Mark:     live set = every backupPath + manifest key from EVERY retained
-//             (still-existing) FILE-type backup_snapshots row across ALL
-//             configs sharing an identity, PLUS every manifest-bearing
-//             snapshot found in the identity's own object LISTING regardless
-//             of row retention. Marking EVERY listed manifest (not just the
-//             newest) closes the dedup-source race: agents pick their
-//             reference base by the manifest's INTERNAL timestamp (agent
-//             clock, stamped at snapshot start), which can diverge from the
-//             S3 object's last-modified (server/upload clock) on overlapping
-//             runs or clock skew — so "newest by last-modified" could protect
-//             snapshot X while an in-flight backup dedups against snapshot Y.
-//             A just-uploaded manifest may also have no backup_snapshots row
-//             yet, or ever, if persistence failed after upload succeeded. ANY
-//             manifest fetch/parse failure anywhere in that combined set
-//             aborts the mark for the WHOLE identity — an incomplete live set
-//             must never justify a delete. (Only FILE-type snapshots use the
-//             snapshots/<id>/manifest.json layout; see the backupType filter
-//             in sweepUnreferencedBackupObjects.)
+//             not per backupConfigs row — see normalizeStorageIdentity.
+//   Root set: every backup_snapshots row whose storage_identity matches this
+//             identity (ANY backupType — the manifest layout
+//             (snapshots/<id>/manifest.json (+ system-state/ for D15)) is
+//             shared by every mode, so scoping is by identity, not type), PLUS
+//             every backup_snapshots row with storage_identity IS NULL whose
+//             config_id maps here (unconditionally a root — "resolved" only
+//             gates self-heal/deferral, never root membership, see §3.6 v3).
+//   Retired:  a snapshot with a backup_snapshot_retirements row (sweptAt IS
+//             NULL) for this identity is NEVER a root regardless of age, and
+//             is reclaimed via the two-phase (non-manifest, then manifest)
+//             rule below.
+//   Orphan:   a listed manifest-bearing prefix with NO row and NO retirement
+//             is a root only while younger than ORPHAN_WINDOW — giving
+//             reconcile time to adopt it. Past the window it is reclaimed
+//             like a retired prefix. This REPLACES the old "every listed
+//             manifest is live forever" rule, which existed only to guard a
+//             dedup-source race that no longer exists now that the server
+//             picks and LEASES the incremental base itself
+//             (base_snapshot_id/publish_lease_expires_at, W01).
+//   Deferred: while ANY unresolved (manifest not found in this run's listing)
+//             NULL-identity row exists for this identity, OR any device with
+//             a recent/in-flight backup_jobs row on this identity runs a
+//             helper below BACKUP_SERVER_BASE_MIN_HELPER_VERSION, retired/
+//             orphan reclamation is suppressed for the WHOLE identity this
+//             run — it runs EXACTLY today's (pre-D18) algorithm instead
+//             (every listed manifest is a root; only the pre-existing 48h
+//             loose-object grace and 9-day manifest-less-prefix rules apply).
 //   Sweep:    per snapshot-ID prefix found in the listing:
-//               - has a manifest.json: normal per-object rule — delete
-//                 objects not in the live set AND older than
-//                 BACKUP_GC_GRACE_MS (48h).
-//               - NO manifest.json (partial/resumable run): protected at
-//                 PREFIX granularity for BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS
-//                 (9 days = the agent's 7-day journalMaxAge + 48h resume
-//                 headroom — equality with journalMaxAge alone left a boundary
-//                 race) — a prefix is swept in full only once its NEWEST
-//                 object clears that window; one single fresh object protects
-//                 the WHOLE prefix.
+//               - rooted, manifest-bearing: per-object 48h grace
+//                 (BACKUP_GC_GRACE_MS) for loose (non-live) objects.
+//               - manifest-less (partial/resumable run): protected at PREFIX
+//                 granularity until the newest object clears
+//                 BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS (9 days default).
+//               - retired or old-orphan, manifest-bearing: two-phase —
+//                 non-manifest objects first, then the manifest ONLY once no
+//                 deletable non-manifest key remains (none failed, none
+//                 capped, none skip-set-excluded).
 //   Null config_id: a backup_snapshots row with no config_id can't be
-//             attributed to any specific storage identity — its objects
-//             could live in ANY bucket we're about to sweep. Its mere
-//             existence blocks GC for every identity this run (fail-closed;
-//             see sweepUnreferencedBackupObjects).
-//   Identity normalization: two configs describing the SAME physical bucket
-//             through cosmetically different config values (blank vs
-//             explicit-default endpoint, trailing slash, host case, local
-//             path spelling) must still collapse to ONE identity, or
-//             cross-config over-deletion comes back via the back door — see
-//             normalizeStorageIdentity and its belt-and-braces collision
-//             check, detectSuspiciousStorageIdentityCollisions.
+//             attributed to any storage identity — blocks the ENTIRE run,
+//             fail-closed (unchanged from pre-D18).
+//   Identity normalization / collision detection: unchanged from pre-D18 —
+//             see normalizeStorageIdentity and detectSuspiciousStorageIdentityCollisions.
+//   Transaction boundaries (spec §3.7): every DB read/write here runs inside
+//             its own SHORT withSystemDbAccessContext call; every storage
+//             call (list/fetch/delete) runs at depth 0 — assertOutsideHeldDbContext
+//             is the runtime tripwire for this invariant.
 
 const BACKUP_GC_GRACE_MS_DEFAULT = 48 * 60 * 60 * 1000;
-// Test/lab knob only (2026-09-09 assurance campaign, cell R1/R4): the grace is a
-// production safety margin and must never be lowered on a real deployment.
-// Lowest grace production will accept from the env knob. The grace window is
-// what protects objects of an in-flight upload whose manifest is not yet
-// published (see sweepUnreferencedBackupObjects); the knob exists so a lab can
-// prove reclamation in seconds, not so an operator can shave the window.
+// Lowest grace production will accept from the env knob. The grace is a
+// production safety margin (protects an in-flight upload whose manifest
+// isn't published yet) and must never be lowered on a real deployment; the
+// knob exists so a lab can prove reclamation in seconds.
 const BACKUP_GC_GRACE_MS_PRODUCTION_FLOOR = 60 * 60 * 1000;
 
-function resolveBackupGcGraceMs(): number {
-  const raw = process.env.BACKUP_GC_GRACE_MS;
-  if (raw === undefined || raw.trim() === '') return BACKUP_GC_GRACE_MS_DEFAULT;
-  const n = Number(raw);
-  if (!Number.isFinite(n) || n <= 0) {
-    console.warn(
-      `[BackupRetention] Ignoring BACKUP_GC_GRACE_MS=${JSON.stringify(raw)} (not a positive number); using default ${BACKUP_GC_GRACE_MS_DEFAULT} ms`,
-    );
-    return BACKUP_GC_GRACE_MS_DEFAULT;
-  }
-  if (process.env.NODE_ENV === 'production' && n < BACKUP_GC_GRACE_MS_PRODUCTION_FLOOR) {
-    console.warn(
-      `[BackupRetention] BACKUP_GC_GRACE_MS=${n} is below the production floor; using ${BACKUP_GC_GRACE_MS_PRODUCTION_FLOOR} ms instead`,
-    );
-    return BACKUP_GC_GRACE_MS_PRODUCTION_FLOOR;
-  }
-  console.warn(
-    `[BackupRetention] BACKUP_GC_GRACE_MS override active: ${n} ms (default ${BACKUP_GC_GRACE_MS_DEFAULT} ms)`,
-  );
-  return n;
+/** Resolved fresh on every GC run — see resolveMsKnob for the override/floor/warn contract. */
+export function resolveBackupGcGraceMs(): number {
+  return resolveMsKnob('BACKUP_GC_GRACE_MS', BACKUP_GC_GRACE_MS_DEFAULT, BACKUP_GC_GRACE_MS_PRODUCTION_FLOOR);
 }
-export const BACKUP_GC_GRACE_MS = resolveBackupGcGraceMs();
 
 // Must stay STRICTLY LARGER than agent/internal/backup/journal.go's
-// journalMaxAge (7 days) — the agent trusts its checkpoint journal (and
-// therefore a partial/manifest-less snapshot prefix) for resume during that
-// window and does not re-verify remote objects on resume. Using
-// journalMaxAge as an exact equality boundary left a race: a resume opened
-// at, say, day 6.9 legitimately keeps running past day 7, so GC could sweep
-// its still-live manifest-less prefix out from under it. The +48h below is
-// resume headroom, not the unrelated BACKUP_GC_GRACE_MS concept, though it
-// happens to reuse the same
-// 48h value — see the cross-reference comment on journalMaxAge itself, which
-// must stay strictly SMALLER than this constant.
+// journalMaxAge (7 days) — apps/api/src/services/backupAgentContract.test.ts
+// greps THIS FILE's source text for this exact literal. Do not move it,
+// rename it, or change its RHS expression without updating that contract test.
 const BACKUP_GC_AGENT_JOURNAL_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000; // must equal the agent's journalMaxAge
-export const BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS =
-  BACKUP_GC_AGENT_JOURNAL_MAX_AGE_MS + BACKUP_GC_GRACE_MS; // journalMaxAge + 48h resume headroom = 9 days
+const BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS_DEFAULT =
+  BACKUP_GC_AGENT_JOURNAL_MAX_AGE_MS + BACKUP_GC_GRACE_MS_DEFAULT; // 9 days
+// Floor is journalMaxAge + 1ms (not a round number): the invariant is STRICT
+// inequality against journalMaxAge, not "at least 7 days" — an override of
+// exactly 7 days would race a resume opened just inside day 7.
+const BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS_PRODUCTION_FLOOR = BACKUP_GC_AGENT_JOURNAL_MAX_AGE_MS + 1;
+
+/** Resolved fresh on every GC run. Replaces the old module-load export. */
+export function resolveBackupManifestlessPrefixMaxAgeMs(): number {
+  return resolveMsKnob(
+    'BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS',
+    BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS_DEFAULT,
+    BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS_PRODUCTION_FLOOR,
+  );
+}
 
 // Providers this GC path knows how to list-with-last-modified and delete for.
-// Mirrors deleteBackupSnapshotArtifacts's s3/local support — other providers
-// (azure_blob, google_cloud, backblaze) aren't wired to object storage here
-// yet, so their identities are skipped (fail-closed: no listing means no
-// age data means no safe sweep decision).
 const BACKUP_GC_SUPPORTED_PROVIDERS = new Set(['s3', 'local']);
 
 // The unit of GC work is a storage identity (possibly several backupConfigs
 // rows sharing one bucket), not a single "destination" row.
-//   skippedIdentities — every identity NOT swept this run, for ANY reason
-//     (unsupported provider, suspicious collision, null-config whole-run block,
-//     OR a fail-closed mark/sweep abort). Kept as the broad "not swept" total.
-//   blockedIdentities — the SUBSET of skippedIdentities we tried to sweep but
-//     had to abort fail-closed because a FILE-type manifest was unfetchable/
-//     unparseable. This is the one that signals a genuine, non-self-healing
-//     storage leak (vs. the benign unsupported-provider skips), so surface it
-//     distinctly rather than letting it hide inside skippedIdentities.
-export type BackupGcResult = { deleted: number; skippedIdentities: number; blockedIdentities: number };
-
-/**
- * backupType values whose manifest lives under the shared
- * snapshots/<id>/manifest.json namespace the mark phase (markLiveBackupObjects)
- * understands. Only these — plus a NULL backupType (legacy rows predating the
- * column's 'file' default) — may safely appear in retainedSnapshotIds:
- * markLiveBackupObjects's ordinary-manifest fetch is UNCONDITIONAL and has no
- * not-found tolerance, so a retained row whose type writes its manifest
- * elsewhere would 404 and fail-close the WHOLE identity (see FIX 6 below).
- *
- * 'system_image' was excluded here too until D15 Wave 1 gave it the SAME
- * snapshots/<id>/manifest.json + system-state/ layout (Option A — see
- * docs/superpowers/plans/backup/2026-09-09-bmr-system-state-contract.md):
- * backup.go's state-only AND mixed-run publish paths now both publish a
- * (possibly empty-files) ordinary manifest.json for EVERY system_image run,
- * specifically so the snapshot-id group stays "manifest-bearing" for GC.
- * Excluding system_image rows from this set left every retained
- * system_image snapshot's bare-metal-recovery state with no DB-side
- * protection at all — surviving only by luck, if its manifest.json also
- * happened to still be present in the bucket LISTING (see
- * listedManifestSnapshotIds).
- *
- * 'application' (hyperv) and 'database' (mssql) still write their manifests
- * to a different key/namespace entirely and must stay excluded.
- *
- * `as const` (rather than `readonly string[]` directly) so the literal tuple
- * type-checks against backupSnapshots.backupType's pgEnum column in the
- * `inArray(...)` call below — Drizzle's enum column typing rejects a bare
- * `string[]`. BACKUP_GC_RETAINED_MANIFEST_BACKUP_TYPES itself is exported as
- * the widened `readonly string[]` (below) since callers like
- * isRetainableBackupTypeForGc only need plain string membership.
- */
-const RETAINABLE_BACKUP_TYPES_FOR_GC = ['file', 'system_image'] as const;
-export const BACKUP_GC_RETAINED_MANIFEST_BACKUP_TYPES: readonly string[] = RETAINABLE_BACKUP_TYPES_FOR_GC;
-
-/**
- * Whether a backupSnapshots row of this backupType may safely be included in
- * retainedSnapshotIds — see BACKUP_GC_RETAINED_MANIFEST_BACKUP_TYPES' doc
- * comment. NULL (legacy rows predating the backupType column) is always
- * retainable. Factored out as its own predicate (rather than inlined into
- * the query's `or(...)` below) purely so it has an isolated unit test
- * independent of the mocked Drizzle query builder, which cannot exercise a
- * real `.where()` filter — see backupRetention.test.ts's own comment on that
- * limitation.
- */
-export function isRetainableBackupTypeForGc(backupType: string | null): boolean {
-  return backupType === null || BACKUP_GC_RETAINED_MANIFEST_BACKUP_TYPES.includes(backupType);
-}
+//   skippedIdentities — every identity NOT swept this run, for ANY reason.
+//   blockedIdentities — the SUBSET of skippedIdentities aborted fail-closed
+//     because a manifest was unfetchable/unparseable — the signal of a
+//     genuine, non-self-healing storage leak.
+//   retiredSwept — retirement rows CONFIRMED fully gone from a fresh listing
+//     this run (durable, via swept_at — see the two-pass rule below).
+//   orphansSwept — best-effort per-run metric (no DB row to confirm against).
+//   deferredIdentities — identities that ran today's (pre-D18) algorithm only
+//     this run (legacy helper and/or unresolved NULL-identity rows).
+//   unreachableIdentities — storage_identity values with rows but no current
+//     config producing that identity (visibility only; see logUnreachableStorageIdentities).
+export type BackupGcResult = {
+  deleted: number;
+  skippedIdentities: number;
+  blockedIdentities: number;
+  retiredSwept: number;
+  orphansSwept: number;
+  deferredIdentities: number;
+  unreachableIdentities: number;
+};
 
 type BackupGcManifest = { files?: Array<{ backupPath?: unknown }> };
 
@@ -796,12 +749,10 @@ function parseBackupGcSystemStateManifest(raw: string): BackupGcSystemStateManif
 /**
  * Resolves the per-run deletion cap from env on every call (not once at
  * module load) so it stays test-overridable without module-reset gymnastics.
- * Same normalization convention as STALE_REAPER_MAX_PER_RUN in
- * staleCommandReaper.ts: 0 means unlimited; negative/NaN falls back to the
- * default rather than silently disabling the sweep. Unset OR blank/whitespace
- * treated identically as "use the default" — `Number('')` is 0 in JS, which
- * would otherwise silently mean "unlimited" for an accidentally-empty env
- * var (e.g. a templated `.env` with `BACKUP_GC_MAX_DELETES_PER_RUN=`).
+ * 0 means unlimited; negative/NaN falls back to the default rather than
+ * silently disabling the sweep. Unset OR blank/whitespace treated identically
+ * as "use the default" — `Number('')` is 0 in JS, which would otherwise
+ * silently mean "unlimited" for an accidentally-empty env var.
  */
 export function resolveBackupGcMaxDeletesPerRun(): number {
   const envValue = process.env.BACKUP_GC_MAX_DELETES_PER_RUN;
@@ -842,25 +793,16 @@ export type BackupGcStorageIdentity = {
 
 // AWS's own default S3 endpoints. An endpoint that's EXPLICITLY the default
 // AWS endpoint must canonicalize to the same identity as a blank/omitted
-// endpoint (both mean "use AWS's default") — otherwise two configs that only
-// differ by "left it blank" vs "typed the default in by hand" would split
-// into two identities and resurrect the cross-config over-deletion bug.
-// Covers the same host shapes
-// deriveS3RegionFromEndpoint (packages/shared/src/utils/s3Region.ts) knows
-// about, plus the bare regionless legacy host.
+// endpoint (both mean "use AWS's default").
 const DEFAULT_AWS_S3_ENDPOINT_PATTERN = /^s3(\.dualstack)?([.-][a-z0-9-]+)?\.amazonaws\.com$/;
 
 /**
  * Normalizes an S3-compatible endpoint for identity comparison: strips
- * scheme/path/trailing-slash (only host+port matter), lowercases the host
- * (URL parsing already does this, but be explicit — this value feeds a
- * cross-config grouping decision, not just an HTTP call), and canonicalizes
- * a blank endpoint and an explicit default-AWS endpoint to the SAME value.
- * A genuinely unparseable endpoint falls back to a trimmed+lowercased raw
- * string rather than being treated as blank — fail toward "different
- * identity" (safe: at worst splits one bucket into two, never merges two
- * different ones), never toward "same identity", for anything not
- * confidently understood.
+ * scheme/path/trailing-slash (only host+port matter), lowercases the host,
+ * and canonicalizes a blank endpoint and an explicit default-AWS endpoint to
+ * the SAME value. A genuinely unparseable endpoint falls back to a
+ * trimmed+lowercased raw string rather than being treated as blank — fail
+ * toward "different identity" (safe), never toward "same identity".
  */
 function normalizeS3Endpoint(endpoint: string | null | undefined): string {
   const raw = endpoint?.trim();
@@ -877,20 +819,9 @@ function normalizeS3Endpoint(endpoint: string | null | undefined): string {
 
 /**
  * Identity = provider + endpoint + bucket (S3) or provider + resolved root
- * path (local) — deliberately EXCLUDING providerConfig.prefix. See the
- * prefix-exclusion comment on backupSnapshotRootPrefix in
- * backupSnapshotStorage.ts for why: the agent ignores prefix when writing, so
- * two configs that only differ by prefix are, physically, the exact same
- * object namespace.
- *
- * Cosmetic variants that must NOT split one physical bucket into two
- * identities: blank endpoint vs the explicit default AWS endpoint; endpoint
- * trailing slash and host
- * case (`https://Minio.local:9000/` vs `https://minio.local:9000`);
- * scheme-less vs schemed (both parsed the same way); local paths differing
- * only by trailing slash, `//`, or `.` segments (`path.resolve` collapses
- * these exactly like `ensureContainedLocalPath` in backupSnapshotStorage.ts
- * already does for the same reason).
+ * path (local) — deliberately EXCLUDING providerConfig.prefix (the agent
+ * ignores prefix when writing, so two configs differing only by prefix are
+ * the same physical namespace).
  */
 export function normalizeStorageIdentity(provider: string, providerConfig: Record<string, unknown>): string {
   if (provider === 'local') {
@@ -928,17 +859,10 @@ function groupBackupConfigsByStorageIdentity(
 
 /**
  * Belt-and-braces: even after normalizeStorageIdentity, an unanticipated
- * cosmetic variant it doesn't yet account for could still produce two
- * DIFFERENT identity keys for the SAME physical bucket — silently re-opening
- * cross-config over-deletion, since each identity would only see its own
- * configs' retained snapshots and could delete the other's live objects.
- * Cross-check with a CRUDER comparison —
- * bucket name case-insensitively + hostname only, ignoring port/scheme/the
- * AWS-default canonicalization entirely — and if THAT collapses two
- * identities normalizeStorageIdentity kept apart, something is wrong: log
- * loudly and fail-closed by excluding ALL of them from this run rather than
- * risk two overlapping sweeps on one bucket. Local identities are already
- * exact-path-resolved and have no separate coarse check.
+ * cosmetic variant could still produce two DIFFERENT identity keys for the
+ * SAME physical bucket. Cross-check with a CRUDER comparison and fail-closed
+ * (exclude ALL of them) if it collapses two identities normalizeStorageIdentity
+ * kept apart.
  */
 function detectSuspiciousStorageIdentityCollisions(
   identities: Map<string, BackupGcStorageIdentity>,
@@ -1018,30 +942,70 @@ function groupListingBySnapshotId(listing: BackupObjectListing[]): Map<string, B
 }
 
 /**
- * Dedup-source race: every manifest-bearing snapshot in the LISTING is marked
- * live, not just retained DB rows — collects the snapshot IDs of all such
- * groups so their backupPaths join the live set.
+ * §3.4 orphan root set: a listed manifest-bearing prefix with no
+ * backup_snapshots row and no retirement row is a root ONLY while its
+ * manifest object is younger than the orphan window — giving reconcile
+ * (backupSnapshotReconcile.ts) time to adopt a completed-but-unpersisted
+ * snapshot into a real row before GC would otherwise reclaim it. A manifest
+ * object with no last-modified data cannot have its age disproven, so it is
+ * fail-closed treated as YOUNG (protected), never as old.
  *
- * Why EVERY listed manifest, not just the newest: an in-flight backup picks
- * its incremental dedup base by the manifest's INTERNAL `timestamp` (stamped
- * on the AGENT clock at snapshot START), while the S3 object's last-modified
- * is the SERVER/upload clock. Those diverge on overlapping runs, clock skew,
- * or a smaller later-started snapshot finishing first — so "newest by
- * last-modified" could protect snapshot X while the running backup references
- * snapshot Y. If Y then lacks a retained DB row and its objects are past the
- * grace window, GC would sweep the very BackupPath the in-flight snapshot
- * points at → a dangling reference / silent missing file at restore. Marking
- * ALL listed manifests is race-proof; the only added cost is extra manifest
- * GETs, and the mark phase already fail-closes on any fetch/parse error. A
- * manifest whose object carries no last-modified is still included here — age
- * is irrelevant to whether its references are live.
+ * Replaces the old listedManifestSnapshotIds, which marked EVERY listed
+ * manifest live FOREVER to guard the agent's listing-based dedup-base
+ * selection race. That race no longer exists: the server now picks and
+ * LEASES the incremental base itself (base_snapshot_id/publish_lease_expires_at,
+ * W01) — an in-flight backup's base is protected by its own retained DB row
+ * and lease, not by an unbounded listing heuristic, so an orphan manifest
+ * past the window really is garbage (or a retirement will already exist).
  */
-function listedManifestSnapshotIds(groups: Map<string, BackupGcSnapshotGroup>): string[] {
+export function orphanManifestSnapshotIds(
+  groups: Map<string, BackupGcSnapshotGroup>,
+  retainedSnapshotIds: Set<string>,
+  retiredSnapshotIds: Map<string, string>,
+  nowMs: number,
+  windowMs: number,
+): string[] {
   const ids: string[] = [];
+  const threshold = nowMs - windowMs;
   for (const [snapshotId, group] of groups) {
-    if (group.manifestItem) ids.push(snapshotId);
+    if (!group.manifestItem) continue;
+    if (retainedSnapshotIds.has(snapshotId)) continue; // already a root via its DB row
+    if (retiredSnapshotIds.has(snapshotId)) continue; // retired -> never a root, regardless of age
+    const lm = group.manifestItem.lastModified;
+    if (!lm || lm.getTime() > threshold) ids.push(snapshotId);
   }
   return ids;
+}
+
+/**
+ * §3.6: rows carry the identity string they were PUBLISHED under, which
+ * survives a later providerConfig edit. An identity with rows but no current
+ * config producing that exact key is unreachable — it is never listed (no
+ * config = no provider/providerConfig to list with), so it leaks silently
+ * unless logged here. This is visibility only; reclaiming an unreachable
+ * identity needs manual tooling (deferred).
+ */
+async function logUnreachableStorageIdentities(
+  identities: Map<string, BackupGcStorageIdentity>,
+): Promise<number> {
+  const usage = await db
+    .select({
+      storageIdentity: backupSnapshots.storageIdentity,
+      count: sql<number>`count(*)`,
+    })
+    .from(backupSnapshots)
+    .groupBy(backupSnapshots.storageIdentity);
+
+  let unreachable = 0;
+  for (const row of usage) {
+    // A NULL storage_identity is not "unreachable" — it's an unresolved row
+    // the self-heal path owns.
+    if (row.storageIdentity === null) continue;
+    if (identities.has(row.storageIdentity)) continue;
+    unreachable++;
+    console.warn(`[BackupGC] unreachable identity ${row.storageIdentity}: ${row.count} rows`);
+  }
+  return unreachable;
 }
 
 /**
@@ -1102,9 +1066,17 @@ async function markLiveBackupObjects(
     // failure: an unproven system-state manifest must never be inferred as
     // "doesn't exist" — that would open the door to sweeping objects a
     // transient error only made unreachable, not orphaned.
-    // layout.json (W01) is a single object with nothing to enumerate, so it is
-    // marked live unconditionally — marking a key that does not exist is
-    // harmless, fetching it would only add a round-trip and a failure mode.
+    //
+    // #5523 bare-metal-recovery layout manifest (layout.json): a single
+    // object with nothing to enumerate, so — like the ordinary manifest key
+    // above — it is marked live UNCONDITIONALLY for every snapshotId this
+    // function is given, never fetched. This is what gives layout.json the
+    // same protection as manifest.json in every root-set case D18 W02 builds
+    // (rooted/retained roots, resolved NULL-identity roots, young orphans,
+    // and every listed manifest under the deferred-identity algorithm) —
+    // markLiveBackupObjects is the single call site all of them funnel
+    // through. Marking a key that doesn't exist is harmless; fetching it
+    // would only add a round-trip and a new failure mode.
     live.add(backupLayoutManifestKey(snapshotId));
 
     const stateManifestKey = backupSystemStateManifestKey(snapshotId);
@@ -1148,178 +1120,420 @@ async function markLiveBackupObjects(
   return live;
 }
 
+// ── Redis-backed failed-key skip set (delete-cap fairness, D18 W02) ─────────
+
+const BACKUP_GC_FAILED_KEY_TTL_SECONDS = 7 * 24 * 60 * 60;
+
+function backupGcFailedKeySetName(identityKey: string): string {
+  return `backup-gc:failed:${createHash('sha1').update(identityKey).digest('hex')}`;
+}
+
+/** Fails open to an empty set (never blocks the sweep) if Redis is unavailable or errors. */
+async function loadGcFailedKeySkipSet(identityKey: string): Promise<Set<string>> {
+  if (!isRedisAvailable()) return new Set();
+  const redis = getRedis();
+  if (!redis) return new Set();
+  try {
+    const members = await redis.smembers(backupGcFailedKeySetName(identityKey));
+    return new Set(members);
+  } catch (error) {
+    console.warn(`[BackupGC] Failed to load skip-set for identity ${identityKey} — proceeding without it:`, error);
+    return new Set();
+  }
+}
+
 /**
- * Sweep phase for one storage identity. Lists the identity's snapshot root
- * ONCE, groups it by snapshot-ID prefix, marks the live set (retained DB
- * rows + EVERY manifest-bearing snapshot in the listing — dedup-source race),
- * then applies the per-group deletion rule: manifest-bearing prefixes use the
- * existing per-object 48h grace; manifest-less prefixes are protected at
- * prefix granularity until their newest object clears
- * BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS. Throws on listing/mark failure so
- * the caller's per-identity try/catch counts it as skipped (fail-closed).
+ * Best-effort; a Redis failure here must never fail the sweep that already
+ * ran. Called from EVERY delete branch (rooted, manifest-less, retired/orphan
+ * non-manifest phase, retired/orphan manifest phase) so a persistently-locked
+ * object anywhere stops burning cap budget on repeat attempts every run.
+ *
+ * ACCEPTED APPROXIMATION (documented, not fixed): `EXPIRE` sets a TTL on the
+ * whole per-identity SET, refreshed to a full 7 days on every call that adds
+ * a new key — Redis SETs have no native per-member TTL. On a busy identity
+ * that keeps failing DIFFERENT keys, an older failed key can therefore stay
+ * excluded from the cap for longer than 7 days. Accepted because it only ever
+ * makes the sweep MORE conservative (skips more, never deletes something it
+ * shouldn't); a precise per-member TTL would need a Redis hash of
+ * `key -> expiresAt` plus a separate pruning pass — unwarranted complexity
+ * for a purely advisory cap-fairness mechanism.
+ */
+async function recordGcFailedKeys(
+  identityKey: string,
+  failedKeys: { key: string; error: string }[],
+): Promise<void> {
+  if (failedKeys.length === 0 || !isRedisAvailable()) return;
+  const redis = getRedis();
+  if (!redis) return;
+  const setKey = backupGcFailedKeySetName(identityKey);
+  try {
+    await redis.sadd(setKey, ...failedKeys.map((f) => f.key));
+    await redis.expire(setKey, BACKUP_GC_FAILED_KEY_TTL_SECONDS);
+  } catch (error) {
+    console.warn(`[BackupGC] Failed to record skip-set entries for identity ${identityKey}:`, error);
+  }
+}
+
+async function deleteCandidatesWithCap(
+  identity: { provider: string; providerConfig: unknown },
+  candidates: BackupObjectListing[],
+  cap: number,
+  skipSet: Set<string>,
+): Promise<{ deletedKeys: string[]; failedKeys: { key: string; error: string }[]; attempted: number }> {
+  const eligible = candidates.filter((c) => !skipSet.has(c.key));
+  if (eligible.length === 0 || cap <= 0) return { deletedKeys: [], failedKeys: [], attempted: 0 };
+  eligible.sort((a, b) => (a.lastModified?.getTime() ?? 0) - (b.lastModified?.getTime() ?? 0));
+  const toDelete = eligible.slice(0, cap).map((c) => c.key);
+  const result = await deleteBackupObjectKeys({ provider: identity.provider, providerConfig: identity.providerConfig, keys: toDelete });
+  // `attempted` (not `deletedKeys.length`) is what the caller charges against
+  // the per-run cap — a failed attempt still cost a real provider call this
+  // run and must not be retried unboundedly within the same run.
+  return { ...result, attempted: toDelete.length };
+}
+
+function manifestOlderThanWindow(item: BackupObjectListing, nowMs: number, windowMs: number): boolean {
+  if (!item.lastModified) return false;
+  return item.lastModified.getTime() <= nowMs - windowMs;
+}
+
+/**
+ * §3.7: pure storage-and-compute — every DB read this needs is gathered by
+ * the caller in a short DB context BEFORE this runs; every DB write this
+ * produces (self-heal, retirement-swept) is applied by the caller in a short
+ * DB context AFTER this returns. Never touches `db` itself.
  */
 async function sweepStorageIdentity(
-  identity: { id: string; provider: string; providerConfig: unknown },
+  identity: { key: string; provider: string; providerConfig: unknown },
   retainedSnapshotIds: string[],
+  nullIdentityRows: { id: string; snapshotId: string }[], // storage_identity IS NULL, configId maps to this identity
+  retiredSnapshotIds: Map<string, string>, // snapshotId -> retirement row id, sweptAt IS NULL only
   nowMs: number,
   deletesRemaining: number,
-): Promise<number> {
+  graceMs: number,
+  orphanWindowMs: number,
+  manifestlessWindowMs: number,
+  legacyHelperDeferred: boolean,
+): Promise<{
+  deleted: number;
+  retiredSweptIds: string[]; // retirement row ids CONFIRMED fully gone from THIS run's fresh listing
+  orphansSwept: number; // best-effort metric — see the accepted-approximation note above
+  selfHealRowIds: string[]; // backup_snapshots.id values to self-heal
+  unresolvedNullIdentityCount: number;
+  deletesUsed: number;
+}> {
+  assertOutsideHeldDbContext('backupGC.sweepStorageIdentity');
+
   const listing = await listBackupObjectsUnderPrefix({
     provider: identity.provider,
     providerConfig: identity.providerConfig,
     prefix: backupSnapshotRootPrefix(),
   });
-
   const groups = groupListingBySnapshotId(listing);
 
-  const snapshotIdsToMark = new Set(retainedSnapshotIds);
-  for (const snapshotId of listedManifestSnapshotIds(groups)) {
-    snapshotIdsToMark.add(snapshotId);
+  // §3.4/§3.6 P1: a NULL-identity row mapped to this identity is a root of I
+  // the moment it's RESOLVED (its manifest is found in THIS run's fresh
+  // listing) — resolution and root-membership are decided by the same check
+  // deliberately, because there is nothing to fetch/protect for a row whose
+  // object was never actually written here (unresolved): attempting to fetch
+  // a manifest key we already know is absent from the listing would only
+  // ever 404 and needlessly fail-close the whole identity. An UNRESOLVED row
+  // instead contributes only to `unresolvedNullIdentityCount`, which gates
+  // deferral below — the identity still runs today's (pre-D18) algorithm
+  // until every such row resolves or ages out via a human fixing the data.
+  // A row that IS resolved is unconditionally rooted (never subject to the
+  // orphan-window aging that a plain, row-less listed manifest would face) —
+  // that unconditional-once-resolved guarantee is the "§3.6 v3 P1" fix.
+  const resolvedNullRows = nullIdentityRows.filter((r) => groups.get(r.snapshotId)?.manifestItem);
+  const selfHealRowIds = resolvedNullRows.map((r) => r.id);
+  const unresolvedNullIdentityCount = nullIdentityRows.length - resolvedNullRows.length;
+  const alwaysRootedIds = new Set([...retainedSnapshotIds, ...resolvedNullRows.map((r) => r.snapshotId)]);
+
+  // §3.4: EITHER condition defers the WHOLE identity to exactly today's
+  // (pre-D18) algorithm — no retired/orphan reclamation at all this run.
+  const deferred = legacyHelperDeferred || unresolvedNullIdentityCount > 0;
+
+  const graceThreshold = nowMs - graceMs;
+  const manifestlessThreshold = nowMs - manifestlessWindowMs;
+  const skipSet = await loadGcFailedKeySkipSet(identity.key);
+  let deleted = 0;
+  let orphansSwept = 0;
+  let remaining = deletesRemaining;
+
+  async function sweepRootedLoose(group: BackupGcSnapshotGroup, liveSet: Set<string>): Promise<void> {
+    const candidates = group.items.filter(
+      (item) => !liveSet.has(item.key) && item.lastModified && item.lastModified.getTime() <= graceThreshold,
+    );
+    const result = await deleteCandidatesWithCap(identity, candidates, remaining, skipSet);
+    deleted += result.deletedKeys.length;
+    remaining -= result.attempted;
+    if (result.failedKeys.length > 0) await recordGcFailedKeys(identity.key, result.failedKeys);
   }
 
-  const liveSet = await markLiveBackupObjects(identity, snapshotIdsToMark);
-  if (liveSet === null) {
-    throw new Error('mark phase failed — see prior log line for the specific snapshot/manifest');
-  }
-
-  const graceThreshold = nowMs - BACKUP_GC_GRACE_MS;
-  const manifestlessThreshold = nowMs - BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS;
-  const deletableItems: BackupObjectListing[] = [];
-
-  for (const group of groups.values()) {
-    if (group.manifestItem) {
-      // Manifest-bearing prefix: existing loose-object 48h-grace rule, per object.
-      for (const item of group.items) {
-        if (liveSet.has(item.key)) continue;
-        // No last-modified data => cannot prove the grace window elapsed;
-        // skip (fail-closed per-object — never delete without age proof).
-        if (!item.lastModified) continue;
-        if (item.lastModified.getTime() > graceThreshold) continue;
-        deletableItems.push(item);
-      }
-      continue;
-    }
-
-    // Manifest-less (partial/resumable) prefix — protected at PREFIX
-    // granularity for the agent's journal lifetime. A single object
-    // with unknown age, or a newest-object age still inside the window,
-    // leaves the ENTIRE prefix untouched this run.
+  async function sweepManifestless(group: BackupGcSnapshotGroup, liveSet: Set<string>): Promise<void> {
     let newestMs: number | null = null;
     let hasUnknownAge = false;
     for (const item of group.items) {
-      if (!item.lastModified) {
-        hasUnknownAge = true;
-        break;
-      }
+      if (!item.lastModified) { hasUnknownAge = true; break; }
       const ms = item.lastModified.getTime();
       if (newestMs === null || ms > newestMs) newestMs = ms;
     }
-    if (hasUnknownAge || newestMs === null || newestMs > manifestlessThreshold) {
-      continue; // whole prefix protected this run
-    }
+    if (hasUnknownAge || newestMs === null || newestMs > manifestlessThreshold) return;
+    const candidates = group.items.filter((item) => !liveSet.has(item.key));
+    const result = await deleteCandidatesWithCap(identity, candidates, remaining, skipSet);
+    deleted += result.deletedKeys.length;
+    remaining -= result.attempted;
+    if (result.failedKeys.length > 0) await recordGcFailedKeys(identity.key, result.failedKeys);
+  }
 
-    // Every object under a manifest-less prefix is provably unreferenced —
-    // dedup only ever bases a reference off a COMPLETED (manifest-bearing)
-    // snapshot (see deleteSnapshotRow's comment above), so nothing here can
-    // be "live". The liveSet check below is pure defense-in-depth.
-    for (const item of group.items) {
-      if (liveSet.has(item.key)) continue;
-      deletableItems.push(item);
+  // Retired (any age) OR old-orphan two-phase reclaim. Also handles a
+  // "manifest-less retired remnant" (manifest already gone from a prior run)
+  // — in that case there is no manifest-gating to do, just delete everything
+  // non-live in one phase. Never sets swept_at itself.
+  async function reclaimUnrooted(group: BackupGcSnapshotGroup, liveSet: Set<string>): Promise<void> {
+    const manifestKey = group.manifestItem?.key;
+    const nonManifestNonLive = group.items.filter((item) => !liveSet.has(item.key) && item.key !== manifestKey);
+    const nonManifestResult = await deleteCandidatesWithCap(identity, nonManifestNonLive, remaining, skipSet);
+    deleted += nonManifestResult.deletedKeys.length;
+    remaining -= nonManifestResult.attempted;
+    if (nonManifestResult.failedKeys.length > 0) await recordGcFailedKeys(identity.key, nonManifestResult.failedKeys);
+
+    if (!group.manifestItem) return; // manifest-less remnant — nothing further to gate
+
+    // v3 manifest-last rule: candidate only when NO deletable non-manifest
+    // key remains — none failed, none capped, none skip-set-excluded.
+    const remainingNonManifest = nonManifestNonLive.filter((item) => !nonManifestResult.deletedKeys.includes(item.key));
+    if (remainingNonManifest.length === 0 && !liveSet.has(manifestKey!) && remaining > 0) {
+      const manifestResult = await deleteCandidatesWithCap(identity, [group.manifestItem], remaining, skipSet);
+      deleted += manifestResult.deletedKeys.length;
+      remaining -= manifestResult.attempted;
+      if (manifestResult.failedKeys.length > 0) await recordGcFailedKeys(identity.key, manifestResult.failedKeys);
     }
   }
 
-  if (deletableItems.length === 0 || deletesRemaining <= 0) {
-    return 0;
+  if (deferred) {
+    // Exactly today's (pre-D18) algorithm. EVERY listed manifest is a root,
+    // not just DB-rooted ids.
+    const everyListedManifestIds: string[] = [];
+    for (const [snapshotId, group] of groups) if (group.manifestItem) everyListedManifestIds.push(snapshotId);
+    const rootsForMark = new Set([...alwaysRootedIds, ...everyListedManifestIds]);
+    const liveSet = await markLiveBackupObjects(identity, rootsForMark);
+    if (liveSet === null) throw new Error('mark phase failed — see prior log line for the specific snapshot/manifest');
+
+    for (const [, group] of groups) {
+      if (remaining <= 0) break;
+      if (group.manifestItem) await sweepRootedLoose(group, liveSet);
+      else await sweepManifestless(group, liveSet);
+    }
+  } else {
+    const orphanIds = orphanManifestSnapshotIds(groups, alwaysRootedIds, retiredSnapshotIds, nowMs, orphanWindowMs);
+    const rootsForMark = new Set([...alwaysRootedIds, ...orphanIds]);
+    const liveSet = await markLiveBackupObjects(identity, rootsForMark);
+    if (liveSet === null) throw new Error('mark phase failed — see prior log line for the specific snapshot/manifest');
+
+    for (const [snapshotId, group] of groups) {
+      if (remaining <= 0) break;
+      if (rootsForMark.has(snapshotId)) { await sweepRootedLoose(group, liveSet); continue; }
+      if (retiredSnapshotIds.has(snapshotId)) { await reclaimUnrooted(group, liveSet); continue; }
+      if (!group.manifestItem) { await sweepManifestless(group, liveSet); continue; }
+      if (!manifestOlderThanWindow(group.manifestItem, nowMs, orphanWindowMs)) continue; // defensive; unreachable given rootsForMark
+      const before = deleted;
+      await reclaimUnrooted(group, liveSet);
+      if (deleted > before) orphansSwept++; // best-effort metric — see accepted approximation
+    }
   }
 
-  // Oldest-first so hitting the cap mid-identity always clears the
-  // longest-standing garbage first; the remainder is simply picked up again
-  // (still unreferenced/still past its window) on the next run.
-  deletableItems.sort((a, b) => (a.lastModified as Date).getTime() - (b.lastModified as Date).getTime());
-  const toDelete = deletableItems.slice(0, deletesRemaining).map((item) => item.key);
+  // swept_at confirmation — independent of `deferred`, and independent of
+  // whatever this run deleted: a retirement is confirmed gone ONLY when
+  // THIS run's fresh listing has NO group at all for its snapshotId.
+  const retiredSweptIds: string[] = [];
+  for (const [snapshotId, retirementId] of retiredSnapshotIds) {
+    if (!groups.has(snapshotId)) retiredSweptIds.push(retirementId);
+  }
 
-  const { deletedKeys, failedKeys } = await deleteBackupObjectKeys({
-    provider: identity.provider,
-    providerConfig: identity.providerConfig,
-    keys: toDelete,
+  return { deleted, retiredSweptIds, orphansSwept, selfHealRowIds, unresolvedNullIdentityCount, deletesUsed: deletesRemaining - remaining };
+}
+
+/**
+ * Capability gate (§3.4 v3): devices considered for an identity are those
+ * with a backup_jobs row on it (via storageIdentity match, OR
+ * storageIdentity IS NULL with configId in this identity's configs, for
+ * legacy jobs predating the column) that are pending/running (any age) or
+ * created within the last 30 days. If ANY such device's helper is below
+ * BACKUP_SERVER_BASE_MIN_HELPER_VERSION, the whole identity defers.
+ */
+async function identityHasLegacyHelper(
+  identity: { key: string; configIds: string[] },
+  nowMs: number,
+): Promise<{ deferred: boolean; deviceId?: string; version?: string | null }> {
+  const cutoff = new Date(nowMs - 30 * 24 * 60 * 60 * 1000);
+  const rows = await db
+    .selectDistinct({ deviceId: backupJobs.deviceId, backupVersion: devices.backupVersion })
+    .from(backupJobs)
+    .innerJoin(devices, eq(backupJobs.deviceId, devices.id))
+    .where(and(
+      or(
+        eq(backupJobs.storageIdentity, identity.key),
+        and(isNull(backupJobs.storageIdentity), inArray(backupJobs.configId, identity.configIds)),
+      ),
+      or(inArray(backupJobs.status, IN_FLIGHT_BACKUP_JOB_STATUSES), gte(backupJobs.createdAt, cutoff)),
+    ));
+
+  for (const row of rows) {
+    if (!backupHelperSupportsServerBase(row.backupVersion)) {
+      return { deferred: true, deviceId: row.deviceId ?? undefined, version: row.backupVersion };
+    }
+  }
+  return { deferred: false };
+}
+
+/** Per-identity DB reads gathered in ONE short system context, per §3.7. */
+async function loadIdentityGcState(
+  identity: BackupGcStorageIdentity,
+  nowMs: number,
+): Promise<{
+  retainedSnapshotIds: string[];
+  nullIdentityRows: { id: string; snapshotId: string }[];
+  retiredSnapshotIds: Map<string, string>;
+  legacyHelper: { deferred: boolean; deviceId?: string; version?: string | null };
+}> {
+  return withSystemDbAccessContext(async () => {
+    // Storage-identity-scoped retained set — deliberately NOT filtered by
+    // backupType (every mode publishes snapshots/<id>/manifest.json — the
+    // spec's own investigation found the file's earlier "hyperv/mssql use a
+    // different namespace" comment factually wrong; see the PR description
+    // for the reasoning) and NOT filtered by configId (storage_identity is
+    // denormalized onto the row at publish time, so it survives a later
+    // providerConfig edit).
+    const retainedRows = await db
+      .select({ snapshotId: backupSnapshots.snapshotId })
+      .from(backupSnapshots)
+      .where(eq(backupSnapshots.storageIdentity, identity.key));
+
+    // P1 fix: fetch the primary key `id`, not just `snapshotId` — snapshot_id
+    // is NOT unique across identities, so the self-heal write-back below
+    // must never match on snapshot_id alone.
+    const nullIdentityRows = await db
+      .select({ id: backupSnapshots.id, snapshotId: backupSnapshots.snapshotId })
+      .from(backupSnapshots)
+      .where(and(isNull(backupSnapshots.storageIdentity), inArray(backupSnapshots.configId, identity.configIds)));
+
+    const retirementRows = await db
+      .select({ id: backupSnapshotRetirements.id, snapshotId: backupSnapshotRetirements.snapshotId })
+      .from(backupSnapshotRetirements)
+      .where(and(eq(backupSnapshotRetirements.storageIdentity, identity.key), isNull(backupSnapshotRetirements.sweptAt)));
+
+    const legacyHelper = await identityHasLegacyHelper(identity, nowMs);
+
+    return {
+      retainedSnapshotIds: retainedRows.map((r) => r.snapshotId),
+      nullIdentityRows,
+      retiredSnapshotIds: new Map(retirementRows.map((r) => [r.snapshotId, r.id])),
+      legacyHelper,
+    };
   });
+}
 
-  if (failedKeys.length > 0) {
-    console.warn(
-      `[BackupGC] Identity ${identity.id}: ${failedKeys.length} object delete(s) rejected (e.g. object-lock) — left in place: ${failedKeys.map((f) => f.key).join(', ')}`,
-    );
-  }
+/** Per-identity DB writes applied in ONE short system context, per §3.7 — always AFTER every storage call for this identity has already returned. */
+async function applyIdentityGcWriteBacks(
+  identity: { key: string },
+  writeBacks: { retiredSweptIds: string[]; selfHealRowIds: string[] },
+): Promise<void> {
+  if (writeBacks.retiredSweptIds.length === 0 && writeBacks.selfHealRowIds.length === 0) return;
+  await withSystemDbAccessContext(async () => {
+    for (const retirementId of writeBacks.retiredSweptIds) {
+      await db.update(backupSnapshotRetirements).set({ sweptAt: new Date() }).where(eq(backupSnapshotRetirements.id, retirementId));
+    }
+    if (writeBacks.selfHealRowIds.length > 0) {
+      // P1 fix: heal by PRIMARY ROW ID, guarded by storage_identity IS NULL —
+      // matching on snapshot_id alone could re-stamp a DIFFERENT identity's
+      // row sharing the same agent-generated snapshot id; the IS NULL guard
+      // also protects against re-stamping a row a concurrent run just healed.
+      await db
+        .update(backupSnapshots)
+        .set({ storageIdentity: identity.key })
+        .where(and(inArray(backupSnapshots.id, writeBacks.selfHealRowIds), isNull(backupSnapshots.storageIdentity)));
+    }
+  });
+}
 
-  return deletedKeys.length;
+async function pruneSweptRetirements(nowMs: number): Promise<void> {
+  await withSystemDbAccessContext(async () => {
+    const cutoff = new Date(nowMs - 30 * 24 * 60 * 60 * 1000);
+    const deletedRows = await db
+      .delete(backupSnapshotRetirements)
+      .where(and(isNotNull(backupSnapshotRetirements.sweptAt), lt(backupSnapshotRetirements.sweptAt, cutoff)))
+      .returning({ id: backupSnapshotRetirements.id });
+    if (deletedRows.length > 0) console.log(`[BackupGC] Pruned ${deletedRows.length} swept retirement row(s) older than 30 days`);
+  });
 }
 
 /**
  * Mark-and-sweep GC over every backup storage identity (provider + endpoint +
  * bucket, grouped across backupConfigs rows). Per-identity failure isolation:
  * one bad/unreachable identity never blocks GC for the others. Bounded total
- * deletes per run (BACKUP_GC_MAX_DELETES_PER_RUN,
- * default 2000, 0 = unlimited) — hitting the cap mid-run just stops cleanly;
- * the sweep is resumable by construction.
+ * deletes per run (BACKUP_GC_MAX_DELETES_PER_RUN, default 2000, 0 =
+ * unlimited) — hitting the cap mid-run just stops cleanly; the sweep is
+ * resumable by construction.
  *
  * Fail-closed on unattributed rows: a backup_snapshots row with a NULL
  * config_id can't be mapped to any storage identity, so we can't rule out
  * that its (unknown) objects live in a bucket we're about to sweep. Its mere
- * existence blocks the ENTIRE run, not just one identity — there is no safe,
- * narrower attribution to fall back on.
+ * existence blocks the ENTIRE run.
+ *
+ * Name and signature deliberately unchanged from pre-D18 — W01's
+ * backupWorker.ts call site depends on this exact export.
  */
 export async function sweepUnreferencedBackupObjects(): Promise<BackupGcResult> {
   const nowMs = Date.now();
+  const graceMs = resolveBackupGcGraceMs();
+  const orphanWindowMs = Math.max(resolveBackupOrphanManifestMaxAgeMs(), resolveBackupBaseLeaseMs() + graceMs);
+  const manifestlessWindowMs = resolveBackupManifestlessPrefixMaxAgeMs();
 
-  const unattributedRows = await db
-    .select({ id: backupSnapshots.id })
-    .from(backupSnapshots)
-    .where(isNull(backupSnapshots.configId));
+  const { unattributedCount, identities, unreachableIdentities } = await withSystemDbAccessContext(async () => {
+    const unattributedRows = await db.select({ id: backupSnapshots.id }).from(backupSnapshots).where(isNull(backupSnapshots.configId));
+    const destinations = await db
+      .select({ id: backupConfigs.id, provider: backupConfigs.provider, providerConfig: backupConfigs.providerConfig })
+      .from(backupConfigs);
+    const identitiesInner = groupBackupConfigsByStorageIdentity(destinations);
+    const unreachable = await logUnreachableStorageIdentities(identitiesInner);
+    return { unattributedCount: unattributedRows.length, identities: identitiesInner, unreachableIdentities: unreachable };
+  });
 
-  const destinations = await db
-    .select({
-      id: backupConfigs.id,
-      provider: backupConfigs.provider,
-      providerConfig: backupConfigs.providerConfig,
-    })
-    .from(backupConfigs);
+  await pruneSweptRetirements(nowMs);
 
-  const identities = groupBackupConfigsByStorageIdentity(destinations);
-
-  if (unattributedRows.length > 0) {
+  if (unattributedCount > 0) {
     // Ops-visible (console.error, not debug) and states the remediation:
-    // nothing about this self-heals. Someone has to either attribute the
-    // row (backfill its config_id) or confirm it's truly orphaned and
-    // delete the row — until then, EVERY GC run is a no-op.
+    // nothing about this self-heals.
     const wedgeMessage =
-      `[BackupGC] ${unattributedRows.length} backup_snapshots row(s) have no config_id — cannot attribute to a ` +
+      `[BackupGC] ${unattributedCount} backup_snapshots row(s) have no config_id — cannot attribute to a ` +
       `storage identity, so their objects could live in ANY bucket. Blocking ALL ${identities.size} identity ` +
       `sweep(s) this run (fail-closed). REMEDIATION REQUIRED: this does not self-heal — attribute the affected ` +
       `row(s) to the correct backup_configs.id, or confirm they're orphaned and delete the row(s), then GC will ` +
       `resume on its next run.`;
     console.error(wedgeMessage);
-    // Permanently-wedged, non-self-healing state — surface to Sentry once per
-    // run (not per row) so a stuck GC is visible beyond the worker's stdout.
     captureException(new Error(wedgeMessage));
     console.log(`[BackupGC] Run complete: deleted 0 object(s), ${identities.size} identity/identities skipped`);
-    return { deleted: 0, skippedIdentities: identities.size, blockedIdentities: 0 };
+    return {
+      deleted: 0, skippedIdentities: identities.size, blockedIdentities: 0,
+      retiredSwept: 0, orphansSwept: 0, deferredIdentities: 0, unreachableIdentities,
+    };
   }
 
   const suspiciousIdentityKeys = detectSuspiciousStorageIdentityCollisions(identities);
   if (suspiciousIdentityKeys.size > 0) {
-    // Fail-closed exclusion already logged loudly per coarse group above;
-    // escalate once to Sentry so the misconfiguration isn't stdout-only.
-    captureException(
-      new Error(
-        `[BackupGC] ${suspiciousIdentityKeys.size} storage identity/identities excluded this run: a cruder ` +
-        `bucket+host comparison collapses identities normalizeStorageIdentity kept apart — likely an ` +
-        `unhandled cosmetic config variant.`,
-      ),
-    );
+    captureException(new Error(
+      `[BackupGC] ${suspiciousIdentityKeys.size} storage identity/identities excluded this run: a cruder ` +
+      `bucket+host comparison collapses identities normalizeStorageIdentity kept apart — likely an ` +
+      `unhandled cosmetic config variant.`,
+    ));
   }
 
   let deleted = 0;
   let skippedIdentities = 0;
   let blockedIdentities = 0;
+  let retiredSwept = 0;
+  let orphansSwept = 0;
+  let deferredIdentities = 0;
   let deletesRemaining = resolveBackupGcMaxDeletesPerRun();
 
   for (const identity of identities.values()) {
@@ -1330,7 +1544,7 @@ export async function sweepUnreferencedBackupObjects(): Promise<BackupGcResult> 
 
     if (suspiciousIdentityKeys.has(identity.key)) {
       skippedIdentities++;
-      continue; // detectSuspiciousStorageIdentityCollisions already logged the error
+      continue;
     }
 
     if (!BACKUP_GC_SUPPORTED_PROVIDERS.has(identity.provider)) {
@@ -1342,51 +1556,43 @@ export async function sweepUnreferencedBackupObjects(): Promise<BackupGcResult> 
     }
 
     try {
-      // Only backupTypes in BACKUP_GC_RETAINED_MANIFEST_BACKUP_TYPES (file,
-      // system_image — plus NULL, legacy rows predating the column) use the
-      // snapshots/<id>/manifest.json layout the mark phase fetches. hyperv
-      // (backupType 'application') / mssql (backupType 'database') snapshots
-      // write their manifests to DIFFERENT keys and never share the
-      // snapshots/ namespace, so fetching snapshots/<id>/manifest.json for
-      // them 404s and fail-closes the WHOLE identity forever (a single such
-      // row sharing a bucket with file backups would silently wedge GC).
-      // Excluding THOSE here confines GC to the layout it actually
-      // understands — see BACKUP_GC_RETAINED_MANIFEST_BACKUP_TYPES' doc
-      // comment for why system_image is no longer in that excluded set.
-      const retainedRows = await db
-        .select({ snapshotId: backupSnapshots.snapshotId })
-        .from(backupSnapshots)
-        .where(
-          and(
-            inArray(backupSnapshots.configId, identity.configIds),
-            or(
-              inArray(backupSnapshots.backupType, RETAINABLE_BACKUP_TYPES_FOR_GC),
-              isNull(backupSnapshots.backupType),
-            ),
-          ),
-        );
-      const retainedSnapshotIds = retainedRows.map((row) => row.snapshotId);
+      const state = await loadIdentityGcState(identity, nowMs);
+      if (state.legacyHelper.deferred) {
+        deferredIdentities++;
+        console.warn(`[BackupGC] reclamation deferred: legacy helper ${state.legacyHelper.deviceId} ${state.legacyHelper.version}`);
+      }
 
-      const identityDeleted = await sweepStorageIdentity(
-        { id: identity.key, provider: identity.provider, providerConfig: identity.providerConfig },
-        retainedSnapshotIds,
-        nowMs,
-        deletesRemaining,
+      const identityResult = await sweepStorageIdentity(
+        identity, state.retainedSnapshotIds, state.nullIdentityRows, state.retiredSnapshotIds,
+        nowMs, deletesRemaining, graceMs, orphanWindowMs, manifestlessWindowMs,
+        state.legacyHelper.deferred,
       );
-      deleted += identityDeleted;
-      deletesRemaining -= identityDeleted;
 
-      if (identityDeleted > 0) {
-        console.log(`[BackupGC] Identity ${identity.key}: deleted ${identityDeleted} unreferenced object(s)`);
+      if (identityResult.unresolvedNullIdentityCount > 0) {
+        console.warn(`[BackupGC] identity deferred: ${identityResult.unresolvedNullIdentityCount} unresolved rows`);
+        if (!state.legacyHelper.deferred) deferredIdentities++; // avoid double-counting one identity for both reasons
+      }
+
+      deleted += identityResult.deleted;
+      retiredSwept += identityResult.retiredSweptIds.length;
+      orphansSwept += identityResult.orphansSwept;
+      deletesRemaining -= identityResult.deletesUsed;
+
+      await applyIdentityGcWriteBacks(identity, {
+        retiredSweptIds: identityResult.retiredSweptIds,
+        selfHealRowIds: identityResult.selfHealRowIds,
+      });
+
+      if (identityResult.deleted > 0) {
+        console.log(`[BackupGC] Identity ${identity.key}: deleted ${identityResult.deleted} object(s)`);
       } else {
         console.debug(`[BackupGC] Identity ${identity.key}: 0 objects deleted`);
       }
     } catch (error) {
       // A sweep abort here is the fail-closed mark/list failure path (an
-      // unfetchable/unparseable FILE-type manifest). Count it as BOTH skipped
-      // (broad "not swept" total) and blocked (the distinct signal that a
-      // genuine, non-self-healing storage leak may be accumulating for this
-      // identity — vs. the benign unsupported-provider/collision skips).
+      // unfetchable/unparseable manifest). Count it as BOTH skipped (broad
+      // "not swept" total) and blocked (the distinct signal that a genuine,
+      // non-self-healing storage leak may be accumulating for this identity).
       skippedIdentities++;
       blockedIdentities++;
       console.error(`[BackupGC] Identity ${identity.key}: sweep failed — isolated, other identities proceed:`, error);
@@ -1395,9 +1601,10 @@ export async function sweepUnreferencedBackupObjects(): Promise<BackupGcResult> 
   }
 
   console.log(
-    `[BackupGC] Run complete: deleted ${deleted} object(s), ${skippedIdentities} identity/identities skipped` +
-    (blockedIdentities > 0 ? ` (${blockedIdentities} blocked by unfetchable manifest — fail-closed)` : ''),
+    `[BackupGC] Run complete: deleted ${deleted} object(s), ${retiredSwept} retirement(s) confirmed swept, ` +
+    `${orphansSwept} orphan(s) swept, ${skippedIdentities} identity/identities skipped, ${deferredIdentities} deferred, ` +
+    `${unreachableIdentities} unreachable` + (blockedIdentities > 0 ? ` (${blockedIdentities} blocked by unfetchable manifest — fail-closed)` : ''),
   );
 
-  return { deleted, skippedIdentities, blockedIdentities };
+  return { deleted, skippedIdentities, blockedIdentities, retiredSwept, orphansSwept, deferredIdentities, unreachableIdentities };
 }

--- a/apps/api/src/jobs/backupRetention.ts
+++ b/apps/api/src/jobs/backupRetention.ts
@@ -7,6 +7,7 @@
  */
 
 import { resolve as resolveLocalPath } from 'node:path';
+import { realpath as fsRealpath } from 'node:fs/promises';
 import { db, withSystemDbAccessContext, assertOutsideHeldDbContext } from '../db';
 import {
   backupSnapshots,
@@ -862,35 +863,70 @@ function groupBackupConfigsByStorageIdentity(
 }
 
 /**
+ * Coarse signature for alias detection — deliberately CRUDER than
+ * normalizeStorageIdentity, to catch a physical-location alias it doesn't
+ * yet know to collapse. Parses the ALREADY-NORMALIZED identity key string
+ * (not raw providerConfig), so the SAME function works both for a live
+ * identity object (built from a current backupConfigs row) and for a bare,
+ * STALE identity string pulled from `backup_snapshots.storage_identity` that
+ * no longer has any config behind it at all (review round 1 finding: an
+ * edited-away config's old identity is exactly the case
+ * detectSuspiciousStorageIdentityCollisions could never see, since it only
+ * ever iterated CURRENT configs).
+ *
+ * s3: bucket lowercased, endpoint reduced to host-only (port dropped) — a
+ * cruder collapse than normalizeStorageIdentity's own (virtual-hosted vs
+ * path-style, an IP vs its hostname, or a non-default port some
+ * self-hosted/MinIO deployments ignore).
+ * local: resolved via the REAL filesystem (`fs.realpath`, follows symlinks
+ * and bind mounts) — normalizeStorageIdentity's own `path.resolve` is purely
+ * LEXICAL and does not collapse a symlink/bind-mount alias, which is exactly
+ * review round 1's second finding (local was previously exempted from this
+ * check entirely). A path that doesn't exist yet (fresh config, no backups
+ * written) or can't be stat'd falls back to its lexically-resolved form —
+ * fail toward "can't prove a collision" here, never toward crashing the run.
+ */
+async function coarseStorageSignatureFromKey(key: string): Promise<string> {
+  if (key.startsWith('local::')) {
+    const rawPath = key.slice('local::'.length);
+    if (!rawPath) return 'local::';
+    try {
+      return `local::${await fsRealpath(rawPath)}`;
+    } catch {
+      return `local::${rawPath}`;
+    }
+  }
+  // Normalized non-local keys are always `${provider}::${endpoint}::${bucket}`
+  // (see normalizeStorageIdentity) — endpoint never itself contains `::`, so
+  // splitting on the first two occurrences and rejoining the remainder keeps
+  // this correct even in the (S3-illegal, but not worth crashing over) event
+  // a bucket name were to contain the separator.
+  const [provider = '', endpoint = '', ...bucketParts] = key.split('::');
+  const bucket = bucketParts.join('::').toLowerCase();
+  const hostOnly = endpoint.split(':')[0];
+  return `${provider}::${hostOnly}::${bucket}`;
+}
+
+/**
  * Belt-and-braces: even after normalizeStorageIdentity, an unanticipated
  * cosmetic variant could still produce two DIFFERENT identity keys for the
- * SAME physical bucket. Cross-check with a CRUDER comparison and fail-closed
- * (exclude ALL of them) if it collapses two identities normalizeStorageIdentity
- * kept apart.
+ * SAME physical bucket/directory — among CURRENT configs. Cross-check every
+ * identity (S3 AND local, review round 1: local was previously skipped
+ * entirely) with the cruder coarseStorageSignatureFromKey comparison and
+ * fail-closed (exclude ALL of them) if it collapses two identities
+ * normalizeStorageIdentity kept apart. This catches two live configs
+ * aliasing each other; it does NOT catch a config that was EDITED AWAY from
+ * an identity old rows still carry — see the separate stale-alias check in
+ * sweepUnreferencedBackupObjects, which uses this same coarse signature
+ * against `logUnreachableStorageIdentities`'s output.
  */
-function detectSuspiciousStorageIdentityCollisions(
+async function detectSuspiciousStorageIdentityCollisions(
   identities: Map<string, BackupGcStorageIdentity>,
-): Set<string> {
+): Promise<Set<string>> {
   const coarseGroups = new Map<string, Set<string>>();
 
   for (const identity of identities.values()) {
-    if (identity.provider === 'local') continue;
-
-    const providerConfig = asRecord(identity.providerConfig);
-    const bucket = (getStringValue(providerConfig, 'bucket') || getStringValue(providerConfig, 'bucketName') || '')
-      .trim()
-      .toLowerCase();
-    const rawEndpoint = getStringValue(providerConfig, 'endpoint');
-    let hostOnly = '';
-    if (rawEndpoint?.trim()) {
-      try {
-        hostOnly = new URL(rawEndpoint.includes('://') ? rawEndpoint : `https://${rawEndpoint}`).hostname.toLowerCase();
-      } catch {
-        hostOnly = rawEndpoint.trim().toLowerCase();
-      }
-    }
-    const coarseKey = `${identity.provider}::${hostOnly}::${bucket}`;
-
+    const coarseKey = await coarseStorageSignatureFromKey(identity.key);
     let identityKeys = coarseGroups.get(coarseKey);
     if (!identityKeys) {
       identityKeys = new Set();
@@ -904,9 +940,9 @@ function detectSuspiciousStorageIdentityCollisions(
     if (identityKeys.size <= 1) continue;
     console.error(
       `[BackupGC] ${identityKeys.size} DIFFERENT normalized storage identities (${[...identityKeys].join(', ')}) ` +
-      `all resolve to the same bucket+host (${coarseKey}) under a cruder comparison — normalizeStorageIdentity ` +
+      `all resolve to the same physical location (${coarseKey}) under a cruder comparison — normalizeStorageIdentity ` +
       `likely missed a cosmetic variant. Excluding all of them from this run (fail-closed) to avoid two ` +
-      `overlapping sweeps on the same physical bucket.`,
+      `overlapping sweeps on the same physical bucket/directory.`,
     );
     for (const key of identityKeys) suspicious.add(key);
   }
@@ -986,12 +1022,24 @@ export function orphanManifestSnapshotIds(
  * survives a later providerConfig edit. An identity with rows but no current
  * config producing that exact key is unreachable — it is never listed (no
  * config = no provider/providerConfig to list with), so it leaks silently
- * unless logged here. This is visibility only; reclaiming an unreachable
- * identity needs manual tooling (deferred).
+ * unless logged here.
+ *
+ * Review round 1 finding: this used to be visibility-only (a warning, no
+ * effect on the run). That's unsafe — an edited config (e.g. a virtual-hosted
+ * vs path-style S3 endpoint, or an IP swapped for its hostname) can produce a
+ * DIFFERENT normalized identity string while pointing at the SAME physical
+ * bucket. Rows still carrying the OLD string become unreachable by this
+ * function's own definition, but their objects are NOT actually gone — they
+ * sit in the bucket the NEW identity is about to sweep, invisible to the
+ * NEW identity's root query, and (once old enough) indistinguishable from
+ * genuine orphan garbage. Returning the unreachable KEYS (not just a count)
+ * lets the caller cross-check each identity it's about to sweep against
+ * them via coarseStorageSignatureFromKey and defer instead of reclaim on a
+ * coarse match — see sweepUnreferencedBackupObjects.
  */
 async function logUnreachableStorageIdentities(
   identities: Map<string, BackupGcStorageIdentity>,
-): Promise<number> {
+): Promise<{ count: number; keys: string[] }> {
   const usage = await db
     .select({
       storageIdentity: backupSnapshots.storageIdentity,
@@ -1000,16 +1048,16 @@ async function logUnreachableStorageIdentities(
     .from(backupSnapshots)
     .groupBy(backupSnapshots.storageIdentity);
 
-  let unreachable = 0;
+  const keys: string[] = [];
   for (const row of usage) {
     // A NULL storage_identity is not "unreachable" — it's an unresolved row
     // the self-heal path owns.
     if (row.storageIdentity === null) continue;
     if (identities.has(row.storageIdentity)) continue;
-    unreachable++;
+    keys.push(row.storageIdentity);
     console.warn(`[BackupGC] unreachable identity ${row.storageIdentity}: ${row.count} rows`);
   }
-  return unreachable;
+  return { count: keys.length, keys };
 }
 
 /**
@@ -1223,6 +1271,10 @@ async function sweepStorageIdentity(
   orphansSwept: number; // best-effort metric — see the accepted-approximation note above
   selfHealRowIds: string[]; // backup_snapshots.id values to self-heal
   unresolvedNullIdentityCount: number;
+  // Review round 1: an operator seeing "N unresolved rows" in the log has
+  // nothing to query. These are the actual snapshot ids so the deferral is
+  // actionable (`SELECT * FROM backup_snapshots WHERE snapshot_id IN (...)`).
+  unresolvedSnapshotIds: string[];
   deletesUsed: number;
 }> {
   assertOutsideHeldDbContext('backupGC.sweepStorageIdentity');
@@ -1248,8 +1300,10 @@ async function sweepStorageIdentity(
   // orphan-window aging that a plain, row-less listed manifest would face) —
   // that unconditional-once-resolved guarantee is the "§3.6 v3 P1" fix.
   const resolvedNullRows = nullIdentityRows.filter((r) => groups.get(r.snapshotId)?.manifestItem);
+  const unresolvedNullRows = nullIdentityRows.filter((r) => !groups.get(r.snapshotId)?.manifestItem);
   const selfHealRowIds = resolvedNullRows.map((r) => r.id);
-  const unresolvedNullIdentityCount = nullIdentityRows.length - resolvedNullRows.length;
+  const unresolvedNullIdentityCount = unresolvedNullRows.length;
+  const unresolvedSnapshotIds = unresolvedNullRows.map((r) => r.snapshotId);
   const alwaysRootedIds = new Set([...retainedSnapshotIds, ...resolvedNullRows.map((r) => r.snapshotId)]);
 
   // §3.4: EITHER condition defers the WHOLE identity to exactly today's
@@ -1334,6 +1388,21 @@ async function sweepStorageIdentity(
     const liveSet = await markLiveBackupObjects(identity, rootsForMark);
     if (liveSet === null) throw new Error('mark phase failed — see prior log line for the specific snapshot/manifest');
 
+    // Review round 1 (suggestion, accepted as a known limitation rather than
+    // fixed): the per-run cap is spent in LISTING order across groups here
+    // (each group's own candidates are sorted oldest-first internally, via
+    // deleteCandidatesWithCap, but there is no global oldest-first ordering
+    // ACROSS groups within this identity, unlike the pre-D18 implementation
+    // which collected every deletable item for the whole identity before
+    // sorting once). A busy, recently-modified retired/orphan prefix
+    // appearing early in the listing can therefore exhaust the cap before an
+    // older, more overdue prefix later in iteration order is even reached.
+    // Not fixed this wave: the identity-wide collect-then-sort shape doesn't
+    // compose cleanly with the two-phase (non-manifest, then manifest)
+    // per-group rule without buffering every candidate across every group
+    // before deciding anything — a larger restructure than this finding
+    // warrants on its own. The garbage is never lost, only delayed to a
+    // later run (the sweep is resumable by construction either way).
     for (const [snapshotId, group] of groups) {
       if (remaining <= 0) break;
       if (rootsForMark.has(snapshotId)) { await sweepRootedLoose(group, liveSet); continue; }
@@ -1354,7 +1423,11 @@ async function sweepStorageIdentity(
     if (!groups.has(snapshotId)) retiredSweptIds.push(retirementId);
   }
 
-  return { deleted, retiredSweptIds, orphansSwept, selfHealRowIds, unresolvedNullIdentityCount, deletesUsed: deletesRemaining - remaining };
+  return {
+    deleted, retiredSweptIds, orphansSwept, selfHealRowIds,
+    unresolvedNullIdentityCount, unresolvedSnapshotIds,
+    deletesUsed: deletesRemaining - remaining,
+  };
 }
 
 /**
@@ -1493,14 +1566,19 @@ export async function sweepUnreferencedBackupObjects(): Promise<BackupGcResult> 
   const orphanWindowMs = Math.max(resolveBackupOrphanManifestMaxAgeMs(), resolveBackupBaseLeaseMs() + graceMs);
   const manifestlessWindowMs = resolveBackupManifestlessPrefixMaxAgeMs();
 
-  const { unattributedCount, identities, unreachableIdentities } = await withSystemDbAccessContext(async () => {
+  const { unattributedCount, identities, unreachableIdentities, unreachableIdentityKeys } = await withSystemDbAccessContext(async () => {
     const unattributedRows = await db.select({ id: backupSnapshots.id }).from(backupSnapshots).where(isNull(backupSnapshots.configId));
     const destinations = await db
       .select({ id: backupConfigs.id, provider: backupConfigs.provider, providerConfig: backupConfigs.providerConfig })
       .from(backupConfigs);
     const identitiesInner = groupBackupConfigsByStorageIdentity(destinations);
     const unreachable = await logUnreachableStorageIdentities(identitiesInner);
-    return { unattributedCount: unattributedRows.length, identities: identitiesInner, unreachableIdentities: unreachable };
+    return {
+      unattributedCount: unattributedRows.length,
+      identities: identitiesInner,
+      unreachableIdentities: unreachable.count,
+      unreachableIdentityKeys: unreachable.keys,
+    };
   });
 
   await pruneSweptRetirements(nowMs);
@@ -1523,13 +1601,27 @@ export async function sweepUnreferencedBackupObjects(): Promise<BackupGcResult> 
     };
   }
 
-  const suspiciousIdentityKeys = detectSuspiciousStorageIdentityCollisions(identities);
+  const suspiciousIdentityKeys = await detectSuspiciousStorageIdentityCollisions(identities);
   if (suspiciousIdentityKeys.size > 0) {
     captureException(new Error(
       `[BackupGC] ${suspiciousIdentityKeys.size} storage identity/identities excluded this run: a cruder ` +
       `bucket+host comparison collapses identities normalizeStorageIdentity kept apart — likely an ` +
       `unhandled cosmetic config variant.`,
     ));
+  }
+
+  // Review round 1 (CRITICAL): a config edit can change the NORMALIZED
+  // identity string while still pointing at the same physical bucket/
+  // directory — old rows keep the old string, which logUnreachableStorageIdentities
+  // reports but (until this fix) never acted on. Cross-checking every
+  // identity we're about to sweep against the COARSE signature of every
+  // unreachable (stale) identity catches this: a coarse match means "this
+  // bucket/directory may still hold objects a stale identity string's rows
+  // still reference", so that identity is forced into the deferred
+  // (rooted-prefix-rule-only) path instead of reclaiming anything unrooted.
+  const unreachableCoarseSignatures = new Set<string>();
+  for (const staleKey of unreachableIdentityKeys) {
+    unreachableCoarseSignatures.add(await coarseStorageSignatureFromKey(staleKey));
   }
 
   let deleted = 0;
@@ -1559,22 +1651,40 @@ export async function sweepUnreferencedBackupObjects(): Promise<BackupGcResult> 
       continue;
     }
 
+    // Review round 1 (CRITICAL): defer, don't reclaim, on an identity that
+    // coarsely aliases a STALE (unreachable) identity — see the comment on
+    // unreachableCoarseSignatures above.
+    const identityCoarseSignature = await coarseStorageSignatureFromKey(identity.key);
+    const aliasDeferred = unreachableCoarseSignatures.has(identityCoarseSignature);
+
     try {
       const state = await loadIdentityGcState(identity, nowMs);
+      const legacyOrAliasDeferred = state.legacyHelper.deferred || aliasDeferred;
       if (state.legacyHelper.deferred) {
         deferredIdentities++;
-        console.warn(`[BackupGC] reclamation deferred: legacy helper ${state.legacyHelper.deviceId} ${state.legacyHelper.version}`);
+        console.warn(`[BackupGC] identity ${identity.key}: reclamation deferred (legacy helper ${state.legacyHelper.deviceId} ${state.legacyHelper.version})`);
+      }
+      if (aliasDeferred) {
+        if (!state.legacyHelper.deferred) deferredIdentities++; // avoid double-counting one identity for both reasons
+        console.warn(
+          `[BackupGC] identity ${identity.key}: reclamation deferred — coarsely aliases a stale/unreachable ` +
+          `identity (${identityCoarseSignature}); a config edit may have changed the identity string while ` +
+          `still pointing at the same physical bucket/directory. Investigate before reclamation resumes.`,
+        );
       }
 
       const identityResult = await sweepStorageIdentity(
         identity, state.retainedSnapshotIds, state.nullIdentityRows, state.retiredSnapshotIds,
         nowMs, deletesRemaining, graceMs, orphanWindowMs, manifestlessWindowMs,
-        state.legacyHelper.deferred,
+        legacyOrAliasDeferred,
       );
 
       if (identityResult.unresolvedNullIdentityCount > 0) {
-        console.warn(`[BackupGC] identity deferred: ${identityResult.unresolvedNullIdentityCount} unresolved rows`);
-        if (!state.legacyHelper.deferred) deferredIdentities++; // avoid double-counting one identity for both reasons
+        console.warn(
+          `[BackupGC] identity ${identity.key}: deferred — ${identityResult.unresolvedNullIdentityCount} unresolved ` +
+          `row(s) (snapshot ids: ${identityResult.unresolvedSnapshotIds.join(', ')})`,
+        );
+        if (!legacyOrAliasDeferred) deferredIdentities++; // avoid double-counting one identity across all 3 deferral reasons
       }
 
       deleted += identityResult.deleted;

--- a/apps/api/src/jobs/backupRetention.ts
+++ b/apps/api/src/jobs/backupRetention.ts
@@ -624,8 +624,12 @@ export function computeExpiresAt(
 //             (snapshots/<id>/manifest.json (+ system-state/ for D15)) is
 //             shared by every mode, so scoping is by identity, not type), PLUS
 //             every backup_snapshots row with storage_identity IS NULL whose
-//             config_id maps here (unconditionally a root — "resolved" only
-//             gates self-heal/deferral, never root membership, see §3.6 v3).
+//             config_id maps here AND whose manifest is found in THIS run's
+//             fresh listing ("resolved") — self-healed by row id at that
+//             point. A NULL row that never resolves contributes no root (its
+//             object isn't in this bucket to protect) but still counts
+//             toward the deferral gate below, since GC cannot yet rule out
+//             that a later run's listing will resolve it.
 //   Retired:  a snapshot with a backup_snapshot_retirements row (sweptAt IS
 //             NULL) for this identity is NEVER a root regardless of age, and
 //             is reclaimed via the two-phase (non-manifest, then manifest)

--- a/apps/api/src/jobs/backupWorker.dbcontext.test.ts
+++ b/apps/api/src/jobs/backupWorker.dbcontext.test.ts
@@ -27,6 +27,7 @@ import type { DispatchOutcome } from '../services/agentCommandRelay';
 const { mockDb, ctxState } = vi.hoisted(() => {
   const db = {
     select: vi.fn(),
+    selectDistinct: vi.fn(),
     update: vi.fn(),
     insert: vi.fn(),
     // D18 W01: stampDispatchPinAndIdentity opens `db.transaction(...)` for a
@@ -66,9 +67,24 @@ vi.mock('../db', () => ({
   SYSTEM_DB_ACCESS_CONTEXT: { scope: 'system', orgId: null, partnerId: null },
 }));
 
+// D18 W02: recording stubs (not plain vi.fn()) so this file's REAL ctxState
+// can prove WHERE each call happens -- specifically that
+// sweepUnreferencedBackupObjects runs at depth 0, never nested inside a held
+// DB context (see the describe block below).
+const cleanupExpiredSnapshotsMock = vi.fn(async () => {
+  ctxState.events.push(`cleanupExpiredSnapshots@depth${ctxState.depth}`);
+  return { deleted: 0, skippedLegalHold: 0, skippedImmutable: 0, skippedPinned: 0, skippedUnresolved: 0, prunedByMaxVersions: 0, failed: 0 };
+});
+const sweepUnreferencedBackupObjectsMock = vi.fn(async () => {
+  ctxState.events.push(`sweepUnreferencedBackupObjects@depth${ctxState.depth}`);
+  return {
+    deleted: 0, skippedIdentities: 0, blockedIdentities: 0,
+    retiredSwept: 0, orphansSwept: 0, deferredIdentities: 0, unreachableIdentities: 0,
+  };
+});
 vi.mock('./backupRetention', () => ({
-  cleanupExpiredSnapshots: vi.fn(),
-  sweepUnreferencedBackupObjects: vi.fn(),
+  cleanupExpiredSnapshots: cleanupExpiredSnapshotsMock,
+  sweepUnreferencedBackupObjects: sweepUnreferencedBackupObjectsMock,
   // D18 W01: real (not mocked) identity logic -- stampDispatchPinAndIdentity
   // calls this for every dispatched target.
   normalizeStorageIdentity: (provider: string, providerConfig: Record<string, unknown>): string => {
@@ -314,5 +330,38 @@ describe('processDispatchBackup DB-context scoping (final-review fix, #4084/#110
       'ctx:exit',
     ]);
     warn.mockRestore();
+  });
+});
+
+describe('processCleanupExpiredSnapshots DB-context scoping (D18 §3.7 / W02)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ctxState.depth = 0;
+    ctxState.events = [];
+    mockDb.selectDistinct.mockReturnValue({
+      from: vi.fn().mockImplementation(async () => {
+        ctxState.events.push(`orgRowsSelect@depth${ctxState.depth}`);
+        return [];
+      }),
+    });
+  });
+
+  it('calls sweepUnreferencedBackupObjects at depth 0 — never nested inside a held DB context', async () => {
+    const { processCleanupExpiredSnapshots } = await import('./backupWorker');
+    await processCleanupExpiredSnapshots();
+
+    expect(sweepUnreferencedBackupObjectsMock).toHaveBeenCalledTimes(1);
+    const sweepEvent = ctxState.events.find((e) => e.startsWith('sweepUnreferencedBackupObjects@'));
+    expect(sweepEvent).toBe('sweepUnreferencedBackupObjects@depth0');
+  });
+
+  it('runs the org-row read inside a short context that closes before the sweep', async () => {
+    const { processCleanupExpiredSnapshots } = await import('./backupWorker');
+    await processCleanupExpiredSnapshots();
+
+    const orgReadIndex = ctxState.events.indexOf('orgRowsSelect@depth1');
+    const sweepIndex = ctxState.events.indexOf('sweepUnreferencedBackupObjects@depth0');
+    expect(orgReadIndex).toBeGreaterThanOrEqual(0);
+    expect(sweepIndex).toBeGreaterThan(orgReadIndex);
   });
 });

--- a/apps/api/src/jobs/backupWorker.test.ts
+++ b/apps/api/src/jobs/backupWorker.test.ts
@@ -476,7 +476,10 @@ describe('processCleanupExpiredSnapshots — GC wiring', () => {
       prunedByMaxVersions: 0,
       failed: 0,
     });
-    sweepUnreferencedBackupObjectsMock.mockResolvedValue({ deleted: 5, skippedIdentities: 2, blockedIdentities: 1 });
+    sweepUnreferencedBackupObjectsMock.mockResolvedValue({
+      deleted: 5, skippedIdentities: 2, blockedIdentities: 1,
+      retiredSwept: 1, orphansSwept: 2, deferredIdentities: 0, unreachableIdentities: 0,
+    });
 
     const result = await processCleanupExpiredSnapshots();
 
@@ -494,6 +497,10 @@ describe('processCleanupExpiredSnapshots — GC wiring', () => {
       gcDeleted: 5,
       gcSkippedIdentities: 2,
       gcBlockedIdentities: 1,
+      gcRetiredSwept: 1,
+      gcOrphansSwept: 2,
+      gcDeferredIdentities: 0,
+      gcUnreachableIdentities: 0,
     });
   });
 
@@ -518,6 +525,10 @@ describe('processCleanupExpiredSnapshots — GC wiring', () => {
     expect(result.gcDeleted).toBe(0);
     expect(result.gcSkippedIdentities).toBe(0);
     expect(result.gcBlockedIdentities).toBe(0);
+    expect(result.gcRetiredSwept).toBe(0);
+    expect(result.gcOrphansSwept).toBe(0);
+    expect(result.gcDeferredIdentities).toBe(0);
+    expect(result.gcUnreachableIdentities).toBe(0);
     // A thrown GC sweep is escalated to Sentry (retention run still succeeds).
     expect(captureExceptionMock).toHaveBeenCalledTimes(1);
   });
@@ -526,7 +537,10 @@ describe('processCleanupExpiredSnapshots — GC wiring', () => {
     mockDb.selectDistinct.mockReturnValue({
       from: vi.fn().mockResolvedValue([]),
     });
-    sweepUnreferencedBackupObjectsMock.mockResolvedValue({ deleted: 0, skippedIdentities: 0, blockedIdentities: 0 });
+    sweepUnreferencedBackupObjectsMock.mockResolvedValue({
+      deleted: 0, skippedIdentities: 0, blockedIdentities: 0,
+      retiredSwept: 0, orphansSwept: 0, deferredIdentities: 0, unreachableIdentities: 0,
+    });
 
     const result = await processCleanupExpiredSnapshots();
 
@@ -540,6 +554,10 @@ describe('processCleanupExpiredSnapshots — GC wiring', () => {
       gcDeleted: 0,
       gcSkippedIdentities: 0,
       gcBlockedIdentities: 0,
+      gcRetiredSwept: 0,
+      gcOrphansSwept: 0,
+      gcDeferredIdentities: 0,
+      gcUnreachableIdentities: 0,
     });
   });
 
@@ -562,7 +580,10 @@ describe('processCleanupExpiredSnapshots — GC wiring', () => {
       prunedByMaxVersions: 0,
       failed: 1,
     });
-    sweepUnreferencedBackupObjectsMock.mockResolvedValue({ deleted: 5, skippedIdentities: 0, blockedIdentities: 0 });
+    sweepUnreferencedBackupObjectsMock.mockResolvedValue({
+      deleted: 5, skippedIdentities: 0, blockedIdentities: 0,
+      retiredSwept: 0, orphansSwept: 0, deferredIdentities: 0, unreachableIdentities: 0,
+    });
 
     await expect(processCleanupExpiredSnapshots()).rejects.toThrow(/1 snapshot row delete\(s\) failed/);
 

--- a/apps/api/src/jobs/backupWorker.ts
+++ b/apps/api/src/jobs/backupWorker.ts
@@ -349,9 +349,21 @@ export async function processCleanupExpiredSnapshots(): Promise<{
   // GC's unit of work is a storage identity (possibly several backupConfigs
   // rows sharing one bucket), not a single "destination" row.
   gcSkippedIdentities: number;
-  // Subset of gcSkippedIdentities that fail-closed on an unfetchable FILE-type
+  // Subset of gcSkippedIdentities that fail-closed on an unfetchable
   // manifest — the distinct signal of a possible non-self-healing storage leak.
   gcBlockedIdentities: number;
+  // D18 W02: retirement rows CONFIRMED fully swept from storage this run
+  // (durable, via swept_at).
+  gcRetiredSwept: number;
+  // D18 W02: abandoned orphan-manifest prefixes reclaimed this run
+  // (best-effort observability metric, no DB row to confirm against).
+  gcOrphansSwept: number;
+  // D18 W02: identities that ran today's (pre-D18) algorithm only this run
+  // (legacy helper and/or unresolved NULL-storage_identity rows).
+  gcDeferredIdentities: number;
+  // D18 W02: storage_identity values with rows but no current config
+  // producing them (visibility only).
+  gcUnreachableIdentities: number;
 }> {
   // D18 §3.7: this whole function now runs with NO ambient DB context (it is
   // called directly from the worker, no longer inside the blanket wrap) — the
@@ -387,22 +399,30 @@ export async function processCleanupExpiredSnapshots(): Promise<{
   // job: row-level retention already succeeded, and BullMQ would otherwise
   // retry/re-log the whole run over an unrelated object-storage problem.
   //
-  // D18 §3.7 (authoritative shape for W02): ONE shared context for the whole
-  // sweep — matches today's read shape, so sweepUnreferencedBackupObjects's
-  // existing internal db.select(...) calls keep the working GUCs they rely on
-  // (it has no context management of its own). This runs strictly AFTER
-  // every row's retention has already committed independently (Task 9), so a
-  // GC failure here can never roll back a retirement that already committed.
-  // W02 replaces this single wrap with genuinely separate per-identity
-  // contexts managed inside sweepUnreferencedBackupObjects itself.
+  // D18 §3.7 (W02): the call is BARE, at depth 0 — no ambient DB context.
+  // sweepUnreferencedBackupObjects (backupRetention.ts) now opens its own
+  // short per-identity withSystemDbAccessContext calls internally and makes
+  // every storage (list/fetch/delete) call outside any held context; wrapping
+  // the whole call in one context here (the pre-W02 shape) would defeat that
+  // split and pin a pooled connection across every identity's storage I/O.
+  // assertOutsideHeldDbContext inside sweepStorageIdentity is the runtime
+  // tripwire for this invariant.
   let gcDeleted = 0;
   let gcSkippedIdentities = 0;
   let gcBlockedIdentities = 0;
+  let gcRetiredSwept = 0;
+  let gcOrphansSwept = 0;
+  let gcDeferredIdentities = 0;
+  let gcUnreachableIdentities = 0;
   try {
-    const gcResult = await runWithSystemDbAccess(() => sweepUnreferencedBackupObjects());
+    const gcResult = await sweepUnreferencedBackupObjects();
     gcDeleted = gcResult.deleted;
     gcSkippedIdentities = gcResult.skippedIdentities;
     gcBlockedIdentities = gcResult.blockedIdentities;
+    gcRetiredSwept = gcResult.retiredSwept;
+    gcOrphansSwept = gcResult.orphansSwept;
+    gcDeferredIdentities = gcResult.deferredIdentities;
+    gcUnreachableIdentities = gcResult.unreachableIdentities;
   } catch (err) {
     console.error('[BackupWorker] Backup object GC sweep failed — retention run still succeeded:', err);
     captureException(err instanceof Error ? err : new Error(String(err)));
@@ -422,7 +442,11 @@ export async function processCleanupExpiredSnapshots(): Promise<{
     );
   }
 
-  return { deleted, skipped, prunedByMaxVersions, failed, gcDeleted, gcSkippedIdentities, gcBlockedIdentities };
+  return {
+    deleted, skipped, prunedByMaxVersions, failed,
+    gcDeleted, gcSkippedIdentities, gcBlockedIdentities,
+    gcRetiredSwept, gcOrphansSwept, gcDeferredIdentities, gcUnreachableIdentities,
+  };
 }
 
 // ── Backup target resolution ─────────────────────────────────────────────────

--- a/apps/api/src/services/backupAgentContract.test.ts
+++ b/apps/api/src/services/backupAgentContract.test.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 import { backupCommandResultSchema } from '../routes/backup/resultSchemas';
-import { BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS } from '../jobs/backupRetention';
+import { resolveBackupManifestlessPrefixMaxAgeMs } from '../jobs/backupRetention';
 import { sanitizeVssMetadata } from './backupResultPersistence';
 import {
   BACKUP_SNAPSHOT_ROOT_DIR,
@@ -293,9 +293,11 @@ describe('backup Go<->TS contract — D18 server-owned base payload fields', () 
     const agentSrc = readRepoFile('agent/internal/backup/snapshot.go');
     expect(agentSrc).toMatch(/uploadLeaseInterval\s*=\s*15\s*\*\s*time\.Minute/);
     const FIFTEEN_MIN_MS = 15 * 60 * 1000;
-    // Real comparison against the imported constant (currently 9 days:
-    // journalMaxAge 7d + BACKUP_GC_GRACE_MS 48h) — not two independent
-    // literals that happen to agree today.
-    expect(FIFTEEN_MIN_MS).toBeLessThan(BACKUP_GC_MANIFESTLESS_PREFIX_MAX_AGE_MS / 100);
+    // Real comparison against the per-run resolver's default output
+    // (currently 9 days: journalMaxAge 7d + BACKUP_GC_GRACE_MS 48h) — not two
+    // independent literals that happen to agree today. D18 W02 moved this
+    // constant off module load (per-run env override support), so it's read
+    // via the resolver function rather than a static import.
+    expect(FIFTEEN_MIN_MS).toBeLessThan(resolveBackupManifestlessPrefixMaxAgeMs() / 100);
   });
 });

--- a/apps/api/src/services/backupGcKnobs.test.ts
+++ b/apps/api/src/services/backupGcKnobs.test.ts
@@ -4,9 +4,11 @@ import {
   resolveBackupBaseLeaseMs,
   resolveBackupRestorePinLingerMs,
   resolveBackupPublishMarginMs,
+  resolveBackupOrphanManifestMaxAgeMs,
   BACKUP_BASE_LEASE_MS_DEFAULT,
   BACKUP_RESTORE_PIN_LINGER_MS_DEFAULT,
   BACKUP_PUBLISH_MARGIN_MS_DEFAULT,
+  BACKUP_ORPHAN_MANIFEST_MAX_AGE_MS_DEFAULT,
 } from './backupGcKnobs';
 
 const ENV_VAR = 'BACKUP_TEST_KNOB_MS';
@@ -51,5 +53,28 @@ describe('per-knob defaults', () => {
     expect(resolveBackupPublishMarginMs()).toBe(BACKUP_PUBLISH_MARGIN_MS_DEFAULT);
     expect(BACKUP_BASE_LEASE_MS_DEFAULT).toBe(7 * 24 * 60 * 60 * 1000);
     expect(BACKUP_PUBLISH_MARGIN_MS_DEFAULT).toBe(60 * 60 * 1000);
+  });
+});
+
+describe('resolveBackupOrphanManifestMaxAgeMs', () => {
+  const ENV = 'BACKUP_GC_ORPHAN_MANIFEST_MAX_AGE_MS';
+  afterEach(() => {
+    delete process.env[ENV];
+  });
+
+  it('defaults to 9 days (journalMaxAge + 48h)', () => {
+    expect(resolveBackupOrphanManifestMaxAgeMs()).toBe(BACKUP_ORPHAN_MANIFEST_MAX_AGE_MS_DEFAULT);
+    expect(BACKUP_ORPHAN_MANIFEST_MAX_AGE_MS_DEFAULT).toBe(9 * 24 * 60 * 60 * 1000);
+  });
+
+  it('honors a positive override outside production', () => {
+    process.env[ENV] = '1234';
+    expect(resolveBackupOrphanManifestMaxAgeMs()).toBe(1234);
+  });
+
+  it('floors an override at/below the agent journal max age in production', () => {
+    process.env.NODE_ENV = 'production';
+    process.env[ENV] = String(7 * 24 * 60 * 60 * 1000); // exactly journalMaxAge
+    expect(resolveBackupOrphanManifestMaxAgeMs()).toBeGreaterThan(7 * 24 * 60 * 60 * 1000);
   });
 });

--- a/apps/api/src/services/backupGcKnobs.ts
+++ b/apps/api/src/services/backupGcKnobs.ts
@@ -61,6 +61,31 @@ export function resolveBackupRestorePinLingerMs(): number {
 }
 
 /**
+ * D18 W02 (#5451): how old an orphan manifest-bearing prefix (no
+ * backup_snapshots row, no retirement row) must be before GC treats it as
+ * abandoned rather than an in-flight/not-yet-adopted upload. Default matches
+ * the agent's 7-day journalMaxAge + 48h resume headroom (9 days) — same
+ * physical constant as backupRetention.ts's
+ * BACKUP_GC_AGENT_JOURNAL_MAX_AGE_MS, duplicated here because this module is
+ * imported BY backupRetention.ts (not the reverse), so it can't be shared by
+ * import; keep both literals in sync if the agent's journalMaxAge ever
+ * changes. The floor mirrors the manifest-less-prefix floor for the same
+ * reason: an override at or below journalMaxAge could reclaim a prefix the
+ * agent might still legitimately resume into.
+ */
+const BACKUP_ORPHAN_MANIFEST_AGENT_JOURNAL_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+export const BACKUP_ORPHAN_MANIFEST_MAX_AGE_MS_DEFAULT =
+  BACKUP_ORPHAN_MANIFEST_AGENT_JOURNAL_MAX_AGE_MS + 48 * 60 * 60 * 1000; // 9 days
+const BACKUP_ORPHAN_MANIFEST_MAX_AGE_MS_PRODUCTION_FLOOR = BACKUP_ORPHAN_MANIFEST_AGENT_JOURNAL_MAX_AGE_MS + 1;
+export function resolveBackupOrphanManifestMaxAgeMs(): number {
+  return resolveMsKnob(
+    'BACKUP_GC_ORPHAN_MANIFEST_MAX_AGE_MS',
+    BACKUP_ORPHAN_MANIFEST_MAX_AGE_MS_DEFAULT,
+    BACKUP_ORPHAN_MANIFEST_MAX_AGE_MS_PRODUCTION_FLOOR,
+  );
+}
+
+/**
  * Grace window added on top of publish_lease_expires_at before retention
  * treats a base pin as released (spec §3.1: "the margin is what turns the
  * pre-PUT check into a fence — the server keeps the pin for lease + margin,

--- a/apps/api/src/services/backupHelperCapabilities.test.ts
+++ b/apps/api/src/services/backupHelperCapabilities.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { BACKUP_QUEUE_MIN_HELPER_VERSION, backupHelperSupportsQueue } from './backupHelperCapabilities';
+import {
+  BACKUP_QUEUE_MIN_HELPER_VERSION,
+  backupHelperSupportsQueue,
+  BACKUP_SERVER_BASE_MIN_HELPER_VERSION,
+  backupHelperSupportsServerBase,
+} from './backupHelperCapabilities';
 
 describe('backupHelperSupportsQueue', () => {
   it('accepts the introducing release and anything newer', () => {
@@ -19,5 +24,26 @@ describe('backupHelperSupportsQueue', () => {
     expect(backupHelperSupportsQueue('')).toBe(false);
     expect(backupHelperSupportsQueue('dev')).toBe(false);
     expect(backupHelperSupportsQueue('unknown')).toBe(false);
+  });
+});
+
+describe('backupHelperSupportsServerBase', () => {
+  it('accepts the introducing release and anything newer', () => {
+    expect(backupHelperSupportsServerBase(BACKUP_SERVER_BASE_MIN_HELPER_VERSION)).toBe(true);
+    expect(backupHelperSupportsServerBase('v0.112.0')).toBe(true);
+    expect(backupHelperSupportsServerBase('0.112.1')).toBe(true);
+    expect(backupHelperSupportsServerBase('0.113.0')).toBe(true);
+    expect(backupHelperSupportsServerBase('1.0.0')).toBe(true);
+  });
+
+  it('rejects older helpers, pre-releases of the introducing version, dev builds, and unknowns', () => {
+    expect(backupHelperSupportsServerBase('0.111.0')).toBe(false);
+    expect(backupHelperSupportsServerBase('0.111.99')).toBe(false);
+    expect(backupHelperSupportsServerBase('0.112.0-rc.1')).toBe(false);
+    expect(backupHelperSupportsServerBase(null)).toBe(false);
+    expect(backupHelperSupportsServerBase(undefined)).toBe(false);
+    expect(backupHelperSupportsServerBase('')).toBe(false);
+    expect(backupHelperSupportsServerBase('dev')).toBe(false);
+    expect(backupHelperSupportsServerBase('unknown')).toBe(false);
   });
 });

--- a/apps/api/src/services/backupHelperCapabilities.ts
+++ b/apps/api/src/services/backupHelperCapabilities.ts
@@ -21,3 +21,26 @@ export function backupHelperSupportsQueue(version: string | null | undefined): b
   if (!parseComparableVersion(version)) return false;
   return compareAgentVersions(version, BACKUP_QUEUE_MIN_HELPER_VERSION) >= 0;
 }
+
+/**
+ * First breeze-backup helper release that supports server-owned dedupe base
+ * selection (D18 W01/W02): the server picks and leases the incremental base,
+ * the agent downloads it by id, and the agent itself never deletes remote
+ * objects. Older helpers still list the bucket to choose a base and still
+ * prune remotely on retention, so GC's unrooted-prefix reclamation (retired +
+ * orphan-past-window deletion) must stay disabled on any identity still
+ * serving a helper below this version — see
+ * apps/api/src/jobs/backupRetention.ts's capability gate.
+ */
+export const BACKUP_SERVER_BASE_MIN_HELPER_VERSION = '0.112.0';
+
+/**
+ * True when `devices.backup_version` reports a helper new enough to trust
+ * with unrooted-prefix GC reclamation. Unknown, unparseable, or missing
+ * versions are treated as NOT capable (conservative: legacy behavior).
+ */
+export function backupHelperSupportsServerBase(version: string | null | undefined): boolean {
+  if (!version) return false;
+  if (!parseComparableVersion(version)) return false;
+  return compareAgentVersions(version, BACKUP_SERVER_BASE_MIN_HELPER_VERSION) >= 0;
+}

--- a/apps/docs/src/content/docs/backup/monitoring.mdx
+++ b/apps/docs/src/content/docs/backup/monitoring.mdx
@@ -116,7 +116,7 @@ Jobs are triggered either **automatically** by a policy schedule, **manually** v
 
 Track storage growth over time from the **Overview** tab's storage section. The usage chart shows cumulative storage by provider over the past 14 days (configurable from 3 to 90 days via the API).
 
-If storage is growing faster than expected, check whether large datasets were recently added to backup scope. Note that expired restore points disappear from Breeze but their data is not yet reclaimed from the storage target (see the retention note on the [storage page](/backup/storage/)), so usage does not fall when retention runs.
+If storage is growing faster than expected, check whether large datasets were recently added to backup scope. Expired restore points are removed from Breeze immediately and their storage is reclaimed by the periodic reclamation sweep (see the [storage page](/backup/storage/) for timing and safety windows) — allow for the grace period and the next scheduled sweep before usage reflects the drop.
 
 ---
 

--- a/apps/docs/src/content/docs/backup/storage.mdx
+++ b/apps/docs/src/content/docs/backup/storage.mdx
@@ -52,12 +52,12 @@ The storage configuration wizard walks you through four steps:
    <Aside type="note" title="What retention removes today">
      When a restore point passes its retention window, Breeze removes it from the snapshot list — it can no
      longer be restored or verified — and marks its data for reclamation. A background storage sweep then
-     deletes the restore point's exclusive data from the storage target on its next scheduled run, after a
-     short safety grace period (48 hours by default) that protects any object still mid-upload. Data another
-     surviving restore point still depends on (for example, a file shared with an incremental backup) is never
-     deleted, no matter how old it is. An upload that never finished, or whose record could not be reconciled,
-     is reclaimed once it has sat idle for about 9 days — giving Breeze time to recognize and finish adopting
-     it first.
+     deletes the restore point's exclusive data from the storage target on its next scheduled run. Data
+     another surviving restore point still depends on (for example, a file shared with an incremental backup)
+     is never deleted, no matter how old it is. A short safety grace period (48 hours by default) additionally
+     protects any loose object that might still be mid-upload before it is considered for deletion at all. An
+     upload that never finished, or whose record could not be reconciled, is reclaimed once it has sat idle
+     for about 9 days — giving Breeze time to recognize and finish adopting it first.
 
      If a device's Breeze backup helper predates version 0.112.0, storage reclamation beyond an expired
      snapshot's own row stays deferred on that device's destination until every device sharing it has

--- a/apps/docs/src/content/docs/backup/storage.mdx
+++ b/apps/docs/src/content/docs/backup/storage.mdx
@@ -50,13 +50,18 @@ The storage configuration wizard walks you through four steps:
    Optionally enable encryption. This is only enforceable for S3 destinations with server-side encryption (SSE-S3 or SSE-KMS) configured — see [Encryption](/backup/encryption/) for details. Local/NAS destinations do not support enabling this toggle.
 
    <Aside type="note" title="What retention removes today">
-     When a restore point passes its retention window it is removed from Breeze: it no longer appears in the
-     snapshot list and can no longer be restored or verified. The objects it wrote to the storage target are
-     handled by a separate background sweep that only deletes data no remaining restore point references,
-     after a 48-hour grace period. In the current release that sweep does not yet reclaim the data of expired
-     restore points themselves, so bucket usage does not shrink when restore points expire. This is tracked in
-     [issue #5429](https://github.com/LanternOps/breeze/issues/5429); plan bucket capacity for growth until it
-     lands.
+     When a restore point passes its retention window, Breeze removes it from the snapshot list — it can no
+     longer be restored or verified — and marks its data for reclamation. A background storage sweep then
+     deletes the restore point's exclusive data from the storage target on its next scheduled run, after a
+     short safety grace period (48 hours by default) that protects any object still mid-upload. Data another
+     surviving restore point still depends on (for example, a file shared with an incremental backup) is never
+     deleted, no matter how old it is. An upload that never finished, or whose record could not be reconciled,
+     is reclaimed once it has sat idle for about 9 days — giving Breeze time to recognize and finish adopting
+     it first.
+
+     If a device's Breeze backup helper predates version 0.112.0, storage reclamation beyond an expired
+     snapshot's own row stays deferred on that device's destination until every device sharing it has
+     upgraded — update the agent to enable full reclamation.
    </Aside>
 </Steps>
 


### PR DESCRIPTION
STACKED on #5483 — rebase before merge

## Summary

**Rebased onto W01's current head** (`f5397c87e0` — W01's migrations were renamed again to `2026-10-15-150301`/`150302` after this PR was first opened, and W01 also picked up an unrelated origin/main merge). Rebase was clean (no conflicts); grepped the diff for the old `150041`/`150042` migration-name references (none — this wave never referenced migration filenames in code or comments) and confirmed W01's `08c8e9d6de` dispatch-stamping fix (for main's `buildBackupWriteCommandDestination` refactor) doesn't touch anything this wave depends on (this wave never touches `prepareBackupDispatchTargets`/dispatch code at all — only `processCleanupExpiredSnapshots`). Full re-verification below is post-rebase.

- Wave 02 of #5449 (backup-gc-reclamation): `sweepUnreferencedBackupObjects` now actually reclaims retired and orphaned backup-object prefixes, not just the pre-existing 48h loose-object grace and 9-day manifest-less-prefix rules.
- Root set is scoped by `backup_snapshots.storage_identity` (any backup type), with `backup_snapshot_retirements` and an age-windowed orphan-manifest rule as new root-set/reclaim inputs.
- A legacy-helper capability gate and an unresolved-NULL-`storage_identity` gate each independently defer an identity to exactly today's (pre-D18) algorithm — no retired/orphan reclamation on that identity until resolved.
- Every DB read/write runs in its own short `withSystemDbAccessContext`; every storage call runs at depth 0 (§3.7), guarded by `assertOutsideHeldDbContext`.
- No schema changes in this wave — only reads existing tables plus writes `storage_identity` self-heal, `swept_at`, and 30-day retirement pruning.

## Verification

| Command | Result |
|---|---|
| `cd apps/api && npx tsc --noEmit -p .` (NODE_OPTIONS=--max-old-space-size=8192) | PASS, 0 errors |
| `npx eslint <every touched file>` | PASS, 0 findings |
| `npx vitest run src/jobs/backupRetention.test.ts` | PASS, 80/80 (7 new from review round 1) |
| `npx vitest run src/jobs/backupWorker.test.ts` | PASS, 31/31 |
| `npx vitest run src/jobs/backupWorker.dbcontext.test.ts` | PASS, 6/6 (incl. new depth-0 assertion) |
| `npx vitest run src/services/backupHelperCapabilities.test.ts` | PASS, 4/4 |
| `npx vitest run src/services/backupGcKnobs.test.ts` | PASS, 9/9 |
| `npx vitest run src/services/backupAgentContract.test.ts` | PASS (7-day journal literal contract intact) |
| `npx vitest run --pool=threads --maxWorkers=2 src/jobs/backup src/services/backup` | PASS, 360/361 (1 skipped, pre-existing) |
| `npx vitest run --config vitest.integration.config.ts src/__tests__/integration/backupGcReclamation.integration.test.ts` (private per-worktree test stack via `pnpm test-stack up`, real Postgres + real local filesystem) | PASS, 11/11 (added a retirement-pruning negative case) |
| `npx vitest run --config vitest.integration.config.ts src/__tests__/integration/{tenantCascade,tenant-export-policy,rls-coverage,tenantExportErasureRoundtrip}` | PASS, 45/45 (sanity check — this wave touches no schema) |
| `pnpm db:check-drift` (against the test-stack DB) | PASS — no drift, 726 migrations |
| Full API unit suite `npx vitest run --pool=threads --maxWorkers=2` (round 2, post review-round-1 fixes, pre-rebase) | PASS — 2003 files / 38151 tests passed, 3 files / 22 tests skipped (0 failures) |
| `pnpm db:check-drift` (post-rebase, fresh test-stack DB with W01's renamed migrations) | PASS — no drift, 728 migrations |
| `pnpm --filter @breeze/api lint` | PASS, 0 findings |

## Deviations from the plan

1. **`resolveBackupOrphanManifestMaxAgeMs()` did not exist in W01's shipped `backupGcKnobs.ts`.** The plan's "Depends on" section assumed W01 shipped it; W01 actually shipped `resolveBackupBaseLeaseMs`, `resolveBackupRestorePinLingerMs`, `resolveBackupPublishMarginMs` but not this one. Added it in this wave, mirroring the existing `resolveMsKnob` convention exactly (default 9d = journalMaxAge + 48h, floor = journalMaxAge + 1ms).
2. **`assertOutsideHeldDbContext` already existed** in `db/index.ts` and was already used by W01's `cleanupExpiredSnapshots` — the task brief's suggestion that it might need adding was based on stale ground truth. Reused as-is; only added a new call site inside the rewritten `sweepStorageIdentity`.
3. **`processCleanupExpiredSnapshots` DID wrap the sweep call in `withSystemDbAccessContext(...)`** in this worktree's actual W01-shipped code (the task brief flagged this as something to verify). Removed that wrapper so the call is bare at depth 0, matching the rewritten sweep's own short-context design; added a regression to `backupWorker.dbcontext.test.ts` proving it.
4. **Dropped the `backupType` allowlist filter entirely from the retained-rows query** (not just switched its scope from `configId` to `storage_identity`) — trusting the plan/spec's explicit finding that every backup type publishes `snapshots/<id>/manifest.json`, over an in-repo comment on `RETAINABLE_BACKUP_TYPES_FOR_GC` asserting `application`/`database` types use a different namespace. Reasoning: keeping that filter while ALSO removing this wave's old "every listed manifest is live forever" fallback would have made an aged `application`/`database` (hyperv/mssql) snapshot silently reclaimable as "orphan garbage" the moment it cleared the orphan window — a real data-loss regression versus today's behavior. Dropping the filter is the conservative choice: worst case a manifest genuinely at a different path 404s and fail-closes (skips, never deletes) that one identity; it never causes an incorrect deletion. `RETAINABLE_BACKUP_TYPES_FOR_GC`/`isRetainableBackupTypeForGc` (now unused — grep confirmed no other call sites) were removed along with their tests.
5. **Integration test fixture used the wrong `backup_type` enum values** (`hyperv`/`mssql`, informal names from a comment) — the real Postgres enum (`schema/backup.ts:36-41`) is `file`/`system_image`/`database`/`application`. Caught by running against real Postgres; fixed to the real values.
6. **Two of my own integration-test fixtures were wrong, caught only by the real-DB run:** (a) a "retained row survives regardless of age" scenario put an *unreferenced* loose file under the retained prefix, which the pre-existing 48h loose-object grace legitimately sweeps regardless of retention — fixed by making the file a real manifest reference; (b) an assertion expected a retired snapshot's `manifest.json` to survive because a *different* one of its original objects (still referenced by a sibling snapshot) survived — but nothing depends on the retired snapshot's own manifest to resolve that sibling reference, so deleting it is safe and is what the implementation actually (correctly) does; the assertion was corrected, not the source.
7. **Rebase onto W01's moved head (no code changes needed).** After review round 1 finished, W01's PR head moved (migrations renamed again, to `150301`/`150302`; W01 also merged an unrelated dispatch-stamping fix against main's `buildBackupWriteCommandDestination` refactor). Rebased this branch onto the new W01 head — clean, no conflicts, no stale migration-name references anywhere in this wave's diff (this wave never names migration files in code/comments), and confirmed the dispatch-stamping refactor doesn't touch anything this wave's code depends on (this wave never touches dispatch code, only `processCleanupExpiredSnapshots`). No fix needed; noted here per the standing instruction to record the check even when nothing needed changing.
8. **Batched TDD cadence rather than the plan's literal one-test-then-implement-then-commit-per-step ceremony.** Given the size of the rewrite (Tasks 3–7 touch the same two functions), I wrote each task's full test coverage, ran it red, implemented that task's slice, ran it green, then committed — but grouped Tasks 3–7 into one commit (they're inseparable edits to the same `sweepStorageIdentity`/`sweepUnreferencedBackupObjects` pair) rather than 5 micro-commits. Every commit is still preceded by a real red-then-green cycle; no test was written after its implementation.

## Open questions

- None outstanding — the two ambiguous points above (backupType filter, deletion-safety re: sibling-shared objects) were resolved with reasoning rather than left open, since both admit a clearly safer/more-correct answer without guessing on the destructive side.

## Review findings addressed (round 1 — head SHA before fixes: c4f9f600aec75f204047581a24861bc743be92fd)

Three independent review agents (code-reviewer, silent-failure-hunter, pr-test-analyzer) reviewed the full diff. One CRITICAL, confirmed finding plus several Important ones.

**CRITICAL — fixed.** Aliased storage identities could let the sweep delete a live snapshot's objects: a `backup_configs` edit that changes the *normalized* identity string while still pointing at the same physical bucket/directory (virtual-hosted vs path-style S3 endpoint, an IP vs its hostname, or two `local` configs aliasing via a symlink/bind mount) left old rows invisible to the new identity's root query — once old enough, their objects looked like abandoned orphan garbage. Fixed by (1) `logUnreachableStorageIdentities` now returns the unreachable identity keys, and every identity about to be swept is cross-checked against their coarse signature (host+bucket for s3, real `fs.realpath` for local) — a match forces that identity into the deferred (no unrooted reclamation) path; (2) `detectSuspiciousStorageIdentityCollisions` now covers `local` providers too (previously fully exempted), using the same realpath-based coarse signature. Four new tests (S3 alias, local symlink alias via a real filesystem symlink, a negative control, and a current-vs-current local collision case) all pass.

**Important — fixed:**
- Both deferral log lines now include `identity.key`; the unresolved-NULL-identity log also includes the actual unresolved snapshot ids, so an operator has something to query.
- Added tests proving the manifest-last rule holds when a non-manifest sibling is cap-exhausted or Redis-skip-set-excluded, not just when it hard-fails to delete (previously untested).
- Added a test proving the NULL-identity self-heal write targets the correct row by primary key even when a different identity has an unresolved row sharing the identical `snapshotId` string (no uniqueness constraint on that column).

**Important — documented as a known limitation (not fixed this wave):**
- **Legacy-helper gate dispatch-race.** `identityHasLegacyHelper` snapshots in-flight/recent devices once, before the identity's storage I/O. A legacy device that dispatches a backup after that snapshot but before the write-back could have its base prefix reclaimed mid-run. Re-checking the gate right before the write-back doesn't close this — the storage deletes already happened by then. Closing it properly needs a lease/lock held for the identity's whole sweep duration, which is a bigger architectural change than this wave's scope. Left as a known, narrow race (bounded by needing both an aged-out reclaimable prefix AND a concurrent legacy-helper dispatch on the exact same identity in the same run).

**Suggestions — one fixed, one documented, one noted:**
- Fixed: `storage.mdx`'s wording overstated the 48h grace period's scope (implied it gates ALL reclamation, when it only gates loose objects under a rooted prefix).
- Documented in code (not fixed): the per-run delete cap is now spent in listing order across groups within an identity, not globally oldest-first as pre-D18 — a busy recent prefix can delay an older one to a later run. Never causes data loss (the sweep is resumable), just a fairness delay; a full fix needs collecting every candidate across every group before deciding anything, which doesn't compose cleanly with the two-phase manifest-last rule.
- Noted, no action: `backupRetention.ts` is ~1650 lines; CLAUDE.md's soft 500-line guideline suggests an eventual `backupGcSweep.ts` split, not required this wave.

Post-fix verification (re-run in full): tsc 0 errors, `pnpm --filter @breeze/api lint` 0 findings, `backupRetention.test.ts` 80/80 (7 new tests), targeted backup suite 360/361 (1 pre-existing skip), integration suite 11/11 against real Postgres + real filesystem, cascade/RLS/export-policy sanity 45/45, full API unit suite — see the Verification table above for the fresh run's numbers.

## Review findings addressed (round 2 — head SHA before fixes: c979ec752bfba820318ab36503cc612e0833c7c7)

**HOLD — fixed (`86e802d74a`, `a29408431d`).** `coarseStorageSignatureFromKey` swallowed every `fs.realpath` error and fell back to the lexical key, so the local symlink/bind-mount alias guard added in round 1 contributed nothing in exactly the failure mode it exists for. It now reports the errno; a `local` root that cannot be resolved **defers** the identity for the run (pre-D18 algorithm, no retired/orphan reclamation). Non-ENOENT (EACCES / ELOOP / EMFILE / …) on ANY local root — current or stale — additionally defers **every** local identity this run (an alias between siblings cannot be ruled out when one signature is lexical and the other resolved) and escalates via `captureException` with key + errno. ENOENT is per-identity only: on a current root it defers with a warn (fresh config or missing mount — nothing legitimate to lose either way); on a stale key it keeps the lexical fallback (the old directory is gone, nothing physical left to alias). Reasoning is in code comments at the helper and both call sites.

**Follow-up 4 — fixed.** `aliasDeferred` escalates via `captureException` like `suspiciousIdentityKeys`.

**Tests (11 new, all red-first; control with the fix reverted: 6 failed):** EACCES / ELOOP / EMFILE on a current root defer + delete nothing + log key/code + escalate; ENOENT current (defer, warn only); stale non-ENOENT (all local deferred, sibling s3 still reclaims); stale ENOENT (no deferral); symlink-aliased current pair with one EACCES (both deferred — this reproduced the round-2 reviewer's cross-config deletion before the fix); legacy-helper + realpath overlap counted once; healthy-realpath control that still reclaims the same fixture.

**Follow-ups 1–3 (structural, deferred by owner decision 2026-09-12):** isolate `logUnreachableStorageIdentities` from the essential run-level reads; isolate `pruneSweptRetirements` from the reclaim loop; preserve `deleted`/write-backs when `sweepStorageIdentity` throws mid-run.

**Owner-visible design choices (documented, no action needed):** persistent ENOENT on a current local root defers forever with warn-level logs only; a non-ENOENT local realpath failure defers all local identities cross-tenant until fixed (logged + escalated every run).

Round-2 verification: `backupRetention.test.ts` 94/94, full API unit suite 2145 files green (1 unrelated load-flake in `auth/password.test.ts`, green alone), tsc 0 errors, lint clean, `backupGcReclamation.integration.test.ts` 11/11 against a live `pnpm test-stack`.

Closes #5451

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YCS42Rm9Fdm17AQagpWb1G

