### PR TITLE
feat(backup): file-backup fidelity — symlinks, directories, ownership, full mode bits (W02)

### DIFF
--- a/agent/internal/backup/backup.go
+++ b/agent/internal/backup/backup.go
@@ -572,7 +572,11 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 			job.FilesBackedUp = len(existing.Files)
 			job.BytesBackedUp = existing.Size
 			for _, f := range existing.Files {
-				if isReferenceEntry(f, existing.ID) {
+				// A content-less entry (symlink/dir) is never a reference —
+				// isReferenceEntry already guards on BackupPath=="", this is
+				// belt-and-suspenders against the same miscount (review
+				// finding, PR #5520).
+				if f.HasContent() && isReferenceEntry(f, existing.ID) {
 					job.ReferencedFiles++
 					job.ReferencedBytes += f.Size
 				}
@@ -1015,7 +1019,9 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 		// reference-count fields (they're result/wire-only, not manifest
 		// content — see BackupJob.ReferencedFiles's doc comment).
 		for _, f := range snapshot.Files {
-			if isReferenceEntry(f, snapshot.ID) {
+			// See the identical guard/comment above: a content-less entry
+			// is never a reference (review finding, PR #5520).
+			if f.HasContent() && isReferenceEntry(f, snapshot.ID) {
 				job.ReferencedFiles++
 				job.ReferencedBytes += f.Size
 			}

--- a/agent/internal/backup/backup.go
+++ b/agent/internal/backup/backup.go
@@ -1323,6 +1323,49 @@ type backupFile struct {
 	// copy device path every run), so keying the journal on it would make
 	// resume silently never match on Windows-with-VSS.
 	originalPath string
+	// kind is "" for a regular file, KindSymlink or KindDir for a
+	// content-less entry — see SnapshotFile.Kind. linkTarget is the verbatim
+	// os.Readlink result for a symlink. modeBits/owner are the full Unix
+	// mode (perm + setuid/setgid/sticky) and uid/gid; nil/0 on Windows.
+	kind       string
+	linkTarget string
+	modeBits   uint32
+	owner      *FileOwner
+}
+
+// fullModeBits keeps perm + setuid/setgid/sticky; everything else (type bits)
+// is dropped so the value round-trips through os.Chmod.
+func fullModeBits(mode os.FileMode) uint32 {
+	return uint32(mode & (os.ModePerm | os.ModeSetuid | os.ModeSetgid | os.ModeSticky))
+}
+
+// dirNeedsEntry decides whether a directory gets its own manifest entry:
+// empty directories always (nothing else recreates them); otherwise only
+// when mode/owner differ from the MkdirAll default the restore would apply.
+func dirNeedsEntry(info os.FileInfo, owner *FileOwner, empty bool) bool {
+	if empty {
+		return true
+	}
+	if runtime.GOOS == "windows" {
+		return false
+	}
+	if fullModeBits(info.Mode()) != 0o755 {
+		return true
+	}
+	if owner == nil {
+		return false
+	}
+	// Compare against the CURRENT PROCESS's own effective owner rather than
+	// a hardcoded 0:0: a restore's MkdirAll creates directories owned by
+	// whichever identity runs it. In production both the whole-machine
+	// backup and the bare-metal restore run as root, so this reduces to
+	// "owner != 0:0" exactly as designed. Hardcoding 0:0 instead would flag
+	// EVERY non-empty directory a non-root run walks (dev machines, and
+	// this package's own test suite on a non-root CI runner) as needing an
+	// entry, since every directory is legitimately owned by that non-root
+	// user — a false positive on every single directory, not a rare edge
+	// case.
+	return owner.UID != os.Geteuid() || owner.GID != os.Getegid()
 }
 
 func (m *BackupManager) collectBackupFiles() ([]backupFile, error) {
@@ -1370,9 +1413,23 @@ func (m *BackupManager) collectBackupFilesFromPaths(ctx context.Context, paths [
 				size:         info.Size(),
 				modTime:      info.ModTime(),
 				mode:         info.Mode(),
+				modeBits:     fullModeBits(info.Mode()),
+				owner:        fileOwner(info),
 			})
 			continue
 		}
+
+		// walkedDir/dirs/childCount defer the "does this directory need its
+		// own manifest entry" decision until after the walk: emptiness is
+		// only known once every child has been visited (see dirNeedsEntry).
+		// childCount is keyed by the ABSOLUTE parent path and counts every
+		// visited child (files, symlinks, subdirs) INCLUDING excluded ones,
+		// so an excluded-only directory still counts as non-empty and gets
+		// no entry of its own — its exclusion means "do not back this up",
+		// not "this is an empty directory worth recreating".
+		type walkedDir struct{ path, rel string }
+		var dirs []walkedDir
+		childCount := map[string]int{}
 
 		err = filepath.WalkDir(cleanRoot, func(path string, entry fs.DirEntry, walkErr error) error {
 			if err := ctx.Err(); err != nil {
@@ -1382,39 +1439,53 @@ func (m *BackupManager) collectBackupFilesFromPaths(ctx context.Context, paths [
 				errs = append(errs, fmt.Errorf("walk error for %s: %w", path, walkErr))
 				return nil
 			}
+			relPath, relErr := filepath.Rel(cleanRoot, path)
+			if relErr != nil {
+				errs = append(errs, fmt.Errorf("failed to resolve relative path for %s: %w", path, relErr))
+				return nil
+			}
+			slashRel := filepath.ToSlash(relPath)
 			if entry.IsDir() {
+				if path == cleanRoot {
+					return nil
+				}
 				// An excluded directory is skipped entirely (fs.SkipDir), not
 				// just its immediate files (#2418).
-				if excl != nil && path != cleanRoot {
-					relPath, relErr := filepath.Rel(cleanRoot, path)
-					if relErr == nil && excl.matches(filepath.ToSlash(relPath)) {
-						return fs.SkipDir
-					}
+				if excl != nil && excl.matches(slashRel) {
+					return fs.SkipDir
 				}
+				dirs = append(dirs, walkedDir{path: path, rel: slashRel})
+				childCount[filepath.Dir(path)]++
 				return nil
 			}
-			if entry.Type()&os.ModeSymlink != 0 {
-				return nil
-			}
-			info, err := entry.Info()
-			if err != nil {
-				errs = append(errs, fmt.Errorf("failed to read info for %s: %w", path, err))
-				return nil
-			}
-			if !info.Mode().IsRegular() {
-				return nil
-			}
-			relPath, err := filepath.Rel(cleanRoot, path)
-			if err != nil {
-				errs = append(errs, fmt.Errorf("failed to resolve relative path for %s: %w", path, err))
-				return nil
-			}
-			if excl.matches(filepath.ToSlash(relPath)) {
+			childCount[filepath.Dir(path)]++
+			if excl.matches(slashRel) {
 				return nil
 			}
 			snapshotPath := filepath.ToSlash(filepath.Join(rootLabel, relPath))
 			if _, exists := seen[snapshotPath]; exists {
 				log.Debug("duplicate backup path skipped", "snapshotPath", snapshotPath)
+				return nil
+			}
+			info, err := entry.Info() // Lstat semantics: never follows the link
+			if err != nil {
+				errs = append(errs, fmt.Errorf("failed to read info for %s: %w", path, err))
+				return nil
+			}
+			if entry.Type()&os.ModeSymlink != 0 {
+				target, linkErr := os.Readlink(path)
+				if linkErr != nil {
+					errs = append(errs, fmt.Errorf("failed to read symlink %s: %w", path, linkErr))
+					return nil
+				}
+				seen[snapshotPath] = struct{}{}
+				files = append(files, backupFile{
+					sourcePath: path, snapshotPath: snapshotPath, modTime: info.ModTime(), mode: info.Mode(),
+					kind: KindSymlink, linkTarget: target, owner: fileOwner(info),
+				})
+				return nil
+			}
+			if !info.Mode().IsRegular() {
 				return nil
 			}
 			seen[snapshotPath] = struct{}{}
@@ -1424,6 +1495,8 @@ func (m *BackupManager) collectBackupFilesFromPaths(ctx context.Context, paths [
 				size:         info.Size(),
 				modTime:      info.ModTime(),
 				mode:         info.Mode(),
+				modeBits:     fullModeBits(info.Mode()),
+				owner:        fileOwner(info),
 			})
 			return nil
 		})
@@ -1432,6 +1505,26 @@ func (m *BackupManager) collectBackupFilesFromPaths(ctx context.Context, paths [
 				return files, errBackupStopped
 			}
 			errs = append(errs, fmt.Errorf("backup walk failed for %s: %w", cleanRoot, err))
+		}
+
+		for _, d := range dirs {
+			info, statErr := os.Lstat(d.path)
+			if statErr != nil {
+				continue
+			}
+			owner := fileOwner(info)
+			if !dirNeedsEntry(info, owner, childCount[d.path] == 0) {
+				continue
+			}
+			snapshotPath := filepath.ToSlash(filepath.Join(rootLabel, d.rel))
+			if _, exists := seen[snapshotPath]; exists {
+				continue
+			}
+			seen[snapshotPath] = struct{}{}
+			files = append(files, backupFile{
+				sourcePath: d.path, snapshotPath: snapshotPath, modTime: info.ModTime(), mode: info.Mode(),
+				kind: KindDir, modeBits: fullModeBits(info.Mode()), owner: owner,
+			})
 		}
 	}
 

--- a/agent/internal/backup/backup_collect_test.go
+++ b/agent/internal/backup/backup_collect_test.go
@@ -1,8 +1,10 @@
 package backup
 
 import (
+	"context"
 	"os"
 	pathpkg "path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -106,7 +108,13 @@ func TestCollectBackupFiles_NonexistentPath(t *testing.T) {
 	}
 }
 
-func TestCollectBackupFiles_SkipsSymlinks(t *testing.T) {
+// W02: the walker used to drop symlinks entirely; it now records them as a
+// content-less backupFile (kind=KindSymlink, the verbatim readlink target,
+// zero size) alongside the real file — see TestCollectBackupFiles_FidelityEntries
+// for the fuller fidelity coverage (modes/owner/directories). This test keeps
+// its original, narrower shape: a real file plus one symlink to it, both
+// captured, the symlink never followed.
+func TestCollectBackupFiles_CapturesSymlinks(t *testing.T) {
 	tmpDir := t.TempDir()
 	subDir := pathpkg.Join(tmpDir, "symlink_test")
 	os.MkdirAll(subDir, 0755)
@@ -125,12 +133,23 @@ func TestCollectBackupFiles_SkipsSymlinks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("collectBackupFiles failed: %v", err)
 	}
-	// Should only include the real file, not the symlink
-	if len(files) != 1 {
-		t.Fatalf("expected 1 file (real only, symlink skipped), got %d", len(files))
+	if len(files) != 2 {
+		t.Fatalf("expected 2 entries (real file + symlink), got %d", len(files))
 	}
-	if !strings.Contains(files[0].sourcePath, "real.txt") {
-		t.Errorf("expected real.txt, got %q", files[0].sourcePath)
+	var real, link *backupFile
+	for i := range files {
+		switch {
+		case strings.Contains(files[i].sourcePath, "real.txt"):
+			real = &files[i]
+		case strings.Contains(files[i].sourcePath, "link.txt"):
+			link = &files[i]
+		}
+	}
+	if real == nil || real.kind != "" {
+		t.Fatalf("real file entry = %+v", real)
+	}
+	if link == nil || link.kind != KindSymlink || link.linkTarget != realFile || link.size != 0 {
+		t.Fatalf("symlink entry = %+v", link)
 	}
 }
 
@@ -216,5 +235,92 @@ func TestCollectBackupFiles_PathLabeling(t *testing.T) {
 	}
 	if !hasPath1 {
 		t.Error("expected a file with path_1 prefix")
+	}
+}
+
+// W02: the walker now records symlinks (never followed), empty directories,
+// and directories whose mode/owner differ from the MkdirAll default — plus
+// full mode bits and owner on every regular file (Unix only; Windows still
+// skips modeBits/owner but keeps symlinks + empty dirs).
+func TestCollectBackupFiles_FidelityEntries(t *testing.T) {
+	root := t.TempDir()
+	mk := func(rel string, mode os.FileMode) string {
+		p := pathpkg.Join(root, rel)
+		if err := os.MkdirAll(pathpkg.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chmod(p, mode); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	// os.Chmod's mode argument is a Go os.FileMode, whose setuid/setgid/sticky
+	// bits live at different bit positions than the traditional unix
+	// 04000/02000/01000 encoding — passing the traditional literal straight
+	// through (e.g. 0o4755) silently sets ONLY the permission bits (Go's
+	// syscallMode only adds the special bits when os.ModeSetuid etc. is
+	// actually set in the FileMode value). Use the os.Mode* constants so the
+	// fixture matches what a real `chmod 4755`'d file decodes to via
+	// os.Lstat (the kernel's raw st_mode IS correctly mapped back to
+	// os.ModeSetuid/Sticky on read — this quirk is Chmod-argument-only).
+	const setuidSticky = os.ModeSetuid | 0o755
+	const stickyDir = os.ModeSticky | 0o730
+	mk("usr/bin/tool", 0o755)
+	mk("usr/bin/sudo", setuidSticky)
+	if err := os.Symlink("usr/bin", pathpkg.Join(root, "bin")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	if err := os.MkdirAll(pathpkg.Join(root, "var", "empty"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(pathpkg.Join(root, "var", "spool", "cron"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(pathpkg.Join(root, "var", "spool", "cron"), stickyDir); err != nil {
+		t.Fatal(err)
+	}
+	mk("var/spool/cron/root", 0o600)
+
+	mgr := NewBackupManager(BackupConfig{Paths: []string{root}})
+	files, err := mgr.collectBackupFilesFromPaths(context.Background(), []string{root}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	byRel := map[string]backupFile{}
+	for _, f := range files {
+		rel, _ := pathpkg.Rel(root, f.sourcePath)
+		byRel[pathpkg.ToSlash(rel)] = f
+	}
+	link, ok := byRel["bin"]
+	if !ok || link.kind != KindSymlink || link.linkTarget != "usr/bin" || link.size != 0 {
+		t.Fatalf("symlink entry = %+v (ok=%v)", link, ok)
+	}
+	empty, ok := byRel["var/empty"]
+	if !ok || empty.kind != KindDir {
+		t.Fatalf("empty dir entry = %+v (ok=%v)", empty, ok)
+	}
+	if _, ok := byRel["usr"]; ok {
+		t.Error("a plain non-empty 0755 directory must not get an entry")
+	}
+	if runtime.GOOS != "windows" {
+		cron := byRel["var/spool/cron"]
+		if cron.kind != KindDir || cron.modeBits != uint32(stickyDir) {
+			t.Errorf("sticky dir entry = %+v", cron)
+		}
+		sudo := byRel["usr/bin/sudo"]
+		if sudo.modeBits != uint32(setuidSticky) || sudo.owner == nil || sudo.owner.UID != os.Getuid() {
+			t.Errorf("setuid file = %+v", sudo)
+		}
+		tool := byRel["usr/bin/tool"]
+		if tool.kind != "" || tool.modeBits != 0o755 {
+			t.Errorf("regular file = %+v", tool)
+		}
+	}
+	// Symlinked directories are recorded as links, never descended.
+	if _, ok := byRel["bin/tool"]; ok {
+		t.Error("walker followed a directory symlink")
 	}
 }

--- a/agent/internal/backup/backup_test.go
+++ b/agent/internal/backup/backup_test.go
@@ -1143,6 +1143,16 @@ func TestRunBackup_IncrementalRetentionDoesNotStrandReferencedObjects(t *testing
 	// A single unchanged file: every run after the first references its bytes
 	// from the first snapshot's prefix.
 	createTempFile(t, tmpDir, "data.txt", "unchanging content that is referenced forward")
+	// Review finding #3 (PR #5520): a content-less entry (symlink) is
+	// recreated fresh every run (never uploaded, never dedup-referenced —
+	// see decideFile's kind!="" short-circuit) and always carries an empty
+	// BackupPath. isReferenceEntry must not mistake "" for "belongs to an
+	// older snapshot's prefix" — if it did, EVERY run (including the very
+	// first, which has no previous snapshot to reference at all) would
+	// over-count ReferencedFiles by one for this entry alone.
+	if err := os.Symlink(pathpkg.Join(tmpDir, "data.txt"), pathpkg.Join(tmpDir, "link")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
 
 	provider := newMockProvider()
 	mgr := NewBackupManager(BackupConfig{
@@ -1170,6 +1180,13 @@ func TestRunBackup_IncrementalRetentionDoesNotStrandReferencedObjects(t *testing
 			t.Fatalf("run #%d produced no snapshot", i+1)
 		}
 		lastSnapshotID = job.Snapshot.ID
+		// Review finding #3: the very first run has no previous snapshot at
+		// all, so NOTHING can legitimately be a reference yet — the
+		// symlink's content-less, empty-BackupPath entry must not be
+		// miscounted as one.
+		if i == 0 && job.ReferencedFiles != 0 {
+			t.Fatalf("first run has no previous snapshot to reference, got ReferencedFiles=%d (content-less entry miscounted as a reference?)", job.ReferencedFiles)
+		}
 		// Runs after the first must reference the earlier object, not re-upload.
 		if i > 0 && job.ReferencedFiles == 0 {
 			t.Fatalf("run #%d expected to reference the unchanged file, got ReferencedFiles=0", i+1)

--- a/agent/internal/backup/bmr/bmr.go
+++ b/agent/internal/backup/bmr/bmr.go
@@ -845,8 +845,33 @@ func restoreFiles(
 		// override by (D8).
 		origPath := restoreSourcePath(file)
 		targetPath := origPath
+		overridden := false
 		if override, ok := cfg.TargetPaths[origPath]; ok {
 			targetPath = override
+			overridden = true
+		}
+
+		// A RESUMED restore must never write THROUGH an ancestor a
+		// previous (possibly interrupted) run already recreated as a
+		// symlink — see ensureNoSymlinkAncestor's doc comment (review
+		// finding, PR #5520). Gated on overridden: this guard needs a
+		// caller-established trusted staging root to walk from (see
+		// symlinkAncestorBase), which only exists when cfg.TargetPaths
+		// redirects this file. Ordinary in-place restore (no override)
+		// writes back to the file's own live original path, whose real
+		// ancestors legitimately include OS-level symlinks having nothing
+		// to do with this restore (e.g. /var -> private/var on macOS,
+		// /var/run -> /run on many Linux distros) — walking those from "/"
+		// would refuse every single in-place restore on such a system.
+		if overridden {
+			if err := ensureNoSymlinkAncestor(symlinkAncestorBase(origPath, targetPath), targetPath); err != nil {
+				addFailure("%s", err.Error())
+				if consecutiveFailures >= maxConsecutiveDownloadFailures {
+					breakerTripped = true
+					break
+				}
+				continue
+			}
 		}
 
 		// W02: a content-less entry (symlink/directory) is recreated
@@ -965,6 +990,95 @@ func restoreFiles(
 			fmt.Errorf("bmr: %d of %d files failed to restore", len(manifest.Files)-filesRestored, len(manifest.Files))
 	}
 	return filesRestored, bytesRestored, warnings, failedFiles, nil
+}
+
+// ensureNoSymlinkAncestor walks every path component strictly below base up
+// to filepath.Dir(target), lstat'ing each one, and refuses if any component
+// is a symlink. bmr's local copy of backup.EnsureNoSymlinkAncestor
+// (agent/internal/backup/restore.go) — see that function's doc comment for
+// the full rationale (a resumed restore must never write THROUGH a symlink
+// an earlier pass, or a prior interrupted run, planted under the restore
+// root; review finding, PR #5520). Kept local for the same
+// deliberately-independent-mirror reason as restoreContentlessEntry below.
+func ensureNoSymlinkAncestor(base, target string) error {
+	if base == "" {
+		// symlinkAncestorBase returns "" when it has nothing safe to
+		// derive a trusted root from — explicitly a no-op, not "walk from
+		// the filesystem root" (see its doc comment for why that would be
+		// unsafe here).
+		return nil
+	}
+	cleanBase := filepath.Clean(base)
+	dir := filepath.Clean(filepath.Dir(target))
+	rel, err := filepath.Rel(cleanBase, dir)
+	if err != nil {
+		return nil
+	}
+	if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return nil
+	}
+	cur := cleanBase
+	for _, part := range strings.Split(filepath.ToSlash(rel), "/") {
+		if part == "" || part == "." {
+			continue
+		}
+		cur = filepath.Join(cur, part)
+		info, statErr := os.Lstat(cur)
+		if statErr != nil {
+			return nil
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to write %s: ancestor %s is a symlink", target, cur)
+		}
+	}
+	return nil
+}
+
+// symlinkAncestorBase derives the trusted root ensureNoSymlinkAncestor
+// should walk from, for one overridden file being restored by
+// restoreFiles. Callers must only invoke this (and the ancestor guard it
+// feeds) when cfg.TargetPaths actually redirects this file — see the call
+// site's doc comment for why: bmr's restoreFiles has no single fixed
+// restore root the way backup.RestoreFromSnapshotContext's TargetPath is
+// (with no override it writes IN PLACE to the file's own live original
+// path, whose real ancestors legitimately include OS-level symlinks that
+// predate this restore entirely), so there is no safe base to derive or
+// walk from in that case.
+//
+// RecoveryConfig.TargetPaths overrides are a per-file map, not one shared
+// directory, but when origPath's override was built the way every real
+// caller builds one — some staging root joined with the file's own
+// original relative path (e.g. the bare-metal rebuild engine staging a
+// snapshot under one directory before applying it) — that root is
+// recovered here by stripping origPath's own relative structure off the
+// override's tail, giving exactly the shared, trusted root the ancestor
+// guard must walk from. Falls back to the filesystem root ("/") only when
+// the override doesn't follow that shape (nothing safe to derive) — the
+// guard still runs, just from "/", which is the conservative direction:
+// it may occasionally over-refuse an unusually-shaped override, never
+// under-protect one.
+func symlinkAncestorBase(origPath, targetPath string) string {
+	rel := strings.TrimPrefix(filepath.ToSlash(origPath), "/")
+	slashTarget := filepath.ToSlash(targetPath)
+	if rel != "" && strings.HasSuffix(slashTarget, rel) {
+		root := strings.TrimSuffix(slashTarget, rel)
+		root = strings.TrimSuffix(root, "/")
+		if root != "" {
+			return filepath.FromSlash(root)
+		}
+	}
+	// Nothing safe to derive — the override doesn't follow the
+	// root+relpath shape. Returning "" (rather than falling back to the
+	// real filesystem root) tells the caller to skip the ancestor guard
+	// for this file: walking from "/" is NOT a safe conservative default
+	// here the way it is in backup.RestoreFromSnapshotContext (whose
+	// TargetPath is always a restore-dedicated directory) — common
+	// top-level paths are legitimately symlinks with nothing to do with
+	// this restore (confirmed: macOS's own /var -> private/var sits in the
+	// ancestor chain of `os.TempDir()`/t.TempDir() itself), so walking from
+	// "/" would refuse restores under perfectly ordinary temp/staging
+	// directories, not just attacker-planted ones.
+	return ""
 }
 
 // restoreContentlessEntry recreates a symlink or directory manifest entry at

--- a/agent/internal/backup/bmr/bmr.go
+++ b/agent/internal/backup/bmr/bmr.go
@@ -236,7 +236,27 @@ type manifestFile struct {
 	// every BMR-restored file landed with drifted permissions/mtimes (O20).
 	Mode    uint32    `json:"mode,omitempty"`
 	ModTime time.Time `json:"modTime"`
+	// Kind, LinkTarget, ModeBits and Owner mirror backup.SnapshotFile's
+	// identically-tagged W02 fields (agent/internal/backup/snapshot.go) —
+	// same deliberately-independent-mirror rationale as OriginalPath/Mode/
+	// ModTime above. Kind is "" for a regular file (content downloaded from
+	// BackupPath) or "symlink"/"dir" for a content-less entry recreated
+	// directly by restoreFiles instead of downloaded — see HasContent.
+	Kind       string             `json:"kind,omitempty"`
+	LinkTarget string             `json:"linkTarget,omitempty"`
+	ModeBits   uint32             `json:"modeBits,omitempty"`
+	Owner      *manifestFileOwner `json:"owner,omitempty"`
 }
+
+// manifestFileOwner mirrors backup.FileOwner.
+type manifestFileOwner struct {
+	UID int `json:"uid"`
+	GID int `json:"gid"`
+}
+
+// HasContent reports whether file has an uploaded object at BackupPath —
+// mirrors backup.SnapshotFile.HasContent.
+func (file manifestFile) HasContent() bool { return file.Kind == "" }
 
 // restoreSourcePath returns the path a BMR restore should re-root file
 // under: file.OriginalPath when VSS rewrote SourcePath to a per-run
@@ -829,6 +849,24 @@ func restoreFiles(
 			targetPath = override
 		}
 
+		// W02: a content-less entry (symlink/directory) is recreated
+		// directly — never downloaded, since its BackupPath is empty (see
+		// manifestFile.HasContent's doc comment and restoreContentlessEntry
+		// below).
+		if !file.HasContent() {
+			if err := restoreContentlessEntry(targetPath, file); err != nil {
+				addFailure("recreate failed for %s: %s", origPath, err.Error())
+				if consecutiveFailures >= maxConsecutiveDownloadFailures {
+					breakerTripped = true
+					break
+				}
+				continue
+			}
+			consecutiveFailures = 0
+			filesRestored++
+			continue
+		}
+
 		dir := filepath.Dir(targetPath)
 		if mkErr := os.MkdirAll(dir, 0o750); mkErr != nil {
 			addFailure("mkdir failed for %s: %s", dir, mkErr.Error())
@@ -927,6 +965,50 @@ func restoreFiles(
 			fmt.Errorf("bmr: %d of %d files failed to restore", len(manifest.Files)-filesRestored, len(manifest.Files))
 	}
 	return filesRestored, bytesRestored, warnings, failedFiles, nil
+}
+
+// restoreContentlessEntry recreates a symlink or directory manifest entry at
+// targetPath — bmr's version of backup.RestoreContentlessEntry
+// (agent/internal/backup/restore.go), kept as a local implementation rather
+// than importing package backup, for the same "deliberately independent
+// mirror" reason manifestFile carries its own Kind/LinkTarget/ModeBits/Owner
+// fields instead of embedding backup.SnapshotFile (see manifestFile's doc
+// comment): package bmr has never otherwise depended on package backup, and
+// nothing else here needs to change that. Ownership is never reapplied by
+// this path (this restore mode — reinstall-then-recover — does not gate on
+// running as root the way the bare-metal rebuild engine's file restore
+// does); mode bits are applied best-effort via the same chmodFile seam the
+// regular-file path above uses, with setuid stripped for directories (a
+// directory legitimately setuid is vanishingly rare and this path never
+// confirms root, so it errs conservative).
+func restoreContentlessEntry(targetPath string, file manifestFile) error {
+	switch file.Kind {
+	case "symlink":
+		if mkErr := os.MkdirAll(filepath.Dir(targetPath), 0o750); mkErr != nil {
+			return mkErr
+		}
+		if existing, statErr := os.Lstat(targetPath); statErr == nil {
+			if existing.Mode()&os.ModeSymlink != 0 {
+				if cur, readErr := os.Readlink(targetPath); readErr == nil && cur == file.LinkTarget {
+					return nil // already correct (resume / idempotent replay)
+				}
+			}
+			if rmErr := os.Remove(targetPath); rmErr != nil {
+				return rmErr
+			}
+		}
+		return symlinkFile(file.LinkTarget, targetPath)
+	case "dir":
+		if mkErr := os.MkdirAll(targetPath, 0o750); mkErr != nil {
+			return mkErr
+		}
+		if file.ModeBits != 0 {
+			return chmodFile(targetPath, os.FileMode(file.ModeBits)&^os.ModeSetuid)
+		}
+		return nil
+	default:
+		return fmt.Errorf("entry %s has content; use the download path", file.SourcePath)
+	}
 }
 
 // clearReadOnly clears the owner-write bit on dst so a subsequent

--- a/agent/internal/backup/bmr/bmr_test.go
+++ b/agent/internal/backup/bmr/bmr_test.go
@@ -1164,3 +1164,71 @@ func TestRestoreFiles_RecreatesSymlinkWithoutDownload(t *testing.T) {
 	// failed) for the content-less entries' empty BackupPath — LocalProvider
 	// errors on a download of a nonexistent/empty key.
 }
+
+// Review finding #1 (PR #5520): restoreFiles must never write THROUGH an
+// ancestor that is a symlink — a prior (possibly interrupted) run may have
+// already recreated a directory-shaped manifest entry as a symlink pointing
+// outside the intended restore root. Uses a TargetPaths override so the
+// "override base" half of the guard is exercised (see
+// symlinkAncestorBase): the override is built the way a real caller (the
+// rebuild engine) builds one — stagingRoot + the original relative path —
+// so the guard can recover stagingRoot as the trusted root to walk from.
+func TestRestoreFiles_ResumedRunDoesNotWriteThroughRestoredSymlink(t *testing.T) {
+	baseDir := t.TempDir()
+	provider := providers.NewLocalProvider(baseDir)
+
+	snapshotID := "bmr-escape"
+	backupPath := filepath.ToSlash(path.Join("snapshots", snapshotID, "files", "pwned.gz"))
+	srcDir := t.TempDir()
+	srcPath := filepath.Join(srcDir, "pwned")
+	content := []byte("pwned content")
+	if err := os.WriteFile(srcPath, content, 0o644); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+	if err := provider.Upload(srcPath, backupPath); err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+
+	stagingRoot := t.TempDir()
+	outside := t.TempDir()
+	// Exactly what a resumed run sees: a prior run already recreated
+	// /escape as a symlink pointing OUTSIDE the staging root.
+	if err := os.Symlink(outside, filepath.Join(stagingRoot, "escape")); err != nil {
+		t.Fatal(err)
+	}
+
+	origPath := filepath.Join(string(filepath.Separator), "escape", "pwned")
+	manifest := &snapshotManifest{
+		ID: snapshotID,
+		Files: []manifestFile{
+			{SourcePath: origPath, BackupPath: backupPath, Size: int64(len(content))},
+		},
+		Size: int64(len(content)),
+	}
+	cfg := RecoveryConfig{
+		TargetPaths: map[string]string{
+			origPath: filepath.Join(stagingRoot, "escape", "pwned"),
+		},
+	}
+
+	filesRestored, _, warnings, failedFiles, _ := restoreFiles(context.Background(), manifest, cfg, provider)
+
+	if _, statErr := os.Stat(filepath.Join(outside, "pwned")); statErr == nil {
+		t.Fatal("restoreFiles wrote through the symlink into the outside directory")
+	}
+	if failedFiles != 1 {
+		t.Fatalf("failedFiles = %d, want 1 (warnings: %v)", failedFiles, warnings)
+	}
+	if filesRestored != 0 {
+		t.Fatalf("filesRestored = %d, want 0", filesRestored)
+	}
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w, "symlink") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("warnings = %v, want one mentioning symlink", warnings)
+	}
+}

--- a/agent/internal/backup/bmr/bmr_test.go
+++ b/agent/internal/backup/bmr/bmr_test.go
@@ -1107,3 +1107,60 @@ func TestRestoreFiles_FidelityFailureThenSuccessBothWarnUncapped(t *testing.T) {
 		t.Fatalf("warnings = %v, want exactly one mtime-reapply warning", warnings)
 	}
 }
+
+// W02: restoreFiles must recreate a symlink/directory manifest entry
+// directly (no download attempted for its empty BackupPath) — mirrors
+// backup.RestoreContentlessEntry's contract (agent/internal/backup/restore.go)
+// for BMR's independent manifestFile mirror.
+func TestRestoreFiles_RecreatesSymlinkWithoutDownload(t *testing.T) {
+	baseDir := t.TempDir()
+	provider := providers.NewLocalProvider(baseDir)
+
+	snapshotID := "bmr-symlink"
+	backupPath := filepath.ToSlash(path.Join("snapshots", snapshotID, "files", "real.gz"))
+	srcDir := t.TempDir()
+	srcPath := filepath.Join(srcDir, "real")
+	content := []byte("real file content")
+	if err := os.WriteFile(srcPath, content, 0o644); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+	if err := provider.Upload(srcPath, backupPath); err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+
+	restoreRoot := t.TempDir()
+	realTarget := filepath.Join(restoreRoot, "assure", "real")
+	linkTarget := filepath.Join(restoreRoot, "assure", "link")
+	dirTarget := filepath.Join(restoreRoot, "assure", "empty")
+
+	manifest := &snapshotManifest{
+		ID: snapshotID,
+		Files: []manifestFile{
+			{SourcePath: realTarget, BackupPath: backupPath, Size: int64(len(content))},
+			{SourcePath: linkTarget, Kind: "symlink", LinkTarget: "real"},
+			{SourcePath: dirTarget, Kind: "dir", ModeBits: 0o700},
+		},
+		Size: int64(len(content)),
+	}
+
+	filesRestored, _, warnings, failedFiles, err := restoreFiles(context.Background(), manifest, RecoveryConfig{}, provider)
+	if err != nil {
+		t.Fatalf("restoreFiles failed: %v (warnings: %v)", err, warnings)
+	}
+	if failedFiles != 0 {
+		t.Fatalf("failedFiles = %d, warnings: %v", failedFiles, warnings)
+	}
+	if filesRestored != 3 {
+		t.Fatalf("filesRestored = %d, want 3 (1 file + 1 link + 1 dir)", filesRestored)
+	}
+	got, err := os.Readlink(linkTarget)
+	if err != nil || got != "real" {
+		t.Fatalf("symlink = %q, err = %v", got, err)
+	}
+	if fi, statErr := os.Stat(dirTarget); statErr != nil || !fi.IsDir() {
+		t.Fatalf("dir missing: %v", statErr)
+	}
+	// failedFiles==0 above already proves no download was attempted (and
+	// failed) for the content-less entries' empty BackupPath — LocalProvider
+	// errors on a download of a nonexistent/empty key.
+}

--- a/agent/internal/backup/incremental.go
+++ b/agent/internal/backup/incremental.go
@@ -258,6 +258,18 @@ func referenceEntry(f backupFile, prevEntry SnapshotFile) SnapshotFile {
 // itself never needs extra reference-count fields (the manifest stays
 // clean — see the design's manifest-v2 section).
 func isReferenceEntry(entry SnapshotFile, snapshotID string) bool {
+	if entry.BackupPath == "" {
+		// A content-less entry (symlink/directory — see SnapshotFile.Kind)
+		// has no uploaded object at all, so it can never "belong to" any
+		// snapshot's prefix, older or otherwise: it is rebuilt fresh from
+		// the live filesystem on every run (decideFile always returns
+		// decideUpload for one). An empty BackupPath trivially fails the
+		// HasPrefix check below against ANY non-empty ownPrefix, which
+		// would otherwise misclassify it as a reference into some other
+		// snapshot — including on the very first run, which has no
+		// previous snapshot to reference at all (review finding, PR #5520).
+		return false
+	}
 	ownPrefix := path.Join(snapshotRootDir, snapshotID) + "/"
 	return !strings.HasPrefix(entry.BackupPath, ownPrefix)
 }

--- a/agent/internal/backup/incremental.go
+++ b/agent/internal/backup/incremental.go
@@ -209,6 +209,14 @@ func buildPreviousIndex(prev *Snapshot) map[string]SnapshotFile {
 // entry itself after the upload actually completes, exactly as before
 // incremental backups existed.
 func decideFile(f backupFile, prev map[string]SnapshotFile) (referenceDecision, SnapshotFile) {
+	if f.kind != "" {
+		// Content-less entries (symlinks/directories) are rebuilt from the
+		// live filesystem on every run — see contentlessEntry (snapshot.go).
+		// They never carry uploaded content, so "reference the old bytes"
+		// is meaningless for them regardless of what the previous manifest
+		// says about this key.
+		return decideUpload, SnapshotFile{}
+	}
 	entry, ok := prev[journalLookupKey(f)]
 	if !ok || entry.Size != f.size {
 		return decideUpload, SnapshotFile{}
@@ -235,6 +243,8 @@ func referenceEntry(f backupFile, prevEntry SnapshotFile) SnapshotFile {
 		ModTime:      f.modTime,
 		Checksum:     prevEntry.Checksum,
 		Mode:         uint32(f.mode.Perm()),
+		ModeBits:     f.modeBits,
+		Owner:        f.owner,
 	}
 }
 

--- a/agent/internal/backup/incremental_test.go
+++ b/agent/internal/backup/incremental_test.go
@@ -490,3 +490,15 @@ func TestFetchServerOwnedBase(t *testing.T) {
 		}
 	})
 }
+
+// W02: content-less entries (symlinks/directories) are rebuilt from the live
+// filesystem on every run — decideFile must never reference them, even when
+// an entry with the same key exists in the previous manifest.
+func TestDecideFile_ContentlessAlwaysUploadPath(t *testing.T) {
+	link := backupFile{sourcePath: "/bin", snapshotPath: "path_0/bin", kind: KindSymlink, linkTarget: "usr/bin"}
+	prev := map[string]SnapshotFile{"/bin": {SourcePath: "/bin", Kind: KindSymlink, LinkTarget: "usr/lib"}}
+	decision, entry := decideFile(link, prev)
+	if decision != decideUpload || entry.BackupPath != "" {
+		t.Fatalf("decision=%v entry=%+v; content-less entries never dedupe by reference", decision, entry)
+	}
+}

--- a/agent/internal/backup/incremental_test.go
+++ b/agent/internal/backup/incremental_test.go
@@ -409,6 +409,12 @@ func TestIsReferenceEntry(t *testing.T) {
 		{"own prefix -> not a reference", "snapshots/snap-A/files/f.txt.gz", "snap-A", false},
 		{"older prefix -> reference", "snapshots/snap-OLD/files/f.txt.gz", "snap-A", true},
 		{"unrelated prefix -> reference", "snapshots/snap-B/files/f.txt.gz", "snap-A", true},
+		// Review finding #3 (PR #5520): a content-less entry (symlink/dir)
+		// always has an empty BackupPath — "" trivially fails a HasPrefix
+		// check against ANY non-empty own-prefix, which used to make it
+		// look like a reference into some other snapshot. It never is one:
+		// it's rebuilt fresh every run (see decideFile's kind!="" branch).
+		{"empty backupPath (content-less entry) -> never a reference", "", "snap-A", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/agent/internal/backup/journal.go
+++ b/agent/internal/backup/journal.go
@@ -328,6 +328,12 @@ func (j *snapshotJournal) Record(f SnapshotFile) error {
 	if j == nil {
 		return nil
 	}
+	if !f.HasContent() {
+		// Content-less entries (symlinks/directories) are rebuilt from the
+		// live filesystem on every run, never resumed from a checkpoint —
+		// see contentlessEntry's doc comment (snapshot.go).
+		return nil
+	}
 	line, err := json.Marshal(f)
 	if err != nil {
 		slog.Warn("failed to encode backup journal entry", "path", j.path, "error", err.Error())

--- a/agent/internal/backup/owner_unix.go
+++ b/agent/internal/backup/owner_unix.go
@@ -1,0 +1,27 @@
+//go:build !windows
+
+package backup
+
+import (
+	"os"
+	"syscall"
+)
+
+// fileOwner returns the Unix uid/gid of info, or nil when unavailable.
+func fileOwner(info os.FileInfo) *FileOwner {
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return nil
+	}
+	return &FileOwner{UID: int(st.Uid), GID: int(st.Gid)}
+}
+
+// restoreCanApplyOwnership reports whether chown/setuid will succeed.
+func restoreCanApplyOwnership() bool { return os.Geteuid() == 0 }
+
+func applyOwner(path string, owner *FileOwner) error {
+	if owner == nil {
+		return nil
+	}
+	return os.Lchown(path, owner.UID, owner.GID)
+}

--- a/agent/internal/backup/owner_windows.go
+++ b/agent/internal/backup/owner_windows.go
@@ -1,0 +1,13 @@
+//go:build windows
+
+package backup
+
+import "os"
+
+// fileOwner is a no-op on Windows: SnapshotFile.Owner stays nil there.
+func fileOwner(_ os.FileInfo) *FileOwner { return nil }
+
+// restoreCanApplyOwnership is always false on Windows (no Unix chown).
+func restoreCanApplyOwnership() bool { return false }
+
+func applyOwner(_ string, _ *FileOwner) error { return nil }

--- a/agent/internal/backup/restore.go
+++ b/agent/internal/backup/restore.go
@@ -224,7 +224,7 @@ func RestoreFromSnapshotContext(ctx context.Context, provider providers.BackupPr
 			result.FilesFailed++
 			result.FailedFiles = append(result.FailedFiles, displayPath)
 			result.Warnings = append(result.Warnings, err.Error())
-			os.Remove(stagingFile)
+			_ = os.Remove(stagingFile)
 			slog.Warn("refusing to restore through a symlinked ancestor", "target", targetPath, "error", err.Error())
 			continue
 		}

--- a/agent/internal/backup/restore.go
+++ b/agent/internal/backup/restore.go
@@ -264,9 +264,7 @@ func RestoreFromSnapshotContext(ctx context.Context, provider providers.BackupPr
 		// chown failure must not fail an otherwise-good restore, but IS
 		// surfaced in result.Warnings so the caller knows fidelity was
 		// partial.
-		for _, w := range applyEntryMetadata(targetPath, file, applyOwnership) {
-			result.Warnings = append(result.Warnings, w)
-		}
+		result.Warnings = append(result.Warnings, applyEntryMetadata(targetPath, file, applyOwnership)...)
 		if !applyOwnership && (file.Owner != nil || file.ModeBits&uint32(os.ModeSetuid|os.ModeSetgid|os.ModeSticky) != 0) {
 			warnOwnership()
 		}

--- a/agent/internal/backup/restore.go
+++ b/agent/internal/backup/restore.go
@@ -81,14 +81,40 @@ func RestoreFromSnapshotContext(ctx context.Context, provider providers.BackupPr
 		return result, fmt.Errorf("download manifest: %w", err)
 	}
 
-	// 2. Filter files by selected paths
+	// 2. Filter files by selected paths, then split into the three restore
+	// passes: regular files (today's download loop), symlinks, and
+	// directories — directories go last so their modes/owners are applied
+	// AFTER every child has been written (see the two passes appended below
+	// the main loop).
 	files := filterFiles(snapshot.Files, cfg.SelectedPaths)
-	if len(files) == 0 {
+	var contentFiles, links, dirs []SnapshotFile
+	for _, f := range files {
+		switch f.Kind {
+		case KindSymlink:
+			links = append(links, f)
+		case KindDir:
+			dirs = append(dirs, f)
+		default:
+			contentFiles = append(contentFiles, f)
+		}
+	}
+	files = contentFiles
+	total := int64(len(contentFiles) + len(links) + len(dirs))
+	if total == 0 {
 		result.Status = "completed"
 		if len(cfg.SelectedPaths) > 0 {
 			result.Warnings = append(result.Warnings, "no files matched the selected paths")
 		}
 		return result, nil
+	}
+	applyOwnership := restoreCanApplyOwnership()
+	ownershipWarned := false
+	warnOwnership := func() {
+		if applyOwnership || ownershipWarned {
+			return
+		}
+		ownershipWarned = true
+		result.Warnings = append(result.Warnings, "ownership/special mode bits not applied: restore is not running as root")
 	}
 
 	// 3. Create or reuse a deterministic staging directory so partial restores
@@ -116,7 +142,6 @@ func RestoreFromSnapshotContext(ctx context.Context, provider providers.BackupPr
 		}
 	}
 
-	total := int64(len(files))
 	if progressFn != nil {
 		progressFn("starting", 0, total, fmt.Sprintf("restoring %d files", total))
 	}
@@ -233,27 +258,17 @@ func RestoreFromSnapshotContext(ctx context.Context, provider providers.BackupPr
 			continue
 		}
 
-		// Reapply the original Unix permissions + modification time so a restore
-		// is faithful (executables keep +x, 0600 secrets stay private, mtimes
-		// are preserved). Both are best-effort: a chmod/chtimes failure must not
-		// fail an otherwise-good restore, but IS surfaced in result.Warnings so
-		// the caller knows fidelity was partial. Pre-checksum manifests carry
-		// Mode==0 (leave the OS default) / a zero ModTime (leave as written).
-		if file.Mode != 0 {
-			if err := os.Chmod(targetPath, os.FileMode(file.Mode).Perm()); err != nil {
-				result.Warnings = append(result.Warnings,
-					fmt.Sprintf("could not reapply mode %o to %s: %v", os.FileMode(file.Mode).Perm(), displayPath, err))
-				slog.Warn("failed to reapply file mode on restore",
-					"target", targetPath, "mode", file.Mode, "error", err.Error())
-			}
+		// Reapply the original Unix permissions/full mode bits, owner (root
+		// only) and modification time so a restore is faithful — see
+		// applyEntryMetadata's doc comment. Best-effort: a chmod/chtimes/
+		// chown failure must not fail an otherwise-good restore, but IS
+		// surfaced in result.Warnings so the caller knows fidelity was
+		// partial.
+		for _, w := range applyEntryMetadata(targetPath, file, applyOwnership) {
+			result.Warnings = append(result.Warnings, w)
 		}
-		if !file.ModTime.IsZero() {
-			if err := os.Chtimes(targetPath, file.ModTime, file.ModTime); err != nil {
-				result.Warnings = append(result.Warnings,
-					fmt.Sprintf("could not reapply mtime to %s: %v", displayPath, err))
-				slog.Warn("failed to reapply mtime on restore",
-					"target", targetPath, "error", err.Error())
-			}
+		if !applyOwnership && (file.Owner != nil || file.ModeBits&uint32(os.ModeSetuid|os.ModeSetgid|os.ModeSticky) != 0) {
+			warnOwnership()
 		}
 
 		result.FilesRestored++
@@ -270,6 +285,40 @@ func RestoreFromSnapshotContext(ctx context.Context, provider providers.BackupPr
 			progressFn("restoring", current, total,
 				fmt.Sprintf("restored: %s", displayPath))
 		}
+	}
+
+	// Pass 2: symlinks (parents exist now, from the file pass above). Pass
+	// 3: directories last so their modes/owners are applied after every
+	// child (file or symlink) has been written under them.
+	base := cfg.TargetPath
+	if base == "" {
+		base = filepath.Join(os.TempDir(), "breeze-restore")
+	}
+	contained := func(p string) bool {
+		cleaned, cleanBase := filepath.Clean(p), filepath.Clean(base)
+		return cleaned == cleanBase || strings.HasPrefix(cleaned, cleanBase+string(filepath.Separator))
+	}
+	for _, entry := range append(links, dirs...) {
+		if checkCancelled() {
+			return result, nil
+		}
+		displayPath := restoreSourcePath(entry)
+		targetPath := resolveTargetPath(cfg.TargetPath, displayPath)
+		if !contained(targetPath) {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("path traversal blocked: %s", displayPath))
+			result.FilesFailed++
+			continue
+		}
+		if err := RestoreContentlessEntry(targetPath, entry, applyOwnership); err != nil {
+			result.FilesFailed++
+			result.FailedFiles = append(result.FailedFiles, displayPath)
+			result.Warnings = append(result.Warnings, fmt.Sprintf("could not recreate %s: %v", displayPath, err))
+			continue
+		}
+		if !applyOwnership && entry.Owner != nil {
+			warnOwnership()
+		}
+		result.FilesRestored++
 	}
 
 	if checkCancelled() {
@@ -563,4 +612,81 @@ func copyAndDelete(src, dst string) error {
 func stagingFileName(backupPath string) string {
 	sum := sha256.Sum256([]byte(backupPath))
 	return hex.EncodeToString(sum[:]) + ".gz"
+}
+
+// applyEntryMetadata reapplies mode bits (full ModeBits when known, else the
+// perm-only Mode), owner (root only) and mtime to a restored regular file.
+func applyEntryMetadata(targetPath string, entry SnapshotFile, applyOwnership bool) []string {
+	var warnings []string
+	switch {
+	case entry.ModeBits != 0:
+		if err := os.Chmod(targetPath, os.FileMode(entry.ModeBits)); err != nil {
+			warnings = append(warnings, fmt.Sprintf("could not reapply mode %o to %s: %v", entry.ModeBits, entry.SourcePath, err))
+		}
+	case entry.Mode != 0:
+		if err := os.Chmod(targetPath, os.FileMode(entry.Mode).Perm()); err != nil {
+			warnings = append(warnings, fmt.Sprintf("could not reapply mode %o to %s: %v", os.FileMode(entry.Mode).Perm(), entry.SourcePath, err))
+		}
+	}
+	if applyOwnership {
+		if err := applyOwner(targetPath, entry.Owner); err != nil {
+			warnings = append(warnings, fmt.Sprintf("could not reapply owner to %s: %v", entry.SourcePath, err))
+		}
+	}
+	if !entry.ModTime.IsZero() {
+		if err := os.Chtimes(targetPath, entry.ModTime, entry.ModTime); err != nil {
+			warnings = append(warnings, fmt.Sprintf("could not reapply mtime to %s: %v", entry.SourcePath, err))
+		}
+	}
+	return warnings
+}
+
+// RestoreContentlessEntry recreates a symlink or directory entry at
+// targetPath. Exported because bmr's reinstall-then-recover path and the
+// rebuild engine (W03) recreate the same entries.
+func RestoreContentlessEntry(targetPath string, entry SnapshotFile, applyOwnership bool) error {
+	switch entry.Kind {
+	case KindSymlink:
+		if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+			return err
+		}
+		if existing, err := os.Lstat(targetPath); err == nil {
+			if existing.Mode()&os.ModeSymlink != 0 {
+				if cur, rerr := os.Readlink(targetPath); rerr == nil && cur == entry.LinkTarget {
+					break // already correct (resume)
+				}
+			}
+			if err := os.Remove(targetPath); err != nil {
+				return err
+			}
+		}
+		if err := os.Symlink(entry.LinkTarget, targetPath); err != nil {
+			return err
+		}
+	case KindDir:
+		if err := os.MkdirAll(targetPath, 0o755); err != nil {
+			return err
+		}
+		mode := os.FileMode(entry.ModeBits)
+		if !applyOwnership {
+			// A non-root owner may legitimately set sticky/setgid on its own
+			// directory (Linux/macOS both permit this); setuid on a
+			// directory is vanishingly rare and this path can't confirm
+			// root, so it errs conservative and strips only that bit.
+			mode &^= os.ModeSetuid
+		}
+		if entry.ModeBits != 0 {
+			if err := os.Chmod(targetPath, mode); err != nil {
+				return err
+			}
+		}
+	default:
+		return fmt.Errorf("entry %s has content; use the file path", entry.SourcePath)
+	}
+	if applyOwnership {
+		if err := applyOwner(targetPath, entry.Owner); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/agent/internal/backup/restore.go
+++ b/agent/internal/backup/restore.go
@@ -117,6 +117,17 @@ func RestoreFromSnapshotContext(ctx context.Context, provider providers.BackupPr
 		result.Warnings = append(result.Warnings, "ownership/special mode bits not applied: restore is not running as root")
 	}
 
+	// base is the restore root every write must stay under — computed once
+	// here (rather than only inside the links/dirs pass below) because the
+	// file loop needs it too: a RESUMED restore's file pass must never
+	// write THROUGH an ancestor a previous (possibly interrupted) run
+	// already recreated as a symlink pointing outside base (review finding,
+	// PR #5520). See EnsureNoSymlinkAncestor.
+	base := cfg.TargetPath
+	if base == "" {
+		base = filepath.Join(os.TempDir(), "breeze-restore")
+	}
+
 	// 3. Create or reuse a deterministic staging directory so partial restores
 	// can resume on a subsequent attempt.
 	stagingDir, err := restoreStagingDir(cfg)
@@ -195,10 +206,6 @@ func RestoreFromSnapshotContext(ctx context.Context, provider providers.BackupPr
 
 		// Path containment check
 		{
-			base := cfg.TargetPath
-			if base == "" {
-				base = filepath.Join(os.TempDir(), "breeze-restore")
-			}
 			cleaned := filepath.Clean(targetPath)
 			cleanBase := filepath.Clean(base)
 			if !strings.HasPrefix(cleaned, cleanBase+string(filepath.Separator)) && cleaned != cleanBase {
@@ -207,6 +214,19 @@ func RestoreFromSnapshotContext(ctx context.Context, provider providers.BackupPr
 				os.Remove(stagingFile)
 				continue
 			}
+		}
+
+		// A RESUMED restore's file pass must never write THROUGH an
+		// ancestor a previous run already recreated as a symlink — lexical
+		// containment above only checks the literal target path string, not
+		// what the filesystem actually resolves through to get there.
+		if err := EnsureNoSymlinkAncestor(base, targetPath); err != nil {
+			result.FilesFailed++
+			result.FailedFiles = append(result.FailedFiles, displayPath)
+			result.Warnings = append(result.Warnings, err.Error())
+			os.Remove(stagingFile)
+			slog.Warn("refusing to restore through a symlinked ancestor", "target", targetPath, "error", err.Error())
+			continue
 		}
 
 		// Create target directory
@@ -288,10 +308,6 @@ func RestoreFromSnapshotContext(ctx context.Context, provider providers.BackupPr
 	// Pass 2: symlinks (parents exist now, from the file pass above). Pass
 	// 3: directories last so their modes/owners are applied after every
 	// child (file or symlink) has been written under them.
-	base := cfg.TargetPath
-	if base == "" {
-		base = filepath.Join(os.TempDir(), "breeze-restore")
-	}
 	contained := func(p string) bool {
 		cleaned, cleanBase := filepath.Clean(p), filepath.Clean(base)
 		return cleaned == cleanBase || strings.HasPrefix(cleaned, cleanBase+string(filepath.Separator))
@@ -305,6 +321,16 @@ func RestoreFromSnapshotContext(ctx context.Context, provider providers.BackupPr
 		if !contained(targetPath) {
 			result.Warnings = append(result.Warnings, fmt.Sprintf("path traversal blocked: %s", displayPath))
 			result.FilesFailed++
+			continue
+		}
+		// Same ancestor-symlink guard as the file pass above: MkdirAll (for
+		// a KindDir entry) or the symlink branch's own MkdirAll(Dir(...))
+		// would otherwise happily traverse THROUGH an ancestor a previous
+		// run already turned into a symlink (review finding, PR #5520).
+		if err := EnsureNoSymlinkAncestor(base, targetPath); err != nil {
+			result.FilesFailed++
+			result.FailedFiles = append(result.FailedFiles, displayPath)
+			result.Warnings = append(result.Warnings, err.Error())
 			continue
 		}
 		if err := RestoreContentlessEntry(targetPath, entry, applyOwnership); err != nil {
@@ -612,6 +638,48 @@ func stagingFileName(backupPath string) string {
 	return hex.EncodeToString(sum[:]) + ".gz"
 }
 
+// EnsureNoSymlinkAncestor walks every path component strictly below base up
+// to filepath.Dir(target), lstat'ing each one, and refuses if any component
+// is a symlink. A resumed restore's file pass must never write THROUGH a
+// symlink an earlier pass (or a prior interrupted run) planted under the
+// restore root — e.g. a manifest entry recreating /etc as a symlink to an
+// absolute path outside base, followed by a file entry for /etc/passwd:
+// lexical containment on the final target path alone does not catch this,
+// since MkdirAll/os.Create happily follow an intermediate symlink to wherever
+// it points (review finding, PR #5520). A missing component is fine —
+// MkdirAll creates it fresh — so this stops (returns nil) at the first
+// component that doesn't exist yet; deeper components can't exist either.
+func EnsureNoSymlinkAncestor(base, target string) error {
+	cleanBase := filepath.Clean(base)
+	dir := filepath.Clean(filepath.Dir(target))
+	rel, err := filepath.Rel(cleanBase, dir)
+	if err != nil {
+		// Can't relate (e.g. different volumes on Windows) — nothing this
+		// helper can walk; the caller's own containment check governs.
+		return nil
+	}
+	if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		// dir IS base (nothing below it to check) or isn't under base at
+		// all — out of this helper's scope.
+		return nil
+	}
+	cur := cleanBase
+	for _, part := range strings.Split(filepath.ToSlash(rel), "/") {
+		if part == "" || part == "." {
+			continue
+		}
+		cur = filepath.Join(cur, part)
+		info, statErr := os.Lstat(cur)
+		if statErr != nil {
+			return nil
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to write %s: ancestor %s is a symlink", target, cur)
+		}
+	}
+	return nil
+}
+
 // applyEntryMetadata reapplies mode bits (full ModeBits when known, else the
 // perm-only Mode), owner (root only) and mtime to a restored regular file.
 func applyEntryMetadata(targetPath string, entry SnapshotFile, applyOwnership bool) []string {
@@ -649,10 +717,16 @@ func RestoreContentlessEntry(targetPath string, entry SnapshotFile, applyOwnersh
 			return err
 		}
 		if existing, err := os.Lstat(targetPath); err == nil {
-			if existing.Mode()&os.ModeSymlink != 0 {
-				if cur, rerr := os.Readlink(targetPath); rerr == nil && cur == entry.LinkTarget {
-					break // already correct (resume)
-				}
+			// Only an existing SYMLINK may be replaced (the resume case: a
+			// prior run already planted the correct link, or a stale one
+			// pointing somewhere else). Anything else — a regular file, a
+			// real directory — must be refused, never silently destroyed
+			// (review finding, PR #5520).
+			if existing.Mode()&os.ModeSymlink == 0 {
+				return fmt.Errorf("%s exists and is not a symlink", targetPath)
+			}
+			if cur, rerr := os.Readlink(targetPath); rerr == nil && cur == entry.LinkTarget {
+				break // already correct (resume)
 			}
 			if err := os.Remove(targetPath); err != nil {
 				return err

--- a/agent/internal/backup/restore_test.go
+++ b/agent/internal/backup/restore_test.go
@@ -1082,3 +1082,120 @@ func TestRestore_RecreatesSymlinksDirsAndModes(t *testing.T) {
 		}
 	}
 }
+
+// Review finding #1 (PR #5520): a resumed restore's file pass must never
+// write THROUGH an ancestor that is a symlink. A prior (possibly
+// interrupted) run may have already recreated a directory-shaped manifest
+// entry as a symlink pointing outside the restore target; the NEXT run's
+// file pass must refuse to write underneath it rather than following it
+// out. Simulates exactly what a resumed run sees: the symlink is already on
+// disk BEFORE RestoreFromSnapshot is called.
+func TestRestore_ResumedRunDoesNotWriteThroughRestoredSymlink(t *testing.T) {
+	provider, snapshotID := setupRestoreTestSnapshot(t, map[string]string{"good.txt": "fine"})
+
+	manifestKey := filepath.ToSlash(filepath.Join("snapshots", snapshotID, "manifest.json"))
+	tmp := filepath.Join(t.TempDir(), "m.json")
+	if err := provider.Download(manifestKey, tmp); err != nil {
+		t.Fatal(err)
+	}
+	var snap Snapshot
+	data, _ := os.ReadFile(tmp)
+	if err := json.Unmarshal(data, &snap); err != nil {
+		t.Fatal(err)
+	}
+
+	outside := t.TempDir()
+
+	// Upload the "pwned" object the attacker-shaped file entry would
+	// download — if the symlink-ancestor guard fails, this content lands at
+	// outside/pwned instead of being refused.
+	pwnedSrc := filepath.Join(t.TempDir(), "pwned")
+	if err := os.WriteFile(pwnedSrc, []byte("pwned content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pwnedBackupPath := filepath.ToSlash(filepath.Join("snapshots", snapshotID, "files", "pwned.gz"))
+	if err := provider.Upload(pwnedSrc, pwnedBackupPath); err != nil {
+		t.Fatal(err)
+	}
+
+	snap.Files = append(snap.Files,
+		SnapshotFile{SourcePath: "/escape", Kind: KindSymlink, LinkTarget: outside, ModTime: time.Now().UTC()},
+		SnapshotFile{SourcePath: "/escape/pwned", BackupPath: pwnedBackupPath, Size: int64(len("pwned content")), ModTime: time.Now().UTC()},
+	)
+	snap.FormatVersion = manifestFormatFidelity
+	out, _ := json.Marshal(snap)
+	if err := os.WriteFile(tmp, out, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := provider.Upload(tmp, manifestKey); err != nil {
+		t.Fatal(err)
+	}
+
+	target := t.TempDir()
+	// Exactly what a resumed run sees: a prior run already recreated
+	// /escape as a symlink pointing OUTSIDE the restore target.
+	if err := os.Symlink(outside, filepath.Join(target, "escape")); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := RestoreFromSnapshot(provider, RestoreConfig{SnapshotID: snapshotID, TargetPath: target}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, statErr := os.Stat(filepath.Join(outside, "pwned")); statErr == nil {
+		t.Fatal("restore wrote through the symlink into the outside directory")
+	}
+
+	failed := false
+	for _, f := range res.FailedFiles {
+		if f == "/escape/pwned" {
+			failed = true
+		}
+	}
+	if !failed {
+		t.Errorf("FailedFiles = %v, want /escape/pwned listed", res.FailedFiles)
+	}
+	warned := false
+	for _, w := range res.Warnings {
+		if strings.Contains(w, "symlink") {
+			warned = true
+		}
+	}
+	if !warned {
+		t.Errorf("Warnings = %v, want one mentioning symlink", res.Warnings)
+	}
+
+	// The unrelated good file must still restore fine.
+	if _, statErr := os.Stat(filepath.Join(target, "original", "good.txt")); statErr != nil {
+		t.Errorf("good.txt not restored: %v", statErr)
+	}
+}
+
+// Review finding #2 (PR #5520): RestoreContentlessEntry's symlink branch
+// must never silently destroy an existing regular file (or directory) at
+// targetPath — only an existing SYMLINK may be replaced (the resume case:
+// re-running a completed pass 2 that already planted the correct or a
+// stale link). Anything else must be refused, not clobbered.
+func TestRestoreContentlessEntry_RefusesToReplaceRegularFile(t *testing.T) {
+	dir := t.TempDir()
+	targetPath := filepath.Join(dir, "important")
+	if err := os.WriteFile(targetPath, []byte("do not delete me"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	entry := SnapshotFile{SourcePath: "/important", Kind: KindSymlink, LinkTarget: "elsewhere"}
+	err := RestoreContentlessEntry(targetPath, entry, false)
+	if err == nil || !strings.Contains(err.Error(), "not a symlink") {
+		t.Fatalf("err = %v, want an error mentioning \"not a symlink\"", err)
+	}
+
+	// The regular file must be untouched.
+	data, statErr := os.ReadFile(targetPath)
+	if statErr != nil {
+		t.Fatalf("regular file was removed: %v", statErr)
+	}
+	if string(data) != "do not delete me" {
+		t.Fatalf("regular file content changed: %q", data)
+	}
+}

--- a/agent/internal/backup/restore_test.go
+++ b/agent/internal/backup/restore_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -999,5 +1000,85 @@ func TestMoveFile_ReadOnlyDestination_CopyFallbackPath(t *testing.T) {
 	}
 	if _, statErr := os.Stat(src); !os.IsNotExist(statErr) {
 		t.Fatalf("src still exists after copyAndDelete: err=%v", statErr)
+	}
+}
+
+// W02: restore recreates symlinks and directories from content-less
+// manifest entries (never downloaded), and reapplies full mode bits
+// (including setuid, which a non-root owner CAN set on its own file) —
+// ownership itself is root-gated and produces one summary warning when not
+// running as root.
+func TestRestore_RecreatesSymlinksDirsAndModes(t *testing.T) {
+	provider, snapshotID := setupRestoreTestSnapshot(t, map[string]string{"usr/bin/tool": "#!/bin/sh\n"})
+	// Append content-less entries + a setuid file to the manifest.
+	manifestKey := filepath.ToSlash(filepath.Join("snapshots", snapshotID, "manifest.json"))
+	tmp := filepath.Join(t.TempDir(), "m.json")
+	if err := provider.Download(manifestKey, tmp); err != nil {
+		t.Fatal(err)
+	}
+	var snap Snapshot
+	data, _ := os.ReadFile(tmp)
+	if err := json.Unmarshal(data, &snap); err != nil {
+		t.Fatal(err)
+	}
+	for i := range snap.Files {
+		snap.Files[i].ModeBits = uint32(os.ModeSetuid | 0o755) // setuid tool
+	}
+	snap.Files = append(snap.Files,
+		SnapshotFile{SourcePath: "/original/bin", Kind: KindSymlink, LinkTarget: "usr/bin", ModTime: time.Now().UTC()},
+		SnapshotFile{SourcePath: "/original/var/empty", Kind: KindDir, ModeBits: 0o700, ModTime: time.Now().UTC()},
+		SnapshotFile{SourcePath: "/original/usr/bin", Kind: KindDir, ModeBits: uint32(os.ModeSticky | 0o777), ModTime: time.Now().UTC()},
+	)
+	snap.FormatVersion = manifestFormatFidelity
+	out, _ := json.Marshal(snap)
+	if err := os.WriteFile(tmp, out, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := provider.Upload(tmp, manifestKey); err != nil {
+		t.Fatal(err)
+	}
+
+	target := t.TempDir()
+	res, err := RestoreFromSnapshot(provider, RestoreConfig{SnapshotID: snapshotID, TargetPath: target}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != "completed" || res.FilesFailed != 0 {
+		t.Fatalf("result = %+v", res)
+	}
+	if res.FilesRestored != 4 {
+		t.Errorf("FilesRestored = %d, want 4 (1 file + 1 link + 2 dirs)", res.FilesRestored)
+	}
+	link := filepath.Join(target, "original", "bin")
+	if got, err := os.Readlink(link); err != nil || got != "usr/bin" {
+		t.Fatalf("symlink = %q err=%v", got, err)
+	}
+	if fi, err := os.Stat(filepath.Join(target, "original", "var", "empty")); err != nil || !fi.IsDir() {
+		t.Fatalf("empty dir missing: %v", err)
+	}
+	if runtime.GOOS != "windows" {
+		fi, _ := os.Stat(filepath.Join(target, "original", "var", "empty"))
+		if fi.Mode().Perm() != 0o700 {
+			t.Errorf("empty dir perm = %o", fi.Mode().Perm())
+		}
+		fi, _ = os.Stat(filepath.Join(target, "original", "usr", "bin"))
+		if fi.Mode()&os.ModeSticky == 0 || fi.Mode().Perm() != 0o777 {
+			t.Errorf("usr/bin mode = %v, want sticky 1777 applied AFTER files were placed", fi.Mode())
+		}
+		fi, _ = os.Stat(filepath.Join(target, "original", "usr", "bin", "tool"))
+		if fi.Mode()&os.ModeSetuid == 0 {
+			t.Errorf("tool mode = %v, want setuid", fi.Mode())
+		}
+		if os.Geteuid() != 0 {
+			found := false
+			for _, w := range res.Warnings {
+				if strings.Contains(w, "not running as root") {
+					found = true
+				}
+			}
+			if len(res.Warnings) > 0 && !found {
+				t.Errorf("warnings = %v", res.Warnings)
+			}
+		}
 	}
 }

--- a/agent/internal/backup/snapshot.go
+++ b/agent/internal/backup/snapshot.go
@@ -271,6 +271,20 @@ func snapshotNeedsFidelityFormat(files []SnapshotFile) bool {
 	return false
 }
 
+// contentlessEntry builds the manifest entry for a symlink or directory:
+// nothing is uploaded, so BackupPath/Checksum/Size stay empty.
+func contentlessEntry(f backupFile) SnapshotFile {
+	return SnapshotFile{
+		SourcePath:   f.sourcePath,
+		OriginalPath: f.originalPath,
+		ModTime:      f.modTime,
+		Kind:         f.kind,
+		LinkTarget:   f.linkTarget,
+		ModeBits:     f.modeBits,
+		Owner:        f.owner,
+	}
+}
+
 // journalEntryKey returns the checkpoint-journal resume key for f:
 // OriginalPath when set (VSS rewrote SourcePath to a per-run-ephemeral
 // shadow-copy device path), else SourcePath itself (the common, non-VSS
@@ -849,6 +863,15 @@ func createSnapshotWithProgress(ctx context.Context, provider providers.BackupPr
 		if err := ctx.Err(); err != nil {
 			return abortStopped()
 		}
+		if file.kind != "" {
+			// Content-less entry (symlink/directory): nothing to upload,
+			// dedupe against, or checkpoint — see contentlessEntry's doc
+			// comment. Rebuilt from the live filesystem on every run.
+			snapshot.Files = append(snapshot.Files, contentlessEntry(file))
+			markDone(1, 0)
+			emitProgress(false)
+			continue
+		}
 		if entry, ok := resumedFiles[journalLookupKey(file)]; ok {
 			// Already uploaded in a prior (interrupted) run with identical
 			// (size, modTime) — filesDone/bytesDone already reflect this
@@ -1029,6 +1052,8 @@ func createSnapshotWithProgress(ctx context.Context, provider providers.BackupPr
 			ModTime:      file.modTime,
 			Checksum:     checksum,
 			Mode:         uint32(file.mode.Perm()),
+			ModeBits:     file.modeBits,
+			Owner:        file.owner,
 		}
 		snapshot.Files = append(snapshot.Files, entry)
 		snapshot.Size += file.size

--- a/agent/internal/backup/snapshot.go
+++ b/agent/internal/backup/snapshot.go
@@ -198,6 +198,25 @@ type Snapshot struct {
 // `omitempty`: manifests written before this change carry neither, and the
 // verify/restore paths treat an absent value as "not available" and fall back
 // gracefully (size-only check on verify, default mode on restore).
+// Entry kinds. "" (the zero value) is a regular file with uploaded content.
+const (
+	KindSymlink = "symlink"
+	KindDir     = "dir"
+)
+
+// manifestFormatFidelity marks a manifest that carries content-less entries
+// (symlinks/directories) and/or ownership — bare-metal W02. Readers older
+// than W02 ignore the fields and would try to download an empty BackupPath
+// for a symlink; every reader in this repo checks HasContent() first.
+const manifestFormatFidelity = 3
+
+// FileOwner is the Unix owner of an entry. Nil on Windows and in manifests
+// written before W02.
+type FileOwner struct {
+	UID int `json:"uid"`
+	GID int `json:"gid"`
+}
+
 type SnapshotFile struct {
 	SourcePath string    `json:"sourcePath"`
 	BackupPath string    `json:"backupPath"`
@@ -226,6 +245,30 @@ type SnapshotFile struct {
 	// of SourcePath when present, since SourcePath is a fresh per-run
 	// shadow-copy device path under VSS and would never match across runs.
 	OriginalPath string `json:"originalPath,omitempty"`
+	// Kind is "" for a regular file (content uploaded at BackupPath),
+	// KindSymlink or KindDir for content-less entries (BackupPath, Checksum
+	// and Size are empty/zero). LinkTarget is the verbatim readlink result.
+	Kind       string `json:"kind,omitempty"`
+	LinkTarget string `json:"linkTarget,omitempty"`
+	// ModeBits is the full Unix mode (perm + setuid/setgid/sticky), unlike
+	// Mode which is perm-only for compatibility. 0 = unknown.
+	ModeBits uint32 `json:"modeBits,omitempty"`
+	// Owner is nil when unknown (Windows, pre-W02 manifests).
+	Owner *FileOwner `json:"owner,omitempty"`
+}
+
+// HasContent reports whether the entry has an uploaded object at BackupPath.
+func (f SnapshotFile) HasContent() bool { return f.Kind == "" }
+
+// snapshotNeedsFidelityFormat reports whether files contains any
+// content-less entry or ownership — see manifestFormatFidelity.
+func snapshotNeedsFidelityFormat(files []SnapshotFile) bool {
+	for _, f := range files {
+		if f.Kind != "" || f.Owner != nil {
+			return true
+		}
+	}
+	return false
 }
 
 // journalEntryKey returns the checkpoint-journal resume key for f:
@@ -1002,6 +1045,15 @@ func createSnapshotWithProgress(ctx context.Context, provider providers.BackupPr
 	// state even if the last file(s) landed inside the throttle window and
 	// were swallowed by the `!force` check above.
 	emitProgress(true)
+
+	// W02: a manifest carrying any content-less entry (symlink/dir) or
+	// ownership is stamped formatVersion 3 so an older reader knows to
+	// check HasContent() before trusting BackupPath — see
+	// manifestFormatFidelity's doc comment. Overrides the incremental
+	// format-2 stamp above when both apply.
+	if snapshotNeedsFidelityFormat(snapshot.Files) {
+		snapshot.FormatVersion = manifestFormatFidelity
+	}
 
 	if len(snapshot.Files) == 0 {
 		return nil, errors.Join(errs...)

--- a/agent/internal/backup/snapshot_test.go
+++ b/agent/internal/backup/snapshot_test.go
@@ -2304,3 +2304,55 @@ func TestSnapshotFile_HasContentAndFormatVersion(t *testing.T) {
 		t.Errorf("symlink JSON = %s", data)
 	}
 }
+
+// W02: content-less entries (symlinks/directories) are never uploaded,
+// never sha256'd, and never opened from disk at all — the manifest carries
+// their metadata straight from backupFile, and the manifest is stamped
+// formatVersion 3.
+func TestCreateSnapshot_ContentlessEntriesNotUploaded(t *testing.T) {
+	provider := newMockProvider()
+	now := time.Now().UTC()
+	tmp := t.TempDir()
+	hosts := pathpkg.Join(tmp, "hosts")
+	if err := os.WriteFile(hosts, []byte("abc"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	files := []backupFile{
+		{sourcePath: hosts, snapshotPath: "path_0/etc/hosts", size: 3, modTime: now, mode: 0o644, modeBits: 0o644, owner: &FileOwner{UID: 0, GID: 0}},
+		{sourcePath: "/bin", snapshotPath: "path_0/bin", modTime: now, mode: os.ModeSymlink | 0o777, kind: KindSymlink, linkTarget: "usr/bin"},
+		{sourcePath: "/var/empty", snapshotPath: "path_0/var/empty", modTime: now, mode: os.ModeDir | 0o755, kind: KindDir, modeBits: 0o755},
+	}
+
+	snap, err := CreateSnapshot(provider, files)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(provider.uploadCalls) != 2 { // hosts + manifest.json
+		t.Fatalf("upload calls = %+v, want file + manifest only", provider.uploadCalls)
+	}
+	if snap.FormatVersion != manifestFormatFidelity || len(snap.Files) != 3 {
+		t.Fatalf("snapshot = %+v", snap)
+	}
+	var link, dir SnapshotFile
+	for _, f := range snap.Files {
+		switch f.Kind {
+		case KindSymlink:
+			link = f
+		case KindDir:
+			dir = f
+		}
+	}
+	if link.BackupPath != "" || link.Checksum != "" || link.LinkTarget != "usr/bin" || link.Size != 0 {
+		t.Errorf("symlink entry = %+v", link)
+	}
+	if dir.BackupPath != "" || dir.ModeBits != 0o755 {
+		t.Errorf("dir entry = %+v", dir)
+	}
+	var stored Snapshot
+	if err := json.Unmarshal(provider.files[path.Join("snapshots", snap.ID, "manifest.json")], &stored); err != nil {
+		t.Fatal(err)
+	}
+	if stored.FormatVersion != 3 || stored.Files[0].Owner == nil {
+		t.Errorf("stored manifest = %+v", stored)
+	}
+}

--- a/agent/internal/backup/snapshot_test.go
+++ b/agent/internal/backup/snapshot_test.go
@@ -2269,3 +2269,38 @@ func TestPublishSystemState_SkipsUploadingSymlinkArtifacts(t *testing.T) {
 		t.Errorf("published symlink artifact LinkTarget = %q, want %q", gotLink.LinkTarget, "real.txt")
 	}
 }
+
+// W02: SnapshotFile gains content-less entry kinds (symlink/dir), full mode
+// bits and owner — HasContent() distinguishes an uploaded-content entry
+// from a content-less one, and snapshotNeedsFidelityFormat decides whether
+// the manifest must be stamped formatVersion 3. Plain-file JSON must stay
+// byte-identical to before these fields existed (omitempty).
+func TestSnapshotFile_HasContentAndFormatVersion(t *testing.T) {
+	file := SnapshotFile{SourcePath: "/etc/hosts", BackupPath: "snapshots/s/files/path_0/etc/hosts", Size: 3}
+	link := SnapshotFile{SourcePath: "/bin", Kind: KindSymlink, LinkTarget: "usr/bin"}
+	dir := SnapshotFile{SourcePath: "/var/empty", Kind: KindDir, ModeBits: 0o755}
+	if !file.HasContent() || link.HasContent() || dir.HasContent() {
+		t.Fatalf("HasContent: file=%v link=%v dir=%v", file.HasContent(), link.HasContent(), dir.HasContent())
+	}
+	if snapshotNeedsFidelityFormat([]SnapshotFile{file}) {
+		t.Error("plain files must not force format 3")
+	}
+	if !snapshotNeedsFidelityFormat([]SnapshotFile{file, link}) {
+		t.Error("a symlink entry must force format 3")
+	}
+	owned := SnapshotFile{SourcePath: "/home/x", BackupPath: "k", Owner: &FileOwner{UID: 1000, GID: 1000}}
+	if !snapshotNeedsFidelityFormat([]SnapshotFile{owned}) {
+		t.Error("an owner must force format 3")
+	}
+	// JSON shape: new fields are omitted when zero so old manifests stay byte-identical.
+	data, _ := json.Marshal(file)
+	for _, k := range []string{"kind", "linkTarget", "modeBits", "owner"} {
+		if strings.Contains(string(data), `"`+k+`"`) {
+			t.Errorf("plain file JSON leaked %s: %s", k, data)
+		}
+	}
+	data, _ = json.Marshal(link)
+	if !strings.Contains(string(data), `"kind":"symlink"`) || !strings.Contains(string(data), `"linkTarget":"usr/bin"`) {
+		t.Errorf("symlink JSON = %s", data)
+	}
+}

--- a/agent/internal/backup/verify.go
+++ b/agent/internal/backup/verify.go
@@ -87,6 +87,11 @@ func VerifyIntegrity(provider providers.BackupProvider, snapshotID string) (*Ver
 
 	// Verify each file by downloading through the provider
 	for _, file := range snapshot.Files {
+		if !file.HasContent() {
+			// Content-less entry (symlink/directory): no uploaded object to
+			// verify — see SnapshotFile.HasContent's doc comment.
+			continue
+		}
 		tempFile, err := os.CreateTemp("", "verify-file-*")
 		if err != nil {
 			result.FilesFailed++
@@ -229,6 +234,16 @@ func TestRestore(provider providers.BackupProvider, snapshotID string, progressF
 	// Restore each file
 	total := len(snapshot.Files)
 	for i, file := range snapshot.Files {
+		if !file.HasContent() {
+			// Content-less entry (symlink/directory): no uploaded object to
+			// restore — see SnapshotFile.HasContent's doc comment. The real
+			// restore path (restore.go) recreates these directly; a test
+			// restore's job is only to prove the uploaded OBJECTS round-trip.
+			if progressFn != nil {
+				progressFn(i+1, total)
+			}
+			continue
+		}
 		destPath := resolveTargetPath(restoreDir, restoreSourcePath(file))
 		if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
 			result.FilesFailed++

--- a/agent/internal/backup/verify_test.go
+++ b/agent/internal/backup/verify_test.go
@@ -364,3 +364,55 @@ func TestTestRestore_UsesOriginalPathUnderVSS(t *testing.T) {
 		t.Fatalf("TestRestore destination = %q, want it to end with the original path's relative structure %q", downloadedTo, wantSuffix)
 	}
 }
+
+// W02: VerifyIntegrity must never try to download a content-less entry's
+// (empty) BackupPath — it has no object to verify, so it's simply skipped;
+// only the one real file counts toward FilesVerified.
+func TestVerifyIntegrity_SkipsContentlessEntries(t *testing.T) {
+	provider := newMockProvider()
+	fileKey := "snapshots/s1/files/path_0/etc/hosts"
+	provider.files[fileKey] = []byte("abc")
+	manifest := Snapshot{ID: "s1", FormatVersion: manifestFormatFidelity, Files: []SnapshotFile{
+		{SourcePath: "/etc/hosts", BackupPath: fileKey, Size: 3, Checksum: "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"},
+		{SourcePath: "/bin", Kind: KindSymlink, LinkTarget: "usr/bin"},
+		{SourcePath: "/var/empty", Kind: KindDir},
+	}}
+	data, _ := json.Marshal(manifest)
+	provider.files["snapshots/s1/manifest.json"] = data
+
+	res, err := VerifyIntegrity(provider, "s1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != "passed" || res.FilesVerified != 1 || res.FilesFailed != 0 {
+		t.Fatalf("result = %+v", res)
+	}
+}
+
+// W02: TestRestore shares VerifyIntegrity's content-less-entry blind spot —
+// without this fix every fidelity-format snapshot would permanently report
+// "partial" from TestRestore (the symlink/dir entries' empty BackupPath
+// downloads would fail) even though a real restore handles them fine (see
+// restore.go's separate symlink/dir passes, Task 4). Not explicitly in the
+// plan's Task 3 scope, but the identical fix on the identical file for the
+// identical reason.
+func TestTestRestore_SkipsContentlessEntries(t *testing.T) {
+	provider := newMockProvider()
+	fileKey := "snapshots/s2/files/path_0/etc/hosts"
+	provider.files[fileKey] = []byte("abc")
+	manifest := Snapshot{ID: "s2", FormatVersion: manifestFormatFidelity, Files: []SnapshotFile{
+		{SourcePath: "/etc/hosts", BackupPath: fileKey, Size: 3},
+		{SourcePath: "/bin", Kind: KindSymlink, LinkTarget: "usr/bin"},
+		{SourcePath: "/var/empty", Kind: KindDir},
+	}}
+	data, _ := json.Marshal(manifest)
+	provider.files["snapshots/s2/manifest.json"] = data
+
+	res, err := TestRestore(provider, "s2", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != "passed" || res.FilesVerified != 1 || res.FilesFailed != 0 {
+		t.Fatalf("result = %+v", res)
+	}
+}

--- a/apps/api/src/jobs/backupEnqueue.ts
+++ b/apps/api/src/jobs/backupEnqueue.ts
@@ -114,6 +114,10 @@ export interface ProcessResultsResult {
       backupPath: string;
       size?: number;
       modTime?: string;
+      // W02 fidelity: content-less entries (symlinks/directories) — see
+      // backupSnapshotFileResultSchema / backupSnapshotFileSchema.
+      kind?: 'symlink' | 'dir';
+      linkTarget?: string;
     }>;
   };
   error?: string;

--- a/apps/api/src/jobs/queueSchemas.test.ts
+++ b/apps/api/src/jobs/queueSchemas.test.ts
@@ -316,6 +316,30 @@ describe('backupProcessResultSchema — system_image manifest passthrough', () =
   });
 });
 
+describe('backupProcessResultSchema — W02 content-less entries (symlink/dir)', () => {
+  it('accepts symlink/dir file entries with an empty backupPath and rejects an empty backupPath on a plain file', () => {
+    const result = backupProcessResultSchema.parse({
+      status: 'completed',
+      snapshotId: 'snap-1',
+      snapshot: {
+        id: 'snap-1',
+        files: [
+          { sourcePath: '/bin', backupPath: '', kind: 'symlink', linkTarget: 'usr/bin' },
+          { sourcePath: '/var/empty', backupPath: '', kind: 'dir' },
+          { sourcePath: '/etc/hosts', backupPath: 'snapshots/snap-1/files/path_0/etc/hosts' },
+        ],
+      },
+    });
+    expect(result.snapshot?.files?.[0]).toMatchObject({ kind: 'symlink', linkTarget: 'usr/bin' });
+    expect(() =>
+      backupProcessResultSchema.parse({
+        status: 'completed',
+        snapshot: { id: 'snap-1', files: [{ sourcePath: '/x', backupPath: '' }] },
+      }),
+    ).toThrow();
+  });
+});
+
 describe('backupProcessResultSchema — incremental dedup + partial-success passthrough', () => {
   // Regression guard: same failure mode as the system_image block above — the
   // strict schema (and the WS enqueue call) lacked referencedFiles/

--- a/apps/api/src/jobs/queueSchemas.ts
+++ b/apps/api/src/jobs/queueSchemas.ts
@@ -13,17 +13,29 @@ export const queueActorMetaSchema = z.object({
   source: z.string().min(1),
 }).strict();
 
-const backupSnapshotFileSchema = z.object({
-  sourcePath: z.string().min(1),
-  // Stable pre-VSS path (D12): under a shadow copy sourcePath is the
-  // \\?\GLOBALROOT device path; originalPath is the real C:\ path the index,
-  // browse tree and selective restore must use. Strict schema: a missing entry
-  // here silently drops the whole result and leaves the job running forever.
-  originalPath: z.string().min(1).optional(),
-  backupPath: z.string().min(1),
-  size: z.number().nonnegative().optional(),
-  modTime: z.string().min(1).optional(),
-}).strict();
+const backupSnapshotFileSchema = z
+  .object({
+    sourcePath: z.string().min(1),
+    // Stable pre-VSS path (D12): under a shadow copy sourcePath is the
+    // \\?\GLOBALROOT device path; originalPath is the real C:\ path the index,
+    // browse tree and selective restore must use. Strict schema: a missing entry
+    // here silently drops the whole result and leaves the job running forever.
+    originalPath: z.string().min(1).optional(),
+    // W02: content-less entries (symlinks/directories) never upload an
+    // object, so backupPath is '' for those — see the superRefine below.
+    backupPath: z.string(),
+    size: z.number().nonnegative().optional(),
+    modTime: z.string().min(1).optional(),
+    // W02 fidelity — mirrors resultSchemas.ts's backupSnapshotFileResultSchema.
+    kind: z.enum(['symlink', 'dir']).optional(),
+    linkTarget: z.string().optional(),
+  })
+  .strict()
+  .superRefine((file, ctx) => {
+    if (!file.kind && file.backupPath.length === 0) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['backupPath'], message: 'backupPath is required for file entries' });
+    }
+  });
 
 const backupSnapshotSummarySchema = z.object({
   id: z.string().min(1),

--- a/apps/api/src/routes/backup/resultSchemas.test.ts
+++ b/apps/api/src/routes/backup/resultSchemas.test.ts
@@ -250,3 +250,18 @@ describe('backupCommandResultSchema — snapshot file manifest originalPath (D12
     expect(parsed.snapshot?.files?.[0]?.sourcePath).toBe('/home/user/file.txt');
   });
 });
+
+describe('backupCommandResultSchema — W02 content-less entries (symlink/dir)', () => {
+  it('accepts symlink/dir entries with an empty backupPath and rejects an empty backupPath on a file', () => {
+    const parsed = backupCommandResultSchema.parse({
+      snapshotId: 's',
+      snapshot: { id: 's', files: [
+        { sourcePath: '/bin', backupPath: '', kind: 'symlink', linkTarget: 'usr/bin' },
+        { sourcePath: '/var/empty', backupPath: '', kind: 'dir' },
+        { sourcePath: '/etc/hosts', backupPath: 'snapshots/s/files/path_0/etc/hosts', size: 3 },
+      ] },
+    });
+    expect(parsed.snapshot?.files?.[0]).toMatchObject({ kind: 'symlink', linkTarget: 'usr/bin' });
+    expect(() => backupCommandResultSchema.parse({ snapshotId: 's', snapshot: { id: 's', files: [{ sourcePath: '/x', backupPath: '' }] } })).toThrow();
+  });
+});

--- a/apps/api/src/routes/backup/resultSchemas.ts
+++ b/apps/api/src/routes/backup/resultSchemas.ts
@@ -5,24 +5,40 @@ import { z } from 'zod';
 // `.datetime()` (which requires Z) rejects them — and one bad modTime fails the
 // whole result parse, so total_size / snapshot id / file_count silently never
 // get recorded (F13). Accept an offset.
-export const backupSnapshotFileResultSchema = z.object({
-  sourcePath: z.string().min(1),
-  backupPath: z.string().min(1),
-  size: z.number().int().nonnegative().optional(),
-  modTime: z.string().datetime({ offset: true }).optional(),
-  // D12: on a Windows VSS-backed run, `sourcePath` is the transient shadow-copy
-  // device path the agent actually read from
-  // (\\?\GLOBALROOT\Device\HarddiskVolumeShadowCopyN\...) — it stops resolving
-  // the moment the shadow copy is released and has no display/selection value.
-  // `originalPath` is the stable, user-facing path (e.g. C:\assure\src\x) the
-  // agent also matches selective-restore selections against. When present, it
-  // is what gets indexed into backup_snapshot_files.source_path (see
-  // backupResultPersistence.ts) so the browse tree and selective-restore
-  // validation both operate on a path that is still meaningful after the
-  // snapshot completes. Omitted by non-Windows / non-VSS runs, where
-  // sourcePath already IS the display/selection path.
-  originalPath: z.string().min(1).optional(),
-});
+export const backupSnapshotFileResultSchema = z
+  .object({
+    sourcePath: z.string().min(1),
+    // W02: content-less entries (symlinks/directories) never upload an
+    // object, so backupPath is '' for those — see the superRefine below,
+    // which still requires a non-empty backupPath for an ordinary file
+    // (kind unset).
+    backupPath: z.string(),
+    size: z.number().int().nonnegative().optional(),
+    modTime: z.string().datetime({ offset: true }).optional(),
+    // D12: on a Windows VSS-backed run, `sourcePath` is the transient shadow-copy
+    // device path the agent actually read from
+    // (\\?\GLOBALROOT\Device\HarddiskVolumeShadowCopyN\...) — it stops resolving
+    // the moment the shadow copy is released and has no display/selection value.
+    // `originalPath` is the stable, user-facing path (e.g. C:\assure\src\x) the
+    // agent also matches selective-restore selections against. When present, it
+    // is what gets indexed into backup_snapshot_files.source_path (see
+    // backupResultPersistence.ts) so the browse tree and selective-restore
+    // validation both operate on a path that is still meaningful after the
+    // snapshot completes. Omitted by non-Windows / non-VSS runs, where
+    // sourcePath already IS the display/selection path.
+    originalPath: z.string().min(1).optional(),
+    // W02 fidelity: content-less entries (symlinks/directories) carry no
+    // object. kind is "" (omitted) for an ordinary file; "symlink"/"dir"
+    // marks an entry the agent recreates directly rather than downloads —
+    // see agent/internal/backup/snapshot.go's SnapshotFile.Kind.
+    kind: z.enum(['symlink', 'dir']).optional(),
+    linkTarget: z.string().optional(),
+  })
+  .superRefine((file, ctx) => {
+    if (!file.kind && file.backupPath.length === 0) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['backupPath'], message: 'backupPath is required for file entries' });
+    }
+  });
 
 export const backupSnapshotResultSchema = z.object({
   id: z.string().min(1),

--- a/apps/api/src/services/backupResultPersistence.test.ts
+++ b/apps/api/src/services/backupResultPersistence.test.ts
@@ -1106,6 +1106,15 @@ describe('backup result persistence', () => {
               backupPath: 'snapshots/snap-1/files/x.gz',
               size: 123,
             },
+            // W02: a content-less entry (symlink) carries an empty backupPath —
+            // it must still be indexed (browse/selective-restore need to know
+            // it exists), just with backupPath persisted as ''.
+            {
+              sourcePath: '/bin',
+              backupPath: '',
+              kind: 'symlink',
+              linkTarget: 'usr/bin',
+            },
           ],
         },
       },
@@ -1116,6 +1125,10 @@ describe('backup result persistence', () => {
       expect.objectContaining({
         sourcePath: 'C:\\assure\\src\\x',
         backupPath: 'snapshots/snap-1/files/x.gz',
+      }),
+      expect.objectContaining({
+        sourcePath: '/bin',
+        backupPath: '',
       }),
     ]);
   });

--- a/apps/api/src/services/backupResultPersistence.ts
+++ b/apps/api/src/services/backupResultPersistence.ts
@@ -1199,7 +1199,10 @@ export async function applyBackupCommandResultToJob(params: {
         // selection. No separate column for the raw shadow path: it has no
         // browsing/restore value once the shadow copy is released.
         sourcePath: file.originalPath ?? file.sourcePath,
-        backupPath: file.backupPath,
+        // W02: content-less entries (symlinks/directories) carry no object —
+        // backupPath is '' for those (backup_snapshot_files.backup_path is
+        // NOT NULL, so '' is the documented value, not a missing column).
+        backupPath: file.backupPath ?? '',
         size: file.size ?? null,
         modifiedAt: file.modTime ? new Date(file.modTime) : null,
       }));


### PR DESCRIPTION
## Summary

Wave 02 of bare-metal recovery (#5493): makes the `file` backup mode capture and restore what a bootable OS tree needs — symbolic links, empty/non-default directories, file ownership, and full setuid/setgid/sticky mode bits — none of which the walker/restore path handled before this PR.

### Per-task changes

**Task 1 — Manifest fields, `HasContent`, format version** (`agent/internal/backup/snapshot.go`)
- `SnapshotFile` gains `Kind`, `LinkTarget`, `ModeBits`, `Owner *FileOwner` (all `omitempty`).
- `HasContent() bool` — `true` iff `Kind == ""`.
- `manifestFormatFidelity = 3`; `snapshotNeedsFidelityFormat` stamps it onto `Snapshot.FormatVersion` when any entry has `Kind != ""` or `Owner != nil`.

**Task 2 — Walker captures symlinks, directories, ownership, full mode bits** (`agent/internal/backup/backup.go`, new `owner_unix.go`/`owner_windows.go`)
- `collectBackupFilesFromPaths` no longer skips symlinks: each becomes a content-less `backupFile{kind: KindSymlink, linkTarget, owner}` (never followed/descended).
- Directories are recorded (content-less) when empty, non-`0755` perm, non-default owner, or setgid/sticky set (Unix); Windows records only empty directories.
- `fullModeBits` keeps perm + setuid/setgid/sticky (as Go's `os.FileMode` bit layout, not traditional octal — see Deviations).
- `fileOwner`/`applyOwner`/`restoreCanApplyOwnership` are platform seams (`owner_unix.go`, `owner_windows.go`).

**Task 3 — Upload/dedupe/journal/verify skip content-less entries** (`snapshot.go`, `incremental.go`, `journal.go`, `verify.go`, `bmr/bmr.go`)
- Upload loop: a `kind != ""` entry is appended straight to the manifest via `contentlessEntry` — no `sha256File`, no upload, no journal `Record`.
- `decideFile` always returns `decideUpload` for a content-less entry (never referenced from a prior snapshot).
- `journal.Record` and `VerifyIntegrity`'s download loop both skip `!HasContent()` entries.
- Also fixed `TestRestore` (same file, same blind spot, not in the plan's explicit Task 3 scope — see Deviations).
- `bmr.go`'s `restoreFiles` (reinstall-then-recover path) recreates content-less entries directly via a new local `restoreContentlessEntry`, never downloading an empty `BackupPath`.

**Task 4 — Restore recreates symlinks/directories, reapplies owner + full mode bits** (`restore.go`)
- `RestoreFromSnapshotContext` splits the manifest into 3 passes: files (unchanged), then symlinks, then directories (mode/owner applied last, after every child is written).
- `RestoreContentlessEntry(targetPath, entry, applyOwnership)` (exported for W03) recreates a symlink or directory.
- `applyEntryMetadata` reapplies full `ModeBits` (falling back to perm-only `Mode` for older manifests) + owner (root-gated) + mtime.
- Ownership/setuid/setgid/sticky are applied only when `os.Geteuid() == 0`; otherwise ONE summary warning `"ownership/special mode bits not applied: restore is not running as root"` per restore run.

**Task 5 — Server accepts content-less entries** (`apps/api/src/routes/backup/resultSchemas.ts`, `apps/api/src/jobs/queueSchemas.ts`, `apps/api/src/jobs/backupEnqueue.ts`, `apps/api/src/services/backupResultPersistence.ts`)
- Both file-item schemas: `backupPath: z.string().min(1)` → `z.string()`, plus `kind: z.enum(['symlink','dir']).optional()` and `linkTarget: z.string().optional()`.
- `.superRefine` requires a non-empty `backupPath` only when `kind` is unset (an ordinary file).
- Persistence writes `backupPath: file.backupPath ?? ''` (the DB column is `NOT NULL`; `''` is the documented value for a content-less row).

### Manifest field additions (verbatim, per plan's Global Constraints)

```go
Kind       string     `json:"kind,omitempty"`       // "" regular file, "symlink", "dir"
LinkTarget string     `json:"linkTarget,omitempty"` // verbatim os.Readlink result
ModeBits   uint32      `json:"modeBits,omitempty"`   // full Unix mode (perm + setuid/setgid/sticky); 0 = unknown
Owner      *FileOwner `json:"owner,omitempty"`       // nil = unknown (Windows, pre-W02 manifests)

type FileOwner struct {
    UID int `json:"uid"`
    GID int `json:"gid"`
}
```
Content-less entries have `BackupPath == ""`, `Checksum == ""`, `Size == 0`. `Snapshot.FormatVersion` becomes `3` only when the manifest carries a `Kind != ""` or `Owner != nil` entry; the existing perm-only `Mode` keeps being written for every regular file exactly as before.

### Backward compatibility

A snapshot containing only plain files never sets `Kind`/`LinkTarget`/`ModeBits`/`Owner` on any entry, so `snapshotNeedsFidelityFormat` returns `false` and `FormatVersion` is left exactly as today (2 for incremental, omitted for a plain full backup). Every new struct field is `omitempty`, so the JSON for a plain-file manifest is **byte-identical** to pre-W02 output — proven directly by `TestSnapshotFile_HasContentAndFormatVersion`'s JSON-shape assertions (`snapshot_test.go`). Every reader (journal, verify, restore, bmr) checks `HasContent()`/`Kind` before trusting `BackupPath`, so an old manifest with no content-less entries flows through every path unchanged.

### Test commands run (this session)

```
cd agent && go test -race -count=1 ./internal/backup/...
  ok  github.com/breeze-rmm/agent/internal/backup           3.165s
  ok  github.com/breeze-rmm/agent/internal/backup/bmr       4.748s
  ok  github.com/breeze-rmm/agent/internal/backup/hyperv    2.179s
  ok  github.com/breeze-rmm/agent/internal/backup/mssql     1.418s
  ok  github.com/breeze-rmm/agent/internal/backup/providers 2.661s
  ok  github.com/breeze-rmm/agent/internal/backup/systemstate 3.223s
  ok  github.com/breeze-rmm/agent/internal/backup/vss       2.893s

cd agent && go test -race -count=1 ./...
  76/76 packages ok (0 FAIL) — full agent module, all platforms' build-tagged code included

GOOS=windows go vet ./internal/backup/...
  3 findings, all in internal/backup/vss/vss_windows.go (unsafe.Pointer) — PRE-EXISTING, file
  untouched by this PR (confirmed via `git diff origin/main`), unrelated to W02.
GOOS=darwin go vet ./internal/backup/...
  clean (exit 0)

golangci-lint run ./internal/backup/...
  38 issues total, all in files/lines this PR did not touch (confirmed via git diff hunks) except
  one S1011 (staticcheck) on restore.go's new applyEntryMetadata call site — fixed in this PR.

cd apps/api && npx vitest run src/routes/backup/resultSchemas.test.ts src/jobs/queueSchemas.test.ts \
  src/services/backupResultPersistence.test.ts src/routes/backup/snapshots.test.ts
  Test Files  4 passed (4)
       Tests  147 passed (147)

cd apps/api && NODE_OPTIONS="--max-old-space-size=8192" npx tsc --noEmit -p .
  exit 0 (clean; default heap OOMs on this project regardless of this PR — see Deviations)
```

### Deviations from the plan

1. **`dirNeedsEntry` owner comparison** (`backup.go`) — the plan's literal `owner.UID != 0 || owner.GID != 0` flags **every** non-empty directory a non-root process walks (this repo's own test suite runs as a non-root user both on this macOS worktree and on the `ubuntu-latest` `test-agent` CI runner — neither is root). Changed to compare against the **current process's own** `os.Geteuid()/os.Getegid()` instead of a hardcoded `0:0`. In production, both backup and the bare-metal restore engine run as root, so this is exactly equivalent to the original "owner != 0:0" check; in a non-root dev/CI run it avoids flagging every directory the test fixtures themselves created. Without this fix, `TestCollectBackupFiles_Excludes` (5 subtests) and others in the pre-existing suite fail/hang.
2. **Test fixtures' `os.Chmod` mode literals** (`backup_collect_test.go`, `restore_test.go`) — `os.Chmod`'s argument is `os.FileMode`, whose setuid/setgid/sticky bits live at different bit positions than the traditional `04000`/`02000`/`01000` unix encoding. Passing the plan's literal `0o4755`/`0o1730` straight to `os.Chmod` silently sets **only** the permission bits (verified: Go's `syscallMode` only adds the special bits when `os.ModeSetuid` etc. is actually set in the `FileMode` value). Fixtures now use `os.ModeSetuid | 0o755` / `os.ModeSticky | 0o730` etc., matching how a real `chmod 4755`'d file decodes via `os.Lstat` (the kernel's raw `st_mode` IS correctly mapped back to `os.ModeSetuid`/`Sticky` on read — this quirk is `Chmod`-argument-only). Assertions updated to compare against the same Go-encoded constants rather than traditional-octal literals.
3. **`TestCollectBackupFiles_SkipsSymlinks` → `TestCollectBackupFiles_CapturesSymlinks`** — this pre-existing test asserted the OLD behavior (symlinks dropped); rewritten to assert the new capture-not-skip contract, same file/region.
4. **`TestRestore` (verify.go) also skips content-less entries** — not explicitly listed in the plan's Task 3 file/scope, but it shares `VerifyIntegrity`'s exact blind spot (downloads every `file.BackupPath`, which is `""` for a content-less entry). Without this fix, every fidelity-format snapshot would permanently report `"partial"` from a test restore even though a real restore handles those entries fine.
5. **bmr's `manifestFile` mirror stays independent, not `backup.RestoreContentlessEntry`** — chose the plan's other explicitly-offered option: added `Kind`/`LinkTarget`/`ModeBits`/`Owner` + `HasContent()` to bmr's own `manifestFile` mirror and a local `restoreContentlessEntry`, rather than importing `package backup`. Matches the file's existing, heavily-documented "deliberately independent mirror" precedent for `OriginalPath`/`Mode`/`ModTime` — package `bmr` has never otherwise depended on package `backup` in production code (only its _test_ file does, to build fixtures). Ownership is never applied on this path (kept the plan's literal `applyOwnership=false` for bmr); mode bits applied best-effort via the existing `chmodFile` seam, stripping setuid for directories (mirrors Task 4's corrected non-root directory handling).
6. **`applyEntryMetadata`'s mode-bits condition simplified per the plan's own Task 4 Step 3 self-correction** — applied unconditionally on `entry.ModeBits != 0` (not gated on `applyOwnership`), letting `os.Chmod` report the rare `EPERM` as a warning; directories strip only `setuid` (not setgid/sticky) when not applying ownership, since a non-root owner may legitimately set sticky/setgid on its own directory.
7. **`golangci-lint` staticcheck S1011** on the new `applyEntryMetadata` call site — fixed (mechanical `append(...)...` simplification), separate small commit.

### Not done — lab proof pending (orchestrator)

Task 6 Step 2 (live proof on the Linux/Windows lab rigs: relative + absolute symlinks, empty dir, `1777` dir, `4755` file, non-root-owned file, restored through the real restore command, `find -printf` diff) was explicitly out of scope for this session — reserved for the orchestrator.

### Out of scope (unchanged from the plan/spec §12)

Hard links (restored as independent copies), extended attributes/capabilities (`setcap` binaries lose them — the rebuild engine's boot phase can re-apply known ones later), Windows ACLs (W06), device nodes (excluded trees only).

## Review fixes (commit 5879c5ef72a9221b6327bdc42bba567e9ec2712d)

Three confirmed defects from review of this PR, fixed red-first on the same branch:

**1. CRITICAL — symlink-ancestor traversal in restore.** Lexical containment on the final target path only checks the literal string; it never asks whether an INTERMEDIATE directory component is actually a symlink. A resumed restore's file pass could therefore write straight through a symlink a previous (possibly interrupted) run already recreated under the restore root, escaping it entirely.
- Fix: new exported `func EnsureNoSymlinkAncestor(base, target string) error` (`restore.go`) — walks every path component strictly below `base` up to `filepath.Dir(target)` via `os.Lstat`, refusing on the first symlink found. Called (a) in the file loop right after the existing containment check and before `MkdirAll`, and (b) in the links/dirs pass before `RestoreContentlessEntry` (this single call site covers both the symlink and `KindDir` cases, since `RestoreContentlessEntry`'s own `MkdirAll` only ever walks from that same `Dir(target)` downward). Failures count as `FilesFailed` plus a warning containing "symlink" — never silent.
- `bmr.go`'s `restoreFiles` gets a local equivalent (`ensureNoSymlinkAncestor` + `symlinkAncestorBase`), **scoped to only run when a `RecoveryConfig.TargetPaths` override applies to that file**. bmr's ordinary in-place restore mode (no override) writes back to the file's own live original path — there is no restore-dedicated root to safely walk from, and real systems routinely have legitimate top-level symlinks (confirmed empirically mid-fix: this very environment's `/var -> private/var` on macOS, which sits in the ancestry of `t.TempDir()`/`os.TempDir()` itself). An initial "fall back to `/`" implementation immediately broke ~8 pre-existing bmr tests by refusing ordinary restores under `/var/folders/...`; `symlinkAncestorBase` instead recovers the caller's implied staging root by stripping the file's own relative path off its override's tail (the shape every real caller — e.g. the W03 rebuild engine staging a snapshot under one directory — actually uses), and skips the guard entirely (returns `""`, which is a documented no-op) when it can't confidently derive one, rather than defaulting to a real filesystem-root walk.
- Red-first tests: `TestRestore_ResumedRunDoesNotWriteThroughRestoredSymlink` (`restore_test.go`) and `TestRestoreFiles_ResumedRunDoesNotWriteThroughRestoredSymlink` (`bmr_test.go`, with a `TargetPaths` override base).

**2. IMPORTANT — `RestoreContentlessEntry`'s symlink branch clobbered non-symlink targets.** It called `os.Remove(targetPath)` for ANY existing entry that didn't already match, including a regular file or a real directory — silently destroying it.
- Fix: only remove when the existing entry is itself a symlink; otherwise return `fmt.Errorf("%s exists and is not a symlink", targetPath)`, surfaced by the caller as a failed entry + warning. Applied to both `restore.go`'s `RestoreContentlessEntry` and bmr's local `restoreContentlessEntry`, which had the identical bug (introduced by the same Task 3 commit that built bmr's independent mirror).
- Red-first test: `TestRestoreContentlessEntry_RefusesToReplaceRegularFile` (`restore_test.go`).

**3. IMPORTANT — content-less entries miscounted as incremental references.** `isReferenceEntry` returns true whenever `BackupPath` doesn't start with the current snapshot's own prefix — but a content-less entry's `BackupPath` is always `""`, which trivially fails that check against ANY non-empty prefix, so every symlink/directory entry was counted as "referenced from an older snapshot" on `backup.go`'s `job.ReferencedFiles`/`ReferencedBytes` accounting — including on a snapshot's very first run, which has no previous snapshot to reference at all.
- Fix: `isReferenceEntry` returns `false` immediately when `entry.BackupPath == ""`, plus a belt-and-suspenders `f.HasContent()` guard at both call sites in `backup.go` (the resume-short-circuit path and the normal run-completion path).
- Red-first tests: a new `TestIsReferenceEntry` table row for an empty-`BackupPath` symlink entry (expect `false`), and a run-level assertion added to `TestRunBackup_IncrementalRetentionDoesNotStrandReferencedObjects` (a symlink added to its source tree; first run must report `ReferencedFiles == 0`).

### Test names, red output, green output

| Test | Red (before fix) | Green (after fix) |
|---|---|---|
| `TestRestore_ResumedRunDoesNotWriteThroughRestoredSymlink` | `restore_test.go:1147: restore wrote through the symlink into the outside directory` | `--- PASS: TestRestore_ResumedRunDoesNotWriteThroughRestoredSymlink (0.00s)` |
| `TestRestoreFiles_ResumedRunDoesNotWriteThroughRestoredSymlink` (bmr) | `bmr_test.go:1217: restoreFiles wrote through the symlink into the outside directory` | `--- PASS: TestRestoreFiles_ResumedRunDoesNotWriteThroughRestoredSymlink (0.01s)` |
| `TestRestoreContentlessEntry_RefusesToReplaceRegularFile` | `restore_test.go:1190: err = <nil>, want an error mentioning "not a symlink"` | `--- PASS: TestRestoreContentlessEntry_RefusesToReplaceRegularFile (0.00s)` |
| `TestIsReferenceEntry/empty_backupPath_(content-less_entry)_->_never_a_reference` | `incremental_test.go:423: isReferenceEntry("", "snap-A") = true, want false` | `--- PASS: TestIsReferenceEntry (0.00s)` (all 4 subtests) |
| `TestRunBackup_IncrementalRetentionDoesNotStrandReferencedObjects` | `backup_test.go:1188: first run has no previous snapshot to reference, got ReferencedFiles=1 (content-less entry miscounted as a reference?)` | `--- PASS: TestRunBackup_IncrementalRetentionDoesNotStrandReferencedObjects (0.00s)` |

Full verification after all three fixes:
```
cd agent && go test -race -count=1 ./internal/backup/...
  ok  github.com/breeze-rmm/agent/internal/backup           3.0s
  ok  github.com/breeze-rmm/agent/internal/backup/bmr       4.4s
  ok  github.com/breeze-rmm/agent/internal/backup/hyperv    2.1s
  ok  github.com/breeze-rmm/agent/internal/backup/mssql     2.3s
  ok  github.com/breeze-rmm/agent/internal/backup/providers 3.3s
  ok  github.com/breeze-rmm/agent/internal/backup/systemstate 2.8s
  ok  github.com/breeze-rmm/agent/internal/backup/vss       2.9s
cd agent && go test -race -count=1 ./...
  76/76 packages ok, 0 FAIL (whole agent module)
GOOS=windows go vet ./internal/backup/...
  3 findings, all pre-existing in internal/backup/vss/vss_windows.go (unrelated, untouched file)
GOOS=darwin go vet ./internal/backup/...
  clean (exit 0)
golangci-lint run ./internal/backup/...
  37 issues, all pre-existing/untouched lines (verified via git diff hunks) — no new findings from this fix
```

Commit: `5879c5ef72a9221b6327bdc42bba567e9ec2712d`

Closes #5495

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SVmA9Kgo45EvgriWK7Qo1C

