### PR TITLE
fix(logs): scope fleet log reads and correlation rules to current site authority (SEC-079, SEC-080)

### DIFF
--- a/apps/api/src/__tests__/integration/logCorrelationRuleSiteAuthority.integration.test.ts
+++ b/apps/api/src/__tests__/integration/logCorrelationRuleSiteAuthority.integration.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Real-PostgreSQL proof for persistent log-correlation rule admission.
+ *
+ * Rules write one shared org-wide snapshot and may create an alert. A caller
+ * with a defined site ceiling must therefore be rejected before that service
+ * path runs; only an unrestricted caller may update the global state.
+ */
+import './setup';
+
+import { randomUUID } from 'node:crypto';
+import { and, eq } from 'drizzle-orm';
+import { Hono } from 'hono';
+import { expect, it } from 'vitest';
+
+import { db, withSystemDbAccessContext } from '../../db';
+import {
+  alerts,
+  deviceEventLogs,
+  devices,
+  logCorrelationRules,
+  logCorrelations,
+  organizationUsers,
+} from '../../db/schema';
+import { logsRoutes } from '../../routes/logs';
+import { clearPermissionCache } from '../../services/permissions';
+import { createAccessToken } from '../../services/jwt';
+import { createSite, setupTestEnvironment, type TestEnvironment } from './db-utils';
+import { getTestDb } from './setup';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+async function mfaToken(env: TestEnvironment): Promise<string> {
+  return createAccessToken({
+    sub: env.user.id,
+    email: env.user.email,
+    roleId: env.role.id,
+    orgId: env.organization.id,
+    partnerId: env.partner.id,
+    scope: 'organization',
+    mfa: true,
+    aep: 1,
+    mep: 1,
+    sid: randomUUID(),
+  });
+}
+
+async function setSiteCeiling(env: TestEnvironment, siteIds: string[] | null): Promise<void> {
+  await withSystemDbAccessContext(async () => {
+    await db
+      .update(organizationUsers)
+      .set({ siteIds })
+      .where(and(
+        eq(organizationUsers.userId, env.user.id),
+        eq(organizationUsers.orgId, env.organization.id),
+      ));
+  });
+  await clearPermissionCache(env.user.id);
+}
+
+async function invokeRules(token: string): Promise<Response> {
+  const app = new Hono();
+  app.route('/logs', logsRoutes);
+  return app.request('/logs/correlation/detect', {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${token}`,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({}),
+  });
+}
+
+runDb('denies selected and empty site ceilings without persistent effects, then allows unrestricted execution', async () => {
+  const env = await setupTestEnvironment();
+  const hiddenSite = await createSite({ orgId: env.organization.id });
+  const testDb = getTestDb();
+
+  const [visibleDevice, hiddenDevice] = await testDb
+    .insert(devices)
+    .values([
+      {
+        orgId: env.organization.id,
+        siteId: env.site.id,
+        agentId: `corr-visible-${randomUUID()}`,
+        hostname: 'corr-visible-host',
+        osType: 'linux',
+        osVersion: '1',
+        architecture: 'amd64',
+        agentVersion: 'test',
+        status: 'online',
+      },
+      {
+        orgId: env.organization.id,
+        siteId: hiddenSite.id,
+        agentId: `corr-hidden-${randomUUID()}`,
+        hostname: 'corr-hidden-host',
+        osType: 'linux',
+        osVersion: '1',
+        architecture: 'amd64',
+        agentVersion: 'test',
+        status: 'online',
+      },
+    ])
+    .returning({ id: devices.id });
+
+  if (!visibleDevice || !hiddenDevice) throw new Error('failed to seed correlation devices');
+
+  const marker = `correlation-marker-${randomUUID()}`;
+  await testDb.insert(deviceEventLogs).values([
+    {
+      orgId: env.organization.id,
+      deviceId: visibleDevice.id,
+      timestamp: new Date(),
+      level: 'error',
+      category: 'application',
+      source: 'integration-test',
+      message: marker,
+    },
+    {
+      orgId: env.organization.id,
+      deviceId: hiddenDevice.id,
+      timestamp: new Date(),
+      level: 'error',
+      category: 'application',
+      source: 'integration-test',
+      message: marker,
+    },
+  ]);
+
+  const [rule] = await testDb
+    .insert(logCorrelationRules)
+    .values({
+      orgId: env.organization.id,
+      name: 'Site authority integration rule',
+      pattern: marker,
+      minOccurrences: 1,
+      minDevices: 1,
+      timeWindow: 300,
+      severity: 'warning',
+      alertOnMatch: true,
+      isActive: true,
+    })
+    .returning({ id: logCorrelationRules.id });
+  if (!rule) throw new Error('failed to seed correlation rule');
+
+  const token = await mfaToken(env);
+  for (const ceiling of [[env.site.id], []] as string[][]) {
+    await setSiteCeiling(env, ceiling);
+    const denied = await invokeRules(token);
+    expect(denied.status).toBe(403);
+    expect(await denied.json()).toEqual({ error: 'Access denied' });
+
+    const [ruleState, correlationRows, alertRows] = await Promise.all([
+      testDb
+        .select({ lastMatchedAt: logCorrelationRules.lastMatchedAt })
+        .from(logCorrelationRules)
+        .where(eq(logCorrelationRules.id, rule.id)),
+      testDb
+        .select({ id: logCorrelations.id })
+        .from(logCorrelations)
+        .where(eq(logCorrelations.ruleId, rule.id)),
+      testDb
+        .select({ id: alerts.id })
+        .from(alerts)
+        .where(eq(alerts.orgId, env.organization.id)),
+    ]);
+    expect(ruleState[0]?.lastMatchedAt).toBeNull();
+    expect(correlationRows).toEqual([]);
+    expect(alertRows).toEqual([]);
+  }
+
+  await setSiteCeiling(env, null);
+  const allowed = await invokeRules(token);
+  const body = await allowed.json() as {
+    count: number;
+    detections: Array<{ affectedDevices: Array<{ deviceId: string }> }>;
+    error?: string;
+  };
+  expect(allowed.status, body.error).toBe(200);
+  expect(body.count).toBe(1);
+  expect(body.detections[0]?.affectedDevices.map((device) => device.deviceId).sort())
+    .toEqual([visibleDevice.id, hiddenDevice.id].sort());
+
+  const [ruleState, correlationRows, alertRows] = await Promise.all([
+    testDb
+      .select({ lastMatchedAt: logCorrelationRules.lastMatchedAt })
+      .from(logCorrelationRules)
+      .where(eq(logCorrelationRules.id, rule.id)),
+    testDb
+      .select({ affectedDevices: logCorrelations.affectedDevices, sampleLogs: logCorrelations.sampleLogs })
+      .from(logCorrelations)
+      .where(eq(logCorrelations.ruleId, rule.id)),
+    testDb
+      .select({ deviceId: alerts.deviceId })
+      .from(alerts)
+      .where(eq(alerts.orgId, env.organization.id)),
+  ]);
+  expect(ruleState[0]?.lastMatchedAt).toBeInstanceOf(Date);
+  expect(correlationRows).toHaveLength(1);
+  expect(correlationRows[0]?.affectedDevices).toHaveLength(2);
+  expect(correlationRows[0]?.sampleLogs).toHaveLength(2);
+  expect(alertRows).toHaveLength(1);
+  expect([visibleDevice.id, hiddenDevice.id]).toContain(alertRows[0]?.deviceId);
+});

--- a/apps/api/src/__tests__/integration/logReadSiteScope.integration.test.ts
+++ b/apps/api/src/__tests__/integration/logReadSiteScope.integration.test.ts
@@ -1,0 +1,411 @@
+import './setup';
+
+import { afterAll, describe, expect, it } from 'vitest';
+import { Hono } from 'hono';
+import { and, eq } from 'drizzle-orm';
+import { randomUUID } from 'node:crypto';
+
+import { db, withDbAccessContext, type DbAccessContext } from '../../db';
+import {
+  deviceEventLogs,
+  devices,
+  logCorrelationRules,
+  logCorrelations,
+  logSearchQueries,
+  organizationUsers,
+  partnerUsers,
+  permissions,
+  rolePermissions,
+  users,
+} from '../../db/schema';
+import { getLogCorrelationQueue, processLogCorrelationJob, shutdownLogCorrelationWorker } from '../../jobs/logCorrelation';
+import { logsRoutes } from '../../routes/logs';
+import type { AuthContext } from '../../middleware/auth';
+import { registerEventLogTools } from '../../services/aiToolsEventLogs';
+import type { AiTool } from '../../services/aiTools';
+import { createAccessToken, type TokenPayload } from '../../services/jwt';
+import { detectPatternCorrelation, getLogAggregation, getLogTrends, searchFleetLogs } from '../../services/logSearch';
+import { resolveCurrentLogReadDeviceIds } from '../../services/logReadAuthority';
+import { clearPermissionCache } from '../../services/permissions';
+import {
+  assignUserToOrganization,
+  createOrganization,
+  createRole,
+  createSite,
+  grantRolePermissions,
+  setupTestEnvironment,
+} from './db-utils';
+
+const SYSTEM_CTX: DbAccessContext = {
+  scope: 'system', orgId: null, accessibleOrgIds: null,
+  accessiblePartnerIds: null, userId: null,
+};
+
+afterAll(async () => {
+  await shutdownLogCorrelationWorker();
+});
+
+describe('fleet log current-site boundary — real PostgreSQL and Redis', () => {
+  it('projects raw/aggregate/correlation/saved data and rejects stale async authority', async () => {
+    const env = await setupTestEnvironment({
+      scope: 'organization',
+      rolePermissions: [
+        { resource: 'devices', action: 'read' },
+        { resource: 'devices', action: 'write' },
+        { resource: 'devices', action: 'execute' },
+      ],
+    });
+    const hiddenSite = await createSite({ orgId: env.organization.id, name: 'Hidden logs' });
+    const suffix = randomUUID().slice(0, 8);
+    const insertedDevices = await withDbAccessContext(SYSTEM_CTX, () => db.insert(devices).values([
+      {
+        orgId: env.organization.id, siteId: env.site.id, agentId: `log-visible-${suffix}`,
+        hostname: `log-visible-${suffix}`, osType: 'linux', osVersion: '1',
+        architecture: 'x64', agentVersion: '1', status: 'online',
+      },
+      {
+        orgId: env.organization.id, siteId: hiddenSite.id, agentId: `log-hidden-${suffix}`,
+        hostname: `log-hidden-${suffix}`, osType: 'linux', osVersion: '1',
+        architecture: 'x64', agentVersion: '1', status: 'online',
+      },
+    ]).returning({ id: devices.id }));
+    const visibleDeviceId = insertedDevices[0]!.id;
+    const hiddenDeviceId = insertedDevices[1]!.id;
+    await withDbAccessContext(SYSTEM_CTX, () => db.update(organizationUsers)
+      .set({ siteIds: [env.site.id] })
+      .where(and(eq(organizationUsers.userId, env.user.id), eq(organizationUsers.orgId, env.organization.id))));
+    await clearPermissionCache(env.user.id);
+
+    const now = new Date();
+    await withDbAccessContext(SYSTEM_CTX, () => db.insert(deviceEventLogs).values([
+      {
+        orgId: env.organization.id, deviceId: visibleDeviceId, timestamp: now,
+        level: 'info', category: 'system', source: `visible-${suffix}`, message: 'allowed synthetic log',
+      },
+      {
+        orgId: env.organization.id, deviceId: hiddenDeviceId, timestamp: now,
+        level: 'critical', category: 'security', source: `hidden-${suffix}`, message: 'denied synthetic log',
+      },
+    ]));
+    const [rule] = await withDbAccessContext(SYSTEM_CTX, () => db.insert(logCorrelationRules).values({
+      orgId: env.organization.id, name: `rule-${suffix}`, pattern: 'synthetic',
+    }).returning({ id: logCorrelationRules.id }));
+    const visibleCorrelationId = randomUUID();
+    const deletedDeviceId = randomUUID();
+    await withDbAccessContext(SYSTEM_CTX, () => db.insert(logCorrelations).values([
+      {
+        id: visibleCorrelationId, orgId: env.organization.id, ruleId: rule!.id, pattern: 'visible',
+        firstSeen: new Date(now.getTime() - 10_000), lastSeen: new Date(now.getTime() - 5_000), occurrences: 1,
+        affectedDevices: [{ deviceId: visibleDeviceId, hostname: 'visible', count: 1 }], sampleLogs: [],
+      },
+      {
+        orgId: env.organization.id, ruleId: rule!.id, pattern: 'mixed-newer',
+        firstSeen: now, lastSeen: now, occurrences: 2,
+        affectedDevices: [
+          { deviceId: visibleDeviceId, hostname: 'visible', count: 1 },
+          { deviceId: hiddenDeviceId, hostname: 'hidden', count: 1 },
+        ], sampleLogs: [],
+      },
+      {
+        orgId: env.organization.id, ruleId: rule!.id, pattern: 'hidden-only-newer',
+        firstSeen: now, lastSeen: new Date(now.getTime() + 500), occurrences: 1,
+        affectedDevices: [{ deviceId: hiddenDeviceId, hostname: 'hidden', count: 1 }], sampleLogs: [],
+      },
+      {
+        orgId: env.organization.id, ruleId: rule!.id, pattern: 'deleted-newest',
+        firstSeen: now, lastSeen: new Date(now.getTime() + 1_000), occurrences: 1,
+        affectedDevices: [{ deviceId: deletedDeviceId, hostname: 'deleted', count: 1 }], sampleLogs: [],
+      },
+      {
+        orgId: env.organization.id, ruleId: rule!.id, pattern: 'malformed-newest',
+        firstSeen: now, lastSeen: new Date(now.getTime() + 2_000), occurrences: 1,
+        affectedDevices: [{ deviceId: 'not-a-uuid', hostname: 'malformed', count: 1 }], sampleLogs: [],
+      },
+      {
+        orgId: env.organization.id, ruleId: rule!.id, pattern: 'device-less-newest',
+        firstSeen: now, lastSeen: new Date(now.getTime() + 3_000), occurrences: 1,
+        affectedDevices: [], sampleLogs: [],
+      },
+      {
+        orgId: env.organization.id, ruleId: rule!.id, pattern: 'hidden-sample-newest',
+        firstSeen: now, lastSeen: new Date(now.getTime() + 4_000), occurrences: 1,
+        affectedDevices: [{ deviceId: visibleDeviceId, hostname: 'visible', count: 1 }],
+        sampleLogs: [{
+          id: randomUUID(), deviceId: hiddenDeviceId, timestamp: now.toISOString(),
+          level: 'critical', source: 'hidden', message: 'hidden sample',
+        }],
+      },
+    ]));
+    const [hiddenSaved] = await withDbAccessContext(SYSTEM_CTX, () => db.insert(logSearchQueries).values({
+      orgId: env.organization.id, name: `saved-${suffix}`, createdBy: env.user.id,
+      filters: { deviceIds: [hiddenDeviceId], siteIds: [hiddenSite.id] },
+    }).returning({ id: logSearchQueries.id }));
+
+    const token = await createAccessToken({
+      sub: env.user.id, email: env.user.email, roleId: env.role.id,
+      orgId: env.organization.id, partnerId: env.partner.id, scope: 'organization',
+      mfa: true, aep: 1, mep: 1, sid: randomUUID(),
+    } satisfies Omit<TokenPayload, 'type'>);
+    const app = new Hono();
+    app.route('/logs', logsRoutes);
+    const request = (path: string, init?: RequestInit) => app.request(`/logs${path}`, {
+      ...init,
+      headers: { Authorization: `Bearer ${token}`, ...(init?.headers ?? {}) },
+    });
+
+    const search = await request('/search', {
+      method: 'POST', headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ limit: 20, countMode: 'exact' }),
+    });
+    expect(search.status, await search.clone().text()).toBe(200);
+    const searchBody = await search.json() as { results: Array<{ log: { deviceId: string } }>; total: number };
+    expect(searchBody.results.map((row) => row.log.deviceId)).toEqual([visibleDeviceId]);
+    expect(searchBody.total).toBe(1);
+
+    const aggregation = await request('/aggregation?groupBy=device');
+    expect(aggregation.status, await aggregation.clone().text()).toBe(200);
+    const aggregationJson = JSON.stringify(await aggregation.json());
+    expect(aggregationJson).toContain(`log-visible-${suffix}`);
+    expect(aggregationJson).not.toContain(`log-hidden-${suffix}`);
+    const trends = await request('/trends');
+    expect(trends.status, await trends.clone().text()).toBe(200);
+    expect(JSON.stringify(await trends.json())).not.toContain(hiddenDeviceId);
+
+    // Hidden/deleted/mixed rows are removed before total and LIMIT, so the
+    // older visible correlation fills page one.
+    const correlations = await request('/correlation?limit=1');
+    expect(correlations.status, await correlations.clone().text()).toBe(200);
+    await expect(correlations.json()).resolves.toMatchObject({
+      data: [{ id: visibleCorrelationId }], total: 1, limit: 1, offset: 0,
+    });
+    const saved = await request('/queries');
+    expect(saved.status, await saved.clone().text()).toBe(200);
+    await expect(saved.json()).resolves.toMatchObject({ data: [{ filters: {
+      deviceIds: [], siteIds: [],
+    } }] });
+    const hiddenSavedSearch = await request('/search', {
+      method: 'POST', headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ savedQueryId: hiddenSaved!.id, countMode: 'exact' }),
+    });
+    expect(hiddenSavedSearch.status, await hiddenSavedSearch.clone().text()).toBe(200);
+    await expect(hiddenSavedSearch.json()).resolves.toMatchObject({ results: [], total: 0 });
+
+    const queued = await request('/correlation/detect', {
+      method: 'POST', headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ pattern: 'allowed synthetic log', minDevices: 1, minOccurrences: 1 }),
+    });
+    expect(queued.status, await queued.clone().text()).toBe(202);
+    const queuedBody = await queued.json() as { jobId: string };
+    expect((await request(`/correlation/detect/${queuedBody.jobId}`)).status).toBe(200);
+    const queue = getLogCorrelationQueue();
+    const queuedJob = await queue.getJob(queuedBody.jobId);
+    await expect(processLogCorrelationJob(queuedJob!.data)).resolves.toMatchObject({
+      mode: 'pattern', detected: true,
+      result: { affectedDevices: [{ deviceId: visibleDeviceId }] },
+    });
+
+    // Poll authorization is bound to both the job org and the current request
+    // ceiling, not merely to the requester id stored in the envelope.
+    const otherOrg = await createOrganization({ partnerId: env.partner.id });
+    await withDbAccessContext(SYSTEM_CTX, () => db.insert(organizationUsers).values({
+      orgId: otherOrg.id, userId: env.user.id, roleId: env.role.id,
+    }));
+    const otherOrgToken = await createAccessToken({
+      sub: env.user.id, email: env.user.email, roleId: env.role.id,
+      orgId: otherOrg.id, partnerId: env.partner.id, scope: 'organization',
+      mfa: true, aep: 1, mep: 1, sid: randomUUID(),
+    } satisfies Omit<TokenPayload, 'type'>);
+    expect((await app.request(`/logs/correlation/detect/${queuedBody.jobId}`, {
+      headers: { Authorization: `Bearer ${otherOrgToken}` },
+    })).status).toBe(404);
+    await withDbAccessContext(SYSTEM_CTX, () => db.update(organizationUsers)
+      .set({ siteIds: [] })
+      .where(and(eq(organizationUsers.userId, env.user.id), eq(organizationUsers.orgId, env.organization.id))));
+    await clearPermissionCache(env.user.id);
+    expect((await request(`/correlation/detect/${queuedBody.jobId}`)).status).toBe(404);
+    await withDbAccessContext(SYSTEM_CTX, () => db.update(organizationUsers)
+      .set({ siteIds: [env.site.id] })
+      .where(and(eq(organizationUsers.userId, env.user.id), eq(organizationUsers.orgId, env.organization.id))));
+    await clearPermissionCache(env.user.id);
+
+    const legacy = await queue.add('pattern-detect', {
+      type: 'pattern', orgId: env.organization.id, pattern: 'legacy', isRegex: false,
+      queuedAt: now.toISOString(),
+    } as never, { jobId: `legacy-log-${suffix}` });
+    expect((await request(`/correlation/detect/${legacy.id}`)).status).toBe(404);
+
+    // Deterministic post-snapshot move: prove the old pre-query snapshot saw
+    // the device, commit its move, then require the correlation statement's
+    // own device/org/site EXISTS to reject the formerly-visible row.
+    const staleAuth = {
+      scope: 'organization', orgId: env.organization.id,
+      allowedSiteIds: [env.site.id], canAccessOrg: (id: string) => id === env.organization.id,
+      canAccessSite: (id: string | null | undefined) => id === env.site.id,
+      orgCondition: (column: Parameters<AuthContext['orgCondition']>[0]) => eq(column, env.organization.id),
+    } as unknown as AuthContext;
+    const staleCtx: DbAccessContext = {
+      scope: 'organization', orgId: env.organization.id,
+      accessibleOrgIds: [env.organization.id], accessiblePartnerIds: [], userId: env.user.id,
+      currentPartnerId: env.partner.id,
+    };
+    await expect(withDbAccessContext(staleCtx, () => resolveCurrentLogReadDeviceIds(
+      staleAuth, env.organization.id,
+    ))).resolves.toContain(visibleDeviceId);
+
+    // Historical raw logs follow the device's CURRENT site.
+    await withDbAccessContext(SYSTEM_CTX, () => db.update(devices)
+      .set({ siteId: hiddenSite.id }).where(eq(devices.id, visibleDeviceId)));
+    const afterMove = await request('/search', {
+      method: 'POST', headers: { 'content-type': 'application/json' }, body: '{}',
+    });
+    expect(afterMove.status).toBe(200);
+    expect((await afterMove.json() as { results: unknown[] }).results).toHaveLength(0);
+    await expect((await request('/correlation?limit=1')).json()).resolves.toMatchObject({
+      data: [], total: 0, limit: 1, offset: 0,
+    });
+
+    // Deterministic TOCTOU regression: carry the pre-move device-id snapshot
+    // into each data-bearing service after the committed move. The correlated
+    // device/org/site predicate in the SQL statement must still exclude it.
+    const staleCeiling = { allowedDeviceIds: [visibleDeviceId], allowedSiteIds: [env.site.id] };
+    await expect(withDbAccessContext(staleCtx, () => searchFleetLogs(
+      staleAuth, { ...staleCeiling, countMode: 'exact' },
+    )))
+      .resolves.toMatchObject({ results: [], total: 0 });
+    expect(JSON.stringify(await withDbAccessContext(staleCtx, () => getLogAggregation(
+      staleAuth, { ...staleCeiling, groupBy: 'device' },
+    ))))
+      .not.toContain(visibleDeviceId);
+    expect(JSON.stringify(await withDbAccessContext(staleCtx, () => getLogTrends(staleAuth, staleCeiling))))
+      .not.toContain(visibleDeviceId);
+    await expect(withDbAccessContext(staleCtx, () => detectPatternCorrelation({
+      orgId: env.organization.id, pattern: 'allowed synthetic', minDevices: 1, minOccurrences: 1,
+      ...staleCeiling,
+    }))).resolves.toBeNull();
+
+    // AI/MCP callers take the same services through a pre-query device-id
+    // snapshot. Every tool must also carry the live site ceiling so the SQL
+    // predicate, not that stale snapshot, decides visibility after a move.
+    const eventLogTools = new Map<string, AiTool>();
+    registerEventLogTools(eventLogTools);
+    const runTool = (name: string, input: Record<string, unknown>) => withDbAccessContext(
+      staleCtx,
+      () => eventLogTools.get(name)!.handler(input, staleAuth),
+    );
+    const aiSearch = JSON.parse(await runTool('search_logs', {
+      query: 'allowed synthetic', countMode: 'exact',
+    }));
+    expect(aiSearch.logs).toEqual([]);
+    expect(aiSearch.total).toBe(0);
+    const aiTrends = JSON.parse(await runTool('get_log_trends', {
+      groupBy: 'device', source: `visible-${suffix}`,
+    }));
+    expect(JSON.stringify(aiTrends)).not.toContain(visibleDeviceId);
+    const aiCorrelation = JSON.parse(await runTool('detect_log_correlations', {
+      pattern: 'allowed synthetic', minDevices: 1, minOccurrences: 1,
+    }));
+    expect(aiCorrelation.detected).toBe(false);
+
+    // Removing execute authority invalidates the durable queued envelope
+    // before any pattern query is evaluated.
+    const [executePermission] = await withDbAccessContext(SYSTEM_CTX, () => db.select({ id: permissions.id })
+      .from(permissions).where(and(eq(permissions.resource, 'devices'), eq(permissions.action, 'execute'))).limit(1));
+    await withDbAccessContext(SYSTEM_CTX, () => db.delete(rolePermissions).where(and(
+      eq(rolePermissions.roleId, env.role.id), eq(rolePermissions.permissionId, executePermission!.id),
+    )));
+    await clearPermissionCache(env.user.id);
+    const revokedJob = await queue.getJob(queuedBody.jobId);
+    await expect(processLogCorrelationJob(revokedJob!.data)).rejects.toThrow('authority is no longer valid');
+    const [liveUser] = await withDbAccessContext(SYSTEM_CTX, () => db.select({ status: users.status })
+      .from(users).where(eq(users.id, env.user.id)).limit(1));
+    expect(liveUser?.status).toBe('active');
+  });
+
+  it('preserves partner all/selected and live platform-system fleet reads on their exact authority axes', async () => {
+    const env = await setupTestEnvironment({
+      scope: 'partner',
+      rolePermissions: [
+        { resource: 'devices', action: 'read' },
+        { resource: 'devices', action: 'write' },
+        { resource: 'devices', action: 'execute' },
+      ],
+    });
+    const suffix = randomUUID().slice(0, 8);
+    const [device] = await withDbAccessContext(SYSTEM_CTX, () => db.insert(devices).values({
+      orgId: env.organization.id, siteId: env.site.id, agentId: `log-partner-${suffix}`,
+      hostname: `log-partner-${suffix}`, osType: 'linux', osVersion: '1',
+      architecture: 'x64', agentVersion: '1', status: 'online',
+    }).returning({ id: devices.id }));
+    await withDbAccessContext(SYSTEM_CTX, () => db.insert(deviceEventLogs).values({
+      orgId: env.organization.id, deviceId: device!.id, timestamp: new Date(),
+      level: 'warning', category: 'system', source: `partner-${suffix}`,
+      message: `partner-axis-${suffix}`,
+    }));
+    await withDbAccessContext(SYSTEM_CTX, () => db.insert(logSearchQueries).values({
+      orgId: env.organization.id, name: `partner-saved-${suffix}`, createdBy: env.user.id,
+      filters: { deviceIds: [device!.id], siteIds: [env.site.id] },
+    }));
+
+    const app = new Hono();
+    app.route('/logs', logsRoutes);
+    const mint = (scope: 'partner' | 'system') => createAccessToken({
+      sub: env.user.id, email: env.user.email, roleId: env.role.id,
+      orgId: null, partnerId: env.partner.id, scope,
+      mfa: true, aep: 1, mep: 1, sid: randomUUID(),
+    } satisfies Omit<TokenPayload, 'type'>);
+    const exercise = async (token: string) => {
+      const headers = { Authorization: `Bearer ${token}` };
+      const search = await app.request('/logs/search', {
+        method: 'POST', headers: { ...headers, 'content-type': 'application/json' },
+        body: JSON.stringify({ query: `partner-axis-${suffix}`, countMode: 'exact' }),
+      });
+      expect(search.status, await search.clone().text()).toBe(200);
+      expect(JSON.stringify(await search.json())).toContain(device!.id);
+      for (const path of ['/logs/aggregation?groupBy=device', '/logs/trends', '/logs/queries']) {
+        const response = await app.request(path, { headers });
+        expect(response.status, `${path}: ${await response.clone().text()}`).toBe(200);
+        const payload = JSON.stringify(await response.json());
+        expect(payload).toContain(path === '/logs/queries' ? device!.id : suffix);
+      }
+    };
+
+    const partnerToken = await mint('partner');
+    await exercise(partnerToken); // orgAccess=all from setupTestEnvironment
+
+    // A lower organization membership must not replace the captured partner
+    // axis when the queued worker revalidates authority.
+    const lowerRole = await createRole({
+      scope: 'organization', orgId: env.organization.id, partnerId: env.partner.id,
+    });
+    await grantRolePermissions(lowerRole.id, [{ resource: 'devices', action: 'read' }]);
+    await assignUserToOrganization(env.user.id, env.organization.id, lowerRole.id);
+    await clearPermissionCache(env.user.id);
+    const queued = await app.request('/logs/correlation/detect', {
+      method: 'POST', headers: {
+        Authorization: `Bearer ${partnerToken}`, 'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        orgId: env.organization.id, pattern: `partner-axis-${suffix}`,
+        minDevices: 1, minOccurrences: 1,
+      }),
+    });
+    expect(queued.status, await queued.clone().text()).toBe(202);
+    const queuedBody = await queued.json() as { jobId: string };
+    const queuedJob = await getLogCorrelationQueue().getJob(queuedBody.jobId);
+    await expect(processLogCorrelationJob(queuedJob!.data)).resolves.toMatchObject({
+      mode: 'pattern', detected: true,
+      result: { affectedDevices: [{ deviceId: device!.id }] },
+    });
+
+    await withDbAccessContext(SYSTEM_CTX, () => db.update(partnerUsers).set({
+      orgAccess: 'selected', orgIds: [env.organization.id],
+    }).where(and(eq(partnerUsers.userId, env.user.id), eq(partnerUsers.partnerId, env.partner.id))));
+    await clearPermissionCache(env.user.id);
+    await exercise(partnerToken);
+
+    await withDbAccessContext(SYSTEM_CTX, () => db.update(users)
+      .set({ isPlatformAdmin: true }).where(eq(users.id, env.user.id)));
+    await clearPermissionCache(env.user.id);
+    await exercise(await mint('system'));
+  });
+});

--- a/apps/api/src/__tests__/integration/logReadSiteScope.integration.test.ts
+++ b/apps/api/src/__tests__/integration/logReadSiteScope.integration.test.ts
@@ -91,6 +91,7 @@ describe('fleet log current-site boundary — real PostgreSQL and Redis', () => 
       orgId: env.organization.id, name: `rule-${suffix}`, pattern: 'synthetic',
     }).returning({ id: logCorrelationRules.id }));
     const visibleCorrelationId = randomUUID();
+    const deviceLessCorrelationId = randomUUID();
     const deletedDeviceId = randomUUID();
     await withDbAccessContext(SYSTEM_CTX, () => db.insert(logCorrelations).values([
       {
@@ -122,6 +123,7 @@ describe('fleet log current-site boundary — real PostgreSQL and Redis', () => 
         affectedDevices: [{ deviceId: 'not-a-uuid', hostname: 'malformed', count: 1 }], sampleLogs: [],
       },
       {
+        id: deviceLessCorrelationId,
         orgId: env.organization.id, ruleId: rule!.id, pattern: 'device-less-newest',
         firstSeen: now, lastSeen: new Date(now.getTime() + 3_000), occurrences: 1,
         affectedDevices: [], sampleLogs: [],
@@ -171,13 +173,24 @@ describe('fleet log current-site boundary — real PostgreSQL and Redis', () => 
     expect(trends.status, await trends.clone().text()).toBe(200);
     expect(JSON.stringify(await trends.json())).not.toContain(hiddenDeviceId);
 
-    // Hidden/deleted/mixed rows are removed before total and LIMIT, so the
-    // older visible correlation fills page one.
+    // Hidden/deleted/malformed/hidden-sample rows are removed before total AND
+    // before LIMIT, so page one is the newest row that survives the ceiling —
+    // not merely the newest row that happens to land on the page.
     const correlations = await request('/correlation?limit=1');
     expect(correlations.status, await correlations.clone().text()).toBe(200);
     await expect(correlations.json()).resolves.toMatchObject({
-      data: [{ id: visibleCorrelationId }], total: 1, limit: 1, offset: 0,
+      data: [{ id: deviceLessCorrelationId }], total: 2, limit: 1, offset: 0,
     });
+    // A correlation naming NO device names no device outside the ceiling, so it
+    // stays visible: the filter excludes out-of-ceiling devices, it does not
+    // require a non-empty affected list.
+    const allCorrelations = await request('/correlation?limit=50');
+    expect(allCorrelations.status, await allCorrelations.clone().text()).toBe(200);
+    const allCorrelationsBody = await allCorrelations.json() as { data: Array<{ id: string }>; total: number };
+    expect(allCorrelationsBody.data.map((row) => row.id)).toEqual([
+      deviceLessCorrelationId, visibleCorrelationId,
+    ]);
+    expect(allCorrelationsBody.total).toBe(2);
     const saved = await request('/queries');
     expect(saved.status, await saved.clone().text()).toBe(200);
     await expect(saved.json()).resolves.toMatchObject({ data: [{ filters: {
@@ -260,8 +273,11 @@ describe('fleet log current-site boundary — real PostgreSQL and Redis', () => 
     });
     expect(afterMove.status).toBe(200);
     expect((await afterMove.json() as { results: unknown[] }).results).toHaveLength(0);
+    // Every device-BEARING correlation is now out of ceiling. The device-less
+    // row survives because it references no device at all — see the limit=50
+    // assertion above.
     await expect((await request('/correlation?limit=1')).json()).resolves.toMatchObject({
-      data: [], total: 0, limit: 1, offset: 0,
+      data: [{ id: deviceLessCorrelationId }], total: 1, limit: 1, offset: 0,
     });
 
     // Deterministic TOCTOU regression: carry the pre-move device-id snapshot

--- a/apps/api/src/jobs/logCorrelation.test.ts
+++ b/apps/api/src/jobs/logCorrelation.test.ts
@@ -34,6 +34,10 @@ vi.mock('../services/sentry', () => ({
   captureException: vi.fn(),
 }));
 
+vi.mock('../services/logReadAuthority', () => ({
+  revalidateLogReadAuthority: vi.fn(),
+}));
+
 vi.mock('../db', () => ({
   withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
@@ -41,10 +45,25 @@ vi.mock('../db', () => ({
 import {
   enqueueAdHocPatternCorrelationDetection,
   enqueueLogCorrelationDetection,
+  processLogCorrelationJob,
   shutdownLogCorrelationWorker,
 } from './logCorrelation';
+import { detectPatternCorrelation } from '../services/logSearch';
+import { revalidateLogReadAuthority } from '../services/logReadAuthority';
 
 describe('log correlation queue helpers', () => {
+  const authority = {
+    version: 1 as const,
+    requesterId: 'user-1',
+    partnerId: 'partner-1',
+    orgId: 'org-1',
+    scope: 'organization' as const,
+    siteIds: null,
+    authEpoch: 1,
+    mfaEpoch: 1,
+    mfaClaim: true,
+    fingerprint: 'fingerprint',
+  };
   beforeEach(async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-03-31T12:00:00.000Z'));
@@ -82,9 +101,37 @@ describe('log correlation queue helpers', () => {
       orgId: 'org-1',
       pattern: 'powershell',
       minDevices: 2,
+      authority,
     });
 
     expect(jobId).toBe('existing-pattern-job');
     expect(addMock).not.toHaveBeenCalled();
+  });
+
+  it('fails closed for a legacy or malformed queued pattern job', async () => {
+    vi.mocked(revalidateLogReadAuthority).mockResolvedValue(null);
+    await expect(processLogCorrelationJob({
+      type: 'pattern', orgId: 'org-1', pattern: 'powershell', isRegex: false,
+      queuedAt: new Date().toISOString(), authority,
+    })).rejects.toThrow('authority is no longer valid');
+    expect(detectPatternCorrelation).not.toHaveBeenCalled();
+    await expect(processLogCorrelationJob({
+      type: 'pattern', orgId: 'org-1', pattern: '', isRegex: false,
+      queuedAt: new Date().toISOString(), authority,
+    })).rejects.toThrow('job is malformed');
+  });
+
+  it('passes the live current-device ceiling to pattern detection', async () => {
+    vi.mocked(revalidateLogReadAuthority).mockResolvedValue({
+      authority, allowedDeviceIds: ['device-visible'], allowedSiteIds: ['site-visible'],
+    });
+    vi.mocked(detectPatternCorrelation).mockResolvedValue(null);
+    await expect(processLogCorrelationJob({
+      type: 'pattern', orgId: 'org-1', pattern: 'powershell', isRegex: false,
+      queuedAt: new Date().toISOString(), authority,
+    })).resolves.toMatchObject({ mode: 'pattern', detected: false });
+    expect(detectPatternCorrelation).toHaveBeenCalledWith(expect.objectContaining({
+      orgId: 'org-1', allowedDeviceIds: ['device-visible'], allowedSiteIds: ['site-visible'],
+    }));
   });
 });

--- a/apps/api/src/jobs/logCorrelation.ts
+++ b/apps/api/src/jobs/logCorrelation.ts
@@ -4,6 +4,10 @@ import { getBullMQConnection } from '../services/redis';
 import { detectPatternCorrelation, runCorrelationRules } from '../services/logSearch';
 import { captureException } from '../services/sentry';
 import { isReusableState } from '../services/bullmqUtils';
+import {
+  revalidateLogReadAuthority,
+  type LogReadAuthorityEnvelope,
+} from '../services/logReadAuthority';
 import * as dbModule from '../db';
 import { attachWorkerObservability } from './workerObservability';
 
@@ -35,9 +39,23 @@ type DetectPatternJobData = {
   minOccurrences?: number;
   sampleLimit?: number;
   queuedAt: string;
+  authority: LogReadAuthorityEnvelope;
 };
 
 type CorrelationJobData = DetectRulesJobData | DetectPatternJobData;
+
+function isValidPatternJobData(data: DetectPatternJobData): boolean {
+  const optionalInteger = (value: unknown, min: number, max: number) => value === undefined
+    || (Number.isInteger(value) && Number(value) >= min && Number(value) <= max);
+  return typeof data.orgId === 'string' && data.orgId.length > 0
+    && typeof data.pattern === 'string' && data.pattern.length > 0 && data.pattern.length <= 1000
+    && typeof data.isRegex === 'boolean'
+    && typeof data.queuedAt === 'string' && Number.isFinite(Date.parse(data.queuedAt))
+    && optionalInteger(data.timeWindowSeconds, 30, 86_400)
+    && optionalInteger(data.minDevices, 1, 200)
+    && optionalInteger(data.minOccurrences, 1, 50_000)
+    && optionalInteger(data.sampleLimit, 1, 1_000);
+}
 
 export interface LogCorrelationDetectionJobSnapshot {
   id: string;
@@ -75,43 +93,49 @@ export function getLogCorrelationQueue(): Queue<CorrelationJobData> {
 export function createLogCorrelationWorker(): Worker<CorrelationJobData> {
   return new Worker<CorrelationJobData>(
     LOG_CORRELATION_QUEUE,
-    async (job: Job<CorrelationJobData>) => {
-      return runWithSystemDbAccess(async () => {
-        if (job.data.type === 'pattern') {
-          const detection = await detectPatternCorrelation({
-            orgId: job.data.orgId,
-            pattern: job.data.pattern,
-            isRegex: job.data.isRegex,
-            minDevices: job.data.minDevices,
-            minOccurrences: job.data.minOccurrences,
-            sampleLimit: job.data.sampleLimit,
-            timeWindowSeconds: job.data.timeWindowSeconds,
-          });
-          return {
-            mode: 'pattern',
-            detected: Boolean(detection),
-            result: detection,
-            queuedAt: job.data.queuedAt,
-          };
-        }
-
-        const detections = await runCorrelationRules({
-          orgId: job.data.orgId,
-          ruleIds: job.data.ruleIds,
-        });
-
-        return {
-          mode: 'rules',
-          detections: detections.length,
-          queuedAt: job.data.queuedAt,
-        };
-      });
-    },
+    async (job: Job<CorrelationJobData>) => processLogCorrelationJob(job.data),
     {
       connection: getBullMQConnection(),
       concurrency: 1,
     }
   );
+}
+
+export async function processLogCorrelationJob(data: CorrelationJobData): Promise<unknown> {
+  return runWithSystemDbAccess(async () => {
+    if (data.type === 'pattern') {
+      if (!isValidPatternJobData(data)) {
+        throw new Error('Log detection job is malformed');
+      }
+      const live = await revalidateLogReadAuthority(data.authority);
+      if (!live || live.authority.orgId !== data.orgId) {
+        throw new Error('Log detection authority is no longer valid');
+      }
+      const detection = await detectPatternCorrelation({
+        orgId: data.orgId,
+        pattern: data.pattern,
+        isRegex: data.isRegex,
+        minDevices: data.minDevices,
+        minOccurrences: data.minOccurrences,
+        sampleLimit: data.sampleLimit,
+        timeWindowSeconds: data.timeWindowSeconds,
+        allowedDeviceIds: live.allowedDeviceIds,
+        allowedSiteIds: live.allowedSiteIds,
+      });
+      return {
+        mode: 'pattern',
+        detected: Boolean(detection),
+        result: detection,
+        queuedAt: data.queuedAt,
+      };
+    }
+
+    const detections = await runCorrelationRules({
+      orgId: data.orgId,
+      ruleIds: data.ruleIds,
+    });
+    return { mode: 'rules', detections: detections.length, queuedAt: data.queuedAt };
+  });
 }
 
 async function scheduleCorrelationDetection(): Promise<void> {
@@ -222,6 +246,7 @@ export async function enqueueAdHocPatternCorrelationDetection(options: {
   minDevices?: number;
   minOccurrences?: number;
   sampleLimit?: number;
+  authority: LogReadAuthorityEnvelope;
 }): Promise<string> {
   const queue = getLogCorrelationQueue();
   const slot = Math.floor(Date.now() / ON_DEMAND_DEDUPE_WINDOW_MS).toString(36);
@@ -235,6 +260,7 @@ export async function enqueueAdHocPatternCorrelationDetection(options: {
       minDevices: options.minDevices,
       minOccurrences: options.minOccurrences,
       sampleLimit: options.sampleLimit,
+      authorityFingerprint: options.authority.fingerprint,
     })),
     slot,
   ].join(':');
@@ -264,6 +290,7 @@ export async function enqueueAdHocPatternCorrelationDetection(options: {
       minOccurrences: options.minOccurrences,
       sampleLimit: options.sampleLimit,
       queuedAt: new Date().toISOString(),
+      authority: options.authority,
     },
     {
       jobId,

--- a/apps/api/src/routes/logs.test.ts
+++ b/apps/api/src/routes/logs.test.ts
@@ -83,7 +83,12 @@ vi.mock('../jobs/logCorrelation', () => ({
   getLogCorrelationDetectionJob: getLogCorrelationDetectionJobMock,
 }));
 
+const { LogReadAuthorityDeniedErrorStub } = vi.hoisted(() => ({
+  LogReadAuthorityDeniedErrorStub: class LogReadAuthorityDeniedError extends Error {},
+}));
+
 vi.mock('../services/logReadAuthority', () => ({
+  LogReadAuthorityDeniedError: LogReadAuthorityDeniedErrorStub,
   captureLogReadAuthority: captureLogReadAuthorityMock,
   correlationResultWithinCurrentDeviceCeiling: correlationResultWithinCurrentDeviceCeilingMock,
   currentLogReadSiteCeiling: vi.fn((auth, orgId) => auth.canAccessOrg(orgId)
@@ -148,6 +153,20 @@ vi.mock('../middleware/auth', () => ({
 import { logsRoutes } from './logs';
 import { authMiddleware } from '../middleware/auth';
 import { db } from '../db';
+
+/**
+ * Walk a Drizzle SQL tree and concatenate every string it contains. The schema
+ * is module-mocked with plain strings here, so PgDialect cannot compile the
+ * condition — this asserts on the raw fragments instead.
+ */
+function collectSqlText(node: unknown, seen = new WeakSet<object>()): string {
+  if (typeof node === 'string') return node;
+  if (!node || typeof node !== 'object') return '';
+  if (seen.has(node)) return '';
+  seen.add(node);
+  const values = Array.isArray(node) ? node : Object.values(node as Record<string, unknown>);
+  return values.map((value) => collectSqlText(value, seen)).join(' ');
+}
 
 describe('logs routes', () => {
   let app: Hono;
@@ -245,6 +264,47 @@ describe('logs routes', () => {
       deviceIds: ['aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'],
       allowedDeviceIds: [],
     }));
+  });
+
+  it('emits the correlation device-existence filter only for a site-restricted caller', async () => {
+    // JSONB affected/sample device ids carry no FK, so a deleted device leaves
+    // them dangling. For an unrestricted caller the filter would permanently
+    // hide those historical correlations — data loss, not tenancy enforcement.
+    const captureCorrelationWhere = async (allowedSiteIds: string[] | undefined) => {
+      const wheres: unknown[] = [];
+      const chain: Record<string, unknown> = {};
+      for (const method of ['from', 'leftJoin', 'orderBy', 'limit', 'offset']) {
+        chain[method] = vi.fn(() => chain);
+      }
+      chain.where = vi.fn((condition: unknown) => { wheres.push(condition); return chain; });
+      chain.then = (resolve: (rows: unknown[]) => unknown) => Promise.resolve([]).then(resolve);
+      vi.mocked(db.select).mockReturnValue(chain as never);
+
+      vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+        c.set('auth', {
+          scope: 'organization',
+          orgId: '11111111-1111-1111-1111-111111111111',
+          accessibleOrgIds: ['11111111-1111-1111-1111-111111111111'],
+          user: { id: 'user-1' },
+          allowedSiteIds,
+          canAccessOrg: (orgId: string) => orgId === '11111111-1111-1111-1111-111111111111',
+          orgCondition: () => undefined,
+        });
+        return next();
+      });
+
+      const res = await app.request('/logs/correlation');
+      expect(res.status).toBe(200);
+      expect(wheres.length).toBeGreaterThan(0);
+      return collectSqlText(wheres);
+    };
+
+    expect(await captureCorrelationWhere(undefined)).not.toContain('jsonb_array_elements');
+    const restricted = await captureCorrelationWhere(['44444444-4444-4444-8444-444444444444']);
+    expect(restricted).toContain('jsonb_array_elements');
+    expect(restricted).toContain('current_correlation_device');
+    // An empty affected/sample list trivially names no out-of-ceiling device.
+    expect(restricted).not.toContain('jsonb_array_length');
   });
 
   it('applies the same current ceiling to aggregation and trends', async () => {

--- a/apps/api/src/routes/logs.test.ts
+++ b/apps/api/src/routes/logs.test.ts
@@ -147,6 +147,7 @@ vi.mock('../middleware/auth', () => ({
 
 import { logsRoutes } from './logs';
 import { authMiddleware } from '../middleware/auth';
+import { db } from '../db';
 
 describe('logs routes', () => {
   let app: Hono;
@@ -472,6 +473,110 @@ describe('logs routes', () => {
     expect(runCorrelationRulesMock).toHaveBeenCalledWith(
       expect.objectContaining({ orgId: '11111111-1111-1111-1111-111111111111' }),
     );
+  });
+
+  it.each([
+    {
+      label: 'partner',
+      auth: {
+        scope: 'partner',
+        orgId: null,
+        accessibleOrgIds: ['11111111-1111-1111-1111-111111111111'],
+        partnerId: '33333333-3333-4333-8333-333333333333',
+        user: { id: 'partner-user' },
+      },
+      body: {},
+    },
+    {
+      label: 'system',
+      auth: {
+        scope: 'system',
+        orgId: null,
+        accessibleOrgIds: null,
+        user: { id: 'system-user', isPlatformAdmin: true },
+      },
+      body: { orgId: '11111111-1111-1111-1111-111111111111' },
+    },
+  ])('preserves unrestricted $label rules execution', async ({ auth, body }) => {
+    vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+      c.set('auth', {
+        ...auth,
+        canAccessOrg: () => true,
+        orgCondition: () => undefined,
+      });
+      return next();
+    });
+
+    const res = await app.request('/logs/correlation/detect', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+
+    expect(res.status).toBe(200);
+    expect(runCorrelationRulesMock).toHaveBeenCalledOnce();
+    expect(runCorrelationRulesMock).toHaveBeenCalledWith({
+      orgId: '11111111-1111-1111-1111-111111111111',
+      ruleIds: undefined,
+    });
+  });
+
+  it.each([
+    { label: 'selected-site', allowedSiteIds: ['aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'] },
+    { label: 'empty-site', allowedSiteIds: [] },
+  ])('denies $label callers before persistent rules execution', async ({ allowedSiteIds }) => {
+    vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+      c.set('auth', {
+        scope: 'organization',
+        orgId: '11111111-1111-1111-1111-111111111111',
+        accessibleOrgIds: ['11111111-1111-1111-1111-111111111111'],
+        allowedSiteIds,
+        user: { id: 'user-1' },
+        canAccessOrg: (orgId: string) => orgId === '11111111-1111-1111-1111-111111111111',
+        orgCondition: () => undefined,
+      });
+      return next();
+    });
+
+    const res = await app.request('/logs/correlation/detect', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        ruleIds: ['22222222-2222-4222-8222-222222222222'],
+      }),
+    });
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'Access denied' });
+    expect(runCorrelationRulesMock).not.toHaveBeenCalled();
+    expect(detectPatternCorrelationMock).not.toHaveBeenCalled();
+    expect(enqueueAdHocPatternCorrelationDetectionMock).not.toHaveBeenCalled();
+    expect(vi.mocked(db.select)).not.toHaveBeenCalled();
+  });
+
+  it('keeps selected-site ad-hoc pattern detection on the separately scoped path', async () => {
+    vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+      c.set('auth', {
+        scope: 'organization',
+        orgId: '11111111-1111-1111-1111-111111111111',
+        accessibleOrgIds: ['11111111-1111-1111-1111-111111111111'],
+        allowedSiteIds: ['aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'],
+        user: { id: 'user-1' },
+        canAccessOrg: (orgId: string) => orgId === '11111111-1111-1111-1111-111111111111',
+        orgCondition: () => undefined,
+      });
+      return next();
+    });
+
+    const res = await app.request('/logs/correlation/detect', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ pattern: 'connection reset by peer' }),
+    });
+
+    expect(res.status).toBe(202);
+    expect(enqueueAdHocPatternCorrelationDetectionMock).toHaveBeenCalledOnce();
+    expect(runCorrelationRulesMock).not.toHaveBeenCalled();
   });
 
   it('GET /logs/queries returns list of saved queries', async () => {

--- a/apps/api/src/routes/logs.test.ts
+++ b/apps/api/src/routes/logs.test.ts
@@ -35,6 +35,18 @@ const { getLogCorrelationDetectionJobMock } = vi.hoisted(() => ({
   getLogCorrelationDetectionJobMock: vi.fn(),
 }));
 
+const {
+  captureLogReadAuthorityMock,
+  correlationResultWithinCurrentDeviceCeilingMock,
+  resolveCurrentLogReadDeviceIdsMock,
+  revalidateLogReadAuthorityMock,
+} = vi.hoisted(() => ({
+  captureLogReadAuthorityMock: vi.fn(),
+  correlationResultWithinCurrentDeviceCeilingMock: vi.fn(),
+  resolveCurrentLogReadDeviceIdsMock: vi.fn(),
+  revalidateLogReadAuthorityMock: vi.fn(),
+}));
+
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
   withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
@@ -45,6 +57,7 @@ vi.mock('../db', () => ({
 }));
 
 vi.mock('../db/schema', () => ({
+  devices: { id: 'deviceId', orgId: 'deviceOrgId', siteId: 'deviceSiteId' },
   logCorrelations: {
     id: 'id',
     orgId: 'orgId',
@@ -68,6 +81,22 @@ vi.mock('../db/schema', () => ({
 vi.mock('../jobs/logCorrelation', () => ({
   enqueueAdHocPatternCorrelationDetection: enqueueAdHocPatternCorrelationDetectionMock,
   getLogCorrelationDetectionJob: getLogCorrelationDetectionJobMock,
+}));
+
+vi.mock('../services/logReadAuthority', () => ({
+  captureLogReadAuthority: captureLogReadAuthorityMock,
+  correlationResultWithinCurrentDeviceCeiling: correlationResultWithinCurrentDeviceCeilingMock,
+  currentLogReadSiteCeiling: vi.fn((auth, orgId) => auth.canAccessOrg(orgId)
+    ? (auth.allowedSiteIds ?? null)
+    : []),
+  intersectLogReadSiteCeilings: vi.fn((left, right) => {
+    if (left === null) return right;
+    if (right === null) return left;
+    const rightSet = new Set(right);
+    return left.filter((id: string) => rightSet.has(id));
+  }),
+  resolveCurrentLogReadDeviceIds: resolveCurrentLogReadDeviceIdsMock,
+  revalidateLogReadAuthority: revalidateLogReadAuthorityMock,
 }));
 
 vi.mock('../services/logSearch', () => ({
@@ -158,6 +187,14 @@ describe('logs routes', () => {
     runCorrelationRulesMock.mockResolvedValue([]);
     listSavedLogSearchQueriesMock.mockResolvedValue([]);
     createSavedLogSearchQueryMock.mockResolvedValue({ id: 'query-1' });
+    resolveCurrentLogReadDeviceIdsMock.mockResolvedValue(null);
+    captureLogReadAuthorityMock.mockReturnValue({ requesterId: 'user-1', orgId: '11111111-1111-1111-1111-111111111111' });
+    revalidateLogReadAuthorityMock.mockResolvedValue({
+      authority: { requesterId: 'user-1', orgId: '11111111-1111-1111-1111-111111111111' },
+      allowedDeviceIds: null,
+      allowedSiteIds: null,
+    });
+    correlationResultWithinCurrentDeviceCeilingMock.mockResolvedValue(true);
   });
 
   it('applies saved query filters and request overrides in POST /logs/search', async () => {
@@ -191,6 +228,38 @@ describe('logs routes', () => {
       }),
     );
     expect(updateSavedSearchRunStatsMock).toHaveBeenCalledWith('22222222-2222-2222-2222-222222222222');
+  });
+
+  it('applies a deny-all current site ceiling after saved filters are merged', async () => {
+    resolveCurrentLogReadDeviceIdsMock.mockResolvedValue([]);
+    getSavedLogSearchQueryMock.mockResolvedValue({
+      filters: { deviceIds: ['aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'] },
+    });
+    const res = await app.request('/logs/search', {
+      method: 'POST', headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ savedQueryId: '22222222-2222-4222-8222-222222222222' }),
+    });
+    expect(res.status).toBe(200);
+    expect(searchFleetLogsMock).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      deviceIds: ['aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'],
+      allowedDeviceIds: [],
+    }));
+  });
+
+  it('applies the same current ceiling to aggregation and trends', async () => {
+    resolveCurrentLogReadDeviceIdsMock
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce(['visible-device']);
+    getLogAggregationMock.mockResolvedValue({ data: [] });
+    getLogTrendsMock.mockResolvedValue({ data: [] });
+    expect((await app.request('/logs/aggregation')).status).toBe(200);
+    expect(getLogAggregationMock).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      allowedDeviceIds: [],
+    }));
+    expect((await app.request('/logs/trends')).status).toBe(200);
+    expect(getLogTrendsMock).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      allowedDeviceIds: ['visible-device'],
+    }));
   });
 
   it('queues ad-hoc correlation detection jobs and returns 202', async () => {
@@ -253,6 +322,7 @@ describe('logs routes', () => {
         pattern: 'panic',
         isRegex: false,
         queuedAt: '2026-02-21T19:00:00.000Z',
+        authority: { requesterId: 'user-1' },
       },
       result: { mode: 'pattern', detected: true },
       failedReason: null,
@@ -268,7 +338,22 @@ describe('logs routes', () => {
     expect(body.result.detected).toBe(true);
   });
 
-  it('returns 403 for inaccessible detection job org', async () => {
+  it('returns an opaque 404 when a completed job contains a newly hidden device', async () => {
+    getLogCorrelationDetectionJobMock.mockResolvedValue({
+      id: 'job-hidden', name: 'pattern-detect', state: 'completed',
+      data: {
+        type: 'pattern', orgId: '11111111-1111-1111-1111-111111111111',
+        pattern: 'panic', isRegex: false, queuedAt: '2026-02-21T19:00:00.000Z',
+        authority: { requesterId: 'user-1' },
+      },
+      result: { mode: 'pattern', detected: true }, failedReason: null,
+      attemptsMade: 1, processedOn: null, finishedOn: null,
+    });
+    correlationResultWithinCurrentDeviceCeilingMock.mockResolvedValue(false);
+    expect((await app.request('/logs/correlation/detect/job-hidden')).status).toBe(404);
+  });
+
+  it('returns an opaque 404 for a detection job not bound to the requester', async () => {
     getLogCorrelationDetectionJobMock.mockResolvedValue({
       id: 'job-2',
       name: 'pattern-detect',
@@ -279,6 +364,7 @@ describe('logs routes', () => {
         pattern: 'panic',
         isRegex: false,
         queuedAt: '2026-02-21T19:00:00.000Z',
+        authority: { requesterId: 'other-user' },
       },
       result: null,
       failedReason: null,
@@ -288,7 +374,7 @@ describe('logs routes', () => {
     });
 
     const res = await app.request('/logs/correlation/detect/job-2');
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(404);
   });
 
   it('allows system scope to delete a non-shared saved query', async () => {
@@ -398,6 +484,51 @@ describe('logs routes', () => {
     const body = await res.json();
     expect(body.data).toHaveLength(1);
     expect(body.data[0].id).toBe('q-1');
+  });
+
+  it('removes hidden saved-query scope metadata for a restricted reader', async () => {
+    vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+      c.set('auth', {
+        scope: 'organization', orgId: '11111111-1111-1111-1111-111111111111',
+        allowedSiteIds: ['22222222-2222-4222-8222-222222222222'],
+        user: { id: 'user-1' }, canAccessOrg: () => true, orgCondition: () => undefined,
+      });
+      return next();
+    });
+    resolveCurrentLogReadDeviceIdsMock.mockResolvedValue(['visible-device']);
+    listSavedLogSearchQueriesMock.mockResolvedValue([{
+      id: 'query-1', filters: {
+        deviceIds: ['visible-device', 'hidden-device'],
+        siteIds: ['22222222-2222-4222-8222-222222222222', '33333333-3333-4333-8333-333333333333'],
+      },
+    }]);
+    const res = await app.request('/logs/queries');
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ data: [{ filters: {
+      deviceIds: ['visible-device'], siteIds: ['22222222-2222-4222-8222-222222222222'],
+    } }] });
+  });
+
+  it('preserves an explicit deny-all array when every saved target is hidden', async () => {
+    vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+      c.set('auth', {
+        scope: 'organization', orgId: '11111111-1111-1111-1111-111111111111',
+        allowedSiteIds: ['22222222-2222-4222-8222-222222222222'],
+        user: { id: 'user-1' }, canAccessOrg: () => true, orgCondition: () => undefined,
+      });
+      return next();
+    });
+    resolveCurrentLogReadDeviceIdsMock.mockResolvedValue(['visible-device']);
+    listSavedLogSearchQueriesMock.mockResolvedValue([{
+      id: 'query-hidden', filters: {
+        deviceIds: ['hidden-device'], siteIds: ['33333333-3333-4333-8333-333333333333'],
+      },
+    }]);
+    const res = await app.request('/logs/queries');
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ data: [{ filters: {
+      deviceIds: [], siteIds: [],
+    } }] });
   });
 
   it('POST /logs/queries creates a saved query and returns 201', async () => {

--- a/apps/api/src/routes/logs.ts
+++ b/apps/api/src/routes/logs.ts
@@ -429,6 +429,14 @@ logsRoutes.post(
       }
 
       // Rules-based path: orgId is required (no pattern provided means broad rule run)
+      // Correlation-rule results are persisted as one org-wide snapshot per rule
+      // and can create alerts. A site-scoped result cannot safely share that state
+      // with the scheduled global runner, so only an unrestricted caller may
+      // initiate this persistent path. A defined empty allowlist is restricted too.
+      if (auth.allowedSiteIds !== undefined) {
+        return c.json({ error: 'Access denied' }, 403);
+      }
+
       const orgId = resolveSingleOrgId(auth, body.orgId);
       if (!orgId) {
         return c.json({ error: 'orgId is required for this scope' }, 400);

--- a/apps/api/src/routes/logs.ts
+++ b/apps/api/src/routes/logs.ts
@@ -29,6 +29,7 @@ import {
   correlationResultWithinCurrentDeviceCeiling,
   currentLogReadSiteCeiling,
   intersectLogReadSiteCeilings,
+  LogReadAuthorityDeniedError,
   resolveCurrentLogReadDeviceIds,
   revalidateLogReadAuthority,
 } from '../services/logReadAuthority';
@@ -383,7 +384,15 @@ logsRoutes.post(
           return c.json({ error: 'orgId is required for this scope' }, 400);
         }
 
-        const authority = captureLogReadAuthority(auth, orgId);
+        let authority;
+        try {
+          authority = captureLogReadAuthority(auth, orgId);
+        } catch (authorityError) {
+          if (authorityError instanceof LogReadAuthorityDeniedError) {
+            return c.json({ error: 'Access denied' }, 403);
+          }
+          throw authorityError;
+        }
         try {
           const jobId = await enqueueAdHocPatternCorrelationDetection({
             orgId,
@@ -492,34 +501,41 @@ logsRoutes.get(
     if (correlationSiteIds?.length === 0) {
       return c.json({ data: [], limit: query.limit ?? 100, offset: query.offset ?? 0, total: 0 });
     }
-    const currentDeviceExists = (element: SQL) => sql`EXISTS (
-      SELECT 1 FROM ${devices} AS current_correlation_device
-      WHERE current_correlation_device.id::text = ${element}->>'deviceId'
-        AND current_correlation_device.org_id = ${logCorrelations.orgId}
-        ${correlationSiteIds === null
-          ? sql``
-          : sql`AND current_correlation_device.site_id IN (${sql.join(correlationSiteIds.map((id) => sql`${id}`), sql`, `)})`}
-    )`;
-    // Correlations are indivisible historical resources. Validate every
+    // Correlations are indivisible historical resources: validate every
     // affected/sample device against its current row inside the list/count
     // statement, before pagination. Text comparison makes malformed UUIDs a
     // clean non-match rather than a cast error, and avoids a fleet-sized bind
     // list or a stale pre-query device snapshot.
-    conditions.push(sql`
-      jsonb_typeof(${logCorrelations.affectedDevices}) = 'array'
-      AND jsonb_array_length(${logCorrelations.affectedDevices}) > 0
-      AND jsonb_typeof(${logCorrelations.sampleLogs}) = 'array'
-      AND NOT EXISTS (
-        SELECT 1
-        FROM jsonb_array_elements(${logCorrelations.affectedDevices}) AS affected(device)
-        WHERE NOT (${currentDeviceExists(sql`affected.device`)})
-      )
-      AND NOT EXISTS (
-        SELECT 1
-        FROM jsonb_array_elements(${logCorrelations.sampleLogs}) AS sample(log)
-        WHERE NOT (${currentDeviceExists(sql`sample.log`)})
-      )
-    `);
+    //
+    // Emitted ONLY for a site-restricted caller. The affected/sample device ids
+    // live in JSONB with no FK, so a device delete leaves them dangling — for an
+    // unrestricted caller this filter would permanently hide every historical
+    // correlation that names a since-deleted device, which is silent data loss,
+    // not tenancy enforcement. Org isolation on this list is RLS's job.
+    if (correlationSiteIds !== null) {
+      const currentDeviceExists = (element: SQL) => sql`EXISTS (
+        SELECT 1 FROM ${devices} AS current_correlation_device
+        WHERE current_correlation_device.id::text = ${element}->>'deviceId'
+          AND current_correlation_device.org_id = ${logCorrelations.orgId}
+          AND current_correlation_device.site_id IN (${sql.join(correlationSiteIds.map((id) => sql`${id}`), sql`, `)})
+      )`;
+      // No jsonb_array_length floor: an empty affected/sample list trivially
+      // satisfies "names no device outside my ceiling" and must stay visible.
+      conditions.push(sql`
+        jsonb_typeof(${logCorrelations.affectedDevices}) = 'array'
+        AND jsonb_typeof(${logCorrelations.sampleLogs}) = 'array'
+        AND NOT EXISTS (
+          SELECT 1
+          FROM jsonb_array_elements(${logCorrelations.affectedDevices}) AS affected(device)
+          WHERE NOT (${currentDeviceExists(sql`affected.device`)})
+        )
+        AND NOT EXISTS (
+          SELECT 1
+          FROM jsonb_array_elements(${logCorrelations.sampleLogs}) AS sample(log)
+          WHERE NOT (${currentDeviceExists(sql`sample.log`)})
+        )
+      `);
+    }
 
     const limit = query.limit ?? 100;
     const offset = query.offset ?? 0;

--- a/apps/api/src/routes/logs.ts
+++ b/apps/api/src/routes/logs.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 import { and, desc, eq, sql, type SQL } from 'drizzle-orm';
 
 import { db } from '../db';
-import { logCorrelations, logCorrelationRules } from '../db/schema';
+import { devices, logCorrelations, logCorrelationRules } from '../db/schema';
 import { enqueueAdHocPatternCorrelationDetection, getLogCorrelationDetectionJob } from '../jobs/logCorrelation';
 import { authMiddleware, requireMfa, requirePermission, requireScope } from '../middleware/auth';
 import { PERMISSIONS } from '../services/permissions';
@@ -24,6 +24,14 @@ import {
   type LogSearchInput,
   updateSavedSearchRunStats,
 } from '../services/logSearch';
+import {
+  captureLogReadAuthority,
+  correlationResultWithinCurrentDeviceCeiling,
+  currentLogReadSiteCeiling,
+  intersectLogReadSiteCeilings,
+  resolveCurrentLogReadDeviceIds,
+  revalidateLogReadAuthority,
+} from '../services/logReadAuthority';
 
 const levelSchema = z.enum(['info', 'warning', 'error', 'critical']);
 const categorySchema = z.enum(['security', 'hardware', 'application', 'system']);
@@ -159,6 +167,25 @@ function mapCorrelationJobState(state: string): 'queued' | 'running' | 'complete
   return 'queued';
 }
 
+function sanitizeSavedQueryScope<T extends { filters: LogSearchInput }>(
+  query: T,
+  allowedDeviceIds: string[] | null,
+  allowedSiteIds: string[] | undefined,
+): T {
+  if (allowedDeviceIds === null && allowedSiteIds === undefined) return query;
+  const allowedDevices = new Set(allowedDeviceIds ?? []);
+  const allowedSites = new Set(allowedSiteIds ?? []);
+  return {
+    ...query,
+    filters: {
+      ...query.filters,
+      deviceIds: query.filters.deviceIds?.filter((id) => allowedDevices.has(id)),
+      siteIds: query.filters.siteIds?.filter((id) => allowedSites.has(id)),
+      allowedDeviceIds: undefined,
+    },
+  };
+}
+
 export const logsRoutes = new Hono();
 const requireLogRead = requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action);
 const requireLogWrite = requirePermission(PERMISSIONS.DEVICES_WRITE.resource, PERMISSIONS.DEVICES_WRITE.action);
@@ -185,6 +212,13 @@ logsRoutes.post(
         }
         filters = mergeSavedLogSearchFilters(saved.filters, inlineFilters);
       }
+
+      // Apply the live authorization ceiling last: neither an inline filter nor
+      // saved JSON may widen it. [] deliberately reaches logSearch as deny-all.
+      filters.allowedDeviceIds = await resolveCurrentLogReadDeviceIds(auth);
+      filters.allowedSiteIds = auth.allowedSiteIds === undefined
+        ? null
+        : Array.from(new Set(auth.allowedSiteIds)).sort();
 
       const result = await searchFleetLogs(auth, filters);
 
@@ -219,8 +253,20 @@ logsRoutes.get(
         return c.json({ error: 'Detection job not found' }, 404);
       }
 
-      if (!auth.canAccessOrg(job.data.orgId)) {
-        return c.json({ error: 'Access denied for requested org' }, 403);
+      if (job.data.authority?.requesterId !== auth.user.id || !auth.canAccessOrg(job.data.orgId)) {
+        return c.json({ error: 'Detection job not found' }, 404);
+      }
+      const live = await revalidateLogReadAuthority(job.data.authority);
+      const requestSiteIds = currentLogReadSiteCeiling(auth, job.data.orgId);
+      const disclosureSiteIds = live
+        ? intersectLogReadSiteCeilings(live.allowedSiteIds, requestSiteIds)
+        : [];
+      if (!live || live.authority.orgId !== job.data.orgId
+        || disclosureSiteIds?.length === 0
+        || !await correlationResultWithinCurrentDeviceCeiling(
+          job.result, job.data.orgId, disclosureSiteIds,
+        )) {
+        return c.json({ error: 'Detection job not found' }, 404);
       }
 
       const status = mapCorrelationJobState(job.state);
@@ -255,6 +301,10 @@ logsRoutes.get(
     const query = c.req.valid('query');
 
     try {
+      const allowedDeviceIds = await resolveCurrentLogReadDeviceIds(auth);
+      const allowedSiteIds = auth.allowedSiteIds === undefined
+        ? null
+        : Array.from(new Set(auth.allowedSiteIds)).sort();
       const payload = await getLogAggregation(auth, {
         start: query.start,
         end: query.end,
@@ -266,6 +316,8 @@ logsRoutes.get(
         deviceIds: parseUuidCsv(query.deviceIds),
         siteIds: parseUuidCsv(query.siteIds),
         limit: query.limit,
+        allowedDeviceIds,
+        allowedSiteIds,
       });
 
       return c.json(payload);
@@ -288,6 +340,10 @@ logsRoutes.get(
     const query = c.req.valid('query');
 
     try {
+      const allowedDeviceIds = await resolveCurrentLogReadDeviceIds(auth);
+      const allowedSiteIds = auth.allowedSiteIds === undefined
+        ? null
+        : Array.from(new Set(auth.allowedSiteIds)).sort();
       const payload = await getLogTrends(auth, {
         start: query.start,
         end: query.end,
@@ -296,6 +352,8 @@ logsRoutes.get(
         deviceIds: parseUuidCsv(query.deviceIds),
         siteIds: parseUuidCsv(query.siteIds),
         limit: query.limit,
+        allowedDeviceIds,
+        allowedSiteIds,
       });
 
       return c.json(payload);
@@ -325,6 +383,7 @@ logsRoutes.post(
           return c.json({ error: 'orgId is required for this scope' }, 400);
         }
 
+        const authority = captureLogReadAuthority(auth, orgId);
         try {
           const jobId = await enqueueAdHocPatternCorrelationDetection({
             orgId,
@@ -333,6 +392,7 @@ logsRoutes.post(
             timeWindowSeconds: body.timeWindow,
             minDevices: body.minDevices,
             minOccurrences: body.minOccurrences,
+            authority,
           });
 
           return c.json({
@@ -343,6 +403,10 @@ logsRoutes.post(
           }, 202);
         } catch (queueError) {
           console.warn('[logs/correlation/detect] Queue unavailable, running inline fallback:', queueError);
+          const live = await revalidateLogReadAuthority(authority);
+          if (!live) {
+            return c.json({ error: 'Detection authority is no longer valid' }, 403);
+          }
           const result = await detectPatternCorrelation({
             orgId,
             pattern: body.pattern,
@@ -350,6 +414,8 @@ logsRoutes.post(
             timeWindowSeconds: body.timeWindow,
             minDevices: body.minDevices,
             minOccurrences: body.minOccurrences,
+            allowedDeviceIds: live.allowedDeviceIds,
+            allowedSiteIds: live.allowedSiteIds,
           });
 
           return c.json({
@@ -412,6 +478,41 @@ logsRoutes.get(
       conditions.push(eq(logCorrelations.status, query.status));
     }
 
+    const correlationSiteIds = auth.scope === 'organization'
+      ? currentLogReadSiteCeiling(auth, query.orgId ?? auth.orgId ?? '')
+      : null;
+    if (correlationSiteIds?.length === 0) {
+      return c.json({ data: [], limit: query.limit ?? 100, offset: query.offset ?? 0, total: 0 });
+    }
+    const currentDeviceExists = (element: SQL) => sql`EXISTS (
+      SELECT 1 FROM ${devices} AS current_correlation_device
+      WHERE current_correlation_device.id::text = ${element}->>'deviceId'
+        AND current_correlation_device.org_id = ${logCorrelations.orgId}
+        ${correlationSiteIds === null
+          ? sql``
+          : sql`AND current_correlation_device.site_id IN (${sql.join(correlationSiteIds.map((id) => sql`${id}`), sql`, `)})`}
+    )`;
+    // Correlations are indivisible historical resources. Validate every
+    // affected/sample device against its current row inside the list/count
+    // statement, before pagination. Text comparison makes malformed UUIDs a
+    // clean non-match rather than a cast error, and avoids a fleet-sized bind
+    // list or a stale pre-query device snapshot.
+    conditions.push(sql`
+      jsonb_typeof(${logCorrelations.affectedDevices}) = 'array'
+      AND jsonb_array_length(${logCorrelations.affectedDevices}) > 0
+      AND jsonb_typeof(${logCorrelations.sampleLogs}) = 'array'
+      AND NOT EXISTS (
+        SELECT 1
+        FROM jsonb_array_elements(${logCorrelations.affectedDevices}) AS affected(device)
+        WHERE NOT (${currentDeviceExists(sql`affected.device`)})
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM jsonb_array_elements(${logCorrelations.sampleLogs}) AS sample(log)
+        WHERE NOT (${currentDeviceExists(sql`sample.log`)})
+      )
+    `);
+
     const limit = query.limit ?? 100;
     const offset = query.offset ?? 0;
 
@@ -462,7 +563,8 @@ logsRoutes.get(
   async (c) => {
     const auth = c.get('auth');
     const data = await listSavedLogSearchQueries(auth);
-    return c.json({ data });
+    const allowedDeviceIds = await resolveCurrentLogReadDeviceIds(auth);
+    return c.json({ data: data.map((query) => sanitizeSavedQueryScope(query, allowedDeviceIds, auth.allowedSiteIds)) });
   }
 );
 
@@ -477,7 +579,9 @@ logsRoutes.post(
     const body = c.req.valid('json');
 
     try {
-      const created = await createSavedLogSearchQuery(auth, body);
+      const allowedDeviceIds = await resolveCurrentLogReadDeviceIds(auth, body.orgId);
+      const sanitized = sanitizeSavedQueryScope({ filters: body.filters }, allowedDeviceIds, auth.allowedSiteIds);
+      const created = await createSavedLogSearchQuery(auth, { ...body, filters: sanitized.filters });
       return c.json({ data: created }, 201);
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Failed to save query';
@@ -500,7 +604,8 @@ logsRoutes.get(
       return c.json({ error: 'Saved query not found' }, 404);
     }
 
-    return c.json({ data: query });
+    const allowedDeviceIds = await resolveCurrentLogReadDeviceIds(auth, query.orgId);
+    return c.json({ data: sanitizeSavedQueryScope(query, allowedDeviceIds, auth.allowedSiteIds) });
   }
 );
 

--- a/apps/api/src/services/aiToolsEventLogs.liveSiteArguments.test.ts
+++ b/apps/api/src/services/aiToolsEventLogs.liveSiteArguments.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  resolveSiteAllowedDeviceIds: vi.fn(async () => ['device-before-move']),
+  searchFleetLogs: vi.fn(async () => ({
+    results: [], total: 0, totalMode: 'exact', limit: 50, offset: 0,
+    hasMore: false, nextCursor: null,
+  })),
+  getLogTrends: vi.fn(async () => ({
+    start: '2026-01-01T00:00:00.000Z', end: '2026-01-02T00:00:00.000Z',
+    minLevel: 'info', levelDistribution: [], topSources: [], topDevices: [],
+    errorTimeline: [], spikes: [], spikeThreshold: 3,
+  })),
+  getLogAggregation: vi.fn(async () => ({ groupBy: 'device', totals: [], series: [] })),
+  detectPatternCorrelation: vi.fn(async () => null),
+}));
+
+vi.mock('./aiToolsSiteScope', () => ({
+  resolveSiteAllowedDeviceIds: mocks.resolveSiteAllowedDeviceIds,
+  SITE_SCOPE_EMPTY_NOTE: 'restricted',
+}));
+vi.mock('./logSearch', () => ({
+  searchFleetLogs: mocks.searchFleetLogs,
+  getLogTrends: mocks.getLogTrends,
+  getLogAggregation: mocks.getLogAggregation,
+  detectPatternCorrelation: mocks.detectPatternCorrelation,
+  resolveSingleOrgId: vi.fn(() => 'org-1'),
+}));
+
+import { registerEventLogTools } from './aiToolsEventLogs';
+import type { AiTool } from './aiTools';
+import type { AuthContext } from '../middleware/auth';
+
+function tools() {
+  const registry = new Map<string, AiTool>();
+  registerEventLogTools(registry);
+  return registry;
+}
+
+const auth = {
+  user: { id: 'user-1', email: 'u@example.test', name: 'User', isPlatformAdmin: false },
+  token: {}, partnerId: null, orgId: 'org-1', scope: 'organization',
+  accessibleOrgIds: ['org-1'], orgCondition: () => undefined, canAccessOrg: () => true,
+  allowedSiteIds: ['site-visible'], canAccessSite: (siteId: string) => siteId === 'site-visible',
+} as unknown as AuthContext;
+
+describe('AI event-log tools preserve the live site predicate after device resolution', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('passes both the stale device snapshot and current site ceiling to every data service', async () => {
+    const registry = tools();
+    await registry.get('search_logs')!.handler({}, auth);
+    await registry.get('get_log_trends')!.handler({ groupBy: 'device' }, auth);
+    await registry.get('detect_log_correlations')!.handler({ pattern: 'synthetic' }, auth);
+
+    const ceiling = {
+      allowedDeviceIds: ['device-before-move'],
+      allowedSiteIds: ['site-visible'],
+    };
+    expect(mocks.searchFleetLogs).toHaveBeenCalledWith(auth, expect.objectContaining(ceiling));
+    expect(mocks.getLogTrends).toHaveBeenCalledWith(auth, expect.objectContaining(ceiling));
+    expect(mocks.getLogAggregation).toHaveBeenCalledWith(auth, expect.objectContaining(ceiling));
+    expect(mocks.detectPatternCorrelation).toHaveBeenCalledWith(expect.objectContaining({
+      orgId: 'org-1',
+      ...ceiling,
+    }));
+  });
+});

--- a/apps/api/src/services/aiToolsEventLogs.ts
+++ b/apps/api/src/services/aiToolsEventLogs.ts
@@ -31,6 +31,17 @@ async function resolveSiteScopedDeviceIds(auth: AuthContext): Promise<string[] |
   return resolveSiteAllowedDeviceIds(orgId, auth);
 }
 
+/**
+ * Preserve the distinction between an unrestricted caller (undefined) and a
+ * caller restricted to no sites ([]), while keeping the statement-local site
+ * predicate deterministic across every log-search service.
+ */
+function normalizedAllowedSiteIds(auth: AuthContext): string[] | null {
+  return auth.allowedSiteIds === undefined
+    ? null
+    : Array.from(new Set(auth.allowedSiteIds)).sort();
+}
+
 export function registerEventLogTools(aiTools: Map<string, AiTool>): void {
   function registerTool(tool: AiTool): void {
     aiTools.set(tool.definition.name, tool);
@@ -98,6 +109,7 @@ export function registerEventLogTools(aiTools: Map<string, AiTool>): void {
         }
         const result = await searchFleetLogs(auth, {
           allowedDeviceIds,
+          allowedSiteIds: normalizedAllowedSiteIds(auth),
           query: typeof input.query === 'string' ? input.query : undefined,
           timeRange: typeof input.timeRange === 'object' && input.timeRange !== null
             ? {
@@ -235,6 +247,7 @@ export function registerEventLogTools(aiTools: Map<string, AiTool>): void {
 
         const trends = await getLogTrends(auth, {
           allowedDeviceIds,
+          allowedSiteIds: normalizedAllowedSiteIds(auth),
           start: timeRange.start,
           end: timeRange.end,
           minLevel: typeof input.minLevel === 'string'
@@ -250,6 +263,7 @@ export function registerEventLogTools(aiTools: Map<string, AiTool>): void {
         if (typeof input.groupBy === 'string') {
           groupingSummary = await getLogAggregation(auth, {
             allowedDeviceIds,
+            allowedSiteIds: normalizedAllowedSiteIds(auth),
             start: trends.start,
             end: trends.end,
             bucket: 'hour',
@@ -314,6 +328,7 @@ export function registerEventLogTools(aiTools: Map<string, AiTool>): void {
         const result = await detectPatternCorrelation({
           orgId,
           allowedDeviceIds,
+          allowedSiteIds: normalizedAllowedSiteIds(auth),
           pattern,
           isRegex: Boolean(input.isRegex),
           timeWindowSeconds: Number(input.timeWindow) || 300,

--- a/apps/api/src/services/logReadAuthority.test.ts
+++ b/apps/api/src/services/logReadAuthority.test.ts
@@ -1,0 +1,215 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { selectMock, getUserPermissionsMock } = vi.hoisted(() => ({
+  selectMock: vi.fn(),
+  getUserPermissionsMock: vi.fn(),
+}));
+
+vi.mock('../db', () => ({ db: { select: selectMock } }));
+vi.mock('../db/schema', () => ({
+  devices: { id: 'devices.id', orgId: 'devices.orgId', siteId: 'devices.siteId' },
+  users: {
+    id: 'users.id', partnerId: 'users.partnerId', status: 'users.status',
+    isPlatformAdmin: 'users.isPlatformAdmin', authEpoch: 'users.authEpoch', mfaEpoch: 'users.mfaEpoch',
+  },
+}));
+vi.mock('./permissions', () => ({
+  getUserPermissions: getUserPermissionsMock,
+  canAccessOrg: vi.fn((permissions, orgId) => {
+    if (permissions.scope === 'organization') return permissions.orgId === orgId;
+    if (permissions.scope === 'partner') {
+      if (permissions.orgAccess === 'all') return true;
+      if (permissions.orgAccess === 'selected') return permissions.allowedOrgIds?.includes(orgId) ?? false;
+      return false;
+    }
+    return true;
+  }),
+  hasPermission: vi.fn((permissions) => permissions.permissions.some((permission: { resource: string; action: string }) => (
+    permission.resource === 'devices' && permission.action === 'execute'
+  ))),
+  PERMISSIONS: { DEVICES_EXECUTE: { resource: 'devices', action: 'execute' } },
+}));
+
+import type { AuthContext } from '../middleware/auth';
+import {
+  captureLogReadAuthority,
+  correlationResultWithinCurrentDeviceCeiling,
+  resolveCurrentLogReadDeviceIds,
+  revalidateLogReadAuthority,
+} from './logReadAuthority';
+
+const ORG = '11111111-1111-4111-8111-111111111111';
+const PARTNER = '22222222-2222-4222-8222-222222222222';
+const USER = '33333333-3333-4333-8333-333333333333';
+const SITE_A = '44444444-4444-4444-8444-444444444444';
+const SITE_B = '55555555-5555-4555-8555-555555555555';
+
+function auth(overrides: Partial<AuthContext> = {}): AuthContext {
+  return {
+    principal: { kind: 'user_session' }, scope: 'organization', orgId: ORG, partnerId: PARTNER,
+    user: { id: USER, email: 'actor@example.test', name: 'Actor', isPlatformAdmin: false },
+    token: { aep: 7, mep: 9, mfa: true }, allowedSiteIds: [SITE_B, SITE_A, SITE_A],
+    accessibleOrgIds: [ORG], canAccessOrg: (id: string) => id === ORG,
+    orgCondition: () => undefined,
+    ...overrides,
+  } as unknown as AuthContext;
+}
+
+function chain(rows: unknown[], limited = false) {
+  const result = Promise.resolve(rows);
+  const builder: Record<string, unknown> = {};
+  builder.from = vi.fn(() => builder);
+  builder.where = vi.fn(() => limited ? builder : result);
+  builder.limit = vi.fn(() => result);
+  return builder;
+}
+
+describe('log read authority', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getUserPermissionsMock.mockResolvedValue({
+      scope: 'organization', orgId: ORG, partnerId: PARTNER,
+      allowedSiteIds: [SITE_A], permissions: [{ resource: 'devices', action: 'execute' }],
+    });
+  });
+
+  it('binds requester, org, epochs, MFA claim and a normalized site ceiling', () => {
+    const envelope = captureLogReadAuthority(auth(), ORG);
+    expect(envelope).toMatchObject({
+      requesterId: USER, orgId: ORG, authEpoch: 7, mfaEpoch: 9,
+      mfaClaim: true, siteIds: [SITE_A, SITE_B],
+    });
+    expect(envelope.fingerprint).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('fails closed for a modified envelope before any database read', async () => {
+    const envelope = captureLogReadAuthority(auth(), ORG);
+    await expect(revalidateLogReadAuthority({ ...envelope, orgId: 'other' })).resolves.toBeNull();
+    expect(selectMock).not.toHaveBeenCalled();
+  });
+
+  it('intersects captured and current sites and resolves only current devices', async () => {
+    const envelope = captureLogReadAuthority(auth(), ORG);
+    selectMock
+      .mockReturnValueOnce(chain([{
+        id: USER, partnerId: PARTNER, status: 'active', isPlatformAdmin: false,
+        authEpoch: 7, mfaEpoch: 9,
+      }], true))
+      .mockReturnValueOnce(chain([{ id: 'visible-device' }]));
+    await expect(revalidateLogReadAuthority(envelope)).resolves.toEqual({
+      authority: envelope,
+      allowedDeviceIds: ['visible-device'],
+      allowedSiteIds: [SITE_A],
+    });
+    expect(getUserPermissionsMock).toHaveBeenCalledWith(USER, {
+      partnerId: PARTNER, orgId: ORG,
+    }, { bypassCache: true });
+  });
+
+  it.each([
+    ['partner-all', auth({
+      scope: 'partner', orgId: null, allowedSiteIds: undefined,
+      canAccessOrg: () => true,
+    })],
+    ['platform-system', auth({
+      scope: 'system', orgId: null, partnerId: null, allowedSiteIds: undefined,
+      user: { id: USER, email: 'platform@example.test', name: 'Platform', isPlatformAdmin: true },
+      canAccessOrg: () => true,
+    })],
+  ])('keeps an unrestricted %s fleet read unrestricted without a synthetic bound org', async (_name, caller) => {
+    await expect(resolveCurrentLogReadDeviceIds(caller)).resolves.toBeNull();
+    expect(selectMock).not.toHaveBeenCalled();
+  });
+
+  it('preserves explicit partner target-org accessibility for selected and denied organizations', async () => {
+    const selected = auth({
+      scope: 'partner', orgId: null, allowedSiteIds: undefined,
+      canAccessOrg: (id: string) => id === ORG,
+    });
+    await expect(resolveCurrentLogReadDeviceIds(selected, ORG)).resolves.toBeNull();
+    await expect(resolveCurrentLogReadDeviceIds(selected, '99999999-9999-4999-8999-999999999999')).resolves.toEqual([]);
+    expect(selectMock).not.toHaveBeenCalled();
+  });
+
+  it('revalidates a partner envelope on the captured partner axis despite a lower org membership', async () => {
+    const envelope = captureLogReadAuthority(auth({
+      scope: 'partner', orgId: null, allowedSiteIds: undefined,
+      canAccessOrg: (id: string) => id === ORG,
+    }), ORG);
+    selectMock.mockReturnValueOnce(chain([{
+      id: USER, partnerId: PARTNER, status: 'active', isPlatformAdmin: false,
+      authEpoch: 7, mfaEpoch: 9,
+    }], true));
+    getUserPermissionsMock.mockResolvedValueOnce({
+      scope: 'partner', partnerId: PARTNER, orgAccess: 'selected', allowedOrgIds: [ORG],
+      permissions: [{ resource: 'devices', action: 'execute' }],
+    });
+    await expect(revalidateLogReadAuthority(envelope)).resolves.toEqual({
+      authority: envelope, allowedDeviceIds: null, allowedSiteIds: null,
+    });
+    expect(getUserPermissionsMock).toHaveBeenCalledWith(USER, { partnerId: PARTNER }, { bypassCache: true });
+
+    selectMock.mockReturnValueOnce(chain([{
+      id: USER, partnerId: PARTNER, status: 'active', isPlatformAdmin: false,
+      authEpoch: 7, mfaEpoch: 9,
+    }], true));
+    getUserPermissionsMock.mockResolvedValueOnce({
+      scope: 'organization', orgId: ORG, partnerId: PARTNER,
+      permissions: [{ resource: 'devices', action: 'execute' }],
+    });
+    await expect(revalidateLogReadAuthority(envelope)).resolves.toBeNull();
+  });
+
+  it('revalidates a genuine captured system envelope only for a live platform administrator', async () => {
+    const envelope = captureLogReadAuthority(auth({
+      scope: 'system', orgId: null, partnerId: null, allowedSiteIds: undefined,
+      user: { id: USER, email: 'platform@example.test', name: 'Platform', isPlatformAdmin: true },
+      canAccessOrg: () => true,
+    }), ORG);
+    selectMock.mockReturnValueOnce(chain([{
+      id: USER, partnerId: null, status: 'active', isPlatformAdmin: true,
+      authEpoch: 7, mfaEpoch: 9,
+    }], true));
+    await expect(revalidateLogReadAuthority(envelope)).resolves.toEqual({
+      authority: envelope, allowedDeviceIds: null, allowedSiteIds: null,
+    });
+    expect(getUserPermissionsMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects inactive, epoch-stale, and execute-revoked requesters', async () => {
+    const envelope = captureLogReadAuthority(auth(), ORG);
+    selectMock.mockReturnValueOnce(chain([{
+      id: USER, partnerId: PARTNER, status: 'disabled', isPlatformAdmin: false,
+      authEpoch: 7, mfaEpoch: 9,
+    }], true));
+    await expect(revalidateLogReadAuthority(envelope)).resolves.toBeNull();
+
+    selectMock.mockReturnValueOnce(chain([{
+      id: USER, partnerId: PARTNER, status: 'active', isPlatformAdmin: false,
+      authEpoch: 8, mfaEpoch: 9,
+    }], true));
+    await expect(revalidateLogReadAuthority(envelope)).resolves.toBeNull();
+
+    getUserPermissionsMock.mockResolvedValueOnce({
+      scope: 'organization', orgId: ORG, partnerId: PARTNER, permissions: [],
+    });
+    selectMock.mockReturnValueOnce(chain([{
+      id: USER, partnerId: PARTNER, status: 'active', isPlatformAdmin: false,
+      authEpoch: 7, mfaEpoch: 9,
+    }], true));
+    await expect(revalidateLogReadAuthority(envelope)).resolves.toBeNull();
+  });
+
+  it('rejects completed results containing any newly hidden device', async () => {
+    const result = {
+      result: {
+        affectedDevices: [{ deviceId: 'visible' }, { deviceId: 'hidden' }],
+        sampleLogs: [{ deviceId: 'visible' }],
+      },
+    };
+    selectMock.mockReturnValueOnce(chain([{ id: 'visible' }]));
+    await expect(correlationResultWithinCurrentDeviceCeiling(result, ORG, [SITE_A])).resolves.toBe(false);
+    selectMock.mockReturnValueOnce(chain([{ id: 'visible' }, { id: 'hidden' }]));
+    await expect(correlationResultWithinCurrentDeviceCeiling(result, ORG, null)).resolves.toBe(true);
+  });
+});

--- a/apps/api/src/services/logReadAuthority.ts
+++ b/apps/api/src/services/logReadAuthority.ts
@@ -1,0 +1,202 @@
+import { createHash } from 'node:crypto';
+import { and, eq, inArray } from 'drizzle-orm';
+
+import { db } from '../db';
+import { devices, users } from '../db/schema';
+import type { AuthContext } from '../middleware/auth';
+import { hasSatisfiedMfa, isInteractiveUserSession } from '../middleware/auth';
+import { ENABLE_2FA } from '../routes/auth/schemas';
+import { canAccessOrg, getUserPermissions, hasPermission, PERMISSIONS } from './permissions';
+
+export interface LogReadAuthorityEnvelope {
+  version: 1;
+  requesterId: string;
+  partnerId: string | null;
+  orgId: string;
+  scope: 'system' | 'partner' | 'organization';
+  siteIds: string[] | null;
+  authEpoch: number;
+  mfaEpoch: number;
+  mfaClaim: boolean;
+  fingerprint: string;
+}
+
+type UnsignedEnvelope = Omit<LogReadAuthorityEnvelope, 'fingerprint'>;
+
+function normalizedSiteIds(siteIds: string[] | undefined): string[] | null {
+  return siteIds === undefined ? null : Array.from(new Set(siteIds)).sort();
+}
+
+function fingerprintAuthority(authority: UnsignedEnvelope): string {
+  return createHash('sha256').update(JSON.stringify(authority)).digest('hex');
+}
+
+export function captureLogReadAuthority(auth: AuthContext, orgId: string): LogReadAuthorityEnvelope {
+  if (!isInteractiveUserSession(auth) || !auth.canAccessOrg(orgId) || !hasSatisfiedMfa(auth)) {
+    throw new Error('Log detection authority denied');
+  }
+  const authEpoch = auth.token?.aep;
+  const mfaEpoch = auth.token?.mep;
+  if (!Number.isSafeInteger(authEpoch) || !Number.isSafeInteger(mfaEpoch)) {
+    throw new Error('Log detection authority is missing current authentication state');
+  }
+  const unsigned: UnsignedEnvelope = {
+    version: 1,
+    requesterId: auth.user.id,
+    partnerId: auth.partnerId,
+    orgId,
+    scope: auth.scope,
+    siteIds: normalizedSiteIds(auth.allowedSiteIds),
+    authEpoch: authEpoch!,
+    mfaEpoch: mfaEpoch!,
+    mfaClaim: auth.token?.mfa === true,
+  };
+  return { ...unsigned, fingerprint: fingerprintAuthority(unsigned) };
+}
+
+function parseEnvelope(value: unknown): LogReadAuthorityEnvelope | null {
+  if (!value || typeof value !== 'object') return null;
+  const candidate = value as Partial<LogReadAuthorityEnvelope>;
+  if (candidate.version !== 1
+    || typeof candidate.requesterId !== 'string'
+    || (candidate.partnerId !== null && typeof candidate.partnerId !== 'string')
+    || typeof candidate.orgId !== 'string'
+    || !['system', 'partner', 'organization'].includes(String(candidate.scope))
+    || (candidate.siteIds !== null && (!Array.isArray(candidate.siteIds) || candidate.siteIds.some((id) => typeof id !== 'string')))
+    || !Number.isSafeInteger(candidate.authEpoch)
+    || !Number.isSafeInteger(candidate.mfaEpoch)
+    || typeof candidate.mfaClaim !== 'boolean'
+    || typeof candidate.fingerprint !== 'string') return null;
+  const unsigned: UnsignedEnvelope = {
+    version: 1,
+    requesterId: candidate.requesterId,
+    partnerId: candidate.partnerId,
+    orgId: candidate.orgId,
+    scope: candidate.scope as UnsignedEnvelope['scope'],
+    siteIds: candidate.siteIds === null ? null : Array.from(new Set(candidate.siteIds)).sort(),
+    authEpoch: candidate.authEpoch!,
+    mfaEpoch: candidate.mfaEpoch!,
+    mfaClaim: candidate.mfaClaim,
+  };
+  if (candidate.fingerprint !== fingerprintAuthority(unsigned)) return null;
+  return { ...unsigned, fingerprint: candidate.fingerprint };
+}
+
+function intersectCeilings(captured: string[] | null, live: string[] | undefined): string[] | null {
+  if (captured === null && live === undefined) return null;
+  if (captured === null) return Array.from(new Set(live!)).sort();
+  if (live === undefined) return captured;
+  const liveSet = new Set(live);
+  return captured.filter((id) => liveSet.has(id));
+}
+
+async function deviceIdsForSites(orgId: string, siteIds: string[] | null): Promise<string[] | null> {
+  if (siteIds === null) return null;
+  if (siteIds.length === 0) return [];
+  const rows = await db.select({ id: devices.id }).from(devices).where(and(
+    eq(devices.orgId, orgId),
+    inArray(devices.siteId, siteIds),
+  ));
+  return rows.map((row) => row.id);
+}
+
+export async function resolveCurrentLogReadDeviceIds(auth: AuthContext, orgId?: string): Promise<string[] | null> {
+  // Partner/system callers are fleet-wide unless they explicitly address one
+  // organization. They have no single auth.orgId to bind, and treating that
+  // absence as deny-all silently empties every otherwise-authorized fleet read.
+  if (orgId === undefined && (auth.scope === 'partner' || auth.scope === 'system')) {
+    return null;
+  }
+  const boundOrgId = orgId ?? auth.orgId;
+  if (!boundOrgId || !auth.canAccessOrg(boundOrgId)) return [];
+  return deviceIdsForSites(boundOrgId, currentLogReadSiteCeiling(auth, boundOrgId));
+}
+
+export function currentLogReadSiteCeiling(auth: AuthContext, orgId: string): string[] | null {
+  if (!auth.canAccessOrg(orgId)) return [];
+  return normalizedSiteIds(auth.allowedSiteIds);
+}
+
+export function intersectLogReadSiteCeilings(
+  left: string[] | null,
+  right: string[] | null,
+): string[] | null {
+  if (left === null) return right;
+  if (right === null) return left;
+  const rightSet = new Set(right);
+  return left.filter((id) => rightSet.has(id));
+}
+
+export async function revalidateLogReadAuthority(value: unknown): Promise<{
+  authority: LogReadAuthorityEnvelope;
+  allowedDeviceIds: string[] | null;
+  allowedSiteIds: string[] | null;
+} | null> {
+  const authority = parseEnvelope(value);
+  if (!authority) return null;
+  if (ENABLE_2FA && !authority.mfaClaim) return null;
+  const rows = await db.select({
+    id: users.id,
+    partnerId: users.partnerId,
+    status: users.status,
+    isPlatformAdmin: users.isPlatformAdmin,
+    authEpoch: users.authEpoch,
+    mfaEpoch: users.mfaEpoch,
+  }).from(users).where(eq(users.id, authority.requesterId)).limit(1);
+  const user = rows[0];
+  if (!user || user.status !== 'active' || user.partnerId !== authority.partnerId
+    || user.authEpoch !== authority.authEpoch || user.mfaEpoch !== authority.mfaEpoch) return null;
+
+  if (authority.scope === 'system') {
+    if (!user.isPlatformAdmin) return null;
+    return {
+      authority,
+      allowedDeviceIds: await deviceIdsForSites(authority.orgId, authority.siteIds),
+      allowedSiteIds: authority.siteIds,
+    };
+  }
+
+  // Re-resolve the exact captured authority axis. Passing orgId for a partner
+  // envelope lets getUserPermissions' intentional org-first precedence select
+  // a lower organization membership instead of the captured partner role.
+  const permissions = await getUserPermissions(authority.requesterId, authority.scope === 'partner'
+    ? { partnerId: authority.partnerId ?? undefined }
+    : { partnerId: authority.partnerId ?? undefined, orgId: authority.orgId },
+  { bypassCache: true });
+  if (!permissions || permissions.scope !== authority.scope
+    || !canAccessOrg(permissions, authority.orgId)
+    || !hasPermission(permissions, PERMISSIONS.DEVICES_EXECUTE.resource, PERMISSIONS.DEVICES_EXECUTE.action)) return null;
+  const effectiveSites = intersectCeilings(authority.siteIds, permissions.allowedSiteIds);
+  return {
+    authority,
+    allowedDeviceIds: await deviceIdsForSites(authority.orgId, effectiveSites),
+    allowedSiteIds: effectiveSites,
+  };
+}
+
+export async function correlationResultWithinCurrentDeviceCeiling(
+  result: unknown,
+  orgId: string,
+  allowedSiteIds: string[] | null,
+): Promise<boolean> {
+  if (result == null) return true;
+  if (typeof result !== 'object') return false;
+  const detection = (result as { result?: unknown }).result;
+  if (detection == null) return true;
+  if (typeof detection !== 'object') return false;
+  const affected = (detection as { affectedDevices?: unknown }).affectedDevices;
+  const samples = (detection as { sampleLogs?: unknown }).sampleLogs;
+  if (!Array.isArray(affected) || !Array.isArray(samples)) return false;
+  const items = [...affected, ...samples];
+  if (items.some((item) => !item || typeof item !== 'object'
+    || typeof (item as { deviceId?: unknown }).deviceId !== 'string')) return false;
+  const ids = Array.from(new Set(items.map((item) => (item as { deviceId: string }).deviceId)));
+  if (ids.length === 0) return true;
+  const conditions = [eq(devices.orgId, orgId), inArray(devices.id, ids)];
+  if (allowedSiteIds !== null) {
+    if (allowedSiteIds.length === 0) return false;
+    conditions.push(inArray(devices.siteId, allowedSiteIds));
+  }
+  const current = await db.select({ id: devices.id }).from(devices).where(and(...conditions));
+  return current.length === ids.length;
+}

--- a/apps/api/src/services/logReadAuthority.ts
+++ b/apps/api/src/services/logReadAuthority.ts
@@ -27,18 +27,33 @@ function normalizedSiteIds(siteIds: string[] | undefined): string[] | null {
   return siteIds === undefined ? null : Array.from(new Set(siteIds)).sort();
 }
 
+/**
+ * Unkeyed integrity check, NOT a signature: it only proves the envelope's
+ * fields have not been edited in transit through the queue. Authenticity comes
+ * entirely from `revalidateLogReadAuthority`, which re-reads the live `users`
+ * row (status, partner, auth/MFA epochs) and re-runs `canAccessOrg` +
+ * `devices:execute` against uncached permissions before any read is authorized.
+ */
 function fingerprintAuthority(authority: UnsignedEnvelope): string {
   return createHash('sha256').update(JSON.stringify(authority)).digest('hex');
 }
 
+/** Thrown when a caller may not open a deferred log read. Routes map this to 403. */
+export class LogReadAuthorityDeniedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'LogReadAuthorityDeniedError';
+  }
+}
+
 export function captureLogReadAuthority(auth: AuthContext, orgId: string): LogReadAuthorityEnvelope {
   if (!isInteractiveUserSession(auth) || !auth.canAccessOrg(orgId) || !hasSatisfiedMfa(auth)) {
-    throw new Error('Log detection authority denied');
+    throw new LogReadAuthorityDeniedError('Log detection authority denied');
   }
   const authEpoch = auth.token?.aep;
   const mfaEpoch = auth.token?.mep;
   if (!Number.isSafeInteger(authEpoch) || !Number.isSafeInteger(mfaEpoch)) {
-    throw new Error('Log detection authority is missing current authentication state');
+    throw new LogReadAuthorityDeniedError('Log detection authority is missing current authentication state');
   }
   const unsigned: UnsignedEnvelope = {
     version: 1,

--- a/apps/api/src/services/logSearch.correlationTimestamp.test.ts
+++ b/apps/api/src/services/logSearch.correlationTimestamp.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeCorrelationTimestamp } from './logSearch';
+
+describe('normalizeCorrelationTimestamp', () => {
+  it('normalizes raw PostgreSQL timestamp strings to Date values', () => {
+    const timestamp = normalizeCorrelationTimestamp('2026-09-06T12:34:56.789Z', 'firstSeen');
+
+    expect(timestamp).toBeInstanceOf(Date);
+    expect(timestamp?.toISOString()).toBe('2026-09-06T12:34:56.789Z');
+  });
+
+  it('copies already-decoded Date values and preserves null aggregates', () => {
+    const source = new Date('2026-09-06T12:34:56.789Z');
+    const timestamp = normalizeCorrelationTimestamp(source, 'lastSeen');
+
+    expect(timestamp).not.toBe(source);
+    expect(timestamp?.getTime()).toBe(source.getTime());
+    expect(normalizeCorrelationTimestamp(null, 'firstSeen')).toBeNull();
+  });
+
+  it.each([
+    ['malformed text', 'not-a-timestamp'],
+    ['non-date object', {}],
+    ['numeric coercion', 0],
+  ])('fails closed for %s', (_label, value) => {
+    expect(() => normalizeCorrelationTimestamp(value, 'firstSeen'))
+      .toThrow('Invalid correlation firstSeen timestamp');
+  });
+});

--- a/apps/api/src/services/logSearch.test.ts
+++ b/apps/api/src/services/logSearch.test.ts
@@ -1,8 +1,11 @@
 import { PgDialect } from 'drizzle-orm/pg-core';
 import { describe, expect, it } from 'vitest';
 
+import { and } from 'drizzle-orm';
+
 import {
   buildLogSearchKeysetCondition,
+  buildSearchConditions,
   decodeSearchCursor,
   encodeSearchCursor,
   mergeSavedLogSearchFilters,
@@ -205,5 +208,31 @@ describe('resolveSingleOrgId', () => {
       canAccessOrg: () => true,
     } as any;
     expect(resolveSingleOrgId(auth)).toBeNull();
+  });
+});
+
+describe('current-device authorization predicate', () => {
+  const dialect = new PgDialect();
+  const auth = { orgCondition: () => undefined } as any;
+  const timeRange = { start: new Date('2026-01-01T00:00:00.000Z'), end: new Date('2026-01-02T00:00:00.000Z') };
+  const render = (allowedSiteIds: string[] | null | undefined) => dialect.sqlToQuery(
+    and(...buildSearchConditions(auth, { allowedSiteIds }, timeRange, 'like'))!,
+  );
+
+  it('omits the authorized_log_device subquery for an unrestricted caller and emits it for a restricted one', () => {
+    // Unrestricted: the EXISTS probe could only ever be true (device_id is a
+    // NOT NULL FK, org_id is the denormalized copy) but costs a non-LEAKPROOF
+    // RLS check per candidate row, so it must not be emitted at all.
+    expect(render(null).sql).not.toContain('authorized_log_device');
+    expect(render(undefined).sql).not.toContain('authorized_log_device');
+
+    const restricted = render(['33333333-3333-4333-8333-333333333333']);
+    expect(restricted.sql).toContain('authorized_log_device');
+    expect(restricted.sql).toContain('site_id in');
+    expect(restricted.params).toContain('33333333-3333-4333-8333-333333333333');
+
+    // A defined-but-empty ceiling stays deny-all, not unrestricted.
+    expect(render([]).sql).toContain('authorized_log_device');
+    expect(render([]).sql).toContain('and false');
   });
 });

--- a/apps/api/src/services/logSearch.ts
+++ b/apps/api/src/services/logSearch.ts
@@ -926,10 +926,16 @@ async function runPatternDetection(
       .limit(sampleLimit)
   ]);
 
+  // postgres.js returns values selected through raw aggregate expressions as
+  // strings even when the TypeScript annotation says Date. Normalize at the
+  // service boundary before these timestamps flow into Drizzle date columns.
+  const firstSeen = normalizeCorrelationTimestamp(summaryRows[0]?.firstSeen, 'firstSeen');
+  const lastSeen = normalizeCorrelationTimestamp(summaryRows[0]?.lastSeen, 'lastSeen');
+
   return {
     summary: {
-      firstSeen: summaryRows[0]?.firstSeen ?? null,
-      lastSeen: summaryRows[0]?.lastSeen ?? null,
+      firstSeen,
+      lastSeen,
       occurrences: Number(summaryRows[0]?.occurrences ?? 0),
     },
     affectedDevices: affectedDeviceRows.map((row) => ({
@@ -940,12 +946,28 @@ async function runPatternDetection(
     sampleLogs: sampleRows.map((row) => ({
       id: row.id,
       deviceId: row.deviceId,
-      timestamp: row.timestamp.toISOString(),
+      timestamp: normalizeCorrelationTimestamp(row.timestamp, 'sample log')!.toISOString(),
       level: row.level,
       source: row.source,
       message: row.message,
     }))
   };
+}
+
+export function normalizeCorrelationTimestamp(value: unknown, field: string): Date | null {
+  if (value == null) return null;
+
+  const timestamp = value instanceof Date
+    ? new Date(value.getTime())
+    : typeof value === 'string'
+      ? new Date(value)
+      : null;
+
+  if (!timestamp || !Number.isFinite(timestamp.getTime())) {
+    throw new Error(`Invalid correlation ${field} timestamp`);
+  }
+
+  return timestamp;
 }
 
 export async function detectPatternCorrelation(input: PatternDetectionInput): Promise<PatternDetectionResult | null> {

--- a/apps/api/src/services/logSearch.ts
+++ b/apps/api/src/services/logSearch.ts
@@ -52,6 +52,8 @@ export interface LogSearchInput {
    * unrestricted caller, no narrowing. RLS does NOT enforce the site axis.
    */
   allowedDeviceIds?: string[] | null;
+  /** Current site ceiling used by the statement-local device authorization predicate. */
+  allowedSiteIds?: string[] | null;
   limit?: number;
   offset?: number;
   cursor?: string;
@@ -72,6 +74,7 @@ export interface LogAggregationInput {
   siteIds?: string[];
   /** Site-axis app-layer authz narrowing (see LogSearchInput.allowedDeviceIds). */
   allowedDeviceIds?: string[] | null;
+  allowedSiteIds?: string[] | null;
   limit?: number;
 }
 
@@ -84,6 +87,7 @@ export interface LogTrendsInput {
   siteIds?: string[];
   /** Site-axis app-layer authz narrowing (see LogSearchInput.allowedDeviceIds). */
   allowedDeviceIds?: string[] | null;
+  allowedSiteIds?: string[] | null;
   limit?: number;
 }
 
@@ -102,6 +106,7 @@ export interface PatternDetectionInput {
    * RLS does NOT enforce the site axis.
    */
   allowedDeviceIds?: string[] | null;
+  allowedSiteIds?: string[] | null;
 }
 
 export interface PatternDetectionResult {
@@ -123,6 +128,22 @@ export interface PersistedCorrelationResult {
 }
 
 type CorrelationRuleRecord = typeof logCorrelationRulesTable.$inferSelect;
+
+function currentDeviceAuthorizationCondition(
+  allowedSiteIds: string[] | null | undefined,
+): SQL {
+  const siteCondition = allowedSiteIds === null || allowedSiteIds === undefined
+    ? sql``
+    : allowedSiteIds.length > 0
+      ? sql`and authorized_log_device.site_id in (${sql.join(allowedSiteIds.map((id) => sql`${id}`), sql`, `)})`
+      : sql`and false`;
+  return sql`exists (
+    select 1 from ${devices} as authorized_log_device
+    where authorized_log_device.id = ${deviceEventLogs.deviceId}
+      and authorized_log_device.org_id = ${deviceEventLogs.orgId}
+      ${siteCondition}
+  )`;
+}
 
 const DEFAULT_TIME_RANGE_MS = 24 * 60 * 60 * 1000;
 const ESTIMATED_COUNT_SAMPLE_RANGE_MS = 60 * 60 * 1000;
@@ -289,12 +310,14 @@ function buildSearchConditions(
     conditions.push(ilike(deviceEventLogs.source, `%${escapeLike(filters.source.trim())}%`));
   }
 
-  if (filters.deviceIds && filters.deviceIds.length > 0) {
-    conditions.push(inArray(deviceEventLogs.deviceId, filters.deviceIds));
+  if (filters.deviceIds !== undefined) {
+    conditions.push(filters.deviceIds.length > 0
+      ? inArray(deviceEventLogs.deviceId, filters.deviceIds)
+      : sql`false`);
   }
 
-  if (filters.siteIds && filters.siteIds.length > 0) {
-    conditions.push(inArray(devices.siteId, filters.siteIds));
+  if (filters.siteIds !== undefined) {
+    conditions.push(filters.siteIds.length > 0 ? inArray(devices.siteId, filters.siteIds) : sql`false`);
   }
 
   // Site-axis app-layer authz narrowing (most-restrictive wins; intersects with
@@ -307,6 +330,7 @@ function buildSearchConditions(
         : sql`false`,
     );
   }
+  conditions.push(currentDeviceAuthorizationCondition(filters.allowedSiteIds));
 
   return conditions;
 }
@@ -549,6 +573,7 @@ export async function getLogAggregation(auth: AuthContext, input: LogAggregation
         : sql`false`,
     );
   }
+  conditions.push(currentDeviceAuthorizationCondition(input.allowedSiteIds));
 
   const bucketExpr = bucket === 'day'
     ? sql`date_trunc('day', ${deviceEventLogs.timestamp})`
@@ -659,6 +684,7 @@ export async function getLogTrends(auth: AuthContext, input: LogTrendsInput) {
         : sql`false`,
     );
   }
+  conditions.push(currentDeviceAuthorizationCondition(input.allowedSiteIds));
 
   const whereCondition = and(...conditions);
 
@@ -837,6 +863,7 @@ async function runPatternDetection(
   sampleLimit: number,
   forceLike = false,
   allowedDeviceIds?: string[] | null,
+  allowedSiteIds?: string[] | null,
 ): Promise<{
   summary: { firstSeen: Date | null; lastSeen: Date | null; occurrences: number };
   affectedDevices: LogCorrelationAffectedDevice[];
@@ -861,6 +888,7 @@ async function runPatternDetection(
     gte(deviceEventLogs.timestamp, since),
     condition,
     ...(siteScopeCondition ? [siteScopeCondition] : []),
+    currentDeviceAuthorizationCondition(allowedSiteIds),
   );
 
   const [summaryRows, affectedDeviceRows, sampleRows] = await Promise.all([
@@ -940,14 +968,18 @@ export async function detectPatternCorrelation(input: PatternDetectionInput): Pr
 
   let detected;
   try {
-    detected = await runPatternDetection(input.orgId, pattern, isRegex, since, sampleLimit, false, allowedDeviceIds);
+    detected = await runPatternDetection(
+      input.orgId, pattern, isRegex, since, sampleLimit, false, allowedDeviceIds, input.allowedSiteIds,
+    );
   } catch (error) {
     // PostgreSQL regex engine errors should gracefully fall back to plain ILIKE.
     if (!isRegex || !(error instanceof Error) || !error.message.toLowerCase().includes('regular expression')) {
       throw error;
     }
     console.warn('[logSearch] Regex pattern detection failed, falling back to ILIKE:', error.message);
-    detected = await runPatternDetection(input.orgId, pattern, false, since, sampleLimit, true, allowedDeviceIds);
+    detected = await runPatternDetection(
+      input.orgId, pattern, false, since, sampleLimit, true, allowedDeviceIds, input.allowedSiteIds,
+    );
   }
 
   if (detected.summary.occurrences === 0) {

--- a/apps/api/src/services/logSearch.ts
+++ b/apps/api/src/services/logSearch.ts
@@ -129,14 +129,25 @@ export interface PersistedCorrelationResult {
 
 type CorrelationRuleRecord = typeof logCorrelationRulesTable.$inferSelect;
 
+/**
+ * Statement-local device authorization predicate for the *site* axis.
+ *
+ * Returns null for an unrestricted caller (`null`/`undefined` ceiling). The
+ * subquery would be tautological for them — `device_event_logs.device_id` is a
+ * NOT NULL FK into `devices` and `org_id` is the moveOrg-maintained denormalized
+ * copy — but it is not free: `devices` carries a non-LEAKPROOF
+ * `breeze_has_org_access` RLS policy, so Postgres cannot fold the probe into an
+ * index condition and pays it per candidate row of the largest table in the
+ * fleet, unbounded on aggregation/trends/pattern detection. Emit it only when it
+ * can actually exclude something.
+ */
 function currentDeviceAuthorizationCondition(
   allowedSiteIds: string[] | null | undefined,
-): SQL {
-  const siteCondition = allowedSiteIds === null || allowedSiteIds === undefined
-    ? sql``
-    : allowedSiteIds.length > 0
-      ? sql`and authorized_log_device.site_id in (${sql.join(allowedSiteIds.map((id) => sql`${id}`), sql`, `)})`
-      : sql`and false`;
+): SQL | null {
+  if (allowedSiteIds === null || allowedSiteIds === undefined) return null;
+  const siteCondition = allowedSiteIds.length > 0
+    ? sql`and authorized_log_device.site_id in (${sql.join(allowedSiteIds.map((id) => sql`${id}`), sql`, `)})`
+    : sql`and false`;
   return sql`exists (
     select 1 from ${devices} as authorized_log_device
     where authorized_log_device.id = ${deviceEventLogs.deviceId}
@@ -268,7 +279,8 @@ export function mergeSavedLogSearchFilters(
   };
 }
 
-function buildSearchConditions(
+/** Exported for unit tests only — see logSearch.test.ts. */
+export function buildSearchConditions(
   auth: AuthContext,
   filters: LogSearchInput,
   timeRange: { start: Date; end: Date },
@@ -330,7 +342,8 @@ function buildSearchConditions(
         : sql`false`,
     );
   }
-  conditions.push(currentDeviceAuthorizationCondition(filters.allowedSiteIds));
+  const currentDeviceAuthz = currentDeviceAuthorizationCondition(filters.allowedSiteIds);
+  if (currentDeviceAuthz) conditions.push(currentDeviceAuthz);
 
   return conditions;
 }
@@ -573,7 +586,8 @@ export async function getLogAggregation(auth: AuthContext, input: LogAggregation
         : sql`false`,
     );
   }
-  conditions.push(currentDeviceAuthorizationCondition(input.allowedSiteIds));
+  const currentDeviceAuthz = currentDeviceAuthorizationCondition(input.allowedSiteIds);
+  if (currentDeviceAuthz) conditions.push(currentDeviceAuthz);
 
   const bucketExpr = bucket === 'day'
     ? sql`date_trunc('day', ${deviceEventLogs.timestamp})`
@@ -684,7 +698,8 @@ export async function getLogTrends(auth: AuthContext, input: LogTrendsInput) {
         : sql`false`,
     );
   }
-  conditions.push(currentDeviceAuthorizationCondition(input.allowedSiteIds));
+  const currentDeviceAuthz = currentDeviceAuthorizationCondition(input.allowedSiteIds);
+  if (currentDeviceAuthz) conditions.push(currentDeviceAuthz);
 
   const whereCondition = and(...conditions);
 
@@ -883,12 +898,14 @@ async function runPatternDetection(
         ? inArray(deviceEventLogs.deviceId, allowedDeviceIds)
         : sql`false`;
 
+  const currentDeviceAuthz = currentDeviceAuthorizationCondition(allowedSiteIds);
+
   const whereCondition = and(
     eq(deviceEventLogs.orgId, orgId),
     gte(deviceEventLogs.timestamp, since),
     condition,
     ...(siteScopeCondition ? [siteScopeCondition] : []),
-    currentDeviceAuthorizationCondition(allowedSiteIds),
+    ...(currentDeviceAuthz ? [currentDeviceAuthz] : []),
   );
 
   const [summaryRows, affectedDeviceRows, sampleRows] = await Promise.all([

--- a/apps/api/src/services/permissions.ts
+++ b/apps/api/src/services/permissions.ts
@@ -87,13 +87,14 @@ async function bumpSharedPermissionCacheVersion(userId?: string): Promise<void> 
 
 export async function getUserPermissions(
   userId: string,
-  context: { partnerId?: string; orgId?: string }
+  context: { partnerId?: string; orgId?: string },
+  options?: { bypassCache?: boolean },
 ): Promise<UserPermissions | null> {
   const cacheKey = userId + ':' + (context.partnerId || '') + ':' + (context.orgId || '');
   const versions = await getPermissionCacheVersions(userId);
   const cached = permissionCache.get(cacheKey);
 
-  if (cached && cached.expiresAt > Date.now() && cacheVersionsMatch(cached.versions, versions)) {
+  if (!options?.bypassCache && cached && cached.expiresAt > Date.now() && cacheVersionsMatch(cached.versions, versions)) {
     return cached.userPerms;
   }
 
@@ -198,11 +199,13 @@ export async function getUserPermissions(
   }
 
   // Cache the result
-  permissionCache.set(cacheKey, {
-    userPerms,
-    expiresAt: Date.now() + CACHE_TTL,
-    versions,
-  });
+  if (!options?.bypassCache) {
+    permissionCache.set(cacheKey, {
+      userPerms,
+      expiresAt: Date.now() + CACHE_TTL,
+      versions,
+    });
+  }
 
   return userPerms;
 }


### PR DESCRIPTION
## Summary

Two Medium findings from the September security review, both on the fleet event-log read surface. Site is an **app-layer** axis only — Postgres RLS does not enforce it — so every one of these paths had to be fixed in application code.

### SEC-2026-09-05-079 — fleet log reads were not bound to the caller's *current* site authority

**What was wrong.** Log search, aggregation, trends, counts, saved-query scope metadata, correlation listing and asynchronous pattern-correlation detection all projected data without re-checking the caller's current device/site ceiling. A site-restricted organization user could read log rows and aggregates for devices outside their sites; an async correlation job kept disclosing results for devices that had moved out of the requester's sites after the job was queued, and for a requester whose role, status or MFA epoch had since changed. An explicitly empty `deviceIds`/`siteIds` filter was treated as "no filter" rather than deny-all.

**What the fix enforces.**
- New `services/logReadAuthority.ts` captures a fingerprinted authority envelope at request time (requester, partner, org, scope, site ceiling, auth/MFA epochs) and re-validates it against live user + permission state before any deferred read. Envelope tampering, a bumped auth/MFA epoch, a deactivated user, a changed scope, or a lost `devices:execute` grant all fail closed.
- `services/logSearch.ts` adds a statement-local `EXISTS (devices …)` predicate that authorizes every log row against its device's **current** org and site, on search, aggregation, trends and pattern detection. Empty `deviceIds`/`siteIds` arrays now mean deny-all.
- `routes/logs.ts` applies the live ceiling *after* saved + inline filters are merged, so neither can widen it; narrows saved-query scope metadata on list/create/get; re-validates the detection-job authority on retrieval and returns an **opaque 404** for a job that is not the requester's, whose authority is stale, or whose result contains a now-hidden device. The correlations list validates every affected/sample device inside the list/count statement, **before** pagination.
- `jobs/logCorrelation.ts` re-validates the queued envelope and shape-checks job data before running detection, so a stale or forged job cannot execute under the queue's system DB context.
- `services/aiToolsEventLogs.ts` passes the same current site ceiling into every shared AI/MCP log tool.
- `services/permissions.ts` gains an opt-in `bypassCache` option on `getUserPermissions` so authority re-validation is never served a stale cached permission set.

### SEC-2026-09-05-080 — site-restricted callers could launch the persistent correlation-rule path

**What was wrong.** Correlation-rule results are persisted as one organization-wide snapshot per rule and can raise alerts — state shared with the scheduled global runner. A site-restricted organization caller could still launch that path (`POST /logs/correlation/detect` with no `pattern`), writing org-wide correlation rows and alerts derived from devices outside their site ceiling.

**What the fix enforces.** The rules branch returns 403 whenever `auth.allowedSiteIds` is defined — a defined-but-empty allowlist counts as restricted. Unrestricted organization, partner, system and scheduled-worker operation is unchanged; the ad-hoc pattern path (owned by SEC-079) is untouched.

Also carried from that commit: `normalizeCorrelationTimestamp` in `services/logSearch.ts`. postgres.js returns values selected through raw aggregate expressions as strings even where the TypeScript annotation says `Date`, so correlation first/last-seen timestamps are now normalized — and fail closed on malformed input — before flowing into Drizzle date columns.

## Ported from

| Finding | Local commit | Notes |
|---|---|---|
| SEC-2026-09-05-079 | `9e0418e62ba3466a0d5c8a3c58bafc19a2b089ec` | cherry-picked clean |
| SEC-2026-09-05-080 | `fde7ce5fa423bddc9384d1e6985b39afc3944811` | cherry-picked clean (three-way auto-merge on `routes/logs.ts`, `routes/logs.test.ts`, `services/logSearch.ts`) |

Both were authored ~200 commits behind current main (bases `f429b5cf1d` and `6c17fcebb3` respectively; the two were siblings, not stacked). **Nothing was dropped or rewritten during the port** — verified: immediately after the two cherry-picks the diff against `origin/main` was 13 files / +1681 / −56, exactly the union of the two originals (11 files / +1309 / −53 and 5 files / +372 / −3, overlapping in `routes/logs.ts`, `routes/logs.test.ts`, `services/logSearch.ts`).

`services/permissions.ts` was the one file flagged as risky (main has moved for SEC-141 and the PAM/accounting permission families). Verified: main's version is kept intact and the ported diff there is exactly the two additive hunks the original had — the `bypassCache` option on `getUserPermissions` (skip cache read, skip cache write). No behavioural change for existing callers.

No migrations, no schema columns, no new tables — so no RLS / cascade / export-policy registration applies.

A third commit on this branch is **not** ported — it is this PR's review round.

## Review round

Applied on top of the two ported commits:

1. **`services/logSearch.ts` — stop emitting the device-authorization `EXISTS` for unrestricted callers.** `currentDeviceAuthorizationCondition` now returns `null` for a `null`/`undefined` ceiling, and each of the four call sites pushes it only when non-null. For an unrestricted caller the probe is tautological (`device_event_logs.device_id` is a NOT NULL FK into `devices`; `org_id` is the moveOrg-maintained denormalized copy) but not free: `devices` carries a non-LEAKPROOF `breeze_has_org_access` RLS policy, so Postgres cannot fold it into an index condition and pays it per candidate row of the largest table in the fleet — unbounded on `/aggregation`, `/trends` and pattern detection. This resolves the perf concern the first revision of this PR raised as an open question. A defined-but-empty ceiling still emits `and false`.
2. **`routes/logs.ts` `GET /logs/correlation` — gate the JSONB device-existence filter on a site-restricted caller, and drop the `jsonb_array_length(...) > 0` floor.** Affected/sample device ids live in JSONB with no FK, so a device delete leaves them dangling. For an unrestricted admin the filter permanently hid every historical correlation naming a since-deleted device, and hid any correlation with an empty affected list — silent data loss, not tenancy enforcement. Org isolation on this list is RLS's job.
3. **`services/logReadAuthority.ts` — typed denial.** `captureLogReadAuthority` now throws `LogReadAuthorityDeniedError`, which the detect route maps to 403 instead of letting it reach the generic handler as a 500. Unreachable today (authMiddleware always sets a user session carrying `aep`/`mep`), but it will bite when an API-key principal is wired in.
4. **`services/logReadAuthority.ts` — documented the fingerprint** as an unkeyed integrity check, not a signature: authenticity comes from the live `users` row plus the `canAccessOrg` / `devices:execute` re-check in `revalidateLogReadAuthority`.

`logReadSiteScope.integration.test.ts` needed two expectation updates as a direct consequence of (2): the `device-less-newest` fixture (empty `affectedDevices`) is now correctly visible to a site-restricted caller, so page one of `?limit=1` is that row and `total` is 2 rather than 1. The suite now also asserts the full visible id set and ordering at `?limit=50`, which keeps the "filtered before `LIMIT`, not after" property explicit.

## Verification

All commands run from `apps/api` in the branch worktree against an ephemeral pg+redis test stack (`pnpm test-stack up`). Every count below is **verified** (I ran it and read the output), not inferred.

**Red-first for the ported fixes.** Restored main's version of all five pre-existing source files and deleted the new module, leaving only the ported tests:

```
git checkout origin/main -- apps/api/src/routes/logs.ts apps/api/src/services/logSearch.ts \
  apps/api/src/jobs/logCorrelation.ts apps/api/src/services/aiToolsEventLogs.ts \
  apps/api/src/services/permissions.ts
rm apps/api/src/services/logReadAuthority.ts
cd apps/api && npx vitest run --pool=threads --maxWorkers=2 \
  src/routes/logs.test.ts src/jobs/logCorrelation.test.ts src/services/logSearch.test.ts \
  src/services/logSearch.correlationTimestamp.test.ts src/services/logReadAuthority.test.ts \
  src/services/aiToolsEventLogs.liveSiteArguments.test.ts \
  src/services/aiToolsEventLogs.siteScope.test.ts src/services/permissions.test.ts
```

→ **RED: `Test Files 5 failed | 3 passed (8)`, `Tests 14 failed | 87 passed (101)`.** Failing assertions were the security ones, by name:

- `routes/logs.test.ts` — 8 failed: *applies a deny-all current site ceiling after saved filters are merged*; *applies the same current ceiling to aggregation and trends*; *returns an opaque 404 when a completed job contains a newly hidden device*; *returns an opaque 404 for a detection job not bound to the requester*; *denies 'selected-site' callers before persistent rules execution*; *denies 'empty-site' callers before persistent rules execution*; *removes hidden saved-query scope metadata for a restricted reader*; *preserves an explicit deny-all array when every saved target is hidden*
- `services/aiToolsEventLogs.liveSiteArguments.test.ts` — 1 failed
- `services/logSearch.correlationTimestamp.test.ts` — 5 failed (incl. all three fail-closed cases)
- `jobs/logCorrelation.test.ts` and `services/logReadAuthority.test.ts` — collected **0 tests**: they import the module that does not exist on main.
- `services/logSearch.test.ts`, `services/aiToolsEventLogs.siteScope.test.ts`, `services/permissions.test.ts` passed, as expected — untouched pre-existing siblings.

Then `git checkout HEAD -- <the six files>` → **GREEN**.

**Red-first for the review round.** The two new assertions were re-run against this branch's own pre-review source (`git checkout <pre-review sha> -- apps/api/src/routes/logs.ts apps/api/src/services/logSearch.ts`, with `buildSearchConditions` re-exported so the failure is behavioural rather than a missing export):

→ **RED: `Tests 2 failed | 47 passed (49)`** — exactly the two new assertions failed, nothing else:
- `services/logSearch.test.ts` › *omits the authorized_log_device subquery for an unrestricted caller and emits it for a restricted one*
- `routes/logs.test.ts` › *emits the correlation device-existence filter only for a site-restricted caller*

Restored → green.

**Unit** — `npx vitest run --pool=threads --maxWorkers=2` over the eight files listed above: **8 files / 117 tests passed** (115 before the review round; +2 new assertions).

**Integration** — `npx vitest run --config vitest.integration.config.ts --pool=threads --maxWorkers=2 SiteScope site-scope logRead logCorrelation logSearchCursor`: **15 files / 76 tests passed**. That is the whole site-scope family (`aiToolsAuditDetailsSiteScope`, `aiToolsNetworkSiteScope`, `alertTemplateSiteScope`, `automationReadSiteScope`, `enrollmentKeyReadSiteScope`, `enrollmentKeysSiteScope`, `mtlsQuarantineSiteScope`, `onboardingTokenSiteScope`, `policyComplianceSiteScope`, `report-site-scope`, `topology-layout-site-scope`, `tunnel-allowlist-site-scope`) plus the two new suites (`logReadSiteScope`, `logCorrelationRuleSiteAuthority`) and `logSearchCursor` (the pre-existing real-DB proof of the search predicate this PR modifies). The run before the `logReadSiteScope` expectation update was 1 failed / 75 passed, and that failure was the review change working as intended — see *Review round*.

**Contract** — `site-scope-coverage.integration.test.ts` is excluded from the integration config and has its own runner: `npx vitest run --config vitest.config.site-scope-coverage.ts` → **1 file / 7 tests passed**.

**Typecheck** — `NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit` → exit 0, no output. (The default heap OOMs on this package.)

**Lint** — `npx eslint` over every touched file → exit 0, no findings.

**Rebased onto `e4fbca279d`** and re-ran the unit suite (117 passed) and `tsc` (exit 0) after the rebase.

**Not checked:** the pre-push hook ran `check-migration-naming: OK`, but no migration is in this PR. I did not run the RLS/cascade/export-policy contract suites — **inferred** not applicable, since the diff adds no table, column or migration.

## Operator impact

- **Site-restricted organization users** lose exactly the access they should never have had: log rows, aggregates, trends, counts, saved-query scope metadata and correlation results outside their assigned sites. Restricted users also get a hard 403 on the persistent correlation-**rule** path; the ad-hoc pattern path remains available to them within their ceiling. Nothing changes for unrestricted organization, partner, system or scheduled-worker callers.
- **Async correlation jobs** now fail closed rather than serving a stale result: a queued job whose requester was deactivated, whose auth/MFA epoch was bumped, or who lost the `devices:execute` grant errors in the worker instead of running, and retrieval of a job whose result contains a device that has since left the requester's ceiling returns an opaque 404 rather than a 403 (deliberate — a 403 confirms the job exists).
- **Unrestricted callers pay nothing new.** After the review round, neither the log-search `EXISTS (devices …)` predicate nor the correlation-list JSONB filter is emitted for a caller with no site ceiling, so unrestricted admin, partner and system read paths generate the same SQL they did before this PR. The added cost falls only on site-restricted callers, whose result sets are bounded by their ceiling.
- **One behaviour change for restricted callers beyond the fix itself:** a correlation with an empty `affectedDevices` list is visible to them (it names no device outside their ceiling). In practice `runCorrelationRules` only persists rows meeting `minDevices >= 1`, so this should be an empty set in production — flagged rather than silently decided.

## Follow-ups (deliberately not in this PR)

1. `resolveCurrentLogReadDeviceIds` still inlines a fleet-sized `inArray` bind list on top of the `EXISTS` predicate for restricted callers. The `EXISTS` alone is sufficient; removing the bind list is a separate PR because the current unit tests assert `allowedDeviceIds` forwarding.
2. `revalidateLogReadAuthority` runs with `bypassCache: true` on the polled `GET /logs/correlation/detect/:jobId`. Correct but uncached — worth a short TTL if that endpoint is polled hard.
3. `logReadSiteScope.integration.test.ts` packs five contracts into two `it()` blocks; it should be split so a failure names the contract that broke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Tugfg88kFiowD7E5xQFpU
