### PR TITLE
docs: specs + wave plans for desired-state software install (#5505) and HP CMSL warranty (#5511)

### DIFF
--- a/docs/superpowers/plans/device-lifecycle/2026-09-10-hp-warranty-cmsl-w01-lab-probe-and-ingest-hardening.md
+++ b/docs/superpowers/plans/device-lifecycle/2026-09-10-hp-warranty-cmsl-w01-lab-probe-and-ingest-hardening.md
@@ -1,0 +1,3429 @@
+---
+tracking_issue: LanternOps/breeze#5511
+---
+
+# Wave 01 — HP warranty via HP CMSL: lab probe + ingest hardening — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the two halves of W01 — (A) a safe, reversible, copy-pasteable HP lab probe that answers the three hardware questions W03 and W04 are gated on, and (B) the ingest hardening that stops the server from destroying agent-collected warranty data, widens the agent path to carry HP's N entitlements, and makes manual refresh tell the truth for HP.
+
+**Architecture:** One new dependency-free module, `apps/api/src/services/warrantyDataSources.ts`, becomes the single definition of "an agent wrote this row" and of which vendor a synthesised agent entitlement belongs to. Four existing writers adopt it: the direct-sync preservation branch and the 7-day sweep selector (`warrantySync.ts`), the CSV importer's apply and preview paths (`warrantyTarget.ts`, `valueImport.ts`), and the manual-refresh route (`routes/devices/warranty.ts`). The agent report path widens across all three of its layers — zod schema, handler field selection, service interface — to carry an entitlements array. No database migration: `entitlements` is already `jsonb NOT NULL DEFAULT '[]'` and `data_source` is an unconstrained `varchar(50)`. The lab half ships as one committed PowerShell probe with five phases plus a results template posted to #5512.
+
+**Tech Stack:** Hono + Drizzle ORM + PostgreSQL (RLS), zod, Vitest (unit + `vitest.integration.config.ts`), PowerShell 5.1 (the lab probe; CMSL's own floor).
+
+**Spec:** `docs/superpowers/specs/device-lifecycle/2026-09-10-hp-warranty-cmsl-design.md` — layer 6 (reporting and ingest) and the wave-1 gate in "Wave sketch"/"Risks". Its **"Corrections after ground-truth verification (2026-09-10)"** section supersedes the body wherever they disagree, and this plan follows the corrections.
+
+**Cross-wave contract:** `contract-B-hp-cmsl.md` (coordinator, authoritative). W01 owns decisions **D9, D10, D11** and the three lab-gate questions. Every locked decision is copied verbatim into Global Constraints below.
+
+**Depends on:** nothing. W03 (#5514) and W04 (#5515) depend on this wave's *lab answers*; nothing depends on its code.
+
+## Global Constraints
+
+Copied verbatim from the contract. No task may rename or re-shape anything here. A task that believes one of these is wrong **stops and reports** rather than diverging.
+
+- **D9 — data source value and the preservation generalisation.** Agent-reported HP rows carry `data_source = 'agent_cmsl'` (varchar(50), no CHECK, so no migration). The preservation branch is generalised, not given a second hardcoded string:
+  ```ts
+  export const AGENT_OWNED_WARRANTY_SOURCES = new Set(['agent_plist', 'agent_cmsl']);
+  export function isAgentOwnedWarrantySource(dataSource: string | null | undefined): boolean;
+  ```
+  Applied in THREE places, not one: (1) `warrantySync.ts:153` — the preservation branch; (2) the sweep candidate selector / direct sync — exclude HP from provider lookup so an HP device is not re-run every 7 days into an overwrite; (3) `apps/api/src/services/customFields/import/warrantyTarget.ts:181,238` — the CSV-import guard is `'provider'`-only today and therefore already stomps `agent_plist` rows.
+- **D10 — entitlements require widening `AgentWarrantyData`.** W01 widens all three layers — schema, handler selection, service type — with bounds: **at most 25 entitlements per report**; **each string field ≤ 200 chars**; **dates as ISO-8601 strings, preserved as HP reports them**; the synthesised entitlement's `provider` is **derived from the reporting source, never hardcoded** — `provider: 'apple' as const` (`warrantySync.ts:367`) is a verified defect and W01 fixes it. `'hp'` is already in the union (`warrantyProviders/types.ts:2`).
+- **D11 — manual refresh on an HP device.** `POST /devices/:id/warranty/refresh` (`devices/warranty.ts:42-67`) currently queues a server-side sync that can never produce HP data. It must not silently no-op. W01 makes it return an honest coded refusal for HP devices (`{ error: '...', code: 'WARRANTY_REFRESH_NOT_AVAILABLE' }`, **409**); W03 may later upgrade it to request agent collection once there is a trigger to call. W01 states which it shipped — **this plan ships the coded refusal.**
+- **D13 — migration slots.** Newest committed migration as of 2026-09-10: `apps/api/migrations/2026-10-15-150300-remote-session-revocation-lease.sql` (re-confirmed by this plan's ground-truth pass). **W01 is expected to need no migration.** If it turns out to need one, it takes the next free slot after that file and says so in its PR — it does **NOT** reuse W04's `2026-10-15-150402-…` slot. `2026-08-06` is a closed date block; today's date does not sort last.
+- **Ownership — W01 must NOT touch:** config policy, any agent Go code, the catalog package, web. (`apps/web/**` is out of scope in every task below, including the `agent_cmsl` label in `DeviceWarrantyCard.tsx`, which is W05's.)
+- **`targetWhere` is load-bearing on every `device_warranty` upsert.** `device_warranty` has TWO partial unique indexes (`db/schema/warranty.ts:60-65`); Postgres can only infer a partial unique index as the `ON CONFLICT` arbiter when the statement repeats its predicate. Dropping `targetWhere` reintroduces a runtime 42P10 on **every** warranty upsert, device rows included.
+- **Non-negotiable testing gates.** The `agent_cmsl`-survives-a-sweep test is the direct regression for a verified data-loss defect and **MUST be written red against unmodified code first** — watched failing, not assumed to fail. Integration suites need a live DB and run only in the **Integration Tests** CI job; a locally-green branch proves nothing about them, so this plan runs them explicitly.
+- **Scoped test runs:** `cd apps/api && npx vitest run <path>`. **Never** `pnpm --filter <pkg> test -- --run <path>` — pnpm forwards the literal `--` into argv, vitest stops flag parsing there, `--run` is swallowed as a positional filter, and the whole 1,470-file suite runs in watch mode. Vitest's path filter is a **plain substring match**, not a glob: a trailing slash silently skips sibling `foo.test.ts` files, and an asterisk matches nothing.
+- **Typecheck:** `apps/api` has no `typecheck` script. Use `pnpm --filter @breeze/api exec tsc --noEmit`.
+- **HP CMSL licence, for the lab half.** HP's licence states verbatim: *"You do not have the right to distribute the Software Product."* **Breeze must never mirror or host the CMSL installer** — install via winget or HP's own URL, both of which pull from HP. Auto-accepting the licence is accepting it on the customer's behalf, which is why the shipped feature is opt-in with recorded consent (W02) and why the probe runs only on hardware the operator owns or has written permission to modify. The licence also permits HP to collect technical information including IP address.
+- **HP rate limit:** 300 requests / 5 minutes **per source IP** — a per-customer-NAT limit, not a per-device one. The probe must not loop `Get-HPWarrantyInfo`.
+
+---
+
+## 0. Ground truth
+
+Every file below was re-opened in this worktree (`/Users/toddhebebrand/.herdr/worktrees/breeze/warranty-testing`, branch `spec/hp-warranty-and-desired-state-install`) on 2026-09-10 and quoted verbatim. The contract's "Verified starting facts" were **confirmed, not copied** — corrections are called out inline.
+
+### The two verified defects
+
+`apps/api/src/services/warrantySync.ts:141-176` — the preservation branch, string-keyed to `'agent_plist'`:
+
+```ts
+141    const provider = getProviderForManufacturer(manufacturer);
+142    if (!provider) {
+143      // Check if we already have agent-reported warranty data for this subject.
+144      // If so, don't overwrite it with an error — just skip. Only an agent writes
+145      // 'agent_plist', so only a device subject can ever carry it.
+146      if (subject.kind === 'device') {
+147        const [existing] = await db
+148          .select({ dataSource: deviceWarranty.dataSource, status: deviceWarranty.status })
+149          .from(deviceWarranty)
+150          .where(eq(deviceWarranty.deviceId, subject.deviceId))
+151          .limit(1);
+152
+153        if (existing?.dataSource === 'agent_plist') {
+154          // Agent-reported data exists — preserve it regardless of status, just update nextSyncAt
+155          const now = new Date();
+156          await db
+157            .update(deviceWarranty)
+158            .set({
+159              lastSyncAt: now,
+160              lastSyncError: null,
+161              nextSyncAt: new Date(now.getTime() + SYNC_CADENCE_MS),
+162              updatedAt: now,
+163            })
+164            .where(eq(deviceWarranty.deviceId, subject.deviceId));
+165          return;
+166        }
+167      }
+168
+169      // No provider and no agent data — upsert as unknown (not an error)
+170      await upsertWarranty(subject, orgId, manufacturer, serialNumber, {
+171        found: false,
+172        entitlements: [],
+173        warrantyStartDate: null,
+174        warrantyEndDate: null,
+175      });
+176      return;
+177    }
+```
+
+`:153` confirmed. **The fall-through at `:170-176` is the data-loss path**: `upsertWarranty` writes `dataSource: 'provider'` (`:289`, `:305`), `warrantyStartDate: null`, `warrantyEndDate: null`, `entitlements: []`. An `agent_cmsl` row reaching it loses everything and changes owner.
+
+`apps/api/src/services/warrantySync.ts:364-373` — the hardcoded provider:
+
+```ts
+364    // Build entitlements array from agent data
+365    const entitlements = data.coverageType
+366      ? [{
+367          provider: 'apple' as const,
+368          serviceLevelDescription: data.coverageType,
+369          entitlementType: data.coverageType,
+370          startDate: data.coverageStartDate ?? '',
+371          endDate: data.coverageEndDate ?? '',
+372        }]
+373      : [];
+```
+
+`:367` confirmed. `apps/api/src/services/warrantyProviders/types.ts:1-7` confirms `'hp'` is already legal:
+
+```ts
+1  export interface WarrantyEntitlement {
+2    provider: 'dell' | 'hp' | 'lenovo' | 'apple';
+3    serviceLevelDescription: string;
+4    entitlementType: string;
+5    startDate: string;
+6    endDate: string;
+7  }
+```
+
+### HP has no server-side provider at all
+
+`apps/api/src/services/warrantyProviders/index.ts:7-30`:
+
+```ts
+ 7  // hpProvider is deliberately NOT registered: its unofficial support.hp.com
+ 8  // endpoint now returns the site's HTML shell (verified 2026-09-09) and HP's real
+ 9  // backend is captcha-gated, so enabling it only parks devices in `unknown` with
+10  // a JSON parse error. HP coverage is coming from the agent instead. The module
+11  // is kept (and unit-tested) until that lands.
+12  const providers: WarrantyProvider[] = [dellProvider, lenovoProvider];
+13
+14  export function normalizeManufacturer(raw: string): string {
+15    const lower = raw.toLowerCase().trim();
+16    if (lower.includes('apple')) return 'apple';
+17    if (lower.includes('dell')) return 'dell';
+18    if (lower.includes('hp') || lower.includes('hewlett')) return 'hp';
+19    if (lower.includes('lenovo')) return 'lenovo';
+20    return lower.replace(/[^a-z0-9]/g, '');
+21  }
+22
+23  export function getProviderForManufacturer(manufacturer: string): WarrantyProvider | null {
+24    for (const provider of providers) {
+25      if (provider.supports(manufacturer) && provider.isConfigured()) {
+26        return provider;
+27      }
+28    }
+29    return null;
+30  }
+```
+
+Consequence used throughout this plan: **`getProviderForManufacturer` is `null` for every HP device**, so an HP device always reaches the `!provider` branch above. Fixing `:153` therefore fixes the direct-sync path completely; the sweep-selector change is the second layer.
+
+Neither `dellProvider.ts`, `lenovoProvider.ts` nor `throttle.ts` imports `../db` (checked) — so the new module in Task 4 may import `normalizeManufacturer` without dragging a database into a route's unit-test module graph.
+
+### The sweep selector — **citation correction**
+
+The contract cites `getDevicesNeedingWarrantySync` as `:454-484`. The function actually spans **`:454-524`**; `:454-484` is only its *device arm*. The device arm's `where(...)` is `:462-477`:
+
+```ts
+457    const deviceRows = await db
+458      .select({ deviceId: devices.id, nextSyncAt: deviceWarranty.nextSyncAt })
+459      .from(devices)
+460      .leftJoin(deviceWarranty, eq(devices.id, deviceWarranty.deviceId))
+461      .leftJoin(deviceHardware, eq(devices.id, deviceHardware.deviceId))
+462      .where(
+463        and(
+464          // Quick Support exclusion — see syncWarrantyForDevice above.
+465          eq(devices.isEphemeral, false),
+466          // Virtual-machine exclusion — see syncWarrantyForDevice above.
+467          eq(devices.isVirtual, false),
+468          // Has hardware with serial number
+469          sql`${deviceHardware.serialNumber} IS NOT NULL`,
+470          sql`${deviceHardware.manufacturer} IS NOT NULL`,
+471          // Either no warranty row or next sync is due
+472          or(
+473            isNull(deviceWarranty.id),
+474            lt(deviceWarranty.nextSyncAt, now)
+475          )
+476        )
+477      )
+```
+
+Confirmed: **no manufacturer or data-source exclusion of any kind.** The manual-asset arm (`:486-503`) needs no change — only a device subject can ever carry an agent-written row.
+
+`warrantySync.ts` imports at `:3`: `import { eq, and, lt, isNull, or, sql } from 'drizzle-orm';` — `notInArray` is **not** imported yet.
+
+### No migration is needed — confirmed against the schema, not the spec
+
+`apps/api/src/db/schema/warranty.ts:43-68`:
+
+```ts
+43    status: warrantyStatusEnum('status').notNull().default('unknown'),
+44    warrantyStartDate: date('warranty_start_date'),
+45    warrantyEndDate: date('warranty_end_date'),
+46    // True when coverage is an active recurring subscription (AppleCare), in which
+47    // case warrantyEndDate is the next renewal date rather than a real expiry.
+48    isSubscription: boolean('is_subscription').notNull().default(false),
+49    entitlements: jsonb('entitlements').notNull().default([]),
+50    dataSource: varchar('data_source', { length: 50 }).default('provider'),
+...
+58    // Two partial unique indexes, one per subject kind — both upsert conflict
+59    // targets must stay valid now that either column can be NULL.
+60    deviceIdIdx: uniqueIndex('device_warranty_device_id_idx')
+61      .on(table.deviceId)
+62      .where(sql`${table.deviceId} IS NOT NULL`),
+63    manualAssetIdIdx: uniqueIndex('device_warranty_manual_asset_id_idx')
+64      .on(table.manualAssetId)
+65      .where(sql`${table.manualAssetId} IS NOT NULL`),
+```
+
+**Confirmed, independently of the spec: W01 needs no `device_warranty` migration.** `entitlements` is `jsonb NOT NULL DEFAULT '[]'` — an array of N objects fits with no DDL. `data_source` is `varchar(50)` with **no CHECK and no enum** (`status` is the enum, not `data_source`), so `'agent_cmsl'` (11 chars) is writable today. Because there is no DDL, there is also nothing to register in `CORE_ORG_CASCADE_DELETE_ORDER`, `CORE_DEVICE_CASCADE_DELETE_TABLES`, `CORE_DEVICE_ORG_DENORMALIZED_TABLES` or `CORE_TENANT_EXPORT_POLICY` — `device_warranty` is already in all of them and **no column is added to it**, which is the only thing that would fire the export-policy contract.
+
+The `targetWhere` the contract warns about, `warrantySync.ts:395-399`:
+
+```ts
+395      .onConflictDoUpdate({
+396        target: deviceWarranty.deviceId,
+397        // device_warranty_device_id_idx is partial since #4622 W03 — the
+398        // predicate must be repeated or Postgres cannot infer the arbiter (42P10).
+399        targetWhere: sql`${deviceWarranty.deviceId} IS NOT NULL`,
+```
+
+Confirmed at `:399`. The same guard exists in `upsertWarranty` (`:296`) and in the importer (`warrantyTarget.ts:229`).
+
+### The agent report path — all three layers
+
+`apps/api/src/routes/agents/schemas.ts:647-675` (confirmed `:658-675`):
+
+```ts
+647  /** Coerce date strings to valid ISO date (YYYY-MM-DD) or null.
+648   *  Accepts ISO-8601 datetime or date-only formats. */
+649  const warrantyDateSchema = z.string().max(50).optional()
+650    .transform((val) => {
+651      if (!val) return undefined;
+652      const d = new Date(val);
+653      if (isNaN(d.getTime())) return undefined;
+654      // Return date portion only (YYYY-MM-DD) for Postgres date columns
+655      return d.toISOString().slice(0, 10);
+656    });
+657
+658  export const agentWarrantyInfoSchema = z.object({
+659    source: z.string().min(1).max(50),
+660    manufacturer: z.string().min(1).max(100),
+661    coverageEndDate: warrantyDateSchema,
+662    coverageStartDate: warrantyDateSchema,
+663    coverageType: z.string().max(200).optional(),
+...
+670    coverageKind: z
+671      .enum(['subscription', 'fixed'])
+672      .or(z.literal(''))
+673      .optional(),
+674    deviceName: z.string().max(200).optional(),
+675  });
+```
+
+No `entitlements` key. `z.object` strips unknown keys by default, so an entitlements array is dropped silently today — confirmed.
+
+`apps/api/src/routes/agents/inventory.ts:331-339` — the explicit field selection:
+
+```ts
+331      await upsertAgentWarranty(device.id, device.orgId, {
+332        source: data.source,
+333        manufacturer: data.manufacturer,
+334        serialNumber: hw?.serialNumber ?? null,
+335        coverageEndDate: data.coverageEndDate ?? null,
+336        coverageStartDate: data.coverageStartDate ?? null,
+337        coverageType: data.coverageType ?? null,
+338        coverageKind: data.coverageKind ?? null,
+339      });
+```
+
+Confirmed: the serial always comes from `device_hardware` (`:334`), never the payload; `deviceName` is accepted and discarded. A second, independent drop point.
+
+`apps/api/src/services/warrantySync.ts:314-331` — `AgentWarrantyData`, a single coverage window:
+
+```ts
+314  /** Upsert warranty data reported directly by the agent (e.g. Apple plist). */
+315  export interface AgentWarrantyData {
+316    source: string;
+317    manufacturer: string;
+318    serialNumber: string | null;
+319    coverageEndDate: string | null;
+320    coverageStartDate: string | null;
+321    coverageType: string | null;
+...
+330    coverageKind?: 'subscription' | 'fixed' | '' | null;
+331  }
+```
+
+Confirmed: no entitlements, no service-level, no product-number field. Three layers, three separate widenings.
+
+### The CSV importer already stomps `agent_plist` today
+
+`apps/api/src/services/customFields/import/warrantyTarget.ts:179-183` and `:231-241`:
+
+```ts
+179    // A manufacturer lookup outranks a hand-typed CSV. Refused here so the
+180    // operator gets `skipped-provider-owned` rather than a silent no-op.
+181    if (existing && existing.dataSource === 'provider' && !options.overrideProvider) {
+182      return 'skipped-provider-owned';
+183    }
+```
+
+```ts
+231        // The AUTHORITY on the provider rule; the read above is advisory. A row
+232        // that turns provider-owned between the two matches no target here and
+233        // the statement writes nothing rather than clobbering it.
+234        ...(options.overrideProvider
+235          ? {}
+236          : {
+237              setWhere: and(
+238                sql`${deviceWarranty.dataSource} IS DISTINCT FROM 'provider'`,
+239              ),
+240            }),
+```
+
+Both confirmed at `:181` and `:238`. Neither mentions `agent_plist`, so a CSV import overwrites an agent-collected macOS row today.
+
+**Found while verifying, and in scope:** the importer's **preview** path carries the same `'provider'`-only guard, `apps/api/src/services/customFields/import/valueImport.ts:343-348`:
+
+```ts
+343      const existing = state.warrantyByDevice.get(target.deviceId);
+344      if (existing?.dataSource === 'provider' && !state.overrideProviderWarranty) {
+345        return {
+346          annotation: { target: mapping, outcome: 'skipped-provider-owned', warning: PROVIDER_WARRANTY_WARNING },
+347        };
+348      }
+```
+
+Leaving it out would make the preview promise `applied` for a row the apply path refuses — preview and commit disagreeing on the one surface whose entire job is to predict the other, which the file's own comment at `:349-353` says is the failure to avoid. It is in scope: `valueImport.ts` is an API service, not config policy / agent / catalog / web.
+
+`WarrantyImportOutcome` (`import/types.ts:506-511`) is `'applied' | 'skipped-provider-owned' | 'skipped-already-set' | 'rejected' | 'none'`. Its members are mirrored in `apps/api/src/openapi.ts:2957` **and** in `apps/web/src/components/devices/CustomFieldImportPreviewTable.tsx:59-60,130-131,140-141` plus two i18n keys — all of which W01 must not touch. **Decision: reuse `'skipped-provider-owned'` for the agent-owned refusal and add a distinct `warning` string** (a free-form field, not an enum). A dedicated `skipped-agent-owned` member is recorded as a W05 follow-up.
+
+### Manual refresh
+
+`apps/api/src/routes/devices/warranty.ts:41-67`:
+
+```ts
+41  // POST /devices/:id/warranty/refresh - Queue on-demand warranty refresh
+42  warrantyRoutes.post(
+43    '/:id/warranty/refresh',
+44    requireScope('organization', 'partner', 'system'),
+45    requirePermission(PERMISSIONS.DEVICES_WRITE.resource, PERMISSIONS.DEVICES_WRITE.action),
+46    requireMfa(),
+...
+59      // force: an explicit click is the escape hatch when virtualization
+60      // detection misfires, and it keeps this endpoint's "queued" promise
+61      // truthful — without it a device flagged virtual would never advance
+62      // lastSyncAt and the card would poll a refresh that never completes.
+63      await queueWarrantySyncForDevice(deviceId, { force: true });
+64
+65      return c.json({ message: 'Warranty refresh queued' });
+66    }
+67  );
+```
+
+Confirmed `:42-67`, already `devices.write` + `requireMfa()`, always `force: true`, enqueues BullMQ and never reaches the agent. Its imports at `:4` are `{ deviceWarranty, devices }` — `deviceHardware` must be added.
+
+The web caller (`apps/web/src/components/devices/DeviceWarrantyCard.tsx:162-173`) wraps this in `runAction` inside a `try`, and a non-401 `ActionError` is already toasted by `runAction` before `handleActionError` runs — so a 409 surfaces as an error toast and stops the spinner **with no web change**. Today's path instead resolves 200 and then polls `lastSyncAt` (`:182`) until the sweep stamps it, showing "Warranty updated" for a lookup that never happened.
+
+### The winget half of the lab gate
+
+`agent/internal/patching/winget_system.go:73-76` — the scan args, **verbatim, including two flags the spec's prose omits**:
+
+```go
+73  func systemScanArgs() []string {
+74      return []string{"upgrade", "--include-unknown", "--scope", "machine",
+75          "--source", "winget", "--accept-source-agreements", "--disable-interactivity"}
+76  }
+```
+
+`:78-81` — the install args the probe must mirror exactly:
+
+```go
+78  func systemInstallArgs(id string) []string {
+79      return []string{"install", "--exact", "--id", id, "--scope", "machine", "--silent",
+80          "--accept-package-agreements", "--accept-source-agreements", "--source", "winget", "--disable-interactivity"}
+81  }
+```
+
+`agent/internal/patching/winget_parse.go:66-73` — the parse is fixed-width on English headers:
+
+```go
+66  func parseWingetUpgradeOutput(output string) ([]AvailablePatch, error) {
+67      cols := findColumnBoundaries(output, []string{"Name", "Id", "Version", "Available"})
+68      if cols == nil {
+69          if wingetReportsNoResults(output) {
+70              return nil, nil
+71          }
+72          return nil, errWingetNoTable
+73      }
+```
+
+So a non-English Windows UI yields `errWingetNoTable` → `ErrScanSkipped` and the probe must record the machine's UI culture.
+
+`agent/internal/heartbeat/heartbeat.go:3571-3588` — the provider→source map:
+
+```go
+3571  func (h *Heartbeat) mapPatchProviderSource(provider string) string {
+3572      switch provider {
+3573      case "windows-update":
+3574          return "microsoft"
+...
+3581      case "winget":
+3582          return "third_party"
+3583      case "apt", "yum":
+3584          return "linux"
+3585      default:
+3586          return "custom"
+3587      }
+3588  }
+```
+
+**Citation nuance the contract does not spell out:** `:3586`'s `default: "custom"` is reached only when `p.Provider` is not one of the listed ids. The SYSTEM winget provider sets `p.Provider = "winget"` via `manager.go:155,165`, so a genuine machine-scope winget patch maps to `third_party` and *does* qualify for ring auto-approval. The `custom` risk is real but narrow: it fires if the CMSL upgrade is surfaced by some other provider id (e.g. a user-scope pass). `mapPatchSource` (`heartbeat.go:3558-3568`) is a *different* function with its own `default: "custom"`, applied to already-installed patches. **The probe must therefore capture the stored `patches.source` value, not assume it.**
+
+`apps/api/src/services/patchApprovalEvaluator.ts:616-629` — the dual consent:
+
+```ts
+616    if (ringAutoApprove.enabled) {
+617      if (isThirdPartyPatchSource(patch.source)) {
+618        if (!(ringConfig.sources ?? []).includes('third_party')) {
+619          return null;
+620        }
+621        if (!ringAutoApprove.thirdPartyApps) {
+622          return null;
+623        }
+624        const hold = ringAutoApprove.thirdPartyDeferralDays ?? ringAutoApprove.deferralDays;
+625        if (isHeldByDeferral(patch, hold, now, 'ring')) {
+626          return null;
+627        }
+628        return 'ring_auto_approve';
+629      }
+```
+
+Confirmed `:616-629`. Four conditions, all required: ring auto-approve enabled, policy `sources` containing the literal `'third_party'`, ring `autoApprove.thirdPartyApps === true`, and the deferral elapsed. `:610-615`'s comment records that the literal check is deliberately narrower than the `THIRD_PARTY_PATCH_SOURCES = ['third_party', 'custom']` bucket (`:185`), so **a patch stored as `custom` never ring-auto-approves.**
+
+### Test conventions this wave reuses
+
+- `apps/api/src/services/warrantySync.test.ts:5-53` — the file-level `insertMock`/`selectMock`, the `vi.mock('../db', ...)` / `vi.mock('../db/schema', ...)` / `vi.mock('./warrantyProviders', ...)` triple, and the `captureUpsert()` helper that returns `{ values, onConflictDoUpdate }`. Note `normalizeManufacturer` is mocked as `(m) => m.toLowerCase()` at `:34`.
+- `apps/api/src/services/warrantySync.manualAsset.test.ts:82-97` — the `queueReads(...)` chainable select mock (`from/leftJoin/innerJoin/where/orderBy` return the chain; `.limit` and `.then` shift one canned result set).
+- `apps/api/src/routes/devices/warranty.test.ts:1-62` — the route-test shape: `vi.hoisted` middleware mocks, `vi.mock('../../db', () => ({ db: { select: vi.fn() } }))`, `vi.mock('./helpers', ...)`, and the `registeredPermissionCalls` / `registeredMfaCallCount` module-load snapshots asserted at `:58-62`. **`getDeviceWithOrgAndSiteCheck` is mocked, so it consumes none of the `db.select` queue.**
+- `apps/api/src/__tests__/integration/deviceWarrantyManualSubject.integration.test.ts:15-71` — `import './setup'`, `const runDb = it.runIf(!!process.env.DATABASE_URL)`, `seedTenant()` from `createPartner`/`createOrganization`/`createSite` in `./db-utils`, raw `getTestDb().execute(sql\`...\`)` for fixtures, and `withSystemDbAccessContext(() => ...)` around every call into a service. Its `:208-252` describe block is the `targetWhere` regression this wave extends; `:225` is the `upsertAgentWarranty` case.
+- `apps/api/vitest.integration.config.ts` — `include` carries `'src/__tests__/integration/**/*.test.ts'` as a standing glob, so a new file in that directory needs **no config edit**.
+- `apps/api/src/__tests__/integration/setup.ts:215-257` — `CLEANUP_TABLES` truncates `devices`, `device_hardware`, `organizations`, `partners`, `sites` (among ~35) `CASCADE` on **every** `beforeEach`. `device_warranty` is reached by the `devices`/`organizations` cascade. **Consequence used by Task 7: inside one integration test the only devices in the database are the ones that test seeded**, so a `getDevicesNeedingWarrantySync` assertion is deterministic.
+- `withSystemDbAccessContext<T>(fn: () => Promise<T>, label?): Promise<T>` (`apps/api/src/db/index.ts:610`) — returns the callback's value, so it can wrap a read.
+- `devices.isVirtual` (`db/schema/devices.ts:72`) and `devices.isEphemeral` (`:88`) are both `notNull().default(false)`, so a bare `INSERT INTO devices (...)` fixture passes the sweep's exclusions.
+- `scripts/backup-assurance/seed-corpus.ps1:1-14` — the repo's lab-PowerShell convention: an ASCII-only header naming the invocation, a `param(...)` block, `$ErrorActionPreference = 'Stop'`. `scripts/hp-warranty-lab/` is the new sibling directory.
+
+### Migration slot, re-confirmed
+
+```
+$ ls apps/api/migrations/*.sql | sort | tail -3
+apps/api/migrations/2026-10-15-150100-governance-approval-generation.sql
+apps/api/migrations/2026-10-15-150200-pam-dedicated-permissions.sql
+apps/api/migrations/2026-10-15-150300-remote-session-revocation-lease.sql
+```
+
+Matches D13. **This wave adds none.**
+
+---
+
+## File structure
+
+**Lab half (A)**
+
+- **Create** `scripts/hp-warranty-lab/hp-cmsl-probe.ps1` — one self-contained, five-phase PowerShell probe (`Baseline`, `InstallPinned`, `WingetScan`, `Collect`, `Teardown`). Every phase writes JSON/text artefacts under `-OutRoot` and prints their paths. No Breeze code imports it; it is operator tooling.
+- **Create** `scripts/hp-warranty-lab/README.md` — the run order, the safety and licence statement, the per-question pass/fail criteria, the server-side verification SQL, and the verbatim results template for #5512.
+
+**Ingest half (B)**
+
+- **Create** `apps/api/src/services/warrantyDataSources.ts` — the single definition of "an agent wrote this row" and of the entitlement provider. No `db` import, no I/O; pure predicates over strings. Imported by `warrantySync.ts`, `warrantyTarget.ts`, `valueImport.ts`, `routes/devices/warranty.ts` and `routes/agents/schemas.ts`.
+- **Create** `apps/api/src/services/warrantyDataSources.test.ts` — unit tests, no mocks needed.
+- **Create** `apps/api/src/__tests__/integration/agentWarrantyPreservation.integration.test.ts` — the real-DB data-loss regression and the sweep-selector exclusion.
+- **Modify** `apps/api/src/services/warrantySync.ts` — preservation branch (`:153`), entitlement provider (`:367`), entitlements widening (`:315-331`, `:364-373`), sweep selector (`:471-475`).
+- **Modify** `apps/api/src/routes/agents/schemas.ts` — bounded `entitlements` on `agentWarrantyInfoSchema`.
+- **Modify** `apps/api/src/routes/agents/inventory.ts` — pass `entitlements` through the explicit field selection.
+- **Modify** `apps/api/src/services/customFields/import/warrantyTarget.ts` — agent-owned guard + unconditional `setWhere` arm.
+- **Modify** `apps/api/src/services/customFields/import/valueImport.ts` — the matching preview guard + its warning string.
+- **Modify** `apps/api/src/routes/devices/warranty.ts` — D11's coded refusal.
+- **Test (modify)** `apps/api/src/services/warrantySync.test.ts`, `apps/api/src/services/warrantySync.manualAsset.test.ts`, `apps/api/src/routes/devices/warranty.test.ts`, `apps/api/src/services/customFields/import/warrantyTarget.test.ts`, `apps/api/src/routes/agents/inventory.test.ts`, `apps/api/src/__tests__/integration/deviceWarrantyManualSubject.integration.test.ts`.
+
+**Explicitly NOT touched:** `apps/web/**`, `agent/**`, `apps/api/src/services/configurationPolicy.ts`, `apps/api/src/services/builtinDeploymentPackages.ts`, `apps/api/src/openapi.ts`, `apps/api/migrations/**`.
+
+---
+
+## Task order and why
+
+Tasks 1-3 (the probe) come first because their deliverable is a **hand-off**: the script and the results template can be committed in an hour, and the hardware runs then happen asynchronously on someone else's clock while Tasks 4-11 proceed. Each of those tasks ends with checkboxes that stay unchecked until real HP results land on #5512 — that is the gate, and it is explicitly *not* a blocker for the code half.
+
+Within the lab half the phase order is forced: **Q1 must be measured on a machine that has never had CMSL installed**, so `Baseline` precedes every install. `InstallPinned` + `WingetScan` (Q2) leave CMSL at the *new* version, which is exactly the state `Collect` (Q3) wants — so Q2 before Q3 avoids an uninstall/reinstall cycle. If Q2 stalls (no ring available, no older version published), Q3 is **not** blocked: install the current version directly and run `Collect`.
+
+---
+
+### Task 1: The probe script and its Baseline phase — Q1, "does the WMI namespace exist without CMSL?"
+
+**Files:**
+- Create: `scripts/hp-warranty-lab/hp-cmsl-probe.ps1`
+- Create: `scripts/hp-warranty-lab/README.md` (created here, extended in Tasks 2 and 3)
+
+**Interfaces:**
+- Produces: a PowerShell script with a `-Phase <Baseline|InstallPinned|WingetScan|Collect|Teardown>` parameter, a `-OutRoot` directory (default `%ProgramData%\BreezeLab\hp-cmsl-probe`) and a `-PinnedVersion` string used only by `InstallPinned`. Tasks 2 and 3 add phases to the same `switch` block; they do not create new scripts.
+- Consumes: nothing.
+
+**Why this question decides money.** If HP's factory image already populates `root/HP/InstrumentedServices/v1`, some fraction of the fleet yields warranty data at **zero install and zero EULA exposure** — the T0 tier alone would cover it, and layers 3 and 4 (the built-in catalog package and the update channel, i.e. all of W04) shrink to "the long tail". If the namespace is never present without CMSL, W04 is load-bearing. This is a measurement, not an estimate — the spec says so in "Risks", and no amount of reading HP's documentation substitutes for it.
+
+- [ ] **Step 1: Create the script header, parameters and shared helpers**
+
+Create `scripts/hp-warranty-lab/hp-cmsl-probe.ps1`:
+
+```powershell
+# HP CMSL warranty lab probe -- Breeze feature #5511, wave W01 (#5512).
+#
+# ASCII-only source, PowerShell 5.1 compatible (5.1 is CMSL's own floor, and the
+# oldest shell a Breeze-managed Windows endpoint is guaranteed to have). Every
+# phase writes artefacts under -OutRoot and prints their paths; paste them onto
+# issue #5512 using the template in README.md.
+#
+#   powershell -NoProfile -ExecutionPolicy Bypass -File hp-cmsl-probe.ps1 -Phase Baseline
+#   powershell -NoProfile -ExecutionPolicy Bypass -File hp-cmsl-probe.ps1 -Phase InstallPinned -PinnedVersion 1.8.4
+#   powershell -NoProfile -ExecutionPolicy Bypass -File hp-cmsl-probe.ps1 -Phase WingetScan
+#   powershell -NoProfile -ExecutionPolicy Bypass -File hp-cmsl-probe.ps1 -Phase Collect
+#   powershell -NoProfile -ExecutionPolicy Bypass -File hp-cmsl-probe.ps1 -Phase Teardown
+#
+# WHAT THIS INSTALLS, AND ON WHOSE LICENCE
+#   Phases InstallPinned and Collect install HP's Client Management Script
+#   Library (winget id HP.HPCMSL) FROM HP, through winget. Breeze never mirrors
+#   or hosts that installer: HP's licence says verbatim "You do not have the
+#   right to distribute the Software Product". winget's --accept-package-
+#   agreements flag (which a silent install requires) accepts HP's EULA ON
+#   BEHALF OF THE MACHINE'S OWNER, and HP's licence permits HP to collect
+#   technical information including this device's IP address when
+#   Get-HPWarrantyInfo calls home. Run those phases ONLY on hardware you own or
+#   have written permission to modify. Never run them against a customer
+#   endpoint to satisfy this probe.
+#
+# RATE LIMIT
+#   HP throttles the warranty backend to ~300 requests / 5 minutes PER SOURCE
+#   IP -- that is per customer NAT, not per device. This script calls
+#   Get-HPWarrantyInfo at most twice per run and never loops it.
+#
+# REVERSIBILITY
+#   -Phase Teardown uninstalls HP.HPCMSL through winget and reports what
+#   remained. It deliberately does NOT delete the WMI namespace
+#   root/HP/InstrumentedServices/v1: whether that namespace survives an
+#   uninstall is itself a Q1 datapoint for re-imaged machines, and deleting WMI
+#   namespaces by hand on a live endpoint is not a safe operation.
+param(
+  [Parameter(Mandatory = $true)]
+  [ValidateSet('Baseline', 'InstallPinned', 'WingetScan', 'Collect', 'Teardown')]
+  [string]$Phase,
+
+  [string]$OutRoot = "$env:ProgramData\BreezeLab\hp-cmsl-probe",
+
+  # InstallPinned only. Must be an OLDER version than the one winget currently
+  # publishes, or Q2 has nothing to upgrade.
+  [string]$PinnedVersion
+)
+
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+
+$HpNamespaceV1 = 'root/HP/InstrumentedServices/v1'
+$stamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+$out = Join-Path $OutRoot ("{0}-{1}" -f $Phase, $stamp)
+New-Item -ItemType Directory -Force -Path $out | Out-Null
+Write-Host "artefact directory: $out"
+
+function Save-Json {
+  param([string]$Name, $Value)
+  $path = Join-Path $out "$Name.json"
+  # Depth 5: HP's CIM instances nest one level (an array of entitlement rows);
+  # deeper only re-serializes CIM plumbing.
+  ($Value | ConvertTo-Json -Depth 5) | Set-Content -LiteralPath $path -Encoding UTF8
+  Write-Host "  wrote $path"
+}
+
+function Save-Text {
+  param([string]$Name, [string]$Value)
+  $path = Join-Path $out "$Name.txt"
+  # Raw text, never reflowed: the Breeze winget parser is FIXED-WIDTH on the
+  # English column headers, so column positions must survive the capture.
+  Set-Content -LiteralPath $path -Value $Value -Encoding UTF8
+  Write-Host "  wrote $path"
+}
+
+function Get-CimOrNull {
+  param([string]$Namespace, [string]$ClassName)
+  try { return Get-CimInstance -Namespace $Namespace -ClassName $ClassName -ErrorAction Stop }
+  catch { return $null }
+}
+
+function Get-CimClassOrNull {
+  param([string]$Namespace, [string]$ClassName)
+  try { return Get-CimClass -Namespace $Namespace -ClassName $ClassName -ErrorAction Stop }
+  catch { return $null }
+}
+
+function Describe-Properties {
+  # Every property with its CLR type, its raw string, and whether it parses as a
+  # date. This is how the HP cache timestamp gets IDENTIFIED rather than
+  # guessed: W03's scheduler keys off that value, and its property name is not
+  # documented anywhere we can trust.
+  param($InputObject)
+  if ($null -eq $InputObject) { return @() }
+  $first = @($InputObject)[0]
+  if ($null -eq $first) { return @() }
+  return @($first.PSObject.Properties | ForEach-Object {
+    $raw = [string]$_.Value
+    $parsed = [datetime]::MinValue
+    $isDate = [datetime]::TryParse($raw, [ref]$parsed)
+    [pscustomobject]@{
+      Name         = $_.Name
+      ClrType      = $(if ($null -ne $_.Value) { $_.Value.GetType().FullName } else { '<null>' })
+      Raw          = $raw
+      ParsesAsDate = $isDate
+      ParsedIso    = $(if ($isDate) { $parsed.ToString('o') } else { $null })
+    }
+  })
+}
+
+function Get-HpInstalledSoftware {
+  # Registry uninstall keys, NOT Win32_Product. Querying Win32_Product makes the
+  # MSI provider run a consistency check -- and frequently a REPAIR -- against
+  # every installed MSI on the machine. That is a genuinely destructive thing to
+  # do on someone's endpoint. Never use it in this script.
+  $roots = @(
+    'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*',
+    'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*'
+  )
+  return @(Get-ItemProperty -Path $roots -ErrorAction SilentlyContinue |
+    Where-Object { $_.DisplayName -like 'HP*' -or $_.Publisher -like 'HP*' -or $_.Publisher -like 'Hewlett*' } |
+    Select-Object DisplayName, DisplayVersion, Publisher, InstallDate |
+    Sort-Object DisplayName)
+}
+
+function Resolve-WingetPath {
+  $cmd = Get-Command winget.exe -ErrorAction SilentlyContinue
+  if ($cmd) { return $cmd.Source }
+  # Under SYSTEM (which is how the Breeze agent runs) winget is usually NOT on
+  # PATH even when App Installer is present, because the alias lives in a
+  # per-user WindowsApps directory. Resolve the machine-scope payload directly
+  # -- this is the same class of problem the agent solves internally, and a
+  # probe that silently fell back to a user-context winget would answer a
+  # different question than the one being asked.
+  $candidate = Get-ChildItem 'C:\Program Files\WindowsApps' -Filter 'winget.exe' -Recurse -ErrorAction SilentlyContinue |
+    Sort-Object FullName -Descending | Select-Object -First 1
+  if (-not $candidate) { throw 'winget.exe not found: App Installer is missing, or not visible to this account' }
+  return $candidate.FullName
+}
+
+function Invoke-Winget {
+  param([string[]]$WingetArgs, [string]$Name)
+  $exePath = Resolve-WingetPath
+  Write-Host "  running: $exePath $($WingetArgs -join ' ')"
+  $stdout = & $exePath @WingetArgs 2>&1 | Out-String
+  Save-Text -Name $Name -Value $stdout
+  Save-Json -Name "$Name-meta" -Value ([pscustomobject]@{
+    Executable = $exePath
+    Arguments  = $WingetArgs
+    ExitCode   = $LASTEXITCODE
+    RanAs      = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+    IsSystem   = [System.Security.Principal.WindowsIdentity]::GetCurrent().IsSystem
+  })
+  return $stdout
+}
+```
+
+- [ ] **Step 2: Add the Baseline phase (Q1) to the same file**
+
+Append to `scripts/hp-warranty-lab/hp-cmsl-probe.ps1`:
+
+```powershell
+switch ($Phase) {
+
+'Baseline' {
+  # Q1 -- does root/HP/InstrumentedServices/v1 exist WITHOUT CMSL installed?
+  #
+  # MUST run before any install phase on this machine. Once CMSL has run once,
+  # this machine can never answer Q1 again.
+
+  Save-Json -Name '01-identity' -Value ([pscustomobject]@{
+    Hostname      = $env:COMPUTERNAME
+    RunAs         = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+    IsSystem      = [System.Security.Principal.WindowsIdentity]::GetCurrent().IsSystem
+    PSVersion     = $PSVersionTable.PSVersion.ToString()
+    PSEdition     = $PSVersionTable.PSEdition
+    OSCaption     = (Get-CimInstance Win32_OperatingSystem).Caption
+    OSBuild       = (Get-CimInstance Win32_OperatingSystem).BuildNumber
+    OSInstallDate = (Get-CimInstance Win32_OperatingSystem).InstallDate
+    CultureTag    = (Get-Culture).Name
+    UICultureTag  = (Get-UICulture).Name
+    SystemLocale  = $(try { (Get-WinSystemLocale).Name } catch { '<unavailable>' })
+    Tls12Enabled  = ([Net.ServicePointManager]::SecurityProtocol -band [Net.SecurityProtocolType]::Tls12) -ne 0
+  })
+
+  Save-Json -Name '02-hardware' -Value ([pscustomobject]@{
+    ComputerSystem = Get-CimInstance Win32_ComputerSystem |
+      Select-Object Manufacturer, Model, SystemFamily, SystemSKUNumber
+    Bios = Get-CimInstance Win32_BIOS |
+      Select-Object Manufacturer, SerialNumber, SMBIOSBIOSVersion, ReleaseDate
+    Product = Get-CimInstance -ClassName Win32_ComputerSystemProduct |
+      Select-Object Name, Vendor, IdentifyingNumber, UUID
+  })
+
+  # PROVE CMSL IS ABSENT. Without this, a positive namespace result is
+  # meaningless -- the machine may simply have had CMSL installed last year.
+  $cmslModules = @(Get-Module -ListAvailable -Name HPCMSL -ErrorAction SilentlyContinue |
+    Select-Object Name, Version, ModuleBase)
+  $cmslCommand = @(Get-Command Get-HPWarrantyInfo -ErrorAction SilentlyContinue |
+    Select-Object Name, Source, Version)
+  Save-Json -Name '03-cmsl-absence' -Value ([pscustomobject]@{
+    ModulesFound    = $cmslModules
+    CommandFound    = $cmslCommand
+    HpSoftware      = Get-HpInstalledSoftware
+    ModuleDirExists = (Test-Path 'C:\Program Files\WindowsPowerShell\Modules\HPCMSL')
+  })
+  Invoke-Winget -Name '04-winget-list-hpcmsl' -WingetArgs @(
+    'list', '--exact', '--id', 'HP.HPCMSL', '--scope', 'machine',
+    '--source', 'winget', '--accept-source-agreements', '--disable-interactivity'
+  ) | Out-Null
+
+  # THE QUESTION ITSELF. Walk down, so a negative result says WHERE it stopped:
+  # "root\HP does not exist at all" and "root\HP exists but has no
+  # InstrumentedServices child" are different findings about HP's factory image.
+  $hpChildren  = Get-CimOrNull -Namespace 'root/HP' -ClassName '__NAMESPACE'
+  $isvChildren = Get-CimOrNull -Namespace 'root/HP/InstrumentedServices' -ClassName '__NAMESPACE'
+  Save-Json -Name '05-namespace-walk' -Value ([pscustomobject]@{
+    RootHpExists              = ($null -ne $hpChildren)
+    RootHpChildren            = @($hpChildren | Select-Object -ExpandProperty Name -ErrorAction SilentlyContinue)
+    InstrumentedServicesExists = ($null -ne $isvChildren)
+    InstrumentedServicesChildren = @($isvChildren | Select-Object -ExpandProperty Name -ErrorAction SilentlyContinue)
+    # HP's BIOS WMI provider ships on the factory image independently of CMSL.
+    # Capturing it distinguishes "this machine has NO HP WMI at all" from
+    # "HP WMI is here, the warranty classes are not".
+    InstrumentedBiosExists    = ($null -ne (Get-CimOrNull -Namespace 'root/HP/InstrumentedBIOS' -ClassName '__NAMESPACE'))
+  })
+
+  $warrantyClass     = Get-CimClassOrNull -Namespace $HpNamespaceV1 -ClassName 'HP_Warranty'
+  $entitlementsClass = Get-CimClassOrNull -Namespace $HpNamespaceV1 -ClassName 'HP_Entitlements'
+  $warrantyRows      = Get-CimOrNull -Namespace $HpNamespaceV1 -ClassName 'HP_Warranty'
+  $entitlementRows   = Get-CimOrNull -Namespace $HpNamespaceV1 -ClassName 'HP_Entitlements'
+
+  Save-Json -Name '06-warranty-classes-before-cmsl' -Value ([pscustomobject]@{
+    Namespace              = $HpNamespaceV1
+    HpWarrantyClassExists      = ($null -ne $warrantyClass)
+    HpEntitlementsClassExists  = ($null -ne $entitlementsClass)
+    HpWarrantyInstanceCount    = @($warrantyRows).Count
+    HpEntitlementsInstanceCount = @($entitlementRows).Count
+    HpWarrantyInstances     = @($warrantyRows | Select-Object -Property * -ExcludeProperty Cim*)
+    HpEntitlementsInstances = @($entitlementRows | Select-Object -Property * -ExcludeProperty Cim*)
+  })
+  Save-Json -Name '07-warranty-property-shapes' -Value ([pscustomobject]@{
+    HpWarranty     = Describe-Properties $warrantyRows
+    HpEntitlements = Describe-Properties $entitlementRows
+  })
+
+  Save-Json -Name '08-hp-services' -Value @(Get-Service -ErrorAction SilentlyContinue |
+    Where-Object { $_.Name -like 'HP*' -or $_.DisplayName -like 'HP *' } |
+    Select-Object Name, DisplayName, Status, StartType)
+
+  Write-Host ''
+  Write-Host '=== Q1 ANSWER ==='
+  Write-Host ("  CMSL installed already : {0}" -f ($cmslModules.Count -gt 0))
+  Write-Host ("  {0} reachable : {1}" -f $HpNamespaceV1, ($null -ne $warrantyClass))
+  Write-Host ("  HP_Warranty rows       : {0}" -f @($warrantyRows).Count)
+  Write-Host ("  HP_Entitlements rows   : {0}" -f @($entitlementRows).Count)
+  Write-Host 'A machine reporting CMSL installed already CANNOT answer Q1 -- record it as INELIGIBLE.'
+}
+
+}
+```
+
+- [ ] **Step 3: Run it against the operator's own HP machine to prove the script executes**
+
+Run (on any HP Windows device, elevated):
+
+```
+powershell -NoProfile -ExecutionPolicy Bypass -File scripts\hp-warranty-lab\hp-cmsl-probe.ps1 -Phase Baseline
+```
+
+Expected: the script completes with no red text and prints an artefact directory containing `01-identity.json` through `08-hp-services.json`. On a **non-HP** machine it still completes — `02-hardware.json` simply reports another manufacturer and `06-…` reports `false`/`0`. A crash here is a script bug, not a finding; fix it before hand-off.
+
+- [ ] **Step 4: Write the README with the safety statement, run order and Q1 criteria**
+
+Create `scripts/hp-warranty-lab/README.md`:
+
+```markdown
+# HP CMSL warranty lab probe (Breeze #5511 W01 / #5512)
+
+Answers the three hardware questions wave W01 is the gate for. Results go on
+GitHub issue #5512 using the template at the bottom of this file.
+
+## Safety, licence and reversibility — read before running
+
+- Phases `InstallPinned` and `Collect` install HP's Client Management Script
+  Library (`HP.HPCMSL`) **from HP, via winget**. Breeze never mirrors or hosts
+  that installer: HP's licence states verbatim *"You do not have the right to
+  distribute the Software Product."*
+- `--accept-package-agreements` (which a silent install requires) **accepts
+  HP's EULA on behalf of the machine's owner**. Run those phases only on
+  hardware you own or have written permission to modify. Never against a
+  customer endpoint.
+- HP's licence permits HP to collect technical information **including the
+  device's IP address** when `Get-HPWarrantyInfo` calls home.
+- HP rate-limits the warranty backend to ~300 requests / 5 minutes **per source
+  IP** — per customer NAT, not per device. The script never loops the call.
+- `-Phase Teardown` uninstalls CMSL. It does **not** delete the WMI namespace:
+  whether `root/HP/InstrumentedServices/v1` survives an uninstall is itself a
+  Q1 datapoint, and hand-deleting WMI namespaces on a live endpoint is not safe.
+- Nothing in this directory writes to a Breeze database or touches a tenant.
+
+## Run order (forced)
+
+1. `-Phase Baseline` — **must be first on each machine.** Once CMSL has run
+   once, that machine can never answer Q1 again.
+2. `-Phase InstallPinned -PinnedVersion <older>` then `-Phase WingetScan` — Q2.
+3. `-Phase Collect` — Q3. Leaves the machine on the current CMSL.
+4. `-Phase Teardown` — optional; returns the machine toward its prior state.
+
+If step 2 cannot be completed (no older version published, no ring available),
+**step 3 is not blocked**: install the current version with
+`winget install --exact --id HP.HPCMSL --scope machine --silent --accept-package-agreements --accept-source-agreements --source winget --disable-interactivity`
+and run `-Phase Collect`.
+
+## Q1 — does `root/HP/InstrumentedServices/v1` exist without CMSL?
+
+Run `-Phase Baseline` on **at least three HP devices with different
+provenance**: an untouched OEM image, a corporate re-image (MDT/Autopilot/SCCM
+task sequence), and one that has been in service more than a year. One machine
+answers nothing useful — the question is what fraction of a real fleet is
+pre-populated.
+
+- **Eligible** only if `03-cmsl-absence.json` shows `ModulesFound: []` and
+  `CommandFound: []`. A machine with CMSL already installed is INELIGIBLE for
+  Q1; record it as such rather than reporting its namespace as a positive.
+- **PASS (pre-populated)** — `06-…json` has `HpWarrantyClassExists: true` **and**
+  `HpWarrantyInstanceCount >= 1`. A class that exists with zero instances is
+  **not** a pass: T0 would read nothing.
+- **FAIL (not pre-populated)** — class missing, or present with zero rows.
+
+Consequence, stated up front so the result is not re-litigated later: a
+substantial PASS rate means T0 alone covers part of the fleet at zero install
+and zero EULA exposure, and W04 (the built-in catalog package that keeps CMSL
+installed) covers only the remainder. A uniform FAIL means W04 is load-bearing.
+Either way the answer is recorded on #5512 as a table, one row per machine.
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/hp-warranty-lab/hp-cmsl-probe.ps1 scripts/hp-warranty-lab/README.md
+git commit -m "lab(warranty): HP CMSL probe script + Q1 namespace-without-CMSL baseline phase (#5512)"
+```
+
+- [ ] **Step 6 (operator, asynchronous): run Baseline on >= 3 HP devices and post the Q1 table to #5512**
+
+This checkbox stays open until real hardware results exist. It does **not** block Tasks 4-11.
+
+```
+| Host | Model | Provenance | CMSL absent? | v1 namespace? | HP_Warranty rows | HP_Entitlements rows |
+|------|-------|------------|--------------|---------------|------------------|----------------------|
+```
+
+Attach `05-namespace-walk.json`, `06-warranty-classes-before-cmsl.json` and
+`07-warranty-property-shapes.json` from each machine.
+
+---
+
+### Task 2: The `InstallPinned` + `WingetScan` phases — Q2, "does a real old→new CMSL upgrade flow through a Breeze third-party ring?"
+
+**Files:**
+- Modify: `scripts/hp-warranty-lab/hp-cmsl-probe.ps1` (two new arms in the existing `switch`)
+- Modify: `scripts/hp-warranty-lab/README.md` (Q2 section)
+
+**Interfaces:**
+- Consumes: Task 1's helpers (`Invoke-Winget`, `Save-Json`, `Save-Text`, `Get-HpInstalledSoftware`, `Resolve-WingetPath`).
+- Produces: `-Phase InstallPinned -PinnedVersion <v>` and `-Phase WingetScan`. Leaves CMSL installed, which is the state Task 3 wants.
+
+**What is actually unproven here.** Spec layer 4's *generic* half is real and needs no HP-specific registration: the agent retains the package id (`heartbeat.go:3437`), maps the `winget` provider to `third_party` (`:3581-3582`), ingest upserts `patches` + `device_patches` (`routes/agents/patches.ts:222,289`), and the evaluator loads rings. The unproven link is the **first** one: `winget upgrade --include-unknown --scope machine --source winget` enumerates *winget-tracked packages*, not PowerShell modules. It works only if winget classifies HP's InnoSetup-based installer as a machine-scope package **and** reports an available upgrade for it. `Install-Module -Scope AllUsers` establishes neither condition, and the user-scope fallback does not rescue it — `winget_system.go:186-194` refuses user-only remediation outright.
+
+**If this fails, the decision goes back to Todd — a wave does not pick the fallback.** The fallback (the agent enforcing a floor CMSL version directly) **bypasses the customer's patch-approval rings**, and that was explicitly *not* the chosen option. Record the failure, state which of the four dual-consent conditions (`patchApprovalEvaluator.ts:616-629`) or which parse step broke, and re-open the decision on #5511. Do not implement a floor-version enforcer inside W03 on the strength of a red lab result.
+
+- [ ] **Step 1: Add the `InstallPinned` arm**
+
+Insert into the `switch ($Phase) { ... }` block in `scripts/hp-warranty-lab/hp-cmsl-probe.ps1`, after the `'Baseline'` arm:
+
+```powershell
+'InstallPinned' {
+  # Q2 setup -- put an OLDER CMSL on the box so there is a real upgrade to see.
+  # Installing the current version proves nothing: winget would report no
+  # available upgrade and the whole chain would look "broken" for the wrong
+  # reason.
+  if (-not $PinnedVersion) {
+    throw '-PinnedVersion is required for this phase. Run -Phase WingetScan first with no CMSL installed to list published versions, or use: winget show --exact --id HP.HPCMSL --source winget --versions'
+  }
+
+  Invoke-Winget -Name '10-available-versions' -WingetArgs @(
+    'show', '--exact', '--id', 'HP.HPCMSL', '--source', 'winget',
+    '--versions', '--accept-source-agreements', '--disable-interactivity'
+  ) | Out-Null
+
+  # EXACTLY the Breeze agent's own machine-scope install argv
+  # (winget_system.go:78-81), plus --version. Any deviation answers a different
+  # question than the one being asked.
+  Invoke-Winget -Name '11-install-pinned' -WingetArgs @(
+    'install', '--exact', '--id', 'HP.HPCMSL', '--version', $PinnedVersion,
+    '--scope', 'machine', '--silent',
+    '--accept-package-agreements', '--accept-source-agreements',
+    '--source', 'winget', '--disable-interactivity'
+  ) | Out-Null
+
+  Invoke-Winget -Name '12-list-after-install' -WingetArgs @(
+    'list', '--exact', '--id', 'HP.HPCMSL', '--scope', 'machine',
+    '--source', 'winget', '--accept-source-agreements', '--disable-interactivity'
+  ) | Out-Null
+
+  Save-Json -Name '13-post-install-state' -Value ([pscustomobject]@{
+    RequestedVersion = $PinnedVersion
+    ModulesFound     = @(Get-Module -ListAvailable -Name HPCMSL -ErrorAction SilentlyContinue |
+                          Select-Object Name, Version, ModuleBase)
+    HpSoftware       = Get-HpInstalledSoftware
+  })
+
+  Write-Host ''
+  Write-Host '=== InstallPinned done. Next: -Phase WingetScan ==='
+}
+```
+
+- [ ] **Step 2: Add the `WingetScan` arm**
+
+Insert after the `'InstallPinned'` arm:
+
+```powershell
+'WingetScan' {
+  # Q2 proper. THREE separate things must hold, and they fail in different
+  # places, so all three are captured rather than collapsed into one verdict:
+  #
+  #  1. winget's machine-scope upgrade list mentions HP.HPCMSL at all;
+  #  2. the output is the ENGLISH fixed-width table the Breeze parser needs
+  #     (winget_parse.go:66-73 keys on the literal headers Name/Id/Version/
+  #     Available; anything else yields errWingetNoTable -> ErrScanSkipped);
+  #  3. the row survives the agent -> API -> ring chain, which is verified
+  #     server-side, not here.
+  #
+  # RUN THIS AS SYSTEM. The Breeze agent is a SYSTEM service, and winget behaves
+  # differently there (no user profile, different package visibility). Running
+  # it as an interactive admin can pass while the agent's own scan finds
+  # nothing. See README.md for both ways to get a SYSTEM shell.
+  Save-Json -Name '20-scan-context' -Value ([pscustomobject]@{
+    RunAs        = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+    IsSystem     = [System.Security.Principal.WindowsIdentity]::GetCurrent().IsSystem
+    CultureTag   = (Get-Culture).Name
+    UICultureTag = (Get-UICulture).Name
+    WingetPath   = Resolve-WingetPath
+  })
+  if (-not [System.Security.Principal.WindowsIdentity]::GetCurrent().IsSystem) {
+    Write-Warning 'NOT running as SYSTEM. This result does not answer Q2 -- see README.md.'
+  }
+
+  # Byte-for-byte the agent's scan argv (winget_system.go:73-76).
+  $scan = Invoke-Winget -Name '21-system-upgrade-scan' -WingetArgs @(
+    'upgrade', '--include-unknown', '--scope', 'machine',
+    '--source', 'winget', '--accept-source-agreements', '--disable-interactivity'
+  )
+
+  $hasEnglishHeaders = ($scan -match '\bName\b') -and ($scan -match '\bId\b') -and
+                       ($scan -match '\bVersion\b') -and ($scan -match '\bAvailable\b')
+  $cmslLines = @(($scan -split "`r?`n") | Where-Object { $_ -match 'HP\.HPCMSL' })
+
+  Save-Json -Name '22-scan-verdict' -Value ([pscustomobject]@{
+    EnglishHeadersPresent = $hasEnglishHeaders
+    CmslRowPresent        = ($cmslLines.Count -gt 0)
+    CmslLines             = $cmslLines
+  })
+
+  Write-Host ''
+  Write-Host '=== Q2 (device half) ==='
+  Write-Host ("  English fixed-width headers : {0}" -f $hasEnglishHeaders)
+  Write-Host ("  HP.HPCMSL upgrade row       : {0}" -f ($cmslLines.Count -gt 0))
+  Write-Host '  Server half: force a Breeze patch scan, then run the SQL in README.md.'
+}
+```
+
+- [ ] **Step 3: Verify both arms parse**
+
+Run (any Windows machine; `InstallPinned` will fail fast without a real HP box, which is fine — the point is that PowerShell accepts the file):
+
+```
+powershell -NoProfile -ExecutionPolicy Bypass -Command "$null = [System.Management.Automation.Language.Parser]::ParseFile('scripts\hp-warranty-lab\hp-cmsl-probe.ps1', [ref]$null, [ref]$errs); $errs"
+```
+
+Expected: no parse errors printed.
+
+- [ ] **Step 4: Document Q2 in the README, including the server-side half**
+
+Append to `scripts/hp-warranty-lab/README.md`:
+
+```markdown
+## Q2 — does an old→new CMSL upgrade reach a Breeze third-party ring?
+
+**Preconditions, all of them.** Missing one turns a green chain red for the
+wrong reason:
+
+1. The device is enrolled in a Breeze instance you control (a worktree stack is
+   fine; do not use production).
+2. A **patch configuration policy** applying to this device has `sources`
+   containing the literal `'third_party'`. The evaluator's check is deliberately
+   narrower than its own source bucket — `patchApprovalEvaluator.ts:610-615`
+   records that a policy whose sources are only `['custom']` does **not** grant
+   third-party auto-approval.
+3. The ring that policy links has `autoApprove.enabled = true`,
+   `autoApprove.thirdPartyApps = true`, and
+   `thirdPartyDeferralDays` (or `deferralDays`) `= 0`, so nothing is held.
+   All four conditions: `patchApprovalEvaluator.ts:616-629`.
+4. `-Phase WingetScan` runs **as SYSTEM**. Either:
+   - run the command through a Breeze script on that device (the agent executes
+     scripts as SYSTEM — this is the closest thing to the real path), or
+   - `psexec -s -h -w C:\ powershell.exe -NoProfile -ExecutionPolicy Bypass -File C:\path\hp-cmsl-probe.ps1 -Phase WingetScan`
+     (Sysinternals).
+
+   A pass obtained as an interactive admin does **not** answer Q2.
+
+**Device half — PASS** when `22-scan-verdict.json` reports
+`EnglishHeadersPresent: true` **and** `CmslRowPresent: true`.
+`EnglishHeadersPresent: false` on a localized Windows is a distinct, expected
+finding: the Breeze parser is fixed-width on the English headers
+(`winget_parse.go:66-73`) and returns `ErrScanSkipped` — record it as a
+localization limitation, not as "CMSL does not surface".
+
+**Server half.** Force a patch scan from Breeze for that device, then query the
+API's database:
+
+```sql
+SELECT p.source,
+       p.package_id,
+       p.external_id,
+       p.version        AS shared_version,
+       p.vendor,
+       p.category,
+       dp.status,
+       dp.available_version,
+       dp.scope,
+       dp.last_checked_at
+FROM device_patches dp
+JOIN patches p ON p.id = dp.patch_id
+JOIN devices d ON d.id = dp.device_id
+WHERE d.hostname = '<HOSTNAME>'
+  AND p.package_id ILIKE 'HP.HPCMSL';
+```
+
+Local stack: `docker exec -it breeze-postgres psql -U breeze_app -d breeze`.
+
+- **PASS** — a row exists, `p.source = 'third_party'`, and `dp.status` reaches
+  `approved` after ring evaluation, and a subsequent install advances the
+  installed version.
+- **FAIL, ring-shaped** — the row exists but `p.source = 'custom'`. `custom` is
+  outside the evaluator's literal `'third_party'` check
+  (`patchApprovalEvaluator.ts:617-620`), so it can never ring-auto-approve.
+  Record the exact provider id the agent reported.
+- **FAIL, scan-shaped** — no row at all. Attach `21-system-upgrade-scan.txt`.
+
+**If Q2 fails, stop.** The fallback — the agent enforcing a floor CMSL version
+itself — bypasses the customer's approval rings, which Todd explicitly did not
+choose. Post the failure on #5512, summarise which link broke, and re-open the
+decision on #5511. **Do not let W03 adopt the fallback on its own authority.**
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/hp-warranty-lab/hp-cmsl-probe.ps1 scripts/hp-warranty-lab/README.md
+git commit -m "lab(warranty): InstallPinned + WingetScan phases for the CMSL upgrade-through-a-ring gate (#5512)"
+```
+
+- [ ] **Step 6 (operator, asynchronous): run Q2 and post the verdict to #5512**
+
+Stays open until real hardware results exist; does not block Tasks 4-11.
+
+---
+
+### Task 3: The `Collect` and `Teardown` phases — Q3, "what does `Get-HPWarrantyInfo` actually return?"
+
+**Files:**
+- Modify: `scripts/hp-warranty-lab/hp-cmsl-probe.ps1` (two new arms)
+- Modify: `scripts/hp-warranty-lab/README.md` (Q3 section + results template)
+
+**Interfaces:**
+- Consumes: Task 1's helpers, especially `Describe-Properties` and `Get-CimOrNull`.
+- Produces: `-Phase Collect` and `-Phase Teardown`. The captured JSON is the **input to W03's parser** — W03 writes its fixtures from these files, not from HP's documentation.
+
+**Why the capture has to be this pedantic.** W03's collector reads
+`root/HP/InstrumentedServices/v1` through `Get-CimInstance -Namespace`
+(spec correction: the agent has no Go WMI binding), and its scheduler keys off
+**HP's own cache timestamp** rather than a fixed interval — HP self-caches for
+30 days, so a day-25 invocation returns stored data and refreshes nothing. That
+timestamp's property name is not documented anywhere trustworthy, which is why
+`Describe-Properties` reports every property's CLR type and whether its value
+parses as a date: the timestamp gets *identified*, not guessed.
+
+- [ ] **Step 1: Add the `Collect` arm**
+
+Insert after the `'WingetScan'` arm in `scripts/hp-warranty-lab/hp-cmsl-probe.ps1`:
+
+```powershell
+'Collect' {
+  # Q3 -- the field-by-field capture W03's parser is written against.
+
+  Import-Module HPCMSL -ErrorAction Stop
+  Save-Json -Name '30-module' -Value @(Get-Module HPCMSL |
+    Select-Object Name, Version, ModuleBase, Path)
+
+  # Does it really take no parameters, and is there any forced-refresh switch?
+  # W03 needs to know whether a refresh can be forced AT ALL before designing a
+  # due-time policy around HP's 30-day cache.
+  $cmd = Get-Command Get-HPWarrantyInfo -ErrorAction Stop
+  Save-Json -Name '31-command-surface' -Value ([pscustomobject]@{
+    Name          = $cmd.Name
+    ModuleName    = $cmd.ModuleName
+    ParameterSets = @($cmd.ParameterSets | ForEach-Object { $_.ToString() })
+    ParameterNames = @($cmd.Parameters.Keys)
+  })
+  Save-Text -Name '32-command-help' -Value ((Get-Help Get-HPWarrantyInfo -Full | Out-String))
+
+  # TWO timed calls. A large first / tiny second is the cache doing its job, and
+  # is the cheapest possible confirmation of HP's 30-day self-cache claim. Two
+  # calls -- never a loop: the backend limit is ~300 requests / 5 minutes per
+  # SOURCE IP, i.e. per customer NAT.
+  $sw1 = [System.Diagnostics.Stopwatch]::StartNew()
+  $first = Get-HPWarrantyInfo
+  $sw1.Stop()
+  $sw2 = [System.Diagnostics.Stopwatch]::StartNew()
+  $second = Get-HPWarrantyInfo
+  $sw2.Stop()
+
+  Save-Json -Name '33-cmdlet-output-first'  -Value $first
+  Save-Json -Name '34-cmdlet-output-second' -Value $second
+  Save-Json -Name '35-cmdlet-timing' -Value ([pscustomobject]@{
+    FirstCallMs  = $sw1.ElapsedMilliseconds
+    SecondCallMs = $sw2.ElapsedMilliseconds
+    CachedLikely = ($sw2.ElapsedMilliseconds * 4) -lt $sw1.ElapsedMilliseconds
+  })
+  Save-Json -Name '36-cmdlet-property-shapes' -Value (Describe-Properties $first)
+
+  # The WMI side -- this, not the cmdlet's return value, is what the agent's T0
+  # tier actually reads.
+  $warrantyRows    = Get-CimOrNull -Namespace $HpNamespaceV1 -ClassName 'HP_Warranty'
+  $entitlementRows = Get-CimOrNull -Namespace $HpNamespaceV1 -ClassName 'HP_Entitlements'
+
+  Save-Json -Name '37-wmi-hp-warranty' -Value @($warrantyRows |
+    Select-Object -Property * -ExcludeProperty Cim*)
+  Save-Json -Name '38-wmi-hp-entitlements' -Value @($entitlementRows |
+    Select-Object -Property * -ExcludeProperty Cim*)
+  Save-Json -Name '39-wmi-property-shapes' -Value ([pscustomobject]@{
+    HpWarranty            = Describe-Properties $warrantyRows
+    HpEntitlements        = Describe-Properties $entitlementRows
+    HpEntitlementRowCount = @($entitlementRows).Count
+  })
+
+  # CIM class metadata: property names WITH their CIM types. A JSON dump alone
+  # cannot tell a CIM_DATETIME from a string that happens to look like a date,
+  # and W03's parser has to know which it is.
+  foreach ($cls in @('HP_Warranty', 'HP_Entitlements')) {
+    $c = Get-CimClassOrNull -Namespace $HpNamespaceV1 -ClassName $cls
+    Save-Json -Name ("40-cimclass-" + $cls) -Value ([pscustomobject]@{
+      ClassName  = $cls
+      Exists     = ($null -ne $c)
+      Properties = @($c.CimClassProperties | Select-Object Name, CimType, Flags)
+    })
+  }
+
+  # The exact one-liner shape the agent will run, captured verbatim so W03 can
+  # diff its own output against a known-good sample.
+  $t0Script = "Get-CimInstance -Namespace '$HpNamespaceV1' -ClassName HP_Entitlements | Select-Object -Property * -ExcludeProperty Cim* | ConvertTo-Json -Depth 5"
+  Save-Text -Name '41-t0-oneliner' -Value $t0Script
+  Save-Text -Name '42-t0-oneliner-output' -Value ((powershell -NoProfile -NonInteractive -Command $t0Script) | Out-String)
+
+  Write-Host ''
+  Write-Host '=== Q3 ANSWER ==='
+  Write-Host ("  first call {0} ms, second call {1} ms (cache likely: {2})" -f `
+    $sw1.ElapsedMilliseconds, $sw2.ElapsedMilliseconds, (($sw2.ElapsedMilliseconds * 4) -lt $sw1.ElapsedMilliseconds))
+  Write-Host ("  HP_Entitlements rows: {0}" -f @($entitlementRows).Count)
+  Write-Host '  Identify the cache-timestamp property in 36-/39- (ParsesAsDate = true) and name it on #5512.'
+}
+
+'Teardown' {
+  Invoke-Winget -Name '90-uninstall' -WingetArgs @(
+    'uninstall', '--exact', '--id', 'HP.HPCMSL', '--scope', 'machine',
+    '--silent', '--disable-interactivity'
+  ) | Out-Null
+
+  # Deliberately reports rather than deletes. Whether the namespace survives an
+  # uninstall is a Q1 datapoint for re-imaged machines, and hand-deleting WMI
+  # namespaces on a live endpoint is not a safe operation.
+  Save-Json -Name '91-post-teardown' -Value ([pscustomobject]@{
+    ModulesStillPresent   = @(Get-Module -ListAvailable -Name HPCMSL -ErrorAction SilentlyContinue |
+                               Select-Object Name, Version, ModuleBase)
+    ModuleDirStillExists  = (Test-Path 'C:\Program Files\WindowsPowerShell\Modules\HPCMSL')
+    NamespaceStillPresent = ($null -ne (Get-CimClassOrNull -Namespace $HpNamespaceV1 -ClassName 'HP_Warranty'))
+    WarrantyRowsRemaining = @(Get-CimOrNull -Namespace $HpNamespaceV1 -ClassName 'HP_Warranty').Count
+    HpSoftware            = Get-HpInstalledSoftware
+  })
+  Write-Host ''
+  Write-Host '=== Teardown done. Namespace intentionally left in place -- see 91-post-teardown.json ==='
+}
+```
+
+- [ ] **Step 2: Verify the file still parses**
+
+Run:
+
+```
+powershell -NoProfile -ExecutionPolicy Bypass -Command "$errs=$null; $null = [System.Management.Automation.Language.Parser]::ParseFile('scripts\hp-warranty-lab\hp-cmsl-probe.ps1', [ref]$null, [ref]$errs); $errs"
+```
+
+Expected: no parse errors.
+
+- [ ] **Step 3: Document Q3 and add the #5512 results template**
+
+Append to `scripts/hp-warranty-lab/README.md`:
+
+```markdown
+## Q3 — what does `Get-HPWarrantyInfo` actually return?
+
+Run `-Phase Collect` on one HP device with CMSL installed (Task 2 leaves it in
+that state; otherwise install the current version directly).
+
+Capture and post **all** of:
+
+- `31-command-surface.json` — confirms or refutes "takes no parameters", and
+  reveals whether a forced refresh is possible at all.
+- `33-cmdlet-output-first.json` + `36-cmdlet-property-shapes.json` — every
+  property with its CLR type and whether it parses as a date.
+- `35-cmdlet-timing.json` — the two-call timing that confirms the self-cache.
+- `37-wmi-hp-warranty.json`, `38-wmi-hp-entitlements.json`,
+  `39-wmi-property-shapes.json` — **the rows W03's T0 tier actually reads.**
+- `40-cimclass-HP_Warranty.json`, `40-cimclass-HP_Entitlements.json` — property
+  names with their CIM types, which a JSON dump alone cannot distinguish.
+- `42-t0-oneliner-output.txt` — the literal output of the command W03 will run.
+
+**The one answer that must be stated in words, not just attached:** *which
+property carries HP's own cache timestamp, what type it is, and what value it
+held.* W03's scheduler keys off that value rather than a fixed interval —
+HP self-caches for 30 days, so a day-25 invocation refreshes nothing. Look for
+`ParsesAsDate: true` in `36-` and `39-`.
+
+Also state the **entitlement row count** (`39-…HpEntitlementRowCount`) against
+the contract's bound of 25 per report. A device exceeding it is a finding.
+
+## Results template — paste onto issue #5512
+
+```
+### W01 lab gate results
+
+**Q1 — namespace without CMSL**
+| Host | Model | Provenance | CMSL absent? | v1 namespace? | HP_Warranty rows | HP_Entitlements rows |
+|------|-------|------------|--------------|---------------|------------------|----------------------|
+Verdict: PASS (pre-populated on N of M) / FAIL (never pre-populated)
+Consequence for W04:
+
+**Q2 — old→new CMSL upgrade through a Breeze ring**
+- Pinned from version: ... → available version: ...
+- Ran as SYSTEM: yes/no
+- English fixed-width headers present: yes/no
+- HP.HPCMSL row in the machine-scope upgrade list: yes/no
+- Stored `patches.source`: ...
+- `device_patches.status` after ring evaluation: ...
+- Install actually applied and version advanced: yes/no
+Verdict: PASS / FAIL (which link broke: ...)
+If FAIL: decision re-opened with Todd on #5511 — W03 must NOT adopt the
+agent-enforced floor-version fallback on its own authority.
+
+**Q3 — Get-HPWarrantyInfo shape**
+- Parameters: ...
+- Cache-timestamp property: `<name>` (`<type>`), value `<value>`
+- Forced refresh possible: yes/no (how)
+- Entitlement row count: N (bound is 25)
+- Attached: 31/33/35/36/37/38/39/40/42
+```
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/hp-warranty-lab/hp-cmsl-probe.ps1 scripts/hp-warranty-lab/README.md
+git commit -m "lab(warranty): Collect + Teardown phases and the #5512 results template (#5512)"
+```
+
+- [ ] **Step 5: Post the hand-off comment on #5512**
+
+```bash
+gh issue comment 5512 --body "$(cat <<'EOF'
+W01 lab probe is committed: `scripts/hp-warranty-lab/hp-cmsl-probe.ps1` + `README.md`.
+
+Run order (forced — Baseline must be first on each machine, and a machine that
+has ever had CMSL installed cannot answer Q1):
+
+1. `-Phase Baseline` on >= 3 HP devices with different provenance (OEM image,
+   corporate re-image, >1 year in service).
+2. `-Phase InstallPinned -PinnedVersion <older>` then `-Phase WingetScan`
+   **as SYSTEM**, with a third-party-enabled ring in place (preconditions in
+   README.md).
+3. `-Phase Collect` on one device.
+4. `-Phase Teardown` when finished.
+
+Read the safety/licence section first: these phases install HP software from HP
+and accept HP's EULA on the machine owner's behalf. Own hardware only.
+
+Post results with the template at the bottom of README.md. **W03 (#5514) and
+W04 (#5515) stay blocked until Q1/Q2/Q3 are answered here.** W01's ingest half
+is independent and proceeds now.
+EOF
+)"
+```
+
+- [ ] **Step 6 (operator, asynchronous): run Q3 and post the answers**
+
+Stays open until real hardware results exist. **The lab half of W01 is not
+complete until #5512 carries all three answers**, and W03/W04 must not start
+before then.
+
+---
+
+### Task 4: `warrantyDataSources.ts` — the one definition of "an agent wrote this row" (D9)
+
+**Files:**
+- Create: `apps/api/src/services/warrantyDataSources.ts`
+- Test: `apps/api/src/services/warrantyDataSources.test.ts`
+
+**Interfaces:**
+- Consumes: `normalizeManufacturer` (`services/warrantyProviders/index.ts:14`) and the `WarrantyEntitlement` type (`warrantyProviders/types.ts:1-7`). Neither pulls in `../db` — verified in Ground truth.
+- Produces, for Tasks 5-10:
+  - `AGENT_PLIST_WARRANTY_SOURCE: 'agent_plist'`, `AGENT_CMSL_WARRANTY_SOURCE: 'agent_cmsl'`
+  - `AGENT_OWNED_WARRANTY_SOURCE_LIST: readonly ['agent_plist', 'agent_cmsl']`
+  - `AGENT_OWNED_WARRANTY_SOURCES: ReadonlySet<string>`
+  - `isAgentOwnedWarrantySource(dataSource: string | null | undefined): boolean`
+  - `isAgentCollectedWarrantyDevice(input: { manufacturer: string | null | undefined; dataSource: string | null | undefined }): boolean`
+  - `warrantyEntitlementProviderForSource(source: string, manufacturer: string): 'dell' | 'hp' | 'lenovo' | 'apple' | null`
+  - `MAX_AGENT_WARRANTY_ENTITLEMENTS: 25`
+
+**Why a new module rather than more exports on `warrantySync.ts`.** Four
+unrelated writers need the same rule and only two of them want a database. The
+manual-refresh route (`routes/devices/warranty.ts`) would otherwise import
+`warrantySync.ts` — and with it `../db` — into its unit-test module graph for a
+two-line predicate, and `routes/agents/schemas.ts` would import a service just
+to read one bound. The module is pure string predicates: no `db`, no I/O, so its
+own test needs no mocks at all.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/src/services/warrantyDataSources.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+
+import {
+  AGENT_CMSL_WARRANTY_SOURCE,
+  AGENT_OWNED_WARRANTY_SOURCE_LIST,
+  AGENT_OWNED_WARRANTY_SOURCES,
+  AGENT_PLIST_WARRANTY_SOURCE,
+  MAX_AGENT_WARRANTY_ENTITLEMENTS,
+  isAgentCollectedWarrantyDevice,
+  isAgentOwnedWarrantySource,
+  warrantyEntitlementProviderForSource,
+} from './warrantyDataSources';
+
+describe('isAgentOwnedWarrantySource', () => {
+  it('recognises both agent collectors', () => {
+    expect(isAgentOwnedWarrantySource(AGENT_PLIST_WARRANTY_SOURCE)).toBe(true);
+    expect(isAgentOwnedWarrantySource(AGENT_CMSL_WARRANTY_SOURCE)).toBe(true);
+  });
+
+  it('does not claim server-written or imported rows', () => {
+    expect(isAgentOwnedWarrantySource('provider')).toBe(false);
+    expect(isAgentOwnedWarrantySource('import')).toBe(false);
+  });
+
+  it('is null-safe — data_source is a nullable varchar with no CHECK', () => {
+    expect(isAgentOwnedWarrantySource(null)).toBe(false);
+    expect(isAgentOwnedWarrantySource(undefined)).toBe(false);
+    expect(isAgentOwnedWarrantySource('')).toBe(false);
+  });
+
+  it('keeps the set and the list in agreement', () => {
+    expect([...AGENT_OWNED_WARRANTY_SOURCES].sort()).toEqual([...AGENT_OWNED_WARRANTY_SOURCE_LIST].sort());
+  });
+});
+
+describe('warrantyEntitlementProviderForSource', () => {
+  it('derives hp from the CMSL collector — the defect this replaces hardcoded apple', () => {
+    expect(warrantyEntitlementProviderForSource(AGENT_CMSL_WARRANTY_SOURCE, 'HP')).toBe('hp');
+    expect(warrantyEntitlementProviderForSource(AGENT_CMSL_WARRANTY_SOURCE, 'Hewlett-Packard')).toBe('hp');
+  });
+
+  it('keeps apple for the macOS plist collector', () => {
+    expect(warrantyEntitlementProviderForSource(AGENT_PLIST_WARRANTY_SOURCE, 'Apple Inc.')).toBe('apple');
+  });
+
+  it('falls back to the normalized manufacturer for an unknown source', () => {
+    expect(warrantyEntitlementProviderForSource('agent_future', 'Dell Inc.')).toBe('dell');
+    expect(warrantyEntitlementProviderForSource('agent_future', 'LENOVO')).toBe('lenovo');
+  });
+
+  it('returns null rather than mislabelling coverage it cannot attribute', () => {
+    expect(warrantyEntitlementProviderForSource('agent_future', 'Acme Whitebox')).toBeNull();
+    expect(warrantyEntitlementProviderForSource('agent_future', '')).toBeNull();
+  });
+
+  it('trusts the source over a contradictory manufacturer string', () => {
+    // A CMSL report is produced by HP's own tooling on an HP device; a garbled
+    // SMBIOS manufacturer must not turn its entitlements into Apple ones.
+    expect(warrantyEntitlementProviderForSource(AGENT_CMSL_WARRANTY_SOURCE, 'Apple Inc.')).toBe('hp');
+  });
+});
+
+describe('isAgentCollectedWarrantyDevice', () => {
+  it('is true for any HP device, with or without a stored row', () => {
+    expect(isAgentCollectedWarrantyDevice({ manufacturer: 'HP', dataSource: null })).toBe(true);
+    expect(isAgentCollectedWarrantyDevice({ manufacturer: 'Hewlett-Packard', dataSource: 'provider' })).toBe(true);
+  });
+
+  it('is true for a device whose row an agent already owns', () => {
+    expect(isAgentCollectedWarrantyDevice({ manufacturer: 'Apple Inc.', dataSource: AGENT_PLIST_WARRANTY_SOURCE })).toBe(true);
+  });
+
+  it('is false for a device a registered vendor provider can answer for', () => {
+    expect(isAgentCollectedWarrantyDevice({ manufacturer: 'Dell Inc.', dataSource: 'provider' })).toBe(false);
+    expect(isAgentCollectedWarrantyDevice({ manufacturer: 'Lenovo', dataSource: null })).toBe(false);
+  });
+
+  it('is false when the manufacturer is unknown and no agent row exists', () => {
+    expect(isAgentCollectedWarrantyDevice({ manufacturer: null, dataSource: null })).toBe(false);
+    expect(isAgentCollectedWarrantyDevice({ manufacturer: '', dataSource: undefined })).toBe(false);
+  });
+});
+
+describe('MAX_AGENT_WARRANTY_ENTITLEMENTS', () => {
+  it('is the contract bound of 25', () => {
+    expect(MAX_AGENT_WARRANTY_ENTITLEMENTS).toBe(25);
+  });
+});
+```
+
+- [ ] **Step 2: Run it to watch it fail**
+
+Run: `cd apps/api && npx vitest run src/services/warrantyDataSources.test.ts`
+Expected: FAIL — `Failed to resolve import "./warrantyDataSources"`.
+
+- [ ] **Step 3: Write the module**
+
+Create `apps/api/src/services/warrantyDataSources.ts`:
+
+```ts
+/**
+ * Which `device_warranty.data_source` values were written BY AN AGENT, and
+ * which vendor a synthesised agent entitlement belongs to.
+ *
+ * Its own module rather than more exports on `warrantySync.ts` because four
+ * unrelated writers need the same rule and only two of them want a database:
+ *   - `warrantySync.ts`                      — the direct sync + the 7-day sweep
+ *   - `customFields/import/warrantyTarget.ts` and `valueImport.ts` — CSV import
+ *   - `routes/devices/warranty.ts`            — manual refresh
+ *   - `routes/agents/schemas.ts`              — the entitlements bound
+ * Importing `warrantySync.ts` from a route would drag `../db` into that route's
+ * unit-test module graph for a two-line predicate. Nothing here does I/O.
+ *
+ * THE RULE: a row an agent wrote describes hardware the agent can see. A
+ * server-side vendor lookup, or a hand-typed CSV, must never overwrite it — the
+ * agent rewrites it on its next report anyway, so the overwrite destroys data
+ * and reports success. #5511 W01; `agent_plist` was already exposed to this
+ * before HP existed.
+ */
+import type { WarrantyEntitlement } from './warrantyProviders/types';
+import { normalizeManufacturer } from './warrantyProviders';
+
+/** macOS: `CollectAppleWarranty` reads the on-device AppleCare plist. */
+export const AGENT_PLIST_WARRANTY_SOURCE = 'agent_plist';
+/** Windows/HP: HP CMSL writes `root/HP/InstrumentedServices/v1`; the agent reads it. */
+export const AGENT_CMSL_WARRANTY_SOURCE = 'agent_cmsl';
+
+/**
+ * Ordered, so SQL predicates generated from it are stable across builds.
+ * `device_warranty.data_source` is `varchar(50)` with no CHECK and no enum
+ * (`db/schema/warranty.ts:50`), so THIS LIST — not the database — is the
+ * definition of "agent-owned".
+ */
+export const AGENT_OWNED_WARRANTY_SOURCE_LIST = [
+  AGENT_PLIST_WARRANTY_SOURCE,
+  AGENT_CMSL_WARRANTY_SOURCE,
+] as const;
+
+export const AGENT_OWNED_WARRANTY_SOURCES: ReadonlySet<string> = new Set(
+  AGENT_OWNED_WARRANTY_SOURCE_LIST,
+);
+
+export function isAgentOwnedWarrantySource(dataSource: string | null | undefined): boolean {
+  return typeof dataSource === 'string' && AGENT_OWNED_WARRANTY_SOURCES.has(dataSource);
+}
+
+/** Contract bound: at most 25 entitlements per agent report. */
+export const MAX_AGENT_WARRANTY_ENTITLEMENTS = 25;
+
+type EntitlementProvider = WarrantyEntitlement['provider'];
+
+/** The closed union from `warrantyProviders/types.ts:2`, as a runtime value. */
+const ENTITLEMENT_PROVIDERS: readonly EntitlementProvider[] = ['dell', 'hp', 'lenovo', 'apple'];
+
+const SOURCE_ENTITLEMENT_PROVIDER: Readonly<Record<string, EntitlementProvider>> = {
+  [AGENT_PLIST_WARRANTY_SOURCE]: 'apple',
+  [AGENT_CMSL_WARRANTY_SOURCE]: 'hp',
+};
+
+/**
+ * The `provider` a synthesised agent entitlement carries.
+ *
+ * Reporting source FIRST — the collector knows which vendor's data it read, and
+ * a garbled SMBIOS manufacturer string must not be able to re-attribute it —
+ * then the normalized manufacturer for any future collector not listed here.
+ *
+ * Returns null when neither resolves, and the caller then synthesises NO
+ * entitlement: one stamped with the wrong vendor is worse than a missing one.
+ * Everything downstream reads `entitlements[].provider` as ground truth, which
+ * is exactly why the hardcoded `provider: 'apple' as const` at
+ * `warrantySync.ts:367` was a defect and not a cosmetic default.
+ */
+export function warrantyEntitlementProviderForSource(
+  source: string,
+  manufacturer: string,
+): EntitlementProvider | null {
+  const bySource = SOURCE_ENTITLEMENT_PROVIDER[source];
+  if (bySource) return bySource;
+  const normalized = normalizeManufacturer(manufacturer ?? '');
+  return ENTITLEMENT_PROVIDERS.find((p) => p === normalized) ?? null;
+}
+
+/**
+ * True when a SERVER-SIDE warranty sync cannot produce anything for this
+ * device, so queuing one and answering "refresh queued" would be a lie (D11).
+ *
+ * Two cases:
+ *  - the stored row is already agent-owned — the device, not the server, is its
+ *    writer; and
+ *  - the device is HP — `warrantyProviders/index.ts:7-12` deliberately does not
+ *    register `hpProvider`, so `getProviderForManufacturer` returns null for
+ *    every HP device whether or not a row exists yet.
+ */
+export function isAgentCollectedWarrantyDevice(input: {
+  manufacturer: string | null | undefined;
+  dataSource: string | null | undefined;
+}): boolean {
+  if (isAgentOwnedWarrantySource(input.dataSource)) return true;
+  return normalizeManufacturer(input.manufacturer ?? '') === 'hp';
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd apps/api && npx vitest run src/services/warrantyDataSources.test.ts`
+Expected: PASS, 1 file, all cases green.
+
+- [ ] **Step 5: Typecheck and commit**
+
+```bash
+pnpm --filter @breeze/api exec tsc --noEmit
+git add apps/api/src/services/warrantyDataSources.ts apps/api/src/services/warrantyDataSources.test.ts
+git commit -m "feat(warranty): add warrantyDataSources — one definition of an agent-owned warranty row (D9, #5512)"
+```
+
+---
+
+### Task 5: Defect 1 — the synthesised entitlement's provider stops being hardcoded `'apple'`
+
+**Files:**
+- Modify: `apps/api/src/services/warrantySync.ts:364-373`
+- Test: `apps/api/src/services/warrantySync.test.ts` (append a describe block)
+
+**Interfaces:**
+- Consumes: `warrantyEntitlementProviderForSource` from Task 4.
+- Produces: nothing new; `upsertAgentWarranty`'s signature is unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `apps/api/src/services/warrantySync.test.ts` (the file's existing
+`insertMock`, `captureUpsert()`, `DEVICE_ID`, `ORG_ID` and `inDays()` are reused
+verbatim — do not redeclare them):
+
+```ts
+describe('upsertAgentWarranty entitlement provider (#5511 W01, defect 1)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("labels an HP CMSL entitlement 'hp', not 'apple'", async () => {
+    const { values, onConflictDoUpdate } = captureUpsert();
+
+    await upsertAgentWarranty(DEVICE_ID, ORG_ID, {
+      source: 'agent_cmsl',
+      manufacturer: 'HP',
+      serialNumber: 'HP-SERIAL-1',
+      coverageEndDate: inDays(400),
+      coverageStartDate: inDays(-100),
+      coverageType: 'HP 3y Next Business Day Onsite',
+    });
+
+    expect(values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entitlements: [expect.objectContaining({ provider: 'hp' })],
+      }),
+    );
+    // The UPDATE arm carries the same value — a fix applied to only one of the
+    // two would mislabel every row after the first report.
+    expect(onConflictDoUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        set: expect.objectContaining({
+          entitlements: [expect.objectContaining({ provider: 'hp' })],
+        }),
+      }),
+    );
+  });
+
+  it("still labels a macOS plist entitlement 'apple'", async () => {
+    const { values } = captureUpsert();
+
+    await upsertAgentWarranty(DEVICE_ID, ORG_ID, {
+      source: 'agent_plist',
+      manufacturer: 'Apple',
+      serialNumber: 'APPLE-SERIAL-1',
+      coverageEndDate: inDays(400),
+      coverageStartDate: inDays(-100),
+      coverageType: 'AppleCare+',
+    });
+
+    expect(values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entitlements: [expect.objectContaining({ provider: 'apple' })],
+      }),
+    );
+  });
+
+  it('synthesises no entitlement at all when the vendor cannot be attributed', async () => {
+    const { values } = captureUpsert();
+
+    await upsertAgentWarranty(DEVICE_ID, ORG_ID, {
+      source: 'agent_future',
+      manufacturer: 'Acme Whitebox',
+      serialNumber: 'ACME-1',
+      coverageEndDate: inDays(400),
+      coverageStartDate: inDays(-100),
+      coverageType: 'Some coverage',
+    });
+
+    // A mislabelled entitlement is worse than a missing one: everything
+    // downstream reads entitlements[].provider as ground truth.
+    expect(values).toHaveBeenCalledWith(expect.objectContaining({ entitlements: [] }));
+  });
+});
+```
+
+**Note for the implementer:** this file mocks `./warrantyProviders` with
+`normalizeManufacturer: (m: string) => m.toLowerCase()` (`:34`). That mock is
+what the *new* module will resolve too, so `'HP'.toLowerCase() === 'hp'`
+happens to satisfy the fallback path. The `'hp'` result above comes from the
+**source** map, not the manufacturer fallback, so the assertion holds either
+way — and `'Acme Whitebox'.toLowerCase()` is not in the union, so the third
+case is genuinely exercised.
+
+- [ ] **Step 2: Run it to watch it fail**
+
+Run: `cd apps/api && npx vitest run src/services/warrantySync.test.ts`
+Expected: FAIL — the first case reports `provider: 'apple'` where `'hp'` was
+expected; the third reports one entitlement where `[]` was expected. The two
+pre-existing describe blocks stay green.
+
+- [ ] **Step 3: Make the change**
+
+In `apps/api/src/services/warrantySync.ts`, add to the imports near `:1-6`:
+
+```ts
+import { warrantyEntitlementProviderForSource } from './warrantyDataSources';
+```
+
+Replace `:364-373` with:
+
+```ts
+  // Build the entitlements array from agent data.
+  //
+  // The provider is DERIVED, never hardcoded. This read `provider: 'apple' as
+  // const` (#5511 W01, defect 1), so every HP entitlement collected by CMSL
+  // would have been stored as an Apple entitlement — `'hp'` has been legal in
+  // the union (`warrantyProviders/types.ts:2`) the whole time. A null return
+  // means the coverage cannot be attributed to a vendor at all, in which case
+  // no entitlement is synthesised: a mislabelled one is worse than none.
+  const entitlementProvider = warrantyEntitlementProviderForSource(data.source, data.manufacturer);
+  const entitlements = data.coverageType && entitlementProvider
+    ? [{
+        provider: entitlementProvider,
+        serviceLevelDescription: data.coverageType,
+        entitlementType: data.coverageType,
+        startDate: data.coverageStartDate ?? '',
+        endDate: data.coverageEndDate ?? '',
+      }]
+    : [];
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd apps/api && npx vitest run src/services/warrantySync.test.ts`
+Expected: PASS — all three new cases plus the four pre-existing coverage-kind
+cases and the five VM-exclusion cases.
+
+- [ ] **Step 5: Typecheck and commit**
+
+```bash
+pnpm --filter @breeze/api exec tsc --noEmit
+git add apps/api/src/services/warrantySync.ts apps/api/src/services/warrantySync.test.ts
+git commit -m "fix(warranty): derive the agent entitlement provider instead of hardcoding apple (D10, #5512)"
+```
+
+---
+
+### Task 6: Defect 2 — the preservation branch stops being keyed to the literal `'agent_plist'` (real-DB, red-first)
+
+**Files:**
+- Create: `apps/api/src/__tests__/integration/agentWarrantyPreservation.integration.test.ts`
+- Modify: `apps/api/src/services/warrantySync.ts:153-165`
+
+**Interfaces:**
+- Consumes: `isAgentOwnedWarrantySource` from Task 4; `warrantyEntitlementProviderForSource`'s effect from Task 5 (the `'hp'` assertion below relies on it).
+- Produces: the new integration file, which Task 7 extends with a second describe block.
+
+**This is the data-loss defect, and its test must be watched failing.** On
+unmodified code an `agent_cmsl` row reaching `syncWarrantyForSubject` falls
+past `:153`'s literal string comparison into the `!provider` fall-through at
+`:170-176`, which calls `upsertWarranty(..., { found: false, entitlements: [],
+warrantyStartDate: null, warrantyEndDate: null })` — writing `dataSource:
+'provider'` (`:289`/`:305`), erasing both dates and emptying `entitlements`.
+Frequent agent reports keep pushing `nextSyncAt` out and mask it until reporting
+stops, which is what makes it latent rather than obvious.
+
+**Why it cannot be a unit test.** Every unit suite mocks `../db`, so the branch
+is exercised against a canned `dataSource` value rather than against the row the
+previous statement actually wrote. The whole point is that the *stored* row
+survives the *real* second write.
+
+**No config edit is needed:** `vitest.integration.config.ts`'s `include` already
+carries the standing glob `'src/__tests__/integration/**/*.test.ts'`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/src/__tests__/integration/agentWarrantyPreservation.integration.test.ts`:
+
+```ts
+/**
+ * Real-PostgreSQL proof that an AGENT-OWNED warranty row survives the
+ * server-side warranty machinery (#5511 W01).
+ *
+ * Both properties proven here are invisible to the mocked unit suites:
+ *
+ *  - `syncWarrantyForDevice` reads the STORED row and branches on its
+ *    `data_source`. Every unit test mocks `../db`, so that branch runs against
+ *    a canned value rather than against the row the previous statement wrote.
+ *  - `getDevicesNeedingWarrantySync`'s exclusion is a SQL predicate. The
+ *    chainable select mock returns whatever rows it is handed regardless of the
+ *    WHERE clause, so a unit test literally cannot fail when it is wrong.
+ *
+ * On unmodified code the first test is RED: the preservation branch is keyed to
+ * the literal 'agent_plist' (`warrantySync.ts:153`), so an `agent_cmsl` row
+ * falls through to the unknown-result upsert, which nulls both dates, empties
+ * `entitlements` and flips `data_source` back to 'provider'. That is silent
+ * data loss, not a cosmetic mislabel.
+ */
+import './setup';
+
+import { describe, expect, it } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { withSystemDbAccessContext } from '../../db';
+import { createOrganization, createPartner, createSite } from './db-utils';
+import { getTestDb } from './setup';
+import {
+  getDevicesNeedingWarrantySync,
+  syncWarrantyForDevice,
+  upsertAgentWarranty,
+} from '../../services/warrantySync';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+async function seedTenant() {
+  const partner = await createPartner();
+  const org = await createOrganization({ partnerId: partner.id });
+  const site = await createSite({ orgId: org.id });
+  return { org, site };
+}
+
+/** `is_virtual` and `is_ephemeral` default to false, so this row passes the sweep's exclusions. */
+async function seedDevice(orgId: string, siteId: string, agentId: string): Promise<string> {
+  const [row] = (await getTestDb().execute(sql`
+    INSERT INTO devices (org_id, site_id, agent_id, hostname, os_type, os_version, architecture, agent_version)
+    VALUES (${orgId}, ${siteId}, ${agentId}, ${'hp-host-' + agentId}, 'windows', '11', 'amd64', '1.0.0')
+    RETURNING id
+  `)) as unknown as Array<{ id: string }>;
+  return row!.id;
+}
+
+/** The sweep requires a NON-NULL serial AND manufacturer on device_hardware. */
+async function seedHardware(deviceId: string, orgId: string, manufacturer: string, serial: string): Promise<void> {
+  await getTestDb().execute(sql`
+    INSERT INTO device_hardware (device_id, org_id, manufacturer, serial_number)
+    VALUES (${deviceId}, ${orgId}, ${manufacturer}, ${serial})
+  `);
+}
+
+interface StoredWarranty {
+  data_source: string | null;
+  start_date: string | null;
+  end_date: string | null;
+  entitlement_count: number;
+  entitlement_provider: string | null;
+}
+
+async function readWarranty(deviceId: string): Promise<StoredWarranty[]> {
+  return (await getTestDb().execute(sql`
+    SELECT data_source,
+           warranty_start_date::text        AS start_date,
+           warranty_end_date::text          AS end_date,
+           jsonb_array_length(entitlements) AS entitlement_count,
+           entitlements #>> '{0,provider}'  AS entitlement_provider
+    FROM device_warranty
+    WHERE device_id = ${deviceId}
+  `)) as unknown as StoredWarranty[];
+}
+
+describe('agent-owned warranty rows survive a server sync (#5511 W01, defect 2)', () => {
+  runDb('an agent_cmsl row is preserved, not overwritten with an unknown provider result', async () => {
+    const { org, site } = await seedTenant();
+    const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const deviceId = await seedDevice(org.id, site.id, `hp-cmsl-${suffix}`);
+    await seedHardware(deviceId, org.id, 'HP', `SN-HP-${suffix}`);
+
+    await withSystemDbAccessContext(() =>
+      upsertAgentWarranty(deviceId, org.id, {
+        source: 'agent_cmsl',
+        manufacturer: 'HP',
+        serialNumber: `SN-HP-${suffix}`,
+        coverageStartDate: '2024-03-01',
+        coverageEndDate: '2099-03-01',
+        coverageType: 'HP 3y Next Business Day Onsite',
+        coverageKind: 'fixed',
+      }),
+    );
+
+    // Precondition, asserted rather than assumed: without it a green result
+    // below could mean the agent write never landed.
+    const before = await readWarranty(deviceId);
+    expect(before).toHaveLength(1);
+    expect(before[0]!.data_source).toBe('agent_cmsl');
+
+    // EXACTLY what the 7-day sweep does with a selected device subject, and
+    // what a manual refresh queues.
+    await withSystemDbAccessContext(() => syncWarrantyForDevice(deviceId));
+
+    const after = await readWarranty(deviceId);
+    expect(after).toHaveLength(1);
+    expect(
+      after[0]!.data_source,
+      'a server sweep must never take ownership of an agent-collected row',
+    ).toBe('agent_cmsl');
+    expect(after[0]!.end_date, 'the agent-reported coverage end date must survive').toBe('2099-03-01');
+    expect(after[0]!.start_date).toBe('2024-03-01');
+    expect(after[0]!.entitlement_count, 'entitlements must not be emptied').toBe(1);
+    expect(after[0]!.entitlement_provider).toBe('hp');
+  });
+
+  runDb('an agent_plist row is preserved too — the generalisation did not narrow it', async () => {
+    const { org, site } = await seedTenant();
+    const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const deviceId = await seedDevice(org.id, site.id, `apple-plist-${suffix}`);
+    await seedHardware(deviceId, org.id, 'Apple Inc.', `SN-APPLE-${suffix}`);
+
+    await withSystemDbAccessContext(() =>
+      upsertAgentWarranty(deviceId, org.id, {
+        source: 'agent_plist',
+        manufacturer: 'Apple Inc.',
+        serialNumber: `SN-APPLE-${suffix}`,
+        coverageStartDate: '2024-01-01',
+        coverageEndDate: '2098-01-01',
+        coverageType: 'AppleCare+',
+        coverageKind: 'fixed',
+      }),
+    );
+
+    await withSystemDbAccessContext(() => syncWarrantyForDevice(deviceId));
+
+    const after = await readWarranty(deviceId);
+    expect(after).toHaveLength(1);
+    expect(after[0]!.data_source).toBe('agent_plist');
+    expect(after[0]!.end_date).toBe('2098-01-01');
+    expect(after[0]!.entitlement_provider).toBe('apple');
+  });
+
+  runDb('a provider-owned row is still refreshed — the preservation branch did not swallow everyone', async () => {
+    const { org, site } = await seedTenant();
+    const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const deviceId = await seedDevice(org.id, site.id, `whitebox-${suffix}`);
+    await seedHardware(deviceId, org.id, 'Acme Whitebox', `SN-ACME-${suffix}`);
+
+    // POSITIVE CONTROL. No provider is registered for this manufacturer, so the
+    // sync takes the `!provider` fall-through and writes an `unknown` row with
+    // data_source 'provider' — which is the CORRECT behaviour for a device no
+    // agent has claimed, and must keep working after the fix.
+    await withSystemDbAccessContext(() => syncWarrantyForDevice(deviceId));
+
+    const after = await readWarranty(deviceId);
+    expect(after).toHaveLength(1);
+    expect(after[0]!.data_source).toBe('provider');
+  });
+});
+```
+
+- [ ] **Step 2: Run it against a real database to watch the RED**
+
+Bring the test database up if it is not already running, then run only this file:
+
+```bash
+pnpm --filter @breeze/api test:docker:up
+cd apps/api && npx vitest run --config vitest.integration.config.ts src/__tests__/integration/agentWarrantyPreservation.integration.test.ts
+```
+
+Expected, on unmodified code: **the first case FAILS** with
+`expected 'provider' to be 'agent_cmsl'` (and the date/entitlement assertions
+would fail too). The second and third cases PASS — the second because
+`'agent_plist'` still matches the literal at `:153`, the third because a
+provider-owned row is supposed to be rewritten.
+
+**Do not proceed on an assumed red.** If every case passes, the fixture is
+wrong — most likely `DATABASE_URL` is unset, so `it.runIf` skipped the whole
+file. A skipped suite reports as green. Confirm the runner printed
+`3 passed` / `1 failed`, not `3 skipped`.
+
+- [ ] **Step 3: Generalise the preservation branch**
+
+In `apps/api/src/services/warrantySync.ts`, extend the Task 5 import:
+
+```ts
+import {
+  isAgentOwnedWarrantySource,
+  warrantyEntitlementProviderForSource,
+} from './warrantyDataSources';
+```
+
+Replace `:143-166` with:
+
+```ts
+      // Check if we already have agent-reported warranty data for this subject.
+      // If so, don't overwrite it with an error — just skip. Only an agent
+      // writes an agent-owned source, so only a device subject can carry one.
+      if (subject.kind === 'device') {
+        const [existing] = await db
+          .select({ dataSource: deviceWarranty.dataSource, status: deviceWarranty.status })
+          .from(deviceWarranty)
+          .where(eq(deviceWarranty.deviceId, subject.deviceId))
+          .limit(1);
+
+        // Generalised, not given a second hardcoded string (#5511 W01, D9).
+        // Keyed to the literal 'agent_plist', this let an `agent_cmsl` row fall
+        // through to the unknown-result upsert below, which nulls both dates,
+        // empties `entitlements` and flips `data_source` back to 'provider'.
+        if (isAgentOwnedWarrantySource(existing?.dataSource)) {
+          // Agent-reported data exists — preserve it regardless of status.
+          //
+          // `lastSyncAt` is deliberately NOT stamped here: nothing was fetched.
+          // That column records the last time warranty data was actually
+          // OBTAINED, and the device card polls it to decide whether a manual
+          // refresh completed (`DeviceWarrantyCard.tsx:182`). Advancing it on a
+          // no-op reports success for a lookup that never happened.
+          const now = new Date();
+          await db
+            .update(deviceWarranty)
+            .set({
+              lastSyncError: null,
+              nextSyncAt: new Date(now.getTime() + SYNC_CADENCE_MS),
+              updatedAt: now,
+            })
+            .where(eq(deviceWarranty.deviceId, subject.deviceId));
+          return;
+        }
+      }
+```
+
+**Decision recorded (the contract did not settle it):** dropping `lastSyncAt`
+from this `set` is the spec's Layer 6 instruction — *"stop the Apple branch's
+habit of stamping `lastSyncAt` when nothing was fetched"* — and it is the reason
+Task 10's refusal must cover `agent_plist` as well as HP. The two are a matched
+pair: stop the false timestamp, and refuse the refresh up front so nobody waits
+on a spinner for it. Distinguishing HP's real *fetch* time from WMI *observation*
+time and report *receipt* time needs new columns and therefore a migration, so
+it is **not** W01 — it belongs to W03 if it is wanted.
+
+- [ ] **Step 4: Re-run the integration file to verify it passes**
+
+Run: `cd apps/api && npx vitest run --config vitest.integration.config.ts src/__tests__/integration/agentWarrantyPreservation.integration.test.ts`
+Expected: PASS, `3 passed`.
+
+- [ ] **Step 5: Re-run the unit suites this touched**
+
+Run: `cd apps/api && npx vitest run src/services/warrantySync.test.ts src/services/warrantySync.manualAsset.test.ts`
+Expected: PASS, 2 files. (Both filenames are listed explicitly — a bare
+`src/services/warrantySync` substring would also drag in unrelated matches, and
+a trailing-slash path would skip both.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+pnpm --filter @breeze/api exec tsc --noEmit
+git add apps/api/src/services/warrantySync.ts apps/api/src/__tests__/integration/agentWarrantyPreservation.integration.test.ts
+git commit -m "fix(warranty): preserve any agent-owned row on a server sync, not just agent_plist (D9, #5512)
+
+A sweep pass over an agent_cmsl row nulled both coverage dates, emptied
+entitlements and flipped data_source back to 'provider'. Real-DB regression
+watched failing on unmodified code first."
+```
+
+---
+
+### Task 7: The 7-day sweep stops re-selecting agent-owned rows (D9, place 2)
+
+**Files:**
+- Modify: `apps/api/src/services/warrantySync.ts:3` (import) and `:471-475` (the device arm's due-ness predicate)
+- Test: `apps/api/src/__tests__/integration/agentWarrantyPreservation.integration.test.ts` (second describe block)
+
+**Interfaces:**
+- Consumes: `AGENT_OWNED_WARRANTY_SOURCE_LIST` from Task 4; Task 6's preservation branch (the second layer of the same defence).
+- Produces: nothing new. `getDevicesNeedingWarrantySync(limit = 50)` keeps its signature.
+
+**Why this is needed once Task 6 already prevents the overwrite.** Two reasons,
+both real. First, every selected-but-preserved row consumes one of the page's
+`limit` slots (default 50) — an MSP with a large HP fleet would starve the
+subjects a vendor *can* answer for out of the sweep indefinitely. Second, it is
+defence in depth on a data-loss path: the preservation branch is one `if` away
+from the destructive fall-through, and a future refactor that moves it is
+otherwise unguarded.
+
+**The NULL trap this predicate has to get right.** `notInArray` compiles to
+`NOT IN (...)`, and `NULL NOT IN ('a','b')` evaluates to **NULL**, not TRUE.
+A row whose `data_source` was never set would therefore be dropped from the
+sweep entirely — fail-closed in the direction that silently stops syncing.
+The explicit `isNull(...)` arm is what keeps it eligible, and it is the same
+three-valued-logic trap that produced a fail-open SQL guard in W01 of #5099.
+
+- [ ] **Step 1: Write the failing test**
+
+Append a second describe block to
+`apps/api/src/__tests__/integration/agentWarrantyPreservation.integration.test.ts`
+(it reuses the file's existing `seedTenant`, `seedDevice`, `seedHardware` and
+`runDb` — do not redeclare them):
+
+```ts
+describe('the fleet sweep excludes agent-owned rows (#5511 W01, D9)', () => {
+  runDb('selects a device a vendor can answer for, skips one an agent owns', async () => {
+    const { org, site } = await seedTenant();
+    const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+
+    const agentDeviceId = await seedDevice(org.id, site.id, `hp-owned-${suffix}`);
+    await seedHardware(agentDeviceId, org.id, 'HP', `SN-HP-${suffix}`);
+
+    const providerDeviceId = await seedDevice(org.id, site.id, `dell-provider-${suffix}`);
+    await seedHardware(providerDeviceId, org.id, 'Dell Inc.', `SN-DELL-${suffix}`);
+
+    await withSystemDbAccessContext(() =>
+      upsertAgentWarranty(agentDeviceId, org.id, {
+        source: 'agent_cmsl',
+        manufacturer: 'HP',
+        serialNumber: `SN-HP-${suffix}`,
+        coverageStartDate: '2024-03-01',
+        coverageEndDate: '2099-03-01',
+        coverageType: 'HP 3y Next Business Day Onsite',
+        coverageKind: 'fixed',
+      }),
+    );
+
+    // upsertAgentWarranty stamped next_sync_at 7 days out. Make the row OVERDUE
+    // so it would genuinely be a candidate on unmodified code — otherwise the
+    // exclusion assertion below passes for the wrong reason.
+    await getTestDb().execute(sql`
+      UPDATE device_warranty SET next_sync_at = now() - interval '1 day'
+      WHERE device_id = ${agentDeviceId}
+    `);
+
+    // The Dell device has no warranty row at all, which is the most overdue
+    // state there is (the NULLS FIRST ordering exists for exactly that).
+    const subjects = await withSystemDbAccessContext(() => getDevicesNeedingWarrantySync(100));
+    const deviceIds = subjects.filter((s) => s.kind === 'device').map((s) => s.deviceId);
+
+    // POSITIVE CONTROL FIRST. setup.ts TRUNCATEs `devices` on every beforeEach,
+    // so these two are the only devices in the database — if the sweep returns
+    // neither, the exclusion assertion below is vacuous.
+    expect(
+      deviceIds,
+      'the sweep must still pick up a device a registered vendor provider can answer for',
+    ).toContain(providerDeviceId);
+
+    expect(
+      deviceIds,
+      'an agent-owned row must not be re-selected — it can only be overwritten, and it starves the page',
+    ).not.toContain(agentDeviceId);
+  });
+
+  runDb('a device with NO warranty row is still selected (the NULL data_source arm)', async () => {
+    const { org, site } = await seedTenant();
+    const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const deviceId = await seedDevice(org.id, site.id, `never-synced-${suffix}`);
+    await seedHardware(deviceId, org.id, 'Dell Inc.', `SN-NEW-${suffix}`);
+
+    const subjects = await withSystemDbAccessContext(() => getDevicesNeedingWarrantySync(100));
+    const deviceIds = subjects.filter((s) => s.kind === 'device').map((s) => s.deviceId);
+
+    // `NULL NOT IN (...)` is NULL, not TRUE. Without the explicit isNull arm
+    // this device would be silently dropped from the sweep forever.
+    expect(deviceIds, 'a never-synced device is the most overdue subject there is').toContain(deviceId);
+  });
+});
+```
+
+- [ ] **Step 2: Run it to watch the first case fail**
+
+Run: `cd apps/api && npx vitest run --config vitest.integration.config.ts src/__tests__/integration/agentWarrantyPreservation.integration.test.ts`
+Expected: the first new case FAILS with
+`an agent-owned row must not be re-selected: expected [ ... ] not to contain '<agentDeviceId>'`.
+The second new case PASSES already (it is the regression guard for the fix, not
+for the bug), and Task 6's three cases stay green. Confirm the runner reports
+`4 passed | 1 failed`, not a skip.
+
+- [ ] **Step 3: Make the change**
+
+In `apps/api/src/services/warrantySync.ts`, extend the drizzle import at `:3`:
+
+```ts
+import { eq, and, lt, isNull, or, sql, notInArray } from 'drizzle-orm';
+```
+
+and the Task 6 import:
+
+```ts
+import {
+  AGENT_OWNED_WARRANTY_SOURCE_LIST,
+  isAgentOwnedWarrantySource,
+  warrantyEntitlementProviderForSource,
+} from './warrantyDataSources';
+```
+
+Replace `:471-475` (the device arm's due-ness predicate) with:
+
+```ts
+        // Either no warranty row at all, or one that is due AND not agent-owned.
+        //
+        // An agent-owned row must never be re-selected (#5511 W01, D9): no
+        // registered provider answers for HP or Apple, so the sync can only
+        // overwrite it, and every selected-but-preserved row burns one of this
+        // page's `limit` slots — a large HP fleet would starve the subjects a
+        // vendor CAN answer for out of the sweep entirely.
+        //
+        // The explicit isNull arm is load-bearing. `notInArray` compiles to
+        // `NOT IN (...)`, and `NULL NOT IN ('a','b')` is NULL, not TRUE — a row
+        // whose data_source was never set would otherwise be dropped from the
+        // sweep forever, which is the fail-closed direction of the same
+        // three-valued-logic trap as #5099 W01.
+        or(
+          isNull(deviceWarranty.id),
+          and(
+            lt(deviceWarranty.nextSyncAt, now),
+            or(
+              isNull(deviceWarranty.dataSource),
+              notInArray(deviceWarranty.dataSource, [...AGENT_OWNED_WARRANTY_SOURCE_LIST]),
+            ),
+          ),
+        )
+```
+
+The manual-asset arm (`:490-500`) is deliberately unchanged: `device_warranty`'s
+XOR subject means only a device row can ever carry an agent-written source.
+
+- [ ] **Step 4: Run the integration file to verify it passes**
+
+Run: `cd apps/api && npx vitest run --config vitest.integration.config.ts src/__tests__/integration/agentWarrantyPreservation.integration.test.ts`
+Expected: PASS, `5 passed`.
+
+- [ ] **Step 5: Run the sweep's own unit suite for regressions**
+
+Run: `cd apps/api && npx vitest run src/services/warrantySync.manualAsset.test.ts`
+Expected: PASS — the two `getDevicesNeedingWarrantySync` cases at `:204-241`
+still hold. They drive a chainable mock that ignores the WHERE clause entirely,
+which is precisely why the real assertion lives in the integration file.
+
+- [ ] **Step 6: Commit**
+
+```bash
+pnpm --filter @breeze/api exec tsc --noEmit
+git add apps/api/src/services/warrantySync.ts apps/api/src/__tests__/integration/agentWarrantyPreservation.integration.test.ts
+git commit -m "fix(warranty): exclude agent-owned rows from the 7-day sweep selector (D9, #5512)"
+```
+
+---
+
+### Task 8: CSV import stops stomping agent-owned rows, in both the apply and the preview path (D9, place 3)
+
+**Files:**
+- Modify: `apps/api/src/services/customFields/import/warrantyTarget.ts:38-47` (imports), `:179-183` (guard), `:231-240` (`setWhere`)
+- Modify: `apps/api/src/services/customFields/import/valueImport.ts:161-163` (a second warning constant) and `:343-348` (the preview guard)
+- Test: `apps/api/src/services/customFields/import/warrantyTarget.test.ts`
+
+**Interfaces:**
+- Consumes: `AGENT_OWNED_WARRANTY_SOURCE_LIST`, `isAgentOwnedWarrantySource` from Task 4.
+- Produces: no new exported symbol. `applyWarrantyImport`'s signature and its
+  `WarrantyImportOutcome` return union are unchanged **on purpose**.
+
+**Two decisions, both stated because a reviewer will ask.**
+
+1. **The agent-owned guard is unconditional — `overrideProvider` does not unlock
+   it.** That option has always meant "override a VENDOR lookup". An agent
+   rewrites its row on the next report, so an import that "won" would be
+   reverted within one heartbeat while the operator was told `applied`.
+2. **The refusal reuses the existing `'skipped-provider-owned'` outcome rather
+   than adding a member.** `WarrantyImportOutcome` (`import/types.ts:506-511`)
+   is mirrored in `apps/api/src/openapi.ts:2957` and in
+   `apps/web/src/components/devices/CustomFieldImportPreviewTable.tsx:59-60,
+   130-131,140-141` plus two i18n keys — all outside W01's ownership. A distinct
+   `warning` string (a free-form field, not an enum) carries the real reason to
+   the operator. A dedicated `skipped-agent-owned` member is a W05 follow-up.
+
+The preview path is included because leaving it out makes the preview promise
+`applied` for a row the apply path refuses — preview and commit disagreeing on
+the one surface whose entire job is to predict the other, which that file's own
+comment at `:349-353` calls out as the failure to avoid.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `apps/api/src/services/customFields/import/warrantyTarget.test.ts`.
+It reuses that file's existing helpers verbatim — `rigExisting(existing)`
+(`:73-78`), `captureUpsert(returned?)` (`:81-87`), the module-level `tx` handle
+(`:92-95`), the `DEVICE` / `ORG` constants (`:57-58`), `inDays()` (`:60-62`) and
+the `ExistingWarranty` interface (`:64-70`). Do not redeclare any of them:
+
+```ts
+describe('agent-owned warranty rows are never stomped by an import (#5511 W01, D9)', () => {
+  const agentRow = (dataSource: string, manufacturer: string): ExistingWarranty => ({
+    dataSource,
+    warrantyStartDate: null,
+    warrantyEndDate: null,
+    manufacturer,
+    status: 'active',
+  });
+
+  it('refuses an agent_cmsl row', async () => {
+    rigExisting(agentRow('agent_cmsl', 'hp'));
+    const upsert = captureUpsert();
+
+    const outcome = await applyWarrantyImport(
+      tx,
+      { deviceId: DEVICE, orgId: ORG, warrantyEndDate: inDays(400) },
+      { overrideProvider: false },
+    );
+
+    expect(outcome).toBe('skipped-provider-owned');
+    expect(upsert.values).not.toHaveBeenCalled();
+  });
+
+  it('refuses an agent_plist row — the pre-existing macOS exposure', async () => {
+    rigExisting(agentRow('agent_plist', 'apple'));
+    const upsert = captureUpsert();
+
+    const outcome = await applyWarrantyImport(
+      tx,
+      { deviceId: DEVICE, orgId: ORG, warrantyEndDate: inDays(400) },
+      { overrideProvider: false },
+    );
+
+    expect(outcome).toBe('skipped-provider-owned');
+    expect(upsert.values).not.toHaveBeenCalled();
+  });
+
+  it('refuses an agent-owned row even with overrideProvider — that flag only ever meant "override a VENDOR lookup"', async () => {
+    rigExisting(agentRow('agent_cmsl', 'hp'));
+    const upsert = captureUpsert();
+
+    const outcome = await applyWarrantyImport(
+      tx,
+      { deviceId: DEVICE, orgId: ORG, warrantyEndDate: inDays(400) },
+      { overrideProvider: true },
+    );
+
+    expect(outcome).toBe('skipped-provider-owned');
+    expect(upsert.values).not.toHaveBeenCalled();
+  });
+
+  it('still writes when nothing owns the row, and keeps the partial-index arbiter', async () => {
+    rigExisting(null);
+    const upsert = captureUpsert();
+
+    const outcome = await applyWarrantyImport(
+      tx,
+      { deviceId: DEVICE, orgId: ORG, warrantyEndDate: inDays(400) },
+      { overrideProvider: false },
+    );
+
+    expect(outcome).toBe('applied');
+    // 42P10 guard: device_warranty_device_id_idx is PARTIAL, so the statement
+    // must repeat the predicate or Postgres cannot infer the arbiter.
+    expect(upsert.onConflictDoUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ targetWhere: expect.anything() }),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run it to watch it fail**
+
+Run: `cd apps/api && npx vitest run src/services/customFields/import/warrantyTarget.test.ts`
+Expected: FAIL — the three refusal cases report `'applied'`, and
+`upsert.values` was called, because today's guard only tests `=== 'provider'`.
+The fourth case passes already; it is the regression guard for the fix.
+
+**Mock note:** this file already mocks `'../../warrantyProviders'` (`:47-50`),
+which resolves to the same module `warrantyDataSources.ts` imports, so the new
+module picks up that mock's `normalizeManufacturer` — no extra `vi.mock` is
+needed. `warrantyDataSources.ts` imports nothing else at runtime.
+
+- [ ] **Step 3: Change the apply path**
+
+In `apps/api/src/services/customFields/import/warrantyTarget.ts`, add to the
+imports at `:38-47`:
+
+```ts
+import {
+  AGENT_OWNED_WARRANTY_SOURCE_LIST,
+  isAgentOwnedWarrantySource,
+} from '../../warrantyDataSources';
+```
+
+Insert immediately **above** the existing provider guard at `:179-183`:
+
+```ts
+  // An agent-collected row is owned by the device itself, and `overrideProvider`
+  // does NOT unlock it (#5511 W01, D9) — that flag has always meant "override a
+  // VENDOR lookup". The agent rewrites this row on its next report, so an import
+  // that won here would be reverted within one heartbeat while the operator was
+  // told `applied`. Reported as `skipped-provider-owned` rather than a new
+  // outcome member: that union is mirrored in `openapi.ts:2957` and in the web
+  // import-preview table, both outside this wave's ownership.
+  if (existing && isAgentOwnedWarrantySource(existing.dataSource)) {
+    return 'skipped-provider-owned';
+  }
+```
+
+Replace the conditional `setWhere` spread at `:234-240` with an unconditional
+`setWhere`:
+
+```ts
+      // The AUTHORITY on both ownership rules; the reads above are advisory. A
+      // row that turns provider- or agent-owned between the read and the write
+      // matches no target here and the statement writes nothing rather than
+      // clobbering it. The agent-owned arms are unconditional — see the guard
+      // above for why `overrideProvider` does not reach them.
+      //
+      // `IS DISTINCT FROM` rather than `<>` on every arm: data_source is
+      // nullable, and `NULL <> 'provider'` is NULL, which would refuse every
+      // brand-new row.
+      setWhere: and(
+        ...(options.overrideProvider
+          ? []
+          : [sql`${deviceWarranty.dataSource} IS DISTINCT FROM 'provider'`]),
+        ...AGENT_OWNED_WARRANTY_SOURCE_LIST.map(
+          (source) => sql`${deviceWarranty.dataSource} IS DISTINCT FROM ${source}`,
+        ),
+      ),
+```
+
+The `targetWhere` at `:229` is untouched — dropping it is a runtime 42P10 on
+every imported warranty row.
+
+- [ ] **Step 4: Change the preview path so it predicts the same outcome**
+
+In `apps/api/src/services/customFields/import/valueImport.ts`, add next to
+`PROVIDER_WARRANTY_WARNING` at `:161-163`:
+
+```ts
+const AGENT_WARRANTY_WARNING =
+  'This device reports its own warranty data through the Breeze agent — '
+  + 'an import cannot replace it, and the next agent report would overwrite it';
+```
+
+and add the import:
+
+```ts
+import { isAgentOwnedWarrantySource } from '../../warrantyDataSources';
+```
+
+Insert immediately **above** the existing provider check at `:344`:
+
+```ts
+    // Mirrors `applyWarrantyImport`'s unconditional agent-owned refusal. Without
+    // it the preview reports `applied` for a row the commit refuses — preview
+    // and commit disagreeing on the one surface whose whole job is to predict
+    // the other (see the comment below, which says exactly that about the
+    // already-set case).
+    if (isAgentOwnedWarrantySource(existing?.dataSource)) {
+      return {
+        annotation: { target: mapping, outcome: 'skipped-provider-owned', warning: AGENT_WARRANTY_WARNING },
+      };
+    }
+```
+
+Note the ordering: `const existing = state.warrantyByDevice.get(target.deviceId);`
+at `:343` must stay above both checks.
+
+- [ ] **Step 5: Run both suites to verify they pass**
+
+Run: `cd apps/api && npx vitest run src/services/customFields/import/warrantyTarget.test.ts src/services/customFields/import/valueImport.test.ts`
+Expected: PASS, 2 files. `valueImport.test.ts:366-371` (the provider-owned
+preview case) must still be green — the new branch sits above it and does not
+match a `'provider'` row.
+
+- [ ] **Step 6: Typecheck and commit**
+
+```bash
+pnpm --filter @breeze/api exec tsc --noEmit
+git add apps/api/src/services/customFields/import/warrantyTarget.ts apps/api/src/services/customFields/import/warrantyTarget.test.ts apps/api/src/services/customFields/import/valueImport.ts
+git commit -m "fix(import): CSV import must not overwrite agent-collected warranty rows (D9, #5512)
+
+Guarded in the apply path, its authoritative setWhere, and the preview path, so
+preview and commit agree. Unconditional of overrideProvider."
+```
+
+---
+
+### Task 9: Entitlements across all three layers of the agent path (D10)
+
+**Files:**
+- Modify: `apps/api/src/routes/agents/schemas.ts:647-675`
+- Modify: `apps/api/src/routes/agents/inventory.ts:331-339`
+- Modify: `apps/api/src/services/warrantySync.ts:314-331` and the Task 5 entitlements block
+- Test: `apps/api/src/routes/agents/schemas.test.ts` (schema bounds)
+- Test: create `apps/api/src/routes/agents/inventoryWarranty.test.ts` (handler pass-through)
+- Test: `apps/api/src/services/warrantySync.test.ts` (service mapping)
+- Test: `apps/api/src/__tests__/integration/deviceWarrantyManualSubject.integration.test.ts` (extend the `targetWhere` case)
+
+**Interfaces:**
+- Consumes: `MAX_AGENT_WARRANTY_ENTITLEMENTS` and `warrantyEntitlementProviderForSource` from Task 4.
+- Produces, for W03's collector:
+  ```ts
+  export interface AgentWarrantyEntitlement {
+    serviceLevelDescription?: string;
+    entitlementType?: string;
+    startDate?: string;
+    endDate?: string;
+  }
+  ```
+  and `AgentWarrantyData.entitlements?: AgentWarrantyEntitlement[] | null`. The
+  wire field is `entitlements` on the existing
+  `PUT /agents/:id/warranty-info` body. **`provider` is not part of the wire
+  shape** — the server derives it.
+
+**Three independent drop points, which is why all three layers move together.**
+`agentWarrantyInfoSchema` is a `z.object`, so it strips unknown keys silently
+(layer 1). The handler's field selection at `inventory.ts:331-339` is an
+explicit object literal that would drop the array even if zod kept it (layer 2).
+`AgentWarrantyData` has no such field at all, so the service could not carry it
+(layer 3). Widening any two of the three still ships a silent drop.
+
+- [ ] **Step 1: Write the failing schema test**
+
+Append to `apps/api/src/routes/agents/schemas.test.ts`:
+
+```ts
+describe('agentWarrantyInfoSchema entitlements (#5511 W01, D10)', () => {
+  const base = { source: 'agent_cmsl', manufacturer: 'HP' };
+
+  it('accepts a bounded entitlements array and normalises its dates', () => {
+    const parsed = agentWarrantyInfoSchema.parse({
+      ...base,
+      entitlements: [
+        {
+          serviceLevelDescription: 'HP 3y Next Business Day Onsite',
+          entitlementType: 'Hardware Support',
+          startDate: '2024-03-01T00:00:00Z',
+          endDate: '2027-02-28',
+        },
+      ],
+    });
+
+    expect(parsed.entitlements).toEqual([
+      {
+        serviceLevelDescription: 'HP 3y Next Business Day Onsite',
+        entitlementType: 'Hardware Support',
+        startDate: '2024-03-01',
+        endDate: '2027-02-28',
+      },
+    ]);
+  });
+
+  it('rejects more than 25 entitlements', () => {
+    const many = Array.from({ length: 26 }, () => ({ entitlementType: 'x' }));
+    expect(() => agentWarrantyInfoSchema.parse({ ...base, entitlements: many })).toThrow();
+  });
+
+  it('accepts exactly 25', () => {
+    const many = Array.from({ length: 25 }, () => ({ entitlementType: 'x' }));
+    expect(agentWarrantyInfoSchema.parse({ ...base, entitlements: many }).entitlements).toHaveLength(25);
+  });
+
+  it('rejects a string field over 200 chars', () => {
+    expect(() =>
+      agentWarrantyInfoSchema.parse({
+        ...base,
+        entitlements: [{ serviceLevelDescription: 'x'.repeat(201) }],
+      }),
+    ).toThrow();
+  });
+
+  it('never accepts a client-supplied provider — the server derives it', () => {
+    const parsed = agentWarrantyInfoSchema.parse({
+      ...base,
+      entitlements: [{ entitlementType: 'Hardware Support', provider: 'apple' }],
+    });
+    expect(parsed.entitlements![0]).not.toHaveProperty('provider');
+  });
+
+  it('still parses a payload with no entitlements at all (macOS plist collectors)', () => {
+    const parsed = agentWarrantyInfoSchema.parse({
+      source: 'agent_plist',
+      manufacturer: 'Apple',
+      coverageType: 'AppleCare+',
+    });
+    expect(parsed.entitlements).toBeUndefined();
+  });
+});
+```
+
+Add `agentWarrantyInfoSchema` to that file's existing import from `./schemas`.
+
+- [ ] **Step 2: Run it to watch it fail**
+
+Run: `cd apps/api && npx vitest run src/routes/agents/schemas.test.ts`
+Expected: FAIL — the first case reports `parsed.entitlements` as `undefined`
+(stripped), and the 26-element case does not throw.
+
+- [ ] **Step 3: Widen the schema (layer 1)**
+
+In `apps/api/src/routes/agents/schemas.ts`, add the import at the top of the
+file, next to the existing zod import:
+
+```ts
+import { MAX_AGENT_WARRANTY_ENTITLEMENTS } from '../../services/warrantyDataSources';
+```
+
+Insert between `warrantyDateSchema` (`:649-656`) and `agentWarrantyInfoSchema`:
+
+```ts
+/**
+ * One entitlement from an agent collector (#5511 W01, D10). HP CMSL reports N
+ * of these per device out of `HP_Entitlements`; the macOS plist collector
+ * reports none and keeps using the flat `coverageType` fields below.
+ *
+ * `provider` is deliberately NOT part of the wire shape. The server derives it
+ * from `source` (`warrantyEntitlementProviderForSource`): an agent that could
+ * name the vendor could label HP coverage as Apple, which is exactly the defect
+ * this wave fixes at `warrantySync.ts:367`. `z.object` strips it silently, and
+ * the schema test pins that.
+ *
+ * Dates run through the same `warrantyDateSchema` as the flat fields, so HP's
+ * own per-entitlement dates are PRESERVED (never re-derived from the coverage
+ * window) while still landing as ISO-8601 `YYYY-MM-DD`. An unparseable date
+ * becomes undefined rather than poisoning the jsonb column.
+ */
+const agentWarrantyEntitlementSchema = z.object({
+  serviceLevelDescription: z.string().max(200).optional(),
+  entitlementType: z.string().max(200).optional(),
+  startDate: warrantyDateSchema,
+  endDate: warrantyDateSchema,
+});
+```
+
+and add one key inside `agentWarrantyInfoSchema`, after `coverageType` (`:663`):
+
+```ts
+  entitlements: z.array(agentWarrantyEntitlementSchema).max(MAX_AGENT_WARRANTY_ENTITLEMENTS).optional(),
+```
+
+- [ ] **Step 4: Run the schema test to verify it passes**
+
+Run: `cd apps/api && npx vitest run src/routes/agents/schemas.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Write the failing handler test (layer 2)**
+
+Create `apps/api/src/routes/agents/inventoryWarranty.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+/**
+ * The warranty-info handler's explicit field selection (`inventory.ts:331-339`)
+ * is a SECOND, independent drop point for anything the zod schema accepts: it
+ * is a hand-written object literal, so a field can pass validation and still
+ * never reach the service. #5511 W01 (D10).
+ */
+vi.mock('../../db', () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    transaction: vi.fn(),
+  },
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+// Real schema objects (cheap table definitions) so the transitive service
+// import graph resolves; the client itself is mocked above. Same rationale as
+// `inventory.test.ts:15-21`.
+vi.mock('../../db/schema', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../db/schema')>();
+  return { ...actual };
+});
+
+const upsertAgentWarrantyMock = vi.fn().mockResolvedValue(undefined);
+vi.mock('../../services/warrantySync', () => ({
+  upsertAgentWarranty: (...args: unknown[]) => upsertAgentWarrantyMock(...args),
+}));
+
+import { db } from '../../db';
+import { inventoryRoutes } from './inventory';
+
+function makeApp() {
+  const app = new Hono();
+  app.use('*', async (c: any, next: any) => {
+    c.set('agent', { orgId: 'org-1', agentId: 'agent-1', role: 'agent' });
+    await next();
+  });
+  app.route('/agents', inventoryRoutes);
+  return app;
+}
+
+/** Two reads in order: the device row, then the hardware row for the serial. */
+function rigReads(device: unknown[], hardware: unknown[]) {
+  const queue = [device, hardware];
+  vi.mocked(db.select).mockImplementation((() => ({
+    from: () => ({ where: () => ({ limit: () => Promise.resolve(queue.shift() ?? []) }) }),
+  })) as never);
+}
+
+describe('PUT /agents/:id/warranty-info entitlements pass-through (#5511 W01, D10)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    upsertAgentWarrantyMock.mockResolvedValue(undefined);
+  });
+
+  it('forwards the entitlements array to the service', async () => {
+    rigReads([{ id: 'device-1', orgId: 'org-1' }], [{ serialNumber: 'HP-SERIAL-1' }]);
+
+    const res = await makeApp().request('/agents/agent-1/warranty-info', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        source: 'agent_cmsl',
+        manufacturer: 'HP',
+        coverageStartDate: '2024-03-01',
+        coverageEndDate: '2027-02-28',
+        entitlements: [
+          { serviceLevelDescription: 'HP 3y NBD Onsite', entitlementType: 'Hardware Support', startDate: '2024-03-01', endDate: '2027-02-28' },
+          { serviceLevelDescription: 'HP Pickup and Return', entitlementType: 'Hardware Support', startDate: '2024-03-01', endDate: '2026-02-28' },
+        ],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(upsertAgentWarrantyMock).toHaveBeenCalledWith(
+      'device-1',
+      'org-1',
+      expect.objectContaining({
+        source: 'agent_cmsl',
+        // The serial always comes from device_hardware, never the payload.
+        serialNumber: 'HP-SERIAL-1',
+        entitlements: [
+          { serviceLevelDescription: 'HP 3y NBD Onsite', entitlementType: 'Hardware Support', startDate: '2024-03-01', endDate: '2027-02-28' },
+          { serviceLevelDescription: 'HP Pickup and Return', entitlementType: 'Hardware Support', startDate: '2024-03-01', endDate: '2026-02-28' },
+        ],
+      }),
+    );
+  });
+
+  it('passes null when the collector reports none (macOS plist)', async () => {
+    rigReads([{ id: 'device-1', orgId: 'org-1' }], [{ serialNumber: 'APPLE-1' }]);
+
+    const res = await makeApp().request('/agents/agent-1/warranty-info', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ source: 'agent_plist', manufacturer: 'Apple', coverageType: 'AppleCare+' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(upsertAgentWarrantyMock).toHaveBeenCalledWith(
+      'device-1',
+      'org-1',
+      expect.objectContaining({ entitlements: null }),
+    );
+  });
+});
+```
+
+- [ ] **Step 6: Run it to watch it fail**
+
+Run: `cd apps/api && npx vitest run src/routes/agents/inventoryWarranty.test.ts`
+Expected: FAIL — the first case's `expect.objectContaining({ entitlements: [...] })`
+does not match, because the handler's literal never sets the key.
+
+- [ ] **Step 7: Widen the handler (layer 2)**
+
+In `apps/api/src/routes/agents/inventory.ts`, add one line to the call at
+`:331-339`, after `coverageKind`:
+
+```ts
+      coverageKind: data.coverageKind ?? null,
+      // #5511 W01 (D10). This literal is an independent drop point from the zod
+      // schema: a field can validate and still never reach the service.
+      entitlements: data.entitlements ?? null,
+```
+
+- [ ] **Step 8: Run the handler test to verify it passes**
+
+Run: `cd apps/api && npx vitest run src/routes/agents/inventoryWarranty.test.ts`
+Expected: PASS, 2 cases. This will still be red at the type level until Step 10
+adds the field to `AgentWarrantyData` — run `tsc` only after Step 10.
+
+- [ ] **Step 9: Write the failing service test (layer 3)**
+
+Append to `apps/api/src/services/warrantySync.test.ts`:
+
+```ts
+describe('upsertAgentWarranty entitlements array (#5511 W01, D10)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("stores every reported entitlement, each stamped with the derived provider", async () => {
+    const { values } = captureUpsert();
+
+    await upsertAgentWarranty(DEVICE_ID, ORG_ID, {
+      source: 'agent_cmsl',
+      manufacturer: 'HP',
+      serialNumber: 'HP-SERIAL-1',
+      coverageStartDate: '2024-03-01',
+      coverageEndDate: '2027-02-28',
+      coverageType: 'HP 3y Next Business Day Onsite',
+      entitlements: [
+        { serviceLevelDescription: 'HP 3y NBD Onsite', entitlementType: 'Hardware Support', startDate: '2024-03-01', endDate: '2027-02-28' },
+        { serviceLevelDescription: 'HP Pickup and Return', entitlementType: 'Hardware Support', startDate: '2024-03-01', endDate: '2026-02-28' },
+      ],
+    });
+
+    expect(values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entitlements: [
+          { provider: 'hp', serviceLevelDescription: 'HP 3y NBD Onsite', entitlementType: 'Hardware Support', startDate: '2024-03-01', endDate: '2027-02-28' },
+          { provider: 'hp', serviceLevelDescription: 'HP Pickup and Return', entitlementType: 'Hardware Support', startDate: '2024-03-01', endDate: '2026-02-28' },
+        ],
+      }),
+    );
+  });
+
+  it('preserves HP dates rather than re-deriving them from the coverage window', async () => {
+    const { values } = captureUpsert();
+
+    await upsertAgentWarranty(DEVICE_ID, ORG_ID, {
+      source: 'agent_cmsl',
+      manufacturer: 'HP',
+      serialNumber: 'HP-SERIAL-2',
+      coverageStartDate: '2024-03-01',
+      coverageEndDate: '2027-02-28',
+      coverageType: 'HP 3y Next Business Day Onsite',
+      entitlements: [{ entitlementType: 'Battery', startDate: '2024-03-01', endDate: '2025-03-01' }],
+    });
+
+    const written = values.mock.calls[0]![0] as { entitlements: Array<{ endDate: string }> };
+    expect(written.entitlements[0]!.endDate).toBe('2025-03-01');
+  });
+
+  it('re-slices to the bound so a non-HTTP caller cannot bypass the schema', async () => {
+    const { values } = captureUpsert();
+
+    await upsertAgentWarranty(DEVICE_ID, ORG_ID, {
+      source: 'agent_cmsl',
+      manufacturer: 'HP',
+      serialNumber: 'HP-SERIAL-3',
+      coverageStartDate: '2024-03-01',
+      coverageEndDate: '2027-02-28',
+      coverageType: 'x',
+      entitlements: Array.from({ length: 40 }, (_, i) => ({ entitlementType: `e${i}` })),
+    });
+
+    const written = values.mock.calls[0]![0] as { entitlements: unknown[] };
+    expect(written.entitlements).toHaveLength(25);
+  });
+
+  it('falls back to the single synthesised window when the collector reports none', async () => {
+    const { values } = captureUpsert();
+
+    await upsertAgentWarranty(DEVICE_ID, ORG_ID, {
+      source: 'agent_plist',
+      manufacturer: 'Apple',
+      serialNumber: 'APPLE-1',
+      coverageStartDate: '2024-01-01',
+      coverageEndDate: '2027-01-01',
+      coverageType: 'AppleCare+',
+      entitlements: null,
+    });
+
+    expect(values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entitlements: [expect.objectContaining({ provider: 'apple', entitlementType: 'AppleCare+' })],
+      }),
+    );
+  });
+});
+```
+
+- [ ] **Step 10: Widen the service type and the mapping (layer 3)**
+
+In `apps/api/src/services/warrantySync.ts`, extend the Task 7 import:
+
+```ts
+import {
+  AGENT_OWNED_WARRANTY_SOURCE_LIST,
+  MAX_AGENT_WARRANTY_ENTITLEMENTS,
+  isAgentOwnedWarrantySource,
+  warrantyEntitlementProviderForSource,
+} from './warrantyDataSources';
+```
+
+and the type import at `:5`:
+
+```ts
+import type { WarrantyEntitlement, WarrantyLookupResult } from './warrantyProviders';
+```
+
+Add above `AgentWarrantyData` (`:314`):
+
+```ts
+/**
+ * One entitlement as an agent collector reports it (#5511 W01, D10). No
+ * `provider` field: the server derives that from the reporting source, so an
+ * agent cannot attribute HP coverage to Apple.
+ */
+export interface AgentWarrantyEntitlement {
+  serviceLevelDescription?: string;
+  entitlementType?: string;
+  startDate?: string;
+  endDate?: string;
+}
+```
+
+and one field inside `AgentWarrantyData`, after `coverageKind` (`:330`):
+
+```ts
+  /**
+   * Per-entitlement coverage rows when the collector produces them (HP CMSL's
+   * `HP_Entitlements`). Bounded to MAX_AGENT_WARRANTY_ENTITLEMENTS by
+   * `agentWarrantyInfoSchema`, and re-sliced below so a non-HTTP caller cannot
+   * bypass that bound. Absent, null or empty keeps the legacy single-window
+   * behaviour synthesised from `coverageType`.
+   */
+  entitlements?: AgentWarrantyEntitlement[] | null;
+```
+
+Replace the Task 5 entitlements block with:
+
+```ts
+  // Build the entitlements array from agent data.
+  //
+  // The provider is DERIVED, never hardcoded (#5511 W01, defect 1). A null
+  // return means the coverage cannot be attributed to a vendor at all, in which
+  // case NO entitlement is synthesised: a mislabelled one is worse than none,
+  // because everything downstream reads entitlements[].provider as ground truth.
+  //
+  // Reported rows win over the synthesised window: HP reports its real
+  // per-entitlement dates, which the single coverageStart/End pair cannot
+  // express. The .slice is a second bound behind the schema's .max — the schema
+  // only guards the HTTP path, and this function is exported.
+  const entitlementProvider = warrantyEntitlementProviderForSource(data.source, data.manufacturer);
+  const reported = data.entitlements ?? [];
+  const entitlements: WarrantyEntitlement[] = !entitlementProvider
+    ? []
+    : reported.length > 0
+      ? reported.slice(0, MAX_AGENT_WARRANTY_ENTITLEMENTS).map((e) => ({
+          provider: entitlementProvider,
+          serviceLevelDescription: e.serviceLevelDescription ?? '',
+          entitlementType: e.entitlementType ?? '',
+          startDate: e.startDate ?? '',
+          endDate: e.endDate ?? '',
+        }))
+      : data.coverageType
+        ? [{
+            provider: entitlementProvider,
+            serviceLevelDescription: data.coverageType,
+            entitlementType: data.coverageType,
+            startDate: data.coverageStartDate ?? '',
+            endDate: data.coverageEndDate ?? '',
+          }]
+        : [];
+```
+
+Both the `values(...)` payload (`:389`) and the `onConflictDoUpdate` `set`
+(`:408`) already reference this one `entitlements` const — do not duplicate it.
+
+- [ ] **Step 11: Extend the real-DB `targetWhere` regression with an HP payload**
+
+In `apps/api/src/__tests__/integration/deviceWarrantyManualSubject.integration.test.ts`,
+append inside the `describe('device_warranty upsert arbiters survive the partial indexes (#4622)')`
+block that ends at `:253`:
+
+```ts
+  runDb('upsertAgentWarranty carries an entitlements ARRAY through both arbiter arms (#5511 W01)', async () => {
+    const { org, site } = await seedTenant();
+    const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const deviceId = await seedDevice(org.id, site.id, `xor-hp-entitlements-${suffix}`);
+
+    const payload = {
+      source: 'agent_cmsl',
+      manufacturer: 'HP',
+      serialNumber: `SN-HP-${suffix}`,
+      coverageStartDate: '2024-03-01',
+      coverageEndDate: '2027-02-28',
+      coverageType: 'HP 3y Next Business Day Onsite',
+      coverageKind: 'fixed' as const,
+      entitlements: [
+        { serviceLevelDescription: 'HP 3y NBD Onsite', entitlementType: 'Hardware Support', startDate: '2024-03-01', endDate: '2027-02-28' },
+        { serviceLevelDescription: 'HP Pickup and Return', entitlementType: 'Hardware Support', startDate: '2024-03-01', endDate: '2026-02-28' },
+      ],
+    };
+
+    // The INSERT arm, then the ON CONFLICT arm — the one that needs the partial
+    // index predicate repeated, or Postgres raises 42P10.
+    await withSystemDbAccessContext(() => upsertAgentWarranty(deviceId, org.id, payload));
+    await withSystemDbAccessContext(() =>
+      upsertAgentWarranty(deviceId, org.id, {
+        ...payload,
+        entitlements: [...payload.entitlements, { entitlementType: 'Battery', startDate: '2024-03-01', endDate: '2025-03-01' }],
+      }),
+    );
+
+    const rows = (await getTestDb().execute(sql`
+      SELECT data_source,
+             jsonb_array_length(entitlements) AS entitlement_count,
+             entitlements #>> '{0,provider}'  AS first_provider,
+             entitlements #>> '{2,endDate}'   AS third_end_date
+      FROM device_warranty WHERE device_id = ${deviceId}
+    `)) as unknown as Array<{
+      data_source: string | null;
+      entitlement_count: number;
+      first_provider: string | null;
+      third_end_date: string | null;
+    }>;
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.data_source).toBe('agent_cmsl');
+    // The UPDATE arm actually ran: three rows, not the two the INSERT wrote.
+    expect(rows[0]!.entitlement_count).toBe(3);
+    expect(rows[0]!.first_provider).toBe('hp');
+    expect(rows[0]!.third_end_date).toBe('2025-03-01');
+  });
+```
+
+- [ ] **Step 12: Run everything this task touched**
+
+```bash
+cd apps/api && npx vitest run \
+  src/routes/agents/schemas.test.ts \
+  src/routes/agents/inventoryWarranty.test.ts \
+  src/services/warrantySync.test.ts
+cd apps/api && npx vitest run --config vitest.integration.config.ts \
+  src/__tests__/integration/deviceWarrantyManualSubject.integration.test.ts
+```
+
+Expected: PASS, 3 unit files; PASS, 1 integration file (`5 passed` — the four
+pre-existing cases plus the new one).
+
+- [ ] **Step 13: Typecheck and commit**
+
+```bash
+pnpm --filter @breeze/api exec tsc --noEmit
+git add apps/api/src/routes/agents/schemas.ts apps/api/src/routes/agents/schemas.test.ts \
+        apps/api/src/routes/agents/inventory.ts apps/api/src/routes/agents/inventoryWarranty.test.ts \
+        apps/api/src/services/warrantySync.ts apps/api/src/services/warrantySync.test.ts \
+        apps/api/src/__tests__/integration/deviceWarrantyManualSubject.integration.test.ts
+git commit -m "feat(warranty): carry agent-reported entitlements through schema, handler and service (D10, #5512)
+
+Three independent drop points, widened together: z.object strips unknown keys,
+the handler's field literal drops what zod keeps, and AgentWarrantyData had no
+field at all. Bounds: 25 rows, 200 chars, ISO-8601 dates preserved as reported."
+```
+
+---
+
+### Task 10: Manual refresh tells the truth for an agent-collected device (D11)
+
+**Files:**
+- Modify: `apps/api/src/routes/devices/warranty.ts:4` (import) and `:47-66` (handler)
+- Test: `apps/api/src/routes/devices/warranty.test.ts`
+
+**Interfaces:**
+- Consumes: `isAgentCollectedWarrantyDevice` from Task 4.
+- Produces: a new refusal on `POST /devices/:id/warranty/refresh` —
+  `409 { error: string, code: 'WARRANTY_REFRESH_NOT_AVAILABLE' }`. W03 may
+  later upgrade this to a real agent-collection trigger; the code string is the
+  stable thing a caller branches on.
+
+**What the endpoint does today, and why it is a lie.** It answers
+`200 { message: 'Warranty refresh queued' }` and enqueues
+`syncWarrantyForDevice(deviceId, { force: true })`. For an HP device that job
+reaches `getProviderForManufacturer('HP') === null` — HP has no registered
+provider and cannot get one — and, after Task 6, the preservation branch, which
+changes nothing an operator can see. The card then polls `lastSyncAt`
+(`DeviceWarrantyCard.tsx:182`) waiting for a timestamp that (also after Task 6)
+correctly no longer advances.
+
+**Scope decision the contract did not settle — stated so a reviewer can object
+deliberately.** D11 says "for HP devices". This ships a predicate that is
+`manufacturer normalizes to 'hp'` **OR** `the stored row is agent-owned`, which
+additionally covers a Mac carrying an `agent_plist` row. Three reasons: those
+devices have the identical dead-end (Apple has no registered provider either);
+Task 6 stopped the false `lastSyncAt` stamp that used to make the Mac case
+*look* like it succeeded, so without this the Mac case degrades from a false
+success into a spinner-to-timeout; and W01 may not touch web, so an immediate
+coded refusal is the only honest outcome available to it. A Mac with **no**
+warranty row yet is unaffected — it still queues, exactly as today.
+
+**No web change is needed.** `DeviceWarrantyCard.tsx:162-173` wraps the call in
+`runAction` inside a `try`; `runAction` already toasts a non-401 `ActionError`,
+and the `catch` clears the spinner. A 409 therefore surfaces as an error toast
+today. Softening that copy into a purpose-written "collected by the agent"
+message is a W05 follow-up.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `apps/api/src/routes/devices/warranty.test.ts`. Note this file mocks
+`db` as `{ select: vi.fn() }` and mocks `getDeviceWithOrgAndSiteCheck`, so the
+handler's two new reads are the **only** consumers of the select queue:
+
+```ts
+describe('manual refresh refuses agent-collected devices (#5511 W01, D11)', () => {
+  /** Two reads in order: device_hardware.manufacturer, then device_warranty.dataSource. */
+  function rigRefreshReads(hardware: unknown[], warranty: unknown[]) {
+    const queue = [hardware, warranty];
+    vi.mocked(db.select).mockImplementation((() => ({
+      from: () => ({ where: () => ({ limit: () => Promise.resolve(queue.shift() ?? []) }) }),
+    })) as never);
+  }
+
+  beforeEach(() => {
+    vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue({ id: 'device-1', orgId: 'org-123' } as never);
+  });
+
+  it('refuses an HP device with a coded 409 instead of queueing a sync that can never answer', async () => {
+    rigRefreshReads([{ manufacturer: 'HP' }], []);
+
+    const res = await app.request('/devices/device-1/warranty/refresh', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({ code: 'WARRANTY_REFRESH_NOT_AVAILABLE' });
+    expect(queueWarrantySyncForDevice).not.toHaveBeenCalled();
+  });
+
+  it('refuses a device whose row an agent already owns', async () => {
+    rigRefreshReads([{ manufacturer: 'Apple Inc.' }], [{ dataSource: 'agent_plist' }]);
+
+    const res = await app.request('/devices/device-1/warranty/refresh', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(409);
+    expect(queueWarrantySyncForDevice).not.toHaveBeenCalled();
+  });
+
+  it('still queues for a device a registered vendor provider can answer for', async () => {
+    rigRefreshReads([{ manufacturer: 'Dell Inc.' }], [{ dataSource: 'provider' }]);
+
+    const res = await app.request('/devices/device-1/warranty/refresh', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(queueWarrantySyncForDevice).toHaveBeenCalledWith('device-1', { force: true });
+  });
+
+  it('still queues for a device with no hardware row and no warranty row', async () => {
+    rigRefreshReads([], []);
+
+    const res = await app.request('/devices/device-1/warranty/refresh', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(queueWarrantySyncForDevice).toHaveBeenCalledWith('device-1', { force: true });
+  });
+});
+```
+
+The pre-existing case at `:87-101` ("queues a manual refresh with force…") does
+not rig `db.select`, so its two new reads resolve against a `vi.fn()` returning
+`undefined` and would throw. **Add `rigRefreshReads([], [])` — or the same
+inline chain — to that test as part of this step**, keeping its assertions
+untouched: with no hardware row and no warranty row the device is not
+agent-collected, so it still queues.
+
+- [ ] **Step 2: Run it to watch it fail**
+
+Run: `cd apps/api && npx vitest run src/routes/devices/warranty.test.ts`
+Expected: FAIL — the first two new cases return 200 and call
+`queueWarrantySyncForDevice`.
+
+- [ ] **Step 3: Make the change**
+
+In `apps/api/src/routes/devices/warranty.ts`, widen the schema import at `:4`
+and add the predicate import:
+
+```ts
+import { deviceWarranty, deviceHardware, devices } from '../../db/schema';
+import { isAgentCollectedWarrantyDevice } from '../../services/warrantyDataSources';
+```
+
+Insert into the refresh handler, between the device checks (which end at `:57`)
+and the `queueWarrantySyncForDevice` call:
+
+```ts
+    // #5511 W01 (D11) — never queue a sync that cannot produce anything.
+    //
+    // `warrantyProviders/index.ts:7-12` deliberately does not register
+    // `hpProvider` (HP's real backend is captcha-gated and its official API is
+    // closed to MSPs), so `getProviderForManufacturer` is null for every HP
+    // device; and an agent-owned row is written by the device, not the server.
+    // In both cases the queued job changes nothing an operator can see, while
+    // this endpoint has already answered "Warranty refresh queued" — a promise
+    // nothing can keep. Refuse with a code the caller can branch on instead.
+    const [hw] = await db
+      .select({ manufacturer: deviceHardware.manufacturer })
+      .from(deviceHardware)
+      .where(eq(deviceHardware.deviceId, deviceId))
+      .limit(1);
+
+    const [existingWarranty] = await db
+      .select({ dataSource: deviceWarranty.dataSource })
+      .from(deviceWarranty)
+      .where(eq(deviceWarranty.deviceId, deviceId))
+      .limit(1);
+
+    if (
+      isAgentCollectedWarrantyDevice({
+        manufacturer: hw?.manufacturer ?? null,
+        dataSource: existingWarranty?.dataSource ?? null,
+      })
+    ) {
+      return c.json(
+        {
+          error:
+            "This device's warranty is collected by the Breeze agent, not by a vendor lookup. "
+            + 'A server-side refresh cannot produce newer data.',
+          code: 'WARRANTY_REFRESH_NOT_AVAILABLE',
+        },
+        409,
+      );
+    }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd apps/api && npx vitest run src/routes/devices/warranty.test.ts`
+Expected: PASS — the four new cases plus the four pre-existing ones, including
+`registeredPermissionCalls`/`registeredMfaCallCount` at `:58-62`. That
+assertion is a guard worth re-reading: this task adds no middleware, so
+`requireMfa` must still be registered exactly once.
+
+- [ ] **Step 5: Typecheck and commit**
+
+```bash
+pnpm --filter @breeze/api exec tsc --noEmit
+git add apps/api/src/routes/devices/warranty.ts apps/api/src/routes/devices/warranty.test.ts
+git commit -m "fix(warranty): refuse manual refresh on agent-collected devices with a coded 409 (D11, #5512)"
+```
+
+---
+
+### Task 11: Verification gate — full suites, the real integration run, and the PR
+
+**Files:** none changed. This task is the gate that stops a locally-green branch
+from being mistaken for a correct one.
+
+- [ ] **Step 1: Typecheck the whole package**
+
+Run: `pnpm --filter @breeze/api exec tsc --noEmit`
+Expected: no output, exit 0.
+
+- [ ] **Step 2: Lint**
+
+Run: `pnpm --filter @breeze/api lint`
+Expected: clean. If a rule is genuinely inapplicable, use `as never` rather than
+an `eslint-disable` for an unregistered rule — that disable comment IS itself
+the lint error in this repo.
+
+- [ ] **Step 3: Run every unit file this wave touched, by explicit path**
+
+```bash
+cd apps/api && npx vitest run \
+  src/services/warrantyDataSources.test.ts \
+  src/services/warrantySync.test.ts \
+  src/services/warrantySync.manualAsset.test.ts \
+  src/services/customFields/import/warrantyTarget.test.ts \
+  src/services/customFields/import/valueImport.test.ts \
+  src/routes/agents/schemas.test.ts \
+  src/routes/agents/inventoryWarranty.test.ts \
+  src/routes/agents/inventory.test.ts \
+  src/routes/devices/warranty.test.ts
+```
+
+Expected: PASS, **9 files**. Count them in the output. Paths are listed
+individually on purpose: vitest's filter is a plain substring match, so
+`src/services/warranty` would silently pull in unrelated files and
+`src/services/customFields/import/` (trailing slash) would skip nothing here but
+does skip siblings elsewhere.
+
+- [ ] **Step 4: Run the API unit suite for collateral damage**
+
+Run: `cd apps/api && npx vitest run`
+Expected: PASS. `warrantyAlertEvaluator.test.ts` and
+`warrantyProviderThrottle.test.ts` are the likely collateral — neither is
+modified by this wave, and `hpProvider.ts` is deliberately left in place (its
+deletion is W05's).
+
+- [ ] **Step 5: Run the integration suites against a real database — this is the step that is not optional**
+
+```bash
+pnpm --filter @breeze/api test:docker:up
+cd apps/api && npx vitest run --config vitest.integration.config.ts \
+  src/__tests__/integration/agentWarrantyPreservation.integration.test.ts \
+  src/__tests__/integration/deviceWarrantyManualSubject.integration.test.ts \
+  src/services/warrantyAlertEvaluator.integration.test.ts
+```
+
+Expected: PASS, 3 files. **Confirm the runner reports passes, not skips.** Every
+case is `it.runIf(!!process.env.DATABASE_URL)`; with `DATABASE_URL` unset the
+whole file reports green while executing nothing, which is the exact shape of a
+false negative this wave cannot afford. `src/__tests__/integration/setup.ts:32-33`
+defaults to `postgresql://breeze_test:breeze_test@localhost:5433/breeze_test`,
+which `docker-compose.test.yml` provisions — but the `runIf` reads the env var,
+so it must actually be exported in the shell running vitest.
+
+- [ ] **Step 6: Re-confirm no migration is needed, and that no cascade list moved**
+
+```bash
+grep -n "entitlements\|data_source" apps/api/src/db/schema/warranty.ts
+git diff --name-only origin/main... -- apps/api/migrations/
+grep -rn "device_warranty" apps/api/src/services/tenantCascade.ts apps/api/src/routes/devices/core.ts apps/api/src/services/tenantExportPolicyRegistry.ts
+```
+
+Expected: `entitlements` is still `jsonb ... notNull().default([])` and
+`data_source` still `varchar(50)` with no CHECK; **the migrations diff is
+empty**; and `device_warranty` still appears in all three registries with the
+same column classification. This wave adds **no column to any org-cascade
+table**, which is the only thing that fires the export-policy contract on a
+non-DDL change. Also re-run `ls apps/api/migrations/*.sql | sort | tail -1` and
+confirm nothing now sorts after `2026-10-15-150300` that would invalidate D13's
+statement in the PR body.
+
+- [ ] **Step 7: Merge main and re-verify — a local branch green is not a CI green**
+
+```bash
+git fetch origin && git merge origin/main
+pnpm --filter @breeze/api exec tsc --noEmit
+cd apps/api && npx vitest run src/services/warrantySync.test.ts src/routes/devices/warranty.test.ts
+```
+
+PR CI tests the **merge commit**, not your branch tip.
+
+- [ ] **Step 8: Open the PR**
+
+```bash
+gh pr create --title "W01: HP warranty lab probe + warranty ingest hardening (#5512)" --body "$(cat <<'EOF'
+Closes #5512
+
+Wave W01 of #5511. Two halves.
+
+## A — lab probe (procedure, not a result)
+
+`scripts/hp-warranty-lab/hp-cmsl-probe.ps1` + `README.md`: a five-phase,
+reversible probe answering the three questions W03/W04 are gated on —
+(1) does `root/HP/InstrumentedServices/v1` exist without CMSL, (2) does a real
+old→new CMSL upgrade surface through `winget upgrade --include-unknown --scope
+machine --source winget` and flow through a Breeze third-party ring, (3) what
+does `Get-HPWarrantyInfo` return field by field, including its own cache
+timestamp. Results are posted to #5512; **W03 and W04 stay blocked until they
+land.** If (2) fails, the decision goes back to Todd on #5511 — the fallback
+(the agent enforcing a floor version) bypasses customer approval rings and was
+explicitly not chosen.
+
+The probe installs HP CMSL **from HP via winget** and never mirrors it; HP's
+licence forbids redistribution, and `--accept-package-agreements` accepts HP's
+EULA on the machine owner's behalf. Own hardware only.
+
+## B — ingest hardening
+
+- **New** `services/warrantyDataSources.ts` — one definition of an agent-owned
+  warranty row (D9), applied in all three places the contract names plus the
+  importer's preview path.
+- **Data-loss fix:** a server sweep over an `agent_cmsl` row nulled both
+  coverage dates, emptied `entitlements` and flipped `data_source` back to
+  `provider`. Real-DB regression watched failing on unmodified code first.
+- **Mislabel fix:** the synthesised agent entitlement's `provider` is derived
+  from the reporting source instead of the hardcoded `'apple' as const`.
+- **Sweep selector** no longer re-selects agent-owned rows (they can only be
+  overwritten, and they starve the page's `limit`). The explicit `isNull` arm is
+  load-bearing: `NULL NOT IN (...)` is NULL, not TRUE.
+- **CSV import** stops stomping agent-owned rows, in the apply path, its
+  authoritative `setWhere`, and the preview path so the two agree.
+  Unconditional of `overrideProvider`.
+- **Entitlements (D10)** now cross all three layers of the agent path — zod
+  schema, the handler's field literal, and `AgentWarrantyData` — bounded at 25
+  rows / 200 chars, HP's own dates preserved. Any two of the three still ships a
+  silent drop.
+- **Manual refresh (D11)** returns `409 WARRANTY_REFRESH_NOT_AVAILABLE` for an
+  agent-collected device instead of queueing a sync that can never answer.
+
+## No migration
+
+Confirmed against `db/schema/warranty.ts:49-50`, not against the spec:
+`entitlements` is `jsonb NOT NULL DEFAULT '[]'` and `data_source` is
+`varchar(50)` with no CHECK and no enum. No column is added to any org-cascade
+table, so no cascade or export-policy registration changes. `targetWhere` is
+preserved on every upsert (42P10).
+
+## Decisions this PR made that the contract left open
+
+1. D11's refusal covers **agent-owned rows generally**, not only HP — a Mac
+   `agent_plist` row has the identical dead end, and Task 6 removed the false
+   `lastSyncAt` stamp that used to make it look successful.
+2. The importer refusal reuses `skipped-provider-owned` rather than adding a
+   `WarrantyImportOutcome` member, because that union is mirrored in
+   `openapi.ts` and in web, both outside W01's ownership. A dedicated member is
+   a W05 follow-up.
+3. The importer's **preview** path is included alongside the apply path so the
+   two cannot disagree.
+
+## Verification
+
+- `tsc --noEmit`, `lint`, full API unit suite.
+- Integration (real Postgres): `agentWarrantyPreservation`,
+  `deviceWarrantyManualSubject`, `warrantyAlertEvaluator` — confirmed executed,
+  not `runIf`-skipped.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+https://claude.ai/code/session_01ANjBwca2cfsLWDLJro3fkz
+EOF
+)"
+```
+
+- [ ] **Step 9: Record the wave state**
+
+```bash
+gh issue comment 5512 --body "Ingest half of W01 is open as a PR. The lab half is committed as a procedure; Q1/Q2/Q3 answers are still outstanding and W03 (#5514) / W04 (#5515) remain blocked on them."
+```
+
+---
+
+## Self-review
+
+**1. Spec coverage.** Every W01 item in the contract's ownership row maps to a
+task:
+
+| Contract item | Task |
+|---|---|
+| The lab probe and its recorded answers (Q1/Q2/Q3) | 1, 2, 3 |
+| Defect 2 — preservation branch (`warrantySync.ts:153`) | 6 |
+| Defect 1 — `provider: 'apple' as const` (`:367`) | 5 |
+| D9 `AGENT_OWNED_WARRANTY_SOURCES` / `isAgentOwnedWarrantySource` | 4 |
+| D9 place 1 — preservation branch | 6 |
+| D9 place 2 — sweep selector / direct sync | 7 |
+| D9 place 3 — `warrantyTarget.ts:181,238` | 8 |
+| D10 — entitlements across schema, handler, service type | 9 |
+| D11 — manual-refresh honesty | 10 |
+| "No migration is needed — confirm it yourself" | Ground truth §"No migration is needed"; re-checked in Task 11 Step 6 |
+| `targetWhere` preserved; extend `deviceWarrantyManualSubject.integration.test.ts:225` | 9 Step 11; asserted again in 8 Step 1 |
+| Red-first, real-DB, watched failing | 6 Step 2 (explicit "do not proceed on an assumed red") |
+| Integration run with `vitest.integration.config.ts` | 6 Step 2/4, 7 Step 4, 9 Step 12, 11 Step 5 |
+
+Spec items deliberately **not** covered, each with its owner: the `agent_cmsl`
+label in `DeviceWarrantyCard.tsx`, deleting `hpProvider.ts` / `HP_WARRANTY_ENABLED`
+and the docs update (all W05); the `hpCmsl` opt-in block, consent, the MFA gate
+and D12's guard arm (W02); the collector and its scheduling (W03); the built-in
+catalog package (W04). The spec's "distinguish HP's real fetch timestamp from
+WMI observation time and report receipt time" needs new columns and therefore a
+migration, so it is flagged in Task 6 Step 3 as W03's, not silently dropped.
+
+**2. Placeholder scan.** No "TBD", no "add error handling", no "similar to Task
+N", no "write tests for the above". Every code step carries complete code,
+including all five PowerShell phases. Two things are deliberately parameterised
+rather than fixed, and both say so: `-PinnedVersion` (the operator reads the
+published version list in the same phase) and the `<HOSTNAME>` in the
+verification SQL.
+
+**3. Type consistency.** `isAgentOwnedWarrantySource`,
+`isAgentCollectedWarrantyDevice`, `warrantyEntitlementProviderForSource`,
+`AGENT_OWNED_WARRANTY_SOURCE_LIST`, `AGENT_OWNED_WARRANTY_SOURCES`,
+`MAX_AGENT_WARRANTY_ENTITLEMENTS`, `AGENT_PLIST_WARRANTY_SOURCE` and
+`AGENT_CMSL_WARRANTY_SOURCE` are defined once in Task 4 and used under exactly
+those names in Tasks 5-10. `AgentWarrantyEntitlement` is defined in Task 9 and
+referenced only there and by W03. The import line in `warrantySync.ts` grows
+across Tasks 5 → 6 → 7 → 9 and each task shows the **complete** line for its
+point in the sequence, not a fragment. The test-helper names in Task 8
+(`rigExisting`, `captureUpsert`, `tx`, `DEVICE`, `ORG`, `inDays`,
+`ExistingWarranty`) were read out of the existing file rather than invented, and
+differ from the `DEVICE_ID`/`ORG_ID` used in `warrantySync.test.ts` — that
+difference is real and is called out at the point of use.
+
+**4. Fixed during review.** Task 8's first draft invented a `makeExecutor(...)`
+helper; corrected to the file's real `rigExisting`/`captureUpsert`/`tx`. The
+contract's `getDevicesNeedingWarrantySync` span (`:454-484`) was corrected to
+`:454-524` in Ground truth. Task 10 Step 1 gained the instruction to rig
+`db.select` in the pre-existing refresh test, which the new reads would
+otherwise break.

--- a/docs/superpowers/plans/device-lifecycle/2026-09-10-hp-warranty-cmsl-w02-opt-in-surface-and-delivery.md
+++ b/docs/superpowers/plans/device-lifecycle/2026-09-10-hp-warranty-cmsl-w02-opt-in-surface-and-delivery.md
@@ -1,0 +1,4261 @@
+---
+tracking_issue: LanternOps/breeze#5511
+---
+
+# Wave 02 — HP CMSL opt-in surface and delivery to the agent — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let an MSP switch on device-side HP warranty collection from the existing `warranty` config-policy feature link, with consent that only the server can write, an authorization gate that matches the software-install gate it stands in for, and delivery of the resolved flag all the way to the Go agent's config dispatcher — with **no collection code at all** (that is W03).
+
+**Architecture:** The `warranty` feature link stays pure JSONB. It gains an `hpCmsl` block validated by a new shared schema; `consent` is refused on input and stamped by `addFeatureLink` / `updateFeatureLink` from an out-of-band actor argument the HTTP routes supply and the AI tool cannot. Authorization is an in-handler, feature-type-conditional gate (`devices.execute` + satisfied MFA) on every write whose result exposes a device to collection — create, update, revert-to-parent delete, assignment, and create-with-parent. The alert evaluator's private hierarchy resolver moves into a shared service so `buildWarrantyConfigUpdate` reads the same effective link instead of a second copy; the heartbeat carries it as `warranty_settings` and the agent dispatches it through a replaceable seam **above** the probe path's unconditional return.
+
+**Tech Stack:** Hono + Drizzle ORM + PostgreSQL (RLS), zod 4, Vitest (API + web), React 19 islands, Go 1.x (`go test -race`), i18next JSON catalogs.
+
+**Spec:** `docs/superpowers/specs/device-lifecycle/2026-09-10-hp-warranty-cmsl-design.md` — layers 1 and 2, plus the `WarrantyTab.tsx` half of layer 7. Its "Corrections after ground-truth verification" section supersedes the body. **Cross-wave contract:** contract B (feature #5511), decisions D1, D2, D3, D4, D5, D6, D7 (W02 half), D12.
+
+**Depends on:** nothing. W01 (#5512) owns `warrantySync.ts`, entitlements and the lab probe; this wave touches none of them and can run in parallel. W03 (#5514) consumes this wave's `warranty_config.go` seam and the persisted agent flag.
+
+## Global Constraints
+
+Copied verbatim from contract B. A wave that believes one of these is wrong stops and reports rather than diverging.
+
+- **D1 — the `hpCmsl` block.** Lives inside the existing `warranty` feature-link inline settings (pure jsonb — **no new table, no tenancy shape, no cascade or export registration, no migration**). Shape:
+  ```ts
+  export interface WarrantyHpCmslSettings {
+    enabled: boolean;              // default false; SEPARATE from the existing `enabled`
+    consent?: {                    // server-stamped ONLY — never read from the client
+      acceptedByUserId: string;
+      acceptedAt: string;          // ISO-8601, server clock
+      eulaId: string;              // see D2
+    };
+  }
+  ```
+  The existing `{ enabled, warnDays, criticalDays }` keep their meaning: `enabled` there is **expiry alerting**, not collection. Do not overload it.
+- **D2 — EULA identifier.** One exported constant, owner W02: `export const HP_CMSL_EULA_ID = 'hp-cmsl-eula-2026-04-01';` Changing HP's terms means a NEW id and re-consent. The id is compared, never parsed; consent recorded against a different id does not satisfy the current id.
+- **D3 — consent is server-stamped, and a forged payload is refused.** A client-supplied `consent` object is **refused with a coded 400**, not silently stripped — dropping it would let a UI believe consent was recorded.
+- **D4 — authorization gates on POST-WRITE state, evaluated in-handler.** Do NOT add `warranty` to `MFA_GATED_FEATURE_TYPES` wholesale — that forces MFA on pure alert-threshold edits, which install nothing. A write whose **resulting** `hpCmsl.enabled` is `true` requires `devices.execute` AND satisfied MFA. A write that leaves it `false` (including turning it off) keeps today's `devices.write`. Disabling is the fail-safe direction: audited, not gated. The gate covers create, update, AND any assignment/inheritance transition that newly exposes a device to an `hpCmsl.enabled` link. Building blocks — use these, invent nothing: `hasPermission(userPerms, PERMISSIONS.DEVICES_EXECUTE.resource, PERMISSIONS.DEVICES_EXECUTE.action)` (`apps/api/src/services/permissions.ts:210`; constant `packages/shared/src/constants/permissions.ts:24`); `hasSatisfiedMfa(auth)` (`apps/api/src/middleware/auth.ts:915`); MFA refusal shape from `requireMfa()`: `c.json({ error: 'MFA required', code: 'MFA_REQUIRED' }, 403)` — a coded body, NOT an `HTTPException`.
+- **D5 — inheritance: nearest link wins, whole link, no deep merge.** Do NOT introduce a deep merge for `warranty`. The consequence is real and must be surfaced, not hidden: a nearer policy carrying only alert thresholds **replaces** an inherited link and drops its `hpCmsl` block, revoking collection. Surface it in the authoring UI and cover it with a test asserting the drop is what happens.
+- **D6 — agent config key.** Wire shape exactly: `{ "warranty_settings": { "hp_cmsl_enabled": true } }`. Server: add `warrantySettings` to the function-local `PolicyConfigUpdates` (`heartbeat.ts:1921-1926`), build it inside the existing shared `withSystemDbAccessContext` (`:1934`) with its own try/catch mirroring `:1977-1982`, and map it in the wire assembly (`:1993-2004`). Agent: dispatch in `applyConfigUpdate` (`heartbeat.go:2851`) **above line 2918** — below it the probe path's unconditional `return` at `:2928-2930` makes the key unreachable on any heartbeat without probes. Check snake_case first at the outer level; accept both cases for the inner field. Both spellings must be covered by a test. **Revocation contract, copied from `buildPatchSourceConfigUpdate` (`helpers.ts:2852-2859`):** a **successfully resolved absent policy** returns the block with the feature `false`; a **resolver error** OMITS the block entirely so a transient failure never revokes.
+- **D7 (W02 half) — agent source layout.** `agent/internal/heartbeat/warranty_config.go`: a package-level func var for the platform call plus an unexported `func (h *Heartbeat) applyWarrantyConfig(raw any)`. **Both lowercase** — the point is that the dispatch + payload parse is unit-testable on a non-Windows runner.
+- **D12 — the missing inline-only guard arm.** Add `warranty` to the inline-only guard list at `configurationPolicy.ts:2656-2662`, with a red-first test.
+- **Scoped test runs.** API: `cd apps/api && npx vitest run <path>`. Web: `cd apps/web && npx vitest run <path>`. Shared: `cd packages/shared && npx vitest run <path>`. Go: `cd agent && go test -race ./internal/heartbeat/...`. **Never** `pnpm --filter <pkg> test -- --run <path>` — pnpm forwards the literal `--` and vitest runs the entire suite in watch mode. Vitest's path filter is a plain substring match, not a glob.
+- **No migration in this wave.** Contract D13 assigns the only expected migration slot to W04. If this wave discovers it needs one, it takes the next free slot (`ls apps/api/migrations/*.sql | sort | tail -1`) and says so in its PR — it does NOT reuse W04's.
+- **Out of scope, do not touch:** `apps/api/src/services/warrantySync.ts` and `apps/api/src/services/customFields/import/warrantyTarget.ts` (W01), `agent/internal/collectors/hp_warranty_*.go` and any collection/scheduling code (W03), `builtinDeploymentPackages.ts` / `INTEGRATION_PROVIDERS` / `useEdrReadiness.ts` (W04), `hpProvider.ts` deletion and `DeviceWarrantyCard.tsx` (W05).
+
+## 0. Ground truth
+
+Every citation below was re-opened in this worktree (`/Users/toddhebebrand/.herdr/worktrees/breeze/warranty-testing`) on 2026-09-10 and quoted from the file, not copied from the spec or the contract. **Three contract line numbers are wrong; they are called out inline.**
+
+### Config policy — service
+
+- `apps/api/src/services/configurationPolicy.ts:1062-1068` — `decomposeInlineSettings`, verbatim:
+  ```ts
+      case 'warranty':
+      case 'helper':
+      case 'pam':
+      case 'vulnerability':
+      case 'device_lifecycle':
+        // Pure JSONB — no normalized table needed
+        break;
+  ```
+  The two sibling switches are at `:1171-1177` (`deleteNormalizedRows`) and `:1416-1422` (`assembleInlineSettings`, which returns `null` for warranty). Confirmed: no normalized table, so `listFeatureLinks` returns the raw feature-link JSONB for warranty.
+- `apps/api/src/services/configurationPolicy.ts:1090-1111` — `assertDecomposableInlineSettings` has arms for `alert_rule`, `event_log`, `monitoring`, `remote_access`, `onedrive_helper` and a bare `default: break;`. **`warranty` is absent** — confirmed. It is called from exactly one place, `:1639`, inside `updateFeatureLink`.
+- `apps/api/src/services/configurationPolicy.ts:1474-1495` — `addFeatureLink`'s per-feature validation, verbatim:
+  ```ts
+  export async function addFeatureLink(
+    configPolicyId: string,
+    featureType: ConfigFeatureType,
+    featurePolicyId?: string | null,
+    inlineSettings?: unknown
+  ) {
+    if (inlineSettings !== undefined && inlineSettings !== null) {
+      inlineSettings = configFeatureInlineSettingsSchema.parse(inlineSettings);
+    }
+
+    if (featureType === 'pam' && inlineSettings !== undefined && inlineSettings !== null) {
+      pamInlineSettingsSchema.parse(inlineSettings);
+    }
+
+    if (featureType === 'vulnerability' && inlineSettings !== undefined && inlineSettings !== null) {
+      vulnerabilityInlineSettingsSchema.parse(inlineSettings);
+    }
+
+    if (featureType === 'device_lifecycle' && inlineSettings !== undefined && inlineSettings !== null) {
+      inlineSettings = deviceLifecycleInlineSettingsSchema.parse(inlineSettings);
+    }
+  ```
+  The reserved-key scan therefore runs FIRST on every path, which is why the existing `configurationPolicy.test.ts:104` warranty case (`rejects marker injection before add transaction`) stays green when a warranty arm is appended after it.
+- `apps/api/src/services/configurationPolicy.ts:1562-1594` — `updateFeatureLink(linkId, updates, configPolicyId?)`; it reads `existing` inside the transaction at `:1577-1582` (`const [existing] = await tx.select().from(configPolicyFeatureLinks)...`), so the previously stored `inlineSettings` is already in hand — no extra query is needed to preserve a recorded consent.
+- `apps/api/src/services/configurationPolicy.ts:2656-2662` — the inline-only guard, verbatim, with its own comment at `:2663-2669`:
+  ```ts
+    if (
+      featureType === 'monitoring' ||
+      featureType === 'event_log' ||
+      featureType === 'onedrive_helper' ||
+      featureType === 'vulnerability' ||
+      featureType === 'device_lifecycle'
+    ) {
+      // These have no policy table — they require inlineSettings.
+      //
+      // Being absent from this list is NOT a harmless omission: the fall-through
+      // below accepts any id that happens to name a configuration policy in the
+      // same org (whole-policy linking), so the write proceeds and the
+      // `config_policy_feature_links_reference_integrity` trigger rejects it —
+      // a 500 where the caller should have got a 400 naming the mistake.
+  ```
+  Contract line numbers confirmed exactly.
+- `apps/api/src/services/configurationPolicy.ts:503-509` — `getParentLinkFeatureTypes(parentId)` returns `string[]` of feature types only; it cannot answer "does the parent enable collection", which is why Task 5 adds a sibling function.
+- `apps/api/src/services/configurationPolicy.ts:359-431` — `getConfigPolicy` returns `{ ...policy, featureLinks, parentPolicy, childPolicies }`, where `featureLinks` is `listFeatureLinks(id)` (`:377`) and `parentPolicy.featureLinks` is `listFeatureLinks(parent.id)` (`:408`). Both carry `inlineSettings`. The delete and assignment gates therefore need **no extra query**.
+- `apps/api/src/services/configurationPolicy.ts:1697-1701` — `listFeatureLinks` selects the whole row (`db.select().from(configPolicyFeatureLinks)`), so `link.inlineSettings` is the stored JSONB.
+- `apps/api/src/services/configurationPolicy.ts:2400-2408` — `FEATURE_TABLE_MAP` is an empty object literal with an explanatory comment. `:2417-2430` — `PARTNER_LINKABLE_FEATURE_TYPES` does not contain `warranty`. Both correct as-is; this wave changes neither.
+
+### Config policy — routes
+
+- `apps/api/src/routes/configurationPolicies/featureLinks.ts:47-48`:
+  ```ts
+  const requireConfigPolicyRead = requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action);
+  const requireConfigPolicyWrite = requirePermission(PERMISSIONS.DEVICES_WRITE.resource, PERMISSIONS.DEVICES_WRITE.action);
+  ```
+- `apps/api/src/routes/configurationPolicies/featureLinks.ts:91` — `export const MFA_GATED_FEATURE_TYPES: ReadonlySet<string> = new Set(['patch', 'maintenance']);` Confirmed.
+- In-handler MFA checks, verbatim: `:145-147`
+  ```ts
+      if (MFA_GATED_FEATURE_TYPES.has(data.featureType) && !hasSatisfiedMfa(auth)) {
+        return c.json({ error: 'MFA required' }, 403);
+      }
+  ```
+  `:340-341` is the same shape keyed on `existingLink.featureType`; `:519-526` is the delete gate:
+  ```ts
+      const parentUnresolved = !!policy.parentPolicyId && !policy.parentPolicy;
+      const parentHasSameType = !!policy.parentPolicy?.featureLinks?.some(
+        (l: { featureType: string }) => l.featureType === existingLink.featureType,
+      );
+      const revertRestoresParentWindow = existingLink.featureType === 'maintenance'
+        && (parentUnresolved || parentHasSameType);
+      if ((existingLink.featureType === 'patch' || revertRestoresParentWindow) && !hasSatisfiedMfa(auth)) {
+        return c.json({ error: 'MFA required' }, 403);
+      }
+  ```
+  This is the precedent Task 5's revert-to-parent arm mirrors, including its **fail-closed** `parentUnresolved` clause.
+- `apps/api/src/routes/configurationPolicies/index.ts:12` — `configPolicyRoutes.use('*', authMiddleware);` so `auth` is always set. `apps/api/src/middleware/auth.ts:874` — `requirePermission` ends with `c.set('permissions', userPerms);`, so `c.get('permissions')` is populated for every handler behind `requireConfigPolicyWrite`. The gate still treats a missing value as denied (fail closed).
+- `apps/api/src/routes/configurationPolicies/assignments.ts:65-158` — `POST /:id/assignments`. It reads `const policy = await getConfigPolicy(id, auth);` at `:76`, and there is **no MFA or execute check anywhere in the file** — confirmed by `grep -n hasSatisfiedMfa apps/api/src/routes/configurationPolicies/assignments.ts` returning nothing. This is the assignment transition D4 requires and it is currently ungated.
+- `apps/api/src/routes/configurationPolicies/crud.ts:76-83` — the create-with-parent inheritance gate, verbatim:
+  ```ts
+      // MFA follows EFFECTIVENESS, not the verb (#5080). Creating a child of a
+      // parent that carries a patch or maintenance link makes that link effective
+      // on the new policy immediately — the same capability the direct
+      // POST /:id/features gate protects, reached through a second door.
+      // Session-claim strength (hasSatisfiedMfa), matching the adjacent gates.
+      if (data.parentPolicyId) {
+        const parentTypes = await getParentLinkFeatureTypes(data.parentPolicyId);
+        if (parentTypes.some((t) => MFA_GATED_FEATURE_TYPES.has(t)) && !hasSatisfiedMfa(auth)) {
+          return c.json({ error: 'MFA required' }, 403);
+        }
+      }
+  ```
+  `grep -n parentPolicyId apps/api/src/routes/configurationPolicies/crud.ts` returns `:78`, `:79`, `:123`, `:192` only — **`parentPolicyId` is settable at CREATE time and never on PATCH**, which bounds the inheritance surface to this one handler.
+- `apps/api/src/middleware/auth.ts:885-909` — `requireMfa()`; its refusal body is `return c.json({ error: 'MFA required', code: 'MFA_REQUIRED' }, 403);` at `:904`. **Contract correction:** the contract cites `:885-908`; the function actually closes at `:909`. Immaterial, recorded for honesty. `:915` — `export function hasSatisfiedMfa(auth: Pick<AuthContext, 'token'>): boolean {` — confirmed exactly.
+- `apps/api/src/services/permissions.ts:210` — `export function hasPermission(userPerms: UserPermissions, resource: string, action: string): boolean` — confirmed. `packages/shared/src/constants/permissions.ts:24` — `DEVICES_EXECUTE: { resource: 'devices', action: 'execute' },` — confirmed.
+- `apps/api/src/routes/software.ts:1774` — the established in-handler shape for reading resolved permissions: `c.get('permissions') as UserPermissions | undefined`.
+
+### Shared validators
+
+- `packages/shared/src/validators/index.ts:595-604` — verbatim:
+  ```ts
+  export const configFeatureInlineSettingsSchema = z
+    .record(z.string(), z.unknown())
+    .superRefine((settings, ctx) => {
+      if (containsConfigPolicyReservedKey(settings)) {
+        ctx.addIssue({
+          code: 'custom',
+          message: 'Reserved configuration feature material is not allowed',
+        });
+      }
+    });
+  ```
+  Its only rule is the reserved-key scan. Confirmed: warranty inline settings receive no shape validation today on any path.
+- `packages/shared/src/validators/index.ts:632-639` — `addFeatureLinkSchema` already lists `'warranty'` in its `featureType` enum, and types `inlineSettings` as `configFeatureInlineSettingsSchema.optional()`. So the reserved-key 400 fires at `zValidator` time, before any handler code — this is why the existing `featureLinks.test.ts:311` warranty case stays green.
+- `packages/shared/src/validators/index.ts:624-628` — `deviceLifecycleInlineSettingsSchema` is `z.object({...}).strict()`; its doc comment states the house rule this wave follows: "`.strict()` so an unknown key is rejected rather than persisted-and-echoed as if it took effect."
+- `packages/shared/package.json:29` — `"zod": "^4.4.3"`. `apps/api/src/routes/agents/schemas.ts:406,489,616,875` use `z.string().datetime()`, so that spelling (not `z.iso.datetime()`) is the repo convention.
+- `packages/shared/src/validators/remoteAccessInlineSettings.ts` exists as a standalone per-feature validator module re-exported from the barrel (`index.ts:22`, `export * from './remoteAccessInlineSettings';`) — the precedent for this wave's new file.
+- `packages/shared/src/index.ts` is `export * from './types'; export * from './constants'; export * from './validators'; export * from './utils'; export * from './m365';`. `apps/web/tsconfig.json:7-8` and `apps/web/vitest.config.ts:18-22` alias **only** `@breeze/shared` and `@breeze/shared/reportPdf` — the web layer therefore must import new symbols from the ROOT barrel, not from `@breeze/shared/validators`.
+
+### AI tool path (why the service backstop is load-bearing)
+
+- `apps/api/src/services/aiToolsConfigPolicy.ts:71-75` — verbatim:
+  ```ts
+  const VALIDATED_INLINE_SETTINGS: Record<string, { schema: { safeParse: (raw: unknown) => any }; normalize: boolean }> = {
+    onedrive_helper: { schema: onedriveHelperInlineSettingsSchema, normalize: true },
+    alert_rule: { schema: alertRuleInlineSettingsSchema, normalize: true },
+    monitoring: { schema: monitoringInlineSettingsSchema, normalize: false },
+  };
+  ```
+  `warranty` is absent, and `:936-942` calls `addFeatureLink(...)` directly. `manage_policy_feature_link` is Tier 2 (auto-executes, audit only, no human approval — see the comment at `:88-90`). So an assistant can today write any warranty JSONB it likes. A route-only consent stamp would be forgeable through this door; the stamp must live in the service and take its actor out-of-band.
+- `apps/api/src/services/aiAgentSdkTools.ts:250` — `manage_policy_feature_link: 2,` — confirmed, the base tier really is 2.
+- `apps/api/src/services/aiGuardrails.ts:533-543` — `isInputAwareTier3`, verbatim:
+  ```ts
+  export function isInputAwareTier3(
+    toolName: string,
+    action: string | undefined,
+    input: Record<string, unknown>,
+  ): boolean {
+    return (
+      toolName === 'manage_policy_feature_link' &&
+      (action === 'add' || action === 'update') &&
+      input.featureType === 'maintenance'
+    );
+  }
+  ```
+  It escalates **only** on `featureType === 'maintenance'`. A warranty link carrying `hpCmsl.enabled: true` therefore auto-executes at Tier 2 with no approval, no MFA and no `devices.execute` — straight around D4. Its two call sites are `:570` (`resolveApprovalScope`, which returns `'supervised'` for the escalated pair) and `:1426` (`checkGuardrails`, after the Tier-1 read downgrade at `:1413-1421` and before the static Tier-3/Tier-2 tables).
+- `apps/api/src/services/aiGuardrails.ts:508-512` — the `TIER3_INPUT_AWARE_ACTIONS` entry comment ("only the INPUT says which it is, so it cannot be classified by (tool, action) in the static tables"); `:507-514` — the set already contains `'manage_policy_feature_link:add'` and `':update'`, so **no set membership changes** and the `approvalScope.contract.test.ts` "classified in exactly one static table" invariant is already satisfied for both pairs.
+- `apps/api/src/services/aiGuardrails.ts:570-578` — the scope rationale, verbatim: "`supervised` matches the #3552/835f7eb3d policy-prerequisite escalations and manage_configuration_policy's own create/update/delete — authoring policy configuration, not an externally binding act."
+- `apps/api/src/services/aiGuardrails.ts:523-531` — the doc comment's two warnings: the strict `=== 'maintenance'` comparison, and "for `update`, **featureType is not a required input**". That second fact is decisive: a warranty escalation keyed on `featureType` alone would miss every `update`, so the predicate must read the settings CONTENT.
+- `apps/api/src/services/aiGuardrails.ts:2327-2330` — the approval description for this tool: `` parts.push(`${action?.toUpperCase()} ${String(input.featureType ?? 'feature')} link`) `` — an `update` with no `featureType` renders "UPDATE feature link", which tells an approver nothing about HP software being installed.
+- `apps/api/src/services/aiGuardrails.imports.contract.test.ts:11-17` — the only import rule on this file is "does not import `./aiToolSchemas` or `getToolDefinitions`" (they pull Drizzle enum objects into partially-mocked suites). A value import from `@breeze/shared/validators` is a pure-zod leaf and does not trip it.
+- Existing escalation coverage: `apps/api/src/services/aiGuardrails.test.ts:1202-1270` (seven cases, including the read-not-escalated and non-string-featureType controls) and `apps/api/src/services/aiGuardrails.approvalScope.contract.test.ts:380-395` (both-branches). `apps/api/src/routes/mcpServer.approvalGate.test.ts:440-500` exercises the same escalation end-to-end through the MCP transport.
+
+### Warranty resolution
+
+- `apps/api/src/services/warrantyAlertEvaluator.ts:58` — `async function resolveWarrantySettings(deviceId: string): Promise<WarrantyAlertSettings> {` — **not exported**, closes at `:186`. Contract's `:58-186` confirmed.
+- **Contract correction:** the contract cites the level-priority sort at `:158-172` and `DISABLED_SETTINGS` at `:156`. Actual lines: `if (rows.length === 0) return DISABLED_SETTINGS;` is **`:160`**; `const levelPriority: Record<string, number> = {` is **`:163`**; `rows.sort((a, b) => {` is **`:171`**; the projection is `:178-185`, verbatim:
+  ```ts
+    const inline = rows[0]!.inlineSettings as Partial<WarrantyAlertSettings> | null;
+    if (!inline) return DEFAULT_SETTINGS;
+
+    return {
+      enabled: inline.enabled ?? DEFAULT_SETTINGS.enabled,
+      warnDays: inline.warnDays ?? DEFAULT_SETTINGS.warnDays,
+      criticalDays: inline.criticalDays ?? DEFAULT_SETTINGS.criticalDays,
+    };
+  ```
+  Ranking is `device: 5, device_group: 4, site: 3, organization: 2, partner: 1` (`:164-170`), then `b.priority - a.priority` (`:175`).
+- `apps/api/src/services/warrantyAlertEvaluator.ts:25-48` — `interface WarrantyAlertSettings { enabled; warnDays; criticalDays }`, `DEFAULT_SETTINGS` = `{true, 90, 30}` (`:36-40`), `DISABLED_SETTINGS` = `{false, 90, 30}` (`:44-48`).
+- `apps/api/src/services/warrantyAlertEvaluator.ts:130-158` — the query joins `configPolicyEffectiveFeatureLinks` → `configurationPolicies` → `configPolicyAssignments`, filtered by `eq(configPolicyEffectiveFeatureLinks.featureType, 'warranty')`, `eq(configurationPolicies.status, 'active')`, `policyOwnershipCondition({ orgId: device.orgId, partnerId: org?.partnerId ?? null })` and `or(...targetConditions)`. The polymorphic per-level target conditions are `:112-129`. The file is 423 lines.
+
+### Heartbeat — server
+
+- `apps/api/src/routes/agents/helpers.ts:2841-2850` — `PatchSourceSettings`; `:2852-2859` — the revocation contract comment, verbatim:
+  ```ts
+  /**
+   * Resolves the patch feature link for the device and surfaces the
+   * sole-source-enforcement flag for the heartbeat config push. A device with no
+   * patch policy assigned resolves to `false`, which the agent treats as "revert
+   * any prior Breeze enforcement" — so removing the policy cleanly reverts the
+   * endpoint. The caller (heartbeat) omits the block entirely on a resolver error
+   * so a transient failure never triggers an unintended revert.
+   */
+  ```
+  `:2860-2863` — the function:
+  ```ts
+  export async function buildPatchSourceConfigUpdate(deviceId: string): Promise<PatchSourceSettings> {
+    const patch = await resolvePatchConfigForDevice(deviceId);
+    return { exclusiveWindowsUpdate: patch?.exclusiveWindowsUpdate ?? false };
+  }
+  ```
+  All three contract citations confirmed exactly. `helpers.ts` is 3116 lines.
+- `apps/api/src/routes/agents/heartbeat.ts:1921-1926` — verbatim:
+  ```ts
+    type PolicyConfigUpdates = {
+      eventLogSettings: Record<string, unknown> | null;
+      monitoringSettings: Record<string, unknown> | null;
+      pamSettings: { uacInterceptionEnabled: boolean } | null;
+      patchSourceSettings: { exclusiveWindowsUpdate: boolean } | null;
+    };
+  ```
+  Function-local, not exported — confirmed. `:1927-1932` is the all-null initialiser; `:1934` is `policyConfigs = await withSystemDbAccessContext(async (): Promise<PolicyConfigUpdates> => {`; `:1976-1982` is the patch-source builder + catch:
+  ```ts
+        // #1872: sole-patch-source enforcement. Omit the block on a resolver error so
+        // a transient failure never reverts an endpoint already under enforcement;
+        // a successful resolve with no patch policy returns false → agent reverts.
+        try {
+          patchSourceSettings = await buildPatchSourceConfigUpdate(scoped.deviceId);
+        } catch (err) {
+          console.error(`[agents] failed to build patch_source config update for ${agentId}:`, err);
+          captureException(err);
+        }
+  ```
+  `:1984` is the `return { eventLogSettings, monitoringSettings, pamSettings, patchSourceSettings };`. The wire assembly is `:1993-2005`:
+  ```ts
+    const { eventLogSettings, monitoringSettings, pamSettings, patchSourceSettings } = policyConfigs;
+
+    const policyConfigUpdate: Record<string, unknown> = {};
+    if (eventLogSettings) {
+      policyConfigUpdate.event_log_settings = eventLogSettings;
+    }
+    if (monitoringSettings) {
+      policyConfigUpdate.monitoring_settings = monitoringSettings;
+    }
+    if (patchSourceSettings) {
+      policyConfigUpdate.patch_source_settings = patchSourceSettings;
+    }
+    const hasPolicyConfigUpdate = Object.keys(policyConfigUpdate).length > 0;
+  ```
+  Note `pamSettings` is deliberately NOT merged here (it ships as a top-level `uacInterceptionEnabled` at `:2047`). `:2007-2015` merges `policyConfigUpdate` into the response `configUpdate`. The import block is `:21-38`, with `buildPatchSourceConfigUpdate` at `:31`.
+
+### Heartbeat — agent
+
+- `agent/internal/heartbeat/heartbeat.go:2851` — `func (h *Heartbeat) applyConfigUpdate(update map[string]any) {`. Confirmed. Outer keys check snake_case first at `:2857`, `:2867`, `:2879`, `:2889`, `:2901`, `:2910` — all six confirmed by direct line count.
+- `agent/internal/heartbeat/heartbeat.go:2909-2916` — the LAST non-probe key, verbatim:
+  ```go
+  	// Apply onedrive_helper_settings if present (Phase 2). No-op on non-Windows.
+  	odRaw, hasOD := update["onedrive_helper_settings"]
+  	if !hasOD {
+  		odRaw, hasOD = update["onedriveHelperSettings"]
+  	}
+  	if hasOD {
+  		h.applyOneDriveHelperConfig(odRaw)
+  	}
+  ```
+  `:2918` starts the probe path and `:2928-2930` is its unconditional bail:
+  ```go
+  	registryRaw, hasRegistry := update["policy_registry_state_probes"]
+  	...
+  	if !hasRegistry && !hasConfig {
+  		return
+  	}
+  ```
+  **The new dispatch goes immediately after `:2916`, before `:2918`.** Confirmed by reading, exactly as the contract states.
+- `agent/internal/heartbeat/patch_source.go` — the whole file is 57 lines. `:7-12`:
+  ```go
+  // applyWinUpdate is the seam to the (Windows-only) enforcement. A package var so
+  // tests can capture the resolved enforce bool on any platform — the dispatch +
+  // payload-parse path is where a key-name regression would silently disable the
+  // whole feature, so it must be unit-tested even though the registry I/O cannot
+  // run on the CI agent.
+  var applyWinUpdate = winupdate.Apply
+  ```
+  `:18` `func (h *Heartbeat) applyPatchSourceConfig(raw any) {`; `:19-23` the `map[string]any` type assertion with a warn-and-return; `:25-33` the dual-key parse, **camelCase first**:
+  ```go
+  	// The API may send either snake_case or camelCase.
+  	v, present := m["exclusiveWindowsUpdate"]
+  	if !present {
+  		v, present = m["exclusive_windows_update"]
+  	}
+  	if !present {
+  		log.Warn("patch_source_settings received without exclusiveWindowsUpdate field")
+  		return
+  	}
+  ```
+  Neither symbol is exported. Confirmed.
+- `agent/internal/heartbeat/patch_source_test.go:1-77` — the table-driven seam test, capturing through `orig := applyWinUpdate; t.Cleanup(func() { applyWinUpdate = orig })` and driving the whole path via `h := &Heartbeat{config: config.Default()}; h.applyConfigUpdate(tt.update)`. Six cases including both key spellings, a non-object payload and an absent block. This is the template Task 10 copies.
+- `agent/internal/heartbeat/heartbeat.go:2809-2848` — `applyRequireManifestSigningKeyIDConfig`, the closest precedent for a **persisted control-plane boolean**: read current under `h.mu`, decide, write `h.config.X` under `h.mu`, then `config.SetAndPersist("require_manifest_signing_key_id", val)` with a `log.Warn` on failure. `:4008-4012` — `func (h *Heartbeat) requireManifestSigningKeyID() bool { h.mu.Lock(); defer h.mu.Unlock(); return h.config.RequireManifestSigningKeyID }` — the mutex-guarded accessor pattern W03 will need.
+- `agent/internal/config/config.go:207` — `RequireManifestSigningKeyID bool \`mapstructure:"require_manifest_signing_key_id" yaml:"require_manifest_signing_key_id"\`` — the field-declaration shape. `:596` — `func SetAndPersist(key string, value any) error`. `:707-727` — `saveToLocked` sets each key explicitly (`viper.Set("require_manifest_signing_key_id", cfg.RequireManifestSigningKeyID)` at `:726`), so a new persisted field must be added there too or `SaveTo` silently drops it. `:327-...` — `Default()` does not initialise `RequireManifestSigningKeyID`; a zero-value `false` default needs no entry.
+
+### Web
+
+- `apps/web/src/components/configurationPolicies/featureTabs/WarrantyTab.tsx:9-18` — verbatim:
+  ```tsx
+  type WarrantySettings = {
+    enabled: boolean;
+    warnDays: number;
+    criticalDays: number;
+  };
+  const defaults: WarrantySettings = {
+    enabled: true,
+    warnDays: 90,
+    criticalDays: 30,
+  };
+  ```
+  `:30-42` seeds state from `existingLink ?? parentLink` and re-syncs in a `useEffect`. `:49-53` and `:63-67` are the save/override payloads, both hardcoding `featurePolicyId: null` with the `#5080` comment. The file is 180 lines and uses `i18n.t("policies:configurationPolicies.featureTabs.warrantyTab.<key>")` for every string.
+- `apps/web/src/components/configurationPolicies/featureTabs/useFeatureLink.ts:34` — `if (payload.inlineSettings) body.inlineSettings = payload.inlineSettings;` — the tab's settings object is sent **verbatim**. Since the tab reads `consent` back out of the saved link for display, it MUST strip it before saving or every subsequent save trips D3's coded 400.
+- `apps/web/src/components/configurationPolicies/featureTabs/types.ts:20-27` — `FeatureLink` carries `inlineSettings: Record<string, unknown> | null`. `:37-53` — `FeatureTabProps` supplies `existingLink`, `parentLink`, `linkedPolicyId`.
+- `apps/web/src/components/configurationPolicies/featureTabs/WarrantyTab.test.tsx:1-50` — the existing suite mocks `./useFeatureLink` and finds the Save button by role+text. `DeviceLifecycleTab.test.tsx:29-52` adds the `link()` and `savedSettings()` helpers this wave reuses, and `DeviceLifecycleTab.tsx:159-166` shows the `data-testid` + `role="switch"` + `aria-checked` convention for a toggle.
+- `apps/web/src/components/configurationPolicies/featureTabs/structuralValues.test.ts:9-22` — `WarrantyTab.tsx` is already in the guarded file list; the guard forbids `update(i18n.t(`, `value: i18n.t(`, and `.x === i18n.t(` patterns. Task 12's code uses machine keys throughout and does not trip it.
+- `apps/web/src/locales/` contains `en`, `de-DE`, `es-419`, `fr-CA`, `fr-FR`, `it-IT`, `pt-BR`, `tr-TR`. `apps/web/src/locales/en/policies.json:1168-1179` is the existing `warrantyTab` block (7 real keys plus three stray machine-value keys `enabled`/`warnDays`/`criticalDays`).
+- `apps/web/src/lib/i18n/localeParity.test.ts:457-461` — ``it(`${locale} matches en namespace files and keys exactly`)`` asserts key-set equality, so **every new `en` key must be added to all seven other locales**. `:465-477` asserts interpolation tokens are preserved. `:513-524` asserts `protectedNames` occurrence counts match per key; the list at `:100-190` includes `'IP'`, `'API'`, `'MSP'`, `'RMM'`, `'PowerShell'`, `'Windows'`, `'winget'` — so a translated string must contain `IP` exactly as often as the English one.
+- `apps/web/src/lib/i18n/translationCoverage.test.ts:764-778` — ``it(`${locale} does not exceed reviewed namespace duplicate baselines`)``: an exact-English copy in a translated catalog counts against a hard per-namespace baseline. **New keys must be genuinely translated, not copied.**
+- `apps/web/src/lib/i18n/terminologyQuality.test.ts:40-49` — the forbidden-pattern lists (`pt-BR`: `/\bvoce\b/i`, `/\besta ativa\b/i`, `/\bcomecar\b/i`, `teste de fumaça`; `fr-*`: `/\bpostuler\b/i`, `/\bsubventions?\b/i`, `test de fumée`, `oscilloire`; `de-DE`: `/\bHauptschalter\b/i`, `/\bKernschalter\b/i`; `it-IT`: `/\bpotrài\b/i`). Task 11's strings avoid all of them.
+- `apps/web/src/lib/i18n/keyUsage.test.ts:336` — `it('every literal t() key resolves in en')`. The check runs key→catalog only; a catalog key with no consumer yet is fine, so the catalogs can land before the tab.
+
+### Existing tests that constrain this wave
+
+- `apps/api/src/routes/configurationPolicies/featureLinks.test.ts:44-56` — the harness: `mfaState` hoisted, `vi.mock('../../middleware/auth', ...)` exporting `hasSatisfiedMfa: vi.fn(() => mfaState.satisfied)` and pass-through `requirePermission`. `:73-83` — `buildApp()` sets only `c.set('auth', makeAuth())`; it does **not** set `permissions`, so Task 5's tests must add it.
+- `apps/api/src/routes/configurationPolicies/featureLinks.test.ts:308-326` — the reserved-material case that includes `'warranty'`; it asserts a 400 and that the body contains neither `__breezePatchInlineMirror` nor `attacker-value`. It passes through `zValidator`, ahead of any new warranty branch.
+- `apps/api/src/services/configurationPolicy.test.ts:102-113` — the service-level twin, calling `addFeatureLink('policy-1', 'warranty', null, { nested: { __breezePatchInlineMirror: ... } })` and expecting `/reserved/i` before `db.transaction` is touched.
+- `apps/api/src/services/configurationPolicy.deviceLifecycle.test.ts:1-57` — the exact template for D12's red-first test, including the db double that returns a MATCHING config-policy row so a removed guard fails on the assertion rather than a TypeError.
+- `apps/api/src/routes/agents/helpers.patchSource.test.ts:1-129` — the module-mock preamble a new `helpers.warranty.test.ts` copies verbatim (`vi.mock('../../db', ...)`, `vi.mock('../../db/schema', ...)` and eleven service mocks) so `helpers.ts` imports without a DB or Redis.
+- `apps/api/src/routes/agents/heartbeat.test.ts:167-176` — the `vi.mock('./helpers', ...)` factory; `:3114-3143` — the two patch-source wiring cases (delivered when true, omitted when the builder rejects) that Task 9's tests mirror.
+
+## File structure
+
+- **Create** `packages/shared/src/constants/hpCmsl.ts` — `HP_CMSL_EULA_ID` (D2). Leaf module, no imports.
+- **Modify** `packages/shared/src/constants/index.ts` — re-export it.
+- **Create** `packages/shared/src/validators/warrantyInlineSettings.ts` — the client schema (consent forbidden), the stored schema (consent allowed and required when enabled), and three predicates. The single source of truth for what an `hpCmsl` block means.
+- **Create** `packages/shared/src/validators/warrantyInlineSettings.test.ts`.
+- **Modify** `packages/shared/src/validators/index.ts` — re-export it.
+- **Modify** `apps/api/src/services/configurationPolicy.ts` — warranty arm in `addFeatureLink`/`updateFeatureLink` with the out-of-band consent stamp; `WarrantyConsentError`; `parentPolicyEnablesHpCmslCollection`; `warranty` added to the inline-only guard list.
+- **Create** `apps/api/src/services/configurationPolicy.warranty.test.ts` — service-level consent tests.
+- **Create** `apps/api/src/services/configurationPolicy.warrantyGuard.test.ts` — D12's red-first guard test.
+- **Create** `apps/api/src/routes/configurationPolicies/hpCmslGate.ts` + `hpCmslGate.test.ts` — the shared `devices.execute` + MFA decision, used from five call sites.
+- **Modify** `apps/api/src/routes/configurationPolicies/featureLinks.ts` — coded consent refusal, warranty schema parse, the gate on create/update/revert-delete, actor passed to the service.
+- **Modify** `apps/api/src/routes/configurationPolicies/assignments.ts` — the gate on assignment.
+- **Modify** `apps/api/src/routes/configurationPolicies/crud.ts` — the gate on create-with-parent.
+- **Modify** `apps/api/src/routes/configurationPolicies/featureLinks.test.ts` — new describes for consent + gate.
+- **Create** `apps/api/src/routes/configurationPolicies/assignments.hpCmsl.test.ts`.
+- **Modify** `apps/api/src/services/aiToolsConfigPolicy.ts` — register the warranty schema so an assistant gets a descriptive refusal.
+- **Modify** `apps/api/src/services/aiGuardrails.ts` — `isInputAwareTier3` gains a second, content-keyed arm so an hpCmsl-enabling feature-link write escalates to Tier 3 (`supervised`); the approval description names it.
+- **Modify** `apps/api/src/services/aiGuardrails.test.ts` and `apps/api/src/services/aiGuardrails.approvalScope.contract.test.ts` — both-directions coverage plus the unchanged-maintenance control.
+- **Create** `apps/api/src/services/warrantyPolicyResolution.ts` + `warrantyPolicyResolution.test.ts` — the hierarchy resolver lifted out of the alert evaluator, now shared.
+- **Modify** `apps/api/src/services/warrantyAlertEvaluator.ts` — `resolveWarrantySettings` becomes a projection over the shared resolver.
+- **Modify** `apps/api/src/routes/agents/helpers.ts` — `buildWarrantyConfigUpdate`.
+- **Create** `apps/api/src/routes/agents/helpers.warranty.test.ts`.
+- **Modify** `apps/api/src/routes/agents/heartbeat.ts` — `warrantySettings` through `PolicyConfigUpdates`, the shared system context, and the wire assembly.
+- **Modify** `apps/api/src/routes/agents/heartbeat.test.ts` — delivery + omit-on-error cases.
+- **Modify** `agent/internal/config/config.go` — `HPWarrantyCollectionEnabled` field + `saveToLocked` entry.
+- **Create** `agent/internal/heartbeat/warranty_config.go` + `warranty_config_test.go` — the seam, the parse, and the accessor W03 reads.
+- **Modify** `agent/internal/heartbeat/heartbeat.go` — dispatch above `:2918`.
+- **Modify** `apps/web/src/locales/{en,de-DE,es-419,fr-CA,fr-FR,it-IT,pt-BR,tr-TR}/policies.json` — six new `warrantyTab` keys.
+- **Modify** `apps/web/src/components/configurationPolicies/featureTabs/WarrantyTab.tsx` — the checkbox, consent copy, read-only acceptance, inheritance warning, consent-stripping save payload.
+- **Modify** `apps/web/src/components/configurationPolicies/featureTabs/WarrantyTab.test.tsx`.
+
+---
+
+### Task 1: Shared contract — EULA id, warranty inline-settings schemas, and the three predicates
+
+**Files:**
+- Create: `packages/shared/src/constants/hpCmsl.ts`
+- Modify: `packages/shared/src/constants/index.ts` (add one `export * from` line)
+- Create: `packages/shared/src/validators/warrantyInlineSettings.ts`
+- Modify: `packages/shared/src/validators/index.ts` (add one `export * from` line)
+- Test: `packages/shared/src/validators/warrantyInlineSettings.test.ts`
+
+**Interfaces:**
+- Consumes: nothing (first task).
+- Produces, all reachable from `@breeze/shared` (root barrel — the only path the web layer's alias resolves) and from `@breeze/shared/validators` / `@breeze/shared/constants`:
+  - `HP_CMSL_EULA_ID: 'hp-cmsl-eula-2026-04-01'`
+  - `warrantyHpCmslConsentSchema`, `WarrantyHpCmslConsent`
+  - `warrantyHpCmslRequestBlockSchema` (no `consent` key — `.strict()` rejects one)
+  - `warrantyHpCmslStoredBlockSchema` (`consent` optional)
+  - `warrantyInlineSettingsSchema` — **client-facing**; `WarrantyInlineSettings`
+  - `storedWarrantyInlineSettingsSchema` — **server/stored**; `StoredWarrantyInlineSettings`
+  - `clientSuppliedWarrantyHpCmslConsent(inlineSettings: unknown): boolean`
+  - `warrantyHpCmslRequested(inlineSettings: unknown): boolean`
+  - `warrantyHpCmslCollectionEffective(inlineSettings: unknown): boolean`
+  - `readRecordedWarrantyHpCmslConsent(inlineSettings: unknown): WarrantyHpCmslConsent | null`
+
+**Why two predicates, not one** (this is the subtlety that decides whether the gate works): `warrantyHpCmslRequested` answers *"is this author asking for collection?"* and is evaluated on a payload **before** the server stamps consent, so it must NOT require consent. `warrantyHpCmslCollectionEffective` answers *"does this stored link actually deliver collection?"* and requires a consent matching the CURRENT `HP_CMSL_EULA_ID` — it is what the agent-delivery builder and the inheritance/assignment gates read. Collapsing them into one predicate makes the create gate a no-op (consent is never present at gate time) or makes delivery ignore a superseded EULA. Keep both.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/shared/src/validators/warrantyInlineSettings.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import {
+  HP_CMSL_EULA_ID,
+  clientSuppliedWarrantyHpCmslConsent,
+  storedWarrantyInlineSettingsSchema,
+  warrantyHpCmslCollectionEffective,
+  warrantyHpCmslRequested,
+  warrantyInlineSettingsSchema,
+} from './warrantyInlineSettings';
+
+const CONSENT = {
+  acceptedByUserId: 'user-1',
+  acceptedAt: '2026-09-10T12:00:00.000Z',
+  eulaId: HP_CMSL_EULA_ID,
+};
+
+describe('warrantyInlineSettingsSchema (client-facing)', () => {
+  it('accepts the legacy three-field alerting shape unchanged', () => {
+    const parsed = warrantyInlineSettingsSchema.safeParse({
+      enabled: true,
+      warnDays: 90,
+      criticalDays: 30,
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('accepts an hpCmsl block with only `enabled`', () => {
+    const parsed = warrantyInlineSettingsSchema.safeParse({
+      enabled: true,
+      warnDays: 90,
+      criticalDays: 30,
+      hpCmsl: { enabled: true },
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('REFUSES a client-supplied consent object (D3 — never silently stripped)', () => {
+    const parsed = warrantyInlineSettingsSchema.safeParse({
+      hpCmsl: { enabled: true, consent: CONSENT },
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it('refuses an unknown top-level key rather than persisting it', () => {
+    expect(warrantyInlineSettingsSchema.safeParse({ hpCsml: { enabled: true } }).success).toBe(false);
+  });
+
+  it('refuses an hpCmsl block with no `enabled`', () => {
+    expect(warrantyInlineSettingsSchema.safeParse({ hpCmsl: {} }).success).toBe(false);
+  });
+});
+
+describe('storedWarrantyInlineSettingsSchema (server/stored)', () => {
+  it('accepts a stamped consent', () => {
+    const parsed = storedWarrantyInlineSettingsSchema.safeParse({
+      hpCmsl: { enabled: true, consent: CONSENT },
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('rejects a consent with a non-ISO acceptedAt', () => {
+    const parsed = storedWarrantyInlineSettingsSchema.safeParse({
+      hpCmsl: { enabled: true, consent: { ...CONSENT, acceptedAt: 'yesterday' } },
+    });
+    expect(parsed.success).toBe(false);
+  });
+});
+
+describe('clientSuppliedWarrantyHpCmslConsent', () => {
+  it('is true when the key is present at all, even undefined-valued', () => {
+    expect(clientSuppliedWarrantyHpCmslConsent({ hpCmsl: { enabled: true, consent: undefined } })).toBe(true);
+    expect(clientSuppliedWarrantyHpCmslConsent({ hpCmsl: { enabled: true, consent: null } })).toBe(true);
+  });
+
+  it('is false for a clean payload and for non-objects', () => {
+    expect(clientSuppliedWarrantyHpCmslConsent({ hpCmsl: { enabled: true } })).toBe(false);
+    expect(clientSuppliedWarrantyHpCmslConsent({ enabled: true })).toBe(false);
+    expect(clientSuppliedWarrantyHpCmslConsent(null)).toBe(false);
+    expect(clientSuppliedWarrantyHpCmslConsent('nope')).toBe(false);
+  });
+});
+
+describe('warrantyHpCmslRequested (pre-stamp gate input)', () => {
+  it('is true for an enable request that carries no consent yet', () => {
+    expect(warrantyHpCmslRequested({ hpCmsl: { enabled: true } })).toBe(true);
+  });
+
+  it('is false for an explicit disable, an absent block, and junk', () => {
+    expect(warrantyHpCmslRequested({ hpCmsl: { enabled: false } })).toBe(false);
+    expect(warrantyHpCmslRequested({ enabled: true, warnDays: 90 })).toBe(false);
+    expect(warrantyHpCmslRequested({ hpCmsl: 'yes' })).toBe(false);
+    expect(warrantyHpCmslRequested(undefined)).toBe(false);
+  });
+});
+
+describe('warrantyHpCmslCollectionEffective (delivery + inheritance gates)', () => {
+  it('is true only for enabled + consent against the current EULA id', () => {
+    expect(warrantyHpCmslCollectionEffective({ hpCmsl: { enabled: true, consent: CONSENT } })).toBe(true);
+  });
+
+  it('is false when consent is missing entirely', () => {
+    expect(warrantyHpCmslCollectionEffective({ hpCmsl: { enabled: true } })).toBe(false);
+  });
+
+  it('is false when consent names a superseded EULA id (D2 — re-consent required)', () => {
+    expect(
+      warrantyHpCmslCollectionEffective({
+        hpCmsl: { enabled: true, consent: { ...CONSENT, eulaId: 'hp-cmsl-eula-2020-01-01' } },
+      }),
+    ).toBe(false);
+  });
+
+  it('is false for a disabled block that still carries consent', () => {
+    expect(warrantyHpCmslCollectionEffective({ hpCmsl: { enabled: false, consent: CONSENT } })).toBe(false);
+  });
+
+  it('is false for a malformed block — fail safe, never collect on a blob we cannot read', () => {
+    expect(warrantyHpCmslCollectionEffective({ hpCmsl: { enabled: true, consent: CONSENT, extra: 1 } })).toBe(false);
+    expect(warrantyHpCmslCollectionEffective(null)).toBe(false);
+  });
+
+  it('ignores unrelated alert-threshold junk on the same object', () => {
+    // The block predicates parse the hpCmsl SUB-BLOCK only, deliberately: a
+    // stray or out-of-range warnDays must not silently switch collection off.
+    expect(
+      warrantyHpCmslCollectionEffective({ warnDays: 99999, hpCmsl: { enabled: true, consent: CONSENT } }),
+    ).toBe(true);
+  });
+});
+
+describe('readRecordedWarrantyHpCmslConsent', () => {
+  it('returns the acceptance verbatim, superseded or not', () => {
+    expect(readRecordedWarrantyHpCmslConsent({ hpCmsl: { enabled: true, consent: CONSENT } })).toEqual(CONSENT);
+    const old = { ...CONSENT, eulaId: 'hp-cmsl-eula-2020-01-01' };
+    expect(readRecordedWarrantyHpCmslConsent({ hpCmsl: { enabled: true, consent: old } })).toEqual(old);
+  });
+
+  it('returns null when there is no acceptance or the block is unreadable', () => {
+    expect(readRecordedWarrantyHpCmslConsent({ hpCmsl: { enabled: true } })).toBeNull();
+    expect(readRecordedWarrantyHpCmslConsent({ enabled: true })).toBeNull();
+    expect(readRecordedWarrantyHpCmslConsent({ hpCmsl: { enabled: true, extra: 1 } })).toBeNull();
+    expect(readRecordedWarrantyHpCmslConsent(undefined)).toBeNull();
+  });
+});
+```
+
+Add `readRecordedWarrantyHpCmslConsent` to the import list at the top of that test file.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/shared && npx vitest run src/validators/warrantyInlineSettings.test.ts`
+Expected: FAIL — `Failed to resolve import "./warrantyInlineSettings"`.
+
+- [ ] **Step 3: Write the constant**
+
+Create `packages/shared/src/constants/hpCmsl.ts`:
+
+```ts
+/**
+ * Identifier for the HP Client Management Script Library (CMSL) licence a
+ * partner accepts when they switch on device-side HP warranty collection
+ * (feature #5511, contract D2).
+ *
+ * The id is COMPARED, never parsed. When HP changes its terms this constant
+ * takes a NEW value: consent recorded against the old id no longer satisfies
+ * the current one, so the config-policy author has to accept again — and the
+ * agent stops collecting until they do. That is deliberate. An acceptance is
+ * an acceptance of specific terms or it is not an acceptance at all.
+ *
+ * The date is the release date of the CMSL package whose licence text was
+ * read (HP.HPCMSL 1.8.6, 2026-04-01), not the date this file was written.
+ */
+export const HP_CMSL_EULA_ID = 'hp-cmsl-eula-2026-04-01';
+```
+
+Append to `packages/shared/src/constants/index.ts`, directly under the `agentFileTransfer` re-export:
+
+```ts
+// HP CMSL licence identifier — the thing a warranty feature link's recorded
+// consent is compared against (#5511 D2). Leaf module, no imports.
+export * from './hpCmsl';
+```
+
+- [ ] **Step 4: Write the schemas and predicates**
+
+Create `packages/shared/src/validators/warrantyInlineSettings.ts`:
+
+```ts
+import { z } from 'zod';
+import { HP_CMSL_EULA_ID } from '../constants/hpCmsl';
+
+/**
+ * `warranty` feature-link inline settings (#5511 W02, contract D1).
+ *
+ * Pure JSONB on `config_policy_feature_links` — no normalized table, no new
+ * tenancy shape, no migration. Two schemas, deliberately:
+ *
+ *  - `warrantyInlineSettingsSchema` is what a CLIENT may send. `consent` is
+ *    not in the shape, and `.strict()` therefore REFUSES it rather than
+ *    stripping it (D3): silently dropping a consent object would let a UI
+ *    believe an acceptance had been recorded when none was.
+ *  - `storedWarrantyInlineSettingsSchema` is what may be PERSISTED. Only the
+ *    server produces a value that satisfies it, because only the server writes
+ *    `consent` — see addFeatureLink/updateFeatureLink in the API's
+ *    configurationPolicy service, which take the accepting user out of band
+ *    rather than from the payload.
+ *
+ * The pre-existing `enabled` field means EXPIRY ALERTING. `hpCmsl.enabled`
+ * means DEVICE-SIDE COLLECTION. They are independent; do not overload either.
+ */
+export const warrantyHpCmslConsentSchema = z
+  .object({
+    /** The authenticated user who accepted, stamped server-side. */
+    acceptedByUserId: z.string().min(1).max(64),
+    /** ISO-8601, server clock. Never a client-supplied time. */
+    acceptedAt: z.string().datetime(),
+    /** Compared against HP_CMSL_EULA_ID; never parsed. */
+    eulaId: z.string().min(1).max(64),
+  })
+  .strict();
+
+export type WarrantyHpCmslConsent = z.infer<typeof warrantyHpCmslConsentSchema>;
+
+/** What a client may send for the hpCmsl block: the flag, and nothing else. */
+export const warrantyHpCmslRequestBlockSchema = z
+  .object({ enabled: z.boolean() })
+  .strict();
+
+/** What may be stored: the flag plus a server-stamped acceptance. */
+export const warrantyHpCmslStoredBlockSchema = z
+  .object({
+    enabled: z.boolean(),
+    consent: warrantyHpCmslConsentSchema.optional(),
+  })
+  .strict();
+
+// The alerting half, unchanged in meaning since #1320. Bounds are wide on
+// purpose (1..3650, matching device_lifecycle's retention window) — a WRITE
+// that fails to parse discards the whole blob, so a legacy row with an odd
+// threshold must still be re-savable after an unrelated edit.
+const warrantyAlertFields = {
+  enabled: z.boolean().optional(),
+  warnDays: z.number().int().min(1).max(3650).optional(),
+  criticalDays: z.number().int().min(1).max(3650).optional(),
+};
+
+export const warrantyInlineSettingsSchema = z
+  .object({
+    ...warrantyAlertFields,
+    hpCmsl: warrantyHpCmslRequestBlockSchema.optional(),
+  })
+  .strict();
+
+export type WarrantyInlineSettings = z.infer<typeof warrantyInlineSettingsSchema>;
+
+export const storedWarrantyInlineSettingsSchema = z
+  .object({
+    ...warrantyAlertFields,
+    hpCmsl: warrantyHpCmslStoredBlockSchema.optional(),
+  })
+  .strict();
+
+export type StoredWarrantyInlineSettings = z.infer<typeof storedWarrantyInlineSettingsSchema>;
+
+function readHpCmslBlock(inlineSettings: unknown): unknown {
+  if (!inlineSettings || typeof inlineSettings !== 'object' || Array.isArray(inlineSettings)) {
+    return undefined;
+  }
+  return (inlineSettings as Record<string, unknown>).hpCmsl;
+}
+
+/**
+ * True when the caller put a `consent` KEY on the hpCmsl block at all —
+ * including `consent: null` or `consent: undefined`. Presence is what matters:
+ * the point of D3 is that a client learns its consent was refused, so the
+ * refusal must not depend on the value being well-formed.
+ */
+export function clientSuppliedWarrantyHpCmslConsent(inlineSettings: unknown): boolean {
+  const block = readHpCmslBlock(inlineSettings);
+  if (!block || typeof block !== 'object' || Array.isArray(block)) return false;
+  return 'consent' in (block as Record<string, unknown>);
+}
+
+/**
+ * "Is this author ASKING for device-side collection?" — the input to the
+ * write-time authorization gate (D4), evaluated on a payload that has not been
+ * consent-stamped yet. Deliberately does NOT require consent.
+ */
+export function warrantyHpCmslRequested(inlineSettings: unknown): boolean {
+  const parsed = warrantyHpCmslStoredBlockSchema.safeParse(readHpCmslBlock(inlineSettings));
+  return parsed.success && parsed.data.enabled === true;
+}
+
+/**
+ * "Does this STORED link actually deliver collection?" — the input to the
+ * agent-config builder and to the inheritance/assignment gates. Requires a
+ * consent recorded against the CURRENT HP_CMSL_EULA_ID, so a superseded
+ * acceptance turns collection off rather than riding on stale terms (D2).
+ *
+ * Parses the hpCmsl SUB-BLOCK, not the whole settings object: an unrelated
+ * out-of-range alert threshold must not silently disable collection.
+ * A block it cannot read at all yields `false` — fail safe.
+ */
+export function warrantyHpCmslCollectionEffective(inlineSettings: unknown): boolean {
+  const parsed = warrantyHpCmslStoredBlockSchema.safeParse(readHpCmslBlock(inlineSettings));
+  if (!parsed.success) return false;
+  return parsed.data.enabled === true && parsed.data.consent?.eulaId === HP_CMSL_EULA_ID;
+}
+
+/**
+ * The acceptance recorded on a stored blob, VERBATIM — including one that
+ * names a superseded EULA id. Two consumers need exactly that: the API carries
+ * a still-current acceptance across an unrelated threshold edit rather than
+ * churning `acceptedAt`, and the authoring UI has to be able to say "these
+ * terms changed since <user> accepted on <date>" instead of silently showing
+ * nothing. Compare `eulaId` at the call site; this reader does not judge.
+ */
+export function readRecordedWarrantyHpCmslConsent(inlineSettings: unknown): WarrantyHpCmslConsent | null {
+  const parsed = warrantyHpCmslStoredBlockSchema.safeParse(readHpCmslBlock(inlineSettings));
+  return parsed.success ? (parsed.data.consent ?? null) : null;
+}
+```
+
+Append to `packages/shared/src/validators/index.ts`, next to the other per-feature validator re-exports (after `export * from './remoteAccessInlineSettings';`):
+
+```ts
+export * from './warrantyInlineSettings';
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd packages/shared && npx vitest run src/validators/warrantyInlineSettings.test.ts`
+Expected: PASS, 1 file.
+
+Then confirm nothing else in the package regressed (the barrel now re-exports new symbols):
+Run: `cd packages/shared && npx vitest run src/validators/index` and `cd packages/shared && npx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/shared/src/constants/hpCmsl.ts packages/shared/src/constants/index.ts packages/shared/src/validators/warrantyInlineSettings.ts packages/shared/src/validators/warrantyInlineSettings.test.ts packages/shared/src/validators/index.ts
+git commit -m "feat(shared): HP CMSL EULA id + warranty inline-settings schemas with unforgeable consent (#5511 W02 D1/D2/D3)"
+```
+
+---
+
+### Task 2: Service — warranty validation and the out-of-band consent stamp
+
+**Files:**
+- Modify: `apps/api/src/services/configurationPolicy.ts` (import block `:48-57`; new symbols after the `PartnerWideWriteDeniedError`-style error declarations; warranty arm in `addFeatureLink` after `:1492-1494`; warranty arm in `updateFeatureLink` after `:1592-1594`; both signatures gain a trailing `consentActor` parameter)
+- Modify: `apps/api/src/services/aiToolsConfigPolicy.ts:71-75` (register the client schema)
+- Test: `apps/api/src/services/configurationPolicy.warranty.test.ts` (new)
+
+**Interfaces:**
+- Consumes: Task 1's `warrantyInlineSettingsSchema`, `warrantyHpCmslStoredBlockSchema`, `warrantyHpCmslCollectionEffective`, `readRecordedWarrantyHpCmslConsent`, `HP_CMSL_EULA_ID`, `WarrantyHpCmslConsent`.
+- Produces:
+  - `export class WarrantyConsentError extends Error` with `readonly code = 'warranty_hp_cmsl_consent_required'`
+  - `export type WarrantyConsentActor = { userId: string } | null | undefined`
+  - `export function resolveWarrantyInlineSettingsForWrite(incoming: unknown, stored: unknown, actor: WarrantyConsentActor): unknown`
+  - `addFeatureLink(configPolicyId, featureType, featurePolicyId?, inlineSettings?, consentActor?: WarrantyConsentActor)`
+  - `updateFeatureLink(linkId, updates, configPolicyId?, consentActor?: WarrantyConsentActor)`
+
+**Why the actor is a separate parameter and not a payload field.** `manage_policy_feature_link` is a Tier-2 AI tool that auto-executes with audit only and calls `addFeatureLink` directly (`aiToolsConfigPolicy.ts:936-942`), and `warranty` is absent from its `VALIDATED_INLINE_SETTINGS`. If consent were readable from `inlineSettings` anywhere, an assistant could fabricate an acceptance; if the HTTP route stamped it and then handed the stamped object to a service that accepts consent, the same object shape would be reachable from the AI tool. Taking the accepting user out of band makes a valid stored blob producible *only* by a caller that has an authenticated user, and the schema in Task 1 makes it unrepresentable in a payload. A caller with no actor may still edit thresholds on an already-consented link — that is not an escalation, collection was already on — but may never turn collection on.
+
+**This makes the AI path inert, not gated.** An assistant can still persist `hpCmsl.enabled: true` with no consent, which delivers `false` to the agent but renders as ON in the UI. Task 6 closes that door properly by escalating the write to Tier 3. Both layers stay: this one is the fail-safe that holds even if the guardrail predicate is later loosened.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/src/services/configurationPolicy.warranty.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./automationReferenceAuthorization', () => ({
+  AutomationReferenceAuthorizationError: class extends Error {},
+  resolveOwnedAutomationReferences: vi.fn(),
+}));
+vi.mock('./automationRuntime', () => ({
+  normalizeAutomationActions: vi.fn((a: unknown) => a),
+  resolveAutomationReferencesForOwner: vi.fn(),
+}));
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    transaction: vi.fn(),
+  },
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+import { HP_CMSL_EULA_ID } from '@breeze/shared/validators';
+import {
+  WarrantyConsentError,
+  addFeatureLink,
+  resolveWarrantyInlineSettingsForWrite,
+} from './configurationPolicy';
+import { db } from '../db';
+
+const ACTOR = { userId: 'user-1' };
+const CURRENT_CONSENT = {
+  acceptedByUserId: 'user-9',
+  acceptedAt: '2026-01-01T00:00:00.000Z',
+  eulaId: HP_CMSL_EULA_ID,
+};
+
+describe('resolveWarrantyInlineSettingsForWrite', () => {
+  it('passes the legacy alerting-only shape through untouched', () => {
+    const out = resolveWarrantyInlineSettingsForWrite(
+      { enabled: true, warnDays: 90, criticalDays: 30 },
+      null,
+      ACTOR,
+    );
+    expect(out).toEqual({ enabled: true, warnDays: 90, criticalDays: 30 });
+  });
+
+  it('throws on a client-supplied consent rather than stripping it (D3)', () => {
+    expect(() =>
+      resolveWarrantyInlineSettingsForWrite(
+        { hpCmsl: { enabled: true, consent: CURRENT_CONSENT } },
+        null,
+        ACTOR,
+      ),
+    ).toThrow();
+  });
+
+  it('stamps consent server-side when collection is switched on', () => {
+    const before = Date.now();
+    const out = resolveWarrantyInlineSettingsForWrite({ hpCmsl: { enabled: true } }, null, ACTOR) as any;
+    expect(out.hpCmsl.enabled).toBe(true);
+    expect(out.hpCmsl.consent.acceptedByUserId).toBe('user-1');
+    expect(out.hpCmsl.consent.eulaId).toBe(HP_CMSL_EULA_ID);
+    expect(Date.parse(out.hpCmsl.consent.acceptedAt)).toBeGreaterThanOrEqual(before);
+  });
+
+  it('refuses to enable collection for a caller with no authenticated actor (the AI-tool door)', () => {
+    expect(() =>
+      resolveWarrantyInlineSettingsForWrite({ hpCmsl: { enabled: true } }, null, null),
+    ).toThrow(WarrantyConsentError);
+  });
+
+  it('carries a still-current acceptance across an unrelated threshold edit without re-attributing it', () => {
+    const stored = { warnDays: 90, hpCmsl: { enabled: true, consent: CURRENT_CONSENT } };
+    const out = resolveWarrantyInlineSettingsForWrite(
+      { warnDays: 45, hpCmsl: { enabled: true } },
+      stored,
+      ACTOR,
+    ) as any;
+    expect(out.warnDays).toBe(45);
+    expect(out.hpCmsl.consent).toEqual(CURRENT_CONSENT);
+  });
+
+  it('lets an actor-less caller edit thresholds on an already-consented link', () => {
+    const stored = { hpCmsl: { enabled: true, consent: CURRENT_CONSENT } };
+    const out = resolveWarrantyInlineSettingsForWrite(
+      { warnDays: 45, hpCmsl: { enabled: true } },
+      stored,
+      null,
+    ) as any;
+    expect(out.hpCmsl.consent).toEqual(CURRENT_CONSENT);
+  });
+
+  it('re-stamps when the recorded acceptance names a superseded EULA id (D2)', () => {
+    const stored = { hpCmsl: { enabled: true, consent: { ...CURRENT_CONSENT, eulaId: 'hp-cmsl-eula-2020-01-01' } } };
+    const out = resolveWarrantyInlineSettingsForWrite({ hpCmsl: { enabled: true } }, stored, ACTOR) as any;
+    expect(out.hpCmsl.consent.acceptedByUserId).toBe('user-1');
+    expect(out.hpCmsl.consent.eulaId).toBe(HP_CMSL_EULA_ID);
+  });
+
+  it('drops the recorded consent when collection is switched off, so re-enabling re-consents', () => {
+    const stored = { hpCmsl: { enabled: true, consent: CURRENT_CONSENT } };
+    const out = resolveWarrantyInlineSettingsForWrite({ hpCmsl: { enabled: false } }, stored, ACTOR) as any;
+    expect(out.hpCmsl).toEqual({ enabled: false });
+  });
+
+  it('leaves undefined/null settings alone (a featurePolicyId-only update)', () => {
+    expect(resolveWarrantyInlineSettingsForWrite(undefined, null, ACTOR)).toBeUndefined();
+    expect(resolveWarrantyInlineSettingsForWrite(null, null, ACTOR)).toBeNull();
+  });
+});
+
+describe('addFeatureLink warranty backstop', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('refuses an actor-less enable before opening a transaction', async () => {
+    await expect(
+      addFeatureLink('policy-1', 'warranty', null, { hpCmsl: { enabled: true } }),
+    ).rejects.toThrow(WarrantyConsentError);
+    expect(vi.mocked(db.transaction)).not.toHaveBeenCalled();
+  });
+
+  it('refuses a forged consent before opening a transaction', async () => {
+    await expect(
+      addFeatureLink('policy-1', 'warranty', null, { hpCmsl: { enabled: true, consent: CURRENT_CONSENT } }, { userId: 'user-1' }),
+    ).rejects.toThrow();
+    expect(vi.mocked(db.transaction)).not.toHaveBeenCalled();
+  });
+});
+```
+
+**Note on coverage split:** `updateFeatureLink` reads the stored row inside its own transaction, so its behaviour is exercised through `resolveWarrantyInlineSettingsForWrite` above (which is where all of the logic lives) plus the route-level tests in Task 3. Do not add a bespoke `db.transaction` double for it — the existing suite's chain helpers do not model `tx.select().from().where().limit()` followed by `tx.update()`, and a half-modelled double proves less than the pure-function cases do.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api && npx vitest run src/services/configurationPolicy.warranty.test.ts`
+Expected: FAIL — `resolveWarrantyInlineSettingsForWrite` and `WarrantyConsentError` are not exported from `./configurationPolicy`.
+
+- [ ] **Step 3: Add the imports and the new symbols**
+
+In `apps/api/src/services/configurationPolicy.ts`, extend the `@breeze/shared/validators` import block (`:48-57`) to:
+
+```ts
+import {
+  alertRuleInlineSettingsSchema,
+  backupExcludePatternsSchema,
+  configFeatureInlineSettingsSchema,
+  deviceLifecycleInlineSettingsSchema,
+  eventLogInlineSettingsSchema,
+  monitoringInlineSettingsSchema,
+  onedriveHelperInlineSettingsSchema,
+  remoteAccessInlineSettingsSchema as remoteAccessCapabilitySettingsSchema,
+  warrantyInlineSettingsSchema,
+  warrantyHpCmslCollectionEffective,
+  readRecordedWarrantyHpCmslConsent,
+  HP_CMSL_EULA_ID,
+  type WarrantyHpCmslConsent,
+} from '@breeze/shared/validators';
+```
+
+Add, immediately above `export async function addFeatureLink(` (`:1474`):
+
+```ts
+/**
+ * Raised when a caller asks to enable HP CMSL warranty collection but cannot
+ * record an acceptance of HP's licence (#5511 W02, contract D3).
+ *
+ * Its own class, mirroring AutomationReferenceAuthorizationError, so the HTTP
+ * routes and the AI tool can map it to a 400 with a useful message instead of
+ * letting a bare Error reach the global onError handler as a 500.
+ */
+export class WarrantyConsentError extends Error {
+  readonly code = 'warranty_hp_cmsl_consent_required' as const;
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'WarrantyConsentError';
+  }
+}
+
+/**
+ * The authenticated user on whose behalf a warranty consent may be stamped.
+ * Supplied OUT OF BAND by the HTTP routes — never read from the payload, and
+ * never available to `manage_policy_feature_link`, which is why an assistant
+ * cannot switch collection on. `null`/`undefined` means "this caller cannot
+ * accept a licence".
+ */
+export type WarrantyConsentActor = { userId: string } | null | undefined;
+
+/**
+ * Validates a warranty inline-settings payload and returns the value to store.
+ *
+ * Contract, in order:
+ *  1. `warrantyInlineSettingsSchema` has no `consent` key and is `.strict()`,
+ *     so a client-supplied acceptance THROWS here rather than being stripped
+ *     (D3). The HTTP routes catch this earlier and return a coded 400; this
+ *     parse is the backstop for every other caller.
+ *  2. Not enabling collection (absent block, or `enabled: false`) stores the
+ *     parsed value as-is. Any previously recorded acceptance goes with the old
+ *     block: re-enabling later re-consents rather than silently reusing an
+ *     acceptance by a user who may have left the partner.
+ *  3. Enabling with a still-current acceptance already on the row carries that
+ *     acceptance forward verbatim, so an unrelated threshold edit does not
+ *     churn `acceptedAt` or re-attribute who accepted.
+ *  4. Enabling with no acceptance — or one naming a superseded EULA id (D2) —
+ *     stamps a fresh one from `actor` and the SERVER clock, or throws when
+ *     there is no actor.
+ *
+ * Exported for direct unit testing: this function is the whole of the consent
+ * rule, and it is the thing worth pinning.
+ */
+export function resolveWarrantyInlineSettingsForWrite(
+  incoming: unknown,
+  stored: unknown,
+  actor: WarrantyConsentActor,
+): unknown {
+  if (incoming === undefined || incoming === null) return incoming;
+
+  const parsed = warrantyInlineSettingsSchema.parse(incoming);
+  if (parsed.hpCmsl?.enabled !== true) return parsed;
+
+  if (warrantyHpCmslCollectionEffective(stored)) {
+    const carried = readRecordedWarrantyHpCmslConsent(stored) as WarrantyHpCmslConsent;
+    return { ...parsed, hpCmsl: { enabled: true, consent: carried } };
+  }
+
+  if (!actor?.userId) {
+    throw new WarrantyConsentError(
+      'Enabling HP CMSL warranty collection records an acceptance of HP\'s licence, which requires an authenticated user. This caller cannot record one.',
+    );
+  }
+
+  return {
+    ...parsed,
+    hpCmsl: {
+      enabled: true,
+      consent: {
+        acceptedByUserId: actor.userId,
+        acceptedAt: new Date().toISOString(),
+        eulaId: HP_CMSL_EULA_ID,
+      },
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Wire it into both write paths**
+
+In `addFeatureLink`, change the signature and add the warranty arm after the `device_lifecycle` arm (`:1492-1494`):
+
+```ts
+export async function addFeatureLink(
+  configPolicyId: string,
+  featureType: ConfigFeatureType,
+  featurePolicyId?: string | null,
+  inlineSettings?: unknown,
+  consentActor?: WarrantyConsentActor
+) {
+```
+
+```ts
+  // #5511 W02: warranty gains an hpCmsl block whose consent only the server may
+  // write. There is no stored row yet on this path, so `stored` is null and an
+  // enable always stamps fresh.
+  if (featureType === 'warranty' && inlineSettings !== undefined && inlineSettings !== null) {
+    inlineSettings = resolveWarrantyInlineSettingsForWrite(inlineSettings, null, consentActor);
+  }
+```
+
+In `updateFeatureLink`, change the signature:
+
+```ts
+export async function updateFeatureLink(
+  linkId: string,
+  updates: { featurePolicyId?: string | null; inlineSettings?: unknown },
+  configPolicyId?: string,
+  consentActor?: WarrantyConsentActor
+) {
+```
+
+and add the warranty arm inside the transaction, immediately after the `device_lifecycle` arm (`:1592-1594`) — it must come after `existing` is read, because the carry-forward rule needs the stored blob:
+
+```ts
+    // #5511 W02: same consent rule as addFeatureLink, but with the row's
+    // current settings in hand so a still-current acceptance survives an
+    // unrelated edit. REPLACE semantics (not merge, contract D5): settings sent
+    // without an hpCmsl block drop it, which revokes collection.
+    if (existing.featureType === 'warranty' && updates.inlineSettings !== undefined && updates.inlineSettings !== null) {
+      updates.inlineSettings = resolveWarrantyInlineSettingsForWrite(
+        updates.inlineSettings,
+        existing.inlineSettings,
+        consentActor,
+      );
+    }
+```
+
+- [ ] **Step 5: Register the schema on the AI-tool surface**
+
+In `apps/api/src/services/aiToolsConfigPolicy.ts`, extend `VALIDATED_INLINE_SETTINGS` (`:71-75`) so an assistant gets a field-level message instead of a bare service throw. Import `warrantyInlineSettingsSchema` from `@breeze/shared/validators` alongside the existing schema imports.
+
+```ts
+const VALIDATED_INLINE_SETTINGS: Record<string, { schema: { safeParse: (raw: unknown) => any }; normalize: boolean }> = {
+  onedrive_helper: { schema: onedriveHelperInlineSettingsSchema, normalize: true },
+  alert_rule: { schema: alertRuleInlineSettingsSchema, normalize: true },
+  monitoring: { schema: monitoringInlineSettingsSchema, normalize: false },
+  // #5511 W02: the CLIENT schema, so an assistant that invents an hpCmsl
+  // consent object is told which field is wrong. It still cannot ENABLE
+  // collection — addFeatureLink refuses without an authenticated actor, and
+  // this Tier-2 tool has none.
+  warranty: { schema: warrantyInlineSettingsSchema, normalize: false },
+};
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd apps/api && npx vitest run src/services/configurationPolicy.warranty.test.ts`
+Expected: PASS.
+
+Regression check on the suites that already exercise these two functions and the AI tool (all must stay green — the reserved-key scan still runs first, and both new parameters are optional):
+Run: `cd apps/api && npx vitest run src/services/configurationPolicy.test.ts src/services/configurationPolicy.backupExcludes.test.ts src/services/aiToolsConfigPolicy.test.ts src/services/aiToolsConfigPolicy.siteScope.test.ts`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/services/configurationPolicy.ts apps/api/src/services/configurationPolicy.warranty.test.ts apps/api/src/services/aiToolsConfigPolicy.ts
+git commit -m "feat(api): warranty inline-settings validation with a server-stamped, out-of-band HP CMSL consent (#5511 W02 D3)"
+```
+
+---
+
+### Task 3: HTTP routes — coded consent refusal, warranty schema parse, actor hand-off
+
+**Files:**
+- Modify: `apps/api/src/routes/configurationPolicies/featureLinks.ts` (shared-validator import `:6-13`; service import `:19-33`; POST warranty block after the `device_lifecycle` block at `:206-214`; POST `addFeatureLink` call `:277-282` and its catch `:283-289`; PATCH warranty block after the `device_lifecycle` arm at `:400-409`; PATCH `updateFeatureLink` call `:461` and its catch `:462-468`)
+- Test: `apps/api/src/routes/configurationPolicies/featureLinks.test.ts` (add one `describe`)
+
+**Interfaces:**
+- Consumes: Task 1's `warrantyInlineSettingsSchema` and `clientSuppliedWarrantyHpCmslConsent`; Task 2's `WarrantyConsentError` and the fifth/fourth `consentActor` parameters.
+- Produces: the coded body `{ error: string; code: 'WARRANTY_CONSENT_NOT_CLIENT_SETTABLE' }` at HTTP 400, which Task 12's UI must never trigger.
+
+**Ordering matters.** The consent refusal runs before the schema parse. Both are 400s, but `.strict()` would report a generic `Unrecognized key: "consent"` with no `code`, and D3 exists so a client can *tell* that its consent was refused. Same shape as the `alert_rule` ordering already in this file (`:240-247`), where the specific offline-duration message deliberately wins over the enum/range message.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `apps/api/src/routes/configurationPolicies/featureLinks.test.ts`, inside the top-level `describe('featureLinks routes', ...)`:
+
+```ts
+  // ============================================================
+  // #5511 W02 — warranty hpCmsl block, server-stamped consent (D3)
+  // ============================================================
+
+  describe('warranty inlineSettings validation and consent', () => {
+    const CONSENT = {
+      acceptedByUserId: 'attacker',
+      acceptedAt: '2020-01-01T00:00:00.000Z',
+      eulaId: 'hp-cmsl-eula-2026-04-01',
+    };
+
+    beforeEach(() => {
+      getConfigPolicyMock.mockResolvedValue({
+        ...STUB_POLICY,
+        featureLinks: [{ id: LINK_ID, featureType: 'warranty', inlineSettings: {} }],
+      });
+      addFeatureLinkMock.mockResolvedValue({ id: LINK_ID });
+      updateFeatureLinkMock.mockResolvedValue({ id: LINK_ID });
+    });
+
+    it('POST refuses a client-supplied consent with a coded 400 and never calls the service', async () => {
+      const res = await app.request(`/${POLICY_ID}/features`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          featureType: 'warranty',
+          inlineSettings: { hpCmsl: { enabled: true, consent: CONSENT } },
+        }),
+      });
+
+      expect(res.status).toBe(400);
+      expect(await res.json()).toMatchObject({ code: 'WARRANTY_CONSENT_NOT_CLIENT_SETTABLE' });
+      expect(addFeatureLinkMock).not.toHaveBeenCalled();
+    });
+
+    it('PATCH refuses a client-supplied consent with the same coded 400', async () => {
+      const res = await app.request(`/${POLICY_ID}/features/${LINK_ID}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ inlineSettings: { hpCmsl: { enabled: true, consent: CONSENT } } }),
+      });
+
+      expect(res.status).toBe(400);
+      expect(await res.json()).toMatchObject({ code: 'WARRANTY_CONSENT_NOT_CLIENT_SETTABLE' });
+      expect(updateFeatureLinkMock).not.toHaveBeenCalled();
+    });
+
+    it('POST rejects an unknown warranty key instead of persisting it', async () => {
+      const res = await app.request(`/${POLICY_ID}/features`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ featureType: 'warranty', inlineSettings: { hpCsml: { enabled: true } } }),
+      });
+
+      expect(res.status).toBe(400);
+      expect(addFeatureLinkMock).not.toHaveBeenCalled();
+    });
+
+    it('POST passes the authenticated user to the service as the consent actor', async () => {
+      const res = await app.request(`/${POLICY_ID}/features`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          featureType: 'warranty',
+          inlineSettings: { enabled: true, warnDays: 90, criticalDays: 30, hpCmsl: { enabled: true } },
+        }),
+      });
+
+      expect(res.status).toBe(201);
+      expect(addFeatureLinkMock).toHaveBeenCalledWith(
+        POLICY_ID,
+        'warranty',
+        undefined,
+        { enabled: true, warnDays: 90, criticalDays: 30, hpCmsl: { enabled: true } },
+        { userId: 'user-1' },
+      );
+    });
+
+    it('PATCH passes the authenticated user to the service as the consent actor', async () => {
+      const res = await app.request(`/${POLICY_ID}/features/${LINK_ID}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ inlineSettings: { hpCmsl: { enabled: false } } }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(updateFeatureLinkMock).toHaveBeenCalledWith(
+        LINK_ID,
+        expect.objectContaining({ inlineSettings: { hpCmsl: { enabled: false } } }),
+        POLICY_ID,
+        { userId: 'user-1' },
+      );
+    });
+
+    it('maps a WarrantyConsentError from the service to a 400, not a 500', async () => {
+      const { WarrantyConsentError } = await import('../../services/configurationPolicy');
+      addFeatureLinkMock.mockRejectedValueOnce(new WarrantyConsentError('nope'));
+
+      const res = await app.request(`/${POLICY_ID}/features`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ featureType: 'warranty', inlineSettings: { hpCmsl: { enabled: true } } }),
+      });
+
+      expect(res.status).toBe(400);
+    });
+  });
+```
+
+**Note:** these cases run with the file's default `mfaState.satisfied = true`. Task 5 adds the `devices.execute` gate ahead of the service call, so once that lands this `describe` also needs `permissions` seeded — Task 5's step 5 says exactly what to add and this `describe` is one of the places it applies.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api && npx vitest run src/routes/configurationPolicies/featureLinks.test.ts`
+Expected: FAIL — the coded cases return 201/200 (the payload sails through today), and the actor assertions fail with a 4-argument call.
+
+- [ ] **Step 3: Extend the imports**
+
+`apps/api/src/routes/configurationPolicies/featureLinks.ts` — shared validators (`:6-13`):
+
+```ts
+import {
+  alertRuleInlineSettingsSchema,
+  backupInlineSettingsSchema,
+  backupProfileLinkedInlineSettingsSchema,
+  clientSuppliedWarrantyHpCmslConsent,
+  monitoringInlineSettingsSchema,
+  onedriveHelperInlineSettingsSchema,
+  patchInlineSettingsSchema,
+  warrantyInlineSettingsSchema,
+} from '@breeze/shared/validators';
+```
+
+and add `WarrantyConsentError,` to the `'../../services/configurationPolicy'` import list (`:19-33`).
+
+- [ ] **Step 4: Add the POST branch and hand over the actor**
+
+Insert after the `device_lifecycle` block (which ends at `:214`):
+
+```ts
+    // #5511 W02 (contract D3): the consent refusal runs FIRST and on its own so
+    // a client that supplied one gets a coded, actionable 400. Letting the
+    // strict schema report it would produce a bare "Unrecognized key" with no
+    // `code`, and silently stripping it would let a UI believe an acceptance
+    // had been recorded when none was.
+    if (data.featureType === 'warranty' && data.inlineSettings) {
+      if (clientSuppliedWarrantyHpCmslConsent(data.inlineSettings)) {
+        return c.json(
+          {
+            error: 'HP CMSL consent is recorded by the server from your authenticated session. Remove hpCmsl.consent from the request and send it again.',
+            code: 'WARRANTY_CONSENT_NOT_CLIENT_SETTABLE',
+          },
+          400
+        );
+      }
+      const parsed = warrantyInlineSettingsSchema.safeParse(data.inlineSettings);
+      if (!parsed.success) {
+        return c.json(
+          zodValidationErrorBody('Invalid warranty settings', parsed.error),
+          400
+        );
+      }
+      data.inlineSettings = parsed.data;
+    }
+```
+
+Change the `addFeatureLink` call (`:277-282`) to pass the actor, and extend its catch (`:283-289`):
+
+```ts
+    let link;
+    try {
+      link = await addFeatureLink(
+        id,
+        data.featureType,
+        data.featurePolicyId,
+        data.inlineSettings,
+        { userId: auth.user.id }
+      );
+    } catch (error) {
+      if (error instanceof AutomationReferenceAuthorizationError) {
+        return c.json({ error: 'Unknown or unauthorized automation reference' }, 400);
+      }
+      if (error instanceof WarrantyConsentError) {
+        return c.json({ error: error.message, code: 'WARRANTY_CONSENT_NOT_CLIENT_SETTABLE' }, 400);
+      }
+      throw error;
+    }
+```
+
+- [ ] **Step 5: Add the PATCH branch and hand over the actor**
+
+Insert inside the `if (data.inlineSettings) {` block, after the `device_lifecycle` arm (`:400-409`):
+
+```ts
+      if (existingLink.featureType === 'warranty') {
+        // Same ordering and reasoning as the POST route above (#5511 W02, D3).
+        if (clientSuppliedWarrantyHpCmslConsent(data.inlineSettings)) {
+          return c.json(
+            {
+              error: 'HP CMSL consent is recorded by the server from your authenticated session. Remove hpCmsl.consent from the request and send it again.',
+              code: 'WARRANTY_CONSENT_NOT_CLIENT_SETTABLE',
+            },
+            400
+          );
+        }
+        const parsed = warrantyInlineSettingsSchema.safeParse(data.inlineSettings);
+        if (!parsed.success) {
+          return c.json(
+            zodValidationErrorBody('Invalid warranty settings', parsed.error),
+            400
+          );
+        }
+        data.inlineSettings = parsed.data;
+      }
+```
+
+Change the `updateFeatureLink` call and its catch (`:459-468`):
+
+```ts
+    let updated;
+    try {
+      updated = await updateFeatureLink(linkId, data, id, { userId: auth.user.id });
+    } catch (error) {
+      if (error instanceof AutomationReferenceAuthorizationError) {
+        return c.json({ error: 'Unknown or unauthorized automation reference' }, 400);
+      }
+      if (error instanceof WarrantyConsentError) {
+        return c.json({ error: error.message, code: 'WARRANTY_CONSENT_NOT_CLIENT_SETTABLE' }, 400);
+      }
+      throw error;
+    }
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd apps/api && npx vitest run src/routes/configurationPolicies/featureLinks.test.ts src/routes/configurationPolicies/featureLinks.remoteAccess.test.ts src/routes/configurationPolicies/featureLinks.siteScope.test.ts`
+Expected: PASS, 3 files. (Listing the siblings explicitly — a bare `src/routes/configurationPolicies/featureLinks` substring filter would also pull them in, but naming them is what makes the run auditable.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/routes/configurationPolicies/featureLinks.ts apps/api/src/routes/configurationPolicies/featureLinks.test.ts
+git commit -m "feat(api): refuse client-supplied HP CMSL consent with a coded 400 and stamp it from the session (#5511 W02 D3)"
+```
+
+---
+
+### Task 4: D12 — the missing inline-only guard arm for `warranty`
+
+**Files:**
+- Modify: `apps/api/src/services/configurationPolicy.ts:2656-2662`
+- Test: `apps/api/src/services/configurationPolicy.warrantyGuard.test.ts` (new)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `validateFeaturePolicyExists('warranty', <any id>, owner)` now returns `{ valid: false, error: 'warranty feature type does not support featurePolicyId; use inlineSettings instead' }`.
+
+**What is broken today:** `warranty` is inline-only (no policy table — `configurationPolicy.ts:1062-1068`, `:1416-1422`) but is absent from the guard list, so a `featurePolicyId` falls through to the generic whole-policy-linking lookup at `:2699-2704`. That lookup succeeds for any id naming a configuration policy in the same org, the write proceeds, and the `config_policy_feature_links_reference_integrity` trigger rejects it — a 500 where the caller should have got a 400 naming the mistake. The code's own comment at `:2663-2669` describes exactly this. The UI never sends one (`WarrantyTab.tsx:51,65` hardcode `featurePolicyId: null`), so this is API surface only; verified by reading, not reproduced at runtime.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/src/services/configurationPolicy.warrantyGuard.test.ts` (modelled on `configurationPolicy.deviceLifecycle.test.ts`, including the deliberately-permissive db double):
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+
+// `warranty` is inline-only, so a correct implementation never reaches the
+// database at all. The db double deliberately returns a MATCHING
+// configuration-policy row for the whole-policy-linking lookup: that is the
+// exact shape that makes a stray featurePolicyId pass validation and then blow
+// up as a 500 on the `config_policy_feature_links_reference_integrity`
+// trigger. With the guard removed this mock lets the fall-through succeed
+// rather than crash, so the test fails on the assertion instead of on an
+// incidental TypeError.
+vi.mock('../db', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => [{ id: 'cfg-policy-1' }],
+        }),
+      }),
+    }),
+  },
+  withDbAccessContext: vi.fn(),
+  withSystemDbAccessContext: vi.fn(),
+  runOutsideDbContext: vi.fn(),
+}));
+
+import { validateFeaturePolicyExists } from './configurationPolicy';
+
+describe('warranty feature type is inline-only (#5511 W02, contract D12)', () => {
+  it('rejects a featurePolicyId with a 400-shaped result instead of letting the DB trigger 500', async () => {
+    const res = await validateFeaturePolicyExists('warranty', 'cfg-policy-1', {
+      orgId: 'org-1',
+      partnerId: null,
+    });
+
+    expect(res.valid).toBe(false);
+    expect(res.error).toMatch(/does not support featurePolicyId/);
+  });
+
+  it('rejects it for a partner-wide policy too', async () => {
+    const res = await validateFeaturePolicyExists('warranty', 'cfg-policy-1', {
+      orgId: null,
+      partnerId: 'partner-1',
+    });
+
+    expect(res.valid).toBe(false);
+    expect(res.error).toMatch(/does not support featurePolicyId/);
+  });
+
+  it('accepts inline-only (no featurePolicyId)', async () => {
+    const res = await validateFeaturePolicyExists('warranty', null, {
+      orgId: 'org-1',
+      partnerId: null,
+    });
+
+    expect(res.valid).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api && npx vitest run src/services/configurationPolicy.warrantyGuard.test.ts`
+Expected: FAIL on the first two cases — `res.valid` is `true`, because the fall-through found the mocked config-policy row. (The third case passes already; that is the control proving the mock is not simply denying everything.)
+
+- [ ] **Step 3: Add `warranty` to the guard list**
+
+`apps/api/src/services/configurationPolicy.ts:2656-2662` becomes:
+
+```ts
+  if (
+    featureType === 'monitoring' ||
+    featureType === 'event_log' ||
+    featureType === 'onedrive_helper' ||
+    featureType === 'vulnerability' ||
+    featureType === 'device_lifecycle' ||
+    featureType === 'warranty'
+  ) {
+```
+
+Leave the comment block at `:2663-2669` untouched — it already explains why the omission mattered.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/api && npx vitest run src/services/configurationPolicy.warrantyGuard.test.ts src/services/configurationPolicy.deviceLifecycle.test.ts src/services/configurationPolicy.onedrive.test.ts`
+Expected: PASS, 3 files.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/configurationPolicy.ts apps/api/src/services/configurationPolicy.warrantyGuard.test.ts
+git commit -m "fix(api): warranty is inline-only — 400 on a stray featurePolicyId instead of a trigger 500 (#5511 W02 D12)"
+```
+
+---
+
+### Task 5: The authorization gate — `devices.execute` + MFA on every transition that exposes a device to collection
+
+**Files:**
+- Create: `apps/api/src/routes/configurationPolicies/hpCmslGate.ts`
+- Create: `apps/api/src/routes/configurationPolicies/hpCmslGate.test.ts`
+- Modify: `apps/api/src/services/configurationPolicy.ts` (new `parentPolicyEnablesHpCmslCollection`, next to `getParentLinkFeatureTypes` at `:503-509`)
+- Modify: `apps/api/src/routes/configurationPolicies/featureLinks.ts` (POST after `:145-147`; PATCH after `:340-341`; DELETE at `:519-526`)
+- Modify: `apps/api/src/routes/configurationPolicies/assignments.ts` (POST `/:id/assignments`, after the site-authorization check at `:121-124`)
+- Modify: `apps/api/src/routes/configurationPolicies/crud.ts` (POST `/`, inside the `if (data.parentPolicyId)` block at `:78-83`)
+- Modify: `apps/api/src/routes/configurationPolicies/featureLinks.test.ts`
+- Create: `apps/api/src/routes/configurationPolicies/assignments.hpCmsl.test.ts`
+
+**Interfaces:**
+- Consumes: Task 1's `warrantyHpCmslRequested` and `warrantyHpCmslCollectionEffective`.
+- Produces:
+  - `export type HpCmslGateResult = { allowed: true } | { allowed: false; body: { error: string; code: string } }`
+  - `export function checkHpCmslWriteAllowed(auth: AuthContext, perms: UserPermissions | undefined): HpCmslGateResult`
+  - `export function warrantyLinkEnablesCollection(links: ReadonlyArray<{ featureType: string; inlineSettings?: unknown }> | undefined | null): boolean`
+  - `export async function parentPolicyEnablesHpCmslCollection(parentId: string): Promise<boolean>` (from `configurationPolicy.ts`)
+
+**The five transitions, and why each one is here.** D4 says the gate covers "create, update, AND any assignment/inheritance transition that newly exposes a device to an `hpCmsl.enabled` link". Enumerated against this codebase, that is exactly five doors, and they split into two kinds:
+
+| # | Door | Predicate | Kind |
+|---|---|---|---|
+| 1 | `POST /:id/features` with `warranty` | `warrantyHpCmslRequested(data.inlineSettings)` | request (pre-stamp) |
+| 2 | `PATCH /:id/features/:linkId` on a `warranty` link | `warrantyHpCmslRequested(data.inlineSettings)` | request (pre-stamp) |
+| 3 | `DELETE /:id/features/:linkId` on a `warranty` link whose parent policy carries a collecting warranty link | `warrantyHpCmslCollectionEffective(parent link)` | stored |
+| 4 | `POST /:id/assignments` for a policy whose effective warranty link collects | `warrantyHpCmslCollectionEffective(own link, else parent's)` | stored |
+| 5 | `POST /` with `parentPolicyId` naming a policy whose warranty link collects | `warrantyHpCmslCollectionEffective(parent link)` | stored |
+
+Doors 1-2 use the **request** predicate because consent has not been stamped yet at gate time — using the consent-qualified one there makes the gate a permanent no-op, which is the single easiest way to ship this feature ungated. Doors 3-5 read **stored** rows, where a consent is always present on anything written through door 1 or 2, and where a superseded EULA id means collection is already off — so exposing a device to it is not an escalation and needs no gate.
+
+Door 3 is the direct analogue of the maintenance `revertRestoresParentWindow` rule already at `:519-526`, including its **fail-closed** `parentUnresolved` clause: `parentPolicyId` set but `parentPolicy` null means the parent was invisible to this read, which is an anomaly, and treating "can't tell" as "no parent" would silently drop the requirement.
+
+Door 5 is bounded by the schema: `grep -n parentPolicyId apps/api/src/routes/configurationPolicies/crud.ts` shows `parentPolicyId` is accepted on CREATE only and never on PATCH, so there is no re-parenting door to cover.
+
+**Not gated, on purpose:** `DELETE /:id/assignments/:aid` and any write whose result is `hpCmsl.enabled: false`. Both move in the revoking direction — the fail-safe one — and are audited by the existing `writeRouteAudit` calls. This mirrors the reasoning already written into `MFA_GATED_FEATURE_TYPES`' doc comment: "REMOVAL IS MOSTLY NOT GATED".
+
+**There is a sixth door, and it is not an HTTP route.** `manage_policy_feature_link` reaches `addFeatureLink` / `updateFeatureLink` directly, at Tier 2, without traversing any handler in this task. It is closed in **Task 6**, at the guardrails layer, because that is the only place an AI tool call is classified. Do not try to solve it here — there is no `auth`/`permissions` context on that path to gate against.
+
+- [ ] **Step 1: Write the failing test for the gate helper**
+
+Create `apps/api/src/routes/configurationPolicies/hpCmslGate.test.ts`:
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+
+const { mfaState } = vi.hoisted(() => ({ mfaState: { satisfied: true } }));
+
+vi.mock('../../middleware/auth', () => ({
+  hasSatisfiedMfa: vi.fn(() => mfaState.satisfied),
+}));
+
+import { checkHpCmslWriteAllowed, warrantyLinkEnablesCollection } from './hpCmslGate';
+import { HP_CMSL_EULA_ID } from '@breeze/shared/validators';
+
+const CONSENT = {
+  acceptedByUserId: 'user-1',
+  acceptedAt: '2026-09-10T00:00:00.000Z',
+  eulaId: HP_CMSL_EULA_ID,
+};
+
+const auth = { token: { mfa: true } } as any;
+const perms = (grants: Array<{ resource: string; action: string }>) =>
+  ({ permissions: grants } as any);
+
+const EXECUTE = [{ resource: 'devices', action: 'execute' }];
+const WRITE_ONLY = [{ resource: 'devices', action: 'write' }];
+
+describe('checkHpCmslWriteAllowed', () => {
+  it('allows a caller with devices.execute and satisfied MFA', () => {
+    mfaState.satisfied = true;
+    expect(checkHpCmslWriteAllowed(auth, perms(EXECUTE))).toEqual({ allowed: true });
+  });
+
+  it('denies devices.write-only with a coded body, not an MFA message', () => {
+    mfaState.satisfied = true;
+    const res = checkHpCmslWriteAllowed(auth, perms(WRITE_ONLY));
+    expect(res.allowed).toBe(false);
+    expect(res).toMatchObject({ body: { code: 'HP_CMSL_EXECUTE_REQUIRED' } });
+  });
+
+  it('denies an execute-capable caller who has not satisfied MFA, with the MFA_REQUIRED code', () => {
+    mfaState.satisfied = false;
+    const res = checkHpCmslWriteAllowed(auth, perms(EXECUTE));
+    expect(res.allowed).toBe(false);
+    expect(res).toMatchObject({ body: { error: 'MFA required', code: 'MFA_REQUIRED' } });
+  });
+
+  it('fails closed when permissions were never resolved', () => {
+    mfaState.satisfied = true;
+    expect(checkHpCmslWriteAllowed(auth, undefined).allowed).toBe(false);
+  });
+});
+
+describe('warrantyLinkEnablesCollection', () => {
+  it('is true for a warranty link with a current consent', () => {
+    expect(
+      warrantyLinkEnablesCollection([
+        { featureType: 'patch', inlineSettings: {} },
+        { featureType: 'warranty', inlineSettings: { hpCmsl: { enabled: true, consent: CONSENT } } },
+      ]),
+    ).toBe(true);
+  });
+
+  it('is false with no warranty link, a disabled block, or no links at all', () => {
+    expect(warrantyLinkEnablesCollection([{ featureType: 'patch', inlineSettings: {} }])).toBe(false);
+    expect(
+      warrantyLinkEnablesCollection([{ featureType: 'warranty', inlineSettings: { hpCmsl: { enabled: false } } }]),
+    ).toBe(false);
+    expect(warrantyLinkEnablesCollection([])).toBe(false);
+    expect(warrantyLinkEnablesCollection(undefined)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api && npx vitest run src/routes/configurationPolicies/hpCmslGate.test.ts`
+Expected: FAIL — `Failed to resolve import "./hpCmslGate"`.
+
+- [ ] **Step 3: Write the gate helper**
+
+Create `apps/api/src/routes/configurationPolicies/hpCmslGate.ts`:
+
+```ts
+import type { AuthContext } from '../../middleware/auth';
+import { hasSatisfiedMfa } from '../../middleware/auth';
+import { PERMISSIONS, hasPermission, type UserPermissions } from '../../services/permissions';
+import { warrantyHpCmslCollectionEffective } from '@breeze/shared/validators';
+
+/**
+ * Authorization for the config-policy writes that switch on — or newly expose a
+ * device to — device-side HP CMSL warranty collection (#5511 W02, contract D4).
+ *
+ * Enabling collection causes HP's ~100 MB CMSL module to be installed on every
+ * HP endpoint the policy reaches. Creating a software deployment requires
+ * `devices.execute` PLUS satisfied MFA (`routes/software.ts`), so a
+ * `devices.write` route that causes the same install would be a
+ * privilege-escalation path around that gate.
+ *
+ * `warranty` is deliberately NOT added to MFA_GATED_FEATURE_TYPES: that set is
+ * keyed on feature TYPE and would force MFA on a pure alert-threshold edit,
+ * which installs nothing. This gate is keyed on the RESULT of the write, and
+ * follows the in-handler, feature-type-conditional pattern the maintenance
+ * gates in featureLinks.ts already established.
+ *
+ * Turning collection OFF is not gated. That is the fail-safe direction, and it
+ * is audited like every other feature-link write.
+ */
+export type HpCmslGateResult =
+  | { allowed: true }
+  | { allowed: false; body: { error: string; code: string } };
+
+export function checkHpCmslWriteAllowed(
+  auth: AuthContext,
+  perms: UserPermissions | undefined,
+): HpCmslGateResult {
+  // Fail closed. Every route behind requireConfigPolicyWrite has permissions
+  // resolved by requirePermission (middleware/auth.ts:874), so `undefined` here
+  // means the middleware chain changed shape — deny rather than infer consent.
+  if (
+    !perms
+    || !hasPermission(perms, PERMISSIONS.DEVICES_EXECUTE.resource, PERMISSIONS.DEVICES_EXECUTE.action)
+  ) {
+    return {
+      allowed: false,
+      body: {
+        error:
+          'Enabling HP warranty collection installs HP software on the devices this policy reaches, so it requires the devices:execute permission — the same permission a software deployment requires.',
+        code: 'HP_CMSL_EXECUTE_REQUIRED',
+      },
+    };
+  }
+
+  // Session-claim strength, matching the adjacent patch/maintenance gates. The
+  // body shape is requireMfa()'s (middleware/auth.ts:904) so callers can branch
+  // on `code` exactly as they already do for every other MFA refusal.
+  if (!hasSatisfiedMfa(auth)) {
+    return { allowed: false, body: { error: 'MFA required', code: 'MFA_REQUIRED' } };
+  }
+
+  return { allowed: true };
+}
+
+/**
+ * True when a policy's OWN feature links contain a warranty link that actually
+ * delivers collection (enabled AND consented against the current EULA id).
+ *
+ * Takes the links array `getConfigPolicy` already returns — for the policy
+ * itself or for its `parentPolicy` — so the gates need no extra query.
+ */
+export function warrantyLinkEnablesCollection(
+  links: ReadonlyArray<{ featureType: string; inlineSettings?: unknown }> | undefined | null,
+): boolean {
+  if (!links) return false;
+  const warranty = links.find((l) => l.featureType === 'warranty');
+  return warrantyHpCmslCollectionEffective(warranty?.inlineSettings);
+}
+```
+
+- [ ] **Step 4: Run the helper test to verify it passes**
+
+Run: `cd apps/api && npx vitest run src/routes/configurationPolicies/hpCmslGate.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Write the failing route tests**
+
+In `apps/api/src/routes/configurationPolicies/featureLinks.test.ts`, first make permissions controllable. Extend the hoisted state and `buildApp`:
+
+```ts
+const { mfaState, permState } = vi.hoisted(() => ({
+  mfaState: { satisfied: true },
+  // Default to the strongest grant so every pre-existing case in this file
+  // keeps its current meaning; the hpCmsl cases narrow it per test.
+  permState: { permissions: { permissions: [{ resource: '*', action: '*' }] } as any },
+}));
+```
+
+```ts
+function buildApp() {
+  const app = new Hono();
+  app.use('*', async (c, next) => {
+    c.set('auth', makeAuth());
+    c.set('permissions', permState.permissions);
+    await next();
+  });
+  app.route('/', featureLinkRoutes);
+  return app;
+}
+```
+
+and reset it in the top-level `beforeEach` alongside `mfaState.satisfied = true`:
+
+```ts
+    permState.permissions = { permissions: [{ resource: '*', action: '*' }] } as any;
+```
+
+Then append this `describe` inside `describe('featureLinks routes', ...)`:
+
+```ts
+  // ============================================================
+  // #5511 W02 — the hpCmsl authorization gate (contract D4)
+  // ============================================================
+
+  describe('hpCmsl authorization gate', () => {
+    const CONSENT = {
+      acceptedByUserId: 'user-1',
+      acceptedAt: '2026-09-10T00:00:00.000Z',
+      eulaId: 'hp-cmsl-eula-2026-04-01',
+    };
+    const WRITE_ONLY = { permissions: [{ resource: 'devices', action: 'write' }] } as any;
+    const EXECUTE = { permissions: [{ resource: 'devices', action: 'execute' }] } as any;
+
+    const collectingLink = (id: string) => ({
+      id,
+      featureType: 'warranty',
+      inlineSettings: { hpCmsl: { enabled: true, consent: CONSENT } },
+    });
+
+    beforeEach(() => {
+      addFeatureLinkMock.mockResolvedValue({ id: LINK_ID });
+      updateFeatureLinkMock.mockResolvedValue({ id: LINK_ID });
+      removeFeatureLinkMock.mockResolvedValue({ id: LINK_ID, featureType: 'warranty' });
+      getConfigPolicyMock.mockResolvedValue(STUB_POLICY);
+    });
+
+    it('POST enabling collection is refused for devices.write-only', async () => {
+      permState.permissions = WRITE_ONLY;
+      const res = await app.request(`/${POLICY_ID}/features`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ featureType: 'warranty', inlineSettings: { hpCmsl: { enabled: true } } }),
+      });
+
+      expect(res.status).toBe(403);
+      expect(await res.json()).toMatchObject({ code: 'HP_CMSL_EXECUTE_REQUIRED' });
+      expect(addFeatureLinkMock).not.toHaveBeenCalled();
+    });
+
+    it('POST enabling collection is refused when MFA is not satisfied', async () => {
+      permState.permissions = EXECUTE;
+      mfaState.satisfied = false;
+      const res = await app.request(`/${POLICY_ID}/features`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ featureType: 'warranty', inlineSettings: { hpCmsl: { enabled: true } } }),
+      });
+
+      expect(res.status).toBe(403);
+      expect(await res.json()).toMatchObject({ code: 'MFA_REQUIRED' });
+      expect(addFeatureLinkMock).not.toHaveBeenCalled();
+    });
+
+    it('POST of alert thresholds only is NOT gated — devices.write still suffices', async () => {
+      permState.permissions = WRITE_ONLY;
+      const res = await app.request(`/${POLICY_ID}/features`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          featureType: 'warranty',
+          inlineSettings: { enabled: true, warnDays: 90, criticalDays: 30 },
+        }),
+      });
+
+      expect(res.status).toBe(201);
+      expect(addFeatureLinkMock).toHaveBeenCalled();
+    });
+
+    it('PATCH turning collection OFF is NOT gated (fail-safe direction)', async () => {
+      permState.permissions = WRITE_ONLY;
+      getConfigPolicyMock.mockResolvedValue({ ...STUB_POLICY, featureLinks: [collectingLink(LINK_ID)] });
+
+      const res = await app.request(`/${POLICY_ID}/features/${LINK_ID}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ inlineSettings: { hpCmsl: { enabled: false } } }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(updateFeatureLinkMock).toHaveBeenCalled();
+    });
+
+    it('PATCH turning collection ON is gated', async () => {
+      permState.permissions = WRITE_ONLY;
+      getConfigPolicyMock.mockResolvedValue({
+        ...STUB_POLICY,
+        featureLinks: [{ id: LINK_ID, featureType: 'warranty', inlineSettings: { hpCmsl: { enabled: false } } }],
+      });
+
+      const res = await app.request(`/${POLICY_ID}/features/${LINK_ID}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ inlineSettings: { hpCmsl: { enabled: true } } }),
+      });
+
+      expect(res.status).toBe(403);
+      expect(updateFeatureLinkMock).not.toHaveBeenCalled();
+    });
+
+    it('DELETE of a warranty link that REVERTS to a collecting parent is gated (inheritance transition)', async () => {
+      permState.permissions = WRITE_ONLY;
+      getConfigPolicyMock.mockResolvedValue({
+        ...STUB_POLICY,
+        parentPolicyId: PARENT_POLICY_ID,
+        parentPolicy: { id: PARENT_POLICY_ID, featureLinks: [collectingLink('parent-link')] },
+        featureLinks: [{ id: LINK_ID, featureType: 'warranty', inlineSettings: { hpCmsl: { enabled: false } } }],
+      });
+
+      const res = await app.request(`/${POLICY_ID}/features/${LINK_ID}`, { method: 'DELETE' });
+
+      expect(res.status).toBe(403);
+      expect(removeFeatureLinkMock).not.toHaveBeenCalled();
+    });
+
+    it('DELETE fails CLOSED when the parent row could not be resolved', async () => {
+      permState.permissions = WRITE_ONLY;
+      getConfigPolicyMock.mockResolvedValue({
+        ...STUB_POLICY,
+        parentPolicyId: PARENT_POLICY_ID,
+        parentPolicy: null,
+        featureLinks: [{ id: LINK_ID, featureType: 'warranty', inlineSettings: {} }],
+      });
+
+      const res = await app.request(`/${POLICY_ID}/features/${LINK_ID}`, { method: 'DELETE' });
+
+      expect(res.status).toBe(403);
+      expect(removeFeatureLinkMock).not.toHaveBeenCalled();
+    });
+
+    it('DELETE of a warranty link with no parent link is NOT gated — it only revokes', async () => {
+      permState.permissions = WRITE_ONLY;
+      getConfigPolicyMock.mockResolvedValue({
+        ...STUB_POLICY,
+        featureLinks: [collectingLink(LINK_ID)],
+      });
+
+      const res = await app.request(`/${POLICY_ID}/features/${LINK_ID}`, { method: 'DELETE' });
+
+      expect(res.status).toBe(200);
+      expect(removeFeatureLinkMock).toHaveBeenCalled();
+    });
+  });
+```
+
+- [ ] **Step 6: Run the route tests to verify they fail**
+
+Run: `cd apps/api && npx vitest run src/routes/configurationPolicies/featureLinks.test.ts`
+Expected: FAIL — the four gated cases return 201/200/200 instead of 403.
+
+- [ ] **Step 7: Wire the gate into featureLinks.ts**
+
+Add to the imports:
+
+```ts
+import { warrantyHpCmslRequested } from '@breeze/shared/validators';
+import type { UserPermissions } from '../../services/permissions';
+import { checkHpCmslWriteAllowed, warrantyLinkEnablesCollection } from './hpCmslGate';
+```
+
+POST — insert immediately after the existing MFA check (`:145-147`):
+
+```ts
+    // #5511 W02 (contract D4): enabling device-side HP warranty collection
+    // installs HP software on every HP endpoint this policy reaches, so it
+    // carries the deployment gate — devices.execute AND satisfied MFA — rather
+    // than the plain devices.write every other feature-link write needs.
+    // Keyed on the RESULT of the write, not the feature type: an alert-threshold
+    // edit installs nothing and stays ungated.
+    if (data.featureType === 'warranty' && warrantyHpCmslRequested(data.inlineSettings)) {
+      const gate = checkHpCmslWriteAllowed(auth, c.get('permissions') as UserPermissions | undefined);
+      if (!gate.allowed) return c.json(gate.body, 403);
+    }
+```
+
+PATCH — insert immediately after the existing MFA check (`:340-341`):
+
+```ts
+    // Same gate as the POST route (#5511 W02, D4). `data.inlineSettings` is the
+    // whole replacement blob (warranty updates are replace, not merge — D5), so
+    // the request predicate reads the post-write state directly.
+    if (existingLink.featureType === 'warranty' && warrantyHpCmslRequested(data.inlineSettings)) {
+      const gate = checkHpCmslWriteAllowed(auth, c.get('permissions') as UserPermissions | undefined);
+      if (!gate.allowed) return c.json(gate.body, 403);
+    }
+```
+
+DELETE — extend the block at `:519-526`. `parentUnresolved` and `parentHasSameType` already exist; add the warranty arm beside `revertRestoresParentWindow` and gate it separately, because its refusal is the coded execute/MFA body rather than the bare `MFA required`:
+
+```ts
+    const parentUnresolved = !!policy.parentPolicyId && !policy.parentPolicy;
+    const parentHasSameType = !!policy.parentPolicy?.featureLinks?.some(
+      (l: { featureType: string }) => l.featureType === existingLink.featureType,
+    );
+    const revertRestoresParentWindow = existingLink.featureType === 'maintenance'
+      && (parentUnresolved || parentHasSameType);
+    if ((existingLink.featureType === 'patch' || revertRestoresParentWindow) && !hasSatisfiedMfa(auth)) {
+      return c.json({ error: 'MFA required' }, 403);
+    }
+
+    // #5511 W02 (contract D4/D5): deleting a warranty link is normally a pure
+    // revocation and stays ungated — but with a parent that COLLECTS, this
+    // delete does not end collection, it reverts to the parent's link and
+    // starts it. Same premise-stops-holding shape as maintenance above. Fails
+    // CLOSED on an unresolvable parent for the same reason.
+    const revertStartsHpCmslCollection = existingLink.featureType === 'warranty'
+      && (parentUnresolved || warrantyLinkEnablesCollection(policy.parentPolicy?.featureLinks));
+    if (revertStartsHpCmslCollection) {
+      const gate = checkHpCmslWriteAllowed(auth, c.get('permissions') as UserPermissions | undefined);
+      if (!gate.allowed) return c.json(gate.body, 403);
+    }
+```
+
+- [ ] **Step 8: Add the service helper for the create-with-parent door**
+
+In `apps/api/src/services/configurationPolicy.ts`, immediately after `getParentLinkFeatureTypes` (`:509`):
+
+```ts
+/**
+ * True when the named parent policy carries a warranty link that actually
+ * delivers HP CMSL collection (#5511 W02, contract D4).
+ *
+ * Its own function rather than a widening of getParentLinkFeatureTypes, which
+ * returns feature TYPES only: the warranty gate is keyed on a value inside the
+ * link's JSONB, not on the presence of a link.
+ *
+ * One level is all that is needed — a parent must itself be a root policy
+ * (`parent_policy_id IS NULL`, see listEligibleParentPolicies), so there is no
+ * grandparent to walk.
+ */
+export async function parentPolicyEnablesHpCmslCollection(parentId: string): Promise<boolean> {
+  const [row] = await db
+    .select({ inlineSettings: configPolicyFeatureLinks.inlineSettings })
+    .from(configPolicyFeatureLinks)
+    .where(
+      and(
+        eq(configPolicyFeatureLinks.configPolicyId, parentId),
+        eq(configPolicyFeatureLinks.featureType, 'warranty')
+      )
+    )
+    .limit(1);
+  return warrantyHpCmslCollectionEffective(row?.inlineSettings);
+}
+```
+
+- [ ] **Step 9: Wire the assignment and create-with-parent doors**
+
+`apps/api/src/routes/configurationPolicies/assignments.ts` — add the imports:
+
+```ts
+import type { UserPermissions } from '../../services/permissions';
+import { checkHpCmslWriteAllowed, warrantyLinkEnablesCollection } from './hpCmslGate';
+```
+
+and insert after the site-authorization check (`:121-124`), before `assignPolicy`:
+
+```ts
+    // #5511 W02 (contract D4): an assignment is how a policy that already
+    // enables HP CMSL collection REACHES devices. Assigning one is therefore
+    // the same capability as authoring it, reached through a second door — the
+    // shape crud.ts already uses for a patch/maintenance parent. The effective
+    // warranty link is the policy's own, else the one it inherits.
+    const assignmentStartsHpCmslCollection =
+      warrantyLinkEnablesCollection(policy.featureLinks)
+      || (!policy.featureLinks?.some((l: { featureType: string }) => l.featureType === 'warranty')
+        && warrantyLinkEnablesCollection(policy.parentPolicy?.featureLinks));
+    if (assignmentStartsHpCmslCollection) {
+      const gate = checkHpCmslWriteAllowed(auth, c.get('permissions') as UserPermissions | undefined);
+      if (!gate.allowed) return c.json(gate.body, 403);
+    }
+```
+
+`apps/api/src/routes/configurationPolicies/crud.ts` — add `parentPolicyEnablesHpCmslCollection` to the `'../../services/configurationPolicy'` import, plus:
+
+```ts
+import type { UserPermissions } from '../../services/permissions';
+import { checkHpCmslWriteAllowed } from './hpCmslGate';
+```
+
+and extend the existing parent block (`:78-83`):
+
+```ts
+    if (data.parentPolicyId) {
+      const parentTypes = await getParentLinkFeatureTypes(data.parentPolicyId);
+      if (parentTypes.some((t) => MFA_GATED_FEATURE_TYPES.has(t)) && !hasSatisfiedMfa(auth)) {
+        return c.json({ error: 'MFA required' }, 403);
+      }
+      // #5511 W02 (contract D4): the same "MFA follows effectiveness" argument,
+      // for a parent that collects HP warranty data. Inheriting it makes the
+      // collection effective on the new policy immediately, so the create
+      // carries the deployment gate too.
+      if (parentTypes.includes('warranty') && await parentPolicyEnablesHpCmslCollection(data.parentPolicyId)) {
+        const gate = checkHpCmslWriteAllowed(auth, c.get('permissions') as UserPermissions | undefined);
+        if (!gate.allowed) return c.json(gate.body, 403);
+      }
+    }
+```
+
+- [ ] **Step 10: Write the assignment-door test**
+
+Create `apps/api/src/routes/configurationPolicies/assignments.hpCmsl.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+const {
+  getConfigPolicyMock,
+  assignPolicyMock,
+  validateAssignmentTargetMock,
+  authorizeAssignmentTargetMock,
+  mfaState,
+  permState,
+} = vi.hoisted(() => ({
+  getConfigPolicyMock: vi.fn(),
+  assignPolicyMock: vi.fn(),
+  validateAssignmentTargetMock: vi.fn(),
+  authorizeAssignmentTargetMock: vi.fn(),
+  mfaState: { satisfied: true },
+  permState: { permissions: { permissions: [{ resource: '*', action: '*' }] } as any },
+}));
+
+vi.mock('../../services/configurationPolicy', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../../services/configurationPolicy')>();
+  return {
+    ...original,
+    getConfigPolicy: getConfigPolicyMock,
+    assignPolicy: assignPolicyMock,
+    unassignPolicy: vi.fn(),
+    listAssignments: vi.fn(),
+    listAssignmentsForTarget: vi.fn(),
+    validateAssignmentTarget: validateAssignmentTargetMock,
+    authorizeAssignmentTarget: authorizeAssignmentTargetMock,
+    getAssignment: vi.fn(),
+  };
+});
+vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
+vi.mock('../../services/remoteAccessPolicy', () => ({ invalidateRemoteAccessCache: vi.fn() }));
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: vi.fn((c: any, next: any) => next()),
+  requireScope: vi.fn(() => (c: any, next: any) => next()),
+  requirePermission: vi.fn(() => (c: any, next: any) => next()),
+  hasSatisfiedMfa: vi.fn(() => mfaState.satisfied),
+}));
+
+import { assignmentRoutes } from './assignments';
+import { HP_CMSL_EULA_ID } from '@breeze/shared/validators';
+
+const ORG_ID = '11111111-1111-1111-1111-111111111111';
+const POLICY_ID = '22222222-2222-2222-2222-222222222222';
+const DEVICE_ID = '44444444-4444-4444-4444-444444444444';
+
+const CONSENT = {
+  acceptedByUserId: 'user-1',
+  acceptedAt: '2026-09-10T00:00:00.000Z',
+  eulaId: HP_CMSL_EULA_ID,
+};
+const COLLECTING_LINK = {
+  id: 'link-1',
+  featureType: 'warranty',
+  inlineSettings: { hpCmsl: { enabled: true, consent: CONSENT } },
+};
+
+function buildApp() {
+  const app = new Hono();
+  app.use('*', async (c, next) => {
+    c.set('auth', {
+      scope: 'organization',
+      orgId: ORG_ID,
+      partnerId: null,
+      user: { id: 'user-1' },
+      token: { scope: 'organization' },
+      accessibleOrgIds: [ORG_ID],
+      canAccessOrg: (o: string) => o === ORG_ID,
+    });
+    c.set('permissions', permState.permissions);
+    await next();
+  });
+  app.route('/', assignmentRoutes);
+  return app;
+}
+
+function assign() {
+  return buildApp().request(`/${POLICY_ID}/assignments`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ level: 'device', targetId: DEVICE_ID }),
+  });
+}
+
+describe('POST /:id/assignments — hpCmsl gate (#5511 W02 D4)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mfaState.satisfied = true;
+    permState.permissions = { permissions: [{ resource: '*', action: '*' }] } as any;
+    validateAssignmentTargetMock.mockResolvedValue({ valid: true });
+    authorizeAssignmentTargetMock.mockResolvedValue({ valid: true });
+    assignPolicyMock.mockResolvedValue({ id: 'assignment-1' });
+  });
+
+  it('refuses a devices.write-only caller assigning a policy that collects', async () => {
+    permState.permissions = { permissions: [{ resource: 'devices', action: 'write' }] } as any;
+    getConfigPolicyMock.mockResolvedValue({
+      id: POLICY_ID, orgId: ORG_ID, partnerId: null, name: 'P',
+      featureLinks: [COLLECTING_LINK], parentPolicy: null,
+    });
+
+    const res = await assign();
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toMatchObject({ code: 'HP_CMSL_EXECUTE_REQUIRED' });
+    expect(assignPolicyMock).not.toHaveBeenCalled();
+  });
+
+  it('refuses when the collecting link is INHERITED from the parent', async () => {
+    permState.permissions = { permissions: [{ resource: 'devices', action: 'write' }] } as any;
+    getConfigPolicyMock.mockResolvedValue({
+      id: POLICY_ID, orgId: ORG_ID, partnerId: null, name: 'P',
+      featureLinks: [],
+      parentPolicy: { id: 'parent', featureLinks: [COLLECTING_LINK] },
+    });
+
+    const res = await assign();
+
+    expect(res.status).toBe(403);
+    expect(assignPolicyMock).not.toHaveBeenCalled();
+  });
+
+  it('does NOT refuse when the policy overrides the parent with collection off', async () => {
+    permState.permissions = { permissions: [{ resource: 'devices', action: 'write' }] } as any;
+    getConfigPolicyMock.mockResolvedValue({
+      id: POLICY_ID, orgId: ORG_ID, partnerId: null, name: 'P',
+      featureLinks: [{ id: 'own', featureType: 'warranty', inlineSettings: { hpCmsl: { enabled: false } } }],
+      parentPolicy: { id: 'parent', featureLinks: [COLLECTING_LINK] },
+    });
+
+    const res = await assign();
+
+    expect(res.status).toBe(201);
+    expect(assignPolicyMock).toHaveBeenCalled();
+  });
+
+  it('does not gate an ordinary assignment of a policy with no warranty link', async () => {
+    permState.permissions = { permissions: [{ resource: 'devices', action: 'write' }] } as any;
+    getConfigPolicyMock.mockResolvedValue({
+      id: POLICY_ID, orgId: ORG_ID, partnerId: null, name: 'P',
+      featureLinks: [{ id: 'p', featureType: 'patch', inlineSettings: {} }],
+      parentPolicy: null,
+    });
+
+    const res = await assign();
+
+    expect(res.status).toBe(201);
+  });
+});
+```
+
+That third case is also the executable statement of D5's override semantics at the assignment door: a nearer link with collection off REPLACES the inherited one, so no device is exposed and no gate applies.
+
+- [ ] **Step 11: Run everything and verify green**
+
+Run: `cd apps/api && npx vitest run src/routes/configurationPolicies/hpCmslGate.test.ts src/routes/configurationPolicies/featureLinks.test.ts src/routes/configurationPolicies/assignments.hpCmsl.test.ts src/routes/configurationPolicies/assignments.test.ts src/routes/configurationPolicies/crud.test.ts src/routes/configurationPolicies/crud.siteScope.test.ts`
+Expected: PASS, 6 files. `assignments.test.ts` and `crud.test.ts` are listed because both routes gained a branch; both must stay green with their existing (unseeded) contexts, which they do because their policies carry no collecting warranty link.
+
+Then typecheck: `cd apps/api && npx tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add apps/api/src/routes/configurationPolicies/hpCmslGate.ts apps/api/src/routes/configurationPolicies/hpCmslGate.test.ts apps/api/src/routes/configurationPolicies/featureLinks.ts apps/api/src/routes/configurationPolicies/featureLinks.test.ts apps/api/src/routes/configurationPolicies/assignments.ts apps/api/src/routes/configurationPolicies/assignments.hpCmsl.test.ts apps/api/src/routes/configurationPolicies/crud.ts apps/api/src/services/configurationPolicy.ts
+git commit -m "feat(api): gate every transition that exposes a device to HP CMSL collection on devices.execute + MFA (#5511 W02 D4)"
+```
+
+---
+
+### Task 6: Close the AI door — escalate an hpCmsl-enabling feature-link write to Tier 3
+
+**Files:**
+- Modify: `apps/api/src/services/aiGuardrails.ts` (imports `:13-23`; the `TIER3_INPUT_AWARE_ACTIONS` comment `:508-513`; the `isInputAwareTier3` doc comment `:517-532` and body `:533-543`; `resolveApprovalScope`'s override comment `:570-578`; `buildApprovalDescription`'s feature-link case `:2327-2330`)
+- Modify: `apps/api/src/services/aiGuardrails.test.ts` (new `describe` beside the maintenance one at `:1202-1270`)
+- Modify: `apps/api/src/services/aiGuardrails.approvalScope.contract.test.ts` (extend the both-branches case at `:380-395`)
+
+**Interfaces:**
+- Consumes: Task 1's `warrantyHpCmslRequested`.
+- Produces: no new exports. `isInputAwareTier3` keeps its signature and gains a second escalation arm; `TIER3_INPUT_AWARE_ACTIONS` is unchanged (both pairs are already members), so the approval-scope contract test's "classified in exactly one static table" invariant needs no new exemption.
+
+**Why inert is not the same as gated.** Task 2 makes the AI path *harmless*: with no `consentActor` the service refuses to stamp, so no consent is recorded, and Task 8's delivery predicate requires a consent against the current EULA id — collection never turns on. That fail-safe stays. But it is not a gate, and two things are still wrong without this task:
+
+1. **The AI can still flip the stored flag.** `hpCmsl.enabled: true` with no consent is a persistable blob (the stored schema allows an absent consent — that is what makes "disabled" and "legacy" representable). The WarrantyTab would then render collection as ON while the agent is delivered `false`. A UI that says a customer's endpoints are being collected from when they are not is its own dishonesty, independent of the security question.
+2. **The gate is one refactor away from bypassable.** D4 is enforced in five HTTP handlers. `manage_policy_feature_link` reaches `addFeatureLink` without passing through any of them (`aiToolsConfigPolicy.ts:936-942`), at Tier 2 — auto-execute, audit only. The moment anyone gives the AI tool an actor, or relaxes the consent rule, the door is open for real. Guardrails is where that door is closed.
+
+This mirrors Feature A's W05 treatment of `autoInstall`: both features gate the act of causing software installation the same way, at the same layer.
+
+**Predicate on CONTENT, not on `featureType`.** `isInputAwareTier3`'s own doc comment (`:523-531`) records that for `update`, `featureType` is **not a required input** — the maintenance arm gets away with it because the handler's principal check is its belt. A warranty escalation keyed on `featureType === 'warranty'` would therefore miss every `update`, which is precisely the write that turns collection on for an existing link. The same comment warns the other way too: the `add`/`update` action guard exists so a read carrying a stray argument is not escalated into an approval the MCP transport then denies. Both constraints are satisfied by keeping the action guard and reading `input.inlineSettings`.
+
+Escalating on content alone is deliberately slightly over-broad: `inlineSettings: { hpCmsl: { enabled: true } }` sent with `featureType: 'patch'` also escalates, even though the write would 400. Requiring approval for a doomed call is the conservative direction and costs nothing; requiring the right `featureType` on an input that need not carry one is how the arm would silently miss.
+
+**Scope is `supervised`, not `four_eyes`.** Per the rationale already written at `:570-578`: this is authoring policy configuration, not an externally binding act, and it matches `manage_configuration_policy`'s own create/update/delete. Note that `manage_policy_feature_link` is in neither whole-tool scope set and `add`/`update` are in neither `*_ACTIONS` scope table, so **without** the existing override an escalated pair falls to the per-tool `four_eyes` fail-safe at the bottom of `resolveApprovalScope` — the override is mandatory, not stylistic. It already covers both pairs, so this task changes the tier predicate only, never the scope resolution.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `apps/api/src/services/aiGuardrails.test.ts`, immediately after the existing `describe('manage_policy_feature_link maintenance escalation (RMM-QA-176 D9)', ...)` block (ends `:1270`):
+
+```ts
+// ─── #5511 W02: manage_policy_feature_link HP CMSL escalation ────────────────
+
+describe('manage_policy_feature_link hpCmsl escalation (#5511 W02, contract D4)', () => {
+  const enabling = { hpCmsl: { enabled: true } };
+  const thresholdsOnly = { enabled: true, warnDays: 90, criticalDays: 30 };
+
+  it('escalates add of a warranty link that enables HP collection to tier 3, supervised', () => {
+    const check = checkGuardrails('manage_policy_feature_link', {
+      action: 'add', configPolicyId: 'p1', featureType: 'warranty', inlineSettings: enabling,
+    });
+    expect(check.tier).toBe(3);
+    expect(check.requiresApproval).toBe(true);
+    expect(check.approvalScope).toBe('supervised');
+  });
+
+  it('escalates update WITHOUT a featureType — the input that turns collection on for an existing link', () => {
+    // featureType is not a required input on `update`, so an escalation keyed
+    // on it would miss exactly this call. Predicating on the settings content
+    // is what makes the arm reachable at all.
+    const check = checkGuardrails('manage_policy_feature_link', {
+      action: 'update', configPolicyId: 'p1', featureLinkId: 'l1', inlineSettings: enabling,
+    });
+    expect(check.tier).toBe(3);
+    expect(check.approvalScope).toBe('supervised');
+  });
+
+  it('leaves an alert-threshold-only warranty link at the tool base tier 2 — it installs nothing', () => {
+    for (const action of ['add', 'update'] as const) {
+      const check = checkGuardrails('manage_policy_feature_link', {
+        action, configPolicyId: 'p1', featureLinkId: 'l1', featureType: 'warranty', inlineSettings: thresholdsOnly,
+      });
+      expect(check.tier, `${action} of thresholds-only must not escalate`).toBe(2);
+      expect(check.requiresApproval).toBe(false);
+    }
+  });
+
+  it('leaves an explicit DISABLE at tier 2 — turning collection off is the fail-safe direction', () => {
+    const check = checkGuardrails('manage_policy_feature_link', {
+      action: 'update', configPolicyId: 'p1', featureLinkId: 'l1', inlineSettings: { hpCmsl: { enabled: false } },
+    });
+    expect(check.tier).toBe(2);
+    expect(check.requiresApproval).toBe(false);
+  });
+
+  it('leaves a warranty link with no inlineSettings at all at tier 2', () => {
+    const check = checkGuardrails('manage_policy_feature_link', {
+      action: 'add', configPolicyId: 'p1', featureType: 'warranty',
+    });
+    expect(check.tier).toBe(2);
+  });
+
+  it('is never triggered by a READ carrying the same settings', () => {
+    // Same protection as the maintenance arm's own read control: the action
+    // guard, not ordering, is what keeps `list` out of an approval the MCP
+    // transport would then deny outright.
+    const check = checkGuardrails('manage_policy_feature_link', {
+      action: 'list', configPolicyId: 'p1', inlineSettings: enabling,
+    });
+    expect(check.tier).toBe(2);
+    expect(check.requiresApproval).toBe(false);
+  });
+
+  it('fails safe on a malformed hpCmsl block rather than escalating on junk', () => {
+    // warrantyHpCmslRequested parses the sub-block strictly, so a
+    // non-conforming shape is not "enabled". The WRITE refuses it anyway
+    // (Task 3's 400), so the base tier is the right answer here.
+    for (const inlineSettings of [
+      { hpCmsl: 'true' },
+      { hpCmsl: { enabled: 'true' } },
+      { hpCmsl: [] },
+    ]) {
+      const check = checkGuardrails('manage_policy_feature_link', {
+        action: 'add', configPolicyId: 'p1', featureType: 'warranty', inlineSettings,
+      });
+      expect(check.tier).toBe(2);
+    }
+  });
+
+  it('names HP CMSL in the approval description so an approver knows software gets installed', () => {
+    const check = checkGuardrails('manage_policy_feature_link', {
+      action: 'update', configPolicyId: 'p1', featureLinkId: 'l1', inlineSettings: enabling,
+    });
+    expect(check.description).toContain('HP CMSL');
+  });
+
+  it('leaves the maintenance escalation exactly as it was', () => {
+    // The control for this whole task: adding an arm must not disturb the
+    // existing one, in either direction.
+    const maintenance = checkGuardrails('manage_policy_feature_link', {
+      action: 'add', configPolicyId: 'p1', featureType: 'maintenance',
+    });
+    expect(maintenance.tier).toBe(3);
+    expect(maintenance.approvalScope).toBe('supervised');
+    expect(maintenance.description).toContain('maintenance');
+
+    const patch = checkGuardrails('manage_policy_feature_link', {
+      action: 'add', configPolicyId: 'p1', featureType: 'patch',
+    });
+    expect(patch.tier).toBe(2);
+  });
+});
+```
+
+And extend `apps/api/src/services/aiGuardrails.approvalScope.contract.test.ts`, immediately after the existing `manage_policy_feature_link resolves supervised for maintenance on both add and update` case (`:380-386`):
+
+```ts
+  it('manage_policy_feature_link resolves supervised for an hpCmsl-enabling write on both add and update (#5511 W02)', () => {
+    const enabling = { inlineSettings: { hpCmsl: { enabled: true } } };
+    expect(resolveApprovalScope('manage_policy_feature_link', 'add', enabling)).toBe('supervised');
+    expect(resolveApprovalScope('manage_policy_feature_link', 'update', enabling)).toBe('supervised');
+    // ...and the escalation is what routes it there. Without the tier arm the
+    // pair is in NEITHER static scope table and would reach the per-tool
+    // four_eyes fail-safe, so this assertion is load-bearing, not decorative.
+    expect(isInputAwareTier3('manage_policy_feature_link', 'add', enabling)).toBe(true);
+    expect(isInputAwareTier3('manage_policy_feature_link', 'update', enabling)).toBe(true);
+  });
+
+  it('checkGuardrails surfaces the hpCmsl escalation on both branches (#5511 W02)', () => {
+    const enabling = checkGuardrails('manage_policy_feature_link', {
+      action: 'add', inlineSettings: { hpCmsl: { enabled: true } },
+    });
+    expect(enabling.tier).toBe(3);
+    expect(enabling.approvalScope).toBe('supervised');
+
+    const thresholds = checkGuardrails('manage_policy_feature_link', {
+      action: 'add', featureType: 'warranty', inlineSettings: { warnDays: 90 },
+    });
+    expect(thresholds.tier).toBe(2);
+    expect(thresholds.approvalScope).toBeUndefined();
+  });
+```
+
+Add `isInputAwareTier3` to that file's import from `./aiGuardrails` if it is not already imported.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd apps/api && npx vitest run src/services/aiGuardrails.test.ts src/services/aiGuardrails.approvalScope.contract.test.ts`
+Expected: FAIL — every escalation case reports `tier: 2` / `approvalScope: undefined`, and the description case reports the bare `UPDATE feature link on config policy p1...`. The tier-2 cases (thresholds-only, disable, read, malformed) pass already; they are the controls that prove the new arm stayed narrow, and they must still pass at the end.
+
+- [ ] **Step 3: Extend the predicate**
+
+Add the import to `apps/api/src/services/aiGuardrails.ts` (with the other service imports, `:15-23`):
+
+```ts
+import { warrantyHpCmslRequested } from '@breeze/shared/validators';
+```
+
+(`aiGuardrails.imports.contract.test.ts:11-17` forbids only `./aiToolSchemas` and `getToolDefinitions`; the shared validators barrel is pure zod and pulls in no Drizzle schema objects, so it does not reintroduce the #5054 partial-mock breakage.)
+
+Replace the `isInputAwareTier3` doc comment and body (`:517-543`) with:
+
+```ts
+/**
+ * True when a (tool, action, input) triple escalates to Tier 3 on argument
+ * CONTENT. Exported so checkGuardrails, resolveApprovalScope and the tests all
+ * ask the SAME question — a second copy of this predicate is how a tier and
+ * its scope drift apart.
+ *
+ * Two arms, both on manage_policy_feature_link's add/update:
+ *
+ *  - `featureType === 'maintenance'` (RMM-QA-176 D9). Strict `===`: a
+ *    non-string featureType stays at the base tier, which is safe here because
+ *    the handler writes exactly the featureType it was given, so a value that
+ *    is not the literal 'maintenance' cannot create a maintenance link either.
+ *    The handler's own principal check (D9.3) is the belt to this brace for
+ *    `update`, where featureType is not a required input.
+ *
+ *  - an inlineSettings payload that would leave HP CMSL warranty collection
+ *    ON (#5511 W02, contract D4). Enabling it installs HP's CMSL module on
+ *    every HP endpoint the policy reaches, which is a software deployment —
+ *    gated behind devices.execute + MFA on the HTTP routes, and this tool
+ *    reaches addFeatureLink without passing through any of them. Keyed on the
+ *    SETTINGS CONTENT rather than on featureType precisely because featureType
+ *    is not a required input on `update`, which is the call that turns
+ *    collection on for an existing link. A warranty link carrying only alert
+ *    thresholds installs nothing and deliberately stays at the base tier.
+ *
+ * The action guard is not decoration: without it a read (`list`) carrying a
+ * stray featureType or inlineSettings argument would be escalated into an
+ * approval that the MCP transport then denies outright.
+ */
+export function isInputAwareTier3(
+  toolName: string,
+  action: string | undefined,
+  input: Record<string, unknown>,
+): boolean {
+  if (toolName !== 'manage_policy_feature_link') return false;
+  if (action !== 'add' && action !== 'update') return false;
+  return (
+    input.featureType === 'maintenance'
+    || warrantyHpCmslRequested(input.inlineSettings)
+  );
+}
+```
+
+Extend the `TIER3_INPUT_AWARE_ACTIONS` comment (`:508-513`) so the set's own note stays true:
+
+```ts
+  // RMM-QA-176 D9: a 'maintenance' feature link is the canonical
+  // monitoring-suppression source, so authoring one is a different class of
+  // act from authoring any other link — but only the INPUT says which it is,
+  // so it cannot be classified by (tool, action) in the static tables.
+  // #5511 W02: same reasoning for a warranty link that switches on device-side
+  // HP CMSL collection — the pair is unchanged, the predicate gained an arm.
+  'manage_policy_feature_link:add',
+  'manage_policy_feature_link:update',
+```
+
+Extend the `resolveApprovalScope` override comment (`:570-578`) with one line, leaving the rest as-is:
+
+```ts
+    // `supervised` matches the #3552/835f7eb3d policy-prerequisite
+    // escalations and manage_configuration_policy's own create/update/delete —
+    // authoring policy configuration, not an externally binding act. The
+    // #5511 hpCmsl arm resolves here too, for the same reason.
+```
+
+- [ ] **Step 4: Name it in the approval description**
+
+Replace `buildApprovalDescription`'s feature-link case (`:2327-2330`):
+
+```ts
+    case 'manage_policy_feature_link':
+      parts.push(`${action?.toUpperCase()} ${String(input.featureType ?? 'feature')} link`);
+      parts.push(`on config policy ${(input.configPolicyId as string)?.slice(0, 8) ?? 'unknown'}...`);
+      // #5511 W02: an `update` need not carry featureType, so without this an
+      // approver sees "UPDATE feature link" for a change that installs HP
+      // software on every HP endpoint the policy reaches. Say what it does.
+      if (warrantyHpCmslRequested(input.inlineSettings)) {
+        parts.push('— enables HP CMSL warranty collection (installs HP software on HP devices)');
+      }
+      break;
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cd apps/api && npx vitest run src/services/aiGuardrails.test.ts src/services/aiGuardrails.approvalScope.contract.test.ts`
+Expected: PASS, 2 files.
+
+Then the rest of the guardrails contract family and the transport-level suite, all of which read this predicate or this file's import surface:
+Run: `cd apps/api && npx vitest run src/services/aiGuardrails.imports.contract.test.ts src/services/aiGuardrails.readonly.contract.test.ts src/services/aiGuardrails.agentPrincipal.contract.test.ts src/services/aiGuardrails.enforcementArming.contract.test.ts src/services/aiGuardrailsTierConfig.parity.test.ts src/services/aiGuardrailsAiDocs.parity.test.ts src/routes/mcpServer.approvalGate.test.ts`
+Expected: PASS, 7 files. `mcpServer.approvalGate.test.ts:440-500` is the one that would notice if the maintenance escalation changed shape end-to-end.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/services/aiGuardrails.ts apps/api/src/services/aiGuardrails.test.ts apps/api/src/services/aiGuardrails.approvalScope.contract.test.ts
+git commit -m "feat(api): escalate an hpCmsl-enabling feature-link write to Tier 3 supervised (#5511 W02 D4)"
+```
+
+---
+
+### Task 7: Share the effective-warranty resolution instead of writing a second resolver
+
+**Files:**
+- Create: `apps/api/src/services/warrantyPolicyResolution.ts`
+- Create: `apps/api/src/services/warrantyPolicyResolution.test.ts`
+- Modify: `apps/api/src/services/warrantyAlertEvaluator.ts` (replace the body of `resolveWarrantySettings`, `:58-186`, with a projection; drop the imports it no longer uses)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces:
+  - `export async function resolveEffectiveWarrantyInlineSettings(deviceId: string): Promise<unknown | undefined>` — the winning link's `inlineSettings` (which may itself be `null`), or `undefined` when **no** active warranty link resolves for the device. Throws on a DB error; callers decide what that means.
+
+**Why a new module rather than exporting from the evaluator.** `warrantyAlertEvaluator.ts` imports `alertService`, `eventBus` and the alert schema; making `routes/agents/helpers.ts` (the heartbeat path) import it would drag that whole graph into every heartbeat for one boolean. A leaf module that both consumers import keeps one resolver — which is what contract D6 asks for — without that coupling, and leaves the evaluator's behaviour byte-for-byte unchanged.
+
+**Behaviour that must not change.** The resolver's ranking is `device 5 > device_group 4 > site 3 > organization 2 > partner 1`, then descending assignment `priority`, then `rows[0].inlineSettings` — a WHOLE link, no deep merge (contract D5). `DISABLED_SETTINGS` on no rows and `DEFAULT_SETTINGS` on a null blob stay in the evaluator, where they belong; the shared resolver reports absence as `undefined` and does not invent defaults.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/src/services/warrantyPolicyResolution.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { selectQueue } = vi.hoisted(() => ({ selectQueue: [] as unknown[][] }));
+
+// db.select() is consumed FIFO: device row, org row, group rows, then the
+// effective-links join. Each chain resolves when awaited.
+function chainable(rows: unknown[]) {
+  const obj: any = {};
+  for (const m of ['from', 'where', 'innerJoin', 'leftJoin', 'orderBy', 'limit']) obj[m] = () => obj;
+  obj.then = (resolve: (v: unknown) => unknown) => Promise.resolve(rows).then(resolve);
+  return obj;
+}
+
+vi.mock('../db', () => ({
+  db: { select: vi.fn(() => chainable(selectQueue.shift() ?? [])) },
+}));
+vi.mock('../db/schema', () => ({
+  devices: {}, organizations: {}, deviceGroupMemberships: {},
+  configPolicyAssignments: {}, configurationPolicies: {},
+  configPolicyEffectiveFeatureLinks: {},
+}));
+vi.mock('./configPolicyOwnership', () => ({ policyOwnershipCondition: vi.fn(() => undefined) }));
+vi.mock('./sentry', () => ({ captureException: vi.fn() }));
+
+import { resolveEffectiveWarrantyInlineSettings } from './warrantyPolicyResolution';
+
+const DEVICE_ID = '00000000-0000-4000-8000-000000000001';
+
+function seed(linkRows: unknown[]) {
+  selectQueue.length = 0;
+  selectQueue.push([{ orgId: 'org-1', siteId: 'site-1' }]);   // device
+  selectQueue.push([{ partnerId: 'partner-1' }]);              // org
+  selectQueue.push([]);                                        // group memberships
+  selectQueue.push(linkRows);                                  // effective links
+}
+
+describe('resolveEffectiveWarrantyInlineSettings', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns undefined when the device does not resolve at all', async () => {
+    selectQueue.length = 0;
+    selectQueue.push([]);
+    await expect(resolveEffectiveWarrantyInlineSettings(DEVICE_ID)).resolves.toBeUndefined();
+  });
+
+  it('returns undefined when no active warranty link is assigned', async () => {
+    seed([]);
+    await expect(resolveEffectiveWarrantyInlineSettings(DEVICE_ID)).resolves.toBeUndefined();
+  });
+
+  it('returns the nearest level\'s WHOLE inlineSettings, not a merge (contract D5)', async () => {
+    seed([
+      { inlineSettings: { enabled: true, warnDays: 90, hpCmsl: { enabled: true } }, level: 'organization', priority: 0 },
+      { inlineSettings: { warnDays: 14 }, level: 'device', priority: 0 },
+    ]);
+
+    // The device-level link carries no hpCmsl block, so the org-level one is
+    // DROPPED wholesale. This is the inheritance footgun the UI has to surface.
+    await expect(resolveEffectiveWarrantyInlineSettings(DEVICE_ID)).resolves.toEqual({ warnDays: 14 });
+  });
+
+  it('breaks a same-level tie on descending assignment priority', async () => {
+    seed([
+      { inlineSettings: { warnDays: 1 }, level: 'site', priority: 0 },
+      { inlineSettings: { warnDays: 2 }, level: 'site', priority: 5 },
+    ]);
+    await expect(resolveEffectiveWarrantyInlineSettings(DEVICE_ID)).resolves.toEqual({ warnDays: 2 });
+  });
+
+  it('ranks partner below organization', async () => {
+    seed([
+      { inlineSettings: { warnDays: 7 }, level: 'partner', priority: 99 },
+      { inlineSettings: { warnDays: 8 }, level: 'organization', priority: 0 },
+    ]);
+    await expect(resolveEffectiveWarrantyInlineSettings(DEVICE_ID)).resolves.toEqual({ warnDays: 8 });
+  });
+
+  it('distinguishes a resolved-but-null blob from no policy at all', async () => {
+    seed([{ inlineSettings: null, level: 'organization', priority: 0 }]);
+    await expect(resolveEffectiveWarrantyInlineSettings(DEVICE_ID)).resolves.toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api && npx vitest run src/services/warrantyPolicyResolution.test.ts`
+Expected: FAIL — `Failed to resolve import "./warrantyPolicyResolution"`.
+
+- [ ] **Step 3: Write the shared resolver**
+
+Create `apps/api/src/services/warrantyPolicyResolution.ts` — this is `warrantyAlertEvaluator.ts:58-177` lifted verbatim, with the three-field projection removed from the end:
+
+```ts
+/**
+ * Effective warranty feature link for a device.
+ *
+ * Lifted out of warrantyAlertEvaluator's private resolveWarrantySettings so the
+ * heartbeat's HP CMSL delivery reads the SAME link the expiry alerting reads
+ * (#5511 W02, contract D6). A second resolver would drift: this one already
+ * carries two hard-won corrections (#3963's polymorphic per-level target
+ * matching and #2930's dual-axis ownership predicate) that a fresh copy would
+ * not have.
+ *
+ * A leaf module on purpose — importing the alert evaluator from
+ * routes/agents/helpers.ts would pull alertService and the event bus into every
+ * heartbeat for one boolean.
+ */
+import { db } from '../db';
+import {
+  devices,
+  configPolicyEffectiveFeatureLinks,
+  configPolicyAssignments,
+  configurationPolicies,
+  deviceGroupMemberships,
+  organizations,
+} from '../db/schema';
+import { eq, and, inArray, or, type SQL } from 'drizzle-orm';
+import { policyOwnershipCondition } from './configPolicyOwnership';
+import { captureException } from './sentry';
+
+// device > device_group > site > organization > partner. Closest wins.
+const LEVEL_PRIORITY: Record<string, number> = {
+  device: 5,
+  device_group: 4,
+  site: 3,
+  organization: 2,
+  partner: 1,
+};
+
+/**
+ * The WHOLE inlineSettings blob of the warranty feature link in effect for a
+ * device, or `undefined` when no active warranty policy resolves.
+ *
+ * `undefined` (no policy) and `null` (a policy whose blob is null) are
+ * different answers and callers treat them differently — warranty alerting
+ * falls back to DISABLED_SETTINGS for the first and DEFAULT_SETTINGS for the
+ * second. Do not collapse them.
+ *
+ * Selection is a whole link, never a deep merge (contract D5): a nearer policy
+ * carrying only alert thresholds REPLACES an inherited link and drops its
+ * hpCmsl block, revoking collection.
+ *
+ * Throws on a database error. The heartbeat caller depends on that: an error
+ * must omit the config block entirely rather than resolve to "off".
+ */
+export async function resolveEffectiveWarrantyInlineSettings(deviceId: string): Promise<unknown | undefined> {
+  const [device] = await db
+    .select({ orgId: devices.orgId, siteId: devices.siteId })
+    .from(devices)
+    .where(eq(devices.id, deviceId))
+    .limit(1);
+
+  if (!device) return undefined;
+
+  // The device org's partner. Needed twice below: a `level='partner'` assignment
+  // targets `partners.id`, and a partner-wide policy carries `org_id NULL`.
+  const [org] = await db
+    .select({ partnerId: organizations.partnerId })
+    .from(organizations)
+    .where(eq(organizations.id, device.orgId))
+    .limit(1);
+
+  // Not reachable by the schema: `devices.org_id` is NOT NULL with an FK to
+  // `organizations.id`, and `organizations.partner_id` is itself NOT NULL. So an
+  // empty result means the invariant broke (org deleted mid-evaluation, or a
+  // caller whose context cannot see its own device's org). Say it out loud —
+  // falling through quietly would resolve in exactly the org-only way #3963
+  // exists to fix, just one join upstream, and be indistinguishable from
+  // "correctly found no policy". Resolution continues so the feature degrades
+  // rather than throwing.
+  if (!org) {
+    console.error(
+      `[warranty] org ${device.orgId} for device ${deviceId} did not resolve; partner-wide warranty policies cannot apply to this evaluation`
+    );
+    captureException(
+      new Error(`warranty: organizations row missing for device org ${device.orgId}`)
+    );
+  }
+
+  const groupRows = await db
+    .select({ groupId: deviceGroupMemberships.groupId })
+    .from(deviceGroupMemberships)
+    .where(eq(deviceGroupMemberships.deviceId, deviceId));
+  const groupIds = groupRows.map((r) => r.groupId);
+
+  // `config_policy_assignments.targetId` is POLYMORPHIC — its referent depends
+  // on `level` ('device' → devices.id, 'device_group' → device_groups.id,
+  // 'site' → sites.id, 'organization' → organizations.id, 'partner' →
+  // **partners.id**). So every id is matched against its OWN level rather than
+  // thrown into one `inArray` bag; that bag had no partner id in it at all,
+  // which is why a partner-level warranty assignment could never match (#3963).
+  const targetConditions: SQL[] = [
+    and(eq(configPolicyAssignments.level, 'device'), eq(configPolicyAssignments.targetId, deviceId))!,
+    and(eq(configPolicyAssignments.level, 'organization'), eq(configPolicyAssignments.targetId, device.orgId))!,
+  ];
+  if (groupIds.length > 0) {
+    targetConditions.push(
+      and(eq(configPolicyAssignments.level, 'device_group'), inArray(configPolicyAssignments.targetId, groupIds))!
+    );
+  }
+  if (device.siteId) {
+    targetConditions.push(
+      and(eq(configPolicyAssignments.level, 'site'), eq(configPolicyAssignments.targetId, device.siteId))!
+    );
+  }
+  if (org?.partnerId) {
+    targetConditions.push(
+      and(eq(configPolicyAssignments.level, 'partner'), eq(configPolicyAssignments.targetId, org.partnerId))!
+    );
+  }
+
+  const rows = await db
+    .select({
+      inlineSettings: configPolicyEffectiveFeatureLinks.inlineSettings,
+      level: configPolicyAssignments.level,
+      priority: configPolicyAssignments.priority,
+    })
+    .from(configPolicyEffectiveFeatureLinks)
+    .innerJoin(
+      configurationPolicies,
+      eq(configPolicyEffectiveFeatureLinks.configPolicyId, configurationPolicies.id)
+    )
+    .innerJoin(
+      configPolicyAssignments,
+      eq(configPolicyAssignments.configPolicyId, configurationPolicies.id)
+    )
+    .where(
+      and(
+        eq(configPolicyEffectiveFeatureLinks.featureType, 'warranty'),
+        eq(configurationPolicies.status, 'active'),
+        // Ownership axis, distinct from the assignment axis above: a
+        // partner-wide policy is `org_id NULL` + `partner_id` set (#1724), so a
+        // resolver must admit both shapes (#2930).
+        policyOwnershipCondition({ orgId: device.orgId, partnerId: org?.partnerId ?? null }),
+        or(...targetConditions)
+      )
+    );
+
+  if (rows.length === 0) return undefined;
+
+  rows.sort((a, b) => {
+    const la = LEVEL_PRIORITY[a.level] ?? 0;
+    const lb = LEVEL_PRIORITY[b.level] ?? 0;
+    if (la !== lb) return lb - la; // higher level priority wins
+    return b.priority - a.priority; // higher priority number wins
+  });
+
+  return rows[0]!.inlineSettings;
+}
+```
+
+- [ ] **Step 4: Reduce the alert evaluator to a projection**
+
+In `apps/api/src/services/warrantyAlertEvaluator.ts`, replace the whole of `resolveWarrantySettings` (`:50-186`, i.e. its doc comment through its closing brace) with:
+
+```ts
+/**
+ * Resolve warranty ALERT thresholds for a device from configuration policies.
+ *
+ * The hierarchy resolution itself lives in warrantyPolicyResolution.ts and is
+ * shared with the heartbeat's HP CMSL delivery (#5511 W02, D6) — a second copy
+ * would drift from this one's #3963 and #2930 fixes.
+ *
+ * Warranty alerting is opt-in: if no active warranty config policy is assigned
+ * to the device (directly or via group/site/org/partner), this returns
+ * DISABLED_SETTINGS so no alert fires (#1320). A policy that resolves with a
+ * null blob is a different case and keeps the per-link DEFAULT_SETTINGS.
+ */
+async function resolveWarrantySettings(deviceId: string): Promise<WarrantyAlertSettings> {
+  const inlineSettings = await resolveEffectiveWarrantyInlineSettings(deviceId);
+  if (inlineSettings === undefined) return DISABLED_SETTINGS;
+
+  const inline = inlineSettings as Partial<WarrantyAlertSettings> | null;
+  if (!inline) return DEFAULT_SETTINGS;
+
+  return {
+    enabled: inline.enabled ?? DEFAULT_SETTINGS.enabled,
+    warnDays: inline.warnDays ?? DEFAULT_SETTINGS.warnDays,
+    criticalDays: inline.criticalDays ?? DEFAULT_SETTINGS.criticalDays,
+  };
+}
+```
+
+Add the import:
+
+```ts
+import { resolveEffectiveWarrantyInlineSettings } from './warrantyPolicyResolution';
+```
+
+Then delete the now-unused imports from this file. After the replacement, `configPolicyEffectiveFeatureLinks`, `configPolicyAssignments`, `configurationPolicies`, `deviceGroupMemberships` and `organizations` are no longer referenced from `../db/schema` (keep `deviceWarranty`, `devices`, `alerts`), `inArray`/`or`/`type SQL` are no longer referenced from `drizzle-orm`, and `policyOwnershipCondition` is no longer used. **Let `tsc --noEmit` and `pnpm lint` tell you exactly which — do not delete an import this task did not orphan.**
+
+- [ ] **Step 5: Run the tests to verify green**
+
+Run: `cd apps/api && npx vitest run src/services/warrantyPolicyResolution.test.ts`
+Expected: PASS.
+
+Run the evaluator's own suites — behaviour must be unchanged:
+Run: `cd apps/api && npx vitest run src/services/warrantyAlertEvaluator`
+Expected: PASS. Check the reported file count and confirm it is non-zero; a substring filter that matches nothing reports "No test files found", which is not a pass.
+
+Run: `cd apps/api && npx tsc --noEmit`
+Expected: clean (this is what proves the orphaned imports were removed).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/services/warrantyPolicyResolution.ts apps/api/src/services/warrantyPolicyResolution.test.ts apps/api/src/services/warrantyAlertEvaluator.ts
+git commit -m "refactor(api): share effective-warranty-link resolution between alerting and agent delivery (#5511 W02 D6)"
+```
+
+---
+
+### Task 8: `buildWarrantyConfigUpdate` — the delivery builder and its revocation contract
+
+**Files:**
+- Modify: `apps/api/src/routes/agents/helpers.ts` (new section immediately after `buildPatchSourceConfigUpdate`, i.e. after `:2863`)
+- Test: `apps/api/src/routes/agents/helpers.warranty.test.ts` (new)
+
+**Interfaces:**
+- Consumes: Task 7's `resolveEffectiveWarrantyInlineSettings`; Task 1's `warrantyHpCmslCollectionEffective`.
+- Produces:
+  - `export interface WarrantySettings { hpCmslEnabled: boolean }`
+  - `export async function buildWarrantyConfigUpdate(deviceId: string): Promise<WarrantySettings>`
+
+**The revocation contract, copied verbatim from `buildPatchSourceConfigUpdate` (`helpers.ts:2852-2859`):** a successfully resolved *absent* policy returns `false` — the agent stops HP activity, so unassigning a policy cleanly reverts the endpoint. A resolver **error** must propagate, so the heartbeat's try/catch omits the block entirely and a transient database failure never revokes a whole fleet. These are different states; conflating them is how a fleet silently turns a feature off. Do not add a `try/catch` here.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/src/routes/agents/helpers.warranty.test.ts`. The module-mock preamble is `helpers.patchSource.test.ts:22-86` verbatim, plus a mock for the new resolver:
+
+```ts
+/**
+ * Tests for buildWarrantyConfigUpdate (#5511 W02) — the heartbeat helper that
+ * surfaces device-side HP CMSL collection to the agent.
+ *
+ * resolveEffectiveWarrantyInlineSettings is mocked directly (its hierarchy
+ * resolution is covered by warrantyPolicyResolution.test.ts), so this file pins
+ * only the mapping the heartbeat relies on:
+ *   - no warranty policy resolved (undefined) → { hpCmslEnabled: false }
+ *     (the revoke-on-unassign contract)
+ *   - resolved but not consented → false (never collect without an acceptance)
+ *   - resolver THROWS → rethrow, so the heartbeat omits the block
+ *
+ * The load-time module mocks mirror helpers.patchSource.test.ts so helpers.ts
+ * imports cleanly without a real DB/Redis.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { resolveEffectiveWarrantyInlineSettingsMock } = vi.hoisted(() => ({
+  resolveEffectiveWarrantyInlineSettingsMock: vi.fn(),
+}));
+
+vi.mock('../../db', () => ({
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: { select: vi.fn() },
+}));
+
+vi.mock('../../db/schema', () => ({
+  devices: {}, organizations: {}, deviceGroupMemberships: {},
+  configPolicyAssignments: {}, configurationPolicies: {}, configPolicyFeatureLinks: {},
+  pamOrgConfig: {}, softwarePolicies: {}, softwareComplianceStatus: {},
+  deviceCommands: { $inferSelect: {} }, deviceDisks: {}, deviceFilesystemSnapshots: {},
+  automationPolicies: {}, cisBaselines: {}, cisBaselineResults: {}, cisRemediationActions: {},
+  securityStatus: {}, securityThreats: {}, securityScans: {},
+  sensitiveDataFindings: {}, sensitiveDataScans: {}, sites: {}, users: {}, deviceGroups: {},
+  configPolicyMonitoringSettings: {}, configPolicyMonitoringWatches: {},
+  configPolicyEventLogSettings: {},
+}));
+
+vi.mock('../../services/redis', () => ({ getRedis: vi.fn(() => null) }));
+vi.mock('../../services/eventBus', () => ({ publishEvent: vi.fn() }));
+vi.mock('../../services/commandQueue', () => ({ queueCommandForExecution: vi.fn() }));
+vi.mock('../../services/cisHardening', () => ({ parseCisCollectorOutput: vi.fn() }));
+vi.mock('../../services/sentry', () => ({ captureException: vi.fn() }));
+vi.mock('../../services/cloudflareMtls', () => ({ CloudflareMtlsService: vi.fn() }));
+vi.mock('../../services/softwarePolicyService', () => ({ recordSoftwarePolicyAudit: vi.fn() }));
+vi.mock('../../services/featureConfigResolver', () => ({ resolvePatchConfigForDevice: vi.fn() }));
+vi.mock('../../services/warrantyPolicyResolution', () => ({
+  resolveEffectiveWarrantyInlineSettings: resolveEffectiveWarrantyInlineSettingsMock,
+}));
+vi.mock('../../services/filesystemAnalysis', () => ({
+  getFilesystemScanState: vi.fn(),
+  mergeFilesystemAnalysisPayload: vi.fn(),
+  parseFilesystemAnalysisStdout: vi.fn(),
+  readCheckpointPendingDirectories: vi.fn(),
+  readHotDirectories: vi.fn(),
+  saveFilesystemSnapshot: vi.fn(),
+  upsertFilesystemScanState: vi.fn(),
+}));
+vi.mock('../metrics', () => ({
+  recordSoftwareRemediationDecision: vi.fn(),
+  recordSensitiveDataFinding: vi.fn(),
+  recordSensitiveDataRemediationDecision: vi.fn(),
+}));
+vi.mock('../../jobs/softwareComplianceWorker', () => ({ scheduleSoftwareComplianceCheck: vi.fn() }));
+vi.mock('./policyProbeSafety', () => ({ isAllowedPolicyConfigProbe: vi.fn(() => true) }));
+
+import { HP_CMSL_EULA_ID } from '@breeze/shared/validators';
+import { buildWarrantyConfigUpdate } from './helpers';
+
+const DEVICE_ID = '00000000-0000-4000-8000-000000000001';
+const CONSENT = {
+  acceptedByUserId: 'user-1',
+  acceptedAt: '2026-09-10T00:00:00.000Z',
+  eulaId: HP_CMSL_EULA_ID,
+};
+
+describe('buildWarrantyConfigUpdate (#5511 W02)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns hpCmslEnabled:false when no warranty policy resolves (revoke-on-unassign)', async () => {
+    resolveEffectiveWarrantyInlineSettingsMock.mockResolvedValue(undefined);
+    await expect(buildWarrantyConfigUpdate(DEVICE_ID)).resolves.toEqual({ hpCmslEnabled: false });
+  });
+
+  it('returns true for a link that is enabled and consented against the current EULA id', async () => {
+    resolveEffectiveWarrantyInlineSettingsMock.mockResolvedValue({
+      enabled: true, warnDays: 90, criticalDays: 30,
+      hpCmsl: { enabled: true, consent: CONSENT },
+    });
+    await expect(buildWarrantyConfigUpdate(DEVICE_ID)).resolves.toEqual({ hpCmslEnabled: true });
+  });
+
+  it('returns false for an alerting-only link (the inheritance drop, contract D5)', async () => {
+    resolveEffectiveWarrantyInlineSettingsMock.mockResolvedValue({ enabled: true, warnDays: 14 });
+    await expect(buildWarrantyConfigUpdate(DEVICE_ID)).resolves.toEqual({ hpCmslEnabled: false });
+  });
+
+  it('returns false when the block is enabled but carries no acceptance', async () => {
+    resolveEffectiveWarrantyInlineSettingsMock.mockResolvedValue({ hpCmsl: { enabled: true } });
+    await expect(buildWarrantyConfigUpdate(DEVICE_ID)).resolves.toEqual({ hpCmslEnabled: false });
+  });
+
+  it('returns false when the acceptance names a superseded EULA id (contract D2)', async () => {
+    resolveEffectiveWarrantyInlineSettingsMock.mockResolvedValue({
+      hpCmsl: { enabled: true, consent: { ...CONSENT, eulaId: 'hp-cmsl-eula-2020-01-01' } },
+    });
+    await expect(buildWarrantyConfigUpdate(DEVICE_ID)).resolves.toEqual({ hpCmslEnabled: false });
+  });
+
+  it('returns false for a resolved-but-null blob', async () => {
+    resolveEffectiveWarrantyInlineSettingsMock.mockResolvedValue(null);
+    await expect(buildWarrantyConfigUpdate(DEVICE_ID)).resolves.toEqual({ hpCmslEnabled: false });
+  });
+
+  it('RETHROWS a resolver error rather than reporting false (no unintended revocation)', async () => {
+    resolveEffectiveWarrantyInlineSettingsMock.mockRejectedValue(new Error('boom'));
+    await expect(buildWarrantyConfigUpdate(DEVICE_ID)).rejects.toThrow('boom');
+  });
+});
+```
+
+That last case is the one that matters: it is the executable difference between "no policy" and "could not tell", and it is what stops a database blip from switching a fleet off.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api && npx vitest run src/routes/agents/helpers.warranty.test.ts`
+Expected: FAIL — `buildWarrantyConfigUpdate` is not exported from `./helpers`.
+
+- [ ] **Step 3: Write the builder**
+
+Add to `apps/api/src/routes/agents/helpers.ts`, immediately after `buildPatchSourceConfigUpdate` ends (`:2863`):
+
+```ts
+// ============================================
+// HP CMSL Warranty Collection Config (#5511 W02)
+// ============================================
+
+export interface WarrantySettings {
+  /**
+   * When true the (Windows-only) agent may collect HP warranty data on the
+   * device via HP's CMSL. False explicitly tells the agent to stop — so
+   * unassigning the policy, or a nearer policy replacing the link without an
+   * hpCmsl block, cleanly revokes collection.
+   */
+  hpCmslEnabled: boolean;
+}
+
+/**
+ * Resolves the warranty feature link for the device and surfaces the HP CMSL
+ * collection flag for the heartbeat config push. A device with no warranty
+ * policy assigned resolves to `false`, which the agent treats as "stop
+ * collecting". The caller (heartbeat) omits the block entirely on a resolver
+ * error so a transient failure never revokes collection fleet-wide — which is
+ * why this function deliberately does NOT catch.
+ *
+ * `warrantyHpCmslCollectionEffective` additionally requires an acceptance
+ * recorded against the CURRENT HP_CMSL_EULA_ID: an enabled block with no
+ * consent, or one naming superseded terms, delivers `false` (contract D2/D3).
+ * Collection never runs on an acceptance we cannot point at.
+ */
+export async function buildWarrantyConfigUpdate(deviceId: string): Promise<WarrantySettings> {
+  const inlineSettings = await resolveEffectiveWarrantyInlineSettings(deviceId);
+  return { hpCmslEnabled: warrantyHpCmslCollectionEffective(inlineSettings) };
+}
+```
+
+Add the two imports near the existing `resolvePatchConfigForDevice` import (`:56`):
+
+```ts
+import { resolveEffectiveWarrantyInlineSettings } from '../../services/warrantyPolicyResolution';
+import { warrantyHpCmslCollectionEffective } from '@breeze/shared/validators';
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/api && npx vitest run src/routes/agents/helpers.warranty.test.ts src/routes/agents/helpers.patchSource.test.ts`
+Expected: PASS, 2 files.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/agents/helpers.ts apps/api/src/routes/agents/helpers.warranty.test.ts
+git commit -m "feat(api): buildWarrantyConfigUpdate with patch_source's revocation contract (#5511 W02 D6)"
+```
+
+---
+
+### Task 9: Heartbeat wiring — `warranty_settings` on the wire
+
+**Files:**
+- Modify: `apps/api/src/routes/agents/heartbeat.ts` (import list `:21-38`; `PolicyConfigUpdates` `:1921-1926`; initialiser `:1927-1932`; locals + builder inside the shared context `:1935-1984`; wire assembly `:1993-2005`)
+- Modify: `apps/api/src/routes/agents/heartbeat.test.ts` (`vi.mock('./helpers')` factory `:167-176`; two new cases beside the patch-source pair at `:3114-3143`)
+
+**Interfaces:**
+- Consumes: Task 8's `buildWarrantyConfigUpdate` and `WarrantySettings`.
+- Produces: the wire block `configUpdate.warranty_settings = { hp_cmsl_enabled: boolean }`, consumed by Task 10's agent dispatch.
+
+**The camelCase→snake_case hop is deliberate.** The TypeScript type stays `{ hpCmslEnabled: boolean }`, matching `PatchSourceSettings` and every other builder in this file; the wire assembly at `:1993-2005` is already where camelCase names become snake_case keys, so the inner field is converted there too. That produces exactly contract D6's `{ "warranty_settings": { "hp_cmsl_enabled": true } }` without an ugly snake_case TypeScript interface. The agent accepts both spellings anyway (Task 10), and both are tested there.
+
+**Do not add a second `withSystemDbAccessContext`.** All four builders share one on purpose — the comment at `:1906-1911` says why: four separate system transactions would cost four connection acquisitions per heartbeat against a 25-connection production ceiling for no isolation gain. The new builder goes inside the existing one with its own try/catch.
+
+- [ ] **Step 1: Write the failing test**
+
+In `apps/api/src/routes/agents/heartbeat.test.ts`, add to the `vi.mock('./helpers', ...)` factory (`:167-176`), next to `buildPatchSourceConfigUpdate`:
+
+```ts
+  // Default OFF, mirroring buildPatchSourceConfigUpdate: every heartbeat test
+  // that does not care about warranty still exercises the delivery merge rather
+  // than the builder-throws path.
+  buildWarrantyConfigUpdate: vi.fn(async () => ({ hpCmslEnabled: false })),
+```
+
+Then add these two cases immediately after the `omits patch_source_settings when the patch resolver throws` case (`:3143`):
+
+```ts
+  it('includes warranty_settings in configUpdate when HP CMSL collection is enabled (#5511 W02)', async () => {
+    const { buildWarrantyConfigUpdate } = await import('./helpers');
+    vi.mocked(buildWarrantyConfigUpdate).mockResolvedValueOnce({ hpCmslEnabled: true });
+
+    const resp = await buildApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(minimalHeartbeatBody),
+    });
+
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as Record<string, unknown>;
+    const configUpdate = body.configUpdate as Record<string, unknown> | null;
+    // Snake_case INSIDE the block too — contract D6 pins the wire shape.
+    expect(configUpdate?.warranty_settings).toEqual({ hp_cmsl_enabled: true });
+  });
+
+  it('delivers warranty_settings false when no warranty policy resolves (revoke-on-unassign)', async () => {
+    const { buildWarrantyConfigUpdate } = await import('./helpers');
+    vi.mocked(buildWarrantyConfigUpdate).mockResolvedValueOnce({ hpCmslEnabled: false });
+
+    const resp = await buildApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(minimalHeartbeatBody),
+    });
+
+    const body = (await resp.json()) as Record<string, unknown>;
+    const configUpdate = body.configUpdate as Record<string, unknown> | null;
+    expect(configUpdate?.warranty_settings).toEqual({ hp_cmsl_enabled: false });
+  });
+
+  it('omits warranty_settings entirely when the warranty resolver throws (no unintended revocation)', async () => {
+    const { buildWarrantyConfigUpdate } = await import('./helpers');
+    vi.mocked(buildWarrantyConfigUpdate).mockRejectedValueOnce(new Error('boom'));
+
+    const resp = await buildApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(minimalHeartbeatBody),
+    });
+
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as Record<string, unknown>;
+    const configUpdate = body.configUpdate as Record<string, unknown> | null;
+    expect(configUpdate?.warranty_settings).toBeUndefined();
+  });
+```
+
+The middle case is not redundant with the third: `false` and *absent* are different instructions to the agent, and only asserting both proves the builder's two failure modes did not collapse into one.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api && npx vitest run src/routes/agents/heartbeat.test.ts`
+Expected: FAIL — `configUpdate?.warranty_settings` is `undefined` in the first two cases (nothing builds or merges it yet). The third case passes vacuously today; that is expected, and it becomes meaningful once the block exists.
+
+- [ ] **Step 3: Import the builder**
+
+Add `buildWarrantyConfigUpdate,` to the `'./helpers'` import block (`:21-38`), directly after `buildPatchSourceConfigUpdate,` (`:31`).
+
+- [ ] **Step 4: Extend `PolicyConfigUpdates` and its initialiser**
+
+`:1921-1932` becomes:
+
+```ts
+  type PolicyConfigUpdates = {
+    eventLogSettings: Record<string, unknown> | null;
+    monitoringSettings: Record<string, unknown> | null;
+    pamSettings: { uacInterceptionEnabled: boolean } | null;
+    patchSourceSettings: { exclusiveWindowsUpdate: boolean } | null;
+    warrantySettings: { hpCmslEnabled: boolean } | null;
+  };
+  let policyConfigs: PolicyConfigUpdates = {
+    eventLogSettings: null,
+    monitoringSettings: null,
+    pamSettings: null,
+    patchSourceSettings: null,
+    warrantySettings: null,
+  };
+```
+
+- [ ] **Step 5: Build it inside the existing shared system context**
+
+Add the local beside the other four (`:1935-1938`):
+
+```ts
+      let warrantySettings: { hpCmslEnabled: boolean } | null = null;
+```
+
+and the builder immediately after the patch-source block (`:1982`), before the `return`:
+
+```ts
+      // #5511 W02: device-side HP CMSL warranty collection. Same shape and same
+      // reason as patch_source above — omit the block on a resolver error so a
+      // transient failure never stops collection on a consented fleet; a
+      // successful resolve with no warranty policy (or a nearer policy that
+      // replaced the link without an hpCmsl block, contract D5) returns false
+      // → the agent stops.
+      try {
+        warrantySettings = await buildWarrantyConfigUpdate(scoped.deviceId);
+      } catch (err) {
+        console.error(`[agents] failed to build warranty config update for ${agentId}:`, err);
+        captureException(err);
+      }
+```
+
+and extend the return (`:1984`):
+
+```ts
+      return { eventLogSettings, monitoringSettings, pamSettings, patchSourceSettings, warrantySettings };
+```
+
+- [ ] **Step 6: Merge it into the wire payload**
+
+`:1993` and `:2003-2004` become:
+
+```ts
+  const { eventLogSettings, monitoringSettings, pamSettings, patchSourceSettings, warrantySettings } = policyConfigs;
+```
+
+```ts
+  if (patchSourceSettings) {
+    policyConfigUpdate.patch_source_settings = patchSourceSettings;
+  }
+  // Snake_case inside the block as well as outside (contract D6): this
+  // assembly is where camelCase resolver output becomes wire keys, and the
+  // agent's inner parse accepts either spelling.
+  if (warrantySettings) {
+    policyConfigUpdate.warranty_settings = { hp_cmsl_enabled: warrantySettings.hpCmslEnabled };
+  }
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `cd apps/api && npx vitest run src/routes/agents/heartbeat.test.ts`
+Expected: PASS. Note the file is ~5,500 lines and holds the delivery-merge cases for four other features; all must stay green.
+
+Run: `cd apps/api && npx tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/api/src/routes/agents/heartbeat.ts apps/api/src/routes/agents/heartbeat.test.ts
+git commit -m "feat(api): deliver warranty_settings.hp_cmsl_enabled on the heartbeat config update (#5511 W02 D6)"
+```
+
+---
+
+### Task 10: Agent — the `warranty_config.go` seam and the dispatch that must sit above line 2918
+
+**Files:**
+- Modify: `agent/internal/config/config.go` (new field beside `RequireManifestSigningKeyID` at `:207`; new `viper.Set` in `saveToLocked` beside `:726`)
+- Create: `agent/internal/heartbeat/warranty_config.go`
+- Create: `agent/internal/heartbeat/warranty_config_test.go`
+- Modify: `agent/internal/heartbeat/heartbeat.go` (dispatch inserted after `:2916`, before `:2918`)
+
+**Interfaces:**
+- Consumes: the wire block `warranty_settings` from Task 9.
+- Produces, all unexported (contract D7) and all consumed by W03:
+  - `var persistWarrantyCollectionEnabled = setWarrantyCollectionEnabled` — the package-level func var tests swap
+  - `func (h *Heartbeat) applyWarrantyConfig(raw any)`
+  - `func (h *Heartbeat) hpWarrantyCollectionEnabled() bool` — the mutex-guarded accessor W03's collector reads
+  - `config.Config.HPWarrantyCollectionEnabled bool` (`mapstructure:"hp_warranty_collection_enabled"`)
+
+**THE TRAP, stated plainly.** `applyConfigUpdate` (`heartbeat.go:2851`) has two halves. Everything from `:2918` is the policy-probe path, and it hits an **unconditional `return`** at `:2928-2930` when neither probe key is present — which is most heartbeats. A `warranty_settings` check added below that line compiles, passes review, and is silently unreachable in production. **The dispatch goes immediately after the onedrive block closes at `:2916` and before `registryRaw` at `:2918`.** This is the single easiest way to ship a feature that never fires, and the test in step 1 is what proves it did not happen: it drives `h.applyConfigUpdate` with an update that contains **no probe keys**, so a misplaced dispatch fails the test rather than shipping.
+
+**Why the seam exists at all.** `patch_source.go:7-11` records the reason for its own: the dispatch + payload-parse path is where a key-name regression silently disables a whole feature, and it must be unit-tested even though the platform I/O cannot run on a CI runner. Here the platform I/O is `config.SetAndPersist`, which writes `agent.yaml` through viper and fails on a runner with no config file — so the var is the persistence call, and the test captures the resolved bool without touching disk.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `agent/internal/heartbeat/warranty_config_test.go`:
+
+```go
+package heartbeat
+
+import (
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/config"
+)
+
+// TestApplyWarrantyConfig_DispatchAndParse pins the two things that silently
+// break this feature: the key names, and WHERE the dispatch sits inside
+// applyConfigUpdate. Every case below is driven through applyConfigUpdate with
+// an update carrying NO policy-probe keys — the probe path returns
+// unconditionally when none are present, so a dispatch added below it would
+// fail here instead of shipping unreachable.
+func TestApplyWarrantyConfig_DispatchAndParse(t *testing.T) {
+	tests := []struct {
+		name        string
+		start       bool
+		update      map[string]any
+		wantCalled  bool
+		wantEnabled bool
+		wantMemory  bool
+	}{
+		{
+			name:        "snake_case block + snake_case field, true (the wire shape the API sends)",
+			update:      map[string]any{"warranty_settings": map[string]any{"hp_cmsl_enabled": true}},
+			wantCalled:  true,
+			wantEnabled: true,
+			wantMemory:  true,
+		},
+		{
+			name:        "camelCase block + camelCase field, true",
+			update:      map[string]any{"warrantySettings": map[string]any{"hpCmslEnabled": true}},
+			wantCalled:  true,
+			wantEnabled: true,
+			wantMemory:  true,
+		},
+		{
+			name:        "revocation: true → false persists and clears memory",
+			start:       true,
+			update:      map[string]any{"warranty_settings": map[string]any{"hp_cmsl_enabled": false}},
+			wantCalled:  true,
+			wantEnabled: false,
+			wantMemory:  false,
+		},
+		{
+			name:       "unchanged value does not rewrite agent.yaml",
+			start:      true,
+			update:     map[string]any{"warranty_settings": map[string]any{"hp_cmsl_enabled": true}},
+			wantCalled: false,
+			wantMemory: true,
+		},
+		{
+			name:       "missing field → no-op",
+			update:     map[string]any{"warranty_settings": map[string]any{}},
+			wantCalled: false,
+		},
+		{
+			name:       "non-boolean field → no-op",
+			update:     map[string]any{"warranty_settings": map[string]any{"hp_cmsl_enabled": "yes"}},
+			wantCalled: false,
+		},
+		{
+			name:       "non-object payload → no-op",
+			update:     map[string]any{"warranty_settings": "enabled"},
+			wantCalled: false,
+		},
+		{
+			name:       "block absent entirely → no-op",
+			update:     map[string]any{"event_log_settings": map[string]any{}},
+			wantCalled: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			orig := persistWarrantyCollectionEnabled
+			t.Cleanup(func() { persistWarrantyCollectionEnabled = orig })
+			var got *bool
+			persistWarrantyCollectionEnabled = func(enabled bool) error {
+				e := enabled
+				got = &e
+				return nil
+			}
+
+			cfg := config.Default()
+			cfg.HPWarrantyCollectionEnabled = tt.start
+			h := &Heartbeat{config: cfg}
+			h.applyConfigUpdate(tt.update)
+
+			if tt.wantCalled {
+				if got == nil {
+					t.Fatalf("persistence was not invoked; expected it with enabled=%v", tt.wantEnabled)
+				}
+				if *got != tt.wantEnabled {
+					t.Errorf("persisted enabled = %v, want %v", *got, tt.wantEnabled)
+				}
+			} else if got != nil {
+				t.Errorf("persistence was invoked (enabled=%v) but the payload should have been a no-op", *got)
+			}
+
+			if tt.wantCalled || tt.start {
+				if h.hpWarrantyCollectionEnabled() != tt.wantMemory {
+					t.Errorf("in-memory flag = %v, want %v", h.hpWarrantyCollectionEnabled(), tt.wantMemory)
+				}
+			}
+		})
+	}
+}
+
+// A persistence failure must not leave the in-memory flag disagreeing with what
+// the control plane just said: the agent keeps applying the pushed value for
+// this process and re-persists on the next heartbeat that changes it.
+func TestApplyWarrantyConfig_PersistFailureKeepsInMemoryValue(t *testing.T) {
+	orig := persistWarrantyCollectionEnabled
+	t.Cleanup(func() { persistWarrantyCollectionEnabled = orig })
+	persistWarrantyCollectionEnabled = func(bool) error { return errPersistStub }
+
+	h := &Heartbeat{config: config.Default()}
+	h.applyConfigUpdate(map[string]any{"warranty_settings": map[string]any{"hp_cmsl_enabled": true}})
+
+	if !h.hpWarrantyCollectionEnabled() {
+		t.Fatal("in-memory flag was not set after a persistence failure")
+	}
+}
+```
+
+Add the stub error at the bottom of the test file:
+
+```go
+type persistStubError struct{}
+
+func (persistStubError) Error() string { return "stub persist failure" }
+
+var errPersistStub = persistStubError{}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd agent && go test -race ./internal/heartbeat/... -run TestApplyWarrantyConfig`
+Expected: FAIL to COMPILE — `undefined: persistWarrantyCollectionEnabled`, `h.hpWarrantyCollectionEnabled undefined`, `cfg.HPWarrantyCollectionEnabled undefined`.
+
+- [ ] **Step 3: Add the config field**
+
+`agent/internal/config/config.go` — add after `RequireManifestSigningKeyID` (`:207`):
+
+```go
+	// HPWarrantyCollectionEnabled is the control-plane switch for device-side
+	// HP warranty collection via HP's CMSL (#5511). Pushed on the heartbeat as
+	// warranty_settings.hp_cmsl_enabled and persisted so the setting survives a
+	// restart; the collector reads it through
+	// Heartbeat.hpWarrantyCollectionEnabled().
+	//
+	// Default false. Collection installs and runs HP software on the endpoint
+	// and is opt-in per configuration policy, so an agent that has never been
+	// told anything must do nothing.
+	HPWarrantyCollectionEnabled bool `mapstructure:"hp_warranty_collection_enabled" yaml:"hp_warranty_collection_enabled"`
+```
+
+and add to `saveToLocked` after `:726`:
+
+```go
+	viper.Set("hp_warranty_collection_enabled", cfg.HPWarrantyCollectionEnabled)
+```
+
+`Default()` needs no entry — the zero value is the intended default, exactly as for `RequireManifestSigningKeyID`.
+
+- [ ] **Step 4: Write the seam**
+
+Create `agent/internal/heartbeat/warranty_config.go`:
+
+```go
+package heartbeat
+
+import (
+	"github.com/breeze-rmm/agent/internal/config"
+)
+
+// warrantyCollectionConfigKey is the agent.yaml key the pushed flag persists to.
+const warrantyCollectionConfigKey = "hp_warranty_collection_enabled"
+
+// persistWarrantyCollectionEnabled is the seam to the on-disk write. A package
+// var so tests can capture the resolved bool on any platform without a config
+// file present — the dispatch + payload-parse path is where a key-name
+// regression would silently disable the whole feature, so it must be
+// unit-tested even though viper.WriteConfig cannot run on the CI agent.
+var persistWarrantyCollectionEnabled = setWarrantyCollectionEnabled
+
+func setWarrantyCollectionEnabled(enabled bool) error {
+	return config.SetAndPersist(warrantyCollectionConfigKey, enabled)
+}
+
+// applyWarrantyConfig handles the warranty_settings block from the heartbeat
+// config update (#5511 W02). True permits device-side HP warranty collection
+// via HP's CMSL; false stops it — which is what a device with no warranty
+// policy, or one whose nearest policy dropped the hpCmsl block, receives. The
+// server omits the block entirely when it could not resolve, so an absent key
+// means "no change", never "off".
+//
+// The API sends snake_case inside the block; camelCase is accepted first here
+// to match patch_source.go's parse, and both spellings are covered by tests.
+func (h *Heartbeat) applyWarrantyConfig(raw any) {
+	m, ok := raw.(map[string]any)
+	if !ok {
+		log.Warn("ignoring invalid warranty_settings payload: not an object")
+		return
+	}
+
+	v, present := m["hpCmslEnabled"]
+	if !present {
+		v, present = m["hp_cmsl_enabled"]
+	}
+	if !present {
+		log.Warn("warranty_settings received without hpCmslEnabled field")
+		return
+	}
+	enabled, ok := v.(bool)
+	if !ok {
+		log.Warn("ignoring warranty_settings: hpCmslEnabled is not a boolean")
+		return
+	}
+
+	h.mu.Lock()
+	changed := h.config.HPWarrantyCollectionEnabled != enabled
+	h.config.HPWarrantyCollectionEnabled = enabled
+	h.mu.Unlock()
+
+	// The in-memory value is what the collector reads, so it is always updated.
+	// Only a CHANGE is written to disk: this runs on every heartbeat, and
+	// rewriting agent.yaml each minute would be pointless churn.
+	if !changed {
+		return
+	}
+
+	if err := persistWarrantyCollectionEnabled(enabled); err != nil {
+		// Keep the in-memory value. The control plane's instruction still
+		// applies for this process and is re-persisted the next time it
+		// changes; reverting here would ignore a live instruction because a
+		// file write failed.
+		log.Warn("failed to persist hp_warranty_collection_enabled", "error", err.Error())
+		return
+	}
+	if enabled {
+		log.Info("HP CMSL warranty collection enabled by control plane")
+	} else {
+		log.Info("HP CMSL warranty collection disabled by control plane")
+	}
+}
+
+// hpWarrantyCollectionEnabled reads the flag under h.mu. The (W03) collector
+// calls this rather than reading h.config directly, so a value pushed mid-run
+// takes effect on the next collection with no restart.
+func (h *Heartbeat) hpWarrantyCollectionEnabled() bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.config.HPWarrantyCollectionEnabled
+}
+```
+
+- [ ] **Step 5: Add the dispatch ABOVE the probe path**
+
+In `agent/internal/heartbeat/heartbeat.go`, insert between the onedrive block's closing brace (`:2916`) and `registryRaw` (`:2918`):
+
+```go
+	// Apply warranty_settings if present (#5511 W02): permit or stop device-side
+	// HP CMSL warranty collection. No-op on non-Windows.
+	//
+	// THIS MUST STAY ABOVE THE POLICY-PROBE BLOCK BELOW. That block returns
+	// unconditionally when neither probe key is present, which is most
+	// heartbeats — a key dispatched after it is silently unreachable in
+	// production with nothing in the logs to show for it.
+	warRaw, hasWar := update["warranty_settings"]
+	if !hasWar {
+		warRaw, hasWar = update["warrantySettings"]
+	}
+	if hasWar {
+		h.applyWarrantyConfig(warRaw)
+	}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd agent && go test -race ./internal/heartbeat/... -run TestApplyWarrantyConfig`
+Expected: PASS.
+
+Then the whole packages, since `config.Config` and `applyConfigUpdate` are widely used:
+Run: `cd agent && go test -race ./internal/heartbeat/... ./internal/config/...`
+Expected: PASS.
+
+Run: `cd agent && go build ./...`
+Expected: clean.
+
+- [ ] **Step 7: Prove the placement, not just the parse**
+
+Temporarily move the new dispatch block to sit **after** the `if !hasRegistry && !hasConfig { return }` at `:2928-2930`, re-run `cd agent && go test -race ./internal/heartbeat/... -run TestApplyWarrantyConfig`, and confirm every `wantCalled: true` case FAILS. Then move it back and re-run to confirm PASS.
+
+This is the one control worth spending two minutes on: it is the difference between a test that pins the key names and a test that pins the key names *and* the reachability. Do not skip it and do not commit the moved version.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add agent/internal/config/config.go agent/internal/heartbeat/warranty_config.go agent/internal/heartbeat/warranty_config_test.go agent/internal/heartbeat/heartbeat.go
+git commit -m "feat(agent): dispatch warranty_settings above the probe path through a testable seam (#5511 W02 D6/D7)"
+```
+
+---
+
+### Task 11: Locale catalogs — six new `warrantyTab` keys in all eight locales
+
+**Files:** Modify `apps/web/src/locales/<locale>/policies.json` for `en`, `de-DE`, `es-419`, `fr-CA`, `fr-FR`, `it-IT`, `pt-BR`, `tr-TR`.
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces six keys under `configurationPolicies.featureTabs.warrantyTab`, consumed by Task 12:
+  `collectHpWarrantyFromTheDevice`, `hpCmslConsentExplainer`, `hpCmslNoAcceptanceRecordedYet`, `hpCmslAcceptedByOn` (interpolates `{{user}}` and `{{date}}`), `hpCmslTermsChangedSaveAgain`, `hpCmslInheritanceReplacesTheWholeLink`.
+
+**Why this is its own task, and why English cannot simply be copied.** Three separate guards apply. `localeParity.test.ts:457-461` requires the key SET to match `en` exactly in every locale, so all eight files change together or CI is red. `translationCoverage.test.ts:764-778` counts exact-English duplicates per namespace against a hard baseline, so pasting the English string into the seven translated catalogs fails. `localeParity.test.ts:513-524` requires each `protectedNames` entry to occur the same number of times in the translation as in English — `IP` is on that list and appears exactly once in the explainer, so **every translation must contain `IP` exactly once**. `terminologyQuality.test.ts:40-49`'s forbidden patterns are avoided throughout (no bare `voce`, `comecar`, `esta ativa`; no `postuler`, `subventions`; no `Hauptschalter`; no `potrài`).
+
+`keyUsage.test.ts:336` checks key→catalog only, so landing the catalogs before the component is fine and keeps this task independently reviewable.
+
+- [ ] **Step 1: Run the guards first, to see them green before the change**
+
+Run: `cd apps/web && npx vitest run src/lib/i18n/localeParity.test.ts src/lib/i18n/translationCoverage.test.ts src/lib/i18n/terminologyQuality.test.ts src/lib/i18n/keyUsage.test.ts`
+Expected: PASS, 4 files. This is the baseline; if any of these is already red on your branch, fix that first — you will not be able to read your own result otherwise.
+
+- [ ] **Step 2: Add the six keys to `en` only, and watch parity go red**
+
+In `apps/web/src/locales/en/policies.json`, add a comma after the `"criticalDays"` entry (`:1178`) and insert before the closing brace of `warrantyTab` (`:1179`):
+
+```json
+        "collectHpWarrantyFromTheDevice": "Collect HP warranty from the device",
+        "hpCmslConsentExplainer": "HP warranty data is read on the device using HP's Client Management Script Library. Ticking this box accepts HP's licence on this customer's behalf, and HP may collect technical information from the device, including its IP address. Left unticked, HP devices keep whatever warranty status they already have.",
+        "hpCmslNoAcceptanceRecordedYet": "No acceptance recorded yet. Saving with this box ticked records your user and the server time.",
+        "hpCmslAcceptedByOn": "Accepted by {{user}} on {{date}}",
+        "hpCmslTermsChangedSaveAgain": "HP has changed its licence terms since this acceptance. Save again to re-accept.",
+        "hpCmslInheritanceReplacesTheWholeLink": "This policy replaces the inherited warranty settings as a whole, with no field-by-field merge. Saving it with device collection switched off stops HP warranty collection on every device this policy reaches."
+```
+
+Run: `cd apps/web && npx vitest run src/lib/i18n/localeParity.test.ts`
+Expected: FAIL — seven `<locale> matches en namespace files and keys exactly` cases, each naming the six missing keys. That failure is the point: it is the mechanism that stops a half-translated feature shipping.
+
+- [ ] **Step 3: Add the translations**
+
+`de-DE`:
+
+```json
+        "collectHpWarrantyFromTheDevice": "HP-Garantiedaten auf dem Gerät erfassen",
+        "hpCmslConsentExplainer": "HP-Garantiedaten werden auf dem Gerät mit der Client Management Script Library von HP gelesen. Mit diesem Kontrollkästchen akzeptieren Sie die HP-Lizenz im Namen dieses Kunden, und HP darf technische Informationen vom Gerät erfassen, einschließlich der IP-Adresse. Bleibt es leer, behalten HP-Geräte den Garantiestatus, den sie bereits haben.",
+        "hpCmslNoAcceptanceRecordedYet": "Noch keine Zustimmung erfasst. Beim Speichern mit gesetztem Kontrollkästchen werden Ihr Benutzer und die Serverzeit erfasst.",
+        "hpCmslAcceptedByOn": "Akzeptiert von {{user}} am {{date}}",
+        "hpCmslTermsChangedSaveAgain": "HP hat seine Lizenzbedingungen seit dieser Zustimmung geändert. Speichern Sie erneut, um erneut zuzustimmen.",
+        "hpCmslInheritanceReplacesTheWholeLink": "Diese Richtlinie ersetzt die geerbten Garantieeinstellungen vollständig, ohne feldweise Zusammenführung. Wird sie mit deaktivierter Erfassung gespeichert, endet die HP-Garantieerfassung auf jedem Gerät, das diese Richtlinie erreicht."
+```
+
+`es-419`:
+
+```json
+        "collectHpWarrantyFromTheDevice": "Recopilar la garantía HP desde el dispositivo",
+        "hpCmslConsentExplainer": "Los datos de garantía de HP se leen en el dispositivo con la Client Management Script Library de HP. Al marcar esta casilla acepta la licencia de HP en nombre de este cliente, y HP puede recopilar información técnica del dispositivo, incluida su dirección IP. Si la deja sin marcar, los dispositivos HP conservan el estado de garantía que ya tienen.",
+        "hpCmslNoAcceptanceRecordedYet": "Aún no hay aceptación registrada. Al guardar con esta casilla marcada se registran su usuario y la hora del servidor.",
+        "hpCmslAcceptedByOn": "Aceptado por {{user}} el {{date}}",
+        "hpCmslTermsChangedSaveAgain": "HP cambió sus términos de licencia desde esta aceptación. Guarde de nuevo para volver a aceptar.",
+        "hpCmslInheritanceReplacesTheWholeLink": "Esta política reemplaza por completo la configuración de garantía heredada, sin combinación campo por campo. Si la guarda con la recopilación en el dispositivo desactivada, se detiene la recopilación de garantía HP en todos los dispositivos que alcanza."
+```
+
+`fr-FR`:
+
+```json
+        "collectHpWarrantyFromTheDevice": "Collecter la garantie HP depuis l'appareil",
+        "hpCmslConsentExplainer": "Les données de garantie HP sont lues sur l'appareil à l'aide de la Client Management Script Library de HP. Cocher cette case accepte la licence HP au nom de ce client, et HP peut collecter des informations techniques depuis l'appareil, y compris son adresse IP. Laissée décochée, les appareils HP conservent l'état de garantie qu'ils possèdent déjà.",
+        "hpCmslNoAcceptanceRecordedYet": "Aucune acceptation enregistrée pour l'instant. L'enregistrement avec cette case cochée consigne votre utilisateur et l'heure du serveur.",
+        "hpCmslAcceptedByOn": "Accepté par {{user}} le {{date}}",
+        "hpCmslTermsChangedSaveAgain": "HP a modifié ses conditions de licence depuis cette acceptation. Enregistrez de nouveau pour accepter à nouveau.",
+        "hpCmslInheritanceReplacesTheWholeLink": "Cette stratégie remplace entièrement les paramètres de garantie hérités, sans fusion champ par champ. L'enregistrer avec la collecte sur l'appareil désactivée arrête la collecte de garantie HP sur tous les appareils qu'elle atteint."
+```
+
+`fr-CA` (same terminology, Canadian phrasing on the first and third entries):
+
+```json
+        "collectHpWarrantyFromTheDevice": "Recueillir la garantie HP à partir de l'appareil",
+        "hpCmslConsentExplainer": "Les données de garantie HP sont lues sur l'appareil à l'aide de la Client Management Script Library de HP. Cocher cette case accepte la licence HP au nom de ce client, et HP peut collecter des informations techniques depuis l'appareil, y compris son adresse IP. Laissée décochée, les appareils HP conservent l'état de garantie qu'ils possèdent déjà.",
+        "hpCmslNoAcceptanceRecordedYet": "Aucune acceptation n'est enregistrée pour le moment. L'enregistrement avec cette case cochée consigne votre utilisateur et l'heure du serveur.",
+        "hpCmslAcceptedByOn": "Accepté par {{user}} le {{date}}",
+        "hpCmslTermsChangedSaveAgain": "HP a modifié ses conditions de licence depuis cette acceptation. Enregistrez de nouveau pour accepter à nouveau.",
+        "hpCmslInheritanceReplacesTheWholeLink": "Cette stratégie remplace entièrement les paramètres de garantie hérités, sans fusion champ par champ. L'enregistrer avec la collecte sur l'appareil désactivée arrête la collecte de garantie HP sur tous les appareils qu'elle atteint."
+```
+
+`it-IT`:
+
+```json
+        "collectHpWarrantyFromTheDevice": "Raccogli la garanzia HP dal dispositivo",
+        "hpCmslConsentExplainer": "I dati di garanzia HP vengono letti sul dispositivo tramite la Client Management Script Library di HP. Selezionando questa casella si accetta la licenza HP per conto di questo cliente e HP può raccogliere informazioni tecniche dal dispositivo, incluso il suo indirizzo IP. Se resta deselezionata, i dispositivi HP mantengono lo stato di garanzia che hanno già.",
+        "hpCmslNoAcceptanceRecordedYet": "Nessuna accettazione registrata finora. Salvando con questa casella selezionata vengono registrati il tuo utente e l'ora del server.",
+        "hpCmslAcceptedByOn": "Accettato da {{user}} il {{date}}",
+        "hpCmslTermsChangedSaveAgain": "HP ha modificato le condizioni di licenza dopo questa accettazione. Salva di nuovo per accettare nuovamente.",
+        "hpCmslInheritanceReplacesTheWholeLink": "Questo criterio sostituisce per intero le impostazioni di garanzia ereditate, senza alcuna unione campo per campo. Salvandolo con la raccolta sul dispositivo disattivata si interrompe la raccolta della garanzia HP su ogni dispositivo che raggiunge."
+```
+
+`pt-BR`:
+
+```json
+        "collectHpWarrantyFromTheDevice": "Coletar a garantia HP do dispositivo",
+        "hpCmslConsentExplainer": "Os dados de garantia da HP são lidos no dispositivo com a Client Management Script Library da HP. Marcar esta caixa aceita a licença da HP em nome deste cliente, e a HP pode coletar informações técnicas do dispositivo, incluindo o endereço IP. Se ficar desmarcada, os dispositivos HP mantêm o status de garantia que já possuem.",
+        "hpCmslNoAcceptanceRecordedYet": "Nenhuma aceitação registrada até agora. Ao salvar com esta caixa marcada, seu usuário e o horário do servidor são registrados.",
+        "hpCmslAcceptedByOn": "Aceito por {{user}} em {{date}}",
+        "hpCmslTermsChangedSaveAgain": "A HP alterou os termos de licença desde esta aceitação. Salve novamente para aceitar de novo.",
+        "hpCmslInheritanceReplacesTheWholeLink": "Esta política substitui por completo as configurações de garantia herdadas, sem mesclagem campo a campo. Salvá-la com a coleta no dispositivo desativada interrompe a coleta de garantia HP em todos os dispositivos que ela alcança."
+```
+
+`tr-TR`:
+
+```json
+        "collectHpWarrantyFromTheDevice": "HP garantisini cihazdan topla",
+        "hpCmslConsentExplainer": "HP garanti verileri, HP'nin Client Management Script Library aracı kullanılarak cihaz üzerinde okunur. Bu kutuyu işaretlemek HP lisansını bu müşteri adına kabul eder ve HP, IP adresi dahil olmak üzere cihazdan teknik bilgi toplayabilir. İşaretlenmezse HP cihazları mevcut garanti durumlarını korur.",
+        "hpCmslNoAcceptanceRecordedYet": "Henüz kayıtlı bir kabul yok. Bu kutu işaretliyken kaydettiğinizde kullanıcınız ve sunucu saati kaydedilir.",
+        "hpCmslAcceptedByOn": "{{date}} tarihinde {{user}} tarafından kabul edildi",
+        "hpCmslTermsChangedSaveAgain": "HP, bu kabulden bu yana lisans koşullarını değiştirdi. Yeniden kabul etmek için tekrar kaydedin.",
+        "hpCmslInheritanceReplacesTheWholeLink": "Bu ilke, devralınan garanti ayarlarının tamamını değiştirir; alan alan birleştirme yoktur. Cihaz üzerinde toplama kapalıyken kaydedilmesi, bu ilkenin ulaştığı her cihazda HP garanti toplamayı durdurur."
+```
+
+Note the `tr-TR` `hpCmslAcceptedByOn` puts `{{date}}` before `{{user}}` — Turkish word order. The parity check compares interpolation tokens as a SORTED set (`localeParity.test.ts:38-41`), so re-ordering is allowed and dropping one is not.
+
+- [ ] **Step 4: Run every i18n guard to verify green**
+
+Run: `cd apps/web && npx vitest run src/lib/i18n/localeParity.test.ts src/lib/i18n/translationCoverage.test.ts src/lib/i18n/terminologyQuality.test.ts src/lib/i18n/extractionQuality.test.ts src/lib/i18n/keyUsage.test.ts`
+Expected: PASS, 5 files.
+
+If `localeParity` reports a `preserves source-aligned technical literals and names` failure, it will name the key and the literal: count the occurrences of that literal in the English string and match it exactly in the translation. `IP` is the one to expect.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/locales/en/policies.json apps/web/src/locales/de-DE/policies.json apps/web/src/locales/es-419/policies.json apps/web/src/locales/fr-CA/policies.json apps/web/src/locales/fr-FR/policies.json apps/web/src/locales/it-IT/policies.json apps/web/src/locales/pt-BR/policies.json apps/web/src/locales/tr-TR/policies.json
+git commit -m "i18n(web): HP CMSL consent and inheritance copy for the warranty policy tab (#5511 W02)"
+```
+
+---
+
+### Task 12: WarrantyTab — the opt-in checkbox, the consent copy, the recorded acceptance, and the inheritance warning
+
+**Files:**
+- Modify: `apps/web/src/components/configurationPolicies/featureTabs/WarrantyTab.tsx` (whole file)
+- Modify: `apps/web/src/components/configurationPolicies/featureTabs/WarrantyTab.test.tsx`
+
+**Interfaces:**
+- Consumes: Task 11's six locale keys; Task 1's `HP_CMSL_EULA_ID`, `readRecordedWarrantyHpCmslConsent`, `warrantyHpCmslCollectionEffective` — imported from the **root** `@breeze/shared` barrel, because `apps/web/tsconfig.json:7-8` and `apps/web/vitest.config.ts:18-22` alias only `@breeze/shared` and `@breeze/shared/reportPdf`.
+- Produces: `data-testid` hooks `warranty-tab-hp-cmsl-toggle`, `warranty-tab-hp-cmsl-consent`, `warranty-tab-hp-cmsl-acceptance`, `warranty-tab-hp-cmsl-superseded`, `warranty-tab-inheritance-warning`.
+
+**Two things this component must get right or the feature breaks.**
+
+1. **It must never send `consent` back.** `useFeatureLink.ts:34` posts `payload.inlineSettings` verbatim, and the tab reads the recorded consent out of the saved link in order to display it. Echoing it on the next save trips Task 3's coded 400 on *every* subsequent edit. The fix is structural, not a `delete`: local state holds a flat `hpCmslEnabled` boolean and the save payload REBUILDS `{ hpCmsl: { enabled } }`, so there is no code path on which a consent object can reach the request body.
+2. **It must surface the inheritance drop (contract D5).** Policy resolution picks a whole link. A child policy carrying only alert thresholds replaces an inherited link and drops its `hpCmsl` block, silently revoking collection on every device it reaches. The warning below is the only place a technician can learn that before pressing Save.
+
+- [ ] **Step 1: Write the failing test**
+
+Replace `apps/web/src/components/configurationPolicies/featureTabs/WarrantyTab.test.tsx` with:
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import WarrantyTab from './WarrantyTab';
+import { HP_CMSL_EULA_ID } from '@breeze/shared';
+
+// useFeatureLink wraps the save/remove API calls; stub it so we can assert the
+// payload the tab submits without hitting the network.
+const saveMock = vi.fn(async () => ({ id: 'link-1' }));
+const removeMock = vi.fn(async () => true);
+
+vi.mock('./useFeatureLink', () => ({
+  useFeatureLink: () => ({
+    save: saveMock,
+    remove: removeMock,
+    saving: false,
+    error: null,
+    clearError: vi.fn(),
+  }),
+}));
+
+import type { FeatureLink, FeatureTabProps } from './types';
+
+const baseProps: FeatureTabProps = {
+  policyId: 'policy-1',
+  existingLink: undefined,
+  linkedPolicyId: null,
+  onLinkChanged: vi.fn(),
+};
+
+const CONSENT = {
+  acceptedByUserId: 'user-7',
+  acceptedAt: '2026-09-10T12:00:00.000Z',
+  eulaId: HP_CMSL_EULA_ID,
+};
+
+function link(id: string, inlineSettings: Record<string, unknown>): FeatureLink {
+  return { id, featureType: 'warranty', featurePolicyId: null, inlineSettings };
+}
+
+function clickSave() {
+  const button = screen
+    .getAllByRole('button')
+    .find((b) => /^save/i.test(b.textContent?.trim() ?? '')) as HTMLButtonElement;
+  fireEvent.click(button);
+}
+
+function savedSettings(): Record<string, any> {
+  const call = saveMock.mock.calls[0] as unknown as [unknown, { inlineSettings: Record<string, any> }];
+  return call[1].inlineSettings;
+}
+
+describe('WarrantyTab', () => {
+  beforeEach(() => {
+    saveMock.mockClear();
+    removeMock.mockClear();
+  });
+
+  // #5080: `featurePolicyId` means a standalone entity id (update ring, backup
+  // profile, ...) — Warranty is inline settings, so it must never carry the
+  // parent CONFIG policy's own id.
+  it('sends featurePolicyId: null even when a parent config policy is linked', () => {
+    render(<WarrantyTab {...baseProps} linkedPolicyId="parent-1" />);
+    clickSave();
+
+    expect(saveMock).toHaveBeenCalled();
+    const call = saveMock.mock.calls[0] as unknown as [unknown, { featurePolicyId: string | null }];
+    expect(call[1].featurePolicyId).toBeNull();
+  });
+
+  it('defaults HP collection to off and says so in the payload', () => {
+    render(<WarrantyTab {...baseProps} />);
+    clickSave();
+
+    expect(savedSettings().hpCmsl).toEqual({ enabled: false });
+  });
+
+  it('sends hpCmsl.enabled true once the box is ticked', () => {
+    render(<WarrantyTab {...baseProps} />);
+    fireEvent.click(screen.getByTestId('warranty-tab-hp-cmsl-toggle'));
+    clickSave();
+
+    expect(savedSettings().hpCmsl).toEqual({ enabled: true });
+  });
+
+  it('NEVER echoes a recorded consent back to the server (#5511 D3)', () => {
+    render(
+      <WarrantyTab
+        {...baseProps}
+        existingLink={link('link-1', { enabled: true, warnDays: 90, criticalDays: 30, hpCmsl: { enabled: true, consent: CONSENT } })}
+      />,
+    );
+    clickSave();
+
+    expect(savedSettings().hpCmsl).toEqual({ enabled: true });
+    expect(JSON.stringify(savedSettings())).not.toContain('consent');
+  });
+
+  it('renders the consent explainer and, once recorded, who accepted', () => {
+    render(
+      <WarrantyTab
+        {...baseProps}
+        existingLink={link('link-1', { hpCmsl: { enabled: true, consent: CONSENT } })}
+      />,
+    );
+
+    expect(screen.getByTestId('warranty-tab-hp-cmsl-consent')).toBeTruthy();
+    expect(screen.getByTestId('warranty-tab-hp-cmsl-acceptance').textContent).toContain('user-7');
+    expect(screen.queryByTestId('warranty-tab-hp-cmsl-superseded')).toBeNull();
+  });
+
+  it('flags an acceptance recorded against superseded terms (#5511 D2)', () => {
+    render(
+      <WarrantyTab
+        {...baseProps}
+        existingLink={link('link-1', {
+          hpCmsl: { enabled: true, consent: { ...CONSENT, eulaId: 'hp-cmsl-eula-2020-01-01' } },
+        })}
+      />,
+    );
+
+    expect(screen.getByTestId('warranty-tab-hp-cmsl-superseded')).toBeTruthy();
+  });
+
+  it('warns that overriding a collecting parent DROPS collection, and proves the drop (#5511 D5)', () => {
+    render(
+      <WarrantyTab
+        {...baseProps}
+        existingLink={link('link-child', { enabled: true, warnDays: 14, criticalDays: 7 })}
+        parentLink={link('link-parent', { hpCmsl: { enabled: true, consent: CONSENT } })}
+      />,
+    );
+
+    // The child link carries no hpCmsl block, so the tab shows collection OFF
+    // and warns. Saving writes `false` — the inherited block is NOT merged in.
+    expect(screen.getByTestId('warranty-tab-inheritance-warning')).toBeTruthy();
+    clickSave();
+    expect(savedSettings().hpCmsl).toEqual({ enabled: false });
+  });
+
+  it('does not warn when the child keeps collection on', () => {
+    render(
+      <WarrantyTab
+        {...baseProps}
+        existingLink={link('link-child', { hpCmsl: { enabled: true, consent: CONSENT } })}
+        parentLink={link('link-parent', { hpCmsl: { enabled: true, consent: CONSENT } })}
+      />,
+    );
+
+    expect(screen.queryByTestId('warranty-tab-inheritance-warning')).toBeNull();
+  });
+
+  it('does not warn when the parent does not collect', () => {
+    render(
+      <WarrantyTab
+        {...baseProps}
+        existingLink={link('link-child', { warnDays: 14 })}
+        parentLink={link('link-parent', { enabled: true, warnDays: 90 })}
+      />,
+    );
+
+    expect(screen.queryByTestId('warranty-tab-inheritance-warning')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && npx vitest run src/components/configurationPolicies/featureTabs/WarrantyTab.test.tsx`
+Expected: FAIL — `Unable to find an element by: [data-testid="warranty-tab-hp-cmsl-toggle"]`, and `savedSettings().hpCmsl` is `undefined`.
+
+- [ ] **Step 3: Rewrite the component**
+
+Replace `apps/web/src/components/configurationPolicies/featureTabs/WarrantyTab.tsx` with:
+
+```tsx
+import { useState, useEffect } from "react";
+import { ShieldCheck } from "lucide-react";
+import type { FeatureTabProps } from "./types";
+import { FEATURE_META } from "./types";
+import { useFeatureLink } from "./useFeatureLink";
+import FeatureTabShell from "./FeatureTabShell";
+import { useTranslation } from "react-i18next";
+import { i18n } from "@/lib/i18n";
+import { formatDateTime } from "@/lib/dateTimeFormat";
+import {
+  HP_CMSL_EULA_ID,
+  readRecordedWarrantyHpCmslConsent,
+  warrantyHpCmslCollectionEffective,
+} from "@breeze/shared";
+
+/**
+ * `warranty` inline settings (#1320 alerting, #5511 W02 HP CMSL collection).
+ *
+ * `enabled` is EXPIRY ALERTING. `hpCmslEnabled` is DEVICE-SIDE COLLECTION.
+ * They are independent switches and neither implies the other.
+ *
+ * State holds the HP flag FLAT even though it is stored nested, so that the
+ * save payload has to rebuild `{ hpCmsl: { enabled } }` from scratch. That is
+ * deliberate: the server refuses a client-supplied `hpCmsl.consent` with a
+ * coded 400 and stamps its own from the authenticated session, and this tab
+ * reads that consent back in order to display it. With a nested settings
+ * object the read value would ride along on the next save and break every edit
+ * after the first; with a flat flag there is no path on which it can.
+ */
+type WarrantySettings = {
+  enabled: boolean;
+  warnDays: number;
+  criticalDays: number;
+  hpCmslEnabled: boolean;
+};
+
+const defaults: WarrantySettings = {
+  enabled: true,
+  warnDays: 90,
+  criticalDays: 30,
+  hpCmslEnabled: false,
+};
+
+function readSettings(
+  inlineSettings: Record<string, unknown> | null | undefined,
+): Partial<WarrantySettings> {
+  if (!inlineSettings) return {};
+  const out: Partial<WarrantySettings> = {};
+  if (typeof inlineSettings.enabled === "boolean") out.enabled = inlineSettings.enabled;
+  if (typeof inlineSettings.warnDays === "number") out.warnDays = inlineSettings.warnDays;
+  if (typeof inlineSettings.criticalDays === "number") out.criticalDays = inlineSettings.criticalDays;
+  const hpCmsl = inlineSettings.hpCmsl as { enabled?: unknown } | null | undefined;
+  out.hpCmslEnabled = !!hpCmsl && hpCmsl.enabled === true;
+  return out;
+}
+
+function toInlineSettings(settings: WarrantySettings) {
+  return {
+    enabled: settings.enabled,
+    warnDays: settings.warnDays,
+    criticalDays: settings.criticalDays,
+    // `consent` is deliberately absent — see the type doc above.
+    hpCmsl: { enabled: settings.hpCmslEnabled },
+  };
+}
+
+export default function WarrantyTab({
+  policyId,
+  existingLink,
+  onLinkChanged,
+  linkedPolicyId,
+  parentLink,
+}: FeatureTabProps) {
+  useTranslation("policies");
+  const { save, remove, saving, error, clearError } = useFeatureLink(policyId);
+  const isInherited = !!parentLink && !existingLink;
+  const effectiveLink = existingLink ?? parentLink;
+  const [settings, setSettings] = useState<WarrantySettings>(() => ({
+    ...defaults,
+    ...readSettings(effectiveLink?.inlineSettings),
+  }));
+  useEffect(() => {
+    const link = existingLink ?? parentLink;
+    setSettings((prev) => ({ ...prev, ...readSettings(link?.inlineSettings) }));
+  }, [existingLink, parentLink]);
+
+  const update = <K extends keyof WarrantySettings>(
+    key: K,
+    value: WarrantySettings[K],
+  ) => setSettings((prev) => ({ ...prev, [key]: value }));
+
+  const handleSave = async () => {
+    clearError();
+    const result = await save(existingLink?.id ?? null, {
+      featureType: "warranty",
+      featurePolicyId: null, // #5080: inline settings — never stamp the parent CONFIG policy's own id here
+      inlineSettings: toInlineSettings(settings),
+    });
+    if (result) onLinkChanged(result, "warranty");
+  };
+  const handleRemove = async () => {
+    if (!existingLink) return;
+    const ok = await remove(existingLink.id);
+    if (ok) onLinkChanged(null, "warranty");
+  };
+  const handleOverride = async () => {
+    clearError();
+    const result = await save(null, {
+      featureType: "warranty",
+      featurePolicyId: null, // #5080: inline settings — never stamp the parent CONFIG policy's own id here
+      inlineSettings: toInlineSettings(settings),
+    });
+    if (result) onLinkChanged(result, "warranty");
+  };
+  const handleRevert = async () => {
+    if (!existingLink) return;
+    const ok = await remove(existingLink.id);
+    if (ok) onLinkChanged(null, "warranty");
+  };
+
+  // The acceptance shown is the one on the link being edited — or, while this
+  // tab is still showing inherited state, the parent's. Both are real answers
+  // to "who accepted HP's licence for the policy in force here".
+  const recordedConsent = readRecordedWarrantyHpCmslConsent(effectiveLink?.inlineSettings);
+  const consentSuperseded = !!recordedConsent && recordedConsent.eulaId !== HP_CMSL_EULA_ID;
+
+  // Contract D5: resolution picks a WHOLE link, never a field-by-field merge.
+  // A child policy that does not collect REPLACES a collecting parent and
+  // revokes collection on every device it reaches. Say so before Save.
+  const parentCollects = warrantyHpCmslCollectionEffective(parentLink?.inlineSettings);
+  const showsInheritanceWarning = parentCollects && !settings.hpCmslEnabled;
+
+  const meta = FEATURE_META.warranty;
+  return (
+    <FeatureTabShell
+      title={meta.label}
+      description={meta.description}
+      icon={<ShieldCheck className="h-5 w-5" />}
+      isConfigured={!!existingLink || isInherited}
+      saving={saving}
+      error={error}
+      onSave={handleSave}
+      onRemove={existingLink && !linkedPolicyId ? handleRemove : undefined}
+      isInherited={isInherited}
+      onOverride={isInherited ? handleOverride : undefined}
+      onRevert={
+        !isInherited && !!linkedPolicyId && !!existingLink
+          ? handleRevert
+          : undefined
+      }
+    >
+      <div className="space-y-6">
+        {/* Opt-in clarification: warranty alerting only happens when this feature is
+            assigned and enabled (#1320). */}
+        <p className="rounded-md border border-border bg-muted/30 px-4 py-3 text-xs text-muted-foreground">
+          {i18n.t(
+            "policies:configurationPolicies.featureTabs.warrantyTab.warrantyAlertingIsOptInDevicesWith",
+          )}
+        </p>
+
+        {/* Enable toggle */}
+        <div className="flex items-center justify-between rounded-md border bg-background px-4 py-3">
+          <div>
+            <p className="text-sm font-medium">
+              {i18n.t(
+                "policies:configurationPolicies.featureTabs.warrantyTab.enableWarrantyExpiryAlerts",
+              )}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {i18n.t(
+                "policies:configurationPolicies.featureTabs.warrantyTab.generateAlertsWhenFixedTermDeviceWarranties",
+              )}
+            </p>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={settings.enabled}
+            data-testid="warranty-tab-alerts-toggle"
+            onClick={() => update("enabled", !settings.enabled)}
+            className={`relative inline-flex h-6 w-11 items-center rounded-full border transition ${settings.enabled ? "bg-emerald-500/80" : "bg-muted"}`}
+          >
+            <span
+              className={`inline-block h-5 w-5 rounded-full bg-white transition ${settings.enabled ? "translate-x-5" : "translate-x-1"}`}
+            />
+          </button>
+        </div>
+
+        {settings.enabled && (
+          <div className="grid gap-6 sm:grid-cols-2">
+            <div>
+              <label className="text-sm font-medium">
+                {i18n.t(
+                  "policies:configurationPolicies.featureTabs.warrantyTab.warningThresholdDays",
+                )}
+              </label>
+              <input
+                type="number"
+                min={1}
+                max={365}
+                value={settings.warnDays}
+                onChange={(e) =>
+                  update("warnDays", Number(e.target.value) || 90)
+                }
+                className="mt-2 h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
+              />
+              <p className="mt-1 text-xs text-muted-foreground">
+                {i18n.t(
+                  "policies:configurationPolicies.featureTabs.warrantyTab.generateAWarningAlertWhenWarrantyExpires",
+                )}
+              </p>
+            </div>
+
+            <div>
+              <label className="text-sm font-medium">
+                {i18n.t(
+                  "policies:configurationPolicies.featureTabs.warrantyTab.criticalThresholdDays",
+                )}
+              </label>
+              <input
+                type="number"
+                min={1}
+                max={365}
+                value={settings.criticalDays}
+                onChange={(e) =>
+                  update("criticalDays", Number(e.target.value) || 30)
+                }
+                className="mt-2 h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
+              />
+              <p className="mt-1 text-xs text-muted-foreground">
+                {i18n.t(
+                  "policies:configurationPolicies.featureTabs.warrantyTab.generateACriticalAlertWhenWarrantyExpires",
+                )}
+              </p>
+            </div>
+          </div>
+        )}
+
+        {/* HP CMSL device-side collection (#5511 W02) */}
+        <div className="space-y-3 rounded-md border bg-background px-4 py-3">
+          <div className="flex items-center justify-between">
+            <p className="text-sm font-medium">
+              {i18n.t(
+                "policies:configurationPolicies.featureTabs.warrantyTab.collectHpWarrantyFromTheDevice",
+              )}
+            </p>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={settings.hpCmslEnabled}
+              data-testid="warranty-tab-hp-cmsl-toggle"
+              onClick={() => update("hpCmslEnabled", !settings.hpCmslEnabled)}
+              className={`relative inline-flex h-6 w-11 items-center rounded-full border transition ${settings.hpCmslEnabled ? "bg-emerald-500/80" : "bg-muted"}`}
+            >
+              <span
+                className={`inline-block h-5 w-5 rounded-full bg-white transition ${settings.hpCmslEnabled ? "translate-x-5" : "translate-x-1"}`}
+              />
+            </button>
+          </div>
+
+          <p
+            data-testid="warranty-tab-hp-cmsl-consent"
+            className="text-xs text-muted-foreground"
+          >
+            {i18n.t(
+              "policies:configurationPolicies.featureTabs.warrantyTab.hpCmslConsentExplainer",
+            )}
+          </p>
+
+          {recordedConsent ? (
+            <p
+              data-testid="warranty-tab-hp-cmsl-acceptance"
+              className="text-xs text-muted-foreground"
+            >
+              {i18n.t(
+                "policies:configurationPolicies.featureTabs.warrantyTab.hpCmslAcceptedByOn",
+                {
+                  user: recordedConsent.acceptedByUserId,
+                  date: formatDateTime(recordedConsent.acceptedAt),
+                },
+              )}
+            </p>
+          ) : (
+            <p
+              data-testid="warranty-tab-hp-cmsl-no-acceptance"
+              className="text-xs text-muted-foreground"
+            >
+              {i18n.t(
+                "policies:configurationPolicies.featureTabs.warrantyTab.hpCmslNoAcceptanceRecordedYet",
+              )}
+            </p>
+          )}
+
+          {consentSuperseded && (
+            <p
+              data-testid="warranty-tab-hp-cmsl-superseded"
+              className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs"
+            >
+              {i18n.t(
+                "policies:configurationPolicies.featureTabs.warrantyTab.hpCmslTermsChangedSaveAgain",
+              )}
+            </p>
+          )}
+        </div>
+
+        {showsInheritanceWarning && (
+          <p
+            data-testid="warranty-tab-inheritance-warning"
+            className="rounded-md border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-xs"
+          >
+            {i18n.t(
+              "policies:configurationPolicies.featureTabs.warrantyTab.hpCmslInheritanceReplacesTheWholeLink",
+            )}
+          </p>
+        )}
+      </div>
+    </FeatureTabShell>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/web && npx vitest run src/components/configurationPolicies/featureTabs/WarrantyTab.test.tsx`
+Expected: PASS.
+
+Then the guards that read this file's source and the tab registry:
+Run: `cd apps/web && npx vitest run src/components/configurationPolicies/featureTabs/structuralValues.test.ts src/components/configurationPolicies/featureTabs/featureTypeParity.test.ts src/lib/i18n/keyUsage.test.ts src/lib/__tests__/no-silent-mutations.test.ts`
+Expected: PASS, 4 files. `structuralValues` already lists `WarrantyTab.tsx`; the new code compares machine values (`settings.hpCmslEnabled`) and never a translated string, so it stays clean.
+
+Run: `cd apps/web && npx tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/configurationPolicies/featureTabs/WarrantyTab.tsx apps/web/src/components/configurationPolicies/featureTabs/WarrantyTab.test.tsx
+git commit -m "feat(web): HP CMSL opt-in, consent copy, recorded acceptance and inheritance warning on the warranty tab (#5511 W02)"
+```
+
+---
+
+## Final verification before opening the PR
+
+- [ ] **API unit suite** — `cd apps/api && npx vitest run src/services/configurationPolicy src/services/warrantyPolicyResolution src/services/warrantyAlertEvaluator src/services/aiGuardrails src/services/aiToolsConfigPolicy src/routes/configurationPolicies src/routes/agents/helpers src/routes/agents/heartbeat.test.ts src/routes/mcpServer.approvalGate.test.ts`. Check the reported FILE COUNT is what you expect; vitest's filter is a plain substring match, so a typo yields "No test files found", which reads like success in a scroll-back. `src/services/aiGuardrails` is a bare substring and pulls in the whole contract family plus `aiGuardrailsTierConfig.parity` / `aiGuardrailsAiDocs.parity` — that is intended here.
+- [ ] **Full API + web + shared suites** — `pnpm --filter @breeze/api test --run`, `pnpm --filter @breeze/web test --run`, `pnpm --filter @breeze/shared test --run`. Note the absent `--` before `--run`: with it, pnpm forwards the literal token, vitest swallows `--run` as a positional filter, and the entire suite runs in watch mode.
+- [ ] **Go** — `cd agent && go test -race ./...` and `cd agent && go build ./...`.
+- [ ] **Typecheck + lint** — `cd apps/api && npx tsc --noEmit`, `cd apps/web && npx tsc --noEmit`, `cd packages/shared && npx tsc --noEmit`, `pnpm lint`.
+- [ ] **Integration suites: not needed, and say so in the PR.** This wave adds no table, no column, no migration and no RLS policy, so `rls-coverage`, `tenantCascade`, `tenant-export-policy` and the erasure round-trip are all unaffected. Contract D1 is explicit that the `hpCmsl` block is pure jsonb on an existing feature link. **If a reviewer asks "which cascade list did you touch?", the answer is "none, and here is why" — not "I forgot".**
+- [ ] **Merge `main` before trusting a green branch.** PR CI tests the merge commit; a locally-green branch on a stale base proves nothing.
+- [ ] **PR body** must carry `Closes #5513` so the wave sub-issue auto-closes, and should state: no migration; no cascade/export registration; the five gated HTTP transitions, the sixth (AI) door closed at the guardrails layer, and the two deliberately ungated ones; and that W03 consumes `hpWarrantyCollectionEnabled()` plus the `persistWarrantyCollectionEnabled` seam.
+
+## Self-review
+
+**Spec coverage.** Spec layer 1 (`hpCmsl` block, server-stamped consent, authorization matching the deployment gate, the inheritance footgun) → Tasks 1, 2, 3, 5, 6, 12. Spec layer 2 (`buildWarrantyConfigUpdate`, `PolicyConfigUpdates`, `applyConfigUpdate` dispatch, the new `warranty_config.go`, the copied revocation contract) → Tasks 7, 8, 9, 10. Spec layer 7's `WarrantyTab.tsx` bullet → Tasks 11, 12. Contract D12 → Task 4. Layers 3-6 and the rest of layer 7 belong to W01/W03/W04/W05 and are listed under Global Constraints as out of scope. The spec's "Corrections" section is honoured throughout: the dispatch is above `:2918`, neither Go symbol is exported, and `patch_source.go`'s camelCase-first inner parse is mirrored.
+
+**D4 coverage is now complete, and that is the change this revision makes.** The first draft enumerated five HTTP doors and made the AI door merely *inert* (no actor → no consent → delivery `false`). Inert is not gated: an assistant could still flip the stored flag, leaving the UI claiming collection was on while nothing was delivered, and the gate one refactor away from a real bypass. Task 6 closes it at the guardrails layer, where an AI tool call is actually classified. Both layers are kept deliberately — Task 2's consent rule is the fail-safe that survives a future loosening of the guardrail predicate, and Task 6 is the gate. Task 5 now names the sixth door and points at Task 6 rather than pretending five was the whole set.
+
+**Placeholder scan.** Every code step carries complete, runnable code — TypeScript, Go, JSX, JSON and shell alike. The only prose-only steps are Task 10 step 7 (a deliberate move-it-and-watch-it-fail control) and Task 7 step 4's instruction to let `tsc` name the orphaned imports rather than guessing at a list that will drift.
+
+**Type consistency.** `WarrantySettings` in `helpers.ts` is `{ hpCmslEnabled: boolean }` in Task 8, referenced by exactly that name in Task 9's `PolicyConfigUpdates` and mapped to the wire's `hp_cmsl_enabled` in one place. The web component's local `WarrantySettings` is a different, file-local type in a different package — same name, no collision, and its `hpCmslEnabled` field name matches deliberately. `resolveEffectiveWarrantyInlineSettings` is spelled identically in Tasks 7, 8 and Task 8's mock path. `persistWarrantyCollectionEnabled` is spelled identically in the Go source and its test. `isInputAwareTier3` keeps its exact existing signature `(toolName, action, input)` in Task 6, so its two call sites (`aiGuardrails.ts:570`, `:1426`) and the contract test need no change beyond the new cases.
+
+**One predicate, three consumers, one meaning.** `warrantyHpCmslRequested` — "is this author asking for collection?" — is now read by the HTTP gate (Task 5), the guardrails escalation (Task 6) and the approval description (Task 6). That is deliberate: the tier a call is assigned, the permission it demands, and the sentence an approver reads must all be answering the same question, or one of them drifts. `warrantyHpCmslCollectionEffective` stays reserved for stored rows (delivery, inheritance/assignment gates) — Task 5's table is the reference if a later reader is tempted to unify them.
+
+**Known risk left in place.** `consent.acceptedByUserId` renders as a raw user id in the tab, because contract D1 fixes the consent shape to three fields and this wave may not widen it. Resolving an id to a name needs either a stamped display name (a contract change) or a user lookup on the policy page (new API surface). Both are follow-ups, not W02 work — flag it in the PR.

--- a/docs/superpowers/plans/device-lifecycle/2026-09-10-hp-warranty-cmsl-w03-collector.md
+++ b/docs/superpowers/plans/device-lifecycle/2026-09-10-hp-warranty-cmsl-w03-collector.md
@@ -1,0 +1,4090 @@
+---
+tracking_issue: LanternOps/breeze#5511
+---
+
+# Wave 03 — Agent collector: HP warranty via HP CMSL — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Windows agent read HP warranty data out of HP's own WMI namespace, refresh it through `Get-HPWarrantyInfo` only when HP's own 30-day cache has genuinely lapsed, and report it to `PUT /agents/:id/warranty-info` as `source: 'agent_cmsl'` on a persisted, jittered, rate-limit-aware schedule.
+
+**Architecture:** Three files in `agent/internal/collectors` — a **build-tag-free** `hp_warranty.go` holds every shared type (`HpWarrantyInfo`, `HpEntitlement`, `HpCollectError`, the tier and reason constants) and every line of logic worth testing (the PowerShell execution seam, the two scripts, the WMI JSON parser, the tier decision T0/T1/T2, rate-limit classification, entitlement bounding), while `hp_warranty_windows.go` (`//go:build windows`) and `hp_warranty_other.go` (`//go:build !windows`) hold **nothing but the platform entry point** — the real `CollectHpWarranty()` and the `(nil, nil)` stub respectively, both referencing the one shared struct. That split is the whole reason the suite runs on a macOS/Linux CI runner — it copies the existing `hardware_windows.go` (tagged, spawns PowerShell) + `hardware_wmi_parse.go` (tag-free, unit-tested by the tag-free `hardware_test.go`) precedent. Scheduling lives in `agent/internal/heartbeat/hp_warranty.go`: a persisted due-time file under `config.GetDataDir()` (the `reliability_state.go` pattern), a deterministic FNV-1a jitter offset keyed on the agent id, bounded transient retries and a much longer back-off after an HP 429 — plus the report call, which reuses `h.sendInventoryData("warranty-info", payload, …)` unchanged.
+
+**Tech Stack:** Go 1.26.6 (`agent/go.mod:3`), stdlib only (`encoding/json`, `hash/fnv`, `regexp`, `time`), `go test -race`. No new module dependency — in particular **no** Go WMI binding (see Global Constraints).
+
+**Spec:** `docs/superpowers/specs/device-lifecycle/2026-09-10-hp-warranty-cmsl-design.md` — layer 5 (collection) and layer 6 (reporting), **as amended by that document's "Corrections after ground-truth verification (2026-09-10)" section, which supersedes the body.**
+
+**Cross-wave contract:** `contract-B-hp-cmsl.md` (coordinator, locked). Decisions D6, D7, D8, D9, D10 bind this wave. Where the contract and the spec body disagree, the contract wins.
+
+**Wave:** W03, sub-issue `LanternOps/breeze#5514`. Feature `#5511`.
+
+---
+
+## ⛔ HARD GATE — do not start this wave until W01's lab probe has reported
+
+**W01 (#5512) must have answered all three of its hardware questions, recorded on issue #5512, before Task 2 of this plan can be implemented.** This is not a formality: two of the three answers are *inputs to code in this plan*, not context.
+
+| # | Question W01 must answer | What in THIS plan depends on it |
+|---|---|---|
+| 1 | Does `root/HP/InstrumentedServices/v1` exist **without** CMSL installed? | Task 3's tier decision. If the namespace is factory-populated, T0 succeeds on stock HP hardware and T2 becomes rare; if it only appears with CMSL, T2 is the common first state and the "report nothing, let the policy install it" branch carries the fleet for its first policy cycle. Either answer works — the code is the same — but the plan's log levels and the PR description must state which world we are in. |
+| 2 | What does `Get-HPWarrantyInfo` **actually return, field by field**, including its own cache timestamp? | **Task 2's parser is written against that captured output, not against documentation.** Task 2 Step 1 pastes the probe's captured JSON verbatim into `agent/internal/collectors/testdata/hp_warranty_wmi_real.json` and the field-name candidate lists in `hp_warranty.go` are corrected to match. Implementing Task 2 without the fixture means shipping a parser validated only against a guess. |
+| 3 | Does an old→new CMSL upgrade surface through the SYSTEM winget scan and a Breeze ring? | Nothing in this wave. This gates **W04**, not W03. Recorded here only so an implementer does not mistake a "no" on Q3 for a blocker on W03. |
+
+**If Q2 has not been answered, stop and report.** Tasks 1 and 6–10 (stubs, scheduling, jitter, back-off, reporting, wiring) are genuinely independent of the probe and may be implemented first; Tasks 2–5 (parser, tiers, classification, bounding) may not.
+
+---
+
+## Global Constraints
+
+Copied verbatim from the locked contract and the spec's corrections section. Every task's requirements implicitly include this section.
+
+- **The agent has NO Go WMI binding, and this wave must not introduce one.** `yusufpapurcu/wmi` is an *indirect* dependency (`agent/go.mod:112`) imported by zero agent files; `go-ole` is direct (`agent/go.mod:18`) but drives only the Windows Update Agent COM API and VSS. Promoting `wmi` to a direct dependency is **rejected** by the contract (D7). Proof is quoted in §0 below.
+- **T0 reads WMI through PowerShell**, via
+  `runCollectorOutput(timeout, "powershell", "-NoProfile", "-NonInteractive", "-Command", utf8PowerShellCommand(script))`
+  — the `agent/internal/collectors/hardware_windows.go:82-121` pattern, including its `Get-WmiSafe`-style graceful-degradation idea and a bounded timeout (D7).
+- **File layout is fixed by D7:** `agent/internal/collectors/hp_warranty_windows.go` (`//go:build windows`) and `agent/internal/collectors/hp_warranty_other.go` (`//go:build !windows`), the stub returning `(nil, nil)` like `agent/internal/collectors/warranty_other.go:21`.
+- **D7 WAS AMENDED (coordinator, 2026-09-10) — shared types are declared exactly ONCE, in the tag-free `hp_warranty.go`.** D7 originally required a *struct-parity* stub, mirroring `HpWarrantyInfo` in both build-tagged files. That requirement was lifted, and a reader checking the original contract should not read this plan as a divergence. Reason: the parity contract documented at `warranty_other.go:12-15` exists only because Apple's collector has **no** tag-free file — its struct has nowhere else to live, so it must be mirrored for `heartbeat.go` to type-check on every platform. This wave already introduces a tag-free `hp_warranty.go`, which removes that constraint; mirroring the struct anyway would preserve a real drift hazard in shipped agent code to imitate a precedent whose reason does not apply. **The two build-tagged files therefore hold nothing but the platform entry point.**
+- **Do NOT retag `agent/internal/collectors/warranty_other.go`.** It is Apple's `//go:build !darwin` stub and already compiles on Windows. Its parity duplication is correct *for Apple* and is not something to "fix" while passing through.
+- **Wire values (D9, D10):** `source` is exactly `'agent_cmsl'`; `manufacturer` is exactly `'HP'`. Entitlement objects sent by the agent carry `serviceLevelDescription`, `entitlementType`, `startDate`, `endDate` and **never** `provider` — W01 derives `provider` from the reporting source server-side, because `provider: 'apple' as const` (`apps/api/src/services/warrantySync.ts:367`) is a verified defect W01 fixes.
+- **Entitlement bounds (D10), enforced client-side too:** at most **25** entitlements per report; each string field at most **200** characters; dates as ISO-8601 strings preserved as HP reports them. Client-side enforcement is not belt-and-braces — a schema rejection is a 400 that drops the *entire* warranty update, which is exactly how #1320 lost Apple coverage records.
+- **Scheduling keys off HP's own cache timestamp (D8),** not a fixed interval: HP self-caches 30 days, so a day-25 invocation returns cached data and refreshes nothing. The collector carries its **own persisted due-time and bounded retries**; it does **NOT** ride the 15-minute `sendInventory` fan-out (`agent/internal/heartbeat/heartbeat.go:2120-2139`).
+- **Per-device jitter is deterministic** (hash of the agent id → offset within the refresh window) and is **explicitly statistical, not a guarantee**: a fleet returning from a shared outage re-bunches because every device's persisted due time already elapsed. Say so in the code comment; do not claim a bound the design cannot deliver.
+- **Back off on an HP 429 rather than retrying into the limit.** HP's limit is 300 requests / 5 minutes **per source IP** — a per-customer-NAT limit, not per-device. One saturated site is every HP device behind one NAT.
+- **Report WHY collection failed rather than failing silently.** PowerShell 5.1 and TLS 1.2 are not universal on older Windows builds; a device that cannot collect must say which of those it was.
+- **Reporting reuses the Apple transport unchanged:** `h.sendInventoryData("warranty-info", payload, "<label>")` (`agent/internal/heartbeat/heartbeat.go:2154-2185`) — **the endpoint is the FIRST argument**, the label the third. Model the payload on `sendAppleWarrantyInfo` (`:2405-2435`), including its belt-and-braces `runtime.GOOS` guard.
+- **Consume W02's config seam; do not re-implement config parsing.** The gate is `warranty_settings.hp_cmsl_enabled`, dispatched through `agent/internal/heartbeat/warranty_config.go` (D6/D7, owner W02).
+- **Out of scope, hard:** any file under `apps/api/`, the catalog package (W04), the config/opt-in surface (W02), `apps/web/`. If a task appears to need one, stop and report.
+- **Go tests run with `-race` and must pass on a NON-Windows runner.** Every test in this wave mocks the command-execution seam; **no test shells out for real**. Command:
+  ```bash
+  cd agent && go test -race ./internal/collectors/... ./internal/heartbeat/...
+  ```
+- Table-driven tests for: tier selection, due-time computation from an HP cache timestamp, jitter determinism *and* distribution, and 429 back-off (spec §Testing).
+
+---
+
+## 0. Ground truth
+
+Re-verified 2026-09-10 against this worktree (`/Users/toddhebebrand/.herdr/worktrees/breeze/warranty-testing`, branch `spec/hp-warranty-and-desired-state-install`). Every file cited below was opened; the quotes are verbatim. **Contract line numbers were re-confirmed, not trusted** — deviations are called out.
+
+### 0.1 The "no Go WMI binding" claim, proven
+
+`agent/go.mod:18` and `agent/go.mod:112`:
+
+```
+	github.com/go-ole/go-ole v1.2.6
+```
+```
+	github.com/yusufpapurcu/wmi v1.2.4 // indirect
+```
+
+`grep -rn "yusufpapurcu/wmi" agent --include="*.go"` → **exit status 1, zero matches.** The package is imported by no agent file; it is pulled in transitively by gopsutil.
+
+`grep -rn "go-ole" agent --include="*.go"` → exactly three lines, none of them WMI:
+
+```
+agent/internal/backup/vss/vss_windows.go:16:	"github.com/go-ole/go-ole"
+agent/internal/patching/windows.go:11:	"github.com/go-ole/go-ole"
+agent/internal/patching/windows.go:12:	"github.com/go-ole/go-ole/oleutil"
+```
+
+`agent/go.mod:3` — `go 1.26.6`. (The W03 calibration reference plan says "Go 1.25"; that is stale, not wrong at the time.)
+
+### 0.2 The stub whose `(nil, nil)` shape this wave copies — and whose duplication it does not
+
+Full file, 22 lines. Note the parity comment at `:12-15` and the `(nil, nil)` return at `:20-21`:
+
+```go
+//go:build !darwin
+
+package collectors
+
+// AppleWarrantyInfo contains warranty data extracted from local macOS plists.
+// On non-darwin platforms, this is a no-op.
+type AppleWarrantyInfo struct {
+	CoverageEndDate   string         `json:"coverageEndDate,omitempty"`
+	CoverageStartDate string         `json:"coverageStartDate,omitempty"`
+	DeviceName        string         `json:"deviceName,omitempty"`
+	CoverageType      string         `json:"coverageType,omitempty"`
+	// CoverageKind mirrors the darwin struct so heartbeat.go (compiled on all
+	// platforms) type-checks on non-darwin; always "" here since collection
+	// is a darwin-only no-op (#1320/#1344 build-tag parity).
+	CoverageKind      string         `json:"coverageKind,omitempty"`
+	Raw               map[string]any `json:"raw,omitempty"`
+}
+
+// CollectAppleWarranty is a no-op on non-darwin platforms.
+func CollectAppleWarranty() (*AppleWarrantyInfo, error) {
+	return nil, nil
+}
+```
+
+Confirmed: `//go:build !darwin` at `:1`, parity comment `:12-15`, `return nil, nil` at `:21`. **This file is NOT retagged and NOT edited by this wave.**
+
+**What this wave copies from it, and what it deliberately does not.** The `(nil, nil)` entry-point stub is copied exactly. The *duplicated struct* is not, and the comment at `:12-15` says why in its own words: the mirror exists "so heartbeat.go (compiled on all platforms) type-checks on non-darwin". `AppleWarrantyInfo` has nowhere else to live — there is no tag-free file in Apple's collector, only `warranty_darwin.go` and `warranty_other.go`. This wave already has a tag-free `hp_warranty.go` (for the reasons in §0.5), so the same type-checking guarantee is available from a single declaration, without two copies to drift apart. Coordinator amended D7 accordingly on 2026-09-10; see Global Constraints.
+
+### 0.3 The canonical PowerShell-WMI precedent — `agent/internal/collectors/hardware_windows.go`
+
+`:14`:
+```go
+const wmicTimeout = 15 * time.Second
+```
+
+`:82-98` — the batched collector and its `Get-WmiSafe` fallback helper:
+```go
+func collectPlatformHardware(hw *HardwareInfo) {
+	// One batched PowerShell invocation fetches all WMI properties at once,
+	// cutting ~9 cold-start process spawns per collection cycle down to one.
+	// Each WMI class tries Get-CimInstance first (preferred, modern) and falls
+	// back to Get-WmiObject for older hosts where CIM is unavailable.
+	script := `
+$ErrorActionPreference = 'SilentlyContinue'
+function Get-WmiSafe($ClassName) {
+  $r = $null
+  if (Get-Command Get-CimInstance -ErrorAction SilentlyContinue) {
+    try { $r = Get-CimInstance -ClassName $ClassName -ErrorAction Stop } catch {}
+  }
+  if ($null -eq $r -and (Get-Command Get-WmiObject -ErrorAction SilentlyContinue)) {
+    try { $r = Get-WmiObject -Class $ClassName -ErrorAction Stop } catch {}
+  }
+  $r
+}
+```
+
+`:118-128` — the `ConvertTo-Json -Compress` tail, the invocation, and the failure log:
+```go
+} | ConvertTo-Json -Compress
+`
+
+	out, err := runCollectorOutput(wmicTimeout, "powershell", "-NoProfile", "-NonInteractive", "-Command", utf8PowerShellCommand(script))
+	if err != nil {
+		// Whole-scan failure (powershell blocked by WDAC/AppLocker, WMI repository
+		// corruption, timeout, …) leaves every WMI-derived field empty this cycle,
+		// so log at Warn — Debug is suppressed at the default "info" level.
+		slog.Warn("hardware WMI batch query failed; WMI-derived hardware fields empty this cycle", "error", err.Error())
+		return
+	}
+```
+
+Contract says `hardware_windows.go:82-121`. **Confirmed exactly** — `collectPlatformHardware` opens at `:82`, `Get-WmiSafe` is `:89-98`, the `runCollectorOutput` call is `:121`.
+
+### 0.4 The execution seam — `agent/internal/collectors/command_limits.go`
+
+**No build tag on this file** — it compiles on every platform, which is what makes the seam mockable from a darwin test.
+
+`:16-24`:
+```go
+const (
+	collectorShortCommandTimeout = 10 * time.Second
+	collectorLongCommandTimeout  = 30 * time.Second
+	collectorCommandOutputLimit  = 4 * 1024 * 1024
+	collectorScannerLimit        = 1024 * 1024
+	collectorFileReadLimit       = 1024 * 1024
+	collectorStringLimit         = 512
+	collectorResultLimit         = 5000
+)
+```
+
+`:26-39`:
+```go
+// utf8PowerShellCommand wraps a PowerShell command so its stdout is emitted as
+// UTF-8. Without this, PowerShell renders output using the console OEM codepage
+// (e.g. CP852 on Polish Windows), which Go then decodes as UTF-8 and corrupts
+// non-Latin characters into U+FFFD. See issue #979.
+func utf8PowerShellCommand(command string) string {
+	return "[Console]::OutputEncoding=[System.Text.Encoding]::UTF8;" + command
+}
+
+func runCollectorOutput(timeout time.Duration, name string, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	return runCollectorOutputWithContext(ctx, timeout, name, args...)
+}
+```
+
+`:41` — `func runCollectorOutputWithContext(parent context.Context, timeout time.Duration, name string, args ...string) ([]byte, error) {`
+
+Contract says `command_limits.go:30,34,41`. **Confirmed exactly**: `utf8PowerShellCommand` body at `:31` with the signature at `:30`; `runCollectorOutput` at `:34`; `runCollectorOutputWithContext` at `:41`.
+
+`:224-230` — the truncation helper this wave reuses for field bounding:
+```go
+func truncateCollectorString(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) <= collectorStringLimit {
+		return value
+	}
+	return strings.TrimSpace(value[:collectorStringLimit]) + "... [truncated]"
+}
+```
+Note `collectorStringLimit` is **512**, not the 200 D10 requires. This wave adds its own 200-char bound; it does not change the shared constant.
+
+### 0.5 The tag-free-parse-file precedent — `agent/internal/collectors/hardware_wmi_parse.go`
+
+`:1-16` (no build tag on line 1 — the file opens straight into `package collectors`):
+```go
+package collectors
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// gpuNameList is the GPU-name field of the batched WMI query. It exists to
+// tolerate both shapes Windows can emit: a JSON array ("GPUNames":["a","b"])
+// and — critically — a bare scalar string. Windows PowerShell 5.1 (the default
+// shell on essentially every managed endpoint) collapses a single-element array
+// to a scalar during ConvertTo-Json, so a one-GPU host (the common case) emits
+// "GPUNames":"Intel UHD" rather than ["Intel UHD"]. Decoding straight into a
+// []string would fail on those hosts and, because the caller treats any parse
+// error as fatal, would drop the entire hardware record (serial, model, …).
+type gpuNameList []string
+```
+
+`agent/internal/collectors/hardware_test.go:1-5` is likewise tag-free and calls the parser at `:266`:
+```go
+package collectors
+
+import (
+	"testing"
+)
+```
+```go
+			got, err := parseHardwareJSON([]byte(tt.input))
+```
+
+**This is the load-bearing precedent for this wave's architecture**: a tag-free parse file next to a tagged collector, unit-tested by a tag-free test, is how WMI parsing is already proven on non-Windows CI. The PowerShell-5.1 single-element-array collapse documented here recurs verbatim for `HP_Entitlements` and is handled in Task 2.
+
+### 0.6 Existing seam-override test pattern — `agent/internal/collectors/software_darwin.go:12` and its test
+
+```go
+var softwareCommandOutput = runCollectorOutput
+```
+
+`agent/internal/collectors/software_darwin_test.go:33-40`:
+```go
+func TestDarwinCollectObservationReportsSourceEvidence(t *testing.T) {
+	original := softwareCommandOutput
+	t.Cleanup(func() { softwareCommandOutput = original })
+
+	t.Run("complete", func(t *testing.T) {
+		softwareCommandOutput = func(_ time.Duration, _ string, _ ...string) ([]byte, error) {
+			return []byte(`{"SPApplicationsDataType":[{"_name":"Breeze","version":"1"}]}`), nil
+		}
+```
+
+This wave copies the save/`t.Cleanup`/restore shape exactly, but declares its seam in the **tag-free** file so the override compiles on darwin and linux.
+
+### 0.7 The 15-minute fan-out this wave must NOT join — `agent/internal/heartbeat/heartbeat.go:2112-2139`
+
+```go
+// sendInventory collects and sends the 15-minute inventory set: software, disk,
+// network, configuration changes, connections, policy registry/config state, and
+// Apple warranty info. All goroutines are tracked via inventoryWg for graceful shutdown.
+//
+// Note: hardware inventory, patch inventory, security status, and session inventory
+// are intentionally absent here — each runs on its own independent cadence:
+//   - hardware / patch:   daily (or configured), dispatched from the tick gate
+//   - security / sessions: every 5 minutes, dispatched from their own tick gates
+func (h *Heartbeat) sendInventory() {
+	fns := []func(){
+		h.sendSoftwareInventory,
+		h.sendDiskInventory,
+		h.sendNetworkInventory,
+		h.sendConfigurationChanges,
+		h.sendConnectionsInventory,
+		h.sendPolicyRegistryState,
+		h.sendPolicyConfigState,
+		h.sendAppleWarrantyInfo,
+	}
+```
+
+Confirmed: `func (h *Heartbeat) sendInventory()` at `:2120`, `h.sendAppleWarrantyInfo` registered at `:2129`, the slice closes at `:2130` and the function at `:2139`. Contract's `heartbeat.go:2120-2139` / `:2129` is **exact**. The doc comment's own "each runs on its own independent cadence … dispatched from the tick gate" is the pattern D8 requires for HP.
+
+### 0.8 The transport — `agent/internal/heartbeat/heartbeat.go:2154-2185`
+
+```go
+// sendInventoryData marshals the payload and sends it to the given endpoint via PUT.
+func (h *Heartbeat) sendInventoryData(endpoint string, payload any, label string) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		log.Error("failed to marshal inventory", "label", label, "error", err.Error())
+		return err
+	}
+
+	url := fmt.Sprintf("%s/api/v1/agents/%s/%s", h.serverURL(), h.config.AgentID, endpoint)
+```
+
+Confirmed: signature at `:2155`, **endpoint first**, label third; the function ends at `:2185`. Contract's `:2154-2185` is exact (`:2154` is the doc comment).
+
+### 0.9 The payload to model — `agent/internal/heartbeat/heartbeat.go:2405-2435`
+
+```go
+func (h *Heartbeat) sendAppleWarrantyInfo() {
+	if runtime.GOOS != "darwin" {
+		return
+	}
+	info, err := collectors.CollectAppleWarranty()
+	if err != nil {
+		log.Warn("failed to collect Apple warranty info", "error", err.Error())
+		return
+	}
+	if info == nil {
+		log.Debug("no Apple warranty plist data found")
+		return
+	}
+
+	payload := map[string]any{
+		"source":            "agent_plist",
+		"manufacturer":      "Apple",
+		"coverageEndDate":   info.CoverageEndDate,
+		"coverageStartDate": info.CoverageStartDate,
+		"coverageType":      info.CoverageType,
+		"deviceName":        info.DeviceName,
+	}
+	// Only include coverageKind when the NDO verb is recognized; omit the key for
+	// timestamp-only/labelless/localized/plist-fallback coverage where it can't be
+	// classified (#1320). The API schema tolerates an empty/absent value and treats
+	// it as fixed for back-compat (#1344), so omitting it here is safe — no 400.
+	if info.CoverageKind != "" {
+		payload["coverageKind"] = info.CoverageKind
+	}
+	h.sendInventoryData("warranty-info", payload, "apple warranty")
+}
+```
+
+Confirmed: `:2405-2435` exact. The belt-and-braces `runtime.GOOS` guard at `:2406-2408` is copied for HP (with `"windows"`), even though `hp_warranty_other.go` already makes collection a no-op — the guard is what stops a non-Windows agent from persisting schedule state and burning a heartbeat tick.
+
+### 0.10 The persisted-state precedent — `agent/internal/heartbeat/reliability_state.go`
+
+`:14-37`:
+```go
+const reliabilityStateFileName = "reliability_state.json"
+
+// reliabilityPostInterval is the minimum spacing between reliability posts —
+// metrics are meant to go out at most once per this window.
+const reliabilityPostInterval = 24 * time.Hour
+
+// reliabilityPostDue reports whether a reliability post is due given the last
+// time one was sent and the current time. A zero `last` (never sent, or an
+// unreadable/corrupt persisted state) is always due, so the first post fails
+// open. Extracted as a pure function so the gate — the heart of #1906 — is
+// unit-testable without driving the long-running heartbeat loop.
+func reliabilityPostDue(last, now time.Time) bool {
+	return now.Sub(last) > reliabilityPostInterval
+}
+
+// reliabilityState persists the last time reliability metrics were posted so
+// the 24h send cadence survives agent restarts. Without it, every restart
+// (crash, auto-update, machine reboot — frequent on POS/checkout boxes) reset
+// the in-memory timer to its zero value and immediately re-posted an
+// overlapping event-log window, creating duplicate device_reliability_history
+// rows and inflating failure counts (issue #1906).
+type reliabilityState struct {
+	LastUpdate time.Time `json:"lastUpdate"`
+}
+```
+
+`:39-53` — the path resolution this wave **deliberately diverges from**:
+```go
+// reliabilityStatePath mirrors ipStatePath: prefer the per-user ~/.breeze dir,
+// fall back to the configured data dir, then a temp dir as a last resort.
+func (h *Heartbeat) reliabilityStatePath() string {
+	if homeDir, err := os.UserHomeDir(); err == nil && strings.TrimSpace(homeDir) != "" {
+		return filepath.Join(homeDir, ".breeze", reliabilityStateFileName)
+	}
+
+	dataDir := strings.TrimSpace(config.GetDataDir())
+	if dataDir == "" {
+		tmpPath := filepath.Join(os.TempDir(), "breeze", reliabilityStateFileName)
+		log.Warn("reliability state directory unavailable, falling back to temp dir", "path", tmpPath)
+		return tmpPath
+	}
+	return filepath.Join(dataDir, reliabilityStateFileName)
+}
+```
+
+`:79-99` — the atomic write this wave copies verbatim in shape:
+```go
+// saveLastReliabilityUpdate atomically persists the last-send timestamp.
+func (h *Heartbeat) saveLastReliabilityUpdate(t time.Time) error {
+	path := h.reliabilityStatePath()
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("failed to create reliability state directory %s: %w", dir, err)
+	}
+
+	payload, err := json.Marshal(reliabilityState{LastUpdate: t})
+	if err != nil {
+		return fmt.Errorf("failed to encode reliability state: %w", err)
+	}
+
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, payload, 0600); err != nil {
+		return fmt.Errorf("failed to write reliability state temp file %s: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("failed to persist reliability state %s: %w", path, err)
+	}
+	return nil
+}
+```
+
+`agent/internal/config/config.go:1058-1068` — the data dir:
+```go
+// GetDataDir returns the platform-specific data directory for the agent
+func GetDataDir() string {
+	switch runtime.GOOS {
+	case "windows":
+		return filepath.Join(configDir(), "data")
+	case "darwin":
+		return "/Library/Application Support/Breeze/data"
+	default:
+		return "/var/lib/breeze"
+	}
+}
+```
+
+### 0.11 The tick-gate and bounded-retry precedent — `agent/internal/heartbeat/heartbeat.go`
+
+`:2220-2222`:
+```go
+func dueForRun(now, last time.Time, interval time.Duration) bool {
+	return now.Sub(last) > interval
+}
+```
+
+`:2236-2241` (the retry-schedule rationale this wave mirrors for HP's *per-NAT* limit):
+```go
+const (
+	maxPatchSendRetries  = 4
+	patchRetryBaseDelay  = 5 * time.Minute
+	patchRetryMaxDelay   = 2 * time.Hour
+	patchRetryJitterFrac = 0.3
+```
+
+`:2248-2263`:
+```go
+func patchRetryDelay(failures int, jitterFrac, rnd float64) time.Duration {
+	if failures < 1 || failures > maxPatchSendRetries {
+		return 0
+	}
+	delay := patchRetryBaseDelay << (failures - 1) // 5m, 10m, 20m, 40m
+	if delay > patchRetryMaxDelay {
+		delay = patchRetryMaxDelay
+	}
+	if jitterFrac > 0 {
+		// Additive-only: spreads a synchronized fleet forward in time without
+		// any agent retrying sooner than the base delay.
+		delay = time.Duration(float64(delay) * (1 + jitterFrac*rnd))
+	}
+	return delay
+}
+```
+
+`:2276-2290` — the **claim gate**, the exact shape Task 8 copies:
+```go
+// claimPatchScanLocked decides whether a patch scan is due and, if so, claims
+// it by advancing the gate so the next tick can't dispatch a duplicate
+// concurrent scan. Returns whether the caller should dispatch.
+//
+// The decision and the state transition live together here (rather than being
+// open-coded in the tick loop) so the whole gate is exercised by one test
+// instead of only its pure predicate. Caller must hold h.mu.
+func (h *Heartbeat) claimPatchScanLocked(now time.Time, interval time.Duration) bool {
+	if !patchScanDue(now, h.lastPatchUpdate, h.nextPatchRetryAt, interval) {
+		return false
+	}
+	h.lastPatchUpdate = now
+```
+
+`:1846-1885` — the tick body where the gate is evaluated under `h.mu` and dispatched after `h.mu.Unlock()`:
+```go
+			h.sendHeartbeatWithWatchdog()
+			now := time.Now()
+			// Send inventory every 15 minutes
+			h.mu.Lock()
+			shouldSendInventory := now.Sub(h.lastInventoryUpdate) > 15*time.Minute
+```
+…
+```go
+			patchIntervalHours := clampPatchScanIntervalHours(h.config.PatchScanIntervalHours)
+			patchInterval := time.Duration(patchIntervalHours) * time.Hour
+			shouldSendPatch := h.claimPatchScanLocked(now, patchInterval)
+			h.mu.Unlock()
+```
+
+`:1789-1809` — the startup seeding of persisted cadence, which Task 6 mirrors:
+```go
+		startupNow := time.Now()
+		persistedReliability := h.loadLastReliabilityUpdate()
+		postReliability := reliabilityPostDue(persistedReliability, startupNow)
+		h.mu.Lock()
+		h.lastPostureUpdate = startupNow
+		if postReliability {
+			h.lastReliabilityUpdate = startupNow
+		} else {
+			h.lastReliabilityUpdate = persistedReliability
+		}
+```
+
+`Heartbeat` struct — `:320`, with `mu sync.Mutex` at `:363` and the cadence fields at `:364-380`. `var log = logging.L("heartbeat")` at `:65`.
+
+### 0.12 The config seam this wave consumes — `agent/internal/heartbeat/patch_source.go` (W02's template)
+
+Full file, 57 lines. **Neither symbol is exported.** `:7-12`:
+```go
+// applyWinUpdate is the seam to the (Windows-only) enforcement. A package var so
+// tests can capture the resolved enforce bool on any platform — the dispatch +
+// payload-parse path is where a key-name regression would silently disable the
+// whole feature, so it must be unit-tested even though the registry I/O cannot
+// run on the CI agent.
+var applyWinUpdate = winupdate.Apply
+```
+
+`:18-33` — note the **camelCase-first** inner parse:
+```go
+func (h *Heartbeat) applyPatchSourceConfig(raw any) {
+	m, ok := raw.(map[string]any)
+	if !ok {
+		log.Warn("ignoring invalid patch_source_settings payload: not an object")
+		return
+	}
+
+	// The API may send either snake_case or camelCase.
+	v, present := m["exclusiveWindowsUpdate"]
+	if !present {
+		v, present = m["exclusive_windows_update"]
+	}
+	if !present {
+		log.Warn("patch_source_settings received without exclusiveWindowsUpdate field")
+		return
+	}
+```
+
+Contract's `patch_source.go:12`, `:18`, `:26-29` — **all exact.**
+
+### 0.13 `applyConfigUpdate` and the probe-path trap — `agent/internal/heartbeat/heartbeat.go:2851-2930`
+
+```go
+func (h *Heartbeat) applyConfigUpdate(update map[string]any) {
+	if len(update) == 0 {
+		return
+	}
+
+	// Apply event_log_settings if present
+	elRaw, hasEL := update["event_log_settings"]
+```
+…snake_case-first outer keys at `:2857`, `:2867`, `:2879`, `:2889`, `:2901`, `:2910`…
+```go
+	registryRaw, hasRegistry := update["policy_registry_state_probes"]
+	if !hasRegistry {
+		registryRaw, hasRegistry = update["policyRegistryStateProbes"]
+	}
+
+	configRaw, hasConfig := update["policy_config_state_probes"]
+	if !hasConfig {
+		configRaw, hasConfig = update["policyConfigStateProbes"]
+	}
+
+	if !hasRegistry && !hasConfig {
+		return
+	}
+```
+
+Confirmed: `applyConfigUpdate` at `:2851`; probe path begins `:2918`; the unconditional `return` is `:2928-2930`. **W02 owns adding the warranty dispatch above `:2918`.** W03 does not touch this function.
+
+### 0.14 Server-side shapes this wave produces against (W01's, do NOT redefine)
+
+`apps/api/src/routes/agents/schemas.ts:658-675` — the *current* schema, which W01 widens with `entitlements`:
+```ts
+export const agentWarrantyInfoSchema = z.object({
+  source: z.string().min(1).max(50),
+  manufacturer: z.string().min(1).max(100),
+  coverageEndDate: warrantyDateSchema,
+  coverageStartDate: warrantyDateSchema,
+  coverageType: z.string().max(200).optional(),
+```
+
+`apps/api/src/services/warrantySync.ts:315-321` — the *current* `AgentWarrantyData`, which W01 widens:
+```ts
+export interface AgentWarrantyData {
+  source: string;
+  manufacturer: string;
+  serialNumber: string | null;
+  coverageEndDate: string | null;
+  coverageStartDate: string | null;
+  coverageType: string | null;
+```
+
+`apps/api/src/services/warrantyProviders/types.ts:1-7` — the entitlement field names the agent's array must use (minus `provider`, which W01 derives):
+```ts
+export interface WarrantyEntitlement {
+  provider: 'dell' | 'hp' | 'lenovo' | 'apple';
+  serviceLevelDescription: string;
+  entitlementType: string;
+  startDate: string;
+  endDate: string;
+}
+```
+
+`apps/api/src/services/warrantySync.ts:364-373` — the defect W01 fixes, quoted so this wave never sends `provider` itself:
+```ts
+  // Build entitlements array from agent data
+  const entitlements = data.coverageType
+    ? [{
+        provider: 'apple' as const,
+```
+Contract says the hardcode is at `:367`. **Confirmed at `:367`** (the spec body's `:364` points at the comment, not the line).
+
+### 0.15 Deviations found from the contract
+
+Two, both cosmetic, neither changes any decision:
+
+1. Contract §Verified facts says `warranty_other.go:20` is the stub's return. `:20` is the `func CollectAppleWarranty()` line; the `return nil, nil` is `:21`. Immaterial.
+2. `agent/go.mod:3` is `go 1.26.6`, not the `1.25` the sibling W03 calibration plan states. This wave targets what `go.mod` says.
+
+**No substantive contract fact was found wrong.** The one item the contract does **not** settle is named in "Open contract question" below.
+
+### 0.16 The one thing the CONTRACT does not settle — how W02's seam hands the flag to this wave
+
+Contract D7 specifies W02's `warranty_config.go` as "a package-level func var for the platform call plus an unexported `func (h *Heartbeat) applyWarrantyConfig(raw any)`". It does **not** say where the resolved `hp_cmsl_enabled` boolean is *stored* for a later consumer. **W02's plan does, and W03 defers to it.**
+
+`docs/superpowers/plans/device-lifecycle/2026-09-10-hp-warranty-cmsl-w02-opt-in-surface-and-delivery.md` (written concurrently with this plan; verified present 2026-09-10) states in its File structure section:
+
+> - **Create** `agent/internal/heartbeat/warranty_config.go` + `warranty_config_test.go` — the seam, the parse, **and the accessor W03 reads**.
+
+and names the pattern in its ground truth:
+
+> `agent/internal/heartbeat/heartbeat.go:2809-2848` — `applyRequireManifestSigningKeyIDConfig`, the closest precedent for a **persisted control-plane boolean**: read current under `h.mu`, decide, write `h.config.X` under `h.mu`, then `config.SetAndPersist(...)` with a `log.Warn` on failure. `:4008-4012` — `func (h *Heartbeat) requireManifestSigningKeyID() bool { h.mu.Lock(); defer h.mu.Unlock(); return h.config.RequireManifestSigningKeyID }` — **the mutex-guarded accessor pattern W03 will need.**
+
+So the expected shipped shape is a **persisted `h.config` field plus a mutex-guarded accessor**, not an in-memory flag. That is the better design and W03 adopts it: persisting the gate means a device that is enrolled, gated on, and then restarted before its next heartbeat still knows collection is authorised, instead of silently reverting to `false` until the next config update.
+
+**W02's plan does not print the accessor's final name.** It is being written in a parallel session and its Go task body was not yet greppable when this plan was authored. Task 9 Step 1 therefore begins with the grep that reads the shipped name, and gives complete code for both outcomes:
+
+- **Primary (expected):** W02 shipped an accessor. `hpCmslCollectionEnabled()` becomes a one-line delegate to it; W03 adds no storage at all.
+- **Fallback:** W02 shipped only the parse and a platform func var. W03 declares the storage itself (a `sync/atomic` `atomic.Bool` field, a setter, and one added line in `applyWarrantyConfig`).
+
+Either way there is exactly one named consumption point in this wave — `func (h *Heartbeat) hpCmslCollectionEnabled() bool` — and every other task reads only that. A duplicate declaration between the two waves is a *compile error*: loud and immediate, never silent.
+
+---
+
+## File structure
+
+| File | Build tag | Responsibility |
+|---|---|---|
+| `agent/internal/collectors/hp_warranty.go` | **none** | **Every shared type, declared exactly once** — `HpWarrantyInfo`, `HpEntitlement`, `HpCollectError`, `IsHpRateLimited`, the `HpTier*` / `HpReason*` constants — plus everything testable: the `hpRunPowerShell` seam, both PowerShell scripts, the WMI JSON decoder + field-candidate lists, date normalisation, `hpCacheStale`, `collectHpWarrantyTiered`, 429 classification, entitlement bounding. |
+| `agent/internal/collectors/hp_warranty_windows.go` | `//go:build windows` | **The platform entry point and nothing else**: `CollectHpWarranty()` delegating to the tag-free orchestrator. ~10 lines. Declares no type. |
+| `agent/internal/collectors/hp_warranty_other.go` | `//go:build !windows` | **The platform entry point and nothing else**: `CollectHpWarranty()` returning `(nil, nil)`. ~8 lines. Declares no type. |
+| `agent/internal/collectors/hp_warranty_test.go` | **none** | Table-driven tests for every function above. Runs on darwin/linux. |
+| `agent/internal/collectors/hp_warranty_other_test.go` | `//go:build !windows` | The `(nil, nil)` stub contract. |
+| `agent/internal/collectors/testdata/hp_warranty_wmi_real.json` | — | The probe's captured WMI output (Task 2 Step 1, from W01). |
+| `agent/internal/heartbeat/hp_warranty.go` | **none** | Persisted `hpWarrantyState`, path resolution, load/save, `hpJitterOffset`, `hpNextDueAt`, `hpRetryDelay`, `hpRateLimitBackoff`, `claimHpWarrantyCycleLocked`, `sendHpWarrantyInfo`, `hpCmslCollectionEnabled`. |
+| `agent/internal/heartbeat/hp_warranty_test.go` | **none** | Table-driven tests for due-time, jitter determinism + distribution, retry/back-off, the claim gate, and the payload shape. |
+| `agent/internal/heartbeat/heartbeat.go` | **none** | Modified: four struct fields, startup seeding, one tick-gate call, one dispatch. |
+| `agent/internal/heartbeat/warranty_config.go` | **none** | Modified by **one line** (Task 8) — W02's file, W03 only adds the setter call. |
+
+---
+
+## Task 1: Shared types and the two platform entry points
+
+**Files:**
+- Create: `agent/internal/collectors/hp_warranty.go` (all shared types — this is where `HpWarrantyInfo` lives, once)
+- Create: `agent/internal/collectors/hp_warranty_windows.go` (entry point only)
+- Create: `agent/internal/collectors/hp_warranty_other.go` (entry point only)
+- Test: `agent/internal/collectors/hp_warranty_other_test.go`
+
+**Interfaces:**
+- Produces: `collectors.HpWarrantyInfo` (struct, declared once in the tag-free file), `collectors.HpEntitlement`, `collectors.CollectHpWarranty() (*HpWarrantyInfo, error)` (one declaration per build tag), `collectors.HpCollectError`, `collectors.IsHpRateLimited(error) bool`, and the `HpReason*` / `HpTier*` constants.
+- Consumes: nothing.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `agent/internal/collectors/hp_warranty_other_test.go`:
+
+```go
+//go:build !windows
+
+package collectors
+
+import "testing"
+
+// The non-Windows stub must be a true no-op with the same signature as the
+// Windows entry point. heartbeat.go compiles on every platform and calls this
+// function, so a signature drift here is a cross-platform build break, not a
+// runtime bug.
+//
+// Note what this test does NOT need to check: that the struct's field set
+// matches across platforms. HpWarrantyInfo is declared once, in the tag-free
+// hp_warranty.go, so there is no second copy to drift from (D7 as amended).
+func TestCollectHpWarranty_IsANoOpOnNonWindows(t *testing.T) {
+	info, err := CollectHpWarranty()
+	if err != nil {
+		t.Fatalf("CollectHpWarranty() error = %v, want nil on non-Windows", err)
+	}
+	if info != nil {
+		t.Fatalf("CollectHpWarranty() = %#v, want nil on non-Windows", info)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd agent && go test -race ./internal/collectors/ -run TestCollectHpWarranty
+```
+Expected: FAIL to build — `undefined: CollectHpWarranty`.
+
+- [ ] **Step 3: Create the tag-free shared types**
+
+Create `agent/internal/collectors/hp_warranty.go`:
+
+```go
+package collectors
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+// HpWarrantyInfo contains HP warranty data read from HP's own WMI namespace
+// (root/HP/InstrumentedServices/v1), populated by HP's Client Management Script
+// Library.
+//
+// Declared HERE, in the build-tag-free file, exactly once — not mirrored into
+// hp_warranty_windows.go and hp_warranty_other.go. The parity duplication in
+// warranty_other.go:12-15 exists because Apple's collector has no tag-free file
+// and its struct has nowhere else to live; this collector does have one, so a
+// single declaration gives heartbeat.go the same cross-platform type-checking
+// guarantee with no second copy to drift from. (Contract D7, as amended
+// 2026-09-10.)
+type HpWarrantyInfo struct {
+	SerialNumber      string          `json:"serialNumber,omitempty"`
+	ProductNumber     string          `json:"productNumber,omitempty"`
+	CoverageStartDate string          `json:"coverageStartDate,omitempty"`
+	CoverageEndDate   string          `json:"coverageEndDate,omitempty"`
+	CoverageType      string          `json:"coverageType,omitempty"`
+	Entitlements      []HpEntitlement `json:"entitlements,omitempty"`
+
+	// HPCacheTime is HP's OWN cache write timestamp, read out of WMI. It is the
+	// scheduling input (contract D8): HP self-caches 30 days, so an arbitrary
+	// day-25 invocation returns cached data and refreshes nothing. Never sent on
+	// the wire — the server has its own receipt time and W01 has HP's real fetch
+	// time, and conflating the three is exactly the defect the spec calls out.
+	HPCacheTime time.Time `json:"-"`
+	// Tier is one of HpTierT0/T1/T2 — diagnostic only.
+	Tier string `json:"-"`
+	// Reason is one of the HpReason* codes — diagnostic only.
+	Reason string `json:"-"`
+	// RateLimited is true when HP refused with a 429 during this cycle, even if
+	// stale WMI data was still returned alongside. The scheduler must see this
+	// to back off; an error return alone would lose it on the serve-stale path.
+	RateLimited bool `json:"-"`
+}
+
+// Tier names for HP warranty collection (spec layer 5). They are diagnostic
+// only — nothing on the wire carries them — but they are what an operator reads
+// out of agent logs to tell "HP never installed CMSL" apart from "CMSL is there
+// and HP's cache is simply still fresh".
+const (
+	// HpTierT0 — the data came from a local WMI read with no network I/O and no
+	// CMSL invocation. The cheap, overwhelmingly common path.
+	HpTierT0 = "t0_wmi"
+	// HpTierT1 — HP's own 30-day cache had genuinely lapsed, so
+	// Get-HPWarrantyInfo was invoked (network round trip to HP) and WMI re-read.
+	HpTierT1 = "t1_refresh"
+	// HpTierT2 — CMSL is not present on the device. Report nothing and let the
+	// software policy install it.
+	HpTierT2 = "t2_absent"
+)
+
+// Reason codes explaining why a collection produced no data, or produced stale
+// data. The spec is explicit that "PowerShell 5.1 and TLS 1.2 prerequisites are
+// not universal on older Windows builds. The collector must report *why* it
+// could not collect rather than failing silently." These are the vocabulary for
+// that: every non-OK exit carries exactly one.
+const (
+	HpReasonOK                = "ok"
+	HpReasonNamespaceAbsent   = "wmi_namespace_absent"
+	HpReasonNoWarrantyRow     = "wmi_no_warranty_row"
+	HpReasonParseFailed       = "wmi_parse_failed"
+	HpReasonPowerShellFailed  = "powershell_failed"
+	HpReasonPowerShellTooOld  = "powershell_below_5_1"
+	HpReasonCmslCmdletAbsent  = "cmsl_cmdlet_absent"
+	HpReasonRefreshFailed     = "cmsl_refresh_failed"
+	HpReasonRateLimited       = "hp_rate_limited"
+)
+
+// HpEntitlement is one HP service entitlement as reported by the device.
+//
+// The field names deliberately mirror WarrantyEntitlement in
+// apps/api/src/services/warrantyProviders/types.ts:1-7 MINUS its `provider`
+// field: W01 derives provider from the reporting source server-side, because
+// hardcoding it is the verified defect at warrantySync.ts:367. An agent that
+// sent `provider` would be asserting something the server is responsible for.
+type HpEntitlement struct {
+	ServiceLevelDescription string `json:"serviceLevelDescription,omitempty"`
+	EntitlementType         string `json:"entitlementType,omitempty"`
+	StartDate               string `json:"startDate,omitempty"`
+	EndDate                 string `json:"endDate,omitempty"`
+}
+
+// HpCollectError explains a collection that produced nothing usable. Reason is
+// one of the HpReason* constants (a stable, greppable code); Detail is the
+// underlying message, already truncated, for human diagnosis.
+type HpCollectError struct {
+	Reason string
+	Detail string
+}
+
+func (e *HpCollectError) Error() string {
+	if e.Detail == "" {
+		return "hp warranty collection failed: " + e.Reason
+	}
+	return fmt.Sprintf("hp warranty collection failed: %s: %s", e.Reason, e.Detail)
+}
+
+// IsHpRateLimited reports whether err is an HP rate-limit refusal. The caller
+// backs off for hours rather than retrying, because HP's limit is 300 requests
+// per 5 minutes per SOURCE IP — a per-customer-NAT limit. A 429 means the whole
+// site's HP fleet is saturating one bucket, so retrying soon re-creates it.
+func IsHpRateLimited(err error) bool {
+	var hpErr *HpCollectError
+	if !errorsAs(err, &hpErr) {
+		return false
+	}
+	return hpErr.Reason == HpReasonRateLimited
+}
+```
+
+Add the `errors.As` helper at the bottom of the same file:
+
+```go
+// errorsAs is errors.As, named locally so every *HpCollectError match in this
+// package reads identically (Tasks 2, 3 and 5 each do one). Behaviour is
+// identical to errors.As; it exists for call-site uniformity, not to change
+// semantics — in particular it still unwraps.
+func errorsAs(err error, target any) bool { return errors.As(err, target) }
+```
+
+The file's import block is already correct as written at the top of this step — `errors` for the helper above, `fmt` for `HpCollectError.Error`, `time` for `HpWarrantyInfo.HPCacheTime`. Later tasks widen it (`bytes`, `encoding/json`, `regexp`, `sort`, `strconv`, `strings`) as they add code.
+
+- [ ] **Step 4: Create the non-Windows entry point**
+
+Create `agent/internal/collectors/hp_warranty_other.go`. **It declares no type** — `HpWarrantyInfo` lives once in `hp_warranty.go` (Step 3). This file is the `(nil, nil)` stub and nothing else:
+
+```go
+//go:build !windows
+
+package collectors
+
+// CollectHpWarranty is a no-op on non-Windows platforms. HP CMSL is a Windows
+// product and the WMI namespace it populates does not exist elsewhere.
+//
+// heartbeat.go compiles on every platform and calls this, so the signature must
+// match the Windows entry point exactly — that cross-platform type-check is the
+// reason this stub exists at all, and it is satisfied by the shared
+// HpWarrantyInfo in hp_warranty.go without a second struct declaration here.
+func CollectHpWarranty() (*HpWarrantyInfo, error) {
+	return nil, nil
+}
+```
+
+- [ ] **Step 5: Create the Windows entry point**
+
+Create `agent/internal/collectors/hp_warranty_windows.go`:
+
+```go
+//go:build windows
+
+package collectors
+
+import "time"
+
+// CollectHpWarranty runs the tiered HP warranty collection: T0 reads HP's WMI
+// namespace, T1 invokes Get-HPWarrantyInfo only when HP's own cache has
+// genuinely lapsed, T2 reports that CMSL is absent. All logic lives in the
+// build-tag-free hp_warranty.go so it is unit-testable on a non-Windows CI
+// runner — this file only supplies the platform entry point.
+func CollectHpWarranty() (*HpWarrantyInfo, error) {
+	return collectHpWarrantyTiered(time.Now())
+}
+```
+
+- [ ] **Step 6: Add the orchestrator's signature so the Windows build resolves**
+
+Append to `agent/internal/collectors/hp_warranty.go` (fleshed out in Task 3; this task only needs the symbol to exist):
+
+```go
+// collectHpWarrantyTiered runs T0 → T1 → T2 against `now`. Filled in by Task 3.
+func collectHpWarrantyTiered(now time.Time) (*HpWarrantyInfo, error) {
+	return nil, &HpCollectError{Reason: HpReasonNamespaceAbsent}
+}
+```
+
+`"time"` is already in that file's import block from Step 3 (`HpWarrantyInfo.HPCacheTime` needs it), so no import change is required here.
+
+- [ ] **Step 7: Run the tests and both cross-compiles**
+
+```bash
+cd agent && go test -race ./internal/collectors/ -run 'TestCollectHpWarranty'
+cd agent && GOOS=windows GOARCH=amd64 go build ./internal/collectors/
+cd agent && GOOS=darwin GOARCH=arm64 go build ./internal/collectors/
+```
+Expected: PASS, and both builds succeed. The two builds are what prove the *entry points* line up — each platform must supply exactly one `CollectHpWarranty` with the same signature over the one shared `HpWarrantyInfo`. A missing or mistyped stub is a build failure here, not a runtime surprise on a customer endpoint.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add agent/internal/collectors/hp_warranty.go agent/internal/collectors/hp_warranty_windows.go agent/internal/collectors/hp_warranty_other.go agent/internal/collectors/hp_warranty_other_test.go
+git commit -m "feat(agent): HP warranty collector scaffolding — shared types plus two platform entry points (W03)"
+```
+
+---
+
+## Task 2: T0 — parse HP's WMI output from the probe's captured JSON
+
+> **Blocked on the W01 gate, question 2.** Do not implement without `hp_warranty_wmi_real.json`.
+
+**Files:**
+- Create: `agent/internal/collectors/testdata/hp_warranty_wmi_real.json`
+- Modify: `agent/internal/collectors/hp_warranty.go`
+- Test: `agent/internal/collectors/hp_warranty_test.go`
+
+**Interfaces:**
+- Produces: `parseHpWarrantyWMI(raw []byte) (*HpWarrantyInfo, error)`, `hpEntitlementRows` (object-or-array tolerant decoder), `normalizeHpDate(string) string`, `parseHpTimestamp(string) time.Time`, `pickHpString(map[string]any, ...string) string`, and the field-candidate vars `hpSerialFields`, `hpProductNumberFields`, `hpCoverageStartFields`, `hpCoverageEndFields`, `hpCoverageTypeFields`, `hpCacheTimeFields`, `hpEntStartFields`, `hpEntEndFields`, `hpEntTypeFields`, `hpEntDescFields`.
+- Consumes: `HpWarrantyInfo`, `HpEntitlement`, `HpCollectError`, the `HpReason*` constants (Task 1).
+
+- [ ] **Step 1: Drop in the probe fixture**
+
+Take the captured `Get-CimInstance` output recorded by W01 on issue #5512 and save it **verbatim** as `agent/internal/collectors/testdata/hp_warranty_wmi_real.json`, wrapped in the envelope the T0 script emits (Task 3):
+
+```json
+{"NamespacePresent":true,"Error":"","Warranty":{"SerialNumber":"5CD1234ABC","ProductNumber":"1A2B3C#ABA","WarrantyStartDate":"20240115000000.000000+000","WarrantyEndDate":"20270114000000.000000+000","WarrantyType":"HP 3 year Next Business Day Onsite","LastUpdate":"20260820113000.000000+000"},"Entitlements":[{"ServiceLevelDescription":"HP 3 year Next Business Day Onsite","OfferDescription":"Next Business Day Onsite","StartDate":"20240115000000.000000+000","EndDate":"20270114000000.000000+000"},{"ServiceLevelDescription":"HP 1 year Accidental Damage Protection","OfferDescription":"Accidental Damage Protection","StartDate":"20240115000000.000000+000","EndDate":"20250114000000.000000+000"}]}
+```
+
+**Then reconcile the candidate lists in Step 3 against the real property names in that file.** If HP's `HP_Warranty` class calls the end date something other than `WarrantyEndDate`/`EndDate`/`CoverageEndDate`, add the real name to `hpCoverageEndFields` — that is a one-line change to a named var, and it is the only place a name lives.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `agent/internal/collectors/hp_warranty_test.go`:
+
+```go
+package collectors
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestParseHpWarrantyWMI_RealProbeFixture(t *testing.T) {
+	raw, err := os.ReadFile("testdata/hp_warranty_wmi_real.json")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	info, err := parseHpWarrantyWMI(raw)
+	if err != nil {
+		t.Fatalf("parseHpWarrantyWMI() error = %v, want nil", err)
+	}
+	if info.SerialNumber == "" {
+		t.Error("SerialNumber did not resolve — add the real property name to hpSerialFields")
+	}
+	if info.CoverageEndDate == "" {
+		t.Error("CoverageEndDate did not resolve — add the real property name to hpCoverageEndFields")
+	}
+	if info.CoverageStartDate == "" {
+		t.Error("CoverageStartDate did not resolve — add the real property name to hpCoverageStartFields")
+	}
+	if info.HPCacheTime.IsZero() {
+		t.Error("HPCacheTime did not resolve — add the real property name to hpCacheTimeFields; scheduling (D8) depends on it")
+	}
+	if len(info.Entitlements) == 0 {
+		t.Error("no entitlements parsed — check hpEntDescFields / the Entitlements envelope key")
+	}
+	for i, e := range info.Entitlements {
+		if e.EndDate == "" {
+			t.Errorf("entitlement %d has no EndDate — add the real property name to hpEntEndFields", i)
+		}
+	}
+}
+
+func TestParseHpWarrantyWMI_Table(t *testing.T) {
+	tests := []struct {
+		name        string
+		raw         string
+		wantErr     bool
+		wantReason  string
+		wantEnd     string
+		wantEntLen  int
+		wantCacheAt string // RFC3339, "" = zero
+	}{
+		{
+			name:       "namespace absent is T2, not a parse failure",
+			raw:        `{"NamespacePresent":false,"Error":"Invalid namespace","Warranty":null,"Entitlements":[]}`,
+			wantErr:    true,
+			wantReason: HpReasonNamespaceAbsent,
+		},
+		{
+			name:       "namespace present but no warranty row",
+			raw:        `{"NamespacePresent":true,"Error":"","Warranty":null,"Entitlements":[]}`,
+			wantErr:    true,
+			wantReason: HpReasonNoWarrantyRow,
+		},
+		{
+			name:       "powershell below 5.1 is reported, not swallowed",
+			raw:        `{"NamespacePresent":false,"Error":"powershell-below-5-1","Warranty":null,"Entitlements":[]}`,
+			wantErr:    true,
+			wantReason: HpReasonPowerShellTooOld,
+		},
+		{
+			name:       "Get-CimInstance unavailable is reported distinctly",
+			raw:        `{"NamespacePresent":false,"Error":"get-ciminstance-unavailable","Warranty":null,"Entitlements":[]}`,
+			wantErr:    true,
+			wantReason: HpReasonPowerShellFailed,
+		},
+		{
+			name:       "not JSON at all",
+			raw:        `Get-CimInstance : Invalid namespace`,
+			wantErr:    true,
+			wantReason: HpReasonParseFailed,
+		},
+		{
+			name:        "CIM DATETIME dates normalise to YYYY-MM-DD and the cache time parses",
+			raw:         `{"NamespacePresent":true,"Error":"","Warranty":{"SerialNumber":"X","WarrantyStartDate":"20240115000000.000000+000","WarrantyEndDate":"20270114000000.000000+000","LastUpdate":"20260820113000.000000+000"},"Entitlements":[]}`,
+			wantEnd:     "2027-01-14",
+			wantEntLen:  0,
+			wantCacheAt: "2026-08-20T11:30:00Z",
+		},
+		{
+			name:        "ISO-8601 dates are accepted as-is",
+			raw:         `{"NamespacePresent":true,"Error":"","Warranty":{"SerialNumber":"X","StartDate":"2024-01-15","EndDate":"2027-01-14T00:00:00Z","LastUpdate":"2026-08-20T11:30:00Z"},"Entitlements":[]}`,
+			wantEnd:     "2027-01-14",
+			wantCacheAt: "2026-08-20T11:30:00Z",
+		},
+		{
+			name:        "/Date(ms)/ dates are accepted",
+			raw:         `{"NamespacePresent":true,"Error":"","Warranty":{"SerialNumber":"X","EndDate":"/Date(1799971200000)/","LastUpdate":"/Date(1787225400000)/"},"Entitlements":[]}`,
+			wantEnd:     "2027-01-14",
+			wantCacheAt: "2026-08-20T11:30:00Z",
+		},
+		{
+			name: "PowerShell 5.1 collapses a single entitlement to an object, not an array (#hardware_wmi_parse.go lesson)",
+			raw: `{"NamespacePresent":true,"Error":"","Warranty":{"SerialNumber":"X","EndDate":"2027-01-14"},` +
+				`"Entitlements":{"ServiceLevelDescription":"HP 3y NBD","OfferDescription":"NBD Onsite","StartDate":"2024-01-15","EndDate":"2027-01-14"}}`,
+			wantEnd:    "2027-01-14",
+			wantEntLen: 1,
+		},
+		{
+			name: "an entitlement with no usable field at all is dropped, the rest survive",
+			raw: `{"NamespacePresent":true,"Error":"","Warranty":{"SerialNumber":"X","EndDate":"2027-01-14"},` +
+				`"Entitlements":[{},{"ServiceLevelDescription":"HP 3y NBD","EndDate":"2027-01-14"}]}`,
+			wantEnd:    "2027-01-14",
+			wantEntLen: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info, err := parseHpWarrantyWMI([]byte(tt.raw))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parseHpWarrantyWMI() error = nil, want %s", tt.wantReason)
+				}
+				var hpErr *HpCollectError
+				if !errorsAs(err, &hpErr) {
+					t.Fatalf("error is %T, want *HpCollectError", err)
+				}
+				if hpErr.Reason != tt.wantReason {
+					t.Fatalf("Reason = %q, want %q", hpErr.Reason, tt.wantReason)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseHpWarrantyWMI() error = %v, want nil", err)
+			}
+			if info.CoverageEndDate != tt.wantEnd {
+				t.Errorf("CoverageEndDate = %q, want %q", info.CoverageEndDate, tt.wantEnd)
+			}
+			if len(info.Entitlements) != tt.wantEntLen {
+				t.Errorf("len(Entitlements) = %d, want %d", len(info.Entitlements), tt.wantEntLen)
+			}
+			if tt.wantCacheAt == "" {
+				if !info.HPCacheTime.IsZero() {
+					t.Errorf("HPCacheTime = %v, want zero", info.HPCacheTime)
+				}
+			} else {
+				want, perr := time.Parse(time.RFC3339, tt.wantCacheAt)
+				if perr != nil {
+					t.Fatalf("bad want in table: %v", perr)
+				}
+				if !info.HPCacheTime.Equal(want) {
+					t.Errorf("HPCacheTime = %v, want %v", info.HPCacheTime, want)
+				}
+			}
+		})
+	}
+}
+
+func TestNormalizeHpDate(t *testing.T) {
+	tests := []struct{ name, in, want string }{
+		{"empty", "", ""},
+		{"CIM DATETIME", "20270114000000.000000+000", "2027-01-14"},
+		{"CIM DATETIME negative offset", "20270114000000.000000-420", "2027-01-14"},
+		{"date only", "2027-01-14", "2027-01-14"},
+		{"RFC3339", "2027-01-14T00:00:00Z", "2027-01-14"},
+		{"US slash form HP sometimes emits", "01/14/2027", "2027-01-14"},
+		{"dotnet date", "/Date(1799971200000)/", "2027-01-14"},
+		{"unparseable is dropped, never forwarded", "sometime next year", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeHpDate(tt.in); got != tt.want {
+				t.Fatalf("normalizeHpDate(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+```bash
+cd agent && go test -race ./internal/collectors/ -run 'TestParseHpWarrantyWMI|TestNormalizeHpDate'
+```
+Expected: FAIL to build — `undefined: parseHpWarrantyWMI`, `undefined: normalizeHpDate`.
+
+- [ ] **Step 4: Implement the parser**
+
+Append to `agent/internal/collectors/hp_warranty.go`:
+
+```go
+// ---------------------------------------------------------------------------
+// T0 — parsing HP's WMI output
+//
+// HP does not publish a stable schema for HP_Warranty / HP_Entitlements, and
+// the property names below were taken from a real HP endpoint captured by the
+// W01 lab probe (issue #5512), not from documentation. Each logical field
+// therefore resolves through an ordered candidate list: the FIRST name present
+// and non-empty wins. Adding a name HP uses on a model we have not seen is a
+// one-line change to exactly one var — no parsing code changes.
+// ---------------------------------------------------------------------------
+
+var (
+	hpSerialFields        = []string{"SerialNumber", "Serial", "SystemSerialNumber"}
+	hpProductNumberFields = []string{"ProductNumber", "SKU", "ProductSKU", "SystemSKU"}
+	hpCoverageStartFields = []string{"WarrantyStartDate", "StartDate", "CoverageStartDate", "PurchaseDate", "ShipDate"}
+	hpCoverageEndFields   = []string{"WarrantyEndDate", "EndDate", "CoverageEndDate", "ExpirationDate"}
+	hpCoverageTypeFields  = []string{"WarrantyType", "ServiceLevelDescription", "OfferDescription", "CoverageType", "Description"}
+	// hpCacheTimeFields resolves HP's OWN cache write time. Scheduling (D8)
+	// depends entirely on this: without it every device falls back to the
+	// bootstrap cadence and re-invokes CMSL far more often than HP's 30-day
+	// cache justifies.
+	hpCacheTimeFields = []string{"LastUpdate", "LastUpdated", "LastRefresh", "Timestamp", "CacheDate", "RetrievedDate", "QueryDate"}
+
+	hpEntDescFields  = []string{"ServiceLevelDescription", "Description", "ServiceLevel", "OfferDescription"}
+	hpEntTypeFields  = []string{"OfferDescription", "EntitlementType", "Type", "ServiceType", "OfferType"}
+	hpEntStartFields = []string{"StartDate", "ServiceStartDate", "CoverageStartDate"}
+	hpEntEndFields   = []string{"EndDate", "ServiceEndDate", "CoverageEndDate", "ExpirationDate"}
+)
+
+// hpWmiEnvelope is the shape the T0 PowerShell script emits (Task 3). The
+// Warranty and Entitlements members are decoded as raw property bags because
+// their property names are HP's, not ours.
+type hpWmiEnvelope struct {
+	NamespacePresent bool               `json:"NamespacePresent"`
+	Error            string             `json:"Error"`
+	Warranty         map[string]any     `json:"Warranty"`
+	Entitlements     hpEntitlementRows  `json:"Entitlements"`
+}
+
+// hpEntitlementRows tolerates both shapes Windows can emit for a class that
+// returned one instance. Windows PowerShell 5.1 — the default shell on
+// essentially every managed endpoint — collapses a single-element array to a
+// bare object during ConvertTo-Json, so a device with exactly one entitlement
+// (very common) emits an object where a multi-entitlement device emits an
+// array. Decoding straight into a slice would fail on those hosts and, because
+// a parse error is fatal here, would drop the ENTIRE warranty record. This is
+// the same trap gpuNameList guards in hardware_wmi_parse.go.
+type hpEntitlementRows []map[string]any
+
+func (r *hpEntitlementRows) UnmarshalJSON(data []byte) error {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || string(trimmed) == "null" {
+		*r = nil
+		return nil
+	}
+	if trimmed[0] == '[' {
+		var rows []map[string]any
+		if err := json.Unmarshal(trimmed, &rows); err != nil {
+			return err
+		}
+		*r = rows
+		return nil
+	}
+	var one map[string]any
+	if err := json.Unmarshal(trimmed, &one); err != nil {
+		return err
+	}
+	*r = hpEntitlementRows{one}
+	return nil
+}
+
+// parseHpWarrantyWMI decodes the T0 script's envelope into an HpWarrantyInfo.
+// A missing namespace is T2 (CMSL not installed) and is returned as a typed
+// error rather than an empty struct, so the caller can tell "HP is not managed
+// here" from "HP is managed and has nothing to say".
+func parseHpWarrantyWMI(raw []byte) (*HpWarrantyInfo, error) {
+	var env hpWmiEnvelope
+	if err := json.Unmarshal(bytes.TrimSpace(raw), &env); err != nil {
+		return nil, &HpCollectError{
+			Reason: HpReasonParseFailed,
+			Detail: truncateHpString(err.Error()),
+		}
+	}
+
+	if !env.NamespacePresent {
+		switch env.Error {
+		case hpErrPowerShellTooOld:
+			return nil, &HpCollectError{Reason: HpReasonPowerShellTooOld, Detail: "PowerShell 5.1 or newer is required by HP CMSL"}
+		case hpErrCimUnavailable:
+			return nil, &HpCollectError{Reason: HpReasonPowerShellFailed, Detail: "Get-CimInstance is unavailable on this host"}
+		default:
+			return nil, &HpCollectError{Reason: HpReasonNamespaceAbsent, Detail: truncateHpString(env.Error)}
+		}
+	}
+	if len(env.Warranty) == 0 {
+		return nil, &HpCollectError{Reason: HpReasonNoWarrantyRow, Detail: truncateHpString(env.Error)}
+	}
+
+	info := &HpWarrantyInfo{
+		SerialNumber:      pickHpString(env.Warranty, hpSerialFields...),
+		ProductNumber:     pickHpString(env.Warranty, hpProductNumberFields...),
+		CoverageStartDate: normalizeHpDate(pickHpString(env.Warranty, hpCoverageStartFields...)),
+		CoverageEndDate:   normalizeHpDate(pickHpString(env.Warranty, hpCoverageEndFields...)),
+		CoverageType:      pickHpString(env.Warranty, hpCoverageTypeFields...),
+		HPCacheTime:       parseHpTimestamp(pickHpString(env.Warranty, hpCacheTimeFields...)),
+		Tier:              HpTierT0,
+		Reason:            HpReasonOK,
+	}
+
+	for _, row := range env.Entitlements {
+		ent := HpEntitlement{
+			ServiceLevelDescription: pickHpString(row, hpEntDescFields...),
+			EntitlementType:         pickHpString(row, hpEntTypeFields...),
+			StartDate:               normalizeHpDate(pickHpString(row, hpEntStartFields...)),
+			EndDate:                 normalizeHpDate(pickHpString(row, hpEntEndFields...)),
+		}
+		// A row with nothing usable is HP metadata noise, not an entitlement.
+		// Forwarding it would push a blank row into device_warranty.entitlements
+		// and show as an empty line in the device UI.
+		if ent.ServiceLevelDescription == "" && ent.EntitlementType == "" && ent.EndDate == "" {
+			continue
+		}
+		info.Entitlements = append(info.Entitlements, ent)
+	}
+
+	return info, nil
+}
+
+// pickHpString returns the first non-empty string value among names. Numeric
+// and boolean WMI values are stringified rather than dropped — HP emits some
+// dates as JSON numbers on older CMSL builds.
+func pickHpString(m map[string]any, names ...string) string {
+	for _, name := range names {
+		v, ok := m[name]
+		if !ok || v == nil {
+			continue
+		}
+		var s string
+		switch typed := v.(type) {
+		case string:
+			s = typed
+		case float64:
+			s = strconv.FormatFloat(typed, 'f', -1, 64)
+		case bool:
+			s = strconv.FormatBool(typed)
+		default:
+			continue
+		}
+		if s = strings.TrimSpace(s); s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+// hpDotNetDateRe matches the JavaScriptSerializer form ConvertTo-Json emits for
+// [datetime] on Windows PowerShell 5.1: /Date(1799971200000)/, optionally with
+// a trailing offset such as /Date(1799971200000+0000)/.
+var hpDotNetDateRe = regexp.MustCompile(`^/Date\((-?\d+)(?:[+-]\d{4})?\)/$`)
+
+// hpDateLayouts are tried in order for a plain string date. The CIM DATETIME
+// layout ("20270114000000.000000+000") is first because it is what a raw WMI
+// property carries when ConvertTo-Json does not coerce it.
+var hpDateLayouts = []string{
+	"20060102150405.000000-070",
+	"20060102150405.000000+070",
+	time.RFC3339,
+	"2006-01-02T15:04:05",
+	"2006-01-02 15:04:05",
+	"2006-01-02",
+	"01/02/2006",
+	"1/2/2006",
+}
+
+// parseHpTimestamp resolves an HP-supplied timestamp to a time.Time in UTC,
+// returning the zero time when it cannot be parsed. Callers MUST treat a zero
+// return as "unknown" and never as "epoch" — hpCacheStale depends on that
+// distinction to decide whether a refresh is warranted.
+func parseHpTimestamp(value string) time.Time {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}
+	}
+	if m := hpDotNetDateRe.FindStringSubmatch(value); m != nil {
+		ms, err := strconv.ParseInt(m[1], 10, 64)
+		if err != nil {
+			return time.Time{}
+		}
+		return time.UnixMilli(ms).UTC()
+	}
+	for _, layout := range hpDateLayouts {
+		if t, err := time.Parse(layout, value); err == nil {
+			return t.UTC()
+		}
+	}
+	return time.Time{}
+}
+
+// normalizeHpDate renders an HP date as YYYY-MM-DD, or "" when it cannot be
+// parsed. Dropping an unparseable date is deliberate: agentWarrantyInfoSchema's
+// warrantyDateSchema (schemas.ts:649-656) would coerce it to undefined anyway,
+// and forwarding garbage risks tripping the .max(50) bound and 400-ing the
+// whole report.
+func normalizeHpDate(value string) string {
+	t := parseHpTimestamp(value)
+	if t.IsZero() {
+		return ""
+	}
+	return t.Format("2006-01-02")
+}
+
+// truncateHpString bounds a diagnostic string to the same 200-char limit D10
+// applies to reported fields, so a runaway PowerShell error can never inflate a
+// log line or a payload field.
+func truncateHpString(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) <= hpFieldMaxLen {
+		return value
+	}
+	return strings.TrimSpace(value[:hpFieldMaxLen])
+}
+```
+
+Extend the import block of `hp_warranty.go` to:
+
+```go
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+```
+
+and add the two script-sentinel constants plus the field bound near the top of the file (they are referenced above and fleshed out in Tasks 3 and 5):
+
+```go
+const (
+	// hpErrPowerShellTooOld / hpErrCimUnavailable are sentinels the T0 script
+	// writes into the envelope's Error field so the Go side can tell a genuine
+	// prerequisite failure from an absent namespace. Both mean "cannot collect",
+	// but only one of them is fixable by installing CMSL.
+	hpErrPowerShellTooOld = "powershell-below-5-1"
+	hpErrCimUnavailable   = "get-ciminstance-unavailable"
+
+	// hpFieldMaxLen is D10's per-field bound: at most 200 characters.
+	hpFieldMaxLen = 200
+)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+cd agent && go test -race ./internal/collectors/ -run 'TestParseHpWarrantyWMI|TestNormalizeHpDate' -v
+```
+Expected: PASS, including `TestParseHpWarrantyWMI_RealProbeFixture`. **If the fixture subtest reports "did not resolve", add the real property name to the named var it points at and re-run — do not weaken the assertion.**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add agent/internal/collectors/hp_warranty.go agent/internal/collectors/hp_warranty_test.go agent/internal/collectors/testdata/hp_warranty_wmi_real.json
+git commit -m "feat(agent): parse HP_Warranty/HP_Entitlements WMI output from the W01 probe capture (W03)"
+```
+
+---
+
+## Task 3: T0 — the mockable PowerShell seam and the WMI read
+
+**Files:**
+- Modify: `agent/internal/collectors/hp_warranty.go`
+- Test: `agent/internal/collectors/hp_warranty_test.go`
+
+**Interfaces:**
+- Produces: `hpRunPowerShell` (package-level func var seam), `hpT0Script` (const), `readHpWarrantyWMI() (*HpWarrantyInfo, error)`, `hpWmiTimeout` / `hpRefreshTimeout` (consts).
+- Consumes: `parseHpWarrantyWMI`, `HpCollectError`, `HpReason*` (Task 2); `runCollectorOutput`, `utf8PowerShellCommand` (`command_limits.go:34,30`).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `agent/internal/collectors/hp_warranty_test.go`:
+
+```go
+// stubHpPowerShell installs a fake for the single PowerShell seam and returns a
+// pointer to the recorded scripts. Every test in this file uses it; NO test in
+// this wave ever spawns a real process, which is what lets the suite run on the
+// darwin/linux CI runner (Global Constraints).
+func stubHpPowerShell(t *testing.T, fn func(script string) ([]byte, error)) *[]string {
+	t.Helper()
+	original := hpRunPowerShell
+	t.Cleanup(func() { hpRunPowerShell = original })
+	var seen []string
+	hpRunPowerShell = func(_ time.Duration, script string) ([]byte, error) {
+		seen = append(seen, script)
+		return fn(script)
+	}
+	return &seen
+}
+
+func TestReadHpWarrantyWMI_UsesTheSeamAndParsesTheEnvelope(t *testing.T) {
+	seen := stubHpPowerShell(t, func(string) ([]byte, error) {
+		return []byte(`{"NamespacePresent":true,"Error":"","Warranty":{"SerialNumber":"5CD1","EndDate":"2027-01-14","LastUpdate":"2026-08-20T11:30:00Z"},"Entitlements":[]}`), nil
+	})
+
+	info, err := readHpWarrantyWMI()
+	if err != nil {
+		t.Fatalf("readHpWarrantyWMI() error = %v, want nil", err)
+	}
+	if info.SerialNumber != "5CD1" || info.CoverageEndDate != "2027-01-14" {
+		t.Fatalf("unexpected info: %#v", info)
+	}
+	if len(*seen) != 1 {
+		t.Fatalf("PowerShell invocations = %d, want exactly 1 (T0 must be a single spawn)", len(*seen))
+	}
+	script := (*seen)[0]
+	for _, want := range []string{
+		"root/HP/InstrumentedServices/v1",
+		"HP_Warranty",
+		"HP_Entitlements",
+		"ConvertTo-Json",
+		"NamespacePresent",
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("T0 script is missing %q", want)
+		}
+	}
+	if strings.Contains(script, "Get-HPWarrantyInfo") {
+		t.Error("T0 must not invoke Get-HPWarrantyInfo — that is T1, and doing it here defeats the whole point of the tiering")
+	}
+}
+
+func TestReadHpWarrantyWMI_PowerShellFailureIsReportedNotSwallowed(t *testing.T) {
+	stubHpPowerShell(t, func(string) ([]byte, error) {
+		return nil, errors.New("powershell timed out: context deadline exceeded")
+	})
+
+	_, err := readHpWarrantyWMI()
+	if err == nil {
+		t.Fatal("readHpWarrantyWMI() error = nil, want a reported failure — the spec requires reporting WHY collection failed")
+	}
+	var hpErr *HpCollectError
+	if !errorsAs(err, &hpErr) {
+		t.Fatalf("error is %T, want *HpCollectError", err)
+	}
+	if hpErr.Reason != HpReasonPowerShellFailed {
+		t.Fatalf("Reason = %q, want %q", hpErr.Reason, HpReasonPowerShellFailed)
+	}
+	if !strings.Contains(hpErr.Detail, "timed out") {
+		t.Fatalf("Detail = %q, want the underlying message preserved", hpErr.Detail)
+	}
+}
+
+func TestReadHpWarrantyWMI_PartialOutputWithAnErrorStillParses(t *testing.T) {
+	// runCollectorOutput returns (output, err) together for a non-zero exit.
+	// PowerShell writes our JSON to stdout and then exits non-zero because
+	// $ErrorActionPreference tripped on an unrelated statement; the envelope is
+	// still complete and must be used rather than discarded.
+	stubHpPowerShell(t, func(string) ([]byte, error) {
+		return []byte(`{"NamespacePresent":true,"Error":"","Warranty":{"SerialNumber":"5CD1","EndDate":"2027-01-14"},"Entitlements":[]}`),
+			errors.New("exit status 1")
+	})
+
+	info, err := readHpWarrantyWMI()
+	if err != nil {
+		t.Fatalf("readHpWarrantyWMI() error = %v, want nil when a complete envelope was captured", err)
+	}
+	if info.SerialNumber != "5CD1" {
+		t.Fatalf("unexpected info: %#v", info)
+	}
+}
+```
+
+Extend that test file's imports to:
+
+```go
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd agent && go test -race ./internal/collectors/ -run 'TestReadHpWarrantyWMI'
+```
+Expected: FAIL to build — `undefined: hpRunPowerShell`, `undefined: readHpWarrantyWMI`.
+
+- [ ] **Step 3: Implement the seam, the script and the read**
+
+Append to `agent/internal/collectors/hp_warranty.go`:
+
+```go
+// ---------------------------------------------------------------------------
+// The PowerShell seam
+//
+// The agent has NO Go WMI binding: yusufpapurcu/wmi is an indirect dependency
+// (agent/go.mod:112) imported by zero agent files, and go-ole (go.mod:18)
+// drives only the Windows Update Agent COM API and VSS. Every WMI read in the
+// agent today goes through PowerShell Get-CimInstance, and this one does too —
+// see hardware_windows.go:82-121 for the canonical batched precedent. Promoting
+// wmi to a direct dependency was considered and rejected (contract D7).
+//
+// hpRunPowerShell is a package-level var, declared in this BUILD-TAG-FREE file,
+// so a darwin/linux test can replace it. That placement is the entire reason
+// this wave's tier logic is testable on CI: a seam inside hp_warranty_windows.go
+// would be invisible to every runner we actually have.
+// ---------------------------------------------------------------------------
+
+var hpRunPowerShell = func(timeout time.Duration, script string) ([]byte, error) {
+	return runCollectorOutput(timeout, "powershell", "-NoProfile", "-NonInteractive", "-Command", utf8PowerShellCommand(script))
+}
+
+const (
+	// hpWmiTimeout bounds the T0 read. Slightly above hardware_windows.go's
+	// wmicTimeout (15s) because opening a vendor namespace on a cold WMI
+	// repository is measurably slower than the Win32_* classes.
+	hpWmiTimeout = 20 * time.Second
+	// hpRefreshTimeout bounds the T1 refresh. Get-HPWarrantyInfo makes a real
+	// network round trip to HP and is documented as slow on first use; five
+	// minutes is generous but still bounded, and the call happens at most once
+	// per HP cache lifetime (~30 days).
+	hpRefreshTimeout = 5 * time.Minute
+)
+
+// hpT0Script reads HP's warranty namespace with no network I/O, no CMSL
+// invocation and no 30-day-cache write. It emits one JSON envelope on stdout so
+// the Go side never has to parse PowerShell's human-readable output.
+//
+// Structure notes:
+//   - The PS 5.1 floor is checked first and reported as its own sentinel: HP
+//     CMSL requires 5.1+, and "your PowerShell is too old" is a completely
+//     different remediation from "CMSL is not installed" (spec Risks).
+//   - Get-CimInstance availability is checked the same way, mirroring
+//     hardware_windows.go's Get-WmiSafe guard.
+//   - The namespace probe is a separate try/catch from the data read so an
+//     "Invalid namespace" (T2 — no CMSL) is distinguishable from a namespace
+//     that exists but has no rows yet.
+//   - Cim*/PS* properties are excluded: they are CIM plumbing, they are large,
+//     and none of them is a warranty field.
+const hpT0Script = `
+$ErrorActionPreference = 'SilentlyContinue'
+$ns = 'root/HP/InstrumentedServices/v1'
+$nsPresent = $false
+$err = ''
+$warranty = $null
+$entitlements = @()
+$v = $PSVersionTable.PSVersion
+if ($v.Major -lt 5 -or ($v.Major -eq 5 -and $v.Minor -lt 1)) {
+  $err = 'powershell-below-5-1'
+} elseif (-not (Get-Command Get-CimInstance -ErrorAction SilentlyContinue)) {
+  $err = 'get-ciminstance-unavailable'
+} else {
+  try {
+    $probe = @(Get-CimInstance -Namespace $ns -ClassName HP_Warranty -ErrorAction Stop)
+    $nsPresent = $true
+    $warranty = $probe | Select-Object -First 1 | Select-Object -Property * -ExcludeProperty Cim*, PS*
+    $entitlements = @(Get-CimInstance -Namespace $ns -ClassName HP_Entitlements -ErrorAction SilentlyContinue |
+      Select-Object -Property * -ExcludeProperty Cim*, PS*)
+  } catch {
+    $err = ([string]$_.Exception.Message).Trim()
+  }
+}
+[PSCustomObject]@{
+  NamespacePresent = $nsPresent
+  Error            = $err
+  Warranty         = $warranty
+  Entitlements     = $entitlements
+} | ConvertTo-Json -Depth 5 -Compress
+`
+
+// readHpWarrantyWMI performs the T0 read: one PowerShell spawn, no network, no
+// CMSL invocation, no write to HP's 30-day cache.
+//
+// A non-zero exit that still produced a complete envelope is NOT treated as a
+// failure. runCollectorOutput returns (output, err) together, and PowerShell
+// exits non-zero for conditions our envelope already describes; discarding a
+// good payload because of the exit code would turn a working device into a
+// permanently unknown one.
+func readHpWarrantyWMI() (*HpWarrantyInfo, error) {
+	out, runErr := hpRunPowerShell(hpWmiTimeout, hpT0Script)
+	if len(bytes.TrimSpace(out)) == 0 {
+		detail := "powershell produced no output"
+		if runErr != nil {
+			detail = runErr.Error()
+		}
+		return nil, &HpCollectError{Reason: HpReasonPowerShellFailed, Detail: truncateHpString(detail)}
+	}
+	info, err := parseHpWarrantyWMI(out)
+	if err != nil {
+		// A run error alongside unparseable output is the more informative of
+		// the two; surface it rather than the JSON syntax complaint.
+		if runErr != nil {
+			var hpErr *HpCollectError
+			if errorsAs(err, &hpErr) && hpErr.Reason == HpReasonParseFailed {
+				return nil, &HpCollectError{Reason: HpReasonPowerShellFailed, Detail: truncateHpString(runErr.Error())}
+			}
+		}
+		return nil, err
+	}
+	return info, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd agent && go test -race ./internal/collectors/ -run 'TestReadHpWarrantyWMI' -v
+```
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add agent/internal/collectors/hp_warranty.go agent/internal/collectors/hp_warranty_test.go
+git commit -m "feat(agent): T0 HP WMI read through a mockable PowerShell seam (W03)"
+```
+
+---
+
+## Task 4: T1 — the CMSL refresh and 429 classification
+
+**Files:**
+- Modify: `agent/internal/collectors/hp_warranty.go`
+- Test: `agent/internal/collectors/hp_warranty_test.go`
+
+**Interfaces:**
+- Produces: `hpT1Script` (const), `refreshHpWarranty() error`, `classifyHpRefreshOutput(out []byte, runErr error) error`, `hpLooksRateLimited(string) bool`, the `hpSentinel*` consts.
+- Consumes: `hpRunPowerShell`, `hpRefreshTimeout` (Task 3); `HpCollectError`, `HpReason*` (Tasks 1–2).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `agent/internal/collectors/hp_warranty_test.go`:
+
+```go
+func TestHpLooksRateLimited(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  string
+		want bool
+	}{
+		{"bare 429 status", "The remote server returned an error: (429) Too Many Requests.", true},
+		{"429 alone as a word", "HTTP 429", true},
+		{"phrase without the number", "Request throttled, please try again later", true},
+		{"hyphenated rate-limit", "rate-limit exceeded for this source address", true},
+		{"spaced rate limit", "Rate Limit Exceeded", true},
+		{"a serial number that merely contains 429 is NOT a rate limit", "Serial 5CD429ABCD not found", false},
+		{"a 4290 status code is not 429", "returned status 4290", false},
+		{"ordinary failure", "The term 'Get-HPWarrantyInfo' is not recognized", false},
+		{"empty", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hpLooksRateLimited(tt.msg); got != tt.want {
+				t.Fatalf("hpLooksRateLimited(%q) = %v, want %v", tt.msg, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassifyHpRefreshOutput(t *testing.T) {
+	tests := []struct {
+		name       string
+		out        string
+		runErr     error
+		wantReason string // "" = success
+	}{
+		{name: "success sentinel", out: "BREEZE_HP_REFRESH_OK", wantReason: ""},
+		{name: "success sentinel with surrounding noise", out: "VERBOSE: contacting HP\r\nBREEZE_HP_REFRESH_OK\r\n", wantReason: ""},
+		{name: "cmsl absent", out: "BREEZE_HP_CMSL_ABSENT", wantReason: HpReasonCmslCmdletAbsent},
+		{name: "powershell too old", out: "BREEZE_HP_PS_TOO_OLD", wantReason: HpReasonPowerShellTooOld},
+		{
+			name:       "hp refused with 429",
+			out:        "BREEZE_HP_REFRESH_ERROR: The remote server returned an error: (429) Too Many Requests.",
+			wantReason: HpReasonRateLimited,
+		},
+		{
+			name:       "ordinary cmsl error",
+			out:        "BREEZE_HP_REFRESH_ERROR: Unable to resolve warrantyapi.hp.com",
+			wantReason: HpReasonRefreshFailed,
+		},
+		{
+			name:       "no sentinel at all is a powershell failure, never a silent success",
+			out:        "",
+			runErr:     errors.New("powershell timed out: context deadline exceeded"),
+			wantReason: HpReasonPowerShellFailed,
+		},
+		{
+			name:       "output with no recognised sentinel is a refresh failure, not a pass",
+			out:        "Get-HPWarrantyInfo : Access denied",
+			wantReason: HpReasonRefreshFailed,
+		},
+		{
+			name:       "a rate limit surfaced through the run error rather than the sentinel",
+			out:        "",
+			runErr:     errors.New("exit status 1 (stderr: HTTP 429 Too Many Requests)"),
+			wantReason: HpReasonRateLimited,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := classifyHpRefreshOutput([]byte(tt.out), tt.runErr)
+			if tt.wantReason == "" {
+				if err != nil {
+					t.Fatalf("classifyHpRefreshOutput() = %v, want nil", err)
+				}
+				return
+			}
+			var hpErr *HpCollectError
+			if !errorsAs(err, &hpErr) {
+				t.Fatalf("error is %T (%v), want *HpCollectError", err, err)
+			}
+			if hpErr.Reason != tt.wantReason {
+				t.Fatalf("Reason = %q, want %q", hpErr.Reason, tt.wantReason)
+			}
+			if tt.wantReason == HpReasonRateLimited && !IsHpRateLimited(err) {
+				t.Fatal("IsHpRateLimited() = false for a 429 — the scheduler would retry straight back into HP's per-NAT limit")
+			}
+		})
+	}
+}
+
+func TestRefreshHpWarranty_ScriptShape(t *testing.T) {
+	seen := stubHpPowerShell(t, func(string) ([]byte, error) {
+		return []byte("BREEZE_HP_REFRESH_OK"), nil
+	})
+	if err := refreshHpWarranty(); err != nil {
+		t.Fatalf("refreshHpWarranty() = %v, want nil", err)
+	}
+	if len(*seen) != 1 {
+		t.Fatalf("PowerShell invocations = %d, want 1", len(*seen))
+	}
+	script := (*seen)[0]
+	for _, want := range []string{"Get-HPWarrantyInfo", "Tls12", "BREEZE_HP_REFRESH_OK", "BREEZE_HP_CMSL_ABSENT"} {
+		if !strings.Contains(script, want) {
+			t.Errorf("T1 script is missing %q", want)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd agent && go test -race ./internal/collectors/ -run 'TestHpLooksRateLimited|TestClassifyHpRefreshOutput|TestRefreshHpWarranty'
+```
+Expected: FAIL to build — `undefined: hpLooksRateLimited`, `undefined: classifyHpRefreshOutput`, `undefined: refreshHpWarranty`.
+
+- [ ] **Step 3: Implement T1**
+
+Append to `agent/internal/collectors/hp_warranty.go`:
+
+```go
+// ---------------------------------------------------------------------------
+// T1 — refreshing HP's own cache
+//
+// Get-HPWarrantyInfo takes no parameters, runs against the local device, writes
+// its results into the WMI classes T0 reads, and self-caches for 30 days. It is
+// invoked ONLY when hpCacheStale says HP's own cache has genuinely lapsed —
+// calling it inside the 30-day window returns cached data, refreshes nothing,
+// and still consumes one of the 300-requests-per-5-minutes-per-SOURCE-IP budget
+// the customer's whole NAT shares.
+// ---------------------------------------------------------------------------
+
+const (
+	hpSentinelRefreshOK  = "BREEZE_HP_REFRESH_OK"
+	hpSentinelCmslAbsent = "BREEZE_HP_CMSL_ABSENT"
+	hpSentinelPSTooOld   = "BREEZE_HP_PS_TOO_OLD"
+	hpSentinelRefreshErr = "BREEZE_HP_REFRESH_ERROR:"
+)
+
+// hpT1Script invokes the CMSL refresh. It communicates through sentinel tokens
+// on stdout rather than exit codes, because PowerShell's exit status is not a
+// reliable channel here: $ErrorActionPreference, module autoload noise and
+// WDAC/AppLocker denials all produce exit codes that mean different things on
+// different hosts, whereas a sentinel is unambiguous.
+//
+// TLS 1.2 is forced because CMSL's HP endpoints require it and older Windows
+// builds still default to TLS 1.0 — one of the two prerequisites the spec's
+// Risks section names. The -bor keeps any protocol the host already enabled.
+const hpT1Script = `
+$ErrorActionPreference = 'SilentlyContinue'
+$v = $PSVersionTable.PSVersion
+if ($v.Major -lt 5 -or ($v.Major -eq 5 -and $v.Minor -lt 1)) {
+  Write-Output 'BREEZE_HP_PS_TOO_OLD'
+  exit 0
+}
+try {
+  [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+} catch {}
+Import-Module HPCMSL -ErrorAction SilentlyContinue | Out-Null
+if (-not (Get-Command Get-HPWarrantyInfo -ErrorAction SilentlyContinue)) {
+  Write-Output 'BREEZE_HP_CMSL_ABSENT'
+  exit 0
+}
+try {
+  $null = Get-HPWarrantyInfo -ErrorAction Stop
+  Write-Output 'BREEZE_HP_REFRESH_OK'
+} catch {
+  Write-Output ('BREEZE_HP_REFRESH_ERROR: ' + ([string]$_.Exception.Message).Trim())
+}
+exit 0
+`
+
+// hpRateLimitRe matches HP's rate-limit refusals. \b429\b is deliberately
+// word-bounded: an unbounded "429" match would classify a serial number or a
+// 4290 status as a rate limit and idle the device for hours for no reason.
+var hpRateLimitRe = regexp.MustCompile(`(?i)\b429\b|too many requests|rate[ _-]?limit|throttl`)
+
+// hpLooksRateLimited reports whether msg describes HP refusing for rate-limit
+// reasons. HP's limit is 300 requests / 5 minutes per SOURCE IP — a
+// per-customer-NAT budget, not a per-device one — so a true here must make the
+// caller wait hours, not seconds.
+func hpLooksRateLimited(msg string) bool {
+	return hpRateLimitRe.MatchString(msg)
+}
+
+// classifyHpRefreshOutput turns the T1 script's stdout (plus any run error)
+// into nil for success or a typed *HpCollectError. Unrecognised output is a
+// refresh FAILURE, never an assumed success: treating "I don't understand this"
+// as "it worked" would advance the schedule 30 days on a device that collected
+// nothing.
+func classifyHpRefreshOutput(out []byte, runErr error) error {
+	text := strings.TrimSpace(string(out))
+
+	switch {
+	case strings.Contains(text, hpSentinelRefreshOK):
+		return nil
+	case strings.Contains(text, hpSentinelPSTooOld):
+		return &HpCollectError{Reason: HpReasonPowerShellTooOld, Detail: "PowerShell 5.1 or newer is required by HP CMSL"}
+	case strings.Contains(text, hpSentinelCmslAbsent):
+		return &HpCollectError{Reason: HpReasonCmslCmdletAbsent, Detail: "Get-HPWarrantyInfo is not available; HP CMSL is not installed"}
+	}
+
+	detail := text
+	if idx := strings.Index(text, hpSentinelRefreshErr); idx >= 0 {
+		detail = strings.TrimSpace(text[idx+len(hpSentinelRefreshErr):])
+	}
+	if runErr != nil {
+		if detail == "" {
+			detail = runErr.Error()
+		} else {
+			detail = detail + " (" + runErr.Error() + ")"
+		}
+	}
+	if hpLooksRateLimited(detail) {
+		return &HpCollectError{Reason: HpReasonRateLimited, Detail: truncateHpString(detail)}
+	}
+	if text == "" && runErr != nil {
+		return &HpCollectError{Reason: HpReasonPowerShellFailed, Detail: truncateHpString(runErr.Error())}
+	}
+	if detail == "" {
+		detail = "Get-HPWarrantyInfo produced no recognised result"
+	}
+	return &HpCollectError{Reason: HpReasonRefreshFailed, Detail: truncateHpString(detail)}
+}
+
+// refreshHpWarranty runs T1 and reports whether HP's cache was refreshed.
+func refreshHpWarranty() error {
+	out, runErr := hpRunPowerShell(hpRefreshTimeout, hpT1Script)
+	return classifyHpRefreshOutput(out, runErr)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd agent && go test -race ./internal/collectors/ -run 'TestHpLooksRateLimited|TestClassifyHpRefreshOutput|TestRefreshHpWarranty' -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Reconcile the 429 matcher against the probe capture**
+
+Open the W01 probe record on issue #5512 and find the text HP produced for any refused/failed `Get-HPWarrantyInfo` call. If HP's wording is not matched by `hpRateLimitRe`, add the literal to the regex alternation **and add a table row for it in `TestHpLooksRateLimited`**. If W01 never triggered a refusal, note in the PR that the matcher is validated against HP's documented `429` status only.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add agent/internal/collectors/hp_warranty.go agent/internal/collectors/hp_warranty_test.go
+git commit -m "feat(agent): T1 CMSL refresh with sentinel-based classification and 429 detection (W03)"
+```
+
+---
+
+## Task 5: Tier selection — T0 / T1 / T2
+
+**Files:**
+- Modify: `agent/internal/collectors/hp_warranty.go`
+- Test: `agent/internal/collectors/hp_warranty_test.go`
+
+**Interfaces:**
+- Produces: `hpCacheStale(cacheTime, now time.Time) bool`, `hpCacheTTL` / `hpRefreshMargin` (consts), and the real `collectHpWarrantyTiered(now time.Time) (*HpWarrantyInfo, error)` (replacing Task 1's placeholder).
+- Consumes: `readHpWarrantyWMI` (Task 3), `refreshHpWarranty` (Task 4), `HpTier*` / `HpReason*` (Task 1).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `agent/internal/collectors/hp_warranty_test.go`:
+
+```go
+func TestHpCacheStale(t *testing.T) {
+	now := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name  string
+		cache time.Time
+		want  bool
+	}{
+		{"unknown cache time is stale (we cannot prove it is fresh)", time.Time{}, true},
+		{"written today", now.Add(-2 * time.Hour), false},
+		{"day 25 — HP would return cached data and refresh nothing", now.Add(-25 * 24 * time.Hour), false},
+		{"day 30 exactly — still inside HP's own TTL", now.Add(-30 * 24 * time.Hour), false},
+		{"day 30 + 6h — inside the clock-skew margin", now.Add(-30*24*time.Hour - 6*time.Hour), false},
+		{"day 30 + 13h — margin elapsed, refresh is worth a network call", now.Add(-30*24*time.Hour - 13*time.Hour), true},
+		{"day 90", now.Add(-90 * 24 * time.Hour), true},
+		{"a cache time in the future (clock skew) is not stale", now.Add(48 * time.Hour), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hpCacheStale(tt.cache, now); got != tt.want {
+				t.Fatalf("hpCacheStale(%v, %v) = %v, want %v", tt.cache, now, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCollectHpWarrantyTiered(t *testing.T) {
+	now := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
+	fresh := now.Add(-3 * 24 * time.Hour).Format(time.RFC3339)
+	stale := now.Add(-45 * 24 * time.Hour).Format(time.RFC3339)
+
+	envelope := func(lastUpdate string) string {
+		return `{"NamespacePresent":true,"Error":"","Warranty":{"SerialNumber":"5CD1","WarrantyEndDate":"2027-01-14","LastUpdate":"` +
+			lastUpdate + `"},"Entitlements":[{"ServiceLevelDescription":"HP 3y NBD","EndDate":"2027-01-14"}]}`
+	}
+
+	tests := []struct {
+		name string
+		// responses is consumed in order, one per PowerShell spawn.
+		responses  []struct {
+			out string
+			err error
+		}
+		wantTier      string
+		wantReason    string
+		wantErrReason string // "" = expect no error
+		wantSpawns    int
+		wantRateLimit bool
+	}{
+		{
+			name: "T0 — fresh HP cache, no refresh, exactly one spawn",
+			responses: []struct {
+				out string
+				err error
+			}{{out: envelope(fresh)}},
+			wantTier:   HpTierT0,
+			wantReason: HpReasonOK,
+			wantSpawns: 1,
+		},
+		{
+			name: "T1 — stale HP cache refreshes then re-reads WMI",
+			responses: []struct {
+				out string
+				err error
+			}{
+				{out: envelope(stale)},
+				{out: hpSentinelRefreshOK},
+				{out: envelope(now.Format(time.RFC3339))},
+			},
+			wantTier:   HpTierT1,
+			wantReason: HpReasonOK,
+			wantSpawns: 3,
+		},
+		{
+			name: "T2 — namespace absent means CMSL is not installed; report nothing and let the policy install it",
+			responses: []struct {
+				out string
+				err error
+			}{{out: `{"NamespacePresent":false,"Error":"Invalid namespace","Warranty":null,"Entitlements":[]}`}},
+			wantErrReason: HpReasonNamespaceAbsent,
+			wantSpawns:    1,
+		},
+		{
+			name: "namespace present but empty escalates to T1 rather than reporting nothing",
+			responses: []struct {
+				out string
+				err error
+			}{
+				{out: `{"NamespacePresent":true,"Error":"","Warranty":null,"Entitlements":[]}`},
+				{out: hpSentinelRefreshOK},
+				{out: envelope(now.Format(time.RFC3339))},
+			},
+			wantTier:   HpTierT1,
+			wantReason: HpReasonOK,
+			wantSpawns: 3,
+		},
+		{
+			name: "T1 refused with 429 — the stale T0 data is still served, flagged rate-limited",
+			responses: []struct {
+				out string
+				err error
+			}{
+				{out: envelope(stale)},
+				{out: hpSentinelRefreshErr + " The remote server returned an error: (429) Too Many Requests."},
+			},
+			wantTier:      HpTierT0,
+			wantReason:    HpReasonRateLimited,
+			wantSpawns:    2,
+			wantRateLimit: true,
+		},
+		{
+			name: "T1 failed and there was no T0 data at all — surface the refresh failure",
+			responses: []struct {
+				out string
+				err error
+			}{
+				{out: `{"NamespacePresent":true,"Error":"","Warranty":null,"Entitlements":[]}`},
+				{out: hpSentinelCmslAbsent},
+			},
+			wantErrReason: HpReasonCmslCmdletAbsent,
+			wantSpawns:    2,
+		},
+		{
+			name: "T1 succeeded but the re-read failed — the stale T0 data is still better than nothing",
+			responses: []struct {
+				out string
+				err error
+			}{
+				{out: envelope(stale)},
+				{out: hpSentinelRefreshOK},
+				{out: "", err: errors.New("powershell timed out")},
+			},
+			wantTier:   HpTierT0,
+			wantReason: HpReasonPowerShellFailed,
+			wantSpawns: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			idx := 0
+			original := hpRunPowerShell
+			t.Cleanup(func() { hpRunPowerShell = original })
+			spawns := 0
+			hpRunPowerShell = func(_ time.Duration, _ string) ([]byte, error) {
+				spawns++
+				if idx >= len(tt.responses) {
+					t.Fatalf("unexpected PowerShell spawn %d — the tier logic invoked more commands than the case allows", spawns)
+				}
+				r := tt.responses[idx]
+				idx++
+				return []byte(r.out), r.err
+			}
+
+			info, err := collectHpWarrantyTiered(now)
+
+			if spawns != tt.wantSpawns {
+				t.Errorf("PowerShell spawns = %d, want %d", spawns, tt.wantSpawns)
+			}
+			if tt.wantErrReason != "" {
+				if err == nil {
+					t.Fatalf("collectHpWarrantyTiered() error = nil, want %s", tt.wantErrReason)
+				}
+				var hpErr *HpCollectError
+				if !errorsAs(err, &hpErr) {
+					t.Fatalf("error is %T, want *HpCollectError", err)
+				}
+				if hpErr.Reason != tt.wantErrReason {
+					t.Fatalf("Reason = %q, want %q", hpErr.Reason, tt.wantErrReason)
+				}
+				if info != nil {
+					t.Fatalf("info = %#v, want nil alongside an error", info)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("collectHpWarrantyTiered() error = %v, want nil", err)
+			}
+			if info.Tier != tt.wantTier {
+				t.Errorf("Tier = %q, want %q", info.Tier, tt.wantTier)
+			}
+			if info.Reason != tt.wantReason {
+				t.Errorf("Reason = %q, want %q", info.Reason, tt.wantReason)
+			}
+			if info.RateLimited != tt.wantRateLimit {
+				t.Errorf("RateLimited = %v, want %v — the scheduler cannot back off from a flag it never sees", info.RateLimited, tt.wantRateLimit)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd agent && go test -race ./internal/collectors/ -run 'TestHpCacheStale|TestCollectHpWarrantyTiered'
+```
+Expected: `TestHpCacheStale` fails to build (`undefined: hpCacheStale`); `TestCollectHpWarrantyTiered` fails on every case because Task 1's placeholder returns `HpReasonNamespaceAbsent` with zero spawns.
+
+- [ ] **Step 3: Implement**
+
+In `agent/internal/collectors/hp_warranty.go`, **replace** Task 1's placeholder `collectHpWarrantyTiered` with the following, and add the two constants:
+
+```go
+const (
+	// hpCacheTTL is HP's own self-cache lifetime: a Get-HPWarrantyInfo call
+	// inside this window returns the stored WMI data without a network round
+	// trip, so invoking early refreshes nothing and burns per-NAT budget.
+	hpCacheTTL = 30 * 24 * time.Hour
+	// hpRefreshMargin is added AFTER the TTL, not before it. HP's cache clock
+	// and ours are not the same clock; refreshing at day 29 because our clock
+	// ran fast would produce a guaranteed no-op call, which is the exact failure
+	// the spec calls out ("an arbitrary day-25 invocation returns cached data
+	// and refreshes nothing"). Waiting a further 12 hours guarantees HP's own
+	// TTL has genuinely lapsed before we spend a request.
+	hpRefreshMargin = 12 * time.Hour
+)
+
+// hpCacheStale reports whether HP's own cache has genuinely lapsed and a T1
+// refresh is therefore worth a network round trip.
+//
+// A zero cacheTime means "unknown", which is treated as stale: we cannot prove
+// the data is fresh, and the alternative — assuming freshness — would leave a
+// device that never resolved a cache timestamp permanently un-refreshed.
+// A cacheTime in the future (device clock behind HP's) is NOT stale: the safe
+// direction under clock skew is to wait.
+func hpCacheStale(cacheTime, now time.Time) bool {
+	if cacheTime.IsZero() {
+		return true
+	}
+	return now.Sub(cacheTime) > hpCacheTTL+hpRefreshMargin
+}
+
+// collectHpWarrantyTiered runs the three tiers, cheapest first.
+//
+//	T0 — read HP's WMI namespace. No network, no CMSL invocation, no cache write.
+//	T1 — invoke Get-HPWarrantyInfo, but ONLY when T0 found no data or HP's own
+//	     cache has genuinely lapsed, then re-read WMI.
+//	T2 — the namespace does not exist: CMSL is not installed. Report nothing and
+//	     let the software policy install it.
+//
+// Two deliberate "serve stale" branches exist. If T1 fails (429, network, CMSL
+// gone) but T0 produced data, that data is returned with the failure recorded in
+// Reason (and RateLimited when applicable) rather than discarded — month-old
+// warranty dates are far more useful to an MSP than `status = 'unknown'`, which
+// is the exact condition this whole feature exists to fix. The scheduler still
+// sees the failure and backs off, because Reason and RateLimited travel on the
+// struct.
+func collectHpWarrantyTiered(now time.Time) (*HpWarrantyInfo, error) {
+	info, err := readHpWarrantyWMI()
+	if err != nil {
+		var hpErr *HpCollectError
+		// T2: the namespace is absent, so CMSL is not installed. There is
+		// nothing to refresh — invoking T1 would only confirm what we know.
+		if errorsAs(err, &hpErr) && hpErr.Reason == HpReasonNamespaceAbsent {
+			return nil, err
+		}
+		// A prerequisite failure (PowerShell too old, Get-CimInstance missing)
+		// is equally unfixable by a refresh.
+		if errorsAs(err, &hpErr) &&
+			(hpErr.Reason == HpReasonPowerShellTooOld || hpErr.Reason == HpReasonPowerShellFailed) {
+			return nil, err
+		}
+		// Otherwise the namespace exists but held no usable warranty row — that
+		// is exactly what a refresh is for. info stays nil; fall through to T1.
+		info = nil
+	}
+
+	if info != nil && !hpCacheStale(info.HPCacheTime, now) {
+		return info, nil
+	}
+
+	if refreshErr := refreshHpWarranty(); refreshErr != nil {
+		if info == nil {
+			return nil, refreshErr
+		}
+		var hpErr *HpCollectError
+		if errorsAs(refreshErr, &hpErr) {
+			info.Reason = hpErr.Reason
+			info.RateLimited = hpErr.Reason == HpReasonRateLimited
+		} else {
+			info.Reason = HpReasonRefreshFailed
+		}
+		info.Tier = HpTierT0
+		return info, nil
+	}
+
+	refreshed, reReadErr := readHpWarrantyWMI()
+	if reReadErr != nil {
+		if info == nil {
+			return nil, reReadErr
+		}
+		var hpErr *HpCollectError
+		if errorsAs(reReadErr, &hpErr) {
+			info.Reason = hpErr.Reason
+		} else {
+			info.Reason = HpReasonParseFailed
+		}
+		info.Tier = HpTierT0
+		return info, nil
+	}
+
+	refreshed.Tier = HpTierT1
+	refreshed.Reason = HpReasonOK
+	return refreshed, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd agent && go test -race ./internal/collectors/ -run 'TestHpCacheStale|TestCollectHpWarrantyTiered' -v
+```
+Expected: PASS (8 + 7 subtests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add agent/internal/collectors/hp_warranty.go agent/internal/collectors/hp_warranty_test.go
+git commit -m "feat(agent): HP warranty tier selection keyed on HP's own cache timestamp (W03)"
+```
+
+---
+
+## Task 6: Bound the report to D10's limits before it leaves the device
+
+**Files:**
+- Modify: `agent/internal/collectors/hp_warranty.go`
+- Test: `agent/internal/collectors/hp_warranty_test.go`
+
+**Interfaces:**
+- Produces: `boundHpWarrantyInfo(*HpWarrantyInfo) *HpWarrantyInfo`, `maxHpEntitlements` (const).
+- Consumes: `HpWarrantyInfo`, `HpEntitlement`, `hpFieldMaxLen` (Tasks 1–2).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `agent/internal/collectors/hp_warranty_test.go`:
+
+```go
+func TestBoundHpWarrantyInfo(t *testing.T) {
+	long := strings.Repeat("x", 900)
+
+	t.Run("nil in, nil out", func(t *testing.T) {
+		if got := boundHpWarrantyInfo(nil); got != nil {
+			t.Fatalf("boundHpWarrantyInfo(nil) = %#v, want nil", got)
+		}
+	})
+
+	t.Run("string fields are capped at 200 characters", func(t *testing.T) {
+		got := boundHpWarrantyInfo(&HpWarrantyInfo{
+			SerialNumber:  long,
+			ProductNumber: long,
+			CoverageType:  long,
+			Entitlements: []HpEntitlement{{
+				ServiceLevelDescription: long,
+				EntitlementType:         long,
+			}},
+		})
+		if len(got.SerialNumber) != hpFieldMaxLen {
+			t.Errorf("len(SerialNumber) = %d, want %d", len(got.SerialNumber), hpFieldMaxLen)
+		}
+		if len(got.ProductNumber) != hpFieldMaxLen {
+			t.Errorf("len(ProductNumber) = %d, want %d", len(got.ProductNumber), hpFieldMaxLen)
+		}
+		if len(got.CoverageType) != hpFieldMaxLen {
+			t.Errorf("len(CoverageType) = %d, want %d", len(got.CoverageType), hpFieldMaxLen)
+		}
+		if len(got.Entitlements[0].ServiceLevelDescription) != hpFieldMaxLen {
+			t.Errorf("len(ServiceLevelDescription) = %d, want %d", len(got.Entitlements[0].ServiceLevelDescription), hpFieldMaxLen)
+		}
+		if len(got.Entitlements[0].EntitlementType) != hpFieldMaxLen {
+			t.Errorf("len(EntitlementType) = %d, want %d", len(got.Entitlements[0].EntitlementType), hpFieldMaxLen)
+		}
+	})
+
+	t.Run("at most 25 entitlements survive, newest end date first", func(t *testing.T) {
+		in := &HpWarrantyInfo{}
+		// 40 entitlements ending on 40 consecutive days; the 25 with the latest
+		// end dates must be the ones that survive.
+		for i := 0; i < 40; i++ {
+			in.Entitlements = append(in.Entitlements, HpEntitlement{
+				ServiceLevelDescription: "ent",
+				EndDate:                 time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC).AddDate(0, 0, i).Format("2006-01-02"),
+			})
+		}
+		got := boundHpWarrantyInfo(in)
+		if len(got.Entitlements) != maxHpEntitlements {
+			t.Fatalf("len(Entitlements) = %d, want %d", len(got.Entitlements), maxHpEntitlements)
+		}
+		if got.Entitlements[0].EndDate != "2027-02-09" {
+			t.Errorf("first entitlement EndDate = %q, want the latest (2027-02-09) — dropping the longest coverage would understate the device", got.Entitlements[0].EndDate)
+		}
+		if got.Entitlements[maxHpEntitlements-1].EndDate != "2027-01-16" {
+			t.Errorf("last retained EndDate = %q, want 2027-01-16", got.Entitlements[maxHpEntitlements-1].EndDate)
+		}
+	})
+
+	t.Run("a report already inside the bounds is untouched", func(t *testing.T) {
+		in := &HpWarrantyInfo{
+			SerialNumber:      "5CD1",
+			CoverageEndDate:   "2027-01-14",
+			CoverageStartDate: "2024-01-15",
+			CoverageType:      "HP 3y NBD",
+			Entitlements:      []HpEntitlement{{ServiceLevelDescription: "HP 3y NBD", EndDate: "2027-01-14"}},
+		}
+		got := boundHpWarrantyInfo(in)
+		if got.SerialNumber != "5CD1" || len(got.Entitlements) != 1 || got.Entitlements[0].EndDate != "2027-01-14" {
+			t.Fatalf("unexpectedly modified: %#v", got)
+		}
+	})
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd agent && go test -race ./internal/collectors/ -run TestBoundHpWarrantyInfo
+```
+Expected: FAIL to build — `undefined: boundHpWarrantyInfo`, `undefined: maxHpEntitlements`.
+
+- [ ] **Step 3: Implement**
+
+Append to `agent/internal/collectors/hp_warranty.go`:
+
+```go
+// maxHpEntitlements is D10's cap: at most 25 entitlements per report.
+const maxHpEntitlements = 25
+
+// boundHpWarrantyInfo enforces D10's bounds on the device, before anything is
+// sent.
+//
+// This is NOT redundant with the server-side zod bounds W01 adds. A schema
+// rejection is a 400 that drops the ENTIRE warranty update, not just the
+// offending field — exactly the failure mode #1320 produced for Apple, where a
+// single unexpected enum value silently lost every coverage record on the
+// device. Clamping here means an HP box with 40 entitlements reports 25 and its
+// coverage dates, instead of reporting nothing at all.
+//
+// When the cap bites, the entitlements with the LATEST end dates are kept: a
+// device's longest-running coverage is the one an MSP renews against, and
+// silently keeping whichever 25 HP happened to list first would understate it.
+// Entitlements with no parseable end date sort last but are still eligible.
+func boundHpWarrantyInfo(info *HpWarrantyInfo) *HpWarrantyInfo {
+	if info == nil {
+		return nil
+	}
+
+	info.SerialNumber = truncateHpString(info.SerialNumber)
+	info.ProductNumber = truncateHpString(info.ProductNumber)
+	info.CoverageType = truncateHpString(info.CoverageType)
+	info.CoverageStartDate = truncateHpString(info.CoverageStartDate)
+	info.CoverageEndDate = truncateHpString(info.CoverageEndDate)
+
+	for i := range info.Entitlements {
+		info.Entitlements[i].ServiceLevelDescription = truncateHpString(info.Entitlements[i].ServiceLevelDescription)
+		info.Entitlements[i].EntitlementType = truncateHpString(info.Entitlements[i].EntitlementType)
+		info.Entitlements[i].StartDate = truncateHpString(info.Entitlements[i].StartDate)
+		info.Entitlements[i].EndDate = truncateHpString(info.Entitlements[i].EndDate)
+	}
+
+	if len(info.Entitlements) > maxHpEntitlements {
+		sort.SliceStable(info.Entitlements, func(a, b int) bool {
+			return info.Entitlements[a].EndDate > info.Entitlements[b].EndDate
+		})
+		info.Entitlements = info.Entitlements[:maxHpEntitlements]
+	}
+
+	return info
+}
+```
+
+Add `"sort"` to the file's import block.
+
+Then apply the bound at the single exit point, so nothing can bypass it. In `collectHpWarrantyTiered`, wrap **every** non-nil return of `info`/`refreshed`:
+
+```go
+	if info != nil && !hpCacheStale(info.HPCacheTime, now) {
+		return boundHpWarrantyInfo(info), nil
+	}
+```
+```go
+		info.Tier = HpTierT0
+		return boundHpWarrantyInfo(info), nil
+	}
+```
+(both serve-stale branches)
+```go
+	refreshed.Tier = HpTierT1
+	refreshed.Reason = HpReasonOK
+	return boundHpWarrantyInfo(refreshed), nil
+```
+
+- [ ] **Step 4: Run the full collectors suite**
+
+```bash
+cd agent && go test -race ./internal/collectors/... && GOOS=windows GOARCH=amd64 go build ./internal/collectors/
+```
+Expected: PASS, Windows build clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add agent/internal/collectors/hp_warranty.go agent/internal/collectors/hp_warranty_test.go
+git commit -m "feat(agent): clamp HP warranty reports to the 25-entitlement / 200-char contract bounds (W03)"
+```
+
+---
+
+## Task 7: Persisted schedule state, deterministic jitter, and the due time
+
+**Files:**
+- Create: `agent/internal/heartbeat/hp_warranty.go`
+- Create: `agent/internal/heartbeat/hp_warranty_test.go`
+- Modify: `agent/internal/collectors/hp_warranty.go` (export the two cadence constants)
+
+**Interfaces:**
+- Produces: `hpWarrantyState` (struct), `hpWarrantyStateFileName` (const), `(*Heartbeat) hpWarrantyStatePath() string`, `(*Heartbeat) loadHpWarrantyState() hpWarrantyState`, `(*Heartbeat) saveHpWarrantyState(hpWarrantyState) error`, `hpJitterOffset(agentID string, window time.Duration) time.Duration`, `hpNextDueAt(cacheTime time.Time, agentID string, now time.Time) time.Time`, `hpBootstrapDueAt(agentID string, now time.Time) time.Time`, and the `hpRefreshJitterWindow` / `hpBootstrapJitterWindow` / `hpMinRecheckInterval` consts.
+- Consumes: `collectors.HpCacheTTL`, `collectors.HpRefreshMargin` (exported in Step 3 below); `config.GetDataDir()` (`agent/internal/config/config.go:1059`).
+
+### Where the persisted state lives, and why
+
+`filepath.Join(config.GetDataDir(), "hp_warranty_state.json")`, mode 0600, written atomically (temp file + rename) — the `reliability_state.go:79-99` shape verbatim.
+
+**This deliberately diverges from `reliabilityStatePath()`'s home-dir-first resolution** (`reliability_state.go:41-53`). That function prefers `~/.breeze`, which for a Windows service running as SYSTEM resolves to `C:\Windows\system32\config\systemprofile\.breeze`. That works, but it makes a machine-scoped schedule live in a per-account directory: change the service account (or run the agent interactively once) and the persisted due time silently disappears, the device believes it has never collected, and it re-invokes CMSL — a per-device bug that becomes a per-NAT rate-limit event when a fleet does it together. HP's 300-requests/5-minutes-per-source-IP budget is exactly the thing this state file exists to protect, so it goes in the machine-wide data dir with a temp-dir last resort. `config.GetDataDir()` is already the machine-wide location for agent data (`netcache.go:75` uses it the same way).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `agent/internal/heartbeat/hp_warranty_test.go`:
+
+```go
+package heartbeat
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/config"
+)
+
+func TestHpJitterOffset_IsDeterministic(t *testing.T) {
+	const window = 24 * time.Hour
+	first := hpJitterOffset("5CD1234ABC-agent-id", window)
+	for i := 0; i < 100; i++ {
+		if got := hpJitterOffset("5CD1234ABC-agent-id", window); got != first {
+			t.Fatalf("hpJitterOffset is not deterministic: call %d = %v, first = %v", i, got, first)
+		}
+	}
+	if first < 0 || first >= window {
+		t.Fatalf("offset %v is outside [0, %v)", first, window)
+	}
+}
+
+func TestHpJitterOffset_EdgeCases(t *testing.T) {
+	if got := hpJitterOffset("", 24*time.Hour); got != 0 {
+		t.Errorf("empty agent id offset = %v, want 0 (no id, no spread — and no panic)", got)
+	}
+	if got := hpJitterOffset("agent", 0); got != 0 {
+		t.Errorf("zero window offset = %v, want 0", got)
+	}
+	if got := hpJitterOffset("agent", -time.Hour); got != 0 {
+		t.Errorf("negative window offset = %v, want 0", got)
+	}
+}
+
+func TestHpJitterOffset_SpreadsAFleetAcrossTheWindow(t *testing.T) {
+	// The spread is STATISTICAL, not a guarantee (see the comment on
+	// hpJitterOffset): a fleet returning from a shared outage re-bunches
+	// because every device's persisted due time already elapsed. What this
+	// test proves is the weaker, still-necessary property — that the hash
+	// actually distributes rather than clumping every device into one hour.
+	const (
+		devices = 10000
+		buckets = 24
+		window  = 24 * time.Hour
+	)
+	counts := make([]int, buckets)
+	for i := 0; i < devices; i++ {
+		id := fmt.Sprintf("%08x-1111-2222-3333-%012x", i, i*2654435761)
+		offset := hpJitterOffset(id, window)
+		bucket := int(offset / time.Hour)
+		if bucket < 0 || bucket >= buckets {
+			t.Fatalf("offset %v mapped to bucket %d, outside [0,%d)", offset, bucket, buckets)
+		}
+		counts[bucket]++
+	}
+	// Uniform expectation is 416 per bucket. These bounds are ~±8 sigma, so a
+	// correct hash can never trip them, while a constant or badly-biased one
+	// always does. The function is deterministic, so this is not a flaky test:
+	// it either passes for all time or fails for all time.
+	for i, c := range counts {
+		if c < 250 || c > 600 {
+			t.Errorf("hour bucket %d holds %d of %d devices, want roughly %d — the jitter is not spreading the fleet", i, c, devices, devices/buckets)
+		}
+	}
+}
+
+func TestHpNextDueAt(t *testing.T) {
+	now := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
+	const agentID = "agent-under-test"
+	refreshJitter := hpJitterOffset(agentID, hpRefreshJitterWindow)
+	bootstrapJitter := hpJitterOffset(agentID, hpBootstrapJitterWindow)
+	cadence := hpCacheTTL + hpRefreshMargin
+
+	tests := []struct {
+		name  string
+		cache time.Time
+		want  time.Time
+	}{
+		{
+			name:  "a cache written today is next due one HP cache lifetime after HP wrote it, plus this device's jitter",
+			cache: now.Add(-2 * time.Hour),
+			want:  now.Add(-2 * time.Hour).Add(cadence + refreshJitter),
+		},
+		{
+			name:  "an unknown cache time schedules a full cadence from now, not from the epoch",
+			cache: time.Time{},
+			want:  now.Add(cadence + refreshJitter),
+		},
+		{
+			name:  "a very stale cache (T1 just failed) is floored, never scheduled in the past",
+			cache: now.Add(-200 * 24 * time.Hour),
+			want:  now.Add(hpMinRecheckInterval + bootstrapJitter),
+		},
+		{
+			name:  "a cache exactly at the cadence boundary is floored to the min recheck, not to now",
+			cache: now.Add(-cadence),
+			want:  now.Add(hpMinRecheckInterval + bootstrapJitter),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hpNextDueAt(tt.cache, agentID, now)
+			if !got.Equal(tt.want) {
+				t.Fatalf("hpNextDueAt() = %v, want %v", got, tt.want)
+			}
+			if !got.After(now) {
+				t.Fatalf("hpNextDueAt() = %v is not after now (%v) — a due time in the past is an every-tick collection loop", got, now)
+			}
+		})
+	}
+}
+
+func TestHpBootstrapDueAt_DelaysTheFirstRunButNeverBeyondTheWindow(t *testing.T) {
+	now := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
+	for i := 0; i < 500; i++ {
+		id := fmt.Sprintf("bootstrap-%d", i)
+		got := hpBootstrapDueAt(id, now)
+		if got.Before(now) {
+			t.Fatalf("%s: bootstrap due %v is before now", id, got)
+		}
+		if got.After(now.Add(hpBootstrapJitterWindow)) {
+			t.Fatalf("%s: bootstrap due %v is beyond the %v window — a policy rollout would take longer than a day to produce data", id, got, hpBootstrapJitterWindow)
+		}
+	}
+}
+
+func TestHpWarrantyState_RoundTrips(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("BREEZE_DATA_DIR_OVERRIDE_FOR_TEST", "") // documents that no such override exists; see below
+	h := &Heartbeat{hpWarrantyStatePathOverride: filepath.Join(dir, "hp_warranty_state.json")}
+
+	want := hpWarrantyState{
+		NextDueAt:     time.Date(2026, 10, 12, 3, 14, 0, 0, time.UTC),
+		LastSuccessAt: time.Date(2026, 9, 10, 3, 14, 0, 0, time.UTC),
+		LastAttemptAt: time.Date(2026, 9, 10, 3, 14, 0, 0, time.UTC),
+		Failures:      2,
+		RateLimitHits: 1,
+		LastReason:    "hp_rate_limited",
+	}
+	if err := h.saveHpWarrantyState(want); err != nil {
+		t.Fatalf("saveHpWarrantyState() = %v", err)
+	}
+
+	info, err := os.Stat(h.hpWarrantyStatePath())
+	if err != nil {
+		t.Fatalf("stat state file: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0600 {
+		t.Errorf("state file mode = %v, want 0600", perm)
+	}
+
+	got := h.loadHpWarrantyState()
+	if !got.NextDueAt.Equal(want.NextDueAt) || got.Failures != 2 || got.RateLimitHits != 1 || got.LastReason != "hp_rate_limited" {
+		t.Fatalf("round trip lost data: got %#v, want %#v", got, want)
+	}
+}
+
+func TestHpWarrantyState_UnreadableOrCorruptFailsOpen(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hp_warranty_state.json")
+	h := &Heartbeat{hpWarrantyStatePathOverride: path}
+
+	t.Run("absent", func(t *testing.T) {
+		got := h.loadHpWarrantyState()
+		if !got.NextDueAt.IsZero() || got.Failures != 0 {
+			t.Fatalf("absent state = %#v, want the zero value", got)
+		}
+	})
+
+	t.Run("corrupt", func(t *testing.T) {
+		if err := os.WriteFile(path, []byte("{not json"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		got := h.loadHpWarrantyState()
+		if !got.NextDueAt.IsZero() {
+			t.Fatalf("corrupt state = %#v, want the zero value (fail open to a bootstrap run, never a permanent stall)", got)
+		}
+	})
+}
+
+func TestHpWarrantyStatePath_UsesTheMachineWideDataDir(t *testing.T) {
+	h := &Heartbeat{}
+	got := h.hpWarrantyStatePath()
+	dataDir := config.GetDataDir()
+	if dataDir != "" && filepath.Dir(got) != dataDir {
+		t.Fatalf("hpWarrantyStatePath() = %q, want it inside the machine-wide data dir %q — a per-user path silently resets the schedule when the service account changes", got, dataDir)
+	}
+	if filepath.Base(got) != hpWarrantyStateFileName {
+		t.Fatalf("state file name = %q, want %q", filepath.Base(got), hpWarrantyStateFileName)
+	}
+}
+```
+
+Delete the `t.Setenv` line above once you read this note: it exists only to make the intent explicit while reading the plan — **there is no data-dir env override in this codebase**, which is exactly why `hpWarrantyStatePathOverride` (a test-only field on `Heartbeat`, nil in production) is the seam. Do not add an env var.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd agent && go test -race ./internal/heartbeat/ -run 'TestHpJitterOffset|TestHpNextDueAt|TestHpBootstrapDueAt|TestHpWarrantyState'
+```
+Expected: FAIL to build — `undefined: hpJitterOffset`, `undefined: hpNextDueAt`, `hpWarrantyStatePathOverride` is not a field of `Heartbeat`, etc.
+
+- [ ] **Step 3: Export the two cadence constants from `collectors`**
+
+In `agent/internal/collectors/hp_warranty.go`, immediately after the `hpCacheTTL`/`hpRefreshMargin` block added in Task 5, add:
+
+```go
+// HpCacheTTL and HpRefreshMargin are exported so the heartbeat scheduler
+// computes its persisted due time from the SAME values the tier decision uses.
+// Two independently maintained copies of "30 days" would drift the moment
+// either side was tuned, and the symptom would be a device that wakes up,
+// spawns PowerShell, learns HP's cache is still fresh, and goes back to sleep —
+// on every cycle, forever, with no error anywhere.
+const (
+	HpCacheTTL      = hpCacheTTL
+	HpRefreshMargin = hpRefreshMargin
+)
+```
+
+- [ ] **Step 4: Implement the heartbeat-side state and schedule**
+
+Create `agent/internal/heartbeat/hp_warranty.go`:
+
+```go
+package heartbeat
+
+import (
+	"encoding/json"
+	"fmt"
+	"hash/fnv"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/collectors"
+	"github.com/breeze-rmm/agent/internal/config"
+)
+
+const hpWarrantyStateFileName = "hp_warranty_state.json"
+
+// hpCacheTTL / hpRefreshMargin mirror the collector's tier decision through the
+// exported constants, so the schedule and the tier can never disagree about how
+// long HP's own cache lasts.
+const (
+	hpCacheTTL      = collectors.HpCacheTTL
+	hpRefreshMargin = collectors.HpRefreshMargin
+
+	// hpRefreshJitterWindow spreads a site's HP fleet across a day around its
+	// natural due time.
+	hpRefreshJitterWindow = 24 * time.Hour
+	// hpBootstrapJitterWindow spreads the FIRST collection after the feature is
+	// switched on. Without it, enabling the policy on 500 devices makes 500
+	// agents reach the same gate on their next heartbeat; if HP's cache is stale
+	// on all of them, that is 500 Get-HPWarrantyInfo calls from one NAT against
+	// a 300-per-5-minutes budget. Six hours is 72 such windows.
+	hpBootstrapJitterWindow = 6 * time.Hour
+	// hpMinRecheckInterval floors the schedule. A device whose refresh failed
+	// still has a stale HP cache, so hpNextDueAt would otherwise compute a due
+	// time in the past and re-collect on every single heartbeat tick.
+	hpMinRecheckInterval = 6 * time.Hour
+)
+
+// hpWarrantyState is the collector's own persisted schedule. It exists because
+// the HP collector deliberately does NOT ride the 15-minute sendInventory
+// fan-out (heartbeat.go:2120-2139) the Apple collector uses: HP's data changes
+// at most monthly, and copying that lifecycle without persistent state would
+// relaunch PowerShell every 15 minutes for days on end (contract D8).
+type hpWarrantyState struct {
+	// NextDueAt is when the next collection cycle may run. Zero means "never
+	// collected" and triggers the bootstrap path.
+	NextDueAt time.Time `json:"nextDueAt"`
+	// LastSuccessAt / LastAttemptAt are diagnostic; nothing branches on them.
+	LastSuccessAt time.Time `json:"lastSuccessAt,omitempty"`
+	LastAttemptAt time.Time `json:"lastAttemptAt,omitempty"`
+	// Failures counts consecutive non-rate-limit failures, driving the bounded
+	// retry schedule. Reset on any success.
+	Failures int `json:"failures,omitempty"`
+	// RateLimitHits counts consecutive HP 429s, driving a much longer back-off
+	// than an ordinary failure: HP's limit is per SOURCE IP, so a 429 means the
+	// customer's whole NAT is saturated and retrying soon re-creates it.
+	RateLimitHits int `json:"rateLimitHits,omitempty"`
+	// LastReason is the last collectors.HpReason* code, so an operator can read
+	// "why is this HP device still unknown" straight off the endpoint.
+	LastReason string `json:"lastReason,omitempty"`
+}
+
+// hpWarrantyStatePath resolves the machine-wide state file.
+//
+// Unlike reliabilityStatePath (reliability_state.go:41-53) this does NOT prefer
+// ~/.breeze. The HP schedule is machine-scoped and protects a per-source-IP
+// rate limit: putting it in a per-account directory means a service-account
+// change silently discards it, the device believes it has never collected, and
+// a fleet doing that together produces exactly the 429 storm the schedule
+// exists to prevent.
+func (h *Heartbeat) hpWarrantyStatePath() string {
+	if h.hpWarrantyStatePathOverride != "" {
+		return h.hpWarrantyStatePathOverride
+	}
+	dataDir := strings.TrimSpace(config.GetDataDir())
+	if dataDir == "" {
+		tmpPath := filepath.Join(os.TempDir(), "breeze", hpWarrantyStateFileName)
+		log.Warn("HP warranty state directory unavailable, falling back to temp dir", "path", tmpPath)
+		return tmpPath
+	}
+	return filepath.Join(dataDir, hpWarrantyStateFileName)
+}
+
+// loadHpWarrantyState returns the persisted schedule, or the zero value when it
+// is absent, unreadable or corrupt. Failing open to the zero value means the
+// device takes the bootstrap path (a jittered first run) rather than stalling
+// forever — the same fail-open choice reliability_state.go:55-59 documents.
+func (h *Heartbeat) loadHpWarrantyState() hpWarrantyState {
+	path := h.hpWarrantyStatePath()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			log.Warn("failed to read HP warranty state", "path", path, "error", err.Error())
+		}
+		return hpWarrantyState{}
+	}
+	var st hpWarrantyState
+	if err := json.Unmarshal(raw, &st); err != nil {
+		log.Warn("failed to decode HP warranty state", "path", path, "error", err.Error())
+		return hpWarrantyState{}
+	}
+	return st
+}
+
+// saveHpWarrantyState atomically persists the schedule (temp file + rename),
+// mirroring saveLastReliabilityUpdate (reliability_state.go:79-99).
+func (h *Heartbeat) saveHpWarrantyState(st hpWarrantyState) error {
+	path := h.hpWarrantyStatePath()
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("failed to create HP warranty state directory %s: %w", dir, err)
+	}
+	payload, err := json.Marshal(st)
+	if err != nil {
+		return fmt.Errorf("failed to encode HP warranty state: %w", err)
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, payload, 0600); err != nil {
+		return fmt.Errorf("failed to write HP warranty state temp file %s: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("failed to persist HP warranty state %s: %w", path, err)
+	}
+	return nil
+}
+
+// hpJitterOffset maps an agent id deterministically onto [0, window).
+//
+// Deterministic (FNV-1a, no rand) so the offset survives restarts and upgrades:
+// a random offset re-rolled on every boot would let a restart-prone fleet
+// re-synchronise, which is the failure this is meant to prevent.
+//
+// Be honest about what this does and does not buy. It spreads a fleet whose
+// devices reach their due times independently. It does NOT bound concurrency:
+// a site coming back from a shared outage has every device past its persisted
+// due time simultaneously, and they all fire on their next heartbeat regardless
+// of jitter. The 429 back-off (hpRateLimitBackoff), not the jitter, is what
+// contains that case.
+func hpJitterOffset(agentID string, window time.Duration) time.Duration {
+	if window <= 0 || agentID == "" {
+		return 0
+	}
+	sum := fnv.New64a()
+	_, _ = sum.Write([]byte(agentID))
+	return time.Duration(sum.Sum64() % uint64(window))
+}
+
+// hpBootstrapDueAt schedules a first-ever collection: soon, but spread across
+// hpBootstrapJitterWindow so switching the policy on for a whole site does not
+// produce a simultaneous CMSL stampede from one NAT.
+func hpBootstrapDueAt(agentID string, now time.Time) time.Time {
+	return now.Add(hpJitterOffset(agentID, hpBootstrapJitterWindow))
+}
+
+// hpNextDueAt computes the next collection time from HP's OWN cache timestamp
+// (contract D8), not from a fixed interval. HP self-caches for 30 days, so a
+// day-25 wake-up spawns PowerShell, learns nothing new and refreshes nothing.
+//
+// The result is always in the future: a device whose refresh failed still has a
+// stale cache, so the natural computation lands in the past and would re-collect
+// on every heartbeat tick. hpMinRecheckInterval plus the bootstrap jitter is the
+// floor.
+func hpNextDueAt(cacheTime time.Time, agentID string, now time.Time) time.Time {
+	cadence := hpCacheTTL + hpRefreshMargin + hpJitterOffset(agentID, hpRefreshJitterWindow)
+
+	var due time.Time
+	if cacheTime.IsZero() {
+		due = now.Add(cadence)
+	} else {
+		due = cacheTime.Add(cadence)
+	}
+
+	floor := now.Add(hpMinRecheckInterval + hpJitterOffset(agentID, hpBootstrapJitterWindow))
+	if due.Before(floor) {
+		return floor
+	}
+	return due
+}
+```
+
+- [ ] **Step 5: Add the test-only path override to the `Heartbeat` struct**
+
+In `agent/internal/heartbeat/heartbeat.go`, inside `type Heartbeat struct` (`:320`), directly after `patchSendFailures int` (`:380`), add:
+
+```go
+	// ---- HP warranty collection (W03) ----
+	// hpWarrantyNextDue is the in-memory mirror of the persisted schedule,
+	// seeded at startup and advanced under h.mu by claimHpWarrantyCycleLocked.
+	hpWarrantyNextDue time.Time
+	// hpWarrantyFailures / hpWarrantyRateLimitHits mirror the persisted counters
+	// so the retry schedule survives neither more nor less than the file does.
+	hpWarrantyFailures      int
+	hpWarrantyRateLimitHits int
+	// hpCmslEnabled is the FALLBACK collection gate — add it ONLY if Task 9
+	// Step 1's grep shows W02 shipped no accessor of its own (see §0.16). When
+	// W02 shipped one, delete this field: the gate is then a persisted
+	// h.config field owned by W02, and a second in-memory copy here would go
+	// stale the moment the two were written at different times. atomic because
+	// applyConfigUpdate runs on the heartbeat-response goroutine while the tick
+	// gate reads it under h.mu.
+	hpCmslEnabled atomic.Bool
+	// hpWarrantyStatePathOverride is a TEST-ONLY seam; nil/empty in production,
+	// where hpWarrantyStatePath() resolves config.GetDataDir(). There is no env
+	// var for this on purpose — a data-dir override would be a real, shippable
+	// misconfiguration surface for a purely test-time need.
+	hpWarrantyStatePathOverride string
+```
+
+`sync/atomic` is already imported (`headlessCachedAt atomic.Value`, `:406`); confirm before adding.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+```bash
+cd agent && go test -race ./internal/heartbeat/ -run 'TestHpJitterOffset|TestHpNextDueAt|TestHpBootstrapDueAt|TestHpWarrantyState' -v
+```
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add agent/internal/collectors/hp_warranty.go agent/internal/heartbeat/hp_warranty.go agent/internal/heartbeat/hp_warranty_test.go agent/internal/heartbeat/heartbeat.go
+git commit -m "feat(agent): persisted HP warranty schedule with deterministic per-device jitter (W03)"
+```
+
+---
+
+## Task 8: Bounded retries and the HP 429 back-off
+
+**Files:**
+- Modify: `agent/internal/heartbeat/hp_warranty.go`
+- Test: `agent/internal/heartbeat/hp_warranty_test.go`
+
+**Interfaces:**
+- Produces: `hpRetryDelay(failures int) time.Duration`, `hpRateLimitBackoff(hits int) time.Duration`, `hpFailureDueAt(st hpWarrantyState, agentID string, now time.Time) time.Time`, and the `maxHpCollectRetries` / `hpRetryBaseDelay` / `hpRetryMaxDelay` / `hpRateLimitBackoffBase` / `hpRateLimitBackoffMax` consts.
+- Consumes: `hpWarrantyState`, `hpJitterOffset`, `hpMinRecheckInterval`, `hpNextDueAt` (Task 7).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `agent/internal/heartbeat/hp_warranty_test.go`:
+
+```go
+func TestHpRetryDelay(t *testing.T) {
+	tests := []struct {
+		name     string
+		failures int
+		want     time.Duration
+	}{
+		{"zero failures is not a retry", 0, 0},
+		{"negative is not a retry", -1, 0},
+		{"first retry", 1, 30 * time.Minute},
+		{"second retry doubles", 2, time.Hour},
+		{"third retry doubles again", 3, 2 * time.Hour},
+		{"fourth retry doubles again", 4, 4 * time.Hour},
+		{"fifth retry is capped, not exhausted", 5, 8 * time.Hour},
+		{"beyond the cap stays at the cap", 12, 8 * time.Hour},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hpRetryDelay(tt.failures); got != tt.want {
+				t.Fatalf("hpRetryDelay(%d) = %v, want %v", tt.failures, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHpRateLimitBackoff(t *testing.T) {
+	tests := []struct {
+		name string
+		hits int
+		want time.Duration
+	}{
+		{"no hits", 0, 0},
+		{"first 429", 1, 4 * time.Hour},
+		{"second 429", 2, 8 * time.Hour},
+		{"third 429", 3, 16 * time.Hour},
+		{"fourth 429 hits the cap", 4, 32 * time.Hour},
+		{"fifth 429 stays at the cap", 5, 48 * time.Hour},
+		{"tenth 429 stays at the cap", 10, 48 * time.Hour},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hpRateLimitBackoff(tt.hits); got != tt.want {
+				t.Fatalf("hpRateLimitBackoff(%d) = %v, want %v", tt.hits, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHpRateLimitBackoff_IsAlwaysFarLongerThanAnOrdinaryRetry(t *testing.T) {
+	// HP's limit is 300 requests / 5 minutes per SOURCE IP — per customer NAT,
+	// not per device. Retrying a 429 on the ordinary failure schedule means the
+	// whole site walks straight back into the limit together.
+	for n := 1; n <= 6; n++ {
+		if hpRateLimitBackoff(n) <= hpRetryDelay(n) {
+			t.Fatalf("hpRateLimitBackoff(%d) = %v is not longer than hpRetryDelay(%d) = %v",
+				n, hpRateLimitBackoff(n), n, hpRetryDelay(n))
+		}
+	}
+	if hpRateLimitBackoff(1) < time.Hour {
+		t.Fatalf("the first 429 back-off is %v — anything under an hour re-enters HP's window", hpRateLimitBackoff(1))
+	}
+}
+
+func TestHpFailureDueAt(t *testing.T) {
+	now := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
+	const agentID = "agent-under-test"
+	jitter := hpJitterOffset(agentID, hpBootstrapJitterWindow)
+
+	tests := []struct {
+		name string
+		st   hpWarrantyState
+		want time.Duration // offset from now, before jitter
+	}{
+		{"a single ordinary failure", hpWarrantyState{Failures: 1}, 30 * time.Minute},
+		{"three ordinary failures", hpWarrantyState{Failures: 3}, 2 * time.Hour},
+		{"a rate limit outranks the ordinary schedule entirely", hpWarrantyState{Failures: 1, RateLimitHits: 1}, 4 * time.Hour},
+		{"repeated rate limits keep escalating", hpWarrantyState{Failures: 4, RateLimitHits: 3}, 16 * time.Hour},
+		{"no failures at all falls back to the min recheck", hpWarrantyState{}, hpMinRecheckInterval},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hpFailureDueAt(tt.st, agentID, now)
+			want := now.Add(tt.want + jitter)
+			if !got.Equal(want) {
+				t.Fatalf("hpFailureDueAt() = %v, want %v", got, want)
+			}
+			if !got.After(now) {
+				t.Fatalf("hpFailureDueAt() = %v is not after now — that is a per-tick retry loop", got)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd agent && go test -race ./internal/heartbeat/ -run 'TestHpRetryDelay|TestHpRateLimitBackoff|TestHpFailureDueAt'
+```
+Expected: FAIL to build — `undefined: hpRetryDelay`, `undefined: hpRateLimitBackoff`, `undefined: hpFailureDueAt`.
+
+- [ ] **Step 3: Implement**
+
+Append to `agent/internal/heartbeat/hp_warranty.go`:
+
+```go
+// Retry schedule. Deliberately slower than the patch-submission schedule
+// (heartbeat.go:2236-2263, 5/10/20/40 minutes) because the payoff is different:
+// a missed patch scan leaves posture stale within a 24h window, whereas HP
+// warranty dates change at most once a year and a failed collection costs
+// nothing until the next cycle. Retrying hard buys nothing and spends a shared
+// rate-limit budget.
+const (
+	maxHpCollectRetries = 5
+	hpRetryBaseDelay    = 30 * time.Minute
+	hpRetryMaxDelay     = 8 * time.Hour
+)
+
+// Rate-limit back-off. HP's limit is 300 requests / 5 minutes per SOURCE IP —
+// a per-customer-NAT budget shared by every HP device behind it. A 429
+// therefore means "your site is saturating HP", not "this device was unlucky",
+// and the only correct response is to leave for hours. Doubling from 4h to a
+// 48h cap means a persistently limited site backs all the way off to roughly
+// one attempt every two days while remaining eventually consistent.
+const (
+	hpRateLimitBackoffBase = 4 * time.Hour
+	hpRateLimitBackoffMax  = 48 * time.Hour
+)
+
+// hpRetryDelay returns the delay before retrying after `failures` consecutive
+// ordinary (non-rate-limit) failures. Unlike patchRetryDelay it does NOT return
+// 0 past the attempt cap: HP collection has no "give up" state — a device that
+// cannot collect today should still try tomorrow, just no more often than the
+// cap. Returning 0 there would mean "due immediately", the exact opposite.
+func hpRetryDelay(failures int) time.Duration {
+	if failures < 1 {
+		return 0
+	}
+	if failures > maxHpCollectRetries {
+		failures = maxHpCollectRetries
+	}
+	delay := hpRetryBaseDelay << (failures - 1) // 30m, 1h, 2h, 4h, 8h
+	if delay > hpRetryMaxDelay {
+		delay = hpRetryMaxDelay
+	}
+	return delay
+}
+
+// hpRateLimitBackoff returns the delay after `hits` consecutive HP 429s.
+func hpRateLimitBackoff(hits int) time.Duration {
+	if hits < 1 {
+		return 0
+	}
+	delay := hpRateLimitBackoffBase
+	for i := 1; i < hits; i++ {
+		delay *= 2
+		if delay >= hpRateLimitBackoffMax {
+			return hpRateLimitBackoffMax
+		}
+	}
+	if delay > hpRateLimitBackoffMax {
+		delay = hpRateLimitBackoffMax
+	}
+	return delay
+}
+
+// hpFailureDueAt computes the next attempt time after an unsuccessful cycle.
+// A rate limit always outranks the ordinary schedule: a device that saw a 429
+// AND an ordinary failure is still behind a saturated NAT.
+//
+// The per-device jitter is applied here too, so a whole site that failed
+// together does not retry together — the one place jitter genuinely helps the
+// re-bunching case the doc comment on hpJitterOffset is honest about.
+func hpFailureDueAt(st hpWarrantyState, agentID string, now time.Time) time.Time {
+	delay := hpMinRecheckInterval
+	if st.RateLimitHits > 0 {
+		delay = hpRateLimitBackoff(st.RateLimitHits)
+	} else if st.Failures > 0 {
+		delay = hpRetryDelay(st.Failures)
+	}
+	return now.Add(delay + hpJitterOffset(agentID, hpBootstrapJitterWindow))
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd agent && go test -race ./internal/heartbeat/ -run 'TestHpRetryDelay|TestHpRateLimitBackoff|TestHpFailureDueAt' -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add agent/internal/heartbeat/hp_warranty.go agent/internal/heartbeat/hp_warranty_test.go
+git commit -m "feat(agent): bounded HP collection retries with a per-NAT-aware 429 back-off (W03)"
+```
+
+---
+
+## Task 9: The claim gate and W02's config seam
+
+**Files:**
+- Modify: `agent/internal/heartbeat/hp_warranty.go`
+- Modify: `agent/internal/heartbeat/warranty_config.go` (**one line** — W02's file)
+- Test: `agent/internal/heartbeat/hp_warranty_test.go`
+
+**Interfaces:**
+- Produces: `(*Heartbeat) hpCmslCollectionEnabled() bool`, `(*Heartbeat) setHpCmslCollectionEnabled(bool)`, `(*Heartbeat) claimHpWarrantyCycleLocked(now time.Time) bool`.
+- Consumes: W02's `func (h *Heartbeat) applyWarrantyConfig(raw any)` in `agent/internal/heartbeat/warranty_config.go` (contract D6/D7) — **only** to add the setter call; the payload parse is W02's and is not re-implemented.
+
+- [ ] **Step 1: Read what W02 actually shipped**
+
+```bash
+cd /Users/toddhebebrand/.herdr/worktrees/breeze/warranty-testing
+cat agent/internal/heartbeat/warranty_config.go
+grep -rn "hp_cmsl_enabled\|hpCmslEnabled\|applyWarrantyConfig" agent/internal/heartbeat/
+```
+
+The contract (D7) fixes the file and the function name but **not** where the resolved boolean is stored. W02's own plan says it ships "the seam, the parse, **and the accessor W03 reads**", modelled on `requireManifestSigningKeyID()` (`heartbeat.go:4008-4012`) — a mutex-guarded accessor over a persisted `h.config` field. See §0.16. Read the shipped name and take one of two branches:
+
+- **Primary (expected) — W02 shipped an accessor.** W03 adds NO storage. Delete the `hpCmslEnabled atomic.Bool` field from Task 7 Step 5's struct block, skip Step 5 of this task entirely, and implement the two functions in Step 4 as delegates:
+
+  ```go
+  func (h *Heartbeat) hpCmslCollectionEnabled() bool {
+      return h.<W02's accessor name>()
+  }
+
+  // setHpCmslCollectionEnabled exists for tests only when W02 owns the storage.
+  // Production writes go through W02's applyWarrantyConfig, never through here.
+  func (h *Heartbeat) setHpCmslCollectionEnabled(enabled bool) {
+      h.mu.Lock()
+      defer h.mu.Unlock()
+      h.config.<W02's config field name> = enabled
+  }
+  ```
+  Tests constructing a bare `&Heartbeat{}` must then also give it a `config: &config.Config{}` so the setter has somewhere to write — Task 10's `newHeartbeat` helper already does; add `config: &config.Config{}` to the `&Heartbeat{}` literals in `TestHpCmslCollectionEnabled_DefaultsOff`, `TestApplyWarrantyConfig_DrivesTheCollectionGate` and `TestClaimHpWarrantyCycleLocked`.
+
+- **Fallback — W02 shipped only the parse and a platform func var, with no accessor.** Keep the `hpCmslEnabled atomic.Bool` field and implement Steps 3–5 exactly as written, including the one-line setter call in Step 5.
+
+If `warranty_config.go` does not exist yet, W02 has not landed — **stop and report**; do not create W02's file.
+
+- [ ] **Step 2: Write the failing test**
+
+Append to `agent/internal/heartbeat/hp_warranty_test.go`:
+
+```go
+func TestHpCmslCollectionEnabled_DefaultsOff(t *testing.T) {
+	h := &Heartbeat{}
+	if h.hpCmslCollectionEnabled() {
+		t.Fatal("HP CMSL collection is on by default — it must be opt-in; CMSL is a ~100MB HP module with HP telemetry rights and an unaccepted EULA")
+	}
+	h.setHpCmslCollectionEnabled(true)
+	if !h.hpCmslCollectionEnabled() {
+		t.Fatal("setHpCmslCollectionEnabled(true) did not take effect")
+	}
+	h.setHpCmslCollectionEnabled(false)
+	if h.hpCmslCollectionEnabled() {
+		t.Fatal("setHpCmslCollectionEnabled(false) did not revoke collection — a revoked policy must stop HP activity")
+	}
+}
+
+func TestApplyWarrantyConfig_DrivesTheCollectionGate(t *testing.T) {
+	// W02 owns the parse; this asserts only that the resolved value reaches
+	// W03's gate. Both key spellings are covered because the API may send
+	// either (contract D6) and every existing seam accepts both.
+	tests := []struct {
+		name string
+		raw  any
+		want bool
+	}{
+		{"snake_case true", map[string]any{"hp_cmsl_enabled": true}, true},
+		{"camelCase true", map[string]any{"hpCmslEnabled": true}, true},
+		{"snake_case false revokes", map[string]any{"hp_cmsl_enabled": false}, false},
+		{"camelCase false revokes", map[string]any{"hpCmslEnabled": false}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &Heartbeat{}
+			h.setHpCmslCollectionEnabled(!tt.want) // start from the opposite state
+			h.applyWarrantyConfig(tt.raw)
+			if got := h.hpCmslCollectionEnabled(); got != tt.want {
+				t.Fatalf("hpCmslCollectionEnabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClaimHpWarrantyCycleLocked(t *testing.T) {
+	now := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
+
+	t.Run("disabled never claims, even when overdue", func(t *testing.T) {
+		h := &Heartbeat{hpWarrantyNextDue: now.Add(-time.Hour)}
+		h.mu.Lock()
+		defer h.mu.Unlock()
+		if h.claimHpWarrantyCycleLocked(now) {
+			t.Fatal("claimed a cycle with the policy disabled — HP activity must stop on revocation")
+		}
+	})
+
+	t.Run("enabled and not yet due does not claim", func(t *testing.T) {
+		h := &Heartbeat{hpWarrantyNextDue: now.Add(time.Hour)}
+		h.setHpCmslCollectionEnabled(true)
+		h.mu.Lock()
+		defer h.mu.Unlock()
+		if h.claimHpWarrantyCycleLocked(now) {
+			t.Fatal("claimed a cycle before its due time")
+		}
+	})
+
+	t.Run("enabled and due claims exactly once", func(t *testing.T) {
+		h := &Heartbeat{hpWarrantyNextDue: now.Add(-time.Minute)}
+		h.setHpCmslCollectionEnabled(true)
+		h.mu.Lock()
+		defer h.mu.Unlock()
+		if !h.claimHpWarrantyCycleLocked(now) {
+			t.Fatal("did not claim an overdue cycle")
+		}
+		if h.claimHpWarrantyCycleLocked(now) {
+			t.Fatal("claimed the SAME cycle twice — two concurrent PowerShell spawns per device")
+		}
+		if !h.hpWarrantyNextDue.After(now) {
+			t.Fatalf("hpWarrantyNextDue = %v was not advanced past now on claim", h.hpWarrantyNextDue)
+		}
+	})
+
+	t.Run("a zero due time (never collected) claims immediately so the bootstrap path can schedule", func(t *testing.T) {
+		h := &Heartbeat{}
+		h.setHpCmslCollectionEnabled(true)
+		h.mu.Lock()
+		defer h.mu.Unlock()
+		if !h.claimHpWarrantyCycleLocked(now) {
+			t.Fatal("a never-collected device did not claim")
+		}
+	})
+
+	t.Run("the provisional advance is a real interval, not a token bump", func(t *testing.T) {
+		h := &Heartbeat{hpWarrantyNextDue: now.Add(-time.Minute)}
+		h.setHpCmslCollectionEnabled(true)
+		h.mu.Lock()
+		defer h.mu.Unlock()
+		h.claimHpWarrantyCycleLocked(now)
+		// If the cycle goroutine dies without persisting (panic, kill -9 between
+		// claim and save), this provisional value is what stops the next tick
+		// re-claiming 30 seconds later.
+		if h.hpWarrantyNextDue.Sub(now) < hpMinRecheckInterval {
+			t.Fatalf("provisional advance is %v, want at least %v so a crashed cycle cannot become a per-tick loop",
+				h.hpWarrantyNextDue.Sub(now), hpMinRecheckInterval)
+		}
+	})
+}
+
+func TestClaimHpWarrantyCycleLocked_IsRaceFreeUnderConcurrentTicks(t *testing.T) {
+	now := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
+	h := &Heartbeat{hpWarrantyNextDue: now.Add(-time.Hour)}
+	h.setHpCmslCollectionEnabled(true)
+
+	const goroutines = 32
+	claims := make(chan bool, goroutines)
+	start := make(chan struct{})
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			<-start
+			h.mu.Lock()
+			claimed := h.claimHpWarrantyCycleLocked(now)
+			h.mu.Unlock()
+			claims <- claimed
+		}()
+	}
+	close(start)
+
+	won := 0
+	for i := 0; i < goroutines; i++ {
+		if <-claims {
+			won++
+		}
+	}
+	if won != 1 {
+		t.Fatalf("%d goroutines claimed the cycle, want exactly 1", won)
+	}
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+```bash
+cd agent && go test -race ./internal/heartbeat/ -run 'TestHpCmslCollectionEnabled|TestApplyWarrantyConfig|TestClaimHpWarrantyCycleLocked'
+```
+Expected: FAIL to build — `undefined: hpCmslCollectionEnabled`, `undefined: setHpCmslCollectionEnabled`, `undefined: claimHpWarrantyCycleLocked`. (`applyWarrantyConfig` resolves — it is W02's.)
+
+- [ ] **Step 4: Implement the gate**
+
+Append to `agent/internal/heartbeat/hp_warranty.go`. The `hpCmslCollectionEnabled` / `setHpCmslCollectionEnabled` bodies below are the **fallback** shape (W03 owns the storage); if Step 1 found W02's accessor, use the delegate bodies from Step 1 instead and keep everything else here — `claimHpWarrantyCycleLocked` is identical either way, and its doc comment is what the rest of the wave depends on.
+
+```go
+// hpCmslCollectionEnabled reports whether the effective warranty policy has HP
+// CMSL collection switched on for this device.
+//
+// The value arrives via warranty_settings.hp_cmsl_enabled through W02's
+// warranty_config.go seam (contract D6). This wave consumes that seam and does
+// not re-implement the payload parse — a second parser is precisely the
+// key-name regression the seam exists to prevent.
+//
+// The default is FALSE and must stay false: CMSL is a ~100 MB HP module with
+// HP telemetry rights on the endpoint, and the feature is opt-in with a
+// recorded consent (spec, "The EULA constrains the install channel").
+func (h *Heartbeat) hpCmslCollectionEnabled() bool {
+	return h.hpCmslEnabled.Load()
+}
+
+// setHpCmslCollectionEnabled records the policy's collection gate. Called from
+// applyWarrantyConfig on the heartbeat-response goroutine.
+//
+// Revocation is load-bearing, not cosmetic: buildWarrantyConfigUpdate's
+// contract (copied from buildPatchSourceConfigUpdate, helpers.ts:2852-2859)
+// distinguishes a successfully resolved ABSENT policy — which sends false and
+// must stop HP activity — from a resolver ERROR, which omits the block so a
+// transient failure never revokes. Only the first ever reaches this setter.
+func (h *Heartbeat) setHpCmslCollectionEnabled(enabled bool) {
+	h.hpCmslEnabled.Store(enabled)
+}
+
+// claimHpWarrantyCycleLocked decides whether an HP warranty collection cycle is
+// due and, if so, claims it by provisionally advancing the schedule so the next
+// tick cannot dispatch a duplicate concurrent cycle. Returns whether the caller
+// should dispatch. Caller must hold h.mu.
+//
+// The decision and the state transition live together here rather than being
+// open-coded in the tick loop, for the reason claimPatchScanLocked
+// (heartbeat.go:2276-2290) gives: one test then exercises the whole gate
+// instead of only its predicate.
+//
+// The provisional advance is a full hpMinRecheckInterval, not a token bump. The
+// dispatched cycle overwrites it with the real due time once it finishes; if it
+// never finishes (panic recovered by observability.Recoverer, or the process is
+// killed between claim and persist), this value is the only thing standing
+// between the device and a PowerShell spawn on every heartbeat tick.
+func (h *Heartbeat) claimHpWarrantyCycleLocked(now time.Time) bool {
+	if !h.hpCmslCollectionEnabled() {
+		return false
+	}
+	if !h.hpWarrantyNextDue.IsZero() && now.Before(h.hpWarrantyNextDue) {
+		return false
+	}
+	h.hpWarrantyNextDue = now.Add(hpMinRecheckInterval)
+	return true
+}
+```
+
+- [ ] **Step 5: FALLBACK ONLY — wire W02's seam to the gate (ONE line)**
+
+**Skip this step entirely if Step 1 found W02's accessor** — in that case W02 already writes the persisted field and adding a second write here would double-write the same value from the same function.
+
+Otherwise, in `agent/internal/heartbeat/warranty_config.go`, at the point where W02's `applyWarrantyConfig` has resolved the boolean (the equivalent of `patch_source.go:40`'s `res, err := applyWinUpdate(enforce)`), add:
+
+```go
+	h.setHpCmslCollectionEnabled(enabled)
+```
+
+If W02's local variable is not called `enabled`, use its name. **Change nothing else in that file** — the parse, the logging and the dual-key handling are W02's and are already covered by W02's own tests.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+```bash
+cd agent && go test -race ./internal/heartbeat/ -run 'TestHpCmslCollectionEnabled|TestApplyWarrantyConfig|TestClaimHpWarrantyCycleLocked' -v
+```
+Expected: PASS, including the 32-goroutine race test under `-race`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add agent/internal/heartbeat/hp_warranty.go agent/internal/heartbeat/warranty_config.go agent/internal/heartbeat/hp_warranty_test.go
+git commit -m "feat(agent): HP warranty collection claim gate driven by the W02 config seam (W03)"
+```
+
+---
+
+## Task 10: Run the cycle, report it, and wire it into the tick loop
+
+**Files:**
+- Modify: `agent/internal/heartbeat/hp_warranty.go`
+- Modify: `agent/internal/heartbeat/heartbeat.go` (startup seeding `:1789-1809`; tick gate `:1846-1885`)
+- Test: `agent/internal/heartbeat/hp_warranty_test.go`
+
+**Interfaces:**
+- Produces: `(*Heartbeat) runHpWarrantyCycle(now time.Time)`, `(*Heartbeat) sendHpWarrantyInfo(info *collectors.HpWarrantyInfo) error`, `buildHpWarrantyPayload(*collectors.HpWarrantyInfo) map[string]any`, `hpCollectFn` (test seam), `(*Heartbeat) seedHpWarrantySchedule(now time.Time)`.
+- Consumes: `collectors.CollectHpWarranty` (Task 1), `collectors.IsHpRateLimited` (Task 1), `collectors.HpCollectError` (Task 1), `h.sendInventoryData` (`heartbeat.go:2155`), `claimHpWarrantyCycleLocked` (Task 9), `hpNextDueAt` / `hpFailureDueAt` / `hpBootstrapDueAt` (Tasks 7–8).
+- Consumes from **W01** (do not redefine): the widened `agentWarrantyInfoSchema` (`apps/api/src/routes/agents/schemas.ts:658-675`) and the widened `AgentWarrantyData` (`apps/api/src/services/warrantySync.ts:315-331`), specifically their new bounded `entitlements` array whose element fields are `serviceLevelDescription`, `entitlementType`, `startDate`, `endDate` — with `provider` derived server-side from `source`, never sent by the agent (D10).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `agent/internal/heartbeat/hp_warranty_test.go`:
+
+```go
+func TestBuildHpWarrantyPayload(t *testing.T) {
+	t.Run("carries the contract's fixed source and manufacturer", func(t *testing.T) {
+		p := buildHpWarrantyPayload(&collectors.HpWarrantyInfo{CoverageEndDate: "2027-01-14"})
+		if p["source"] != "agent_cmsl" {
+			t.Errorf("source = %v, want agent_cmsl (contract D9 — this is what makes the row agent-owned server-side)", p["source"])
+		}
+		if p["manufacturer"] != "HP" {
+			t.Errorf("manufacturer = %v, want HP", p["manufacturer"])
+		}
+	})
+
+	t.Run("entitlements are omitted entirely when empty, never sent as an empty array", func(t *testing.T) {
+		p := buildHpWarrantyPayload(&collectors.HpWarrantyInfo{CoverageEndDate: "2027-01-14"})
+		if _, present := p["entitlements"]; present {
+			t.Error("entitlements key present with no entitlements — an empty array would overwrite a populated column server-side")
+		}
+	})
+
+	t.Run("entitlements never carry provider — W01 derives it from the source", func(t *testing.T) {
+		p := buildHpWarrantyPayload(&collectors.HpWarrantyInfo{
+			CoverageEndDate: "2027-01-14",
+			Entitlements: []collectors.HpEntitlement{{
+				ServiceLevelDescription: "HP 3y NBD",
+				EntitlementType:         "NBD Onsite",
+				StartDate:               "2024-01-15",
+				EndDate:                 "2027-01-14",
+			}},
+		})
+		ents, ok := p["entitlements"].([]map[string]any)
+		if !ok || len(ents) != 1 {
+			t.Fatalf("entitlements = %#v, want one element", p["entitlements"])
+		}
+		if _, present := ents[0]["provider"]; present {
+			t.Error("the agent sent `provider` — warrantySync.ts:367 is W01's to fix, and an agent-supplied value would defeat it")
+		}
+		for _, k := range []string{"serviceLevelDescription", "entitlementType", "startDate", "endDate"} {
+			if _, present := ents[0][k]; !present {
+				t.Errorf("entitlement is missing %q — the field names must match WarrantyEntitlement in warrantyProviders/types.ts:1-7", k)
+			}
+		}
+	})
+
+	t.Run("nil info yields a nil payload, never a blank report", func(t *testing.T) {
+		if p := buildHpWarrantyPayload(nil); p != nil {
+			t.Fatalf("buildHpWarrantyPayload(nil) = %#v, want nil", p)
+		}
+	})
+
+	t.Run("a report with no coverage dates and no entitlements is not worth sending", func(t *testing.T) {
+		if p := buildHpWarrantyPayload(&collectors.HpWarrantyInfo{SerialNumber: "5CD1"}); p != nil {
+			t.Fatalf("buildHpWarrantyPayload() = %#v, want nil — a serial-only report would flip data_source to agent_cmsl with nothing to show for it", p)
+		}
+	})
+}
+
+func TestRunHpWarrantyCycle(t *testing.T) {
+	now := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
+	hpCache := now.Add(-2 * 24 * time.Hour)
+
+	newHeartbeat := func(t *testing.T) (*Heartbeat, *int) {
+		t.Helper()
+		sent := 0
+		h := &Heartbeat{
+			config:                      &config.Config{AgentID: "agent-under-test"},
+			hpWarrantyStatePathOverride: filepath.Join(t.TempDir(), "hp_warranty_state.json"),
+			hpSendFn:                    func(map[string]any) error { sent++; return nil },
+		}
+		h.setHpCmslCollectionEnabled(true)
+		return h, &sent
+	}
+
+	t.Run("a successful cycle reports once and schedules from HP's cache timestamp", func(t *testing.T) {
+		h, sent := newHeartbeat(t)
+		original := hpCollectFn
+		t.Cleanup(func() { hpCollectFn = original })
+		hpCollectFn = func() (*collectors.HpWarrantyInfo, error) {
+			return &collectors.HpWarrantyInfo{
+				CoverageEndDate: "2027-01-14",
+				HPCacheTime:     hpCache,
+				Tier:            collectors.HpTierT0,
+				Reason:          collectors.HpReasonOK,
+			}, nil
+		}
+
+		h.runHpWarrantyCycle(now)
+
+		if *sent != 1 {
+			t.Fatalf("reports sent = %d, want 1", *sent)
+		}
+		st := h.loadHpWarrantyState()
+		want := hpNextDueAt(hpCache, "agent-under-test", now)
+		if !st.NextDueAt.Equal(want) {
+			t.Fatalf("persisted NextDueAt = %v, want %v (derived from HP's own cache timestamp, contract D8)", st.NextDueAt, want)
+		}
+		if st.Failures != 0 || st.RateLimitHits != 0 {
+			t.Fatalf("counters not reset on success: %#v", st)
+		}
+		if !h.hpWarrantyNextDue.Equal(want) {
+			t.Fatalf("in-memory due %v does not match persisted %v", h.hpWarrantyNextDue, want)
+		}
+	})
+
+	t.Run("T2 (CMSL absent) reports nothing but records why", func(t *testing.T) {
+		h, sent := newHeartbeat(t)
+		original := hpCollectFn
+		t.Cleanup(func() { hpCollectFn = original })
+		hpCollectFn = func() (*collectors.HpWarrantyInfo, error) {
+			return nil, &collectors.HpCollectError{Reason: collectors.HpReasonNamespaceAbsent, Detail: "Invalid namespace"}
+		}
+
+		h.runHpWarrantyCycle(now)
+
+		if *sent != 0 {
+			t.Fatalf("reports sent = %d, want 0 — T2 reports nothing and lets the policy install CMSL", *sent)
+		}
+		st := h.loadHpWarrantyState()
+		if st.LastReason != collectors.HpReasonNamespaceAbsent {
+			t.Fatalf("LastReason = %q, want %q — the spec requires reporting WHY collection failed", st.LastReason, collectors.HpReasonNamespaceAbsent)
+		}
+		if st.Failures != 1 {
+			t.Fatalf("Failures = %d, want 1", st.Failures)
+		}
+		if !st.NextDueAt.After(now) {
+			t.Fatalf("NextDueAt = %v is not in the future", st.NextDueAt)
+		}
+	})
+
+	t.Run("an HP 429 escalates the rate-limit counter, not the ordinary failure counter", func(t *testing.T) {
+		h, _ := newHeartbeat(t)
+		original := hpCollectFn
+		t.Cleanup(func() { hpCollectFn = original })
+		hpCollectFn = func() (*collectors.HpWarrantyInfo, error) {
+			return nil, &collectors.HpCollectError{Reason: collectors.HpReasonRateLimited, Detail: "(429) Too Many Requests"}
+		}
+
+		h.runHpWarrantyCycle(now)
+
+		st := h.loadHpWarrantyState()
+		if st.RateLimitHits != 1 {
+			t.Fatalf("RateLimitHits = %d, want 1", st.RateLimitHits)
+		}
+		if got := st.NextDueAt.Sub(now); got < hpRateLimitBackoffBase {
+			t.Fatalf("next attempt in %v, want at least %v — anything sooner walks the whole NAT back into HP's limit", got, hpRateLimitBackoffBase)
+		}
+	})
+
+	t.Run("stale data served alongside a 429 is still reported AND still backs off", func(t *testing.T) {
+		h, sent := newHeartbeat(t)
+		original := hpCollectFn
+		t.Cleanup(func() { hpCollectFn = original })
+		hpCollectFn = func() (*collectors.HpWarrantyInfo, error) {
+			return &collectors.HpWarrantyInfo{
+				CoverageEndDate: "2027-01-14",
+				HPCacheTime:     now.Add(-45 * 24 * time.Hour),
+				Tier:            collectors.HpTierT0,
+				Reason:          collectors.HpReasonRateLimited,
+				RateLimited:     true,
+			}, nil
+		}
+
+		h.runHpWarrantyCycle(now)
+
+		if *sent != 1 {
+			t.Fatalf("reports sent = %d, want 1 — month-old dates beat status='unknown', which is the whole point of the feature", *sent)
+		}
+		st := h.loadHpWarrantyState()
+		if st.RateLimitHits != 1 {
+			t.Fatalf("RateLimitHits = %d, want 1 — RateLimited on the struct is the only channel for a serve-stale 429", st.RateLimitHits)
+		}
+		if got := st.NextDueAt.Sub(now); got < hpRateLimitBackoffBase {
+			t.Fatalf("next attempt in %v, want at least %v", got, hpRateLimitBackoffBase)
+		}
+	})
+
+	t.Run("consecutive failures escalate the delay monotonically", func(t *testing.T) {
+		h, _ := newHeartbeat(t)
+		original := hpCollectFn
+		t.Cleanup(func() { hpCollectFn = original })
+		hpCollectFn = func() (*collectors.HpWarrantyInfo, error) {
+			return nil, &collectors.HpCollectError{Reason: collectors.HpReasonRefreshFailed, Detail: "network unreachable"}
+		}
+
+		var previous time.Duration
+		for attempt := 1; attempt <= 4; attempt++ {
+			h.runHpWarrantyCycle(now)
+			st := h.loadHpWarrantyState()
+			if st.Failures != attempt {
+				t.Fatalf("attempt %d: Failures = %d, want %d", attempt, st.Failures, attempt)
+			}
+			delay := st.NextDueAt.Sub(now)
+			if attempt > 1 && delay <= previous {
+				t.Fatalf("attempt %d: delay %v did not grow past %v", attempt, delay, previous)
+			}
+			previous = delay
+		}
+	})
+
+	t.Run("a send failure does not advance the schedule as if it succeeded", func(t *testing.T) {
+		h, _ := newHeartbeat(t)
+		h.hpSendFn = func(map[string]any) error { return errors.New("503 from the API") }
+		original := hpCollectFn
+		t.Cleanup(func() { hpCollectFn = original })
+		hpCollectFn = func() (*collectors.HpWarrantyInfo, error) {
+			return &collectors.HpWarrantyInfo{CoverageEndDate: "2027-01-14", HPCacheTime: hpCache, Reason: collectors.HpReasonOK}, nil
+		}
+
+		h.runHpWarrantyCycle(now)
+
+		st := h.loadHpWarrantyState()
+		if st.Failures != 1 {
+			t.Fatalf("Failures = %d, want 1 — collected-but-never-delivered is a failure, and pushing NextDueAt out 30 days would hide it for a month", st.Failures)
+		}
+		if got := st.NextDueAt.Sub(now); got > hpCacheTTL {
+			t.Fatalf("NextDueAt is %v out, want a retry interval not a full cache lifetime", got)
+		}
+	})
+
+	t.Run("a disabled policy never collects", func(t *testing.T) {
+		h, sent := newHeartbeat(t)
+		h.setHpCmslCollectionEnabled(false)
+		collected := 0
+		original := hpCollectFn
+		t.Cleanup(func() { hpCollectFn = original })
+		hpCollectFn = func() (*collectors.HpWarrantyInfo, error) {
+			collected++
+			return &collectors.HpWarrantyInfo{CoverageEndDate: "2027-01-14"}, nil
+		}
+
+		h.runHpWarrantyCycle(now)
+
+		if collected != 0 || *sent != 0 {
+			t.Fatalf("collected=%d sent=%d, want 0/0 with the policy disabled", collected, *sent)
+		}
+	})
+}
+
+func TestSeedHpWarrantySchedule(t *testing.T) {
+	now := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
+
+	t.Run("a fresh device bootstraps into the jitter window, not immediately", func(t *testing.T) {
+		h := &Heartbeat{
+			config:                      &config.Config{AgentID: "fresh-device"},
+			hpWarrantyStatePathOverride: filepath.Join(t.TempDir(), "hp_warranty_state.json"),
+		}
+		h.seedHpWarrantySchedule(now)
+		want := hpBootstrapDueAt("fresh-device", now)
+		if !h.hpWarrantyNextDue.Equal(want) {
+			t.Fatalf("seeded due = %v, want %v", h.hpWarrantyNextDue, want)
+		}
+	})
+
+	t.Run("a restart honours the persisted due time instead of collecting again", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "hp_warranty_state.json")
+		h := &Heartbeat{config: &config.Config{AgentID: "restarted"}, hpWarrantyStatePathOverride: path}
+		persisted := now.Add(11 * 24 * time.Hour)
+		if err := h.saveHpWarrantyState(hpWarrantyState{NextDueAt: persisted, Failures: 2, RateLimitHits: 1}); err != nil {
+			t.Fatal(err)
+		}
+
+		fresh := &Heartbeat{config: &config.Config{AgentID: "restarted"}, hpWarrantyStatePathOverride: path}
+		fresh.seedHpWarrantySchedule(now)
+
+		if !fresh.hpWarrantyNextDue.Equal(persisted) {
+			t.Fatalf("seeded due = %v, want the persisted %v — a restart-prone endpoint must not re-collect on every boot (#1906's lesson)", fresh.hpWarrantyNextDue, persisted)
+		}
+		if fresh.hpWarrantyFailures != 2 || fresh.hpWarrantyRateLimitHits != 1 {
+			t.Fatalf("counters not restored: failures=%d rateLimitHits=%d", fresh.hpWarrantyFailures, fresh.hpWarrantyRateLimitHits)
+		}
+	})
+}
+```
+
+Extend that test file's imports to:
+
+```go
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/collectors"
+	"github.com/breeze-rmm/agent/internal/config"
+)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd agent && go test -race ./internal/heartbeat/ -run 'TestBuildHpWarrantyPayload|TestRunHpWarrantyCycle|TestSeedHpWarrantySchedule'
+```
+Expected: FAIL to build — `undefined: buildHpWarrantyPayload`, `undefined: hpCollectFn`, `undefined: runHpWarrantyCycle`, `undefined: seedHpWarrantySchedule`, `hpSendFn` is not a field of `Heartbeat`.
+
+- [ ] **Step 3: Add the two seams to the `Heartbeat` struct**
+
+In `agent/internal/heartbeat/heartbeat.go`, extend the W03 block added in Task 7 Step 5:
+
+```go
+	// hpSendFn is a TEST-ONLY seam for the report call; nil in production, where
+	// runHpWarrantyCycle uses sendHpWarrantyInfo → sendInventoryData. Without it
+	// a cycle test would have to stand up an HTTP server to prove a scheduling
+	// decision, which is the wrong thing to make expensive.
+	hpSendFn func(payload map[string]any) error
+```
+
+- [ ] **Step 4: Implement the cycle, the payload and the report**
+
+Append to `agent/internal/heartbeat/hp_warranty.go`:
+
+```go
+// hpCollectFn is the collection seam. It defaults to the real collector, which
+// is a genuine no-op on non-Windows (collectors/hp_warranty_other.go), so tests
+// on the CI runner replace it rather than relying on that no-op — a test that
+// passed only because collection returned (nil, nil) would prove nothing.
+var hpCollectFn = collectors.CollectHpWarranty
+
+// buildHpWarrantyPayload renders an HpWarrantyInfo for
+// PUT /agents/:id/warranty-info, modelled on sendAppleWarrantyInfo
+// (heartbeat.go:2405-2435).
+//
+// Returns nil when there is nothing worth reporting. That matters: an
+// agent_cmsl row with no dates would still flip device_warranty.data_source to
+// 'agent_cmsl' and, once W01's preservation generalisation lands, make the
+// server preserve an empty row against future provider syncs.
+//
+// The entitlement objects mirror WarrantyEntitlement
+// (warrantyProviders/types.ts:1-7) MINUS `provider`: W01 derives that from the
+// reporting source server-side, because hardcoding it is the verified defect at
+// warrantySync.ts:367. An agent-supplied `provider` would re-create it.
+func buildHpWarrantyPayload(info *collectors.HpWarrantyInfo) map[string]any {
+	if info == nil {
+		return nil
+	}
+	if info.CoverageEndDate == "" && info.CoverageStartDate == "" && len(info.Entitlements) == 0 {
+		return nil
+	}
+
+	payload := map[string]any{
+		"source":            "agent_cmsl",
+		"manufacturer":      "HP",
+		"coverageEndDate":   info.CoverageEndDate,
+		"coverageStartDate": info.CoverageStartDate,
+		"coverageType":      info.CoverageType,
+	}
+
+	// Omitted, never sent empty: an empty array is a value the server would
+	// write over a populated entitlements column.
+	if len(info.Entitlements) > 0 {
+		ents := make([]map[string]any, 0, len(info.Entitlements))
+		for _, e := range info.Entitlements {
+			ents = append(ents, map[string]any{
+				"serviceLevelDescription": e.ServiceLevelDescription,
+				"entitlementType":         e.EntitlementType,
+				"startDate":               e.StartDate,
+				"endDate":                 e.EndDate,
+			})
+		}
+		payload["entitlements"] = ents
+	}
+
+	return payload
+}
+
+// sendHpWarrantyInfo PUTs the payload to /agents/:id/warranty-info, reusing the
+// Apple transport unchanged. Note sendInventoryData takes the ENDPOINT first
+// and the label third (heartbeat.go:2155).
+func (h *Heartbeat) sendHpWarrantyInfo(payload map[string]any) error {
+	if h.hpSendFn != nil {
+		return h.hpSendFn(payload)
+	}
+	return h.sendInventoryData("warranty-info", payload, "hp warranty")
+}
+
+// seedHpWarrantySchedule restores the persisted schedule at startup, mirroring
+// the reliability seeding at heartbeat.go:1789-1809. A device that has never
+// collected bootstraps into the jitter window rather than firing immediately,
+// so switching the policy on for a site does not produce a simultaneous CMSL
+// stampede from one NAT.
+func (h *Heartbeat) seedHpWarrantySchedule(now time.Time) {
+	st := h.loadHpWarrantyState()
+	next := st.NextDueAt
+	if next.IsZero() {
+		next = hpBootstrapDueAt(h.agentIDForJitter(), now)
+	}
+	h.mu.Lock()
+	h.hpWarrantyNextDue = next
+	h.hpWarrantyFailures = st.Failures
+	h.hpWarrantyRateLimitHits = st.RateLimitHits
+	h.mu.Unlock()
+}
+
+// agentIDForJitter returns the stable per-device key the jitter hashes. The
+// agent id is a sha256 hash assigned at enrolment and never changes for the
+// life of the enrolment, which is exactly the stability the offset needs.
+func (h *Heartbeat) agentIDForJitter() string {
+	if h.config == nil {
+		return ""
+	}
+	return h.config.AgentID
+}
+
+// runHpWarrantyCycle performs one HP warranty collection: collect, report, then
+// persist the next due time. Called from the tick loop only after
+// claimHpWarrantyCycleLocked has claimed the cycle.
+//
+// Every exit path persists a schedule. A path that returned without persisting
+// would leave only the claim's provisional advance, so the device would retry
+// in hpMinRecheckInterval regardless of what happened — losing both the 30-day
+// cadence on success and the 429 back-off on failure.
+func (h *Heartbeat) runHpWarrantyCycle(now time.Time) {
+	if !h.hpCmslCollectionEnabled() {
+		return
+	}
+
+	h.mu.Lock()
+	st := hpWarrantyState{
+		Failures:      h.hpWarrantyFailures,
+		RateLimitHits: h.hpWarrantyRateLimitHits,
+	}
+	h.mu.Unlock()
+	st.LastAttemptAt = now
+
+	info, err := hpCollectFn()
+
+	switch {
+	case err != nil:
+		var hpErr *collectors.HpCollectError
+		reason := "collect_failed"
+		if errorsAsHp(err, &hpErr) {
+			reason = hpErr.Reason
+		}
+		st.LastReason = reason
+		if collectors.IsHpRateLimited(err) {
+			st.RateLimitHits++
+			log.Warn("HP refused the warranty refresh with a rate limit; backing off",
+				"reason", reason, "rateLimitHits", st.RateLimitHits, "error", err.Error())
+		} else {
+			st.Failures++
+			// Warn, not Debug: the whole point of the reason codes is that an
+			// operator can tell "CMSL is not installed" from "PowerShell is too
+			// old" without a lab visit, and Debug is suppressed at the default
+			// level.
+			log.Warn("HP warranty collection produced no data",
+				"reason", reason, "failures", st.Failures, "error", err.Error())
+		}
+		st.NextDueAt = hpFailureDueAt(st, h.agentIDForJitter(), now)
+
+	case info == nil:
+		// Not an error and not data: the non-Windows no-op, or a Windows host
+		// that resolved nothing worth sending. Neither is a failure to escalate.
+		st.LastReason = collectors.HpReasonNoWarrantyRow
+		st.Failures = 0
+		st.RateLimitHits = 0
+		st.NextDueAt = hpNextDueAt(time.Time{}, h.agentIDForJitter(), now)
+
+	default:
+		payload := buildHpWarrantyPayload(info)
+		if payload == nil {
+			st.LastReason = collectors.HpReasonNoWarrantyRow
+			st.Failures = 0
+			st.RateLimitHits = 0
+			st.NextDueAt = hpNextDueAt(info.HPCacheTime, h.agentIDForJitter(), now)
+			break
+		}
+		if sendErr := h.sendHpWarrantyInfo(payload); sendErr != nil {
+			// Collected but never delivered. Treating this as success would push
+			// the next attempt a full HP cache lifetime out and hide the outage
+			// for a month.
+			st.Failures++
+			st.LastReason = "report_failed"
+			st.NextDueAt = hpFailureDueAt(st, h.agentIDForJitter(), now)
+			log.Warn("HP warranty report failed to send", "failures", st.Failures, "error", sendErr.Error())
+			break
+		}
+		st.LastSuccessAt = now
+		st.LastReason = info.Reason
+		if info.RateLimited {
+			// Stale data was served alongside a 429. The report succeeded, so
+			// the ordinary failure counter resets — but HP still refused, so the
+			// rate-limit back-off must still apply.
+			st.RateLimitHits++
+			st.Failures = 0
+			st.NextDueAt = hpFailureDueAt(st, h.agentIDForJitter(), now)
+			log.Warn("HP warranty reported from a stale cache after a rate limit; backing off",
+				"rateLimitHits", st.RateLimitHits, "tier", info.Tier)
+		} else {
+			st.Failures = 0
+			st.RateLimitHits = 0
+			st.NextDueAt = hpNextDueAt(info.HPCacheTime, h.agentIDForJitter(), now)
+			log.Info("HP warranty reported",
+				"tier", info.Tier, "entitlements", len(info.Entitlements),
+				"hpCacheTime", info.HPCacheTime.Format(time.RFC3339),
+				"nextDueAt", st.NextDueAt.Format(time.RFC3339))
+		}
+	}
+
+	h.mu.Lock()
+	h.hpWarrantyNextDue = st.NextDueAt
+	h.hpWarrantyFailures = st.Failures
+	h.hpWarrantyRateLimitHits = st.RateLimitHits
+	h.mu.Unlock()
+
+	if err := h.saveHpWarrantyState(st); err != nil {
+		// Non-fatal: the in-memory schedule above still holds for this process,
+		// so the device does not spin. It only loses the schedule on restart.
+		log.Warn("failed to persist HP warranty state", "error", err.Error())
+	}
+}
+
+// errorsAsHp is errors.As specialised for *collectors.HpCollectError.
+func errorsAsHp(err error, target **collectors.HpCollectError) bool {
+	return errors.As(err, target)
+}
+```
+
+Add `"errors"` to `agent/internal/heartbeat/hp_warranty.go`'s import block.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+cd agent && go test -race ./internal/heartbeat/ -run 'TestBuildHpWarrantyPayload|TestRunHpWarrantyCycle|TestSeedHpWarrantySchedule' -v
+```
+Expected: PASS.
+
+- [ ] **Step 6: Wire the cycle into startup and the tick loop**
+
+In `agent/internal/heartbeat/heartbeat.go`, in the startup block, immediately after `h.mu.Unlock()` at `:1806` and before the `if postReliability {` at `:1807`, add:
+
+```go
+	// HP warranty has its own persisted cadence and does NOT join the 15-minute
+	// sendInventory fan-out: HP self-caches 30 days, so riding that lifecycle
+	// would relaunch PowerShell every 15 minutes for days (contract D8).
+	h.seedHpWarrantySchedule(startupNow)
+```
+
+Then in the tick body, inside the `h.mu` critical section — after `shouldSendPatch := h.claimPatchScanLocked(now, patchInterval)` (`:1884`) and before `h.mu.Unlock()` (`:1885`) — add:
+
+```go
+			shouldCollectHpWarranty := h.claimHpWarrantyCycleLocked(now)
+```
+
+and after the `h.mu.Unlock()`, alongside the other post-unlock dispatches, add:
+
+```go
+			if shouldCollectHpWarranty {
+				go func() {
+					defer observability.Recoverer("heartbeat.hpWarranty")
+					h.runHpWarrantyCycle(time.Now())
+				}()
+			}
+```
+
+`observability` is already imported and used the same way at `:2135`.
+
+- [ ] **Step 7: Full verification**
+
+```bash
+cd agent && go vet ./internal/collectors/... ./internal/heartbeat/...
+cd agent && go test -race ./internal/collectors/... ./internal/heartbeat/...
+cd agent && GOOS=windows GOARCH=amd64 go build ./... && GOOS=linux GOARCH=amd64 go build ./... && GOOS=darwin GOARCH=arm64 go build ./...
+```
+Expected: vet clean, all tests PASS, all three cross-compiles succeed. The cross-compiles still earn their place with the struct declared once: the Windows build is the only place the `//go:build windows` entry point, its PowerShell scripts and the tagged half of the tree are compiled at all, and the darwin/linux builds prove the `!windows` stub still satisfies every caller — including `heartbeat.go`, which references `collectors.HpWarrantyInfo` on every platform.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add agent/internal/heartbeat/hp_warranty.go agent/internal/heartbeat/hp_warranty_test.go agent/internal/heartbeat/heartbeat.go
+git commit -m "feat(agent): run and report the HP warranty cycle on its own persisted cadence (W03)"
+```
+
+---
+
+## Verification checklist before opening the PR
+
+- [ ] `cd agent && go test -race ./internal/collectors/... ./internal/heartbeat/...` — green.
+- [ ] `cd agent && go vet ./internal/collectors/... ./internal/heartbeat/...` — clean.
+- [ ] `cd agent && make build-all` — all platform/arch combinations build.
+- [ ] `grep -rn "yusufpapurcu/wmi\|go-ole" agent/internal/collectors/` returns nothing — no WMI binding was introduced.
+- [ ] `git diff --stat origin/main -- apps/ packages/ ee/` is **empty** — this wave touches no server, web or shared code.
+- [ ] `git diff origin/main -- agent/internal/heartbeat/warranty_config.go` is **empty** (W02 shipped the accessor — the expected case) or **one added line** (the Task 9 Step 5 fallback). Anything more means this wave re-implemented W02's parse.
+- [ ] `git diff origin/main -- agent/internal/collectors/warranty_other.go` is **empty** — Apple's `!darwin` stub was not retagged or "tidied".
+- [ ] The two build-tagged files declare **no type**: `grep -n "^type " agent/internal/collectors/hp_warranty_windows.go agent/internal/collectors/hp_warranty_other.go` returns nothing, and `grep -c "^type HpWarrantyInfo" agent/internal/collectors/hp_warranty.go` returns `1`. This is D7 as amended (Global Constraints); a second declaration would reintroduce the drift hazard the amendment removed.
+- [ ] `agent/internal/collectors/testdata/hp_warranty_wmi_real.json` contains the W01 probe's real capture, and `TestParseHpWarrantyWMI_RealProbeFixture` passes against it without any assertion having been weakened.
+- [ ] No test spawns a real process: `grep -n "runCollectorOutput\|exec.Command" agent/internal/collectors/hp_warranty_test.go agent/internal/heartbeat/hp_warranty_test.go` returns nothing.
+- [ ] PR body records W01's answer to lab question 1 (does the namespace exist without CMSL) and states which world the fleet is in.
+- [ ] PR body includes `Closes #5514`.
+
+---
+
+## Self-review
+
+**1. Spec coverage.** Walking spec layer 5 and layer 6, and contract D7/D8/D9/D10:
+
+| Requirement | Task |
+|---|---|
+| `hp_warranty_windows.go` + `hp_warranty_other.go`, `(nil, nil)` stub, shared types declared once (D7 as amended) | 1 |
+| Do not retag `warranty_other.go` | verified in the pre-PR checklist |
+| T0 reads WMI via PowerShell `Get-CimInstance -Namespace`, no Go WMI binding | 3 (+ §0.1 proof) |
+| T1 runs `Get-HPWarrantyInfo` only when the data is missing or HP's cache is genuinely stale, then re-reads WMI | 4, 5 |
+| T2 — CMSL absent, report nothing, let the policy install it | 5 |
+| Report WHY collection failed (PS 5.1 / TLS 1.2 not universal) | 2 (reason codes), 3 (T0 sentinels), 4 (T1 sentinels), 10 (persisted `LastReason` + Warn logs) |
+| Scheduling keys off the ACTUAL HP cache timestamp, not a fixed interval | 5 (`hpCacheStale`), 7 (`hpNextDueAt`) |
+| Own persisted due time and bounded retries; does not ride `sendInventory` | 7, 8, 10 |
+| Distinct first-run/bootstrap behaviour | 7 (`hpBootstrapDueAt`), 10 (`seedHpWarrantySchedule`) |
+| Deterministic per-device jitter, honestly described as statistical | 7 (implementation + doc comment + distribution test) |
+| Back off on an HP 429 rather than retrying into the limit | 4 (detection), 8 (back-off), 10 (both the error and serve-stale paths) |
+| Reuse `sendInventoryData("warranty-info", …)` with the `runtime.GOOS` guard | 10 |
+| `source: 'agent_cmsl'`, `manufacturer: 'HP'` | 10 |
+| Entitlements written against W01's widened schema/type, never redefined; `provider` omitted | 10 (Interfaces "Consumes"), 6 (bounds) |
+| Gated by W02's `warranty_config.go` seam, config parsing not re-implemented | 9 |
+| Table-driven tests: tier selection, due time from an HP cache timestamp, jitter determinism + distribution, 429 back-off | 5, 7, 7, 8 |
+| Every test passes on a non-Windows runner with the command seam mocked | 3 (`stubHpPowerShell`), 10 (`hpCollectFn`, `hpSendFn`) |
+
+One spec line is **deliberately not implemented here**: "the `runtime.GOOS` guard" appears in Task 10's Interfaces via `sendHpWarrantyInfo`, but the actual early return lives in `hp_warranty_other.go`'s `(nil, nil)` plus `hpCollectFn`. Task 10's cycle therefore runs harmlessly on non-Windows and takes the `info == nil` branch. That is intentional — it keeps the cycle itself testable on CI — and the `runtime.GOOS` belt-and-braces is redundant with a compile-time build tag, which is strictly stronger. Called out here rather than silently dropped.
+
+**2. Placeholder scan.** No "TBD", no "add appropriate error handling", no "similar to Task N", no "write tests for the above". Every code step carries complete Go. The two forward-looking items are both concrete, named, one-line reconciliations against data that does not exist yet (Task 2 Step 1's field-candidate vars, Task 4 Step 5's regex alternation), each pointing at an exact identifier and each guarded by a failing assertion rather than a comment.
+
+**3. Type consistency.** Cross-checked:
+- `HpWarrantyInfo` fields — declared **once** in Task 1 Step 3's tag-free file, set in Task 2's parser, mutated in Tasks 5 and 6, read in Task 10's payload builder. `HPCacheTime`, `Tier`, `Reason`, `RateLimited` are `json:"-"`, so the struct's own JSON tags never reach the wire — Task 10 builds the payload explicitly instead of marshalling the struct, which is what keeps the scheduling fields out of the report.
+- `HpEntitlement` — four fields, single declaration (Task 1), populated in Task 2, truncated in Task 6, rendered in Task 10. Names match `WarrantyEntitlement` minus `provider` throughout.
+- `HpCollectError{Reason, Detail}` — constructed in Tasks 2, 3, 4; matched via `errorsAs` in Tasks 2/3/5 (collectors) and `errorsAsHp` in Task 10 (heartbeat, different package so a separate helper is required, not a duplicate name).
+- `hpRunPowerShell(timeout time.Duration, script string) ([]byte, error)` — declared Task 3, overridden in Tasks 3, 4, 5 with the identical signature.
+- `hpCacheTTL`/`hpRefreshMargin` — defined once in `collectors` (Task 5), exported (Task 7 Step 3), re-bound in `heartbeat` as aliases so there is exactly one source of truth.
+- `hpWarrantyState` field names — written in Task 7, read/written in Tasks 8 (`hpFailureDueAt`) and 10 (`runHpWarrantyCycle`, `seedHpWarrantySchedule`). Consistent.
+- `Heartbeat` fields added — `hpWarrantyNextDue`, `hpWarrantyFailures`, `hpWarrantyRateLimitHits`, `hpCmslEnabled`, `hpWarrantyStatePathOverride` (Task 7), `hpSendFn` (Task 10). Every one is referenced by a later task; none is orphaned.
+
+**4. Gaps deliberately left, and who owns them.**
+- The exact HP WMI property names and HP's 429 wording are W01 probe outputs, reconciled in Task 2 Step 1 and Task 4 Step 5.
+- W02's storage shape for the config flag is unsettled by the *contract* but settled by *W02's plan* (§0.16): a persisted `h.config` field plus a mutex-guarded accessor. Task 9 Step 1 reads the shipped name and gives complete code for that primary path and for the fallback. This is the only place in the wave an implementer chooses between two written implementations, and both are fully specified.
+- Manual refresh on an HP device (D11) stays W01's honest 409. This wave adds no trigger to upgrade it to "request agent collection" — doing so needs an `apps/api` route change, which is explicitly out of scope here.

--- a/docs/superpowers/plans/device-lifecycle/2026-09-10-hp-warranty-cmsl-w04-builtin-package.md
+++ b/docs/superpowers/plans/device-lifecycle/2026-09-10-hp-warranty-cmsl-w04-builtin-package.md
@@ -1,0 +1,2806 @@
+---
+tracking_issue: LanternOps/breeze#5511
+---
+
+# Wave 04 — Built-in HP CMSL catalog package — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make HP's Client Management Script Library (CMSL) a first-class built-in Breeze deployment package — a third, package-manager-shaped arm of `BuiltinPackageDef` that provisions a partner-scoped `software_catalog` row plus a `winget`/`HP.HPCMSL` install method — and separate it cleanly from EDR credential readiness on both sides of the wire so the catalog page renders it without crashing.
+
+**Architecture:** The `software_catalog_integration_provider_chk` CHECK is widened forward-only to admit `hp_cmsl`. `BuiltinPackageDef`'s discriminant changes from the boolean `requiresBinaryUpload` (which cannot express three shapes) to an explicit `installSource: 'derived_url' | 'partner_upload' | 'package_manager'`; `ensureBuiltinPackage` gains a `package_manager` branch that upserts one `software_install_methods` row under system DB context. `BuiltinProvider` splits into `BuiltinEdrProvider` (the credential-backed pair that `edrInstallerResolver` is typed against) and the wider `BuiltinProvider`, so HP can never be routed into EDR secret resolution. The web mirrors that split exactly: `EDR_PROVIDERS` ⊂ `INTEGRATION_PROVIDERS`, `useEdrReadiness` narrows to `EdrProvider`, and the catalog's readiness pill is gated on `isEdrProvider` while branding and the "Built-in" chip stay on `isIntegrationProvider`.
+
+**Tech Stack:** Hono + Drizzle ORM + PostgreSQL (RLS), Vitest (unit + `vitest.integration.config.ts`), React + Vitest/jsdom + Testing Library, zod.
+
+**Spec:** `docs/superpowers/specs/device-lifecycle/2026-09-10-hp-warranty-cmsl-design.md` — Layer 3 ("Getting CMSL onto the device"), plus its "Corrections after ground-truth verification" section, which supersedes the body wherever the two disagree.
+
+**Cross-wave contract:** `contract-B-hp-cmsl.md` (coordinator, locked). The parts this wave needs are copied verbatim into Global Constraints below.
+
+**Depends on:** W01 #5512 (lab probe — see Gate 1), Feature A #5505 wave W03 = issue **#5508** (see Gate 2). W02 #5513 lands before this wave and owns the `hpCmsl` inline-settings block that Task 6 reads.
+
+---
+
+## ⛔ TWO HARD GATES — read before writing any code
+
+### Gate 1 — W01's lab probe must have answered the namespace question, and Todd must have ruled on it
+
+W01 (#5512) probes real HP hardware for: **does `root/HP/InstrumentedServices/v1` exist and carry `HP_Warranty` / `HP_Entitlements` rows WITHOUT CMSL installed?**
+
+If HP's factory image populates that namespace broadly, a large fraction of the fleet yields warranty data at **zero install and zero EULA exposure**, and most of this wave stops being worth building — the collector (W03) alone would cover those devices, and a built-in package would only serve the remainder.
+
+**That is a scope decision for Todd, not for the implementer.** Before starting Task 1:
+
+1. Read the recorded answer on issue **#5512** (the contract requires W01 to record all three answers there, not only in its plan doc).
+2. If the answer is "populated without CMSL on a meaningful share of hardware", **stop and surface it**. Do not narrow, re-scope, or delete tasks on your own judgement.
+3. If #5512 has no recorded answer yet, this wave is not startable. Say so and stop.
+
+### Gate 2 — Feature A #5505 wave W03 (issue **#5508**) must have MERGED
+
+Issue #5508 is *"W03: Remediation worker: policy-owned deployment creation, dispatch, dedup, `software_policy_id` column and its registrations"*. Verified 2026-09-10: **#5508 is OPEN.**
+
+That wave is the machinery that turns a `missing` software-policy violation into an actual install. Without it:
+
+- `SoftwarePolicyRemediationOptions` has exactly one verb, `autoUninstall?: boolean` (`apps/api/src/db/schema/softwarePolicies.ts:65-71`). There is no `autoInstall` field to set.
+- `remediationOptionsSchema` (`softwarePolicies.ts:79-85`) is a non-strict `z.object`, so an `autoInstall` key written today is **silently stripped**, not rejected — a policy would look armed and install nothing.
+- The compliance worker's remediation gate requires at least one `unauthorized` violation before it queues anything, so a device with only `missing` violations is unreachable (per Feature A's own corrections section, `softwareComplianceWorker.ts:423-444`).
+
+**Consequence for task ordering:** Tasks 1–8 of this plan build the catalog package and its UI. They have **no dependency on #5508** and are independently valuable — an MSP can deploy CMSL to HP devices in one click through the existing Deploy wizard, using `targetType: 'filter'` on `hardware.manufacturer` (which *is* supported: `apps/api/src/services/deploymentTargetResolver.ts:60-62` → `evaluateFilter`). **Task 9 — the policy that keeps CMSL present — is blocked on #5508 and must not be started until it has merged.** Ship Tasks 1–8 as one PR if #5508 has not landed; Task 9 follows as a second PR.
+
+### A third thing that is not a gate but bounds the design: the HP CMSL EULA
+
+HP's CMSL licence states verbatim: *"You do not have the right to distribute the Software Product."*
+
+**Breeze must NEVER mirror or host the CMSL installer.** That rules out the `winget_bootstrap` pattern, where Breeze serves pinned artifacts from disk over `/agents/:id/...` (`apps/api/src/routes/agents/wingetBootstrap.ts:22-30`). Installing via **winget**, or via an **HP-hosted URL**, satisfies the licence because the bytes come from HP. This constraint is written into a code comment in Task 2 on purpose: a future change that copies the installer into S3, into the winget-bootstrap artifact set, or into any Breeze-served path is a licence violation, not a performance win.
+
+---
+
+## Global Constraints
+
+Copied verbatim from the coordinator's contract (`contract-B-hp-cmsl.md`) except where marked **[ground-truth correction]**.
+
+- **Migration slot.** Newest committed migration verified 2026-09-10 by `ls apps/api/migrations/*.sql | sort | tail -1`: `apps/api/migrations/2026-10-15-150300-remote-session-revocation-lease.sql` (730 files total). The contract's slot for this wave is `apps/api/migrations/2026-10-15-150402-software-catalog-hp-cmsl-provider.sql`, which sorts after it. **Re-run `ls apps/api/migrations/*.sql | sort | tail -1` at implementation time and rename upward if anything now sorts after that slot** — #5508 must merge first (Gate 2) and it ships its own migration. Filenames in this repo run ahead of real time; today's date does NOT sort last. `2026-08-06` is a closed date block — never add `-g-` or later to it.
+- **Never edit a shipped migration.** `2026-07-02-builtin-catalog-partner-read-rls.sql` is content-hash immutable. Widening its CHECK means a new forward-only file that `DROP CONSTRAINT IF EXISTS` + re-`ADD`s.
+- **Migration idempotency.** `IF NOT EXISTS` / `DROP ... IF EXISTS` / guarded `DO $$` blocks. Re-applying must be a true no-op. **No inner `BEGIN;`/`COMMIT;`** — `autoMigrate` wraps each file in `client.begin(...)`.
+- **`breeze.scope` elevation.** Any migration statement that `UPDATE`/`DELETE`/`INSERT`/`MERGE`s rows must be preceded by `SELECT set_config('breeze.scope', 'system', true);` in the same file (and, in a `-- @no-transaction` file, the same statement). This wave's migration performs **no DML** — it only drops and re-adds a CHECK constraint — so no elevation is required. `apps/api/src/db/migrationRlsScope.test.ts` must still be run (Task 1, step 6).
+- **`BuiltinPackageDef` is a THREE-armed union.** A winget package is a third arm — no URL, no upload, just a package id. Extend the union; do not force HP into an existing arm.
+- **Keep HP out of the EDR secret branch** at `apps/api/src/services/softwareDeployment.ts:554-584`. That path injects Huntress/SentinelOne account and site tokens and has nothing to do with HP.
+- **HP has no credential-readiness concept and must be SEPARATED from EDR readiness, not folded into it.** `INTEGRATION_PROVIDERS` (`apps/web/src/components/software/providerBranding.ts:5`) is the single source both the union and the type guard derive from; adding `hp_cmsl` there without touching readiness is what crashes the catalog page.
+- **Non-negotiable testing gates (contract):**
+  - Web: a test that renders the catalog with an `hp_cmsl` item present. Mandatory.
+  - Integration suites need a live DB and run only in the **Integration Tests** job; a locally-green branch proves nothing about them.
+  - Scoped test runs: `cd apps/api && npx vitest run <path>` / `cd apps/web && npx vitest run <path>`. **Never** `pnpm --filter <pkg> test -- --run <path>` — pnpm forwards the literal `--` into argv, vitest stops flag parsing there, and the full suite runs in watch mode. Vitest's path filter is a plain substring match, so a trailing slash silently skips sibling `foo.test.ts` files.
+- **No new i18n keys.** `apps/web/src/lib/i18n/localeParity.test.ts` enforces parity across nine locales (`de-DE, en, es-419, fr-CA, fr-FR, it-IT, pt-BR, tr-TR`). Existing built-in branding strings (`providerBranding.ts` `label`/`blurb`) are plain untranslated literals; HP's follow that precedent, and Task 8 removes rather than adds rendered strings. Verified: this wave introduces zero `i18n.t()` keys.
+- **`software_catalog` needs no new registry entry.** It is already in `DUAL_AXIS_TENANT_TABLES` (`apps/api/src/__tests__/integration/rls-coverage.integration.test.ts:382`) and `XOR_OWNERSHIP_DUAL_AXIS_TABLES` (`:592`); `software_install_methods` is already in `PARENT_FK_JOIN_POLICY_TABLES` (`:692`). This wave adds **no table and no column**, so `CORE_ORG_CASCADE_DELETE_ORDER`, `CORE_DEVICE_CASCADE_DELETE_TABLES`, `CORE_DEVICE_ORG_DENORMALIZED_TABLES` and `CORE_TENANT_EXPORT_POLICY` are all untouched. (Task 9 also adds no column — it inserts rows into existing tables.)
+- **`hp_cmsl` is the provider string everywhere**, on both sides of the wire: DB CHECK value, `BuiltinProvider` member, `INTEGRATION_PROVIDERS` member, `software_catalog.integration_provider` value. `integration_provider` is `varchar(20)`; `'hp_cmsl'` is 7 characters.
+- **The winget package id is `HP.HPCMSL`.** It satisfies `WINGET_PACKAGE_ID_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/` (`apps/api/src/routes/softwareInstallMethods.ts:22`).
+
+---
+
+## 0. Ground truth
+
+Every file below was re-opened in the worktree at `/Users/toddhebebrand/.herdr/worktrees/breeze/warranty-testing` on 2026-09-10. Citations are mine, not copied from the spec or the contract. **Four contract/spec citations were found wrong and are flagged inline.**
+
+### The DB CHECK
+
+`apps/api/migrations/2026-07-02-builtin-catalog-partner-read-rls.sql:13-25` — verbatim (contract's `:13-25` **confirmed**; the `CHECK` line itself is `:23`):
+
+```sql
+-- Also pin integration_provider to the known set (defense-in-depth; no shipped rows).
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'software_catalog_integration_provider_chk'
+      AND conrelid = 'software_catalog'::regclass
+  ) THEN
+    ALTER TABLE software_catalog
+      ADD CONSTRAINT software_catalog_integration_provider_chk
+      CHECK (integration_provider IS NULL OR integration_provider IN ('huntress', 'sentinelone'));
+  END IF;
+END $$;
+```
+
+Note the `IF NOT EXISTS` guard: the shipped file will **not** re-narrow the constraint after this wave widens it, because the constraint will already exist. Re-applying the whole migration set stays correct.
+
+### The union and the provisioner
+
+`apps/api/src/services/builtinDeploymentPackages.ts` (full file read, 123 lines). Contract citations **confirmed**: `BuiltinProvider` `:5`; union doc comment `:19-23` and the union itself `:24-26`; `BUILTIN_PACKAGES` `:28-54`; `ensureBuiltinPackage` doc comment `:60-65` and function `:66-123`; `originalFileName: 'HuntressInstaller.exe'` at `:112`.
+
+```ts
+// :5
+export type BuiltinProvider = 'huntress' | 'sentinelone';
+// :19-26
+/**
+ * Discriminated on `requiresBinaryUpload` so the two valid shapes can't drift:
+ *  - false → installer URL is derivable, `downloadUrlTemplate` is required (Huntress)
+ *  - true  → no derivable URL; the partner uploads the binary (SentinelOne)
+ */
+export type BuiltinPackageDef =
+  | (BuiltinPackageBase & { requiresBinaryUpload: false; downloadUrlTemplate: string })
+  | (BuiltinPackageBase & { requiresBinaryUpload: true; downloadUrlTemplate?: never });
+```
+
+```ts
+// :99-118 — the version-row branch, with the hardcoded filename at :112
+      // Templated version only when the binary URL is derivable (Huntress).
+      if (!def.requiresBinaryUpload && def.downloadUrlTemplate) {
+        const versions = await db
+          .select({ id: softwareVersions.id })
+          .from(softwareVersions)
+          .where(eq(softwareVersions.catalogId, catalogId))
+          .limit(1);
+        if (versions.length === 0) {
+          await db.insert(softwareVersions).values({
+            catalogId,
+            version: 'latest',
+            downloadUrl: def.downloadUrlTemplate,
+            fileType: def.fileType,
+            originalFileName: 'HuntressInstaller.exe',
+            supportedOs: def.supportedOs,
+            silentInstallArgs: def.silentInstallArgsTemplate,
+            isLatest: true,
+          });
+        }
+      }
+```
+
+`BuiltinPackageBase` (`:7-17`) carries `fileType`, `supportedOs` and `silentInstallArgsTemplate` — all three meaningless for a winget package, which is why Task 2 splits the base rather than adding a fourth optional field.
+
+`ensureBuiltinPackage` runs `runOutsideDbContext(() => withSystemDbAccessContext(async () => { ... }))` (`:72-73`). Confirmed sanctioned here: `software_catalog` is a partner-axis (dual-axis) table and this is a partner-axis WRITE, which is the case CLAUDE.md keeps the escalation for. Both existing call sites fire it **after** their own write has returned, outside any request transaction (`apps/api/src/routes/huntress.ts:454-461`, `apps/api/src/routes/sentinelOne.ts:435`). Task 6 keeps that shape.
+
+Callers today (`grep -rn 'ensureBuiltinPackage' apps/api/src`): `routes/huntress.ts:25,456`, `routes/sentinelOne.ts:13,435`, and the two test files. **There is no HP trigger anywhere** — HP has no integration to connect, which is why Task 6 exists.
+
+`apps/api/src/services/builtinDeploymentPackages.test.ts:29-31` — the assertion this wave turns red first:
+
+```ts
+  it('exposes both providers', () => {
+    expect(Object.keys(BUILTIN_PACKAGES).sort()).toEqual(['huntress', 'sentinelone']);
+  });
+```
+
+### The EDR resolver — a latent trap the contract does not mention
+
+`apps/api/src/services/edrInstallerResolver.ts:54-62` — verbatim:
+
+```ts
+export async function resolveEdrInstaller(params: {
+  provider: BuiltinProvider;
+  orgId: string;
+  downloadUrlTemplate: string | null;
+  silentInstallArgsTemplate: string | null;
+}): Promise<ResolvedInstaller | EdrResolveError> {
+  if (params.provider === 'huntress') return resolveHuntress(params);
+  return resolveSentinelOne(params);
+}
+```
+
+`params.provider` is typed `BuiltinProvider` (`:5` of the imported module, `:55` here). **Widening `BuiltinProvider` to include `'hp_cmsl'` silently widens this function too, and the `return resolveSentinelOne(params)` fall-through would route HP into SentinelOne's site-token resolver.** TypeScript cannot catch it — there is no exhaustive switch. This is the same class of trap as the hardcoded `HuntressInstaller.exe`, and it is why Task 3 splits `BuiltinEdrProvider` out of `BuiltinProvider` instead of just widening the one type.
+
+### The dispatch path — HP structurally cannot reach the EDR branch
+
+`apps/api/src/services/softwareDeployment.ts:521-531` — verbatim:
+
+```ts
+  // Package-manager deploys take a completely different (and much shorter)
+  // path: no installer to presign, no checksum, no destination policy to
+  // evaluate and no `{{...}}` templates to resolve.
+  if (installMethod) {
+    return dispatchManagerInstalls(input, installMethod, fanoutDeviceIds);
+  }
+  if (!versionRecord) {
+    throw new Error(
+      `Software deployment ${deploymentId} has neither a version record nor an install method`,
+    );
+  }
+```
+
+The EDR secret branch is at `:554-584`, gated by `:558-561`:
+
+```ts
+  if (
+    catalogItem.integrationProvider === 'huntress' ||
+    catalogItem.integrationProvider === 'sentinelone'
+  ) {
+```
+
+So an `hp_cmsl` deployment (which always carries an `installMethod`, never a `versionRecord`) returns at `:525`, **before** `:558` is ever evaluated. `dispatchManagerInstalls`'s own doc comment says so (`:361-366`: *"there is no installer binary, so presign, EDR resolution, checksum … are all inapplicable"*). This is stronger than the spec's "keep HP out of the EDR secret branch" — it is already structurally impossible via the manager path. Task 3 pins that with a regression test rather than changing behaviour.
+
+### The install-method API boundary
+
+`apps/api/src/routes/softwareInstallMethods.ts:39-53` (`installMethodBodySchema`) — confirmed. Field is **`kind`**, not `manager`; values `winget | homebrew_cask | homebrew_formula`; platform `windows | macos` only (no `linux`); a `superRefine` at `:44-53` requires `winget ⇔ windows`. `{ platform: 'windows', kind: 'winget', packageId: 'HP.HPCMSL' }` is valid.
+
+`:110-114` — the built-in rejection, **POST only**:
+
+```ts
+    const item = await loadOwnedCatalogItem(c.req.param('id'), orgResult.orgId);
+    if (!item) return c.json({ error: 'Catalog item not found or access denied' }, 404);
+    if (item.integrationProvider !== null) {
+      return c.json({ error: 'Built-in packages cannot carry install methods' }, 400);
+    }
+```
+
+**NEW FINDING — the guard is missing on PATCH and DELETE.** `:144-183` (PATCH) and `:272-308` (DELETE) call `loadOwnedCatalogItem` and then `loadInstallMethod`, with no `integrationProvider` check at all. `loadOwnedCatalogItem` (`:69-74`) is:
+
+```ts
+async function loadOwnedCatalogItem(catalogId: string, orgId: string) {
+  const [item] = await db.select().from(softwareCatalog).where(eq(softwareCatalog.id, catalogId)).limit(1);
+  // RLS restricts visibility; extra guard mirrors software.ts deploy handlers.
+  if (!item || (item.orgId !== null && item.orgId !== orgId)) return null;
+  return item;
+}
+```
+
+A built-in row has `org_id IS NULL`, so `item.orgId !== null` is false and the item passes. RLS does not close the gap either: `software_install_methods`'s UPDATE and DELETE policies (`apps/api/migrations/2026-08-16-a-software-install-methods.sql:89-119`) admit `breeze_has_org_access(sc.org_id) OR (sc.partner_id IS NOT NULL AND breeze_has_partner_access(sc.partner_id))`. For a **partner-scoped** caller the second branch is TRUE. So today a partner admin with `devices.write` + MFA can PATCH a built-in's install method to an arbitrary winget package id, or DELETE it. Once HP CMSL ships an install method, that becomes "install anything you like on every device this built-in reaches". Task 5 closes it.
+
+(Org-scoped callers are already blocked by RLS — `breeze_has_org_access(NULL)` is FALSE and `breeze_has_partner_access(P)` is FALSE for an org token — so this is a partner-scope hole, not an org-scope one.)
+
+`apps/api/migrations/2026-08-16-a-software-install-methods.sql:16-51` — the table, its three CHECKs and the unique index the upsert keys on:
+
+```sql
+CREATE UNIQUE INDEX IF NOT EXISTS software_install_methods_catalog_platform_kind_uq
+  ON software_install_methods (catalog_id, platform, kind);
+```
+
+Mirrored in Drizzle at `apps/api/src/db/schema/software.ts:262` (`catalogPlatformKindUq`). The table cascades from `software_catalog` (`ON DELETE CASCADE`, `:55`) and has no `org_id` — parent-FK join tenancy, already registered.
+
+`breeze_has_partner_access` short-circuits for system scope (`apps/api/migrations/2026-04-11-partners-rls.sql:63-67`: `WHEN public.breeze_current_scope() = 'system' THEN TRUE`), so the provisioner's insert under `withSystemDbAccessContext` passes the INSERT policy. Verified, not assumed.
+
+### The catalog list feed — already generic
+
+`apps/api/src/routes/software.ts:719-732` — the list WHERE already unions in *any* built-in for an org caller (`isNotNull(softwareCatalog.integrationProvider)`), and `:774-775` already computes `methodCount` / `methodKinds` from `software_install_methods`. **No API list change is needed** for an HP CMSL card to appear with a `winget` badge.
+
+`software.ts:939` and `:978` already refuse catalog UPDATE and DELETE on any row with a non-null `integrationProvider` for non-system scope.
+
+`apps/web/src/components/software/DeploymentWizard.tsx:374-393` fetches `/software/catalog/:id/install-methods` for every catalog row generically, so a built-in carrying a winget method is deployable through the existing wizard with no wizard change.
+
+### The web crash — the contract's claim is conditional, not unconditional
+
+`apps/web/src/components/software/providerBranding.ts` (full file, 41 lines). Contract citations **confirmed**: `INTEGRATION_PROVIDERS` `:5`, `BRANDING` `:18` (not exported), `getProviderBranding` `:35`, `isIntegrationProvider` `:39-41`.
+
+`apps/web/src/components/software/useEdrReadiness.ts:123-135` — verbatim:
+
+```ts
+export function useEdrReadiness(
+  providers: IntegrationProvider[],
+  opts?: { s1VersionCount?: number },
+): Record<IntegrationProvider, EdrReadiness> {
+  const s1VersionCount = opts?.s1VersionCount ?? 0;
+  const key = useMemo(
+    () => `${Array.from(new Set(providers)).sort().join(',')}|${s1VersionCount}`,
+    [providers, s1VersionCount],
+  );
+  const [map, setMap] = useState<Record<IntegrationProvider, EdrReadiness>>({
+    huntress: LOADING,
+    sentinelone: LOADING,
+  });
+```
+
+`apps/web/src/components/software/SoftwareCatalog.tsx:637-641` and `:824-828` — the two unguarded dereferences, both **confirmed**:
+
+```tsx
+                  {isIntegrationProvider(item.integrationProvider) && (
+                    <div className="flex items-center gap-1.5">
+                      <ReadinessPill
+                        status={readinessMap[item.integrationProvider].status}
+                      />
+```
+
+```tsx
+              (isIntegrationProvider(selectedSoftware.integrationProvider) ? (
+                <BuiltinPackageDetail
+                  name={selectedSoftware.name}
+                  provider={selectedSoftware.integrationProvider}
+                  readiness={readinessMap[selectedSoftware.integrationProvider]}
+```
+
+**NEW FINDING — a third site the contract does not name, and it is the one that gates the other two.** `SoftwareCatalog.tsx:271-275`, inside the catalog loader's row mapping:
+
+```tsx
+            integrationProvider:
+              item.integrationProvider === "huntress" ||
+              item.integrationProvider === "sentinelone"
+                ? item.integrationProvider
+                : undefined,
+```
+
+This hardcodes the pair. As written, adding `hp_cmsl` to `INTEGRATION_PROVIDERS` **does not crash the page** — an `hp_cmsl` row arrives from the API, is narrowed to `undefined` here, and renders as an ordinary *org* package: no branding, no "Built-in" chip, and a **Delete** button in the detail panel (`:843-850`) that the API would refuse with a 400 (`software.ts:978`). That is a worse outcome than a crash, because it is silent. The crash the contract describes is real but only becomes reachable once `:271-275` is widened, which Task 8 must do. Task 8 exercises both states in sequence so the red is genuine at each step.
+
+`builtinProviders` (`:314-324`) filters with `isIntegrationProvider` and feeds `useEdrReadiness` at `:331` — that filter must become `isEdrProvider`.
+
+`apps/web/src/components/software/BuiltinPackageDetail.tsx:16-37` — `readiness: EdrReadiness` is required today and `:31-33` reads `.status` three times; `:77-146` is the readiness box. Its existing suite `BuiltinPackageDetail.test.tsx` passes a non-null `EdrReadiness`, which stays assignable after Task 8 widens the prop to `EdrReadiness | null`.
+
+Blast radius, from `grep -rn 'providerBranding\|IntegrationProvider\|useEdrReadiness\|EdrReadiness' apps/web/src`: exactly three source files (`providerBranding.ts`, `useEdrReadiness.ts`, `SoftwareCatalog.tsx`, `BuiltinPackageDetail.tsx`) and three test files. Nothing outside `apps/web/src/components/software/`.
+
+`SoftwareCatalog.test.tsx:226-297` is the existing built-in test block, including the `routeBuiltin(items, huntress?, s1?)` URL-routing fetch helper (`:237-245`) that Task 8's new test reuses.
+
+### The policy half — three findings that change Task 9
+
+**[ground-truth correction 1] `filterEngine.ts:88` and `:94` are off by one.** The real lines are `apps/api/src/services/filterEngine.ts:89` (`{ key: 'osType', ... }`) and `:95` (`{ key: 'hardware.manufacturer', ... }`). `:88` and `:94` are the `// OS fields` and `// Hardware fields` section comments. Both fields do exist.
+
+**[ground-truth correction 2] the spec's `software.ts:287` citation for "`targetType: 'sites'` is unimplemented" is wrong.** `software.ts:287` is a status-count sum inside `computeSoftwareDeploymentAggregateStatus`. The real refusal is `apps/api/src/routes/software.ts:400-405`:
+
+```ts
+  if (payload.targetType === 'sites') {
+    return {
+      error: 'Site targeting is not implemented for software deployments',
+      deviceIds: [] as string[],
+    };
+  }
+```
+
+**[ground-truth correction 3 — the substantive one] a software policy does NOT target devices through the filter engine, or through its own `targetType`/`targetIds` columns.** The compliance worker resolves devices via `resolveDeviceIdsForSoftwarePolicy` (`apps/api/src/jobs/softwareComplianceWorker.ts:324` → `apps/api/src/services/featureConfigResolver.ts:1044-1171`), which:
+
+1. finds **configuration policies** that carry a `software_policy` feature link pointing at this software policy (`:1048-1067`),
+2. reads those config policies' **assignments** (`:1072-1078`),
+3. fans each assignment out by `level` — `device`, `device_group`, `site`, `organization`, `partner` (`:1088-1138`); there is **no `filter` level**,
+4. keeps a device only if this is the *closest-winning* software policy for it (`:1150-1168`).
+
+`softwarePolicies.targetType` / `targetIds` (`apps/api/src/db/schema/softwarePolicies.ts:91-92`) are read by **nothing** on this path — `grep -rn 'targetType' apps/api/src/jobs/softwareComplianceWorker.ts apps/api/src/services/softwarePolicyService.ts` returns zero hits.
+
+The only narrowing an assignment can carry is `roleFilter` and `osFilter` (`apps/api/src/db/schema/configurationPolicies.ts:170-171`), applied by `buildRoleOsFilterConditions` (`featureConfigResolver.ts:134-139`). **There is no manufacturer filter.** And `device_groups.orgId` is `NOT NULL` (`apps/api/src/db/schema/devices.ts:478`), so a partner-wide "HP hardware" device group cannot exist either.
+
+So the spec's Layer-3 sentence *"Targeting is expressible with existing filters: `osType` and `hardware.manufacturer` are both supported by the filter engine"* is true of **deployments** (`deploymentTargetResolver.ts:60-62` runs `evaluateFilter`) and false of **software policies**. Task 9 is written around that.
+
+**[NEW FINDING] `allowUnknown: true` is mandatory on the built-in policy.** `evaluateSoftwareInventory` (`apps/api/src/services/softwarePolicyService.ts:306-350`), allowlist arm:
+
+```ts
+  if (mode === 'allowlist') {
+    for (const installed of inventory) {
+      const allowed = softwareRules.some((rule) => matchesSoftwareRule(installed, rule));
+      if (!allowed && !allowUnknown) {
+        violations.push({ type: 'unauthorized', ... severity: 'medium', detectedAt });
+      }
+    }
+```
+
+and `normalizeSoftwarePolicyRules` (`:265-268`) defaults `allowUnknown: raw.allowUnknown === true` — i.e. **false unless explicitly set**. A one-rule allowlist policy without `allowUnknown: true` marks *every other installed application on every targeted device* as `unauthorized`, at severity `medium`, every 15 minutes. The spec never mentions this. Task 9 sets it and tests it.
+
+`config_policy_feature_links` carries `uniqueFeaturePerPolicy` on `(configPolicyId, featureType)` (`apps/api/src/db/schema/configurationPolicies.ts:127`), so **one `software_policy` link per configuration policy** — the built-in cannot piggyback on an MSP's existing config policy without displacing their own software policy. Task 9 provisions a dedicated configuration policy.
+
+### Auth building blocks (used by Task 6)
+
+- `AuthContext.partnerId: string | null` — `apps/api/src/middleware/auth.ts:95`. Present on org tokens too.
+- `hasSatisfiedMfa(auth)` — `apps/api/src/middleware/auth.ts:915`. Contract citation **confirmed**.
+- `hasPermission(userPerms, resource, action)` — `apps/api/src/services/permissions.ts:210`. Contract citation **confirmed**.
+- `PERMISSIONS.DEVICES_EXECUTE` — `packages/shared/src/constants/permissions.ts:24`. Contract citation **confirmed**.
+- `MFA_GATED_FEATURE_TYPES` — `apps/api/src/routes/configurationPolicies/featureLinks.ts:91` (contract **confirmed**; the spec body's `:86` is wrong and its own corrections section already says so).
+- `featureLinks.ts` POST returns the created link at `:279-307`; PATCH returns `updated` at `:460-480`. Both give Task 6 a post-write link object, which is what D4's "gate on POST-WRITE state" principle wants.
+- `captureException` is imported from `'../services/sentry'` (`apps/api/src/routes/huntress.ts:29`).
+
+### Test infrastructure
+
+- `apps/api/vitest.integration.config.ts:11-12` — `include` carries the standing glob `'src/__tests__/integration/**/*.test.ts'`. New files there need **no** config edit.
+- `apps/api/src/__tests__/integration/builtinDeploymentPackages.integration.test.ts` (full file, 60 lines) — the convention Task 4's integration test extends: `import './setup'`, `createPartner()` from `./db-utils` (`:176`), exercise the real function, verify via a second `withSystemDbAccessContext` read.
+- `apps/api/src/routes/softwareInstallMethods.test.ts` — `chainMock` proxy (`:17-22`), the `vi.mock('../db')` shape (`:24-35`), `ownedCatalogItem(overrides)` (`:84-92`), and the existing built-in POST rejection test (`:241-252`). Task 5's tests mirror `:291-340` (PATCH) and `:342-373` (DELETE).
+- `apps/api/src/services/softwareDeployment.test.ts` — `sel(rows)` (`:138-144`), `resolveEdrInstaller` mocked wholesale (`:39-44`), `resolveEdrMock` (`:130`), the manager-dispatch describe block starting `:1900` with `primeSelects(method, targetDevices)` (`:1933-1939`) which primes selects in the order *install method → catalog item → devices*.
+- `apps/api/src/services/edrInstallerResolver.test.ts` (full file, 35 lines) — mocks `../db` to `{ withSystemDbAccessContext, runOutsideDbContext, db: {} }` and imports only the pure substitution helpers today.
+- `apps/api/package.json:26` and `apps/web/package.json:17` are both `"test": "vitest"` (bare, watch-mode). Use `npx vitest run <path>` from inside the package.
+- `apps/web/vitest.config.ts` — jsdom, `include: ['src/**/*.test.{ts,tsx}']`, setup at `src/__tests__/setup.ts`. New co-located tests need no config edit.
+
+---
+
+## File structure
+
+**Create**
+
+- `apps/api/migrations/2026-10-15-150402-software-catalog-hp-cmsl-provider.sql` — forward-only CHECK widening. DDL only.
+- `apps/api/src/services/hpCmslProvisioning.ts` — the HP-specific glue: the `hpCmsl.enabled` predicate, the partner resolution, and the fire-and-forget provisioning call. Kept out of `builtinDeploymentPackages.ts` so that module stays a provider-agnostic registry.
+- `apps/api/src/services/hpCmslProvisioning.test.ts` — unit tests for the predicate and the trigger decision.
+- `apps/api/src/__tests__/integration/hpCmslBuiltinPackage.integration.test.ts` — real-DB provisioning: catalog row + install-method row, idempotent, self-healing.
+- *(Task 9 only)* `apps/api/src/services/hpCmslPolicyProvisioning.ts` + `apps/api/src/services/hpCmslPolicyProvisioning.test.ts` + `apps/api/src/__tests__/integration/hpCmslPolicyProvisioning.integration.test.ts`.
+
+**Modify**
+
+- `apps/api/src/services/builtinDeploymentPackages.ts` — three-armed union, `BuiltinEdrProvider`/`BuiltinProvider` split, `hp_cmsl` def, `package_manager` provisioning branch, `originalFileName` moved onto the def.
+- `apps/api/src/services/edrInstallerResolver.ts` — narrow to `BuiltinEdrProvider`, exhaustive switch.
+- `apps/api/src/routes/softwareInstallMethods.ts` — one shared built-in-denied constant, applied to POST, PATCH and DELETE.
+- `apps/api/src/routes/configurationPolicies/featureLinks.ts` — provisioning trigger on the warranty feature link's post-write state (POST + PATCH).
+- `apps/web/src/components/software/providerBranding.ts` — `EDR_PROVIDERS` / `INTEGRATION_PROVIDERS` split, `isEdrProvider`, `hp_cmsl` branding.
+- `apps/web/src/components/software/useEdrReadiness.ts` — narrow the signature to `EdrProvider`.
+- `apps/web/src/components/software/SoftwareCatalog.tsx` — widen the row-mapping narrowing, gate the readiness pill on `isEdrProvider`, pass `null` readiness for non-EDR built-ins.
+- `apps/web/src/components/software/BuiltinPackageDetail.tsx` — `readiness: EdrReadiness | null`.
+
+**Test (modify)**
+
+- `apps/api/src/services/builtinDeploymentPackages.test.ts`
+- `apps/api/src/services/edrInstallerResolver.test.ts`
+- `apps/api/src/services/softwareDeployment.test.ts`
+- `apps/api/src/routes/softwareInstallMethods.test.ts`
+- `apps/api/src/__tests__/integration/builtinDeploymentPackages.integration.test.ts`
+- `apps/web/src/components/software/providerBranding.test.ts`
+- `apps/web/src/components/software/SoftwareCatalog.test.tsx`
+
+---
+
+### Task 1: Migration — widen `software_catalog_integration_provider_chk` to admit `hp_cmsl`
+
+**Files:**
+- Create: `apps/api/migrations/2026-10-15-150402-software-catalog-hp-cmsl-provider.sql`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: the DB precondition for every later task — `software_catalog.integration_provider` may hold `'hp_cmsl'`.
+
+- [ ] **Step 1: Confirm the slot still sorts last, and rename upward if not**
+
+```bash
+ls apps/api/migrations/*.sql | sort | tail -1
+```
+
+Expected as of 2026-09-10: `apps/api/migrations/2026-10-15-150300-remote-session-revocation-lease.sql`. If anything now sorts at or after `2026-10-15-150402` (Gate 2 requires #5508 to merge first, and it ships its own migration), pick the next free slot **after the newest committed file** and use that name for the rest of this task. Do not reuse a lower number, and do not touch `2026-08-06-*` (closed block).
+
+- [ ] **Step 2: Write the failing check**
+
+This migration has no unit-testable TypeScript surface; the red is the constraint refusing the value against a real database.
+
+```bash
+docker exec -i breeze-postgres psql -U breeze_app -d breeze -c \
+  "SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conname = 'software_catalog_integration_provider_chk';"
+```
+
+- [ ] **Step 3: Run it, expect FAIL (the constraint does not admit `hp_cmsl`)**
+
+Expected output contains `integration_provider IN ('huntress'::text, 'sentinelone'::text)` and **not** `hp_cmsl`. That is the baseline red.
+
+- [ ] **Step 4: Write the migration**
+
+```sql
+-- apps/api/migrations/2026-10-15-150402-software-catalog-hp-cmsl-provider.sql
+-- Feature #5511 W04 (#5515): admit the built-in HP CMSL package as a third
+-- integration provider on software_catalog.
+--
+-- The shipped constraint (2026-07-02-builtin-catalog-partner-read-rls.sql:13-25)
+-- pins integration_provider to NULL / 'huntress' / 'sentinelone'. HP CMSL is a
+-- THIRD built-in shape: a package-manager (winget) package with no derivable
+-- installer URL and no partner binary upload — see BuiltinPackageDef's
+-- `installSource: 'package_manager'` arm in
+-- services/builtinDeploymentPackages.ts. The CHECK has to admit 'hp_cmsl'
+-- before ensureBuiltinPackage can write its catalog row.
+--
+-- FORWARD-ONLY. The shipped file is content-hash immutable and is never edited;
+-- DROP + re-ADD is the only way to widen a CHECK in Postgres. Note that the
+-- shipped file guards its ADD with `IF NOT EXISTS (SELECT 1 FROM pg_constraint
+-- ...)`, so replaying the full migration set after this file will NOT re-narrow
+-- the constraint.
+--
+-- NO DML: this file only drops and re-adds a constraint, so no
+-- `SELECT set_config('breeze.scope','system', true)` elevation is required.
+-- db/migrationRlsScope.test.ts requires the wrapper only before
+-- UPDATE/DELETE/INSERT/MERGE. ALTER TABLE ... ADD CONSTRAINT validates existing
+-- rows as the table owner and is not row-level-security filtered.
+--
+-- Idempotent: DROP ... IF EXISTS then an unconditional ADD inside one guarded
+-- DO block, so re-applying is a true no-op. No inner BEGIN/COMMIT — autoMigrate
+-- wraps each file in its own transaction.
+
+DO $$
+BEGIN
+  ALTER TABLE software_catalog
+    DROP CONSTRAINT IF EXISTS software_catalog_integration_provider_chk;
+
+  ALTER TABLE software_catalog
+    ADD CONSTRAINT software_catalog_integration_provider_chk
+    CHECK (
+      integration_provider IS NULL
+      OR integration_provider IN ('huntress', 'sentinelone', 'hp_cmsl')
+    );
+
+  RAISE NOTICE 'software_catalog_integration_provider_chk widened to include hp_cmsl';
+END $$;
+```
+
+- [ ] **Step 5: Apply and re-run the check, expect PASS**
+
+```bash
+export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze"
+pnpm db:migrate
+docker exec -i breeze-postgres psql -U breeze_app -d breeze -c \
+  "SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conname = 'software_catalog_integration_provider_chk';"
+```
+
+Expected: the definition now lists all three values. Then prove idempotency — a second `pnpm db:migrate` must report zero newly-applied migrations:
+
+```bash
+pnpm db:migrate
+```
+
+- [ ] **Step 6: Run the migration guards**
+
+```bash
+cd apps/api && npx vitest run src/db/migrationRlsScope.test.ts src/db/autoMigrate.test.ts
+```
+
+Expected: PASS. `migrationRlsScope.test.ts` carries a frozen baseline of 122 pre-existing offenders — this file must **not** be added to it. `autoMigrate.test.ts` asserts filename ordering and that every migration path referenced from a test resolves.
+
+- [ ] **Step 7: Verify drift**
+
+```bash
+pnpm db:check-drift
+```
+
+Expected: PASS. (This only verifies that the hand-written migration set applies cleanly and that `breeze_migrations` has one row per file — it does **not** diff the Drizzle schema against the live DB.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/api/migrations/2026-10-15-150402-software-catalog-hp-cmsl-provider.sql
+git commit -m "feat(software): admit hp_cmsl as a built-in catalog integration provider (#5515)"
+```
+
+---
+
+### Task 2: Three-armed `BuiltinPackageDef` + the `hp_cmsl` definition
+
+**Files:**
+- Modify: `apps/api/src/services/builtinDeploymentPackages.ts:1-58` (types + registry)
+- Test: `apps/api/src/services/builtinDeploymentPackages.test.ts`
+
+**Interfaces:**
+- Consumes: Task 1's widened CHECK (needed only at insert time, in Task 4).
+- Produces:
+  - `export const BUILTIN_EDR_PROVIDERS: readonly ['huntress', 'sentinelone']`
+  - `export type BuiltinEdrProvider = 'huntress' | 'sentinelone'`
+  - `export const BUILTIN_PROVIDERS: readonly ['huntress', 'sentinelone', 'hp_cmsl']`
+  - `export type BuiltinProvider = 'huntress' | 'sentinelone' | 'hp_cmsl'`
+  - `export interface BuiltinInstallMethodDef { platform: 'windows' | 'macos'; kind: 'winget' | 'homebrew_cask' | 'homebrew_formula'; packageId: string }`
+  - `export type BuiltinPackageDef` — discriminated on `installSource: 'derived_url' | 'partner_upload' | 'package_manager'`. **`requiresBinaryUpload` is removed.**
+  - `BUILTIN_PACKAGES.hp_cmsl` with `installMethod = { platform: 'windows', kind: 'winget', packageId: 'HP.HPCMSL' }`
+  - `getBuiltinPackage(provider: BuiltinProvider): BuiltinPackageDef` (unchanged signature, widened parameter)
+
+- [ ] **Step 1: Write the failing tests**
+
+Replace `apps/api/src/services/builtinDeploymentPackages.test.ts` in full:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import {
+  BUILTIN_EDR_PROVIDERS,
+  BUILTIN_PACKAGES,
+  BUILTIN_PROVIDERS,
+  getBuiltinPackage,
+} from './builtinDeploymentPackages';
+
+// Note: the DB-backed ensureBuiltinPackage tests live in
+// src/__tests__/integration/builtinDeploymentPackages.integration.test.ts and
+// src/__tests__/integration/hpCmslBuiltinPackage.integration.test.ts
+// (real partner fixture, runs as breeze_app). This file stays pure-unit.
+
+describe('builtin deployment packages', () => {
+  it('defines a Windows-only Huntress package with derivable URL + keys', () => {
+    const pkg = getBuiltinPackage('huntress');
+    expect(pkg.installSource).toBe('derived_url');
+    expect(pkg.vendor).toBe('Huntress');
+    if (pkg.installSource !== 'derived_url') throw new Error('narrowing failed');
+    expect(pkg.fileType).toBe('exe');
+    expect(pkg.supportedOs).toEqual(['windows']);
+    expect(pkg.downloadUrlTemplate).toContain('{huntress_acct_key}');
+    expect(pkg.silentInstallArgsTemplate).toContain('{huntress_acct_key}');
+    expect(pkg.silentInstallArgsTemplate).toContain('{huntress_org_key}');
+    // Moved off the provisioner's hardcode (spec "Also noted", :112) and onto
+    // the definition, so the next derived-URL package can't inherit it.
+    expect(pkg.originalFileName).toBe('HuntressInstaller.exe');
+  });
+
+  it('defines a SentinelOne package that needs a binary upload and a site token', () => {
+    const pkg = getBuiltinPackage('sentinelone');
+    expect(pkg.installSource).toBe('partner_upload');
+    expect(pkg.vendor).toBe('SentinelOne');
+    if (pkg.installSource !== 'partner_upload') throw new Error('narrowing failed');
+    expect(pkg.fileType).toBe('msi');
+    expect(pkg.supportedOs).toEqual(['windows']);
+    expect(pkg.silentInstallArgsTemplate).toContain('{s1_site_token}');
+  });
+
+  it('defines HP CMSL as a package-manager built-in with no URL and no upload', () => {
+    const pkg = getBuiltinPackage('hp_cmsl');
+    expect(pkg.installSource).toBe('package_manager');
+    expect(pkg.vendor).toBe('HP Inc.');
+    if (pkg.installSource !== 'package_manager') throw new Error('narrowing failed');
+    expect(pkg.installMethod).toEqual({
+      platform: 'windows',
+      kind: 'winget',
+      packageId: 'HP.HPCMSL',
+    });
+    // EULA: Breeze never hosts or mirrors the CMSL installer, so there is no
+    // downloadUrlTemplate and no artifact metadata on this arm at all.
+    expect(pkg).not.toHaveProperty('downloadUrlTemplate');
+    expect(pkg).not.toHaveProperty('fileType');
+    expect(pkg).not.toHaveProperty('silentInstallArgsTemplate');
+  });
+
+  it('exposes all three providers, with the EDR pair as a strict subset', () => {
+    expect(Object.keys(BUILTIN_PACKAGES).sort()).toEqual([
+      'hp_cmsl',
+      'huntress',
+      'sentinelone',
+    ]);
+    expect([...BUILTIN_PROVIDERS].sort()).toEqual(['hp_cmsl', 'huntress', 'sentinelone']);
+    expect([...BUILTIN_EDR_PROVIDERS].sort()).toEqual(['huntress', 'sentinelone']);
+    for (const p of BUILTIN_EDR_PROVIDERS) {
+      expect(BUILTIN_PROVIDERS).toContain(p);
+    }
+    // hp_cmsl is a built-in but NOT an EDR provider — this is the whole point of
+    // the split (edrInstallerResolver is typed against BuiltinEdrProvider).
+    expect(BUILTIN_EDR_PROVIDERS as readonly string[]).not.toContain('hp_cmsl');
+  });
+
+  it('keys every registry entry by its own provider value', () => {
+    for (const provider of BUILTIN_PROVIDERS) {
+      expect(BUILTIN_PACKAGES[provider].provider).toBe(provider);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run it, expect FAIL**
+
+```bash
+cd apps/api && npx vitest run src/services/builtinDeploymentPackages.test.ts
+```
+
+Expected: FAIL — the import of `BUILTIN_EDR_PROVIDERS` / `BUILTIN_PROVIDERS` is undefined, `getBuiltinPackage('hp_cmsl')` is a type error and returns `undefined` at runtime, and `Object.keys(BUILTIN_PACKAGES).sort()` is `['huntress','sentinelone']`.
+
+- [ ] **Step 3: Replace the type block and registry**
+
+Replace `apps/api/src/services/builtinDeploymentPackages.ts:1-58` (everything from the imports down to and including `getBuiltinPackage`) with:
+
+```ts
+import { and, eq } from 'drizzle-orm';
+import { db, withSystemDbAccessContext, runOutsideDbContext } from '../db';
+import { softwareCatalog, softwareInstallMethods, softwareVersions } from '../db/schema';
+
+/**
+ * Built-in providers whose installer is a BINARY and whose per-org secrets are
+ * resolved server-side at dispatch (services/edrInstallerResolver.ts).
+ *
+ * Keep this set narrow. `resolveEdrInstaller` is typed against it, so a built-in
+ * that has no credentials can never be routed into EDR secret resolution by
+ * accident — which is exactly what a single widened `BuiltinProvider` would have
+ * allowed, silently, via that function's `return resolveSentinelOne(params)`
+ * fall-through.
+ */
+export const BUILTIN_EDR_PROVIDERS = ['huntress', 'sentinelone'] as const;
+export type BuiltinEdrProvider = (typeof BUILTIN_EDR_PROVIDERS)[number];
+
+/**
+ * Every built-in provider. `hp_cmsl` (feature #5511) is a package-manager
+ * built-in: HP's Client Management Script Library, installed by the winget
+ * package id `HP.HPCMSL`. It carries no installer URL, no uploaded binary and
+ * no credentials, so it is deliberately NOT a BuiltinEdrProvider.
+ *
+ * EULA CONSTRAINT — do not "optimise" this away. HP's CMSL licence states
+ * verbatim: "You do not have the right to distribute the Software Product."
+ * Breeze must NEVER mirror or host the CMSL installer. That rules out serving
+ * it through the pinned-artifact pattern in routes/agents/wingetBootstrap.ts.
+ * Installing via winget (or an HP-hosted URL) satisfies the licence because the
+ * bytes come from HP. A future change that copies the installer into S3, into
+ * the winget-bootstrap artifact set, or into any Breeze-served path is a licence
+ * violation, not a performance win.
+ */
+export const BUILTIN_PROVIDERS = [...BUILTIN_EDR_PROVIDERS, 'hp_cmsl'] as const;
+export type BuiltinProvider = (typeof BUILTIN_PROVIDERS)[number];
+
+/** Identity fields every built-in carries, whatever its install shape. */
+interface BuiltinPackageIdentity {
+  provider: BuiltinProvider;
+  name: string;
+  vendor: string;
+  category: string;
+  iconUrl?: string;
+  websiteUrl?: string;
+}
+
+/** Fields that only mean anything when there IS an installer artifact. */
+interface BuiltinArtifactFields {
+  fileType: string;
+  supportedOs: string[];
+  silentInstallArgsTemplate: string;
+}
+
+/** One package-manager install method, mirroring a software_install_methods row. */
+export interface BuiltinInstallMethodDef {
+  platform: 'windows' | 'macos';
+  kind: 'winget' | 'homebrew_cask' | 'homebrew_formula';
+  packageId: string;
+}
+
+/**
+ * Discriminated on `installSource` so all THREE valid shapes can't drift:
+ *  - 'derived_url'     → installer URL is derivable from per-org secrets; a
+ *                        templated software_versions row is created (Huntress)
+ *  - 'partner_upload'  → no derivable URL; the partner uploads the binary and
+ *                        the version row appears then (SentinelOne)
+ *  - 'package_manager' → no URL and no upload at all; a software_install_methods
+ *                        row carries the package id (HP CMSL / winget)
+ *
+ * The previous discriminant was the boolean `requiresBinaryUpload`, which cannot
+ * express a third arm. It is gone; `installSource` replaces it. The artifact
+ * fields (fileType / supportedOs / silentInstallArgsTemplate) live only on the
+ * two artifact arms — a winget package has no file, no silent-install args and
+ * no per-OS artifact list.
+ */
+export type BuiltinPackageDef =
+  | (BuiltinPackageIdentity & BuiltinArtifactFields & {
+      installSource: 'derived_url';
+      downloadUrlTemplate: string;
+      /**
+       * Filename stamped on the templated version row. Provider-specific: it
+       * used to be hardcoded to 'HuntressInstaller.exe' inside an otherwise
+       * provider-generic branch of ensureBuiltinPackage (the trap the spec's
+       * "Also noted, not blocking" section names). It lives on the definition
+       * now so the next derived-URL package cannot inherit Huntress's filename.
+       */
+      originalFileName: string;
+    })
+  | (BuiltinPackageIdentity & BuiltinArtifactFields & {
+      installSource: 'partner_upload';
+      downloadUrlTemplate?: never;
+    })
+  | (BuiltinPackageIdentity & {
+      installSource: 'package_manager';
+      installMethod: BuiltinInstallMethodDef;
+      downloadUrlTemplate?: never;
+    });
+
+export const BUILTIN_PACKAGES: Record<BuiltinProvider, BuiltinPackageDef> = {
+  huntress: {
+    provider: 'huntress',
+    name: 'Huntress EDR Agent',
+    vendor: 'Huntress',
+    category: 'security',
+    websiteUrl: 'https://www.huntress.com',
+    installSource: 'derived_url',
+    fileType: 'exe',
+    supportedOs: ['windows'],
+    downloadUrlTemplate:
+      'https://update.huntress.io/download/{huntress_acct_key}/HuntressInstaller.exe',
+    silentInstallArgsTemplate:
+      '/ACCT_KEY="{huntress_acct_key}" /ORG_KEY="{huntress_org_key}" /S',
+    originalFileName: 'HuntressInstaller.exe',
+  },
+  sentinelone: {
+    provider: 'sentinelone',
+    name: 'SentinelOne Agent',
+    vendor: 'SentinelOne',
+    category: 'security',
+    websiteUrl: 'https://www.sentinelone.com',
+    installSource: 'partner_upload',
+    fileType: 'msi',
+    supportedOs: ['windows'],
+    silentInstallArgsTemplate: 'SITE_TOKEN={s1_site_token} /q /NORESTART',
+  },
+  hp_cmsl: {
+    provider: 'hp_cmsl',
+    name: 'HP Client Management Script Library',
+    vendor: 'HP Inc.',
+    // 'utility' is a member of the catalog's category enum
+    // (routes/software.ts:461-464), so the category filter keeps working.
+    category: 'utility',
+    websiteUrl:
+      'https://developers.hp.com/hp-client-management/doc/client-management-script-library',
+    installSource: 'package_manager',
+    installMethod: { platform: 'windows', kind: 'winget', packageId: 'HP.HPCMSL' },
+  },
+};
+
+export function getBuiltinPackage(provider: BuiltinProvider): BuiltinPackageDef {
+  return BUILTIN_PACKAGES[provider];
+}
+```
+
+- [ ] **Step 4: Fix the one existing consumer of `requiresBinaryUpload`**
+
+In the same file, `ensureBuiltinPackage`'s version branch currently reads `if (!def.requiresBinaryUpload && def.downloadUrlTemplate) {`. Change that line and the hardcoded filename:
+
+```ts
+      // Templated version only when the binary URL is derivable (Huntress).
+      if (def.installSource === 'derived_url') {
+```
+
+```ts
+            originalFileName: def.originalFileName,
+```
+
+(The `package_manager` branch is added in Task 4; this step only keeps the file compiling.)
+
+- [ ] **Step 5: Run the tests, expect PASS**
+
+```bash
+cd apps/api && npx vitest run src/services/builtinDeploymentPackages.test.ts
+```
+
+Expected: PASS, 5 tests.
+
+- [ ] **Step 6: Typecheck — expect ONE remaining error, in `edrInstallerResolver.ts`**
+
+```bash
+pnpm --filter @breeze/api exec tsc --noEmit
+```
+
+Expected: clean **except** nothing yet — `resolveEdrInstaller`'s `provider: BuiltinProvider` still compiles, it has just silently widened. That is precisely the trap Task 3 closes; do not stop here.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/services/builtinDeploymentPackages.ts apps/api/src/services/builtinDeploymentPackages.test.ts
+git commit -m "feat(software): three-armed BuiltinPackageDef with an hp_cmsl package-manager arm (#5515)"
+```
+
+---
+
+### Task 3: Narrow `resolveEdrInstaller` to `BuiltinEdrProvider`, and pin the dispatch path
+
+**Files:**
+- Modify: `apps/api/src/services/edrInstallerResolver.ts:5,54-62`
+- Test: `apps/api/src/services/edrInstallerResolver.test.ts`
+- Test: `apps/api/src/services/softwareDeployment.test.ts`
+
+**Interfaces:**
+- Consumes: `BuiltinEdrProvider` from Task 2.
+- Produces: `resolveEdrInstaller(params: { provider: BuiltinEdrProvider; orgId: string; downloadUrlTemplate: string | null; silentInstallArgsTemplate: string | null })` — same return type; a non-EDR provider is now a **compile error**, and (if forced through with a cast) a **throw**, never a silent SentinelOne resolution.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `apps/api/src/services/edrInstallerResolver.test.ts`:
+
+```ts
+import { resolveEdrInstaller } from './edrInstallerResolver';
+import type { BuiltinEdrProvider } from './builtinDeploymentPackages';
+
+describe('resolveEdrInstaller provider exhaustiveness', () => {
+  it('throws rather than silently resolving a non-EDR built-in as SentinelOne', async () => {
+    // hp_cmsl is a BuiltinProvider but NOT a BuiltinEdrProvider, so this cast is
+    // the only way to get it here. Before the exhaustive switch, the function's
+    // `return resolveSentinelOne(params)` fall-through accepted it — an HP
+    // package would have been handed SentinelOne's site-token resolver.
+    await expect(
+      resolveEdrInstaller({
+        provider: 'hp_cmsl' as unknown as BuiltinEdrProvider,
+        orgId: '00000000-0000-4000-8000-000000000001',
+        downloadUrlTemplate: null,
+        silentInstallArgsTemplate: null,
+      }),
+    ).rejects.toThrow(/unhandled EDR provider: hp_cmsl/);
+  });
+});
+```
+
+And append to the manager-dispatch describe block in `apps/api/src/services/softwareDeployment.test.ts` (the block that starts at `:1900` and defines `primeSelects`), a regression that fixes today's structural behaviour in place:
+
+```ts
+  it('never resolves EDR secrets for an hp_cmsl built-in on the manager path', async () => {
+    resolveEdrMock.mockClear();
+    // Same shape as wingetMethod, but the catalog item is the HP CMSL built-in.
+    // primeSelects primes: install method -> catalog item -> devices.
+    selectMock
+      .mockReturnValueOnce(sel([{ ...wingetMethod, packageId: 'HP.HPCMSL' }]))
+      .mockReturnValueOnce(sel([{ name: 'HP Client Management Script Library', integrationProvider: 'hp_cmsl' }]))
+      .mockReturnValueOnce(sel([{ id: 'dev-1', agentId: 'agent-1', osType: 'windows' }]));
+    insertMock.mockReturnValueOnce(insCapture([deployment])).mockReturnValueOnce(ins());
+
+    const result = await createSoftwareDeployment({
+      orgId: 'org-1',
+      installMethodId: 'method-win',
+      deploymentType: 'install',
+      deviceIds: ['dev-1'],
+      scheduleType: 'immediate',
+      createdBy: null,
+      name: 'HP CMSL',
+    });
+
+    expect(result.status).toBe('pending');
+    // buildAndDispatchSoftwareInstalls returns at the `if (installMethod)`
+    // branch (softwareDeployment.ts:524-526), BEFORE the EDR branch at :558.
+    // If a future refactor moves the EDR check above that return, this fails.
+    expect(resolveEdrMock).not.toHaveBeenCalled();
+    const payload = dispatchDeviceCommandMock.mock.calls[0]![0].payload;
+    expect(payload.installMethod).toEqual({ kind: 'winget', packageId: 'HP.HPCMSL' });
+    expect(payload).not.toHaveProperty('downloadUrl');
+  });
+```
+
+- [ ] **Step 2: Run them, expect the first to FAIL and the second to PASS**
+
+```bash
+cd apps/api && npx vitest run src/services/edrInstallerResolver.test.ts src/services/softwareDeployment.test.ts
+```
+
+Expected:
+- `edrInstallerResolver.test.ts` → **FAIL**: the promise resolves (or rejects with a DB error from the empty `db: {}` mock) instead of throwing `unhandled EDR provider: hp_cmsl`. Record the actual failure text — it is what proves the fall-through exists.
+- `softwareDeployment.test.ts` → **PASS**. That is expected and correct: this assertion documents a structural property that already holds; it is a regression fence, not a red-first driver. Do not manufacture a fake red for it.
+
+- [ ] **Step 3: Implement the exhaustive switch**
+
+In `apps/api/src/services/edrInstallerResolver.ts`, change the import at `:5`:
+
+```ts
+import type { BuiltinEdrProvider } from './builtinDeploymentPackages';
+```
+
+and replace `:54-62`:
+
+```ts
+/**
+ * Resolve the per-org installer URL + silent args for a credential-backed
+ * built-in EDR package.
+ *
+ * The parameter is `BuiltinEdrProvider`, NOT `BuiltinProvider`: HP CMSL and any
+ * future non-credential built-in must never reach here. This used to end in a
+ * bare `return resolveSentinelOne(params)`, so widening the provider union
+ * would have routed a new provider into SentinelOne's site-token resolver with
+ * no compile error and no runtime complaint.
+ */
+export async function resolveEdrInstaller(params: {
+  provider: BuiltinEdrProvider;
+  orgId: string;
+  downloadUrlTemplate: string | null;
+  silentInstallArgsTemplate: string | null;
+}): Promise<ResolvedInstaller | EdrResolveError> {
+  switch (params.provider) {
+    case 'huntress':
+      return resolveHuntress(params);
+    case 'sentinelone':
+      return resolveSentinelOne(params);
+    default: {
+      // Exhaustiveness fence: adding a BuiltinEdrProvider without a branch here
+      // is a COMPILE error, not a silent fall-through.
+      const unreachable: never = params.provider;
+      throw new Error(`resolveEdrInstaller: unhandled EDR provider: ${String(unreachable)}`);
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run both files, expect PASS**
+
+```bash
+cd apps/api && npx vitest run src/services/edrInstallerResolver.test.ts src/services/softwareDeployment.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck**
+
+```bash
+pnpm --filter @breeze/api exec tsc --noEmit
+```
+
+Expected: clean. `softwareDeployment.ts:558-563` passes a narrowed `'huntress' | 'sentinelone'` literal (the `if` at `:558-561` proves it), so the call site still type-checks against the narrower parameter.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/services/edrInstallerResolver.ts apps/api/src/services/edrInstallerResolver.test.ts apps/api/src/services/softwareDeployment.test.ts
+git commit -m "fix(software): type EDR resolution against BuiltinEdrProvider with an exhaustive switch (#5515)"
+```
+
+---
+
+### Task 4: `ensureBuiltinPackage` — the `package_manager` provisioning branch
+
+**Files:**
+- Modify: `apps/api/src/services/builtinDeploymentPackages.ts` (`ensureBuiltinPackage` body)
+- Create: `apps/api/src/__tests__/integration/hpCmslBuiltinPackage.integration.test.ts`
+- Test (modify): `apps/api/src/__tests__/integration/builtinDeploymentPackages.integration.test.ts`
+
+**Interfaces:**
+- Consumes: `BUILTIN_PACKAGES.hp_cmsl` (Task 2), the widened CHECK (Task 1).
+- Produces: `ensureBuiltinPackage({ provider: 'hp_cmsl', partnerId })` → `{ catalogId: string }`, having ensured exactly one `software_catalog` row (`org_id NULL`, `partner_id` set, `integration_provider = 'hp_cmsl'`, `is_managed = true`) **and** exactly one `software_install_methods` row (`platform 'windows'`, `kind 'winget'`, `package_id 'HP.HPCMSL'`, `enabled true`), repaired to the built-in definition on every call.
+
+**DECISION — the install-method API boundary (the spec asks for this explicitly): the system provisioner inserts directly, and the route's built-in rejection becomes absolute across POST, PATCH and DELETE (Task 5).** Reasons, in order of weight:
+
+1. **A built-in's definition is server-owned, and an editable install method makes it caller-owned.** The `software_catalog` row is already written under system DB context and is already un-editable and un-deletable through the API for non-system scope (`software.ts:939`, `:978`). An install method is not metadata about the built-in — it *is* the built-in's payload. Letting `POST`/`PATCH` write it would let a partner admin with `devices.write` + MFA retarget "HP CMSL" at any winget package id, and that package would then be installed on every device the HP policy reaches. That is a privilege problem, not a hypothetical.
+2. **The relaxation would have to be scope-gated, and there is no scope that wants it.** A `system`-scope exception would be dead code (nothing calls it); a `partner`-scope exception is exactly the hole in (1).
+3. **The provisioner is already the idempotent repair path.** Making it upsert (below) means an out-of-band edit is corrected on the next enable, which a route-based exception could not offer.
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `apps/api/src/__tests__/integration/hpCmslBuiltinPackage.integration.test.ts`:
+
+```ts
+/**
+ * Integration test for the HP CMSL built-in package (feature #5511 W04, #5515).
+ *
+ * hp_cmsl is the first `installSource: 'package_manager'` built-in: it creates a
+ * PARTNER-scoped software_catalog row (org_id NULL, partner_id set,
+ * integration_provider 'hp_cmsl') and one software_install_methods row carrying
+ * the winget package id — and NO software_versions row, because Breeze never
+ * hosts or mirrors the CMSL installer (HP's licence: "You do not have the right
+ * to distribute the Software Product").
+ *
+ * Runs as breeze_app so RLS, the widened
+ * software_catalog_integration_provider_chk, and the parent-FK-join policies on
+ * software_install_methods are all genuinely exercised.
+ */
+import './setup';
+import { describe, it, expect } from 'vitest';
+import { and, eq } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../../db';
+import { softwareCatalog, softwareInstallMethods, softwareVersions } from '../../db/schema';
+import { ensureBuiltinPackage } from '../../services/builtinDeploymentPackages';
+import { createPartner } from './db-utils';
+
+describe('ensureBuiltinPackage — hp_cmsl (db)', () => {
+  it('creates one catalog row and one winget install method, and no version row', async () => {
+    const partner = await createPartner();
+
+    const { catalogId } = await ensureBuiltinPackage({ provider: 'hp_cmsl', partnerId: partner.id });
+
+    const { catalogRows, methods, versions } = await withSystemDbAccessContext(async () => {
+      const catalogRows = await db
+        .select()
+        .from(softwareCatalog)
+        .where(and(
+          eq(softwareCatalog.partnerId, partner.id),
+          eq(softwareCatalog.integrationProvider, 'hp_cmsl'),
+        ));
+      const methods = await db
+        .select()
+        .from(softwareInstallMethods)
+        .where(eq(softwareInstallMethods.catalogId, catalogId));
+      const versions = await db
+        .select()
+        .from(softwareVersions)
+        .where(eq(softwareVersions.catalogId, catalogId));
+      return { catalogRows, methods, versions };
+    });
+
+    expect(catalogRows).toHaveLength(1);
+    expect(catalogRows[0]!.orgId).toBeNull();
+    expect(catalogRows[0]!.isManaged).toBe(true);
+    expect(catalogRows[0]!.vendor).toBe('HP Inc.');
+
+    expect(methods).toHaveLength(1);
+    expect(methods[0]!.platform).toBe('windows');
+    expect(methods[0]!.kind).toBe('winget');
+    expect(methods[0]!.packageId).toBe('HP.HPCMSL');
+    expect(methods[0]!.enabled).toBe(true);
+
+    // Breeze never hosts the installer — no artifact row of any kind.
+    expect(versions).toHaveLength(0);
+  });
+
+  it('is idempotent: a second call reuses the catalog row and adds no second method', async () => {
+    const partner = await createPartner();
+
+    const first = await ensureBuiltinPackage({ provider: 'hp_cmsl', partnerId: partner.id });
+    const second = await ensureBuiltinPackage({ provider: 'hp_cmsl', partnerId: partner.id });
+    expect(second.catalogId).toBe(first.catalogId);
+
+    const methods = await withSystemDbAccessContext(() =>
+      db.select().from(softwareInstallMethods).where(eq(softwareInstallMethods.catalogId, first.catalogId)),
+    );
+    expect(methods).toHaveLength(1);
+  });
+
+  it('repairs an out-of-band edit to the install method on the next call', async () => {
+    const partner = await createPartner();
+    const { catalogId } = await ensureBuiltinPackage({ provider: 'hp_cmsl', partnerId: partner.id });
+
+    // Simulate a partner admin retargeting the built-in through the API before
+    // Task 5's guard existed (RLS allows a partner-scoped UPDATE on this table).
+    await withSystemDbAccessContext(() =>
+      db
+        .update(softwareInstallMethods)
+        .set({ packageId: 'Evil.Package', enabled: false })
+        .where(eq(softwareInstallMethods.catalogId, catalogId)),
+    );
+
+    await ensureBuiltinPackage({ provider: 'hp_cmsl', partnerId: partner.id });
+
+    const methods = await withSystemDbAccessContext(() =>
+      db.select().from(softwareInstallMethods).where(eq(softwareInstallMethods.catalogId, catalogId)),
+    );
+    expect(methods).toHaveLength(1);
+    expect(methods[0]!.packageId).toBe('HP.HPCMSL');
+    expect(methods[0]!.enabled).toBe(true);
+  });
+});
+```
+
+Also extend `apps/api/src/__tests__/integration/builtinDeploymentPackages.integration.test.ts` so the two artifact arms are pinned as *not* creating install methods. Add inside its `describe`:
+
+```ts
+  it('creates no install method for the artifact-shaped built-ins', async () => {
+    const partner = await createPartner();
+
+    const huntress = await ensureBuiltinPackage({ provider: 'huntress', partnerId: partner.id });
+    const s1 = await ensureBuiltinPackage({ provider: 'sentinelone', partnerId: partner.id });
+
+    const methods = await withSystemDbAccessContext(() =>
+      db
+        .select()
+        .from(softwareInstallMethods)
+        .where(inArray(softwareInstallMethods.catalogId, [huntress.catalogId, s1.catalogId])),
+    );
+    expect(methods).toHaveLength(0);
+  });
+```
+
+and widen that file's imports to `import { and, eq, inArray } from 'drizzle-orm';` and `import { softwareCatalog, softwareInstallMethods, softwareVersions } from '../../db/schema';`.
+
+- [ ] **Step 2: Run them, expect FAIL**
+
+```bash
+cd apps/api && npx vitest run --config vitest.integration.config.ts \
+  src/__tests__/integration/hpCmslBuiltinPackage.integration.test.ts \
+  src/__tests__/integration/builtinDeploymentPackages.integration.test.ts
+```
+
+Requires a live test database — bring up `docker-compose.test.yml` first if it is not running (the suite defaults `DATABASE_URL` to `postgresql://breeze_test:breeze_test@localhost:5433/breeze_test`). Expected: the three `hp_cmsl` tests FAIL (no install-method row is created); the artifact-arm test PASSES.
+
+- [ ] **Step 3: Add the `package_manager` branch**
+
+In `apps/api/src/services/builtinDeploymentPackages.ts`, immediately after the `installSource === 'derived_url'` block and before `return { catalogId };`:
+
+```ts
+      if (def.installSource === 'package_manager') {
+        // Re-asserted on EVERY call, not only at creation. The install method is
+        // the entire definition of a package-manager built-in — it is what the
+        // agent is told to install — so it is server-owned state, not a
+        // user-editable row. routes/softwareInstallMethods.ts refuses to create,
+        // edit or delete methods on built-in catalog items; this upsert is the
+        // repair path for anything that got through before that guard existed,
+        // or through a direct DB edit.
+        //
+        // onConflictDoUpdate keys on the shipped unique index
+        // software_install_methods_catalog_platform_kind_uq
+        // (2026-08-16-a-software-install-methods.sql:48-49).
+        await db
+          .insert(softwareInstallMethods)
+          .values({
+            catalogId,
+            platform: def.installMethod.platform,
+            kind: def.installMethod.kind,
+            packageId: def.installMethod.packageId,
+            enabled: true,
+          })
+          .onConflictDoUpdate({
+            target: [
+              softwareInstallMethods.catalogId,
+              softwareInstallMethods.platform,
+              softwareInstallMethods.kind,
+            ],
+            set: { packageId: def.installMethod.packageId, enabled: true },
+          });
+      }
+```
+
+Also update the function's doc comment (`:60-65`) to describe all three shapes:
+
+```ts
+/**
+ * Idempotently upsert the partner-scoped built-in package and whatever its
+ * install shape needs:
+ *   - 'derived_url'     → a templated software_versions row (Huntress)
+ *   - 'partner_upload'  → nothing else; the partner uploads the binary later
+ *   - 'package_manager' → one software_install_methods row, re-asserted on
+ *                         every call (HP CMSL / winget)
+ *
+ * Safe to call on every integration connect, and on every HP CMSL opt-in. Runs
+ * in a system DB context because the caller's request scope is partner- or
+ * org-level and we are writing partner-axis rows; breeze_has_partner_access
+ * short-circuits to TRUE under system scope
+ * (2026-04-11-partners-rls.sql:63-67), which is what lets the
+ * software_install_methods INSERT policy pass.
+ */
+```
+
+- [ ] **Step 4: Run the integration tests, expect PASS**
+
+```bash
+cd apps/api && npx vitest run --config vitest.integration.config.ts \
+  src/__tests__/integration/hpCmslBuiltinPackage.integration.test.ts \
+  src/__tests__/integration/builtinDeploymentPackages.integration.test.ts
+```
+
+Expected: PASS, all five tests.
+
+- [ ] **Step 5: Re-run the unit suite and typecheck**
+
+```bash
+cd apps/api && npx vitest run src/services/builtinDeploymentPackages.test.ts
+pnpm --filter @breeze/api exec tsc --noEmit
+```
+
+Expected: PASS / clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/services/builtinDeploymentPackages.ts \
+        apps/api/src/__tests__/integration/hpCmslBuiltinPackage.integration.test.ts \
+        apps/api/src/__tests__/integration/builtinDeploymentPackages.integration.test.ts
+git commit -m "feat(software): provision the HP CMSL winget install method from ensureBuiltinPackage (#5515)"
+```
+
+---
+
+### Task 5: Make the built-in install-method rejection absolute (POST + PATCH + DELETE)
+
+**Files:**
+- Modify: `apps/api/src/routes/softwareInstallMethods.ts:112-114` (POST), `:150-158` (PATCH), `:277-285` (DELETE)
+- Test: `apps/api/src/routes/softwareInstallMethods.test.ts`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks (this is an independent hardening of the boundary Task 4's decision relies on).
+- Produces: `BUILTIN_INSTALL_METHOD_DENIED` (module-private const) applied at all three write verbs; any request naming a catalog row with a non-null `integration_provider` gets `400 { error: 'Built-in packages cannot carry install methods' }` before any DB write.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `apps/api/src/routes/softwareInstallMethods.test.ts`, inside the `PATCH` describe (after `:325`):
+
+```ts
+    it('rejects updating a method on a built-in item (integrationProvider set)', async () => {
+      // Regression for #5515: only POST carried this guard. A partner-scoped
+      // caller passes both loadOwnedCatalogItem (built-ins have org_id NULL) and
+      // the RLS UPDATE policy (breeze_has_partner_access on the parent's
+      // partner_id), so this route could retarget a server-provisioned built-in
+      // — e.g. the HP CMSL winget package id — at anything.
+      vi.mocked(db.select)
+        .mockReturnValueOnce(chainMock([ownedCatalogItem({ orgId: null, integrationProvider: 'hp_cmsl' })]) as any)
+        .mockReturnValueOnce(chainMock([installedMethod({ packageId: 'HP.HPCMSL' })]) as any);
+
+      const res = await app.request(`/software/catalog/${CATALOG_ID}/install-methods/${METHOD_ID}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ packageId: 'Evil.Package' }),
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toMatch(/Built-in packages cannot carry install methods/);
+      expect(db.update).not.toHaveBeenCalled();
+      expect(writeRouteAudit).not.toHaveBeenCalled();
+    });
+```
+
+and inside the `DELETE` describe (after `:360`):
+
+```ts
+    it('rejects deleting a method on a built-in item (integrationProvider set)', async () => {
+      // Same regression as the PATCH case: deleting the HP CMSL winget method
+      // would leave the built-in undeployable until the next provisioning call.
+      vi.mocked(db.select)
+        .mockReturnValueOnce(chainMock([ownedCatalogItem({ orgId: null, integrationProvider: 'hp_cmsl' })]) as any)
+        .mockReturnValueOnce(chainMock([installedMethod({ packageId: 'HP.HPCMSL' })]) as any);
+
+      const res = await app.request(`/software/catalog/${CATALOG_ID}/install-methods/${METHOD_ID}`, {
+        method: 'DELETE',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toMatch(/Built-in packages cannot carry install methods/);
+      expect(db.delete).not.toHaveBeenCalled();
+      expect(writeRouteAudit).not.toHaveBeenCalled();
+    });
+```
+
+- [ ] **Step 2: Run them, expect FAIL**
+
+```bash
+cd apps/api && npx vitest run src/routes/softwareInstallMethods.test.ts
+```
+
+Expected: both new tests FAIL with `expected 200 to be 400` (the PATCH succeeds and calls `db.update`; the DELETE succeeds and calls `db.delete`).
+
+- [ ] **Step 3: Implement**
+
+In `apps/api/src/routes/softwareInstallMethods.ts`, add above `loadOwnedCatalogItem` (`:69`):
+
+```ts
+/**
+ * Built-in (integration-provider) catalog rows are SERVER-provisioned: their
+ * install methods are written by ensureBuiltinPackage under system DB context
+ * and re-asserted on every provisioning call
+ * (services/builtinDeploymentPackages.ts). Creating, editing or deleting them
+ * through this router would let a partner admin with devices.write + MFA
+ * retarget a built-in at an arbitrary winget package id — installing anything
+ * they like on every device that built-in's policy reaches.
+ *
+ * RLS does NOT close this on its own: the UPDATE/DELETE policies on
+ * software_install_methods (2026-08-16-a-software-install-methods.sql:89-119)
+ * admit `sc.partner_id IS NOT NULL AND breeze_has_partner_access(sc.partner_id)`,
+ * which is TRUE for a partner-scoped caller against a partner-owned built-in.
+ * (Org-scoped callers are already blocked there: breeze_has_org_access(NULL) and
+ * breeze_has_partner_access(P) are both FALSE for an org token.)
+ *
+ * The string is unchanged from the original POST-only guard so existing clients
+ * and tests keep matching on it.
+ */
+const BUILTIN_INSTALL_METHOD_DENIED = 'Built-in packages cannot carry install methods';
+```
+
+Replace the POST guard at `:112-114` with the shared constant:
+
+```ts
+    if (item.integrationProvider !== null) {
+      return c.json({ error: BUILTIN_INSTALL_METHOD_DENIED }, 400);
+    }
+```
+
+Add the same three lines to PATCH, immediately after its `if (!item) return c.json({ error: 'Catalog item not found or access denied' }, 404);` (currently `:155`) and **before** `loadInstallMethod`:
+
+```ts
+    if (item.integrationProvider !== null) {
+      return c.json({ error: BUILTIN_INSTALL_METHOD_DENIED }, 400);
+    }
+```
+
+And to DELETE, immediately after its `if (!item) ...` (currently `:282`) and before `loadInstallMethod`:
+
+```ts
+    if (item.integrationProvider !== null) {
+      return c.json({ error: BUILTIN_INSTALL_METHOD_DENIED }, 400);
+    }
+```
+
+> The new tests prime **two** `db.select` calls each, so placing the guard before `loadInstallMethod` leaves the second mock unconsumed — harmless, and it keeps the fixtures readable if the guard ever moves.
+
+- [ ] **Step 4: Run, expect PASS**
+
+```bash
+cd apps/api && npx vitest run src/routes/softwareInstallMethods.test.ts
+```
+
+Expected: PASS, including the pre-existing POST rejection test at `:241-252`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/softwareInstallMethods.ts apps/api/src/routes/softwareInstallMethods.test.ts
+git commit -m "fix(software): refuse install-method PATCH/DELETE on built-in catalog items (#5515)"
+```
+
+---
+
+### Task 6: Provision the HP CMSL package when a warranty policy turns `hpCmsl` on
+
+**Files:**
+- Create: `apps/api/src/services/hpCmslProvisioning.ts`
+- Create: `apps/api/src/services/hpCmslProvisioning.test.ts`
+- Modify: `apps/api/src/routes/configurationPolicies/featureLinks.ts` (POST tail `:294-307`, PATCH tail `:469-480`)
+
+**Interfaces:**
+- Consumes: `ensureBuiltinPackage` (Task 4); W02's `hpCmsl` inline-settings block on the `warranty` feature link (contract D1: `{ enabled: boolean; consent?: {...} }`).
+- Produces:
+  - `export function warrantyLinkEnablesHpCmsl(inlineSettings: unknown): boolean`
+  - `export async function provisionHpCmslForFeatureLink(input: { featureType: string; inlineSettings: unknown; policyPartnerId: string | null; authPartnerId: string | null; policyOrgId: string | null }): Promise<void>` — fire-and-forget, never throws.
+
+**Why here.** `ensureBuiltinPackage` has exactly two call sites today, both "the partner just connected the thing this package belongs to" (`huntress.ts:456`, `sentinelOne.ts:435`). HP has no integration to connect; the equivalent moment is the partner (or org) turning `hpCmsl.enabled` on for a warranty feature link, which is also the moment W02 records the EULA consent. Provisioning earlier would put a 100 MB HP module in every partner's catalog unasked; provisioning later would mean the policy in Task 9 references a catalog item that does not exist.
+
+**Why duck-typed.** W02 (#5513) owns `WarrantyHpCmslSettings` and lands before this wave, but its export name is not pinned by the contract (D1 gives the shape, not the module). `warrantyLinkEnablesHpCmsl` reads the shape D1 specifies without importing W02's type, so a rename in W02 cannot silently disable provisioning. If W02 exported the type under a stable name, importing it is a fine follow-up — the predicate's behaviour must not change either way.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/api/src/services/hpCmslProvisioning.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { ensureBuiltinPackageMock } = vi.hoisted(() => ({ ensureBuiltinPackageMock: vi.fn() }));
+vi.mock('./builtinDeploymentPackages', () => ({ ensureBuiltinPackage: ensureBuiltinPackageMock }));
+vi.mock('./sentry', () => ({ captureException: vi.fn() }));
+
+import { provisionHpCmslForFeatureLink, warrantyLinkEnablesHpCmsl } from './hpCmslProvisioning';
+
+const PARTNER = '11111111-1111-4111-8111-111111111111';
+const ORG = '22222222-2222-4222-8222-222222222222';
+
+describe('warrantyLinkEnablesHpCmsl', () => {
+  it('is true only for an explicit hpCmsl.enabled === true', () => {
+    expect(warrantyLinkEnablesHpCmsl({ hpCmsl: { enabled: true } })).toBe(true);
+  });
+
+  it('is false for every other shape', () => {
+    expect(warrantyLinkEnablesHpCmsl(null)).toBe(false);
+    expect(warrantyLinkEnablesHpCmsl(undefined)).toBe(false);
+    expect(warrantyLinkEnablesHpCmsl({})).toBe(false);
+    expect(warrantyLinkEnablesHpCmsl({ hpCmsl: null })).toBe(false);
+    expect(warrantyLinkEnablesHpCmsl({ hpCmsl: {} })).toBe(false);
+    expect(warrantyLinkEnablesHpCmsl({ hpCmsl: { enabled: false } })).toBe(false);
+    // Truthy-but-not-true must not arm it: the existing `enabled` on this block
+    // means expiry ALERTING, and a coercing check would conflate the two.
+    expect(warrantyLinkEnablesHpCmsl({ hpCmsl: { enabled: 'yes' } })).toBe(false);
+    expect(warrantyLinkEnablesHpCmsl({ hpCmsl: { enabled: 1 } })).toBe(false);
+    // The alerting flag on the OUTER block is not the collection flag.
+    expect(warrantyLinkEnablesHpCmsl({ enabled: true })).toBe(false);
+  });
+});
+
+describe('provisionHpCmslForFeatureLink', () => {
+  beforeEach(() => {
+    ensureBuiltinPackageMock.mockReset();
+    ensureBuiltinPackageMock.mockResolvedValue({ catalogId: 'cat-1' });
+  });
+
+  it('provisions for a partner-wide warranty link using the policy partner', async () => {
+    await provisionHpCmslForFeatureLink({
+      featureType: 'warranty',
+      inlineSettings: { hpCmsl: { enabled: true } },
+      policyPartnerId: PARTNER,
+      authPartnerId: null,
+      policyOrgId: null,
+    });
+    expect(ensureBuiltinPackageMock).toHaveBeenCalledWith({ provider: 'hp_cmsl', partnerId: PARTNER });
+  });
+
+  it('falls back to the authenticated partner for an org-scoped policy', async () => {
+    await provisionHpCmslForFeatureLink({
+      featureType: 'warranty',
+      inlineSettings: { hpCmsl: { enabled: true } },
+      policyPartnerId: null,
+      authPartnerId: PARTNER,
+      policyOrgId: ORG,
+    });
+    expect(ensureBuiltinPackageMock).toHaveBeenCalledWith({ provider: 'hp_cmsl', partnerId: PARTNER });
+  });
+
+  it('does nothing for a non-warranty feature type', async () => {
+    await provisionHpCmslForFeatureLink({
+      featureType: 'patch',
+      inlineSettings: { hpCmsl: { enabled: true } },
+      policyPartnerId: PARTNER,
+      authPartnerId: null,
+      policyOrgId: null,
+    });
+    expect(ensureBuiltinPackageMock).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when hpCmsl is off — turning it off never provisions', async () => {
+    await provisionHpCmslForFeatureLink({
+      featureType: 'warranty',
+      inlineSettings: { hpCmsl: { enabled: false }, enabled: true, warnDays: 90 },
+      policyPartnerId: PARTNER,
+      authPartnerId: null,
+      policyOrgId: null,
+    });
+    expect(ensureBuiltinPackageMock).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when no partner can be resolved', async () => {
+    await provisionHpCmslForFeatureLink({
+      featureType: 'warranty',
+      inlineSettings: { hpCmsl: { enabled: true } },
+      policyPartnerId: null,
+      authPartnerId: null,
+      policyOrgId: ORG,
+    });
+    expect(ensureBuiltinPackageMock).not.toHaveBeenCalled();
+  });
+
+  it('never throws when provisioning fails — the policy write already succeeded', async () => {
+    ensureBuiltinPackageMock.mockRejectedValue(new Error('boom'));
+    await expect(
+      provisionHpCmslForFeatureLink({
+        featureType: 'warranty',
+        inlineSettings: { hpCmsl: { enabled: true } },
+        policyPartnerId: PARTNER,
+        authPartnerId: null,
+        policyOrgId: null,
+      }),
+    ).resolves.toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run it, expect FAIL**
+
+```bash
+cd apps/api && npx vitest run src/services/hpCmslProvisioning.test.ts
+```
+
+Expected: FAIL — `Failed to resolve import "./hpCmslProvisioning"`.
+
+- [ ] **Step 3: Implement the service**
+
+Create `apps/api/src/services/hpCmslProvisioning.ts`:
+
+```ts
+import { ensureBuiltinPackage } from './builtinDeploymentPackages';
+import { captureException } from './sentry';
+
+/**
+ * HP CMSL built-in provisioning, triggered from the `warranty` configuration
+ * feature link (feature #5511 W04, #5515).
+ *
+ * HP has no integration to connect, so there is no equivalent of
+ * huntress.ts:456 / sentinelOne.ts:435. The moment that means "this partner
+ * wants HP CMSL" is the moment a warranty feature link's `hpCmsl.enabled` goes
+ * true — which is also the moment W02 records the EULA consent. Provisioning
+ * any earlier would push a ~100 MB HP module into every partner's catalog
+ * unasked; any later and the software policy in W04 Task 9 would reference a
+ * catalog item that does not exist.
+ */
+
+/**
+ * True only when a warranty feature link's inline settings explicitly turn HP
+ * CMSL COLLECTION on.
+ *
+ * Deliberately duck-typed against contract D1's shape rather than importing
+ * W02's `WarrantyHpCmslSettings`: a rename over there must not silently stop
+ * provisioning here.
+ *
+ * `=== true` and not a truthy check, on purpose. The warranty block already has
+ * an outer `enabled` that means expiry ALERTING; conflating the two — or
+ * accepting `'yes'` / `1` from a hand-rolled API client — would arm software
+ * installation from a value that never meant that.
+ */
+export function warrantyLinkEnablesHpCmsl(inlineSettings: unknown): boolean {
+  if (!inlineSettings || typeof inlineSettings !== 'object') return false;
+  const hpCmsl = (inlineSettings as Record<string, unknown>).hpCmsl;
+  if (!hpCmsl || typeof hpCmsl !== 'object') return false;
+  return (hpCmsl as Record<string, unknown>).enabled === true;
+}
+
+/**
+ * Ensure the partner's built-in HP CMSL catalog package exists, if this feature
+ * link write turned HP CMSL on.
+ *
+ * Fire-and-forget by contract: the caller's policy write has ALREADY committed
+ * by the time this runs, so a provisioning failure must never turn a successful
+ * write into an error response. The package is re-ensured on every subsequent
+ * enable, so a transient failure self-heals. Same shape as huntress.ts:454-461.
+ *
+ * MUST be called AFTER the feature-link write returns and OUTSIDE any request
+ * transaction: ensureBuiltinPackage opens its own system DB context, and
+ * nesting that inside the request's own withDbAccessContext transaction
+ * double-holds a pooled connection (a hang at concurrency >= pool size).
+ */
+export async function provisionHpCmslForFeatureLink(input: {
+  featureType: string;
+  inlineSettings: unknown;
+  /** configuration_policies.partner_id — set only for a partner-wide policy. */
+  policyPartnerId: string | null;
+  /** AuthContext.partnerId — present on org tokens too (middleware/auth.ts:95). */
+  authPartnerId: string | null;
+  /** configuration_policies.org_id — for the log line only. */
+  policyOrgId: string | null;
+}): Promise<void> {
+  if (input.featureType !== 'warranty') return;
+  if (!warrantyLinkEnablesHpCmsl(input.inlineSettings)) return;
+
+  const partnerId = input.policyPartnerId ?? input.authPartnerId;
+  if (!partnerId) {
+    // A system-scope caller acting on an org-owned policy with no partner in
+    // context. Say so rather than guessing an owner for a partner-axis row.
+    console.warn(
+      `[hp-cmsl] warranty link enabled hpCmsl for org ${input.policyOrgId ?? 'unknown'} but no partner is in context — built-in package not provisioned`,
+    );
+    return;
+  }
+
+  try {
+    await ensureBuiltinPackage({ provider: 'hp_cmsl', partnerId });
+  } catch (error) {
+    console.error('[hp-cmsl] failed to provision the built-in HP CMSL package:', error);
+    captureException(error instanceof Error ? error : new Error(String(error)));
+    // Non-fatal: the policy is saved; the package is re-ensured on the next enable.
+  }
+}
+```
+
+- [ ] **Step 4: Run it, expect PASS**
+
+```bash
+cd apps/api && npx vitest run src/services/hpCmslProvisioning.test.ts
+```
+
+Expected: PASS, 8 tests.
+
+- [ ] **Step 5: Wire the two call sites**
+
+In `apps/api/src/routes/configurationPolicies/featureLinks.ts`, add to the imports:
+
+```ts
+import { provisionHpCmslForFeatureLink } from '../../services/hpCmslProvisioning';
+```
+
+In the **POST** handler, between the `writeRouteAudit(...)` call (`:298-305`) and `return c.json(link, 201);` (`:307`):
+
+```ts
+    // #5515: enabling HP CMSL collection is what asks Breeze for the built-in HP
+    // CMSL catalog package. Gated on the POST-WRITE state (`link`), not the
+    // request body, and awaited AFTER addFeatureLink returned so this never runs
+    // inside the write's own DB context. It never throws.
+    await provisionHpCmslForFeatureLink({
+      featureType: data.featureType,
+      inlineSettings: link.inlineSettings,
+      policyPartnerId: policy.partnerId ?? null,
+      authPartnerId: auth.partnerId ?? null,
+      policyOrgId: policy.orgId ?? null,
+    });
+```
+
+In the **PATCH** handler, between its `writeRouteAudit(...)` (`:471-478`) and `return c.json(updated);` (`:480`):
+
+```ts
+    // Same trigger as the POST route: a PATCH that flips hpCmsl on is the same
+    // event. Reads `updated` (post-write state), not `data`, because a PATCH
+    // body may be partial.
+    await provisionHpCmslForFeatureLink({
+      featureType: existingLink.featureType,
+      inlineSettings: updated.inlineSettings,
+      policyPartnerId: policy.partnerId ?? null,
+      authPartnerId: auth.partnerId ?? null,
+      policyOrgId: policy.orgId ?? null,
+    });
+```
+
+- [ ] **Step 6: Run the feature-link route suite and typecheck**
+
+```bash
+cd apps/api && npx vitest run src/routes/configurationPolicies
+pnpm --filter @breeze/api exec tsc --noEmit
+```
+
+Expected: PASS / clean. If any existing feature-link test mocks `../../services/hpCmslProvisioning` implicitly by mocking the whole services directory, add an explicit `vi.mock('../../services/hpCmslProvisioning', () => ({ provisionHpCmslForFeatureLink: vi.fn() }))` to that file — the new import must not drag `ensureBuiltinPackage`'s real DB access into a unit test. Check the reported file count: `src/routes/configurationPolicies` is a substring filter, not a directory glob.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/services/hpCmslProvisioning.ts \
+        apps/api/src/services/hpCmslProvisioning.test.ts \
+        apps/api/src/routes/configurationPolicies/featureLinks.ts
+git commit -m "feat(warranty): provision the HP CMSL built-in when a warranty link enables hpCmsl (#5515)"
+```
+
+---
+
+### Task 7: Web — split the provider taxonomy so HP is a built-in but not an EDR provider
+
+**Files:**
+- Modify: `apps/web/src/components/software/providerBranding.ts`
+- Modify: `apps/web/src/components/software/useEdrReadiness.ts:1-3,123-135,137-155`
+- Test: `apps/web/src/components/software/providerBranding.test.ts`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks (the web reads `integrationProvider` off the API's existing catalog feed).
+- Produces:
+  - `export const EDR_PROVIDERS: readonly ['huntress', 'sentinelone']`
+  - `export type EdrProvider = 'huntress' | 'sentinelone'`
+  - `export const INTEGRATION_PROVIDERS: readonly ['huntress', 'sentinelone', 'hp_cmsl']`
+  - `export type IntegrationProvider = 'huntress' | 'sentinelone' | 'hp_cmsl'`
+  - `export function isEdrProvider(v: unknown): v is EdrProvider`
+  - `isIntegrationProvider` unchanged in name, widened in meaning
+  - `getProviderBranding(p: IntegrationProvider)` — now covers `hp_cmsl`
+  - `useEdrReadiness(providers: EdrProvider[], opts?): Record<EdrProvider, EdrReadiness>` — **narrowed**, so the two-key seed is type-correct rather than a hazard
+
+This mirrors, exactly, the `BuiltinEdrProvider` ⊂ `BuiltinProvider` split Task 2 made on the API side. Same reason, same shape, both ends of the wire.
+
+- [ ] **Step 1: Write the failing tests**
+
+Replace `apps/web/src/components/software/providerBranding.test.ts` in full:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import {
+  EDR_PROVIDERS,
+  INTEGRATION_PROVIDERS,
+  getProviderBranding,
+  isEdrProvider,
+  isIntegrationProvider,
+} from './providerBranding';
+
+describe('providerBranding', () => {
+  it('returns label, icon, accent, and blurb for huntress', () => {
+    const b = getProviderBranding('huntress');
+    expect(b.label).toBe('Huntress');
+    // lucide icons are forwardRef components (objects in this version), not plain functions
+    expect(b.icon).toBeDefined();
+    expect(['function', 'object']).toContain(typeof b.icon);
+    expect(b.accent).toMatch(/\S/);
+    expect(b.blurb.length).toBeGreaterThan(0);
+  });
+
+  it('returns branding for sentinelone', () => {
+    expect(getProviderBranding('sentinelone').label).toBe('SentinelOne');
+  });
+
+  it('returns branding for hp_cmsl', () => {
+    const b = getProviderBranding('hp_cmsl');
+    expect(b.label).toBe('HP CMSL');
+    expect(b.icon).toBeDefined();
+    expect(b.accent).toMatch(/\S/);
+    expect(b.blurb.length).toBeGreaterThan(0);
+  });
+
+  it('brands every member of the provider set', () => {
+    for (const p of INTEGRATION_PROVIDERS) {
+      expect(getProviderBranding(p)).toBeDefined();
+    }
+  });
+
+  it('type-guards provider strings', () => {
+    expect(isIntegrationProvider('huntress')).toBe(true);
+    expect(isIntegrationProvider('hp_cmsl')).toBe(true);
+    expect(isIntegrationProvider('nope')).toBe(false);
+    expect(isIntegrationProvider(undefined)).toBe(false);
+  });
+
+  it('separates EDR providers from the wider built-in set', () => {
+    // hp_cmsl is a built-in with branding, but it holds no credentials and has
+    // nothing to be "ready" about — useEdrReadiness is typed against EdrProvider
+    // so it can never be folded into EDR readiness.
+    expect(isEdrProvider('huntress')).toBe(true);
+    expect(isEdrProvider('sentinelone')).toBe(true);
+    expect(isEdrProvider('hp_cmsl')).toBe(false);
+    expect(isEdrProvider(undefined)).toBe(false);
+    for (const p of EDR_PROVIDERS) {
+      expect(INTEGRATION_PROVIDERS).toContain(p);
+    }
+    expect(EDR_PROVIDERS.length).toBeLessThan(INTEGRATION_PROVIDERS.length);
+  });
+});
+```
+
+- [ ] **Step 2: Run it, expect FAIL**
+
+```bash
+cd apps/web && npx vitest run src/components/software/providerBranding.test.ts
+```
+
+Expected: FAIL — `EDR_PROVIDERS` and `isEdrProvider` are not exported; `getProviderBranding('hp_cmsl')` returns `undefined`.
+
+- [ ] **Step 3: Implement `providerBranding.ts`**
+
+Replace `apps/web/src/components/software/providerBranding.ts:1-41` with:
+
+```ts
+import { Laptop, ShieldCheck, type LucideIcon } from 'lucide-react';
+
+/** Built-in providers that are credential-backed EDR integrations: they have a
+ *  readiness concept (integration connected? key configured? orgs mapped?) that
+ *  useEdrReadiness fetches. `useEdrReadiness` is typed against THIS set, so a
+ *  built-in with no credentials can never be folded into EDR readiness — which
+ *  is what would leave its card stuck on "Checking" forever, or crash on an
+ *  unseeded readiness lookup. */
+export const EDR_PROVIDERS = ['huntress', 'sentinelone'] as const;
+
+export type EdrProvider = (typeof EDR_PROVIDERS)[number];
+
+/** Single source of truth for the FULL built-in provider set — the union and the
+ *  type guard both derive from this, so adding a provider can't leave one of
+ *  them stale. `hp_cmsl` is a built-in (branded, "Built-in" chip, not deletable)
+ *  but NOT an EdrProvider: it installs from winget, holds no credentials, and
+ *  has nothing to configure before it can deploy. */
+export const INTEGRATION_PROVIDERS = [...EDR_PROVIDERS, 'hp_cmsl'] as const;
+
+export type IntegrationProvider = (typeof INTEGRATION_PROVIDERS)[number];
+
+export interface ProviderBranding {
+  label: string;
+  icon: LucideIcon;
+  /** Tailwind classes for the tinted icon tile + chip (theme-aware). NOT a logo. */
+  accent: string;
+  blurb: string;
+  websiteUrl?: string;
+}
+
+const BRANDING: Record<IntegrationProvider, ProviderBranding> = {
+  huntress: {
+    label: 'Huntress',
+    icon: ShieldCheck,
+    accent: 'bg-orange-500/15 text-orange-600 dark:text-orange-400 border-orange-500/40',
+    blurb: 'Managed endpoint detection & response — installs the latest agent automatically.',
+    websiteUrl: 'https://www.huntress.com',
+  },
+  sentinelone: {
+    label: 'SentinelOne',
+    icon: ShieldCheck,
+    accent: 'bg-purple-500/15 text-purple-600 dark:text-purple-400 border-purple-500/40',
+    blurb: 'Autonomous EDR agent deployed from your uploaded installer.',
+    websiteUrl: 'https://www.sentinelone.com',
+  },
+  hp_cmsl: {
+    label: 'HP CMSL',
+    icon: Laptop,
+    accent: 'bg-sky-500/15 text-sky-600 dark:text-sky-400 border-sky-500/40',
+    blurb:
+      "HP's Client Management Script Library, installed from winget on HP business hardware so the agent can read warranty and entitlement data. Installed from HP — Breeze never hosts a copy.",
+    websiteUrl:
+      'https://developers.hp.com/hp-client-management/doc/client-management-script-library',
+  },
+};
+
+export function getProviderBranding(p: IntegrationProvider): ProviderBranding {
+  return BRANDING[p];
+}
+
+export function isIntegrationProvider(v: unknown): v is IntegrationProvider {
+  return (INTEGRATION_PROVIDERS as readonly unknown[]).includes(v);
+}
+
+/** Narrower guard: is this built-in one of the credential-backed EDR providers,
+ *  i.e. does it have an EDR readiness entry at all? */
+export function isEdrProvider(v: unknown): v is EdrProvider {
+  return (EDR_PROVIDERS as readonly unknown[]).includes(v);
+}
+```
+
+- [ ] **Step 4: Narrow `useEdrReadiness` to `EdrProvider`**
+
+In `apps/web/src/components/software/useEdrReadiness.ts`, change the type import at `:3`:
+
+```ts
+import type { EdrProvider } from './providerBranding';
+```
+
+and the hook signature + seed at `:123-135`:
+
+```ts
+/**
+ * EDR readiness for the credential-backed built-ins only.
+ *
+ * The parameter and return type are `EdrProvider`, NOT `IntegrationProvider`:
+ * the seed below is a hardcoded two-key literal, so a widened key type would
+ * either fail to compile or — worse, if someone "fixed" it by adding a key —
+ * leave a non-EDR built-in permanently reporting `loading`. HP CMSL has no
+ * credential readiness concept and must not appear in this map at all; the
+ * catalog gates its readiness UI on `isEdrProvider` instead.
+ */
+export function useEdrReadiness(
+  providers: EdrProvider[],
+  opts?: { s1VersionCount?: number },
+): Record<EdrProvider, EdrReadiness> {
+  const s1VersionCount = opts?.s1VersionCount ?? 0;
+  const key = useMemo(
+    () => `${Array.from(new Set(providers)).sort().join(',')}|${s1VersionCount}`,
+    [providers, s1VersionCount],
+  );
+  const [map, setMap] = useState<Record<EdrProvider, EdrReadiness>>({
+    huntress: LOADING,
+    sentinelone: LOADING,
+  });
+```
+
+and the one cast inside the effect at `:140`:
+
+```ts
+    const wanted = provPart ? (provPart.split(',') as EdrProvider[]) : [];
+```
+
+- [ ] **Step 5: Run the branding + readiness tests, expect PASS**
+
+```bash
+cd apps/web && npx vitest run src/components/software/providerBranding.test.ts src/components/software/useEdrReadiness.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Typecheck — expect a failure in `SoftwareCatalog.tsx`, which is correct**
+
+```bash
+pnpm --filter @breeze/web exec tsc --noEmit
+```
+
+Expected: **FAIL** at `SoftwareCatalog.tsx:331` (`builtinProviders` is `IntegrationProvider[]`, the hook now wants `EdrProvider[]`) and at `:640` / `:828` (indexing a `Record<EdrProvider, …>` with an `IntegrationProvider`). Record those errors — they are the compiler pointing at exactly the three sites Task 8 fixes. Do not paper over them here.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/components/software/providerBranding.ts \
+        apps/web/src/components/software/useEdrReadiness.ts \
+        apps/web/src/components/software/providerBranding.test.ts
+git commit -m "feat(web): split EdrProvider out of IntegrationProvider and brand hp_cmsl (#5515)"
+```
+
+---
+
+### Task 8: Web — render an `hp_cmsl` catalog item without crashing
+
+**Files:**
+- Modify: `apps/web/src/components/software/SoftwareCatalog.tsx:22-28,271-275,312-331,637-651,824-828`
+- Modify: `apps/web/src/components/software/BuiltinPackageDetail.tsx:9-37,77-146`
+- Test: `apps/web/src/components/software/SoftwareCatalog.test.tsx`
+
+**Interfaces:**
+- Consumes: `isEdrProvider`, `isIntegrationProvider`, `EdrProvider` (Task 7).
+- Produces: `BuiltinPackageDetailProps.readiness: EdrReadiness | null` — `null` means "this built-in has no credential readiness concept": no readiness box, and Deploy is never disabled.
+
+This is the wave's mandatory regression. It is staged so the red is genuine **twice**: once for the silent misrender that exists today, and once for the crash the contract describes.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `apps/web/src/components/software/SoftwareCatalog.test.tsx`, after the existing `describe('SoftwareCatalog built-in packages', ...)` block:
+
+```tsx
+const HP_CMSL_ITEM = {
+  id: 'builtin-hp-cmsl',
+  name: 'HP Client Management Script Library',
+  vendor: 'HP Inc.',
+  category: 'utility',
+  description: 'HP CMSL, installed from winget.',
+  createdAt: '2026-09-10T00:00:00Z',
+  integrationProvider: 'hp_cmsl',
+  partnerId: 'partner-1',
+  versionCount: 0,
+  methodCount: 1,
+  methodKinds: ['winget'],
+};
+
+describe('SoftwareCatalog non-EDR built-in (hp_cmsl)', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    showToast.mockReset();
+  });
+
+  it('renders the built-in chip and no readiness pill, and never dereferences EDR readiness', async () => {
+    // The crash this guards: useEdrReadiness seeds only {huntress, sentinelone},
+    // while the card and the detail panel index readinessMap by the item's
+    // provider. Adding hp_cmsl to INTEGRATION_PROVIDERS without separating
+    // readiness makes `readinessMap['hp_cmsl'].status` throw during render.
+    routeBuiltin([HP_CMSL_ITEM]);
+
+    render(<SoftwareCatalog />);
+
+    await waitFor(() =>
+      expect(screen.getByText('HP Client Management Script Library')).toBeInTheDocument(),
+    );
+    // It IS a built-in: branded chip, and no EDR readiness pill of any kind.
+    expect(screen.getByText(/^Built-in$/)).toBeInTheDocument();
+    expect(screen.queryByText(/^Ready$/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^Setup needed$/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^Checking$/)).not.toBeInTheDocument();
+    // The winget install method still badges the card.
+    expect(screen.getByTestId('package-manager-badges').textContent).toMatch(/winget/);
+    // Deploy is enabled: there is no credential to configure first.
+    expect(screen.getByRole('button', { name: /^Deploy$/ })).not.toBeDisabled();
+  });
+
+  it('opens a Managed built-in detail panel with no Delete control and no readiness checklist', async () => {
+    routeBuiltin([HP_CMSL_ITEM]);
+
+    render(<SoftwareCatalog />);
+    await waitFor(() =>
+      expect(screen.getByText('HP Client Management Script Library')).toBeInTheDocument(),
+    );
+
+    fireEvent.click(screen.getByText('HP Client Management Script Library'));
+
+    expect(await screen.findByText(/Managed built-in/i)).toBeInTheDocument();
+    // A built-in is never deletable through the catalog UI.
+    expect(screen.queryByRole('button', { name: /^Delete$/ })).not.toBeInTheDocument();
+    // ...and there is no EDR readiness box to render.
+    expect(screen.queryByText(/Checking setup/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Next step:/i)).not.toBeInTheDocument();
+  });
+
+  it('still fetches EDR readiness for an EDR built-in shown alongside it', async () => {
+    // Regression fence for the readiness split: narrowing the readiness fetch to
+    // EdrProvider must not stop Huntress readiness from loading.
+    routeBuiltin([HP_CMSL_ITEM, BUILTIN_ITEM], HUNTRESS_READY);
+
+    render(<SoftwareCatalog />);
+
+    await waitFor(() => expect(screen.getByText(/^Ready$/)).toBeInTheDocument());
+    expect(screen.getAllByText(/^Built-in$/)).toHaveLength(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run it, expect FAIL (the silent misrender)**
+
+```bash
+cd apps/web && npx vitest run src/components/software/SoftwareCatalog.test.tsx
+```
+
+Expected: the first two tests FAIL — no "Built-in" chip, and a **Delete** button IS present in the detail panel. That is `SoftwareCatalog.tsx:271-275` narrowing `hp_cmsl` to `undefined`: the built-in renders as an ordinary org package. Record it.
+
+- [ ] **Step 3: Widen the row-mapping narrowing ONLY**
+
+In `apps/web/src/components/software/SoftwareCatalog.tsx`, replace `:271-275`:
+
+```tsx
+            // Derived from INTEGRATION_PROVIDERS via the type guard, not a
+            // hardcoded pair: a hardcoded list here silently demoted any new
+            // built-in to an ordinary org package (no branding, no Built-in
+            // chip, a Delete button the API refuses with a 400).
+            integrationProvider: isIntegrationProvider(item.integrationProvider)
+              ? item.integrationProvider
+              : undefined,
+```
+
+- [ ] **Step 4: Run it again, expect FAIL — and this time it is THE CRASH**
+
+```bash
+cd apps/web && npx vitest run src/components/software/SoftwareCatalog.test.tsx
+```
+
+Expected: FAIL with `TypeError: Cannot read properties of undefined (reading 'status')`, thrown from `SoftwareCatalog.tsx:640` during render (`readinessMap['hp_cmsl']` is `undefined` — `useEdrReadiness` seeds only `huntress` and `sentinelone`). **This is the exact defect the contract names. Record the message before fixing it** — it is the proof that the readiness separation in the next step is load-bearing rather than cosmetic. (Vitest transpiles without type-checking, so Task 7's `tsc` errors do not stop this run; the runtime crash is what surfaces here.)
+
+- [ ] **Step 5: Separate readiness from branding**
+
+In `apps/web/src/components/software/SoftwareCatalog.tsx`:
+
+Imports (`:22-26`):
+
+```tsx
+import {
+  getProviderBranding,
+  isEdrProvider,
+  isIntegrationProvider,
+  type IntegrationProvider,
+} from "./providerBranding";
+```
+
+The readiness fetch set (`:312-331`) — rename and re-guard:
+
+```tsx
+  // Built-in EDR readiness: one fetch per present EDR provider (there's one
+  // integration per partner), shared by the cards and the detail panel.
+  // Filtered by isEdrProvider, NOT isIntegrationProvider: a non-EDR built-in
+  // (hp_cmsl) has no credentials and no readiness endpoint to ask.
+  const edrProviders = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          catalogItems
+            .map((i) => i.integrationProvider)
+            .filter(isEdrProvider),
+        ),
+      ),
+    [catalogItems],
+  );
+  const s1VersionCount = useMemo(
+    () =>
+      catalogItems.find((i) => i.integrationProvider === "sentinelone")
+        ?.versionCount ?? 0,
+    [catalogItems],
+  );
+  const readinessMap = useEdrReadiness(edrProviders, { s1VersionCount });
+```
+
+The card's chip row (`:637-651`) — split the readiness pill off the built-in chip:
+
+```tsx
+                  {isIntegrationProvider(item.integrationProvider) && (
+                    <div className="flex items-center gap-1.5">
+                      {/* Readiness is an EDR-only concept: hp_cmsl has no
+                          credentials to check, so it wears the Built-in chip
+                          with no pill rather than a pill that never resolves. */}
+                      {isEdrProvider(item.integrationProvider) && (
+                        <ReadinessPill
+                          status={readinessMap[item.integrationProvider].status}
+                        />
+                      )}
+                      <span
+                        className={cn(
+                          "inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium",
+                          getProviderBranding(item.integrationProvider).accent,
+                        )}
+                      >
+                        {i18n.t("policies:software.softwareCatalog.builtIn")}
+                      </span>
+                    </div>
+                  )}
+```
+
+The detail panel (`:824-828`):
+
+```tsx
+              (isIntegrationProvider(selectedSoftware.integrationProvider) ? (
+                <BuiltinPackageDetail
+                  name={selectedSoftware.name}
+                  provider={selectedSoftware.integrationProvider}
+                  readiness={
+                    isEdrProvider(selectedSoftware.integrationProvider)
+                      ? readinessMap[selectedSoftware.integrationProvider]
+                      : null
+                  }
+```
+
+In `apps/web/src/components/software/BuiltinPackageDetail.tsx`, widen the prop (`:16-33`):
+
+```tsx
+export interface BuiltinPackageDetailProps {
+  name: string;
+  provider: IntegrationProvider;
+  /** EDR readiness, or `null` for a built-in that has no credential readiness
+   *  concept (hp_cmsl). A null readiness renders no readiness box and never
+   *  disables Deploy — there is nothing to configure first. */
+  readiness: EdrReadiness | null;
+  onDeploy: () => void;
+}
+export default function BuiltinPackageDetail({
+  name,
+  provider,
+  readiness,
+  onDeploy,
+}: BuiltinPackageDetailProps) {
+  useTranslation("policies");
+  const branding = getProviderBranding(provider);
+  const Icon = branding.icon;
+  const ready = readiness?.status === "ready";
+  const gap = readiness ? firstGap(readiness) : undefined;
+  const disabled = readiness?.status === "incomplete";
+```
+
+and wrap the readiness box (currently `:77-146`) so it renders only when there is a readiness to render. Change its opening line from:
+
+```tsx
+      <div className="rounded-md border bg-muted/30 p-4">
+```
+
+to:
+
+```tsx
+      {readiness && (
+      <div className="rounded-md border bg-muted/30 p-4">
+```
+
+and its closing `</div>` (the one immediately before `<div className="flex items-center justify-end">`) to:
+
+```tsx
+      </div>
+      )}
+```
+
+Inside that block, `readiness` is narrowed to non-null, so `readiness.status` and `readiness.checks` need no further change.
+
+- [ ] **Step 6: Run the web software suite, expect PASS**
+
+```bash
+cd apps/web && npx vitest run src/components/software/SoftwareCatalog.test.tsx src/components/software/BuiltinPackageDetail.test.tsx src/components/software/providerBranding.test.ts src/components/software/useEdrReadiness.test.tsx
+```
+
+Expected: PASS. Check the reported file count is 4 — vitest's filter is substring matching, so a typo silently narrows the run.
+
+- [ ] **Step 7: Typecheck and lint**
+
+```bash
+pnpm --filter @breeze/web exec tsc --noEmit
+pnpm lint
+```
+
+Expected: clean. Task 7's three recorded errors are now gone.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/web/src/components/software/SoftwareCatalog.tsx \
+        apps/web/src/components/software/BuiltinPackageDetail.tsx \
+        apps/web/src/components/software/SoftwareCatalog.test.tsx
+git commit -m "fix(web): render non-EDR built-ins without dereferencing EDR readiness (#5515)"
+```
+
+---
+
+### Task 9: The policy that keeps CMSL present — **BLOCKED ON #5508**
+
+> **Do not start this task until issue #5508 (Feature A W03) has merged.** Verify with `gh pr list --repo LanternOps/breeze --search "5508" --state merged` or `gh issue view 5508 --repo LanternOps/breeze --json state`. Until then, `remediationOptionsSchema` (`apps/api/src/db/schema/softwarePolicies.ts:79-85`) is a non-strict `z.object` that **silently strips** an `autoInstall` key, and the compliance worker cannot act on a `missing` violation at all. A policy written before #5508 lands would look armed and install nothing. Tasks 1–8 ship as their own PR; this is the second.
+
+**Files:**
+- Create: `apps/api/src/services/hpCmslPolicyProvisioning.ts`
+- Create: `apps/api/src/services/hpCmslPolicyProvisioning.test.ts`
+- Create: `apps/api/src/__tests__/integration/hpCmslPolicyProvisioning.integration.test.ts`
+- Modify: `apps/api/src/services/hpCmslProvisioning.ts` (chain the policy provisioner after the package)
+
+**Interfaces:**
+- Consumes: `ensureBuiltinPackage({ provider: 'hp_cmsl', partnerId })` → `{ catalogId }` (Task 4); `SoftwarePolicyRemediationOptions.autoInstall?: boolean` (#5508).
+- Produces: `export async function ensureHpCmslSoftwarePolicy(params: { partnerId: string; catalogId: string }): Promise<{ softwarePolicyId: string; configPolicyId: string }>` — idempotent, system DB context.
+
+#### Two constraints this task must respect, both discovered in the ground-truth pass
+
+**(a) `allowUnknown: true` is mandatory.** `evaluateSoftwareInventory` (`softwarePolicyService.ts:316-331`) flags every non-matching installed application as `unauthorized` at severity `medium` when `allowUnknown` is falsy, and `normalizeSoftwarePolicyRules` (`:265-268`) defaults it to `false`. A one-rule allowlist policy without it would flood compliance for every targeted device, every 15 minutes.
+
+**(b) A software policy cannot be targeted at HP hardware.** Device resolution goes through **configuration-policy assignments only** (`featureConfigResolver.ts:1044-1171`); assignments carry `roleFilter` and `osFilter` and nothing else (`configurationPolicies.ts:170-171`); `device_groups.orgId` is `NOT NULL` so a partner-wide hardware group cannot exist; and `softwarePolicies.targetType`/`targetIds` are read by nothing on this path. `hardware.manufacturer` targeting exists only for **deployments** (`deploymentTargetResolver.ts:60-62`). The spec's Layer-3 sentence conflates the two models.
+
+**DECISION: provision the policy, but provision NO assignment.** `ensureHpCmslSoftwarePolicy` creates the partner-owned `software_policies` row and a dedicated partner-owned `configuration_policies` row carrying the single `software_policy` feature link — and stops there. The MSP assigns that configuration policy to the orgs, sites, groups or devices they choose, through the existing assignment UI, exactly like every other configuration policy.
+
+Rejected alternatives, and why:
+
+- **A `partner`-level assignment with `osFilter: ['windows']`.** This is the only broad targeting the machinery can express, and it would auto-install a ~100 MB HP module on *every Windows endpoint under the partner*, Dell and Lenovo included, plus the HP EULA and HP's telemetry rights that go with it. Not acceptable, and it is not what the spec's "HP devices" language describes.
+- **Adding a `manufacturer_filter` to `config_policy_assignments`.** This is the change that would make hardware-scoped policy targeting real, and it is genuinely reusable ("apply this policy only to Dell/HP/Lenovo hardware" is a plain MSP primitive). But it is a cross-module change to shared policy machinery — a migration, a `device_hardware` join in two resolvers, and a NULL-manufacturer semantics decision for devices that have not reported inventory yet. Per CLAUDE.md that is a consequential design choice needing an advisor quorum, not something a wave plan slips in. **Filed as the follow-up below.**
+- **Piggybacking the link onto the MSP's existing configuration policy.** Impossible: `config_policy_feature_links` is unique on `(config_policy_id, feature_type)` (`configurationPolicies.ts:127`), so it would displace their own software policy.
+
+**Open question for Todd, to be raised with this PR (do not decide it inside the wave):** should hardware-scoped policy targeting be built (`manufacturer_filter` on `config_policy_assignments`), or is "the MSP assigns the built-in configuration policy to the orgs they want CMSL on" the intended end state? The second is what this task ships, and it is also the more defensible EULA posture — the MSP chooses where HP software lands rather than Breeze choosing for them.
+
+**Also state plainly in the PR body (the spec asks for this):** because `software_deployments` are org-owned, a partner-wide policy produces **one deployment run per organisation**. That is inherent to the schema, not a defect to work around.
+
+- [ ] **Step 1: Confirm the gate, and read #5508's landed shape**
+
+```bash
+gh issue view 5508 --repo LanternOps/breeze --json state,title
+```
+
+Expected: `CLOSED`. Then re-read the three things #5508 defines, because this task writes against them and the plan cannot pin their final spelling:
+
+```bash
+grep -n "autoInstall" apps/api/src/db/schema/softwarePolicies.ts
+grep -n "autoInstall" apps/api/src/services/softwarePolicyService.ts
+```
+
+Expected: `SoftwarePolicyRemediationOptions.autoInstall?: boolean` and `remediationOptionsSchema` accepting it. If either is absent, #5508 did not land what this task needs — stop and report.
+
+- [ ] **Step 2: Write the failing unit test**
+
+Create `apps/api/src/services/hpCmslPolicyProvisioning.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { buildHpCmslPolicyRows, HP_CMSL_POLICY_NAME, HP_CMSL_CONFIG_POLICY_NAME } from './hpCmslPolicyProvisioning';
+
+const PARTNER = '11111111-1111-4111-8111-111111111111';
+const CATALOG = '33333333-3333-4333-8333-333333333333';
+
+describe('buildHpCmslPolicyRows', () => {
+  it('builds a partner-owned allowlist policy armed for install only', () => {
+    const { softwarePolicy } = buildHpCmslPolicyRows({ partnerId: PARTNER, catalogId: CATALOG });
+
+    expect(softwarePolicy.partnerId).toBe(PARTNER);
+    expect(softwarePolicy.orgId).toBeNull();
+    expect(softwarePolicy.name).toBe(HP_CMSL_POLICY_NAME);
+    expect(softwarePolicy.mode).toBe('allowlist');
+    expect(softwarePolicy.enforceMode).toBe(true);
+    expect(softwarePolicy.isActive).toBe(true);
+    expect(softwarePolicy.remediationOptions).toMatchObject({ autoInstall: true });
+    // Arming install must NOT arm uninstall — different verbs, different flags.
+    expect(softwarePolicy.remediationOptions.autoUninstall).toBeUndefined();
+  });
+
+  it('sets allowUnknown so the one-rule allowlist does not flag every other app', () => {
+    const { softwarePolicy } = buildHpCmslPolicyRows({ partnerId: PARTNER, catalogId: CATALOG });
+    // evaluateSoftwareInventory (softwarePolicyService.ts:316-331) emits an
+    // 'unauthorized' violation for EVERY installed app that matches no rule
+    // unless allowUnknown is true, and normalizeSoftwarePolicyRules defaults it
+    // to false. Without this the policy would flood compliance every 15 minutes.
+    expect(softwarePolicy.rules.allowUnknown).toBe(true);
+  });
+
+  it('carries exactly one rule, pointed at the HP CMSL catalog item', () => {
+    const { softwarePolicy } = buildHpCmslPolicyRows({ partnerId: PARTNER, catalogId: CATALOG });
+    expect(softwarePolicy.rules.software).toHaveLength(1);
+    expect(softwarePolicy.rules.software[0]).toMatchObject({
+      vendor: 'HP Inc.',
+      catalogId: CATALOG,
+    });
+    // The rule name is matched against Add/Remove Programs display names via a
+    // '*'-to-'.*' anchored regex (matchesSoftwareRule, :283-287), so it is a
+    // wildcard, not an exact string.
+    expect(softwarePolicy.rules.software[0]!.name).toContain('*');
+  });
+
+  it('builds a partner-owned configuration policy with one software_policy link and NO assignment', () => {
+    const { configPolicy, featureLink, assignments } = buildHpCmslPolicyRows({
+      partnerId: PARTNER,
+      catalogId: CATALOG,
+    });
+
+    expect(configPolicy.partnerId).toBe(PARTNER);
+    expect(configPolicy.orgId).toBeNull();
+    expect(configPolicy.name).toBe(HP_CMSL_CONFIG_POLICY_NAME);
+    expect(featureLink.featureType).toBe('software_policy');
+
+    // The load-bearing assertion. Assignments carry only roleFilter/osFilter
+    // (configurationPolicies.ts:170-171) — there is NO manufacturer filter — so
+    // any assignment Breeze created for the partner would install a ~100 MB HP
+    // module on every non-HP Windows endpoint under it. The MSP assigns this
+    // policy themselves, to the orgs they chose to enable HP collection for.
+    expect(assignments).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 3: Run it, expect FAIL**
+
+```bash
+cd apps/api && npx vitest run src/services/hpCmslPolicyProvisioning.test.ts
+```
+
+Expected: FAIL — `Failed to resolve import "./hpCmslPolicyProvisioning"`.
+
+- [ ] **Step 4: Implement**
+
+Create `apps/api/src/services/hpCmslPolicyProvisioning.ts`:
+
+```ts
+import { and, eq, isNull } from 'drizzle-orm';
+import { db, withSystemDbAccessContext, runOutsideDbContext } from '../db';
+import {
+  configPolicyFeatureLinks,
+  configurationPolicies,
+  softwarePolicies,
+} from '../db/schema';
+import type {
+  SoftwarePolicyRemediationOptions,
+  SoftwarePolicyRulesDefinition,
+} from '../db/schema/softwarePolicies';
+
+/**
+ * The built-in "keep HP CMSL installed" policy pair (feature #5511 W04, #5515).
+ *
+ * WHAT THIS CREATES
+ *   1. a partner-owned software_policies row: allowlist mode, enforceMode on,
+ *      remediationOptions.autoInstall armed, ONE rule pointed at the partner's
+ *      HP CMSL catalog item;
+ *   2. a partner-owned configuration_policies row carrying the single
+ *      `software_policy` feature link to (1).
+ *
+ * WHAT THIS DELIBERATELY DOES NOT CREATE: an assignment.
+ *
+ * A software policy resolves its devices ONLY through configuration-policy
+ * assignments (services/featureConfigResolver.ts:1044-1171 — softwarePolicies'
+ * own targetType/targetIds are read by nothing on that path). An assignment can
+ * narrow by device role and OS (db/schema/configurationPolicies.ts:170-171) and
+ * by NOTHING ELSE — there is no manufacturer filter, and device_groups.orgId is
+ * NOT NULL so a partner-wide hardware group cannot exist either. The broadest
+ * assignment Breeze could create is therefore "every Windows device under this
+ * partner", which would push a ~100 MB HP module (and HP's licence and its
+ * telemetry rights) onto every Dell and Lenovo endpoint the partner manages.
+ *
+ * hardware.manufacturer targeting DOES exist, but only for one-shot deployments
+ * (services/deploymentTargetResolver.ts:60-62 → evaluateFilter). The spec's
+ * Layer-3 claim that policy targeting can use it conflates the two models.
+ *
+ * So the MSP assigns this configuration policy, to the orgs/sites/groups they
+ * chose to enable HP warranty collection for, through the normal assignment UI.
+ * That is also the right EULA posture: the MSP decides where HP software lands.
+ *
+ * Follow-up under discussion with Todd: a `manufacturer_filter` column on
+ * config_policy_assignments would make hardware-scoped policy targeting real and
+ * is plainly reusable, but it is a cross-module change to shared policy
+ * machinery and needs its own design pass.
+ *
+ * NOTE ON BLAST RADIUS: because software_deployments are org-owned, a
+ * partner-wide policy produces one deployment run per organisation. That is
+ * inherent to the schema, not a defect to work around.
+ */
+
+export const HP_CMSL_POLICY_NAME = 'HP CMSL (built-in)';
+export const HP_CMSL_CONFIG_POLICY_NAME = 'HP warranty collection (built-in)';
+
+/**
+ * Add/Remove Programs display name pattern for HP CMSL.
+ *
+ * matchesSoftwareRule (services/softwarePolicyService.ts:283-287) turns the rule
+ * name into an ANCHORED regex with '*' → '.*', case-insensitive. A wildcard is
+ * required because the exact DisplayName HP's InnoSetup installer registers is
+ * a lab observation (W01 gate question 3), not documentation, and it carries a
+ * version suffix on some builds.
+ */
+export const HP_CMSL_RULE_NAME = 'HP Client Management Script Library*';
+
+export interface HpCmslPolicyRows {
+  softwarePolicy: {
+    orgId: null;
+    partnerId: string;
+    name: string;
+    description: string;
+    mode: 'allowlist';
+    rules: SoftwarePolicyRulesDefinition;
+    priority: number;
+    isActive: boolean;
+    enforceMode: boolean;
+    remediationOptions: SoftwarePolicyRemediationOptions;
+  };
+  configPolicy: {
+    orgId: null;
+    partnerId: string;
+    name: string;
+    description: string;
+  };
+  featureLink: { featureType: 'software_policy' };
+  /** Always empty — see the module docstring. Typed as an array so a future
+   *  change that starts creating assignments has to change this contract, and
+   *  the test that asserts it is empty, visibly. */
+  assignments: never[];
+}
+
+export function buildHpCmslPolicyRows(params: {
+  partnerId: string;
+  catalogId: string;
+}): HpCmslPolicyRows {
+  return {
+    softwarePolicy: {
+      orgId: null,
+      partnerId: params.partnerId,
+      name: HP_CMSL_POLICY_NAME,
+      description:
+        "Keeps HP's Client Management Script Library installed on assigned devices so the Breeze agent can read HP warranty and entitlement data. Installed from winget — Breeze never hosts a copy of the installer.",
+      mode: 'allowlist',
+      rules: {
+        software: [
+          { name: HP_CMSL_RULE_NAME, vendor: 'HP Inc.', catalogId: params.catalogId },
+        ],
+        // MANDATORY. Without it, evaluateSoftwareInventory's allowlist arm
+        // (softwarePolicyService.ts:316-331) marks every OTHER installed
+        // application on every targeted device 'unauthorized' at severity
+        // medium, every 15 minutes. normalizeSoftwarePolicyRules defaults it to
+        // false (:265-268), so it has to be set explicitly.
+        allowUnknown: true,
+      },
+      priority: 50,
+      isActive: true,
+      enforceMode: true,
+      remediationOptions: {
+        // Install only. Arming install must never arm uninstall — a policy that
+        // keeps software present is not thereby armed to remove anything.
+        autoInstall: true,
+      },
+    },
+    configPolicy: {
+      orgId: null,
+      partnerId: params.partnerId,
+      name: HP_CMSL_CONFIG_POLICY_NAME,
+      description:
+        'Assign this policy to the organizations, sites or device groups where HP warranty collection is enabled. Breeze does not assign it for you: policy targeting cannot narrow to HP hardware, so a partner-wide assignment would install HP CMSL on non-HP Windows devices too.',
+    },
+    featureLink: { featureType: 'software_policy' },
+    assignments: [],
+  };
+}
+
+/**
+ * Idempotently ensure the built-in HP CMSL policy pair for one partner.
+ *
+ * Keyed on (partner_id, name) for both rows — neither table has a natural unique
+ * key for "the built-in one", and adding one would be a schema change for a
+ * single feature. Renaming either constant would orphan the existing rows, so
+ * the names are exported constants and must not be edited casually.
+ */
+export async function ensureHpCmslSoftwarePolicy(params: {
+  partnerId: string;
+  catalogId: string;
+}): Promise<{ softwarePolicyId: string; configPolicyId: string }> {
+  const rows = buildHpCmslPolicyRows(params);
+
+  return runOutsideDbContext(() =>
+    withSystemDbAccessContext(async () => {
+      const existingPolicy = await db
+        .select({ id: softwarePolicies.id })
+        .from(softwarePolicies)
+        .where(and(
+          eq(softwarePolicies.partnerId, params.partnerId),
+          isNull(softwarePolicies.orgId),
+          eq(softwarePolicies.name, HP_CMSL_POLICY_NAME),
+        ))
+        .limit(1);
+
+      let softwarePolicyId = existingPolicy[0]?.id;
+      if (!softwarePolicyId) {
+        const [row] = await db
+          .insert(softwarePolicies)
+          .values(rows.softwarePolicy)
+          .returning({ id: softwarePolicies.id });
+        softwarePolicyId = row!.id;
+      } else {
+        // Re-assert the server-owned shape: the catalogId can change if the
+        // built-in package was re-provisioned, and allowUnknown must never drift
+        // to false.
+        await db
+          .update(softwarePolicies)
+          .set({ rules: rows.softwarePolicy.rules, updatedAt: new Date() })
+          .where(eq(softwarePolicies.id, softwarePolicyId));
+      }
+
+      const existingConfig = await db
+        .select({ id: configurationPolicies.id })
+        .from(configurationPolicies)
+        .where(and(
+          eq(configurationPolicies.partnerId, params.partnerId),
+          isNull(configurationPolicies.orgId),
+          eq(configurationPolicies.name, HP_CMSL_CONFIG_POLICY_NAME),
+        ))
+        .limit(1);
+
+      let configPolicyId = existingConfig[0]?.id;
+      if (!configPolicyId) {
+        const [row] = await db
+          .insert(configurationPolicies)
+          .values(rows.configPolicy)
+          .returning({ id: configurationPolicies.id });
+        configPolicyId = row!.id;
+      }
+
+      // One software_policy link per configuration policy
+      // (config_feature_links_unique on (config_policy_id, feature_type)).
+      await db
+        .insert(configPolicyFeatureLinks)
+        .values({
+          configPolicyId,
+          featureType: 'software_policy',
+          featurePolicyId: softwarePolicyId,
+          inlineSettings: null,
+        })
+        .onConflictDoUpdate({
+          target: [configPolicyFeatureLinks.configPolicyId, configPolicyFeatureLinks.featureType],
+          set: { featurePolicyId: softwarePolicyId, updatedAt: new Date() },
+        });
+
+      // NO assignment is created. See the module docstring.
+      return { softwarePolicyId, configPolicyId };
+    })
+  );
+}
+```
+
+> Before running: confirm `configurationPolicies`'s insert shape against `apps/api/src/db/schema/configurationPolicies.ts` — if `status` is `NOT NULL` without a default, add `status: 'active'` to `rows.configPolicy` (the resolver joins on `configurationPolicies.status = 'active'`, `featureConfigResolver.ts:1057`, so an inactive policy resolves nothing). Fix it in `buildHpCmslPolicyRows` and add an assertion for it to the unit test rather than patching only the insert.
+
+- [ ] **Step 5: Run the unit test, expect PASS**
+
+```bash
+cd apps/api && npx vitest run src/services/hpCmslPolicyProvisioning.test.ts
+```
+
+Expected: PASS, 4 tests.
+
+- [ ] **Step 6: Write and run the real-DB integration test**
+
+Create `apps/api/src/__tests__/integration/hpCmslPolicyProvisioning.integration.test.ts`:
+
+```ts
+/**
+ * Real-DB provisioning of the built-in HP CMSL policy pair (#5515, Task 9).
+ *
+ * Runs as breeze_app so the partner-axis RLS on software_policies,
+ * configuration_policies and config_policy_feature_links is genuinely
+ * exercised, and so the XOR owner CHECKs on both policy tables are hit.
+ */
+import './setup';
+import { describe, it, expect } from 'vitest';
+import { and, eq, isNull } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../../db';
+import {
+  configPolicyAssignments,
+  configPolicyFeatureLinks,
+  configurationPolicies,
+  softwarePolicies,
+} from '../../db/schema';
+import { ensureBuiltinPackage } from '../../services/builtinDeploymentPackages';
+import {
+  ensureHpCmslSoftwarePolicy,
+  HP_CMSL_CONFIG_POLICY_NAME,
+  HP_CMSL_POLICY_NAME,
+} from '../../services/hpCmslPolicyProvisioning';
+import { createPartner } from './db-utils';
+
+describe('ensureHpCmslSoftwarePolicy (db)', () => {
+  it('creates the partner-owned policy pair, links them, and creates NO assignment', async () => {
+    const partner = await createPartner();
+    const { catalogId } = await ensureBuiltinPackage({ provider: 'hp_cmsl', partnerId: partner.id });
+
+    const { softwarePolicyId, configPolicyId } = await ensureHpCmslSoftwarePolicy({
+      partnerId: partner.id,
+      catalogId,
+    });
+
+    const { policies, configs, links, assignments } = await withSystemDbAccessContext(async () => {
+      const policies = await db
+        .select()
+        .from(softwarePolicies)
+        .where(and(
+          eq(softwarePolicies.partnerId, partner.id),
+          isNull(softwarePolicies.orgId),
+          eq(softwarePolicies.name, HP_CMSL_POLICY_NAME),
+        ));
+      const configs = await db
+        .select()
+        .from(configurationPolicies)
+        .where(and(
+          eq(configurationPolicies.partnerId, partner.id),
+          eq(configurationPolicies.name, HP_CMSL_CONFIG_POLICY_NAME),
+        ));
+      const links = await db
+        .select()
+        .from(configPolicyFeatureLinks)
+        .where(eq(configPolicyFeatureLinks.configPolicyId, configPolicyId));
+      const assignments = await db
+        .select()
+        .from(configPolicyAssignments)
+        .where(eq(configPolicyAssignments.configPolicyId, configPolicyId));
+      return { policies, configs, links, assignments };
+    });
+
+    expect(policies).toHaveLength(1);
+    expect(policies[0]!.id).toBe(softwarePolicyId);
+    expect(policies[0]!.orgId).toBeNull();
+    expect(policies[0]!.mode).toBe('allowlist');
+    expect(policies[0]!.enforceMode).toBe(true);
+    expect(policies[0]!.rules.allowUnknown).toBe(true);
+    expect(policies[0]!.rules.software[0]!.catalogId).toBe(catalogId);
+    expect(policies[0]!.remediationOptions).toMatchObject({ autoInstall: true });
+
+    expect(configs).toHaveLength(1);
+    expect(links).toHaveLength(1);
+    expect(links[0]!.featureType).toBe('software_policy');
+    expect(links[0]!.featurePolicyId).toBe(softwarePolicyId);
+
+    // The load-bearing one: Breeze must not decide where HP software lands.
+    expect(assignments).toHaveLength(0);
+  });
+
+  it('is idempotent and never duplicates the pair or the link', async () => {
+    const partner = await createPartner();
+    const { catalogId } = await ensureBuiltinPackage({ provider: 'hp_cmsl', partnerId: partner.id });
+
+    const first = await ensureHpCmslSoftwarePolicy({ partnerId: partner.id, catalogId });
+    const second = await ensureHpCmslSoftwarePolicy({ partnerId: partner.id, catalogId });
+
+    expect(second.softwarePolicyId).toBe(first.softwarePolicyId);
+    expect(second.configPolicyId).toBe(first.configPolicyId);
+
+    const links = await withSystemDbAccessContext(() =>
+      db
+        .select()
+        .from(configPolicyFeatureLinks)
+        .where(eq(configPolicyFeatureLinks.configPolicyId, first.configPolicyId)),
+    );
+    expect(links).toHaveLength(1);
+  });
+
+  it('does not survive a partner-scoped caller re-pointing the link (RLS + system-only writes)', async () => {
+    // An MSP-visible policy is fine; a Breeze-owned link that a partner can
+    // silently retarget is not. Re-provisioning restores it.
+    const partner = await createPartner();
+    const { catalogId } = await ensureBuiltinPackage({ provider: 'hp_cmsl', partnerId: partner.id });
+    const { softwarePolicyId, configPolicyId } = await ensureHpCmslSoftwarePolicy({
+      partnerId: partner.id,
+      catalogId,
+    });
+
+    await withSystemDbAccessContext(() =>
+      db
+        .update(configPolicyFeatureLinks)
+        .set({ featurePolicyId: null })
+        .where(eq(configPolicyFeatureLinks.configPolicyId, configPolicyId)),
+    );
+
+    await ensureHpCmslSoftwarePolicy({ partnerId: partner.id, catalogId });
+
+    const links = await withSystemDbAccessContext(() =>
+      db
+        .select()
+        .from(configPolicyFeatureLinks)
+        .where(eq(configPolicyFeatureLinks.configPolicyId, configPolicyId)),
+    );
+    expect(links).toHaveLength(1);
+    expect(links[0]!.featurePolicyId).toBe(softwarePolicyId);
+  });
+});
+```
+
+```bash
+cd apps/api && npx vitest run --config vitest.integration.config.ts src/__tests__/integration/hpCmslPolicyProvisioning.integration.test.ts
+```
+
+Expected: PASS, 3 tests. If the first run fails on an XOR CHECK (`software_policies_one_owner_chk` or `configuration_policies`' equivalent) or on a `NOT NULL status`, fix `buildHpCmslPolicyRows` and re-run the unit test too — the row shape is the unit test's subject.
+
+- [ ] **Step 7: Chain the policy provisioner after the package provisioner**
+
+In `apps/api/src/services/hpCmslProvisioning.ts`, extend the `try` block of `provisionHpCmslForFeatureLink`:
+
+```ts
+  try {
+    const { catalogId } = await ensureBuiltinPackage({ provider: 'hp_cmsl', partnerId });
+    // The catalog item alone installs nothing. The policy pair is what keeps
+    // CMSL present — but Breeze creates NO assignment for it; the MSP assigns
+    // the configuration policy to the orgs they enabled HP collection for.
+    // See services/hpCmslPolicyProvisioning.ts for why.
+    await ensureHpCmslSoftwarePolicy({ partnerId, catalogId });
+  } catch (error) {
+```
+
+and add the import:
+
+```ts
+import { ensureHpCmslSoftwarePolicy } from './hpCmslPolicyProvisioning';
+```
+
+Then extend `apps/api/src/services/hpCmslProvisioning.test.ts` — add the mock and one assertion:
+
+```ts
+const { ensureHpCmslSoftwarePolicyMock } = vi.hoisted(() => ({ ensureHpCmslSoftwarePolicyMock: vi.fn() }));
+vi.mock('./hpCmslPolicyProvisioning', () => ({ ensureHpCmslSoftwarePolicy: ensureHpCmslSoftwarePolicyMock }));
+```
+
+```ts
+  it('provisions the policy pair with the catalog id the package call returned', async () => {
+    ensureBuiltinPackageMock.mockResolvedValue({ catalogId: 'cat-hp' });
+    ensureHpCmslSoftwarePolicyMock.mockResolvedValue({ softwarePolicyId: 'sp-1', configPolicyId: 'cp-1' });
+
+    await provisionHpCmslForFeatureLink({
+      featureType: 'warranty',
+      inlineSettings: { hpCmsl: { enabled: true } },
+      policyPartnerId: PARTNER,
+      authPartnerId: null,
+      policyOrgId: null,
+    });
+
+    expect(ensureHpCmslSoftwarePolicyMock).toHaveBeenCalledWith({ partnerId: PARTNER, catalogId: 'cat-hp' });
+  });
+```
+
+Add `ensureHpCmslSoftwarePolicyMock.mockReset()` to that file's `beforeEach`.
+
+- [ ] **Step 8: Run everything this wave touched**
+
+```bash
+cd apps/api && npx vitest run \
+  src/services/hpCmslProvisioning.test.ts \
+  src/services/hpCmslPolicyProvisioning.test.ts \
+  src/services/builtinDeploymentPackages.test.ts \
+  src/services/edrInstallerResolver.test.ts \
+  src/services/softwareDeployment.test.ts \
+  src/routes/softwareInstallMethods.test.ts
+cd apps/api && npx vitest run --config vitest.integration.config.ts \
+  src/__tests__/integration/hpCmslBuiltinPackage.integration.test.ts \
+  src/__tests__/integration/hpCmslPolicyProvisioning.integration.test.ts \
+  src/__tests__/integration/builtinDeploymentPackages.integration.test.ts
+pnpm --filter @breeze/api exec tsc --noEmit
+```
+
+Expected: PASS / clean. Check the reported file counts.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/api/src/services/hpCmslPolicyProvisioning.ts \
+        apps/api/src/services/hpCmslPolicyProvisioning.test.ts \
+        apps/api/src/services/hpCmslProvisioning.ts \
+        apps/api/src/services/hpCmslProvisioning.test.ts \
+        apps/api/src/__tests__/integration/hpCmslPolicyProvisioning.integration.test.ts
+git commit -m "feat(warranty): built-in HP CMSL allowlist policy with autoInstall, assigned by the MSP (#5515)"
+```
+
+---
+
+## Pre-PR checklist
+
+- [ ] Gate 1: #5512's three lab answers are recorded on the issue, and Todd has ruled on the namespace-coverage question.
+- [ ] Gate 2 (Task 9 only): #5508 is merged, and `SoftwarePolicyRemediationOptions.autoInstall` plus its schema entry exist on `main`.
+- [ ] Migration filename still sorts after the newest file on `origin/main`:
+  ```bash
+  git fetch origin main && git diff --name-only origin/main -- apps/api/migrations/
+  ls apps/api/migrations/*.sql | sort | tail -3
+  ```
+  The pre-push hook re-checks against `origin/main` (`scripts/check-migration-naming.sh --against-ref origin/main`); a name that was fine at commit time can fail at push time.
+- [ ] Full API unit suite: `cd apps/api && npx vitest run`
+- [ ] Full web unit suite: `cd apps/web && npx vitest run`
+- [ ] Contract suites (live DB required; they run only in the **Integration Tests** CI job, so a locally-green branch proves nothing about them):
+  ```bash
+  cd apps/api && npx vitest run --config vitest.integration.config.ts src/__tests__/integration/rls-coverage.integration.test.ts src/__tests__/integration/tenantCascade.integration.test.ts src/__tests__/integration/tenant-export-policy.integration.test.ts
+  ```
+  Expected PASS with no edits: this wave adds no table and no column.
+- [ ] `pnpm lint`
+- [ ] Cross-tenant forge, by hand, as `breeze_app` — the CHECK widening did not touch RLS, but the new install-method write path is new:
+  ```bash
+  docker exec -it breeze-postgres psql -U breeze_app -d breeze
+  -- with no breeze.scope set, an insert naming another partner's built-in must fail
+  INSERT INTO software_install_methods (catalog_id, platform, kind, package_id)
+  VALUES ('<some other partner''s hp_cmsl catalog id>', 'windows', 'winget', 'Evil.Package');
+  -- expected: new row violates row-level security policy
+  ```
+- [ ] PR body states: (a) the install-method boundary decision and its reasoning; (b) that a partner-wide policy produces one deployment run per organisation, inherent to the schema; (c) the open question on hardware-scoped policy targeting; (d) the EULA constraint, so no reviewer suggests mirroring the installer.
+
+---
+
+## Self-review
+
+**1. Spec coverage (Layer 3 + the corrections section).**
+
+| Spec item | Task |
+|---|---|
+| DB CHECK widening, forward-only | 1 |
+| `BuiltinPackageDef` third arm ("do not force HP into an existing arm") | 2 |
+| `ensureBuiltinPackage` creates an install-method row, not a version row | 4 |
+| Install-method API boundary — "decide which in the plan" | 4 (decision) + 5 (implementation) |
+| Install-method validation shape (`kind`, `winget`, `windows`, `HP.HPCMSL`) | 2 (definition), 4 (test), 5 (route) |
+| Web readiness separation + branding entry | 7, 8 |
+| Catalog renders with an `hp_cmsl` item (mandatory test) | 8 |
+| Keep HP out of the EDR secret branch | 3 |
+| `originalFileName` hardcode — "guard or fix it" | 2 (fixed: moved onto the def) |
+| Partner-wide allowlist policy, `catalogId` rule, `enforceMode`, `autoInstall` | 9 |
+| "one deployment run per organisation … say so" | 9 (module docstring + PR checklist) |
+| EULA: never mirror or host the installer | Gates section + Task 2 code comment |
+| Targeting via `osType` / `hardware.manufacturer` | 9 — **spec claim does not hold for software policies; corrected, with the alternative recorded as an open question for Todd** |
+
+No spec item is unassigned.
+
+**2. Placeholder scan.** No `TBD`, no "similar to Task N", no "add appropriate error handling". Every code step carries complete code. Two places defer to a runtime observation rather than inventing a value, and both say so explicitly and carry a fallback: Task 9's `HP_CMSL_RULE_NAME` wildcard (the exact Add/Remove Programs DisplayName is W01 gate question 3) and Task 9 Step 4's note to confirm `configurationPolicies`' required columns. Neither is a placeholder — both are named unknowns with a stated default and a test.
+
+**3. Type consistency.** `BuiltinEdrProvider` / `BuiltinProvider` (Task 2) are consumed by name in Tasks 3 and 4. `installSource` is spelled identically in Tasks 2 and 4 and in the tests. `BuiltinInstallMethodDef`'s field names (`platform`, `kind`, `packageId`) match `software_install_methods` columns and `installMethodBodySchema`. `EdrProvider` / `IntegrationProvider` / `isEdrProvider` (Task 7) are consumed by name in Task 8. `warrantyLinkEnablesHpCmsl` and `provisionHpCmslForFeatureLink` (Task 6) match their call sites and Task 9's extension. `ensureHpCmslSoftwarePolicy(params: { partnerId, catalogId })` returns `{ softwarePolicyId, configPolicyId }` in the implementation, the unit test and the integration test. `ensureBuiltinPackage` keeps its existing `{ provider, partnerId } → { catalogId }` signature throughout.
+
+**4. Contract facts found wrong (reported, plan written to the corrected facts).** `filterEngine.ts:88`/`:94` are off by one (real: `:89`, `:95`). The spec's `software.ts:287` for the unimplemented `sites` targeting is wrong (real: `:400-405`). The claim that `hardware.manufacturer` targeting is available to a software policy is wrong — it is available to deployments only. The claim that adding `hp_cmsl` to `INTEGRATION_PROVIDERS` crashes the catalog is conditional: `SoftwareCatalog.tsx:271-275` currently narrows it away, so the first symptom is a silent misrender, and the crash only appears once that line is widened. Everything else the contract asserts was re-opened and confirmed.

--- a/docs/superpowers/plans/device-lifecycle/2026-09-10-hp-warranty-cmsl-w05-cleanup-and-docs.md
+++ b/docs/superpowers/plans/device-lifecycle/2026-09-10-hp-warranty-cmsl-w05-cleanup-and-docs.md
@@ -1,0 +1,742 @@
+---
+tracking_issue: LanternOps/breeze#5511
+---
+
+# HP Warranty via HP CMSL — W05: Cleanup and Docs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the dead, deliberately-unregistered HP warranty provider (`hpProvider.ts`) and its unique dependencies now that HP coverage comes from the agent-collected CMSL path, add the missing `agent_cmsl` (and `import`) data-source labels to the device warranty card, and correct the two docs pages that still say "HP has no lookup."
+
+**Architecture:** Pure cleanup — no new runtime behavior. Delete one module and its now-orphaned rate limiter, shrink one comment and one test file to match, extend a `switch` statement by two cases, and edit two Starlight docs pages.
+
+**Tech Stack:** TypeScript (Hono API service layer), React (Astro island), Vitest, Starlight/Astro docs.
+
+**Spec:** `docs/superpowers/specs/device-lifecycle/2026-09-10-hp-warranty-cmsl-design.md` (see its "Layer 7 — UI and cleanup" section and "Corrections after ground-truth verification"). Cross-wave contract (authoritative on conflicts): `/private/tmp/claude-501/-Users-toddhebebrand--herdr-worktrees-breeze-warranty-testing/4b860881-d3d0-4020-ad1e-65daf215df86/scratchpad/contract-B-hp-cmsl.md`, wave ownership map.
+
+## GATE — read this before starting Task 2
+
+**None of the deletion work in this plan may run until the new HP-CMSL path has actually landed and is verified working.** The comment this wave deletes (`warrantyProviders/index.ts:7-11`) says so explicitly today: *"HP coverage is coming from the agent instead. The module is kept (and unit-tested) until that lands."* Deleting `hpProvider.ts` before W01–W04 (#5512–#5515) ship would leave HP devices with **no path at all** — not the old broken one, not the new one.
+
+Task 1 below is a hard, mechanical gate check. If it fails, **stop the plan** — do not execute Task 2, 3, or 4 — and report which prerequisite is missing. Tasks 3 (web label) and 4 (docs) are also gated the same way: they describe the new agent-collected path as live, which is false until W02–W04 ship.
+
+## Global Constraints
+
+- **Tracking:** `LanternOps/breeze#5511` (parent), this plan implements wave `#5516` (W05).
+- **Wave ownership (from the cross-wave contract):** W05 owns *only*: deleting `hpProvider.ts`, `HP_WARRANTY_ENABLED`, the throttle references, and `hpRateLimiter` if unused; the `agent_cmsl` label in `DeviceWarrantyCard.tsx`; `warranty-tracking.mdx`. W05 must **not** touch config policy, agent code, the catalog/built-in package, or `warrantySync.ts` — those belong to W01–W04.
+- **Ground truth, verified 2026-09-10 (re-confirm only if a cited file has moved):**
+  - `hpProvider.ts` exports exactly one symbol, `hpProvider` (`:4`).
+  - `hpProvider.ts` is referenced from exactly three other places in the repo: `warrantyProviders/index.ts:7` (a comment only — never registered/imported), `warrantyProviderThrottle.test.ts:19,42,43,44,50,55` (import + 3 HP-specific `it` bodies).
+  - `hpRateLimiter` (`throttle.ts:48`) is referenced from exactly two other places: `hpProvider.ts:2,25` and `warrantyProviderThrottle.test.ts:14` (a `vi.mock` factory entry). Nothing else in `apps/api`, `apps/web`, or `packages/shared` imports it — `dellProvider.ts` uses no rate limiter at all (official OAuth API), and `lenovoProvider.ts` uses only `lenovoRateLimiter`. **Confirmed safe to delete alongside `hpProvider.ts`.**
+  - `HP_WARRANTY_ENABLED` is read at exactly one place in the whole repo, `hpProvider.ts:13`. It appears in no `.env.example` (root or any app), no `docker-compose*.yml`, and no `.github/` CI config — confirmed by repo-wide grep. Deleting `hpProvider.ts` removes every reference; no separate deletion step is needed.
+  - `DeviceWarrantyCard.tsx`'s `dataSourceLabel` function (`:60-67`) falls through to the **raw string** for any unrecognized `dataSource` (`:65`, `default: return source;`). Today `'agent_cmsl'` and `'import'` are both unrecognized and would render literally.
+  - `'import'` is written by `apps/api/src/services/customFields/import/warrantyTarget.ts:216` (`dataSource: 'import' as const`) — an existing, already-shipped data source, unrelated to this feature, that happens to share the same unhandled-fallback bug. **Decision: fix it in the same pass** (Task 3) — it's the same one-line `switch` statement, the same bug class the task is already touching, and leaving it half-fixed would mean re-opening this exact function in a future PR for one more `case`.
+  - `apps/docs/src/content/docs/features/warranty-tracking.mdx:14` says *"HP has no lookup yet, so HP devices stay `unknown`."*
+  - **Additional finding, in scope:** `apps/docs/src/content/docs/deploy/environment.mdx:790` (inside the Lenovo `<Aside>` in the "Warranty lookups" section) also says *"HP has no lookup yet — HP's Warranty API is not available to MSP or RMM vendors, so HP devices stay `unknown`."* `warranty-tracking.mdx:14` itself sends readers here ("Vendor configuration is described under Environment → Warranty lookups"), so leaving this stale would make the two pages contradict each other the moment `warranty-tracking.mdx` is fixed. In scope for Task 4.
+- **Testing command trap:** Never `pnpm --filter <pkg> test -- --run <path>` — the `--` token breaks vitest's flag parsing and it silently runs the whole suite in watch mode. Use `cd apps/api && npx vitest run <path>` / `cd apps/web && npx vitest run <path>`.
+- **No migration needed.** This wave touches no database schema — `HP_WARRANTY_ENABLED` is a process env var, and the data-source values (`agent_cmsl`, `import`) already exist as free-form strings against a `varchar(50)` column with no CHECK constraint.
+- **No placeholders.** Every step below shows the exact file content, not a description of it.
+
+---
+
+## 0. Ground truth
+
+### `apps/api/src/services/warrantyProviders/hpProvider.ts` (95 lines, to be deleted in full)
+
+```ts
+1  import type { WarrantyProvider, WarrantyLookupResult, WarrantyEntitlement } from './types';
+2  import { hpRateLimiter } from './throttle';
+3
+4  export const hpProvider: WarrantyProvider = {
+5    name: 'hp',
+6
+7    supports(manufacturer: string): boolean {
+8      const lower = manufacturer.toLowerCase();
+9      return lower.includes('hp') || lower.includes('hewlett');
+10   },
+11
+12   isConfigured(): boolean {
+13     const enabled = process.env.HP_WARRANTY_ENABLED;
+14     // Opt-in only — requires explicit enable (consistent with Dell/Lenovo credential requirements)
+15     return enabled === 'true' || enabled === '1';
+16   },
+17
+18   async lookup(serialNumbers: string[]): Promise<Map<string, WarrantyLookupResult>> {
+     ... (fetches https://support.hp.com/hp-pps-api/os/getWarrantyInfo, rate-limited via hpRateLimiter)
+95 };
+```
+`isConfigured()` (`:12-16`) is the sole reader of `HP_WARRANTY_ENABLED`. `lookup()` (`:18-94`) is the sole caller of `hpRateLimiter.acquire()`.
+
+### `apps/api/src/services/warrantyProviders/index.ts` (34 lines, comment + array to edit)
+
+```ts
+1  import type { WarrantyProvider } from './types';
+2  import { dellProvider } from './dellProvider';
+3  import { lenovoProvider } from './lenovoProvider';
+4
+5  export type { WarrantyProvider, WarrantyLookupResult, WarrantyEntitlement } from './types';
+6
+7  // hpProvider is deliberately NOT registered: its unofficial support.hp.com
+8  // endpoint now returns the site's HTML shell (verified 2026-09-09) and HP's real
+9  // backend is captcha-gated, so enabling it only parks devices in `unknown` with
+10 // a JSON parse error. HP coverage is coming from the agent instead. The module
+11 // is kept (and unit-tested) until that lands.
+12 const providers: WarrantyProvider[] = [dellProvider, lenovoProvider];
+13
+14 export function normalizeManufacturer(raw: string): string {
+15   const lower = raw.toLowerCase().trim();
+16   if (lower.includes('apple')) return 'apple';
+17   if (lower.includes('dell')) return 'dell';
+18   if (lower.includes('hp') || lower.includes('hewlett')) return 'hp';
+19   if (lower.includes('lenovo')) return 'lenovo';
+20   return lower.replace(/[^a-z0-9]/g, '');
+21 }
+22
+23 export function getProviderForManufacturer(manufacturer: string): WarrantyProvider | null {
+    ...
+30 }
+31
+32 export function getConfiguredProviders(): WarrantyProvider[] {
+33   return providers.filter((p) => p.isConfigured());
+34 }
+```
+`hpProvider` is never imported here — `providers` (`:12`) already omits it. Only the comment (`:7-11`) references the (soon-deleted) module by name and needs rewriting; `normalizeManufacturer` (`:14-21`) already collapses `hp`/`hewlett` → `'hp'` and is untouched — it's used by the agent-reported `manufacturer` field too, not just this file's own providers.
+
+### `apps/api/src/services/warrantyProviders/throttle.ts` (49 lines)
+
+```ts
+1  // Per-provider request rate limiter for the third-party warranty lookups (HP's
+2  // unofficial support endpoint, Lenovo's pcsupport API).
+...
+44 export const WARRANTY_LOOKUP_MIN_INTERVAL_MS = 250;
+45
+46 // One limiter per provider — they hit different vendors, so their rate limits
+47 // are independent.
+48 export const hpRateLimiter = createWarrantyRateLimiter(WARRANTY_LOOKUP_MIN_INTERVAL_MS);
+49 export const lenovoRateLimiter = createWarrantyRateLimiter(WARRANTY_LOOKUP_MIN_INTERVAL_MS);
+```
+Line 48 (`hpRateLimiter`) is the only HP-specific line; `createWarrantyRateLimiter`, `WarrantyRateLimiter`, and `WARRANTY_LOOKUP_MIN_INTERVAL_MS` are generic and stay, still used by `lenovoRateLimiter` (`:49`) and, through it, `lenovoProvider.ts:2,338,356`.
+
+### `apps/api/src/services/warrantyProviders/warrantyProviderThrottle.test.ts` (105 lines)
+
+Full current content (reproduced because Task 2 rewrites most of it):
+
+```ts
+1   import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+2
+3   // Spy on the per-provider limiter INSTANCES so we can prove the providers
+4   // acquire once per vendor fetch, while keeping the real createWarrantyRateLimiter
+5   // for the spacing unit test below.
+6   const { hpAcquire, lenovoAcquire } = vi.hoisted(() => ({
+7     hpAcquire: vi.fn().mockResolvedValue(undefined),
+8     lenovoAcquire: vi.fn().mockResolvedValue(undefined),
+9   }));
+10  vi.mock('./throttle', async (importOriginal) => {
+11    const actual = await importOriginal<typeof import('./throttle')>();
+12    return {
+13      ...actual,
+14      hpRateLimiter: { acquire: hpAcquire },
+15      lenovoRateLimiter: { acquire: lenovoAcquire },
+16    };
+17  });
+18
+19  import { hpProvider } from './hpProvider';
+20  import { lenovoProvider } from './lenovoProvider';
+21  import { createWarrantyRateLimiter } from './throttle';
+...
+37  describe('warranty provider request throttling (#3201)', () => {
+38    // ... 3 HP its at lines 41-57 (acquires per call, per serial, no-serials-no-acquire)
+59    // ... 2 Lenovo its at lines 59-73
+75  });
+76
+77  describe('createWarrantyRateLimiter', () => {
+    // ... 1 generic it, lines 77-104, no HP/Lenovo dependency
+105 });
+```
+Lines needing to change: `6-9` (drop `hpAcquire`), `14` (drop the `hpRateLimiter` mock entry), `19` (drop the `hpProvider` import), `27` (drop `hpAcquire.mockClear()` in `beforeEach`), and the three HP `it`s inside the first `describe` (`41-57`). The two Lenovo `it`s (`59-73`) and the entire `createWarrantyRateLimiter` `describe` (`77-104`) are untouched.
+
+### `apps/web/src/components/devices/DeviceWarrantyCard.tsx:60-67`
+
+```ts
+60 function dataSourceLabel(source: string | null): string {
+61   if (!source) return '';
+62   switch (source) {
+63     case 'agent_plist': return 'Agent (macOS plist)';
+64     case 'provider': return 'Vendor API';
+65     default: return source;
+66   }
+67 }
+```
+Called at `:357` as `dataSourceLabel(warranty.dataSource)`, rendered inside `t('deviceWarrantyCard.source', { source: ... })`. The i18n key resolves (`apps/web/src/locales/en/devices.json:1819`) to `"Source: {{source}}"` — the label itself is plain hardcoded English (matching the existing `'agent_plist'`/`'provider'` cases), not a translation key. The `warranty.dataSource` / `Source: ...` line only renders in the **full (non-compact)** card view (`:354-358`, inside the `// Full expanded view` return block) — `compact` mode never shows it.
+
+### `apps/web/src/components/devices/DeviceWarrantyCard.test.tsx`
+
+Existing pattern: a `warrantyPayload(overrides)` helper (`:40-57`) defaults `dataSource: 'provider'`; tests `render(<DeviceWarrantyCard deviceId={deviceId} />)` (full, non-compact by default) and assert on `screen`. No existing test covers `dataSourceLabel` / the "Source: ..." line at all.
+
+### `apps/docs/src/content/docs/features/warranty-tracking.mdx:14`
+
+```
+Breeze stores one warranty record per device (`device_warranty`) with the manufacturer, serial number, coverage status, and start/end dates. A background worker runs every 6 hours and re-checks each device about once every 7 days (50 devices per run), looking the serial number up against the vendor providers your instance has configured — Dell (official API credentials) and Lenovo (official API ClientID and/or the credential-free opt-in); Apple/AppleCare coverage is reported by the macOS agent. HP has no lookup yet, so HP devices stay `unknown`. Vendor configuration is described under [Environment → Warranty lookups](/deploy/environment/#warranty-lookups). The Warranty **tab does not set warranty dates** — it only configures the alert thresholds evaluated against whatever dates the sync has discovered. Devices whose warranty status is still `unknown`, or that have no end date, are skipped.
+```
+The page imports `{ Steps, Aside }` from `@astrojs/starlight/components` (`:6`) and already uses both — new content should reuse these, not introduce new components.
+
+### `apps/docs/src/content/docs/deploy/environment.mdx:778-791`
+
+```
+778 ## Warranty lookups
+779
+780 The warranty worker looks each physical device's serial number up against its manufacturer so the device page and [warranty-expiry alerts](/features/warranty-tracking/) carry real coverage dates. Every vendor is off until configured; an unconfigured vendor leaves its devices at status `unknown`. Apple coverage is reported by the macOS agent and needs no configuration.
+781
+782 | Variable | Default | Description |
+783 |---|---|---|
+784 | `DELL_CLIENT_ID` | — | OAuth client ID from Dell's [TechDirect](https://techdirect.dell.com) Warranty API |
+785 | `DELL_CLIENT_SECRET` | — | Matching Dell OAuth client secret. Both are required for Dell lookups. |
+786 | `LENOVO_API_KEY` | — | ClientID for Lenovo's official [Warranty API](https://supportapi.lenovo.com/Documentation/Warranty.html) (`supportapi.lenovo.com`), issued through a Lenovo partner manager |
+787 | `LENOVO_WARRANTY_ENABLED` | — | `true` enables credential-free Lenovo lookups through the JSON endpoint behind Lenovo's public warranty-lookup page. It is not documented by Lenovo and may stop working without notice, so it is opt-in. |
+788
+789 <Aside>
+790   When both Lenovo settings are present the official API is authoritative: a definite "no warranty found" from it is final, and the public endpoint is only consulted when the official call itself fails (bad key, outage). HP has no lookup yet — HP's Warranty API is not available to MSP or RMM vendors, so HP devices stay `unknown`.
+791 </Aside>
+```
+No `HP_*` row exists in the table (correctly — the agent-collected path is app-configured, not env-var-configured), so the fix is confined to the `<Aside>` prose.
+
+### Repo-wide grep hit lists (run 2026-09-10, sole basis for "safe to delete")
+
+```
+$ grep -rn "hpProvider" --include="*.ts" --include="*.tsx" apps/ packages/
+apps/api/src/services/warrantyProviders/hpProvider.ts:4:export const hpProvider: WarrantyProvider = {
+apps/api/src/services/warrantyProviders/warrantyProviderThrottle.test.ts:19:import { hpProvider } from './hpProvider';
+apps/api/src/services/warrantyProviders/warrantyProviderThrottle.test.ts:42:    await hpProvider.lookup(['a']);
+apps/api/src/services/warrantyProviders/warrantyProviderThrottle.test.ts:43:    await hpProvider.lookup(['b']);
+apps/api/src/services/warrantyProviders/warrantyProviderThrottle.test.ts:44:    await hpProvider.lookup(['c']);
+apps/api/src/services/warrantyProviders/warrantyProviderThrottle.test.ts:50:    await hpProvider.lookup(['a', 'b']);
+apps/api/src/services/warrantyProviders/warrantyProviderThrottle.test.ts:55:    await hpProvider.lookup([]);
+apps/api/src/services/warrantyProviders/index.ts:7:// hpProvider is deliberately NOT registered: its unofficial support.hp.com
+
+$ grep -rn "hpRateLimiter" --include="*.ts" --include="*.tsx" apps/ packages/
+apps/api/src/services/warrantyProviders/warrantyProviderThrottle.test.ts:14:    hpRateLimiter: { acquire: hpAcquire },
+apps/api/src/services/warrantyProviders/throttle.ts:48:export const hpRateLimiter = createWarrantyRateLimiter(WARRANTY_LOOKUP_MIN_INTERVAL_MS);
+apps/api/src/services/warrantyProviders/hpProvider.ts:2:import { hpRateLimiter } from './throttle';
+apps/api/src/services/warrantyProviders/hpProvider.ts:25:      await hpRateLimiter.acquire();
+
+$ grep -rn "HP_WARRANTY_ENABLED" . --include="*.ts" --include="*.tsx" --include="*.env*" --include="*.yml" --include="*.yaml" --include="*.md"
+docs/superpowers/specs/device-lifecycle/2026-09-10-hp-warranty-cmsl-design.md:285: (the spec's own prose, not code)
+apps/api/src/services/warrantyProviders/hpProvider.ts:13:    const enabled = process.env.HP_WARRANTY_ENABLED;
+```
+Every hit in each list resolves inside a file this plan already touches. There is no fourth file anywhere in the repo.
+
+---
+
+## Task 1: Gate check — confirm the new HP CMSL path has actually landed
+
+**Files:** none modified. Read-only verification.
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks (this is the first task).
+- Produces: a go/no-go decision gating Tasks 2-4.
+
+- [ ] **Step 1: Check the built-in HP CMSL package landed (W04, #5515)**
+
+Run:
+```bash
+grep -n "hp_cmsl" apps/api/src/services/builtinDeploymentPackages.ts
+```
+Expected: at least one match (the third `BuiltinPackageDef` union arm / `BUILTIN_PACKAGES` entry). **If zero matches, STOP — do not proceed to Task 2.**
+
+- [ ] **Step 2: Check the agent collector landed (W03, #5514)**
+
+Run:
+```bash
+ls agent/internal/collectors/hp_warranty_windows.go agent/internal/collectors/hp_warranty_other.go
+```
+Expected: both files exist. **If either is missing, STOP.**
+
+- [ ] **Step 3: Check the agent config seam landed (W02, #5513)**
+
+Run:
+```bash
+ls agent/internal/heartbeat/warranty_config.go
+grep -n "hpCmsl\|hp_cmsl" apps/web/src/components/configurationPolicies/featureTabs/WarrantyTab.tsx
+```
+Expected: the file exists, and the grep returns at least one match (the opt-in checkbox / consent UI). **If either check comes back empty, STOP.**
+
+- [ ] **Step 4: Check the ingest hardening landed (W01, #5512)**
+
+Run:
+```bash
+grep -n "AGENT_OWNED_WARRANTY_SOURCES\|isAgentOwnedWarrantySource" apps/api/src/services/warrantySync.ts
+```
+Expected: at least one match. **If zero matches, STOP** — without this, deleting the old provider removes HP's only *server-side* path while the agent path still can't safely preserve its own rows.
+
+- [ ] **Step 5: Confirm the tracking sub-issues are closed**
+
+Run:
+```bash
+gh issue view 5512 --repo LanternOps/breeze --json state,title
+gh issue view 5513 --repo LanternOps/breeze --json state,title
+gh issue view 5514 --repo LanternOps/breeze --json state,title
+gh issue view 5515 --repo LanternOps/breeze --json state,title
+```
+Expected: `"state": "CLOSED"` on all four. If any is still `OPEN`, treat Steps 1-4 as the authoritative signal (code merged but issue not yet closed is a bookkeeping lag, not a blocker) — but if an issue is open **and** its corresponding code check in Steps 1-4 also failed, that confirms STOP is correct.
+
+- [ ] **Step 6: Record the outcome**
+
+If all of Steps 1-4 passed: proceed to Task 2. State in the wave's PR description (or issue #5516 comment) which commit/PR satisfied each check, so the eventual reviewer doesn't have to re-derive it.
+
+If any check failed: do not touch any file. Report exactly which wave is missing (W01/W02/W03/W04) and stop working this plan until it lands — re-run Task 1 later rather than guessing.
+
+---
+
+## Task 2: Delete `hpProvider.ts` and sweep every reference
+
+**Files:**
+- Delete: `apps/api/src/services/warrantyProviders/hpProvider.ts`
+- Modify: `apps/api/src/services/warrantyProviders/throttle.ts` (remove `hpRateLimiter`)
+- Modify: `apps/api/src/services/warrantyProviders/index.ts` (rewrite the non-registration comment)
+- Modify: `apps/api/src/services/warrantyProviders/warrantyProviderThrottle.test.ts` (drop HP-specific mocks/tests)
+- Test: `apps/api/src/services/warrantyProviders/warrantyProviderThrottle.test.ts` (same file — it IS the test)
+
+**Interfaces:**
+- Consumes: Task 1's go-ahead. Nothing else — this task has no dependency on any other wave's code beyond what Task 1 already confirmed exists.
+- Produces: nothing later tasks in this plan depend on (Tasks 3 and 4 touch unrelated files).
+
+- [ ] **Step 1: Baseline — confirm the current suite is green before touching anything**
+
+Run:
+```bash
+cd apps/api && npx vitest run src/services/warrantyProviders/warrantyProviderThrottle.test.ts
+```
+Expected: PASS, 6 tests (3 HP + 2 Lenovo in the first `describe`, 1 in `createWarrantyRateLimiter`).
+
+- [ ] **Step 2: Delete the module**
+
+```bash
+rm apps/api/src/services/warrantyProviders/hpProvider.ts
+```
+
+- [ ] **Step 3: Run the test file again to see the break the deletion causes**
+
+Run:
+```bash
+cd apps/api && npx vitest run src/services/warrantyProviders/warrantyProviderThrottle.test.ts
+```
+Expected: FAIL — module resolution error on `import { hpProvider } from './hpProvider'` (line 19), since the file no longer exists.
+
+- [ ] **Step 4: Rewrite the test file to drop every HP reference**
+
+Replace the full content of `apps/api/src/services/warrantyProviders/warrantyProviderThrottle.test.ts` with:
+
+```ts
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Spy on the per-provider limiter INSTANCE so we can prove the provider
+// acquires once per vendor fetch, while keeping the real createWarrantyRateLimiter
+// for the spacing unit test below.
+const { lenovoAcquire } = vi.hoisted(() => ({
+  lenovoAcquire: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('./throttle', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./throttle')>();
+  return {
+    ...actual,
+    lenovoRateLimiter: { acquire: lenovoAcquire },
+  };
+});
+
+import { lenovoProvider } from './lenovoProvider';
+import { createWarrantyRateLimiter } from './throttle';
+
+const okJson = (body: unknown) =>
+  ({ ok: true, status: 200, json: async () => body }) as unknown as Response;
+
+beforeEach(() => {
+  lenovoAcquire.mockClear();
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue(okJson({})));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+describe('warranty provider request throttling (#3201)', () => {
+  // The bug this guards: production calls lookup([oneSerial]) once per device, so
+  // the limiter MUST fire per fetch across separate calls — not just within one
+  // multi-serial call.
+  it('Lenovo: acquires the limiter on every request when configured', async () => {
+    vi.stubEnv('LENOVO_API_KEY', 'test-client-id');
+    vi.stubEnv('LENOVO_WARRANTY_ENABLED', '');
+    await lenovoProvider.lookup(['a']);
+    await lenovoProvider.lookup(['b']);
+    expect(lenovoAcquire).toHaveBeenCalledTimes(2);
+  });
+
+  it('Lenovo: no API key → no vendor calls and no acquire', async () => {
+    vi.stubEnv('LENOVO_API_KEY', '');
+    vi.stubEnv('LENOVO_WARRANTY_ENABLED', '');
+    await lenovoProvider.lookup(['a', 'b', 'c']);
+    expect(lenovoAcquire).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('createWarrantyRateLimiter', () => {
+  it('lets the first acquire through immediately but spaces the next by the interval', async () => {
+    vi.useFakeTimers();
+    // A realistic clock so the initial lastReleaseAt=0 makes the first wait
+    // negative (immediate), as in production.
+    vi.setSystemTime(1_700_000_000_000);
+    try {
+      const limiter = createWarrantyRateLimiter(250);
+
+      let firstDone = false;
+      limiter.acquire().then(() => {
+        firstDone = true;
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(firstDone).toBe(true);
+
+      let secondDone = false;
+      limiter.acquire().then(() => {
+        secondDone = true;
+      });
+      // Not yet — must wait out the interval.
+      await vi.advanceTimersByTimeAsync(100);
+      expect(secondDone).toBe(false);
+      await vi.advanceTimersByTimeAsync(200);
+      expect(secondDone).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+```
+
+- [ ] **Step 5: Remove `hpRateLimiter` from `throttle.ts`**
+
+In `apps/api/src/services/warrantyProviders/throttle.ts`, replace:
+
+```ts
+// Per-provider request rate limiter for the third-party warranty lookups (HP's
+// unofficial support endpoint, Lenovo's pcsupport API).
+```
+
+with:
+
+```ts
+// Per-provider request rate limiter for third-party warranty lookups (Lenovo's
+// pcsupport API and any future server-side vendor lookup).
+```
+
+and replace:
+
+```ts
+// One limiter per provider — they hit different vendors, so their rate limits
+// are independent.
+export const hpRateLimiter = createWarrantyRateLimiter(WARRANTY_LOOKUP_MIN_INTERVAL_MS);
+export const lenovoRateLimiter = createWarrantyRateLimiter(WARRANTY_LOOKUP_MIN_INTERVAL_MS);
+```
+
+with:
+
+```ts
+export const lenovoRateLimiter = createWarrantyRateLimiter(WARRANTY_LOOKUP_MIN_INTERVAL_MS);
+```
+
+`createWarrantyRateLimiter`, `WarrantyRateLimiter`, `WARRANTY_LOOKUP_MIN_INTERVAL_MS`, and `sleep` are untouched — they're generic and `lenovoRateLimiter` still depends on all three.
+
+- [ ] **Step 6: Rewrite the non-registration comment in `index.ts`**
+
+In `apps/api/src/services/warrantyProviders/index.ts`, replace:
+
+```ts
+// hpProvider is deliberately NOT registered: its unofficial support.hp.com
+// endpoint now returns the site's HTML shell (verified 2026-09-09) and HP's real
+// backend is captcha-gated, so enabling it only parks devices in `unknown` with
+// a JSON parse error. HP coverage is coming from the agent instead. The module
+// is kept (and unit-tested) until that lands.
+const providers: WarrantyProvider[] = [dellProvider, lenovoProvider];
+```
+
+with:
+
+```ts
+// HP has no entry in `providers`: HP's official Warranty API is closed to
+// MSP/RMM vendors, and the unofficial support.hp.com endpoint HP once exposed
+// now returns the site's HTML shell behind a captcha, not JSON — there is no
+// working server-side lookup to register. HP coverage instead comes from the
+// agent: it collects warranty and entitlement data on-device via HP's Client
+// Management Script Library and reports it through the normal agent
+// warranty-info ingest path (data source `agent_cmsl`), bypassing this
+// provider/lookup mechanism entirely. See
+// docs/superpowers/specs/device-lifecycle/2026-09-10-hp-warranty-cmsl-design.md.
+const providers: WarrantyProvider[] = [dellProvider, lenovoProvider];
+```
+
+- [ ] **Step 7: Run the test file again to confirm it's green**
+
+Run:
+```bash
+cd apps/api && npx vitest run src/services/warrantyProviders/warrantyProviderThrottle.test.ts
+```
+Expected: PASS, 3 tests (2 Lenovo + 1 `createWarrantyRateLimiter`).
+
+- [ ] **Step 8: Run the full warrantyProviders directory's tests to catch anything adjacent**
+
+Run:
+```bash
+cd apps/api && npx vitest run src/services/warrantyProviders
+```
+Expected: PASS — this also exercises `dellProvider.test.ts` / `lenovoProvider.test.ts` / `index.test.ts` if they exist, confirming nothing else in the directory referenced the deleted symbols.
+
+- [ ] **Step 9: Repo-wide grep sweep — prove zero remaining references**
+
+Run:
+```bash
+grep -rn "hpProvider\|hpRateLimiter\|HP_WARRANTY_ENABLED" apps/ packages/ --include="*.ts" --include="*.tsx"
+```
+Expected: **no output**. If anything prints, it is a reference this plan's ground-truth pass missed — stop and fix it before committing (do not silently ignore it; the whole point of this wave is not missing one).
+
+- [ ] **Step 10: Typecheck the API package as a belt-and-suspenders check**
+
+Run:
+```bash
+cd apps/api && npx tsc --noEmit
+```
+Expected: no new errors attributable to this change (pre-existing unrelated errors, if any, are out of scope — compare against a baseline run on `main` if unsure).
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add apps/api/src/services/warrantyProviders/hpProvider.ts \
+  apps/api/src/services/warrantyProviders/throttle.ts \
+  apps/api/src/services/warrantyProviders/index.ts \
+  apps/api/src/services/warrantyProviders/warrantyProviderThrottle.test.ts
+git commit -m "chore(api): delete dead hpProvider now the agent CMSL path has landed
+
+HP warranty coverage moved to the agent-collected HP CMSL path (#5511).
+hpProvider.ts was deliberately unregistered and kept only until that
+path shipped; it's gone now, along with its unique HP_WARRANTY_ENABLED
+flag and hpRateLimiter (unused by anything else)."
+```
+(Note: this repository's own `hpProvider.ts` deletion is itself a `git rm` picked up by `git add` on the removed path — running `git add` on a deleted file stages the deletion.)
+
+---
+
+## Task 3: Add `agent_cmsl` and `import` data-source labels
+
+**Files:**
+- Modify: `apps/web/src/components/devices/DeviceWarrantyCard.tsx:60-67`
+- Test: `apps/web/src/components/devices/DeviceWarrantyCard.test.tsx`
+
+**Interfaces:**
+- Consumes: nothing from Task 2 — independent file, independent package (`apps/web` vs `apps/api`).
+- Produces: nothing later tasks depend on.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add this new `describe` block to the end of `apps/web/src/components/devices/DeviceWarrantyCard.test.tsx`, just before the file's closing (after the existing `describe('DeviceWarrantyCard — refresh feedback (#1723)', ...)` block, same top-level nesting):
+
+```tsx
+describe('DeviceWarrantyCard — data source labels', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('labels an agent_cmsl row as "Agent (HP CMSL)"', async () => {
+    fetchWithAuthMock.mockImplementation(async () =>
+      jsonResponse(warrantyPayload({ dataSource: 'agent_cmsl' }))
+    );
+
+    render(<DeviceWarrantyCard deviceId={deviceId} />);
+
+    await screen.findByText('Source: Agent (HP CMSL)');
+  });
+
+  it('labels an import row as "CSV Import"', async () => {
+    fetchWithAuthMock.mockImplementation(async () =>
+      jsonResponse(warrantyPayload({ dataSource: 'import' }))
+    );
+
+    render(<DeviceWarrantyCard deviceId={deviceId} />);
+
+    await screen.findByText('Source: CSV Import');
+  });
+
+  it('still falls through to the raw string for a genuinely unknown source', async () => {
+    fetchWithAuthMock.mockImplementation(async () =>
+      jsonResponse(warrantyPayload({ dataSource: 'some_future_source' }))
+    );
+
+    render(<DeviceWarrantyCard deviceId={deviceId} />);
+
+    await screen.findByText('Source: some_future_source');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test file to confirm the new tests fail**
+
+Run:
+```bash
+cd apps/web && npx vitest run src/components/devices/DeviceWarrantyCard.test.tsx
+```
+Expected: the first two new tests FAIL (current code renders `'Source: agent_cmsl'` and `'Source: import'` literally — the text the test looks for doesn't exist), the third new test PASSES (it's asserting today's actual fallback behavior), and all pre-existing tests still PASS.
+
+- [ ] **Step 3: Implement the label additions**
+
+In `apps/web/src/components/devices/DeviceWarrantyCard.tsx`, replace:
+
+```ts
+function dataSourceLabel(source: string | null): string {
+  if (!source) return '';
+  switch (source) {
+    case 'agent_plist': return 'Agent (macOS plist)';
+    case 'provider': return 'Vendor API';
+    default: return source;
+  }
+}
+```
+
+with:
+
+```ts
+function dataSourceLabel(source: string | null): string {
+  if (!source) return '';
+  switch (source) {
+    case 'agent_plist': return 'Agent (macOS plist)';
+    case 'agent_cmsl': return 'Agent (HP CMSL)';
+    case 'provider': return 'Vendor API';
+    case 'import': return 'CSV Import';
+    default: return source;
+  }
+}
+```
+
+- [ ] **Step 4: Run the test file again to confirm everything passes**
+
+Run:
+```bash
+cd apps/web && npx vitest run src/components/devices/DeviceWarrantyCard.test.tsx
+```
+Expected: PASS, all tests including the three new ones and every pre-existing test in the file.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/devices/DeviceWarrantyCard.tsx \
+  apps/web/src/components/devices/DeviceWarrantyCard.test.tsx
+git commit -m "fix(web): label agent_cmsl and import warranty data sources
+
+Both previously fell through to the raw string ('agent_cmsl', 'import')
+in the device warranty card's source line. agent_cmsl is the new
+HP-CMSL agent-collected source (#5511); import was an existing,
+unrelated gap in the same fallback."
+```
+
+---
+
+## Task 4: Fix the two stale "HP has no lookup" docs pages
+
+**Files:**
+- Modify: `apps/docs/src/content/docs/features/warranty-tracking.mdx`
+- Modify: `apps/docs/src/content/docs/deploy/environment.mdx`
+
+**Interfaces:**
+- Consumes: nothing from Tasks 2-3 — pure prose, no code dependency. (Documenting a UI checkbox that Task 1 already confirmed exists.)
+- Produces: nothing later tasks depend on.
+
+This is **Manual Mode** under the `update-breeze-docs` skill: a specific, known-stale doc, not a diff-driven sweep. Both pages are in the `features/` and `deploy/` sections respectively — audience is MSP technicians and sysadmins deploying/configuring Breeze, so write in product language (HP's CMSL, the consent checkbox, what happens on the endpoint), not implementation language (no `hpCmsl` JSON key names, no `warrantySync.ts`, no `data_source` column name — that's why the label in Task 3 said "Agent (HP CMSL)" and this doc should say the same, not `agent_cmsl`).
+
+- [ ] **Step 1: Update `warranty-tracking.mdx` — replace the stale HP sentence**
+
+In `apps/docs/src/content/docs/features/warranty-tracking.mdx`, in the "## Where warranty dates come from" section, replace:
+
+```
+Breeze stores one warranty record per device (`device_warranty`) with the manufacturer, serial number, coverage status, and start/end dates. A background worker runs every 6 hours and re-checks each device about once every 7 days (50 devices per run), looking the serial number up against the vendor providers your instance has configured — Dell (official API credentials) and Lenovo (official API ClientID and/or the credential-free opt-in); Apple/AppleCare coverage is reported by the macOS agent. HP has no lookup yet, so HP devices stay `unknown`. Vendor configuration is described under [Environment → Warranty lookups](/deploy/environment/#warranty-lookups). The Warranty **tab does not set warranty dates** — it only configures the alert thresholds evaluated against whatever dates the sync has discovered. Devices whose warranty status is still `unknown`, or that have no end date, are skipped.
+```
+
+with:
+
+```
+Breeze stores one warranty record per device (`device_warranty`) with the manufacturer, serial number, coverage status, and start/end dates. A background worker runs every 6 hours and re-checks each device about once every 7 days (50 devices per run), looking the serial number up against the vendor providers your instance has configured — Dell (official API credentials) and Lenovo (official API ClientID and/or the credential-free opt-in); Apple/AppleCare coverage is reported by the macOS agent. HP works differently — see [HP warranty collection](#hp-warranty-collection-opt-in) below. Vendor configuration for Dell and Lenovo is described under [Environment → Warranty lookups](/deploy/environment/#warranty-lookups). The Warranty **tab does not set warranty dates** — it only configures the alert thresholds evaluated against whatever dates the sync has discovered. Devices whose warranty status is still `unknown`, or that have no end date, are skipped.
+```
+
+- [ ] **Step 2: Add a new "HP warranty collection" section**
+
+Insert this new section into `apps/docs/src/content/docs/features/warranty-tracking.mdx` immediately after the closing `</Aside>` of the existing AppleCare note and before `## Configure in a policy` (i.e., right after line 18 in the current file):
+
+```mdx
+## HP warranty collection (opt-in)
+
+HP's official Warranty API isn't available to MSP or RMM vendors, so there's no server-side HP lookup the way there is for Dell and Lenovo. Instead, HP coverage is collected **directly on the device** using HP's own Client Management Script Library (CMSL) — the same tool HP ships to IT teams for this purpose.
+
+This is off by default and must be turned on per policy, on the same Warranty tab used for alert thresholds:
+
+<Steps>
+
+1. Open the policy's **Warranty** tab and toggle **Enable HP CMSL collection** on.
+
+2. Accept HP's CMSL licence when prompted. Breeze records who accepted it and when.
+
+3. **Save** and assign the policy. Devices covered by the policy install HP's CMSL software (about 100 MB) the next time they check in, then read HP's own warranty data from the device and report it back to Breeze. A device that already has this data cached locally reports it without a fresh HP lookup.
+
+</Steps>
+
+<Aside type="caution">
+Turning this on installs HP's software on every HP endpoint the policy covers, under HP's own licence — not Breeze's. That licence permits HP to collect technical information from the device, including its IP address. Because this causes software installation, enabling it requires the **Execute Devices** permission and multi-factor authentication, the same gate as any other software deployment.
+</Aside>
+
+Devices collected this way show **Agent (HP CMSL)** as their warranty data source on the device page.
+```
+
+- [ ] **Step 3: Update `environment.mdx`'s stale Aside**
+
+In `apps/docs/src/content/docs/deploy/environment.mdx`, in the "## Warranty lookups" section, replace:
+
+```
+<Aside>
+  When both Lenovo settings are present the official API is authoritative: a definite "no warranty found" from it is final, and the public endpoint is only consulted when the official call itself fails (bad key, outage). HP has no lookup yet — HP's Warranty API is not available to MSP or RMM vendors, so HP devices stay `unknown`.
+</Aside>
+```
+
+with:
+
+```
+<Aside>
+  When both Lenovo settings are present the official API is authoritative: a definite "no warranty found" from it is final, and the public endpoint is only consulted when the official call itself fails (bad key, outage). HP's official Warranty API is still not available to MSP or RMM vendors, so there's no `HP_*` variable to set here. HP coverage instead comes from an opt-in, agent-collected path — see [HP warranty collection](/features/warranty-tracking/#hp-warranty-collection-opt-in), configured per policy rather than by environment variable.
+</Aside>
+```
+
+- [ ] **Step 4: Build-verify both docs pages**
+
+Run:
+```bash
+cd apps/docs && npx astro build 2>&1 | tail -30
+```
+Expected: build succeeds with no new errors (a broken `<Steps>`/`<Aside>` tag or bad frontmatter would fail here). If it fails, fix the MDX before proceeding — do not commit a broken docs build.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/docs/src/content/docs/features/warranty-tracking.mdx \
+  apps/docs/src/content/docs/deploy/environment.mdx
+git commit -m "docs: describe the agent-collected HP warranty path
+
+Both warranty-tracking.mdx and environment.mdx still said 'HP has no
+lookup yet.' HP coverage now comes from an opt-in, agent-collected
+path using HP's own CMSL (#5511); document the opt-in checkbox,
+consent, and the licence/IP-collection caveat."
+```
+
+---
+
+## Self-review
+
+**1. Spec/contract coverage.** Every bullet in the spec's "Layer 7 — UI and cleanup" and the contract's W05 ownership row is covered: `hpProvider.ts` deletion (Task 2), throttle/`hpRateLimiter` sweep (Task 2), `index.ts` comment rewrite (Task 2), `HP_WARRANTY_ENABLED` removal (Task 2, automatic via file deletion, confirmed by grep), `agent_cmsl` label (Task 3), `warranty-tracking.mdx` (Task 4). The gate stated in both the user's brief and the module's own comment is enforced as Task 1, not left as an unstated assumption. The `'import'` fallback bug and the `environment.mdx` staleness were both found during the ground-truth pass and folded in with explicit reasoning rather than silently expanded scope.
+
+**2. Placeholder scan.** Every step shows complete file content or an exact, runnable diff — no "add appropriate handling," no "similar to Task N," no elided code. The one intentionally-elided block is the `hpProvider.ts` `lookup()` body in the Ground Truth section (already fully quoted earlier in this same conversation's research and irrelevant to reconstruct since the whole file is simply deleted, never edited).
+
+**3. Type/name consistency.** `dataSourceLabel` (Task 3) is referenced with the same signature (`(source: string | null): string`) as it already has — no rename. `hpRateLimiter`, `hpProvider`, `HP_WARRANTY_ENABLED` are named identically to their current declarations throughout Tasks 1-2, matching the grep hit list in Global Constraints exactly. `AGENT_OWNED_WARRANTY_SOURCES` / `isAgentOwnedWarrantySource` (Task 1's gate check) are named exactly as the cross-wave contract's D9 specifies, since Task 1 is checking for W01's output, not defining anything itself.
+
+**4. Task independence.** Tasks 2, 3, and 4 touch disjoint files (`apps/api/.../warrantyProviders/*` vs `apps/web/.../DeviceWarrantyCard.*` vs `apps/docs/.../*.mdx`) and none produces an interface another consumes — they can run in any order after Task 1 passes, including in parallel across subagents.

--- a/docs/superpowers/plans/vuln-patch/2026-09-10-desired-state-software-install-w01-arming-and-authorization.md
+++ b/docs/superpowers/plans/vuln-patch/2026-09-10-desired-state-software-install-w01-arming-and-authorization.md
@@ -1,0 +1,1957 @@
+---
+tracking_issue: LanternOps/breeze#5505
+---
+
+# Wave 01 — Arming: `autoInstall`, verb-aware arming, install authorization, audit actions, violation `catalogId` — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a software policy *expressible* and *authorizable* as "install this" — add the `autoInstall` arming flag end-to-end through the type and both HTTP schemas, turn the single-verb arming gate into a verb-aware one, gate arming behind deployment-grade authorization (`devices.execute` + MFA) evaluated over post-write merged state, create the four install audit-action constants, and put `catalogId` on the `missing` violation so a later wave has something to install. **Nothing dispatches an install in this wave.**
+
+**Architecture:** Five independent, small surfaces in `apps/api`. `SoftwarePolicyRemediationOptions` gains `autoInstall?: boolean`, and the single shared `remediationOptionsSchema` (consumed by both `createPolicySchema` and `updatePolicySchema`) gains the matching zod field — without it a non-strict `z.object` silently strips the key. `evaluateSoftwarePolicyArming` gains a **required** second parameter `verb: 'uninstall' | 'install'` so the compiler finds every existing caller, and its three refusal messages become verb-aware. A new service `softwarePolicyAuthorization.ts` computes whether a write leaves the policy armed for install from the merged (stored row ⊕ request body) state and refuses without `devices.execute` + satisfied MFA. Four exported audit-action constants become the registry for install events (the column is a bare `varchar(50)` with no enum). Finally the `missing` violation emission carries `catalogId`/`reason`, which W02/W03 need to resolve what to install.
+
+**Tech Stack:** Hono + Drizzle ORM + PostgreSQL, zod, Vitest (unit only — this wave adds no migration and no integration suite).
+
+**Spec:** `docs/superpowers/specs/vuln-patch/2026-09-10-desired-state-software-install-design.md` — §1 (`autoInstall`), §5 (Authorization), §6 (Audit), plus the "Corrections after ground-truth verification" section, which supersedes the body. **NOT** §2 (compliance-worker branch), §3 (dispatch/deployment coupling), §4 (resolving what to install) — those are W02/W03.
+
+**Cross-wave contract:** `contract-A-desired-state.md` (coordinator, authoritative). This wave implements D2, D3, D6, D9 and the `autoInstall` half of §1.
+
+**Depends on:** nothing. W02 (#5507), W03 (#5508) and W05 (#5510) all consume interfaces this wave produces.
+
+---
+
+## Global Constraints
+
+Copied from the cross-wave contract. These are locked; do not rename, re-shape, or re-decide any of them.
+
+- **D2 — the arming helper gains a verb; it keeps its real name.**
+  ```ts
+  export type PolicyRemediationVerb = 'uninstall' | 'install';
+
+  export type SoftwarePolicyUnarmedReason =
+    'audit_mode' | 'enforce_mode_off' | 'auto_uninstall_off' | 'auto_install_off';
+
+  export function readSoftwarePolicyAutoInstall(raw: unknown): boolean;
+
+  export function evaluateSoftwarePolicyArming(
+    policy: SoftwarePolicyArmingInput,
+    verb: PolicyRemediationVerb
+  ): SoftwarePolicyArmingState;
+  ```
+  A **required** second parameter — not optional, not defaulted — so the compiler finds both existing call sites (`softwareRemediationWorker.ts:318`, `aiToolsCompliance.ts:509`), which pass `'uninstall'`. The `audit_mode` and `enforce_mode_off` messages take the verb noun; `auto_install_off` gets its own message naming `remediationOptions.autoInstall`. A technician must be told WHICH verb is unarmed.
+- **D3 — authorization: the delta is `devices.execute`, evaluated post-write.** New file `apps/api/src/services/softwarePolicyAuthorization.ts` exporting `assertMayArmInstall`. Semantics: if the write would leave the policy armed for install (`mode !== 'audit'` AND `enforceMode === true` AND `remediationOptions.autoInstall === true`), the caller MUST hold `devices.execute` AND have satisfied MFA. Assert **both** even though both current routes already carry `requireMfa()` — the assertion must stay correct if reused on a route without it. "Post-write state" = the merged result of the stored row and the request body, so editing the rules of an already-armed policy is also gated.
+  Building blocks — use these, invent nothing:
+  - `hasPermission(userPerms, PERMISSIONS.DEVICES_EXECUTE.resource, PERMISSIONS.DEVICES_EXECUTE.action)` — `apps/api/src/services/permissions.ts:210`; constant `packages/shared/src/constants/permissions.ts:24`.
+  - `hasSatisfiedMfa(auth)` — `apps/api/src/middleware/auth.ts:915`. Returns true when 2FA is globally disabled; that is intended, do not work around it.
+  - MFA refusal shape copied from `requireMfa()` (`auth.ts:897-905`): `c.json({ error: 'MFA required', code: 'MFA_REQUIRED' }, 403)` — a coded body.
+- **D6 — audit actions: new exported constants.** No const set exists to extend, so W01 creates one in `softwarePolicyService.ts` and every emitter imports it — no string literals at emit sites: `install_queued`, `install_succeeded`, `install_failed`, `install_gave_up`. Never reuse an uninstall action value. Existing uninstall action strings are **NOT** refactored.
+- **D9 — the emitted `missing` violation must carry `catalogId`.** Add `catalogId?: string` (and `reason?: string`) to the emitted `rule` object at `softwarePolicyService.ts:333-347` AND to `SoftwarePolicyViolation['rule']`. `violations` is jsonb and `software_compliance_status` appears in no export or org-cascade registry, so this needs **no migration and no registration**. Re-matching a violation to its rule by name at install time is rejected: rule names are not unique within a policy.
+- **`autoInstall` mirrors `autoUninstall` and deliberately does not share it.** A policy armed to remove unauthorised software is not thereby armed to install anything. Absent or non-boolean means NOT armed.
+- **Red-first on every behavioural change:** write the assertion, watch it fail against unmodified code, then implement. A test written after the code confirms rather than discriminates.
+- **Scoped test runs:** `cd apps/api && npx vitest run <path>`. Never `pnpm --filter <pkg> test -- --run <path>` (the `--` makes vitest run the whole suite in watch mode). Vitest's path filter is a plain **substring** match — no globbing, and a trailing slash silently skips sibling `foo.test.ts` files, so name files explicitly.
+- **Typecheck:** `pnpm --filter @breeze/api exec tsc --noEmit` (there is no `typecheck` script in `apps/api/package.json`).
+
+### Contract deviation (one, deliberate — flagged to the coordinator)
+
+The contract states the D3 signature as `assertMayArmInstall(c: Context): Promise<void>`. That signature cannot be implemented:
+
+1. `Promise<void>` cannot deliver the mandated coded 403 body. Hono handlers return responses; the contract explicitly forbids the `HTTPException` route.
+2. `c` alone does not carry the **stored** policy row, which the post-write merged state requires. Re-reading it inside the helper would be a second query of a row the PATCH handler already loaded at `softwarePolicies.ts:531`, and could read a different row than the one the handler authorized.
+
+Implemented instead, with the name, file path, semantics and refusal shape **exactly** as the contract specifies:
+
+```ts
+export async function assertMayArmInstall(
+  c: Context,
+  stored: SoftwarePolicyArmingInput | null,   // null on create
+  patch: SoftwarePolicyInstallArmingPatch
+): Promise<Response | null>;                   // null = allowed
+```
+
+Everything else in D2/D3/D6/D9 is implemented verbatim.
+
+### Explicitly OUT OF SCOPE for this wave
+
+State this in the PR body too. W01 does **not** touch:
+
+- `apps/api/src/jobs/softwareComplianceWorker.ts` — the remediation gate (`:423-444`), its local `readRemediationOptions` (`:136-162`), `readEarliestUnauthorizedDetection` (`:164-182`, D10) and `shouldQueueAutoRemediation` (`:184-212`). D11 (removing the inline gate duplication) is **W02**.
+- `apps/api/src/jobs/softwareRemediationWorker.ts` beyond adding the single `'uninstall'` argument at `:318`. No dispatch, no dedup, no payload type change.
+- Any migration. This wave adds zero SQL files. The three `software_compliance_status` install columns are **W02** (`…150400`); `software_deployments.software_policy_id` is **W03** (`…150401`).
+- Any AI file beyond the single `'uninstall'` argument the compiler forces at `aiToolsCompliance.ts:509`. `aiGuardrails.ts`, `aiToolSchemas.ts`, `aiAgentSdkTools.ts`, `aiToolsPolicyPrereqs.ts` and `summarizeEnforcementChange` are **W05**.
+- Any `apps/web` file. The arm/disarm UI, dry-run count and `catalogId` authoring warning are **W04**.
+- The `'outdated'` violation type. Reserved, never emitted, explicitly a spec non-goal — do not partially wire it.
+
+---
+
+## 0. Ground truth
+
+Every citation below was re-opened in this worktree (`/Users/toddhebebrand/.herdr/worktrees/breeze/warranty-testing`, branch `spec/hp-warranty-and-desired-state-install`) on 2026-09-10. Nothing here is copied from the spec or the contract on trust.
+
+**Confirmed exactly as the contract states:**
+
+- `apps/api/src/db/schema/softwarePolicies.ts:65-71` — `SoftwarePolicyRemediationOptions`, five fields, no `autoInstall`:
+  ```ts
+  export type SoftwarePolicyRemediationOptions = {
+    autoUninstall?: boolean;
+    notifyUser?: boolean; // not yet implemented
+    gracePeriod?: number; // hours; max 90 days
+    cooldownMinutes?: number;
+    maintenanceWindowOnly?: boolean; // not yet implemented
+  };
+  ```
+- `apps/api/src/db/schema/softwarePolicies.ts:48-63` — `SoftwarePolicyViolation`. Its `rule` sub-object is `:55-60` and reads `{ name: string; minVersion?: string; maxVersion?: string; reason?: string }` — **no `catalogId`**.
+- `apps/api/src/db/schema/softwarePolicies.ts:25-32` — `SoftwarePolicyRuleDefinition` HAS `catalogId?: string` at `:30` and `reason?: string` at `:31`.
+- `apps/api/src/services/softwarePolicyService.ts:333-347` — the `missing` emission, verbatim:
+  ```ts
+      for (const rule of softwareRules) {
+        const found = inventory.some((installed) => matchesSoftwareRule(installed, rule));
+        if (!found) {
+          violations.push({
+            type: 'missing',
+            rule: {
+              name: rule.name,
+              minVersion: rule.minVersion,
+              maxVersion: rule.maxVersion,
+            },
+            severity: 'high',
+            detectedAt,
+          });
+        }
+      }
+  ```
+- `apps/api/src/services/softwarePolicyService.ts:159` — `SoftwarePolicyUnarmedReason = 'audit_mode' | 'enforce_mode_off' | 'auto_uninstall_off'`. `:161-163` `SoftwarePolicyArmingState`. `:165-169` `SoftwarePolicyArmingInput` = `{ mode: string | null | undefined; enforceMode: boolean | null | undefined; remediationOptions: unknown }`. `:172-175` `readSoftwarePolicyAutoUninstall`. `:177-206` `evaluateSoftwarePolicyArming`, **one parameter**. Refusal messages at `:184`, `:192-193`, `:201-202`, all three saying "uninstall" verbatim.
+- `apps/api/src/services/softwarePolicyService.ts:533-573` — `recordSoftwarePolicyAudit`; its input declares `action: string` at `:542`; the owner-axis invariant ("at least one", not XOR) is `:548-550`; the insert writes `action: input.action` at `:556`.
+- `apps/api/src/db/schema/softwarePolicies.ts:142` — `action: varchar('action', { length: 50 }).notNull()`. No enum, no const set anywhere.
+- Non-test callers of `evaluateSoftwarePolicyArming` — exactly two, confirmed by a repo-wide grep over `apps/`, `packages/`, `ee/`: `apps/api/src/jobs/softwareRemediationWorker.ts:318` (`const arming = evaluateSoftwarePolicyArming(policy);`) and `apps/api/src/services/aiToolsCompliance.ts:509` (same expression).
+- `apps/api/src/routes/softwarePolicies.ts:79-85` — `remediationOptionsSchema`, a **non-strict, non-exported** `z.object`, so an unknown `autoInstall` key is silently stripped today.
+- `apps/api/src/routes/softwarePolicies.ts:291-296` — policy create: `requireSoftwarePolicyWrite` (`= requirePermission(PERMISSIONS.DEVICES_WRITE.resource, …)`, `:30-33`) + `requireMfa()` + `zValidator('json', createPolicySchema)`. In-handler `canMutateOrgWideGovernance` at `:298-300`.
+- `apps/api/src/routes/softwarePolicies.ts:517-525` — policy update: same middleware pair; `canMutateOrgWideGovernance` at `:525-527`; the partner-wide administration gate at `:539-541`.
+- `apps/api/src/middleware/auth.ts:915-918` — `hasSatisfiedMfa(auth: Pick<AuthContext, 'token'>): boolean` — `if (!ENABLE_2FA) return true; return auth.token?.mfa === true;`.
+- `apps/api/src/services/permissions.ts:210-218` — `hasPermission(userPerms: UserPermissions, resource: string, action: string): boolean`.
+- `packages/shared/src/constants/permissions.ts:24` — `DEVICES_EXECUTE: { resource: 'devices', action: 'execute' }`.
+- `apps/api/src/services/tenantCascade.ts` and `apps/api/src/services/tenantExportPolicyRegistry.ts` — **zero** occurrences of `software_compliance_status` in either file (grep count 0). D9 therefore needs no registration, confirmed rather than assumed.
+
+**Corrections — contract/spec citations that are now wrong:**
+
+- **`tenantExportPolicyRegistry.ts:430` is wrong for `software_policies`.** The spec body §1 cites `:430` as the entry classifying `remediation_options` as `excludedOpen`. `:430` is `software_catalog`. The real entry is **`:437`**, and it does classify `remediation_options` in `excludedOpen` alongside `rules` and `target_ids` — so §1's conclusion (no export-policy change, no migration for `autoInstall`) is correct, only the line number was off. (The contract's own `:434` for `software_deployments` is correct; that row is W03's problem, not this wave's.)
+- **`requireMfa()`'s coded-body rationale is stale.** The contract says an `HTTPException` is unusable "because the global onError handler drops `code`". `apps/api/src/index.ts:1046-1062` now reads a `code` property off a caught `HTTPException` and copies it into the body (`:1053-1058`), so that rationale no longer holds. The decision stands anyway on a different ground: a bare `new Hono()` route test — the established convention in `apps/api/src/routes/softwarePolicies*.test.ts` — installs no `onError`, so a thrown `HTTPException` would surface as a plain-text body and the coded shape would be untestable at the unit level. Return a Response.
+- **"BOTH HTTP zod schemas" is one edit, not two.** `createPolicySchema` (`:107`) and `updatePolicySchema` (`:117`) both reference the same `remediationOptionsSchema` object defined at `:79-85`. Adding the field once covers both surfaces; both must still be tested.
+
+**Additional facts this wave depends on, none of them in the contract:**
+
+- `apps/api/src/services/softwarePolicyService.ts:98-111` — `violationFingerprint` for a non-`unauthorized` violation is `` `${type}:rule:${ruleName}:${minVersion}:${maxVersion}` ``. It does **not** compare the rule object structurally. `withStableViolationTimestamps` (`:113-146`) keys off that fingerprint, and `apps/api/src/jobs/softwareComplianceWorker.ts:377` calls that same shared helper (imported at `:17`) rather than carrying its own copy. **Therefore D9's new `catalogId`/`reason` fields cannot change `detectedAt` stabilisation.** This answers the "W02 must check, do not assume either way" note in D9 — the answer is *no change*, and Task 4 pins it with a regression test so W02 can rely on it.
+- `apps/api/src/services/softwarePolicyService.ts:208-273` — `normalizeSoftwarePolicyRules` preserves `catalogId` (`:228`, `:234`) and `reason` (`:229`, `:235`) on every rule, so a `catalogId` authored through the HTTP route really does reach `evaluateSoftwareInventory`.
+- `apps/api/src/routes/softwarePolicies.ts:46-53` — `softwareRuleSchema` already accepts `catalogId: z.string().guid().optional()` at `:51`. No route change is needed for D9.
+- `apps/api/src/middleware/auth.ts:848-878` — `requirePermission` sets `c.set('permissions', userPerms)` at `:874` after resolving them. Both policy-write routes run `requireSoftwarePolicyWrite` first, so `c.get('permissions')` is always populated by the time the handler runs. A missing value therefore means the assertion is being used off a route that never resolved permissions — fail closed.
+- `apps/api/src/services/deviceSiteAccess.ts:1,15` — the established service convention for a Hono-aware helper: `import type { Context } from 'hono'` and read `c.get('permissions') as … | undefined`. Mirrored by `installerBuilder.ts:1` and `mobileDeviceBinding.ts:1`.
+- `apps/api/src/services/siteCeilingAccess.ts:37-47` — `canMutateOrgWideGovernance(auth)` is `auth.scope !== 'organization' || auth.allowedSiteIds === undefined`. A test auth object with `allowedSiteIds: undefined` passes it. This module is **not** mocked by the existing route tests, so the real implementation runs.
+- `apps/api/src/routes/softwarePolicies.ts:215-227` — `getPolicyWithAccess` runs a bare `db.select()` (no projection), so the `policy` object the PATCH handler holds at `:531` carries `mode`, `enforceMode` and `remediationOptions` — everything the merged-state check needs, with no extra query.
+- `apps/api/src/routes/softwarePolicies.ts:556` — PATCH **replaces** `remediationOptions` wholesale (`updates.remediationOptions = payload.remediationOptions`); it does not merge into the stored object. The merged-state rule "body field if provided, else stored field" is therefore an exact model of the write.
+- `apps/api/src/services/softwarePolicyArming.test.ts` (126 lines, read in full) — the existing unit suite for the gate. It calls `evaluateSoftwarePolicyArming` at `:38`, `:44`, `:53`, `:61`, `:73`, `:114`; **all six need the new `'uninstall'` argument**. `:87-97` carries `complianceWorkerInlineGate`, a hand-written oracle reproducing `softwareComplianceWorker.ts:423-427`, and `:99-125` is the truth-table parity guard against it. That guard must keep passing for the `'uninstall'` verb — W02 replaces the inline gate outright (D11), not this wave.
+- `apps/api/src/routes/softwarePolicies.approvalGeneration.test.ts` (119 lines, read in full) — the cleanest route-test template in this directory: a `vi.hoisted` `authRef`, a `vi.mock('../middleware/auth')` that injects it, a `db.transaction` stub capturing the `set()` payload, and `app()` returning `new Hono().route('/software-policies', softwarePoliciesRoutes)`. Task 6's tests mirror it.
+- Grep over `apps/api/src/routes/softwarePolicies*.test.ts`: **zero** occurrences of `remediationOptions` or `autoUninstall`. No existing route test can trip the new arming gate, so none of the three existing files needs its `../services/permissions` mock widened (they mock only `PERMISSIONS` + `canAccessSite`; `hasPermission` is reached only on the armed path).
+- Existing `software_policy_audit.action` values, enumerated repo-wide so Task 3 can prove no collision: `policy_created`, `policy_updated`, `policy_deleted`, `compliance_check_requested`, `compliance_check_failed`, `violation_detected`, `remediation_requested`, `remediation_scheduled`, `remediation_denied`, `remediation_deferred`, `remediation_skipped_unarmed`, `remediation_manual_override`, `remediation_command_failed`. **No `install_*` value exists.**
+- `apps/api/package.json:26` — `"test": "vitest"` (bare, watch-mode by default: the `--` trap applies). No `typecheck` script.
+- `apps/api/eslint.config.js` — flat config, `rules: {}` plus the SQLSTATE guard and a `no-restricted-imports` rule for `@hono/zod-validator`. `@typescript-eslint/require-await` is **not** enabled, so an `async` function with no `await` is fine.
+
+---
+
+## File structure
+
+- **Modify** `apps/api/src/db/schema/softwarePolicies.ts` — `autoInstall?: boolean` on `SoftwarePolicyRemediationOptions` (Task 1); `catalogId?: string` on `SoftwarePolicyViolation['rule']` (Task 4).
+- **Modify** `apps/api/src/routes/softwarePolicies.ts` — export + extend `remediationOptionsSchema` (Task 1); wire `assertMayArmInstall` into the create and update handlers (Task 6).
+- **Modify** `apps/api/src/services/softwarePolicyService.ts` — verb-aware arming + `readSoftwarePolicyAutoInstall` (Task 2); install audit-action constants (Task 3); `catalogId`/`reason` on the `missing` emission (Task 4).
+- **Modify** `apps/api/src/jobs/softwareRemediationWorker.ts` — one argument at `:318` (Task 2). Nothing else.
+- **Modify** `apps/api/src/services/aiToolsCompliance.ts` — one argument at `:509` (Task 2). Nothing else; this is the wave's only AI-file edit.
+- **Create** `apps/api/src/services/softwarePolicyAuthorization.ts` — `willBeArmedForInstall` + `assertMayArmInstall` (Task 5).
+- **Create** `apps/api/src/services/softwarePolicyAuthorization.test.ts` — unit tests for both (Task 5).
+- **Create** `apps/api/src/routes/softwarePolicies.autoInstall.test.ts` — route-level tests: schema passthrough (Task 1), then the create/update authorization matrix (Task 6).
+- **Modify** `apps/api/src/services/softwarePolicyArming.test.ts` — verb argument on six call sites + the install-verb suites (Task 2).
+- **Modify** `apps/api/src/services/softwarePolicyService.test.ts` — audit-action constants (Task 3), `catalogId` emission + fingerprint regression (Task 4).
+
+No migration. No registry file. No web file.
+
+---
+
+### Task 1: `autoInstall` on the remediation-options type and the HTTP schema
+
+**Files:**
+- Modify: `apps/api/src/db/schema/softwarePolicies.ts:65-71`
+- Modify: `apps/api/src/routes/softwarePolicies.ts:79-85`
+- Test (create): `apps/api/src/routes/softwarePolicies.autoInstall.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `SoftwarePolicyRemediationOptions.autoInstall?: boolean` (schema type, imported by Tasks 2/5 indirectly); `remediationOptionsSchema` becomes an exported `z.ZodObject` from `apps/api/src/routes/softwarePolicies.ts`, accepting `autoInstall: boolean | undefined`.
+
+- [ ] **Step 1: Export `remediationOptionsSchema` so it can be asserted directly**
+
+This is a visibility change only — no behaviour. It mirrors `softwareRulesSchema` (`:70`) and `executableRuleSchema` (`:58`), both already exported for exactly this reason.
+
+In `apps/api/src/routes/softwarePolicies.ts`, change line 79 from:
+
+```ts
+const remediationOptionsSchema = z.object({
+```
+
+to:
+
+```ts
+export const remediationOptionsSchema = z.object({
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `apps/api/src/routes/softwarePolicies.autoInstall.test.ts`. This file is the home for every W01 route-level assertion; Task 6 appends to it, so set the full mock harness up now.
+
+```ts
+/**
+ * #5505 W01 — `remediationOptions.autoInstall` (the desired-state install
+ * arming flag) and the authorization gate that guards arming it.
+ *
+ * `remediationOptionsSchema` is a NON-STRICT z.object, so before this wave an
+ * `autoInstall` sent by a client was silently STRIPPED — no error, no field,
+ * no way for a caller to tell. Both createPolicySchema and updatePolicySchema
+ * reuse that one object, so the passthrough is asserted through both routes as
+ * well as against the schema directly.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import type { AuthContext } from '../middleware/auth';
+
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    transaction: vi.fn(),
+  },
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock('../db/schema', () => ({
+  devices: { id: 'devices.id', orgId: 'devices.orgId', siteId: 'devices.siteId', hostname: 'devices.hostname', status: 'devices.status', osType: 'devices.osType' },
+  softwareComplianceStatus: { id: 'x', policyId: 'x', deviceId: 'x', status: 'x', violations: 'x', lastChecked: 'x', remediationStatus: 'x', lastRemediationAttempt: 'x' },
+  softwarePolicies: { id: 'id', orgId: 'orgId', partnerId: 'partnerId', mode: 'mode', name: 'name', isActive: 'isActive', updatedAt: 'updatedAt', approvalGeneration: 'approvalGeneration' },
+}));
+
+const { authRef, mfaRef, executeRef } = vi.hoisted(() => ({
+  authRef: { current: {} as Record<string, unknown> },
+  mfaRef: { current: true },
+  executeRef: { current: true },
+}));
+
+vi.mock('../middleware/auth', () => ({
+  authMiddleware: vi.fn((c: any, next: any) => {
+    c.set('auth', authRef.current);
+    // requirePermission normally sets this (middleware/auth.ts:874); the mock
+    // above replaces it, so inject the same shape the handler will read.
+    c.set('permissions', { permissions: [], scope: 'organization', orgId: null, partnerId: null, roleId: 'role-1' });
+    return next();
+  }),
+  requireScope: vi.fn(() => async (_c: any, next: any) => next()),
+  requirePermission: vi.fn(() => async (_c: any, next: any) => next()),
+  requireMfa: vi.fn(() => async (_c: any, next: any) => next()),
+  hasSatisfiedMfa: vi.fn(() => mfaRef.current),
+}));
+
+vi.mock('../jobs/softwareComplianceWorker', () => ({ scheduleSoftwareComplianceCheck: vi.fn() }));
+vi.mock('../jobs/softwareRemediationWorker', () => ({ scheduleSoftwareRemediation: vi.fn(async () => 1) }));
+vi.mock('../services/softwarePolicyService', () => ({
+  normalizeSoftwarePolicyRules: (r: any) => ({ software: r.software ?? [], executable: r.executable, allowUnknown: r.allowUnknown }),
+  recordSoftwarePolicyAudit: vi.fn(async () => undefined),
+  // Faithful copy of the real helper (softwarePolicyService.ts) — the
+  // authorization service imports it from this module, so the mock has to
+  // supply it. Arming is opt-in: only the literal boolean `true` counts.
+  readSoftwarePolicyAutoInstall: (raw: unknown) =>
+    !!raw && typeof raw === 'object' && (raw as Record<string, unknown>).autoInstall === true,
+}));
+vi.mock('../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
+vi.mock('../services/pamActuationLifecycle', () => ({ requestPamCleanup: vi.fn() }));
+vi.mock('../services/sentry', () => ({ captureException: vi.fn() }));
+vi.mock('../services/permissions', () => ({
+  PERMISSIONS: {
+    DEVICES_READ: { resource: 'devices', action: 'read' },
+    DEVICES_WRITE: { resource: 'devices', action: 'write' },
+    DEVICES_EXECUTE: { resource: 'devices', action: 'execute' },
+  },
+  canAccessSite: () => true,
+  hasPermission: vi.fn((_perms: unknown, resource: string, action: string) =>
+    resource === 'devices' && action === 'execute' ? executeRef.current : true),
+}));
+
+import { remediationOptionsSchema, softwarePoliciesRoutes } from './softwarePolicies';
+import { db } from '../db';
+import type { SoftwarePolicyRemediationOptions } from '../db/schema/softwarePolicies';
+
+const ORG_ID = '11111111-1111-4111-8111-111111111111';
+const POLICY_ID = '22222222-2222-4222-8222-222222222222';
+
+function orgAuth(): AuthContext {
+  return {
+    scope: 'organization',
+    orgId: ORG_ID,
+    canAccessOrg: (id: string) => id === ORG_ID,
+    orgCondition: () => null,
+    user: { id: 'user-1' },
+    accessibleOrgIds: [ORG_ID],
+    allowedSiteIds: undefined,
+    token: { mfa: true },
+  } as unknown as AuthContext;
+}
+
+function app() {
+  const instance = new Hono();
+  instance.route('/software-policies', softwarePoliciesRoutes);
+  return instance;
+}
+
+/** db.insert(...).values(...).returning() — captures the inserted values. */
+function mockInsertCapturing(captured: { values?: Record<string, unknown> }) {
+  (db.insert as any).mockReturnValue({
+    values: (v: Record<string, unknown>) => {
+      captured.values = v;
+      return { returning: () => Promise.resolve([{ id: POLICY_ID, orgId: ORG_ID, mode: v.mode, name: v.name }]) };
+    },
+  });
+}
+
+describe('#5505 remediationOptions.autoInstall reaches the server', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authRef.current = orgAuth() as unknown as Record<string, unknown>;
+    mfaRef.current = true;
+    executeRef.current = true;
+  });
+
+  it('remediationOptionsSchema keeps autoInstall instead of stripping it', () => {
+    const parsed = remediationOptionsSchema.parse({ autoInstall: true, autoUninstall: false });
+    expect(parsed.autoInstall).toBe(true);
+    expect(parsed.autoUninstall).toBe(false);
+  });
+
+  it('remediationOptionsSchema rejects a non-boolean autoInstall', () => {
+    expect(() => remediationOptionsSchema.parse({ autoInstall: 'true' })).toThrow();
+    expect(() => remediationOptionsSchema.parse({ autoInstall: 1 })).toThrow();
+  });
+
+  it('autoInstall and autoUninstall are independent flags on the type', () => {
+    const installOnly: SoftwarePolicyRemediationOptions = { autoInstall: true };
+    const uninstallOnly: SoftwarePolicyRemediationOptions = { autoUninstall: true };
+    expect(installOnly.autoUninstall).toBeUndefined();
+    expect(uninstallOnly.autoInstall).toBeUndefined();
+  });
+
+  it('POST persists autoInstall into remediation_options', async () => {
+    const captured: { values?: Record<string, unknown> } = {};
+    mockInsertCapturing(captured);
+
+    const res = await app().request('/software-policies', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        orgId: ORG_ID,
+        name: 'Required software',
+        mode: 'allowlist',
+        rules: { software: [{ name: '7-Zip' }] },
+        enforceMode: true,
+        remediationOptions: { autoInstall: true },
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    expect(captured.values?.remediationOptions).toEqual({ autoInstall: true });
+  });
+
+  it('PATCH persists autoInstall into remediation_options', async () => {
+    let updateSetArg: Record<string, unknown> | undefined;
+    (db.select as any).mockReturnValue({
+      from: () => ({ where: () => ({ limit: () => Promise.resolve([{ id: POLICY_ID, orgId: ORG_ID, isActive: true, mode: 'allowlist', enforceMode: true, remediationOptions: null }]) }) }),
+    });
+    (db.transaction as any).mockImplementation(async (fn: (tx: unknown) => unknown) => fn({
+      update: () => ({
+        set: (setArg: Record<string, unknown>) => {
+          updateSetArg = setArg;
+          return { where: () => ({ returning: () => Promise.resolve([{ id: POLICY_ID, orgId: ORG_ID, name: 'Required software', approvalGeneration: 2 }]) }) };
+        },
+      }),
+    }));
+
+    const res = await app().request(`/software-policies/${POLICY_ID}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ remediationOptions: { autoInstall: true } }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(updateSetArg?.remediationOptions).toEqual({ autoInstall: true });
+  });
+});
+```
+
+- [ ] **Step 3: Run the test and watch it fail**
+
+```bash
+cd apps/api && npx vitest run src/routes/softwarePolicies.autoInstall.test.ts
+```
+
+Expected: the three assertions that touch the field fail —
+`remediationOptionsSchema keeps autoInstall` fails with `expected undefined to be true` (the non-strict object strips it);
+`rejects a non-boolean autoInstall` fails with "expected function to throw" (an unknown key is stripped, never validated);
+both route tests fail with `expected {} to equal { autoInstall: true }`.
+`autoInstall and autoUninstall are independent flags` passes at runtime (vitest strips types) — its red is the typecheck in Step 4.
+
+- [ ] **Step 4: Confirm the type-level red**
+
+```bash
+pnpm --filter @breeze/api exec tsc --noEmit
+```
+
+Expected: `error TS2353: Object literal may only specify known properties, and 'autoInstall' does not exist in type 'SoftwarePolicyRemediationOptions'.` — in `softwarePolicies.autoInstall.test.ts`. That is the failing assertion for the schema-type half of this task.
+
+- [ ] **Step 5: Add the field to the schema type**
+
+In `apps/api/src/db/schema/softwarePolicies.ts`, replace lines 65-71 with:
+
+```ts
+export type SoftwarePolicyRemediationOptions = {
+  autoUninstall?: boolean;
+  /**
+   * Desired-state install arming (#5505). Opt-in — absent or non-boolean means
+   * NOT armed — and deliberately NOT sharing `autoUninstall`'s flag: a policy
+   * armed to REMOVE unauthorised software is not thereby armed to INSTALL
+   * anything. Both verbs still sit behind `enforceMode` and `mode !== 'audit'`.
+   */
+  autoInstall?: boolean;
+  notifyUser?: boolean; // not yet implemented
+  gracePeriod?: number; // hours; max 90 days
+  cooldownMinutes?: number;
+  maintenanceWindowOnly?: boolean; // not yet implemented
+};
+```
+
+- [ ] **Step 6: Add the field to the HTTP schema**
+
+In `apps/api/src/routes/softwarePolicies.ts`, replace lines 79-85 (the block you exported in Step 1) with:
+
+```ts
+// NOTE: a non-strict z.object STRIPS unknown keys silently rather than
+// rejecting them, so a field is invisible to the API until it is declared
+// here. Both createPolicySchema and updatePolicySchema reference this one
+// object, so a field added here covers the create and update surfaces alike.
+export const remediationOptionsSchema = z.object({
+  autoUninstall: z.boolean().optional(),
+  autoInstall: z.boolean().optional(), // #5505 — see SoftwarePolicyRemediationOptions
+  notifyUser: z.boolean().optional(),
+  gracePeriod: z.number().int().min(0).max(24 * 90).optional(), // hours; max 90 days
+  cooldownMinutes: z.number().int().min(1).max(24 * 90 * 60).optional(),
+  maintenanceWindowOnly: z.boolean().optional(),
+});
+```
+
+- [ ] **Step 7: Run the test and watch it pass**
+
+```bash
+cd apps/api && npx vitest run src/routes/softwarePolicies.autoInstall.test.ts
+```
+
+Expected: 5 passed, 1 file.
+
+- [ ] **Step 8: Typecheck, then re-run the three neighbouring route suites**
+
+```bash
+pnpm --filter @breeze/api exec tsc --noEmit
+cd apps/api && npx vitest run src/routes/softwarePolicies.test.ts src/routes/softwarePolicies.siteScope.test.ts src/routes/softwarePolicies.approvalGeneration.test.ts
+```
+
+Expected: tsc clean; 3 files passed. (Listing the three files explicitly is deliberate — `vitest run src/routes/softwarePolicies` would substring-match, and a trailing slash would skip all three.)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/api/src/db/schema/softwarePolicies.ts apps/api/src/routes/softwarePolicies.ts apps/api/src/routes/softwarePolicies.autoInstall.test.ts
+git commit -m "feat(api): add remediationOptions.autoInstall to the policy type and HTTP schema (#5506)"
+```
+
+---
+
+### Task 2: verb-aware arming (`PolicyRemediationVerb`, `readSoftwarePolicyAutoInstall`, `auto_install_off`)
+
+**Files:**
+- Modify: `apps/api/src/services/softwarePolicyService.ts:148-206`
+- Modify: `apps/api/src/jobs/softwareRemediationWorker.ts:318`
+- Modify: `apps/api/src/services/aiToolsCompliance.ts:509`
+- Test: `apps/api/src/services/softwarePolicyArming.test.ts`
+
+**Interfaces:**
+- Consumes: `SoftwarePolicyRemediationOptions.autoInstall` (Task 1) — only as documentation; the helper reads `unknown`.
+- Produces, all exported from `apps/api/src/services/softwarePolicyService.ts`:
+  - `type PolicyRemediationVerb = 'uninstall' | 'install'`
+  - `type SoftwarePolicyUnarmedReason = 'audit_mode' | 'enforce_mode_off' | 'auto_uninstall_off' | 'auto_install_off'`
+  - `function readSoftwarePolicyAutoInstall(raw: unknown): boolean`
+  - `function evaluateSoftwarePolicyArming(policy: SoftwarePolicyArmingInput, verb: PolicyRemediationVerb): SoftwarePolicyArmingState`
+  - `SoftwarePolicyArmingInput` and `SoftwarePolicyArmingState` are unchanged and still exported.
+
+- [ ] **Step 1: Write the failing tests**
+
+Rewrite `apps/api/src/services/softwarePolicyArming.test.ts` in full. Three things change: the header docblock, the six existing calls gain `'uninstall'`, and two new `describe` blocks cover the install verb and message byte-identity.
+
+```ts
+/**
+ * #3543 — the arming gate, unit-tested directly plus a drift guard.
+ * #5505 W01 — the gate is now verb-aware: `evaluateSoftwarePolicyArming(policy,
+ * verb)` answers "may this policy UNINSTALL?" or "may this policy INSTALL?"
+ * against two independent flags. The second parameter is REQUIRED so the
+ * compiler finds every caller; there is no default verb.
+ *
+ * `softwareComplianceWorker.ts` still carries its own inline copy of the
+ * uninstall rule (W02 removes it, contract D11). Two independent copies of a
+ * security gate drift, and drift in THAT file reintroduces the #3381 bug class,
+ * so the parity block below pins them together over a truth table.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  evaluateSoftwarePolicyArming,
+  readSoftwarePolicyAutoInstall,
+  readSoftwarePolicyAutoUninstall,
+} from './softwarePolicyService';
+
+describe('readSoftwarePolicyAutoUninstall — arming is opt-in', () => {
+  it.each([
+    ['null', null, false],
+    ['undefined', undefined, false],
+    ['empty object', {}, false],
+    ['array', [], false],
+    ['string "true"', 'true', false],
+    ['number 1', 1, false],
+    ['boolean true', true, false],
+    ['autoUninstall: false', { autoUninstall: false }, false],
+    ['autoUninstall: "true" (string, not boolean)', { autoUninstall: 'true' }, false],
+    ['autoUninstall: 1 (truthy, not true)', { autoUninstall: 1 }, false],
+    ['autoUninstall: true', { autoUninstall: true }, true],
+  ])('%s -> %s', (_label, input, expected) => {
+    expect(readSoftwarePolicyAutoUninstall(input)).toBe(expected);
+  });
+});
+
+describe('readSoftwarePolicyAutoInstall — arming is opt-in', () => {
+  it.each([
+    ['null', null, false],
+    ['undefined', undefined, false],
+    ['empty object', {}, false],
+    ['array', [], false],
+    ['string "true"', 'true', false],
+    ['number 1', 1, false],
+    ['boolean true', true, false],
+    ['autoInstall: false', { autoInstall: false }, false],
+    ['autoInstall: "true" (string, not boolean)', { autoInstall: 'true' }, false],
+    ['autoInstall: 1 (truthy, not true)', { autoInstall: 1 }, false],
+    ['autoInstall: true', { autoInstall: true }, true],
+  ])('%s -> %s', (_label, input, expected) => {
+    expect(readSoftwarePolicyAutoInstall(input)).toBe(expected);
+  });
+
+  it('does not read autoUninstall', () => {
+    expect(readSoftwarePolicyAutoInstall({ autoUninstall: true })).toBe(false);
+    expect(readSoftwarePolicyAutoUninstall({ autoInstall: true })).toBe(false);
+  });
+});
+
+describe('evaluateSoftwarePolicyArming — uninstall verb', () => {
+  const ARMED_OPTIONS = { autoUninstall: true };
+
+  it('is armed only when mode is non-audit AND enforceMode AND autoUninstall', () => {
+    expect(evaluateSoftwarePolicyArming({
+      mode: 'blocklist', enforceMode: true, remediationOptions: ARMED_OPTIONS,
+    }, 'uninstall')).toEqual({ armed: true });
+  });
+
+  it('reports audit_mode first, even when otherwise fully armed', () => {
+    const state = evaluateSoftwarePolicyArming({
+      mode: 'audit', enforceMode: true, remediationOptions: ARMED_OPTIONS,
+    }, 'uninstall');
+    expect(state.armed).toBe(false);
+    expect(state).toMatchObject({ reason: 'audit_mode' });
+  });
+
+  it('reports enforce_mode_off when enforcement is off', () => {
+    for (const enforceMode of [false, null, undefined]) {
+      const state = evaluateSoftwarePolicyArming({
+        mode: 'blocklist', enforceMode, remediationOptions: ARMED_OPTIONS,
+      }, 'uninstall');
+      expect(state).toMatchObject({ armed: false, reason: 'enforce_mode_off' });
+    }
+  });
+
+  it('reports auto_uninstall_off when enforcement is on but uninstall is not armed', () => {
+    const state = evaluateSoftwarePolicyArming({
+      mode: 'allowlist', enforceMode: true, remediationOptions: { autoUninstall: false },
+    }, 'uninstall');
+    expect(state).toMatchObject({ armed: false, reason: 'auto_uninstall_off' });
+  });
+
+  it('always carries an operator-legible message when unarmed', () => {
+    for (const policy of [
+      { mode: 'audit', enforceMode: true, remediationOptions: ARMED_OPTIONS },
+      { mode: 'blocklist', enforceMode: false, remediationOptions: ARMED_OPTIONS },
+      { mode: 'blocklist', enforceMode: true, remediationOptions: null },
+    ]) {
+      const state = evaluateSoftwarePolicyArming(policy, 'uninstall');
+      expect(state.armed).toBe(false);
+      if (!state.armed) expect(state.message.length).toBeGreaterThan(20);
+    }
+  });
+});
+
+describe('evaluateSoftwarePolicyArming — install verb', () => {
+  const ARMED_OPTIONS = { autoInstall: true };
+
+  it('is armed only when mode is non-audit AND enforceMode AND autoInstall', () => {
+    expect(evaluateSoftwarePolicyArming({
+      mode: 'allowlist', enforceMode: true, remediationOptions: ARMED_OPTIONS,
+    }, 'install')).toEqual({ armed: true });
+  });
+
+  it('reports audit_mode first, even when otherwise fully armed', () => {
+    const state = evaluateSoftwarePolicyArming({
+      mode: 'audit', enforceMode: true, remediationOptions: ARMED_OPTIONS,
+    }, 'install');
+    expect(state).toMatchObject({ armed: false, reason: 'audit_mode' });
+  });
+
+  it('reports enforce_mode_off when enforcement is off', () => {
+    for (const enforceMode of [false, null, undefined]) {
+      const state = evaluateSoftwarePolicyArming({
+        mode: 'allowlist', enforceMode, remediationOptions: ARMED_OPTIONS,
+      }, 'install');
+      expect(state).toMatchObject({ armed: false, reason: 'enforce_mode_off' });
+    }
+  });
+
+  it('reports auto_install_off — never auto_uninstall_off — when install is not armed', () => {
+    const state = evaluateSoftwarePolicyArming({
+      mode: 'allowlist', enforceMode: true, remediationOptions: { autoInstall: false },
+    }, 'install');
+    expect(state).toMatchObject({ armed: false, reason: 'auto_install_off' });
+    if (!state.armed) expect(state.message).toContain('remediationOptions.autoInstall');
+  });
+});
+
+describe('the two verbs are independent (spec: "arming install does not arm uninstall")', () => {
+  const BASE = { mode: 'allowlist' as const, enforceMode: true };
+
+  it('autoUninstall alone arms uninstall and NOT install', () => {
+    const policy = { ...BASE, remediationOptions: { autoUninstall: true } };
+    expect(evaluateSoftwarePolicyArming(policy, 'uninstall').armed).toBe(true);
+    expect(evaluateSoftwarePolicyArming(policy, 'install')).toMatchObject({ armed: false, reason: 'auto_install_off' });
+  });
+
+  it('autoInstall alone arms install and NOT uninstall', () => {
+    const policy = { ...BASE, remediationOptions: { autoInstall: true } };
+    expect(evaluateSoftwarePolicyArming(policy, 'install').armed).toBe(true);
+    expect(evaluateSoftwarePolicyArming(policy, 'uninstall')).toMatchObject({ armed: false, reason: 'auto_uninstall_off' });
+  });
+
+  it('both flags arm both verbs', () => {
+    const policy = { ...BASE, remediationOptions: { autoInstall: true, autoUninstall: true } };
+    expect(evaluateSoftwarePolicyArming(policy, 'install').armed).toBe(true);
+    expect(evaluateSoftwarePolicyArming(policy, 'uninstall').armed).toBe(true);
+  });
+});
+
+/**
+ * The uninstall messages are user-visible: `aiToolsCompliance.ts` returns
+ * `arming.message` straight to the model and the route surfaces it to a
+ * technician. Making the gate verb-aware must not reword the uninstall copy,
+ * so pin all three byte-for-byte.
+ */
+describe('uninstall refusal messages are unchanged byte-for-byte', () => {
+  it.each([
+    [
+      { mode: 'audit', enforceMode: true, remediationOptions: { autoUninstall: true } },
+      'Policy is audit-only (mode="audit"); it cannot uninstall software.',
+    ],
+    [
+      { mode: 'blocklist', enforceMode: false, remediationOptions: { autoUninstall: true } },
+      'Policy enforcement is off (enforceMode=false), so it is detect-only and must not uninstall software. '
+      + 'An administrator has to enable enforcement on the policy first.',
+    ],
+    [
+      { mode: 'blocklist', enforceMode: true, remediationOptions: null },
+      'Policy remediation is not armed (remediationOptions.autoUninstall is not true), so it must not uninstall software. '
+      + 'An administrator has to enable automatic uninstall on the policy first.',
+    ],
+  ])('%#', (policy, expected) => {
+    const state = evaluateSoftwarePolicyArming(policy, 'uninstall');
+    expect(state.armed).toBe(false);
+    if (!state.armed) expect(state.message).toBe(expected);
+  });
+});
+
+describe('install refusal messages name the install verb', () => {
+  it('audit_mode says "install", not "uninstall"', () => {
+    const state = evaluateSoftwarePolicyArming(
+      { mode: 'audit', enforceMode: true, remediationOptions: { autoInstall: true } },
+      'install'
+    );
+    expect(state.armed).toBe(false);
+    if (!state.armed) {
+      expect(state.message).toBe('Policy is audit-only (mode="audit"); it cannot install software.');
+    }
+  });
+
+  it('enforce_mode_off says "install", not "uninstall"', () => {
+    const state = evaluateSoftwarePolicyArming(
+      { mode: 'allowlist', enforceMode: false, remediationOptions: { autoInstall: true } },
+      'install'
+    );
+    expect(state.armed).toBe(false);
+    if (!state.armed) {
+      expect(state.message).toBe(
+        'Policy enforcement is off (enforceMode=false), so it is detect-only and must not install software. '
+        + 'An administrator has to enable enforcement on the policy first.'
+      );
+    }
+  });
+
+  it('auto_install_off names the autoInstall option', () => {
+    const state = evaluateSoftwarePolicyArming(
+      { mode: 'allowlist', enforceMode: true, remediationOptions: {} },
+      'install'
+    );
+    expect(state.armed).toBe(false);
+    if (!state.armed) {
+      expect(state.message).toBe(
+        'Policy remediation is not armed (remediationOptions.autoInstall is not true), so it must not install software. '
+        + 'An administrator has to enable automatic install on the policy first.'
+      );
+    }
+  });
+});
+
+/**
+ * Drift guard against the untouched inline gate in
+ * `apps/api/src/jobs/softwareComplianceWorker.ts:423-427`:
+ *   policy.enforceMode && policy.mode !== 'audit' && remediationOptions.autoUninstallEnabled
+ * where `autoUninstallEnabled` comes from its local `readRemediationOptions`
+ * (`:158`, `options.autoUninstall === true`). Reproduced here as the reference
+ * oracle. W02 deletes that inline copy (contract D11); until then this holds.
+ */
+function complianceWorkerInlineGate(policy: {
+  mode: string | null | undefined;
+  enforceMode: boolean | null | undefined;
+  remediationOptions: unknown;
+}): boolean {
+  const raw = policy.remediationOptions;
+  const autoUninstallEnabled = !raw || typeof raw !== 'object'
+    ? false
+    : (raw as Record<string, unknown>).autoUninstall === true;
+  return Boolean(policy.enforceMode) && policy.mode !== 'audit' && autoUninstallEnabled;
+}
+
+describe('gate parity with the inline compliance-worker gate (#3543 drift guard)', () => {
+  const MODES = ['allowlist', 'blocklist', 'audit'];
+  const ENFORCE = [true, false, null, undefined];
+  const OPTIONS: unknown[] = [
+    null, undefined, {}, [], 'true', 1,
+    { autoUninstall: true }, { autoUninstall: false }, { autoUninstall: 'true' },
+    { autoUninstall: true, cooldownMinutes: 30 },
+    { autoInstall: true }, { autoInstall: true, autoUninstall: true },
+  ];
+
+  it('agrees on every combination of mode / enforceMode / remediationOptions', () => {
+    const disagreements: string[] = [];
+    for (const mode of MODES) {
+      for (const enforceMode of ENFORCE) {
+        for (const remediationOptions of OPTIONS) {
+          const policy = { mode, enforceMode, remediationOptions };
+          const shared = evaluateSoftwarePolicyArming(policy, 'uninstall').armed;
+          const inline = complianceWorkerInlineGate(policy);
+          if (shared !== inline) {
+            disagreements.push(
+              `mode=${mode} enforceMode=${String(enforceMode)} options=${JSON.stringify(remediationOptions)}: shared=${shared} inline=${inline}`
+            );
+          }
+        }
+      }
+    }
+    expect(disagreements).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests and watch them fail**
+
+```bash
+cd apps/api && npx vitest run src/services/softwarePolicyArming.test.ts
+```
+
+Expected: the whole file fails to load —
+`SyntaxError: The requested module './softwarePolicyService' does not provide an export named 'readSoftwarePolicyAutoInstall'`.
+
+- [ ] **Step 3: Make the gate verb-aware**
+
+In `apps/api/src/services/softwarePolicyService.ts`, replace the docblock and the whole helper block — lines 148 through 206 — with:
+
+```ts
+/**
+ * Remediation-arming gate (#3543, incident #3381; verb-aware since #5505).
+ *
+ * A policy only authorises remediation commands for a given verb when all three
+ * are true: `mode !== 'audit'`, `enforceMode`, and that verb's own flag —
+ * `remediationOptions.autoUninstall` for `'uninstall'`,
+ * `remediationOptions.autoInstall` for `'install'`. The two flags are
+ * deliberately independent: a policy armed to REMOVE unauthorised software is
+ * not thereby armed to INSTALL anything.
+ *
+ * Until #3543 the gate lived ONLY inline in softwareComplianceWorker.ts, so
+ * every other path that reached `scheduleSoftwareRemediation` (the AI tool, the
+ * manual route, a replayed BullMQ job) could queue mass uninstalls against a
+ * policy whose owner had deliberately left enforcement off. This is the single
+ * shared definition — callers must use it rather than re-deriving the check.
+ *
+ * `verb` is REQUIRED and has no default: an unarmed policy must never be
+ * mistaken for an armed one because a caller forgot an argument.
+ */
+export type PolicyRemediationVerb = 'uninstall' | 'install';
+
+export type SoftwarePolicyUnarmedReason =
+  | 'audit_mode'
+  | 'enforce_mode_off'
+  | 'auto_uninstall_off'
+  | 'auto_install_off';
+
+export type SoftwarePolicyArmingState =
+  | { armed: true }
+  | { armed: false; reason: SoftwarePolicyUnarmedReason; message: string };
+
+export type SoftwarePolicyArmingInput = {
+  mode: string | null | undefined;
+  enforceMode: boolean | null | undefined;
+  remediationOptions: unknown;
+};
+
+/** `autoUninstall` is opt-in: absent or non-object options mean NOT armed. */
+export function readSoftwarePolicyAutoUninstall(raw: unknown): boolean {
+  if (!raw || typeof raw !== 'object') return false;
+  return (raw as Record<string, unknown>).autoUninstall === true;
+}
+
+/** `autoInstall` is opt-in: absent or non-object options mean NOT armed. */
+export function readSoftwarePolicyAutoInstall(raw: unknown): boolean {
+  if (!raw || typeof raw !== 'object') return false;
+  return (raw as Record<string, unknown>).autoInstall === true;
+}
+
+export function evaluateSoftwarePolicyArming(
+  policy: SoftwarePolicyArmingInput,
+  verb: PolicyRemediationVerb
+): SoftwarePolicyArmingState {
+  if (policy.mode === 'audit') {
+    return {
+      armed: false,
+      reason: 'audit_mode',
+      message: `Policy is audit-only (mode="audit"); it cannot ${verb} software.`,
+    };
+  }
+  if (policy.enforceMode !== true) {
+    return {
+      armed: false,
+      reason: 'enforce_mode_off',
+      message:
+        `Policy enforcement is off (enforceMode=false), so it is detect-only and must not ${verb} software. `
+        + 'An administrator has to enable enforcement on the policy first.',
+    };
+  }
+  if (verb === 'install') {
+    if (!readSoftwarePolicyAutoInstall(policy.remediationOptions)) {
+      return {
+        armed: false,
+        reason: 'auto_install_off',
+        message:
+          'Policy remediation is not armed (remediationOptions.autoInstall is not true), so it must not install software. '
+          + 'An administrator has to enable automatic install on the policy first.',
+      };
+    }
+    return { armed: true };
+  }
+  if (!readSoftwarePolicyAutoUninstall(policy.remediationOptions)) {
+    return {
+      armed: false,
+      reason: 'auto_uninstall_off',
+      message:
+        'Policy remediation is not armed (remediationOptions.autoUninstall is not true), so it must not uninstall software. '
+        + 'An administrator has to enable automatic uninstall on the policy first.',
+    };
+  }
+  return { armed: true };
+}
+```
+
+- [ ] **Step 4: Update the two non-test call sites the compiler now rejects**
+
+In `apps/api/src/jobs/softwareRemediationWorker.ts`, line 318:
+
+```ts
+  const arming = evaluateSoftwarePolicyArming(policy, 'uninstall');
+```
+
+In `apps/api/src/services/aiToolsCompliance.ts`, line 509:
+
+```ts
+    const arming = evaluateSoftwarePolicyArming(policy, 'uninstall');
+```
+
+Change nothing else in either file. The `aiToolsCompliance.ts` edit is the only AI-file change in this wave; the AI's *write* refusals are W05.
+
+- [ ] **Step 5: Run the tests and watch them pass**
+
+```bash
+cd apps/api && npx vitest run src/services/softwarePolicyArming.test.ts
+```
+
+Expected: all suites pass, including the byte-identity block and the drift guard.
+
+- [ ] **Step 6: Typecheck**
+
+```bash
+pnpm --filter @breeze/api exec tsc --noEmit
+```
+
+Expected: clean. If it reports a call site other than the two above, a third caller appeared since the ground-truth pass — pass `'uninstall'` there too and note it in the PR body.
+
+- [ ] **Step 7: Run the two suites that exercise the changed call sites**
+
+```bash
+cd apps/api && npx vitest run src/jobs/softwareRemediationWorker.test.ts src/services/aiToolsCompliance.siteScope.test.ts
+```
+
+Expected: both pass. Both re-export the real helper through their mocks (`softwareRemediationWorker.test.ts:46`, `aiToolsCompliance.siteScope.test.ts:17`), so they exercise the new signature without needing an edit.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/api/src/services/softwarePolicyService.ts apps/api/src/services/softwarePolicyArming.test.ts apps/api/src/jobs/softwareRemediationWorker.ts apps/api/src/services/aiToolsCompliance.ts
+git commit -m "feat(api): make the software-policy arming gate verb-aware (install/uninstall) (#5506)"
+```
+
+---
+
+### Task 3: install audit-action constants
+
+**Files:**
+- Modify: `apps/api/src/services/softwarePolicyService.ts` (append after the arming block from Task 2)
+- Test: `apps/api/src/services/softwarePolicyService.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces, exported from `apps/api/src/services/softwarePolicyService.ts`:
+  - `const SOFTWARE_POLICY_INSTALL_AUDIT_ACTIONS = { queued: 'install_queued', succeeded: 'install_succeeded', failed: 'install_failed', gaveUp: 'install_gave_up' } as const`
+  - `type SoftwarePolicyInstallAuditAction` — the union of those four literals.
+  W02 and W03 import this object and pass its members as `recordSoftwarePolicyAudit({ action })`; no emitter writes a string literal.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `apps/api/src/services/softwarePolicyService.test.ts`. Add the import at the top of the file — the existing import block is lines 2-8, so extend it:
+
+```ts
+import {
+  SOFTWARE_POLICY_INSTALL_AUDIT_ACTIONS,
+  compareSoftwareVersions,
+  evaluateSoftwareInventory,
+  matchesSoftwareRule,
+  normalizeSoftwarePolicyRules,
+  withStableViolationTimestamps,
+} from './softwarePolicyService';
+```
+
+Then append this block at the end of the file:
+
+```ts
+/**
+ * #5505 D6 — `software_policy_audit.action` is a bare varchar(50) with no enum
+ * and no pre-existing const set (softwarePolicies.ts:142), so this object IS
+ * the registry. An audit reader must never have to infer the verb, so install
+ * events never reuse an uninstall action value.
+ */
+describe('SOFTWARE_POLICY_INSTALL_AUDIT_ACTIONS', () => {
+  // Every action string already written to software_policy_audit.action,
+  // enumerated from the emitters as of #5506. The point is collision, not
+  // completeness: a new install action must not be any of these.
+  const EXISTING_ACTIONS = [
+    'policy_created',
+    'policy_updated',
+    'policy_deleted',
+    'compliance_check_requested',
+    'compliance_check_failed',
+    'violation_detected',
+    'remediation_requested',
+    'remediation_scheduled',
+    'remediation_denied',
+    'remediation_deferred',
+    'remediation_skipped_unarmed',
+    'remediation_manual_override',
+    'remediation_command_failed',
+  ];
+
+  it('exposes exactly the four install actions the contract names', () => {
+    expect(SOFTWARE_POLICY_INSTALL_AUDIT_ACTIONS).toEqual({
+      queued: 'install_queued',
+      succeeded: 'install_succeeded',
+      failed: 'install_failed',
+      gaveUp: 'install_gave_up',
+    });
+  });
+
+  it('never collides with an existing uninstall or lifecycle action', () => {
+    for (const action of Object.values(SOFTWARE_POLICY_INSTALL_AUDIT_ACTIONS)) {
+      expect(EXISTING_ACTIONS).not.toContain(action);
+    }
+  });
+
+  it('every value is install-prefixed and fits software_policy_audit.action varchar(50)', () => {
+    for (const action of Object.values(SOFTWARE_POLICY_INSTALL_AUDIT_ACTIONS)) {
+      expect(action.startsWith('install_')).toBe(true);
+      expect(action.length).toBeLessThanOrEqual(50);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and watch it fail**
+
+```bash
+cd apps/api && npx vitest run src/services/softwarePolicyService.test.ts
+```
+
+Expected: `SyntaxError: The requested module './softwarePolicyService' does not provide an export named 'SOFTWARE_POLICY_INSTALL_AUDIT_ACTIONS'`.
+
+- [ ] **Step 3: Add the constants**
+
+In `apps/api/src/services/softwarePolicyService.ts`, insert immediately after the closing brace of `evaluateSoftwarePolicyArming` (which ends at what was line 206 before Task 2, and now ends just before `export function normalizeSoftwarePolicyRules`):
+
+```ts
+/**
+ * Install-remediation audit actions (#5505 D6).
+ *
+ * `software_policy_audit.action` is a bare `varchar(50)`
+ * (`db/schema/softwarePolicies.ts:142`) written as `action: string` — no enum,
+ * no pre-existing const set — so this object IS the registry. Every emitter
+ * imports it; no install emit site writes a string literal.
+ *
+ * Install actions never reuse an uninstall action value: an audit reader must
+ * never have to infer which verb an event describes. The existing uninstall
+ * action strings are deliberately NOT refactored into a matching object here —
+ * that is a separate, unrelated change.
+ */
+export const SOFTWARE_POLICY_INSTALL_AUDIT_ACTIONS = {
+  /** An install was queued for a (policy, device). */
+  queued: 'install_queued',
+  /** The queued install reported success. */
+  succeeded: 'install_succeeded',
+  /** The queued install reported failure (one attempt). */
+  failed: 'install_failed',
+  /** Consecutive attempts exhausted; the install loop guard stopped retrying. */
+  gaveUp: 'install_gave_up',
+} as const;
+
+export type SoftwarePolicyInstallAuditAction =
+  (typeof SOFTWARE_POLICY_INSTALL_AUDIT_ACTIONS)[keyof typeof SOFTWARE_POLICY_INSTALL_AUDIT_ACTIONS];
+```
+
+- [ ] **Step 4: Run the test and watch it pass**
+
+```bash
+cd apps/api && npx vitest run src/services/softwarePolicyService.test.ts
+```
+
+Expected: all suites pass, 3 new tests included.
+
+- [ ] **Step 5: Typecheck and commit**
+
+```bash
+pnpm --filter @breeze/api exec tsc --noEmit
+git add apps/api/src/services/softwarePolicyService.ts apps/api/src/services/softwarePolicyService.test.ts
+git commit -m "feat(api): add install-remediation audit action constants (#5506)"
+```
+
+---
+
+### Task 4: `catalogId` on the `missing` violation (contract D9)
+
+**Files:**
+- Modify: `apps/api/src/db/schema/softwarePolicies.ts:55-60`
+- Modify: `apps/api/src/services/softwarePolicyService.ts:333-347`
+- Test: `apps/api/src/services/softwarePolicyService.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `SoftwarePolicyViolation['rule'].catalogId?: string`. W02 and W03 read `violation.rule?.catalogId` off a stored `missing` violation to resolve what to install. `reason` was already on the type (`:59`); this task starts *populating* it on the `missing` branch, which previously dropped it.
+
+**No migration and no registration.** `violations` is a jsonb column and `software_compliance_status` appears in neither `tenantCascade.ts` nor `tenantExportPolicyRegistry.ts` (grep count 0 in both) — re-verified in §0.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `apps/api/src/services/softwarePolicyService.test.ts`:
+
+```ts
+/**
+ * #5505 D9 — a `missing` violation is the ONLY place the install path can
+ * learn WHAT to install. Before this wave the emission dropped the rule's
+ * `catalogId`, and re-matching a violation to its rule by name is not an
+ * option: rule names are not unique within a policy and nothing enforces that
+ * they are.
+ */
+describe('missing violations carry the rule catalogId', () => {
+  const CATALOG_ID = '99999999-9999-4999-8999-999999999999';
+
+  it('emits catalogId and reason from the unmatched rule', () => {
+    const rules = normalizeSoftwarePolicyRules({
+      software: [{ name: '7-Zip', minVersion: '23.0', catalogId: CATALOG_ID, reason: 'Standard archive tool' }],
+      allowUnknown: true,
+    });
+
+    const violations = evaluateSoftwareInventory('allowlist', rules, []);
+    const missing = violations.find((v) => v.type === 'missing');
+
+    expect(missing).toBeDefined();
+    expect(missing?.rule).toEqual({
+      name: '7-Zip',
+      minVersion: '23.0',
+      maxVersion: undefined,
+      catalogId: CATALOG_ID,
+      reason: 'Standard archive tool',
+    });
+  });
+
+  it('leaves catalogId undefined for a rule that has none — never fabricates one', () => {
+    const rules = normalizeSoftwarePolicyRules({
+      software: [{ name: 'Firefox' }],
+      allowUnknown: true,
+    });
+
+    const missing = evaluateSoftwareInventory('allowlist', rules, []).find((v) => v.type === 'missing');
+    expect(missing?.rule?.name).toBe('Firefox');
+    expect(missing?.rule?.catalogId).toBeUndefined();
+  });
+
+  /**
+   * Contract D9 asks whether the new field changes violation matching.
+   * `violationFingerprint` keys a `missing` violation on
+   * `type:rule:name:minVersion:maxVersion` only (softwarePolicyService.ts:107-110),
+   * so it must NOT. Pinned here so W02 can rely on it: a previously-stored
+   * violation with no catalogId still stabilises the new one's detectedAt.
+   */
+  it('does not disturb detectedAt stabilisation against previously-stored violations', () => {
+    const rules = normalizeSoftwarePolicyRules({
+      software: [{ name: '7-Zip', catalogId: CATALOG_ID }],
+      allowUnknown: true,
+    });
+    const next = evaluateSoftwareInventory('allowlist', rules, []);
+
+    const previous = [{
+      type: 'missing',
+      rule: { name: '7-Zip' }, // stored before D9 shipped — no catalogId
+      severity: 'high',
+      detectedAt: '2026-01-01T00:00:00.000Z',
+    }];
+
+    const stabilised = withStableViolationTimestamps(next, previous);
+    expect(stabilised[0]?.detectedAt).toBe('2026-01-01T00:00:00.000Z');
+    expect(stabilised[0]?.rule?.catalogId).toBe(CATALOG_ID);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and watch it fail**
+
+```bash
+cd apps/api && npx vitest run src/services/softwarePolicyService.test.ts
+```
+
+Expected: the first test fails —
+`expected { name: '7-Zip', minVersion: '23.0', maxVersion: undefined } to deeply equal { name: '7-Zip', minVersion: '23.0', maxVersion: undefined, catalogId: '999…', reason: 'Standard archive tool' }`.
+The second and third pass already (they assert absence and stabilisation); they are the guard rails, not the discriminator. Also run:
+
+```bash
+pnpm --filter @breeze/api exec tsc --noEmit
+```
+
+Expected: `error TS2353: Object literal may only specify known properties, and 'catalogId' does not exist in type '{ name: string; minVersion?: string; maxVersion?: string; reason?: string; }'` — the type-level red.
+
+- [ ] **Step 3: Add `catalogId` to the violation type**
+
+In `apps/api/src/db/schema/softwarePolicies.ts`, replace lines 55-60 with:
+
+```ts
+  rule?: {
+    name: string;
+    minVersion?: string;
+    maxVersion?: string;
+    reason?: string;
+    /**
+     * The catalog item the matched/unmatched rule points at (#5505 D9).
+     * Load-bearing for desired-state install: a `missing` violation is the only
+     * place the install path can learn WHAT to install, and rule names are not
+     * unique within a policy, so re-deriving it by name is not an option.
+     */
+    catalogId?: string;
+  };
+```
+
+- [ ] **Step 4: Carry `catalogId` and `reason` through the `missing` emission**
+
+In `apps/api/src/services/softwarePolicyService.ts`, replace the loop at lines 333-347 with:
+
+```ts
+    for (const rule of softwareRules) {
+      const found = inventory.some((installed) => matchesSoftwareRule(installed, rule));
+      if (!found) {
+        violations.push({
+          type: 'missing',
+          rule: {
+            name: rule.name,
+            minVersion: rule.minVersion,
+            maxVersion: rule.maxVersion,
+            // #5505 D9: the install path resolves the catalog item from here.
+            // `reason` mirrors the audit-mode branch below, which has always
+            // carried it — a `missing` violation dropping it was an oversight.
+            catalogId: rule.catalogId,
+            reason: rule.reason,
+          },
+          severity: 'high',
+          detectedAt,
+        });
+      }
+    }
+```
+
+- [ ] **Step 5: Run the tests and watch them pass**
+
+```bash
+cd apps/api && npx vitest run src/services/softwarePolicyService.test.ts
+pnpm --filter @breeze/api exec tsc --noEmit
+```
+
+Expected: all suites pass; tsc clean.
+
+- [ ] **Step 6: Run the compliance-worker suite — it consumes these violations**
+
+```bash
+cd apps/api && npx vitest run src/jobs/softwareComplianceWorker.test.ts
+```
+
+Expected: pass, unchanged. This wave does not edit that worker; the run confirms the extra jsonb field did not disturb its violation handling.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/db/schema/softwarePolicies.ts apps/api/src/services/softwarePolicyService.ts apps/api/src/services/softwarePolicyService.test.ts
+git commit -m "feat(api): carry rule catalogId and reason on missing software violations (#5506)"
+```
+
+---
+
+### Task 5: `softwarePolicyAuthorization.ts` — the install-arming gate
+
+**Files:**
+- Create: `apps/api/src/services/softwarePolicyAuthorization.ts`
+- Test (create): `apps/api/src/services/softwarePolicyAuthorization.test.ts`
+
+**Interfaces:**
+- Consumes: `readSoftwarePolicyAutoInstall` and `SoftwarePolicyArmingInput` from `./softwarePolicyService` (Task 2); `hasPermission`, `PERMISSIONS`, `UserPermissions` from `./permissions`; `hasSatisfiedMfa` from `../middleware/auth`.
+- Produces:
+  - `type SoftwarePolicyInstallArmingPatch = { mode?: string | null; enforceMode?: boolean | null; remediationOptions?: unknown }`
+  - `const ARM_INSTALL_EXECUTE_DENIED_MESSAGE: string`
+  - `function willBeArmedForInstall(stored: SoftwarePolicyArmingInput | null, patch: SoftwarePolicyInstallArmingPatch): boolean`
+  - `async function assertMayArmInstall(c: Context, stored: SoftwarePolicyArmingInput | null, patch: SoftwarePolicyInstallArmingPatch): Promise<Response | null>` — `null` means allowed; a `Response` is the 403 the handler must return. (See "Contract deviation" in Global Constraints.)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/src/services/softwarePolicyAuthorization.test.ts`:
+
+```ts
+/**
+ * #5505 D3 — arming `remediationOptions.autoInstall` installs software on
+ * customer machines, which is exactly what creating a software deployment does
+ * (`routes/software.ts:1882-1888`: devices:execute + requireMfa()). The
+ * software-policy write routes carry only devices:write + requireMfa(), so
+ * without this gate a devices:write holder reaches installation through the
+ * policy route — a privilege-escalation path around the deployment gate.
+ *
+ * The check is over POST-WRITE state: stored row overlaid with the request
+ * body. That is what makes "edit the rules of an ALREADY-armed policy" gated
+ * too — adding a catalogId to an armed policy installs new software.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+const { mfaRef, executeRef } = vi.hoisted(() => ({
+  mfaRef: { current: true },
+  executeRef: { current: true },
+}));
+
+vi.mock('../middleware/auth', () => ({
+  hasSatisfiedMfa: vi.fn(() => mfaRef.current),
+}));
+
+vi.mock('./permissions', () => ({
+  PERMISSIONS: {
+    DEVICES_EXECUTE: { resource: 'devices', action: 'execute' },
+  },
+  hasPermission: vi.fn((_perms: unknown, resource: string, action: string) =>
+    resource === 'devices' && action === 'execute' ? executeRef.current : false),
+}));
+
+import {
+  ARM_INSTALL_EXECUTE_DENIED_MESSAGE,
+  assertMayArmInstall,
+  willBeArmedForInstall,
+} from './softwarePolicyAuthorization';
+
+const ARMED_STORED = { mode: 'allowlist', enforceMode: true, remediationOptions: { autoInstall: true } };
+const UNARMED_STORED = { mode: 'allowlist', enforceMode: true, remediationOptions: { autoUninstall: true } };
+
+describe('willBeArmedForInstall — post-write merged state', () => {
+  it('create: body alone arms', () => {
+    expect(willBeArmedForInstall(null, {
+      mode: 'allowlist', enforceMode: true, remediationOptions: { autoInstall: true },
+    })).toBe(true);
+  });
+
+  it('create: enforceMode absent means not armed (the row is created with enforceMode=false)', () => {
+    expect(willBeArmedForInstall(null, {
+      mode: 'allowlist', remediationOptions: { autoInstall: true },
+    })).toBe(false);
+  });
+
+  it('create: audit mode is never armed', () => {
+    expect(willBeArmedForInstall(null, {
+      mode: 'audit', enforceMode: true, remediationOptions: { autoInstall: true },
+    })).toBe(false);
+  });
+
+  it('create: autoUninstall does not arm install', () => {
+    expect(willBeArmedForInstall(null, {
+      mode: 'allowlist', enforceMode: true, remediationOptions: { autoUninstall: true },
+    })).toBe(false);
+  });
+
+  it('update: an empty body over an ARMED stored row is still armed', () => {
+    expect(willBeArmedForInstall(ARMED_STORED, {})).toBe(true);
+  });
+
+  it('update: an empty body over an UNARMED stored row is still unarmed', () => {
+    expect(willBeArmedForInstall(UNARMED_STORED, {})).toBe(false);
+  });
+
+  it('update: the body wins over the stored row when it supplies the field', () => {
+    expect(willBeArmedForInstall(ARMED_STORED, { remediationOptions: { autoInstall: false } })).toBe(false);
+    expect(willBeArmedForInstall(ARMED_STORED, { enforceMode: false })).toBe(false);
+    expect(willBeArmedForInstall(ARMED_STORED, { mode: 'audit' })).toBe(false);
+    expect(willBeArmedForInstall(UNARMED_STORED, { remediationOptions: { autoInstall: true } })).toBe(true);
+  });
+
+  it('update: remediationOptions is REPLACED, not merged (routes/softwarePolicies.ts:556)', () => {
+    // The stored row is armed; the body sends an options object without
+    // autoInstall. The route writes that object wholesale, so the result is
+    // disarmed — and the gate must agree.
+    expect(willBeArmedForInstall(ARMED_STORED, { remediationOptions: { cooldownMinutes: 30 } })).toBe(false);
+  });
+});
+
+/** Minimal Hono Context factory: runs a handler and hands back its Response. */
+async function runGate(
+  ctxSetup: (c: any) => void,
+  stored: Parameters<typeof assertMayArmInstall>[1],
+  patch: Parameters<typeof assertMayArmInstall>[2]
+): Promise<Response> {
+  const app = new Hono();
+  app.get('/probe', async (c) => {
+    ctxSetup(c);
+    const denied = await assertMayArmInstall(c, stored, patch);
+    return denied ?? c.json({ ok: true }, 200);
+  });
+  return app.request('/probe');
+}
+
+const ALLOWED_CTX = (c: any) => {
+  c.set('auth', { user: { id: 'user-1' }, token: { mfa: true } });
+  c.set('permissions', { permissions: [], scope: 'organization', orgId: null, partnerId: null, roleId: 'role-1' });
+};
+
+describe('assertMayArmInstall', () => {
+  beforeEach(() => {
+    mfaRef.current = true;
+    executeRef.current = true;
+  });
+
+  it('allows any write that does not arm install, regardless of permissions', async () => {
+    executeRef.current = false;
+    mfaRef.current = false;
+    const res = await runGate(ALLOWED_CTX, UNARMED_STORED, { mode: 'allowlist' });
+    expect(res.status).toBe(200);
+  });
+
+  it('allows an arming write from a caller with devices.execute and MFA', async () => {
+    const res = await runGate(ALLOWED_CTX, null, {
+      mode: 'allowlist', enforceMode: true, remediationOptions: { autoInstall: true },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it('refuses an arming write without devices.execute', async () => {
+    executeRef.current = false;
+    const res = await runGate(ALLOWED_CTX, null, {
+      mode: 'allowlist', enforceMode: true, remediationOptions: { autoInstall: true },
+    });
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({
+      error: ARM_INSTALL_EXECUTE_DENIED_MESSAGE,
+      code: 'DEVICES_EXECUTE_REQUIRED',
+    });
+  });
+
+  it('refuses an arming write when MFA is not satisfied, even with devices.execute', async () => {
+    mfaRef.current = false;
+    const res = await runGate(ALLOWED_CTX, null, {
+      mode: 'allowlist', enforceMode: true, remediationOptions: { autoInstall: true },
+    });
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'MFA required', code: 'MFA_REQUIRED' });
+  });
+
+  it('fails closed when the route never resolved permissions', async () => {
+    const res = await runGate(
+      (c: any) => { c.set('auth', { user: { id: 'user-1' }, token: { mfa: true } }); },
+      null,
+      { mode: 'allowlist', enforceMode: true, remediationOptions: { autoInstall: true } }
+    );
+    expect(res.status).toBe(403);
+    expect((await res.json()).code).toBe('DEVICES_EXECUTE_REQUIRED');
+  });
+
+  it('refuses with 401 when there is no auth context at all', async () => {
+    const res = await runGate(
+      (c: any) => { c.set('permissions', { permissions: [] }); },
+      null,
+      { mode: 'allowlist', enforceMode: true, remediationOptions: { autoInstall: true } }
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('gates an edit that leaves an ALREADY-armed policy armed', async () => {
+    executeRef.current = false;
+    // Body touches only the name; the stored row stays armed for install.
+    const res = await runGate(ALLOWED_CTX, ARMED_STORED, {});
+    expect(res.status).toBe(403);
+  });
+
+  it('does not gate a write that DISARMS an armed policy', async () => {
+    executeRef.current = false;
+    const res = await runGate(ALLOWED_CTX, ARMED_STORED, { remediationOptions: { autoInstall: false } });
+    expect(res.status).toBe(200);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and watch it fail**
+
+```bash
+cd apps/api && npx vitest run src/services/softwarePolicyAuthorization.test.ts
+```
+
+Expected: `Error: Failed to load url ./softwarePolicyAuthorization` — the module does not exist yet.
+
+- [ ] **Step 3: Write the service**
+
+Create `apps/api/src/services/softwarePolicyAuthorization.ts`:
+
+```ts
+import type { Context } from 'hono';
+import { hasSatisfiedMfa } from '../middleware/auth';
+import { hasPermission, PERMISSIONS, type UserPermissions } from './permissions';
+import { readSoftwarePolicyAutoInstall, type SoftwarePolicyArmingInput } from './softwarePolicyService';
+
+/**
+ * Install-arming authorization (#5505 D3).
+ *
+ * Arming `remediationOptions.autoInstall` causes software to be installed on
+ * customer machines — exactly what creating a software deployment does, which
+ * requires `devices:execute` + `requireMfa()` (`routes/software.ts:1882-1888`).
+ * The software-policy write routes require only `devices:write` +
+ * `requireMfa()` + the in-handler `canMutateOrgWideGovernance` site ceiling, so
+ * the delta needed to reach deployment-grade authorization is `devices.execute`.
+ * Without this assertion the policy route is a privilege-escalation path around
+ * the deployment gate.
+ *
+ * Why in-handler and not middleware: middleware cannot see whether the write
+ * ARMS install — that depends on the resulting policy, which only exists once
+ * the request body has been merged onto the stored row.
+ *
+ * Both conditions are asserted even though both current call sites already sit
+ * behind `requireMfa()`. The assertion must stay correct if it is ever reused
+ * on a route without it.
+ */
+
+/** The subset of a policy write body that can change install arming. */
+export type SoftwarePolicyInstallArmingPatch = {
+  mode?: string | null;
+  enforceMode?: boolean | null;
+  remediationOptions?: unknown;
+};
+
+export const ARM_INSTALL_EXECUTE_DENIED_MESSAGE =
+  'Arming remediationOptions.autoInstall installs software on managed devices, so it requires the '
+  + 'devices.execute permission — the same permission as creating a software deployment.';
+
+/**
+ * Post-write arming: `stored` is the row as it exists today (null on create),
+ * `patch` is the validated request body. A field the body does not supply keeps
+ * its stored value, which mirrors the PATCH handler exactly — note that
+ * `remediationOptions` is REPLACED wholesale there
+ * (`routes/softwarePolicies.ts:556`), never merged key-by-key.
+ */
+export function willBeArmedForInstall(
+  stored: SoftwarePolicyArmingInput | null,
+  patch: SoftwarePolicyInstallArmingPatch
+): boolean {
+  const mode = patch.mode !== undefined ? patch.mode : stored?.mode;
+  const enforceMode = patch.enforceMode !== undefined ? patch.enforceMode : stored?.enforceMode;
+  const remediationOptions = patch.remediationOptions !== undefined
+    ? patch.remediationOptions
+    : stored?.remediationOptions;
+
+  if (mode === 'audit') return false;
+  if (enforceMode !== true) return false;
+  return readSoftwarePolicyAutoInstall(remediationOptions);
+}
+
+/**
+ * Returns `null` when the write is allowed, or the 403/401 `Response` the
+ * handler must return when it is not:
+ *
+ *   const denied = await assertMayArmInstall(c, stored, patch);
+ *   if (denied) return denied;
+ *
+ * Refusals use coded bodies rather than `HTTPException` so callers branch on
+ * `code` (mirrors `requireMfa()`, `middleware/auth.ts:897-905`).
+ */
+export async function assertMayArmInstall(
+  c: Context,
+  stored: SoftwarePolicyArmingInput | null,
+  patch: SoftwarePolicyInstallArmingPatch
+): Promise<Response | null> {
+  if (!willBeArmedForInstall(stored, patch)) return null;
+
+  const auth = c.get('auth');
+  if (!auth) {
+    return c.json({ error: 'Not authenticated', code: 'NOT_AUTHENTICATED' }, 401);
+  }
+
+  // `requirePermission` populates this (middleware/auth.ts:874) and runs ahead
+  // of both current handlers. A missing value means this assertion is being
+  // used off a route that never resolved permissions — fail closed.
+  const perms = c.get('permissions') as UserPermissions | undefined;
+  if (!perms || !hasPermission(
+    perms,
+    PERMISSIONS.DEVICES_EXECUTE.resource,
+    PERMISSIONS.DEVICES_EXECUTE.action
+  )) {
+    return c.json({ error: ARM_INSTALL_EXECUTE_DENIED_MESSAGE, code: 'DEVICES_EXECUTE_REQUIRED' }, 403);
+  }
+
+  if (!hasSatisfiedMfa(auth)) {
+    return c.json({ error: 'MFA required', code: 'MFA_REQUIRED' }, 403);
+  }
+
+  return null;
+}
+```
+
+- [ ] **Step 4: Run the tests and watch them pass**
+
+```bash
+cd apps/api && npx vitest run src/services/softwarePolicyAuthorization.test.ts
+```
+
+Expected: 17 passed, 1 file.
+
+- [ ] **Step 5: Typecheck and commit**
+
+```bash
+pnpm --filter @breeze/api exec tsc --noEmit
+git add apps/api/src/services/softwarePolicyAuthorization.ts apps/api/src/services/softwarePolicyAuthorization.test.ts
+git commit -m "feat(api): add the install-arming authorization gate (devices.execute + MFA) (#5506)"
+```
+
+---
+
+### Task 6: wire the gate into the policy create and update routes
+
+**Files:**
+- Modify: `apps/api/src/routes/softwarePolicies.ts` (import; create handler after `:301`; update handler after `:541`)
+- Test: `apps/api/src/routes/softwarePolicies.autoInstall.test.ts` (append)
+
+**Interfaces:**
+- Consumes: `assertMayArmInstall` from `../services/softwarePolicyAuthorization` (Task 5); `remediationOptionsSchema` with `autoInstall` (Task 1).
+- Produces: no new exports. Behavioural contract: `POST /software-policies` and `PATCH /software-policies/:id` return `403 { code: 'DEVICES_EXECUTE_REQUIRED' }` or `403 { code: 'MFA_REQUIRED' }` when the write would leave the policy armed for install and the caller is not authorized. No write occurs on refusal.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `apps/api/src/routes/softwarePolicies.autoInstall.test.ts`. Extend the existing import of `./softwarePolicies` — no change needed there — and add one import at the top of the import block:
+
+```ts
+import { ARM_INSTALL_EXECUTE_DENIED_MESSAGE } from '../services/softwarePolicyAuthorization';
+```
+
+Then append:
+
+```ts
+describe('#5505 D3 — arming autoInstall requires devices.execute + MFA', () => {
+  const ARMED_BODY = {
+    orgId: ORG_ID,
+    name: 'Required software',
+    mode: 'allowlist',
+    rules: { software: [{ name: '7-Zip' }] },
+    enforceMode: true,
+    remediationOptions: { autoInstall: true },
+  };
+
+  function mockStoredPolicy(row: Record<string, unknown>) {
+    (db.select as any).mockReturnValue({
+      from: () => ({ where: () => ({ limit: () => Promise.resolve([row]) }) }),
+    });
+  }
+
+  function mockUpdateTransaction() {
+    (db.transaction as any).mockImplementation(async (fn: (tx: unknown) => unknown) => fn({
+      update: () => ({
+        set: () => ({ where: () => ({ returning: () => Promise.resolve([{ id: POLICY_ID, orgId: ORG_ID, name: 'renamed', approvalGeneration: 2 }]) }) }),
+      }),
+    }));
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authRef.current = orgAuth() as unknown as Record<string, unknown>;
+    mfaRef.current = true;
+    executeRef.current = true;
+  });
+
+  it('POST refuses an arming create without devices.execute, and writes nothing', async () => {
+    executeRef.current = false;
+    const captured: { values?: Record<string, unknown> } = {};
+    mockInsertCapturing(captured);
+
+    const res = await app().request('/software-policies', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(ARMED_BODY),
+    });
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({
+      error: ARM_INSTALL_EXECUTE_DENIED_MESSAGE,
+      code: 'DEVICES_EXECUTE_REQUIRED',
+    });
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it('POST refuses an arming create when MFA is unsatisfied', async () => {
+    mfaRef.current = false;
+    mockInsertCapturing({});
+
+    const res = await app().request('/software-policies', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(ARMED_BODY),
+    });
+
+    expect(res.status).toBe(403);
+    expect((await res.json()).code).toBe('MFA_REQUIRED');
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it('POST allows an arming create for a caller with devices.execute + MFA', async () => {
+    const captured: { values?: Record<string, unknown> } = {};
+    mockInsertCapturing(captured);
+
+    const res = await app().request('/software-policies', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(ARMED_BODY),
+    });
+
+    expect(res.status).toBe(201);
+    expect(captured.values?.remediationOptions).toEqual({ autoInstall: true });
+  });
+
+  it('POST does NOT gate autoInstall without enforceMode (the row is created detect-only)', async () => {
+    executeRef.current = false;
+    const captured: { values?: Record<string, unknown> } = {};
+    mockInsertCapturing(captured);
+
+    const res = await app().request('/software-policies', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...ARMED_BODY, enforceMode: false }),
+    });
+
+    expect(res.status).toBe(201);
+  });
+
+  it('POST does NOT gate an audit-mode policy even with enforceMode + autoInstall', async () => {
+    executeRef.current = false;
+    mockInsertCapturing({});
+
+    const res = await app().request('/software-policies', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...ARMED_BODY, mode: 'audit' }),
+    });
+
+    expect(res.status).toBe(201);
+  });
+
+  it('POST does NOT gate an autoUninstall-only create', async () => {
+    executeRef.current = false;
+    mockInsertCapturing({});
+
+    const res = await app().request('/software-policies', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...ARMED_BODY, remediationOptions: { autoUninstall: true } }),
+    });
+
+    expect(res.status).toBe(201);
+  });
+
+  it('PATCH gates a rules edit on an ALREADY-armed policy (post-write merged state)', async () => {
+    executeRef.current = false;
+    mockStoredPolicy({
+      id: POLICY_ID, orgId: ORG_ID, isActive: true,
+      mode: 'allowlist', enforceMode: true, remediationOptions: { autoInstall: true },
+    });
+    mockUpdateTransaction();
+
+    const res = await app().request(`/software-policies/${POLICY_ID}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ rules: { software: [{ name: 'Firefox' }] } }),
+    });
+
+    expect(res.status).toBe(403);
+    expect((await res.json()).code).toBe('DEVICES_EXECUTE_REQUIRED');
+    expect(db.transaction).not.toHaveBeenCalled();
+  });
+
+  it('PATCH allows DISARMING an armed policy without devices.execute', async () => {
+    executeRef.current = false;
+    mockStoredPolicy({
+      id: POLICY_ID, orgId: ORG_ID, isActive: true,
+      mode: 'allowlist', enforceMode: true, remediationOptions: { autoInstall: true },
+    });
+    mockUpdateTransaction();
+
+    const res = await app().request(`/software-policies/${POLICY_ID}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ remediationOptions: { autoInstall: false } }),
+    });
+
+    expect(res.status).toBe(200);
+  });
+
+  it('PATCH gates arming an unarmed policy', async () => {
+    executeRef.current = false;
+    mockStoredPolicy({
+      id: POLICY_ID, orgId: ORG_ID, isActive: true,
+      mode: 'allowlist', enforceMode: true, remediationOptions: { autoUninstall: true },
+    });
+    mockUpdateTransaction();
+
+    const res = await app().request(`/software-policies/${POLICY_ID}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ remediationOptions: { autoInstall: true } }),
+    });
+
+    expect(res.status).toBe(403);
+    expect(db.transaction).not.toHaveBeenCalled();
+  });
+
+  it('PATCH leaves an ordinary edit on an unarmed policy alone', async () => {
+    executeRef.current = false;
+    mockStoredPolicy({
+      id: POLICY_ID, orgId: ORG_ID, isActive: true,
+      mode: 'allowlist', enforceMode: true, remediationOptions: null,
+    });
+    mockUpdateTransaction();
+
+    const res = await app().request(`/software-policies/${POLICY_ID}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'renamed' }),
+    });
+
+    expect(res.status).toBe(200);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests and watch them fail**
+
+```bash
+cd apps/api && npx vitest run src/routes/softwarePolicies.autoInstall.test.ts
+```
+
+Expected: the six refusal/gating tests fail with `expected 201 to be 403` / `expected 200 to be 403` and `expected "insert" not to be called` — the routes do not consult the gate yet. The permissive tests pass.
+
+- [ ] **Step 3: Import the gate into the route module**
+
+In `apps/api/src/routes/softwarePolicies.ts`, add the import next to the other service imports (after line 20, `siteCeilingAccess`):
+
+```ts
+import { assertMayArmInstall } from '../services/softwarePolicyAuthorization';
+```
+
+- [ ] **Step 4: Gate the create handler**
+
+In `apps/api/src/routes/softwarePolicies.ts`, replace line 301 (`const payload = c.req.valid('json');` inside the POST handler) with:
+
+```ts
+    const payload = c.req.valid('json');
+
+    // #5505 D3: arming remediationOptions.autoInstall installs software on
+    // managed devices, so it needs deployment-grade authorization
+    // (devices.execute + MFA) on top of the devices:write + requireMfa() this
+    // route already carries. `stored` is null — nothing exists yet — so the
+    // merged state is the body alone.
+    const armDenied = await assertMayArmInstall(c, null, {
+      mode: payload.mode,
+      enforceMode: payload.enforceMode,
+      remediationOptions: payload.remediationOptions,
+    });
+    if (armDenied) return armDenied;
+```
+
+- [ ] **Step 5: Gate the update handler**
+
+In `apps/api/src/routes/softwarePolicies.ts`, insert immediately after the partner-wide administration check that ends at line 541 (`}` closing `if (policy.orgId === null && !canManagePartnerWidePolicies(auth))`), and before the `const updates: …` declaration:
+
+```ts
+    // #5505 D3: evaluated over the POST-WRITE merged state — the stored row
+    // overlaid with this body — so editing an ALREADY-armed policy is gated
+    // too. Adding a catalogId to an armed policy installs new software, and
+    // that must not be reachable with a weaker credential than arming was.
+    const armDenied = await assertMayArmInstall(c, policy, {
+      mode: payload.mode,
+      enforceMode: payload.enforceMode,
+      remediationOptions: payload.remediationOptions,
+    });
+    if (armDenied) return armDenied;
+```
+
+- [ ] **Step 6: Run the tests and watch them pass**
+
+```bash
+cd apps/api && npx vitest run src/routes/softwarePolicies.autoInstall.test.ts
+```
+
+Expected: all suites pass (5 from Task 1 + 10 here).
+
+- [ ] **Step 7: Re-run the neighbouring route suites and typecheck**
+
+```bash
+cd apps/api && npx vitest run src/routes/softwarePolicies.test.ts src/routes/softwarePolicies.siteScope.test.ts src/routes/softwarePolicies.approvalGeneration.test.ts
+pnpm --filter @breeze/api exec tsc --noEmit
+```
+
+Expected: 3 files passed; tsc clean. None of those files sends `remediationOptions` (verified in §0), so the gate short-circuits before it can touch their `../services/permissions` mock — which supplies no `hasPermission`. If one of them ever starts sending armed options, add `hasPermission: () => true` to that file's permissions mock.
+
+- [ ] **Step 8: Lint and commit**
+
+```bash
+pnpm --filter @breeze/api lint
+git add apps/api/src/routes/softwarePolicies.ts apps/api/src/routes/softwarePolicies.autoInstall.test.ts
+git commit -m "feat(api): gate autoInstall arming on devices.execute + MFA in both policy write routes (#5506)"
+```
+
+---
+
+## Wave close-out
+
+- [ ] **Run every suite this wave touched, in one command**
+
+```bash
+cd apps/api && npx vitest run \
+  src/routes/softwarePolicies.autoInstall.test.ts \
+  src/routes/softwarePolicies.test.ts \
+  src/routes/softwarePolicies.siteScope.test.ts \
+  src/routes/softwarePolicies.approvalGeneration.test.ts \
+  src/services/softwarePolicyArming.test.ts \
+  src/services/softwarePolicyService.test.ts \
+  src/services/softwarePolicyAuthorization.test.ts \
+  src/services/aiToolsCompliance.siteScope.test.ts \
+  src/jobs/softwareRemediationWorker.test.ts \
+  src/jobs/softwareComplianceWorker.test.ts
+```
+
+Every path is listed explicitly on purpose: vitest's filter is a plain substring match, so `src/services/softwarePolicy` would also pull in unrelated files and `src/services/softwarePolicy/` would match nothing.
+
+- [ ] **Typecheck and lint the package**
+
+```bash
+pnpm --filter @breeze/api exec tsc --noEmit
+pnpm --filter @breeze/api lint
+```
+
+- [ ] **No migration, no registry — assert it rather than assume it**
+
+```bash
+git diff --name-only main...HEAD | grep -E 'migrations/|tenantCascade|tenantExportPolicyRegistry|rls-coverage|routes/devices/core' || echo "clean: no migration or registry file touched"
+```
+
+Expected: `clean: …`. This wave changes only jsonb-typed shapes and TypeScript, so the cascade/export/RLS contracts are untouched. If this grep prints a filename, something outside W01's scope was edited — revert it.
+
+- [ ] **PR body must state the out-of-scope list**
+
+Include the "Explicitly OUT OF SCOPE" section from this plan verbatim, plus `Closes #5506`, so a reviewer does not read the missing worker/dispatch/migration work as an omission.
+
+---
+
+## Self-review
+
+**1. Spec coverage.** Walked the spec and the contract's wave-ownership row for W01:
+
+| Requirement | Task |
+|---|---|
+| `autoInstall?: boolean` on `SoftwarePolicyRemediationOptions` (spec §1) | 1 |
+| `autoInstall` on both HTTP zod schemas (contract "Verified starting facts": one shared object) | 1 |
+| No migration / no export-policy change for `autoInstall` (spec §1) | 1 + close-out grep |
+| `PolicyRemediationVerb`, extended `SoftwarePolicyUnarmedReason`, `readSoftwarePolicyAutoInstall`, required verb param (D2) | 2 |
+| Both non-test call sites pass `'uninstall'` (D2) | 2 (step 4) |
+| Verb-aware refusal messages, `auto_install_off` names `remediationOptions.autoInstall` (D2) | 2 |
+| Regression: arming install does not arm uninstall and vice versa (spec Testing) | 2 (`the two verbs are independent`) |
+| `softwarePolicyAuthorization.ts` + `assertMayArmInstall` (D3) | 5 |
+| `devices.execute` **and** MFA both asserted (D3) | 5 |
+| Post-write merged state; editing an already-armed policy gated (D3) | 5 + 6 |
+| Wired into policy create and update (D3) | 6 |
+| Four exported audit-action constants, no literals, no uninstall refactor (D6) | 3 |
+| `catalogId` (+ `reason`) on the emitted `missing` violation and on the type (D9) | 4 |
+| D9's open question — does the new field disturb violation matching? | 4 (answered *no*, with a regression test; see §0) |
+
+Not covered, by design: everything in the "Explicitly OUT OF SCOPE" list. Spec §5's AI-tool decision ("the safe default is no") is D4, owned by **W05** — W01 deliberately leaves the AI write sites alone, and because `aiAgentSdkTools.ts:2251` types `remediationOptions` as `z.record(z.string(), z.unknown())`, adding `autoInstall` to the HTTP schema in Task 1 does **not** widen the AI surface (it was already unconstrained). The one AI-adjacent edit here is the compiler-forced `'uninstall'` argument at `aiToolsCompliance.ts:509`.
+
+**2. Placeholder scan.** No "TBD", no "similar to Task N", no "add appropriate error handling". Every code step carries the complete literal it replaces or inserts, quoted against a line range that was re-opened during the ground-truth pass. The one judgement call left to the implementer is spelled out with its exact remedy (Task 6 step 7's permissions-mock note).
+
+**3. Type consistency.** Names used across tasks: `SoftwarePolicyArmingInput` (Task 2 keeps it unchanged; Tasks 5/6 consume it as `stored`'s type); `readSoftwarePolicyAutoInstall` (Task 2 defines, Task 5 imports, Task 1's route-test mock reproduces it faithfully); `SoftwarePolicyInstallArmingPatch` (Task 5 defines, Task 6 passes object literals matching it — `mode?: string | null` accepts the route's `'allowlist' | 'blocklist' | 'audit' | undefined`, `enforceMode?: boolean | null` accepts `boolean | undefined`); `ARM_INSTALL_EXECUTE_DENIED_MESSAGE` (Task 5 exports, Tasks 5 and 6 assert against it rather than restating the string); `SOFTWARE_POLICY_INSTALL_AUDIT_ACTIONS` (Task 3, consumed by W02/W03 only). `assertMayArmInstall`'s three-parameter shape is used identically in Task 5's tests and Task 6's two call sites.
+
+**4. Known deviation.** One, recorded in Global Constraints → "Contract deviation": `assertMayArmInstall` returns `Promise<Response | null>` and takes `(c, stored, patch)` rather than the contract's `(c): Promise<void>`. Name, file path, semantics and both refusal bodies are exactly as contracted.

--- a/docs/superpowers/plans/vuln-patch/2026-09-10-desired-state-software-install-w02-compliance-worker.md
+++ b/docs/superpowers/plans/vuln-patch/2026-09-10-desired-state-software-install-w02-compliance-worker.md
@@ -1,0 +1,2758 @@
+---
+tracking_issue: LanternOps/breeze#5505
+---
+
+# Wave 02 — Compliance worker: missing-violation install remediation, per-pass cap, give-up counter — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the software compliance worker act on `missing` violations — gate the new install verb on W01's shared arming helper, decide per device whether to queue an install (grace, cooldown, catalog-id presence, per-pass cap, consecutive-attempt give-up), record the decision in three new `software_compliance_status` columns, and enqueue a typed install-remediation job that W03's processor will consume.
+
+**Architecture:** `software_compliance_status` gains `install_remediation_status` / `last_install_remediation_attempt` / `install_remediation_attempts` — a second, parallel status axis so every existing uninstall read and write stays byte-for-byte untouched (contract D1). `upsertSoftwareComplianceStatuses` generalises its existing two-branch "was `remediationStatus` provided" split into a shape-keyed grouping so a pass that says nothing about a column still never clobbers it. The worker stops re-deriving the arming gate inline and calls W01's `evaluateSoftwarePolicyArming(policy, verb)` for both verbs (D11); the grace clock stops hard-filtering `unauthorized` and takes the violation type it should measure (D10). A new pure `decideInstallRemediation()` holds all install-specific gating so the failure mode the spec calls out — an install loop that reinstalls forever every 15 minutes — is bounded by a per-policy per-pass cap and a consecutive-attempt counter that terminates at `gave_up`. Install jobs ride the existing `software-remediation` BullMQ queue under their own `type` discriminant and their own jobId namespace, so a device can be queued for uninstall AND install in the same pass without one deduping into the other.
+
+**Tech Stack:** Hono + Drizzle ORM + PostgreSQL (RLS), BullMQ, Vitest (unit), zod (not touched by this wave).
+
+**Spec:** `docs/superpowers/specs/vuln-patch/2026-09-10-desired-state-software-install-design.md` (§2 missing-violation branch, §6 audit, Risks §1 install loops and §2 fleet-wide first run, Testing bullets 1-2 and the install half of bullet 6 — NOT §3 dispatch, §4 catalog resolution, §5 authorization, which are W01/W03/W05). Its **"Corrections after ground-truth verification"** section supersedes the body.
+
+**Contract:** `contract-A-desired-state.md` (coordinator, authoritative). This wave owns D1, D5, D10, D11, the D9 *check*, and the install job payload. It does not re-decide anything there.
+
+**Depends on:** **W01 (#5506)**, which must be merged first. W01 produces `PolicyRemediationVerb`, `readSoftwarePolicyAutoInstall`, the two-argument `evaluateSoftwarePolicyArming(policy, verb)`, the install audit-action constants, and `SoftwarePolicyViolation['rule'].catalogId`.
+
+**Consumed by:** **W03 (#5508)**, which implements the processor for the job payload defined in Task 8 and replaces the parking branch installed there.
+
+## Global Constraints
+
+- **Migration slot:** `apps/api/migrations/2026-10-15-150400-software-compliance-install-remediation.sql`. Confirmed at plan time via `ls apps/api/migrations/*.sql | sort | tail -1` → `2026-10-15-150300-remote-session-revocation-lease.sql`, so `150400` sorts last. **Re-run that command at implementation time and rename upward if anything now sorts after it** — migration filenames run ahead of real time and today's date does NOT sort last. `2026-08-06` is a closed date block; never use it. Never edit a shipped migration.
+- The migration is **DDL only** (three `ADD COLUMN IF NOT EXISTS`). It performs no `UPDATE`/`DELETE`/`INSERT`/`MERGE`, so it needs **no** `SELECT set_config('breeze.scope','system',true);`. Run `apps/api/src/db/migrationRlsScope.test.ts` anyway (Task 1 Step 5) to prove the guard stays green and that this file is not added to the 122-file frozen baseline.
+- **No registration changes.** `software_compliance_status` has no `org_id`; verified zero occurrences in `apps/api/src/services/tenantCascade.ts` and `apps/api/src/services/tenantExportPolicyRegistry.ts`, and it is already registered in `CORE_DEVICE_CASCADE_DELETE_TABLES` at `apps/api/src/routes/devices/core.ts:511`. It is deliberately absent from `CORE_DEVICE_ORG_DENORMALIZED_TABLES` (documented at `core.ts:208` as "no `org_id` column today"). Adding columns changes none of that.
+- **New column shapes, verbatim from contract D1** (mirroring the existing `remediation_status` / `last_remediation_attempt` types at `softwarePolicies.ts:121-122`):
+  ```
+  install_remediation_status        varchar(20)  NULL DEFAULT 'none'
+  last_install_remediation_attempt  timestamp    NULL
+  install_remediation_attempts      integer      NOT NULL DEFAULT 0
+  ```
+- **Allowed `install_remediation_status` values — a TS union, no DB enum:**
+  `'none' | 'pending' | 'in_progress' | 'completed' | 'failed' | 'gave_up' | 'skipped'`
+  where `'gave_up'` = consecutive attempts exhausted and `'skipped'` = rule has no `catalogId`, platform mismatch (W03), or the per-pass cap was hit.
+- **`install_remediation_attempts` is the CONSECUTIVE attempt counter** for the install-loop guard: reset to 0 whenever that (policy, device) has no `missing` violation left; incremented on every queue.
+- **New env knobs, resolved PER CALL, never captured at module load** (contract D5), in new file `apps/api/src/services/softwareInstallRemediationKnobs.ts`:
+
+  | Knob | Default | Floor | Meaning |
+  |---|---|---|---|
+  | `SOFTWARE_INSTALL_REMEDIATION_MAX_PER_PASS` | `50` | `1` | installs queued per policy per compliance pass |
+  | `SOFTWARE_INSTALL_REMEDIATION_MAX_ATTEMPTS` | `3` | `1` | consecutive attempts before giving up |
+
+  Do **NOT** write `export const X = resolveX()` — that is the frozen-at-module-load bug `BACKUP_GC_GRACE_MS` shipped at `apps/api/src/jobs/backupRetention.ts:539`.
+- **Audit action values are locked by contract D6:** `install_queued`, `install_succeeded`, `install_failed`, `install_gave_up`. W02 emits `install_queued` and `install_gave_up`. Import the constant object W01 exported from `softwarePolicyService.ts` — **never a string literal at an emit site**.
+- **The existing upsert's non-clobber property is load-bearing and must be preserved.** `upsertSoftwareComplianceStatuses` splits on "was `remediationStatus` provided" precisely so a pass with nothing to say about that column does not write `excluded.remediation_status` (which for a fresh `values()` row would be the insert-time DEFAULT) over a live value. The install columns must inherit that behaviour, not always-write.
+- **Explicitly OUT OF SCOPE for this wave** (contract wave-ownership map): deployment creation or dispatch of any kind, the `software_deployments` table and its `software_policy_id` column, `createSoftwareDeployment`, `dispatchSoftwareInstallToDevice`, catalog→install-method resolution and the platform-mismatch filter (all W03); any file under `apps/web` (W04); `aiGuardrails.ts`, `aiToolsCompliance.ts`, `aiToolsPolicyPrereqs.ts`, `aiToolSchemas.ts`, `aiAgentSdkTools.ts`, `aiToolsSoftwarePolicyAudit.ts` (W05); the `autoInstall` schema field, the arming helper's own body, the authorization assertion, and the `catalogId` emission (all W01). The `'outdated'` violation type stays unwired (spec Non-goals).
+- **TDD is mandatory and red-first.** Write the assertion, run it against unmodified code, watch it fail, then implement.
+- **Scoped test runs are `cd apps/api && npx vitest run <path>`.** Never `pnpm --filter <pkg> test -- --run <path>` — the `--` makes vitest run the whole suite in watch mode. Vitest's path filter is a plain substring match, not a glob: list dotted sibling files explicitly and always check the reported file count.
+
+---
+
+## 0. Ground truth
+
+Every claim below was verified by re-opening the file in this worktree (`/Users/toddhebebrand/.herdr/worktrees/breeze/warranty-testing`, branch `spec/hp-warranty-and-desired-state-install`) on 2026-09-10. The contract's "Verified starting facts" line numbers were **confirmed, not copied**. Deltas are flagged.
+
+### Schema — `apps/api/src/db/schema/softwarePolicies.ts` (188 lines)
+
+- `:25-32` `SoftwarePolicyRuleDefinition` — `{ name; vendor?; minVersion?; maxVersion?; catalogId?; reason? }`. **Confirmed**, and `catalogId?` is present today.
+- `:48-63` `SoftwarePolicyViolation`. Its `rule` sub-object is verbatim:
+  ```ts
+    rule?: {
+      name: string;
+      minVersion?: string;
+      maxVersion?: string;
+      reason?: string;
+    };
+  ```
+  **No `catalogId`** — confirmed. W01 adds it (contract D9).
+- `:65-71` `SoftwarePolicyRemediationOptions` — `{ autoUninstall?; notifyUser?; gracePeriod?; cooldownMinutes?; maintenanceWindowOnly? }`. **Confirmed**; no `autoInstall` yet.
+- `:114-129` `softwareComplianceStatus`. Columns verbatim:
+  ```ts
+    status: varchar('status', { length: 20 }).notNull().default('compliant'),
+    lastChecked: timestamp('last_checked').notNull(),
+    violations: jsonb('violations').$type<SoftwarePolicyViolation[]>(),
+    remediationStatus: varchar('remediation_status', { length: 20 }).default('none'),
+    lastRemediationAttempt: timestamp('last_remediation_attempt'),
+    remediationErrors: jsonb('remediation_errors').$type<RemediationError[]>(),
+  ```
+  Unique index `software_compliance_device_policy_unique` on `(deviceId, policyId)` at `:128`. **Confirmed.** `integer` is already imported at `:10`, `timestamp` at `:6`, `varchar` at `:4` — Task 2 needs no new imports.
+- `:142` `action: varchar('action', { length: 50 }).notNull()` on `softwarePolicyAudit` — bare varchar, no enum. **Confirmed.**
+
+### Service — `apps/api/src/services/softwarePolicyService.ts` (575 lines)
+
+- `:1` imports are `import { and, eq, inArray, sql } from 'drizzle-orm';` — `sql` is already there; Task 3 adds only `type SQL`.
+- `:28` `export type SoftwarePolicyRemediationStatus = 'none' | 'pending' | 'in_progress' | 'completed' | 'failed';` — **confirmed**, five values, no `gave_up`/`skipped`.
+- `:30-37` `SoftwareComplianceUpsertInput` = `{ deviceId; policyId; status; violations; checkedAt?; remediationStatus? }`. **Confirmed.**
+- `:99-111` `violationFingerprint` — **this is the D9 answer.** Verbatim:
+  ```ts
+  function violationFingerprint(violation: SoftwarePolicyViolation): string {
+    const type = violation.type.toLowerCase();
+    if (violation.type === 'unauthorized') {
+      const name = normalizeComparable(violation.software?.name ?? '');
+      const version = normalizeComparable(violation.software?.version ?? '');
+      return `${type}:software:${name}:${version}`;
+    }
+
+    const ruleName = normalizeComparable(violation.rule?.name ?? '');
+    const minVersion = normalizeComparable(violation.rule?.minVersion ?? '');
+    const maxVersion = normalizeComparable(violation.rule?.maxVersion ?? '');
+    return `${type}:rule:${ruleName}:${minVersion}:${maxVersion}`;
+  }
+  ```
+  **It does NOT compare violation objects structurally.** It builds an explicit key from four named fields and ignores every other property. Adding `catalogId` to the emitted `rule` object therefore **cannot** change match behaviour — no fix is required in this wave, only a regression pin (Task 5). Two consequences worth recording: (a) two `missing` rules with the same name/minVersion/maxVersion but different `catalogId` collapse to one fingerprint and share the earliest `detectedAt`, which makes the grace clock *conservative* (fires sooner), never permissive; (b) `decideInstallRemediation` must therefore key nothing off the fingerprint.
+- `:113-146` `withStableViolationTimestamps(nextViolations, previousViolations)` — builds `previousByKey` from `violationFingerprint`, then maps each next violation to the earliest previous `detectedAt` for the same key, **spreading the original object** (`{ ...violation, detectedAt }`). So a new `rule.catalogId` survives stabilisation untouched. Confirmed. Called only from `softwareComplianceWorker.ts:377` and its own test at `softwarePolicyService.test.ts:88`.
+- `:159` `SoftwarePolicyUnarmedReason = 'audit_mode' | 'enforce_mode_off' | 'auto_uninstall_off'`; `:161-163` `SoftwarePolicyArmingState`; `:165-169` `SoftwarePolicyArmingInput` = `{ mode; enforceMode; remediationOptions }`; `:172-175` `readSoftwarePolicyAutoUninstall`; `:177-206` `evaluateSoftwarePolicyArming(policy)` — **one argument today**. All **confirmed**. The three refusal messages at `:184`, `:192-193`, `:201-202` all say "uninstall" explicitly.
+- `:333-347` the `missing` emission — writes `rule: { name, minVersion, maxVersion }` only. **Confirmed; no `catalogId`, no `reason`.** (The audit-mode branch at `:364-369` does carry `reason`.)
+- `:455-514` `upsertSoftwareComplianceStatuses` — the two-branch split is at `:468-469`:
+  ```ts
+    const withRemediationStatus = normalized.filter((input) => input.remediationStatus !== undefined);
+    const withoutRemediationStatus = normalized.filter((input) => input.remediationStatus === undefined);
+  ```
+  followed by two near-identical `chunkArray` loops (`:471-490` without, `:492-513` with). **Confirmed.** Note the guard is `!== undefined`, not truthiness — Task 3 must preserve that, since `installRemediationAttempts: 0` is a meaningful value that a truthiness check would silently drop.
+- `:516-531` `upsertSoftwareComplianceStatus` (singular) — a thin wrapper with its own inlined status union at `:521`. **It has zero non-test callers** (grep across `apps/api/src` for `upsertSoftwareComplianceStatus(` returns only its own definition and the plural it delegates to). This wave leaves it alone; it simply never carries install fields.
+- `:533-574` `recordSoftwarePolicyAudit` — `action: string` at `:542`, owner-axis invariant at `:548-550` ("at least one", not XOR), failures swallowed to console + Sentry. **Confirmed.**
+
+### Compliance worker — `apps/api/src/jobs/softwareComplianceWorker.ts` (668 lines)
+
+- `:2` `import { and, eq, inArray } from 'drizzle-orm';` — **`sql` is NOT imported.** Task 9 must add it.
+- `:4` `import { devices, softwareComplianceStatus, softwarePolicies } from '../db/schema';` — no type imports from schema yet.
+- `:44` `const SCAN_INTERVAL_MS = 15 * 60 * 1000;` and `:45` `REMEDIATION_COOLDOWN_DEFAULT_MINUTES = 120`. **Confirmed.**
+- `:67-73` `ExistingComplianceState` = `{ deviceId; status; violations; remediationStatus; lastRemediationAttempt }`. `:82-93` `parseRemediationStatus` accepts exactly the five `SoftwarePolicyRemediationStatus` values and returns `null` otherwise.
+- `:95-134` `readComplianceStateByDevice` — chunked `db.select({...})` of five columns. This is where the three new columns must be read.
+- `:136-162` `readRemediationOptions` — returns `{ autoUninstallEnabled, gracePeriodHours, cooldownMinutes }`; `autoUninstallEnabled` is derived at `:158` as `options.autoUninstall === true`. **This is the duplicate arming derivation D11 removes.** The function is module-private (not exported), so removing that one field breaks no external caller.
+- `:164-182` `readEarliestUnauthorizedDetection(violations)` — exported. The hard filter is at `:171`:
+  ```ts
+      if (typed.type !== 'unauthorized' || typeof typed.detectedAt !== 'string') {
+        continue;
+      }
+  ```
+  **Confirmed.** A `missing` violation contributes nothing to grace today.
+- `:184-212` `shouldQueueAutoRemediation` — exported; its declared return is `{ queue: boolean; reason?: string }`; it calls `readEarliestUnauthorizedDetection` at `:196`. Sole non-test call site is `:429`. **Confirmed.** The only reasons it ever returns are `'in_progress'` (`:193`), `'grace_period'` (`:200`), `'cooldown'` (`:207`).
+- `:280-330` `processCheckPolicy` — policy reload `:286-293`, generation gate `:311-321`, `resolveDeviceIdsForSoftwarePolicy` `:324`, the ephemeral-device `orgByDevice` narrowing `:342-350`.
+- `:361-369` the pass preamble: `normalizedRules`, `remediationOptions`, `existingByDevice`, `inventoryByDevice`, `violations`, `remediationTargets: Set<string>`, `complianceUpserts`, `now`.
+- `:371-475` the per-device loop. `:377-380` `withStableViolationTimestamps(...)`; `:383-394` the uninstall `remediationStatus` derivation; `:396-403` the `complianceUpserts.push`; `:406-445` the `status === 'violation'` block.
+- `:423-427` the remediation gate, verbatim — **this is the two-part blocker:**
+  ```ts
+        if (
+          policy.enforceMode
+          && policy.mode !== 'audit'
+          && remediationOptions.autoUninstallEnabled
+          && violationsWithStableTimestamps.some((violation) => violation.type === 'unauthorized')
+        ) {
+  ```
+  The contract's `:423-444` range is **confirmed** (the block closes at `:444`). Note `enforceMode` is `boolean NOT NULL` in the schema (`softwarePolicies.ts:94`), so `policy.enforceMode &&` and `evaluateSoftwarePolicyArming`'s `policy.enforceMode !== true` are exactly equivalent — D11 is behaviour-preserving for uninstall.
+- `:477-479` the upsert flush; `:481-516` the post-schedule block (`scheduleSoftwareRemediation` at `:484`, the chunked UPDATE at `:487-498`, `remediation_scheduled` audit at `:501-513`).
+- `:526-548` `createSoftwareComplianceWorker`; `:550-568` `scheduleComplianceScan` with `repeat: { every: SCAN_INTERVAL_MS }` at `:563`. **Confirmed.**
+
+### Remediation worker — `apps/api/src/jobs/softwareRemediationWorker.ts` (792 lines)
+
+- `:56-72` `type RemediateDeviceJobData = { type: 'remediate-device'; policyId; deviceId; trigger?; requestedByUserId?; manualRequestId? }` — **not exported. Confirmed.**
+- `:74` `type SoftwareRemediationJobData = RemediateDeviceJobData;` — a bare alias, not yet a union.
+- `:148-155` `getSoftwareRemediationQueue(): Queue<SoftwareRemediationJobData>` — **exported.**
+- `:168-195` `readInFlightUninstallKeys` — the uninstall dedup, `payload ->> 'policyId'` at `:181`.
+- `:199` `processRemediateDevice(data: RemediateDeviceJobData)` — uninstall-specific end to end: manual-authorization consume `:308-316`, `evaluateSoftwarePolicyArming(policy)` at `:318` (one argument), the unarmed refusal + `remediationStatus: 'failed'` write `:343-380`, the `SOFTWARE_UNINSTALL` queue site `:522-532`, the terminal `remediationStatus`/`lastRemediationAttempt` write `:545-558`.
+- `:601-620` `createSoftwareRemediationWorker` — the processor is a bare `return processRemediateDevice(job.data);` at `:606`, no `type` switch.
+- `:712-792` `scheduleSoftwareRemediation(policyId, deviceIds, options)` — jobId namespaces at `:755-757`:
+  ```ts
+      const jobId = trigger === 'manual'
+        ? `software-remediation-manual-${manualRequestId}`
+        : `software-remediation-${policyId}-${deviceId}`;
+  ```
+  Dedup via `queue.getJob(jobId)` + `isReusableState(state)` at `:758-768`; `queue.add` opts at `:780-786`. Returns a **count**, and `softwareComplianceWorker.ts:486` then stamps `remediationStatus:'pending'` on **all** targets whenever that count is `> 0` — including devices that deduped and got no job. That is a pre-existing uninstall inaccuracy; this wave does not fix it (out of scope) but **must not replicate it** — Task 8's install scheduler returns the deviceIds actually enqueued.
+
+### Registries, metrics, tests
+
+- `apps/api/src/routes/devices/core.ts:511` — `'software_compliance_status', 'software_policy_audit', 'software_remediation_requests',` inside `CORE_DEVICE_CASCADE_DELETE_TABLES`. **Confirmed** (the contract's `:511` is right; the spec body's `:507` is stale).
+- `grep -rn 'software_compliance_status' apps/api/src/services/tenantCascade.ts apps/api/src/services/tenantExportPolicyRegistry.ts` → **zero hits in both.** Confirmed.
+- Every non-test reader of `softwareComplianceStatus` uses an explicit column projection, never a bare `select()` splat: `routes/softwarePolicies.ts:411-423,482-493,871,906-913`, `services/userRiskScoring.ts:600-609`, `services/aiToolsCompliance.ts:97-98`, `jobs/softwareRemediationWorker.ts`. Adding columns breaks none of them. **Corollary flagged for the coordinator: `routes/softwarePolicies.ts:482-487` is the compliance-list API projection and does NOT include the new columns, and no wave in the ownership map owns adding them** — W04 is "web UI only / must not touch any `apps/api` file". W02 leaves it alone per scope; see the closing note.
+- `apps/api/src/routes/metrics.ts:918` — `recordSoftwareRemediationDecision(decision: string, count = 1)`. It lowercases and trims the label and accepts any string, so new decision labels need no registration.
+- `apps/api/src/jobs/softwareComplianceWorker.test.ts` (291 lines) — mocks `bullmq`, `../services/redis`, `../db` (**only `db.select`**, plus `runOutsideDbContext`/`withDbAccessContext`/`withSystemDbAccessContext` passthroughs) and `../services/featureConfigResolver`. It imports `processCheckPolicy`, `readEarliestUnauthorizedDetection`, `scheduleSoftwareComplianceCheck`, `shouldQueueAutoRemediation`. Its `shouldQueueAutoRemediation` describe block is `:89-187` (8 cases) and its `readEarliestUnauthorizedDetection` block is `:189-223` (5 cases). Every one of those 13 cases must gain the new required argument in Task 4.
+- `apps/api/src/services/softwarePolicyService.test.ts` — pure-function tests only; it declares **no `vi.mock` at all**. Task 3's upsert tests therefore need a new file with its own db mock rig rather than an edit here.
+- `apps/api/src/db/migrationRlsScope.test.ts:1-60` — the guard reads every `^\d{4}-.*\.sql$` file and requires `SELECT set_config('breeze.scope','system',true);` before any DML. Pure-DDL files are unaffected.
+- `apps/api/package.json` — `"test": "vitest"` (bare/watch). No `typecheck` script; use `pnpm --filter @breeze/api exec tsc --noEmit`.
+- `apps/api/src/jobs/backupRetention.ts:539` — `export const BACKUP_GC_GRACE_MS = resolveBackupGcGraceMs();`. The defect D5 forbids repeating. Its floor is applied **only** under `NODE_ENV === 'production'` (`:517`); this wave's floors are unconditional (see Task 6 rationale).
+
+## File structure
+
+- **Create** `apps/api/migrations/2026-10-15-150400-software-compliance-install-remediation.sql` — three `ADD COLUMN IF NOT EXISTS`, DDL only.
+- **Modify** `apps/api/src/db/schema/softwarePolicies.ts` — three columns on `softwareComplianceStatus`.
+- **Modify** `apps/api/src/services/softwarePolicyService.ts` — `SoftwarePolicyInstallRemediationStatus`, the extended `SoftwareComplianceUpsertInput`, and the shape-keyed rewrite of `upsertSoftwareComplianceStatuses`.
+- **Create** `apps/api/src/services/softwarePolicyService.complianceUpsert.test.ts` — the non-clobber contract, with a db mock rig the existing pure-function test file does not have.
+- **Create** `apps/api/src/services/softwareInstallRemediationKnobs.ts` + `apps/api/src/services/softwareInstallRemediationKnobs.test.ts` — per-call env resolvers.
+- **Modify** `apps/api/src/jobs/softwareComplianceWorker.ts` — verb-aware grace clock (D10), delegated arming (D11), `decideInstallRemediation`, the new columns in `ExistingComplianceState`/`readComplianceStateByDevice`, the install branch, the install scheduling block.
+- **Modify** `apps/api/src/jobs/softwareComplianceWorker.test.ts` — thread the new required arguments through the 13 existing cases.
+- **Create** `apps/api/src/jobs/softwareComplianceWorker.install.test.ts` — the install decision matrix, the D11 divergence guard, and the full-loop wiring test, each with its own mock rig.
+- **Modify** `apps/api/src/jobs/softwareRemediationWorker.ts` — the exported install job payload type, `scheduleSoftwareInstallRemediation`, the discriminated `SoftwareRemediationJobData` union, and the processor parking branch W03 replaces.
+- **Modify** `apps/api/src/jobs/softwareRemediationWorker.test.ts` — the jobId-namespace separation and the parking branch.
+- **Create** `apps/api/src/services/softwarePolicyService.violationFingerprint.test.ts` — the D9 regression pin (Task 5).
+
+---
+
+### Task 1: Migration `150400` — the three install-remediation columns
+
+**Files:**
+- Create: `apps/api/migrations/2026-10-15-150400-software-compliance-install-remediation.sql`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: the columns `software_compliance_status.install_remediation_status`, `.last_install_remediation_attempt`, `.install_remediation_attempts`.
+
+- [ ] **Step 1: Confirm the slot still sorts last**
+
+```bash
+cd /Users/toddhebebrand/.herdr/worktrees/breeze/warranty-testing
+ls apps/api/migrations/*.sql | sort | tail -1
+```
+
+Expected at plan time: `apps/api/migrations/2026-10-15-150300-remote-session-revocation-lease.sql`. If anything now sorts at or after `2026-10-15-150400`, pick the next free timestamp that sorts after the newest committed file and use that name **everywhere in this task**. Do not assume today's date sorts last.
+
+- [ ] **Step 2: Observe the red — the columns are absent**
+
+```bash
+docker exec -it breeze-postgres psql -U breeze_app -d breeze -c "\d software_compliance_status"
+```
+
+Expected: `install_remediation_status`, `last_install_remediation_attempt`, `install_remediation_attempts` are all absent. (This is the baseline; a migration has no unit-testable TypeScript surface.)
+
+- [ ] **Step 3: Write the migration**
+
+```sql
+-- apps/api/migrations/2026-10-15-150400-software-compliance-install-remediation.sql
+-- Feature #5505 W02 (#5507), contract D1: a SECOND remediation-status axis on
+-- software_compliance_status, for the `missing`-violation install verb.
+--
+-- WHY THREE COLUMNS AND NOT A JSONB BLOB. remediation_status is a single
+-- varchar today and two verbs sharing it would lie: a successful install
+-- alongside a failed uninstall has no honest single value. Separate columns
+-- leave every existing uninstall read/write and the uninstall cooldown logic
+-- (softwareRemediationWorker.ts:545-558, softwareComplianceWorker.ts:486-498)
+-- byte-for-byte untouched, which a jsonb reshape would not.
+--
+-- install_remediation_attempts is the CONSECUTIVE attempt counter behind the
+-- install-loop guard (spec Risks §1): a policy whose rule never matches what
+-- the installer actually registers in Add/Remove Programs would otherwise
+-- re-detect `missing` and reinstall every 15 minutes forever. It resets to 0
+-- when the (policy, device) has no `missing` violation left and increments on
+-- every queue; at SOFTWARE_INSTALL_REMEDIATION_MAX_ATTEMPTS the compliance
+-- worker stops and writes install_remediation_status = 'gave_up'.
+--
+-- Types deliberately mirror the existing remediation_status /
+-- last_remediation_attempt columns (schema/softwarePolicies.ts:121-122):
+-- varchar(20) and a bare `timestamp`, NOT timestamptz. Allowed status values
+-- are a TypeScript union, not a DB enum, matching how remediation_status is
+-- already constrained: 'none' | 'pending' | 'in_progress' | 'completed' |
+-- 'failed' | 'gave_up' | 'skipped'.
+--
+-- NO REGISTRATION CHANGES ARE NEEDED, verified: software_compliance_status has
+-- no org_id column, appears zero times in services/tenantCascade.ts and zero
+-- times in services/tenantExportPolicyRegistry.ts, and is already listed in
+-- CORE_DEVICE_CASCADE_DELETE_TABLES (routes/devices/core.ts:511). It is
+-- deliberately absent from CORE_DEVICE_ORG_DENORMALIZED_TABLES (documented as
+-- such at routes/devices/core.ts:208).
+--
+-- DDL ONLY. No UPDATE/DELETE/INSERT/MERGE, so no
+-- `SELECT set_config('breeze.scope','system',true);` is required (#4518 guard,
+-- src/db/migrationRlsScope.test.ts). Idempotent: ADD COLUMN IF NOT EXISTS on
+-- all three, so re-applying is a true no-op. No inner BEGIN/COMMIT — autoMigrate
+-- already wraps each file in client.begin(...).
+--
+-- Note on existing rows: PostgreSQL 11+ materialises the DEFAULT for existing
+-- rows via attmissingval without a table rewrite, so every pre-existing row
+-- reads back 'none' / NULL / 0 immediately. That is the intended starting
+-- state, identical to a freshly inserted row.
+
+ALTER TABLE software_compliance_status
+  ADD COLUMN IF NOT EXISTS install_remediation_status varchar(20) DEFAULT 'none';
+
+ALTER TABLE software_compliance_status
+  ADD COLUMN IF NOT EXISTS last_install_remediation_attempt timestamp;
+
+ALTER TABLE software_compliance_status
+  ADD COLUMN IF NOT EXISTS install_remediation_attempts integer NOT NULL DEFAULT 0;
+```
+
+- [ ] **Step 4: Apply it and verify green**
+
+```bash
+cd /Users/toddhebebrand/.herdr/worktrees/breeze/warranty-testing
+export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze"
+pnpm db:migrate
+docker exec -it breeze-postgres psql -U breeze_app -d breeze -c "\d software_compliance_status"
+```
+
+Expected: all three columns present; `install_remediation_attempts` shows `not null default 0`; `install_remediation_status` shows `character varying(20)` with `default 'none'::character varying`.
+
+Then prove idempotency and the default backfill:
+
+```bash
+pnpm db:migrate   # second run must report zero newly-applied migrations
+docker exec -it breeze-postgres psql -U breeze_app -d breeze \
+  -c "SELECT install_remediation_status, install_remediation_attempts, count(*) FROM software_compliance_status GROUP BY 1,2;"
+```
+
+Expected: every existing row reads `none | 0`.
+
+- [ ] **Step 5: Run the migration guards**
+
+```bash
+cd apps/api && npx vitest run src/db/migrationRlsScope.test.ts src/db/autoMigrate.test.ts
+```
+
+Expected: PASS. `migrationRlsScope` must pass **without** the new file being added to its frozen 122-file baseline — if it demands an entry, the migration has DML in it that should not be there. `autoMigrate.test.ts` proves the filename sorts correctly and that no path reference is broken.
+
+- [ ] **Step 6: Run the drift check**
+
+```bash
+cd /Users/toddhebebrand/.herdr/worktrees/breeze/warranty-testing && pnpm db:check-drift
+```
+
+Expected: PASS (one `breeze_migrations` row per file after a fresh apply).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/migrations/2026-10-15-150400-software-compliance-install-remediation.sql
+git commit -m "feat(software): install-remediation status columns on software_compliance_status (#5505 W02, D1)"
+```
+
+---
+
+### Task 2: Drizzle schema — the three columns on `softwareComplianceStatus`
+
+**Files:**
+- Modify: `apps/api/src/db/schema/softwarePolicies.ts:114-129`
+
+**Interfaces:**
+- Consumes: Task 1's migration.
+- Produces: `softwareComplianceStatus.installRemediationStatus`, `.lastInstallRemediationAttempt`, `.installRemediationAttempts` (Drizzle columns; every later task selects, sets and upserts through these).
+
+- [ ] **Step 1: No automated red step — state the verification instead**
+
+`pnpm db:check-drift` does **not** compare the Drizzle schema against a live database; it verifies migration-ledger parity only. A Drizzle column definition is proven correct by real inserts/queries through it, which happens in Task 3's test (compiled SQL) and at runtime. The red for this task is the TypeScript compiler: Task 3's code references `softwareComplianceStatus.installRemediationStatus` and will not compile until this task lands.
+
+- [ ] **Step 2: Implement**
+
+```ts
+// apps/api/src/db/schema/softwarePolicies.ts — inside softwareComplianceStatus's
+// column object, immediately after `remediationErrors` (currently :123)
+  remediationErrors: jsonb('remediation_errors').$type<RemediationError[]>(),
+  // Feature #5505 W02 (contract D1): the SECOND remediation axis, for the
+  // `missing`-violation install verb. Deliberately separate columns rather than
+  // widening remediationStatus — two verbs sharing one status field would lie
+  // (a successful install alongside a failed uninstall has no honest single
+  // value), and separate columns leave every uninstall read/write untouched.
+  // Types mirror remediationStatus/lastRemediationAttempt above exactly.
+  // Allowed values are the TS union SoftwarePolicyInstallRemediationStatus in
+  // services/softwarePolicyService.ts — there is no DB enum, matching how
+  // remediation_status is already constrained.
+  installRemediationStatus: varchar('install_remediation_status', { length: 20 }).default('none'),
+  lastInstallRemediationAttempt: timestamp('last_install_remediation_attempt'),
+  // CONSECUTIVE attempts, not lifetime: reset to 0 the moment this
+  // (policy, device) has no `missing` violation left, incremented on every
+  // queue. This is the install-loop guard from spec Risks §1 — grace and
+  // cooldown bound the RATE of a mismatched-rule reinstall loop but never stop
+  // it; this counter is what terminates it, at 'gave_up'.
+  installRemediationAttempts: integer('install_remediation_attempts').notNull().default(0),
+}, (table) => ({
+```
+
+(`varchar`, `timestamp` and `integer` are already imported at `softwarePolicies.ts:4,6,10` — no import edit is needed.)
+
+- [ ] **Step 3: Typecheck**
+
+```bash
+cd /Users/toddhebebrand/.herdr/worktrees/breeze/warranty-testing
+pnpm --filter @breeze/api exec tsc --noEmit
+```
+
+Expected: PASS (no consumer yet).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/db/schema/softwarePolicies.ts
+git commit -m "feat(software): Drizzle columns for install remediation status (#5505 W02, D1)"
+```
+
+---
+
+### Task 3: `upsertSoftwareComplianceStatuses` carries the install columns without clobbering
+
+**Files:**
+- Modify: `apps/api/src/services/softwarePolicyService.ts:1` (import `type SQL`), `:28-37` (types), `:455-514` (the upsert)
+- Test: `apps/api/src/services/softwarePolicyService.complianceUpsert.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `softwareComplianceStatus.installRemediationStatus` / `.installRemediationAttempts` (Task 2).
+- Produces:
+  - `export type SoftwarePolicyInstallRemediationStatus = 'none' | 'pending' | 'in_progress' | 'completed' | 'failed' | 'gave_up' | 'skipped';`
+  - `SoftwareComplianceUpsertInput` extended with `installRemediationStatus?: SoftwarePolicyInstallRemediationStatus` and `installRemediationAttempts?: number`.
+  - The non-clobber guarantee, now generalised to every optional column: an input that omits a column produces a statement whose `set` clause does not mention it.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// apps/api/src/services/softwarePolicyService.complianceUpsert.test.ts
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The existing softwarePolicyService.test.ts is pure-function only and declares
+// no vi.mock at all, so the upsert's SQL shape needs its own rig here. We
+// capture the exact objects handed to values()/onConflictDoUpdate() rather than
+// asserting on compiled SQL: the property this guards is "which columns does
+// the ON CONFLICT set clause name", and that is visible in the set object's
+// own keys.
+type CapturedInsert = {
+  values: Record<string, unknown>[];
+  setKeys: string[];
+};
+
+const { captured, insertMock } = vi.hoisted(() => {
+  const captured: CapturedInsert[] = [];
+  const insertMock = vi.fn(() => ({
+    values: (rows: Record<string, unknown>[]) => ({
+      onConflictDoUpdate: async (config: { set: Record<string, unknown> }) => {
+        captured.push({ values: rows, setKeys: Object.keys(config.set) });
+      },
+    }),
+  }));
+  return { captured, insertMock };
+});
+
+vi.mock('../db', () => ({
+  db: { insert: insertMock },
+}));
+vi.mock('./sentry', () => ({ captureException: vi.fn() }));
+
+import { upsertSoftwareComplianceStatuses } from './softwarePolicyService';
+
+const DEVICE_A = '11111111-1111-4111-8111-111111111111';
+const DEVICE_B = '22222222-2222-4222-8222-222222222222';
+const POLICY = '33333333-3333-4333-8333-333333333333';
+
+function baseInput(deviceId: string) {
+  return {
+    deviceId,
+    policyId: POLICY,
+    status: 'violation' as const,
+    violations: [],
+    checkedAt: new Date('2026-09-10T00:00:00.000Z'),
+  };
+}
+
+describe('upsertSoftwareComplianceStatuses — per-column non-clobber contract', () => {
+  beforeEach(() => {
+    captured.length = 0;
+    vi.clearAllMocks();
+  });
+
+  it('omits every optional column from the set clause when the input carries none', async () => {
+    await upsertSoftwareComplianceStatuses([baseInput(DEVICE_A)]);
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0].setKeys.sort()).toEqual(['lastChecked', 'status', 'violations']);
+    expect(captured[0].values[0]).not.toHaveProperty('remediationStatus');
+    expect(captured[0].values[0]).not.toHaveProperty('installRemediationStatus');
+    expect(captured[0].values[0]).not.toHaveProperty('installRemediationAttempts');
+  });
+
+  it('writes remediationStatus WITHOUT touching either install column (existing behaviour, unchanged)', async () => {
+    await upsertSoftwareComplianceStatuses([
+      { ...baseInput(DEVICE_A), remediationStatus: 'pending' },
+    ]);
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0].setKeys.sort()).toEqual(['lastChecked', 'remediationStatus', 'status', 'violations']);
+  });
+
+  it('writes installRemediationStatus WITHOUT touching remediationStatus', async () => {
+    await upsertSoftwareComplianceStatuses([
+      { ...baseInput(DEVICE_A), installRemediationStatus: 'skipped' },
+    ]);
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0].setKeys.sort()).toEqual([
+      'installRemediationStatus', 'lastChecked', 'status', 'violations',
+    ]);
+    expect(captured[0].values[0].installRemediationStatus).toBe('skipped');
+  });
+
+  // The discriminating case: 0 is falsy. A `if (input.installRemediationAttempts)`
+  // guard would silently drop the counter reset and leave a device stuck one
+  // attempt short of 'gave_up' forever. The guard must be `!== undefined`.
+  it('treats installRemediationAttempts: 0 as a value to write, not as absent', async () => {
+    await upsertSoftwareComplianceStatuses([
+      { ...baseInput(DEVICE_A), installRemediationAttempts: 0 },
+    ]);
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0].setKeys).toContain('installRemediationAttempts');
+    expect(captured[0].values[0].installRemediationAttempts).toBe(0);
+  });
+
+  it('splits a mixed batch into one statement per column shape', async () => {
+    await upsertSoftwareComplianceStatuses([
+      baseInput(DEVICE_A),
+      { ...baseInput(DEVICE_B), installRemediationStatus: 'gave_up', installRemediationAttempts: 3 },
+    ]);
+
+    expect(captured).toHaveLength(2);
+    const shapes = captured.map((c) => c.setKeys.sort().join(',')).sort();
+    expect(shapes).toEqual([
+      'installRemediationAttempts,installRemediationStatus,lastChecked,status,violations',
+      'lastChecked,status,violations',
+    ]);
+  });
+
+  it('still skips inputs with a blank deviceId or policyId', async () => {
+    await upsertSoftwareComplianceStatuses([
+      { ...baseInput(''), installRemediationStatus: 'pending' },
+    ]);
+
+    expect(captured).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+cd apps/api && npx vitest run src/services/softwarePolicyService.complianceUpsert.test.ts
+```
+
+Expected: FAIL. The `installRemediationStatus` / `installRemediationAttempts` cases fail to typecheck against today's `SoftwareComplianceUpsertInput` (`:30-37`), and the mixed-batch case fails because today's split is on `remediationStatus` alone and would produce **one** statement.
+
+- [ ] **Step 3: Extend the types**
+
+```ts
+// apps/api/src/services/softwarePolicyService.ts:1 — add the SQL type
+import { and, eq, inArray, sql, type SQL } from 'drizzle-orm';
+```
+
+```ts
+// apps/api/src/services/softwarePolicyService.ts — replacing :28-37
+export type SoftwarePolicyRemediationStatus = 'none' | 'pending' | 'in_progress' | 'completed' | 'failed';
+
+/**
+ * Feature #5505 (contract D1): the install verb's own status axis. It is a
+ * SUPERSET of SoftwarePolicyRemediationStatus, adding two install-specific
+ * terminal states:
+ *  - 'gave_up'  — the consecutive-attempt counter hit
+ *                 SOFTWARE_INSTALL_REMEDIATION_MAX_ATTEMPTS. This is the
+ *                 install-loop terminator (spec Risks §1); a policy whose rule
+ *                 never matches what the installer registers would otherwise
+ *                 reinstall every 15 minutes forever.
+ *  - 'skipped'  — nothing was attempted and nothing is wrong with the device:
+ *                 the rule carries no catalogId (so there is nothing to
+ *                 install), the per-pass cap was reached, or (W03) the
+ *                 catalog item has no install method for this device's OS.
+ * Deliberately NOT a DB enum — remediation_status is a bare varchar(20) too.
+ */
+export type SoftwarePolicyInstallRemediationStatus =
+  | 'none'
+  | 'pending'
+  | 'in_progress'
+  | 'completed'
+  | 'failed'
+  | 'gave_up'
+  | 'skipped';
+
+export type SoftwareComplianceUpsertInput = {
+  deviceId: string;
+  policyId: string;
+  status: SoftwarePolicyComplianceStatus;
+  violations: SoftwarePolicyViolation[];
+  checkedAt?: Date;
+  /**
+   * OPTIONAL ON PURPOSE, for all three of these. `undefined` means "this pass
+   * has nothing to say about that column" and the generated statement must not
+   * name it at all — see upsertSoftwareComplianceStatuses. Passing a value when
+   * you mean "leave it alone" silently overwrites a live status.
+   */
+  remediationStatus?: SoftwarePolicyRemediationStatus;
+  installRemediationStatus?: SoftwarePolicyInstallRemediationStatus;
+  installRemediationAttempts?: number;
+};
+```
+
+- [ ] **Step 4: Rewrite the upsert as a shape-keyed grouping**
+
+```ts
+// apps/api/src/services/softwarePolicyService.ts — replacing :455-514 entirely
+
+/**
+ * Optional columns of software_compliance_status, keyed by their
+ * SoftwareComplianceUpsertInput field name. Values are FACTORIES, not shared
+ * SQL objects, so each generated statement gets its own fragment.
+ */
+const COMPLIANCE_UPSERT_OPTIONAL_COLUMNS: Record<string, () => SQL> = {
+  remediationStatus: () => sql`excluded.remediation_status`,
+  installRemediationStatus: () => sql`excluded.install_remediation_status`,
+  installRemediationAttempts: () => sql`excluded.install_remediation_attempts`,
+};
+
+type ComplianceUpsertOptionalKey = keyof SoftwareComplianceUpsertInput
+  & ('remediationStatus' | 'installRemediationStatus' | 'installRemediationAttempts');
+
+const COMPLIANCE_UPSERT_OPTIONAL_KEYS = Object.keys(
+  COMPLIANCE_UPSERT_OPTIONAL_COLUMNS
+) as ComplianceUpsertOptionalKey[];
+
+export async function upsertSoftwareComplianceStatuses(
+  inputs: SoftwareComplianceUpsertInput[]
+): Promise<void> {
+  if (inputs.length === 0) return;
+
+  const normalized = inputs.filter((input) => (
+    typeof input.deviceId === 'string'
+    && input.deviceId.length > 0
+    && typeof input.policyId === 'string'
+    && input.policyId.length > 0
+  ));
+  if (normalized.length === 0) return;
+
+  // Group by WHICH optional columns each input actually carries.
+  //
+  // A bulk onConflictDoUpdate shares ONE `set` clause across its whole chunk,
+  // and `excluded.<col>` reads the value of the row this statement tried to
+  // insert. So an input that says nothing about a column must not travel in the
+  // same statement as one that does — otherwise the silent input's insert-time
+  // DEFAULT ('none' / 0) is written over a live value. That is exactly why the
+  // original implementation split on "was remediationStatus provided"; this
+  // generalises the same split to every optional column and is byte-equivalent
+  // for callers that pass only remediationStatus (they still produce the same
+  // two groups, with the same set clauses, as before).
+  //
+  // The membership test is `!== undefined`, NOT truthiness:
+  // installRemediationAttempts: 0 is the counter RESET and must be written.
+  const byShape = new Map<string, SoftwareComplianceUpsertInput[]>();
+  for (const input of normalized) {
+    const presentKeys = COMPLIANCE_UPSERT_OPTIONAL_KEYS.filter((key) => input[key] !== undefined);
+    const shapeKey = presentKeys.join('|');
+    const bucket = byShape.get(shapeKey);
+    if (bucket) bucket.push(input);
+    else byShape.set(shapeKey, [input]);
+  }
+
+  for (const [shapeKey, group] of byShape) {
+    const optionalKeys = shapeKey.length > 0
+      ? (shapeKey.split('|') as ComplianceUpsertOptionalKey[])
+      : [];
+
+    for (const chunk of chunkArray(group)) {
+      if (chunk.length === 0) continue;
+      await db
+        .insert(softwareComplianceStatus)
+        .values(chunk.map((input) => {
+          const row: Record<string, unknown> = {
+            deviceId: input.deviceId,
+            policyId: input.policyId,
+            status: input.status,
+            violations: input.violations,
+            lastChecked: input.checkedAt ?? new Date(),
+          };
+          for (const key of optionalKeys) {
+            row[key] = input[key];
+          }
+          return row as typeof softwareComplianceStatus.$inferInsert;
+        }))
+        .onConflictDoUpdate({
+          target: [softwareComplianceStatus.deviceId, softwareComplianceStatus.policyId],
+          set: {
+            status: sql`excluded.status`,
+            violations: sql`excluded.violations`,
+            lastChecked: sql`excluded.last_checked`,
+            ...Object.fromEntries(
+              optionalKeys.map((key) => [key, COMPLIANCE_UPSERT_OPTIONAL_COLUMNS[key]()])
+            ),
+          },
+        });
+    }
+  }
+}
+```
+
+- [ ] **Step 5: Run the tests and watch them pass**
+
+```bash
+cd apps/api && npx vitest run src/services/softwarePolicyService.complianceUpsert.test.ts src/services/softwarePolicyService.test.ts
+```
+
+Expected: PASS, 2 files. The existing `softwarePolicyService.test.ts` must stay green — this change is behaviour-preserving for every current caller.
+
+- [ ] **Step 6: Typecheck and commit**
+
+```bash
+cd /Users/toddhebebrand/.herdr/worktrees/breeze/warranty-testing
+pnpm --filter @breeze/api exec tsc --noEmit
+git add apps/api/src/services/softwarePolicyService.ts apps/api/src/services/softwarePolicyService.complianceUpsert.test.ts
+git commit -m "feat(software): shape-keyed compliance upsert carries install columns without clobbering (#5505 W02, D1)"
+```
+
+---
+
+### Task 4: D10 — the grace clock becomes verb-aware
+
+**Files:**
+- Modify: `apps/api/src/jobs/softwareComplianceWorker.ts:164-212` (both helpers) and `:429-436` (the sole call site)
+- Modify: `apps/api/src/jobs/softwareComplianceWorker.test.ts:89-223` (13 existing cases)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces:
+  - `export type AutoRemediationDeferralReason = 'in_progress' | 'grace_period' | 'cooldown';`
+  - `export function readEarliestViolationDetection(violations: unknown, violationType: SoftwarePolicyViolation['type']): Date | null;` — replaces `readEarliestUnauthorizedDetection`, which is deleted.
+  - `shouldQueueAutoRemediation` gains a **required** `violationType` input field and a narrowed return type `{ queue: boolean; reason?: AutoRemediationDeferralReason }`.
+
+Contract D10 says generalise rather than add a near-duplicate, and a **required** parameter (mirroring D2's discipline) is what makes the compiler enumerate every call site instead of letting one silently keep the old default.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `apps/api/src/jobs/softwareComplianceWorker.test.ts`, and update the import block at `:36-41` first:
+
+```ts
+// apps/api/src/jobs/softwareComplianceWorker.test.ts — replacing the import block at :36-41
+import {
+  processCheckPolicy,
+  readEarliestViolationDetection,
+  scheduleSoftwareComplianceCheck,
+  shouldQueueAutoRemediation,
+} from './softwareComplianceWorker';
+```
+
+```ts
+// apps/api/src/jobs/softwareComplianceWorker.test.ts — append at end of file
+describe('readEarliestViolationDetection — verb awareness (contract D10)', () => {
+  const MIXED = [
+    { type: 'unauthorized', detectedAt: '2025-01-10T00:00:00Z' },
+    { type: 'missing', detectedAt: '2025-01-02T00:00:00Z' },
+    { type: 'unauthorized', detectedAt: '2025-01-05T00:00:00Z' },
+    { type: 'missing', detectedAt: '2025-01-20T00:00:00Z' },
+  ];
+
+  it('measures only unauthorized violations when asked for unauthorized', () => {
+    expect(readEarliestViolationDetection(MIXED, 'unauthorized')?.toISOString())
+      .toBe('2025-01-05T00:00:00.000Z');
+  });
+
+  it('measures only missing violations when asked for missing', () => {
+    expect(readEarliestViolationDetection(MIXED, 'missing')?.toISOString())
+      .toBe('2025-01-02T00:00:00.000Z');
+  });
+
+  it('returns null when the requested type is absent', () => {
+    expect(readEarliestViolationDetection(
+      [{ type: 'unauthorized', detectedAt: '2025-01-10T00:00:00Z' }],
+      'missing',
+    )).toBeNull();
+  });
+});
+
+describe('shouldQueueAutoRemediation — grace measured against the requested verb', () => {
+  const NOW_D10 = new Date('2025-01-10T00:00:00Z');
+
+  // A device with a fresh `missing` violation and a long-stale `unauthorized`
+  // one. Before D10 the grace clock read the unauthorized timestamp for BOTH
+  // verbs, so the install verb would queue immediately, ignoring its own grace.
+  const MIXED_AGES = [
+    { type: 'unauthorized', detectedAt: '2024-01-01T00:00:00Z' },
+    { type: 'missing', detectedAt: '2025-01-09T23:00:00Z' },
+  ];
+
+  it('defers the install verb inside ITS grace window even though an unauthorized violation is ancient', () => {
+    expect(shouldQueueAutoRemediation({
+      violations: MIXED_AGES,
+      violationType: 'missing',
+      previousRemediationStatus: null,
+      lastRemediationAttempt: null,
+      now: NOW_D10,
+      gracePeriodHours: 24,
+      cooldownMinutes: 120,
+    })).toEqual({ queue: false, reason: 'grace_period' });
+  });
+
+  it('still queues the uninstall verb against the same violation set', () => {
+    expect(shouldQueueAutoRemediation({
+      violations: MIXED_AGES,
+      violationType: 'unauthorized',
+      previousRemediationStatus: null,
+      lastRemediationAttempt: null,
+      now: NOW_D10,
+      gracePeriodHours: 24,
+      cooldownMinutes: 120,
+    })).toEqual({ queue: true });
+  });
+});
+```
+
+Then thread `violationType: 'unauthorized'` into all 8 existing `shouldQueueAutoRemediation` cases at `:89-187` (add the field immediately after `violations:` in each object literal), and rewrite the 5 `readEarliestUnauthorizedDetection` cases at `:189-223` to call `readEarliestViolationDetection(x, 'unauthorized')` with the same expectations. The 5 rewritten cases are the **byte-identical-behaviour** proof the contract requires.
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+cd apps/api && npx vitest run src/jobs/softwareComplianceWorker.test.ts
+```
+
+Expected: FAIL — `readEarliestViolationDetection` is not exported, and `violationType` is not a property of `shouldQueueAutoRemediation`'s input type.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// apps/api/src/jobs/softwareComplianceWorker.ts — replacing :164-212
+
+/**
+ * Earliest detection timestamp among violations of ONE type (contract D10).
+ *
+ * This used to be readEarliestUnauthorizedDetection, which hard-filtered
+ * `type !== 'unauthorized'`, so a `missing` violation contributed nothing to
+ * grace. With two remediation verbs each having their own grace clock, the
+ * type is a REQUIRED argument rather than a default: the compiler then has to
+ * point at every call site instead of letting one silently keep uninstall
+ * semantics. Behaviour for 'unauthorized' is unchanged, byte for byte.
+ */
+export function readEarliestViolationDetection(
+  violations: unknown,
+  violationType: SoftwarePolicyViolation['type']
+): Date | null {
+  if (!Array.isArray(violations)) return null;
+  let earliest: Date | null = null;
+
+  for (const violation of violations) {
+    if (!violation || typeof violation !== 'object') continue;
+    const typed = violation as { type?: unknown; detectedAt?: unknown };
+    if (typed.type !== violationType || typeof typed.detectedAt !== 'string') {
+      continue;
+    }
+    const detectedAt = new Date(typed.detectedAt);
+    if (Number.isNaN(detectedAt.getTime())) continue;
+    if (!earliest || detectedAt.getTime() < earliest.getTime()) {
+      earliest = detectedAt;
+    }
+  }
+
+  return earliest;
+}
+
+/** The only reasons this function ever defers. Narrowed from `string` so the
+ *  install decision can widen it into its own union without a cast. */
+export type AutoRemediationDeferralReason = 'in_progress' | 'grace_period' | 'cooldown';
+
+export function shouldQueueAutoRemediation(input: {
+  violations: unknown;
+  /** Which violation type's clock the grace window is measured against (D10). */
+  violationType: SoftwarePolicyViolation['type'];
+  previousRemediationStatus: string | null;
+  lastRemediationAttempt: Date | null;
+  now: Date;
+  gracePeriodHours: number;
+  cooldownMinutes: number;
+}): { queue: boolean; reason?: AutoRemediationDeferralReason } {
+  if (input.previousRemediationStatus === 'pending' || input.previousRemediationStatus === 'in_progress') {
+    return { queue: false, reason: 'in_progress' };
+  }
+
+  const earliestDetectedAt = readEarliestViolationDetection(input.violations, input.violationType);
+  if (input.gracePeriodHours > 0 && earliestDetectedAt) {
+    const graceMs = input.gracePeriodHours * 60 * 60 * 1000;
+    if ((input.now.getTime() - earliestDetectedAt.getTime()) < graceMs) {
+      return { queue: false, reason: 'grace_period' };
+    }
+  }
+
+  if (input.lastRemediationAttempt) {
+    const cooldownMs = input.cooldownMinutes * 60 * 1000;
+    if ((input.now.getTime() - input.lastRemediationAttempt.getTime()) < cooldownMs) {
+      return { queue: false, reason: 'cooldown' };
+    }
+  }
+
+  return { queue: true };
+}
+```
+
+Add the type import at `softwareComplianceWorker.ts:4`:
+
+```ts
+import {
+  devices,
+  softwareComplianceStatus,
+  softwarePolicies,
+  type SoftwarePolicyViolation,
+} from '../db/schema';
+```
+
+And update the sole call site at `:429-436`:
+
+```ts
+// apps/api/src/jobs/softwareComplianceWorker.ts — inside the uninstall gate
+          const remediationDecision = shouldQueueAutoRemediation({
+            violations: violationsWithStableTimestamps,
+            violationType: 'unauthorized',
+            previousRemediationStatus: existing?.remediationStatus ?? null,
+            lastRemediationAttempt: existing?.lastRemediationAttempt ?? null,
+            now,
+            gracePeriodHours: remediationOptions.gracePeriodHours,
+            cooldownMinutes: remediationOptions.cooldownMinutes,
+          });
+```
+
+- [ ] **Step 4: Run the tests and watch them pass**
+
+```bash
+cd apps/api && npx vitest run src/jobs/softwareComplianceWorker.test.ts
+```
+
+Expected: PASS. Confirm the reported file count is **1** and that all 13 pre-existing cases plus the 5 new ones ran.
+
+- [ ] **Step 5: Prove nothing else referenced the old name**
+
+```bash
+cd /Users/toddhebebrand/.herdr/worktrees/breeze/warranty-testing
+grep -rn "readEarliestUnauthorizedDetection" apps packages ee 2>/dev/null | grep -v node_modules
+pnpm --filter @breeze/api exec tsc --noEmit
+```
+
+Expected: the grep returns **nothing**, and tsc passes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/jobs/softwareComplianceWorker.ts apps/api/src/jobs/softwareComplianceWorker.test.ts
+git commit -m "refactor(software): verb-aware grace clock for remediation (#5505 W02, D10)"
+```
+
+---
+
+### Task 5: D9 check — pin that `catalogId` on a violation's rule cannot change match behaviour
+
+**Files:**
+- Test: `apps/api/src/services/softwarePolicyService.violationFingerprint.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `withStableViolationTimestamps` (existing, `softwarePolicyService.ts:113-146`) and W01's `SoftwarePolicyViolation['rule'].catalogId`.
+- Produces: nothing at runtime. This is a regression pin.
+
+**Finding (the contract asked W02 to open the code and state what it found, not to assume):** `violationFingerprint` (`softwarePolicyService.ts:99-111`) does **not** compare violation objects structurally. It builds an explicit string key from four named fields — `type` plus, for `missing`, `rule.name` / `rule.minVersion` / `rule.maxVersion` — and ignores every other property of the object. W01's new `rule.catalogId` is therefore invisible to matching, and `withStableViolationTimestamps` returns `{ ...violation, detectedAt }`, so the field survives stabilisation intact. **No fix is needed.** This task pins that, because the grace clock W02 just made verb-aware depends on `missing` violations keeping a stable `detectedAt` across the W01 change — if a future edit folds `catalogId` into the fingerprint, every rule edit would silently reset the install grace window and re-arm a loop the give-up counter is supposed to terminate.
+
+- [ ] **Step 1: Write the test**
+
+```ts
+// apps/api/src/services/softwarePolicyService.violationFingerprint.test.ts
+import { describe, expect, it } from 'vitest';
+import { withStableViolationTimestamps } from './softwarePolicyService';
+import type { SoftwarePolicyViolation } from '../db/schema';
+
+/**
+ * Contract D9 guard (feature #5505). W01 adds `catalogId` to the `rule` object
+ * of an emitted `missing` violation. violationFingerprint keys on
+ * type + rule.name + rule.minVersion + rule.maxVersion and NOTHING else, so
+ * that addition must not change which stored violation a fresh one matches.
+ *
+ * Why this matters beyond tidiness: the install grace clock
+ * (readEarliestViolationDetection(v, 'missing')) reads detectedAt off the
+ * STABILISED violation. If catalogId ever joined the fingerprint, editing a
+ * policy rule's catalogId would reset every device's install grace window and
+ * restart the attempt budget — re-arming exactly the reinstall loop the
+ * give-up counter exists to terminate.
+ */
+describe('withStableViolationTimestamps — catalogId is not part of the match key (D9)', () => {
+  const STORED: SoftwarePolicyViolation[] = [{
+    type: 'missing',
+    rule: { name: 'Google Chrome', minVersion: '120.0' },
+    severity: 'high',
+    detectedAt: '2026-09-01T00:00:00.000Z',
+  }];
+
+  it('carries the stored detectedAt onto a fresh violation that now also has catalogId', () => {
+    const next: SoftwarePolicyViolation[] = [{
+      type: 'missing',
+      rule: { name: 'Google Chrome', minVersion: '120.0', catalogId: 'catalog-abc' },
+      severity: 'high',
+      detectedAt: '2026-09-10T12:00:00.000Z',
+    }];
+
+    const stabilized = withStableViolationTimestamps(next, STORED);
+
+    expect(stabilized[0].detectedAt).toBe('2026-09-01T00:00:00.000Z');
+    // and the field itself must survive — W03 resolves the install target from it
+    expect(stabilized[0].rule?.catalogId).toBe('catalog-abc');
+  });
+
+  it('is symmetric: a stored violation WITH catalogId still matches a fresh one without', () => {
+    const stored: SoftwarePolicyViolation[] = [{
+      type: 'missing',
+      rule: { name: 'Google Chrome', minVersion: '120.0', catalogId: 'catalog-abc' },
+      severity: 'high',
+      detectedAt: '2026-09-01T00:00:00.000Z',
+    }];
+    const next: SoftwarePolicyViolation[] = [{
+      type: 'missing',
+      rule: { name: 'Google Chrome', minVersion: '120.0' },
+      severity: 'high',
+      detectedAt: '2026-09-10T12:00:00.000Z',
+    }];
+
+    expect(withStableViolationTimestamps(next, stored)[0].detectedAt)
+      .toBe('2026-09-01T00:00:00.000Z');
+  });
+
+  it('still separates violations that differ in a field the fingerprint DOES read', () => {
+    const next: SoftwarePolicyViolation[] = [{
+      type: 'missing',
+      rule: { name: 'Google Chrome', minVersion: '121.0', catalogId: 'catalog-abc' },
+      severity: 'high',
+      detectedAt: '2026-09-10T12:00:00.000Z',
+    }];
+
+    // minVersion changed, so this is a genuinely different requirement and must
+    // start its own clock. Without this control the two cases above would pass
+    // against a fingerprint that returned a constant.
+    expect(withStableViolationTimestamps(next, STORED)[0].detectedAt)
+      .toBe('2026-09-10T12:00:00.000Z');
+  });
+});
+```
+
+- [ ] **Step 2: Run it**
+
+```bash
+cd apps/api && npx vitest run src/services/softwarePolicyService.violationFingerprint.test.ts
+```
+
+Expected: PASS (all three) once W01 is merged. **If the first two fail, `catalogId` HAS entered the fingerprint** — stop and fix `violationFingerprint` to exclude it before continuing; that would be a real behaviour change W01 introduced.
+
+Note on the red step: this task pins existing correct behaviour rather than driving new code, so there is no "watch it fail" moment for cases 1-2. Case 3 is the positive control that makes the pin non-vacuous — temporarily edit `violationFingerprint` to `return type;` and re-run: cases 1-2 still pass while case 3 goes red. Revert the edit before committing.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/services/softwarePolicyService.violationFingerprint.test.ts
+git commit -m "test(software): pin that violation catalogId stays out of the stable-timestamp match key (#5505 W02, D9)"
+```
+
+---
+
+### Task 6: The install-remediation knobs, resolved per call
+
+**Files:**
+- Create: `apps/api/src/services/softwareInstallRemediationKnobs.ts`
+- Test: `apps/api/src/services/softwareInstallRemediationKnobs.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `resolveInstallRemediationMaxPerPass(): number` and `resolveInstallRemediationMaxAttempts(): number` (contract D5 fixes both names).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// apps/api/src/services/softwareInstallRemediationKnobs.test.ts
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  resolveInstallRemediationMaxAttempts,
+  resolveInstallRemediationMaxPerPass,
+} from './softwareInstallRemediationKnobs';
+
+const KEYS = [
+  'SOFTWARE_INSTALL_REMEDIATION_MAX_PER_PASS',
+  'SOFTWARE_INSTALL_REMEDIATION_MAX_ATTEMPTS',
+] as const;
+
+describe('softwareInstallRemediationKnobs', () => {
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of KEYS) saved[key] = process.env[key];
+    for (const key of KEYS) delete process.env[key];
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    for (const key of KEYS) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key] as string;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('returns the documented defaults when unset', () => {
+    expect(resolveInstallRemediationMaxPerPass()).toBe(50);
+    expect(resolveInstallRemediationMaxAttempts()).toBe(3);
+  });
+
+  /**
+   * THE POINT OF THIS FILE (contract D5). BACKUP_GC_GRACE_MS froze its knob at
+   * module load (`export const X = resolveX()`, backupRetention.ts:539), so a
+   * lab could set the env var and watch it do nothing. Two calls straddling an
+   * env change must disagree; a module-load-cached implementation makes them
+   * agree and this case goes red.
+   */
+  it('re-reads the environment on EVERY call, never caching at module load', () => {
+    process.env.SOFTWARE_INSTALL_REMEDIATION_MAX_PER_PASS = '7';
+    expect(resolveInstallRemediationMaxPerPass()).toBe(7);
+
+    process.env.SOFTWARE_INSTALL_REMEDIATION_MAX_PER_PASS = '9';
+    expect(resolveInstallRemediationMaxPerPass()).toBe(9);
+
+    delete process.env.SOFTWARE_INSTALL_REMEDIATION_MAX_PER_PASS;
+    expect(resolveInstallRemediationMaxPerPass()).toBe(50);
+  });
+
+  it('clamps to the floor of 1 in every environment, not just production', () => {
+    process.env.SOFTWARE_INSTALL_REMEDIATION_MAX_PER_PASS = '0';
+    process.env.SOFTWARE_INSTALL_REMEDIATION_MAX_ATTEMPTS = '-4';
+    expect(resolveInstallRemediationMaxPerPass()).toBe(1);
+    expect(resolveInstallRemediationMaxAttempts()).toBe(1);
+  });
+
+  it('falls back to the default for non-numeric, blank and fractional-below-floor input', () => {
+    process.env.SOFTWARE_INSTALL_REMEDIATION_MAX_ATTEMPTS = 'three';
+    expect(resolveInstallRemediationMaxAttempts()).toBe(3);
+
+    process.env.SOFTWARE_INSTALL_REMEDIATION_MAX_ATTEMPTS = '   ';
+    expect(resolveInstallRemediationMaxAttempts()).toBe(3);
+
+    process.env.SOFTWARE_INSTALL_REMEDIATION_MAX_ATTEMPTS = 'Infinity';
+    expect(resolveInstallRemediationMaxAttempts()).toBe(3);
+  });
+
+  it('floors a fractional override rather than carrying a fraction into a counter comparison', () => {
+    process.env.SOFTWARE_INSTALL_REMEDIATION_MAX_ATTEMPTS = '2.9';
+    expect(resolveInstallRemediationMaxAttempts()).toBe(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+cd apps/api && npx vitest run src/services/softwareInstallRemediationKnobs.test.ts
+```
+
+Expected: FAIL — the module does not exist.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// apps/api/src/services/softwareInstallRemediationKnobs.ts
+/**
+ * Env knobs for install remediation (feature #5505, contract D5).
+ *
+ * RESOLVED PER CALL, DELIBERATELY. Do NOT hoist any of these into
+ * `export const X = resolveX()`: that is the defect BACKUP_GC_GRACE_MS shipped
+ * (apps/api/src/jobs/backupRetention.ts:539), where the value froze at module
+ * load and an operator setting the variable saw no effect at all. Both
+ * resolvers below are cheap (one process.env read plus a Number cast) and run
+ * at most twice per compliance pass, so there is nothing to optimise.
+ *
+ * FLOORS APPLY IN EVERY ENVIRONMENT, unlike BACKUP_GC_GRACE_MS's
+ * production-only floor. A value below 1 is not a "risky but valid lab
+ * setting" for either knob — it is a silent feature kill: 0 installs per pass
+ * means the feature appears armed and never acts, and 0 attempts means every
+ * device goes straight to 'gave_up'. Both would look like a product bug, not a
+ * configuration choice, so they are clamped everywhere.
+ */
+
+const MAX_PER_PASS_ENV = 'SOFTWARE_INSTALL_REMEDIATION_MAX_PER_PASS';
+const MAX_PER_PASS_DEFAULT = 50;
+
+const MAX_ATTEMPTS_ENV = 'SOFTWARE_INSTALL_REMEDIATION_MAX_ATTEMPTS';
+const MAX_ATTEMPTS_DEFAULT = 3;
+
+const KNOB_FLOOR = 1;
+
+function resolveCountKnob(envKey: string, defaultValue: number): number {
+  const raw = process.env[envKey];
+  if (raw === undefined || raw.trim() === '') return defaultValue;
+
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) {
+    console.warn(
+      `[SoftwareInstallRemediation] Ignoring ${envKey}=${JSON.stringify(raw)} (not a finite number); using default ${defaultValue}`,
+    );
+    return defaultValue;
+  }
+
+  const floored = Math.floor(parsed);
+  if (floored < KNOB_FLOOR) {
+    console.warn(
+      `[SoftwareInstallRemediation] ${envKey}=${parsed} is below the floor of ${KNOB_FLOOR}; using ${KNOB_FLOOR} instead`,
+    );
+    return KNOB_FLOOR;
+  }
+
+  if (floored !== defaultValue) {
+    console.warn(`[SoftwareInstallRemediation] ${envKey} override active: ${floored} (default ${defaultValue})`);
+  }
+  return floored;
+}
+
+/**
+ * Maximum install jobs queued for ONE policy in ONE compliance pass.
+ *
+ * Spec Risks §2: arming autoInstall on an existing broad policy could otherwise
+ * queue thousands of installs in a single 15-minute pass. Devices over the cap
+ * are recorded 'skipped' and picked up by the next pass — they are deferred,
+ * never dropped, and never burn an attempt from the give-up budget.
+ */
+export function resolveInstallRemediationMaxPerPass(): number {
+  return resolveCountKnob(MAX_PER_PASS_ENV, MAX_PER_PASS_DEFAULT);
+}
+
+/**
+ * CONSECUTIVE install attempts for one (policy, device) before giving up.
+ *
+ * Spec Risks §1: a policy whose rule never matches what the installer registers
+ * in Add/Remove Programs re-detects `missing` forever. Grace and cooldown bound
+ * the rate of that loop but do not stop it; this counter does, by writing
+ * install_remediation_status = 'gave_up'. The counter resets to 0 the moment
+ * the device has no `missing` violation left for that policy.
+ */
+export function resolveInstallRemediationMaxAttempts(): number {
+  return resolveCountKnob(MAX_ATTEMPTS_ENV, MAX_ATTEMPTS_DEFAULT);
+}
+```
+
+- [ ] **Step 4: Run it and watch it pass**
+
+```bash
+cd apps/api && npx vitest run src/services/softwareInstallRemediationKnobs.test.ts
+```
+
+Expected: PASS, 6 cases.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/softwareInstallRemediationKnobs.ts apps/api/src/services/softwareInstallRemediationKnobs.test.ts
+git commit -m "feat(software): per-call install remediation env knobs (#5505 W02, D5)"
+```
+
+---
+
+### Task 7: D11 — the worker delegates arming to the shared helper for both verbs
+
+**Files:**
+- Modify: `apps/api/src/jobs/softwareComplianceWorker.ts:136-162` (drop `autoUninstallEnabled`), `:361-369` (pass preamble), `:423-427` (the gate)
+- Test: `apps/api/src/jobs/softwareComplianceWorker.install.test.ts` (create — the divergence guard lives here)
+
+**Interfaces:**
+- Consumes (from W01, exact names): `evaluateSoftwarePolicyArming(policy: SoftwarePolicyArmingInput, verb: PolicyRemediationVerb): SoftwarePolicyArmingState`, `type PolicyRemediationVerb = 'uninstall' | 'install'`.
+- Produces: the worker's `uninstallArming` / `installArming` per-pass values; no new exports.
+
+**Before starting, confirm W01's actual export names:**
+
+```bash
+cd /Users/toddhebebrand/.herdr/worktrees/breeze/warranty-testing
+grep -n "PolicyRemediationVerb\|evaluateSoftwarePolicyArming\|readSoftwarePolicyAutoInstall\|install_queued\|install_gave_up" apps/api/src/services/softwarePolicyService.ts
+```
+
+`PolicyRemediationVerb`, `evaluateSoftwarePolicyArming(policy, verb)` and `readSoftwarePolicyAutoInstall` are locked by contract D2 and must match exactly. The **audit-action constant's export identifier** is not locked (D6 fixes only the four string VALUES and leaves W01 to name the object) — this plan writes `SOFTWARE_POLICY_INSTALL_AUDIT_ACTIONS` with fields `.queued`, `.succeeded`, `.failed`, `.gaveUp`. If W01 shipped a different identifier or field names, use W01's; the values `install_queued` / `install_gave_up` are non-negotiable.
+
+- [ ] **Step 1: Write the failing divergence test**
+
+```ts
+// apps/api/src/jobs/softwareComplianceWorker.install.test.ts
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  addMock,
+  dbSelectMock,
+  dbUpdateMock,
+  resolveDeviceIdsMock,
+  armingMock,
+  upsertMock,
+  inventoryMock,
+  scheduleUninstallMock,
+  scheduleInstallMock,
+} = vi.hoisted(() => ({
+  addMock: vi.fn(async () => ({ id: 'queued-job-1' })),
+  dbSelectMock: vi.fn(),
+  dbUpdateMock: vi.fn(() => ({ set: () => ({ where: async () => undefined }) })),
+  resolveDeviceIdsMock: vi.fn(async () => ['device-1']),
+  armingMock: vi.fn(() => ({ armed: true as const })),
+  upsertMock: vi.fn(async () => undefined),
+  inventoryMock: vi.fn(async () => new Map<string, unknown[]>([['device-1', []]])),
+  scheduleUninstallMock: vi.fn(async () => 0),
+  scheduleInstallMock: vi.fn(async () => [] as string[]),
+}));
+
+vi.mock('bullmq', () => ({
+  Queue: class { add = addMock; addBulk = vi.fn(); getRepeatableJobs = vi.fn(async () => []); },
+  Worker: class { on = vi.fn(); close = vi.fn(); },
+  Job: class {},
+}));
+vi.mock('../services/redis', () => ({ getBullMQConnection: vi.fn(() => ({})) }));
+vi.mock('../db', () => ({
+  db: { select: dbSelectMock, update: dbUpdateMock },
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+vi.mock('../services/featureConfigResolver', () => ({
+  resolveDeviceIdsForSoftwarePolicy: resolveDeviceIdsMock,
+}));
+vi.mock('./softwareRemediationWorker', () => ({
+  scheduleSoftwareRemediation: scheduleUninstallMock,
+  scheduleSoftwareInstallRemediation: scheduleInstallMock,
+}));
+vi.mock('../services/softwarePolicyService', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../services/softwarePolicyService')>();
+  return {
+    ...actual,
+    evaluateSoftwarePolicyArming: armingMock,
+    upsertSoftwareComplianceStatuses: upsertMock,
+    getSoftwareInventoryByDeviceIds: inventoryMock,
+    recordSoftwarePolicyAudit: vi.fn(async () => undefined),
+  };
+});
+
+import { processCheckPolicy } from './softwareComplianceWorker';
+
+const POLICY_ID = 'policy-1';
+
+/**
+ * A policy that is armed for BOTH verbs by every inline criterion the worker
+ * used to check for itself: mode allowlist, enforceMode true, autoUninstall
+ * true, autoInstall true.
+ */
+const FULLY_ARMED_POLICY = {
+  id: POLICY_ID,
+  orgId: 'org-1',
+  partnerId: null,
+  isActive: true,
+  approvalGeneration: 1,
+  mode: 'allowlist',
+  enforceMode: true,
+  remediationOptions: { autoUninstall: true, autoInstall: true },
+  rules: { software: [{ name: 'Google Chrome', catalogId: 'catalog-abc' }] },
+};
+
+/** FIFO for db.select(): policy reload → devices(orgByDevice) → compliance state. */
+function primeSelects(rows: unknown[][]) {
+  for (const result of rows) {
+    dbSelectMock.mockReturnValueOnce({
+      from: () => ({
+        where: Object.assign(
+          () => ({ limit: () => Promise.resolve(result) }),
+          { then: (r: (v: unknown) => void) => r(result) },
+        ),
+        limit: () => Promise.resolve(result),
+      }),
+    });
+  }
+}
+
+function primeStandardPass() {
+  primeSelects([
+    [FULLY_ARMED_POLICY],                                   // policy reload
+    [{ id: 'device-1', orgId: 'org-1' }],                   // orgByDevice
+    [],                                                     // readComplianceStateByDevice
+  ]);
+  inventoryMock.mockResolvedValueOnce(new Map([['device-1', []]]));
+}
+
+describe('processCheckPolicy — arming comes from the shared helper only (contract D11)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    armingMock.mockReturnValue({ armed: true });
+    scheduleUninstallMock.mockResolvedValue(0);
+    scheduleInstallMock.mockResolvedValue([]);
+  });
+
+  it('asks evaluateSoftwarePolicyArming for BOTH verbs, once each', async () => {
+    primeStandardPass();
+
+    await processCheckPolicy({ type: 'check-policy', policyId: POLICY_ID });
+
+    const verbs = armingMock.mock.calls.map((call) => call[1]);
+    expect(verbs).toContain('uninstall');
+    expect(verbs).toContain('install');
+  });
+
+  /**
+   * THE DIVERGENCE GUARD. The policy row below satisfies every criterion the
+   * worker's old inline gate checked (softwareComplianceWorker.ts:423-427), but
+   * the shared helper says NOT ARMED. If the worker re-derives arming for
+   * itself — today, or after some future edit re-inlines it — it queues anyway
+   * and this fails. There is exactly one arming truth.
+   */
+  it('queues NOTHING when the shared helper says unarmed, even on a policy the old inline gate would have passed', async () => {
+    armingMock.mockReturnValue({
+      armed: false,
+      reason: 'enforce_mode_off',
+      message: 'test double: unarmed',
+    });
+    primeSelects([
+      [FULLY_ARMED_POLICY],
+      [{ id: 'device-1', orgId: 'org-1' }],
+      [],
+    ]);
+    inventoryMock.mockResolvedValueOnce(new Map([['device-1', [
+      { name: 'Some Unapproved App', version: '1.0', vendor: 'Acme', catalogId: null },
+    ]]]));
+
+    const result = await processCheckPolicy({ type: 'check-policy', policyId: POLICY_ID });
+
+    expect(result.violations).toBeGreaterThan(0);        // it DID detect
+    expect(scheduleUninstallMock).not.toHaveBeenCalled(); // and refused to act
+    expect(scheduleInstallMock).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+cd apps/api && npx vitest run src/jobs/softwareComplianceWorker.install.test.ts
+```
+
+Expected: FAIL on both cases — `armingMock` is never called (the worker derives inline), and `scheduleSoftwareInstallRemediation` is not yet an export of `./softwareRemediationWorker` (that arrives in Task 8; the mock factory declaring it is harmless).
+
+- [ ] **Step 3: Drop the duplicate derivation from `readRemediationOptions`**
+
+```ts
+// apps/api/src/jobs/softwareComplianceWorker.ts — replacing :136-162
+/**
+ * Timing options only. `autoUninstall` used to be read here as
+ * `autoUninstallEnabled`, which meant the worker carried its own copy of the
+ * arming rule alongside evaluateSoftwarePolicyArming — the duplication that let
+ * the two drift (contract D11). Arming now comes exclusively from that helper;
+ * this function answers only "how long to wait", never "may we act".
+ */
+function readRemediationOptions(raw: unknown): {
+  gracePeriodHours: number;
+  cooldownMinutes: number;
+} {
+  if (!raw || typeof raw !== 'object') {
+    return {
+      gracePeriodHours: 0,
+      cooldownMinutes: REMEDIATION_COOLDOWN_DEFAULT_MINUTES,
+    };
+  }
+
+  const options = raw as Record<string, unknown>;
+  const gracePeriodHours = typeof options.gracePeriod === 'number'
+    ? Math.max(0, Math.min(24 * 90, Math.floor(options.gracePeriod)))
+    : 0;
+  const cooldownMinutes = typeof options.cooldownMinutes === 'number'
+    ? Math.max(1, Math.min(24 * 90 * 60, Math.floor(options.cooldownMinutes)))
+    : REMEDIATION_COOLDOWN_DEFAULT_MINUTES;
+
+  return {
+    gracePeriodHours,
+    cooldownMinutes,
+  };
+}
+```
+
+- [ ] **Step 4: Evaluate arming once per pass and use it in the gate**
+
+```ts
+// apps/api/src/jobs/softwareComplianceWorker.ts — in the pass preamble, replacing :361-362
+  const normalizedRules = normalizeSoftwarePolicyRules(policy.rules);
+  const remediationOptions = readRemediationOptions(policy.remediationOptions);
+  // Contract D11: ONE arming truth, shared with softwareRemediationWorker.ts and
+  // the AI compliance tool. Evaluated once per pass — the policy row cannot
+  // change mid-loop, and the generation gate at :311 already refused a job whose
+  // policy was edited after enqueue.
+  const uninstallArming = evaluateSoftwarePolicyArming(policy, 'uninstall');
+  const installArming = evaluateSoftwarePolicyArming(policy, 'install');
+```
+
+```ts
+// apps/api/src/jobs/softwareComplianceWorker.ts — replacing the gate at :423-427
+        // Two INDEPENDENT gates over the same violation set (spec §2). A policy
+        // may arm both, one, or neither, and a device may be queued for both
+        // verbs in one pass — removing an unauthorised app and installing a
+        // required one are not in conflict.
+        if (
+          uninstallArming.armed
+          && violationsWithStableTimestamps.some((violation) => violation.type === 'unauthorized')
+        ) {
+```
+
+Add the import at `softwareComplianceWorker.ts:11-20`:
+
+```ts
+import {
+  evaluateSoftwarePolicyAgainstInventory,
+  evaluateSoftwarePolicyArming,
+  getSoftwareInventoryByDeviceIds,
+  normalizeSoftwarePolicyRules,
+  recordSoftwarePolicyAudit,
+  upsertSoftwareComplianceStatuses,
+  withStableViolationTimestamps,
+  type SoftwarePolicyComplianceStatus,
+  type SoftwarePolicyRemediationStatus,
+} from '../services/softwarePolicyService';
+```
+
+**Equivalence note for the reviewer:** the removed inline gate was `policy.enforceMode && policy.mode !== 'audit' && remediationOptions.autoUninstallEnabled`. `enforceMode` is `boolean NOT NULL` (`softwarePolicies.ts:94`), so `policy.enforceMode &&` and the helper's `policy.enforceMode !== true` agree on every possible value; `mode !== 'audit'` and the helper's `mode === 'audit'` early-return agree; `options.autoUninstall === true` is character-for-character the helper's `readSoftwarePolicyAutoUninstall`. The replacement is behaviour-preserving for uninstall.
+
+- [ ] **Step 5: Run the tests**
+
+```bash
+cd apps/api && npx vitest run src/jobs/softwareComplianceWorker.install.test.ts src/jobs/softwareComplianceWorker.test.ts
+```
+
+Expected: the divergence case and the "asks for both verbs" case PASS; `softwareComplianceWorker.test.ts` stays green (2 files reported). The install-scheduling half is still absent — that is Task 8/9.
+
+- [ ] **Step 6: Typecheck and commit**
+
+```bash
+cd /Users/toddhebebrand/.herdr/worktrees/breeze/warranty-testing
+pnpm --filter @breeze/api exec tsc --noEmit
+git add apps/api/src/jobs/softwareComplianceWorker.ts apps/api/src/jobs/softwareComplianceWorker.install.test.ts
+git commit -m "refactor(software): compliance worker delegates arming to the shared helper for both verbs (#5505 W02, D11)"
+```
+
+---
+
+### Task 8: `decideInstallRemediation` — the pure install gate
+
+**Files:**
+- Modify: `apps/api/src/jobs/softwareComplianceWorker.ts` (new exported function, placed immediately after `shouldQueueAutoRemediation`)
+- Test: `apps/api/src/jobs/softwareComplianceWorker.install.test.ts` (append a describe block)
+
+**Interfaces:**
+- Consumes: `shouldQueueAutoRemediation` + `AutoRemediationDeferralReason` (Task 4), `SoftwarePolicyInstallRemediationStatus` (Task 3), `SoftwarePolicyViolation['rule'].catalogId` (W01).
+- Produces:
+  - `export type InstallRemediationSkipReason = AutoRemediationDeferralReason | 'no_missing_violations' | 'no_catalog_id' | 'attempts_exhausted' | 'pass_cap';`
+  - `export type InstallRemediationDecision = { queue: true; catalogIds: string[]; attempt: number } | { queue: false; reason: InstallRemediationSkipReason };`
+  - `export function decideInstallRemediation(input): InstallRemediationDecision;`
+  - `export function installStatusForSkip(reason: InstallRemediationSkipReason): SoftwarePolicyInstallRemediationStatus | undefined;`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// apps/api/src/jobs/softwareComplianceWorker.install.test.ts — append at end of file
+import { decideInstallRemediation, installStatusForSkip } from './softwareComplianceWorker';
+import type { SoftwarePolicyViolation } from '../db/schema';
+
+const DECIDE_NOW = new Date('2026-09-10T12:00:00.000Z');
+
+function missing(catalogId?: string, detectedAt = '2026-01-01T00:00:00.000Z'): SoftwarePolicyViolation {
+  return {
+    type: 'missing',
+    rule: { name: 'Google Chrome', ...(catalogId ? { catalogId } : {}) },
+    severity: 'high',
+    detectedAt,
+  };
+}
+
+function unauthorized(detectedAt = '2026-01-01T00:00:00.000Z'): SoftwarePolicyViolation {
+  return {
+    type: 'unauthorized',
+    software: { name: 'Bad App', version: '1.0', vendor: 'Acme' },
+    severity: 'medium',
+    detectedAt,
+  };
+}
+
+function decideWith(overrides: Partial<Parameters<typeof decideInstallRemediation>[0]> = {}) {
+  return decideInstallRemediation({
+    violations: [missing('catalog-abc')],
+    previousInstallStatus: null,
+    lastInstallAttempt: null,
+    attempts: 0,
+    now: DECIDE_NOW,
+    gracePeriodHours: 0,
+    cooldownMinutes: 120,
+    maxAttempts: 3,
+    capRemaining: 10,
+    ...overrides,
+  });
+}
+
+describe('decideInstallRemediation', () => {
+  it('queues with the deduped catalog ids and a 1-based attempt number', () => {
+    expect(decideWith({
+      violations: [missing('catalog-abc'), missing('catalog-def'), missing('catalog-abc')],
+    })).toEqual({ queue: true, catalogIds: ['catalog-abc', 'catalog-def'], attempt: 1 });
+  });
+
+  it('reports the next attempt number from the stored counter', () => {
+    expect(decideWith({ attempts: 2, maxAttempts: 5 }))
+      .toEqual({ queue: true, catalogIds: ['catalog-abc'], attempt: 3 });
+  });
+
+  it('ignores unauthorized violations entirely', () => {
+    expect(decideWith({ violations: [unauthorized()] }))
+      .toEqual({ queue: false, reason: 'no_missing_violations' });
+  });
+
+  it('refuses a missing violation whose rule carries no catalogId', () => {
+    expect(decideWith({ violations: [missing()] }))
+      .toEqual({ queue: false, reason: 'no_catalog_id' });
+  });
+
+  it('ignores blank and whitespace-only catalog ids', () => {
+    expect(decideWith({ violations: [missing('   ')] }))
+      .toEqual({ queue: false, reason: 'no_catalog_id' });
+  });
+
+  it('still queues when SOME missing rules have a catalogId and others do not', () => {
+    expect(decideWith({ violations: [missing(), missing('catalog-abc')] }))
+      .toEqual({ queue: true, catalogIds: ['catalog-abc'], attempt: 1 });
+  });
+
+  it('gives up once the consecutive counter reaches maxAttempts', () => {
+    expect(decideWith({ attempts: 3, maxAttempts: 3 }))
+      .toEqual({ queue: false, reason: 'attempts_exhausted' });
+  });
+
+  it('gives up on a counter that somehow exceeded maxAttempts', () => {
+    expect(decideWith({ attempts: 99, maxAttempts: 3 }))
+      .toEqual({ queue: false, reason: 'attempts_exhausted' });
+  });
+
+  // Ordering: attempts BEFORE timing, so an exhausted device reports the honest
+  // terminal reason instead of hiding behind an incidental cooldown.
+  it('reports attempts_exhausted rather than cooldown when both apply', () => {
+    expect(decideWith({
+      attempts: 3,
+      maxAttempts: 3,
+      lastInstallAttempt: new Date(DECIDE_NOW.getTime() - 60_000),
+    })).toEqual({ queue: false, reason: 'attempts_exhausted' });
+  });
+
+  it('defers while an install is already pending', () => {
+    expect(decideWith({ previousInstallStatus: 'pending' }))
+      .toEqual({ queue: false, reason: 'in_progress' });
+  });
+
+  it('defers inside the grace window, measured on the MISSING clock', () => {
+    expect(decideWith({
+      violations: [missing('catalog-abc', '2026-09-10T11:00:00.000Z')],
+      gracePeriodHours: 24,
+    })).toEqual({ queue: false, reason: 'grace_period' });
+  });
+
+  it('defers inside the cooldown window', () => {
+    expect(decideWith({
+      lastInstallAttempt: new Date(DECIDE_NOW.getTime() - 60 * 1000),
+      cooldownMinutes: 120,
+    })).toEqual({ queue: false, reason: 'cooldown' });
+  });
+
+  // Ordering: cap LAST, so the pass budget is only consumed by devices that
+  // would genuinely have queued. Checking it first would let devices already in
+  // cooldown eat the cap and starve devices that are actually ready.
+  it('applies the per-pass cap only after every other gate has passed', () => {
+    expect(decideWith({ capRemaining: 0 }))
+      .toEqual({ queue: false, reason: 'pass_cap' });
+
+    expect(decideWith({ capRemaining: 0, previousInstallStatus: 'in_progress' }))
+      .toEqual({ queue: false, reason: 'in_progress' });
+  });
+
+  it('treats a negative or non-finite stored counter as zero rather than throwing', () => {
+    expect(decideWith({ attempts: -5 }))
+      .toEqual({ queue: true, catalogIds: ['catalog-abc'], attempt: 1 });
+    expect(decideWith({ attempts: Number.NaN }))
+      .toEqual({ queue: true, catalogIds: ['catalog-abc'], attempt: 1 });
+  });
+});
+
+describe('installStatusForSkip', () => {
+  it('records a terminal give-up', () => {
+    expect(installStatusForSkip('attempts_exhausted')).toBe('gave_up');
+  });
+
+  it('records the two "nothing attempted, nothing wrong with the device" cases as skipped', () => {
+    expect(installStatusForSkip('no_catalog_id')).toBe('skipped');
+    expect(installStatusForSkip('pass_cap')).toBe('skipped');
+  });
+
+  // Timing deferrals write NOTHING, mirroring the uninstall path: a device in
+  // grace or cooldown has no new status to report, and overwriting a live
+  // 'pending' with 'skipped' would tell a technician the install was abandoned.
+  it('writes no status for a timing deferral or a device with nothing missing', () => {
+    expect(installStatusForSkip('in_progress')).toBeUndefined();
+    expect(installStatusForSkip('grace_period')).toBeUndefined();
+    expect(installStatusForSkip('cooldown')).toBeUndefined();
+    expect(installStatusForSkip('no_missing_violations')).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+cd apps/api && npx vitest run src/jobs/softwareComplianceWorker.install.test.ts
+```
+
+Expected: FAIL — neither function is exported.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// apps/api/src/jobs/softwareComplianceWorker.ts — immediately after shouldQueueAutoRemediation
+
+/** Why an install was not queued for a device on this pass. */
+export type InstallRemediationSkipReason =
+  | AutoRemediationDeferralReason
+  | 'no_missing_violations'
+  | 'no_catalog_id'
+  | 'attempts_exhausted'
+  | 'pass_cap';
+
+export type InstallRemediationDecision =
+  | { queue: true; catalogIds: string[]; attempt: number }
+  | { queue: false; reason: InstallRemediationSkipReason };
+
+/**
+ * The whole install gate for one device, as a pure function (feature #5505 W02).
+ *
+ * GATE ORDER IS DELIBERATE and is the part most worth reading twice:
+ *
+ *  1. `missing` violations at all? A device whose only violations are
+ *     `unauthorized` is not an install candidate — the uninstall verb owns it.
+ *  2. Any of them carry a catalogId? A rule without one can be DETECTED as
+ *     missing but cannot be installed: there is nothing to install. Spec §4
+ *     requires the worker to skip it and say so rather than fail silently, so
+ *     this maps to a visible 'skipped'. Checked before the timing gates because
+ *     it is a policy-authoring defect the technician has to see now, not in two
+ *     hours when the cooldown lapses.
+ *  3. Consecutive attempts exhausted? Checked BEFORE grace/cooldown so an
+ *     exhausted device reports the honest terminal reason ('gave_up') instead
+ *     of disappearing behind an incidental cooldown. This is the terminator for
+ *     spec Risks §1: a policy whose rule never matches what the installer
+ *     registers in Add/Remove Programs would otherwise reinstall forever.
+ *  4. Timing (in_progress / grace / cooldown), via the SAME
+ *     shouldQueueAutoRemediation the uninstall verb uses, with the grace clock
+ *     pointed at the `missing` violations (contract D10).
+ *  5. Per-pass cap LAST. The cap must only be consumed by devices that would
+ *     genuinely have queued; checking it earlier would let devices sitting in
+ *     cooldown eat the budget and starve devices that are actually ready.
+ *
+ * Pure and total: no I/O, no clock read, no env read. Every input is supplied
+ * by the caller so the whole matrix is testable without a database.
+ */
+export function decideInstallRemediation(input: {
+  violations: SoftwarePolicyViolation[];
+  previousInstallStatus: string | null;
+  lastInstallAttempt: Date | null;
+  attempts: number;
+  now: Date;
+  gracePeriodHours: number;
+  cooldownMinutes: number;
+  maxAttempts: number;
+  capRemaining: number;
+}): InstallRemediationDecision {
+  const missingViolations = input.violations.filter(
+    (violation) => !!violation && violation.type === 'missing'
+  );
+  if (missingViolations.length === 0) {
+    return { queue: false, reason: 'no_missing_violations' };
+  }
+
+  const catalogIds: string[] = [];
+  for (const violation of missingViolations) {
+    const raw = violation.rule?.catalogId;
+    if (typeof raw !== 'string') continue;
+    const catalogId = raw.trim();
+    if (catalogId.length === 0) continue;
+    if (!catalogIds.includes(catalogId)) catalogIds.push(catalogId);
+  }
+  if (catalogIds.length === 0) {
+    return { queue: false, reason: 'no_catalog_id' };
+  }
+
+  const attempts = Number.isFinite(input.attempts) ? Math.max(0, Math.floor(input.attempts)) : 0;
+  if (attempts >= input.maxAttempts) {
+    return { queue: false, reason: 'attempts_exhausted' };
+  }
+
+  const timing = shouldQueueAutoRemediation({
+    violations: input.violations,
+    violationType: 'missing',
+    previousRemediationStatus: input.previousInstallStatus,
+    lastRemediationAttempt: input.lastInstallAttempt,
+    now: input.now,
+    gracePeriodHours: input.gracePeriodHours,
+    cooldownMinutes: input.cooldownMinutes,
+  });
+  if (!timing.queue && timing.reason) {
+    return { queue: false, reason: timing.reason };
+  }
+
+  if (input.capRemaining <= 0) {
+    return { queue: false, reason: 'pass_cap' };
+  }
+
+  return { queue: true, catalogIds, attempt: attempts + 1 };
+}
+
+/**
+ * What (if anything) a skip should write to install_remediation_status.
+ *
+ * Timing deferrals write NOTHING, mirroring the uninstall path: a device inside
+ * grace or cooldown has no new status to report, and overwriting a live
+ * 'pending' with 'skipped' would tell a technician Breeze abandoned an install
+ * that is in fact still in flight.
+ */
+export function installStatusForSkip(
+  reason: InstallRemediationSkipReason
+): SoftwarePolicyInstallRemediationStatus | undefined {
+  if (reason === 'attempts_exhausted') return 'gave_up';
+  if (reason === 'no_catalog_id' || reason === 'pass_cap') return 'skipped';
+  return undefined;
+}
+```
+
+Add `type SoftwarePolicyInstallRemediationStatus` to the `softwarePolicyService` import block edited in Task 7 Step 4.
+
+- [ ] **Step 4: Run it and watch it pass**
+
+```bash
+cd apps/api && npx vitest run src/jobs/softwareComplianceWorker.install.test.ts
+```
+
+Expected: PASS, 18 cases across the three describe blocks.
+
+- [ ] **Step 5: Typecheck and commit**
+
+```bash
+cd /Users/toddhebebrand/.herdr/worktrees/breeze/warranty-testing
+pnpm --filter @breeze/api exec tsc --noEmit
+git add apps/api/src/jobs/softwareComplianceWorker.ts apps/api/src/jobs/softwareComplianceWorker.install.test.ts
+git commit -m "feat(software): pure install remediation gate with per-pass cap and give-up counter (#5505 W02)"
+```
+
+---
+
+### Task 9: The install-remediation job payload and its producer
+
+**Files:**
+- Modify: `apps/api/src/jobs/softwareRemediationWorker.ts:56-74` (types), `:601-620` (processor), and append the producer after `scheduleSoftwareRemediation` (`:792`)
+- Test: `apps/api/src/jobs/softwareRemediationWorker.test.ts` (append a describe block)
+
+**Interfaces:**
+- Consumes: `getSoftwareRemediationQueue()` (`softwareRemediationWorker.ts:148`), `isReusableState` (`services/bullmqUtils`), `recordSoftwareRemediationDecision` (`routes/metrics`) — all already imported in that file.
+- Produces, and **W03 consumes these exact names**:
+
+```ts
+export type InstallRemediateDeviceJobData = {
+  type: 'install-remediate-device';
+  policyId: string;
+  deviceId: string;
+  /** Catalog item ids to install, deduped, in rule order. NEVER empty. */
+  catalogIds: string[];
+  /** policy.approval_generation at enqueue time (site-ceiling gate contract §3). */
+  generation: number;
+  /** 1-based consecutive attempt this job represents. Observability only — the
+   *  DB counter incremented by the compliance worker is authoritative. */
+  attempt: number;
+};
+
+export type SoftwareRemediationJobData = RemediateDeviceJobData | InstallRemediateDeviceJobData;
+
+export type InstallRemediationTarget = {
+  deviceId: string;
+  catalogIds: string[];
+  attempt: number;
+};
+
+export async function scheduleSoftwareInstallRemediation(
+  policyId: string,
+  targets: InstallRemediationTarget[],
+  generation: number
+): Promise<string[]>; // the deviceIds actually enqueued, in input order
+```
+
+**Decision, stated as the contract requires: a SIBLING TYPE, not a widened `RemediateDeviceJobData`.** Three reasons, in order of weight:
+
+1. **JobId collision.** The uninstall auto path keys on `software-remediation-${policyId}-${deviceId}` (`:757`). The spec explicitly requires that a device may be queued for both verbs in one pass. A widened type sharing that key would silently dedupe one verb into the other — the install job would be discarded as a duplicate of the uninstall job, or vice versa, with `isReusableState` reporting a clean `job_deduped`. The sibling gets `software-install-remediation-${policyId}-${deviceId}`.
+2. **`processRemediateDevice` is uninstall-specific end to end** — it consumes a single-use manual-authorization row (`:308-316`), selects `unauthorized` violations, queues `SOFTWARE_UNINSTALL`, and writes the `remediation_status` column. Routing a second verb through it would put install traffic through the #3543/#3553 manual-override machinery, where a forged `trigger:'manual'` on an install job could consume an uninstall authorization. A separate `type` keeps that boundary intact by construction.
+3. `SoftwareRemediationJobData` is already a type alias at `:74` waiting to become a discriminated union, and `SoftwareComplianceJobData` in the sibling worker (`softwareComplianceWorker.ts:233`) is already exactly that shape. This is the house pattern.
+
+`RemediateDeviceJobData` itself stays **unexported and unchanged**.
+
+**Why the type lives in `softwareRemediationWorker.ts` rather than a new file:** it is the producer half of the same BullMQ queue, and that file already owns the queue instance (`:148`), the union type (`:74`) and the jobId namespace. A separate module would have to import `getSoftwareRemediationQueue` while the worker imports the payload type back — a runtime import cycle for no benefit. The file grows ~75 lines; W03's processor goes in its own new file, which is where the bulk actually is.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// apps/api/src/jobs/softwareRemediationWorker.test.ts — append at end of file
+describe('scheduleSoftwareInstallRemediation (feature #5505 W02)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getJobMock.mockResolvedValue(null);
+  });
+
+  it('enqueues one job per target with the full payload and returns the enqueued deviceIds', async () => {
+    const enqueued = await scheduleSoftwareInstallRemediation(
+      'policy-1',
+      [
+        { deviceId: 'device-1', catalogIds: ['catalog-abc'], attempt: 1 },
+        { deviceId: 'device-2', catalogIds: ['catalog-abc', 'catalog-def'], attempt: 2 },
+      ],
+      7,
+    );
+
+    expect(enqueued).toEqual(['device-1', 'device-2']);
+    expect(addMock).toHaveBeenCalledTimes(2);
+    expect(addMock.mock.calls[1][0]).toBe('install-remediate-device');
+    expect(addMock.mock.calls[1][1]).toEqual({
+      type: 'install-remediate-device',
+      policyId: 'policy-1',
+      deviceId: 'device-2',
+      catalogIds: ['catalog-abc', 'catalog-def'],
+      generation: 7,
+      attempt: 2,
+    });
+  });
+
+  /**
+   * The reason this is a sibling type and not a widened RemediateDeviceJobData:
+   * a device may legitimately be queued for BOTH verbs in one compliance pass
+   * (spec §2), and a shared jobId would make one silently dedupe into the other.
+   */
+  it('uses a jobId namespace disjoint from the uninstall path', async () => {
+    await scheduleSoftwareInstallRemediation(
+      'policy-1',
+      [{ deviceId: 'device-1', catalogIds: ['catalog-abc'], attempt: 1 }],
+      1,
+    );
+
+    const installJobId = addMock.mock.calls[0][2].jobId as string;
+    expect(installJobId).toBe('software-install-remediation-policy-1-device-1');
+    expect(installJobId).not.toBe('software-remediation-policy-1-device-1');
+  });
+
+  it('dedupes against a reusable in-flight job instead of enqueuing a second', async () => {
+    getJobMock.mockResolvedValue({ getState: async () => 'waiting', remove: vi.fn() });
+
+    const enqueued = await scheduleSoftwareInstallRemediation(
+      'policy-1',
+      [{ deviceId: 'device-1', catalogIds: ['catalog-abc'], attempt: 1 }],
+      1,
+    );
+
+    expect(enqueued).toEqual([]);
+    expect(addMock).not.toHaveBeenCalled();
+  });
+
+  it('refuses a target with no usable catalogIds rather than shipping an empty payload', async () => {
+    const enqueued = await scheduleSoftwareInstallRemediation(
+      'policy-1',
+      [
+        { deviceId: 'device-1', catalogIds: [], attempt: 1 },
+        { deviceId: 'device-2', catalogIds: ['  '], attempt: 1 },
+        { deviceId: '', catalogIds: ['catalog-abc'], attempt: 1 },
+      ],
+      1,
+    );
+
+    expect(enqueued).toEqual([]);
+    expect(addMock).not.toHaveBeenCalled();
+  });
+
+  it('deduplicates repeated deviceIds and repeated catalogIds', async () => {
+    const enqueued = await scheduleSoftwareInstallRemediation(
+      'policy-1',
+      [
+        { deviceId: 'device-1', catalogIds: ['catalog-abc', 'catalog-abc'], attempt: 1 },
+        { deviceId: 'device-1', catalogIds: ['catalog-def'], attempt: 1 },
+      ],
+      1,
+    );
+
+    expect(enqueued).toEqual(['device-1']);
+    expect(addMock).toHaveBeenCalledTimes(1);
+    expect((addMock.mock.calls[0][1] as { catalogIds: string[] }).catalogIds).toEqual(['catalog-abc']);
+  });
+});
+```
+
+Add `scheduleSoftwareInstallRemediation` to that file's import block. If the existing rig has no `getJobMock`/`addMock` on its BullMQ `Queue` double, add them there first (`Queue: class { add = addMock; getJob = getJobMock; }` inside the existing `vi.mock('bullmq', ...)` factory, both declared in the file's `vi.hoisted` block).
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+cd apps/api && npx vitest run src/jobs/softwareRemediationWorker.test.ts
+```
+
+Expected: FAIL — `scheduleSoftwareInstallRemediation` is not exported.
+
+- [ ] **Step 3: Add the payload type and the union**
+
+```ts
+// apps/api/src/jobs/softwareRemediationWorker.ts — replacing :74
+/**
+ * Install remediation (feature #5505). A SIBLING type, deliberately not a
+ * widened RemediateDeviceJobData:
+ *
+ *  - The uninstall auto path keys its BullMQ jobId on
+ *    `software-remediation-${policyId}-${deviceId}`. A device may legitimately
+ *    be queued for BOTH verbs in one compliance pass (spec §2) — removing an
+ *    unauthorised app and installing a required one are not in conflict — so a
+ *    shared key would silently dedupe one verb into the other.
+ *  - processRemediateDevice is uninstall-specific end to end: it consumes a
+ *    single-use manual-authorization row (#3553), selects `unauthorized`
+ *    violations and writes the remediation_status column. Install traffic must
+ *    not travel through that machinery, where a forged trigger:'manual' could
+ *    consume an uninstall authorization.
+ *
+ * W02 (#5507) DEFINES this payload and produces it; W03 (#5508) consumes it and
+ * replaces the parking branch in createSoftwareRemediationWorker below.
+ */
+export type InstallRemediateDeviceJobData = {
+  type: 'install-remediate-device';
+  policyId: string;
+  deviceId: string;
+  /**
+   * Catalog item ids to install, deduped, in rule order. NEVER empty —
+   * scheduleSoftwareInstallRemediation refuses a target that would produce an
+   * empty list, because a deployment with no install target cannot satisfy
+   * software_deployments_one_target_chk.
+   */
+  catalogIds: string[];
+  /**
+   * policy.approval_generation at enqueue time (site-ceiling gate contract §3).
+   * W03 re-reads the policy and skips a job whose premise was edited away.
+   */
+  generation: number;
+  /**
+   * 1-based consecutive attempt this job represents, for the audit trail.
+   * OBSERVABILITY ONLY: software_compliance_status.install_remediation_attempts,
+   * incremented in SQL by the compliance worker, is authoritative.
+   */
+  attempt: number;
+};
+
+type SoftwareRemediationJobData = RemediateDeviceJobData | InstallRemediateDeviceJobData;
+```
+
+- [ ] **Step 4: Add the producer**
+
+```ts
+// apps/api/src/jobs/softwareRemediationWorker.ts — append after scheduleSoftwareRemediation (:792)
+
+export type InstallRemediationTarget = {
+  deviceId: string;
+  catalogIds: string[];
+  attempt: number;
+};
+
+/**
+ * Enqueue install remediation for a batch of devices under one policy.
+ *
+ * Returns THE DEVICE IDS ACTUALLY ENQUEUED, not a count. The uninstall sibling
+ * returns a count, and its caller (softwareComplianceWorker.ts:486) then stamps
+ * remediationStatus:'pending' on every target whenever that count is > 0 —
+ * including devices that deduped and got no job. That inaccuracy predates this
+ * feature and is out of scope to fix here, but it must not be replicated: an
+ * install row wrongly left at 'pending' blocks its own next pass (pending reads
+ * as in_progress) and would strand the device.
+ */
+export async function scheduleSoftwareInstallRemediation(
+  policyId: string,
+  targets: InstallRemediationTarget[],
+  generation: number
+): Promise<string[]> {
+  const queue = getSoftwareRemediationQueue();
+  const enqueued: string[] = [];
+  const seenDeviceIds = new Set<string>();
+
+  for (const target of targets) {
+    if (typeof target.deviceId !== 'string' || target.deviceId.length === 0) continue;
+    if (seenDeviceIds.has(target.deviceId)) continue;
+    seenDeviceIds.add(target.deviceId);
+
+    const catalogIds: string[] = [];
+    for (const raw of target.catalogIds ?? []) {
+      if (typeof raw !== 'string') continue;
+      const catalogId = raw.trim();
+      if (catalogId.length === 0) continue;
+      if (!catalogIds.includes(catalogId)) catalogIds.push(catalogId);
+    }
+    // A target with nothing to install is a caller bug, not a queueable job:
+    // W03 would try to create a deployment with neither software_version_id nor
+    // install_method_id and abort on software_deployments_one_target_chk.
+    // Refuse it here rather than shipping an empty payload into Redis.
+    if (catalogIds.length === 0) {
+      console.warn('[SoftwareRemediationWorker] Install target has no usable catalogIds, skipping', {
+        policyId,
+        deviceId: target.deviceId,
+      });
+      recordSoftwareRemediationDecision('install_no_catalog_id');
+      continue;
+    }
+
+    // Its OWN jobId namespace — see InstallRemediateDeviceJobData's docstring.
+    const jobId = `software-install-remediation-${policyId}-${target.deviceId}`;
+    const existing = await queue.getJob(jobId);
+    if (existing) {
+      const state = await existing.getState();
+      if (isReusableState(state)) {
+        recordSoftwareRemediationDecision('install_job_deduped');
+        continue;
+      }
+      await existing.remove().catch((err) => {
+        console.warn('[SoftwareRemediationWorker] Failed to remove stale install job (non-fatal):', { jobId, error: err });
+      });
+    }
+
+    await queue.add(
+      'install-remediate-device',
+      {
+        type: 'install-remediate-device' as const,
+        policyId,
+        deviceId: target.deviceId,
+        catalogIds,
+        generation,
+        attempt: target.attempt,
+      },
+      {
+        jobId,
+        removeOnComplete: { count: 100 },
+        removeOnFail: { count: 200 },
+        attempts: 3,
+        backoff: { type: 'exponential' as const, delay: 5000 },
+      }
+    );
+    enqueued.push(target.deviceId);
+  }
+
+  return enqueued;
+}
+```
+
+- [ ] **Step 5: Park the new job type in the processor until W03 lands**
+
+```ts
+// apps/api/src/jobs/softwareRemediationWorker.ts — replacing the processor body at :604-608
+    async (job: Job<SoftwareRemediationJobData>) => {
+      return runWithSystemDbAccess(async () => {
+        if (job.data.type === 'install-remediate-device') {
+          // W03 (#5508) installs the real install processor here.
+          //
+          // Until it lands this job is PARKED, never routed to
+          // processRemediateDevice: that function is uninstall-specific end to
+          // end (manual-authorization consumption, unauthorized-violation
+          // selection, remediation_status writes) and would misread install job
+          // data. Parking is the safe intermediate state, not a leak: the
+          // compliance row stays at 'pending', which
+          // shouldQueueAutoRemediation reads as in_progress, so the device is
+          // queued exactly ONCE and no reinstall loop can form. W03 replaces
+          // this branch and clears those rows on its first pass.
+          console.warn(
+            '[SoftwareRemediationWorker] install-remediate-device received but no processor is installed yet (feature #5505 W03) — parking',
+            { policyId: job.data.policyId, deviceId: job.data.deviceId, catalogIds: job.data.catalogIds }
+          );
+          recordSoftwareRemediationDecision('install_processor_unavailable');
+          return {
+            policyId: job.data.policyId,
+            deviceId: job.data.deviceId,
+            commandsQueued: 0,
+            errors: 0,
+          };
+        }
+        return processRemediateDevice(job.data);
+      });
+    },
+```
+
+- [ ] **Step 6: Run the tests and watch them pass**
+
+```bash
+cd apps/api && npx vitest run src/jobs/softwareRemediationWorker.test.ts
+```
+
+Expected: PASS — the 5 new cases plus every pre-existing case in the file. Confirm the reported file count is **1** and that the pre-existing count did not drop.
+
+- [ ] **Step 7: Typecheck and commit**
+
+```bash
+cd /Users/toddhebebrand/.herdr/worktrees/breeze/warranty-testing
+pnpm --filter @breeze/api exec tsc --noEmit
+git add apps/api/src/jobs/softwareRemediationWorker.ts apps/api/src/jobs/softwareRemediationWorker.test.ts
+git commit -m "feat(software): install-remediation job payload and producer (#5505 W02)"
+```
+
+---
+
+### Task 10: Wire the install branch into `processCheckPolicy`
+
+**Files:**
+- Modify: `apps/api/src/jobs/softwareComplianceWorker.ts:2` (import `sql`), `:67-93` (state type + parser), `:95-134` (read the new columns), `:280-285` (return type), `:361-369` (preamble), `:371-445` (the loop), `:481-524` (the scheduling block)
+- Test: `apps/api/src/jobs/softwareComplianceWorker.install.test.ts` (append a describe block)
+
+**Interfaces:**
+- Consumes: `decideInstallRemediation` / `installStatusForSkip` (Task 8), `scheduleSoftwareInstallRemediation` (Task 9), `resolveInstallRemediationMaxPerPass` / `resolveInstallRemediationMaxAttempts` (Task 6), the extended `SoftwareComplianceUpsertInput` (Task 3), W01's `evaluateSoftwarePolicyArming(policy, 'install')` and its install audit-action constants.
+- Produces: `processCheckPolicy` returns an additional `installRemediationQueued: number`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// apps/api/src/jobs/softwareComplianceWorker.install.test.ts — append at end of file
+describe('processCheckPolicy — install remediation wiring', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    armingMock.mockReturnValue({ armed: true });
+    scheduleUninstallMock.mockResolvedValue(0);
+    scheduleInstallMock.mockResolvedValue([]);
+    delete process.env.SOFTWARE_INSTALL_REMEDIATION_MAX_PER_PASS;
+    delete process.env.SOFTWARE_INSTALL_REMEDIATION_MAX_ATTEMPTS;
+  });
+
+  function primePass(devices: string[], existingRows: Record<string, unknown>[]) {
+    resolveDeviceIdsMock.mockResolvedValueOnce(devices);
+    primeSelects([
+      [FULLY_ARMED_POLICY],
+      devices.map((id) => ({ id, orgId: 'org-1' })),
+      existingRows,
+    ]);
+    // Inventory is EMPTY for every device, so the allowlist rule
+    // { name: 'Google Chrome', catalogId: 'catalog-abc' } produces exactly one
+    // `missing` violation per device.
+    inventoryMock.mockResolvedValueOnce(new Map(devices.map((id) => [id, []])));
+  }
+
+  it('queues an install for a device whose allowlist rule is missing', async () => {
+    primePass(['device-1'], []);
+    scheduleInstallMock.mockResolvedValueOnce(['device-1']);
+
+    const result = await processCheckPolicy({ type: 'check-policy', policyId: POLICY_ID });
+
+    expect(result.installRemediationQueued).toBe(1);
+    expect(scheduleInstallMock).toHaveBeenCalledWith(
+      POLICY_ID,
+      [{ deviceId: 'device-1', catalogIds: ['catalog-abc'], attempt: 1 }],
+      1,
+    );
+    // and it must stamp only the devices that actually got a job
+    expect(dbUpdateMock).toHaveBeenCalled();
+  });
+
+  it('does not queue an install when only the install verb is unarmed', async () => {
+    armingMock.mockImplementation((_policy: unknown, verb: string) => (
+      verb === 'install'
+        ? { armed: false, reason: 'auto_install_off', message: 'unarmed' }
+        : { armed: true }
+    ));
+    primePass(['device-1'], []);
+
+    const result = await processCheckPolicy({ type: 'check-policy', policyId: POLICY_ID });
+
+    expect(result.installRemediationQueued).toBe(0);
+    expect(scheduleInstallMock).not.toHaveBeenCalled();
+  });
+
+  it('caps installs per pass and records the overflow devices as skipped', async () => {
+    process.env.SOFTWARE_INSTALL_REMEDIATION_MAX_PER_PASS = '2';
+    primePass(['device-1', 'device-2', 'device-3'], []);
+    scheduleInstallMock.mockResolvedValueOnce(['device-1', 'device-2']);
+
+    await processCheckPolicy({ type: 'check-policy', policyId: POLICY_ID });
+
+    expect(scheduleInstallMock.mock.calls[0][1]).toHaveLength(2);
+    const upserted = upsertMock.mock.calls[0][0] as Array<Record<string, unknown>>;
+    const third = upserted.find((row) => row.deviceId === 'device-3');
+    expect(third?.installRemediationStatus).toBe('skipped');
+  });
+
+  it('gives up on a device whose consecutive attempts are exhausted', async () => {
+    process.env.SOFTWARE_INSTALL_REMEDIATION_MAX_ATTEMPTS = '3';
+    primePass(['device-1'], [{
+      deviceId: 'device-1',
+      status: 'violation',
+      violations: [],
+      remediationStatus: null,
+      lastRemediationAttempt: null,
+      installRemediationStatus: 'failed',
+      lastInstallRemediationAttempt: null,
+      installRemediationAttempts: 3,
+    }]);
+
+    await processCheckPolicy({ type: 'check-policy', policyId: POLICY_ID });
+
+    expect(scheduleInstallMock).not.toHaveBeenCalled();
+    const upserted = upsertMock.mock.calls[0][0] as Array<Record<string, unknown>>;
+    expect(upserted[0].installRemediationStatus).toBe('gave_up');
+  });
+
+  it('resets the consecutive counter once the device has no missing violation left', async () => {
+    resolveDeviceIdsMock.mockResolvedValueOnce(['device-1']);
+    primeSelects([
+      [FULLY_ARMED_POLICY],
+      [{ id: 'device-1', orgId: 'org-1' }],
+      [{
+        deviceId: 'device-1',
+        status: 'violation',
+        violations: [],
+        remediationStatus: null,
+        lastRemediationAttempt: null,
+        installRemediationStatus: 'pending',
+        lastInstallRemediationAttempt: null,
+        installRemediationAttempts: 2,
+      }],
+    ]);
+    // Chrome is now installed, so the allowlist rule matches and nothing is missing.
+    inventoryMock.mockResolvedValueOnce(new Map([['device-1', [
+      { name: 'Google Chrome', version: '121.0', vendor: 'Google', catalogId: 'catalog-abc' },
+    ]]]));
+
+    await processCheckPolicy({ type: 'check-policy', policyId: POLICY_ID });
+
+    const upserted = upsertMock.mock.calls[0][0] as Array<Record<string, unknown>>;
+    expect(upserted[0].installRemediationAttempts).toBe(0);
+    expect(upserted[0].installRemediationStatus).toBe('completed');
+    expect(scheduleInstallMock).not.toHaveBeenCalled();
+  });
+
+  it('says nothing about the install columns for a device with no missing violation and no install history', async () => {
+    resolveDeviceIdsMock.mockResolvedValueOnce(['device-1']);
+    primeSelects([
+      [FULLY_ARMED_POLICY],
+      [{ id: 'device-1', orgId: 'org-1' }],
+      [],
+    ]);
+    inventoryMock.mockResolvedValueOnce(new Map([['device-1', [
+      { name: 'Google Chrome', version: '121.0', vendor: 'Google', catalogId: 'catalog-abc' },
+    ]]]));
+
+    await processCheckPolicy({ type: 'check-policy', policyId: POLICY_ID });
+
+    const upserted = upsertMock.mock.calls[0][0] as Array<Record<string, unknown>>;
+    expect(upserted[0].installRemediationStatus).toBeUndefined();
+    expect(upserted[0].installRemediationAttempts).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+cd apps/api && npx vitest run src/jobs/softwareComplianceWorker.install.test.ts
+```
+
+Expected: FAIL — `installRemediationQueued` is not on the result, and `scheduleSoftwareInstallRemediation` is never called.
+
+- [ ] **Step 3: Read the new columns into the pass state**
+
+```ts
+// apps/api/src/jobs/softwareComplianceWorker.ts:2 — sql is needed for the atomic counter increment
+import { and, eq, inArray, sql } from 'drizzle-orm';
+```
+
+```ts
+// apps/api/src/jobs/softwareComplianceWorker.ts — replacing :67-93
+type ExistingComplianceState = {
+  deviceId: string;
+  status: SoftwarePolicyComplianceStatus;
+  violations: unknown;
+  remediationStatus: SoftwarePolicyRemediationStatus | null;
+  lastRemediationAttempt: Date | null;
+  // Feature #5505 W02: the install verb's parallel axis.
+  installRemediationStatus: SoftwarePolicyInstallRemediationStatus | null;
+  lastInstallRemediationAttempt: Date | null;
+  installRemediationAttempts: number;
+};
+
+function parseComplianceStatus(value: unknown): SoftwarePolicyComplianceStatus {
+  if (value === 'compliant' || value === 'violation' || value === 'unknown') {
+    return value;
+  }
+  return 'unknown';
+}
+
+function parseRemediationStatus(value: unknown): SoftwarePolicyRemediationStatus | null {
+  if (
+    value === 'none'
+    || value === 'pending'
+    || value === 'in_progress'
+    || value === 'completed'
+    || value === 'failed'
+  ) {
+    return value;
+  }
+  return null;
+}
+
+/** Superset of parseRemediationStatus: the install axis adds two terminal states. */
+function parseInstallRemediationStatus(value: unknown): SoftwarePolicyInstallRemediationStatus | null {
+  if (value === 'gave_up' || value === 'skipped') return value;
+  return parseRemediationStatus(value);
+}
+
+/** A NULL or garbage counter reads as 0 — never NaN into a `>=` comparison. */
+function parseAttemptCount(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return 0;
+  return Math.max(0, Math.floor(value));
+}
+```
+
+```ts
+// apps/api/src/jobs/softwareComplianceWorker.ts — replacing the select + mapping inside
+// readComplianceStateByDevice (:108-130)
+    const rows = await db
+      .select({
+        deviceId: softwareComplianceStatus.deviceId,
+        status: softwareComplianceStatus.status,
+        violations: softwareComplianceStatus.violations,
+        remediationStatus: softwareComplianceStatus.remediationStatus,
+        lastRemediationAttempt: softwareComplianceStatus.lastRemediationAttempt,
+        installRemediationStatus: softwareComplianceStatus.installRemediationStatus,
+        lastInstallRemediationAttempt: softwareComplianceStatus.lastInstallRemediationAttempt,
+        installRemediationAttempts: softwareComplianceStatus.installRemediationAttempts,
+      })
+      .from(softwareComplianceStatus)
+      .where(and(
+        eq(softwareComplianceStatus.policyId, policyId),
+        inArray(softwareComplianceStatus.deviceId, chunk),
+      ));
+
+    for (const row of rows) {
+      byDevice.set(row.deviceId, {
+        deviceId: row.deviceId,
+        status: parseComplianceStatus(row.status),
+        violations: row.violations,
+        remediationStatus: parseRemediationStatus(row.remediationStatus),
+        lastRemediationAttempt: row.lastRemediationAttempt,
+        installRemediationStatus: parseInstallRemediationStatus(row.installRemediationStatus),
+        lastInstallRemediationAttempt: row.lastInstallRemediationAttempt,
+        installRemediationAttempts: parseAttemptCount(row.installRemediationAttempts),
+      });
+    }
+```
+
+- [ ] **Step 4: Extend the pass preamble and the return type**
+
+```ts
+// apps/api/src/jobs/softwareComplianceWorker.ts — replacing the signature at :280-285
+export async function processCheckPolicy(data: CheckPolicyJobData): Promise<{
+  policyId: string;
+  devicesEvaluated: number;
+  violations: number;
+  remediationQueued: number;
+  installRemediationQueued: number;
+}> {
+```
+
+Every early return in that function (`:299-304`, `:315-320`, `:353-358`) gains `installRemediationQueued: 0`.
+
+```ts
+// apps/api/src/jobs/softwareComplianceWorker.ts — extending the preamble at :366-369
+  let violations = 0;
+  const remediationTargets = new Set<string>();
+  // Feature #5505 W02. Knobs are read ONCE PER PASS — per call, never module
+  // load (contract D5); the cap is per policy per pass by definition.
+  const installMaxPerPass = resolveInstallRemediationMaxPerPass();
+  const installMaxAttempts = resolveInstallRemediationMaxAttempts();
+  const installTargets: InstallRemediationTarget[] = [];
+  const complianceUpserts: Parameters<typeof upsertSoftwareComplianceStatuses>[0] = [];
+  const now = new Date();
+```
+
+New imports:
+
+```ts
+// apps/api/src/jobs/softwareComplianceWorker.ts:22 — replacing the single-name import
+import {
+  scheduleSoftwareRemediation,
+  scheduleSoftwareInstallRemediation,
+  type InstallRemediationTarget,
+} from './softwareRemediationWorker';
+import {
+  resolveInstallRemediationMaxAttempts,
+  resolveInstallRemediationMaxPerPass,
+} from '../services/softwareInstallRemediationKnobs';
+```
+
+and add `SOFTWARE_POLICY_INSTALL_AUDIT_ACTIONS` to the `softwarePolicyService` import block (confirm W01's exact identifier first — Task 7 Step 0).
+
+- [ ] **Step 5: Add the install decision to the per-device loop**
+
+Insert this between the uninstall `remediationStatus` derivation (which ends at `:394`) and the `complianceUpserts.push` (`:396`). The decision must run **before** the push so its status can ride the same upsert.
+
+```ts
+// apps/api/src/jobs/softwareComplianceWorker.ts — after the remediationStatus derivation,
+// before complianceUpserts.push
+      // ---- Feature #5505 W02: the install verb -------------------------------
+      // Keyed on "does this device have a `missing` violation", NOT on the
+      // overall compliance status: a device can be in `violation` purely
+      // because of unauthorized software while having nothing missing, and the
+      // two verbs must not read each other's condition.
+      const hasMissingViolation = violationsWithStableTimestamps.some((v) => v.type === 'missing');
+
+      let installRemediationStatus: SoftwarePolicyInstallRemediationStatus | undefined;
+      let installRemediationAttempts: number | undefined;
+      if (!hasMissingViolation) {
+        // Desired state reached. Mirrors the uninstall transition above: a
+        // working status settles to 'completed', and the CONSECUTIVE counter
+        // resets so a future recurrence starts with a full attempt budget.
+        // 'gave_up' also settles to 'completed' — the software is present now,
+        // however it got there, and leaving a permanent tombstone on a healthy
+        // device would be a lie.
+        if (
+          existing?.installRemediationStatus
+          && existing.installRemediationStatus !== 'none'
+          && existing.installRemediationStatus !== 'completed'
+        ) {
+          installRemediationStatus = 'completed';
+        }
+        if ((existing?.installRemediationAttempts ?? 0) > 0) {
+          installRemediationAttempts = 0;
+        }
+      } else if (existing?.installRemediationStatus === 'completed') {
+        // It came back. Clear the stale success so the next decision is not read
+        // against a status describing a previous cycle.
+        installRemediationStatus = 'none';
+      }
+
+      if (hasMissingViolation && installArming.armed) {
+        const installDecision = decideInstallRemediation({
+          violations: violationsWithStableTimestamps,
+          previousInstallStatus: existing?.installRemediationStatus ?? null,
+          lastInstallAttempt: existing?.lastInstallRemediationAttempt ?? null,
+          attempts: existing?.installRemediationAttempts ?? 0,
+          now,
+          gracePeriodHours: remediationOptions.gracePeriodHours,
+          cooldownMinutes: remediationOptions.cooldownMinutes,
+          maxAttempts: installMaxAttempts,
+          // Cap is measured against what THIS pass has already committed to.
+          capRemaining: installMaxPerPass - installTargets.length,
+        });
+
+        if (installDecision.queue) {
+          installTargets.push({
+            deviceId,
+            catalogIds: installDecision.catalogIds,
+            attempt: installDecision.attempt,
+          });
+          recordSoftwareRemediationDecision('install_queued');
+        } else {
+          recordSoftwareRemediationDecision(`install_${installDecision.reason}`);
+          const skipStatus = installStatusForSkip(installDecision.reason);
+          if (skipStatus) {
+            installRemediationStatus = skipStatus;
+          }
+          // Audit the give-up ONCE, on the transition. Firing it every pass
+          // would put one row per device per 15 minutes into
+          // software_policy_audit for as long as the policy stays armed.
+          if (skipStatus === 'gave_up' && existing?.installRemediationStatus !== 'gave_up') {
+            fireAudit({
+              orgId: policy.orgId ?? orgByDevice.get(deviceId) ?? null,
+              partnerId: policy.partnerId,
+              policyId: policy.id,
+              deviceId,
+              action: SOFTWARE_POLICY_INSTALL_AUDIT_ACTIONS.gaveUp,
+              actor: 'system',
+              details: {
+                policyName: policy.name,
+                attempts: existing?.installRemediationAttempts ?? 0,
+                maxAttempts: installMaxAttempts,
+              },
+            });
+          }
+        }
+      }
+      // ---- end install verb -------------------------------------------------
+
+      complianceUpserts.push({
+        deviceId,
+        policyId: policy.id,
+        status,
+        violations: violationsWithStableTimestamps,
+        checkedAt: now,
+        remediationStatus,
+        installRemediationStatus,
+        installRemediationAttempts,
+      });
+```
+
+- [ ] **Step 6: Add the install scheduling block after the upsert flush**
+
+Insert immediately after the existing uninstall scheduling block closes (`:516`), before the function's `return` at `:518`.
+
+```ts
+// apps/api/src/jobs/softwareComplianceWorker.ts — after the uninstall scheduling block
+  let installRemediationQueued = 0;
+  if (installTargets.length > 0) {
+    // Placed AFTER the upsertSoftwareComplianceStatuses flush above, so every
+    // row this block is about to UPDATE is guaranteed to exist.
+    const enqueuedDeviceIds = await scheduleSoftwareInstallRemediation(
+      policy.id,
+      installTargets,
+      policy.approvalGeneration,
+    );
+    installRemediationQueued = enqueuedDeviceIds.length;
+
+    if (enqueuedDeviceIds.length > 0) {
+      const attemptedAt = new Date();
+      for (const chunk of chunkArray(enqueuedDeviceIds)) {
+        await db
+          .update(softwareComplianceStatus)
+          .set({
+            installRemediationStatus: 'pending',
+            lastInstallRemediationAttempt: attemptedAt,
+            // Incremented in SQL, not from the value read at the top of the
+            // pass: this is the authoritative counter, and doing the arithmetic
+            // in the statement keeps it correct even if a concurrent pass or the
+            // W03 processor touched the row in between.
+            installRemediationAttempts: sql`${softwareComplianceStatus.installRemediationAttempts} + 1`,
+          })
+          .where(and(
+            eq(softwareComplianceStatus.policyId, policy.id),
+            inArray(softwareComplianceStatus.deviceId, chunk),
+          ));
+      }
+    }
+
+    fireAudit({
+      orgId: policy.orgId,
+      partnerId: policy.partnerId,
+      policyId: policy.id,
+      action: SOFTWARE_POLICY_INSTALL_AUDIT_ACTIONS.queued,
+      actor: 'system',
+      details: {
+        targetCount: installTargets.length,
+        queuedCount: installRemediationQueued,
+        deferredCount: Math.max(0, installTargets.length - installRemediationQueued),
+        maxPerPass: installMaxPerPass,
+        maxAttempts: installMaxAttempts,
+      },
+    });
+
+    recordSoftwareRemediationDecision('install_scheduled', installRemediationQueued);
+  }
+
+  return {
+    policyId: policy.id,
+    devicesEvaluated: deviceIds.length,
+    violations,
+    remediationQueued,
+    installRemediationQueued,
+  };
+```
+
+- [ ] **Step 7: Run the tests and watch them pass**
+
+```bash
+cd apps/api && npx vitest run src/jobs/softwareComplianceWorker.install.test.ts src/jobs/softwareComplianceWorker.test.ts
+```
+
+Expected: PASS, 2 files, every case green.
+
+- [ ] **Step 8: Typecheck and commit**
+
+```bash
+cd /Users/toddhebebrand/.herdr/worktrees/breeze/warranty-testing
+pnpm --filter @breeze/api exec tsc --noEmit
+git add apps/api/src/jobs/softwareComplianceWorker.ts apps/api/src/jobs/softwareComplianceWorker.install.test.ts
+git commit -m "feat(software): compliance worker queues install remediation for missing violations (#5505 W02)"
+```
+
+---
+
+### Task 11: Wave verification
+
+**Files:** none modified.
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: the evidence this wave is safe to open as a PR.
+
+- [ ] **Step 1: Sweep for leftover references to the removed names**
+
+```bash
+cd /Users/toddhebebrand/.herdr/worktrees/breeze/warranty-testing
+grep -rn "readEarliestUnauthorizedDetection\|autoUninstallEnabled" apps packages ee 2>/dev/null | grep -v node_modules
+```
+
+Expected: **no output.** Both were deleted in Tasks 4 and 7; a survivor means a call site still carries the duplicated arming logic D11 exists to remove.
+
+- [ ] **Step 2: Confirm no out-of-scope file was touched**
+
+```bash
+git diff --name-only main...HEAD
+```
+
+Expected: exactly the files listed in this plan's File structure section. **Any of these appearing is a scope violation, stop and revert it:** `apps/api/src/services/softwareDeployment.ts`, `apps/api/src/db/schema/software.ts`, `apps/api/src/services/tenantCascade.ts`, `apps/api/src/services/tenantExportPolicyRegistry.ts`, anything under `apps/web/`, and any `ai*` file.
+
+- [ ] **Step 3: Run the full affected test set explicitly**
+
+```bash
+cd apps/api && npx vitest run \
+  src/jobs/softwareComplianceWorker.test.ts \
+  src/jobs/softwareComplianceWorker.install.test.ts \
+  src/jobs/softwareRemediationWorker.test.ts \
+  src/services/softwarePolicyService.test.ts \
+  src/services/softwarePolicyService.complianceUpsert.test.ts \
+  src/services/softwarePolicyService.violationFingerprint.test.ts \
+  src/services/softwareInstallRemediationKnobs.test.ts \
+  src/db/migrationRlsScope.test.ts \
+  src/db/autoMigrate.test.ts
+```
+
+Expected: PASS, **9 files reported.** Every path is listed explicitly rather than by prefix, because vitest's filter is a plain substring match and a trailing-slash or bare-prefix filter silently skips dotted sibling files.
+
+- [ ] **Step 4: Run the broader compliance/policy surface**
+
+```bash
+cd apps/api && npx vitest run src/routes/softwarePolicies.test.ts src/services/userRiskScoring.test.ts
+```
+
+Expected: PASS. These read `software_compliance_status` with explicit column projections and must be unaffected by the three new columns; if either fails, a projection somewhere is broader than the ground-truth pass found.
+
+- [ ] **Step 5: Typecheck and lint the whole API package**
+
+```bash
+cd /Users/toddhebebrand/.herdr/worktrees/breeze/warranty-testing
+pnpm --filter @breeze/api exec tsc --noEmit
+pnpm lint
+```
+
+Expected: PASS both.
+
+- [ ] **Step 6: Prove the migration applies to a database that already has it**
+
+```bash
+export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze"
+pnpm db:migrate && pnpm db:check-drift
+```
+
+Expected: zero newly-applied migrations on the second run, and drift check green.
+
+- [ ] **Step 7: Record what this wave deliberately did NOT do, in the PR body**
+
+The PR description must state all of these so a reviewer does not read them as omissions:
+
+- **No deployment is created and nothing is dispatched.** Install jobs are enqueued and parked by `createSoftwareRemediationWorker` until W03 (#5508) lands. A parked job leaves the compliance row at `'pending'`, which `shouldQueueAutoRemediation` reads as `in_progress`, so each device is queued exactly once and no loop can form.
+- **No platform-mismatch filter.** Spec §4 wants a cross-platform policy filtered before it generates guaranteed-failing deployments. That needs catalog→install-method resolution against `device.osType`, which is W03's resolution step; duplicating it in the compliance worker would create two places to keep in sync. W03 writes `install_remediation_status = 'skipped'` for that case, which is why `'skipped'` is in the union already.
+- **No registration changes**, and none are needed: `software_compliance_status` has no `org_id`, is absent from `tenantCascade.ts` and `tenantExportPolicyRegistry.ts` (zero hits in both), and is already in `CORE_DEVICE_CASCADE_DELETE_TABLES` at `routes/devices/core.ts:511`.
+- **The uninstall path is untouched**, including its pre-existing inaccuracy at `softwareComplianceWorker.ts:486` where all targets are stamped `'pending'` whenever the queued count is `> 0`. The install path deliberately does not replicate it (Task 9).
+- **`install_remediation_status` is not yet exposed by the API.** `routes/softwarePolicies.ts:482-487` projects `remediationStatus` only, and no wave in the contract's ownership map owns widening it — W04 is "web UI only, must not touch any `apps/api` file". Flag this to the coordinator.
+
+---
+
+## Self-review
+
+**1. Spec coverage.** Every requirement this wave owns maps to a task:
+
+| Requirement | Task |
+|---|---|
+| Contract D1 — three columns, migration, upsert plumbing, non-clobber preserved | 1, 2, 3 |
+| Contract D5 — per-call knobs file | 6 |
+| Contract D10 — verb-aware grace clock | 4 |
+| Contract D11 — worker delegates arming, divergence test | 7 |
+| Contract D9 — the required check on stable-timestamp matching | 5 |
+| Spec §2 — missing-violation branch, two independent gates, both verbs in one pass | 7, 8, 10 |
+| Spec Risks §1 — consecutive-attempt give-up counter | 6, 8, 10 |
+| Spec Risks §2 — per-pass cap | 6, 8, 10 |
+| Spec §4 — rule without `catalogId` is skipped and says so | 8, 10 |
+| Spec §6 — install-specific audit actions, never the uninstall ones | 10 |
+| Spec Testing 1-2 — verb-aware arming, branch selection, `catalogId` skip, `shouldQueueAutoRemediation` on install | 7, 8, 10 |
+| Spec Testing 6 — arming install does not arm uninstall and vice versa | 10 |
+| Install job payload W03 consumes, stated verbatim | 9 |
+
+Deliberate non-coverage, each argued in Task 11 Step 7: platform filter (W03), deployment creation (W03), integration suites for `tenantCascade` / `tenant-export-policy` (W03 — this wave adds no `org_id` column and no FK, so neither contract is engaged), `'outdated'` violations (spec Non-goals).
+
+**2. Placeholder scan.** No "TBD", no "add error handling", no "similar to Task N". Every code step carries complete, runnable code. The one forward reference — W01's audit-action constant identifier — is handled with an explicit `grep` verification step (Task 7, before Step 1) plus a stated fallback rule, because contract D6 locks the four string values but leaves the export name to W01.
+
+**3. Type consistency.** Checked end to end: `SoftwarePolicyInstallRemediationStatus` (Task 3) is the return type of `installStatusForSkip` (Task 8) and the type of `ExistingComplianceState.installRemediationStatus` (Task 10) and of `SoftwareComplianceUpsertInput.installRemediationStatus` (Task 3). `AutoRemediationDeferralReason` (Task 4) is a member of `InstallRemediationSkipReason` (Task 8), which is why `decideInstallRemediation` returns `timing.reason` with no cast. `InstallRemediationTarget` (Task 9) is exactly what `installTargets.push` builds (Task 10) and what `scheduleSoftwareInstallRemediation` accepts (Task 9). `readEarliestViolationDetection` is the single name used in Task 4's implementation, its tests, and `shouldQueueAutoRemediation`'s body — the old `readEarliestUnauthorizedDetection` appears nowhere after Task 4 and is grepped for in Task 11.

--- a/docs/superpowers/plans/vuln-patch/2026-09-10-desired-state-software-install-w03-policy-owned-deployments.md
+++ b/docs/superpowers/plans/vuln-patch/2026-09-10-desired-state-software-install-w03-policy-owned-deployments.md
@@ -1,0 +1,2260 @@
+---
+tracking_issue: LanternOps/breeze#5505
+---
+
+# Wave 03 — Policy-owned deployments: origin column, target resolution, dispatch, dedup — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give `software_deployments` a nullable `software_policy_id` origin FK stamped at INSERT, and teach the software remediation worker to turn an enqueued install-remediation job into a real, policy-owned, platform-correct, tenancy-checked, deduped `software_deployments` row that dispatches through the existing install seam — closing the `missing`-violation loop that W01 and W02 open.
+
+**Architecture:** Contract D7's `software_policy_id uuid NULL REFERENCES software_policies(id) ON DELETE SET NULL` is added by migration `2026-10-15-150401`, mirrored on the Drizzle table, and threaded through `CreateSoftwareDeploymentInput` so the origin is written by the same INSERT that creates the row (never patched afterwards). A new service module `services/softwarePolicyInstallRemediation.ts` owns the three decisions that must happen **before** a deployment exists — is the rule's `catalogId` reachable from the DEVICE's tenant, does the catalog item have an install target for the DEVICE's OS, and is there already unfinished policy-owned work for this (policy, device) — and then calls `createSoftwareDeployment` for the survivors. A new `processRemediateDeviceInstall` in `jobs/softwareRemediationWorker.ts` orchestrates that per job, re-checking arming for the `install` verb the same way the uninstall path re-checks it for `uninstall`. The uninstall path is not touched at all.
+
+**Tech Stack:** Hono + Drizzle ORM + PostgreSQL (RLS, FORCE), BullMQ, Vitest (unit + `vitest.integration.config.ts`).
+
+**Spec:** `docs/superpowers/specs/vuln-patch/2026-09-10-desired-state-software-install-design.md` §3 (install dispatch + the `deploymentId` coupling), §4 (resolving what to install), and the "Corrections after ground-truth verification" section, which supersedes the body. Cross-wave contract: `contract-A-desired-state.md` (coordinator scratchpad), decisions **D6, D7, D8**.
+
+**Depends on:** **W01 (#5506)** — verb-aware `evaluateSoftwarePolicyArming(policy, verb)`, the D6 audit-action constants, and `catalogId` on `SoftwarePolicyViolation['rule']`. **W02 (#5507)** — the install-remediation job payload type, the `install_remediation_*` columns on `software_compliance_status`, and `services/softwareInstallRemediationKnobs.ts`. W03 **consumes** all of those and redefines none of them.
+
+---
+
+## Global Constraints
+
+Copied verbatim from the cross-wave contract. W03 may not rename or re-shape anything here.
+
+- **Migration slot (D8):** `apps/api/migrations/2026-10-15-150401-software-deployments-policy-origin.sql`. W02 owns `…-150400-…`; W03 sorts immediately after it. **Re-run `ls apps/api/migrations/*.sql | sort | tail -1` at implementation time and rename upward if anything now sorts after this slot** — migration filenames run ahead of real time and today's date does NOT sort last. `2026-08-06` is a closed date block; never use it.
+- **Column (D7), exact DDL:**
+  ```sql
+  software_policy_id uuid NULL REFERENCES software_policies(id) ON DELETE SET NULL
+  ```
+  on `software_deployments`, plus `softwarePolicyId?: string` on `CreateSoftwareDeploymentInput` (`apps/api/src/services/softwareDeployment.ts:32-71`) so the row is stamped at insert rather than patched afterwards.
+- **`ON DELETE SET NULL` is load-bearing**, not style: it is what makes deleting a policy — including the cascade's own `DELETE FROM software_policies` — incapable of aborting an org or partner erasure on a 23503.
+- **This is NOT a composite `(x, org_id)` FK**, so CLAUDE.md's `DEFERRABLE INITIALLY IMMEDIATE` rule (org merge runs `SET CONSTRAINTS ALL DEFERRED` and re-points parent/child `org_id` in separate statements) **does not apply**. Do not add `DEFERRABLE` to it.
+- **Registration obligations, all in the same PR:**
+  - add `software_policy_id` to the `included` bucket of the `software_deployments` entry at `apps/api/src/services/tenantExportPolicyRegistry.ts:434`. This is the one registration rule that fires on a new **column**, not just a new table.
+  - re-run `tenantCascade.integration.test.ts` — ordering here comes from the pre-clear steps at `tenantCascade.ts:840-852` (org) and `:1484-1502` (partner), **not** array position, so reason about those.
+  - `rls-coverage.integration.test.ts` needs **no** change: `software_deployments` is shape 1 (direct `org_id`) and auto-discovered; a new column does not change its shape.
+  - `CORE_DEVICE_CASCADE_DELETE_TABLES` / `CORE_DEVICE_ORG_DENORMALIZED_TABLES` need **no** change: `software_deployments` has no `device_id` column and is already reached by the org cascade.
+- **Non-negotiable testing gates:**
+  - `tenantCascade.integration.test.ts` and `tenant-export-policy.integration.test.ts` run **ONLY** in the **Integration Tests** CI job. A locally-green unit branch proves nothing about them. W03 MUST run both explicitly, with the integration config, before opening its PR (Task 8).
+  - This migration performs **no DML** (no `UPDATE`/`DELETE`/`INSERT`/`MERGE`), so no `SELECT set_config('breeze.scope','system',true);` elevation is required. Run `apps/api/src/db/migrationRlsScope.test.ts` anyway to prove the guard agrees.
+  - Red-first on every behavioural change: write the assertion, watch it fail against unmodified code, then implement.
+  - Scoped test runs: `cd apps/api && npx vitest run <path>`. **Never** `pnpm --filter <pkg> test -- --run <path>` — pnpm forwards the literal `--` into argv, vitest stops flag parsing there, `--run` is swallowed, and the whole 1,470-file suite runs in watch mode. Vitest's path filter is a plain **substring** match, not a glob and not a directory prefix.
+- **Out of scope for W03, do not touch:** the arming helper itself (`evaluateSoftwarePolicyArming`'s body, `readSoftwarePolicyAutoInstall`, the refusal messages) — W01; the compliance worker's gate logic, the per-pass cap, the attempt counter, the knobs file, `readEarliestUnauthorizedDetection` — W02; any file under `apps/web` — W04; `aiGuardrails.ts`, `aiTools*.ts`, `aiToolSchemas.ts`, `aiAgentSdkTools.ts` — W05. The uninstall path in `softwareRemediationWorker.ts` (`readInFlightUninstallKeys` `:168-195`, `processRemediateDevice` `:199-599`) stays byte-identical apart from the one job-type switch in Task 7.
+- **HP / EDR stay out of it:** the secret-resolution branch at `softwareDeployment.ts:554-584` fires only when `catalogItem.integrationProvider === 'huntress' | 'sentinelone'`. W03 adds no special handling for it and no new branch that reads it.
+
+### W01/W02-owned identifiers this wave imports
+
+The contract lets W01 and W02 fix these exact export names. **Their semantics and field sets are contract-locked; the identifiers are not.** Task 4 Step 1 and Task 6 Step 1 open the landed files and record the real names; if one differs from the expected name below, change only the import.
+
+| Expected name | Owner | Where it lands | What W03 does with it |
+|---|---|---|---|
+| `evaluateSoftwarePolicyArming(policy, verb)` | W01 | `apps/api/src/services/softwarePolicyService.ts:177` | called with the literal `'install'` |
+| `SOFTWARE_POLICY_INSTALL_AUDIT_ACTIONS` — `{ queued: 'install_queued', succeeded: 'install_succeeded', failed: 'install_failed', gaveUp: 'install_gave_up' } as const`, plus the union type `SoftwarePolicyInstallAuditAction` (name and member keys confirmed against W01's landed plan, Task 3) | W01 | `apps/api/src/services/softwarePolicyService.ts` | imported; W03 emits `.queued` and `.failed`. **Never a string literal at an emit site.** |
+| `SoftwarePolicyViolation['rule'].catalogId` | W01 | `apps/api/src/db/schema/softwarePolicies.ts:55-60` | read off each `missing` violation |
+| `RemediateDeviceInstallJobData`, discriminant `type: 'remediate-device-install'`, fields `{ policyId: string; deviceId: string }` | W02 | `apps/api/src/jobs/softwareRemediationWorker.ts` | the job payload `processRemediateDeviceInstall` accepts |
+| `softwareComplianceStatus.installRemediationStatus` (`varchar(20)`), `.lastInstallRemediationAttempt` (`timestamp`) | W02 | `apps/api/src/db/schema/softwarePolicies.ts` | W03 writes `'in_progress'`, `'pending'`, `'skipped'`, `'failed'` |
+
+W03 does **not** write `installRemediationAttempts` — that counter and the `'gave_up'` transition are W02's, and double-incrementing it would halve the effective attempt budget.
+
+---
+
+## 0. Ground truth
+
+Every citation below was re-opened in this worktree (`/Users/toddhebebrand/.herdr/worktrees/breeze/warranty-testing`) on 2026-09-10 and quoted from the file, not copied from the spec or the contract. **All contract line numbers for W03's files were confirmed correct.** Divergences from the spec BODY (already recorded in its corrections section) are marked.
+
+**Migration slot.** `ls apps/api/migrations/*.sql | sort | tail -1` → `apps/api/migrations/2026-10-15-150300-remote-session-revocation-lease.sql` (730 migration files total). Nothing sorts after it, so `…-150400-…` (W02) and `…-150401-…` (W03) are free and correctly ordered. **Re-confirm before writing the file.**
+
+**`software_deployments` — `apps/api/src/db/schema/software.ts:82-116`** (contract said `:82-116` — correct). Org-only, no `partner_id`. Verbatim, the parts this wave touches:
+```ts
+82:export const softwareDeployments = pgTable('software_deployments', {
+83:  id: uuid('id').primaryKey().defaultRandom(),
+84:  orgId: uuid('org_id').notNull().references(() => organizations.id),
+...
+109:  dispatchedAt: timestamp('dispatched_at', { withTimezone: true }),
+110:  createdAt: timestamp('created_at').defaultNow().notNull()
+111:}, (table) => ({
+112:  orgIdx: index('software_deployments_org_id_idx').on(table.orgId),
+113:  versionIdx: index('software_deployments_version_id_idx').on(table.softwareVersionId),
+114:  installMethodIdx: index('software_deployments_install_method_idx').on(table.installMethodId),
+115:  scheduleIdx: index('software_deployments_schedule_idx').on(table.scheduleType, table.scheduledAt)
+116:}));
+```
+`software.ts:1-21` imports from `./orgs`, `./devices`, `./users`, `./maintenance`, `./deployments` — **not** from `./softwarePolicies`. `softwarePolicies.ts:15-17` imports `./orgs`, `./users`, `./devices` — **not** `./software`. So adding `import { softwarePolicies } from './softwarePolicies'` to `software.ts` creates a one-way edge and **no import cycle**. Verified both directions.
+
+**The CHECK + idempotency template — `apps/api/migrations/2026-08-16-b-software-deployments-install-method.sql`** (read in full). This is the exact precedent to copy: a header comment that names the export-policy obligation in the same PR, `ADD COLUMN IF NOT EXISTS`, a `DO $$ … EXCEPTION WHEN duplicate_object THEN NULL; END $$;` guard around the constraint, `CREATE INDEX IF NOT EXISTS`. It contains **no DML and no `set_config`** — the same shape W03's migration takes.
+
+**`CreateSoftwareDeploymentInput` — `apps/api/src/services/softwareDeployment.ts:32-71`** (contract `:32-71` — correct). `createdBy: string | null` at `:46` is a **required, non-optional** property. The last member is `targetIds?: string[] | null;` at `:70`, closing brace `:71`.
+
+**`createSoftwareDeployment` — `softwareDeployment.ts:974-1133`** (contract said `:974-…` — correct). The XOR guard is verbatim at `:995-1002`:
+```ts
+995:  // Mirrors the DB CHECK (software_deployments_one_target_chk): a deployment
+996:  // targets an uploaded/URL version OR a package-manager method, never both
+997:  // and never neither.
+998:  if ((softwareVersionId == null) === (installMethodId == null)) {
+999:    throw new Error(
+1000:      'createSoftwareDeployment requires exactly one of softwareVersionId / installMethodId',
+1001:    );
+1002:  }
+```
+The destructure is `:977-993`; the INSERT `.values({…})` is `:1065-1079` (last member `dependencyFingerprint,` at `:1078`); per-device `deployment_results` rows are inserted at `:1087-1095`; the immediate-dispatch branch is `:1103-1124` and fires only when `scheduleType === 'immediate' && deploymentType === 'install' && deviceIds.length > 0`. A non-immediate call returns `{ deploymentId, deployment, status: 'pending', dispatchedDeviceIds: [], deviceResults: [] }` at `:1126-1132`.
+
+**Platform mismatch is downstream and install-method-only — `softwareDeployment.ts:413-429`** (contract `:413-429` — correct), inside `dispatchManagerInstalls` (`:374`, correct), using `NO_INSTALL_METHOD_FOR_OS` (`:297`, correct):
+```ts
+413:  let osMismatchCount = 0;
+414:  for (const device of targetDevices) {
+415:    if (device.osType !== installMethod.platform) {
+416:      await db
+417:        .update(deploymentResults)
+418:        .set({
+419:          status: 'failed',
+420:          errorMessage: `${NO_INSTALL_METHOD_FOR_OS} (${device.osType})`,
+```
+**Note the asymmetry, and it matters for Task 4:** this check exists only on the install-**method** path. The `software_versions` path has **no** OS check anywhere at dispatch time (`supportedOs` is written by `routes/software.ts:1109,1237-1242` and read by nothing outside routes — verified by `grep -rn supportedOs src/`). So the version branch needs its own filter or nothing filters it at all.
+
+**EDR branch — `softwareDeployment.ts:554-584`**, reached only via `catalogItem.integrationProvider`. Untouched by this wave.
+
+**`dispatchSoftwareInstallToDevice` — `softwareDeployment.ts:126-165`** (contract `:126-165` — correct). It only UPDATEs a `deployment_results` row that must already exist (`:151-159`); the synthetic `sw-install-<deployment>-<device>-<attempt>` id is gone (see the comment at `:110-117`) and the row id travels as `res.command.id`. This is why W03 creates a real deployment instead of inventing a new dispatch seam.
+
+**`software_install_methods` — `software.ts:261-272`.** No `org_id`; parent-FK-join tenancy via `software_catalog`. `platform varchar(10)` is `'windows' | 'macos'` (`:264`), `kind` is `'winget' | 'homebrew_cask' | 'homebrew_formula'` (`:265`), `enabled boolean NOT NULL DEFAULT true` (`:267`), unique on `(catalog_id, platform, kind)` (`:270`). **There is no `linux` install method**, by construction.
+
+**`software_versions` — `software.ts:49-80`.** `supportedOs: jsonb('supported_os')` at `:61`; `isLatest boolean NOT NULL DEFAULT false` at `:72` with a unique partial index `software_versions_one_latest_per_catalog_idx` on `(catalog_id) WHERE is_latest = true` at `:77-79` — so "the latest version for a catalog item" is at most one row. `platformSchema = z.enum(['windows','macos','linux'])` (`routes/software.ts:465`) and `supportedOs: z.array(platformSchema)` (`:523`), so its values line up exactly with `devices.osType`.
+
+**`software_catalog` — `software.ts:23-47`.** Dual-axis XOR ownership: `orgId` (`:29`) / `partnerId` (`:30`), CHECK `software_catalog_one_owner_chk`, `integrationProvider varchar(20)` (`:31`). The route-layer reachability precedent is `routes/software.ts:867-870`:
+```ts
+867:    const scopeBranches: SQL[] = [eq(softwareCatalog.orgId, orgId), isNotNull(softwareCatalog.integrationProvider)];
+868:    if (auth.scope === 'partner' && auth.partnerId) {
+869:      scopeBranches.push(and(isNull(softwareCatalog.orgId), eq(softwareCatalog.partnerId, auth.partnerId))!);
+870:    }
+```
+
+**`deployment_results` — `software.ts:118-136`.** `deploymentId` (`:120`) and `deviceId` (`:121`) are both NOT NULL FKs; `status: deploymentStatusEnum('status').notNull().default('pending')` at `:122`. **`deployment_results` has no `org_id` and no `created_at`.** `deploymentStatusEnum` — `apps/api/src/db/schema/deployments.ts:15-26` — is `['draft','pending','running','paused','downloading','installing','completed','failed','cancelled','rollback']`.
+
+**`devices.osType` — `apps/api/src/db/schema/devices.ts:6,62`:** `osTypeEnum = pgEnum('os_type', ['windows','macos','linux'])`, `osType: osTypeEnum('os_type').notNull()`.
+
+**`software_policies` — `apps/api/src/db/schema/softwarePolicies.ts:83-112`.** `orgId` (`:85`) / `partnerId` (`:86`) XOR (CHECK `software_policies_one_owner_chk`), `name varchar(200) NOT NULL` (`:87`), `mode` (`:89`), `rules jsonb NOT NULL` (`:90`), `enforceMode boolean NOT NULL DEFAULT false` (`:95`), `remediationOptions jsonb` (`:96`).
+
+**`SoftwarePolicyRuleDefinition` — `softwarePolicies.ts:25-32`** (contract `:25-32` — correct), `catalogId?: string` at **`:30`**. The spec BODY cites `:28`; the corrections section already fixes this to `:30`. Confirmed `:30`.
+
+**`SoftwarePolicyViolation` — `softwarePolicies.ts:48-63`** (contract `:48-63` — correct). Its `rule` sub-object at `:55-60` is `{ name; minVersion?; maxVersion?; reason? }` — **no `catalogId`**, exactly as the contract's D9 says. W01 adds it.
+
+**The `missing` emission — `softwarePolicyService.ts:333-347`** (contract `:333-347` — correct), verbatim, showing the D9 gap:
+```ts
+333:    for (const rule of softwareRules) {
+334:      const found = inventory.some((installed) => matchesSoftwareRule(installed, rule));
+335:      if (!found) {
+336:        violations.push({
+337:          type: 'missing',
+338:          rule: {
+339:            name: rule.name,
+340:            minVersion: rule.minVersion,
+341:            maxVersion: rule.maxVersion,
+342:          },
+343:          severity: 'high',
+344:          detectedAt,
+345:        });
+346:      }
+347:    }
+```
+
+**Arming helper — `softwarePolicyService.ts:159-206`** (contract `:159`, `:161-163`, `:165-169`, `:172-175`, `:177-206` — all correct). Today `evaluateSoftwarePolicyArming(policy: SoftwarePolicyArmingInput)` takes **one** argument; W01 adds the required second `verb`. Its three refusal messages at `:184`, `:191-193`, `:200-202` all say "uninstall" verbatim. `SoftwarePolicyRemediationStatus` at `:28` is `'none' | 'pending' | 'in_progress' | 'completed' | 'failed'`. `recordSoftwarePolicyAudit` at `:533-560` takes `{ orgId, partnerId?, policyId?, deviceId?, action: string, actor: 'user'|'system'|'ai', actorId?, details? }` and throws at `:548-550` unless at least one owner axis is set.
+
+**Remediation worker — `apps/api/src/jobs/softwareRemediationWorker.ts` (792 lines, read in full).** All contract citations confirmed:
+- imports `:1-11`; `const { db } = dbModule;` `:13`; `runWithSystemDbAccess` `:14-22`; `fireAudit` `:24-28`.
+- `IN_FLIGHT_LOOKBACK_MINUTES = 24 * 60` at `:36`.
+- `RemediateDeviceJobData` `:56-72` — **not exported**; `SoftwareRemediationJobData = RemediateDeviceJobData` (a one-member alias, not a union) at `:74`.
+- uninstall dedup `readInFlightUninstallKeys` `:168-195`, pinned to `eq(deviceCommands.type, CommandTypes.SOFTWARE_UNINSTALL)` at `:178` and `(payload ->> 'policyId') = policyId` at `:181`. **Confirmed: this cannot cover installs and must not be extended.**
+- `processRemediateDevice` `:199-599`. Policy SELECT `:205-218`; device SELECT with `.for('update')` `:243-248` (the #3553 retenanting lock) selecting only `{ orgId, isEphemeral }`; ephemeral early-return `:255-262`; `auditOrgId = policy.orgId ?? deviceRow?.orgId ?? null` at **`:264`** — the dual-owner audit rule; compliance SELECT `:266-273`; arming call `evaluateSoftwarePolicyArming(policy)` at **`:318`**; unarmed refusal + compliance write `:343-390`; cooldown `:414-448`; `in_progress` write `:450-457`; queue site `:522-532`; terminal status `:545-558`.
+- worker processor `:601-620`, whose body is `return runWithSystemDbAccess(async () => { return processRemediateDevice(job.data); });` at `:605-607` — **this is the single line Task 7 changes.**
+- `scheduleSoftwareRemediation` `:712-792`.
+
+**Export policy — `apps/api/src/services/tenantExportPolicyRegistry.ts:434`** (contract `:434` — correct). Verbatim, with its two-line preceding comment at `:431-433`:
+```ts
+434:  "software_deployments": tablePolicy("org_id", {"included":["id","org_id","name","software_version_id","install_method_id","deployment_type","target_type","schedule_type","scheduled_at","dispatched_at","maintenance_window_id","created_by","created_at"],"reviewedIncluded":["dependency_fingerprint"],"excludedSensitive":[],"excludedOpen":["target_ids","options"]}),
+```
+`tablePolicy` is defined at `:17-39` and **throws** on a duplicate classification (`:23-27`), so a column may appear in exactly one bucket. `maintenance_window_id` and `created_by` are the in-file precedent for classifying an FK to another tenant-owned table as `included`.
+
+**Cascade — `apps/api/src/services/tenantCascade.ts`.** Array positions confirmed: `'software_deployments'` at **`:597`**, `'software_policies'` at **`:600`** (contract correct; the spec body's `:436`/`:439` are stale and its corrections section already says so). `CORE_ORG_CASCADE_DELETE_ORDER` is declared at `:228`. The real ordering for `deployment_results` → `software_deployments` comes from explicit pre-clear entries — org at **`:840-852`**:
+```ts
+840:  {
+841:    table: 'deployment_results',
+842:    clearSql: (orgId) => sql`
+843:      DELETE FROM deployment_results
+844:      WHERE deployment_id IN (SELECT id FROM software_deployments WHERE org_id = ${orgId})
+845:    `,
+846:  },
+847:  {
+848:    table: 'software_deployments',
+849:    clearSql: (orgId) => sql`
+850:      DELETE FROM software_deployments WHERE org_id = ${orgId}
+851:    `,
+852:  },
+```
+whose comment at `:835` states "After these pre-clears the main loop's `software_deployments` DELETE is a no-op" — i.e. **the pre-clears run before the main ordered loop.** The partner twin is at **`:1484-1502`** (`deployment_results`) and `:1503-1517+` (`software_deployments`), keyed off partner-owned `software_versions` / `software_install_methods` rather than `org_id`, with the comment at `:1475-1482` explaining they are belt-and-braces because `software_deployments.org_id` is NOT NULL.
+
+**Cascade conclusion (stated explicitly, as required).** The new FK is safe, for two independent reasons:
+1. **Ordering already holds.** `software_deployments` (`:597`) precedes `software_policies` (`:600`) in the alphabetical array, so the referencing table is deleted before the referenced one; and the org pre-clear at `:840-852` empties `software_deployments` for the tenant *before* the main loop starts, so by the time the loop reaches `software_policies` there is no same-org deployment row left to reference it. `tenantCascade.integration.test.ts`'s "FK children before parents" property is satisfied without any array edit.
+2. **Ordering is not even required**, because `ON DELETE SET NULL` cannot raise 23503. This matters for the case ordering does **not** cover: a **partner-wide** policy (`org_id NULL`, `partner_id` set) is referenced by policy-owned deployments in *every* child org. Erasing ONE org deletes only that org's deployments; the partner-wide policy survives, so nothing is orphaned. Erasing the PARTNER walks each child org first, then deletes the partner-wide policies — and any deployment row that somehow outlived its org would have its `software_policy_id` nulled rather than aborting the purge. A `NO ACTION` FK (the default, and what the two sibling FKs `software_version_id` / `install_method_id` use) would have made exactly that case a latent GDPR-erasure abort.
+   PostgreSQL runs referential actions in internal RI triggers as the referencing table's owner and bypasses row security for them, so the SET NULL fires even though `software_deployments` is FORCE RLS. Task 8's integration test proves this against real Postgres rather than resting on the doc claim.
+**No `CORE_ORG_CASCADE_DELETE_ORDER` edit, and no new pre-clear entry, is needed.** The one registration that *is* needed is the export-policy column (Task 3).
+
+**Test conventions.**
+- `apps/api/package.json:26` `"test": "vitest"` (bare — the `--` trap applies), `:31` `"test:integration": "vitest run --config vitest.integration.config.ts"`, `:35` `"test:rls"`, `:28` `"test:docker"` (up → integration → down).
+- `vitest.integration.config.ts:11` `include:` already carries the standing `src/__tests__/integration/**` glob — a new file there needs **no** config edit.
+- `apps/api/src/__tests__/integration/softwareInstallMethods.integration.test.ts` (read in full) is this wave's model: `import './setup'`, `getTestDb()` for superuser seeding, `withDbAccessContext(orgCtx(id), …)` for RLS-scoped assertions, the local `orgCtx` helper at `:120-125`, `pgErrorCode`/`expectPgCode` at `:127-142`, `seedCatalog` at `:144-153`, `seedMethod` at `:155-167`, device inserts at `:499-510` (`{ orgId, siteId, agentId, hostname, osType, osVersion, architecture, agentVersion }`), and `createOrganization`/`createPartner`/`createSite` from `./db-utils`. **Case 8 of that file already covers org and partner erasure of the whole software chain** — it is the natural home for W03's cascade fixture.
+- `apps/api/src/jobs/softwareRemediationWorker.test.ts` (356 lines) — mock shape at `:20-60` (`vi.hoisted` + `vi.mock('../db', …)` exposing `select`/`update`/`insert`), the `chain(result)` helper at `:68-72` whose method list is `['from','innerJoin','where','limit','orderBy','returning','values','for']`, `primeDb` at `:106-122` which serves `db.select()` results in the worker's fixed call order, `policyAuditActions()` at `:124-126`. **Crucially it keeps the REAL `evaluateSoftwarePolicyArming` (`:41-49`)** — "the whole point of the suite is that the gate itself is correct, not that a stubbed gate was consulted." W03's new cases must preserve that.
+- `apps/api/src/services/softwareDeployment.test.ts:47-80` — the `softwareDeployment.ts` mock shape: `selectMock`/`insertMock`/`updateMock`, `vi.mock('../db', …)` with `runOutsideDbContext`/`withSystemDbAccessContext` pass-throughs, and a **hand-written `vi.mock('../db/schema', …)`** that stubs each table as a plain object of string column markers. Any new table or column W03 reads in that module must be added to that stub or the test throws on an undefined property.
+- **Known trap (memory `drizzle_condition_deep_search_matches_enum_values_vacuous`):** a deep-search over a mocked Drizzle condition matches a pgEnum's `enumValues` array, so an assertion like "the WHERE mentions `'completed'`" passes against *unfixed* code. Assert on the **bound `Param` values** of the built condition, or assert behaviour (rows returned / not returned), never on a substring of the serialized condition.
+
+---
+
+## File structure
+
+- **Create** `apps/api/migrations/2026-10-15-150401-software-deployments-policy-origin.sql` — the `software_policy_id` column, its FK and its index. DDL only.
+- **Modify** `apps/api/src/db/schema/software.ts` — `softwarePolicyId` column + index on `softwareDeployments`; new import of `softwarePolicies`.
+- **Modify** `apps/api/src/services/softwareDeployment.ts` — `softwarePolicyId?: string` on `CreateSoftwareDeploymentInput`, destructured and written by the existing INSERT. **No other change to this file.**
+- **Modify** `apps/api/src/services/tenantExportPolicyRegistry.ts:434` — classify the new column `included`.
+- **Create** `apps/api/src/services/softwarePolicyInstallRemediation.ts` — target resolution (tenancy + platform), in-flight dedup, and the policy-owned deployment entry point. One responsibility: everything that must be decided *before* a deployment row exists, plus the thin stamped call that creates one.
+- **Create** `apps/api/src/services/softwarePolicyInstallRemediation.test.ts` — unit coverage for the above.
+- **Modify** `apps/api/src/jobs/softwareRemediationWorker.ts` — `processRemediateDeviceInstall` + the job-type switch in the BullMQ processor. The uninstall path is untouched.
+- **Modify** `apps/api/src/jobs/softwareRemediationWorker.test.ts` — new `describe` block for the install processor.
+- **Modify** `apps/api/src/services/softwareDeployment.test.ts` — one case proving the origin is stamped by the INSERT.
+- **Modify** `apps/api/src/__tests__/integration/softwareInstallMethods.integration.test.ts` — the live-Postgres cases: policy-owned creation, no-second-deployment, cross-tenant `catalogId` refusal, and FK `SET NULL` survival through an org cascade.
+
+---
+
+### Task 1: Migration — `software_deployments.software_policy_id`
+
+**Files:**
+- Create: `apps/api/migrations/2026-10-15-150401-software-deployments-policy-origin.sql`
+
+**Interfaces:**
+- Consumes: nothing. This task has no TypeScript surface.
+- Produces: the `software_policy_id` column, the FK `software_deployments_software_policy_id_fkey` (`ON DELETE SET NULL`), and the index `software_deployments_software_policy_idx`. Tasks 2, 3 and 8 depend on all three existing in a live database.
+
+- [ ] **Step 1: Re-confirm the slot is still sort-last**
+
+```bash
+cd /Users/toddhebebrand/.herdr/worktrees/breeze/warranty-testing
+ls apps/api/migrations/*.sql | sort | tail -3
+```
+
+Expected (as of 2026-09-10): the last entry is `2026-10-15-150300-remote-session-revocation-lease.sql`, plus W02's `2026-10-15-150400-software-compliance-install-remediation.sql` if W02 has already landed. If anything sorts **after** `2026-10-15-150401`, rename this file upward (bump the time component, never the `-a-`/`-b-` infix, and never into the closed `2026-08-06` block) and use the new name everywhere below.
+
+- [ ] **Step 2: Write the red observation**
+
+There is no TypeScript surface to assert against, so the red step is observing the column's absence in a live database.
+
+```bash
+docker exec -i breeze-postgres psql -U breeze_app -d breeze -c "\d software_deployments" | grep -c software_policy_id
+```
+
+Expected: `0` (and `grep` exits non-zero). If the local stack is not up, bring the test database up instead and use it for every DB step in this task:
+
+```bash
+cd apps/api && pnpm test:docker:up
+docker exec -i $(docker compose -f docker-compose.test.yml ps -q postgres) psql -U breeze_test -d breeze_test -c "\d software_deployments" | grep -c software_policy_id
+```
+
+- [ ] **Step 3: Write the migration**
+
+```sql
+-- apps/api/migrations/2026-10-15-150401-software-deployments-policy-origin.sql
+--
+-- Feature #5505 (desired-state software install) W03 / #5508, cross-wave
+-- contract D7. Marks a software_deployments row as created BY a software
+-- policy's autoInstall remediation rather than by an operator, so:
+--   * the remediation worker can dedupe in-flight policy-owned work on the
+--     DEPLOYMENT row (the uninstall dedup in softwareRemediationWorker.ts:168-195
+--     pins device_commands.type = software_uninstall and cannot see installs);
+--   * the deployment list can label the row as policy-owned (W04).
+--
+-- The column is stamped by the INSERT in createSoftwareDeployment
+-- (softwareDeployment.ts:1063-1080), never patched onto an existing row.
+--
+-- WHY ON DELETE SET NULL — this is load-bearing, not style. software_policies
+-- is in CORE_ORG_CASCADE_DELETE_ORDER (tenantCascade.ts:600) and a PARTNER-WIDE
+-- policy (org_id NULL, partner_id set) is referenced by policy-owned deployments
+-- in EVERY child org of that partner. With the NO ACTION default that the two
+-- sibling FKs (software_version_id, install_method_id) use, deleting such a
+-- policy — including the cascade's own DELETE FROM software_policies — would
+-- abort an org or partner erasure with 23503 the moment one deployment row
+-- outlived its policy. SET NULL degrades the label instead of aborting the
+-- purge. Ordering is ALSO fine on its own (software_deployments sorts before
+-- software_policies at tenantCascade.ts:597 vs :600, and the org pre-clear at
+-- tenantCascade.ts:840-852 empties software_deployments before the main loop
+-- runs), but SET NULL is what makes the cross-org partner-wide case safe.
+--
+-- NOT a composite (x, org_id) FK, so CLAUDE.md's "every composite FK that
+-- references an org_id column MUST be DEFERRABLE INITIALLY IMMEDIATE" rule does
+-- NOT apply: org merge runs SET CONSTRAINTS ALL DEFERRED and re-points org_id
+-- on parent and child in separate statements, and never touches this column.
+-- Do not add DEFERRABLE.
+--
+-- Export policy: software_policy_id is classified 'included' (a tenant row
+-- identifier, no secret material — same treatment as the existing
+-- maintenance_window_id and created_by FKs on this table) in
+-- CORE_TENANT_EXPORT_POLICY in this same PR. software_deployments is an
+-- org-cascade table, so every one of its columns must be classified, and
+-- tenant-export-policy.integration.test.ts fails on an unclassified ADD COLUMN.
+--
+-- RLS: software_deployments is shape 1 (direct org_id) and its policies are
+-- unchanged — a new column does not change the shape, so
+-- rls-coverage.integration.test.ts needs no allowlist entry.
+--
+-- DDL ONLY: no UPDATE / DELETE / INSERT / MERGE, so no
+-- `SELECT set_config('breeze.scope','system',true);` elevation is required
+-- (migrationRlsScope.test.ts only flags files that write rows).
+--
+-- Idempotent: IF NOT EXISTS on the column and the index, and a duplicate_object
+-- guard on the constraint (the same shape as
+-- 2026-08-16-b-software-deployments-install-method.sql). Re-applying is a no-op.
+-- No inner BEGIN/COMMIT — autoMigrate wraps each file in its own transaction.
+
+ALTER TABLE software_deployments
+  ADD COLUMN IF NOT EXISTS software_policy_id uuid;
+
+DO $$ BEGIN
+  ALTER TABLE software_deployments
+    ADD CONSTRAINT software_deployments_software_policy_id_fkey
+    FOREIGN KEY (software_policy_id) REFERENCES software_policies(id) ON DELETE SET NULL;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE INDEX IF NOT EXISTS software_deployments_software_policy_idx
+  ON software_deployments (software_policy_id);
+```
+
+- [ ] **Step 4: Apply and verify green, including idempotency**
+
+```bash
+cd /Users/toddhebebrand/.herdr/worktrees/breeze/warranty-testing
+export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze"
+pnpm db:migrate
+pnpm db:migrate   # second run must report zero newly-applied migrations
+docker exec -i breeze-postgres psql -U breeze_app -d breeze -c "\d software_deployments" | grep software_policy_id
+docker exec -i breeze-postgres psql -U breeze_app -d breeze -c \
+  "SELECT confdeltype FROM pg_constraint WHERE conname = 'software_deployments_software_policy_id_fkey';"
+```
+
+Expected: the column appears; `confdeltype` is `n` (SET NULL). `a` would mean NO ACTION and the migration is wrong.
+
+- [ ] **Step 5: Prove the RLS-scope guard is satisfied**
+
+```bash
+cd apps/api && npx vitest run src/db/migrationRlsScope.test.ts
+```
+
+Expected: PASS. This file writes no rows, so it must not need to appear in the guard's frozen baseline. **If it fails, do not add the file to the baseline** — that baseline is frozen at 122 pre-existing offenders and #4518 forbids new entries; fix the migration instead.
+
+- [ ] **Step 6: Prove the migration ordering guard is satisfied**
+
+```bash
+cd /Users/toddhebebrand/.herdr/worktrees/breeze/warranty-testing
+./scripts/check-migration-naming.sh --against-ref origin/main
+cd apps/api && npx vitest run src/db/autoMigrate.test.ts
+```
+
+Expected: both PASS. The `--against-ref origin/main` form is what the pre-push hook runs, so a slot that looked free at commit time can still fail here if `origin/main` gained a later-sorting migration; rename if it does.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/migrations/2026-10-15-150401-software-deployments-policy-origin.sql
+git commit -m "feat(software): add software_deployments.software_policy_id origin FK (ON DELETE SET NULL) — #5505 W03
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01ANjBwca2cfsLWDLJro3fkz"
+```
+
+---
+
+### Task 2: Drizzle schema + `CreateSoftwareDeploymentInput.softwarePolicyId`
+
+**Files:**
+- Modify: `apps/api/src/db/schema/software.ts` (import block `:1-21`; `softwareDeployments` columns after `:109`; index block `:111-116`)
+- Modify: `apps/api/src/services/softwareDeployment.ts` (`CreateSoftwareDeploymentInput` `:32-71`; destructure `:977-993`; INSERT `.values` `:1065-1079`)
+- Test: `apps/api/src/services/softwareDeployment.test.ts`
+
+**Interfaces:**
+- Consumes: Task 1's live column.
+- Produces:
+  - `softwareDeployments.softwarePolicyId` — Drizzle column, `uuid`, nullable, `onDelete: 'set null'`.
+  - `CreateSoftwareDeploymentInput.softwarePolicyId?: string` — optional; when omitted the INSERT writes `null`.
+  Task 4 (`createPolicyOwnedInstallDeployment`) and Task 8's integration cases depend on both. W04 reads `softwareDeployments.softwarePolicyId` off deployment rows for its label.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `apps/api/src/services/softwareDeployment.test.ts`. Note the mock at `:71-80` stubs `../db/schema` by hand — extend `softwareDeployments` there with `softwarePolicyId: 'sd.softwarePolicyId'` in the same edit, or the module throws on an undefined property.
+
+```ts
+describe('createSoftwareDeployment — policy origin (#5505 W03)', () => {
+  it('stamps softwarePolicyId on the INSERT, and writes null when not supplied', async () => {
+    // Two calls through the same fixture: one policy-owned, one operator-made.
+    const insertedValues: Array<Record<string, unknown>> = [];
+
+    const primeCreate = () => {
+      // db.select() call order inside createSoftwareDeployment:
+      //   1. install method (softwareDeployment.ts:1009-1012)
+      //   2. catalog item  (:1031-1039)
+      const selectResults = [
+        [{ id: 'im-1', catalogId: 'cat-1', platform: 'windows', kind: 'winget', packageId: 'Vendor.App', enabled: true }],
+        [{ id: 'cat-1', orgId: 'org-1', name: 'App', integrationProvider: null }],
+      ];
+      let call = 0;
+      selectMock.mockImplementation(() => chain(selectResults[Math.min(call++, selectResults.length - 1)]));
+      insertMock.mockImplementation(() => ({
+        values: (v: Record<string, unknown> | Array<Record<string, unknown>>) => {
+          if (!Array.isArray(v)) insertedValues.push(v);
+          return chain(Array.isArray(v) ? [] : [{ id: 'dep-1', ...v }]);
+        },
+      }));
+      updateMock.mockImplementation(() => ({ set: () => chain([]) }));
+    };
+
+    primeCreate();
+    await createSoftwareDeployment({
+      orgId: 'org-1',
+      installMethodId: 'im-1',
+      deploymentType: 'install',
+      deviceIds: [],                 // no devices => no dispatch branch, INSERT only
+      scheduleType: 'scheduled',
+      createdBy: null,
+      softwarePolicyId: 'pol-1',
+    });
+
+    primeCreate();
+    await createSoftwareDeployment({
+      orgId: 'org-1',
+      installMethodId: 'im-1',
+      deploymentType: 'install',
+      deviceIds: [],
+      scheduleType: 'scheduled',
+      createdBy: null,
+    });
+
+    expect(insertedValues).toHaveLength(2);
+    expect(insertedValues[0]!.softwarePolicyId).toBe('pol-1');
+    // Explicit null, not undefined: an undefined would let the column default,
+    // which is the same value here but a different contract.
+    expect(insertedValues[1]!.softwarePolicyId).toBeNull();
+  });
+});
+```
+
+If `chain` is not already a helper in this file, add the same shape the worker suite uses:
+
+```ts
+function chain(result: unknown): any {
+  const p: any = Promise.resolve(result);
+  for (const m of ['from', 'innerJoin', 'where', 'limit', 'orderBy', 'returning', 'values', 'for']) p[m] = () => p;
+  return p;
+}
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+cd apps/api && npx vitest run src/services/softwareDeployment.test.ts -t "policy origin"
+```
+
+Expected: FAIL — TypeScript rejects `softwarePolicyId` as not assignable to `CreateSoftwareDeploymentInput`, and at runtime `insertedValues[0].softwarePolicyId` is `undefined`.
+
+- [ ] **Step 3: Add the Drizzle column**
+
+In `apps/api/src/db/schema/software.ts`, add to the import block (after the `./deployments` import at `:21`):
+
+```ts
+import { softwarePolicies } from './softwarePolicies';
+```
+
+`softwarePolicies.ts` does not import `./software`, so this edge introduces no cycle — verified.
+
+Then insert between `dispatchedAt` (`:109`) and `createdAt` (`:110`):
+
+```ts
+  // #5505 W03 (contract D7): set when this deployment was created BY a software
+  // policy's autoInstall remediation rather than by an operator. Stamped by the
+  // INSERT in createSoftwareDeployment, never patched afterwards. ON DELETE SET
+  // NULL (migration 2026-10-15-150401) is load-bearing: a partner-wide policy is
+  // referenced by deployments in every child org, so a NO ACTION FK would abort
+  // an org or partner erasure with 23503. The remediation worker dedupes
+  // in-flight policy-owned work on this column.
+  softwarePolicyId: uuid('software_policy_id').references(() => softwarePolicies.id, { onDelete: 'set null' }),
+```
+
+And add to the index block, after `installMethodIdx` (`:114`):
+
+```ts
+  softwarePolicyIdx: index('software_deployments_software_policy_idx').on(table.softwarePolicyId),
+```
+
+- [ ] **Step 4: Thread it through `CreateSoftwareDeploymentInput`**
+
+In `apps/api/src/services/softwareDeployment.ts`, append to the interface (after `targetIds?: string[] | null;` at `:70`):
+
+```ts
+  /**
+   * #5505 W03: the software policy whose autoInstall remediation produced this
+   * deployment. Set ONLY by services/softwarePolicyInstallRemediation.ts —
+   * HTTP callers never pass it, because an operator-created deployment is not
+   * policy-owned. Stamped by this function's INSERT so the origin is durable
+   * from the first moment the row exists (the remediation worker's dedup reads
+   * it on the very next pass, 15 minutes later).
+   */
+  softwarePolicyId?: string;
+```
+
+Add `softwarePolicyId,` to the destructure at `:977-993` (after `targetIds,`), and add to the INSERT `.values({…})` at `:1065-1079`, after `dependencyFingerprint,`:
+
+```ts
+      softwarePolicyId: softwarePolicyId ?? null,
+```
+
+- [ ] **Step 5: Run the test and watch it pass**
+
+```bash
+cd apps/api && npx vitest run src/services/softwareDeployment.test.ts
+```
+
+Expected: PASS, including every pre-existing case in the file (the new column must not disturb them).
+
+- [ ] **Step 6: Typecheck**
+
+```bash
+pnpm --filter @breeze/api exec tsc --noEmit
+```
+
+Expected: no errors. There is no root `typecheck` script.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/db/schema/software.ts apps/api/src/services/softwareDeployment.ts apps/api/src/services/softwareDeployment.test.ts
+git commit -m "feat(software): stamp softwarePolicyId at deployment INSERT — #5505 W03
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01ANjBwca2cfsLWDLJro3fkz"
+```
+
+---
+
+### Task 3: Export-policy registration for the new column
+
+**Files:**
+- Modify: `apps/api/src/services/tenantExportPolicyRegistry.ts:431-434`
+
+**Interfaces:**
+- Consumes: Task 1's live column (the contract test reads `information_schema` for every column of every org-cascade table).
+- Produces: nothing importable. It satisfies `tenant-export-policy.integration.test.ts` and `tenantExportErasureRoundtrip.integration.test.ts`.
+
+This is the registration CLAUDE.md records as having shipped or blocked CI five times with code review catching it 0/5 and contract tests 5/5. **It is a mechanical edit, not a judgement call.**
+
+- [ ] **Step 1: Confirm the failing state is real, not assumed**
+
+```bash
+cd /Users/toddhebebrand/.herdr/worktrees/breeze/warranty-testing
+grep -n 'software_policy_id' apps/api/src/services/tenantExportPolicyRegistry.ts
+```
+
+Expected: no output — the column is unclassified. That is the red state; the contract test that observes it needs a live DB and runs in Task 8.
+
+- [ ] **Step 2: Classify the column `included`**
+
+Replace line `:434` (keeping the `:431-433` comment above it untouched) with the same entry plus one new member in `included`, placed after `install_method_id` so the list keeps mirroring the column order:
+
+```ts
+  "software_deployments": tablePolicy("org_id", {"included":["id","org_id","name","software_version_id","install_method_id","software_policy_id","deployment_type","target_type","schedule_type","scheduled_at","dispatched_at","maintenance_window_id","created_by","created_at"],"reviewedIncluded":["dependency_fingerprint"],"excludedSensitive":[],"excludedOpen":["target_ids","options"]}),
+```
+
+Rationale for `included`, for the reviewer: `software_policy_id` is a plain uuid FK to another tenant-owned table — exactly the shape of `maintenance_window_id` and `created_by` already in this list. It matches nothing in `SUSPICIOUS_NAME_PARTS` (no password/hash/token/secret/credential/refresh substring), so it does not belong in `reviewedIncluded`. It is not credential, private-key or verifier material, so not `excludedSensitive`. It is `uuid`, not `json`/`jsonb`/`bytea`, so the `excludedOpen` open-container rule does not reach it.
+
+- [ ] **Step 3: Prove the registry still builds and rejects nothing**
+
+```bash
+cd apps/api && npx vitest run src/services/tenantExportPolicy.test.ts src/services/tenantExportPolicyRegistry.test.ts
+```
+
+Expected: PASS. (If neither file exists, this step is `pnpm --filter @breeze/api exec tsc --noEmit` only — `tablePolicy` throws at module load on a duplicate classification, so a typo surfaces the moment the module is imported by anything.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/services/tenantExportPolicyRegistry.ts
+git commit -m "chore(tenancy): classify software_deployments.software_policy_id as included — #5505 W03
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01ANjBwca2cfsLWDLJro3fkz"
+```
+
+---
+
+### Task 4: `softwarePolicyInstallRemediation.ts` — tenancy-checked, platform-aware target resolution
+
+**Files:**
+- Create: `apps/api/src/services/softwarePolicyInstallRemediation.ts`
+- Test: `apps/api/src/services/softwarePolicyInstallRemediation.test.ts`
+
+**Interfaces:**
+- Consumes: `softwareCatalog`, `softwareInstallMethods`, `softwareVersions` from `../db/schema`; `db` from `../db`. Nothing from W01 or W02.
+- Produces (Task 5 extends this file; Task 6 imports all of it):
+  ```ts
+  export type PolicyInstallSkipReason =
+    | 'no_catalog_id'
+    | 'catalog_item_not_reachable'
+    | 'no_install_target_for_platform';
+
+  export type PolicyInstallTarget =
+    | { kind: 'install_method'; catalogId: string; installMethodId: string }
+    | { kind: 'version'; catalogId: string; softwareVersionId: string };
+
+  export type PolicyInstallTargetResolution =
+    | { ok: true; target: PolicyInstallTarget }
+    | { ok: false; reason: PolicyInstallSkipReason };
+
+  export function resolvePolicyInstallTarget(input: {
+    catalogId: string | null | undefined;
+    deviceOrgId: string;
+    deviceOsType: string;
+  }): Promise<PolicyInstallTargetResolution>;
+  ```
+
+- [ ] **Step 1: Record the W01/W02 identifier names before writing anything**
+
+```bash
+cd /Users/toddhebebrand/.herdr/worktrees/breeze/warranty-testing
+grep -n "export function evaluateSoftwarePolicyArming" -A 4 apps/api/src/services/softwarePolicyService.ts
+grep -n "install_queued\|install_failed" apps/api/src/services/softwarePolicyService.ts
+grep -n "catalogId" apps/api/src/db/schema/softwarePolicies.ts
+```
+
+Write the three real names down. Task 6 uses them. If W01 has not landed yet, stop and say so rather than inventing them — this wave cannot be finished ahead of W01.
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `apps/api/src/services/softwarePolicyInstallRemediation.test.ts`:
+
+```ts
+/**
+ * #5505 W03 — what must be decided BEFORE a policy-owned deployment row exists.
+ *
+ * The tenancy case is the sharp one. This module runs inside the remediation
+ * worker's SYSTEM db context (softwareRemediationWorker.ts:14-22), where
+ * breeze_has_org_access short-circuits true and RLS scopes nothing. A rule's
+ * catalogId is operator-authored jsonb inside software_policies.rules, so
+ * without an explicit ownership predicate a policy could name ANOTHER tenant's
+ * catalog item and install that tenant's uploaded binary onto these machines.
+ * The WHERE clause IS the entire guard here; there is no second line of defence.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { selectMock } = vi.hoisted(() => ({ selectMock: vi.fn() }));
+vi.mock('../db', () => ({
+  db: { select: (...a: unknown[]) => selectMock(...a) },
+  runOutsideDbContext: <T>(fn: () => T): T => fn(),
+  withSystemDbAccessContext: async <T>(fn: () => Promise<T>): Promise<T> => fn(),
+}));
+
+import { resolvePolicyInstallTarget } from './softwarePolicyInstallRemediation';
+
+function chain(result: unknown): any {
+  const p: any = Promise.resolve(result);
+  for (const m of ['from', 'innerJoin', 'where', 'limit', 'orderBy', 'returning', 'values', 'for']) p[m] = () => p;
+  return p;
+}
+
+/** Serves db.select() in this module's fixed order: catalog -> method -> version. */
+function primeSelects(...results: unknown[][]) {
+  let call = 0;
+  selectMock.mockImplementation(() => chain(results[Math.min(call++, results.length - 1)] ?? []));
+}
+
+const CATALOG_ROW = { id: 'cat-1', orgId: 'org-1', partnerId: null, integrationProvider: null };
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('resolvePolicyInstallTarget', () => {
+  it('refuses a rule with no catalogId without touching the database', async () => {
+    primeSelects([]);
+    const result = await resolvePolicyInstallTarget({
+      catalogId: undefined,
+      deviceOrgId: 'org-1',
+      deviceOsType: 'windows',
+    });
+    expect(result).toEqual({ ok: false, reason: 'no_catalog_id' });
+    expect(selectMock).not.toHaveBeenCalled();
+  });
+
+  it('refuses a catalogId the device tenant cannot reach', async () => {
+    // The ownership predicate filters it out, so the catalog SELECT returns [].
+    primeSelects([]);
+    const result = await resolvePolicyInstallTarget({
+      catalogId: 'cat-from-another-tenant',
+      deviceOrgId: 'org-1',
+      deviceOsType: 'windows',
+    });
+    expect(result).toEqual({ ok: false, reason: 'catalog_item_not_reachable' });
+  });
+
+  it('prefers an enabled install method matching the device OS', async () => {
+    primeSelects([CATALOG_ROW], [{ id: 'im-win' }]);
+    const result = await resolvePolicyInstallTarget({
+      catalogId: 'cat-1',
+      deviceOrgId: 'org-1',
+      deviceOsType: 'windows',
+    });
+    expect(result).toEqual({
+      ok: true,
+      target: { kind: 'install_method', catalogId: 'cat-1', installMethodId: 'im-win' },
+    });
+  });
+
+  it('falls back to the latest version when no install method matches the OS', async () => {
+    primeSelects([CATALOG_ROW], [], [{ id: 'sv-1', supportedOs: ['windows'] }]);
+    const result = await resolvePolicyInstallTarget({
+      catalogId: 'cat-1',
+      deviceOrgId: 'org-1',
+      deviceOsType: 'windows',
+    });
+    expect(result).toEqual({
+      ok: true,
+      target: { kind: 'version', catalogId: 'cat-1', softwareVersionId: 'sv-1' },
+    });
+  });
+
+  it('treats a null/empty supportedOs as unrestricted', async () => {
+    primeSelects([CATALOG_ROW], [], [{ id: 'sv-1', supportedOs: null }]);
+    const result = await resolvePolicyInstallTarget({
+      catalogId: 'cat-1',
+      deviceOrgId: 'org-1',
+      deviceOsType: 'linux',
+    });
+    expect(result).toMatchObject({ ok: true, target: { kind: 'version', softwareVersionId: 'sv-1' } });
+  });
+
+  it('refuses when the only version declares a different OS — the cross-platform loop guard', async () => {
+    // Without this the worker would create a guaranteed-failing deployment
+    // every 15 minutes for every macOS device under a Windows-only policy.
+    primeSelects([CATALOG_ROW], [], [{ id: 'sv-1', supportedOs: ['windows'] }]);
+    const result = await resolvePolicyInstallTarget({
+      catalogId: 'cat-1',
+      deviceOrgId: 'org-1',
+      deviceOsType: 'macos',
+    });
+    expect(result).toEqual({ ok: false, reason: 'no_install_target_for_platform' });
+  });
+
+  it('refuses a linux device with no version row — there is no linux install method by construction', async () => {
+    primeSelects([CATALOG_ROW], [], []);
+    const result = await resolvePolicyInstallTarget({
+      catalogId: 'cat-1',
+      deviceOrgId: 'org-1',
+      deviceOsType: 'linux',
+    });
+    expect(result).toEqual({ ok: false, reason: 'no_install_target_for_platform' });
+  });
+});
+```
+
+- [ ] **Step 3: Run it and watch it fail**
+
+```bash
+cd apps/api && npx vitest run src/services/softwarePolicyInstallRemediation.test.ts
+```
+
+Expected: FAIL — `Failed to resolve import "./softwarePolicyInstallRemediation"`.
+
+- [ ] **Step 4: Implement**
+
+Create `apps/api/src/services/softwarePolicyInstallRemediation.ts`:
+
+```ts
+import { and, eq, isNull, or, sql } from 'drizzle-orm';
+import { db } from '../db';
+import {
+  softwareCatalog,
+  softwareInstallMethods,
+  softwareVersions,
+} from '../db/schema';
+
+/**
+ * #5505 W03 — everything that must be decided BEFORE a policy-owned
+ * software_deployments row exists.
+ *
+ * The whole module runs inside the software remediation worker's SYSTEM db
+ * context (softwareRemediationWorker.ts:14-22), where breeze_has_org_access
+ * short-circuits true and RLS scopes nothing. Every predicate below is
+ * therefore load-bearing on its own: a rule's catalogId is operator-authored
+ * jsonb living in software_policies.rules, and nothing else checks it.
+ */
+
+/** Why a (policy, device, rule) triple produced no install deployment. */
+export type PolicyInstallSkipReason =
+  /** The rule can be DETECTED as missing but names nothing to install. */
+  | 'no_catalog_id'
+  /** The catalogId does not resolve to an item this device's tenant may use. */
+  | 'catalog_item_not_reachable'
+  /** Reachable item, but nothing installable on this device's OS. */
+  | 'no_install_target_for_platform';
+
+export type PolicyInstallTarget =
+  | { kind: 'install_method'; catalogId: string; installMethodId: string }
+  | { kind: 'version'; catalogId: string; softwareVersionId: string };
+
+export type PolicyInstallTargetResolution =
+  | { ok: true; target: PolicyInstallTarget }
+  | { ok: false; reason: PolicyInstallSkipReason };
+
+/**
+ * software_install_methods.platform is 'windows' | 'macos' only
+ * (db/schema/software.ts:264) — there is no linux install method by
+ * construction, so a linux device can only ever be served by a version row.
+ */
+const INSTALL_METHOD_PLATFORM_BY_OS_TYPE: Readonly<Record<string, 'windows' | 'macos'>> = {
+  windows: 'windows',
+  macos: 'macos',
+};
+
+/**
+ * `supported_os` is an optional array of the same three values as
+ * devices.os_type (routes/software.ts:465,523). Null, non-array or empty means
+ * the uploader declared no restriction, which stays permissive — this filter
+ * may only ever narrow what an operator already allowed, never widen it.
+ */
+function versionSupportsOs(supportedOs: unknown, osType: string): boolean {
+  if (!Array.isArray(supportedOs) || supportedOs.length === 0) return true;
+  return supportedOs.some((value) => typeof value === 'string' && value === osType);
+}
+
+/**
+ * Resolve a catalog item the DEVICE's tenant is actually entitled to install.
+ *
+ * Mirrors the route-layer widening at routes/software.ts:867-870, but keyed on
+ * the DEVICE's org rather than on a request's auth: an org-owned item must
+ * belong to this device's org, and a partner-owned item (built-in integration
+ * package or partner-wide custom package) is reachable only when this device's
+ * org belongs to that partner. Anything else — including another org's item
+ * under the same partner — resolves to nothing.
+ */
+async function readReachableCatalogItem(
+  catalogId: string,
+  deviceOrgId: string,
+): Promise<{ id: string } | null> {
+  const [row] = await db
+    .select({ id: softwareCatalog.id })
+    .from(softwareCatalog)
+    .where(
+      and(
+        eq(softwareCatalog.id, catalogId),
+        or(
+          eq(softwareCatalog.orgId, deviceOrgId),
+          and(
+            isNull(softwareCatalog.orgId),
+            sql`EXISTS (
+              SELECT 1 FROM organizations o
+              WHERE o.id = ${deviceOrgId}
+                AND o.partner_id = ${softwareCatalog.partnerId}
+            )`,
+          ),
+        ),
+      ),
+    )
+    .limit(1);
+  return row ?? null;
+}
+
+/**
+ * Resolve a policy rule's catalogId to exactly one deployment target for this
+ * device, or say precisely why it cannot.
+ *
+ * Package-manager install methods win over uploaded versions when both exist:
+ * a manager deploy always resolves the current package at install time, so it
+ * cannot go stale the way a pinned version row can.
+ *
+ * The platform filter is deliberately done HERE rather than relying on
+ * softwareDeployment.ts:413-429, which (a) only covers the install-method path
+ * and never the version path, and (b) fires downstream, after a deployment row
+ * and a failed deployment_results row already exist — which a compliance pass
+ * every 15 minutes would turn into an unbounded stream of guaranteed-failing
+ * deployments for every cross-platform device under the policy.
+ */
+export async function resolvePolicyInstallTarget(input: {
+  catalogId: string | null | undefined;
+  deviceOrgId: string;
+  deviceOsType: string;
+}): Promise<PolicyInstallTargetResolution> {
+  if (!input.catalogId) {
+    return { ok: false, reason: 'no_catalog_id' };
+  }
+
+  const catalogItem = await readReachableCatalogItem(input.catalogId, input.deviceOrgId);
+  if (!catalogItem) {
+    return { ok: false, reason: 'catalog_item_not_reachable' };
+  }
+
+  const platform = INSTALL_METHOD_PLATFORM_BY_OS_TYPE[input.deviceOsType];
+  if (platform) {
+    const [method] = await db
+      .select({ id: softwareInstallMethods.id })
+      .from(softwareInstallMethods)
+      .where(
+        and(
+          eq(softwareInstallMethods.catalogId, catalogItem.id),
+          eq(softwareInstallMethods.platform, platform),
+          eq(softwareInstallMethods.enabled, true),
+        ),
+      )
+      .limit(1);
+    if (method) {
+      return {
+        ok: true,
+        target: { kind: 'install_method', catalogId: catalogItem.id, installMethodId: method.id },
+      };
+    }
+  }
+
+  // At most one row can match: software_versions_one_latest_per_catalog_idx is
+  // a unique partial index on (catalog_id) WHERE is_latest = true.
+  const [version] = await db
+    .select({ id: softwareVersions.id, supportedOs: softwareVersions.supportedOs })
+    .from(softwareVersions)
+    .where(
+      and(eq(softwareVersions.catalogId, catalogItem.id), eq(softwareVersions.isLatest, true)),
+    )
+    .limit(1);
+
+  if (!version || !versionSupportsOs(version.supportedOs, input.deviceOsType)) {
+    return { ok: false, reason: 'no_install_target_for_platform' };
+  }
+
+  return {
+    ok: true,
+    target: { kind: 'version', catalogId: catalogItem.id, softwareVersionId: version.id },
+  };
+}
+```
+
+- [ ] **Step 5: Run the tests and watch them pass**
+
+```bash
+cd apps/api && npx vitest run src/services/softwarePolicyInstallRemediation.test.ts
+```
+
+Expected: PASS, 7 tests.
+
+- [ ] **Step 6: Typecheck and commit**
+
+```bash
+pnpm --filter @breeze/api exec tsc --noEmit
+git add apps/api/src/services/softwarePolicyInstallRemediation.ts apps/api/src/services/softwarePolicyInstallRemediation.test.ts
+git commit -m "feat(software): tenancy-checked, platform-aware install target resolution for policy remediation — #5505 W03
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01ANjBwca2cfsLWDLJro3fkz"
+```
+
+---
+
+### Task 5: Deployment-row dedup + the policy-owned creation entry point
+
+**Files:**
+- Modify: `apps/api/src/services/softwarePolicyInstallRemediation.ts`
+- Test: `apps/api/src/services/softwarePolicyInstallRemediation.test.ts`
+
+**Interfaces:**
+- Consumes: Task 2's `softwareDeployments.softwarePolicyId` and `CreateSoftwareDeploymentInput.softwarePolicyId`; `createSoftwareDeployment` (`softwareDeployment.ts:974`); `deploymentResults`, `softwareDeployments` from `../db/schema`; Task 4's `PolicyInstallTarget`.
+- Produces (Task 6 imports both):
+  ```ts
+  export const POLICY_INSTALL_IN_FLIGHT_LOOKBACK_MINUTES: number;   // 24 * 60
+
+  export function hasUnfinishedPolicyOwnedInstall(
+    policyId: string,
+    deviceId: string,
+  ): Promise<boolean>;
+
+  export function createPolicyOwnedInstallDeployment(input: {
+    policyId: string;
+    policyName: string;
+    /** The DEVICE's org — never the policy's, which is NULL for partner-wide. */
+    orgId: string;
+    deviceId: string;
+    target: PolicyInstallTarget;
+  }): Promise<{ deploymentId: string; status: 'pending' | 'failed'; message?: string }>;
+  ```
+
+**Design note for the reviewer — why the dedup lives on the deployment row and what "unfinished" means.** The existing uninstall dedup (`softwareRemediationWorker.ts:168-195`) reads `device_commands` filtered to `type = software_uninstall`, so it is structurally blind to installs; the spec directs the install path to dedupe on the deployment row instead, and this does. "Unfinished" is expressed as **NOT IN a closed list of terminal statuses** rather than IN a list of live ones, so a future `deployment_status` enum member counts as *unfinished* and suppresses a duplicate install — the failure the spec calls the most likely to reach a customer. The 24-hour lookback (mirroring `IN_FLIGHT_LOOKBACK_MINUTES` at `:36`) bounds the cost of that choice: a permanently wedged result row stops blocking the policy after a day instead of forever.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `apps/api/src/services/softwarePolicyInstallRemediation.test.ts`. Add `createSoftwareDeploymentMock` to the existing `vi.hoisted` block and a `vi.mock('./softwareDeployment', …)` alongside the `../db` mock at the top of the file:
+
+```ts
+const { createSoftwareDeploymentMock } = vi.hoisted(() => ({
+  createSoftwareDeploymentMock: vi.fn(async (..._args: any[]) => ({
+    deploymentId: 'dep-1',
+    deployment: {},
+    status: 'pending' as const,
+    dispatchedDeviceIds: ['dev-1'],
+    deviceResults: [],
+  })),
+}));
+vi.mock('./softwareDeployment', () => ({ createSoftwareDeployment: createSoftwareDeploymentMock }));
+```
+
+and the cases:
+
+```ts
+import {
+  createPolicyOwnedInstallDeployment,
+  hasUnfinishedPolicyOwnedInstall,
+} from './softwarePolicyInstallRemediation';
+
+describe('hasUnfinishedPolicyOwnedInstall', () => {
+  it('is true when a non-terminal policy-owned result row exists', async () => {
+    primeSelects([{ id: 'dr-1' }]);
+    await expect(hasUnfinishedPolicyOwnedInstall('pol-1', 'dev-1')).resolves.toBe(true);
+  });
+
+  it('is false when the join returns nothing', async () => {
+    primeSelects([]);
+    await expect(hasUnfinishedPolicyOwnedInstall('pol-1', 'dev-1')).resolves.toBe(false);
+  });
+
+  it('excludes exactly completed/failed/cancelled and nothing else', async () => {
+    // Asserted on the CONSTANT, not on a serialized drizzle condition: a deep
+    // search over a mocked condition also matches deploymentStatusEnum's own
+    // enumValues array, which makes such an assertion pass against unfixed code
+    // (memory: drizzle_condition_deep_search_matches_enum_values_vacuous).
+    const { FINISHED_POLICY_INSTALL_RESULT_STATUSES } = await import(
+      './softwarePolicyInstallRemediation'
+    );
+    expect([...FINISHED_POLICY_INSTALL_RESULT_STATUSES].sort()).toEqual([
+      'cancelled',
+      'completed',
+      'failed',
+    ]);
+  });
+});
+
+describe('createPolicyOwnedInstallDeployment', () => {
+  it('creates an immediate install stamped with the policy, under the DEVICE org, with a null actor', async () => {
+    await createPolicyOwnedInstallDeployment({
+      policyId: 'pol-1',
+      policyName: 'Standard workstation build',
+      orgId: 'device-org-1',
+      deviceId: 'dev-1',
+      target: { kind: 'install_method', catalogId: 'cat-1', installMethodId: 'im-1' },
+    });
+
+    expect(createSoftwareDeploymentMock).toHaveBeenCalledTimes(1);
+    const input = createSoftwareDeploymentMock.mock.calls[0]![0];
+    expect(input).toMatchObject({
+      orgId: 'device-org-1',
+      installMethodId: 'im-1',
+      versionMode: 'latest',
+      deploymentType: 'install',
+      deviceIds: ['dev-1'],
+      scheduleType: 'immediate',
+      createdBy: null,
+      softwarePolicyId: 'pol-1',
+      targetType: 'devices',
+      targetIds: ['dev-1'],
+    });
+    // XOR: exactly one target field reaches createSoftwareDeployment, or its
+    // guard at softwareDeployment.ts:998-1002 throws.
+    expect(input.softwareVersionId).toBeUndefined();
+    expect(String(input.name)).toContain('Standard workstation build');
+  });
+
+  it('passes a version target as softwareVersionId and never sets installMethodId', async () => {
+    await createPolicyOwnedInstallDeployment({
+      policyId: 'pol-1',
+      policyName: 'P',
+      orgId: 'device-org-1',
+      deviceId: 'dev-1',
+      target: { kind: 'version', catalogId: 'cat-1', softwareVersionId: 'sv-1' },
+    });
+    const input = createSoftwareDeploymentMock.mock.calls.at(-1)![0];
+    expect(input.softwareVersionId).toBe('sv-1');
+    expect(input.installMethodId).toBeUndefined();
+    expect(input.versionMode).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run and watch it fail**
+
+```bash
+cd apps/api && npx vitest run src/services/softwarePolicyInstallRemediation.test.ts
+```
+
+Expected: FAIL — `hasUnfinishedPolicyOwnedInstall`, `createPolicyOwnedInstallDeployment` and `FINISHED_POLICY_INSTALL_RESULT_STATUSES` are not exported.
+
+- [ ] **Step 3: Implement**
+
+Replace the import block at the top of `apps/api/src/services/softwarePolicyInstallRemediation.ts` with this (three added drizzle operators, two added tables, one new module import — `PolicyInstallTarget` is declared in this same file and needs no import):
+
+```ts
+import { and, eq, gte, isNull, notInArray, or, sql } from 'drizzle-orm';
+import { db } from '../db';
+import {
+  deploymentResults,
+  softwareCatalog,
+  softwareDeployments,
+  softwareInstallMethods,
+  softwareVersions,
+} from '../db/schema';
+import { createSoftwareDeployment } from './softwareDeployment';
+```
+
+Append:
+
+```ts
+/**
+ * Mirrors IN_FLIGHT_LOOKBACK_MINUTES (softwareRemediationWorker.ts:36) so both
+ * verbs forget stuck work on the same horizon. Its job here is to bound the
+ * cost of the deliberately conservative "unfinished" definition below: without
+ * it, one permanently wedged deployment_results row would suppress every future
+ * policy install for that (policy, device) pair forever.
+ */
+export const POLICY_INSTALL_IN_FLIGHT_LOOKBACK_MINUTES = 24 * 60;
+
+/**
+ * The CLOSED set of deployment_status values that mean "this device is done
+ * with that deployment". Deliberately a terminal list rather than a live list:
+ * a deployment_status enum member added later then counts as UNFINISHED and
+ * suppresses a duplicate install, which is the safe direction — the spec's
+ * top-ranked customer-facing risk is an install loop, not a delayed install.
+ * (deployment_status = draft|pending|running|paused|downloading|installing|
+ *  completed|failed|cancelled|rollback — db/schema/deployments.ts:15-26.
+ *  'rollback' is deliberately NOT terminal.)
+ */
+export const FINISHED_POLICY_INSTALL_RESULT_STATUSES = [
+  'completed',
+  'failed',
+  'cancelled',
+] as const;
+
+/**
+ * The install-side dedup, and the reason W03 adds a column instead of reusing
+ * readInFlightUninstallKeys (softwareRemediationWorker.ts:168-195): that query
+ * pins device_commands.type to SOFTWARE_UNINSTALL, so it is structurally blind
+ * to installs. This asks the deployment row instead — is there already
+ * unfinished policy-owned work for this exact (policy, device)?
+ */
+export async function hasUnfinishedPolicyOwnedInstall(
+  policyId: string,
+  deviceId: string,
+): Promise<boolean> {
+  const cutoff = new Date(Date.now() - POLICY_INSTALL_IN_FLIGHT_LOOKBACK_MINUTES * 60 * 1000);
+  const [row] = await db
+    .select({ id: deploymentResults.id })
+    .from(deploymentResults)
+    .innerJoin(softwareDeployments, eq(softwareDeployments.id, deploymentResults.deploymentId))
+    .where(
+      and(
+        eq(softwareDeployments.softwarePolicyId, policyId),
+        eq(deploymentResults.deviceId, deviceId),
+        notInArray(deploymentResults.status, [...FINISHED_POLICY_INSTALL_RESULT_STATUSES]),
+        gte(softwareDeployments.createdAt, cutoff),
+      ),
+    )
+    .limit(1);
+  return row != null;
+}
+
+/**
+ * Create ONE policy-owned deployment for ONE device and dispatch it through the
+ * existing seam.
+ *
+ * `orgId` is the DEVICE's org, never the policy's: a partner-wide policy has
+ * org_id NULL, and every worker-created child row takes the device's org (the
+ * partner-wide playbook's rule, and the same rule the audit rows follow at
+ * softwareRemediationWorker.ts:264).
+ *
+ * `createdBy: null` is required and deliberate — createSoftwareDeployment
+ * declares it non-optional (softwareDeployment.ts:46) and there is no operator
+ * behind an automatic remediation. `scheduleType: 'immediate'` +
+ * `deploymentType: 'install'` is what makes createSoftwareDeployment take its
+ * dispatch branch (:1103) rather than leaving the row sitting for the scheduler.
+ *
+ * Exactly one of installMethodId / softwareVersionId is set, mirroring
+ * software_deployments_one_target_chk; passing both or neither throws at
+ * softwareDeployment.ts:998-1002.
+ *
+ * Nothing here touches the EDR secret-resolution branch
+ * (softwareDeployment.ts:554-584): that fires only when the resolved catalog
+ * item's integrationProvider is 'huntress' or 'sentinelone', and this path adds
+ * no special handling for it either way.
+ */
+export async function createPolicyOwnedInstallDeployment(input: {
+  policyId: string;
+  policyName: string;
+  orgId: string;
+  deviceId: string;
+  target: PolicyInstallTarget;
+}): Promise<{ deploymentId: string; status: 'pending' | 'failed'; message?: string }> {
+  const targetFields =
+    input.target.kind === 'install_method'
+      ? { installMethodId: input.target.installMethodId, versionMode: 'latest' as const }
+      : { softwareVersionId: input.target.softwareVersionId };
+
+  const result = await createSoftwareDeployment({
+    orgId: input.orgId,
+    ...targetFields,
+    deploymentType: 'install',
+    deviceIds: [input.deviceId],
+    scheduleType: 'immediate',
+    createdBy: null,
+    // software_deployments.name is varchar(255) and software_policies.name is
+    // varchar(200), so the prefixed form always fits.
+    name: `Policy: ${input.policyName}`,
+    targetType: 'devices',
+    targetIds: [input.deviceId],
+    softwarePolicyId: input.policyId,
+  });
+
+  return {
+    deploymentId: result.deploymentId,
+    status: result.status,
+    ...(result.message ? { message: result.message } : {}),
+  };
+}
+```
+
+- [ ] **Step 4: Run and watch it pass**
+
+```bash
+cd apps/api && npx vitest run src/services/softwarePolicyInstallRemediation.test.ts
+```
+
+Expected: PASS, 12 tests.
+
+- [ ] **Step 5: Typecheck and commit**
+
+```bash
+pnpm --filter @breeze/api exec tsc --noEmit
+git add apps/api/src/services/softwarePolicyInstallRemediation.ts apps/api/src/services/softwarePolicyInstallRemediation.test.ts
+git commit -m "feat(software): deployment-row dedup + policy-owned deployment creation — #5505 W03
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01ANjBwca2cfsLWDLJro3fkz"
+```
+
+---
+
+### Task 6: `processRemediateDeviceInstall` in the remediation worker
+
+**Files:**
+- Modify: `apps/api/src/jobs/softwareRemediationWorker.ts` (new function after `processRemediateDevice` ends at `:599`; new imports)
+- Test: `apps/api/src/jobs/softwareRemediationWorker.test.ts`
+
+**Interfaces:**
+- Consumes:
+  - **W01:** `evaluateSoftwarePolicyArming(policy, 'install')`, the D6 audit-action constants (`install_queued`, `install_failed` members), `SoftwarePolicyViolation['rule'].catalogId`.
+  - **W02:** `RemediateDeviceInstallJobData` (`type: 'remediate-device-install'`, `{ policyId, deviceId }`), `softwareComplianceStatus.installRemediationStatus`, `.lastInstallRemediationAttempt`.
+  - **W03 Tasks 4-5:** `resolvePolicyInstallTarget`, `hasUnfinishedPolicyOwnedInstall`, `createPolicyOwnedInstallDeployment`, `PolicyInstallSkipReason`.
+  - existing in-file: `db`, `fireAudit`, `recordSoftwareRemediationDecision`, `devices`, `softwareComplianceStatus`, `softwarePolicies`.
+- Produces: `processRemediateDeviceInstall(data): Promise<{ policyId; deviceId; deploymentsCreated: number; skipped: number; errors: number }>` — exported for tests and used by Task 7's switch.
+
+**Decision the contract left open, recorded here.** The dedup gate is evaluated **once, at the top of the job**. If it is clean, this pass creates **one deployment per distinct resolvable missing rule** — not one deployment total. Rationale: a `software_deployments` row carries exactly one target (the XOR CHECK), so N missing apps require N rows no matter when they are created; creating them together lets a device converge in one 15-minute cycle instead of N, while the top-of-job gate still guarantees the *next* pass queues nothing until this batch finishes. The per-device blast radius is bounded by the policy's own rule count, and the per-policy fleet blast radius is bounded by W02's per-pass cap.
+
+- [ ] **Step 1: Confirm the W01/W02 names have landed**
+
+```bash
+cd /Users/toddhebebrand/.herdr/worktrees/breeze/warranty-testing
+grep -n "remediate-device-install" apps/api/src/jobs/softwareRemediationWorker.ts
+grep -n "installRemediationStatus\|lastInstallRemediationAttempt" apps/api/src/db/schema/softwarePolicies.ts
+grep -n "install_queued" apps/api/src/services/softwarePolicyService.ts
+grep -n "verb" apps/api/src/services/softwarePolicyService.ts | head -5
+```
+
+All four must return hits. Substitute the real identifiers into every snippet below; do not invent them and do not fall back to string literals for the audit actions.
+
+- [ ] **Step 2: Write the failing tests**
+
+Append to `apps/api/src/jobs/softwareRemediationWorker.test.ts`. Extend the existing `vi.mock('../services/softwarePolicyService', …)` at `:41-49` to also re-export W01's audit-action constants (keep `evaluateSoftwarePolicyArming` REAL), and add a mock for the new service module:
+
+```ts
+const { resolveTargetMock, hasUnfinishedMock, createPolicyDeploymentMock } = vi.hoisted(() => ({
+  resolveTargetMock: vi.fn(),
+  hasUnfinishedMock: vi.fn(async () => false),
+  createPolicyDeploymentMock: vi.fn(async () => ({ deploymentId: 'dep-1', status: 'pending' as const })),
+}));
+vi.mock('../services/softwarePolicyInstallRemediation', () => ({
+  resolvePolicyInstallTarget: resolveTargetMock,
+  hasUnfinishedPolicyOwnedInstall: hasUnfinishedMock,
+  createPolicyOwnedInstallDeployment: createPolicyDeploymentMock,
+}));
+```
+
+then the cases:
+
+```ts
+import { processRemediateDeviceInstall } from './softwareRemediationWorker';
+
+const INSTALL_ARMED = { enforceMode: true, remediationOptions: { autoUninstall: false, autoInstall: true } };
+
+const MISSING_COMPLIANCE = {
+  id: 'cs-1',
+  policyId: POLICY_ID,
+  deviceId: DEVICE_ID,
+  lastRemediationAttempt: null,
+  violations: [{ type: 'missing', rule: { name: 'Chrome', catalogId: 'cat-1' }, severity: 'high' }],
+  remediationStatus: 'none',
+};
+
+/** db.select() order for the install processor: policy -> device -> compliance. */
+function primeInstallDb(policy: unknown, compliance: unknown = MISSING_COMPLIANCE) {
+  const results = [[policy], [{ orgId: ORG_ID, osType: 'windows', isEphemeral: false }], [compliance]];
+  let call = 0;
+  selectMock.mockImplementation(() => chain(results[Math.min(call++, results.length - 1)]));
+  setSpy = vi.fn(() => chain([]));
+  updateMock.mockImplementation(() => ({ set: setSpy }));
+}
+
+describe('processRemediateDeviceInstall — #5505 W03', () => {
+  beforeEach(() => {
+    hasUnfinishedMock.mockResolvedValue(false);
+    resolveTargetMock.mockResolvedValue({
+      ok: true,
+      target: { kind: 'install_method', catalogId: 'cat-1', installMethodId: 'im-1' },
+    });
+    createPolicyDeploymentMock.mockResolvedValue({ deploymentId: 'dep-1', status: 'pending' });
+  });
+
+  it('creates a policy-owned deployment for an armed policy and a missing violation', async () => {
+    primeInstallDb(policyRow({ mode: 'allowlist', ...INSTALL_ARMED }));
+
+    const result = await processRemediateDeviceInstall({
+      type: 'remediate-device-install',
+      policyId: POLICY_ID,
+      deviceId: DEVICE_ID,
+    });
+
+    expect(result.deploymentsCreated).toBe(1);
+    expect(createPolicyDeploymentMock).toHaveBeenCalledWith(
+      expect.objectContaining({ policyId: POLICY_ID, deviceId: DEVICE_ID, orgId: ORG_ID }),
+    );
+    expect(policyAuditActions()).toContain('install_queued');
+  });
+
+  it('refuses a policy that is armed for uninstall but NOT for install', async () => {
+    primeInstallDb(policyRow({ mode: 'allowlist', enforceMode: true, remediationOptions: { autoUninstall: true } }));
+
+    const result = await processRemediateDeviceInstall({
+      type: 'remediate-device-install',
+      policyId: POLICY_ID,
+      deviceId: DEVICE_ID,
+    });
+
+    expect(result.deploymentsCreated).toBe(0);
+    expect(createPolicyDeploymentMock).not.toHaveBeenCalled();
+    expect(policyAuditActions()).toContain('remediation_skipped_unarmed');
+    // The refusal must land on the INSTALL column, never on the uninstall one —
+    // a shared column would make a refused install look like a refused uninstall.
+    const written = setSpy.mock.calls[0]![0];
+    expect(written.installRemediationStatus).toBe('failed');
+    expect(written.remediationStatus).toBeUndefined();
+  });
+
+  it('records skipped, not failed, for a rule with no catalogId', async () => {
+    resolveTargetMock.mockResolvedValue({ ok: false, reason: 'no_catalog_id' });
+    primeInstallDb(policyRow({ mode: 'allowlist', ...INSTALL_ARMED }), {
+      ...MISSING_COMPLIANCE,
+      violations: [{ type: 'missing', rule: { name: 'Chrome' }, severity: 'high' }],
+    });
+
+    const result = await processRemediateDeviceInstall({
+      type: 'remediate-device-install',
+      policyId: POLICY_ID,
+      deviceId: DEVICE_ID,
+    });
+
+    expect(result.deploymentsCreated).toBe(0);
+    expect(result.skipped).toBe(1);
+    const written = setSpy.mock.calls.at(-1)![0];
+    expect(written.installRemediationStatus).toBe('skipped');
+    // "Never fail silently": the reason has to be greppable in the audit trail.
+    const audit = recordPolicyAuditMock.mock.calls.at(-1)![0] as any;
+    expect(JSON.stringify(audit.details)).toContain('no_catalog_id');
+  });
+
+  it('skips a platform mismatch instead of creating a guaranteed-failing deployment', async () => {
+    resolveTargetMock.mockResolvedValue({ ok: false, reason: 'no_install_target_for_platform' });
+    primeInstallDb(policyRow({ mode: 'allowlist', ...INSTALL_ARMED }));
+
+    const result = await processRemediateDeviceInstall({
+      type: 'remediate-device-install',
+      policyId: POLICY_ID,
+      deviceId: DEVICE_ID,
+    });
+
+    expect(createPolicyDeploymentMock).not.toHaveBeenCalled();
+    expect(result.skipped).toBe(1);
+    expect(setSpy.mock.calls.at(-1)![0].installRemediationStatus).toBe('skipped');
+  });
+
+  it('does not queue a second deployment while one is unfinished', async () => {
+    hasUnfinishedMock.mockResolvedValue(true);
+    primeInstallDb(policyRow({ mode: 'allowlist', ...INSTALL_ARMED }));
+
+    const result = await processRemediateDeviceInstall({
+      type: 'remediate-device-install',
+      policyId: POLICY_ID,
+      deviceId: DEVICE_ID,
+    });
+
+    expect(result.deploymentsCreated).toBe(0);
+    expect(createPolicyDeploymentMock).not.toHaveBeenCalled();
+    expect(recordDecisionMock).toHaveBeenCalledWith('command_deduped');
+  });
+
+  it('never installs onto an ephemeral Quick Support device', async () => {
+    const results = [
+      [policyRow({ mode: 'allowlist', ...INSTALL_ARMED })],
+      [{ orgId: ORG_ID, osType: 'windows', isEphemeral: true }],
+    ];
+    let call = 0;
+    selectMock.mockImplementation(() => chain(results[Math.min(call++, results.length - 1)]));
+
+    const result = await processRemediateDeviceInstall({
+      type: 'remediate-device-install',
+      policyId: POLICY_ID,
+      deviceId: DEVICE_ID,
+    });
+
+    expect(result.deploymentsCreated).toBe(0);
+    expect(createPolicyDeploymentMock).not.toHaveBeenCalled();
+  });
+
+  it('deduplicates two rules that name the same catalogId into one deployment', async () => {
+    primeInstallDb(policyRow({ mode: 'allowlist', ...INSTALL_ARMED }), {
+      ...MISSING_COMPLIANCE,
+      violations: [
+        { type: 'missing', rule: { name: 'Chrome', catalogId: 'cat-1' }, severity: 'high' },
+        { type: 'missing', rule: { name: 'Chrome (alias)', catalogId: 'cat-1' }, severity: 'high' },
+      ],
+    });
+
+    const result = await processRemediateDeviceInstall({
+      type: 'remediate-device-install',
+      policyId: POLICY_ID,
+      deviceId: DEVICE_ID,
+    });
+
+    expect(result.deploymentsCreated).toBe(1);
+    expect(createPolicyDeploymentMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores unauthorized violations entirely — the install verb never uninstalls', async () => {
+    primeInstallDb(policyRow({ mode: 'allowlist', ...INSTALL_ARMED }), {
+      ...MISSING_COMPLIANCE,
+      violations: [{ type: 'unauthorized', software: { name: 'Unwanted App', version: '1.0' } }],
+    });
+
+    const result = await processRemediateDeviceInstall({
+      type: 'remediate-device-install',
+      policyId: POLICY_ID,
+      deviceId: DEVICE_ID,
+    });
+
+    expect(result.deploymentsCreated).toBe(0);
+    expect(queueCommandMock).not.toHaveBeenCalled();
+    expect(createPolicyDeploymentMock).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 3: Run and watch it fail**
+
+```bash
+cd apps/api && npx vitest run src/jobs/softwareRemediationWorker.test.ts -t "processRemediateDeviceInstall"
+```
+
+Expected: FAIL — `processRemediateDeviceInstall` is not exported from `./softwareRemediationWorker`.
+
+- [ ] **Step 4: Implement**
+
+Extend the imports at the top of `apps/api/src/jobs/softwareRemediationWorker.ts`:
+
+```ts
+import {
+  evaluateSoftwarePolicyArming,
+  recordSoftwarePolicyAudit,
+  SOFTWARE_POLICY_INSTALL_AUDIT_ACTIONS,   // W01's D6 constants — use the landed name
+} from '../services/softwarePolicyService';
+import {
+  createPolicyOwnedInstallDeployment,
+  hasUnfinishedPolicyOwnedInstall,
+  resolvePolicyInstallTarget,
+  type PolicyInstallSkipReason,
+  type PolicyInstallTarget,
+} from '../services/softwarePolicyInstallRemediation';
+```
+
+Then append after `processRemediateDevice` ends at `:599`:
+
+```ts
+/**
+ * #5505 W03 — turn one enqueued install-remediation job into policy-owned
+ * software_deployments rows.
+ *
+ * Deliberately a SEPARATE function from processRemediateDevice rather than a
+ * branch inside it: the uninstall path carries the #3553 manual-authorization
+ * machinery (single-use token consume, ownership TOCTOU lock, manual override
+ * of the arming gate) and none of it applies to install remediation, which has
+ * no manual route in this feature. Every install job is therefore `auto` and
+ * unconditionally gated — there is no override to reach.
+ *
+ * The arming re-check here is the same defence-in-depth as #3543 for uninstall
+ * (incident #3381, 259 devices mass-uninstalled by a stale job): this worker is
+ * the last hop before real software lands on a customer machine, so a policy
+ * disarmed AFTER its job was enqueued, or a replayed/hand-enqueued job, must
+ * not install anything.
+ *
+ * Exported for tests.
+ */
+export async function processRemediateDeviceInstall(
+  data: RemediateDeviceInstallJobData,
+): Promise<{
+  policyId: string;
+  deviceId: string;
+  deploymentsCreated: number;
+  skipped: number;
+  errors: number;
+}> {
+  const nothing = {
+    policyId: data.policyId,
+    deviceId: data.deviceId,
+    deploymentsCreated: 0,
+    skipped: 0,
+    errors: 0,
+  };
+
+  const [policy] = await db
+    .select({
+      id: softwarePolicies.id,
+      orgId: softwarePolicies.orgId,
+      partnerId: softwarePolicies.partnerId,
+      name: softwarePolicies.name,
+      isActive: softwarePolicies.isActive,
+      mode: softwarePolicies.mode,
+      enforceMode: softwarePolicies.enforceMode,
+      remediationOptions: softwarePolicies.remediationOptions,
+    })
+    .from(softwarePolicies)
+    .where(eq(softwarePolicies.id, data.policyId))
+    .limit(1);
+
+  if (!policy || !policy.isActive) {
+    console.warn('[SoftwareRemediationWorker] Policy not found or inactive, skipping install remediation', {
+      policyId: data.policyId,
+      deviceId: data.deviceId,
+    });
+    return nothing;
+  }
+
+  // FOR UPDATE mirrors the uninstall path (:243-248): it pins this device row
+  // for the worker's system transaction so a concurrent org move cannot land
+  // between reading the device's org and creating a deployment under it.
+  const [deviceRow] = await db
+    .select({ orgId: devices.orgId, osType: devices.osType, isEphemeral: devices.isEphemeral })
+    .from(devices)
+    .where(eq(devices.id, data.deviceId))
+    .limit(1)
+    .for('update');
+
+  // Quick Support exclusion: an ephemeral device is a stranger's personal
+  // machine borrowed for one ~20-minute session. Installing software on it
+  // would be strictly worse than the uninstall this same guard already blocks.
+  if (!deviceRow || deviceRow.isEphemeral) {
+    return nothing;
+  }
+
+  // Dual-owner audit (#2126): a per-device event under a partner-wide policy
+  // (policy.orgId NULL) must carry the DEVICE's org so the org admin sees it.
+  const auditOrgId = policy.orgId ?? deviceRow.orgId ?? null;
+
+  const [compliance] = await db
+    .select()
+    .from(softwareComplianceStatus)
+    .where(and(
+      eq(softwareComplianceStatus.policyId, data.policyId),
+      eq(softwareComplianceStatus.deviceId, data.deviceId),
+    ))
+    .limit(1);
+
+  if (!compliance) {
+    console.warn('[SoftwareRemediationWorker] Compliance record not found for install remediation', {
+      policyId: data.policyId,
+      deviceId: data.deviceId,
+    });
+    return nothing;
+  }
+
+  const arming = evaluateSoftwarePolicyArming(policy, 'install');
+  if (!arming.armed) {
+    console.warn('[SoftwareRemediationWorker] Policy is not armed for install, skipping remediation', {
+      policyId: policy.id,
+      deviceId: data.deviceId,
+      reason: arming.reason,
+    });
+    fireAudit({
+      orgId: auditOrgId,
+      partnerId: policy.partnerId,
+      policyId: policy.id,
+      deviceId: data.deviceId,
+      action: 'remediation_skipped_unarmed',
+      actor: 'system',
+      details: {
+        policyName: policy.name,
+        verb: 'install',
+        reason: arming.reason,
+        mode: policy.mode,
+        enforceMode: policy.enforceMode,
+      },
+    });
+    recordSoftwareRemediationDecision('policy_not_armed');
+    // The INSTALL column only. Writing remediationStatus here would make a
+    // refused install indistinguishable from a refused uninstall — the exact
+    // ambiguity D1's separate columns exist to prevent.
+    await db
+      .update(softwareComplianceStatus)
+      .set({ installRemediationStatus: 'failed' })
+      .where(eq(softwareComplianceStatus.id, compliance.id))
+      .catch((err: unknown) => {
+        console.error('[SoftwareRemediationWorker] Failed to record refused install status:', err);
+        captureException(err);
+      });
+    return nothing;
+  }
+
+  const now = new Date();
+
+  // Dedup gate, evaluated ONCE per job: unfinished policy-owned work for this
+  // (policy, device) means queue nothing at all this pass. Checked before the
+  // in_progress write so a deduped pass does not churn the status column.
+  if (await hasUnfinishedPolicyOwnedInstall(policy.id, data.deviceId)) {
+    recordSoftwareRemediationDecision('command_deduped');
+    await db
+      .update(softwareComplianceStatus)
+      .set({ installRemediationStatus: 'pending', lastInstallRemediationAttempt: now })
+      .where(eq(softwareComplianceStatus.id, compliance.id));
+    return nothing;
+  }
+
+  await db
+    .update(softwareComplianceStatus)
+    .set({ installRemediationStatus: 'in_progress', lastInstallRemediationAttempt: now })
+    .where(eq(softwareComplianceStatus.id, compliance.id));
+
+  try {
+    // Only 'missing' violations, deduplicated by catalogId: two rules may name
+    // the same catalog item, and installing it twice is never right.
+    const rawViolations = Array.isArray(compliance.violations) ? compliance.violations : [];
+    const missingRules: Array<{ ruleName: string; catalogId: string | undefined }> = [];
+    const seenCatalogIds = new Set<string>();
+    let rulesWithoutCatalogId = 0;
+    for (const violation of rawViolations) {
+      if (!violation || typeof violation !== 'object') continue;
+      const typed = violation as {
+        type?: string;
+        rule?: { name?: string; catalogId?: string };
+      };
+      if (typed.type !== 'missing') continue;
+      const catalogId = typeof typed.rule?.catalogId === 'string' ? typed.rule.catalogId : undefined;
+      if (!catalogId) {
+        // Detectable but not installable. Counted, never dropped silently.
+        rulesWithoutCatalogId += 1;
+        missingRules.push({ ruleName: typed.rule?.name ?? '(unnamed rule)', catalogId: undefined });
+        continue;
+      }
+      if (seenCatalogIds.has(catalogId)) continue;
+      seenCatalogIds.add(catalogId);
+      missingRules.push({ ruleName: typed.rule?.name ?? '(unnamed rule)', catalogId });
+    }
+    void rulesWithoutCatalogId;
+
+    if (missingRules.length === 0) {
+      await db
+        .update(softwareComplianceStatus)
+        .set({ installRemediationStatus: 'completed', lastInstallRemediationAttempt: now })
+        .where(eq(softwareComplianceStatus.id, compliance.id));
+      recordSoftwareRemediationDecision('no_violations');
+      return nothing;
+    }
+
+    const skips: Array<{ rule: string; reason: PolicyInstallSkipReason }> = [];
+    const targets: Array<{ rule: string; target: PolicyInstallTarget }> = [];
+    for (const rule of missingRules) {
+      const resolution = await resolvePolicyInstallTarget({
+        catalogId: rule.catalogId,
+        deviceOrgId: deviceRow.orgId,
+        deviceOsType: deviceRow.osType,
+      });
+      if (resolution.ok) {
+        targets.push({ rule: rule.ruleName, target: resolution.target });
+      } else {
+        skips.push({ rule: rule.ruleName, reason: resolution.reason });
+      }
+    }
+
+    const errors: Array<{ rule: string; message: string }> = [];
+    const deploymentIds: string[] = [];
+    for (const entry of targets) {
+      try {
+        const created = await createPolicyOwnedInstallDeployment({
+          policyId: policy.id,
+          policyName: policy.name,
+          // The DEVICE's org, never the policy's — a partner-wide policy has none.
+          orgId: deviceRow.orgId,
+          deviceId: data.deviceId,
+          target: entry.target,
+        });
+        deploymentIds.push(created.deploymentId);
+        recordSoftwareRemediationDecision('command_queued');
+      } catch (error) {
+        errors.push({
+          rule: entry.rule,
+          message: error instanceof Error ? error.message : 'Failed to create install deployment',
+        });
+        recordSoftwareRemediationDecision('command_failed');
+      }
+    }
+
+    const installRemediationStatus = (() => {
+      if (deploymentIds.length > 0) return 'pending';
+      if (errors.length > 0) return 'failed';
+      return 'skipped';
+    })();
+
+    await db
+      .update(softwareComplianceStatus)
+      .set({ installRemediationStatus, lastInstallRemediationAttempt: now })
+      .where(eq(softwareComplianceStatus.id, compliance.id));
+
+    fireAudit({
+      orgId: auditOrgId,
+      partnerId: policy.partnerId,
+      policyId: policy.id,
+      deviceId: data.deviceId,
+      action: errors.length > 0 && deploymentIds.length === 0
+        ? SOFTWARE_POLICY_INSTALL_AUDIT_ACTIONS.failed
+        : SOFTWARE_POLICY_INSTALL_AUDIT_ACTIONS.queued,
+      actor: 'system',
+      details: {
+        policyName: policy.name,
+        missingViolations: missingRules.length,
+        deploymentsCreated: deploymentIds.length,
+        deploymentIds,
+        // "Skip it and say so": there is no install-errors jsonb column
+        // (D1 ships only status/timestamp/attempts), so the audit row is the
+        // only durable place a technician can read WHY a rule was skipped.
+        skipped: skips,
+        errors,
+      },
+    });
+
+    return {
+      policyId: data.policyId,
+      deviceId: data.deviceId,
+      deploymentsCreated: deploymentIds.length,
+      skipped: skips.length,
+      errors: errors.length,
+    };
+  } catch (error) {
+    console.error(
+      `[SoftwareRemediationWorker] Unhandled install-remediation error for device ${data.deviceId}, policy ${data.policyId}:`,
+      error,
+    );
+    await db
+      .update(softwareComplianceStatus)
+      .set({ installRemediationStatus: 'failed' })
+      .where(eq(softwareComplianceStatus.id, compliance.id))
+      .catch((resetErr: unknown) => {
+        console.error('[SoftwareRemediationWorker] Failed to reset installRemediationStatus to failed:', resetErr);
+      });
+    throw error;
+  }
+}
+```
+
+Remove the `void rulesWithoutCatalogId;` line and the local counter if the linter flags it — the `no_catalog_id` reason already reaches the audit through `skips`; the counter exists only if a reviewer wants it in `details`. Prefer deleting both.
+
+- [ ] **Step 5: Run and watch it pass**
+
+```bash
+cd apps/api && npx vitest run src/jobs/softwareRemediationWorker.test.ts
+```
+
+Expected: PASS, including every pre-existing `#3543`/`#3553` uninstall case unchanged. If any uninstall case broke, the install path leaked into it — revert and isolate.
+
+- [ ] **Step 6: Typecheck, lint, commit**
+
+```bash
+pnpm --filter @breeze/api exec tsc --noEmit
+pnpm lint
+git add apps/api/src/jobs/softwareRemediationWorker.ts apps/api/src/jobs/softwareRemediationWorker.test.ts
+git commit -m "feat(software): policy-owned install remediation in the remediation worker — #5505 W03
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01ANjBwca2cfsLWDLJro3fkz"
+```
+
+---
+
+### Task 7: Route the install job type through the BullMQ processor
+
+**Files:**
+- Modify: `apps/api/src/jobs/softwareRemediationWorker.ts:74` (the `SoftwareRemediationJobData` alias) and `:601-620` (`createSoftwareRemediationWorker`)
+- Test: `apps/api/src/jobs/softwareRemediationWorker.test.ts`
+
+**Interfaces:**
+- Consumes: W02's `RemediateDeviceInstallJobData`; Task 6's `processRemediateDeviceInstall`.
+- Produces: nothing importable. It is the wiring that makes an enqueued install job actually run.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { createSoftwareRemediationWorker } from './softwareRemediationWorker';
+
+describe('createSoftwareRemediationWorker — job-type routing (#5505 W03)', () => {
+  it('routes remediate-device-install to the install processor and leaves uninstall alone', async () => {
+    // The bullmq mock at the top of this file replaces Worker with a class that
+    // ignores its processor, so capture the processor argument directly.
+    const captured: Array<(job: any) => Promise<unknown>> = [];
+    const bullmq = await import('bullmq');
+    const OriginalWorker = bullmq.Worker as any;
+    (bullmq as any).Worker = class {
+      constructor(_name: string, processor: (job: any) => Promise<unknown>) {
+        captured.push(processor);
+      }
+      on = vi.fn();
+      close = vi.fn();
+    };
+
+    createSoftwareRemediationWorker();
+    (bullmq as any).Worker = OriginalWorker;
+
+    const processor = captured[0]!;
+    primeInstallDb(policyRow({ mode: 'allowlist', ...INSTALL_ARMED }));
+    const installResult: any = await processor({
+      data: { type: 'remediate-device-install', policyId: POLICY_ID, deviceId: DEVICE_ID },
+    });
+    expect(installResult).toHaveProperty('deploymentsCreated');
+
+    primeDb(policyRow({ enforceMode: false }));
+    const uninstallResult: any = await processor({
+      data: { type: 'remediate-device', policyId: POLICY_ID, deviceId: DEVICE_ID },
+    });
+    expect(uninstallResult).toHaveProperty('commandsQueued');
+    expect(uninstallResult).not.toHaveProperty('deploymentsCreated');
+  });
+});
+```
+
+- [ ] **Step 2: Run and watch it fail**
+
+```bash
+cd apps/api && npx vitest run src/jobs/softwareRemediationWorker.test.ts -t "job-type routing"
+```
+
+Expected: FAIL — the processor returns a `commandsQueued` shape for the install job, because everything currently falls through to `processRemediateDevice`.
+
+- [ ] **Step 3: Implement**
+
+At `:74`, widen the alias — **only if W02 has not already done so**; check first, and if the union already contains the install member, leave the line untouched:
+
+```ts
+type SoftwareRemediationJobData = RemediateDeviceJobData | RemediateDeviceInstallJobData;
+```
+
+Then replace the processor body at `:605-607`:
+
+```ts
+      return runWithSystemDbAccess(async () => {
+        // #5505 W03: the two verbs are separate processors. Discriminating on
+        // job.data.type keeps the uninstall path (and its #3553 manual-
+        // authorization machinery) byte-identical.
+        if (job.data.type === 'remediate-device-install') {
+          return processRemediateDeviceInstall(job.data);
+        }
+        return processRemediateDevice(job.data);
+      });
+```
+
+- [ ] **Step 4: Run and watch it pass**
+
+```bash
+cd apps/api && npx vitest run src/jobs/softwareRemediationWorker.test.ts
+```
+
+Expected: PASS, whole file.
+
+- [ ] **Step 5: Typecheck and commit**
+
+```bash
+pnpm --filter @breeze/api exec tsc --noEmit
+git add apps/api/src/jobs/softwareRemediationWorker.ts apps/api/src/jobs/softwareRemediationWorker.test.ts
+git commit -m "feat(software): route remediate-device-install jobs to the install processor — #5505 W03
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01ANjBwca2cfsLWDLJro3fkz"
+```
+
+---
+
+### Task 8: Live-Postgres contract coverage and the two blocking integration suites
+
+**Files:**
+- Modify: `apps/api/src/__tests__/integration/softwareInstallMethods.integration.test.ts`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-7, plus `cascadeDeleteOrg` / `cascadeDeletePartner` (already imported by this file) and `createOrganization` / `createPartner` / `createSite` from `./db-utils`.
+- Produces: nothing importable. This is the wave's proof.
+
+**Why this file and not a new one.** `softwareInstallMethods.integration.test.ts` already owns the live-Postgres contract for the whole catalog → version → install-method → deployment → deployment_result chain, including case 8 ("ORG ERASURE of the whole software chain") and the `software_deployments_one_target_chk` case. The new FK belongs beside them, and `vitest.integration.config.ts:11`'s standing `src/__tests__/integration/**` glob means no config edit either way.
+
+- [ ] **Step 1: Bring up the integration database**
+
+```bash
+cd apps/api && pnpm test:docker:up
+```
+
+`src/__tests__/integration/setup.ts` defaults `DATABASE_URL`/`DATABASE_URL_APP` to `postgresql://breeze_test:breeze_test@localhost:5433/breeze_test`, which `docker-compose.test.yml` provisions — no override needed. `assertTestDatabaseUrlSafe` refuses any URL on port 5432 or with a non-`breeze_test*` database name, so do not point this at the dev DB.
+
+- [ ] **Step 2: Write the failing tests**
+
+Append to `apps/api/src/__tests__/integration/softwareInstallMethods.integration.test.ts`, reusing its existing `orgCtx`, `expectPgCode`, `seedCatalog`, `seedMethod` helpers:
+
+```ts
+describe('software_deployments.software_policy_id — policy origin (#5505 W03)', () => {
+  async function seedDevice(orgId: string, siteId: string, osType: 'windows' | 'macos' = 'windows') {
+    const [device] = await getTestDb()
+      .insert(devices)
+      .values({
+        orgId,
+        siteId,
+        agentId: `w03-agent-${crypto.randomUUID()}`,
+        hostname: 'w03-host',
+        osType,
+        osVersion: '11',
+        architecture: 'amd64',
+        agentVersion: '1.0.0',
+      })
+      .returning();
+    if (!device) throw new Error('failed to seed device');
+    return device;
+  }
+
+  async function seedPolicy(owner: { orgId?: string; partnerId?: string }, catalogId: string) {
+    const [policy] = await getTestDb()
+      .insert(softwarePolicies)
+      .values({
+        orgId: owner.orgId ?? null,
+        partnerId: owner.partnerId ?? null,
+        name: 'Standard workstation build',
+        mode: 'allowlist',
+        rules: { software: [{ name: 'Chrome', catalogId }] },
+        enforceMode: true,
+        remediationOptions: { autoInstall: true },
+      })
+      .returning();
+    if (!policy) throw new Error('failed to seed policy');
+    return policy;
+  }
+
+  it('the FK is ON DELETE SET NULL: deleting the policy nulls the column and keeps the deployment', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const catalog = await seedCatalog(org.id);
+    const method = await seedMethod(catalog.id, 'windows', 'winget', 'Google.Chrome');
+    // A PARTNER-WIDE policy: this is the case array ordering does not cover,
+    // because such a policy is referenced from every child org.
+    const policy = await seedPolicy({ partnerId: partner.id }, catalog.id);
+
+    const [deployment] = await getTestDb()
+      .insert(softwareDeployments)
+      .values({
+        orgId: org.id,
+        name: 'Policy: Standard workstation build',
+        installMethodId: method.id,
+        deploymentType: 'install',
+        targetType: 'devices',
+        scheduleType: 'immediate',
+        softwarePolicyId: policy.id,
+      })
+      .returning();
+    expect(deployment!.softwarePolicyId).toBe(policy.id);
+
+    await getTestDb().delete(softwarePolicies).where(eq(softwarePolicies.id, policy.id));
+
+    const [after] = await getTestDb()
+      .select()
+      .from(softwareDeployments)
+      .where(eq(softwareDeployments.id, deployment!.id));
+    // Survived, with the label degraded rather than the delete aborting.
+    expect(after).toBeDefined();
+    expect(after!.softwarePolicyId).toBeNull();
+  });
+
+  it('org erasure still completes with a policy-owned deployment present', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const site = await createSite({ orgId: org.id });
+    const catalog = await seedCatalog(org.id);
+    const method = await seedMethod(catalog.id, 'windows', 'winget', 'Google.Chrome');
+    const policy = await seedPolicy({ partnerId: partner.id }, catalog.id);
+    const device = await seedDevice(org.id, site.id);
+
+    const [deployment] = await getTestDb()
+      .insert(softwareDeployments)
+      .values({
+        orgId: org.id,
+        name: 'Policy: Standard workstation build',
+        installMethodId: method.id,
+        deploymentType: 'install',
+        targetType: 'devices',
+        scheduleType: 'immediate',
+        softwarePolicyId: policy.id,
+      })
+      .returning();
+    await getTestDb()
+      .insert(deploymentResults)
+      .values({ deploymentId: deployment!.id, deviceId: device.id, status: 'pending' });
+
+    // Must not raise 23503. This is the contract that has caught this class of
+    // mistake 5/5 times while code review caught it 0/5.
+    await expect(
+      cascadeDeleteOrg(org.id, { performedBy: PERFORMED_BY, performedByEmail: PERFORMED_EMAIL }),
+    ).resolves.toBeDefined();
+
+    const remaining = await getTestDb()
+      .select()
+      .from(softwareDeployments)
+      .where(eq(softwareDeployments.id, deployment!.id));
+    expect(remaining).toHaveLength(0);
+  });
+
+  it('a policy rule naming ANOTHER org\'s catalog item resolves to nothing', async () => {
+    const partner = await createPartner();
+    const orgA = await createOrganization({ partnerId: partner.id });
+    const orgB = await createOrganization({ partnerId: partner.id });
+    const catalogB = await seedCatalog(orgB.id, 'B Chrome');
+    await seedMethod(catalogB.id, 'windows', 'winget', 'Google.Chrome');
+
+    // The worker runs in a SYSTEM context where RLS scopes nothing, so this is
+    // the only thing standing between a forged catalogId and org B's package
+    // landing on org A's machines.
+    const resolution = await resolvePolicyInstallTarget({
+      catalogId: catalogB.id,
+      deviceOrgId: orgA.id,
+      deviceOsType: 'windows',
+    });
+    expect(resolution).toEqual({ ok: false, reason: 'catalog_item_not_reachable' });
+  });
+
+  it('a partner-owned catalog item IS reachable from a child org of that partner', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const [catalog] = await getTestDb()
+      .insert(softwareCatalog)
+      .values({ orgId: null, partnerId: partner.id, name: 'Partner-wide App' })
+      .returning();
+    await seedMethod(catalog!.id, 'windows', 'winget', 'Partner.App');
+
+    const resolution = await resolvePolicyInstallTarget({
+      catalogId: catalog!.id,
+      deviceOrgId: org.id,
+      deviceOsType: 'windows',
+    });
+    expect(resolution).toMatchObject({ ok: true, target: { kind: 'install_method' } });
+  });
+
+  it('does not create a second policy-owned deployment while one is unfinished', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const site = await createSite({ orgId: org.id });
+    const catalog = await seedCatalog(org.id);
+    const method = await seedMethod(catalog.id, 'windows', 'winget', 'Google.Chrome');
+    const policy = await seedPolicy({ partnerId: partner.id }, catalog.id);
+    const device = await seedDevice(org.id, site.id);
+
+    const [first] = await getTestDb()
+      .insert(softwareDeployments)
+      .values({
+        orgId: org.id,
+        name: 'Policy: Standard workstation build',
+        installMethodId: method.id,
+        deploymentType: 'install',
+        targetType: 'devices',
+        scheduleType: 'immediate',
+        softwarePolicyId: policy.id,
+      })
+      .returning();
+    await getTestDb()
+      .insert(deploymentResults)
+      .values({ deploymentId: first!.id, deviceId: device.id, status: 'installing' });
+
+    await expect(hasUnfinishedPolicyOwnedInstall(policy.id, device.id)).resolves.toBe(true);
+
+    // Once the result reaches a terminal status the gate reopens.
+    await getTestDb()
+      .update(deploymentResults)
+      .set({ status: 'completed' })
+      .where(eq(deploymentResults.deploymentId, first!.id));
+    await expect(hasUnfinishedPolicyOwnedInstall(policy.id, device.id)).resolves.toBe(false);
+  });
+});
+```
+
+Add `softwarePolicies` to the `../../db/schema` import list and
+`import { hasUnfinishedPolicyOwnedInstall, resolvePolicyInstallTarget } from '../../services/softwarePolicyInstallRemediation';`
+at the top of the file.
+
+- [ ] **Step 3: Run and watch them fail**
+
+```bash
+cd apps/api && npx vitest run --config vitest.integration.config.ts src/__tests__/integration/softwareInstallMethods.integration.test.ts
+```
+
+Expected before Tasks 1-5 are applied: FAIL on `column "software_policy_id" does not exist`. If Tasks 1-5 are already committed this run is green — that is fine; the red was observed at Task 1 Step 2 and Task 4 Step 3.
+
+- [ ] **Step 4: Run the two blocking contract suites — the gate this whole task exists for**
+
+```bash
+cd apps/api
+npx vitest run --config vitest.integration.config.ts src/__tests__/integration/tenant-export-policy.integration.test.ts
+npx vitest run --config vitest.integration.config.ts src/__tests__/integration/tenantCascade.integration.test.ts
+npx vitest run --config vitest.integration.config.ts src/__tests__/integration/tenantExportErasureRoundtrip.integration.test.ts
+```
+
+Expected: all three PASS. `tenant-export-policy` is the one that fails on an unclassified `ADD COLUMN` — if Task 3 was skipped, it fails here and nowhere else, and it will fail in **Integration Tests** on the PR. `tenantCascade` asserts alphabetisation with `organizations` last, every `org_id` table present, no non-existent table, each table exactly once, and FK children before parents.
+
+**Do not use `pnpm test:integration -- <path>`** — the `--` makes vitest run the whole integration suite. The `npx vitest run --config … <path>` form above is the one that scopes.
+
+- [ ] **Step 5: Run the full affected unit set**
+
+```bash
+cd apps/api && npx vitest run \
+  src/services/softwarePolicyInstallRemediation.test.ts \
+  src/services/softwareDeployment.test.ts \
+  src/jobs/softwareRemediationWorker.test.ts \
+  src/db/migrationRlsScope.test.ts \
+  src/db/autoMigrate.test.ts \
+  src/config/composeBindMounts.test.ts
+```
+
+Expected: all PASS. Note the paths are listed explicitly rather than as a prefix — vitest's filter is a plain substring match and a trailing slash silently skips sibling `foo.test.ts` files.
+
+- [ ] **Step 6: Verify schema/migration parity and lint**
+
+```bash
+cd /Users/toddhebebrand/.herdr/worktrees/breeze/warranty-testing
+export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze"
+pnpm db:check-drift
+pnpm lint
+pnpm --filter @breeze/api exec tsc --noEmit
+```
+
+`db:check-drift` verifies migration-ledger parity only — it cannot fail on a Drizzle-schema change alone, so a green result here is not evidence the column matches; Step 3's live inserts through the Drizzle table objects are.
+
+- [ ] **Step 7: Merge `main` before trusting any of this**
+
+CI tests the merge commit, not your branch head. A stale base is how a locally-green branch reddens `main`.
+
+```bash
+git fetch origin && git merge origin/main
+cd apps/api && npx vitest run --config vitest.integration.config.ts src/__tests__/integration/tenant-export-policy.integration.test.ts src/__tests__/integration/tenantCascade.integration.test.ts
+```
+
+Re-run Step 4's suites after the merge; if `origin/main` added an org-cascade table or column in the meantime, the export-policy suite will say so.
+
+- [ ] **Step 8: Commit and open the PR**
+
+```bash
+git add apps/api/src/__tests__/integration/softwareInstallMethods.integration.test.ts
+git commit -m "test(software): live-Postgres coverage for policy-owned deployments and the SET NULL origin FK — #5505 W03
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01ANjBwca2cfsLWDLJro3fkz"
+git push -u origin HEAD
+gh pr create --title "feat(software): policy-owned install deployments (#5505 W03)" --body "$(cat <<'EOF'
+Closes #5508
+
+W03 of feature #5505 (desired-state software install). Adds the deployment origin column and turns an enqueued install-remediation job into a real, policy-owned, tenancy-checked, platform-correct, deduped `software_deployments` row.
+
+## What changed
+- Migration `2026-10-15-150401`: `software_deployments.software_policy_id uuid NULL REFERENCES software_policies(id) ON DELETE SET NULL` + index. DDL only, no DML, no `breeze.scope` elevation needed.
+- `CreateSoftwareDeploymentInput.softwarePolicyId?` — stamped by the existing INSERT, never patched afterwards.
+- New `services/softwarePolicyInstallRemediation.ts`: tenancy-checked catalog resolution, platform filtering ahead of dispatch, deployment-row dedup, and the policy-owned creation entry point.
+- New `processRemediateDeviceInstall` in the remediation worker + job-type routing. The uninstall path is untouched.
+
+## Registrations (contract D7)
+- `software_policy_id` added to the `included` bucket of `software_deployments` in `CORE_TENANT_EXPORT_POLICY` — the one registration rule that fires on a new COLUMN.
+- **Cascade: no change needed, and here is why.** `software_deployments` (`tenantCascade.ts:597`) already precedes `software_policies` (`:600`), and the org pre-clear at `:840-852` empties `software_deployments` before the main loop starts, so child-before-parent already holds. Independently, `ON DELETE SET NULL` means the FK cannot raise 23503 at all — which is what covers the case ordering does not: a partner-wide policy referenced by deployments in every child org. Proven live in `softwareInstallMethods.integration.test.ts`.
+- Not a composite `(x, org_id)` FK, so `DEFERRABLE INITIALLY IMMEDIATE` does not apply.
+- `rls-coverage`, `CORE_DEVICE_CASCADE_DELETE_TABLES`, `CORE_DEVICE_ORG_DENORMALIZED_TABLES`: no change (shape 1, no `device_id`).
+
+## Tests run
+- `tenant-export-policy.integration.test.ts`, `tenantCascade.integration.test.ts`, `tenantExportErasureRoundtrip.integration.test.ts` — run explicitly against a live DB, since they only run in the **Integration Tests** job.
+- `softwareInstallMethods.integration.test.ts` extended: SET NULL survival, org erasure with a policy-owned deployment, cross-tenant `catalogId` refusal, partner-owned reachability, dedup open/close.
+- Unit: `softwarePolicyInstallRemediation.test.ts` (new), `softwareDeployment.test.ts`, `softwareRemediationWorker.test.ts`, `migrationRlsScope.test.ts`, `autoMigrate.test.ts`.
+
+## Notable decisions
+- Dedup is checked **once per job**; a clean pass then creates one deployment per distinct resolvable missing rule, so a device converges in one 15-minute cycle while the next pass still queues nothing.
+- "Unfinished" is a closed terminal list (`completed`/`failed`/`cancelled`), so a future `deployment_status` member counts as unfinished and suppresses a duplicate install. A 24h lookback (mirroring `IN_FLIGHT_LOOKBACK_MINUTES`) bounds that.
+- Cross-tenant `catalogId` guard: the worker runs in a system DB context where RLS scopes nothing, and a rule's `catalogId` is operator-authored jsonb — the ownership predicate in `readReachableCatalogItem` is the only thing stopping another tenant's package from installing. Not in the contract; added deliberately.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+https://claude.ai/code/session_01ANjBwca2cfsLWDLJro3fkz
+EOF
+)"
+```
+
+- [ ] **Step 9: Tear the local stacks down**
+
+```bash
+cd apps/api && pnpm test:docker:down
+docker compose ls -a
+```
+
+---
+
+## Self-review
+
+**1. Spec coverage.** Walked the spec's §3, §4 and the corrections section against the wave-ownership map.
+
+| Spec / contract item | Task |
+|---|---|
+| §3 D7 `software_policy_id` column + `ON DELETE SET NULL` | 1 |
+| §3 D7 `softwarePolicyId` on `CreateSoftwareDeploymentInput`, stamped at INSERT | 2 |
+| §3 D7 export-policy registration | 3 |
+| §3 D7 cascade verification (org + partner pre-clears, not array position) | 0 (conclusion), 8 (proof) |
+| §3 D7 "not a composite `(x, org_id)` FK, so no DEFERRABLE" | Global Constraints + Task 1 header comment |
+| §3 "policy remediation creates a real, policy-owned deployment" | 5, 6 |
+| §3 "dedup on the deployment row, not `device_commands`" | 5 (design note), 6 |
+| §4 resolve `catalogId` → install method XOR version | 4 |
+| §4 rule without `catalogId` → skip and say so (`'skipped'`) | 4 (`no_catalog_id`), 6 (status + audit) |
+| §4 platform filter BEFORE creating a deployment | 4, 6 |
+| §5/D6 audit actions from W01's constants, no literals | 6 |
+| "Keep HP/EDR out of it" | Global Constraints + Task 5 comment; no new `integrationProvider` branch anywhere |
+| D8 migration slot + re-check | 1 Steps 1, 6 |
+| Both contract suites run before the PR | 8 Steps 4, 7 |
+| Non-goals (`'outdated'`, replacing deployments, uninstall behaviour) | untouched — no task references any of them |
+
+Out-of-scope items confirmed absent from every task: the arming helper's body, `readSoftwarePolicyAutoInstall`, the compliance worker, the per-pass cap, the attempt counter, the knobs file, any `apps/web` file, any AI file.
+
+**2. Placeholder scan.** No "TBD", no "add error handling", no "similar to Task N", no "write tests for the above". Every code step carries runnable code. The one genuine unknown — W01/W02's exact export names — is handled by a named verification step (Task 4 Step 1, Task 6 Step 1) with the exact `grep` commands and an explicit instruction to stop rather than invent, not by a placeholder.
+
+**3. Type consistency.** Cross-checked every identifier used in a later task against its definition in an earlier one:
+- `PolicyInstallTarget` (Task 4) is consumed by `createPolicyOwnedInstallDeployment` (Task 5) and by `processRemediateDeviceInstall` (Task 6) with the same two-variant shape and the same field names (`kind`, `catalogId`, `installMethodId` / `softwareVersionId`).
+- `PolicyInstallSkipReason`'s three members are the same three strings in Task 4's implementation, Task 4's tests, Task 6's implementation, Task 6's tests and Task 8's integration case (`catalog_item_not_reachable`, not `catalog_item_not_visible` — the earlier draft's name was normalised).
+- `resolvePolicyInstallTarget`'s parameter object is `{ catalogId, deviceOrgId, deviceOsType }` at every call site (Tasks 4, 6, 8).
+- `createPolicyOwnedInstallDeployment`'s input is `{ policyId, policyName, orgId, deviceId, target }` in Task 5's signature, Task 5's test and Task 6's call.
+- `hasUnfinishedPolicyOwnedInstall(policyId, deviceId)` — positional, two strings, in Tasks 5, 6 and 8.
+- `softwarePolicyId` (camel, Drizzle/TS) vs `software_policy_id` (snake, SQL/export registry) are used consistently in their respective layers.
+- `installRemediationStatus` values written by Task 6 (`'in_progress'`, `'pending'`, `'skipped'`, `'failed'`, `'completed'`) are all members of D1's declared union.
+
+**4. Gap found and fixed inline.** The contract does not say what happens when a rule's `catalogId` names a catalog item belonging to a different tenant. Because the remediation worker runs under `withSystemDbAccessContext` (`softwareRemediationWorker.ts:14-22`), RLS scopes nothing there, and `rules` is operator-authored jsonb — so with no explicit predicate this path would install another tenant's uploaded binary. Task 4's `readReachableCatalogItem` is the fail-closed guard, and Task 8 proves it against real Postgres in both directions (another org refused, own partner allowed).

--- a/docs/superpowers/plans/vuln-patch/2026-09-10-desired-state-software-install-w04-ui.md
+++ b/docs/superpowers/plans/vuln-patch/2026-09-10-desired-state-software-install-w04-ui.md
@@ -1,0 +1,2208 @@
+---
+tracking_issue: LanternOps/breeze#5505
+---
+
+# Desired-State Software Install — W04 Web UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a technician arm/disarm `remediationOptions.autoInstall` on a software policy from the web UI, see a blast-radius warning before arming it, see which rules can never be auto-installed because they have no linked catalog item, see which deployments in the deployment list were created by policy remediation rather than a human, and see an honest error (never a silent no-op) when the server refuses to arm install for lack of `devices.execute` or MFA.
+
+**Architecture:** Extend the existing `PolicyForm` (react-hook-form + zod) with a `catalogId` field per rule, an `autoInstall` checkbox gated to allowlist+enforce mode, a client-computed authoring warning, and a best-effort dry-run device-count fetch. Wire `ComplianceDashboard` to fetch the software catalog for the rule-linking picker, extend its local `Policy` type, migrate its policy-save handler (`handleFormSubmit`) to the repo's `runAction` contract so a 403 (`MFA_REQUIRED` or `DEVICES_EXECUTE_REQUIRED`) is never silently swallowed, and surface W02's per-device install-remediation status (including the loop-terminating `'gave_up'` state, per spec Risks §1) in the existing violations list. Add a "Policy-owned" badge to `DeploymentList` keyed off the new `software_policy_id` column that W03 adds to `software_deployments`.
+
+**Tech Stack:** Astro + React Islands, react-hook-form + zod, Vitest + jsdom + Testing Library, i18next (8 locales, strict key parity enforced by `localeParity.test.ts`).
+
+**Spec:** `docs/superpowers/specs/vuln-patch/2026-09-10-desired-state-software-install-design.md` (see especially "Corrections after ground-truth verification"). Cross-wave contract (authoritative over the spec where they disagree): `/private/tmp/claude-501/-Users-toddhebebrand--herdr-worktrees-breeze-warranty-testing/4b860881-d3d0-4020-ad1e-65daf215df86/scratchpad/contract-A-desired-state.md`.
+
+## Global Constraints
+
+- **Web files only.** This wave (W04, sub-issue #5509) may not touch anything under `apps/api`. Every fact below about server behavior is either already shipped (verified in this pass) or an explicit, flagged dependency on another wave — never implemented here.
+- **Depends on W01 (`autoInstall` field + server gate), W03 (`software_policy_id` on `software_deployments`), and W06 (#5522, both halves — the install-preview endpoint AND the widened violations projection).** None of the three has landed as of this writing (`git log` shows only Lenovo-warranty commits on this branch). Code in this plan is written against their documented contracts (below), not against code that exists yet.
+- **W03's column needs no extra API route work for the deployment-list label.** `GET /software/deployments` (`apps/api/src/routes/software.ts:1525` `db.select().from(softwareDeployments)`) is a wildcard select with no column list — once W03 adds `software_policy_id` (camelCase `softwarePolicyId` per Drizzle convention) to the schema, it flows into the JSON response automatically via `...item` at `:1537`. Verified by reading the route; no dependency to flag here.
+- **W06 (#5522) owns both the dry-run device count and the install-status projection.** No route today returns an accurate count of devices a policy's `missing` violations would install to (`GET /software-policies/violations?policyId=X`, `apps/api/src/routes/softwarePolicies.ts:688-733`, returns `{ data: rows, total: rows.length }` capped at `limit` — not a real count, silently undercounts exactly the broad policies spec Risk §2 warns about), and nothing exposes W02's three `software_compliance_status` install-remediation columns over HTTP at all. As of this plan's first draft neither gap was owned by any wave; the coordinator has since filed **W06 (#5522)** to close both, plan at `docs/superpowers/plans/vuln-patch/2026-09-10-desired-state-software-install-w06-install-preview-endpoint.md`. This plan's Task 2 and Task 4 are written against W06's documented contract (verified against that plan doc, not trusted from a summary — see each task's own verify-or-proceed step) and **both degrade gracefully if W06 has not landed when this wave is implemented**:
+  - **W06 Task 2** — `GET /software-policies/:id/install-preview` → `200 { eligibleDeviceCount: number }`. Consumed by Task 2 below. Treated as **advisory only, never a gate**: any non-2xx response (including 404 because the route doesn't exist yet) renders a "preview unavailable" message and the checkbox stays fully usable. Safe because the *actual* blast-radius bound is W02's per-pass cap (`SOFTWARE_INSTALL_REMEDIATION_MAX_PER_PASS`), a backend safety net independent of whether this UI preview exists.
+  - **W06 Task 3** — widens `GET /software-policies/violations`'s existing compliance projection (`apps/api/src/routes/softwarePolicies.ts:481-488`) to add `installRemediationStatus`, `lastInstallRemediationAttempt`, `installRemediationAttempts`. Consumed by Task 4 below. Every render Task 4 adds is gated on `installRemediationStatus` being present and non-`'none'`, so an unlanded W06 means those fields are simply absent from the response and nothing extra renders — the same as today.
+  - Both verify-or-proceed steps (Task 2 Step 1a, Task 4 Step 1) grep the actual landed route file rather than trusting this summary, per the coordinator's instruction, mirroring the "W01/W02-owned identifiers this wave imports" verify-or-stop discipline W03's plan uses for its own upstream dependency — except where W03 must hard-stop (a compile-time import with no real name to import), W04's dependency is a runtime JSON field this plan already codes defensively against absence, so an unlanded W06 means "proceed in degraded mode", not "stop".
+- **The authoring-warning field (`catalogId` per rule) does not exist in the web rule editor today.** `PolicyForm.tsx`'s `softwareRuleSchema` (`:7-13`) has no `catalogId` field, even though the server-side `SoftwarePolicyRuleDefinition.catalogId` has existed since before this feature (spec: `softwarePolicies.ts:28`, contract: `:25-32`). Without adding a way to *set* `catalogId` from the UI, "warn when rules lack `catalogId`" would fire on 100% of existing policies with no way to resolve it. This plan therefore adds a catalog-item picker to each rule row (Task 1) — a necessary, in-scope prerequisite for the warning to be actionable, not scope creep.
+- **`'skipped'` cannot be fully disambiguated from currently-projected data.** W02 collapses three distinct causes (no `catalogId` on the rule, the per-pass cap, or no install method for the device's platform) into one `installRemediationStatus: 'skipped'` value with no persisted sub-reason column. Task 4 gives the one cause reconstructable from already-projected data (no `catalogId` on the device's own `missing` violation) a specific explanation, and hedges honestly on the other two rather than fabricating precision the data doesn't support — flagged as a further gap for the coordinator, same treatment as the dry-run endpoint gap above.
+- **i18n locale parity is enforced by `apps/web/src/lib/i18n/localeParity.test.ts`.** Every leaf key in `en/*.json` must exist with the same type and interpolation tokens in all 7 other locale directories (`de-DE`, `es-419`, `fr-CA`, `fr-FR`, `it-IT`, `pt-BR`, `tr-TR`) or that suite goes red. Each task below adds its new keys to `en/policies.json` only, as part of the same step that references them (so that task's own tests go green immediately using the English string). Task 6 is the single consolidation pass that backfills all 7 other locales and runs `localeParity.test.ts` — **the plan is not done until Task 6 lands**; `localeParity.test.ts` is expected to be red between Task 1 and Task 6, which is normal mid-plan, not a regression to chase.
+- **`no-silent-mutations.test.ts` (`apps/web/src/lib/__tests__/no-silent-mutations.test.ts`) does not currently cover `ComplianceDashboard.tsx`.** It is in neither `TARGET_GLOBS` (the enforced set) nor `RUN_ACTION_ALLOWLIST` nor `RUN_ACTION_MIGRATION_BACKLOG` — an existing gap, not something this plan is required to fully close. Task 3 migrates only `handleFormSubmit` (the handler this feature's authorization requirement touches) to `runAction`; `handleConfirmDelete`, `handleCheckCompliance`, and `handleRemediate` are deliberately left on their current bare-`fetchWithAuth` pattern — out of scope for this wave. Because of that partial state, **do not add `ComplianceDashboard.tsx` to `TARGET_GLOBS`** (the AST guard would then flag the three untouched handlers and fail CI for work this plan didn't do). Task 3 does add the file to `RUN_ACTION_MIGRATION_BACKLOG` with a comment recording the partial migration, per the array's own "migrate opportunistically... move each into TARGET_GLOBS as it's done" philosophy.
+- **`CLAUDE.md` "Web Mutation Handlers — runAction"**: every mutating `fetchWithAuth` call this plan adds or touches must be wrapped in `runAction`, and a 403 must never be silently swallowed. The `ActionError` catch pattern (`if (err instanceof ActionError && err.status === 401) return; if (!(err instanceof ActionError)) showToast(...)`) is used verbatim in Task 3, matching the established sibling pattern in `apps/web/src/components/devices/ManualAssetModal.tsx:199-241`.
+- **`CLAUDE.md` "URL State in Components"**: not applicable — this wave adds no new tabs or selectable list items that need shareable state.
+- **Test commands**: `cd apps/web && npx vitest run <path>`. Never `pnpm --filter <pkg> test -- --run <path>` (the bare `--` makes vitest fall back to watch mode over the whole suite — confirmed repo-wide gotcha). Vitest's path filter is a plain substring match — a trailing `/` silently skips sibling `*.test.tsx` files, so scope test runs to explicit file paths, not directories.
+- **Red-first, every task.** Write the assertion, run it, watch it fail against the unmodified code, then implement.
+
+## File Structure
+
+**Modify:**
+- `apps/web/src/components/software/PolicyForm.tsx` — rule-level `catalogId` picker, `autoInstall` checkbox, authoring warning, dry-run preview block.
+- `apps/web/src/components/software/ComplianceDashboard.tsx` — local `Policy`/`PolicyFormValues`-adjacent types, software-catalog fetch, `handleFormSubmit` payload + `runAction` migration, per-device install-remediation status display.
+- `apps/web/src/components/software/DeploymentList.tsx` — `DeploymentRow.softwarePolicyId` + "Policy-owned" badge.
+- `apps/web/src/lib/runActionAllowlist.ts` — add `ComplianceDashboard.tsx` to `RUN_ACTION_MIGRATION_BACKLOG` (partial-migration note).
+- `apps/web/src/locales/en/policies.json` (+7 non-English locale files in Task 6) — new keys under `policyForm`, `complianceDashboard`, `deploymentList`.
+
+**Create:**
+- `apps/web/src/components/software/PolicyForm.autoInstall.test.tsx` — PolicyForm's first direct unit-test file (today it's exercised only indirectly through `ComplianceDashboard.ownerScope.test.tsx`).
+- `apps/web/src/components/software/ComplianceDashboard.autoInstall.test.tsx`
+- `apps/web/src/components/software/DeploymentList.policyOwned.test.tsx`
+
+## 0. Ground Truth
+
+Quoted verbatim, `path:line`, from the state of the repo at plan-writing time (`fix/lenovo-warranty-provider` branch, worktree `warranty-testing`).
+
+**`apps/web/src/components/software/PolicyForm.tsx`**
+
+```
+7:  const softwareRuleSchema = z.object({
+8:    name: z.string().min(1, "Software name is required").max(500),
+9:    vendor: z.string().max(200).optional().or(z.literal("")),
+10:   minVersion: z.string().max(100).optional().or(z.literal("")),
+11:   maxVersion: z.string().max(100).optional().or(z.literal("")),
+12:   reason: z.string().max(1000).optional().or(z.literal("")),
+13: });
+```
+No `catalogId`. Also no `autoInstall` in `policyFormSchema` (`:14-28`), which has `autoUninstall: z.boolean().optional()` (`:26`) but nothing else install-related.
+
+```
+32: type PolicyFormProps = {
+33:   onSubmit?: (values: PolicyFormValues) => void | Promise<void>;
+34:   onCancel?: () => void;
+35:   defaultValues?: Partial<PolicyFormValues>;
+36:   submitLabel?: string;
+37:   loading?: boolean;
+38:   /** Show the ownership-scope selector (create-only, partner-scope users). */
+39:   showOwnerScope?: boolean;
+40: };
+```
+No `policyId` or `catalogItems` prop. `PolicyForm` currently performs **zero** `fetchWithAuth` calls — it is a pure controlled form.
+
+```
+70:  const { fields, append, remove } = useFieldArray({
+71:    control,
+72:    name: "software",
+73:  });
+74:  const watchMode = watch("mode");
+75:  const watchEnforceMode = watch("enforceMode");
+```
+
+Autouninstall + gracePeriod block (`:295-318`):
+```
+294:          {watchEnforceMode && (
+295:            <label className="flex items-center gap-2">
+296:              <input
+297:                type="checkbox"
+298:                className="h-4 w-4 rounded border-border"
+299:                {...register("autoUninstall")}
+300:              />
+301:              <span className="text-sm">
+302:                {i18n.t("policies:software.policyForm.autoUninstall")}
+303:              </span>
+304:            </label>
+305:          )}
+```
+`allowUnknown` (the existing precedent for an allowlist-only field, `:270-282`):
+```
+270:        {watchMode === "allowlist" && (
+271:          <label className="flex items-center gap-2 px-1">
+272:            <input
+273:              type="checkbox"
+274:              className="h-4 w-4 rounded border-border"
+275:              {...register("allowUnknown")}
+276:            />
+```
+
+**`apps/web/src/components/software/ComplianceDashboard.tsx`**
+
+Local `Policy` type (`:20-44`) — no `catalogId` on rules, no `autoInstall` on `remediationOptions`:
+```
+20: type Policy = {
+...
+28:   rules?: {
+29:     software: Array<{
+30:       name: string;
+31:       vendor?: string;
+32:       minVersion?: string;
+33:       maxVersion?: string;
+34:       reason?: string;
+35:     }>;
+36:     allowUnknown?: boolean;
+37:   };
+38:   isActive: boolean;
+39:   enforceMode: boolean;
+40:   remediationOptions?: {
+41:     autoUninstall?: boolean;
+42:     gracePeriod?: number;
+43:   } | null;
+```
+
+`handleFormSubmit` (`:216-268`) — builds the PATCH/POST body directly from `fetchWithAuth`, no `runAction`:
+```
+239:        remediationOptions: values.enforceMode
+240:          ? {
+241:              autoUninstall: values.autoUninstall,
+242:              gracePeriod: values.gracePeriod,
+243:            }
+244:          : undefined,
+...
+248:      const res = await fetchWithAuth(url, {
+249:        method,
+250:        body: JSON.stringify(body),
+251:      });
+252:      if (!res.ok) {
+253:        const data = await res.json().catch(() => ({}));
+254:        throw new Error(
+255:          (data as { error?: string }).error || i18n.t(...),
+256:        );
+257:      }
+```
+Catch block (`:266-275`) shows `err.message` verbatim in a toast — for a `{error:'MFA required', code:'MFA_REQUIRED'}` body this renders the raw string "MFA required", not any friendly copy, and there is no `code`-aware handling anywhere in this file.
+
+`policyToFormDefaults` (`:400-411`):
+```
+400:  const policyToFormDefaults = (policy: Policy): Partial<PolicyFormValues> => ({
+...
+403:    software: policy.rules?.software?.map((s) => ({
+404:      name: s.name,
+405:      vendor: s.vendor ?? "",
+406:      minVersion: s.minVersion ?? "",
+407:      maxVersion: s.maxVersion ?? "",
+408:      reason: s.reason ?? "",
+409:    })) ?? [
+410:      { name: "", vendor: "", minVersion: "", maxVersion: "", reason: "" },
+411:    ],
+412:    allowUnknown: policy.rules?.allowUnknown ?? false,
+413:    enforceMode: policy.enforceMode,
+414:    autoUninstall: policy.remediationOptions?.autoUninstall ?? false,
+415:    gracePeriod: policy.remediationOptions?.gracePeriod ?? 24,
+416:  });
+```
+
+`refresh()` (`:105-138`) fetches policies/overview/violations via `Promise.all` and throws if any of the three `!res.ok` — a good reason NOT to fold a new catalog fetch into this same `Promise.all` (a catalog-fetch hiccup must not blank the whole dashboard).
+
+**`apps/web/src/components/software/DeploymentList.tsx`**
+
+Already uses `runAction`/`handleActionError` (`:13`, `:169`, `:181`) — the sibling pattern to copy for any *new* mutation, though this task adds a read-only label, no new mutation.
+
+```
+34: type DeploymentRow = {
+35:   id: string;
+36:   orgId?: string;
+37:   name: string;
+38:   deploymentType?: string;
+39:   scheduleType: string;
+40:   scheduledAt?: string | null;
+41:   createdAt: string;
+42:   status: SoftwareDeploymentAggregateStatus;
+43:   counts: SoftwareDeploymentCounts;
+44: };
+```
+No `softwarePolicyId`.
+
+Row rendering, Name column (`:391-399`):
+```
+391:                        <td className="px-4 py-3">
+392:                          <p className="font-medium text-foreground">
+393:                            {item.name}
+394:                          </p>
+395:                          <p className="text-xs text-muted-foreground">
+396:                            {item.id}
+397:                          </p>
+398:                        </td>
+```
+
+**Partner-wide badge precedent** (`ComplianceDashboard.tsx:499-514`), the exact visual pattern to copy for "Policy-owned":
+```
+499:                      {policy.orgId === null && (
+500:                        <span
+501:                          className="inline-flex items-center gap-1 rounded-full border border-primary/30 bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary"
+502:                          title={i18n.t(...)}
+503:                          data-testid="software-policy-partner-wide-badge"
+504:                        >
+505:                          <Layers className="h-3 w-3" />
+506:                          {i18n.t("policies:software.complianceDashboard.allOrgs")}
+507:                        </span>
+508:                      )}
+```
+
+**`apps/web/src/lib/runAction.ts`** — `RunActionOptions.friendly?: (code: string) => string | undefined`, called with `body.code` when present, else `body.error` (`:27-32`, `:75-83`). `ActionError` carries `.status` and `.code` (`:5-19`).
+
+**MFA-refusal UI precedent — `apps/web/src/components/devices/ManualAssetModal.tsx:199,234`**:
+```
+199:  const mfaFriendly = (code: string) => (code === 'MFA_REQUIRED' ? t('manualAssetModal.errors.mfaRequired') : undefined);
+...
+228:      result = await runAction<{ warnings?: { code: string; message: string }[] }>({
+229:        request: () =>
+230:          fetchWithAuth(isEdit ? `/devices/manual/${existing!.id}` : '/devices/manual', {
+231:            method: isEdit ? 'PATCH' : 'POST',
+232:            body: JSON.stringify(body),
+233:          }),
+234:        errorFallback: isEdit ? t('manualAssetModal.errors.updateFailed') : t('manualAssetModal.errors.createFailed'),
+235:        friendly: mfaFriendly,
+```
+This is the exact pattern Task 3 copies (with `i18n.t()` in place of the hook's `t()`, matching `ComplianceDashboard.tsx`'s existing convention of calling the global `i18n.t()` for static keys).
+
+**Server-side MFA refusal shape** (from the cross-wave contract, D3, citing `apps/api/src/middleware/auth.ts:885-908`): `c.json({ error: 'MFA required', code: 'MFA_REQUIRED' }, 403)`.
+
+**Server-side permission refusal shape — corrected after this plan's first draft.** The contract's "Contract corrections found during plan authoring" section (added after W01's plan-authoring pass) fixes the exact body for the non-MFA refusal: `{ error: ARM_INSTALL_EXECUTE_DENIED_MESSAGE, code: 'DEVICES_EXECUTE_REQUIRED' }`, 403 — **it also carries a `code`**, not a bare message as this plan's first draft assumed. Both refusal paths are therefore coded, and both get their own `friendly` mapping in Task 3 rather than one coded case plus a generic fallback.
+
+**`apps/web/src/lib/asList.ts:34-52`** — `asList<T>(payload, ...aliasKeys)` coerces `{data:[...]}` / `{<alias>:[...]}` / bare-array API responses to `T[]`, failing closed to `[]` with a console warning on an unrecognized shape. Used by `DeploymentWizard.tsx:344` and `SoftwareCatalog.tsx` for the exact same `/software/catalog` endpoint this plan also calls, with the alias `'catalog'`.
+
+**`GET /software/catalog`** (used already by `SoftwareCatalog.tsx:252` and `DeploymentWizard.tsx:342`) returns rows shaped `{ id, orgId?, name, vendor, category, description, ... }` (`SoftwareCatalog.tsx:262-270` normalization).
+
+**i18n locale files** — all 8 locale directories mirror `en/policies.json`'s structure at identical line numbers for the sections this plan touches (`complianceDashboard` ends at line 1353, `deploymentList` spans 1354-1429, `policyForm` ends at line 1619, confirmed identical across `de-DE`, `es-419`, `fr-CA`, `fr-FR`, `it-IT`, `pt-BR`, `tr-TR`). `apps/web/src/lib/i18n/localeParity.test.ts` enforces that every English leaf key exists, with matching type and interpolation tokens (`{{count}}` etc.), in every other locale.
+
+## Task 1: `PolicyForm` — catalog-item link per rule, `autoInstall` checkbox, authoring warning
+
+**Files:**
+- Modify: `apps/web/src/components/software/PolicyForm.tsx`
+- Modify: `apps/web/src/locales/en/policies.json`
+- Create: `apps/web/src/components/software/PolicyForm.autoInstall.test.tsx`
+
+**Interfaces:**
+- Consumes: nothing from other tasks in this plan.
+- Produces (for Task 2 and Task 3 to build on):
+  - `CatalogOption = { id: string; name: string; vendor?: string }` (exported from `PolicyForm.tsx`).
+  - `PolicyFormValues.software[number].catalogId?: string`
+  - `PolicyFormValues.autoInstall?: boolean`
+  - New `PolicyFormProps.catalogItems?: CatalogOption[]` (defaults to `[]`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/web/src/components/software/PolicyForm.autoInstall.test.tsx`:
+
+```tsx
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import PolicyForm from "./PolicyForm";
+
+const CATALOG = [
+  { id: "cat-1", name: "Zoom", vendor: "Zoom Video" },
+  { id: "cat-2", name: "1Password", vendor: "AgileBits" },
+];
+
+function fillRequired() {
+  fireEvent.change(screen.getByPlaceholderText("e.g. Block Unauthorized Software"), {
+    target: { value: "Required Apps" },
+  });
+  fireEvent.change(screen.getByPlaceholderText("Name *"), {
+    target: { value: "Zoom" },
+  });
+}
+
+describe("PolicyForm — catalog link + autoInstall arming (#5509)", () => {
+  it("renders a catalog-link select for each software rule, defaulting to none", () => {
+    render(<PolicyForm catalogItems={CATALOG} />);
+    const select = screen.getByTestId("software-rule-catalog-0") as HTMLSelectElement;
+    expect(select).toBeInTheDocument();
+    expect(select.value).toBe("");
+    expect(screen.getByText("Zoom (Zoom Video)")).toBeInTheDocument();
+    expect(screen.getByText("1Password (AgileBits)")).toBeInTheDocument();
+  });
+
+  it("includes the selected catalogId in the submitted values", async () => {
+    const onSubmit = vi.fn();
+    render(<PolicyForm catalogItems={CATALOG} onSubmit={onSubmit} />);
+    fillRequired();
+    fireEvent.change(screen.getByTestId("software-rule-catalog-0"), {
+      target: { value: "cat-1" },
+    });
+    fireEvent.click(screen.getByText("Save Policy"));
+    await vi.waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    expect(onSubmit.mock.calls[0][0].software[0].catalogId).toBe("cat-1");
+  });
+
+  it("hides the auto-install checkbox unless mode is allowlist and enforce is on", () => {
+    render(<PolicyForm catalogItems={CATALOG} />);
+    expect(screen.queryByTestId("policy-auto-install-checkbox")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText("Enforce (auto-remediate)"));
+    expect(screen.queryByTestId("policy-auto-install-checkbox")).not.toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Mode"), { target: { value: "allowlist" } });
+    expect(screen.getByTestId("policy-auto-install-checkbox")).toBeInTheDocument();
+  });
+
+  it("warns when auto-install is armed but a rule has no linked catalog item", () => {
+    render(<PolicyForm catalogItems={CATALOG} />);
+    fireEvent.change(screen.getByLabelText("Mode"), { target: { value: "allowlist" } });
+    fireEvent.click(screen.getByLabelText("Enforce (auto-remediate)"));
+    expect(screen.queryByTestId("autoinstall-catalog-warning")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("policy-auto-install-checkbox"));
+    expect(screen.getByTestId("autoinstall-catalog-warning")).toHaveTextContent(
+      "1 of 1 rule(s) have no linked catalog item",
+    );
+    fireEvent.change(screen.getByTestId("software-rule-catalog-0"), {
+      target: { value: "cat-1" },
+    });
+    expect(screen.queryByTestId("autoinstall-catalog-warning")).not.toBeInTheDocument();
+  });
+});
+```
+
+Note: `PolicyForm.tsx` has no `htmlFor`/`id` pairing on the Mode `<select>` today (`<label htmlFor="policy-mode">` / `<select id="policy-mode">` — already present at `:139-159`, so `getByLabelText("Mode")` already resolves; verified by reading the existing markup, not assumed).
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd apps/web && npx vitest run src/components/software/PolicyForm.autoInstall.test.tsx`
+Expected: FAIL — `getByTestId("software-rule-catalog-0")` not found (no such element yet), and `PolicyForm` doesn't accept a `catalogItems` prop.
+
+- [ ] **Step 3: Implement — schema, props, rule-row picker, checkbox, warning**
+
+Edit `apps/web/src/components/software/PolicyForm.tsx`. First, add `useMemo` to the React import:
+
+```tsx
+import { useMemo } from "react";
+import { useForm, useFieldArray } from "react-hook-form";
+```
+
+Extend the rule schema and top-level schema:
+
+```tsx
+const softwareRuleSchema = z.object({
+  name: z.string().min(1, "Software name is required").max(500),
+  vendor: z.string().max(200).optional().or(z.literal("")),
+  minVersion: z.string().max(100).optional().or(z.literal("")),
+  maxVersion: z.string().max(100).optional().or(z.literal("")),
+  reason: z.string().max(1000).optional().or(z.literal("")),
+  // Links this rule to a software-catalog item so an armed autoInstall
+  // policy has something concrete to install (#5509). Empty string = no
+  // link, matching the other optional string fields' convention above.
+  catalogId: z.string().optional().or(z.literal("")),
+});
+const policyFormSchema = z.object({
+  name: z.string().min(1, "Policy name is required").max(200),
+  description: z.string().max(4000).optional().or(z.literal("")),
+  mode: z.enum(["allowlist", "blocklist", "audit"]),
+  ownerScope: z.enum(["organization", "partner"]).optional(),
+  software: z
+    .array(softwareRuleSchema)
+    .min(1, "At least one software rule is required"),
+  allowUnknown: z.boolean().optional(),
+  enforceMode: z.boolean(),
+  autoUninstall: z.boolean().optional(),
+  // Arms desired-state install remediation (#5505). Only meaningful on an
+  // allowlist policy — 'missing' violations, the only kind autoInstall
+  // acts on, are only ever emitted for allowlist rule mismatches.
+  autoInstall: z.boolean().optional(),
+  gracePeriod: z.coerce.number().int().min(0).max(2160).optional(),
+});
+export type PolicyFormValues = z.infer<typeof policyFormSchema>;
+export type CatalogOption = { id: string; name: string; vendor?: string };
+type PolicyFormProps = {
+  onSubmit?: (values: PolicyFormValues) => void | Promise<void>;
+  onCancel?: () => void;
+  defaultValues?: Partial<PolicyFormValues>;
+  submitLabel?: string;
+  loading?: boolean;
+  showOwnerScope?: boolean;
+  /** Existing policy id when editing — undefined while creating (#5509).
+   *  Feeds the install dry-run preview in Task 2; a brand-new policy has no
+   *  id to query yet. */
+  policyId?: string;
+  /** Software catalog items available to link a rule to. Fetched once by
+   *  the parent (ComplianceDashboard); an empty array degrades the picker
+   *  to "no catalog items" rather than blocking the form. */
+  catalogItems?: CatalogOption[];
+};
+```
+
+Update the `useForm` default values and `append(...)` call:
+
+```tsx
+export default function PolicyForm({
+  onSubmit,
+  onCancel,
+  defaultValues,
+  submitLabel = "Save Policy",
+  loading,
+  showOwnerScope = false,
+  policyId,
+  catalogItems = [],
+}: PolicyFormProps) {
+  useTranslation("policies");
+  const {
+    register,
+    handleSubmit,
+    control,
+    watch,
+    formState: { errors, isSubmitting },
+  } = useForm<PolicyFormValues>({
+    resolver: zodResolver(policyFormSchema) as never,
+    defaultValues: {
+      name: "",
+      description: "",
+      mode: "blocklist",
+      software: [
+        { name: "", vendor: "", minVersion: "", maxVersion: "", reason: "", catalogId: "" },
+      ],
+      allowUnknown: false,
+      enforceMode: false,
+      autoUninstall: false,
+      autoInstall: false,
+      gracePeriod: 24,
+      ...defaultValues,
+    },
+  });
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: "software",
+  });
+  const watchMode = watch("mode");
+  const watchEnforceMode = watch("enforceMode");
+  const watchAutoInstall = watch("autoInstall");
+  const watchSoftware = watch("software");
+  const rulesWithoutCatalog = useMemo(
+    () => watchSoftware.filter((rule) => !rule.catalogId).length,
+    [watchSoftware],
+  );
+  const isLoading = loading ?? isSubmitting;
+```
+
+Update the `append` button:
+
+```tsx
+          <button
+            type="button"
+            onClick={() =>
+              append({
+                name: "",
+                vendor: "",
+                minVersion: "",
+                maxVersion: "",
+                reason: "",
+                catalogId: "",
+              })
+            }
+            className="inline-flex items-center gap-1 rounded-md border px-2 py-1 text-xs font-medium hover:bg-muted"
+          >
+```
+
+Add the catalog-link select to each rule row. Replace the rule-row grid (currently `sm:grid-cols-2 md:grid-cols-5`) with a 6th field:
+
+```tsx
+                <div className="flex-1 grid gap-2 sm:grid-cols-2 md:grid-cols-6">
+                  <input
+                    placeholder={i18n.t("policies:software.policyForm.name")}
+                    className="h-8 w-full rounded-md border bg-background px-2 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
+                    {...register(`software.${index}.name`)}
+                  />
+                  <input
+                    placeholder={i18n.t("policies:software.policyForm.vendor")}
+                    className="h-8 w-full rounded-md border bg-background px-2 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
+                    {...register(`software.${index}.vendor`)}
+                  />
+                  <input
+                    placeholder={i18n.t("policies:software.policyForm.minVer")}
+                    className="h-8 w-full rounded-md border bg-background px-2 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
+                    {...register(`software.${index}.minVersion`)}
+                  />
+                  <input
+                    placeholder={i18n.t("policies:software.policyForm.maxVer")}
+                    className="h-8 w-full rounded-md border bg-background px-2 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
+                    {...register(`software.${index}.maxVersion`)}
+                  />
+                  <input
+                    placeholder={i18n.t("policies:software.policyForm.reason")}
+                    className="h-8 w-full rounded-md border bg-background px-2 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
+                    {...register(`software.${index}.reason`)}
+                  />
+                  <select
+                    className="h-8 w-full rounded-md border bg-background px-2 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
+                    title={i18n.t("policies:software.policyForm.catalogLink")}
+                    data-testid={`software-rule-catalog-${index}`}
+                    {...register(`software.${index}.catalogId`)}
+                  >
+                    <option value="">
+                      {i18n.t("policies:software.policyForm.catalogLinkNone")}
+                    </option>
+                    {catalogItems.map((item) => (
+                      <option key={item.id} value={item.id}>
+                        {item.vendor ? `${item.name} (${item.vendor})` : item.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+```
+
+Add the `autoInstall` checkbox next to `autoUninstall` (still inside the existing `grid gap-3 md:grid-cols-2 items-center` container):
+
+```tsx
+          {watchEnforceMode && watchMode === "allowlist" && (
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                className="h-4 w-4 rounded border-border"
+                data-testid="policy-auto-install-checkbox"
+                {...register("autoInstall")}
+              />
+              <span className="text-sm">
+                {i18n.t("policies:software.policyForm.autoInstall")}
+              </span>
+            </label>
+          )}
+```
+
+Add the authoring warning immediately after that block (still inside the "Policy Settings" `<div>`, before the grace-period block):
+
+```tsx
+        {watchEnforceMode && watchMode === "allowlist" && watchAutoInstall && rulesWithoutCatalog > 0 && (
+          <p
+            className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-700"
+            data-testid="autoinstall-catalog-warning"
+          >
+            {i18n.t("policies:software.policyForm.autoInstallCatalogWarning", {
+              count: rulesWithoutCatalog,
+              total: watchSoftware.length,
+            })}
+          </p>
+        )}
+```
+
+Add the four new keys to `apps/web/src/locales/en/policies.json`. Find the `policyForm` section's last key (`"saving": "Saving..."` at line 1618, immediately before the closing `},` of that object at line 1619) and insert before it:
+
+```json
+      "saving": "Saving...",
+      "catalogLink": "Linked catalog item",
+      "catalogLinkNone": "None — not linked",
+      "autoInstall": "Auto-install missing software",
+      "autoInstallCatalogWarning": "{{count}} of {{total}} rule(s) have no linked catalog item and will be detected as missing but never installed."
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd apps/web && npx vitest run src/components/software/PolicyForm.autoInstall.test.tsx`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/software/PolicyForm.tsx \
+        apps/web/src/components/software/PolicyForm.autoInstall.test.tsx \
+        apps/web/src/locales/en/policies.json
+git commit -m "$(cat <<'EOF'
+feat(web): PolicyForm — catalog-item link per rule, autoInstall checkbox, authoring warning (#5505 W04)
+
+Adds the client-side half of arming desired-state install remediation:
+a catalogId picker per software rule (previously unsettable from the
+UI, even though the server schema has supported it), an autoInstall
+checkbox gated to allowlist+enforce mode (missing violations — the
+only kind autoInstall acts on — only fire for allowlist rules), and a
+warning when a rule with no linked catalog item can never be
+auto-installed.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01ANjBwca2cfsLWDLJro3fkz
+EOF
+)"
+```
+
+## Task 2: `PolicyForm` — dry-run device-count preview
+
+**Files:**
+- Modify: `apps/web/src/components/software/PolicyForm.tsx`
+- Modify: `apps/web/src/locales/en/policies.json`
+- Modify: `apps/web/src/components/software/PolicyForm.autoInstall.test.tsx`
+
+**Interfaces:**
+- Consumes: `PolicyFormProps.policyId` (produced by Task 1), `watchMode`/`watchEnforceMode`/`watchAutoInstall` (Task 1). `GET /software-policies/:id/install-preview` → `200 { eligibleDeviceCount: number }` — **W06 (#5522) Task 2**, field name verified in Step 1 below against W06's own plan doc, not assumed.
+- Produces: nothing new for later tasks — this is a leaf feature.
+- **Dependency on W06, degrades gracefully if unlanded.** The implementation below calls this endpoint and degrades gracefully (see Global Constraints) if it 404s or errors, so this task ships correctly regardless of when/whether W06 has landed by the time this task is implemented.
+
+- [ ] **Step 1: Verify W06's install-preview endpoint contract (or proceed in degraded mode)**
+
+```bash
+cd /Users/toddhebebrand/.herdr/worktrees/breeze/warranty-testing
+grep -n "install-preview" apps/api/src/routes/softwarePolicies.ts
+```
+
+Expected, per W06's plan (`docs/superpowers/plans/vuln-patch/2026-09-10-desired-state-software-install-w06-install-preview-endpoint.md`, Task 2's Interfaces block): a route `GET /software-policies/:id/install-preview` returning `200 { eligibleDeviceCount: number }` on success. Three outcomes:
+- **Grep finds the route:** confirmed — proceed with implementation exactly as written below.
+- **Grep finds nothing:** W06 has not landed yet. This is expected and does not block this task — proceed with implementation exactly as written below. `fetchWithAuth` will receive a 404 from the real API in that case (not a mock), which the code below already treats as "unavailable" rather than an error; the preview lights up with no further code change once W06 ships.
+- **Grep finds a route under a different path or response shape:** stop this task and reconcile against the real contract — do not silently guess.
+
+- [ ] **Step 2: Write the failing tests**
+
+Append to `apps/web/src/components/software/PolicyForm.autoInstall.test.tsx`:
+
+```tsx
+vi.mock("../../stores/auth", () => ({ fetchWithAuth: vi.fn() }));
+import { fetchWithAuth } from "../../stores/auth";
+const fetchMock = vi.mocked(fetchWithAuth);
+const jsonRes = (payload: unknown, ok = true, status = ok ? 200 : 404): Response =>
+  ({ ok, status, statusText: ok ? "OK" : "ERROR", json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+describe("PolicyForm — dry-run device count preview (#5509)", () => {
+  it("shows a 'new policy' message instead of fetching when there is no policyId yet", () => {
+    render(<PolicyForm catalogItems={[]} />);
+    fireEvent.change(screen.getByLabelText("Mode"), { target: { value: "allowlist" } });
+    fireEvent.click(screen.getByLabelText("Enforce (auto-remediate)"));
+    fireEvent.click(screen.getByTestId("policy-auto-install-checkbox"));
+    expect(screen.getByTestId("autoinstall-dry-run")).toHaveTextContent(
+      "This is a new policy",
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("fetches and renders the eligible device count for an existing policy", async () => {
+    fetchMock.mockResolvedValue(jsonRes({ eligibleDeviceCount: 42 }));
+    render(<PolicyForm catalogItems={[]} policyId="pol-1" />);
+    fireEvent.change(screen.getByLabelText("Mode"), { target: { value: "allowlist" } });
+    fireEvent.click(screen.getByLabelText("Enforce (auto-remediate)"));
+    fireEvent.click(screen.getByTestId("policy-auto-install-checkbox"));
+    await screen.findByText("This will install missing software on approximately 42 device(s).");
+    expect(fetchMock).toHaveBeenCalledWith("/software-policies/pol-1/install-preview");
+  });
+
+  it("degrades to an 'unavailable' message when the preview endpoint fails or doesn't exist", async () => {
+    fetchMock.mockResolvedValue(jsonRes({}, false, 404));
+    render(<PolicyForm catalogItems={[]} policyId="pol-1" />);
+    fireEvent.change(screen.getByLabelText("Mode"), { target: { value: "allowlist" } });
+    fireEvent.click(screen.getByLabelText("Enforce (auto-remediate)"));
+    fireEvent.click(screen.getByTestId("policy-auto-install-checkbox"));
+    await screen.findByTestId("autoinstall-dry-run");
+    expect(screen.getByTestId("autoinstall-dry-run")).toHaveTextContent(
+      "Device-count preview isn't available yet",
+    );
+  });
+});
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `cd apps/web && npx vitest run src/components/software/PolicyForm.autoInstall.test.tsx`
+Expected: FAIL — `getByTestId("autoinstall-dry-run")` not found; `fetchWithAuth` mock target doesn't exist in `PolicyForm.tsx` yet.
+
+- [ ] **Step 4: Implement**
+
+Edit `apps/web/src/components/software/PolicyForm.tsx`. Add imports:
+
+```tsx
+import { useEffect, useMemo, useState } from "react";
+import { useForm, useFieldArray } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Plus, Trash2 } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { i18n } from "@/lib/i18n";
+import { fetchWithAuth } from "../../stores/auth";
+```
+
+Add the dry-run state and effect inside the component, after the `rulesWithoutCatalog` `useMemo`:
+
+```tsx
+  type DryRunState =
+    | { status: "idle" }
+    | { status: "loading" }
+    | { status: "ready"; eligibleDeviceCount: number }
+    | { status: "unavailable" };
+  const [dryRun, setDryRun] = useState<DryRunState>({ status: "idle" });
+  useEffect(() => {
+    if (!policyId || watchMode !== "allowlist" || !watchEnforceMode || !watchAutoInstall) {
+      return;
+    }
+    let cancelled = false;
+    setDryRun({ status: "loading" });
+    (async () => {
+      try {
+        // Dependency on W06 (#5522) Task 2, which may not have landed yet
+        // when this code runs (see plan Global Constraints). Any non-2xx
+        // (including a plain 404 because the route doesn't exist) degrades
+        // to "unavailable" below — this preview is advisory only and never
+        // blocks arming; the real blast-radius bound is W02's per-pass cap.
+        const response = await fetchWithAuth(`/software-policies/${policyId}/install-preview`);
+        if (cancelled) return;
+        if (!response.ok) {
+          setDryRun({ status: "unavailable" });
+          return;
+        }
+        const payload = await response.json();
+        const count = Number((payload as { eligibleDeviceCount?: unknown })?.eligibleDeviceCount);
+        if (!Number.isFinite(count)) {
+          setDryRun({ status: "unavailable" });
+          return;
+        }
+        setDryRun({ status: "ready", eligibleDeviceCount: count });
+      } catch {
+        if (!cancelled) setDryRun({ status: "unavailable" });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [policyId, watchMode, watchEnforceMode, watchAutoInstall]);
+```
+
+Add the preview block right after the authoring-warning `<p>` added in Task 1:
+
+```tsx
+        {watchEnforceMode && watchMode === "allowlist" && watchAutoInstall && (
+          <div
+            className="rounded-md border border-blue-500/30 bg-blue-500/5 px-3 py-2 text-xs"
+            data-testid="autoinstall-dry-run"
+          >
+            {!policyId ? (
+              <p className="text-muted-foreground">
+                {i18n.t("policies:software.policyForm.dryRunNewPolicy")}
+              </p>
+            ) : dryRun.status === "loading" ? (
+              <p className="text-muted-foreground">
+                {i18n.t("policies:software.policyForm.dryRunLoading")}
+              </p>
+            ) : dryRun.status === "ready" ? (
+              <p>
+                {i18n.t("policies:software.policyForm.dryRunResult", {
+                  count: dryRun.eligibleDeviceCount,
+                })}
+              </p>
+            ) : (
+              <p className="text-muted-foreground">
+                {i18n.t("policies:software.policyForm.dryRunUnavailable")}
+              </p>
+            )}
+          </div>
+        )}
+```
+
+Add the four new keys to `apps/web/src/locales/en/policies.json`, after the ones Task 1 added (still before the `policyForm` object's closing `},`):
+
+```json
+      "autoInstallCatalogWarning": "{{count}} of {{total}} rule(s) have no linked catalog item and will be detected as missing but never installed.",
+      "dryRunLoading": "Checking how many devices this will affect...",
+      "dryRunResult": "This will install missing software on approximately {{count}} device(s).",
+      "dryRunUnavailable": "Device-count preview isn't available yet. Arming will still take effect on the next compliance pass.",
+      "dryRunNewPolicy": "This is a new policy — device impact isn't known until the first compliance pass after you save."
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cd apps/web && npx vitest run src/components/software/PolicyForm.autoInstall.test.tsx`
+Expected: PASS (7 tests total across both `describe` blocks).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/software/PolicyForm.tsx \
+        apps/web/src/components/software/PolicyForm.autoInstall.test.tsx \
+        apps/web/src/locales/en/policies.json
+git commit -m "$(cat <<'EOF'
+feat(web): PolicyForm — dry-run device-count preview before arming autoInstall (#5505 W04)
+
+Shows "this will install missing software on ~N device(s)" before an
+operator arms autoInstall on an existing policy, per spec Risks §2
+(arming on a broad policy could otherwise queue thousands of installs
+with no warning). Calls GET /software-policies/:id/install-preview
+(W06 #5522 Task 2), verified against that wave's own plan doc rather
+than assumed. The preview is advisory only: any non-2xx response
+(including a 404 if W06 hasn't landed yet) degrades to an
+"unavailable" message without blocking the checkbox, since the actual
+blast-radius bound is W02's per-pass cap.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01ANjBwca2cfsLWDLJro3fkz
+EOF
+)"
+```
+
+## Task 3: `ComplianceDashboard` — wire arming into the save flow, honest 403 handling
+
+**Files:**
+- Modify: `apps/web/src/components/software/ComplianceDashboard.tsx`
+- Modify: `apps/web/src/lib/runActionAllowlist.ts`
+- Modify: `apps/web/src/locales/en/policies.json`
+- Create: `apps/web/src/components/software/ComplianceDashboard.autoInstall.test.tsx`
+
+**Interfaces:**
+- Consumes: `PolicyForm`'s `CatalogOption` type, `catalogItems`/`policyId` props (Task 1/2). Server contract (not yet implemented, per W01): a write that would leave a policy armed for install must hold `devices.execute` + MFA, refusing with `403 { error: 'MFA required', code: 'MFA_REQUIRED' }` for the MFA case, or `403 { error: ARM_INSTALL_EXECUTE_DENIED_MESSAGE, code: 'DEVICES_EXECUTE_REQUIRED' }` for the missing-permission case (both per the cross-wave contract's post-W01 corrections — both refusals are coded, neither is a bare message).
+- Produces: nothing new for later tasks in this plan.
+
+- [ ] **Step 1: Write the failing tests (payload correctness)**
+
+Create `apps/web/src/components/software/ComplianceDashboard.autoInstall.test.tsx`:
+
+```tsx
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+const showToast = vi.fn();
+vi.mock('../shared/Toast', () => ({ showToast: (a: unknown) => showToast(a) }));
+
+import ComplianceDashboard from './ComplianceDashboard';
+import { fetchWithAuth } from '../../stores/auth';
+
+const fetchMock = vi.mocked(fetchWithAuth);
+const json = (payload: unknown, ok = true, status = ok ? 200 : 400): Response =>
+  ({ ok, status, statusText: 'OK', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+const OVERVIEW = { total: 0, compliant: 0, violations: 0, unknown: 0 };
+
+function mockEndpoints() {
+  fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+    if (url.startsWith('/software-policies/compliance/overview')) return Promise.resolve(json(OVERVIEW));
+    if (url.startsWith('/software-policies/violations')) return Promise.resolve(json({ data: [] }));
+    if (url.startsWith('/software-policies?')) return Promise.resolve(json({ data: [] }));
+    if (url === '/software/catalog') return Promise.resolve(json({ data: [] }));
+    if (url === '/software-policies' && (init as RequestInit)?.method === 'POST') {
+      return Promise.resolve(json({ id: 'new-1' }));
+    }
+    return Promise.resolve(json({ data: [] }));
+  });
+}
+
+function postBody(): Record<string, unknown> {
+  const post = fetchMock.mock.calls.find(
+    (c) => c[0] === '/software-policies' && (c[1] as RequestInit)?.method === 'POST',
+  );
+  expect(post).toBeTruthy();
+  return JSON.parse((post![1] as RequestInit).body as string);
+}
+
+function openCreateAndFill() {
+  fireEvent.click(screen.getByText('Create Policy'));
+  fireEvent.change(screen.getByPlaceholderText('e.g. Block Unauthorized Software'), {
+    target: { value: 'Required Apps' },
+  });
+  fireEvent.change(screen.getByPlaceholderText('Name *'), { target: { value: 'Zoom' } });
+}
+
+describe('ComplianceDashboard — autoInstall arming (#5509)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEndpoints();
+  });
+
+  it('sends remediationOptions.autoInstall when armed on an allowlist enforce policy', async () => {
+    render(<ComplianceDashboard />);
+    await waitFor(() => expect(screen.queryByText('Loading software policy compliance...')).not.toBeInTheDocument());
+    openCreateAndFill();
+    fireEvent.change(screen.getByLabelText('Mode'), { target: { value: 'allowlist' } });
+    fireEvent.click(screen.getByLabelText('Enforce (auto-remediate)'));
+    fireEvent.click(screen.getByTestId('policy-auto-install-checkbox'));
+    fireEvent.click(screen.getByText('Create Policy', { selector: 'button[type="submit"]' }));
+    await waitFor(() => expect(postBody().remediationOptions).toMatchObject({ autoInstall: true }));
+  });
+
+  it('omits autoInstall when mode is switched away from allowlist, even if the checkbox had been checked', async () => {
+    render(<ComplianceDashboard />);
+    await waitFor(() => expect(screen.queryByText('Loading software policy compliance...')).not.toBeInTheDocument());
+    openCreateAndFill();
+    fireEvent.change(screen.getByLabelText('Mode'), { target: { value: 'allowlist' } });
+    fireEvent.click(screen.getByLabelText('Enforce (auto-remediate)'));
+    fireEvent.click(screen.getByTestId('policy-auto-install-checkbox'));
+    fireEvent.change(screen.getByLabelText('Mode'), { target: { value: 'blocklist' } });
+    fireEvent.click(screen.getByText('Create Policy', { selector: 'button[type="submit"]' }));
+    await waitFor(() => expect(postBody().remediationOptions?.autoInstall).toBeUndefined());
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd apps/web && npx vitest run src/components/software/ComplianceDashboard.autoInstall.test.tsx`
+Expected: FAIL — `getByTestId('policy-auto-install-checkbox')` renders (Task 1 landed), but `postBody().remediationOptions.autoInstall` is `undefined` because `ComplianceDashboard.tsx` doesn't read `values.autoInstall` yet.
+
+- [ ] **Step 3: Implement — types, catalog fetch, payload**
+
+Edit `apps/web/src/components/software/ComplianceDashboard.tsx`. Extend the local `Policy` type:
+
+```tsx
+type Policy = {
+  id: string;
+  name: string;
+  description?: string;
+  orgId?: string | null;
+  partnerId?: string | null;
+  mode: "allowlist" | "blocklist" | "audit";
+  rules?: {
+    software: Array<{
+      name: string;
+      vendor?: string;
+      minVersion?: string;
+      maxVersion?: string;
+      reason?: string;
+      catalogId?: string;
+    }>;
+    allowUnknown?: boolean;
+  };
+  isActive: boolean;
+  enforceMode: boolean;
+  remediationOptions?: {
+    autoUninstall?: boolean;
+    autoInstall?: boolean;
+    gracePeriod?: number;
+  } | null;
+  createdAt?: string;
+  updatedAt?: string;
+};
+```
+
+Add the catalog-items fetch. Add `asList` to the imports and `useState`/`useEffect` (already imported at top — `useCallback, useEffect, useState` from `"react"`; add nothing new there):
+
+```tsx
+import { asList } from "@/lib/asList";
+import PolicyForm, { type PolicyFormValues, type CatalogOption } from "./PolicyForm";
+```
+
+Inside the component, after the `submitting` state declaration:
+
+```tsx
+  const [catalogItems, setCatalogItems] = useState<CatalogOption[]>([]);
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetchWithAuth("/software/catalog");
+        if (!res.ok || cancelled) return;
+        const payload = await res.json();
+        const rows = asList<Record<string, unknown>>(payload, "catalog");
+        const items = rows
+          .map((item) => ({
+            id: String(item.id ?? ""),
+            name: String(item.name ?? ""),
+            vendor: item.vendor ? String(item.vendor) : undefined,
+          }))
+          .filter((item) => item.id.length > 0);
+        if (!cancelled) setCatalogItems(items);
+      } catch (err) {
+        // Non-fatal: the catalog-link picker in PolicyForm just shows no
+        // options. The rest of the dashboard (policies, overview,
+        // violations) loads independently via refresh() and must not be
+        // blanked by a catalog hiccup.
+        console.warn(
+          "[ComplianceDashboard] Failed to load software catalog for policy linking:",
+          err,
+        );
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+```
+
+Update `policyToFormDefaults`:
+
+```tsx
+  const policyToFormDefaults = (policy: Policy): Partial<PolicyFormValues> => ({
+    name: policy.name,
+    description: policy.description ?? "",
+    mode: policy.mode,
+    software: policy.rules?.software?.map((s) => ({
+      name: s.name,
+      vendor: s.vendor ?? "",
+      minVersion: s.minVersion ?? "",
+      maxVersion: s.maxVersion ?? "",
+      reason: s.reason ?? "",
+      catalogId: s.catalogId ?? "",
+    })) ?? [
+      { name: "", vendor: "", minVersion: "", maxVersion: "", reason: "", catalogId: "" },
+    ],
+    allowUnknown: policy.rules?.allowUnknown ?? false,
+    enforceMode: policy.enforceMode,
+    autoUninstall: policy.remediationOptions?.autoUninstall ?? false,
+    autoInstall: policy.remediationOptions?.autoInstall ?? false,
+    gracePeriod: policy.remediationOptions?.gracePeriod ?? 24,
+  });
+```
+
+Update the `remediationOptions` construction inside `handleFormSubmit` (leave the surrounding function structure as-is for this step — Step 3 of Task 3 only fixes the payload; Step 7 below migrates the transport):
+
+```tsx
+        remediationOptions: values.enforceMode
+          ? {
+              autoUninstall: values.autoUninstall,
+              // Arming is meaningless outside allowlist mode — only
+              // allowlist rules ever produce a 'missing' violation
+              // (softwarePolicyService.ts emits it only for allowlist rule
+              // mismatches). Guard here so a stale `true` react-hook-form
+              // kept from before the operator switched mode away from
+              // allowlist (the checkbox unmounts but RHF retains its last
+              // value) never reaches the server. Mirrors the allowUnknown
+              // guard two lines above in the rules block.
+              autoInstall: values.mode === "allowlist" ? values.autoInstall : undefined,
+              gracePeriod: values.gracePeriod,
+            }
+          : undefined,
+```
+
+Also update the `rules.software` mapping a few lines above it, to forward `catalogId`:
+
+```tsx
+        rules: {
+          software: values.software.map((s) => ({
+            name: s.name,
+            vendor: s.vendor || undefined,
+            minVersion: s.minVersion || undefined,
+            maxVersion: s.maxVersion || undefined,
+            reason: s.reason || undefined,
+            catalogId: s.catalogId || undefined,
+          })),
+          allowUnknown:
+            values.mode === "allowlist" ? values.allowUnknown : undefined,
+        },
+```
+
+Pass the new props to `PolicyForm` in the create/edit modal JSX:
+
+```tsx
+              <PolicyForm
+                key={selectedPolicy?.id ?? "create"}
+                onSubmit={handleFormSubmit}
+                onCancel={closeModal}
+                defaultValues={
+                  modalMode === "edit" && selectedPolicy
+                    ? policyToFormDefaults(selectedPolicy)
+                    : { ownerScope: defaultOwnerScope }
+                }
+                submitLabel={
+                  modalMode === "create"
+                    ? i18n.t("policies:software.complianceDashboard.createPolicy")
+                    : i18n.t("policies:software.complianceDashboard.updatePolicy")
+                }
+                loading={submitting}
+                showOwnerScope={modalMode === "create" && isPartnerScope}
+                policyId={modalMode === "edit" ? (selectedPolicy?.id || undefined) : undefined}
+                catalogItems={catalogItems}
+              />
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd apps/web && npx vitest run src/components/software/ComplianceDashboard.autoInstall.test.tsx`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Write the failing tests (honest 403 handling)**
+
+Append to `apps/web/src/components/software/ComplianceDashboard.autoInstall.test.tsx`:
+
+```tsx
+describe('ComplianceDashboard — honest 403 refusal on arming (#5509)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows the MFA-required friendly message on a 403 MFA_REQUIRED refusal, and keeps the modal open', async () => {
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url === '/software-policies' && (init as RequestInit)?.method === 'POST') {
+        return Promise.resolve(json({ error: 'MFA required', code: 'MFA_REQUIRED' }, false, 403));
+      }
+      if (url.startsWith('/software-policies/compliance/overview')) return Promise.resolve(json(OVERVIEW));
+      if (url.startsWith('/software-policies/violations')) return Promise.resolve(json({ data: [] }));
+      if (url.startsWith('/software-policies?')) return Promise.resolve(json({ data: [] }));
+      if (url === '/software/catalog') return Promise.resolve(json({ data: [] }));
+      return Promise.resolve(json({ data: [] }));
+    });
+    render(<ComplianceDashboard />);
+    await waitFor(() => expect(screen.queryByText('Loading software policy compliance...')).not.toBeInTheDocument());
+    openCreateAndFill();
+    fireEvent.change(screen.getByLabelText('Mode'), { target: { value: 'allowlist' } });
+    fireEvent.click(screen.getByLabelText('Enforce (auto-remediate)'));
+    fireEvent.click(screen.getByTestId('policy-auto-install-checkbox'));
+    fireEvent.click(screen.getByText('Create Policy', { selector: 'button[type="submit"]' }));
+    await waitFor(() =>
+      expect(showToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'error',
+          message: expect.stringContaining('multi-factor authentication'),
+        }),
+      ),
+    );
+    // Modal stayed open — the create form is still on screen.
+    expect(screen.getByText('Create Software Policy')).toBeInTheDocument();
+  });
+
+  it('shows the devices.execute-permission friendly message on a 403 DEVICES_EXECUTE_REQUIRED refusal', async () => {
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url === '/software-policies' && (init as RequestInit)?.method === 'POST') {
+        return Promise.resolve(
+          json(
+            { error: 'Arming automatic install requires devices.execute', code: 'DEVICES_EXECUTE_REQUIRED' },
+            false,
+            403,
+          ),
+        );
+      }
+      if (url.startsWith('/software-policies/compliance/overview')) return Promise.resolve(json(OVERVIEW));
+      if (url.startsWith('/software-policies/violations')) return Promise.resolve(json({ data: [] }));
+      if (url.startsWith('/software-policies?')) return Promise.resolve(json({ data: [] }));
+      if (url === '/software/catalog') return Promise.resolve(json({ data: [] }));
+      return Promise.resolve(json({ data: [] }));
+    });
+    render(<ComplianceDashboard />);
+    await waitFor(() => expect(screen.queryByText('Loading software policy compliance...')).not.toBeInTheDocument());
+    openCreateAndFill();
+    fireEvent.change(screen.getByLabelText('Mode'), { target: { value: 'allowlist' } });
+    fireEvent.click(screen.getByLabelText('Enforce (auto-remediate)'));
+    fireEvent.click(screen.getByTestId('policy-auto-install-checkbox'));
+    fireEvent.click(screen.getByText('Create Policy', { selector: 'button[type="submit"]' }));
+    await waitFor(() =>
+      expect(showToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'error',
+          message: expect.stringContaining('devices.execute'),
+        }),
+      ),
+    );
+    expect(screen.getByText('Create Software Policy')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 6: Run the tests to verify they fail**
+
+Run: `cd apps/web && npx vitest run src/components/software/ComplianceDashboard.autoInstall.test.tsx`
+Expected: FAIL — the current `handleFormSubmit` shows `err.message`, which for the MFA case is the raw server string `"MFA required"` (not the friendly copy containing "multi-factor authentication") and for the `DEVICES_EXECUTE_REQUIRED` case is whatever raw `error` string the server sent, with no `code`-aware mapping at all — both new tests fail their message-content assertions.
+
+- [ ] **Step 7: Implement — migrate `handleFormSubmit` to `runAction`**
+
+Add the import at the top of `apps/web/src/components/software/ComplianceDashboard.tsx`:
+
+```tsx
+import { runAction, ActionError } from "@/lib/runAction";
+```
+
+Replace the whole `handleFormSubmit` function:
+
+```tsx
+  // Both arming-refusal codes are coded 403s per the cross-wave contract
+  // (post-W01 correction): MFA_REQUIRED from the existing requireMfa()
+  // gate, DEVICES_EXECUTE_REQUIRED from assertMayArmInstall's own
+  // permission check ({ error: ARM_INSTALL_EXECUTE_DENIED_MESSAGE, code:
+  // 'DEVICES_EXECUTE_REQUIRED' }). Neither is a bare, uncoded message, so
+  // both get an explicit friendly mapping rather than falling through to
+  // the server's raw string for one of the two.
+  const armInstallFriendly = (code: string) => {
+    if (code === "MFA_REQUIRED") {
+      return i18n.t("policies:software.complianceDashboard.armInstallRequiresMfa");
+    }
+    if (code === "DEVICES_EXECUTE_REQUIRED") {
+      return i18n.t("policies:software.complianceDashboard.armInstallRequiresPermission");
+    }
+    return undefined;
+  };
+
+  const handleFormSubmit = async (values: PolicyFormValues) => {
+    setSubmitting(true);
+    const isEdit = modalMode === "edit" && selectedPolicy;
+    const body = {
+      name: values.name,
+      description: values.description || undefined,
+      mode: values.mode,
+      // Ownership is immutable after create — only send the intent on create.
+      // The server derives the partner from the caller's own token (#2126).
+      ownerScope: modalMode === "create" ? values.ownerScope : undefined,
+      rules: {
+        software: values.software.map((s) => ({
+          name: s.name,
+          vendor: s.vendor || undefined,
+          minVersion: s.minVersion || undefined,
+          maxVersion: s.maxVersion || undefined,
+          reason: s.reason || undefined,
+          catalogId: s.catalogId || undefined,
+        })),
+        allowUnknown:
+          values.mode === "allowlist" ? values.allowUnknown : undefined,
+      },
+      enforceMode: values.enforceMode,
+      remediationOptions: values.enforceMode
+        ? {
+            autoUninstall: values.autoUninstall,
+            autoInstall: values.mode === "allowlist" ? values.autoInstall : undefined,
+            gracePeriod: values.gracePeriod,
+          }
+        : undefined,
+    };
+    const url = isEdit
+      ? `/software-policies/${selectedPolicy.id}`
+      : "/software-policies";
+    const method = isEdit ? "PATCH" : "POST";
+    try {
+      await runAction({
+        request: () => fetchWithAuth(url, { method, body: JSON.stringify(body) }),
+        errorFallback: i18n.t(
+          /* i18n-dynamic */ isEdit
+            ? "policies:software.complianceDashboard.failedToUpdatePolicy"
+            : "policies:software.complianceDashboard.failedToCreatePolicy",
+        ),
+        friendly: armInstallFriendly,
+        successMessage: i18n.t(
+          /* i18n-dynamic */ isEdit
+            ? "policies:software.complianceDashboard.policyUpdated"
+            : "policies:software.complianceDashboard.policyCreated",
+        ),
+      });
+    } catch (err) {
+      // runAction already toasted an ActionError (including the friendly
+      // MFA_REQUIRED copy above, or the server's raw message for any other
+      // refusal — never a silent no-op). A non-ActionError (e.g. a bug in
+      // parseSuccess) still needs its own toast.
+      if (!(err instanceof ActionError)) {
+        showToast({ type: "error", message: "Failed to save policy" });
+      }
+      setSubmitting(false);
+      return;
+    }
+    setSubmitting(false);
+    setModalMode("closed");
+    setSelectedPolicy(null);
+    // The save genuinely succeeded — a throw from refresh() must not read
+    // back as a failed save (runAction's own catch above already handled
+    // that case).
+    try {
+      await refresh();
+    } catch (err) {
+      console.error(
+        "[ComplianceDashboard] refresh() failed after a successful policy save",
+        err,
+      );
+    }
+  };
+```
+
+Add the new key to `apps/web/src/locales/en/policies.json`. Find the `complianceDashboard` section's last key (`"policyCreated": "Policy created successfully"` at line 1353, immediately before that object's closing `},`) and insert before it:
+
+```json
+      "policyCreated": "Policy created successfully",
+      "armInstallRequiresMfa": "Arming automatic install requires multi-factor authentication. Complete MFA, then try again.",
+      "armInstallRequiresPermission": "Arming automatic install requires the devices.execute permission. Ask an administrator to grant it, then try again."
+```
+
+Finally, record the partial `runAction` migration in `apps/web/src/lib/runActionAllowlist.ts`. Add to `RUN_ACTION_MIGRATION_BACKLOG`, matching the array's existing comment convention:
+
+```ts
+  // ComplianceDashboard.tsx: handleFormSubmit (policy create/update, the
+  // handler that arms autoInstall — #5505 W04) migrated to runAction.
+  // handleConfirmDelete / handleCheckCompliance / handleRemediate remain on
+  // bare fetchWithAuth — out of this wave's scope. Not yet added to
+  // TARGET_GLOBS: doing so would flag those three untouched handlers.
+  'apps/web/src/components/software/ComplianceDashboard.tsx',
+```
+
+- [ ] **Step 8: Run the tests to verify they pass**
+
+Run: `cd apps/web && npx vitest run src/components/software/ComplianceDashboard.autoInstall.test.tsx`
+Expected: PASS (4 tests total across both `describe` blocks).
+
+- [ ] **Step 9: Run the full ComplianceDashboard suite to check for regressions**
+
+Run: `cd apps/web && npx vitest run src/components/software/ComplianceDashboard.ownerScope.test.tsx src/components/software/ComplianceDashboard.autoInstall.test.tsx`
+Expected: PASS (both files).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add apps/web/src/components/software/ComplianceDashboard.tsx \
+        apps/web/src/components/software/ComplianceDashboard.autoInstall.test.tsx \
+        apps/web/src/lib/runActionAllowlist.ts \
+        apps/web/src/locales/en/policies.json
+git commit -m "$(cat <<'EOF'
+feat(web): ComplianceDashboard — wire autoInstall arming into policy save, honest 403 handling (#5505 W04)
+
+Fetches the software catalog for PolicyForm's new catalog-link picker
+(non-fatal on failure), forwards catalogId + autoInstall through the
+policy create/update payload with the same allowlist-only guard the
+existing allowUnknown field already uses, and migrates handleFormSubmit
+to runAction so a 403 refusal (MFA_REQUIRED, or DEVICES_EXECUTE_REQUIRED
+from the server-side assertMayArmInstall gate W01 ships) always surfaces
+a friendly, code-specific message to the operator and the modal stays
+open for retry — never a silent no-op, per CLAUDE.md's runAction
+contract.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01ANjBwca2cfsLWDLJro3fkz
+EOF
+)"
+```
+
+## Task 4: `ComplianceDashboard` — surface install-remediation status per device
+
+**Scope addition from the coordinator, added after this plan's first draft.** Spec Risks §1 requires the consecutive-attempt give-up counter to be "visible in the UI" — the plan as first written never rendered any of W02's three `software_compliance_status` columns, so a technician had no way to see that a device had silently stopped being auto-installed. W06 (#5522), Task 3, widens `GET /software-policies/violations`'s existing compliance projection (`apps/api/src/routes/softwarePolicies.ts:481-488`) to carry them. This task consumes that.
+
+**Files:**
+- Modify: `apps/web/src/components/software/ComplianceDashboard.tsx`
+- Modify: `apps/web/src/locales/en/policies.json`
+- Modify: `apps/web/src/components/software/ComplianceDashboard.autoInstall.test.tsx`
+
+**Interfaces:**
+- Consumes: `GET /software-policies/violations` response rows' `compliance.installRemediationStatus: string | null`, `compliance.lastInstallRemediationAttempt: string | null`, `compliance.installRemediationAttempts: number` — **W06 Task 3**, field names verified in Step 1 below against W06's own plan doc, not assumed. Also `compliance.violations[].rule.catalogId?: string` — **W01, contract D9** — already flowing through this same route's pre-existing `violations` field regardless of W06, since W06 Task 3 does not touch that field.
+- Produces: nothing consumed by a later task in this plan.
+
+### 4.0 Ground truth for this task
+
+`ViolationRow` (`apps/web/src/components/software/ComplianceDashboard.tsx:53-66`), unmodified by Tasks 1-3:
+```
+53: type ViolationRow = {
+54:   device: {
+55:     id: string;
+56:     hostname: string;
+57:   };
+58:   compliance: {
+59:     policyId: string;
+60:     violations?: Array<{
+61:       type: string;
+62:     }>;
+63:     remediationStatus?: string;
+64:     lastChecked: string;
+65:   };
+66: };
+```
+
+The "Recent Violations" render block (`:619-643`), the only place `remediationStatus` is rendered anywhere in `apps/web/src` today (confirmed: `grep -rln "remediationStatus" apps/web/src` returns exactly this one file) — the pattern this task extends rather than inventing a new one:
+```
+619:  {violations.map((row) => (
+620:    <div
+621:      key={`${row.compliance.policyId}:${row.device.id}`}
+622:      className="flex flex-col gap-2 px-4 py-3 text-sm sm:flex-row sm:items-center sm:justify-between"
+623:    >
+624:      <div>
+625:        <p className="font-medium">{row.device.hostname}</p>
+626:        <p className="text-xs text-muted-foreground">
+627:          {Array.isArray(row.compliance.violations)
+628:            ? row.compliance.violations.length
+629:            : 0}{" "}
+630:          {i18n.t("policies:software.complianceDashboard.violationS")}
+631:        </p>
+632:      </div>
+633:      <div className="text-xs text-muted-foreground">
+634:        {i18n.t("policies:software.complianceDashboard.remediation")}
+635:        {row.compliance.remediationStatus ??
+636:          i18n.t("policies:software.complianceDashboard.none")}
+637:      </div>
+638:      <div className="text-xs text-muted-foreground">
+639:        {i18n.t("policies:software.complianceDashboard.checked")}
+640:        {formatDateTime(row.compliance.lastChecked)}
+641:      </div>
+642:    </div>
+643:  ))}
+```
+
+**Why `'skipped'` cannot be fully disambiguated from data alone — read before implementing.** W02's plan doc (`docs/superpowers/plans/vuln-patch/2026-09-10-desired-state-software-install-w02-compliance-worker.md:542-560`) defines `SoftwarePolicyInstallRemediationStatus` and documents that a single `'skipped'` value covers THREE causes — "the rule carries no catalogId ..., the per-pass cap was reached, or (W03) the catalog item has no install method for this device's OS" — and **no column persists which of the three fired**; `installRemediationAttempts`/`installRemediationStatus` are the only two install-specific fields on the row. Of the three causes, exactly one is reconstructable from data this route already returns: whether the device's own `missing` violation lacks a `catalogId` (visible via `compliance.violations[].rule.catalogId`, W01 D9). The other two — per-pass cap and platform mismatch — have no per-device signal anywhere in the projected response. This task therefore gives the no-catalogId case a specific, actionable explanation (pointing at the exact fix — Task 1's new catalog-link picker) and gives the other two a single honest, hedged sentence, rather than fabricating certainty the data does not support. **This is a further gap worth flagging to the coordinator**, same as the dry-run endpoint: a future wave could add a persisted skip-reason column for full precision.
+
+- [ ] **Step 1: Verify W06 Task 3's projected field names (or proceed in degraded mode)**
+
+```bash
+cd /Users/toddhebebrand/.herdr/worktrees/breeze/warranty-testing
+grep -n "installRemediationStatus\|lastInstallRemediationAttempt\|installRemediationAttempts" apps/api/src/routes/softwarePolicies.ts
+```
+
+Expected, per W06's plan (`docs/superpowers/plans/vuln-patch/2026-09-10-desired-state-software-install-w06-install-preview-endpoint.md`, Task 3 Step 4), inside `GET /violations`'s existing `compliance` projection:
+```ts
+installRemediationStatus: softwareComplianceStatus.installRemediationStatus,
+lastInstallRemediationAttempt: softwareComplianceStatus.lastInstallRemediationAttempt,
+installRemediationAttempts: softwareComplianceStatus.installRemediationAttempts,
+```
+
+Unlike W03's dependency on W01/W02 (a compile-time TypeScript import that cannot proceed at all without the real export name), this is a runtime JSON field on an HTTP response, and every render this task adds is already gated on `row.compliance.installRemediationStatus` being present and truthy (Step 3 below). Three outcomes:
+- **Grep finds exactly these three fields:** confirmed — proceed with implementation exactly as written below.
+- **Grep finds nothing:** W06 has not landed yet. This is expected and does not block this task — proceed with implementation exactly as written below. The new UI renders nothing extra (the same as today) until W06 ships the projection, then lights up with no further code change, because the gate is "is the field present and non-`'none'`", not "does the field exist in the type".
+- **Grep finds different field names than the three above:** W06 landed under a different contract than its own plan doc promised. **Stop this task and reconcile against the real names** — do not silently rename to match; report the mismatch.
+
+- [ ] **Step 2: Write the failing tests**
+
+Append to `apps/web/src/components/software/ComplianceDashboard.autoInstall.test.tsx`:
+
+```tsx
+describe('ComplianceDashboard — install-remediation status display (#5509, coordinator scope addition)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function mockViolationsWith(complianceOverrides: Record<string, unknown>) {
+    fetchMock.mockImplementation((url: string) => {
+      if (url.startsWith('/software-policies/compliance/overview')) return Promise.resolve(json(OVERVIEW));
+      if (url.startsWith('/software-policies/violations')) {
+        return Promise.resolve(
+          json({
+            data: [
+              {
+                device: { id: 'dev-1', hostname: 'workstation-1' },
+                compliance: {
+                  policyId: 'pol-1',
+                  violations: [{ type: 'missing', rule: { name: 'Zoom' } }],
+                  lastChecked: '2026-09-10T10:00:00Z',
+                  ...complianceOverrides,
+                },
+              },
+            ],
+          }),
+        );
+      }
+      if (url.startsWith('/software-policies?')) return Promise.resolve(json({ data: [] }));
+      if (url === '/software/catalog') return Promise.resolve(json({ data: [] }));
+      return Promise.resolve(json({ data: [] }));
+    });
+  }
+
+  it('renders nothing extra when installRemediationStatus is absent', async () => {
+    mockViolationsWith({});
+    render(<ComplianceDashboard />);
+    await waitFor(() => expect(screen.queryByText('Loading software policy compliance...')).not.toBeInTheDocument());
+    expect(screen.queryByTestId('install-remediation-dev-1')).not.toBeInTheDocument();
+  });
+
+  it("shows 'gave_up' as a visually distinct terminal state (not styled like 'failed'), with the consecutive attempt count", async () => {
+    mockViolationsWith({ installRemediationStatus: 'gave_up', installRemediationAttempts: 3 });
+    render(<ComplianceDashboard />);
+    const block = await screen.findByTestId('install-remediation-dev-1');
+    expect(block).toHaveTextContent('Gave up after repeated failures');
+    expect(block).toHaveTextContent('3 attempt(s)');
+    const badge = screen.getByText('Gave up after repeated failures');
+    expect(badge.className).toContain('text-destructive');
+    expect(badge.className).not.toContain('text-amber-700');
+  });
+
+  it('shows the last install-attempt time when present', async () => {
+    mockViolationsWith({
+      installRemediationStatus: 'failed',
+      lastInstallRemediationAttempt: '2026-09-10T09:30:00Z',
+    });
+    const block = await screen.findByTestId('install-remediation-dev-1');
+    expect(block).toHaveTextContent('Last install attempt:');
+  });
+
+  it('explains a skipped device with a missing catalog link distinctly from the generic cap/platform hedge', async () => {
+    mockViolationsWith({
+      installRemediationStatus: 'skipped',
+      violations: [{ type: 'missing', rule: { name: 'Zoom' } }], // no catalogId
+    });
+    const block = await screen.findByTestId('install-remediation-dev-1');
+    expect(block).toHaveTextContent('has no linked catalog item');
+  });
+
+  it('falls back to the generic cap/platform hedge for a skipped device whose rule already has a catalog link', async () => {
+    mockViolationsWith({
+      installRemediationStatus: 'skipped',
+      violations: [{ type: 'missing', rule: { name: 'Zoom', catalogId: 'cat-1' } }],
+    });
+    const block = await screen.findByTestId('install-remediation-dev-1');
+    expect(block).toHaveTextContent('per-pass install cap');
+  });
+});
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `cd apps/web && npx vitest run src/components/software/ComplianceDashboard.autoInstall.test.tsx`
+Expected: FAIL — `getByTestId('install-remediation-dev-1')` not found in every test that expects it; `ViolationRow` doesn't carry the new fields yet so nothing renders.
+
+- [ ] **Step 4: Implement**
+
+Edit `apps/web/src/components/software/ComplianceDashboard.tsx`. Extend `ViolationRow`:
+
+```tsx
+type ViolationRow = {
+  device: {
+    id: string;
+    hostname: string;
+  };
+  compliance: {
+    policyId: string;
+    violations?: Array<{
+      type: string;
+      rule?: {
+        catalogId?: string;
+      };
+    }>;
+    remediationStatus?: string;
+    installRemediationStatus?: string;
+    lastInstallRemediationAttempt?: string;
+    installRemediationAttempts?: number;
+    lastChecked: string;
+  };
+};
+```
+
+Add module-level constants and helpers (placed near `parsePolicyMode`, before the component — pure functions, no component state needed):
+
+```tsx
+const installStatusLabelKeys: Record<string, string> = {
+  pending: "policies:software.complianceDashboard.installStatusPending",
+  in_progress: "policies:software.complianceDashboard.installStatusInProgress",
+  completed: "policies:software.complianceDashboard.installStatusCompleted",
+  failed: "policies:software.complianceDashboard.installStatusFailed",
+  gave_up: "policies:software.complianceDashboard.installStatusGaveUp",
+  skipped: "policies:software.complianceDashboard.installStatusSkipped",
+};
+
+const installStatusBadgeStyles: Record<string, string> = {
+  pending: "bg-blue-100 text-blue-700",
+  in_progress: "bg-blue-100 text-blue-700",
+  completed: "bg-emerald-100 text-emerald-700",
+  failed: "bg-amber-100 text-amber-700",
+  // 'gave_up' is a distinct terminal state from 'failed' (spec Risks §1: the
+  // install-loop guard's give-up state must be visible, not just another
+  // shade of "broken") — destructive red instead of amber so it reads as
+  // "Breeze stopped trying", not "one attempt failed".
+  gave_up: "bg-destructive/10 text-destructive",
+  skipped: "bg-slate-100 text-slate-600",
+};
+
+function installStatusBadgeClass(status: string): string {
+  return installStatusBadgeStyles[status] ?? installStatusBadgeStyles.failed;
+}
+
+// A 'skipped' status collapses three causes W02 does not persist separately
+// (see this task's Ground Truth — no column stores WHICH one fired): no
+// catalogId on the rule, the per-pass cap, or no install method for the
+// device's platform (W03). Of those three, only the first is reconstructable
+// from data already on this row — the violation's own rule carries catalogId
+// (W01, contract D9) — so that is the only case given a specific, actionable
+// explanation. The other two collapse into one honest, hedged sentence
+// rather than a false claim of precision this data can't support.
+function installSkipHasMissingCatalogLink(row: ViolationRow): boolean {
+  return (row.compliance.violations ?? []).some(
+    (violation) => violation.type === "missing" && !violation.rule?.catalogId,
+  );
+}
+```
+
+Insert a new block between the existing "Remediation:" `<div>` (`:633-637`) and the "Checked:" `<div>` (`:638-641`):
+
+```tsx
+              <div className="text-xs text-muted-foreground">
+                {i18n.t("policies:software.complianceDashboard.remediation")}
+                {row.compliance.remediationStatus ??
+                  i18n.t("policies:software.complianceDashboard.none")}
+              </div>
+              {row.compliance.installRemediationStatus &&
+                row.compliance.installRemediationStatus !== "none" && (
+                  <div
+                    className="flex flex-col items-start gap-1 text-xs text-muted-foreground sm:items-end"
+                    data-testid={`install-remediation-${row.device.id}`}
+                  >
+                    <span
+                      className={`rounded-full px-2 py-0.5 text-xs font-medium ${installStatusBadgeClass(
+                        row.compliance.installRemediationStatus,
+                      )}`}
+                    >
+                      {i18n.t(
+                        /* i18n-dynamic */ installStatusLabelKeys[
+                          row.compliance.installRemediationStatus
+                        ] ?? installStatusLabelKeys.failed,
+                      )}
+                    </span>
+                    {row.compliance.installRemediationStatus === "skipped" && (
+                      <span>
+                        {installSkipHasMissingCatalogLink(row)
+                          ? i18n.t(
+                              "policies:software.complianceDashboard.installSkippedNoCatalog",
+                            )
+                          : i18n.t(
+                              "policies:software.complianceDashboard.installSkippedCapOrPlatform",
+                            )}
+                      </span>
+                    )}
+                    {!!row.compliance.installRemediationAttempts && (
+                      <span>
+                        {i18n.t(
+                          "policies:software.complianceDashboard.installAttempts",
+                          { count: row.compliance.installRemediationAttempts },
+                        )}
+                      </span>
+                    )}
+                    {row.compliance.lastInstallRemediationAttempt && (
+                      <span>
+                        {i18n.t(
+                          "policies:software.complianceDashboard.installLastAttempt",
+                        )}
+                        {formatDateTime(row.compliance.lastInstallRemediationAttempt)}
+                      </span>
+                    )}
+                  </div>
+                )}
+              <div className="text-xs text-muted-foreground">
+                {i18n.t("policies:software.complianceDashboard.checked")}
+                {formatDateTime(row.compliance.lastChecked)}
+              </div>
+```
+
+Add the ten new keys to `apps/web/src/locales/en/policies.json`, in the `complianceDashboard` object, after the two keys Task 3 added (`"armInstallRequiresPermission"` is now the last key before the object's closing `},`):
+
+```json
+      "armInstallRequiresPermission": "Arming automatic install requires the devices.execute permission. Ask an administrator to grant it, then try again.",
+      "installStatusPending": "Install queued",
+      "installStatusInProgress": "Installing…",
+      "installStatusCompleted": "Installed",
+      "installStatusFailed": "Install failed",
+      "installStatusGaveUp": "Gave up after repeated failures",
+      "installStatusSkipped": "Skipped this pass",
+      "installSkippedNoCatalog": "A required rule has no linked catalog item, so there's nothing to install. Add a catalog link in the policy editor to fix this.",
+      "installSkippedCapOrPlatform": "Not a failure — either the per-pass install cap was reached or this device's platform has no install method for the software. May be attempted again next pass.",
+      "installAttempts": "{{count}} attempt(s)",
+      "installLastAttempt": "Last install attempt: "
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cd apps/web && npx vitest run src/components/software/ComplianceDashboard.autoInstall.test.tsx`
+Expected: PASS (9 tests total across all three `describe` blocks in the file).
+
+- [ ] **Step 6: Run the full ComplianceDashboard suite to check for regressions**
+
+Run: `cd apps/web && npx vitest run src/components/software/ComplianceDashboard.ownerScope.test.tsx src/components/software/ComplianceDashboard.autoInstall.test.tsx`
+Expected: PASS (both files).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/components/software/ComplianceDashboard.tsx \
+        apps/web/src/components/software/ComplianceDashboard.autoInstall.test.tsx \
+        apps/web/src/locales/en/policies.json
+git commit -m "$(cat <<'EOF'
+feat(web): surface install-remediation status per device in the compliance view (#5505 W04, coordinator scope addition)
+
+Spec Risks §1 requires the install-loop give-up counter to be "visible
+in the UI"; nothing did that until now. Renders a status badge (queued
+/ installing / installed / failed / skipped / gave up) per device in
+the Recent Violations list, giving 'gave_up' distinct destructive
+styling rather than another shade of "failed" so the give-up state
+reads as terminal, not transient. Shows the consecutive attempt count
+when non-zero and the last-attempt time. For 'skipped' — which W02
+collapses three causes into (no catalogId, the per-pass cap, or no
+install method for the platform) with no persisted sub-reason — gives
+the one case reconstructable from already-projected data (no catalogId
+on the violation's own rule) a specific, actionable explanation, and
+hedges honestly on the other two rather than fabricating certainty.
+Consumes W06 Task 3's widened GET /violations projection; degrades to
+rendering nothing extra (today's behavior) if W06 has not landed.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01ANjBwca2cfsLWDLJro3fkz
+EOF
+)"
+```
+
+## Task 5: `DeploymentList` — "Policy-owned" badge
+
+**Files:**
+- Modify: `apps/web/src/components/software/DeploymentList.tsx`
+- Modify: `apps/web/src/locales/en/policies.json`
+- Create: `apps/web/src/components/software/DeploymentList.policyOwned.test.tsx`
+
+**Interfaces:**
+- Consumes: `software_policy_id` on `GET /software/deployments` rows, produced by W03 (flows automatically per the Global Constraints note — no API change needed in this wave).
+- Produces: nothing consumed elsewhere in this plan.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/components/software/DeploymentList.policyOwned.test.tsx`:
+
+```tsx
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import DeploymentList from "./DeploymentList";
+import { fetchWithAuth } from "../../stores/auth";
+
+vi.mock("../../stores/auth", () => ({ fetchWithAuth: vi.fn() }));
+vi.mock("../shared/Toast", () => ({ showToast: vi.fn() }));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+const jsonResponse = (payload: unknown): Response =>
+  ({ ok: true, status: 200, statusText: "OK", json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+const POLICY_OWNED = {
+  id: "dep-policy-1",
+  orgId: "org-1",
+  name: "Required Apps — auto-install",
+  scheduleType: "immediate",
+  createdAt: "2026-09-10T10:00:00Z",
+  status: "pending",
+  softwarePolicyId: "pol-1",
+  counts: { pending: 3, inProgress: 0, completed: 0, failed: 0, cancelled: 0, total: 3 },
+};
+
+const MANUAL = {
+  id: "dep-manual-1",
+  orgId: "org-1",
+  name: "Chrome Rollout",
+  scheduleType: "immediate",
+  createdAt: "2026-09-10T09:00:00Z",
+  status: "pending",
+  softwarePolicyId: null,
+  counts: { pending: 1, inProgress: 0, completed: 0, failed: 0, cancelled: 0, total: 1 },
+};
+
+describe("DeploymentList — policy-owned badge (#5509)", () => {
+  it("labels a policy-originated deployment as policy-owned", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ data: [POLICY_OWNED, MANUAL], pagination: { page: 1, limit: 20, total: 2 } }),
+    );
+    render(<DeploymentList />);
+    await waitFor(() => expect(screen.getByTestId("deployment-row-dep-policy-1")).toBeInTheDocument());
+    expect(screen.getByTestId("deployment-policy-owned-dep-policy-1")).toHaveTextContent("Policy-owned");
+    expect(screen.queryByTestId("deployment-policy-owned-dep-manual-1")).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/web && npx vitest run src/components/software/DeploymentList.policyOwned.test.tsx`
+Expected: FAIL — `getByTestId("deployment-policy-owned-dep-policy-1")` not found.
+
+- [ ] **Step 3: Implement**
+
+Edit `apps/web/src/components/software/DeploymentList.tsx`. Add `ShieldCheck` to the lucide-react import:
+
+```tsx
+import {
+  AlertTriangle,
+  CheckCircle,
+  Loader2,
+  PlayCircle,
+  ShieldCheck,
+  XCircle,
+} from "lucide-react";
+```
+
+Extend `DeploymentRow`:
+
+```tsx
+type DeploymentRow = {
+  id: string;
+  orgId?: string;
+  name: string;
+  deploymentType?: string;
+  scheduleType: string;
+  scheduledAt?: string | null;
+  createdAt: string;
+  status: SoftwareDeploymentAggregateStatus;
+  counts: SoftwareDeploymentCounts;
+  /** Set when this deployment was created by policy remediation rather than
+   *  a human operator (software_policy_id on software_deployments, #5505
+   *  W03). Null/undefined for an ordinary manual deployment. */
+  softwarePolicyId?: string | null;
+};
+```
+
+Replace the Name column's `<td>` body:
+
+```tsx
+                        <td className="px-4 py-3">
+                          <div className="flex items-center gap-2">
+                            <p className="font-medium text-foreground">
+                              {item.name}
+                            </p>
+                            {item.softwarePolicyId && (
+                              <span
+                                className="inline-flex items-center gap-1 rounded-full border border-primary/30 bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary"
+                                title={i18n.t(
+                                  "policies:software.deploymentList.policyOwnedTooltip",
+                                )}
+                                data-testid={`deployment-policy-owned-${item.id}`}
+                              >
+                                <ShieldCheck className="h-3 w-3" />
+                                {i18n.t("policies:software.deploymentList.policyOwned")}
+                              </span>
+                            )}
+                          </div>
+                          <p className="text-xs text-muted-foreground">
+                            {item.id}
+                          </p>
+                        </td>
+```
+
+Add the two new keys to `apps/web/src/locales/en/policies.json`. Find the `deploymentList` section's last key (`"managerUnavailableSummary_other"` at line 1428, immediately before that object's closing `},`) and insert before it:
+
+```json
+      "managerUnavailableSummary_other": "{{count}} devices are missing their package manager. This is a one-time device setup task — install winget (Windows) or Homebrew (macOS) on them; until then every package-manager deployment to them will fail.",
+      "policyOwned": "Policy-owned",
+      "policyOwnedTooltip": "Created automatically by a software policy's auto-install remediation"
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd apps/web && npx vitest run src/components/software/DeploymentList.policyOwned.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Run the existing DeploymentList suite to check for regressions**
+
+Run: `cd apps/web && npx vitest run src/components/software/DeploymentList.test.tsx src/components/software/DeploymentList.policyOwned.test.tsx`
+Expected: PASS (both files).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/software/DeploymentList.tsx \
+        apps/web/src/components/software/DeploymentList.policyOwned.test.tsx \
+        apps/web/src/locales/en/policies.json
+git commit -m "$(cat <<'EOF'
+feat(web): DeploymentList — label policy-owned deployments (#5505 W04)
+
+Renders a "Policy-owned" badge next to any deployment whose
+software_policy_id is set (W03's new column on software_deployments),
+so a technician can tell a policy-remediation-created deployment apart
+from one they created by hand. No API change needed: GET
+/software/deployments already wildcard-selects the row and will
+include the new column once W03 lands.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01ANjBwca2cfsLWDLJro3fkz
+EOF
+)"
+```
+
+## Task 6: Locale parity — backfill the 7 non-English locales
+
+**Files:**
+- Modify: `apps/web/src/locales/de-DE/policies.json`
+- Modify: `apps/web/src/locales/es-419/policies.json`
+- Modify: `apps/web/src/locales/fr-CA/policies.json`
+- Modify: `apps/web/src/locales/fr-FR/policies.json`
+- Modify: `apps/web/src/locales/it-IT/policies.json`
+- Modify: `apps/web/src/locales/pt-BR/policies.json`
+- Modify: `apps/web/src/locales/tr-TR/policies.json`
+
+**Interfaces:**
+- Consumes: the 22 keys added to `en/policies.json` across Tasks 1-5 — `policyForm`: `catalogLink`, `catalogLinkNone`, `autoInstall`, `autoInstallCatalogWarning`, `dryRunLoading`, `dryRunResult`, `dryRunUnavailable`, `dryRunNewPolicy` (8, Tasks 1-2); `complianceDashboard`: `armInstallRequiresMfa`, `armInstallRequiresPermission` (Task 3), `installStatusPending`, `installStatusInProgress`, `installStatusCompleted`, `installStatusFailed`, `installStatusGaveUp`, `installStatusSkipped`, `installSkippedNoCatalog`, `installSkippedCapOrPlatform`, `installAttempts`, `installLastAttempt` (10, Task 4) — 12 total; `deploymentList`: `policyOwned`, `policyOwnedTooltip` (2, Task 5).
+- Produces: nothing — this is the plan's final consolidation task.
+
+- [ ] **Step 1: Run `localeParity.test.ts` to confirm it is currently red**
+
+Run: `cd apps/web && npx vitest run src/lib/i18n/localeParity.test.ts`
+Expected: FAIL — each of the 7 non-English locale files is missing the 22 keys Tasks 1-5 added to `en/policies.json`.
+
+- [ ] **Step 2: Add the keys to `de-DE/policies.json`**
+
+In the `complianceDashboard` object, after `"policyCreated": "Richtlinie erfolgreich erstellt"` (immediately before that object's closing `},`):
+
+```json
+      "policyCreated": "Richtlinie erfolgreich erstellt",
+      "armInstallRequiresMfa": "Die Aktivierung der automatischen Installation erfordert Multi-Faktor-Authentifizierung. Schließen Sie die MFA ab und versuchen Sie es erneut.",
+      "armInstallRequiresPermission": "Die Aktivierung der automatischen Installation erfordert die Berechtigung devices.execute. Bitten Sie einen Administrator, sie zu erteilen, und versuchen Sie es dann erneut.",
+      "installStatusPending": "Installation eingereiht",
+      "installStatusInProgress": "Wird installiert…",
+      "installStatusCompleted": "Installiert",
+      "installStatusFailed": "Installation fehlgeschlagen",
+      "installStatusGaveUp": "Nach wiederholten Fehlschlägen aufgegeben",
+      "installStatusSkipped": "Diesen Durchlauf übersprungen",
+      "installSkippedNoCatalog": "Eine erforderliche Regel hat keinen verknüpften Katalogeintrag, daher gibt es nichts zu installieren. Fügen Sie im Richtlinien-Editor eine Katalogverknüpfung hinzu, um dies zu beheben.",
+      "installSkippedCapOrPlatform": "Kein Fehler — entweder wurde die Installationsobergrenze pro Durchlauf erreicht, oder für die Plattform dieses Geräts gibt es keine Installationsmethode für die Software. Wird eventuell im nächsten Durchlauf erneut versucht.",
+      "installAttempts": "{{count}} Versuch(e)",
+      "installLastAttempt": "Letzter Installationsversuch: "
+```
+
+In the `deploymentList` object, after `"managerUnavailableSummary_other": "Auf {{count}} Geräten fehlt der Paketmanager. Das ist eine einmalige Geräteeinrichtung – installieren Sie dort winget (Windows) oder Homebrew (macOS); bis dahin schlägt jede Paketmanager-Bereitstellung darauf fehl."`:
+
+```json
+      "policyOwned": "Richtliniengesteuert",
+      "policyOwnedTooltip": "Automatisch erstellt durch die Auto-Installations-Remediation einer Softwarerichtlinie"
+```
+
+In the `policyForm` object, after `"saving": "Speichern..."`:
+
+```json
+      "catalogLink": "Verknüpfter Katalogeintrag",
+      "catalogLinkNone": "Keiner — nicht verknüpft",
+      "autoInstall": "Fehlende Software automatisch installieren",
+      "autoInstallCatalogWarning": "{{count}} von {{total}} Regel(n) haben keinen verknüpften Katalogeintrag und werden als fehlend erkannt, aber nie installiert.",
+      "dryRunLoading": "Wird geprüft, wie viele Geräte betroffen sind...",
+      "dryRunResult": "Dies installiert fehlende Software auf etwa {{count}} Gerät(en).",
+      "dryRunUnavailable": "Die Geräteanzahl-Vorschau ist noch nicht verfügbar. Die Aktivierung wirkt trotzdem beim nächsten Compliance-Durchlauf.",
+      "dryRunNewPolicy": "Dies ist eine neue Richtlinie — die Auswirkung auf Geräte ist erst nach dem ersten Compliance-Durchlauf nach dem Speichern bekannt."
+```
+
+- [ ] **Step 3: Add the keys to `es-419/policies.json`**
+
+`complianceDashboard`, after `"policyCreated": "Política creada exitosamente"`:
+
+```json
+      "policyCreated": "Política creada exitosamente",
+      "armInstallRequiresMfa": "Activar la instalación automática requiere autenticación multifactor. Complete la MFA y vuelva a intentarlo.",
+      "armInstallRequiresPermission": "Activar la instalación automática requiere el permiso devices.execute. Pida a un administrador que lo conceda y vuelva a intentarlo.",
+      "installStatusPending": "Instalación en cola",
+      "installStatusInProgress": "Instalando…",
+      "installStatusCompleted": "Instalado",
+      "installStatusFailed": "Falló la instalación",
+      "installStatusGaveUp": "Se desistió tras fallos repetidos",
+      "installStatusSkipped": "Omitido en este ciclo",
+      "installSkippedNoCatalog": "Una regla obligatoria no tiene un elemento de catálogo vinculado, así que no hay nada que instalar. Agregue un vínculo de catálogo en el editor de políticas para solucionarlo.",
+      "installSkippedCapOrPlatform": "No es un error: se alcanzó el límite de instalaciones por ciclo o la plataforma de este dispositivo no tiene un método de instalación para el software. Es posible que se intente de nuevo en el próximo ciclo.",
+      "installAttempts": "{{count}} intento(s)",
+      "installLastAttempt": "Último intento de instalación: "
+```
+
+`deploymentList`, after `"managerUnavailableSummary_other": "A {{count}} dispositivos les falta su gestor de paquetes. Es una tarea de configuración única del dispositivo: instala winget (Windows) o Homebrew (macOS) en ellos; hasta entonces, todas las implementaciones con gestor de paquetes fallarán."`:
+
+```json
+      "policyOwned": "Gestionado por política",
+      "policyOwnedTooltip": "Creado automáticamente por la remediación de instalación automática de una política de software"
+```
+
+`policyForm`, after `"saving": "Guardando..."`:
+
+```json
+      "catalogLink": "Elemento de catálogo vinculado",
+      "catalogLinkNone": "Ninguno — no vinculado",
+      "autoInstall": "Instalar automáticamente el software faltante",
+      "autoInstallCatalogWarning": "{{count}} de {{total}} regla(s) no tienen un elemento de catálogo vinculado y se detectarán como faltantes, pero nunca se instalarán.",
+      "dryRunLoading": "Comprobando cuántos dispositivos se verán afectados...",
+      "dryRunResult": "Esto instalará el software faltante en aproximadamente {{count}} dispositivo(s).",
+      "dryRunUnavailable": "La vista previa del número de dispositivos aún no está disponible. La activación tendrá efecto de todos modos en el próximo análisis de cumplimiento.",
+      "dryRunNewPolicy": "Esta es una política nueva — el impacto en los dispositivos no se conocerá hasta el primer análisis de cumplimiento después de guardar."
+```
+
+- [ ] **Step 4: Add the keys to `fr-CA/policies.json`**
+
+`complianceDashboard`, after `"policyCreated": "Politique créée avec succès"`:
+
+```json
+      "policyCreated": "Politique créée avec succès",
+      "armInstallRequiresMfa": "L'activation de l'installation automatique nécessite l'authentification multifacteur. Complétez la MFA, puis réessayez.",
+      "armInstallRequiresPermission": "L'activation de l'installation automatique nécessite la permission devices.execute. Demandez à un administrateur de l'accorder, puis réessayez.",
+      "installStatusPending": "Installation en file d'attente",
+      "installStatusInProgress": "Installation en cours…",
+      "installStatusCompleted": "Installé",
+      "installStatusFailed": "Échec de l'installation",
+      "installStatusGaveUp": "Abandonné après des échecs répétés",
+      "installStatusSkipped": "Ignoré pour ce cycle",
+      "installSkippedNoCatalog": "Une règle obligatoire n'a pas d'élément de catalogue lié, donc il n'y a rien à installer. Ajoutez un lien de catalogue dans l'éditeur de politiques pour corriger cela.",
+      "installSkippedCapOrPlatform": "Ce n'est pas un échec — soit la limite d'installations par cycle a été atteinte, soit la plateforme de cet appareil n'a pas de méthode d'installation pour le logiciel. Une nouvelle tentative pourrait avoir lieu au prochain cycle.",
+      "installAttempts": "{{count}} tentative(s)",
+      "installLastAttempt": "Dernière tentative d'installation : "
+```
+
+`deploymentList`, after `"managerUnavailableSummary_other": "Le gestionnaire de paquets est absent sur {{count}} appareils. Il s'agit d'une configuration ponctuelle : installez-y winget (Windows) ou Homebrew (macOS); d'ici là, tout déploiement par gestionnaire de paquets échouera."`:
+
+```json
+      "policyOwned": "Géré par une politique",
+      "policyOwnedTooltip": "Créé automatiquement par la remédiation d'installation automatique d'une politique logicielle"
+```
+
+`policyForm`, after `"saving": "Enregistrement..."`:
+
+```json
+      "catalogLink": "Élément de catalogue lié",
+      "catalogLinkNone": "Aucun — non lié",
+      "autoInstall": "Installer automatiquement les logiciels manquants",
+      "autoInstallCatalogWarning": "{{count}} règle(s) sur {{total}} n'ont pas d'élément de catalogue lié et seront détectées comme manquantes, mais jamais installées.",
+      "dryRunLoading": "Vérification du nombre d'appareils touchés...",
+      "dryRunResult": "Ceci installera les logiciels manquants sur environ {{count}} appareil(s).",
+      "dryRunUnavailable": "L'aperçu du nombre d'appareils n'est pas encore disponible. L'activation prendra quand même effet lors de la prochaine vérification de conformité.",
+      "dryRunNewPolicy": "Il s'agit d'une nouvelle politique — l'impact sur les appareils ne sera connu qu'après la première vérification de conformité suivant l'enregistrement."
+```
+
+- [ ] **Step 5: Add the keys to `fr-FR/policies.json`**
+
+`complianceDashboard`, after `"policyCreated": "Politique créée avec succès"`:
+
+```json
+      "policyCreated": "Politique créée avec succès",
+      "armInstallRequiresMfa": "L'activation de l'installation automatique nécessite l'authentification multifacteur. Terminez la MFA, puis réessayez.",
+      "armInstallRequiresPermission": "L'activation de l'installation automatique nécessite la permission devices.execute. Demandez à un administrateur de l'accorder, puis réessayez.",
+      "installStatusPending": "Installation en file d'attente",
+      "installStatusInProgress": "Installation en cours…",
+      "installStatusCompleted": "Installé",
+      "installStatusFailed": "Échec de l'installation",
+      "installStatusGaveUp": "Abandon après des échecs répétés",
+      "installStatusSkipped": "Ignoré lors de ce passage",
+      "installSkippedNoCatalog": "Une règle obligatoire n'a pas d'élément de catalogue lié, il n'y a donc rien à installer. Ajoutez un lien de catalogue dans l'éditeur de politique pour corriger cela.",
+      "installSkippedCapOrPlatform": "Ce n'est pas un échec : soit la limite d'installations par passage a été atteinte, soit la plateforme de cet appareil n'a pas de méthode d'installation pour ce logiciel. Une nouvelle tentative pourra avoir lieu au prochain passage.",
+      "installAttempts": "{{count}} tentative(s)",
+      "installLastAttempt": "Dernière tentative d'installation : "
+```
+
+`deploymentList`, after `"managerUnavailableSummary_other": "Le gestionnaire de paquets est absent sur {{count}} appareils. Il s'agit d'une configuration ponctuelle : installez-y winget (Windows) ou Homebrew (macOS) ; d'ici là, tout déploiement par gestionnaire de paquets échouera."`:
+
+```json
+      "policyOwned": "Géré par une politique",
+      "policyOwnedTooltip": "Créé automatiquement par la remédiation d'installation automatique d'une politique logicielle"
+```
+
+`policyForm`, after `"saving": "Enregistrement..."`:
+
+```json
+      "catalogLink": "Élément de catalogue lié",
+      "catalogLinkNone": "Aucun — non lié",
+      "autoInstall": "Installer automatiquement les logiciels manquants",
+      "autoInstallCatalogWarning": "{{count}} règle(s) sur {{total}} n'ont pas d'élément de catalogue lié et seront détectées comme manquantes mais jamais installées.",
+      "dryRunLoading": "Vérification du nombre d'appareils concernés...",
+      "dryRunResult": "Cela installera les logiciels manquants sur environ {{count}} appareil(s).",
+      "dryRunUnavailable": "L'aperçu du nombre d'appareils n'est pas encore disponible. L'activation prendra tout de même effet lors du prochain contrôle de conformité.",
+      "dryRunNewPolicy": "Il s'agit d'une nouvelle politique — l'impact sur les appareils ne sera connu qu'après le premier contrôle de conformité suivant l'enregistrement."
+```
+
+- [ ] **Step 6: Add the keys to `it-IT/policies.json`**
+
+`complianceDashboard`, after `"policyCreated": "Criterio creato correttamente"`:
+
+```json
+      "policyCreated": "Criterio creato correttamente",
+      "armInstallRequiresMfa": "L'attivazione dell'installazione automatica richiede l'autenticazione a più fattori. Completa la MFA, quindi riprova.",
+      "armInstallRequiresPermission": "L'attivazione dell'installazione automatica richiede l'autorizzazione devices.execute. Chiedi a un amministratore di concederla, quindi riprova.",
+      "installStatusPending": "Installazione in coda",
+      "installStatusInProgress": "Installazione in corso…",
+      "installStatusCompleted": "Installato",
+      "installStatusFailed": "Installazione non riuscita",
+      "installStatusGaveUp": "Rinuncia dopo ripetuti fallimenti",
+      "installStatusSkipped": "Saltato in questo passaggio",
+      "installSkippedNoCatalog": "Una regola obbligatoria non ha un elemento del catalogo collegato, quindi non c'è nulla da installare. Aggiungi un collegamento al catalogo nell'editor dei criteri per risolvere il problema.",
+      "installSkippedCapOrPlatform": "Non è un errore: è stato raggiunto il limite di installazioni per passaggio oppure la piattaforma di questo dispositivo non ha un metodo di installazione per il software. Potrebbe essere ritentato al passaggio successivo.",
+      "installAttempts": "{{count}} tentativo/i",
+      "installLastAttempt": "Ultimo tentativo di installazione: "
+```
+
+`deploymentList`, after `"managerUnavailableSummary_other": "Su {{count}} dispositivi manca il gestore di pacchetti. È una configurazione una tantum dei dispositivi: installa winget (Windows) o Homebrew (macOS); fino ad allora ogni distribuzione tramite gestore di pacchetti fallirà."`:
+
+```json
+      "policyOwned": "Gestito da criterio",
+      "policyOwnedTooltip": "Creato automaticamente dalla remediation di installazione automatica di un criterio software"
+```
+
+`policyForm`, after `"saving": "Salvataggio..."`:
+
+```json
+      "catalogLink": "Elemento del catalogo collegato",
+      "catalogLinkNone": "Nessuno — non collegato",
+      "autoInstall": "Installa automaticamente il software mancante",
+      "autoInstallCatalogWarning": "{{count}} di {{total}} regola/e non hanno un elemento del catalogo collegato e verranno rilevate come mancanti ma mai installate.",
+      "dryRunLoading": "Verifica di quanti dispositivi saranno interessati...",
+      "dryRunResult": "Questo installerà il software mancante su circa {{count}} dispositivo/i.",
+      "dryRunUnavailable": "L'anteprima del numero di dispositivi non è ancora disponibile. L'attivazione avrà comunque effetto alla prossima verifica di conformità.",
+      "dryRunNewPolicy": "Questo è un nuovo criterio — l'impatto sui dispositivi non sarà noto fino alla prima verifica di conformità dopo il salvataggio."
+```
+
+- [ ] **Step 7: Add the keys to `pt-BR/policies.json`**
+
+`complianceDashboard`, after `"policyCreated": "Política criada com sucesso"`:
+
+```json
+      "policyCreated": "Política criada com sucesso",
+      "armInstallRequiresMfa": "Ativar a instalação automática requer autenticação multifator. Conclua o MFA e tente novamente.",
+      "armInstallRequiresPermission": "Ativar a instalação automática requer a permissão devices.execute. Peça a um administrador para concedê-la e tente novamente.",
+      "installStatusPending": "Instalação na fila",
+      "installStatusInProgress": "Instalando…",
+      "installStatusCompleted": "Instalado",
+      "installStatusFailed": "Falha na instalação",
+      "installStatusGaveUp": "Desistiu após falhas repetidas",
+      "installStatusSkipped": "Ignorado nesta passagem",
+      "installSkippedNoCatalog": "Uma regra obrigatória não tem um item de catálogo vinculado, então não há nada para instalar. Adicione um vínculo de catálogo no editor de políticas para corrigir isso.",
+      "installSkippedCapOrPlatform": "Não é uma falha — o limite de instalações por passagem foi atingido ou a plataforma deste dispositivo não tem um método de instalação para o software. Pode ser tentado novamente na próxima passagem.",
+      "installAttempts": "{{count}} tentativa(s)",
+      "installLastAttempt": "Última tentativa de instalação: "
+```
+
+`deploymentList`, after `"managerUnavailableSummary_other": "Falta o gerenciador de pacotes em {{count}} dispositivos. É uma configuração única dos dispositivos: instale o winget (Windows) ou o Homebrew (macOS) neles; até lá, toda implantação por gerenciador de pacotes vai falhar."`:
+
+```json
+      "policyOwned": "Gerenciado por política",
+      "policyOwnedTooltip": "Criado automaticamente pela remediação de instalação automática de uma política de software"
+```
+
+`policyForm`, after `"saving": "Salvando..."`:
+
+```json
+      "catalogLink": "Item de catálogo vinculado",
+      "catalogLinkNone": "Nenhum — não vinculado",
+      "autoInstall": "Instalar automaticamente o software ausente",
+      "autoInstallCatalogWarning": "{{count}} de {{total}} regra(s) não têm um item de catálogo vinculado e serão detectadas como ausentes, mas nunca instaladas.",
+      "dryRunLoading": "Verificando quantos dispositivos serão afetados...",
+      "dryRunResult": "Isso instalará o software ausente em aproximadamente {{count}} dispositivo(s).",
+      "dryRunUnavailable": "A prévia da contagem de dispositivos ainda não está disponível. A ativação ainda terá efeito na próxima verificação de conformidade.",
+      "dryRunNewPolicy": "Esta é uma política nova — o impacto nos dispositivos só será conhecido após a primeira verificação de conformidade depois de salvar."
+```
+
+- [ ] **Step 8: Add the keys to `tr-TR/policies.json`**
+
+`complianceDashboard`, after `"policyCreated": "Politika başarıyla oluşturuldu"`:
+
+```json
+      "policyCreated": "Politika başarıyla oluşturuldu",
+      "armInstallRequiresMfa": "Otomatik yüklemeyi etkinleştirmek çok faktörlü kimlik doğrulama gerektirir. MFA'yı tamamlayıp tekrar deneyin.",
+      "armInstallRequiresPermission": "Otomatik yüklemeyi etkinleştirmek devices.execute iznini gerektirir. Bir yöneticiden bu izni vermesini isteyin, ardından tekrar deneyin.",
+      "installStatusPending": "Yükleme sırada",
+      "installStatusInProgress": "Yükleniyor…",
+      "installStatusCompleted": "Yüklendi",
+      "installStatusFailed": "Yükleme başarısız",
+      "installStatusGaveUp": "Tekrarlanan başarısızlıklardan sonra vazgeçildi",
+      "installStatusSkipped": "Bu geçişte atlandı",
+      "installSkippedNoCatalog": "Gerekli bir kuralın bağlı bir katalog öğesi yok, bu yüzden yüklenecek bir şey yok. Bunu düzeltmek için politika düzenleyicisinde bir katalog bağlantısı ekleyin.",
+      "installSkippedCapOrPlatform": "Bu bir hata değil — geçiş başına yükleme sınırına ulaşıldı ya da bu cihazın platformunda yazılım için bir yükleme yöntemi yok. Bir sonraki geçişte tekrar denenebilir.",
+      "installAttempts": "{{count}} deneme",
+      "installLastAttempt": "Son yükleme denemesi: "
+```
+
+`deploymentList`, after `"managerUnavailableSummary_other": "{{count}} cihazda paket yöneticisi eksik. Bu, tek seferlik bir cihaz kurulum işidir — o cihazlara winget (Windows) veya Homebrew (macOS) yükleyin; o zamana kadar bu cihazlara yapılan her paket yöneticisi dağıtımı başarısız olacaktır."`:
+
+```json
+      "policyOwned": "Politika tarafından yönetiliyor",
+      "policyOwnedTooltip": "Bir yazılım politikasının otomatik yükleme düzeltmesi tarafından otomatik olarak oluşturuldu"
+```
+
+`policyForm`, after `"saving": "Kaydediliyor..."`:
+
+```json
+      "catalogLink": "Bağlı katalog öğesi",
+      "catalogLinkNone": "Yok — bağlı değil",
+      "autoInstall": "Eksik yazılımı otomatik yükle",
+      "autoInstallCatalogWarning": "{{total}} kuraldan {{count}} tanesinin bağlı bir katalog öğesi yok ve eksik olarak algılanacak ama asla yüklenmeyecek.",
+      "dryRunLoading": "Kaç cihazın etkileneceği kontrol ediliyor...",
+      "dryRunResult": "Bu, eksik yazılımı yaklaşık {{count}} cihaza yükleyecek.",
+      "dryRunUnavailable": "Cihaz sayısı önizlemesi henüz kullanılamıyor. Etkinleştirme yine de bir sonraki uyumluluk taramasında geçerli olacak.",
+      "dryRunNewPolicy": "Bu yeni bir politika — cihaz etkisi, kaydettikten sonraki ilk uyumluluk taramasına kadar bilinmeyecek."
+```
+
+- [ ] **Step 9: Run `localeParity.test.ts` to verify it now passes**
+
+Run: `cd apps/web && npx vitest run src/lib/i18n/localeParity.test.ts`
+Expected: PASS.
+
+- [ ] **Step 10: Run every test file this plan touched or created, in one pass**
+
+Run:
+```bash
+cd apps/web && npx vitest run \
+  src/components/software/PolicyForm.autoInstall.test.tsx \
+  src/components/software/ComplianceDashboard.autoInstall.test.tsx \
+  src/components/software/ComplianceDashboard.ownerScope.test.tsx \
+  src/components/software/DeploymentList.test.tsx \
+  src/components/software/DeploymentList.policyOwned.test.tsx \
+  src/lib/i18n/localeParity.test.ts \
+  src/lib/__tests__/no-silent-mutations.test.ts
+```
+Expected: PASS (all 7 files). The `no-silent-mutations.test.ts` run confirms `ComplianceDashboard.tsx` was correctly left out of `TARGET_GLOBS` and that the `RUN_ACTION_MIGRATION_BACKLOG` entry added in Task 3 is a valid `apps/web/src/` path.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add apps/web/src/locales/de-DE/policies.json \
+        apps/web/src/locales/es-419/policies.json \
+        apps/web/src/locales/fr-CA/policies.json \
+        apps/web/src/locales/fr-FR/policies.json \
+        apps/web/src/locales/it-IT/policies.json \
+        apps/web/src/locales/pt-BR/policies.json \
+        apps/web/src/locales/tr-TR/policies.json
+git commit -m "$(cat <<'EOF'
+i18n(web): locale parity for the autoInstall arming UI (#5505 W04)
+
+Backfills the 22 keys Tasks 1-5 added to en/policies.json (catalog
+link, autoInstall checkbox, authoring warning, dry-run preview, the two
+coded arming-refusal messages — MFA_REQUIRED and
+DEVICES_EXECUTE_REQUIRED — the six install-remediation status labels
+plus the skip-reason/attempt-count/last-attempt copy, and the
+policy-owned deployment badge) across all 7 other locale directories,
+so localeParity.test.ts is green again. This is the plan's final task
+— the feature is not done until this lands.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01ANjBwca2cfsLWDLJro3fkz
+EOF
+)"
+```
+
+## Self-Review
+
+**1. Spec/task coverage:**
+- "Arm/disarm `autoInstall` in the policy editor" → Task 1 (checkbox) + Task 3 (payload wiring, allowlist-mode guard).
+- "A dry-run count before arming" → Task 2, with the endpoint dependency (now owned by W06, #5522) stated plainly in Global Constraints and the task's own Interfaces block, verified against W06's plan doc rather than trusted from the coordinator's summary, with a verify-or-proceed-in-degraded-mode step.
+- "An authoring warning when `autoInstall` is armed on a policy whose rules lack `catalogId`" → Task 1 (also had to add the `catalogId` field itself — flagged as a necessary prerequisite, not scope creep).
+- **Coordinator scope addition — the install-loop give-up counter must be "visible in the UI" (spec Risks §1)** → Task 4 (new). Surfaces `installRemediationStatus` (with `'gave_up'` given visually distinct destructive styling, never the same treatment as `'failed'`), the consecutive attempt count when non-zero, the last-attempt time, and — for `'skipped'` — the one sub-reason (no linked catalog item) reconstructable from already-projected data, with an honest hedge for the other two (per-pass cap, platform mismatch) that the current schema cannot distinguish. Depends on W06 Task 3 (also newly filed), with its own verify-or-proceed step; the further "no persisted skip sub-reason" gap is flagged to the coordinator in Global Constraints, the same treatment as the dry-run endpoint gap.
+- "Label policy-owned deployments as such" → Task 5, using W03's `software_policy_id` (verified to flow through the existing wildcard-select route with no API change).
+- "Handle the [403] refusal honestly" → Task 3 Steps 5-8, mirroring the established `ManualAssetModal.tsx` `mfaFriendly`/`runAction`/`ActionError` pattern; both coded refusals — `MFA_REQUIRED` and `DEVICES_EXECUTE_REQUIRED` (the exact shapes fixed by the cross-wave contract's post-W01 correction, picked up mid-authoring) — get their own friendly message and are covered by separate tests.
+
+**2. Placeholder scan:** No "TBD"/"handle appropriately"/"similar to Task N" language. Every code step contains complete, real TSX/TS/JSON. The two places this plan intentionally calls or projects data that may not exist yet (`GET /software-policies/:id/install-preview` in Task 2, the three `installRemediationStatus`/`lastInstallRemediationAttempt`/`installRemediationAttempts` fields in Task 4) are each declared as a W06 dependency in at least three places (Global Constraints, the task's own Interfaces block, and an inline code comment at the call/render site) with an explicit verify-or-proceed-in-degraded-mode step, rather than presented as already-real.
+
+**3. Type consistency:** `CatalogOption` is defined once (Task 1, `PolicyForm.tsx`) and imported by name in Task 3 (`ComplianceDashboard.tsx`) rather than redefined. `PolicyFormValues.software[number].catalogId` (Task 1) is the same field read by Task 3's payload construction and `policyToFormDefaults`, and by Task 4's `installSkipHasMissingCatalogLink` (reading the analogous `compliance.violations[].rule.catalogId` on the read side). `DeploymentRow.softwarePolicyId` (Task 5) matches the camelCase Drizzle convention the contract (D7) specifies for the column W03 ships. `dryRun`'s `DryRunState` union in Task 2 is local to `PolicyForm.tsx` and not referenced elsewhere, so no cross-task drift risk there. The three install-remediation field names in Task 4 (`installRemediationStatus`, `lastInstallRemediationAttempt`, `installRemediationAttempts`) are spelled identically in Global Constraints, this task's Ground Truth, its Step 1 verify command, its `ViolationRow` type extension, and its render block — copied verbatim from W06's plan doc (itself copied verbatim from W02's), never re-derived.
+
+**4. Scope boundary check:** No `apps/api` file is modified anywhere in this plan (grep the plan for `apps/api/` — the only occurrences are in Ground Truth citations, dependency notes, and code comments, never in a `Modify:`/`Create:` line or a `git add`).
+
+**5. Task/key-count consistency after the coordinator's scope addition:** six tasks total (was five); Task 4 is new, the former Tasks 4-5 (`DeploymentList`, locale parity) are renumbered to 5-6 throughout, including every internal cross-reference (`File Structure`, Global Constraints' locale-parity bullet, Task 6's own Interfaces/Step-1 text). Twenty-two `en/policies.json` keys total (was twelve): 8 from Tasks 1-2, 2 from Task 3, 10 from the new Task 4, 2 from Task 5 — verified by grepping the plan for `installStatusPending`/`installLastAttempt` (the first/last of Task 4's ten keys) and confirming exactly one block of ten appears under each of the 8 locale sections Task 6 touches.

--- a/docs/superpowers/plans/vuln-patch/2026-09-10-desired-state-software-install-w05-ai-guardrails.md
+++ b/docs/superpowers/plans/vuln-patch/2026-09-10-desired-state-software-install-w05-ai-guardrails.md
@@ -1,0 +1,1229 @@
+---
+tracking_issue: LanternOps/breeze#5505
+---
+
+# Desired-State Software Install — W05: AI Guardrails and Tool Schemas — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Guarantee the AI agent can never arm `remediationOptions.autoInstall` on a software policy — an `autoInstall: true` reaching any of the four AI write sites is refused outright, not silently stripped — while leaving every existing AI capability (including arming `autoUninstall`, and reading a policy's armed state) unchanged.
+
+**Architecture:** Schema typing cannot hold this line (both AI input-validation surfaces let extra/untyped keys reach the handler unmodified — verified below in Ground Truth). The refusal therefore lives as an explicit runtime check inside each of the four handler functions that can write `remediationOptions`, backed by one shared helper and one exported message string so all four sites say the same thing. A companion change makes the refusal greppable in the audit trail and documents it in the guardrail comment block and the tool-facing schema text.
+
+**Tech Stack:** TypeScript, Hono AI tool handlers, Vitest (unit, mocked Drizzle — no live DB needed; this wave ships no migration and no schema change).
+
+**Spec:** `docs/superpowers/specs/vuln-patch/2026-09-10-desired-state-software-install-design.md` (see its "Corrections after ground-truth verification" section — authoritative over the body where they disagree)
+
+**Contract:** `/private/tmp/claude-501/-Users-toddhebebrand--herdr-worktrees-breeze-warranty-testing/4b860881-d3d0-4020-ad1e-65daf215df86/scratchpad/contract-A-desired-state.md` (locked, cross-wave, authoritative — this plan copies the parts it needs verbatim below)
+
+**Tracking:** Feature #5505, wave W05 = sub-issue #5510.
+
+## Global Constraints
+
+(Copied verbatim from the locked contract, `contract-A-desired-state.md`, §D4 and the wave-ownership map — this wave may not diverge from them.)
+
+- **D4 — the AI may never arm install.** `remediationOptionsSchema` (HTTP side) is non-strict, and `aiAgentSdkTools.ts:2251` types `remediationOptions` as `z.record(z.string(), z.unknown())` — schema-level typing cannot hold the line for the AI (verified below: neither AI validation path even uses its own parsed/stripped output). The refusal therefore lives at the four AI write sites: `aiToolsCompliance.ts:287` (create), `:356-357` (update); `aiToolsPolicyPrereqs.ts:441` (create), `:496` (update). An `autoInstall: true` reaching any of them is **refused, not stripped**.
+- **Exact refusal message, verbatim, used at all four sites, exported once:**
+  `'Arming autoInstall requires a human operator with devices.execute and MFA; the AI agent cannot arm software installation.'`
+- W05 also adds an `autoInstall` line to `summarizeEnforcementChange` (`aiToolsSoftwarePolicyAudit.ts:76-84`) so it is greppable in the audit trail, and extends the `aiGuardrails.ts:211-245` comment block, whose text currently names only `autoUninstall` as the arming pair.
+- **Wave ownership map (row for this wave):** W05 #5510 owns `aiGuardrails.ts`, the four AI write sites, AI zod/JSON schemas, `summarizeEnforcementChange`. **Must NOT touch:** everything else — in particular, not `aiToolsCompliance.ts:509` (the `remediate_software_violation` handler's `evaluateSoftwarePolicyArming(policy)` call — W01 owns updating that call site to pass the new required `'uninstall'` verb argument), not `softwarePolicyService.ts` (arming helper, audit-action constants — W01), not the compliance/remediation workers (W02/W03), not any migration, not any HTTP route.
+- **Reads stay Tier 1 and are never escalated.** `list`/`get` on both software-policy AI tools deliberately auto-execute with no approval prompt; this wave must not change that, and the AI may freely **read** a policy's armed state (including a human-armed `autoInstall: true`) — only **writing** it is refused.
+- **Testing gates (non-negotiable):** Red-first on every behavioural change — write the assertion, watch it fail against unmodified code, then implement. Scoped test runs: `cd apps/api && npx vitest run <path>`. **Never** `pnpm --filter <pkg> test -- --run <path>` (the `--` makes vitest run the whole suite in watch mode). Remember vitest's path filter is a plain substring match, not a directory prefix.
+- This wave ships **no migration and no DB schema change** — `remediation_options` is jsonb and the AI write paths bypass `remediationOptionsSchema` entirely (they cast to `Record<string, unknown>`/`any`), so the guard works identically whether or not W01 (which adds `autoInstall` to the typed schema and DB column semantics) has landed yet.
+
+---
+
+## 0. Ground Truth
+
+Every file and line the task brief cited was re-opened against the current worktree (branch `spec/hp-warranty-and-desired-state-install`, commit `02d3e7b143`). **All cited line numbers are confirmed correct — nothing in the brief was wrong.** Full verbatim quotes below.
+
+### 0.1 The four AI write sites
+
+**`apps/api/src/services/aiToolsCompliance.ts:262-319`** (create action, `manage_software_policy` tool):
+```ts
+    if (action === 'create') {
+      if (typeof input.name !== 'string' || typeof input.mode !== 'string') {
+        return JSON.stringify({ error: 'name and mode are required for create' });
+      }
+
+      const orgResolution = resolveWritableToolOrgId(auth, typeof input.orgId === 'string' ? input.orgId : undefined);
+      if (!orgResolution.orgId) return JSON.stringify({ error: orgResolution.error });
+
+      const rules = normalizeSoftwarePolicyRules({
+        software: Array.isArray(input.software) ? input.software : [],
+        allowUnknown: input.allowUnknown === true,
+      });
+      if (rules.software.length === 0) {
+        return JSON.stringify({ error: 'At least one software rule is required' });
+      }
+
+      const [policy] = await db
+        .insert(softwarePolicies)
+        .values({
+          orgId: orgResolution.orgId,
+          name: input.name as string,
+          description: (input.description as string) ?? null,
+          mode: input.mode as 'allowlist' | 'blocklist' | 'audit',
+          rules,
+          enforceMode: input.enforceMode === true,
+          remediationOptions: (input.remediationOptions as Record<string, unknown>) ?? null,   // :287
+          createdBy: auth.user.id,
+        })
+        .returning();
+```
+Confirmed: `remediationOptions` write is at **line 287**, exactly as cited.
+
+**`apps/api/src/services/aiToolsCompliance.ts:321-358`** (update action):
+```ts
+    if (action === 'update') {
+      if (!input.policyId) return JSON.stringify({ error: 'policyId is required' });
+      ...
+      const [existing] = await db.select().from(softwarePolicies).where(and(...conditions)).limit(1);
+      if (!existing) return JSON.stringify({ error: 'Policy not found or access denied' });
+
+      // Partner-wide templates are administrable only with the partner-wide
+      // capability (same gate as the HTTP route).
+      if (existing.orgId === null && !canManagePartnerWidePolicies(auth)) {
+        return JSON.stringify({ error: 'Modifying a partner-wide software policy requires full partner org access (orgAccess must be "all")' });
+      }
+
+      const updates: Omit<Partial<typeof softwarePolicies.$inferInsert>, 'approvalGeneration'> & { approvalGeneration?: SQL } = {
+        updatedAt: new Date(),
+        approvalGeneration: bumpApprovalGeneration(softwarePolicies.approvalGeneration),
+      };
+      if (typeof input.name === 'string') updates.name = input.name;
+      if (typeof input.description === 'string') updates.description = input.description;
+      if (typeof input.mode === 'string') updates.mode = input.mode as 'allowlist' | 'blocklist' | 'audit';
+      if (typeof input.enforceMode === 'boolean') updates.enforceMode = input.enforceMode;
+      if (typeof input.isActive === 'boolean') updates.isActive = input.isActive;
+      if (input.remediationOptions && typeof input.remediationOptions === 'object') {           // :356
+        updates.remediationOptions = input.remediationOptions as Record<string, unknown>;        // :357
+      }
+```
+Confirmed: exactly `:356-357` as cited.
+
+**`apps/api/src/services/aiToolsPolicyPrereqs.ts:415-468`** (create action, `manage_software_policies` tool):
+```ts
+      if (action === 'create') {
+        let owner: { orgId: string | null; partnerId: string | null };
+        if (input.ownerScope === 'partner') {
+          if (!auth.partnerId) return JSON.stringify({ error: 'Partner-wide software policies require partner scope' });
+          if (!canManagePartnerWidePolicies(auth)) {
+            return JSON.stringify({ error: 'Partner-wide software policies require full partner org access (orgAccess must be "all")' });
+          }
+          owner = { orgId: null, partnerId: auth.partnerId };
+        } else {
+          if (!orgId) return JSON.stringify({ error: 'Organization context required' });
+          owner = { orgId, partnerId: null };
+        }
+        if (!input.name) return JSON.stringify({ error: 'name is required' });
+        if (!input.mode) return JSON.stringify({ error: 'mode is required (allowlist, blocklist, or audit)' });
+
+        const rows = await db.insert(softwarePolicies).values({
+          orgId: owner.orgId,
+          partnerId: owner.partnerId,
+          name: input.name as string,
+          description: (input.description as string) ?? null,
+          mode: input.mode as any,
+          rules: (input.rules as any) ?? { software: [], allowUnknown: false },
+          enforceMode: input.enforceMode === true,
+          remediationOptions: (input.remediationOptions as any) ?? null,                          // :441
+          isActive: input.isActive !== false,
+          createdBy: auth.user.id,
+        }).returning();
+```
+Confirmed: **line 441** exactly.
+
+**`apps/api/src/services/aiToolsPolicyPrereqs.ts:470-499`** (update action):
+```ts
+      if (action === 'update') {
+        if (!input.policyId) return JSON.stringify({ error: 'policyId is required' });
+        ...
+        const [existing] = await db.select().from(softwarePolicies).where(and(...conditions)).limit(1);
+        if (!existing) return JSON.stringify({ error: 'Software policy not found or access denied' });
+
+        if (existing.orgId === null && !canManagePartnerWidePolicies(auth)) {
+          return JSON.stringify({ error: 'Modifying a partner-wide software policy requires full partner org access (orgAccess must be "all")' });
+        }
+
+        const updates: Record<string, unknown> = {
+          updatedAt: new Date(),
+          approvalGeneration: bumpApprovalGeneration(softwarePolicies.approvalGeneration),
+        };
+        if (typeof input.name === 'string') updates.name = input.name;
+        if (typeof input.description === 'string') updates.description = input.description;
+        if (typeof input.mode === 'string') updates.mode = input.mode;
+        if (input.rules) updates.rules = input.rules;
+        if (typeof input.enforceMode === 'boolean') updates.enforceMode = input.enforceMode;
+        if (input.remediationOptions) updates.remediationOptions = input.remediationOptions;      // :496
+        if (typeof input.isActive === 'boolean') updates.isActive = input.isActive;
+```
+Confirmed: **line 496** exactly.
+
+### 0.2 Why the schema cannot hold the line (verified, not assumed)
+
+`apps/api/src/services/aiTools.ts:522-540` (`executeTool`):
+```ts
+  let effectiveInput = input;
+  if (auth.helperDeviceId) {
+    const scoped = applyHelperDeviceScope(toolName, input, auth.helperDeviceId);
+    if ('error' in scoped) return JSON.stringify({ error: scoped.error });
+    effectiveInput = scoped.input;
+  }
+
+  const validation = extensionTool
+    ? extensionTool.validateInput(effectiveInput)
+    : validateToolInput(toolName, effectiveInput);
+  if (!validation.success) {
+    return JSON.stringify({ error: validation.error });
+  }
+  ...
+  if (coreTool) return coreTool.handler(effectiveInput, auth, opts?.context);
+```
+`apps/api/src/services/aiToolSchemas.ts:1699-1721` (`validateToolInput`):
+```ts
+export function validateToolInput(
+  toolName: string,
+  input: Record<string, unknown>
+): { success: true } | { success: false; error: string } {
+  const schema = toolInputSchemas[toolName];
+  if (!schema) { ... }
+  const result = schema.safeParse(input);
+  if (result.success) {
+    return { success: true };
+  }
+  ...
+}
+```
+**Confirmed:** `validateToolInput` calls `schema.safeParse(input)` but discards `result.data` — it returns only `{ success: true }`. `executeTool` then calls `coreTool.handler(effectiveInput, ...)` with the **original, unparsed** `effectiveInput`, not any zod-sanitized value. Since `remediationOptionsSchema`-shaped Zod objects in `aiToolSchemas.ts` (`:1120-1126`, `:1647-1653`) are plain `z.object({...}).optional()` — **not** `.strict()` — an unknown key like `autoInstall` causes no validation failure (zod only *strips* unknown keys from its own parsed output in non-strict mode; it does not reject the call). So `input.remediationOptions.autoInstall` reaches the handler completely untouched regardless of whether `autoInstall` is ever added to these Zod schemas.
+
+The SDK path (`apps/api/src/services/aiAgentSdkTools.ts:2251`, inside the `manage_software_policies` tool registration) types `remediationOptions: z.record(z.string(), z.unknown()).optional()` — an explicitly untyped bag — and its handler (`makeHandler`, confirmed at `aiAgentSdkTools.ts:16,525-526`) delegates to the **same** `executeTool(toolName, args, auth)`. Both AI invocation paths converge on the same four handler functions.
+
+**Conclusion (matches contract D4 exactly): the refusal must be a runtime check inside the four handler functions. Adding `autoInstall` to the AI-facing Zod schemas would be inert — it wouldn't block anything, since the schema's parsed/stripped value is never used — so this plan does not add it there (see §7 Decisions).**
+
+### 0.3 The shared audit/description module
+
+**`apps/api/src/services/aiToolsSoftwarePolicyAudit.ts`** (full file, 84 lines) — relevant tail, confirmed verbatim:
+```ts
+export function summarizeEnforcementChange(input: Record<string, unknown>): Record<string, unknown> {
+  const summary: Record<string, unknown> = {};
+  if (typeof input.enforceMode === 'boolean') summary.enforceMode = input.enforceMode;
+  if (input.remediationOptions && typeof input.remediationOptions === 'object') {
+    summary.remediationOptions = input.remediationOptions;
+    summary.autoUninstall = (input.remediationOptions as Record<string, unknown>).autoUninstall === true;
+  }
+  return summary;
+}
+```
+This is lines 76-84 exactly as cited. Both write-site files already import from this module:
+- `aiToolsCompliance.ts:27-31`: `import { auditSoftwarePolicyToolEvent, summarizeEnforcementChange } from './aiToolsSoftwarePolicyAudit';`
+- `aiToolsPolicyPrereqs.ts:27-30`: identical import shape.
+
+No other non-test file imports `aiToolsSoftwarePolicyAudit.ts` (verified: `grep -rln "aiToolsSoftwarePolicyAudit" apps/api/src --include="*.ts" | grep -v test` returns only these two files).
+
+### 0.4 `aiGuardrails.ts` comment block
+
+**`apps/api/src/services/aiGuardrails.ts:211-245`** (inside `export const TIER3_ACTIONS`), confirmed verbatim, the relevant lines:
+```ts
+  // Policy prerequisite tools (#3552) — the standalone feature policies that
+  ...
+  // action on real endpoints with no human in the loop:                          // :224
+  //   - software policies: `enforceMode` + `remediationOptions.autoUninstall`     // :225
+  //     turn a detect-only allowlist into fleet-wide auto-uninstall (the #3381    // :226
+  //     mass-uninstall failure mode).                                            // :227
+  //   - update rings: `autoApprove` + `deadlineDays` + `gracePeriodHours` arm     // :228
+  ...
+  manage_update_rings: ['create', 'update'],
+  manage_software_policies: ['create', 'update'],                                  // :245
+```
+Confirmed: `:225` is exactly the `enforceMode` + `remediationOptions.autoUninstall` line, `:245` is exactly the `manage_software_policies` tier entry. Both `manage_software_policy` (`aiToolsCompliance.ts`, base tier 3 — confirmed by its file-header doc comment `manage_software_policy (Tier 3): CRUD for software policies`) and `manage_software_policies` (this entry) are **already** gated Tier 3 for `create`/`update` — this wave changes no tier, only documents the new, stronger (outright-refusal, not merely approval-gated) rule for `autoInstall`.
+
+### 0.5 The JSON-schema description strings
+
+`apps/api/src/services/aiToolsCompliance.ts:203`:
+```ts
+        remediationOptions: { type: 'object', description: 'Remediation behavior options' },
+```
+`apps/api/src/services/aiToolsPolicyPrereqs.ts:362`:
+```ts
+          remediationOptions: { type: 'object', description: '{ autoUninstall?: false, notifyUser?: true, gracePeriod?: number, cooldownMinutes?: 30, maintenanceWindowOnly?: false }' },
+```
+Both confirmed exactly as cited.
+
+### 0.6 Existing tests that mock the shared module and will break without a fix
+
+`grep -rln "vi.mock.*aiToolsSoftwarePolicyAudit" apps/api/src --include="*.test.ts"` finds exactly **four** files whose mock factory fully replaces the module (all four blocks are byte-identical):
+```ts
+vi.mock('./aiToolsSoftwarePolicyAudit', () => ({
+  auditSoftwarePolicyToolEvent: vi.fn(),
+  summarizeEnforcementChange: vi.fn(() => ({})),
+}));
+```
+- `aiToolsCompliance.siteScope.test.ts:21-24` — exercises `manage_software_policy` create/update (confirmed: `handlerFor('manage_software_policy')({action: 'create', ...})` at line 217-218).
+- `aiToolsPolicyPrereqs.siteScope.test.ts:29-32` — exercises `manage_software_policies` create/update (confirmed: `['manage_software_policies', { action: 'create', ...}]` at line 66-67).
+- `aiToolsPolicyPrereqs.test.ts:47-50` — exercises `manage_software_policies` create (confirmed: `tools.get('manage_software_policies')` at line 598-599, "partner-wide create gate" describe block).
+- `aiToolsPolicyPrereqs.updateRings.test.ts:39-42` — exercises only `manage_update_rings` (confirmed: `tools.get('manage_update_rings')` at line 65), **not** software policies.
+
+**This is load-bearing:** once a handler calls a named export (`remediationOptionsArmsAutoInstall`) that these four mock factories don't provide, that export resolves to `undefined` inside the mocked module, and `undefined(...)` throws `TypeError: remediationOptionsArmsAutoInstall is not a function` on **every** create/update call in the first three files (and, defensively, would do the same in the fourth the moment any future test there touches software policies). All four factories must gain the new export in the same task that introduces the call, or those suites go red as an unintended regression, not a deliberate one this plan tracks.
+
+Two sibling files (`aiToolsCompliance.auditAndArming.test.ts`, `aiToolsPolicyPrereqs.softwarePolicyAudit.test.ts`) do **not** mock `./aiToolsSoftwarePolicyAudit` (they let the real module run and instead mock `./auditEvents` + `softwarePolicyService`'s `recordSoftwarePolicyAudit`), so they need no fix — they exercise the real `remediationOptionsArmsAutoInstall` and serve as an additional regression check that unrelated `autoUninstall`-arming behavior is unchanged.
+
+### 0.7 W01 boundary — confirmed, not assumed
+
+Current (pre-W01) state of `apps/api/src/services/softwarePolicyService.ts:177-206`:
+```ts
+export function evaluateSoftwarePolicyArming(
+  policy: SoftwarePolicyArmingInput
+): SoftwarePolicyArmingState {
+```
+Single-argument, as the contract's "Verified starting facts" describe. Its sole non-test call sites are `softwareRemediationWorker.ts:318` and `aiToolsCompliance.ts:509`:
+```ts
+apps/api/src/services/aiToolsCompliance.ts:509:    const arming = evaluateSoftwarePolicyArming(policy);
+```
+Per the contract's D2 and wave-ownership map, **W01 owns updating this call site** (to `evaluateSoftwarePolicyArming(policy, 'uninstall')`) as part of making the helper verb-aware — it is explicitly listed under W01's scope ("verb-aware `evaluateSoftwarePolicyArming` + `readSoftwarePolicyAutoInstall` + both call sites"), not W05's. **This plan does not touch line 509.** It sits well after (line 509 > line 380) every region this plan edits in `aiToolsCompliance.ts`, so W01 landing before or after this wave causes no line-number drift in the regions this plan cites. This wave has **no compile-time dependency** on W01 — none of the code added here references any W01-introduced symbol (`PolicyRemediationVerb`, `readSoftwarePolicyAutoInstall`, `evaluateSoftwarePolicyArming`'s new parameter, `assertMayArmInstall`, the audit-action constants). It can be implemented and merged independently of W01's landing order; if both touch `aiToolsCompliance.ts` in the same PR window, the two changes are in disjoint line ranges (this plan: ~200-360; W01: ~509) so a rebase is mechanical.
+
+---
+
+## File Structure
+
+- **Modify** `apps/api/src/services/aiToolsSoftwarePolicyAudit.ts` — add the exported refusal message + guard helper; extend `summarizeEnforcementChange`.
+- **Create** `apps/api/src/services/aiToolsSoftwarePolicyAudit.test.ts` — unit tests for the new helper and the extended summary.
+- **Modify** `apps/api/src/services/aiToolsCompliance.ts` — wire the guard into create + update; update the `remediationOptions` JSON-schema description.
+- **Create** `apps/api/src/services/aiToolsCompliance.autoInstallGuardrail.test.ts` — refusal + regression tests for both write sites, plus a read-is-never-gated check.
+- **Modify** `apps/api/src/services/aiToolsCompliance.siteScope.test.ts` — add the new export to its full-module mock.
+- **Modify** `apps/api/src/services/aiToolsPolicyPrereqs.ts` — wire the guard into create + update; update the `remediationOptions` JSON-schema description.
+- **Create** `apps/api/src/services/aiToolsPolicyPrereqs.autoInstallGuardrail.test.ts` — refusal + regression tests for both write sites.
+- **Modify** `apps/api/src/services/aiToolsPolicyPrereqs.siteScope.test.ts`, `apps/api/src/services/aiToolsPolicyPrereqs.test.ts`, `apps/api/src/services/aiToolsPolicyPrereqs.updateRings.test.ts` — add the new export to their full-module mocks.
+- **Modify** `apps/api/src/services/aiGuardrails.ts` — extend the `TIER3_ACTIONS` comment block documenting the software-policy arming fields.
+
+No migration. No schema file. No HTTP route. No worker file.
+
+---
+
+## Task 1: Shared refusal helper and audit-summary line
+
+**Files:**
+- Modify: `apps/api/src/services/aiToolsSoftwarePolicyAudit.ts`
+- Test: `apps/api/src/services/aiToolsSoftwarePolicyAudit.test.ts`
+
+**Interfaces:**
+- Produces (consumed by Tasks 2 and 3):
+  - `export const AI_AUTO_INSTALL_REFUSAL_MESSAGE: string`
+  - `export function remediationOptionsArmsAutoInstall(remediationOptions: unknown): boolean`
+- Consumes: nothing new.
+
+- [ ] **Step 1: Write the failing unit test file**
+
+Create `apps/api/src/services/aiToolsSoftwarePolicyAudit.test.ts`:
+```ts
+/**
+ * Unit tests for the AI software-policy audit helpers — specifically the
+ * autoInstall refusal guard (contract-A D4, #5505 W05) and its greppable
+ * audit-summary line.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  AI_AUTO_INSTALL_REFUSAL_MESSAGE,
+  remediationOptionsArmsAutoInstall,
+  summarizeEnforcementChange,
+} from './aiToolsSoftwarePolicyAudit';
+
+describe('remediationOptionsArmsAutoInstall (contract-A D4)', () => {
+  it('is true only for a literal { autoInstall: true }', () => {
+    expect(remediationOptionsArmsAutoInstall({ autoInstall: true })).toBe(true);
+  });
+
+  it('is false when autoInstall is absent', () => {
+    expect(remediationOptionsArmsAutoInstall({ autoUninstall: true })).toBe(false);
+  });
+
+  it('is false when autoInstall is explicitly false', () => {
+    expect(remediationOptionsArmsAutoInstall({ autoInstall: false })).toBe(false);
+  });
+
+  it('is false for a truthy non-boolean value (string "true")', () => {
+    expect(remediationOptionsArmsAutoInstall({ autoInstall: 'true' })).toBe(false);
+  });
+
+  it('is false for null, undefined, arrays, and non-objects', () => {
+    expect(remediationOptionsArmsAutoInstall(null)).toBe(false);
+    expect(remediationOptionsArmsAutoInstall(undefined)).toBe(false);
+    expect(remediationOptionsArmsAutoInstall([{ autoInstall: true }])).toBe(false);
+    expect(remediationOptionsArmsAutoInstall('autoInstall')).toBe(false);
+    expect(remediationOptionsArmsAutoInstall(42)).toBe(false);
+  });
+
+  it('exports a stable, non-empty refusal message naming the required credential', () => {
+    expect(AI_AUTO_INSTALL_REFUSAL_MESSAGE).toMatch(/devices\.execute/);
+    expect(AI_AUTO_INSTALL_REFUSAL_MESSAGE).toMatch(/MFA/);
+  });
+});
+
+describe('summarizeEnforcementChange — autoInstall is greppable (contract-A D4)', () => {
+  it('surfaces autoInstall:true at the top level, not just buried in remediationOptions', () => {
+    const summary = summarizeEnforcementChange({ remediationOptions: { autoInstall: true } });
+    expect(summary.autoInstall).toBe(true);
+  });
+
+  it('surfaces autoInstall:false when remediationOptions is present without it', () => {
+    const summary = summarizeEnforcementChange({ remediationOptions: { autoUninstall: true } });
+    expect(summary.autoInstall).toBe(false);
+  });
+
+  it('omits autoInstall entirely when remediationOptions is absent', () => {
+    const summary = summarizeEnforcementChange({ enforceMode: true });
+    expect(summary).not.toHaveProperty('autoInstall');
+  });
+
+  it('still reports autoUninstall unchanged (regression — this wave adds a verb, not replaces one)', () => {
+    const summary = summarizeEnforcementChange({ remediationOptions: { autoUninstall: true, autoInstall: false } });
+    expect(summary.autoUninstall).toBe(true);
+    expect(summary.autoInstall).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `cd apps/api && npx vitest run src/services/aiToolsSoftwarePolicyAudit.test.ts`
+Expected: FAIL — `AI_AUTO_INSTALL_REFUSAL_MESSAGE` and `remediationOptionsArmsAutoInstall` are not exported by the module yet (import error / undefined).
+
+- [ ] **Step 3: Add the helper and message, and extend the summary function**
+
+In `apps/api/src/services/aiToolsSoftwarePolicyAudit.ts`, add after the imports (before `export type SoftwarePolicyToolAuditEntry`):
+```ts
+/**
+ * Contract-A D4 (`contract-A-desired-state.md`, locked 2026-09-10, #5505 W05):
+ * the AI agent may never arm `remediationOptions.autoInstall`. Both AI
+ * invocation paths let a call reach a handler with this key present and
+ * untouched — `aiToolSchemas.ts`'s `remediationOptions` Zod schema is
+ * non-strict (unknown keys don't fail `safeParse`, and `validateToolInput`
+ * discards the parsed/stripped value anyway — see `aiTools.ts:522-540`), and
+ * the SDK path (`aiAgentSdkTools.ts:2251`) types the whole object as an
+ * untyped `z.record` before delegating to the same `executeTool()`. Schema
+ * typing cannot hold this line, so the four handler write sites that can set
+ * `remediationOptions` (`aiToolsCompliance.ts` create/update,
+ * `aiToolsPolicyPrereqs.ts` create/update) call
+ * `remediationOptionsArmsAutoInstall` before touching the database and
+ * refuse with this exact message rather than silently dropping the field.
+ */
+export const AI_AUTO_INSTALL_REFUSAL_MESSAGE =
+  'Arming autoInstall requires a human operator with devices.execute and MFA; the AI agent cannot arm software installation.';
+
+/**
+ * True only for a literal `{ autoInstall: true }` — mirrors the strict
+ * `=== true` check `readSoftwarePolicyAutoUninstall` uses for the sibling
+ * verb (`softwarePolicyService.ts:172-175`), so a truthy-but-not-boolean
+ * value (e.g. the string `"true"`) does not count as an arm attempt.
+ */
+export function remediationOptionsArmsAutoInstall(remediationOptions: unknown): boolean {
+  if (!remediationOptions || typeof remediationOptions !== 'object' || Array.isArray(remediationOptions)) {
+    return false;
+  }
+  return (remediationOptions as Record<string, unknown>).autoInstall === true;
+}
+```
+
+Then change `summarizeEnforcementChange` from:
+```ts
+export function summarizeEnforcementChange(input: Record<string, unknown>): Record<string, unknown> {
+  const summary: Record<string, unknown> = {};
+  if (typeof input.enforceMode === 'boolean') summary.enforceMode = input.enforceMode;
+  if (input.remediationOptions && typeof input.remediationOptions === 'object') {
+    summary.remediationOptions = input.remediationOptions;
+    summary.autoUninstall = (input.remediationOptions as Record<string, unknown>).autoUninstall === true;
+  }
+  return summary;
+}
+```
+to:
+```ts
+export function summarizeEnforcementChange(input: Record<string, unknown>): Record<string, unknown> {
+  const summary: Record<string, unknown> = {};
+  if (typeof input.enforceMode === 'boolean') summary.enforceMode = input.enforceMode;
+  if (input.remediationOptions && typeof input.remediationOptions === 'object') {
+    summary.remediationOptions = input.remediationOptions;
+    summary.autoUninstall = (input.remediationOptions as Record<string, unknown>).autoUninstall === true;
+    summary.autoInstall = (input.remediationOptions as Record<string, unknown>).autoInstall === true;
+  }
+  return summary;
+}
+```
+
+- [ ] **Step 4: Run the test again and confirm it passes**
+
+Run: `cd apps/api && npx vitest run src/services/aiToolsSoftwarePolicyAudit.test.ts`
+Expected: PASS (all 10 assertions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/aiToolsSoftwarePolicyAudit.ts apps/api/src/services/aiToolsSoftwarePolicyAudit.test.ts
+git commit -m "$(cat <<'EOF'
+feat(ai): add autoInstall refusal guard to the software-policy audit module (#5505 W05)
+
+Shared helper + exported message so all four AI write sites that can set
+remediationOptions refuse an autoInstall:true attempt identically, and
+summarizeEnforcementChange surfaces autoInstall in the audit trail.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01ANjBwca2cfsLWDLJro3fkz
+EOF
+)"
+```
+
+---
+
+## Task 2: Wire the refusal into `aiToolsCompliance.ts` (`manage_software_policy`)
+
+**Files:**
+- Modify: `apps/api/src/services/aiToolsCompliance.ts:27-31` (import), `:274-278` (create), `:341-345` (update), `:203` (schema description)
+- Modify: `apps/api/src/services/aiToolsCompliance.siteScope.test.ts:21-24` (mock fix — required, see Ground Truth §0.6)
+- Test: `apps/api/src/services/aiToolsCompliance.autoInstallGuardrail.test.ts`
+
+**Interfaces:**
+- Consumes: `AI_AUTO_INSTALL_REFUSAL_MESSAGE`, `remediationOptionsArmsAutoInstall` from `./aiToolsSoftwarePolicyAudit` (Task 1).
+- Produces: nothing new (behavioural change only).
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `apps/api/src/services/aiToolsCompliance.autoInstallGuardrail.test.ts`:
+```ts
+/**
+ * Contract-A D4 (#5505 W05): the AI may never arm
+ * `remediationOptions.autoInstall` via `manage_software_policy`
+ * (aiToolsCompliance.ts). An `autoInstall: true` reaching either write site
+ * must be REFUSED outright, not silently stripped.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: any) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: { select: vi.fn(), insert: vi.fn(), update: vi.fn(), delete: vi.fn(), transaction: vi.fn() },
+}));
+vi.mock('../jobs/softwareComplianceWorker', () => ({ scheduleSoftwareComplianceCheck: vi.fn(async () => 'job-1') }));
+vi.mock('../jobs/softwareRemediationWorker', () => ({ scheduleSoftwareRemediation: vi.fn(async () => 1) }));
+vi.mock('./softwarePolicyService', async (orig) => {
+  const actual = await orig<typeof import('./softwarePolicyService')>();
+  return {
+    ...actual,
+    normalizeSoftwarePolicyRules: vi.fn((r: any) => ({
+      software: Array.isArray(r?.software) ? r.software : [],
+      allowUnknown: r?.allowUnknown === true,
+    })),
+    recordSoftwarePolicyAudit: vi.fn(async () => {}),
+  };
+});
+vi.mock('./auditEvents', () => ({
+  writeAuditEvent: vi.fn(),
+  requestLikeFromSnapshot: vi.fn(() => ({ req: { header: () => undefined } })),
+}));
+
+import { db } from '../db';
+import { registerComplianceTools } from './aiToolsCompliance';
+import { AI_AUTO_INSTALL_REFUSAL_MESSAGE } from './aiToolsSoftwarePolicyAudit';
+import type { AuthContext } from '../middleware/auth';
+import type { AiTool } from './aiTools';
+
+const mockDb = db as unknown as {
+  select: ReturnType<typeof vi.fn>;
+  insert: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+};
+
+const USER_ID = 'user-1';
+const ORG_ID = 'org-1';
+const POLICY_ID = 'pol-1';
+
+function handlerFor(name: string): AiTool['handler'] {
+  const reg = new Map<string, AiTool>();
+  registerComplianceTools(reg);
+  return reg.get(name)!.handler;
+}
+
+function makeAuth(): AuthContext {
+  return {
+    user: { id: USER_ID, email: 'ai@example.com', name: 'AI', isPlatformAdmin: false },
+    token: {} as any,
+    partnerId: null,
+    orgId: ORG_ID,
+    scope: 'organization',
+    accessibleOrgIds: [ORG_ID],
+    orgCondition: () => undefined,
+    canAccessOrg: () => true,
+  } as unknown as AuthContext;
+}
+
+function chain(result: unknown): any {
+  const p: any = Promise.resolve(result);
+  for (const m of ['from', 'where', 'orderBy', 'limit', 'set', 'values', 'returning']) {
+    p[m] = () => p;
+  }
+  return p;
+}
+
+function policyRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: POLICY_ID,
+    orgId: ORG_ID,
+    partnerId: null,
+    name: 'Allowlist policy',
+    mode: 'allowlist',
+    enforceMode: false,
+    remediationOptions: null,
+    isActive: true,
+    rules: { software: [{ name: 'Foo' }], allowUnknown: false },
+    ...overrides,
+  };
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('manage_software_policy create — autoInstall refusal (contract-A D4)', () => {
+  it('refuses { autoInstall: true } with the exact contract message and writes nothing', async () => {
+    const result = JSON.parse(await handlerFor('manage_software_policy')({
+      action: 'create',
+      name: 'Armed policy',
+      mode: 'allowlist',
+      software: [{ name: 'Foo' }],
+      enforceMode: true,
+      remediationOptions: { autoInstall: true },
+    }, makeAuth()));
+
+    expect(result.error).toBe(AI_AUTO_INSTALL_REFUSAL_MESSAGE);
+    expect(mockDb.insert).not.toHaveBeenCalled();
+  });
+
+  it('still allows autoUninstall arming (unrelated, unchanged verb) when autoInstall is absent', async () => {
+    mockDb.insert.mockImplementation(() =>
+      chain([policyRow({ enforceMode: true, remediationOptions: { autoUninstall: true } })]));
+
+    const result = JSON.parse(await handlerFor('manage_software_policy')({
+      action: 'create',
+      name: 'Armed for uninstall',
+      mode: 'allowlist',
+      software: [{ name: 'Foo' }],
+      enforceMode: true,
+      remediationOptions: { autoUninstall: true },
+    }, makeAuth()));
+
+    expect(result.error).toBeUndefined();
+    expect(result.success).toBe(true);
+  });
+
+  it('allows autoInstall: false (an explicit opt-out is not an arm attempt)', async () => {
+    mockDb.insert.mockImplementation(() => chain([policyRow({ remediationOptions: { autoInstall: false } })]));
+
+    const result = JSON.parse(await handlerFor('manage_software_policy')({
+      action: 'create',
+      name: 'Not armed',
+      mode: 'allowlist',
+      software: [{ name: 'Foo' }],
+      remediationOptions: { autoInstall: false },
+    }, makeAuth()));
+
+    expect(result.error).toBeUndefined();
+  });
+});
+
+describe('manage_software_policy update — autoInstall refusal (contract-A D4)', () => {
+  it('refuses { autoInstall: true } on an existing policy and writes nothing', async () => {
+    mockDb.select.mockImplementation(() => chain([policyRow()]));
+
+    const result = JSON.parse(await handlerFor('manage_software_policy')({
+      action: 'update',
+      policyId: POLICY_ID,
+      remediationOptions: { autoInstall: true },
+    }, makeAuth()));
+
+    expect(result.error).toBe(AI_AUTO_INSTALL_REFUSAL_MESSAGE);
+    expect(mockDb.update).not.toHaveBeenCalled();
+  });
+
+  it('refuses regardless of the policy\'s current enforcement state (this is a write-time refusal, not an arming check)', async () => {
+    mockDb.select.mockImplementation(() => chain([policyRow({ mode: 'audit', enforceMode: false })]));
+
+    const result = JSON.parse(await handlerFor('manage_software_policy')({
+      action: 'update',
+      policyId: POLICY_ID,
+      remediationOptions: { autoInstall: true },
+    }, makeAuth()));
+
+    expect(result.error).toBe(AI_AUTO_INSTALL_REFUSAL_MESSAGE);
+    expect(mockDb.update).not.toHaveBeenCalled();
+  });
+});
+
+describe('manage_software_policy get — reads are never gated (decision: AI may read armed state, never write it)', () => {
+  it('returns a policy whose autoInstall is already armed (by a human, via HTTP) without refusing', async () => {
+    mockDb.select.mockImplementation(() =>
+      chain([policyRow({ enforceMode: true, remediationOptions: { autoInstall: true } })]));
+
+    const result = JSON.parse(await handlerFor('manage_software_policy')({
+      action: 'get',
+      policyId: POLICY_ID,
+    }, makeAuth()));
+
+    expect(result.error).toBeUndefined();
+    expect(result.policy.remediationOptions.autoInstall).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run it and confirm the refusal tests fail**
+
+Run: `cd apps/api && npx vitest run src/services/aiToolsCompliance.autoInstallGuardrail.test.ts`
+Expected: FAIL — the two refusal tests get `result.error === undefined` (or a DB-mock error) instead of the refusal message, because nothing refuses `autoInstall` yet. The "still allows autoUninstall" and "get" tests may already pass; that's fine, they document current behavior that must not regress.
+
+- [ ] **Step 3: Wire the guard into the create and update write sites**
+
+In `apps/api/src/services/aiToolsCompliance.ts`, change the import block (lines 27-31) from:
+```ts
+import {
+  auditSoftwarePolicyToolEvent,
+  summarizeEnforcementChange,
+} from './aiToolsSoftwarePolicyAudit';
+```
+to:
+```ts
+import {
+  auditSoftwarePolicyToolEvent,
+  summarizeEnforcementChange,
+  AI_AUTO_INSTALL_REFUSAL_MESSAGE,
+  remediationOptionsArmsAutoInstall,
+} from './aiToolsSoftwarePolicyAudit';
+```
+
+In the `create` branch, change (around line 274-278):
+```ts
+      if (rules.software.length === 0) {
+        return JSON.stringify({ error: 'At least one software rule is required' });
+      }
+
+      const [policy] = await db
+        .insert(softwarePolicies)
+```
+to:
+```ts
+      if (rules.software.length === 0) {
+        return JSON.stringify({ error: 'At least one software rule is required' });
+      }
+
+      // Contract-A D4 (#5505 W05): the AI may never arm autoInstall. Refused
+      // outright — never silently stripped — because the input schema cannot
+      // hold this line (see aiToolsSoftwarePolicyAudit.ts).
+      if (remediationOptionsArmsAutoInstall(input.remediationOptions)) {
+        return JSON.stringify({ error: AI_AUTO_INSTALL_REFUSAL_MESSAGE });
+      }
+
+      const [policy] = await db
+        .insert(softwarePolicies)
+```
+
+In the `update` branch, change (around line 339-345):
+```ts
+      if (existing.orgId === null && !canManagePartnerWidePolicies(auth)) {
+        return JSON.stringify({ error: 'Modifying a partner-wide software policy requires full partner org access (orgAccess must be "all")' });
+      }
+
+      const updates: Omit<Partial<typeof softwarePolicies.$inferInsert>, 'approvalGeneration'> & { approvalGeneration?: SQL } = {
+```
+to:
+```ts
+      if (existing.orgId === null && !canManagePartnerWidePolicies(auth)) {
+        return JSON.stringify({ error: 'Modifying a partner-wide software policy requires full partner org access (orgAccess must be "all")' });
+      }
+
+      // Contract-A D4 (#5505 W05): the AI may never arm autoInstall, on
+      // create OR on an already-armed policy's update.
+      if (remediationOptionsArmsAutoInstall(input.remediationOptions)) {
+        return JSON.stringify({ error: AI_AUTO_INSTALL_REFUSAL_MESSAGE });
+      }
+
+      const updates: Omit<Partial<typeof softwarePolicies.$inferInsert>, 'approvalGeneration'> & { approvalGeneration?: SQL } = {
+```
+
+Also update the schema description at line 203 from:
+```ts
+        remediationOptions: { type: 'object', description: 'Remediation behavior options' },
+```
+to:
+```ts
+        remediationOptions: { type: 'object', description: 'Remediation behavior options: { autoUninstall?: boolean, notifyUser?: boolean, gracePeriod?: number, cooldownMinutes?: number, maintenanceWindowOnly?: boolean }. autoInstall is NOT settable here — arming software installation requires a human operator with devices.execute and MFA.' },
+```
+
+- [ ] **Step 4: Run the new test file again and confirm it passes**
+
+Run: `cd apps/api && npx vitest run src/services/aiToolsCompliance.autoInstallGuardrail.test.ts`
+Expected: PASS (all 5 tests).
+
+- [ ] **Step 5: Fix the sibling suite that fully mocks the module (required — see Ground Truth §0.6)**
+
+In `apps/api/src/services/aiToolsCompliance.siteScope.test.ts`, change (lines 21-24):
+```ts
+vi.mock('./aiToolsSoftwarePolicyAudit', () => ({
+  auditSoftwarePolicyToolEvent: vi.fn(),
+  summarizeEnforcementChange: vi.fn(() => ({})),
+}));
+```
+to:
+```ts
+vi.mock('./aiToolsSoftwarePolicyAudit', () => ({
+  auditSoftwarePolicyToolEvent: vi.fn(),
+  summarizeEnforcementChange: vi.fn(() => ({})),
+  remediationOptionsArmsAutoInstall: vi.fn(() => false),
+  AI_AUTO_INSTALL_REFUSAL_MESSAGE: 'AI_AUTO_INSTALL_REFUSAL_MESSAGE (mocked)',
+}));
+```
+
+- [ ] **Step 6: Run the full affected set and confirm no regression**
+
+Run:
+```bash
+cd apps/api && npx vitest run \
+  src/services/aiToolsCompliance.autoInstallGuardrail.test.ts \
+  src/services/aiToolsCompliance.siteScope.test.ts \
+  src/services/aiToolsCompliance.auditAndArming.test.ts
+```
+Expected: PASS — all three files green. (`aiToolsCompliance.auditAndArming.test.ts` uses the real, unmocked module — see Ground Truth §0.6 — so it directly proves `autoUninstall` arming and audit behavior are unchanged.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/services/aiToolsCompliance.ts \
+  apps/api/src/services/aiToolsCompliance.autoInstallGuardrail.test.ts \
+  apps/api/src/services/aiToolsCompliance.siteScope.test.ts
+git commit -m "$(cat <<'EOF'
+fix(ai): refuse autoInstall arming in manage_software_policy create/update (#5505 W05)
+
+Both AI write sites in aiToolsCompliance.ts now refuse remediationOptions
+.autoInstall:true outright instead of silently accepting it (contract-A D4).
+Reads (get/list) are untouched — the AI may still see an already-armed
+policy, it just can never arm one itself.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01ANjBwca2cfsLWDLJro3fkz
+EOF
+)"
+```
+
+---
+
+## Task 3: Wire the refusal into `aiToolsPolicyPrereqs.ts` (`manage_software_policies`)
+
+**Files:**
+- Modify: `apps/api/src/services/aiToolsPolicyPrereqs.ts:27-30` (import), `:430-433` (create), `:481-485` (update), `:362` (schema description)
+- Modify: `apps/api/src/services/aiToolsPolicyPrereqs.siteScope.test.ts:29-32`, `apps/api/src/services/aiToolsPolicyPrereqs.test.ts:47-50`, `apps/api/src/services/aiToolsPolicyPrereqs.updateRings.test.ts:39-42` (mock fixes — required, see Ground Truth §0.6)
+- Test: `apps/api/src/services/aiToolsPolicyPrereqs.autoInstallGuardrail.test.ts`
+
+**Interfaces:**
+- Consumes: `AI_AUTO_INSTALL_REFUSAL_MESSAGE`, `remediationOptionsArmsAutoInstall` from `./aiToolsSoftwarePolicyAudit` (Task 1).
+- Produces: nothing new (behavioural change only).
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `apps/api/src/services/aiToolsPolicyPrereqs.autoInstallGuardrail.test.ts`:
+```ts
+/**
+ * Contract-A D4 (#5505 W05): the AI may never arm
+ * `remediationOptions.autoInstall` via `manage_software_policies`
+ * (aiToolsPolicyPrereqs.ts). Refused outright at both write sites, never
+ * silently stripped.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { insertMock, updateMock, selectMock, recordPolicyAuditMock, writeAuditEventMock } = vi.hoisted(() => ({
+  insertMock: vi.fn(),
+  updateMock: vi.fn(),
+  selectMock: vi.fn(),
+  recordPolicyAuditMock: vi.fn(async () => {}),
+  writeAuditEventMock: vi.fn(),
+}));
+
+vi.mock('../db', () => ({ db: { insert: insertMock, update: updateMock, select: selectMock } }));
+vi.mock('../db/schema/patches', () => ({ patchPolicies: {} }));
+vi.mock('../db/schema/softwarePolicies', () => ({ softwarePolicies: {} }));
+vi.mock('../db/schema/peripheralControl', () => ({ peripheralPolicies: {} }));
+vi.mock('../db/schema/backup', () => ({ backupConfigs: {}, backupProfiles: {} }));
+vi.mock('../db/schema/configurationPolicies', () => ({ configPolicyBackupSettings: {} }));
+vi.mock('../jobs/peripheralJobs', () => ({
+  resolvePeripheralPolicyDeviceIds: vi.fn(async () => []),
+  schedulePeripheralPolicyDevices: vi.fn(async () => undefined),
+}));
+vi.mock('./softwarePolicyService', () => ({ recordSoftwarePolicyAudit: recordPolicyAuditMock }));
+vi.mock('./auditEvents', () => ({
+  writeAuditEvent: writeAuditEventMock,
+  requestLikeFromSnapshot: vi.fn(() => ({ req: { header: () => undefined } })),
+}));
+
+import { registerPolicyPrereqTools } from './aiToolsPolicyPrereqs';
+import { AI_AUTO_INSTALL_REFUSAL_MESSAGE } from './aiToolsSoftwarePolicyAudit';
+
+const PARTNER_ID = '00000000-0000-0000-0000-000000000001';
+const ORG_ID = '33333333-3333-3333-3333-333333333333';
+const POLICY_ID = '55555555-5555-5555-5555-555555555555';
+const USER_ID = 'user-1';
+
+function makeOrgAuth() {
+  return {
+    user: { id: USER_ID, email: 'ai@example.com', name: 'AI' },
+    scope: 'organization',
+    partnerId: PARTNER_ID,
+    orgId: ORG_ID,
+    accessibleOrgIds: [ORG_ID],
+    canAccessOrg: () => true,
+    orgCondition: () => undefined,
+  } as any;
+}
+
+function tool() {
+  const tools = new Map<string, any>();
+  registerPolicyPrereqTools(tools);
+  return tools.get('manage_software_policies');
+}
+
+function mockInsertReturns(row: unknown) {
+  const returning = vi.fn(async () => [row]);
+  const values = vi.fn(() => ({ returning }));
+  insertMock.mockReturnValue({ values });
+}
+
+function mockUpdate() {
+  const where = vi.fn(async () => undefined);
+  const set = vi.fn((_payload: Record<string, unknown>) => ({ where }));
+  updateMock.mockReturnValue({ set });
+  return { set, where };
+}
+
+function mockSelectReturns(rows: unknown[]) {
+  selectMock.mockReturnValue({
+    from: () => ({ where: () => ({ limit: async () => rows }) }),
+  });
+}
+
+beforeEach(() => {
+  insertMock.mockReset();
+  updateMock.mockReset();
+  selectMock.mockReset();
+  recordPolicyAuditMock.mockClear();
+  writeAuditEventMock.mockClear();
+});
+
+describe('manage_software_policies create — autoInstall refusal (contract-A D4)', () => {
+  it('refuses { autoInstall: true } with the exact contract message and writes nothing', async () => {
+    const out = JSON.parse(await tool().handler({
+      action: 'create',
+      name: 'Armed policy',
+      mode: 'allowlist',
+      enforceMode: true,
+      remediationOptions: { autoInstall: true },
+    }, makeOrgAuth()));
+
+    expect(out.error).toBe(AI_AUTO_INSTALL_REFUSAL_MESSAGE);
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  it('still allows autoUninstall arming (unrelated, unchanged verb) when autoInstall is absent', async () => {
+    mockInsertReturns({ id: POLICY_ID, name: 'Armed for uninstall', orgId: ORG_ID, partnerId: null, mode: 'allowlist' });
+
+    const out = JSON.parse(await tool().handler({
+      action: 'create',
+      name: 'Armed for uninstall',
+      mode: 'allowlist',
+      enforceMode: true,
+      remediationOptions: { autoUninstall: true },
+    }, makeOrgAuth()));
+
+    expect(out.error).toBeUndefined();
+    expect(out.success).toBe(true);
+  });
+});
+
+describe('manage_software_policies update — autoInstall refusal (contract-A D4)', () => {
+  it('refuses { autoInstall: true } on an existing policy and writes nothing', async () => {
+    mockSelectReturns([{ id: POLICY_ID, name: 'Detect only', orgId: ORG_ID, partnerId: null, mode: 'allowlist' }]);
+    mockUpdate();
+
+    const out = JSON.parse(await tool().handler({
+      action: 'update',
+      policyId: POLICY_ID,
+      remediationOptions: { autoInstall: true },
+    }, makeOrgAuth()));
+
+    expect(out.error).toBe(AI_AUTO_INSTALL_REFUSAL_MESSAGE);
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run it and confirm the refusal tests fail**
+
+Run: `cd apps/api && npx vitest run src/services/aiToolsPolicyPrereqs.autoInstallGuardrail.test.ts`
+Expected: FAIL — the two refusal tests get `out.error === undefined` (create/update proceed) instead of the refusal message.
+
+- [ ] **Step 3: Wire the guard into the create and update write sites**
+
+In `apps/api/src/services/aiToolsPolicyPrereqs.ts`, change the import block (lines 27-30) from:
+```ts
+import {
+  auditSoftwarePolicyToolEvent,
+  summarizeEnforcementChange,
+} from './aiToolsSoftwarePolicyAudit';
+```
+to:
+```ts
+import {
+  auditSoftwarePolicyToolEvent,
+  summarizeEnforcementChange,
+  AI_AUTO_INSTALL_REFUSAL_MESSAGE,
+  remediationOptionsArmsAutoInstall,
+} from './aiToolsSoftwarePolicyAudit';
+```
+
+In the `create` branch, change (around line 430-433):
+```ts
+        if (!input.name) return JSON.stringify({ error: 'name is required' });
+        if (!input.mode) return JSON.stringify({ error: 'mode is required (allowlist, blocklist, or audit)' });
+
+        const rows = await db.insert(softwarePolicies).values({
+```
+to:
+```ts
+        if (!input.name) return JSON.stringify({ error: 'name is required' });
+        if (!input.mode) return JSON.stringify({ error: 'mode is required (allowlist, blocklist, or audit)' });
+
+        // Contract-A D4 (#5505 W05): the AI may never arm autoInstall.
+        // Refused outright — never silently stripped.
+        if (remediationOptionsArmsAutoInstall(input.remediationOptions)) {
+          return JSON.stringify({ error: AI_AUTO_INSTALL_REFUSAL_MESSAGE });
+        }
+
+        const rows = await db.insert(softwarePolicies).values({
+```
+
+In the `update` branch, change (around line 479-485):
+```ts
+        if (existing.orgId === null && !canManagePartnerWidePolicies(auth)) {
+          return JSON.stringify({ error: 'Modifying a partner-wide software policy requires full partner org access (orgAccess must be "all")' });
+        }
+
+        const updates: Record<string, unknown> = {
+```
+to:
+```ts
+        if (existing.orgId === null && !canManagePartnerWidePolicies(auth)) {
+          return JSON.stringify({ error: 'Modifying a partner-wide software policy requires full partner org access (orgAccess must be "all")' });
+        }
+
+        // Contract-A D4 (#5505 W05): the AI may never arm autoInstall, on
+        // create OR on an already-armed policy's update.
+        if (remediationOptionsArmsAutoInstall(input.remediationOptions)) {
+          return JSON.stringify({ error: AI_AUTO_INSTALL_REFUSAL_MESSAGE });
+        }
+
+        const updates: Record<string, unknown> = {
+```
+
+Also update the schema description at line 362 from:
+```ts
+          remediationOptions: { type: 'object', description: '{ autoUninstall?: false, notifyUser?: true, gracePeriod?: number, cooldownMinutes?: 30, maintenanceWindowOnly?: false }' },
+```
+to:
+```ts
+          remediationOptions: { type: 'object', description: '{ autoUninstall?: false, notifyUser?: true, gracePeriod?: number, cooldownMinutes?: 30, maintenanceWindowOnly?: false }. autoInstall is NOT settable via AI tools — arming software installation requires a human operator with devices.execute and MFA.' },
+```
+
+- [ ] **Step 4: Run the new test file again and confirm it passes**
+
+Run: `cd apps/api && npx vitest run src/services/aiToolsPolicyPrereqs.autoInstallGuardrail.test.ts`
+Expected: PASS (all 3 tests).
+
+- [ ] **Step 5: Fix the three sibling suites that fully mock the module (required — see Ground Truth §0.6)**
+
+In each of `apps/api/src/services/aiToolsPolicyPrereqs.siteScope.test.ts` (lines 29-32), `apps/api/src/services/aiToolsPolicyPrereqs.test.ts` (lines 47-50), and `apps/api/src/services/aiToolsPolicyPrereqs.updateRings.test.ts` (lines 39-42), change:
+```ts
+vi.mock('./aiToolsSoftwarePolicyAudit', () => ({
+  auditSoftwarePolicyToolEvent: vi.fn(),
+  summarizeEnforcementChange: vi.fn(() => ({})),
+}));
+```
+to:
+```ts
+vi.mock('./aiToolsSoftwarePolicyAudit', () => ({
+  auditSoftwarePolicyToolEvent: vi.fn(),
+  summarizeEnforcementChange: vi.fn(() => ({})),
+  remediationOptionsArmsAutoInstall: vi.fn(() => false),
+  AI_AUTO_INSTALL_REFUSAL_MESSAGE: 'AI_AUTO_INSTALL_REFUSAL_MESSAGE (mocked)',
+}));
+```
+(All three blocks are byte-identical before the edit, so the same replacement applies verbatim to each file.)
+
+- [ ] **Step 6: Run the full affected set and confirm no regression**
+
+Run:
+```bash
+cd apps/api && npx vitest run \
+  src/services/aiToolsPolicyPrereqs.autoInstallGuardrail.test.ts \
+  src/services/aiToolsPolicyPrereqs.siteScope.test.ts \
+  src/services/aiToolsPolicyPrereqs.test.ts \
+  src/services/aiToolsPolicyPrereqs.updateRings.test.ts \
+  src/services/aiToolsPolicyPrereqs.softwarePolicyAudit.test.ts
+```
+Expected: PASS — all five files green. (`aiToolsPolicyPrereqs.softwarePolicyAudit.test.ts` uses the real, unmocked module, directly proving `autoUninstall` arming and audit behavior are unchanged.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/services/aiToolsPolicyPrereqs.ts \
+  apps/api/src/services/aiToolsPolicyPrereqs.autoInstallGuardrail.test.ts \
+  apps/api/src/services/aiToolsPolicyPrereqs.siteScope.test.ts \
+  apps/api/src/services/aiToolsPolicyPrereqs.test.ts \
+  apps/api/src/services/aiToolsPolicyPrereqs.updateRings.test.ts
+git commit -m "$(cat <<'EOF'
+fix(ai): refuse autoInstall arming in manage_software_policies create/update (#5505 W05)
+
+Both AI write sites in aiToolsPolicyPrereqs.ts now refuse remediationOptions
+.autoInstall:true outright instead of silently accepting it (contract-A D4),
+mirroring the same fix in aiToolsCompliance.ts's manage_software_policy.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01ANjBwca2cfsLWDLJro3fkz
+EOF
+)"
+```
+
+---
+
+## Task 4: Document the new rule in the guardrail comment block
+
+**Files:**
+- Modify: `apps/api/src/services/aiGuardrails.ts:225-227`
+
+**Interfaces:**
+- Consumes: nothing (documentation-only change).
+- Produces: nothing (no exported symbol changes).
+
+This task changes no logic — `manage_software_policy` and `manage_software_policies` `create`/`update` are already Tier 3 (confirmed in Ground Truth §0.4), and the actual enforcement is the refusal added in Tasks 2-3, not a tier escalation. This step exists because the contract requires the comment block that currently names only `autoUninstall` as the arming pair to also name `autoInstall`, so a future reader of `aiGuardrails.ts` does not have to rediscover this asymmetry from scratch.
+
+- [ ] **Step 1: Confirm the baseline — the existing contract suite is green before this edit**
+
+Run: `cd apps/api && npx vitest run src/services/aiGuardrails.enforcementArming.contract.test.ts`
+Expected: PASS (this is a pre-existing suite; this step establishes the baseline this task must not disturb — there is no new assertion to red here, since this task changes no logic that suite exercises).
+
+- [ ] **Step 2: Update the comment block**
+
+In `apps/api/src/services/aiGuardrails.ts`, change (lines 225-227):
+```ts
+  //   - software policies: `enforceMode` + `remediationOptions.autoUninstall`
+  //     turn a detect-only allowlist into fleet-wide auto-uninstall (the #3381
+  //     mass-uninstall failure mode).
+```
+to:
+```ts
+  //   - software policies: `enforceMode` + `remediationOptions.autoUninstall`
+  //     turn a detect-only allowlist into fleet-wide auto-uninstall (the #3381
+  //     mass-uninstall failure mode). `remediationOptions.autoInstall` (#5505
+  //     desired-state install) is NOT gated the same way as the fields above —
+  //     it is never accepted from the AI at all. The four handler write sites
+  //     in aiToolsCompliance.ts/aiToolsPolicyPrereqs.ts refuse an
+  //     autoInstall:true outright, regardless of tier or approval, because
+  //     only a human operator holding devices.execute + MFA may arm software
+  //     installation (contract-A D4). Tier-3 approval on this tool remains
+  //     for enforceMode/autoUninstall; it is not the mechanism that protects
+  //     autoInstall.
+```
+
+- [ ] **Step 3: Confirm the contract suite is still green (no functional change)**
+
+Run: `cd apps/api && npx vitest run src/services/aiGuardrails.enforcementArming.contract.test.ts`
+Expected: PASS, identical result to Step 1 — this proves the comment-only edit changed no behavior the contract test observes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/services/aiGuardrails.ts
+git commit -m "$(cat <<'EOF'
+docs(ai): document that autoInstall is refused outright, not tier-gated (#5505 W05)
+
+Extends the TIER3_ACTIONS comment block in aiGuardrails.ts, which previously
+named only remediationOptions.autoUninstall as the software-policy arming
+pair, to explain that autoInstall is never accepted from the AI at all —
+a stronger guarantee than Tier-3 approval.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01ANjBwca2cfsLWDLJro3fkz
+EOF
+)"
+```
+
+---
+
+## Task 5: Full regression sweep and self-review
+
+**Files:** none (verification only).
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Run every test file this wave touched or could affect, together**
+
+```bash
+cd apps/api && npx vitest run \
+  src/services/aiToolsSoftwarePolicyAudit.test.ts \
+  src/services/aiToolsCompliance.autoInstallGuardrail.test.ts \
+  src/services/aiToolsCompliance.siteScope.test.ts \
+  src/services/aiToolsCompliance.auditAndArming.test.ts \
+  src/services/aiToolsPolicyPrereqs.autoInstallGuardrail.test.ts \
+  src/services/aiToolsPolicyPrereqs.siteScope.test.ts \
+  src/services/aiToolsPolicyPrereqs.test.ts \
+  src/services/aiToolsPolicyPrereqs.updateRings.test.ts \
+  src/services/aiToolsPolicyPrereqs.softwarePolicyAudit.test.ts \
+  src/services/aiGuardrails.enforcementArming.contract.test.ts \
+  src/services/aiGuardrails.test.ts \
+  src/services/aiGuardrailsTierConfig.parity.test.ts \
+  src/services/aiGuardrailsAiDocs.parity.test.ts \
+  src/services/aiGuardrails.readonly.contract.test.ts
+```
+Expected: PASS across all 14 files. (Note vitest's path-filter is a substring match — these are listed as explicit file paths, one per argument, precisely to avoid the trailing-slash/substring traps documented in CLAUDE.md.)
+
+- [ ] **Step 2: Typecheck the touched files**
+
+Run: `cd apps/api && npx tsc --noEmit -p .`
+Expected: no new errors introduced by this wave's changes. (There is no root typecheck script per CLAUDE.md; this runs the API package's own TS config directly.)
+
+- [ ] **Step 3: Self-review against the contract**
+
+Confirm each of the following by inspection (this is a checklist, not a code step):
+- [ ] All four write sites (`aiToolsCompliance.ts:287,356-357`; `aiToolsPolicyPrereqs.ts:441,496`) refuse `autoInstall: true` with the exact string `'Arming autoInstall requires a human operator with devices.execute and MFA; the AI agent cannot arm software installation.'` — not four different strings, not a stripped/ignored field.
+- [ ] `list`/`get` on both tools are untouched — no new gate, no tier change (verified by the "reads are never gated" test in Task 2 and by `aiGuardrails.enforcementArming.contract.test.ts` staying green in Task 4).
+- [ ] `aiToolsCompliance.ts:509` (`remediate_software_violation`'s `evaluateSoftwarePolicyArming` call) was not touched — grep confirms: `git diff main --stat -- apps/api/src/services/aiToolsCompliance.ts` shows only the import block and the two write-site regions changed.
+- [ ] No migration file was created; no `apps/api/src/db/schema/*` file was touched; no HTTP route file was touched.
+- [ ] `summarizeEnforcementChange` surfaces `autoInstall` at the top level of its return value whenever `remediationOptions` is present (Task 1 test).
+- [ ] `aiGuardrails.ts`'s comment block names `autoInstall` alongside `autoUninstall` (Task 4).
+- [ ] Every existing test that previously passed for `manage_software_policy` / `manage_software_policies` still passes unchanged (Task 2 Step 6, Task 3 Step 6).
+
+- [ ] **Step 4: Report**
+
+No commit in this task (verification only) — if Steps 1-2 surface any regression, fix it under the task whose file it belongs to and re-run this sweep before considering the wave done.
+
+---
+
+## Self-Review
+
+**1. Spec/contract coverage:**
+- D4's core requirement (refuse, don't strip, at all four sites, exact message) → Tasks 2 and 3, all four write sites, each independently tested.
+- "W05 also adds an autoInstall line to summarizeEnforcementChange" → Task 1.
+- "extends the aiGuardrails.ts:211-245 comment block" → Task 4.
+- "AI zod/JSON schemas" ownership → addressed as the two description-string updates in Tasks 2-3 (Step 3 of each); explicitly **not** adding `autoInstall` to the typed Zod schemas themselves, with the reasoning recorded in Ground Truth §0.2 and Decisions below (adding it there would be inert, since neither AI validation path uses its schema's parsed/stripped output).
+- "Do not escalate read tools" → verified as a passing regression test in Task 2 and confirmed via the untouched `aiGuardrails.enforcementArming.contract.test.ts` in Task 4.
+- "Must NOT touch: everything else" (in particular `aiToolsCompliance.ts:509`) → confirmed in Ground Truth §0.7 and re-checked in Task 5's self-review checklist.
+
+**2. Placeholder scan:** none found — every step above contains complete, real code (no "add validation", no "similar to Task N" without the code, no TBD).
+
+**3. Type consistency:** `AI_AUTO_INSTALL_REFUSAL_MESSAGE` and `remediationOptionsArmsAutoInstall` are defined once (Task 1) and imported with identical names in every consuming file (Tasks 2, 3) and every mock factory (Task 2 Step 5, Task 3 Step 5) — no renaming drift between tasks.
+
+## Decisions this plan made that the contract left open
+
+1. **The refusal happens *before* any audit write, and is itself unaudited.** Matches the existing precedent in both files (see the "does not audit when the create is rejected before any row is written" tests already in `aiToolsCompliance.auditAndArming.test.ts` and `aiToolsPolicyPrereqs.softwarePolicyAudit.test.ts`) — a rejected-before-any-row-exists validation failure is not written to `software_policy_audit`/`audit_logs` today, and this plan treats the autoInstall refusal the same way rather than inventing a new audit action. Inventing one would also require a new `software_policy_audit.action` constant, which is explicitly W01's file (`softwarePolicyService.ts`), not W05's.
+2. **`autoInstall` is deliberately NOT added to the AI-facing Zod schemas** (`aiToolSchemas.ts:1120-1126,1647-1653`) or the SDK's `z.record` (`aiAgentSdkTools.ts:2251`). Ground Truth §0.2 proves this would be inert (neither path uses its schema's parsed output), so adding it would only cost a second place D4's message could drift out of sync with the handler-level string. The two JSON-schema *description* strings (documentation, not validation) are updated instead, in Tasks 2-3.

--- a/docs/superpowers/plans/vuln-patch/2026-09-10-desired-state-software-install-w06-install-preview-endpoint.md
+++ b/docs/superpowers/plans/vuln-patch/2026-09-10-desired-state-software-install-w06-install-preview-endpoint.md
@@ -1,0 +1,1197 @@
+---
+tracking_issue: LanternOps/breeze#5505
+---
+
+# Wave 06 — Install-preview endpoint + install-remediation status projection — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the PolicyForm dry-run warning ("this will install missing software on ~N device(s)") a real, cost-bounded backend — `GET /software-policies/:id/install-preview` — that applies the EXACT SAME eligibility predicate the install-remediation worker will apply (W03's `resolvePolicyInstallTarget`), never fetches-and-`.length`s a capped row set the way `GET /violations` does today. Also close a second gap the coordinator found while W02's plan was being authored: W02 adds three install-remediation columns to `software_compliance_status` that no wave currently exposes over HTTP — project them through `GET /violations` alongside the existing uninstall `remediationStatus`.
+
+**Architecture:** A new service, `services/softwarePolicyInstallPreview.ts`, resolves the policy's target devices via the SAME pre-existing resolver the compliance worker uses (`resolveDeviceIdsForSoftwarePolicy`), groups them by `(orgId, osType)` — the only two device attributes that change W03's `resolvePolicyInstallTarget` answer — and calls that function once per **group × candidate catalogId**, never once per device. For each group with at least one eligible catalogId, a single SQL `COUNT(DISTINCT device_id)` query (a real aggregate, not a capped `SELECT ... LIMIT` whose `.length` is reported as the total) counts how many of that group's devices already carry a `missing` violation for one of the eligible catalogIds. A new read-only route on the existing software-policies router calls this service after the same tenancy (`getPolicyWithAccess`) and site-ceiling (`resolveSiteAllowedDeviceIds`) checks its GET siblings already use. Separately, `GET /violations`'s existing compliance projection gains three columns W02 will add to `software_compliance_status`.
+
+**Tech Stack:** Hono + Drizzle ORM + PostgreSQL, Vitest (unit, mocked Drizzle — no migration, no RLS/cascade surface, so no integration suite is required by this wave).
+
+**Spec:** `docs/superpowers/specs/vuln-patch/2026-09-10-desired-state-software-install-design.md` — Risks §2 ("Fleet-wide first run": arming `autoInstall` on an existing broad policy could queue thousands of installs in one pass; "the UI should show a dry-run count... before arming"). Cross-wave contract: `contract-A-desired-state.md` (coordinator scratchpad) — this wave did not exist when D1–D11 were written; it consumes D1 (W02's three columns) and reuses (never re-implements) the Task-4 service D7/W03 shipped.
+
+**Depends on:**
+- **W03 (#5508)** — `resolvePolicyInstallTarget(input: { catalogId, deviceOrgId, deviceOsType }): Promise<PolicyInstallTargetResolution>`, exported from `apps/api/src/services/softwarePolicyInstallRemediation.ts`. This wave imports and calls it verbatim; it does **not** modify that file, and does not need anything added to its exports — `resolvePolicyInstallTarget` was already public in W03's own plan (Task 4).
+- **W02 (#5507)** — the three `software_compliance_status` columns (`install_remediation_status`, `last_install_remediation_attempt`, `install_remediation_attempts`) and their Drizzle fields (`installRemediationStatus`, `lastInstallRemediationAttempt`, `installRemediationAttempts`). Task 3 of this plan only *reads* them.
+- Pre-existing, wave-independent: `resolveDeviceIdsForSoftwarePolicy(softwarePolicyId): Promise<string[]>` (`apps/api/src/services/featureConfigResolver.ts:1044`) — already shipped, already what `processCheckPolicy` (the compliance worker) uses to resolve a policy's target devices (`jobs/softwareComplianceWorker.ts:324`). Reusing it is what makes this endpoint's device set the SAME set the worker would act on.
+
+**Consumed by:** **W04 (#5509)** — `PolicyForm.tsx` Task 2 already calls `GET /software-policies/:id/install-preview` defensively (any non-2xx, including today's 404, degrades to an "unavailable" message and never blocks the checkbox — see that plan's Task 2). This wave is what turns that degraded path into a real number. The three projected columns from Task 3 have no current UI consumer in the W04 plan as written (verified: zero occurrences of `installRemediationStatus`/`gave_up`/`installRemediationAttempts` in that plan doc) — this task only makes the data reachable over HTTP; wiring a UI column/give-up-count display is a follow-up for whichever wave touches `ComplianceDashboard.tsx` next.
+
+---
+
+## Global Constraints
+
+- **No migration in this wave.** Task 1/2 read existing tables through an existing resolver and an existing `resolvePolicyInstallTarget`; Task 3 reads three columns *some other wave* (W02) adds via its own migration. If W02's migration has not landed when Task 3 starts, its Step 1 stops and says so rather than inventing column names — same discipline W03's plan used for its own W01/W02 dependency (see that plan's "W01/W02-owned identifiers this wave imports" table).
+- **Reuse, never reimplement, W03's resolution service.** `resolvePolicyInstallTarget` already does the tenancy-fail-closed catalog reachability check (`readReachableCatalogItem`, private to that module) and the platform/install-target check. This wave never re-derives that logic in SQL or in JS — every eligibility decision routes through that one function.
+- **Cost bound — the load-bearing design constraint of this wave.** `resolvePolicyInstallTarget` costs up to 3 DB round trips per call. Calling it once per device would be O(devices) — thousands of round trips on exactly the "broad policy" scenario the spec's Risk section is about. Instead it is called **at most once per (distinct device `orgId`, distinct device `osType`, candidate `catalogId`)** triple — bounded by tenant/OS variety, not device count, because catalog **reachability** varies only with a device's org and install-**target existence** varies only with platform. The per-group device tally is a real SQL `COUNT(DISTINCT device_id)`, never a `SELECT ... LIMIT n` whose `.length` is reported as the total — that pattern is the literal bug already shipped at `GET /violations` (`routes/softwarePolicies.ts:496`, `total: rows.length` after a `.limit(query.limit ?? 100)`), and it silently undercounts on exactly the broad policies this feature exists to warn about. This wave does not repeat it.
+- **Read-only. No arming, no write, no MFA.** This route only reports blast radius; it authorizes identically to its GET siblings (`requireSoftwarePolicyRead` + router-level `authMiddleware`/`requireScope`, `apps/api/src/routes/softwarePolicies.ts:26-29,39-40`) plus the same site-ceiling narrowing `GET /violations` already applies (`resolveSiteAllowedDeviceIds`, `:235-247`). It does **not** need `canMutateOrgWideGovernance` — that gate exists only on writes.
+- **Multi-tenant isolation is via the existing `getPolicyWithAccess` 404, unchanged.** A policy id that does not exist, and a policy id that exists in another tenant, produce the byte-identical 404 body — this is deliberate, pre-existing behavior (`GET /:id`, `:508-511`) that this wave's new route copies rather than reinvents; it does not (and must not) leak which case occurred.
+- **Response contract is exactly what W04 already codes against:** `{ eligibleDeviceCount: number }`, nothing else. W04's `PolicyForm.tsx` (Task 2, already written) does `Number((payload as { eligibleDeviceCount?: unknown })?.eligibleDeviceCount)` and treats any non-finite result as unavailable — do not add or rename fields.
+- **Scoped test runs:** `cd apps/api && npx vitest run <path>`. **Never** `pnpm --filter <pkg> test -- --run <path>` — pnpm forwards the literal `--` into vitest's argv, vitest stops flag-parsing there, `--run` is swallowed as a positional filter, and vitest falls back to watch mode over the whole 1,470-file suite. Vitest's path filter is a plain **substring** match, not a glob and not a directory prefix — always check the reported file count.
+- **TDD is mandatory and red-first.** Write the assertion, run it against unmodified code, watch it fail for the stated reason, then implement.
+- **Out of scope, do not touch:** the arming helper, the compliance worker's gate/cap/attempt-counter logic, `software_deployments`/deployment creation, any file under `apps/web`, `aiGuardrails.ts`/`aiTools*.ts`/`aiToolSchemas.ts`/`aiAgentSdkTools.ts` (a sibling projection of `software_compliance_status.remediationStatus` was found at `services/aiToolsCompliance.ts:130` during ground truth — it is **not** touched by this wave; it belongs to whichever wave owns AI-facing compliance tooling, matching the contract's convention that `aiTools*.ts` files are reserved territory the other server waves also do not touch).
+
+---
+
+## 0. Ground truth
+
+Every citation below was re-opened in this worktree (`/Users/toddhebebrand/.herdr/worktrees/breeze/warranty-testing`) on 2026-09-10.
+
+**Newest migration** (confirms no wave has yet added W02's columns): `ls apps/api/migrations/*.sql | sort | tail -1` → `apps/api/migrations/2026-10-15-150300-remote-session-revocation-lease.sql`. `grep -rn "installRemediationStatus" apps/api/src/db/schema/softwarePolicies.ts apps/api/src/services/softwarePolicyService.ts` → **zero matches** — W02 has not landed. `ls apps/api/src/services/softwarePolicyInstallRemediation.ts` → **does not exist** — W03 has not landed either. This wave's Task 1/2 Step 1 and Task 3 Step 1 exist specifically to re-check this at implementation time and stop if either dependency is still missing.
+
+**`GET /software-policies/violations` — the exact bug this wave's cost design replaces**, `apps/api/src/routes/softwarePolicies.ts:448-498`, verbatim the tail:
+```ts
+473:    const rows = await db
+474:      .select({
+...
+490:      .from(softwareComplianceStatus)
+491:      .innerJoin(devices, eq(softwareComplianceStatus.deviceId, devices.id))
+492:      .where(and(...conditions))
+493:      .orderBy(desc(softwareComplianceStatus.lastChecked))
+494:      .limit(query.limit ?? 100);
+495:
+496:    return c.json({ data: rows, total: rows.length });
+```
+`total` is `rows.length` **after** a `.limit(query.limit ?? 100)` — on a policy with more than 100 matching rows this silently reports 100, not the true count. This is precisely what the task brief calls out and what this wave's `COUNT(DISTINCT ...)` design avoids.
+
+**`GET /:id` — the tenancy/404 pattern this wave's new route copies**, `:500-515`:
+```ts
+500:softwarePoliciesRoutes.get(
+501:  '/:id',
+502:  requireSoftwarePolicyRead,
+503:  zValidator('param', policyIdParamSchema),
+504:  async (c) => {
+505:    const auth = c.get('auth');
+506:    const { id } = c.req.valid('param');
+507:
+508:    const policy = await getPolicyWithAccess(id, auth);
+509:    if (!policy) {
+510:      return c.json({ error: 'Policy not found' }, 404);
+511:    }
+512:
+513:    return c.json({ data: policy });
+514:  }
+515:);
+```
+`getPolicyWithAccess` (`:215-227`) filters on `eq(softwarePolicies.id, policyId)` AND `softwarePolicyAccessCondition(auth)` (`:171-179`, the dual-axis org/partner-wide condition) in one query — a nonexistent id and a cross-tenant id both simply match zero rows, producing the identical 404. This wave's new route reuses `getPolicyWithAccess` unchanged.
+
+**`resolveSiteAllowedDeviceIds` — the site-ceiling narrowing this wave's new route also applies**, `:229-247`:
+```ts
+235:async function resolveSiteAllowedDeviceIds(
+236:  orgId: string,
+237:  perms: UserPermissions | undefined,
+238:): Promise<string[] | null> {
+239:  if (!perms?.allowedSiteIds) return null;
+240:  const orgDevices = await db
+241:    .select({ id: devices.id, siteId: devices.siteId })
+242:    .from(devices)
+243:    .where(eq(devices.orgId, orgId));
+244:  return orgDevices
+245:    .filter((d) => typeof d.siteId === 'string' && canAccessSite(perms, d.siteId))
+246:    .map((d) => d.id);
+247:}
+```
+Its call site inside `GET /violations` (`:460-469`), the exact narrowing pattern this wave's route copies:
+```ts
+460:    if (perms?.allowedSiteIds && auth.orgId) {
+461:      const allowedDeviceIds = await resolveSiteAllowedDeviceIds(auth.orgId, perms);
+462:      if (query.deviceId && !allowedDeviceIds!.includes(query.deviceId)) {
+463:        return c.json({ error: 'Device not found or access denied' }, 403);
+464:      }
+465:      if (perms.allowedSiteIds.length === 0) {
+466:        return c.json({ data: [], total: 0 });
+467:      }
+468:      conditions.push(inArray(devices.siteId, perms.allowedSiteIds));
+469:    }
+```
+(This wave has no `deviceId` query param, so only the `allowedSiteIds`-present / zero-length / narrow-to-allowed-ids shape applies — the 403-on-explicit-denied-device branch does not.)
+
+**Router-level middleware and the read-gate constant**, `:1,25-40`:
+```ts
+25:export const softwarePoliciesRoutes = new Hono();
+26:const requireSoftwarePolicyRead = requirePermission(
+27:  PERMISSIONS.DEVICES_READ.resource,
+28:  PERMISSIONS.DEVICES_READ.action,
+29:);
+...
+39:softwarePoliciesRoutes.use('*', authMiddleware);
+40:softwarePoliciesRoutes.use('*', requireScope('organization', 'partner', 'system'));
+```
+Imports already present at `:5-23` cover everything this wave's route needs except its own new service import: `db`, `devices`, `softwareComplianceStatus`, `softwarePolicies` (`:6-10`); `authMiddleware`/`requireMfa`/`requirePermission`/`requireScope`/`AuthContext` (`:11`); `normalizeSoftwarePolicyRules` (`:16-18`); `PERMISSIONS`/`canAccessSite`/`UserPermissions` (`:22`).
+
+**`resolveDeviceIdsForSoftwarePolicy` — the pre-existing, worker-shared device resolver this wave reuses**, `apps/api/src/services/featureConfigResolver.ts:1044` (signature) through the end of its function body (multi-step: config-policy links → assignments → per-level fan-out → closest-wins narrowing). Its only exported surface this wave needs:
+```ts
+export async function resolveDeviceIdsForSoftwarePolicy(
+  softwarePolicyId: string
+): Promise<string[]>
+```
+Its production call site, `apps/api/src/jobs/softwareComplianceWorker.ts:324`:
+```ts
+324:  const resolvedDeviceIds = await resolveDeviceIdsForSoftwarePolicy(policy.id);
+```
+This is the SAME function the compliance worker uses to decide which devices a policy governs — reusing it (rather than re-deriving device targeting) is what makes this endpoint's device set match the worker's, which is the entire point of a dry-run preview.
+
+**`resolvePolicyInstallTarget` — W03's function this wave calls, not reimplements** (cited from W03's plan, Task 4, since the file does not exist yet in this worktree — see "Newest migration" above). Exact signature this wave depends on:
+```ts
+export type PolicyInstallSkipReason =
+  | 'no_catalog_id'
+  | 'catalog_item_not_reachable'
+  | 'no_install_target_for_platform';
+
+export type PolicyInstallTarget =
+  | { kind: 'install_method'; catalogId: string; installMethodId: string }
+  | { kind: 'version'; catalogId: string; softwareVersionId: string };
+
+export type PolicyInstallTargetResolution =
+  | { ok: true; target: PolicyInstallTarget }
+  | { ok: false; reason: PolicyInstallSkipReason };
+
+export function resolvePolicyInstallTarget(input: {
+  catalogId: string | null | undefined;
+  deviceOrgId: string;
+  deviceOsType: string;
+}): Promise<PolicyInstallTargetResolution>;
+```
+Location: `apps/api/src/services/softwarePolicyInstallRemediation.ts`. Reachability depends only on `deviceOrgId` (fail-closed cross-tenant guard, `readReachableCatalogItem`, private to that module); install-target existence depends only on `deviceOsType` and the platform of the catalog item's install methods/versions. Neither depends on any OTHER device attribute — this is exactly what licenses grouping by `(orgId, osType)` instead of calling once per device.
+
+**`evaluateSoftwareInventory` — confirms `missing` violations are allowlist-only**, `apps/api/src/services/softwarePolicyService.ts:304-374`. The `mode === 'allowlist'` branch (`:311-343`) is the only branch that ever pushes `type: 'missing'`; the blocklist/audit branch (`:353-373`) only ever pushes `type: 'unauthorized'`. So a non-allowlist policy can never have a `missing` violation recorded in `software_compliance_status.violations`, and this wave's new route short-circuits to `{ eligibleDeviceCount: 0 }` for `mode !== 'allowlist'` before touching device resolution at all — a correctness-preserving optimization, not a new rule (the long way round would reach the same answer, just after O(devices) work).
+
+**`software_compliance_status` schema** (unique constraint the Task 3 query relies on for "at most one row per (device, policy)"), `apps/api/src/db/schema/softwarePolicies.ts:114-129`:
+```ts
+114:export const softwareComplianceStatus = pgTable('software_compliance_status', {
+115:  id: uuid('id').primaryKey().defaultRandom(),
+116:  deviceId: uuid('device_id').notNull().references(() => devices.id),
+117:  policyId: uuid('policy_id').notNull().references(() => softwarePolicies.id, { onDelete: 'cascade' }),
+118:  status: varchar('status', { length: 20 }).notNull().default('compliant'),
+119:  lastChecked: timestamp('last_checked').notNull(),
+120:  violations: jsonb('violations').$type<SoftwarePolicyViolation[]>(),
+121:  remediationStatus: varchar('remediation_status', { length: 20 }).default('none'),
+122:  lastRemediationAttempt: timestamp('last_remediation_attempt'),
+123:  remediationErrors: jsonb('remediation_errors').$type<RemediationError[]>(),
+124:}, (table) => ({
+...
+128:  devicePolicyUnique: uniqueIndex('software_compliance_device_policy_unique').on(table.deviceId, table.policyId),
+129:}));
+```
+
+**`SoftwarePolicyRulesDefinition` / `SoftwarePolicyRuleDefinition`** (where `catalogId` on a rule lives, and how it is re-exported), `apps/api/src/db/schema/softwarePolicies.ts:25-45`:
+```ts
+25:export type SoftwarePolicyRuleDefinition = {
+26:  name: string;
+27:  vendor?: string;
+28:  minVersion?: string;
+29:  maxVersion?: string;
+30:  catalogId?: string;
+31:  reason?: string;
+32:};
+...
+42:export type SoftwarePolicyRulesDefinition = {
+43:  software: SoftwarePolicyRuleDefinition[];
+44:  allowUnknown?: boolean;
+45:  executable?: SoftwarePolicyExecutableRule[];
+46:};
+```
+`apps/api/src/db/schema/index.ts:40` — `export * from './softwarePolicies';` — so this wave imports the type from the `../db/schema` barrel, the same source `services/softwarePolicyService.ts:4-13` already uses, not the deeper file path.
+
+**`normalizeSoftwarePolicyRules`**, `services/softwarePolicyService.ts:208` (signature) — `(rules: unknown): SoftwarePolicyRulesDefinition`, already imported into `routes/softwarePolicies.ts` at `:16-18` and used by every existing handler that needs a policy's parsed rules (e.g. the POST/PATCH handlers). This wave's new route reuses it rather than reading `policy.rules` raw.
+
+**`jsonb_array_elements` safety idiom already established in this codebase** (Task 1's `EXISTS` subquery copies this exactly), `apps/api/src/services/aiAgents/impactRollup.ts:227-230`:
+```ts
+227:        CROSS JOIN LATERAL jsonb_array_elements(
+228:          CASE WHEN jsonb_typeof(r.outcome->'proposedActions') = 'array'
+229:               THEN r.outcome->'proposedActions' ELSE '[]'::jsonb END
+230:        ) AS p(item)
+```
+and `services/metricRollups.ts:44`: "empty / NULL array: `jsonb_array_elements` yields zero rows either way." The `CASE WHEN jsonb_typeof(...) = 'array' THEN ... ELSE '[]'::jsonb END` guard defends against a NULL or malformed (non-array) jsonb value making the set-returning function raise, per the comment at `services/aiAgents/narrativeContext.ts:806-810`. This wave's Task 1 query uses the identical guard around `softwareComplianceStatus.violations`.
+
+**The safe pattern for binding a JS array into `= ANY(...)` with this codebase's `sql` tag**, `apps/api/src/extensions/tenancyTripwire.ts:223-227`:
+```ts
+223:  // Bind every table name as an individually-parameterised text literal inside
+224:  // an explicit ARRAY[...]::text[]. Embedding the JS array directly
+225:  // (`= ANY(${names})`) makes drizzle expand it to a TUPLE — `= ANY(($1, $2))` —
+226:  // which Postgres rejects with 42809. An empty list yields `ARRAY[]::text[]`,
+227:  // which is valid and simply matches nothing.
+228:  const declaredArray = sql`ARRAY[${sql.join([...declared].map((t) => sql`${t}`), sql`, `)}]::text[]`;
+```
+Task 1's query builds its `catalogId` list the same way (never interpolates a bare JS array directly into `= ANY(...)`).
+
+**`count(*)::int` precedent already in this exact file**, `routes/softwarePolicies.ts:429`, inside `GET /compliance/overview`:
+```ts
+429:      count: sql<number>`count(*)::int`,
+```
+Task 1's `COUNT(DISTINCT device_id)::int` follows the identical `sql<number>` typing convention.
+
+**Test file conventions** — `apps/api/src/routes/softwarePolicies.test.ts` (929 lines, read in full) establishes the mock shape this wave's route tests must match: `vi.mock('../db', ...)` with bare `select`/`insert`/`update`/`delete`/`transaction` mocks (`:5-16`); `vi.mock('../db/schema', ...)` with each table stubbed as a plain object of string column markers (`:18-38`); `vi.mock('../middleware/auth', ...)` stubbing `authMiddleware`/`requireScope`/`requirePermission`/`requireMfa` as unconditional passthroughs (`:40-45`); a per-describe-block `setAuth(allowedSiteIds?)` helper that calls `vi.mocked(authMiddleware).mockImplementation((c, next) => { c.set('auth', {...}); if (allowedSiteIds) c.set('permissions', { allowedSiteIds }); return next(); })` (`:659-672`, the "GET /violations — site scope" block); `mockPolicyLookup()` for `getPolicyWithAccess`'s `select().from().where().limit()` chain (`:290-301`, the "POST /:id/remediate — site scope" block); and an existing, directly-reusable precedent for simulating an unauthenticated request by making the mocked `authMiddleware` return a 401 `Response` WITHOUT calling `next` — `routes/sso.test.ts:3928`: `vi.mocked(authMiddleware).mockImplementation((c: any) => c.json({ error: 'Unauthorized' }, 401));`. `apps/api/src/routes/softwarePolicies.siteScope.test.ts` and `.approvalGeneration.test.ts` establish the precedent of **splitting concern-specific test coverage for this route file into sibling files** rather than growing the single 929-line file further — this wave's new route tests follow that precedent as a new sibling file.
+
+**`requirePermission`'s own rejection behaviour is covered elsewhere, not by this file's mocked middleware.** `apps/api/src/middleware/auth.test.ts:977` — `describe('requirePermission', ...)` — a dedicated suite. In `routes/softwarePolicies.test.ts` (and every sibling test file for this router), `requirePermission` is globally stubbed to an unconditional passthrough (`:40-45` above) for ALL nine existing routes in the file; none of them tests a `requirePermission`-driven 403, because the shared mock has no per-route way to make it reject (the returned middleware function is a fresh, non-`vi.fn()` closure on every call, and `requireSoftwarePolicyRead` — like the route this wave adds — is bound once at module-import time, before any test-specific mock override could apply). This wave's "wrong permission" coverage is therefore a **wiring** check (this route is gated by the same permission middleware, in the same position, as its sibling reads) rather than a live-rejection test — consistent with, not weaker than, the other nine routes in this file.
+
+**`Hono.routes` introspection precedent**, confirming route-table inspection is an established technique in this codebase (not a novel one introduced by this wave): `routes/m365.test.ts:92` — `const middleware = m365Routes.routes.filter((route) => route.method === 'ALL');`; `routes/quotesPublic.superseded.test.ts:400-401` — `(quotesPublicRoutes as unknown as { routes: Array<{ method: string; path: string }> }).routes`.
+
+**Sibling projections of `softwareComplianceStatus.remediationStatus`, searched repo-wide** (`grep -rn "remediationStatus:\s*softwareComplianceStatus.remediationStatus"`): three hits — `routes/softwarePolicies.ts:487` (the one Task 3 widens), `jobs/softwareComplianceWorker.ts:113` (the worker's own internal `readComplianceStateByDevice`, reading OLD state to decide an upsert — not an HTTP-facing projection, out of scope), and `services/aiToolsCompliance.ts:130` (an AI-tool-facing projection — out of scope per this wave's Global Constraints; it is `aiTools*.ts` territory). Within `routes/softwarePolicies.ts` itself, `grep -n "softwareComplianceStatus\." routes/softwarePolicies.ts` shows exactly one column-projecting `.select()` (`:473-497`, `GET /violations`) — the other five hits in that file (`:411,857-873,912-913`) are `deviceId`-only or aggregate-only selects used for internal filtering, not external projections, and are unaffected by this wave.
+
+---
+
+## File Structure
+
+- **Create** `apps/api/src/services/softwarePolicyInstallPreview.ts` — the cost-bounded eligible-device-count computation. One responsibility: given a policy's parsed rules and its resolved (and optionally site-narrowed) device id set, decide how many devices would receive an install right now.
+- **Create** `apps/api/src/services/softwarePolicyInstallPreview.test.ts` — unit coverage for the above.
+- **Modify** `apps/api/src/routes/softwarePolicies.ts` — one new import, one new `GET /:id/install-preview` route (Task 2), and a three-field widen of `GET /violations`'s existing compliance projection (Task 3).
+- **Create** `apps/api/src/routes/softwarePolicies.installPreview.test.ts` — route-level coverage for the new endpoint (auth, tenancy, site-ceiling, validation, response contract), following the established sibling-file split (`softwarePolicies.siteScope.test.ts`, `.approvalGeneration.test.ts`).
+- **Modify** `apps/api/src/routes/softwarePolicies.test.ts` — extend the shared mocked `db/schema` fixture with the three new column markers, add one new RED-discriminating test proving the `GET /violations` projection includes them, and extend the existing site-scope test's mock row so the new fields are proven to survive site-ceiling narrowing too.
+
+---
+
+### Task 1: `softwarePolicyInstallPreview.ts` — cost-bounded eligible-device-count computation
+
+**Files:**
+- Create: `apps/api/src/services/softwarePolicyInstallPreview.ts`
+- Test: `apps/api/src/services/softwarePolicyInstallPreview.test.ts`
+
+**Interfaces:**
+- Consumes: `resolveDeviceIdsForSoftwarePolicy(policyId): Promise<string[]>` from `./featureConfigResolver` (pre-existing, unmodified); `resolvePolicyInstallTarget(input): Promise<PolicyInstallTargetResolution>` from `./softwarePolicyInstallRemediation` (**W03**, not reimplemented); `devices`, `softwareComplianceStatus`, `type SoftwarePolicyRulesDefinition` from `../db/schema`; `db` from `../db`.
+- Produces (Task 2 imports this):
+  ```ts
+  export async function computeInstallPreviewEligibleDeviceCount(input: {
+    policyId: string;
+    rules: SoftwarePolicyRulesDefinition;
+    siteAllowedDeviceIds?: string[] | null;
+  }): Promise<number>;
+  ```
+
+- [ ] **Step 1: Verify W03 has landed and record the real names**
+
+```bash
+cd /Users/toddhebebrand/.herdr/worktrees/breeze/warranty-testing
+grep -n "export function resolvePolicyInstallTarget" -A 6 apps/api/src/services/softwarePolicyInstallRemediation.ts
+grep -n "export async function resolveDeviceIdsForSoftwarePolicy" -A 2 apps/api/src/services/featureConfigResolver.ts
+```
+
+Expected: the first command shows `resolvePolicyInstallTarget(input: { catalogId: string | null | undefined; deviceOrgId: string; deviceOsType: string }): Promise<PolicyInstallTargetResolution>`. If it shows nothing, **W03 has not landed — stop this task and report that rather than inventing the function.** The second command is a sanity check on the pre-existing (wave-independent) resolver and should already match this plan's ground truth.
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `apps/api/src/services/softwarePolicyInstallPreview.test.ts`:
+
+```ts
+/**
+ * #5505 W06 — the dry-run device count behind PolicyForm's "this will install
+ * missing software on ~N device(s)" warning (spec Risks §2, "Fleet-wide first
+ * run": arming autoInstall on a broad existing policy could otherwise queue
+ * thousands of installs with no warning).
+ *
+ * Cost bound: resolvePolicyInstallTarget (W03) costs up to 3 DB round trips
+ * per call, so calling it once per DEVICE would be O(devices) — exactly what
+ * this module exists to avoid on a policy that can resolve thousands of them.
+ * It is instead called at most once per (distinct orgId, distinct osType,
+ * candidate catalogId) triple: catalog reachability only varies by org, and
+ * install-target existence only varies by platform, so grouping resolved
+ * devices by (orgId, osType) collapses the common case (one org, a handful of
+ * OS types) to a small number of calls regardless of device count. The actual
+ * device tally per group is a real SQL COUNT(DISTINCT ...), never a capped
+ * fetch-and-.length (the bug this replaces — GET /violations,
+ * routes/softwarePolicies.ts:496).
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { selectMock } = vi.hoisted(() => ({ selectMock: vi.fn() }));
+vi.mock('../db', () => ({
+  db: { select: (...a: unknown[]) => selectMock(...a) },
+}));
+
+vi.mock('../db/schema', () => ({
+  devices: { id: 'devices.id', orgId: 'devices.orgId', osType: 'devices.osType' },
+  softwareComplianceStatus: {
+    deviceId: 'softwareComplianceStatus.deviceId',
+    policyId: 'softwareComplianceStatus.policyId',
+    violations: 'softwareComplianceStatus.violations',
+  },
+}));
+
+const { resolveDeviceIdsMock } = vi.hoisted(() => ({ resolveDeviceIdsMock: vi.fn() }));
+vi.mock('./featureConfigResolver', () => ({
+  resolveDeviceIdsForSoftwarePolicy: (...a: unknown[]) => resolveDeviceIdsMock(...a),
+}));
+
+const { resolveTargetMock } = vi.hoisted(() => ({ resolveTargetMock: vi.fn() }));
+vi.mock('./softwarePolicyInstallRemediation', () => ({
+  resolvePolicyInstallTarget: (...a: unknown[]) => resolveTargetMock(...a),
+}));
+
+import { computeInstallPreviewEligibleDeviceCount } from './softwarePolicyInstallPreview';
+
+/** Thenable chain matching this module's fixed `.select().from().where()` shape. */
+function chain(result: unknown): any {
+  const p: any = Promise.resolve(result);
+  for (const m of ['from', 'where']) p[m] = () => p;
+  return p;
+}
+
+/** Serves db.select() in this module's fixed order: device-meta chunk(s), then one COUNT query per eligible group. */
+function primeSelects(...results: unknown[][]) {
+  let call = 0;
+  selectMock.mockImplementation(() => chain(results[Math.min(call++, results.length - 1)] ?? []));
+}
+
+const RULES_ONE_CATALOG = { software: [{ name: 'Zoom', catalogId: 'cat-1' }] };
+const RULES_NO_CATALOG = { software: [{ name: 'Zoom' }] };
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('computeInstallPreviewEligibleDeviceCount', () => {
+  it('returns 0 without touching the database when no rule has a catalogId', async () => {
+    const count = await computeInstallPreviewEligibleDeviceCount({
+      policyId: 'pol-1',
+      rules: RULES_NO_CATALOG,
+    });
+    expect(count).toBe(0);
+    expect(resolveDeviceIdsMock).not.toHaveBeenCalled();
+    expect(selectMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 0 without a count query when the policy resolves zero devices', async () => {
+    resolveDeviceIdsMock.mockResolvedValue([]);
+    const count = await computeInstallPreviewEligibleDeviceCount({
+      policyId: 'pol-1',
+      rules: RULES_ONE_CATALOG,
+    });
+    expect(count).toBe(0);
+    expect(selectMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 0 without a count query when the caller site allowlist excludes every resolved device', async () => {
+    resolveDeviceIdsMock.mockResolvedValue(['dev-1', 'dev-2']);
+    const count = await computeInstallPreviewEligibleDeviceCount({
+      policyId: 'pol-1',
+      rules: RULES_ONE_CATALOG,
+      siteAllowedDeviceIds: [],
+    });
+    expect(count).toBe(0);
+    expect(selectMock).not.toHaveBeenCalled();
+  });
+
+  it('counts eligible devices for a single (org, os) group via a real COUNT query', async () => {
+    resolveDeviceIdsMock.mockResolvedValue(['dev-1', 'dev-2']);
+    resolveTargetMock.mockResolvedValue({
+      ok: true,
+      target: { kind: 'install_method', catalogId: 'cat-1', installMethodId: 'im-1' },
+    });
+    primeSelects(
+      [
+        { id: 'dev-1', orgId: 'org-1', osType: 'windows' },
+        { id: 'dev-2', orgId: 'org-1', osType: 'windows' },
+      ],
+      [{ count: 2 }],
+    );
+
+    const count = await computeInstallPreviewEligibleDeviceCount({
+      policyId: 'pol-1',
+      rules: RULES_ONE_CATALOG,
+    });
+
+    expect(count).toBe(2);
+    expect(resolveTargetMock).toHaveBeenCalledWith({
+      catalogId: 'cat-1',
+      deviceOrgId: 'org-1',
+      deviceOsType: 'windows',
+    });
+    expect(selectMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips the count query entirely for a group where no rule resolves — the cross-platform loop guard', async () => {
+    resolveDeviceIdsMock.mockResolvedValue(['dev-1']);
+    resolveTargetMock.mockResolvedValue({ ok: false, reason: 'no_install_target_for_platform' });
+    primeSelects([{ id: 'dev-1', orgId: 'org-1', osType: 'linux' }]);
+
+    const count = await computeInstallPreviewEligibleDeviceCount({
+      policyId: 'pol-1',
+      rules: RULES_ONE_CATALOG,
+    });
+
+    expect(count).toBe(0);
+    // Only the device-meta select ran; no per-group count query followed.
+    expect(selectMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('sums across multiple (org, os) groups independently, skipping ineligible ones', async () => {
+    resolveDeviceIdsMock.mockResolvedValue(['dev-win', 'dev-mac']);
+    resolveTargetMock.mockImplementation(async ({ deviceOsType }: { deviceOsType: string }) =>
+      deviceOsType === 'windows'
+        ? { ok: true, target: { kind: 'install_method', catalogId: 'cat-1', installMethodId: 'im-1' } }
+        : { ok: false, reason: 'no_install_target_for_platform' },
+    );
+    primeSelects(
+      [
+        { id: 'dev-win', orgId: 'org-1', osType: 'windows' },
+        { id: 'dev-mac', orgId: 'org-1', osType: 'macos' },
+      ],
+      [{ count: 1 }],
+    );
+
+    const count = await computeInstallPreviewEligibleDeviceCount({
+      policyId: 'pol-1',
+      rules: RULES_ONE_CATALOG,
+    });
+
+    expect(count).toBe(1);
+    // Device-meta select + exactly ONE count query (windows group only — the
+    // macos group had zero eligible catalogIds and never reached a query).
+    expect(selectMock).toHaveBeenCalledTimes(2);
+  });
+});
+```
+
+- [ ] **Step 3: Run it and watch it fail**
+
+```bash
+cd apps/api && npx vitest run src/services/softwarePolicyInstallPreview.test.ts
+```
+
+Expected: FAIL — `Failed to resolve import "./softwarePolicyInstallPreview"`.
+
+- [ ] **Step 4: Implement**
+
+Create `apps/api/src/services/softwarePolicyInstallPreview.ts`:
+
+```ts
+import { and, eq, inArray, sql } from 'drizzle-orm';
+import { db } from '../db';
+import { devices, softwareComplianceStatus, type SoftwarePolicyRulesDefinition } from '../db/schema';
+import { resolveDeviceIdsForSoftwarePolicy } from './featureConfigResolver';
+import { resolvePolicyInstallTarget } from './softwarePolicyInstallRemediation';
+
+/**
+ * #5505 W06 — the dry-run device count behind the "this will install missing
+ * software on ~N device(s)" warning (spec Risks §2, "Fleet-wide first run").
+ *
+ * COST BOUND (the reason this file exists rather than a per-device loop):
+ * resolvePolicyInstallTarget (W03) does up to 3 DB round trips per call.
+ * Reachability of a catalogId depends only on the DEVICE'S ORG (the
+ * fail-closed cross-tenant guard); install-target existence depends only on
+ * the DEVICE'S OS TYPE. Neither depends on any other device attribute. So
+ * resolved devices are grouped by (orgId, osType) and resolvePolicyInstallTarget
+ * is called at most once per (group x candidate catalogId) — bounded by
+ * tenant/OS variety, never by device count — instead of once per device.
+ * The actual per-group device tally is a real SQL COUNT(DISTINCT device_id),
+ * never a capped SELECT ... LIMIT whose .length is reported as the total
+ * (the bug at GET /violations, routes/softwarePolicies.ts:496, which silently
+ * undercounts past its default limit of 100).
+ */
+
+const PREVIEW_QUERY_CHUNK_SIZE = 500;
+
+function chunkArray<T>(items: T[], size = PREVIEW_QUERY_CHUNK_SIZE): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += size) chunks.push(items.slice(i, i + size));
+  return chunks;
+}
+
+type DeviceGroup = { orgId: string; osType: string; deviceIds: string[] };
+
+export async function computeInstallPreviewEligibleDeviceCount(input: {
+  policyId: string;
+  rules: SoftwarePolicyRulesDefinition;
+  siteAllowedDeviceIds?: string[] | null;
+}): Promise<number> {
+  // A rule with no catalogId can be DETECTED as missing but never installed
+  // (spec §4) — skip before resolving a single device.
+  const candidateCatalogIds = Array.from(
+    new Set(
+      (input.rules.software ?? [])
+        .map((rule) => rule.catalogId)
+        .filter((catalogId): catalogId is string => typeof catalogId === 'string' && catalogId.length > 0),
+    ),
+  );
+  if (candidateCatalogIds.length === 0) return 0;
+
+  // Same resolver the compliance worker uses (softwareComplianceWorker.ts:324)
+  // — this is what makes the preview's device set match what the worker would
+  // actually act on.
+  let deviceIds = await resolveDeviceIdsForSoftwarePolicy(input.policyId);
+  if (input.siteAllowedDeviceIds) {
+    const allowed = new Set(input.siteAllowedDeviceIds);
+    deviceIds = deviceIds.filter((deviceId) => allowed.has(deviceId));
+  }
+  deviceIds = Array.from(new Set(deviceIds));
+  if (deviceIds.length === 0) return 0;
+
+  const groups = new Map<string, DeviceGroup>();
+  for (const chunk of chunkArray(deviceIds)) {
+    const rows = await db
+      .select({ id: devices.id, orgId: devices.orgId, osType: devices.osType })
+      .from(devices)
+      .where(inArray(devices.id, chunk));
+    for (const row of rows) {
+      const key = `${row.orgId}:${row.osType}`;
+      let group = groups.get(key);
+      if (!group) {
+        group = { orgId: row.orgId, osType: row.osType, deviceIds: [] };
+        groups.set(key, group);
+      }
+      group.deviceIds.push(row.id);
+    }
+  }
+
+  let total = 0;
+  for (const group of groups.values()) {
+    const eligibleCatalogIds: string[] = [];
+    for (const catalogId of candidateCatalogIds) {
+      const resolution = await resolvePolicyInstallTarget({
+        catalogId,
+        deviceOrgId: group.orgId,
+        deviceOsType: group.osType,
+      });
+      if (resolution.ok) eligibleCatalogIds.push(catalogId);
+    }
+    if (eligibleCatalogIds.length === 0) continue;
+
+    // Safe ARRAY[...]::text[] construction — embedding a bare JS array
+    // directly into `= ANY(${arr})` makes drizzle expand it to a comma tuple
+    // instead of a real Postgres array (extensions/tenancyTripwire.ts:223-228).
+    const catalogIdsArray = sql`ARRAY[${sql.join(
+      eligibleCatalogIds.map((catalogId) => sql`${catalogId}`),
+      sql`, `,
+    )}]::text[]`;
+
+    for (const idsChunk of chunkArray(group.deviceIds)) {
+      const [row] = await db
+        .select({
+          count: sql<number>`count(distinct ${softwareComplianceStatus.deviceId})::int`,
+        })
+        .from(softwareComplianceStatus)
+        .where(
+          and(
+            eq(softwareComplianceStatus.policyId, input.policyId),
+            inArray(softwareComplianceStatus.deviceId, idsChunk),
+            sql`EXISTS (
+              SELECT 1
+              FROM jsonb_array_elements(
+                CASE WHEN jsonb_typeof(${softwareComplianceStatus.violations}) = 'array'
+                     THEN ${softwareComplianceStatus.violations}
+                     ELSE '[]'::jsonb END
+              ) AS elem
+              WHERE elem->>'type' = 'missing'
+                AND elem->'rule'->>'catalogId' = ANY(${catalogIdsArray})
+            )`,
+          ),
+        );
+      total += Number(row?.count ?? 0);
+    }
+  }
+
+  return total;
+}
+```
+
+- [ ] **Step 5: Run the tests and watch them pass**
+
+```bash
+cd apps/api && npx vitest run src/services/softwarePolicyInstallPreview.test.ts
+```
+
+Expected: PASS, 6 tests.
+
+- [ ] **Step 6: Typecheck and commit**
+
+```bash
+pnpm --filter @breeze/api exec tsc --noEmit
+git add apps/api/src/services/softwarePolicyInstallPreview.ts apps/api/src/services/softwarePolicyInstallPreview.test.ts
+git commit -m "$(cat <<'EOF'
+feat(software): cost-bounded install-preview eligible-device count — #5505 W06
+
+Reuses W03's resolvePolicyInstallTarget (never reimplements it), grouping
+resolved devices by (orgId, osType) so it costs O(groups x catalogIds),
+never O(devices) — the scenario spec Risks §2 warns about (a broad policy
+could resolve thousands of devices from a single UI checkbox). Per-group
+tally is a real SQL COUNT(DISTINCT ...), not the capped fetch-and-.length
+GET /violations uses today.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01ANjBwca2cfsLWDLJro3fkz
+EOF
+)"
+```
+
+---
+
+### Task 2: `GET /software-policies/:id/install-preview` route
+
+**Files:**
+- Modify: `apps/api/src/routes/softwarePolicies.ts:15-18` (import), insert new route after `:515`
+- Test: `apps/api/src/routes/softwarePolicies.installPreview.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `computeInstallPreviewEligibleDeviceCount(input)` (Task 1); `getPolicyWithAccess(id, auth)`, `resolveSiteAllowedDeviceIds(orgId, perms)`, `requireSoftwarePolicyRead`, `normalizeSoftwarePolicyRules`, `policyIdParamSchema` — all pre-existing in this file.
+- Produces: `GET /software-policies/:id/install-preview` → `200 { eligibleDeviceCount: number }` | `404 { error: 'Policy not found' }` | `400` (zValidator). This is the exact contract W04's `PolicyForm.tsx` Task 2 already codes against.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/api/src/routes/softwarePolicies.installPreview.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+vi.mock('../db', () => ({
+  db: { select: vi.fn(), insert: vi.fn(), update: vi.fn(), delete: vi.fn(), transaction: vi.fn() },
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock('../db/schema', () => ({
+  devices: {
+    id: 'devices.id', orgId: 'devices.orgId', siteId: 'devices.siteId',
+    hostname: 'devices.hostname', status: 'devices.status', osType: 'devices.osType',
+  },
+  softwareComplianceStatus: {
+    id: 'x', policyId: 'x', deviceId: 'x', status: 'x', violations: 'x', lastChecked: 'x',
+    remediationStatus: 'x', lastRemediationAttempt: 'x',
+    installRemediationStatus: 'x', lastInstallRemediationAttempt: 'x', installRemediationAttempts: 'x',
+  },
+  softwarePolicies: {
+    id: 'id', orgId: 'orgId', partnerId: 'partnerId', mode: 'mode', rules: 'rules',
+    name: 'name', isActive: 'isActive', updatedAt: 'updatedAt',
+  },
+}));
+
+vi.mock('../middleware/auth', () => ({
+  authMiddleware: vi.fn((c: any, next: any) => next()),
+  requireScope: vi.fn(() => async (_c: any, next: any) => next()),
+  requirePermission: vi.fn(() => async (_c: any, next: any) => next()),
+  requireMfa: vi.fn(() => async (_c: any, next: any) => next()),
+}));
+
+vi.mock('../jobs/softwareComplianceWorker', () => ({ scheduleSoftwareComplianceCheck: vi.fn() }));
+vi.mock('../jobs/softwareRemediationWorker', () => ({ scheduleSoftwareRemediation: vi.fn(async () => 1) }));
+vi.mock('../services/softwarePolicyService', () => ({
+  normalizeSoftwarePolicyRules: (r: any) => ({
+    software: r?.software ?? [],
+    executable: r?.executable,
+    allowUnknown: r?.allowUnknown,
+  }),
+  recordSoftwarePolicyAudit: vi.fn(async () => undefined),
+}));
+vi.mock('../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
+vi.mock('../services/pamActuationLifecycle', () => ({ requestPamCleanup: vi.fn() }));
+vi.mock('../services/sentry', () => ({ captureException: vi.fn() }));
+vi.mock('../services/permissions', () => ({
+  PERMISSIONS: {
+    DEVICES_READ: { resource: 'devices', action: 'read' },
+    DEVICES_WRITE: { resource: 'devices', action: 'write' },
+    DEVICES_EXECUTE: { resource: 'devices', action: 'execute' },
+  },
+  canAccessSite: (perms: any, siteId: string) => !perms?.allowedSiteIds || perms.allowedSiteIds.includes(siteId),
+}));
+
+const { computeMock } = vi.hoisted(() => ({ computeMock: vi.fn() }));
+vi.mock('../services/softwarePolicyInstallPreview', () => ({
+  computeInstallPreviewEligibleDeviceCount: (...a: unknown[]) => computeMock(...a),
+}));
+
+import { softwarePoliciesRoutes } from './softwarePolicies';
+import { db } from '../db';
+import { authMiddleware } from '../middleware/auth';
+
+const ORG_ID = '11111111-1111-1111-1111-111111111111';
+const POLICY_ID = '22222222-2222-2222-2222-222222222222';
+
+function setAuth(allowedSiteIds?: string[]) {
+  vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+    c.set('auth', {
+      scope: 'organization',
+      orgId: ORG_ID,
+      accessibleOrgIds: [ORG_ID],
+      canAccessOrg: (id: string) => id === ORG_ID,
+      orgCondition: () => undefined,
+      user: { id: 'user-123', email: 'test@example.com' },
+    });
+    if (allowedSiteIds) c.set('permissions', { allowedSiteIds });
+    return next();
+  });
+}
+
+function mockPolicyLookup(row: Record<string, unknown> | null) {
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(row ? [row] : []),
+      }),
+    }),
+  } as any);
+}
+
+function mockSiteResolution(rows: Array<{ id: string; siteId: string | null }>) {
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(rows),
+    }),
+  } as any);
+}
+
+const ALLOWLIST_POLICY = {
+  id: POLICY_ID,
+  orgId: ORG_ID,
+  partnerId: null,
+  mode: 'allowlist',
+  rules: { software: [{ name: 'Zoom', catalogId: 'cat-1' }] },
+};
+
+function app() {
+  const instance = new Hono();
+  instance.route('/software-policies', softwarePoliciesRoutes);
+  return instance;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setAuth();
+});
+
+describe('GET /software-policies/:id/install-preview', () => {
+  it('returns the eligible device count for an accessible allowlist policy', async () => {
+    mockPolicyLookup(ALLOWLIST_POLICY);
+    computeMock.mockResolvedValue(42);
+
+    const res = await app().request(`/software-policies/${POLICY_ID}/install-preview`, {
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ eligibleDeviceCount: 42 });
+    expect(computeMock).toHaveBeenCalledWith({
+      policyId: POLICY_ID,
+      rules: { software: [{ name: 'Zoom', catalogId: 'cat-1' }], executable: undefined, allowUnknown: undefined },
+      siteAllowedDeviceIds: null,
+    });
+  });
+
+  it('returns 0 without calling the count service for a non-allowlist policy', async () => {
+    mockPolicyLookup({ ...ALLOWLIST_POLICY, mode: 'blocklist' });
+
+    const res = await app().request(`/software-policies/${POLICY_ID}/install-preview`, {
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ eligibleDeviceCount: 0 });
+    expect(computeMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when the request is unauthenticated', async () => {
+    // Precedent: routes/sso.test.ts:3928 — a mocked middleware that returns a
+    // Response without calling next() short-circuits the chain, same as the
+    // real authMiddleware does for a missing/invalid token.
+    vi.mocked(authMiddleware).mockImplementation((c: any) => c.json({ error: 'Unauthorized' }, 401));
+
+    const res = await app().request(`/software-policies/${POLICY_ID}/install-preview`);
+
+    expect(res.status).toBe(401);
+    expect(computeMock).not.toHaveBeenCalled();
+  });
+
+  it('is gated by the same devices:read permission middleware as every sibling GET route', () => {
+    // requirePermission is globally stubbed to an unconditional passthrough in
+    // this file's mock block (see this file's top), matching every other
+    // route in softwarePolicies.ts — there is no per-route way to force it to
+    // reject with that mock shape (requireSoftwarePolicyRead is bound once at
+    // module-import time). requirePermission's own rejection behaviour has its
+    // own dedicated suite: middleware/auth.test.ts, describe('requirePermission').
+    // What IS verifiable here, and is the meaningful "wrong permission"
+    // regression guard for THIS route, is that it is wired with a permission
+    // gate in the same position as its established-good sibling GET /:id —
+    // i.e. it was not registered as a bare unguarded handler.
+    const routes = (softwarePoliciesRoutes as unknown as { routes: Array<{ method: string; path: string }> }).routes;
+    const previewEntries = routes.filter((r) => r.method === 'GET' && r.path === '/:id/install-preview');
+    const siblingEntries = routes.filter((r) => r.method === 'GET' && r.path === '/:id');
+    expect(previewEntries.length).toBeGreaterThan(1);
+    expect(previewEntries.length).toBe(siblingEntries.length);
+  });
+
+  it('returns 400 for a non-UUID policy id', async () => {
+    const res = await app().request('/software-policies/not-a-uuid/install-preview', {
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(400);
+    expect(computeMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 404, not a count, for a policy id that does not exist', async () => {
+    mockPolicyLookup(null);
+
+    const res = await app().request(`/software-policies/${POLICY_ID}/install-preview`, {
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'Policy not found' });
+    expect(computeMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 404, not a count, for a policy id belonging to another org — multi-tenant isolation', async () => {
+    // getPolicyWithAccess's WHERE always includes the caller's tenant access
+    // condition (softwarePolicyAccessCondition), so a real cross-org id is
+    // filtered out at the database layer and the query returns zero rows —
+    // indistinguishable at this mocked layer from a nonexistent id, which is
+    // deliberate: GET /:id already returns this identical 404 body for both
+    // cases rather than leaking which one occurred, and this route reuses
+    // getPolicyWithAccess unchanged.
+    mockPolicyLookup(null);
+
+    const res = await app().request(`/software-policies/${POLICY_ID}/install-preview`, {
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(404);
+    expect(computeMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 0 without calling the count service when the caller has a zero-site allowlist', async () => {
+    setAuth([]);
+    mockPolicyLookup(ALLOWLIST_POLICY);
+
+    const res = await app().request(`/software-policies/${POLICY_ID}/install-preview`, {
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ eligibleDeviceCount: 0 });
+    expect(computeMock).not.toHaveBeenCalled();
+  });
+
+  it('narrows to the caller site allowlist before counting', async () => {
+    setAuth(['site-1']);
+    mockPolicyLookup(ALLOWLIST_POLICY);
+    mockSiteResolution([
+      { id: 'dev-allowed', siteId: 'site-1' },
+      { id: 'dev-denied', siteId: 'site-2' },
+    ]);
+    computeMock.mockResolvedValue(1);
+
+    const res = await app().request(`/software-policies/${POLICY_ID}/install-preview`, {
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(computeMock).toHaveBeenCalledWith(
+      expect.objectContaining({ siteAllowedDeviceIds: ['dev-allowed'] }),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd apps/api && npx vitest run src/routes/softwarePolicies.installPreview.test.ts
+```
+
+Expected: FAIL — every test either 404s (route does not exist yet) or fails to import `computeInstallPreviewEligibleDeviceCount` from a module that does not exist, and the wiring test finds zero `previewEntries`.
+
+- [ ] **Step 3: Implement — add the import**
+
+Modify `apps/api/src/routes/softwarePolicies.ts:15-18`:
+
+```ts
+import {
+  normalizeSoftwarePolicyRules,
+  recordSoftwarePolicyAudit,
+} from '../services/softwarePolicyService';
+import { computeInstallPreviewEligibleDeviceCount } from '../services/softwarePolicyInstallPreview';
+```
+
+- [ ] **Step 4: Implement — add the route**
+
+Insert after `apps/api/src/routes/softwarePolicies.ts:515` (the closing `);` of `GET /:id`), before `PATCH /:id` at `:517`:
+
+```ts
+softwarePoliciesRoutes.get(
+  '/:id/install-preview',
+  requireSoftwarePolicyRead,
+  zValidator('param', policyIdParamSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const perms = c.get('permissions') as UserPermissions | undefined;
+    const { id } = c.req.valid('param');
+
+    const policy = await getPolicyWithAccess(id, auth);
+    if (!policy) {
+      return c.json({ error: 'Policy not found' }, 404);
+    }
+
+    // 'missing' violations — the only kind autoInstall ever acts on — are
+    // only ever emitted for allowlist policies (evaluateSoftwareInventory's
+    // blocklist/audit branches only ever emit 'unauthorized'). Short-circuit
+    // before resolving a single device.
+    if (policy.mode !== 'allowlist') {
+      return c.json({ eligibleDeviceCount: 0 });
+    }
+
+    // Site-ceiling gate (app-layer only, RLS does not enforce it) — mirrors
+    // GET /violations exactly, so a site-restricted caller previews the same
+    // device set they are actually allowed to act on.
+    let siteAllowedDeviceIds: string[] | null = null;
+    if (perms?.allowedSiteIds && auth.orgId) {
+      if (perms.allowedSiteIds.length === 0) {
+        return c.json({ eligibleDeviceCount: 0 });
+      }
+      siteAllowedDeviceIds = await resolveSiteAllowedDeviceIds(auth.orgId, perms);
+    }
+
+    const rules = normalizeSoftwarePolicyRules(policy.rules);
+    const eligibleDeviceCount = await computeInstallPreviewEligibleDeviceCount({
+      policyId: policy.id,
+      rules,
+      siteAllowedDeviceIds,
+    });
+
+    return c.json({ eligibleDeviceCount });
+  }
+);
+```
+
+- [ ] **Step 5: Run the tests and watch them pass**
+
+```bash
+cd apps/api && npx vitest run src/routes/softwarePolicies.installPreview.test.ts
+```
+
+Expected: PASS, 9 tests.
+
+- [ ] **Step 6: Run the full existing softwarePolicies test suite to confirm no regression**
+
+```bash
+cd apps/api && npx vitest run src/routes/softwarePolicies.test.ts src/routes/softwarePolicies.siteScope.test.ts src/routes/softwarePolicies.approvalGeneration.test.ts
+```
+
+Expected: PASS, all pre-existing tests unaffected (this task only adds an import and a new route; no existing handler is modified).
+
+- [ ] **Step 7: Typecheck and commit**
+
+```bash
+pnpm --filter @breeze/api exec tsc --noEmit
+git add apps/api/src/routes/softwarePolicies.ts apps/api/src/routes/softwarePolicies.installPreview.test.ts
+git commit -m "$(cat <<'EOF'
+feat(software): GET /:id/install-preview — the dry-run device count W04 already calls — #5505 W06
+
+Gives PolicyForm's "this will install missing software on ~N device(s)"
+warning (spec Risks §2) a real backend. Read-only: same auth gate and
+site-ceiling narrowing as its GET siblings (/:id, /violations), no MFA,
+arms nothing. Response contract {eligibleDeviceCount: number} matches
+W04's PolicyForm.tsx Task 2 exactly, which was written to degrade
+gracefully (any non-2xx becomes "unavailable") ahead of this endpoint
+existing.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01ANjBwca2cfsLWDLJro3fkz
+EOF
+)"
+```
+
+---
+
+### Task 3: Expose the three install-remediation status columns via `GET /violations`
+
+**Files:**
+- Modify: `apps/api/src/routes/softwarePolicies.ts:481-488`
+- Modify: `apps/api/src/routes/softwarePolicies.test.ts:18-38` (mock schema fixture), and its "GET /violations — site scope" describe block (new test + one existing test extended)
+
+**Interfaces:**
+- Consumes: `softwareComplianceStatus.installRemediationStatus`, `.lastInstallRemediationAttempt`, `.installRemediationAttempts` — **W02**, exact Drizzle field names confirmed against that wave's own plan doc (see Step 1).
+- Produces: `GET /software-policies/violations` response rows gain three fields under `compliance`: `installRemediationStatus`, `lastInstallRemediationAttempt`, `installRemediationAttempts`. Purely additive — no existing field removed or renamed, no new query parameter, no change to the route's authorization or WHERE-clause tenancy/site-ceiling logic.
+
+**Why this task's coverage is narrower than Task 1/2's.** This is a column-list widen on an EXISTING, already-authorized, already tenant-scoped route — it introduces no new auth surface, no new tenancy surface, and no new query parameter. The existing site-scope and org-scope tests on `GET /violations` (unmodified by this task) continue to prove isolation for the route as a whole; this task's new test proves specifically that the three new columns are now part of the projection, and the one extended test proves they survive the site-ceiling-narrowed path too — that is the actual new behavior, and vacuous duplicate 401/403 tests over an unchanged code path would not discriminate anything.
+
+- [ ] **Step 1: Verify W02 has landed and record the real names**
+
+```bash
+cd /Users/toddhebebrand/.herdr/worktrees/breeze/warranty-testing
+grep -n "installRemediationStatus\|lastInstallRemediationAttempt\|installRemediationAttempts" apps/api/src/db/schema/softwarePolicies.ts
+```
+
+Expected, per W02's plan (`docs/superpowers/plans/vuln-patch/2026-09-10-desired-state-software-install-w02-compliance-worker.md`, Task 2 Step 2):
+```ts
+installRemediationStatus: varchar('install_remediation_status', { length: 20 }).default('none'),
+lastInstallRemediationAttempt: timestamp('last_install_remediation_attempt'),
+installRemediationAttempts: integer('install_remediation_attempts').notNull().default(0),
+```
+If this grep shows nothing, **W02 has not landed — stop this task and report that rather than inventing column names.**
+
+- [ ] **Step 2: Write the failing tests**
+
+Modify `apps/api/src/routes/softwarePolicies.test.ts:18-38` — add the three markers to the existing mocked `db/schema` fixture (values are opaque test markers, matching the six that are already there):
+
+```ts
+vi.mock('../db/schema', () => ({
+  devices: {
+    id: 'devices.id',
+    orgId: 'devices.orgId',
+    siteId: 'devices.siteId',
+    hostname: 'devices.hostname',
+    status: 'devices.status',
+    osType: 'devices.osType',
+  },
+  softwareComplianceStatus: {
+    id: 'softwareComplianceStatus.id',
+    policyId: 'softwareComplianceStatus.policyId',
+    deviceId: 'softwareComplianceStatus.deviceId',
+    status: 'softwareComplianceStatus.status',
+    violations: 'softwareComplianceStatus.violations',
+    lastChecked: 'softwareComplianceStatus.lastChecked',
+    remediationStatus: 'softwareComplianceStatus.remediationStatus',
+    lastRemediationAttempt: 'softwareComplianceStatus.lastRemediationAttempt',
+    installRemediationStatus: 'softwareComplianceStatus.installRemediationStatus',
+    lastInstallRemediationAttempt: 'softwareComplianceStatus.lastInstallRemediationAttempt',
+    installRemediationAttempts: 'softwareComplianceStatus.installRemediationAttempts',
+  },
+  softwarePolicies: { id: 'id', orgId: 'orgId', partnerId: 'partnerId', mode: 'mode', name: 'name', isActive: 'isActive', updatedAt: 'updatedAt' },
+}));
+```
+
+Then, inside the existing `describe('GET /violations — site scope', ...)` block (`:634-767`), add one new test right after `'keeps unrestricted violation reads unchanged with no site predicate'` (which currently ends at `:766`, just before the closing `});` of the describe block at `:767`):
+
+```ts
+  it('projects the three install-remediation columns into the compliance selection (#5505 W06)', async () => {
+    // db.select is fully mocked (returns canned rows regardless of its
+    // column-projection argument), so asserting on the RETURNED rows would be
+    // vacuous — it would pass even without touching the route. This asserts
+    // on the ARGUMENT passed to db.select(...), which only contains these
+    // keys if the route code actually projects them.
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        innerJoin: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([]),
+            }),
+          }),
+        }),
+      }),
+    } as any);
+
+    const res = await app.request('/software-policies/violations', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(200);
+    const selectArg = vi.mocked(db.select).mock.calls[0]?.[0] as { compliance?: Record<string, unknown> };
+    expect(selectArg?.compliance).toHaveProperty('installRemediationStatus');
+    expect(selectArg?.compliance).toHaveProperty('lastInstallRemediationAttempt');
+    expect(selectArg?.compliance).toHaveProperty('installRemediationAttempts');
+  });
+```
+
+And extend the existing `'narrows violation list reads to allowed sites for a restricted caller'` test's mock row (`:729-734`) so the new columns are proven to survive the site-ceiling-narrowed path too — replace:
+
+```ts
+    mockViolationsSelect([
+      {
+        device: { id: DEVICE_ALLOWED, hostname: 'allowed-device' },
+        compliance: { id: 'compliance-1', status: 'violation' },
+      },
+    ], whereArgs);
+```
+
+with:
+
+```ts
+    mockViolationsSelect([
+      {
+        device: { id: DEVICE_ALLOWED, hostname: 'allowed-device' },
+        compliance: {
+          id: 'compliance-1',
+          status: 'violation',
+          installRemediationStatus: 'gave_up',
+          installRemediationAttempts: 3,
+        },
+      },
+    ], whereArgs);
+```
+
+and add, after the existing `expect(whereArgs).toHaveLength(1);` assertions in that same test:
+
+```ts
+    expect((await res.json()).data[0].compliance).toMatchObject({
+      installRemediationStatus: 'gave_up',
+      installRemediationAttempts: 3,
+    });
+```
+
+(Note: `res.json()` is called once already in that test to read `.total` — reuse the same `await res.json()` result in a local variable rather than calling it twice, since `Response.json()` can only be consumed once. Rewrite the test to capture `const body = await res.json();` once, then assert `body.total` and `body.data[0].compliance` from that same `body`.)
+
+- [ ] **Step 3: Run it and watch it fail**
+
+```bash
+cd apps/api && npx vitest run src/routes/softwarePolicies.test.ts
+```
+
+Expected: FAIL — the new "projects the three install-remediation columns" test fails because `selectArg.compliance` has no `installRemediationStatus` key yet; the extended site-scope test fails because the response's `compliance` object has no `installRemediationStatus`/`installRemediationAttempts` fields yet.
+
+- [ ] **Step 4: Implement**
+
+Modify `apps/api/src/routes/softwarePolicies.ts:481-488`:
+
+```ts
+        compliance: {
+          id: softwareComplianceStatus.id,
+          policyId: softwareComplianceStatus.policyId,
+          status: softwareComplianceStatus.status,
+          violations: softwareComplianceStatus.violations,
+          lastChecked: softwareComplianceStatus.lastChecked,
+          remediationStatus: softwareComplianceStatus.remediationStatus,
+          installRemediationStatus: softwareComplianceStatus.installRemediationStatus,
+          lastInstallRemediationAttempt: softwareComplianceStatus.lastInstallRemediationAttempt,
+          installRemediationAttempts: softwareComplianceStatus.installRemediationAttempts,
+        },
+```
+
+- [ ] **Step 5: Run the tests and watch them pass**
+
+```bash
+cd apps/api && npx vitest run src/routes/softwarePolicies.test.ts
+```
+
+Expected: PASS, all tests in the file (existing + the two touched by this task).
+
+- [ ] **Step 6: Typecheck and commit**
+
+```bash
+pnpm --filter @breeze/api exec tsc --noEmit
+git add apps/api/src/routes/softwarePolicies.ts apps/api/src/routes/softwarePolicies.test.ts
+git commit -m "$(cat <<'EOF'
+feat(software): project install-remediation status through GET /violations — #5505 W06
+
+W02 adds install_remediation_status / last_install_remediation_attempt /
+install_remediation_attempts to software_compliance_status; no wave in
+the cross-wave contract currently exposes them over HTTP (W04 is scoped
+web-UI-only and cannot touch apps/api). Purely additive to the existing
+compliance projection — no new auth/tenancy surface, no query param
+change. A UI consumer (install-status column, give-up count) is a
+follow-up for whichever wave next touches ComplianceDashboard.tsx.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01ANjBwca2cfsLWDLJro3fkz
+EOF
+)"
+```
+
+---
+
+## Self-review
+
+**1. Spec coverage.** Spec Risks §2 ("the UI should show a dry-run count... before arming") — Task 1+2 deliver exactly the endpoint W04's `PolicyForm.tsx` already calls defensively. The coordinator's added scope (W02's three columns have no HTTP consumer) — Task 3. No other spec section is in this wave's brief (dispatch/arming/authorization/AI guardrails belong to W01/W02/W03/W05, explicitly out of scope per Global Constraints).
+
+**2. Placeholder scan.** Every code step above is complete, runnable TypeScript/SQL/bash — no `TODO`, no "add appropriate tests", no elided function bodies. The two verify-or-stop steps (Task 1 Step 1, Task 3 Step 1) are deliberate dependency gates, not placeholders — they tell the executor exactly what to grep for and what to do if the dependency hasn't landed, matching W03's own plan's precedent for the same W01/W02 dependency problem.
+
+**3. Type consistency.** `computeInstallPreviewEligibleDeviceCount`'s signature is identical between its Task 1 "Produces" interface block, its Task 1 implementation, and its Task 2 call site (`{ policyId: string; rules: SoftwarePolicyRulesDefinition; siteAllowedDeviceIds?: string[] | null }): Promise<number>`). `resolvePolicyInstallTarget`'s input/output shape is quoted identically in Global Constraints, Ground Truth, and Task 1's implementation — copied from W03's own plan, not re-derived. The three W02 column names (`installRemediationStatus` / `lastInstallRemediationAttempt` / `installRemediationAttempts`) are identical across Global Constraints, Ground Truth, Task 3's Step 1 expected output, and Task 3's implementation — copied verbatim from W02's plan doc, not guessed.
+
+**4. Open items for the coordinator, explicitly flagged rather than silently resolved:**
+- **Nothing needed to be added to W03's exports.** `resolvePolicyInstallTarget` was already public in W03's own Task 4 — this wave only had to import and call it, never modify `softwarePolicyInstallRemediation.ts`.
+- **`services/aiToolsCompliance.ts:130`** is a second sibling projection of `softwareComplianceStatus.remediationStatus`, found during the repo-wide sweep the coordinator asked for. It is deliberately **not** touched — it is `aiTools*.ts` territory, which every other wave in this contract also avoids, and widening it would mean deciding whether/how the AI agent should see give-up counts, which is a product decision this wave was not asked to make.
+- **W04 has no current line referencing the three W02 columns** (verified: zero hits for `installRemediationStatus`/`gave_up`/`installRemediationAttempts` in that plan doc as written). Task 3 makes the data reachable; nothing in this wave's brief covers wiring it into `ComplianceDashboard.tsx` or any other view — that remains open for whoever picks it up next.
+- **Cost-bound trade-off, stated plainly:** this wave's design scales with **tenant/OS variety** (distinct `orgId` × `osType` combinations among a policy's resolved devices), not with device count. For the overwhelmingly common case (an org-scoped policy, one org, up to three OS types) this is at most a handful of `resolvePolicyInstallTarget` calls regardless of whether the policy resolves 10 or 10,000 devices. For a partner-wide policy spanning many child orgs, the group count scales with the partner's org roster — still bounded by the MSP's client count, not by device count, but not zero-cost either. This wave does not add an artificial cap on group count, because any cap would have to either silently undercount (repeating the exact bug this wave exists to fix) or add a `truncated` field the locked `{ eligibleDeviceCount: number }` response contract does not have room for. This is a deliberate, documented trade-off, not an oversight.

--- a/docs/superpowers/specs/device-lifecycle/2026-09-10-hp-warranty-cmsl-design.md
+++ b/docs/superpowers/specs/device-lifecycle/2026-09-10-hp-warranty-cmsl-design.md
@@ -1,0 +1,337 @@
+# HP warranty via HP CMSL (agent-collected)
+
+Status: design drafted 2026-09-10, awaiting review. Not implemented.
+Tracking: TBD — register via feature-lifecycle once approved.
+Depends on: `vuln-patch/2026-09-10-desired-state-software-install-design.md`
+(the `autoInstall` remediation half of software policies). Only wave 4 below
+needs it; waves 1-3 and 5 are independent and can run in parallel with that work.
+
+## Problem
+
+HP devices sit at `status = 'unknown'` forever. Dell and Lenovo have working
+server-side providers; HP does not, and cannot. `hpProvider.ts` is written,
+unit-tested, and deliberately unregistered — the comment at
+`apps/api/src/services/warrantyProviders/index.ts:7-11` records why: the
+unofficial `support.hp.com` endpoint now returns the site's HTML shell (verified
+2026-09-09) and HP's real backend is captcha-gated. HP's official Warranty API is
+explicitly closed to IT service companies and third-party ISVs, so no amount of
+credential work opens it.
+
+That comment also names the intended fix: *"HP coverage is coming from the agent
+instead. The module is kept (and unit-tested) until that lands."* This spec is
+that.
+
+## Approach
+
+Collect on the device with HP's own Client Management Script Library (CMSL).
+HP blesses this path; it needs no MSP API key because the device authenticates
+as itself.
+
+External facts, researched 2026-09-10, **all of which wave 1 must confirm on real
+hardware before anything is built on them**:
+
+- `Get-HPWarrantyInfo` takes no parameters and runs on the local HP device.
+- It writes results to WMI classes `HP_Warranty` and `HP_Entitlements` in
+  namespace `root/HP/InstrumentedServices/v1`.
+- It self-caches for 30 days: a call inside that window returns the stored WMI
+  data without a network round trip.
+- HP rate-limits it to 300 requests / 5 minutes **per source IP** — which is a
+  per-customer-NAT limit, not a per-device one.
+- winget package id is `HP.HPCMSL` (1.8.6, 2026-04-01). Also installable via HP's
+  InnoSetup `.exe /VERYSILENT` or `Install-Module HPCMSL -AcceptLicense -Scope AllUsers`.
+- CMSL requires PowerShell 5.1+, the NuGet provider, and TLS 1.2 for the gallery
+  path; it lands in `Program Files\WindowsPowerShell\Modules`.
+
+### The EULA constrains the install channel
+
+HP's CMSL licence states verbatim: *"You do not have the right to distribute the
+Software Product."* This is a reading of the licence text, not legal advice, and
+it should get a short legal skim before wave 3. Two consequences shape the design:
+
+- **Breeze must never mirror or host the CMSL installer.** This rules out the
+  `winget_bootstrap` pattern, where we serve pinned artifacts from
+  `apps/api/src/routes/agents/wingetBootstrap.ts`. Installing via winget or HP's
+  own URL satisfies this; both pull from HP.
+- **Auto-accepting the licence is accepting it on the customer's behalf.** That
+  is why this feature is opt-in with a recorded consent, not a default-on toggle.
+
+The licence also permits HP to collect technical information including IP
+address. An MSP is entitled to know that before HP software lands on their
+customers' endpoints; say it plainly in the consent copy.
+
+## Scope
+
+HP Inc client hardware running Windows. Not HPE servers, not HP hardware running
+Linux. Devices outside that set are untouched and keep whatever status they have.
+
+## Design
+
+### Layer 1 — Opt-in on the existing warranty config-policy feature
+
+The `warranty` feature type is pure JSONB inline settings on the feature link
+(`apps/api/src/services/configurationPolicy.ts:1062` — "Pure JSONB — no
+normalized table needed"), currently `{ enabled, warnDays, criticalDays }`
+(`apps/web/src/components/configurationPolicies/featureTabs/WarrantyTab.tsx:9-13`).
+No new table, no new tenancy shape, no cascade or export registration.
+
+Add an `hpCmsl` block. Three things it must get right:
+
+- **`enabled` on the existing block means expiry alerting, not collection.** The
+  new block needs its own default-`false` enablement. Do not overload the
+  existing flag.
+- **Consent is server-stamped.** Generic inline-settings validation accepts
+  arbitrary records (`packages/shared/src/validators/index.ts:595`), so a client
+  could today persist fabricated consent attribution. Add warranty-specific
+  validation and write the actor id, server timestamp and an explicit EULA
+  identifier server-side from the authenticated session — never from the payload.
+- **Authorization must match the deployment gate.** Feature-link writes require
+  only `devices.write` and `warranty` is absent from `MFA_GATED_FEATURE_TYPES`,
+  which is `{patch, maintenance}` (`apps/api/src/routes/configurationPolicies/featureLinks.ts:86`).
+  Creating a deployment requires `devices.execute` **plus** MFA
+  (`apps/api/src/routes/software.ts:1754`). Because enabling `hpCmsl` causes
+  software installation, it must carry the stronger gate — otherwise it is a
+  privilege-escalation path around the deployment gate. Add `warranty` to the
+  MFA-gated set, or gate the `hpCmsl` sub-block specifically, and cover the
+  assignment/inheritance transitions too, not just the checkbox.
+
+**Inheritance footgun:** policy resolution selects a whole feature link, not a
+deep merge. A nearer policy carrying only alert thresholds will replace an
+inherited link and silently drop its `hpCmsl` block. The UI must make that
+visible when authoring a child policy, and the plan should state the intended
+semantics explicitly rather than leaving it to resolution order.
+
+### Layer 2 — Delivery to the agent
+
+Mirror `exclusiveWindowsUpdate` (#1872) exactly; it is the closest working
+precedent and its revocation semantics are already correct.
+
+| Location | Change |
+|---|---|
+| `apps/api/src/routes/agents/helpers.ts` | Add `buildWarrantyConfigUpdate(deviceId)` alongside `buildPatchSourceConfigUpdate` (`helpers.ts:2861`). Share effective-warranty resolution with the alert evaluator, whose private resolver currently returns only the three alert fields (`warrantyAlertEvaluator.ts:178`). |
+| `apps/api/src/routes/agents/heartbeat.ts` | Extend `PolicyConfigUpdates` + defaults, invoke the builder in the existing post-org-transaction policy block (`heartbeat.ts:1905-1997`), merge `warranty_settings` into `policyConfigUpdate`. |
+| `agent/internal/heartbeat/heartbeat.go` | `ConfigUpdate` is already a generic map; add warranty dispatch in `applyConfigUpdate` (`heartbeat.go:2699`), accepting both snake_case and camelCase as every other key does. |
+| New `agent/internal/heartbeat/warranty_config.go` | Follow the replaceable-seam pattern of `patch_source.go`, whose header explains why: a key-name regression would otherwise silently disable the whole feature with no test able to catch it on a non-Windows CI runner. |
+
+Copy `buildPatchSourceConfigUpdate`'s revocation contract verbatim
+(`helpers.ts:2855-2860`): a **successfully resolved absent policy** returns
+`false` and the agent stops HP activity; a **resolver error** omits the block
+entirely so a transient failure never triggers an unintended revert. These are
+different states and conflating them is how a fleet silently turns a feature off.
+
+### Layer 3 — Getting CMSL onto the device
+
+A built-in catalog package, installed and kept present by a partner-wide
+allowlist software policy with `autoInstall` armed.
+
+**Built-in package.** `apps/api/src/services/builtinDeploymentPackages.ts`
+already provides the seam: a `BUILTIN_PACKAGES` registry and an idempotent
+`ensureBuiltinPackage({ provider, partnerId })` running in system DB context.
+Adding `hp_cmsl` touches more than the union:
+
+| Boundary | Change |
+|---|---|
+| DB CHECK | `software_catalog_integration_provider_chk` permits only NULL/`huntress`/`sentinelone` (`apps/api/migrations/2026-07-02-builtin-catalog-partner-read-rls.sql:23`). Forward migration required — never edit the shipped one. |
+| `BuiltinPackageDef` | The union is discriminated on `requiresBinaryUpload` into "derivable URL" (Huntress) and "partner uploads binary" (SentinelOne). A winget package is a **third arm** — no URL, no upload, just a package id. Extend the union; do not force HP into an existing arm. |
+| `ensureBuiltinPackage` | Creates catalog and version rows, not install methods (`builtinDeploymentPackages.ts:99`). HP needs an install-method row instead of a version row. |
+| Install-method API | `POST` rejects every non-null integration provider — *"Built-in packages cannot carry install methods"* (`apps/api/src/routes/softwareInstallMethods.ts:112`). The system provisioner must insert directly, or that rule needs a documented exception. Decide which in the plan. |
+| Install-method validation | Already accepts the shape we need: `{ platform: 'windows', kind: 'winget', packageId: 'HP.HPCMSL' }`. Note the field is `kind`, not `manager` (`softwareInstallMethods.ts:39`). |
+| Web UI | `useEdrReadiness` seeds state with only `{huntress, sentinelone}` (`useEdrReadiness.ts:132`) while `SoftwareCatalog.tsx:640` dereferences `readinessMap[provider].status` for **any** provider passing `isIntegrationProvider`. Adding `hp_cmsl` to that union without touching readiness **crashes the catalog page**. HP has no credential readiness concept and must be separated from EDR readiness, not folded into it. Branding also needs an entry (`providerBranding.ts:5`). |
+
+Keep HP out of the EDR secret-resolution branch at
+`softwareDeployment.ts:554-558` — that path injects Huntress/SentinelOne account
+and site tokens and has nothing to do with HP.
+
+**Keeping it present.** A built-in partner-wide `software_policies` row in
+`allowlist` mode with one rule whose `catalogId` points at the HP CMSL catalog
+item, `enforceMode` on and `autoInstall` armed. The compliance worker re-resolves
+targets every 15 minutes, so devices that enrol later — or whose HP identity
+arrives later, once hardware inventory reports a manufacturer — are picked up
+without any re-dispatch machinery.
+
+Targeting is expressible with existing filters: `osType` and
+`hardware.manufacturer` are both supported by the filter engine
+(`apps/api/src/services/filterEngine.ts:89`). Note `targetType: 'sites'` is
+explicitly unimplemented (`apps/api/src/routes/software.ts:287`) — use filters or
+resolved device IDs.
+
+Because deployments are org-owned, a partner-wide policy produces one deployment
+run per organisation. That is inherent to the schema, not a defect to work around.
+
+### Layer 4 — Keeping CMSL current
+
+**This layer is unproven and wave 1 must prove or kill it.**
+
+The claim is that once CMSL is installed via winget, the agent's SYSTEM patch
+scan sees it and updates flow through the normal third-party ring approval. The
+generic half is real: heartbeat retains the package id and maps winget to
+`third_party` (`agent/internal/heartbeat/heartbeat.go:3270,3429`), ingest creates
+the shared patch row and upserts `device_patches`
+(`apps/api/src/routes/agents/patches.ts:222,289`), and the approval evaluator
+loads `patch_policies` rings (`apps/api/src/jobs/patchJobExecutor.ts:1130`).
+No HP-specific registration is needed anywhere in that chain.
+
+The unproven half is the first link. The SYSTEM scan runs
+`winget upgrade --include-unknown --scope machine --source winget` and parses
+that output (`agent/internal/patching/winget_system.go:73,97`). It enumerates
+winget-tracked packages, **not** PowerShell modules. So this works only if winget
+classifies HP's InnoSetup-based installer as a machine-scope package *and*
+reports an available upgrade. `Install-Module -Scope AllUsers` establishes
+neither condition, and the user-scope fallback does not rescue it — user-only
+remediation is explicitly refused (`winget_system.go:186`).
+
+Ring approval is also not automatic: third-party auto-approval requires the ring
+to have auto-approval enabled, `sources` containing `third_party`,
+`thirdPartyApps: true`, and the deferral elapsed
+(`apps/api/src/services/patchApprovalEvaluator.ts:616`). CMSL being installed by
+the warranty policy does not approve its updates.
+
+**Wave 1 gate: perform a real old→new CMSL upgrade on an HP device through the
+SYSTEM agent and a Breeze ring.** If winget does not surface it, treat CMSL as a
+separate channel with its own update strategy — the agent enforcing a floor
+version directly — and re-open that decision with Todd, since it bypasses the
+customer's approval rings and that was explicitly not the chosen option.
+
+### Layer 5 — Collection on the device
+
+New files, independent of the Apple collector's build tags:
+`agent/internal/collectors/hp_warranty_windows.go` (`//go:build windows`) and
+`hp_warranty_other.go` (`//go:build !windows`). Do **not** retag
+`warranty_other.go`, which is Apple's `!darwin` stub and already compiles on
+Windows.
+
+Tiered, cheapest first:
+
+- **T0 — read WMI.** Query `HP_Warranty` / `HP_Entitlements` from
+  `root/HP/InstrumentedServices/v1` directly. The agent already vendors
+  `go-ole` v1.2.6 and `yusufpapurcu/wmi` v1.2.4, so this needs no PowerShell, no
+  network and no install. **Wave 1 must determine whether that namespace exists
+  without CMSL** — if HP's factory image populates it, some of the fleet yields
+  warranty data at zero cost and zero EULA exposure, which would materially
+  change how much of layer 3 is worth building.
+- **T1 — refresh.** Run `Get-HPWarrantyInfo` only when the WMI data is missing or
+  its own cache is genuinely stale, then re-read WMI.
+- **T2 — absent.** CMSL not installed: report nothing and let the policy install it.
+
+**Scheduling — two corrections that matter.** HP's cache is 30 days, so invoking
+at day 25 returns cached data and refreshes nothing; the trigger must key off the
+*actual HP cache timestamp* read from WMI, not an arbitrary interval. And the
+Apple collector runs inside the 15-minute `sendInventory` fan-out
+(`heartbeat.go:1977`); copying that lifecycle without persistent due/attempt
+state would relaunch PowerShell every 15 minutes for days. The HP collector needs
+its own persisted due time and bounded retries, with distinct
+first-run/bootstrap behaviour.
+
+Spreading uses deterministic per-device jitter — hash the device id into an
+offset across the refresh window — so a site's HP fleet never bunches. Be honest
+that this is statistical, not a guarantee: a fleet coming back from an outage can
+re-bunch. The collector must also back off on an HP 429 rather than retry into
+the limit.
+
+### Layer 6 — Reporting and ingest
+
+Reuse the Apple transport unchanged:
+`sendInventoryData("warranty-info", payload)` → `PUT /agents/:id/warranty-info`.
+
+`agentWarrantyInfoSchema` (`apps/api/src/routes/agents/schemas.ts:645`) already
+accepts `source: 'agent_cmsl'` and `manufacturer: 'HP'` — both are free-form
+bounded strings. But it has **no entitlements field**, so an entitlements array
+is silently stripped by the object schema. Add validated, bounded entitlements to
+the schema, the handler's explicit field selection (`inventory.ts:324`) and the
+service interface, preserving HP's own dates.
+
+**Two defects to fix in the same wave, both verified:**
+
+1. `upsertAgentWarranty` hardcodes `provider: 'apple' as const` when synthesising
+   an entitlement from `coverageType` (`warrantySync.ts:364`). Sending HP through
+   it unchanged mislabels every HP entitlement as Apple. The entitlement type
+   already includes `'hp'` (`warrantyProviders/types.ts:2`), so this is a code
+   fix with no migration.
+2. `syncWarrantyForSubject` preserves agent-written rows only when
+   `dataSource === 'agent_plist'` (`warrantySync.ts:145`). An `agent_cmsl` row
+   falls through to the unknown-result upsert, which **overwrites the agent's
+   dates and entitlements and flips `data_source` back to `'provider'`**. The
+   sweep selector has no manufacturer or provider exclusion
+   (`warrantySync.ts:454`), so HP devices are selected. Frequent agent reports
+   would keep pushing `nextSyncAt` out and mask this until reporting stopped —
+   a latent data-loss bug, not a cosmetic one.
+
+Fix by excluding HP from provider lookup in both candidate selection and direct
+sync, and by generalising the preservation branch to any agent-owned source
+rather than adding a second hardcoded string. Also stop the Apple branch's habit
+of stamping `lastSyncAt` when nothing was fetched: HP needs its real fetch
+timestamp distinguished from WMI observation time and report receipt time.
+
+Manual refresh (`POST /devices/:id/warranty/refresh`, `devices/warranty.ts:63`)
+currently queues a server-side sync. For an HP device that is meaningless — it
+must either request agent collection or honestly report that refresh is not
+available, never silently no-op.
+
+`upsertAgentWarranty` already carries the correct
+`targetWhere: sql\`${deviceWarranty.deviceId} IS NOT NULL\`` for the partial
+unique index (`warrantySync.ts:395`). Dropping it during refactoring reintroduces
+a 42P10 at runtime. There is an existing real-DB insert-then-update regression
+test to extend (`deviceWarrantyManualSubject.integration.test.ts:225`).
+
+No `device_warranty` migration is needed: `entitlements` is jsonb and
+`data_source` is varchar.
+
+### Layer 7 — UI and cleanup
+
+- `DeviceWarrantyCard.tsx:59-66` gains an `agent_cmsl` → "Agent (HP CMSL)" label.
+- `WarrantyTab.tsx` gains the `hpCmsl` block, the consent checkbox naming HP and
+  its data collection, and the recorded acceptor/timestamp read-only.
+- Delete `hpProvider.ts`, its references in
+  `warrantyProviderThrottle.test.ts:19`, the `hpRateLimiter` if unused elsewhere,
+  and the dead `HP_WARRANTY_ENABLED` flag — which appears in exactly one place in
+  the repo (`hpProvider.ts:13`) and in no env example. Do this **when the new path
+  lands**, not before; the module's own comment says it is kept until then.
+- `apps/docs/src/content/docs/features/warranty-tracking.mdx:14` currently states
+  "HP has no lookup yet, so HP devices stay `unknown`." Update it.
+
+## Risks
+
+- **Layer 4 is unproven** and is the stated reason for the wave 1 gate.
+- **Coverage is unknowable in advance.** How many HP devices already have the
+  WMI namespace populated is a wave 1 measurement, not an estimate.
+- **The MSP may refuse.** CMSL is a ~100 MB HP module with HP telemetry rights on
+  every HP endpoint. Some partners will decline, and that is a legitimate
+  outcome, not a failure — the feature must degrade to "HP stays unknown"
+  cleanly rather than half-installing.
+- **PowerShell 5.1 and TLS 1.2 prerequisites** are not universal on older
+  Windows builds. The collector must report *why* it could not collect rather
+  than failing silently.
+
+## Testing
+
+- Go unit: T0 WMI parse from fixture rows; tier selection; due-time computation
+  from an HP cache timestamp; jitter determinism and distribution; back-off on 429.
+- Go unit: config dispatch through the `warranty_config.go` seam on a non-Windows
+  runner, asserting both snake_case and camelCase keys — the regression
+  `patch_source.go` exists to prevent.
+- API unit: entitlements schema bounds; HP entitlement provider is `'hp'`, not
+  `'apple'`.
+- API integration (real DB): an `agent_cmsl` row survives a full sweep pass
+  unchanged — this is the direct regression for defect 2 above, and it must be
+  written red against current code first.
+- API integration: consent fields are server-stamped and a forged payload cannot
+  set them.
+- Authorization: a `devices.write` user without MFA cannot enable `hpCmsl`.
+- Web: catalog page renders with an `hp_cmsl` item present (the readiness-map
+  crash regression).
+- Lab, on real HP hardware: namespace presence without CMSL; a full
+  install→collect→report cycle; an old→new CMSL upgrade through a Breeze ring.
+
+## Wave sketch
+
+1. **Lab probe + ingest hardening.** Answer the three hardware questions; fix the
+   two `warrantySync` defects with red-first regression tests; add entitlements to
+   the schema. Delivers value even if every later wave is cancelled.
+2. **Opt-in surface.** `hpCmsl` block, server-stamped consent, MFA/execute gate,
+   heartbeat delivery, agent config seam. No collection yet.
+3. **Collector.** T0/T1/T2, scheduling off the HP cache timestamp, jitter,
+   back-off, reporting. *(Independent of the desired-state work.)*
+4. **Built-in package.** Third union arm, migration, provisioner, UI readiness
+   separation and branding. *(Requires the desired-state feature for the policy
+   that keeps it installed.)*
+5. **Cleanup + docs.** Delete `hpProvider.ts` and the dead flag, update the docs
+   page, UI labels.

--- a/docs/superpowers/specs/device-lifecycle/2026-09-10-hp-warranty-cmsl-design.md
+++ b/docs/superpowers/specs/device-lifecycle/2026-09-10-hp-warranty-cmsl-design.md
@@ -335,3 +335,149 @@ No `device_warranty` migration is needed: `entitlements` is jsonb and
    that keeps it installed.)*
 5. **Cleanup + docs.** Delete `hpProvider.ts` and the dead flag, update the docs
    page, UI labels.
+
+## Corrections after ground-truth verification (2026-09-10)
+
+Every file this spec cites was re-opened after approval. The design holds, with
+one substantive correction (T0's transport) and a set of citation fixes. Wave
+plans carry the corrected citations — prefer this section where they disagree.
+
+### Substantive: the agent has no WMI binding, so T0 uses PowerShell
+
+Layer 5 claims "the agent already vendors `go-ole` v1.2.6 and
+`yusufpapurcu/wmi` v1.2.4, so this needs no PowerShell". That is wrong:
+
+- `yusufpapurcu/wmi` is an **indirect** dependency (`agent/go.mod:112`), pulled
+  in by gopsutil. Zero agent files import it — `wmi.Query` / `wmi.QueryNamespace`
+  appear nowhere outside `go.mod`/`go.sum`.
+- `go-ole` is direct (`agent/go.mod:18`) but drives only the Windows Update
+  Agent COM API (`agent/internal/patching/windows.go:11-12,240`) and VSS
+  (`agent/internal/backup/vss/vss_windows.go:16,358,767`). Neither does WMI.
+- **Every WMI read in the agent today goes through PowerShell
+  `Get-CimInstance`.** The canonical precedent batches four classes into one
+  spawn: `agent/internal/collectors/hardware_windows.go:82-121`, with its
+  `Get-WmiSafe` fallback helper (`:89-98`), `wmicTimeout = 15s` (`:14`), and
+  invocation via `runCollectorOutput(...)` + `utf8PowerShellCommand(...)`
+  (`agent/internal/collectors/command_limits.go:30,34,41`). Eight more
+  `Get-CimInstance` call sites exist across collectors, security and backup.
+
+Decision: **T0 reads `root/HP/InstrumentedServices/v1` with
+`Get-CimInstance -Namespace`, through `runCollectorOutput` +
+`utf8PowerShellCommand`, matching `hardware_windows.go`.** Promoting
+`yusufpapurcu/wmi` to a direct dependency to avoid the spawn is rejected: it
+would be the agent's only Go-side WMI call, with its own COM-threading
+behaviour and no existing test seam, to save a few hundred milliseconds on a
+collection that runs at most daily. The tiering is unaffected — T0 is still the
+cheap local read (no network, no CMSL invocation, no 30-day cache write); only
+its transport changes.
+
+### Citation corrections
+
+- Apple warranty: collector entry `CollectAppleWarranty()` in
+  `agent/internal/collectors/warranty_darwin.go:45` (stub
+  `warranty_other.go:20`); sender `sendAppleWarrantyInfo` at
+  `agent/internal/heartbeat/heartbeat.go:2405-2435`, registered in the 15-minute
+  `sendInventory` fan-out at `:2129`. `sendInventoryData` is at `:2154-2185`
+  and takes the endpoint as its FIRST argument plus a label as its third.
+- **`applyConfigUpdate` is at `heartbeat.go:2851`, and a new key MUST be
+  dispatched above line 2918.** Everything from `:2918` is the policy-probe
+  path, which hits an unconditional `return` at `:2928-2930` when no probes are
+  present — a warranty key added below that line is silently unreachable on
+  most heartbeats. Every existing key checks snake_case first, then camelCase
+  (`:2857`, `:2867`, `:2879`, `:2889`, `:2901`, `:2910`).
+- `patch_source.go` has no file header comment; the doc comments sit on the two
+  symbols, and **neither is exported**: `var applyWinUpdate = winupdate.Apply`
+  (`:12`, a package-level var — the swap point tests override) and
+  `func (h *Heartbeat) applyPatchSourceConfig(raw any)` (`:18`). The dual-key
+  parse is `:26-29`; note it checks **camelCase first**, the reverse of
+  `applyConfigUpdate`'s outer keys.
+- `buildPatchSourceConfigUpdate` is `helpers.ts:2860-2863`, its revocation
+  contract comment `:2852-2859`, its settings type `:2841-2850`.
+- `PolicyConfigUpdates` is `heartbeat.ts:1921-1926` and is **function-local, not
+  exported**; the four builders share one `withSystemDbAccessContext` at `:1934`
+  with per-builder try/catch (`:1944-1982`); the camelCase→snake_case wire
+  assembly is `:1993-2004`. `pamSettings` is resolved but deliberately not
+  merged there.
+- `MFA_GATED_FEATURE_TYPES` is `featureLinks.ts:91`, not `:86`. Its in-handler
+  MFA checks are at `:145-147` (create), `:340-341` (update), `:525-526`
+  (delete) — so a feature-type-conditional, in-handler gate is the established
+  pattern here, not a new one. All four link routes require only
+  `requireConfigPolicyWrite` = `devices.write` (`:47-48`).
+- The warranty alert resolver is `resolveWarrantySettings` at
+  `warrantyAlertEvaluator.ts:58-186` (not exported); its level-priority sort is
+  `:158-172` and it returns `DISABLED_SETTINGS` when no policy resolves (`:156`),
+  so alerting is opt-in.
+- `configFeatureInlineSettingsSchema` is
+  `packages/shared/src/validators/index.ts:595-604`; its only rule is a
+  reserved-key scan. `warranty` is absent from
+  `assertDecomposableInlineSettings`, so warranty inline settings receive **no**
+  server-side shape validation today.
+- `useEdrReadiness` lives at `apps/web/src/components/software/useEdrReadiness.ts`
+  (not `src/hooks/`); the hardcoded two-key seed is `:132-135`. The unguarded
+  dereference is `SoftwareCatalog.tsx:637-640` and again at `:828`.
+  `providerBranding.ts:5` is `INTEGRATION_PROVIDERS` (the single source the
+  union and type guard both derive from); the `BRANDING` map is `:18` and is not
+  exported — `getProviderBranding` (`:35`) is the accessor.
+- `software_catalog_integration_provider_chk` is
+  `apps/api/migrations/2026-07-02-builtin-catalog-partner-read-rls.sql:13-25`.
+  `installMethodBodySchema` is `softwareInstallMethods.ts:39-53` (fields
+  `platform`, `kind`, `packageId`, `enabled`; no `linux` platform); the built-in
+  rejection is `:112-114`.
+- winget SYSTEM scan args are `winget_system.go:73-76`; the **parse lives in a
+  different file**, `agent/internal/patching/winget_parse.go:66-115`, and is a
+  fixed-width parse of the English headers `Name`/`Id`/`Version`/`Available` —
+  localized output yields `errWingetNoTable` → `ErrScanSkipped`. The user-scope
+  refusal is `winget_system.go:186-194`, called from `Install` (`:208`) and
+  `Uninstall` (`:227`). Package id retention is `heartbeat.go:3437`; the
+  winget→`third_party` mapping is `:3581-3582`; note `default: "custom"`
+  (`:3586`), and `custom` does NOT qualify for ring third-party auto-approval.
+  The dual-consent condition is `patchApprovalEvaluator.ts:616-629`.
+- `device_warranty` is `apps/api/src/db/schema/warranty.ts:29-69`. Confirmed:
+  `entitlements` is jsonb NOT NULL default `[]` (`:49`); `data_source` is
+  `varchar(50)` nullable default `'provider'` (`:50`) with **no CHECK or enum**;
+  there are TWO partial unique indexes (`:60-65`), so every upsert needs its
+  `targetWhere`.
+- `agentWarrantyInfoSchema` is `schemas.ts:658-675`; the handler is
+  `inventory.ts:306-343` with explicit field selection at `:331-339`. Note the
+  serial number is taken from `device_hardware` (`:334`), never from the agent
+  payload, and `deviceName` is accepted then discarded.
+- `AgentWarrantyData` is `warrantySync.ts:315-331` — a **single coverage
+  window**, with no entitlements, service-level or product-number field. An HP
+  payload with N entitlements cannot be expressed without widening it.
+- The two verified defects are confirmed at `warrantySync.ts:153` (the
+  preservation branch is string-keyed to `'agent_plist'`) and `:367`
+  (`provider: 'apple' as const`). `upsertAgentWarranty` is `:341-423`; the sweep
+  selector is `:454-484`; the `targetWhere` guard is `:399`.
+- Manual refresh is `devices/warranty.ts:42-67`. It already requires
+  `devices.write` + `requireMfa()` and always passes `force: true`; it enqueues
+  a BullMQ job and never reaches the agent.
+- `DeviceWarrantyCard.tsx:60-67` is the label map; unknown sources render as the
+  raw string, so `agent_cmsl` would display literally until extended.
+- `filterEngine.ts` confirms `osType` (`:88`) and `hardware.manufacturer`
+  (`:94`). There is no warranty-related filter field at all.
+
+### Two additional defects found while verifying (both in scope)
+
+1. **CSV import can stomp agent-owned warranty rows.**
+   `apps/api/src/services/customFields/import/warrantyTarget.ts` guards only
+   against `'provider'` rows (`:181`, `:238` —
+   `data_source IS DISTINCT FROM 'provider'`), so an import overwrites an
+   `agent_plist` row today and would overwrite `agent_cmsl` too. The
+   `isAgentOwnedWarrantySource` generalisation must be applied here as well, not
+   only in `warrantySync.ts`. Owner: W01.
+2. **A `warranty` feature link sent with a `featurePolicyId` yields a 500, not a
+   400.** `warranty` is missing from the inline-only guard list at
+   `configurationPolicy.ts:2656-2662`, so it falls through to the generic
+   whole-policy path and is rejected by the
+   `config_policy_feature_links_reference_integrity` trigger. The code's own
+   comment (`:2665-2669`) describes exactly this failure. The UI never sends one
+   (`WarrantyTab.tsx:51,65` hardcode `featurePolicyId: null`), so this is
+   API-surface only. Verified by reading, not reproduced at runtime. Owner: W02.
+
+### Also noted, not blocking
+
+`ensureBuiltinPackage` hardcodes `originalFileName: 'HuntressInstaller.exe'`
+(`builtinDeploymentPackages.ts:112`) inside an otherwise provider-generic
+branch. HP takes the winget path and creates no version row, so it is not hit —
+but W04 should guard or fix it rather than leave the trap for the next
+derivable-URL package.

--- a/docs/superpowers/specs/device-lifecycle/2026-09-10-hp-warranty-cmsl-design.md
+++ b/docs/superpowers/specs/device-lifecycle/2026-09-10-hp-warranty-cmsl-design.md
@@ -1,7 +1,7 @@
 # HP warranty via HP CMSL (agent-collected)
 
-Status: design drafted 2026-09-10, awaiting review. Not implemented.
-Tracking: TBD — register via feature-lifecycle once approved.
+Status: approved 2026-09-10. Not implemented.
+Tracking: LanternOps/breeze#5511 (waves #5512-#5516).
 Depends on: `vuln-patch/2026-09-10-desired-state-software-install-design.md`
 (the `autoInstall` remediation half of software policies). Only wave 4 below
 needs it; waves 1-3 and 5 are independent and can run in parallel with that work.

--- a/docs/superpowers/specs/vuln-patch/2026-09-10-desired-state-software-install-design.md
+++ b/docs/superpowers/specs/vuln-patch/2026-09-10-desired-state-software-install-design.md
@@ -1,7 +1,7 @@
 # Desired-state software install (`autoInstall` remediation)
 
-Status: design drafted 2026-09-10, awaiting review. Not implemented.
-Tracking: TBD — register via feature-lifecycle once approved.
+Status: approved 2026-09-10. Not implemented.
+Tracking: LanternOps/breeze#5505 (waves #5506-#5510).
 Prerequisite for: `device-lifecycle/2026-09-10-hp-warranty-cmsl-design.md`.
 
 ## Problem
@@ -259,3 +259,91 @@ before opening the PR.
 4. UI: arm/disarm with dry-run count, `catalogId` authoring warning, policy-owned
    deployments labelled as such in the deployment list.
 5. AI guardrails + tool schema decisions.
+
+## Corrections after ground-truth verification (2026-09-10)
+
+The design above is unchanged; these are citation and fact corrections found by
+re-opening every file cited, after the spec was approved. Wave plans carry the
+corrected citations — prefer this section over the body where they disagree.
+
+- **`isPolicyArmedForRemediation` does not exist.** The real API is
+  `evaluateSoftwarePolicyArming(policy)` (`softwarePolicyService.ts:177-206`),
+  returning `SoftwarePolicyArmingState`, with the helper
+  `readSoftwarePolicyAutoUninstall` (`:172-175`) and the reason union
+  `SoftwarePolicyUnarmedReason = 'audit_mode' | 'enforce_mode_off' | 'auto_uninstall_off'`
+  (`:159`). The three refusal messages are at `:184`, `:192-193`, `:201-202` and
+  all three say "uninstall" explicitly — none is verb-neutral. Only two non-test
+  callers: `softwareRemediationWorker.ts:318`, `aiToolsCompliance.ts:509`.
+- **The compliance worker does not use that helper at all** — it re-derives the
+  gate inline at `softwareComplianceWorker.ts:423-427` from its own local
+  `readRemediationOptions` (`:136-162`). That duplication is why the two places
+  can drift; the install work unifies them rather than adding a third copy.
+- **The remediation gate is at `softwareComplianceWorker.ts:423-444`**, not
+  `398-404`. `shouldQueueAutoRemediation` is at `:184-212` (correct) and its sole
+  call site is `:429`. Line `:427` requires at least one `unauthorized`
+  violation, so a device with only `missing` violations is unreachable today —
+  that line, not just the `autoUninstallEnabled` check, is the blocker.
+- **The grace-period clock is unauthorized-only.**
+  `readEarliestUnauthorizedDetection` (`:164-182`) hard-filters
+  `typed.type !== 'unauthorized'` at `:171`, so a `missing` violation contributes
+  nothing to grace today. It must be generalised per verb, not reused as-is.
+- **NEW GAP — a `missing` violation carries no `catalogId`.** The emission at
+  `softwarePolicyService.ts:333-347` writes only
+  `rule: { name, minVersion, maxVersion }` — no `catalogId`, no `software`
+  object, no `reason`, even though `SoftwarePolicyRuleDefinition.catalogId`
+  exists (`softwarePolicies.ts:30`). §4 of this spec assumes `catalogId` is
+  reachable from the violation; it is not. The fix is to add `catalogId` to the
+  emitted `rule` object and to the `SoftwarePolicyViolation['rule']` type
+  (`softwarePolicies.ts:55-60`) — `violations` is jsonb and
+  `software_compliance_status` is in no export or org-cascade registry, so this
+  needs no migration and no registration. Matching a violation back to its rule
+  by name instead is rejected: rule names are not unique.
+- `software_compliance_status` is defined in
+  `apps/api/src/db/schema/softwarePolicies.ts:114-129`, not its own file. Its
+  upsert conflict target is the unique index
+  `software_compliance_device_policy_unique` on `(device_id, policy_id)` (`:128`).
+  It is registered in `CORE_DEVICE_CASCADE_DELETE_TABLES` at
+  `apps/api/src/routes/devices/core.ts:511` (not `:507`); its absence from the
+  org-cascade order and the export registry is confirmed (zero occurrences in
+  either file).
+- **The `sw-install-<deployment>-<device>-<attempt>` id is gone.** #5128 replaced
+  it with the persisted `device_commands` UUID;
+  `dispatchSoftwareInstallToDevice` (`softwareDeployment.ts:126-165`) no longer
+  constructs one, and the attempt number travels in `payload.retryCount`. The
+  shape survives only as the legacy parser `SW_INSTALL_COMMAND_ID_REGEX`
+  (`softwareDeploymentResult.ts:16`). The coupling the spec describes is still
+  real — the function only UPDATEs a `deployment_results` row that must already
+  exist — but for that reason, not the id.
+- **Cascade ordering is not achieved by array position.**
+  `software_deployments` is at `tenantCascade.ts:597` and `software_policies` at
+  `:600` (alphabetical). Correct child-before-parent ordering comes from explicit
+  pre-clear steps at `:841-851` (org) and `:1485-1506` (partner), because
+  `deployment_results` has no `org_id` and is absent from the array entirely.
+  The export-policy entry for `software_deployments` is at
+  `tenantExportPolicyRegistry.ts:434`.
+- **Authorization is closer than the spec implies.** `software.ts:1754` is a DB
+  query inside a handler, not a route; the deployment-create route is
+  `software.ts:1882-1888` (`requireScope` + `devices:execute` + `requireMfa()`).
+  Software-policy create (`softwarePolicies.ts:291-296`) and update (`:517-525`)
+  **already** require `devices:write` + `requireMfa()` plus the in-handler
+  `canMutateOrgWideGovernance` site-ceiling check. So the delta needed to reach
+  deployment-grade authorization is `devices.execute` alone, not MFA as well.
+- `remediationOptionsSchema` (`softwarePolicies.ts:79-85`) is a non-strict
+  `z.object`, so an `autoInstall` field is silently **stripped**, not rejected,
+  until it is added there. The AI SDK registration is worse:
+  `aiAgentSdkTools.ts:2251` types `remediationOptions` as
+  `z.record(z.string(), z.unknown())`, so the AI can pass arbitrary keys — the
+  refusal has to live at the four AI write sites
+  (`aiToolsCompliance.ts:287,356-357`, `aiToolsPolicyPrereqs.ts:441,496`), not
+  in the schema.
+- There is **no bulk or import path** that writes `remediation_options`; six
+  single-policy write sites exist in total (the two HTTP routes above plus those
+  four AI sites).
+- `software_policy_audit.action` has **no enum or const** — it is a bare
+  `varchar(50)` (`softwarePolicies.ts:142`) written as `action: string`
+  (`softwarePolicyService.ts:542`). The only enforced invariant is that at least
+  one owner axis is set (`:548-550`). New install actions therefore need their
+  own exported constants; there is no existing set to extend.
+- `summarizeEnforcementChange` (`aiToolsSoftwarePolicyAudit.ts:76-84`) hoists
+  `autoUninstall` to a top-level greppable audit key. An `autoInstall` field
+  needs its own line there or it stays buried inside the blob.

--- a/docs/superpowers/specs/vuln-patch/2026-09-10-desired-state-software-install-design.md
+++ b/docs/superpowers/specs/vuln-patch/2026-09-10-desired-state-software-install-design.md
@@ -1,0 +1,261 @@
+# Desired-state software install (`autoInstall` remediation)
+
+Status: design drafted 2026-09-10, awaiting review. Not implemented.
+Tracking: TBD — register via feature-lifecycle once approved.
+Prerequisite for: `device-lifecycle/2026-09-10-hp-warranty-cmsl-design.md`.
+
+## Problem
+
+`software_policies` in `allowlist` mode already means "this is the software that
+should be on these machines". The detection half is built and working: for every
+allowlist rule with no matching install, `evaluateSoftwareInventory` emits a
+`{ type: 'missing', severity: 'high' }` violation and the compliance worker
+records it on `software_compliance_status`
+(`apps/api/src/services/softwarePolicyService.ts:331-345`).
+
+Nothing ever acts on it. `remediationOptions` carries exactly one verb —
+`autoUninstall?: boolean` (`apps/api/src/db/schema/softwarePolicies.ts:66`) —
+the compliance worker's remediation branch gates on
+`violation.type === 'unauthorized'`
+(`apps/api/src/jobs/softwareComplianceWorker.ts:399-402`), and the remediation
+worker only ever queues `CommandTypes.SOFTWARE_UNINSTALL`
+(`apps/api/src/jobs/softwareRemediationWorker.ts:524`).
+
+So today an allowlist policy tells a technician that required software is
+missing on 400 machines and offers no way to fix it. This spec closes that loop.
+
+## Why now, and why not a deployment
+
+`software_deployments` cannot express continuing intent, and this is not a
+tuning problem — it is structural:
+
+- `createSoftwareDeployment` materialises the current device IDs into
+  `deployment_results` at creation time
+  (`apps/api/src/services/softwareDeployment.ts:1076`).
+- The scheduler permanently excludes already-dispatched deployments and
+  dispatches only the pending result rows that already exist; it never
+  re-evaluates the stored target or filter
+  (`apps/api/src/jobs/softwareDeploymentScheduler.ts:130,238`).
+
+Consequences, all verified: a device that enrols after creation never gets the
+software — even if it enrols *before* the scheduled dispatch time. A device
+whose hardware inventory (and therefore manufacturer/OS identity) arrives later
+is likewise missed. Editing `targetIds` after dispatch does nothing at all.
+
+Compliance evaluation has the opposite shape. It runs every 15 minutes per
+active policy, self-scheduled via `repeat: { every: SCAN_INTERVAL_MS }`
+(`softwareComplianceWorker.ts:44,538`), and re-resolves target devices on each
+pass. That is the reconciliation loop this feature needs, and it already exists.
+
+## Non-goals
+
+- The `'outdated'` violation type. The schema reserves it
+  (`softwarePolicies.ts:48`) but nothing emits it, and version-drift remediation
+  is a separate problem from presence. Out of scope; do not partially wire it.
+- Replacing `software_deployments` for one-shot, operator-driven installs. Both
+  remain. A deployment stays the right model for "push this now to these
+  machines"; a policy is the right model for "keep this present".
+- Uninstall behaviour. Untouched.
+
+## Design
+
+### 1. `remediationOptions.autoInstall`
+
+Add to `SoftwarePolicyRemediationOptions`
+(`apps/api/src/db/schema/softwarePolicies.ts:62-68`):
+
+```ts
+autoInstall?: boolean; // opt-in; absent or non-boolean means NOT armed
+```
+
+`remediation_options` is already classified `excludedOpen` in
+`CORE_TENANT_EXPORT_POLICY` (`tenantExportPolicyRegistry.ts:430`) because it is
+jsonb, so this addition needs **no** export-policy change and **no** migration.
+
+Arming mirrors `autoUninstall` exactly, and deliberately does not share its
+flag: a policy that is armed to remove unauthorised software is not thereby
+armed to install anything. Both verbs sit behind `enforceMode` and
+`mode !== 'audit'`, and each has its own boolean. Extend
+`isPolicyArmedForRemediation` (`softwarePolicyService.ts:171-174`) into a
+verb-aware check rather than adding a second near-identical helper — the
+existing refusal messages at `softwarePolicyService.ts:192,201` must gain an
+install variant so a technician is told which verb is unarmed.
+
+### 2. Missing-violation remediation branch
+
+In `softwareComplianceWorker.ts:398-404`, the single remediation gate becomes
+two independent gates over the same violation set:
+
+- `unauthorized` + `autoUninstallEnabled` → existing uninstall path, unchanged.
+- `missing` + `autoInstallEnabled` → new install path.
+
+Both continue through `shouldQueueAutoRemediation`
+(`softwareComplianceWorker.ts:184`) so grace period, cooldown and the
+previous-remediation-status checks apply identically. A policy may arm both, one,
+or neither; a device may be queued for both in the same pass (removing an
+unauthorised app and installing a required one are not in conflict).
+
+`softwareComplianceStatus.remediationStatus` is a single column today. Two verbs
+sharing one status field will lie — a successful install alongside a failed
+uninstall has no honest single value. Either widen it to a small jsonb
+per-verb status or add a second column; **decide this in the plan, do not let
+the implementation pick silently.** Recommendation: a second column
+(`install_remediation_status`, `last_install_remediation_attempt`) so the
+existing uninstall reaper logic and its cooldown reads stay untouched.
+
+That is a migration on `software_compliance_status`, which needs **no**
+registration changes — verified: it has no `org_id`, is absent from both
+`CORE_ORG_CASCADE_DELETE_ORDER` and `CORE_TENANT_EXPORT_POLICY`, and is already
+registered in `CORE_DEVICE_CASCADE_DELETE_TABLES`
+(`apps/api/src/routes/devices/core.ts:507`).
+
+### 3. Install dispatch, and the `deploymentId` coupling
+
+`dispatchSoftwareInstallToDevice` cannot be called directly: it takes a
+`deploymentId`, and after dispatch it writes the command id back onto a
+`deployment_results` row (`apps/api/src/services/softwareDeployment.ts:122-160`).
+Its whole retry/reconciliation contract — the `sw-install-<deployment>-<device>-<attempt>`
+result path and the superseded-attempt rejection in `applySoftwareInstallResult`
+— hangs off that row.
+
+**Decision: policy remediation creates a real, policy-owned deployment.** When
+the compliance worker queues install remediation for a set of devices, the
+remediation worker creates one `software_deployments` row per (policy, org,
+batch) with `install_method_id` or `software_version_id` resolved from the
+rule's `catalogId`, then dispatches through the existing seam.
+
+Rejected alternative: a new dispatch seam that skips `deployment_results`. It
+would need its own result correlation, its own retry accounting and its own
+offline-queue reconciliation, duplicating three mechanisms that already work.
+
+This requires marking a deployment as policy-originated so the UI can label it
+and so the worker can dedupe. Add a nullable FK column to `software_deployments`:
+
+```sql
+software_policy_id uuid REFERENCES software_policies(id) ON DELETE SET NULL
+```
+
+**Registration obligations for that column, all mandatory in the same PR:**
+
+- `software_deployments` is in `CORE_ORG_CASCADE_DELETE_ORDER`
+  (`tenantCascade.ts:436`), so per the export-policy contract a *new column on an
+  already-registered table* breaks `tenant-export-policy.integration.test.ts`.
+  Add `software_policy_id` to the `included` list at
+  `tenantExportPolicyRegistry.ts:427`.
+- The FK references `software_policies`, which is also in the cascade order
+  (`tenantCascade.ts:439`). `ON DELETE SET NULL` is required so deleting a policy
+  does not abort an org cascade on an FK violation. Note that `software_policies`
+  currently sorts *after* `software_deployments` alphabetically — verify the
+  child-before-parent property still holds, since `tenantCascade.integration.test.ts`
+  asserts FK children precede parents.
+- This is not a composite `(x, org_id)` FK, so the `DEFERRABLE INITIALLY IMMEDIATE`
+  rule does not apply. Confirm that reading remains true if the FK shape changes.
+
+Note the existing dedup precedent: the uninstall path already dedupes in-flight
+work by querying `deviceCommands.payload ->> 'policyId'`
+(`softwareRemediationWorker.ts:174-181`). The install path should dedupe on the
+deployment row instead — an unfinished policy-owned deployment for the same
+(policy, device) means do not queue another.
+
+### 4. Resolving what to install
+
+`SoftwarePolicyRuleDefinition.catalogId` already exists
+(`softwarePolicies.ts:28`) and is already used for match narrowing
+(`softwarePolicyService.ts:279`). It becomes load-bearing here.
+
+- A rule **without** `catalogId` can be detected as missing but **cannot** be
+  auto-installed — there is nothing to install. The worker must skip it and say
+  so, not fail silently. Surface this in the policy editor at authoring time:
+  arming `autoInstall` on a policy whose rules lack `catalogId` should warn.
+- A rule **with** `catalogId` resolves to the catalog item, then to either its
+  install method (winget/homebrew) or its version artifact. Reuse the existing
+  one-target rule: a deployment sets `software_version_id` XOR `install_method_id`
+  (CHECK `software_deployments_one_target_chk`).
+- Platform mismatch is already handled downstream —
+  `softwareDeployment.ts:410` rejects when `device.osType !== installMethod.platform`
+  — but the worker should filter first so a cross-platform policy does not
+  generate guaranteed-failing deployments every 15 minutes.
+
+`minVersion` on a rule is a detection input only in this iteration. Installing
+to satisfy `minVersion` on already-present software is version drift, which is a
+non-goal above.
+
+### 5. Authorization
+
+This is the sharpest edge in the feature. Today:
+
+- Software policy writes are gated by the software policy routes.
+- Creating a deployment requires `devices.execute` **plus** MFA
+  (`apps/api/src/routes/software.ts:1754`, `requireSoftwareExecute`).
+
+Arming `autoInstall` causes software installation on customer machines. It must
+therefore carry authorization **at least as strong as creating a deployment** —
+`devices.execute` + `requireMfa()` — on every path that can set it, including
+policy create, policy update, and any bulk/import path. A weaker gate on the
+policy route would be a privilege-escalation route around the deployment gate.
+
+`aiGuardrails.ts:225` currently describes the arming pair as
+`enforceMode` + `remediationOptions.autoUninstall`; it must learn about
+`autoInstall`, and the AI tool schemas that expose `remediationOptions`
+(`aiToolSchemas.ts:1121,1142,1648`, `aiToolsPolicyPrereqs.ts:360`,
+`aiToolsCompliance.ts:464`) must not let an agent arm installation implicitly.
+Treat "can the AI arm autoInstall" as an explicit product decision in the plan;
+the safe default is no.
+
+### 6. Audit
+
+`software_policy_audit` already carries both axes deliberately so partner and
+org admins each see events (`softwarePolicies.ts:120-124`). Install remediation
+emits its own action values (`install_queued`, `install_succeeded`,
+`install_failed`) rather than reusing the uninstall ones — an audit reader must
+never have to infer the verb.
+
+## Risks
+
+- **Install loops.** A policy whose rule never matches what actually gets
+  installed (name/vendor mismatch between the catalog item and what the
+  installer registers in Add/Remove Programs) will re-detect `missing` every 15
+  minutes and reinstall forever. Grace period and cooldown bound the rate but do
+  not stop the loop. Mitigation: a per-(policy, device) consecutive-attempt
+  counter that gives up and marks the compliance row `remediation_failed` after
+  N attempts, with the count visible in the UI. **This is the failure mode most
+  likely to reach a customer; do not defer it to a follow-up.**
+- **Fleet-wide first run.** Arming `autoInstall` on an existing broad policy
+  could queue thousands of installs in one 15-minute pass. The compliance worker
+  should cap installs queued per pass per policy, and the UI should show a
+  dry-run count ("this will install X on N devices") before arming.
+- **Detection rules vs. exit code.** `software_detection.go` already evaluates
+  `detection_rules` independently of installer exit code
+  (`software.ts:67-71`). Catalog items used by policies should carry detection
+  rules, or a "successful" install that the inventory never sees will feed the
+  loop above.
+
+## Testing
+
+- Unit: verb-aware arming (armed for uninstall only, install only, both,
+  neither); missing-violation branch selection; rule-without-`catalogId` skip;
+  platform filter.
+- Unit: `shouldQueueAutoRemediation` applied to install decisions — grace,
+  cooldown, previous-status.
+- Integration (real DB): a partner-owned allowlist policy with `autoInstall`
+  armed creates a policy-owned deployment for an eligible device, and does *not*
+  create a second one while the first is in flight.
+- Integration: org cascade still passes with the new FK — this is the contract
+  that has caught this class of mistake 5/5 times.
+- Contract: `tenant-export-policy.integration.test.ts` with the new column.
+- Regression: arming install does not arm uninstall, and vice versa.
+
+Both integration suites need a live database and run only in the **Integration
+Tests** job, so a locally-green branch proves nothing here. Run them explicitly
+before opening the PR.
+
+## Wave sketch
+
+1. Schema + arming: `autoInstall`, verb-aware arming helper, authorization gate,
+   audit actions. No dispatch yet.
+2. Compliance worker: missing-violation branch, per-pass cap, attempt counter.
+3. Remediation worker: policy-owned deployment creation + dispatch, dedup,
+   `software_policy_id` column and its three registrations.
+4. UI: arm/disarm with dry-run count, `catalogId` authoring warning, policy-owned
+   deployments labelled as such in the deployment list.
+5. AI guardrails + tool schema decisions.


### PR DESCRIPTION
Docs-only. Two approved specs plus eleven wave plans, tracked as feature issues #5505 and #5511.

## What's here

| Feature | Waves | Plans |
|---|---|---|
| #5505 desired-state software install | #5506–#5510, #5522 | W01 arming/authorization, W02 compliance worker, W03 policy-owned deployments, W04 UI, W05 AI guardrails, W06 install-preview endpoint |
| #5511 HP warranty via CMSL | #5512–#5516 | W01 lab probe + ingest hardening, W02 opt-in surface + delivery, W03 agent collector, W04 built-in package, W05 cleanup |

The waves were written against a locked cross-wave contract, so they agree on names, column shapes, migration slots and gates rather than discovering each other at implementation time. Migration slots claimed: `…150400` (W02/A), `…150401` (W03/A), `…150402` (W04/B) — no collision, and each plan re-checks the tip before use.

## Corrections to the approved specs

Both specs carry an appended `Corrections after ground-truth verification` section rather than inline rewrites, so the approved text stands. The substantive one: **the agent has no Go WMI binding.** `yusufpapurcu/wmi` is indirect and imported nowhere; `go-ole` drives only Windows Update and VSS. Every WMI read in the agent goes through PowerShell `Get-CimInstance`, so HP's T0 tier follows `hardware_windows.go` instead. Tiering is unchanged. The rest are citation fixes, including several that were simply wrong (`isPolicyArmedForRemediation` does not exist; `software.ts:1754` is a query, not a route).

## Defects found while planning

Each has a red-first regression test in the owning wave.

1. **`missing` violations carry no `catalogId`** (`softwarePolicyService.ts:333-347`) — the install path had nothing to resolve from. Fixed in A-W01; jsonb, no migration.
2. **Cross-tenant catalog reachability.** A rule's `catalogId` is validated only as a guid (`softwarePolicies.ts:51`) and the remediation worker runs under `runWithSystemDbAccess`. Harmless while `catalogId` only narrows detection; a cross-tenant install the moment it drives one. A-W03 adds a fail-closed ownership guard.
3. **The built-in install-method guard covers one verb.** "Built-in packages cannot carry install methods" appears once, at `softwareInstallMethods.ts:113`, inside POST. PATCH (`:144`) and DELETE (`:272`) have none, and RLS does not close it for a partner-scoped caller. Not reachable today because no built-in has an install method; B-W04 would make HP CMSL the first, and closes it.
4. **An AI door around the authorization gate.** `manage_policy_feature_link` is tier 2 (`aiAgentSdkTools.ts:250`), calls `addFeatureLink` directly (`aiToolsConfigPolicy.ts:936`), and `warranty` is absent from `VALIDATED_INLINE_SETTINGS`. `isInputAwareTier3` escalates only on `featureType === 'maintenance'`. B-W02 escalates an hpCmsl-enabling write to tier 3, keyed on settings content — `featureType` is not a required input on `update`, which is the call that turns collection on.
5. **CSV import overwrites agent-reported warranty today.** `warrantyTarget.ts:181,238` guards only `provider` rows, so `agent_plist` is already stomped. B-W01 generalises it.

## Decisions taken, open to override

- Authorization gates on **post-write** state via an in-handler assertion, not route middleware — middleware cannot see the resulting policy, and this also covers editing rules on an already-armed policy. Both features gate the act of causing installation identically.
- `warranty` is **not** added to `MFA_GATED_FEATURE_TYPES` wholesale; alert-threshold edits stay at `devices.write`.
- Per-verb remediation status uses separate columns, not a widened jsonb, leaving the uninstall path untouched.
- B-W01 widens the manual-refresh refusal to any agent-owned row, not just HP — once the false `lastSyncAt` stamp is removed, a Mac `agent_plist` device has the same dead end with a worse symptom.

## Needs your decision

**HP CMSL policy targeting.** `resolveDeviceIdsForSoftwarePolicy` (`featureConfigResolver.ts:1044`) resolves through config-policy assignments, whose only filters are `roleFilter` and `osFilter` — there is no manufacturer filter, and `softwarePolicies.targetType`/`targetIds` are unread on that path. `hardware.manufacturer` targeting exists for deployments, not policies, so the spec's Layer 3 conflates the two. The broadest honest scope is "every Windows device under the assignment", which would push a ~100 MB HP module and HP's EULA onto Dell and Lenovo endpoints.

Either build `manufacturer_filter` on `config_policy_assignments` (reusable, but shared machinery needing its own design pass), or Breeze creates the built-in policy and the MSP assigns it. The plans assume the latter — better consent posture, and B-W04's Task 9 creates no assignment.

## Known gaps, recorded not hidden

- `install_remediation_status` collapses three skip causes (no `catalogId`, per-pass cap, platform mismatch) into one value with no persisted sub-reason. Only the first is reconstructable at render time; A-W04 gives that one a specific message and the others one honest hedge. Adding a sub-reason column is a small W02 follow-up if you want it.
- HP W01's lab probe is a written procedure, not a result — three questions still need real HP hardware, and a red answer on the winget upgrade path comes back to you rather than being decided inside a wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ANjBwca2cfsLWDLJro3fkz