### PR TITLE
fix(ci): customer-PII guard ignores systemd unit names

### DIFF
--- a/scripts/security/check-customer-pii.sh
+++ b/scripts/security/check-customer-pii.sh
@@ -28,7 +28,7 @@ cd "$(dirname "$0")/../.."
 # reserved/placeholder TLDs + infra families, then exact known-safe domains).
 # "domains" that are really file extensions (e.g. an icon path "128x128@2x.png"
 # parses as foo@2x.png) — never customer data.
-ALLOW_RE='\.(png|ico|svg|jpe?g|webp|gif|html?|css|js|jsx|ts|tsx|json|md|sh|ya?ml|txt|woff2?|patch)$'
+ALLOW_RE='\.(png|ico|svg|jpe?g|webp|gif|html?|css|js|jsx|ts|tsx|json|md|sh|ya?ml|txt|woff2?|patch|service|socket|timer|target|mount|path|slice)$'
 ALLOW_RE="$ALLOW_RE"'|\.(test|example|local|internal|invalid|localhost)$'
 ALLOW_RE="$ALLOW_RE"'|(^|\.)example\.(com|net|org)$'
 ALLOW_RE="$ALLOW_RE"'|(^|\.)sentry\.io$'


### PR DESCRIPTION
The customer-PII guard reads systemd template unit names (`serial-getty@ttyS0.service`, `getty@tty1.service`) in the bare-metal W04b plan as email addresses with an unrecognised domain, and dequeued #5527 (merge-group run 34532011783; #5525 behind it fell out too).

Adds the systemd unit suffixes (`service|socket|timer|target|mount|path|slice`) to the existing file-extension allowance in `ALLOW_RE`.

Verified locally: guard OK on main; with a probe file containing both unit names and `real@castellinilaw.com`, only the real domain is reported.

Unblocks #5527 without touching its branch (checked out by another session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T2XMLdsXt3sYzM5fD4Qbsc