### PR TITLE
feat(web): devices list refresh button + soft org context switch (no full reload)

### DIFF
--- a/apps/web/src/components/auth/AuthOverlay.ssoFailureRace.test.tsx
+++ b/apps/web/src/components/auth/AuthOverlay.ssoFailureRace.test.tsx
@@ -89,7 +89,7 @@ describe('AuthOverlay SSO failure redirect vs. refresh eviction (#3704)', () => 
     useAuthStore.setState({ ...STALE_SESSION, isAuthenticated: false, user: null });
     window.history.replaceState({}, '', '/');
     const { navigateTo } = await import('../../lib/navigation');
-    vi.mocked(navigateTo).mockImplementation(async () => {});
+    vi.mocked(navigateTo).mockImplementation(async () => 'soft' as const);
   });
 
   it('holds the gated refresh until the sso_exchange_failed redirect has committed', async () => {
@@ -104,6 +104,7 @@ describe('AuthOverlay SSO failure redirect vs. refresh eviction (#3704)', () => 
     vi.mocked(navigateTo).mockImplementation(async (path: string) => {
       await navigationCommitted;
       window.history.replaceState({}, '', path);
+      return 'soft' as const;
     });
 
     stubFetch({
@@ -162,6 +163,7 @@ describe('AuthOverlay SSO failure redirect vs. refresh eviction (#3704)', () => 
     vi.mocked(navigateTo).mockImplementation(async (path: string) => {
       await navigationCommitted;
       window.history.replaceState({}, '', path);
+      return 'soft' as const;
     });
 
     stubFetch({ '/auth/refresh': () => json(401, { error: 'invalid refresh token' }) });
@@ -240,6 +242,7 @@ describe('AuthOverlay SSO failure redirect vs. refresh eviction (#3704)', () => 
     const { navigateTo } = await import('../../lib/navigation');
     vi.mocked(navigateTo).mockImplementation(async () => {
       // Resolves without moving the URL, exactly like the fallback branch.
+      return 'hard' as const;
     });
 
     // jsdom refuses real navigations, so swap the whole location object and spy

--- a/apps/web/src/components/devices/DevicesPage.test.tsx
+++ b/apps/web/src/components/devices/DevicesPage.test.tsx
@@ -3048,3 +3048,32 @@ describe('DevicesPage — header "Add" split menu (#5213)', () => {
     expect(screen.queryByTestId('devices-page-add-menu')).toBeNull();
   });
 });
+
+describe('DevicesPage — header refresh button', () => {
+  it('refetches the fleet in place without dropping the list into the loading skeleton', async () => {
+    render(<DevicesPage />);
+    await screen.findByTestId('device-list');
+    expect(vi.mocked(fetchAllDevices)).toHaveBeenCalledTimes(1);
+
+    let resolveSecond: (v: unknown) => void = () => {};
+    vi.mocked(fetchAllDevices).mockImplementationOnce(
+      () => new Promise((resolve) => { resolveSecond = resolve; }) as never
+    );
+
+    fireEvent.click(screen.getByTestId('devices-page-refresh'));
+
+    // While the refetch is in flight the list stays mounted (no skeleton swap).
+    expect(vi.mocked(fetchAllDevices)).toHaveBeenCalledTimes(2);
+    expect(screen.getByTestId('device-list')).toBeTruthy();
+    expect(screen.getByTestId('devices-page-refresh').getAttribute('aria-busy')).toBe('true');
+
+    await act(async () => {
+      resolveSecond({ data: [rawDevice(DEV_1, 'host-refreshed')] });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('device-list').getAttribute('data-hostnames')).toContain('host-refreshed');
+    });
+    expect(screen.getByTestId('devices-page-refresh').getAttribute('aria-busy')).toBe('false');
+  });
+});

--- a/apps/web/src/components/devices/DevicesPage.test.tsx
+++ b/apps/web/src/components/devices/DevicesPage.test.tsx
@@ -3076,4 +3076,23 @@ describe('DevicesPage — header refresh button', () => {
     });
     expect(screen.getByTestId('devices-page-refresh').getAttribute('aria-busy')).toBe('false');
   });
+
+  it('keeps the last-good list on screen and toasts when a background refresh fails', async () => {
+    const { showToast } = await import('../shared/Toast');
+    render(<DevicesPage />);
+    await screen.findByTestId('device-list');
+
+    vi.mocked(fetchAllDevices).mockRejectedValueOnce(new Error('boom'));
+    fireEvent.click(screen.getByTestId('devices-page-refresh'));
+
+    await waitFor(() => {
+      expect(vi.mocked(showToast)).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+    });
+    // No full-page error card: the rows the user was looking at are still there.
+    expect(screen.getByTestId('device-list').getAttribute('data-hostnames')).toContain('host-alpha');
+    expect(screen.queryByText('Try again')).toBeNull();
+    const btn = screen.getByTestId('devices-page-refresh');
+    expect(btn.getAttribute('aria-busy')).toBe('false');
+    expect((btn as HTMLButtonElement).disabled).toBe(false);
+  });
 });

--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useEventStream } from '../../hooks/useEventStream';
 import { useAdvancedFilterIds } from '../../hooks/useAdvancedFilterIds';
-import { List, Grid, Plus, AlertCircle, ChevronDown } from 'lucide-react';
+import { List, Grid, Plus, AlertCircle, ChevronDown, RefreshCw } from 'lucide-react';
 import { showToast } from '../shared/Toast';
 import { formatDateTime } from '@/lib/dateTimeFormat';
 import type { FilterConditionGroup } from '@breeze/shared';
@@ -311,6 +311,11 @@ export default function DevicesPage() {
   const [deviceGroups, setDeviceGroups] = useState<DeviceGroup[]>([]);
   const [groupMembershipMap, setGroupMembershipMap] = useState<Map<string, Set<string>>>(new Map());
   const [loading, setLoading] = useState(true);
+  // True while a user-initiated (header button) refetch is in flight. Kept
+  // separate from `loading` so the rendered list stays mounted instead of
+  // swapping to the skeleton — the whole point of the button is to avoid a
+  // full-page-reload feel.
+  const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<unknown>(null);
   const [viewMode, setViewMode] = useState<ViewMode>('list');
   const [actionInProgress, setActionInProgress] = useState(false);
@@ -615,9 +620,11 @@ export default function DevicesPage() {
   const hiddenDecommissionedCount = includeDecommissioned ? 0 : decommissionedCount;
   const shownDecommissionedCount = includeDecommissioned ? decommissionedCount : 0;
 
-  const fetchDevices = useCallback(async (signal?: AbortSignal) => {
+  const fetchDevices = useCallback(async (signal?: AbortSignal, opts?: { background?: boolean }) => {
+    const background = opts?.background === true;
     try {
-      setLoading(true);
+      if (background) setRefreshing(true);
+      else setLoading(true);
       setError(null);
 
       // Devices walk the cursor (Discussion #742 PR 3); orgs/sites/groups
@@ -952,7 +959,10 @@ export default function DevicesPage() {
       // setState on unmounted components for hook-based components) but
       // we still skip it when we know the call aborted, to avoid a
       // brief flicker if the component remounts on the same key.
-      if (!signal?.aborted) setLoading(false);
+      if (!signal?.aborted) {
+        if (background) setRefreshing(false);
+        else setLoading(false);
+      }
     }
   }, [t]);
 
@@ -977,6 +987,17 @@ export default function DevicesPage() {
     await fetchDevices();
     refetchAdvancedFilterIds();
   }, [fetchDevices, refetchAdvancedFilterIds]);
+
+  /**
+   * Header "Refresh" button. Same pairing as `refreshDevices` (rows + server-
+   * resolved filter ids) but runs in the background so the list stays on
+   * screen while the new page set streams in.
+   */
+  const handleManualRefresh = useCallback(async () => {
+    if (refreshing) return;
+    await fetchDevices(undefined, { background: true });
+    refetchAdvancedFilterIds();
+  }, [fetchDevices, refetchAdvancedFilterIds, refreshing]);
 
   useEffect(() => {
     // Org context not usable for scoping yet (#4147). A request now would go
@@ -2174,6 +2195,18 @@ export default function DevicesPage() {
           </p>
         </div>
         <div className="flex items-center gap-3">
+          <button
+            type="button"
+            data-testid="devices-page-refresh"
+            onClick={() => { void handleManualRefresh(); }}
+            disabled={refreshing}
+            aria-busy={refreshing ? 'true' : 'false'}
+            title={t('devicesPage.refresh')}
+            aria-label={t('devicesPage.refresh')}
+            className="flex h-10 w-10 items-center justify-center rounded-md border transition hover:bg-muted disabled:cursor-default disabled:opacity-60"
+          >
+            <RefreshCw className={`h-4 w-4 ${refreshing ? 'animate-spin' : ''}`} />
+          </button>
           <div className="flex rounded-md border">
             <button
               type="button"

--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -276,9 +276,9 @@ export default function DevicesPage() {
   // fetchOrganizations. A fetch fired at mount therefore went out with no
   // orgId — the API reads that as "every accessible org" — and nothing ever
   // refetched, so the list stayed fleet-wide while the switcher pill showed a
-  // single org. (Re-picking an org only "fixed" it because applyOrgSwitch does
-  // a full window.location.reload, by which point the org IS persisted and
-  // rehydrates synchronously.)
+  // single org. (Re-picking an org only "fixed" it because applyOrgSwitch
+  // re-navigates — historically a full window.location.reload, now a soft
+  // remount of the page island — by which point the org IS in the store.)
   //
   // So key the fetch on the RESOLVED scope rather than on mount: hold while the
   // context is still loading, then fetch — and refetch — whenever the scope
@@ -953,6 +953,14 @@ export default function DevicesPage() {
       // Aborts are expected when the component unmounts mid-walk — drop
       // them silently rather than rendering a misleading error banner.
       if (err instanceof Error && err.name === 'AbortError') return;
+      if (background) {
+        // The whole point of a background refresh is to keep the last-good
+        // list on screen. Swapping it for the full-page error card would
+        // throw away data the user was already looking at over a transient
+        // blip, so report the failure without tearing the page down.
+        showToast({ type: 'error', message: t('devicesPage.toasts.refreshFailed') });
+        return;
+      }
       setError(err);
     } finally {
       // setLoading(false) is harmless after unmount (React 18 ignores
@@ -981,7 +989,9 @@ export default function DevicesPage() {
    *
    * The mount effect below deliberately keeps calling `fetchDevices` directly:
    * the hook resolves the filter itself on mount, so going through here would
-   * just fire a second, redundant /filters/preview.
+   * just fire a second, redundant /filters/preview. `handleManualRefresh` also
+   * calls `fetchDevices` directly, only to pass the `background` flag; it
+   * re-applies the same id-set pairing.
    */
   const refreshDevices = useCallback(async () => {
     await fetchDevices();

--- a/apps/web/src/components/layout/OrgSwitcher.test.tsx
+++ b/apps/web/src/components/layout/OrgSwitcher.test.tsx
@@ -9,8 +9,10 @@ const {
   selectAllOrgsMock,
   fetchOrganizationsMock,
   waitForPendingRefreshMock,
+  navigateToMock,
   mockStoreRef,
 } = vi.hoisted(() => ({
+  navigateToMock: vi.fn().mockResolvedValue('soft'),
   selectOrganizationMock: vi.fn(),
   selectAllOrgsMock: vi.fn(),
   fetchOrganizationsMock: vi.fn(),
@@ -24,6 +26,10 @@ const {
 vi.mock('@/stores/auth', () => ({
   waitForPendingRefresh: waitForPendingRefreshMock
 }));
+
+// The switch is a soft (view-transition) navigation now, never a reload.
+vi.mock('@/lib/navigation', () => ({ navigateTo: navigateToMock }));
+vi.mock('@/components/shared/Toast', () => ({ showToast: vi.fn() }));
 
 let mockStoreState: {
   currentOrgId: string | null;
@@ -156,12 +162,13 @@ describe('OrgSwitcher (unified control)', () => {
 
     expect(selectOrganizationMock).toHaveBeenCalledWith('org-b');
     // Navigation is gated behind await waitForPendingRefresh() (#950 race guard).
-    await waitFor(() => expect(hrefSetter).toHaveBeenCalledWith('/devices'));
+    await waitFor(() => expect(navigateToMock).toHaveBeenCalledWith('/devices', { replace: true }));
     expect(reloadMock).not.toHaveBeenCalled();
+    expect(hrefSetter).not.toHaveBeenCalled();
     expect(waitForPendingRefreshMock).toHaveBeenCalled();
   });
 
-  it('reloads in place when switching orgs from a non-detail page', async () => {
+  it('soft-navigates in place (no reload) when switching orgs from a non-detail page', async () => {
     const { reloadMock, hrefSetter } = stubLocation('/devices');
 
     render(<OrgSwitcher />);
@@ -169,9 +176,24 @@ describe('OrgSwitcher (unified control)', () => {
     openDropdownAndClickOrg('Org B');
 
     expect(selectOrganizationMock).toHaveBeenCalledWith('org-b');
-    await waitFor(() => expect(reloadMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(navigateToMock).toHaveBeenCalledWith('/devices', { replace: true }));
+    expect(reloadMock).not.toHaveBeenCalled();
     expect(hrefSetter).not.toHaveBeenCalled();
     expect(waitForPendingRefreshMock).toHaveBeenCalled();
+  });
+
+  it('clears the switching spinner once the soft navigation settles (the island persists across it)', async () => {
+    stubLocation('/devices');
+    let settle: () => void = () => {};
+    navigateToMock.mockImplementationOnce(() => new Promise<'soft'>((resolve) => { settle = () => resolve('soft'); }));
+
+    render(<OrgSwitcher />);
+    openDropdownAndClickOrg('Org B');
+
+    const trigger = screen.getByTestId('org-switcher-trigger');
+    await waitFor(() => expect(trigger).toHaveProperty('disabled', true));
+    settle();
+    await waitFor(() => expect(trigger).toHaveProperty('disabled', false));
   });
 
   it('does nothing when clicking the already-selected organization', () => {
@@ -218,7 +240,7 @@ describe('OrgSwitcher (unified control)', () => {
     expect(screen.queryByTestId('org-scope-all')).toBeNull();
   });
 
-  it('clicking the fleet row clears the selection and reloads', async () => {
+  it('clicking the fleet row clears the selection and soft-navigates', async () => {
     const { reloadMock } = stubLocation('/devices');
 
     render(<OrgSwitcher />);
@@ -226,7 +248,8 @@ describe('OrgSwitcher (unified control)', () => {
     fireEvent.click(screen.getByTestId('org-option-all'));
 
     expect(selectAllOrgsMock).toHaveBeenCalled();
-    await waitFor(() => expect(reloadMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(navigateToMock).toHaveBeenCalledWith('/devices', { replace: true }));
+    expect(reloadMock).not.toHaveBeenCalled();
     expect(waitForPendingRefreshMock).toHaveBeenCalled();
   });
 

--- a/apps/web/src/components/layout/OrgSwitcher.tsx
+++ b/apps/web/src/components/layout/OrgSwitcher.tsx
@@ -53,8 +53,10 @@ const SEARCH_THRESHOLD = 6;
 export default function OrgSwitcher() {
   const { t } = useTranslation('common');
   const [isOpen, setIsOpen] = useState(false);
-  // True from the moment a switch is initiated until the page reloads — shows a
-  // spinner on the trigger and disables it so the bar never silently freezes.
+  // True from the moment a switch is initiated until the soft navigation
+  // settles — shows a spinner on the trigger and disables it so the bar never
+  // silently freezes. This island is `transition:persist`, so it survives the
+  // switch and must clear the flag itself.
   const [switching, setSwitching] = useState(false);
   const [query, setQuery] = useState('');
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -74,7 +76,8 @@ export default function OrgSwitcher() {
   // organizations" from the transient null of a fresh session (#1423).
   const isFleet = !currentOrgId && allOrgs;
 
-  // Surface the "Switched to X" confirmation stashed before the last reload.
+  // Surface the "Switched to X" confirmation stashed before a switch that fell
+  // back to a full reload (the soft path toasts inside applyOrgSwitch).
   useEffect(() => {
     const message = consumeSwitchToast();
     if (message) showToast({ type: 'success', message });
@@ -166,10 +169,10 @@ export default function OrgSwitcher() {
   const showFleetOption = organizations.length > 1;
 
   // Apply a context change: a concrete org id, or null for fleet view. The
-  // reload (inside applyOrgSwitch) propagates the new scope everywhere at once
-  // (pages don't need to subscribe); registered detail routes (currently only
-  // device detail — see getOrgSwitchRedirect) redirect up to their list first so
-  // the new org doesn't 404 on the old org's record.
+  // soft re-navigation (inside applyOrgSwitch) remounts the page island and so
+  // propagates the new scope everywhere at once (pages don't need to
+  // subscribe); registered detail routes (see getOrgSwitchRedirect) redirect up
+  // to their list first so the new org doesn't 404 on the old org's record.
   const applyContext = async (orgId: string | null) => {
     setIsOpen(false);
     const changed = orgId ? orgId !== currentOrgId : !isFleet;
@@ -180,7 +183,11 @@ export default function OrgSwitcher() {
           name: organizations.find((o) => o.id === orgId)?.name ?? t('labels.organization')
         })
       : t('layout.org.toast.showingAll');
-    await applyOrgSwitch(orgId, message);
+    try {
+      await applyOrgSwitch(orgId, message);
+    } finally {
+      setSwitching(false);
+    }
   };
 
   return (

--- a/apps/web/src/components/shared/OrgRequiredState.tsx
+++ b/apps/web/src/components/shared/OrgRequiredState.tsx
@@ -27,7 +27,12 @@ export function OrgRequiredState({ description }: { description?: string }) {
   const pick = async (orgId: string, name: string) => {
     if (switchingId) return;
     setSwitchingId(orgId);
-    await applyOrgSwitch(orgId, t('layout.org.toast.switched', { name }));
+    try {
+      await applyOrgSwitch(orgId, t('layout.org.toast.switched', { name }));
+    } finally {
+      // Normally unmounted by the soft navigation; guards the no-op case.
+      setSwitchingId(null);
+    }
   };
 
   return (

--- a/apps/web/src/components/shared/OrgRequiredState.tsx
+++ b/apps/web/src/components/shared/OrgRequiredState.tsx
@@ -30,7 +30,9 @@ export function OrgRequiredState({ description }: { description?: string }) {
     try {
       await applyOrgSwitch(orgId, t('layout.org.toast.switched', { name }));
     } finally {
-      // Normally unmounted by the soft navigation; guards the no-op case.
+      // This page island is normally unmounted by the soft navigation; the
+      // reset only matters if the switch fell back to a hard load and the
+      // island is still on screen before unload.
       setSwitchingId(null);
     }
   };

--- a/apps/web/src/lib/navigation.test.ts
+++ b/apps/web/src/lib/navigation.test.ts
@@ -108,8 +108,26 @@ describe('navigateTo reports which path it took', () => {
     navigateMock.mockResolvedValue(undefined);
   });
 
-  it("resolves 'soft' when the view-transition router handled it", async () => {
+  it("resolves 'soft' only when the router actually swapped the document (astro:after-swap fired)", async () => {
+    navigateMock.mockImplementation(async () => {
+      document.dispatchEvent(new Event('astro:after-swap'));
+    });
     await expect(navigateTo('/devices')).resolves.toBe('soft');
+  });
+
+  it("resolves 'hard' when navigate() resolved without a swap (Astro's own full-load fallbacks never throw)", async () => {
+    // e.g. fetch failed / non-HTML response / no view-transitions meta: the
+    // router sets location.href and resolves normally.
+    navigateMock.mockResolvedValue(undefined);
+    await expect(navigateTo('/devices')).resolves.toBe('hard');
+  });
+
+  it('does not leave the after-swap listener behind once settled', async () => {
+    navigateMock.mockResolvedValue(undefined);
+    await navigateTo('/devices');
+    const before = navigateMock.mock.calls.length;
+    document.dispatchEvent(new Event('astro:after-swap'));
+    expect(navigateMock.mock.calls.length).toBe(before); // no side effects either way
   });
 
   it("resolves 'hard' when it had to fall back to a full navigation", async () => {

--- a/apps/web/src/lib/navigation.test.ts
+++ b/apps/web/src/lib/navigation.test.ts
@@ -101,3 +101,30 @@ describe('navigateTo same-origin guard', () => {
     });
   });
 });
+
+describe('navigateTo reports which path it took', () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+    navigateMock.mockResolvedValue(undefined);
+  });
+
+  it("resolves 'soft' when the view-transition router handled it", async () => {
+    await expect(navigateTo('/devices')).resolves.toBe('soft');
+  });
+
+  it("resolves 'hard' when it had to fall back to a full navigation", async () => {
+    navigateMock.mockRejectedValue(new Error('no router'));
+    const assign = vi.fn();
+    const original = window.location;
+    Object.defineProperty(window, 'location', {
+      configurable: true, writable: true,
+      value: { ...original, assign, replace: vi.fn() },
+    });
+    try {
+      await expect(navigateTo('/devices')).resolves.toBe('hard');
+      expect(assign).toHaveBeenCalledWith('/devices');
+    } finally {
+      Object.defineProperty(window, 'location', { configurable: true, writable: true, value: original });
+    }
+  });
+});

--- a/apps/web/src/lib/navigation.ts
+++ b/apps/web/src/lib/navigation.ts
@@ -4,9 +4,18 @@ interface NavigateOptions {
   replace?: boolean;
 }
 
-export async function navigateTo(path: string, options: NavigateOptions = {}): Promise<void> {
+/**
+ * `'soft'` when Astro's view-transition router handled the navigation (the
+ * document is swapped in place and `transition:persist` islands survive);
+ * `'hard'` when it fell back to a full page load. Callers that need to act
+ * AFTER a navigation (e.g. show a toast from a persisted island) can only do
+ * so on the soft path — on the hard path the page is about to unload.
+ */
+export type NavigationMode = 'soft' | 'hard';
+
+export async function navigateTo(path: string, options: NavigateOptions = {}): Promise<NavigationMode> {
   if (typeof window === 'undefined') {
-    return;
+    return 'hard';
   }
 
   // Guard against open-redirect: callers may pass server-supplied values
@@ -19,11 +28,13 @@ export async function navigateTo(path: string, options: NavigateOptions = {}): P
     await navigate(safePath, {
       history: options.replace ? 'replace' : 'auto'
     });
+    return 'soft';
   } catch {
     if (options.replace) {
       window.location.replace(safePath);
     } else {
       window.location.assign(safePath);
     }
+    return 'hard';
   }
 }

--- a/apps/web/src/lib/navigation.ts
+++ b/apps/web/src/lib/navigation.ts
@@ -5,11 +5,15 @@ interface NavigateOptions {
 }
 
 /**
- * `'soft'` when Astro's view-transition router handled the navigation (the
- * document is swapped in place and `transition:persist` islands survive);
- * `'hard'` when it fell back to a full page load. Callers that need to act
- * AFTER a navigation (e.g. show a toast from a persisted island) can only do
- * so on the soft path — on the hard path the page is about to unload.
+ * `'soft'` when Astro's view-transition router swapped the document in place
+ * (`transition:persist` islands survived and the page is still alive);
+ * `'hard'` when a full page load is happening instead — our own fallback, or
+ * Astro's: `navigate()` RESOLVES rather than throws on its internal hard-load
+ * paths (fetch failure, non-HTML response, missing view-transitions meta,
+ * cross-origin), so "did not throw" is not evidence of a swap. The witness is
+ * the `astro:after-swap` event. Outside a browser nothing navigates at all and
+ * the result is `'hard'`. Callers that need to act AFTER a navigation (e.g.
+ * show a toast from a persisted island) can only do so on the soft path.
  */
 export type NavigationMode = 'soft' | 'hard';
 
@@ -23,12 +27,15 @@ export async function navigateTo(path: string, options: NavigateOptions = {}): P
   // anything else falls back to '/'.
   const safePath = getSafeNext(path, '/');
 
+  let swapped = false;
+  const onSwap = () => { swapped = true; };
+  document.addEventListener('astro:after-swap', onSwap, { once: true });
   try {
     const { navigate } = await import('astro:transitions/client');
     await navigate(safePath, {
       history: options.replace ? 'replace' : 'auto'
     });
-    return 'soft';
+    return swapped ? 'soft' : 'hard';
   } catch {
     if (options.replace) {
       window.location.replace(safePath);
@@ -36,5 +43,7 @@ export async function navigateTo(path: string, options: NavigateOptions = {}): P
       window.location.assign(safePath);
     }
     return 'hard';
+  } finally {
+    document.removeEventListener('astro:after-swap', onSwap);
   }
 }

--- a/apps/web/src/lib/orgSwitch.test.ts
+++ b/apps/web/src/lib/orgSwitch.test.ts
@@ -1,5 +1,19 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import { stashSwitchToast, consumeSwitchToast, getOrgSwitchRedirect } from './orgSwitch';
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
+
+const { navigateToMock, showToastMock, selectOrganizationMock, selectAllOrgsMock } = vi.hoisted(() => ({
+  navigateToMock: vi.fn(),
+  showToastMock: vi.fn(),
+  selectOrganizationMock: vi.fn(),
+  selectAllOrgsMock: vi.fn(),
+}));
+vi.mock('./navigation', () => ({ navigateTo: navigateToMock }));
+vi.mock('../components/shared/Toast', () => ({ showToast: showToastMock }));
+vi.mock('../stores/auth', () => ({ waitForPendingRefresh: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('../stores/orgStore', () => ({
+  useOrgStore: { getState: () => ({ selectOrganization: selectOrganizationMock, selectAllOrgs: selectAllOrgsMock }) },
+}));
+
+import { stashSwitchToast, consumeSwitchToast, getOrgSwitchRedirect, applyOrgSwitch } from './orgSwitch';
 
 describe('orgSwitch toast round-trip', () => {
   beforeEach(() => sessionStorage.clear());
@@ -44,5 +58,58 @@ describe('getOrgSwitchRedirect — organization record (#5075)', () => {
   it('leaves deeper record sub-routes and the bare prefix alone', () => {
     expect(getOrgSwitchRedirect('/organizations/abc123/anything')).toBeNull();
     expect(getOrgSwitchRedirect('/organizations')).toBeNull();
+  });
+});
+
+describe('applyOrgSwitch — soft navigation instead of a full reload', () => {
+  const originalLocation = window.location;
+  function stubLocation(pathname: string, search = '', hash = '') {
+    Object.defineProperty(window, 'location', {
+      configurable: true, writable: true,
+      value: { ...originalLocation, pathname, search, hash, reload: vi.fn() },
+    });
+  }
+  beforeEach(() => {
+    sessionStorage.clear();
+    navigateToMock.mockReset().mockResolvedValue('soft');
+    showToastMock.mockReset();
+    selectOrganizationMock.mockReset();
+    selectAllOrgsMock.mockReset();
+  });
+  afterAll(() => {
+    Object.defineProperty(window, 'location', { configurable: true, writable: true, value: originalLocation });
+  });
+
+  it('re-navigates to the current path (query kept, hash dropped) via the view-transition router, replacing history', async () => {
+    stubLocation('/devices', '?view=grid', '#dev-1');
+    await applyOrgSwitch('org-b', 'Switched to B');
+    expect(selectOrganizationMock).toHaveBeenCalledWith('org-b');
+    expect(navigateToMock).toHaveBeenCalledWith('/devices?view=grid', { replace: true });
+    expect((window.location as unknown as { reload: ReturnType<typeof vi.fn> }).reload).not.toHaveBeenCalled();
+  });
+
+  it('shows the confirmation toast itself after a soft navigation (the persisted switcher never remounts)', async () => {
+    stubLocation('/devices');
+    await applyOrgSwitch(null, 'Showing all');
+    expect(selectAllOrgsMock).toHaveBeenCalled();
+    expect(showToastMock).toHaveBeenCalledWith({ type: 'success', message: 'Showing all' });
+    expect(consumeSwitchToast()).toBeNull();
+  });
+
+  it('leaves the stashed toast for the next mount when navigation fell back to a hard load', async () => {
+    navigateToMock.mockResolvedValue('hard');
+    stubLocation('/devices');
+    await applyOrgSwitch('org-b', 'Switched to B');
+    expect(showToastMock).not.toHaveBeenCalled();
+    expect(consumeSwitchToast()).toBe('Switched to B');
+  });
+
+  it('redirects detail routes up to their list, and honours an explicit destination without replacing history', async () => {
+    stubLocation('/devices/dev-1');
+    await applyOrgSwitch('org-b', 'x');
+    expect(navigateToMock).toHaveBeenLastCalledWith('/devices', { replace: true });
+
+    await applyOrgSwitch('org-b', 'x', '/dashboard');
+    expect(navigateToMock).toHaveBeenLastCalledWith('/dashboard', { replace: false });
   });
 });

--- a/apps/web/src/lib/orgSwitch.ts
+++ b/apps/web/src/lib/orgSwitch.ts
@@ -19,7 +19,8 @@ export function stashSwitchToast(message: string) {
   }
 }
 
-/** Pop the stashed confirmation (if any) after a reload. */
+/** Pop the stashed confirmation (if any). Fired from OrgSwitcher's mount after
+ *  a hard load, and by applyOrgSwitch itself once a soft navigation settles. */
 export function consumeSwitchToast(): string | null {
   try {
     const message = sessionStorage.getItem(SWITCH_TOAST_KEY);
@@ -34,7 +35,7 @@ export function consumeSwitchToast(): string | null {
  * When switching organizations, certain detail-view routes show data scoped to
  * the previous org and would render blank or 404 under the new org. For those
  * routes we navigate up to the list view in the destination org instead of
- * reloading the now-inaccessible URL.
+ * re-navigating to the now-inaccessible URL.
  *
  * Returns the destination URL when redirection is needed, otherwise null
  * (meaning the caller should keep the current path and just re-navigate).
@@ -50,7 +51,7 @@ export function getOrgSwitchRedirect(pathname: string): string | null {
     }
   }
   // /organizations/:id (the org RECORD) -> the organizations list. The record's
-  // subject is the org in the URL, so reloading it after a switch would leave
+  // subject is the org in the URL, so re-navigating to it after a switch would leave
   // the user on the customer they just switched away from (#5075).
   if (/^\/organizations\/[^/]+\/?$/.test(pathname)) {
     return '/settings/organizations';
@@ -96,7 +97,7 @@ export async function applyOrgSwitch(
     ?? getOrgSwitchRedirect(window.location.pathname)
     ?? `${window.location.pathname}${window.location.search}`;
   const mode = await navigateTo(target, { replace: !destination });
-  if (mode !== 'soft') return; // page is unloading; the next mount pops the stash
+  if (mode !== 'soft') return; // a full load is under way; the next mount pops the stash
   // The persisted switcher never remounts on a soft navigation, so its
   // mount-time consume would never fire — surface the confirmation here.
   const message = consumeSwitchToast();

--- a/apps/web/src/lib/orgSwitch.ts
+++ b/apps/web/src/lib/orgSwitch.ts
@@ -1,9 +1,13 @@
 import { useOrgStore } from '../stores/orgStore';
 import { waitForPendingRefresh } from '../stores/auth';
+import { navigateTo } from './navigation';
+import { showToast } from '../components/shared/Toast';
 
-// Switching org/scope reloads the page. Stash a confirmation message so the
-// destination page can surface "Switched to X" after the reload, landing the
-// peak-end of every context switch on a clear success rather than a blank flash.
+// Switching org/scope re-navigates the page. Stash a confirmation message so
+// the destination page can surface "Switched to X" if that navigation turns
+// out to be a full reload (the router fallback), landing the peak-end of every
+// context switch on a clear success rather than a blank flash. On the normal
+// soft path applyOrgSwitch pops the stash and shows the toast itself.
 export const SWITCH_TOAST_KEY = 'breeze.orgSwitch.toast';
 
 export function stashSwitchToast(message: string) {
@@ -33,7 +37,7 @@ export function consumeSwitchToast(): string | null {
  * reloading the now-inaccessible URL.
  *
  * Returns the destination URL when redirection is needed, otherwise null
- * (meaning the caller should keep the current path and just reload).
+ * (meaning the caller should keep the current path and just re-navigate).
  */
 export function getOrgSwitchRedirect(pathname: string): string | null {
   // /devices/:id -> /devices (but not /devices, /devices/compare, /devices/groups, etc.)
@@ -59,8 +63,19 @@ export function getOrgSwitchRedirect(pathname: string): string | null {
  * affordance (e.g. OrgRequiredState's quick-pick): set the selection (null →
  * fleet view), stash the confirmation toast, wait out any in-flight
  * /auth/refresh (#950 login-bounce race, fixed in #953/#956/#958), then
- * redirect detail routes up to their list — or reload in place — so the new
- * scope propagates everywhere at once.
+ * redirect detail routes up to their list — or re-navigate to the current
+ * path — so the new scope propagates everywhere at once.
+ *
+ * The navigation is a SOFT one through Astro's view-transition router rather
+ * than `location.reload()`: the page island is swapped and remounts under the
+ * new org (every page reads the ambient org on mount, so a remount is the
+ * propagation mechanism), while the shell islands marked `transition:persist`
+ * — sidebar, header, AI chat, toasts — stay put. Pages do not need to
+ * subscribe to the store.
+ *
+ * The in-place target drops the URL hash on purpose: the router treats a
+ * same-path navigation that carries a hash as a scroll-to-anchor and does not
+ * swap the document, and hash state (selected tab/row) is org-specific anyway.
  *
  * `destination` overrides both: for a switch that is itself a navigation ("Work
  * in this org" on the organization record hands the user their new workspace's
@@ -77,14 +92,13 @@ export async function applyOrgSwitch(
   else store.selectAllOrgs();
   stashSwitchToast(toastMessage);
   await waitForPendingRefresh();
-  if (destination) {
-    window.location.href = destination;
-    return;
-  }
-  const redirect = getOrgSwitchRedirect(window.location.pathname);
-  if (redirect) {
-    window.location.href = redirect;
-  } else {
-    window.location.reload();
-  }
+  const target = destination
+    ?? getOrgSwitchRedirect(window.location.pathname)
+    ?? `${window.location.pathname}${window.location.search}`;
+  const mode = await navigateTo(target, { replace: !destination });
+  if (mode !== 'soft') return; // page is unloading; the next mount pops the stash
+  // The persisted switcher never remounts on a soft navigation, so its
+  // mount-time consume would never fire — surface the confirmation here.
+  const message = consumeSwitchToast();
+  if (message) showToast({ type: 'success', message });
 }

--- a/apps/web/src/locales/de-DE/devices.json
+++ b/apps/web/src/locales/de-DE/devices.json
@@ -1874,6 +1874,7 @@
       "disablingMaintenance": "Wartungsmodus deaktivieren",
       "enablingMaintenance": "Wartungsmodus aktivieren"
     },
+    "refresh": "Aktualisieren",
     "selectedOrganization": "die ausgewählte Organisation",
     "subtitle": "Verwalten und überwachen Sie Ihre Flotte.",
     "title": "Geräte",

--- a/apps/web/src/locales/de-DE/devices.json
+++ b/apps/web/src/locales/de-DE/devices.json
@@ -1929,6 +1929,7 @@
       "permanentDeleteCancelled": "Endgültiges Löschen abgebrochen",
       "permanentDeleting": "{{hostname}} wird endgültig gelöscht…",
       "permanentlyDeleted": "{{hostname}} endgültig gelöscht",
+      "refreshFailed": "Geräte konnten nicht aktualisiert werden. Die angezeigte Liste ist möglicherweise veraltet.",
       "restored": "Wiederhergestellt",
       "scriptQueueFailed": "Skriptwarteschlange fehlgeschlagen",
       "scriptQueuedMany": "Skriptausführungen in die Warteschlange gestellt",

--- a/apps/web/src/locales/en/devices.json
+++ b/apps/web/src/locales/en/devices.json
@@ -1878,6 +1878,7 @@
       "disablingMaintenance": "Disabling maintenance mode",
       "enablingMaintenance": "Enabling maintenance mode"
     },
+    "refresh": "Refresh",
     "selectedOrganization": "the selected organization",
     "subtitle": "Manage and monitor your fleet.",
     "title": "Devices",

--- a/apps/web/src/locales/en/devices.json
+++ b/apps/web/src/locales/en/devices.json
@@ -1934,6 +1934,7 @@
       "permanentDeleting": "Permanently deleting {{hostname}}…",
       "permanentlyDeleted": "{{hostname}} permanently deleted",
       "queuedOfflineTail": ", {{count}} queued for offline devices",
+      "refreshFailed": "Couldn't refresh devices. The list shown may be out of date.",
       "restored": "Restored",
       "runsWhenOnline": "Runs when the device is online — expires {{date}}",
       "runsWhenOnlineNoExpiry": "Runs when the device is online",

--- a/apps/web/src/locales/es-419/devices.json
+++ b/apps/web/src/locales/es-419/devices.json
@@ -1873,6 +1873,7 @@
       "disablingMaintenance": "Desactivar el modo de mantenimiento",
       "enablingMaintenance": "Habilitar el modo de mantenimiento"
     },
+    "refresh": "Actualizar",
     "selectedOrganization": "la organización seleccionada",
     "subtitle": "Gestiona y monitoriza su flota.",
     "title": "Dispositivos",

--- a/apps/web/src/locales/es-419/devices.json
+++ b/apps/web/src/locales/es-419/devices.json
@@ -1928,6 +1928,7 @@
       "permanentDeleteCancelled": "Eliminación permanente cancelada",
       "permanentDeleting": "Eliminando permanentemente {{hostname}}…",
       "permanentlyDeleted": "{{hostname}} eliminado permanentemente",
+      "refreshFailed": "No se pudieron actualizar los dispositivos. La lista mostrada puede estar desactualizada.",
       "restored": "Restaurado",
       "scriptQueueFailed": "Error en la cola de script",
       "scriptQueuedMany": "Script en cola muchos",

--- a/apps/web/src/locales/fr-CA/devices.json
+++ b/apps/web/src/locales/fr-CA/devices.json
@@ -1873,6 +1873,7 @@
       "disablingMaintenance": "Désactivation du mode maintenance",
       "enablingMaintenance": "Activation du mode maintenance"
     },
+    "refresh": "Actualiser",
     "selectedOrganization": "L’organisation sélectionnée",
     "subtitle": "Gérez et surveillez votre flotte.",
     "title": "Dispositifs",

--- a/apps/web/src/locales/fr-CA/devices.json
+++ b/apps/web/src/locales/fr-CA/devices.json
@@ -1928,6 +1928,7 @@
       "permanentDeleteCancelled": "Suppression permanente annulée",
       "permanentDeleting": "Suppression permanente de {{hostname}} en cours…",
       "permanentlyDeleted": "{{hostname}} supprimé définitivement",
+      "refreshFailed": "Impossible d'actualiser les appareils. La liste affichée peut être périmée.",
       "restored": "Restauré",
       "scriptQueueFailed": "File d’attente de scripts échouée",
       "scriptQueuedMany": "Script en file d’attente de nombreux",

--- a/apps/web/src/locales/fr-FR/devices.json
+++ b/apps/web/src/locales/fr-FR/devices.json
@@ -1873,6 +1873,7 @@
       "disablingMaintenance": "Désactivation du mode maintenance",
       "enablingMaintenance": "Activation du mode maintenance"
     },
+    "refresh": "Actualiser",
     "selectedOrganization": "L’organisation sélectionnée",
     "subtitle": "Gérez et surveillez votre flotte.",
     "title": "Dispositifs",

--- a/apps/web/src/locales/fr-FR/devices.json
+++ b/apps/web/src/locales/fr-FR/devices.json
@@ -1928,6 +1928,7 @@
       "permanentDeleteCancelled": "Suppression permanente annulée",
       "permanentDeleting": "Suppression permanente de {{hostname}} en cours…",
       "permanentlyDeleted": "{{hostname}} supprimé définitivement",
+      "refreshFailed": "Impossible d'actualiser les appareils. La liste affichée peut être obsolète.",
       "restored": "Restauré",
       "scriptQueueFailed": "File d’attente de scripts échouée",
       "scriptQueuedMany": "Script en file d’attente de nombreux",

--- a/apps/web/src/locales/it-IT/devices.json
+++ b/apps/web/src/locales/it-IT/devices.json
@@ -1932,6 +1932,7 @@
       "permanentDeleteCancelled": "Eliminazione permanente annullata",
       "permanentDeleting": "Eliminazione permanente di {{hostname}} in corso…",
       "permanentlyDeleted": "{{hostname}} eliminato definitivamente",
+      "refreshFailed": "Impossibile aggiornare i dispositivi. L'elenco visualizzato potrebbe non essere aggiornato.",
       "restored": "Ripristinato",
       "scriptQueueFailed": "Accodamento script non riuscito",
       "scriptQueuedMany": "Script accodato per più dispositivi",

--- a/apps/web/src/locales/it-IT/devices.json
+++ b/apps/web/src/locales/it-IT/devices.json
@@ -1877,6 +1877,7 @@
       "disablingMaintenance": "Disattivazione modalità di manutenzione",
       "enablingMaintenance": "Attivazione modalità di manutenzione"
     },
+    "refresh": "Aggiorna",
     "selectedOrganization": "l'organizzazione selezionata",
     "subtitle": "Gestisci e monitora la tua flotta.",
     "title": "Dispositivi",

--- a/apps/web/src/locales/pt-BR/devices.json
+++ b/apps/web/src/locales/pt-BR/devices.json
@@ -1877,6 +1877,7 @@
       "disablingMaintenance": "Desativando o modo de manutenção",
       "enablingMaintenance": "Ativando o modo de manutenção"
     },
+    "refresh": "Atualizar",
     "selectedOrganization": "a organização selecionada",
     "subtitle": "Gerencie e monitore sua frota.",
     "title": "Dispositivos",

--- a/apps/web/src/locales/pt-BR/devices.json
+++ b/apps/web/src/locales/pt-BR/devices.json
@@ -1932,6 +1932,7 @@
       "permanentDeleteCancelled": "Exclusão permanente cancelada",
       "permanentDeleting": "Excluindo permanentemente {{hostname}}…",
       "permanentlyDeleted": "{{hostname}} excluído permanentemente",
+      "refreshFailed": "Não foi possível atualizar os dispositivos. A lista exibida pode estar desatualizada.",
       "restored": "Restaurado",
       "scriptQueueFailed": "Falha ao colocar o script na fila",
       "scriptQueuedMany": "Scripts colocados na fila",

--- a/apps/web/src/locales/tr-TR/devices.json
+++ b/apps/web/src/locales/tr-TR/devices.json
@@ -1932,6 +1932,7 @@
       "permanentDeleteCancelled": "Kalıcı Silme İptal Edildi",
       "permanentDeleting": "{{hostname}} kalıcı olarak siliniyor…",
       "permanentlyDeleted": "{{hostname}} kalıcı olarak silindi",
+      "refreshFailed": "Cihazlar yenilenemedi. Gösterilen liste güncel olmayabilir.",
       "restored": "Yenilendi",
       "scriptQueueFailed": "Komut Dosyası Sırası Başarısız",
       "scriptQueuedMany": "Komut Dosyası Çok Sayıda Sıraya Alındı",

--- a/apps/web/src/locales/tr-TR/devices.json
+++ b/apps/web/src/locales/tr-TR/devices.json
@@ -1877,6 +1877,7 @@
       "disablingMaintenance": "Bakım modunun devre dışı bırakılması",
       "enablingMaintenance": "Bakım modunu etkinleştirme"
     },
+    "refresh": "Yenile",
     "selectedOrganization": "seçilen kuruluş",
     "subtitle": "Filonuzu yönetin ve izleyin.",
     "title": "Cihazlar",


### PR DESCRIPTION
## Summary

Two changes that remove full page reloads from everyday device-list work:

1. **Refresh button on the devices list page.** A header icon button (left of the list/grid toggle) refetches devices, network assets, manual assets, orgs/sites/groups and the server-resolved advanced-filter id set. It runs through a new `background` option on `fetchDevices` that tracks a separate `refreshing` state instead of flipping `loading`, so the rendered list stays mounted (spinner on the icon, `aria-busy`, button disabled) rather than swapping to the skeleton.

2. **Org context switch via soft navigation.** `applyOrgSwitch` now re-navigates through Astro's view-transition router (`navigateTo`) instead of `window.location.reload()`. The page island remounts under the new org (the existing propagation mechanism, since every page reads the ambient org on mount) while `transition:persist` shell islands (sidebar, header, AI chat, toasts) stay put. Detail-route redirects and the explicit `destination` path are unchanged.
   - `navigateTo` returns `'soft' | 'hard'` so callers can act after a soft navigation. On the hard fallback the stashed toast is still popped by the next mount, as before.
   - The in-place target drops the URL hash: the router treats a same-path navigation carrying a hash as scroll-to-anchor and would not swap the page.
   - `OrgSwitcher` (persisted) clears its switching spinner once the navigation settles; `OrgRequiredState` likewise.

Module-level caches were checked: ticket config is partner-scoped, approximate billing totals use `skipOrgIdInjection`, neither depends on the ambient org.

## Test plan

- [x] Red-first unit tests: `DevicesPage.test.tsx` (list stays mounted mid-refetch), `navigation.test.ts` (soft/hard mode), `orgSwitch.test.ts` (target/hash/toast/redirect), `OrgSwitcher.test.tsx` (no reload, spinner clears)
- [x] `tsc` clean; `src/components/devices/DevicesPage`, `src/locales`, `src/lib/i18n`, `src/lib/navigation`, `src/lib/orgSwitch`, `src/components/layout`, `src/components/shared/OrgRequired`, `src/components/organizations`, `AuthOverlay.ssoFailureRace` suites green
- [x] Browser (wt-stack): switching org on `/devices#hash` kept a `window` marker and the sidebar DOM node alive, dropped the hash, cleared the spinner, showed one "Switched to …" toast; switching from `/devices/:id` soft-redirected to `/devices`; Refresh button refetched with the list on screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YM9qUFZV4emJFmE4MfmoSK