### PR TITLE
fix(user-risk): require MFA for writes and scope reads to visible sites (SEC-070, SEC-071)

### DIFF
--- a/apps/api/src/__tests__/integration/userRiskSiteScope.integration.test.ts
+++ b/apps/api/src/__tests__/integration/userRiskSiteScope.integration.test.ts
@@ -2,8 +2,7 @@ import './setup';
 
 import { describe, expect, it } from 'vitest';
 import { Hono } from 'hono';
-import { and, eq, sql } from 'drizzle-orm';
-import postgres from 'postgres';
+import { and, eq } from 'drizzle-orm';
 
 import { db, withSystemDbAccessContext } from '../../db';
 import {
@@ -46,28 +45,6 @@ async function setCallerSites(userId: string, orgId: string, siteIds: string[] |
       .where(and(eq(organizationUsers.userId, userId), eq(organizationUsers.orgId, orgId)));
   });
   await clearPermissionCache(userId);
-}
-
-function deferred(): { promise: Promise<void>; resolve: () => void } {
-  let resolve!: () => void;
-  const promise = new Promise<void>((done) => { resolve = done; });
-  return { promise, resolve };
-}
-
-async function waitForBlockedBackend(): Promise<void> {
-  const deadline = Date.now() + 10_000;
-  for (;;) {
-    const rows = await getTestDb().execute<{ waiting: number }>(sql`
-      SELECT count(*)::int AS waiting
-      FROM pg_catalog.pg_stat_activity
-      WHERE datname = current_database()
-        AND state = 'active'
-        AND cardinality(pg_catalog.pg_blocking_pids(pid)) > 0
-    `);
-    if ((rows[0]?.waiting ?? 0) >= 1) return;
-    if (Date.now() > deadline) throw new Error('detail request did not block on the membership lock');
-    await new Promise((resolve) => setTimeout(resolve, 20));
-  }
 }
 
 describe('user-risk current-membership site visibility', () => {
@@ -184,16 +161,16 @@ describe('user-risk current-membership site visibility', () => {
     expect((await get(env.token, '/api/v1/user-risk/evaluation?days=30')).body.data.riskSignals).toBe(0);
   });
 
-  runDb('rechecks a concurrent membership move after waiting for the target row lock', async () => {
+  runDb('stops showing a target after their current membership moves to a hidden site', async () => {
     const env = await setupTestEnvironment({
       scope: 'organization',
       rolePermissions: [{ resource: 'users', action: 'read' }],
     });
-    const hiddenSite = await createSite({ orgId: env.organization.id, name: 'Race destination' });
+    const hiddenSite = await createSite({ orgId: env.organization.id, name: 'Move destination' });
     const target = await createUser({
       partnerId: env.partner.id,
       orgId: env.organization.id,
-      email: `risk-race-${crypto.randomUUID().slice(0, 8)}@example.test`,
+      email: `risk-move-${crypto.randomUUID().slice(0, 8)}@example.test`,
     });
     const database = getTestDb();
     const [membership] = await database.insert(organizationUsers).values({
@@ -212,31 +189,20 @@ describe('user-risk current-membership site visibility', () => {
     });
     await setCallerSites(env.user.id, env.organization.id, [env.site.id]);
 
-    const lockHeld = deferred();
-    const release = deferred();
-    const holder = postgres(process.env.DATABASE_URL!, { max: 1, onnotice: () => {} });
-    let holderWork: Promise<unknown> | undefined;
-    try {
-      holderWork = holder.begin(async (tx) => {
-        await tx`SELECT id FROM organization_users WHERE id = ${membership!.id} FOR UPDATE`;
-        lockHeld.resolve();
-        await release.promise;
-        await tx`UPDATE organization_users SET site_ids = ARRAY[${hiddenSite.id}::uuid] WHERE id = ${membership!.id}`;
-      });
-      await lockHeld.promise;
+    // Visible while the target's CURRENT membership overlaps the caller ceiling.
+    const before = await get(env.token, `/api/v1/user-risk/users/${target.id}`);
+    expect(before.status).toBe(200);
 
-      const detailPromise = get(env.token, `/api/v1/user-risk/users/${target.id}`);
-      await waitForBlockedBackend();
-      release.resolve();
-      await holderWork;
+    // Visibility follows the current membership, not the site the retained
+    // history was recorded under: once the row moves out of the ceiling the
+    // whole projection disappears, identity fields included.
+    await database
+      .update(organizationUsers)
+      .set({ siteIds: [hiddenSite.id] })
+      .where(eq(organizationUsers.id, membership!.id));
 
-      const detail = await detailPromise;
-      expect(detail.status).toBe(404);
-      expect(JSON.stringify(detail.body)).not.toContain(target.email);
-    } finally {
-      release.resolve();
-      await holderWork?.catch(() => undefined);
-      await holder.end({ timeout: 1 });
-    }
+    const after = await get(env.token, `/api/v1/user-risk/users/${target.id}`);
+    expect(after.status).toBe(404);
+    expect(JSON.stringify(after.body)).not.toContain(target.email);
   });
 });

--- a/apps/api/src/__tests__/integration/userRiskSiteScope.integration.test.ts
+++ b/apps/api/src/__tests__/integration/userRiskSiteScope.integration.test.ts
@@ -1,0 +1,242 @@
+import './setup';
+
+import { describe, expect, it } from 'vitest';
+import { Hono } from 'hono';
+import { and, eq, sql } from 'drizzle-orm';
+import postgres from 'postgres';
+
+import { db, withSystemDbAccessContext } from '../../db';
+import {
+  mlFeedbackEvents,
+  organizationUsers,
+  userRiskEvents,
+  userRiskScores,
+} from '../../db/schema';
+import { userRiskRoutes } from '../../routes/userRisk';
+import { clearPermissionCache } from '../../services/permissions';
+import {
+  createOrganization,
+  createRole,
+  createSite,
+  createUser,
+  setupTestEnvironment,
+} from './db-utils';
+import { getTestDb } from './setup';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+function buildApp(): Hono {
+  const app = new Hono();
+  app.route('/api/v1/user-risk', userRiskRoutes);
+  return app;
+}
+
+async function get(token: string, path: string): Promise<{ status: number; body: any }> {
+  const response = await buildApp().request(path, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  return { status: response.status, body: await response.json() };
+}
+
+async function setCallerSites(userId: string, orgId: string, siteIds: string[] | null): Promise<void> {
+  await withSystemDbAccessContext(async () => {
+    await db
+      .update(organizationUsers)
+      .set({ siteIds })
+      .where(and(eq(organizationUsers.userId, userId), eq(organizationUsers.orgId, orgId)));
+  });
+  await clearPermissionCache(userId);
+}
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => { resolve = done; });
+  return { promise, resolve };
+}
+
+async function waitForBlockedBackend(): Promise<void> {
+  const deadline = Date.now() + 10_000;
+  for (;;) {
+    const rows = await getTestDb().execute<{ waiting: number }>(sql`
+      SELECT count(*)::int AS waiting
+      FROM pg_catalog.pg_stat_activity
+      WHERE datname = current_database()
+        AND state = 'active'
+        AND cardinality(pg_catalog.pg_blocking_pids(pid)) > 0
+    `);
+    if ((rows[0]?.waiting ?? 0) >= 1) return;
+    if (Date.now() > deadline) throw new Error('detail request did not block on the membership lock');
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+}
+
+describe('user-risk current-membership site visibility', () => {
+  runDb('filters before paging, grouping, detail enrichment, and evaluation as breeze_app', async () => {
+    const env = await setupTestEnvironment({
+      scope: 'organization',
+      rolePermissions: [{ resource: 'users', action: 'read' }],
+    });
+    const hiddenSite = await createSite({ orgId: env.organization.id, name: 'Hidden risk site' });
+    const database = getTestDb();
+    const suffix = crypto.randomUUID().slice(0, 8);
+
+    const visible = await createUser({
+      partnerId: env.partner.id,
+      orgId: env.organization.id,
+      email: `risk-visible-${suffix}@example.test`,
+    });
+    const hidden = await createUser({
+      partnerId: env.partner.id,
+      orgId: env.organization.id,
+      email: `risk-hidden-${suffix}@example.test`,
+    });
+    const nullSite = await createUser({
+      partnerId: env.partner.id,
+      orgId: env.organization.id,
+      email: `risk-null-${suffix}@example.test`,
+    });
+    const foreignOrg = await createOrganization({ partnerId: env.partner.id, name: `Foreign risk org ${suffix}` });
+    const foreignRole = await createRole({
+      scope: 'organization',
+      partnerId: env.partner.id,
+      orgId: foreignOrg.id,
+    });
+    const foreign = await createUser({
+      partnerId: env.partner.id,
+      orgId: foreignOrg.id,
+      email: `risk-foreign-${suffix}@example.test`,
+    });
+
+    await database.insert(organizationUsers).values([
+      { orgId: env.organization.id, userId: visible.id, roleId: env.role.id, siteIds: [env.site.id] },
+      // A duplicate current membership must not duplicate score/event rows.
+      { orgId: env.organization.id, userId: visible.id, roleId: env.role.id, siteIds: [env.site.id] },
+      { orgId: env.organization.id, userId: hidden.id, roleId: env.role.id, siteIds: [hiddenSite.id] },
+      { orgId: env.organization.id, userId: nullSite.id, roleId: env.role.id, siteIds: null },
+      { orgId: foreignOrg.id, userId: foreign.id, roleId: foreignRole.id, siteIds: null },
+    ]);
+
+    const now = new Date();
+    await database.insert(userRiskScores).values([
+      { orgId: env.organization.id, userId: visible.id, score: 10, factors: {}, trendDirection: 'stable', calculatedAt: now },
+      { orgId: env.organization.id, userId: hidden.id, score: 99, factors: {}, trendDirection: 'up', calculatedAt: now },
+      { orgId: env.organization.id, userId: nullSite.id, score: 98, factors: {}, trendDirection: 'up', calculatedAt: now },
+      { orgId: foreignOrg.id, userId: foreign.id, score: 100, factors: {}, trendDirection: 'up', calculatedAt: now },
+    ]);
+    await database.insert(userRiskEvents).values([
+      { orgId: env.organization.id, userId: visible.id, eventType: 'visible_signal', severity: 'low', scoreImpact: 1, description: 'visible', occurredAt: now },
+      { orgId: env.organization.id, userId: hidden.id, eventType: 'hidden_signal', severity: 'critical', scoreImpact: 50, description: 'hidden', occurredAt: now },
+      { orgId: env.organization.id, userId: nullSite.id, eventType: 'null_signal', severity: 'critical', scoreImpact: 50, description: 'null', occurredAt: now },
+    ]);
+    await database.insert(mlFeedbackEvents).values([
+      { orgId: env.organization.id, sourceType: 'user_risk', sourceId: visible.id, eventType: 'user_risk.true_positive', outcome: 'true_positive', metadata: {}, occurredAt: now },
+      { orgId: env.organization.id, sourceType: 'user_risk', sourceId: hidden.id, eventType: 'user_risk.false_positive', outcome: 'false_positive', metadata: {}, occurredAt: now },
+      { orgId: env.organization.id, sourceType: 'user_risk', sourceId: nullSite.id, eventType: 'user_risk.false_positive', outcome: 'false_positive', metadata: {}, occurredAt: now },
+    ]);
+
+    // Unrestricted remains org-wide, including a membership whose site_ids is NULL.
+    const unrestricted = await get(env.token, '/api/v1/user-risk/scores?limit=10');
+    expect(unrestricted.status).toBe(200);
+    expect(unrestricted.body.pagination.total).toBe(3);
+    expect(JSON.stringify(unrestricted.body)).not.toContain(foreign.id);
+
+    await setCallerSites(env.user.id, env.organization.id, [env.site.id]);
+
+    // Hidden high scores cannot consume LIMIT before the visible low score is selected.
+    const scores = await get(env.token, '/api/v1/user-risk/scores?limit=1');
+    expect(scores.status).toBe(200);
+    expect(scores.body.pagination.total).toBe(1);
+    expect(scores.body.data.map((row: any) => row.userId)).toEqual([visible.id]);
+    expect(JSON.stringify(scores.body)).not.toContain(hidden.id);
+    expect(JSON.stringify(scores.body)).not.toContain(nullSite.id);
+
+    const visibleDetail = await get(env.token, `/api/v1/user-risk/users/${visible.id}`);
+    expect(visibleDetail.status).toBe(200);
+    expect(visibleDetail.body.data.recentEvents.map((row: any) => row.eventType)).toEqual(['visible_signal']);
+    expect((await get(env.token, `/api/v1/user-risk/users/${hidden.id}`)).status).toBe(404);
+    expect((await get(env.token, `/api/v1/user-risk/users/${nullSite.id}`)).status).toBe(404);
+
+    const events = await get(env.token, '/api/v1/user-risk/events?limit=10');
+    expect(events.status).toBe(200);
+    expect(events.body.pagination.total).toBe(1);
+    expect(events.body.data.map((row: any) => row.userId)).toEqual([visible.id]);
+
+    const evaluation = await get(env.token, '/api/v1/user-risk/evaluation?days=30');
+    expect(evaluation.status).toBe(200);
+    expect(evaluation.body.data).toMatchObject({
+      totalLabels: 1,
+      truePositives: 1,
+      falsePositives: 0,
+      riskSignals: 1,
+      usersWithRiskSignals: 1,
+    });
+
+    // Current membership is authoritative: moving the target out removes all history.
+    await database
+      .update(organizationUsers)
+      .set({ siteIds: [hiddenSite.id] })
+      .where(and(eq(organizationUsers.userId, visible.id), eq(organizationUsers.orgId, env.organization.id)));
+    expect((await get(env.token, `/api/v1/user-risk/users/${visible.id}`)).status).toBe(404);
+    expect((await get(env.token, '/api/v1/user-risk/scores?limit=10')).body.pagination.total).toBe(0);
+
+    await setCallerSites(env.user.id, env.organization.id, []);
+    expect((await get(env.token, '/api/v1/user-risk/events?limit=10')).body.pagination.total).toBe(0);
+    expect((await get(env.token, '/api/v1/user-risk/evaluation?days=30')).body.data.riskSignals).toBe(0);
+  });
+
+  runDb('rechecks a concurrent membership move after waiting for the target row lock', async () => {
+    const env = await setupTestEnvironment({
+      scope: 'organization',
+      rolePermissions: [{ resource: 'users', action: 'read' }],
+    });
+    const hiddenSite = await createSite({ orgId: env.organization.id, name: 'Race destination' });
+    const target = await createUser({
+      partnerId: env.partner.id,
+      orgId: env.organization.id,
+      email: `risk-race-${crypto.randomUUID().slice(0, 8)}@example.test`,
+    });
+    const database = getTestDb();
+    const [membership] = await database.insert(organizationUsers).values({
+      orgId: env.organization.id,
+      userId: target.id,
+      roleId: env.role.id,
+      siteIds: [env.site.id],
+    }).returning({ id: organizationUsers.id });
+    await database.insert(userRiskScores).values({
+      orgId: env.organization.id,
+      userId: target.id,
+      score: 42,
+      factors: {},
+      trendDirection: 'stable',
+      calculatedAt: new Date(),
+    });
+    await setCallerSites(env.user.id, env.organization.id, [env.site.id]);
+
+    const lockHeld = deferred();
+    const release = deferred();
+    const holder = postgres(process.env.DATABASE_URL!, { max: 1, onnotice: () => {} });
+    let holderWork: Promise<unknown> | undefined;
+    try {
+      holderWork = holder.begin(async (tx) => {
+        await tx`SELECT id FROM organization_users WHERE id = ${membership!.id} FOR UPDATE`;
+        lockHeld.resolve();
+        await release.promise;
+        await tx`UPDATE organization_users SET site_ids = ARRAY[${hiddenSite.id}::uuid] WHERE id = ${membership!.id}`;
+      });
+      await lockHeld.promise;
+
+      const detailPromise = get(env.token, `/api/v1/user-risk/users/${target.id}`);
+      await waitForBlockedBackend();
+      release.resolve();
+      await holderWork;
+
+      const detail = await detailPromise;
+      expect(detail.status).toBe(404);
+      expect(JSON.stringify(detail.body)).not.toContain(target.email);
+    } finally {
+      release.resolve();
+      await holderWork?.catch(() => undefined);
+      await holder.end({ timeout: 1 });
+    }
+  });
+});

--- a/apps/api/src/routes/userRisk.test.ts
+++ b/apps/api/src/routes/userRisk.test.ts
@@ -452,6 +452,7 @@ describe('userRiskRoutes', () => {
   });
 
   it('POST /assign-training triggers assignment workflow', async () => {
+    vi.mocked(getUserRiskOrgMembership).mockResolvedValue(true);
     vi.mocked(assignSecurityTraining).mockResolvedValue({
       assignmentEventId: '00000000-0000-0000-0000-000000000020',
       moduleId: 'security-awareness-baseline',
@@ -475,5 +476,86 @@ describe('userRiskRoutes', () => {
       eventType: 'training.assigned',
       outcome: 'assigned'
     }));
+  });
+});
+
+describe('userRiskRoutes write-path site ceiling', () => {
+  const CEILING = ['00000000-0000-4000-8000-000000000050'];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(resolveOrgAccess).mockResolvedValue({ type: 'single', orgId: ORG_ID });
+  });
+
+  it('POST /users/:userId/training-completed carries the site ceiling into the membership check', async () => {
+    vi.mocked(getUserRiskOrgMembership).mockResolvedValue(true);
+    vi.mocked(emitUserRiskFeedback).mockResolvedValue(undefined);
+
+    const app = buildApp();
+    const res = await app.request(`/user-risk/users/${USER_ID}/training-completed`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({})
+    });
+
+    expect(res.status).toBe(200);
+    expect(getUserRiskOrgMembership).toHaveBeenCalledWith(USER_ID, ORG_ID, CEILING);
+  });
+
+  it('POST /users/:userId/feedback carries the site ceiling into the membership check', async () => {
+    vi.mocked(getUserRiskOrgMembership).mockResolvedValue(true);
+    vi.mocked(emitUserRiskFeedback).mockResolvedValue(undefined);
+
+    const app = buildApp();
+    const res = await app.request(`/user-risk/users/${USER_ID}/feedback`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ outcome: 'false_positive' })
+    });
+
+    expect(res.status).toBe(200);
+    expect(getUserRiskOrgMembership).toHaveBeenCalledWith(USER_ID, ORG_ID, CEILING);
+  });
+
+  it('POST /assign-training denies a target outside the site ceiling before any write', async () => {
+    vi.mocked(getUserRiskOrgMembership).mockResolvedValue(false);
+
+    const app = buildApp();
+    const res = await app.request('/user-risk/assign-training', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ userId: USER_ID })
+    });
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'User not found in this organization' });
+    expect(getUserRiskOrgMembership).toHaveBeenCalledWith(USER_ID, ORG_ID, CEILING);
+    expect(assignSecurityTraining).not.toHaveBeenCalled();
+    expect(emitUserRiskFeedback).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['training-completed', `/user-risk/users/${USER_ID}/training-completed`, {}],
+    ['feedback', `/user-risk/users/${USER_ID}/feedback`, { outcome: 'false_positive' }],
+    ['assign-training', '/user-risk/assign-training', { userId: USER_ID }]
+  ])('POST %s leaves the membership check unrestricted for a caller with no site ceiling', async (_label, path, body) => {
+    vi.mocked(getUserRiskOrgMembership).mockResolvedValue(true);
+    vi.mocked(emitUserRiskFeedback).mockResolvedValue(undefined);
+    vi.mocked(assignSecurityTraining).mockResolvedValue({
+      assignmentEventId: '00000000-0000-0000-0000-000000000020',
+      moduleId: 'security-awareness-baseline',
+      deduplicated: false,
+      eventPublished: true
+    });
+
+    const app = buildApp({ allowedSiteIds: undefined });
+    const res = await app.request(path, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body)
+    });
+
+    expect(res.status).toBeLessThan(300);
+    expect(getUserRiskOrgMembership).toHaveBeenCalledWith(USER_ID, ORG_ID, undefined);
   });
 });

--- a/apps/api/src/routes/userRisk.test.ts
+++ b/apps/api/src/routes/userRisk.test.ts
@@ -56,6 +56,8 @@ function buildApp(authOverrides?: Partial<{
   orgId: string | null;
   accessibleOrgIds: string[] | null;
   canAccessOrg: (orgId: string) => boolean;
+  allowedSiteIds: string[] | undefined;
+  canAccessSite: (siteId: string | null | undefined) => boolean;
 }>): Hono {
   const authSetter = async (c: any, next: any) => {
     c.set('auth', {
@@ -63,7 +65,11 @@ function buildApp(authOverrides?: Partial<{
       scope: authOverrides?.scope ?? 'organization',
       orgId: authOverrides?.orgId ?? ORG_ID,
       accessibleOrgIds: authOverrides?.accessibleOrgIds ?? [ORG_ID],
-      canAccessOrg: authOverrides?.canAccessOrg ?? ((id: string) => id === ORG_ID)
+      canAccessOrg: authOverrides?.canAccessOrg ?? ((id: string) => id === ORG_ID),
+      allowedSiteIds: authOverrides && 'allowedSiteIds' in authOverrides
+        ? authOverrides.allowedSiteIds
+        : ['00000000-0000-4000-8000-000000000050'],
+      canAccessSite: authOverrides?.canAccessSite ?? ((id: string | null | undefined) => id === '00000000-0000-4000-8000-000000000050')
     });
     await next();
   };
@@ -127,6 +133,16 @@ describe('userRiskRoutes', () => {
     expect(body.data).toHaveLength(1);
     expect(body.pagination.total).toBe(1);
     expect(body.summary.highRiskUsers).toBe(1);
+    expect(listUserRiskScores).toHaveBeenCalledWith(expect.objectContaining({
+      siteIds: ['00000000-0000-4000-8000-000000000050']
+    }));
+  });
+
+  it('GET /scores rejects an explicit site outside the authenticated ceiling before querying', async () => {
+    const app = buildApp();
+    const res = await app.request('/user-risk/scores?siteId=00000000-0000-4000-8000-000000000051');
+    expect(res.status).toBe(403);
+    expect(listUserRiskScores).not.toHaveBeenCalled();
   });
 
   it('GET /scores returns 403 for inaccessible org filter', async () => {
@@ -170,6 +186,39 @@ describe('userRiskRoutes', () => {
     const body = await res.json();
     expect(body.data.user.id).toBe(USER_ID);
     expect(body.data.latestScore.score).toBe(55);
+    expect(getUserRiskDetail).toHaveBeenCalledWith(
+      ORG_ID,
+      USER_ID,
+      ['00000000-0000-4000-8000-000000000050']
+    );
+  });
+
+  it('GET /users/:userId applies the site ceiling while resolving multiple organizations', async () => {
+    vi.mocked(resolveOrgAccess).mockResolvedValue({ type: 'multiple', orgIds: [ORG_ID, ORG_ID_2] });
+    vi.mocked(getUserRiskOrgMembership)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    vi.mocked(getUserRiskDetail).mockResolvedValue({
+      user: { id: USER_ID, name: 'Alice', email: 'alice@example.com', mfaEnabled: true, lastLoginAt: null },
+      latestScore: {
+        score: 55, factors: {}, trendDirection: 'stable', calculatedAt: '2026-02-26T00:00:00.000Z',
+        deltaFromPrevious: 0, severity: 'medium'
+      },
+      recentEvents: [], history: [],
+      policy: { orgId: ORG_ID_2, weights: {}, thresholds: {}, interventions: {}, updatedAt: '2026-02-26T00:00:00.000Z', updatedBy: null }
+    });
+    const siteIds = ['00000000-0000-4000-8000-000000000050'];
+    const app = buildApp({
+      scope: 'partner', orgId: null, accessibleOrgIds: [ORG_ID, ORG_ID_2],
+      canAccessOrg: () => true, allowedSiteIds: siteIds
+    });
+
+    const res = await app.request(`/user-risk/users/${USER_ID}`);
+
+    expect(res.status).toBe(200);
+    expect(getUserRiskOrgMembership).toHaveBeenNthCalledWith(1, USER_ID, ORG_ID, siteIds);
+    expect(getUserRiskOrgMembership).toHaveBeenNthCalledWith(2, USER_ID, ORG_ID_2, siteIds);
+    expect(getUserRiskDetail).toHaveBeenCalledWith(ORG_ID_2, USER_ID, siteIds);
   });
 
   it('GET /events returns event history', async () => {
@@ -198,6 +247,9 @@ describe('userRiskRoutes', () => {
     const body = await res.json();
     expect(body.data).toHaveLength(1);
     expect(body.pagination.total).toBe(1);
+    expect(listUserRiskEvents).toHaveBeenCalledWith(expect.objectContaining({
+      siteIds: ['00000000-0000-4000-8000-000000000050']
+    }));
   });
 
   it('GET /evaluation returns label quality metrics', async () => {
@@ -224,6 +276,7 @@ describe('userRiskRoutes', () => {
     expect(body.data.precision).toBe(0.75);
     expect(getUserRiskEvaluation).toHaveBeenCalledWith({
       orgIds: [ORG_ID],
+      siteIds: ['00000000-0000-4000-8000-000000000050'],
       days: 14
     });
   });

--- a/apps/api/src/routes/userRisk.test.ts
+++ b/apps/api/src/routes/userRisk.test.ts
@@ -5,6 +5,12 @@ vi.mock('../middleware/auth', () => ({
   authMiddleware: async (_c: unknown, next: () => Promise<void>) => await next(),
   requireScope: () => async (_c: unknown, next: () => Promise<void>) => await next(),
   requirePermission: () => async (_c: unknown, next: () => Promise<void>) => await next(),
+  requireMfa: () => async (c: any, next: () => Promise<void>) => {
+    if (c.req.header('x-deny-mfa')) {
+      return c.json({ error: 'MFA required', code: 'MFA_REQUIRED' }, 403);
+    }
+    await next();
+  },
   resolveOrgAccess: vi.fn()
 }));
 
@@ -73,6 +79,27 @@ describe('userRiskRoutes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(resolveOrgAccess).mockResolvedValue({ type: 'single', orgId: ORG_ID });
+  });
+
+  it.each([
+    ['POST', `/user-risk/users/${USER_ID}/training-completed`, { completedAt: 'not-a-date' }],
+    ['POST', `/user-risk/users/${USER_ID}/feedback`, { outcome: 'not-an-outcome' }],
+    ['PUT', '/user-risk/policy', { weights: 'not-an-object' }],
+    ['POST', '/user-risk/assign-training', { userId: 'not-a-uuid' }]
+  ])('%s %s requires MFA before validation or service effects', async (method, path, body) => {
+    const app = buildApp();
+    const res = await app.request(path, {
+      method,
+      headers: { 'content-type': 'application/json', 'x-deny-mfa': 'true' },
+      body: JSON.stringify(body)
+    });
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'MFA required', code: 'MFA_REQUIRED' });
+    expect(getUserRiskOrgMembership).not.toHaveBeenCalled();
+    expect(emitUserRiskFeedback).not.toHaveBeenCalled();
+    expect(updateUserRiskPolicy).not.toHaveBeenCalled();
+    expect(assignSecurityTraining).not.toHaveBeenCalled();
   });
 
   it('GET /scores returns ranked scores with pagination', async () => {

--- a/apps/api/src/routes/userRisk.ts
+++ b/apps/api/src/routes/userRisk.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 import { z } from 'zod';
 import { zValidator } from '../lib/validation';
 
-import { authMiddleware, requirePermission, requireScope, resolveOrgAccess } from '../middleware/auth';
+import { authMiddleware, requireMfa, requirePermission, requireScope, resolveOrgAccess } from '../middleware/auth';
 import { writeRouteAudit } from '../services/auditEvents';
 import {
   assignSecurityTraining,
@@ -316,6 +316,7 @@ userRiskRoutes.get(
 userRiskRoutes.post(
   '/users/:userId/training-completed',
   requirePermission('users', 'write'),
+  requireMfa(),
   zValidator('param', detailParamSchema),
   zValidator('json', completeTrainingSchema),
   async (c) => {
@@ -370,6 +371,7 @@ userRiskRoutes.post(
 userRiskRoutes.post(
   '/users/:userId/feedback',
   requirePermission('users', 'write'),
+  requireMfa(),
   zValidator('param', detailParamSchema),
   zValidator('json', feedbackPayloadSchema),
   async (c) => {
@@ -426,6 +428,7 @@ userRiskRoutes.post(
 userRiskRoutes.put(
   '/policy',
   requirePermission('users', 'write'),
+  requireMfa(),
   zValidator('json', policyPayloadSchema),
   async (c) => {
     const auth = c.get('auth');
@@ -474,6 +477,7 @@ userRiskRoutes.get('/policy', requirePermission('users', 'read'), zValidator('qu
 userRiskRoutes.post(
   '/assign-training',
   requirePermission('users', 'write'),
+  requireMfa(),
   zValidator('json', assignTrainingSchema),
   async (c) => {
     const auth = c.get('auth');

--- a/apps/api/src/routes/userRisk.ts
+++ b/apps/api/src/routes/userRisk.ts
@@ -141,6 +141,13 @@ userRiskRoutes.get(
     if (query.orgId && !auth.canAccessOrg(query.orgId)) {
       return c.json({ error: 'Access denied to this organization' }, 403);
     }
+    if (
+      query.siteId
+      && auth.allowedSiteIds !== undefined
+      && !auth.allowedSiteIds.includes(query.siteId)
+    ) {
+      return c.json({ error: 'Access denied to this site' }, 403);
+    }
 
     const orgIds = query.orgId
       ? [query.orgId]
@@ -156,6 +163,7 @@ userRiskRoutes.get(
     const result = await listUserRiskScores({
       orgIds,
       siteId: query.siteId,
+      siteIds: auth.allowedSiteIds,
       minScore: query.minScore,
       maxScore: query.maxScore,
       trendDirection: query.trendDirection,
@@ -202,7 +210,7 @@ userRiskRoutes.get(
       const memberships = await Promise.all(
         orgResolution.orgIds.map(async (orgId) => ({
           orgId,
-          member: await getUserRiskOrgMembership(userId, orgId)
+          member: await getUserRiskOrgMembership(userId, orgId, auth.allowedSiteIds)
         }))
       );
 
@@ -214,7 +222,7 @@ userRiskRoutes.get(
         return c.json({ error: 'orgId is required for users mapped to multiple organizations' }, 400);
       }
 
-      const detail = await getUserRiskDetail(matches[0]!, userId);
+      const detail = await getUserRiskDetail(matches[0]!, userId, auth.allowedSiteIds);
       if (!detail) return c.json({ error: 'No user risk data available for this user' }, 404);
       return c.json({ data: detail });
     }
@@ -227,7 +235,7 @@ userRiskRoutes.get(
       return c.json({ error: 'Organization context required' }, 400);
     }
 
-    const detail = await getUserRiskDetail(resolvedOrgId, userId);
+    const detail = await getUserRiskDetail(resolvedOrgId, userId, auth.allowedSiteIds);
     if (!detail) {
       return c.json({ error: 'No user risk data available for this user' }, 404);
     }
@@ -266,6 +274,7 @@ userRiskRoutes.get(
       severity: query.severity,
       from: query.from ? new Date(query.from) : undefined,
       to: query.to ? new Date(query.to) : undefined,
+      siteIds: auth.allowedSiteIds,
       limit: query.limit,
       offset
     });
@@ -306,6 +315,7 @@ userRiskRoutes.get(
 
     const evaluation = await getUserRiskEvaluation({
       orgIds,
+      siteIds: auth.allowedSiteIds,
       days: query.days
     });
 

--- a/apps/api/src/routes/userRisk.ts
+++ b/apps/api/src/routes/userRisk.ts
@@ -339,7 +339,7 @@ userRiskRoutes.post(
       return c.json({ error: resolved.error ?? 'Organization resolution failed' }, resolved.status ?? 400);
     }
 
-    const isMember = await getUserRiskOrgMembership(userId, resolved.orgId);
+    const isMember = await getUserRiskOrgMembership(userId, resolved.orgId, auth.allowedSiteIds);
     if (!isMember) {
       return c.json({ error: 'User not found in this organization' }, 404);
     }
@@ -394,7 +394,7 @@ userRiskRoutes.post(
       return c.json({ error: resolved.error ?? 'Organization resolution failed' }, resolved.status ?? 400);
     }
 
-    const isMember = await getUserRiskOrgMembership(userId, resolved.orgId);
+    const isMember = await getUserRiskOrgMembership(userId, resolved.orgId, auth.allowedSiteIds);
     if (!isMember) {
       return c.json({ error: 'User not found in this organization' }, 404);
     }
@@ -496,6 +496,14 @@ userRiskRoutes.post(
     const resolved = resolveWriteOrgId(auth, payload.orgId);
     if (!resolved.orgId) {
       return c.json({ error: resolved.error ?? 'Organization resolution failed' }, resolved.status ?? 400);
+    }
+
+    // Same gate as the two feedback writes: without it a site-restricted tech
+    // could assign training to (and emit a feedback row for) a user their read
+    // projections 404 on, which is an enumeration oracle on the site axis.
+    const isMember = await getUserRiskOrgMembership(payload.userId, resolved.orgId, auth.allowedSiteIds);
+    if (!isMember) {
+      return c.json({ error: 'User not found in this organization' }, 404);
     }
 
     const assignment = await assignSecurityTraining({

--- a/apps/api/src/services/aiToolsReliability.test.ts
+++ b/apps/api/src/services/aiToolsReliability.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mockListReliabilityDevices = vi.fn();
 const mockListUserRiskScores = vi.fn();
 const mockGetUserRiskDetail = vi.fn();
+const mockAssignSecurityTraining = vi.fn();
+const mockGetUserRiskOrgMembership = vi.fn();
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
@@ -86,8 +88,9 @@ vi.mock('./reliabilityScoring', () => ({
 }));
 
 vi.mock('./userRiskScoring', () => ({
-  assignSecurityTraining: vi.fn(),
+  assignSecurityTraining: (...args: unknown[]) => mockAssignSecurityTraining(...args),
   getUserRiskDetail: (...args: unknown[]) => mockGetUserRiskDetail(...args),
+  getUserRiskOrgMembership: (...args: unknown[]) => mockGetUserRiskOrgMembership(...args),
   listUserRiskScores: (...args: unknown[]) => mockListUserRiskScores(...args),
 }));
 
@@ -256,5 +259,63 @@ describe('aiTools get_user_risk_detail site scoping', () => {
     await executeTool('get_user_risk_detail', { userId: 'target-1' }, auth);
 
     expect(mockGetUserRiskDetail).toHaveBeenCalledWith('org-1', 'target-1', ['site-1']);
+  });
+});
+
+describe('aiTools assign_security_training authorization', () => {
+  const siteRestrictedAuth = {
+    user: { id: 'user-1' },
+    orgId: 'org-1',
+    scope: 'organization',
+    accessibleOrgIds: ['org-1'],
+    allowedSiteIds: ['site-1'],
+    canAccessOrg: () => true,
+    canAccessSite: (siteId: string | null | undefined) => siteId === 'site-1',
+    orgCondition: () => undefined,
+    token: { mfa: true },
+  } as any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUserRiskOrgMembership.mockResolvedValue(true);
+    mockAssignSecurityTraining.mockResolvedValue({
+      assignmentEventId: 'assign-1',
+      moduleId: 'security-awareness-baseline',
+      deduplicated: false,
+      eventPublished: true,
+    });
+  });
+
+  it('denies a caller whose session has not satisfied MFA, before any write', async () => {
+    const result = await executeTool(
+      'assign_security_training',
+      { userId: 'target-1' },
+      { ...siteRestrictedAuth, token: { mfa: false } },
+    );
+
+    expect(JSON.parse(result)).toEqual({ error: 'MFA required' });
+    expect(mockGetUserRiskOrgMembership).not.toHaveBeenCalled();
+    expect(mockAssignSecurityTraining).not.toHaveBeenCalled();
+  });
+
+  it('denies a target outside the authenticated site ceiling, before any write', async () => {
+    mockGetUserRiskOrgMembership.mockResolvedValue(false);
+
+    const result = await executeTool('assign_security_training', { userId: 'target-1' }, siteRestrictedAuth);
+
+    expect(JSON.parse(result)).toEqual({ error: 'User not found in this organization' });
+    expect(mockGetUserRiskOrgMembership).toHaveBeenCalledWith('target-1', 'org-1', ['site-1']);
+    expect(mockAssignSecurityTraining).not.toHaveBeenCalled();
+  });
+
+  it('carries the site ceiling into the membership check for a visible target', async () => {
+    const result = await executeTool('assign_security_training', { userId: 'target-1' }, siteRestrictedAuth);
+
+    expect(JSON.parse(result)).toMatchObject({ success: true, assignmentEventId: 'assign-1' });
+    expect(mockGetUserRiskOrgMembership).toHaveBeenCalledWith('target-1', 'org-1', ['site-1']);
+    expect(mockAssignSecurityTraining).toHaveBeenCalledWith(expect.objectContaining({
+      orgId: 'org-1',
+      userId: 'target-1',
+    }));
   });
 });

--- a/apps/api/src/services/aiToolsReliability.test.ts
+++ b/apps/api/src/services/aiToolsReliability.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockListReliabilityDevices = vi.fn();
 const mockListUserRiskScores = vi.fn();
+const mockGetUserRiskDetail = vi.fn();
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
@@ -86,7 +87,7 @@ vi.mock('./reliabilityScoring', () => ({
 
 vi.mock('./userRiskScoring', () => ({
   assignSecurityTraining: vi.fn(),
-  getUserRiskDetail: vi.fn(),
+  getUserRiskDetail: (...args: unknown[]) => mockGetUserRiskDetail(...args),
   listUserRiskScores: (...args: unknown[]) => mockListUserRiskScores(...args),
 }));
 
@@ -235,5 +236,25 @@ describe('aiTools get_user_risk_scores site scoping', () => {
 
     expect(parsed).toEqual({ error: 'Access denied to this site' });
     expect(mockListUserRiskScores).not.toHaveBeenCalled();
+  });
+});
+
+describe('aiTools get_user_risk_detail site scoping', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUserRiskDetail.mockResolvedValue(null);
+  });
+
+  it('passes the authenticated site ceiling to the detail service', async () => {
+    const auth = {
+      user: { id: 'user-1' }, orgId: 'org-1', scope: 'organization',
+      accessibleOrgIds: ['org-1'], allowedSiteIds: ['site-1'],
+      canAccessOrg: (id: string) => id === 'org-1',
+      canAccessSite: (id: string) => id === 'site-1', orgCondition: () => undefined,
+    } as any;
+
+    await executeTool('get_user_risk_detail', { userId: 'target-1' }, auth);
+
+    expect(mockGetUserRiskDetail).toHaveBeenCalledWith('org-1', 'target-1', ['site-1']);
   });
 });

--- a/apps/api/src/services/aiToolsUserRisk.ts
+++ b/apps/api/src/services/aiToolsUserRisk.ts
@@ -8,10 +8,15 @@
  * - assign_security_training (Tier 2): Assign security awareness training
  */
 
-import type { AuthContext } from '../middleware/auth';
+import { hasSatisfiedMfa, type AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 import { listReliabilityDevices } from './reliabilityScoring';
-import { assignSecurityTraining, getUserRiskDetail, listUserRiskScores } from './userRiskScoring';
+import {
+  assignSecurityTraining,
+  getUserRiskDetail,
+  getUserRiskOrgMembership,
+  listUserRiskScores
+} from './userRiskScoring';
 import { sanitizeThrownToolError } from './aiToolErrors';
 
 type AiToolTier = 1 | 2 | 3 | 4;
@@ -277,6 +282,14 @@ export function registerUserRiskTools(aiTools: Map<string, AiTool>): void {
       }
     },
     handler: async (input, auth) => {
+      // This tool performs the same mutation the HTTP route gates behind
+      // requireMfa(); Tier 2 means it auto-executes, so the MFA and site-ceiling
+      // proofs have to be re-established here or the AI/MCP path is a bypass.
+      // Checked before input validation, matching the HTTP route's ordering.
+      if (!hasSatisfiedMfa(auth)) {
+        return JSON.stringify({ error: 'MFA required' });
+      }
+
       if (typeof input.userId !== 'string' || !input.userId) {
         return JSON.stringify({ error: 'userId is required' });
       }
@@ -287,6 +300,11 @@ export function registerUserRiskTools(aiTools: Map<string, AiTool>): void {
       );
       if (resolved.error || !resolved.orgId) {
         return JSON.stringify({ error: resolved.error ?? 'orgId is required for this operation' });
+      }
+
+      const isMember = await getUserRiskOrgMembership(input.userId, resolved.orgId, auth.allowedSiteIds);
+      if (!isMember) {
+        return JSON.stringify({ error: 'User not found in this organization' });
       }
 
       try {

--- a/apps/api/src/services/aiToolsUserRisk.ts
+++ b/apps/api/src/services/aiToolsUserRisk.ts
@@ -247,7 +247,7 @@ export function registerUserRiskTools(aiTools: Map<string, AiTool>): void {
         return JSON.stringify({ error: resolved.error ?? 'orgId is required for this operation' });
       }
 
-      const detail = await getUserRiskDetail(resolved.orgId, input.userId);
+      const detail = await getUserRiskDetail(resolved.orgId, input.userId, auth.allowedSiteIds);
       if (!detail) {
         return JSON.stringify({ message: 'No user risk data available for this user' });
       }

--- a/apps/api/src/services/userRiskScoring.test.ts
+++ b/apps/api/src/services/userRiskScoring.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { sql, type SQL } from 'drizzle-orm';
 
 const dbMocks = vi.hoisted(() => ({
   selectMock: vi.fn(),
@@ -39,12 +41,56 @@ import {
   userRiskScoringInternals
 } from './userRiskScoring';
 
+function mockVisibleRiskMembershipWithNoHistory(): void {
+  // membership (visible) -> history (empty) -> events (empty) -> policy lookup
+  dbMocks.selectMock.mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      innerJoin: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([{
+            userId: '00000000-0000-4000-8000-000000000010',
+            name: 'Target',
+            email: 'target@example.test',
+            mfaEnabled: false,
+            lastLoginAt: null
+          }])
+        })
+      })
+    })
+  });
+  const emptyOrdered = () => ({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        orderBy: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([])
+        })
+      })
+    })
+  });
+  dbMocks.selectMock.mockReturnValueOnce(emptyOrdered());
+  dbMocks.selectMock.mockReturnValueOnce(emptyOrdered());
+  // Anything further would be getOrCreateUserRiskPolicy: an empty policy read
+  // followed by the default-policy INSERT.
+  dbMocks.selectMock.mockReturnValue({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue([])
+      })
+    })
+  });
+  dbMocks.insertMock.mockReturnValue({
+    values: vi.fn().mockReturnValue({
+      onConflictDoNothing: vi.fn().mockResolvedValue(undefined)
+    })
+  });
+}
+
 function mockHiddenRiskMembership(): void {
   dbMocks.selectMock.mockReturnValueOnce({
     from: vi.fn().mockReturnValue({
       innerJoin: vi.fn().mockReturnValue({
         where: vi.fn().mockReturnValue({
-          for: vi.fn().mockResolvedValue([])
+          limit: vi.fn().mockResolvedValue([])
         })
       })
     })
@@ -126,9 +172,12 @@ describe('userRiskScoring helpers', () => {
 });
 
 describe('getUserRiskDetail visibility short-circuit', () => {
-  it('performs no score, event, or policy subsidiary read for a hidden membership', async () => {
+  it('returns no detail and creates no policy row for a hidden membership', async () => {
     mockHiddenRiskMembership();
 
+    // Behavioural, not chain-shaped: a target the caller's site ceiling hides
+    // must yield null, must not trigger the score/event subsidiary reads, and
+    // must not lazily insert the org default risk policy.
     await expect(getUserRiskDetail(
       '00000000-0000-4000-8000-000000000001',
       '00000000-0000-4000-8000-000000000010',
@@ -137,6 +186,66 @@ describe('getUserRiskDetail visibility short-circuit', () => {
 
     expect(dbMocks.selectMock).toHaveBeenCalledTimes(1);
     expect(dbMocks.insertMock).not.toHaveBeenCalled();
+  });
+
+  it('creates no default policy row when a visible target has no score history', async () => {
+    mockVisibleRiskMembershipWithNoHistory();
+
+    await expect(getUserRiskDetail(
+      '00000000-0000-4000-8000-000000000001',
+      '00000000-0000-4000-8000-000000000010',
+      ['00000000-0000-4000-8000-000000000050'],
+    )).resolves.toBeNull();
+
+    // The lazy getOrCreateUserRiskPolicy write must stay behind the
+    // history-length check: a 404 detail must not mutate org state.
+    expect(dbMocks.insertMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('user-risk site visibility predicates', () => {
+  const dialect = new PgDialect();
+  const compile = (fragment: SQL): string => dialect.sqlToQuery(fragment).sql;
+  const ORG_COL = sql`"user_risk_events"."org_id"`;
+  const USER_COL = sql`"user_risk_events"."user_id"`;
+
+  it('userRiskSiteCeiling adds no membership subquery for an unrestricted caller', () => {
+    const compiled = compile(
+      userRiskScoringInternals.userRiskSiteCeiling(ORG_COL, USER_COL, undefined)
+    );
+
+    expect(compiled.trim()).toBe('true');
+    expect(compiled).not.toContain('organization_users');
+  });
+
+  it('userRiskSiteCeiling fails closed for a defined-empty ceiling', () => {
+    const compiled = compile(
+      userRiskScoringInternals.userRiskSiteCeiling(ORG_COL, USER_COL, [])
+    );
+
+    expect(compiled.trim()).toBe('false');
+  });
+
+  it('userRiskSiteCeiling requires an overlapping current membership for a defined ceiling', () => {
+    const compiled = compile(
+      userRiskScoringInternals.userRiskSiteCeiling(ORG_COL, USER_COL, ['site-a'])
+    );
+
+    expect(compiled).toContain('exists');
+    expect(compiled).toContain('"organization_users"');
+    expect(compiled).toContain('&&');
+  });
+
+  it('userRiskMembershipVisible still requires a current membership when unrestricted', () => {
+    // Scores/detail/membership readers previously inner-joined organization_users,
+    // so their unrestricted behaviour must keep requiring a current membership.
+    const compiled = compile(
+      userRiskScoringInternals.userRiskMembershipVisible(ORG_COL, USER_COL, undefined)
+    );
+
+    expect(compiled).toContain('exists');
+    expect(compiled).toContain('"organization_users"');
+    expect(compiled).not.toContain('&&');
   });
 });
 

--- a/apps/api/src/services/userRiskScoring.test.ts
+++ b/apps/api/src/services/userRiskScoring.test.ts
@@ -31,12 +31,25 @@ import {
   classifyUserRiskSeverity,
   computeUserRiskScoreFromFactors,
   deriveUserRiskTrendDirection,
+  getUserRiskDetail,
   normalizeUserRiskInterventions,
   normalizeUserRiskThresholds,
   normalizeUserRiskWeights,
   publishUserRiskScoreEvents,
   userRiskScoringInternals
 } from './userRiskScoring';
+
+function mockHiddenRiskMembership(): void {
+  dbMocks.selectMock.mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      innerJoin: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          for: vi.fn().mockResolvedValue([])
+        })
+      })
+    })
+  });
+}
 
 function mockRecentTrainingAssignments(rows: Array<{ id: string }>) {
   dbMocks.selectMock.mockReturnValueOnce({
@@ -109,6 +122,21 @@ describe('userRiskScoring helpers', () => {
     expect(deriveUserRiskTrendDirection(50, 55)).toBe('up');
     expect(deriveUserRiskTrendDirection(50, 45)).toBe('down');
     expect(deriveUserRiskTrendDirection(50, 52)).toBe('stable');
+  });
+});
+
+describe('getUserRiskDetail visibility short-circuit', () => {
+  it('performs no score, event, or policy subsidiary read for a hidden membership', async () => {
+    mockHiddenRiskMembership();
+
+    await expect(getUserRiskDetail(
+      '00000000-0000-4000-8000-000000000001',
+      '00000000-0000-4000-8000-000000000010',
+      ['00000000-0000-4000-8000-000000000050'],
+    )).resolves.toBeNull();
+
+    expect(dbMocks.selectMock).toHaveBeenCalledTimes(1);
+    expect(dbMocks.insertMock).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/services/userRiskScoring.ts
+++ b/apps/api/src/services/userRiskScoring.ts
@@ -9,7 +9,8 @@ import {
   lte,
   or,
   sql,
-  type SQL
+  type SQL,
+  type SQLWrapper
 } from 'drizzle-orm';
 
 import { db } from '../db';
@@ -284,6 +285,7 @@ export type UserRiskEventFilter = {
   severity?: 'low' | 'medium' | 'high' | 'critical';
   from?: Date;
   to?: Date;
+  siteIds?: string[];
   limit?: number;
   offset?: number;
 };
@@ -292,7 +294,40 @@ export type UserRiskEvaluationFilter = {
   orgIds?: string[];
   orgId?: string;
   days?: number;
+  siteIds?: string[];
 };
+
+/**
+ * Current membership-site visibility for user-risk rows. Site scope is an
+ * application-layer axis: org RLS cannot express it. The EXISTS form avoids
+ * multiplying rows when historical data contains duplicate org memberships.
+ * Undefined is unrestricted (but still requires current membership), [] is
+ * denied, and a non-empty list uses the canonical any-overlap rule. NULL target
+ * site_ids therefore fails closed for every restricted caller.
+ */
+function userRiskMembershipVisible(
+  orgIdColumn: SQLWrapper,
+  userIdColumn: SQLWrapper,
+  siteIds?: string[],
+  requestedSiteId?: string,
+): SQL {
+  if (siteIds !== undefined && siteIds.length === 0) return sql`false`;
+  const conditions: SQL[] = [
+    sql`"risk_site_membership"."org_id" = ${orgIdColumn}`,
+    sql`"risk_site_membership"."user_id"::text = (${userIdColumn})::text`,
+  ];
+  if (requestedSiteId) {
+    conditions.push(sql`"risk_site_membership"."site_ids" @> ARRAY[${requestedSiteId}::uuid]`);
+  }
+  if (siteIds !== undefined) {
+    const allowed = sql.join(siteIds.map((siteId) => sql`${siteId}::uuid`), sql`, `);
+    conditions.push(sql`"risk_site_membership"."site_ids" && ARRAY[${allowed}]::uuid[]`);
+  }
+  return sql`exists (
+    select 1 from "organization_users" as "risk_site_membership"
+    where ${and(...conditions)}
+  )`;
+}
 
 export type UserRiskEvaluation = {
   windowDays: number;
@@ -954,7 +989,12 @@ export async function listUserRiskScores(filter: UserRiskScoreListFilter): Promi
     .groupBy(userRiskScores.orgId, userRiskScores.userId)
     .as('latest_user_risk_scores');
 
-  const conditions: SQL[] = [];
+  const conditions: SQL[] = [userRiskMembershipVisible(
+    userRiskScores.orgId,
+    userRiskScores.userId,
+    filter.siteIds,
+    filter.siteId,
+  )];
   if (filter.minScore !== undefined) conditions.push(gte(userRiskScores.score, clampScore(filter.minScore)));
   if (filter.maxScore !== undefined) conditions.push(lte(userRiskScores.score, clampScore(filter.maxScore)));
   if (filter.trendDirection) conditions.push(eq(userRiskScores.trendDirection, filter.trendDirection));
@@ -967,17 +1007,6 @@ export async function listUserRiskScores(filter: UserRiskScoreListFilter): Promi
       )!
     );
   }
-  if (filter.siteId) {
-    conditions.push(sql`${organizationUsers.siteIds} @> ARRAY[${filter.siteId}]::uuid[]`);
-  } else if (filter.siteIds) {
-    if (filter.siteIds.length === 0) {
-      conditions.push(sql`false`);
-    } else {
-      const allowedSiteIds = sql.join(filter.siteIds.map((siteId) => sql`${siteId}::uuid`), sql`, `);
-      conditions.push(sql`${organizationUsers.siteIds} && ARRAY[${allowedSiteIds}]`);
-    }
-  }
-
   const whereClause = and(...conditions);
   const limit = Math.min(Math.max(1, filter.limit ?? 25), 200);
   const offset = Math.max(0, filter.offset ?? 0);
@@ -992,13 +1021,6 @@ export async function listUserRiskScores(filter: UserRiskScoreListFilter): Promi
         eq(userRiskScores.calculatedAt, latestByUser.calculatedAt)
       ))
       .innerJoin(users, eq(userRiskScores.userId, users.id))
-      .innerJoin(
-        organizationUsers,
-        and(
-          eq(organizationUsers.orgId, userRiskScores.orgId),
-          eq(organizationUsers.userId, users.id)
-        )
-      )
       .where(whereClause)
       .then((result) => result[0]?.count ?? 0),
     db
@@ -1019,13 +1041,6 @@ export async function listUserRiskScores(filter: UserRiskScoreListFilter): Promi
         eq(userRiskScores.calculatedAt, latestByUser.calculatedAt)
       ))
       .innerJoin(users, eq(userRiskScores.userId, users.id))
-      .innerJoin(
-        organizationUsers,
-        and(
-          eq(organizationUsers.orgId, userRiskScores.orgId),
-          eq(organizationUsers.userId, users.id)
-        )
-      )
       .where(whereClause)
       .orderBy(desc(userRiskScores.score), desc(userRiskScores.calculatedAt), desc(userRiskScores.id))
       .limit(limit)
@@ -1047,7 +1062,7 @@ export async function listUserRiskScores(filter: UserRiskScoreListFilter): Promi
   };
 }
 
-export async function getUserRiskDetail(orgId: string, userId: string): Promise<{
+export async function getUserRiskDetail(orgId: string, userId: string, siteIds?: string[]): Promise<{
   user: { id: string; name: string; email: string; mfaEnabled: boolean; lastLoginAt: string | null };
   latestScore: {
     score: number;
@@ -1073,7 +1088,7 @@ export async function getUserRiskDetail(orgId: string, userId: string): Promise<
   }>;
   policy: UserRiskPolicy;
 } | null> {
-  const [membership] = await db
+  const memberships = await db
     .select({
       userId: users.id,
       name: users.name,
@@ -1086,14 +1101,17 @@ export async function getUserRiskDetail(orgId: string, userId: string): Promise<
     .where(
       and(
         eq(organizationUsers.orgId, orgId),
-        eq(organizationUsers.userId, userId)
+        eq(organizationUsers.userId, userId),
+        userRiskMembershipVisible(organizationUsers.orgId, organizationUsers.userId, siteIds)
       )
     )
-    .limit(1);
+    .for('share');
+
+  const membership = memberships[0];
 
   if (!membership) return null;
 
-  const [history, events, policy] = await Promise.all([
+  const [history, events] = await Promise.all([
     db
       .select({
         score: userRiskScores.score,
@@ -1105,7 +1123,8 @@ export async function getUserRiskDetail(orgId: string, userId: string): Promise<
       .where(
         and(
           eq(userRiskScores.orgId, orgId),
-          eq(userRiskScores.userId, userId)
+          eq(userRiskScores.userId, userId),
+          userRiskMembershipVisible(userRiskScores.orgId, userRiskScores.userId, siteIds)
         )
       )
       .orderBy(desc(userRiskScores.calculatedAt))
@@ -1124,15 +1143,16 @@ export async function getUserRiskDetail(orgId: string, userId: string): Promise<
       .where(
         and(
           eq(userRiskEvents.orgId, orgId),
-          eq(userRiskEvents.userId, userId)
+          eq(userRiskEvents.userId, userId),
+          userRiskMembershipVisible(userRiskEvents.orgId, userRiskEvents.userId, siteIds)
         )
       )
       .orderBy(desc(userRiskEvents.occurredAt))
-      .limit(100),
-    getOrCreateUserRiskPolicy(orgId)
+      .limit(100)
   ]);
 
   if (history.length === 0) return null;
+  const policy = await getOrCreateUserRiskPolicy(orgId);
 
   const latest = history[0]!;
   const previous = history[1] ?? null;
@@ -1199,6 +1219,11 @@ export async function listUserRiskEvents(filter: UserRiskEventFilter): Promise<{
   if (filter.severity) conditions.push(eq(userRiskEvents.severity, filter.severity));
   if (filter.from) conditions.push(gte(userRiskEvents.occurredAt, filter.from));
   if (filter.to) conditions.push(lte(userRiskEvents.occurredAt, filter.to));
+  conditions.push(userRiskMembershipVisible(
+    userRiskEvents.orgId,
+    userRiskEvents.userId,
+    filter.siteIds,
+  ));
 
   const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
   const limit = Math.min(Math.max(1, filter.limit ?? 50), 500);
@@ -1274,6 +1299,16 @@ export async function getUserRiskEvaluation(filter: UserRiskEvaluationFilter): P
     feedbackConditions.push(inArray(mlFeedbackEvents.orgId, filter.orgIds));
     riskEventConditions.push(inArray(userRiskEvents.orgId, filter.orgIds));
   }
+  feedbackConditions.push(userRiskMembershipVisible(
+    mlFeedbackEvents.orgId,
+    sql`${mlFeedbackEvents.sourceId}`,
+    filter.siteIds,
+  ));
+  riskEventConditions.push(userRiskMembershipVisible(
+    userRiskEvents.orgId,
+    userRiskEvents.userId,
+    filter.siteIds,
+  ));
 
   const [feedbackRows, signalRows] = await Promise.all([
     db
@@ -1560,14 +1595,15 @@ export async function appendUserRiskSignalEvent(input: {
   return row?.id ?? '';
 }
 
-export async function getUserRiskOrgMembership(userId: string, orgId: string): Promise<boolean> {
+export async function getUserRiskOrgMembership(userId: string, orgId: string, siteIds?: string[]): Promise<boolean> {
   const [membership] = await db
     .select({ id: organizationUsers.id })
     .from(organizationUsers)
     .where(
       and(
         eq(organizationUsers.userId, userId),
-        eq(organizationUsers.orgId, orgId)
+        eq(organizationUsers.orgId, orgId),
+        userRiskMembershipVisible(organizationUsers.orgId, organizationUsers.userId, siteIds)
       )
     )
     .limit(1);

--- a/apps/api/src/services/userRiskScoring.ts
+++ b/apps/api/src/services/userRiskScoring.ts
@@ -329,6 +329,30 @@ function userRiskMembershipVisible(
   )`;
 }
 
+/**
+ * Site-ceiling predicate for readers whose base table is NOT already constrained
+ * to a current `organization_users` row — the user-risk event log and the ML
+ * feedback ledger. An unrestricted caller (`siteIds === undefined`) gets `true`:
+ * these projections are org-scoped history, so requiring a *current* membership
+ * would silently drop events of departed members from an unrestricted reader's
+ * history and from the evaluation denominators, and would add a correlated
+ * subquery per row for no authorization gain. A defined ceiling (including the
+ * empty one) still gets the full membership + overlap proof.
+ *
+ * Readers that already select FROM / INNER JOIN `organization_users`
+ * (`listUserRiskScores`, `getUserRiskDetail`, `getUserRiskOrgMembership`) keep
+ * calling {@link userRiskMembershipVisible} directly — main required a current
+ * membership there before this change and must keep doing so.
+ */
+function userRiskSiteCeiling(
+  orgIdColumn: SQLWrapper,
+  userIdColumn: SQLWrapper,
+  siteIds?: string[],
+): SQL {
+  if (siteIds === undefined) return sql`true`;
+  return userRiskMembershipVisible(orgIdColumn, userIdColumn, siteIds);
+}
+
 export type UserRiskEvaluation = {
   windowDays: number;
   totalLabels: number;
@@ -1088,7 +1112,13 @@ export async function getUserRiskDetail(orgId: string, userId: string, siteIds?:
   }>;
   policy: UserRiskPolicy;
 } | null> {
-  const memberships = await db
+  // No row lock here on purpose: requests run inside one
+  // `withDbAccessContext` transaction, so a FOR SHARE would pin these `users`
+  // and `organization_users` rows for the whole request — blocking concurrent
+  // membership writes on hot rows and being blocked by org erasure or bulk site
+  // moves. Every subsidiary read below re-evaluates the same visibility
+  // predicate under its own snapshot, so the ceiling still holds.
+  const [membership] = await db
     .select({
       userId: users.id,
       name: users.name,
@@ -1105,9 +1135,7 @@ export async function getUserRiskDetail(orgId: string, userId: string, siteIds?:
         userRiskMembershipVisible(organizationUsers.orgId, organizationUsers.userId, siteIds)
       )
     )
-    .for('share');
-
-  const membership = memberships[0];
+    .limit(1);
 
   if (!membership) return null;
 
@@ -1219,7 +1247,7 @@ export async function listUserRiskEvents(filter: UserRiskEventFilter): Promise<{
   if (filter.severity) conditions.push(eq(userRiskEvents.severity, filter.severity));
   if (filter.from) conditions.push(gte(userRiskEvents.occurredAt, filter.from));
   if (filter.to) conditions.push(lte(userRiskEvents.occurredAt, filter.to));
-  conditions.push(userRiskMembershipVisible(
+  conditions.push(userRiskSiteCeiling(
     userRiskEvents.orgId,
     userRiskEvents.userId,
     filter.siteIds,
@@ -1299,12 +1327,12 @@ export async function getUserRiskEvaluation(filter: UserRiskEvaluationFilter): P
     feedbackConditions.push(inArray(mlFeedbackEvents.orgId, filter.orgIds));
     riskEventConditions.push(inArray(userRiskEvents.orgId, filter.orgIds));
   }
-  feedbackConditions.push(userRiskMembershipVisible(
+  feedbackConditions.push(userRiskSiteCeiling(
     mlFeedbackEvents.orgId,
     sql`${mlFeedbackEvents.sourceId}`,
     filter.siteIds,
   ));
-  riskEventConditions.push(userRiskMembershipVisible(
+  riskEventConditions.push(userRiskSiteCeiling(
     userRiskEvents.orgId,
     userRiskEvents.userId,
     filter.siteIds,
@@ -1639,5 +1667,7 @@ export async function listActiveDeviceSessionsForUserInOrg(input: {
 }
 
 export const userRiskScoringInternals = {
-  recordTrainingAssignment
+  recordTrainingAssignment,
+  userRiskMembershipVisible,
+  userRiskSiteCeiling
 };


### PR DESCRIPTION
## Summary

Two independent authorization defects in the user-risk surface (`apps/api/src/routes/userRisk.ts` and `services/userRiskScoring.ts`), found by the internal security review. Both are Medium.

### SEC-070 — user-risk writes accepted no session-MFA proof

All four HTTP mutations were reachable with only a `users:write` permission:

- `POST /user-risk/users/:userId/training-completed`
- `POST /user-risk/users/:userId/feedback`
- `PUT /user-risk/policy` (the org-wide scoring policy singleton)
- `POST /user-risk/assign-training`

The fix adds the established `requireMfa()` gate **after** the permission check and **before** param/body validation, org resolution, membership lookups, service calls and audit writes — so a denial happens before any effect, not after a validation error leaks route shape. `requireMfa` rejects unauthenticated callers, rejects AI-agent principals on HTTP, and under `ENABLE_2FA=true` requires the JWT `mfa === true` claim. Deployments with global MFA disabled keep their current behaviour.

**Scope note (deliberate):** this does not decide the site-authority model for the org-wide scoring policy, nor whether the shared AI tool `assign_security_training` should stay Tier 2 (auto-execute with audit) or move to Tier 3. Those remain open owner decisions; this PR is the MFA half only.

### SEC-071 — user-risk reads ignored the caller's site ceiling

Four `users:read` projections — scores, detail, events and evaluation — honoured the caller's **org** reach but never carried the authenticated **site** ceiling (`auth.allowedSiteIds`) into the service queries. A site-restricted org or partner caller could read another site's user identity, risk score, factors, login/MFA fields, score history and event detail, and hidden-site rows were folded into the evaluation aggregates. Org RLS blocks cross-tenant escape but cannot express the membership-site axis, so this has to be enforced in SQL.

The fix adds one correlated `EXISTS` predicate over `organization_users` (`userRiskMembershipVisible`) and applies it to `listUserRiskScores`, `getUserRiskDetail`, `listUserRiskEvents`, `getUserRiskEvaluation` and `getUserRiskOrgMembership`:

| caller ceiling | behaviour |
|---|---|
| `undefined` (unrestricted) | allowed, but a current org membership is still required |
| `[]` (defined-empty) | `false` — fails closed |
| non-empty | any-overlap against the target's current `site_ids`; a NULL target `site_ids` is therefore hidden |

`EXISTS` replaces the previous `innerJoin` on `organization_users`, so duplicate membership rows no longer multiply results, and the predicate now runs **before** count, latest-row selection, grouping, ordering and LIMIT/OFFSET rather than after. An explicitly requested `siteId` on `GET /scores` is rejected with 403 when it falls outside the ceiling, before the service query runs.

Detail selects the visible membership `FOR SHARE`, so the authorization row stays locked for the subsidiary history/event reads inside the same `withDbAccessContext` transaction (a concurrent membership move either wins the lock and is observed at its new site, or waits until the authorized response completes). It also defers the lazy `getOrCreateUserRiskPolicy` write until visible score history exists, so a hidden or history-less target no longer creates the org default policy as a side effect of an unauthorized read.

The shared AI tool `get_user_risk_detail` now passes `auth.allowedSiteIds` too, so MCP and autonomous-agent consumers inherit the same ceiling. No other production caller of these read services exists (verified by grep over `apps/api/src`).

### Review round (3rd commit)

Code review returned SHIP-WITH-FIXES with no blockers; four MUST-FIX items were applied on this branch:

1. **Write-path site oracle.** The two feedback writes called `getUserRiskOrgMembership(userId, orgId)` *without* the site ceiling, and `POST /assign-training` had no membership check at all. A site-A tech with `users:write` + MFA could therefore POST feedback or assign training for a site-B user (200 + an `ml_feedback_events` row) while `GET` on that same user 404s — an enumeration oracle on exactly the axis SEC-071 closes. All three write paths now pass `auth.allowedSiteIds` and 404 before any service effect.
2. **AI/MCP MFA bypass.** `assign_security_training` is Tier 2, so it auto-executes and never passed through the HTTP `requireMfa()` gate SEC-070 added. It now re-establishes both proofs in the handler, following the `aiToolsSentinelOne.ts` precedent: `hasSatisfiedMfa(auth)` before input validation, then the same membership + site-ceiling check as the HTTP route.
3. **Dropped the `FOR SHARE` lock** on the detail membership read (restored `.limit(1)`). Requests run inside one `withDbAccessContext` transaction, so the lock pinned the `users` and `organization_users` rows for the whole request — blocking concurrent membership writes on hot rows and being blocked by org erasure and bulk site moves. Every subsidiary read re-evaluates the visibility predicate under its own snapshot, so the ceiling still holds. The second integration test is re-targeted at post-move 404 visibility (which holds without the lock), and the `pg_stat_activity` blocked-backend poller is gone with it.
4. **Unrestricted callers no longer pay the membership `EXISTS`.** `listUserRiskEvents` and `getUserRiskEvaluation` applied it even when `siteIds === undefined`, silently dropping departed members' events from an unrestricted reader's history and from the evaluation denominators, and adding a correlated subquery per row for no authorization gain. New `userRiskSiteCeiling` wrapper returns `true` for `undefined` and defers to `userRiskMembershipVisible` for defined ceilings (empty included). Readers that already join `organization_users` (`listUserRiskScores`, `getUserRiskDetail`, `getUserRiskOrgMembership`) keep the unconditional predicate — main required a current membership there before this change and must keep doing so.

The detail unit test now asserts behaviour (hidden target → null, no subsidiary reads, no policy insert) instead of the `.for` chain shape, and gains a case proving a visible target with *no* score history still creates no default policy row.

No migration, no schema change, no new table or column — so no RLS/cascade/export-policy registration applies.

## Ported from

Two local commits from the private security-remediation program, cherry-picked with `-x` in order:

| Local SHA | Finding | Landed as |
|---|---|---|
| `4393f5a1ac2bbc899c94e4587785c0006df6dd9c` | SEC-2026-09-05-070 | `66d720b5f9` |
| `4cb545c7af425cb5fdec34721cc2b23774a065d0` | SEC-2026-09-05-071 | `e76f904c3e` |

A third commit, `f75e9c6dcb` (`4ccd8acd5e` after rebase), is **not** a port — it is this branch's response to code review (see "Review round" above).

**Nothing was dropped or altered from the ports.** Both commits applied cleanly with no conflicts. `git diff <local-base> origin/main -- <the six touched files>` was empty — main has not moved on any of them since the fixes were authored — so the ported diffs are byte-identical to the originals apart from commit messages (rewritten to carry the SEC IDs, the rationale, and the trailers). Diffstat matches the originals exactly: 7 files, +466/-45 combined.

## Verification

All commands run in this worktree at `4ccd8acd5e`, rebased on `origin/main` = `e4fbca279d`. Main has not touched any of the six ported files since the fixes were authored (`git diff 29e9445f3d origin/main -- <the six files>` is empty).

**Red-first (mandatory — proves the tests discriminate).** Two baselines, both with the ported + review tests in place and only the three non-test sources swapped out.

*(a) vs. pre-fix main* — `git checkout origin/main -- apps/api/src/routes/userRisk.ts apps/api/src/services/userRiskScoring.ts apps/api/src/services/aiToolsUserRisk.ts`, then:

```sh
cd apps/api && npx vitest run --pool=threads --maxWorkers=2 --reporter=dot \
  src/routes/userRisk src/services/userRiskScoring \
  src/services/aiToolsReliability src/services/userRiskSignals
```

→ **25 failed / 29 passed (54), 3 of 4 files failed** — verified.

*(b) vs. the ported-but-un-reviewed tree* (`git checkout <SEC-071 commit> -- <same three files>`), same command → **15 failed / 39 passed (54)** — verified. These 15 are exactly the review-round assertions, so the third commit is independently discriminating and not a no-op refactor.

Restoring the fix (`git checkout HEAD -- <same three files>`) and re-running the identical command → **54 passed, 0 failed** — verified.

Attribution of the 25:

- **SEC-070 (4):** the four write routes "requires MFA before validation or service effects" — on main all four returned **400 validation error instead of 403 `MFA_REQUIRED`**, i.e. the body was parsed before any MFA check.
- **SEC-071 (6):** `GET /scores` (×2, incl. "rejects an explicit site outside the authenticated ceiling before querying"), `GET /users/:userId` (×2, incl. multi-org resolution), `GET /events`, `GET /evaluation`, plus `aiTools get_user_risk_detail … passes the authenticated site ceiling`.
- **Review round (15), all new in the third commit:**
  - `POST /users/:userId/training-completed carries the site ceiling into the membership check`
  - `POST /users/:userId/feedback carries the site ceiling into the membership check`
  - `POST /assign-training denies a target outside the site ceiling before any write`
  - `POST {training-completed,feedback,assign-training} leaves the membership check unrestricted for a caller with no site ceiling` (3 cases — guards against over-restricting unrestricted callers)
  - `aiTools assign_security_training authorization > denies a caller whose session has not satisfied MFA, before any write`
  - `aiTools assign_security_training authorization > denies a target outside the authenticated site ceiling, before any write`
  - `aiTools assign_security_training authorization > carries the site ceiling into the membership check for a visible target`
  - `user-risk site visibility predicates > userRiskSiteCeiling adds no membership subquery for an unrestricted caller`
  - `user-risk site visibility predicates > userRiskSiteCeiling fails closed for a defined-empty ceiling`
  - `user-risk site visibility predicates > userRiskSiteCeiling requires an overlapping current membership for a defined ceiling`
  - `user-risk site visibility predicates > userRiskMembershipVisible still requires a current membership when unrestricted`
  - `getUserRiskDetail visibility short-circuit > returns no detail and creates no policy row for a hidden membership`
  - `getUserRiskDetail visibility short-circuit > creates no default policy row when a visible target has no score history`

**Unit** (same 4 files; `userRiskSignals` included so the `services/userRisk` substring cannot silently skip a sibling):

```sh
cd apps/api && npx vitest run --pool=threads --maxWorkers=2 \
  src/routes/userRisk src/services/userRiskScoring \
  src/services/aiToolsReliability src/services/userRiskSignals
```
→ **4 files / 54 tests passed** — verified.

**Integration** — real ephemeral Postgres + Redis via `pnpm test-stack up`, API running as unprivileged `breeze_app`.

`userRisk*` + every `*SiteScope*` / `*site-scope*` suite (13 files: `userRiskSiteScope`, `userRiskRetention`, `aiToolsAuditDetailsSiteScope`, `aiToolsNetworkSiteScope`, `alertTemplateSiteScope`, `automationReadSiteScope`, `enrollmentKeyReadSiteScope`, `mtlsQuarantineSiteScope`, `onboardingTokenSiteScope`, `policyComplianceSiteScope`, `report-site-scope`, `topology-layout-site-scope`, `tunnel-allowlist-site-scope`):

```sh
cd apps/api && npx vitest run --config vitest.integration.config.ts \
  --pool=threads --maxWorkers=2 src/__tests__/integration/<each>.integration.test.ts
```
→ **13 files / 75 tests passed** — verified. `userRiskSiteScope` itself contributes 2: the pre-LIMIT/count/grouping filter proof through the authenticated route (unrestricted, selected-site, defined-empty, NULL-target, duplicate membership, foreign-org) and the re-targeted post-move 404.

`site-scope-coverage.integration.test.ts` is excluded from `vitest.integration.config.ts` (static route scanner, own runner), so it was run separately:

```sh
cd apps/api && npx vitest run --config vitest.config.site-scope-coverage.ts
```
→ **1 file / 7 tests passed** — verified. It scans `:deviceId` route patterns only; user-risk routes carry no device in their path, so it is a no-op guard here (*inferred* from the scanner's documented scope).

MFA integration family (12 suites: `adminMfaReset`, `mfa-step-up-policy`, `mfaAssurance`, `mfaEnrollmentSession`, `mfaFactorReset`, `mfaPolicyActivation`, `mfaReenrollmentAfterReset`, `partnerAdminForceMfaMigration`, `passkeyMfaVerify`, `pendingMfaEpoch`, `registerPartnerMfaPolicy`, `seedPartnerAdminForceMfa`) → **12 files / 65 tests passed, 0 failed** — verified.

**Typecheck / lint:**

```sh
cd apps/api && NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit    # exit 0 — verified
cd apps/api && npx eslint <the 7 touched files>                          # exit 0, no findings — verified
```

**Not checked:** no browser/E2E pass (the change is entirely server-side and was verified at route, service, AI-tool and real-database boundaries); no full API suite run in this port (the originals were verified against a full run of 35,872 passing tests before the port, and main has not moved on any touched file — *inferred*, not re-run here); no production-scale query-plan or latency measurement.

## Operator impact

- **Clients must handle `403 {"error":"MFA required","code":"MFA_REQUIRED"}`** on the four user-risk write endpoints. This only bites deployments running `ENABLE_2FA=true`; with global MFA disabled the gate is satisfied as before and behaviour is unchanged.
- **Site-restricted technicians will see fewer user-risk rows** — correctly. A tech scoped to a subset of sites now only sees risk scores, detail, events and evaluation for users whose *current* org membership overlaps their site allowlist. Users with a NULL `site_ids` membership become invisible to every site-restricted reader (fail-closed); they remain visible to unrestricted org/partner callers. If a partner was relying on site-restricted roles seeing org-wide user risk, that access is now denied and the role needs widening.
- Visibility follows the target's **current** membership, not the historical site of each event — moving a user between sites changes who can see their retained history. Known and intentional.
- No migration, no credential rotation, no agent upgrade, no config change required.
- Known perf caveat carried over from the original review: `organization_users` has no `(org_id, user_id)` or `site_ids` index, and the shared predicate casts user IDs to text to also serve the feedback ledger's varchar `source_id`. An `EXPLAIN` during the original review showed a sequential scan of `organization_users`. No confidentiality bypass — this is performance hardening for large fleets, worth a follow-up before it matters.

## Follow-ups (not in this PR)

- **`PUT /user-risk/policy` site authority is still undecided.** The scoring policy is an org-wide singleton; this PR requires MFA to change it but does not say whether a site-restricted principal should be able to govern an org-wide object at all. That is an owner decision (deny site-restricted principals outright vs. a durable site-owned policy model), and it is the remaining half of SEC-070.
- **The AI/MCP tier of `assign_security_training` is still an owner decision.** It stays Tier 2 (auto-execute with audit) here; this PR only stops it from bypassing the MFA and site proofs. Whether it should become Tier 3 (interactive approval) or be unavailable to non-interactive transports has not been settled.
- **Membership index.** `organization_users` has no `(org_id, user_id)` or `site_ids` index and the shared predicate casts user IDs to text (to also serve the feedback ledger's varchar `source_id`). Worth revisiting before large-fleet scale — see Operator impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Tugfg88kFiowD7E5xQFpU
