### PR TITLE
chore(ops): backup --data, HIGH+CRITICAL audit gate, restore-test readiness race, backup alerts, teardown docs

### DIFF
--- a/.claude/skills/e2e-coverage/runbook.md
+++ b/.claude/skills/e2e-coverage/runbook.md
@@ -55,6 +55,7 @@ docker compose -f docker-compose.yml -f docker-compose.override.yml.dev up -d --
 - Dev mode runs `autoMigrate` on boot — branch migrations apply automatically (forward-only, idempotent).
 - The `:dev` images supply `node_modules`; **mounted `src` is what runs**. If the branch added dependencies (check `git log --since=...-p -- apps/api/package.json`), the `:dev` image may be missing them → `docker compose ... up -d --build api web`.
 - After editing `src`, `tsx watch` usually hot-reloads; if a change doesn't take, `docker compose ... restart api`.
+- **When done:** `docker compose -f docker-compose.yml -f docker-compose.override.yml.dev down -v --remove-orphans` (same `-f` files as `up`; caddy is in the same `breeze` project). Nothing tears it down for you — `docker compose ls -a` shows what is still up across all worktrees; full checklist in the `worktree-stack` skill → "Tear down when done".
 
 ---
 

--- a/.claude/skills/feature-testing/SKILL.md
+++ b/.claude/skills/feature-testing/SKILL.md
@@ -293,6 +293,23 @@ After recording results, create tasks for any follow-up:
 - Performance concerns observed
 - Documentation gaps
 
+## Phase 8: Tear Down
+
+If you brought the stack up for this verification (`pnpm wt-stack up`,
+`pnpm test-stack up`, or a compose-mode `up`), tear it down from the same
+worktree and branch — nothing does it for you:
+
+```bash
+pnpm wt-stack down       # dev stack (drops volumes)
+pnpm test-stack down     # integration pg+redis
+docker compose ls -a     # confirm nothing from this run is still listed
+```
+
+If you verified against a shared dev stack you did not start, leave it up.
+Either way, state in the final summary what is still running. Full checklist
+(orphaned projects, bare containers): `worktree-stack` skill → "Tear down when
+done".
+
 ## Quick Reference
 
 ### Playwright MCP Cheat Sheet

--- a/.claude/skills/pre-release-sweep/SKILL.md
+++ b/.claude/skills/pre-release-sweep/SKILL.md
@@ -130,7 +130,10 @@ Both go in the doc: `Fixes applied` (commit SHA) and `Issues filed` (#).
 Summary table (group → PASS/PARTIAL/FAIL/BLOCKED counts), "Top findings"
 (systemic patterns beat single bugs), the oldest PR reached, and what a
 release cut still needs (flags to enable, BLOCKED rows needing a live agent).
-Open one PR: the fixes + the tracking doc. `pnpm wt-stack down` when done.
+Open one PR: the fixes + the tracking doc. Then tear down: `pnpm wt-stack down`
+from this worktree, and `docker compose ls -a` to confirm nothing from the sweep
+is still up — sweep agents' `pnpm test-stack` copies included (`worktree-stack`
+skill → "Tear down when done"). Report anything you left running and why.
 
 ## Model tiering
 

--- a/.claude/skills/ui-qa-sweep/SKILL.md
+++ b/.claude/skills/ui-qa-sweep/SKILL.md
@@ -41,6 +41,12 @@ bug, not a pass.
    (not just at the end), with a running UI/UX observations sub-log.
 7. **File issues** — use the `github-issues` skill; one focused issue per defect,
    dedupe against open issues first, link to the log.
+8. **Tear down** — `pnpm wt-stack down` (or the same-`-f` `docker compose ...
+   down -v --remove-orphans` for a compose-mode stack) from the worktree that
+   created it, then `docker compose ls -a` to confirm nothing from this sweep
+   is still up. State in the final summary what you left running and why.
+   Nothing reaps a stack for you — full checklist: `worktree-stack` skill →
+   "Tear down when done".
 
 Use `TaskCreate` to track the checklist so progress survives context limits.
 Prefer dispatching this sweep to a background agent (it is long-running and

--- a/.claude/skills/worktree-stack/SKILL.md
+++ b/.claude/skills/worktree-stack/SKILL.md
@@ -14,7 +14,10 @@ Loop for testing the current worktree end to end:
    `portalUrl`, and admin creds (`admin@breeze.local` / `BreezeAdmin123!`).
 3. Drive Playwright: `pnpm wt-stack test -- tests/<spec>.spec.ts`, or point the
    Playwright MCP browser at `baseUrl`.
-4. Tear down: `pnpm wt-stack down` (removes volumes by default).
+4. Tear down: `pnpm wt-stack down` (removes volumes by default). Run it from
+   the same worktree **and branch** that ran `up` — the project name is derived
+   from the branch, so a renamed branch or deleted worktree orphans the stack
+   (see "Tear down when done" below for how to reap those).
 
 Notes:
 - Requires Node v22.20.0 on PATH and a populated root `.env` (image refs).
@@ -22,3 +25,53 @@ Notes:
 - OrbStack is recommended for speed but not required — the CLI uses only the
   standard `docker compose` interface.
 - `pnpm wt-stack ls` lists running stacks; `pnpm wt-stack info` prints the descriptor.
+
+## Tear down when done (mandatory — nothing reaps a local stack for you)
+
+Every stack you bring up stays up until something tears it down: OrbStack /
+Docker never expire them, and each agent session tends to leave its own
+behind. On 2026-09-01 the dev machine had **five** Breeze compose projects and
+two bare containers running from earlier sessions. Tear down what you brought
+up before you end, and say in your final summary what you left running and why.
+
+**`pnpm wt-stack ls` is not the whole picture.** It lists only `breeze` and
+`breeze-wt-*` projects. `pnpm test-stack ls` lists only `breeze-test-*`. Neither
+shows a `docker-compose.test.yml` brought up without `-p` (project = directory
+name, e.g. `worktree-quiet-field-f8d5`) or an ad-hoc `docker run` Postgres from a
+plan task. Use the engine-wide listing below.
+
+```bash
+# 1. What is still up, across ALL worktrees and sessions?
+docker compose ls -a --format json \
+  | jq -r '.[] | select(.ConfigFiles|test("breeze")) | "\(.Name)\t\(.Status)"'
+docker ps -a --format '{{.Names}}\t{{.Status}}\t{{.Label "com.docker.compose.project"}}' \
+  | grep -i breeze            # blank 3rd column = bare `docker run` container, no compose project
+
+# 2. Tear down what YOU brought up, from the worktree that created it
+pnpm wt-stack down                                    # this worktree's dev stack (drops volumes)
+pnpm test-stack down                                  # this worktree's integration pg+redis
+pnpm --filter @breeze/api test:docker:down            # the shared :5433 test stack (docker-compose.test.yml, no -p)
+docker compose -f docker-compose.yml -f docker-compose.override.yml.dev down -v --remove-orphans
+                                                      # a compose-mode stack — pass the same -f files you used for `up`
+
+# 3. Anything left over (worktree deleted, branch renamed, another session's stack)
+docker compose -p <name> down -v --remove-orphans     # <name> = first column of step 1; no -f needed
+docker rm -f <container>                              # bare containers, e.g. breeze-<issue>-drift
+
+# 4. Verify — both must print nothing
+docker compose ls -a --format json | jq -r '.[] | select(.ConfigFiles|test("breeze")) | .Name'
+docker ps -a --format '{{.Names}}' | grep -i breeze
+```
+
+**Everything-Breeze reset.** Only when you own every stack on the machine — this
+kills other sessions' stacks too, so never run it from a parallel agent:
+
+```bash
+docker compose ls -a --format json | jq -r '.[] | select(.ConfigFiles|test("breeze")) | .Name' \
+  | xargs -r -I{} docker compose -p {} down -v --remove-orphans
+docker ps -aq --filter name=breeze | xargs -r docker rm -f
+docker network ls --format '{{.Name}}' | grep -i breeze | xargs -r docker network rm   # stray *-net networks
+```
+
+`--keep-volumes` on `wt-stack down` keeps the Postgres data for a re-`up`; the
+default drops it, which is what you want at the end of a task.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1045,12 +1045,12 @@ jobs:
       # resolved that, and the tree is now clean at every severity, so the scan
       # covers dev dependencies too.
       #
-      # Follow-up: tighten AUDIT_THRESHOLD to HIGH once we're comfortable that a
-      # new dev-only advisory blocking PRs is an acceptable trade.
+      # Gate is HIGH+CRITICAL as of 2026-09-03 (SOC 2 CC7.1). A new dev-only
+      # HIGH advisory blocks PRs until patched or an exception is recorded.
       - name: Install osv-scanner
         run: bash scripts/security/install-osv-scanner.sh
 
-      - name: Run dependency audit (critical gate)
+      - name: Run dependency audit (high+critical gate)
         run: bash scripts/security/check-npm-audit.sh
 
       - name: Run supply-chain hardening guard

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -275,6 +275,9 @@ cd apps/api && npx vitest run src/routes/auth.test.ts
 # NOTE: `pnpm test` does NOT run the RLS/integration contract suites
 # (separate vitest configs: vitest.config.rls.ts, vitest.integration.config.ts).
 # Local green ≠ CI green — run those explicitly when touching tenancy/cascade code.
+# They need real Postgres+Redis. Per-worktree copy (safe alongside other sessions):
+pnpm test-stack up       # private pg+redis for this worktree (docker-compose.test.yml under -p)
+pnpm test-stack down     # tear it down when finished — nothing does this for you
 
 # Go agent (with race detection)
 cd agent && go test -race ./...
@@ -375,6 +378,18 @@ docker compose -f docker-compose.yml -f docker-compose.override.yml.local-build 
 ln -sf docker-compose.override.yml.dev docker-compose.override.yml
 docker compose up --build -d
 ```
+
+**Tear down when you're done — nothing reaps a local stack for you.** Every `up` (these modes, `pnpm wt-stack up`, `pnpm test-stack up`, an ad-hoc `docker run` Postgres) stays up until torn down, and each agent session tends to leave its own behind — five Breeze projects were found running on 2026-09-01. `pnpm wt-stack ls` and `pnpm test-stack ls` each see only their own prefix; the engine-wide truth is:
+
+```bash
+docker compose ls -a --format json | jq -r '.[] | select(.ConfigFiles|test("breeze")) | "\(.Name)\t\(.Status)"'   # every Breeze project, all worktrees
+docker compose -f docker-compose.yml -f docker-compose.override.yml.dev down -v --remove-orphans   # this checkout (same -f files as up)
+pnpm wt-stack down            # a wt-stack, from the worktree+branch that created it
+pnpm test-stack down          # a per-worktree integration stack, from the same worktree (reads the project it recorded in .env.test)
+docker compose -p <name> down -v --remove-orphans   # anything else the first command listed (no -f needed)
+```
+
+Before ending a session, tear down what you brought up and say what you left running. Full checklist (bare containers, orphaned projects, the everything-Breeze reset): `.claude/skills/worktree-stack/SKILL.md` → "Tear down when done".
 
 **Deleting a config file? Sweep the Compose mounts in the same PR.** Docker creates a missing bind-mount source as an empty **directory** on the host, which then gets `COPY`d into dev images where Vite/PostCSS discovery dies on it (`EISDIR`) — `breeze-web` comes up permanently unhealthy on a fresh clone. `apps/api/src/config/composeBindMounts.test.ts` (required **Test API** job) parses every tracked compose file and fails when a file-shaped, repo-relative bind-mount source doesn't exist — or has already become a phantom directory. Extensionless sources (`./agent/bin`) are exempt as intended build outputs; out-of-repo sources (`../breeze-billing/…`) can't be asserted and are skipped. Shipped three times before the guard existed: #1999 (postcss), #2208 (partial tailwind), #2012 (the mounts #2208 missed).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,11 @@ pnpm db:seed
 
 # Start dev servers
 pnpm dev
+
+# When you're done: stop the infrastructure (nothing stops it for you).
+# Add -v to also drop the database volumes.
+docker compose down
+docker compose ls -a   # shows any stack still running, from any checkout
 ```
 
 - **Frontend**: http://localhost:4321

--- a/apps/docs/src/content/docs/security/backup.mdx
+++ b/apps/docs/src/content/docs/security/backup.mdx
@@ -17,7 +17,7 @@ A Compose deployment keeps state in six named Docker volumes, plus your object s
 | `postgres_data` | Yes. This is the critical backup. | `--db` | PostgreSQL data at `/var/lib/postgresql/data` |
 | Object storage | Yes, when configured. | `--storage` | The bucket configured by `S3_ENDPOINT` and `S3_BUCKET` |
 | Configuration | Yes. | `--config` | `.env`, certificates, and Compose files. Encrypted with `tar` and `openssl` |
-| `api_data` | Yes, manually. | None | Patch compliance report CSV files at `/data/patch-reports` |
+| `api_data` | Yes. | `--data` (included in `--all` since 2026-09-03) | Patch compliance report CSV files at `/data/patch-reports` |
 | `redis_data` | No. Preserve the volume, but do not back it up and do not restore a snapshot. | None | Rebuildable Redis state at `/data` |
 | `binaries` | No. | None | Agent, viewer, and helper binaries at `/data/binaries`, mounted read-only. Refilled on every start |
 | `caddy_data` | Usually no. | None | Caddy's ACME account key and issued TLS certificates. See the note below |
@@ -35,7 +35,7 @@ The `api_data` volume is mounted at `/data` on the `api` service, and on the `wo
 
 A report can be run again, but the replacement uses the current patch state. It does not reproduce the historical snapshot captured by the original CSV file.
 
-`scripts/backup.sh` has no flag for this volume. It shells out to `pg_dump`, the S3 client and `openssl`, and reading a Docker volume needs access to the Docker socket, so the volume is handled as a separate command rather than a fourth flag. Copy it out with a throwaway container, writing into the same `$BACKUP_DIR` the script uses:
+`scripts/backup.sh --data` (also part of `--all`) copies this volume out with a throwaway container into the same `$BACKUP_DIR` as the other artifacts, as `api_data_<timestamp>.tar.gz`. It auto-detects the volume name (`*_api_data`) or takes `API_DATA_VOLUME` explicitly, and needs access to the Docker socket. The equivalent manual command, if you are on a release before the flag existed:
 
 ```bash
 docker run --rm -v breeze_api_data:/data -v "${BACKUP_DIR:-/var/backups/breeze}":/backup alpine \

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,6 +1,8 @@
 # Test Docker Compose - Ephemeral services for integration testing
 # Usage: docker compose -f docker-compose.test.yml up -d
 # Cleanup: docker compose -f docker-compose.test.yml down -v
+#          (per-worktree copy: `pnpm test-stack down`). Nothing tears these down
+#          for you — `docker compose ls -a` lists every copy still running.
 #
 # Concurrent worktrees (#3066): the BREEZE_TEST_* variables below let
 # `pnpm test-stack up` (scripts/dev/test-stack) run a PRIVATE copy of this

--- a/docs/operations/BACKUP_RESTORE.md
+++ b/docs/operations/BACKUP_RESTORE.md
@@ -9,9 +9,9 @@ This document covers backup and restore procedures for a Breeze RMM deployment.
 | Database | `--db` | `pg_dump` / `pg_restore` | All PostgreSQL data: devices, users, orgs, alerts, audit logs, etc. |
 | Object storage | `--storage` | `aws s3 sync` or `mc mirror` | Scripts, agent binaries, report exports, attachments mirrored from MinIO/S3 into a directory |
 | Configuration | `--config` | `tar` + `openssl` | `.env`, `.env.production`, `certs/`, `docker/` -- encrypted at rest |
-| `api_data` volume | None | `docker run` + `tar` | Patch compliance report CSVs at `/data/patch-reports`. Not covered by any script flag |
+| `api_data` volume | `--data` | `docker run` + `tar` | Patch compliance report CSVs at `/data/patch-reports` |
 
-Use `--all` with the backup script to back up the first three components at once. **`--all` does not cover the `api_data` volume** -- that is a separate manual command.
+Use `--all` with the backup script to back up all four components at once (`--data` was added 2026-09-03; on older releases `api_data` required a separate manual `docker run` + `tar`).
 
 The `redis_data` volume is deliberately not backed up. Preserve the volume across upgrades, but never restore it from a snapshot: Redis and PostgreSQL have no consistent-snapshot mechanism, so a stale Redis re-injects job state that PostgreSQL already recorded as complete.
 

--- a/docs/operations/DISASTER_RECOVERY.md
+++ b/docs/operations/DISASTER_RECOVERY.md
@@ -93,7 +93,7 @@ Services    (10,000+)
 | **Object storage** | S3 cross-region replication or daily `rclone sync` | Daily | 30 days |
 | **Configuration** | Encrypted backup of `.env`, certs, and secrets | On every change | 90 days |
 | **TLS/mTLS certificates** | Backup private keys and cert files | On every change | Until expiry + 30 days |
-| **`api_data` volume** | `docker run` + `tar` (no script flag) | Daily | Match the database retention |
+| **`api_data` volume** | `scripts/backup.sh --data` (included in `--all`) | Daily | Match the database retention |
 | **`redis_data` volume** | Do not back up | N/A | Rebuildable. Preserve the volume, but never restore a stale snapshot over a live database |
 | **Go agents** | No backup needed | N/A | Agents auto-reconnect and re-sync |
 
@@ -170,7 +170,7 @@ RESTORE_TEST_ALERT_URL=https://hooks.slack.com/services/...   # optional
 > The dumps are gpg-encrypted before they leave the droplet (the dump contains all
 > tenant data in the clear; app-layer field encryption only covers secret columns).
 > `restore-test.sh` decrypts with the same passphrase. Losing the passphrase makes
-> the off-region copies unrecoverable — keep it in an offline vault as well.
+> the off-region copies unrecoverable — it is also held in the 1Password vault "Breeze Compliance".
 
 **Cron (on the droplet):**
 
@@ -708,12 +708,33 @@ If the attacker modified data, perform a targeted or full restore from a backup 
 
 ### Internal Notification Chain
 
-| Priority | Who to Notify | Method | Timeframe |
-|----------|--------------|--------|-----------|
-| **P1** (full outage) | On-call engineer, Engineering lead, CTO | PagerDuty / phone call | Immediately |
-| **P2** (degraded service) | On-call engineer, Engineering lead | Slack #incidents | Within 5 minutes |
-| **P3** (minor issue) | On-call engineer | Slack #ops | Within 15 minutes |
-| **Security incident** | On-call engineer, Security lead, CTO, Legal | Phone call + encrypted channel | Immediately |
+Breeze production is operated by a single on-call operator (the founder). There is no
+separate engineering lead, CTO, security lead, or legal function; the roles below are
+filled as stated. Alerts are delivered by Alertmanager to the operator's phone.
+
+| Priority | Who acts | How they are reached | Timeframe |
+|----------|----------|----------------------|-----------|
+| **P1** (full outage) | Operator | Alertmanager page to phone; automated restore-test and dead-man alerts also page | Immediately |
+| **P2** (degraded service) | Operator | Alertmanager notification | Within 15 minutes |
+| **P3** (minor issue) | Operator | Alertmanager notification, reviewed at next working session | Within 1 business day |
+| **Security incident** | Operator, with Huntress MDR for endpoint/tenant detections | Alertmanager page; Huntress escalation call/email | Immediately |
+
+**Backup contact.** If the operator is unreachable for more than 4 hours during a P1 or
+security incident, the designated backup contact (name, relationship and phone are recorded in the
+1Password vault "Breeze Compliance", next to the break-glass credentials) is authorized to use the
+DigitalOcean console break-glass account to restore service following Scenario 3 of this
+runbook, and to send the customer notifications below. Break-glass credentials are held
+in the 1Password vault "Breeze Compliance" (which also holds the off-region backup GPG passphrases and the LUKS keyfile + header backup for each droplet); use of the break-glass account is alerted on and must be recorded in
+the incident register.
+
+**Outside counsel and disclosure.** For a security incident involving customer data, the
+operator engages outside counsel or the cyber-insurance incident hotline (both recorded
+in the 1Password vault "Breeze Compliance") before customer notification to
+confirm notification obligations and timing.
+
+**Incident register.** Every P1, P2, and security incident is recorded in the incident
+register (`breeze-evidence/soc2/incident-register.md`) with detection time, severity,
+actions, resolution time, and a link to the post-incident review.
 
 ### External Communication
 

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -201,6 +201,14 @@ Bring the local stack up:
 docker compose -f docker-compose.yml -f docker-compose.override.yml.dev up --build -d
 ```
 
+When you're done, tear it down with the same `-f` files (nothing does this for you):
+```bash
+docker compose -f docker-compose.yml -f docker-compose.override.yml.dev down -v --remove-orphans
+pnpm wt-stack down     # if you used `pnpm wt-stack up` instead
+docker compose ls -a   # confirm nothing is still listed
+```
+Full checklist for stacks left behind by other worktrees: `.claude/skills/worktree-stack/SKILL.md` → "Tear down when done".
+
 ### Login 429 (rate limited)
 
 `globalSetup` clears the per-email rate-limit window before it logs in, and now

--- a/monitoring/rules/breeze-rules.yml
+++ b/monitoring/rules/breeze-rules.yml
@@ -252,6 +252,45 @@ groups:
           description: "{{ $value }} commands dispatched in 5m for tenant {{ $labels.tenant }} — possible compromised account fanning out commands"
           runbook_url: "https://docs.breeze.local/runbooks/command-dispatch-spike"
 
+  - name: breeze-backup-alerts
+    interval: 60s
+    rules:
+      # Emitted by internal/ops/restore-test-encrypted.sh via node_exporter's
+      # textfile collector after every weekly restore drill. A 0 means the last
+      # drill could not prove the off-region backup restorable. Before this rule
+      # existed a failed drill on 2026-08-30 sat unnoticed for four days.
+      - alert: BackupRestoreTestFailed
+        expr: breeze_db_restore_test_success == 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Off-region backup restore drill failed ({{ $labels.region }})"
+          description: "The last restore test for bucket {{ $labels.bucket }} failed. The backup is not proven restorable. See /var/log/breeze-restore-test.log on the region host."
+
+      # Dead-man: the drill runs weekly. If the last *successful* drill is more
+      # than 8 days old — or the metric is absent because the cron, the host, or
+      # the textfile collector died — nobody is proving restorability.
+      - alert: BackupRestoreTestStale
+        expr: |
+          (time() - breeze_db_restore_test_last_success_timestamp_seconds) > 8 * 86400
+          or breeze_db_restore_test_last_success_timestamp_seconds == 0
+        for: 30m
+        labels:
+          severity: critical
+        annotations:
+          summary: "No successful backup restore drill in 8+ days ({{ $labels.region }})"
+          description: "Last successful restore drill for {{ $labels.bucket }} is older than 8 days. Check the Sunday cron and the restore-test log."
+
+      - alert: BackupRestoreTestMetricsMissing
+        expr: absent(breeze_db_restore_test_success)
+        for: 1h
+        labels:
+          severity: warning
+        annotations:
+          summary: "breeze_db_restore_test_success metric is absent"
+          description: "No region host is publishing restore-drill metrics. Either the textfile collector directory is missing or node_exporter is not scraped."
+
   - name: breeze-recording-rules
     interval: 30s
     rules:

--- a/package.json
+++ b/package.json
@@ -104,7 +104,8 @@
       "js-yaml@>=4.0.0 <4.3.1": ">=4.3.1 <5.0.0",
       "nanoid@<3.3.18": ">=3.3.18 <4.0.0",
       "deepmerge-ts@<8.0.0": ">=8.0.1 <9.0.0",
-      "fast-uri": ">=3.1.6"
+      "fast-uri": ">=3.1.6",
+      "browserslist@<4.28.7": "4.28.9"
     },
     "patchedDependencies": {
       "postgres@3.4.9": "patches/postgres@3.4.9.patch"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,7 @@ overrides:
   nanoid@<3.3.18: '>=3.3.18 <4.0.0'
   deepmerge-ts@<8.0.0: '>=8.0.1 <9.0.0'
   fast-uri: '>=3.1.6'
+  browserslist@<4.28.7: 4.28.9
 
 patchedDependencies:
   postgres@3.4.9:
@@ -6340,11 +6341,6 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.10.44:
-    resolution: {integrity: sha512-T3ghW+sl/ZJ8w1v/yQx3qvJ9040DWoLBz8JT/CILbAKcFyG9b2MRe75v6W5uXjv6uH1lumK2Kv46y2zSkcej0Q==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
   baseline-browser-mapping@2.11.21:
     resolution: {integrity: sha512-uh8vpY/1/YyFkunIDFH/12p7/7VdPKA1hejMVEbdkEaWnUz0Hesvx5EbiU6XxjyHZIOju+ZMbQJkRh+es3/spQ==}
     engines: {node: '>=6.0.0'}
@@ -6413,11 +6409,6 @@ packages:
 
   browserify-zlib@0.2.0:
     resolution: {integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==}
-
-  browserslist@4.28.6:
-    resolution: {integrity: sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
 
   browserslist@4.28.9:
     resolution: {integrity: sha512-EWazOblFYUvlGZcfGhPUPmYh3nikUxBVb+y9MJun5f3hBi812X+8MSQTujLBtgK3cf51fJWbWfOjyeO954d+Eg==}
@@ -7340,9 +7331,6 @@ packages:
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
-
-  electron-to-chromium@1.5.393:
-    resolution: {integrity: sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==}
 
   electron-to-chromium@1.5.422:
     resolution: {integrity: sha512-UvA/32XqrLDdZSn7Jllo1AYNcWji/G0d5M0GTViE7KoGBiMunw3a34Sb2KO4ZZyrSEhqsxFoVhWWJshdyfKqJA==}
@@ -9557,10 +9545,6 @@ packages:
   node-mock-http@1.0.5:
     resolution: {integrity: sha512-KQyt/wLjG3TAc7DOUhpqWzgd4ERxR80JOlTK5VE5R1S12IaPVN5qkj4klBce9HPG1Njuup4Sb5bljaT34lIyjw==}
 
-  node-releases@2.0.51:
-    resolution: {integrity: sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==}
-    engines: {node: '>=18'}
-
   node-releases@2.0.54:
     resolution: {integrity: sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==}
     engines: {node: '>=18'}
@@ -11439,17 +11423,11 @@ packages:
       uploadthing:
         optional: true
 
-  update-browserslist-db@1.2.3:
-    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
-    hasBin: true
-    peerDependencies:
-      browserslist: '>= 4.21.0'
-
   update-browserslist-db@1.3.2:
     resolution: {integrity: sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==}
     hasBin: true
     peerDependencies:
-      browserslist: '>= 4.21.0'
+      browserslist: 4.28.9
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -17550,7 +17528,7 @@ snapshots:
 
   autoprefixer@10.5.4(postcss@8.5.28):
     dependencies:
-      browserslist: 4.28.6
+      browserslist: 4.28.9
       caniuse-lite: 1.0.30001806
       fraction.js: 5.3.4
       picocolors: 1.1.1
@@ -17764,8 +17742,6 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.10.44: {}
-
   baseline-browser-mapping@2.11.21: {}
 
   bcp-47-match@2.0.3: {}
@@ -17844,14 +17820,6 @@ snapshots:
   browserify-zlib@0.2.0:
     dependencies:
       pako: 1.0.11
-
-  browserslist@4.28.6:
-    dependencies:
-      baseline-browser-mapping: 2.10.44
-      caniuse-lite: 1.0.30001806
-      electron-to-chromium: 1.5.393
-      node-releases: 2.0.51
-      update-browserslist-db: 1.2.3(browserslist@4.28.6)
 
   browserslist@4.28.9:
     dependencies:
@@ -18685,8 +18653,6 @@ snapshots:
     optional: true
 
   ee-first@1.1.1: {}
-
-  electron-to-chromium@1.5.393: {}
 
   electron-to-chromium@1.5.422: {}
 
@@ -21622,8 +21588,6 @@ snapshots:
 
   node-mock-http@1.0.5: {}
 
-  node-releases@2.0.51: {}
-
   node-releases@2.0.54: {}
 
   node-stream-zip@1.16.0: {}
@@ -23758,12 +23722,6 @@ snapshots:
       '@azure/identity': 4.13.1
       '@azure/keyvault-secrets': 4.11.2
       ioredis: 5.11.1
-
-  update-browserslist-db@1.2.3(browserslist@4.28.6):
-    dependencies:
-      browserslist: 4.28.6
-      escalade: 3.2.0
-      picocolors: 1.1.1
 
   update-browserslist-db@1.3.2(browserslist@4.28.9):
     dependencies:

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -7,6 +7,7 @@
 #   ./scripts/backup.sh --db
 #   ./scripts/backup.sh --storage
 #   ./scripts/backup.sh --config
+#   ./scripts/backup.sh --data          # api_data volume (patch compliance reports)
 #   ./scripts/backup.sh --db --config
 #
 # Environment variables:
@@ -14,6 +15,7 @@
 #   BACKUP_DIR              Destination directory (default: /var/backups/breeze)
 #   BACKUP_RETENTION_DAYS   Delete backups older than N days (default: 30)
 #   BACKUP_ENCRYPTION_KEY   Passphrase for config encryption (required for --config)
+#   API_DATA_VOLUME         Docker volume holding /data (default: auto-detect *_api_data)
 #   S3_ENDPOINT             MinIO/S3 endpoint (required for --storage)
 #   S3_BUCKET               Bucket name (default: breeze)
 #   S3_ACCESS_KEY           S3 access key (required for --storage)
@@ -71,9 +73,10 @@ ensure_dir() {
 DO_DB=false
 DO_STORAGE=false
 DO_CONFIG=false
+DO_DATA=false
 
 if [ $# -eq 0 ]; then
-  echo "Usage: $0 [--all | --db] [--storage] [--config]"
+  echo "Usage: $0 [--all | --db] [--storage] [--config] [--data]"
   echo "At least one flag is required."
   exit 2
 fi
@@ -84,12 +87,14 @@ while [ $# -gt 0 ]; do
       DO_DB=true
       DO_STORAGE=true
       DO_CONFIG=true
+      DO_DATA=true
       ;;
     --db)       DO_DB=true ;;
     --storage)  DO_STORAGE=true ;;
     --config)   DO_CONFIG=true ;;
+    --data)     DO_DATA=true ;;
     -h|--help)
-      echo "Usage: $0 [--all | --db] [--storage] [--config]"
+      echo "Usage: $0 [--all | --db] [--storage] [--config] [--data]"
       exit 0
       ;;
     *)
@@ -141,6 +146,20 @@ if $DO_CONFIG; then
   fi
   if ! command -v openssl &>/dev/null; then
     die "openssl is not installed or not in PATH"
+  fi
+fi
+
+if $DO_DATA; then
+  TASKS_REQUESTED=$((TASKS_REQUESTED + 1))
+  if ! command -v docker &>/dev/null; then
+    die "docker is required for --data backups"
+  fi
+  API_DATA_VOLUME="${API_DATA_VOLUME:-}"
+  if [ -z "$API_DATA_VOLUME" ]; then
+    API_DATA_VOLUME="$(docker volume ls --format '{{.Name}}' | grep -E '(^|_)api_data$' | head -1 || true)"
+  fi
+  if [ -z "$API_DATA_VOLUME" ]; then
+    die "Could not find an api_data docker volume; set API_DATA_VOLUME explicitly"
   fi
 fi
 
@@ -275,6 +294,29 @@ backup_config() {
 }
 
 # ---------------------------------------------------------------------------
+# api_data volume backup (patch compliance reports at /data/patch-reports)
+# ---------------------------------------------------------------------------
+
+backup_api_data() {
+  log "Starting api_data volume backup (${API_DATA_VOLUME})..."
+  local dest="${BACKUP_DIR}/api_data_${TIMESTAMP}.tar.gz"
+
+  if docker run --rm \
+       -v "${API_DATA_VOLUME}:/data:ro" \
+       -v "${BACKUP_DIR}:/backup" \
+       alpine:3 tar -czf "/backup/$(basename "${dest}")" -C /data . 2>&1; then
+    local size
+    size=$(du -h "${dest}" | cut -f1)
+    log "api_data backup complete: ${dest} (${size})"
+    TASKS_SUCCEEDED=$((TASKS_SUCCEEDED + 1))
+  else
+    log "ERROR: api_data backup failed"
+    rm -f "${dest}"
+    return 1
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # Retention cleanup
 # ---------------------------------------------------------------------------
 
@@ -321,6 +363,12 @@ fi
 if $DO_CONFIG; then
   if ! backup_config; then
     log "ERROR: backup_config returned non-zero exit status"
+  fi
+fi
+
+if $DO_DATA; then
+  if ! backup_api_data; then
+    log "ERROR: backup_api_data returned non-zero exit status"
   fi
 fi
 

--- a/scripts/ops/restore-test.sh
+++ b/scripts/ops/restore-test.sh
@@ -136,15 +136,25 @@ docker run -d --name "${CONTAINER}" \
 
 SCRATCH_URL="postgresql://postgres:${PG_PASSWORD}@127.0.0.1:${PG_PORT}/breeze"
 
-log "Waiting for scratch postgres to accept connections..."
-ready=false
-for _ in $(seq 1 30); do
-  if docker exec "${CONTAINER}" pg_isready -U postgres -d breeze >/dev/null 2>&1; then
-    ready=true; break
+# The official postgres image boots a temporary, socket-only server to run its
+# init scripts and then restarts it as the real, TCP-listening server. An
+# in-container `pg_isready` can pass during that first phase, after which the
+# restart closes the connection pg_restore just opened ("server closed the
+# connection unexpectedly" — seen 2026-08-30 on breeze-us). So: probe from the
+# host over the published port, and require three consecutive successes.
+log "Waiting for scratch postgres to accept TCP connections..."
+ready=false; streak=0
+for _ in $(seq 1 60); do
+  if PGPASSWORD="${PG_PASSWORD}" psql -h 127.0.0.1 -p "${PG_PORT}" -U postgres -d breeze \
+       -t -A -c 'select 1' >/dev/null 2>&1; then
+    streak=$((streak + 1))
+    [ "${streak}" -ge 3 ] && { ready=true; break; }
+  else
+    streak=0
   fi
   sleep 1
 done
-$ready || fail "scratch postgres never became ready" 2
+$ready || fail "scratch postgres never became ready over TCP" 2
 
 # --- 3) restore via the existing, tested restore.sh ---
 # restore.sh runs pg_restore + a device-count sanity check; we point it at the

--- a/scripts/security/check-npm-audit.sh
+++ b/scripts/security/check-npm-audit.sh
@@ -9,14 +9,15 @@ set -euo pipefail
 # `pnpm audit` fails closed on every release line. osv-scanner reads the
 # lockfile directly and needs no npm audit endpoint.
 #
-# Gate: fail on CRITICAL only, matching the previous `--audit-level=critical`.
-# Lower severities are reported but do not block. The tree is currently clean at
-# every severity, so tightening this to HIGH is viable if we want it.
+# Gate: fail on HIGH and CRITICAL (raised from CRITICAL-only on 2026-09-03 for
+# SOC 2 CC7.1; the tree was clean at every severity at the time). MODERATE and
+# below are reported but do not block. Override with AUDIT_THRESHOLD=CRITICAL
+# only for an emergency hotfix, and record the exception.
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 
-THRESHOLD="${AUDIT_THRESHOLD:-CRITICAL}"
+THRESHOLD="${AUDIT_THRESHOLD:-HIGH}"
 LOCKFILE="pnpm-lock.yaml"
 
 fail() {
@@ -61,12 +62,28 @@ if [ "$total_vulns" -gt 0 ]; then
         "$report" | sort -u
 fi
 
-blocking="$(jq --arg t "$THRESHOLD" \
+# Severities at or above the threshold block. Ranks: CRITICAL=4 HIGH=3
+# MODERATE=2 LOW=1 UNSPECIFIED=0.
+rank_of() {
+  case "$(echo "$1" | tr '[:lower:]' '[:upper:]')" in
+    CRITICAL) echo 4 ;;
+    HIGH) echo 3 ;;
+    MODERATE|MEDIUM) echo 2 ;;
+    LOW) echo 1 ;;
+    *) echo 0 ;;
+  esac
+}
+threshold_rank="$(rank_of "$THRESHOLD")"
+[ "$threshold_rank" -gt 0 ] || fail "unknown AUDIT_THRESHOLD '$THRESHOLD' (use CRITICAL, HIGH, MODERATE, or LOW)"
+
+blocking="$(jq --argjson min "$threshold_rank" \
   '[.results[]?.packages[]?.vulnerabilities[]?
-    | select((.database_specific.severity // "") == $t)] | length' "$report")"
+    | (.database_specific.severity // "" | ascii_upcase) as $s
+    | ({"CRITICAL":4,"HIGH":3,"MODERATE":2,"MEDIUM":2,"LOW":1}[$s] // 0) as $r
+    | select($r >= $min)] | length' "$report")"
 
 if [ "$blocking" -gt 0 ]; then
-  fail "found ${blocking} ${THRESHOLD} advisory/advisories — see detail above"
+  fail "found ${blocking} advisory/advisories at or above ${THRESHOLD} — see detail above"
 fi
 
-echo "OK: no ${THRESHOLD} advisories in $LOCKFILE"
+echo "OK: no advisories at or above ${THRESHOLD} in $LOCKFILE"


### PR DESCRIPTION
## Summary

Salvages uncommitted edits from `~/breeze` (made 2026-09-01 → 09-09 on a checkout frozen at a 09-01 base, never pushed) and re-applies them onto current main. Nothing here was on main in any form except the gh-queue staleness block, which was dropped.

**Ops scripts**
- `scripts/backup.sh --data` backs up the `api_data` volume (patch-report CSVs) through a throwaway container; part of `--all`; auto-detects `*_api_data` or honours `API_DATA_VOLUME`. `BACKUP_RESTORE.md` and the docs site row updated to match.
- `scripts/security/check-npm-audit.sh` gates on **HIGH+CRITICAL** (was CRITICAL only) with a rank-based comparator; `ci.yml` step name and comment follow. If main currently carries a HIGH dev-only advisory, this PR's CI will show it, which is the point.
- `scripts/ops/restore-test.sh`: in-container `pg_isready` can succeed against Postgres's temporary init server; readiness now needs three consecutive host-side `psql` successes.

**Monitoring**
- `BackupRestoreTestFailed` / `BackupRestoreTestStale` / `BackupRestoreTestMetricsMissing` on the textfile metrics the restore drill already emits.
- The original edit also added `OffsiteBackupFailed` / `OffsiteBackupStale`. **Left out**: the offsite script emits no metrics, so both rules would have been permanently inert. Follow-up issue filed.

**Docs**
- `DISASTER_RECOVERY.md`: replaces the fictional four-role escalation chain with the single-operator reality, adds the break-glass backup contact, outside counsel, and the incident register. The original edit had two literal `[PLACEHOLDER]`s for a person's name/phone and a law-firm hotline; those now point at the "Breeze Compliance" 1Password vault so no PII lands in the public repo. **Todd: make sure those vault items exist.**
- CLAUDE.md, CONTRIBUTING.md, `e2e-tests/README.md`, `docker-compose.test.yml`, five skills: tear-down discipline (`docker compose ls -a` is the engine-wide truth; `wt-stack ls` / `test-stack ls` each see only their prefix).

## Verification
- `bash -n` and shellcheck (warning level) clean on all three scripts; `ci.yml` and `docker-compose.test.yml` parse.
- `check-npm-audit.sh` could not run locally (no `osv-scanner` on this machine); CI installs it.
- Docs/skills: text only.

## Provenance
The exact pre-salvage patch is preserved on local branch `wip/local-edits-2026-09-01-to-09-09` (commit `10ab3e6a6a`) and in `internal/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013auR2S4tHMtuKXj1bXD9aD
