### PR TITLE
fix(tenancy): enforce invitation scope ceilings with row-locked membership validation

### DIFF
--- a/apps/api/src/__tests__/integration/accountingPartnerAuthority.integration.test.ts
+++ b/apps/api/src/__tests__/integration/accountingPartnerAuthority.integration.test.ts
@@ -1,0 +1,64 @@
+/** Real-PostgreSQL proof for partner-global accounting admission. */
+import './setup';
+
+import { eq } from 'drizzle-orm';
+import { Hono } from 'hono';
+import { describe, expect, it } from 'vitest';
+import { accountingConnections, partnerUsers } from '../../db/schema';
+import { accountingRoutes } from '../../routes/accounting';
+import { clearPermissionCache } from '../../services/permissions';
+import { createIntegrationTestClient } from './db-utils';
+import { getTestDb } from './setup';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+function app() {
+  const result = new Hono();
+  result.route('/accounting', accountingRoutes);
+  return result;
+}
+
+describe('accounting partner authority (real PostgreSQL as breeze_app)', () => {
+  runDb('allows all access and denies selected/none before the partner-axis read', async () => {
+    const client = await createIntegrationTestClient(app(), { scope: 'partner' });
+    await getTestDb().insert(accountingConnections).values({
+      partnerId: client.env.partner.id,
+      provider: 'quickbooks',
+      environment: 'sandbox',
+      status: 'connected',
+      pushMode: 'manual',
+    });
+
+    const allowed = await client.get('/accounting/quickbooks');
+    expect(allowed.status).toBe(200);
+    await expect(allowed.json()).resolves.toMatchObject({
+      status: 'connected',
+      environment: 'sandbox',
+      pushMode: 'manual',
+    });
+
+    for (const orgAccess of ['selected', 'none'] as const) {
+      await getTestDb()
+        .update(partnerUsers)
+        .set({
+          orgAccess,
+          orgIds: orgAccess === 'selected' ? [client.env.organization.id] : null,
+        })
+        .where(eq(partnerUsers.userId, client.env.user.id));
+      await clearPermissionCache(client.env.user.id);
+
+      const denied = await client.get('/accounting/quickbooks');
+      expect(denied.status, orgAccess).toBe(403);
+      await expect(denied.json()).resolves.toEqual({
+        error: 'Full partner organization access is required',
+      });
+    }
+
+    await getTestDb()
+      .update(partnerUsers)
+      .set({ orgAccess: 'all', orgIds: null })
+      .where(eq(partnerUsers.userId, client.env.user.id));
+    await clearPermissionCache(client.env.user.id);
+    expect((await client.get('/accounting/quickbooks')).status).toBe(200);
+  });
+});

--- a/apps/api/src/__tests__/integration/organizationInvitationSerialization.integration.test.ts
+++ b/apps/api/src/__tests__/integration/organizationInvitationSerialization.integration.test.ts
@@ -1,0 +1,166 @@
+/** Current authenticated invitation serialization on disposable PostgreSQL.
+ * The only substituted boundary is outbound mail; auth, permissions, request
+ * context, delegation and final membership insert use the production path.
+ */
+import './setup';
+import { randomUUID } from 'node:crypto';
+import { and, eq, sql } from 'drizzle-orm';
+import { Hono } from 'hono';
+import postgres from 'postgres';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { organizationUsers } from '../../db/schema';
+import { userRoutes } from '../../routes/users';
+import { createAccessToken } from '../../services/jwt';
+import { createSite, setupTestEnvironment } from './db-utils';
+import { getTestDb } from './setup';
+
+const mail = vi.hoisted(() => ({ sendInvite: vi.fn(async () => undefined) }));
+vi.mock('../../services/email', () => ({ getEmailService: () => mail }));
+const writer = postgres(process.env.DATABASE_URL!, { max: 1, onnotice: () => undefined });
+
+function barrier() {
+  let release!: () => void;
+  const ready = new Promise<void>((resolve) => { release = resolve; });
+  return { ready, release };
+}
+
+// Attach rejection handlers immediately, then drain every started operation after
+// releasing barriers. A cleanup rejection must not replace the primary assertion.
+function startedOperations() {
+  const pending: Promise<PromiseSettledResult<unknown>[]>[] = [];
+  return {
+    track<T>(operation: Promise<T>): Promise<T> {
+      pending.push(Promise.allSettled([operation]));
+      return operation;
+    },
+    async drain(primaryFailed: boolean) {
+      const results = (await Promise.all(pending)).flat();
+      const rejected = results.find((result) => result.status === 'rejected');
+      if (!primaryFailed && rejected?.status === 'rejected') throw rejected.reason;
+    },
+  };
+}
+
+async function blockedBy(pid: number) {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    const rows = await getTestDb().execute<{ waiting: number }>(sql`
+      SELECT count(*)::int AS waiting FROM pg_stat_activity
+      WHERE datname = current_database() AND state = 'active'
+        AND ${pid} = ANY(pg_blocking_pids(pid))
+    `);
+    if (rows[0]?.waiting) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error('expected membership writer/request lock dependency was not observed');
+}
+
+async function fixture() {
+  const env = await setupTestEnvironment({ scope: 'organization', userOptions: { mfaEnabled: true },
+    rolePermissions: [{ resource: 'users', action: 'invite' }] });
+  const second = await createSite({ orgId: env.organization.id });
+  await getTestDb().update(organizationUsers).set({ siteIds: [env.site.id, second.id] })
+    .where(and(eq(organizationUsers.orgId, env.organization.id), eq(organizationUsers.userId, env.user.id)));
+  const token = await createAccessToken({ sub: env.user.id, email: env.user.email,
+    roleId: env.role.id, orgId: env.organization.id, partnerId: env.partner.id,
+    scope: 'organization', mfa: true, aep: 1, mep: 1, sid: randomUUID() });
+  const email = `invitation-${randomUUID()}@example.test`;
+  const app = new Hono();
+  app.route('/users', userRoutes);
+  const invite = async (siteIds?: string[]) => app.request('/users/invite', {
+    method: 'POST', headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, name: 'Synthetic invitee', roleId: env.role.id, siteIds }),
+  });
+  const memberships = () => getTestDb().select().from(organizationUsers)
+    .where(eq(organizationUsers.orgId, env.organization.id));
+  return { env, second, email, invite, memberships };
+}
+
+beforeEach(() => { mail.sendInvite.mockReset(); mail.sendInvite.mockResolvedValue(undefined); });
+afterAll(async () => { await writer.end({ timeout: 5 }); });
+
+describe('authenticated invitation transaction serialization', () => {
+  for (const explicitRemovedSite of [false, true]) {
+    it(explicitRemovedSite ? 'denies a removed explicit site after the concurrent scope writer commits'
+      : 'inherits the committed reduced scope through the final membership insert', async () => {
+      const fx = await fixture();
+      const changed = barrier();
+      const release = barrier();
+      const pid = (await writer<{ pid: number }[]>`SELECT pg_backend_pid()::int AS pid`)[0]!.pid;
+      const started = startedOperations();
+      let primaryFailed = false;
+      try {
+        const update = started.track(writer.begin(async (connection) => {
+          await connection`UPDATE organization_users SET site_ids = ARRAY[${fx.second.id}]::uuid[]
+            WHERE org_id = ${fx.env.organization.id} AND user_id = ${fx.env.user.id}`;
+          changed.release();
+          await release.ready;
+        }));
+        await Promise.race([changed.ready, update.then(() => {
+          throw new Error('scope writer ended before its barrier');
+        })]);
+        const request = started.track(fx.invite(explicitRemovedSite ? [fx.env.site.id] : undefined));
+        try { await blockedBy(pid); } finally { release.release(); }
+        await update;
+        const response = await request;
+        expect(response.status).toBe(explicitRemovedSite ? 403 : 201);
+        const links = await fx.memberships();
+        const invited = links.filter((link) => link.userId !== fx.env.user.id);
+        if (explicitRemovedSite) {
+          expect(invited).toEqual([]);
+          expect(mail.sendInvite).not.toHaveBeenCalled();
+        } else {
+          expect(invited).toHaveLength(1);
+          expect(invited[0]?.siteIds).toEqual([fx.second.id]);
+          expect(mail.sendInvite).toHaveBeenCalledOnce();
+        }
+      } catch (error) {
+        primaryFailed = true;
+        throw error;
+      } finally {
+        release.release();
+        await started.drain(primaryFailed);
+      }
+    });
+  }
+
+  it('holds the inviter lock through membership insertion and request commit before the next scope writer', async () => {
+    const fx = await fixture();
+    const reachedMail = barrier();
+    const releaseMail = barrier();
+    mail.sendInvite.mockImplementationOnce(async () => { reachedMail.release(); await releaseMail.ready; });
+    const started = startedOperations();
+    let primaryFailed = false;
+    try {
+      const request = started.track(fx.invite([fx.env.site.id]));
+      await Promise.race([reachedMail.ready, request.then(async (response) => {
+        throw new Error(`request ended before inert-mail barrier: ${response.status}: ${await response.clone().text()}`);
+      })]);
+      // The mail boundary is after INSERT, still inside the real request context.
+      // Its transaction is not visible to an independent reader until commit.
+      expect(await fx.memberships()).toHaveLength(1);
+      const rows = await getTestDb().execute<{ pid: number }>(sql`
+        SELECT DISTINCT activity.pid FROM pg_stat_activity activity JOIN pg_locks locks USING (pid)
+        WHERE activity.datname = current_database() AND activity.usename = 'breeze_app'
+          AND activity.state = 'idle in transaction'
+          AND locks.relation = 'organization_users'::regclass
+      `);
+      expect(rows).toHaveLength(1);
+      const update = started.track(writer`UPDATE organization_users SET site_ids = ARRAY[${fx.second.id}]::uuid[]
+        WHERE org_id = ${fx.env.organization.id} AND user_id = ${fx.env.user.id}`.execute());
+      try { await blockedBy(rows[0]!.pid); } finally { releaseMail.release(); }
+      expect((await request).status).toBe(201);
+      await update;
+      const links = await fx.memberships();
+      expect(links.find((link) => link.userId === fx.env.user.id)?.siteIds).toEqual([fx.second.id]);
+      expect(links.find((link) => link.userId !== fx.env.user.id)?.siteIds).toEqual([fx.env.site.id]);
+      expect(mail.sendInvite).toHaveBeenCalledOnce();
+    } catch (error) {
+      primaryFailed = true;
+      throw error;
+    } finally {
+      releaseMail.release();
+      await started.drain(primaryFailed);
+    }
+  });
+});

--- a/apps/api/src/__tests__/integration/organizationMembershipDelegation.integration.test.ts
+++ b/apps/api/src/__tests__/integration/organizationMembershipDelegation.integration.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Real-PostgreSQL proof for organization site-scope delegation.
+ *
+ * Run only against the disposable per-worktree stack. The production `db`
+ * pool connects as `breeze_app`; fixture creation uses the test superuser.
+ */
+import './setup';
+
+import postgres from 'postgres';
+import { afterAll, describe, expect, it } from 'vitest';
+import { and, eq, sql } from 'drizzle-orm';
+import { db, withDbAccessContext, type DbAccessContext } from '../../db';
+import { organizationUsers } from '../../db/schema';
+import { resolveDelegatedSiteIds } from '../../services/organizationMembershipDelegation';
+import { getTestDb } from './setup';
+import {
+  createOrganization,
+  createPartner,
+  createRole,
+  createSite,
+  createUser,
+} from './db-utils';
+
+const DATABASE_URL = process.env.DATABASE_URL
+  ?? 'postgresql://breeze_test:breeze_test@localhost:5433/breeze_test';
+const writer = postgres(DATABASE_URL, { max: 1, onnotice: () => undefined });
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((r) => { resolve = r; });
+  return { promise, resolve };
+}
+
+async function waitForBackendBlockedBy(blockerPid: number): Promise<void> {
+  const deadline = Date.now() + 10_000;
+  for (;;) {
+    const rows = await getTestDb().execute<{ waiting: number }>(sql`
+      SELECT count(*)::int AS waiting
+      FROM pg_catalog.pg_stat_activity
+      WHERE datname = current_database()
+        AND state = 'active'
+        AND ${blockerPid} = ANY(pg_catalog.pg_blocking_pids(pid))
+    `);
+    if ((rows[0]?.waiting ?? 0) >= 1) return;
+    if (Date.now() > deadline) throw new Error('delegation did not block on the inviter membership lock');
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+async function fixture(options: { unrestricted?: boolean } = {}) {
+  const partner = await createPartner();
+  const orgA = await createOrganization({ partnerId: partner.id });
+  const orgB = await createOrganization({ partnerId: partner.id });
+  const siteA = await createSite({ orgId: orgA.id, name: 'Visible A' });
+  const siteA2 = await createSite({ orgId: orgA.id, name: 'Visible A2' });
+  const siteB = await createSite({ orgId: orgB.id, name: 'Foreign B' });
+  const role = await createRole({ scope: 'organization', orgId: orgA.id, partnerId: partner.id });
+  const inviter = await createUser({ partnerId: partner.id, orgId: orgA.id });
+  const invitee = await createUser({ partnerId: partner.id, orgId: orgA.id });
+
+  await getTestDb().insert(organizationUsers).values({
+    orgId: orgA.id,
+    userId: inviter.id,
+    roleId: role.id,
+    siteIds: options.unrestricted ? null : [siteA.id, siteA2.id],
+  });
+
+  const context: DbAccessContext = {
+    scope: 'organization',
+    orgId: orgA.id,
+    accessibleOrgIds: [orgA.id],
+    accessiblePartnerIds: [partner.id],
+    userId: inviter.id,
+    currentPartnerId: partner.id,
+  };
+  return { partner, orgA, orgB, siteA, siteA2, siteB, role, inviter, invitee, context };
+}
+
+afterAll(async () => {
+  await writer.end({ timeout: 5 });
+});
+
+describe('organization membership site-scope delegation', () => {
+  it('persists omitted scope as the restricted inviter scope under breeze_app', async () => {
+    const fx = await fixture();
+
+    await withDbAccessContext(fx.context, () => db.transaction(async (tx) => {
+      const siteIds = await resolveDelegatedSiteIds(tx, {
+        inviterUserId: fx.inviter.id,
+        orgId: fx.orgA.id,
+      });
+      await tx.insert(organizationUsers).values({
+        orgId: fx.orgA.id,
+        userId: fx.invitee.id,
+        roleId: fx.role.id,
+        siteIds,
+      });
+    }));
+
+    const [membership] = await getTestDb()
+      .select({ siteIds: organizationUsers.siteIds })
+      .from(organizationUsers)
+      .where(and(
+        eq(organizationUsers.orgId, fx.orgA.id),
+        eq(organizationUsers.userId, fx.invitee.id),
+      ));
+    expect(new Set(membership?.siteIds)).toEqual(new Set([fx.siteA.id, fx.siteA2.id]));
+  });
+
+  it('allows an own-org subset and denies hidden/foreign and cross-org membership writes', async () => {
+    const fx = await fixture();
+
+    await expect(withDbAccessContext(fx.context, () => db.transaction((tx) =>
+      resolveDelegatedSiteIds(tx, {
+        inviterUserId: fx.inviter.id,
+        orgId: fx.orgA.id,
+        requestedSiteIds: [fx.siteA.id],
+      })))).resolves.toEqual([fx.siteA.id]);
+
+    await expect(withDbAccessContext(fx.context, () => db.transaction((tx) =>
+      resolveDelegatedSiteIds(tx, {
+        inviterUserId: fx.inviter.id,
+        orgId: fx.orgA.id,
+        requestedSiteIds: [fx.siteB.id],
+      })))).rejects.toMatchObject({ status: 403 });
+
+    let crossOrgError: unknown;
+    try {
+      await withDbAccessContext(fx.context, () => db.insert(organizationUsers).values({
+        orgId: fx.orgB.id,
+        userId: fx.invitee.id,
+        roleId: fx.role.id,
+        siteIds: [fx.siteB.id],
+      }));
+    } catch (error) {
+      crossOrgError = error;
+    }
+    expect(crossOrgError).toBeDefined();
+    expect((crossOrgError as { cause?: { code?: string } }).cause?.code).toBe('42501');
+  });
+
+  it('serializes against a concurrent inviter-scope change and inherits the committed winner', async () => {
+    const fx = await fixture();
+    const writerChanged = deferred<void>();
+    const releaseWriter = deferred<void>();
+    const writerPid = (await writer<{ pid: number }[]>`
+      SELECT pg_backend_pid()::int AS pid
+    `)[0]?.pid;
+    if (writerPid === undefined) throw new Error('could not determine membership-writer backend PID');
+
+    const update = writer.begin(async (sql) => {
+      await sql`
+        UPDATE organization_users
+        SET site_ids = ARRAY[${fx.siteA2.id}]::uuid[]
+        WHERE org_id = ${fx.orgA.id} AND user_id = ${fx.inviter.id}
+      `;
+      writerChanged.resolve();
+      await releaseWriter.promise;
+    });
+    await writerChanged.promise;
+
+    const delegation = withDbAccessContext(fx.context, () => db.transaction((tx) =>
+      resolveDelegatedSiteIds(tx, {
+        inviterUserId: fx.inviter.id,
+        orgId: fx.orgA.id,
+      })));
+
+    await waitForBackendBlockedBy(writerPid);
+
+    releaseWriter.resolve();
+    await update;
+    await expect(delegation).resolves.toEqual([fx.siteA2.id]);
+  });
+
+  it('validates explicit sites even when the inviter is unrestricted', async () => {
+    const fx = await fixture({ unrestricted: true });
+    await expect(withDbAccessContext(fx.context, () => db.transaction((tx) =>
+      resolveDelegatedSiteIds(tx, {
+        inviterUserId: fx.inviter.id,
+        orgId: fx.orgA.id,
+        requestedSiteIds: [fx.siteB.id],
+      })))).rejects.toMatchObject({ status: 400 });
+  });
+});

--- a/apps/api/src/__tests__/integration/partnerSettingsAuthority.integration.test.ts
+++ b/apps/api/src/__tests__/integration/partnerSettingsAuthority.integration.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Partner-global settings authority — real PostgreSQL request-role coverage.
+ *
+ * Partner-axis RLS intentionally allows a partner member to reach their
+ * partner row, so the application-level full-partner capability is the
+ * load-bearing boundary for this mutation. These controls exercise the real
+ * route through the `breeze_app` request pool: selected/none memberships must
+ * be denied, while an all-access member may update and restore the setting.
+ */
+import './setup';
+
+import { randomUUID } from 'node:crypto';
+import { and, eq } from 'drizzle-orm';
+import { Hono } from 'hono';
+import { describe, expect, it } from 'vitest';
+
+import { partners, partnerUsers, users } from '../../db/schema';
+import { orgRoutes } from '../../routes/orgs';
+import { createAccessToken } from '../../services/jwt';
+import { setupTestEnvironment } from './db-utils';
+import { getTestDb } from './setup';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+function buildApp(): Hono {
+  const app = new Hono();
+  app.route('/orgs', orgRoutes);
+  return app;
+}
+
+describe('PATCH /orgs/partners/me partner-global authority', () => {
+  runDb('denies selected/none members and allows an all-access update and restore', async () => {
+    const env = await setupTestEnvironment({ scope: 'partner' });
+    const database = getTestDb();
+    await database
+      .update(partners)
+      .set({ settings: { security: { requireMfa: true, maxSessions: 4 } } })
+      .where(eq(partners.id, env.partner.id));
+    await database
+      .update(users)
+      .set({ mfaEnabled: true, mfaMethod: 'totp' })
+      .where(eq(users.id, env.user.id));
+
+    const token = await createAccessToken({
+      sub: env.user.id,
+      email: env.user.email,
+      roleId: env.role.id,
+      orgId: null,
+      partnerId: env.partner.id,
+      scope: 'partner',
+      mfa: true,
+      aep: 1,
+      mep: 1,
+      sid: randomUUID(),
+    });
+    const patch = (requireMfa: boolean) => buildApp().request('/orgs/partners/me', {
+      method: 'PATCH',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ settings: { security: { requireMfa } } }),
+    });
+    const readRequireMfa = async (): Promise<boolean | undefined> => {
+      const [row] = await database
+        .select({ settings: partners.settings })
+        .from(partners)
+        .where(eq(partners.id, env.partner.id))
+        .limit(1);
+      return (row?.settings as { security?: { requireMfa?: boolean } } | null)?.security?.requireMfa;
+    };
+    const setOrgAccess = async (orgAccess: 'all' | 'selected' | 'none') => {
+      await database
+        .update(partnerUsers)
+        .set({
+          orgAccess,
+          orgIds: orgAccess === 'selected' ? [env.organization.id] : null,
+        })
+        .where(and(
+          eq(partnerUsers.userId, env.user.id),
+          eq(partnerUsers.partnerId, env.partner.id),
+        ));
+    };
+
+    await setOrgAccess('selected');
+    expect((await patch(false)).status).toBe(403);
+    expect(await readRequireMfa()).toBe(true);
+
+    await setOrgAccess('none');
+    expect((await patch(false)).status).toBe(403);
+    expect(await readRequireMfa()).toBe(true);
+
+    await setOrgAccess('all');
+    const allowed = await patch(false);
+    expect(allowed.status).toBe(200);
+    expect(await readRequireMfa()).toBe(false);
+
+    const restored = await patch(true);
+    expect(restored.status).toBe(200);
+    expect(await readRequireMfa()).toBe(true);
+  });
+});

--- a/apps/api/src/__tests__/partner-wide-write-coverage.test.ts
+++ b/apps/api/src/__tests__/partner-wide-write-coverage.test.ts
@@ -170,7 +170,7 @@ const ALLOWED_WITHOUT_CAPABILITY_CHECK: Record<string, string> = {
   'services/contacts/compat.ts': 'updates one org\'s legacy billing-contact blob by org id',
   'services/invoiceService.ts': 'org billing settings + time-entry billing status, org-axis authority',
   'services/orgCurrencyService.ts': 'updates the selected organization\'s currency by org id',
-  'services/orgImport/index.ts': 'org import creates org-axis rows; gated by organizations:write on the route',
+  'services/orgImport/index.ts': 'org import creates org-axis rows across the resolved partner under system context; every HTTP entry point requires canManagePartnerWidePolicies, while mutating and CSV/PSA preview routes additionally require organizations:write and sites:write',
   'services/quickSupportOrg.ts': 'quick-support provisioning creates an org-axis container',
   'services/softwareDownloadPolicy.ts': 'writes one org\'s encrypted settings by org id',
   'services/softwarePolicyService.ts': 'flagged table is append-only policy audit evidence, not config',

--- a/apps/api/src/routes/accounting/customers.test.ts
+++ b/apps/api/src/routes/accounting/customers.test.ts
@@ -6,10 +6,12 @@ const { listAnnotatedMock, importMock, writeRouteAuditMock, QbImportError, authS
   const importMock = vi.fn();
   const writeRouteAuditMock = vi.fn();
   class QbImportError extends Error { code: string; status: number; constructor(m: string, c: string, s: number) { super(m); this.code = c; this.status = s; } }
-  // Both customer routes create orgs + default sites, so both are gated on
-  // organizations:write + sites:write.
+  // The import route creates orgs + default sites and is gated on both write
+  // permissions. The list route is read-only, but both routes still require
+  // full-partner org access because they enter the partner-wide import seam.
   const authState = {
     scope: 'partner' as 'partner' | 'system',
+    partnerOrgAccess: 'all' as 'all' | 'selected' | 'none' | null,
     permissions: new Set<string>(['organizations:write', 'sites:write']),
   };
   return { listAnnotatedMock, importMock, writeRouteAuditMock, QbImportError, authState };
@@ -26,6 +28,7 @@ vi.mock('../../middleware/auth', () => ({
     c.set('auth', {
       scope: authState.scope,
       partnerId: authState.scope === 'system' ? null : 'p1',
+      partnerOrgAccess: authState.scope === 'system' ? null : authState.partnerOrgAccess,
       user: { id: 'u1' },
     });
     await next();
@@ -48,6 +51,7 @@ vi.mock('../../config/env', () => ({
 }));
 
 import { accountingRoutes } from './index';
+import { PARTNER_WIDE_WRITE_DENIED_MESSAGE } from '../../services/partnerWideAccess';
 
 function app() {
   const a = new Hono();
@@ -58,10 +62,24 @@ function app() {
 beforeEach(() => {
   vi.clearAllMocks();
   authState.scope = 'partner';
+  authState.partnerOrgAccess = 'all';
   authState.permissions = new Set(['organizations:write', 'sites:write']);
 });
 
 describe('GET /accounting/:provider/customers', () => {
+  it.each(['selected', 'none'] as const)(
+    'denies partnerOrgAccess=%s before the partner-wide preview seam',
+    async (partnerOrgAccess) => {
+      authState.partnerOrgAccess = partnerOrgAccess;
+
+      const res = await app().request('/accounting/quickbooks/customers');
+
+      expect(res.status).toBe(403);
+      expect(await res.json()).toEqual({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE });
+      expect(listAnnotatedMock).not.toHaveBeenCalled();
+    },
+  );
+
   it('returns annotated customers', async () => {
     listAnnotatedMock.mockResolvedValue([{ id: '1', displayName: 'Acme', alreadyImported: false, organizationId: null }]);
     const res = await app().request('/accounting/quickbooks/customers');
@@ -109,6 +127,23 @@ describe('GET /accounting/:provider/customers', () => {
 });
 
 describe('POST /accounting/:provider/customers/import', () => {
+  it.each(['selected', 'none'] as const)(
+    'denies partnerOrgAccess=%s before the partner-wide commit seam',
+    async (partnerOrgAccess) => {
+      authState.partnerOrgAccess = partnerOrgAccess;
+
+      const res = await app().request('/accounting/quickbooks/customers/import', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ customerIds: ['1'] }),
+      });
+
+      expect(res.status).toBe(403);
+      expect(await res.json()).toEqual({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE });
+      expect(importMock).not.toHaveBeenCalled();
+    },
+  );
+
   it('imports selected customers and returns the summary', async () => {
     importMock.mockResolvedValue({
       imported: [{ customerId: '1', displayName: 'Acme', organizationId: 'org-1', siteId: 'site-1' }],

--- a/apps/api/src/routes/accounting/index.test.ts
+++ b/apps/api/src/routes/accounting/index.test.ts
@@ -32,6 +32,7 @@ const { authState, mocks, AccountingConnectionErrorClass } = vi.hoisted(() => {
     authState: {
       scope: 'partner' as 'partner' | 'system' | 'organization',
       partnerId: '11111111-1111-1111-1111-111111111111' as string | null,
+      partnerOrgAccess: 'all' as 'all' | 'selected' | 'none' | null,
       mfa: true,
       // Finding D: PATCH /settings must gate pullPayments/pushMode on the same
       // invoices:write the push routes use, so the suite needs a REVOCABLE
@@ -106,6 +107,7 @@ vi.mock('../../middleware/auth', () => ({
     c.set('auth', {
       scope: authState.scope,
       partnerId: authState.partnerId,
+      partnerOrgAccess: authState.partnerOrgAccess,
       orgId: null,
       accessibleOrgIds: [],
       canAccessOrg: vi.fn(() => true),
@@ -122,8 +124,10 @@ vi.mock('../../middleware/auth', () => ({
     if (!authState.mfa) return c.json({ error: 'MFA required' }, 403);
     return next();
   }),
-  // The customer routes are permission-gated (organizations:write +
-  // sites:write); this suite covers the OAuth/settings routes, so grant those.
+  // The customer import route is permission-gated (organizations:write +
+  // sites:write); the read-only customer list instead uses the full-partner
+  // capability without those write permissions. This suite covers the
+  // OAuth/settings routes, so grant the import permissions here.
   // `invoices:write` is separately revocable — see authState.invoicesWrite.
   requirePermission: vi.fn((resource: string, action: string) => async (c: any, next: any) => {
     if (resource === 'invoices' && action === 'write' && !authState.invoicesWrite) {
@@ -206,6 +210,7 @@ describe('accounting routes', () => {
     vi.clearAllMocks();
     authState.scope = 'partner';
     authState.partnerId = '11111111-1111-1111-1111-111111111111';
+    authState.partnerOrgAccess = 'all';
     authState.mfa = true;
     authState.invoicesWrite = true;
     app = new Hono();

--- a/apps/api/src/routes/accounting/index.ts
+++ b/apps/api/src/routes/accounting/index.ts
@@ -45,10 +45,25 @@ import { writeRouteAudit } from '../../services/auditEvents';
 import { getAccountingProvider } from '../../services/accounting/providerRegistry';
 import { captureException, captureMessage } from '../../services/sentry';
 import type { AccountingProviderId } from '../../services/accounting/types';
+import {
+  canManagePartnerWidePolicies,
+  PARTNER_WIDE_WRITE_DENIED_MESSAGE,
+} from '../../services/partnerWideAccess';
 
 export const accountingRoutes = new Hono();
 
 const partnerScopes = requireScope('partner', 'system');
+
+// Customer annotation and import both enter the shared org-import seam, which
+// reads the whole partner tenant tree under system DB context. The capability
+// follows that blast radius, not the accounting connection: an org-selected
+// member must not infer matches or create tenants outside their selection.
+const requireFullPartnerOrgImportAccess: MiddlewareHandler = async (c, next) => {
+  if (!canManagePartnerWidePolicies(c.get('auth') as AuthContext)) {
+    return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
+  }
+  return next();
+};
 
 // The IMPORT route creates organizations and their default sites, so it carries
 // the same permission pair as routes/orgs.ts POST /import. The customer LIST
@@ -67,8 +82,9 @@ const requireSiteWrite = requirePermission(PERMISSIONS.SITES_WRITE.resource, PER
  * from `?partnerId=`. System scope is already the most privileged scope and is
  * gated above, so the per-partner role check does not apply to it.
  *
- * Note routes/orgs.ts POST /import has the same latent gap; it is not fixed
- * here to keep this PR's blast radius on the QuickBooks path.
+ * routes/orgs.ts POST /import advertises the same system scope but still uses
+ * the raw permission guards, so membership-less system callers remain a
+ * separate route-contract/availability residual rather than an authz bypass.
  */
 function partnerScopedPermission(...guards: MiddlewareHandler[]): MiddlewareHandler {
   return async (c, next) => {
@@ -349,6 +365,25 @@ function resolvePartnerId(auth: Pick<AuthContext, 'scope' | 'partnerId'>, reques
   return { partnerId: requested };
 }
 
+/**
+ * Every interactive accounting route operates on one partner-global provider
+ * realm. Prove both the exact partner binding and raw all-organization partner
+ * authority before validation, configuration checks, database/provider work,
+ * queueing, or audit. System automation keeps its explicit-partner behavior;
+ * signed provider callbacks and background workers use separate trust paths.
+ */
+const requireAccountingPartnerAuthority: MiddlewareHandler = async (c, next) => {
+  const auth = c.get('auth') as AuthContext | undefined;
+  if (!auth) return c.json({ error: 'Not authenticated' }, 401);
+
+  const partner = resolvePartnerId(auth, c.req.query('partnerId'));
+  if ('error' in partner) return c.json({ error: partner.error }, partner.status);
+  if (!canManagePartnerWidePolicies(auth)) {
+    return c.json({ error: 'Full partner organization access is required' }, 403);
+  }
+  return next();
+};
+
 function validateProviderConfig(provider: AccountingProviderId): string | null {
   if (provider !== 'quickbooks') return null;
   if (!QBO_CLIENT_ID || !QBO_CLIENT_SECRET || !QBO_REDIRECT_URI || !QBO_ENVIRONMENT) {
@@ -362,7 +397,7 @@ function validateProviderConfig(provider: AccountingProviderId): string | null {
 
 // Initiate the OAuth flow. Authenticated + MFA-gated: this is the privileged
 // action that decides which partner an external accounting realm links to.
-accountingRoutes.get('/:provider/connect', authMiddleware, partnerScopes, requireMfa(), zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), async (c) => {
+accountingRoutes.get('/:provider/connect', authMiddleware, partnerScopes, requireAccountingPartnerAuthority, requireMfa(), zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), async (c) => {
   const { provider } = c.req.valid('param');
   const configError = validateProviderConfig(provider);
   if (configError) return c.json({ error: configError }, 400);
@@ -605,7 +640,7 @@ accountingRoutes.get('/:provider/callback', zValidator('param', providerParamSch
   return c.redirect('/integrations?accounting=quickbooks&connected=1#accounting');
 });
 
-accountingRoutes.post('/:provider/disconnect', authMiddleware, partnerScopes, requireMfa(), zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), async (c) => {
+accountingRoutes.post('/:provider/disconnect', authMiddleware, partnerScopes, requireAccountingPartnerAuthority, requireMfa(), zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), async (c) => {
   const { provider } = c.req.valid('param');
   const partner = resolvePartnerId(c.get('auth'), c.req.valid('query').partnerId);
   if ('error' in partner) return c.json({ error: partner.error }, partner.status);
@@ -636,7 +671,7 @@ accountingRoutes.post('/:provider/disconnect', authMiddleware, partnerScopes, re
   return c.json({ disconnected: true });
 });
 
-accountingRoutes.get('/:provider', authMiddleware, partnerScopes, zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), async (c) => {
+accountingRoutes.get('/:provider', authMiddleware, partnerScopes, requireAccountingPartnerAuthority, zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), async (c) => {
   const { provider } = c.req.valid('param');
   const partner = resolvePartnerId(c.get('auth'), c.req.valid('query').partnerId);
   if ('error' in partner) return c.json({ error: partner.error }, partner.status);
@@ -684,10 +719,10 @@ accountingRoutes.get('/:provider', authMiddleware, partnerScopes, zValidator('pa
 });
 
 // List remote QuickBooks customers, annotated with whether each is already
-// imported. Read-only — it creates nothing in Breeze — so partner/system scope
-// is the whole gate; see requireImportPermissions for why no write permission
-// is required here.
-accountingRoutes.get('/:provider/customers', authMiddleware, partnerScopes, zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), async (c) => {
+// imported. The route creates nothing in Breeze, so it needs no write-role
+// permission, but annotation still compares against every organization in the
+// partner and therefore requires full-partner org access.
+accountingRoutes.get('/:provider/customers', authMiddleware, partnerScopes, requireFullPartnerOrgImportAccess, requireAccountingPartnerAuthority, zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), async (c) => {
   const { provider } = c.req.valid('param');
   const configError = validateProviderConfig(provider);
   if (configError) return c.json({ error: configError }, 400);
@@ -702,7 +737,7 @@ accountingRoutes.get('/:provider/customers', authMiddleware, partnerScopes, zVal
 });
 
 // Import selected QuickBooks customers as orgs + sites. Write + MFA-gated.
-accountingRoutes.post('/:provider/customers/import', authMiddleware, partnerScopes, requireImportPermissions, requireMfa(), zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), zValidator('json', importCustomersSchema), async (c) => {
+accountingRoutes.post('/:provider/customers/import', authMiddleware, partnerScopes, requireFullPartnerOrgImportAccess, requireAccountingPartnerAuthority, requireImportPermissions, requireMfa(), zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), zValidator('json', importCustomersSchema), async (c) => {
   const { provider } = c.req.valid('param');
   const configError = validateProviderConfig(provider);
   if (configError) return c.json({ error: configError }, 400);
@@ -738,7 +773,7 @@ accountingRoutes.post('/:provider/customers/import', authMiddleware, partnerScop
   return c.json({ data: summary });
 });
 
-accountingRoutes.patch('/:provider/settings', authMiddleware, partnerScopes, requireMfa(), zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), zValidator('json', settingsSchema), requireInvoicePushForSyncSwitches, async (c) => {
+accountingRoutes.patch('/:provider/settings', authMiddleware, partnerScopes, requireAccountingPartnerAuthority, requireMfa(), zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), zValidator('json', settingsSchema), requireInvoicePushForSyncSwitches, async (c) => {
   const { provider } = c.req.valid('param');
   const body = c.req.valid('json');
   const partner = resolvePartnerId(c.get('auth'), c.req.valid('query').partnerId);
@@ -795,7 +830,7 @@ accountingRoutes.patch('/:provider/settings', authMiddleware, partnerScopes, req
 // already open, so no connection is pinned across the QuickBooks round trip
 // and each phase commits on its own (services/accounting/dbContextGuard.ts).
 // The same applies to the four mapping-workbench routes below.
-accountingRoutes.post('/:provider/settings/refresh', authMiddleware, partnerScopes, requireMfa(), zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), async (c) => {
+accountingRoutes.post('/:provider/settings/refresh', authMiddleware, partnerScopes, requireAccountingPartnerAuthority, requireMfa(), zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), async (c) => {
   const { provider } = c.req.valid('param');
   const configError = validateProviderConfig(provider);
   if (configError) return c.json({ error: configError }, 400);
@@ -842,7 +877,7 @@ accountingRoutes.post('/:provider/settings/refresh', authMiddleware, partnerScop
 // Reports `enqueued` HONESTLY (the Phase C lesson: `enqueueAccountingInvoicePush`
 // swallows a Redis outage by design, so the caller must surface its boolean
 // rather than assume the job landed — see the push-bulk route's comment above).
-accountingRoutes.post('/:provider/reconcile', authMiddleware, partnerScopes, requireMfa(), requireInvoicePush, zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), async (c) => {
+accountingRoutes.post('/:provider/reconcile', authMiddleware, partnerScopes, requireAccountingPartnerAuthority, requireMfa(), requireInvoicePush, zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), async (c) => {
   const { provider } = c.req.valid('param');
   const partner = resolvePartnerId(c.get('auth'), c.req.valid('query').partnerId);
   if ('error' in partner) return c.json({ error: partner.error }, partner.status);
@@ -886,7 +921,7 @@ accountingRoutes.post('/:provider/reconcile', authMiddleware, partnerScopes, req
 // SELF_MANAGED_DB_CONTEXT_ROUTES (middleware/selfManagedDbContextRoutes.ts) —
 // no ambient request transaction, so the service's ambient-`db` reads need an
 // explicit context (Task 5 review fix — see the settings/refresh comment above).
-accountingRoutes.get('/:provider/mappings', authMiddleware, partnerScopes, zValidator('param', providerParamSchema), zValidator('query', mappingEntityQuerySchema), async (c) => {
+accountingRoutes.get('/:provider/mappings', authMiddleware, partnerScopes, requireAccountingPartnerAuthority, zValidator('param', providerParamSchema), zValidator('query', mappingEntityQuerySchema), async (c) => {
   const { provider } = c.req.valid('param');
   const configError = validateProviderConfig(provider);
   if (configError) return c.json({ error: configError }, 400);
@@ -909,7 +944,7 @@ accountingRoutes.get('/:provider/mappings', authMiddleware, partnerScopes, zVali
 // Remote income account selector for item mapping — read-only. Also QBO-HTTP
 // backed, so it carries the same SELF_MANAGED_DB_CONTEXT_ROUTES registration
 // (and the same explicit-context requirement — Task 5 review fix).
-accountingRoutes.get('/:provider/income-accounts', authMiddleware, partnerScopes, zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), async (c) => {
+accountingRoutes.get('/:provider/income-accounts', authMiddleware, partnerScopes, requireAccountingPartnerAuthority, zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), async (c) => {
   const { provider } = c.req.valid('param');
   const configError = validateProviderConfig(provider);
   if (configError) return c.json({ error: configError }, 400);
@@ -933,7 +968,7 @@ accountingRoutes.get('/:provider/income-accounts', authMiddleware, partnerScopes
 // `confirmed` path calls the provider list to verify the remote entity, so
 // this route also carries the SELF_MANAGED_DB_CONTEXT_ROUTES registration
 // (and the same explicit-context requirement — Task 5 review fix).
-accountingRoutes.put('/:provider/mappings', authMiddleware, partnerScopes, requireMfa(), zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), zValidator('json', mappingDecisionSchema), requireMappingWrite, async (c) => {
+accountingRoutes.put('/:provider/mappings', authMiddleware, partnerScopes, requireAccountingPartnerAuthority, requireMfa(), zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), zValidator('json', mappingDecisionSchema), requireMappingWrite, async (c) => {
   const { provider } = c.req.valid('param');
   const configError = validateProviderConfig(provider);
   if (configError) return c.json({ error: configError }, 400);
@@ -978,7 +1013,7 @@ accountingRoutes.put('/:provider/mappings', authMiddleware, partnerScopes, requi
 // SELF_MANAGED_DB_CONTEXT_ROUTES registration (the provider upsert call is
 // real QuickBooks HTTP) — and the same explicit-context requirement (Task 5
 // review fix).
-accountingRoutes.post('/:provider/mappings/sync', authMiddleware, partnerScopes, requireMfa(), zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), zValidator('json', mappingSyncSchema), requireMappingWrite, async (c) => {
+accountingRoutes.post('/:provider/mappings/sync', authMiddleware, partnerScopes, requireAccountingPartnerAuthority, requireMfa(), zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), zValidator('json', mappingSyncSchema), requireMappingWrite, async (c) => {
   const { provider } = c.req.valid('param');
   const configError = validateProviderConfig(provider);
   if (configError) return c.json({ error: configError }, 400);
@@ -1036,6 +1071,7 @@ accountingRoutes.post(
   '/:provider/invoices/:invoiceId/push',
   authMiddleware,
   partnerScopes,
+  requireAccountingPartnerAuthority,
   requireMfa(),
   requireInvoicePush,
   zValidator('param', invoicePushParamSchema),
@@ -1083,6 +1119,7 @@ accountingRoutes.post(
   '/:provider/invoices/push-bulk',
   authMiddleware,
   partnerScopes,
+  requireAccountingPartnerAuthority,
   requireMfa(),
   requireInvoicePush,
   zValidator('param', providerParamSchema),
@@ -1146,6 +1183,7 @@ accountingRoutes.get(
   '/:provider/remote-candidates',
   authMiddleware,
   partnerScopes,
+  requireAccountingPartnerAuthority,
   zValidator('param', providerParamSchema),
   zValidator('query', remoteCandidatesQuerySchema),
   async (c) => {

--- a/apps/api/src/routes/accounting/invoicePush.test.ts
+++ b/apps/api/src/routes/accounting/invoicePush.test.ts
@@ -47,6 +47,7 @@ const {
   }
   const authState = {
     scope: 'partner' as 'partner' | 'system' | 'organization',
+    partnerOrgAccess: 'all' as 'all' | 'selected' | 'none' | null,
     permissions: new Set<string>(['invoices:write']),
     mfa: true,
   };
@@ -117,6 +118,7 @@ vi.mock('../../middleware/auth', () => ({
     c.set('auth', {
       scope: authState.scope,
       partnerId: authState.scope === 'organization' ? null : 'p1',
+      partnerOrgAccess: authState.partnerOrgAccess,
       user: { id: 'u1' },
     });
     await next();

--- a/apps/api/src/routes/accounting/mappings.test.ts
+++ b/apps/api/src/routes/accounting/mappings.test.ts
@@ -29,6 +29,7 @@ const {
   }
   const authState = {
     scope: 'partner' as 'partner' | 'system',
+    partnerOrgAccess: 'all' as 'all' | 'selected' | 'none' | null,
     permissions: new Set<string>(['organizations:write', 'catalog:write']),
     mfa: true,
   };
@@ -73,6 +74,7 @@ vi.mock('../../middleware/auth', () => ({
     c.set('auth', {
       scope: authState.scope,
       partnerId: authState.scope === 'system' ? null : 'p1',
+      partnerOrgAccess: authState.partnerOrgAccess,
       user: { id: 'u1' },
     });
     await next();

--- a/apps/api/src/routes/accounting/partnerAuthority.test.ts
+++ b/apps/api/src/routes/accounting/partnerAuthority.test.ts
@@ -1,0 +1,309 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+const PARTNER_ID = '11111111-1111-4111-8111-111111111111';
+const OTHER_PARTNER_ID = '22222222-2222-4222-8222-222222222222';
+const ENTITY_ID = '33333333-3333-4333-8333-333333333333';
+
+const { authState, effects, AccountingError } = vi.hoisted(() => {
+  class AccountingError extends Error {
+    constructor(
+      public readonly code: string,
+      public readonly status: number,
+      message: string,
+    ) {
+      super(message);
+    }
+  }
+  return {
+    authState: {
+      scope: 'partner' as 'partner' | 'system' | 'organization',
+      partnerId: '11111111-1111-4111-8111-111111111111' as string | null,
+      partnerOrgAccess: 'selected' as 'all' | 'selected' | 'none' | null,
+    },
+    effects: {
+      buildAuthUrl: vi.fn(() => 'https://provider.example.test/oauth'),
+      getConnection: vi.fn(),
+      deleteConnection: vi.fn(),
+      refreshRealmSettings: vi.fn(),
+      listCustomers: vi.fn(),
+      importCustomers: vi.fn(),
+      listMappings: vi.fn(),
+      listIncomeAccounts: vi.fn(),
+      saveMapping: vi.fn(),
+      syncMapping: vi.fn(),
+      resolveConnection: vi.fn(),
+      listRemoteCustomers: vi.fn(),
+      pushInvoice: vi.fn(),
+      enqueueInvoice: vi.fn(),
+      enqueueReconcile: vi.fn(),
+      dbSelect: vi.fn(),
+      dbUpdateReturning: vi.fn(),
+      audit: vi.fn(),
+    },
+    AccountingError,
+  };
+});
+
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: async (c: any, next: any) => {
+    c.set('auth', {
+      scope: authState.scope,
+      partnerId: authState.partnerId,
+      partnerOrgAccess: authState.partnerOrgAccess,
+      orgId: authState.scope === 'organization' ? ENTITY_ID : null,
+      user: { id: ENTITY_ID },
+      token: { mfa: true },
+    });
+    return next();
+  },
+  requireScope: (...scopes: string[]) => async (c: any, next: any) => (
+    scopes.includes(c.get('auth').scope)
+      ? next()
+      : c.json({ error: 'Insufficient permissions' }, 403)
+  ),
+  requireMfa: () => async (_c: any, next: any) => next(),
+  requirePermission: () => async (_c: any, next: any) => next(),
+  withAuthDbAccessContext: async (_auth: unknown, fn: () => unknown) => fn(),
+}));
+
+vi.mock('../../db', () => ({
+  db: {
+    select: effects.dbSelect,
+    update: vi.fn(() => ({
+      set: () => ({ where: () => ({ returning: effects.dbUpdateReturning }) }),
+    })),
+  },
+  runOutsideDbContext: <T>(fn: () => T) => fn(),
+  withSystemDbAccessContext: <T>(fn: () => T) => fn(),
+}));
+
+vi.mock('../../services/accounting/accountingConnectionService', () => ({
+  getConnection: effects.getConnection,
+  deleteConnection: effects.deleteConnection,
+  refreshRealmSettings: effects.refreshRealmSettings,
+  upsertConnection: vi.fn(),
+  resetConnectionForRealmChange: vi.fn(),
+  updateHomeCurrency: vi.fn(),
+  updateMultiCurrencyEnabled: vi.fn(),
+  isHomeCurrencyCasAbort: () => false,
+  AccountingConnectionError: AccountingError,
+}));
+
+vi.mock('../../services/accounting/quickbooksCustomerImport', () => ({
+  listQuickbooksCustomersAnnotated: effects.listCustomers,
+  importQuickbooksCustomers: effects.importCustomers,
+  QbImportError: AccountingError,
+}));
+
+vi.mock('../../services/accounting/accountingMappingService', () => ({
+  listMappingProposals: effects.listMappings,
+  listRemoteIncomeAccountsForPartner: effects.listIncomeAccounts,
+  saveMappingDecision: effects.saveMapping,
+  syncMappedEntity: effects.syncMapping,
+  resolveConnectionAndToken: effects.resolveConnection,
+  AccountingMappingError: AccountingError,
+}));
+
+vi.mock('../../services/accounting/accountingInvoicePush', () => ({
+  pushInvoiceToAccounting: effects.pushInvoice,
+  AccountingInvoicePushError: AccountingError,
+}));
+
+vi.mock('../../services/accounting/providerRegistry', () => ({
+  getAccountingProvider: () => ({
+    buildAuthUrl: effects.buildAuthUrl,
+    listRemoteCustomers: effects.listRemoteCustomers,
+    listRemoteItems: vi.fn(),
+  }),
+}));
+
+vi.mock('../../jobs/accountingSyncWorker', () => ({
+  enqueueAccountingInvoicePush: effects.enqueueInvoice,
+}));
+vi.mock('../../jobs/accountingReconcileWorker', () => ({
+  enqueueAccountingReconcile: effects.enqueueReconcile,
+}));
+vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: effects.audit }));
+vi.mock('../../services/sentry', () => ({ captureException: vi.fn(), captureMessage: vi.fn() }));
+vi.mock('../../config/env', () => ({
+  QBO_CLIENT_ID: 'client-id',
+  QBO_CLIENT_SECRET: 'client-secret',
+  QBO_REDIRECT_URI: 'https://api.example.test/accounting/quickbooks/callback',
+  QBO_ENVIRONMENT: 'production',
+}));
+
+import { accountingRoutes } from './index';
+
+type RouteCase = {
+  name: string;
+  method?: string;
+  path: string;
+  body?: unknown;
+  effect: keyof typeof effects;
+};
+
+const routes: RouteCase[] = [
+  { name: 'connect', path: '/quickbooks/connect', effect: 'buildAuthUrl' },
+  { name: 'disconnect', method: 'POST', path: '/quickbooks/disconnect', effect: 'deleteConnection' },
+  { name: 'status', path: '/quickbooks', effect: 'getConnection' },
+  { name: 'customers', path: '/quickbooks/customers', effect: 'listCustomers' },
+  {
+    name: 'customer import', method: 'POST', path: '/quickbooks/customers/import',
+    body: { customerIds: ['remote-1'] }, effect: 'importCustomers',
+  },
+  {
+    name: 'settings update', method: 'PATCH', path: '/quickbooks/settings',
+    body: { defaultIncomeAccountRef: '79' }, effect: 'dbUpdateReturning',
+  },
+  { name: 'settings refresh', method: 'POST', path: '/quickbooks/settings/refresh', effect: 'refreshRealmSettings' },
+  { name: 'reconcile', method: 'POST', path: '/quickbooks/reconcile', effect: 'enqueueReconcile' },
+  { name: 'mapping proposals', path: '/quickbooks/mappings?entityType=org', effect: 'listMappings' },
+  { name: 'income accounts', path: '/quickbooks/income-accounts', effect: 'listIncomeAccounts' },
+  {
+    name: 'mapping decision', method: 'PUT', path: '/quickbooks/mappings',
+    body: { breezeEntityType: 'org', breezeEntityId: ENTITY_ID, decision: 'unlinked' }, effect: 'saveMapping',
+  },
+  {
+    name: 'mapping sync', method: 'POST', path: '/quickbooks/mappings/sync',
+    body: { breezeEntityType: 'org', breezeEntityId: ENTITY_ID }, effect: 'syncMapping',
+  },
+  { name: 'invoice push', method: 'POST', path: `/quickbooks/invoices/${ENTITY_ID}/push`, effect: 'pushInvoice' },
+  {
+    name: 'bulk invoice push', method: 'POST', path: '/quickbooks/invoices/push-bulk',
+    body: { invoiceIds: [ENTITY_ID] }, effect: 'enqueueInvoice',
+  },
+  { name: 'remote candidates', path: '/quickbooks/remote-candidates?entityType=org', effect: 'resolveConnection' },
+];
+
+const effectMocks = Object.values(effects);
+
+function app() {
+  const result = new Hono();
+  result.route('/accounting', accountingRoutes);
+  return result;
+}
+
+function pathFor(route: RouteCase, explicitPartnerId?: string): string {
+  const suffix = explicitPartnerId
+    ? `${route.path.includes('?') ? '&' : '?'}partnerId=${explicitPartnerId}`
+    : '';
+  return `/accounting${route.path}${suffix}`;
+}
+
+async function request(route: RouteCase, explicitPartnerId?: string) {
+  return app().request(pathFor(route, explicitPartnerId), {
+    method: route.method,
+    headers: route.body ? { 'Content-Type': 'application/json' } : undefined,
+    body: route.body ? JSON.stringify(route.body) : undefined,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  authState.scope = 'partner';
+  authState.partnerId = PARTNER_ID;
+  authState.partnerOrgAccess = 'selected';
+  effects.getConnection.mockResolvedValue({ id: 'connection-1', partnerId: PARTNER_ID, pullPayments: true });
+  effects.deleteConnection.mockResolvedValue({ id: 'connection-1' });
+  effects.refreshRealmSettings.mockResolvedValue({ homeCurrency: 'USD', multiCurrencyEnabled: false });
+  effects.listCustomers.mockResolvedValue([]);
+  effects.importCustomers.mockResolvedValue({ imported: [], skipped: [], errors: [] });
+  effects.listMappings.mockResolvedValue([]);
+  effects.listIncomeAccounts.mockResolvedValue([]);
+  const mapping = {
+    id: 'mapping-1', breezeEntityType: 'org', breezeEntityId: ENTITY_ID,
+    remoteEntityType: 'Customer', remoteEntityId: null, linkStatus: 'unlinked',
+    syncStatus: 'pending', lastSyncedAt: null, lastError: null,
+  };
+  effects.saveMapping.mockResolvedValue(mapping);
+  effects.syncMapping.mockResolvedValue(mapping);
+  effects.resolveConnection.mockResolvedValue({ liveConn: {} });
+  effects.listRemoteCustomers.mockResolvedValue([]);
+  effects.pushInvoice.mockResolvedValue({
+    mappingId: 'mapping-1', remoteEntityId: 'remote-1', docNumber: '1',
+    syncStatus: 'synced', taxVarianceCents: 0,
+  });
+  effects.enqueueInvoice.mockResolvedValue(true);
+  effects.enqueueReconcile.mockResolvedValue(true);
+  effects.dbSelect.mockReturnValue({
+    from: () => ({ where: () => Promise.resolve([{ id: ENTITY_ID }]) }),
+  });
+  effects.dbUpdateReturning.mockResolvedValue([{
+    status: 'connected', environment: 'production', pushMode: 'auto',
+    defaultIncomeAccountRef: '79', defaultTaxCodeRef: null, lastError: null, pullPayments: true,
+  }]);
+});
+
+describe('partner-global accounting route authority', () => {
+  const deniedCases = (['selected', 'none', null] as const).flatMap((partnerOrgAccess) =>
+    routes.map((route) => ({ partnerOrgAccess, route })),
+  );
+
+  it.each(deniedCases)(
+    'denies partnerOrgAccess=$partnerOrgAccess before the $route.name sink',
+    async ({ partnerOrgAccess, route }) => {
+      authState.partnerOrgAccess = partnerOrgAccess;
+      const response = await request(route);
+      expect(response.status, route.name).toBe(403);
+      expect(response.headers.get('set-cookie'), route.name).toBeNull();
+      for (const effect of effectMocks) expect(effect, route.name).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(routes)('allows full-partner authority through to $name', async (route) => {
+    authState.partnerOrgAccess = 'all';
+    const response = await request(route);
+    expect(response.status).not.toBe(403);
+    expect(effects[route.effect]).toHaveBeenCalled();
+  });
+
+  it.each(routes)('allows system scope with an explicit partner through to $name', async (route) => {
+    authState.scope = 'system';
+    authState.partnerId = null;
+    authState.partnerOrgAccess = null;
+    const response = await request(route, PARTNER_ID);
+    expect(response.status).not.toBe(403);
+    expect(effects[route.effect]).toHaveBeenCalled();
+  });
+
+  it.each(routes)('denies organization scope before the $name sink', async (route) => {
+    authState.scope = 'organization';
+    authState.partnerId = null;
+    authState.partnerOrgAccess = null;
+    const response = await request(route);
+    expect(response.status).toBe(403);
+    expect(effects[route.effect]).not.toHaveBeenCalled();
+  });
+
+  it('denies a full-partner caller that requests a different partner before the sink', async () => {
+    authState.partnerOrgAccess = 'all';
+    const response = await request(routes.find((route) => route.name === 'status')!, OTHER_PARTNER_ID);
+    expect(response.status).toBe(403);
+    expect(effects.getConnection).not.toHaveBeenCalled();
+  });
+
+  it('requires system scope to bind an explicit partner before the sink', async () => {
+    authState.scope = 'system';
+    authState.partnerId = null;
+    authState.partnerOrgAccess = null;
+    const response = await request(routes.find((route) => route.name === 'status')!);
+    expect(response.status).toBe(400);
+    expect(effects.getConnection).not.toHaveBeenCalled();
+  });
+
+  it('denies restricted authority before provider and body validation', async () => {
+    const response = await app().request('/accounting/not-a-provider/settings', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    });
+    expect(response.status).toBe(403);
+    for (const effect of effectMocks) expect(effect).not.toHaveBeenCalled();
+  });
+
+  it('keeps the unauthenticated signed callback outside the human-route gate', async () => {
+    const response = await app().request('/accounting/quickbooks/callback');
+    expect(response.status).toBe(400);
+  });
+});

--- a/apps/api/src/routes/accounting/reconcile.test.ts
+++ b/apps/api/src/routes/accounting/reconcile.test.ts
@@ -17,6 +17,7 @@ const {
   const writeRouteAuditMock = vi.fn();
   const authState = {
     scope: 'partner' as 'partner' | 'system' | 'organization',
+    partnerOrgAccess: 'all' as 'all' | 'selected' | 'none' | null,
     permissions: new Set<string>(['invoices:write']),
     mfa: true,
   };
@@ -95,6 +96,7 @@ vi.mock('../../middleware/auth', () => ({
     c.set('auth', {
       scope: authState.scope,
       partnerId: authState.scope === 'organization' ? null : 'p1',
+      partnerOrgAccess: authState.partnerOrgAccess,
       user: { id: 'u1' },
     });
     await next();

--- a/apps/api/src/routes/orgs.test.ts
+++ b/apps/api/src/routes/orgs.test.ts
@@ -15,6 +15,16 @@ vi.mock('../services/sentry', () => ({
   isSentryEnabled: vi.fn().mockReturnValue(false)
 }));
 
+vi.mock('../services/auditEvents', () => ({
+  writeAuditEvent: vi.fn(),
+  writeRouteAudit: vi.fn(),
+}));
+
+vi.mock('../oauth/partnerScopePolicy', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../oauth/partnerScopePolicy')>()),
+  clearPartnerScopePolicyCache: vi.fn(),
+}));
+
 vi.mock('../services/clientIp', () => ({
   getTrustedClientIpOrUndefined: vi.fn()
 }));
@@ -338,6 +348,9 @@ import {
 import { captureException } from '../services/sentry';
 import { seedSystemTicketStatuses } from '../services/ticketConfigService';
 import { enqueueAiBudgetEvaluationForPartner } from '../jobs/aiBudgetAlertDelivery';
+import { writeRouteAudit } from '../services/auditEvents';
+import { clearPartnerScopePolicyCache } from '../oauth/partnerScopePolicy';
+import { PARTNER_WIDE_WRITE_DENIED_MESSAGE } from '../services/partnerWideAccess';
 
 describe('org routes', () => {
   let app: Hono;
@@ -5457,6 +5470,90 @@ describe('org routes', () => {
   });
 
   describe('PATCH /orgs/partners/me', () => {
+    it.each([
+      ['selected', ['org-1']],
+      ['none', []],
+      [null, []],
+      [undefined, []],
+    ] as const)(
+      'rejects partnerOrgAccess=%s before any partner-global side effect',
+      async (partnerOrgAccess, accessibleOrgIds) => {
+        setAuthContext({
+          scope: 'partner',
+          partnerOrgAccess,
+          accessibleOrgIds: [...accessibleOrgIds],
+        });
+
+        const res = await app.request('/orgs/partners/me', {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ settings: { security: { requireMfa: false } } }),
+        });
+
+        expect(res.status).toBe(403);
+        expect(db.select).not.toHaveBeenCalled();
+        expect(db.update).not.toHaveBeenCalled();
+        expect(clearPartnerScopePolicyCache).not.toHaveBeenCalled();
+        expect(clearPartnerAllowlistCache).not.toHaveBeenCalled();
+        expect(enqueueAiBudgetEvaluationForPartner).not.toHaveBeenCalled();
+        expect(writeRouteAudit).not.toHaveBeenCalled();
+      },
+    );
+
+    it('allows full-partner authority to update a partner-global security control', async () => {
+      setAuthContext({ scope: 'partner', partnerOrgAccess: 'all' });
+      const currentPartner = {
+        id: 'partner-123',
+        name: 'Acme MSP',
+        settings: { security: { requireMfa: true, maxSessions: 4 } },
+      };
+      vi.mocked(db.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([currentPartner]),
+            }),
+          }),
+        } as any)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              orderBy: vi.fn().mockReturnValue({
+                limit: vi.fn().mockResolvedValue([{ id: 'org-1' }]),
+              }),
+            }),
+          }),
+        } as any);
+      vi.mocked(db.update).mockReturnValueOnce({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([{
+              ...currentPartner,
+              settings: { security: { requireMfa: false, maxSessions: 4 } },
+            }]),
+          }),
+        }),
+      } as any);
+
+      const res = await app.request('/orgs/partners/me', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ settings: { security: { requireMfa: false } } }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toMatchObject({
+        settings: { security: { requireMfa: false, maxSessions: 4 } },
+      });
+      expect(db.update).toHaveBeenCalledTimes(1);
+      expect(clearPartnerScopePolicyCache).toHaveBeenCalledWith('partner-123');
+      expect(clearPartnerAllowlistCache).toHaveBeenCalledWith('partner-123');
+      expect(writeRouteAudit).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+        action: 'partner.settings.update',
+        resourceId: 'partner-123',
+      }));
+    });
+
     it.each(['pt-BR', 'es-419', 'fr-FR', 'fr-CA', 'de-DE', 'it-IT', 'tr-TR'] as const)(
       'accepts %s as the partner default language',
       async (language) => {
@@ -6835,6 +6932,33 @@ describe('org routes', () => {
 
   describe('POST /orgs/import/preview and /orgs/import (#3242)', () => {
     const previewBody = { rows: [{ organization: 'Acme', site: 'HQ' }] };
+
+    it.each([
+      ['selected', '/orgs/import/preview', 'preview'],
+      ['none', '/orgs/import/preview', 'preview'],
+      ['selected', '/orgs/import', 'commit'],
+      ['none', '/orgs/import', 'commit'],
+    ] as const)(
+      'rejects partnerOrgAccess=%s on %s before entering the system-context %s seam',
+      async (partnerOrgAccess, path, seam) => {
+        setAuthContext({
+          scope: 'partner',
+          partnerOrgAccess,
+          accessibleOrgIds: partnerOrgAccess === 'selected' ? ['org-1'] : [],
+        });
+
+        const res = await app.request(path, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(previewBody),
+        });
+
+        expect(res.status).toBe(403);
+        expect(await res.json()).toEqual({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE });
+        expect(orgImportMocks.previewOrgImport).not.toHaveBeenCalled();
+        expect(orgImportMocks.commitOrgImport).not.toHaveBeenCalled();
+      },
+    );
 
     it('preview returns the annotated rows for the partner scope caller', async () => {
       setAuthContext({ scope: 'partner' });

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -61,7 +61,10 @@ import { isValidIpOrCidr } from '../services/ipMatch';
 import { applyNewPartnerDefaultSettings } from '../services/partnerDefaultSettings';
 import { seedSystemTicketStatuses } from '../services/ticketConfigService';
 import { getTrustedClientIpOrUndefined } from '../services/clientIp';
-import { canManagePartnerWidePolicies } from '../services/partnerWideAccess';
+import {
+  canManagePartnerWidePolicies,
+  PARTNER_WIDE_WRITE_DENIED_MESSAGE,
+} from '../services/partnerWideAccess';
 import { clearPartnerAllowlistCache, ipAllowlistMode, readPartnerAllowlist } from '../services/ipAllowlist';
 import { commitOrgImport, previewOrgImport, MAX_IMPORT_ROWS } from '../services/orgImport';
 import { writeOrgImportAudits } from '../services/orgImport/audit';
@@ -883,6 +886,12 @@ orgRoutes.patch(
   requirePartner,
   requireOrgWrite,
   requireMfa(),
+  async (c, next) => {
+    if (!canManagePartnerWidePolicies(c.get('auth'))) {
+      return c.json({ error: 'Full partner access required' }, 403);
+    }
+    await next();
+  },
   zValidator('json', updatePartnerSettingsSchema, (result, c) => {
     if (!result.success && result.error.issues.some((issue) => issue.path[0] === 'inboundLocalPart')) {
       return c.json({ error: 'Use lowercase letters, numbers, and hyphens only' }, 422);
@@ -1822,8 +1831,18 @@ orgRoutes.post('/organizations', requireScope('partner', 'system'), requireOrgWr
 //
 // Preview → commit pipeline over services/orgImport. CSV is parsed client-side;
 // the API takes JSON only, so the migration-toolkit scripts can call these
-// directly. Gating matches the single-record write routes this composes
-// (POST /organizations, POST /sites): partner/system scope + orgs:write + MFA.
+// directly. Unlike the single-record routes this composes, the import seam
+// enumerates and can mutate ANY organization in the resolved partner while
+// running under system DB context. Selected/none partner members therefore
+// need an additional full-partner capability gate on both preview and commit.
+
+const requireFullPartnerOrgImportAccess = async (c: Context, next: Next) => {
+  const auth = c.get('auth') as AuthContext;
+  if (!canManagePartnerWidePolicies(auth)) {
+    return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
+  }
+  return next();
+};
 
 // Row shape lives in services/orgImport/schemas.ts so the PSA company-import
 // route (#3246) accepts the byte-identical row contract.
@@ -1842,7 +1861,7 @@ const commitOrgImportSchema = z.object({
 // The import creates SITES as well as orgs, so it is gated on sites:write in
 // addition to orgs:write (#3242). Preview carries the same gate for an early,
 // honest failure — a preview a caller could never commit is a trap.
-orgRoutes.post('/import/preview', requireScope('partner', 'system'), requireOrgWrite, requireSiteWrite, requireMfa(), zValidator('json', previewOrgImportSchema), async (c) => {
+orgRoutes.post('/import/preview', requireScope('partner', 'system'), requireOrgWrite, requireSiteWrite, requireMfa(), requireFullPartnerOrgImportAccess, zValidator('json', previewOrgImportSchema), async (c) => {
   const auth = c.get('auth') as AuthContext;
   const { rows, partnerId: bodyPartnerId } = c.req.valid('json');
 
@@ -1855,7 +1874,7 @@ orgRoutes.post('/import/preview', requireScope('partner', 'system'), requireOrgW
   return c.json({ rows: annotated });
 });
 
-orgRoutes.post('/import', requireScope('partner', 'system'), requireOrgWrite, requireSiteWrite, requireMfa(), zValidator('json', commitOrgImportSchema), async (c) => {
+orgRoutes.post('/import', requireScope('partner', 'system'), requireOrgWrite, requireSiteWrite, requireMfa(), requireFullPartnerOrgImportAccess, zValidator('json', commitOrgImportSchema), async (c) => {
   const auth = c.get('auth') as AuthContext;
   const { rows, mode, partnerId: bodyPartnerId } = c.req.valid('json');
 

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -161,7 +161,15 @@ vi.mock('../db/schema', () => ({
     disabledAt: { __column: 'user_passkeys.disabled_at' },
   },
   partnerUsers: {},
-  organizationUsers: {},
+  organizationUsers: {
+    userId: { __column: 'organization_users.user_id' },
+    orgId: { __column: 'organization_users.org_id' },
+    siteIds: { __column: 'organization_users.site_ids' },
+  },
+  sites: {
+    id: { __column: 'sites.id' },
+    orgId: { __column: 'sites.org_id' },
+  },
   roles: {},
   permissions: {},
   rolePermissions: {},
@@ -461,6 +469,109 @@ describe('user routes', () => {
   });
 
   describe('POST /users/invite', () => {
+    it('does not let a site-restricted org inviter create an unrestricted sibling by omitting siteIds', async () => {
+      const SITE_A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+      const ROLE_ID = '22222222-2222-4222-8222-222222222222';
+      const USER_ID = '11111111-1111-4111-8111-111111111111';
+      vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+        c.set('auth', {
+          scope: 'organization',
+          partnerId: 'partner-123',
+          orgId: '33333333-3333-4333-8333-333333333333',
+          allowedSiteIds: [SITE_A],
+          canAccessSite: (siteId: string | null | undefined) => siteId === SITE_A,
+          user: { id: 'user-123', email: 'restricted@example.com' },
+        });
+        return next();
+      });
+
+      // Role, effective-role parent, effective permissions, tombstone preflight.
+      vi.mocked(db.select)
+        .mockReturnValueOnce({ from: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([{ id: ROLE_ID, scope: 'organization', name: 'Technician', description: null, isSystem: true, partnerId: null, orgId: null }]) }) }) } as any)
+        .mockReturnValueOnce({ from: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([{ parentRoleId: null }]) }) }) } as any)
+        .mockReturnValueOnce({ from: vi.fn().mockReturnValue({ innerJoin: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue([]) }) }) } as any)
+        .mockReturnValueOnce({ from: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }) }) } as any)
+        // Post-commit organization-name lookup for the invite email.
+        .mockReturnValueOnce({ from: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([{ name: 'Org A' }]) }) }) } as any);
+
+      const insertedMemberships: Array<Record<string, unknown>> = [];
+      const txSelect = vi.fn()
+        // Locked live inviter membership.
+        .mockReturnValueOnce({ from: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ limit: vi.fn().mockReturnValue({ for: vi.fn().mockResolvedValue([{ siteIds: [SITE_A] }]) }) }) }) })
+        // Same-org validation of the normalized site set.
+        .mockReturnValueOnce({ from: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ for: vi.fn().mockResolvedValue([{ id: SITE_A }]) }) }) })
+        // Existing user, organization tenancy, existing membership.
+        .mockReturnValueOnce({ from: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }) }) })
+        .mockReturnValueOnce({ from: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([{ partnerId: 'partner-123' }]) }) }) })
+        .mockReturnValueOnce({ from: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }) }) });
+      const txInsert = vi.fn()
+        .mockReturnValueOnce({ values: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([{ id: USER_ID, email: 'invitee@example.com', name: 'Invitee', status: 'invited' }]) }) })
+        .mockReturnValueOnce({ values: vi.fn((values: Record<string, unknown>) => {
+          insertedMemberships.push(values);
+          return { returning: vi.fn().mockResolvedValue([{ id: 'link-1' }]) };
+        }) });
+      vi.mocked(db.transaction).mockImplementation(async (fn) => fn({ select: txSelect, insert: txInsert } as any));
+
+      const res = await app.request('/users/invite', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: 'invitee@example.com', name: 'Invitee', roleId: ROLE_ID }),
+      });
+
+      expect(res.status).toBe(201);
+      expect(insertedMemberships).toHaveLength(1);
+      expect(insertedMemberships[0]).toMatchObject({ siteIds: [SITE_A] });
+    });
+
+    it('rejects an explicit site outside the live inviter scope before creating the invitee', async () => {
+      const SITE_A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+      const SITE_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+      const ROLE_ID = '22222222-2222-4222-8222-222222222222';
+      vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+        c.set('auth', {
+          scope: 'organization',
+          partnerId: 'partner-123',
+          orgId: '33333333-3333-4333-8333-333333333333',
+          allowedSiteIds: [SITE_A],
+          canAccessSite: (siteId: string | null | undefined) => siteId === SITE_A,
+          user: { id: 'user-123', email: 'restricted@example.com' },
+        });
+        return next();
+      });
+
+      vi.mocked(db.select)
+        .mockReturnValueOnce({ from: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([{ id: ROLE_ID, scope: 'organization', name: 'Technician', description: null, isSystem: true, partnerId: null, orgId: null }]) }) }) } as any)
+        .mockReturnValueOnce({ from: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([{ parentRoleId: null }]) }) }) } as any)
+        .mockReturnValueOnce({ from: vi.fn().mockReturnValue({ innerJoin: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue([]) }) }) } as any)
+        .mockReturnValueOnce({ from: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }) }) } as any);
+
+      const txInsert = vi.fn();
+      const txSelect = vi.fn().mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockReturnValue({
+              for: vi.fn().mockResolvedValue([{ siteIds: [SITE_A] }]),
+            }),
+          }),
+        }),
+      });
+      vi.mocked(db.transaction).mockImplementation(async (fn) => fn({ select: txSelect, insert: txInsert } as any));
+
+      const res = await app.request('/users/invite', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email: 'invitee@example.com',
+          name: 'Invitee',
+          roleId: ROLE_ID,
+          siteIds: [SITE_B],
+        }),
+      });
+
+      expect(res.status).toBe(403);
+      expect(txInsert).not.toHaveBeenCalled();
+    });
+
     it('should invite a partner user with selected orgs', async () => {
       vi.mocked(db.select).mockReturnValueOnce({
         from: vi.fn().mockReturnValue({

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -46,6 +46,7 @@ import { resetAllFactorsAndInvalidate, sweepPendingFactorArtifacts } from '../se
 import { neutralizeUserIfOrphaned } from '../services/userNeutralization';
 import { getEffectiveMfaPolicy } from '../services/mfaPolicy';
 import { requestPendingEmailChange } from '../services/pendingEmail';
+import { resolveDelegatedSiteIds } from '../services/organizationMembershipDelegation';
 
 export const userRoutes = new Hono();
 const supportedLocales = SUPPORTED_LOCALES;
@@ -1228,6 +1229,19 @@ userRoutes.post(
     }
 
     const result = await db.transaction(async (tx) => {
+      // The membership row is the authoritative live site ceiling. Lock and
+      // re-read it inside the SAME transaction that creates the invitee link:
+      // a request snapshot alone would let a concurrent scope reduction race
+      // an unrestricted invitation. Partner invitations use their independent
+      // full-partner gate above and do not carry an organization site axis.
+      const delegatedSiteIds = scopeContext.scope === 'organization'
+        ? await resolveDelegatedSiteIds(tx, {
+            inviterUserId: auth.user.id,
+            orgId: scopeContext.orgId,
+            requestedSiteIds: data.siteIds,
+          })
+        : undefined;
+
       const [existingUser] = await tx
         .select()
         .from(users)
@@ -1315,7 +1329,7 @@ userRoutes.post(
           .limit(1);
 
         if (existingLink) {
-          return { user, linkCreated: false };
+          return { user, linkCreated: false, delegatedSiteIds };
         }
 
         const orgAccess = data.orgAccess ?? 'none';
@@ -1332,7 +1346,7 @@ userRoutes.post(
           })
           .returning();
 
-        return { user, linkCreated: true, link };
+        return { user, linkCreated: true, link, delegatedSiteIds };
       }
 
       const [existingLink] = await tx
@@ -1342,7 +1356,7 @@ userRoutes.post(
         .limit(1);
 
       if (existingLink) {
-        return { user, linkCreated: false };
+        return { user, linkCreated: false, delegatedSiteIds };
       }
 
       const [link] = await tx
@@ -1351,12 +1365,12 @@ userRoutes.post(
           orgId: scopeContext.orgId,
           userId: user.id,
           roleId: data.roleId,
-          siteIds: data.siteIds ?? null,
+          siteIds: delegatedSiteIds,
           deviceGroupIds: data.deviceGroupIds ?? null
         })
         .returning();
 
-      return { user, linkCreated: true, link };
+      return { user, linkCreated: true, link, delegatedSiteIds };
     });
 
     if (!result.linkCreated) {
@@ -1381,7 +1395,7 @@ userRoutes.post(
         scope: scopeContext.scope,
         orgAccess: scopeContext.scope === 'partner' ? data.orgAccess ?? 'none' : undefined,
         orgIds: scopeContext.scope === 'partner' ? data.orgIds ?? [] : undefined,
-        siteIds: scopeContext.scope === 'organization' ? data.siteIds ?? [] : undefined,
+        siteIds: scopeContext.scope === 'organization' ? result.delegatedSiteIds : undefined,
         deviceGroupIds: scopeContext.scope === 'organization' ? data.deviceGroupIds ?? [] : undefined,
         inviteEmailSent: invite.inviteEmailSent
       }

--- a/apps/api/src/services/organizationMembershipDelegation.test.ts
+++ b/apps/api/src/services/organizationMembershipDelegation.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { db } from '../db';
+import { resolveDelegatedSiteIds } from './organizationMembershipDelegation';
+
+type Transaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+function transactionWithRows(membershipRows: unknown[], siteRows: unknown[] = []) {
+  let selectIndex = 0;
+  const select = vi.fn(() => {
+    const rows = selectIndex++ === 0 ? membershipRows : siteRows;
+    const terminal = { for: vi.fn().mockResolvedValue(rows) };
+    return {
+      from: () => ({
+        where: () => ({
+          ...terminal,
+          limit: () => terminal,
+        }),
+      }),
+    };
+  });
+  return { tx: { select } as unknown as Transaction, select };
+}
+
+describe('resolveDelegatedSiteIds', () => {
+  it('inherits and deduplicates a restricted inviter scope when siteIds is omitted', async () => {
+    const { tx, select } = transactionWithRows([{ siteIds: ['site-a', 'site-a', 'site-b'] }], [
+      { id: 'site-a' },
+      { id: 'site-b' },
+    ]);
+
+    await expect(resolveDelegatedSiteIds(tx, {
+      inviterUserId: 'user-a',
+      orgId: 'org-a',
+    })).resolves.toEqual(['site-a', 'site-b']);
+    expect(select).toHaveBeenCalledTimes(2);
+  });
+
+  it('allows only an explicit subset of a restricted inviter scope', async () => {
+    const { tx } = transactionWithRows([{ siteIds: ['site-a', 'site-b'] }], [{ id: 'site-b' }]);
+    await expect(resolveDelegatedSiteIds(tx, {
+      inviterUserId: 'user-a',
+      orgId: 'org-a',
+      requestedSiteIds: ['site-b'],
+    })).resolves.toEqual(['site-b']);
+  });
+
+  it('preserves an explicit empty scope as restricted-to-no-sites', async () => {
+    const { tx, select } = transactionWithRows([{ siteIds: ['site-a'] }]);
+    await expect(resolveDelegatedSiteIds(tx, {
+      inviterUserId: 'user-a',
+      orgId: 'org-a',
+      requestedSiteIds: [],
+    })).resolves.toEqual([]);
+    expect(select).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects an explicit site outside the inviter scope before probing site existence', async () => {
+    const { tx, select } = transactionWithRows([{ siteIds: ['site-a'] }]);
+    await expect(resolveDelegatedSiteIds(tx, {
+      inviterUserId: 'user-a',
+      orgId: 'org-a',
+      requestedSiteIds: ['site-hidden'],
+    })).rejects.toMatchObject({ status: 403 });
+    expect(select).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves unrestricted only for an unrestricted inviter', async () => {
+    const { tx, select } = transactionWithRows([{ siteIds: null }]);
+    await expect(resolveDelegatedSiteIds(tx, {
+      inviterUserId: 'user-a',
+      orgId: 'org-a',
+    })).resolves.toBeNull();
+    expect(select).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects an unknown or foreign site for an unrestricted inviter', async () => {
+    const { tx } = transactionWithRows([{ siteIds: null }], []);
+    await expect(resolveDelegatedSiteIds(tx, {
+      inviterUserId: 'user-a',
+      orgId: 'org-a',
+      requestedSiteIds: ['not-in-org-a'],
+    })).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('fails closed if the inviter no longer has an organization membership', async () => {
+    const { tx, select } = transactionWithRows([]);
+    await expect(resolveDelegatedSiteIds(tx, {
+      inviterUserId: 'user-a',
+      orgId: 'org-a',
+    })).rejects.toMatchObject({ status: 403 });
+    expect(select).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/services/organizationMembershipDelegation.ts
+++ b/apps/api/src/services/organizationMembershipDelegation.ts
@@ -1,0 +1,65 @@
+import { and, eq, inArray } from 'drizzle-orm';
+import { HTTPException } from 'hono/http-exception';
+import { db } from '../db';
+import { organizationUsers, sites } from '../db/schema';
+
+type Transaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+export interface ResolveDelegatedSiteIdsInput {
+  inviterUserId: string;
+  orgId: string;
+  requestedSiteIds?: string[];
+}
+
+/**
+ * Resolve an invited organization member's site ceiling while holding the
+ * inviter membership row lock. `NULL` is the persisted unrestricted sentinel;
+ * a restricted inviter can never delegate it.
+ */
+export async function resolveDelegatedSiteIds(
+  tx: Transaction,
+  input: ResolveDelegatedSiteIdsInput,
+): Promise<string[] | null> {
+  const [inviterMembership] = await tx
+    .select({ siteIds: organizationUsers.siteIds })
+    .from(organizationUsers)
+    .where(and(
+      eq(organizationUsers.userId, input.inviterUserId),
+      eq(organizationUsers.orgId, input.orgId),
+    ))
+    .limit(1)
+    .for('update');
+
+  if (!inviterMembership) {
+    throw new HTTPException(403, { message: 'Current organization membership required' });
+  }
+
+  const inviterSiteIds = inviterMembership.siteIds;
+  const requested = input.requestedSiteIds === undefined
+    ? (inviterSiteIds === null ? null : [...new Set(inviterSiteIds)])
+    : [...new Set(input.requestedSiteIds)];
+
+  if (requested === null) return null;
+
+  if (inviterSiteIds !== null) {
+    const allowed = new Set(inviterSiteIds);
+    if (requested.some((siteId) => !allowed.has(siteId))) {
+      throw new HTTPException(403, { message: 'Cannot grant site access beyond the inviter scope' });
+    }
+  }
+
+  if (requested.length === 0) return [];
+
+  // Hold key-share locks through membership insertion so validation and the
+  // delegated array refer to the same live organization/site relationship.
+  const validSites = await tx
+    .select({ id: sites.id })
+    .from(sites)
+    .where(and(eq(sites.orgId, input.orgId), inArray(sites.id, requested)))
+    .for('key share');
+  if (validSites.length !== requested.length) {
+    throw new HTTPException(400, { message: 'Every delegated site must belong to the organization' });
+  }
+
+  return requested;
+}


### PR DESCRIPTION
## Summary

Security hardening for organization invitations and membership delegation.

- The delegating membership row is locked and the requested site scope is validated inside the same transaction, so a concurrent change to the delegator's own scope cannot be raced into a wider invitation.
- An invitation that omits a site scope now inherits the delegator's live ceiling instead of widening to the whole organization.
- Partner authority over accounting and partner-settings routes is preserved across delegated operations.
- The new HTTP invitation test fixture releases its barrier in a `finally` block so a failed step cannot hang the suite.

No migration is introduced. The Office add-in MFA-epoch binding this builds on shipped in #5475 (`2026-10-15-150051`).

## Verification

- `tsc --noEmit` and `pnpm --filter @breeze/api lint`: clean
- Unit: 16 files / 841 tests (invitation, membership delegation, orgs, users, accounting authority, MFA/office-addin siblings)
- Live database: 56 files / 316 tests across every suite matching invitations, membership, office add-in, MFA, site scope, accounting and partner settings, plus the tenant cascade / export-policy / erasure round-trip contracts; RLS suite 31/31; RLS coverage 102/102
- Rebased onto main after #5475 merged; re-ran type-check and the invitation/membership unit suites (5 files / 454 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013auR2S4tHMtuKXj1bXD9aD
