### PR TITLE
fix(ticket-mailbox): fall back to live Graph role check when wids is absent Fixes #5487

### DIFF
--- a/apps/api/src/routes/tickets/mailboxConnect.test.ts
+++ b/apps/api/src/routes/tickets/mailboxConnect.test.ts
@@ -42,6 +42,7 @@ const { authRef, mocks } = vi.hoisted(() => ({
     exchangeMicrosoftAuthorizationCode: vi.fn(),
     verifyMicrosoftAdminIdToken: vi.fn(),
     hasMailboxConsentAdminRole: vi.fn(() => true),
+    hasMailboxConsentAdminRoleViaGraph: vi.fn(async () => false),
     writeRouteAudit: vi.fn(),
     writeAuditEvent: vi.fn(),
     captureException: vi.fn(),
@@ -117,6 +118,7 @@ vi.mock('../../services/ticketMailbox/microsoftIdentity', () => ({
   exchangeMicrosoftAuthorizationCode: mocks.exchangeMicrosoftAuthorizationCode,
   verifyMicrosoftAdminIdToken: mocks.verifyMicrosoftAdminIdToken,
   hasMailboxConsentAdminRole: mocks.hasMailboxConsentAdminRole,
+  hasMailboxConsentAdminRoleViaGraph: mocks.hasMailboxConsentAdminRoleViaGraph,
 }));
 vi.mock('../../services/auditEvents', () => ({
   writeRouteAudit: mocks.writeRouteAudit,
@@ -212,11 +214,14 @@ describe('M365 mailbox lifecycle routes', () => {
       session: session('identity_verification'), codeChallenge: 'stored-code-challenge',
     });
     mocks.consumeConsentSession.mockImplementation(async (_state: string, phase: string) => session(phase as never));
-    mocks.exchangeMicrosoftAuthorizationCode.mockResolvedValue({ idToken: 'verified-id-token' });
+    mocks.exchangeMicrosoftAuthorizationCode.mockResolvedValue({
+      idToken: 'verified-id-token', accessToken: 'delegated-access-token',
+    });
     mocks.verifyMicrosoftAdminIdToken.mockResolvedValue({
       tid: TENANT_ID, oid: MICROSOFT_OID, sub: 'microsoft-sub', wids: ['accepted-role'],
     });
     mocks.hasMailboxConsentAdminRole.mockReturnValue(true);
+    mocks.hasMailboxConsentAdminRoleViaGraph.mockResolvedValue(false);
     mocks.getMailboxConnection.mockResolvedValue(connection());
     mocks.probeMailbox.mockResolvedValue({ ok: true });
     app = new Hono();
@@ -578,8 +583,9 @@ describe('M365 mailbox lifecycle routes', () => {
     expect(serialized).not.toContain('bad-code');
   });
 
-  it('rejects an identity without an accepted administrator role', async () => {
+  it('rejects an identity without an accepted administrator role via wids or a live Graph lookup', async () => {
     mocks.hasMailboxConsentAdminRole.mockReturnValue(false);
+    mocks.hasMailboxConsentAdminRoleViaGraph.mockResolvedValue(false);
     const response = await app.request('/callback?state=identity-state&code=authorization-code', {
       headers: { cookie: `ticket_mailbox_oauth_state=${cookieFor('identity_verification', 'identity-state')}` },
     });
@@ -589,6 +595,21 @@ describe('M365 mailbox lifecycle routes', () => {
     expect(mocks.writeAuditEvent).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
       details: expect.objectContaining({ outcome: 'insufficient_role' }),
     }));
+  });
+
+  it('falls back to a live Graph directory-role check when wids has no accepted role, and connects on success', async () => {
+    // Reproduces tenants where wids is absent or unaccepted in the ID token
+    // despite correct optionalClaims.idToken configuration.
+    mocks.hasMailboxConsentAdminRole.mockReturnValue(false);
+    mocks.hasMailboxConsentAdminRoleViaGraph.mockResolvedValue(true);
+    const response = await app.request('/callback?state=identity-state&code=authorization-code', {
+      headers: { cookie: `ticket_mailbox_oauth_state=${cookieFor('identity_verification', 'identity-state')}` },
+    });
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toContain('ticketMailbox=connected');
+    expect(mocks.hasMailboxConsentAdminRoleViaGraph).toHaveBeenCalledWith('delegated-access-token');
+    expect(mocks.probeMailbox).toHaveBeenCalled();
+    expect(mocks.bindVerifiedTenant).toHaveBeenCalled();
   });
 
   it('rejects replayed state before any identity or audit work', async () => {

--- a/apps/api/src/routes/tickets/mailboxConnect.ts
+++ b/apps/api/src/routes/tickets/mailboxConnect.ts
@@ -43,6 +43,7 @@ import {
   buildMicrosoftAuthorizationUrl,
   exchangeMicrosoftAuthorizationCode,
   hasMailboxConsentAdminRole,
+  hasMailboxConsentAdminRoleViaGraph,
   verifyMicrosoftAdminIdToken,
 } from '../../services/ticketMailbox/microsoftIdentity';
 import {
@@ -460,7 +461,13 @@ mailboxRoutes.get('/callback', zValidator('query', callbackQuery), async (c) => 
       clientId: platform.clientId,
       nonce: session.nonce,
     });
-    if (!hasMailboxConsentAdminRole(claims.wids)) return fail('insufficient_role');
+    // Fast path: the wids ID token claim, when the tenant actually populates
+    // it. Fallback: a live Graph directory-role lookup using the delegated
+    // access token from the same exchange, for tenants where wids is absent
+    // despite correct optionalClaims.idToken configuration.
+    const isAdmin = hasMailboxConsentAdminRole(claims.wids)
+      || await hasMailboxConsentAdminRoleViaGraph(exchanged.accessToken);
+    if (!isAdmin) return fail('insufficient_role');
 
     const probe = await probeMailbox(claims.tid, connection.mailboxAddress);
     if (!probe.ok) return fail('probe_failed', 'needs_policy', claims.tid);

--- a/apps/api/src/services/ticketMailbox/microsoftIdentity.test.ts
+++ b/apps/api/src/services/ticketMailbox/microsoftIdentity.test.ts
@@ -7,6 +7,7 @@ import {
   buildMicrosoftAuthorizationUrl,
   exchangeMicrosoftAuthorizationCode,
   hasMailboxConsentAdminRole,
+  hasMailboxConsentAdminRoleViaGraph,
   verifyMicrosoftAdminIdToken,
 } from './microsoftIdentity';
 
@@ -136,6 +137,7 @@ describe('exchangeMicrosoftAuthorizationCode', () => {
 
     await expect(exchangeMicrosoftAuthorizationCode(input, { fetch: fetchImpl })).resolves.toEqual({
       idToken: 'id-token',
+      accessToken: null,
     });
 
     const [url, init] = fetchImpl.mock.calls[0]!;
@@ -179,6 +181,18 @@ describe('exchangeMicrosoftAuthorizationCode', () => {
 
     await expect(exchangeMicrosoftAuthorizationCode(input, { fetch: fetchImpl }))
       .rejects.toThrow('Microsoft identity verification failed');
+  });
+
+  it('extracts the delegated access_token alongside the id_token when present', async () => {
+    const fetchImpl = vi.fn<TestFetch>(async () => new Response(JSON.stringify({
+      id_token: 'id-token',
+      access_token: 'delegated-access-token',
+    }), { status: 200 }));
+
+    await expect(exchangeMicrosoftAuthorizationCode(input, { fetch: fetchImpl })).resolves.toEqual({
+      idToken: 'id-token',
+      accessToken: 'delegated-access-token',
+    });
   });
 });
 
@@ -239,19 +253,71 @@ describe('verifyMicrosoftAdminIdToken', () => {
       .rejects.toThrow('Microsoft identity verification failed');
   });
 
-  it('rejects missing administrator roles', async () => {
+  // verifyMicrosoftAdminIdToken no longer rejects on missing/unaccepted wids.
+  // Some tenants never populate wids in the ID token even with
+  // optionalClaims.idToken correctly configured — reproduced against a
+  // from-scratch app registration and confirmed with Microsoft's own jwt.ms
+  // token inspector. The admin-role decision now happens one level up
+  // (hasMailboxConsentAdminRole / hasMailboxConsentAdminRoleViaGraph), so
+  // this function's job is only to hand back whatever wids it found, valid
+  // or empty, and let the caller decide.
+  it('resolves with an empty wids array when the claim is missing, deferring the role decision to the caller', async () => {
     await expect(verify(await mintToken({ wids: undefined })))
-      .rejects.toThrow('Microsoft identity verification failed');
+      .resolves.toMatchObject({ wids: [] });
   });
 
-  it('rejects malformed administrator roles', async () => {
+  it('resolves with an empty wids array when the claim is malformed', async () => {
     await expect(verify(await mintToken({ wids: GLOBAL_ADMIN_ROLE_ID })))
-      .rejects.toThrow('Microsoft identity verification failed');
+      .resolves.toMatchObject({ wids: [] });
   });
 
-  it('rejects unknown administrator roles', async () => {
+  it('resolves with the presented wids even when none are accepted admin roles', async () => {
     await expect(verify(await mintToken({
       wids: ['9b895d92-2cd3-44c7-9d02-a6ac2d5ea5c3'],
-    }))).rejects.toThrow('Microsoft identity verification failed');
+    }))).resolves.toMatchObject({ wids: ['9b895d92-2cd3-44c7-9d02-a6ac2d5ea5c3'] });
+  });
+});
+
+describe('hasMailboxConsentAdminRoleViaGraph', () => {
+  it('returns false without a delegated access token', async () => {
+    await expect(hasMailboxConsentAdminRoleViaGraph(null)).resolves.toBe(false);
+  });
+
+  it('accepts a Global Administrator returned by the live directory-role lookup', async () => {
+    const fetchImpl = vi.fn<TestFetch>(async (input, init) => {
+      expect(input.toString()).toBe(
+        'https://graph.microsoft.com/v1.0/me/transitiveMemberOf/microsoft.graph.directoryRole?$select=roleTemplateId',
+      );
+      expect((init?.headers as Record<string, string>).authorization).toBe('Bearer delegated-token');
+      return new Response(JSON.stringify({
+        value: [{ roleTemplateId: GLOBAL_ADMIN_ROLE_ID }],
+      }), { status: 200 });
+    });
+
+    await expect(hasMailboxConsentAdminRoleViaGraph('delegated-token', { fetch: fetchImpl })).resolves.toBe(true);
+  });
+
+  it('rejects a signed-in user with no accepted directory role', async () => {
+    const fetchImpl = vi.fn<TestFetch>(async () => new Response(JSON.stringify({
+      value: [{ roleTemplateId: '9b895d92-2cd3-44c7-9d02-a6ac2d5ea5c3' }],
+    }), { status: 200 }));
+
+    await expect(hasMailboxConsentAdminRoleViaGraph('delegated-token', { fetch: fetchImpl })).resolves.toBe(false);
+  });
+
+  it('treats a non-2xx Graph response (e.g. missing Directory.Read.All consent) as not-an-admin rather than throwing', async () => {
+    const fetchImpl = vi.fn<TestFetch>(async () => new Response(JSON.stringify({
+      error: { code: 'Authorization_RequestDenied' },
+    }), { status: 403 }));
+
+    await expect(hasMailboxConsentAdminRoleViaGraph('delegated-token', { fetch: fetchImpl })).resolves.toBe(false);
+  });
+
+  it('treats a network failure as not-an-admin rather than throwing', async () => {
+    const fetchImpl = vi.fn<TestFetch>(async () => {
+      throw new Error('network unreachable');
+    });
+
+    await expect(hasMailboxConsentAdminRoleViaGraph('delegated-token', { fetch: fetchImpl })).resolves.toBe(false);
   });
 });

--- a/apps/api/src/services/ticketMailbox/microsoftIdentity.ts
+++ b/apps/api/src/services/ticketMailbox/microsoftIdentity.ts
@@ -69,7 +69,11 @@ export function buildMicrosoftAuthorizationUrl(input: {
   url.searchParams.set('redirect_uri', input.redirectUri);
   url.searchParams.set('response_type', 'code');
   url.searchParams.set('response_mode', 'query');
-  url.searchParams.set('scope', 'openid profile');
+  // Directory.Read.All (delegated) lets verifyMailboxConsentAdminRole fall back
+  // to a live Graph directory-role lookup when the `wids` ID token claim is
+  // absent. Must also be added as a Delegated permission on the app
+  // registration and admin-consented, or the live check will 403.
+  url.searchParams.set('scope', 'openid profile Directory.Read.All');
   url.searchParams.set('state', input.state);
   url.searchParams.set('nonce', input.nonce);
   url.searchParams.set('code_challenge', input.codeChallenge);
@@ -84,7 +88,7 @@ export async function exchangeMicrosoftAuthorizationCode(input: {
   redirectUri: string;
   code: string;
   codeVerifier: string;
-}, dependencies: Pick<MicrosoftIdentityDependencies, 'fetch'> = {}): Promise<{ idToken: string }> {
+}, dependencies: Pick<MicrosoftIdentityDependencies, 'fetch'> = {}): Promise<{ idToken: string; accessToken: string | null }> {
   const tenant = requireTenantHint(input.tenantHint);
   const tokenUrl = new URL(`/${tenant}/oauth2/v2.0/token`, MICROSOFT_LOGIN_ORIGIN);
   const body = new URLSearchParams({
@@ -106,16 +110,23 @@ export async function exchangeMicrosoftAuthorizationCode(input: {
     if (!response.ok) throw new MicrosoftIdentityVerificationError('Microsoft identity verification failed');
 
     const tokenResponse: unknown = await response.json();
-    const idToken = (
-      typeof tokenResponse === 'object' && tokenResponse !== null
-        ? (tokenResponse as Record<string, unknown>).id_token
-        : undefined
-    );
+    const record = typeof tokenResponse === 'object' && tokenResponse !== null
+      ? (tokenResponse as Record<string, unknown>)
+      : undefined;
+    const idToken = record?.id_token;
     if (typeof idToken !== 'string' || idToken.length === 0) {
       throw new MicrosoftIdentityVerificationError('Microsoft identity verification failed');
     }
-    return { idToken };
-  } catch {
+    // Optional: only used for the live directory-role fallback below. Its
+    // absence must never fail the exchange — the wids claim path still works
+    // without it, and probeMailbox/Graph mail calls use the app-only token
+    // from getMailboxToken(), not this delegated one.
+    const accessToken = typeof record?.access_token === 'string' && record.access_token.length > 0
+      ? record.access_token
+      : null;
+    return { idToken, accessToken };
+  } catch (error) {
+    if (error instanceof MicrosoftIdentityVerificationError) throw error;
     throw new MicrosoftIdentityVerificationError('Microsoft identity verification failed');
   }
 }
@@ -148,17 +159,22 @@ export async function verifyMicrosoftAdminIdToken(
 
   const oid = normalizeGuid(payload.oid);
   const expectedIssuer = `${MICROSOFT_LOGIN_ORIGIN}/${tid}/v2.0`;
+  // `wids` is intentionally NOT required here. Some tenants do not populate
+  // it in the ID token even with optionalClaims.idToken correctly configured
+  // (observed against a from-scratch app registration, verified with
+  // Microsoft's own jwt.ms token inspector — see the linked GitHub issue).
+  // Admin-role verification for mailbox consent now happens one level up in
+  // hasMailboxConsentAdminRole / hasMailboxConsentAdminRoleViaGraph, which
+  // treats wids as a fast path and falls back to a live Graph role lookup.
   const wids = Array.isArray(payload.wids) && payload.wids.every((wid) => typeof wid === 'string')
     ? payload.wids
-    : null;
+    : [];
   if (
     !oid
     || payload.iss !== expectedIssuer
     || payload.nonce !== expected.nonce
     || typeof payload.sub !== 'string'
     || payload.sub.length === 0
-    || !wids
-    || !hasMailboxConsentAdminRole(wids)
   ) {
     throw new MicrosoftIdentityVerificationError('Microsoft identity verification failed');
   }
@@ -173,4 +189,46 @@ export async function verifyMicrosoftAdminIdToken(
 
 export function hasMailboxConsentAdminRole(wids: readonly string[]): boolean {
   return wids.some((wid) => ACCEPTED_ADMIN_ROLES.has(wid.toLowerCase()));
+}
+
+/**
+ * Fallback for tenants where the `wids` ID token claim is not populated even
+ * with optionalClaims.idToken correctly configured on the app registration.
+ * Reads the signed-in user's directory role membership directly from Graph
+ * using the delegated access token from the same authorization-code
+ * exchange. Requires the Directory.Read.All delegated permission to be
+ * granted (admin-consented) on the app registration — a 401/403 here is
+ * treated as "not an admin" rather than a hard failure, since an
+ * unconfigured permission should not be indistinguishable from a real
+ * privilege-escalation attempt in the audit log, but also must never be
+ * treated as success.
+ */
+export async function hasMailboxConsentAdminRoleViaGraph(
+  accessToken: string | null,
+  dependencies: Pick<MicrosoftIdentityDependencies, 'fetch'> = {},
+): Promise<boolean> {
+  if (!accessToken) return false;
+  try {
+    const response = await (dependencies.fetch ?? globalThis.fetch)(
+      'https://graph.microsoft.com/v1.0/me/transitiveMemberOf/microsoft.graph.directoryRole?$select=roleTemplateId',
+      { headers: { authorization: `Bearer ${accessToken}` } },
+    );
+    if (!response.ok) return false;
+
+    const body: unknown = await response.json();
+    const values = typeof body === 'object' && body !== null
+      ? (body as Record<string, unknown>).value
+      : undefined;
+    if (!Array.isArray(values)) return false;
+
+    const roleTemplateIds = values
+      .map((role) => (typeof role === 'object' && role !== null
+        ? (role as Record<string, unknown>).roleTemplateId
+        : undefined))
+      .filter((id): id is string => typeof id === 'string');
+
+    return hasMailboxConsentAdminRole(roleTemplateIds);
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION
…absent

The wids ID token claim, required by verifyMicrosoftAdminIdToken to confirm the consenting user is a tenant admin, is undocumented (nothing in .env.example or the release notes mentions the optionalClaims.idToken manifest requirement) and was found to be unreliable even when correctly configured — reproduced against a from-scratch app registration verified with Microsoft's own jwt.ms token inspector, with no Breeze code involved.

verifyMicrosoftAdminIdToken no longer hard-requires wids. The /callback route now checks hasMailboxConsentAdminRole(claims.wids) first (unchanged fast path for tenants where it works) and falls back to a live Graph directory-role lookup (hasMailboxConsentAdminRoleViaGraph) using the delegated access token from the same token exchange when it doesn't. Requires Directory.Read.All (delegated) requested and admin-consented.

Verified end-to-end against a live tenant where wids was confirmed absent: mailbox connection succeeded via the fallback and a real test email was imported into Breeze as a ticket.


Claude-Session: https://claude.ai/code/session_01VXeXK2VFKRmMWg1maG5yQh

## Summary

<!-- What does this PR do? Keep it brief (1-3 bullets). -->

-

## Linked Issues

<!--
Use `Closes #1234` when this PR fully resolves the issue — it closes on merge.
Use `Refs #1234` ONLY if this fixes part of it, or a community reporter still has
to verify; in that case say below which half shipped and which did not.
`Closes #1 #2` only closes #1 — repeat the keyword: `Closes #1, closes #2`.
-->

Closes #

## Type of Change

<!-- Check the one that applies: -->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] CI / build / tooling
- [ ] Other: <!-- describe -->

## Testing

<!-- How did you verify this works? -->

- [x] Existing tests pass (`pnpm test` / `make test`)
- [ ] Added new tests
- [ ] Manual testing (describe below)

## Checklist

- [x] My code follows the project's code style
- [x] I have reviewed my own changes
- [x] I have tested on the relevant platforms
- [x] No secrets, credentials, or personal data included
