### PR TITLE
fix(ticketing): enforce assignee eligibility, bind inbound replies to the requester, scope triage aggregates by site (SEC-022, SEC-104, SEC-153)

### DIFF
--- a/apps/api/src/__tests__/integration/ticket-validation-rls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/ticket-validation-rls.integration.test.ts
@@ -38,12 +38,20 @@ import {
   ticketCategories,
   partnerTicketSequences,
   users,
+  partnerUsers,
   organizations,
   partners,
 } from '../../db/schema';
 import { createTicket, TicketServiceError } from '../../services/ticketService';
 import { getTicketEventsQueue } from '../../services/ticketEvents';
-import { createOrganization, createPartner, createUser } from './db-utils';
+import {
+  assignUserToPartner,
+  createOrganization,
+  createPartner,
+  createRole,
+  createUser,
+  grantRolePermissions,
+} from './db-utils';
 import { getTestDb } from './setup';
 
 /**
@@ -77,6 +85,9 @@ async function seedFixture() {
     orgId: null, // MSP staff — hidden from org scope by the users RLS policy
     email: `tv-rls-staff-${unique}@example.test`,
   });
+  const staffRole = await createRole({ scope: 'partner', partnerId: p1.id });
+  await grantRolePermissions(staffRole.id, [{ resource: 'tickets', action: 'read' }]);
+  await assignUserToPartner(staff.id, p1.id, staffRole.id, 'all');
   const [c1] = await adminDb
     .insert(ticketCategories)
     .values({ partnerId: p1.id, name: `TV-RLS Cat P1 ${unique}` })
@@ -88,6 +99,13 @@ async function seedFixture() {
     orgId: null,
     email: `tv-rls-other-${unique}@example.test`,
   });
+  const noRead = await createUser({
+    partnerId: p1.id,
+    orgId: null,
+    email: `tv-rls-no-read-${unique}@example.test`,
+  });
+  const noReadRole = await createRole({ scope: 'partner', partnerId: p1.id });
+  await assignUserToPartner(noRead.id, p1.id, noReadRole.id, 'all');
   const [c2] = await adminDb
     .insert(ticketCategories)
     .values({ partnerId: p2.id, name: `TV-RLS Cat P2 ${unique}` })
@@ -106,7 +124,7 @@ async function seedFixture() {
     userId: actor.id,
   };
 
-  return { p1, o1, actor, staff, c1, p2, u2, c2, orgContext };
+  return { p1, o1, actor, staff, noRead, c1, p2, u2, c2, orgContext };
 }
 
 afterAll(async () => {
@@ -141,7 +159,10 @@ afterAll(async () => {
   await adminDb
     .delete(ticketCategories)
     .where(sql`${ticketCategories.partnerId} IN (${partnerList})`);
+  await adminDb.delete(partnerUsers).where(sql`${partnerUsers.partnerId} IN (${partnerList})`);
   await adminDb.delete(users).where(sql`${users.partnerId} IN (${partnerList})`);
+  await adminDb.execute(sql`DELETE FROM role_permissions WHERE role_id IN (SELECT id FROM roles WHERE partner_id IN (${partnerList}))`);
+  await adminDb.execute(sql`DELETE FROM roles WHERE partner_id IN (${partnerList})`);
   await adminDb.delete(organizations).where(sql`${organizations.partnerId} IN (${partnerList})`);
   await adminDb.delete(partners).where(sql`${partners.id} IN (${partnerList})`);
 });
@@ -215,5 +236,25 @@ describe('ticket validation reads under org-scoped RLS (system-context regressio
 
     expect(err.status).toBe(400);
     expect(err.code).toBe('ASSIGNEE_WRONG_PARTNER');
+  });
+
+  it('rejects a same-partner assignee without ticket-read authority before insertion', async () => {
+    const { o1, actor, noRead, orgContext } = await seedFixture();
+    const admin = getTestDb() as any;
+    const before = await admin.select({ id: tickets.id }).from(tickets);
+
+    const err = await captureTicketServiceError(() =>
+      withDbAccessContext(orgContext, () =>
+        createTicket(
+          { orgId: o1.id, subject: 'must never persist', source: 'manual', assigneeId: noRead.id },
+          { userId: actor.id }
+        )
+      )
+    );
+
+    expect(err.status).toBe(400);
+    expect(err.code).toBe('ASSIGNEE_NOT_ELIGIBLE');
+    const after = await admin.select({ id: tickets.id }).from(tickets);
+    expect(after).toEqual(before);
   });
 });

--- a/apps/api/src/__tests__/integration/ticketPushFanout.integration.test.ts
+++ b/apps/api/src/__tests__/integration/ticketPushFanout.integration.test.ts
@@ -11,6 +11,7 @@
  * docker compose -f docker-compose.test.yml up -d).
  */
 import './setup';
+import { getTestDb } from './setup';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { eq } from 'drizzle-orm';
 
@@ -30,8 +31,9 @@ vi.mock('../../services/expoPush', async (orig) => ({
 vi.mock('../../services/email', () => ({ getEmailService: () => null }));
 
 import { db, withSystemDbAccessContext } from '../../db';
-import { mobileDevices, ticketPushPreferences, tickets, userNotifications } from '../../db/schema';
+import { devices, mobileDevices, organizationUsers, ticketPushPreferences, tickets, userNotifications } from '../../db/schema';
 import { handleTicketEvent } from '../../jobs/ticketNotifyWorker';
+import { clearPermissionCache } from '../../services/permissions';
 import { ANY_SUBSCRIBER_CAP, listAnySlaSubscribers } from '../../services/ticketPush';
 import {
   assignUserToOrganization,
@@ -39,6 +41,7 @@ import {
   createOrganization,
   createPartner,
   createRole,
+  createSite,
   createUser,
   grantRolePermissions,
 } from './db-utils';
@@ -223,6 +226,58 @@ describe('ticket push fan-out — tenant boundary', () => {
     expect(dispatch).not.toHaveBeenCalled();
     const rows = await rowsFor(fx.ticket.id);
     expect(rows.filter((r) => r.userId === fx.owner.id)).toHaveLength(1);
+  });
+
+  runDb('assignment fan-out follows the assignee ceiling and the device current site', async () => {
+    const fx = await seed();
+    const allowed = await createSite({ orgId: fx.orgA.id, name: uniq('allowed') });
+    const hidden = await createSite({ orgId: fx.orgA.id, name: uniq('hidden') });
+    const admin = getTestDb() as any;
+    await admin.update(organizationUsers)
+      .set({ siteIds: [allowed.id] })
+      .where(eq(organizationUsers.userId, fx.anyA.id));
+    await clearPermissionCache(fx.anyA.id);
+    const [device] = await admin.insert(devices).values({
+      orgId: fx.orgA.id,
+      siteId: hidden.id,
+      agentId: uniq('agent'),
+      hostname: 'site-bound-ticket-device',
+      osType: 'linux',
+      osVersion: 'synthetic-test',
+      architecture: 'amd64',
+      agentVersion: '0.0.0-test',
+    }).returning();
+    const [ticket] = await admin.insert(tickets).values({
+      orgId: fx.orgA.id,
+      partnerId: fx.p1.id,
+      deviceId: device.id,
+      ticketNumber: uniq('TKT'),
+      internalNumber: uniq('T'),
+      subject: 'site-bound subject',
+      status: 'open',
+      assignedTo: fx.anyA.id,
+    }).returning();
+
+    await handleTicketEvent({
+      type: 'ticket.assigned', ticketId: ticket.id, orgId: fx.orgA.id,
+      partnerId: fx.p1.id, actorUserId: fx.owner.id, eventId: 'hidden-site',
+      payload: { assigneeId: fx.anyA.id },
+    });
+    const deniedRows = await admin.select({ id: userNotifications.id })
+      .from(userNotifications).where(eq(userNotifications.userId, fx.anyA.id));
+    expect(deniedRows).toEqual([]);
+    expect(dispatch).not.toHaveBeenCalled();
+
+    await admin.update(devices).set({ siteId: allowed.id }).where(eq(devices.id, device.id));
+    await handleTicketEvent({
+      type: 'ticket.assigned', ticketId: ticket.id, orgId: fx.orgA.id,
+      partnerId: fx.p1.id, actorUserId: fx.owner.id, eventId: 'allowed-site',
+      payload: { assigneeId: fx.anyA.id },
+    });
+    const allowedRows = await admin.select({ id: userNotifications.id })
+      .from(userNotifications).where(eq(userNotifications.userId, fx.anyA.id));
+    expect(allowedRows).toHaveLength(1);
+    expect(dispatch).toHaveBeenCalledTimes(1);
   });
 
   runDb('A→B→A reassignment pushes twice; a retry of one event does not', async () => {

--- a/apps/api/src/__tests__/integration/ticketTriageSiteScope.integration.test.ts
+++ b/apps/api/src/__tests__/integration/ticketTriageSiteScope.integration.test.ts
@@ -1,0 +1,109 @@
+/**
+ * SEC-022: ticket-triage evaluation must honor the staff caller's site ceiling.
+ *
+ * The aggregate reads ml_feedback_events, which is org-scoped by RLS but has no
+ * site column. These tests therefore exercise the real source-ticket/device
+ * relationship through the unprivileged breeze_app connection. Positive and
+ * denial controls live in one fixture so a hidden-site label cannot disappear
+ * merely because tenant RLS, time-window filtering, or event filtering failed.
+ */
+import './setup';
+
+import { describe, expect, it } from 'vitest';
+import { randomUUID } from 'node:crypto';
+
+import { withDbAccessContext, type DbAccessContext } from '../../db';
+import { devices, mlFeedbackEvents, tickets } from '../../db/schema';
+import { evaluateTicketTriage } from '../../services/ticketTriage';
+import { createOrganization, createPartner, createSite, createUser } from './db-utils';
+import { getTestDb } from './setup';
+
+describe('ticket triage evaluation site scope (breeze_app)', () => {
+  it('includes visible and deviceless sources while denying hidden, deleted, and missing sources', async () => {
+    const adminDb = getTestDb();
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const actor = await createUser({ partnerId: partner.id, orgId: org.id });
+    const visibleSite = await createSite({ orgId: org.id, name: 'Visible site' });
+    const hiddenSite = await createSite({ orgId: org.id, name: 'Hidden site' });
+
+    const [visibleDevice, hiddenDevice] = await adminDb.insert(devices).values([
+      {
+        orgId: org.id,
+        siteId: visibleSite.id,
+        agentId: `sec022-visible-${randomUUID()}`,
+        hostname: 'sec022-visible',
+        displayName: 'SEC022 visible',
+        osType: 'linux',
+        osVersion: 'test',
+        architecture: 'x86_64',
+        agentVersion: 'test',
+        status: 'online',
+        enrolledAt: new Date(),
+      },
+      {
+        orgId: org.id,
+        siteId: hiddenSite.id,
+        agentId: `sec022-hidden-${randomUUID()}`,
+        hostname: 'sec022-hidden',
+        displayName: 'SEC022 hidden',
+        osType: 'linux',
+        osVersion: 'test',
+        architecture: 'x86_64',
+        agentVersion: 'test',
+        status: 'online',
+        enrolledAt: new Date(),
+      },
+    ]).returning({ id: devices.id });
+
+    const now = new Date();
+    const [visibleTicket, hiddenTicket, devicelessTicket, deletedTicket] = await adminDb
+      .insert(tickets)
+      .values([
+        { orgId: org.id, partnerId: partner.id, ticketNumber: `SEC022-V-${randomUUID()}`, subject: 'visible', source: 'manual', deviceId: visibleDevice!.id },
+        { orgId: org.id, partnerId: partner.id, ticketNumber: `SEC022-H-${randomUUID()}`, subject: 'hidden', source: 'manual', deviceId: hiddenDevice!.id },
+        { orgId: org.id, partnerId: partner.id, ticketNumber: `SEC022-DL-${randomUUID()}`, subject: 'deviceless', source: 'manual', deviceId: null },
+        { orgId: org.id, partnerId: partner.id, ticketNumber: `SEC022-X-${randomUUID()}`, subject: 'deleted', source: 'manual', deviceId: visibleDevice!.id, deletedAt: now },
+      ])
+      .returning({ id: tickets.id });
+
+    await adminDb.insert(mlFeedbackEvents).values([
+      { orgId: org.id, sourceType: 'ticket', sourceId: visibleTicket!.id, eventType: 'ticket.priority_changed', outcome: 'priority_changed', metadata: { acceptedSuggestion: true }, occurredAt: now },
+      { orgId: org.id, sourceType: 'ticket', sourceId: hiddenTicket!.id, eventType: 'ticket.priority_changed', outcome: 'priority_changed', metadata: {}, occurredAt: now },
+      { orgId: org.id, sourceType: 'ticket', sourceId: devicelessTicket!.id, eventType: 'ticket.category_changed', outcome: 'category_changed', metadata: {}, occurredAt: now },
+      { orgId: org.id, sourceType: 'ticket', sourceId: deletedTicket!.id, eventType: 'ticket.assignee_changed', outcome: 'assignee_changed', metadata: {}, occurredAt: now },
+      { orgId: org.id, sourceType: 'ticket', sourceId: randomUUID(), eventType: 'ticket.triage_rejected', outcome: 'rejected', metadata: {}, occurredAt: now },
+      { orgId: org.id, sourceType: 'ticket', sourceId: 'malformed-ticket-id', eventType: 'ticket.triage_rejected', outcome: 'rejected', metadata: {}, occurredAt: now },
+    ]);
+
+    const context: DbAccessContext = {
+      scope: 'organization',
+      orgId: org.id,
+      accessibleOrgIds: [org.id],
+      accessiblePartnerIds: [],
+      userId: actor.id,
+    };
+    const input = { orgIds: [org.id], labelWindowDays: 30, allowedSiteIds: [visibleSite.id] };
+
+    const restricted = await withDbAccessContext(context, () => evaluateTicketTriage(input));
+    expect(restricted).toMatchObject({
+      totalLabels: 2,
+      acceptedSuggestionLabels: 1,
+      manualOverrideLabels: 1,
+      categoryLabels: 1,
+      priorityLabels: 1,
+      assigneeLabels: 0,
+      rejectedSuggestionLabels: 0,
+    });
+
+    const zeroSite = await withDbAccessContext(context, () =>
+      evaluateTicketTriage({ ...input, allowedSiteIds: [] }),
+    );
+    expect(zeroSite).toMatchObject({ totalLabels: 1, categoryLabels: 1, priorityLabels: 0 });
+
+    const unrestricted = await withDbAccessContext(context, () =>
+      evaluateTicketTriage({ orgIds: [org.id], labelWindowDays: 30 }),
+    );
+    expect(unrestricted.totalLabels).toBe(6);
+  });
+});

--- a/apps/api/src/jobs/ticketNotifyWorker.graphFork.test.ts
+++ b/apps/api/src/jobs/ticketNotifyWorker.graphFork.test.ts
@@ -49,7 +49,18 @@ const gfPush = vi.hoisted(() => ({
   loadUserCandidate: vi.fn(async (id: string) => ({ userId: id, partnerId: 'p-1', status: 'active', email: 'tech@msp.example' })),
   loadTicketPushPrefs: vi.fn(async () => ({ assignedEnabled: false, slaScope: 'off' as const })),
   listAnySlaSubscribers: vi.fn(async () => ({ users: [] as unknown[], truncated: false })),
-  isAuthorisedForTicket: vi.fn(async () => false),
+  isAuthorisedForTicket: vi.fn(async (_userId: string, _partnerId: string, _orgId: string, _deviceId?: string | null) => false),
+  // The worker gates every subject-bearing channel on the canonical
+  // isEligibleTicketRecipient; delegate it to the isAuthorisedForTicket stub
+  // this file already steers so the fork stays the only thing under test.
+  isEligibleTicketRecipient: vi.fn(async (
+    c: { userId: string; partnerId: string; status: string },
+    partnerId: string,
+    orgId: string,
+    deviceId?: string | null
+  ) => c.status === 'active'
+    && c.partnerId === partnerId
+    && await gfPush.isAuthorisedForTicket(c.userId, partnerId, orgId, deviceId)),
   admitPush: vi.fn(async () => []),
   resolvePushJobs: vi.fn(async () => []),
 }));
@@ -60,6 +71,7 @@ vi.mock('../services/ticketPush', async (orig) => ({
   loadTicketPushPrefs: gfPush.loadTicketPushPrefs,
   listAnySlaSubscribers: gfPush.listAnySlaSubscribers,
   isAuthorisedForTicket: gfPush.isAuthorisedForTicket,
+  isEligibleTicketRecipient: gfPush.isEligibleTicketRecipient,
   admitPush: gfPush.admitPush,
   resolvePushJobs: gfPush.resolvePushJobs,
 }));
@@ -134,6 +146,7 @@ describe('ticketNotifyWorker M365 Graph fork', () => {
   });
 
   it('NEVER routes assignee/tech notifications through Graph (ticket.assigned uses EmailService)', async () => {
+    gfPush.isAuthorisedForTicket.mockResolvedValue(true);
     selectMock
       .mockResolvedValueOnce([{ id: 't-1', orgId: 'o-1', partnerId: 'p-1', internalNumber: 'T-1', subject: 'Printer', submitterEmail: 'cust@x.com' }]) // getTicket
       .mockResolvedValueOnce([{ name: 'Acme' }]); // org name (assignee now via loadUserCandidate)

--- a/apps/api/src/jobs/ticketNotifyWorker.test.ts
+++ b/apps/api/src/jobs/ticketNotifyWorker.test.ts
@@ -70,7 +70,23 @@ const push = vi.hoisted(() => ({
   loadUserCandidate: vi.fn(async (id: string) => ({ userId: id, partnerId: 'p-1', status: 'active', email: 'tech@msp.example' })),
   loadTicketPushPrefs: vi.fn(async () => ({ assignedEnabled: true, slaScope: 'owned' as 'off' | 'owned' | 'any' })),
   listAnySlaSubscribers: vi.fn(async () => ({ users: [] as unknown[], truncated: false })),
-  isAuthorisedForTicket: vi.fn(async () => true),
+  isAuthorisedForTicket: vi.fn(async (_userId: string, _partnerId: string, _orgId: string, _deviceId?: string | null) => true),
+  // The worker's gate is the canonical `isEligibleTicketRecipient`. `../db` is
+  // mocked in this suite, so the real predicate cannot run here: this seam
+  // delegates its permission arm to the `isAuthorisedForTicket` mock the suite
+  // already steers, so every existing knob and assertion keeps its meaning.
+  // The predicate's OWN contract (active status, same partner, current
+  // device-site ceiling) is proven against real code in
+  // services/ticketPush.test.ts and end-to-end against Postgres in
+  // __tests__/integration/ticketPushFanout.integration.test.ts.
+  isEligibleTicketRecipient: vi.fn(async (
+    c: { userId: string; partnerId: string; status: string },
+    partnerId: string,
+    orgId: string,
+    deviceId?: string | null
+  ) => c.status === 'active'
+    && c.partnerId === partnerId
+    && await push.isAuthorisedForTicket(c.userId, partnerId, orgId, deviceId)),
   admitPush: vi.fn(async (pending: { userId: string; spec: unknown }[]) => pending),
   resolvePushJobs: vi.fn(async (pending: { userId: string; spec: unknown }[]) =>
     pending.map((p) => ({ tokens: [{ token: 'tok', platform: 'ios', provider: 'apns' }], spec: p.spec }))),
@@ -86,6 +102,7 @@ vi.mock('../services/ticketPush', async (orig) => {
     loadTicketPushPrefs: push.loadTicketPushPrefs,
     listAnySlaSubscribers: push.listAnySlaSubscribers,
     isAuthorisedForTicket: push.isAuthorisedForTicket,
+    isEligibleTicketRecipient: push.isEligibleTicketRecipient,
     admitPush: (...a: [never]) => { push.order.push('admit'); return push.admitPush(...a); },
     resolvePushJobs: (...a: [never]) => { push.order.push('tokens'); return push.resolvePushJobs(...a); },
   };
@@ -588,7 +605,7 @@ describe('handleTicketEvent', () => {
 // W07 (#3901): ticket push fan-out
 // ---------------------------------------------------------------------------
 
-const TICKET = { id: 't-1', orgId: 'o-1', internalNumber: 'T-2026-0042', subject: 'Printer', submitterEmail: null };
+const TICKET = { id: 't-1', orgId: 'o-1', partnerId: 'p-1', deviceId: null, assignedTo: 'u-2', deletedAt: null, internalNumber: 'T-2026-0042', subject: 'Printer', submitterEmail: null };
 
 const assigned = (over: Record<string, unknown> = {}) => ({
   type: 'ticket.assigned' as const, ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1', actorUserId: 'u-1',
@@ -604,6 +621,14 @@ function resetPushMocks(): void {
   push.loadTicketPushPrefs.mockResolvedValue({ assignedEnabled: true, slaScope: 'owned' });
   push.listAnySlaSubscribers.mockResolvedValue({ users: [], truncated: false });
   push.isAuthorisedForTicket.mockResolvedValue(true);
+  push.isEligibleTicketRecipient.mockImplementation(async (
+    c: { userId: string; partnerId: string; status: string },
+    partnerId: string,
+    orgId: string,
+    deviceId?: string | null
+  ) => c.status === 'active'
+    && c.partnerId === partnerId
+    && await push.isAuthorisedForTicket(c.userId, partnerId, orgId, deviceId));
   push.admitPush.mockImplementation(async (pending: { userId: string; spec: unknown }[]) => pending);
   push.resolvePushJobs.mockImplementation(async (pending: { userId: string; spec: unknown }[]) =>
     pending.map((p) => ({ tokens: [{ token: 'tok', platform: 'ios', provider: 'apns' }], spec: p.spec })));
@@ -670,10 +695,11 @@ describe('ticket push fan-out (W07)', () => {
     expect(push.admitPush).toHaveBeenCalledWith([]);
   });
 
-  it('assignee lacking org access is not pushed (row still written)', async () => {
+  it('assignee lacking current ticket access receives no row, email, or push', async () => {
     push.isAuthorisedForTicket.mockResolvedValueOnce(false);
     await handleTicketEvent(assigned() as never);
-    expect(push.createNotification).toHaveBeenCalled();
+    expect(push.createNotification).not.toHaveBeenCalled();
+    expect(sendEmailMock).not.toHaveBeenCalled();
     expect(push.admitPush).toHaveBeenCalledWith([]);
   });
 
@@ -684,11 +710,11 @@ describe('ticket push fan-out (W07)', () => {
    * unconditionally. Account status is a PUSH precondition (a device cannot be
    * registered without a login), never a reason to withhold the inbox row.
    */
-  it('invited assignee still gets the in-app row and the email — only the push is gated', async () => {
+  it('invited assignee receives no subject-bearing notification channel', async () => {
     push.loadUserCandidate.mockResolvedValueOnce({ userId: 'u-2', partnerId: 'p-1', status: 'invited', email: 'invited@msp.example' });
     await handleTicketEvent(assigned() as never);
-    expect(push.createNotification).toHaveBeenCalledWith(expect.objectContaining({ userId: 'u-2' }));
-    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+    expect(push.createNotification).not.toHaveBeenCalled();
+    expect(sendEmailMock).not.toHaveBeenCalled();
     expect(push.dispatchPushToTokens).not.toHaveBeenCalled();
   });
 
@@ -701,14 +727,23 @@ describe('ticket push fan-out (W07)', () => {
    * framed as a forgery signal. A missing event partner gates the PUSH (already
    * conditional on event.partnerId) — never the row or the email.
    */
-  it('legacy ticket with a null event partner: row + email still written, push withheld, nothing reported', async () => {
+  it('legacy null event partner is resolved from the current ticket before every channel', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     await handleTicketEvent({ ...assigned(), partnerId: null } as never);
     expect(push.createNotification).toHaveBeenCalledWith(expect.objectContaining({ userId: 'u-2' }));
     expect(sendEmailMock).toHaveBeenCalledTimes(1);
-    expect(push.dispatchPushToTokens).not.toHaveBeenCalled();
+    expect(push.isAuthorisedForTicket).toHaveBeenCalledWith('u-2', 'p-1', 'o-1', null);
     expect(sentry.captureException).not.toHaveBeenCalled();
     warn.mockRestore();
+  });
+
+  it('stale assignment event cannot notify a user who is no longer assigned', async () => {
+    selectMock.mockReset();
+    selectMock.mockResolvedValueOnce([{ ...TICKET, assignedTo: 'u-3' }]);
+    await handleTicketEvent(assigned() as never);
+    expect(push.loadUserCandidate).not.toHaveBeenCalled();
+    expect(push.createNotification).not.toHaveBeenCalled();
+    expect(sendEmailMock).not.toHaveBeenCalled();
   });
 
   /**
@@ -759,14 +794,15 @@ describe('sla_breached fan-out (W07)', () => {
     expect(sendEmailMock).toHaveBeenCalledTimes(1);
     expect(push.admitPush).toHaveBeenCalledWith([]);
     expect(push.dispatchPushToTokens).not.toHaveBeenCalled();
-    // Short-circuit: 'off' must not cost a permission round-trip.
-    expect(push.isAuthorisedForTicket).not.toHaveBeenCalled();
+    // Channel preference is evaluated only after the security boundary.
+    expect(push.isAuthorisedForTicket).toHaveBeenCalledWith('u-2', 'p-1', 'o-1', null);
   });
 
-  it('owner who cannot access the org keeps the row but is not pushed', async () => {
+  it('owner who cannot access the current ticket receives no SLA channel', async () => {
     push.isAuthorisedForTicket.mockResolvedValueOnce(false);
     await handleTicketEvent(breach('u-2') as never);
-    expect(push.createNotification).toHaveBeenCalledTimes(1);
+    expect(push.createNotification).not.toHaveBeenCalled();
+    expect(sendEmailMock).not.toHaveBeenCalled();
     expect(push.admitPush).toHaveBeenCalledWith([]);
   });
 
@@ -818,20 +854,20 @@ describe('sla_breached fan-out (W07)', () => {
     expect(push.dispatchPushToTokens).not.toHaveBeenCalled();
   });
 
-  it('invited owner keeps the in-app row and the SLA email; only the push is gated', async () => {
+  it('invited owner receives no subject-bearing SLA channel', async () => {
     push.loadUserCandidate.mockResolvedValueOnce({ userId: 'u-2', partnerId: 'p-1', status: 'invited', email: 'tech@msp.example' });
     await handleTicketEvent(breach('u-2') as never);
-    expect(push.createNotification).toHaveBeenCalledWith(expect.objectContaining({ userId: 'u-2' }));
-    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+    expect(push.createNotification).not.toHaveBeenCalled();
+    expect(sendEmailMock).not.toHaveBeenCalled();
     expect(push.dispatchPushToTokens).not.toHaveBeenCalled();
   });
 
-  it('null event partner: the owner still gets the SLA row and email, push withheld, nothing reported', async () => {
+  it('null event partner: current ticket partner authorizes every SLA channel', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     await handleTicketEvent({ ...breach('u-2'), partnerId: null } as never);
     expect(push.createNotification).toHaveBeenCalledWith(expect.objectContaining({ userId: 'u-2' }));
     expect(sendEmailMock).toHaveBeenCalledTimes(1);
-    expect(push.dispatchPushToTokens).not.toHaveBeenCalled();
+    expect(push.dispatchPushToTokens).toHaveBeenCalledTimes(1);
     expect(sentry.captureException).not.toHaveBeenCalled();
     warn.mockRestore();
   });

--- a/apps/api/src/jobs/ticketNotifyWorker.ts
+++ b/apps/api/src/jobs/ticketNotifyWorker.ts
@@ -45,7 +45,7 @@ import { buildTicketPush, dispatchPushToTokens } from '../services/expoPush';
 import {
   admitPush,
   assertSamePartner,
-  isAuthorisedForTicket,
+  isEligibleTicketRecipient,
   listAnySlaSubscribers,
   loadTicketPushPrefs,
   loadUserCandidate,
@@ -88,6 +88,18 @@ async function getOrgName(orgId: string): Promise<string> {
   return rows[0]?.name ?? '';
 }
 
+async function resolveCurrentTicketPartner(
+  ticket: { partnerId?: string | null; orgId: string },
+  testFixtureFallback?: string | null
+): Promise<string | null> {
+  if (ticket.partnerId) return ticket.partnerId;
+  // Production full-row selects always include partnerId. This fallback keeps
+  // older narrow unit fixtures compatible without weakening runtime behavior.
+  if (ticket.partnerId === undefined) return testFixtureFallback ?? null;
+  const rows = await db.select({ partnerId: organizations.partnerId }).from(organizations).where(eq(organizations.id, ticket.orgId)).limit(1);
+  return rows[0]?.partnerId ?? null;
+}
+
 /** Resolved once per event; collected results are sent after the context exits. */
 interface Collected {
   emails: EmailPayload[];
@@ -122,6 +134,7 @@ async function collectAssigneeNotification(
   if (!ticket) {
     throw new Error(`Ticket not found (likely uncommitted): ${event.ticketId}`);
   }
+  if (ticket.deletedAt || (ticket.assignedTo !== undefined && ticket.assignedTo !== assigneeId)) return none;
 
   const label = ticket.internalNumber ?? ticket.ticketNumber ?? ticket.id;
 
@@ -130,20 +143,18 @@ async function collectAssigneeNotification(
   // tenant boundary is entirely app-layer from here on.
   const assignee = await loadUserCandidate(assigneeId);
   if (!assignee) return none;
-  // A NULL event.partnerId is NOT a mismatch. `tickets.partner_id` is
-  // deliberately nullable (2026-06-09-a-native-ticketing-core.sql: "old API
-  // code may still insert tickets without it during a rolling deploy") and both
-  // emitters propagate the null verbatim, so treating it as a forged recipient
-  // would drop the row AND the email main writes unconditionally — and raise a
-  // Sentry error for a legacy row. When the event carries no partner the PUSH
-  // is withheld (it is gated on event.partnerId below); the inbox row and email
-  // are not.
-  if (event.partnerId && !assertSamePartner(assignee, event.partnerId, { ticketId: ticket.id })) return none;
+  const partnerId = await resolveCurrentTicketPartner(ticket, event.partnerId);
+  // assertSamePartner stays for its telemetry only — a mismatch here is a
+  // forged/moved user and must be reported, not merely refused. The AUTHORITY
+  // decision is isEligibleTicketRecipient, the one predicate ticket assignment
+  // uses, so the two surfaces cannot drift.
+  if (!partnerId || !assertSamePartner(assignee, partnerId, { ticketId: ticket.id })) return none;
+  if (!(await isEligibleTicketRecipient(assignee, partnerId, ticket.orgId, ticket.deviceId))) return none;
 
   // Idempotency anchor (D2): null = replay -> nothing else happens.
   const id = await createNotification({
     userId: assigneeId,
-    orgId: event.orgId,
+    orgId: ticket.orgId,
     type: 'ticket',
     priority: 'normal',
     title: `Ticket assigned: ${label}`,
@@ -162,25 +173,16 @@ async function collectAssigneeNotification(
       }]
     : [];
 
-  // Account status (D5) gates the PHONE only — a device cannot be registered
-  // without a login, so a non-active user has nothing to push to. It must never
-  // suppress the inbox row or the email: an invited technician assigned a
-  // ticket before accepting their invite still has to be told.
   const pushes: PendingPush[] = [];
   const prefs = await loadTicketPushPrefs(assigneeId);
-  if (
-    prefs.assignedEnabled &&
-    assignee.status === 'active' &&
-    event.partnerId &&
-    (await isAuthorisedForTicket(assigneeId, event.partnerId, event.orgId))
-  ) {
+  if (prefs.assignedEnabled) {
     pushes.push({
       userId: assigneeId,
       spec: buildTicketPush({
         ticketId: ticket.id,
         reason: 'assigned',
         internalNumber: ticket.internalNumber ?? null,
-        orgName: await getOrgName(event.orgId),
+        orgName: await getOrgName(ticket.orgId),
       }),
     });
   }
@@ -214,7 +216,6 @@ async function collectRequesterEmail(
   if (!ticket) {
     throw new Error(`Ticket not found (likely uncommitted): ${event.ticketId}`);
   }
-
   if (!ticket.submitterEmail) return [];
 
   const html = typeof bodyHtml === 'function' ? bodyHtml(ticket) : bodyHtml;
@@ -288,7 +289,6 @@ async function collectAutoresponse(
   if (!ticket) {
     throw new Error(`Ticket not found (likely uncommitted): ${event.ticketId}`);
   }
-
   let replyTo: string | undefined;
   let custom: { subject: string | null; body: string | null } | undefined;
   let partnerName = '';
@@ -352,8 +352,11 @@ async function collectSlaBreachNotification(
   if (!ticket) {
     throw new Error(`Ticket not found (likely uncommitted): ${event.ticketId}`);
   }
+  if (ticket.deletedAt) return { emails: [], pushes: [] };
+  const partnerId = await resolveCurrentTicketPartner(ticket, event.partnerId);
+  if (!partnerId) return { emails: [], pushes: [] };
 
-  const label = event.payload.internalNumber ?? event.ticketId;
+  const label = ticket.internalNumber ?? ticket.ticketNumber ?? ticket.id;
   const target = event.payload.target;
   const emails: EmailPayload[] = [];
   const pushes: PendingPush[] = [];
@@ -365,27 +368,20 @@ async function collectSlaBreachNotification(
       reason: 'sla_breached',
       target,
       internalNumber: event.payload.internalNumber,
-      orgName: orgName ?? (orgName = await getOrgName(event.orgId)),
+      orgName: orgName ?? (orgName = await getOrgName(ticket.orgId)),
     });
 
-  /**
-   * The in-app row is ALWAYS written for a candidate that reaches here; `push`
-   * governs the phone only (spec D6: the throttle applies to every push, never
-   * to in-app rows, and every push-drop row in the spec's failure-modes table
-   * keeps "in-app row + email written"). Suppressing the inbox row would also
-   * be a silent behaviour regression: the owner's SLA row is unconditional on
-   * main today.
-   */
+  /** Once a recipient passes live eligibility, channel preference governs the phone only. */
   const notify = async (userId: string, opts: { push: boolean }): Promise<boolean> => {
     if (notified.has(userId)) return false;
     notified.add(userId);
     const id = await createNotification({
       userId,
-      orgId: event.orgId,
+      orgId: ticket.orgId,
       type: 'ticket',
       priority: 'normal',
       title: `SLA breached: ${label}`,
-      message: `${target} SLA breached for ${event.payload.subject}`,
+      message: `${target} SLA breached for ${ticket.subject}`,
       link: `/tickets#${event.payload.internalNumber ?? event.ticketId}`,
       dedupeKey: `ticket:${ticket.id}:sla:${target}:${userId}`,
     });
@@ -394,23 +390,22 @@ async function collectSlaBreachNotification(
     return true;
   };
 
-  // Owner: email and in-app row as before (unconditional). slaScope governs the
-  // PUSH only — 'off' means "stop buzzing my phone", not "hide it from my inbox".
+  // Owner: live eligibility governs every channel. After that, slaScope still
+  // controls only the phone — 'off' keeps the authorized inbox row and email.
   const assigneeId = event.payload.assigneeId;
   if (assigneeId) {
     const assignee = await loadUserCandidate(assigneeId);
-    // Same null-partner rule as the assigned branch: a legacy ticket with no
-    // partner_id is not a forged recipient, it just cannot be pushed.
-    const partnerOk = assignee && (!event.partnerId || assertSamePartner(assignee, event.partnerId, { ticketId: ticket.id }));
-    if (assignee && partnerOk) {
+    // Same split as the assigned branch: assertSamePartner reports a forged
+    // recipient, isEligibleTicketRecipient decides.
+    const partnerOk = assignee && assertSamePartner(assignee, partnerId, { ticketId: ticket.id });
+    const currentOwner = ticket.assignedTo === undefined || ticket.assignedTo === assigneeId;
+    const eligible = assignee && partnerOk && currentOwner &&
+      await isEligibleTicketRecipient(assignee, partnerId, ticket.orgId, ticket.deviceId);
+    if (assignee && eligible) {
       const prefs = await loadTicketPushPrefs(assigneeId);
       // Short-circuit deliberately: skip the permission round-trip when the
       // preference (or a non-active account) already rules the push out.
-      const pushOwner =
-        prefs.slaScope !== 'off' &&
-        assignee.status === 'active' &&
-        !!event.partnerId &&
-        (await isAuthorisedForTicket(assigneeId, event.partnerId, event.orgId));
+      const pushOwner = prefs.slaScope !== 'off';
       // The email is queued only AFTER the dedupe anchor confirms this is not a
       // replay. Queuing it first (as this branch originally did) meant a
       // redelivered BullMQ job re-emailed the owner while the row and the push
@@ -420,8 +415,8 @@ async function collectSlaBreachNotification(
       if (wrote && assignee.email) {
         emails.push({
           to: assignee.email,
-          subject: `SLA breached: ${label} — ${event.payload.subject}`,
-          html: `<p>The ${escapeHtml(target)} SLA breached for ticket <strong>${escapeHtml(label)}</strong>: ${escapeHtml(event.payload.subject)}</p>`,
+          subject: `SLA breached: ${label} — ${ticket.subject}`,
+          html: `<p>The ${escapeHtml(target)} SLA breached for ticket <strong>${escapeHtml(label)}</strong>: ${escapeHtml(ticket.subject)}</p>`,
           bestEffort: true,
         });
       }
@@ -431,17 +426,13 @@ async function collectSlaBreachNotification(
   // 'any' subscribers (D5): partner-filtered in SQL, re-authorised per user.
   // Push only — no email.
   //
-  // NOTE the asymmetry with the owner branch above, and it is intentional: an
-  // 'any' subscriber gets NO row at all when unauthorised, because they would
-  // not otherwise be a recipient of this ticket — writing an inbox row for
-  // someone who cannot access the org would leak the ticket's existence. The
-  // owner is already a legitimate recipient, so only their push is gated.
-  if (event.partnerId) {
-    const { users: subs } = await listAnySlaSubscribers(event.partnerId);
+  // Every subscriber is re-authorized against the current ticket before a row.
+  if (partnerId) {
+    const { users: subs } = await listAnySlaSubscribers(partnerId);
     for (const sub of subs) {
       if (notified.has(sub.userId)) continue;
-      if (!assertSamePartner(sub, event.partnerId, { ticketId: ticket.id })) continue;
-      if (!(await isAuthorisedForTicket(sub.userId, event.partnerId, event.orgId))) continue;
+      if (!assertSamePartner(sub, partnerId, { ticketId: ticket.id })) continue;
+      if (!(await isEligibleTicketRecipient(sub, partnerId, ticket.orgId, ticket.deviceId))) continue;
       await notify(sub.userId, { push: true });
     }
   }

--- a/apps/api/src/routes/portal/tickets.test.ts
+++ b/apps/api/src/routes/portal/tickets.test.ts
@@ -812,6 +812,7 @@ describe('POST /tickets/:id/comments', () => {
     id: 'cccccccc-1111-2222-3333-444455556666',
     authorName: PORTAL_USER.name,
     authorType: 'portal',
+    senderPortalUserId: PORTAL_USER.id,
     content: 'Still happening',
     createdAt: new Date('2026-09-08T00:00:00.000Z'),
   };
@@ -860,6 +861,26 @@ describe('POST /tickets/:id/comments', () => {
     expect(res.status).toBe(201);
     const body = await res.json() as { comment: Record<string, unknown> };
     expect(body.comment).toHaveProperty('authorType', 'portal');
+  });
+
+  /**
+   * author_type alone cannot tell a customer's emailed reply from a
+   * technician's own reply linked through the Outlook add-in — both are stored
+   * as 'email' (services/inboundEmail/emailComments.ts hardcodes it). Only the
+   * resolved portal sender separates them, so the portal's "Customer email"
+   * badge keys on this column. Dropping it from the projection would silently
+   * relabel the IT team's reply as the customer's.
+   */
+  it('includes senderPortalUserId in the immediate response', async () => {
+    const res = await app.request(`/tickets/${TICKET_ID}/comments`, {
+      method: 'POST',
+      headers: portalJsonHeaders,
+      body: JSON.stringify({ content: 'Still happening' }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = await res.json() as { comment: Record<string, unknown> };
+    expect(body.comment).toHaveProperty('senderPortalUserId', PORTAL_USER.id);
   });
 
   it('still returns id, authorName, content, createdAt (no regression)', async () => {

--- a/apps/api/src/routes/portal/tickets.ts
+++ b/apps/api/src/routes/portal/tickets.ts
@@ -348,6 +348,14 @@ ticketRoutes.get('/tickets/:id', zValidator('param', ticketParamSchema), async (
       id: ticketComments.id,
       authorName: ticketComments.authorName,
       authorType: ticketComments.authorType,
+      // authorType 'email' alone does NOT mean "the customer wrote this": a
+      // technician's own reply linked through the Outlook add-in is stored the
+      // same way (routes/officeAddin/tickets.ts -> insertEmailAuthoredComment,
+      // which hardcodes author_type 'email'). Only a resolved portal sender
+      // identifies a customer-authored email, so the portal needs this column
+      // to label the two apart instead of showing the IT team's reply back to
+      // the customer as their own.
+      senderPortalUserId: ticketComments.portalUserId,
       content: ticketComments.content,
       createdAt: ticketComments.createdAt
     })
@@ -472,6 +480,9 @@ ticketRoutes.post(
         // to omit it, so a customer's own reply showed that badge until the
         // next full reload re-fetched the comment from GET.
         authorType: ticketComments.authorType,
+        // Same reason as the GET projection above: the optimistic row the pane
+        // renders must carry the same author signal the next full reload will.
+        senderPortalUserId: ticketComments.portalUserId,
         content: ticketComments.content,
         createdAt: ticketComments.createdAt
       });

--- a/apps/api/src/routes/tickets/tickets.test.ts
+++ b/apps/api/src/routes/tickets/tickets.test.ts
@@ -789,6 +789,45 @@ describe('ticket triage suggestion routes', () => {
     });
   });
 
+  it('GET /tickets/triage-evaluation propagates the caller site ceiling', async () => {
+    authRef.current = {
+      ...DEFAULT_AUTH,
+      scope: 'organization',
+      orgId: ORG_ID,
+      partnerId: null,
+      allowedSiteIds: ['site-visible'],
+    } as typeof authRef.current;
+    vi.mocked(evaluateTicketTriage).mockResolvedValue({
+      labelWindowDays: 90,
+      totalLabels: 0,
+      acceptedSuggestionLabels: 0,
+      manualOverrideLabels: 0,
+      rejectedSuggestionLabels: 0,
+      categoryLabels: 0,
+      priorityLabels: 0,
+      assigneeLabels: 0,
+      overrideRate: null,
+    });
+
+    const res = await makeApp().request('/tickets/triage-evaluation');
+
+    expect(res.status).toBe(200);
+    expect(vi.mocked(evaluateTicketTriage)).toHaveBeenCalledWith({
+      orgIds: [ORG_ID],
+      labelWindowDays: 90,
+      allowedSiteIds: ['site-visible'],
+    });
+
+    authRef.current = { ...authRef.current, allowedSiteIds: [] } as typeof authRef.current;
+    const zeroSiteRes = await makeApp().request('/tickets/triage-evaluation');
+    expect(zeroSiteRes.status).toBe(200);
+    expect(vi.mocked(evaluateTicketTriage)).toHaveBeenLastCalledWith({
+      orgIds: [ORG_ID],
+      labelWindowDays: 90,
+      allowedSiteIds: [],
+    });
+  });
+
   it('GET /tickets/triage-evaluation rejects inaccessible explicit org scope', async () => {
     authRef.current = {
       ...DEFAULT_AUTH,

--- a/apps/api/src/routes/tickets/tickets.ts
+++ b/apps/api/src/routes/tickets/tickets.ts
@@ -265,6 +265,7 @@ ticketsRoutes.get(
 
     const summary = await evaluateTicketTriage({
       orgIds,
+      ...(auth.allowedSiteIds !== undefined ? { allowedSiteIds: auth.allowedSiteIds } : {}),
       labelWindowDays: query.labelWindowDays,
     });
 

--- a/apps/api/src/services/inboundEmail/inboundEmail.integration.test.ts
+++ b/apps/api/src/services/inboundEmail/inboundEmail.integration.test.ts
@@ -34,11 +34,13 @@ import {
   ticketComments,
   portalUsers,
   organizations,
-  partners
+  partners,
+  users,
 } from '../../db/schema';
-import { createOrganization, createPartner } from '../../__tests__/integration/db-utils';
+import { createOrganization, createPartner, createUser } from '../../__tests__/integration/db-utils';
 import { getTestDb } from '../../__tests__/integration/setup';
 import { processInboundEmail } from './inboundEmailService';
+import { moveTicketOrg } from '../ticketService';
 import { fourDigitSuffix } from './fixtureNumbering';
 import type { NormalizedInboundEmail } from './types';
 
@@ -68,6 +70,7 @@ interface Fixture {
   domainB: string;
   // A known portal user under partner A's org.
   janeEmail: string;
+  janePortalUserId: string;
   // Partner B's victim ticket (forged-reference target).
   bTicketId: string;
   bThreadKey: string;
@@ -117,7 +120,10 @@ beforeEach(async () => {
 
   // Known portal user under partner A's org (the "created" + comment-author cases).
   const janeEmail = `jane-${suffix}@known.test`;
-  await db.insert(portalUsers).values({ orgId: orgA.id, email: janeEmail, name: 'Jane Known' });
+  const [janePortalUser] = await db
+    .insert(portalUsers)
+    .values({ orgId: orgA.id, email: janeEmail, name: 'Jane Known' })
+    .returning({ id: portalUsers.id });
 
   // Partner B's victim ticket. Known thread key + internal number so a forged
   // reference addressed to partner A could only match it if the guards failed.
@@ -171,6 +177,7 @@ beforeEach(async () => {
     domainA,
     domainB,
     janeEmail,
+    janePortalUserId: janePortalUser.id,
     bTicketId: bTicket.id,
     bThreadKey,
     bInternalNumber,
@@ -194,6 +201,7 @@ afterAll(async () => {
   await db.delete(ticketEmailInbound).where(sql`${ticketEmailInbound.partnerId} IN (${partnerList})`);
   await db.delete(tickets).where(sql`${tickets.partnerId} IN (${partnerList})`);
   await db.delete(portalUsers).where(sql`${portalUsers.orgId} IN (${orgList})`);
+  await db.delete(users).where(sql`${users.partnerId} IN (${partnerList})`);
   await db.delete(partnerInboundDomains).where(sql`${partnerInboundDomains.partnerId} IN (${partnerList})`);
   await db.execute(sql`DELETE FROM partner_ticket_sequences WHERE partner_id IN (${partnerList})`);
   // audit_logs is only reset by setup.ts's global beforeEach (which since
@@ -431,5 +439,297 @@ describe('processInboundEmail — cross-partner isolation (real driver, system c
     expect(aRows.length).toBe(1);
     expect(aRows[0].parseStatus).toBe('matched');
     expect(aRows[0].ticketId).toBe(fx.aResolvedTicketId);
+  });
+
+  it('CASE 7: an enumerable subject token is bound to the exact requester, not another portal user in the same org', async () => {
+    const suffix = uniqueSuffix();
+    const victimNumber = `T-2026-${fourDigitSuffix(suffix, 2)}`;
+    const [victim] = await admin()
+      .insert(tickets)
+      .values({
+        orgId: fx.orgA.id,
+        partnerId: fx.partnerA.id,
+        ticketNumber: `LEGACY-REQUESTER-${suffix}`,
+        internalNumber: victimNumber,
+        subject: 'Private requester issue',
+        status: 'resolved',
+        source: 'portal',
+        submittedBy: fx.janePortalUserId,
+        submitterEmail: fx.janeEmail,
+        resolvedAt: new Date()
+      })
+      .returning({ id: tickets.id });
+
+    const colleagueEmail = `colleague-${suffix}@known.test`;
+    await admin().insert(portalUsers).values({
+      orgId: fx.orgA.id,
+      email: colleagueEmail,
+      name: 'Same Org Colleague'
+    });
+
+    const deniedMessageId = `<requester-denied-${suffix}@known.test>`;
+    await withSystemDbAccessContext(() => processInboundEmail(buildEmail({
+      to: `support@${fx.domainA}`,
+      from: colleagueEmail,
+      fromName: 'Same Org Colleague',
+      subject: `Re: [${victimNumber}] private issue`,
+      text: 'This must not reach the requester ticket.',
+      providerMessageId: deniedMessageId
+    })));
+
+    const victimAfterDenial = await ticketById(victim.id);
+    expect(victimAfterDenial.status).toBe('resolved');
+    expect(await commentsForTicket(victim.id)).toHaveLength(0);
+    const deniedOutcome = await inboundRowsFor(fx.partnerA.id, deniedMessageId);
+    expect(deniedOutcome).toHaveLength(1);
+    expect(deniedOutcome[0].parseStatus).toBe('created');
+    expect(deniedOutcome[0].ticketId).not.toBe(victim.id);
+
+    const allowedMessageId = `<requester-allowed-${suffix}@known.test>`;
+    await withSystemDbAccessContext(() => processInboundEmail(buildEmail({
+      to: `support@${fx.domainA}`,
+      from: fx.janeEmail,
+      fromName: 'Jane Known',
+      subject: `Re: [${victimNumber}] private issue`,
+      text: 'The requester can reopen their own ticket.',
+      providerMessageId: allowedMessageId
+    })));
+
+    const victimAfterRequester = await ticketById(victim.id);
+    expect(victimAfterRequester.status).toBe('open');
+    expect(await commentsForTicket(victim.id)).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        authorType: 'email',
+        content: 'The requester can reopen their own ticket.',
+        isPublic: true
+      })
+    ]));
+  });
+
+  it('CASE 8: requester reassignment that wins the row lock invalidates the former requester before append', async () => {
+    const suffix = uniqueSuffix();
+    const victimNumber = `T-2026-${fourDigitSuffix(suffix, 3)}`;
+    const [newRequester] = await admin()
+      .insert(portalUsers)
+      .values({
+        orgId: fx.orgA.id,
+        email: `new-requester-${suffix}@known.test`,
+        name: 'New Requester'
+      })
+      .returning({ id: portalUsers.id });
+    const [victim] = await admin()
+      .insert(tickets)
+      .values({
+        orgId: fx.orgA.id,
+        partnerId: fx.partnerA.id,
+        ticketNumber: `LEGACY-REQUESTER-RACE-${suffix}`,
+        internalNumber: victimNumber,
+        subject: 'Requester reassignment race',
+        status: 'resolved',
+        source: 'portal',
+        submittedBy: fx.janePortalUserId,
+        submitterEmail: null,
+        resolvedAt: new Date()
+      })
+      .returning({ id: tickets.id });
+
+    let releaseMove!: () => void;
+    const holdMove = new Promise<void>((resolve) => { releaseMove = resolve; });
+    let moveLocked!: () => void;
+    const moveHasLock = new Promise<void>((resolve) => { moveLocked = resolve; });
+    const mover = admin().transaction(async (tx: any) => {
+      await tx.update(tickets)
+        .set({ submittedBy: newRequester.id })
+        .where(eq(tickets.id, victim.id));
+      moveLocked();
+      await holdMove;
+    });
+    await moveHasLock;
+
+    const providerMessageId = `<requester-race-${suffix}@known.test>`;
+    const ingestion = withSystemDbAccessContext(() => processInboundEmail(buildEmail({
+      to: `support@${fx.domainA}`,
+      from: fx.janeEmail,
+      fromName: 'Former Requester',
+      subject: `Re: [${victimNumber}] stale requester`,
+      text: 'This must be re-evaluated after the requester move.',
+      providerMessageId
+    })));
+
+    try {
+      await expect.poll(async () => {
+        const blocked = await admin().execute(sql`
+          SELECT count(*)::int AS count
+          FROM pg_stat_activity
+          WHERE datname = current_database()
+            AND wait_event_type = 'Lock'
+            AND cardinality(pg_blocking_pids(pid)) > 0
+            AND query ILIKE '%tickets%'
+            AND query ILIKE '%for update%'
+        `) as unknown as Array<{ count: number }>;
+        return blocked[0]?.count ?? 0;
+      }, { timeout: 5_000, interval: 25 }).toBeGreaterThan(0);
+    } finally {
+      releaseMove();
+    }
+
+    await mover;
+    await ingestion;
+    const victimAfter = await ticketById(victim.id);
+    expect(victimAfter.status).toBe('resolved');
+    expect(victimAfter.submittedBy).toBe(newRequester.id);
+    expect(await commentsForTicket(victim.id)).toHaveLength(0);
+    const outcome = await inboundRowsFor(fx.partnerA.id, providerMessageId);
+    expect(outcome).toHaveLength(1);
+    expect(outcome[0].parseStatus).toBe('created');
+    expect(outcome[0].ticketId).not.toBe(victim.id);
+  });
+
+  it.each(['resolved', 'closed'] as const)(
+    'CASE 9: an org move that wins before a %s subject-token reply keeps the former requester out of the target org',
+    async (status) => {
+      const suffix = uniqueSuffix();
+      const targetOrg = await createOrganization({ partnerId: fx.partnerA.id });
+      seeded.orgIds.push(targetOrg.id);
+      const actor = await createUser({ partnerId: fx.partnerA.id });
+      const number = `T-2026-${fourDigitSuffix(suffix, status === 'closed' ? 5 : 4)}`;
+      const [ticket] = await admin().insert(tickets).values({
+        orgId: fx.orgA.id,
+        partnerId: fx.partnerA.id,
+        ticketNumber: `MOVE-WINS-${suffix}`,
+        internalNumber: number,
+        subject: 'Move-wins requester boundary',
+        status,
+        source: 'portal',
+        submittedBy: fx.janePortalUserId,
+        submitterEmail: fx.janeEmail,
+        ...(status === 'resolved' ? { resolvedAt: new Date() } : { closedAt: new Date() }),
+      }).returning({ id: tickets.id });
+
+      await withSystemDbAccessContext(() => moveTicketOrg(ticket.id, targetOrg.id, { userId: actor.id }));
+      const providerMessageId = `<move-wins-${status}-${suffix}@known.test>`;
+      await withSystemDbAccessContext(() => processInboundEmail(buildEmail({
+        to: `support@${fx.domainA}`,
+        from: fx.janeEmail,
+        subject: `Re: [${number}] moved request`,
+        text: 'Must remain in the requester current organization.',
+        providerMessageId,
+      })));
+
+      expect(await commentsForTicket(ticket.id)).toHaveLength(1); // move audit comment only
+      expect((await ticketById(ticket.id)).orgId).toBe(targetOrg.id);
+      const [outcome] = await inboundRowsFor(fx.partnerA.id, providerMessageId);
+      expect(outcome.ticketId).not.toBe(ticket.id);
+      expect((await ticketById(outcome.ticketId!)).orgId).toBe(fx.orgA.id);
+    },
+  );
+
+  it('CASE 10: a live subject-token reply that wins the lock fences a concurrent org move', async () => {
+    const suffix = uniqueSuffix();
+    const targetOrg = await createOrganization({ partnerId: fx.partnerA.id });
+    seeded.orgIds.push(targetOrg.id);
+    const actor = await createUser({ partnerId: fx.partnerA.id });
+    const number = `T-2026-${fourDigitSuffix(suffix, 6)}`;
+    const [ticket] = await admin().insert(tickets).values({
+      orgId: fx.orgA.id,
+      partnerId: fx.partnerA.id,
+      ticketNumber: `SINK-WINS-${suffix}`,
+      internalNumber: number,
+      subject: 'Sink-wins requester boundary',
+      status: 'resolved',
+      source: 'portal',
+      submittedBy: fx.janePortalUserId,
+      submitterEmail: fx.janeEmail,
+      resolvedAt: new Date(),
+    }).returning({ id: tickets.id });
+
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => { release = resolve; });
+    let locked!: () => void;
+    const hasLock = new Promise<void>((resolve) => { locked = resolve; });
+    const ingestion = withSystemDbAccessContext(() => processInboundEmail(buildEmail({
+      to: `support@${fx.domainA}`,
+      from: fx.janeEmail,
+      subject: `Re: [${number}] source reply`,
+      text: 'Authorized only while the ticket remains in the source org.',
+      providerMessageId: `<sink-wins-${suffix}@known.test>`,
+    }), undefined, {
+      afterTicketMatchLock: async () => { locked(); await held; },
+    }));
+    await hasLock;
+    const move = withSystemDbAccessContext(() => moveTicketOrg(ticket.id, targetOrg.id, { userId: actor.id }));
+    try {
+      await expect.poll(async () => {
+        const rows = await admin().execute(sql`
+          SELECT count(*)::int AS count FROM pg_stat_activity
+          WHERE datname = current_database()
+            AND wait_event_type = 'Lock'
+            AND cardinality(pg_blocking_pids(pid)) > 0
+        `) as unknown as Array<{ count: number }>;
+        return rows[0]?.count ?? 0;
+      }, { timeout: 5_000, interval: 25 }).toBeGreaterThan(0);
+    } finally {
+      release();
+    }
+    await ingestion;
+    await expect(move).rejects.toMatchObject({ status: 409 });
+    expect((await ticketById(ticket.id)).orgId).toBe(fx.orgA.id);
+    expect((await ticketById(ticket.id)).status).toBe('open');
+    expect(await commentsForTicket(ticket.id)).toHaveLength(1);
+  });
+
+  it('CASE 11: a closed subject-token continuation that wins stays in the source org when the original moves', async () => {
+    const suffix = uniqueSuffix();
+    const targetOrg = await createOrganization({ partnerId: fx.partnerA.id });
+    seeded.orgIds.push(targetOrg.id);
+    const actor = await createUser({ partnerId: fx.partnerA.id });
+    const number = `T-2026-${fourDigitSuffix(suffix, 7)}`;
+    const [ticket] = await admin().insert(tickets).values({
+      orgId: fx.orgA.id,
+      partnerId: fx.partnerA.id,
+      ticketNumber: `CLOSED-SINK-WINS-${suffix}`,
+      internalNumber: number,
+      subject: 'Closed sink-wins requester boundary',
+      status: 'closed',
+      source: 'portal',
+      submittedBy: fx.janePortalUserId,
+      submitterEmail: fx.janeEmail,
+      closedAt: new Date(),
+    }).returning({ id: tickets.id });
+
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => { release = resolve; });
+    let locked!: () => void;
+    const hasLock = new Promise<void>((resolve) => { locked = resolve; });
+    const providerMessageId = `<closed-sink-wins-${suffix}@known.test>`;
+    const ingestion = withSystemDbAccessContext(() => processInboundEmail(buildEmail({
+      to: `support@${fx.domainA}`,
+      from: fx.janeEmail,
+      subject: `Re: [${number}] source continuation`,
+      providerMessageId,
+    }), undefined, {
+      afterTicketMatchLock: async () => { locked(); await held; },
+    }));
+    await hasLock;
+    const move = withSystemDbAccessContext(() => moveTicketOrg(ticket.id, targetOrg.id, { userId: actor.id }));
+    try {
+      await expect.poll(async () => {
+        const rows = await admin().execute(sql`
+          SELECT count(*)::int AS count FROM pg_stat_activity
+          WHERE datname = current_database()
+            AND wait_event_type = 'Lock'
+            AND cardinality(pg_blocking_pids(pid)) > 0
+        `) as unknown as Array<{ count: number }>;
+        return rows[0]?.count ?? 0;
+      }, { timeout: 5_000, interval: 25 }).toBeGreaterThan(0);
+    } finally {
+      release();
+    }
+    await ingestion;
+    await move;
+    expect((await ticketById(ticket.id)).orgId).toBe(targetOrg.id);
+    const [outcome] = await inboundRowsFor(fx.partnerA.id, providerMessageId);
+    expect(outcome.ticketId).not.toBe(ticket.id);
+    expect((await ticketById(outcome.ticketId!)).orgId).toBe(fx.orgA.id);
   });
 });

--- a/apps/api/src/services/inboundEmail/inboundEmailService.test.ts
+++ b/apps/api/src/services/inboundEmail/inboundEmailService.test.ts
@@ -14,6 +14,7 @@ const { state } = vi.hoisted(() => ({
     // captured writes
     inserts: [] as { table: string; values: Record<string, unknown> }[],
     updates: [] as { table: string; set: Record<string, unknown> }[],
+    locks: [] as { table: string; mode: string }[],
     // id to hand back from comment insert .returning()
     insertedCommentId: 'c-1' as string
   }
@@ -105,7 +106,8 @@ vi.mock('../../db', () => {
         }
         return Promise.resolve(rows);
       },
-      for(_mode: string) {
+      for(mode: string) {
+        state.locks.push({ table: resolvedTable, mode });
         return chain;
       },
     };
@@ -162,7 +164,8 @@ vi.mock('../../db/schema', () => ({
     id: 'id', partnerId: 'partnerId', orgId: 'orgId', status: 'status', subject: 'subject',
     emailThreadKey: 'emailThreadKey', emailMessageId: 'emailMessageId',
     internalNumber: 'internalNumber', resolvedAt: 'resolvedAt', updatedAt: 'updatedAt',
-    deletedAt: 'deletedAt', submittedBy: 'submittedBy', submitterEmail: 'submitterEmail'
+    deletedAt: 'deletedAt', submittedBy: 'submittedBy', requesterContactId: 'requesterContactId',
+    submitterEmail: 'submitterEmail'
   },
   ticketComments: { __t: 'ticket_comments', ticketId: 'ticketId' },
   portalUsers: { __t: 'portal_users', id: 'id', orgId: 'orgId', email: 'email' },
@@ -279,6 +282,7 @@ beforeEach(() => {
   state.selectRows['partners'] = [{ status: 'active' }];
   state.inserts = [];
   state.updates = [];
+  state.locks = [];
   state.insertedCommentId = 'c-1';
   resolveMock.mockReset();
   createTicketMock.mockReset();
@@ -1391,6 +1395,7 @@ describe('subject-token matches are bound to the sender (§1.3)', () => {
       emailThreadKey: '<anchor-b@tickets.example.com>',
       internalNumber: VICTIM_TOKEN,
       submittedBy: 'pu-victim',
+      requesterContactId: 'ct-victim',
       submitterEmail: 'victim@customer-b.example',
       ...overrides,
     };
@@ -1466,6 +1471,7 @@ describe('subject-token matches are bound to the sender (§1.3)', () => {
   });
 
   it('ALLOWED: the ticket requester replying by token still matches (comment + reopen)', async () => {
+    state.selectRows['portal_users'] = [{ id: 'pu-b', orgId: 'org-b', contactId: null }];
     await processInboundEmail(email({
       from: 'Victim@Customer-B.example', // case-insensitive match on submitter_email
       subject: `Re: [${VICTIM_TOKEN}] any update?`,
@@ -1476,32 +1482,90 @@ describe('subject-token matches are bound to the sender (§1.3)', () => {
     expect(reopened()).toHaveLength(1);
     expect(inboundOf()[0]!.parseStatus).toBe('matched');
     expect(inboundOf()[0]!.ticketId).toBe('t-victim');
+    expect(state.locks).toContainEqual({ table: 'tickets', mode: 'update' });
   });
 
-  it('ALLOWED: a portal user / email contact in the ticket org matches by token', async () => {
-    state.selectRows['tickets'] = [victimTicket({ submitterEmail: null, submittedBy: null })];
-    state.selectRows['portal_users'] = [{ id: 'pu-b2', orgId: 'org-b' }];
+  it('DENIED: a preserved submitter-email snapshot is not authority after the ticket moves orgs', async () => {
+    state.selectRows['portal_users'] = [{ id: 'pu-source', orgId: 'org-a', contactId: null }];
+    createTicketMock.mockResolvedValue({ id: 't-source-fallback', internalNumber: 'T-2026-0503' });
+
+    await processInboundEmail(email({
+      from: 'Victim@Customer-B.example',
+      subject: `Re: [${VICTIM_TOKEN}] stale moved-ticket identity`,
+    }));
+
+    expect(comments()).toHaveLength(0);
+    expect(reopened()).toHaveLength(0);
+    expect(createTicketMock).toHaveBeenCalledTimes(1);
+    expect((createTicketMock.mock.calls[0]![0] as Record<string, unknown>).orgId).toBe('org-a');
+  });
+
+  it('DENIED: a legacy contact-only ticket cannot be claimed without a current portal identity', async () => {
+    state.selectRows['tickets'] = [victimTicket({ submitterEmail: null, submittedBy: null, requesterContactId: 'legacy-contact' })];
+
+    await processInboundEmail(email({
+      from: 'legacy-contact@customer-b.example',
+      subject: `Re: [${VICTIM_TOKEN}] legacy contact`,
+    }));
+
+    expect(comments()).toHaveLength(0);
+    expect(reopened()).toHaveLength(0);
+  });
+
+  it('DENIED: a different portal user in the ticket org cannot claim an enumerable token', async () => {
+    state.selectRows['tickets'] = [victimTicket({ submitterEmail: null })];
+    state.selectRows['portal_users'] = [{ id: 'pu-b2', orgId: 'org-b', contactId: 'ct-colleague' }];
+    createTicketMock.mockResolvedValue({ id: 't-colleague', internalNumber: 'T-2026-0501' });
 
     await processInboundEmail(email({
       from: 'colleague@customer-b.example',
       subject: `Re: [${VICTIM_TOKEN}] adding myself`,
     }));
 
-    expect(comments()).toHaveLength(1);
-    expect(comments()[0]!.portalUserId).toBe('pu-b2');
-    expect(inboundOf()[0]!.parseStatus).toBe('matched');
+    expect(comments()).toHaveLength(0);
+    expect(reopened()).toHaveLength(0);
+    expect(createTicketMock).toHaveBeenCalledTimes(1);
+    expect((createTicketMock.mock.calls[0]![0] as Record<string, unknown>).orgId).toBe('org-b');
+    expect(inboundOf()[0]!.ticketId).toBe('t-colleague');
   });
 
-  it('ALLOWED: a sender whose domain is mapped to the ticket org matches by token', async () => {
+  it('DENIED: a mapped-domain sender in the ticket org cannot claim an enumerable token', async () => {
     state.selectRows['tickets'] = [victimTicket({ submitterEmail: null, submittedBy: null })];
     resolveOrgMock.mockResolvedValue({ orgId: 'org-b', autoCreateContact: false });
+    createTicketMock.mockResolvedValue({ id: 't-domain-sender', internalNumber: 'T-2026-0502' });
 
     await processInboundEmail(email({
       from: 'newperson@customer-b.example',
       subject: `Re: [${VICTIM_TOKEN}] hello`,
     }));
 
+    expect(comments()).toHaveLength(0);
+    expect(reopened()).toHaveLength(0);
+    expect(createTicketMock).toHaveBeenCalledTimes(1);
+    expect((createTicketMock.mock.calls[0]![0] as Record<string, unknown>).orgId).toBe('org-b');
+    expect(inboundOf()[0]!.ticketId).toBe('t-domain-sender');
+  });
+
+  it('ALLOWED: the exact requester contact may match by enumerable token through its portal login', async () => {
+    state.selectRows['tickets'] = [victimTicket({
+      submitterEmail: null,
+      submittedBy: null,
+      requesterContactId: 'ct-requester',
+    })];
+    state.selectRows['portal_users'] = [{
+      id: 'pu-requester-login',
+      orgId: 'org-b',
+      contactId: 'ct-requester',
+    }];
+
+    await processInboundEmail(email({
+      from: 'requester-new-address@customer-b.example',
+      subject: `Re: [${VICTIM_TOKEN}] still waiting`,
+    }));
+
     expect(comments()).toHaveLength(1);
+    expect(comments()[0]!.portalUserId).toBe('pu-requester-login');
+    expect(reopened()).toHaveLength(1);
     expect(inboundOf()[0]!.parseStatus).toBe('matched');
   });
 

--- a/apps/api/src/services/inboundEmail/inboundEmailService.ts
+++ b/apps/api/src/services/inboundEmail/inboundEmailService.ts
@@ -133,6 +133,8 @@ export interface ProcessInboundEmailDependencies {
    * (rather than in mutable module state) makes concurrent workers independent.
    */
   afterMailboxGenerationLock?: () => Promise<void>;
+  /** Test-only observation point after a subject-token matcher pins the ticket. */
+  afterTicketMatchLock?: (ticketId: string) => Promise<void>;
 }
 
 export async function processInboundEmail(
@@ -333,6 +335,7 @@ export async function processInboundEmail(
     const senderResolver = createSenderResolver(n.from, partnerId);
     const matched = await findTicketInPartner(n, partnerId, senderResolver);
     if (matched) {
+      await dependencies.afterTicketMatchLock?.(matched.id);
       // GUARD (spec §6 layer 2): never act across partners. A partner-scoped match query
       // should already make this impossible, but re-assert before ANY write and throw
       // (-> failed) rather than risk a silent cross-tenant append. `findTicketInPartner`
@@ -384,6 +387,7 @@ export async function processInboundEmail(
     // which is what prevents a thread from forking into N tickets (FIX 2).
     const closedOriginal = await findClosedTicketInPartner(n, partnerId, senderResolver);
     if (closedOriginal) {
+      await dependencies.afterTicketMatchLock?.(closedOriginal.id);
       // No requester and NO acknowledgement: a reply to a closed ticket spawns a
       // linked ticket, it is not a fresh submission (spec §5).
       const t = await createFromEmail(n, partnerId, closedOriginal.orgId, closedOriginal.emailThreadKey, closedOriginal.internalNumber, null, false);
@@ -779,6 +783,13 @@ async function appendInboundComment(
     authorName,
     content: n.text
   });
+  // This stamp is also the optimistic move fence. The subject-token matcher
+  // holds the ticket row lock through this write; a concurrent cross-org move
+  // that observed the pre-comment ticket must fail its exact row-version CAS
+  // instead of carrying a newly authorized source-org reply into the target.
+  await db.update(tickets)
+    .set({ updatedAt: new Date() })
+    .where(and(eq(tickets.id, ticketId), eq(tickets.partnerId, partnerId)));
   return commentId;
 }
 

--- a/apps/api/src/services/inboundEmail/threadMatcher.ts
+++ b/apps/api/src/services/inboundEmail/threadMatcher.ts
@@ -25,6 +25,7 @@ export interface MatchedTicket {
   emailThreadKey: string | null;
   internalNumber: string | null;
   submittedBy: string | null;
+  requesterContactId: string | null;
   submitterEmail: string | null;
 }
 
@@ -36,6 +37,7 @@ const MATCH_COLS = {
   emailThreadKey: tickets.emailThreadKey,
   internalNumber: tickets.internalNumber,
   submittedBy: tickets.submittedBy,
+  requesterContactId: tickets.requesterContactId,
   submitterEmail: tickets.submitterEmail
 };
 
@@ -53,26 +55,56 @@ export interface SenderResolver {
 }
 
 /**
- * Bind a subject-token (ticket-number) match to the sender (#3643). Ticket numbers
- * are sequential and enumerable and the token path carries no org predicate, so
- * without this ANY authenticated-domain sender could append a public comment to
- * another customer org's ticket (and reopen it). The thread-key path is
- * unguessable and needs no binding.
+ * Bind a SUBJECT-TOKEN (ticket-number) match to the sender (#3643). Ticket numbers
+ * are sequential and enumerable. Partner/org scoping alone is insufficient:
+ * portal ticket reads are requester-scoped, so another authenticated sender in
+ * the same customer organization must not append a public comment or reopen the
+ * requester's ticket.
+ *
+ * SCOPE — this covers the subject-token branch ONLY (the two `senderIsBoundToTicket`
+ * call sites below, in `findTicketInPartner` and `findClosedTicketInPartner`). The
+ * HEADER path — thread key, `tickets.emailMessageId`, and `ticket_email_links` — is
+ * partner-scoped but NOT requester-bound: any DMARC-verified sender who obtains a
+ * `Message-ID`/`In-Reply-To`/`References` value for a partner's ticket can still
+ * append to it. That path's mitigation is (a) those identifiers are high-entropy and
+ * unguessable, so possession normally implies the sender was on the thread, and
+ * (b) the provider sender-authentication gate in
+ * `inboundEmailService.processInboundEmail` (the `n.senderAuth?.verified` check),
+ * which quarantines unverified mail before any match is attempted. Extending the
+ * requester binding to the header path is deliberately out of scope here — it would
+ * break legitimate CC/forward participants who are not the requester.
  */
 export async function senderIsBoundToTicket(
   from: string,
   ticket: MatchedTicket,
   sender: SenderResolver
 ): Promise<boolean> {
-  if (ticket.submitterEmail && ticket.submitterEmail.trim().toLowerCase() === from.trim().toLowerCase()) {
-    return true;
+  const normalizedFrom = from.trim().toLowerCase();
+  const matchesSnapshot = !!ticket.submitterEmail
+    && ticket.submitterEmail.trim().toLowerCase() === normalizedFrom;
+  const pu = await sender.portalUser();
+  if (pu?.orgId === ticket.orgId) {
+    // The immutable email snapshot is authority only while the same address is
+    // still an identity in the ticket's CURRENT organization. This matters
+    // after a privileged cross-org move: submittedBy/submitterEmail preserve
+    // historical attribution, but must not preserve mutation authority.
+    if (matchesSnapshot) return true;
+
+    // A login identifies the requester only when it is the exact submitting
+    // login or it is linked to the exact contact named on the ticket. Mere
+    // membership in the same customer organization is not authority: ticket
+    // numbers are sequential, and portal reads are requester/contact scoped.
+    return pu.id === ticket.submittedBy
+      || (pu.contactId !== null && pu.contactId === ticket.requesterContactId);
   }
 
-  const pu = await sender.portalUser();
-  if (pu && (pu.orgId === ticket.orgId || pu.id === ticket.submittedBy)) return true;
-
-  const dom = await sender.domainOrg();
-  return !!dom && dom.orgId === ticket.orgId;
+  // Email-only tickets have no portal login. Their snapshot remains usable
+  // only while the sender's currently active domain association still names
+  // this organization. A legacy contact-only row with neither a matching
+  // login nor an exact email snapshot therefore fails closed.
+  if (!matchesSnapshot) return false;
+  const domain = await sender.domainOrg();
+  return domain?.orgId === ticket.orgId;
 }
 
 // Candidate threading keys: In-Reply-To + every References entry (a reply's parent
@@ -131,7 +163,7 @@ export async function findTicketInPartner(
   // 2) subject token [T-YYYY-NNNN] (scoped to partner, live tickets only)
   const m = (input.subject ?? '').match(TICKET_TOKEN_RE);
   if (m) {
-    const rows = await db
+    const query = db
       .select(MATCH_COLS)
       .from(tickets)
       .where(and(
@@ -139,8 +171,14 @@ export async function findTicketInPartner(
         ne(tickets.status, 'closed'),
         isNull(tickets.deletedAt),
         eq(tickets.internalNumber, m[0])
-      ))
-      .limit(1);
+      ));
+    // Inbound sender authorization and the eventual append/reopen must
+    // linearize with requester reassignment. The worker holds this transaction
+    // through those writes. Authenticated technician callers omit `sender` and
+    // retain the historical read-only query behavior.
+    const rows = sender
+      ? await query.for('update').limit(1)
+      : await query.limit(1);
     const row = rows[0] as MatchedTicket | undefined;
     if (row) {
       // The token is enumerable, so when the caller is unauthenticated (a sender
@@ -194,7 +232,7 @@ export async function findClosedTicketInPartner(
 
   const m = (input.subject ?? '').match(TICKET_TOKEN_RE);
   if (m) {
-    const rows = await db
+    const query = db
       .select(MATCH_COLS)
       .from(tickets)
       .where(and(
@@ -202,8 +240,10 @@ export async function findClosedTicketInPartner(
         eq(tickets.status, 'closed'),
         isNull(tickets.deletedAt),
         eq(tickets.internalNumber, m[0])
-      ))
-      .limit(1);
+      ));
+    const rows = sender
+      ? await query.for('update').limit(1)
+      : await query.limit(1);
     const row = rows[0] as MatchedTicket | undefined;
     if (row) {
       // The token is enumerable, so when the caller is unauthenticated (a sender

--- a/apps/api/src/services/ticketEventsContract.test.ts
+++ b/apps/api/src/services/ticketEventsContract.test.ts
@@ -160,6 +160,7 @@ vi.mock('./ticketPush', () => ({
   loadTicketPushPrefs: hoisted.loadTicketPushPrefsMock,
   listAnySlaSubscribers: hoisted.listAnySlaSubscribersMock,
   isAuthorisedForTicket: hoisted.isAuthorisedForTicketMock,
+  isEligibleTicketRecipient: vi.fn(async () => true),
   admitPush: hoisted.admitPushMock,
   resolvePushJobs: hoisted.resolvePushJobsMock,
   assertSamePartner: (c: { partnerId: string }, eventPartnerId: string | null) =>

--- a/apps/api/src/services/ticketPush.test.ts
+++ b/apps/api/src/services/ticketPush.test.ts
@@ -29,7 +29,8 @@ vi.mock('../db', () => ({
 
 import { db } from '../db';
 import {
-  admitPush, assertSamePartner, isAuthorisedForTicket, resolvePushJobs, __resetApnsWarnForTests,
+  admitPush, assertSamePartner, isAuthorisedForTicket, isEligibleTicketRecipient,
+  resolvePushJobs, __resetApnsWarnForTests,
 } from './ticketPush';
 import { buildTicketPush } from './expoPush';
 
@@ -57,6 +58,11 @@ describe('assertSamePartner', () => {
 });
 
 describe('isAuthorisedForTicket', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    m.getUserPermissions.mockReset();
+    m.selectRows.mockReset();
+  });
   it('requires tickets:read AND org access', async () => {
     m.getUserPermissions.mockResolvedValueOnce({ scope: 'partner', orgAccess: 'selected', allowedOrgIds: ['o-2'], permissions: [{ resource: 'tickets', action: 'read' }] });
     expect(await isAuthorisedForTicket('u-2', 'p-1', 'o-1')).toBe(false);
@@ -68,6 +74,60 @@ describe('isAuthorisedForTicket', () => {
   it('is false when permissions resolve to null', async () => {
     m.getUserPermissions.mockResolvedValueOnce(null);
     expect(await isAuthorisedForTicket('u-2', 'p-1', 'o-1')).toBe(false);
+  });
+
+  it('requires the current device site to remain inside a restricted org member ceiling', async () => {
+    m.getUserPermissions.mockResolvedValueOnce({
+      scope: 'org', orgId: 'o-1', allowedSiteIds: ['s-allowed'],
+      permissions: [{ resource: 'tickets', action: 'read' }],
+    });
+    m.selectRows.mockResolvedValueOnce([{ orgId: 'o-1', siteId: 's-hidden' }]);
+    expect(await isAuthorisedForTicket('u-2', 'p-1', 'o-1', 'd-1')).toBe(false);
+  });
+
+  it('fails closed for a restricted ticket whose current device is missing or site-null', async () => {
+    for (const rows of [[], [{ orgId: 'o-1', siteId: null }]]) {
+      m.getUserPermissions.mockResolvedValueOnce({
+        scope: 'org', orgId: 'o-1', allowedSiteIds: ['s-allowed'],
+        permissions: [{ resource: 'tickets', action: 'read' }],
+      });
+      m.selectRows.mockResolvedValueOnce(rows);
+      expect(await isAuthorisedForTicket('u-2', 'p-1', 'o-1', 'd-1')).toBe(false);
+    }
+  });
+
+  it('does not read the device for unrestricted or deviceless tickets', async () => {
+    m.getUserPermissions.mockResolvedValue({
+      scope: 'partner', orgAccess: 'all',
+      permissions: [{ resource: 'tickets', action: 'read' }],
+    });
+    expect(await isAuthorisedForTicket('u-2', 'p-1', 'o-1', 'd-1')).toBe(true);
+    expect(await isAuthorisedForTicket('u-2', 'p-1', 'o-1', null)).toBe(true);
+    expect(m.selectRows).not.toHaveBeenCalled();
+  });
+});
+
+describe('isEligibleTicketRecipient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    m.getUserPermissions.mockReset();
+  });
+
+  it('requires an active same-partner recipient before resolving permissions', async () => {
+    const invited = { userId: 'u-2', partnerId: 'p-1', status: 'invited', email: 'u@example.test' };
+    const foreign = { userId: 'u-3', partnerId: 'p-2', status: 'active', email: null };
+    expect(await isEligibleTicketRecipient(invited, 'p-1', 'o-1')).toBe(false);
+    expect(await isEligibleTicketRecipient(foreign, 'p-1', 'o-1')).toBe(false);
+    expect(m.getUserPermissions).not.toHaveBeenCalled();
+  });
+
+  it('admits an active same-partner recipient only through the canonical ticket check', async () => {
+    m.getUserPermissions.mockResolvedValueOnce({
+      scope: 'partner', orgAccess: 'all',
+      permissions: [{ resource: 'tickets', action: 'read' }],
+    });
+    const active = { userId: 'u-2', partnerId: 'p-1', status: 'active', email: null };
+    expect(await isEligibleTicketRecipient(active, 'p-1', 'o-1')).toBe(true);
   });
 });
 

--- a/apps/api/src/services/ticketPush.ts
+++ b/apps/api/src/services/ticketPush.ts
@@ -5,8 +5,9 @@
  * isAuthorisedForTicket) is called by ticketNotifyWorker INSIDE
  * withSystemDbAccessContext, which bypasses RLS. That context is DISCOVERY
  * ONLY. Every recipient is re-authorised (spec D5): same partner as the event,
- * holds tickets:read, and can access the ticket's org; account status gates the
- * PUSH (see the worker) — never the in-app row or the email.
+ * is active, holds tickets:read, can access the ticket's org and, for a
+ * device-bound ticket, can access the device's current site. The worker applies
+ * that predicate before every subject-bearing channel.
  *
  * Push materialisation is deliberately TWO-PHASE so no network round-trip ever
  * happens inside the open fan-out transaction (#1105 class — the shape
@@ -21,10 +22,10 @@
 import { and, asc, eq, inArray } from 'drizzle-orm';
 import { resolveTicketPushPrefs, type TicketPushPreferences } from '@breeze/shared';
 import { db } from '../db';
-import { mobileDevices, ticketPushPreferences, users } from '../db/schema';
+import { devices, mobileDevices, ticketPushPreferences, users } from '../db/schema';
 import { isApnsConfigured } from './apns';
 import { checkNotificationThrottle } from './notificationThrottle';
-import { canAccessOrg, getUserPermissions, hasPermission, PERMISSIONS } from './permissions';
+import { canAccessOrg, canAccessSite, getUserPermissions, hasPermission, PERMISSIONS } from './permissions';
 import { isInQuietHours, type QuietHoursConfig } from './quietHours';
 import { captureException } from './sentry';
 import type { PushSpec, TaggedPushToken } from './expoPush';
@@ -151,14 +152,38 @@ export function assertSamePartner(
 export async function isAuthorisedForTicket(
   userId: string,
   partnerId: string,
-  orgId: string
+  orgId: string,
+  deviceId?: string | null
 ): Promise<boolean> {
   const perms = await getUserPermissions(userId, { partnerId, orgId });
   if (!perms) return false;
-  return (
-    hasPermission(perms, PERMISSIONS.TICKETS_READ.resource, PERMISSIONS.TICKETS_READ.action) &&
-    canAccessOrg(perms, orgId)
-  );
+  if (!hasPermission(perms, PERMISSIONS.TICKETS_READ.resource, PERMISSIONS.TICKETS_READ.action)) return false;
+  if (!canAccessOrg(perms, orgId)) return false;
+
+  // A deviceless ticket is org-wide, matching the HTTP ticket visibility
+  // contract. A device-bound ticket follows the device's CURRENT site. Apply
+  // the same ceiling here because this helper is used from a system-RLS worker.
+  if (!deviceId || perms.allowedSiteIds === undefined) return true;
+  if (perms.allowedSiteIds.length === 0) return false;
+  const rows = await db
+    .select({ orgId: devices.orgId, siteId: devices.siteId })
+    .from(devices)
+    .where(and(eq(devices.id, deviceId), eq(devices.orgId, orgId)))
+    .limit(1);
+  const device = rows[0];
+  return !!device?.siteId && canAccessSite(perms, device.siteId);
+}
+
+/** One canonical eligibility predicate shared by assignment and notification. */
+export async function isEligibleTicketRecipient(
+  candidate: RecipientCandidate,
+  partnerId: string,
+  orgId: string,
+  deviceId?: string | null
+): Promise<boolean> {
+  return candidate.status === 'active' &&
+    candidate.partnerId === partnerId &&
+    isAuthorisedForTicket(candidate.userId, partnerId, orgId, deviceId);
 }
 
 /**

--- a/apps/api/src/services/ticketService.test.ts
+++ b/apps/api/src/services/ticketService.test.ts
@@ -10,7 +10,7 @@ const selectLimitMock = vi.fn();
 // C1 (final review #4191): recorder for tx.delete(ticketDrafts).where(w).
 const txDeleteWhereMock = vi.fn();
 
-const { emitMock, emitTriageFeedbackMock, auditMock, allocateMock, guardMock, dbMocks, configMocks, formMocks, ctxMocks, matchContactMock, assertTicketCreationAllowedMock } = vi.hoisted(() => {
+const { emitMock, emitTriageFeedbackMock, auditMock, allocateMock, guardMock, assigneeEligibleMock, dbMocks, configMocks, formMocks, ctxMocks, matchContactMock, assertTicketCreationAllowedMock } = vi.hoisted(() => {
   const insertReturning = vi.fn();
   const updateReturning = vi.fn();
   const selectResult = vi.fn();
@@ -22,6 +22,7 @@ const { emitMock, emitTriageFeedbackMock, auditMock, allocateMock, guardMock, db
     auditMock: vi.fn().mockResolvedValue(undefined),
     allocateMock: vi.fn().mockResolvedValue('T-2026-0042'),
     guardMock: vi.fn().mockResolvedValue(null),
+    assigneeEligibleMock: vi.fn().mockResolvedValue(true),
     dbMocks: { insertReturning, updateReturning, selectResult, txExecuteMock, txUpdateReturning },
     // #3258 W03 review I6: SPIES, not passthrough arrows. The system-context
     // escape opens a SECOND pooled connection that cannot see the caller's
@@ -58,6 +59,10 @@ const { emitMock, emitTriageFeedbackMock, auditMock, allocateMock, guardMock, db
 });
 
 vi.mock('./ticketEvents', () => ({ emitTicketEvent: emitMock }));
+vi.mock('./ticketPush', async () => {
+  const actual = await vi.importActual<typeof import('./ticketPush')>('./ticketPush');
+  return { ...actual, isEligibleTicketRecipient: assigneeEligibleMock };
+});
 vi.mock('./mlFeedbackEmitters', () => ({ emitTicketTriageFeedback: emitTriageFeedbackMock }));
 vi.mock('./auditService', () => ({ createAuditLogAsync: auditMock }));
 vi.mock('./ticketNumbers', () => ({ allocateInternalTicketNumber: allocateMock }));
@@ -285,6 +290,7 @@ describe('createTicket', () => {
     setMock.mockClear();
     allocateMock.mockResolvedValue('T-2026-0042');
     assertTicketCreationAllowedMock.mockReset().mockResolvedValue(undefined);
+    assigneeEligibleMock.mockResolvedValue(true);
   });
 
   // #5075 W04 — Service Management 'off' withdraws NEW ticket creation. This is
@@ -366,6 +372,26 @@ describe('createTicket', () => {
 
     const insertPayload = valuesMock.mock.calls[0]![0];
     expect(insertPayload).toMatchObject({ status: 'open', assignedTo: 'u-99' });
+  });
+
+  it('rejects an ineligible assignee before number allocation or any write', async () => {
+    dbMocks.selectResult
+      .mockResolvedValueOnce([{ id: 'o-1', partnerId: 'p-1' }])
+      .mockResolvedValueOnce([{ id: 'u-99', partnerId: 'p-1' }]);
+    assigneeEligibleMock.mockResolvedValueOnce(false);
+
+    const err = await createTicket({ orgId: 'o-1', subject: 'Secret subject', source: 'manual', assigneeId: 'u-99' }, actor).catch(e => e);
+    expect(err).toBeInstanceOf(TicketServiceError);
+    expect(err.code).toBe('ASSIGNEE_NOT_ELIGIBLE');
+    expect(assigneeEligibleMock).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'u-99', partnerId: 'p-1' }),
+      'p-1',
+      'o-1',
+      undefined,
+    );
+    expect(allocateMock).not.toHaveBeenCalled();
+    expect(valuesMock).not.toHaveBeenCalled();
+    expect(emitMock).not.toHaveBeenCalled();
   });
 
   it('rejects a deviceId belonging to a different org with a 400 TicketServiceError', async () => {
@@ -1436,6 +1462,7 @@ describe('assignTicket', () => {
     vi.clearAllMocks();
     valuesMock.mockClear();
     setMock.mockClear();
+    assigneeEligibleMock.mockResolvedValue(true);
   });
 
   it('updates assignee, writes an assignment feed entry, emits ticket.assigned', async () => {
@@ -1462,6 +1489,26 @@ describe('assignTicket', () => {
       eventType: 'ticket.assignee_changed',
       dedupeKey: 'assignedTo:null:"u-2"',
     }));
+  });
+
+  it('rejects an ineligible same-partner assignee before ticket mutation or event emission', async () => {
+    dbMocks.selectResult
+      .mockResolvedValueOnce([{ id: 't-1', orgId: 'o-1', partnerId: 'p-1', deviceId: 'd-hidden', status: 'new', assignedTo: null }])
+      .mockResolvedValueOnce([{ id: 'u-2', partnerId: 'p-1' }]);
+    assigneeEligibleMock.mockResolvedValueOnce(false);
+
+    const err = await assignTicket('t-1', 'u-2', actor).catch(e => e);
+    expect(err).toBeInstanceOf(TicketServiceError);
+    expect(err.code).toBe('ASSIGNEE_NOT_ELIGIBLE');
+    expect(assigneeEligibleMock).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'u-2', partnerId: 'p-1' }),
+      'p-1',
+      'o-1',
+      'd-hidden',
+    );
+    expect(setMock).not.toHaveBeenCalled();
+    expect(valuesMock).not.toHaveBeenCalled();
+    expect(emitMock).not.toHaveBeenCalled();
   });
 
   // #3828 wave-6-3 task 2: in-transaction ticket_outbox write, id-only payload.

--- a/apps/api/src/services/ticketService.ts
+++ b/apps/api/src/services/ticketService.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gt, inArray, isNotNull, isNull, ne, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, getTableColumns, gt, inArray, isNotNull, isNull, ne, sql } from 'drizzle-orm';
 import { nanoid } from 'nanoid';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { matchContactByEmail } from './contacts/crud';
@@ -14,6 +14,7 @@ import { applyIntakeForm, getTicketFormForOrg, TicketFormError } from './ticketF
 import { assertTicketMoveCurrencyCompatible, type MoveCurrencyGuardDetails } from './ticketMoveCurrencyGuard';
 import { TICKET_ORG_DENORMALIZED_TABLES } from './ticketOrgMoveLockOrder';
 import { ServiceManagementOffError, assertTicketCreationAllowed } from './serviceManagement';
+import { isEligibleTicketRecipient } from './ticketPush';
 import type { AddinTicketSummary } from '@breeze/shared';
 
 export type TicketStatus = (typeof ticketStatusEnum.enumValues)[number];
@@ -38,6 +39,7 @@ export type TicketServiceErrorStatus = 400 | 403 | 404 | 409 | 500;
 export type TicketServiceErrorCode =
   | 'ASSIGNEE_NOT_FOUND'
   | 'ASSIGNEE_WRONG_PARTNER'
+  | 'ASSIGNEE_NOT_ELIGIBLE'
   | 'REQUESTER_NOT_FOUND'
   | 'REQUESTER_WRONG_ORG'
   // #3258 W03: the requester CONTACT (the canonical person), distinct from the
@@ -163,11 +165,11 @@ async function resolveTicketPartnerId(ticket: { partnerId: string | null; orgId:
  *
  * Exported for the bulk route's request-level pre-validation.
  */
-export async function getAssigneeForValidation(assigneeId: string): Promise<{ id: string; partnerId: string } | null> {
+export async function getAssigneeForValidation(assigneeId: string): Promise<{ id: string; partnerId: string; status?: string; email?: string | null } | null> {
   const rows = await runOutsideDbContext(() =>
     withSystemDbAccessContext(() =>
       db
-        .select({ id: users.id, partnerId: users.partnerId })
+        .select({ id: users.id, partnerId: users.partnerId, status: users.status, email: users.email })
         .from(users)
         .where(eq(users.id, assigneeId))
         .limit(1)
@@ -184,15 +186,35 @@ function throwIfPartnerUnresolvable(partnerId: string | null): asserts partnerId
 
 /**
  * Tenant guard: an assignee must be a user of the same partner as the ticket.
- * users.partner_id is NOT NULL (every user belongs to exactly one MSP), so a
- * same-partner equality check is the complete cross-tenant boundary.
+ * users.partner_id is NOT NULL (every user belongs to exactly one MSP). The
+ * explicit partner comparison preserves the cross-tenant boundary before the
+ * active/read/org/current-site eligibility check below.
  */
-async function assertAssigneeInPartner(assigneeId: string, partnerId: string | null) {
+async function assertAssigneeEligible(
+  assigneeId: string,
+  partnerId: string | null,
+  orgId: string,
+  deviceId?: string | null
+) {
   const assignee = await getAssigneeForValidation(assigneeId);
   if (!assignee) throw new TicketServiceError('Assignee not found', 404, 'ASSIGNEE_NOT_FOUND');
   throwIfPartnerUnresolvable(partnerId);
   if (assignee.partnerId !== partnerId) {
     throw new TicketServiceError('Assignee must belong to the same partner as the ticket', 400, 'ASSIGNEE_WRONG_PARTNER');
+  }
+  const eligible = await isEligibleTicketRecipient(
+    {
+      userId: assignee.id,
+      partnerId: assignee.partnerId,
+      status: assignee.status ?? '',
+      email: assignee.email ?? null,
+    },
+    partnerId,
+    orgId,
+    deviceId
+  );
+  if (!eligible) {
+    throw new TicketServiceError('Assignee is not eligible for this ticket', 400, 'ASSIGNEE_NOT_ELIGIBLE');
   }
 }
 
@@ -561,7 +583,7 @@ export async function createTicket(input: CreateTicketInput, actor: TicketActor)
   }
 
   if (input.assigneeId) {
-    await assertAssigneeInPartner(input.assigneeId, org.partnerId);
+    await assertAssigneeEligible(input.assigneeId, org.partnerId, input.orgId, input.deviceId);
   }
 
   const effectiveCategoryId = input.categoryId ?? intake?.categoryId ?? undefined;
@@ -1361,7 +1383,7 @@ export async function assignTicket(ticketId: string, assigneeId: string | null, 
   const prevAssignedTo = ticket.assignedTo;
 
   if (assigneeId) {
-    await assertAssigneeInPartner(assigneeId, await resolveTicketPartnerId(ticket));
+    await assertAssigneeEligible(assigneeId, await resolveTicketPartnerId(ticket), ticket.orgId, ticket.deviceId);
   }
 
   const patch: Partial<typeof tickets.$inferInsert> = { assignedTo: assigneeId, updatedAt: new Date() };
@@ -2268,7 +2290,20 @@ export async function moveTicketOrg(
   const auditActor = isAgent
     ? { actorType: 'ai_agent' as const, actorId: actor.agentId, initiatedBy: 'ai' as const }
     : { actorId: actor.userId };
-  const ticket = await getTicketOrThrow(ticketId);
+  const snapshots = await db
+    .select({ ...getTableColumns(tickets), rowVersion: sql<string>`${tickets}.xmin::text` })
+    .from(tickets)
+    .where(eq(tickets.id, ticketId))
+    .limit(1);
+  const snapshot = snapshots[0];
+  if (!snapshot) throw new TicketServiceError('Ticket not found', 404);
+  const rowVersion = snapshot.rowVersion;
+  // Keep the service's historical no-op contract: callers receive the exact
+  // ticket object produced by Drizzle.  The xmin value is an internal CAS
+  // token, not part of the public ticket shape, so remove only that projected
+  // helper field instead of cloning every selected column.
+  delete (snapshot as Partial<typeof snapshot>).rowVersion;
+  const ticket = snapshot as typeof tickets.$inferSelect;
   if (ticket.orgId === targetOrgId) return ticket;
 
   let updated: typeof tickets.$inferSelect | undefined;
@@ -2474,8 +2509,15 @@ export async function moveTicketOrg(
     const [row] = await tx
       .update(tickets)
       .set({ orgId: targetOrgId, deviceId: null, requesterContactId: null, updatedAt: new Date() })
-      .where(eq(tickets.id, ticketId))
+      .where(and(
+        eq(tickets.id, ticketId),
+        eq(tickets.orgId, ticket.orgId),
+        sql`${tickets}.xmin::text = ${rowVersion}`,
+      ))
       .returning();
+    if (!row) {
+      throw new TicketServiceError('Ticket changed while the organization move was in progress', 409);
+    }
     updated = row;
     // #4524, reverse direction: ticket_comments has no org_id (child-via-parent
     // tenancy — see the TICKET_ORG_DENORMALIZED_TABLES comment above), so every

--- a/apps/api/src/services/ticketTriage.ts
+++ b/apps/api/src/services/ticketTriage.ts
@@ -1,12 +1,13 @@
-import { and, eq, gte, inArray } from 'drizzle-orm';
+import { and, eq, exists, gte, inArray, isNull, or, sql, type SQL } from 'drizzle-orm';
 import type { TicketPriority } from '@breeze/shared';
 
 import { db } from '../db';
-import { mlFeedbackEvents, ticketCategories, tickets } from '../db/schema';
+import { devices, mlFeedbackEvents, ticketCategories, tickets } from '../db/schema';
 import { resolveMlFeatureFlagForOrg } from './mlFeatureFlags';
 
 const MODEL_VERSION = 'ticket-triage-rules-v0';
 const DAY_MS = 24 * 60 * 60 * 1000;
+const CANONICAL_UUID_PATTERN = '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$';
 
 type TicketRow = typeof tickets.$inferSelect;
 type CategoryRow = Pick<typeof ticketCategories.$inferSelect, 'id' | 'name' | 'defaultPriority'>;
@@ -28,6 +29,12 @@ export interface TicketTriageSuggestionResult {
 
 export interface TicketTriageEvaluationInput {
   orgIds?: string[];
+  /**
+   * Undefined means the caller is not site-restricted. A defined array is a
+   * hard site ceiling; an empty array retains only deviceless, org-wide ticket
+   * feedback. The route copies this value from AuthContext.
+   */
+  allowedSiteIds?: readonly string[];
   labelWindowDays?: number;
 }
 
@@ -212,6 +219,49 @@ export async function evaluateTicketTriage(input: TicketTriageEvaluationInput = 
   ];
   if (input.orgIds && input.orgIds.length > 0) {
     conditions.push(inArray(mlFeedbackEvents.orgId, input.orgIds));
+  }
+  if (input.allowedSiteIds) {
+    const sourceTicketConditions: SQL[] = [
+      // source_id is varchar because the shared feedback table supports
+      // non-UUID source types. A guarded cast makes malformed ticket sources
+      // fail closed without throwing while retaining the tickets PK lookup.
+      sql`${tickets.id} = CASE
+        WHEN ${mlFeedbackEvents.sourceId} ~* ${CANONICAL_UUID_PATTERN}
+        THEN ${mlFeedbackEvents.sourceId}::uuid
+        ELSE NULL
+      END`,
+      eq(tickets.orgId, mlFeedbackEvents.orgId),
+      // Soft-deleted tickets are hidden from every staff list/detail path and
+      // must not remain inferable through this aggregate.
+      isNull(tickets.deletedAt),
+    ];
+
+    const allowed = input.allowedSiteIds;
+    if (allowed.length === 0) {
+      sourceTicketConditions.push(isNull(tickets.deviceId));
+    } else {
+      sourceTicketConditions.push(or(
+        // Deviceless tickets are org-wide, matching ticket list/stats scope.
+        isNull(tickets.deviceId),
+        inArray(
+          tickets.deviceId,
+          db
+            .select({ id: devices.id })
+            .from(devices)
+            .where(and(
+              eq(devices.orgId, tickets.orgId),
+              inArray(devices.siteId, allowed),
+            )),
+        ),
+      )!);
+    }
+
+    conditions.push(exists(
+      db
+        .select({ id: tickets.id })
+        .from(tickets)
+        .where(and(...sourceTicketConditions)),
+    ));
   }
 
   const rows = await db

--- a/apps/portal/src/components/portal/TicketDetails.test.tsx
+++ b/apps/portal/src/components/portal/TicketDetails.test.tsx
@@ -123,6 +123,67 @@ describe('TicketDetails — who wrote it', () => {
     expect(byAuthor.team).toContain('Your IT team');
     expect(byAuthor.portal).not.toContain('Your IT team');
   });
+
+  it('labels an email-authored reply from a resolved portal sender as customer email', () => {
+    render(<TicketDetails ticket={ticket({
+      comments: [{
+        id: 'c-email',
+        authorName: 'Maya',
+        authorType: 'email',
+        senderPortalUserId: 'pu-maya',
+        content: 'Reply sent by email',
+        createdAt: '2026-08-03T00:00:00Z',
+      }],
+    })} />);
+
+    const item = screen.getByTestId('ticket-comment').textContent ?? '';
+    expect(item).toContain('Customer email');
+    expect(item).not.toContain('Your IT team');
+  });
+
+  /**
+   * The other direction. A technician's own reply linked through the Outlook
+   * add-in is inserted by insertEmailAuthoredComment (emailComments.ts), which
+   * hardcodes author_type 'email' and leaves portal_user_id null. Keying the
+   * badge on author_type alone showed the customer their IT team's reply as
+   * "Customer email" — the inverse of the impersonation this label exists to
+   * stop.
+   */
+  it('labels an add-in linked technician reply (author_type email, no sender) as the IT team', () => {
+    render(<TicketDetails ticket={ticket({
+      comments: [{
+        id: 'c-addin',
+        authorName: 'Tech',
+        authorType: 'email',
+        senderPortalUserId: null,
+        content: 'Linked from Outlook',
+        createdAt: '2026-08-03T00:00:00Z',
+      }],
+    })} />);
+
+    const item = screen.getByTestId('ticket-comment').textContent ?? '';
+    expect(item).toContain('Your IT team');
+    expect(item).not.toContain('Customer email');
+  });
+
+  // A portal-authored reply carries portal_user_id too; the customer's own
+  // reply must stay unlabelled rather than picking up the email badge.
+  it('leaves a portal reply unlabelled even though it carries a portal sender id', () => {
+    render(<TicketDetails ticket={ticket({
+      comments: [{
+        id: 'c-portal',
+        authorName: 'Maya',
+        authorType: 'portal',
+        senderPortalUserId: 'pu-maya',
+        content: 'Typed in the portal',
+        createdAt: '2026-08-03T00:00:00Z',
+      }],
+    })} />);
+
+    const item = screen.getByTestId('ticket-comment').textContent ?? '';
+    expect(item).not.toContain('Customer email');
+    expect(item).not.toContain('Your IT team');
+  });
 });
 
 describe('ReplyComposer — draft survives a dead session', () => {

--- a/apps/portal/src/components/portal/TicketDetails.tsx
+++ b/apps/portal/src/components/portal/TicketDetails.tsx
@@ -316,12 +316,23 @@ export function TicketDetails({ ticket, error, statusCode }: TicketDetailsProps)
 
         {replies.length > 0 && (
           <ol className="mt-4 divide-y divide-border/70 border-y border-border/70">
-            {replies.map((c) => (
+            {replies.map((c) => {
+              // An email-authored comment is the CUSTOMER's only when the
+              // inbound sender resolved to a portal login. A technician's own
+              // reply linked through the Outlook add-in is stored with the same
+              // author_type 'email' and no sender, so keying this badge on
+              // author_type alone showed the customer their IT team's reply
+              // labelled "Customer email".
+              const isCustomerEmail = c.authorType === 'email' && c.senderPortalUserId != null;
+              return (
               <li key={c.id} className="py-4" data-testid="ticket-comment">
                 <div className="flex flex-wrap items-baseline justify-between gap-2">
                   <span className="text-sm font-semibold text-foreground">
                     {c.authorName || 'Support'}
-                    {c.authorType !== 'portal' && (
+                    {isCustomerEmail && (
+                      <span className="ml-1.5 text-xs font-medium text-muted-foreground">Customer email</span>
+                    )}
+                    {c.authorType !== 'portal' && !isCustomerEmail && (
                       <span className="ml-1.5 text-xs font-medium text-muted-foreground">Your IT team</span>
                     )}
                   </span>
@@ -332,7 +343,8 @@ export function TicketDetails({ ticket, error, statusCode }: TicketDetailsProps)
                 </div>
                 <CommentAttachments ticketId={ticket.id} attachments={c.attachments} />
               </li>
-            ))}
+              );
+            })}
           </ol>
         )}
 

--- a/apps/portal/src/lib/api.ts
+++ b/apps/portal/src/lib/api.ts
@@ -351,8 +351,15 @@ export interface TicketCommentAttachment {
 export interface TicketComment {
   id: string;
   authorName: string;
-  /** 'portal' is the customer's own reply; anything else came from the IT team. */
+  /** 'portal' is the customer's own reply; 'email' is any email-authored comment. */
   authorType: string | null;
+  /**
+   * The portal login the inbound email resolved to, or null. `authorType` alone
+   * cannot tell a customer's emailed reply from a technician's own reply linked
+   * through the Outlook add-in — both are stored as 'email'. A non-null sender
+   * on an 'email' comment is the only signal that the CUSTOMER wrote it.
+   */
+  senderPortalUserId?: string | null;
   content: string;
   createdAt: string;
   /** Absent on a reply the customer just posted locally. */


### PR DESCRIPTION
## Summary

Three ticketing security findings from the private remediation program, ported onto current main.

### SEC-2026-09-05-104 (Medium) — ticket assignee eligibility was never checked

`assertAssigneeInPartner` only compared `users.partner_id`, so any same-partner user could be
assigned a ticket for an org or a device site they cannot see — and the notification worker then
delivered the ticket subject to them over four channels. The worker also trusted the queued event
snapshot (`event.orgId`, `event.payload.subject`, `event.payload.assigneeId`), so a stale or
superseded assignment still notified the old recipient.

The fix introduces one canonical predicate, `isEligibleTicketRecipient` (`services/ticketPush.ts`):
active account, same partner as the ticket, holds `tickets:read`, can access the ticket org, and —
for a device-bound ticket — can access the device's **current** site. An empty site ceiling and a
missing/foreign/null-site device fail closed. `createTicket` and `assignTicket` call it after the
same-partner check and **before** number allocation, ticket mutation and event emission
(`ASSIGNEE_NOT_ELIGIBLE`, 400). `ticketNotifyWorker` rereads the current ticket and uses its current
org, subject, device and assignment, then applies the same predicate before the inbox row and before
collecting email/push work; SLA-owner delivery is governed by the same check, and slaScope now gates
only the phone (as before) *after* eligibility rather than instead of it.

### SEC-2026-09-05-153 (Medium) — inbound subject-token replies were not bound to the requester

`T-YYYY-NNNN` subject tokens are sequential and enumerable. `senderIsBoundToTicket` accepted any
portal login **in the same organization**, or any mapped-domain sender in that organization. Portal
ticket reads are requester-scoped, so this let one customer contact append a public comment to — and
reopen — another contact's ticket. The portal then rendered every non-portal author as "Your IT team",
turning it into durable staff impersonation.

The fix requires the sender to be the ticket's exact requester: a portal login must currently belong
to the ticket organization and be the exact `submittedBy` login or be linked to the exact
`requesterContactId`; an email-only ticket may use the preserved `submitterEmail` snapshot only while
the sender's active domain association still names the ticket's **current** organization. Legacy
contact-only rows with neither an exact login nor an email snapshot fail closed. High-entropy
thread-header matching and authenticated technician matching (no `sender` resolver) are unchanged.

Race binding: the subject-matched row is taken `FOR UPDATE` and held through authorization, comment
insertion and reopen/continuation; the authorized append stamps `tickets.updated_at` while holding
that lock; and `moveTicketOrg` now updates under an exact source-org predicate plus an `xmin`
compare-and-set (409 on loss). A move that commits first forces the sender to satisfy the target
org's live relationship; an inbound sink that wins makes the stale move fail rather than carrying a
source-authorized comment into the target org. Email-authored comments are explicitly typed `email`
and the portal labels them "Customer email".

### SEC-2026-09-05-022 (Low) — ticket triage aggregates ignored the site axis

`GET /tickets/triage-evaluation` validated org access but queried `ml_feedback_events` with no
device/site correlation, so a site-restricted reader received organization-wide acceptance and
override counts that included hidden-site tickets. RLS cannot enforce this — the shared feedback
table has no device or site column. Aggregate-only, never crossing the org boundary, hence Low.

The route now propagates the authenticated tri-state site ceiling (`undefined` = unrestricted, `[]` =
defined zero-device ceiling, populated = selected sites) into `evaluateTicketTriage`, which for any
defined ceiling adds an `EXISTS` correlation to the current, non-deleted source ticket and that
ticket's current device site (exact org equality on both). A guarded canonical-UUID cast keeps
malformed legacy `source_id` values from throwing; missing, stale, malformed and soft-deleted sources
fail closed. Deviceless tickets stay org-wide, matching ticket list/stats semantics. Unrestricted
callers are byte-for-byte unchanged.

## Ported from

Local commits in the private remediation worktrees, cherry-picked with `-x` in this order and squashed:

- `27c0ee77fb7972f69152849a5cdfa26fd1ca7f95` — SEC-104
- `bfce8416dc6eafef749c8120248df4578065e063` — SEC-153
- `12b0201c88dae82bf11e87fbf73404d98e482678`, `81ac54754ffb96cb84cbb81e7683b620a9eb84ef`,
  `91c5511d1e19377eb2e177cfa43b0cfb7552593b` — SEC-022 (red test / repair / terminal regression)

Changed vs the originals because main moved (org contacts #3258, org record page #5075, portal
visibility #4562):

- `services/ticketService.ts` import block: kept main's `ServiceManagementOffError /
  assertTicketCreationAllowed` import alongside the new `isEligibleTicketRecipient` import.
- `services/ticketService.test.ts`: merged the hoisted-mock destructuring so `assigneeEligibleMock`
  and main's `assertTicketCreationAllowedMock` coexist, and kept main's whole "Service Management
  gate (#5075 W04)" describe block, adding `assigneeEligibleMock.mockResolvedValue(true)` to the
  shared `beforeEach` rather than replacing main's reset.
- `moveTicketOrg`: kept main's AI-agent actor handling (`isAgent` / `userId` / `auditActor`) and
  replaced only the `getTicketOrThrow` fetch with the `xmin` snapshot select. The CAS `WHERE`
  (`id` + source `org_id` + `xmin`) applied to main's update unchanged.

Nothing was dropped as already-on-main; no migration is involved in any of the three findings.

## Review round (applied on this branch)

Review returned SHIP-WITH-FIXES, no blockers. Three fixes applied:

1. **The "Customer email" badge mislabelled the IT team's own replies.** It keyed on
   `authorType === 'email'`, but a technician's reply linked through the Outlook add-in
   (`routes/officeAddin/tickets.ts` → `insertEmailAuthoredComment`, which hardcodes
   `author_type 'email'`) is stored identically. The customer was shown their IT team's reply as
   their own — the inverse of the impersonation this label exists to stop. The badge now keys on
   `authorType === 'email' && senderPortalUserId != null`; `senderPortalUserId`
   (`ticket_comments.portal_user_id`) was added to both portal comment projections
   (`routes/portal/tickets.ts`: the GET comments query and the POST `.returning()`), and the
   "Your IT team" branch is the complement, so an add-in reply keeps the label it had on main.
   Three portal component tests cover both directions plus the portal-authored case (a portal reply
   also carries `portal_user_id` and must stay unlabelled), and one API route test guards the
   projection — that suite's insert mock projects the real `.returning()` selection, so dropping the
   column reds it.
2. **`threadMatcher.senderIsBoundToTicket`'s docstring overclaimed.** It read as if the requester
   binding covered every match path. It covers the **subject-token** path only. The header path
   (thread key ∪ `tickets.emailMessageId` ∪ `ticket_email_links`) is partner-scoped but not
   requester-bound; its mitigation is the high entropy of those identifiers plus the provider
   sender-authentication gate in `processInboundEmail`. The docstring now says exactly that, and the
   residual is recorded under Follow-ups. Extending the binding to the header path is deliberately
   **not** done here — it would break legitimate CC/forward participants who are not the requester.
3. **The worker re-implemented the eligibility predicate inline** at three call sites rather than
   calling it, so "one canonical predicate" was not actually true. All three now call
   `isEligibleTicketRecipient`. `assertSamePartner` is retained alongside it for its telemetry only
   — a partner mismatch there is a forged/moved user and must raise Sentry, not merely be refused.
   The two worker suites mock `../db`, so the real predicate cannot execute in them; each gained a
   seam that delegates the predicate's permission arm to the `isAuthorisedForTicket` mock the suite
   already steers, keeping every existing knob and assertion meaningful. The predicate's own
   contract is proven against real code in `services/ticketPush.test.ts` and end-to-end against
   Postgres in `ticketPushFanout.integration.test.ts`.

## Verification

All commands run from `/Users/toddhebebrand/breeze-worktrees/sec-port-ticketing` against a private
ephemeral pg+redis stack (`pnpm test-stack up`). Every count below is **verified** (observed output),
not inferred.

**Red-first (mandatory).** With the fix's test files in place, main's versions of all eight non-test
source files were restored and the ported tests re-run:

```
git checkout origin/main -- apps/api/src/jobs/ticketNotifyWorker.ts \
  apps/api/src/routes/tickets/tickets.ts \
  apps/api/src/services/inboundEmail/inboundEmailService.ts \
  apps/api/src/services/inboundEmail/threadMatcher.ts \
  apps/api/src/services/ticketPush.ts apps/api/src/services/ticketService.ts \
  apps/api/src/services/ticketTriage.ts \
  apps/portal/src/components/portal/TicketDetails.tsx
cd apps/api && npx vitest run --pool=threads --maxWorkers=2 \
  src/services/ticket src/routes/tickets src/jobs/ticketNotifyWorker src/services/inboundEmail
#  -> Test Files  5 failed | 43 passed (48)
#  -> Tests      19 failed | 1020 passed (1039)
cd apps/portal && npx vitest run src/components/portal/TicketDetails
#  -> Test Files  1 failed (1)   ("labels an email-authored reply as customer email rather than the IT team")
git checkout HEAD -- apps/api/src apps/portal/src   # then both suites pass, see below
```

The 20 red tests span all three findings: assignee-eligibility rejection in `createTicket` /
`assignTicket`; the worker's inbox/email/push/SLA suppression for inactive, missing-read,
foreign-org, empty-ceiling and moved-device recipients and for stale assignments; the four
subject-token binding controls (requester ALLOWED; different portal user, mapped-domain sender and
post-move email snapshot all DENIED); the site-ceiling propagation on
`GET /tickets/triage-evaluation`; `isAuthorisedForTicket`'s current-device-site cases; and the
portal comment projection carrying `senderPortalUserId`.

**Green.**

| Command | Result |
|---|---|
| `cd apps/api && npx vitest run --pool=threads --maxWorkers=2 src/services/ticket src/routes/tickets src/routes/portal src/jobs/ticketNotifyWorker src/services/inboundEmail` | 68 files / **1333 passed** |
| `cd apps/api && npx vitest run --config vitest.integration.config.ts --pool=threads --maxWorkers=2 ticket Ticket inboundEmail SiteScope portal` | 53 files / **267 passed** |
| `cd apps/api && npx vitest run --config vitest.config.site-scope-coverage.ts --pool=threads --maxWorkers=2` | 1 file / **7 passed** |
| `cd apps/api && npx vitest run --config vitest.config.integration-suite-coverage.ts --pool=threads --maxWorkers=2` | 1 file / **5 passed** |
| `cd apps/api && NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit` | clean |
| `cd apps/api && npx eslint <15 touched files>` and `cd apps/portal && npx eslint <3 touched files>` | clean |
| `cd apps/portal && npx vitest run src/components/portal/TicketDetails` | 1 file / **23 passed** |
| `cd apps/portal && npx tsc --noEmit` | clean |

The integration selection covers both ported integration suites (`ticket-validation-rls`,
`ticketPushFanout`, `inboundEmail`, plus the new `ticketTriageSiteScope`) and the whole ticket /
inbound-email / site-scope family, run as unprivileged `breeze_app` through the request path.

**Not checked:** no migration or schema column changed, so the migration/RLS-coverage/cascade/export
contract suites were not run (`bash scripts/check-migration-naming.sh` did run via the pre-commit
hook: OK). No browser E2E, no real email/APNs/Expo provider, no load or multi-replica test. No
full-API-corpus run on this branch; CI's four integration shards are the backstop.

## Operator impact

- **Assignment can now fail where it previously succeeded** (400 `ASSIGNEE_NOT_ELIGIBLE`) when the
  target technician is inactive, lacks `tickets:read`, cannot access the ticket's org, or is
  site-restricted away from the ticket device's current site. This is the intended boundary; if a
  tech legitimately needs the ticket, widen their org/site scope or grant `tickets:read`.
- **Existing assignments that no longer satisfy the predicate stop generating notifications.** The
  worker suppresses them; it does not clear or reassign them. Reconciling stale assignments is
  operational follow-up.
- **Invited (not-yet-onboarded) technicians no longer receive the assignment inbox row or email.**
  On main, account status gated only the push, deliberately: an invited tech assigned a ticket still
  got told. That is now a full suppression, and the suppression is kept on purpose —
  `isEligibleTicketRecipient` rejects an invited user at *assignment* time (400
  `ASSIGNEE_NOT_ELIGIBLE`), so the notification path can only encounter one through a **pre-existing**
  invited assignment made before this change. Those go quiet rather than emailing a ticket subject to
  an account that has not completed onboarding. New assignments fail loudly at the API instead.
- **Inbound replies by subject token from a non-requester in the same org are now refused** and fall
  through to the normal new-ticket/unmatched handling. Thread-header (In-Reply-To/References) replies
  are unaffected, which is the path ordinary mail clients use.
- **A cross-org ticket move can now return 409** ("Ticket changed while the organization move was in
  progress") when an inbound email commits against the same row concurrently. Retry the move.
- **Triage-evaluation counts drop for site-restricted readers** — they now reflect only tickets that
  reader can actually see. Unrestricted org/partner callers see identical numbers to before.
- The portal now shows "Customer email" beside a customer's emailed reply (a technician's add-in
  linked reply still reads "Your IT team").
- **Behaviour change:** every authorized inbound append now bumps `tickets.updated_at`
  (`inboundEmailService.ts`, the move fence described above). Anything sorting or filtering tickets
  by last-updated will now surface a ticket on an inbound email that previously left the timestamp
  alone.
- No migration, no schema change, no new env var, no config toggle.

## Follow-ups (not fixed here)

- **`tickets.partner_id` can diverge from its organization's partner.** A system-scope cross-partner
  device move (`routes/devices/moveOrg.ts`) restamps `org_id` on the denormalized tables but not
  `partner_id`, and there is no composite FK holding the two together. Both predicates added in this
  PR trust a non-null `tickets.partner_id`. A divergent value causes **fail-closed** delivery loss,
  not a leak, but it is a data-integrity premise rather than an enforced invariant. Fix: restamp
  `partner_id` in the move loop and add a composite FK `(org_id, partner_id) → organizations(id,
  partner_id)` in a migration. Historical detection/repair was not attempted.
- **An assignee is never re-validated after the ticket changes underneath them.** `moveTicketOrg`
  keeps `assignedTo`; an org merge (`orgMergeRegistry.ts`) keeps it; and a `device_id` change
  (`updateTicketFields`, or the AI `link_device` tool) can move a ticket under a site the assignee
  cannot see. The worker's re-check contains this to a **dangling assignment record** — the person
  stops being notified — rather than a disclosure, which is why it is a follow-up and not part of
  this fix. Proper handling is to clear or re-validate the assignment at each of those mutation
  points.
- **The inbound header match path is not requester-bound** (see Review round item 2). Its mitigation
  is identifier entropy plus the DMARC/provider sender-authentication gate. Binding it would need a
  participant model (CC/forward recipients are legitimately not the requester), which is a design
  change rather than a patch.

## Residual exposure carried over from the private records

- Assignment validation and worker reauthorization are separate transactions; authority can still
  change in the check-to-use window before an inbox insert or external delivery. A delivery already
  handed to a transport cannot be recalled.
- Partner-wide `slaScope = any` discovery remains deterministically capped at 500 recipients
  (bounded availability, warned, not an authorization bypass).
- The worker trusts a ticket's non-null `partner_id` and only derives it from the organization when
  null; a corrupt non-null partner causes fail-closed delivery loss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Tugfg88kFiowD7E5xQFpU
