### PR TITLE
fix(logs): anchor agent-log retention and read windows to server receipt time (SEC-117)

### DIFF
--- a/apps/api/migrations/2026-10-15-160130-agent-log-receipt-time-indexes.sql
+++ b/apps/api/migrations/2026-10-15-160130-agent-log-receipt-time-indexes.sql
@@ -1,0 +1,63 @@
+-- @no-transaction
+-- Receipt time is the authoritative retention/default-recency clock for agent
+-- diagnostic logs. Keep the existing event-time indexes: explicit event-time
+-- investigations and incident RCA still use agent_logs.timestamp.
+--
+-- agent_logs is a hot agent-write table, so build these online. Each statement
+-- is independently idempotent for autoMigrate's no-transaction retry lane. An
+-- interrupted concurrent build can leave an INVALID index that IF NOT EXISTS
+-- would otherwise silently retain, so the final block fails loudly. Recovery:
+-- DROP INDEX CONCURRENTLY <invalid name>, then re-apply this migration.
+--
+-- OPERATOR NOTE -- BUILD THESE BY HAND BEFORE THE RELEASE ROLLS ON EU/US.
+-- CONCURRENTLY does not block agent writes (ShareUpdateExclusiveLock), but it
+-- IS a two-pass scan that waits on older transactions, and autoMigrate runs
+-- inside initializeDatabaseForStartup, which index.ts awaits BEFORE serve().
+-- So on a multi-million-row agent_logs the API does not accept traffic until
+-- all three builds finish, and a boot killed mid-build leaves an INVALID index
+-- that makes the DO block below abort every subsequent boot -- a crash loop
+-- until an operator runs DROP INDEX CONCURRENTLY. Run these three statements
+-- against the live database first (psql, any time, no downtime); IF NOT EXISTS
+-- then makes this migration instant when the release deploys:
+--
+--   CREATE INDEX CONCURRENTLY IF NOT EXISTS agent_logs_created_at_idx
+--     ON agent_logs (created_at);
+--   CREATE INDEX CONCURRENTLY IF NOT EXISTS agent_logs_device_created_at_idx
+--     ON agent_logs (device_id, created_at DESC, id DESC);
+--   CREATE INDEX CONCURRENTLY IF NOT EXISTS agent_logs_org_created_at_idx
+--     ON agent_logs (org_id, created_at DESC, id DESC);
+--
+-- Then confirm all three report indisvalid = true before deploying.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS agent_logs_created_at_idx
+  ON agent_logs (created_at);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS agent_logs_device_created_at_idx
+  ON agent_logs (device_id, created_at DESC, id DESC);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS agent_logs_org_created_at_idx
+  ON agent_logs (org_id, created_at DESC, id DESC);
+
+DO $$
+DECLARE
+  bad text;
+BEGIN
+  SELECT string_agg(c.relname, ', ')
+    INTO bad
+    FROM (VALUES
+      ('public.agent_logs'::regclass, 'agent_logs_created_at_idx'),
+      ('public.agent_logs'::regclass, 'agent_logs_device_created_at_idx'),
+      ('public.agent_logs'::regclass, 'agent_logs_org_created_at_idx')
+    ) AS expected(tbl, idx)
+    JOIN pg_class c
+      ON c.relname = expected.idx
+     AND c.relnamespace = 'public'::regnamespace
+    JOIN pg_index i
+      ON i.indexrelid = c.oid
+     AND i.indrelid = expected.tbl
+   WHERE NOT i.indisvalid;
+
+  IF bad IS NOT NULL THEN
+    RAISE EXCEPTION 'agent-log receipt-time index build left INVALID index(es): % — DROP INDEX CONCURRENTLY each and re-apply this migration', bad;
+  END IF;
+END $$;

--- a/apps/api/src/__tests__/integration/agentLogReceiptTime.integration.test.ts
+++ b/apps/api/src/__tests__/integration/agentLogReceiptTime.integration.test.ts
@@ -1,0 +1,202 @@
+import './setup';
+import { randomUUID } from 'node:crypto';
+import { Hono } from 'hono';
+import { and, eq, inArray, sql } from 'drizzle-orm';
+import { describe, expect, it } from 'vitest';
+import { agentLogs, devices } from '../../db/schema';
+import { diagnosticLogsRoutes } from '../../routes/devices/diagnosticLogs';
+import { watchdogLogsRoutes } from '../../routes/devices/watchdogLogs';
+import { __testOnly as retentionTestOnly } from '../../jobs/agentLogRetention';
+import { getTestDb } from './setup';
+import { setupTestEnvironment } from './db-utils';
+
+async function insertDevice(orgId: string, siteId: string, suffix: string) {
+  const [device] = await getTestDb().insert(devices).values({
+    orgId,
+    siteId,
+    agentId: `receipt-${suffix}-${randomUUID()}`.slice(0, 64),
+    hostname: `receipt-${suffix}`,
+    osType: 'linux',
+    osVersion: 'test',
+    architecture: 'x64',
+    agentVersion: 'test',
+  }).returning({ id: devices.id });
+  return device!;
+}
+
+describe('agent log receipt-time boundary', () => {
+  it('orders HTTP readers by receipt, keeps explicit event-time filters, and denies cross-org detail', async () => {
+    const own = await setupTestEnvironment({
+      rolePermissions: [{ resource: 'devices', action: 'read' }],
+    });
+    const foreign = await setupTestEnvironment({
+      rolePermissions: [{ resource: 'devices', action: 'read' }],
+    });
+    const ownDevice = await insertDevice(own.organization.id, own.site.id, 'own');
+    const foreignDevice = await insertDevice(foreign.organization.id, foreign.site.id, 'foreign');
+    const historicalFutureId = randomUUID();
+    const newestReceiptId = randomUUID();
+
+    await getTestDb().insert(agentLogs).values([
+      {
+        id: historicalFutureId,
+        deviceId: ownDevice.id,
+        orgId: own.organization.id,
+        timestamp: new Date('2099-01-01T00:00:00.000Z'),
+        createdAt: new Date('2026-05-01T00:00:00.000Z'),
+        level: 'warn',
+        component: 'watchdog.clock',
+        message: 'historical future event time',
+      },
+      {
+        id: newestReceiptId,
+        deviceId: ownDevice.id,
+        orgId: own.organization.id,
+        timestamp: new Date('2026-05-01T00:00:00.000Z'),
+        createdAt: new Date('2026-05-02T00:00:00.000Z'),
+        level: 'warn',
+        component: 'watchdog.current',
+        message: 'newest receipt',
+      },
+    ]);
+
+    const app = new Hono();
+    app.route('/devices', diagnosticLogsRoutes);
+    app.route('/devices', watchdogLogsRoutes);
+    const headers = { Authorization: `Bearer ${own.token}` };
+
+    for (const suffix of ['diagnostic-logs', 'watchdog-logs']) {
+      const response = await app.request(`/devices/${ownDevice.id}/${suffix}`, { headers });
+      expect(response.status).toBe(200);
+      const body = await response.json() as { logs: Array<{ id: string }> };
+      expect(body.logs.map((row) => row.id)).toEqual([newestReceiptId, historicalFutureId]);
+    }
+
+    const eventTimeResponse = await app.request(
+      `/devices/${ownDevice.id}/diagnostic-logs?since=2098-01-01T00:00:00.000Z`,
+      { headers },
+    );
+    expect(eventTimeResponse.status).toBe(200);
+    expect((await eventTimeResponse.json() as { logs: Array<{ id: string }> }).logs.map((row) => row.id))
+      .toEqual([historicalFutureId]);
+
+    const denied = await app.request(`/devices/${foreignDevice.id}/diagnostic-logs`, { headers });
+    expect(denied.status).toBe(404);
+  });
+
+  it('breaks ties inside one receipt instant by event time, not by random uuid', async () => {
+    // Ingest writes up to 100 rows per INSERT, so a whole batch lands on the
+    // same created_at to the microsecond. Without the event-time tie-break the
+    // random uuid id decides the order and each batch reads back shuffled.
+    const env = await setupTestEnvironment({
+      rolePermissions: [{ resource: 'devices', action: 'read' }],
+    });
+    const device = await insertDevice(env.organization.id, env.site.id, 'tie');
+    const sharedReceipt = new Date('2026-06-01T00:00:00.000Z');
+    // Ids chosen so ascending id order is the OPPOSITE of the expected order:
+    // an id-only tie-break returns [olderEvent, newerEvent] and fails below.
+    const newerEventId = '00000000-0000-4000-8000-00000000000a';
+    const olderEventId = '11111111-1111-4111-8111-11111111111b';
+
+    await getTestDb().insert(agentLogs).values([
+      {
+        id: newerEventId,
+        deviceId: device.id,
+        orgId: env.organization.id,
+        timestamp: new Date('2026-06-01T00:00:09.000Z'),
+        createdAt: sharedReceipt,
+        level: 'info',
+        component: 'watchdog.tie',
+        message: 'second event in the batch',
+      },
+      {
+        id: olderEventId,
+        deviceId: device.id,
+        orgId: env.organization.id,
+        timestamp: new Date('2026-06-01T00:00:01.000Z'),
+        createdAt: sharedReceipt,
+        level: 'info',
+        component: 'watchdog.tie',
+        message: 'first event in the batch',
+      },
+    ]);
+
+    const app = new Hono();
+    app.route('/devices', diagnosticLogsRoutes);
+    app.route('/devices', watchdogLogsRoutes);
+    const headers = { Authorization: `Bearer ${env.token}` };
+
+    for (const suffix of ['diagnostic-logs', 'watchdog-logs']) {
+      const response = await app.request(`/devices/${device.id}/${suffix}`, { headers });
+      expect(response.status).toBe(200);
+      const body = await response.json() as { logs: Array<{ id: string }> };
+      expect(body.logs.map((row) => row.id)).toEqual([newerEventId, olderEventId]);
+    }
+  });
+
+  it('prunes by receipt time and installs the online receipt query indexes', async () => {
+    const env = await setupTestEnvironment();
+    const device = await insertDevice(env.organization.id, env.site.id, 'retention');
+    const oldReceiptFutureEvent = randomUUID();
+    const freshReceiptPastEvent = randomUUID();
+    const now = Date.now();
+
+    await getTestDb().insert(agentLogs).values([
+      {
+        id: oldReceiptFutureEvent,
+        deviceId: device.id,
+        orgId: env.organization.id,
+        timestamp: new Date('2099-01-01T00:00:00.000Z'),
+        createdAt: new Date(now - 8 * 86_400_000),
+        level: 'info',
+        component: 'receipt.retention',
+        message: 'old receipt, future event',
+      },
+      {
+        id: freshReceiptPastEvent,
+        deviceId: device.id,
+        orgId: env.organization.id,
+        timestamp: new Date('2000-01-01T00:00:00.000Z'),
+        createdAt: new Date(now),
+        level: 'info',
+        component: 'receipt.retention',
+        message: 'fresh receipt, old event',
+      },
+    ]);
+
+    const result = await retentionTestOnly.pruneAgentLogsByReceiptTime({
+      cutoff: new Date(now - 7 * 86_400_000).toISOString(),
+      batchSize: 10,
+      maxBatches: 2,
+    });
+    expect(result.deleted).toBe(1);
+
+    const remaining = await getTestDb()
+      .select({ id: agentLogs.id })
+      .from(agentLogs)
+      .where(and(eq(agentLogs.orgId, env.organization.id), inArray(agentLogs.id, [oldReceiptFutureEvent, freshReceiptPastEvent])));
+    expect(remaining).toEqual([{ id: freshReceiptPastEvent }]);
+
+    const indexes = await getTestDb().execute(sql`
+      SELECT indexname, indexdef
+      FROM pg_indexes
+      WHERE schemaname = 'public'
+        AND tablename = 'agent_logs'
+        AND indexname IN (
+          'agent_logs_created_at_idx',
+          'agent_logs_device_created_at_idx',
+          'agent_logs_org_created_at_idx'
+        )
+      ORDER BY indexname
+    `) as unknown as Array<{ indexname: string; indexdef: string }>;
+    expect(indexes.map((row) => row.indexname)).toEqual([
+      'agent_logs_created_at_idx',
+      'agent_logs_device_created_at_idx',
+      'agent_logs_org_created_at_idx',
+    ]);
+    expect(indexes.find((row) => row.indexname === 'agent_logs_device_created_at_idx')?.indexdef)
+      .toContain('(device_id, created_at DESC, id DESC)');
+    expect(indexes.find((row) => row.indexname === 'agent_logs_org_created_at_idx')?.indexdef)
+      .toContain('(org_id, created_at DESC, id DESC)');
+  });
+});

--- a/apps/api/src/db/schema/agentLogs.ts
+++ b/apps/api/src/db/schema/agentLogs.ts
@@ -19,6 +19,9 @@ export const agentLogs = pgTable('agent_logs', {
 }, (table) => ({
   deviceIdx: index('agent_logs_device_idx').on(table.deviceId),
   orgTimestampIdx: index('agent_logs_org_ts_idx').on(table.orgId, table.timestamp),
+  orgCreatedAtIdx: index('agent_logs_org_created_at_idx').on(table.orgId, table.createdAt.desc(), table.id.desc()),
   levelComponentIdx: index('agent_logs_level_component_idx').on(table.level, table.component),
   timestampIdx: index('agent_logs_timestamp_idx').on(table.timestamp),
+  createdAtIdx: index('agent_logs_created_at_idx').on(table.createdAt),
+  deviceCreatedAtIdx: index('agent_logs_device_created_at_idx').on(table.deviceId, table.createdAt.desc(), table.id.desc()),
 }));

--- a/apps/api/src/jobs/agentLogRetention.test.ts
+++ b/apps/api/src/jobs/agentLogRetention.test.ts
@@ -107,7 +107,7 @@ describe('Agent log retention worker', () => {
     );
   });
 
-  it('deletes agent_logs in bounded ctid batches on the timestamp column, inside system DB context', async () => {
+  it('deletes agent_logs in bounded ctid batches on server receipt time, inside system DB context', async () => {
     dbExecuteMock
       .mockResolvedValueOnce({ rowCount: 4 })
       .mockResolvedValueOnce({ rowCount: 4 })
@@ -131,7 +131,8 @@ describe('Agent log retention worker', () => {
     expect(sqlDump).toContain('DELETE FROM');
     expect(sqlDump).toContain('agent_logs');
     expect(sqlDump).toContain('SELECT ctid');
-    expect(sqlDump).toContain('\\"timestamp\\" <');
+    expect(sqlDump).toContain('\\"created_at\\" <');
+    expect(sqlDump).not.toContain('\\"timestamp\\" <');
     expect(sqlDump).toContain('LIMIT');
     expect(result).toMatchObject({
       deletedCount: 10,

--- a/apps/api/src/jobs/agentLogRetention.ts
+++ b/apps/api/src/jobs/agentLogRetention.ts
@@ -9,7 +9,8 @@
  * `agent_logs` is a hot agent-write table, so this used to be the worst kind of
  * sweeper: a single unbounded DELETE holding a pooled connection (and row locks
  * on a table the agent path is inserting into) for the whole statement (#4343).
- * Pruning rides `agent_logs_timestamp_idx`.
+ * Pruning rides `agent_logs_created_at_idx`. The agent-reported `timestamp`
+ * remains event evidence and must never extend or shorten the receipt-time TTL.
  */
 
 import { Queue, Worker, Job } from 'bullmq';
@@ -49,6 +50,20 @@ interface RetentionJobData {
   maxBatches?: number;
 }
 
+async function pruneAgentLogsByReceiptTime(input: {
+  cutoff: string;
+  batchSize: number;
+  maxBatches: number;
+}) {
+  return pruneInCtidBatches({
+    table: 'agent_logs',
+    where: sql`"created_at" < ${input.cutoff}`,
+    batchSize: input.batchSize,
+    maxBatches: input.maxBatches,
+    label: 'agentLogRetention.prune',
+  });
+}
+
 export function createAgentLogRetentionWorker(): Worker<RetentionJobData> {
   return new Worker<RetentionJobData>(
     QUEUE_NAME,
@@ -62,12 +77,10 @@ export function createAgentLogRetentionWorker(): Worker<RetentionJobData> {
       // postgres-js does not coerce JS Date in template-literal params; pass an ISO string.
       const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000).toISOString();
 
-      const { deleted: deletedCount, batches, hasMore } = await pruneInCtidBatches({
-        table: 'agent_logs',
-        where: sql`"timestamp" < ${cutoff}`,
+      const { deleted: deletedCount, batches, hasMore } = await pruneAgentLogsByReceiptTime({
+        cutoff,
         batchSize,
         maxBatches,
-        label: 'agentLogRetention.prune',
       });
 
       const durationMs = Date.now() - startTime;
@@ -140,4 +153,5 @@ export const __testOnly = {
   DEFAULT_RETENTION_DAYS,
   BATCH_SIZE,
   MAX_BATCHES,
+  pruneAgentLogsByReceiptTime,
 };

--- a/apps/api/src/routes/agents/logs.test.ts
+++ b/apps/api/src/routes/agents/logs.test.ts
@@ -113,6 +113,101 @@ describe('agent logs routes', () => {
     app.route('/agents', logsRoutes);
   });
 
+  it('clamps excessive future event time and records server-authored provenance', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-01T12:00:00.000Z'));
+    try {
+      mockDeviceLookup(true);
+      const values = mockInsertSuccess();
+
+      const res = await app.request(`/agents/${AGENT_ID}/logs`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          logs: [makeLogEntry({
+            timestamp: '2099-01-01T00:00:00.000Z',
+            fields: { sequence: 7, timestampClamped: false },
+          })],
+        }),
+      });
+
+      expect(res.status).toBe(201);
+      expect(values).toHaveBeenCalledWith([
+        expect.objectContaining({
+          timestamp: new Date('2026-05-01T12:00:00.000Z'),
+          fields: {
+            sequence: 7,
+            originalTimestamp: '2099-01-01T00:00:00.000Z',
+            timestampClamped: true,
+          },
+        }),
+      ]);
+      expect(writeAuditEvent).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+        details: expect.objectContaining({ timestampClampedCount: 1 }),
+      }));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('strips agent-forged clamp provenance from a row the server did not clamp', async () => {
+    // redactAgentLogFields redacts values but preserves unknown keys, so an
+    // agent shipping its own timestampClamped/originalTimestamp on an ordinary
+    // in-window row would otherwise fabricate server-authored provenance.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-01T12:00:00.000Z'));
+    try {
+      mockDeviceLookup(true);
+      const values = mockInsertSuccess();
+
+      const res = await app.request(`/agents/${AGENT_ID}/logs`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          logs: [makeLogEntry({
+            timestamp: '2026-05-01T11:59:00.000Z',
+            fields: {
+              sequence: 7,
+              timestampClamped: true,
+              originalTimestamp: '2099-01-01T00:00:00.000Z',
+            },
+          })],
+        }),
+      });
+
+      expect(res.status).toBe(201);
+      const row = values.mock.calls[0]![0][0];
+      expect(row.timestamp).toEqual(new Date('2026-05-01T11:59:00.000Z'));
+      expect(row.fields).toEqual({ sequence: 7 });
+      expect(row.fields).not.toHaveProperty('timestampClamped');
+      expect(row.fields).not.toHaveProperty('originalTimestamp');
+      expect(writeAuditEvent).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+        details: expect.not.objectContaining({ timestampClampedCount: expect.anything() }),
+      }));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('ignores an agent-supplied createdAt — receipt time is server-assigned', async () => {
+    mockDeviceLookup(true);
+    const values = mockInsertSuccess();
+
+    const res = await app.request(`/agents/${AGENT_ID}/logs`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        logs: [makeLogEntry({ createdAt: '2099-01-01T00:00:00.000Z' })],
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const row = values.mock.calls[0]![0][0];
+    // Nothing named createdAt reaches the insert; the column defaults to now()
+    // in the database, so an agent cannot pre-date or post-date its receipt.
+    expect(row).not.toHaveProperty('createdAt');
+  });
+
   describe('POST /agents/:id/logs — batch size limit', () => {
     it('accepts a batch with exactly 200 entries (at the cap)', async () => {
       mockDeviceLookup(true);

--- a/apps/api/src/routes/agents/logs.ts
+++ b/apps/api/src/routes/agents/logs.ts
@@ -24,6 +24,28 @@ export const logsRoutes = new Hono();
 //     to ~200 logs/min/agent, which is 5-10x the realistic steady-state rate.
 const LOG_BATCH_MAX_BODY_BYTES = 256 * 1024;
 const LOG_BATCH_TOO_LARGE = 'Log batch too large (max 256KB gzipped)';
+// Match the event-log ingest boundary: modest positive clock skew is useful
+// event evidence, but an agent must not place records arbitrarily far into the
+// future. Receipt time remains the authoritative lifecycle/recency clock.
+const MAX_AGENT_LOG_FUTURE_SKEW_MS = 10 * 60 * 1000;
+
+/**
+ * Remove the two server-authored clamp-provenance keys from redacted agent
+ * fields.
+ *
+ * `redactAgentLogFields` redacts *values* but preserves unknown *keys*
+ * verbatim, so without this an agent could ship `timestampClamped: true` /
+ * `originalTimestamp: <anything>` on an ordinary in-window row and forge
+ * provenance the server never wrote. Both keys are stripped unconditionally
+ * here; only the clamp branch in the ingest handler re-adds them.
+ */
+function stripClampProvenance(fields: unknown): unknown {
+  if (!fields || typeof fields !== 'object' || Array.isArray(fields)) return fields;
+  const copy = { ...(fields as Record<string, unknown>) };
+  delete copy.timestampClamped;
+  delete copy.originalTimestamp;
+  return copy;
+}
 
 const agentLogEntrySchema = z.object({
   timestamp: z.string().datetime({ offset: true }),
@@ -106,17 +128,36 @@ logsRoutes.post(
     return c.json({ received: 0 }, 200);
   }
 
-  const rows = data.logs.map((log: any) => ({
-    deviceId: device.id,
-    orgId: device.orgId,
-    timestamp: new Date(log.timestamp),
-    level: log.level,
-    component: log.component,
-    // Ingest and every read path share one rule set — see redactAgentLogRow (#3109).
-    message: redactAgentLogMessage(log.message),
-    fields: log.fields ? redactAgentLogFields(log.fields) : null,
-    agentVersion: log.agentVersion || null,
-  }));
+  const receivedAt = new Date();
+  let timestampClampedCount = 0;
+  const rows = data.logs.map((log: any) => {
+    const reportedTimestamp = new Date(log.timestamp);
+    const timestampClamped = reportedTimestamp.getTime()
+      > receivedAt.getTime() + MAX_AGENT_LOG_FUTURE_SKEW_MS;
+    if (timestampClamped) timestampClampedCount++;
+    const redactedFields = log.fields
+      ? stripClampProvenance(redactAgentLogFields(log.fields))
+      : null;
+
+    return {
+      deviceId: device.id,
+      orgId: device.orgId,
+      timestamp: timestampClamped ? receivedAt : reportedTimestamp,
+      level: log.level,
+      component: log.component,
+      // Ingest and every read path share one rule set — see redactAgentLogRow (#3109).
+      message: redactAgentLogMessage(log.message),
+      fields: timestampClamped
+        ? {
+            ...(redactedFields || {}),
+            // Server-authored keys; the agent's own copies were stripped above.
+            originalTimestamp: log.timestamp,
+            timestampClamped: true,
+          }
+        : redactedFields,
+      agentVersion: log.agentVersion || null,
+    };
+  });
 
   let inserted = 0;
   try {
@@ -145,6 +186,7 @@ logsRoutes.post(
     details: {
       submittedCount: data.logs.length,
       insertedCount: inserted,
+      ...(timestampClampedCount > 0 ? { timestampClampedCount } : {}),
       ...(partialFailure > 0 ? { partialFailure } : {}),
     },
   });

--- a/apps/api/src/routes/devices/diagnosticLogs.test.ts
+++ b/apps/api/src/routes/devices/diagnosticLogs.test.ts
@@ -24,8 +24,10 @@ vi.mock('../../db/schema', () => ({
     siteId: 'devices.siteId',
   },
   agentLogs: {
+    id: 'agentLogs.id',
     deviceId: 'agentLogs.deviceId',
     timestamp: 'agentLogs.timestamp',
+    createdAt: 'agentLogs.createdAt',
     level: 'agentLogs.level',
     component: 'agentLogs.component',
     message: 'agentLogs.message',
@@ -67,6 +69,18 @@ describe('diagnostic log routes', () => {
   });
 
   it('redacts legacy raw secrets before returning diagnostic logs', async () => {
+    const orderBy = vi.fn().mockReturnValue({
+      limit: vi.fn().mockReturnValue({
+        offset: vi.fn().mockResolvedValue([{
+          id: 'log-1',
+          deviceId: '11111111-2222-4333-8444-555555555555',
+          message: 'failed with token=raw-token',
+          fields: { apiKey: 'raw-key', nested: { password: 'raw-password' } },
+          timestamp: new Date('2099-05-01T00:00:00.000Z'),
+          createdAt: new Date('2026-05-01T00:00:00.000Z'),
+        }]),
+      }),
+    });
     vi.mocked(db.select)
       .mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
@@ -78,17 +92,7 @@ describe('diagnostic log routes', () => {
       .mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
-            orderBy: vi.fn().mockReturnValue({
-              limit: vi.fn().mockReturnValue({
-                offset: vi.fn().mockResolvedValue([{
-                  id: 'log-1',
-                  deviceId: '11111111-2222-4333-8444-555555555555',
-                  message: 'failed with token=raw-token',
-                  fields: { apiKey: 'raw-key', nested: { password: 'raw-password' } },
-                  timestamp: new Date('2026-05-01T00:00:00.000Z'),
-                }]),
-              }),
-            }),
+            orderBy,
           }),
         }),
       } as any)
@@ -109,6 +113,15 @@ describe('diagnostic log routes', () => {
       apiKey: '[REDACTED]',
       nested: { password: '[REDACTED]' },
     });
+    // Receipt time dominates; event time only breaks ties inside one receipt
+    // instant (a 100-row ingest batch shares created_at), and the random uuid
+    // is last. Assert the sequence, not just membership.
+    const orderingDump = JSON.stringify(orderBy.mock.calls);
+    expect(orderingDump).toContain('agentLogs.createdAt');
+    expect(orderingDump.indexOf('agentLogs.timestamp'))
+      .toBeGreaterThan(orderingDump.indexOf('agentLogs.createdAt'));
+    expect(orderingDump.indexOf('agentLogs.id'))
+      .toBeGreaterThan(orderingDump.indexOf('agentLogs.timestamp'));
   });
 
   it('denies diagnostic logs when site scope excludes the device', async () => {

--- a/apps/api/src/routes/devices/diagnosticLogs.ts
+++ b/apps/api/src/routes/devices/diagnosticLogs.ts
@@ -49,7 +49,8 @@ diagnosticLogsRoutes.get(
       conditions.push(eq(agentLogs.component, query.component));
     }
 
-    // Time range: ?since=ISO&until=ISO
+    // Explicit ranges are event-time investigations. Default recency below is
+    // receipt-time so an agent clock cannot pin a row ahead of newer evidence.
     if (query.since) {
       const d = new Date(query.since);
       if (isNaN(d.getTime())) {
@@ -87,7 +88,11 @@ diagnosticLogsRoutes.get(
           .select()
           .from(agentLogs)
           .where(and(...conditions))
-          .orderBy(desc(agentLogs.timestamp), desc(agentLogs.id))
+          // Receipt time dominates. Ingest writes up to 100 rows in one INSERT,
+          // so a whole batch shares created_at to the microsecond and the random
+          // uuid id would shuffle it; agent event time only breaks ties WITHIN a
+          // single receipt instant, which cannot reorder rows across receipts.
+          .orderBy(desc(agentLogs.createdAt), desc(agentLogs.timestamp), desc(agentLogs.id))
           .limit(limit)
           .offset(offset),
         db

--- a/apps/api/src/routes/devices/watchdogLogs.test.ts
+++ b/apps/api/src/routes/devices/watchdogLogs.test.ts
@@ -24,8 +24,10 @@ vi.mock('../../db/schema', () => ({
     siteId: 'devices.siteId',
   },
   agentLogs: {
+    id: 'agentLogs.id',
     deviceId: 'agentLogs.deviceId',
     timestamp: 'agentLogs.timestamp',
+    createdAt: 'agentLogs.createdAt',
     level: 'agentLogs.level',
     component: 'agentLogs.component',
     message: 'agentLogs.message',
@@ -67,6 +69,19 @@ describe('watchdog log routes', () => {
   });
 
   it('redacts legacy raw secrets before returning watchdog logs', async () => {
+    const orderBy = vi.fn().mockReturnValue({
+      limit: vi.fn().mockReturnValue({
+        offset: vi.fn().mockResolvedValue([{
+          id: 'log-1',
+          deviceId: '11111111-2222-4333-8444-555555555555',
+          component: 'watchdog.service',
+          message: 'restart failed token=raw-token',
+          fields: { apiKey: 'raw-key', nested: { password: 'raw-password' } },
+          timestamp: new Date('2099-05-01T00:00:00.000Z'),
+          createdAt: new Date('2026-05-01T00:00:00.000Z'),
+        }]),
+      }),
+    });
     vi.mocked(db.select)
       .mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
@@ -78,18 +93,7 @@ describe('watchdog log routes', () => {
       .mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
-            orderBy: vi.fn().mockReturnValue({
-              limit: vi.fn().mockReturnValue({
-                offset: vi.fn().mockResolvedValue([{
-                  id: 'log-1',
-                  deviceId: '11111111-2222-4333-8444-555555555555',
-                  component: 'watchdog.service',
-                  message: 'restart failed token=raw-token',
-                  fields: { apiKey: 'raw-key', nested: { password: 'raw-password' } },
-                  timestamp: new Date('2026-05-01T00:00:00.000Z'),
-                }]),
-              }),
-            }),
+            orderBy,
           }),
         }),
       } as any)
@@ -110,6 +114,15 @@ describe('watchdog log routes', () => {
       apiKey: '[REDACTED]',
       nested: { password: '[REDACTED]' },
     });
+    // Receipt time dominates; event time only breaks ties inside one receipt
+    // instant (a 100-row ingest batch shares created_at), and the random uuid
+    // is last. Assert the sequence, not just membership.
+    const orderingDump = JSON.stringify(orderBy.mock.calls);
+    expect(orderingDump).toContain('agentLogs.createdAt');
+    expect(orderingDump.indexOf('agentLogs.timestamp'))
+      .toBeGreaterThan(orderingDump.indexOf('agentLogs.createdAt'));
+    expect(orderingDump.indexOf('agentLogs.id'))
+      .toBeGreaterThan(orderingDump.indexOf('agentLogs.timestamp'));
   });
 
   it('denies watchdog logs when site scope excludes the device', async () => {

--- a/apps/api/src/routes/devices/watchdogLogs.ts
+++ b/apps/api/src/routes/devices/watchdogLogs.ts
@@ -55,7 +55,8 @@ watchdogLogsRoutes.get(
       conditions.push(eq(agentLogs.component, query.component));
     }
 
-    // Time range: ?since=ISO&until=ISO
+    // Explicit ranges are event-time investigations. Default recency below is
+    // receipt-time so an agent clock cannot pin a row ahead of newer evidence.
     if (query.since) {
       const d = new Date(query.since);
       if (isNaN(d.getTime())) {
@@ -93,7 +94,11 @@ watchdogLogsRoutes.get(
           .select()
           .from(agentLogs)
           .where(and(...conditions))
-          .orderBy(desc(agentLogs.timestamp), desc(agentLogs.id))
+          // Receipt time dominates. Ingest writes up to 100 rows in one INSERT,
+          // so a whole batch shares created_at to the microsecond and the random
+          // uuid id would shuffle it; agent event time only breaks ties WITHIN a
+          // single receipt instant, which cannot reorder rows across receipts.
+          .orderBy(desc(agentLogs.createdAt), desc(agentLogs.timestamp), desc(agentLogs.id))
           .limit(limit)
           .offset(offset),
         db

--- a/apps/api/src/services/aiToolsAgentLogs.test.ts
+++ b/apps/api/src/services/aiToolsAgentLogs.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
 
 // Mock dependencies before imports
 vi.mock('../db', () => ({
@@ -85,6 +87,7 @@ describe('aiToolsAgentLogs', () => {
           id: 'log-1',
           deviceId: 'dev-1',
           timestamp: new Date('2026-02-15T10:00:00Z'),
+          createdAt: new Date('2026-02-15T10:00:05Z'),
           level: 'error',
           component: 'heartbeat',
           message: 'connection failed',
@@ -92,13 +95,14 @@ describe('aiToolsAgentLogs', () => {
           agentVersion: '1.0.0',
         },
       ];
+      const orderBy = vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(mockRows),
+      });
 
       vi.mocked(db.select).mockReturnValue({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
-            orderBy: vi.fn().mockReturnValue({
-              limit: vi.fn().mockResolvedValue(mockRows),
-            }),
+            orderBy,
           }),
         }),
       } as any);
@@ -114,6 +118,17 @@ describe('aiToolsAgentLogs', () => {
       expect(parsed.logs[0].message).toBe('connection failed');
       expect(parsed.logs[0].level).toBe('error');
       expect(parsed.logs[0].timestamp).toBe('2026-02-15T10:00:00.000Z');
+      expect(parsed.logs[0].receivedAt).toBe('2026-02-15T10:00:05.000Z');
+      // Receipt time dominates; event time only breaks ties inside one receipt
+      // instant (a 100-row ingest batch shares created_at), and the random uuid
+      // is last. Assert the sequence, not just membership.
+      const dialect = new PgDialect();
+      const orderingSql = (orderBy.mock.calls[0] as SQL[])
+        .map((clause) => dialect.sqlToQuery(clause).sql)
+        .join(', ');
+      expect(orderingSql).toContain('"created_at"');
+      expect(orderingSql.indexOf('"timestamp"')).toBeGreaterThan(orderingSql.indexOf('"created_at"'));
+      expect(orderingSql.indexOf('"id"')).toBeGreaterThan(orderingSql.indexOf('"timestamp"'));
     });
 
     it('redacts legacy raw secrets before returning log search results', async () => {
@@ -125,6 +140,7 @@ describe('aiToolsAgentLogs', () => {
                 id: 'log-1',
                 deviceId: 'dev-1',
                 timestamp: new Date('2026-02-15T10:00:00Z'),
+                createdAt: new Date('2026-02-15T10:00:05Z'),
                 level: 'error',
                 component: 'heartbeat',
                 message: 'failed token=raw-token',

--- a/apps/api/src/services/aiToolsAgentLogs.ts
+++ b/apps/api/src/services/aiToolsAgentLogs.ts
@@ -38,7 +38,7 @@ export function registerAgentLogTools(aiTools: Map<string, AiTool>): void {
     definition: {
       name: 'search_agent_logs',
       description:
-        'Search agent diagnostic logs across the fleet. Filter by device, log level, component, time range, or message text. Returns matching log entries ordered by timestamp (newest first).',
+        'Search agent diagnostic logs across the fleet. Filter by device, log level, component, event-time range, or message text. Returns matching log entries ordered by server receipt time (newest received first).',
       input_schema: {
         type: 'object' as const,
         properties: {
@@ -121,7 +121,11 @@ export function registerAgentLogTools(aiTools: Map<string, AiTool>): void {
           .select()
           .from(agentLogs)
           .where(and(...filters))
-          .orderBy(desc(agentLogs.timestamp))
+          // Receipt time dominates. Ingest writes up to 100 rows in one INSERT,
+          // so a whole batch shares created_at to the microsecond and the random
+          // uuid id would shuffle it; agent event time only breaks ties WITHIN a
+          // single receipt instant, which cannot reorder rows across receipts.
+          .orderBy(desc(agentLogs.createdAt), desc(agentLogs.timestamp), desc(agentLogs.id))
           .limit(maxLimit);
 
         return JSON.stringify({
@@ -131,6 +135,7 @@ export function registerAgentLogTools(aiTools: Map<string, AiTool>): void {
               id: r.id,
               deviceId: r.deviceId,
               timestamp: r.timestamp.toISOString(),
+              receivedAt: r.createdAt.toISOString(),
               level: r.level,
               component: r.component,
               message: redacted.message,

--- a/apps/api/src/services/alertCorrelationRca.ts
+++ b/apps/api/src/services/alertCorrelationRca.ts
@@ -728,6 +728,9 @@ export async function buildAlertCorrelationRca(options: BuildRcaOptions): Promis
         .limit(10)
     : [];
 
+  // Incident RCA is an explicit event-time investigation, unlike default log
+  // recency views. Ingest clamps excessive future skew, while timestamp keeps
+  // legitimate delayed/offline event chronology inside the requested window.
   const agentLogRows = deviceIds.length > 0
     ? await db
         .select()


### PR DESCRIPTION
## Summary

**SEC-2026-09-05-117 (Low, confidence 9) — an enrolled agent controlled the durable retention clock for its own diagnostic logs.**

Every `agent_logs` row carried an agent-supplied `timestamp`, and that untrusted value drove:

1. **Retention.** `jobs/agentLogRetention.ts` pruned on `"timestamp" < cutoff`. An agent that stamps rows in the far future keeps them past TTL indefinitely (unbounded tenant storage growth, log-volume cost); one that stamps them in the far past has them swept on the next pass (evidence destruction just after shipping).
2. **Default recency.** The diagnostic-log view, the watchdog-log view and the `search_agent_logs` AI tool all ordered `timestamp DESC`, so a single far-future row pins itself above every piece of newer, real evidence in the default (unfiltered) view an operator or the AI agent actually looks at.

The fix splits the two clocks. Server receipt time is authoritative for lifecycle and default recency; agent event time stays trusted for *explicit* investigation.

- **Ingest** (`routes/agents/logs.ts`) captures one server instant per batch and clamps any event timestamp more than **10 minutes** in the future to it. The submitted value is preserved as provenance in `fields.originalTimestamp` with a `fields.timestampClamped: true` marker. `redactAgentLogFields` redacts *values* but preserves unknown *keys*, so both provenance keys are **stripped unconditionally** from the redacted fields (`stripClampProvenance`) and re-added only in the clamp branch — an agent cannot forge clamp provenance on a row the server never clamped. The existing audit event gains `timestampClampedCount` when non-zero. Past/delayed timestamps are left alone — legitimate offline chronology is preserved.
- **Retention** (`jobs/agentLogRetention.ts`) prunes bounded ctid batches on `created_at`. Batching, `maxBatches`, the system DB context and the backlog warning are unchanged.
- **Default recency** in `routes/devices/diagnosticLogs.ts`, `routes/devices/watchdogLogs.ts` and `services/aiToolsAgentLogs.ts` orders by `created_at DESC, timestamp DESC, id DESC`. Receipt time dominates and cannot be influenced by the agent; event time only breaks ties **within one receipt instant**, which matters because ingest writes up to 100 rows in a single `INSERT` — a whole batch shares `created_at` to the microsecond, and without the tie-break the random uuid `id` shuffles every batch in the default view. Explicit `since`/`until` filters still match on **event** time, so investigation semantics do not change. The AI projection additionally exposes `receivedAt` so the model can see both clocks.
- **Incident RCA** (`services/alertCorrelationRca.ts`) deliberately keeps its event-time window and order; that is a reconstruction of what happened on the endpoint, not a recency view. Comment-only change documenting the intent so a future reader does not "fix" it.
- **Migration** `2026-10-15-160130-agent-log-receipt-time-indexes.sql` adds the three receipt-time indexes the new order/prune paths need, via the runner's `-- @no-transaction` lane and `CREATE INDEX CONCURRENTLY IF NOT EXISTS`. A trailing `DO $$` block fails loudly if an interrupted build left an `indisvalid = false` index, because `IF NOT EXISTS` would otherwise silently keep it. **See Rollout below — build these by hand before the release rolls.** The index shapes are unchanged by the tie-break: incremental sort handles a ≤100-row tie group off the presorted `(…, created_at DESC, id DESC)` prefix.

Writer/reader sweep: `agent_logs` has exactly two writers (this ingest route and `routes/agents/heartbeat.ts`, which already assigns `new Date()` server-side) and four readers (diagnostic, watchdog, `search_agent_logs`, RCA). All are covered above. No new table and no new column, so no `CORE_TENANT_EXPORT_POLICY` / cascade-list registration is due — `agent_logs` is already in `CORE_ORG_CASCADE_DELETE_ORDER`, `CORE_DEVICE_CASCADE_DELETE_TABLES` and `CORE_DEVICE_ORG_DENORMALIZED_TABLES`.

## Ported from

Local remediation commit `e4cebff143219a6d6a39ac739884a6c6c4f4398c` (`fix(logs): anchor retention to receipt time`), authored against a base ~200 commits behind this branch point.

- Cherry-picked with `git cherry-pick -x`. **Zero conflicts** — all 14 files applied cleanly against `29e9445f3d`; nothing was dropped as already-on-main and nothing was rewritten for drift.
- Migration file renamed from `2026-10-12-100200-agent-log-receipt-time-indexes.sql` to `2026-10-15-160130-…` so it sorts after the newest committed migration (`2026-10-15-160010-backup-snapshots-layout-manifest.sql`) under `localeCompare`. Verified no other file in the repo references the old path.
- **Changed vs the original, from PR review:** the event-time tie-break in the three readers; the unconditional `stripClampProvenance` strip at ingest; the operator note in the migration header. Everything else is the original patch.

**On `CREATE INDEX CONCURRENTLY`** — `autoMigrate.ts:194,690-722` implements a `-- @no-transaction` lane that splits the file with `splitSqlStatements()` and sends each statement as its own simple-query exchange precisely so `CREATE INDEX CONCURRENTLY` works; its comment names `agent_logs` as a target table (#753 P0). Ten shipped migrations already use the lane.

## Rollout — build the indexes by hand first

`autoMigrate` runs inside `initializeDatabaseForStartup`, which `index.ts:1566` **awaits before `serve()` at :1705**. `CONCURRENTLY` does not block agent writes (`ShareUpdateExclusiveLock`), but it is a two-pass scan that waits on older transactions, so on a multi-million-row `agent_logs` **the API does not accept traffic until all three builds finish**, and a boot killed mid-build leaves an `INVALID` index that makes the migration's `DO` block abort **every subsequent boot** — a crash loop until an operator drops it.

Run these against the live EU/US databases at any time before the release (no downtime, no lock on writers); `IF NOT EXISTS` then makes the migration instant when the release deploys:

```sql
CREATE INDEX CONCURRENTLY IF NOT EXISTS agent_logs_created_at_idx
  ON agent_logs (created_at);
CREATE INDEX CONCURRENTLY IF NOT EXISTS agent_logs_device_created_at_idx
  ON agent_logs (device_id, created_at DESC, id DESC);
CREATE INDEX CONCURRENTLY IF NOT EXISTS agent_logs_org_created_at_idx
  ON agent_logs (org_id, created_at DESC, id DESC);
```

Then confirm all three are valid before deploying:

```sql
SELECT c.relname, i.indisvalid FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid
 WHERE i.indrelid = 'agent_logs'::regclass AND c.relname LIKE '%created_at%';
```

Any row with `indisvalid = f` must be dropped (`DROP INDEX CONCURRENTLY <name>;`) and rebuilt before the release rolls. The same note is in the migration file header.

## Verification

All commands run in the worktree at head ``9f0114437e95f8f2f9e3a029477c5060046a55e4`` against an ephemeral `pnpm test-stack` Postgres (`breeze_test`), unless noted.

**Red-first — full restore (verified).** Restored main's version of all seven non-test source files, re-ran the unit family:

```
git checkout origin/main -- apps/api/src/db/schema/agentLogs.ts apps/api/src/jobs/agentLogRetention.ts \
  apps/api/src/routes/agents/logs.ts apps/api/src/routes/devices/diagnosticLogs.ts \
  apps/api/src/routes/devices/watchdogLogs.ts apps/api/src/services/aiToolsAgentLogs.ts \
  apps/api/src/services/alertCorrelationRca.ts
cd apps/api && npx vitest run --pool=threads --maxWorkers=2 src/jobs/agentLogRetention src/routes/agents/logs \
  src/routes/devices/diagnosticLogs src/routes/devices/watchdogLogs src/services/aiToolsAgentLogs \
  src/services/alertCorrelationRca
# → Test Files 5 failed | 2 passed (7);  Tests 6 failed | 49 passed (55)
git checkout HEAD -- <same seven files>   # → 7 files / 55 passed
```

**Red-first — targeted mutants (verified).** A whole-file restore proves too much, so each new assertion was also run against a *single-line* mutation of the fixed source:

| Mutation | Suite | Result |
|---|---|---|
| drop `desc(agentLogs.timestamp)` from the three readers (i.e. the pre-review `created_at DESC, id DESC`) | `diagnosticLogs`, `watchdogLogs`, `aiToolsAgentLogs` unit | **3 failed** \| 32 passed (35) |
| same mutation, real Postgres | `agentLogReceiptTime.integration.test.ts` | **1 failed** \| 2 passed (3) — the tie test only |
| replace `stripClampProvenance(redactAgentLogFields(…))` with `redactAgentLogFields(…)` | `routes/agents/logs` unit | **1 failed** \| 10 passed (11) — the forged-provenance test only |

So the tie-break and the provenance strip are each independently load-bearing. One assertion is deliberately **not** a discriminator and is labelled as such: *"ignores an agent-supplied `createdAt`"* passes on main too — it pins an invariant (the ingest row object never carries `createdAt`; the column is server-defaulted) rather than proving a change.

**Unit (verified).** 7 files / **55** tests passed. New tests:
- `agent logs routes > strips agent-forged clamp provenance from a row the server did not clamp`
- `agent logs routes > ignores an agent-supplied createdAt — receipt time is server-assigned` (invariant pin, see above)
- ordering assertions in the existing `diagnostic log routes` / `watchdog log routes` / `search_agent_logs` cases upgraded from "contains `createdAt`, not `timestamp`" to an ordered `created_at → timestamp → id` sequence check.

**Integration (verified).**
```
cd apps/api && npx vitest run --config vitest.integration.config.ts --pool=threads --maxWorkers=2 \
  src/__tests__/integration/agentLogReceiptTime.integration.test.ts \
  src/__tests__/integration/{audit-retention,auditRetentionPrivSep,mlOutputRetention,outboxRetention,reliabilityRetention,userRiskRetention}.integration.test.ts
# → 7 files / 34 tests passed
npx vitest run --config vitest.config.integration-suite-coverage.ts       # 1 file / 5 tests passed
npx vitest run --config vitest.config.site-scope-coverage.ts              # 1 file / 7 tests passed
```
New integration test `breaks ties inside one receipt instant by event time, not by random uuid`: two rows with identical `created_at`, inverted `timestamp`, and uuids chosen so an id-only tie-break returns the wrong order. `agentLogReceiptTime` also covers real HTTP diagnostic/watchdog ordering, explicit event-time filtering, cross-organization denial, receipt-time TTL and all three indexes as `breeze_app`.

**Contract suites (verified).**
```
npx vitest run --config vitest.integration.config.ts --pool=threads --maxWorkers=2 \
  rls-coverage tenant-export-policy tenantCascade tenantExportErasureRoundtrip
# → 7 files / 45 tests passed
```

**Migration + schema (verified).**
```
bash scripts/check-migration-naming.sh                                    # OK
npx vitest run src/db/autoMigrate.test.ts src/db/migrationRlsScope.test.ts # 2 files / 103 tests passed
npx drizzle-kit check                                                     # Everything's fine
pnpm --filter @breeze/api db:check-drift                                  # no drift; 734 files match ledger
```
After a full `autoMigrate` on a fresh stack, all three indexes report `indisvalid = t`. Re-applying the file by hand is a clean no-op (`NOTICE: … already exists, skipping` ×3, `DO`, exit 0) — idempotency confirmed, including with the semicolon-bearing operator note in the header (the no-transaction splitter strips line comments before splitting).

**Typecheck + lint (verified).** `NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit` → exit 0, no diagnostics. `npx eslint` over the 13 touched files → exit 0.

**Not checked:** production-scale index build time, lock duration or query plans on a real multi-million-row `agent_logs`; real agent transport / gzip ingestion; multi-replica clock skew; sustained retention load. No production or customer system was contacted.

## Operator impact

- **Boot blocks on the index build** unless you pre-build — see Rollout above. Roll one region at a time and watch for `[auto-migrate] Applying: … (no-transaction)`.
- **Retention backlog.** Historical far-future rows are **not** rewritten. Their `created_at` is already correct, so they become eligible immediately and the next retention passes remove them in bounded batches — this may take several passes to drain. `warnOnRetentionBacklog` already logs when `hasMore` is set; watch it rather than assuming one pass clears it.
- **Visible behaviour change.** The default (unfiltered) diagnostic-log, watchdog-log and `search_agent_logs` views now order by receipt time. For healthy agents this is indistinguishable from before. For an agent with a skewed clock, rows appear in the order the server received them; `?since=` / `?until=` still filter on the event timestamp, and clamped rows keep the original value in `fields.originalTimestamp`.
- **Clock skew.** The clamp uses the API process clock while the lifecycle uses the database clock. Modest skew can shift classification at the 10-minute boundary but cannot extend receipt-time retention or reorder the default view.
- Suggested release note: "Agent diagnostic-log retention and default recency now use server receipt time, while excessive future event timestamps are bounded and retained as provenance."

## Follow-ups (not in this PR)

- **`routes/agents/eventlogs.ts:46-58` has the same forgeable-provenance gap.** `mergeEventDetails` returns the agent's `details` unchanged when the row was not clamped, so an agent can ship `details.timestampClamped: true` / `details.originalTimestamp` and fabricate the marker on an unclamped event-log row. Same one-line shape of fix as `stripClampProvenance` here; left out to keep this PR to the agent_logs path it was reviewed against.
- **Far-past event timestamps remain accepted by design.** Retention no longer depends on them, so a backdated row can no longer be swept early — it can only hide from an event-time `?since=` window while remaining fully visible in every default receipt-ordered view. Bounding the past side would break legitimate offline/backfilled chronology, so it is deliberately out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Tugfg88kFiowD7E5xQFpU
