### PR TITLE
feat(rebuild): bare-metal recovery Linux rebuild engine (W03)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1519,8 +1519,19 @@ jobs:
       - name: Rebuild engine loopback test (root)
         if: runner.os == 'Linux'
         run: |
-          sudo apt-get install -y --no-install-recommends gdisk dosfstools e2fsprogs
-          cd agent && sudo -E env "PATH=$PATH" BREEZE_REBUILD_LOOP_TEST=1 go test -run TestRun_LoopbackRealSystem ./internal/backup/rebuild/ -v
+          set -o pipefail
+          sudo apt-get install -y --no-install-recommends gdisk dosfstools e2fsprogs xfsprogs parted util-linux udev
+          sudo udevadm settle || true
+          cd agent
+          sudo -E env "PATH=$PATH" BREEZE_REBUILD_LOOP_TEST=1 go test -count=1 -run TestRun_LoopbackRealSystem ./internal/backup/rebuild/ -v 2>&1 | tee /tmp/rebuild-loopback.log
+          # A t.Skip (missing root, missing BREEZE_REBUILD_LOOP_TEST, or a
+          # missing tool) must never read as a pass here — the whole point
+          # of this step is to prove provisioning against a real loop
+          # device, not merely that `go test` exited 0.
+          if grep -q -- '--- SKIP' /tmp/rebuild-loopback.log; then
+            echo "::error::TestRun_LoopbackRealSystem was SKIPPED, not proven — see the skip reason logged above. Fix the environment (root/BREEZE_REBUILD_LOOP_TEST/missing tool), don't let this step go green on a skip."
+            exit 1
+          fi
 
       - name: Test build-edition.sh (edition fail-closed matrix + real build)
         run: agent/scripts/build-edition_test.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1516,6 +1516,12 @@ jobs:
         working-directory: agent
         run: CGO_ENABLED=0 go test -v -coverprofile=coverage.out ./...
 
+      - name: Rebuild engine loopback test (root)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get install -y --no-install-recommends gdisk dosfstools e2fsprogs
+          cd agent && sudo -E env "PATH=$PATH" BREEZE_REBUILD_LOOP_TEST=1 go test -run TestRun_LoopbackRealSystem ./internal/backup/rebuild/ -v
+
       - name: Test build-edition.sh (edition fail-closed matrix + real build)
         run: agent/scripts/build-edition_test.sh
 

--- a/agent/cmd/breeze-backup/rebuild_cmd.go
+++ b/agent/cmd/breeze-backup/rebuild_cmd.go
@@ -43,11 +43,11 @@ func newRebuildCommand() *cobra.Command {
 				StateDir: stateDir, DryRun: dryRun, ForceReprovision: force, AllowPartialRestore: allowPartial,
 				RegenerateInitramfs: !noInitramfs, SkipBoot: skipBoot,
 				Progress: func(ph rebuild.Phase, msg string, cur, total int64) {
-					fmt.Fprintf(cmd.ErrOrStderr(), "[%s] %s", ph, msg)
+					line := fmt.Sprintf("[%s] %s", ph, msg)
 					if total > 0 {
-						fmt.Fprintf(cmd.ErrOrStderr(), " (%d/%d)", cur, total)
+						line += fmt.Sprintf(" (%d/%d)", cur, total)
 					}
-					fmt.Fprintln(cmd.ErrOrStderr())
+					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), line)
 				},
 			}
 			if markerFile != "" {

--- a/agent/cmd/breeze-backup/rebuild_cmd.go
+++ b/agent/cmd/breeze-backup/rebuild_cmd.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/breeze-rmm/agent/internal/backup/providers"
+	"github.com/breeze-rmm/agent/internal/backup/rebuild"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(newRebuildCommand())
+}
+
+// newRebuildCommand wires the bare-metal rebuild engine (agent/internal/
+// backup/rebuild) to the CLI. W04 (the boot-media console) adds
+// --token/--server (a bootstrap-driven provider) on top of this command;
+// this wave's provider comes from a JSON file in the same {provider,
+// providerConfig} shape the backup_run/restore command payloads carry.
+func newRebuildCommand() *cobra.Command {
+	var (
+		snapshot, target, imageSize, providerConfig, identityFlag, markerFile, resultJSON, stateDir string
+		dryRun, force, allowPartial, noInitramfs, skipBoot                                          bool
+	)
+	cmd := &cobra.Command{
+		Use:   "rebuild",
+		Short: "Rebuild a whole machine from a snapshot onto a disk or raw image (bare-metal recovery engine)",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			tgt, err := parseTargetFlag(target, imageSize)
+			if err != nil {
+				return err
+			}
+			provider, err := providerFromConfigFile(providerConfig)
+			if err != nil {
+				return err
+			}
+			opts := rebuild.Options{
+				SnapshotID: snapshot, Provider: provider, Target: tgt, Identity: rebuild.IdentityMode(identityFlag),
+				StateDir: stateDir, DryRun: dryRun, ForceReprovision: force, AllowPartialRestore: allowPartial,
+				RegenerateInitramfs: !noInitramfs, SkipBoot: skipBoot,
+				Progress: func(ph rebuild.Phase, msg string, cur, total int64) {
+					fmt.Fprintf(cmd.ErrOrStderr(), "[%s] %s", ph, msg)
+					if total > 0 {
+						fmt.Fprintf(cmd.ErrOrStderr(), " (%d/%d)", cur, total)
+					}
+					fmt.Fprintln(cmd.ErrOrStderr())
+				},
+			}
+			if markerFile != "" {
+				var m rebuild.Marker
+				b, err := os.ReadFile(markerFile)
+				if err != nil {
+					return err
+				}
+				if err := json.Unmarshal(b, &m); err != nil || m.RecoveryID == "" || m.Nonce == "" {
+					return fmt.Errorf("marker file must be JSON {\"recoveryId\",\"nonce\"}: %v", err)
+				}
+				opts.Marker = &m
+			}
+			ctx, stop := recoveryContext()
+			defer stop()
+			res, runErr := rebuild.Run(ctx, opts)
+			if res != nil {
+				encoded, _ := json.MarshalIndent(res, "", "  ")
+				_, _ = cmd.OutOrStdout().Write(append(encoded, '\n'))
+				if resultJSON != "" {
+					_ = os.WriteFile(resultJSON, encoded, 0o600)
+				}
+			}
+			return runErr
+		},
+	}
+	cmd.Flags().StringVar(&snapshot, "snapshot", "", "snapshot id")
+	cmd.Flags().StringVar(&target, "target", "", "disk:/dev/sdX or image:/path/to/file.img")
+	cmd.Flags().StringVar(&imageSize, "image-size", "", "size for a new image file, e.g. 40G")
+	cmd.Flags().StringVar(&providerConfig, "provider-config", "", "JSON file {provider, providerConfig}")
+	cmd.Flags().StringVar(&identityFlag, "identity", "original", "original|new")
+	cmd.Flags().StringVar(&markerFile, "marker-file", "", "JSON {recoveryId, nonce} for original identity")
+	cmd.Flags().StringVar(&resultJSON, "result-json", "", "write the result JSON here as well as stdout")
+	cmd.Flags().StringVar(&stateDir, "state-dir", "", "engine state dir (default /var/lib/breeze/rebuild)")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "preflight only; print the plan")
+	cmd.Flags().BoolVar(&force, "force-reprovision", false, "discard resume state and start from provisioning")
+	cmd.Flags().BoolVar(&allowPartial, "allow-partial", false, "continue when some files fail to restore")
+	cmd.Flags().BoolVar(&noInitramfs, "no-initramfs", false, "do not regenerate the initramfs")
+	cmd.Flags().BoolVar(&skipBoot, "skip-boot", false, "tests only: skip bootloader installation")
+	_ = cmd.MarkFlagRequired("snapshot")
+	_ = cmd.MarkFlagRequired("target")
+	_ = cmd.MarkFlagRequired("provider-config")
+	return cmd
+}
+
+// providerFromConfigFile reads path as JSON {"provider":..., "providerConfig":{...}}
+// — the same shape a backup_run/restore command payload carries — and
+// resolves it to a provider via restoreProviderFromPayload (exec_backup.go),
+// so the rebuild CLI never duplicates that provider-construction logic.
+func providerFromConfigFile(path string) (providers.BackupProvider, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read --provider-config: %w", err)
+	}
+	provider, err := restoreProviderFromPayload(data)
+	if err != nil {
+		return nil, err
+	}
+	if provider == nil {
+		return nil, fmt.Errorf("--provider-config %s did not resolve to a provider (missing provider/providerConfig)", path)
+	}
+	return provider, nil
+}
+
+// parseTargetFlag parses --target "disk:<device>" or "image:<file>" plus an
+// optional --image-size for the image form.
+func parseTargetFlag(v, size string) (rebuild.Target, error) {
+	kind, p, ok := strings.Cut(v, ":")
+	if !ok || p == "" {
+		return rebuild.Target{}, fmt.Errorf("--target must be disk:<device> or image:<file>, got %q", v)
+	}
+	switch kind {
+	case "disk":
+		return rebuild.Target{Kind: rebuild.TargetDisk, Path: p}, nil
+	case "image":
+		t := rebuild.Target{Kind: rebuild.TargetImage, Path: p}
+		if size != "" {
+			n, err := parseSize(size)
+			if err != nil {
+				return rebuild.Target{}, err
+			}
+			t.ImageSizeBytes = n
+		}
+		return t, nil
+	}
+	return rebuild.Target{}, fmt.Errorf("unsupported target kind %q (disk|image)", kind)
+}
+
+// parseSize parses a human size like "40G", "512M", "1T", or a plain byte
+// count, returning bytes.
+func parseSize(s string) (int64, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, fmt.Errorf("empty size")
+	}
+	mult := int64(1)
+	unit := s[len(s)-1]
+	numPart := s
+	switch unit {
+	case 'K', 'k':
+		mult = 1 << 10
+		numPart = s[:len(s)-1]
+	case 'M', 'm':
+		mult = 1 << 20
+		numPart = s[:len(s)-1]
+	case 'G', 'g':
+		mult = 1 << 30
+		numPart = s[:len(s)-1]
+	case 'T', 't':
+		mult = 1 << 40
+		numPart = s[:len(s)-1]
+	}
+	n, err := strconv.ParseInt(numPart, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid size %q: %w", s, err)
+	}
+	if n < 0 {
+		return 0, fmt.Errorf("invalid size %q: must not be negative", s)
+	}
+	return n * mult, nil
+}

--- a/agent/cmd/breeze-backup/rebuild_cmd_test.go
+++ b/agent/cmd/breeze-backup/rebuild_cmd_test.go
@@ -58,7 +58,9 @@ func TestRebuildCommand_DryRunWritesResultJSON(t *testing.T) {
 	}
 	dir := t.TempDir()
 	provFile := filepath.Join(dir, "prov.json")
-	os.WriteFile(provFile, []byte(`{"provider":"local","providerConfig":{"path":"`+filepath.Join(dir, "store")+`"}}`), 0o600)
+	if err := os.WriteFile(provFile, []byte(`{"provider":"local","providerConfig":{"path":"`+filepath.Join(dir, "store")+`"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	// No snapshot seeded — this only asserts the wiring: an unknown snapshot
 	// yields a refused result written to --result-json, and a non-nil error.
 	out := filepath.Join(dir, "result.json")

--- a/agent/cmd/breeze-backup/rebuild_cmd_test.go
+++ b/agent/cmd/breeze-backup/rebuild_cmd_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/backup/rebuild"
+)
+
+func TestParseTargetFlag(t *testing.T) {
+	for _, tt := range []struct {
+		in, size string
+		want     rebuild.Target
+		wantErr  bool
+	}{
+		{"disk:/dev/sdb", "", rebuild.Target{Kind: rebuild.TargetDisk, Path: "/dev/sdb"}, false},
+		{"image:/tmp/x.img", "40G", rebuild.Target{Kind: rebuild.TargetImage, Path: "/tmp/x.img", ImageSizeBytes: 40 << 30}, false},
+		{"image:/tmp/x.img", "512M", rebuild.Target{Kind: rebuild.TargetImage, Path: "/tmp/x.img", ImageSizeBytes: 512 << 20}, false},
+		{"/dev/sdb", "", rebuild.Target{}, true},
+		{"vhdx:/x", "", rebuild.Target{}, true},
+		{"image:/tmp/x.img", "lots", rebuild.Target{}, true},
+	} {
+		got, err := parseTargetFlag(tt.in, tt.size)
+		if (err != nil) != tt.wantErr || got != tt.want {
+			t.Errorf("%s/%s = %+v err=%v", tt.in, tt.size, got, err)
+		}
+	}
+}
+
+func TestParseSize(t *testing.T) {
+	for _, tt := range []struct {
+		in      string
+		want    int64
+		wantErr bool
+	}{
+		{"40G", 40 << 30, false},
+		{"512M", 512 << 20, false},
+		{"1T", 1 << 40, false},
+		{"1024", 1024, false},
+		{"", 0, true},
+		{"lots", 0, true},
+		{"-5G", 0, true},
+	} {
+		got, err := parseSize(tt.in)
+		if (err != nil) != tt.wantErr || got != tt.want {
+			t.Errorf("%q = %d err=%v", tt.in, got, err)
+		}
+	}
+}
+
+func TestRebuildCommand_DryRunWritesResultJSON(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("rebuild engine host is Linux-only")
+	}
+	dir := t.TempDir()
+	provFile := filepath.Join(dir, "prov.json")
+	os.WriteFile(provFile, []byte(`{"provider":"local","providerConfig":{"path":"`+filepath.Join(dir, "store")+`"}}`), 0o600)
+	// No snapshot seeded — this only asserts the wiring: an unknown snapshot
+	// yields a refused result written to --result-json, and a non-nil error.
+	out := filepath.Join(dir, "result.json")
+	cmd := newRebuildCommand()
+	cmd.SetArgs([]string{"--snapshot", "nope", "--target", "image:" + filepath.Join(dir, "t.img"), "--image-size", "1G", "--provider-config", provFile, "--identity", "new", "--dry-run", "--result-json", out, "--state-dir", dir})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for missing snapshot")
+	}
+	b, rerr := os.ReadFile(out)
+	if rerr != nil {
+		t.Fatalf("result file missing: %v", rerr)
+	}
+	var res rebuild.Result
+	if json.Unmarshal(b, &res) != nil || res.Status != "refused" || !strings.Contains(res.Refusal, "no disk layout was captured") {
+		t.Fatalf("result = %s", b)
+	}
+}
+
+func TestRebuildCommand_RequiresFlags(t *testing.T) {
+	cmd := newRebuildCommand()
+	cmd.SetArgs([]string{})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected an error for missing required flags")
+	}
+}

--- a/agent/internal/backup/bmr/download_system_state.go
+++ b/agent/internal/backup/bmr/download_system_state.go
@@ -45,10 +45,22 @@ func DownloadSystemState(ctx context.Context, provider providers.BackupProvider,
 	defer func() { _ = os.Remove(tmpPath) }()
 
 	if dlErr := provider.Download(stateManifestKey, tmpPath); dlErr != nil {
-		if expect {
-			return nil, nil, fmt.Errorf("bmr: snapshot advertises system state but system-state/manifest.json is missing: %w", dlErr)
+		// ErrNoSystemState means "this snapshot never captured system
+		// state" — a legitimate, common outcome preflight treats as a soft
+		// warning. That can ONLY be concluded when the provider positively
+		// confirms the object doesn't exist (errors.Is ErrObjectNotFound —
+		// see its doc comment). Any other error (timeout, auth failure,
+		// network blip, ...) is NOT "confirmed absent": returning the
+		// sentinel for it would make preflight silently proceed into
+		// destructive phases after a mere transport failure, exactly the
+		// fail-open bug ErrObjectNotFound exists to prevent.
+		if errors.Is(dlErr, providers.ErrObjectNotFound) {
+			if expect {
+				return nil, nil, fmt.Errorf("bmr: snapshot advertises system state but system-state/manifest.json is missing: %w", dlErr)
+			}
+			return nil, nil, ErrNoSystemState
 		}
-		return nil, nil, ErrNoSystemState
+		return nil, nil, fmt.Errorf("bmr: download system-state manifest: %w", dlErr)
 	}
 
 	data, readErr := os.ReadFile(tmpPath)

--- a/agent/internal/backup/bmr/download_system_state.go
+++ b/agent/internal/backup/bmr/download_system_state.go
@@ -1,0 +1,109 @@
+package bmr
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/breeze-rmm/agent/internal/backup/providers"
+	"github.com/breeze-rmm/agent/internal/backup/systemstate"
+)
+
+// ErrNoSystemState is returned by DownloadSystemState when
+// snapshots/<id>/system-state/manifest.json does not exist and expect was
+// false — "this snapshot never captured system state", not an error.
+var ErrNoSystemState = errors.New("bmr: no system state found in snapshot")
+
+// DownloadSystemState fetches snapshots/<id>/system-state/manifest.json and
+// every artifact into stagingDir, verifying each checksum before returning.
+//
+// Unlike applySystemState's artifact loop (best-effort: a bad artifact is
+// discarded and logged as a warning so a live recovery still applies
+// whatever it can), DownloadSystemState fails hard on the FIRST verification
+// problem it hits. It exists for callers — the rebuild engine's preflight
+// phase — whose whole point is to refuse before any write happens, never to
+// silently proceed past a corrupted artifact. expect=true makes a missing
+// manifest a hard error (the caller already knows the snapshot advertises
+// system state, e.g. via layout/bootstrap metadata); expect=false returns
+// the sentinel ErrNoSystemState so the caller can treat "nothing to
+// restore" as a soft outcome. The caller owns stagingDir — it is neither
+// created nor removed here.
+func DownloadSystemState(ctx context.Context, provider providers.BackupProvider, snapshotID string, expect bool, stagingDir string) (*systemstate.SystemStateManifest, []string, error) {
+	stateManifestKey := path.Join(snapshotRootDir, snapshotID, systemStatePath, "manifest.json")
+
+	tmpFile, tmpErr := os.CreateTemp("", "bmr-state-manifest-*.json")
+	if tmpErr != nil {
+		return nil, nil, fmt.Errorf("bmr: create temp: %w", tmpErr)
+	}
+	tmpPath := tmpFile.Name()
+	_ = tmpFile.Close()
+	defer os.Remove(tmpPath)
+
+	if dlErr := provider.Download(stateManifestKey, tmpPath); dlErr != nil {
+		if expect {
+			return nil, nil, fmt.Errorf("bmr: snapshot advertises system state but system-state/manifest.json is missing: %w", dlErr)
+		}
+		return nil, nil, ErrNoSystemState
+	}
+
+	data, readErr := os.ReadFile(tmpPath)
+	if readErr != nil {
+		return nil, nil, fmt.Errorf("bmr: read state manifest: %w", readErr)
+	}
+	var stateManifest systemstate.SystemStateManifest
+	if err := json.Unmarshal(data, &stateManifest); err != nil {
+		return nil, nil, fmt.Errorf("bmr: decode state manifest: %w", err)
+	}
+
+	var warnings []string
+	if blocking := intersectStrings(stateManifest.RequiredSteps, stateManifest.IncompleteSteps); len(blocking) > 0 {
+		return nil, nil, fmt.Errorf("bmr: required system-state steps incomplete: %s", strings.Join(blocking, ", "))
+	}
+	if nonRequired := subtractStrings(stateManifest.IncompleteSteps, stateManifest.RequiredSteps); len(nonRequired) > 0 {
+		warnings = append(warnings, fmt.Sprintf("system state capture incomplete for non-required steps: %s", strings.Join(nonRequired, ", ")))
+	}
+	if expect && len(stateManifest.Artifacts) == 0 {
+		return nil, nil, fmt.Errorf("bmr: system-state manifest has no artifacts")
+	}
+
+	for _, artifact := range stateManifest.Artifacts {
+		if ctx != nil && ctx.Err() != nil {
+			return nil, nil, ctx.Err()
+		}
+		localPath, pathErr := resolveStagingArtifactPath(stagingDir, artifact.Path)
+		if pathErr != nil {
+			return nil, nil, fmt.Errorf("artifact %s (%s): %w", artifact.Name, artifact.Path, pathErr)
+		}
+		if mkErr := os.MkdirAll(filepath.Dir(localPath), 0o750); mkErr != nil {
+			return nil, nil, fmt.Errorf("artifact %s (%s): create dir: %w", artifact.Name, artifact.Path, mkErr)
+		}
+		if artifact.LinkTarget != "" {
+			if rmErr := os.Remove(localPath); rmErr != nil && !os.IsNotExist(rmErr) {
+				return nil, nil, fmt.Errorf("artifact %s (%s): clear existing path: %w", artifact.Name, artifact.Path, rmErr)
+			}
+			if symErr := symlinkFile(artifact.LinkTarget, localPath); symErr != nil {
+				return nil, nil, fmt.Errorf("artifact %s (%s): create symlink: %w", artifact.Name, artifact.Path, symErr)
+			}
+			continue
+		}
+		remoteKey := path.Join(snapshotRootDir, snapshotID, systemStatePath, artifact.Path)
+		if dlErr := provider.Download(remoteKey, localPath); dlErr != nil {
+			_ = os.Remove(localPath)
+			return nil, nil, fmt.Errorf("artifact %s (%s): download: %w", artifact.Name, artifact.Path, dlErr)
+		}
+		if verifyErr := verifyArtifactIntegrity(localPath, artifact); verifyErr != nil {
+			_ = os.Remove(localPath)
+			return nil, nil, fmt.Errorf("artifact %s (%s): %w", artifact.Name, artifact.Path, verifyErr)
+		}
+		if artifact.Checksum == "" {
+			warnings = append(warnings, fmt.Sprintf("artifact %s (%s) has no checksum (older manifest schema), unverified", artifact.Name, artifact.Path))
+		}
+		warnings = append(warnings, applyArtifactMetadata(localPath, artifact)...)
+	}
+	return &stateManifest, warnings, nil
+}

--- a/agent/internal/backup/bmr/download_system_state.go
+++ b/agent/internal/backup/bmr/download_system_state.go
@@ -42,7 +42,7 @@ func DownloadSystemState(ctx context.Context, provider providers.BackupProvider,
 	}
 	tmpPath := tmpFile.Name()
 	_ = tmpFile.Close()
-	defer os.Remove(tmpPath)
+	defer func() { _ = os.Remove(tmpPath) }()
 
 	if dlErr := provider.Download(stateManifestKey, tmpPath); dlErr != nil {
 		if expect {

--- a/agent/internal/backup/bmr/download_system_state_test.go
+++ b/agent/internal/backup/bmr/download_system_state_test.go
@@ -1,0 +1,113 @@
+package bmr
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/backup/systemstate"
+)
+
+// memStateProvider is an in-memory BackupProvider for DownloadSystemState
+// tests that need to tamper with already-"uploaded" bytes directly (a real
+// LocalProvider writes to disk, which is fine for the existing
+// applySystemState fixtures but awkward for a "corrupt this one object"
+// test).
+type memStateProvider struct{ files map[string][]byte }
+
+func (m *memStateProvider) Upload(local, remote string) error {
+	b, err := os.ReadFile(local)
+	if err != nil {
+		return err
+	}
+	m.files[remote] = b
+	return nil
+}
+func (m *memStateProvider) Download(remote, local string) error {
+	b, ok := m.files[remote]
+	if !ok {
+		return os.ErrNotExist
+	}
+	if err := os.MkdirAll(filepath.Dir(local), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(local, b, 0o600)
+}
+func (m *memStateProvider) List(prefix string) ([]string, error) {
+	var out []string
+	for k := range m.files {
+		if strings.HasPrefix(k, prefix) {
+			out = append(out, k)
+		}
+	}
+	return out, nil
+}
+func (m *memStateProvider) Delete(remote string) error { delete(m.files, remote); return nil }
+
+func stateSum(b []byte) string { h := sha256.Sum256(b); return hex.EncodeToString(h[:]) }
+
+// seedSystemStateSnapshot builds a minimal system-state/manifest.json plus
+// one artifact per entry in artifacts (path -> content) for snapshotID.
+func seedSystemStateSnapshot(t *testing.T, artifacts map[string][]byte) (*memStateProvider, string) {
+	t.Helper()
+	snapshotID := "snap-download-state"
+	p := &memStateProvider{files: map[string][]byte{}}
+	var man systemstate.SystemStateManifest
+	man.SchemaVersion = 1
+	for artifactPath, content := range artifacts {
+		key := "snapshots/" + snapshotID + "/system-state/" + artifactPath
+		p.files[key] = content
+		man.Artifacts = append(man.Artifacts, systemstate.Artifact{
+			Name: strings.SplitN(artifactPath, "/", 2)[0], Category: "test", Path: artifactPath,
+			SizeBytes: int64(len(content)), Checksum: stateSum(content),
+		})
+	}
+	data, err := json.Marshal(man)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p.files["snapshots/"+snapshotID+"/system-state/manifest.json"] = data
+	return p, snapshotID
+}
+
+func TestDownloadSystemState_VerifiesArtifacts(t *testing.T) {
+	provider, snapshotID := seedSystemStateSnapshot(t, map[string][]byte{"services/systemd.txt": []byte("ssh.service\n")})
+	dir := t.TempDir()
+	m, warnings, err := DownloadSystemState(context.Background(), provider, snapshotID, true, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(warnings) != 0 || m == nil || len(m.Artifacts) != 1 {
+		t.Fatalf("m=%+v warnings=%v", m, warnings)
+	}
+	if b, err := os.ReadFile(filepath.Join(dir, "services", "systemd.txt")); err != nil || string(b) != "ssh.service\n" {
+		t.Fatalf("artifact = %q err=%v", b, err)
+	}
+	// Tamper → error names the artifact.
+	provider.files["snapshots/"+snapshotID+"/system-state/services/systemd.txt"] = []byte("evil\n")
+	if _, _, err := DownloadSystemState(context.Background(), provider, snapshotID, true, t.TempDir()); err == nil || !strings.Contains(err.Error(), "services/systemd.txt") {
+		t.Fatalf("tamper err = %v", err)
+	}
+}
+
+func TestDownloadSystemState_NoManifest_ExpectFalse_ReturnsSentinel(t *testing.T) {
+	provider := &memStateProvider{files: map[string][]byte{}}
+	_, _, err := DownloadSystemState(context.Background(), provider, "nope", false, t.TempDir())
+	if !errors.Is(err, ErrNoSystemState) {
+		t.Fatalf("err = %v, want ErrNoSystemState", err)
+	}
+}
+
+func TestDownloadSystemState_NoManifest_ExpectTrue_Fatal(t *testing.T) {
+	provider := &memStateProvider{files: map[string][]byte{}}
+	_, _, err := DownloadSystemState(context.Background(), provider, "nope", true, t.TempDir())
+	if err == nil || errors.Is(err, ErrNoSystemState) {
+		t.Fatalf("err = %v, want a hard (non-sentinel) error", err)
+	}
+}

--- a/agent/internal/backup/bmr/download_system_state_test.go
+++ b/agent/internal/backup/bmr/download_system_state_test.go
@@ -6,11 +6,13 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/breeze-rmm/agent/internal/backup/providers"
 	"github.com/breeze-rmm/agent/internal/backup/systemstate"
 )
 
@@ -19,7 +21,14 @@ import (
 // LocalProvider writes to disk, which is fine for the existing
 // applySystemState fixtures but awkward for a "corrupt this one object"
 // test).
-type memStateProvider struct{ files map[string][]byte }
+type memStateProvider struct {
+	files map[string][]byte
+	// failErr, when set, makes every Download call return this error
+	// verbatim instead of consulting files — for asserting how
+	// DownloadSystemState classifies a transport failure (NOT a confirmed
+	// absence) differently from a genuine not-found.
+	failErr error
+}
 
 func (m *memStateProvider) Upload(local, remote string) error {
 	b, err := os.ReadFile(local)
@@ -30,9 +39,15 @@ func (m *memStateProvider) Upload(local, remote string) error {
 	return nil
 }
 func (m *memStateProvider) Download(remote, local string) error {
+	if m.failErr != nil {
+		return m.failErr
+	}
 	b, ok := m.files[remote]
 	if !ok {
-		return os.ErrNotExist
+		// Mirrors providers.LocalProvider/S3Provider: wrap with
+		// ErrObjectNotFound only when positively confirming absence — see
+		// providers.ErrObjectNotFound's doc comment.
+		return fmt.Errorf("%w: %s", providers.ErrObjectNotFound, remote)
 	}
 	if err := os.MkdirAll(filepath.Dir(local), 0o755); err != nil {
 		return err
@@ -109,5 +124,39 @@ func TestDownloadSystemState_NoManifest_ExpectTrue_Fatal(t *testing.T) {
 	_, _, err := DownloadSystemState(context.Background(), provider, "nope", true, t.TempDir())
 	if err == nil || errors.Is(err, ErrNoSystemState) {
 		t.Fatalf("err = %v, want a hard (non-sentinel) error", err)
+	}
+}
+
+// TestDownloadSystemState_ClassifiesManifestDownloadErrors proves the
+// review fix: ErrNoSystemState is returned ONLY when the provider
+// positively confirms the manifest object doesn't exist
+// (errors.Is(dlErr, providers.ErrObjectNotFound)) — never for an ordinary
+// transport failure, which preflight must refuse on rather than silently
+// treat as "no system state, proceed."
+func TestDownloadSystemState_ClassifiesManifestDownloadErrors(t *testing.T) {
+	for _, tt := range []struct {
+		name         string
+		dlErr        error
+		wantSentinel bool
+	}{
+		{"confirmed not found", fmt.Errorf("%w: manifest.json", providers.ErrObjectNotFound), true},
+		{"transport timeout", errors.New("timeout"), false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := &memStateProvider{files: map[string][]byte{}, failErr: tt.dlErr}
+			_, _, err := DownloadSystemState(context.Background(), provider, "snap", false, t.TempDir())
+			if tt.wantSentinel {
+				if !errors.Is(err, ErrNoSystemState) {
+					t.Fatalf("err = %v, want ErrNoSystemState", err)
+				}
+				return
+			}
+			if errors.Is(err, ErrNoSystemState) {
+				t.Fatalf("err = %v, must NOT be ErrNoSystemState for a transport failure", err)
+			}
+			if err == nil || !strings.Contains(err.Error(), "timeout") {
+				t.Fatalf("err = %v, want it to contain %q", err, "timeout")
+			}
+		})
 	}
 }

--- a/agent/internal/backup/bmr/exec_seam.go
+++ b/agent/internal/backup/bmr/exec_seam.go
@@ -1,0 +1,30 @@
+package bmr
+
+import (
+	"context"
+	"os/exec"
+)
+
+// runCommand executes an external command and returns its combined output.
+// It is a package-level var (rather than calling exec.Command directly)
+// purely so tests can substitute a fake instead of shelling out to real
+// apt-get/dnf/systemctl/crontab/iptables-restore/chroot. Deliberately
+// untagged (not restore_linux.go, its only real caller today): the rebuild
+// engine's cross-platform unit tests (engine_test.go, built on darwin and
+// windows too via `go test`/`go vet`) call SetRunCommandForTest below to
+// observe RestoreSystemStateOffline's `systemctl --root=…` calls, so this
+// seam and its test hook must compile everywhere even though every actual
+// production caller is Linux-only.
+var runCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, name, args...).CombinedOutput()
+}
+
+// SetRunCommandForTest swaps runCommand for the duration of a test, in this
+// package or another — see runCommand's doc comment for why a cross-package
+// caller needs this. Test-only: exported so it is callable from outside this
+// package, but every real caller is a _test.go file.
+func SetRunCommandForTest(fn func(ctx context.Context, name string, args ...string) ([]byte, error)) (restore func()) {
+	orig := runCommand
+	runCommand = fn
+	return func() { runCommand = orig }
+}

--- a/agent/internal/backup/bmr/restore_linux.go
+++ b/agent/internal/backup/bmr/restore_linux.go
@@ -9,8 +9,8 @@ import (
 	"io/fs"
 	"log/slog"
 	"os"
-	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 )
@@ -20,14 +20,6 @@ type linuxRestorer struct{}
 
 func newRestorer() Restorer {
 	return &linuxRestorer{}
-}
-
-// runCommand executes an external command and returns its combined output.
-// It is a package-level var (rather than calling exec.Command directly)
-// purely so tests can substitute a fake instead of shelling out to real
-// apt-get/dnf/systemctl/crontab/iptables-restore.
-var runCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
-	return exec.CommandContext(ctx, name, args...).CombinedOutput()
 }
 
 // etcTargetDir is where restoreEtcTree copies the staged /etc tree. It is a
@@ -51,19 +43,19 @@ func (r *linuxRestorer) RestoreSystemState(stagingDir string) error {
 	slog.Info("bmr: restoring Linux system state", "stagingDir", stagingDir)
 
 	var errs []error
-	if _, err := r.restoreEtcTree(stagingDir); err != nil {
+	if _, err := r.restoreEtcTree(stagingDir, etcTargetDir); err != nil {
 		errs = append(errs, fmt.Errorf("etc: %w", err))
 	}
 	if err := r.reinstallPackages(stagingDir); err != nil {
 		errs = append(errs, fmt.Errorf("packages: %w", err))
 	}
-	if err := r.restoreServices(stagingDir); err != nil {
+	if err := r.restoreServices(stagingDir, ""); err != nil {
 		errs = append(errs, fmt.Errorf("services: %w", err))
 	}
 	if err := r.restoreFirewall(stagingDir); err != nil {
 		errs = append(errs, fmt.Errorf("firewall: %w", err))
 	}
-	if err := r.restoreCrontabs(stagingDir); err != nil {
+	if err := r.restoreCrontabs(stagingDir, ""); err != nil {
 		errs = append(errs, fmt.Errorf("crontabs: %w", err))
 	}
 
@@ -105,7 +97,21 @@ func (r *linuxRestorer) InjectDrivers(_ string) (int, error) {
 // function provides as inert/a no-op relative to the real source machine.
 // Tracked for a systemstate follow-up; do not assume restored /etc
 // permissions are trustworthy in the meantime.
-func (r *linuxRestorer) restoreEtcTree(stagingDir string) ([]string, error) {
+func (r *linuxRestorer) restoreEtcTree(stagingDir, targetEtc string) ([]string, error) {
+	return r.restoreEtcTreeMode(stagingDir, targetEtc, true)
+}
+
+// restoreEtcTreeMode is restoreEtcTree's implementation. applyExcludes is
+// true for the live path (targetEtc is the currently-running system's real
+// /etc — etcRestoreExcludes protects that system's own identity/network
+// config from being clobbered by an older snapshot) and false for the
+// offline path (RestoreSystemStateOffline: targetEtc is a freshly
+// provisioned, not-yet-booted tree with no identity of its own to protect —
+// the source machine's fstab/machine-id/hostname/network config must land
+// there faithfully, same as every other restored file; the rebuild engine's
+// later identity phase is what mutates machine-id/hostname for a fresh
+// identity, not this exclusion list).
+func (r *linuxRestorer) restoreEtcTreeMode(stagingDir, targetEtc string, applyExcludes bool) ([]string, error) {
 	srcDir := filepath.Join(stagingDir, "etc")
 	if _, err := os.Stat(srcDir); os.IsNotExist(err) {
 		slog.Info("bmr: no etc/ artifact in staging dir, skipping /etc restore")
@@ -126,14 +132,14 @@ func (r *linuxRestorer) restoreEtcTree(stagingDir string) ([]string, error) {
 		if relPath == "." {
 			return nil
 		}
-		if isExcludedEtcPath(relPath) {
+		if applyExcludes && isExcludedEtcPath(relPath) {
 			skipped = append(skipped, relPath)
 			if d.IsDir() {
 				return fs.SkipDir
 			}
 			return nil
 		}
-		dst := filepath.Join(etcTargetDir, relPath)
+		dst := filepath.Join(targetEtc, relPath)
 		info, infoErr := d.Info() // Lstat-based: does not follow symlinks
 		if infoErr != nil {
 			copyErrs = append(copyErrs, fmt.Errorf("%s: stat: %w", relPath, infoErr))
@@ -388,8 +394,11 @@ func (r *linuxRestorer) reinstallDnf(listPath string) error {
 // restoreServices re-enables systemd services from the collector's
 // `systemctl list-unit-files --type=service` capture at
 // services/systemd.txt, restricted to units whose STATE was "enabled"
-// (parseEnabledServices in restore_linux_logic.go).
-func (r *linuxRestorer) restoreServices(stagingDir string) error {
+// (parseEnabledServices in restore_linux_logic.go). When root is non-empty
+// (an offline apply under a mounted-but-not-booted tree — see
+// RestoreSystemStateOffline), each unit is enabled via
+// `systemctl --root=<root> enable <unit>` instead of the live-system form.
+func (r *linuxRestorer) restoreServices(stagingDir, root string) error {
 	listPath := filepath.Join(stagingDir, "services", "systemd.txt")
 	if _, err := os.Stat(listPath); os.IsNotExist(err) {
 		slog.Info("bmr: no service list found in staging dir, skipping service restore")
@@ -410,7 +419,13 @@ func (r *linuxRestorer) restoreServices(stagingDir string) error {
 	var errs []error
 	enabled := 0
 	for _, svc := range services {
-		out, runErr := runCommand(context.Background(), "systemctl", "enable", svc)
+		var args []string
+		if root != "" {
+			args = []string{"--root=" + root, "enable", svc}
+		} else {
+			args = []string{"enable", svc}
+		}
+		out, runErr := runCommand(context.Background(), "systemctl", args...)
 		if runErr != nil {
 			slog.Warn("bmr: failed to enable service",
 				"service", svc, "error", runErr.Error(), "output", string(out))
@@ -451,7 +466,12 @@ func (r *linuxRestorer) restoreFirewall(stagingDir string) error {
 // collector's copy of /etc/crontab — is deliberately never restored here:
 // it lives one level above spool/, so a walk rooted at spool/ never sees
 // it, and it is redundant with the /etc tree restore anyway.
-func (r *linuxRestorer) restoreCrontabs(stagingDir string) error {
+//
+// When root is non-empty (offline apply — see RestoreSystemStateOffline),
+// there is no running crond to hand the file to via `crontab -u`, so each
+// entry is written directly into the restored tree's spool directory
+// instead of shelling out.
+func (r *linuxRestorer) restoreCrontabs(stagingDir, root string) error {
 	spoolDir := filepath.Join(stagingDir, "crontabs", "spool")
 	if _, err := os.Stat(spoolDir); os.IsNotExist(err) {
 		slog.Info("bmr: no crontab spool found in staging dir, skipping crontab restore")
@@ -475,6 +495,10 @@ func (r *linuxRestorer) restoreCrontabs(stagingDir string) error {
 		return nil
 	}
 
+	if root != "" {
+		return placeCrontabsOffline(root, entries)
+	}
+
 	var errs []error
 	restored := 0
 	for user, path := range entries {
@@ -492,6 +516,180 @@ func (r *linuxRestorer) restoreCrontabs(stagingDir string) error {
 		return fmt.Errorf("crontab restore had %d/%d error(s): %w", len(errs), len(entries), errors.Join(errs...))
 	}
 	return nil
+}
+
+// crontabsSpoolDirIsDebian reports whether the restored tree under root
+// looks like a Debian family (crontabs live at
+// /var/spool/cron/crontabs/<user>) as opposed to RHEL (/var/spool/cron/<user>
+// directly). Defaults to the Debian layout — the more common convention —
+// when neither family's own marker is present in the restored tree.
+func crontabsSpoolDirIsDebian(root string) bool {
+	_, rhelErr := os.Stat(filepath.Join(root, "usr", "sbin", "grub2-mkconfig"))
+	return rhelErr != nil
+}
+
+// placeCrontabsOffline writes each user's crontab spool file directly into
+// root's restored spool directory, mirroring what `crontab -u <user> <file>`
+// would install on a live system: mode 0600, owned by the user (uid looked
+// up from the restored /etc/passwd) and the crontab group (gid looked up
+// from the restored /etc/group) when this process can chown at all.
+func placeCrontabsOffline(root string, entries map[string]string) error {
+	debian := crontabsSpoolDirIsDebian(root)
+	gid := lookupGroupGID(root, "crontab")
+	var errs []error
+	for user, srcPath := range entries {
+		data, err := os.ReadFile(srcPath)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("read %s: %w", srcPath, err))
+			continue
+		}
+		var dst string
+		if debian {
+			dst = filepath.Join(root, "var", "spool", "cron", "crontabs", user)
+		} else {
+			dst = filepath.Join(root, "var", "spool", "cron", user)
+		}
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			errs = append(errs, fmt.Errorf("mkdir for %s: %w", user, err))
+			continue
+		}
+		if err := os.WriteFile(dst, data, 0o600); err != nil {
+			errs = append(errs, fmt.Errorf("write crontab for %s: %w", user, err))
+			continue
+		}
+		if os.Geteuid() == 0 {
+			uid := lookupPasswdUID(root, user)
+			if uid >= 0 {
+				if err := os.Lchown(dst, uid, gid); err != nil {
+					slog.Warn("bmr: failed to chown offline crontab", "user", user, "path", dst, "error", err.Error())
+				}
+			}
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("place %d/%d offline crontab(s) had errors: %w", len(errs), len(entries), errors.Join(errs...))
+	}
+	return nil
+}
+
+// lookupPasswdUID returns the uid for user from root's restored
+// /etc/passwd, or -1 when not found or unreadable.
+func lookupPasswdUID(root, user string) int {
+	data, err := os.ReadFile(filepath.Join(root, "etc", "passwd"))
+	if err != nil {
+		return -1
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Split(line, ":")
+		if len(fields) >= 3 && fields[0] == user {
+			uid, err := strconv.Atoi(fields[2])
+			if err != nil {
+				return -1
+			}
+			return uid
+		}
+	}
+	return -1
+}
+
+// lookupGroupGID returns the gid for group name from root's restored
+// /etc/group, or 0 when not found or unreadable.
+func lookupGroupGID(root, name string) int {
+	data, err := os.ReadFile(filepath.Join(root, "etc", "group"))
+	if err != nil {
+		return 0
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Split(line, ":")
+		if len(fields) >= 3 && fields[0] == name {
+			gid, err := strconv.Atoi(fields[2])
+			if err != nil {
+				return 0
+			}
+			return gid
+		}
+	}
+	return 0
+}
+
+// restoreFirewallOffline stages firewall/iptables.rules into the restored
+// tree under root instead of running iptables-restore against the live
+// kernel netfilter table (there is none for a not-yet-booted tree). When the
+// tree has iptables-persistent (netfilter-persistent or iptables-restore
+// under usr/sbin), the rules land where that service reads them on first
+// boot; otherwise they're staged at a Breeze-owned recovery path and the
+// returned warning tells the operator where to find them.
+func (r *linuxRestorer) restoreFirewallOffline(stagingDir, root string) (string, error) {
+	rulesPath := filepath.Join(stagingDir, "firewall", "iptables.rules")
+	data, err := os.ReadFile(rulesPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("read %s: %w", rulesPath, err)
+	}
+
+	hasPersistent := fileExistsOffline(filepath.Join(root, "usr", "sbin", "netfilter-persistent")) ||
+		fileExistsOffline(filepath.Join(root, "usr", "sbin", "iptables-restore"))
+
+	var dst, warning string
+	if hasPersistent {
+		dst = filepath.Join(root, "etc", "iptables", "rules.v4")
+	} else {
+		dst = filepath.Join(root, "etc", "breeze", "recovery", "iptables.rules")
+		warning = "firewall rules staged at /etc/breeze/recovery/iptables.rules (no iptables-persistent in the restored system)"
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return "", fmt.Errorf("mkdir for firewall rules: %w", err)
+	}
+	if err := os.WriteFile(dst, data, 0o640); err != nil {
+		return "", fmt.Errorf("write firewall rules: %w", err)
+	}
+	return warning, nil
+}
+
+func fileExistsOffline(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// RestoreSystemStateOffline applies a downloaded system state (typically the
+// output of DownloadSystemState) under root — a mounted, not-yet-booted
+// tree, as the bare-metal rebuild engine's restore phase uses it. Package
+// reinstall is deliberately skipped: the whole-machine file backup already
+// restored the package database and files, and dpkg/dnf cannot run against
+// a tree that is not booted (no running dpkg lock holder, no chroot-safe
+// postinst environment for most packages). Services are enabled via
+// `systemctl --root=<root>`; firewall rules and crontabs are placed as
+// files for the restored system's first real boot rather than applied live.
+func RestoreSystemStateOffline(ctx context.Context, root, stagingDir string) ([]string, error) {
+	if root == "" || root == "/" {
+		return nil, errors.New("offline apply requires a non-root target tree")
+	}
+	r := &linuxRestorer{}
+	var warnings []string
+	var errs []error
+	if skipped, err := r.restoreEtcTreeMode(stagingDir, filepath.Join(root, "etc"), false); err != nil {
+		errs = append(errs, fmt.Errorf("etc: %w", err))
+	} else if len(skipped) > 0 {
+		warnings = append(warnings, fmt.Sprintf("etc: skipped %d excluded path(s)", len(skipped)))
+	}
+	if _, err := os.Stat(filepath.Join(stagingDir, "packages")); err == nil {
+		warnings = append(warnings, "package reinstall skipped in offline mode (files restored from backup)")
+	}
+	if err := r.restoreServices(stagingDir, root); err != nil {
+		errs = append(errs, fmt.Errorf("services: %w", err))
+	}
+	if w, err := r.restoreFirewallOffline(stagingDir, root); err != nil {
+		errs = append(errs, fmt.Errorf("firewall: %w", err))
+	} else if w != "" {
+		warnings = append(warnings, w)
+	}
+	if err := r.restoreCrontabs(stagingDir, root); err != nil {
+		errs = append(errs, fmt.Errorf("crontabs: %w", err))
+	}
+	_ = ctx // no long-running step here needs cancellation today; kept for the call-site contract
+	return warnings, errors.Join(errs...)
 }
 
 // shellQuote wraps s in double quotes for interpolation into a `bash -c`

--- a/agent/internal/backup/bmr/restore_linux_test.go
+++ b/agent/internal/backup/bmr/restore_linux_test.go
@@ -511,3 +511,64 @@ var errTestCommandFailed = &testCommandError{"exit status 1"}
 type testCommandError struct{ msg string }
 
 func (e *testCommandError) Error() string { return e.msg }
+
+// hasCommand reports whether calls contains a recorded invocation whose
+// name+args, joined with spaces, equals full exactly.
+func hasCommand(calls []recordedCommand, full string) bool {
+	for _, c := range calls {
+		joined := strings.TrimSpace(c.name + " " + strings.Join(c.args, " "))
+		if joined == full {
+			return true
+		}
+	}
+	return false
+}
+
+func TestRestoreSystemStateOffline_AppliesUnderRootWithoutTouchingHost(t *testing.T) {
+	root := t.TempDir()
+	staging := t.TempDir()
+	mustWriteFile(t, filepath.Join(staging, "etc", "hostname"), "srv-1\n")
+	mustWriteFile(t, filepath.Join(staging, "services", "systemd.txt"), "ssh.service enabled\ncron.service enabled\n")
+	mustWriteFile(t, filepath.Join(staging, "firewall", "iptables.rules"), "*filter\nCOMMIT\n")
+	mustWriteFile(t, filepath.Join(staging, "crontabs", "spool", "root"), "* * * * * /bin/true\n")
+	mustWriteFile(t, filepath.Join(staging, "packages", "dpkg.txt"), "vim\tinstall\n")
+	mustWriteFile(t, filepath.Join(root, "etc", "passwd"), "root:x:0:0:root:/root:/bin/bash\n")
+	mustWriteFile(t, filepath.Join(root, "etc", "group"), "root:x:0:\ncrontab:x:105:\n")
+	mustWriteFile(t, filepath.Join(root, "usr", "sbin", "netfilter-persistent"), "#!/bin/sh\n")
+	recorded := fakeCommands(t, map[string]error{})
+
+	warnings, err := RestoreSystemStateOffline(context.Background(), root, staging)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b, _ := os.ReadFile(filepath.Join(root, "etc", "hostname")); string(b) != "srv-1\n" {
+		t.Errorf("etc tree not applied under root: %q", b)
+	}
+	if !hasCommand(*recorded, "systemctl --root="+root+" enable ssh.service") || !hasCommand(*recorded, "systemctl --root="+root+" enable cron.service") {
+		t.Errorf("services not enabled offline: %+v", *recorded)
+	}
+	for _, c := range *recorded {
+		if strings.HasPrefix(c.name, "iptables-restore") || c.name == "crontab" || c.name == "dpkg" || c.name == "apt-get" || c.name == "bash" {
+			t.Errorf("offline apply must not run %q against the host", c.name)
+		}
+	}
+	if b, _ := os.ReadFile(filepath.Join(root, "etc", "iptables", "rules.v4")); !strings.Contains(string(b), "COMMIT") {
+		t.Errorf("firewall rules not staged for first boot: %q", b)
+	}
+	if fi, err := os.Stat(filepath.Join(root, "var", "spool", "cron", "crontabs", "root")); err != nil || fi.Mode().Perm() != 0o600 {
+		t.Errorf("crontab not placed (err=%v mode=%v)", err, fi)
+	}
+	joined := strings.Join(warnings, "\n")
+	if !strings.Contains(joined, "package reinstall skipped") {
+		t.Errorf("warnings = %v", warnings)
+	}
+}
+
+func TestRestoreSystemStateOffline_RejectsLiveRoot(t *testing.T) {
+	if _, err := RestoreSystemStateOffline(context.Background(), "", t.TempDir()); err == nil {
+		t.Fatal("expected an error for an empty root")
+	}
+	if _, err := RestoreSystemStateOffline(context.Background(), "/", t.TempDir()); err == nil {
+		t.Fatal("expected an error for root \"/\"")
+	}
+}

--- a/agent/internal/backup/bmr/restore_offline_other.go
+++ b/agent/internal/backup/bmr/restore_offline_other.go
@@ -1,0 +1,16 @@
+//go:build !linux
+
+package bmr
+
+import (
+	"context"
+	"errors"
+)
+
+// RestoreSystemStateOffline is Linux-only in this release — the rebuild
+// engine itself (agent/internal/backup/rebuild) only ever runs on Linux
+// hosts, so this stub exists purely so the bmr package still builds (and its
+// cross-platform test doubles still compile) on darwin/windows.
+func RestoreSystemStateOffline(_ context.Context, _, _ string) ([]string, error) {
+	return nil, errors.New("offline system-state apply is Linux-only in this release")
+}

--- a/agent/internal/backup/rebuild/boot.go
+++ b/agent/internal/backup/rebuild/boot.go
@@ -1,0 +1,196 @@
+// Deliberately named boot.go, not boot_linux.go: Go's build tool treats a
+// "_linux" filename suffix as an IMPLICIT linux-only build constraint even
+// with no //go:build line, which would defeat the point of this file — it
+// only touches the System interface and the filesystem, so it must compile
+// and run against fakeSystem on every platform (including the darwin dev
+// machine this was written on) the same as engine.go does.
+package rebuild
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/breeze-rmm/agent/internal/backup/layout"
+)
+
+func detectBootFamily(root string) (string, error) {
+	if _, err := os.Stat(filepath.Join(root, "usr", "sbin", "update-grub")); err == nil {
+		return "debian", nil
+	}
+	if _, err := os.Stat(filepath.Join(root, "usr", "sbin", "grub2-mkconfig")); err == nil {
+		return "rhel", nil
+	}
+	return "", errors.New("restored tree has neither update-grub (Debian family) nor grub2-mkconfig (RHEL family)")
+}
+
+func bootloaderID(root string) string {
+	if data, err := os.ReadFile(filepath.Join(root, "etc", "os-release")); err == nil {
+		for _, line := range strings.Split(string(data), "\n") {
+			if k, v, ok := strings.Cut(line, "="); ok && k == "ID" {
+				if id := strings.Trim(v, `"'`); id != "" {
+					return id
+				}
+			}
+		}
+	}
+	// No (or unreadable) os-release: fall back to whatever distro directory
+	// the restored EFI System Partition already has under EFI/ — that's the
+	// real installed bootloader-id from the source machine (grub-install
+	// --bootloader-id=<id> names EFI/<id>/), so reusing it keeps
+	// grub-install idempotent instead of installing a second "linux"
+	// directory alongside it.
+	if entries, err := os.ReadDir(filepath.Join(root, "boot", "efi", "EFI")); err == nil {
+		var found string
+		for _, e := range entries {
+			if !e.IsDir() || strings.EqualFold(e.Name(), "BOOT") {
+				continue
+			}
+			if found != "" {
+				found = "" // more than one candidate — ambiguous, don't guess
+				break
+			}
+			found = e.Name()
+		}
+		if found != "" {
+			return found
+		}
+	}
+	return "linux"
+}
+
+func grubTarget(arch string) (target, efiFile string) {
+	if arch == "arm64" {
+		return "arm64-efi", "BOOTAA64.EFI"
+	}
+	return "x86_64-efi", "BOOTX64.EFI"
+}
+
+var pseudoMounts = []string{"/dev", "/dev/pts", "/proc", "/sys", "/run"}
+
+func boot(ctx context.Context, r *run) error {
+	if r.opts.SkipBoot {
+		r.warn("boot phase skipped by request (SkipBoot)")
+		return nil
+	}
+	family, err := detectBootFamily(r.staging)
+	if err != nil {
+		return err
+	}
+	for _, m := range pseudoMounts {
+		dir := filepath.Join(r.staging, filepath.FromSlash(strings.TrimPrefix(m, "/")))
+		if err := r.sys.BindMount(ctx, m, dir); err != nil {
+			return err
+		}
+		r.mounts = append(r.mounts, dir)
+	}
+	efivars := "/sys/firmware/efi/efivars"
+	haveNVRAM := false
+	if fi, err := os.Stat(efivars); err == nil && fi.IsDir() && r.opts.Target.Kind == TargetDisk {
+		if err := r.sys.BindMount(ctx, efivars, filepath.Join(r.staging, "sys", "firmware", "efi", "efivars")); err == nil {
+			r.mounts = append(r.mounts, filepath.Join(r.staging, "sys", "firmware", "efi", "efivars"))
+			haveNVRAM = true
+		}
+	}
+	inRoot := r.sys.Chroot(r.staging)
+	target, efiFile := grubTarget(r.sys.Arch())
+	id := bootloaderID(r.staging)
+	switch family {
+	case "debian":
+		args := []string{"--target=" + target, "--efi-directory=/boot/efi", "--bootloader-id=" + id, "--recheck"}
+		if !haveNVRAM {
+			args = append(args, "--no-nvram")
+		}
+		args = append(args, "--force-extra-removable")
+		if out, err := inRoot(ctx, "grub-install", args...); err != nil {
+			// Older grub without the Debian-only flag: retry without it.
+			if strings.Contains(string(out), "unrecognized option") || strings.Contains(string(out), "force-extra-removable") {
+				if out2, err2 := inRoot(ctx, "grub-install", args[:len(args)-1]...); err2 != nil {
+					return fmt.Errorf("grub-install: %s: %w", strings.TrimSpace(string(out2)), err2)
+				}
+			} else {
+				return fmt.Errorf("grub-install: %s: %w", strings.TrimSpace(string(out)), err)
+			}
+		}
+		if out, err := inRoot(ctx, "update-grub"); err != nil {
+			return fmt.Errorf("update-grub: %s: %w", strings.TrimSpace(string(out)), err)
+		}
+		if r.opts.RegenerateInitramfs {
+			if out, err := inRoot(ctx, "update-initramfs", "-u", "-k", "all"); err != nil {
+				r.warn("update-initramfs failed (the restored initramfs is kept): %s", strings.TrimSpace(string(out)))
+			}
+		}
+	case "rhel":
+		cfg := "/boot/grub2/grub.cfg"
+		if _, err := os.Stat(filepath.Join(r.staging, "boot", "efi", "EFI", id, "grub.cfg")); err == nil {
+			if _, err := os.Stat(filepath.Join(r.staging, "boot", "grub2", "grub.cfg")); err != nil {
+				cfg = "/boot/efi/EFI/" + id + "/grub.cfg"
+			}
+		}
+		if out, err := inRoot(ctx, "grub2-mkconfig", "-o", cfg); err != nil {
+			return fmt.Errorf("grub2-mkconfig: %s: %w", strings.TrimSpace(string(out)), err)
+		}
+		if r.opts.RegenerateInitramfs {
+			if out, err := inRoot(ctx, "dracut", "--regenerate-all", "--force"); err != nil {
+				r.warn("dracut failed (the restored initramfs is kept): %s", strings.TrimSpace(string(out)))
+			}
+		}
+		if haveNVRAM {
+			efiNum := 0
+			for _, p := range r.result.Plan.Partitions {
+				if p.Role == layout.RoleEFI {
+					efiNum = p.Number
+				}
+			}
+			loader := `\EFI\` + id + `\shimx64.efi`
+			if r.sys.Arch() == "arm64" {
+				loader = `\EFI\` + id + `\shimaa64.efi`
+			}
+			if out, err := r.sys.Run(ctx, "efibootmgr", "--create", "--disk", r.disk, "--part", strconv.Itoa(efiNum), "--label", id, "--loader", loader); err != nil {
+				r.warn("efibootmgr entry not created (firmware fallback path will be used): %s", strings.TrimSpace(string(out)))
+			}
+		}
+	}
+	// Fallback boot path: firmware with empty NVRAM (fresh VM, replaced board)
+	// boots EFI/BOOT/BOOT<ARCH>.EFI. Ensure it exists.
+	efiBoot := filepath.Join(r.staging, "boot", "efi", "EFI", "BOOT")
+	if _, err := os.Stat(filepath.Join(efiBoot, efiFile)); err != nil {
+		distroDir := filepath.Join(r.staging, "boot", "efi", "EFI", id)
+		for _, cand := range []string{"shimx64.efi", "shimaa64.efi", "grubx64.efi", "grubaa64.efi"} {
+			if src := filepath.Join(distroDir, cand); fileExists(src) {
+				if err := copyFile(src, filepath.Join(efiBoot, efiFile)); err != nil {
+					return fmt.Errorf("install fallback bootloader: %w", err)
+				}
+				if strings.HasPrefix(cand, "shim") {
+					grub := strings.Replace(cand, "shim", "grub", 1)
+					_ = copyFile(filepath.Join(distroDir, grub), filepath.Join(efiBoot, grub))
+				}
+				break
+			}
+		}
+	}
+	if !fileExists(filepath.Join(efiBoot, efiFile)) {
+		return fmt.Errorf("no fallback bootloader at EFI/BOOT/%s after install", efiFile)
+	}
+	return nil
+}
+
+func fileExists(p string) bool {
+	_, err := os.Stat(p)
+	return err == nil
+}
+
+func copyFile(src, dst string) error {
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(dst, data, 0o644)
+}

--- a/agent/internal/backup/rebuild/engine.go
+++ b/agent/internal/backup/rebuild/engine.go
@@ -22,7 +22,6 @@ type runState struct {
 	SnapshotID string         `json:"snapshotId"`
 	TargetKey  string         `json:"targetKey"`
 	Plan       *Plan          `json:"plan"`
-	Disk       string         `json:"disk,omitempty"` // attached device (disk targets); images re-attach on resume
 	Completed  map[Phase]bool `json:"completed"`
 	UpdatedAt  time.Time      `json:"updatedAt"`
 }
@@ -185,14 +184,19 @@ func (r *run) loadState() {
 		}
 		r.state = &s
 		r.result.Plan = s.Plan
-		r.disk = s.Disk
+		// r.disk is deliberately NOT restored from persisted state: a
+		// TargetImage's loop device does not survive across Run() calls
+		// (teardown always detaches it, even on failure — see teardown's
+		// doc comment), so trusting a persisted device path here would mean
+		// mounting a stale or foreign loop device on resume. reattach()
+		// always re-derives it (cheap recompute for TargetDisk, a fresh
+		// AttachImage for TargetImage) whenever r.disk == "".
 	}
 }
 
 func (r *run) saveState() {
 	r.state.UpdatedAt = time.Now().UTC()
 	r.state.Plan = r.result.Plan
-	r.state.Disk = r.disk
 	if err := os.MkdirAll(filepath.Dir(r.statePath), 0o700); err != nil {
 		return
 	}

--- a/agent/internal/backup/rebuild/engine.go
+++ b/agent/internal/backup/rebuild/engine.go
@@ -1,0 +1,240 @@
+package rebuild
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/backup"
+	"github.com/breeze-rmm/agent/internal/backup/layout"
+)
+
+// runState is the engine's resumable on-disk state: which phases already
+// completed destructively (provision, restore) so a re-run after a failure
+// does not repeat them.
+type runState struct {
+	SnapshotID string         `json:"snapshotId"`
+	TargetKey  string         `json:"targetKey"`
+	Plan       *Plan          `json:"plan"`
+	Disk       string         `json:"disk,omitempty"` // attached device (disk targets); images re-attach on resume
+	Completed  map[Phase]bool `json:"completed"`
+	UpdatedAt  time.Time      `json:"updatedAt"`
+}
+
+// run carries one Run call's working state across its phase functions.
+type run struct {
+	opts      Options
+	sys       System
+	result    *Result
+	state     *runState
+	statePath string
+	disk      string       // block device under provisioning (/dev/sdb or /dev/loopN)
+	detach    func() error // image targets
+	staging   string
+	// Mounts are tracked in three groups so teardown can unmount safely
+	// AND deterministically: rootMount (the disk's root partition, mounted
+	// at r.staging itself) must always be the very LAST thing unmounted —
+	// every other mount point here is nested inside it. treeMounts (the
+	// rest of mountTree's real partition mounts — /boot, /boot/efi, ...) is
+	// unmounted first, deepest (mount order) last-appended first. mounts
+	// (boot()'s chroot-prep bind mounts: /dev, /proc, /sys, /run,
+	// optionally efivars) is unmounted next, in its own reverse order.
+	// Neither group nests inside the other, so their relative order
+	// doesn't matter for safety — only that both finish before rootMount.
+	rootMount    string
+	treeMounts   []string
+	mounts       []string // chroot-prep bind mounts, in mount order
+	stateStaging string   // downloaded system-state artifacts
+	layout       *layout.Manifest
+	manifest     *backup.Snapshot
+	warnings     []string
+}
+
+func targetKey(t Target) string {
+	h := sha256.Sum256([]byte(string(t.Kind) + ":" + t.Path))
+	return hex.EncodeToString(h[:])[:12]
+}
+
+// Run executes the seven phases (preflight, provision, restore, boot,
+// identity, encryption, validate). It returns (result, nil) on success and
+// (result, err) on refusal or failure — result is never nil once options
+// validate.
+func Run(ctx context.Context, opts Options) (*Result, error) {
+	start := time.Now()
+	if opts.SnapshotID == "" || opts.Provider == nil {
+		return nil, errors.New("rebuild: snapshot id and provider are required")
+	}
+	if opts.Target.Kind != TargetDisk && opts.Target.Kind != TargetImage {
+		return nil, fmt.Errorf("rebuild: unknown target kind %q", opts.Target.Kind)
+	}
+	if opts.Identity == "" {
+		opts.Identity = IdentityOriginal
+	}
+	if opts.StateDir == "" {
+		opts.StateDir = "/var/lib/breeze/rebuild"
+	}
+	if opts.StagingRoot == "" {
+		opts.StagingRoot = filepath.Join(opts.StateDir, "mnt", opts.SnapshotID)
+	}
+	if opts.System == nil {
+		opts.System = NewSystem()
+		if opts.System == nil {
+			return nil, ErrUnsupportedHost
+		}
+	}
+	r := &run{opts: opts, sys: opts.System, staging: opts.StagingRoot,
+		result: &Result{SnapshotID: opts.SnapshotID, Target: opts.Target, Identity: opts.Identity, Status: "failed"}}
+	r.statePath = filepath.Join(opts.StateDir, fmt.Sprintf("rebuild-%s-%s.json", opts.SnapshotID, targetKey(opts.Target)))
+	if opts.ForceReprovision {
+		_ = os.Remove(r.statePath)
+	}
+	r.loadState()
+	defer r.teardown()
+
+	type phaseFn struct {
+		phase Phase
+		fn    func(context.Context, *run) error
+	}
+	phases := []phaseFn{
+		{PhasePreflight, preflight}, {PhaseProvision, provision}, {PhaseRestore, restoreTree},
+		{PhaseBoot, boot}, {PhaseIdentity, identity}, {PhaseEncryption, encryption}, {PhaseValidate, validate},
+	}
+	for _, p := range phases {
+		r.result.PhaseReached = p.phase
+		pr := PhaseResult{Phase: p.phase, StartedAt: time.Now().UTC()}
+		if r.state.Completed[p.phase] && p.phase != PhasePreflight && p.phase != PhaseValidate {
+			pr.Status, pr.Message, pr.CompletedAt = PhaseSkipped, "already completed by an earlier run", time.Now().UTC()
+			r.result.Phases = append(r.result.Phases, pr)
+			r.result.Resumed = true
+			if p.phase == PhaseProvision || p.phase == PhaseRestore {
+				if err := r.reattach(ctx); err != nil { // mounts the already-provisioned partitions
+					return r.fail(start, pr, err)
+				}
+			}
+			continue
+		}
+		r.progress(p.phase, "starting", 0, 0)
+		err := p.fn(ctx, r)
+		pr.CompletedAt = time.Now().UTC()
+		if err != nil {
+			var ref *RefusalError
+			if errors.As(err, &ref) {
+				pr.Status, pr.Message = PhaseRefused, ref.Reason
+				r.result.Phases = append(r.result.Phases, pr)
+				r.result.Status, r.result.Refusal = "refused", ref.Reason
+				r.result.DurationMs = time.Since(start).Milliseconds()
+				return r.result, err
+			}
+			return r.fail(start, pr, err)
+		}
+		pr.Status = PhaseCompleted
+		r.result.Phases = append(r.result.Phases, pr)
+		r.state.Completed[p.phase] = true
+		if p.phase != PhasePreflight {
+			r.saveState()
+		}
+		if opts.DryRun && p.phase == PhasePreflight {
+			break
+		}
+	}
+	r.result.Status = "completed"
+	r.result.Warnings = r.warnings
+	r.result.DurationMs = time.Since(start).Milliseconds()
+	if !opts.DryRun {
+		_ = os.Remove(r.statePath)
+	}
+	return r.result, nil
+}
+
+func (r *run) fail(start time.Time, pr PhaseResult, err error) (*Result, error) {
+	pr.Status, pr.Message, pr.CompletedAt = PhaseFailed, err.Error(), time.Now().UTC()
+	r.result.Phases = append(r.result.Phases, pr)
+	r.result.Status, r.result.Error = "failed", err.Error()
+	r.result.Warnings = r.warnings
+	r.result.DurationMs = time.Since(start).Milliseconds()
+	r.saveState() // keeps completed phases for resume
+	return r.result, err
+}
+
+func (r *run) progress(ph Phase, msg string, cur, total int64) {
+	if r.opts.Progress != nil {
+		r.opts.Progress(ph, msg, cur, total)
+	}
+}
+
+func (r *run) warn(format string, args ...any) {
+	r.warnings = append(r.warnings, fmt.Sprintf(format, args...))
+}
+
+func (r *run) loadState() {
+	r.state = &runState{SnapshotID: r.opts.SnapshotID, TargetKey: targetKey(r.opts.Target), Completed: map[Phase]bool{}}
+	data, err := os.ReadFile(r.statePath)
+	if err != nil {
+		return
+	}
+	var s runState
+	if json.Unmarshal(data, &s) == nil && s.SnapshotID == r.opts.SnapshotID && s.TargetKey == r.state.TargetKey && s.Plan != nil {
+		if s.Completed == nil {
+			s.Completed = map[Phase]bool{}
+		}
+		r.state = &s
+		r.result.Plan = s.Plan
+		r.disk = s.Disk
+	}
+}
+
+func (r *run) saveState() {
+	r.state.UpdatedAt = time.Now().UTC()
+	r.state.Plan = r.result.Plan
+	r.state.Disk = r.disk
+	if err := os.MkdirAll(filepath.Dir(r.statePath), 0o700); err != nil {
+		return
+	}
+	data, _ := json.MarshalIndent(r.state, "", "  ")
+	tmp := r.statePath + ".tmp"
+	if os.WriteFile(tmp, data, 0o600) == nil {
+		_ = os.Rename(tmp, r.statePath)
+	}
+}
+
+// teardown unmounts everything (deepest first, rootMount always last —
+// see the run struct's mount-field doc comment), detaches the loop device,
+// and removes the system-state staging dir. Errors are warnings: the
+// result already carries the outcome.
+func (r *run) teardown() {
+	ctx := context.Background()
+	for i := len(r.treeMounts) - 1; i >= 0; i-- {
+		if err := r.sys.Unmount(ctx, r.treeMounts[i]); err != nil {
+			r.warn("unmount %s: %v", r.treeMounts[i], err)
+		}
+	}
+	r.treeMounts = nil
+	for i := len(r.mounts) - 1; i >= 0; i-- {
+		if err := r.sys.Unmount(ctx, r.mounts[i]); err != nil {
+			r.warn("unmount %s: %v", r.mounts[i], err)
+		}
+	}
+	r.mounts = nil
+	if r.rootMount != "" {
+		if err := r.sys.Unmount(ctx, r.rootMount); err != nil {
+			r.warn("unmount %s: %v", r.rootMount, err)
+		}
+		r.rootMount = ""
+	}
+	if r.detach != nil {
+		if err := r.detach(); err != nil {
+			r.warn("detach image: %v", err)
+		}
+		r.detach = nil
+	}
+	if r.stateStaging != "" {
+		_ = os.RemoveAll(r.stateStaging)
+		r.stateStaging = ""
+	}
+}

--- a/agent/internal/backup/rebuild/engine_test.go
+++ b/agent/internal/backup/rebuild/engine_test.go
@@ -142,7 +142,7 @@ func seedSnapshot(t *testing.T, id string, lay *layout.Manifest) *memProvider {
 	p := &memProvider{files: map[string][]byte{}}
 	content := map[string][]byte{
 		"/etc/hostname":                    []byte("srv-1\n"),
-		"/etc/fstab":                       []byte("UUID=9f7a-root / ext4 defaults 0 1\nUUID=ABCD-1234 /boot/efi vfat umask=0077 0 1\n"),
+		"/etc/fstab":                       []byte("UUID=" + testRootFSUUID + " / ext4 defaults 0 1\nUUID=ABCD-1234 /boot/efi vfat umask=0077 0 1\n"),
 		"/etc/machine-id":                  []byte("0123456789abcdef0123456789abcdef\n"),
 		"/etc/breeze/agent.yaml":           []byte("server_url: https://example.invalid\nagent_id: a1\ndevice_id: d1\nauth_token: t\n"),
 		"/etc/breeze/secrets.yaml":         []byte("auth_token: t\n"),
@@ -296,18 +296,18 @@ func TestRun_FullLinuxFlowOnFakeSystem(t *testing.T) {
 	// Provision: zap, three partitions with type GUIDs + partition GUIDs, rescan, formats with UUIDs.
 	for _, want := range []string{
 		"sgdisk --zap-all /dev/loop7",
-		"sgdisk --new=1:2048:", "--typecode=1:" + layout.GUIDEFISystem, "--partition-guid=1:1111-aaaa",
+		"sgdisk --new=1:2048:", "--typecode=1:" + layout.GUIDEFISystem, "--partition-guid=1:" + testEFIPartUUID,
 		"sgdisk --new=3:",
 		"partprobe /dev/loop7",
 		"mkfs.vfat -F 32 -i ABCD1234 /dev/loop7p1",
-		"mkfs.ext4 -F -q -U boot-uuid /dev/loop7p2",
-		"mkfs.ext4 -F -q -U 9f7a-root -L rootfs /dev/loop7p3",
+		"mkfs.ext4 -F -q -U " + testBootFSUUID + " /dev/loop7p2",
+		"mkfs.ext4 -F -q -U " + testRootFSUUID + " -L rootfs /dev/loop7p3",
 	} {
 		if !sys.has(want) && !strings.Contains(strings.Join(sys.cmds, "\n"), want) {
 			t.Errorf("missing command containing %q\n%s", want, sys.dump())
 		}
 	}
-	if sys.indexOf("sgdisk --zap-all") < 0 || sys.indexOf("mkfs.ext4 -F -q -U 9f7a-root") < sys.indexOf("partprobe") {
+	if sys.indexOf("sgdisk --zap-all") < 0 || sys.indexOf("mkfs.ext4 -F -q -U "+testRootFSUUID) < sys.indexOf("partprobe") {
 		t.Errorf("format must follow rescan\n%s", sys.dump())
 	}
 	// Mount order: root, then /boot, then /boot/efi.

--- a/agent/internal/backup/rebuild/engine_test.go
+++ b/agent/internal/backup/rebuild/engine_test.go
@@ -1,0 +1,360 @@
+package rebuild
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/backup"
+	"github.com/breeze-rmm/agent/internal/backup/bmr"
+	"github.com/breeze-rmm/agent/internal/backup/layout"
+	"github.com/breeze-rmm/agent/internal/backup/systemstate"
+)
+
+// bmrCall records one invocation through bmr's own exec seam
+// (bmr.SetRunCommandForTest). RestoreSystemStateOffline (called from
+// restoreTree during a real Run()) shells out through THAT seam, not
+// through this package's fakeSystem — a fakeSystem swapped into
+// Options.System cannot see it. TestMain below installs a package-wide
+// override for the whole test binary so nothing in this file ever risks
+// invoking a real systemctl.
+type bmrCall struct {
+	name string
+	args []string
+}
+
+var (
+	bmrCallsMu sync.Mutex
+	bmrCalls   []bmrCall
+)
+
+func TestMain(m *testing.M) {
+	bmr.SetRunCommandForTest(func(_ context.Context, name string, args ...string) ([]byte, error) {
+		bmrCallsMu.Lock()
+		bmrCalls = append(bmrCalls, bmrCall{name: name, args: args})
+		bmrCallsMu.Unlock()
+		return []byte("ok"), nil
+	})
+	os.Exit(m.Run())
+}
+
+func resetBmrCalls() {
+	bmrCallsMu.Lock()
+	bmrCalls = nil
+	bmrCallsMu.Unlock()
+}
+
+func bmrCallsSnapshot() []bmrCall {
+	bmrCallsMu.Lock()
+	defer bmrCallsMu.Unlock()
+	out := make([]bmrCall, len(bmrCalls))
+	copy(out, bmrCalls)
+	return out
+}
+
+// skipUnlessLinuxSystemState skips a full round-trip Run() test off Linux:
+// bmr.RestoreSystemStateOffline (restore_offline_other.go) is Linux-only by
+// design — same precedent as applySystemState's real restore work — so a
+// Run() that reaches the restore phase always fails off Linux regardless of
+// this package's own fakeSystem being cross-platform. Verified for real
+// against golang:1.26 on Linux; see the wave's PR description.
+func skipUnlessLinuxSystemState(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS != "linux" {
+		t.Skip("full Run() round-trip needs bmr.RestoreSystemStateOffline, which is Linux-only")
+	}
+}
+
+func hasBmrCall(calls []bmrCall, full string) bool {
+	for _, c := range calls {
+		joined := strings.TrimSpace(c.name + " " + strings.Join(c.args, " "))
+		if joined == full {
+			return true
+		}
+	}
+	return false
+}
+
+type memProvider struct{ files map[string][]byte }
+
+func (m *memProvider) Upload(local, remote string) error {
+	b, err := os.ReadFile(local)
+	if err != nil {
+		return err
+	}
+	m.files[remote] = b
+	return nil
+}
+func (m *memProvider) Download(remote, local string) error {
+	b, ok := m.files[remote]
+	if !ok {
+		return os.ErrNotExist
+	}
+	if err := os.MkdirAll(filepath.Dir(local), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(local, b, 0o600)
+}
+func (m *memProvider) List(prefix string) ([]string, error) {
+	var out []string
+	for k := range m.files {
+		if strings.HasPrefix(k, prefix) {
+			out = append(out, k)
+		}
+	}
+	return out, nil
+}
+func (m *memProvider) Delete(remote string) error { delete(m.files, remote); return nil }
+
+func sum(b []byte) string { h := sha256.Sum256(b); return hex.EncodeToString(h[:]) }
+
+// seedSnapshot builds a whole-machine-shaped snapshot: files, a symlink, the
+// restored EFI tree, fstab with the recorded UUIDs, a Debian-style
+// update-grub, plus layout.json and a system-state manifest.
+func seedSnapshot(t *testing.T, id string, lay *layout.Manifest) *memProvider {
+	t.Helper()
+	p := &memProvider{files: map[string][]byte{}}
+	content := map[string][]byte{
+		"/etc/hostname":                    []byte("srv-1\n"),
+		"/etc/fstab":                       []byte("UUID=9f7a-root / ext4 defaults 0 1\nUUID=ABCD-1234 /boot/efi vfat umask=0077 0 1\n"),
+		"/etc/machine-id":                  []byte("0123456789abcdef0123456789abcdef\n"),
+		"/etc/breeze/agent.yaml":           []byte("server_url: https://example.invalid\nagent_id: a1\ndevice_id: d1\nauth_token: t\n"),
+		"/etc/breeze/secrets.yaml":         []byte("auth_token: t\n"),
+		"/usr/sbin/update-grub":            []byte("#!/bin/sh\n"),
+		"/usr/bin/tool":                    []byte("#!/bin/sh\n"),
+		"/boot/efi/EFI/ubuntu/shimx64.efi": []byte("shim"),
+		"/boot/efi/EFI/ubuntu/grubx64.efi": []byte("grub"),
+		"/boot/efi/EFI/BOOT/BOOTX64.EFI":   []byte("shim"),
+		"/boot/grub/grub.cfg":              []byte("set default=0\n"),
+	}
+	var files []backup.SnapshotFile
+	for src, b := range content {
+		key := "snapshots/" + id + "/files/path_0" + src
+		p.files[key] = b
+		files = append(files, backup.SnapshotFile{SourcePath: src, BackupPath: key, Size: int64(len(b)), Checksum: sum(b), Mode: 0o644, ModTime: time.Now().UTC()})
+	}
+	files = append(files, backup.SnapshotFile{SourcePath: "/bin", Kind: backup.KindSymlink, LinkTarget: "usr/bin", ModTime: time.Now().UTC()})
+	man, _ := json.Marshal(backup.Snapshot{ID: id, Timestamp: time.Now().UTC(), Files: files})
+	p.files["snapshots/"+id+"/manifest.json"] = man
+	lb, _ := json.Marshal(lay)
+	p.files["snapshots/"+id+"/layout.json"] = lb
+	svc := []byte("ssh.service enabled\n")
+	p.files["snapshots/"+id+"/system-state/services/systemd.txt"] = svc
+	sm, _ := json.Marshal(systemstate.SystemStateManifest{Platform: "linux", SchemaVersion: 1, Artifacts: []systemstate.Artifact{{Name: "services", Category: "services", Path: "services/systemd.txt", SizeBytes: int64(len(svc)), Checksum: sum(svc)}}})
+	p.files["snapshots/"+id+"/system-state/manifest.json"] = sm
+	return p
+}
+
+func testLayout() *layout.Manifest {
+	d := srcDisk()
+	return &layout.Manifest{SchemaVersion: layout.SchemaVersion, Platform: "linux", BootMode: layout.BootModeUEFI, OSRelease: "Ubuntu 24.04", Hostname: "srv-1", Disks: []layout.Disk{*d}}
+}
+
+func TestRun_DryRunProducesPlanWithoutWrites(t *testing.T) {
+	dir := t.TempDir()
+	sys := newFakeSystem(dir, 100*GiB)
+	p := seedSnapshot(t, "snap-1", testLayout())
+	res, err := Run(context.Background(), Options{SnapshotID: "snap-1", Provider: p, Target: Target{Kind: TargetDisk, Path: "/dev/sdb"}, Identity: IdentityNew, StateDir: dir, StagingRoot: filepath.Join(dir, "mnt"), DryRun: true, System: sys})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != "completed" || res.Plan == nil || len(res.Plan.Partitions) != 3 || res.PhaseReached != PhasePreflight {
+		t.Fatalf("res = %+v", res)
+	}
+	for _, c := range sys.cmds {
+		if strings.HasPrefix(c, "sgdisk") || strings.HasPrefix(c, "mkfs") || strings.HasPrefix(c, "mount") {
+			t.Fatalf("dry run wrote: %s\n%s", c, sys.dump())
+		}
+	}
+}
+
+func TestRun_PreflightRefusals(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(sys *fakeSystem, p *memProvider, lay *layout.Manifest)
+		want   string
+	}{
+		{"unsupported layout", func(_ *fakeSystem, _ *memProvider, lay *layout.Manifest) { lay.BootMode = layout.BootModeBIOS }, layout.ReasonBIOSBoot},
+		{"target mounted", func(sys *fakeSystem, _ *memProvider, _ *layout.Manifest) { sys.mounted = []string{"/dev/sdb2"} }, "target disk /dev/sdb is in use"},
+		{"target is the running system", func(sys *fakeSystem, _ *memProvider, _ *layout.Manifest) { sys.rootSrcs = []string{"/dev/sdb1"} }, "running system"},
+		{"target too small", func(sys *fakeSystem, _ *memProvider, _ *layout.Manifest) { sys.diskSize = 4 * GiB }, "target is too small"},
+		{"layout schema from the future", func(_ *fakeSystem, _ *memProvider, lay *layout.Manifest) { lay.SchemaVersion = 99 }, "layout schema version 99"},
+		{"missing layout.json", func(_ *fakeSystem, p *memProvider, _ *layout.Manifest) {
+			delete(p.files, "snapshots/snap-1/layout.json")
+		}, "no disk layout was captured"},
+		{"tampered system state", func(_ *fakeSystem, p *memProvider, _ *layout.Manifest) {
+			p.files["snapshots/snap-1/system-state/services/systemd.txt"] = []byte("evil")
+		}, "services/systemd.txt"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			sys := newFakeSystem(dir, 100*GiB)
+			lay := testLayout()
+			p := seedSnapshot(t, "snap-1", lay)
+			tt.mutate(sys, p, lay)
+			lb, _ := json.Marshal(lay)
+			if _, ok := p.files["snapshots/snap-1/layout.json"]; ok {
+				p.files["snapshots/snap-1/layout.json"] = lb
+			}
+			res, err := Run(context.Background(), Options{SnapshotID: "snap-1", Provider: p, Target: Target{Kind: TargetDisk, Path: "/dev/sdb"}, Identity: IdentityNew, StateDir: dir, StagingRoot: filepath.Join(dir, "mnt"), System: sys})
+			if err == nil {
+				t.Fatalf("expected refusal, got %+v", res)
+			}
+			if res == nil || res.Status != "refused" || !strings.Contains(res.Refusal, tt.want) || res.PhaseReached != PhasePreflight {
+				t.Fatalf("res = %+v err=%v", res, err)
+			}
+			if sys.has("sgdisk") || sys.has("mkfs") {
+				t.Fatalf("refusal must not write: %s", sys.dump())
+			}
+		})
+	}
+}
+
+func phaseNames(ps []Phase) []string {
+	out := make([]string, len(ps))
+	for i, p := range ps {
+		out[i] = string(p)
+	}
+	return out
+}
+
+func TestRun_FullLinuxFlowOnFakeSystem(t *testing.T) {
+	skipUnlessLinuxSystemState(t)
+	resetBmrCalls()
+	dir := t.TempDir()
+	sys := newFakeSystem(dir, 100*GiB)
+	p := seedSnapshot(t, "snap-1", testLayout())
+	staging := filepath.Join(dir, "mnt")
+	var phases []Phase
+	res, err := Run(context.Background(), Options{
+		SnapshotID: "snap-1", Provider: p, Target: Target{Kind: TargetImage, Path: filepath.Join(dir, "t.img"), ImageSizeBytes: 100 * GiB},
+		Identity: IdentityOriginal, Marker: &Marker{RecoveryID: "rec-1", Nonce: "n-1"}, StateDir: dir, StagingRoot: staging, System: sys,
+		RegenerateInitramfs: true,
+		Progress: func(ph Phase, _ string, _, _ int64) {
+			if len(phases) == 0 || phases[len(phases)-1] != ph {
+				phases = append(phases, ph)
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("err=%v\n%s", err, sys.dump())
+	}
+	if res.Status != "completed" || res.PhaseReached != PhaseValidate || len(res.Phases) != 7 {
+		t.Fatalf("res = %+v\n%s", res, sys.dump())
+	}
+	// Provision: zap, three partitions with type GUIDs + partition GUIDs, rescan, formats with UUIDs.
+	for _, want := range []string{
+		"sgdisk --zap-all /dev/loop7",
+		"sgdisk --new=1:2048:", "--typecode=1:" + layout.GUIDEFISystem, "--partition-guid=1:1111-aaaa",
+		"sgdisk --new=3:",
+		"partprobe /dev/loop7",
+		"mkfs.vfat -F 32 -i ABCD1234 /dev/loop7p1",
+		"mkfs.ext4 -F -q -U boot-uuid /dev/loop7p2",
+		"mkfs.ext4 -F -q -U 9f7a-root -L rootfs /dev/loop7p3",
+	} {
+		if !sys.has(want) && !strings.Contains(strings.Join(sys.cmds, "\n"), want) {
+			t.Errorf("missing command containing %q\n%s", want, sys.dump())
+		}
+	}
+	if sys.indexOf("sgdisk --zap-all") < 0 || sys.indexOf("mkfs.ext4 -F -q -U 9f7a-root") < sys.indexOf("partprobe") {
+		t.Errorf("format must follow rescan\n%s", sys.dump())
+	}
+	// Mount order: root, then /boot, then /boot/efi.
+	if len(sys.mountLog) < 3 || !strings.HasSuffix(sys.mountLog[0], " "+staging) || !strings.HasSuffix(sys.mountLog[1], filepath.Join(staging, "boot")) || !strings.HasSuffix(sys.mountLog[2], filepath.Join(staging, "boot", "efi")) {
+		t.Errorf("mount order = %v", sys.mountLog)
+	}
+	// Restore landed under the staging root, including the symlink.
+	if b, err := os.ReadFile(filepath.Join(staging, "etc", "hostname")); err != nil || string(b) != "srv-1\n" {
+		t.Errorf("hostname = %q err=%v", b, err)
+	}
+	if got, err := os.Readlink(filepath.Join(staging, "bin")); err != nil || got != "usr/bin" {
+		t.Errorf("symlink = %q err=%v", got, err)
+	}
+	// System state applied offline, through bmr's own exec seam (not
+	// visible to fakeSystem — see bmrCall's doc comment above).
+	if !hasBmrCall(bmrCallsSnapshot(), "systemctl --root="+staging+" enable ssh.service") {
+		t.Errorf("services not enabled offline via bmr seam: %+v", bmrCallsSnapshot())
+	}
+	// Boot: bind mounts, grub-install in chroot with the EFI target, config regen, initramfs.
+	for _, want := range []string{
+		"mount --bind /dev " + filepath.Join(staging, "dev"),
+		"mount --bind /proc " + filepath.Join(staging, "proc"),
+		"mount --bind /sys " + filepath.Join(staging, "sys"),
+		"chroot " + staging + " grub-install --target=x86_64-efi --efi-directory=/boot/efi --bootloader-id=ubuntu --recheck --no-nvram --force-extra-removable",
+		"chroot " + staging + " update-grub",
+		"chroot " + staging + " update-initramfs -u -k all",
+	} {
+		if !sys.has(want) {
+			t.Errorf("missing %q\n%s", want, sys.dump())
+		}
+	}
+	// Identity original: marker written, machine-id untouched.
+	var marker map[string]string
+	mb, err := os.ReadFile(filepath.Join(staging, "var", "lib", "breeze", "recovery-marker.json"))
+	if err != nil || json.Unmarshal(mb, &marker) != nil || marker["recoveryId"] != "rec-1" || marker["nonce"] != "n-1" || marker["snapshotId"] != "snap-1" {
+		t.Errorf("marker = %s err=%v", mb, err)
+	}
+	if b, _ := os.ReadFile(filepath.Join(staging, "etc", "machine-id")); !strings.HasPrefix(string(b), "0123456789abcdef") {
+		t.Errorf("machine-id changed on original identity: %q", b)
+	}
+	// Validate: sync, boot/efi unmounts before its parents, loop detached, no warnings.
+	if !sys.has("sync") || len(sys.unmounts) < 3 || sys.unmounts[0] != filepath.Join(staging, "boot", "efi") || !sys.has("losetup -d /dev/loop7") {
+		t.Errorf("teardown = unmounts %v\n%s", sys.unmounts, sys.dump())
+	}
+	if res.FilesRestored < 11 || len(res.Warnings) != 0 {
+		t.Errorf("files=%d warnings=%v", res.FilesRestored, res.Warnings)
+	}
+	if strings.Join(phaseNames(phases), ",") != "preflight,provision,restore,boot,identity,encryption,validate" {
+		t.Errorf("progress phases = %v", phases)
+	}
+}
+
+func TestRun_ResumeSkipsProvisionAndReusesPlan(t *testing.T) {
+	skipUnlessLinuxSystemState(t)
+	resetBmrCalls()
+	dir := t.TempDir()
+	sys := newFakeSystem(dir, 100*GiB)
+	sys.fail["chroot"] = os.ErrPermission // first run dies in boot
+	p := seedSnapshot(t, "snap-1", testLayout())
+	opts := Options{SnapshotID: "snap-1", Provider: p, Target: Target{Kind: TargetDisk, Path: "/dev/sdb"}, Identity: IdentityNew, StateDir: dir, StagingRoot: filepath.Join(dir, "mnt"), System: sys}
+	res, err := Run(context.Background(), opts)
+	if err == nil || res.Status != "failed" || res.PhaseReached != PhaseBoot {
+		t.Fatalf("first run = %+v err=%v", res, err)
+	}
+	sys2 := newFakeSystem(dir, 100*GiB)
+	opts.System = sys2
+	res2, err := Run(context.Background(), opts)
+	if err != nil || res2.Status != "completed" || !res2.Resumed {
+		t.Fatalf("second run = %+v err=%v\n%s", res2, err, sys2.dump())
+	}
+	if sys2.has("sgdisk") || sys2.has("mkfs") {
+		t.Fatalf("resume re-provisioned the disk\n%s", sys2.dump())
+	}
+	if res2.Phases[1].Status != PhaseSkipped || res2.Phases[2].Status != PhaseSkipped {
+		t.Errorf("phases = %+v", res2.Phases)
+	}
+	// State file is removed after success.
+	if m, _ := filepath.Glob(filepath.Join(dir, "rebuild-snap-1-*.json")); len(m) != 0 {
+		t.Errorf("state file left behind: %v", m)
+	}
+}
+
+func TestRun_StrictRestoreFailsOnMissingObject(t *testing.T) {
+	dir := t.TempDir()
+	sys := newFakeSystem(dir, 100*GiB)
+	p := seedSnapshot(t, "snap-1", testLayout())
+	delete(p.files, "snapshots/snap-1/files/path_0/usr/bin/tool")
+	res, err := Run(context.Background(), Options{SnapshotID: "snap-1", Provider: p, Target: Target{Kind: TargetDisk, Path: "/dev/sdb"}, Identity: IdentityNew, StateDir: dir, StagingRoot: filepath.Join(dir, "mnt"), System: sys})
+	if err == nil || res.Status != "failed" || res.PhaseReached != PhaseRestore || !strings.Contains(res.Error, "/usr/bin/tool") {
+		t.Fatalf("res = %+v err=%v", res, err)
+	}
+}

--- a/agent/internal/backup/rebuild/engine_test.go
+++ b/agent/internal/backup/rebuild/engine_test.go
@@ -5,6 +5,8 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -16,6 +18,7 @@ import (
 	"github.com/breeze-rmm/agent/internal/backup"
 	"github.com/breeze-rmm/agent/internal/backup/bmr"
 	"github.com/breeze-rmm/agent/internal/backup/layout"
+	"github.com/breeze-rmm/agent/internal/backup/providers"
 	"github.com/breeze-rmm/agent/internal/backup/systemstate"
 )
 
@@ -83,7 +86,14 @@ func hasBmrCall(calls []bmrCall, full string) bool {
 	return false
 }
 
-type memProvider struct{ files map[string][]byte }
+type memProvider struct {
+	files map[string][]byte
+	// failKey, when set for a given remote key, makes Download return that
+	// error verbatim instead of consulting files — for simulating a
+	// transport failure (as opposed to a confirmed-absent object) on a
+	// specific object.
+	failKey map[string]error
+}
 
 func (m *memProvider) Upload(local, remote string) error {
 	b, err := os.ReadFile(local)
@@ -94,9 +104,17 @@ func (m *memProvider) Upload(local, remote string) error {
 	return nil
 }
 func (m *memProvider) Download(remote, local string) error {
+	if m.failKey != nil {
+		if err, ok := m.failKey[remote]; ok {
+			return err
+		}
+	}
 	b, ok := m.files[remote]
 	if !ok {
-		return os.ErrNotExist
+		// Mirrors providers.LocalProvider/S3Provider: wrap with
+		// ErrObjectNotFound only when positively confirming absence — see
+		// providers.ErrObjectNotFound's doc comment.
+		return fmt.Errorf("%w: %s", providers.ErrObjectNotFound, remote)
 	}
 	if err := os.MkdirAll(filepath.Dir(local), 0o755); err != nil {
 		return err
@@ -216,6 +234,30 @@ func TestRun_PreflightRefusals(t *testing.T) {
 				t.Fatalf("refusal must not write: %s", sys.dump())
 			}
 		})
+	}
+}
+
+// TestRun_PreflightRefusesOnSystemStateTransportError proves the review fix
+// for bmr.DownloadSystemState: a mere transport failure fetching
+// system-state/manifest.json (NOT a confirmed-absent object) must refuse
+// the whole run rather than being silently treated as "this snapshot has
+// no system state, proceed with files only."
+func TestRun_PreflightRefusesOnSystemStateTransportError(t *testing.T) {
+	dir := t.TempDir()
+	sys := newFakeSystem(dir, 100*GiB)
+	p := seedSnapshot(t, "snap-1", testLayout())
+	p.failKey = map[string]error{
+		"snapshots/snap-1/system-state/manifest.json": errors.New("timeout talking to storage"),
+	}
+	res, err := Run(context.Background(), Options{SnapshotID: "snap-1", Provider: p, Target: Target{Kind: TargetDisk, Path: "/dev/sdb"}, Identity: IdentityNew, StateDir: dir, StagingRoot: filepath.Join(dir, "mnt"), System: sys})
+	if err == nil {
+		t.Fatalf("expected refusal, got %+v", res)
+	}
+	if res == nil || res.Status != "refused" || !strings.Contains(res.Refusal, "system state could not be verified") || !strings.Contains(res.Refusal, "timeout talking to storage") || res.PhaseReached != PhasePreflight {
+		t.Fatalf("res = %+v err=%v", res, err)
+	}
+	if sys.has("sgdisk") || sys.has("mkfs") || sys.has("mount") {
+		t.Fatalf("refusal must not write: %s", sys.dump())
 	}
 }
 
@@ -345,6 +387,79 @@ func TestRun_ResumeSkipsProvisionAndReusesPlan(t *testing.T) {
 	// State file is removed after success.
 	if m, _ := filepath.Glob(filepath.Join(dir, "rebuild-snap-1-*.json")); len(m) != 0 {
 		t.Errorf("state file left behind: %v", m)
+	}
+}
+
+// TestRun_ResumeImageTargetReattachesLoop proves the review fix: an image
+// target's loop device does NOT survive across Run() calls (teardown always
+// detaches it on exit, even on failure), so a resumed run must re-attach a
+// FRESH loop device rather than trusting a persisted device path — which
+// could by then be stale, freed, or reused by something else entirely.
+func TestRun_ResumeImageTargetReattachesLoop(t *testing.T) {
+	skipUnlessLinuxSystemState(t)
+	resetBmrCalls()
+	dir := t.TempDir()
+	sys := newFakeSystem(dir, 100*GiB)
+	sys.fail["chroot"] = os.ErrPermission // first run dies in boot
+	p := seedSnapshot(t, "snap-1", testLayout())
+	img := filepath.Join(dir, "t.img")
+	opts := Options{SnapshotID: "snap-1", Provider: p, Target: Target{Kind: TargetImage, Path: img, ImageSizeBytes: 100 * GiB}, Identity: IdentityNew, StateDir: dir, StagingRoot: filepath.Join(dir, "mnt"), System: sys}
+	res, err := Run(context.Background(), opts)
+	if err == nil || res.Status != "failed" || res.PhaseReached != PhaseBoot {
+		t.Fatalf("first run = %+v err=%v", res, err)
+	}
+
+	sys2 := newFakeSystem(dir, 100*GiB)
+	opts.System = sys2
+	res2, err := Run(context.Background(), opts)
+	if err != nil || res2.Status != "completed" || !res2.Resumed {
+		t.Fatalf("second run = %+v err=%v\n%s", res2, err, sys2.dump())
+	}
+	if sys2.has("sgdisk") || sys2.has("mkfs") {
+		t.Fatalf("resume re-provisioned the disk\n%s", sys2.dump())
+	}
+	losetupIdx := sys2.indexOf("losetup --find --show --partscan " + img)
+	if losetupIdx < 0 {
+		t.Fatalf("resume did not re-attach the image via losetup\n%s", sys2.dump())
+	}
+	mountIdx := -1
+	for i, c := range sys2.cmds {
+		if strings.HasPrefix(c, "mount ") || strings.HasPrefix(c, "mount -") {
+			mountIdx = i
+			break
+		}
+	}
+	if mountIdx < 0 {
+		t.Fatalf("resume never mounted anything\n%s", sys2.dump())
+	}
+	if mountIdx < losetupIdx {
+		t.Fatalf("mount happened before the loop device was re-attached\n%s", sys2.dump())
+	}
+}
+
+// TestRun_ResumeDiskTargetNeverCallsLosetup is TestRun_ResumeImageTargetReattachesLoop's
+// disk-target sibling: a disk target never goes through losetup at all, on
+// a fresh run or a resumed one.
+func TestRun_ResumeDiskTargetNeverCallsLosetup(t *testing.T) {
+	skipUnlessLinuxSystemState(t)
+	resetBmrCalls()
+	dir := t.TempDir()
+	sys := newFakeSystem(dir, 100*GiB)
+	sys.fail["chroot"] = os.ErrPermission
+	p := seedSnapshot(t, "snap-1", testLayout())
+	opts := Options{SnapshotID: "snap-1", Provider: p, Target: Target{Kind: TargetDisk, Path: "/dev/sdb"}, Identity: IdentityNew, StateDir: dir, StagingRoot: filepath.Join(dir, "mnt"), System: sys}
+	if _, err := Run(context.Background(), opts); err == nil {
+		t.Fatal("expected the first run to fail in boot")
+	}
+
+	sys2 := newFakeSystem(dir, 100*GiB)
+	opts.System = sys2
+	res2, err := Run(context.Background(), opts)
+	if err != nil || res2.Status != "completed" {
+		t.Fatalf("second run = %+v err=%v\n%s", res2, err, sys2.dump())
+	}
+	if sys2.has("losetup") {
+		t.Errorf("a disk target must never call losetup\n%s", sys2.dump())
 	}
 }
 

--- a/agent/internal/backup/rebuild/fetch.go
+++ b/agent/internal/backup/rebuild/fetch.go
@@ -22,8 +22,8 @@ func fetchLayout(ctx context.Context, provider providers.BackupProvider, snapsho
 		return nil, err
 	}
 	tmpPath := tmp.Name()
-	tmp.Close()
-	defer os.Remove(tmpPath)
+	_ = tmp.Close()
+	defer func() { _ = os.Remove(tmpPath) }()
 	if err := provider.Download(path.Join("snapshots", snapshotID, "layout.json"), tmpPath); err != nil {
 		return nil, &RefusalError{Reason: layout.ReasonNilManifest + " for snapshot " + snapshotID + " (was the backup taken with the whole-machine profile?)"}
 	}
@@ -50,8 +50,8 @@ func fetchManifest(ctx context.Context, provider providers.BackupProvider, snaps
 		return nil, err
 	}
 	tmpPath := tmp.Name()
-	tmp.Close()
-	defer os.Remove(tmpPath)
+	_ = tmp.Close()
+	defer func() { _ = os.Remove(tmpPath) }()
 	if err := provider.Download(path.Join("snapshots", snapshotID, "manifest.json"), tmpPath); err != nil {
 		return nil, &RefusalError{Reason: "snapshot manifest not found for " + snapshotID}
 	}

--- a/agent/internal/backup/rebuild/fetch.go
+++ b/agent/internal/backup/rebuild/fetch.go
@@ -1,0 +1,67 @@
+package rebuild
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/breeze-rmm/agent/internal/backup"
+	"github.com/breeze-rmm/agent/internal/backup/layout"
+	"github.com/breeze-rmm/agent/internal/backup/providers"
+)
+
+// fetchLayout downloads and decodes snapshots/<id>/layout.json. A missing
+// object or an unsupported schema version is a RefusalError, not a plain
+// error — preflight surfaces it verbatim as the operator-facing refusal
+// reason.
+func fetchLayout(ctx context.Context, provider providers.BackupProvider, snapshotID string) (*layout.Manifest, error) {
+	tmp, err := os.CreateTemp("", "breeze-layout-*.json")
+	if err != nil {
+		return nil, err
+	}
+	tmpPath := tmp.Name()
+	tmp.Close()
+	defer os.Remove(tmpPath)
+	if err := provider.Download(path.Join("snapshots", snapshotID, "layout.json"), tmpPath); err != nil {
+		return nil, &RefusalError{Reason: layout.ReasonNilManifest + " for snapshot " + snapshotID + " (was the backup taken with the whole-machine profile?)"}
+	}
+	data, err := os.ReadFile(tmpPath)
+	if err != nil {
+		return nil, err
+	}
+	var m layout.Manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("decode layout.json: %w", err)
+	}
+	if m.SchemaVersion != layout.SchemaVersion {
+		return nil, &RefusalError{Reason: fmt.Sprintf("layout schema version %d is not supported by this helper (supports %d)", m.SchemaVersion, layout.SchemaVersion)}
+	}
+	return &m, nil
+}
+
+// fetchManifest downloads and decodes snapshots/<id>/manifest.json — the
+// ordinary whole-machine file backup manifest (same shape as
+// backup.downloadManifest's own snapshots/<id>/manifest.json read).
+func fetchManifest(ctx context.Context, provider providers.BackupProvider, snapshotID string) (*backup.Snapshot, error) {
+	tmp, err := os.CreateTemp("", "breeze-manifest-*.json")
+	if err != nil {
+		return nil, err
+	}
+	tmpPath := tmp.Name()
+	tmp.Close()
+	defer os.Remove(tmpPath)
+	if err := provider.Download(path.Join("snapshots", snapshotID, "manifest.json"), tmpPath); err != nil {
+		return nil, &RefusalError{Reason: "snapshot manifest not found for " + snapshotID}
+	}
+	data, err := os.ReadFile(tmpPath)
+	if err != nil {
+		return nil, err
+	}
+	var s backup.Snapshot
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, fmt.Errorf("decode manifest.json: %w", err)
+	}
+	return &s, nil
+}

--- a/agent/internal/backup/rebuild/identity.go
+++ b/agent/internal/backup/rebuild/identity.go
@@ -1,0 +1,93 @@
+package rebuild
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// enrollmentKeys are the agent.yaml keys applyNewIdentity removes so a
+// rebuilt "new identity" machine re-enrolls from scratch instead of
+// colliding with the source device's identity. org_id/site_id are
+// deliberately KEPT — they let the fresh enrollment land back in the same
+// org/site — as are server_url and every other non-identity setting.
+var enrollmentKeys = []string{"agent_id", "device_id", "auth_token", "watchdog_auth_token", "helper_auth_token"}
+
+func identity(ctx context.Context, r *run) error {
+	switch r.opts.Identity {
+	case IdentityOriginal:
+		if r.opts.Marker == nil {
+			r.warn("no recovery marker given; the server will not auto-complete this recovery")
+			return nil
+		}
+		dir := filepath.Join(r.staging, "var", "lib", "breeze")
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return err
+		}
+		data, _ := json.MarshalIndent(map[string]string{
+			"recoveryId": r.opts.Marker.RecoveryID, "nonce": r.opts.Marker.Nonce,
+			"snapshotId": r.opts.SnapshotID, "completedAt": time.Now().UTC().Format(time.RFC3339),
+		}, "", "  ")
+		return os.WriteFile(filepath.Join(dir, "recovery-marker.json"), data, 0o600)
+	case IdentityNew:
+		return applyNewIdentity(r.staging)
+	default:
+		return fmt.Errorf("unknown identity mode %q", r.opts.Identity)
+	}
+}
+
+// applyNewIdentity makes the tree boot as a fresh machine: empty machine-id
+// (systemd regenerates it on first boot), "-restored" hostname, no
+// enrollment credentials or secrets.
+func applyNewIdentity(root string) error {
+	_ = os.WriteFile(filepath.Join(root, "etc", "machine-id"), []byte{}, 0o644)
+	_ = os.Remove(filepath.Join(root, "var", "lib", "dbus", "machine-id"))
+	if hn, err := os.ReadFile(filepath.Join(root, "etc", "hostname")); err == nil {
+		name := strings.TrimSpace(string(hn))
+		if name != "" && !strings.HasSuffix(name, "-restored") {
+			_ = os.WriteFile(filepath.Join(root, "etc", "hostname"), []byte(name+"-restored\n"), 0o644)
+		}
+	}
+	_ = os.Remove(filepath.Join(root, "etc", "breeze", "secrets.yaml"))
+	return stripEnrollment(filepath.Join(root, "etc", "breeze", "agent.yaml"))
+}
+
+// stripEnrollment deletes enrollmentKeys from an agent.yaml document,
+// leaving every other setting (server_url, log_level, org_id, site_id, ...)
+// untouched. A missing file is not an error — a rebuilt tree with no agent
+// config yet is fine as-is.
+func stripEnrollment(agentYAML string) error {
+	data, err := os.ReadFile(agentYAML)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	var doc map[string]any
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return fmt.Errorf("parse %s: %w", agentYAML, err)
+	}
+	for _, k := range enrollmentKeys {
+		delete(doc, k)
+	}
+	out, err := yaml.Marshal(doc)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(agentYAML, out, 0o644)
+}
+
+// encryption is a recorded no-op on the Linux engine: LUKS sources are
+// refused at preflight (layout.Assess's ReasonLUKS guard) and BitLocker is
+// the Windows engine's job (a later wave). The phase still appears in
+// Result.Phases so every platform reports the same seven phases.
+func encryption(_ context.Context, r *run) error {
+	return nil
+}

--- a/agent/internal/backup/rebuild/identity_test.go
+++ b/agent/internal/backup/rebuild/identity_test.go
@@ -1,0 +1,43 @@
+package rebuild
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestStripEnrollment_RemovesIdentityKeysKeepsServer(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "etc", "breeze")
+	os.MkdirAll(dir, 0o755)
+	os.WriteFile(filepath.Join(dir, "agent.yaml"), []byte("server_url: https://example.invalid\nagent_id: a1\ndevice_id: d1\norg_id: o1\nsite_id: s1\nauth_token: t1\nwatchdog_auth_token: w1\nhelper_auth_token: h1\nlog_level: info\n"), 0o644)
+	os.WriteFile(filepath.Join(dir, "secrets.yaml"), []byte("auth_token: t1\n"), 0o600)
+	os.MkdirAll(filepath.Join(root, "etc"), 0o755)
+	os.WriteFile(filepath.Join(root, "etc", "machine-id"), []byte("abc\n"), 0o644)
+	os.WriteFile(filepath.Join(root, "etc", "hostname"), []byte("srv-1\n"), 0o644)
+
+	if err := applyNewIdentity(root); err != nil {
+		t.Fatal(err)
+	}
+	b, _ := os.ReadFile(filepath.Join(dir, "agent.yaml"))
+	for _, gone := range []string{"agent_id", "device_id", "auth_token", "watchdog_auth_token", "helper_auth_token"} {
+		if strings.Contains(string(b), gone+":") {
+			t.Errorf("%s still present:\n%s", gone, b)
+		}
+	}
+	for _, kept := range []string{"server_url: https://example.invalid", "log_level: info"} {
+		if !strings.Contains(string(b), kept) {
+			t.Errorf("%s lost:\n%s", kept, b)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(dir, "secrets.yaml")); !os.IsNotExist(err) {
+		t.Error("secrets.yaml must be removed")
+	}
+	if mid, _ := os.ReadFile(filepath.Join(root, "etc", "machine-id")); len(strings.TrimSpace(string(mid))) != 0 {
+		t.Errorf("machine-id = %q, want empty (systemd regenerates on first boot)", mid)
+	}
+	if hn, _ := os.ReadFile(filepath.Join(root, "etc", "hostname")); string(hn) != "srv-1-restored\n" {
+		t.Errorf("hostname = %q", hn)
+	}
+}

--- a/agent/internal/backup/rebuild/identity_test.go
+++ b/agent/internal/backup/rebuild/identity_test.go
@@ -7,15 +7,32 @@ import (
 	"testing"
 )
 
+func mustMkdirAll(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustWriteFile(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestStripEnrollment_RemovesIdentityKeysKeepsServer(t *testing.T) {
 	root := t.TempDir()
 	dir := filepath.Join(root, "etc", "breeze")
-	os.MkdirAll(dir, 0o755)
-	os.WriteFile(filepath.Join(dir, "agent.yaml"), []byte("server_url: https://example.invalid\nagent_id: a1\ndevice_id: d1\norg_id: o1\nsite_id: s1\nauth_token: t1\nwatchdog_auth_token: w1\nhelper_auth_token: h1\nlog_level: info\n"), 0o644)
-	os.WriteFile(filepath.Join(dir, "secrets.yaml"), []byte("auth_token: t1\n"), 0o600)
-	os.MkdirAll(filepath.Join(root, "etc"), 0o755)
-	os.WriteFile(filepath.Join(root, "etc", "machine-id"), []byte("abc\n"), 0o644)
-	os.WriteFile(filepath.Join(root, "etc", "hostname"), []byte("srv-1\n"), 0o644)
+	mustMkdirAll(t, dir)
+	mustWriteFile(t, filepath.Join(dir, "agent.yaml"), "server_url: https://example.invalid\nagent_id: a1\ndevice_id: d1\norg_id: o1\nsite_id: s1\nauth_token: t1\nwatchdog_auth_token: w1\nhelper_auth_token: h1\nlog_level: info\n")
+	mustWriteFile(t, filepath.Join(dir, "secrets.yaml"), "auth_token: t1\n")
+	mustMkdirAll(t, filepath.Join(root, "etc"))
+	mustWriteFile(t, filepath.Join(root, "etc", "machine-id"), "abc\n")
+	mustWriteFile(t, filepath.Join(root, "etc", "hostname"), "srv-1\n")
 
 	if err := applyNewIdentity(root); err != nil {
 		t.Fatal(err)

--- a/agent/internal/backup/rebuild/loopback_linux_test.go
+++ b/agent/internal/backup/rebuild/loopback_linux_test.go
@@ -41,7 +41,7 @@ func TestRun_LoopbackRealSystem(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer detach()
+	defer func() { _ = detach() }()
 	out, _ := exec.Command("blkid", "-o", "export", partitionDevice(dev, 3)).CombinedOutput()
 	if !strings.Contains(string(out), "UUID=9f7a-root") || !strings.Contains(string(out), "TYPE=ext4") {
 		t.Fatalf("root partition: %s", out)
@@ -51,11 +51,13 @@ func TestRun_LoopbackRealSystem(t *testing.T) {
 		t.Fatalf("efi partition: %s", out)
 	}
 	mnt := filepath.Join(dir, "verify")
-	os.MkdirAll(mnt, 0o755)
+	if err := os.MkdirAll(mnt, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	if out, err := exec.Command("mount", partitionDevice(dev, 3), mnt).CombinedOutput(); err != nil {
 		t.Fatalf("mount: %s", out)
 	}
-	defer exec.Command("umount", mnt).Run()
+	defer func() { _ = exec.Command("umount", mnt).Run() }()
 	if b, err := os.ReadFile(filepath.Join(mnt, "etc", "hostname")); err != nil || string(b) != "srv-1-restored\n" {
 		t.Fatalf("hostname = %q err=%v", b, err)
 	}

--- a/agent/internal/backup/rebuild/loopback_linux_test.go
+++ b/agent/internal/backup/rebuild/loopback_linux_test.go
@@ -43,7 +43,7 @@ func TestRun_LoopbackRealSystem(t *testing.T) {
 	}
 	defer func() { _ = detach() }()
 	out, _ := exec.Command("blkid", "-o", "export", partitionDevice(dev, 3)).CombinedOutput()
-	if !strings.Contains(string(out), "UUID=9f7a-root") || !strings.Contains(string(out), "TYPE=ext4") {
+	if !strings.Contains(string(out), "UUID="+testRootFSUUID) || !strings.Contains(string(out), "TYPE=ext4") {
 		t.Fatalf("root partition: %s", out)
 	}
 	out, _ = exec.Command("blkid", "-o", "export", partitionDevice(dev, 1)).CombinedOutput()

--- a/agent/internal/backup/rebuild/loopback_linux_test.go
+++ b/agent/internal/backup/rebuild/loopback_linux_test.go
@@ -1,0 +1,65 @@
+//go:build linux
+
+package rebuild
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRun_LoopbackRealSystem runs only as root with
+// BREEZE_REBUILD_LOOP_TEST=1 (CI: a privileged step in the test-agent job;
+// locally: sudo). It proves sgdisk/mkfs/mount/restore on a real loop device
+// — boot is skipped (SkipBoot) because the synthetic root has no GRUB.
+func TestRun_LoopbackRealSystem(t *testing.T) {
+	if os.Getenv("BREEZE_REBUILD_LOOP_TEST") != "1" || os.Geteuid() != 0 {
+		t.Skip("needs root and BREEZE_REBUILD_LOOP_TEST=1")
+	}
+	for _, tool := range []string{"sgdisk", "losetup", "mkfs.vfat", "mkfs.ext4", "partprobe", "blkid"} {
+		if _, err := exec.LookPath(tool); err != nil {
+			t.Skipf("%s not installed", tool)
+		}
+	}
+	dir := t.TempDir()
+	lay := testLayout()
+	// Shrink the source so a 3 GiB image is enough: EFI 64 MiB, boot 256 MiB, root used 512 MiB.
+	d := &lay.Disks[0]
+	d.Partitions[0].SizeBytes = 64 * MiB
+	d.Partitions[1].SizeBytes = 256 * MiB
+	d.Partitions[2].UsedBytes = 512 * MiB
+	p := seedSnapshot(t, "loop-1", lay)
+	img := filepath.Join(dir, "disk.img")
+	res, err := Run(context.Background(), Options{SnapshotID: "loop-1", Provider: p, Target: Target{Kind: TargetImage, Path: img, ImageSizeBytes: 3 * GiB}, Identity: IdentityNew, StateDir: dir, StagingRoot: filepath.Join(dir, "mnt"), SkipBoot: true})
+	if err != nil {
+		t.Fatalf("run: %v\n%+v", err, res)
+	}
+	dev, detach, err := NewSystem().AttachImage(img, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer detach()
+	out, _ := exec.Command("blkid", "-o", "export", partitionDevice(dev, 3)).CombinedOutput()
+	if !strings.Contains(string(out), "UUID=9f7a-root") || !strings.Contains(string(out), "TYPE=ext4") {
+		t.Fatalf("root partition: %s", out)
+	}
+	out, _ = exec.Command("blkid", "-o", "export", partitionDevice(dev, 1)).CombinedOutput()
+	if !strings.Contains(string(out), "UUID=ABCD-1234") || !strings.Contains(string(out), "TYPE=vfat") {
+		t.Fatalf("efi partition: %s", out)
+	}
+	mnt := filepath.Join(dir, "verify")
+	os.MkdirAll(mnt, 0o755)
+	if out, err := exec.Command("mount", partitionDevice(dev, 3), mnt).CombinedOutput(); err != nil {
+		t.Fatalf("mount: %s", out)
+	}
+	defer exec.Command("umount", mnt).Run()
+	if b, err := os.ReadFile(filepath.Join(mnt, "etc", "hostname")); err != nil || string(b) != "srv-1-restored\n" {
+		t.Fatalf("hostname = %q err=%v", b, err)
+	}
+	if got, err := os.Readlink(filepath.Join(mnt, "bin")); err != nil || got != "usr/bin" {
+		t.Fatalf("symlink = %q err=%v", got, err)
+	}
+}

--- a/agent/internal/backup/rebuild/plan.go
+++ b/agent/internal/backup/rebuild/plan.go
@@ -2,12 +2,47 @@ package rebuild
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/breeze-rmm/agent/internal/backup/layout"
 )
 
 var supportedFilesystems = map[string]bool{"vfat": true, "fat32": true, "ext4": true, "xfs": true, "swap": true}
+
+// uuidPattern is what mkfs.ext4 -U / mkfs.xfs -m uuid= / mkswap -U actually
+// accept: a real 8-4-4-4-12 hex UUID. vfatUUIDPattern is what mkfs.vfat -i
+// accepts: the FAT volume id, 8 hex digits with an optional separating
+// dash (the form layout captures it in, e.g. "ABCD-1234").
+var (
+	uuidPattern     = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+	vfatUUIDPattern = regexp.MustCompile(`^[0-9A-Fa-f]{4}-?[0-9A-Fa-f]{4}$`)
+)
+
+// validateFSUUID checks a partition's recorded filesystem UUID against the
+// shape mkfs actually accepts for fs. A malformed value reaches provision
+// only after sgdisk has already written the partition table — at which
+// point mkfs's own rejection ("could not parse UUID") aborts mid-provision
+// with the target already wiped. Refusing here, before any write, is
+// strictly better. An EMPTY uuid is fine (mkfs generates a fresh one) and
+// only produces a warning, since the restored fstab's UUID= entry for that
+// partition then won't resolve to anything on the rebuilt disk.
+func validateFSUUID(number int, fs, uuid string) (warning string, err error) {
+	if uuid == "" {
+		return fmt.Sprintf("partition %d has no recorded UUID; fstab entries using UUID= for it will not resolve", number), nil
+	}
+	switch fs {
+	case "vfat", "fat32":
+		if !vfatUUIDPattern.MatchString(uuid) {
+			return "", &RefusalError{Reason: fmt.Sprintf("partition %d filesystem UUID %q is not a valid vfat UUID (expected 4-4 hex, e.g. ABCD-1234)", number, uuid)}
+		}
+	case "ext4", "xfs", "swap":
+		if !uuidPattern.MatchString(uuid) {
+			return "", &RefusalError{Reason: fmt.Sprintf("partition %d filesystem UUID %q is not a valid %s UUID (expected 8-4-4-4-12 hex)", number, uuid, fs)}
+		}
+	}
+	return "", nil
+}
 
 func alignUp(n, a int64) int64 { return (n + a - 1) / a * a }
 
@@ -38,11 +73,19 @@ func PlanPartitions(src *layout.Disk, targetSizeBytes int64, sectorSize int) (*P
 			growIdx = i
 		}
 	}
+	var warnings []string
 	var fixed, growMin int64
 	for i, p := range parts {
 		fs := strings.ToLower(p.Filesystem)
 		if fs != "" && !supportedFilesystems[fs] && p.Role != layout.RoleMSR {
 			return nil, &RefusalError{Reason: fmt.Sprintf("partition %d filesystem %q is not supported by the Linux engine (vfat, ext4, xfs, swap)", p.Number, p.Filesystem)}
+		}
+		if fs != "" && p.Role != layout.RoleMSR {
+			if w, err := validateFSUUID(p.Number, fs, p.FSUUID); err != nil {
+				return nil, err
+			} else if w != "" {
+				warnings = append(warnings, w)
+			}
 		}
 		if i == growIdx {
 			growMin = int64(float64(p.UsedBytes) * 1.1)
@@ -53,7 +96,7 @@ func PlanPartitions(src *layout.Disk, targetSizeBytes int64, sectorSize int) (*P
 		}
 		fixed += alignUp(p.SizeBytes, MiB)
 	}
-	plan := &Plan{SourceDisk: src.Name, SourceSizeBytes: src.SizeBytes, TargetSizeBytes: targetSizeBytes, SectorSize: sectorSize, MinimumBytes: fixed + growMin + 2*MiB}
+	plan := &Plan{SourceDisk: src.Name, SourceSizeBytes: src.SizeBytes, TargetSizeBytes: targetSizeBytes, SectorSize: sectorSize, MinimumBytes: fixed + growMin + 2*MiB, Warnings: warnings}
 	if targetSizeBytes < plan.MinimumBytes {
 		return nil, &RefusalError{Reason: fmt.Sprintf("target is too small: %d bytes available, %d bytes needed (fixed partitions %d + root data %d + GPT reserve)", targetSizeBytes, plan.MinimumBytes, fixed, growMin)}
 	}

--- a/agent/internal/backup/rebuild/plan.go
+++ b/agent/internal/backup/rebuild/plan.go
@@ -1,0 +1,84 @@
+package rebuild
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/breeze-rmm/agent/internal/backup/layout"
+)
+
+var supportedFilesystems = map[string]bool{"vfat": true, "fat32": true, "ext4": true, "xfs": true, "swap": true}
+
+func alignUp(n, a int64) int64 { return (n + a - 1) / a * a }
+
+// PlanPartitions lays the source disk's partitions onto a target of
+// targetSizeBytes. Fixed partitions keep their recorded size; the last
+// root/data partition absorbs the remainder (or shrinks to used×1.1 on a
+// smaller target). Non-partition children (Kind != "") are ignored — the W01
+// guard already refused layouts that depend on them.
+func PlanPartitions(src *layout.Disk, targetSizeBytes int64, sectorSize int) (*Plan, error) {
+	if src == nil {
+		return nil, &RefusalError{Reason: "no source disk in layout"}
+	}
+	if sectorSize <= 0 {
+		sectorSize = 512
+	}
+	var parts []layout.Partition
+	for _, p := range src.Partitions {
+		if p.Kind == "" && p.Number > 0 {
+			parts = append(parts, p)
+		}
+	}
+	if len(parts) == 0 {
+		return nil, &RefusalError{Reason: "source disk has no partitions"}
+	}
+	growIdx := -1
+	for i, p := range parts {
+		if p.Role == layout.RoleRoot || p.Role == layout.RoleData {
+			growIdx = i
+		}
+	}
+	var fixed, growMin int64
+	for i, p := range parts {
+		fs := strings.ToLower(p.Filesystem)
+		if fs != "" && !supportedFilesystems[fs] && p.Role != layout.RoleMSR {
+			return nil, &RefusalError{Reason: fmt.Sprintf("partition %d filesystem %q is not supported by the Linux engine (vfat, ext4, xfs, swap)", p.Number, p.Filesystem)}
+		}
+		if i == growIdx {
+			growMin = int64(float64(p.UsedBytes) * 1.1)
+			if growMin < GiB {
+				growMin = GiB
+			}
+			continue
+		}
+		fixed += alignUp(p.SizeBytes, MiB)
+	}
+	plan := &Plan{SourceDisk: src.Name, SourceSizeBytes: src.SizeBytes, TargetSizeBytes: targetSizeBytes, SectorSize: sectorSize, MinimumBytes: fixed + growMin + 2*MiB}
+	if targetSizeBytes < plan.MinimumBytes {
+		return nil, &RefusalError{Reason: fmt.Sprintf("target is too small: %d bytes available, %d bytes needed (fixed partitions %d + root data %d + GPT reserve)", targetSizeBytes, plan.MinimumBytes, fixed, growMin)}
+	}
+	usableEnd := targetSizeBytes - MiB
+	cursor := MiB
+	for i, p := range parts {
+		size := alignUp(p.SizeBytes, MiB)
+		grown := false
+		if i == growIdx {
+			// Everything after this partition is fixed; leave room for it.
+			var after int64
+			for _, q := range parts[i+1:] {
+				after += alignUp(q.SizeBytes, MiB)
+			}
+			size = usableEnd - after - cursor
+			grown = true
+		}
+		plan.Partitions = append(plan.Partitions, PlannedPartition{
+			Number: p.Number, Role: p.Role, TypeGUID: p.TypeGUID, PartUUID: p.PartUUID, Name: p.Label,
+			StartBytes: cursor, SizeBytes: size, Filesystem: strings.ToLower(p.Filesystem), FSUUID: p.FSUUID, Label: p.Label, MountPoint: p.MountPoint, Grown: grown,
+		})
+		cursor += size
+	}
+	if cursor > usableEnd {
+		return nil, &RefusalError{Reason: fmt.Sprintf("target is too small: plan ends at %d bytes but only %d are usable", cursor, usableEnd)}
+	}
+	return plan, nil
+}

--- a/agent/internal/backup/rebuild/plan_test.go
+++ b/agent/internal/backup/rebuild/plan_test.go
@@ -8,11 +8,25 @@ import (
 	"github.com/breeze-rmm/agent/internal/backup/layout"
 )
 
+// Real-format UUIDs (see TestPlanPartitions_RefusesMalformedUUIDs / the
+// review fix that added FSUUID format validation): mkfs itself rejects a
+// non-UUID string like the old "boot-uuid"/"9f7a-root" placeholders
+// ("could not parse UUID") — which used to surface only when the loopback
+// test ran mkfs for real, well after sgdisk had already wiped the target.
+const (
+	testEFIPartUUID  = "11111111-2222-3333-4444-555555555555"
+	testBootPartUUID = "66666666-7777-8888-9999-aaaaaaaaaaaa"
+	testRootPartUUID = "bbbbbbbb-cccc-dddd-eeee-ffffffffffff"
+	testEFIFSUUID    = "ABCD-1234" // vfat volume id: 4-4 hex
+	testBootFSUUID   = "1b3c5d7e-9f01-4a2b-8c3d-4e5f6a7b8c9d"
+	testRootFSUUID   = "9f7a2c41-6b3e-4d5f-8a9b-0c1d2e3f4a5b"
+)
+
 func srcDisk() *layout.Disk {
 	return &layout.Disk{Name: "/dev/sda", SizeBytes: 64 * GiB, SectorSize: 512, TableType: "gpt", IsSystem: true, Partitions: []layout.Partition{
-		{Number: 1, Name: "/dev/sda1", TypeGUID: layout.GUIDEFISystem, PartUUID: "1111-aaaa", StartBytes: MiB, SizeBytes: 512 * MiB, Filesystem: "vfat", FSUUID: "ABCD-1234", MountPoint: "/boot/efi", Role: layout.RoleEFI, Encryption: layout.EncryptionNone},
-		{Number: 2, Name: "/dev/sda2", TypeGUID: layout.GUIDLinuxFilesystem, PartUUID: "2222-bbbb", StartBytes: 513 * MiB, SizeBytes: 2 * GiB, Filesystem: "ext4", FSUUID: "boot-uuid", MountPoint: "/boot", Role: layout.RoleBoot, Encryption: layout.EncryptionNone},
-		{Number: 3, Name: "/dev/sda3", TypeGUID: layout.GUIDLinuxFilesystem, PartUUID: "3333-cccc", StartBytes: (513 + 2048) * MiB, SizeBytes: 64*GiB - (513+2048)*MiB - MiB, UsedBytes: 8 * GiB, Filesystem: "ext4", FSUUID: "9f7a-root", Label: "rootfs", MountPoint: "/", Role: layout.RoleRoot, Encryption: layout.EncryptionNone},
+		{Number: 1, Name: "/dev/sda1", TypeGUID: layout.GUIDEFISystem, PartUUID: testEFIPartUUID, StartBytes: MiB, SizeBytes: 512 * MiB, Filesystem: "vfat", FSUUID: testEFIFSUUID, MountPoint: "/boot/efi", Role: layout.RoleEFI, Encryption: layout.EncryptionNone},
+		{Number: 2, Name: "/dev/sda2", TypeGUID: layout.GUIDLinuxFilesystem, PartUUID: testBootPartUUID, StartBytes: 513 * MiB, SizeBytes: 2 * GiB, Filesystem: "ext4", FSUUID: testBootFSUUID, MountPoint: "/boot", Role: layout.RoleBoot, Encryption: layout.EncryptionNone},
+		{Number: 3, Name: "/dev/sda3", TypeGUID: layout.GUIDLinuxFilesystem, PartUUID: testRootPartUUID, StartBytes: (513 + 2048) * MiB, SizeBytes: 64*GiB - (513+2048)*MiB - MiB, UsedBytes: 8 * GiB, Filesystem: "ext4", FSUUID: testRootFSUUID, Label: "rootfs", MountPoint: "/", Role: layout.RoleRoot, Encryption: layout.EncryptionNone},
 	}}
 }
 
@@ -78,5 +92,61 @@ func TestPlanPartitions_SkipsNonPartitionChildren(t *testing.T) {
 	p, err := PlanPartitions(d, 100*GiB, 512)
 	if err != nil || len(p.Partitions) != 3 {
 		t.Fatalf("p=%+v err=%v", p, err)
+	}
+}
+
+// TestPlanPartitions_RefusesMalformedUUIDs proves the review fix: mkfs
+// itself rejects a non-UUID FSUUID string ("could not parse UUID") — which
+// used to surface only mid-provision, well after sgdisk had already wiped
+// the target's partition table. PlanPartitions now refuses up front, before
+// any write, for both the ext4/xfs/swap UUID shape and the vfat volume-id
+// shape.
+func TestPlanPartitions_RefusesMalformedUUIDs(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		mutate  func(d *layout.Disk)
+		wantErr string // substring of RefusalError.Reason; "" means no error expected
+	}{
+		{"malformed ext4 UUID (the old placeholder fixture value)", func(d *layout.Disk) { d.Partitions[1].FSUUID = "boot-uuid" }, `partition 2 filesystem UUID "boot-uuid" is not a valid ext4 UUID`},
+		{"malformed vfat UUID", func(d *layout.Disk) { d.Partitions[0].FSUUID = "ZZZZ-1234" }, `partition 1 filesystem UUID "ZZZZ-1234" is not a valid vfat UUID`},
+		{"valid UUIDs pass unchanged", func(d *layout.Disk) {}, ""},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			d := srcDisk()
+			tt.mutate(d)
+			_, err := PlanPartitions(d, 100*GiB, 512)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			var ref *RefusalError
+			if err == nil || !errors.As(err, &ref) || !strings.Contains(ref.Reason, tt.wantErr) {
+				t.Fatalf("err = %v, want a RefusalError containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestPlanPartitions_EmptyFSUUID_WarnsButDoesNotRefuse proves an empty
+// FSUUID (mkfs will generate a fresh one) is allowed, not refused — but
+// produces a warning, since the restored fstab's UUID= entry for that
+// partition then won't resolve to anything on the rebuilt disk.
+func TestPlanPartitions_EmptyFSUUID_WarnsButDoesNotRefuse(t *testing.T) {
+	d := srcDisk()
+	d.Partitions[2].FSUUID = ""
+	p, err := PlanPartitions(d, 100*GiB, 512)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	found := false
+	for _, w := range p.Warnings {
+		if strings.Contains(w, "partition 3 has no recorded UUID") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("warnings = %v, want a 'no recorded UUID' warning for partition 3", p.Warnings)
 	}
 }

--- a/agent/internal/backup/rebuild/plan_test.go
+++ b/agent/internal/backup/rebuild/plan_test.go
@@ -1,0 +1,82 @@
+package rebuild
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/backup/layout"
+)
+
+func srcDisk() *layout.Disk {
+	return &layout.Disk{Name: "/dev/sda", SizeBytes: 64 * GiB, SectorSize: 512, TableType: "gpt", IsSystem: true, Partitions: []layout.Partition{
+		{Number: 1, Name: "/dev/sda1", TypeGUID: layout.GUIDEFISystem, PartUUID: "1111-aaaa", StartBytes: MiB, SizeBytes: 512 * MiB, Filesystem: "vfat", FSUUID: "ABCD-1234", MountPoint: "/boot/efi", Role: layout.RoleEFI, Encryption: layout.EncryptionNone},
+		{Number: 2, Name: "/dev/sda2", TypeGUID: layout.GUIDLinuxFilesystem, PartUUID: "2222-bbbb", StartBytes: 513 * MiB, SizeBytes: 2 * GiB, Filesystem: "ext4", FSUUID: "boot-uuid", MountPoint: "/boot", Role: layout.RoleBoot, Encryption: layout.EncryptionNone},
+		{Number: 3, Name: "/dev/sda3", TypeGUID: layout.GUIDLinuxFilesystem, PartUUID: "3333-cccc", StartBytes: (513 + 2048) * MiB, SizeBytes: 64*GiB - (513+2048)*MiB - MiB, UsedBytes: 8 * GiB, Filesystem: "ext4", FSUUID: "9f7a-root", Label: "rootfs", MountPoint: "/", Role: layout.RoleRoot, Encryption: layout.EncryptionNone},
+	}}
+}
+
+func TestPlanPartitions_GrowsLastRootOnLargerTarget(t *testing.T) {
+	p, err := PlanPartitions(srcDisk(), 100*GiB, 512)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(p.Partitions) != 3 {
+		t.Fatalf("partitions = %+v", p.Partitions)
+	}
+	efi, boot, root := p.Partitions[0], p.Partitions[1], p.Partitions[2]
+	if efi.StartBytes != MiB || efi.SizeBytes != 512*MiB || efi.FSUUID != "ABCD-1234" || efi.Role != layout.RoleEFI {
+		t.Errorf("efi = %+v", efi)
+	}
+	if boot.StartBytes != efi.StartBytes+efi.SizeBytes || boot.SizeBytes != 2*GiB {
+		t.Errorf("boot = %+v", boot)
+	}
+	if !root.Grown || root.StartBytes != boot.StartBytes+boot.SizeBytes || root.StartBytes+root.SizeBytes != 100*GiB-MiB {
+		t.Errorf("root = %+v (want grown to the end minus 1 MiB)", root)
+	}
+	if root.StartBytes%MiB != 0 || root.SizeBytes%MiB != 0 {
+		t.Errorf("root not 1 MiB aligned: %+v", root)
+	}
+	usedRoot := int64(8 * GiB)
+	if p.MinimumBytes != 512*MiB+2*GiB+int64(float64(usedRoot)*1.1)+2*MiB {
+		t.Errorf("MinimumBytes = %d", p.MinimumBytes)
+	}
+}
+
+func TestPlanPartitions_SmallerTargetShrinksRootToUsedPlusMargin(t *testing.T) {
+	p, err := PlanPartitions(srcDisk(), 12*GiB, 512)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := p.Partitions[2]
+	usedRoot := int64(8 * GiB)
+	if root.SizeBytes < int64(float64(usedRoot)*1.1) || root.StartBytes+root.SizeBytes > 12*GiB-MiB {
+		t.Errorf("root = %+v", root)
+	}
+}
+
+func TestPlanPartitions_RefusesTooSmall(t *testing.T) {
+	_, err := PlanPartitions(srcDisk(), 10*GiB, 512)
+	var ref *RefusalError
+	if err == nil || !errors.As(err, &ref) || !strings.Contains(ref.Reason, "target is too small") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestPlanPartitions_RefusesUnsupportedFilesystem(t *testing.T) {
+	d := srcDisk()
+	d.Partitions[1].Filesystem = "btrfs"
+	_, err := PlanPartitions(d, 100*GiB, 512)
+	if err == nil || !strings.Contains(err.Error(), "partition 2 filesystem \"btrfs\"") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestPlanPartitions_SkipsNonPartitionChildren(t *testing.T) {
+	d := srcDisk()
+	d.Partitions = append(d.Partitions, layout.Partition{Kind: "crypt", Name: "/dev/mapper/x", Filesystem: "ext4"})
+	p, err := PlanPartitions(d, 100*GiB, 512)
+	if err != nil || len(p.Partitions) != 3 {
+		t.Fatalf("p=%+v err=%v", p, err)
+	}
+}

--- a/agent/internal/backup/rebuild/preflight.go
+++ b/agent/internal/backup/rebuild/preflight.go
@@ -1,0 +1,106 @@
+package rebuild
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/breeze-rmm/agent/internal/backup/bmr"
+	"github.com/breeze-rmm/agent/internal/backup/layout"
+)
+
+// preflight verifies everything it can before any write happens: the
+// layout is restorable by this engine, the target is big enough and not in
+// use / not the running system, and the ordinary manifest + system state
+// artifacts download and verify (checksums) against the snapshot. Nothing
+// in this phase touches the target disk.
+func preflight(ctx context.Context, r *run) error {
+	// 1. Layout + guard.
+	lay := r.opts.Layout
+	if lay == nil {
+		var err error
+		if lay, err = fetchLayout(ctx, r.opts.Provider, r.opts.SnapshotID); err != nil {
+			return err
+		}
+	} else if lay.SchemaVersion != layout.SchemaVersion {
+		return &RefusalError{Reason: fmt.Sprintf("layout schema version %d is not supported by this helper (supports %d)", lay.SchemaVersion, layout.SchemaVersion)}
+	}
+	if v := layout.Assess(lay); !v.Restorable {
+		return &RefusalError{Reason: "layout is not bare-metal restorable: " + strings.Join(v.Reasons, "; ")}
+	}
+	if lay.Platform != "linux" {
+		return &RefusalError{Reason: fmt.Sprintf("snapshot platform %q cannot be rebuilt by the Linux engine", lay.Platform)}
+	}
+	r.layout = lay
+	src := lay.SystemDisk()
+
+	// 2. Target sizing and safety. Nothing below writes.
+	var targetSize int64
+	switch r.opts.Target.Kind {
+	case TargetDisk:
+		mounted, err := r.sys.MountedSources()
+		if err != nil {
+			return err
+		}
+		for _, m := range mounted {
+			if m == r.opts.Target.Path || strings.HasPrefix(m, r.opts.Target.Path) {
+				return &RefusalError{Reason: fmt.Sprintf("target disk %s is in use (%s is mounted)", r.opts.Target.Path, m)}
+			}
+		}
+		roots, _ := r.sys.RootSources()
+		for _, m := range roots {
+			if m == r.opts.Target.Path || strings.HasPrefix(m, r.opts.Target.Path) {
+				return &RefusalError{Reason: fmt.Sprintf("target disk %s backs the running system (%s)", r.opts.Target.Path, m)}
+			}
+		}
+		size, err := r.sys.BlockDeviceSize(r.opts.Target.Path)
+		if err != nil {
+			return err
+		}
+		targetSize = size
+	case TargetImage:
+		targetSize = r.opts.Target.ImageSizeBytes
+		if fi, err := os.Stat(r.opts.Target.Path); err == nil {
+			targetSize = fi.Size()
+		}
+		if targetSize <= 0 {
+			return &RefusalError{Reason: "image target needs a size (--image-size) when the file does not exist"}
+		}
+	}
+	sector := src.SectorSize
+	if sector == 0 {
+		sector = 512
+	}
+	plan, err := PlanPartitions(src, targetSize, sector)
+	if err != nil {
+		return err
+	}
+	plan.TargetPath = r.opts.Target.Path
+	r.result.Plan = plan
+	r.progress(PhasePreflight, "plan ready", 1, 3)
+
+	// 3. Verify what we will restore: ordinary manifest + system state (checksums).
+	man, err := fetchManifest(ctx, r.opts.Provider, r.opts.SnapshotID)
+	if err != nil {
+		return err
+	}
+	r.manifest = man
+	staging, err := os.MkdirTemp("", "breeze-rebuild-state-*")
+	if err != nil {
+		return err
+	}
+	r.stateStaging = staging
+	if _, warnings, err := bmr.DownloadSystemState(ctx, r.opts.Provider, r.opts.SnapshotID, false, staging); err != nil {
+		if errors.Is(err, bmr.ErrNoSystemState) {
+			r.warn("snapshot has no system state; only files will be restored")
+		} else {
+			return &RefusalError{Reason: "system state verification failed: " + err.Error()}
+		}
+	} else {
+		r.warnings = append(r.warnings, warnings...)
+	}
+	r.progress(PhasePreflight, "verified", 3, 3)
+	return nil
+}

--- a/agent/internal/backup/rebuild/preflight.go
+++ b/agent/internal/backup/rebuild/preflight.go
@@ -11,6 +11,41 @@ import (
 	"github.com/breeze-rmm/agent/internal/backup/layout"
 )
 
+// deviceBelongsTo reports whether dev names disk itself or one of its
+// partitions. A bare strings.HasPrefix(dev, disk) is not enough — disk
+// "/dev/sda" is a STRING prefix of the unrelated disk "/dev/sdaa1" too — so
+// this checks the suffix left after the prefix matches partitionDevice's
+// own naming rule: a disk whose name ends in a digit (nvme0n1, mmcblk0,
+// loop0) always gets a "p" infix before the partition number, so anything
+// else immediately after the prefix (including a bare digit, as in
+// "/dev/nvme0n10" — a DIFFERENT nvme namespace, not a partition of
+// nvme0n1) does not belong to it; a disk ending in a letter (sda, vda)
+// never gets that infix, so the suffix must be digits directly.
+func deviceBelongsTo(disk, dev string) bool {
+	if dev == disk {
+		return true
+	}
+	if !strings.HasPrefix(dev, disk) {
+		return false
+	}
+	rest := dev[len(disk):]
+	if n := len(disk); n > 0 && disk[n-1] >= '0' && disk[n-1] <= '9' {
+		if !strings.HasPrefix(rest, "p") {
+			return false
+		}
+		rest = rest[1:]
+	}
+	if rest == "" {
+		return false
+	}
+	for _, c := range rest {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
+}
+
 // preflight verifies everything it can before any write happens: the
 // layout is restorable by this engine, the target is big enough and not in
 // use / not the running system, and the ordinary manifest + system state
@@ -45,13 +80,13 @@ func preflight(ctx context.Context, r *run) error {
 			return err
 		}
 		for _, m := range mounted {
-			if m == r.opts.Target.Path || strings.HasPrefix(m, r.opts.Target.Path) {
+			if deviceBelongsTo(r.opts.Target.Path, m) {
 				return &RefusalError{Reason: fmt.Sprintf("target disk %s is in use (%s is mounted)", r.opts.Target.Path, m)}
 			}
 		}
 		roots, _ := r.sys.RootSources()
 		for _, m := range roots {
-			if m == r.opts.Target.Path || strings.HasPrefix(m, r.opts.Target.Path) {
+			if deviceBelongsTo(r.opts.Target.Path, m) {
 				return &RefusalError{Reason: fmt.Sprintf("target disk %s backs the running system (%s)", r.opts.Target.Path, m)}
 			}
 		}
@@ -96,7 +131,7 @@ func preflight(ctx context.Context, r *run) error {
 		if errors.Is(err, bmr.ErrNoSystemState) {
 			r.warn("snapshot has no system state; only files will be restored")
 		} else {
-			return &RefusalError{Reason: "system state verification failed: " + err.Error()}
+			return &RefusalError{Reason: "system state could not be verified: " + err.Error()}
 		}
 	} else {
 		r.warnings = append(r.warnings, warnings...)

--- a/agent/internal/backup/rebuild/preflight_test.go
+++ b/agent/internal/backup/rebuild/preflight_test.go
@@ -1,0 +1,21 @@
+package rebuild
+
+import "testing"
+
+func TestDeviceBelongsTo(t *testing.T) {
+	for _, tt := range []struct {
+		disk, dev string
+		want      bool
+	}{
+		{"/dev/sda", "/dev/sda1", true},
+		{"/dev/sda", "/dev/sdaa1", false},
+		{"/dev/nvme0n1", "/dev/nvme0n1p2", true},
+		{"/dev/nvme0n1", "/dev/nvme0n10", false},
+		{"/dev/loop0", "/dev/loop0p1", true},
+		{"/dev/sda", "/dev/sda", true},
+	} {
+		if got := deviceBelongsTo(tt.disk, tt.dev); got != tt.want {
+			t.Errorf("deviceBelongsTo(%q, %q) = %v, want %v", tt.disk, tt.dev, got, tt.want)
+		}
+	}
+}

--- a/agent/internal/backup/rebuild/provision.go
+++ b/agent/internal/backup/rebuild/provision.go
@@ -4,7 +4,43 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 )
+
+// partitionDeviceWaitTimeout bounds how long provision/reattach will poll
+// for a partition's device node to appear after a Rescan (partprobe). A
+// package var, not a const, so a test could shrink it (none currently need
+// to — the fake System's Exists always reports true immediately).
+var partitionDeviceWaitTimeout = 10 * time.Second
+
+// waitForPartitionDevices polls for every planned partition's device node
+// to exist before any mkfs/mount touches it. sgdisk/partprobe tell the
+// kernel about a new partition table; the /dev entry itself is materialized
+// asynchronously by udev — proceeding before it exists is exactly how a
+// "no such file or directory" mkfs/mount failure happens on a slow or
+// udev-less host (see the CI loopback job).
+func waitForPartitionDevices(ctx context.Context, r *run) error {
+	if r.result.Plan == nil {
+		return nil
+	}
+	deadline := time.Now().Add(partitionDeviceWaitTimeout)
+	for _, p := range r.result.Plan.Partitions {
+		if p.Filesystem == "" {
+			continue // MSR-style partitions carry no filesystem and are never formatted/mounted
+		}
+		dev := r.sys.PartitionDevice(r.disk, p.Number)
+		for !r.sys.Exists(dev) {
+			if ctx != nil && ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if time.Now().After(deadline) {
+				return fmt.Errorf("partition device %s did not appear within %s of rescan", dev, partitionDeviceWaitTimeout)
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+	return nil
+}
 
 // provision partitions and formats the target per r.result.Plan: sgdisk lays
 // down the GPT (type + partition GUIDs so the restored fstab/GRUB config
@@ -38,6 +74,9 @@ func provision(ctx context.Context, r *run) error {
 		}
 	}
 	if err := r.sys.Rescan(ctx, r.disk); err != nil {
+		return err
+	}
+	if err := waitForPartitionDevices(ctx, r); err != nil {
 		return err
 	}
 	for i, p := range plan.Partitions {
@@ -94,7 +133,11 @@ func provision(ctx context.Context, r *run) error {
 	return nil
 }
 
-// attach resolves r.disk: the block device itself, or the loop device for an image.
+// attach resolves r.disk: the block device itself, or a freshly attached
+// loop device for an image target. Called both by provision() (first run)
+// and reattach() (resume) — for TargetImage this ALWAYS performs a new
+// losetup, never reuses a device path from a previous call, because a loop
+// device does not survive across Run() calls (teardown always detaches it).
 func (r *run) attach(ctx context.Context) error {
 	switch r.opts.Target.Kind {
 	case TargetDisk:
@@ -106,15 +149,26 @@ func (r *run) attach(ctx context.Context) error {
 		}
 		r.disk, r.detach = dev, detach
 	}
-	r.state.Disk = r.disk
 	return nil
 }
 
-// reattach is used on resume: attach (images) and mount the planned
-// partitions without touching the partition table or filesystems.
+// reattach is used on resume: re-attach the target (always a fresh losetup
+// for an image — see attach's doc comment — then a Rescan and a wait for
+// the partition device nodes, since a resumed process's kernel/udev state
+// is otherwise unknown; a disk target's real block device nodes need
+// neither, they persist independently of this process) and mount the
+// planned partitions without touching the partition table or filesystems.
 func (r *run) reattach(ctx context.Context) error {
 	if r.disk == "" {
 		if err := r.attach(ctx); err != nil {
+			return err
+		}
+		if r.opts.Target.Kind == TargetImage {
+			if err := r.sys.Rescan(ctx, r.disk); err != nil {
+				return err
+			}
+		}
+		if err := waitForPartitionDevices(ctx, r); err != nil {
 			return err
 		}
 	}

--- a/agent/internal/backup/rebuild/provision.go
+++ b/agent/internal/backup/rebuild/provision.go
@@ -1,0 +1,125 @@
+package rebuild
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// provision partitions and formats the target per r.result.Plan: sgdisk lays
+// down the GPT (type + partition GUIDs so the restored fstab/GRUB config
+// resolves unchanged), then each partition is formatted with the recorded
+// filesystem UUID/label.
+func provision(ctx context.Context, r *run) error {
+	if err := r.attach(ctx); err != nil {
+		return err
+	}
+	plan := r.result.Plan
+	sector := int64(plan.SectorSize)
+	if out, err := r.sys.Run(ctx, "sgdisk", "--zap-all", r.disk); err != nil {
+		return fmt.Errorf("sgdisk --zap-all: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	for _, p := range plan.Partitions {
+		startSector := p.StartBytes / sector
+		endSector := (p.StartBytes+p.SizeBytes)/sector - 1
+		args := []string{fmt.Sprintf("--new=%d:%d:%d", p.Number, startSector, endSector)}
+		if p.TypeGUID != "" {
+			args = append(args, fmt.Sprintf("--typecode=%d:%s", p.Number, p.TypeGUID))
+		}
+		if p.PartUUID != "" {
+			args = append(args, fmt.Sprintf("--partition-guid=%d:%s", p.Number, p.PartUUID))
+		}
+		if p.Name != "" {
+			args = append(args, fmt.Sprintf("--change-name=%d:%s", p.Number, p.Name))
+		}
+		args = append(args, r.disk)
+		if out, err := r.sys.Run(ctx, "sgdisk", args...); err != nil {
+			return fmt.Errorf("sgdisk partition %d: %s: %w", p.Number, strings.TrimSpace(string(out)), err)
+		}
+	}
+	if err := r.sys.Rescan(ctx, r.disk); err != nil {
+		return err
+	}
+	for i, p := range plan.Partitions {
+		dev := r.sys.PartitionDevice(r.disk, p.Number)
+		var name string
+		var args []string
+		switch p.Filesystem {
+		case "vfat", "fat32":
+			name = "mkfs.vfat"
+			args = []string{"-F", "32"}
+			if id := strings.ReplaceAll(strings.ToUpper(p.FSUUID), "-", ""); len(id) == 8 {
+				args = append(args, "-i", id)
+			}
+			if p.Label != "" {
+				args = append(args, "-n", strings.ToUpper(p.Label))
+			}
+		case "ext4":
+			name = "mkfs.ext4"
+			args = []string{"-F", "-q"}
+			if p.FSUUID != "" {
+				args = append(args, "-U", p.FSUUID)
+			}
+			if p.Label != "" {
+				args = append(args, "-L", p.Label)
+			}
+		case "xfs":
+			name = "mkfs.xfs"
+			args = []string{"-f", "-q"}
+			if p.FSUUID != "" {
+				args = append(args, "-m", "uuid="+p.FSUUID)
+			}
+			if p.Label != "" {
+				args = append(args, "-L", p.Label)
+			}
+		case "swap":
+			name = "mkswap"
+			if p.FSUUID != "" {
+				args = append(args, "-U", p.FSUUID)
+			}
+			if p.Label != "" {
+				args = append(args, "-L", p.Label)
+			}
+		case "":
+			continue // MSR-style partitions carry no filesystem
+		default:
+			return fmt.Errorf("unsupported filesystem %q reached provision (preflight bug)", p.Filesystem)
+		}
+		args = append(args, dev)
+		if out, err := r.sys.Run(ctx, name, args...); err != nil {
+			return fmt.Errorf("%s %s: %s: %w", name, dev, strings.TrimSpace(string(out)), err)
+		}
+		r.progress(PhaseProvision, "formatted "+dev, int64(i+1), int64(len(plan.Partitions)))
+	}
+	return nil
+}
+
+// attach resolves r.disk: the block device itself, or the loop device for an image.
+func (r *run) attach(ctx context.Context) error {
+	switch r.opts.Target.Kind {
+	case TargetDisk:
+		r.disk = r.opts.Target.Path
+	case TargetImage:
+		dev, detach, err := r.sys.AttachImage(r.opts.Target.Path, r.opts.Target.ImageSizeBytes)
+		if err != nil {
+			return err
+		}
+		r.disk, r.detach = dev, detach
+	}
+	r.state.Disk = r.disk
+	return nil
+}
+
+// reattach is used on resume: attach (images) and mount the planned
+// partitions without touching the partition table or filesystems.
+func (r *run) reattach(ctx context.Context) error {
+	if r.disk == "" {
+		if err := r.attach(ctx); err != nil {
+			return err
+		}
+	}
+	if r.rootMount == "" && r.state.Completed[PhaseProvision] {
+		return mountTree(ctx, r)
+	}
+	return nil
+}

--- a/agent/internal/backup/rebuild/restore_tree.go
+++ b/agent/internal/backup/rebuild/restore_tree.go
@@ -1,0 +1,87 @@
+package rebuild
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/breeze-rmm/agent/internal/backup"
+	"github.com/breeze-rmm/agent/internal/backup/bmr"
+)
+
+// mountTree mounts every planned partition with a mount point under the
+// staging root, shallowest first (/ then /boot then /boot/efi).
+func mountTree(ctx context.Context, r *run) error {
+	parts := make([]PlannedPartition, 0, len(r.result.Plan.Partitions))
+	for _, p := range r.result.Plan.Partitions {
+		if p.MountPoint != "" && p.Filesystem != "swap" && p.Filesystem != "" {
+			parts = append(parts, p)
+		}
+	}
+	sort.Slice(parts, func(i, j int) bool {
+		di, dj := strings.Count(parts[i].MountPoint, "/"), strings.Count(parts[j].MountPoint, "/")
+		if di != dj {
+			return di < dj
+		}
+		return parts[i].MountPoint < parts[j].MountPoint
+	})
+	if len(parts) == 0 || parts[0].MountPoint != "/" {
+		return errors.New("plan has no root mount point")
+	}
+	for _, p := range parts {
+		dir := filepath.Join(r.staging, filepath.FromSlash(strings.TrimPrefix(p.MountPoint, "/")))
+		fstype := p.Filesystem
+		if fstype == "fat32" {
+			fstype = "vfat"
+		}
+		if err := r.sys.Mount(ctx, r.sys.PartitionDevice(r.disk, p.Number), dir, fstype); err != nil {
+			return err
+		}
+		if p.MountPoint == "/" {
+			r.rootMount = dir
+		} else {
+			r.treeMounts = append(r.treeMounts, dir)
+		}
+	}
+	return nil
+}
+
+// restoreTree mounts the provisioned partitions (if not already mounted by
+// a resumed reattach), restores the whole-machine file snapshot into the
+// staging root, and layers the offline system-state apply on top.
+func restoreTree(ctx context.Context, r *run) error {
+	if r.rootMount == "" {
+		if err := mountTree(ctx, r); err != nil {
+			return err
+		}
+	}
+	res, err := backup.RestoreFromSnapshotContext(ctx, r.opts.Provider, backup.RestoreConfig{SnapshotID: r.opts.SnapshotID, TargetPath: r.staging}, func(phase string, cur, total int64, msg string) {
+		r.progress(PhaseRestore, msg, cur, total)
+	})
+	if err != nil {
+		return fmt.Errorf("restore files: %w", err)
+	}
+	r.result.FilesRestored, r.result.BytesRestored = res.FilesRestored, res.BytesRestored
+	r.warnings = append(r.warnings, res.Warnings...)
+	if res.FilesFailed > 0 {
+		msg := fmt.Sprintf("%d file(s) failed to restore: %s", res.FilesFailed, strings.Join(res.FailedFiles, ", "))
+		if !r.opts.AllowPartialRestore {
+			return errors.New(msg)
+		}
+		r.warn("%s", msg)
+	}
+	if r.stateStaging != "" {
+		if entries, _ := os.ReadDir(r.stateStaging); len(entries) > 0 {
+			warnings, err := bmr.RestoreSystemStateOffline(ctx, r.staging, r.stateStaging)
+			r.warnings = append(r.warnings, warnings...)
+			if err != nil {
+				return fmt.Errorf("apply system state: %w", err)
+			}
+		}
+	}
+	return nil
+}

--- a/agent/internal/backup/rebuild/system.go
+++ b/agent/internal/backup/rebuild/system.go
@@ -26,8 +26,14 @@ type System interface {
 	AttachImage(path string, sizeBytes int64) (device string, detach func() error, err error)
 	PartitionDevice(disk string, number int) string // /dev/sda1, /dev/nvme0n1p1, /dev/loop0p1
 	Rescan(ctx context.Context, disk string) error  // partprobe + udevadm settle
-	MountedSources() ([]string, error)              // every SOURCE in /proc/self/mounts
-	RootSources() ([]string, error)                 // devices backing / and /run/live/medium (findmnt -no SOURCE)
+	// Exists reports whether path exists on the filesystem — used to poll
+	// for a partition device node to actually appear after Rescan, since
+	// sgdisk/partprobe telling the kernel about a new partition table and
+	// udev materializing the corresponding /dev entry are two separate,
+	// asynchronous steps.
+	Exists(path string) bool
+	MountedSources() ([]string, error) // every SOURCE in /proc/self/mounts
+	RootSources() ([]string, error)    // devices backing / and /run/live/medium (findmnt -no SOURCE)
 	Mount(ctx context.Context, device, dir, fstype string, opts ...string) error
 	BindMount(ctx context.Context, src, dir string) error
 	Unmount(ctx context.Context, dir string) error

--- a/agent/internal/backup/rebuild/system.go
+++ b/agent/internal/backup/rebuild/system.go
@@ -1,0 +1,54 @@
+package rebuild
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ErrUnsupportedHost is returned by Run when no System was supplied and the
+// host has no real implementation to fall back to (system_other.go's
+// NewSystem returns nil off Linux).
+var ErrUnsupportedHost = errors.New("the rebuild engine runs on Linux only in this release")
+
+// System is every interaction with the machine the engine needs. The real
+// implementation (system_linux.go) shells out; tests use fakeSystem
+// (system_fake_test.go).
+type System interface {
+	Run(ctx context.Context, name string, args ...string) ([]byte, error)
+	// Chroot returns a runner that executes inside root (via `chroot root name args…`).
+	Chroot(root string) func(ctx context.Context, name string, args ...string) ([]byte, error)
+	BlockDeviceSize(path string) (int64, error) // blockdev --getsize64
+	// AttachImage creates a sparse file if missing, then attaches it via
+	// losetup --find --show --partscan, returning the loop device and a
+	// detach func.
+	AttachImage(path string, sizeBytes int64) (device string, detach func() error, err error)
+	PartitionDevice(disk string, number int) string // /dev/sda1, /dev/nvme0n1p1, /dev/loop0p1
+	Rescan(ctx context.Context, disk string) error  // partprobe + udevadm settle
+	MountedSources() ([]string, error)              // every SOURCE in /proc/self/mounts
+	RootSources() ([]string, error)                 // devices backing / and /run/live/medium (findmnt -no SOURCE)
+	Mount(ctx context.Context, device, dir, fstype string, opts ...string) error
+	BindMount(ctx context.Context, src, dir string) error
+	Unmount(ctx context.Context, dir string) error
+	Sync(ctx context.Context) error
+	Arch() string // runtime.GOARCH
+}
+
+func partitionDevice(disk string, number int) string {
+	if len(disk) > 0 && disk[len(disk)-1] >= '0' && disk[len(disk)-1] <= '9' {
+		return fmt.Sprintf("%sp%d", disk, number)
+	}
+	return fmt.Sprintf("%s%d", disk, number)
+}
+
+func parseMountSources(procMounts string) []string {
+	var out []string
+	for _, line := range strings.Split(procMounts, "\n") {
+		f := strings.Fields(line)
+		if len(f) >= 2 {
+			out = append(out, f[0])
+		}
+	}
+	return out
+}

--- a/agent/internal/backup/rebuild/system_fake_test.go
+++ b/agent/internal/backup/rebuild/system_fake_test.go
@@ -1,0 +1,113 @@
+package rebuild
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// fakeSystem records every command, "mounts" devices by creating directories,
+// and answers size/mount questions from fields. Files restored under a
+// mounted dir land in the real filesystem under fake.dir, so later phases
+// and assertions can inspect them.
+type fakeSystem struct {
+	mu       sync.Mutex
+	dir      string   // temp root
+	cmds     []string // "name arg1 arg2"
+	diskSize int64
+	mounted  []string // devices reported by MountedSources
+	rootSrcs []string
+	fail     map[string]error // command prefix → error
+	arch     string
+	mountLog []string // "device dir"
+	unmounts []string
+}
+
+func newFakeSystem(dir string, diskSize int64) *fakeSystem {
+	return &fakeSystem{dir: dir, diskSize: diskSize, fail: map[string]error{}, arch: "amd64"}
+}
+
+func (f *fakeSystem) record(name string, args ...string) ([]byte, error) {
+	line := strings.TrimSpace(name + " " + strings.Join(args, " "))
+	f.mu.Lock()
+	f.cmds = append(f.cmds, line)
+	f.mu.Unlock()
+	for prefix, err := range f.fail {
+		if strings.HasPrefix(line, prefix) {
+			return []byte("simulated failure"), err
+		}
+	}
+	return nil, nil
+}
+
+func (f *fakeSystem) Run(_ context.Context, name string, args ...string) ([]byte, error) {
+	return f.record(name, args...)
+}
+func (f *fakeSystem) Chroot(root string) func(context.Context, string, ...string) ([]byte, error) {
+	return func(_ context.Context, name string, args ...string) ([]byte, error) {
+		return f.record("chroot", append([]string{root, name}, args...)...)
+	}
+}
+func (f *fakeSystem) BlockDeviceSize(string) (int64, error) { return f.diskSize, nil }
+func (f *fakeSystem) AttachImage(path string, size int64) (string, func() error, error) {
+	_, _ = f.record("losetup", "--find", "--show", "--partscan", path)
+	return "/dev/loop7", func() error { _, _ = f.record("losetup", "-d", "/dev/loop7"); return nil }, nil
+}
+func (f *fakeSystem) PartitionDevice(disk string, n int) string { return partitionDevice(disk, n) }
+func (f *fakeSystem) Rescan(_ context.Context, disk string) error {
+	_, err := f.record("partprobe", disk)
+	return err
+}
+func (f *fakeSystem) MountedSources() ([]string, error) { return f.mounted, nil }
+func (f *fakeSystem) RootSources() ([]string, error)    { return f.rootSrcs, nil }
+func (f *fakeSystem) Mount(_ context.Context, device, dir, fstype string, opts ...string) error {
+	_, err := f.record("mount", append([]string{"-t", fstype, device, dir}, opts...)...)
+	if err != nil {
+		return err
+	}
+	f.mountLog = append(f.mountLog, device+" "+dir)
+	return os.MkdirAll(dir, 0o755)
+}
+func (f *fakeSystem) BindMount(_ context.Context, src, dir string) error {
+	_, err := f.record("mount", "--bind", src, dir)
+	if err != nil {
+		return err
+	}
+	return os.MkdirAll(dir, 0o755)
+}
+func (f *fakeSystem) Unmount(_ context.Context, dir string) error {
+	f.unmounts = append(f.unmounts, dir)
+	_, err := f.record("umount", dir)
+	return err
+}
+func (f *fakeSystem) Sync(context.Context) error { _, err := f.record("sync"); return err }
+func (f *fakeSystem) Arch() string               { return f.arch }
+
+func (f *fakeSystem) has(prefix string) bool {
+	for _, c := range f.cmds {
+		if strings.HasPrefix(c, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func (f *fakeSystem) indexOf(prefix string) int {
+	for i, c := range f.cmds {
+		if strings.HasPrefix(c, prefix) {
+			return i
+		}
+	}
+	return -1
+}
+
+func (f *fakeSystem) dump() string { return fmt.Sprintf("commands:\n  %s", strings.Join(f.cmds, "\n  ")) }
+
+var _ System = (*fakeSystem)(nil)
+
+func stagingPath(root string, parts ...string) string {
+	return filepath.Join(append([]string{root}, parts...)...)
+}

--- a/agent/internal/backup/rebuild/system_fake_test.go
+++ b/agent/internal/backup/rebuild/system_fake_test.go
@@ -56,6 +56,11 @@ func (f *fakeSystem) AttachImage(path string, size int64) (string, func() error,
 	return "/dev/loop7", func() error { _, _ = f.record("losetup", "-d", "/dev/loop7"); return nil }, nil
 }
 func (f *fakeSystem) PartitionDevice(disk string, n int) string { return partitionDevice(disk, n) }
+
+// Exists always reports true: fakeSystem has no real device nodes, and no
+// current test needs to simulate a partition device node that never
+// appears (the loopback test, real-Linux-only, is what proves that path).
+func (f *fakeSystem) Exists(string) bool { return true }
 func (f *fakeSystem) Rescan(_ context.Context, disk string) error {
 	_, err := f.record("partprobe", disk)
 	return err

--- a/agent/internal/backup/rebuild/system_fake_test.go
+++ b/agent/internal/backup/rebuild/system_fake_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 )
@@ -104,10 +103,8 @@ func (f *fakeSystem) indexOf(prefix string) int {
 	return -1
 }
 
-func (f *fakeSystem) dump() string { return fmt.Sprintf("commands:\n  %s", strings.Join(f.cmds, "\n  ")) }
+func (f *fakeSystem) dump() string {
+	return fmt.Sprintf("commands:\n  %s", strings.Join(f.cmds, "\n  "))
+}
 
 var _ System = (*fakeSystem)(nil)
-
-func stagingPath(root string, parts ...string) string {
-	return filepath.Join(append([]string{root}, parts...)...)
-}

--- a/agent/internal/backup/rebuild/system_linux.go
+++ b/agent/internal/backup/rebuild/system_linux.go
@@ -1,0 +1,128 @@
+//go:build linux
+
+package rebuild
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+type realSystem struct{}
+
+// NewSystem returns the real OS implementation.
+func NewSystem() System { return realSystem{} }
+
+func (realSystem) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, name, args...).CombinedOutput()
+}
+
+func (s realSystem) Chroot(root string) func(context.Context, string, ...string) ([]byte, error) {
+	return func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		return s.Run(ctx, "chroot", append([]string{root, name}, args...)...)
+	}
+}
+
+func (s realSystem) BlockDeviceSize(path string) (int64, error) {
+	out, err := s.Run(context.Background(), "blockdev", "--getsize64", path)
+	if err != nil {
+		return 0, fmt.Errorf("blockdev --getsize64 %s: %s: %w", path, strings.TrimSpace(string(out)), err)
+	}
+	return strconv.ParseInt(strings.TrimSpace(string(out)), 10, 64)
+}
+
+func (s realSystem) AttachImage(path string, sizeBytes int64) (string, func() error, error) {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		if sizeBytes <= 0 {
+			return "", nil, fmt.Errorf("image %s does not exist and no size was given", path)
+		}
+		f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0o600)
+		if err != nil {
+			return "", nil, err
+		}
+		if err := f.Truncate(sizeBytes); err != nil {
+			f.Close()
+			return "", nil, err
+		}
+		f.Close()
+	}
+	out, err := s.Run(context.Background(), "losetup", "--find", "--show", "--partscan", path)
+	if err != nil {
+		return "", nil, fmt.Errorf("losetup %s: %s: %w", path, strings.TrimSpace(string(out)), err)
+	}
+	dev := strings.TrimSpace(string(out))
+	return dev, func() error { _, err := s.Run(context.Background(), "losetup", "-d", dev); return err }, nil
+}
+
+func (realSystem) PartitionDevice(disk string, n int) string { return partitionDevice(disk, n) }
+
+func (s realSystem) Rescan(ctx context.Context, disk string) error {
+	if out, err := s.Run(ctx, "partprobe", disk); err != nil {
+		return fmt.Errorf("partprobe %s: %s: %w", disk, strings.TrimSpace(string(out)), err)
+	}
+	_, _ = s.Run(ctx, "udevadm", "settle", "--timeout=15")
+	return nil
+}
+
+func (realSystem) MountedSources() ([]string, error) {
+	data, err := os.ReadFile("/proc/self/mounts")
+	if err != nil {
+		return nil, err
+	}
+	return parseMountSources(string(data)), nil
+}
+
+func (s realSystem) RootSources() ([]string, error) {
+	var out []string
+	for _, mp := range []string{"/", "/run/live/medium", "/lib/live/mount/medium"} {
+		b, err := s.Run(context.Background(), "findmnt", "-no", "SOURCE", mp)
+		if err == nil {
+			if src := strings.TrimSpace(string(b)); src != "" {
+				out = append(out, src)
+			}
+		}
+	}
+	return out, nil
+}
+
+func (s realSystem) Mount(ctx context.Context, device, dir, fstype string, opts ...string) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	args := []string{}
+	if fstype != "" {
+		args = append(args, "-t", fstype)
+	}
+	if len(opts) > 0 {
+		args = append(args, "-o", strings.Join(opts, ","))
+	}
+	args = append(args, device, dir)
+	if out, err := s.Run(ctx, "mount", args...); err != nil {
+		return fmt.Errorf("mount %s %s: %s: %w", device, dir, strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
+func (s realSystem) BindMount(ctx context.Context, src, dir string) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	if out, err := s.Run(ctx, "mount", "--bind", src, dir); err != nil {
+		return fmt.Errorf("bind mount %s %s: %s: %w", src, dir, strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
+func (s realSystem) Unmount(ctx context.Context, dir string) error {
+	if out, err := s.Run(ctx, "umount", dir); err != nil {
+		return fmt.Errorf("umount %s: %s: %w", dir, strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
+func (s realSystem) Sync(ctx context.Context) error { _, err := s.Run(ctx, "sync"); return err }
+func (realSystem) Arch() string                     { return runtime.GOARCH }

--- a/agent/internal/backup/rebuild/system_linux.go
+++ b/agent/internal/backup/rebuild/system_linux.go
@@ -45,10 +45,10 @@ func (s realSystem) AttachImage(path string, sizeBytes int64) (string, func() er
 			return "", nil, err
 		}
 		if err := f.Truncate(sizeBytes); err != nil {
-			f.Close()
+			_ = f.Close()
 			return "", nil, err
 		}
-		f.Close()
+		_ = f.Close()
 	}
 	out, err := s.Run(context.Background(), "losetup", "--find", "--show", "--partscan", path)
 	if err != nil {

--- a/agent/internal/backup/rebuild/system_linux.go
+++ b/agent/internal/backup/rebuild/system_linux.go
@@ -60,6 +60,11 @@ func (s realSystem) AttachImage(path string, sizeBytes int64) (string, func() er
 
 func (realSystem) PartitionDevice(disk string, n int) string { return partitionDevice(disk, n) }
 
+func (realSystem) Exists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
 func (s realSystem) Rescan(ctx context.Context, disk string) error {
 	if out, err := s.Run(ctx, "partprobe", disk); err != nil {
 		return fmt.Errorf("partprobe %s: %s: %w", disk, strings.TrimSpace(string(out)), err)

--- a/agent/internal/backup/rebuild/system_linux_test.go
+++ b/agent/internal/backup/rebuild/system_linux_test.go
@@ -1,0 +1,31 @@
+//go:build linux
+
+package rebuild
+
+import "testing"
+
+func TestPartitionDevice(t *testing.T) {
+	for _, tt := range []struct {
+		disk string
+		n    int
+		want string
+	}{
+		{"/dev/sda", 2, "/dev/sda2"},
+		{"/dev/nvme0n1", 3, "/dev/nvme0n1p3"},
+		{"/dev/loop0", 1, "/dev/loop0p1"},
+		{"/dev/mmcblk0", 2, "/dev/mmcblk0p2"},
+		{"/dev/vda", 1, "/dev/vda1"},
+	} {
+		if got := partitionDevice(tt.disk, tt.n); got != tt.want {
+			t.Errorf("%s #%d = %s want %s", tt.disk, tt.n, got, tt.want)
+		}
+	}
+}
+
+func TestParseMountSources(t *testing.T) {
+	in := "sysfs /sys sysfs rw 0 0\n/dev/sda2 / ext4 rw 0 0\n/dev/sda1 /boot/efi vfat rw 0 0\n"
+	got := parseMountSources(in)
+	if len(got) != 3 || got[1] != "/dev/sda2" || got[2] != "/dev/sda1" {
+		t.Errorf("got %v", got)
+	}
+}

--- a/agent/internal/backup/rebuild/system_other.go
+++ b/agent/internal/backup/rebuild/system_other.go
@@ -1,0 +1,6 @@
+//go:build !linux
+
+package rebuild
+
+// NewSystem is unavailable off Linux in this wave (Windows engine is W06).
+func NewSystem() System { return nil }

--- a/agent/internal/backup/rebuild/types.go
+++ b/agent/internal/backup/rebuild/types.go
@@ -113,19 +113,28 @@ type Plan struct {
 
 // Options configures a single Run call.
 type Options struct {
-	SnapshotID string
-	Provider   providers.BackupProvider
-	Target     Target
-	Identity   IdentityMode
-	Marker     *Marker          // original identity only
-	Layout     *layout.Manifest // nil → downloaded from snapshots/<id>/layout.json
-	StateDir   string           // default /var/lib/breeze/rebuild
-	StagingRoot string          // default <StateDir>/mnt/<snapshotID>
+	SnapshotID  string
+	Provider    providers.BackupProvider
+	Target      Target
+	Identity    IdentityMode
+	Marker      *Marker          // original identity only
+	Layout      *layout.Manifest // nil → downloaded from snapshots/<id>/layout.json
+	StateDir    string           // default /var/lib/breeze/rebuild
+	StagingRoot string           // default <StateDir>/mnt/<snapshotID>
 
 	DryRun              bool // preflight only; returns the Plan
 	ForceReprovision    bool
 	AllowPartialRestore bool
-	RegenerateInitramfs bool // default true; CLI --no-initramfs clears it
+	// RegenerateInitramfs is NOT defaulted by Run() — a bare Options{} leaves
+	// it false (Go's zero value), same as any other bool field. "Default
+	// true" is a CLI-level convention: breeze-backup rebuild always passes
+	// this explicitly (RegenerateInitramfs: !noInitramfs), so an operator
+	// who never touches --no-initramfs gets regeneration without asking for
+	// it — but Run() itself cannot distinguish "caller left it unset,
+	// wants the default" from "caller explicitly wants no regen" (both are
+	// the zero value), so a direct Options caller (tests, a future W04
+	// console) must set it explicitly to get initramfs regeneration.
+	RegenerateInitramfs bool
 	SkipBoot            bool // tests/CI only: synthetic roots have no bootloader
 
 	System   System // nil → real system (system_linux.go)

--- a/agent/internal/backup/rebuild/types.go
+++ b/agent/internal/backup/rebuild/types.go
@@ -1,0 +1,162 @@
+// Package rebuild implements the bare-metal recovery engine (spec §6): given
+// a snapshot id, its recorded disk layout, a target (block device or raw
+// image file), and an identity mode, it provisions GPT partitions, restores
+// the whole-machine file snapshot, applies Linux system state offline,
+// installs/refreshes the bootloader, writes the identity marker, validates,
+// and returns a structured Result. All OS interaction goes through the
+// System seam (system.go) so the engine is fully testable without root.
+package rebuild
+
+import (
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/backup/layout"
+	"github.com/breeze-rmm/agent/internal/backup/providers"
+)
+
+// TargetKind selects what rebuild.Run writes to.
+type TargetKind string
+
+const (
+	TargetDisk  TargetKind = "disk"
+	TargetImage TargetKind = "image"
+)
+
+// Target is where the engine provisions and restores the machine.
+type Target struct {
+	Kind TargetKind `json:"kind"`
+	Path string     `json:"path"`
+	// ImageSizeBytes is used only for TargetImage: the size to create the
+	// file at when it does not already exist (sparse).
+	ImageSizeBytes int64 `json:"imageSizeBytes,omitempty"`
+}
+
+// IdentityMode selects whether the rebuilt machine keeps the source
+// machine's identity (bound to a pending recovery via Marker) or becomes a
+// fresh, unenrolled machine.
+type IdentityMode string
+
+const (
+	IdentityOriginal IdentityMode = "original"
+	IdentityNew      IdentityMode = "new"
+)
+
+// Marker binds the restored device to a pending server-side recovery (W04).
+type Marker struct {
+	RecoveryID string `json:"recoveryId"`
+	Nonce      string `json:"nonce"`
+}
+
+// Phase is one of the seven engine phases, always run and reported in the
+// same order.
+type Phase string
+
+const (
+	PhasePreflight  Phase = "preflight"
+	PhaseProvision  Phase = "provision"
+	PhaseRestore    Phase = "restore"
+	PhaseBoot       Phase = "boot"
+	PhaseIdentity   Phase = "identity"
+	PhaseEncryption Phase = "encryption"
+	PhaseValidate   Phase = "validate"
+)
+
+// AllPhases is the fixed phase order every rebuild.Run reports.
+var AllPhases = []Phase{PhasePreflight, PhaseProvision, PhaseRestore, PhaseBoot, PhaseIdentity, PhaseEncryption, PhaseValidate}
+
+// PhaseStatus is the outcome of one phase within a single Run call.
+type PhaseStatus string
+
+const (
+	PhaseCompleted PhaseStatus = "completed"
+	PhaseSkipped   PhaseStatus = "skipped" // resumed run: already done by an earlier call
+	PhaseFailed    PhaseStatus = "failed"
+	PhaseRefused   PhaseStatus = "refused"
+)
+
+// PhaseResult records one phase's outcome and timing within Result.Phases.
+type PhaseResult struct {
+	Phase       Phase       `json:"phase"`
+	Status      PhaseStatus `json:"status"`
+	StartedAt   time.Time   `json:"startedAt"`
+	CompletedAt time.Time   `json:"completedAt"`
+	Message     string      `json:"message,omitempty"`
+}
+
+// PlannedPartition is one partition PlanPartitions laid out on the target.
+type PlannedPartition struct {
+	Number     int    `json:"number"`
+	Role       string `json:"role"`
+	TypeGUID   string `json:"typeGuid"`
+	PartUUID   string `json:"partUuid,omitempty"`
+	Name       string `json:"name,omitempty"`
+	StartBytes int64  `json:"startBytes"`
+	SizeBytes  int64  `json:"sizeBytes"`
+	Filesystem string `json:"filesystem,omitempty"`
+	FSUUID     string `json:"fsUuid,omitempty"`
+	Label      string `json:"label,omitempty"`
+	MountPoint string `json:"mountPoint,omitempty"`
+	Grown      bool   `json:"grown"` // absorbed the target's extra (or short) space
+}
+
+// Plan is PlanPartitions' output: the partition table the engine will
+// provision on the target.
+type Plan struct {
+	SourceDisk      string             `json:"sourceDisk"`
+	SourceSizeBytes int64              `json:"sourceSizeBytes"`
+	TargetPath      string             `json:"targetPath"`
+	TargetSizeBytes int64              `json:"targetSizeBytes"`
+	SectorSize      int                `json:"sectorSize"`
+	Partitions      []PlannedPartition `json:"partitions"`
+	MinimumBytes    int64              `json:"minimumBytes"` // what the target must offer
+}
+
+// Options configures a single Run call.
+type Options struct {
+	SnapshotID string
+	Provider   providers.BackupProvider
+	Target     Target
+	Identity   IdentityMode
+	Marker     *Marker          // original identity only
+	Layout     *layout.Manifest // nil → downloaded from snapshots/<id>/layout.json
+	StateDir   string           // default /var/lib/breeze/rebuild
+	StagingRoot string          // default <StateDir>/mnt/<snapshotID>
+
+	DryRun              bool // preflight only; returns the Plan
+	ForceReprovision    bool
+	AllowPartialRestore bool
+	RegenerateInitramfs bool // default true; CLI --no-initramfs clears it
+	SkipBoot            bool // tests/CI only: synthetic roots have no bootloader
+
+	System   System // nil → real system (system_linux.go)
+	Progress func(phase Phase, message string, current, total int64)
+}
+
+// Result is Run's structured outcome.
+type Result struct {
+	SnapshotID    string        `json:"snapshotId"`
+	Target        Target        `json:"target"`
+	Identity      IdentityMode  `json:"identity"`
+	Status        string        `json:"status"` // completed | refused | failed
+	PhaseReached  Phase         `json:"phaseReached"`
+	Phases        []PhaseResult `json:"phases"`
+	Plan          *Plan         `json:"plan,omitempty"`
+	Refusal       string        `json:"refusal,omitempty"`
+	Error         string        `json:"error,omitempty"`
+	Warnings      []string      `json:"warnings,omitempty"`
+	FilesRestored int           `json:"filesRestored"`
+	BytesRestored int64         `json:"bytesRestored"`
+	DurationMs    int64         `json:"durationMs"`
+	Resumed       bool          `json:"resumed"`
+}
+
+// RefusalError carries an operator-facing reason; Run maps it to Status
+// "refused" without touching the target.
+type RefusalError struct{ Reason string }
+
+func (e *RefusalError) Error() string { return "refused: " + e.Reason }
+
+const (
+	MiB = int64(1) << 20
+	GiB = int64(1) << 30
+)

--- a/agent/internal/backup/rebuild/types.go
+++ b/agent/internal/backup/rebuild/types.go
@@ -108,7 +108,8 @@ type Plan struct {
 	TargetSizeBytes int64              `json:"targetSizeBytes"`
 	SectorSize      int                `json:"sectorSize"`
 	Partitions      []PlannedPartition `json:"partitions"`
-	MinimumBytes    int64              `json:"minimumBytes"` // what the target must offer
+	MinimumBytes    int64              `json:"minimumBytes"`       // what the target must offer
+	Warnings        []string           `json:"warnings,omitempty"` // non-fatal planning issues, e.g. a partition with no recorded filesystem UUID
 }
 
 // Options configures a single Run call.

--- a/agent/internal/backup/rebuild/validate.go
+++ b/agent/internal/backup/rebuild/validate.go
@@ -1,0 +1,95 @@
+package rebuild
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/breeze-rmm/agent/internal/backup"
+)
+
+const validateSampleSize = 64
+
+// identityMutatedPaths lists snapshot source paths the identity phase's
+// IdentityNew branch (applyNewIdentity) intentionally rewrites or removes.
+// validate's restored-file checksum sample must skip them for an IdentityNew
+// run — a byte difference there is the whole point of that phase, not a
+// sign of restore corruption.
+var identityMutatedPaths = map[string]bool{
+	"/etc/machine-id":          true,
+	"/etc/hostname":            true,
+	"/etc/breeze/agent.yaml":   true,
+	"/etc/breeze/secrets.yaml": true,
+}
+
+// validate proves the rebuild before declaring success: a sample of
+// restored files still hashes to what the snapshot recorded, the boot
+// phase's expected artifacts exist, fstab references only UUIDs actually on
+// the rebuilt disk, then flushes and releases the target.
+func validate(ctx context.Context, r *run) error {
+	// 1. Sample checksums of restored files.
+	var withSum []backup.SnapshotFile
+	if r.manifest != nil {
+		for _, f := range r.manifest.Files {
+			if !f.HasContent() || f.Checksum == "" {
+				continue
+			}
+			if r.opts.Identity == IdentityNew && identityMutatedPaths[f.SourcePath] {
+				continue
+			}
+			withSum = append(withSum, f)
+		}
+	}
+	step := 1
+	if len(withSum) > validateSampleSize {
+		step = len(withSum) / validateSampleSize
+	}
+	checked, mismatched := 0, []string{}
+	for i := 0; i < len(withSum); i += step {
+		f := withSum[i]
+		target := filepath.Join(r.staging, filepath.FromSlash(strings.TrimPrefix(f.SourcePath, "/")))
+		sum, err := backup.SHA256File(target)
+		if err != nil || sum != f.Checksum {
+			mismatched = append(mismatched, f.SourcePath)
+		}
+		checked++
+	}
+	if len(mismatched) > 0 {
+		return fmt.Errorf("%d of %d sampled files differ from the snapshot: %s", len(mismatched), checked, strings.Join(mismatched, ", "))
+	}
+	// 2. Boot artefacts.
+	if !r.opts.SkipBoot {
+		_, efiFile := grubTarget(r.sys.Arch())
+		if !fileExists(filepath.Join(r.staging, "boot", "efi", "EFI", "BOOT", efiFile)) {
+			return fmt.Errorf("EFI/BOOT/%s missing after boot phase", efiFile)
+		}
+		if !fileExists(filepath.Join(r.staging, "boot", "grub", "grub.cfg")) && !fileExists(filepath.Join(r.staging, "boot", "grub2", "grub.cfg")) && !fileExists(filepath.Join(r.staging, "boot", "efi", "EFI", bootloaderID(r.staging), "grub.cfg")) {
+			return errors.New("no grub.cfg found in the restored tree")
+		}
+	}
+	// 3. fstab UUIDs resolve to planned partitions.
+	if fstab, err := os.ReadFile(filepath.Join(r.staging, "etc", "fstab")); err == nil {
+		known := map[string]bool{}
+		for _, p := range r.result.Plan.Partitions {
+			known[strings.ToLower(p.FSUUID)] = true
+		}
+		for _, line := range strings.Split(string(fstab), "\n") {
+			f := strings.Fields(line)
+			if len(f) == 0 || strings.HasPrefix(f[0], "#") {
+				continue
+			}
+			if u, ok := strings.CutPrefix(f[0], "UUID="); ok && !known[strings.ToLower(u)] {
+				r.warn("fstab references UUID %s which is not on the rebuilt disk (%s)", u, line)
+			}
+		}
+	}
+	// 4. Flush and release.
+	if err := r.sys.Sync(ctx); err != nil {
+		return err
+	}
+	r.teardown()
+	return nil
+}

--- a/agent/internal/backup/snapshot.go
+++ b/agent/internal/backup/snapshot.go
@@ -22,9 +22,13 @@ import (
 	"github.com/breeze-rmm/agent/internal/backup/systemstate"
 )
 
-// sha256File streams a file through SHA-256 and returns the lowercase-hex
-// digest. Streaming keeps memory flat for large files.
-func sha256File(path string) (string, error) {
+// SHA256File streams a file through SHA-256 and returns the lowercase-hex
+// digest. Streaming keeps memory flat for large files. Exported so other
+// packages needing the same "hash this restored file and compare" check
+// (the rebuild engine's validate phase) never drift from this package's own
+// checksum logic — see sha256File, the unexported alias every call site in
+// this package already uses.
+func SHA256File(path string) (string, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return "", err
@@ -36,6 +40,11 @@ func sha256File(path string) (string, error) {
 	}
 	return hex.EncodeToString(h.Sum(nil)), nil
 }
+
+// sha256File is an unexported alias for SHA256File — kept so every existing
+// call site in this package (written before SHA256File was exported) needs
+// no change.
+func sha256File(path string) (string, error) { return SHA256File(path) }
 
 // checksumMatches reports whether the file at path hashes to want. A hashing
 // error counts as a mismatch (fail-closed) so verification never passes a file


### PR DESCRIPTION
## Summary

Wave 03 of #5493: `agent/internal/backup/rebuild`, a Go package that takes a snapshot id + its `layout.json` (W01) + a target (block device or raw image) + an identity mode and provisions GPT partitions, restores the whole-machine file snapshot, applies Linux system state offline, installs/refreshes the bootloader, writes the identity marker, validates, and returns a structured `Result` — plus a `breeze-backup rebuild` CLI. Everything is testable without root through a `System` seam; a root-gated loopback test proves provisioning for real.

### Task-by-task

- **Task 1** — `rebuild.Options/Result/Plan/PlannedPartition/RefusalError` and the pure `PlanPartitions` (fixed partitions keep size, the last root/data partition grows/shrinks to fill the target, 1 MiB alignment, refuses when too small or an unsupported filesystem appears).
- **Task 2** — the `System` interface (12 OS operations: Run, Chroot, BlockDeviceSize, AttachImage, PartitionDevice, Rescan, Exists, MountedSources, RootSources, Mount, BindMount, Unmount, Sync, Arch), `system_linux.go` (real), `system_other.go` (nil off Linux), and a recording `fakeSystem` test double.
- **Task 3** (`bmr` package) — `DownloadSystemState` (new, hard-fails on the first artifact verification problem — preflight's whole point is to refuse before any write) and `RestoreSystemStateOffline` (applies system state under a mounted, not-yet-booted tree: `systemctl --root=`, firewall/crontabs staged as files, package reinstall skipped). Kept independent from `applySystemState`'s existing soft-fail artifact loop — see Deviations.
- **Task 4** — `Run`'s seven-phase state machine with a resumable JSON state file (`<StateDir>/rebuild-<snapshotID>-<targetHash>.json`), `preflight` (layout guard, target sizing/safety, manifest+state checksum verification — no writes), `provision` (sgdisk + mkfs with recorded type/partition GUIDs and filesystem UUIDs), `restoreTree` (mount, whole-machine restore, offline state apply).
- **Task 5** — `boot` (Debian/RHEL detection, chroot grub-install/update-grub/update-initramfs, always leaves an `EFI/BOOT/BOOT<ARCH>.EFI` fallback), `identity` (recovery marker for `original`, machine-id/hostname/enrollment reset for `new`), `validate` (sampled checksums, boot artifacts, fstab UUIDs, sync+teardown). Exported `backup.SHA256File` so validate shares the backup package's own checksum logic.
- **Task 6** — `breeze-backup rebuild` CLI + `TestRun_LoopbackRealSystem` (root-gated, `BREEZE_REBUILD_LOOP_TEST=1`) + CI wiring in `.github/workflows/ci.yml`'s `test-agent` job.
- **Task 7** (lab proof + boot on KIT) is **not done** — out of scope per the assignment; left for the orchestrator.

### CLI synopsis

```
breeze-backup rebuild --snapshot <id> --target disk:/dev/sdb|image:/path.img [--image-size 40G] \
  --provider-config <file.json> --identity original|new [--marker-file <json>] \
  [--result-json <path>] [--dry-run] [--force-reprovision] [--allow-partial] \
  [--no-initramfs] [--skip-boot] [--state-dir <dir>]
```

`--provider-config` is a JSON file `{"provider":"s3|local","providerConfig":{...}}` — the same shape a `backup_run`/restore command payload carries — resolved via `exec_backup.go`'s existing `restoreProviderFromPayload` so provider construction is never duplicated.

## Review fixes (round 1)

Three confirmed defects from review, fixed red-first on this branch:

1. **CRITICAL — image-target resume never re-attached the loop device.** `teardown()` always detaches the loop on `Run()` exit (even on failure); `runState` persisted the attached device path, and `reattach()` only re-attached when `r.disk == ""`, so a resumed image run mounted whatever stale/foreign device the first run's loop happened to be. Fixed by never persisting/restoring the attached device across `Run()` calls — `reattach()` now always re-derives it (a fresh `AttachImage`/`losetup` for `TargetImage`, a trivial recompute for `TargetDisk`), then `Rescan`s and polls (new `System.Exists`, up to 10s, shared with `provision()`'s own first-run path which had the identical gap) for the planned partition device nodes before mounting.
   - Red: `TestRun_ResumeImageTargetReattachesLoop` — `engine_test.go:423: resume did not re-attach the image via losetup` (sys2's commands went straight to `mount -t ext4 /dev/loop7p3 ...` with zero `losetup` calls — the exact stale-device bug).
   - Green: same test passes; `losetup --find --show --partscan <img>` recorded before any `mount`, no `sgdisk`/`mkfs` on resume, run completes. Disk-target sibling `TestRun_ResumeDiskTargetNeverCallsLosetup` asserts zero `losetup` calls for a disk target, fresh or resumed.

2. **IMPORTANT — `bmr.DownloadSystemState` returned `ErrNoSystemState` for ANY manifest-download error, not only a confirmed-absent object.** With `expect=false`, preflight would warn and proceed into destructive phases after a mere transport failure. Fixed: `ErrNoSystemState` now returned only when `errors.Is(dlErr, providers.ErrObjectNotFound)` (the repo's documented confirmed-absent sentinel); every other error is wrapped and `preflight` turns it into a `RefusalError` (`"system state could not be verified: ..."`). `applySystemState`'s behavior and full test suite are unchanged (it never calls `DownloadSystemState` — see Deviations below).
   - Red: `TestDownloadSystemState_ClassifiesManifestDownloadErrors/transport_timeout` — `download_system_state_test.go:155: err = bmr: no system state found in snapshot, must NOT be ErrNoSystemState for a transport failure`.
   - Green: same test (table: not-found → sentinel, `errors.New("timeout")` → wrapped error containing "timeout", never the sentinel); new engine test `TestRun_PreflightRefusesOnSystemStateTransportError` (memProvider returns a non-not-found error for the state manifest → `status: refused`, no `sgdisk`/`mkfs`/`mount`).

3. **IMPORTANT — preflight's wrong-disk check used a bare `strings.HasPrefix`**, so target `/dev/sda` collided with the unrelated disk `/dev/sdaa1` (and `/dev/nvme0n1` vs `/dev/nvme0n10`). New `deviceBelongsTo(disk, dev string) bool` applies `partitionDevice`'s own naming rule (a disk ending in a digit — nvme/mmcblk/loop — always gets a mandatory `p` infix before the partition number; a disk ending in a letter — sd/vd — never does), used for both `MountedSources` and `RootSources` checks.
   - Red: build failure (`undefined: deviceBelongsTo`) before the helper existed, since the test was written first.
   - Green: `TestDeviceBelongsTo`, all 6 reviewer-specified cases (`/dev/sda`+`/dev/sda1`→true, `/dev/sda`+`/dev/sdaa1`→false, `/dev/nvme0n1`+`/dev/nvme0n1p2`→true, `/dev/nvme0n1`+`/dev/nvme0n10`→false, `/dev/loop0`+`/dev/loop0p1`→true, `/dev/sda`+`/dev/sda`→true).

4. **CI loopback step.** Broadened the `apt-get` line (`gdisk dosfstools e2fsprogs xfsprogs parted util-linux udev`), added `sudo udevadm settle || true` before the test, pinned `-count=1`, and added a guard so a `--- SKIP` in the test output fails the step (`exit 1`) instead of reading as green. Also fixed the likely root cause the reviewer named: `provision()`'s first-run path (not just `reattach()`) called `Rescan` (`partprobe`) and went straight to `mkfs` with no wait for the kernel-registered partition to actually get a `/dev` entry from udev — both paths now share `waitForPartitionDevices` (polls `System.Exists` up to 10s). Confirmed in a privileged `golang:1.26` container that this now fails fast with a clear message (`partition device /dev/loop1p1 did not appear within 10s of rescan`) instead of the previous confusing raw `mkfs.vfat: unable to open ...` error or an unbounded hang — the container still has no working `udevd` at all (Docker-Desktop-on-macOS sandbox limitation, not a code bug — GitHub Actions' `ubuntu-latest` is a full VM with `systemd-udevd`), so I still could not prove this step green in this sandbox. The actual CI run on this PR is the real proof; flagging for the orchestrator to confirm.

### Review-fix verification

| Command | Result |
|---|---|
| `go test -race -count=1 ./internal/backup/rebuild/... ./internal/backup/bmr/...` (native darwin) | **ok** |
| `go test -race -count=1 ./internal/backup/rebuild/... ./internal/backup/bmr/... ./cmd/breeze-backup/...` (`docker run golang:1.26`, real Linux) | **ok**, all three packages, all platform-gated full-flow + new tests |
| `go test -race -count=1 ./...` (native darwin) | **ok** — full 80-package agent suite |
| `git fetch origin main && golangci-lint run --new-from-rev=origin/main ./...` (Docker, matching `Lint Agent (Go)` CI exactly: `ubuntu-latest`-equivalent, `CGO_ENABLED=0`, v2.12.2, main repo's `.git` mounted alongside the worktree) | **`0 issues.`** |
| `GOOS=linux go vet ./...` | clean |
| `GOOS=windows go vet ./internal/backup/...` | same 3 pre-existing `vss_windows.go` warnings noted below, untouched |
| `GOOS=windows/darwin/linux go build ./cmd/breeze-backup/` | ok, all three |

## Review fixes (round 2)

CI's loopback job (a real GH Actions Linux runner) reached mkfs for real and hit the bug our fakeSystem-based unit tests couldn't see:

```
loopback_linux_test.go:38: run: mkfs.ext4 /dev/loop0p2: /dev/loop0p2: could not parse UUID: boot-uuid: exit status 1
```

`losetup`/`partprobe`/partition-node creation all worked fine on the real runner (confirming round 1's fix #4 did its job) — the failure was our own test fixtures: `srcDisk()`'s boot/root `FSUUID` values (`"boot-uuid"`, `"9f7a-root"`) were never valid UUIDs, something only a real `mkfs` invocation (not the fakeSystem-based unit tests) could ever catch.

1. **Fixtures now use real UUID formats.** `srcDisk()` (`plan_test.go`) and every dependent fixture: boot `FSUUID` → `1b3c5d7e-9f01-4a2b-8c3d-4e5f6a7b8c9d`, root `FSUUID` → `9f7a2c41-6b3e-4d5f-8a9b-0c1d2e3f4a5b`, all three `PartUUID`s → real 8-4-4-4-12 hex GUIDs; the EFI `FSUUID` keeps its real vfat volume-id shape (`ABCD-1234`, 4-4 hex) unchanged. Updated every assertion that embedded the old placeholder strings: `engine_test.go`'s `seedSnapshot` fstab fixture and its `mkfs`/`sgdisk --partition-guid` command assertions, and `loopback_linux_test.go`'s `blkid` assertion.
2. **Preflight now validates filesystem UUID format before any write.** New `validateFSUUID`, wired into `PlanPartitions`' existing per-partition loop: `ext4`/`xfs`/`swap` require `^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`; `vfat`/`fat32` require `^[0-9A-Fa-f]{4}-?[0-9A-Fa-f]{4}$`. A malformed value now refuses with `RefusalError` `"partition N filesystem UUID %q is not a valid <ext4|xfs|swap> UUID (expected 8-4-4-4-12 hex)"` (or the vfat equivalent) instead of a mid-provision `mkfs` failure after `sgdisk` has already wiped the target's partition table. An **empty** `FSUUID` stays allowed (`mkfs` generates a fresh one) and instead adds a new `Plan.Warnings` entry (`"partition N has no recorded UUID; fstab entries using UUID= for it will not resolve"`), since `PlanPartitions`' exported signature (`(*Plan, error)`) doesn't change — the warning rides on the returned `Plan` itself.
   - Red: `TestPlanPartitions_RefusesMalformedUUIDs` — build failure (`p.Warnings undefined`) before `Plan.Warnings` existed; after adding the field, the `malformed_ext4_UUID`/`malformed_vfat_UUID` subtests failed with `err == nil` before `validateFSUUID` existed and was wired in.
   - Green: same test (table: `ext4` `"boot-uuid"` → refused, `vfat` `"ZZZZ-1234"` → refused, a valid set → passes unchanged) plus `TestPlanPartitions_EmptyFSUUID_WarnsButDoesNotRefuse` (empty `FSUUID` → no error, `Plan.Warnings` contains the "no recorded UUID" message).

Also confirmed in a privileged `golang:1.26` container that the fixture fix resolves the actual `mkfs` failure — the loopback test now gets past `mkfs` entirely and fails only on the already-documented, unrelated `udevd`-less-sandbox limitation (`partition device /dev/loop1p1 did not appear within 10s of rescan`, from round 1's fix #4's own poll-timeout, not a `mkfs`/UUID error). This container limitation doesn't apply to GitHub Actions' `ubuntu-latest` (a full VM with `systemd-udevd`) — the real CI run is the proof.

### Round-2 verification

| Command | Result |
|---|---|
| `go test -race -count=1 ./internal/backup/rebuild/...` (native darwin) | **ok** |
| `go test -race -count=1 ./internal/backup/rebuild/... ./internal/backup/bmr/... ./cmd/breeze-backup/...` (`docker run golang:1.26`, real Linux) | **ok**, including the new UUID tests and every previously-added test |
| `go test -race -count=1 ./internal/backup/... ./cmd/breeze-backup/` (native darwin) | **ok** |
| `git fetch origin main && golangci-lint run --new-from-rev=origin/main ./...` (Docker, matching `Lint Agent (Go)` CI exactly) | **`0 issues.`** |
| `GOOS=linux go vet ./...` | clean |
| `GOOS=windows go vet ./internal/backup/...` | same 3 pre-existing `vss_windows.go` warnings, untouched |
| `GOOS=windows/darwin/linux go build ./cmd/breeze-backup/` | ok, all three |
| Root loopback proof (`docker run --rm --privileged golang:1.26`) | past `mkfs` (UUID error gone); still blocked by the sandbox's missing `udevd` — see above |

Also checked: `git diff origin/main --stat` shows this PR never touches `internal/executor` — the Windows Test Agent job's `TestExecutePythonScript` failure on this PR is unrelated to these changes.

## Verification (original wave)

All commands run from `agent/`. `go test`/`go vet` need `GOOS=linux` (or a Linux container) to exercise `bmr.RestoreSystemStateOffline`, which is Linux-only by design (same precedent as `applySystemState`) — the full round-trip `Run()` tests skip off Linux and were verified green against `golang:1.26` in Docker.

| Command | Result |
|---|---|
| `go test -race -count=1 ./internal/backup/... ./cmd/breeze-backup/` (native darwin) | **ok** — all 10 packages |
| `go test -race -count=1 ./...` (native darwin) | **ok** — full agent suite, 80 packages |
| `GOOS=windows go build ./cmd/breeze-backup/` | **ok** |
| `GOOS=darwin go build ./cmd/breeze-backup/` | **ok** |
| `GOOS=linux go build ./cmd/breeze-backup/` | **ok** |
| `GOOS=linux go vet ./...` | **clean**, no output |
| `GOOS=windows go vet ./internal/backup/...` | 3 pre-existing `unsafe.Pointer` warnings in `vss/vss_windows.go` — confirmed via `git diff --stat origin/main -- agent/internal/backup/vss/` (empty) and `git log -1` on that file (predates this session); not touched by this wave |
| `git fetch origin main && golangci-lint run --new-from-rev=origin/main ./...` | **`0 issues.`** |
| `go test -race -count=1 ./internal/backup/rebuild/... ./internal/backup/bmr/... ./cmd/breeze-backup/...` (real Linux) | **ok** |
| Root loopback proof (`docker run --rm --privileged golang:1.26`) | **Did not pass** — partition table created correctly (`partx -l`/`/proc/partitions` confirm it), but no `/dev/loop0p1` device node materialized; Docker-Desktop-on-macOS has no running `udevd`. See item 4 above for the follow-up fix and re-test. |

## Deviations from the plan

1. **`DownloadSystemState` is independent from `applySystemState`**, not a delegation, despite the plan's literal "move the body into DownloadSystemState" instruction. The plan's own `DownloadSystemState` unit test requires a hard failure (with the artifact path in the error) on the first bad artifact — but `applySystemState`'s **existing, unchanged** tests (`TestApplySystemState_WrongChecksum_NotAppliedAndArtifactDiscarded` et al.) require the opposite: continue past a bad artifact, discard it, keep going, restorer still runs, `err == nil`. The two contracts are incompatible for the same loop. Low-level helpers (`verifyArtifactIntegrity`, `applyArtifactMetadata`, `resolveStagingArtifactPath`) are still shared; `applySystemState` itself is byte-for-byte untouched.
2. **`bootloaderID` falls back to the ESP's own `EFI/<id>/` directory name** when `/etc/os-release` is absent (the plan's own test fixture has no os-release) — otherwise `grub-install --bootloader-id=linux` would install a second bootloader-id directory alongside the source machine's real one (`ubuntu`), and the plan's own full-flow test asserts `--bootloader-id=ubuntu`.
3. **`Options.RegenerateInitramfs` is not auto-defaulted by `Run()`** — doing so would silently override the CLI's explicit `--no-initramfs`. "Default true" is a CLI-level contract (`rebuild_cmd.go` always passes `RegenerateInitramfs: !noInitramfs`); a direct `Options` caller (tests, a future W04 console) must set it explicitly. Documented on the field.
4. **`validate`'s checksum sample skips the fixed set of paths `identity`'s `IdentityNew` branch intentionally rewrites** (machine-id, hostname, agent.yaml, secrets.yaml) — found via the real-Linux run of `TestRun_ResumeSkipsProvisionAndReusesPlan` (uses `IdentityNew`), which failed validate with "4 of 11 sampled files differ" before this fix. Comparing intentionally-mutated files against the original snapshot bytes would always "fail" by design.
5. **Mount bookkeeping uses three groups** (`rootMount` / `treeMounts` / `mounts`) instead of one stack, so teardown always releases the disk's own root partition last (everything else nests inside it) while still unmounting `/boot/efi` before the chroot-prep bind mounts, matching the plan's `unmounts[0] == boot/efi` assertion.
6. **`boot_linux.go` → `boot.go`**: Go's build tool treats a `_linux` filename suffix as an *implicit* linux-only build constraint even with no `//go:build` line, which would have defeated the plan's own instruction to keep this file untagged so the fake-system tests run on macOS.
7. **CLI registration via its own `init()`** in `rebuild_cmd.go` instead of editing `bmr_recover_cmd.go:35` — functionally identical, avoids touching a file this wave doesn't otherwise need to change.
8. Task 7 (lab proof, boot on KIT, campaign doc row) explicitly out of scope per the assignment — left for the orchestrator, along with confirming the loopback CI step on a real runner.
9. **(Review round 1)** The attached-device path (`runState.Disk`) is no longer persisted at all, for either target kind — not just images. A disk target's device path is a zero-cost recompute (`Target.Path` itself), so persisting it bought nothing and dropping it entirely is simpler than a kind-conditional rule.
10. **(Review round 2)** `Plan` gained a `Warnings []string` field rather than changing `PlanPartitions`' return signature to `(*Plan, []string, error)` — the plan's own contract ("keep every exported signature exactly") only bends when a fix genuinely needs it, and an additive struct field is the smaller, non-breaking option here; `preflight`/the CLI's `--dry-run` JSON output surface it either way since both already pass the whole `Plan` through.

## Commits

1. `feat(rebuild): engine types, result model and pure partition planner (W03)`
2. `feat(bmr): extract DownloadSystemState; add RestoreSystemStateOffline for mounted trees (W03)`
3. `feat(rebuild): engine phases preflight/provision/restore/boot/identity/encryption/validate (W03)`
4. `feat(breeze-backup): rebuild CLI; root-gated loopback proof of provisioning + restore (W03)`
5. `fix(rebuild): satisfy golangci-lint errcheck on every new file (W03)`
6. `fix(rebuild): re-attach image on resume; fail closed on system-state transport errors; disk-boundary matching (W03 review)`
7. `fix(rebuild): real UUIDs in engine fixtures; preflight validates filesystem UUID formats (W03 review)`

Closes #5496

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SVmA9Kgo45EvgriWK7Qo1C

