### PR TITLE
fix(alerts): scope legacy correlations to visible alerts (SEC-049)

### DIFF
--- a/apps/api/src/__tests__/integration/alertTemplateCorrelationScope.integration.test.ts
+++ b/apps/api/src/__tests__/integration/alertTemplateCorrelationScope.integration.test.ts
@@ -1,0 +1,178 @@
+/** Real-PostgreSQL/Redis route proof for legacy alert correlation authorization. */
+import './setup';
+
+import { randomUUID } from 'node:crypto';
+import { and, eq } from 'drizzle-orm';
+import { describe, expect, it } from 'vitest';
+import { Hono } from 'hono';
+import { alertCorrelations, alerts, devices, organizationUsers } from '../../db/schema';
+import { alertTemplateRoutes } from '../../routes/alertTemplates';
+import { clearPermissionCache } from '../../services/permissions';
+import { createIntegrationTestClient, createSite, type TestEnvironment } from './db-utils';
+import { getTestDb } from './setup';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+function makeApp() {
+  const app = new Hono();
+  app.route('/alert-templates', alertTemplateRoutes);
+  return app;
+}
+
+async function restrictUserToSites(env: TestEnvironment, siteIds: string[] | null) {
+  await getTestDb()
+    .update(organizationUsers)
+    .set({ siteIds })
+    .where(and(
+      eq(organizationUsers.userId, env.user.id),
+      eq(organizationUsers.orgId, env.organization.id),
+    ));
+  await clearPermissionCache(env.user.id);
+}
+
+async function seedDevice(orgId: string, siteId: string, label: string) {
+  const [device] = await getTestDb().insert(devices).values({
+    orgId,
+    siteId,
+    agentId: `corr-${label}-${randomUUID().slice(0, 12)}`,
+    hostname: `legacy-correlation-${label}`,
+    osType: 'linux',
+    osVersion: '1',
+    architecture: 'amd64',
+    agentVersion: '1',
+    status: 'online',
+  }).returning();
+  if (!device) throw new Error('device fixture insert failed');
+  return device;
+}
+
+async function seedAlert(orgId: string, deviceId: string, label: string) {
+  const [alert] = await getTestDb().insert(alerts).values({
+    orgId,
+    deviceId,
+    severity: 'high',
+    title: `private-${label}`,
+    message: `private-message-${label}`,
+  }).returning();
+  if (!alert) throw new Error('alert fixture insert failed');
+  return alert;
+}
+
+describe('legacy alert correlation permission and site scope (real PostgreSQL/Redis)', () => {
+  runDb('denies missing permission and exposes only complete visible-site edges', async () => {
+    const app = makeApp();
+    const denied = await createIntegrationTestClient(app, {
+      scope: 'organization',
+      rolePermissions: [],
+    });
+
+    for (const [method, path, body] of [
+      ['GET', '/alert-templates/correlations', undefined],
+      ['GET', '/alert-templates/correlations/groups', undefined],
+      ['POST', '/alert-templates/correlations/analyze', { alertIds: [] }],
+      ['GET', `/alert-templates/correlations/${randomUUID()}`, undefined],
+    ] as const) {
+      const response = method === 'POST' ? await denied.post(path, body) : await denied.get(path);
+      expect(response.status, `${method} ${path}`).toBe(403);
+    }
+
+    const reader = await createIntegrationTestClient(app, {
+      scope: 'organization',
+      rolePermissions: [{ resource: 'alerts', action: 'read' }],
+    });
+    const hiddenSite = await createSite({ orgId: reader.env.organization.id });
+    const visibleDevice = await seedDevice(reader.env.organization.id, reader.env.site.id, 'visible-a');
+    const visibleDevice2 = await seedDevice(reader.env.organization.id, reader.env.site.id, 'visible-b');
+    const hiddenDevice = await seedDevice(reader.env.organization.id, hiddenSite.id, 'hidden');
+    const visibleAlert = await seedAlert(reader.env.organization.id, visibleDevice.id, 'visible-a');
+    const visibleAlert2 = await seedAlert(reader.env.organization.id, visibleDevice2.id, 'visible-b');
+    const hiddenAlert = await seedAlert(reader.env.organization.id, hiddenDevice.id, 'hidden');
+    const [visibleEdge, hiddenEdge] = await getTestDb().insert(alertCorrelations).values([
+      {
+        parentAlertId: visibleAlert.id,
+        childAlertId: visibleAlert2.id,
+        correlationType: 'same-device',
+        confidence: '0.90',
+      },
+      {
+        parentAlertId: visibleAlert.id,
+        childAlertId: hiddenAlert.id,
+        correlationType: 'temporal',
+        confidence: '0.99',
+      },
+    ]).returning();
+    if (!visibleEdge || !hiddenEdge) throw new Error('correlation fixture insert failed');
+
+    const foreign = await createIntegrationTestClient(app, {
+      scope: 'organization',
+      rolePermissions: [{ resource: 'alerts', action: 'read' }],
+    });
+    const foreignDeviceA = await seedDevice(foreign.env.organization.id, foreign.env.site.id, 'foreign-a');
+    const foreignDeviceB = await seedDevice(foreign.env.organization.id, foreign.env.site.id, 'foreign-b');
+    const foreignAlertA = await seedAlert(foreign.env.organization.id, foreignDeviceA.id, 'foreign-a');
+    const foreignAlertB = await seedAlert(foreign.env.organization.id, foreignDeviceB.id, 'foreign-b');
+    const [foreignEdge] = await getTestDb().insert(alertCorrelations).values({
+      parentAlertId: foreignAlertA.id,
+      childAlertId: foreignAlertB.id,
+      correlationType: 'foreign-control',
+      confidence: '1.00',
+    }).returning();
+    if (!foreignEdge) throw new Error('foreign correlation fixture insert failed');
+
+    // Null siteIds is the unrestricted control and must preserve both edges.
+    const unrestricted = await reader.get('/alert-templates/correlations');
+    expect(unrestricted.status).toBe(200);
+    const unrestrictedIds = (await unrestricted.json() as { data: Array<{ id: string }> }).data.map((row) => row.id);
+    expect(unrestrictedIds).toEqual(expect.arrayContaining([visibleEdge.id, hiddenEdge.id]));
+    expect(unrestrictedIds).not.toContain(foreignEdge.id);
+    expect((await reader.get(`/alert-templates/correlations/${foreignAlertA.id}`)).status).toBe(404);
+
+    await restrictUserToSites(reader.env, [reader.env.site.id]);
+
+    const list = await reader.get('/alert-templates/correlations');
+    expect(list.status).toBe(200);
+    expect((await list.json() as { data: Array<{ id: string }> }).data.map((row) => row.id))
+      .toEqual([visibleEdge.id]);
+    const hiddenFilteredList = await reader.get(`/alert-templates/correlations?alertId=${hiddenAlert.id}`);
+    expect(hiddenFilteredList.status).toBe(200);
+    expect((await hiddenFilteredList.json() as { data: unknown[] }).data).toEqual([]);
+
+    const groups = await reader.get('/alert-templates/correlations/groups');
+    expect(groups.status).toBe(200);
+    const groupsBody = await groups.json() as { data: Array<{ alerts: Array<{ id: string }> }> };
+    expect(groupsBody.data).toHaveLength(1);
+    expect(groupsBody.data[0]?.alerts.map((row) => row.id).sort())
+      .toEqual([visibleAlert.id, visibleAlert2.id].sort());
+    expect(JSON.stringify(groupsBody)).not.toContain(hiddenAlert.id);
+    expect(JSON.stringify(groupsBody)).not.toContain('private-hidden');
+
+    expect((await reader.get(`/alert-templates/correlations/${hiddenAlert.id}`)).status).toBe(404);
+    const detail = await reader.get(`/alert-templates/correlations/${visibleAlert.id}`);
+    expect(detail.status).toBe(200);
+    const detailBody = await detail.json() as {
+      data: { correlations: Array<{ id: string }>; relatedAlerts: Array<{ id: string }> };
+    };
+    expect(detailBody.data.correlations.map((row) => row.id)).toEqual([visibleEdge.id]);
+    expect(detailBody.data.relatedAlerts.map((row) => row.id)).toEqual([visibleAlert2.id]);
+
+    const analyze = await reader.post('/alert-templates/correlations/analyze', {});
+    expect(analyze.status).toBe(200);
+    expect((await analyze.json() as { data: { links: Array<{ id: string }> } }).data.links.map((row) => row.id))
+      .toEqual([visibleEdge.id]);
+    const hiddenOnly = await reader.post('/alert-templates/correlations/analyze', { alertIds: [hiddenAlert.id] });
+    expect(hiddenOnly.status).toBe(200);
+    expect((await hiddenOnly.json() as { data: { requestedAlertIds: string[]; links: unknown[] } }).data)
+      .toMatchObject({ requestedAlertIds: [], links: [] });
+
+    // An explicit empty ceiling is restrictive, not equivalent to null/all.
+    await restrictUserToSites(reader.env, []);
+    expect((await reader.get('/alert-templates/correlations')).status).toBe(200);
+    expect((await (await reader.get('/alert-templates/correlations')).json() as { data: unknown[] }).data).toEqual([]);
+    expect((await reader.get('/alert-templates/correlations/groups')).status).toBe(200);
+    expect((await (await reader.get('/alert-templates/correlations/groups')).json() as { data: unknown[] }).data).toEqual([]);
+    expect((await reader.get(`/alert-templates/correlations/${visibleAlert.id}`)).status).toBe(404);
+    const emptyAnalyze = await reader.post('/alert-templates/correlations/analyze', {});
+    expect(emptyAnalyze.status).toBe(200);
+    expect((await emptyAnalyze.json() as { data: { links: unknown[] } }).data.links).toEqual([]);
+  });
+});

--- a/apps/api/src/routes/alertTemplates/correlations.authz.test.ts
+++ b/apps/api/src/routes/alertTemplates/correlations.authz.test.ts
@@ -1,0 +1,197 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+const { authRef, grantedRef, selectRows, visibleAlertIds, deviceVisible, auditMock } = vi.hoisted(() => ({
+  authRef: { current: {
+    scope: 'organization',
+    orgId: '11111111-1111-4111-8111-111111111111',
+    partnerId: null,
+    accessibleOrgIds: null,
+    allowedSiteIds: ['aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'],
+    user: { id: 'user-1' },
+  } },
+  grantedRef: { current: new Set<string>() },
+  selectRows: { current: [] as unknown[][] },
+  visibleAlertIds: { current: new Set<string>() },
+  deviceVisible: { current: true },
+  auditMock: vi.fn(),
+}));
+
+function queryResult(rows: unknown[]) {
+  const query: Record<string, unknown> = {};
+  for (const method of ['where', 'orderBy', 'limit']) {
+    query[method] = vi.fn(() => query);
+  }
+  query.then = (resolve: (value: unknown[]) => unknown) => Promise.resolve(rows).then(resolve);
+  return query;
+}
+
+vi.mock('../../db', () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => queryResult(selectRows.current.shift() ?? [])),
+    })),
+  },
+}));
+
+vi.mock('../../db/schema', () => ({
+  alerts: { id: 'alerts.id', orgId: 'alerts.org_id', deviceId: 'alerts.device_id' },
+  alertCorrelations: {
+    parentAlertId: 'alert_correlations.parent_alert_id',
+    childAlertId: 'alert_correlations.child_alert_id',
+    createdAt: 'alert_correlations.created_at',
+  },
+}));
+
+vi.mock('../../middleware/auth', () => ({
+  requireScope: () => async (c: any, next: any) => {
+    c.set('auth', authRef.current);
+    return next();
+  },
+  requirePermission: (resource: string, action: string) => async (c: any, next: any) => {
+    if (!grantedRef.current.has(`${resource}:${action}`)) return c.json({ error: 'Forbidden' }, 403);
+    return next();
+  },
+}));
+
+vi.mock('../../services/permissions', () => ({
+  PERMISSIONS: { ALERTS_READ: { resource: 'alerts', action: 'read' } },
+}));
+
+vi.mock('../tickets/siteScope', () => ({
+  filterAlertsBySiteScope: vi.fn(async (_auth: unknown, rows: Array<{ id: string }>) =>
+    rows.filter((row) => visibleAlertIds.current.has(row.id))),
+  deviceInSiteScope: vi.fn(async () => deviceVisible.current),
+}));
+
+vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: auditMock }));
+vi.mock('./helpers', () => ({ resolveScopedOrgId: () => authRef.current.orgId }));
+vi.mock('../../utils/pagination', () => ({ getPagination: () => ({ page: 1, limit: 20, offset: 0 }) }));
+
+import { correlationRoutes, filterCorrelationsToVisibleAlerts } from './correlations';
+
+const ALERT_A = 'aaaaaaaa-1111-4111-8111-111111111111';
+const ALERT_B = 'bbbbbbbb-2222-4222-8222-222222222222';
+const ALERT_HIDDEN = 'cccccccc-3333-4333-8333-333333333333';
+
+function makeApp() {
+  const app = new Hono();
+  app.route('/alert-templates', correlationRoutes);
+  return app;
+}
+
+describe('legacy correlation authorization and site scope', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    grantedRef.current = new Set<string>();
+    selectRows.current = [];
+    visibleAlertIds.current = new Set([ALERT_A, ALERT_B]);
+    deviceVisible.current = true;
+  });
+
+  for (const request of [
+    () => makeApp().request('/alert-templates/correlations'),
+    () => makeApp().request('/alert-templates/correlations/groups'),
+    () => makeApp().request('/alert-templates/correlations/analyze', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ alertIds: [ALERT_A] }),
+    }),
+    () => makeApp().request(`/alert-templates/correlations/${ALERT_A}`),
+  ]) {
+    it('denies a caller without alerts:read before any database access', async () => {
+      const response = await request();
+      expect(response.status).toBe(403);
+      const { db } = await import('../../db');
+      expect(db.select).not.toHaveBeenCalled();
+      expect(auditMock).not.toHaveBeenCalled();
+    });
+  }
+
+  it('filters every correlation edge unless both endpoints are visible', () => {
+    expect(filterCorrelationsToVisibleAlerts([
+      { id: 'visible', parentAlertId: ALERT_A, childAlertId: ALERT_B },
+      { id: 'hidden-child', parentAlertId: ALERT_A, childAlertId: ALERT_HIDDEN },
+      { id: 'hidden-parent', parentAlertId: ALERT_HIDDEN, childAlertId: ALERT_B },
+    ], [ALERT_A, ALERT_B]).map((row) => row.id)).toEqual(['visible']);
+  });
+
+  it('groups only visible alerts and drops edges to a hidden-site alert', async () => {
+    grantedRef.current.add('alerts:read');
+    selectRows.current = [
+      [[
+        { id: ALERT_A, deviceId: 'device-a', title: 'Allowed A' },
+        { id: ALERT_B, deviceId: 'device-b', title: 'Allowed B' },
+        { id: ALERT_HIDDEN, deviceId: 'device-hidden', title: 'Hidden' },
+      ]],
+      [[
+        { parentAlertId: ALERT_A, childAlertId: ALERT_B, confidence: '0.9', createdAt: new Date() },
+        { parentAlertId: ALERT_A, childAlertId: ALERT_HIDDEN, confidence: '1.0', createdAt: new Date() },
+      ]],
+    ].flat();
+
+    const response = await makeApp().request('/alert-templates/correlations/groups');
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].alerts.map((alert: { id: string }) => alert.id)).toEqual([ALERT_A, ALERT_B]);
+    expect(JSON.stringify(body)).not.toContain(ALERT_HIDDEN);
+    expect(body.data[0].correlationScore).toBe(0.9);
+  });
+
+  it('returns an opaque 404 for a named alert outside the site ceiling', async () => {
+    grantedRef.current.add('alerts:read');
+    deviceVisible.current = false;
+    selectRows.current = [[{ id: ALERT_HIDDEN, deviceId: 'device-hidden' }]];
+
+    const response = await makeApp().request(`/alert-templates/correlations/${ALERT_HIDDEN}`);
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: 'Alert not found' });
+    const { db } = await import('../../db');
+    expect(db.select).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops hidden related alerts and their correlation rows from by-id output', async () => {
+    grantedRef.current.add('alerts:read');
+    selectRows.current = [
+      [{ id: ALERT_A, deviceId: 'device-a' }],
+      [
+        { id: 'edge-visible', parentAlertId: ALERT_A, childAlertId: ALERT_B },
+        { id: 'edge-hidden', parentAlertId: ALERT_A, childAlertId: ALERT_HIDDEN },
+      ],
+      [
+        { id: ALERT_B, deviceId: 'device-b' },
+        { id: ALERT_HIDDEN, deviceId: 'device-hidden' },
+      ],
+    ];
+
+    const response = await makeApp().request(`/alert-templates/correlations/${ALERT_A}`);
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data.relatedAlerts.map((alert: { id: string }) => alert.id)).toEqual([ALERT_B]);
+    expect(body.data.correlations.map((edge: { id: string }) => edge.id)).toEqual(['edge-visible']);
+    expect(JSON.stringify(body)).not.toContain(ALERT_HIDDEN);
+  });
+
+  it('does not expand an analyze request containing only hidden alert IDs to all visible links', async () => {
+    grantedRef.current.add('alerts:read');
+    visibleAlertIds.current = new Set([ALERT_A]);
+    selectRows.current = [
+      [
+        { id: ALERT_A, deviceId: 'device-a' },
+        { id: ALERT_HIDDEN, deviceId: 'device-hidden' },
+      ],
+      [{ id: 'should-drop', parentAlertId: ALERT_A, childAlertId: ALERT_A }],
+    ];
+
+    const response = await makeApp().request('/alert-templates/correlations/analyze', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ alertIds: [ALERT_HIDDEN] }),
+    });
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data.requestedAlertIds).toEqual([]);
+    expect(body.data.links).toEqual([]);
+  });
+});

--- a/apps/api/src/routes/alertTemplates/correlations.ts
+++ b/apps/api/src/routes/alertTemplates/correlations.ts
@@ -2,18 +2,44 @@ import { Hono } from 'hono';
 import { zValidator } from '../../lib/validation';
 import { db } from '../../db';
 import { alerts, alertCorrelations } from '../../db/schema';
-import { eq, and, or, gte, desc, sql, inArray } from 'drizzle-orm';
-import { requireScope } from '../../middleware/auth';
+import { eq, and, or, desc, inArray } from 'drizzle-orm';
+import { requirePermission, requireScope, type AuthContext } from '../../middleware/auth';
 import { writeRouteAudit } from '../../services/auditEvents';
+import { PERMISSIONS } from '../../services/permissions';
 import { listCorrelationsSchema, analyzeCorrelationsSchema } from './schemas';
 import { resolveScopedOrgId } from './helpers';
 import { getPagination } from '../../utils/pagination';
+import { deviceInSiteScope, filterAlertsBySiteScope } from '../tickets/siteScope';
 
 export const correlationRoutes = new Hono();
+
+const requireAlertRead = requirePermission(
+  PERMISSIONS.ALERTS_READ.resource,
+  PERMISSIONS.ALERTS_READ.action,
+);
+
+async function visibleOrgAlertIds(auth: AuthContext, orgId: string): Promise<string[]> {
+  const orgAlerts = await db
+    .select({ id: alerts.id, deviceId: alerts.deviceId })
+    .from(alerts)
+    .where(eq(alerts.orgId, orgId));
+  const visibleAlerts = await filterAlertsBySiteScope({ ...auth, orgId }, orgAlerts);
+  return visibleAlerts.map((alert) => alert.id);
+}
+
+export function filterCorrelationsToVisibleAlerts<
+  T extends { parentAlertId: string; childAlertId: string },
+>(correlations: T[], visibleAlertIds: readonly string[]): T[] {
+  const visible = new Set(visibleAlertIds);
+  return correlations.filter(
+    (correlation) => visible.has(correlation.parentAlertId) && visible.has(correlation.childAlertId),
+  );
+}
 
 correlationRoutes.get(
   '/correlations',
   requireScope('organization', 'partner', 'system'),
+  requireAlertRead,
   zValidator('query', listCorrelationsSchema),
   async (c) => {
     try {
@@ -26,12 +52,7 @@ correlationRoutes.get(
       const query = c.req.valid('query');
 
       // Get all alert IDs for this org to scope correlations
-      const orgAlerts = await db
-        .select({ id: alerts.id })
-        .from(alerts)
-        .where(eq(alerts.orgId, orgId));
-
-      const orgAlertIds = orgAlerts.map(a => a.id);
+      const orgAlertIds = await visibleOrgAlertIds(auth, orgId);
 
       if (orgAlertIds.length === 0) {
         return c.json({ data: [], page: 1, limit: 20, total: 0 });
@@ -56,6 +77,7 @@ correlationRoutes.get(
         .from(alertCorrelations)
         .where(and(...filterConditions))
         .orderBy(desc(alertCorrelations.createdAt));
+      allCorrelations = filterCorrelationsToVisibleAlerts(allCorrelations, orgAlertIds);
 
       if (query.minConfidence) {
         const minConfidence = Number.parseFloat(query.minConfidence);
@@ -83,6 +105,7 @@ correlationRoutes.get(
 correlationRoutes.get(
   '/correlations/groups',
   requireScope('organization', 'partner', 'system'),
+  requireAlertRead,
   async (c) => {
     try {
       const auth = c.get('auth');
@@ -93,10 +116,11 @@ correlationRoutes.get(
 
       // Build correlation groups from real data:
       // Group alerts that share correlation links into clusters
-      const orgAlerts = await db
+      const allOrgAlerts = await db
         .select()
         .from(alerts)
         .where(eq(alerts.orgId, orgId));
+      const orgAlerts = await filterAlertsBySiteScope({ ...auth, orgId }, allOrgAlerts);
 
       const orgAlertIds = orgAlerts.map(a => a.id);
       const alertMap = new Map(orgAlerts.map(a => [a.id, a]));
@@ -105,7 +129,7 @@ correlationRoutes.get(
         return c.json({ data: [] });
       }
 
-      const scopedCorrelations = await db
+      const correlationRows = await db
         .select()
         .from(alertCorrelations)
         .where(and(
@@ -113,6 +137,7 @@ correlationRoutes.get(
           inArray(alertCorrelations.childAlertId, orgAlertIds)
         ))
         .orderBy(desc(alertCorrelations.createdAt));
+      const scopedCorrelations = filterCorrelationsToVisibleAlerts(correlationRows, orgAlertIds);
 
       // Union-find to group correlated alerts
       const parent = new Map<string, string>();
@@ -169,6 +194,7 @@ correlationRoutes.get(
 correlationRoutes.post(
   '/correlations/analyze',
   requireScope('organization', 'partner', 'system'),
+  requireAlertRead,
   zValidator('json', analyzeCorrelationsSchema),
   async (c) => {
     try {
@@ -181,14 +207,10 @@ correlationRoutes.post(
       const data = c.req.valid('json');
       const windowMinutes = data.windowMinutes ?? 60;
 
-      const orgAlerts = await db
-        .select({ id: alerts.id })
-        .from(alerts)
-        .where(eq(alerts.orgId, orgId));
-
-      const orgAlertIdList = orgAlerts.map(a => a.id);
+      const orgAlertIdList = await visibleOrgAlertIds(auth, orgId);
       const orgAlertIdSet = new Set(orgAlertIdList);
-      const alertIds = (data.alertIds ?? []).filter(id => orgAlertIdSet.has(id));
+      const requestedAlertIds = data.alertIds ?? [];
+      const alertIds = requestedAlertIds.filter(id => orgAlertIdSet.has(id));
 
       if (orgAlertIdList.length === 0) {
         return c.json({
@@ -206,7 +228,7 @@ correlationRoutes.post(
         inArray(alertCorrelations.childAlertId, orgAlertIdList),
       ];
 
-      if (alertIds.length) {
+      if (requestedAlertIds.length && alertIds.length > 0) {
         scopeConditions.push(
           or(
             inArray(alertCorrelations.parentAlertId, alertIds),
@@ -215,11 +237,17 @@ correlationRoutes.post(
         );
       }
 
-      const links = await db
-        .select()
-        .from(alertCorrelations)
-        .where(and(...scopeConditions))
-        .orderBy(desc(alertCorrelations.createdAt));
+      // A non-empty request that resolves entirely outside the caller's site
+      // ceiling is an empty selection, not an implicit request for every
+      // visible correlation in the organization.
+      const linkRows = requestedAlertIds.length > 0 && alertIds.length === 0
+        ? []
+        : await db
+          .select()
+          .from(alertCorrelations)
+          .where(and(...scopeConditions))
+          .orderBy(desc(alertCorrelations.createdAt));
+      const links = filterCorrelationsToVisibleAlerts(linkRows, orgAlertIdList);
 
       writeRouteAudit(c, {
         orgId,
@@ -237,8 +265,10 @@ correlationRoutes.post(
           requestedAlertIds: alertIds,
           windowMinutes,
           links,
-          summary: alertIds.length
-            ? 'Correlation analysis complete for requested alerts.'
+          summary: requestedAlertIds.length
+            ? alertIds.length
+              ? 'Correlation analysis complete for requested alerts.'
+              : 'No visible requested alerts found.'
             : 'Returning all correlation data.'
         }
       });
@@ -252,6 +282,7 @@ correlationRoutes.post(
 correlationRoutes.get(
   '/correlations/:alertId',
   requireScope('organization', 'partner', 'system'),
+  requireAlertRead,
   async (c) => {
     try {
       const auth = c.get('auth');
@@ -268,7 +299,7 @@ correlationRoutes.get(
         .where(and(eq(alerts.id, alertId), eq(alerts.orgId, orgId)))
         .limit(1);
 
-      if (!alert) {
+      if (!alert || !(await deviceInSiteScope(auth, alert.deviceId))) {
         return c.json({ error: 'Alert not found' }, 404);
       }
 
@@ -300,12 +331,21 @@ correlationRoutes.get(
               inArray(alerts.id, ids)
             )
           );
+        relatedAlerts = await filterAlertsBySiteScope({ ...auth, orgId }, relatedAlerts);
       }
+
+      const visibleRelatedIds = new Set(relatedAlerts.map((related) => related.id));
+      const visibleCorrelations = correlations.filter((correlation) => {
+        const relatedId = correlation.parentAlertId === alertId
+          ? correlation.childAlertId
+          : correlation.parentAlertId;
+        return visibleRelatedIds.has(relatedId);
+      });
 
       return c.json({
         data: {
           alert,
-          correlations,
+          correlations: visibleCorrelations,
           relatedAlerts,
         }
       });


### PR DESCRIPTION
## Summary

### SEC-049 (Medium) — legacy alert correlations ignored the site ceiling and the alerts:read permission

The four legacy correlation endpoints mounted under `/alert-templates`
(`GET /correlations`, `GET /correlations/groups`, `POST /correlations/analyze`,
`GET /correlations/:alertId`) scoped their queries **by organization only**.

Two problems:

1. **No permission gate.** None of the four routes called `requirePermission`, so a
   custom role with `alerts:read` removed could still read the org's alert
   relationship graph through them.
2. **No site ceiling.** A site-restricted (sub-org) reader — the case
   `UserPermissions.allowedSiteIds` exists for — saw correlation edges, union-find
   groups, related-alert payloads and analyze results covering alerts on devices in
   sites they are not granted. `GET /alerts` and `GET /alerts/:id` have enforced
   that ceiling for a while; these routes were never brought along, so they were a
   side door onto the same data (alert ids, severities, titles, device linkage).

There was also a latent widening in `POST /correlations/analyze`: a request whose
`alertIds` all resolved outside the caller's ceiling filtered down to an empty
`alertIds` list, which the old code read as "no selection given" and answered with
**every** correlation in the org.

The fix applies the ceiling that already exists for the alert list/detail routes,
reusing the shared `routes/tickets/siteScope.ts` helpers (`filterAlertsBySiteScope`,
`deviceInSiteScope`):

- all four routes now require `PERMISSIONS.ALERTS_READ`;
- the org alert set that scopes correlations is narrowed by
  `filterAlertsBySiteScope` first (`visibleOrgAlertIds`);
- a new `filterCorrelationsToVisibleAlerts` keeps an edge only when **both**
  endpoints are visible, so a visible alert can never be used to disclose a hidden
  partner alert's id;
- `GET /correlations/:alertId` returns an opaque `404 Alert not found` for an alert
  outside the ceiling, and drops hidden related alerts plus the edges pointing at
  them;
- `POST /correlations/analyze` treats "requested ids, none visible" as an empty
  selection (empty `links`, `summary: 'No visible requested alerts found.'`) rather
  than an implicit request for the whole org.

Unrestricted callers (partner/system scope, or org users with no site restriction)
are unaffected — `allowedSiteIds === undefined` short-circuits every helper.

## Ported from

| Finding | Local commit | Status here |
|---|---|---|
| SEC-2026-09-05-049 | `cec5940419f060fe237e26a968523b082a3826a5` | **Ported** — cherry-picked clean, no conflicts, no content changes |
| SEC-2026-09-05-035 | `4e0f760bcbdc22aa2699c025d26da3e29064c9de` | **Dropped — already on main** |

**Why SEC-035 was dropped (verified).** SEC-035 was "alert summary aggregates are
not site-scoped and do not require alerts:read". That fix landed independently on
main in **#5070** (`d8a06fb015`, *fix(alerts): enforce read permission and
site-scoped summaries*), in equivalent-or-better form:

- `alertsRoutes.get('/summary', …)` on main carries `requireAlertRead`
  (`PERMISSIONS.ALERTS_READ`) — same gate the local commit added;
- main computes `visibleFilter = and(orgFilter, alertSiteScopeCondition(c.get('permissions').allowedSiteIds))`
  and applies it, with `leftJoin(devices, …)`, to **all three** aggregates
  (severity, status, total). `alertSiteScopeCondition`
  (`routes/alerts/helpers.ts:55`) has the same semantics the local commit inlined:
  `undefined` when unrestricted, `isNull(alerts.deviceId)` for an empty allowlist,
  `or(isNull(deviceId), inArray(devices.siteId, allowed))` otherwise. Main factored
  it into a shared helper that `GET /alerts` also uses — strictly better than the
  local commit's duplicated inline expression.

The local commit's integration proof (`alertSummarySiteScope.integration.test.ts`)
is likewise superseded by main's `alertsReadAuthorization.integration.test.ts`,
which is broader: it asserts list/detail/summary agree for both `one` and `empty`
site allowlists, checks the partner fleet summary, site revocation, and that moving
a device out of an allowed site changes list + summary + detail together. Porting
the local tests would have added assertions that pass on unmodified main — vacuous
by the red-first rule below — so nothing from SEC-035 is in this PR.

Because only one finding landed, the PR title names only SEC-049.

## Verification

All commands run in the worktree at head `adb1cc6749`, rebased on `origin/main`
`29e9445f3d`, against an ephemeral Postgres+Redis stack (`pnpm test-stack up`).
Every claim below is **verified** (commands run, counts copied from the reporter)
unless labelled otherwise.

**Red-first — unit** (verified)

```
git checkout origin/main -- apps/api/src/routes/alertTemplates/correlations.ts
cd apps/api && npx vitest run --pool=threads --maxWorkers=2 \
  src/routes/alertTemplates/correlations.authz.test.ts
#  Test Files  1 failed (1)
#       Tests  9 failed (9)      <- all 9 ported assertions fail on main's source

git checkout HEAD -- apps/api/src/routes/alertTemplates/correlations.ts
cd apps/api && npx vitest run --pool=threads --maxWorkers=2 \
  src/routes/alertTemplates/correlations.authz.test.ts
#  Test Files  1 passed (1)
#       Tests  9 passed (9)
```

**Red-first — integration, real Postgres as `breeze_app`** (verified)

```
git checkout origin/main -- apps/api/src/routes/alertTemplates/correlations.ts
cd apps/api && npx vitest run --config vitest.integration.config.ts \
  --pool=threads --maxWorkers=2 alertTemplateCorrelationScope
#  Test Files  1 failed (1)
#       Tests  1 failed (1)
#   × denies missing permission and exposes only complete visible-site edges

git checkout HEAD -- apps/api/src/routes/alertTemplates/correlations.ts
# same command -> Test Files 1 passed (1) / Tests 1 passed (1)
```

**Unit suites** (verified)

```
cd apps/api && npx vitest run --pool=threads --maxWorkers=2 src/routes/alertTemplates
#  Test Files  11 passed (11)   Tests  75 passed (75)

cd apps/api && npx vitest run --pool=threads --maxWorkers=2 src/routes/alerts
#  Test Files  32 passed (32)   Tests  374 passed (374)
```

**Integration family** — every `alert`/`Alert` integration suite plus the whole
site-scope family, including `site-scope-coverage` (verified)

```
cd apps/api && npx vitest run --config vitest.integration.config.ts \
  --pool=threads --maxWorkers=2 --reporter=verbose alert Alert SiteScope site-scope
#  Test Files  28 passed (28)   Tests  143 passed (143)
```

Files exercised include `alertTemplateCorrelationScope`, `alertCorrelationGroups`,
`alertCorrelationPublish`, `alertsReadAuthorization`, `alertAuthenticatedSite`,
`alertTemplateSiteScope`, `alertTemplateReadPermission`, `site-scope-coverage`,
`report-site-scope`, `policyComplianceSiteScope`, `automationReadSiteScope` and the
rest of the `*SiteScope` set.

**Typecheck / lint** (verified)

```
cd apps/api && NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit   # exit 0, no output
cd apps/api && npx eslint src/routes/alertTemplates/correlations.ts \
  src/routes/alertTemplates/correlations.authz.test.ts \
  src/__tests__/integration/alertTemplateCorrelationScope.integration.test.ts  # exit 0
```

**Not applicable / not checked**

- No migration, no schema column, no new table — RLS coverage, tenant cascade,
  export policy and migration-naming contracts are untouched (*inferred* from the
  diff: three files, all under `apps/api/src/routes/alertTemplates` and
  `apps/api/src/__tests__/integration`).
- `apps/web`, `apps/portal`, `packages/shared` untouched — **not checked**, no diff
  in those packages.
- Full API unit suite and the remaining integration shards — **not checked**
  locally; CI covers them.

## Operator impact

- **Behaviour change for site-restricted org users only.** A user whose role
  carries a site restriction now sees correlation edges, groups and related alerts
  limited to alerts on devices in their granted sites (plus device-less, org-wide
  alerts, matching `GET /alerts`). Counts and group sizes on those endpoints will
  drop for those users. Partner-, system- and unrestricted org-scope callers see no
  change.
- **New permission requirement.** All four correlation endpoints now return `403`
  for a caller without `alerts:read`. Any custom role that was reading correlations
  without that permission must be granted `alerts:read`.
- `POST /correlations/analyze` with an `alertIds` list that is entirely outside the
  caller's site ceiling now returns an empty `links` array and
  `summary: "No visible requested alerts found."` instead of the org's full
  correlation set.
- No migration, no config, no env var. Nothing to do at deploy time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Tugfg88kFiowD7E5xQFpU
