### PR TITLE
fix(authz): require MFA for extension runtime toggles and configuration-policy effective mutations (SEC-097, SEC-107)

### DIFF
--- a/apps/api/src/__tests__/integration/configPolicyInheritance.integration.test.ts
+++ b/apps/api/src/__tests__/integration/configPolicyInheritance.integration.test.ts
@@ -52,7 +52,6 @@ import {
   createConfigPolicy,
   deleteConfigPolicy,
   getConfigPolicy,
-  getParentLinkFeatureTypes,
   listEligibleParentPolicies,
   InvalidParentPolicyError,
   PolicyHasChildrenError,
@@ -899,41 +898,13 @@ describe('config policy inheritance — effective-links view (live DB)', () => {
 // ============================================================
 
 /**
- * Both of these are exercised elsewhere only against mocks, and both depend on
- * the caller's own RLS context resolving a PARTNER-WIDE parent through the
- * `*_partner_wide_select` branch. If that branch ever stops applying, a mock
- * test keeps passing while the real behaviour degrades silently — the MFA gate
- * stops firing and the editor stops showing inherited state.
+ * Exercised elsewhere only against mocks, and dependent on the caller's own RLS
+ * context resolving a PARTNER-WIDE parent through the `*_partner_wide_select`
+ * branch. If that branch ever stops applying, a mock test keeps passing while
+ * the real behaviour degrades silently and the editor stops showing inherited
+ * state.
  */
 describe('config policy inheritance — RLS-dependent reads (live DB)', () => {
-  it('getParentLinkFeatureTypes sees a PARTNER-WIDE parent\'s gated link from an ORG session', async () => {
-    const t = await seedTenancy();
-    const parent = await seedPolicy({ partnerId: t.p1, name: 'MSP baseline' });
-    await seedLink(parent.id, 'event_log');
-    await withDbAccessContext(SYSTEM_CTX, () => db.execute(sql`
-      INSERT INTO config_policy_feature_links (config_policy_id, feature_type)
-      VALUES (${parent.id}::uuid, 'maintenance')
-    `));
-
-    const types = await withDbAccessContext(orgContext(t.a1, t.p1), () =>
-      getParentLinkFeatureTypes(parent.id));
-
-    // This is what the create-time MFA gate keys on. An empty array here would
-    // silently skip the gate.
-    expect(types.sort()).toEqual(['event_log', 'maintenance']);
-  });
-
-  it('getParentLinkFeatureTypes returns nothing for ANOTHER partner\'s baseline', async () => {
-    const t = await seedTenancy();
-    const foreign = await seedPolicy({ partnerId: t.p2, name: 'Other MSP baseline' });
-    await seedLink(foreign.id, 'event_log');
-
-    const types = await withDbAccessContext(orgContext(t.a1, t.p1), () =>
-      getParentLinkFeatureTypes(foreign.id));
-
-    expect(types).toEqual([]);
-  });
-
   it('getConfigPolicy embeds a PARTNER-WIDE parent for an ORG caller, with its links', async () => {
     const t = await seedTenancy();
     const parent = await seedPolicy({ partnerId: t.p1, name: 'MSP baseline' });

--- a/apps/api/src/__tests__/integration/extensionsAdminMfa.integration.test.ts
+++ b/apps/api/src/__tests__/integration/extensionsAdminMfa.integration.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Real-database boundary test for the platform extension on/off switch.
+ *
+ * The extension itself is deliberately fake and is never loaded or executed.
+ * Only the global `installed_extensions.enabled` row is exercised, through the
+ * production state store running as the unprivileged `breeze_app` role.
+ */
+import './setup';
+import { randomUUID } from 'node:crypto';
+import { afterAll, describe, expect, it, vi } from 'vitest';
+import { eq, sql } from 'drizzle-orm';
+import { Hono } from 'hono';
+import type { AuthContext } from '../../middleware/auth';
+import { withSystemDbAccessContext } from '../../db';
+import { installedExtensions } from '../../db/schema';
+import { createExtensionsAdminRoutes } from '../../routes/extensionsAdmin';
+import {
+  DrizzleExtensionStateBackend,
+  ExtensionStateStore,
+} from '../../extensions/stateStore';
+import { getAppDb } from './setup';
+
+vi.mock('../../services/auditService', () => ({
+  createAuditLogAsync: vi.fn(),
+  createAuditLog: vi.fn(),
+}));
+
+const extensionName = `mfa-boundary-it-${randomUUID().slice(0, 8)}`;
+const registry = {
+  get: vi.fn(() => undefined),
+  activate: vi.fn(),
+  withdraw: vi.fn(),
+};
+
+function authContext(args: { platformAdmin: boolean; mfa: boolean }): AuthContext {
+  return {
+    principal: { kind: 'user_session' },
+    user: {
+      id: randomUUID(),
+      email: args.platformAdmin ? 'platform-admin@breeze.test' : 'operator@breeze.test',
+      name: 'Synthetic operator',
+      isPlatformAdmin: args.platformAdmin,
+    },
+    token: { mfa: args.mfa },
+    scope: args.platformAdmin ? 'system' : 'organization',
+    orgId: args.platformAdmin ? null : randomUUID(),
+    partnerId: null,
+    accessibleOrgIds: args.platformAdmin ? null : [],
+  } as unknown as AuthContext;
+}
+
+async function readEnabledWithoutSystemScope(): Promise<unknown[]> {
+  return getAppDb()
+    .select({ enabled: installedExtensions.enabled })
+    .from(installedExtensions)
+    .where(eq(installedExtensions.name, extensionName));
+}
+
+describe('extensions admin MFA boundary with real PostgreSQL', () => {
+  const store = new ExtensionStateStore(new DrizzleExtensionStateBackend());
+
+  afterAll(async () => {
+    await withSystemDbAccessContext(async () => {
+      const { db } = await import('../../db');
+      await db.delete(installedExtensions).where(eq(installedExtensions.name, extensionName));
+    });
+  });
+
+  it('requires MFA and platform authority before changing global state as breeze_app', async () => {
+    await store.upsertObserved({ name: extensionName, configuredVersion: '1.0.0' });
+    expect((await store.get(extensionName))?.enabled).toBe(true);
+
+    let auth = authContext({ platformAdmin: true, mfa: false });
+    const app = new Hono();
+    app.use('*', async (c, next) => {
+      c.set('auth', auth);
+      await next();
+    });
+    app.route('/api/v1/admin/extensions', createExtensionsAdminRoutes({
+      stateStore: store,
+      registry,
+      hostDescriptor: {
+        apiVersions: ['1'],
+        breezeVersion: '1.0.0',
+        serverSdkVersion: '1.0.0',
+        webSdkVersion: '1.0.0',
+        capabilities: [],
+        slots: {},
+      },
+      extensionRoots: () => new Map(),
+    }));
+
+    const noMfa = await app.request(
+      `/api/v1/admin/extensions/${extensionName}/disable`,
+      { method: 'POST' },
+    );
+    expect(noMfa.status).toBe(403);
+    expect(await noMfa.json()).toEqual({ error: 'MFA required', code: 'MFA_REQUIRED' });
+    expect((await store.get(extensionName))?.enabled).toBe(true);
+    expect(registry.get).not.toHaveBeenCalled();
+
+    auth = authContext({ platformAdmin: false, mfa: true });
+    const ordinaryOrg = await app.request(
+      `/api/v1/admin/extensions/${extensionName}/disable`,
+      { method: 'POST' },
+    );
+    expect(ordinaryOrg.status).toBe(403);
+    expect((await store.get(extensionName))?.enabled).toBe(true);
+
+    auth = authContext({ platformAdmin: true, mfa: true });
+    const allowed = await app.request(
+      `/api/v1/admin/extensions/${extensionName}/disable`,
+      { method: 'POST' },
+    );
+    expect(allowed.status).toBe(200);
+    expect(await allowed.json()).toEqual({ name: extensionName, enabled: false });
+    expect((await store.get(extensionName))?.enabled).toBe(false);
+
+    // The production store's successful access is not a superuser shortcut:
+    // the same global row remains invisible on a contextless breeze_app read.
+    expect(await readEnabledWithoutSystemScope()).toEqual([]);
+    const role = await getAppDb().execute(sql`
+      SELECT current_user AS user_name,
+             rolsuper,
+             rolbypassrls
+      FROM pg_roles
+      WHERE rolname = current_user
+    `);
+    expect(role[0]).toMatchObject({
+      user_name: 'breeze_app',
+      rolsuper: false,
+      rolbypassrls: false,
+    });
+  });
+});

--- a/apps/api/src/routes/configurationPolicies/assignments.test.ts
+++ b/apps/api/src/routes/configurationPolicies/assignments.test.ts
@@ -52,6 +52,10 @@ vi.mock('../../services/remoteAccessPolicy', () => ({
   invalidateRemoteAccessCache: vi.fn(),
 }));
 
+// ORDERING stand-in for `requireMfa()`: proves the gate runs ahead of every
+// handler body here. What the real gate ACCEPTS (an API-key `token: {}` is not
+// an MFA claim) is asserted in `crud.test.ts`, which mounts the genuine
+// middleware via `importOriginal`.
 vi.mock('../../middleware/auth', () => ({
   authMiddleware: vi.fn((c: any, next: any) => next()),
   requireScope: vi.fn(() => (c: any, next: any) => next()),

--- a/apps/api/src/routes/configurationPolicies/assignments.test.ts
+++ b/apps/api/src/routes/configurationPolicies/assignments.test.ts
@@ -11,6 +11,7 @@ const {
   authorizeAssignmentTargetMock,
   getAssignmentMock,
   canManagePartnerWideMock,
+  mfaState,
 } = vi.hoisted(() => ({
   getConfigPolicyMock: vi.fn(),
   assignPolicyMock: vi.fn(),
@@ -21,6 +22,7 @@ const {
   authorizeAssignmentTargetMock: vi.fn(),
   getAssignmentMock: vi.fn(),
   canManagePartnerWideMock: vi.fn(),
+  mfaState: { satisfied: true },
 }));
 
 vi.mock('../../services/configurationPolicy', async (importOriginal) => {
@@ -54,6 +56,10 @@ vi.mock('../../middleware/auth', () => ({
   authMiddleware: vi.fn((c: any, next: any) => next()),
   requireScope: vi.fn(() => (c: any, next: any) => next()),
   requirePermission: vi.fn(() => (c: any, next: any) => next()),
+  requireMfa: vi.fn(() => async (c: any, next: any) => {
+    if (!mfaState.satisfied) return c.json({ error: 'MFA required', code: 'MFA_REQUIRED' }, 403);
+    await next();
+  }),
 }));
 
 import { assignmentRoutes } from './assignments';
@@ -94,6 +100,7 @@ describe('configurationPolicies assignment routes', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mfaState.satisfied = true;
     // SR5-07 site sub-axis: default to "allowed" so existing (unrestricted)
     // cases are unaffected; individual tests override to assert denial. The real
     // helper is a no-op for callers without allowedSiteIds, so mocking it keeps
@@ -107,6 +114,38 @@ describe('configurationPolicies assignment routes', () => {
       await next();
     });
     app.route('/', assignmentRoutes);
+  });
+
+  describe('MFA boundary for assignment mutations', () => {
+    beforeEach(() => {
+      mfaState.satisfied = false;
+    });
+
+    it('denies assignment before policy, target, mutation, cache, or audit work', async () => {
+      const res = await app.request(`/${POLICY_ID}/assignments`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ level: 'device', targetId: DEVICE_ID }),
+      });
+
+      expect(res.status).toBe(403);
+      await expect(res.json()).resolves.toMatchObject({ code: 'MFA_REQUIRED' });
+      expect(getConfigPolicyMock).not.toHaveBeenCalled();
+      expect(validateAssignmentTargetMock).not.toHaveBeenCalled();
+      expect(assignPolicyMock).not.toHaveBeenCalled();
+    });
+
+    it('denies unassignment before reading or deleting the assignment', async () => {
+      const res = await app.request(`/${POLICY_ID}/assignments/77777777-7777-7777-7777-777777777777`, {
+        method: 'DELETE',
+      });
+
+      expect(res.status).toBe(403);
+      await expect(res.json()).resolves.toMatchObject({ code: 'MFA_REQUIRED' });
+      expect(getConfigPolicyMock).not.toHaveBeenCalled();
+      expect(getAssignmentMock).not.toHaveBeenCalled();
+      expect(unassignPolicyMock).not.toHaveBeenCalled();
+    });
   });
 
   it('filters policy assignment reads through target site authorization', async () => {

--- a/apps/api/src/routes/configurationPolicies/assignments.ts
+++ b/apps/api/src/routes/configurationPolicies/assignments.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { zValidator } from '../../lib/validation';
 import type { AuthContext } from '../../middleware/auth';
-import { requirePermission, requireScope } from '../../middleware/auth';
+import { requireMfa, requirePermission, requireScope } from '../../middleware/auth';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { PERMISSIONS } from '../../services/permissions';
 import {
@@ -66,6 +66,7 @@ assignmentRoutes.post(
   '/:id/assignments',
   requireScope('organization', 'partner', 'system'),
   requireConfigPolicyWrite,
+  requireMfa(),
   zValidator('param', idParamSchema),
   zValidator('json', assignPolicySchema),
   async (c) => {
@@ -162,6 +163,7 @@ assignmentRoutes.delete(
   '/:id/assignments/:aid',
   requireScope('organization', 'partner', 'system'),
   requireConfigPolicyWrite,
+  requireMfa(),
   zValidator('param', assignmentIdParamSchema),
   async (c) => {
     const auth = c.get('auth') as AuthContext;

--- a/apps/api/src/routes/configurationPolicies/crud.siteScope.test.ts
+++ b/apps/api/src/routes/configurationPolicies/crud.siteScope.test.ts
@@ -6,13 +6,11 @@ const {
   updateConfigPolicyMock,
   deleteConfigPolicyMock,
   dbSelectMock,
-  getParentLinkFeatureTypesMock,
 } = vi.hoisted(() => ({
   createConfigPolicyMock: vi.fn(),
   updateConfigPolicyMock: vi.fn(),
   deleteConfigPolicyMock: vi.fn(),
   dbSelectMock: vi.fn(),
-  getParentLinkFeatureTypesMock: vi.fn(),
 }));
 
 vi.mock('../../services/configurationPolicy', async (importOriginal) => {
@@ -22,7 +20,6 @@ vi.mock('../../services/configurationPolicy', async (importOriginal) => {
     createConfigPolicy: createConfigPolicyMock,
     updateConfigPolicy: updateConfigPolicyMock,
     deleteConfigPolicy: deleteConfigPolicyMock,
-    getParentLinkFeatureTypes: getParentLinkFeatureTypesMock,
   };
 });
 
@@ -41,7 +38,6 @@ vi.mock('../../middleware/auth', () => ({
   requireScope: vi.fn(() => (c: any, next: any) => next()),
   requirePermission: vi.fn(() => (c: any, next: any) => next()),
   requireMfa: vi.fn(() => (_c: any, next: any) => next()),
-  hasSatisfiedMfa: vi.fn(() => true),
 }));
 
 import { crudRoutes } from './crud';
@@ -76,7 +72,6 @@ function app(auth: any) {
 describe('configuration policies CRUD — site-ceiling gate', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    getParentLinkFeatureTypesMock.mockResolvedValue([]);
   });
 
   it.each([

--- a/apps/api/src/routes/configurationPolicies/crud.siteScope.test.ts
+++ b/apps/api/src/routes/configurationPolicies/crud.siteScope.test.ts
@@ -40,6 +40,7 @@ vi.mock('../../middleware/auth', () => ({
   authMiddleware: vi.fn((c: any, next: any) => next()),
   requireScope: vi.fn(() => (c: any, next: any) => next()),
   requirePermission: vi.fn(() => (c: any, next: any) => next()),
+  requireMfa: vi.fn(() => (_c: any, next: any) => next()),
   hasSatisfiedMfa: vi.fn(() => true),
 }));
 

--- a/apps/api/src/routes/configurationPolicies/crud.test.ts
+++ b/apps/api/src/routes/configurationPolicies/crud.test.ts
@@ -11,7 +11,6 @@ const {
   assignPolicyMock,
   dbSelectMock,
   listEligibleParentPoliciesMock,
-  getParentLinkFeatureTypesMock,
   mfaState,
 } = vi.hoisted(() => ({
   listConfigPoliciesMock: vi.fn(),
@@ -22,7 +21,6 @@ const {
   assignPolicyMock: vi.fn(),
   dbSelectMock: vi.fn(),
   listEligibleParentPoliciesMock: vi.fn(),
-  getParentLinkFeatureTypesMock: vi.fn(),
   // Mutable so a single test can flip MFA off without re-mocking the module.
   mfaState: { satisfied: true },
 }));
@@ -40,7 +38,6 @@ vi.mock('../../services/configurationPolicy', async (importOriginal) => {
     deleteConfigPolicy: deleteConfigPolicyMock,
     assignPolicy: assignPolicyMock,
     listEligibleParentPolicies: listEligibleParentPoliciesMock,
-    getParentLinkFeatureTypes: getParentLinkFeatureTypesMock,
   };
 });
 
@@ -70,6 +67,10 @@ vi.mock('../../middleware/auth', () => ({
   authMiddleware: vi.fn((c: any, next: any) => next()),
   requireScope: vi.fn(() => (c: any, next: any) => next()),
   requirePermission: vi.fn(() => (c: any, next: any) => next()),
+  requireMfa: vi.fn(() => async (c: any, next: any) => {
+    if (!mfaState.satisfied) return c.json({ error: 'MFA required', code: 'MFA_REQUIRED' }, 403);
+    await next();
+  }),
   hasSatisfiedMfa: vi.fn(() => mfaState.satisfied),
 }));
 
@@ -123,7 +124,6 @@ describe('configurationPolicies CRUD routes', () => {
     // auto-assign error-path test leaks into later cases.
     assignPolicyMock.mockResolvedValue({ id: 'assignment-1' });
     deleteConfigPolicyMock.mockResolvedValue({ id: POLICY_ID });
-    getParentLinkFeatureTypesMock.mockResolvedValue([]);
     listEligibleParentPoliciesMock.mockResolvedValue([]);
     mfaState.satisfied = true;
     mockOrgExists(true); // default: system-scope org-existence check passes
@@ -134,6 +134,29 @@ describe('configurationPolicies CRUD routes', () => {
       await next();
     });
     app.route('/', crudRoutes);
+  });
+
+  describe('MFA boundary for effective policy mutations', () => {
+    beforeEach(() => {
+      mfaState.satisfied = false;
+    });
+
+    it.each([
+      ['create', '/', 'POST', { name: 'Must not persist' }, createConfigPolicyMock],
+      ['update', `/${POLICY_ID}`, 'PATCH', { status: 'inactive' }, updateConfigPolicyMock],
+      ['delete', `/${POLICY_ID}`, 'DELETE', undefined, deleteConfigPolicyMock],
+    ] as const)('denies %s before any policy service or success audit', async (_name, path, method, body, sink) => {
+      const res = await app.request(path, {
+        method,
+        headers: body ? { 'Content-Type': 'application/json' } : undefined,
+        body: body ? JSON.stringify(body) : undefined,
+      });
+
+      expect(res.status).toBe(403);
+      await expect(res.json()).resolves.toMatchObject({ code: 'MFA_REQUIRED' });
+      expect(sink).not.toHaveBeenCalled();
+      expect(writeRouteAudit).not.toHaveBeenCalled();
+    });
   });
 
   // ============================================
@@ -749,10 +772,7 @@ describe('configurationPolicies CRUD routes', () => {
       expect(await res.json()).toMatchObject({ error: 'INVALID_PARENT_POLICY' });
     });
 
-    // MFA follows effectiveness: inheriting a gated link enables it on the new
-    // policy, the same capability POST /:id/features already gates.
-    it('POST requires MFA when the parent carries a gated link', async () => {
-      getParentLinkFeatureTypesMock.mockResolvedValue(['maintenance']);
+    it('POST with a parent requires MFA before resolving or creating the policy', async () => {
       mfaState.satisfied = false;
 
       const res = await app.request('/', {
@@ -766,21 +786,7 @@ describe('configurationPolicies CRUD routes', () => {
       expect(createConfigPolicyMock).not.toHaveBeenCalled();
     });
 
-    it('POST allows an ungated parent without MFA', async () => {
-      getParentLinkFeatureTypesMock.mockResolvedValue(['event_log']);
-      mfaState.satisfied = false;
-      createConfigPolicyMock.mockResolvedValue({ id: POLICY_ID, name: 'Child', orgId: ORG_ID });
-
-      const res = await app.request('/', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: 'Child', parentPolicyId: PARENT_ID }),
-      });
-
-      expect(res.status).toBe(201);
-    });
-
-    it('POST without a parent never consults the parent MFA gate', async () => {
+    it('POST without a parent also requires MFA before policy creation', async () => {
       mfaState.satisfied = false;
       createConfigPolicyMock.mockResolvedValue({ id: POLICY_ID, name: 'Root', orgId: ORG_ID });
 
@@ -790,8 +796,8 @@ describe('configurationPolicies CRUD routes', () => {
         body: JSON.stringify({ name: 'Root' }),
       });
 
-      expect(res.status).toBe(201);
-      expect(getParentLinkFeatureTypesMock).not.toHaveBeenCalled();
+      expect(res.status).toBe(403);
+      expect(createConfigPolicyMock).not.toHaveBeenCalled();
     });
 
     it('DELETE maps PolicyHasChildrenError to 409 with the children', async () => {

--- a/apps/api/src/routes/configurationPolicies/crud.test.ts
+++ b/apps/api/src/routes/configurationPolicies/crud.test.ts
@@ -11,7 +11,6 @@ const {
   assignPolicyMock,
   dbSelectMock,
   listEligibleParentPoliciesMock,
-  mfaState,
 } = vi.hoisted(() => ({
   listConfigPoliciesMock: vi.fn(),
   createConfigPolicyMock: vi.fn(),
@@ -21,8 +20,6 @@ const {
   assignPolicyMock: vi.fn(),
   dbSelectMock: vi.fn(),
   listEligibleParentPoliciesMock: vi.fn(),
-  // Mutable so a single test can flip MFA off without re-mocking the module.
-  mfaState: { satisfied: true },
 }));
 
 vi.mock('../../services/configurationPolicy', async (importOriginal) => {
@@ -63,15 +60,18 @@ vi.mock('../../services/auditEvents', () => ({
   writeRouteAudit: vi.fn(),
 }));
 
-vi.mock('../../middleware/auth', () => ({
+// `importOriginal` on purpose: this is the ONE config-policy route suite that
+// exercises the REAL `requireMfa()` (and, through it, the real
+// `hasSatisfiedMfa` + `ENABLE_2FA` resolution) rather than a hand-written
+// stand-in. A stand-in can only prove middleware ORDERING; it cannot catch a
+// change to what the gate actually accepts — e.g. an API-key context whose
+// `token: {}` carries no `mfa` claim. Only `authMiddleware` / `requireScope` /
+// `requirePermission` are stubbed, so the suite can inject its own auth.
+vi.mock('../../middleware/auth', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../middleware/auth')>()),
   authMiddleware: vi.fn((c: any, next: any) => next()),
   requireScope: vi.fn(() => (c: any, next: any) => next()),
   requirePermission: vi.fn(() => (c: any, next: any) => next()),
-  requireMfa: vi.fn(() => async (c: any, next: any) => {
-    if (!mfaState.satisfied) return c.json({ error: 'MFA required', code: 'MFA_REQUIRED' }, 403);
-    await next();
-  }),
-  hasSatisfiedMfa: vi.fn(() => mfaState.satisfied),
 }));
 
 import { crudRoutes } from './crud';
@@ -94,7 +94,10 @@ function makeAuth(overrides: Record<string, unknown> = {}): any {
     orgId: ORG_ID,
     partnerId: null,
     user: { id: 'user-1', email: 'test@example.com', name: 'Test User' },
-    token: { scope: 'organization' },
+    // The real `requireMfa()` runs in this suite (see the auth mock above), so
+    // the default session must carry a satisfied claim or every mutation case
+    // would 403. Individual tests override `token` to assert the denial.
+    token: { scope: 'organization', mfa: true },
     accessibleOrgIds: [ORG_ID],
     canAccessOrg: (orgId: string) => orgId === ORG_ID,
     orgCondition: () => undefined,
@@ -116,6 +119,9 @@ function makePermissions(overrides: Record<string, unknown> = {}): any {
 
 describe('configurationPolicies CRUD routes', () => {
   let app: Hono;
+  // Swapped in per test so a case can drive the shared `app` with a different
+  // principal without rebuilding it (the beforeEach app is mounted once).
+  let authOverride: any = null;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -125,12 +131,12 @@ describe('configurationPolicies CRUD routes', () => {
     assignPolicyMock.mockResolvedValue({ id: 'assignment-1' });
     deleteConfigPolicyMock.mockResolvedValue({ id: POLICY_ID });
     listEligibleParentPoliciesMock.mockResolvedValue([]);
-    mfaState.satisfied = true;
+    authOverride = null;
     mockOrgExists(true); // default: system-scope org-existence check passes
     app = new Hono();
     // Set auth context before mounting routes
     app.use('*', async (c, next) => {
-      c.set('auth', makeAuth());
+      c.set('auth', authOverride ?? makeAuth());
       await next();
     });
     app.route('/', crudRoutes);
@@ -138,7 +144,9 @@ describe('configurationPolicies CRUD routes', () => {
 
   describe('MFA boundary for effective policy mutations', () => {
     beforeEach(() => {
-      mfaState.satisfied = false;
+      // A human session that never satisfied MFA: same shape as the default,
+      // minus the `mfa` claim. Denial here comes from the REAL requireMfa().
+      authOverride = makeAuth({ token: { scope: 'organization' } });
     });
 
     it.each([
@@ -156,6 +164,38 @@ describe('configurationPolicies CRUD routes', () => {
       await expect(res.json()).resolves.toMatchObject({ code: 'MFA_REQUIRED' });
       expect(sink).not.toHaveBeenCalled();
       expect(writeRouteAudit).not.toHaveBeenCalled();
+    });
+
+    it('denies an API-key principal whose token carries no mfa claim', async () => {
+      // Machine MCP/API-key contexts are minted with `token: {}` (mcpServer.ts),
+      // so with ENABLE_2FA on they never satisfy the real gate. This is the
+      // assertion a hand-written requireMfa stand-in cannot make: it proves
+      // what the gate ACCEPTS, not merely that some middleware ran first.
+      authOverride = makeAuth({ principal: { kind: 'api_key', apiKeyId: 'key-1' }, token: {} });
+
+      const res = await app.request('/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Must not persist' }),
+      });
+
+      expect(res.status).toBe(403);
+      await expect(res.json()).resolves.toMatchObject({ code: 'MFA_REQUIRED' });
+      expect(createConfigPolicyMock).not.toHaveBeenCalled();
+    });
+
+    it('admits the default session, proving the gate is not denying unconditionally', async () => {
+      createConfigPolicyMock.mockResolvedValue({ id: POLICY_ID, name: 'Root', orgId: ORG_ID });
+      authOverride = null; // makeAuth() default: token.mfa === true
+
+      const res = await app.request('/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Root' }),
+      });
+
+      expect(res.status).toBe(201);
+      expect(createConfigPolicyMock).toHaveBeenCalled();
     });
   });
 
@@ -773,7 +813,7 @@ describe('configurationPolicies CRUD routes', () => {
     });
 
     it('POST with a parent requires MFA before resolving or creating the policy', async () => {
-      mfaState.satisfied = false;
+      authOverride = makeAuth({ token: { scope: 'organization' } });
 
       const res = await app.request('/', {
         method: 'POST',
@@ -787,7 +827,7 @@ describe('configurationPolicies CRUD routes', () => {
     });
 
     it('POST without a parent also requires MFA before policy creation', async () => {
-      mfaState.satisfied = false;
+      authOverride = makeAuth({ token: { scope: 'organization' } });
       createConfigPolicyMock.mockResolvedValue({ id: POLICY_ID, name: 'Root', orgId: ORG_ID });
 
       const res = await app.request('/', {

--- a/apps/api/src/routes/configurationPolicies/crud.ts
+++ b/apps/api/src/routes/configurationPolicies/crud.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 import { zValidator } from '../../lib/validation';
 import { eq } from 'drizzle-orm';
 import type { AuthContext } from '../../middleware/auth';
-import { hasSatisfiedMfa, requirePermission, requireScope } from '../../middleware/auth';
+import { requireMfa, requirePermission, requireScope } from '../../middleware/auth';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { PERMISSIONS } from '../../services/permissions';
 import { db } from '../../db';
@@ -14,7 +14,6 @@ import {
   updateConfigPolicy,
   deleteConfigPolicy,
   listEligibleParentPolicies,
-  getParentLinkFeatureTypes,
   canManagePartnerWidePolicies,
   PartnerWideWriteDeniedError,
   InvalidParentPolicyError,
@@ -22,7 +21,6 @@ import {
 } from '../../services/configurationPolicy';
 import { invalidateRemoteAccessCache } from '../../services/remoteAccessPolicy';
 import { canMutateOrgWideGovernance, SITE_CEILING_WRITE_DENIED_MESSAGE } from '../../services/siteCeilingAccess';
-import { MFA_GATED_FEATURE_TYPES } from './featureLinks';
 import {
   createConfigPolicySchema,
   updateConfigPolicySchema,
@@ -62,6 +60,7 @@ crudRoutes.post(
   '/',
   requireScope('organization', 'partner', 'system'),
   requireConfigPolicyWrite,
+  requireMfa(),
   zValidator('json', createConfigPolicySchema),
   async (c) => {
     const auth = c.get('auth') as AuthContext;
@@ -69,18 +68,6 @@ crudRoutes.post(
       return c.json({ error: SITE_CEILING_WRITE_DENIED_MESSAGE }, 403);
     }
     const data = c.req.valid('json');
-
-    // MFA follows EFFECTIVENESS, not the verb (#5080). Creating a child of a
-    // parent that carries a patch or maintenance link makes that link effective
-    // on the new policy immediately — the same capability the direct
-    // POST /:id/features gate protects, reached through a second door.
-    // Session-claim strength (hasSatisfiedMfa), matching the adjacent gates.
-    if (data.parentPolicyId) {
-      const parentTypes = await getParentLinkFeatureTypes(data.parentPolicyId);
-      if (parentTypes.some((t) => MFA_GATED_FEATURE_TYPES.has(t)) && !hasSatisfiedMfa(auth)) {
-        return c.json({ error: 'MFA required' }, 403);
-      }
-    }
 
     // Partner-wide / all-orgs policy (#1724). The partner is ALWAYS derived from
     // the caller's own token — never from a client-supplied value — so a caller
@@ -248,6 +235,7 @@ crudRoutes.patch(
   '/:id',
   requireScope('organization', 'partner', 'system'),
   requireConfigPolicyWrite,
+  requireMfa(),
   zValidator('param', idParamSchema),
   zValidator('json', updateConfigPolicySchema),
   async (c) => {
@@ -291,6 +279,7 @@ crudRoutes.delete(
   '/:id',
   requireScope('organization', 'partner', 'system'),
   requireConfigPolicyWrite,
+  requireMfa(),
   zValidator('param', idParamSchema),
   async (c) => {
     const auth = c.get('auth') as AuthContext;

--- a/apps/api/src/routes/configurationPolicies/featureLinks.remoteAccess.test.ts
+++ b/apps/api/src/routes/configurationPolicies/featureLinks.remoteAccess.test.ts
@@ -36,7 +36,6 @@ vi.mock('../../middleware/auth', () => ({
   requireScope: vi.fn(() => (c: any, next: any) => next()),
   requirePermission: vi.fn(() => (c: any, next: any) => next()),
   requireMfa: vi.fn(() => (_c: any, next: any) => next()),
-  hasSatisfiedMfa: vi.fn(() => true),
 }));
 
 import { featureLinkRoutes } from './featureLinks';

--- a/apps/api/src/routes/configurationPolicies/featureLinks.remoteAccess.test.ts
+++ b/apps/api/src/routes/configurationPolicies/featureLinks.remoteAccess.test.ts
@@ -35,6 +35,7 @@ vi.mock('../../middleware/auth', () => ({
   authMiddleware: vi.fn((c: any, next: any) => next()),
   requireScope: vi.fn(() => (c: any, next: any) => next()),
   requirePermission: vi.fn(() => (c: any, next: any) => next()),
+  requireMfa: vi.fn(() => (_c: any, next: any) => next()),
   hasSatisfiedMfa: vi.fn(() => true),
 }));
 

--- a/apps/api/src/routes/configurationPolicies/featureLinks.siteScope.test.ts
+++ b/apps/api/src/routes/configurationPolicies/featureLinks.siteScope.test.ts
@@ -34,7 +34,6 @@ vi.mock('../../middleware/auth', () => ({
   requireScope: vi.fn(() => (c: any, next: any) => next()),
   requirePermission: vi.fn(() => (c: any, next: any) => next()),
   requireMfa: vi.fn(() => (_c: any, next: any) => next()),
-  hasSatisfiedMfa: vi.fn(() => true),
 }));
 
 import { featureLinkRoutes } from './featureLinks';

--- a/apps/api/src/routes/configurationPolicies/featureLinks.siteScope.test.ts
+++ b/apps/api/src/routes/configurationPolicies/featureLinks.siteScope.test.ts
@@ -33,6 +33,7 @@ vi.mock('../../middleware/auth', () => ({
   authMiddleware: vi.fn((c: any, next: any) => next()),
   requireScope: vi.fn(() => (c: any, next: any) => next()),
   requirePermission: vi.fn(() => (c: any, next: any) => next()),
+  requireMfa: vi.fn(() => (_c: any, next: any) => next()),
   hasSatisfiedMfa: vi.fn(() => true),
 }));
 

--- a/apps/api/src/routes/configurationPolicies/featureLinks.test.ts
+++ b/apps/api/src/routes/configurationPolicies/featureLinks.test.ts
@@ -40,11 +40,12 @@ vi.mock('../../services/auditEvents', () => ({
   writeRouteAudit: vi.fn(),
 }));
 
-// RMM-QA-176: the MFA answer becomes per-test controllable, DEFAULTING TO TRUE
-// so every pre-existing case in this file keeps exactly its current meaning
-// (they are about inline-settings validation and partner-wide scope, not MFA).
-// Before this, `hasSatisfiedMfa: () => true` meant no test in the repo ever
-// exercised this route's MFA branch — for maintenance OR for patch.
+// The MFA answer is per-test controllable, DEFAULTING TO TRUE so every
+// pre-existing case in this file keeps exactly its current meaning (they are
+// about inline-settings validation and partner-wide scope, not MFA).
+// This is an ORDERING stand-in: it proves `requireMfa()` runs ahead of every
+// handler body. What the real gate ACCEPTS is asserted in `crud.test.ts`,
+// which mounts the genuine middleware via `importOriginal`.
 const { mfaState } = vi.hoisted(() => ({ mfaState: { satisfied: true } }));
 
 vi.mock('../../middleware/auth', () => ({
@@ -55,7 +56,6 @@ vi.mock('../../middleware/auth', () => ({
     if (!mfaState.satisfied) return c.json({ error: 'MFA required', code: 'MFA_REQUIRED' }, 403);
     await next();
   }),
-  hasSatisfiedMfa: vi.fn(() => mfaState.satisfied),
 }));
 
 import { featureLinkRoutes } from './featureLinks';

--- a/apps/api/src/routes/configurationPolicies/featureLinks.test.ts
+++ b/apps/api/src/routes/configurationPolicies/featureLinks.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Hono } from 'hono';
 import { onedriveHelperInlineSettingsSchema } from '@breeze/shared/validators';
+import { writeRouteAudit } from '../../services/auditEvents';
 
 // Hoist mock values so they're available in vi.mock factories
 const {
@@ -50,10 +51,14 @@ vi.mock('../../middleware/auth', () => ({
   authMiddleware: vi.fn((c: any, next: any) => next()),
   requireScope: vi.fn(() => (c: any, next: any) => next()),
   requirePermission: vi.fn(() => (c: any, next: any) => next()),
+  requireMfa: vi.fn(() => async (c: any, next: any) => {
+    if (!mfaState.satisfied) return c.json({ error: 'MFA required', code: 'MFA_REQUIRED' }, 403);
+    await next();
+  }),
   hasSatisfiedMfa: vi.fn(() => mfaState.satisfied),
 }));
 
-import { MFA_GATED_FEATURE_TYPES, featureLinkRoutes } from './featureLinks';
+import { featureLinkRoutes } from './featureLinks';
 
 const ORG_ID = '11111111-1111-1111-1111-111111111111';
 const POLICY_ID = '22222222-2222-2222-2222-222222222222';
@@ -103,6 +108,32 @@ const STUB_POLICY_WITH_PAM_LINK = {
 };
 
 describe('featureLinks routes', () => {
+  describe('MFA boundary for every feature-link mutation', () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+      mfaState.satisfied = false;
+    });
+
+    it.each([
+      ['add', `/${POLICY_ID}/features`, 'POST', { featureType: 'pam', inlineSettings: {} }, addFeatureLinkMock],
+      ['update', `/${POLICY_ID}/features/${LINK_ID}`, 'PATCH', { inlineSettings: {} }, updateFeatureLinkMock],
+      ['remove', `/${POLICY_ID}/features/${LINK_ID}`, 'DELETE', undefined, removeFeatureLinkMock],
+    ] as const)('denies %s before policy lookup, mutation, or audit', async (_name, path, method, body, sink) => {
+      const app = buildApp();
+      const res = await app.request(path, {
+        method,
+        headers: body ? { 'Content-Type': 'application/json' } : undefined,
+        body: body ? JSON.stringify(body) : undefined,
+      });
+
+      expect(res.status).toBe(403);
+      await expect(res.json()).resolves.toMatchObject({ code: 'MFA_REQUIRED' });
+      expect(getConfigPolicyMock).not.toHaveBeenCalled();
+      expect(sink).not.toHaveBeenCalled();
+      expect(writeRouteAudit).not.toHaveBeenCalled();
+    });
+  });
+
   let app: Hono;
 
   beforeEach(() => {
@@ -921,10 +952,10 @@ describe('featureLinks routes', () => {
     });
   });
   // ============================================================
-  // MFA gate on monitoring-suppression feature links (RMM-QA-176 D8)
+  // MFA gate on every persistent feature-link mutation
   // ============================================================
 
-  describe('MFA gate on monitoring-suppression feature links (RMM-QA-176 D8)', () => {
+  describe('MFA gate on feature-link mutations', () => {
     const STUB_POLICY_WITH_MAINTENANCE_LINK = {
       ...STUB_POLICY,
       featureLinks: [{ id: LINK_ID, featureType: 'maintenance' }],
@@ -969,17 +1000,15 @@ describe('featureLinks routes', () => {
       expect(await res.json()).toMatchObject({ error: 'MFA required' });
     });
 
-    it('still allows REMOVING a maintenance link without MFA — removal ENDS suppression', async () => {
-      // Mirrors "keep exit safely available" (D3): the safe direction is never
-      // gated. A technician must always be able to stop suppressing monitoring.
+    it('requires MFA to remove a maintenance link', async () => {
       mfaState.satisfied = false;
       getConfigPolicyMock.mockResolvedValue(STUB_POLICY_WITH_MAINTENANCE_LINK);
       removeFeatureLinkMock.mockResolvedValue({ id: LINK_ID, featureType: 'maintenance' });
 
       const res = await buildApp().request(`/${POLICY_ID}/features/${LINK_ID}`, { method: 'DELETE' });
 
-      expect(res.status).toBe(200);
-      expect(removeFeatureLinkMock).toHaveBeenCalled();
+      expect(res.status).toBe(403);
+      expect(removeFeatureLinkMock).not.toHaveBeenCalled();
     });
 
     // #5080: "removal ends suppression" stops holding once a link can be
@@ -1005,7 +1034,7 @@ describe('featureLinks routes', () => {
       expect(await res.json()).toMatchObject({ error: 'MFA required' });
     });
 
-    it('does NOT gate removal when the parent has no maintenance link of its own', async () => {
+    it('requires MFA to remove a maintenance link even when the parent has none', async () => {
       mfaState.satisfied = false;
       getConfigPolicyMock.mockResolvedValue({
         ...STUB_POLICY_WITH_MAINTENANCE_LINK,
@@ -1020,13 +1049,11 @@ describe('featureLinks routes', () => {
 
       const res = await buildApp().request(`/${POLICY_ID}/features/${LINK_ID}`, { method: 'DELETE' });
 
-      expect(res.status).toBe(200);
-      expect(removeFeatureLinkMock).toHaveBeenCalled();
+      expect(res.status).toBe(403);
+      expect(removeFeatureLinkMock).not.toHaveBeenCalled();
     });
 
-    it('does NOT gate removal of a non-maintenance override the parent also has', async () => {
-      // The revert exception is maintenance-only: reverting an event_log
-      // override restores config, not suppression.
+    it('requires MFA to remove a non-maintenance override', async () => {
       mfaState.satisfied = false;
       getConfigPolicyMock.mockResolvedValue({
         ...STUB_POLICY,
@@ -1042,8 +1069,8 @@ describe('featureLinks routes', () => {
 
       const res = await buildApp().request(`/${POLICY_ID}/features/${LINK_ID}`, { method: 'DELETE' });
 
-      expect(res.status).toBe(200);
-      expect(removeFeatureLinkMock).toHaveBeenCalled();
+      expect(res.status).toBe(403);
+      expect(removeFeatureLinkMock).not.toHaveBeenCalled();
     });
 
     // FAIL-CLOSED regression. parentPolicyId set + parentPolicy null means the
@@ -1066,9 +1093,7 @@ describe('featureLinks routes', () => {
       expect(await res.json()).toMatchObject({ error: 'MFA required' });
     });
 
-    // Control: a ROOT policy (no parentPolicyId at all) must stay ungated — the
-    // fail-closed branch keys on an UNRESOLVED parent, not on a missing one.
-    it('still allows removal on a root policy, where parentPolicy is legitimately absent', async () => {
+    it('requires MFA to remove a link from a root policy', async () => {
       mfaState.satisfied = false;
       getConfigPolicyMock.mockResolvedValue({
         ...STUB_POLICY_WITH_MAINTENANCE_LINK,
@@ -1079,8 +1104,8 @@ describe('featureLinks routes', () => {
 
       const res = await buildApp().request(`/${POLICY_ID}/features/${LINK_ID}`, { method: 'DELETE' });
 
-      expect(res.status).toBe(200);
-      expect(removeFeatureLinkMock).toHaveBeenCalled();
+      expect(res.status).toBe(403);
+      expect(removeFeatureLinkMock).not.toHaveBeenCalled();
     });
 
     it('keeps patch DELETE unconditionally gated even with an inheriting parent', async () => {
@@ -1113,9 +1138,7 @@ describe('featureLinks routes', () => {
       expect(res.status).toBe(403);
     });
 
-    it('does NOT gate an unrelated feature type (monitoring) — the gate stays narrow', async () => {
-      // Regression guard against over-gating: this PR promotes exactly one
-      // feature type. `monitoring` is agent-side watches, not suppression.
+    it('requires MFA for monitoring feature mutations too', async () => {
       mfaState.satisfied = false;
       getConfigPolicyMock.mockResolvedValue(STUB_POLICY);
       addFeatureLinkMock.mockResolvedValue({ id: LINK_ID, featureType: 'monitoring' });
@@ -1126,8 +1149,8 @@ describe('featureLinks routes', () => {
         body: JSON.stringify({ featureType: 'monitoring', inlineSettings: { checkIntervalSeconds: 60, watches: [] } }),
       });
 
-      expect(res.status).toBe(201);
-      expect(addFeatureLinkMock).toHaveBeenCalled();
+      expect(res.status).toBe(403);
+      expect(addFeatureLinkMock).not.toHaveBeenCalled();
     });
 
     it('an assured session is unaffected on every gated type', async () => {
@@ -1145,8 +1168,5 @@ describe('featureLinks routes', () => {
       expect(addFeatureLinkMock).toHaveBeenCalled();
     });
 
-    it('names maintenance and patch as the gated set, and nothing else', () => {
-      expect([...MFA_GATED_FEATURE_TYPES].sort()).toEqual(['maintenance', 'patch']);
-    });
   });
 });

--- a/apps/api/src/routes/configurationPolicies/featureLinks.ts
+++ b/apps/api/src/routes/configurationPolicies/featureLinks.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 import { zValidator } from '../../lib/validation';
 import { zodValidationErrorBody } from '../../lib/zodIssues';
 import type { AuthContext } from '../../middleware/auth';
-import { hasSatisfiedMfa, requirePermission, requireScope } from '../../middleware/auth';
+import { requireMfa, requirePermission, requireScope } from '../../middleware/auth';
 import {
   alertRuleInlineSettingsSchema,
   backupInlineSettingsSchema,
@@ -61,35 +61,6 @@ const requireConfigPolicyWrite = requirePermission(PERMISSIONS.DEVICES_WRITE.res
 // under the partner. See configPolicyPatching.ts.
 const ORG_SCOPED_ONLY_FEATURES: ReadonlySet<string> = ORG_SCOPED_ONLY_FEATURE_TYPES;
 
-/**
- * Feature types whose feature link may only be authored (added or updated) by
- * a session that has satisfied MFA.
- *
- * `patch` was here from the start: a patch link arms unattended installs and
- * reboots. `maintenance` joins it (RMM-QA-176 D8) because a maintenance link
- * is the CANONICAL monitoring-suppression source — every alert, patch, script
- * and reboot consumer reads it via featureConfigResolver's
- * checkDeviceMaintenanceWindow / resolveMaintenanceConfigForDevice. Gating
- * POST /devices/:id/maintenance while leaving this open would have left the
- * same capability reachable through a second door.
- *
- * Session-claim strength on purpose, NOT the operation-bound step-up grant the
- * device route requires (RMM-QA-176 D1): a policy-level window is authored
- * CONFIGURATION, not a per-device actuation, and parity with the adjacent
- * patch gate is the shape that stays consistent as more types are added.
- *
- * REMOVAL IS MOSTLY NOT GATED: removing a maintenance link ENDS suppression —
- * the safe direction, the same reasoning that keeps maintenance EXIT un-gated on
- * the device route. Patch removal stays unconditionally gated.
- *
- * ONE EXCEPTION, added with inheritance (#5080): when the policy has a parent
- * that carries a `maintenance` link, deleting the child's own maintenance link
- * is not an exit at all — it REVERTS to the parent's window and restores
- * suppression. That transition is gated. The premise "removal ends suppression"
- * simply stops holding once a link can be inherited.
- */
-export const MFA_GATED_FEATURE_TYPES: ReadonlySet<string> = new Set(['patch', 'maintenance']);
-
 // GET /:id/features — list feature links for a policy
 featureLinkRoutes.get(
   '/:id/features',
@@ -113,6 +84,7 @@ featureLinkRoutes.post(
   '/:id/features',
   requireScope('organization', 'partner', 'system'),
   requireConfigPolicyWrite,
+  requireMfa(),
   zValidator('param', idParamSchema),
   zValidator('json', addFeatureLinkSchema),
   async (c) => {
@@ -140,10 +112,6 @@ featureLinkRoutes.post(
         { error: `The "${data.featureType}" feature is not supported on partner-wide policies; it must be configured on an organization-scoped policy.` },
         400
       );
-    }
-
-    if (MFA_GATED_FEATURE_TYPES.has(data.featureType) && !hasSatisfiedMfa(auth)) {
-      return c.json({ error: 'MFA required' }, 403);
     }
 
     // Validate the referenced feature policy exists (only when a policy ID is provided)
@@ -313,6 +281,7 @@ featureLinkRoutes.patch(
   '/:id/features/:linkId',
   requireScope('organization', 'partner', 'system'),
   requireConfigPolicyWrite,
+  requireMfa(),
   zValidator('param', linkIdParamSchema),
   zValidator('json', updateFeatureLinkSchema),
   async (c) => {
@@ -335,10 +304,6 @@ featureLinkRoutes.patch(
 
     if (!existingLink) {
       return c.json({ error: 'Feature link not found' }, 404);
-    }
-
-    if (MFA_GATED_FEATURE_TYPES.has(existingLink.featureType) && !hasSatisfiedMfa(auth)) {
-      return c.json({ error: 'MFA required' }, 403);
     }
 
     if (data.featurePolicyId !== undefined && data.featurePolicyId !== null) {
@@ -486,6 +451,7 @@ featureLinkRoutes.delete(
   '/:id/features/:linkId',
   requireScope('organization', 'partner', 'system'),
   requireConfigPolicyWrite,
+  requireMfa(),
   zValidator('param', linkIdParamSchema),
   async (c) => {
     const auth = c.get('auth') as AuthContext;
@@ -504,27 +470,6 @@ featureLinkRoutes.delete(
 
     const existingLink = policy.featureLinks.find((l: any) => l.id === linkId);
     if (!existingLink) return c.json({ error: 'Feature link not found' }, 404);
-
-    // Patch removal stays unconditionally gated. Maintenance removal is exempt
-    // ONLY while it genuinely ends suppression — with a parent that has its own
-    // maintenance link, this delete REVERTS to the parent's window and restores
-    // it, so that one transition is gated too (MFA follows effectiveness).
-    //
-    // FAIL CLOSED when the parent cannot be resolved. `parentPolicyId` is set but
-    // `parentPolicy` came back null means the parent row was invisible to this
-    // read — an anomaly, not a legitimate state, because the write-time trigger
-    // only ever accepts a parent the child's own tenant can see. Treating
-    // "can't tell" as "no parent" would silently drop the MFA requirement, which
-    // is exactly the fail-open shape this feature already hit once in SQL.
-    const parentUnresolved = !!policy.parentPolicyId && !policy.parentPolicy;
-    const parentHasSameType = !!policy.parentPolicy?.featureLinks?.some(
-      (l: { featureType: string }) => l.featureType === existingLink.featureType,
-    );
-    const revertRestoresParentWindow = existingLink.featureType === 'maintenance'
-      && (parentUnresolved || parentHasSameType);
-    if ((existingLink.featureType === 'patch' || revertRestoresParentWindow) && !hasSatisfiedMfa(auth)) {
-      return c.json({ error: 'MFA required' }, 403);
-    }
 
     const deleted = await removeFeatureLink(linkId, id);
     if (!deleted) return c.json({ error: 'Feature link not found' }, 404);

--- a/apps/api/src/routes/extensionsAdmin.test.ts
+++ b/apps/api/src/routes/extensionsAdmin.test.ts
@@ -3,10 +3,9 @@
 // of the stub, so the `isPlatformAdmin === true` gate is genuinely exercised.
 import { describe, expect, it, vi, beforeEach, type Mock } from 'vitest';
 
-vi.mock('../middleware/auth', () => ({
+vi.mock('../middleware/auth', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../middleware/auth')>()),
   authMiddleware: vi.fn(async (_c: unknown, next: () => Promise<void>) => next()),
-  requireMfa: vi.fn(() => async (_c: unknown, next: () => Promise<void>) => next()),
-  hasSatisfiedMfa: vi.fn(() => true),
   requirePermission: vi.fn(() => async (_c: unknown, next: () => Promise<void>) => next()),
 }));
 
@@ -20,6 +19,7 @@ import { createExtensionsAdminRoutes, type ExtensionsAdminDeps } from './extensi
 import { ExtensionContributionRegistry, type StagedExtensionContributions } from '../extensions/contributionRegistry';
 import type { ExtensionStateRecord } from '../extensions/stateStore';
 import type { ExtensionHostDescriptor } from '../extensions/compatibility';
+import { createAuditLogAsync } from '../services/auditService';
 
 type FakeAuth = {
   user: { id: string; email: string; name: string; isPlatformAdmin: boolean };
@@ -29,6 +29,11 @@ type FakeAuth = {
 const platformAdmin: FakeAuth = {
   user: { id: 'admin-1', email: 'admin@breeze.test', name: 'PA', isPlatformAdmin: true },
   token: { mfa: true },
+};
+
+const platformAdminNoMfa: FakeAuth = {
+  ...platformAdmin,
+  token: { mfa: false },
 };
 
 const nonAdmin: FakeAuth = {
@@ -154,23 +159,52 @@ beforeEach(() => {
 });
 
 describe('extensions admin authorization', () => {
-  it('requires platform admin for enable and disable', async () => {
-    const { app } = buildHarness({ auth: nonAdmin });
-    const res = await app.request('/api/v1/admin/extensions/demo/disable', { method: 'POST' });
+  it.each(['enable', 'disable'])('requires platform admin for %s', async (verb) => {
+    const { app, setEnabled } = buildHarness({ auth: nonAdmin });
+    const res = await app.request(`/api/v1/admin/extensions/demo/${verb}`, { method: 'POST' });
     expect(res.status).toBe(403);
+    expect(setEnabled).not.toHaveBeenCalled();
   });
 
   it('rejects an unauthenticated caller', async () => {
     const { app } = buildHarness({ auth: null });
     expect((await app.request('/api/v1/admin/extensions')).status).toBe(403);
-    expect(
-      (await app.request('/api/v1/admin/extensions/demo/enable', { method: 'POST' })).status,
-    ).toBe(403);
+    for (const verb of ['enable', 'disable']) {
+      expect(
+        (await app.request(`/api/v1/admin/extensions/demo/${verb}`, { method: 'POST' })).status,
+      ).toBe(403);
+    }
   });
 
-  it('does not mutate state when a non-admin attempts a disable', async () => {
-    const { app, setEnabled } = buildHarness({ auth: nonAdmin });
-    await app.request('/api/v1/admin/extensions/demo/disable', { method: 'POST' });
+  it.each([
+    { verb: 'enable', initiallyEnabled: false },
+    { verb: 'disable', initiallyEnabled: true },
+  ])('requires MFA before $verb reads or mutates extension state', async ({ verb, initiallyEnabled }) => {
+    const staged = snapshot({ enabled: initiallyEnabled });
+    const { app, setEnabled, storeCalls, registry } = buildHarness({
+      auth: platformAdminNoMfa,
+      registrySnapshots: [staged],
+      rows: [record({ enabled: initiallyEnabled })],
+    });
+
+    const res = await app.request(`/api/v1/admin/extensions/demo/${verb}`, { method: 'POST' });
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'MFA required', code: 'MFA_REQUIRED' });
+    expect(storeCalls).toEqual([]);
+    expect(setEnabled).not.toHaveBeenCalled();
+    expect(registry.get('demo')?.enabled).toBe(initiallyEnabled);
+    expect(createAuditLogAsync).toHaveBeenCalledWith(expect.objectContaining({
+      action: `platform_admin.extensions.demo.${verb}`,
+      result: 'failure',
+    }));
+  });
+
+  it('keeps platform-admin list and doctor reads available without MFA', async () => {
+    const { app, setEnabled } = buildHarness({ auth: platformAdminNoMfa });
+
+    expect((await app.request('/api/v1/admin/extensions')).status).toBe(200);
+    expect((await app.request('/api/v1/admin/extensions/demo/doctor')).status).toBe(200);
     expect(setEnabled).not.toHaveBeenCalled();
   });
 });
@@ -256,6 +290,23 @@ describe('GET /:name/doctor', () => {
 });
 
 describe('POST enable / disable', () => {
+  it.each([
+    { verb: 'enable', expected: true, initiallyEnabled: false },
+    { verb: 'disable', expected: false, initiallyEnabled: true },
+  ])('allows an MFA-satisfied platform admin to $verb', async ({ verb, expected, initiallyEnabled }) => {
+    const { app, setEnabled, registry } = buildHarness({
+      rows: [record({ enabled: initiallyEnabled })],
+      registrySnapshots: [snapshot({ enabled: initiallyEnabled })],
+    });
+
+    const res = await app.request(`/api/v1/admin/extensions/demo/${verb}`, { method: 'POST' });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ name: 'demo', enabled: expected });
+    expect(setEnabled).toHaveBeenCalledExactlyOnceWith('demo', expected);
+    expect(registry.get('demo')?.enabled).toBe(expected);
+  });
+
   it('flips only the database enabled flag', async () => {
     const { app, setEnabled, storeCalls } = buildHarness({
       registrySnapshots: [snapshot()],

--- a/apps/api/src/routes/extensionsAdmin.ts
+++ b/apps/api/src/routes/extensionsAdmin.ts
@@ -37,6 +37,7 @@
  */
 import { Hono, type Context } from 'hono';
 import { platformAdminMiddleware } from '../middleware/platformAdmin';
+import { requireMfa } from '../middleware/auth';
 import {
   checkExtensionCompatibility,
   type CompatibilityResult,
@@ -187,8 +188,8 @@ export function createExtensionsAdminRoutes(deps: ExtensionsAdminDeps): Hono {
     });
   });
 
-  routes.post('/:name/enable', (c) => applyEnabled(c, deps, true));
-  routes.post('/:name/disable', (c) => applyEnabled(c, deps, false));
+  routes.post('/:name/enable', requireMfa(), (c) => applyEnabled(c, deps, true));
+  routes.post('/:name/disable', requireMfa(), (c) => applyEnabled(c, deps, false));
 
   return routes;
 }

--- a/apps/api/src/services/aiToolsConfigPolicy.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsConfigPolicy.siteScope.test.ts
@@ -66,6 +66,10 @@ function makeAuth(allowedSiteIds: string[] | undefined) {
   return {
     user: { id: 'user-1', email: 'test@example.com', name: 'Test User' },
     scope: 'organization',
+    // The MFA boundary (SEC-107) runs before the site-ceiling check, mirroring
+    // requireMfa() ahead of the handler on the HTTP routes. Satisfy it here so
+    // these cases still exercise the site-ceiling gate specifically.
+    token: { mfa: true },
     orgId: ORG_ID,
     accessibleOrgIds: [ORG_ID],
     allowedSiteIds,

--- a/apps/api/src/services/aiToolsConfigPolicy.test.ts
+++ b/apps/api/src/services/aiToolsConfigPolicy.test.ts
@@ -114,7 +114,13 @@ import {
   MAINTENANCE_LINK_MACHINE_PRINCIPAL_DENIED,
   MAINTENANCE_LINK_FEATURE_TYPE_REQUIRED,
 } from './aiToolsConfigPolicy';
-import { addFeatureLink, getConfigPolicy, removeFeatureLink, updateFeatureLink } from './configurationPolicy';
+import {
+  addFeatureLink,
+  getConfigPolicy,
+  listFeatureLinks,
+  removeFeatureLink,
+  updateFeatureLink,
+} from './configurationPolicy';
 import { onedriveHelperInlineSettingsSchema } from '@breeze/shared/validators';
 import { GENERIC_TOOL_ERROR_MESSAGE } from './aiToolErrors';
 
@@ -130,6 +136,7 @@ function makeAuth() {
     scope: 'organization',
     orgId: ORG_ID,
     accessibleOrgIds: [ORG_ID],
+    token: { mfa: true },
     canAccessOrg: (orgId: string) => orgId === ORG_ID,
     orgCondition: () => undefined,
   } as any;
@@ -142,6 +149,7 @@ function makePartnerAuth() {
     orgId: null,
     partnerId: PARTNER_ID,
     accessibleOrgIds: [ORG_ID],
+    token: { mfa: true },
     canAccessOrg: (orgId: string) => orgId === ORG_ID,
     orgCondition: () => undefined,
   } as any;
@@ -184,6 +192,94 @@ function mockSelectWhereRows(rows: unknown[]) {
   const chain: any = { from: vi.fn(() => chain), where: vi.fn().mockResolvedValue(rows) };
   vi.mocked(db.select).mockReturnValueOnce(chain);
 }
+
+describe('configuration policy AI/MCP mutation MFA boundary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(db.select).mockReset();
+    enable2faState.value = true;
+  });
+
+  function tools() {
+    const result = new Map<string, any>();
+    registerConfigPolicyTools(result);
+    return result;
+  }
+
+  function unassuredUser() {
+    return { ...makeUserAuth(), token: { mfa: false } } as any;
+  }
+
+  it.each([
+    ['apply_configuration_policy', { configPolicyId: POLICY_ID, level: 'device', targetId: DEVICE_ID }],
+    ['remove_configuration_policy_assignment', { assignmentId: 'assignment-1' }],
+    ['manage_configuration_policy', { action: 'create', name: 'Unassured policy' }],
+    ['manage_policy_feature_link', {
+      action: 'add', configPolicyId: POLICY_ID, featureType: 'monitoring',
+      inlineSettings: { checkIntervalSeconds: 60, watches: [] },
+    }],
+  ])('denies an unassured user in %s before any query or mutation', async (toolName, input) => {
+    const output = await tools().get(toolName)!.handler(input, unassuredUser());
+
+    expect(JSON.parse(output)).toEqual({ error: 'MFA required' });
+    expect(db.select).not.toHaveBeenCalled();
+    expect(assignPolicyMock).not.toHaveBeenCalled();
+    expect(unassignPolicyMock).not.toHaveBeenCalled();
+    expect(createConfigPolicyMock).not.toHaveBeenCalled();
+    expect(vi.mocked(addFeatureLink)).not.toHaveBeenCalled();
+  });
+
+  it.each(['api_key', 'oauth_grant'] as const)(
+    'does not treat an empty %s token as MFA under an MFA-enabled deployment',
+    async (kind) => {
+      const output = await tools().get('manage_configuration_policy')!.handler(
+        { action: 'create', name: 'Machine policy' },
+        makeMachineAuth(kind),
+      );
+
+      expect(JSON.parse(output)).toEqual({ error: 'MFA required' });
+      expect(db.select).not.toHaveBeenCalled();
+      expect(createConfigPolicyMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it('denies autonomous agents consistently with requireMfa middleware', async () => {
+    const output = await tools().get('manage_configuration_policy')!.handler(
+      { action: 'create', name: 'Autonomous policy' },
+      makeAgentAuth(),
+    );
+
+    expect(JSON.parse(output)).toEqual({ error: 'MFA required' });
+    expect(createConfigPolicyMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps read-only feature-link listing available without MFA', async () => {
+    vi.mocked(getConfigPolicy).mockResolvedValue({ id: POLICY_ID, orgId: ORG_ID, name: 'Policy' } as any);
+    vi.mocked(listFeatureLinks).mockResolvedValue([] as any);
+
+    const output = await tools().get('manage_policy_feature_link')!.handler(
+      { action: 'list', configPolicyId: POLICY_ID },
+      unassuredUser(),
+    );
+
+    expect(JSON.parse(output)).toMatchObject({ configPolicyId: POLICY_ID, featureLinks: [] });
+    expect(listFeatureLinks).toHaveBeenCalledWith(POLICY_ID);
+  });
+
+  it('preserves the global MFA-disabled behavior for non-maintenance MCP mutations', async () => {
+    enable2faState.value = false;
+    vi.mocked(getConfigPolicy).mockResolvedValue({ id: POLICY_ID, orgId: ORG_ID, name: 'Policy' } as any);
+    vi.mocked(addFeatureLink).mockResolvedValue({ id: 'link-1', featureType: 'monitoring' } as any);
+
+    const output = await tools().get('manage_policy_feature_link')!.handler({
+      action: 'add', configPolicyId: POLICY_ID, featureType: 'monitoring',
+      inlineSettings: { checkIntervalSeconds: 60, watches: [] },
+    }, makeMachineAuth('api_key'));
+
+    expect(JSON.parse(output).success).toBe(true);
+    expect(addFeatureLink).toHaveBeenCalled();
+  });
+});
 
 describe('configuration policy AI tools', () => {
   beforeEach(() => {
@@ -1032,16 +1128,17 @@ describe('manage_policy_feature_link machine-principal denial (RMM-QA-176 D9.3)'
     return tools;
   }
 
-  it('denies an api_key principal adding a maintenance link, before the feature-link write', async () => {
+  it('denies an unassured api_key principal before maintenance-link lookup or write', async () => {
     const output = await toolsWithPolicy().get('manage_policy_feature_link')!.handler({
       action: 'add', configPolicyId: POLICY_ID, featureType: 'maintenance', inlineSettings: MAINTENANCE_SETTINGS,
     }, makeMachineAuth('api_key'));
 
-    expect(JSON.parse(output).error).toBe(MAINTENANCE_LINK_MACHINE_PRINCIPAL_DENIED);
+    expect(JSON.parse(output).error).toBe('MFA required');
+    expect(getConfigPolicy).not.toHaveBeenCalled();
     expect(vi.mocked(addFeatureLink)).not.toHaveBeenCalled();
   });
 
-  it('denies an oauth_grant principal updating an existing maintenance link', async () => {
+  it('denies an unassured oauth_grant principal before maintenance-link lookup or write', async () => {
     const tools = toolsWithPolicy();
     mockSelectRows([{ featureType: 'maintenance' }]);
     const output = await tools.get('manage_policy_feature_link')!.handler({
@@ -1049,7 +1146,8 @@ describe('manage_policy_feature_link machine-principal denial (RMM-QA-176 D9.3)'
       featureType: 'maintenance', inlineSettings: MAINTENANCE_SETTINGS,
     }, makeMachineAuth('oauth_grant'));
 
-    expect(JSON.parse(output).error).toBe(MAINTENANCE_LINK_MACHINE_PRINCIPAL_DENIED);
+    expect(JSON.parse(output).error).toBe('MFA required');
+    expect(getConfigPolicy).not.toHaveBeenCalled();
     expect(vi.mocked(updateFeatureLink)).not.toHaveBeenCalled();
   });
 
@@ -1113,36 +1211,35 @@ describe('manage_policy_feature_link machine-principal denial (RMM-QA-176 D9.3)'
     expect(vi.mocked(updateFeatureLink)).toHaveBeenCalled();
   });
 
-  it('an ai_agent principal PROCEEDS — approval is upstream, the handler must not hard-deny', async () => {
-    // Inside the web app an escalated call is a normal supervised approval; an
-    // APPROVED run reaching this handler must execute. Hard-denying here would
-    // break the approval workflow the escalation exists to create.
+  it('an ai_agent principal cannot substitute upstream approval for MFA', async () => {
     vi.mocked(addFeatureLink).mockResolvedValue({ id: 'link-1', featureType: 'maintenance' } as any);
     const output = await toolsWithPolicy().get('manage_policy_feature_link')!.handler({
       action: 'add', configPolicyId: POLICY_ID, featureType: 'maintenance', inlineSettings: MAINTENANCE_SETTINGS,
     }, makeAgentAuth());
 
-    expect(JSON.parse(output).success).toBe(true);
-    expect(vi.mocked(addFeatureLink)).toHaveBeenCalled();
+    expect(JSON.parse(output).error).toBe('MFA required');
+    expect(vi.mocked(addFeatureLink)).not.toHaveBeenCalled();
   });
 
-  it('an api_key principal is NOT denied for a non-maintenance link', async () => {
+  it('an unassured api_key principal is denied for a non-maintenance link', async () => {
     vi.mocked(addFeatureLink).mockResolvedValue({ id: 'link-1', featureType: 'monitoring' } as any);
     const output = await toolsWithPolicy().get('manage_policy_feature_link')!.handler({
       action: 'add', configPolicyId: POLICY_ID, featureType: 'monitoring',
       inlineSettings: { checkIntervalSeconds: 60, watches: [] },
     }, makeMachineAuth('api_key'));
 
-    expect(JSON.parse(output).success).toBe(true);
+    expect(JSON.parse(output).error).toBe('MFA required');
+    expect(addFeatureLink).not.toHaveBeenCalled();
   });
 
-  it('remove is untouched — it is already Tier 3 and ending suppression is the safe direction', async () => {
+  it('requires MFA for remove even when the direction ends suppression', async () => {
     vi.mocked(removeFeatureLink).mockResolvedValue(true as any);
     const output = await toolsWithPolicy().get('manage_policy_feature_link')!.handler({
       action: 'remove', configPolicyId: POLICY_ID, featureLinkId: 'link-1',
     }, makeMachineAuth('api_key'));
 
-    expect(JSON.parse(output).success).toBe(true);
+    expect(JSON.parse(output).error).toBe('MFA required');
+    expect(removeFeatureLink).not.toHaveBeenCalled();
   });
 
   it('the pre-existing no-principal auth shape still reaches the real handler, not a generic error', async () => {

--- a/apps/api/src/services/aiToolsConfigPolicy.test.ts
+++ b/apps/api/src/services/aiToolsConfigPolicy.test.ts
@@ -243,14 +243,22 @@ describe('configuration policy AI/MCP mutation MFA boundary', () => {
     },
   );
 
-  it('denies autonomous agents consistently with requireMfa middleware', async () => {
-    const output = await tools().get('manage_configuration_policy')!.handler(
-      { action: 'create', name: 'Autonomous policy' },
-      makeAgentAuth(),
-    );
+  it('lets an ai_agent principal through — its authorization is the upstream approval, not a session claim', async () => {
+    // RMM-QA-176 D9.3, restated for the blanket gate: an agent has no session
+    // and can never satisfy `hasSatisfiedMfa`, so an MFA-shaped denial here is
+    // not a gate — it is a permanent shutdown of the grantable
+    // `config_policies` agent capability (agentToolCatalog.ts). The real
+    // authorization for an agent run is the Tier-3 approval in aiGuardrails.
+    vi.mocked(getConfigPolicy).mockResolvedValue({ id: POLICY_ID, orgId: ORG_ID, partnerId: null, name: 'Policy' } as any);
+    vi.mocked(addFeatureLink).mockResolvedValue({ id: 'link-1', featureType: 'monitoring' } as any);
 
-    expect(JSON.parse(output)).toEqual({ error: 'MFA required' });
-    expect(createConfigPolicyMock).not.toHaveBeenCalled();
+    const output = await tools().get('manage_policy_feature_link')!.handler({
+      action: 'add', configPolicyId: POLICY_ID, featureType: 'monitoring',
+      inlineSettings: { checkIntervalSeconds: 60, watches: [] },
+    }, makeAgentAuth());
+
+    expect(JSON.parse(output).success).toBe(true);
+    expect(vi.mocked(addFeatureLink)).toHaveBeenCalled();
   });
 
   it('keeps read-only feature-link listing available without MFA', async () => {
@@ -1211,14 +1219,20 @@ describe('manage_policy_feature_link machine-principal denial (RMM-QA-176 D9.3)'
     expect(vi.mocked(updateFeatureLink)).toHaveBeenCalled();
   });
 
-  it('an ai_agent principal cannot substitute upstream approval for MFA', async () => {
+  it('an ai_agent principal PROCEEDS — approval is upstream, the handler must not hard-deny', async () => {
+    // Inside the web app an escalated call is a normal supervised approval; an
+    // APPROVED run reaching this handler must execute. Hard-denying here would
+    // break the approval workflow the escalation exists to create — and the MFA
+    // gate must not reintroduce that denial by a side door: an agent principal
+    // has no session and can never carry an `mfa` claim, so gating on one would
+    // permanently disable the grantable `config_policies` agent capability.
     vi.mocked(addFeatureLink).mockResolvedValue({ id: 'link-1', featureType: 'maintenance' } as any);
     const output = await toolsWithPolicy().get('manage_policy_feature_link')!.handler({
       action: 'add', configPolicyId: POLICY_ID, featureType: 'maintenance', inlineSettings: MAINTENANCE_SETTINGS,
     }, makeAgentAuth());
 
-    expect(JSON.parse(output).error).toBe('MFA required');
-    expect(vi.mocked(addFeatureLink)).not.toHaveBeenCalled();
+    expect(JSON.parse(output).success).toBe(true);
+    expect(vi.mocked(addFeatureLink)).toHaveBeenCalled();
   });
 
   it('an unassured api_key principal is denied for a non-maintenance link', async () => {

--- a/apps/api/src/services/aiToolsConfigPolicy.ts
+++ b/apps/api/src/services/aiToolsConfigPolicy.ts
@@ -47,17 +47,26 @@ const MFA_REQUIRED_ERROR = JSON.stringify({ error: 'MFA required' });
 
 /**
  * Match the HTTP `requireMfa()` boundary for config-policy mutations reached
- * through AI or MCP instead of a Hono route. Interactive user sessions must
- * carry the live MFA claim. Autonomous agents cannot substitute an approval
- * envelope for that claim, just as `requireMfa()` rejects an `ai_agent`
- * principal before inspecting its token. API-key and OAuth MCP callers retain
- * the product-wide `ENABLE_2FA=false` behavior through `hasSatisfiedMfa`.
+ * through AI or MCP instead of a Hono route: a human session must carry the
+ * live MFA claim before it can change what takes effect across a fleet.
+ *
+ * `ai_agent` principals are EXEMPT, deliberately. `requireMfa()` rejects them
+ * (middleware/auth.ts) because HTTP is not an agent's channel at all — not
+ * because an agent failed an MFA check. An agent never has, and never could
+ * have, a session MFA claim, so deriving its authorization from one would
+ * permanently disable the grantable `config_policies` agent capability
+ * (agentToolCatalog.ts) rather than gate it. An approved agent run's
+ * authorization is the UPSTREAM Tier-3 approval enforced in aiGuardrails; the
+ * maintenance-link machine-principal check below exempts `ai_agent` for exactly
+ * the same reason (RMM-QA-176 D9.3).
+ *
+ * API-key and OAuth MCP callers carry `token: {}` (mcpServer.ts) and so are
+ * denied while `ENABLE_2FA` is on, and retain the product-wide
+ * `ENABLE_2FA=false` behavior through `hasSatisfiedMfa`.
  */
 function configPolicyMutationMfaError(auth: AuthContext): string | null {
-  if (auth.principal?.kind === 'ai_agent' || !hasSatisfiedMfa(auth)) {
-    return MFA_REQUIRED_ERROR;
-  }
-  return null;
+  if (auth.principal?.kind === 'ai_agent') return null;
+  return hasSatisfiedMfa(auth) ? null : MFA_REQUIRED_ERROR;
 }
 
 /**

--- a/apps/api/src/services/aiToolsConfigPolicy.ts
+++ b/apps/api/src/services/aiToolsConfigPolicy.ts
@@ -2,7 +2,7 @@ import { db } from '../db';
 import { ORG_SCOPED_ONLY_FEATURE_TYPES, type ConfigFeatureType } from '@breeze/shared/constants';
 import { configurationPolicies, configPolicyFeatureLinks, configPolicyAssignments, automationPolicyCompliance } from '../db/schema';
 import { eq, and, desc, isNull, isNotNull, inArray, SQL } from 'drizzle-orm';
-import type { AuthContext } from '../middleware/auth';
+import { hasSatisfiedMfa, type AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 import {
   alertRuleInlineSettingsSchema,
@@ -41,6 +41,23 @@ import {
 
 function getOrgId(auth: AuthContext): string | null {
   return auth.orgId ?? auth.accessibleOrgIds?.[0] ?? null;
+}
+
+const MFA_REQUIRED_ERROR = JSON.stringify({ error: 'MFA required' });
+
+/**
+ * Match the HTTP `requireMfa()` boundary for config-policy mutations reached
+ * through AI or MCP instead of a Hono route. Interactive user sessions must
+ * carry the live MFA claim. Autonomous agents cannot substitute an approval
+ * envelope for that claim, just as `requireMfa()` rejects an `ai_agent`
+ * principal before inspecting its token. API-key and OAuth MCP callers retain
+ * the product-wide `ENABLE_2FA=false` behavior through `hasSatisfiedMfa`.
+ */
+function configPolicyMutationMfaError(auth: AuthContext): string | null {
+  if (auth.principal?.kind === 'ai_agent' || !hasSatisfiedMfa(auth)) {
+    return MFA_REQUIRED_ERROR;
+  }
+  return null;
 }
 
 /**
@@ -327,6 +344,9 @@ export function registerConfigPolicyTools(aiTools: Map<string, AiTool>): void {
       },
     },
     handler: safeHandler('apply_configuration_policy', async (input, auth) => {
+      const mfaError = configPolicyMutationMfaError(auth);
+      if (mfaError) return mfaError;
+
       // Dual-axis reader so a partner-scoped caller can reach a partner-OWNED
       // policy (org_id NULL) to assign it — auth.orgCondition alone hid these.
       const conditions: SQL[] = [eq(configurationPolicies.id, input.configPolicyId as string)];
@@ -422,6 +442,9 @@ export function registerConfigPolicyTools(aiTools: Map<string, AiTool>): void {
       },
     },
     handler: safeHandler('remove_configuration_policy_assignment', async (input, auth) => {
+      const mfaError = configPolicyMutationMfaError(auth);
+      if (mfaError) return mfaError;
+
       // Verify the assignment belongs to a policy the caller can see. The
       // dual-axis reader keeps partner-OWNED policies (org_id NULL) reachable
       // for partner-scoped callers; policyOrgId is selected so the partner-wide
@@ -524,9 +547,13 @@ export function registerConfigPolicyTools(aiTools: Map<string, AiTool>): void {
       },
     },
     handler: safeHandler('manage_configuration_policy', async (input, auth) => {
+      const mfaError = configPolicyMutationMfaError(auth);
+      if (mfaError) return mfaError;
+
       if (!canMutateOrgWideGovernance(auth)) {
         return JSON.stringify({ error: SITE_CEILING_WRITE_DENIED_MESSAGE });
       }
+
       const action = input.action as string;
 
       if (action === 'create') {
@@ -843,6 +870,11 @@ For link-only types, set featurePolicyId instead of inlineSettings:
     handler: safeHandler('manage_policy_feature_link', async (input, auth) => {
       const action = input.action as string;
       const configPolicyId = input.configPolicyId as string;
+
+      if (action === 'add' || action === 'update' || action === 'remove') {
+        const mfaError = configPolicyMutationMfaError(auth);
+        if (mfaError) return mfaError;
+      }
 
       // Reads (list) are not gated by the site-ceiling — only add/update/remove.
       if (action !== 'list' && !canMutateOrgWideGovernance(auth)) {

--- a/apps/api/src/services/configurationPolicy.inheritance.test.ts
+++ b/apps/api/src/services/configurationPolicy.inheritance.test.ts
@@ -29,7 +29,6 @@ import {
   createConfigPolicy,
   deleteConfigPolicy,
   getConfigPolicy,
-  getParentLinkFeatureTypes,
   listEligibleParentPolicies,
   InvalidParentPolicyError,
   PolicyHasChildrenError,
@@ -416,16 +415,5 @@ describe('listEligibleParentPolicies', () => {
   it('partner scope with no partner on the token returns nothing and queries nothing', async () => {
     await expect(listEligibleParentPolicies(partnerAuth(null), { ownerScope: 'partner' })).resolves.toEqual([]);
     expect(db.select).not.toHaveBeenCalled();
-  });
-});
-
-describe('getParentLinkFeatureTypes', () => {
-  it('returns the parent\'s linked feature types', async () => {
-    vi.mocked(db.select).mockReturnValueOnce(selectWhere([
-      { featureType: 'maintenance' },
-      { featureType: 'event_log' },
-    ]) as never);
-
-    await expect(getParentLinkFeatureTypes(PARENT)).resolves.toEqual(['maintenance', 'event_log']);
   });
 });

--- a/apps/api/src/services/configurationPolicy.ts
+++ b/apps/api/src/services/configurationPolicy.ts
@@ -493,21 +493,6 @@ export async function listEligibleParentPolicies(
   }));
 }
 
-/**
- * Feature types linked on a prospective parent, read under the caller's own RLS
- * context (no access condition — same read-only rationale as the parent embed).
- *
- * Feeds the MFA-by-effectiveness gate: creating a child of a parent that carries
- * a gated link makes that link effective on the new policy.
- */
-export async function getParentLinkFeatureTypes(parentId: string): Promise<string[]> {
-  const rows = await db
-    .select({ featureType: configPolicyFeatureLinks.featureType })
-    .from(configPolicyFeatureLinks)
-    .where(eq(configPolicyFeatureLinks.configPolicyId, parentId));
-  return rows.map((r) => r.featureType);
-}
-
 export async function listConfigPolicies(
   auth: AuthContext,
   filters: { status?: string; search?: string; orgId?: string },


### PR DESCRIPTION
## Summary

Two Medium-severity authorization findings from the private security-review
program. Both are the same shape: a mutation that changes what code or policy
takes effect across a tenant (or the whole instance) was reachable by a session
that had never satisfied MFA.

### SEC-097 — extension runtime toggles (`apps/api/src/routes/extensionsAdmin.ts`)

`POST /admin/extensions/:name/enable` and `.../disable` flip a **global**
`installed_extensions.enabled` row — loading or withdrawing server-side
extension code for every tenant on the instance — and were protected by
`platformAdminMiddleware` alone. A borrowed or stolen platform-admin session
could arm or disarm extension code with no live MFA claim.

**Fix:** both toggles now sit behind `requireMfa()`, which additionally rejects
an `ai_agent` principal outright before inspecting the token. Read routes are
unchanged.

### SEC-107 — configuration-policy effective mutations (`routes/configurationPolicies/*`, `services/aiToolsConfigPolicy.ts`)

Configuration policies decide what actually runs on every device an org owns:
patch windows, maintenance suppression (the canonical monitoring-suppression
source), remote-access posture, script and automation linkage. Before this
change the MFA requirement was spot-applied **per feature type**
(`MFA_GATED_FEATURE_TYPES = {patch, maintenance}`) on three feature-link
handlers, plus one inherited-parent special case on create. Everything else was
reachable without MFA:

- policy `POST /`, `PATCH /:id`, `DELETE /:id`
- assignment `POST /:id/assignments`, `DELETE /:id/assignments/:aid`
- feature links of every type other than `patch` / `maintenance`
- the entire AI/MCP tool surface — `apply_configuration_policy`,
  `remove_configuration_policy_assignment`, `manage_configuration_policy`,
  `manage_policy_feature_link` — which never consulted the HTTP gates at all,
  so the same capability was reachable through a second door.

**Fix:** MFA now follows **effectiveness**, not the verb or the feature type.

- `requireMfa()` is applied uniformly to every config-policy mutation route
  (crud POST/PATCH/DELETE, assignments POST/DELETE, feature links
  POST/PATCH/DELETE). The per-feature-type set and the create-time
  parent-link probe are deleted: with a blanket gate on every mutation they are
  unreachable, and the case analysis about which transitions "restore
  suppression" no longer has to hold.
- `configPolicyMutationMfaError` gives the AI/MCP tool handlers the same
  boundary the HTTP routes get: every principal must satisfy `hasSatisfiedMfa`.
  Reads (`manage_policy_feature_link` action=`list`) are **not** gated, and
  `ai_agent` principals are **exempt** — see below.

**`ai_agent` principals are deliberately exempt.** `requireMfa()` rejects an
agent on the HTTP routes because HTTP is not an agent's channel, not because
the agent failed an MFA check. An agent has no session and can never carry an
`mfa` claim, so an MFA-shaped denial there is not a gate — it would permanently
disable the grantable `config_policies` agent capability
(`services/aiAgents/agentToolCatalog.ts:188-195`, surfaced in the web UI) and
reverse RMM-QA-176 D9.3 ("an approved agent run must proceed — approval is
upstream"). The real authorization for an agent run is the Tier-3 approval
enforced in `aiGuardrails`. This keeps the new gate consistent with the
maintenance-link machine-principal check in the same file, whose comment
already states `ai_agent` is deliberately not denied there. API-key and OAuth
MCP contexts carry `token: {}` and remain denied while `ENABLE_2FA` is on.

## Ported from

| Finding | Local commit | Notes |
|---|---|---|
| SEC-2026-09-05-097 (Medium) | `7be4b080670dc2e567af8bd1aeb049ca2d8a499e` | cherry-picked clean, no conflicts |
| SEC-2026-09-05-107 (Medium) | `c96585417fbf57618ab2f5db41ac253446b434c0` | conflicts in `crud.ts` + `aiToolsConfigPolicy.ts`, resolved below |

Changed vs. the original because main moved:

- **#5482's site-ceiling gate is kept, everywhere it exists on main.** The
  original was authored ~200 commits back, before `canMutateOrgWideGovernance`
  / `SITE_CEILING_WRITE_DENIED_MESSAGE` existed. Every `canMutateOrgWideGovernance`
  call site on `crud.ts`, `featureLinks.ts` and `aiToolsConfigPolicy.ts` is
  retained unchanged; the MFA gate is layered on top, never in place of it.
- **Gate ordering in the AI tools.** On the HTTP routes `requireMfa()` is
  middleware and therefore runs *before* the handler body's site-ceiling check.
  The two conflicted AI-tool handlers (`manage_configuration_policy`,
  `manage_policy_feature_link`) place the MFA check ahead of the site-ceiling
  check so the AI path and the HTTP path deny in the same order.
- **Three `*.siteScope.test.ts` suites updated** (`crud.siteScope`,
  `featureLinks.siteScope`, `aiToolsConfigPolicy.siteScope`). These are #5482's
  tests and did not exist when the fix was authored. The two route suites mock
  `../../middleware/auth` wholesale and had no `requireMfa` key, so the routes
  loaded `undefined` as middleware and the files failed at collection; the AI
  suite's `makeAuth` carried no MFA claim, so it started hitting the new MFA
  denial before reaching the gate it is meant to test. Both are fixture
  changes only — no site-ceiling assertion was weakened or removed.
- **Nothing was dropped as already-on-main.** The `~59` deleted lines in
  `featureLinks.ts` (the `MFA_GATED_FEATURE_TYPES` export, its doc comment, and
  the three per-type checks) were re-verified against main: main still carries
  all of it, so the deletion is still correct and is the substance of the fix,
  not a stale refactor.

### Review round 1 (commit 3, `1c0b5375ae`)

- **`ai_agent` exemption** — the port originally denied `ai_agent` principals in
  `configPolicyMutationMfaError`. Corrected as described in the Summary. The
  deleted D9.3 test `an ai_agent principal PROCEEDS — approval is upstream, the
  handler must not hard-deny` is restored verbatim in intent, and a second
  agent-proceeds case was added on the blanket gate.
- **`crud.test.ts` now exercises the REAL `requireMfa()`** via `importOriginal`
  (the pattern `extensionsAdmin.test.ts` already uses) instead of a hand-written
  stand-in. The other two route suites keep ordering stand-ins and are now
  labelled as such, with a pointer to the suite that proves acceptance.
- **`getParentLinkFeatureTypes` deleted** (`services/configurationPolicy.ts`)
  together with its unit + integration coverage and the leftover mock in
  `crud.siteScope.test.ts`. Its only production caller was the create-time
  parent-link probe this PR replaces.
- **Dead `hasSatisfiedMfa` mocks removed** from all four config-policy route
  suites — no route in that directory imports it any more.

### Out of scope, deliberate — candidate follow-up

`services/aiToolsPolicyPrereqs.ts` (`manage_update_rings`,
`manage_software_policies`, `manage_peripheral_policies`,
`manage_backup_configs`) has **no MFA check** — verified by grep, there is no
`hasSatisfiedMfa` reference in that file. Those tools write standalone
feature-policy rows (update rings, software/peripheral policies, backup
configs), not the `configuration_policies` / `config_policy_feature_links` /
`config_policy_assignments` tables this PR covers, so they are outside the
boundary of SEC-107 and are left unchanged here. They are a reasonable
follow-up: several of them are linkable *from* a config policy, so the same
"reachable through a second door" argument may apply.

## Verification

All commands run from `apps/api` unless noted, against an ephemeral pg+redis
test stack (`pnpm test-stack up`). Node heap raised (`NODE_OPTIONS=--max-old-space-size=8192`)
because the default OOMs `tsc` on this repo.

**Typecheck — verified, pass**
```
npx tsc --noEmit          # exit 0
```

**Lint — verified, pass**
```
npx eslint <all 15 touched files>   # exit 0, no output
```

**Unit — verified, 22 files / 436 tests passed**
```
npx vitest run --pool=threads --maxWorkers=2 \
  src/routes/extensionsAdmin src/routes/configurationPolicies \
  src/services/aiToolsConfigPolicy src/services/configurationPolicy
```
(Bare substrings, no trailing slash, so the dotted siblings —
`crud.siteScope.test.ts`, `featureLinks.remoteAccess.test.ts`,
`aiToolsConfigPolicy.siteScope.test.ts` — are actually included; file count
checked.)

Adjacent consumers of the touched modules — **verified, 8 files / 60 tests passed**
```
npx vitest run --pool=threads --maxWorkers=2 src/routes/policyManagement src/services/aiToolsReliability
```

**Red-first — verified.** With the branch's *test* files in place, main's five
non-test source files were restored and the same unit command re-run:
```
git checkout origin/main -- \
  apps/api/src/routes/extensionsAdmin.ts \
  apps/api/src/routes/configurationPolicies/assignments.ts \
  apps/api/src/routes/configurationPolicies/crud.ts \
  apps/api/src/routes/configurationPolicies/featureLinks.ts \
  apps/api/src/services/aiToolsConfigPolicy.ts
npx vitest run --pool=threads --maxWorkers=2 \
  src/routes/extensionsAdmin src/routes/configurationPolicies \
  src/services/aiToolsConfigPolicy src/services/configurationPolicy
```
(`services/configurationPolicy.ts` is restored alongside them so main's
`crud.ts` still resolves its imports.)

→ **5 files failed / 40 tests failed** (396 passed), one failing file per touched
source file, i.e. every ported suite discriminates:

| file | failed |
|---|---|
| `routes/configurationPolicies/featureLinks.test.ts` | 18 |
| `services/aiToolsConfigPolicy.test.ts` | 10 |
| `routes/configurationPolicies/crud.test.ts` | 8 |
| `routes/configurationPolicies/assignments.test.ts` | 2 |
| `routes/extensionsAdmin.test.ts` | 2 |

Then `git checkout HEAD -- <same six files>` → back to **22 files / 436 passed**.

**Second red-first control, for the `ai_agent` exemption specifically — verified.**
The two agent-proceeds tests pass against main (main has no gate at all), so main
is not a discriminating baseline for them. The baseline they discriminate against
is the *rejected* first version of this fix. Reinstating that one line:
```
-  if (auth.principal?.kind === 'ai_agent') return null;
+  if (auth.principal?.kind === 'ai_agent') return MFA_REQUIRED_ERROR;

npx vitest run --pool=threads --maxWorkers=2 src/services/aiToolsConfigPolicy
```
→ **exactly 2 failed / 61 passed**, and the two failures are
`an ai_agent principal PROCEEDS — approval is upstream, the handler must not hard-deny`
and `lets an ai_agent principal through — its authorization is the upstream approval, not a session claim`.
Reverted → 2 files / 63 passed.

**`crud.test.ts` gate-acceptance control — verified.** Because that suite now
mounts the real `requireMfa()`, its `denies an API-key principal whose token
carries no mfa claim` case would pass trivially if `ENABLE_2FA` resolved false in
the unit env; the paired `admits the default session, proving the gate is not
denying unconditionally` case (expects 201) is the positive control that rules
that out. Both pass.

**Integration — verified, all green** (`--config vitest.integration.config.ts --pool=threads --maxWorkers=2`)

| family | filters | result |
|---|---|---|
| extensions (incl. the new `extensionsAdminMfa.integration.test.ts`) + config policies | `extensionsAdminMfa extensionState extensionTenancyRls extensionMigrator configPolicy configurationPolic normalizedConfigPolicyRls` | 17 files / 206 tests passed |
| MFA | `mfa Mfa passkeyMfaVerify adminMfaReset pendingMfaEpoch registerPartnerMfaPolicy partnerAdminForceMfaMigration seedPartnerAdminForceMfa` + `src/services/mfaStepUpGrant` | 13 files / 70 tests passed |

**Contract suites — verified, all green.** These three have dedicated runners and
are *excluded* from `vitest.integration.config.ts`, so a plain integration run
silently skips them:
```
npx vitest run --config vitest.config.site-scope-coverage.ts        # 1 file / 7 tests
npx vitest run --config vitest.config.integration-suite-coverage.ts # 1 file / 5 tests
npx vitest run --pool=threads --maxWorkers=2 src/__tests__/partner-wide-write-coverage.test.ts  # 1 file / 5 tests
```
`integration-suite-coverage` is what proves the new
`extensionsAdminMfa.integration.test.ts` is actually picked up by a CI
integration shard rather than running in no job at all.

**Not applicable — not-checked by design:** no migration, no schema column, no
new table. RLS coverage / tenant-cascade / export-policy contract suites and
`check-migration-naming.sh` were therefore not run beyond the pre-commit hook
(which reported `check-migration-naming: OK`). No `apps/web`, `apps/portal` or
`packages/shared` files are touched, so those packages were not re-tested.

**Rebase:** branch is on `29e9445f3d`, which is current `origin/main` at push
time (`git fetch && git rebase origin/main` → "up to date").

## Operator impact

- **`ENABLE_2FA` defaults to `true`**, so this is a live behaviour change on
  default deployments. An operator who has not satisfied MFA in the current
  session now receives `403 {"error":"MFA required","code":"MFA_REQUIRED"}` from:
  extension enable/disable, and every configuration-policy create/update/delete,
  assignment add/remove, and feature-link add/update/remove. Web mutation
  handlers route through `runAction`, so the denial surfaces as a toast rather
  than a silent no-op.
- **Reads are unaffected** — policy list/get, feature-link list, assignment list,
  extension list/detail, and the AI `manage_policy_feature_link` action=`list`
  all behave exactly as before.
- **API-key and OAuth/MCP automation that mutates configuration policies will
  now be denied** while `ENABLE_2FA=true`, because those principals carry no
  JWT `mfa` claim. This is the same treatment `POST /:id/patch-jobs` already
  applies on main, so the shape is established rather than new — but any script
  that creates or edits config policies with an API key is a breaking change and
  should be checked before rolling this out. Deployments running `ENABLE_2FA=false`
  keep the previous behaviour for those callers via `hasSatisfiedMfa`.
- **AI agents are unaffected.** The grantable `config_policies` agent capability
  keeps working exactly as before; an approved agent run's authorization remains
  the upstream Tier-3 approval, not a session MFA claim it could never hold.
- No migration, no config flag, no restart-ordering requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Tugfg88kFiowD7E5xQFpU
