### PR TITLE
docs(self-host): treat manifest signing-key rotation as agent re-enrollment

### DIFF
--- a/apps/docs/src/content/docs/deploy/binaries.mdx
+++ b/apps/docs/src/content/docs/deploy/binaries.mdx
@@ -59,6 +59,14 @@ RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS=yzx8ftmcls6uBetFC5SYnZhBo+cbur3IX50TbBthTs
 
 This is a public key (also embedded in the agent and CI), so it is safe to commit. Only override it if you build and sign your own binaries. The API refuses to start in production without it. During a signing-key rotation you can trust multiple keys at once by comma-separating them (`RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS=old,new`).
 
+<Aside type="caution" title="Rotation on the server doesn't retire trust on agents">
+  Comma-separating keys makes the *server* trust both. Each agent still only
+  trusts the key(s) it pinned at enrollment and keeps trusting a retired key
+  indefinitely — there's no remote revocation yet. Treat rotation as a fleet
+  re-enrollment: see [Key
+  rotation](/deploy/sign-your-own-packages/#key-rotation).
+</Aside>
+
 #### Unsigned signing inputs
 
 Official releases also publish `*-unsigned` build outputs with manifest entries marked `intendedUse: "signing-input"` and `platformTrust: "none"`. These exist solely as inputs for self-signing and are never registrable or downloadable through the API.

--- a/apps/docs/src/content/docs/deploy/sign-your-own-packages.mdx
+++ b/apps/docs/src/content/docs/deploy/sign-your-own-packages.mdx
@@ -399,6 +399,22 @@ any other instance. See
   `docs/operations/agent-network-and-manifest-rollout.md`.
 </Aside>
 
+### Key rotation
+
+<Aside type="caution" title="Rotation adds trust — it doesn't remove it">
+  Agents pin the manifest public key(s) they were installed or last enrolled
+  under (`RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS`). Generating a new manifest
+  key and updating your instance's env var adds trust in the new key, but
+  agents that enrolled under the retired key keep trusting that key too —
+  there is no remote mechanism today to revoke it from already-enrolled
+  agents. Treat a rotation as a fleet re-enrollment: afterwards, reinstall or
+  re-enroll your fleet so agents pin only the current key, and keep the
+  retired private key protected as a long-lived secret (or destroy it)
+  rather than assuming rotation alone retires it. A signed key-retirement
+  mechanism is planned so a future rotation won't require a full
+  re-enrollment — no timeline yet.
+</Aside>
+
 ---
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary
- Add a "Key rotation" section to `sign-your-own-packages.mdx` explaining that agents pin the manifest public key(s) they were enrolled under, that rotating `RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS` adds trust in a new key without removing trust in a retired one, and that there is no remote revocation today — so a rotation should be treated as a fleet re-enrollment. Notes that a signed key-retirement mechanism is planned (no dates).
- Add a short caution `Aside` in `binaries.mdx`, next to the existing comma-separated-keys rotation note, clarifying that server-side trust of multiple keys does not retire agent-side trust of a dropped key, with a link to the fuller explanation.

## Test plan
- [x] `pnpm --filter @breeze/docs check` (astro check) — 0 errors/warnings/hints
- [x] `pnpm --filter @breeze/docs build` — builds cleanly, new `#key-rotation` anchor and cross-link resolve correctly in the generated HTML