### PR TITLE
fix(auth): report acknowledged refresh-token family revocation truthfully (SEC-004)

### DIFF
--- a/apps/api/src/__tests__/integration/familyRevocationOutcome.integration.test.ts
+++ b/apps/api/src/__tests__/integration/familyRevocationOutcome.integration.test.ts
@@ -1,0 +1,69 @@
+import './setup';
+import { randomUUID } from 'node:crypto';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { eq, sql } from 'drizzle-orm';
+import { db, withDbAccessContext, withSystemDbAccessContext } from '../../db';
+import { refreshTokenFamilies } from '../../db/schema';
+import * as redisService from '../../services/redis';
+import { mintRefreshTokenFamily } from '../../services/refreshTokenFamily';
+import { revokeFamily } from '../../services/tokenRevocation';
+import { createPartner, createUser } from './db-utils';
+import { getTestDb, getTestRedis } from './setup';
+
+async function readFamily(familyId: string) {
+  const [row] = await getTestDb().select().from(refreshTokenFamilies)
+    .where(eq(refreshTokenFamilies.familyId, familyId));
+  return row;
+}
+
+async function seedFamily() {
+  const partner = await createPartner();
+  const user = await createUser({ partnerId: partner.id });
+  return mintRefreshTokenFamily(user.id);
+}
+
+describe('family revocation outcomes with real request-role transactions', () => {
+  beforeEach(() => { vi.spyOn(redisService, 'getRedis').mockReturnValue(getTestRedis()); });
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it('acknowledges the committed row and Redis sentinel; repeats preserve the first revocation', async () => {
+    const [role] = await withSystemDbAccessContext(() => db.execute(sql`
+      SELECT current_user AS name, rolsuper, rolbypassrls
+      FROM pg_roles WHERE rolname = current_user
+    `));
+    expect(role).toMatchObject({ name: 'breeze_app', rolsuper: false, rolbypassrls: false });
+    const familyId = await seedFamily();
+    expect(await revokeFamily(familyId, 'x'.repeat(100))).toEqual({ redis: 'confirmed', database: 'confirmed' });
+    const first = await readFamily(familyId);
+    expect(first?.revokedAt).toBeInstanceOf(Date);
+    expect(first?.revokedReason).toBe('x'.repeat(64));
+    expect(await getTestRedis().get(`refresh-fam-revoked:${familyId}`)).toBe('1');
+
+    expect(await revokeFamily(familyId, 'later-reason')).toEqual({ redis: 'confirmed', database: 'confirmed' });
+    expect(await readFamily(familyId)).toEqual(first);
+  });
+
+  it('reports an unmatched row as unconfirmed even if Redis accepts the sentinel', async () => {
+    const familyId = randomUUID();
+    expect(await revokeFamily(familyId, 'reuse-detected')).toEqual({ redis: 'confirmed', database: 'not_found' });
+    expect(await readFamily(familyId)).toBeUndefined();
+  });
+
+  it('independently commits before reporting confirmation inside an ambient context that later rolls back', async () => {
+    const familyId = await seedFamily();
+    await expect(withDbAccessContext({
+      scope: 'organization', orgId: null, accessibleOrgIds: [], userId: null,
+    }, async () => {
+      expect(await revokeFamily(familyId, 'reuse-detected')).toEqual({ redis: 'confirmed', database: 'confirmed' });
+      throw new Error('ambient rollback');
+    })).rejects.toThrow('ambient rollback');
+    expect((await readFamily(familyId))?.revokedAt).toBeInstanceOf(Date);
+  });
+
+  it('still commits the durable revocation when Redis is unavailable', async () => {
+    vi.mocked(redisService.getRedis).mockReturnValue(null);
+    const familyId = await seedFamily();
+    expect(await revokeFamily(familyId, 'reuse-detected')).toEqual({ redis: 'unavailable', database: 'confirmed' });
+    expect((await readFamily(familyId))?.revokedAt).toBeInstanceOf(Date);
+  });
+});

--- a/apps/api/src/routes/auth.passkeys.test.ts
+++ b/apps/api/src/routes/auth.passkeys.test.ts
@@ -145,7 +145,7 @@ vi.mock('../services', () => {
   wasRefreshTokenJtiRecentlyRotated: vi.fn().mockResolvedValue(false),
   rememberJtiFamily: vi.fn().mockResolvedValue(undefined),
   getFamilyForJti: vi.fn().mockResolvedValue(null),
-  revokeFamily: vi.fn().mockResolvedValue(undefined),
+  revokeFamily: vi.fn().mockResolvedValue({ redis: 'confirmed', database: 'confirmed' }),
   isFamilyRevoked: vi.fn().mockResolvedValue(false),
   touchFamilyLastUsed: vi.fn().mockResolvedValue(undefined),
   mintRefreshTokenFamily,

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -70,7 +70,7 @@ vi.mock('../services', () => {
   // tests continue to assert success on the happy path.
   rememberJtiFamily: vi.fn().mockResolvedValue(undefined),
   getFamilyForJti: vi.fn().mockResolvedValue(null),
-  revokeFamily: vi.fn().mockResolvedValue(undefined),
+  revokeFamily: vi.fn().mockResolvedValue({ redis: 'confirmed', database: 'confirmed' }),
   isFamilyRevoked: vi.fn().mockResolvedValue(false),
   touchFamilyLastUsed: vi.fn().mockResolvedValue(undefined),
   // Task 7 follow-up: shared family-mint helper used by every authenticated
@@ -425,6 +425,7 @@ import {
   markRefreshTokenJtiRotated,
   wasRefreshTokenJtiRecentlyRotated,
   revokeFamily,
+  isFamilyRevoked,
   getFamilyForJti,
   getTrustedClientIp,
   rateLimiter,
@@ -551,6 +552,7 @@ describe('auth routes', () => {
     vi.mocked(revokeRefreshTokenJti).mockResolvedValue(true);
     vi.mocked(wasRefreshTokenJtiRecentlyRotated).mockResolvedValue(false);
     vi.mocked(getFamilyForJti).mockResolvedValue(null);
+    vi.mocked(revokeFamily).mockResolvedValue({ redis: 'confirmed', database: 'confirmed' });
     vi.mocked(getTrustedClientIp).mockReturnValue('127.0.0.1');
     vi.mocked(rateLimiter).mockResolvedValue({ allowed: true, remaining: 4, resetAt: new Date() });
     vi.mocked(enforceIpAllowlist).mockResolvedValue({ decision: 'allow' });
@@ -2565,6 +2567,7 @@ describe('auth routes', () => {
       expect(body.reason).toBe('refresh_raced');
       // The whole point: the family must survive, and the cookie must NOT be cleared.
       expect(revokeFamily).not.toHaveBeenCalled();
+      expect(createAuditLogAsync).not.toHaveBeenCalled();
       expect(createTokenPair).not.toHaveBeenCalled();
       const setCookie = res.headers.get('set-cookie') ?? '';
       expect(setCookie).not.toContain('breeze_refresh_token=;');
@@ -2603,6 +2606,53 @@ describe('auth routes', () => {
       // Genuine reuse DOES clear the cookie.
       const setCookie = res.headers.get('set-cookie') ?? '';
       expect(setCookie).toContain('breeze_refresh_token=;');
+    });
+
+    it.each((['confirmed', 'unavailable', 'failed'] as const).flatMap((redis) =>
+      (['confirmed', 'not_found', 'failed'] as const).map((database) => ({ redis, database })),
+    ))('records bounded family outcomes redis=$redis database=$database without claiming complete containment', async (outcome) => {
+      vi.mocked(isRefreshTokenJtiRevoked).mockResolvedValue(true);
+      vi.mocked(wasRefreshTokenJtiRecentlyRotated).mockResolvedValue(false);
+      vi.mocked(revokeFamily).mockResolvedValue(outcome);
+      vi.mocked(verifyToken).mockResolvedValue({
+        sub: '11111111-1111-4111-8111-111111111111',
+        email: 'user@example.test',
+        roleId: null, orgId: null, partnerId: null, scope: 'system',
+        type: 'refresh', mfa: false, iat: 123456,
+        jti: 'rejected-jti', fam: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      });
+
+      const res = await app.request('/auth/refresh', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-breeze-csrf': 'test-csrf-token',
+          Cookie: 'breeze_refresh_token=rejected-token; breeze_csrf_token=test-csrf-token',
+        },
+      });
+
+      // Denial is unconditional: an unacknowledged durable write must never
+      // soften the response, it must only stop the audit row from claiming
+      // containment that was not acknowledged by any store.
+      expect(res.status).toBe(401);
+      expect(await res.json()).toEqual({ error: 'Invalid refresh token' });
+      expect(res.headers.get('set-cookie')).toContain('breeze_refresh_token=;');
+      expect(createTokenPair).not.toHaveBeenCalled();
+      expect(isFamilyRevoked).not.toHaveBeenCalled();
+      expect(createAuditLogAsync).toHaveBeenCalledWith(expect.objectContaining({
+        action: 'auth.refresh.reuse_detected',
+        result: 'denied',
+        resourceId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+        details: {
+          replayedJti: 'rejected-jti',
+          detection: 'revoked_or_unavailable',
+          familyRevocation: outcome,
+          reason: outcome.database === 'confirmed'
+            ? 'Refresh token rejected outside rotation grace; durable family revocation confirmed'
+            : 'Refresh token rejected outside rotation grace; durable family revocation unconfirmed',
+        },
+      }));
+      expect(JSON.stringify(vi.mocked(createAuditLogAsync).mock.calls)).not.toContain('entire family revoked');
     });
 
     it('#1107: a successful refresh records a rotation-grace marker for the old jti', async () => {

--- a/apps/api/src/routes/auth/login.test.ts
+++ b/apps/api/src/routes/auth/login.test.ts
@@ -103,7 +103,7 @@ vi.mock('../../services', () => {
   revokeRefreshTokenJti: vi.fn(async () => true),
   markRefreshTokenJtiRotated: vi.fn(async () => undefined),
   wasRefreshTokenJtiRecentlyRotated: vi.fn(async () => false),
-  revokeFamily: vi.fn(async () => undefined),
+  revokeFamily: vi.fn(async () => ({ redis: 'confirmed', database: 'confirmed' })),
   isFamilyRevoked: vi.fn(async () => false),
   touchFamilyLastUsed: vi.fn(async () => undefined),
   isTokenIssuedBeforePasswordChange: vi.fn(() => false),
@@ -1150,6 +1150,56 @@ describe('POST /refresh — hard-reject fam-less legacy tokens (#917 L-1)', () =
     expect(clearRefreshTokenCookie).toHaveBeenCalled();
     expect(isRefreshTokenJtiRevoked).not.toHaveBeenCalled();
     expect(createTokenPair).not.toHaveBeenCalled();
+  });
+
+  it('still blocks, but does not claim durable containment, when the family write is unacknowledged', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.mocked(verifyToken).mockResolvedValue({
+      sub: 'user-1',
+      email: 'admin@msp.com',
+      type: 'refresh',
+      jti: 'jti-blocked',
+      fam: 'family-blocked',
+      mdid: 'lost-installation',
+    } as any);
+    mobileBlockMocks.getBoundMobileDeviceBlock.mockResolvedValueOnce({ reason: 'lost phone' });
+    vi.mocked(revokeFamily).mockResolvedValueOnce({ redis: 'failed', database: 'failed' });
+
+    const res = await postRefresh();
+
+    // The block is terminal for THIS request regardless of the stores.
+    expect(res.status).toBe(403);
+    expect(await res.json()).toMatchObject({ code: 'device_blocked', reason: 'lost phone' });
+    expect(clearRefreshTokenCookie).toHaveBeenCalled();
+    expect(createTokenPair).not.toHaveBeenCalled();
+    // ...but the unacknowledged durable write must be operator-visible rather
+    // than silently treated as a completed revocation.
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[auth] Mobile-device block could not durably revoke the refresh family',
+      expect.objectContaining({ familyId: 'family-blocked', redis: 'failed', database: 'failed' }),
+    );
+    errorSpy.mockRestore();
+  });
+
+  it('does not warn when the mobile-device block durably revoked the family', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.mocked(verifyToken).mockResolvedValue({
+      sub: 'user-1',
+      email: 'admin@msp.com',
+      type: 'refresh',
+      jti: 'jti-blocked',
+      fam: 'family-blocked',
+      mdid: 'lost-installation',
+    } as any);
+    mobileBlockMocks.getBoundMobileDeviceBlock.mockResolvedValueOnce({ reason: 'lost phone' });
+    vi.mocked(revokeFamily).mockResolvedValueOnce({ redis: 'unavailable', database: 'confirmed' });
+
+    expect((await postRefresh()).status).toBe(403);
+    expect(errorSpy).not.toHaveBeenCalledWith(
+      '[auth] Mobile-device block could not durably revoke the refresh family',
+      expect.anything(),
+    );
+    errorSpy.mockRestore();
   });
 
 });

--- a/apps/api/src/routes/auth/login.ts
+++ b/apps/api/src/routes/auth/login.ts
@@ -856,12 +856,21 @@ loginRoutes.post('/refresh', async (c) => {
 
   // Refresh is pre-auth and therefore does not pass through authMiddleware.
   // Enforce the signed installation binding before rate limiting, replay
-  // checks, rotation or issuance, and durably revoke the presented family so
-  // the block remains terminal even if a later code path misses the live row.
+  // checks, rotation or issuance, and attempt to durably revoke the presented
+  // family so the block survives this request. The block itself is terminal
+  // here regardless of the stores — but an unacknowledged durable write means
+  // the family may still be live for a later code path that reads the row, so
+  // surface it rather than treating the revocation as completed.
   if (payload.mdid) {
     const block = await getBoundMobileDeviceBlock(payload.sub, payload.mdid);
     if (block) {
-      await revokeFamily(payload.fam, 'mobile-device-blocked');
+      const familyRevocation = await revokeFamily(payload.fam, 'mobile-device-blocked');
+      if (familyRevocation.database !== 'confirmed') {
+        console.error('[auth] Mobile-device block could not durably revoke the refresh family', {
+          familyId: payload.fam,
+          ...familyRevocation,
+        });
+      }
       clearRefreshTokenCookie(c);
       return mobileDeviceBlockedResponse(c, block);
     }
@@ -917,11 +926,10 @@ loginRoutes.post('/refresh', async (c) => {
   // carries a family and the Redis jti→family fallback is no longer needed.
   const familyId: string = payload.fam;
 
-  // Reuse detection: if this jti has already been revoked AND we have a
-  // family id, this is a replay of an old (rotated) refresh token. Kill the
-  // whole family + write an audit row + return 401. Without this check the
-  // attacker's later jti would still be valid even after the legitimate
-  // user's next rotation.
+  // Reuse detection also fails closed when the JTI lookup is unavailable.
+  // Outside rotation grace, attempt family revocation, audit the per-store
+  // acknowledgements, and deny this refresh. Do not equate denial of this
+  // request with durable family containment after failed writes.
   const jtiAlreadyRevoked = await isRefreshTokenJtiRevoked(payload.jti);
   if (jtiAlreadyRevoked) {
     // Distinguish a benign concurrent/double-fired refresh from a true
@@ -933,11 +941,11 @@ loginRoutes.post('/refresh', async (c) => {
     // clear the cookie — clearing it would wipe the winner's valid token and
     // log the user out (issue #1107). The loser just retries and picks up the
     // winner's new token. Only a replay OUTSIDE the grace window (an old,
-    // long-rotated jti) is treated as reuse and kills the family.
+    // long-rotated jti) is treated as reuse and attempts family revocation.
     if (await wasRefreshTokenJtiRecentlyRotated(payload.jti)) {
       return c.json({ error: 'Refresh already in progress', reason: 'refresh_raced' }, 401);
     }
-    await revokeFamily(familyId, 'reuse-detected');
+    const familyRevocation = await revokeFamily(familyId, 'reuse-detected');
     createAuditLogAsync({
       actorType: 'user',
       actorId: payload.sub,
@@ -947,7 +955,13 @@ loginRoutes.post('/refresh', async (c) => {
       resourceId: familyId,
       details: {
         replayedJti: payload.jti,
-        reason: 'Revoked refresh-token JTI replayed — entire family revoked',
+        // Preserve the established action/JTI fields for audit consumers, but
+        // the fail-closed JTI lookup also returns true on an unavailable store.
+        detection: 'revoked_or_unavailable',
+        familyRevocation,
+        reason: familyRevocation.database === 'confirmed'
+          ? 'Refresh token rejected outside rotation grace; durable family revocation confirmed'
+          : 'Refresh token rejected outside rotation grace; durable family revocation unconfirmed',
       },
       ipAddress: getClientIP(c),
       userAgent: c.req.header('user-agent'),

--- a/apps/api/src/services/tokenRevocation.family.test.ts
+++ b/apps/api/src/services/tokenRevocation.family.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Redis } from 'ioredis';
+import { PgDialect } from 'drizzle-orm/pg-core';
+
+const mocks = vi.hoisted(() => ({
+  returning: vi.fn(),
+  where: vi.fn(),
+  set: vi.fn(),
+  update: vi.fn(),
+  outside: vi.fn(),
+  system: vi.fn(),
+}));
+
+vi.mock('../db', () => ({
+  db: { update: mocks.update },
+  runOutsideDbContext: mocks.outside,
+  withSystemDbAccessContext: mocks.system,
+}));
+vi.mock('./redis', () => ({ getRedis: vi.fn() }));
+
+import { getRedis } from './redis';
+import { revokeFamily } from './tokenRevocation';
+
+const FAMILY_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const redisStatuses = ['confirmed', 'unavailable', 'failed'] as const;
+const databaseStatuses = ['confirmed', 'not_found', 'failed'] as const;
+
+describe('family revocation acknowledgements', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    mocks.returning.mockResolvedValue([{ familyId: FAMILY_ID }]);
+    mocks.where.mockReturnValue({ returning: mocks.returning });
+    mocks.set.mockReturnValue({ where: mocks.where });
+    mocks.update.mockReturnValue({ set: mocks.set });
+    mocks.outside.mockImplementation((fn: () => unknown) => fn());
+    mocks.system.mockImplementation((fn: () => unknown) => fn());
+  });
+
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it.each(redisStatuses.flatMap((redis) =>
+    databaseStatuses.map((database) => ({ redis, database })),
+  ))('reports redis=$redis and database=$database independently', async ({ redis, database }) => {
+    const setex = vi.fn().mockResolvedValue('OK');
+    if (redis === 'failed') setex.mockRejectedValue(new Error('redis unavailable'));
+    vi.mocked(getRedis).mockReturnValue(redis === 'unavailable' ? null : { setex } as unknown as Redis);
+    if (database === 'failed') mocks.returning.mockRejectedValue(new Error('database unavailable'));
+    if (database === 'not_found') mocks.returning.mockResolvedValue([]);
+
+    expect(await revokeFamily(FAMILY_ID, 'reuse-detected')).toEqual({ redis, database });
+    expect(mocks.update).toHaveBeenCalledOnce();
+    expect(mocks.returning).toHaveBeenCalledOnce();
+    expect(setex).toHaveBeenCalledTimes(redis === 'unavailable' ? 0 : 1);
+    if (redis !== 'unavailable') {
+      expect(setex).toHaveBeenCalledWith(
+        `refresh-fam-revoked:${FAMILY_ID}`, 7 * 24 * 60 * 60 + 15 * 60, '1',
+      );
+    }
+  });
+
+  it('does not confirm a returned row when the enclosing system transaction fails', async () => {
+    vi.mocked(getRedis).mockReturnValue({ setex: vi.fn().mockResolvedValue('OK') } as unknown as Redis);
+    mocks.system.mockImplementation(async (fn: () => Promise<unknown>) => {
+      await fn();
+      throw new Error('commit acknowledgement unavailable');
+    });
+
+    expect(await revokeFamily(FAMILY_ID, 'reuse-detected')).toEqual({
+      redis: 'confirmed', database: 'failed',
+    });
+    expect(mocks.returning).toHaveBeenCalledOnce();
+  });
+
+  it('escapes an ambient context before opening the independently committed system write', async () => {
+    vi.mocked(getRedis).mockReturnValue(null);
+    let outside = false;
+    mocks.outside.mockImplementation(async (fn: () => Promise<unknown>) => {
+      outside = true;
+      try { return await fn(); } finally { outside = false; }
+    });
+    mocks.system.mockImplementation(async (fn: () => Promise<unknown>) => {
+      expect(outside).toBe(true);
+      return fn();
+    });
+
+    expect(await revokeFamily(FAMILY_ID, 'reuse-detected')).toEqual({
+      redis: 'unavailable', database: 'confirmed',
+    });
+    expect(mocks.outside).toHaveBeenCalledOnce();
+  });
+
+  it('caps the persisted reason and preserves the first timestamp/reason on repeat attempts', async () => {
+    vi.mocked(getRedis).mockReturnValue(null);
+    await revokeFamily(FAMILY_ID, 'x'.repeat(100));
+    const update = mocks.set.mock.calls[0]![0];
+    const dialect = new PgDialect();
+    expect(dialect.sqlToQuery(update.revokedAt)).toMatchObject({ sql: 'COALESCE(revoked_at, now())' });
+    expect(dialect.sqlToQuery(update.revokedReason)).toMatchObject({
+      sql: 'COALESCE(revoked_reason, $1)', params: ['x'.repeat(64)],
+    });
+    // Assert the predicate COLUMN too, not just the bound value: matching only
+    // on params would still pass if the filter were swapped to another
+    // uuid-shaped column (user_id), which would revoke far more than asked.
+    const predicate = dialect.sqlToQuery(mocks.where.mock.calls[0]![0]);
+    expect(predicate.sql).toBe('"refresh_token_families"."family_id" = $1');
+    expect(predicate.params).toEqual([FAMILY_ID]);
+  });
+});

--- a/apps/api/src/services/tokenRevocation.ts
+++ b/apps/api/src/services/tokenRevocation.ts
@@ -372,62 +372,93 @@ export async function getFamilyForJti(jti: string): Promise<string | null> {
   }
 }
 
-/** Publish only the hot-path family sentinel after a caller's durable transaction commits. */
-export async function publishFamilyRevocationSentinel(familyId: string): Promise<boolean> {
-  const redis = getRedis();
-  if (redis) {
-    try {
-      await redis.setex(
-        getRevokedFamilyKey(familyId),
-        REFRESH_FAMILY_REVOCATION_TTL_SECONDS,
-        '1'
-      );
-      return true;
-    } catch (error) {
-      console.error('[token-revocation] Failed to write family-revoked sentinel to Redis:', error);
-    }
-  } else {
-    console.error('[token-revocation] Redis unavailable while revoking family — DB row will still be updated');
-  }
-  return false;
+export interface FamilyRevocationResult {
+  /** Acknowledges the expiring Redis sentinel, not durable containment. */
+  redis: 'confirmed' | 'unavailable' | 'failed';
+  /** Confirmed only after a matching row update and transaction completion. */
+  database: 'confirmed' | 'not_found' | 'failed';
 }
 
 /**
- * Marks the family as revoked in Redis (hot path) and Postgres (durable audit).
- * Idempotent: a second call preserves the PG row's first revocation timestamp
- * and reason. Callers that already revoked inside their own transaction should
- * use publishFamilyRevocationSentinel only after that transaction commits.
- *
- * Uses `withSystemDbAccessContext` for the DB write because reuse-detection
- * runs before the user-scope is established in /refresh.
+ * Writes the hot-path sentinel and reports which of the three terminal states
+ * actually happened. `unavailable` (no client) and `failed` (the client
+ * rejected the write) are deliberately distinct: only `confirmed` means a
+ * reader will see the sentinel, and a caller that reports containment must be
+ * able to tell "we never tried" from "we tried and it did not land".
  */
-export async function revokeFamily(familyId: string, reason: string): Promise<void> {
+async function writeFamilyRevocationSentinel(
+  familyId: string,
+): Promise<FamilyRevocationResult['redis']> {
+  const redis = getRedis();
+  if (!redis) {
+    console.error('[token-revocation] Redis unavailable while revoking family — sentinel not published');
+    return 'unavailable';
+  }
+  try {
+    await redis.setex(
+      getRevokedFamilyKey(familyId),
+      REFRESH_FAMILY_REVOCATION_TTL_SECONDS,
+      '1'
+    );
+    return 'confirmed';
+  } catch (error) {
+    console.error('[token-revocation] Failed to write family-revoked sentinel to Redis:', error);
+    return 'failed';
+  }
+}
+
+/**
+ * Publish only the hot-path family sentinel after a caller's durable transaction
+ * commits. Returns true only when the sentinel was actually accepted by Redis.
+ */
+export async function publishFamilyRevocationSentinel(familyId: string): Promise<boolean> {
+  return await writeFamilyRevocationSentinel(familyId) === 'confirmed';
+}
+
+/**
+ * Independently attempts the Redis sentinel and durable Postgres revocation.
+ * These writes are not atomic across stores, and failures are not retried here.
+ * Callers must report the returned acknowledgements, not assume containment.
+ * COALESCE preserves the first revocation timestamp/reason on repeated calls.
+ *
+ * The family must come from verified authority (the signed refresh JWT at the
+ * current caller). A fresh system transaction supports pre-auth revocation and
+ * ensures confirmation does not depend on a later ambient transaction commit —
+ * without `runOutsideDbContext` a caller inside a request transaction that
+ * later rolls back would be told the revocation was durable when it was not.
+ */
+export async function revokeFamily(familyId: string, reason: string): Promise<FamilyRevocationResult> {
   const truncatedReason = reason.length > 64 ? reason.slice(0, 64) : reason;
+  const result: FamilyRevocationResult = { redis: 'unavailable', database: 'failed' };
 
   // Best-effort Redis flip first. Failure here is logged but the DB update
-  // still goes through — fail-closed semantics live in isFamilyRevoked,
+  // is still attempted — fail-closed lookup semantics live in isFamilyRevoked,
   // which prefers Redis but falls back to PG on Redis miss.
-  await publishFamilyRevocationSentinel(familyId);
+  result.redis = await writeFamilyRevocationSentinel(familyId);
 
-  // Durable audit: stamp revoked_at on the PG row (idempotent — only the
-  // first revocation wins). Bypass RLS via system scope so the call works
-  // regardless of which DB context (if any) is on the stack.
+  // The durable row is also an enforcement source on Redis miss/eviction.
+  // A missing row is fail-closed at lookup, but is not a confirmed write.
   try {
-    await dbModule.withSystemDbAccessContext(async () => {
-      await dbModule.db
+    const rows = await dbModule.runOutsideDbContext(() => dbModule.withSystemDbAccessContext(async () =>
+      dbModule.db
         .update(refreshTokenFamilies)
         .set({
           revokedAt: sql`COALESCE(revoked_at, now())`,
           revokedReason: sql`COALESCE(revoked_reason, ${truncatedReason})`,
         })
-        .where(eq(refreshTokenFamilies.familyId, familyId));
-    });
+        .where(eq(refreshTokenFamilies.familyId, familyId))
+        .returning({ familyId: refreshTokenFamilies.familyId }),
+    ));
+    result.database = rows.length > 0 ? 'confirmed' : 'not_found';
+    if (result.database === 'not_found') {
+      console.error('[token-revocation] No matching family row; durable revocation unconfirmed');
+    }
   } catch (error) {
-    // The Redis sentinel above is what gates /refresh; the DB row is a
-    // durable audit. If Redis flipped but PG didn't, we still block the
-    // attacker — we just lose the audit trail.
+    // Redis-only acknowledgement blocks while the sentinel survives. It is
+    // not durable confirmation, and neither-store failure leaves no retry.
     console.error('[token-revocation] Failed to persist family revocation to DB:', error);
   }
+  return result;
 }
 
 /**


### PR DESCRIPTION
## Summary

`revokeFamily` wrote a Redis sentinel and a Postgres row, swallowed every failure, and returned `void`. The `/refresh` reuse-detection audit row then recorded, unconditionally:

> `Revoked refresh-token JTI replayed — entire family revoked`

That is a durable containment claim that **neither store had acknowledged**. After a Redis outage, a failed DB write, or an UPDATE that matched zero rows, the audit trail said the family was revoked when it may not have been — and an operator reading that trail could not tell contained families from uncontained ones. The `mobile-device-blocked` path had the same problem in its code comment ("durably revoke the presented family so the block remains terminal even if a later code path misses the live row") with no signal at all when the write did not land.

**What the fix enforces.** `revokeFamily` now returns a `FamilyRevocationResult` reporting each store independently:

```ts
{ redis: 'confirmed' | 'unavailable' | 'failed',
  database: 'confirmed' | 'not_found' | 'failed' }
```

and both `/refresh` call sites report only what was actually acknowledged:

- **reuse-detected** — the audit row carries the `familyRevocation` object, and its `reason` says *confirmed* only when the durable row was matched **and** committed. It also records `detection: 'revoked_or_unavailable'`, because the fail-closed JTI lookup returns `true` both when the jti really was revoked and when its store is unavailable — the old row implied the former.
- **mobile-device-blocked** — an unconfirmed durable write is now logged for operators instead of being silently treated as a completed revocation.

**Denial is unchanged on every path.** An unacknowledged write never softens a response, never skips a revocation attempt, and never leaves a cookie in place. Status codes, cookie clearing, and call ordering are byte-for-byte identical; only the recorded claim changes. The nine-case `it.each` in `auth.test.ts` pins that: all 9 `redis × database` combinations must still yield `401`, a cleared cookie, no minted token pair, and no `isFamilyRevoked` fallthrough.

Two supporting corrections were required to make `database: 'confirmed'` actually mean confirmed:

- The durable UPDATE now runs under `runOutsideDbContext(() => withSystemDbAccessContext(...))` and uses `.returning()`. Without escaping an ambient request transaction, a caller whose transaction later rolled back would still have been told the revocation was durable; without `returning`, a zero-row UPDATE was indistinguishable from a committed one (now reported as `not_found`). This follows the contract already documented in `CLAUDE.md` — *"`withSystemDbAccessContext` (background/seeds — call `runOutsideDbContext` first if inside a request)"*.
- The three-state sentinel write is factored into a private helper so `publishFamilyRevocationSentinel` keeps its **existing boolean contract** (`true` only on a confirmed write) for its `routes/lifecycle.ts` callers, while `revokeFamily` can still distinguish "no Redis client" (`unavailable`) from "Redis rejected the write" (`failed`).

No migration, no schema column, no config change.

## Ported from

Private security-remediation commits, re-implemented against current `main` rather than cherry-picked (both target files had drifted):

| Local commit | What it was | How it landed here |
|---|---|---|
| `ca840fa3ad` | `test(auth): require truthful family revocation outcomes` — the red-first suite | Ported. `tokenRevocation.family.test.ts` is new; the `auth.test.ts` hunks were re-anchored onto main's current mock block and `beforeEach`. |
| `ec45e4cca0` | `fix(auth): report acknowledged family revocation stores` — the product fix | Re-implemented. Main had since split a `publishFamilyRevocationSentinel` helper out of `revokeFamily`, so the private version's inline Redis block no longer applied; the three-state write is now a shared private helper and the exported boolean contract is preserved. `login.ts` had drifted heavily (auth-transition v1 gating, mobile-device blocking, `AuthIssuanceCapability` reshape), so the two call sites were edited in place. |
| `2a505d9c57` | `test(auth): align revocation fixtures with current schema` | Folded in. Its `createUser({})` → `createPartner()` + `createUser({ partnerId })` fixture shape is what current `db-utils.ts` requires, so the integration file was taken at its post-image. |

**Added beyond the private commits:** the `mobile-device-blocked` call site. The private fix threaded the outcome only through reuse-detection; that path had no audit row and no signal, so it kept a comment claiming durable revocation with nothing to back it. Two tests in `login.test.ts` cover it (warns when unconfirmed, stays quiet when confirmed).

**Also verified while porting — nothing to do, recorded for the ledger.** Two sibling findings from the same private batch were checked hunk-by-hunk against `main` and are **already fully remediated in public** by PR #5471 (`999ae05b83`, *"fix(portal): separate password and Entra identity paths; epoch-check invitations and live sessions"*), which is a superset of both:

- **SEC-155** (portal/Client-AI sessions bound to a durable auth epoch) — main's `apps/api/migrations/2026-10-15-150010-portal-user-auth-epoch.sql` is **byte-identical** to the private `2026-10-12-100100-portal-user-auth-epoch.sql` (`diff` empty; filename only differs). Of the 24 non-migration files, 12 are byte-identical to the private post-image. A line sweep of all 441 non-blank added lines found 19 absent verbatim, every one a non-gap: the invite compare-and-set is on main **stronger** (`auth.ts:801` adds `eq(authMethod,'password')`); the legacy `PUT /profile` password writer is gone entirely on main (`schemas.ts`: `password: z.never().optional()`) with the epoch bump moved to the dedicated route (`profile.ts:170`); the rest is vitest mock-scaffolding drift.
- **SEC-156** (portal auth lifecycle audit) — main carries the `PORTAL_AUTH_AUDIT_ACTIONS` map, the outer `/auth/*` middleware and `setPortalAuthAuditIdentity` at `routes/portal/auth.ts:71-121`, the context type in `routes/portal/schemas.ts`, and `__tests__/integration/portalAuthAudit.integration.test.ts`.

## Verification

All commands run from the worktree against an ephemeral Postgres + Redis stack (`pnpm test-stack up`). Every count below is **verified** — copied from the run output — unless labelled otherwise.

**Red-first (verified).** Tests were written before the implementation, then re-proved formally by restoring main's source under the ported tests:

```
git checkout origin/main -- apps/api/src/services/tokenRevocation.ts apps/api/src/routes/auth/login.ts
cd apps/api && npx vitest run --pool=threads --maxWorkers=2 \
  src/services/tokenRevocation.family.test.ts src/routes/auth.test.ts src/routes/auth/login.test.ts
#   Test Files  3 failed (3)
#        Tests  21 failed | 211 passed (232)

git checkout HEAD -- apps/api/src/services/tokenRevocation.ts apps/api/src/routes/auth/login.ts
cd apps/api && npx vitest run --pool=threads --maxWorkers=2 \
  src/services/tokenRevocation.family.test.ts src/routes/auth.test.ts src/routes/auth/login.test.ts
#   Test Files  3 passed (3)
#        Tests  232 passed (232)
```

The 21 discriminating failures were: 9 × `tokenRevocation.family.test.ts` (`revokeFamily` returned `undefined`), 9 × `auth.test.ts` (audit row still said *"entire family revoked"*), 2 × `tokenRevocation.family.test.ts` (no `runOutsideDbContext`, no `.returning()`), 1 × `login.test.ts` (mobile-blocked path emitted no warning).

One negative control — *"does not warn when the mobile-device block durably revoked the family"* — passes on main too, **vacuously** (main never warns at all). It is retained deliberately as a guard against over-warning after the fix, not as red-first evidence, and is **not** counted among the 21.

**Unit — full auth/revocation family, dotted siblings listed explicitly (verified):**

```
cd apps/api && npx vitest run --pool=threads --maxWorkers=2 \
  src/routes/auth.passkeys.test.ts src/routes/auth.test.ts src/routes/authenticator.test.ts \
  src/routes/auth/ src/routes/lifecycle.test.ts src/services/refreshTokenFamily.test.ts \
  src/services/tokenRevocation.family.test.ts src/services/tokenRevocation.test.ts
#   Test Files  30 passed (30)
#        Tests  891 passed (891)
```

`lifecycle.test.ts` is in that list on purpose: it is the caller that depends on `publishFamilyRevocationSentinel` still returning a boolean.

**Integration — real Postgres as `breeze_app` (verified):**

```
cd apps/api && npx vitest run --config vitest.integration.config.ts --pool=threads --maxWorkers=2 \
  src/__tests__/integration/familyRevocationOutcome.integration.test.ts \
  src/__tests__/integration/refresh-token-family.integration.test.ts \
  src/__tests__/integration/refreshEpoch.integration.test.ts \
  src/__tests__/integration/auth.integration.test.ts \
  src/__tests__/integration/authLifecycle.integration.test.ts \
  src/__tests__/integration/mobileDeviceRevocation.integration.test.ts
#   Test Files  5 passed (5)
#        Tests  20 passed (20)
```

5 rather than 6 because `auth.integration.test.ts` is on main's `exclude` list (pre-existing broken tests, `vitest.integration.config.ts:319`) — **verified**, not a skip introduced here. `familyRevocationOutcome` was confirmed to have actually executed via `--reporter=verbose` (4/4 named tests), not merely to have been listed; its first assertion pins `current_user = breeze_app, rolsuper=false, rolbypassrls=false`. `mobileDeviceRevocation` passing is the real-DB proof that the `publishFamilyRevocationSentinel` boolean contract survived the refactor.

Broader sweep of the same family (verified):

```
cd apps/api && npx vitest run --config vitest.integration.config.ts --pool=threads --maxWorkers=2 \
  src/__tests__/integration/auth-browser-transition.integration.test.ts \
  src/__tests__/integration/auth-browser-transition-rls.integration.test.ts \
  src/__tests__/integration/authLifecycle.integration.test.ts \
  src/__tests__/integration/refresh-token-family.integration.test.ts \
  src/__tests__/integration/refreshTokenStorageHardeningMigration.integration.test.ts \
  src/__tests__/integration/ssoReauthBinding.integration.test.ts \
  src/__tests__/integration/oauth-revocation-service.integration.test.ts \
  src/__tests__/integration/oauth-token-rls.integration.test.ts
#   Test Files  8 passed (8)
#        Tests  50 passed (50)
```

**Contract / typecheck / lint (verified):**

```
cd apps/api && npx vitest run --config vitest.config.integration-suite-coverage.ts
#   Test Files  1 passed (1)   Tests  5 passed (5)

cd apps/api && NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit     # exit 0

cd apps/api && npx eslint src/services/tokenRevocation.ts \
  src/services/tokenRevocation.family.test.ts src/routes/auth/login.ts \
  src/routes/auth/login.test.ts src/routes/auth.test.ts \
  src/__tests__/integration/familyRevocationOutcome.integration.test.ts   # exit 0
```

The new integration file lands in a CI shard by construction — `vitest.integration.config.ts:12` includes `src/__tests__/integration/**/*.test.ts` and the 4-way split is by `vitest --shard` over the resolved file list — and `integration-suite-coverage` (its own runner config) re-proves that statically.

**Not checked, stated plainly:** the tenancy contract suites (`rls-coverage`, `tenantCascade`, `tenant-export-policy`, `tenantExportErasureRoundtrip`) were **not** run — this PR adds no table, no column and no migration, so none of the four registration lists apply. No fault-injection, load, multi-process or production-runtime test was performed; `redis: 'failed'` and `database: 'failed'` are proven by mock at unit level and by a `not_found` case against real Postgres, not by inducing a real outage.

## Independent review

One review round (auth = high blast radius). Verdict: **no blocker, no High, no Medium.** The reviewer mutation-tested the key assertion — reverting `details.reason` in `login.ts` to the old `"…entire family revoked"` string failed all 9 `it.each` cases at `auth.test.ts:2642` — so the suite is discriminating, not confirmatory. It also independently re-ran both integration suites against a live Postgres/Redis and confirmed the `refresh_token_families` RLS policy (`FOR ALL TO breeze_app USING (user_id = breeze_current_user_id() OR breeze_current_scope() = 'system')`) is satisfied by the added `RETURNING`, and that neither `lifecycle.ts` caller of `publishFamilyRevocationSentinel` breaks.

Two findings were raised and **both are fixed in this PR**:

- `auth.passkeys.test.ts:148` still stubbed `revokeFamily` as `undefined`. Inert today (no test in that file reaches either call site) but the next one that did would have thrown a TypeError on `familyRevocation.database` instead of exposing a real defect. Now returns the structured value like the other two suites.
- The `COALESCE` unit case asserted only the bound param, so swapping the `where` column from `family_id` to `user_id` would still have passed. It now pins the predicate SQL as well — that mutation would revoke every family for a user rather than the one presented.

One finding is deliberately **left as follow-up, not fixed here**: `services/tokenRevocation.ts:178` `revokeAllRefreshTokenFamiliesForUser` still uses bare `withSystemDbAccessContext` — the exact pattern this PR corrected in `revokeFamily` — so inside a request context it would join the ambient transaction under the caller's GUCs and, for an admin resetting another user's password, silently match zero rows under that same RLS policy. It has **zero production callers today** (verified by grep across `apps ee packages`; tests only), so it is latent rather than live, and fixing it is a separate change with its own red-first proof rather than scope creep on an audit-truthfulness PR.

## Operator impact

- **No behaviour change for users.** No migration, no new env var, no config change, no API contract change. Every denial that happened before still happens, with the same status code and the same cookie handling.
- **Audit consumers should expect two new fields** in `auth.refresh.reuse_detected` rows: `details.detection` (always `'revoked_or_unavailable'`) and `details.familyRevocation` (`{redis, database}`). `details.replayedJti` is unchanged.
- **`details.reason` changed value.** Anything grepping for the literal `entire family revoked` will stop matching — that string is gone, and a test asserts it never comes back. The replacement is one of *"Refresh token rejected outside rotation grace; durable family revocation confirmed"* / *"...unconfirmed"*.
- **New operator signal:** `[auth] Mobile-device block could not durably revoke the refresh family` (console.error with `{familyId, redis, database}`) fires when a blocked mobile installation's family write did not durably land. A non-trivial rate of this, or of `familyRevocation.database !== 'confirmed'` in audit rows, means real families are being reported as revoked without a durable row behind them and warrants investigation — that visibility is the entire point of this change.
- **Residual, unchanged by this PR:** `revokeFamily` still does not retry, and no store is transactional across Redis and Postgres. This PR makes the failure *legible*; it does not make it *durable*. A retry/reconciliation path for `database !== 'confirmed'` remains open work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Tugfg88kFiowD7E5xQFpU
