### PR TITLE
fix(dr): enforce site scope on disaster-recovery reads and AI DR tools (SEC-078)

### DIFF
--- a/apps/api/src/__tests__/integration/drReadSiteScope.integration.test.ts
+++ b/apps/api/src/__tests__/integration/drReadSiteScope.integration.test.ts
@@ -1,0 +1,70 @@
+import './setup';
+import { describe, expect, it } from 'vitest';
+import { Hono } from 'hono';
+import { and, eq } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../../db';
+import { devices, drExecutions, drPlanGroups, drPlans, organizationUsers } from '../../db/schema';
+import { drRoutes } from '../../routes/dr';
+import { clearPermissionCache } from '../../services/permissions';
+import { createSite, setupTestEnvironment } from './db-utils';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+describe('DR read site scope', () => {
+  runDb('omits mixed/hidden resources and follows current device site moves', async () => {
+    const env = await setupTestEnvironment({ scope: 'organization', rolePermissions: [{ resource: 'devices', action: 'read' }] });
+    const hiddenSite = await createSite({ orgId: env.organization.id, name: 'Hidden DR site' });
+    const suffix = crypto.randomUUID().slice(0, 8);
+    const seeded = await withSystemDbAccessContext(async () => {
+      const deviceRows = await db.insert(devices).values([
+        { orgId: env.organization.id, siteId: env.site.id, agentId: `dr-visible-${suffix}`, hostname: `visible-${suffix}`, osType: 'linux', osVersion: '1', architecture: 'x86_64', agentVersion: 'test' },
+        { orgId: env.organization.id, siteId: hiddenSite.id, agentId: `dr-hidden-${suffix}`, hostname: `hidden-${suffix}`, osType: 'linux', osVersion: '1', architecture: 'x86_64', agentVersion: 'test' },
+      ]).returning({ id: devices.id });
+      const [visible, hidden] = deviceRows;
+      const plans = await db.insert(drPlans).values([
+        { orgId: env.organization.id, name: `Visible ${suffix}` },
+        { orgId: env.organization.id, name: `Mixed ${suffix}` },
+        { orgId: env.organization.id, name: `Empty ${suffix}` },
+      ]).returning({ id: drPlans.id, name: drPlans.name });
+      await db.insert(drPlanGroups).values([
+        { orgId: env.organization.id, planId: plans[0]!.id, name: 'visible', devices: [visible!.id], restoreConfig: { marker: 'visible' } },
+        { orgId: env.organization.id, planId: plans[1]!.id, name: 'mixed', devices: [visible!.id, hidden!.id], restoreConfig: { marker: 'hidden-secret' } },
+      ]);
+      const validResults = (id: string) => ({ plannedGroups: [{ id: 'g', deviceCount: 1 }], groupResults: [{ groupId: 'g', devices: [{ id, status: 'completed' }] }], queuedCommands: [], failedDispatches: [] });
+      const executions = await db.insert(drExecutions).values([
+        { orgId: env.organization.id, planId: plans[0]!.id, executionType: 'rehearsal', results: validResults(visible!.id), createdAt: new Date('2026-09-06T12:00:00Z'), authorizationPrincipalKind: 'unknown', authorizationState: 'quarantined_authorization_unknown', authorizationDenialCode: 'authorization_subject_unknown' },
+        { orgId: env.organization.id, planId: plans[0]!.id, executionType: 'rehearsal', results: validResults(hidden!.id), createdAt: new Date('2026-09-06T12:01:00Z'), authorizationPrincipalKind: 'unknown', authorizationState: 'quarantined_authorization_unknown', authorizationDenialCode: 'authorization_subject_unknown' },
+      ]).returning({ id: drExecutions.id });
+      return { visible: visible!, hidden: hidden!, plans, executions };
+    });
+    const app = new Hono(); app.route('/dr', drRoutes);
+    const get = async (path: string) => {
+      const res = await app.request(`/dr${path}`, { headers: { Authorization: `Bearer ${env.token}` } });
+      return { status: res.status, body: await res.json() as any };
+    };
+
+    expect((await get('/plans')).body.data).toHaveLength(3);
+    expect((await get('/executions?limit=1')).body.data.map((e: any) => e.id)).toEqual([seeded.executions[1]!.id]);
+    await withSystemDbAccessContext(() => db.update(organizationUsers).set({ siteIds: [env.site.id] }).where(and(eq(organizationUsers.userId, env.user.id), eq(organizationUsers.orgId, env.organization.id))));
+    await clearPermissionCache(env.user.id);
+    const list = await get('/plans');
+    expect(list.body.data.map((p: any) => p.name).sort()).toEqual([`Empty ${suffix}`, `Visible ${suffix}`]);
+    const mixed = await get(`/plans/${seeded.plans[1]!.id}`);
+    expect(mixed.status).toBe(404);
+    expect(JSON.stringify(mixed.body)).not.toContain('hidden-secret');
+    const execs = await get('/executions');
+    expect(execs.body.data.map((e: any) => e.id)).toEqual([seeded.executions[0]!.id]);
+    const limitedExecs = await get('/executions?limit=1');
+    expect(limitedExecs.body.data.map((e: any) => e.id)).toEqual([seeded.executions[0]!.id]);
+    expect((await get(`/executions/${seeded.executions[1]!.id}`)).status).toBe(404);
+
+    await withSystemDbAccessContext(() => db.update(devices).set({ siteId: hiddenSite.id }).where(eq(devices.id, seeded.visible.id)));
+    expect((await get('/plans')).body.data.map((p: any) => p.name)).toEqual([`Empty ${suffix}`]);
+    expect((await get(`/plans/${seeded.plans[0]!.id}`)).status).toBe(404);
+
+    await withSystemDbAccessContext(() => db.update(organizationUsers).set({ siteIds: [] }).where(and(eq(organizationUsers.userId, env.user.id), eq(organizationUsers.orgId, env.organization.id))));
+    await clearPermissionCache(env.user.id);
+    expect((await get('/plans')).body.data).toEqual([]);
+    expect((await get('/executions')).body.data).toEqual([]);
+  });
+});

--- a/apps/api/src/routes/dr.ts
+++ b/apps/api/src/routes/dr.ts
@@ -1,7 +1,7 @@
 import { Hono, type Context } from 'hono';
 import { zValidator } from '../lib/validation';
 import { z } from 'zod';
-import { eq, and, desc, asc, inArray } from 'drizzle-orm';
+import { eq, and, desc, asc, inArray, lt, or } from 'drizzle-orm';
 import { db } from '../db';
 import { drPlans, drPlanGroups, drExecutions, devices } from '../db/schema';
 import { authMiddleware, requireMfa, requirePermission } from '../middleware/auth';
@@ -21,6 +21,13 @@ import {
   classifyDrExecutionAuthorizationError,
   createDrExecutionAndEnqueue,
 } from '../services/drExecutionService';
+import {
+  collectReadableDrRows,
+  drGroupsReadable,
+  drReadSiteCeiling,
+  filterReadableDrExecutions,
+  filterReadableDrPlans,
+} from '../services/drReadAuthorization';
 
 export const drRoutes = new Hono();
 const requireDrRead = requirePermission(
@@ -70,6 +77,12 @@ function uniqueDeviceIds(value: unknown): string[] {
 function siteRestriction(c: Context): UserPermissions | null {
   // authMiddleware runs on '*' before every handler here, so auth is always set.
   const auth = c.get('auth') as AuthContext;
+  // An unrecognised principal kind reads as unrestricted here because every
+  // route in this file is already behind authMiddleware + requirePermission.
+  // `drReadSiteCeiling` (services/drReadAuthorization.ts) deliberately DENIES
+  // the same kind, because it is also reached by shared AI/MCP and autonomous
+  // tool execution where no such middleware runs. The asymmetry is intentional;
+  // converging the two is a security change, not a cleanup.
   if (!isSiteRestrictedPrincipalKind(auth.principal?.kind)) return null;
 
   // Fall back to the token's own grant rather than treating a missing
@@ -253,7 +266,8 @@ drRoutes.get('/plans', requireDrRead, async (c) => {
     .where(eq(drPlans.orgId, orgId))
     .orderBy(desc(drPlans.createdAt));
 
-  return c.json({ data: rows });
+  const permissions = c.get('permissions') as UserPermissions | undefined;
+  return c.json({ data: await filterReadableDrPlans(rows, auth, orgId, permissions?.allowedSiteIds) });
 });
 
 drRoutes.get(
@@ -279,6 +293,11 @@ drRoutes.get(
       .from(drPlanGroups)
       .where(eq(drPlanGroups.planId, id))
       .orderBy(asc(drPlanGroups.sequence));
+
+    const permissions = c.get('permissions') as UserPermissions | undefined;
+    if (!await drGroupsReadable(groups, auth, orgId, permissions?.allowedSiteIds)) {
+      return c.json({ error: 'Plan not found' }, 404);
+    }
 
     return c.json({ data: { ...plan, groups } });
   }
@@ -611,14 +630,30 @@ drRoutes.get(
 
     const limit = query.limit ?? 100;
 
-    const rows = await db
-      .select()
-      .from(drExecutions)
-      .where(and(...conditions))
-      .orderBy(desc(drExecutions.createdAt))
-      .limit(limit);
+    const permissions = c.get('permissions') as UserPermissions | undefined;
+    const allowedSiteIds = permissions?.allowedSiteIds;
+    const siteCeiling = drReadSiteCeiling(auth, allowedSiteIds);
+    if (siteCeiling?.length === 0) return c.json({ data: [] });
 
-    return c.json({ data: rows });
+    const load = (cursor: { createdAt: Date; id: string } | undefined, pageSize: number) => {
+      const pageConditions = [...conditions];
+      if (cursor) {
+        pageConditions.push(or(
+          lt(drExecutions.createdAt, cursor.createdAt),
+          and(eq(drExecutions.createdAt, cursor.createdAt), lt(drExecutions.id, cursor.id)),
+        )!);
+      }
+      return db.select().from(drExecutions).where(and(...pageConditions))
+        .orderBy(desc(drExecutions.createdAt), desc(drExecutions.id)).limit(pageSize);
+    };
+    if (siteCeiling === null) return c.json({ data: await load(undefined, limit) });
+
+    const visible = await collectReadableDrRows({
+      limit,
+      load,
+      filter: (rows) => filterReadableDrExecutions(rows, auth, orgId, allowedSiteIds),
+    });
+    return c.json({ data: visible });
   }
 );
 
@@ -654,6 +689,17 @@ drRoutes.get(
           .where(eq(drPlanGroups.planId, plan.id))
           .orderBy(asc(drPlanGroups.sequence))
       : [];
+
+    const permissions = c.get('permissions') as UserPermissions | undefined;
+    const [visible] = await filterReadableDrExecutions(
+      [{ ...execution, planId: execution.planId, results: execution.results }],
+      auth,
+      orgId,
+      permissions?.allowedSiteIds,
+    );
+    if (!visible || !await drGroupsReadable(groups, auth, orgId, permissions?.allowedSiteIds)) {
+      return c.json({ error: 'Execution not found' }, 404);
+    }
 
     return c.json({
       data: {

--- a/apps/api/src/services/aiToolsDR.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsDR.siteScope.test.ts
@@ -39,11 +39,17 @@ function makeAuth(allowedSiteIds?: string[]): AuthContext {
 // Thenable that resolves to `rows` and supports any query-builder chaining shape.
 function chain(rows: unknown[]): any {
   const p: any = Promise.resolve(rows);
-  for (const m of ['from', 'where', 'limit', 'orderBy', 'leftJoin', 'innerJoin', 'groupBy']) {
+  for (const m of ['from', 'where', 'orderBy', 'leftJoin', 'innerJoin', 'groupBy']) {
     p[m] = () => p;
   }
+  p.limit = (value: number) => {
+    limitCalls.push(value);
+    return p;
+  };
   return p;
 }
+
+const limitCalls: number[] = [];
 
 function seqSelect(results: Array<unknown[]>) {
   let call = 0;
@@ -91,19 +97,96 @@ describe('execute_dr_plan — durable authorization subject handoff', () => {
   });
 });
 
-describe('query_dr_plans — hides fully out-of-scope plans', () => {
-  beforeEach(() => vi.clearAllMocks());
+describe('query_dr_plans — requires whole-plan site visibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    limitCalls.length = 0;
+  });
 
   it('hides a plan whose devices are all outside the caller\'s site scope', async () => {
     seqSelect([
       [{ id: 'p1', name: 'P1', groupCount: 1 }, { id: 'p2', name: 'P2', groupCount: 1 }], // plans
-      [{ id: 'dev-A', siteId: 'site-A' }, { id: 'dev-B', siteId: 'site-B' }],             // partition
       [{ planId: 'p1', devices: ['dev-A'] }, { planId: 'p2', devices: ['dev-B'] }],       // groups per plan
+      // Both ids resolve to a live device; only dev-A sits in the ceiling. Every
+      // id is looked up in ONE chunked query, so both rows come back together.
+      [{ id: 'dev-A', siteId: 'site-A' }, { id: 'dev-B', siteId: 'site-B' }],
     ]);
     const result = await handlerFor('query_dr_plans')({}, makeAuth(['site-A']));
     const parsed = JSON.parse(result);
     expect(parsed.showing).toBe(1);
     expect(parsed.plans.map((p: any) => p.id)).toEqual(['p1']);
+  });
+
+  it('omits a mixed plan and filters before applying the requested limit', async () => {
+    seqSelect([
+      [{ id: 'mixed', name: 'Mixed', groupCount: 1 }, { id: 'visible', name: 'Visible', groupCount: 1 }],
+      [{ planId: 'mixed', devices: ['dev-A', 'dev-B'] }, { planId: 'visible', devices: ['dev-A'] }],
+      [{ id: 'dev-A', siteId: 'site-A' }, { id: 'dev-B', siteId: 'site-B' }],
+      [{ id: 'dev-A', siteId: 'site-A' }],
+    ]);
+    const parsed = JSON.parse(await handlerFor('query_dr_plans')({ limit: 1 }, makeAuth(['site-A'])));
+    expect(parsed.plans.map((p: any) => p.id)).toEqual(['visible']);
+    expect(parsed.showing).toBe(1);
+  });
+
+  // `dr_plan_groups.devices` is jsonb with no FK and is not scrubbed by the
+  // device cascade, so a decommissioned machine leaves a permanently
+  // unresolvable id behind. Treating that as "hidden" would wedge the plan out
+  // of view for every restricted tech forever. The write side already decided
+  // this the other way (`authorizeStoredDevices`, routes/dr.ts).
+  it('ignores a stale device identity that no longer resolves to any org device', async () => {
+    seqSelect([
+      [{ id: 'stale', name: 'Stale', groupCount: 1 }],
+      [{ planId: 'stale', devices: ['missing-device', 'dev-A'] }],
+      [{ id: 'dev-A', siteId: 'site-A' }],
+    ]);
+    const parsed = JSON.parse(await handlerFor('query_dr_plans')({}, makeAuth(['site-A'])));
+    expect(parsed.plans.map((plan: any) => plan.id)).toEqual(['stale']);
+  });
+
+  it('still denies when a SURVIVING member device sits outside the ceiling', async () => {
+    seqSelect([
+      [{ id: 'mixed', name: 'Mixed', groupCount: 1 }],
+      [{ planId: 'mixed', devices: ['missing-device', 'dev-A', 'dev-B'] }],
+      [{ id: 'dev-A', siteId: 'site-A' }, { id: 'dev-B', siteId: 'site-B' }],
+    ]);
+    const parsed = JSON.parse(await handlerFor('query_dr_plans')({}, makeAuth(['site-A'])));
+    expect(parsed.plans).toEqual([]);
+  });
+
+  it('denies when a surviving member device carries no site at all', async () => {
+    seqSelect([
+      [{ id: 'orphan', name: 'Orphan', groupCount: 1 }],
+      [{ planId: 'orphan', devices: ['dev-A'] }],
+      [{ id: 'dev-A', siteId: null }],
+    ]);
+    const parsed = JSON.parse(await handlerFor('query_dr_plans')({}, makeAuth(['site-A'])));
+    expect(parsed.plans).toEqual([]);
+  });
+
+  // Regression for the org-guard fail-CLOSED bug: a system-scope session has no
+  // auth.orgId and no accessibleOrgIds, so guarding on getOrgId() turned every
+  // system read into an empty list.
+  it('system-scope session keeps the unfiltered single-query path', async () => {
+    const auth = makeAuth(undefined);
+    auth.principal = { kind: 'system' } as any;
+    (auth as any).orgId = null;
+    (auth as any).accessibleOrgIds = null;
+    seqSelect([[{ id: 'p1', name: 'P1', groupCount: 1 }, { id: 'p2', name: 'P2', groupCount: 1 }]]);
+    const parsed = JSON.parse(await handlerFor('query_dr_plans')({}, auth));
+    expect(parsed.plans.map((plan: any) => plan.id)).toEqual(['p1', 'p2']);
+    expect(mockDb.select).toHaveBeenCalledTimes(1);
+    expect(limitCalls).toEqual([25]);
+  });
+
+  it('a RESTRICTED caller with no resolvable org still fails closed', async () => {
+    const auth = makeAuth(['site-A']);
+    (auth as any).orgId = null;
+    (auth as any).accessibleOrgIds = null;
+    seqSelect([[{ id: 'p1', name: 'P1', groupCount: 1 }]]);
+    const parsed = JSON.parse(await handlerFor('query_dr_plans')({}, auth));
+    expect(parsed.plans).toEqual([]);
+    expect(mockDb.select).not.toHaveBeenCalled();
   });
 
   it('unrestricted caller sees all plans (no regression)', async () => {
@@ -113,6 +196,131 @@ describe('query_dr_plans — hides fully out-of-scope plans', () => {
     const result = await handlerFor('query_dr_plans')({}, makeAuth(undefined));
     const parsed = JSON.parse(result);
     expect(parsed.showing).toBe(2);
+    expect(limitCalls).toEqual([25]);
+    expect(mockDb.select).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns no plans for an empty site ceiling without subsidiary reads', async () => {
+    seqSelect([[{ id: 'p1', name: 'P1', groupCount: 0 }]]);
+    const parsed = JSON.parse(await handlerFor('query_dr_plans')({}, makeAuth([])));
+    expect(parsed.plans).toEqual([]);
+    expect(mockDb.select).not.toHaveBeenCalled();
+  });
+
+  it('keyset-scans past a full hidden page before applying limit 1', async () => {
+    const hiddenPlans = Array.from({ length: 100 }, (_, index) => ({
+      id: `hidden-${String(index).padStart(3, '0')}`,
+      name: `Hidden ${index}`,
+      createdAt: new Date(200_000 - index),
+      groupCount: 1,
+    }));
+    seqSelect([
+      hiddenPlans,
+      hiddenPlans.map((plan) => ({ planId: plan.id, devices: ['dev-B'] })),
+      [{ id: 'dev-B', siteId: 'site-B' }],
+      [{ id: 'visible', name: 'Visible', createdAt: new Date(1), groupCount: 1 }],
+      [{ planId: 'visible', devices: ['dev-A'] }],
+      [{ id: 'dev-A', siteId: 'site-A' }],
+    ]);
+
+    const parsed = JSON.parse(await handlerFor('query_dr_plans')({ limit: 1 }, makeAuth(['site-A'])));
+    expect(parsed.plans.map((plan: any) => plan.id)).toEqual(['visible']);
+    expect(limitCalls).toEqual([100, 100]);
+    expect(mockDb.select).toHaveBeenCalledTimes(6);
+  });
+
+  it('chunks large device membership lookups below the bind ceiling', async () => {
+    const deviceIds = Array.from({ length: 501 }, (_, index) => `dev-${index}`);
+    seqSelect([
+      [{ id: 'large', name: 'Large', createdAt: new Date(1), groupCount: 1 }],
+      [{ planId: 'large', devices: deviceIds }],
+      deviceIds.slice(0, 500).map((id) => ({ id, siteId: 'site-A' })),
+      [{ id: deviceIds[500], siteId: 'site-A' }],
+    ]);
+
+    const parsed = JSON.parse(await handlerFor('query_dr_plans')({}, makeAuth(['site-A'])));
+    expect(parsed.plans.map((plan: any) => plan.id)).toEqual(['large']);
+    expect(mockDb.select).toHaveBeenCalledTimes(4);
+  });
+
+  it('fails closed without querying for an unsupported principal kind', async () => {
+    const auth = makeAuth(undefined);
+    auth.principal = { kind: 'unknown' };
+    const parsed = JSON.parse(await handlerFor('query_dr_plans')({}, auth));
+    expect(parsed.plans).toEqual([]);
+    expect(mockDb.select).not.toHaveBeenCalled();
+  });
+});
+
+describe('DR detail reads — current and historical site visibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    limitCalls.length = 0;
+  });
+
+  it('returns an opaque denial for mixed plan details', async () => {
+    seqSelect([
+      [PLAN],
+      [{ planId: 'p1', devices: ['dev-A', 'dev-B'], restoreConfig: { secretRef: 'hidden' } }],
+      [{ id: 'dev-A', siteId: 'site-A' }, { id: 'dev-B', siteId: 'site-B' }],
+    ]);
+    const parsed = JSON.parse(await handlerFor('get_dr_plan_details')({ planId: 'p1' }, makeAuth(['site-A'])));
+    expect(parsed).toEqual({ error: 'Plan not found or access denied' });
+    expect(JSON.stringify(parsed)).not.toContain('hidden');
+  });
+
+  it('denies execution history when an immutable result names a hidden device', async () => {
+    const results = {
+      plannedGroups: [{ id: 'g1', deviceCount: 1 }],
+      groupResults: [{ groupId: 'g1', devices: [{ id: 'dev-B', status: 'completed' }] }],
+      queuedCommands: [], failedDispatches: [],
+    };
+    seqSelect([
+      [{ id: 'e1', planId: 'p1', orgId: 'org-1', results }],
+      [PLAN],
+      [{ planId: 'p1', devices: ['dev-A'] }],
+      [{ planId: 'p1', devices: ['dev-A'] }],
+      [{ id: 'dev-A', siteId: 'site-A' }, { id: 'dev-B', siteId: 'site-B' }],
+    ]);
+    const parsed = JSON.parse(await handlerFor('get_dr_execution_status')({ executionId: 'e1' }, makeAuth(['site-A'])));
+    expect(parsed).toEqual({ error: 'Execution not found or access denied' });
+  });
+
+  it('denies malformed legacy execution results', async () => {
+    seqSelect([
+      [{ id: 'e1', planId: 'p1', orgId: 'org-1', results: { plannedGroups: [{ restoreConfig: { x: 1 } }] } }],
+      [PLAN], [{ planId: 'p1', devices: ['dev-A'] }], [{ planId: 'p1', devices: ['dev-A'] }],
+    ]);
+    const parsed = JSON.parse(await handlerFor('get_dr_execution_status')({ executionId: 'e1' }, makeAuth(['site-A'])));
+    expect(parsed.error).toMatch(/access denied/i);
+  });
+
+  it('keyset-scans past hidden execution history before applying limit 1', async () => {
+    const resultFor = (deviceId: string) => ({
+      plannedGroups: [{ id: 'g1', deviceCount: 1 }],
+      groupResults: [{ groupId: 'g1', devices: [{ id: deviceId, status: 'completed' }] }],
+      queuedCommands: [],
+      failedDispatches: [],
+    });
+    const hiddenExecutions = Array.from({ length: 100 }, (_, index) => ({
+      id: `hidden-exec-${String(index).padStart(3, '0')}`,
+      planId: 'p1',
+      createdAt: new Date(200_000 - index),
+      results: resultFor('dev-B'),
+    }));
+    seqSelect([
+      hiddenExecutions,
+      [{ planId: 'p1', devices: ['dev-A'] }],
+      [{ id: 'dev-A', siteId: 'site-A' }, { id: 'dev-B', siteId: 'site-B' }],
+      [{ id: 'visible-exec', planId: 'p1', createdAt: new Date(1), results: resultFor('dev-A') }],
+      [{ planId: 'p1', devices: ['dev-A'] }],
+      [{ id: 'dev-A', siteId: 'site-A' }],
+    ]);
+
+    const parsed = JSON.parse(await handlerFor('get_dr_execution_status')({ limit: 1 }, makeAuth(['site-A'])));
+    expect(parsed.executions.map((execution: any) => execution.id)).toEqual(['visible-exec']);
+    expect(limitCalls).toEqual([100, 100]);
+    expect(mockDb.select).toHaveBeenCalledTimes(6);
   });
 });
 

--- a/apps/api/src/services/aiToolsDR.test.ts
+++ b/apps/api/src/services/aiToolsDR.test.ts
@@ -121,6 +121,8 @@ function makeAuth(): AuthContext {
     partnerId: null,
     orgId: ORG_ID,
     scope: 'organization',
+    principal: { kind: 'user_session' },
+    allowedSiteIds: undefined,
     accessibleOrgIds: [ORG_ID],
     canAccessOrg: (orgId: string) => orgId === ORG_ID,
     orgCondition: vi.fn(() => undefined),

--- a/apps/api/src/services/aiToolsDR.ts
+++ b/apps/api/src/services/aiToolsDR.ts
@@ -8,11 +8,18 @@
 
 import { db } from '../db';
 import { drExecutions, drPlanGroups, drPlans } from '../db/schema';
-import { eq, and, asc, desc, inArray, sql, SQL } from 'drizzle-orm';
+import { eq, and, asc, desc, lt, or, sql, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 import { createDrExecutionAndEnqueue } from './drExecutionService';
 import { resolveSiteDevicePartition } from './aiToolsSiteScope';
+import {
+  collectReadableDrRows,
+  drGroupsReadable,
+  drReadSiteCeiling,
+  filterReadableDrExecutions,
+  filterReadableDrPlans,
+} from './drReadAuthorization';
 
 /**
  * Deny a group mutation whose STORED membership reaches outside the caller's
@@ -150,72 +157,50 @@ export function registerDRTools(aiTools: Map<string, AiTool>): void {
       if (typeof input.status === 'string') conditions.push(eq(drPlans.status, input.status));
 
       const limit = clampLimit(input.limit);
-      const rows = await db
-        .select({
-          id: drPlans.id,
-          name: drPlans.name,
-          description: drPlans.description,
-          status: drPlans.status,
-          rpoTargetMinutes: drPlans.rpoTargetMinutes,
-          rtoTargetMinutes: drPlans.rtoTargetMinutes,
-          createdBy: drPlans.createdBy,
-          createdAt: drPlans.createdAt,
-          updatedAt: drPlans.updatedAt,
-          groupCount: sql<number>`count(${drPlanGroups.id})::int`,
-        })
-        .from(drPlans)
-        .leftJoin(
-          drPlanGroups,
-          and(eq(drPlanGroups.planId, drPlans.id), eq(drPlanGroups.orgId, drPlans.orgId))
-        )
-        .where(conditions.length > 0 ? and(...conditions) : undefined)
-        .groupBy(
-          drPlans.id,
-          drPlans.name,
-          drPlans.description,
-          drPlans.status,
-          drPlans.rpoTargetMinutes,
-          drPlans.rtoTargetMinutes,
-          drPlans.createdBy,
-          drPlans.createdAt,
-          drPlans.updatedAt
-        )
-        .orderBy(desc(drPlans.createdAt))
-        .limit(limit);
-
-      // Site axis (app-layer only; RLS enforces org, NOT site). Hide plans that
-      // are ENTIRELY outside a site-restricted caller's scope so they cannot
-      // enumerate foreign plans/devices. No-op for unrestricted callers.
-      const orgId = getOrgId(auth);
-      const partition = orgId ? await resolveSiteDevicePartition(orgId, auth) : null;
-      if (partition && rows.length > 0) {
-        const allowed = new Set(partition.allowed);
-        const planIds = rows.map((row) => row.id);
-        const groupRows = await db
-          .select({ planId: drPlanGroups.planId, devices: drPlanGroups.devices })
-          .from(drPlanGroups)
-          .where(inArray(drPlanGroups.planId, planIds));
-        const deviceIdsByPlan = new Map<string, string[]>();
-        for (const group of groupRows) {
-          const list = deviceIdsByPlan.get(group.planId) ?? [];
-          if (Array.isArray(group.devices)) {
-            for (const deviceId of group.devices) {
-              if (typeof deviceId === 'string') list.push(deviceId);
-            }
-          }
-          deviceIdsByPlan.set(group.planId, list);
+      // Site axis (app-layer only; RLS enforces org, NOT site). Hide any plan
+      // a site-restricted caller cannot see in full, so they cannot enumerate
+      // foreign plans/devices. No-op for unrestricted callers.
+      const siteCeiling = drReadSiteCeiling(auth);
+      if (siteCeiling?.length === 0) return JSON.stringify({ plans: [], showing: 0 });
+      const load = (cursor: { createdAt: Date; id: string } | undefined, pageSize: number) => {
+        const pageConditions = [...conditions];
+        if (cursor) {
+          pageConditions.push(or(
+            lt(drPlans.createdAt, cursor.createdAt),
+            and(eq(drPlans.createdAt, cursor.createdAt), lt(drPlans.id, cursor.id)),
+          )!);
         }
-        const visible = rows.filter((row) => {
-          const ids = deviceIdsByPlan.get(row.id) ?? [];
-          // A plan with no assigned devices carries nothing site-sensitive.
-          if (ids.length === 0) return true;
-          // Otherwise require at least one device in an accessible site.
-          return ids.some((id) => allowed.has(id));
-        });
-        return JSON.stringify({ plans: visible, showing: visible.length });
+        return db.select({
+          id: drPlans.id, name: drPlans.name, description: drPlans.description,
+          status: drPlans.status, rpoTargetMinutes: drPlans.rpoTargetMinutes,
+          rtoTargetMinutes: drPlans.rtoTargetMinutes, createdBy: drPlans.createdBy,
+          createdAt: drPlans.createdAt, updatedAt: drPlans.updatedAt,
+          groupCount: sql<number>`count(${drPlanGroups.id})::int`,
+        }).from(drPlans).leftJoin(
+          drPlanGroups,
+          and(eq(drPlanGroups.planId, drPlans.id), eq(drPlanGroups.orgId, drPlans.orgId)),
+        ).where(pageConditions.length > 0 ? and(...pageConditions) : undefined)
+          .groupBy(
+            drPlans.id, drPlans.name, drPlans.description, drPlans.status,
+            drPlans.rpoTargetMinutes, drPlans.rtoTargetMinutes, drPlans.createdBy,
+            drPlans.createdAt, drPlans.updatedAt,
+          ).orderBy(desc(drPlans.createdAt), desc(drPlans.id)).limit(pageSize);
+      };
+      // Unrestricted and system callers keep the original single-query path.
+      // Only the restricted branch needs a concrete org to resolve device
+      // sites; a restricted caller whose org cannot be resolved fails CLOSED.
+      if (siteCeiling === null) {
+        const rows = await load(undefined, limit);
+        return JSON.stringify({ plans: rows, showing: rows.length });
       }
-
-      return JSON.stringify({ plans: rows, showing: rows.length });
+      const orgId = getOrgId(auth);
+      if (!orgId) return JSON.stringify({ plans: [], showing: 0 });
+      const visible = await collectReadableDrRows({
+        limit,
+        load,
+        filter: (rows) => filterReadableDrPlans(rows, auth, orgId),
+      });
+      return JSON.stringify({ plans: visible, showing: visible.length });
     }),
   });
 
@@ -251,6 +236,10 @@ export function registerDRTools(aiTools: Map<string, AiTool>): void {
         .from(drPlanGroups)
         .where(and(...groupConditions))
         .orderBy(asc(drPlanGroups.sequence));
+
+      if (!await drGroupsReadable(groups, auth, plan.orgId)) {
+        return JSON.stringify({ error: 'Plan not found or access denied' });
+      }
 
       return JSON.stringify({
         ...plan,
@@ -303,9 +292,19 @@ export function registerDRTools(aiTools: Map<string, AiTool>): void {
               .orderBy(asc(drPlanGroups.sequence))
           : [];
 
+        // Authorize against the execution's OWN org: it is already org-gated by
+        // `orgWhere` above, and unlike `getOrgId(auth)` it resolves for a
+        // system-scope session too. Both helpers no-op for an unrestricted
+        // ceiling, so this costs such a caller nothing.
+        const [visible] = await filterReadableDrExecutions([execution], auth, execution.orgId);
+        if (!visible || !await drGroupsReadable(groups, auth, plan?.orgId ?? execution.orgId)) {
+          return JSON.stringify({ error: 'Execution not found or access denied' });
+        }
+        // A missing plan is a dangling reference, not an authorization failure —
+        // mirrors the HTTP twin in routes/dr.ts, which returns `plan: null`.
         return JSON.stringify({
           ...execution,
-          plan,
+          plan: plan ?? null,
           groups,
         });
       }
@@ -317,26 +316,41 @@ export function registerDRTools(aiTools: Map<string, AiTool>): void {
       if (typeof input.status === 'string') conditions.push(eq(drExecutions.status, input.status));
 
       const limit = clampLimit(input.limit);
-      const executions = await db
-        .select({
-          id: drExecutions.id,
-          planId: drExecutions.planId,
-          planName: drPlans.name,
-          executionType: drExecutions.executionType,
-          status: drExecutions.status,
-          startedAt: drExecutions.startedAt,
-          completedAt: drExecutions.completedAt,
-          initiatedBy: drExecutions.initiatedBy,
-          results: drExecutions.results,
+      const siteCeiling = drReadSiteCeiling(auth);
+      if (siteCeiling?.length === 0) return JSON.stringify({ executions: [], showing: 0 });
+      const load = (cursor: { createdAt: Date; id: string } | undefined, pageSize: number) => {
+        const pageConditions = [...conditions];
+        if (cursor) {
+          pageConditions.push(or(
+            lt(drExecutions.createdAt, cursor.createdAt),
+            and(eq(drExecutions.createdAt, cursor.createdAt), lt(drExecutions.id, cursor.id)),
+          )!);
+        }
+        return db.select({
+          id: drExecutions.id, planId: drExecutions.planId, planName: drPlans.name,
+          executionType: drExecutions.executionType, status: drExecutions.status,
+          startedAt: drExecutions.startedAt, completedAt: drExecutions.completedAt,
+          initiatedBy: drExecutions.initiatedBy, results: drExecutions.results,
           createdAt: drExecutions.createdAt,
-        })
-        .from(drExecutions)
-        .leftJoin(drPlans, eq(drExecutions.planId, drPlans.id))
-        .where(conditions.length > 0 ? and(...conditions) : undefined)
-        .orderBy(desc(drExecutions.createdAt))
-        .limit(limit);
-
-      return JSON.stringify({ executions, showing: executions.length });
+        }).from(drExecutions).leftJoin(drPlans, eq(drExecutions.planId, drPlans.id))
+          .where(pageConditions.length > 0 ? and(...pageConditions) : undefined)
+          .orderBy(desc(drExecutions.createdAt), desc(drExecutions.id)).limit(pageSize);
+      };
+      // See query_dr_plans: unrestricted/system keeps the single-query path;
+      // only the restricted branch needs a concrete org, and fails closed
+      // without one.
+      if (siteCeiling === null) {
+        const rows = await load(undefined, limit);
+        return JSON.stringify({ executions: rows, showing: rows.length });
+      }
+      const orgId = getOrgId(auth);
+      if (!orgId) return JSON.stringify({ executions: [], showing: 0 });
+      const visible = await collectReadableDrRows({
+        limit,
+        load,
+        filter: (rows) => filterReadableDrExecutions(rows, auth, orgId),
+      });
+      return JSON.stringify({ executions: visible, showing: visible.length });
     }),
   });
 

--- a/apps/api/src/services/drReadAuthorization.test.ts
+++ b/apps/api/src/services/drReadAuthorization.test.ts
@@ -1,0 +1,291 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../db', () => ({
+  db: { select: vi.fn() },
+}));
+
+import { db } from '../db';
+import {
+  DR_READ_CANDIDATE_CHUNK_SIZE,
+  DR_READ_MAX_CANDIDATE_PAGES,
+  collectReadableDrRows,
+  drReadSiteCeiling,
+  filterReadableDrExecutions,
+  filterReadableDrPlans,
+} from './drReadAuthorization';
+import type { AuthContext } from '../middleware/auth';
+
+const mockDb = db as unknown as { select: ReturnType<typeof vi.fn> };
+
+/** Thenable resolving to `rows`, tolerant of any query-builder chain shape. */
+function chain(rows: unknown[]): any {
+  const p: any = Promise.resolve(rows);
+  for (const m of ['from', 'where', 'limit', 'orderBy', 'leftJoin', 'innerJoin', 'groupBy']) {
+    p[m] = () => p;
+  }
+  return p;
+}
+
+function seqSelect(results: Array<unknown[]>) {
+  let call = 0;
+  mockDb.select.mockImplementation(() => chain(results[call++] ?? []));
+}
+
+function makeAuth(allowedSiteIds?: string[], kind = 'user_session'): AuthContext {
+  return {
+    principal: { kind },
+    user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
+    token: {} as any, partnerId: null, orgId: 'org-1', scope: 'organization',
+    accessibleOrgIds: ['org-1'], orgCondition: () => undefined, canAccessOrg: () => true,
+    allowedSiteIds, canAccessSite: () => true,
+  } as unknown as AuthContext;
+}
+
+const RESTRICTED = () => makeAuth(['site-A']);
+
+/** Minimal well-formed execution results document naming exactly `deviceIds`. */
+function resultsDoc(deviceIds: string[], extra: Record<string, unknown> = {}) {
+  return {
+    plannedGroups: [{ id: 'g1', deviceCount: deviceIds.length }],
+    groupResults: [{ groupId: 'g1', devices: deviceIds.map((id) => ({ id, status: 'completed' })) }],
+    queuedCommands: [],
+    failedDispatches: [],
+    ...extra,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('drReadSiteCeiling', () => {
+  it('is unrestricted for a system principal', () => {
+    expect(drReadSiteCeiling(makeAuth(['site-A'], 'system'))).toBeNull();
+  });
+
+  it('is unrestricted for a site-restricted principal holding no site grant', () => {
+    expect(drReadSiteCeiling(makeAuth(undefined))).toBeNull();
+  });
+
+  it('denies an unrecognised principal kind outright', () => {
+    // Deliberately stricter than routes/dr.ts `siteRestriction`, which maps the
+    // same kind to "unrestricted" because it sits behind requirePermission.
+    // This boundary is also reached by AI/MCP execution, where nothing does.
+    expect(drReadSiteCeiling(makeAuth(undefined, 'unknown'))).toEqual([]);
+    expect(drReadSiteCeiling(makeAuth(['site-A'], 'agent'))).toEqual([]);
+  });
+
+  it('prefers an explicit override over the token grant', () => {
+    expect(drReadSiteCeiling(makeAuth(['site-A']), ['site-Z'])).toEqual(['site-Z']);
+  });
+});
+
+describe('collectReadableDrRows — bounded candidate scan', () => {
+  it('stops at the page cap when every candidate is hidden', async () => {
+    let loads = 0;
+    const page = (offset: number) => Array.from({ length: DR_READ_CANDIDATE_CHUNK_SIZE }, (_, i) => ({
+      id: `hidden-${offset + i}`,
+      createdAt: new Date(1_000_000 - offset - i),
+    }));
+
+    const visible = await collectReadableDrRows({
+      limit: 5,
+      load: async () => page((loads++) * DR_READ_CANDIDATE_CHUNK_SIZE),
+      filter: async () => [],
+    });
+
+    expect(visible).toEqual([]);
+    // Without the cap this walks the whole table one page at a time.
+    expect(loads).toBe(DR_READ_MAX_CANDIDATE_PAGES);
+  });
+
+  it('returns a short page rather than scanning past the cap', async () => {
+    let loads = 0;
+    const visible = await collectReadableDrRows({
+      // One visible row per page, so the requested limit can never be filled
+      // within the cap — the caller gets a short page instead of a long scan.
+      limit: DR_READ_MAX_CANDIDATE_PAGES + 10,
+      load: async () => {
+        loads += 1;
+        return Array.from({ length: DR_READ_CANDIDATE_CHUNK_SIZE }, (_, i) => ({
+          id: `row-${loads}-${i}`,
+          createdAt: new Date(1_000_000 - loads * 1000 - i),
+        }));
+      },
+      filter: async (rows) => rows.slice(0, 1),
+    });
+
+    expect(loads).toBe(DR_READ_MAX_CANDIDATE_PAGES);
+    expect(visible).toHaveLength(DR_READ_MAX_CANDIDATE_PAGES);
+  });
+
+  it('stops early once the limit is filled without hitting the cap', async () => {
+    let loads = 0;
+    const visible = await collectReadableDrRows({
+      limit: 2,
+      load: async () => {
+        loads += 1;
+        return Array.from({ length: DR_READ_CANDIDATE_CHUNK_SIZE }, (_, i) => ({
+          id: `row-${i}`,
+          createdAt: new Date(1_000_000 - i),
+        }));
+      },
+      filter: async (rows) => rows,
+    });
+
+    expect(loads).toBe(1);
+    expect(visible).toHaveLength(2);
+  });
+
+  it('stops on a short page (end of table)', async () => {
+    let loads = 0;
+    const visible = await collectReadableDrRows({
+      limit: 50,
+      load: async () => {
+        loads += 1;
+        return [{ id: 'only', createdAt: new Date(1) }];
+      },
+      filter: async (rows) => rows,
+    });
+
+    expect(loads).toBe(1);
+    expect(visible).toHaveLength(1);
+  });
+});
+
+describe('filterReadableDrPlans — whole-plan visibility', () => {
+  it('ignores an id with no surviving device row', async () => {
+    seqSelect([
+      [{ planId: 'p1', devices: ['gone', 'dev-A'] }],
+      [{ id: 'dev-A', siteId: 'site-A' }],
+    ]);
+    expect(await filterReadableDrPlans([{ id: 'p1' }], RESTRICTED(), 'org-1')).toEqual([{ id: 'p1' }]);
+  });
+
+  it('denies on a surviving device outside the ceiling', async () => {
+    seqSelect([
+      [{ planId: 'p1', devices: ['dev-A', 'dev-B'] }],
+      [{ id: 'dev-A', siteId: 'site-A' }, { id: 'dev-B', siteId: 'site-B' }],
+    ]);
+    expect(await filterReadableDrPlans([{ id: 'p1' }], RESTRICTED(), 'org-1')).toEqual([]);
+  });
+
+  it('denies on a surviving device with a null site', async () => {
+    seqSelect([
+      [{ planId: 'p1', devices: ['dev-A'] }],
+      [{ id: 'dev-A', siteId: null }],
+    ]);
+    expect(await filterReadableDrPlans([{ id: 'p1' }], RESTRICTED(), 'org-1')).toEqual([]);
+  });
+
+  it('denies a malformed group device array', async () => {
+    seqSelect([[{ planId: 'p1', devices: 'not-an-array' }]]);
+    expect(await filterReadableDrPlans([{ id: 'p1' }], RESTRICTED(), 'org-1')).toEqual([]);
+  });
+
+  it('denies a group array holding a non-string member', async () => {
+    seqSelect([[{ planId: 'p1', devices: ['dev-A', 42] }]]);
+    expect(await filterReadableDrPlans([{ id: 'p1' }], RESTRICTED(), 'org-1')).toEqual([]);
+  });
+
+  it('admits a plan with no groups at all (nothing site-bound to hide)', async () => {
+    seqSelect([[]]);
+    expect(await filterReadableDrPlans([{ id: 'p1' }], RESTRICTED(), 'org-1')).toEqual([{ id: 'p1' }]);
+  });
+
+  it('returns nothing for a defined-empty ceiling without querying', async () => {
+    expect(await filterReadableDrPlans([{ id: 'p1' }], makeAuth([]), 'org-1')).toEqual([]);
+    expect(mockDb.select).not.toHaveBeenCalled();
+  });
+
+  it('returns every row for an unrestricted caller without querying', async () => {
+    const rows = [{ id: 'p1' }, { id: 'p2' }];
+    expect(await filterReadableDrPlans(rows, makeAuth(undefined), 'org-1')).toBe(rows);
+    expect(mockDb.select).not.toHaveBeenCalled();
+  });
+});
+
+describe('filterReadableDrExecutions — malformed result documents', () => {
+  const row = (results: unknown) => ({ planId: 'p1', results });
+  const denied = async (results: unknown, groups: unknown[] = [{ planId: 'p1', devices: [] }]) => {
+    seqSelect([groups, [{ id: 'dev-A', siteId: 'site-A' }]]);
+    return filterReadableDrExecutions([row(results)], RESTRICTED(), 'org-1');
+  };
+
+  it.each([
+    ['null', null],
+    ['an array', []],
+    ['a scalar', 'nope'],
+    ['missing groupResults', { queuedCommands: [], failedDispatches: [], plannedGroups: [] }],
+    ['missing queuedCommands', { groupResults: [], failedDispatches: [], plannedGroups: [] }],
+    ['missing failedDispatches', { groupResults: [], queuedCommands: [], plannedGroups: [] }],
+    ['missing plannedGroups', { groupResults: [], queuedCommands: [], failedDispatches: [] }],
+    ['a group result with no devices array', {
+      groupResults: [{ groupId: 'g1' }], queuedCommands: [], failedDispatches: [], plannedGroups: [],
+    }],
+    ['a device entry with a non-string id', {
+      groupResults: [{ groupId: 'g1', devices: [{ id: 7 }] }],
+      queuedCommands: [], failedDispatches: [], plannedGroups: [],
+    }],
+    ['a non-object queued command', {
+      groupResults: [], queuedCommands: [null], failedDispatches: [], plannedGroups: [],
+    }],
+    ['a queued command with a non-string deviceId', {
+      groupResults: [], queuedCommands: [{ deviceId: 7 }], failedDispatches: [], plannedGroups: [],
+    }],
+    ['a non-string entry in authorizedDeviceIds', resultsDoc([], { authorizedDeviceIds: ['dev-A', 7] })],
+  ])('denies when results is %s', async (_label, results) => {
+    expect(await denied(results)).toEqual([]);
+  });
+
+  it('admits a well-formed document whose devices are all visible', async () => {
+    seqSelect([
+      [{ planId: 'p1', devices: ['dev-A'] }],
+      [{ id: 'dev-A', siteId: 'site-A' }],
+    ]);
+    const rows = [row(resultsDoc(['dev-A']))];
+    expect(await filterReadableDrExecutions(rows, RESTRICTED(), 'org-1')).toEqual(rows);
+  });
+
+  it('treats a null authorizedDeviceIds as "no extra ids", not a malformed doc', async () => {
+    // drExecutionService declares the field `string[] | null`, so null is a
+    // normal value a real execution row carries.
+    seqSelect([
+      [{ planId: 'p1', devices: ['dev-A'] }],
+      [{ id: 'dev-A', siteId: 'site-A' }],
+    ]);
+    const rows = [row(resultsDoc(['dev-A'], { authorizedDeviceIds: null }))];
+    expect(await filterReadableDrExecutions(rows, RESTRICTED(), 'org-1')).toEqual(rows);
+  });
+
+  it('denies when only the historical authorizedDeviceIds names a hidden device', async () => {
+    seqSelect([
+      [{ planId: 'p1', devices: ['dev-A'] }],
+      [{ id: 'dev-A', siteId: 'site-A' }, { id: 'dev-B', siteId: 'site-B' }],
+    ]);
+    const rows = [row(resultsDoc(['dev-A'], { authorizedDeviceIds: ['dev-B'] }))];
+    expect(await filterReadableDrExecutions(rows, RESTRICTED(), 'org-1')).toEqual([]);
+  });
+
+  it('denies on a hidden device named only by the CURRENT plan groups', async () => {
+    seqSelect([
+      [{ planId: 'p1', devices: ['dev-A', 'dev-B'] }],
+      [{ id: 'dev-A', siteId: 'site-A' }, { id: 'dev-B', siteId: 'site-B' }],
+    ]);
+    expect(await filterReadableDrExecutions([row(resultsDoc(['dev-A']))], RESTRICTED(), 'org-1')).toEqual([]);
+  });
+
+  it('ignores a stale historical device that no longer resolves', async () => {
+    seqSelect([
+      [{ planId: 'p1', devices: ['dev-A'] }],
+      [{ id: 'dev-A', siteId: 'site-A' }],
+    ]);
+    const rows = [row(resultsDoc(['dev-A', 'decommissioned']))];
+    expect(await filterReadableDrExecutions(rows, RESTRICTED(), 'org-1')).toEqual(rows);
+  });
+
+  it('returns nothing for a defined-empty ceiling without querying', async () => {
+    expect(await filterReadableDrExecutions([row(resultsDoc([]))], makeAuth([]), 'org-1')).toEqual([]);
+    expect(mockDb.select).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/drReadAuthorization.ts
+++ b/apps/api/src/services/drReadAuthorization.ts
@@ -1,0 +1,209 @@
+import { and, eq, inArray } from 'drizzle-orm';
+import { db } from '../db';
+import { devices, drPlanGroups } from '../db/schema';
+import type { AuthContext } from '../middleware/auth';
+import { isSiteRestrictedPrincipalKind } from './resilienceSiteAuthorization';
+
+export const DR_READ_CANDIDATE_CHUNK_SIZE = 100;
+const DR_READ_IN_QUERY_CHUNK_SIZE = 500;
+
+/**
+ * Ceiling on how far a restricted list read will scan for visible rows.
+ *
+ * Filtering happens after the database returns candidates, so a caller who can
+ * see nothing in a large org would otherwise walk the whole table one 100-row
+ * keyset page at a time (50k hidden executions ≈ 1,500 queries per request).
+ * That is a self-inflicted denial of service on a read a restricted tech can
+ * issue at will. The scan stops at the cap and returns whatever was visible so
+ * far — a short page, never a leaked one.
+ */
+export const DR_READ_MAX_CANDIDATE_PAGES = 20;
+export const DR_READ_MAX_CANDIDATES = DR_READ_CANDIDATE_CHUNK_SIZE * DR_READ_MAX_CANDIDATE_PAGES;
+
+type GroupRef = { planId: string; devices: unknown };
+type ExecutionRef = { planId: string; results: unknown };
+
+function stringArray(value: unknown): string[] | null {
+  if (!Array.isArray(value) || value.some((id) => typeof id !== 'string')) return null;
+  return value as string[];
+}
+
+function groupIds(groups: GroupRef[]): string[] | null {
+  const ids: string[] = [];
+  for (const group of groups) {
+    const parsed = stringArray(group.devices);
+    if (!parsed) return null;
+    ids.push(...parsed);
+  }
+  return [...new Set(ids)];
+}
+
+function executionIds(results: unknown): string[] | null {
+  if (!results || typeof results !== 'object' || Array.isArray(results)) return null;
+  const doc = results as Record<string, unknown>;
+  const groupResults = doc.groupResults;
+  const queued = doc.queuedCommands;
+  const failures = doc.failedDispatches;
+  const planned = doc.plannedGroups;
+  if (!Array.isArray(groupResults) || !Array.isArray(queued) || !Array.isArray(failures) || !Array.isArray(planned)) return null;
+  const ids: string[] = [];
+  for (const group of groupResults) {
+    if (!group || typeof group !== 'object' || !Array.isArray((group as any).devices)) return null;
+    for (const item of (group as any).devices) {
+      const id = item && typeof item === 'object' ? ((item as any).deviceId ?? (item as any).id) : null;
+      if (typeof id !== 'string') return null;
+      ids.push(id);
+    }
+  }
+  for (const entry of [...queued, ...failures]) {
+    if (!entry || typeof entry !== 'object') return null;
+    const id = (entry as any).deviceId;
+    if (id !== undefined && typeof id !== 'string') return null;
+    if (typeof id === 'string') ids.push(id);
+  }
+  // `results.authorizedDeviceIds` is declared in drExecutionService.ts as
+  // "Historical audit context only. Never authorization authority." That
+  // contract holds here: the field can only ADD ids to the must-be-visible
+  // set, never admit a row, so reading it tightens the boundary rather than
+  // deriving authority from it. It is optional and explicitly nullable, so an
+  // absent or null value means "no extra ids" — not a malformed document.
+  if (doc.authorizedDeviceIds !== undefined && doc.authorizedDeviceIds !== null) {
+    const historical = stringArray(doc.authorizedDeviceIds);
+    if (!historical) return null;
+    ids.push(...historical);
+  }
+  return [...new Set(ids)];
+}
+
+/**
+ * The sites a caller may read DR resources for: `null` = unrestricted, `[]` =
+ * nothing, otherwise the allowlist.
+ *
+ * NOTE the asymmetry with `siteRestriction()` in routes/dr.ts, which maps an
+ * unrecognised principal kind to `null` (unrestricted) because every mutation
+ * there is already behind `requirePermission`. This read boundary is also
+ * reached by shared AI/MCP and autonomous tool execution, where no such
+ * middleware runs, so an unrecognised kind is denied outright instead. Keep
+ * both behaviours deliberate: converging them is a security change, not a
+ * cleanup.
+ */
+export function drReadSiteCeiling(auth: AuthContext, override?: string[]): string[] | null {
+  const kind = auth.principal?.kind;
+  if (kind === 'system') return null;
+  if (!isSiteRestrictedPrincipalKind(kind)) return [];
+  return override ?? auth.allowedSiteIds ?? null;
+}
+
+function chunks<T>(values: T[], size = DR_READ_IN_QUERY_CHUNK_SIZE): T[][] {
+  const result: T[][] = [];
+  for (let offset = 0; offset < values.length; offset += size) {
+    result.push(values.slice(offset, offset + size));
+  }
+  return result;
+}
+
+export type DrReadCursor = { createdAt: Date; id: string };
+
+export async function collectReadableDrRows<T extends DrReadCursor>(input: {
+  limit: number;
+  load: (cursor: DrReadCursor | undefined, chunkSize: number) => Promise<T[]>;
+  filter: (rows: T[]) => Promise<T[]>;
+}): Promise<T[]> {
+  const visible: T[] = [];
+  let cursor: DrReadCursor | undefined;
+  let pages = 0;
+  let scanned = 0;
+  while (
+    visible.length < input.limit
+    && pages < DR_READ_MAX_CANDIDATE_PAGES
+    && scanned < DR_READ_MAX_CANDIDATES
+  ) {
+    const candidates = await input.load(cursor, DR_READ_CANDIDATE_CHUNK_SIZE);
+    if (candidates.length === 0) break;
+    pages += 1;
+    scanned += candidates.length;
+    visible.push(...await input.filter(candidates));
+    const last = candidates.at(-1)!;
+    cursor = { createdAt: last.createdAt, id: last.id };
+    if (candidates.length < DR_READ_CANDIDATE_CHUNK_SIZE) break;
+  }
+  return visible.slice(0, input.limit);
+}
+
+async function readableKeys(
+  auth: AuthContext,
+  orgId: string,
+  entries: Array<{ key: string; ids: string[] | null }>,
+  override?: string[],
+): Promise<Set<string>> {
+  const sites = drReadSiteCeiling(auth, override);
+  if (sites === null) return new Set(entries.map((entry) => entry.key));
+  if (sites.length === 0) return new Set();
+  const allIds = [...new Set(entries.flatMap((entry) => entry.ids ?? []))];
+  const rows: Array<{ id: string; siteId: string | null }> = [];
+  for (const idChunk of chunks(allIds)) {
+    rows.push(...await db.select({ id: devices.id, siteId: devices.siteId }).from(devices)
+      .where(and(eq(devices.orgId, orgId), inArray(devices.id, idChunk))));
+  }
+  const allowed = new Set(sites);
+  const resolved = new Map(rows.map((row) => [row.id, row.siteId]));
+  // An id with no surviving device row in this org cannot be a restore target,
+  // so — exactly as `authorizeStoredDevices` decides on the write side in
+  // routes/dr.ts — it does not gate the read. `dr_plan_groups.devices` is jsonb
+  // with no foreign key and is not scrubbed by the device cascade, so a single
+  // decommissioned machine would otherwise wedge the whole plan (and all of its
+  // execution history) out of view for every restricted technician, forever.
+  // A device that DOES still exist and sits outside the ceiling — or carries no
+  // site at all — still denies the whole resource.
+  const denies = (id: string) => {
+    const siteId = resolved.get(id);
+    if (siteId === undefined) return false;
+    return siteId === null || !allowed.has(siteId);
+  };
+  return new Set(entries.filter((entry) => entry.ids !== null && !entry.ids.some(denies)).map((entry) => entry.key));
+}
+
+export async function filterReadableDrPlans<T extends { id: string }>(
+  rows: T[], auth: AuthContext, orgId: string, override?: string[],
+): Promise<T[]> {
+  const sites = drReadSiteCeiling(auth, override);
+  if (sites === null || rows.length === 0) return rows;
+  if (sites.length === 0) return [];
+  const groups: GroupRef[] = [];
+  for (const planIds of chunks(rows.map((row) => row.id))) {
+    groups.push(...await db.select({ planId: drPlanGroups.planId, devices: drPlanGroups.devices })
+      .from(drPlanGroups).where(and(eq(drPlanGroups.orgId, orgId), inArray(drPlanGroups.planId, planIds))));
+  }
+  const byPlan = new Map<string, GroupRef[]>();
+  for (const group of groups) byPlan.set(group.planId, [...(byPlan.get(group.planId) ?? []), group]);
+  const visible = await readableKeys(auth, orgId, rows.map((row) => ({ key: row.id, ids: groupIds(byPlan.get(row.id) ?? []) })), override);
+  return rows.filter((row) => visible.has(row.id));
+}
+
+export async function drGroupsReadable(groups: GroupRef[], auth: AuthContext, orgId: string, override?: string[]) {
+  return (await readableKeys(auth, orgId, [{ key: 'resource', ids: groupIds(groups) }], override)).has('resource');
+}
+
+export async function filterReadableDrExecutions<T extends ExecutionRef>(
+  rows: T[], auth: AuthContext, orgId: string, override?: string[],
+): Promise<T[]> {
+  const sites = drReadSiteCeiling(auth, override);
+  if (sites === null || rows.length === 0) return rows;
+  if (sites.length === 0) return [];
+  const planIds = [...new Set(rows.map((r) => r.planId))];
+  const groups: GroupRef[] = [];
+  for (const planIdChunk of chunks(planIds)) {
+    groups.push(...await db.select({ planId: drPlanGroups.planId, devices: drPlanGroups.devices })
+      .from(drPlanGroups).where(and(eq(drPlanGroups.orgId, orgId), inArray(drPlanGroups.planId, planIdChunk))));
+  }
+  const byPlan = new Map<string, GroupRef[]>();
+  for (const group of groups) byPlan.set(group.planId, [...(byPlan.get(group.planId) ?? []), group]);
+  const entries = rows.map((row) => {
+    const current = groupIds(byPlan.get(row.planId) ?? []);
+    const historical = executionIds(row.results);
+    const union = current && historical ? [...new Set([...current, ...historical])] : null;
+    return { key: row as T, ids: union };
+  });
+  const visible = await readableKeys(auth, orgId, entries.map((entry, index) => ({ key: String(index), ids: entry.ids })), override);
+  return entries.filter((_entry, index) => visible.has(String(index))).map((entry) => entry.key);
+}


### PR DESCRIPTION
## Summary

**SEC-2026-09-05-078 (Medium)** — site-scope escalation on disaster-recovery **reads**.

An earlier upstream change (`a7df9c314`) added current-site authorization to DR plan/group **mutation**, stored-member removal, execution start and abort. The **read** residual remained: authenticated HTTP `GET /dr/plans`, `GET /dr/plans/:id`, `GET /dr/executions` and `GET /dr/executions/:id`, plus the shared `query_dr_plans`, `get_dr_plan_details` and `get_dr_execution_status` AI tools (inherited by MCP and autonomous execution), still returned **complete** same-organization resources to a site-restricted or empty-site caller. Those resources carry hidden device UUIDs, restore configuration, current group membership and historical execution results. Site is an app-layer axis only — Postgres RLS enforces org, not site — so nothing else stopped this.

**What the fix enforces.** DR plans and executions are treated as whole resources, not redactable ones: redacting individual members would make the web editor's full-array replacement silently delete hidden members from a recovery plan, and would misrepresent recovery history. The invariant is therefore:

> A site-restricted principal may receive a DR plan or execution only when **every** current and historical member device needed to understand that resource resolves to a currently visible site.

New `apps/api/src/services/drReadAuthorization.ts` is the single HTTP/AI boundary. It parses current `dr_plan_groups.devices` arrays and the immutable execution `results` shapes (`groupResults[].devices[]`, `queuedCommands[]`, `failedDispatches[]`, `authorizedDeviceIds`), unions current + historical ids, resolves those devices within the same org, and admits the resource only when every id has a non-null currently-allowed site. **Fails closed** on: unsupported principal kinds (no query issued), malformed/legacy result shapes, non-string array members, and missing/deleted/null-site devices.

**Availability and pagination are part of the fix, not an afterthought.** Unrestricted callers keep the direct SQL `LIMIT` fast path (one query, unchanged). Restricted list reads scan deterministic `(created_at DESC, id DESC)` keyset chunks of 100 and filter **before** applying the caller-visible limit, so a fully hidden first page neither leaks nor starves later visible rows. Plan-id and device-id lookups are split into bounded 500-element `IN` chunks. A *defined-empty* site ceiling (`allowedSiteIds: []`) returns immediately with zero candidate or subsidiary reads; an *undefined* ceiling remains unrestricted.

Create / update / delete / execute / abort authorization, durable execution authorization, cross-site restore permission, result creation and agent dispatch are **not** touched.

## Ported from

Local security-program commit `b61def17286be7a80a9258c58362be4ac40b69c5` ("fix(dr): enforce site scope on recovery reads"), cherry-picked with `-x` and squashed into one commit.

- **Nothing was dropped.** All six boundary files (`routes/dr.ts`, `services/aiToolsDR.ts`, `services/aiToolsDR.test.ts`, `services/aiToolsDR.siteScope.test.ts`, and the two new files) are **byte-identical** between the fix's base commit and current `main` — verified by comparing `git hash-object` of each blob at `b61def172^` and `origin/main`. The cherry-pick applied with zero conflicts despite the heavy 09-09/09-10 DR/backup traffic (backup assurance, bare-metal recovery W01/W02 #5523/#5520, SEC-121 #5519), because none of that work touched these files.
- **One cleanup beyond the original patch:** removed the now-unused `inArray` import from `services/aiToolsDR.ts`. The fix deleted the last call site (the old partition-based filter) but left the import; ESLint did not flag it. Behaviour-neutral.
- **Review round applied on this branch** (see *Review fixes* below): three defects in the ported patch itself — a permanent-hide availability bug on decommissioned devices, a fail-closed regression for system-scope callers, and an unbounded candidate scan. All three were introduced by the original patch, not by the port.

No migrations, no schema columns, no new tables — so no RLS-policy, cascade-list or `CORE_TENANT_EXPORT_POLICY` registration is implicated. *(verified: diff touches only `src/routes/`, `src/services/` and test files)*

## Review fixes

Applied after code review returned SHIP-WITH-FIXES (boundary sound, no bypass found).

**1 — a decommissioned device permanently hid a plan from every restricted tech.** `dr_plan_groups.devices` is jsonb with no foreign key, and the table is not in `CORE_DEVICE_CASCADE_DELETE_TABLES`, so deleting a device leaves an id behind that can never resolve again. The original `ids.every(id => visibleIds.has(id))` treated "unresolvable" as "hidden", so one decommissioned machine hid the plan **and all of its execution history** from every site-restricted technician, forever — and it directly contradicted the write side (`authorizeStoredDevices`, `routes/dr.ts`: *"a deleted device must not wedge group maintenance"*). Now an id with no surviving org device row is skipped; a device that **does** still exist and sits outside the ceiling — or carries a null site — still denies the whole resource. This is a deliberate, documented tradeoff: an unresolvable id and a foreign-org id are indistinguishable under RLS, so both are skipped, exactly as the write side already decided.

**2 — system-scope reads fail-closed regression.** `query_dr_plans` and `get_dr_execution_status` guarded on `getOrgId(auth)`, which returns null for a system-scope session (no `orgId`, no `accessibleOrgIds`). That turned every system read into an empty list / "not found" where main returned everything. The guard now hangs off the **site ceiling**: unrestricted and system callers take the original single-query path untouched, and only the restricted branch needs a concrete org — a restricted caller without one still fails **closed**. The execution-detail path now authorizes against `execution.orgId` (already org-gated by `orgWhere`, and resolvable for system sessions) instead of `getOrgId`.

**3 — unbounded keyset scan.** `while (visible.length < limit)` had no ceiling: ~50k hidden executions meant ~1,500 queries in a single request a restricted tech can issue at will. Capped at `DR_READ_MAX_CANDIDATE_PAGES = 20` / `DR_READ_MAX_CANDIDATES = 2000`; the scan returns a short page rather than a long walk. Never returns a row it would otherwise have hidden.

**4 — `plan: plan ?? null`.** A dangling plan reference on an execution is a data-integrity condition, not an authorization failure. `get_dr_execution_status` no longer folds `!plan` into "not found or access denied", matching the HTTP twin in `routes/dr.ts`.

**5 — `authorizedDeviceIds` reconciled.** `drExecutionService.ts` declares the field *"Historical audit context only. Never authorization authority."* The contract holds — the field can only **add** ids to the must-be-visible set, never admit a row — and that is now stated at the read site. Separately it is declared `string[] | null`, and an explicit `null` previously denied the row as malformed; null now means "no extra ids".

**6 — co-located `services/drReadAuthorization.test.ts`** (new, 34 tests) covering the ceiling semantics, the scan cap, the stale-id contract, and the malformed-document matrix directly rather than only through the AI tools.

## Follow-ups (deferred, not addressed here)

- **Abort-route existence oracle** (`routes/dr.ts` `POST /executions/:id/abort`): the handler returns a distinguishable `404` / `400 Cannot abort execution in <state>` before the site check, so a restricted caller can probe execution ids and states. **Pre-existing on main**, unchanged by this PR, and on the mutation path this PR does not touch.
- **Unknown-principal-kind asymmetry**: `drReadSiteCeiling` denies an unrecognised kind; `routes/dr.ts` `siteRestriction` treats it as unrestricted (every route there is behind `requirePermission`; the shared AI/MCP path has no such middleware). Deliberate. A comment now records the reasoning **on both sides**; converging them is a security change, not a cleanup.

## Verification

All commands run in the worktree at head `edc2bc08e6` (rebased onto `main` `e4fbca279d`), against an ephemeral `pnpm test-stack` Postgres+Redis. Every result below is **verified** (observed output), not inferred.

### Red-first A — does the fix close the vulnerability? (vs. `origin/main`)

```
git checkout origin/main -- apps/api/src/routes/dr.ts apps/api/src/services/aiToolsDR.ts
cd apps/api && npx vitest run --pool=threads --maxWorkers=2 \
  src/services/aiToolsDR src/routes/dr.test.ts src/services/drExecutionService.test.ts
```
→ **RED: 13 failed | 79 passed (92)**. All 13 are site-scope assertions in `aiToolsDR.siteScope.test.ts`, including the retained `still denies when a SURVIVING member device sits outside the ceiling`. Restored → **GREEN**.

HTTP route side, proven separately (the unit red-first exercises only the AI-tool path):
```
git checkout origin/main -- apps/api/src/routes/dr.ts
cd apps/api && npx vitest run --config vitest.integration.config.ts --pool=threads --maxWorkers=2 \
  src/__tests__/integration/drReadSiteScope.integration.test.ts
```
→ **RED: 1 failed (1)** — `AssertionError: expected [ 'Empty …', …(2) ] to deeply equal [ Array(2) ]`; main returned the mixed plan that must be hidden. Restored → **GREEN: 1 passed**.

### Red-first B — do the review fixes' tests discriminate? (vs. the pre-review commit `383696af1d`)

Restored the pre-review `drReadAuthorization.ts` and `aiToolsDR.ts`, leaving the new tests in place:

```
cd apps/api && npx vitest run --pool=threads --maxWorkers=2 src/services/aiToolsDR
```
→ **RED: 2 failed | 47 passed (49)** — exactly the two MUST-FIX regressions:
- `ignores a stale device identity that no longer resolves to any org device` (fix 1)
- `system-scope session keeps the unfiltered single-query path` (fix 2)

The scan-cap test (fix 3) cannot report a failure count on the pre-review source because the uncapped `while` loop **never terminates**: `src/services/drReadAuthorization.test.ts` was run alone against it and was **still executing after 90 s** (confirmed the file on disk lacked `DR_READ_MAX_CANDIDATE_PAGES` before the run), then killed. The same file on the fixed source completes as part of a 5-file run in ~4 s. A non-terminating run is the failure signal here; it is not a timing flake.

### Green

| | command | result |
|---|---|---|
| Unit | `npx vitest run --pool=threads --maxWorkers=2 src/services/aiToolsDR src/services/drReadAuthorization src/routes/dr.test.ts src/services/drExecutionService.test.ts` | **5 files / 126 passed** (was 88 pre-review) |
| Integration | `--config vitest.integration.config.ts` filters `backup SiteScope site-scope drRead drExecution` | **20 files / 129 passed** |
| Contract | `--config vitest.config.site-scope-coverage.ts` | **1 file / 7 passed** |
| Contract | `--config vitest.config.integration-suite-coverage.ts` | **1 file / 5 passed** |
| tsc | `NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit` | **exit 0** |
| Lint | `npx eslint` on the 7 touched files | **exit 0** |

Unit set re-run after the rebase onto `e4fbca279d` → **5 files / 126 passed**.

Both contract suites are **excluded** from `vitest.integration.config.ts` and have dedicated runners; passing their paths to the integration config silently collects nothing rather than erroring. `integration-suite-coverage` is the one that confirms the new `drReadSiteScope.integration.test.ts` is actually picked up by a CI job rather than orphaned.

**Not checked:** browser E2E; concurrent site/membership moves during a read; very large allowlists or history documents; fleet-scale query-plan and latency evidence for restricted keyset scans. `apps/web`, `apps/portal` and `packages/shared` are untouched by this diff, so their suites were not run.

## Operator impact

No migration, no credential rotation, no agent upgrade, no schedule reapproval, no customer configuration action. Ships as an ordinary bundled API release note — suggested wording: *"Disaster-recovery plan and execution reads now require complete current-site visibility across HTTP and AI-assisted administration."*

Behaviour changes operators should expect:

- **Plan visibility tightens from "any member device visible" to "all member devices visible".** A tech restricted to a subset of an org's sites **no longer sees** a DR plan or execution whose membership reaches any site outside their scope — previously a single in-scope member was enough to return the whole resource. Plan detail and execution detail return an opaque `404 Plan not found` / `404 Execution not found` rather than a distinguishable authorization error.
- Authorization follows the device's **current** site, not its site at execution time. **Moving a device between sites changes who can read retained recovery history.**
- Legacy or **malformed** group/result documents now **fail closed** for restricted callers — such resources stay invisible to them until the data is repaired. No cleanup migration is included; unrestricted administrators still see everything.
- Plans referencing **deleted** devices stay visible: an id that no longer resolves to a live device in the org does not gate the read, matching how group mutation already behaves. Only surviving out-of-scope (or null-site) devices deny.
- A restricted list read stops after 20 candidate pages / 2,000 rows and returns a **short page**. In an org where nearly everything is out of scope, a page can come back smaller than the requested limit — including empty — without meaning "no more data".
- A plan with no groups (and a group with an empty device list) stays readable to a restricted caller: it contains no site-bound resource. This is the retained whole-resource semantics.

Rollback re-exposes hidden-member recovery metadata and restore configuration; prefer a corrected roll-forward, or temporarily restrict these reads to unrestricted administrators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Tugfg88kFiowD7E5xQFpU
