### PR TITLE
fix(billing): preserve invoiced source records and reserve billed state for invoice issue (SEC-105, SEC-154)

### DIFF
--- a/apps/api/migrations/2026-10-15-160150-repair-orphan-billed-sources.sql
+++ b/apps/api/migrations/2026-10-15-160150-repair-orphan-billed-sources.sql
@@ -1,0 +1,50 @@
+-- `billed` is an invoice lifecycle fact. Routine time/part APIs now reject it;
+-- preserve only rows backed by an issued, non-void invoice line and return all
+-- other historical rows to the invoice-candidate state. Report both counts so
+-- the rollout retains an auditable record even when no suspect rows exist.
+
+DO $$
+DECLARE
+  repaired_count bigint;
+BEGIN
+  PERFORM set_config('breeze.scope', 'system', true);
+
+  UPDATE time_entries AS te
+  SET billing_status = 'not_billed', updated_at = now()
+  WHERE te.billing_status = 'billed'
+    AND NOT EXISTS (
+      SELECT 1
+      FROM invoice_lines AS il
+      JOIN invoices AS i ON i.id = il.invoice_id AND i.org_id = il.org_id
+      WHERE il.source_type = 'time_entry'
+        AND il.source_id = te.id
+        AND il.org_id = te.org_id
+        AND i.status IN ('sent', 'partially_paid', 'overdue', 'paid')
+    );
+
+  GET DIAGNOSTICS repaired_count = ROW_COUNT;
+  RAISE WARNING 'orphan billed-source repair: reset % time_entries row(s) without issued invoice lineage', repaired_count;
+END $$;
+
+DO $$
+DECLARE
+  repaired_count bigint;
+BEGIN
+  PERFORM set_config('breeze.scope', 'system', true);
+
+  UPDATE ticket_parts AS tp
+  SET billing_status = 'not_billed', updated_at = now()
+  WHERE tp.billing_status = 'billed'
+    AND NOT EXISTS (
+      SELECT 1
+      FROM invoice_lines AS il
+      JOIN invoices AS i ON i.id = il.invoice_id AND i.org_id = il.org_id
+      WHERE il.source_type = 'part'
+        AND il.source_id = tp.id
+        AND il.org_id = tp.org_id
+        AND i.status IN ('sent', 'partially_paid', 'overdue', 'paid')
+    );
+
+  GET DIAGNOSTICS repaired_count = ROW_COUNT;
+  RAISE WARNING 'orphan billed-source repair: reset % ticket_parts row(s) without issued invoice lineage', repaired_count;
+END $$;

--- a/apps/api/migrations/2026-10-15-160150-repair-orphan-billed-sources.sql
+++ b/apps/api/migrations/2026-10-15-160150-repair-orphan-billed-sources.sql
@@ -1,50 +1,83 @@
 -- `billed` is an invoice lifecycle fact. Routine time/part APIs now reject it;
 -- preserve only rows backed by an issued, non-void invoice line and return all
--- other historical rows to the invoice-candidate state. Report both counts so
--- the rollout retains an auditable record even when no suspect rows exist.
+-- other historical rows to the invoice-candidate state. Report both the counts
+-- and the affected ids so the rollout retains an auditable record even when no
+-- suspect rows exist — the reset is not reversible from a bare count.
+--
+-- Lineage is `(invoice_lines.source_type, invoice_lines.source_id)` plus the
+-- invoice status, and NOTHING ELSE. Deliberately no org conjunct: moveTicketOrg
+-- re-stamps time_entries/ticket_parts by ticket_id with no billing_status
+-- filter, while invoice_lines/invoices are excluded from that rewrite by design
+-- (issued billing history keeps the org that was billed). After a ticket org
+-- move the source and its invoice line legitimately sit under DIFFERENT orgs,
+-- so an `il.org_id = te.org_id` conjunct would un-bill genuinely invoiced work
+-- and hand it straight back to invoiceAssembly to bill a second time. source_id
+-- is a UUID and the statement runs system-scoped, so the pair is already exact.
+--
+-- `draft` is deliberately absent from the preserved status list. issueInvoice is
+-- the only writer of `billed` and sets status='sent' in the same transaction, so
+-- a billed source whose only line sits on a draft is reachable only by forgery —
+-- and leaving it billed would wedge that draft forever on SOURCE_ALREADY_BILLED.
+-- `void` is absent because voidInvoice already releases its sources.
+--
+-- Both statements full-scan time_entries/ticket_parts (there is no
+-- billing_status index). These are human-entered tables — thousands of rows, not
+-- millions — so a single boot-time sequential scan is acceptable.
 
 DO $$
 DECLARE
+  repaired_ids uuid[];
   repaired_count bigint;
 BEGIN
   PERFORM set_config('breeze.scope', 'system', true);
 
-  UPDATE time_entries AS te
-  SET billing_status = 'not_billed', updated_at = now()
-  WHERE te.billing_status = 'billed'
-    AND NOT EXISTS (
-      SELECT 1
-      FROM invoice_lines AS il
-      JOIN invoices AS i ON i.id = il.invoice_id AND i.org_id = il.org_id
-      WHERE il.source_type = 'time_entry'
-        AND il.source_id = te.id
-        AND il.org_id = te.org_id
-        AND i.status IN ('sent', 'partially_paid', 'overdue', 'paid')
-    );
+  WITH repaired AS (
+    UPDATE time_entries AS te
+    SET billing_status = 'not_billed', updated_at = now()
+    WHERE te.billing_status = 'billed'
+      AND NOT EXISTS (
+        SELECT 1
+        FROM invoice_lines AS il
+        JOIN invoices AS i ON i.id = il.invoice_id
+        WHERE il.source_type = 'time_entry'
+          AND il.source_id = te.id
+          AND i.status IN ('sent', 'partially_paid', 'overdue', 'paid')
+      )
+    RETURNING te.id
+  )
+  SELECT COALESCE(array_agg(id), ARRAY[]::uuid[]), count(*)
+  INTO repaired_ids, repaired_count
+  FROM repaired;
 
-  GET DIAGNOSTICS repaired_count = ROW_COUNT;
-  RAISE WARNING 'orphan billed-source repair: reset % time_entries row(s) without issued invoice lineage', repaired_count;
+  RAISE WARNING 'orphan billed-source repair: reset % time_entries row(s) without issued invoice lineage; ids (capped at 200): %',
+    repaired_count, repaired_ids[1:200];
 END $$;
 
 DO $$
 DECLARE
+  repaired_ids uuid[];
   repaired_count bigint;
 BEGIN
   PERFORM set_config('breeze.scope', 'system', true);
 
-  UPDATE ticket_parts AS tp
-  SET billing_status = 'not_billed', updated_at = now()
-  WHERE tp.billing_status = 'billed'
-    AND NOT EXISTS (
-      SELECT 1
-      FROM invoice_lines AS il
-      JOIN invoices AS i ON i.id = il.invoice_id AND i.org_id = il.org_id
-      WHERE il.source_type = 'part'
-        AND il.source_id = tp.id
-        AND il.org_id = tp.org_id
-        AND i.status IN ('sent', 'partially_paid', 'overdue', 'paid')
-    );
+  WITH repaired AS (
+    UPDATE ticket_parts AS tp
+    SET billing_status = 'not_billed', updated_at = now()
+    WHERE tp.billing_status = 'billed'
+      AND NOT EXISTS (
+        SELECT 1
+        FROM invoice_lines AS il
+        JOIN invoices AS i ON i.id = il.invoice_id
+        WHERE il.source_type = 'part'
+          AND il.source_id = tp.id
+          AND i.status IN ('sent', 'partially_paid', 'overdue', 'paid')
+      )
+    RETURNING tp.id
+  )
+  SELECT COALESCE(array_agg(id), ARRAY[]::uuid[]), count(*)
+  INTO repaired_ids, repaired_count
+  FROM repaired;
 
-  GET DIAGNOSTICS repaired_count = ROW_COUNT;
-  RAISE WARNING 'orphan billed-source repair: reset % ticket_parts row(s) without issued invoice lineage', repaired_count;
+  RAISE WARNING 'orphan billed-source repair: reset % ticket_parts row(s) without issued invoice lineage; ids (capped at 200): %',
+    repaired_count, repaired_ids[1:200];
 END $$;

--- a/apps/api/src/__tests__/integration/billedSourceLineageMigration.integration.test.ts
+++ b/apps/api/src/__tests__/integration/billedSourceLineageMigration.integration.test.ts
@@ -149,6 +149,11 @@ describe.runIf(!!process.env.DATABASE_URL && !!process.env.DATABASE_URL_APP)(
       const first = await applyMigration();
       expect(first.some((n) => n.includes('reset 1 time_entries row(s)'))).toBe(true);
       expect(first.some((n) => n.includes('reset 1 ticket_parts row(s)'))).toBe(true);
+      // Forensic trail: the reset is irreversible, so the WARNING must name the
+      // rows it touched — a bare count cannot be reconciled after the fact.
+      expect(first.some((n) => n.includes('time_entries') && n.includes(orphanEntry!.id))).toBe(true);
+      expect(first.some((n) => n.includes('ticket_parts') && n.includes(voidPart!.id))).toBe(true);
+      expect(first.some((n) => n.includes('time_entries') && n.includes(issuedEntry!.id))).toBe(false);
 
       const entries = await db.select({ id: timeEntries.id, status: timeEntries.billingStatus }).from(timeEntries);
       const parts = await db.select({ id: ticketParts.id, status: ticketParts.billingStatus }).from(ticketParts);
@@ -162,6 +167,177 @@ describe.runIf(!!process.env.DATABASE_URL && !!process.env.DATABASE_URL_APP)(
       const second = await applyMigration();
       expect(second.some((n) => n.includes('reset 0 time_entries row(s)'))).toBe(true);
       expect(second.some((n) => n.includes('reset 0 ticket_parts row(s)'))).toBe(true);
+    });
+
+    /**
+     * Regression for the org-conjunct blocker. `moveTicketOrg` re-stamps
+     * time_entries/ticket_parts by ticket_id with no billing_status filter,
+     * while invoice_lines/invoices are deliberately excluded from that rewrite
+     * (issued billing history keeps the org that was billed). So a genuinely
+     * invoiced source can legitimately sit under a DIFFERENT org than its
+     * invoice line. A lineage predicate that joined on org_id would call that
+     * orphaned and hand the work back to invoiceAssembly to bill twice.
+     */
+    it('preserves a billed source whose issued invoice line sits under a different org (moved ticket)', async () => {
+      const db = getTestDb();
+      const partner = await createPartner();
+      const billedOrg = await createOrganization({ partnerId: partner.id });
+      const movedOrg = await createOrganization({ partnerId: partner.id });
+      const user = await createUser({ partnerId: partner.id, orgId: movedOrg.id });
+      const suffix = Math.random().toString(36).slice(2, 10);
+      const [ticket] = await db.insert(tickets).values({
+        partnerId: partner.id,
+        orgId: movedOrg.id,
+        ticketNumber: `BILLED-MOVED-${suffix}`,
+        subject: 'Ticket moved after being invoiced',
+        source: 'manual',
+      }).returning({ id: tickets.id });
+
+      // Post-move state: sources carry the DESTINATION org, the invoice and its
+      // lines still carry the org that was actually billed.
+      const [movedEntry] = await db.insert(timeEntries).values({
+        partnerId: partner.id,
+        orgId: movedOrg.id,
+        ticketId: ticket!.id,
+        userId: user.id,
+        startedAt: new Date('2026-09-02T09:00:00Z'),
+        endedAt: new Date('2026-09-02T10:00:00Z'),
+        currencyCode: 'USD',
+        billingStatus: 'billed',
+      }).returning({ id: timeEntries.id });
+
+      const [movedPart] = await db.insert(ticketParts).values({
+        ticketId: ticket!.id,
+        orgId: movedOrg.id,
+        description: 'Invoiced part on a moved ticket',
+        quantity: '1.00',
+        unitPrice: '40.00',
+        currencyCode: 'USD',
+        billingStatus: 'billed',
+      }).returning({ id: ticketParts.id });
+
+      const [sentInvoice] = await db.insert(invoices).values({
+        partnerId: partner.id,
+        orgId: billedOrg.id,
+        currencyCode: 'USD',
+        status: 'sent',
+        invoiceNumber: `LINEAGE-MOVED-${suffix}`,
+      }).returning({ id: invoices.id });
+
+      await db.insert(invoiceLines).values([
+        {
+          invoiceId: sentInvoice!.id,
+          orgId: billedOrg.id,
+          sourceType: 'time_entry',
+          sourceId: movedEntry!.id,
+          description: 'Issued labor, ticket since moved',
+          quantity: '1.00',
+          unitPrice: '100.00',
+          lineTotal: '100.00',
+        },
+        {
+          invoiceId: sentInvoice!.id,
+          orgId: billedOrg.id,
+          sourceType: 'part',
+          sourceId: movedPart!.id,
+          description: 'Issued part, ticket since moved',
+          quantity: '1.00',
+          unitPrice: '40.00',
+          lineTotal: '40.00',
+        },
+      ]);
+
+      const notices = await applyMigration();
+      expect(notices.some((n) => n.includes('reset 0 time_entries row(s)'))).toBe(true);
+      expect(notices.some((n) => n.includes('reset 0 ticket_parts row(s)'))).toBe(true);
+
+      const [entry] = await db.select({ status: timeEntries.billingStatus }).from(timeEntries);
+      const [part] = await db.select({ status: ticketParts.billingStatus }).from(ticketParts);
+      expect(entry?.status).toBe('billed');
+      expect(part?.status).toBe('billed');
+    });
+
+    /**
+     * `draft` is not a preserved status: issueInvoice is the only writer of
+     * `billed` and sets status='sent' in the same transaction, so billed + draft
+     * is only reachable by forgery — and leaving it billed would wedge the draft
+     * forever on SOURCE_ALREADY_BILLED.
+     */
+    it('resets a billed source whose only invoice line sits on a draft invoice', async () => {
+      const db = getTestDb();
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+      const user = await createUser({ partnerId: partner.id, orgId: org.id });
+      const suffix = Math.random().toString(36).slice(2, 10);
+      const [ticket] = await db.insert(tickets).values({
+        partnerId: partner.id,
+        orgId: org.id,
+        ticketNumber: `BILLED-DRAFT-${suffix}`,
+        subject: 'Forged billed source on a draft invoice',
+        source: 'manual',
+      }).returning({ id: tickets.id });
+
+      const [draftEntry] = await db.insert(timeEntries).values({
+        partnerId: partner.id,
+        orgId: org.id,
+        ticketId: ticket!.id,
+        userId: user.id,
+        startedAt: new Date('2026-09-03T09:00:00Z'),
+        endedAt: new Date('2026-09-03T10:00:00Z'),
+        currencyCode: 'USD',
+        billingStatus: 'billed',
+      }).returning({ id: timeEntries.id });
+
+      const [draftPart] = await db.insert(ticketParts).values({
+        ticketId: ticket!.id,
+        orgId: org.id,
+        description: 'Part on a draft invoice',
+        quantity: '1.00',
+        unitPrice: '15.00',
+        currencyCode: 'USD',
+        billingStatus: 'billed',
+      }).returning({ id: ticketParts.id });
+
+      const [draftInvoice] = await db.insert(invoices).values({
+        partnerId: partner.id,
+        orgId: org.id,
+        currencyCode: 'USD',
+        status: 'draft',
+        invoiceNumber: `LINEAGE-DRAFT-${suffix}`,
+      }).returning({ id: invoices.id });
+
+      await db.insert(invoiceLines).values([
+        {
+          invoiceId: draftInvoice!.id,
+          orgId: org.id,
+          sourceType: 'time_entry',
+          sourceId: draftEntry!.id,
+          description: 'Draft labor',
+          quantity: '1.00',
+          unitPrice: '100.00',
+          lineTotal: '100.00',
+        },
+        {
+          invoiceId: draftInvoice!.id,
+          orgId: org.id,
+          sourceType: 'part',
+          sourceId: draftPart!.id,
+          description: 'Draft part',
+          quantity: '1.00',
+          unitPrice: '15.00',
+          lineTotal: '15.00',
+        },
+      ]);
+
+      const notices = await applyMigration();
+      expect(notices.some((n) => n.includes('reset 1 time_entries row(s)'))).toBe(true);
+      expect(notices.some((n) => n.includes('reset 1 ticket_parts row(s)'))).toBe(true);
+      expect(notices.some((n) => n.includes('time_entries') && n.includes(draftEntry!.id))).toBe(true);
+
+      const [entry] = await db.select({ status: timeEntries.billingStatus }).from(timeEntries);
+      const [part] = await db.select({ status: ticketParts.billingStatus }).from(ticketParts);
+      expect(entry?.status).toBe('not_billed');
+      expect(part?.status).toBe('not_billed');
     });
   },
 );

--- a/apps/api/src/__tests__/integration/billedSourceLineageMigration.integration.test.ts
+++ b/apps/api/src/__tests__/integration/billedSourceLineageMigration.integration.test.ts
@@ -1,0 +1,167 @@
+import './setup';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import postgres from 'postgres';
+import { describe, expect, it } from 'vitest';
+import {
+  invoiceLines,
+  invoices,
+  ticketParts,
+  tickets,
+  timeEntries,
+} from '../../db/schema';
+import { createOrganization, createPartner, createUser } from './db-utils';
+import { getTestDb } from './setup';
+
+const MIGRATION_FILE = join(
+  __dirname,
+  '../../../migrations/2026-10-15-160150-repair-orphan-billed-sources.sql',
+);
+
+async function applyMigration(): Promise<string[]> {
+  const notices: string[] = [];
+  const client = postgres(process.env.DATABASE_URL_APP!, {
+    max: 1,
+    onnotice: (notice) => notices.push(String(notice.message ?? '')),
+  });
+  try {
+    await client.unsafe(readFileSync(MIGRATION_FILE, 'utf8'));
+  } finally {
+    await client.end();
+  }
+  return notices;
+}
+
+describe.runIf(!!process.env.DATABASE_URL && !!process.env.DATABASE_URL_APP)(
+  'orphan billed-source lineage migration',
+  () => {
+    it('repairs only unlined or void-lined sources as breeze_app and is idempotent', async () => {
+      const db = getTestDb();
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+      const user = await createUser({ partnerId: partner.id, orgId: org.id });
+      const suffix = Math.random().toString(36).slice(2, 10);
+      const [ticket] = await db.insert(tickets).values({
+        partnerId: partner.id,
+        orgId: org.id,
+        ticketNumber: `BILLED-LINEAGE-${suffix}`,
+        subject: 'Billed source lineage fixture',
+        source: 'manual',
+      }).returning({ id: tickets.id });
+
+      const entryRows = await db.insert(timeEntries).values([
+        {
+          partnerId: partner.id,
+          orgId: org.id,
+          ticketId: ticket!.id,
+          userId: user.id,
+          startedAt: new Date('2026-09-01T09:00:00Z'),
+          endedAt: new Date('2026-09-01T10:00:00Z'),
+          currencyCode: 'USD',
+          billingStatus: 'billed',
+        },
+        {
+          partnerId: partner.id,
+          orgId: org.id,
+          ticketId: ticket!.id,
+          userId: user.id,
+          startedAt: new Date('2026-09-01T10:00:00Z'),
+          endedAt: new Date('2026-09-01T11:00:00Z'),
+          currencyCode: 'USD',
+          billingStatus: 'billed',
+        },
+      ]).returning({ id: timeEntries.id });
+      const [orphanEntry, issuedEntry] = entryRows;
+
+      const partRows = await db.insert(ticketParts).values([
+        {
+          ticketId: ticket!.id,
+          orgId: org.id,
+          description: 'Void-lined part',
+          quantity: '1.00',
+          unitPrice: '25.00',
+          currencyCode: 'USD',
+          billingStatus: 'billed',
+        },
+        {
+          ticketId: ticket!.id,
+          orgId: org.id,
+          description: 'Issued part',
+          quantity: '1.00',
+          unitPrice: '30.00',
+          currencyCode: 'USD',
+          billingStatus: 'billed',
+        },
+      ]).returning({ id: ticketParts.id });
+      const [voidPart, issuedPart] = partRows;
+
+      const invoiceRows = await db.insert(invoices).values([
+        {
+          partnerId: partner.id,
+          orgId: org.id,
+          currencyCode: 'USD',
+          status: 'sent',
+          invoiceNumber: `LINEAGE-SENT-${suffix}`,
+        },
+        {
+          partnerId: partner.id,
+          orgId: org.id,
+          currencyCode: 'USD',
+          status: 'void',
+          invoiceNumber: `LINEAGE-VOID-${suffix}`,
+        },
+      ]).returning({ id: invoices.id });
+      const [sentInvoice, voidInvoice] = invoiceRows;
+
+      await db.insert(invoiceLines).values([
+        {
+          invoiceId: sentInvoice!.id,
+          orgId: org.id,
+          sourceType: 'time_entry',
+          sourceId: issuedEntry!.id,
+          description: 'Issued labor',
+          quantity: '1.00',
+          unitPrice: '100.00',
+          lineTotal: '100.00',
+        },
+        {
+          invoiceId: sentInvoice!.id,
+          orgId: org.id,
+          sourceType: 'part',
+          sourceId: issuedPart!.id,
+          description: 'Issued part',
+          quantity: '1.00',
+          unitPrice: '30.00',
+          lineTotal: '30.00',
+        },
+        {
+          invoiceId: voidInvoice!.id,
+          orgId: org.id,
+          sourceType: 'part',
+          sourceId: voidPart!.id,
+          description: 'Voided part',
+          quantity: '1.00',
+          unitPrice: '25.00',
+          lineTotal: '25.00',
+        },
+      ]);
+
+      const first = await applyMigration();
+      expect(first.some((n) => n.includes('reset 1 time_entries row(s)'))).toBe(true);
+      expect(first.some((n) => n.includes('reset 1 ticket_parts row(s)'))).toBe(true);
+
+      const entries = await db.select({ id: timeEntries.id, status: timeEntries.billingStatus }).from(timeEntries);
+      const parts = await db.select({ id: ticketParts.id, status: ticketParts.billingStatus }).from(ticketParts);
+      const entryStatuses = new Map(entries.map((row) => [row.id, row.status]));
+      const partStatuses = new Map(parts.map((row) => [row.id, row.status]));
+      expect(entryStatuses.get(orphanEntry!.id)).toBe('not_billed');
+      expect(entryStatuses.get(issuedEntry!.id)).toBe('billed');
+      expect(partStatuses.get(voidPart!.id)).toBe('not_billed');
+      expect(partStatuses.get(issuedPart!.id)).toBe('billed');
+
+      const second = await applyMigration();
+      expect(second.some((n) => n.includes('reset 0 time_entries row(s)'))).toBe(true);
+      expect(second.some((n) => n.includes('reset 0 ticket_parts row(s)'))).toBe(true);
+    });
+  },
+);

--- a/apps/api/src/__tests__/integration/invoiceIssueRace.integration.test.ts
+++ b/apps/api/src/__tests__/integration/invoiceIssueRace.integration.test.ts
@@ -6,12 +6,14 @@ import { describe, it, expect, vi } from 'vitest';
 // to the test Redis (same rationale as invoiceService.issue.integration).
 vi.mock('../../services/invoiceEvents', () => ({ emitInvoiceEvent: vi.fn().mockResolvedValue(undefined) }));
 vi.mock('../../jobs/invoiceWorker', () => ({ enqueueInvoicePdfRender: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('../../services/timeEntryEvents', () => ({ emitTimeEntryEvent: vi.fn().mockResolvedValue(undefined) }));
 
 import { inArray, sql } from 'drizzle-orm';
 import postgres, { type Sql } from 'postgres';
 import { db, withSystemDbAccessContext, withDbAccessContext, type DbAccessContext } from '../../db';
 import { partners, organizations, users, timeEntries, invoices, invoiceLines } from '../../db/schema';
 import * as svc from '../../services/invoiceService';
+import { deleteTimeEntry } from '../../services/timeEntryService';
 import type { InvoiceActor } from '../../services/invoiceTypes';
 import { getTestDb } from './setup';
 
@@ -176,6 +178,69 @@ function errorCode(result: PromiseSettledResult<unknown>): string | undefined {
 }
 
 describe.runIf(RUN)('issueInvoice race safety (B10)', () => {
+  it('issue wins the source lock before delete: delete observes billed and void is the only release path', async () => {
+    const f = await seedFixture(1);
+    const entryId = f.timeEntryIds[0]!;
+    const draftId = await forgeDraftReferencing(f, [entryId]);
+    const locksHeld = deferred<void>();
+    const releaseLocks = deferred<void>();
+    const holder = postgres(DATABASE_URL, { max: 1, onnotice: () => {} });
+    let holderWork: Promise<void> | undefined;
+    try {
+      holderWork = holder.begin(async (tx) => {
+        await tx`SELECT id FROM public.time_entries WHERE id = ${entryId} FOR UPDATE`;
+        locksHeld.resolve();
+        await releaseLocks.promise;
+      });
+      await locksHeld.promise;
+
+      const issue = withDbAccessContext(ctx(f), () => svc.issueInvoice(draftId, actor(f)));
+      await waitForBlockedBackends(1);
+      const deletion = withDbAccessContext(ctx(f), () => deleteTimeEntry(entryId, {
+        userId: f.userId,
+        name: 'Billing admin',
+        partnerId: f.partnerId,
+        manageAll: true,
+        accessibleOrgIds: [f.orgId],
+      }));
+      await waitForBlockedBackends(2);
+      releaseLocks.resolve();
+      await holderWork;
+
+      const [issueResult, deleteResult] = await Promise.allSettled([issue, deletion]);
+      expect(issueResult).toMatchObject({
+        status: 'fulfilled',
+        value: expect.objectContaining({ id: draftId, status: 'sent' }),
+      });
+      expect(deleteResult).toMatchObject({
+        status: 'rejected',
+        reason: expect.objectContaining({ code: 'ENTRY_BILLED', status: 409 }),
+      });
+
+      const [stillBilled] = await withSystemDbAccessContext(() =>
+        db.select({ status: timeEntries.billingStatus }).from(timeEntries)
+          .where(inArray(timeEntries.id, [entryId])));
+      expect(stillBilled?.status).toBe('billed');
+
+      await withDbAccessContext(ctx(f), () => svc.voidInvoice(draftId, 'test release', {}, actor(f)));
+      await withDbAccessContext(ctx(f), () => deleteTimeEntry(entryId, {
+        userId: f.userId,
+        name: 'Billing admin',
+        partnerId: f.partnerId,
+        manageAll: true,
+        accessibleOrgIds: [f.orgId],
+      }));
+      const afterDelete = await withSystemDbAccessContext(() =>
+        db.select({ id: timeEntries.id }).from(timeEntries)
+          .where(inArray(timeEntries.id, [entryId])));
+      expect(afterDelete).toEqual([]);
+    } finally {
+      releaseLocks.resolve();
+      if (holderWork) await Promise.allSettled([holderWork]);
+      await closeRaceClients(holder);
+    }
+  }, 30_000);
+
   it('two drafts over the SAME not_billed sources: exactly one issues, loser gets SOURCE_ALREADY_BILLED after lock-wait', async () => {
     const f = await seedFixture(2);
     const draftA = await forgeDraftReferencing(f, f.timeEntryIds);

--- a/apps/api/src/routes/tickets/parts.test.ts
+++ b/apps/api/src/routes/tickets/parts.test.ts
@@ -160,6 +160,17 @@ describe('parts routes', () => {
     expect(body.data).toHaveProperty('id', PART_ID);
   });
 
+  it('rejects billed on create before ticket lookup or service work', async () => {
+    const res = await ticketsRoutes.request(`/${TICKET_ID}/parts`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ description: 'SSD', quantity: 1, billingStatus: 'billed' })
+    });
+    expect(res.status).toBe(400);
+    expect(getScopedTicketOr404Mock).not.toHaveBeenCalled();
+    expect(timeServiceMocks.addTicketPart).not.toHaveBeenCalled();
+  });
+
   it('passes a catalogItemId through to the service (#1368 catalog link)', async () => {
     getScopedTicketOr404Mock.mockResolvedValue({ id: TICKET_ID, orgId: 'o-1', deviceId: null });
     timeServiceMocks.addTicketPart.mockResolvedValue({ id: PART_ID });
@@ -226,6 +237,18 @@ describe('parts routes', () => {
     });
     expect(res.status).toBe(200);
     expect(timeServiceMocks.updateTicketPart).toHaveBeenCalled();
+  });
+
+  it('rejects billed on update before part or ticket lookup and service work', async () => {
+    const res = await ticketsRoutes.request(`/parts/${PART_ID}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ billingStatus: 'billed' })
+    });
+    expect(res.status).toBe(400);
+    expect(dbSelectMock).not.toHaveBeenCalled();
+    expect(getScopedTicketOr404Mock).not.toHaveBeenCalled();
+    expect(timeServiceMocks.updateTicketPart).not.toHaveBeenCalled();
   });
 
   it('DELETE /parts/:id 404s for out-of-scope ticket', async () => {

--- a/apps/api/src/routes/timeEntries/timeEntries.test.ts
+++ b/apps/api/src/routes/timeEntries/timeEntries.test.ts
@@ -173,6 +173,15 @@ describe('POST /bulk-approve', () => {
 });
 
 describe('PATCH /:id and DELETE /:id', () => {
+  it('rejects billed as an invoice-only lifecycle state before the update service', async () => {
+    const res = await timeEntriesRoutes.request(`/${TIME_ENTRY_ID}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ billingStatus: 'billed' })
+    });
+    expect(res.status).toBe(400);
+    expect(serviceMocks.updateTimeEntry).not.toHaveBeenCalled();
+  });
   it('PATCH /:id passes the parsed update body and actor to the service', async () => {
     serviceMocks.updateTimeEntry.mockResolvedValue({ id: TIME_ENTRY_ID, description: 'fixed' });
     const res = await timeEntriesRoutes.request(`/${TIME_ENTRY_ID}`, {
@@ -218,6 +227,22 @@ describe('PATCH /:id and DELETE /:id', () => {
     const res = await timeEntriesRoutes.request(`/${TIME_ENTRY_ID}`, { method: 'DELETE' });
     expect(res.status).toBe(404);
     expect(await res.json()).toMatchObject({ code: 'ENTRY_NOT_FOUND' });
+  });
+});
+
+describe('POST /time-entries billed-state admission', () => {
+  it('rejects billed before the create service', async () => {
+    const res = await timeEntriesRoutes.request('/', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        startedAt: '2026-06-11T09:00:00Z',
+        endedAt: '2026-06-11T09:30:00Z',
+        billingStatus: 'billed'
+      })
+    });
+    expect(res.status).toBe(400);
+    expect(serviceMocks.createTimeEntry).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/services/timeEntryService.test.ts
+++ b/apps/api/src/services/timeEntryService.test.ts
@@ -19,6 +19,7 @@ const { dbMocks, emitMock, configMocks } = vi.hoisted(() => {
     forUpdateCalls: 0,
     deleteError: null as Error | null,
     deleteResult: [] as unknown[],
+    deleteCalls: 0,
   };
   const configMocks = {
     getOrgBillingDefaults: vi.fn().mockResolvedValue(null),
@@ -99,6 +100,7 @@ vi.mock('../db', () => ({
     })),
     delete: vi.fn(() => ({
       where: vi.fn(() => {
+        dbMocks.deleteCalls += 1;
         const terminal = dbMocks.deleteError
           ? Promise.reject(dbMocks.deleteError)
           : Promise.resolve();
@@ -143,6 +145,7 @@ vi.mock('../db/schema', () => ({
 import {
   computeDurationMinutes, createTimeEntry, startTimer, stopTimer,
   updateTimeEntry, deleteTimeEntry, approveTimeEntries, addTicketPart, updateTicketPart,
+  deleteTicketPart,
   getTimesheet, getTicketBillingSummary, listBillables, entryOrgAllowed, resolveDefaultRate,
   resolveAndLockOrgLink, readTimeEntryById, getTicketTimeEntryDefaults
 } from './timeEntryService';
@@ -188,6 +191,7 @@ beforeEach(() => {
   dbMocks.forUpdateCalls = 0;
   dbMocks.deleteError = null;
   dbMocks.deleteResult = [];
+  dbMocks.deleteCalls = 0;
   emitMock.mockClear();
   configMocks.getOrgBillingDefaults.mockResolvedValue(null);
 });
@@ -655,14 +659,67 @@ describe('deleteTimeEntry', () => {
     dbMocks.selectResults.push([{ id: 'te-1', userId: 'u-1', isApproved: true, partnerId: 'p-1', ticketId: null }]);
     await expect(deleteTimeEntry('te-1', ACTOR)).rejects.toMatchObject({ code: 'APPROVED_IMMUTABLE' });
   });
-  it('owner deletes own unapproved entry: emits deleted event with entry userId', async () => {
-    dbMocks.selectResults.push([{ id: 'te-1', userId: 'u-1', isApproved: false, partnerId: 'p-1', ticketId: null }]);
-    await deleteTimeEntry('te-1', ACTOR);
-    expect(emitMock).toHaveBeenCalledWith(expect.objectContaining({
-      type: 'time_entry.deleted',
-      payload: expect.objectContaining({ userId: 'u-1' })
-    }));
+  it.each(['not_billed', 'no_charge', 'contract'] as const)(
+    'owner deletes an own unapproved %s entry and emits its userId',
+    async (billingStatus) => {
+      dbMocks.selectResults.push([{
+        id: 'te-1', userId: 'u-1', isApproved: false, partnerId: 'p-1',
+        ticketId: null, billingStatus,
+      }]);
+      await deleteTimeEntry('te-1', ACTOR);
+      expect(dbMocks.deleteCalls).toBe(1);
+      expect(emitMock).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'time_entry.deleted',
+        payload: expect.objectContaining({ userId: 'u-1' })
+      }));
+    },
+  );
+
+  it('409s before delete, feed, audit, or lifecycle event when the locked entry is billed', async () => {
+    const recordAuditMutation = vi.fn();
+    dbMocks.selectResults.push([{
+      id: 'te-billed', orgId: 'o-1', userId: 'u-1', isApproved: false,
+      partnerId: 'p-1', ticketId: 't-1', durationMinutes: 30,
+      billingStatus: 'billed',
+    }]);
+
+    await expect(deleteTimeEntry('te-billed', { ...ACTOR, recordAuditMutation }))
+      .rejects.toMatchObject({ code: 'ENTRY_BILLED', status: 409 });
+
+    expect(dbMocks.deleteCalls).toBe(0);
+    expect(dbMocks.insertedValues).toHaveLength(0);
+    expect(recordAuditMutation).not.toHaveBeenCalled();
+    expect(emitMock).not.toHaveBeenCalled();
+    expect(dbMocks.forUpdateCalls).toBe(1);
   });
+});
+
+describe('deleteTicketPart', () => {
+  it('409s before delete when the locked part is billed', async () => {
+    dbMocks.selectResults.push([{
+      id: 'part-billed', billingStatus: 'billed', currencyCode: 'USD',
+    }]);
+
+    await expect(deleteTicketPart('part-billed', ACTOR))
+      .rejects.toMatchObject({ code: 'PART_BILLED', status: 409 });
+
+    expect(dbMocks.deleteCalls).toBe(0);
+    expect(dbMocks.forUpdateCalls).toBe(1);
+  });
+
+  it.each(['not_billed', 'no_charge', 'contract'] as const)(
+    'allows deletion after locked re-read when status is %s',
+    async (billingStatus) => {
+      dbMocks.selectResults.push([{
+        id: `part-${billingStatus}`, billingStatus, currencyCode: 'USD',
+      }]);
+
+      await deleteTicketPart(`part-${billingStatus}`, ACTOR);
+
+      expect(dbMocks.deleteCalls).toBe(1);
+      expect(dbMocks.forUpdateCalls).toBe(1);
+    },
+  );
 });
 
 describe('approveTimeEntries', () => {
@@ -973,6 +1030,52 @@ describe('addTicketPart', () => {
     dbMocks.insertResult = [];
     await expect(addTicketPart('t-3', { description: 'Cable', quantity: 1, unitPrice: 5 }, ACTOR))
       .rejects.toThrow('Failed to create ticket part');
+  });
+});
+
+describe('routine billed-state admission', () => {
+  const range = {
+    startedAt: new Date('2026-06-11T09:00:00Z'),
+    endedAt: new Date('2026-06-11T09:30:00Z'),
+  };
+
+  it('rejects billed on time-entry creation before any database work', async () => {
+    await expect(createTimeEntry(
+      { ...range, billingStatus: 'billed' } as never,
+      ACTOR,
+    )).rejects.toMatchObject({ code: 'BILLING_STATUS_RESERVED', status: 409 });
+    expect(dbMocks.insertedValues).toHaveLength(0);
+    expect(dbMocks.selectResults).toHaveLength(0);
+  });
+
+  it('rejects a direct transition to billed before locking or updating the entry', async () => {
+    await expect(updateTimeEntry(
+      'te-1',
+      { billingStatus: 'billed' } as never,
+      ACTOR,
+    )).rejects.toMatchObject({ code: 'BILLING_STATUS_RESERVED', status: 409 });
+    expect(dbMocks.forUpdateCalls).toBe(0);
+    expect(dbMocks.updateSetArgs).toHaveLength(0);
+  });
+
+  it('rejects billed on part creation before ticket lookup or insert', async () => {
+    await expect(addTicketPart(
+      't-1',
+      { description: 'SSD', quantity: 1, billingStatus: 'billed' } as never,
+      ACTOR,
+    )).rejects.toMatchObject({ code: 'BILLING_STATUS_RESERVED', status: 409 });
+    expect(dbMocks.forUpdateCalls).toBe(0);
+    expect(dbMocks.insertedValues).toHaveLength(0);
+  });
+
+  it('rejects a direct transition to billed before locking or updating the part', async () => {
+    await expect(updateTicketPart(
+      'part-1',
+      { billingStatus: 'billed' } as never,
+      ACTOR,
+    )).rejects.toMatchObject({ code: 'BILLING_STATUS_RESERVED', status: 409 });
+    expect(dbMocks.forUpdateCalls).toBe(0);
+    expect(dbMocks.updateSetArgs).toHaveLength(0);
   });
 });
 

--- a/apps/api/src/services/timeEntryService.ts
+++ b/apps/api/src/services/timeEntryService.ts
@@ -21,6 +21,8 @@ export type TimeEntryServiceErrorCode =
   | 'PARTNER_UNRESOLVABLE'
   | 'INVALID_RANGE'
   | 'CURRENCY_MISMATCH'
+  /** 409 — `billed` is written only by the locked invoice-issue transition. */
+  | 'BILLING_STATUS_RESERVED'
   /** 409 — issueInvoice already flipped the row to `billed`; only description-class fields may change. */
   | 'ENTRY_BILLED'
   | 'PART_BILLED'
@@ -127,6 +129,17 @@ function assertRepresentable(value: string | null, currencyCode: string | null):
     throw new TimeEntryServiceError(
       `${value} is not representable in ${currencyCode} — this currency has ${minorUnitExponent(currencyCode)} decimal place(s)`,
       400, 'PRICE_NOT_REPRESENTABLE'
+    );
+  }
+}
+
+/** Reject a forged invoice lifecycle fact at every routine service entrypoint. */
+function assertRoutineBillingStatus(status: BillingStatus | undefined): void {
+  if (status === 'billed') {
+    throw new TimeEntryServiceError(
+      'Billed status is assigned only when an invoice is issued',
+      409,
+      'BILLING_STATUS_RESERVED',
     );
   }
 }
@@ -444,6 +457,7 @@ export async function createTimeEntry(
   actor: TimeEntryActor,
   provenance: TimeEntryProvenance = { source: 'manual' },
 ) {
+  assertRoutineBillingStatus(input.billingStatus);
   let partnerId = actor.partnerId;
   let orgId: string | null = null;
   let defaultBillable = false;
@@ -740,6 +754,7 @@ function assertCanMutate(entry: { userId: string; isApproved: boolean }, actor: 
 }
 
 export async function updateTimeEntry(id: string, input: UpdateTimeEntryInput, actor: TimeEntryActor) {
+  assertRoutineBillingStatus(input.billingStatus);
   // Global lock order: the TARGET ticket (relink) before the entry row.
   const link = typeof input.ticketId === 'string' ? await resolveAndLockTicketLink(input.ticketId, actor) : null;
   const entry = await getEntryOr404(id, actor); // FOR UPDATE — re-read under lock
@@ -834,6 +849,13 @@ export async function updateTimeEntry(id: string, input: UpdateTimeEntryInput, a
 export async function deleteTimeEntry(id: string, actor: TimeEntryActor) {
   const entry = await getEntryOr404(id, actor);
   assertCanMutate(entry, actor);
+  if (entry.billingStatus === 'billed') {
+    throw new TimeEntryServiceError(
+      'This entry has been invoiced and cannot be deleted; void the invoice first',
+      409,
+      'ENTRY_BILLED',
+    );
+  }
   const deleted = await db
     .delete(timeEntries)
     .where(eq(timeEntries.id, id))
@@ -942,6 +964,7 @@ export async function approveTimeEntries(ids: string[], approve: boolean, actor:
 // ── Parts ────────────────────────────────────────────────────────────────
 
 export async function addTicketPart(ticketId: string, input: TicketPartInput, actor: TimeEntryActor) {
+  assertRoutineBillingStatus(input.billingStatus);
   // Lock order tickets → ticket_parts (see lockTicketRow).
   const link = await resolveAndLockTicketLink(ticketId, actor);
   const partUnitPrice = (input.unitPrice ?? 0).toFixed(2);
@@ -985,6 +1008,7 @@ async function getPartOr404(id: string) {
 
 /** `set` must never contain currencyCode: the part's currency is a creation-time snapshot. */
 export async function updateTicketPart(id: string, input: Partial<TicketPartInput>, _actor: TimeEntryActor) {
+  assertRoutineBillingStatus(input.billingStatus);
   const part = await getPartOr404(id);
   if (part.billingStatus === 'billed' && BILLED_LOCKED_PART_FIELDS.some((k) => input[k] !== undefined)) {
     throw new TimeEntryServiceError('This part has been invoiced; only its description, vendor, part number and notes can change', 409, 'PART_BILLED');
@@ -1011,7 +1035,14 @@ export async function updateTicketPart(id: string, input: Partial<TicketPartInpu
 }
 
 export async function deleteTicketPart(id: string, _actor: TimeEntryActor) {
-  await getPartOr404(id);
+  const part = await getPartOr404(id);
+  if (part.billingStatus === 'billed') {
+    throw new TimeEntryServiceError(
+      'This part has been invoiced and cannot be deleted; void the invoice first',
+      409,
+      'PART_BILLED',
+    );
+  }
   await db.delete(ticketParts).where(eq(ticketParts.id, id));
 }
 

--- a/packages/shared/src/validators/timeEntries.test.ts
+++ b/packages/shared/src/validators/timeEntries.test.ts
@@ -8,6 +8,12 @@ import {
 const UUID = '3f2f1d8e-1111-4222-8333-444455556666';
 
 describe('createTimeEntrySchema', () => {
+  it('reserves billed for invoice issuance while retaining technician dispositions', () => {
+    const base = { startedAt: '2026-06-11T09:00:00Z', endedAt: '2026-06-11T09:30:00Z' };
+    expect(createTimeEntrySchema.safeParse({ ...base, billingStatus: 'billed' }).success).toBe(false);
+    expect(createTimeEntrySchema.safeParse({ ...base, billingStatus: 'no_charge' }).success).toBe(true);
+    expect(createTimeEntrySchema.safeParse({ ...base, billingStatus: 'contract' }).success).toBe(true);
+  });
   it('accepts a minimal manual entry', () => {
     const r = createTimeEntrySchema.safeParse({
       startedAt: '2026-06-11T09:00:00Z',
@@ -61,6 +67,11 @@ describe('listTimeEntriesQuerySchema', () => {
 });
 
 describe('updateTimeEntrySchema', () => {
+  it('reserves billed for invoice issuance while retaining technician dispositions', () => {
+    expect(updateTimeEntrySchema.safeParse({ billingStatus: 'billed' }).success).toBe(false);
+    expect(updateTimeEntrySchema.safeParse({ billingStatus: 'no_charge' }).success).toBe(true);
+    expect(updateTimeEntrySchema.safeParse({ billingStatus: 'contract' }).success).toBe(true);
+  });
   it('rejects empty object (at-least-one-field refine)', () => {
     expect(updateTimeEntrySchema.safeParse({}).success).toBe(false);
   });
@@ -91,6 +102,12 @@ describe('bulkApproveSchema', () => {
 });
 
 describe('ticketPartSchema', () => {
+  it('reserves billed for invoice issuance while retaining technician dispositions', () => {
+    const base = { description: 'SSD', quantity: 1 };
+    expect(ticketPartSchema.safeParse({ ...base, billingStatus: 'billed' }).success).toBe(false);
+    expect(ticketPartSchema.safeParse({ ...base, billingStatus: 'no_charge' }).success).toBe(true);
+    expect(ticketPartSchema.safeParse({ ...base, billingStatus: 'contract' }).success).toBe(true);
+  });
   it('accepts a minimal part', () => {
     expect(ticketPartSchema.safeParse({ description: 'SSD 1TB', quantity: 1 }).success).toBe(true);
   });
@@ -102,6 +119,11 @@ describe('ticketPartSchema', () => {
 });
 
 describe('updateTicketPartSchema', () => {
+  it('reserves billed for invoice issuance while retaining technician dispositions', () => {
+    expect(updateTicketPartSchema.safeParse({ billingStatus: 'billed' }).success).toBe(false);
+    expect(updateTicketPartSchema.safeParse({ billingStatus: 'no_charge' }).success).toBe(true);
+    expect(updateTicketPartSchema.safeParse({ billingStatus: 'contract' }).success).toBe(true);
+  });
   it('rejects empty object (at-least-one-field refine)', () => {
     expect(updateTicketPartSchema.safeParse({}).success).toBe(false);
   });

--- a/packages/shared/src/validators/timeEntries.ts
+++ b/packages/shared/src/validators/timeEntries.ts
@@ -3,6 +3,10 @@ import { optionalQueryBoolean } from './queryParams';
 
 export const billingStatusSchema = z.enum(['not_billed', 'billed', 'no_charge', 'contract']);
 export type BillingStatus = z.infer<typeof billingStatusSchema>;
+// `billed` is an invoice lifecycle fact, not a routine time/part disposition.
+// Invoice issue writes it internally after locking the invoice and every source;
+// public create/update inputs retain the technician-owned dispositions only.
+const routineBillingStatusSchema = z.enum(['not_billed', 'no_charge', 'contract']);
 
 const CLOCK_SKEW_MS = 5 * 60_000;
 const notFarFuture = (d: Date) => d.getTime() <= Date.now() + CLOCK_SKEW_MS;
@@ -19,7 +23,7 @@ export const createTimeEntrySchema = z.object({
   description: z.string().max(10_000).optional(),
   isBillable: z.boolean().optional(),
   hourlyRate: z.number().nonnegative().multipleOf(0.01).nullable().optional(),
-  billingStatus: billingStatusSchema.optional()
+  billingStatus: routineBillingStatusSchema.optional()
 }).refine((v) => v.endedAt.getTime() > v.startedAt.getTime(), {
   message: 'endedAt must be after startedAt',
   path: ['endedAt']
@@ -32,7 +36,7 @@ export const updateTimeEntrySchema = z.object({
   description: z.string().max(10_000).nullable().optional(),
   isBillable: z.boolean().optional(),
   hourlyRate: z.number().nonnegative().multipleOf(0.01).nullable().optional(),
-  billingStatus: billingStatusSchema.optional()
+  billingStatus: routineBillingStatusSchema.optional()
 }).refine((v) => Object.keys(v).length > 0, { message: 'At least one field is required' });
 
 export const startTimerSchema = z.object({
@@ -83,7 +87,7 @@ export const ticketPartSchema = z.object({
   unitPrice: z.number().nonnegative().multipleOf(0.01).default(0),
   costBasis: z.number().nonnegative().multipleOf(0.01).nullable().optional(),
   isBillable: z.boolean().optional(),
-  billingStatus: billingStatusSchema.optional(),
+  billingStatus: routineBillingStatusSchema.optional(),
   notes: z.string().max(10_000).optional()
 });
 


### PR DESCRIPTION
## Summary

`billed` on a `time_entries` / `ticket_parts` row is an **invoice lifecycle fact**: it is written only by the locked invoice-issue transition, and released only by invoice void. Two routine paths let ordinary ticket/time authority write or destroy that fact outside the invoice lifecycle.

### SEC-105 (Medium) — a billed source could be deleted

`deleteTimeEntry` / `deleteTicketPart` deleted a row regardless of its billing state. The issued invoice line survives the delete (`invoice_lines.source_id` is polymorphic convention, **not** a foreign key), so the invoice still totals correctly — but the operational source row and its live linkage are destroyed, with no supported way back and no record that the source ever existed.

Both services now reject a **locked** billed row with `409 ENTRY_BILLED` / `409 PART_BILLED` before any delete, activity-feed write, audit write or lifecycle event. The check reuses each service's existing `FOR UPDATE` re-read (`getEntryOr404` / `getPartOr404`), so invoice issue, invoice void and deletion all serialize on the same row:

- issue wins → delete observes `billed` and 409s;
- delete wins first → issue's existing source validation fails and its transaction rolls back.

No invoice permission override was added. **Invoice void remains the only release path**, and `not_billed` / `no_charge` / `contract` rows keep their ordinary deletion rules.

### SEC-154 (Medium, financial integrity) — `billed` was writable by routine APIs

`createTimeEntrySchema`, `updateTimeEntrySchema`, `ticketPartSchema` and `updateTicketPartSchema` accepted `billingStatus: 'billed'` straight from the request body, so any actor with time/part write permission could stamp a row as invoiced with no invoice behind it. Downstream that row is then excluded from invoice assembly (`invoiceAssembly` only picks up `not_billed`), silently dropping billable work off future invoices, and it inherits the SEC-105 delete protection above.

- **Validators**: create/update inputs now admit only the technician-owned dispositions (`not_billed`, `no_charge`, `contract`). The **list-query filter keeps `billed`** — filtering by it is legitimate.
- **Service layer**: `createTimeEntry`, `updateTimeEntry`, `addTicketPart` and `updateTicketPart` assert the same invariant *before* any lock or write (`409 BILLING_STATUS_RESERVED`), so non-HTTP callers (AI ticketing tools, Office add-in, time-suggestion service) are covered too, not just the zod boundary.
- **Migration** `2026-10-15-160150-repair-orphan-billed-sources.sql`: returns historical `billed` rows with **no invoice line on an issued, non-void invoice** (`sent`/`partially_paid`/`overdue`/`paid`) to `not_billed`, so they become invoice candidates again. Idempotent; elects `breeze.scope = system` before the DML; a data-modifying CTE reports both the row count (including `0`) **and the affected ids** (capped at 200) via `RAISE WARNING`, because an irreversible reset cannot be reconciled from a bare count.

  Lineage is `(invoice_lines.source_type, invoice_lines.source_id)` plus the invoice status and **nothing else — deliberately no org conjunct**. `moveTicketOrg` re-stamps `time_entries`/`ticket_parts` by `ticket_id` with no `billing_status` filter (`ticketOrgMoveLockOrder.ts`; `ticketMoveCurrencyGuard` only guards `not_billed` rows), while `invoice_lines`/`invoices` are excluded from that rewrite by design — issued billing history keeps the org that was billed. So after a ticket org move a genuinely invoiced source legitimately sits under a *different* org than its line, and an `il.org_id = te.org_id` conjunct would un-bill it and hand it back to `invoiceAssembly` to bill twice. `source_id` is a UUID and the statement runs system-scoped, so the pair is already exact.

  `draft` is deliberately **not** in the preserved list: `issueInvoice` is the only writer of `billed` and sets `status='sent'` in the same transaction, so billed + draft is reachable only by forgery — and leaving it billed would wedge that draft forever on `SOURCE_ALREADY_BILLED`. `void` is absent because `voidInvoice` already releases its sources.

  Both statements sequentially scan `time_entries` / `ticket_parts` (there is no `billing_status` index). These are human-entered tables — thousands of rows, not millions — so one boot-time full scan is acceptable and no index is added.

## Ported from

Two locally-tested commits from the private security remediation program, cherry-picked with `-x` onto current `main` and squashed into one commit (both edit `services/timeEntryService.ts`; they are one billing-lineage family).

| Local SHA | Finding |
|---|---|
| `9938ea9ff2cf4996f09acdbc7d7eb17b681cf02d` | SEC-2026-09-05-105 — preserve invoiced source records |
| `675792c80b7a97d52601d836b826c493f8db4935` | SEC-2026-09-05-154 — reserve `billed` for invoice issue |

Changed vs. the original commits:

- **Migration renamed** `2026-10-12-110000-…` → `2026-10-15-160150-repair-orphan-billed-sources.sql` so it sorts after the newest committed migration (`2026-10-15-160010-backup-snapshots-layout-manifest.sql`). The path reference in `billedSourceLineageMigration.integration.test.ts` was updated to match; a repo-wide grep confirms no other reference to the old name.
- **Nothing dropped.** Both cherry-picks applied without conflict. Main had moved under `timeEntryService.ts` (`getTicketTimeEntryDefaults`, #5321) and under `parts.test.ts` / `timeEntryService.test.ts`, but only additively — no hunk of either fix was already present on main in equivalent form.
- No schema column was added, so no `CORE_TENANT_EXPORT_POLICY` / cascade-list registration applies (contract suites run below confirm).

## Verification

Test stack: ephemeral pg+redis via `pnpm test-stack up`. All commands run from the worktree.

**Red-first (mandatory).** Ported tests were run against `origin/main`'s versions of the two non-test source files (`git checkout origin/main -- apps/api/src/services/timeEntryService.ts packages/shared/src/validators/timeEntries.ts`) — **verified**:

```
# RED — main's source, ported tests
cd apps/api && npx vitest run --pool=threads --maxWorkers=2 \
  src/services/timeEntryService src/routes/timeEntries src/routes/tickets/parts
  → 3 files failed | 1 passed (4);  10 failed | 196 passed (206)

cd packages/shared && npx vitest run src/validators/timeEntries
  → 1 file failed (1);  4 failed | 29 passed (33)
```

The 14 red tests were exactly the ported ones:

- `deleteTimeEntry > 409s before delete, feed, audit, or lifecycle event when the locked entry is billed`
- `deleteTicketPart > 409s before delete when the locked part is billed`
- `routine billed-state admission > {create,update} × {time entry, part}` (4)
- `timeEntries.test.ts > rejects billed as an invoice-only lifecycle state before the update service`
- `timeEntries.test.ts > rejects billed before the create service`
- `parts.test.ts > rejects billed on {create,update} …` (2)
- shared `{create,update}TimeEntrySchema` / `{ticketPart,updateTicketPart}Schema > reserves billed for invoice issuance…` (4)

```
# GREEN — restored (git checkout HEAD -- <same files>)
cd apps/api && npx vitest run --pool=threads --maxWorkers=2 \
  src/services/timeEntryService src/routes/timeEntries src/routes/tickets/parts
  → 4 files passed;  206 passed (206)
```

**Unit (API)** — verified:
```
cd apps/api && npx vitest run --pool=threads --maxWorkers=2 \
  src/services/timeEntryService src/services/invoiceService \
  src/routes/timeEntries src/routes/tickets/parts src/routes/invoices
  → 14 files passed;  481 passed (481)

# every unit test file that touches timeEntryService / billingStatus / ticketParts
cd apps/api && npx vitest run --pool=threads --maxWorkers=2 \
  src/__tests__/partner-wide-write-coverage src/routes/ai.ticket src/routes/tickets/tickets \
  src/routes/timeEntries src/routes/tickets/parts src/services/aiToolsTicketing \
  src/routes/officeAddin src/services/timeSuggestionService src/services/timeEntryService \
  src/services/invoiceService src/routes/invoices src/services/invoiceAssembly
  → 29 files passed;  906 passed (906)
```
**Not checked**: the *whole* `apps/api` unit suite. It was started but killed before completion — the machine was running five other test suites concurrently and the run was making almost no progress. The 29-file sweep above covers every unit test file that imports `timeEntryService`, references `billingStatus`, or exercises ticket parts, which is the reachable blast radius of this diff. CI's `test-api` job will run the rest.

**Migration guards** — verified:
```
bash scripts/check-migration-naming.sh                      → check-migration-naming: OK
cd apps/api && npx vitest run --pool=threads --maxWorkers=2 \
  src/db/autoMigrate.test.ts src/db/migrationRlsScope.test.ts
  → 2 files passed;  103 passed (103)
```

**Integration** — verified (`vitest.integration.config.ts`, real Postgres as `breeze_app`):
```
cd apps/api && npx vitest run --config vitest.integration.config.ts --pool=threads --maxWorkers=2 \
  invoice Invoice ticket Ticket timeEntr timeentr billed
  → 44 files passed;  245 passed (245)
```
The new `billedSourceLineageMigration.integration.test.ts` was confirmed to actually **run** (not `runIf`-skipped) via a `--reporter=verbose` re-run: `✓ … repairs only unlined or void-lined sources as breeze_app and is idempotent 393ms`. It proves the lineage filter (issued line kept `billed`, void-lined and unlined reset), the `breeze_app` (non-superuser) path, the reported row counts, and idempotency (second apply reports `reset 0`).

**Contract suites** — verified:
```
cd apps/api && npx vitest run --config vitest.integration.config.ts --pool=threads --maxWorkers=2 \
  rls-coverage tenant-export-policy tenantCascade tenantExportErasureRoundtrip
  → 7 files passed;  45 passed (45)

cd apps/api && npx vitest run --config vitest.config.integration-suite-coverage.ts
  → 1 file passed;  5 passed (5)   # proves the new integration file lands in a CI shard
```

**Typecheck / lint** — verified:
```
cd apps/api        && NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit   → clean
cd apps/web        && NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit   → clean
cd packages/shared && npx vitest run                                            → 101 files, 2559 passed
cd apps/api        && npx eslint <6 touched files>                              → clean
cd packages/shared && npx eslint <2 touched files>                              → clean
```
`packages/shared && npx tsc --noEmit` reports 3 errors in `src/validators/quotes.test.ts` — **verified pre-existing on `origin/main`**: reverting only this PR's two shared files to `origin/main` reproduces the identical 3 errors, and `git diff origin/main -- packages/shared/src/validators/quotes.test.ts` is empty.

**Call-site sweep** — verified: no UI, add-in, mobile or AI-tool caller sends `billingStatus: 'billed'` on create/update. `apps/web` and `apps/mobile` only *read* it (badges, disabled states) and `apps/mobile` declares its own local `BillingStatus` union. `addinLogTimeSchema` has no `billingStatus` field at all. The only writers of `billed` are `invoiceService.issueInvoice` (and `voidInvoice` writing it back to `not_billed`), which do not go through these validators.

**Rebased** onto `origin/main` (`e4fbca279d`) and the touched unit + migration-guard suites re-run green afterwards (6 files, 309 passed; shared 33 passed; `check-migration-naming: OK`).

**Not checked**: no browser/E2E walkthrough, no multi-replica or failure-injection test, and no dedicated real-Postgres fixture for *ticket-part* deletion (the part path is covered by the same `FOR UPDATE` service pattern and focused unit tests; the real-Postgres race fixture in `invoiceIssueRace.integration.test.ts` covers the time-entry path end to end).

## Review fixes (commit `09ebeda4ce`)

**BLOCKER — the repair migration's org conjuncts un-billed legitimately invoiced work.** Matching the invoice line on `(source_type, source_id, org_id)` broke for any source whose ticket had been moved between orgs: `moveTicketOrg` re-stamps `time_entries`/`ticket_parts` by `ticket_id` with no `billing_status` filter, `invoice_lines`/`invoices` are excluded from that rewrite by design, so the orgs diverge, `NOT EXISTS` becomes true, the row resets to `not_billed` at boot and `invoiceAssembly` bills it a second time. **Both org conjuncts (`il.org_id = te.org_id` and the `i.org_id = il.org_id` join term) are dropped.**

Also applied: the `draft` exclusion and the full-scan cost are now stated in the migration header, and the `RAISE WARNING` names the affected ids (capped at 200) via a data-modifying CTE instead of reporting only a count.

**Red-first for the blocker** — verified. Against the *previous* (org-conjunct) migration, with the new fixtures in place:
```
cd apps/api && npx vitest run --config vitest.integration.config.ts --pool=threads --maxWorkers=2 \
  --reporter=verbose src/__tests__/integration/billedSourceLineageMigration
  → 1 file failed;  3 failed (3)
```
`preserves a billed source whose issued invoice line sits under a different org (moved ticket)` failed on its own assertions (`reset 0` and `billingStatus` still `billed`) — that red **is** the blocker, not an incidental assertion. After the fix, all three pass:
```
  ✓ repairs only unlined or void-lined sources as breeze_app and is idempotent
  ✓ preserves a billed source whose issued invoice line sits under a different org (moved ticket)
  ✓ resets a billed source whose only invoice line sits on a draft invoice
  → 1 file passed;  3 passed (3)
```
(The checksum guard fired on the first green attempt because the test database had already recorded the pre-fix file — the migration is unmerged and therefore editable, so the fix was to recreate the test stack, not to add a second migration.)

**Full re-verification after the fix** — all verified:

| Gate | Result |
|---|---|
| `check-migration-naming.sh` | OK |
| `autoMigrate.test.ts` + `migrationRlsScope.test.ts` | 2 files, **103 passed** |
| unit sweep (29 dependent files) | **906 passed** |
| `packages/shared` validators | **33 passed** |
| integration `invoice Invoice ticket Ticket timeEntr timeentr billed` | 44 files, **247 passed** (was 245; +2 new fixtures) |
| contract `rls-coverage tenant-export-policy tenantCascade tenantExportErasureRoundtrip` | 7 files, **45 passed** |
| `integration-suite-coverage` | **5 passed** |
| `apps/api` `tsc --noEmit` (8 GB heap) | clean |
| eslint, 6 API + 2 shared touched files | clean |

## Operator impact

- **Behaviour change (intentional).** `POST`/`PATCH` on time entries and ticket parts now **400** on `billingStatus: 'billed'`, rejected at the zod boundary. That 400 is the client contract. The service-level `409 BILLING_STATUS_RESERVED` is **defence-in-depth only and unreachable over HTTP** (the validators reject first); it exists for direct in-process callers and should not be documented or relied on as an API response. No shipped UI offers `billed` as a settable option, so no first-party client regresses. Any external integration that was setting `billed` directly must stop; issue an invoice instead.
- **Deleting an invoiced time entry or part now 409s** (`ENTRY_BILLED` / `PART_BILLED`) with a message pointing at invoice void. Voiding the invoice releases the sources to `not_billed`, after which deletion works as before.
- **The migration mutates data.** On deploy it resets `billed` rows that have no invoice line on an issued (non-void) invoice back to `not_billed`, which makes them eligible for a future invoice again. It logs `orphan billed-source repair: reset N …` at `WARNING` for both tables even when `N = 0` — **check the Postgres log after deploy and record the counts**. Non-zero counts on a production database indicate rows that were forged or orphaned historically and are now invoice candidates; review them before the next invoice run.
- **Residual, not addressed here** (carried over from the finding record): historical invoice lines may already reference time entries or parts that were deleted before this patch. The invoice documents remain immutable evidence, but those source rows are not reconstructed. Inventorying missing-source incidence and deciding on any reconciliation is a separate owner decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Tugfg88kFiowD7E5xQFpU
