### PR TITLE
fix(inventory): enforce site scope on software deployments, software name search, monitoring names and asset mutations (SEC-023, SEC-046, SEC-084, SEC-110)

### DIFF
--- a/apps/api/src/__tests__/integration/monitoringAssetMutationSiteScope.integration.test.ts
+++ b/apps/api/src/__tests__/integration/monitoringAssetMutationSiteScope.integration.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Real-PostgreSQL proof for discovered-asset monitoring mutation site scope.
+ * The route runs as breeze_app inside an organization request context. The
+ * deterministic move case holds the asset row in another transaction, moves it
+ * from an allowed to a hidden site, then releases the route's SELECT FOR UPDATE.
+ * A plain pre-check would read the stale allowed site and mutate the monitor;
+ * the locked current-row check must instead deny with no monitor change.
+ */
+import './setup';
+
+import { Hono } from 'hono';
+import { randomUUID } from 'crypto';
+import { and, eq } from 'drizzle-orm';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: vi.fn((c: any, next: any) => {
+    const orgId = c.req.header('x-org-id');
+    const encodedSites = c.req.header('x-site-ceiling');
+    c.set('auth', {
+      user: { id: 'synthetic-site-actor' },
+      scope: 'organization',
+      partnerId: null,
+      orgId,
+      accessibleOrgIds: orgId ? [orgId] : [],
+      canAccessOrg: (candidate: string) => candidate === orgId,
+    });
+    c.set('permissions', {
+      allowedSiteIds: encodedSites === '__empty__' ? [] : (encodedSites?.split(',') ?? undefined),
+    });
+    return next();
+  }),
+  requireScope: vi.fn(() => async (_c: any, next: any) => next()),
+  requirePermission: vi.fn(() => async (_c: any, next: any) => next()),
+  requireMfa: vi.fn(() => async (_c: any, next: any) => next()),
+}));
+
+vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
+vi.mock('../../services/redis', () => ({ isRedisAvailable: vi.fn(() => true) }));
+
+import { db, withDbAccessContext, type DbAccessContext } from '../../db';
+import { discoveredAssets, networkMonitors, snmpDevices } from '../../db/schema';
+import { monitoringRoutes } from '../../routes/monitoring';
+import { createOrganization, createPartner, createSite } from './db-utils';
+import { getTestDb } from './setup';
+
+const app = new Hono();
+app.route('/monitoring', monitoringRoutes);
+
+let fixture: Awaited<ReturnType<typeof seedFixture>>;
+
+async function seedFixture() {
+  const adminDb = getTestDb() as any;
+  const partner = await createPartner();
+  const org = await createOrganization({ partnerId: partner.id });
+  const allowedSite = await createSite({ orgId: org.id });
+  const hiddenSite = await createSite({ orgId: org.id });
+  const [asset] = await adminDb.insert(discoveredAssets).values({
+    orgId: org.id,
+    siteId: allowedSite.id,
+    ipAddress: '192.0.2.110',
+    hostname: `monitor-${randomUUID().slice(0, 8)}`,
+    approvalStatus: 'approved',
+  }).returning();
+  const [snmp] = await adminDb.insert(snmpDevices).values({
+    orgId: org.id,
+    assetId: asset.id,
+    name: 'Synthetic monitor',
+    ipAddress: '192.0.2.110',
+    snmpVersion: 'v2c',
+    community: 'synthetic-not-a-secret',
+    isActive: true,
+  }).returning();
+  await adminDb.insert(networkMonitors).values({
+    orgId: org.id,
+    assetId: asset.id,
+    name: 'Synthetic ping',
+    monitorType: 'icmp_ping',
+    target: '192.0.2.110',
+    isActive: true,
+  });
+
+  const context: DbAccessContext = {
+    scope: 'organization',
+    orgId: org.id,
+    accessibleOrgIds: [org.id],
+    accessiblePartnerIds: [],
+    userId: null,
+  };
+  return { adminDb, org, allowedSite, hiddenSite, asset, snmp, context };
+}
+
+beforeEach(async () => {
+  fixture = await seedFixture();
+});
+
+function patchMonitor(siteCeiling: string) {
+  return withDbAccessContext(fixture.context, async () => app.request(
+    `/monitoring/assets/${fixture.asset.id}/snmp`,
+    {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-org-id': fixture.org.id,
+        'x-site-ceiling': siteCeiling,
+      },
+      body: JSON.stringify({ isActive: false }),
+    },
+  ));
+}
+
+describe('monitoring asset mutations enforce current site as breeze_app', () => {
+  it('allows the visible site, denies empty scope, and denies a concurrent move before mutation', async () => {
+    const allowed = await patchMonitor(fixture.allowedSite.id);
+    expect(allowed.status).toBe(200);
+
+    await fixture.adminDb.update(snmpDevices)
+      .set({ isActive: true })
+      .where(eq(snmpDevices.id, fixture.snmp.id));
+    const empty = await patchMonitor('__empty__');
+    expect(empty.status).toBe(403);
+
+    let releaseMove!: () => void;
+    let movedAndLocked!: () => void;
+    const releasePromise = new Promise<void>((resolve) => { releaseMove = resolve; });
+    const lockedPromise = new Promise<void>((resolve) => { movedAndLocked = resolve; });
+    const mover = fixture.adminDb.transaction(async (tx: any) => {
+      await tx.select({ id: discoveredAssets.id })
+        .from(discoveredAssets)
+        .where(and(
+          eq(discoveredAssets.id, fixture.asset.id),
+          eq(discoveredAssets.orgId, fixture.org.id),
+        ))
+        .limit(1)
+        .for('update');
+      await tx.update(discoveredAssets)
+        .set({ siteId: fixture.hiddenSite.id })
+        .where(eq(discoveredAssets.id, fixture.asset.id));
+      movedAndLocked();
+      await releasePromise;
+    });
+    await lockedPromise;
+
+    let requestSettled = false;
+    const movedRequest = patchMonitor(fixture.allowedSite.id).finally(() => {
+      requestSettled = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 75));
+    expect(requestSettled, 'the route must wait for the current asset row').toBe(false);
+
+    releaseMove();
+    await mover;
+    const deniedAfterMove = await movedRequest;
+    expect(deniedAfterMove.status).toBe(403);
+
+    const [monitor] = await fixture.adminDb.select({ isActive: snmpDevices.isActive })
+      .from(snmpDevices)
+      .where(eq(snmpDevices.id, fixture.snmp.id));
+    expect(monitor?.isActive).toBe(true);
+  });
+});

--- a/apps/api/src/__tests__/integration/monitoringKnownServicesSiteScope.integration.test.ts
+++ b/apps/api/src/__tests__/integration/monitoringKnownServicesSiteScope.integration.test.ts
@@ -1,0 +1,157 @@
+import './setup';
+
+import { randomUUID } from 'node:crypto';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { Hono } from 'hono';
+import { eq } from 'drizzle-orm';
+
+import { getTestDb } from './setup';
+import { createOrganization, createPartner, createSite, setupTestEnvironment } from './db-utils';
+import { monitoringRoutes } from '../../routes/monitoring';
+import { clearPermissionCache } from '../../services/permissions';
+import {
+  devices,
+  deviceChangeLog,
+  organizationUsers,
+  serviceProcessCheckResults,
+} from '../../db/schema';
+
+function buildApp(): Hono {
+  const app = new Hono();
+  app.route('/monitoring', monitoringRoutes);
+  return app;
+}
+
+function request(app: Hono, token: string, orgId?: string): Promise<Response> {
+  const query = orgId ? `?orgId=${encodeURIComponent(orgId)}` : '';
+  return Promise.resolve(app.request(`/monitoring/known-services${query}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  }));
+}
+
+describe('GET /monitoring/known-services — real PostgreSQL site scope', () => {
+  let app: Hono;
+
+  beforeEach(() => { app = buildApp(); });
+
+  it('filters both sources before aggregation and follows each device current site', async () => {
+    const env = await setupTestEnvironment({
+      scope: 'organization',
+      rolePermissions: [{ resource: 'devices', action: 'read' }],
+    });
+    const hiddenSite = await createSite({ orgId: env.organization.id, name: 'Hidden Site' });
+    const foreignPartner = await createPartner();
+    const foreignOrg = await createOrganization({ partnerId: foreignPartner.id });
+
+    const [visibleDevice, hiddenDevice] = await getTestDb().insert(devices).values([
+      {
+        orgId: env.organization.id,
+        siteId: env.site.id,
+        agentId: `known-visible-${randomUUID()}`,
+        hostname: 'known-visible',
+        osType: 'linux',
+        osVersion: 'test',
+        architecture: 'x64',
+        agentVersion: 'test',
+      },
+      {
+        orgId: env.organization.id,
+        siteId: hiddenSite.id,
+        agentId: `known-hidden-${randomUUID()}`,
+        hostname: 'known-hidden',
+        osType: 'linux',
+        osVersion: 'test',
+        architecture: 'x64',
+        agentVersion: 'test',
+      },
+    ]).returning({ id: devices.id });
+    if (!visibleDevice || !hiddenDevice) throw new Error('device fixtures were not inserted');
+
+    await getTestDb().insert(deviceChangeLog).values([
+      {
+        deviceId: visibleDevice.id,
+        orgId: env.organization.id,
+        fingerprint: 'a'.repeat(64),
+        timestamp: new Date(),
+        changeType: 'service',
+        changeAction: 'added',
+        subject: 'visible-change-service',
+      },
+      {
+        deviceId: hiddenDevice.id,
+        orgId: env.organization.id,
+        fingerprint: 'b'.repeat(64),
+        timestamp: new Date(),
+        changeType: 'service',
+        changeAction: 'added',
+        subject: 'hidden-change-service',
+      },
+    ]);
+    await getTestDb().insert(serviceProcessCheckResults).values([
+      {
+        orgId: env.organization.id,
+        deviceId: visibleDevice.id,
+        watchType: 'process',
+        name: 'visible-check-process',
+        status: 'running',
+      },
+      {
+        orgId: env.organization.id,
+        deviceId: hiddenDevice.id,
+        watchType: 'process',
+        name: 'hidden-check-process',
+        status: 'running',
+      },
+    ]);
+
+    await getTestDb().update(organizationUsers)
+      .set({ siteIds: [env.site.id] })
+      .where(eq(organizationUsers.userId, env.user.id));
+    await clearPermissionCache(env.user.id);
+
+    let response = await request(app, env.token);
+    expect(response.status).toBe(200);
+    expect((await response.json()).data.map((row: { name: string }) => row.name).sort()).toEqual([
+      'visible-change-service',
+      'visible-check-process',
+    ]);
+
+    // Current-device authority is deliberate: moving the device into the
+    // allowed site makes both of its historical name sources visible.
+    await getTestDb().update(devices)
+      .set({ siteId: env.site.id })
+      .where(eq(devices.id, hiddenDevice.id));
+    response = await request(app, env.token);
+    expect((await response.json()).data.map((row: { name: string }) => row.name).sort()).toEqual([
+      'hidden-change-service',
+      'hidden-check-process',
+      'visible-change-service',
+      'visible-check-process',
+    ]);
+
+    await getTestDb().update(devices)
+      .set({ siteId: hiddenSite.id })
+      .where(eq(devices.id, hiddenDevice.id));
+    await getTestDb().update(organizationUsers)
+      .set({ siteIds: [] })
+      .where(eq(organizationUsers.userId, env.user.id));
+    await clearPermissionCache(env.user.id);
+    response = await request(app, env.token);
+    expect(await response.json()).toEqual({ data: [] });
+
+    await getTestDb().update(organizationUsers)
+      .set({ siteIds: null })
+      .where(eq(organizationUsers.userId, env.user.id));
+    await clearPermissionCache(env.user.id);
+    response = await request(app, env.token);
+    expect((await response.json()).data.map((row: { name: string }) => row.name).sort()).toEqual([
+      'hidden-change-service',
+      'hidden-check-process',
+      'visible-change-service',
+      'visible-check-process',
+    ]);
+
+    response = await request(app, env.token, foreignOrg.id);
+    expect(response.status).toBe(403);
+  });
+});

--- a/apps/api/src/__tests__/integration/snmpWorkerSiteAuthority.integration.test.ts
+++ b/apps/api/src/__tests__/integration/snmpWorkerSiteAuthority.integration.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Real-PostgreSQL proof that asset-bound SNMP polls select an executor from the
+ * asset's current site. Agent connectivity and dispatch are synthetic; no
+ * command leaves this process and no SNMP credential reaches a real endpoint.
+ */
+import './setup';
+
+import { randomUUID } from 'crypto';
+import { eq } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { relayMock, decryptMock } = vi.hoisted(() => ({
+  relayMock: {
+    isAgentConnectedAnywhere: vi.fn(async () => true),
+    dispatchCommandToAgent: vi.fn(async () => ({ status: 'sent' as const, via: 'local' as const })),
+  },
+  decryptMock: vi.fn((value: string | null) => value),
+}));
+
+vi.mock('bullmq', () => ({
+  Queue: class {},
+  Worker: class { close = vi.fn(); on = vi.fn(); },
+  Job: class {},
+}));
+
+vi.mock('../../services/agentCommandRelay', () => ({
+  isAgentConnectedAnywhere: relayMock.isAgentConnectedAnywhere,
+  dispatchCommandToAgent: relayMock.dispatchCommandToAgent,
+}));
+
+vi.mock('../../services/snmpSecrets', () => ({ decryptSnmpSecret: decryptMock }));
+vi.mock('../../services/redis', () => ({
+  getBullMQConnection: vi.fn(() => ({ host: 'localhost', port: 6379 })),
+}));
+vi.mock('../../jobs/workerObservability', () => ({ attachWorkerObservability: vi.fn() }));
+
+import { devices, discoveredAssets, snmpDevices, snmpTemplates } from '../../db/schema';
+import { __testables, shutdownSnmpWorker } from '../../jobs/snmpWorker';
+import { createOrganization, createPartner, createSite } from './db-utils';
+import { getTestDb } from './setup';
+
+const { processPollDevice } = __testables;
+
+let fixture: Awaited<ReturnType<typeof seedFixture>>;
+
+async function seedFixture() {
+  const adminDb = getTestDb() as any;
+  const partner = await createPartner();
+  const org = await createOrganization({ partnerId: partner.id });
+  const originalSite = await createSite({ orgId: org.id });
+  const currentSite = await createSite({ orgId: org.id });
+  const noAgentSite = await createSite({ orgId: org.id });
+
+  const originalAgentId = `snmp-original-${randomUUID()}`;
+  const currentAgentId = `snmp-current-${randomUUID()}`;
+  await adminDb.insert(devices).values([
+    {
+      orgId: org.id,
+      siteId: originalSite.id,
+      agentId: originalAgentId,
+      hostname: 'original-site-agent',
+      osType: 'linux',
+      osVersion: 'test',
+      architecture: 'amd64',
+      agentVersion: 'test',
+      status: 'online',
+      isEphemeral: false,
+    },
+    {
+      orgId: org.id,
+      siteId: currentSite.id,
+      agentId: currentAgentId,
+      hostname: 'current-site-agent',
+      osType: 'linux',
+      osVersion: 'test',
+      architecture: 'amd64',
+      agentVersion: 'test',
+      status: 'online',
+      isEphemeral: false,
+    },
+  ]);
+
+  const [asset] = await adminDb.insert(discoveredAssets).values({
+    orgId: org.id,
+    siteId: currentSite.id,
+    ipAddress: '192.0.2.114',
+    hostname: 'current-site-switch',
+    approvalStatus: 'approved',
+  }).returning();
+  const [template] = await adminDb.insert(snmpTemplates).values({
+    orgId: org.id,
+    name: 'Synthetic uptime',
+    oids: [{ oid: '1.3.6.1.2.1.1.3.0' }],
+  }).returning();
+  const [snmp] = await adminDb.insert(snmpDevices).values({
+    orgId: org.id,
+    assetId: asset.id,
+    name: 'Synthetic switch',
+    ipAddress: '192.0.2.114',
+    snmpVersion: 'v2c',
+    community: 'synthetic-encrypted-community',
+    templateId: template.id,
+    isActive: true,
+  }).returning();
+
+  return { adminDb, org, asset, snmp, originalSite, currentSite, noAgentSite, originalAgentId, currentAgentId };
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  relayMock.isAgentConnectedAnywhere.mockResolvedValue(true);
+  relayMock.dispatchCommandToAgent.mockResolvedValue({ status: 'sent', via: 'local' });
+  fixture = await seedFixture();
+});
+
+afterEach(async () => {
+  await shutdownSnmpWorker();
+});
+
+describe('SNMP worker current-site executor authority as breeze_app', () => {
+  it('follows a moved asset to its current site and fails closed when that site has no agent', async () => {
+    const dispatched = await processPollDevice({
+      type: 'poll-device',
+      deviceId: fixture.snmp.id,
+      orgId: fixture.org.id,
+    });
+    expect(dispatched).toEqual({ dispatched: true, agentId: fixture.currentAgentId });
+    expect(relayMock.dispatchCommandToAgent).toHaveBeenCalledWith(
+      fixture.currentAgentId,
+      expect.objectContaining({ type: 'snmp_poll' }),
+      { priority: 'probe' },
+    );
+    expect(relayMock.dispatchCommandToAgent).not.toHaveBeenCalledWith(
+      fixture.originalAgentId,
+      expect.anything(),
+      expect.anything(),
+    );
+
+    relayMock.dispatchCommandToAgent.mockClear();
+    decryptMock.mockClear();
+    await fixture.adminDb.update(discoveredAssets)
+      .set({ siteId: fixture.noAgentSite.id })
+      .where(eq(discoveredAssets.id, fixture.asset.id));
+
+    const denied = await processPollDevice({
+      type: 'poll-device',
+      deviceId: fixture.snmp.id,
+      orgId: fixture.org.id,
+    });
+    expect(denied).toEqual({ dispatched: false, agentId: null });
+    expect(decryptMock).not.toHaveBeenCalled();
+    expect(relayMock.dispatchCommandToAgent).not.toHaveBeenCalled();
+
+    const [attempted] = await fixture.adminDb.select({ lastPollAttemptedAt: snmpDevices.lastPollAttemptedAt })
+      .from(snmpDevices)
+      .where(eq(snmpDevices.id, fixture.snmp.id));
+    expect(attempted?.lastPollAttemptedAt).toBeInstanceOf(Date);
+  });
+});

--- a/apps/api/src/__tests__/integration/softwareDeploymentSiteScope.integration.test.ts
+++ b/apps/api/src/__tests__/integration/softwareDeploymentSiteScope.integration.test.ts
@@ -1,0 +1,113 @@
+import './setup';
+import { describe, expect, it } from 'vitest';
+import { and, eq } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../../db';
+import {
+  deploymentResults,
+  devices,
+  softwareCatalog,
+  softwareDeployments,
+  softwareVersions,
+} from '../../db/schema';
+import { createOrganization, createPartner, createSite } from './db-utils';
+import { getTestDb } from './setup';
+import { softwareDeploymentSiteScopePredicate } from '../../routes/software';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+describe('software deployment parent site scope', () => {
+  runDb('shows only parents whose complete result set remains inside the site ceiling', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const allowedSite = await createSite({ orgId: org.id });
+    const hiddenSite = await createSite({ orgId: org.id });
+    const testDb = getTestDb();
+
+    const [allowedDevice, hiddenDevice] = await testDb.insert(devices).values([
+      {
+        orgId: org.id,
+        siteId: allowedSite.id,
+        agentId: `site-scope-allowed-${Date.now()}`,
+        hostname: 'site-scope-allowed',
+        osType: 'windows',
+        osVersion: '11',
+        architecture: 'x86_64',
+        agentVersion: 'test',
+        status: 'online',
+        enrolledAt: new Date(),
+      },
+      {
+        orgId: org.id,
+        siteId: hiddenSite.id,
+        agentId: `site-scope-hidden-${Date.now()}`,
+        hostname: 'site-scope-hidden',
+        osType: 'windows',
+        osVersion: '11',
+        architecture: 'x86_64',
+        agentVersion: 'test',
+        status: 'online',
+        enrolledAt: new Date(),
+      },
+    ]).returning({ id: devices.id });
+
+    const [catalog] = await testDb.insert(softwareCatalog).values({ orgId: org.id, name: 'scope fixture' }).returning();
+    const [version] = await testDb.insert(softwareVersions).values({
+      catalogId: catalog!.id,
+      version: '1.0.0',
+      downloadUrl: 'https://example.invalid/package.exe',
+    }).returning();
+    const makeDeployment = (name: string) => testDb.insert(softwareDeployments).values({
+      orgId: org.id,
+      name,
+      softwareVersionId: version!.id,
+      deploymentType: 'install',
+      targetType: 'devices',
+      scheduleType: 'immediate',
+    }).returning({ id: softwareDeployments.id });
+    const [allowedOnly] = await makeDeployment('allowed-only');
+    const [hiddenOnly] = await makeDeployment('hidden-only');
+    const [mixed] = await makeDeployment('mixed');
+    const [empty] = await makeDeployment('empty');
+    await testDb.insert(deploymentResults).values([
+      { deploymentId: allowedOnly!.id, deviceId: allowedDevice!.id },
+      { deploymentId: hiddenOnly!.id, deviceId: hiddenDevice!.id },
+      { deploymentId: mixed!.id, deviceId: allowedDevice!.id },
+      { deploymentId: mixed!.id, deviceId: hiddenDevice!.id },
+    ]);
+
+    const visible = await withSystemDbAccessContext(() => db
+      .select({ id: softwareDeployments.id })
+      .from(softwareDeployments)
+      .where(and(
+        eq(softwareDeployments.orgId, org.id),
+        softwareDeploymentSiteScopePredicate(
+          softwareDeployments.id,
+          { allowedSiteIds: [allowedSite.id] } as never,
+        ),
+      )));
+    expect(visible.map((row) => row.id)).toEqual([allowedOnly!.id]);
+
+    const emptyCeiling = await withSystemDbAccessContext(() => db
+      .select({ id: softwareDeployments.id })
+      .from(softwareDeployments)
+      .where(and(
+        eq(softwareDeployments.orgId, org.id),
+        softwareDeploymentSiteScopePredicate(
+          softwareDeployments.id,
+          { allowedSiteIds: [] } as never,
+        ),
+      )));
+    expect(emptyCeiling).toEqual([]);
+
+    const unrestricted = await withSystemDbAccessContext(() => db
+      .select({ id: softwareDeployments.id })
+      .from(softwareDeployments)
+      .where(and(
+        eq(softwareDeployments.orgId, org.id),
+        softwareDeploymentSiteScopePredicate(softwareDeployments.id, undefined),
+      )));
+    expect(new Set(unrestricted.map((row) => row.id))).toEqual(
+      new Set([allowedOnly!.id, hiddenOnly!.id, mixed!.id, empty!.id]),
+    );
+  });
+});

--- a/apps/api/src/__tests__/integration/softwareInventoryNameSiteScope.integration.test.ts
+++ b/apps/api/src/__tests__/integration/softwareInventoryNameSiteScope.integration.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Real bearer/PostgreSQL coverage for current-site software-name visibility.
+ * Requests use the production auth middleware and unprivileged application
+ * role; fixture writes use the privileged integration connection.
+ */
+import './setup';
+
+import { randomUUID } from 'node:crypto';
+import { and, eq } from 'drizzle-orm';
+import { Hono } from 'hono';
+import { describe, expect, it } from 'vitest';
+
+import { getTestDb } from './setup';
+import {
+  createOrganization,
+  createPartner,
+  createSite,
+  setupTestEnvironment,
+  type TestEnvironment,
+} from './db-utils';
+import { devices, organizationUsers, softwareInventory } from '../../db/schema';
+import { softwareInventoryRoutes } from '../../routes/softwareInventory';
+import { clearPermissionCache } from '../../services/permissions';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+function app(): Hono {
+  const instance = new Hono();
+  instance.route('/software-inventory', softwareInventoryRoutes);
+  return instance;
+}
+
+async function setSiteCeiling(env: TestEnvironment, siteIds: string[] | null): Promise<void> {
+  await getTestDb()
+    .update(organizationUsers)
+    .set({ siteIds })
+    .where(and(
+      eq(organizationUsers.userId, env.user.id),
+      eq(organizationUsers.orgId, env.organization.id),
+    ));
+  await clearPermissionCache(env.user.id);
+}
+
+describe('GET /software-inventory/names current-site scope — real bearer/PostgreSQL', () => {
+  runDb('filters before DISTINCT/LIMIT and follows current device ownership and site', async () => {
+    const env = await setupTestEnvironment({
+      scope: 'organization',
+      rolePermissions: [{ resource: 'devices', action: 'read' }],
+    });
+    const hiddenSite = await createSite({ orgId: env.organization.id, name: 'Hidden inventory site' });
+    const foreignPartner = await createPartner();
+    const foreignOrg = await createOrganization({ partnerId: foreignPartner.id });
+    const foreignSite = await createSite({ orgId: foreignOrg.id, name: 'Foreign inventory site' });
+    const suffix = randomUUID().slice(0, 8);
+    const database = getTestDb();
+
+    const inserted = await database.insert(devices).values([
+      {
+        orgId: env.organization.id, siteId: env.site.id, agentId: `software-visible-a-${suffix}`,
+        hostname: `software-visible-a-${suffix}`, osType: 'linux', osVersion: '1',
+        architecture: 'x64', agentVersion: '1', status: 'online',
+      },
+      {
+        orgId: env.organization.id, siteId: env.site.id, agentId: `software-visible-b-${suffix}`,
+        hostname: `software-visible-b-${suffix}`, osType: 'linux', osVersion: '1',
+        architecture: 'x64', agentVersion: '1', status: 'online',
+      },
+      {
+        orgId: env.organization.id, siteId: hiddenSite.id, agentId: `software-hidden-${suffix}`,
+        hostname: `software-hidden-${suffix}`, osType: 'linux', osVersion: '1',
+        architecture: 'x64', agentVersion: '1', status: 'online',
+      },
+      {
+        orgId: env.organization.id, siteId: env.site.id, agentId: `software-ephemeral-${suffix}`,
+        hostname: `software-ephemeral-${suffix}`, osType: 'linux', osVersion: '1',
+        architecture: 'x64', agentVersion: '1', status: 'online', isEphemeral: true,
+      },
+      {
+        orgId: foreignOrg.id, siteId: foreignSite.id, agentId: `software-foreign-${suffix}`,
+        hostname: `software-foreign-${suffix}`, osType: 'linux', osVersion: '1',
+        architecture: 'x64', agentVersion: '1', status: 'online',
+      },
+    ]).returning({ id: devices.id });
+    const [visibleA, visibleB, hidden, ephemeral, foreign] = inserted;
+    const hiddenName = `a-hidden-${suffix}`;
+    const ephemeralName = `b-ephemeral-${suffix}`;
+    const visibleName = `c-visible-${suffix}`;
+    const moveOnlyName = `d-move-${suffix}`;
+    const foreignName = `e-foreign-${suffix}`;
+
+    await database.insert(softwareInventory).values([
+      { orgId: env.organization.id, deviceId: hidden!.id, name: hiddenName },
+      { orgId: env.organization.id, deviceId: ephemeral!.id, name: ephemeralName },
+      { orgId: env.organization.id, deviceId: visibleA!.id, name: visibleName },
+      { orgId: env.organization.id, deviceId: visibleB!.id, name: visibleName },
+      { orgId: env.organization.id, deviceId: visibleA!.id, name: moveOnlyName },
+      { orgId: foreignOrg.id, deviceId: foreign!.id, name: foreignName },
+    ]);
+
+    const get = (query: string) => app().request(`/software-inventory/names?${query}`, {
+      headers: { Authorization: `Bearer ${env.token}` },
+    });
+
+    await setSiteCeiling(env, [env.site.id]);
+    const selected = await get(`q=${suffix}&limit=50`);
+    expect(selected.status, await selected.clone().text()).toBe(200);
+    await expect(selected.json()).resolves.toEqual({ data: [visibleName, moveOnlyName] });
+
+    // Hidden and ephemeral names sort first, so limit=1 proves the current-site
+    // predicate runs before ORDER/LIMIT rather than filtering a fetched page.
+    const firstVisible = await get(`q=${suffix}&limit=1`);
+    await expect(firstVisible.json()).resolves.toEqual({ data: [visibleName] });
+
+    await setSiteCeiling(env, []);
+    await expect((await get(`q=${suffix}`)).json()).resolves.toEqual({ data: [] });
+
+    await setSiteCeiling(env, null);
+    const unrestricted = await get(`q=${suffix}&limit=50`);
+    await expect(unrestricted.json()).resolves.toEqual({
+      data: [hiddenName, visibleName, moveOnlyName],
+    });
+
+    await setSiteCeiling(env, [env.site.id]);
+    await database.update(devices).set({ siteId: hiddenSite.id }).where(eq(devices.id, visibleA!.id));
+    const afterMove = await get(`q=${suffix}&limit=50`);
+    await expect(afterMove.json()).resolves.toEqual({ data: [visibleName] });
+  });
+});

--- a/apps/api/src/jobs/snmpWorker.orgAuthority.test.ts
+++ b/apps/api/src/jobs/snmpWorker.orgAuthority.test.ts
@@ -186,12 +186,21 @@ function selectForUpdateChain(rows: unknown[]) {
 
 /** Records every `snmp_devices` UPDATE by which write it is. */
 const updateLog: string[] = [];
+/** Every `.set()` payload, in order, so tests can assert the recorded outcome. */
+const updatePayloads: Record<string, unknown>[] = [];
 function updateChain() {
   return {
     set: (payload: Record<string, unknown>) => ({
       where: async () => {
+        updatePayloads.push(payload);
         updateLog.push(
-          !('consecutiveFailures' in payload) ? 'attemptStamp' : 'dispatchCount'
+          !('consecutiveFailures' in payload)
+            ? 'attemptStamp'
+            // A site-authority refusal writes a literal string status; the
+            // dispatch counter writes a CASE expression instead.
+            : typeof payload.lastStatus === 'string'
+              ? 'siteAuthorityFailure'
+              : 'dispatchCount'
         );
       },
     }),
@@ -234,6 +243,7 @@ describe('snmpWorker org authority (#3226)', () => {
     vi.clearAllMocks();
     eqCalls.length = 0;
     updateLog.length = 0;
+    updatePayloads.length = 0;
     // mockReset, not clearAllMocks: several tests deliberately leave part of the
     // `mockReturnValueOnce` chain unconsumed (the org guard short-circuits before
     // the template and agent selects). `clearAllMocks` clears recorded calls but
@@ -384,15 +394,35 @@ describe('snmpWorker org authority (#3226)', () => {
 
   describe('asset-bound polls use current site authority', () => {
     it('selects the polling agent from the asset current site after a move before decrypting or dispatching', async () => {
-      wireAssetDispatch([{ siteId: CURRENT_SITE }]);
+      // Poll the SAME snmp_devices row twice across a simulated asset move.
+      // Nothing on the SNMP row records a site, so the only way the second poll
+      // can bind CURRENT_SITE is by re-reading the locked asset each time. The
+      // first pass is what makes PREVIOUS_SITE a value the code demonstrably
+      // CAN bind — without it the "not PREVIOUS_SITE" assertion below is
+      // unfalsifiable, since that id appears nowhere else in the fixture.
+      wireAssetDispatch([{ siteId: PREVIOUS_SITE }], [{ agentId: 'agent-in-previous-site' }]);
 
-      const result = await processPollDevice({
+      const before = await processPollDevice({
         type: 'poll-device',
         deviceId: DEVICE_ID,
         orgId: LIVE_ORG,
       });
 
-      expect(result).toEqual({ dispatched: true, agentId: 'agent-in-current-site' });
+      expect(before).toEqual({ dispatched: true, agentId: 'agent-in-previous-site' });
+      expect(eqCalls).toContainEqual(['devices.siteId', PREVIOUS_SITE]);
+
+      // The asset moves. Same job payload, same SNMP row, new asset site.
+      eqCalls.length = 0;
+      vi.clearAllMocks();
+      wireAssetDispatch([{ siteId: CURRENT_SITE }]);
+
+      const after = await processPollDevice({
+        type: 'poll-device',
+        deviceId: DEVICE_ID,
+        orgId: LIVE_ORG,
+      });
+
+      expect(after).toEqual({ dispatched: true, agentId: 'agent-in-current-site' });
       expect(eqCalls).toContainEqual(['discoveredAssets.id', ASSET_ID]);
       expect(eqCalls).toContainEqual(['discoveredAssets.orgId', LIVE_ORG]);
       expect(eqCalls).toContainEqual(['devices.siteId', CURRENT_SITE]);
@@ -411,6 +441,11 @@ describe('snmpWorker org authority (#3226)', () => {
       expect(warn).toHaveBeenCalledWith(expect.stringContaining(`Asset ${ASSET_ID} not found`));
       expect(decryptMock).not.toHaveBeenCalled();
       expect(agentRelayMock.dispatchCommandToAgent).not.toHaveBeenCalled();
+      // Durable, not just a log line: nothing else will poll this device, so
+      // the refusal must reach the row the dashboard and alerting read.
+      expect(updateLog).toContain('siteAuthorityFailure');
+      expect(updatePayloads.at(-1)?.lastStatus).toBe('asset_missing');
+      expect(updatePayloads.at(-1)).toHaveProperty('consecutiveFailures');
       warn.mockRestore();
     });
 
@@ -424,6 +459,9 @@ describe('snmpWorker org authority (#3226)', () => {
       expect(warn).toHaveBeenCalledWith(expect.stringContaining(`Asset ${ASSET_ID} has no site`));
       expect(decryptMock).not.toHaveBeenCalled();
       expect(agentRelayMock.dispatchCommandToAgent).not.toHaveBeenCalled();
+      expect(updateLog).toContain('siteAuthorityFailure');
+      expect(updatePayloads.at(-1)?.lastStatus).toBe('asset_no_site');
+      expect(updatePayloads.at(-1)).toHaveProperty('consecutiveFailures');
       warn.mockRestore();
     });
 
@@ -437,6 +475,12 @@ describe('snmpWorker org authority (#3226)', () => {
       expect(eqCalls).toContainEqual(['devices.siteId', CURRENT_SITE]);
       expect(decryptMock).not.toHaveBeenCalled();
       expect(agentRelayMock.dispatchCommandToAgent).not.toHaveBeenCalled();
+      // The whole point of refusing the cross-site fallback: this device is now
+      // unpolled, and it must SAY so rather than sitting on its last-known
+      // status forever.
+      expect(updateLog).toContain('siteAuthorityFailure');
+      expect(updatePayloads.at(-1)?.lastStatus).toBe('no_agent_in_site');
+      expect(updatePayloads.at(-1)).toHaveProperty('consecutiveFailures');
       warn.mockRestore();
     });
 
@@ -447,6 +491,27 @@ describe('snmpWorker org authority (#3226)', () => {
 
       expect(result).toEqual({ dispatched: true, agentId: 'legacy-org-agent' });
       expect(eqCalls).not.toContainEqual(['devices.siteId', CURRENT_SITE]);
+    });
+
+    it('leaves the org-wide no-agent branch uncounted, as before', async () => {
+      // The org having no online agent at all is a transient Breeze-side
+      // condition (an MSP's only agent host rebooting) and has always been
+      // deliberately uncounted — counting it would mark healthy switches
+      // offline. Only the site-scoped refusals above are recorded.
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      wireDispatchSelects(LIVE_ORG, '');
+      mockDb.select.mockReset();
+      mockDb.select
+        .mockReturnValueOnce(selectChain([deviceRow(LIVE_ORG)]) as never)
+        .mockReturnValueOnce(selectChain([{ oids: [{ oid: '1.3.6.1.2.1.1.3.0' }] }]) as never)
+        .mockReturnValueOnce(selectChain([]) as never);
+
+      const result = await processPollDevice({ type: 'poll-device', deviceId: DEVICE_ID, orgId: LIVE_ORG });
+
+      expect(result).toEqual({ dispatched: false, agentId: null });
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining(`No online agent for org ${LIVE_ORG}`));
+      expect(updateLog).not.toContain('siteAuthorityFailure');
+      warn.mockRestore();
     });
   });
 

--- a/apps/api/src/jobs/snmpWorker.orgAuthority.test.ts
+++ b/apps/api/src/jobs/snmpWorker.orgAuthority.test.ts
@@ -86,6 +86,7 @@ vi.mock('../db/schema', () => ({
   snmpDevices: {
     id: 'snmpDevices.id',
     orgId: 'snmpDevices.orgId',
+    assetId: 'snmpDevices.assetId',
     isActive: 'snmpDevices.isActive',
     lastPolled: 'snmpDevices.lastPolled',
     lastPollAttemptedAt: 'snmpDevices.lastPollAttemptedAt',
@@ -103,8 +104,14 @@ vi.mock('../db/schema', () => ({
   devices: {
     agentId: 'devices.agentId',
     orgId: 'devices.orgId',
+    siteId: 'devices.siteId',
     isEphemeral: 'devices.isEphemeral',
     status: 'devices.status',
+  },
+  discoveredAssets: {
+    id: 'discoveredAssets.id',
+    orgId: 'discoveredAssets.orgId',
+    siteId: 'discoveredAssets.siteId',
   },
 }));
 
@@ -132,12 +139,16 @@ const { processPollDevice } = __testables;
 const LIVE_ORG = '11111111-1111-1111-1111-111111111111';
 const STALE_ORG = '22222222-2222-2222-2222-222222222222';
 const DEVICE_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const ASSET_ID = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+const CURRENT_SITE = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+const PREVIOUS_SITE = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
 
 /** The `snmp_devices` row as the dispatch path sees it, with v2c + v3 secrets. */
-function deviceRow(orgId: string) {
+function deviceRow(orgId: string, assetId: string | null = null) {
   return {
     id: DEVICE_ID,
     orgId,
+    assetId,
     templateId: 'template-1',
     ipAddress: '10.0.0.1',
     port: 161,
@@ -157,6 +168,17 @@ function selectChain(rows: unknown[]) {
     from: vi.fn().mockReturnValue({
       where: vi.fn().mockReturnValue({
         limit: vi.fn().mockResolvedValue(rows),
+      }),
+    }),
+  };
+}
+
+/** A `.select().from().where().for('update')` chain resolving to `rows`. */
+function selectForUpdateChain(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        for: vi.fn().mockResolvedValue(rows),
       }),
     }),
   };
@@ -193,6 +215,18 @@ function wireDispatchSelects(deviceOrgId: string, agentId: string) {
     .mockReturnValueOnce(selectChain([deviceRow(deviceOrgId)]) as never)
     .mockReturnValueOnce(selectChain([{ oids: [{ oid: '1.3.6.1.2.1.1.3.0' }] }]) as never)
     .mockReturnValueOnce(selectChain([{ agentId }]) as never);
+}
+
+/** Wire an asset-bound dispatch: SNMP row → template → current asset → site agent. */
+function wireAssetDispatch(
+  assetRows: unknown[],
+  agentRows: unknown[] = [{ agentId: 'agent-in-current-site' }],
+) {
+  mockDb.select
+    .mockReturnValueOnce(selectChain([deviceRow(LIVE_ORG, ASSET_ID)]) as never)
+    .mockReturnValueOnce(selectChain([{ oids: [{ oid: '1.3.6.1.2.1.1.3.0' }] }]) as never)
+    .mockReturnValueOnce(selectForUpdateChain(assetRows) as never)
+    .mockReturnValueOnce(selectChain(agentRows) as never);
 }
 
 describe('snmpWorker org authority (#3226)', () => {
@@ -345,6 +379,74 @@ describe('snmpWorker org authority (#3226)', () => {
       ];
       expect(agentId).toBe('agent-live');
       expect(command.type).toBe('snmp_poll');
+    });
+  });
+
+  describe('asset-bound polls use current site authority', () => {
+    it('selects the polling agent from the asset current site after a move before decrypting or dispatching', async () => {
+      wireAssetDispatch([{ siteId: CURRENT_SITE }]);
+
+      const result = await processPollDevice({
+        type: 'poll-device',
+        deviceId: DEVICE_ID,
+        orgId: LIVE_ORG,
+      });
+
+      expect(result).toEqual({ dispatched: true, agentId: 'agent-in-current-site' });
+      expect(eqCalls).toContainEqual(['discoveredAssets.id', ASSET_ID]);
+      expect(eqCalls).toContainEqual(['discoveredAssets.orgId', LIVE_ORG]);
+      expect(eqCalls).toContainEqual(['devices.siteId', CURRENT_SITE]);
+      expect(eqCalls).not.toContainEqual(['devices.siteId', PREVIOUS_SITE]);
+      expect(decryptMock).toHaveBeenCalled();
+      expect(agentRelayMock.dispatchCommandToAgent).toHaveBeenCalledTimes(1);
+    });
+
+    it('fails closed when the asset was removed before dispatch', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      wireAssetDispatch([]);
+
+      const result = await processPollDevice({ type: 'poll-device', deviceId: DEVICE_ID, orgId: LIVE_ORG });
+
+      expect(result).toEqual({ dispatched: false, agentId: null });
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining(`Asset ${ASSET_ID} not found`));
+      expect(decryptMock).not.toHaveBeenCalled();
+      expect(agentRelayMock.dispatchCommandToAgent).not.toHaveBeenCalled();
+      warn.mockRestore();
+    });
+
+    it('fails closed when the current asset has no site', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      wireAssetDispatch([{ siteId: null }]);
+
+      const result = await processPollDevice({ type: 'poll-device', deviceId: DEVICE_ID, orgId: LIVE_ORG });
+
+      expect(result).toEqual({ dispatched: false, agentId: null });
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining(`Asset ${ASSET_ID} has no site`));
+      expect(decryptMock).not.toHaveBeenCalled();
+      expect(agentRelayMock.dispatchCommandToAgent).not.toHaveBeenCalled();
+      warn.mockRestore();
+    });
+
+    it('does not fall back across sites when no online agent exists in the current site', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      wireAssetDispatch([{ siteId: CURRENT_SITE }], []);
+
+      const result = await processPollDevice({ type: 'poll-device', deviceId: DEVICE_ID, orgId: LIVE_ORG });
+
+      expect(result).toEqual({ dispatched: false, agentId: null });
+      expect(eqCalls).toContainEqual(['devices.siteId', CURRENT_SITE]);
+      expect(decryptMock).not.toHaveBeenCalled();
+      expect(agentRelayMock.dispatchCommandToAgent).not.toHaveBeenCalled();
+      warn.mockRestore();
+    });
+
+    it('preserves established org-wide selection only for legacy non-asset rows', async () => {
+      wireDispatchSelects(LIVE_ORG, 'legacy-org-agent');
+
+      const result = await processPollDevice({ type: 'poll-device', deviceId: DEVICE_ID, orgId: LIVE_ORG });
+
+      expect(result).toEqual({ dispatched: true, agentId: 'legacy-org-agent' });
+      expect(eqCalls).not.toContainEqual(['devices.siteId', CURRENT_SITE]);
     });
   });
 

--- a/apps/api/src/jobs/snmpWorker.ts
+++ b/apps/api/src/jobs/snmpWorker.ts
@@ -49,6 +49,55 @@ const MAX_BACKOFF_SECONDS = 3600; // sub-hour intervals never stretch past an ho
  */
 const FAILURE_STATUS_THRESHOLD = 3;
 
+/**
+ * `snmp_devices.last_status` values for the three site-authority refusals below.
+ *
+ * These are NOT the same class of event as "the org has no online agent". That
+ * one is a transient Breeze-side condition — an MSP's only agent host rebooting
+ * — and `markPollDispatched` deliberately refuses to count it, so a healthy
+ * switch is not marked offline for an hour every reboot.
+ *
+ * A site-authority refusal is different: nothing else will poll this device.
+ * Before asset-site authority existed, any online agent in the org picked the
+ * poll up, so these devices kept reporting. Now they do not, and leaving
+ * `last_status` at its last-known value would show a green switch that has not
+ * been polled since the asset moved — silent monitoring loss. Each cause gets
+ * its own value (rather than the generic 'offline') so the dashboard can say
+ * WHY, and `consecutive_failures` is incremented so the existing backoff and
+ * failure/alert path treats it like any other sustained polling failure. A
+ * genuine successful poll clears both.
+ *
+ * All three fit `last_status varchar(20)`.
+ */
+const SITE_AUTHORITY_STATUS = {
+  assetMissing: 'asset_missing',
+  assetNoSite: 'asset_no_site',
+  noAgentInSite: 'no_agent_in_site',
+} as const;
+
+/**
+ * Record a site-authority refusal durably against the SNMP device.
+ *
+ * Runs in its own short system DB context: phase 1's context has already closed
+ * by the time the outcome switch runs, and phase 2 deliberately holds no
+ * context across the agent socket. This path is a failure path only, so the
+ * extra connection acquisition is not on the hot poll.
+ */
+async function recordSiteAuthorityFailure(
+  deviceId: string,
+  status: (typeof SITE_AUTHORITY_STATUS)[keyof typeof SITE_AUTHORITY_STATUS],
+): Promise<void> {
+  await runWithSystemDbAccess(() =>
+    db
+      .update(snmpDevices)
+      .set({
+        consecutiveFailures: sql`${snmpDevices.consecutiveFailures} + 1`,
+        lastStatus: status,
+      })
+      .where(eq(snmpDevices.id, deviceId))
+  );
+}
+
 let snmpQueue: Queue | null = null;
 
 export function getSnmpQueue(): Queue {
@@ -419,14 +468,22 @@ async function processPollDevice(data: PollDeviceJobData): Promise<{
       return { dispatched: false, agentId: null };
     case 'asset-missing':
       console.warn(`[SnmpWorker] Asset ${inputs.assetId} not found in org ${inputs.orgId}; refusing asset-bound SNMP poll`);
+      await recordSiteAuthorityFailure(data.deviceId, SITE_AUTHORITY_STATUS.assetMissing);
       return { dispatched: false, agentId: null };
     case 'asset-site-missing':
       console.warn(`[SnmpWorker] Asset ${inputs.assetId} has no site in org ${inputs.orgId}; refusing asset-bound SNMP poll`);
+      await recordSiteAuthorityFailure(data.deviceId, SITE_AUTHORITY_STATUS.assetNoSite);
       return { dispatched: false, agentId: null };
     case 'no-agent':
       console.warn(inputs.siteId
         ? `[SnmpWorker] No online agent for org ${inputs.orgId} in site ${inputs.siteId}`
         : `[SnmpWorker] No online agent for org ${inputs.orgId}`);
+      // Site-scoped only. The org-wide branch keeps its established
+      // don't-count-it behaviour (see SITE_AUTHORITY_STATUS above): that is a
+      // transient Breeze-side condition, not a device that nothing will poll.
+      if (inputs.siteId) {
+        await recordSiteAuthorityFailure(data.deviceId, SITE_AUTHORITY_STATUS.noAgentInSite);
+      }
       return { dispatched: false, agentId: null };
   }
 

--- a/apps/api/src/jobs/snmpWorker.ts
+++ b/apps/api/src/jobs/snmpWorker.ts
@@ -7,7 +7,7 @@
 
 import { Queue, Worker, Job } from 'bullmq';
 import * as dbModule from '../db';
-import { snmpDevices, snmpMetrics, snmpTemplates, devices } from '../db/schema';
+import { discoveredAssets, snmpDevices, snmpMetrics, snmpTemplates, devices } from '../db/schema';
 import { eq, and, or, sql } from 'drizzle-orm';
 import { getBullMQConnection } from '../services/redis';
 import { createInstrumentedQueue } from '../services/bullmqQueue';
@@ -219,7 +219,9 @@ type PollDispatchInputs =
   | { status: 'device-missing' }
   | { status: 'org-mismatch'; payloadOrgId: string; deviceOrgId: string }
   | { status: 'no-oids' }
-  | { status: 'no-agent'; orgId: string }
+  | { status: 'asset-missing'; assetId: string; orgId: string }
+  | { status: 'asset-site-missing'; assetId: string; orgId: string }
+  | { status: 'no-agent'; orgId: string; siteId: string | null }
   | {
       status: 'ok';
       device: typeof snmpDevices.$inferSelect;
@@ -291,29 +293,59 @@ async function loadPollDispatchInputs(data: PollDeviceJobData): Promise<PollDisp
     return { status: 'no-oids' };
   }
 
-  // Find an online agent for this org — `device.orgId`, the live row, never the
-  // job payload (#3226).
+  // Asset-bound SNMP polls are a site-scoped operation. Resolve and lock the
+  // CURRENT asset row before selecting an executor so a concurrent site move
+  // cannot split the authorization read from the agent-selection read. The
+  // lock is released with this short phase-1 DB context, before connectivity,
+  // credential decryption, or WebSocket dispatch.
+  //
+  // Legacy SNMP rows without an assetId predate discovered-asset binding and
+  // retain their established org-wide executor selection. New route-created
+  // rows are always asset-bound.
+  let executionSiteId: string | null = null;
+  if (device.assetId) {
+    const assetRows = await db
+      .select({ siteId: discoveredAssets.siteId })
+      .from(discoveredAssets)
+      .where(and(
+        eq(discoveredAssets.id, device.assetId),
+        eq(discoveredAssets.orgId, device.orgId),
+      ))
+      .for('update');
+    const asset = assetRows[0];
+    if (!asset) {
+      return { status: 'asset-missing', assetId: device.assetId, orgId: device.orgId };
+    }
+    if (typeof asset.siteId !== 'string') {
+      return { status: 'asset-site-missing', assetId: device.assetId, orgId: device.orgId };
+    }
+    executionSiteId = asset.siteId;
+  }
+
+  // Find an online agent for this org — and, for asset-bound rows, the current
+  // asset site. `device.orgId` is the live row, never the job payload (#3226).
   //
   // Quick Support exclusion: ephemeral devices (`devices.isEphemeral`) live in
   // the hidden per-partner 'quick_support' org and are a stranger's personal
   // machine borrowed for one ~20-minute session. That org stays inside
   // technicians' accessibleOrgIds for RLS reasons, so a bare "any online device
   // in this org" pick could conscript a home PC into polling SNMP targets.
+  const agentConditions = [
+    eq(devices.orgId, device.orgId),
+    eq(devices.isEphemeral, false),
+    eq(devices.status, 'online'),
+  ];
+  if (executionSiteId) agentConditions.push(eq(devices.siteId, executionSiteId));
+
   const [onlineAgent] = await db
     .select({ agentId: devices.agentId })
     .from(devices)
-    .where(
-      and(
-        eq(devices.orgId, device.orgId),
-        eq(devices.isEphemeral, false),
-        eq(devices.status, 'online')
-      )
-    )
+    .where(and(...agentConditions))
     .limit(1);
 
   const agentId = onlineAgent?.agentId ?? null;
   if (!agentId) {
-    return { status: 'no-agent', orgId: device.orgId };
+    return { status: 'no-agent', orgId: device.orgId, siteId: executionSiteId };
   }
 
   return { status: 'ok', device, oids, agentId };
@@ -385,8 +417,16 @@ async function processPollDevice(data: PollDeviceJobData): Promise<{
     case 'no-oids':
       console.warn(`[SnmpWorker] No OIDs configured for device ${data.deviceId}`);
       return { dispatched: false, agentId: null };
+    case 'asset-missing':
+      console.warn(`[SnmpWorker] Asset ${inputs.assetId} not found in org ${inputs.orgId}; refusing asset-bound SNMP poll`);
+      return { dispatched: false, agentId: null };
+    case 'asset-site-missing':
+      console.warn(`[SnmpWorker] Asset ${inputs.assetId} has no site in org ${inputs.orgId}; refusing asset-bound SNMP poll`);
+      return { dispatched: false, agentId: null };
     case 'no-agent':
-      console.warn(`[SnmpWorker] No online agent for org ${inputs.orgId}`);
+      console.warn(inputs.siteId
+        ? `[SnmpWorker] No online agent for org ${inputs.orgId} in site ${inputs.siteId}`
+        : `[SnmpWorker] No online agent for org ${inputs.orgId}`);
       return { dispatched: false, agentId: null };
   }
 

--- a/apps/api/src/routes/monitoring.ts
+++ b/apps/api/src/routes/monitoring.ts
@@ -70,6 +70,42 @@ async function resolveOrgIdForAsset(auth: AuthContext, assetId: string, requeste
   return { orgId: asset.orgId } as const;
 }
 
+/**
+ * Resolve and, for a site-restricted caller, lock the discovered asset before a
+ * monitoring mutation. The ambient request transaction holds the row lock
+ * through the downstream SNMP/network-monitor write, so a concurrent asset move
+ * cannot invalidate the current-site decision between check and use.
+ */
+async function resolveAssetForMonitoringMutation(
+  auth: AuthContext,
+  perms: UserPermissions | undefined,
+  assetId: string,
+) {
+  if (perms?.allowedSiteIds?.length === 0) {
+    return { error: 'Access to this site denied', status: 403 } as const;
+  }
+
+  const orgResult = await resolveOrgIdForAsset(auth, assetId);
+  if ('error' in orgResult) {
+    return { error: orgResult.error, status: orgResult.status } as const;
+  }
+  const orgId = orgResult.orgId;
+  if (!orgId) return { error: 'Could not determine organization context', status: 400 } as const;
+
+  const query = db.select()
+    .from(discoveredAssets)
+    .where(and(eq(discoveredAssets.id, assetId), eq(discoveredAssets.orgId, orgId)))
+    .limit(1);
+  const rows = perms?.allowedSiteIds ? await query.for('update') : await query;
+  const asset = rows[0];
+  if (!asset) return { error: 'Asset not found', status: 404 } as const;
+  if (perms?.allowedSiteIds && (typeof asset.siteId !== 'string' || !canAccessSite(perms, asset.siteId))) {
+    return { error: 'Access to this site denied', status: 403 } as const;
+  }
+
+  return { asset } as const;
+}
+
 export const monitoringRoutes = new Hono();
 monitoringRoutes.use('*', authMiddleware);
 const requireMonitoringRead = requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action);
@@ -411,17 +447,13 @@ monitoringRoutes.put(
     const auth = c.get('auth') as AuthContext;
     const assetId = c.req.param('id')!;
     const body = c.req.valid('json');
-
-    const orgResult = await resolveOrgIdForAsset(auth, assetId);
-    if ('error' in orgResult) return c.json({ error: orgResult.error }, orgResult.status);
-    const orgId = orgResult.orgId;
-    if (!orgId) return c.json({ error: 'Could not determine organization context' }, 400);
-
-    const [asset] = await db.select()
-      .from(discoveredAssets)
-      .where(and(eq(discoveredAssets.id, assetId), eq(discoveredAssets.orgId, orgId)))
-      .limit(1);
-    if (!asset) return c.json({ error: 'Asset not found' }, 404);
+    const assetResult = await resolveAssetForMonitoringMutation(
+      auth,
+      c.get('permissions') as UserPermissions | undefined,
+      assetId,
+    );
+    if ('error' in assetResult) return c.json({ error: assetResult.error }, assetResult.status);
+    const { asset } = assetResult;
 
     // #5213: ip_address is nullable now (manual website / DNS-only assets).
     // snmp_devices.ip_address is varchar NOT NULL, so the old `?? ''` fallback
@@ -558,17 +590,13 @@ monitoringRoutes.patch(
     const auth = c.get('auth') as AuthContext;
     const assetId = c.req.param('id')!;
     const body = c.req.valid('json');
-
-    const orgResult = await resolveOrgIdForAsset(auth, assetId);
-    if ('error' in orgResult) return c.json({ error: orgResult.error }, orgResult.status);
-    const orgId = orgResult.orgId;
-    if (!orgId) return c.json({ error: 'Could not determine organization context' }, 400);
-
-    const [asset] = await db.select({ id: discoveredAssets.id, orgId: discoveredAssets.orgId })
-      .from(discoveredAssets)
-      .where(and(eq(discoveredAssets.id, assetId), eq(discoveredAssets.orgId, orgId)))
-      .limit(1);
-    if (!asset) return c.json({ error: 'Asset not found' }, 404);
+    const assetResult = await resolveAssetForMonitoringMutation(
+      auth,
+      c.get('permissions') as UserPermissions | undefined,
+      assetId,
+    );
+    if ('error' in assetResult) return c.json({ error: assetResult.error }, assetResult.status);
+    const { asset } = assetResult;
 
     if (body.templateId && !(await validateSnmpTemplateAccess(body.templateId, asset.orgId))) {
       return c.json({ error: 'SNMP template not found' }, 404);
@@ -638,17 +666,13 @@ monitoringRoutes.delete(
   async (c) => {
     const auth = c.get('auth') as AuthContext;
     const assetId = c.req.param('id')!;
-
-    const orgResult = await resolveOrgIdForAsset(auth, assetId);
-    if ('error' in orgResult) return c.json({ error: orgResult.error }, orgResult.status);
-    const orgId = orgResult.orgId;
-    if (!orgId) return c.json({ error: 'Could not determine organization context' }, 400);
-
-    const [asset] = await db.select({ id: discoveredAssets.id, orgId: discoveredAssets.orgId })
-      .from(discoveredAssets)
-      .where(and(eq(discoveredAssets.id, assetId), eq(discoveredAssets.orgId, orgId)))
-      .limit(1);
-    if (!asset) return c.json({ error: 'Asset not found' }, 404);
+    const assetResult = await resolveAssetForMonitoringMutation(
+      auth,
+      c.get('permissions') as UserPermissions | undefined,
+      assetId,
+    );
+    if ('error' in assetResult) return c.json({ error: assetResult.error }, assetResult.status);
+    const { asset } = assetResult;
 
     const disabledSnmp = await db.update(snmpDevices)
       .set({ isActive: false })
@@ -703,17 +727,36 @@ monitoringRoutes.get(
     if ('error' in orgResult) return c.json({ error: orgResult.error }, orgResult.status);
     const orgId = orgResult.orgId;
     if (!orgId) return c.json({ error: 'Could not determine organization context' }, 400);
+    const allowedSiteIds = (c.get('permissions') as UserPermissions | undefined)?.allowedSiteIds;
+
+    // An explicitly empty ceiling is deny-all. Return before either source
+    // query so an unavailable/misconfigured database cannot turn deny-all
+    // into an error oracle.
+    if (allowedSiteIds?.length === 0) return c.json({ data: [] });
 
     // Source 1: Distinct service names from device change log (change tracker
     // already snapshots all services on every heartbeat cycle)
     let changeLogNames: { subject: string }[] = [];
     try {
-      changeLogNames = await db
-        .select({ subject: deviceChangeLog.subject })
-        .from(deviceChangeLog)
-        .where(and(eq(deviceChangeLog.orgId, orgId), eq(deviceChangeLog.changeType, 'service')))
-        .groupBy(deviceChangeLog.subject)
-        .limit(1000);
+      changeLogNames = allowedSiteIds === undefined
+        ? await db
+            .select({ subject: deviceChangeLog.subject })
+            .from(deviceChangeLog)
+            .where(and(eq(deviceChangeLog.orgId, orgId), eq(deviceChangeLog.changeType, 'service')))
+            .groupBy(deviceChangeLog.subject)
+            .limit(1000)
+        : await db
+            .select({ subject: deviceChangeLog.subject })
+            .from(deviceChangeLog)
+            .innerJoin(devices, eq(deviceChangeLog.deviceId, devices.id))
+            .where(and(
+              eq(deviceChangeLog.orgId, orgId),
+              eq(deviceChangeLog.changeType, 'service'),
+              eq(devices.orgId, orgId),
+              inArray(devices.siteId, allowedSiteIds)
+            ))
+            .groupBy(deviceChangeLog.subject)
+            .limit(1000);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       if (!msg.includes('does not exist')) {
@@ -724,15 +767,28 @@ monitoringRoutes.get(
     // Source 2: Distinct service/process names from monitoring check results
     let checkNames: { name: string; watchType: string }[] = [];
     try {
-      checkNames = await db
-        .select({
-          name: serviceProcessCheckResults.name,
-          watchType: serviceProcessCheckResults.watchType,
-        })
-        .from(serviceProcessCheckResults)
-        .where(eq(serviceProcessCheckResults.orgId, orgId))
-        .groupBy(serviceProcessCheckResults.name, serviceProcessCheckResults.watchType)
-        .limit(500);
+      const selection = {
+        name: serviceProcessCheckResults.name,
+        watchType: serviceProcessCheckResults.watchType,
+      };
+      checkNames = allowedSiteIds === undefined
+        ? await db
+            .select(selection)
+            .from(serviceProcessCheckResults)
+            .where(eq(serviceProcessCheckResults.orgId, orgId))
+            .groupBy(serviceProcessCheckResults.name, serviceProcessCheckResults.watchType)
+            .limit(500)
+        : await db
+            .select(selection)
+            .from(serviceProcessCheckResults)
+            .innerJoin(devices, eq(serviceProcessCheckResults.deviceId, devices.id))
+            .where(and(
+              eq(serviceProcessCheckResults.orgId, orgId),
+              eq(devices.orgId, orgId),
+              inArray(devices.siteId, allowedSiteIds)
+            ))
+            .groupBy(serviceProcessCheckResults.name, serviceProcessCheckResults.watchType)
+            .limit(500);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       if (!msg.includes('does not exist')) {

--- a/apps/api/src/routes/monitoring_assets_snmp.test.ts
+++ b/apps/api/src/routes/monitoring_assets_snmp.test.ts
@@ -94,6 +94,7 @@ vi.mock('../db/schema', () => ({
 
 vi.mock('../middleware/auth', () => ({
   authMiddleware: vi.fn((c: any, next: any) => {
+    const siteHeader = c.req.header('x-restrict-site');
     c.set('auth', {
       user: { id: 'user-1', email: 'test@example.com', name: 'Test User' },
       scope: 'organization',
@@ -103,6 +104,11 @@ vi.mock('../middleware/auth', () => ({
       orgCondition: () => undefined,
       canAccessOrg: (id: string) => id === 'org-111',
     });
+    if (siteHeader) {
+      c.set('permissions', {
+        allowedSiteIds: siteHeader === '__empty__' ? [] : siteHeader.split(','),
+      });
+    }
     return next();
   }),
   requireScope: vi.fn(() => async (_c: any, next: any) => next()),
@@ -126,6 +132,8 @@ const ORG_ID = 'org-111';
 const ASSET_ID = '11111111-1111-1111-1111-111111111111';
 const DEVICE_ID = '22222222-2222-2222-2222-222222222222';
 const SNMP_DEVICE_ID = '33333333-3333-3333-3333-333333333333';
+const SITE_ALLOWED = 'aaaaaaaa-0000-0000-0000-000000000001';
+const SITE_HIDDEN = 'bbbbbbbb-0000-0000-0000-000000000002';
 
 
 describe('monitoring routes', () => {
@@ -133,6 +141,10 @@ describe('monitoring routes', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(db.select).mockReset();
+    vi.mocked(db.insert).mockReset();
+    vi.mocked(db.update).mockReset();
+    vi.mocked(db.delete).mockReset();
     app = new Hono();
     app.route('/monitoring', monitoringRoutes);
   });
@@ -141,18 +153,73 @@ describe('monitoring routes', () => {
   // PUT /assets/:id/snmp
   // ============================================
   describe('PUT /monitoring/assets/:id/snmp', () => {
+    it('denies a hidden-site asset before credential or monitor writes', async () => {
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockReturnValue({
+              for: vi.fn().mockResolvedValue([{
+                id: ASSET_ID,
+                orgId: ORG_ID,
+                siteId: SITE_HIDDEN,
+                hostname: 'hidden-switch',
+                ipAddress: '10.0.0.2',
+              }]),
+            }),
+          }),
+        }),
+      } as any).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
+          }),
+        }),
+      } as any);
+      vi.mocked(db.insert).mockReturnValueOnce({
+        values: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([{
+          id: SNMP_DEVICE_ID,
+          snmpVersion: 'v2c',
+          port: 161,
+          community: 'enc:v1:mock',
+          username: null,
+          templateId: null,
+          pollingInterval: 300,
+          isActive: true,
+          lastPolled: null,
+          lastStatus: null,
+        }]) }),
+      } as any);
+
+      const res = await app.request(`/monitoring/assets/${ASSET_ID}/snmp`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer token',
+          'x-restrict-site': SITE_ALLOWED,
+        },
+        body: JSON.stringify({ snmpVersion: 'v2c', community: 'secret' }),
+      });
+
+      expect(res.status).toBe(403);
+      expect(db.insert).not.toHaveBeenCalled();
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
     it('stores encrypted SNMP community strings for an asset', async () => {
       // Asset lookup
       vi.mocked(db.select)
         .mockReturnValueOnce({
           from: vi.fn().mockReturnValue({
             where: vi.fn().mockReturnValue({
-              limit: vi.fn().mockResolvedValue([{
-                id: ASSET_ID,
-                orgId: ORG_ID,
-                hostname: 'switch-01',
-                ipAddress: '10.0.0.1',
-              }]),
+              limit: vi.fn().mockReturnValue({
+                for: vi.fn().mockResolvedValue([{
+                  id: ASSET_ID,
+                  orgId: ORG_ID,
+                  siteId: SITE_ALLOWED,
+                  hostname: 'switch-01',
+                  ipAddress: '10.0.0.1',
+                }]),
+              }),
             }),
           }),
         } as any)
@@ -187,7 +254,11 @@ describe('monitoring routes', () => {
 
       const res = await app.request(`/monitoring/assets/${ASSET_ID}/snmp`, {
         method: 'PUT',
-        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer token',
+          'x-restrict-site': SITE_ALLOWED,
+        },
         body: JSON.stringify({ snmpVersion: 'v2c', community: 'public' }),
       });
 
@@ -338,6 +409,64 @@ describe('monitoring routes', () => {
   // PATCH /assets/:id/snmp
   // ============================================
   describe('PATCH /monitoring/assets/:id/snmp', () => {
+    it('denies an empty site ceiling before reading or changing SNMP configuration', async () => {
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockReturnValue({
+              for: vi.fn().mockResolvedValue([{
+                id: ASSET_ID,
+                orgId: ORG_ID,
+                siteId: SITE_HIDDEN,
+              }]),
+            }),
+          }),
+        }),
+      } as any);
+
+      const res = await app.request(`/monitoring/assets/${ASSET_ID}/snmp`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer token',
+          'x-restrict-site': '__empty__',
+        },
+        body: JSON.stringify({ isActive: false }),
+      });
+
+      expect(res.status).toBe(403);
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it('denies a null-site asset to a site-restricted caller before SNMP reads', async () => {
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockReturnValue({
+              for: vi.fn().mockResolvedValue([{
+                id: ASSET_ID,
+                orgId: ORG_ID,
+                siteId: null,
+              }]),
+            }),
+          }),
+        }),
+      } as any);
+
+      const res = await app.request(`/monitoring/assets/${ASSET_ID}/snmp`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer token',
+          'x-restrict-site': SITE_ALLOWED,
+        },
+        body: JSON.stringify({ isActive: false }),
+      });
+
+      expect(res.status).toBe(403);
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
     it('updates existing SNMP config', async () => {
       // Asset lookup
       vi.mocked(db.select)
@@ -516,6 +645,30 @@ describe('monitoring routes', () => {
   // DELETE /assets/:id
   // ============================================
   describe('DELETE /monitoring/assets/:id', () => {
+    it('denies a hidden-site asset before disabling SNMP or network monitors', async () => {
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockReturnValue({
+              for: vi.fn().mockResolvedValue([{
+                id: ASSET_ID,
+                orgId: ORG_ID,
+                siteId: SITE_HIDDEN,
+              }]),
+            }),
+          }),
+        }),
+      } as any);
+
+      const res = await app.request(`/monitoring/assets/${ASSET_ID}`, {
+        method: 'DELETE',
+        headers: { Authorization: 'Bearer token', 'x-restrict-site': SITE_ALLOWED },
+      });
+
+      expect(res.status).toBe(403);
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
     it('disables all monitoring for an asset', async () => {
       vi.mocked(db.select).mockReturnValueOnce({
         from: vi.fn().mockReturnValue({

--- a/apps/api/src/routes/monitoring_results_status.test.ts
+++ b/apps/api/src/routes/monitoring_results_status.test.ts
@@ -21,6 +21,7 @@ vi.mock('../db/schema', () => ({
   },
   deviceSoftware: {},
   deviceChangeLog: {
+    deviceId: 'deviceChangeLog.deviceId',
     orgId: 'deviceChangeLog.orgId',
     changeType: 'deviceChangeLog.changeType',
     subject: 'deviceChangeLog.subject',
@@ -128,6 +129,7 @@ vi.mock('../services/permissions', () => ({
 
 import { monitoringRoutes } from './monitoring';
 import { db } from '../db';
+import { devices } from '../db/schema';
 
 const ORG_ID = 'org-111';
 const ASSET_ID = '11111111-1111-1111-1111-111111111111';
@@ -524,6 +526,53 @@ describe('monitoring routes', () => {
   // GET /known-services
   // ============================================
   describe('GET /monitoring/known-services', () => {
+    it('joins both name sources to current devices inside the selected-site ceiling', async () => {
+      const changeWhere = vi.fn().mockReturnValue({
+        groupBy: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([{ subject: 'allowed-service' }]),
+        }),
+      });
+      const changeJoin = vi.fn().mockReturnValue({ where: changeWhere });
+      const checkWhere = vi.fn().mockReturnValue({
+        groupBy: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([{ name: 'allowed-process', watchType: 'process' }]),
+        }),
+      });
+      const checkJoin = vi.fn().mockReturnValue({ where: checkWhere });
+
+      vi.mocked(db.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({ innerJoin: changeJoin }),
+        } as any)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({ innerJoin: checkJoin }),
+        } as any);
+
+      const res = await app.request('/monitoring/known-services', {
+        headers: { Authorization: 'Bearer token', 'x-restrict-site': SITE_ALLOWED },
+      });
+
+      expect(res.status).toBe(200);
+      expect((await res.json()).data.map((row: { name: string }) => row.name)).toEqual([
+        'allowed-process',
+        'allowed-service',
+      ]);
+      expect(changeJoin).toHaveBeenCalledWith(devices, expect.anything());
+      expect(checkJoin).toHaveBeenCalledWith(devices, expect.anything());
+      expect(JSON.stringify(changeWhere.mock.calls)).toContain(SITE_ALLOWED);
+      expect(JSON.stringify(checkWhere.mock.calls)).toContain(SITE_ALLOWED);
+    });
+
+    it('returns an empty autocomplete without database access for an empty site ceiling', async () => {
+      const res = await app.request('/monitoring/known-services', {
+        headers: { Authorization: 'Bearer token', 'x-restrict-site': ',' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ data: [] });
+      expect(db.select).not.toHaveBeenCalled();
+    });
+
     it('returns deduplicated service names', async () => {
       // Change log query
       vi.mocked(db.select).mockReturnValueOnce({

--- a/apps/api/src/routes/monitoring_results_status.test.ts
+++ b/apps/api/src/routes/monitoring_results_status.test.ts
@@ -130,6 +130,7 @@ vi.mock('../services/permissions', () => ({
 import { monitoringRoutes } from './monitoring';
 import { db } from '../db';
 import { devices } from '../db/schema';
+import { PgDialect } from 'drizzle-orm/pg-core';
 
 const ORG_ID = 'org-111';
 const ASSET_ID = '11111111-1111-1111-1111-111111111111';
@@ -559,8 +560,19 @@ describe('monitoring routes', () => {
       ]);
       expect(changeJoin).toHaveBeenCalledWith(devices, expect.anything());
       expect(checkJoin).toHaveBeenCalledWith(devices, expect.anything());
-      expect(JSON.stringify(changeWhere.mock.calls)).toContain(SITE_ALLOWED);
-      expect(JSON.stringify(checkWhere.mock.calls)).toContain(SITE_ALLOWED);
+
+      // Compile the WHERE and assert on the BOUND PARAMETERS, not a
+      // JSON.stringify deep-search of the mock call graph. A deep-search
+      // matches any string anywhere in the object tree — including schema-stub
+      // values and drizzle-internal metadata — so it can report success for a
+      // site id that never became a bound predicate.
+      const dialect = new PgDialect();
+      const changeQuery = dialect.sqlToQuery(changeWhere.mock.calls[0]![0]);
+      const checkQuery = dialect.sqlToQuery(checkWhere.mock.calls[0]![0]);
+      expect(changeQuery.params).toContain(SITE_ALLOWED);
+      expect(checkQuery.params).toContain(SITE_ALLOWED);
+      expect(changeQuery.params).not.toContain(SITE_DENIED);
+      expect(checkQuery.params).not.toContain(SITE_DENIED);
     });
 
     it('returns an empty autocomplete without database access for an empty site ceiling', async () => {

--- a/apps/api/src/routes/software.test.ts
+++ b/apps/api/src/routes/software.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Hono } from 'hono';
-import { softwareRoutes, computeSoftwareDeploymentAggregateStatus } from './software';
+import {
+  softwareRoutes,
+  computeSoftwareDeploymentAggregateStatus,
+  softwareDeploymentSiteScopePredicate,
+} from './software';
 import { db } from '../db';
 import {
   uploadBinary,
@@ -14,6 +18,7 @@ import { parseStreamingMultipart } from '../services/streamingUpload';
 import { createHash } from 'node:crypto';
 import { authMiddleware } from '../middleware/auth';
 import { inArray, eq, isNull } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
 import { resolveDeploymentTargets } from '../services/deploymentTargetResolver';
 import { createSoftwareDeployment } from '../services/softwareDeployment';
 import {
@@ -225,6 +230,29 @@ vi.mock('../services/streamingUpload', async () => {
     '../services/streamingUpload'
   );
   return { ...actual, parseStreamingMultipart: vi.fn(actual.parseStreamingMultipart) };
+});
+
+describe('software deployment parent site predicate', () => {
+  it('is absent for unrestricted callers and false for an empty site ceiling', () => {
+    expect(softwareDeploymentSiteScopePredicate('id' as never, undefined)).toBeUndefined();
+    const empty = softwareDeploymentSiteScopePredicate('id' as never, { allowedSiteIds: [] } as never)!;
+    expect(new PgDialect().sqlToQuery(empty).sql).toContain('false');
+  });
+
+  it('requires children and rejects any missing, null-site, or outside-site device', () => {
+    const predicate = softwareDeploymentSiteScopePredicate(
+      'id' as never,
+      { allowedSiteIds: ['11111111-1111-4111-8111-111111111111'] } as never,
+    )!;
+    const query = new PgDialect().sqlToQuery(predicate);
+
+    expect(query.sql).toContain('EXISTS');
+    expect(query.sql).toContain('NOT EXISTS');
+    expect(query.sql).toContain('deployment_scope_device.id IS NULL');
+    expect(query.sql).toContain('deployment_scope_device.site_id IS NULL');
+    expect(query.sql).toContain('deployment_scope_device.site_id NOT IN');
+    expect(query.params).toContain('11111111-1111-4111-8111-111111111111');
+  });
 });
 
 describe('software routes', () => {
@@ -2504,6 +2532,39 @@ describe('software routes', () => {
         headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
         body: JSON.stringify({}),
       });
+
+    it('returns an opaque not-found with no mutation or audit when the scoped parent is not visible', async () => {
+      vi.mocked(authMiddleware).mockImplementationOnce((c: any, next: any) => {
+        c.set('auth', {
+          user: { id: 'user-123', email: 'test@example.com', name: 'Test User' },
+          userId: 'user-123',
+          scope: 'organization',
+          orgId: 'org-123',
+          partnerId: null,
+        });
+        c.set('permissions', { allowedSiteIds: ['site-1'] });
+        return next();
+      });
+      const lookup = selectCapture([]);
+      vi.mocked(db.select).mockReturnValueOnce(lookup.chain);
+
+      const res = await cancel();
+
+      expect(res.status).toBe(404);
+      expect(await res.json()).toEqual({ error: 'Deployment not found' });
+      expect(db.update).not.toHaveBeenCalled();
+      expect(applyAutomationActionTerminalMock).not.toHaveBeenCalled();
+      expect(writeRouteAudit).not.toHaveBeenCalled();
+
+      // The parent must be narrowed in SQL, not filtered afterwards: the
+      // preflight WHERE has to carry the site-scope predicate (allowed site id
+      // bound as a parameter) alongside the id/org equality.
+      const whereArgs = lookup.calls.where?.[0];
+      expect(whereArgs).toBeDefined();
+      const compiled = new PgDialect().sqlToQuery(whereArgs![0]);
+      expect(compiled.sql).toContain('deployment_scope_result');
+      expect(compiled.params).toContain('site-1');
+    });
 
     it('purges still-queued commands, leaves delivered ones alone, and reports the count', async () => {
       vi.mocked(db.select)

--- a/apps/api/src/routes/software.test.ts
+++ b/apps/api/src/routes/software.test.ts
@@ -1892,6 +1892,46 @@ describe('software routes', () => {
       buildDispatchMock.mockResolvedValue({ status: 'pending', dispatchedDeviceIds: [DEVICE_A] });
     });
 
+    it('narrows the parent lookup with the site predicate before any mutation', async () => {
+      // Without this the route is both an existence oracle and a mutation
+      // vector: GET /deployments/:id 404s for a hidden-site parent while
+      // /retry still resolves it and re-dispatches installs. Strict parent
+      // everywhere.
+      vi.mocked(authMiddleware).mockImplementationOnce((c: any, next: any) => {
+        c.set('auth', {
+          user: { id: 'user-123', email: 'test@example.com', name: 'Test User' },
+          userId: 'user-123',
+          scope: 'organization',
+          orgId: 'org-123',
+          partnerId: null,
+        });
+        c.set('permissions', { allowedSiteIds: ['site-1'] });
+        return next();
+      });
+      const whereCalls: any[][] = [];
+      const lookup: any = new Proxy(() => lookup, {
+        get: (_t, prop) => {
+          if (prop === 'then') return (resolve: any) => resolve([]);
+          return (...args: any[]) => {
+            if (prop === 'where') whereCalls.push(args);
+            return lookup;
+          };
+        },
+      });
+      vi.mocked(db.select).mockReturnValueOnce(lookup);
+
+      const res = await retry();
+
+      expect(res.status).toBe(404);
+      expect(await res.json()).toEqual({ error: 'Deployment not found' });
+      expect(db.update).not.toHaveBeenCalled();
+      expect(buildDispatchMock).not.toHaveBeenCalled();
+
+      const compiled = new PgDialect().sqlToQuery(whereCalls[0]![0]);
+      expect(compiled.sql).toContain('deployment_scope_result');
+      expect(compiled.params).toContain('site-1');
+    });
+
     it('flips failed rows to pending with incremented retryCount, cleared fields, and re-dispatches (no body)', async () => {
       vi.mocked(db.select)
         .mockReturnValueOnce(selectResult([deploymentRow]))  // deployment lookup
@@ -2409,6 +2449,39 @@ describe('software routes', () => {
     const DEVICE_A = '22222222-2222-4222-8222-222222222222';
 
     const deploymentRow = { id: DEP_ID, orgId: 'org-123', name: 'Results Deploy' };
+
+    it('narrows the parent lookup with the site predicate, not just the child rows', async () => {
+      // Without this the route is an existence oracle: GET /deployments/:id
+      // 404s for a hidden-site parent while /results still answers 200 with an
+      // empty page, confirming the deployment exists. Strict parent everywhere.
+      vi.mocked(authMiddleware).mockImplementationOnce((c: any, next: any) => {
+        c.set('auth', {
+          user: { id: 'user-123', email: 'test@example.com', name: 'Test User' },
+          userId: 'user-123',
+          scope: 'organization',
+          orgId: 'org-123',
+          partnerId: null,
+        });
+        c.set('permissions', { allowedSiteIds: ['site-1'] });
+        return next();
+      });
+      const lookup = selectCapture([]);
+      vi.mocked(db.select).mockReturnValueOnce(lookup.chain);
+
+      const res = await app.request(
+        `/software/deployments/${DEP_ID}/results`,
+        { method: 'GET', headers: { Authorization: 'Bearer token' } },
+      );
+
+      expect(res.status).toBe(404);
+      expect(await res.json()).toEqual({ error: 'Deployment not found' });
+      // No page query, no count query — the parent gate ran first.
+      expect(db.select).toHaveBeenCalledTimes(1);
+
+      const compiled = new PgDialect().sqlToQuery(lookup.calls.where![0]![0]);
+      expect(compiled.sql).toContain('deployment_scope_result');
+      expect(compiled.params).toContain('site-1');
+    });
 
     it('returns hostname-joined rows with queuedOffline and a total, paginated in SQL', async () => {
       const resultRow = {

--- a/apps/api/src/routes/software.ts
+++ b/apps/api/src/routes/software.ts
@@ -133,6 +133,19 @@ function resolveCatalogListScope(
  * aggregate status describe every child device. Restricted callers may see or
  * mutate it only when it has at least one result and every result still points
  * to a live device in one of their allowed sites.
+ *
+ * Applied by every deployment-parent route: list, summary, get-by-id, cancel,
+ * retry and results. Uniformly, on purpose — a route that resolves the parent
+ * without it is an existence oracle for the ones that do.
+ *
+ * The aliased subqueries name `deployment_id`, `device_id` and `site_id` as raw
+ * SQL because Drizzle aliasing inside a `sql` template would not carry the
+ * column mapping. They are the physical names declared in
+ * `db/schema/software.ts:118-121` (`deployment_results.deployment_id`,
+ * `.device_id`) and `db/schema/devices.ts` (`devices.site_id`); a rename there
+ * must be mirrored here, and is caught by
+ * `__tests__/integration/softwareDeploymentSiteScope.integration.test.ts`,
+ * which runs this predicate against real Postgres.
  */
 export function softwareDeploymentSiteScopePredicate(
   deploymentIdColumn: typeof softwareDeployments.id,
@@ -2452,8 +2465,20 @@ softwareRoutes.post(
     const { id } = c.req.valid('param');
     const { deviceIds } = c.req.valid('json');
 
+    // Strict parent, same as list/summary/get/cancel. The per-device retry
+    // narrowing below is not sufficient on its own: without this the parent
+    // still resolves for a site-restricted caller, so a deployment that
+    // `GET /deployments/:id` refuses to show is still confirmed to exist here
+    // (and remains mutable) — an existence oracle around the SEC-046 gate.
     const [deployment] = await db.select().from(softwareDeployments)
-      .where(and(eq(softwareDeployments.id, id), eq(softwareDeployments.orgId, orgId)));
+      .where(and(
+        eq(softwareDeployments.id, id),
+        eq(softwareDeployments.orgId, orgId),
+        softwareDeploymentSiteScopePredicate(
+          softwareDeployments.id,
+          c.get('permissions') as UserPermissions | undefined,
+        ),
+      ));
     if (!deployment) return c.json({ error: 'Deployment not found' }, 404);
 
     // Retrying an undispatched scheduled/maintenance deployment makes no sense —
@@ -2578,8 +2603,21 @@ softwareRoutes.get(
     const query = c.req.valid('query');
     const { limit, offset } = getLimitOffset(query);
 
+    // Strict parent, same as list/summary/get/cancel. The per-device result
+    // narrowing below is not sufficient on its own: without this the parent
+    // still resolves for a site-restricted caller, so a deployment that
+    // `GET /deployments/:id` refuses to show is still confirmed to exist here
+    // (returning 200 with an empty page) — an existence oracle around the
+    // SEC-046 gate.
     const [deployment] = await db.select().from(softwareDeployments)
-      .where(and(eq(softwareDeployments.id, id), eq(softwareDeployments.orgId, orgId)));
+      .where(and(
+        eq(softwareDeployments.id, id),
+        eq(softwareDeployments.orgId, orgId),
+        softwareDeploymentSiteScopePredicate(
+          softwareDeployments.id,
+          c.get('permissions') as UserPermissions | undefined,
+        ),
+      ));
     if (!deployment) return c.json({ error: 'Deployment not found' }, 404);
 
     const conditions: SQL[] = [eq(deploymentResults.deploymentId, id)];

--- a/apps/api/src/routes/software.ts
+++ b/apps/api/src/routes/software.ts
@@ -129,6 +129,40 @@ function resolveCatalogListScope(
 }
 
 /**
+ * A software deployment is an indivisible parent: its target metadata and
+ * aggregate status describe every child device. Restricted callers may see or
+ * mutate it only when it has at least one result and every result still points
+ * to a live device in one of their allowed sites.
+ */
+export function softwareDeploymentSiteScopePredicate(
+  deploymentIdColumn: typeof softwareDeployments.id,
+  permissions: UserPermissions | undefined,
+): SQL | undefined {
+  const allowedSiteIds = permissions?.allowedSiteIds;
+  if (allowedSiteIds === undefined) return undefined;
+  if (allowedSiteIds.length === 0) return sql`false`;
+
+  const allowedSites = sql.join(allowedSiteIds.map((siteId) => sql`${siteId}::uuid`), sql`, `);
+  return sql`
+    EXISTS (
+      SELECT 1 FROM ${deploymentResults} AS deployment_scope_result
+      WHERE deployment_scope_result.deployment_id = ${deploymentIdColumn}
+    )
+    AND NOT EXISTS (
+      SELECT 1
+      FROM ${deploymentResults} AS deployment_scope_result
+      LEFT JOIN ${devices} AS deployment_scope_device
+        ON deployment_scope_device.id = deployment_scope_result.device_id
+      WHERE deployment_scope_result.deployment_id = ${deploymentIdColumn}
+        AND (
+          deployment_scope_device.id IS NULL
+          OR deployment_scope_device.site_id IS NULL
+          OR deployment_scope_device.site_id NOT IN (${allowedSites})
+        )
+    )`;
+}
+
+/**
  * Authorize a write against a catalog row fetched by id (dual-axis, #2135).
  * Org-owned rows: the same resolved-org narrowing as the reads
  * (authorizeCatalogItemRead) — a partner caller acting as org A must not
@@ -1521,7 +1555,13 @@ softwareRoutes.get(
     // but is ignored — clients filter the returned page on the computed
     // `status` field instead. (Previously the route fetched every org row,
     // filtered in JS and sliced — SQL pagination replaces that.)
-    const orgCondition = eq(softwareDeployments.orgId, orgId);
+    const orgCondition = and(
+      eq(softwareDeployments.orgId, orgId),
+      softwareDeploymentSiteScopePredicate(
+        softwareDeployments.id,
+        c.get('permissions') as UserPermissions | undefined,
+      ),
+    );
     const [items, countRows] = await Promise.all([
       db.select().from(softwareDeployments)
         .where(orgCondition)
@@ -1580,7 +1620,13 @@ softwareRoutes.get(
       })
       .from(softwareDeployments)
       .leftJoin(deploymentResults, eq(deploymentResults.deploymentId, softwareDeployments.id))
-      .where(eq(softwareDeployments.orgId, orgId))
+      .where(and(
+        eq(softwareDeployments.orgId, orgId),
+        softwareDeploymentSiteScopePredicate(
+          softwareDeployments.id,
+          c.get('permissions') as UserPermissions | undefined,
+        ),
+      ))
       .groupBy(
         softwareDeployments.id,
         softwareDeployments.dispatchedAt,
@@ -2123,7 +2169,14 @@ softwareRoutes.get(
 
     const { id } = c.req.valid('param');
     const [deployment] = await db.select().from(softwareDeployments)
-      .where(and(eq(softwareDeployments.id, id), eq(softwareDeployments.orgId, orgId)));
+      .where(and(
+        eq(softwareDeployments.id, id),
+        eq(softwareDeployments.orgId, orgId),
+        softwareDeploymentSiteScopePredicate(
+          softwareDeployments.id,
+          c.get('permissions') as UserPermissions | undefined,
+        ),
+      ));
     if (!deployment) return c.json({ error: 'Deployment not found' }, 404);
 
     const statusMap = await getDeploymentStatusMap([deployment.id]);
@@ -2155,7 +2208,14 @@ softwareRoutes.post(
 
     const { id } = c.req.valid('param');
     const [deployment] = await db.select().from(softwareDeployments)
-      .where(and(eq(softwareDeployments.id, id), eq(softwareDeployments.orgId, orgId)));
+      .where(and(
+        eq(softwareDeployments.id, id),
+        eq(softwareDeployments.orgId, orgId),
+        softwareDeploymentSiteScopePredicate(
+          softwareDeployments.id,
+          c.get('permissions') as UserPermissions | undefined,
+        ),
+      ));
     if (!deployment) return c.json({ error: 'Deployment not found' }, 404);
 
     // Update pending results to cancelled. `.returning()` surfaces which rows

--- a/apps/api/src/routes/softwareInventory.ts
+++ b/apps/api/src/routes/softwareInventory.ts
@@ -378,11 +378,17 @@ softwareInventoryRoutes.get('/names', requireSoftwareInventoryRead, zValidator('
     return c.json({ data: [] });
   }
 
+  // Same org-axis resolution as the sibling read routes (`GET /` and the
+  // observations route): honour an explicit `?orgId=` after an access check
+  // instead of silently ignoring it and aggregating every reachable org.
+  const orgScope = resolveOrgReadScope(auth, c.req.query('orgId'));
+  if ('error' in orgScope) return c.json({ error: orgScope.error }, orgScope.status);
+
   const conditions: SQL[] = [
     eq(devices.isEphemeral, false),
     sql`${softwareInventory.name} ILIKE ${pattern}`,
   ];
-  const orgCondition = auth.orgCondition(devices.orgId);
+  const orgCondition = orgScope.applyTo(devices.orgId);
   if (orgCondition) conditions.push(orgCondition);
   if (perms?.allowedSiteIds) {
     conditions.push(inArray(devices.siteId, perms.allowedSiteIds));

--- a/apps/api/src/routes/softwareInventory.ts
+++ b/apps/api/src/routes/softwareInventory.ts
@@ -369,12 +369,30 @@ softwareInventoryRoutes.get('/', requireSoftwareInventoryRead, zValidator('query
 // ============================================
 
 softwareInventoryRoutes.get('/names', requireSoftwareInventoryRead, zValidator('query', nameSearchQuerySchema), async (c) => {
+  const auth = c.get('auth') as AuthContext;
+  const perms = c.get('permissions') as UserPermissions | undefined;
   const { q, limit } = c.req.valid('query');
   const pattern = `%${escapeLike(q)}%`;
 
-  // No manual org filter: software_inventory has RLS enabled + forced
-  // (org_id, shape 1), and the request runs inside the auth-established
-  // withDbAccessContext, so the proxied db auto-scopes to the caller's orgs.
+  if (perms?.allowedSiteIds?.length === 0) {
+    return c.json({ data: [] });
+  }
+
+  const conditions: SQL[] = [
+    eq(devices.isEphemeral, false),
+    sql`${softwareInventory.name} ILIKE ${pattern}`,
+  ];
+  const orgCondition = auth.orgCondition(devices.orgId);
+  if (orgCondition) conditions.push(orgCondition);
+  if (perms?.allowedSiteIds) {
+    conditions.push(inArray(devices.siteId, perms.allowedSiteIds));
+  }
+  const whereClause = and(...conditions);
+
+  // Keep the authorization predicate inside the DISTINCT statement and before
+  // ORDER/LIMIT. RLS protects the org axis on software_inventory, while the
+  // current-device join enforces the app-layer site axis and excludes ephemeral
+  // or stale/mismatched inventory rows from the picker.
   const rows = await db.transaction(async (tx) => {
     await tx.execute(
       sql`select set_config('statement_timeout', ${`${NAME_SEARCH_TIMEOUT_MS}ms`}, true)`
@@ -382,7 +400,10 @@ softwareInventoryRoutes.get('/names', requireSoftwareInventoryRead, zValidator('
     return tx.execute(sql`
       SELECT DISTINCT ${softwareInventory.name} AS name
       FROM ${softwareInventory}
-      WHERE ${softwareInventory.name} ILIKE ${pattern}
+      INNER JOIN ${devices}
+        ON ${softwareInventory.deviceId} = ${devices.id}
+        AND ${softwareInventory.orgId} = ${devices.orgId}
+      WHERE ${whereClause}
       ORDER BY ${softwareInventory.name}
       LIMIT ${limit}
     `);

--- a/apps/api/src/routes/softwareInventory_names_search.test.ts
+++ b/apps/api/src/routes/softwareInventory_names_search.test.ts
@@ -81,6 +81,8 @@ vi.mock('../services/softwarePolicyService', () => ({ recordSoftwarePolicyAudit:
 
 import { softwareInventoryRoutes } from './softwareInventory';
 import { db } from '../db';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import type { SQL } from 'drizzle-orm';
 
 function dumpSql(value: unknown, seen = new WeakSet<object>()): string {
   if (value === null || value === undefined) return '';
@@ -169,6 +171,32 @@ describe('GET /software-inventory/names', () => {
     const querySql = dumpSql(executedSql[1]);
     expect(querySql).toContain('devices.siteId');
     expect(querySql).toContain('LIMIT');
+  });
+
+  it('honours an accessible ?orgId= as a bound predicate instead of ignoring it', async () => {
+    mockTransaction([{ name: 'Scoped App' }]);
+
+    const res = await app.request(
+      '/software-inventory/names?q=a&orgId=11111111-1111-1111-1111-111111111111',
+      { headers: { Authorization: 'Bearer token' } },
+    );
+
+    expect(res.status).toBe(200);
+    // Bound param, not a deep-search of the object graph: the org must reach
+    // the WHERE clause, not merely exist somewhere in the mock tree.
+    const compiled = new PgDialect().sqlToQuery(executedSql[1] as SQL);
+    expect(compiled.params).toContain('11111111-1111-1111-1111-111111111111');
+  });
+
+  it('rejects an inaccessible ?orgId= instead of silently aggregating every reachable org', async () => {
+    const res = await app.request(
+      '/software-inventory/names?q=a&orgId=99999999-9999-4999-8999-999999999999',
+      { headers: { Authorization: 'Bearer token' } },
+    );
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'Access to this organization denied' });
+    expect(db.transaction).not.toHaveBeenCalled();
   });
 
   it('returns an empty result without touching the database for an empty site ceiling', async () => {

--- a/apps/api/src/routes/softwareInventory_names_search.test.ts
+++ b/apps/api/src/routes/softwareInventory_names_search.test.ts
@@ -29,27 +29,43 @@ vi.mock('../db/schema', () => ({
   configPolicyAssignments: {},
   configPolicyFeatureLinks: {},
   configurationPolicies: {},
-  devices: { id: 'devices.id', orgId: 'devices.orgId', siteId: 'devices.siteId' },
+  devices: {
+    id: 'devices.id', orgId: 'devices.orgId', siteId: 'devices.siteId',
+    isEphemeral: 'devices.isEphemeral',
+  },
   softwareInventory: {
     name: 'softwareInventory.name',
+    deviceId: 'softwareInventory.deviceId',
+    orgId: 'softwareInventory.orgId',
   },
   softwarePolicies: {},
+}));
+
+const testAuthState = vi.hoisted(() => ({
+  scope: 'organization' as 'organization' | 'partner' | 'system',
+  allowedSiteIds: ['22222222-2222-4222-8222-222222222222'] as string[] | undefined,
 }));
 
 vi.mock('../middleware/auth', () => ({
   authMiddleware: vi.fn((c: any, next: any) => {
     c.set('auth', {
       user: { id: 'user-1', email: 'test@example.com', name: 'Test User' },
-      scope: 'organization',
+      scope: testAuthState.scope,
       partnerId: null,
       orgId: '11111111-1111-1111-1111-111111111111',
       accessibleOrgIds: ['11111111-1111-1111-1111-111111111111'],
       canAccessOrg: (id: string) => id === '11111111-1111-1111-1111-111111111111',
+      orgCondition: (column: unknown) => testAuthState.scope === 'system'
+        ? undefined
+        : { kind: 'org-condition', column },
     });
     return next();
   }),
   requireScope: vi.fn(() => async (_c: any, next: any) => next()),
-  requirePermission: vi.fn(() => async (_c: any, next: any) => next()),
+  requirePermission: vi.fn(() => async (c: any, next: any) => {
+    c.set('permissions', { allowedSiteIds: testAuthState.allowedSiteIds });
+    return next();
+  }),
   requireMfa: vi.fn(() => async (_c: any, next: any) => next()),
 }));
 
@@ -88,6 +104,8 @@ describe('GET /software-inventory/names', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    testAuthState.scope = 'organization';
+    testAuthState.allowedSiteIds = ['22222222-2222-4222-8222-222222222222'];
     executedSql = [];
     app = new Hono();
     app.route('/software-inventory', softwareInventoryRoutes);
@@ -133,6 +151,50 @@ describe('GET /software-inventory/names', () => {
     const querySql = dumpSql(executedSql[1]);
     expect(querySql).toContain('DISTINCT');
     expect(querySql).toContain('ILIKE');
+    expect(querySql).toContain('devices.id');
+    expect(querySql).toContain('softwareInventory.orgId');
+    expect(querySql).toContain('devices.siteId');
+    expect(querySql).toContain('devices.isEphemeral');
+  });
+
+  it('filters hidden-only names before DISTINCT and LIMIT', async () => {
+    mockTransaction([{ name: 'Visible Next' }]);
+
+    const res = await app.request('/software-inventory/names?q=a&limit=1', {
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ data: ['Visible Next'] });
+    const querySql = dumpSql(executedSql[1]);
+    expect(querySql).toContain('devices.siteId');
+    expect(querySql).toContain('LIMIT');
+  });
+
+  it('returns an empty result without touching the database for an empty site ceiling', async () => {
+    testAuthState.allowedSiteIds = [];
+
+    const res = await app.request('/software-inventory/names?q=hidden', {
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ data: [] });
+    expect(db.transaction).not.toHaveBeenCalled();
+  });
+
+  it.each(['partner', 'system'] as const)('preserves unrestricted %s name search', async (scope) => {
+    testAuthState.scope = scope;
+    testAuthState.allowedSiteIds = undefined;
+    mockTransaction([{ name: 'Fleet Software' }]);
+
+    const res = await app.request('/software-inventory/names?q=fleet', {
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ data: ['Fleet Software'] });
+    expect(db.transaction).toHaveBeenCalledTimes(1);
   });
 
   it('escapes LIKE wildcards in the search term', async () => {


### PR DESCRIPTION
## Summary

Four site-scope findings from the September security review. Site is an app-layer
concept only — Postgres RLS defends the org axis but never the site axis — so
every one of these is a cross-site read or write available to a technician whose
`allowedSiteIds` ceiling is a subset of the org.

**SEC-046 (Medium) — software deployment parents were org-scoped only.**
A deployment is an indivisible parent: its target metadata and aggregate status
describe every child device. `GET /software/deployments`, `GET /software/deployments/summary`,
`GET /software/deployments/:id` and `POST /software/deployments/:id/cancel` narrowed
on `eq(softwareDeployments.orgId, orgId)` alone, so a site-restricted caller could
read — and cancel — a deployment whose result set targeted devices in sites they
cannot see. `softwareDeploymentSiteScopePredicate` now narrows the parent **in SQL**:
the deployment must have at least one result, and no result may point at a missing
device, a null-site device, or a device outside the ceiling. An empty ceiling
compiles to `false`; an unrestricted caller gets `undefined` (partner/system reads
unchanged).

**Strict parent everywhere.** `POST /deployments/:id/retry` and
`GET /deployments/:id/results` already filtered their *child* rows by site
(#864/#868), but still resolved the *parent* on id+org alone. That left an
existence oracle around the gate: a deployment `GET /deployments/:id` now 404s
still answered 200 from `/results` (empty page) and stayed mutable via `/retry`.
Both now apply the same predicate, per the indivisible-parent contract.

**SEC-084 (Medium) — the software name picker leaked names across sites.**
`GET /software-inventory/names` relied on RLS alone, which covers org but not site
and not staleness. The DISTINCT picker returned software names harvested from devices
outside the caller's ceiling, from ephemeral Quick Support machines, and from inventory
rows whose device had since moved or been deleted. The query now inner-joins the current
`devices` row on `(device_id, org_id)`, excludes ephemeral devices, and applies the
caller's org condition and `allowedSiteIds` — all **inside the DISTINCT statement,
before ORDER BY and LIMIT**, so a hidden name cannot displace a visible one out of the
result page. An empty ceiling short-circuits to `{ data: [] }` without touching the DB.

**SEC-023 (Low) — known-service autocomplete leaked names across sites.**
`GET /monitoring/known-services` built its autocomplete from two org-only aggregates
(`device_change_log` service subjects, `service_process_check_results` names). Neither
joined the device, so a site-restricted technician saw the service and process names
running on every device in the org. Both sources now inner-join `devices` and filter on
`allowedSiteIds`. An empty ceiling returns `{ data: [] }` **before either query runs**,
so an unavailable or misconfigured database cannot turn deny-all into an error oracle.

**SEC-110 (Medium) — monitoring asset mutations were org-scoped only.**
`PUT`, `PATCH` and `DELETE /monitoring/assets/:id/snmp` resolved the discovered asset by
org alone, so a site-restricted caller could write SNMP credentials onto, reconfigure, or
disable monitoring for an asset in a site they cannot see. `resolveAssetForMonitoringMutation`
is now the single chokepoint for all three: it denies an empty ceiling up front, and for a
restricted caller selects the asset `FOR UPDATE` so the row lock is held through the
downstream SNMP/network-monitor write and a concurrent site move cannot invalidate the
decision between check and use. Null-site or out-of-ceiling is 403; missing stays 404.

`snmpWorker` carried the same gap on the *execution* side: an asset-bound poll picked any
online agent in the org, so an asset moved into a restricted site kept being polled from
its old site. Asset-bound rows now resolve and lock the current asset, refuse to dispatch
when the asset is gone or has no site, and select the executing agent from the asset's
current site with no cross-site fallback. Legacy rows with no `assetId` predate
discovered-asset binding and keep org-wide selection.

## Ported from

Local security-remediation commits, cherry-picked in order onto `29e9445f3d`:

| Finding | Local commit(s) | Result |
|---|---|---|
| SEC-2026-09-05-046 | `d33fc657e5` | applied clean (auto-merge, no conflict) |
| SEC-2026-09-05-084 | `623f4b4ea2` | applied clean (auto-merge, no conflict) |
| SEC-2026-09-05-023 | `00ebb3cc2a` + `672f275cb8` | applied clean |
| SEC-2026-09-05-110 | `a6ee6e4ac0` | applied clean (auto-merge in `monitoring.ts`) |

Squashed to three commits: one per software finding, and one for SEC-023 + SEC-110
together because both rewrite `routes/monitoring.ts` and are not cleanly separable
by file.

**Changed vs. the original commits:** one test was rewritten because it did not
discriminate. The original SEC-046 cancel test (`returns an opaque not-found …`)
stubbed the deployment lookup to return `[]`, which yields 404 on `main` too — it
passed against unfixed source, i.e. it was vacuous. It now captures the `where()`
argument, compiles it with `PgDialect`, and asserts the site-scope predicate
(`deployment_scope_result`) and the bound site id are actually in the SQL. Verified
red on `main`'s source (see below).

**Nothing was dropped as already-on-main.** No migrations, no schema columns, so no
cascade / export-policy / RLS-coverage registration applies.

### Review round (commits 4 and 5)

Applied after review, beyond the original local commits:

- **`snmpWorker` now records site-authority refusals durably.** The port refused
  asset-bound polls on three grounds (asset gone, asset has no site, no online agent
  in the asset's site) with only a `console.warn`. Because the fix deliberately
  removes the cross-site agent fallback, *nothing else polls those devices* — so
  `last_status` sat at its last-known value forever and nothing alerted. That traded
  the isolation win for silent monitoring loss. Each refusal now increments
  `consecutive_failures` and writes a distinct `last_status` (`asset_missing`,
  `asset_no_site`, `no_agent_in_site`), so the existing backoff and failure/alert
  path surfaces it. The org-wide no-agent branch keeps its established *uncounted*
  behaviour (a rebooting agent host is transient, not an unpollable device) and a
  test pins that distinction. No migration: both columns already exist and all three
  values fit `last_status varchar(20)`.
- **Strict parent on `/retry` and `/results`** (see Summary above).
- **`GET /software-inventory/names` now honours `?orgId=`** via `resolveOrgReadScope`,
  like its sibling read routes, instead of silently ignoring it and aggregating every
  reachable org.
- **Two vacuous test assertions replaced.** The snmpWorker move test asserted
  `not.toContainEqual([..., PREVIOUS_SITE])` against an id that appeared nowhere in
  the fixture — unfalsifiable; it now polls the same row across a simulated asset
  move so that id is a value the code demonstrably *can* bind. The known-services
  test used a `JSON.stringify` deep-search of the mock call graph, which matches any
  string anywhere in the object tree; it now compiles the WHERE with `PgDialect` and
  asserts bound `params`.

The `FOR UPDATE` lock-lifetime question raised in the first round is **resolved**:
`authMiddleware` wraps the whole request in one `baseDb.transaction` via
`withDbAccessContext` (`db/index.ts:554`, `middleware/auth.ts:775`) and the exported
`db` proxies to that transaction, so the row lock does hold through the downstream
write. No wrapper needed.

## Verification

All commands run in `apps/api` in an isolated worktree against an ephemeral
`pnpm test-stack` Postgres+Redis. Every count below is **verified** (observed
output), not inferred.

**Red-first (mandatory).** `git checkout origin/main -- apps/api/src/routes/software.ts
apps/api/src/routes/softwareInventory.ts apps/api/src/routes/monitoring.ts
apps/api/src/jobs/snmpWorker.ts`, then:

```
npx vitest run --pool=threads --maxWorkers=2 \
  src/routes/software.test.ts src/routes/softwareInventory_names_search.test.ts \
  src/routes/monitoring_results_status.test.ts src/routes/monitoring_assets_snmp.test.ts \
  src/jobs/snmpWorker.orgAuthority.test.ts
→ Test Files 5 failed (5) | Tests 19 failed | 192 passed (211)
```

Failures spanned all five files and all four findings: the deployment-predicate and
strict-parent tests (list/cancel, retry, results), the SNMP-asset mutation denials,
the known-services tests, the name-search tests, and the snmpWorker site-authority
tests. After the vacuous cancel test was rewritten, re-running `software.test.ts`
alone against `main`'s source gave `Tests 3 failed | 138 passed (141)` — the rewritten
test is now among the reds.

`git checkout HEAD -- <the four source files>`, re-run the same five files:
`Test Files 5 passed (5) | Tests 211 passed (211)`.

**Surgical red-first for the two narrow review fixes.** A whole-file revert proves the
port, not the follow-ups, so each was mutated on its own against otherwise-fixed
source: removing only the three `recordSiteAuthorityFailure` calls → 3 failed (`fails
closed when the asset was removed before dispatch`, `fails closed when the current
asset has no site`, `does not fall back across sites when no online agent exists in
the current site`); reverting only the `resolveOrgReadScope` lines → 2 failed (both
new `?orgId=` tests). Both restored afterwards; suite green.

**Unit (fixed source).**
```
npx vitest run --pool=threads --maxWorkers=2 \
  src/routes/software src/routes/monitoring src/jobs/snmpWorker src/routes/softwareInventory
→ Test Files 18 passed (18) | Tests 407 passed (407)
```
(Bare substrings, no trailing slash, so dotted sibling files are included — file count
checked. Re-run after rebasing onto current main: same 18 files / 407 tests.)

**New tests this round** (7, each verified red against the relevant unfixed source):
`software.test.ts` → `narrows the parent lookup with the site predicate before any
mutation` (retry) and `… not just the child rows` (results);
`snmpWorker.orgAuthority.test.ts` → `leaves the org-wide no-agent branch uncounted, as
before`, plus durable-outcome assertions folded into the three existing site-authority
tests and a real asset move driving the previously-unfalsifiable site assertion;
`softwareInventory_names_search.test.ts` → `honours an accessible ?orgId= as a bound
predicate instead of ignoring it` and `rejects an inaccessible ?orgId= instead of
silently aggregating every reachable org`.

**Integration (real Postgres as `breeze_app`).**
```
npx vitest run --config vitest.integration.config.ts --pool=threads --maxWorkers=2 \
  src/__tests__/integration/softwareDeploymentSiteScope \
  src/__tests__/integration/softwareInventoryNameSiteScope \
  src/__tests__/integration/monitoringKnownServicesSiteScope \
  src/__tests__/integration/monitoringAssetMutationSiteScope \
  src/__tests__/integration/snmpWorkerSiteAuthority
→ Test Files 5 passed (5) | Tests 5 passed (5)
```
Wider family, to catch what a diff-only run misses:
```
npx vitest run --config vitest.integration.config.ts --pool=threads --maxWorkers=2 \
  software monitoring snmp SiteScope
→ Test Files 26 passed (26) | Tests 100 passed (100)

npx vitest run --config vitest.integration.config.ts --pool=threads --maxWorkers=2 \
  Scope scope Authority
→ Test Files 35 passed (35) | Tests 172 passed (172)
```

**Site-scope contract.** `site-scope-coverage.integration.test.ts` is *excluded* from
`vitest.integration.config.ts` and runs under its own config in CI, so it needs a
separate invocation:
```
npx vitest run --config vitest.config.site-scope-coverage.ts
→ Test Files 1 passed (1) | Tests 7 passed (7)
```
No new allowlist entries were needed.

**Typecheck / lint.**
```
NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit   → exit 0, 0 lines of output
npx eslint <all 14 touched files>                          → exit 0, no findings
```
(The default heap OOMs `tsc` on this package on macOS; that is pre-existing and
unrelated to this diff.)

**Not checked:** no migration/schema contract suites were run — this diff adds no
migration and no schema column, so `rls-coverage`, `tenantCascade`,
`tenant-export-policy` and `tenantExportErasureRoundtrip` do not apply. No web,
portal or shared package was touched.

## Operator impact

- No migration, no schema change, no config or env change. Deploy is a plain API roll.
- **Unrestricted callers (org-wide technicians, partner scope, system scope) see no
  behaviour change.** Every gate keys on `permissions.allowedSiteIds`, which is
  `undefined` for them, and the added predicates compile away.
- **Site-restricted technicians no longer see org-wide deployments — including the
  per-device results for their own devices — whenever the deployment also targeted a
  device outside their site ceiling.** A deployment is treated as an indivisible
  parent, so a mixed-site deployment is hidden in full: list, summary, by-id, cancel,
  retry and results all refuse it. That is the accepted SEC-046 posture, chosen over a
  partial view that would still leak the parent's target metadata and aggregate status.
  The residual question — whether the *generic* (non-software) deployment family should
  adopt the same strict-parent rule — remains an open owner decision (B-046 residual)
  and is not addressed here.
- Other visible narrowing for the same callers: software-name and service-name
  autocomplete now offer only names present on devices in their sites; SNMP asset
  mutations on a hidden-site asset return 403 instead of succeeding. Expect "a
  deployment vanished from my list" reports from MSPs who use site restrictions and had
  been relying on the leaked view.
- **SNMP polling of asset-bound devices now requires an online agent in the asset's own
  site.** Previously any online agent in the org would do. An asset in a site with no
  online agent stops being polled — and now **says so**: `consecutive_failures`
  increments and `last_status` is set to `no_agent_in_site` (or `asset_missing` /
  `asset_no_site`), so the device backs off and surfaces through the existing failure
  path instead of showing a stale green forever. Legacy `snmp_devices` rows with no
  `asset_id` are unaffected, and the org-wide no-agent case stays deliberately
  uncounted. Watch for these three `last_status` values after rollout on tenants with
  sparse per-site agent coverage — they mean "put an agent in that site", not "the
  device is down". No dashboard work ships here, so they render as an unstyled status
  string until the UI is taught about them.
- The asset-mutation path now takes a `FOR UPDATE` row lock on `discovered_assets` for
  site-restricted callers only, held for the duration of the mutation. Contention is
  bounded to concurrent mutations of the same asset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Tugfg88kFiowD7E5xQFpU
