### PR TITLE
fix(accounting): dedicated accounting:read / accounting:manage permissions; full-partner authority on every QuickBooks route (SEC-057)

### DIFF
--- a/apps/api/migrations/2026-10-15-150500-accounting-dedicated-permissions.sql
+++ b/apps/api/migrations/2026-10-15-150500-accounting-dedicated-permissions.sql
@@ -1,0 +1,119 @@
+-- Dedicated accounting:read / accounting:manage permissions for the
+-- QuickBooks integration routes (SEC-2026-09-05-057, owner decision Option A).
+--
+-- Before this change, every interactive accounting route gated only on
+-- partner/organization authority: there was no accounting permission at all,
+-- so any full-partner member — however low their role — could read the shared
+-- provider realm (status, customers, entity mappings, income accounts, remote
+-- candidates) and, with MFA, reach realm lifecycle and settings mutations
+-- (connect, disconnect, settings update/refresh, mapping writes, provider and
+-- mapping synchronization, reconcile triggers).
+--
+-- Grant predicate: copies 2026-10-15-150200-pam-dedicated-permissions.sql
+-- exactly. `r.name = 'Org Admin' AND r.scope = 'organization' AND
+-- r.is_system = TRUE`, with NO `partner_id IS NULL` clause: per-partner
+-- `is_system` Org Admin clones exist in production (Org Admin roles are seeded
+-- per-partner, one row per partner), so a global-template-only grant would
+-- reach nobody on upgrade. `is_system = TRUE` is the anti-forgery filter —
+-- custom roles created via routes/roles.ts are always `is_system = FALSE`, so
+-- this can never grant accounting authority to an attacker-created role merely
+-- named "Org Admin".
+--
+-- Partner Admin already holds the wildcard '*:*' permission, so it needs no
+-- explicit row here — and since the accounting routes are partner-scope only
+-- (requireScope('partner','system')), Partner Admin is in practice the only
+-- built-in role that can exercise these permissions today. The Org Admin grant
+-- mirrors the 150200 predicate so the two permission families stay
+-- operationally identical, and so an org-scoped accounting surface added later
+-- inherits the same default. NO other built-in role and NO custom role gains
+-- either permission automatically: an operator who relied on a low-privilege
+-- partner role reaching QuickBooks must grant these explicitly after upgrade.
+--
+-- Idempotent: safe to re-run. permissions.id defaults to gen_random_uuid() at
+-- the DB level (0001-baseline.sql), so no id is supplied on insert.
+--
+-- NOTE: permissions has NO UNIQUE constraint on (resource, action) — only a
+-- primary key on id. `ON CONFLICT DO NOTHING` therefore has nothing to
+-- conflict against and would silently insert a duplicate on every re-apply.
+-- Use an explicit existence check, matching 150200.
+--
+-- Every write in this file runs under system scope: on a connection that does
+-- not bypass RLS, an UPDATE/INSERT with no scope elected either matches zero
+-- rows silently or aborts with 42501 (issue #4518). One `set_config` at the
+-- top of the file covers the whole migration — `is_local = true` scopes it to
+-- autoMigrate's per-file transaction.
+SELECT set_config('breeze.scope', 'system', true);
+
+DO $$
+DECLARE
+  n integer;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM permissions WHERE resource = 'accounting' AND action = 'read'
+  ) THEN
+    INSERT INTO permissions (resource, action, description)
+    VALUES ('accounting', 'read', 'Read accounting provider status, customers, mappings, and income accounts');
+    GET DIAGNOSTICS n = ROW_COUNT;
+    IF n > 0 THEN
+      RAISE WARNING 'seeded accounting:read permission row';
+    END IF;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM permissions WHERE resource = 'accounting' AND action = 'manage'
+  ) THEN
+    INSERT INTO permissions (resource, action, description)
+    VALUES ('accounting', 'manage', 'Connect, disconnect, configure, and synchronize accounting provider integrations');
+    GET DIAGNOSTICS n = ROW_COUNT;
+    IF n > 0 THEN
+      RAISE WARNING 'seeded accounting:manage permission row';
+    END IF;
+  END IF;
+END $$;
+
+DO $$
+DECLARE
+  n integer;
+  v_read_id uuid;
+  v_manage_id uuid;
+BEGIN
+  -- Scalar lookups (not JOINs) so this stays correct even if a duplicate
+  -- permissions row were ever present — always resolves to exactly one id.
+  SELECT id INTO v_read_id FROM permissions
+  WHERE resource = 'accounting' AND action = 'read' ORDER BY id LIMIT 1;
+
+  SELECT id INTO v_manage_id FROM permissions
+  WHERE resource = 'accounting' AND action = 'manage' ORDER BY id LIMIT 1;
+
+  INSERT INTO role_permissions (role_id, permission_id)
+  SELECT r.id, v_read_id
+  FROM roles r
+  WHERE r.name = 'Org Admin'
+    AND r.scope = 'organization'
+    AND r.is_system = TRUE
+    AND v_read_id IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM role_permissions rp
+      WHERE rp.role_id = r.id AND rp.permission_id = v_read_id
+    );
+  GET DIAGNOSTICS n = ROW_COUNT;
+  IF n > 0 THEN
+    RAISE WARNING 'granted accounting:read to % existing Org Admin role(s)', n;
+  END IF;
+
+  INSERT INTO role_permissions (role_id, permission_id)
+  SELECT r.id, v_manage_id
+  FROM roles r
+  WHERE r.name = 'Org Admin'
+    AND r.scope = 'organization'
+    AND r.is_system = TRUE
+    AND v_manage_id IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM role_permissions rp
+      WHERE rp.role_id = r.id AND rp.permission_id = v_manage_id
+    );
+  GET DIAGNOSTICS n = ROW_COUNT;
+  IF n > 0 THEN
+    RAISE WARNING 'granted accounting:manage to % existing Org Admin role(s)', n;
+  END IF;
+END $$;

--- a/apps/api/src/__tests__/integration/accountingDedicatedPermissionsMigration.integration.test.ts
+++ b/apps/api/src/__tests__/integration/accountingDedicatedPermissionsMigration.integration.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Live-DB replay test for
+ * 2026-10-15-150500-accounting-dedicated-permissions.sql (SEC-2026-09-05-057,
+ * owner decision Option A). Exercises the migration file directly against a
+ * real Postgres instance — not the seeded state a fresh `autoMigrate` run
+ * leaves behind — covering the properties the PR description promises:
+ *
+ *   1. accounting:read / accounting:manage permission rows exist exactly once.
+ *   2. Re-running the migration is a no-op (no duplicate rows/grants).
+ *   3. The grant reaches BOTH the global system-template Org Admin row
+ *      (partner_id IS NULL) AND a per-partner is_system Org Admin clone —
+ *      but never a custom role merely named "Org Admin" (is_system = false),
+ *      and never any other built-in role.
+ *
+ * Mirrors pamDedicatedPermissionsMigration.integration.test.ts, whose
+ * migration this one's grant predicate copies verbatim.
+ */
+import './setup';
+import { describe, it, expect, afterAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import postgres from 'postgres';
+
+const RUN = !!process.env.DATABASE_URL;
+const MIGRATION = '2026-10-15-150500-accounting-dedicated-permissions.sql';
+const migrationSql = readFileSync(join(__dirname, '../../../migrations', MIGRATION), 'utf8');
+
+const notices: string[] = [];
+const adminSql = postgres(process.env.DATABASE_URL ?? '', {
+  max: 1,
+  onnotice: (n) => { notices.push(String(n.message)); },
+});
+afterAll(async () => { await adminSql.end({ timeout: 5 }); });
+
+async function replay(): Promise<string[]> {
+  notices.length = 0;
+  await adminSql.unsafe(migrationSql);
+  return [...notices];
+}
+
+function uniqueSlug(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function makePartner(name: string) {
+  const [row] = await adminSql`
+    insert into partners (name, slug, type, plan, status, currency_code)
+    values (${name}, ${uniqueSlug('acct-mig')}, 'msp', 'free', 'active', 'USD')
+    returning id
+  `;
+  return row!.id as string;
+}
+
+describe.skipIf(!RUN)('migration: 2026-10-15-150500-accounting-dedicated-permissions', () => {
+  it('permission rows exist exactly once for accounting:read and accounting:manage', async () => {
+    await replay();
+    const read = await adminSql`select id from permissions where resource = 'accounting' and action = 'read'`;
+    const manage = await adminSql`select id from permissions where resource = 'accounting' and action = 'manage'`;
+    expect(read).toHaveLength(1);
+    expect(manage).toHaveLength(1);
+  });
+
+  it('re-running the migration is a no-op: no duplicate permission rows or grants', async () => {
+    await replay(); // ensure baseline seeded
+    const countPerms = () => adminSql`select count(*)::int as n from permissions where resource = 'accounting'`;
+    const countGrants = () => adminSql`
+      select count(*)::int as n from role_permissions rp
+      join permissions p on p.id = rp.permission_id
+      where p.resource = 'accounting'
+    `;
+
+    const beforePerm = (await countPerms())[0]!.n;
+    const beforeGrant = (await countGrants())[0]!.n;
+
+    const msgs = await replay();
+
+    expect((await countPerms())[0]!.n).toBe(beforePerm);
+    expect((await countGrants())[0]!.n).toBe(beforeGrant);
+    expect(msgs.some((m) => m.startsWith('seeded accounting:'))).toBe(false);
+    expect(msgs.some((m) => m.startsWith('granted accounting:'))).toBe(false);
+  });
+
+  it('grants reach BOTH the global system-template Org Admin AND a per-partner is_system clone, never a forged custom role sharing the name, never another built-in role', async () => {
+    await replay(); // ensure the permission rows exist
+
+    const partnerId = await makePartner('Accounting Migration Grant Test');
+
+    // setup.ts's per-test cleanupDatabase() TRUNCATEs `roles`, so the global
+    // system-template row seed.ts would normally have created is recreated
+    // here explicitly rather than relying on incidental state.
+    const [globalTemplateSeed] = await adminSql`
+      insert into roles (scope, name, is_system, force_mfa)
+      values ('organization', 'Org Admin', true, false)
+      returning id
+    `;
+    // Production shape: a per-partner is_system clone alongside the template.
+    const [clone] = await adminSql`
+      insert into roles (partner_id, scope, name, is_system, force_mfa)
+      values (${partnerId}, 'organization', 'Org Admin', true, false)
+      returning id
+    `;
+    // Anti-forgery control: same name, is_system = false (routes/roles.ts
+    // always creates custom roles this way) — must NEVER be swept in.
+    const [forged] = await adminSql`
+      insert into roles (partner_id, scope, name, is_system, force_mfa)
+      values (${partnerId}, 'organization', 'Org Admin', false, false)
+      returning id
+    `;
+    // No other built-in role may gain either permission automatically —
+    // Partner Technician is the role the finding's over-authorized caller
+    // most plausibly holds, so it is the explicit negative control.
+    const [partnerTech] = await adminSql`
+      insert into roles (partner_id, scope, name, is_system, force_mfa)
+      values (${partnerId}, 'partner', 'Partner Technician', true, false)
+      returning id
+    `;
+
+    await replay();
+
+    const [readPerm] = await adminSql`select id from permissions where resource = 'accounting' and action = 'read'`;
+    const [managePerm] = await adminSql`select id from permissions where resource = 'accounting' and action = 'manage'`;
+
+    for (const roleId of [clone!.id, globalTemplateSeed!.id]) {
+      const grants = await adminSql`select permission_id from role_permissions where role_id = ${roleId}`;
+      const grantedIds = grants.map((g) => g.permission_id as string);
+      expect(grantedIds).toContain(readPerm!.id);
+      expect(grantedIds).toContain(managePerm!.id);
+    }
+
+    for (const roleId of [forged!.id, partnerTech!.id]) {
+      const grants = await adminSql`select permission_id from role_permissions where role_id = ${roleId}`;
+      const grantedIds = grants.map((g) => g.permission_id as string);
+      expect(grantedIds).not.toContain(readPerm!.id);
+      expect(grantedIds).not.toContain(managePerm!.id);
+    }
+  });
+});

--- a/apps/api/src/db/seed.test.ts
+++ b/apps/api/src/db/seed.test.ts
@@ -436,6 +436,43 @@ describe('PAM dedicated permissions (pam:approve / pam:manage_policy)', () => {
   });
 });
 
+describe('Accounting dedicated permissions (accounting:read / accounting:manage)', () => {
+  const byName = (name: string) => SYSTEM_ROLES.find((r) => r.name === name);
+
+  it('defines accounting:read and accounting:manage in DEFAULT_PERMISSIONS', () => {
+    expect(
+      DEFAULT_PERMISSIONS.some((p) => p.resource === 'accounting' && p.action === 'read'),
+    ).toBe(true);
+    expect(
+      DEFAULT_PERMISSIONS.some((p) => p.resource === 'accounting' && p.action === 'manage'),
+    ).toBe(true);
+  });
+
+  it('registers accounting:read and accounting:manage in the shared PERMISSION_GRANTS registry', () => {
+    expect(PERMISSION_GRANTS.ACCOUNTING_READ).toEqual({ resource: 'accounting', action: 'read' });
+    expect(PERMISSION_GRANTS.ACCOUNTING_MANAGE).toEqual({ resource: 'accounting', action: 'manage' });
+  });
+
+  it('grants BOTH accounting permissions to Org Admin (the same built-in role the PAM 150200 migration granted)', () => {
+    expect(byName('Org Admin')?.permissions).toContain('accounting:read');
+    expect(byName('Org Admin')?.permissions).toContain('accounting:manage');
+  });
+
+  it('does NOT grant either accounting permission to any other built-in role', () => {
+    // SEC-2026-09-05-057: the finding is precisely that full-partner low-role
+    // members reached the shared QuickBooks realm. Partner Technician /
+    // Partner Billing must NOT acquire that authority automatically.
+    for (const role of SYSTEM_ROLES.filter((r) => !['Partner Admin', 'Org Admin'].includes(r.name))) {
+      expect(role.permissions, `role "${role.name}"`).not.toContain('accounting:read');
+      expect(role.permissions, `role "${role.name}"`).not.toContain('accounting:manage');
+    }
+  });
+
+  it('Partner Admin covers accounting via the wildcard grant (does not need a redundant literal entry)', () => {
+    expect(byName('Partner Admin')?.permissions).toContain('*:*');
+  });
+});
+
 describe('permission-registry consistency: every SYSTEM_ROLES literal is seeded (§6G)', () => {
   // seedRoles() drops any permission literal it can't resolve to a seeded
   // permissions row (a console.warn + continue) — a role definition can

--- a/apps/api/src/db/seed.ts
+++ b/apps/api/src/db/seed.ts
@@ -246,6 +246,14 @@ export const DEFAULT_PERMISSIONS = [
   { resource: 'pam', action: 'manage_policy',
     description: 'Create, update, and delete PAM rules, signer groups, and org config' },
 
+  // Accounting / QuickBooks integration — dedicated capabilities, distinct
+  // from the partner-authority-only gate the routes previously carried
+  // (SEC-2026-09-05-057).
+  { resource: 'accounting', action: 'read',
+    description: 'Read accounting provider status, customers, mappings, and income accounts' },
+  { resource: 'accounting', action: 'manage',
+    description: 'Connect, disconnect, configure, and synchronize accounting provider integrations' },
+
   // Admin
   { resource: '*', action: '*', description: 'Full administrative access' }
 ];
@@ -373,6 +381,10 @@ export const SYSTEM_ROLES: readonly SystemRoleDefinition[] = [
       // devices:execute/devices:write above — an Org Technician holds those
       // for ordinary device work but must not thereby gain PAM authority.
       'pam:approve', 'pam:manage_policy',
+      // Accounting (SEC-2026-09-05-057): dedicated, NOT implied by partner
+      // authority — a full-partner low-role member must not thereby reach the
+      // shared QuickBooks realm.
+      'accounting:read', 'accounting:manage',
       // Workspace and partner connected-app permissions were introduced with
       // no built-in role grant except Partner Admin's wildcard, which would
       // have silently dropped this access for every existing Org Admin on

--- a/apps/api/src/routes/accounting/customers.test.ts
+++ b/apps/api/src/routes/accounting/customers.test.ts
@@ -12,7 +12,7 @@ const { listAnnotatedMock, importMock, writeRouteAuditMock, QbImportError, authS
   const authState = {
     scope: 'partner' as 'partner' | 'system',
     partnerOrgAccess: 'all' as 'all' | 'selected' | 'none' | null,
-    permissions: new Set<string>(['organizations:write', 'sites:write']),
+    permissions: new Set<string>(['accounting:read', 'accounting:manage', 'organizations:write', 'sites:write']),
   };
   return { listAnnotatedMock, importMock, writeRouteAuditMock, QbImportError, authState };
 });
@@ -63,7 +63,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   authState.scope = 'partner';
   authState.partnerOrgAccess = 'all';
-  authState.permissions = new Set(['organizations:write', 'sites:write']);
+  authState.permissions = new Set(['accounting:read', 'accounting:manage', 'organizations:write', 'sites:write']);
 });
 
 describe('GET /accounting/:provider/customers', () => {
@@ -118,7 +118,7 @@ describe('GET /accounting/:provider/customers', () => {
   it('allows a read-only caller with NO write permissions (listing creates nothing)', async () => {
     // The seeded "Partner Billing" role owns the QuickBooks connection but has
     // no orgs:write — it must still be able to browse customers.
-    authState.permissions = new Set();
+    authState.permissions = new Set(['accounting:read', 'accounting:manage']);
     listAnnotatedMock.mockResolvedValue([]);
     const res = await app().request('/accounting/quickbooks/customers');
     expect(res.status).toBe(200);
@@ -167,7 +167,7 @@ describe('POST /accounting/:provider/customers/import', () => {
   });
 
   it('denies a caller without organizations:write (403) before importing anything', async () => {
-    authState.permissions = new Set(['sites:write']);
+    authState.permissions = new Set(['accounting:read', 'accounting:manage', 'sites:write']);
     const res = await app().request('/accounting/quickbooks/customers/import', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -178,7 +178,7 @@ describe('POST /accounting/:provider/customers/import', () => {
   });
 
   it('denies a caller without sites:write (403) — the import creates a default site', async () => {
-    authState.permissions = new Set(['organizations:write']);
+    authState.permissions = new Set(['accounting:read', 'accounting:manage', 'organizations:write']);
     const res = await app().request('/accounting/quickbooks/customers/import', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -193,7 +193,7 @@ describe('POST /accounting/:provider/customers/import', () => {
     // system-scope token does not have — without the bypass every system-scope
     // import 403s while requireScope still advertises support for it.
     authState.scope = 'system';
-    authState.permissions = new Set();
+    authState.permissions = new Set(['accounting:read', 'accounting:manage']);
     importMock.mockResolvedValue({ imported: [], skipped: [], errors: [] });
     const res = await app().request('/accounting/quickbooks/customers/import?partnerId=11111111-1111-4111-8111-111111111111', {
       method: 'POST',

--- a/apps/api/src/routes/accounting/index.ts
+++ b/apps/api/src/routes/accounting/index.ts
@@ -100,7 +100,17 @@ function partnerScopedPermission(...guards: MiddlewareHandler[]): MiddlewareHand
   };
 }
 
-const requireImportPermissions = partnerScopedPermission(requireOrgWrite, requireSiteWrite);
+// NOTE: the accounting:read guard is folded INTO this composition rather than
+// listed separately on the route. The import route's middleware chain is
+// already at Hono's variadic-inference limit — adding a 10th handler collapses
+// the handler's `c.req.valid(...)` types to `never`. Composing keeps the chain
+// length unchanged and the ordering identical (system scope is exempt from all
+// three for the reason documented on partnerScopedPermission).
+const requireImportPermissions = partnerScopedPermission(
+  requirePermission(PERMISSIONS.ACCOUNTING_READ.resource, PERMISSIONS.ACCOUNTING_READ.action),
+  requireOrgWrite,
+  requireSiteWrite,
+);
 
 /**
  * Dedicated accounting capabilities (SEC-2026-09-05-057). Before these, every
@@ -115,6 +125,11 @@ const requireImportPermissions = partnerScopedPermission(requireOrgWrite, requir
  * the same reason the import/invoice guards are: a system-scope token carries
  * no partner or org membership, so `requirePermission` can resolve no role for
  * it (see that helper's comment above).
+ *
+ * `accounting:manage` also covers BOTH invoice-push routes (PR review
+ * finding): a push writes an invoice into the shared provider realm, exactly
+ * like a mapping sync or a reconcile trigger, so it belongs on the same
+ * capability rather than on `invoices:write` alone.
  *
  * These are ADDITIVE. Every pre-existing route requirement — MFA,
  * organizations:write + sites:write on customer import, invoices:write on
@@ -763,6 +778,10 @@ accountingRoutes.get('/:provider/customers', authMiddleware, partnerScopes, requ
 });
 
 // Import selected QuickBooks customers as orgs + sites. Write + MFA-gated.
+// Carries `accounting:read` cumulatively (PR review finding): the response
+// echoes remote QuickBooks displayNames for the caller-supplied ids, so this
+// route reads the shared provider realm as well as creating tenants. That
+// guard lives inside `requireImportPermissions` — see its comment.
 accountingRoutes.post('/:provider/customers/import', authMiddleware, partnerScopes, requireFullPartnerOrgImportAccess, requireAccountingPartnerAuthority, requireImportPermissions, requireMfa(), zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), zValidator('json', importCustomersSchema), async (c) => {
   const { provider } = c.req.valid('param');
   const configError = validateProviderConfig(provider);
@@ -1098,6 +1117,7 @@ accountingRoutes.post(
   authMiddleware,
   partnerScopes,
   requireAccountingPartnerAuthority,
+  requireAccountingManage,
   requireMfa(),
   requireInvoicePush,
   zValidator('param', invoicePushParamSchema),
@@ -1146,6 +1166,7 @@ accountingRoutes.post(
   authMiddleware,
   partnerScopes,
   requireAccountingPartnerAuthority,
+  requireAccountingManage,
   requireMfa(),
   requireInvoicePush,
   zValidator('param', providerParamSchema),
@@ -1197,8 +1218,10 @@ accountingRoutes.post(
 
 // Remote candidate search (Phase B follow-up, surfaced by Task 5): replaces
 // manual remote-ID entry in the mapping workbench. Read-only — same gate
-// shape as GET /:provider/customers above (no MFA/permission; see that
-// route's comment for why). Makes a real outbound QuickBooks call via
+// shape as GET /:provider/customers above: full-partner authority plus
+// `accounting:read`, and no MFA (reads are not step-up gated) and no write
+// permission (it creates nothing in Breeze). Makes a real outbound QuickBooks
+// call via
 // `resolveConnectionAndToken` + `listRemoteCustomers`/`listRemoteItems`, so it
 // carries the same SELF_MANAGED_DB_CONTEXT_ROUTES + `runInDbContext` runner
 // treatment as the push route above. Wraps its response in `{ data }` —

--- a/apps/api/src/routes/accounting/index.ts
+++ b/apps/api/src/routes/accounting/index.ts
@@ -101,6 +101,32 @@ function partnerScopedPermission(...guards: MiddlewareHandler[]): MiddlewareHand
 }
 
 const requireImportPermissions = partnerScopedPermission(requireOrgWrite, requireSiteWrite);
+
+/**
+ * Dedicated accounting capabilities (SEC-2026-09-05-057). Before these, every
+ * interactive QuickBooks route gated on partner authority alone, so any
+ * full-partner member — however low their role — could read the shared
+ * provider realm and, with MFA, drive realm lifecycle and settings mutations.
+ *
+ * `accounting:read` covers the provider reads (status, customers, entity
+ * mappings, income accounts, remote candidates); `accounting:manage` covers
+ * connect/disconnect, settings update/refresh, mapping writes and provider or
+ * mapping synchronization. Both are wrapped in `partnerScopedPermission` for
+ * the same reason the import/invoice guards are: a system-scope token carries
+ * no partner or org membership, so `requirePermission` can resolve no role for
+ * it (see that helper's comment above).
+ *
+ * These are ADDITIVE. Every pre-existing route requirement — MFA,
+ * organizations:write + sites:write on customer import, invoices:write on
+ * invoice push, catalog:write on item mappings, and the full-partner authority
+ * check — stays exactly as it was.
+ */
+const requireAccountingRead = partnerScopedPermission(
+  requirePermission(PERMISSIONS.ACCOUNTING_READ.resource, PERMISSIONS.ACCOUNTING_READ.action),
+);
+const requireAccountingManage = partnerScopedPermission(
+  requirePermission(PERMISSIONS.ACCOUNTING_MANAGE.resource, PERMISSIONS.ACCOUNTING_MANAGE.action),
+);
 const providerParamSchema = z.object({ provider: z.enum(['quickbooks']) });
 const partnerQuerySchema = z.object({ partnerId: z.string().guid().optional() });
 const callbackQuerySchema = z.object({
@@ -397,7 +423,7 @@ function validateProviderConfig(provider: AccountingProviderId): string | null {
 
 // Initiate the OAuth flow. Authenticated + MFA-gated: this is the privileged
 // action that decides which partner an external accounting realm links to.
-accountingRoutes.get('/:provider/connect', authMiddleware, partnerScopes, requireAccountingPartnerAuthority, requireMfa(), zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), async (c) => {
+accountingRoutes.get('/:provider/connect', authMiddleware, partnerScopes, requireAccountingPartnerAuthority, requireAccountingManage, requireMfa(), zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), async (c) => {
   const { provider } = c.req.valid('param');
   const configError = validateProviderConfig(provider);
   if (configError) return c.json({ error: configError }, 400);
@@ -640,7 +666,7 @@ accountingRoutes.get('/:provider/callback', zValidator('param', providerParamSch
   return c.redirect('/integrations?accounting=quickbooks&connected=1#accounting');
 });
 
-accountingRoutes.post('/:provider/disconnect', authMiddleware, partnerScopes, requireAccountingPartnerAuthority, requireMfa(), zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), async (c) => {
+accountingRoutes.post('/:provider/disconnect', authMiddleware, partnerScopes, requireAccountingPartnerAuthority, requireAccountingManage, requireMfa(), zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), async (c) => {
   const { provider } = c.req.valid('param');
   const partner = resolvePartnerId(c.get('auth'), c.req.valid('query').partnerId);
   if ('error' in partner) return c.json({ error: partner.error }, partner.status);
@@ -671,7 +697,7 @@ accountingRoutes.post('/:provider/disconnect', authMiddleware, partnerScopes, re
   return c.json({ disconnected: true });
 });
 
-accountingRoutes.get('/:provider', authMiddleware, partnerScopes, requireAccountingPartnerAuthority, zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), async (c) => {
+accountingRoutes.get('/:provider', authMiddleware, partnerScopes, requireAccountingPartnerAuthority, requireAccountingRead, zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), async (c) => {
   const { provider } = c.req.valid('param');
   const partner = resolvePartnerId(c.get('auth'), c.req.valid('query').partnerId);
   if ('error' in partner) return c.json({ error: partner.error }, partner.status);
@@ -722,7 +748,7 @@ accountingRoutes.get('/:provider', authMiddleware, partnerScopes, requireAccount
 // imported. The route creates nothing in Breeze, so it needs no write-role
 // permission, but annotation still compares against every organization in the
 // partner and therefore requires full-partner org access.
-accountingRoutes.get('/:provider/customers', authMiddleware, partnerScopes, requireFullPartnerOrgImportAccess, requireAccountingPartnerAuthority, zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), async (c) => {
+accountingRoutes.get('/:provider/customers', authMiddleware, partnerScopes, requireFullPartnerOrgImportAccess, requireAccountingPartnerAuthority, requireAccountingRead, zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), async (c) => {
   const { provider } = c.req.valid('param');
   const configError = validateProviderConfig(provider);
   if (configError) return c.json({ error: configError }, 400);
@@ -773,7 +799,7 @@ accountingRoutes.post('/:provider/customers/import', authMiddleware, partnerScop
   return c.json({ data: summary });
 });
 
-accountingRoutes.patch('/:provider/settings', authMiddleware, partnerScopes, requireAccountingPartnerAuthority, requireMfa(), zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), zValidator('json', settingsSchema), requireInvoicePushForSyncSwitches, async (c) => {
+accountingRoutes.patch('/:provider/settings', authMiddleware, partnerScopes, requireAccountingPartnerAuthority, requireAccountingManage, requireMfa(), zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), zValidator('json', settingsSchema), requireInvoicePushForSyncSwitches, async (c) => {
   const { provider } = c.req.valid('param');
   const body = c.req.valid('json');
   const partner = resolvePartnerId(c.get('auth'), c.req.valid('query').partnerId);
@@ -830,7 +856,7 @@ accountingRoutes.patch('/:provider/settings', authMiddleware, partnerScopes, req
 // already open, so no connection is pinned across the QuickBooks round trip
 // and each phase commits on its own (services/accounting/dbContextGuard.ts).
 // The same applies to the four mapping-workbench routes below.
-accountingRoutes.post('/:provider/settings/refresh', authMiddleware, partnerScopes, requireAccountingPartnerAuthority, requireMfa(), zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), async (c) => {
+accountingRoutes.post('/:provider/settings/refresh', authMiddleware, partnerScopes, requireAccountingPartnerAuthority, requireAccountingManage, requireMfa(), zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), async (c) => {
   const { provider } = c.req.valid('param');
   const configError = validateProviderConfig(provider);
   if (configError) return c.json({ error: configError }, 400);
@@ -877,7 +903,7 @@ accountingRoutes.post('/:provider/settings/refresh', authMiddleware, partnerScop
 // Reports `enqueued` HONESTLY (the Phase C lesson: `enqueueAccountingInvoicePush`
 // swallows a Redis outage by design, so the caller must surface its boolean
 // rather than assume the job landed — see the push-bulk route's comment above).
-accountingRoutes.post('/:provider/reconcile', authMiddleware, partnerScopes, requireAccountingPartnerAuthority, requireMfa(), requireInvoicePush, zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), async (c) => {
+accountingRoutes.post('/:provider/reconcile', authMiddleware, partnerScopes, requireAccountingPartnerAuthority, requireAccountingManage, requireMfa(), requireInvoicePush, zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), async (c) => {
   const { provider } = c.req.valid('param');
   const partner = resolvePartnerId(c.get('auth'), c.req.valid('query').partnerId);
   if ('error' in partner) return c.json({ error: partner.error }, partner.status);
@@ -921,7 +947,7 @@ accountingRoutes.post('/:provider/reconcile', authMiddleware, partnerScopes, req
 // SELF_MANAGED_DB_CONTEXT_ROUTES (middleware/selfManagedDbContextRoutes.ts) —
 // no ambient request transaction, so the service's ambient-`db` reads need an
 // explicit context (Task 5 review fix — see the settings/refresh comment above).
-accountingRoutes.get('/:provider/mappings', authMiddleware, partnerScopes, requireAccountingPartnerAuthority, zValidator('param', providerParamSchema), zValidator('query', mappingEntityQuerySchema), async (c) => {
+accountingRoutes.get('/:provider/mappings', authMiddleware, partnerScopes, requireAccountingPartnerAuthority, requireAccountingRead, zValidator('param', providerParamSchema), zValidator('query', mappingEntityQuerySchema), async (c) => {
   const { provider } = c.req.valid('param');
   const configError = validateProviderConfig(provider);
   if (configError) return c.json({ error: configError }, 400);
@@ -944,7 +970,7 @@ accountingRoutes.get('/:provider/mappings', authMiddleware, partnerScopes, requi
 // Remote income account selector for item mapping — read-only. Also QBO-HTTP
 // backed, so it carries the same SELF_MANAGED_DB_CONTEXT_ROUTES registration
 // (and the same explicit-context requirement — Task 5 review fix).
-accountingRoutes.get('/:provider/income-accounts', authMiddleware, partnerScopes, requireAccountingPartnerAuthority, zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), async (c) => {
+accountingRoutes.get('/:provider/income-accounts', authMiddleware, partnerScopes, requireAccountingPartnerAuthority, requireAccountingRead, zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), async (c) => {
   const { provider } = c.req.valid('param');
   const configError = validateProviderConfig(provider);
   if (configError) return c.json({ error: configError }, 400);
@@ -968,7 +994,7 @@ accountingRoutes.get('/:provider/income-accounts', authMiddleware, partnerScopes
 // `confirmed` path calls the provider list to verify the remote entity, so
 // this route also carries the SELF_MANAGED_DB_CONTEXT_ROUTES registration
 // (and the same explicit-context requirement — Task 5 review fix).
-accountingRoutes.put('/:provider/mappings', authMiddleware, partnerScopes, requireAccountingPartnerAuthority, requireMfa(), zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), zValidator('json', mappingDecisionSchema), requireMappingWrite, async (c) => {
+accountingRoutes.put('/:provider/mappings', authMiddleware, partnerScopes, requireAccountingPartnerAuthority, requireAccountingManage, requireMfa(), zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), zValidator('json', mappingDecisionSchema), requireMappingWrite, async (c) => {
   const { provider } = c.req.valid('param');
   const configError = validateProviderConfig(provider);
   if (configError) return c.json({ error: configError }, 400);
@@ -1013,7 +1039,7 @@ accountingRoutes.put('/:provider/mappings', authMiddleware, partnerScopes, requi
 // SELF_MANAGED_DB_CONTEXT_ROUTES registration (the provider upsert call is
 // real QuickBooks HTTP) — and the same explicit-context requirement (Task 5
 // review fix).
-accountingRoutes.post('/:provider/mappings/sync', authMiddleware, partnerScopes, requireAccountingPartnerAuthority, requireMfa(), zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), zValidator('json', mappingSyncSchema), requireMappingWrite, async (c) => {
+accountingRoutes.post('/:provider/mappings/sync', authMiddleware, partnerScopes, requireAccountingPartnerAuthority, requireAccountingManage, requireMfa(), zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), zValidator('json', mappingSyncSchema), requireMappingWrite, async (c) => {
   const { provider } = c.req.valid('param');
   const configError = validateProviderConfig(provider);
   if (configError) return c.json({ error: configError }, 400);
@@ -1184,6 +1210,7 @@ accountingRoutes.get(
   authMiddleware,
   partnerScopes,
   requireAccountingPartnerAuthority,
+  requireAccountingRead,
   zValidator('param', providerParamSchema),
   zValidator('query', remoteCandidatesQuerySchema),
   async (c) => {

--- a/apps/api/src/routes/accounting/invoicePush.test.ts
+++ b/apps/api/src/routes/accounting/invoicePush.test.ts
@@ -48,7 +48,7 @@ const {
   const authState = {
     scope: 'partner' as 'partner' | 'system' | 'organization',
     partnerOrgAccess: 'all' as 'all' | 'selected' | 'none' | null,
-    permissions: new Set<string>(['invoices:write']),
+    permissions: new Set<string>(['accounting:read', 'accounting:manage', 'invoices:write']),
     mfa: true,
   };
   return {
@@ -199,7 +199,7 @@ function pushOutcome(overrides: Record<string, unknown> = {}) {
 beforeEach(() => {
   vi.clearAllMocks();
   authState.scope = 'partner';
-  authState.permissions = new Set(['invoices:write']);
+  authState.permissions = new Set(['accounting:read', 'accounting:manage', 'invoices:write']);
   authState.mfa = true;
   // The enqueue helper reports whether the queue ACCEPTED the job; the bulk
   // route counts on that, so the default must be a real acceptance.
@@ -281,7 +281,7 @@ describe('POST /accounting/:provider/invoices/:invoiceId/push', () => {
   });
 
   it('denies a partner-scoped caller without INVOICES_WRITE (403) before calling the coordinator', async () => {
-    authState.permissions = new Set();
+    authState.permissions = new Set(['accounting:read', 'accounting:manage']);
     const res = await pushInvoice();
     expect(res.status).toBe(403);
     expect(pushInvoiceToAccountingMock).not.toHaveBeenCalled();
@@ -289,7 +289,7 @@ describe('POST /accounting/:provider/invoices/:invoiceId/push', () => {
 
   it('allows a SYSTEM-scope caller that holds no per-partner role (bypasses the permission check)', async () => {
     authState.scope = 'system';
-    authState.permissions = new Set();
+    authState.permissions = new Set(['accounting:read', 'accounting:manage']);
     pushInvoiceToAccountingMock.mockResolvedValue(pushOutcome());
     const res = await pushInvoice(INVOICE_ID, `?partnerId=${OTHER_PARTNER_ID}`);
     expect(res.status).toBe(200);
@@ -391,7 +391,7 @@ describe('POST /accounting/:provider/invoices/push-bulk', () => {
   });
 
   it('denies a partner-scoped caller without INVOICES_WRITE (403)', async () => {
-    authState.permissions = new Set();
+    authState.permissions = new Set(['accounting:read', 'accounting:manage']);
     const res = await pushBulk([INVOICE_ID]);
     expect(res.status).toBe(403);
     expect(enqueueAccountingInvoicePushMock).not.toHaveBeenCalled();
@@ -399,7 +399,7 @@ describe('POST /accounting/:provider/invoices/push-bulk', () => {
 
   it('allows a SYSTEM-scope caller that holds no per-partner role', async () => {
     authState.scope = 'system';
-    authState.permissions = new Set();
+    authState.permissions = new Set(['accounting:read', 'accounting:manage']);
     selectMock.mockReturnValue({
       from: () => ({ where: () => Promise.resolve([{ id: INVOICE_ID }]) }),
     });
@@ -467,7 +467,7 @@ describe('GET /accounting/:provider/remote-candidates', () => {
   });
 
   it('is read-only: no MFA/permission gate blocks a plain partner-scoped caller', async () => {
-    authState.permissions = new Set();
+    authState.permissions = new Set(['accounting:read', 'accounting:manage']);
     resolveConnectionAndTokenMock.mockResolvedValue({ conn: { provider: 'quickbooks' }, liveConn: { accessToken: 'tok' } });
     listRemoteCustomersMock.mockResolvedValue([]);
     const res = await getCandidates('?entityType=org');

--- a/apps/api/src/routes/accounting/mappings.test.ts
+++ b/apps/api/src/routes/accounting/mappings.test.ts
@@ -30,7 +30,7 @@ const {
   const authState = {
     scope: 'partner' as 'partner' | 'system',
     partnerOrgAccess: 'all' as 'all' | 'selected' | 'none' | null,
-    permissions: new Set<string>(['organizations:write', 'catalog:write']),
+    permissions: new Set<string>(['accounting:read', 'accounting:manage', 'organizations:write', 'catalog:write']),
     mfa: true,
   };
   return {
@@ -147,7 +147,7 @@ const INTERNAL_MAPPING_FIELDS = ['integrationId', 'partnerId', 'remoteSyncToken'
 beforeEach(() => {
   vi.clearAllMocks();
   authState.scope = 'partner';
-  authState.permissions = new Set(['organizations:write', 'catalog:write']);
+  authState.permissions = new Set(['accounting:read', 'accounting:manage', 'organizations:write', 'catalog:write']);
   authState.mfa = true;
 });
 
@@ -275,7 +275,7 @@ describe('GET /accounting/:provider/income-accounts', () => {
   });
 
   it('is read-only: no MFA/permission gate blocks a plain partner-scoped caller', async () => {
-    authState.permissions = new Set();
+    authState.permissions = new Set(['accounting:read', 'accounting:manage']);
     listRemoteIncomeAccountsForPartnerMock.mockResolvedValue([]);
     const res = await app().request('/accounting/quickbooks/income-accounts');
     expect(res.status).toBe(200);
@@ -392,7 +392,7 @@ describe('PUT /accounting/:provider/mappings', () => {
   });
 
   it('denies an org decision without ORGS_WRITE (403) before calling the service', async () => {
-    authState.permissions = new Set(['catalog:write']);
+    authState.permissions = new Set(['accounting:read', 'accounting:manage', 'catalog:write']);
     const res = await putMapping({
       breezeEntityType: 'org',
       breezeEntityId: VALID_ORG_ID,
@@ -403,7 +403,7 @@ describe('PUT /accounting/:provider/mappings', () => {
   });
 
   it('denies a catalog_item decision without CATALOG_WRITE (403) before calling the service', async () => {
-    authState.permissions = new Set(['organizations:write']);
+    authState.permissions = new Set(['accounting:read', 'accounting:manage', 'organizations:write']);
     const res = await putMapping({
       breezeEntityType: 'catalog_item',
       breezeEntityId: VALID_ITEM_ID,
@@ -415,7 +415,7 @@ describe('PUT /accounting/:provider/mappings', () => {
 
   it('allows a SYSTEM-scope caller that holds no per-partner role', async () => {
     authState.scope = 'system';
-    authState.permissions = new Set();
+    authState.permissions = new Set(['accounting:read', 'accounting:manage']);
     saveMappingDecisionMock.mockResolvedValue(fullMappingRow({
       partnerId: OTHER_PARTNER_ID, remoteEntityId: null, linkStatus: 'create_new',
     }));
@@ -547,14 +547,14 @@ describe('POST /accounting/:provider/mappings/sync', () => {
   });
 
   it('denies an org sync without ORGS_WRITE (403) before calling the service', async () => {
-    authState.permissions = new Set(['catalog:write']);
+    authState.permissions = new Set(['accounting:read', 'accounting:manage', 'catalog:write']);
     const res = await postSync({ breezeEntityType: 'org', breezeEntityId: VALID_ORG_ID });
     expect(res.status).toBe(403);
     expect(syncMappedEntityMock).not.toHaveBeenCalled();
   });
 
   it('denies a catalog_item sync without CATALOG_WRITE (403) before calling the service', async () => {
-    authState.permissions = new Set(['organizations:write']);
+    authState.permissions = new Set(['accounting:read', 'accounting:manage', 'organizations:write']);
     const res = await postSync({ breezeEntityType: 'catalog_item', breezeEntityId: VALID_ITEM_ID });
     expect(res.status).toBe(403);
     expect(syncMappedEntityMock).not.toHaveBeenCalled();

--- a/apps/api/src/routes/accounting/permissions.test.ts
+++ b/apps/api/src/routes/accounting/permissions.test.ts
@@ -5,9 +5,7 @@ import { Hono } from 'hono';
 // (`accounting:read` / `accounting:manage`, SEC-2026-09-05-057 Option A).
 //
 // Every interactive QuickBooks route is listed exactly once below with the
-// accounting capability it requires (or `null` where the route deliberately
-// keeps only its pre-existing route-specific permission — customer import and
-// the two invoice-push routes). The parameterized cases prove, for every
+// accounting capability it requires. The parameterized cases prove, for every
 // route: denial for a caller holding no accounting grant, correct separation
 // of read-only vs manage-only, that full-partner authority is still required
 // regardless of grant, that MFA remains cumulative on mutations, and that
@@ -196,15 +194,18 @@ const routes: RouteCase[] = [
     body: { breezeEntityType: 'org', breezeEntityId: ENTITY_ID }, effect: 'syncMapping',
     requires: 'accounting:manage', mfa: true,
   },
-  // --- routes that keep only their pre-existing route-specific permission --
-  {
-    name: 'customer import', method: 'POST', path: '/quickbooks/customers/import',
-    body: { customerIds: ['remote-1'] }, effect: 'importCustomers', requires: null, mfa: true,
-  },
-  { name: 'invoice push', method: 'POST', path: `/quickbooks/invoices/${ENTITY_ID}/push`, effect: 'pushInvoice', requires: null, mfa: true },
+  // --- invoice push writes into the shared realm, so it is manage-gated too --
+  { name: 'invoice push', method: 'POST', path: `/quickbooks/invoices/${ENTITY_ID}/push`, effect: 'pushInvoice', requires: 'accounting:manage', mfa: true },
   {
     name: 'bulk invoice push', method: 'POST', path: '/quickbooks/invoices/push-bulk',
-    body: { invoiceIds: [ENTITY_ID] }, effect: 'enqueueInvoice', requires: null, mfa: true,
+    body: { invoiceIds: [ENTITY_ID] }, effect: 'enqueueInvoice', requires: 'accounting:manage', mfa: true,
+  },
+  // --- customer import reads the realm (it returns remote displayNames for
+  //     caller-supplied ids) on top of creating orgs + sites, so it carries
+  //     accounting:read cumulatively with organizations:write + sites:write. ---
+  {
+    name: 'customer import', method: 'POST', path: '/quickbooks/customers/import',
+    body: { customerIds: ['remote-1'] }, effect: 'importCustomers', requires: 'accounting:read', mfa: true,
   },
 ];
 
@@ -281,9 +282,9 @@ describe('accounting permission family — route matrix', () => {
   it('covers every interactive accounting route exactly once', () => {
     expect(new Set(routes.map((route) => route.name)).size).toBe(routes.length);
     expect(routes).toHaveLength(15);
-    expect(readRoutes).toHaveLength(5);
-    expect(manageRoutes).toHaveLength(7);
-    expect(ungatedRoutes).toHaveLength(3);
+    expect(readRoutes).toHaveLength(6);
+    expect(manageRoutes).toHaveLength(9);
+    expect(ungatedRoutes).toHaveLength(0);
   });
 
   it.each(gatedRoutes)(
@@ -331,14 +332,13 @@ describe('accounting permission family — route matrix', () => {
     expect(effects[route.effect], route.name).toHaveBeenCalled();
   });
 
-  it.each(ungatedRoutes)(
-    'leaves $name on its pre-existing route-specific permission only',
-    async (route) => {
-      const response = await request(route);
-      expect(response.status, route.name).not.toBe(403);
-      expect(effects[route.effect], route.name).toHaveBeenCalled();
-    },
-  );
+  it('leaves no interactive accounting route ungated by the permission family', () => {
+    // PR review finding: customer import and both invoice-push routes used to
+    // sit here on their write permission alone. Invoice push writes into the
+    // shared provider realm and import reads remote displayNames out of it, so
+    // every interactive route now carries an accounting capability.
+    expect(ungatedRoutes).toEqual([]);
+  });
 });
 
 describe('accounting permission family — cumulative with existing gates', () => {

--- a/apps/api/src/routes/accounting/permissions.test.ts
+++ b/apps/api/src/routes/accounting/permissions.test.ts
@@ -1,0 +1,421 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+// Central route matrix for the dedicated accounting permission family
+// (`accounting:read` / `accounting:manage`, SEC-2026-09-05-057 Option A).
+//
+// Every interactive QuickBooks route is listed exactly once below with the
+// accounting capability it requires (or `null` where the route deliberately
+// keeps only its pre-existing route-specific permission — customer import and
+// the two invoice-push routes). The parameterized cases prove, for every
+// route: denial for a caller holding no accounting grant, correct separation
+// of read-only vs manage-only, that full-partner authority is still required
+// regardless of grant, that MFA remains cumulative on mutations, and that
+// every denial lands BEFORE any provider/db/queue/audit/cookie side effect.
+
+const PARTNER_ID = '11111111-1111-4111-8111-111111111111';
+const ENTITY_ID = '33333333-3333-4333-8333-333333333333';
+
+const { authState, effects, AccountingError } = vi.hoisted(() => {
+  class AccountingError extends Error {
+    constructor(
+      public readonly code: string,
+      public readonly status: number,
+      message: string,
+    ) {
+      super(message);
+    }
+  }
+  return {
+    authState: {
+      scope: 'partner' as 'partner' | 'system' | 'organization',
+      partnerId: '11111111-1111-4111-8111-111111111111' as string | null,
+      partnerOrgAccess: 'all' as 'all' | 'selected' | 'none' | null,
+      mfa: true,
+      permissions: new Set<string>(),
+    },
+    effects: {
+      buildAuthUrl: vi.fn(() => 'https://provider.example.test/oauth'),
+      getConnection: vi.fn(),
+      deleteConnection: vi.fn(),
+      refreshRealmSettings: vi.fn(),
+      listCustomers: vi.fn(),
+      importCustomers: vi.fn(),
+      listMappings: vi.fn(),
+      listIncomeAccounts: vi.fn(),
+      saveMapping: vi.fn(),
+      syncMapping: vi.fn(),
+      resolveConnection: vi.fn(),
+      listRemoteCustomers: vi.fn(),
+      pushInvoice: vi.fn(),
+      enqueueInvoice: vi.fn(),
+      enqueueReconcile: vi.fn(),
+      dbSelect: vi.fn(),
+      dbUpdateReturning: vi.fn(),
+      audit: vi.fn(),
+    },
+    AccountingError,
+  };
+});
+
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: async (c: any, next: any) => {
+    c.set('auth', {
+      scope: authState.scope,
+      partnerId: authState.partnerId,
+      partnerOrgAccess: authState.partnerOrgAccess,
+      orgId: authState.scope === 'organization' ? ENTITY_ID : null,
+      user: { id: ENTITY_ID },
+      token: { mfa: authState.mfa },
+    });
+    return next();
+  },
+  requireScope: (...scopes: string[]) => async (c: any, next: any) => (
+    scopes.includes(c.get('auth').scope)
+      ? next()
+      : c.json({ error: 'Insufficient permissions' }, 403)
+  ),
+  requireMfa: () => async (c: any, next: any) => (
+    authState.mfa ? next() : c.json({ error: 'MFA required' }, 403)
+  ),
+  requirePermission: (resource: string, action: string) => async (c: any, next: any) => (
+    authState.permissions.has(`${resource}:${action}`)
+      ? next()
+      : c.json({ error: 'Insufficient permissions' }, 403)
+  ),
+  withAuthDbAccessContext: async (_auth: unknown, fn: () => unknown) => fn(),
+}));
+
+vi.mock('../../db', () => ({
+  db: {
+    select: effects.dbSelect,
+    update: vi.fn(() => ({
+      set: () => ({ where: () => ({ returning: effects.dbUpdateReturning }) }),
+    })),
+  },
+  runOutsideDbContext: <T>(fn: () => T) => fn(),
+  withSystemDbAccessContext: <T>(fn: () => T) => fn(),
+}));
+
+vi.mock('../../services/accounting/accountingConnectionService', () => ({
+  getConnection: effects.getConnection,
+  deleteConnection: effects.deleteConnection,
+  refreshRealmSettings: effects.refreshRealmSettings,
+  upsertConnection: vi.fn(),
+  resetConnectionForRealmChange: vi.fn(),
+  updateHomeCurrency: vi.fn(),
+  updateMultiCurrencyEnabled: vi.fn(),
+  isHomeCurrencyCasAbort: () => false,
+  AccountingConnectionError: AccountingError,
+}));
+
+vi.mock('../../services/accounting/quickbooksCustomerImport', () => ({
+  listQuickbooksCustomersAnnotated: effects.listCustomers,
+  importQuickbooksCustomers: effects.importCustomers,
+  QbImportError: AccountingError,
+}));
+
+vi.mock('../../services/accounting/accountingMappingService', () => ({
+  listMappingProposals: effects.listMappings,
+  listRemoteIncomeAccountsForPartner: effects.listIncomeAccounts,
+  saveMappingDecision: effects.saveMapping,
+  syncMappedEntity: effects.syncMapping,
+  resolveConnectionAndToken: effects.resolveConnection,
+  AccountingMappingError: AccountingError,
+}));
+
+vi.mock('../../services/accounting/accountingInvoicePush', () => ({
+  pushInvoiceToAccounting: effects.pushInvoice,
+  AccountingInvoicePushError: AccountingError,
+}));
+
+vi.mock('../../services/accounting/providerRegistry', () => ({
+  getAccountingProvider: () => ({
+    buildAuthUrl: effects.buildAuthUrl,
+    listRemoteCustomers: effects.listRemoteCustomers,
+    listRemoteItems: vi.fn(),
+  }),
+}));
+
+vi.mock('../../jobs/accountingSyncWorker', () => ({
+  enqueueAccountingInvoicePush: effects.enqueueInvoice,
+}));
+vi.mock('../../jobs/accountingReconcileWorker', () => ({
+  enqueueAccountingReconcile: effects.enqueueReconcile,
+}));
+vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: effects.audit }));
+vi.mock('../../services/sentry', () => ({ captureException: vi.fn(), captureMessage: vi.fn() }));
+vi.mock('../../config/env', () => ({
+  QBO_CLIENT_ID: 'client-id',
+  QBO_CLIENT_SECRET: 'client-secret',
+  QBO_REDIRECT_URI: 'https://api.example.test/accounting/quickbooks/callback',
+  QBO_ENVIRONMENT: 'production',
+}));
+
+import { accountingRoutes } from './index';
+
+type AccountingCapability = 'accounting:read' | 'accounting:manage' | null;
+
+type RouteCase = {
+  name: string;
+  method?: string;
+  path: string;
+  body?: unknown;
+  effect: keyof typeof effects;
+  /** The accounting capability this route requires, or null if it keeps only
+   *  its pre-existing route-specific permissions (import / invoice push). */
+  requires: AccountingCapability;
+  /** True when the route also carries requireMfa(). */
+  mfa: boolean;
+};
+
+const routes: RouteCase[] = [
+  // --- reads -------------------------------------------------------------
+  { name: 'status', path: '/quickbooks', effect: 'getConnection', requires: 'accounting:read', mfa: false },
+  { name: 'customers', path: '/quickbooks/customers', effect: 'listCustomers', requires: 'accounting:read', mfa: false },
+  { name: 'mapping proposals', path: '/quickbooks/mappings?entityType=org', effect: 'listMappings', requires: 'accounting:read', mfa: false },
+  { name: 'income accounts', path: '/quickbooks/income-accounts', effect: 'listIncomeAccounts', requires: 'accounting:read', mfa: false },
+  { name: 'remote candidates', path: '/quickbooks/remote-candidates?entityType=org', effect: 'resolveConnection', requires: 'accounting:read', mfa: false },
+  // --- realm lifecycle / settings / synchronization ----------------------
+  { name: 'connect', path: '/quickbooks/connect', effect: 'buildAuthUrl', requires: 'accounting:manage', mfa: true },
+  { name: 'disconnect', method: 'POST', path: '/quickbooks/disconnect', effect: 'deleteConnection', requires: 'accounting:manage', mfa: true },
+  {
+    name: 'settings update', method: 'PATCH', path: '/quickbooks/settings',
+    body: { defaultIncomeAccountRef: '79' }, effect: 'dbUpdateReturning',
+    requires: 'accounting:manage', mfa: true,
+  },
+  { name: 'settings refresh', method: 'POST', path: '/quickbooks/settings/refresh', effect: 'refreshRealmSettings', requires: 'accounting:manage', mfa: true },
+  { name: 'reconcile', method: 'POST', path: '/quickbooks/reconcile', effect: 'enqueueReconcile', requires: 'accounting:manage', mfa: true },
+  {
+    name: 'mapping decision', method: 'PUT', path: '/quickbooks/mappings',
+    body: { breezeEntityType: 'org', breezeEntityId: ENTITY_ID, decision: 'unlinked' }, effect: 'saveMapping',
+    requires: 'accounting:manage', mfa: true,
+  },
+  {
+    name: 'mapping sync', method: 'POST', path: '/quickbooks/mappings/sync',
+    body: { breezeEntityType: 'org', breezeEntityId: ENTITY_ID }, effect: 'syncMapping',
+    requires: 'accounting:manage', mfa: true,
+  },
+  // --- routes that keep only their pre-existing route-specific permission --
+  {
+    name: 'customer import', method: 'POST', path: '/quickbooks/customers/import',
+    body: { customerIds: ['remote-1'] }, effect: 'importCustomers', requires: null, mfa: true,
+  },
+  { name: 'invoice push', method: 'POST', path: `/quickbooks/invoices/${ENTITY_ID}/push`, effect: 'pushInvoice', requires: null, mfa: true },
+  {
+    name: 'bulk invoice push', method: 'POST', path: '/quickbooks/invoices/push-bulk',
+    body: { invoiceIds: [ENTITY_ID] }, effect: 'enqueueInvoice', requires: null, mfa: true,
+  },
+];
+
+const gatedRoutes = routes.filter((route) => route.requires !== null);
+const readRoutes = routes.filter((route) => route.requires === 'accounting:read');
+const manageRoutes = routes.filter((route) => route.requires === 'accounting:manage');
+const ungatedRoutes = routes.filter((route) => route.requires === null);
+
+// Permissions every route already required before this change. Held throughout
+// so the only variable under test is the accounting capability.
+const PRE_EXISTING_GRANTS = [
+  'organizations:write', 'sites:write', 'invoices:write', 'catalog:write',
+];
+
+const effectMocks = Object.values(effects);
+
+function app() {
+  const result = new Hono();
+  result.route('/accounting', accountingRoutes);
+  return result;
+}
+
+async function request(route: RouteCase) {
+  return app().request(`/accounting${route.path}`, {
+    method: route.method,
+    headers: route.body ? { 'Content-Type': 'application/json' } : undefined,
+    body: route.body ? JSON.stringify(route.body) : undefined,
+  });
+}
+
+function grant(...capabilities: string[]) {
+  authState.permissions = new Set([...PRE_EXISTING_GRANTS, ...capabilities]);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  authState.scope = 'partner';
+  authState.partnerId = PARTNER_ID;
+  authState.partnerOrgAccess = 'all';
+  authState.mfa = true;
+  grant();
+  effects.getConnection.mockResolvedValue({ id: 'connection-1', partnerId: PARTNER_ID, pullPayments: true });
+  effects.deleteConnection.mockResolvedValue({ id: 'connection-1' });
+  effects.refreshRealmSettings.mockResolvedValue({ homeCurrency: 'USD', multiCurrencyEnabled: false });
+  effects.listCustomers.mockResolvedValue([]);
+  effects.importCustomers.mockResolvedValue({ imported: [], skipped: [], errors: [] });
+  effects.listMappings.mockResolvedValue([]);
+  effects.listIncomeAccounts.mockResolvedValue([]);
+  const mapping = {
+    id: 'mapping-1', breezeEntityType: 'org', breezeEntityId: ENTITY_ID,
+    remoteEntityType: 'Customer', remoteEntityId: null, linkStatus: 'unlinked',
+    syncStatus: 'pending', lastSyncedAt: null, lastError: null,
+  };
+  effects.saveMapping.mockResolvedValue(mapping);
+  effects.syncMapping.mockResolvedValue(mapping);
+  effects.resolveConnection.mockResolvedValue({ liveConn: {} });
+  effects.listRemoteCustomers.mockResolvedValue([]);
+  effects.pushInvoice.mockResolvedValue({
+    mappingId: 'mapping-1', remoteEntityId: 'remote-1', docNumber: '1',
+    syncStatus: 'synced', taxVarianceCents: 0,
+  });
+  effects.enqueueInvoice.mockResolvedValue(true);
+  effects.enqueueReconcile.mockResolvedValue(true);
+  effects.dbSelect.mockReturnValue({
+    from: () => ({ where: () => Promise.resolve([{ id: ENTITY_ID }]) }),
+  });
+  effects.dbUpdateReturning.mockResolvedValue([{
+    status: 'connected', environment: 'production', pushMode: 'auto',
+    defaultIncomeAccountRef: '79', defaultTaxCodeRef: null, lastError: null, pullPayments: true,
+  }]);
+});
+
+describe('accounting permission family — route matrix', () => {
+  it('covers every interactive accounting route exactly once', () => {
+    expect(new Set(routes.map((route) => route.name)).size).toBe(routes.length);
+    expect(routes).toHaveLength(15);
+    expect(readRoutes).toHaveLength(5);
+    expect(manageRoutes).toHaveLength(7);
+    expect(ungatedRoutes).toHaveLength(3);
+  });
+
+  it.each(gatedRoutes)(
+    'denies a full-partner caller with no accounting grant before the $name sink',
+    async (route) => {
+      const response = await request(route);
+      expect(response.status, route.name).toBe(403);
+      expect(response.headers.get('set-cookie'), route.name).toBeNull();
+      for (const effect of effectMocks) expect(effect, route.name).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(readRoutes)('allows accounting:read through to $name', async (route) => {
+    grant('accounting:read');
+    const response = await request(route);
+    expect(response.status).not.toBe(403);
+    expect(effects[route.effect]).toHaveBeenCalled();
+  });
+
+  it.each(manageRoutes)('denies accounting:read-only before the $name sink', async (route) => {
+    grant('accounting:read');
+    const response = await request(route);
+    expect(response.status, route.name).toBe(403);
+    for (const effect of effectMocks) expect(effect, route.name).not.toHaveBeenCalled();
+  });
+
+  it.each(manageRoutes)('allows accounting:manage through to $name', async (route) => {
+    grant('accounting:manage');
+    const response = await request(route);
+    expect(response.status).not.toBe(403);
+    expect(effects[route.effect]).toHaveBeenCalled();
+  });
+
+  it.each(readRoutes)('denies accounting:manage-only before the read-gated $name sink', async (route) => {
+    grant('accounting:manage');
+    const response = await request(route);
+    expect(response.status, route.name).toBe(403);
+    for (const effect of effectMocks) expect(effect, route.name).not.toHaveBeenCalled();
+  });
+
+  it.each(routes)('allows a caller holding both capabilities through to $name', async (route) => {
+    grant('accounting:read', 'accounting:manage');
+    const response = await request(route);
+    expect(response.status, route.name).not.toBe(403);
+    expect(effects[route.effect], route.name).toHaveBeenCalled();
+  });
+
+  it.each(ungatedRoutes)(
+    'leaves $name on its pre-existing route-specific permission only',
+    async (route) => {
+      const response = await request(route);
+      expect(response.status, route.name).not.toBe(403);
+      expect(effects[route.effect], route.name).toHaveBeenCalled();
+    },
+  );
+});
+
+describe('accounting permission family — cumulative with existing gates', () => {
+  const partnerAccessCases = (['selected', 'none', null] as const).flatMap((partnerOrgAccess) =>
+    routes.map((route) => ({ partnerOrgAccess, route })),
+  );
+
+  it.each(partnerAccessCases)(
+    'denies partnerOrgAccess=$partnerOrgAccess for $route.name even with both accounting grants',
+    async ({ partnerOrgAccess, route }) => {
+      grant('accounting:read', 'accounting:manage');
+      authState.partnerOrgAccess = partnerOrgAccess;
+      const response = await request(route);
+      expect(response.status, route.name).toBe(403);
+      expect(response.headers.get('set-cookie'), route.name).toBeNull();
+      for (const effect of effectMocks) expect(effect, route.name).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(routes.filter((route) => route.mfa))(
+    'still requires MFA on $name with both accounting grants held',
+    async (route) => {
+      grant('accounting:read', 'accounting:manage');
+      authState.mfa = false;
+      const response = await request(route);
+      expect(response.status, route.name).toBe(403);
+      expect(await response.json(), route.name).toEqual({ error: 'MFA required' });
+      for (const effect of effectMocks) expect(effect, route.name).not.toHaveBeenCalled();
+    },
+  );
+
+  it('still requires invoices:write on invoice push when both accounting grants are held', async () => {
+    grant('accounting:read', 'accounting:manage');
+    authState.permissions.delete('invoices:write');
+    const response = await request(routes.find((route) => route.name === 'invoice push')!);
+    expect(response.status).toBe(403);
+    expect(effects.pushInvoice).not.toHaveBeenCalled();
+  });
+
+  it('still requires organizations:write + sites:write on customer import', async () => {
+    grant('accounting:read', 'accounting:manage');
+    authState.permissions.delete('sites:write');
+    const response = await request(routes.find((route) => route.name === 'customer import')!);
+    expect(response.status).toBe(403);
+    expect(effects.importCustomers).not.toHaveBeenCalled();
+  });
+
+  it.each(gatedRoutes)(
+    'exempts system scope from the accounting permission gate on $name',
+    async (route) => {
+      // System-scope tokens carry no partner/org membership, so requirePermission
+      // can resolve no role for them — the same partnerScopedPermission exemption
+      // the pre-existing import/invoice guards already rely on.
+      authState.scope = 'system';
+      authState.partnerId = null;
+      authState.partnerOrgAccess = null;
+      const separator = route.path.includes('?') ? '&' : '?';
+      const response = await app().request(
+        `/accounting${route.path}${separator}partnerId=${PARTNER_ID}`,
+        {
+          method: route.method,
+          headers: route.body ? { 'Content-Type': 'application/json' } : undefined,
+          body: route.body ? JSON.stringify(route.body) : undefined,
+        },
+      );
+      expect(response.status, route.name).not.toBe(403);
+      expect(effects[route.effect], route.name).toHaveBeenCalled();
+    },
+  );
+
+  it('denies a missing accounting grant before provider and body validation', async () => {
+    const response = await app().request('/accounting/not-a-provider/settings', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    });
+    expect(response.status).toBe(403);
+    for (const effect of effectMocks) expect(effect).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/routes/accounting/reconcile.test.ts
+++ b/apps/api/src/routes/accounting/reconcile.test.ts
@@ -18,7 +18,7 @@ const {
   const authState = {
     scope: 'partner' as 'partner' | 'system' | 'organization',
     partnerOrgAccess: 'all' as 'all' | 'selected' | 'none' | null,
-    permissions: new Set<string>(['invoices:write']),
+    permissions: new Set<string>(['accounting:read', 'accounting:manage', 'invoices:write']),
     mfa: true,
   };
   return { getConnectionMock, enqueueAccountingReconcileMock, writeRouteAuditMock, authState };
@@ -146,7 +146,7 @@ function connectionRow(overrides: Record<string, unknown> = {}) {
 beforeEach(() => {
   vi.clearAllMocks();
   authState.scope = 'partner';
-  authState.permissions = new Set(['invoices:write']);
+  authState.permissions = new Set(['accounting:read', 'accounting:manage', 'invoices:write']);
   authState.mfa = true;
 });
 
@@ -253,7 +253,7 @@ describe('POST /accounting/:provider/reconcile', () => {
   });
 
   it('denies a partner-scoped caller without INVOICES_WRITE (403)', async () => {
-    authState.permissions = new Set();
+    authState.permissions = new Set(['accounting:read', 'accounting:manage']);
 
     const res = await reconcile();
 
@@ -264,7 +264,7 @@ describe('POST /accounting/:provider/reconcile', () => {
 
   it('allows a SYSTEM-scope caller that holds no per-partner role (bypasses the permission check)', async () => {
     authState.scope = 'system';
-    authState.permissions = new Set();
+    authState.permissions = new Set(['accounting:read', 'accounting:manage']);
     getConnectionMock.mockResolvedValue(connectionRow({ id: 'c2', partnerId: 'p9' }));
     enqueueAccountingReconcileMock.mockResolvedValue(true);
 

--- a/apps/api/src/routes/permissionsCatalog.ts
+++ b/apps/api/src/routes/permissionsCatalog.ts
@@ -39,6 +39,7 @@ const RESOURCE_LABELS: Record<string, string> = {
   approvals: 'Approvals',
   variables: 'Variables',
   pam: 'Privileged Access',
+  accounting: 'Accounting',
   workspace: 'Workspace'
 };
 

--- a/apps/web/src/components/integrations/IntegrationsPage.accountingPermissions.test.tsx
+++ b/apps/web/src/components/integrations/IntegrationsPage.accountingPermissions.test.tsx
@@ -1,0 +1,110 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * SEC-2026-09-05-057 web gate: the QuickBooks sub-tab entry and its panel are
+ * gated on the dedicated `accounting:read` capability. Without it the sub-tab
+ * button is not rendered and the panel shows the standard permission-denied
+ * state (`AccessDenied`) rather than a screen of 403s. The Stripe payments
+ * sub-tab is a separate integration and stays reachable either way.
+ *
+ * The sibling IntegrationsPage.test.tsx holds the grant throughout and covers
+ * the positive tab/sub-tab wiring; this suite covers the NEGATIVE branch.
+ */
+type Perm = { resource: string; action: string };
+const state = vi.hoisted(() => ({ permissions: [] as Perm[] }));
+
+vi.mock("../../lib/permissions", () => ({
+  usePermissions: () => ({
+    permissions: state.permissions,
+    can: (resource: string, action: string) =>
+      state.permissions.some((p) => p.resource === resource && p.action === action),
+  }),
+}));
+
+vi.mock("../../lib/authScope", () => ({
+  getJwtClaims: () => ({ scope: "partner", orgId: null, partnerId: "partner-1" }),
+  loginPathWithNext: () => "/login",
+}));
+vi.mock("../../stores/orgStore", () => ({
+  useOrgStore: (selector: (value: { currentOrgId: string | null }) => unknown) =>
+    selector({ currentOrgId: null }),
+}));
+vi.mock("../../stores/helpStore", () => ({
+  useHelpStore: { getState: () => ({ open: vi.fn() }) },
+  rebaseDocsUrl: (url: string) => url,
+}));
+vi.mock("../../stores/auth", async (importActual) => ({
+  ...(await importActual<typeof import("../../stores/auth")>()),
+  fetchWithAuth: vi.fn(),
+}));
+
+// Stub every heavy panel; this suite only asserts the accounting gate.
+vi.mock("../webhooks/WebhooksPage", () => ({ default: () => <div /> }));
+vi.mock("./CommunicationIntegrations", () => ({ default: () => <div /> }));
+vi.mock("../psa/PsaConnectionsPage", () => ({ default: () => <div /> }));
+vi.mock("./SecurityIntegration", () => ({ default: () => <div /> }));
+vi.mock("./HuntressIntegration", () => ({ default: () => <div /> }));
+vi.mock("./MonitoringIntegration", () => ({ default: () => <div /> }));
+vi.mock("./GoogleWorkspaceIntegration", () => ({ default: () => <div /> }));
+vi.mock("./M365Integration", () => ({ default: () => <div /> }));
+vi.mock("./M365CustomerGraphReadCard", () => ({
+  M365_CUSTOMER_GRAPH_READ_CALLBACK_RESULTS: [],
+  default: () => <div />,
+}));
+vi.mock("./M365CustomerGraphActionsCard", () => ({
+  M365_CUSTOMER_GRAPH_ACTIONS_CALLBACK_RESULTS: [],
+  default: () => <div />,
+}));
+vi.mock("./Pax8Integration", () => ({ default: () => <div /> }));
+vi.mock("../settings/TdSynnexCatalogPanel", () => ({ default: () => <div /> }));
+vi.mock("../settings/TdSynnexEcExpressPanel", () => ({ default: () => <div /> }));
+vi.mock("../settings/TdSynnexSftpPanel", () => ({ default: () => <div /> }));
+vi.mock("./UnifiIntegration", () => ({ default: () => <div /> }));
+vi.mock("./StripePaymentsIntegration", () => ({
+  default: () => <div data-testid="stub-stripe-payments" />,
+}));
+vi.mock("./QuickbooksIntegration", () => ({
+  default: () => <div data-testid="stub-quickbooks" />,
+}));
+
+import IntegrationsPage from "./IntegrationsPage";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.permissions = [];
+  window.history.replaceState({}, "", "/integrations#quickbooks");
+});
+
+describe("IntegrationsPage QuickBooks accounting:read gate", () => {
+  it("hides the QuickBooks sub-tab and renders AccessDenied without accounting:read", () => {
+    render(<IntegrationsPage />);
+
+    expect(screen.queryByTestId("stub-quickbooks")).toBeNull();
+    expect(screen.getByTestId("accounting-quickbooks-denied")).toBeTruthy();
+    // The sub-tab entry itself is gone; Stripe payments stays available.
+    const buttons = screen.getAllByRole("button").map((b) => b.textContent ?? "");
+    expect(buttons.some((label) => /quickbooks/i.test(label))).toBe(false);
+    expect(buttons.some((label) => /payment/i.test(label))).toBe(true);
+  });
+
+  it("renders the QuickBooks panel and sub-tab once accounting:read is granted", () => {
+    state.permissions = [{ resource: "accounting", action: "read" }];
+
+    render(<IntegrationsPage />);
+
+    expect(screen.getByTestId("stub-quickbooks")).toBeTruthy();
+    expect(screen.queryByTestId("accounting-quickbooks-denied")).toBeNull();
+    const buttons = screen.getAllByRole("button").map((b) => b.textContent ?? "");
+    expect(buttons.some((label) => /quickbooks/i.test(label))).toBe(true);
+  });
+
+  it("does not let an unrelated grant (invoices:write) unlock QuickBooks", () => {
+    state.permissions = [{ resource: "invoices", action: "write" }];
+
+    render(<IntegrationsPage />);
+
+    expect(screen.queryByTestId("stub-quickbooks")).toBeNull();
+    expect(screen.getByTestId("accounting-quickbooks-denied")).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/integrations/IntegrationsPage.test.tsx
+++ b/apps/web/src/components/integrations/IntegrationsPage.test.tsx
@@ -16,6 +16,17 @@ vi.mock("../../lib/authScope", () => ({
   getJwtClaims: () => ({ scope, orgId: orgState.jwtOrgId, partnerId: "partner-1" }),
   loginPathWithNext: () => "/login",
 }));
+// SEC-2026-09-05-057: the QuickBooks sub-tab and panel are gated on
+// `accounting:read`. This suite covers tab/sub-tab wiring, so it holds the
+// grant throughout; the negative branch lives in
+// IntegrationsPage.accountingPermissions.test.tsx.
+vi.mock("../../lib/permissions", () => ({
+  usePermissions: () => ({
+    permissions: [{ resource: "accounting", action: "read" }],
+    can: (resource: string, action: string) =>
+      resource === "accounting" && action === "read",
+  }),
+}));
 vi.mock("../../stores/orgStore", () => ({
   useOrgStore: (selector: (value: { currentOrgId: string | null }) => unknown) =>
     selector({ currentOrgId: orgState.currentOrgId }),

--- a/apps/web/src/components/integrations/IntegrationsPage.tsx
+++ b/apps/web/src/components/integrations/IntegrationsPage.tsx
@@ -35,6 +35,8 @@ import TdSynnexSftpPanel from "../settings/TdSynnexSftpPanel";
 import QuickbooksIntegration from "./QuickbooksIntegration";
 import StripePaymentsIntegration from "./StripePaymentsIntegration";
 import UnifiIntegration from "./UnifiIntegration";
+import AccessDenied from "../shared/AccessDenied";
+import { usePermissions } from "../../lib/permissions";
 import { getJwtClaims } from "../../lib/authScope";
 import { useHelpStore, rebaseDocsUrl } from "../../stores/helpStore";
 import { useOrgStore } from "../../stores/orgStore";
@@ -307,6 +309,17 @@ export default function IntegrationsPage({
   // null scope on a missing/undecodable token, so only a confirmed 'organization'
   // scope is blocked; everything else falls through to the server's own check.
   const isOrgScoped = claims.scope === "organization";
+
+  // SEC-2026-09-05-057: the QuickBooks routes now require the dedicated
+  // `accounting:read` capability. Gate the QuickBooks sub-tab entry and its
+  // panel on it so a caller without the grant gets the standard
+  // permission-denied state instead of a screen of 403s. The Stripe payments
+  // sub-tab is a separate integration with its own routes and is NOT gated on
+  // the accounting capability. UX only — every route re-checks server-side.
+  const canReadAccounting = usePermissions().can("accounting", "read");
+  const visibleAccountingSubTabs = accountingSubTabs.filter(
+    (sub) => sub.id !== "quickbooks" || canReadAccounting,
+  );
   const visibleCustomerGraphReadResult = callbackOrgId !== null
     && customerGraphReadCallback.orgId === callbackOrgId
     ? customerGraphReadCallback.result
@@ -451,7 +464,7 @@ export default function IntegrationsPage({
       {/* Accounting sub-tabs (hidden for org-scope users, who can't use these APIs) */}
       {activeTab === "accounting" && !isOrgScoped && (
         <div className="flex gap-2">
-          {accountingSubTabs.map((sub) => {
+          {visibleAccountingSubTabs.map((sub) => {
             const isActive = sub.id === accountingSubTab;
             return (
               <button
@@ -536,7 +549,12 @@ export default function IntegrationsPage({
       )}
       {activeTab === "accounting" &&
         !isOrgScoped &&
-        accountingSubTab === "quickbooks" && <QuickbooksIntegration />}
+        accountingSubTab === "quickbooks" &&
+        (canReadAccounting ? (
+          <QuickbooksIntegration />
+        ) : (
+          <AccessDenied testId="accounting-quickbooks-denied" />
+        ))}
       {activeTab === "accounting" &&
         !isOrgScoped &&
         accountingSubTab === "stripe" && <StripePaymentsIntegration />}

--- a/apps/web/src/components/integrations/QuickbooksIntegration.accountingPermissions.test.tsx
+++ b/apps/web/src/components/integrations/QuickbooksIntegration.accountingPermissions.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * SEC-2026-09-05-057 web gate: every mutating QuickBooks control mirrors the
+ * server's dedicated `accounting:manage` capability. A caller holding only
+ * `accounting:read` (plus the pre-existing `invoices:write`) can still SEE the
+ * panel but cannot operate connect, disconnect, refresh-settings, push mode,
+ * payment sync or reconcile.
+ *
+ * The sibling QuickbooksIntegration.test.tsx grants everything except
+ * `invoices:write`; this suite covers the accounting:manage branch.
+ */
+const fetchWithAuth = vi.fn();
+const state = vi.hoisted(() => ({ canManage: false }));
+
+vi.mock("../../lib/permissions", () => ({
+  usePermissions: () => ({
+    permissions: [],
+    can: (resource: string, action: string) =>
+      resource === "accounting" && action === "manage"
+        ? state.canManage
+        : true,
+  }),
+}));
+vi.mock("../../stores/auth", () => ({
+  fetchWithAuth: (...args: unknown[]) => fetchWithAuth(...args),
+}));
+vi.mock("../shared/Toast", () => ({ showToast: vi.fn() }));
+vi.mock("@/lib/navigation", () => ({ navigateTo: vi.fn() }));
+vi.mock("../../lib/authScope", () => ({
+  loginPathWithNext: () => "/login?next=/integrations",
+  getJwtClaims: () => ({ scope: "partner", orgId: null, partnerId: "partner-1" }),
+}));
+
+import QuickbooksIntegration from "./QuickbooksIntegration";
+
+const jsonResponse = (payload: unknown, status = 200): Response =>
+  ({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: "OK",
+    json: vi.fn().mockResolvedValue(payload),
+  }) as unknown as Response;
+
+const disconnected = {
+  status: "disconnected",
+  environment: null,
+  pushMode: "auto",
+  connectedAt: null,
+  lastError: null,
+};
+const connected = {
+  status: "connected",
+  environment: "production",
+  pushMode: "auto",
+  connectedAt: "2026-06-23T00:00:00Z",
+  lastError: null,
+  pullPayments: true,
+  lastReconcileAt: null,
+};
+
+function serve(status: unknown) {
+  fetchWithAuth.mockImplementation(async (url: string) =>
+    url === "/accounting/quickbooks" ? jsonResponse(status) : jsonResponse({}, 404),
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.canManage = false;
+  window.history.replaceState({}, "", "/integrations");
+});
+
+describe("QuickbooksIntegration accounting:manage gate", () => {
+  it("disables Connect without accounting:manage", async () => {
+    serve(disconnected);
+    render(<QuickbooksIntegration />);
+    const connect = await screen.findByTestId("quickbooks-connect");
+    expect((connect as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("enables Connect once accounting:manage is granted", async () => {
+    state.canManage = true;
+    serve(disconnected);
+    render(<QuickbooksIntegration />);
+    const connect = await screen.findByTestId("quickbooks-connect");
+    expect((connect as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("disables disconnect / refresh-settings and hides push-mode + reconcile without accounting:manage", async () => {
+    serve(connected);
+    render(<QuickbooksIntegration />);
+    await screen.findByTestId("quickbooks-status-connected");
+
+    expect((screen.getByTestId("quickbooks-disconnect") as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByTestId("quickbooks-settings-refresh") as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.queryByTestId("quickbooks-pushmode-auto")).toBeNull();
+    expect(screen.queryByTestId("quickbooks-pushmode-manual")).toBeNull();
+    expect(screen.queryByTestId("quickbooks-reconcile-now")).toBeNull();
+  });
+
+  it("restores every control once accounting:manage is granted", async () => {
+    state.canManage = true;
+    serve(connected);
+    render(<QuickbooksIntegration />);
+    await screen.findByTestId("quickbooks-status-connected");
+
+    expect((screen.getByTestId("quickbooks-disconnect") as HTMLButtonElement).disabled).toBe(false);
+    expect((screen.getByTestId("quickbooks-settings-refresh") as HTMLButtonElement).disabled).toBe(false);
+    expect(screen.getByTestId("quickbooks-pushmode-auto")).toBeTruthy();
+    expect(screen.getByTestId("quickbooks-pushmode-manual")).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/integrations/QuickbooksIntegration.tsx
+++ b/apps/web/src/components/integrations/QuickbooksIntegration.tsx
@@ -83,6 +83,16 @@ export default function QuickbooksIntegration() {
    */
   const canWriteInvoices = usePermissions().can("invoices", "write");
 
+  /**
+   * SEC-2026-09-05-057: the QuickBooks routes now carry dedicated
+   * `accounting:read` / `accounting:manage` capabilities on top of the
+   * full-partner authority check. Every mutating control below is disabled or
+   * hidden without `accounting:manage`, matching the server gate (the panel
+   * itself only renders for a caller holding `accounting:read` — see
+   * IntegrationsPage). UX only; every route re-checks server-side.
+   */
+  const canManageAccounting = usePermissions().can("accounting", "manage");
+
   const [status, setStatus] = useState<QuickbooksStatus | null>(null);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -510,7 +520,7 @@ export default function QuickbooksIntegration() {
           <button
             type="button"
             onClick={() => void handleConnect()}
-            disabled={connecting}
+            disabled={connecting || !canManageAccounting}
             className="mt-4 inline-flex h-10 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
             data-testid="quickbooks-connect"
           >
@@ -570,7 +580,7 @@ export default function QuickbooksIntegration() {
             </div>
           </dl>
 
-          {canWriteInvoices && (
+          {canWriteInvoices && canManageAccounting && (
           <div>
             <p className="text-sm font-medium">
               {t("quickbooksIntegration.invoicePush")}
@@ -612,7 +622,7 @@ export default function QuickbooksIntegration() {
           {/* Phase D: payment pull-back. Sits beside the push-mode row because
               the two together are the whole direction-of-travel story — push
               invoices out, pull payments back. */}
-          {canWriteInvoices && (
+          {canWriteInvoices && canManageAccounting && (
           <div className="flex items-start justify-between gap-4">
             <div>
               <p className="text-sm font-medium">
@@ -649,7 +659,7 @@ export default function QuickbooksIntegration() {
 
           {/* Phase D2: the outbound half. Sits under the pull toggle so the two
               read as one direction-of-travel pair. */}
-          {canWriteInvoices && (
+          {canWriteInvoices && canManageAccounting && (
           <div className="flex items-start justify-between gap-4">
             <div>
               <p className="text-sm font-medium">
@@ -685,7 +695,7 @@ export default function QuickbooksIntegration() {
           )}
 
           <div className="flex items-center gap-3 border-t pt-4">
-            {canWriteInvoices && (
+            {canWriteInvoices && canManageAccounting && (
             <button
               type="button"
               onClick={() => void handleReconcileNow()}
@@ -741,7 +751,7 @@ export default function QuickbooksIntegration() {
             <button
               type="button"
               onClick={() => void handleRefreshSettings()}
-              disabled={refreshingSettings}
+              disabled={refreshingSettings || !canManageAccounting}
               className="inline-flex h-9 items-center gap-2 rounded-md border px-3 text-sm font-medium hover:bg-muted disabled:opacity-50"
               data-testid="quickbooks-settings-refresh"
             >
@@ -755,7 +765,7 @@ export default function QuickbooksIntegration() {
             <button
               type="button"
               onClick={() => void handleDisconnect()}
-              disabled={disconnecting}
+              disabled={disconnecting || !canManageAccounting}
               className="inline-flex h-9 items-center gap-2 rounded-md border border-red-200 px-3 text-sm font-medium text-red-700 hover:bg-red-50 disabled:opacity-50"
               data-testid="quickbooks-disconnect"
             >

--- a/apps/web/src/components/integrations/QuickbooksMappingWorkbench.accountingPermissions.test.tsx
+++ b/apps/web/src/components/integrations/QuickbooksMappingWorkbench.accountingPermissions.test.tsx
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+/**
+ * SEC-2026-09-05-057 (PR review finding): the mapping workbench drives three
+ * manage-gated routes — Save income account (PATCH /accounting/:provider/settings),
+ * Confirm / Create / Unlink (PUT /accounting/:provider/mappings) and Sync now
+ * (POST /accounting/:provider/mappings/sync). Without `accounting:manage` a
+ * read-only caller must see every one of those disabled; the read-only Load
+ * button and the tab switches stay operable.
+ */
+const fetchWithAuthMock = vi.fn();
+const state = vi.hoisted(() => ({ canManage: false }));
+
+vi.mock("../../lib/permissions", () => ({
+  usePermissions: () => ({
+    permissions: [],
+    can: (resource: string, action: string) =>
+      resource === "accounting" && action === "manage" ? state.canManage : true,
+  }),
+}));
+vi.mock("../../stores/auth", () => ({
+  fetchWithAuth: (...a: unknown[]) => fetchWithAuthMock(...a),
+}));
+vi.mock("../shared/Toast", () => ({ showToast: vi.fn() }));
+
+import QuickbooksMappingWorkbench from "./QuickbooksMappingWorkbench";
+
+const ORG_ID = "11111111-1111-1111-1111-111111111111";
+
+const suggestedOrgProposal = {
+  breezeEntityType: "org",
+  breezeEntityId: ORG_ID,
+  breezeDisplayName: "Acme Corp",
+  remoteEntityType: "Customer",
+  proposedRemoteId: "qb-12",
+  proposedRemoteName: "Acme Corp (QBO)",
+  confidence: "exact_email",
+  linkStatus: "confirmed",
+  syncStatus: "pending",
+  lastError: null,
+};
+
+function jsonResponse(body: unknown, status = 200) {
+  return Promise.resolve(
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    }),
+  );
+}
+
+async function renderLoaded() {
+  fetchWithAuthMock.mockResolvedValueOnce(
+    jsonResponse({ data: [suggestedOrgProposal] }),
+  );
+  render(
+    <QuickbooksMappingWorkbench
+      onUnauthorized={vi.fn()}
+      defaultIncomeAccountRef="income-1"
+    />,
+  );
+  fireEvent.click(screen.getByTestId("quickbooks-mapping-load"));
+  await screen.findByTestId(`quickbooks-mapping-row-${ORG_ID}`);
+}
+
+const disabled = (testId: string) =>
+  (screen.getByTestId(testId) as HTMLButtonElement).disabled;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fetchWithAuthMock.mockReset();
+  state.canManage = false;
+  window.location.hash = "";
+});
+
+describe("QuickbooksMappingWorkbench accounting:manage gate", () => {
+  it("disables Confirm/Create/Unlink and Sync now without accounting:manage", async () => {
+    await renderLoaded();
+
+    expect(disabled(`quickbooks-mapping-confirm-${ORG_ID}`)).toBe(true);
+    expect(disabled(`quickbooks-mapping-create-${ORG_ID}`)).toBe(true);
+    expect(disabled(`quickbooks-mapping-unlink-${ORG_ID}`)).toBe(true);
+    expect(disabled(`quickbooks-mapping-sync-${ORG_ID}`)).toBe(true);
+  });
+
+  it("keeps the read-only Load control operable without accounting:manage", async () => {
+    await renderLoaded();
+    expect(disabled("quickbooks-mapping-load")).toBe(false);
+  });
+
+  it("never issues a mutating request from a disabled control", async () => {
+    await renderLoaded();
+    const callsAfterLoad = fetchWithAuthMock.mock.calls.length;
+
+    fireEvent.click(screen.getByTestId(`quickbooks-mapping-sync-${ORG_ID}`));
+    fireEvent.click(screen.getByTestId(`quickbooks-mapping-unlink-${ORG_ID}`));
+
+    expect(fetchWithAuthMock.mock.calls.length).toBe(callsAfterLoad);
+  });
+
+  // The income-account control only renders on the Items tab (it gates item
+  // creation in QuickBooks), so it needs its own render.
+  it.each([
+    { canManage: false, expected: true },
+    { canManage: true, expected: false },
+  ])(
+    "Save income account disabled=$expected when accounting:manage=$canManage",
+    async ({ canManage, expected }) => {
+      state.canManage = canManage;
+      window.location.hash = "#quickbooks-items";
+      // income-accounts fetch on mount, then the proposals load.
+      fetchWithAuthMock
+        .mockResolvedValueOnce(jsonResponse({ data: [{ id: "income-1", displayName: "Sales" }] }))
+        .mockResolvedValueOnce(jsonResponse({ data: [] }));
+      render(
+        <QuickbooksMappingWorkbench
+          onUnauthorized={vi.fn()}
+          defaultIncomeAccountRef="income-1"
+        />,
+      );
+
+      expect(disabled("quickbooks-income-account-save")).toBe(expected);
+    },
+  );
+
+  it("restores the mutating controls once accounting:manage is granted", async () => {
+    state.canManage = true;
+    await renderLoaded();
+
+    expect(disabled(`quickbooks-mapping-confirm-${ORG_ID}`)).toBe(false);
+    expect(disabled(`quickbooks-mapping-unlink-${ORG_ID}`)).toBe(false);
+  });
+});

--- a/apps/web/src/components/integrations/QuickbooksMappingWorkbench.test.tsx
+++ b/apps/web/src/components/integrations/QuickbooksMappingWorkbench.test.tsx
@@ -2,6 +2,14 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import QuickbooksMappingWorkbench from "./QuickbooksMappingWorkbench";
 
+// SEC-2026-09-05-057: every mutating control here is gated on
+// `accounting:manage`. This suite covers the workbench's own behaviour, so it
+// holds the grant throughout; the gate itself is covered by
+// QuickbooksMappingWorkbench.accountingPermissions.test.tsx.
+vi.mock("../../lib/permissions", () => ({
+  usePermissions: () => ({ permissions: [], can: () => true }),
+}));
+
 const fetchWithAuthMock = vi.fn();
 vi.mock("../../stores/auth", () => ({
   fetchWithAuth: (...a: unknown[]) => fetchWithAuthMock(...a),

--- a/apps/web/src/components/integrations/QuickbooksMappingWorkbench.tsx
+++ b/apps/web/src/components/integrations/QuickbooksMappingWorkbench.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Loader2 } from "lucide-react";
 import { fetchWithAuth } from "../../stores/auth";
+import { usePermissions } from "../../lib/permissions";
 import { runAction, handleActionError, ActionError } from "../../lib/runAction";
 import { showToast } from "../shared/Toast";
 import { useHashTab } from "@/lib/useHashState";
@@ -104,6 +105,17 @@ export default function QuickbooksMappingWorkbench({
   onSettingsChanged,
 }: Props) {
   const { t } = useTranslation("integrations");
+
+  /**
+   * SEC-2026-09-05-057 (PR review finding): every mutating control in this
+   * workbench drives a route that now requires `accounting:manage` — Save
+   * income account (PATCH /settings), Confirm/Create/Unlink (PUT /mappings)
+   * and Sync now (POST /mappings/sync). Disable them without the grant so a
+   * read-only caller sees an inert control instead of a 403. Loading proposals
+   * and switching tabs are reads and stay operable. UX only — every route
+   * re-checks server-side.
+   */
+  const canManageAccounting = usePermissions().can("accounting", "manage");
   const [tab, setTab] = useHashTab<WorkbenchTab>(TABS, "quickbooks-customers");
   const entityType: MappingEntityType = tab === "quickbooks-items" ? "catalog_item" : "org";
 
@@ -451,7 +463,7 @@ export default function QuickbooksMappingWorkbench({
               type="button"
               data-testid="quickbooks-income-account-save"
               onClick={() => void saveIncomeAccount()}
-              disabled={savingIncomeAccount || !incomeAccountRef}
+              disabled={savingIncomeAccount || !incomeAccountRef || !canManageAccounting}
               className="inline-flex h-8 items-center rounded-md border px-3 text-sm font-medium hover:bg-muted disabled:opacity-50"
             >
               {t("quickbooksMapping.saveIncomeAccount")}
@@ -574,7 +586,7 @@ export default function QuickbooksMappingWorkbench({
                     <button
                       type="button"
                       data-testid={`quickbooks-mapping-confirm-${id}`}
-                      disabled={busy || !remoteIdFor(id, p)}
+                      disabled={busy || !remoteIdFor(id, p) || !canManageAccounting}
                       onClick={() => void decide(p, "confirmed", remoteIdFor(id, p))}
                       className="rounded-md border px-2 py-1 text-xs font-medium hover:bg-muted disabled:opacity-50"
                     >
@@ -583,7 +595,7 @@ export default function QuickbooksMappingWorkbench({
                     <button
                       type="button"
                       data-testid={`quickbooks-mapping-create-${id}`}
-                      disabled={busy || createGated}
+                      disabled={busy || createGated || !canManageAccounting}
                       onClick={() => void decide(p, "create_new")}
                       className="rounded-md border px-2 py-1 text-xs font-medium hover:bg-muted disabled:opacity-50"
                     >
@@ -592,7 +604,7 @@ export default function QuickbooksMappingWorkbench({
                     <button
                       type="button"
                       data-testid={`quickbooks-mapping-unlink-${id}`}
-                      disabled={busy || p.linkStatus === "unlinked"}
+                      disabled={busy || p.linkStatus === "unlinked" || !canManageAccounting}
                       onClick={() => void decide(p, "unlinked")}
                       className="rounded-md border px-2 py-1 text-xs font-medium hover:bg-muted disabled:opacity-50"
                     >
@@ -601,7 +613,7 @@ export default function QuickbooksMappingWorkbench({
                     <button
                       type="button"
                       data-testid={`quickbooks-mapping-sync-${id}`}
-                      disabled={busy || syncGated}
+                      disabled={busy || syncGated || !canManageAccounting}
                       onClick={() => void sync(p)}
                       className="rounded-md border px-2 py-1 text-xs font-medium hover:bg-muted disabled:opacity-50"
                     >

--- a/packages/shared/src/constants/permissions.test.ts
+++ b/packages/shared/src/constants/permissions.test.ts
@@ -24,6 +24,17 @@ describe('PAM dedicated permissions (pam:approve / pam:manage_policy)', () => {
   });
 });
 
+describe('Accounting dedicated permissions (accounting:read / accounting:manage)', () => {
+  it('exposes a dedicated provider-read capability, distinct from partner authority alone', () => {
+    expect(PERMISSION_GRANTS.ACCOUNTING_READ).toEqual({ resource: 'accounting', action: 'read' });
+  });
+
+  it('exposes a dedicated realm-management capability, distinct from invoices:write', () => {
+    expect(PERMISSION_GRANTS.ACCOUNTING_MANAGE).toEqual({ resource: 'accounting', action: 'manage' });
+    expect(PERMISSION_GRANTS.ACCOUNTING_MANAGE).not.toEqual(PERMISSION_GRANTS.INVOICES_WRITE);
+  });
+});
+
 describe('Workspace extension grants', () => {
   it('keeps read, configuration, credentials, and execution as distinct capabilities', () => {
     expect(PERMISSION_GRANTS.WORKSPACE_READ).toEqual({ resource: 'workspace', action: 'read' });

--- a/packages/shared/src/constants/permissions.ts
+++ b/packages/shared/src/constants/permissions.ts
@@ -180,6 +180,22 @@ export const PERMISSION_GRANTS = {
   PAM_APPROVE: { resource: 'pam', action: 'approve' },
   PAM_MANAGE_POLICY: { resource: 'pam', action: 'manage_policy' },
 
+  // Accounting / QuickBooks integration (SEC-2026-09-05-057). The interactive
+  // QuickBooks routes used to gate on partner authority alone, so any
+  // full-partner member — however low their role — could read the shared
+  // provider realm (customers, entity mappings, income accounts, remote
+  // candidates) and, with MFA, reach realm lifecycle and settings mutations.
+  // These two capabilities make that authority explicit and separately
+  // grantable: `accounting:read` for provider reads, `accounting:manage` for
+  // connect/disconnect, settings, mapping writes and synchronization.
+  // Route-specific requirements (organizations:write + sites:write on customer
+  // import, invoices:write on invoice push, catalog:write on item mappings,
+  // and MFA) remain cumulative on top. Only Org Admin (and Partner Admin via
+  // its `*:*` wildcard) hold these by default; existing custom roles gain
+  // neither automatically.
+  ACCOUNTING_READ: { resource: 'accounting', action: 'read' },
+  ACCOUNTING_MANAGE: { resource: 'accounting', action: 'manage' },
+
   // Admin
   ADMIN_ALL: { resource: '*', action: '*' },
 } as const;


### PR DESCRIPTION
## Summary

Every interactive QuickBooks route in `apps/api/src/routes/accounting/index.ts` gated only on partner/organization authority — **there was no accounting permission at all**. Any full-partner member, however low their role, could read the shared provider realm (customers, entity mappings, income accounts, remote candidates) and, with MFA, reach realm lifecycle and settings mutations (connect, disconnect, settings, sync). This is SEC-2026-09-05-057, **owner decision Option A**.

Adds two dedicated capabilities, copying the shape of the PAM family shipped in #5480 (migration `2026-10-15-150200-pam-dedicated-permissions.sql`):

- **`accounting:read`** — read the accounting provider realm.
- **`accounting:manage`** — connect/disconnect, configure and synchronize it.

Both guards are wrapped in the file's existing `partnerScopedPermission` helper (a system-scope token carries neither `partnerId` nor `orgId`, so `requirePermission` can resolve no role for it — the same exemption the pre-existing import/invoice guards already rely on), and are placed **immediately after `requireAccountingPartnerAuthority`, before `zValidator`, provider-config validation, and every provider/DB/queue/cookie/audit side effect**.

### Note on the partner-authority partial

The tested partial referenced by the finding (`requireAccountingPartnerAuthority` + `partnerAuthority.test.ts` + `accountingPartnerAuthority.integration.test.ts`) is **already on `main`**, in a form slightly newer than the original commit. Nothing needed porting; this PR is the Option A permission family on top of it.

## Route → permission matrix

All 15 interactive routes (the unauthenticated signed OAuth `GET /:provider/callback` is deliberately outside the human-route gate and unchanged):

| Route | New gate | Pre-existing gates (unchanged, cumulative) |
|---|---|---|
| `GET /:provider` (status) | `accounting:read` | partner scope, full-partner authority |
| `GET /:provider/customers` | `accounting:read` | full-partner org-import access, full-partner authority |
| `GET /:provider/mappings` | `accounting:read` | partner scope, full-partner authority |
| `GET /:provider/income-accounts` | `accounting:read` | partner scope, full-partner authority |
| `GET /:provider/remote-candidates` | `accounting:read` | partner scope, full-partner authority |
| `GET /:provider/connect` (OAuth start) | `accounting:manage` | MFA, full-partner authority |
| `POST /:provider/disconnect` | `accounting:manage` | MFA, full-partner authority |
| `PATCH /:provider/settings` | `accounting:manage` | MFA, `invoices:write` on sync switches |
| `POST /:provider/settings/refresh` | `accounting:manage` | MFA, full-partner authority |
| `POST /:provider/reconcile` | `accounting:manage` | MFA, `invoices:write` |
| `PUT /:provider/mappings` | `accounting:manage` | MFA, `organizations:write` / `catalog:write` |
| `POST /:provider/mappings/sync` | `accounting:manage` | MFA, `organizations:write` / `catalog:write` |
| `POST /:provider/invoices/:invoiceId/push` | `accounting:manage` | MFA, `invoices:write` |
| `POST /:provider/invoices/push-bulk` | `accounting:manage` | MFA, `invoices:write` |
| `POST /:provider/customers/import` | `accounting:read` | full-partner org-import access, `organizations:write` + `sites:write`, MFA |

**No interactive accounting route is left ungated by the permission family** (6 read-gated, 9 manage-gated — asserted directly in the matrix test).

Both invoice-push routes and customer import were gated in the review round: a push *writes* an invoice into the shared provider realm, exactly like a mapping sync or a reconcile trigger, and import's response echoes remote QuickBooks displayNames for the caller-supplied ids, so it *reads* the realm as well as creating tenants. Production impact is nil — the only connected partner's sole user is a Partner Admin.

Implementation note: `accounting:read` on the import route is folded into `requireImportPermissions` rather than listed as a separate handler. That chain was already at Hono's variadic-inference limit; a 10th handler collapses the handler's `c.req.valid(...)` types to `never`. Composition keeps the chain length and the ordering unchanged.

## Built-in role grants

Exactly the predicate the 150200 PAM migration used:

- **Org Admin** (`scope = 'organization' AND is_system = TRUE`) — **both** permissions, swept across **every** such row: the global system-template row *and* every per-partner `is_system` clone (no `partner_id IS NULL` filter, because those clones exist in production).
- **Partner Admin** — already covered by its `*:*` wildcard; no explicit row.
- **No other built-in role.** Explicitly *not* Partner Technician, Partner Viewer, Partner Billing, Partner Billing Viewer, Org Technician, Org Viewer, Security Approver, or Partner Security Approver.
- **No custom role gains either permission automatically.** `is_system = TRUE` is the anti-forgery filter — `routes/roles.ts` always creates custom roles with `is_system = false`, so a role merely *named* "Org Admin" can never be swept in. Asserted by the migration integration test.

**Worth knowing:** the accounting routes are partner-scope only (`requireScope('partner','system')`), so in practice **Partner Admin (via `*:*`) is the only built-in role that can exercise these permissions today**; the Org Admin grant mirrors 150200 so the two families stay operationally identical and any future org-scoped accounting surface inherits the same default. This is the least-privilege outcome Option A asks for.

## Operator impact

- **Existing non-Partner-Admin users lose QuickBooks access until granted.** A Partner Technician / Partner Billing user who could previously browse the QuickBooks screens and (with MFA) run connect/settings/sync will now get 403 until an admin grants `accounting:read` and/or `accounting:manage` on their role in Settings → Roles.
- The permissions appear automatically in the role editor: `RoleManager.tsx` is fully driven by `GET /permissions/catalog`, which this PR extends with the `accounting` resource label.
- No API contract change, no schema change, no data migration beyond permission/grant rows.

## Migration / rollback

`apps/api/migrations/2026-10-15-150500-accounting-dedicated-permissions.sql` (sorts after everything on `main` and after the in-flight `150400`).

- Elects system scope first (`SELECT set_config('breeze.scope', 'system', true)`) — required, since it writes rows and 425 of 442 tables are `FORCE ROW LEVEL SECURITY` (#4518). Enforced by `migrationRlsScope.test.ts`.
- Idempotent: explicit existence checks (there is **no** unique constraint on `permissions(resource, action)`, so `ON CONFLICT DO NOTHING` would silently duplicate on every re-apply) and `NOT EXISTS` on the grant inserts. Re-apply is a proven no-op.
- No inner `BEGIN;`/`COMMIT;`. Reports row counts via `RAISE WARNING`.
- Adds no tables and no columns, so the cascade / device / export-policy registration lists are untouched (verified: `tenantCascade`, `tenant-export-policy`, `tenantExportErasureRoundtrip` all green).
- **Rollback:** delete the two `permissions` rows (their `role_permissions` rows cascade) and revert the code. The routes then fall back to partner-authority-only, i.e. the pre-PR posture.

## Web

- The **QuickBooks sub-tab entry and panel** on `/integrations#accounting` are gated on `accounting:read`; without it the sub-tab button is not rendered and the panel shows the standard `AccessDenied` state (`data-testid="accounting-quickbooks-denied"`). The **Stripe payments** sub-tab is a separate integration with its own routes and is intentionally *not* gated on the accounting capability.
- Every mutating QuickBooks control mirrors `accounting:manage`: Connect, Disconnect and Refresh settings are disabled; push-mode, pull-payments, push-payments and Reconcile now are hidden (they already required `invoices:write` — now `invoices:write && accounting:manage`).
- **`QuickbooksMappingWorkbench`** (review finding): Save income account, Confirm match, Create new, Unlink and Sync now are all disabled without `accounting:manage` — every one of them drives a manage-gated route. Loading proposals and switching between the Customers/Items tabs are reads and stay operable.
- UX only — every route re-checks server-side. No new mutation handlers were introduced, so no `runAction` adoption changes; `no-silent-mutations.test.ts` stays green.

## Tests

Red-first: the central route matrix was written and confirmed **failing** against the pre-fix code (25 failures / 125), and every web gating suite was re-run against a stashed component to prove the control (2/3, 2/4 and 3/6 failing without the fix). The review round was applied the same way — the matrix went red 6/135 on the new invoice-push and import rows before the route guards landed, and the workbench suite red 3/6 before its gate landed.

| Command | Result |
|---|---|
| `vitest run src/routes/accounting/permissions.test.ts` (**new**, central matrix, 15 routes × grant combinations) | 135/135 |
| `vitest run src/routes/accounting` (whole directory) | 371/371 |
| `vitest run src/db/seed.test.ts` (5 new accounting-RBAC assertions) | 185/185 |
| `vitest run src/db/migrationRlsScope.test.ts src/db/autoMigrate.test.ts src/routes/permissionsCatalog.test.ts src/services/permissions.test.ts` | 145/145 |
| API combined unit run (accounting + seed + migration guards + catalog + permissions) | 701/701 |
| `packages/shared` `src/constants/` (2 new grant assertions) | 9/9 |
| web `src/components/integrations/` + `no-silent-mutations.test.ts` | 417/417 |
| web `IntegrationsPage.accountingPermissions.test.tsx` (**new**) | 3/3 |
| web `QuickbooksIntegration.accountingPermissions.test.tsx` (**new**) | 4/4 |
| web `QuickbooksMappingWorkbench.accountingPermissions.test.tsx` (**new**) | 6/6 |
| **live DB** `accountingDedicatedPermissionsMigration.integration.test.ts` (**new**) + `accountingPartnerAuthority.integration.test.ts` | 4/4 |
| **live DB** `vitest.config.rls-coverage.ts` | 102/102 |
| **live DB** `vitest.config.rls.ts` | 26 passed / 5 skipped |
| **live DB** `tenantCascade` + `tenant-export-policy` + `tenantExportErasureRoundtrip` | 14/14 |
| `tsc --noEmit` (apps/api, apps/web) | clean |
| `tsc --noEmit` (packages/shared) | 3 pre-existing errors in `quotes.test.ts`, untouched by this diff |
| `pnpm lint` | 6/6 packages clean |
| `scripts/check-migration-naming.sh` | OK |

Live-DB suites ran against a private `pnpm test-stack` instance, torn down afterwards (the migration also applied cleanly on that fresh database via `autoMigrate` during global setup).

The migration integration test proves: both permission rows exist exactly once; re-running is a no-op (no duplicate rows or grants, and no `seeded`/`granted` warnings on the second pass); the grant reaches both the global template and a fabricated per-partner `is_system` clone; and it reaches **neither** a forged `is_system = false` role sharing the name **nor** Partner Technician.

## Not done

- No `apps/docs` page was updated (the QuickBooks integration doc does not currently enumerate required permissions). Worth a follow-up if the operator-facing upgrade note should live there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013auR2S4tHMtuKXj1bXD9aD
