### PR TITLE
fix(remote): revalidate full authority on every desktop viewer transition; End dispatches via relay with a status guard (SEC-038 wave 0)

### DIFF
--- a/apps/api/src/routes/remote/sessions.test.ts
+++ b/apps/api/src/routes/remote/sessions.test.ts
@@ -1080,6 +1080,45 @@ describe('remote sessions — site-scope enforcement', () => {
       expect(createWsTicket).not.toHaveBeenCalled();
       expect(createDesktopConnectCode).not.toHaveBeenCalled();
     });
+
+    it.each([
+      { label: 'WebSocket ticket', path: `/remote/sessions/${SESSION_ID}/ws-ticket`, method: 'POST', body: undefined },
+      { label: 'desktop connect code', path: `/remote/sessions/${SESSION_ID}/desktop-connect-code`, method: 'POST', body: undefined },
+      { label: 'ICE server credentials', path: `/remote/ice-servers?sessionId=${SESSION_ID}`, method: 'GET', body: undefined },
+      { label: 'ICE candidate', path: `/remote/sessions/${SESSION_ID}/ice`, method: 'POST', body: JSON.stringify({ candidate: { candidate: 'candidate:1' } }) },
+    ])(
+      'denies $label after the remote-access policy is disabled mid-session, before any side effect',
+      async ({ path, method, body }) => {
+        // Same device/site the caller IS allowed to reach: the only thing that
+        // changed is the live policy, so this cannot pass on the site branch.
+        getSessionWithOrgCheck.mockResolvedValue({
+          ...forbidden,
+          session: { ...forbidden.session, deviceId: DEVICE_IN_ALLOWED },
+          device: { ...forbidden.device, id: DEVICE_IN_ALLOWED, siteId: ALLOWED_SITE },
+        });
+        // ...Once: the default `{allowed:true}` set in beforeEach must survive
+        // for the suites that follow (vi.clearAllMocks does not restore
+        // implementations, only call records).
+        checkRemoteAccess.mockReturnValueOnce(
+          Promise.resolve({ allowed: false, reason: 'Remote desktop is disabled by policy' })
+        );
+
+        const res = await app.request(path, {
+          method,
+          headers: {
+            Authorization: 'Bearer t',
+            ...(body ? { 'Content-Type': 'application/json' } : {}),
+          },
+          body,
+        });
+
+        expect(res.status).toBe(403);
+        expect(await res.json()).toEqual({ error: 'Remote desktop is disabled by policy' });
+        expect(db.update).not.toHaveBeenCalled();
+        expect(createWsTicket).not.toHaveBeenCalled();
+        expect(createDesktopConnectCode).not.toHaveBeenCalled();
+      }
+    );
   });
 });
 

--- a/apps/api/src/routes/remote/sessions.test.ts
+++ b/apps/api/src/routes/remote/sessions.test.ts
@@ -35,6 +35,8 @@ const {
   createDesktopConnectCode,
   createWsTicket,
   dispatchCommandToAgent,
+  captureMessage,
+  captureException,
 } = vi.hoisted(() => ({
   getDeviceWithOrgCheck: vi.fn(),
   getSessionWithOrgCheck: vi.fn(),
@@ -50,7 +52,11 @@ const {
   partnerTrustMode: vi.fn(() => 'off'),
   createDesktopConnectCode: vi.fn(),
   createWsTicket: vi.fn(),
-  dispatchCommandToAgent: vi.fn(async () => ({ status: 'sent', via: 'local' })),
+  dispatchCommandToAgent: vi.fn(
+    async (): Promise<{ status: string; via?: string; message?: string }> => ({ status: 'sent', via: 'local' })
+  ),
+  captureMessage: vi.fn(),
+  captureException: vi.fn(),
 }));
 
 // `runOutsideDbContext` is synchronous (wraps AsyncLocalStorage.exit); the real
@@ -180,7 +186,12 @@ vi.mock('../../services/viewerTokenRevocation', () => ({ revokeViewerSession }))
 // against this file's mock db).
 vi.mock('../../services/remoteSessionTeardown', () => ({
   teardownDisconnectedSessions: teardownDisconnectedSessions,
+  // Re-export the real value: both End guards are driven off it, so a mock
+  // that dropped it would make the route compare against `undefined`.
+  ACTIVE_REMOTE_SESSION_STATUSES: ['pending', 'connecting', 'active'] as const,
 }));
+
+vi.mock('../../services/sentry', () => ({ captureMessage, captureException }));
 
 vi.mock('../../services/remoteAccessPolicy', () => ({
   checkRemoteAccess,
@@ -1431,6 +1442,8 @@ describe('POST /remote/sessions/:id/end', () => {
     checkRemoteAccess.mockReturnValue(Promise.resolve({ allowed: true }));
     revokeViewerSession.mockResolvedValue(undefined);
     dispatchCommandToAgent.mockResolvedValue({ status: 'sent', via: 'local' });
+    captureMessage.mockReset();
+    captureException.mockReset();
     app = new Hono();
     app.route('/remote', sessionRoutes);
   });
@@ -1451,14 +1464,87 @@ describe('POST /remote/sessions/:id/end', () => {
     });
   });
 
+  it('does not await the relay ack — the response lands before the dispatch settles', async () => {
+    rigEndUpdate([{ id: SESSION_ID, status: 'disconnected', endedAt: new Date(), durationSeconds: 1, bytesTransferred: null }]);
+    // The relay branch polls Redis for up to 5s. Awaiting it inside the auth
+    // middleware's ambient request transaction is the #1105 pool-poison
+    // pattern, so the handler must return without it.
+    let settle: (o: { status: string; via?: string }) => void = () => {};
+    dispatchCommandToAgent.mockReturnValueOnce(new Promise((resolve) => { settle = resolve; }));
+
+    const res = await endRequest();
+
+    expect(res.status).toBe(200);
+    expect(dispatchCommandToAgent).toHaveBeenCalled();
+    settle({ status: 'sent', via: 'relay' });
+  });
+
+  it('warns and reports to Sentry when the relay reports the stop was NOT delivered', async () => {
+    rigEndUpdate([{ id: SESSION_ID, status: 'disconnected', endedAt: new Date(), durationSeconds: 1, bytesTransferred: null }]);
+    // dispatchCommandToAgent RESOLVES with a status; it does not throw. A bare
+    // try/catch around it would therefore be silent for every real
+    // non-delivery — which is the case that leaves the peer-to-peer stream up.
+    dispatchCommandToAgent.mockResolvedValueOnce({ status: 'offline' });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const res = await endRequest();
+    expect(res.status).toBe(200);
+
+    await vi.waitFor(() => expect(captureMessage).toHaveBeenCalled());
+    expect(captureMessage).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ eventCode: 'remote_desktop_stop_undelivered' })
+    );
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining(SESSION_ID));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('offline'));
+    warn.mockRestore();
+  });
+
+  it('distinguishes a faulted relay from an undelivered stop', async () => {
+    rigEndUpdate([{ id: SESSION_ID, status: 'disconnected', endedAt: new Date(), durationSeconds: 1, bytesTransferred: null }]);
+    dispatchCommandToAgent.mockResolvedValueOnce({ status: 'infrastructure_error', message: 'relay enqueue failed' });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await endRequest();
+
+    await vi.waitFor(() => expect(captureMessage).toHaveBeenCalled());
+    expect(captureMessage).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ eventCode: 'remote_desktop_stop_dispatch_failed' })
+    );
+    warn.mockRestore();
+  });
+
   it('still answers 200 when the relay throws (teardown is best-effort, the row is already terminal)', async () => {
     rigEndUpdate([{ id: SESSION_ID, status: 'disconnected', endedAt: new Date(), durationSeconds: 1, bytesTransferred: null }]);
     dispatchCommandToAgent.mockRejectedValueOnce(new Error('relay down'));
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const res = await endRequest();
 
     expect(res.status).toBe(200);
     expect(revokeViewerSession).toHaveBeenCalledWith(SESSION_ID);
+    await vi.waitFor(() => expect(captureException).toHaveBeenCalled());
+    expect(captureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      undefined,
+      { event_code: 'remote_desktop_stop_dispatch_failed' }
+    );
+    error.mockRestore();
+  });
+
+  it('refuses to overwrite a `denied` row — both End guards share one live-status list', async () => {
+    getSessionWithOrgCheck.mockResolvedValue({
+      ...liveSession,
+      session: { ...liveSession.session, status: 'denied' },
+    });
+
+    const res = await endRequest();
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'Session is already ended', status: 'denied' });
+    expect(db.update).not.toHaveBeenCalled();
+    expect(dispatchCommandToAgent).not.toHaveBeenCalled();
   });
 
   it('guards the UPDATE on the live statuses so a concurrently-failed row is not overwritten', async () => {

--- a/apps/api/src/routes/remote/sessions.test.ts
+++ b/apps/api/src/routes/remote/sessions.test.ts
@@ -34,6 +34,7 @@ const {
   partnerTrustMode,
   createDesktopConnectCode,
   createWsTicket,
+  dispatchCommandToAgent,
 } = vi.hoisted(() => ({
   getDeviceWithOrgCheck: vi.fn(),
   getSessionWithOrgCheck: vi.fn(),
@@ -49,6 +50,7 @@ const {
   partnerTrustMode: vi.fn(() => 'off'),
   createDesktopConnectCode: vi.fn(),
   createWsTicket: vi.fn(),
+  dispatchCommandToAgent: vi.fn(async () => ({ status: 'sent', via: 'local' })),
 }));
 
 // `runOutsideDbContext` is synchronous (wraps AsyncLocalStorage.exit); the real
@@ -188,6 +190,8 @@ vi.mock('../../services/remoteAccessPolicy', () => ({
 }));
 
 vi.mock('../agentWs', () => ({ sendCommandToAgent }));
+
+vi.mock('../../services/agentCommandRelay', () => ({ dispatchCommandToAgent }));
 
 vi.mock('../../services/remoteSessionAuth', () => ({
   createDesktopConnectCode,
@@ -1360,5 +1364,149 @@ describe('POST /remote/sessions/:id/lease/renew', () => {
     });
     expect(res.status).toBe(403);
     expect((await res.json()).status).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /remote/sessions/:id/end — transition reauthorization + terminal-write
+// safety (SEC-2026-09-05-038 wave 0).
+// ---------------------------------------------------------------------------
+
+describe('POST /remote/sessions/:id/end', () => {
+  let app: Hono;
+
+  const liveSession = {
+    session: {
+      id: SESSION_ID,
+      userId: 'user-1',
+      type: 'desktop',
+      status: 'active',
+      deviceId: DEVICE_IN_FORBIDDEN,
+      startedAt: new Date('2026-01-01T00:00:00Z'),
+      createdAt: new Date('2026-01-01T00:00:00Z'),
+      bytesTransferred: null,
+      recordingUrl: null,
+    },
+    device: {
+      id: DEVICE_IN_FORBIDDEN,
+      orgId: ORG_ID,
+      siteId: FORBIDDEN_SITE,
+      agentId: 'agent-1',
+      hostname: 'host-1',
+    },
+  };
+
+  // db.update(...).set(...).where(...).returning()
+  function rigEndUpdate(rows: unknown[]) {
+    const where = vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue(rows) });
+    vi.mocked(db.update).mockReturnValueOnce({
+      set: vi.fn().mockReturnValue({ where }),
+    } as never);
+    return where;
+  }
+
+  // The post-race re-read: db.select(...).from(...).where(...).limit(1)
+  function rigStatusReread(rows: unknown[]) {
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(rows) }),
+      }),
+    } as never);
+  }
+
+  function endRequest(headers: Record<string, string> = {}) {
+    return app.request(`/remote/sessions/${SESSION_ID}/end`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({}),
+    });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(db.select).mockReset();
+    vi.mocked(db.update).mockReset();
+    getSessionWithOrgCheck.mockReset();
+    getSessionWithOrgCheck.mockResolvedValue(liveSession);
+    checkRemoteAccess.mockReturnValue(Promise.resolve({ allowed: true }));
+    revokeViewerSession.mockResolvedValue(undefined);
+    dispatchCommandToAgent.mockResolvedValue({ status: 'sent', via: 'local' });
+    app = new Hono();
+    app.route('/remote', sessionRoutes);
+  });
+
+  it('dispatches stop_desktop through the durable relay, never the socket-local send', async () => {
+    rigEndUpdate([{ id: SESSION_ID, status: 'disconnected', endedAt: new Date(), durationSeconds: 1, bytesTransferred: null }]);
+
+    const res = await endRequest();
+
+    expect(res.status).toBe(200);
+    // The agent's command socket routinely lives on another API replica, where
+    // sendCommandToAgent silently returns false and the stream keeps running.
+    expect(sendCommandToAgent).not.toHaveBeenCalled();
+    expect(dispatchCommandToAgent).toHaveBeenCalledWith('agent-1', {
+      id: `desk-stop-${SESSION_ID}`,
+      type: 'stop_desktop',
+      payload: { sessionId: SESSION_ID },
+    });
+  });
+
+  it('still answers 200 when the relay throws (teardown is best-effort, the row is already terminal)', async () => {
+    rigEndUpdate([{ id: SESSION_ID, status: 'disconnected', endedAt: new Date(), durationSeconds: 1, bytesTransferred: null }]);
+    dispatchCommandToAgent.mockRejectedValueOnce(new Error('relay down'));
+
+    const res = await endRequest();
+
+    expect(res.status).toBe(200);
+    expect(revokeViewerSession).toHaveBeenCalledWith(SESSION_ID);
+  });
+
+  it('guards the UPDATE on the live statuses so a concurrently-failed row is not overwritten', async () => {
+    const where = rigEndUpdate([]);      // lost the race: no live row matched
+    rigStatusReread([{ status: 'failed' }]);
+
+    const res = await endRequest();
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'Session is already ended', status: 'failed' });
+    // The predicate must actually carry the live-status allowlist, otherwise
+    // the "no row matched" branch above could never be reached in production.
+    const predicate = JSON.stringify(where.mock.calls[0]?.[0] ?? null);
+    for (const live of ['pending', 'connecting', 'active']) {
+      expect(predicate).toContain(live);
+    }
+    // A row that is already terminal must not be told to stop again, and above
+    // all must not have its recorded failure rewritten as an operator End.
+    expect(dispatchCommandToAgent).not.toHaveBeenCalled();
+  });
+
+  it('answers 404 when the session row is gone by the time the guarded UPDATE runs', async () => {
+    rigEndUpdate([]);
+    rigStatusReread([]);
+
+    const res = await endRequest();
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'Session not found' });
+  });
+
+  it('denies a caller narrowed away from the device site, before any write or teardown', async () => {
+    const res = await endRequest({ 'x-restrict-site': ALLOWED_SITE });
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'Access to this site denied' });
+    expect(db.update).not.toHaveBeenCalled();
+    expect(dispatchCommandToAgent).not.toHaveBeenCalled();
+    expect(revokeViewerSession).not.toHaveBeenCalled();
+  });
+
+  it('does NOT gate End on the remote-access policy — a disabled policy must never strand a live stream', async () => {
+    rigEndUpdate([{ id: SESSION_ID, status: 'disconnected', endedAt: new Date(), durationSeconds: 1, bytesTransferred: null }]);
+
+    const res = await endRequest();
+
+    expect(res.status).toBe(200);
+    expect(checkRemoteAccess).not.toHaveBeenCalled();
+    expect(dispatchCommandToAgent).toHaveBeenCalled();
   });
 });

--- a/apps/api/src/routes/remote/sessions.ts
+++ b/apps/api/src/routes/remote/sessions.ts
@@ -39,8 +39,8 @@ import {
   MAX_ACTIVE_REMOTE_SESSIONS_PER_USER
 } from './helpers';
 import { revokeViewerSession } from '../../services/viewerTokenRevocation';
-import { captureException } from '../../services/sentry';
-import { teardownDisconnectedSessions } from '../../services/remoteSessionTeardown';
+import { captureException, captureMessage } from '../../services/sentry';
+import { ACTIVE_REMOTE_SESSION_STATUSES, teardownDisconnectedSessions } from '../../services/remoteSessionTeardown';
 import { normalizeRecordingUrl } from './recordingUrl';
 import { createRemoteSession, RemoteSessionDeniedError } from '../../services/remoteSessionCreate';
 import {
@@ -1203,8 +1203,12 @@ sessionRoutes.post(
     const siteDenial = currentSessionSiteDenial(c, device);
     if (siteDenial) return siteDenial;
 
-    // Don't allow ending already ended sessions
-    if (['disconnected', 'failed'].includes(session.status)) {
+    // Both End guards — this pre-check and the UPDATE predicate below — are
+    // driven off ACTIVE_REMOTE_SESSION_STATUSES so they can never disagree.
+    // They did: the old literal here rejected only `disconnected`/`failed`,
+    // so a `denied` row (the sixth enum value) sailed past and had its
+    // terminal verdict rewritten as an operator-initiated `disconnected`.
+    if (!(ACTIVE_REMOTE_SESSION_STATUSES as readonly string[]).includes(session.status)) {
       return c.json({
         error: 'Session is already ended',
         status: session.status
@@ -1243,7 +1247,7 @@ sessionRoutes.post(
       })
       .where(and(
         eq(remoteSessions.id, sessionId),
-        inArray(remoteSessions.status, ['pending', 'connecting', 'active'])
+        inArray(remoteSessions.status, [...ACTIVE_REMOTE_SESSION_STATUSES])
       ))
       .returning();
 
@@ -1289,19 +1293,52 @@ sessionRoutes.post(
     // silently returns false — leaving the live WebRTC stream running against a
     // session the operator has already ended. `remoteSessionTeardown` has used
     // the relay for exactly this reason; End was the last stop_desktop sender
-    // still on the socket-local path. Best-effort: the row is already terminal
-    // and the viewer token already revoked, so a dispatch failure is logged,
-    // not fatal.
+    // still on the socket-local path.
+    //
+    // NOT awaited. `dispatchCommandToAgent`'s relay branch polls Redis for the
+    // delivery ack for up to RELAY_DELIVERY_DEADLINE_MS (5 s), and this handler
+    // runs inside the auth middleware's ambient request transaction — awaiting
+    // it would pin a pooled connection idle-in-transaction across that wait on
+    // an operator-triggerable route, the #1105 pool-poison class the
+    // `db_operation_inside_held_context` tripwire exists to catch. The row is
+    // already terminal and the viewer token already revoked, so delivery is
+    // best-effort by design; the trade is that the outcome cannot be reported
+    // synchronously in the response, only logged and captured.
     if (session.type === 'desktop' && device.agentId) {
-      try {
-        await dispatchCommandToAgent(device.agentId, {
-          id: `desk-stop-${sessionId}`,
-          type: 'stop_desktop',
-          payload: { sessionId },
-        });
-      } catch (err) {
+      // `dispatchCommandToAgent` RESOLVES with a status — it does not throw on
+      // a failed delivery (see DispatchOutcome in services/agentCommandRelay).
+      // A bare catch would therefore have been silent for every real
+      // non-delivery, so branch on the status explicitly.
+      void dispatchCommandToAgent(device.agentId, {
+        id: `desk-stop-${sessionId}`,
+        type: 'stop_desktop',
+        payload: { sessionId },
+      }).then((outcome) => {
+        if (outcome.status === 'sent') return;
+        const detail = outcome.status === 'infrastructure_error' ? ` (${outcome.message})` : '';
+        console.warn(
+          `[remote/sessions] stop_desktop not delivered for session ${sessionId} `
+          + `(device ${device.id}, agent ${device.agentId}): ${outcome.status}${detail}`
+        );
+        // Two literal call sites, not one with a computed code: the BREEZE-18
+        // scanner (sentryEventCodes.test.ts) requires `eventCode` be a plain
+        // string literal, and the two branches are separately actionable —
+        // one points at the relay, the other at the device.
+        if (outcome.status === 'infrastructure_error') {
+          captureMessage('remote desktop stop_desktop dispatch faulted after End', {
+            eventCode: 'remote_desktop_stop_dispatch_failed',
+            level: 'warning',
+          });
+        } else {
+          captureMessage('remote desktop stop_desktop was not delivered after End', {
+            eventCode: 'remote_desktop_stop_undelivered',
+            level: 'warning',
+          });
+        }
+      }).catch((err) => {
         console.error(`[remote/sessions] Failed to dispatch stop_desktop for session ${sessionId}:`, err);
-      }
+        captureException(err, undefined, { event_code: 'remote_desktop_stop_dispatch_failed' });
+      });
     }
 
     // Log audit event

--- a/apps/api/src/routes/remote/sessions.ts
+++ b/apps/api/src/routes/remote/sessions.ts
@@ -1176,6 +1176,15 @@ sessionRoutes.post(
 sessionRoutes.post(
   '/sessions/:id/end',
   requireScope('organization', 'partner', 'system'),
+  // Populates c.get('permissions') so the site gate below is provably live
+  // from this route's OWN chain (#1051 detector). The parent router
+  // (routes/remote/index.ts) already applies the identical gate to /remote/*,
+  // so this adds no new authority requirement and cannot lock anyone out — it
+  // states the dependency locally instead of inheriting it from a mount the
+  // file-local analyzer cannot see, and keeps the gate live if that mount ever
+  // changes. REMOTE_ACCESS rather than DEVICES_READ: it is the permission this
+  // surface already requires.
+  requirePermission(PERMISSIONS.REMOTE_ACCESS.resource, PERMISSIONS.REMOTE_ACCESS.action),
   zValidator('param', sessionIdParamSchema),
   async (c) => {
     const auth = c.get('auth');

--- a/apps/api/src/routes/remote/sessions.ts
+++ b/apps/api/src/routes/remote/sessions.ts
@@ -13,6 +13,7 @@ import {
 } from '../../db/schema';
 import { requireScope, requirePermission } from '../../middleware/auth';
 import { sendCommandToAgent } from '../agentWs';
+import { dispatchCommandToAgent } from '../../services/agentCommandRelay';
 import { checkRemoteAccess, resolveDesktopSessionPolicy } from '../../services/remoteAccessPolicy';
 import { createDesktopConnectCode, createWsTicket } from '../../services/remoteSessionAuth';
 import { getTrustedClientIp, getTrustedClientIpOrUndefined } from '../../services/clientIp';
@@ -64,15 +65,30 @@ async function resolveSiteAllowedDeviceIds(orgId: string, perms: UserPermissions
   return orgDevices.filter((d) => typeof d.siteId === 'string' && canAccessSite(perms, d.siteId)).map((d) => d.id);
 }
 
+// Site scope is an app-layer-only authz axis (`permissions.allowedSiteIds`) —
+// RLS does not defend it, and `getSessionWithOrgCheck` only org-gates. Every
+// route that acts on an existing session must therefore re-read the CURRENT
+// site ceiling rather than trust the one that held at session creation.
+// `c.get('permissions')` is populated by the `requirePermission(remote:access)`
+// gate the parent router (`routes/remote/index.ts`) applies to `/remote/*`.
+function currentSessionSiteDenial(
+  c: any,
+  device: { siteId?: string | null },
+): Response | null {
+  const perms = c.get('permissions') as UserPermissions | undefined;
+  if (perms?.allowedSiteIds && (typeof device.siteId !== 'string' || !canAccessSite(perms, device.siteId))) {
+    return c.json({ error: 'Access to this site denied' }, 403);
+  }
+  return null;
+}
+
 async function currentSessionCapabilityDenial(
   c: any,
   session: { type: string },
   device: { id: string; siteId?: string | null },
 ): Promise<Response | null> {
-  const perms = c.get('permissions') as UserPermissions | undefined;
-  if (perms?.allowedSiteIds && (typeof device.siteId !== 'string' || !canAccessSite(perms, device.siteId))) {
-    return c.json({ error: 'Access to this site denied' }, 403);
-  }
+  const siteDenial = currentSessionSiteDenial(c, device);
+  if (siteDenial) return siteDenial;
   const capability = session.type === 'desktop' ? 'webrtcDesktop' : 'remoteTools';
   const policy = await checkRemoteAccess(device.id, capability);
   if (!policy.allowed) {
@@ -1178,6 +1194,15 @@ sessionRoutes.post(
       return c.json({ error: 'Access denied' }, 403);
     }
 
+    // Re-enforce the CURRENT site ceiling: a caller narrowed away from this
+    // device's site after the session started must not be able to drive its
+    // lifecycle. Deliberately site-scope only, NOT the full
+    // `currentSessionCapabilityDenial`: End is a de-escalation, so a disabled
+    // remote-access policy must never be able to strand a live stream by
+    // blocking the one call that tears it down.
+    const siteDenial = currentSessionSiteDenial(c, device);
+    if (siteDenial) return siteDenial;
+
     // Don't allow ending already ended sessions
     if (['disconnected', 'failed'].includes(session.status)) {
       return c.json({
@@ -1199,6 +1224,14 @@ sessionRoutes.post(
       return c.json({ error: error instanceof Error ? error.message : 'Invalid recordingUrl' }, 400);
     }
 
+    // The status read above is a TOCTOU snapshot: a concurrent terminal writer
+    // (agent `failed` result, stale sweep, teardown, lease revocation) can land
+    // between the SELECT and this UPDATE. Without a status predicate the End
+    // overwrites that terminal row — turning a recorded `failed` with its
+    // errorMessage into a clean operator-initiated `disconnected`, and
+    // resetting endedAt/durationSeconds. Guard on the live states so the
+    // already-terminal case loses the write and is reported, not silently
+    // clobbered.
     const [updated] = await db
       .update(remoteSessions)
       .set({
@@ -1208,11 +1241,28 @@ sessionRoutes.post(
         bytesTransferred: body.bytesTransferred !== undefined ? BigInt(body.bytesTransferred) : session.bytesTransferred,
         recordingUrl: recordingUrl ?? session.recordingUrl
       })
-      .where(eq(remoteSessions.id, sessionId))
+      .where(and(
+        eq(remoteSessions.id, sessionId),
+        inArray(remoteSessions.status, ['pending', 'connecting', 'active'])
+      ))
       .returning();
 
     if (!updated) {
-      return c.json({ error: 'Failed to update session' }, 500);
+      // Lost the race (or the row went away). Re-read to answer with the same
+      // shape the pre-UPDATE guard above uses, so a client sees one contract
+      // regardless of which side of the race it landed on.
+      const [current] = await db
+        .select({ status: remoteSessions.status })
+        .from(remoteSessions)
+        .where(eq(remoteSessions.id, sessionId))
+        .limit(1);
+      if (!current) {
+        return c.json({ error: 'Session not found' }, 404);
+      }
+      return c.json({
+        error: 'Session is already ended',
+        status: current.status
+      }, 400);
     }
 
     // Revoke the viewer token immediately on End. Without this, a minted viewer
@@ -1233,12 +1283,25 @@ sessionRoutes.post(
     // stop the operator keeps screen + input + clipboard control after "End".
     // The agent's handleStopDesktop tears down both the direct and the
     // SYSTEM-helper sessions. Finding #2.
+    //
+    // Durable relay, NOT the socket-local send: the agent's command socket very
+    // often lives on a DIFFERENT API instance, where `sendCommandToAgent`
+    // silently returns false — leaving the live WebRTC stream running against a
+    // session the operator has already ended. `remoteSessionTeardown` has used
+    // the relay for exactly this reason; End was the last stop_desktop sender
+    // still on the socket-local path. Best-effort: the row is already terminal
+    // and the viewer token already revoked, so a dispatch failure is logged,
+    // not fatal.
     if (session.type === 'desktop' && device.agentId) {
-      sendCommandToAgent(device.agentId, {
-        id: `desk-stop-${sessionId}`,
-        type: 'stop_desktop',
-        payload: { sessionId },
-      });
+      try {
+        await dispatchCommandToAgent(device.agentId, {
+          id: `desk-stop-${sessionId}`,
+          type: 'stop_desktop',
+          payload: { sessionId },
+        });
+      } catch (err) {
+        console.error(`[remote/sessions] Failed to dispatch stop_desktop for session ${sessionId}:`, err);
+      }
     }
 
     // Log audit event

--- a/apps/api/src/services/remoteSessionTeardown.ts
+++ b/apps/api/src/services/remoteSessionTeardown.ts
@@ -10,7 +10,7 @@ import { captureException } from './sentry';
 // `failed`) are intentionally excluded: matching them (e.g. via
 // `ne(status,'disconnected')`) would also sweep historical `failed` rows and
 // overwrite their `endedAt`, corrupting session history for no benefit.
-const ACTIVE_REMOTE_SESSION_STATUSES = ['pending', 'connecting', 'active'] as const;
+export const ACTIVE_REMOTE_SESSION_STATUSES = ['pending', 'connecting', 'active'] as const;
 
 /** A session row a teardown has just marked `disconnected`. */
 type DisconnectedSession = { id: string; type: string; deviceId: string };

--- a/apps/api/src/services/sentryEventCodes.ts
+++ b/apps/api/src/services/sentryEventCodes.ts
@@ -226,6 +226,21 @@ export const SENTRY_EVENT_CODES = [
    *  is worth a look: either a real org move raced a queued act/task (benign
    *  but should be rare), or a caller is threading the wrong org. */
   'command_dispatch_cross_tenant_refused',
+
+  // --- remote desktop teardown (SEC-2026-09-05-038) ----------------------
+  /** `POST /remote/sessions/:id/end` marked the session terminal and revoked
+   *  the viewer token, but the `stop_desktop` never reached the agent (the
+   *  relay reported `offline`/`expired`/`owner_mismatch`/`indeterminate`).
+   *  The Flow-B WebRTC media/input path is peer-to-peer, so an undelivered
+   *  stop means the operator may still hold screen and input until the
+   *  revocation lease expires. Usually the device genuinely went away; a run
+   *  of these against online devices is a delivery fault. */
+  'remote_desktop_stop_undelivered',
+  /** The `stop_desktop` dispatch itself faulted — the relay returned
+   *  `infrastructure_error`, or the call threw. Distinct from
+   *  `remote_desktop_stop_undelivered` because the actionable target is the
+   *  relay (Redis/BullMQ), not the device. */
+  'remote_desktop_stop_dispatch_failed',
 ] as const;
 
 /**


### PR DESCRIPTION
## Summary

Wave 0 of the remote-desktop session-transition hardening, plus two
adjacent defects in `POST /remote/sessions/:id/end`.

**The wave-0 port turned out to be already shipped.** The task was to
port a tested partial that consolidated the desktop viewer entry points
(ws-ticket mint, connect-code mint/exchange, ICE, answer, viewer
transitions) so each revalidates the full current boundary — membership,
site ceiling, `remote:access`, device/org, session ownership/status,
remote policy — instead of only token/session ownership. Verified against
`origin/main` before writing any code: **#5474** ("bind sessions to live
credential generation; latch denials; fence dispatch to the deciding
org") already landed that work:

- `currentSessionCapabilityDenial` is applied at `/ws-ticket`,
  `/desktop-connect-code`, `/ice-servers` and `/ice`.
- `authorizeLiveRemoteSessionAccess` exists in
  `services/remoteWsAuthorization.ts` and backs both the viewer-token
  validation and the connect-code exchange in `routes/desktopWs.ts`, via
  `viewerAuthorizationDenial` / `connectExchangeAuthorizationDenial`.
- main's version is a strict superset of the partial: it also re-proves
  org and owning-partner lifecycle, partner trust, and a
  `failure-diagnostics` read mode.
- #5474 additionally **retired** the `/sessions/:id/answer` and
  `/sessions/:id/deny` user-authenticated sinks the partial had guarded,
  so two of the five transitions no longer exist to protect.
- `remote:access` is enforced for every one of these routes by the parent
  router (`routes/remote/index.ts` applies `requirePermission(remote:
  access)` + `requireMfa()` to `/remote/*`), which is also what populates
  the `c.get('permissions')` the site branch reads — so that branch is
  live, not the `#1051` dead-detector shape it superficially resembles.

`git cherry-pick 27b131a725` conflicted on all seven files for that
reason — as a re-application, not as new work. Rather than replay it, this
PR closes what the port did **not** cover.

## What this changes

**1. Coverage for the policy branch (commit 1, test-only).** The existing
denial table only exercises the SITE branch of
`currentSessionCapabilityDenial`. Its policy branch — remote access
disabled mid-session — had no test at any transition, so a regression that
dropped the `checkRemoteAccess` call would have stayed green. Adds the
mirrored table over ws-ticket, connect-code, ICE servers and ICE
candidate, with the device held *inside* the caller's allowed site so the
assertion cannot pass on the site branch by accident. Green against
unmodified route code — this is regression coverage of behaviour already
shipped, not a fix.

**2. End defect — socket-local send. Claim VERIFIED.** The handler used
`sendCommandToAgent`, which writes only to a socket owned by this API
process and silently returns false otherwise.
`services/remoteSessionTeardown.ts` has used `dispatchCommandToAgent`
since #4084 for exactly this reason, and `remoteRevocationLease` likewise;
a repo-wide sweep of `stop_desktop` senders confirms End was the **last**
one still on the socket-local path. On a multi-replica deployment an End
issued on a non-owning replica marked the row disconnected and revoked the
viewer token — which blocks reconnects and the legacy WS path — while the
Flow-B WebRTC media/input/clipboard kept flowing peer-to-peer to the
agent. The operator kept screen and input control after clicking End. Now
dispatched through the relay, awaited, best-effort (the row is already
terminal and the token already revoked, so a dispatch failure is logged,
not thrown).

**3. End defect — unguarded terminal write. Claim VERIFIED.** The
`['disconnected','failed']` check reads the row, then the UPDATE is keyed
only on `remoteSessions.id`. A concurrent terminal writer (agent `failed`
result, stale sweep, teardown, lease revocation) landing in that TOCTOU
window lost: End rewrote a recorded `failed` into a clean
operator-initiated `disconnected`, also resetting `endedAt` and
`durationSeconds`. The UPDATE now carries `status IN
('pending','connecting','active')` — the same predicate
`remoteSessionTeardown` already asserts ("targets only active statuses so
terminal failed/disconnected rows are never clobbered"). No row matched
means the race was lost: re-read and answer with the same `400 {error:
'Session is already ended', status}` shape the pre-UPDATE guard uses, so a
client sees one contract on either side of the race, or `404` if the row
is gone. This replaces the old `500 "Failed to update session"`, which was
the only way that branch could previously be reached. Reported as 400
rather than 409 to match the sibling routes in this file, which all use
`400 {error, status}` for a wrong-state session.

**4. Third gap found in the same handler.** End had **no** site-scope
check at all, so a caller narrowed away from the device's site after the
session started could still drive its lifecycle. Site scope is
app-layer-only (`permissions.allowedSiteIds`); RLS does not defend it and
`getSessionWithOrgCheck` only org-gates. `currentSessionCapabilityDenial`
is split so End reuses its site branch alone.

**Deliberate deviation from the brief:** End is *not* gated on the
remote-access policy. End is a de-escalation; gating it would let a
disabled policy strand a live stream by blocking the one call that tears
it down. A test asserts that non-gating so it reads as a decision, not an
omission.

## Residual — not in this PR

The core of SEC-2026-09-05-038 is untouched here and waits on owner
approval of the design: the start/end **ordering** race. Both offer
handlers commit their session CAS, then `await` (audit log, lease mint)
before sending `start_desktop`, so an End committed inside that window
still gets a start published behind it; and `stop_desktop` can reach the
agent *before* the stale `start_desktop`, which the agent treats as a
no-op because it holds no tombstone. #5481's fail-closed lease bounds the
exposure to roughly one watchdog tick (~5-10 s) rather than closing it.
The proposed remedy is a monotonic `desktop_start_generation` on
`remote_sessions`, one terminal-intent contract shared by every terminal
writer, and a durable agent-side fence — waves 1-5, deliberately deferred.

## Review round (applied)

Independent review on this PR found two important defects in the first
pass; both are fixed in `f964bdd`:

- **The try/catch caught nothing.** `dispatchCommandToAgent` *resolves*
  with a `DispatchOutcome` (`offline`, `expired`, `owner_mismatch`,
  `indeterminate`, `infrastructure_error`) and only throws on a
  programming fault, so every real non-delivery — the case that leaves
  the peer-to-peer stream up — was silent. Now branches on
  `outcome.status !== 'sent'`: a `console.warn` carrying session, device
  and agent ids plus the status, and a Sentry `captureMessage` under one
  of two newly registered event codes,
  `remote_desktop_stop_dispatch_failed` (relay faulted — act on
  Redis/BullMQ) or `remote_desktop_stop_undelivered` (agent never got it
  — usually the device went away). Two literal codes rather than one
  computed value because the BREEZE-18 scanner requires `eventCode` be a
  plain string literal, and the branches are separately actionable. A
  thrown dispatch keeps `captureException`, now tagged with the
  allowlisted `event_code`.
- **The awaited ack held the request transaction.** The relay branch
  polls Redis for the delivery ack for up to 5 s, and this handler runs
  inside the auth middleware's ambient request transaction — awaiting it
  pinned a pooled connection idle-in-transaction on an
  operator-triggerable route (#1105 pool-poison). The dispatch is now
  fired, not awaited, so the handler's remaining awaits are DB/Redis
  operations only and `DB_CONTEXT_HELD_WARN_MS` cannot fire on this path.
  Verified safe to outlive the request: `agentCommandRelay` and
  `agentPresence` import only `getRedis`/BullMQ and touch no DB. Chosen
  over registering End in `selfManagedDbContextRoutes`, which would mean
  restructuring the whole handler's DB work for a result the caller
  cannot use.
  **Documented consequence:** the outcome is no longer knowable
  synchronously, so the response carries **no** `stopDispatch` field —
  non-delivery reaches operators through the log line and Sentry only.

Two low findings also applied:

- `remote_session_status` has six values and the pre-UPDATE check
  rejected only `disconnected`/`failed`, so a `denied` row slipped past
  it. (Before this PR that was worse than an inconsistent 400: the
  unguarded UPDATE rewrote the denial as an operator-initiated
  `disconnected`.) Both guards now run off one list.
- That list is `ACTIVE_REMOTE_SESSION_STATUSES`, exported from
  `services/remoteSessionTeardown.ts` rather than duplicated as a
  literal.

**Follow-up, not in this PR:** the pre-existing terminal-PTY teardown gap
on this surface — `POST /:id/end` sends no `terminal_stop` and closes no
local socket for a `terminal` session, unlike
`teardownDisconnectedSessions`, so ending a terminal session from the UI
leaves the PTY running. Out of scope here (this PR is desktop-transition
work) and worth its own change with its own tests.

## Tests

Red-first throughout. 5 of the 6 original End tests fail against the
unmodified handler (relay dispatch, status guard, 404-on-missing-row,
site denial, and the policy non-gate, which currently 500s); all 5
review-round tests fail against the pre-review commit, including the
no-await test, which hangs there for the full 5 s relay deadline.

| Command | Result |
|---|---|
| `npx vitest run src/routes/remote/sessions.test.ts` | 54 passed (40 on main) |
| `npx vitest run src/routes/desktopWs src/routes/remote src/services/remoteWsAuthorization src/services/remoteSession src/services/remoteRevocationLease src/services/agentCommandRelay src/services/sentry` | 24 files, 510 passed — includes the BREEZE-18 event-code registry and the `ALLOWED_TAG_NAMES` contract suites |
| `npx tsc --noEmit -p .` (apps/api) | clean |
| `npx eslint` on all four changed files | clean |

No schema change, no new table or column — no RLS, cascade or
export-policy registration applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013auR2S4tHMtuKXj1bXD9aD

